### PR TITLE
Add and use meson-multilib.eclass

### DIFF
--- a/app-accessibility/at-spi2-atk/at-spi2-atk-2.38.0.ebuild
+++ b/app-accessibility/at-spi2-atk/at-spi2-atk-2.38.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit gnome.org meson multilib-minimal virtualx xdg
+inherit gnome.org meson-multilib virtualx xdg
 
 DESCRIPTION="Gtk module for bridging AT-SPI to Atk"
 HOMEPAGE="https://wiki.gnome.org/Accessibility"
@@ -33,14 +33,6 @@ multilib_src_configure() {
 	meson_src_configure
 }
 
-multilib_src_compile() {
-	meson_src_compile
-}
-
 multilib_src_test() {
 	virtx dbus-run-session meson test -C "${BUILD_DIR}"
-}
-
-multilib_src_install() {
-	meson_src_install
 }

--- a/app-accessibility/at-spi2-core/at-spi2-core-2.40.1.ebuild
+++ b/app-accessibility/at-spi2-core/at-spi2-core-2.40.1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit gnome.org meson multilib-minimal systemd virtualx xdg
+inherit gnome.org meson-multilib systemd virtualx xdg
 
 DESCRIPTION="D-Bus accessibility specifications and registration daemon"
 HOMEPAGE="https://wiki.gnome.org/Accessibility"
@@ -42,21 +42,13 @@ PATCHES=(
 multilib_src_configure() {
 	local emesonargs=(
 		-Dsystemd_user_dir="$(systemd_get_userunitdir)"
-		-Ddocs=$(multilib_native_usex gtk-doc true false)
+		$(meson_native_use_bool gtk-doc docs)
 		-Dintrospection=$(multilib_native_usex introspection)
 		-Dx11=$(usex X)
 	)
 	meson_src_configure
 }
 
-multilib_src_compile() {
-	meson_src_compile
-}
-
 multilib_src_test() {
 	virtx dbus-run-session meson test -C "${BUILD_DIR}"
-}
-
-multilib_src_install() {
-	meson_src_install
 }

--- a/app-arch/bzip2/bzip2-9999.ebuild
+++ b/app-arch/bzip2/bzip2-9999.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-inherit meson multilib-minimal usr-ldscript
+inherit meson-multilib usr-ldscript
 
 DESCRIPTION="A high-quality data compressor used extensively by Gentoo Linux"
 HOMEPAGE="https://gitlab.com/federicomenaquintero/bzip2"
@@ -27,10 +27,6 @@ multilib_src_configure() {
 	)
 
 	meson_src_configure
-}
-
-multilib_src_compile() {
-	meson_src_compile
 }
 
 multilib_src_install() {

--- a/app-crypt/libsecret/libsecret-0.20.4.ebuild
+++ b/app-crypt/libsecret/libsecret-0.20.4.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 PYTHON_COMPAT=( python3_{7..9} )
 VALA_USE_DEPEND=vapigen
 
-inherit gnome2 meson multilib-minimal python-any-r1 vala virtualx
+inherit gnome2 meson-multilib python-any-r1 vala virtualx
 
 DESCRIPTION="GObject library for accessing the freedesktop.org Secret Service API"
 HOMEPAGE="https://wiki.gnome.org/Projects/Libsecret"
@@ -71,32 +71,20 @@ src_prepare() {
 		-i libsecret/secret-enum-types.h.template || die
 }
 
-meson_multilib_native_use() {
-	multilib_native_usex "$1" "-D${2-$1}=true" "-D${2-$1}=false"
-}
-
 multilib_src_configure() {
 	local emesonargs=(
 		$(meson_use crypt gcrypt)
 
 		# Don't build docs multiple times
-		-Dmanpage=$(multilib_is_native_abi && echo true || echo false)
-		$(meson_multilib_native_use gtk-doc gtk_doc)
+		$(meson_native_true manpage)
+		$(meson_native_use_bool gtk-doc gtk_doc)
 
-		$(meson_multilib_native_use introspection)
-		$(meson_multilib_native_use vala vapi)
+		$(meson_native_use_bool introspection)
+		$(meson_native_use_bool vala vapi)
 	)
 	meson_src_configure
 }
 
-multilib_src_compile() {
-	meson_src_compile
-}
-
 multilib_src_test() {
 	virtx meson_src_test
-}
-
-multilib_src_install() {
-	meson_src_install
 }

--- a/app-emulation/gallium-nine-standalone/gallium-nine-standalone-0.7.ebuild
+++ b/app-emulation/gallium-nine-standalone/gallium-nine-standalone-0.7.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit meson multilib-minimal toolchain-funcs
+inherit meson-multilib toolchain-funcs
 
 MY_PN="wine-nine-standalone"
 DESCRIPTION="A standalone version of the WINE parts of Gallium Nine"
@@ -85,14 +85,6 @@ multilib_src_configure() {
 		-Ddri2=false
 	)
 	meson_src_configure
-}
-
-multilib_src_compile() {
-	meson_src_compile
-}
-
-multilib_src_install() {
-	meson_src_install
 }
 
 pkg_postinst() {

--- a/app-emulation/gallium-nine-standalone/gallium-nine-standalone-0.8.ebuild
+++ b/app-emulation/gallium-nine-standalone/gallium-nine-standalone-0.8.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit meson multilib-minimal toolchain-funcs
+inherit meson-multilib toolchain-funcs
 
 MY_PN="wine-nine-standalone"
 DESCRIPTION="A standalone version of the WINE parts of Gallium Nine"
@@ -84,27 +84,4 @@ multilib_src_configure() {
 		-Ddri2=false
 	)
 	meson_src_configure
-}
-
-multilib_src_compile() {
-	meson_src_compile
-}
-
-multilib_src_install() {
-	meson_src_install
-}
-
-pkg_postinst() {
-	local bits=$(bits)
-
-	einfo "Don't remove the Z: drive from your WINEPREFIX as this relies on it."
-	einfo
-	einfo "To set up the ${bits}-bit library, launch your preferred Wine as follows:"
-	einfo "  wine${bits/32} ${EPREFIX}/usr/$(get_libdir)/ninewinecfg.exe.so"
-
-	if use abi_x86_64 && use abi_x86_32; then
-		einfo
-		einfo "To set up the 32-bit library, launch your preferred Wine as follows:"
-		einfo "  wine ${EPREFIX}/usr/$(ABI=x86 get_libdir)/ninewinecfg.exe.so"
-	fi
 }

--- a/app-emulation/gallium-nine-standalone/gallium-nine-standalone-9999.ebuild
+++ b/app-emulation/gallium-nine-standalone/gallium-nine-standalone-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit meson multilib-minimal toolchain-funcs
+inherit meson-multilib toolchain-funcs
 
 MY_PN="wine-nine-standalone"
 DESCRIPTION="A standalone version of the WINE parts of Gallium Nine"
@@ -84,27 +84,4 @@ multilib_src_configure() {
 		-Ddri2=false
 	)
 	meson_src_configure
-}
-
-multilib_src_compile() {
-	meson_src_compile
-}
-
-multilib_src_install() {
-	meson_src_install
-}
-
-pkg_postinst() {
-	local bits=$(bits)
-
-	einfo "Don't remove the Z: drive from your WINEPREFIX as this relies on it."
-	einfo
-	einfo "To set up the ${bits}-bit library, launch your preferred Wine as follows:"
-	einfo "  wine${bits/32} ${EPREFIX}/usr/$(get_libdir)/ninewinecfg.exe.so"
-
-	if use abi_x86_64 && use abi_x86_32; then
-		einfo
-		einfo "To set up the 32-bit library, launch your preferred Wine as follows:"
-		einfo "  wine ${EPREFIX}/usr/$(ABI=x86 get_libdir)/ninewinecfg.exe.so"
-	fi
 }

--- a/dev-cpp/atkmm/atkmm-2.28.2.ebuild
+++ b/dev-cpp/atkmm/atkmm-2.28.2.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 
 PYTHON_COMPAT=( python3_{7..9} )
-inherit gnome.org meson multilib-minimal python-any-r1
+inherit gnome.org meson-multilib python-any-r1
 
 DESCRIPTION="C++ interface for the ATK library"
 HOMEPAGE="https://www.gtkmm.org"
@@ -32,19 +32,7 @@ BDEPEND="
 
 multilib_src_configure() {
 	local emesonargs=(
-		-Dbuild-documentation=$(multilib_native_usex doc true false)
+		$(meson_native_use_bool doc build-documentation)
 	)
 	meson_src_configure
-}
-
-multilib_src_compile() {
-	meson_src_compile
-}
-
-multilib_src_install() {
-	meson_src_install
-}
-
-multilib_src_test() {
-	meson_src_test
 }

--- a/dev-cpp/atkmm/atkmm-2.36.1.ebuild
+++ b/dev-cpp/atkmm/atkmm-2.36.1.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 
 PYTHON_COMPAT=( python3_{7..9} )
-inherit gnome.org meson multilib-minimal python-any-r1
+inherit gnome.org meson-multilib python-any-r1
 
 DESCRIPTION="C++ interface for the ATK library"
 HOMEPAGE="https://www.gtkmm.org"
@@ -32,19 +32,7 @@ BDEPEND="
 
 multilib_src_configure() {
 	local emesonargs=(
-		-Dbuild-documentation=$(multilib_native_usex doc true false)
+		$(meson_native_use_bool doc build-documentation)
 	)
 	meson_src_configure
-}
-
-multilib_src_compile() {
-	meson_src_compile
-}
-
-multilib_src_install() {
-	meson_src_install
-}
-
-multilib_src_test() {
-	meson_src_test
 }

--- a/dev-cpp/cairomm/cairomm-1.14.3.ebuild
+++ b/dev-cpp/cairomm/cairomm-1.14.3.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit meson multilib-minimal
+inherit meson-multilib
 
 DESCRIPTION="C++ bindings for the Cairo vector graphics library"
 HOMEPAGE="https://cairographics.org/cairomm/"
@@ -36,22 +36,10 @@ BDEPEND="
 
 multilib_src_configure() {
 	local emesonargs=(
-		-Dbuild-documentation=$(multilib_native_usex doc true false)
+		$(meson_native_use_bool doc build-documentation)
 		-Dbuild-examples=false
-		-Dbuild-tests=$(usex test true false)
+		$(meson_use test build-tests)
 		-Dboost-shared=true
 	)
 	meson_src_configure
-}
-
-multilib_src_compile() {
-	meson_src_compile
-}
-
-multilib_src_install() {
-	meson_src_install
-}
-
-multilib_src_test() {
-	meson_src_test
 }

--- a/dev-cpp/cairomm/cairomm-1.16.1.ebuild
+++ b/dev-cpp/cairomm/cairomm-1.16.1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit meson multilib-minimal
+inherit meson-multilib
 
 DESCRIPTION="C++ bindings for the Cairo vector graphics library"
 HOMEPAGE="https://cairographics.org/cairomm/"
@@ -36,22 +36,10 @@ BDEPEND="
 
 multilib_src_configure() {
 	local emesonargs=(
-		-Dbuild-documentation=$(multilib_native_usex doc true false)
+		$(meson_native_use_bool doc documentation)
 		-Dbuild-examples=false
-		-Dbuild-tests=$(usex test true false)
+		$(meson_use test build-tests)
 		-Dboost-shared=true
 	)
 	meson_src_configure
-}
-
-multilib_src_compile() {
-	meson_src_compile
-}
-
-multilib_src_install() {
-	meson_src_install
-}
-
-multilib_src_test() {
-	meson_src_test
 }

--- a/dev-cpp/glibmm/glibmm-2.66.1.ebuild
+++ b/dev-cpp/glibmm/glibmm-2.66.1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 PYTHON_COMPAT=( python3_{7..9} )
-inherit gnome.org meson multilib-minimal python-any-r1
+inherit gnome.org meson-multilib python-any-r1
 
 DESCRIPTION="C++ interface for glib2"
 HOMEPAGE="https://www.gtkmm.org"
@@ -46,21 +46,9 @@ multilib_src_configure() {
 	local emesonargs=(
 		-Dwarnings=min
 		-Dbuild-deprecated-api=true
-		-Dbuild-documentation=$(usex doc true false)
-		-Ddebug-refcounting=$(usex debug true false)
+		$(meson_native_use_bool doc build-documentation)
+		$(meson_use debug debug-refcounting)
 		-Dbuild-examples=false
 	)
 	meson_src_configure
-}
-
-multilib_src_compile() {
-	meson_src_compile
-}
-
-multilib_src_test() {
-	meson_src_test
-}
-
-multilib_src_install() {
-	meson_src_install
 }

--- a/dev-cpp/glibmm/glibmm-2.68.1.ebuild
+++ b/dev-cpp/glibmm/glibmm-2.68.1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 PYTHON_COMPAT=( python3_{7..9} )
-inherit gnome.org meson multilib-minimal python-any-r1
+inherit gnome.org meson-multilib python-any-r1
 
 DESCRIPTION="C++ interface for glib2"
 HOMEPAGE="https://www.gtkmm.org"
@@ -44,21 +44,9 @@ multilib_src_configure() {
 	local emesonargs=(
 		-Dwarnings=min
 		-Dbuild-deprecated-api=true
-		-Dbuild-documentation=$(usex doc true false)
-		-Ddebug-refcounting=$(usex debug true false)
+		$(meson_native_use_bool doc build-documentation)
+		$(meson_use debug debug-refcounting)
 		-Dbuild-examples=false
 	)
 	meson_src_configure
-}
-
-multilib_src_compile() {
-	meson_src_compile
-}
-
-multilib_src_test() {
-	meson_src_test
-}
-
-multilib_src_install() {
-	meson_src_install
 }

--- a/dev-cpp/gtkmm/gtkmm-3.24.5.ebuild
+++ b/dev-cpp/gtkmm/gtkmm-3.24.5.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 
 PYTHON_COMPAT=( python3_{7..9} )
-inherit gnome.org meson multilib-minimal python-any-r1 virtualx
+inherit gnome.org meson-multilib python-any-r1 virtualx
 
 DESCRIPTION="C++ interface for GTK+"
 HOMEPAGE="https://www.gtkmm.org"
@@ -42,19 +42,11 @@ multilib_src_configure() {
 	local emesonargs=(
 		-Dbuild-atkmm-api=true
 		-Dbuild-demos=false
-		-Dbuild-documentation=$(multilib_native_usex doc true false)
-		-Dbuild-tests=$(usex test true false)
-		-Dbuild-x11-api=$(usex X true false)
+		$(meson_native_use_bool doc build-documentation)
+		$(meson_use test build-tests)
+		$(meson_use X build-x11-api)
 	)
 	meson_src_configure
-}
-
-multilib_src_compile() {
-	meson_src_compile
-}
-
-multilib_src_install() {
-	meson_src_install
 }
 
 multilib_src_test() {

--- a/dev-cpp/pangomm/pangomm-2.42.2.ebuild
+++ b/dev-cpp/pangomm/pangomm-2.42.2.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 
 PYTHON_COMPAT=( python3_{7..9} )
-inherit gnome.org meson multilib-minimal python-any-r1
+inherit gnome.org meson-multilib python-any-r1
 
 DESCRIPTION="C++ interface for pango"
 HOMEPAGE="https://www.gtkmm.org"
@@ -33,19 +33,7 @@ BDEPEND="
 
 multilib_src_configure() {
 	local emesonargs=(
-		-Dbuild-documentation=$(multilib_native_usex doc true false)
+		$(meson_native_use_bool doc build-documentation)
 	)
 	meson_src_configure
-}
-
-multilib_src_compile() {
-	meson_src_compile
-}
-
-multilib_src_install() {
-	meson_src_install
-}
-
-multilib_src_test() {
-	meson_src_test
 }

--- a/dev-cpp/pangomm/pangomm-2.48.1.ebuild
+++ b/dev-cpp/pangomm/pangomm-2.48.1.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 
 PYTHON_COMPAT=( python3_{7..9} )
-inherit gnome.org meson multilib-minimal python-any-r1
+inherit gnome.org meson-multilib python-any-r1
 
 DESCRIPTION="C++ interface for pango"
 HOMEPAGE="https://www.gtkmm.org"
@@ -33,19 +33,7 @@ BDEPEND="
 
 multilib_src_configure() {
 	local emesonargs=(
-		-Dbuild-documentation=$(multilib_native_usex doc true false)
+		$(meson_native_use_bool doc build-documentation)
 	)
 	meson_src_configure
-}
-
-multilib_src_compile() {
-	meson_src_compile
-}
-
-multilib_src_install() {
-	meson_src_install
-}
-
-multilib_src_test() {
-	meson_src_test
 }

--- a/dev-lang/orc/orc-0.4.31.ebuild
+++ b/dev-lang/orc/orc-0.4.31.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit meson multilib-minimal
+inherit meson-multilib
 
 DESCRIPTION="The Oil Runtime Compiler, a just-in-time compiler for array operations"
 HOMEPAGE="https://gstreamer.freedesktop.org/"
@@ -32,21 +32,9 @@ multilib_src_configure() {
 		-Dorc-test=enabled # FIXME: always installs static library, bug 645232
 		-Dbenchmarks=disabled
 		-Dexamples=disabled
-		$(meson_feature gtk-doc gtk_doc)
+		$(meson_native_use_feature gtk-doc gtk_doc)
 		$(meson_feature test tests)
 		-Dtools=enabled # requires orc-test
 	)
 	meson_src_configure
-}
-
-multilib_src_compile() {
-	meson_src_compile
-}
-
-multilib_src_test() {
-	meson_src_test
-}
-
-multilib_src_install() {
-	meson_src_install
 }

--- a/dev-libs/atk/atk-2.36.0.ebuild
+++ b/dev-libs/atk/atk-2.36.0.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-inherit gnome.org meson multilib-minimal xdg
+inherit gnome.org meson-multilib xdg
 
 DESCRIPTION="GTK+ & GNOME Accessibility Toolkit"
 HOMEPAGE="https://wiki.gnome.org/Accessibility"
@@ -28,20 +28,8 @@ BDEPEND="
 
 multilib_src_configure() {
 	local emesonargs=(
-		-Ddocs=$(multilib_native_usex gtk-doc true false)
-		-Dintrospection=$(multilib_native_usex introspection true false)
+		$(meson_native_use_bool gtk-doc docs)
+		$(meson_native_use_bool introspection)
 	)
 	meson_src_configure
-}
-
-multilib_src_compile() {
-	meson_src_compile
-}
-
-multilib_src_test() {
-	meson_src_test
-}
-
-multilib_src_install() {
-	meson_src_install
 }

--- a/dev-libs/glib/glib-2.66.8.ebuild
+++ b/dev-libs/glib/glib-2.66.8.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 PYTHON_COMPAT=( python3_{7,8,9} )
 
-inherit flag-o-matic gnome.org gnome2-utils linux-info meson multilib multilib-minimal python-any-r1 toolchain-funcs xdg
+inherit flag-o-matic gnome.org gnome2-utils linux-info meson-multilib multilib python-any-r1 toolchain-funcs xdg
 
 DESCRIPTION="The GLib library of C routines"
 HOMEPAGE="https://www.gtk.org/"
@@ -170,17 +170,13 @@ multilib_src_configure() {
 		$(meson_use systemtap dtrace)
 		$(meson_use systemtap)
 		$(meson_feature sysprof)
-		-Dgtk_doc=$(multilib_native_usex gtk-doc true false)
+		$(meson_native_use_bool gtk-doc gtk_doc)
 		$(meson_use fam)
 		-Dinstalled_tests=false
 		-Dnls=enabled
 		-Doss_fuzz=disabled
 	)
 	meson_src_configure
-}
-
-multilib_src_compile() {
-	meson_src_compile
 }
 
 multilib_src_test() {

--- a/dev-libs/glib/glib-2.68.2.ebuild
+++ b/dev-libs/glib/glib-2.68.2.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 PYTHON_COMPAT=( python3_{7..9} )
 
-inherit flag-o-matic gnome.org gnome2-utils linux-info meson multilib multilib-minimal python-any-r1 toolchain-funcs xdg
+inherit flag-o-matic gnome.org gnome2-utils linux-info meson-multilib multilib python-any-r1 toolchain-funcs xdg
 
 DESCRIPTION="The GLib library of C routines"
 HOMEPAGE="https://www.gtk.org/"
@@ -166,19 +166,15 @@ multilib_src_configure() {
 		$(meson_use systemtap dtrace)
 		$(meson_use systemtap)
 		$(meson_feature sysprof)
-		-Dgtk_doc=$(multilib_native_usex gtk-doc true false)
+		$(meson_native_use_bool gtk-doc gtk_doc)
 		$(meson_use fam)
 		$(meson_use test tests)
 		-Dinstalled_tests=false
 		-Dnls=enabled
 		-Doss_fuzz=disabled
-		-Dlibelf=$(multilib_native_usex elf enabled disabled)
+		$(meson_native_use_feature elf libelf)
 	)
 	meson_src_configure
-}
-
-multilib_src_compile() {
-	meson_src_compile
 }
 
 multilib_src_test() {
@@ -202,8 +198,6 @@ multilib_src_install() {
 }
 
 multilib_src_install_all() {
-	einstalldocs
-
 	# These are installed by dev-util/glib-utils
 	# TODO: With patching we might be able to get rid of the python-any deps and removals, and test depend on glib-utils instead; revisit now with meson
 	rm "${ED}/usr/bin/glib-genmarshal" || die

--- a/dev-libs/inih/inih-53.ebuild
+++ b/dev-libs/inih/inih-53.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit meson multilib-minimal
+inherit meson-multilib
 
 DESCRIPTION="inih (INI not invented here) simple .INI file parser"
 HOMEPAGE="https://github.com/benhoyt/inih"
@@ -26,14 +26,6 @@ multilib_src_configure() {
 	)
 
 	meson_src_configure
-}
-
-multilib_src_compile() {
-	meson_src_compile
-}
-
-multilib_src_install() {
-	meson_src_install
 }
 
 multilib_src_install_all() {

--- a/dev-libs/json-glib/json-glib-1.6.2.ebuild
+++ b/dev-libs/json-glib/json-glib-1.6.2.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-inherit gnome.org meson multilib-minimal xdg-utils
+inherit gnome.org meson-multilib xdg-utils
 
 DESCRIPTION="Library providing GLib serialization and deserialization for the JSON format"
 HOMEPAGE="https://wiki.gnome.org/Projects/JsonGlib"
@@ -38,21 +38,9 @@ src_prepare() {
 
 multilib_src_configure() {
 	local emesonargs=(
-		-Dintrospection=$(multilib_native_usex introspection enabled disabled)
-		-Dgtk_doc=$(multilib_native_usex gtk-doc enabled disabled)
-		-Dman=true
+		$(meson_native_use_feature introspection)
+		$(meson_native_use_feature gtk-doc gtk_doc)
+		$(meson_native_true man)
 	)
 	meson_src_configure
-}
-
-multilib_src_compile() {
-	meson_src_compile
-}
-
-multilib_src_install() {
-	meson_src_install
-}
-
-multilib_src_test() {
-	meson_src_test
 }

--- a/dev-libs/libevdev/libevdev-1.11.0.ebuild
+++ b/dev-libs/libevdev/libevdev-1.11.0.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{7,8,9} )
 
-inherit meson multilib-minimal python-any-r1
+inherit meson-multilib python-any-r1
 
 DESCRIPTION="Handler library for evdev events"
 HOMEPAGE="https://www.freedesktop.org/wiki/Software/libevdev/ https://gitlab.freedesktop.org/libevdev/libevdev"
@@ -38,16 +38,8 @@ multilib_src_configure() {
 	meson_src_configure
 }
 
-multilib_src_compile() {
-	meson_src_compile
-}
-
 multilib_src_test() {
-	meson test -v -C "${BUILD_DIR}" -t 100 || die "tests failed"
-}
-
-multilib_src_install() {
-	meson_src_install
+	meson_src_test -t 100
 }
 
 multilib_src_install_all() {

--- a/dev-libs/libevdev/libevdev-9999.ebuild
+++ b/dev-libs/libevdev/libevdev-9999.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{7,8,9} )
 
-inherit meson multilib-minimal python-any-r1
+inherit meson-multilib python-any-r1
 
 DESCRIPTION="Handler library for evdev events"
 HOMEPAGE="https://www.freedesktop.org/wiki/Software/libevdev/ https://gitlab.freedesktop.org/libevdev/libevdev"
@@ -38,16 +38,8 @@ multilib_src_configure() {
 	meson_src_configure
 }
 
-multilib_src_compile() {
-	meson_src_compile
-}
-
 multilib_src_test() {
-	meson test -v -C "${BUILD_DIR}" -t 100 || die "tests failed"
-}
-
-multilib_src_install() {
-	meson_src_install
+	meson_src_test -t 100
 }
 
 multilib_src_install_all() {

--- a/dev-libs/libgusb/libgusb-0.3.7.ebuild
+++ b/dev-libs/libgusb/libgusb-0.3.7.ebuild
@@ -7,7 +7,7 @@ VALA_USE_DEPEND="vapigen"
 PYTHON_COMPAT=( python3_{7,8,9} )
 PYTHON_REQ_USE="xml(+)"
 
-inherit meson multilib-minimal python-any-r1 vala
+inherit meson-multilib python-any-r1 vala
 
 DESCRIPTION="GObject wrapper for libusb"
 HOMEPAGE="https://github.com/hughsie/libgusb"
@@ -53,22 +53,11 @@ multilib_src_configure() {
 	local emesonargs=(
 		-Ddefault_library=$(usex static-libs both shared)
 		$(meson_use test tests)
-		-Dvapi=$(multilib_native_usex vala true false)
+		$(meson_native_use_bool vala vapi)
 		-Dusb_ids="${EPREFIX}"/usr/share/misc/usb.ids
-		-Ddocs=$(multilib_native_usex gtk-doc true false)
-		-Dintrospection=$(multilib_native_usex introspection true false)
+		$(meson_native_use_bool gtk-doc docs)
+		$(meson_native_use_bool introspection)
+
 	)
 	meson_src_configure
-}
-
-multilib_src_compile() {
-	meson_src_compile
-}
-
-multilib_src_test() {
-	meson_src_test
-}
-
-multilib_src_install() {
-	meson_src_install
 }

--- a/dev-libs/libsigc++/libsigc++-2.10.7.ebuild
+++ b/dev-libs/libsigc++/libsigc++-2.10.7.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-inherit flag-o-matic gnome.org meson multilib-minimal
+inherit flag-o-matic gnome.org meson-multilib
 
 DESCRIPTION="Typesafe callback system for standard C++"
 HOMEPAGE="https://libsigcplusplus.github.io/libsigcplusplus/
@@ -23,28 +23,14 @@ multilib_src_configure() {
 
 	local -a emesonargs=(
 		-Ddefault_library=$(usex static-libs both shared)
-		-Dbenchmark=$(usex test true false)
-		-Dbuild-documentation=$(multilib_native_usex doc true false)
+		$(meson_use test benchmark)
+		$(meson_native_use_bool doc build-documentation)
 		-Dbuild-examples=false
 	)
 	meson_src_configure
 }
 
-multilib_src_compile() {
-	meson_src_compile
-}
-
-multilib_src_test() {
-	meson_src_test
-}
-
-multilib_src_install() {
-	meson_src_install
-}
-
 multilib_src_install_all() {
-	einstalldocs
-
 	# Note: html docs are installed into /usr/share/doc/libsigc++-2.0
 	# We can't use /usr/share/doc/${PF} because of links from glibmm etc. docs
 	if use doc; then

--- a/dev-libs/libsigc++/libsigc++-3.0.7.ebuild
+++ b/dev-libs/libsigc++/libsigc++-3.0.7.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-inherit gnome.org flag-o-matic meson multilib-minimal
+inherit gnome.org flag-o-matic meson-multilib
 
 DESCRIPTION="Typesafe callback system for standard C++"
 HOMEPAGE="https://libsigcplusplus.github.io/libsigcplusplus/
@@ -35,27 +35,13 @@ multilib_src_configure() {
 
 	local emesonargs=(
 		-Dbuild-examples=false
-		-Dbuild-documentation=$(multilib_native_usex doc true false)
+		$(meson_native_use_bool doc build-documentation)
 	)
 	meson_src_configure
 }
 
-multilib_src_compile() {
-	meson_src_compile
-}
-
-multilib_src_install() {
-	meson_src_install
-}
-
 multilib_src_install_all() {
-	einstalldocs
-
 	# Note: html docs are installed into /usr/share/doc/libsigc++-3.0
 	# We can't use /usr/share/doc/${PF} because of links from glibmm etc. docs
 	use examples && dodoc -r examples
-}
-
-multilib_src_test() {
-	meson_src_test
 }

--- a/dev-libs/tinyxml2/tinyxml2-8.1.0.ebuild
+++ b/dev-libs/tinyxml2/tinyxml2-8.1.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit meson multilib-minimal
+inherit meson-multilib
 
 DESCRIPTION="A simple, small, efficient, C++ XML parser"
 HOMEPAGE="http://www.grinninglizard.com/tinyxml2/ https://github.com/leethomason/tinyxml2/"
@@ -20,25 +20,9 @@ PATCHES=(
 )
 
 multilib_src_configure() {
-	local mymesonargs=()
+	local emesonargs=(
+		$(meson_native_use_bool test tests)
+	)
 
-	if multilib_is_native_abi ; then
-		mymesonargs+=(
-			$(meson_use test tests)
-		)
-	fi
-
-	meson_src_configure "${mymesonargs[@]}"
-}
-
-multilib_src_compile() {
-	meson_src_compile
-}
-
-multilib_src_test() {
-	meson_src_test
-}
-
-multilib_src_install() {
-	meson_src_install
+	meson_src_configure
 }

--- a/dev-libs/wayland/wayland-1.19.0.ebuild
+++ b/dev-libs/wayland/wayland-1.19.0.ebuild
@@ -10,7 +10,7 @@ else
 	SRC_URI="https://wayland.freedesktop.org/releases/${P}.tar.xz"
 	KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86"
 fi
-inherit meson multilib-minimal
+inherit meson-multilib
 
 DESCRIPTION="Wayland protocol libraries"
 HOMEPAGE="https://wayland.freedesktop.org/ https://gitlab.freedesktop.org/wayland/wayland"
@@ -35,38 +35,14 @@ DEPEND="
 "
 RDEPEND="${DEPEND}"
 
-meson_multilib() {
-	if multilib_is_native_abi; then
-		echo true
-	else
-		echo false
-	fi
-}
-
-meson_multilib_native_use() {
-	if multilib_is_native_abi && use "$1"; then
-		echo true
-	else
-		echo false
-	fi
-}
-
 multilib_src_configure() {
 	local emesonargs=(
-		-Ddocumentation=$(meson_multilib_native_use doc)
-		-Ddtd_validation=$(meson_multilib)
+		$(meson_native_use_bool doc documentation)
+		$(meson_native_true dtd_validation)
 		-Dlibraries=true
 		-Dscanner=false
 	)
 	meson_src_configure
-}
-
-multilib_src_compile() {
-	meson_src_compile
-}
-
-multilib_src_test() {
-	meson_src_test
 }
 
 src_test() {
@@ -78,8 +54,4 @@ src_test() {
 	chmod 0700 "${XDG_RUNTIME_DIR}" || die
 
 	multilib-minimal_src_test
-}
-
-multilib_src_install() {
-	meson_src_install
 }

--- a/dev-libs/wayland/wayland-9999.ebuild
+++ b/dev-libs/wayland/wayland-9999.ebuild
@@ -10,7 +10,7 @@ else
 	SRC_URI="https://wayland.freedesktop.org/releases/${P}.tar.xz"
 	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
 fi
-inherit meson multilib-minimal
+inherit meson-multilib
 
 DESCRIPTION="Wayland protocol libraries"
 HOMEPAGE="https://wayland.freedesktop.org/ https://gitlab.freedesktop.org/wayland/wayland"
@@ -35,38 +35,14 @@ DEPEND="
 "
 RDEPEND="${DEPEND}"
 
-meson_multilib() {
-	if multilib_is_native_abi; then
-		echo true
-	else
-		echo false
-	fi
-}
-
-meson_multilib_native_use() {
-	if multilib_is_native_abi && use "$1"; then
-		echo true
-	else
-		echo false
-	fi
-}
-
 multilib_src_configure() {
 	local emesonargs=(
-		-Ddocumentation=$(meson_multilib_native_use doc)
-		-Ddtd_validation=$(meson_multilib)
+		$(meson_native_use_bool doc documentation)
+		$(meson_native_true dtd_validation)
 		-Dlibraries=true
 		-Dscanner=false
 	)
 	meson_src_configure
-}
-
-multilib_src_compile() {
-	meson_src_compile
-}
-
-multilib_src_test() {
-	meson_src_test
 }
 
 src_test() {
@@ -78,8 +54,4 @@ src_test() {
 	chmod 0700 "${XDG_RUNTIME_DIR}" || die
 
 	multilib-minimal_src_test
-}
-
-multilib_src_install() {
-	meson_src_install
 }

--- a/dev-util/sysprof-capture/sysprof-capture-3.36.0-r1.ebuild
+++ b/dev-util/sysprof-capture/sysprof-capture-3.36.0-r1.ebuild
@@ -1,10 +1,10 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 GNOME_ORG_MODULE="sysprof"
 
-inherit gnome.org meson multilib-minimal systemd
+inherit gnome.org meson-multilib systemd
 
 DESCRIPTION="Static library for sysprof capture data generation"
 HOMEPAGE="http://sysprof.com/"
@@ -34,16 +34,4 @@ multilib_src_configure() {
 		-Dlibunwind=false
 	)
 	meson_src_configure
-}
-
-multilib_src_compile() {
-	meson_src_compile
-}
-
-multilib_src_test() {
-	meson_src_test
-}
-
-multilib_src_install() {
-	meson_src_install
 }

--- a/dev-util/sysprof-capture/sysprof-capture-3.38.1-r1.ebuild
+++ b/dev-util/sysprof-capture/sysprof-capture-3.38.1-r1.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 GNOME_ORG_MODULE="sysprof"
 
-inherit gnome.org meson multilib-minimal systemd
+inherit gnome.org meson-multilib systemd
 
 DESCRIPTION="Static library for sysprof capture data generation"
 HOMEPAGE="http://sysprof.com/"
@@ -36,16 +36,4 @@ multilib_src_configure() {
 		-Denable_examples=false
 	)
 	meson_src_configure
-}
-
-multilib_src_compile() {
-	meson_src_compile
-}
-
-multilib_src_test() {
-	meson_src_test
-}
-
-multilib_src_install() {
-	meson_src_install
 }

--- a/dev-util/wayland-scanner/wayland-scanner-1.19.0.ebuild
+++ b/dev-util/wayland-scanner/wayland-scanner-1.19.0.ebuild
@@ -11,7 +11,7 @@ else
 	KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86"
 	S="${WORKDIR}/wayland-${PV}"
 fi
-inherit meson multilib-minimal
+inherit meson-multilib
 
 DESCRIPTION="wayland-scanner tool"
 HOMEPAGE="https://wayland.freedesktop.org/ https://gitlab.freedesktop.org/wayland/wayland"
@@ -34,16 +34,4 @@ multilib_src_configure() {
 		-Dscanner=true
 	)
 	meson_src_configure
-}
-
-multilib_src_compile() {
-	meson_src_compile
-}
-
-multilib_src_test() {
-	meson_src_test
-}
-
-multilib_src_install() {
-	meson_src_install
 }

--- a/dev-util/wayland-scanner/wayland-scanner-9999.ebuild
+++ b/dev-util/wayland-scanner/wayland-scanner-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ else
 	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
 	S="${WORKDIR}/wayland-${PV}"
 fi
-inherit meson multilib-minimal
+inherit meson-multilib
 
 DESCRIPTION="wayland-scanner tool"
 HOMEPAGE="https://wayland.freedesktop.org/ https://gitlab.freedesktop.org/wayland/wayland"
@@ -34,16 +34,4 @@ multilib_src_configure() {
 		-Dscanner=true
 	)
 	meson_src_configure
-}
-
-multilib_src_compile() {
-	meson_src_compile
-}
-
-multilib_src_test() {
-	meson_src_test
-}
-
-multilib_src_install() {
-	meson_src_install
 }

--- a/eclass/meson-multilib.eclass
+++ b/eclass/meson-multilib.eclass
@@ -1,0 +1,131 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+# @ECLASS: meson-multilib.eclass
+# @MAINTAINER:
+# Author: Matt Turner <mattst88@gentoo.org>
+# @AUTHOR:
+# Author: Michał Górny <mgorny@gentoo.org>
+# Author: Matt Turner <mattst88@gentoo.org>
+# @SUPPORTED_EAPIS: 7
+# @BLURB: meson wrapper for multilib builds
+# @DESCRIPTION:
+# The meson-multilib.eclass provides a glue between meson.eclass(5)
+# and multilib-minimal.eclass(5), aiming to provide a convenient way
+# to build packages using meson for multiple ABIs.
+#
+# Inheriting this eclass sets IUSE and exports default multilib_src_*()
+# sub-phases that call meson phase functions for each ABI enabled.
+# The multilib_src_*() functions can be defined in ebuild just like
+# in multilib-minimal, yet they ought to call appropriate meson
+# phase rather than 'default'.
+
+if [[ -z ${_MESON_MULTILIB_ECLASS} ]] ; then
+_MESON_MULTILIB_ECLASS=1
+
+case ${EAPI:-0} in
+	7) ;;
+	*) die "EAPI=${EAPI} is not supported" ;;
+esac
+
+inherit meson multilib-minimal
+
+EXPORT_FUNCTIONS src_configure src_compile src_test src_install
+
+# @FUNCTION: meson_native_use_bool
+# @USAGE: <USE flag> [option name]
+# @DESCRIPTION:
+# Given a USE flag and a meson project option, output a string like:
+#
+#   -Doption=true
+#   -Doption=false
+#
+# if building for the native ABI (multilib_is_native_abi is true). Otherwise,
+# output -Doption=false. If the project option is unspecified, it defaults
+# to the USE flag.
+meson_native_use_bool() {
+	multilib_native_usex "${1}" "-D${2-${1}}=true" "-D${2-${1}}=false"
+}
+
+# @FUNCTION: meson_native_use_feature
+# @USAGE: <USE flag> [option name]
+# @DESCRIPTION:
+# Given a USE flag and a meson project option, output a string like:
+#
+#   -Doption=enabled
+#   -Doption=disabled
+#
+# if building for the native ABI (multilib_is_native_abi is true). Otherwise,
+# output -Doption=disabled. If the project option is unspecified, it defaults
+# to the USE flag.
+meson_native_use_feature() {
+	multilib_native_usex "${1}" "-D${2-${1}}=enabled" "-D${2-${1}}=disabled"
+}
+
+# @FUNCTION: meson_native_enabled
+# @USAGE: <option name>
+# @DESCRIPTION:
+# Output -Doption=enabled option if executables are being built
+# (multilib_is_native_abi is true). Otherwise, output -Doption=disabled option.
+meson_native_enabled() {
+	if multilib_is_native_abi; then
+		echo "-D${1}=enabled"
+	else
+		echo "-D${1}=disabled"
+	fi
+}
+
+# @FUNCTION: meson_native_true
+# @USAGE: <option name>
+# @DESCRIPTION:
+# Output -Doption=true option if executables are being built
+# (multilib_is_native_abi is true). Otherwise, output -Doption=false option.
+meson_native_true() {
+	if multilib_is_native_abi; then
+		echo "-D${1}=true"
+	else
+		echo "-D${1}=false"
+	fi
+}
+
+meson-multilib_src_configure() {
+	local _meson_args=( "${@}" )
+
+	multilib-minimal_src_configure
+}
+
+multilib_src_configure() {
+	meson_src_configure "${_meson_args[@]}"
+}
+
+meson-multilib_src_compile() {
+	local _meson_args=( "${@}" )
+
+	multilib-minimal_src_compile
+}
+
+multilib_src_compile() {
+	meson_src_compile "${_meson_args[@]}"
+}
+
+meson-multilib_src_test() {
+	local _meson_args=( "${@}" )
+
+	multilib-minimal_src_test
+}
+
+multilib_src_test() {
+	meson_src_test "${_meson_args[@]}"
+}
+
+meson-multilib_src_install() {
+	local _meson_args=( "${@}" )
+
+	multilib-minimal_src_install
+}
+
+multilib_src_install() {
+	meson_src_install "${_meson_args[@]}"
+}
+
+fi

--- a/eclass/meson.eclass
+++ b/eclass/meson.eclass
@@ -420,7 +420,10 @@ meson_src_install() {
 	debug-print-function ${FUNCNAME} "$@"
 
 	DESTDIR="${D}" eninja -C "${BUILD_DIR}" install "$@"
+
+	pushd "${S}" > /dev/null || die
 	einstalldocs
+	popd > /dev/null || die
 }
 
 fi

--- a/games-util/gamemode/gamemode-1.6.1.ebuild
+++ b/games-util/gamemode/gamemode-1.6.1.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 MULTILIB_COMPAT=( abi_x86_{32,64} )
 
-inherit meson multilib-minimal ninja-utils systemd
+inherit meson-multilib systemd
 
 DESCRIPTION="Optimise Linux system performance on demand"
 HOMEPAGE="https://github.com/FeralInteractive/gamemode"
@@ -89,12 +89,7 @@ multilib_src_configure() {
 	meson_src_configure
 }
 
-multilib_src_compile() {
-	eninja
-}
-
-multilib_src_install() {
-	DESTDIR="${D}" eninja install
+multilib_src_install_all() {
 	if multilib_is_native_abi; then
 		insinto /etc/security/limits.d
 		newins - 45-gamemode.conf <<-EOF

--- a/games-util/gamemode/gamemode-9999.ebuild
+++ b/games-util/gamemode/gamemode-9999.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 MULTILIB_COMPAT=( abi_x86_{32,64} )
 
-inherit meson multilib-minimal ninja-utils systemd
+inherit meson-multilib systemd
 
 DESCRIPTION="Optimise Linux system performance on demand"
 HOMEPAGE="https://github.com/FeralInteractive/gamemode"
@@ -89,12 +89,7 @@ multilib_src_configure() {
 	meson_src_configure
 }
 
-multilib_src_compile() {
-	eninja
-}
-
-multilib_src_install() {
-	DESTDIR="${D}" eninja install
+multilib_src_install_all() {
 	if multilib_is_native_abi; then
 		insinto /etc/security/limits.d
 		newins - 45-gamemode.conf <<-EOF

--- a/gui-libs/gdk-pixbuf-loader-webp/gdk-pixbuf-loader-webp-0.0.2.ebuild
+++ b/gui-libs/gdk-pixbuf-loader-webp/gdk-pixbuf-loader-webp-0.0.2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit gnome2-utils meson multilib-minimal
+inherit gnome2-utils meson-multilib
 
 DESCRIPTION="WebP GDK Pixbuf Loader library"
 HOMEPAGE="https://github.com/aruiz/webp-pixbuf-loader"
@@ -24,22 +24,6 @@ src_prepare() {
 	default
 	# Drop handling of pixbuf cache update by upstream
 	sed -e '/query_loaders/d' -i meson.build || die
-}
-
-multilib_src_configure() {
-	meson_src_configure
-}
-
-multilib_src_compile() {
-	meson_src_compile
-}
-
-multilib_src_test() {
-	meson_src_test
-}
-
-multilib_src_install() {
-	meson_src_install
 }
 
 pkg_preinst() {

--- a/media-libs/dav1d/dav1d-0.8.0.ebuild
+++ b/media-libs/dav1d/dav1d-0.8.0.ebuild
@@ -12,7 +12,7 @@ else
 	SRC_URI="https://code.videolan.org/videolan/dav1d/-/archive/${PV}/${P}.tar.bz2"
 fi
 
-inherit ${SCM} meson ninja-utils multilib-minimal
+inherit ${SCM} meson-multilib
 
 DESCRIPTION="dav1d is an AV1 Decoder :)"
 HOMEPAGE="https://code.videolan.org/videolan/dav1d"
@@ -46,12 +46,4 @@ multilib_src_configure() {
 		-D enable_asm=${enable_asm}
 	)
 	meson_src_configure
-}
-
-multilib_src_compile() {
-	eninja
-}
-
-multilib_src_install() {
-	DESTDIR="${D}" eninja install
 }

--- a/media-libs/dav1d/dav1d-0.8.2.ebuild
+++ b/media-libs/dav1d/dav1d-0.8.2.ebuild
@@ -12,7 +12,7 @@ else
 	SRC_URI="https://code.videolan.org/videolan/dav1d/-/archive/${PV}/${P}.tar.bz2"
 fi
 
-inherit ${SCM} meson ninja-utils multilib-minimal
+inherit ${SCM} meson-multilib
 
 DESCRIPTION="dav1d is an AV1 Decoder :)"
 HOMEPAGE="https://code.videolan.org/videolan/dav1d"
@@ -48,16 +48,8 @@ multilib_src_configure() {
 	meson_src_configure
 }
 
-multilib_src_compile() {
-	eninja
-}
-
 multilib_src_test() {
 	if multilib_is_native_abi ; then
 		meson_src_test
 	fi
-}
-
-multilib_src_install() {
-	DESTDIR="${D}" eninja install
 }

--- a/media-libs/dav1d/dav1d-0.9.0.ebuild
+++ b/media-libs/dav1d/dav1d-0.9.0.ebuild
@@ -12,7 +12,7 @@ else
 	SRC_URI="https://code.videolan.org/videolan/dav1d/-/archive/${PV}/${P}.tar.bz2"
 fi
 
-inherit ${SCM} meson ninja-utils multilib-minimal
+inherit ${SCM} meson-multilib
 
 DESCRIPTION="dav1d is an AV1 Decoder :)"
 HOMEPAGE="https://code.videolan.org/videolan/dav1d"
@@ -48,16 +48,8 @@ multilib_src_configure() {
 	meson_src_configure
 }
 
-multilib_src_compile() {
-	eninja
-}
-
 multilib_src_test() {
 	if multilib_is_native_abi ; then
 		meson_src_test
 	fi
-}
-
-multilib_src_install() {
-	DESTDIR="${D}" eninja install
 }

--- a/media-libs/dav1d/dav1d-9999.ebuild
+++ b/media-libs/dav1d/dav1d-9999.ebuild
@@ -12,7 +12,7 @@ else
 	SRC_URI="https://code.videolan.org/videolan/dav1d/-/archive/${PV}/${P}.tar.bz2"
 fi
 
-inherit ${SCM} meson ninja-utils multilib-minimal
+inherit ${SCM} meson-multilib
 
 DESCRIPTION="dav1d is an AV1 Decoder :)"
 HOMEPAGE="https://code.videolan.org/videolan/dav1d"
@@ -48,16 +48,8 @@ multilib_src_configure() {
 	meson_src_configure
 }
 
-multilib_src_compile() {
-	eninja
-}
-
 multilib_src_test() {
 	if multilib_is_native_abi ; then
 		meson_src_test
 	fi
-}
-
-multilib_src_install() {
-	DESTDIR="${D}" eninja install
 }

--- a/media-libs/graphene/graphene-1.10.6.ebuild
+++ b/media-libs/graphene/graphene-1.10.6.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 
 PYTHON_COMPAT=( python3_{7..9} )
-inherit xdg-utils meson multilib-minimal python-any-r1
+inherit xdg-utils meson-multilib python-any-r1
 
 DESCRIPTION="A thin layer of types for graphic libraries"
 HOMEPAGE="https://ebassi.github.io/graphene/"
@@ -34,9 +34,9 @@ BDEPEND="
 multilib_src_configure() {
 	# TODO: Do we want G_DISABLE_ASSERT as buildtype=release would do upstream?
 	local emesonargs=(
-		-Dgtk_doc=$(multilib_native_usex doc true false)
+		$(meson_native_use_bool doc gtk_doc)
 		-Dgobject_types=true
-		-Dintrospection=$(multilib_native_usex introspection enabled disabled)
+		$(meson_native_use_feature introspection)
 		-Dgcc_vector=true # if built-in support tests fail, it'll just not enable vector intrinsics; unfortunately this probably means disabled on clang too, due to it claiming to be <gcc-4.9
 		$(meson_use cpu_flags_x86_sse2 sse2)
 		$(meson_use cpu_flags_arm_neon arm_neon)
@@ -44,16 +44,4 @@ multilib_src_configure() {
 		-Dinstalled_tests=false
 	)
 	meson_src_configure
-}
-
-multilib_src_compile() {
-	meson_src_compile
-}
-
-multilib_src_test() {
-	meson_src_test
-}
-
-multilib_src_install() {
-	meson_src_install
 }

--- a/media-libs/harfbuzz/harfbuzz-2.7.4.ebuild
+++ b/media-libs/harfbuzz/harfbuzz-2.7.4.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{7..9} )
 
-inherit flag-o-matic meson multilib-minimal python-any-r1 xdg-utils
+inherit flag-o-matic meson-multilib python-any-r1 xdg-utils
 
 DESCRIPTION="An OpenType text shaping engine"
 HOMEPAGE="https://www.freedesktop.org/wiki/Software/HarfBuzz"
@@ -73,23 +73,15 @@ src_prepare() {
 	done
 }
 
-meson_multilib_native_feature() {
-	if multilib_is_native_abi && use "$1" ; then
-		echo "enabled"
-	else
-		echo "disabled"
-	fi
-}
-
 multilib_src_configure() {
 	# harfbuzz-gobject only used for instrospection, bug #535852
 	local emesonargs=(
-		-Dcairo="$(meson_multilib_native_feature cairo)"
+		$(meson_native_use_feature cairo)
 		-Dcoretext="disabled"
-		-Ddocs="$(meson_multilib_native_feature doc)"
+		$(meson_native_use_feature doc)
 		-Dfontconfig="disabled" #609300
-		-Dintrospection="$(meson_multilib_native_feature introspection)"
-		-Dstatic="$(usex static-libs true false)"
+		$(meson_native_use_feature introspection)
+		$(meson_use static-libs static)
 		$(meson_feature glib)
 		$(meson_feature graphite)
 		$(meson_feature icu)
@@ -98,16 +90,4 @@ multilib_src_configure() {
 		$(meson_feature truetype freetype)
 	)
 	meson_src_configure
-}
-
-multilib_src_compile() {
-	meson_src_compile
-}
-
-multilib_src_install() {
-	meson_src_install
-}
-
-multilib_src_install_all() {
-	einstalldocs
 }

--- a/media-libs/harfbuzz/harfbuzz-2.8.0.ebuild
+++ b/media-libs/harfbuzz/harfbuzz-2.8.0.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{7..9} )
 
-inherit flag-o-matic meson multilib-minimal python-any-r1 xdg-utils
+inherit flag-o-matic meson-multilib python-any-r1 xdg-utils
 
 DESCRIPTION="An OpenType text shaping engine"
 HOMEPAGE="https://www.freedesktop.org/wiki/Software/HarfBuzz"
@@ -73,23 +73,15 @@ src_prepare() {
 	done
 }
 
-meson_multilib_native_feature() {
-	if multilib_is_native_abi && use "$1" ; then
-		echo "enabled"
-	else
-		echo "disabled"
-	fi
-}
-
 multilib_src_configure() {
 	# harfbuzz-gobject only used for instrospection, bug #535852
 	local emesonargs=(
-		-Dcairo="$(meson_multilib_native_feature cairo)"
+		$(meson_native_use_feature cairo)
 		-Dcoretext="disabled"
-		-Ddocs="$(meson_multilib_native_feature doc)"
+		$(meson_native_use_feature doc)
 		-Dfontconfig="disabled" #609300
-		-Dintrospection="$(meson_multilib_native_feature introspection)"
-		-Dstatic="$(usex static-libs true false)"
+		$(meson_native_use_feature introspection)
+		$(meson_use static-libs static)
 		$(meson_feature glib)
 		$(meson_feature graphite)
 		$(meson_feature icu)
@@ -98,16 +90,4 @@ multilib_src_configure() {
 		$(meson_feature truetype freetype)
 	)
 	meson_src_configure
-}
-
-multilib_src_compile() {
-	meson_src_compile
-}
-
-multilib_src_install() {
-	meson_src_install
-}
-
-multilib_src_install_all() {
-	einstalldocs
 }

--- a/media-libs/harfbuzz/harfbuzz-2.8.1.ebuild
+++ b/media-libs/harfbuzz/harfbuzz-2.8.1.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{7..9} )
 
-inherit flag-o-matic meson multilib-minimal python-any-r1 xdg-utils
+inherit flag-o-matic meson-multilib python-any-r1 xdg-utils
 
 DESCRIPTION="An OpenType text shaping engine"
 HOMEPAGE="https://www.freedesktop.org/wiki/Software/HarfBuzz"
@@ -73,23 +73,15 @@ src_prepare() {
 	done
 }
 
-meson_multilib_native_feature() {
-	if multilib_is_native_abi && use "$1" ; then
-		echo "enabled"
-	else
-		echo "disabled"
-	fi
-}
-
 multilib_src_configure() {
 	# harfbuzz-gobject only used for instrospection, bug #535852
 	local emesonargs=(
-		-Dcairo="$(meson_multilib_native_feature cairo)"
+		$(meson_native_use_feature cairo)
 		-Dcoretext="disabled"
-		-Ddocs="$(meson_multilib_native_feature doc)"
+		$(meson_native_use_feature doc)
 		-Dfontconfig="disabled" #609300
-		-Dintrospection="$(meson_multilib_native_feature introspection)"
-		-Dstatic="$(usex static-libs true false)"
+		$(meson_native_use_feature introspection)
+		$(meson_use static-libs static)
 		$(meson_feature glib)
 		$(meson_feature graphite)
 		$(meson_feature icu)
@@ -98,16 +90,4 @@ multilib_src_configure() {
 		$(meson_feature truetype freetype)
 	)
 	meson_src_configure
-}
-
-multilib_src_compile() {
-	meson_src_compile
-}
-
-multilib_src_install() {
-	meson_src_install
-}
-
-multilib_src_install_all() {
-	einstalldocs
 }

--- a/media-libs/harfbuzz/harfbuzz-9999.ebuild
+++ b/media-libs/harfbuzz/harfbuzz-9999.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{7..9} )
 
-inherit flag-o-matic meson multilib-minimal python-any-r1 xdg-utils
+inherit flag-o-matic meson-multilib python-any-r1 xdg-utils
 
 DESCRIPTION="An OpenType text shaping engine"
 HOMEPAGE="https://www.freedesktop.org/wiki/Software/HarfBuzz"
@@ -73,23 +73,15 @@ src_prepare() {
 	done
 }
 
-meson_multilib_native_feature() {
-	if multilib_is_native_abi && use "$1" ; then
-		echo "enabled"
-	else
-		echo "disabled"
-	fi
-}
-
 multilib_src_configure() {
 	# harfbuzz-gobject only used for instrospection, bug #535852
 	local emesonargs=(
-		-Dcairo="$(meson_multilib_native_feature cairo)"
+		$(meson_native_use_feature cairo)
 		-Dcoretext="disabled"
-		-Ddocs="$(meson_multilib_native_feature doc)"
+		$(meson_native_use_feature doc)
 		-Dfontconfig="disabled" #609300
-		-Dintrospection="$(meson_multilib_native_feature introspection)"
-		-Dstatic="$(usex static-libs true false)"
+		$(meson_native_use_feature introspection)
+		$(meson_use static-libs static)
 		$(meson_feature glib)
 		$(meson_feature graphite)
 		$(meson_feature icu)
@@ -98,16 +90,4 @@ multilib_src_configure() {
 		$(meson_feature truetype freetype)
 	)
 	meson_src_configure
-}
-
-multilib_src_compile() {
-	meson_src_compile
-}
-
-multilib_src_install() {
-	meson_src_install
-}
-
-multilib_src_install_all() {
-	einstalldocs
 }

--- a/media-libs/libepoxy/libepoxy-1.5.5.ebuild
+++ b/media-libs/libepoxy/libepoxy-1.5.5.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{7,8,9} )
 PYTHON_REQ_USE='xml(+)'
-inherit meson multilib-minimal python-any-r1 virtualx
+inherit meson-multilib python-any-r1 virtualx
 
 if [[ ${PV} = 9999* ]]; then
 	EGIT_REPO_URI="https://github.com/anholt/${PN}.git"
@@ -41,14 +41,6 @@ multilib_src_configure() {
 	meson_src_configure
 }
 
-multilib_src_compile() {
-	meson_src_compile
-}
-
 multilib_src_test() {
 	virtx meson_src_test
-}
-
-multilib_src_install() {
-	meson_src_install
 }

--- a/media-libs/libepoxy/libepoxy-1.5.8.ebuild
+++ b/media-libs/libepoxy/libepoxy-1.5.8.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
 PYTHON_COMPAT=( python3_{7,8,9} )
 PYTHON_REQ_USE='xml(+)'
-inherit meson multilib-minimal python-any-r1 virtualx
+inherit meson-multilib python-any-r1 virtualx
 
 if [[ ${PV} = 9999* ]]; then
 	EGIT_REPO_URI="https://github.com/anholt/${PN}.git"
@@ -41,14 +41,6 @@ multilib_src_configure() {
 	meson_src_configure
 }
 
-multilib_src_compile() {
-	meson_src_compile
-}
-
 multilib_src_test() {
 	virtx meson_src_test
-}
-
-multilib_src_install() {
-	meson_src_install
 }

--- a/media-libs/libepoxy/libepoxy-9999.ebuild
+++ b/media-libs/libepoxy/libepoxy-9999.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
 PYTHON_COMPAT=( python3_{7,8,9} )
 PYTHON_REQ_USE='xml(+)'
-inherit meson multilib-minimal python-any-r1 virtualx
+inherit meson-multilib python-any-r1 virtualx
 
 if [[ ${PV} = 9999* ]]; then
 	EGIT_REPO_URI="https://github.com/anholt/${PN}.git"
@@ -41,14 +41,6 @@ multilib_src_configure() {
 	meson_src_configure
 }
 
-multilib_src_compile() {
-	meson_src_compile
-}
-
 multilib_src_test() {
 	virtx meson_src_test
-}
-
-multilib_src_install() {
-	meson_src_install
 }

--- a/media-libs/libglvnd/libglvnd-1.3.3.ebuild
+++ b/media-libs/libglvnd/libglvnd-1.3.3.ebuild
@@ -12,7 +12,7 @@ fi
 PYTHON_COMPAT=( python3_{7..9} )
 VIRTUALX_REQUIRED=manual
 
-inherit ${GIT_ECLASS} meson multilib-minimal python-any-r1 virtualx
+inherit ${GIT_ECLASS} meson-multilib python-any-r1 virtualx
 
 DESCRIPTION="The GL Vendor-Neutral Dispatch library"
 HOMEPAGE="https://gitlab.freedesktop.org/glvnd/libglvnd"
@@ -56,18 +56,10 @@ multilib_src_configure() {
 	meson_src_configure
 }
 
-multilib_src_compile() {
-	meson_src_compile
-}
-
 multilib_src_test() {
 	if use X; then
 		virtx meson_src_test
 	else
 		meson_src_test
 	fi
-}
-
-multilib_src_install() {
-	meson_src_install
 }

--- a/media-libs/libglvnd/libglvnd-9999.ebuild
+++ b/media-libs/libglvnd/libglvnd-9999.ebuild
@@ -12,7 +12,7 @@ fi
 PYTHON_COMPAT=( python3_{7..9} )
 VIRTUALX_REQUIRED=manual
 
-inherit ${GIT_ECLASS} meson multilib-minimal python-any-r1 virtualx
+inherit ${GIT_ECLASS} meson-multilib python-any-r1 virtualx
 
 DESCRIPTION="The GL Vendor-Neutral Dispatch library"
 HOMEPAGE="https://gitlab.freedesktop.org/glvnd/libglvnd"
@@ -56,18 +56,10 @@ multilib_src_configure() {
 	meson_src_configure
 }
 
-multilib_src_compile() {
-	meson_src_compile
-}
-
 multilib_src_test() {
 	if use X; then
 		virtx meson_src_test
 	else
 		meson_src_test
 	fi
-}
-
-multilib_src_install() {
-	meson_src_install
 }

--- a/media-libs/libplacebo/libplacebo-2.43.0.ebuild
+++ b/media-libs/libplacebo/libplacebo-2.43.0.ebuild
@@ -12,7 +12,7 @@ else
 	S="${WORKDIR}/${PN}-v${PV}"
 fi
 
-inherit meson multilib-minimal
+inherit meson-multilib
 
 DESCRIPTION="Reusable library for GPU-accelerated image processing primitives"
 HOMEPAGE="https://code.videolan.org/videolan/libplacebo"
@@ -51,14 +51,6 @@ multilib_src_configure() {
 	meson_src_configure
 }
 
-multilib_src_compile() {
-	meson_src_compile
-}
-
 multilib_src_test() {
 	meson_src_test -t 10
-}
-
-multilib_src_install() {
-	meson_src_install
 }

--- a/media-libs/libplacebo/libplacebo-2.43.1.ebuild
+++ b/media-libs/libplacebo/libplacebo-2.43.1.ebuild
@@ -12,7 +12,7 @@ else
 	S="${WORKDIR}/${PN}-v${PV}"
 fi
 
-inherit meson multilib-minimal
+inherit meson-multilib
 
 DESCRIPTION="Reusable library for GPU-accelerated image processing primitives"
 HOMEPAGE="https://code.videolan.org/videolan/libplacebo"
@@ -51,14 +51,6 @@ multilib_src_configure() {
 	meson_src_configure
 }
 
-multilib_src_compile() {
-	meson_src_compile
-}
-
 multilib_src_test() {
 	meson_src_test -t 10
-}
-
-multilib_src_install() {
-	meson_src_install
 }

--- a/media-libs/libplacebo/libplacebo-2.72.2.ebuild
+++ b/media-libs/libplacebo/libplacebo-2.72.2.ebuild
@@ -15,7 +15,7 @@ else
 	S="${WORKDIR}/${PN}-v${PV}"
 fi
 
-inherit meson multilib-minimal python-any-r1
+inherit meson-multilib python-any-r1
 
 DESCRIPTION="Reusable library for GPU-accelerated image processing primitives"
 HOMEPAGE="https://code.videolan.org/videolan/libplacebo"
@@ -68,14 +68,6 @@ multilib_src_configure() {
 	meson_src_configure
 }
 
-multilib_src_compile() {
-	meson_src_compile
-}
-
 multilib_src_test() {
 	meson_src_test -t 10
-}
-
-multilib_src_install() {
-	meson_src_install
 }

--- a/media-libs/libplacebo/libplacebo-3.120.3.ebuild
+++ b/media-libs/libplacebo/libplacebo-3.120.3.ebuild
@@ -15,7 +15,7 @@ else
 	S="${WORKDIR}/${PN}-v${PV}"
 fi
 
-inherit meson multilib-minimal python-any-r1
+inherit meson-multilib python-any-r1
 
 DESCRIPTION="Reusable library for GPU-accelerated image processing primitives"
 HOMEPAGE="https://code.videolan.org/videolan/libplacebo"
@@ -64,14 +64,6 @@ multilib_src_configure() {
 	meson_src_configure
 }
 
-multilib_src_compile() {
-	meson_src_compile
-}
-
 multilib_src_test() {
 	meson_src_test -t 10
-}
-
-multilib_src_install() {
-	meson_src_install
 }

--- a/media-libs/libplacebo/libplacebo-9999.ebuild
+++ b/media-libs/libplacebo/libplacebo-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -15,7 +15,7 @@ else
 	S="${WORKDIR}/${PN}-v${PV}"
 fi
 
-inherit meson multilib-minimal python-any-r1
+inherit meson-multilib python-any-r1
 
 DESCRIPTION="Reusable library for GPU-accelerated image processing primitives"
 HOMEPAGE="https://code.videolan.org/videolan/libplacebo"
@@ -65,14 +65,6 @@ multilib_src_configure() {
 	meson_src_configure
 }
 
-multilib_src_compile() {
-	meson_src_compile
-}
-
 multilib_src_test() {
 	meson_src_test -t 10
-}
-
-multilib_src_install() {
-	meson_src_install
 }

--- a/media-libs/mesa/mesa-20.3.5.ebuild
+++ b/media-libs/mesa/mesa-20.3.5.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{7,8,9} )
 
-inherit llvm meson multilib-minimal python-any-r1 linux-info
+inherit llvm meson-multilib python-any-r1 linux-info
 
 OPENGL_DIR="xorg-x11"
 
@@ -524,18 +524,6 @@ multilib_src_configure() {
 		-Db_ndebug=$(usex debug false true)
 	)
 	meson_src_configure
-}
-
-multilib_src_compile() {
-	meson_src_compile
-}
-
-multilib_src_install() {
-	meson_src_install
-}
-
-multilib_src_install_all() {
-	einstalldocs
 }
 
 multilib_src_test() {

--- a/media-libs/mesa/mesa-21.0.3.ebuild
+++ b/media-libs/mesa/mesa-21.0.3.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{7,8,9} )
 
-inherit llvm meson multilib-minimal python-any-r1 linux-info
+inherit llvm meson-multilib python-any-r1 linux-info
 
 OPENGL_DIR="xorg-x11"
 
@@ -522,18 +522,6 @@ multilib_src_configure() {
 		-Db_ndebug=$(usex debug false true)
 	)
 	meson_src_configure
-}
-
-multilib_src_compile() {
-	meson_src_compile
-}
-
-multilib_src_install() {
-	meson_src_install
-}
-
-multilib_src_install_all() {
-	einstalldocs
 }
 
 multilib_src_test() {

--- a/media-libs/mesa/mesa-21.1.1.ebuild
+++ b/media-libs/mesa/mesa-21.1.1.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{7,8,9} )
 
-inherit llvm meson multilib-minimal python-any-r1 linux-info
+inherit llvm meson-multilib python-any-r1 linux-info
 
 OPENGL_DIR="xorg-x11"
 
@@ -523,18 +523,6 @@ multilib_src_configure() {
 		-Db_ndebug=$(usex debug false true)
 	)
 	meson_src_configure
-}
-
-multilib_src_compile() {
-	meson_src_compile
-}
-
-multilib_src_install() {
-	meson_src_install
-}
-
-multilib_src_install_all() {
-	einstalldocs
 }
 
 multilib_src_test() {

--- a/media-libs/mesa/mesa-21.1.2.ebuild
+++ b/media-libs/mesa/mesa-21.1.2.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{7,8,9} )
 
-inherit llvm meson multilib-minimal python-any-r1 linux-info
+inherit llvm meson-multilib python-any-r1 linux-info
 
 OPENGL_DIR="xorg-x11"
 
@@ -523,18 +523,6 @@ multilib_src_configure() {
 		-Db_ndebug=$(usex debug false true)
 	)
 	meson_src_configure
-}
-
-multilib_src_compile() {
-	meson_src_compile
-}
-
-multilib_src_install() {
-	meson_src_install
-}
-
-multilib_src_install_all() {
-	einstalldocs
 }
 
 multilib_src_test() {

--- a/media-libs/mesa/mesa-9999.ebuild
+++ b/media-libs/mesa/mesa-9999.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{7,8,9} )
 
-inherit llvm meson multilib-minimal python-any-r1 linux-info
+inherit llvm meson-multilib python-any-r1 linux-info
 
 OPENGL_DIR="xorg-x11"
 
@@ -522,18 +522,6 @@ multilib_src_configure() {
 		-Db_ndebug=$(usex debug false true)
 	)
 	meson_src_configure
-}
-
-multilib_src_compile() {
-	meson_src_compile
-}
-
-multilib_src_install() {
-	meson_src_install
-}
-
-multilib_src_install_all() {
-	einstalldocs
 }
 
 multilib_src_test() {

--- a/media-libs/rubberband/rubberband-1.9.1-r1.ebuild
+++ b/media-libs/rubberband/rubberband-1.9.1-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit meson multilib-minimal
+inherit meson-multilib
 
 DESCRIPTION="An audio time-stretching and pitch-shifting library and utility program"
 HOMEPAGE="https://www.breakfastquay.com/rubberband/"
@@ -37,7 +37,7 @@ multilib_src_configure() {
 		--buildtype=release
 		-Dfft=fftw
 		-Dresampler=libsamplerate
-		-Dstatic=$(usex static-libs true false)
+		$(meson_use static-libs static)
 		$(meson_use ladspa)
 		$(meson_use jni)
 		$(meson_use programs)
@@ -49,15 +49,6 @@ multilib_src_configure() {
 	meson_src_configure
 }
 
-multilib_src_compile() {
-	meson_src_compile
-}
-
-multilib_src_install() {
-	meson_src_install
-}
-
 multilib_src_install_all() {
 	! use jni && find "${ED}" -name "*.a" -delete
-	einstalldocs
 }

--- a/media-libs/waffle/waffle-1.7.0.ebuild
+++ b/media-libs/waffle/waffle-1.7.0.ebuild
@@ -11,7 +11,7 @@ else
 	KEYWORDS="amd64 arm ~arm64 ~ppc ~ppc64 x86"
 	S="${WORKDIR}"/${PN}-v${PV}
 fi
-inherit meson multilib-minimal ${GIT_ECLASS}
+inherit meson-multilib ${GIT_ECLASS}
 
 DESCRIPTION="Library that allows selection of GL API and of window system at runtime"
 HOMEPAGE="http://www.waffle-gl.org/ https://gitlab.freedesktop.org/mesa/waffle"
@@ -49,14 +49,10 @@ multilib_src_configure() {
 		$(meson_feature X x11_egl)
 		$(meson_feature gbm)
 		$(meson_feature egl surfaceless_egl)
-		-Dbuild-manpages=$(multilib_is_native_abi && echo true || echo false)
+		$(meson_native_true build-manpages)
 		-Dbuild-tests=false
 	)
 	meson_src_configure
-}
-
-multilib_src_compile() {
-	meson_src_compile
 }
 
 multilib_src_install() {

--- a/media-libs/waffle/waffle-9999.ebuild
+++ b/media-libs/waffle/waffle-9999.ebuild
@@ -11,7 +11,7 @@ else
 	KEYWORDS="amd64 arm ~arm64 ~ppc ~ppc64 x86"
 	S="${WORKDIR}"/${PN}-v${PV}
 fi
-inherit meson multilib-minimal ${GIT_ECLASS}
+inherit meson-multilib ${GIT_ECLASS}
 
 DESCRIPTION="Library that allows selection of GL API and of window system at runtime"
 HOMEPAGE="http://www.waffle-gl.org/ https://gitlab.freedesktop.org/mesa/waffle"
@@ -49,14 +49,10 @@ multilib_src_configure() {
 		$(meson_feature X x11_egl)
 		$(meson_feature gbm)
 		$(meson_feature egl surfaceless_egl)
-		-Dbuild-manpages=$(multilib_is_native_abi && echo true || echo false)
+		$(meson_native_true build-manpages)
 		-Dbuild-tests=false
 	)
 	meson_src_configure
-}
-
-multilib_src_compile() {
-	meson_src_compile
 }
 
 multilib_src_install() {

--- a/media-video/pipewire/pipewire-0.3.27-r1.ebuild
+++ b/media-video/pipewire/pipewire-0.3.27-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI="7"
 
-inherit meson optfeature udev multilib-minimal
+inherit meson-multilib optfeature udev
 
 if [[ ${PV} == 9999 ]]; then
 	EGIT_REPO_URI="https://gitlab.freedesktop.org/${PN}/${PN}.git"
@@ -103,18 +103,6 @@ PATCHES=(
 # with changes as necessary.
 limitsdfile=40-${PN}.conf
 
-meson_native_enabled() {
-	if multilib_is_native_abi; then
-		echo "-D${1}=enabled"
-	else
-		echo "-D${1}=disabled"
-	fi
-}
-
-meson_native_feature() {
-	multilib_native_usex "${1}" "-D${2-${1}}=enabled" "-D${2-${1}}=disabled"
-}
-
 src_prepare() {
 	default
 
@@ -137,58 +125,54 @@ src_prepare() {
 multilib_src_configure() {
 	local emesonargs=(
 		-Ddocdir="${EPREFIX}"/usr/share/doc/${PF}
-		$(meson_native_feature doc docs)
+		$(meson_native_use_feature doc docs)
 		$(meson_native_enabled examples) # Disabling this implicitly disables -Dmedia-session
 		$(meson_native_enabled media-session)
 		$(meson_native_enabled man)
 		$(meson_feature test tests)
 		-Dinstalled_tests=disabled # Matches upstream; Gentoo never installs tests
-		$(meson_native_feature gstreamer)
-		$(meson_native_feature gstreamer gstreamer-device-provider)
-		$(meson_native_feature systemd)
+		$(meson_native_use_feature gstreamer)
+		$(meson_native_use_feature gstreamer gstreamer-device-provider)
+		$(meson_native_use_feature systemd)
 		-Dsystemd-system-service=disabled # Matches upstream
-		$(meson_native_feature systemd systemd-user-service)
+		$(meson_native_use_feature systemd systemd-user-service)
 		$(meson_feature pipewire-alsa) # Allows integrating ALSA apps into PW graph
 		-Dspa-plugins=enabled
 		-Dalsa=enabled # Allows using kernel ALSA for sound I/O (-Dmedia-session depends on this)
 		-Daudiomixer=enabled # Matches upstream
 		-Daudioconvert=enabled # Matches upstream
-		$(meson_native_feature bluetooth bluez5)
-		$(meson_native_feature bluetooth bluez5-backend-hsp-native)
-		$(meson_native_feature bluetooth bluez5-backend-hfp-native)
-		$(meson_native_feature bluetooth bluez5-backend-ofono)
-		$(meson_native_feature bluetooth bluez5-backend-hsphfpd)
-		$(meson_native_feature aac bluez5-codec-aac)
-		$(meson_native_feature aptx bluez5-codec-aptx)
-		$(meson_native_feature ldac bluez5-codec-ldac)
+		$(meson_native_use_feature bluetooth bluez5)
+		$(meson_native_use_feature bluetooth bluez5-backend-hsp-native)
+		$(meson_native_use_feature bluetooth bluez5-backend-hfp-native)
+		$(meson_native_use_feature bluetooth bluez5-backend-ofono)
+		$(meson_native_use_feature bluetooth bluez5-backend-hsphfpd)
+		$(meson_native_use_feature aac bluez5-codec-aac)
+		$(meson_native_use_feature aptx bluez5-codec-aptx)
+		$(meson_native_use_feature ldac bluez5-codec-ldac)
 		-Dcontrol=enabled # Matches upstream
 		-Daudiotestsrc=enabled # Matches upstream
 		-Dffmpeg=disabled # Disabled by upstream and no major developments to spa/plugins/ffmpeg/ since May 2020
 		-Dpipewire-jack=enabled # Allows integrating JACK apps into PW graph
-		$(meson_native_feature jack-client jack) # Allows PW to act as a JACK client
+		$(meson_native_use_feature jack-client jack) # Allows PW to act as a JACK client
 		$(meson_feature jack-sdk jack-devel)
 		$(usex jack-sdk "-Dlibjack-path=${EPREFIX}/usr/$(get_libdir)" '')
 		-Dsupport=enabled # Miscellaneous/common plugins, such as null sink
 		-Devl=disabled # Matches upstream
 		-Dtest=disabled # fakesink and fakesource plugins
-		$(meson_native_feature v4l v4l2)
+		$(meson_native_use_feature v4l v4l2)
 		-Dlibcamera=disabled # libcamera is not in Portage tree
 		-Dvideoconvert=enabled # Matches upstream
 		-Dvideotestsrc=enabled # Matches upstream
 		-Dvolume=enabled # Matches upstream
 		-Dvulkan=disabled # Uses pre-compiled Vulkan compute shader to provide a CGI video source (dev thing; disabled by upstream)
-		$(meson_native_feature extra pw-cat)
+		$(meson_native_use_feature extra pw-cat)
 		-Dudev=enabled
 		-Dudevrulesdir="$(get_udevdir)/rules.d"
 		-Dsdl2=disabled # Controls SDL2 dependent code (currently only examples when -Dinstalled_tests=enabled which we never install)
-		$(meson_native_feature extra sndfile) # Enables libsndfile dependent code (currently only pw-cat)
+		$(meson_native_use_feature extra sndfile) # Enables libsndfile dependent code (currently only pw-cat)
 	)
 
 	meson_src_configure
-}
-
-multilib_src_compile() {
-	meson_src_compile
 }
 
 multilib_src_install() {

--- a/media-video/pipewire/pipewire-0.3.28.ebuild
+++ b/media-video/pipewire/pipewire-0.3.28.ebuild
@@ -3,7 +3,7 @@
 
 EAPI="7"
 
-inherit meson optfeature udev multilib-minimal
+inherit meson-multilib optfeature udev
 
 if [[ ${PV} == 9999 ]]; then
 	EGIT_REPO_URI="https://gitlab.freedesktop.org/${PN}/${PN}.git"
@@ -104,18 +104,6 @@ PATCHES=(
 # with changes as necessary.
 limitsdfile=40-${PN}.conf
 
-meson_native_enabled() {
-	if multilib_is_native_abi; then
-		echo "-D${1}=enabled"
-	else
-		echo "-D${1}=disabled"
-	fi
-}
-
-meson_native_feature() {
-	multilib_native_usex "${1}" "-D${2-${1}}=enabled" "-D${2-${1}}=disabled"
-}
-
 src_prepare() {
 	default
 
@@ -138,58 +126,54 @@ src_prepare() {
 multilib_src_configure() {
 	local emesonargs=(
 		-Ddocdir="${EPREFIX}"/usr/share/doc/${PF}
-		$(meson_native_feature doc docs)
+		$(meson_native_use_feature doc docs)
 		$(meson_native_enabled examples) # Disabling this implicitly disables -Dmedia-session
 		$(meson_native_enabled media-session)
 		$(meson_native_enabled man)
 		$(meson_feature test tests)
 		-Dinstalled_tests=disabled # Matches upstream; Gentoo never installs tests
-		$(meson_native_feature gstreamer)
-		$(meson_native_feature gstreamer gstreamer-device-provider)
-		$(meson_native_feature systemd)
+		$(meson_native_use_feature gstreamer)
+		$(meson_native_use_feature gstreamer gstreamer-device-provider)
+		$(meson_native_use_feature systemd)
 		-Dsystemd-system-service=disabled # Matches upstream
-		$(meson_native_feature systemd systemd-user-service)
+		$(meson_native_use_feature systemd systemd-user-service)
 		$(meson_feature pipewire-alsa) # Allows integrating ALSA apps into PW graph
 		-Dspa-plugins=enabled
 		-Dalsa=enabled # Allows using kernel ALSA for sound I/O (-Dmedia-session depends on this)
 		-Daudiomixer=enabled # Matches upstream
 		-Daudioconvert=enabled # Matches upstream
-		$(meson_native_feature bluetooth bluez5)
-		$(meson_native_feature bluetooth bluez5-backend-hsp-native)
-		$(meson_native_feature bluetooth bluez5-backend-hfp-native)
-		$(meson_native_feature bluetooth bluez5-backend-ofono)
-		$(meson_native_feature bluetooth bluez5-backend-hsphfpd)
-		$(meson_native_feature aac bluez5-codec-aac)
-		$(meson_native_feature aptx bluez5-codec-aptx)
-		$(meson_native_feature ldac bluez5-codec-ldac)
+		$(meson_native_use_feature bluetooth bluez5)
+		$(meson_native_use_feature bluetooth bluez5-backend-hsp-native)
+		$(meson_native_use_feature bluetooth bluez5-backend-hfp-native)
+		$(meson_native_use_feature bluetooth bluez5-backend-ofono)
+		$(meson_native_use_feature bluetooth bluez5-backend-hsphfpd)
+		$(meson_native_use_feature aac bluez5-codec-aac)
+		$(meson_native_use_feature aptx bluez5-codec-aptx)
+		$(meson_native_use_feature ldac bluez5-codec-ldac)
 		-Dcontrol=enabled # Matches upstream
 		-Daudiotestsrc=enabled # Matches upstream
 		-Dffmpeg=disabled # Disabled by upstream and no major developments to spa/plugins/ffmpeg/ since May 2020
 		-Dpipewire-jack=enabled # Allows integrating JACK apps into PW graph
-		$(meson_native_feature jack-client jack) # Allows PW to act as a JACK client
+		$(meson_native_use_feature jack-client jack) # Allows PW to act as a JACK client
 		$(meson_feature jack-sdk jack-devel)
 		$(usex jack-sdk "-Dlibjack-path=${EPREFIX}/usr/$(get_libdir)" '')
 		-Dsupport=enabled # Miscellaneous/common plugins, such as null sink
 		-Devl=disabled # Matches upstream
 		-Dtest=disabled # fakesink and fakesource plugins
-		$(meson_native_feature v4l v4l2)
+		$(meson_native_use_feature v4l v4l2)
 		-Dlibcamera=disabled # libcamera is not in Portage tree
 		-Dvideoconvert=enabled # Matches upstream
 		-Dvideotestsrc=enabled # Matches upstream
 		-Dvolume=enabled # Matches upstream
 		-Dvulkan=disabled # Uses pre-compiled Vulkan compute shader to provide a CGI video source (dev thing; disabled by upstream)
-		$(meson_native_feature extra pw-cat)
+		$(meson_native_use_feature extra pw-cat)
 		-Dudev=enabled
 		-Dudevrulesdir="$(get_udevdir)/rules.d"
 		-Dsdl2=disabled # Controls SDL2 dependent code (currently only examples when -Dinstalled_tests=enabled which we never install)
-		$(meson_native_feature extra sndfile) # Enables libsndfile dependent code (currently only pw-cat)
+		$(meson_native_use_feature extra sndfile) # Enables libsndfile dependent code (currently only pw-cat)
 	)
 
 	meson_src_configure
-}
-
-multilib_src_compile() {
-	meson_src_compile
 }
 
 multilib_src_install() {

--- a/media-video/pipewire/pipewire-9999.ebuild
+++ b/media-video/pipewire/pipewire-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI="7"
 
-inherit meson optfeature udev multilib-minimal
+inherit meson-multilib optfeature udev
 
 if [[ ${PV} == 9999 ]]; then
 	EGIT_REPO_URI="https://gitlab.freedesktop.org/${PN}/${PN}.git"
@@ -104,18 +104,6 @@ PATCHES=(
 # with changes as necessary.
 limitsdfile=40-${PN}.conf
 
-meson_native_enabled() {
-	if multilib_is_native_abi; then
-		echo "-D${1}=enabled"
-	else
-		echo "-D${1}=disabled"
-	fi
-}
-
-meson_native_feature() {
-	multilib_native_usex "${1}" "-D${2-${1}}=enabled" "-D${2-${1}}=disabled"
-}
-
 src_prepare() {
 	default
 
@@ -138,58 +126,54 @@ src_prepare() {
 multilib_src_configure() {
 	local emesonargs=(
 		-Ddocdir="${EPREFIX}"/usr/share/doc/${PF}
-		$(meson_native_feature doc docs)
+		$(meson_native_use_feature doc docs)
 		$(meson_native_enabled examples) # Disabling this implicitly disables -Dmedia-session
 		$(meson_native_enabled media-session)
 		$(meson_native_enabled man)
 		$(meson_feature test tests)
 		-Dinstalled_tests=disabled # Matches upstream; Gentoo never installs tests
-		$(meson_native_feature gstreamer)
-		$(meson_native_feature gstreamer gstreamer-device-provider)
-		$(meson_native_feature systemd)
+		$(meson_native_use_feature gstreamer)
+		$(meson_native_use_feature gstreamer gstreamer-device-provider)
+		$(meson_native_use_feature systemd)
 		-Dsystemd-system-service=disabled # Matches upstream
-		$(meson_native_feature systemd systemd-user-service)
+		$(meson_native_use_feature systemd systemd-user-service)
 		$(meson_feature pipewire-alsa) # Allows integrating ALSA apps into PW graph
 		-Dspa-plugins=enabled
 		-Dalsa=enabled # Allows using kernel ALSA for sound I/O (-Dmedia-session depends on this)
 		-Daudiomixer=enabled # Matches upstream
 		-Daudioconvert=enabled # Matches upstream
-		$(meson_native_feature bluetooth bluez5)
-		$(meson_native_feature bluetooth bluez5-backend-hsp-native)
-		$(meson_native_feature bluetooth bluez5-backend-hfp-native)
-		$(meson_native_feature bluetooth bluez5-backend-ofono)
-		$(meson_native_feature bluetooth bluez5-backend-hsphfpd)
-		$(meson_native_feature aac bluez5-codec-aac)
-		$(meson_native_feature aptx bluez5-codec-aptx)
-		$(meson_native_feature ldac bluez5-codec-ldac)
+		$(meson_native_use_feature bluetooth bluez5)
+		$(meson_native_use_feature bluetooth bluez5-backend-hsp-native)
+		$(meson_native_use_feature bluetooth bluez5-backend-hfp-native)
+		$(meson_native_use_feature bluetooth bluez5-backend-ofono)
+		$(meson_native_use_feature bluetooth bluez5-backend-hsphfpd)
+		$(meson_native_use_feature aac bluez5-codec-aac)
+		$(meson_native_use_feature aptx bluez5-codec-aptx)
+		$(meson_native_use_feature ldac bluez5-codec-ldac)
 		-Dcontrol=enabled # Matches upstream
 		-Daudiotestsrc=enabled # Matches upstream
 		-Dffmpeg=disabled # Disabled by upstream and no major developments to spa/plugins/ffmpeg/ since May 2020
 		-Dpipewire-jack=enabled # Allows integrating JACK apps into PW graph
-		$(meson_native_feature jack-client jack) # Allows PW to act as a JACK client
+		$(meson_native_use_feature jack-client jack) # Allows PW to act as a JACK client
 		$(meson_feature jack-sdk jack-devel)
 		$(usex jack-sdk "-Dlibjack-path=${EPREFIX}/usr/$(get_libdir)" '')
 		-Dsupport=enabled # Miscellaneous/common plugins, such as null sink
 		-Devl=disabled # Matches upstream
 		-Dtest=disabled # fakesink and fakesource plugins
-		$(meson_native_feature v4l v4l2)
+		$(meson_native_use_feature v4l v4l2)
 		-Dlibcamera=disabled # libcamera is not in Portage tree
 		-Dvideoconvert=enabled # Matches upstream
 		-Dvideotestsrc=enabled # Matches upstream
 		-Dvolume=enabled # Matches upstream
 		-Dvulkan=disabled # Uses pre-compiled Vulkan compute shader to provide a CGI video source (dev thing; disabled by upstream)
-		$(meson_native_feature extra pw-cat)
+		$(meson_native_use_feature extra pw-cat)
 		-Dudev=enabled
 		-Dudevrulesdir="$(get_udevdir)/rules.d"
 		-Dsdl2=disabled # Controls SDL2 dependent code (currently only examples when -Dinstalled_tests=enabled which we never install)
-		$(meson_native_feature extra sndfile) # Enables libsndfile dependent code (currently only pw-cat)
+		$(meson_native_use_feature extra sndfile) # Enables libsndfile dependent code (currently only pw-cat)
 	)
 
 	meson_src_configure
-}
-
-multilib_src_compile() {
-	meson_src_compile
 }
 
 multilib_src_install() {

--- a/net-libs/glib-networking/glib-networking-2.68.1.ebuild
+++ b/net-libs/glib-networking/glib-networking-2.68.1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit gnome.org gnome2-utils meson multilib-minimal xdg
+inherit gnome.org gnome2-utils meson-multilib xdg
 
 DESCRIPTION="Network-related giomodules for glib"
 HOMEPAGE="https://gitlab.gnome.org/GNOME/glib-networking"
@@ -53,14 +53,6 @@ multilib_src_configure() {
 		-Dstatic_modules=false
 	)
 	meson_src_configure
-}
-
-multilib_src_compile() {
-	meson_src_compile
-}
-
-multilib_src_install() {
-	meson_src_install
 }
 
 multilib_src_test() {

--- a/net-libs/gssdp/gssdp-1.2.2.ebuild
+++ b/net-libs/gssdp/gssdp-1.2.2.ebuild
@@ -1,10 +1,10 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="7"
 VALA_USE_DEPEND="vapigen"
 
-inherit gnome.org meson multilib-minimal vala xdg
+inherit gnome.org meson-multilib vala xdg
 
 DESCRIPTION="GObject-based API for handling resource discovery and announcement over SSDP"
 HOMEPAGE="https://wiki.gnome.org/Projects/GUPnP"
@@ -39,23 +39,11 @@ src_prepare() {
 
 multilib_src_configure() {
 	local emesonargs=(
-		-Dgtk_doc=$(multilib_native_usex gtk-doc true false)
-		-Dsniffer=$(multilib_native_usex gtk true false)
-		-Dintrospection=$(multilib_native_usex introspection true false)
-		-Dvapi=$(multilib_native_usex vala true false)
+		$(meson_native_use_bool gtk-doc gtk_doc)
+		$(meson_native_use_bool gtk sniffer)
+		$(meson_native_use_bool introspection)
+		$(meson_native_use_bool vala vapi)
 		-Dexamples=false
 	)
 	meson_src_configure
-}
-
-multilib_src_compile() {
-	meson_src_compile
-}
-
-multilib_src_test() {
-	meson_src_test
-}
-
-multilib_src_install() {
-	meson_src_install
 }

--- a/net-libs/gssdp/gssdp-1.2.3.ebuild
+++ b/net-libs/gssdp/gssdp-1.2.3.ebuild
@@ -1,10 +1,10 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="7"
 VALA_USE_DEPEND="vapigen"
 
-inherit gnome.org meson multilib-minimal vala xdg
+inherit gnome.org meson-multilib vala xdg
 
 DESCRIPTION="GObject-based API for handling resource discovery and announcement over SSDP"
 HOMEPAGE="https://wiki.gnome.org/Projects/GUPnP"
@@ -39,23 +39,11 @@ src_prepare() {
 
 multilib_src_configure() {
 	local emesonargs=(
-		-Dgtk_doc=$(multilib_native_usex gtk-doc true false)
-		-Dsniffer=$(multilib_native_usex gtk true false)
-		-Dintrospection=$(multilib_native_usex introspection true false)
-		-Dvapi=$(multilib_native_usex vala true false)
+		$(meson_native_use_bool gtk-doc gtk_doc)
+		$(meson_native_use_bool gtk sniffer)
+		$(meson_native_use_bool introspection)
+		$(meson_native_use_bool vala vapi)
 		-Dexamples=false
 	)
 	meson_src_configure
-}
-
-multilib_src_compile() {
-	meson_src_compile
-}
-
-multilib_src_test() {
-	meson_src_test
-}
-
-multilib_src_install() {
-	meson_src_install
 }

--- a/net-libs/gupnp/gupnp-1.2.6.ebuild
+++ b/net-libs/gupnp/gupnp-1.2.6.ebuild
@@ -6,7 +6,7 @@ VALA_USE_DEPEND="vapigen"
 PYTHON_COMPAT=( python3_{7,8,9} )
 PYTHON_REQ_USE="xml"
 
-inherit gnome.org meson multilib-minimal python-single-r1 vala xdg
+inherit gnome.org meson-multilib python-single-r1 vala xdg
 
 DESCRIPTION="An object-oriented framework for creating UPnP devs and control points"
 HOMEPAGE="https://wiki.gnome.org/Projects/GUPnP"
@@ -58,27 +58,14 @@ multilib_src_configure() {
 
 	local emesonargs=(
 		-Dcontext_manager=${backend}
-		-Dintrospection=$(multilib_native_usex introspection true false)
-		-Dvapi=$(multilib_native_usex vala true false)
-		-Dgtk_doc=$(multilib_native_usex gtk-doc true false)
+		$(meson_native_use_bool introspection)
+		$(meson_native_use_bool vala vapi)
+		$(meson_native_use_bool gtk-doc gtk_doc)
 		-Dexamples=false
 	)
 	meson_src_configure
 }
 
-multilib_src_compile() {
-	meson_src_compile
-}
-
-multilib_src_test() {
-	meson_src_test
-}
-
-multilib_src_install() {
-	meson_src_install
-}
-
 multilib_src_install_all() {
-	einstalldocs
 	python_fix_shebang "${ED}"/usr/bin/gupnp-binding-tool-1.2
 }

--- a/net-libs/libsoup/libsoup-2.72.0.ebuild
+++ b/net-libs/libsoup/libsoup-2.72.0.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 VALA_USE_DEPEND="vapigen"
 
-inherit gnome.org meson multilib-minimal vala xdg
+inherit gnome.org meson-multilib vala xdg
 
 DESCRIPTION="HTTP client/server library for GNOME"
 HOMEPAGE="https://wiki.gnome.org/Projects/libsoup"
@@ -80,24 +80,12 @@ multilib_src_configure() {
 		-Dntlm_auth="${EPREFIX}/usr/bin/ntlm_auth"
 		-Dtls_check=false # disables check, we still rdep on glib-networking
 		-Dgnome=false
-		-Dintrospection=$(multilib_native_usex introspection enabled disabled)
-		-Dvapi=$(multilib_native_usex vala enabled disabled)
-		-Dgtk_doc=$(multilib_native_usex gtk-doc true false)
+		$(meson_native_use_feature introspection)
+		$(meson_native_use_feature vala vapi)
+		$(meson_native_use_bool gtk-doc gtk_doc)
 		$(meson_use test tests)
 		-Dinstalled_tests=false
 		$(meson_feature sysprof)
 	)
 	meson_src_configure
-}
-
-multilib_src_compile() {
-	meson_src_compile
-}
-
-multilib_src_test() {
-	meson_src_test
-}
-
-multilib_src_install() {
-	meson_src_install
 }

--- a/sys-apps/systemd/systemd-9999.ebuild
+++ b/sys-apps/systemd/systemd-9999.ebuild
@@ -21,7 +21,7 @@ fi
 
 PYTHON_COMPAT=( python3_{7..9} )
 
-inherit bash-completion-r1 linux-info meson multilib-minimal ninja-utils pam python-any-r1 systemd toolchain-funcs udev usr-ldscript
+inherit bash-completion-r1 linux-info meson-multilib pam python-any-r1 systemd toolchain-funcs udev usr-ldscript
 
 DESCRIPTION="System and service manager for Linux"
 HOMEPAGE="https://www.freedesktop.org/wiki/Software/systemd"
@@ -239,26 +239,6 @@ src_configure() {
 	multilib-minimal_src_configure
 }
 
-sd_use() {
-	usex "$1" true false
-}
-
-sd_native() {
-	if multilib_is_native_abi; then
-		echo true
-	else
-		echo false
-	fi
-}
-
-sd_native_use() {
-	if multilib_is_native_abi && use "$1"; then
-		echo true
-	else
-		echo false
-	fi
-}
-
 multilib_src_configure() {
 	local myconf=(
 		--localstatedir="${EPREFIX}/var"
@@ -267,7 +247,7 @@ multilib_src_configure() {
 		# avoid bash-completion dep
 		-Dbashcompletiondir="$(get_bashcompdir)"
 		# make sure we get /bin:/sbin in PATH
-		-Dsplit-usr=$(usex split-usr true false)
+		$(meson_use split-usr)
 		-Dsplit-bin=true
 		-Drootprefix="$(usex split-usr "${EPREFIX:-/}" "${EPREFIX}/usr")"
 		-Drootlibdir="${EPREFIX}/usr/$(get_libdir)"
@@ -277,87 +257,79 @@ multilib_src_configure() {
 		-Dima=true
 		-Ddefault-hierarchy=$(usex cgroup-hybrid hybrid unified)
 		# Optional components/dependencies
-		-Dacl=$(sd_native_use acl)
-		-Dapparmor=$(sd_native_use apparmor)
-		-Daudit=$(sd_native_use audit)
-		-Dlibcryptsetup=$(sd_native_use cryptsetup)
-		-Dlibcurl=$(sd_native_use curl)
-		-Ddns-over-tls=$(sd_native_use dns-over-tls)
-		-Delfutils=$(sd_native_use elfutils)
-		-Dgcrypt=$(sd_use gcrypt)
-		-Dgnu-efi=$(sd_native_use gnuefi)
+		$(meson_native_use_bool acl)
+		$(meson_native_use_bool apparmor)
+		$(meson_native_use_bool audit)
+		$(meson_native_use_bool cryptsetup libcryptsetup)
+		$(meson_native_use_bool curl libcurl)
+		$(meson_native_use_bool dns-over-tls dns-over-tls)
+		$(meson_native_use_bool elfutils)
+		$(meson_use gcrypt)
+		$(meson_native_use_bool gnuefi gnu-efi)
 		-Defi-includedir="${ESYSROOT}/usr/include/efi"
 		-Defi-ld="$(tc-getLD)"
 		-Defi-libdir="${ESYSROOT}/usr/$(get_libdir)"
-		-Dhomed=$(sd_native_use homed)
-		-Dhwdb=$(sd_native_use hwdb)
-		-Dmicrohttpd=$(sd_native_use http)
-		-Didn=$(sd_native_use idn)
-		-Dimportd=$(sd_native_use importd)
-		-Dbzip2=$(sd_native_use importd)
-		-Dzlib=$(sd_native_use importd)
-		-Dkmod=$(sd_native_use kmod)
-		-Dlz4=$(sd_use lz4)
-		-Dxz=$(sd_use lzma)
-		-Dzstd=$(sd_use zstd)
-		-Dlibiptc=$(sd_native_use nat)
-		-Dpam=$(sd_use pam)
-		-Dp11kit=$(sd_native_use pkcs11)
-		-Dpcre2=$(sd_native_use pcre)
-		-Dpolkit=$(sd_native_use policykit)
-		-Dpwquality=$(sd_native_use pwquality)
-		-Dqrencode=$(sd_native_use qrcode)
-		-Drepart=$(sd_native_use repart)
-		-Dseccomp=$(sd_native_use seccomp)
-		-Dselinux=$(sd_native_use selinux)
-		-Dtpm2=$(sd_native_use tpm)
-		-Ddbus=$(sd_native_use test)
-		-Dxkbcommon=$(sd_native_use xkb)
+		$(meson_native_use_bool homed)
+		$(meson_native_use_bool hwdb)
+		$(meson_native_use_bool http microhttpd)
+		$(meson_native_use_bool idn)
+		$(meson_native_use_bool importd)
+		$(meson_native_use_bool importd bzip2)
+		$(meson_native_use_bool importd zlib)
+		$(meson_native_use_bool kmod)
+		$(meson_use lz4)
+		$(meson_use lzma xz)
+		$(meson_use zstd)
+		$(meson_native_use_bool nat libiptc)
+		$(meson_use pam)
+		$(meson_native_use_bool pkcs11 p11kit)
+		$(meson_native_use_bool pcre pcre2)
+		$(meson_native_use_bool policykit polkit)
+		$(meson_native_use_bool pwquality)
+		$(meson_native_use_bool qrcode qrencode)
+		$(meson_native_use_bool repart)
+		$(meson_native_use_bool seccomp)
+		$(meson_native_use_bool selinux)
+		$(meson_native_use_bool tpm tpm2)
+		$(meson_native_use_bool test dbus)
+		$(meson_native_use_bool xkb xkbcommon)
 		-Dntp-servers="0.gentoo.pool.ntp.org 1.gentoo.pool.ntp.org 2.gentoo.pool.ntp.org 3.gentoo.pool.ntp.org"
 		# Breaks screen, tmux, etc.
 		-Ddefault-kill-user-processes=false
 		-Dcreate-log-dirs=false
 
 		# multilib options
-		-Dbacklight=$(sd_native)
-		-Dbinfmt=$(sd_native)
-		-Dcoredump=$(sd_native)
-		-Denvironment-d=$(sd_native)
-		-Dfirstboot=$(sd_native)
-		-Dhibernate=$(sd_native)
-		-Dhostnamed=$(sd_native)
-		-Dldconfig=$(sd_native)
-		-Dlocaled=$(sd_native)
-		-Dman=$(sd_native)
-		-Dnetworkd=$(sd_native)
-		-Dquotacheck=$(sd_native)
-		-Drandomseed=$(sd_native)
-		-Drfkill=$(sd_native)
-		-Dsysusers=$(sd_native)
-		-Dtimedated=$(sd_native)
-		-Dtimesyncd=$(sd_native)
-		-Dtmpfiles=$(sd_native)
-		-Dvconsole=$(sd_native)
+		$(meson_native_true backlight)
+		$(meson_native_true binfmt)
+		$(meson_native_true coredump)
+		$(meson_native_true environment-d)
+		$(meson_native_true firstboot)
+		$(meson_native_true hibernate)
+		$(meson_native_true hostnamed)
+		$(meson_native_true ldconfig)
+		$(meson_native_true localed)
+		$(meson_native_true man)
+		$(meson_native_true networkd)
+		$(meson_native_true quotacheck)
+		$(meson_native_true randomseed)
+		$(meson_native_true rfkill)
+		$(meson_native_true sysusers)
+		$(meson_native_true timedated)
+		$(meson_native_true timesyncd)
+		$(meson_native_true tmpfiles)
+		$(meson_native_true vconsole)
 
 		# static-libs
-		-Dstatic-libsystemd=$(usex static-libs true false)
-		-Dstatic-libudev=$(usex static-libs true false)
+		$(meson_use static-libs static-libsystemd)
+		$(meson_use static-libs static-libudev)
 	)
 
 	meson_src_configure "${myconf[@]}"
 }
 
-multilib_src_compile() {
-	eninja
-}
-
 multilib_src_test() {
 	unset DBUS_SESSION_BUS_ADDRESS XDG_RUNTIME_DIR
 	meson_src_test
-}
-
-multilib_src_install() {
-	DESTDIR="${D}" eninja install
 }
 
 multilib_src_install_all() {

--- a/sys-fs/fuse/fuse-3.10.3.ebuild
+++ b/sys-fs/fuse/fuse-3.10.3.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 
 PYTHON_COMPAT=( python3_{7,8,9} )
-inherit meson multilib-minimal udev python-any-r1
+inherit meson-multilib udev python-any-r1
 
 DESCRIPTION="An interface for filesystems implemented in userspace"
 HOMEPAGE="https://github.com/libfuse/libfuse"
@@ -35,15 +35,11 @@ pkg_setup() {
 
 multilib_src_configure() {
 	local emesonargs=(
-		-Dexamples=$(usex test true false)
+		$(meson_use test examples)
 		-Duseroot=false
 		-Dudevrulesdir="${EPREFIX}$(get_udevdir)/rules.d"
 	)
 	meson_src_configure
-}
-
-multilib_src_compile() {
-	eninja
 }
 
 src_test() {
@@ -60,13 +56,7 @@ multilib_src_test() {
 	${EPYTHON} -m pytest test || die
 }
 
-multilib_src_install() {
-	DESTDIR="${D}" eninja install
-}
-
 multilib_src_install_all() {
-	einstalldocs
-
 	# installed via fuse-common
 	rm -r "${ED}"/{etc,$(get_udevdir)} || die
 

--- a/sys-fs/fuse/fuse-3.9.3.ebuild
+++ b/sys-fs/fuse/fuse-3.9.3.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 PYTHON_COMPAT=( python3_{7,8} )
 
-inherit meson multilib-minimal flag-o-matic udev python-any-r1
+inherit meson-multilib flag-o-matic udev python-any-r1
 
 DESCRIPTION="An interface for filesystems implemented in userspace"
 HOMEPAGE="https://github.com/libfuse/libfuse"
@@ -42,15 +42,11 @@ src_prepare() {
 
 multilib_src_configure() {
 	local emesonargs=(
-		-Dexamples=$(usex test true false)
+		$(meson_use test examples)
 		-Duseroot=false
 		-Dudevrulesdir="${EPREFIX}$(get_udevdir)/rules.d"
 	)
 	meson_src_configure
-}
-
-multilib_src_compile() {
-	eninja
 }
 
 src_test() {
@@ -67,13 +63,7 @@ multilib_src_test() {
 	${EPYTHON} -m pytest test || die
 }
 
-multilib_src_install() {
-	DESTDIR="${D}" eninja install
-}
-
 multilib_src_install_all() {
-	einstalldocs
-
 	# installed via fuse-common
 	rm -r "${ED}"/{etc,$(get_udevdir)} || die
 

--- a/sys-fs/udev/udev-248.ebuild
+++ b/sys-fs/udev/udev-248.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 PYTHON_COMPAT=( python3_{7..9} )
 
-inherit bash-completion-r1 linux-info meson ninja-utils multilib-minimal python-any-r1 toolchain-funcs udev usr-ldscript
+inherit bash-completion-r1 linux-info meson-multilib ninja-utils python-any-r1 toolchain-funcs udev usr-ldscript
 
 if [[ ${PV} = 9999* ]] ; then
 	EGIT_REPO_URI="https://github.com/systemd/systemd.git"
@@ -99,24 +99,16 @@ src_prepare() {
 	default
 }
 
-meson_multilib_native_use() {
-	if multilib_is_native_abi && use "$1" ; then
-		echo true
-	else
-		echo false
-	fi
-}
-
 multilib_src_configure() {
 	local emesonargs=(
-		-Dacl=$(meson_multilib_native_use acl)
+		$(meson_native_use_bool acl)
 		-Defi=false
-		-Dkmod=$(meson_multilib_native_use kmod)
-		-Dselinux=$(meson_multilib_native_use selinux)
+		$(meson_native_use_bool kmod)
+		$(meson_native_use_bool selinux)
 		-Dlink-udev-shared=false
 		-Dsplit-usr=true
 		-Drootlibdir="${EPREFIX}/usr/$(get_libdir)"
-		-Dstatic-libudev=$(usex static-libs true false)
+		$(meson_use static-libs static-libudev)
 
 		# Prevent automagic deps
 		-Dgcrypt=false

--- a/sys-fs/udev/udev-9999.ebuild
+++ b/sys-fs/udev/udev-9999.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 PYTHON_COMPAT=( python3_{7..9} )
 
-inherit bash-completion-r1 linux-info meson ninja-utils multilib-minimal python-any-r1 toolchain-funcs udev usr-ldscript
+inherit bash-completion-r1 linux-info meson-multilib ninja-utils python-any-r1 toolchain-funcs udev usr-ldscript
 
 if [[ ${PV} = 9999* ]] ; then
 	EGIT_REPO_URI="https://github.com/systemd/systemd.git"
@@ -99,24 +99,16 @@ src_prepare() {
 	default
 }
 
-meson_multilib_native_use() {
-	if multilib_is_native_abi && use "$1" ; then
-		echo true
-	else
-		echo false
-	fi
-}
-
 multilib_src_configure() {
 	local emesonargs=(
-		-Dacl=$(meson_multilib_native_use acl)
+		$(meson_native_use_bool acl)
 		-Defi=false
-		-Dkmod=$(meson_multilib_native_use kmod)
-		-Dselinux=$(meson_multilib_native_use selinux)
+		$(meson_native_use_bool kmod)
+		$(meson_native_use_bool selinux)
 		-Dlink-udev-shared=false
 		-Dsplit-usr=true
 		-Drootlibdir="${EPREFIX}/usr/$(get_libdir)"
-		-Dstatic-libudev=$(usex static-libs true false)
+		$(meson_use static-libs static-libudev)
 
 		# Prevent automagic deps
 		-Dgcrypt=false

--- a/x11-libs/gdk-pixbuf-xlib/gdk-pixbuf-xlib-2.40.2.ebuild
+++ b/x11-libs/gdk-pixbuf-xlib/gdk-pixbuf-xlib-2.40.2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit gnome.org meson multilib-minimal
+inherit gnome.org meson-multilib
 
 DESCRIPTION="Deprecated Xlib integration for GdkPixbuf"
 HOMEPAGE="https://gitlab.gnome.org/Archive/gdk-pixbuf-xlib"
@@ -28,15 +28,7 @@ BDEPEND="
 
 multilib_src_configure() {
 	local emesonargs=(
-		-Dgtk-doc="$(multilib_native_usex gtk-doc true false)"
+		$(meson_native_use_bool gtk-doc)
 	)
 	meson_src_configure
-}
-
-multilib_src_compile() {
-	meson_src_compile
-}
-
-multilib_src_install() {
-	meson_src_install
 }

--- a/x11-libs/gdk-pixbuf/gdk-pixbuf-2.42.6.ebuild
+++ b/x11-libs/gdk-pixbuf/gdk-pixbuf-2.42.6.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit gnome.org gnome2-utils meson multilib multilib-minimal xdg
+inherit gnome.org gnome2-utils meson-multilib multilib xdg
 
 DESCRIPTION="Image loading library for GTK+"
 HOMEPAGE="https://gitlab.gnome.org/GNOME/gdk-pixbuf"
@@ -70,37 +70,15 @@ multilib_src_configure() {
 		#native_windows_loaders
 		-Dinstalled_tests=false
 		-Dgio_sniffing=true
+		$(meson_native_use_bool gtk-doc gtk_doc)
+		$(meson_native_use_feature introspection)
+		$(meson_native_true man)
 	)
-	if multilib_is_native_abi; then
-		emesonargs+=(
-			$(meson_use gtk-doc gtk_doc)
-			$(meson_feature introspection)
-			-Dman=true
-		)
-	else
-		emesonargs+=(
-			-Dgtk_doc=false
-			-Dintrospection=disabled
-			-Dman=false
-		)
-	fi
+
 	meson_src_configure
 }
 
-multilib_src_compile() {
-	meson_src_compile
-}
-
-multilib_src_test() {
-	meson_src_test
-}
-
-multilib_src_install() {
-	meson_src_install
-}
-
 multilib_src_install_all() {
-	einstalldocs
 	if use gtk-doc; then
 		mkdir "${ED}"/usr/share/doc/${PF}/html || die
 		mv "${ED}"/usr/share/doc/{${PN}/,${PF}/html/} || die

--- a/x11-libs/libdrm/libdrm-2.4.106.ebuild
+++ b/x11-libs/libdrm/libdrm-2.4.106.ebuild
@@ -9,7 +9,7 @@ if [[ ${PV} = 9999* ]]; then
 	GIT_ECLASS="git-r3"
 fi
 
-inherit ${GIT_ECLASS} meson multilib-minimal
+inherit ${GIT_ECLASS} meson-multilib
 
 DESCRIPTION="X.Org libdrm library"
 HOMEPAGE="https://dri.freedesktop.org/ https://gitlab.freedesktop.org/mesa/drm"
@@ -40,32 +40,20 @@ multilib_src_configure() {
 		# Udev is only used by tests now.
 		-Dudev=false
 		-Dcairo-tests=false
-		-Damdgpu=$(usex video_cards_amdgpu true false)
-		-Dexynos=$(usex video_cards_exynos true false)
-		-Dfreedreno=$(usex video_cards_freedreno true false)
-		-Dintel=$(usex video_cards_intel true false)
-		-Dnouveau=$(usex video_cards_nouveau true false)
-		-Domap=$(usex video_cards_omap true false)
-		-Dradeon=$(usex video_cards_radeon true false)
-		-Dtegra=$(usex video_cards_tegra true false)
-		-Dvc4=$(usex video_cards_vc4 true false)
-		-Detnaviv=$(usex video_cards_vivante true false)
-		-Dvmwgfx=$(usex video_cards_vmware true false)
-		-Dlibkms=$(usex libkms true false)
+		$(meson_use video_cards_amdgpu amdgpu)
+		$(meson_use video_cards_exynos exynos)
+		$(meson_use video_cards_freedreno freedreno)
+		$(meson_use video_cards_intel intel)
+		$(meson_use video_cards_nouveau nouveau)
+		$(meson_use video_cards_omap omap)
+		$(meson_use video_cards_radeon radeon)
+		$(meson_use video_cards_tegra tegra)
+		$(meson_use video_cards_vc4 vc4)
+		$(meson_use video_cards_vivante etnaviv)
+		$(meson_use video_cards_vmware vmwgfx)
+		$(meson_use libkms)
 		# valgrind installs its .pc file to the pkgconfig for the primary arch
 		-Dvalgrind=$(usex valgrind auto false)
 	)
 	meson_src_configure
-}
-
-multilib_src_compile() {
-	meson_src_compile
-}
-
-multilib_src_test() {
-	meson_src_test
-}
-
-multilib_src_install() {
-	meson_src_install
 }

--- a/x11-libs/libdrm/libdrm-9999.ebuild
+++ b/x11-libs/libdrm/libdrm-9999.ebuild
@@ -9,7 +9,7 @@ if [[ ${PV} = 9999* ]]; then
 	GIT_ECLASS="git-r3"
 fi
 
-inherit ${GIT_ECLASS} meson multilib-minimal
+inherit ${GIT_ECLASS} meson-multilib
 
 DESCRIPTION="X.Org libdrm library"
 HOMEPAGE="https://dri.freedesktop.org/ https://gitlab.freedesktop.org/mesa/drm"
@@ -40,32 +40,20 @@ multilib_src_configure() {
 		# Udev is only used by tests now.
 		-Dudev=false
 		-Dcairo-tests=false
-		-Damdgpu=$(usex video_cards_amdgpu true false)
-		-Dexynos=$(usex video_cards_exynos true false)
-		-Dfreedreno=$(usex video_cards_freedreno true false)
-		-Dintel=$(usex video_cards_intel true false)
-		-Dnouveau=$(usex video_cards_nouveau true false)
-		-Domap=$(usex video_cards_omap true false)
-		-Dradeon=$(usex video_cards_radeon true false)
-		-Dtegra=$(usex video_cards_tegra true false)
-		-Dvc4=$(usex video_cards_vc4 true false)
-		-Detnaviv=$(usex video_cards_vivante true false)
-		-Dvmwgfx=$(usex video_cards_vmware true false)
-		-Dlibkms=$(usex libkms true false)
+		$(meson_use video_cards_amdgpu amdgpu)
+		$(meson_use video_cards_exynos exynos)
+		$(meson_use video_cards_freedreno freedreno)
+		$(meson_use video_cards_intel intel)
+		$(meson_use video_cards_nouveau nouveau)
+		$(meson_use video_cards_omap omap)
+		$(meson_use video_cards_radeon radeon)
+		$(meson_use video_cards_tegra tegra)
+		$(meson_use video_cards_vc4 vc4)
+		$(meson_use video_cards_vivante etnaviv)
+		$(meson_use video_cards_vmware vmwgfx)
+		$(meson_use libkms)
 		# valgrind installs its .pc file to the pkgconfig for the primary arch
 		-Dvalgrind=$(usex valgrind auto false)
 	)
 	meson_src_configure
-}
-
-multilib_src_compile() {
-	meson_src_compile
-}
-
-multilib_src_test() {
-	meson_src_test
-}
-
-multilib_src_install() {
-	meson_src_install
 }

--- a/x11-libs/libnotify/libnotify-0.7.8.ebuild
+++ b/x11-libs/libnotify/libnotify-0.7.8.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit gnome.org meson multilib-minimal xdg-utils
+inherit gnome.org meson-multilib xdg-utils
 
 DESCRIPTION="A library for sending desktop notifications"
 HOMEPAGE="https://gitlab.gnome.org/GNOME/libnotify"
@@ -38,9 +38,9 @@ src_prepare() {
 
 multilib_src_configure() {
 	local emesonargs=(
-		-Dtests="$(usex test true false)"
-		-Dintrospection="$(multilib_native_usex introspection enabled disabled)"
-		-Dgtk_doc=$(multilib_native_usex gtk-doc true false)
+		$(meson_use test tests)
+		$(meson_native_use_feature introspection)
+		$(meson_native_use_bool gtk-doc gtk_doc)
 		-Ddocbook_docs=disabled
 	)
 	meson_src_configure

--- a/x11-libs/libnotify/libnotify-0.7.9.ebuild
+++ b/x11-libs/libnotify/libnotify-0.7.9.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit gnome.org meson multilib-minimal xdg-utils
+inherit gnome.org meson-multilib xdg-utils
 
 DESCRIPTION="A library for sending desktop notifications"
 HOMEPAGE="https://gitlab.gnome.org/GNOME/libnotify"
@@ -40,9 +40,9 @@ src_prepare() {
 
 multilib_src_configure() {
 	local emesonargs=(
-		-Dtests="$(usex test true false)"
-		-Dintrospection="$(multilib_native_usex introspection enabled disabled)"
-		-Dgtk_doc=$(multilib_native_usex gtk-doc true false)
+		$(meson_use test tests)
+		$(meson_native_use_feature introspection)
+		$(meson_native_use_bool gtk-doc gtk_doc)
 		-Ddocbook_docs=disabled
 	)
 	meson_src_configure

--- a/x11-libs/libvdpau/libvdpau-1.4.ebuild
+++ b/x11-libs/libvdpau/libvdpau-1.4.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 VIRTUALX_REQUIRED="test"
-inherit flag-o-matic meson virtualx multilib-minimal
+inherit flag-o-matic meson-multilib virtualx
 
 DESCRIPTION="VDPAU wrapper and trace libraries"
 HOMEPAGE="https://www.freedesktop.org/wiki/Software/VDPAU"
@@ -38,20 +38,12 @@ src_prepare() {
 multilib_src_configure() {
 	append-cppflags -D_GNU_SOURCE
 	local emesonargs=(
-		-Ddri2=$(usex dri true false)
-		-Ddocumentation=$(usex doc true false)
+		$(meson_use dri dri2)
+		$(meson_native_use_bool doc documentation)
 	)
 	meson_src_configure
 }
 
-multilib_src_compile() {
-	meson_src_compile
-}
 multilib_src_test() {
 	virtx meson_src_test
-}
-
-multilib_src_install() {
-	meson_src_install
-	find "${ED}" -name '*.la' -delete || die
 }

--- a/x11-libs/libvdpau/libvdpau-99999.ebuild
+++ b/x11-libs/libvdpau/libvdpau-99999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 VIRTUALX_REQUIRED="test"
-inherit flag-o-matic git-r3 meson virtualx multilib-minimal
+inherit flag-o-matic git-r3 meson-multilib virtualx
 
 DESCRIPTION="VDPAU wrapper and trace libraries"
 HOMEPAGE="https://www.freedesktop.org/wiki/Software/VDPAU"
@@ -38,20 +38,12 @@ src_prepare() {
 multilib_src_configure() {
 	append-cppflags -D_GNU_SOURCE
 	local emesonargs=(
-		-Ddri2=$(usex dri true false)
-		-Ddocumentation=$(usex doc true false)
+		$(meson_use dri dri2)
+		$(meson_native_use_bool doc documentation)
 	)
 	meson_src_configure
 }
 
-multilib_src_compile() {
-	meson_src_compile
-}
 multilib_src_test() {
 	virtx meson_src_test
-}
-
-multilib_src_install() {
-	meson_src_install
-	find "${ED}" -name '*.la' -delete || die
 }

--- a/x11-libs/libxkbcommon/libxkbcommon-1.3.0.ebuild
+++ b/x11-libs/libxkbcommon/libxkbcommon-1.3.0.ebuild
@@ -13,7 +13,7 @@ fi
 
 PYTHON_COMPAT=( python3_{7..9} )
 
-inherit meson multilib-minimal ${GIT_ECLASS} python-any-r1 virtualx
+inherit meson-multilib ${GIT_ECLASS} python-any-r1 virtualx
 
 DESCRIPTION="keymap handling library for toolkits and window systems"
 HOMEPAGE="https://xkbcommon.org/ https://github.com/xkbcommon/libxkbcommon/"
@@ -56,14 +56,6 @@ multilib_src_configure() {
 	meson_src_configure
 }
 
-multilib_src_compile() {
-	meson_src_compile
-}
-
 multilib_src_test() {
 	virtx meson_src_test
-}
-
-multilib_src_install() {
-	meson_src_install
 }

--- a/x11-libs/pango/pango-1.48.5.ebuild
+++ b/x11-libs/pango/pango-1.48.5.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit gnome2-utils meson multilib-minimal toolchain-funcs xdg
+inherit gnome2-utils meson-multilib toolchain-funcs xdg
 
 DESCRIPTION="Internationalized text layout and rendering library"
 HOMEPAGE="https://www.pango.org/"
@@ -62,28 +62,15 @@ multilib_src_configure() {
 		-Dcairo=enabled
 		-Dfontconfig=enabled
 		-Dfreetype=enabled
-		-Dgtk_doc="$(multilib_native_usex gtk-doc true false)"
-		-Dintrospection="$(multilib_native_usex introspection enabled disabled)"
+		$(meson_native_use_bool gtk-doc gtk_doc)
+		$(meson_native_use_feature introspection)
 		-Dinstall-tests=false
 		-Dlibthai=disabled
 	)
 	meson_src_configure
 }
 
-muiltilib_src_compile() {
-	meson_src_compile
-}
-
-multilib_src_test() {
-	meson_src_test
-}
-
-multilib_src_install() {
-	meson_src_install
-}
-
 multilib_src_install_all() {
-	einstalldocs
 	if use gtk-doc; then
 		mv "${ED}"/usr/share/doc/{${PN}/reference/,${PF}/html/} || die
 		rmdir "${ED}"/usr/share/doc/${PN} || die

--- a/x11-libs/pixman/pixman-0.40.0.ebuild
+++ b/x11-libs/pixman/pixman-0.40.0.ebuild
@@ -9,7 +9,7 @@ if [[ ${PV} = 9999* ]]; then
 	GIT_ECLASS="git-r3"
 fi
 
-inherit ${GIT_ECLASS} meson multilib-minimal multiprocessing toolchain-funcs
+inherit ${GIT_ECLASS} meson-multilib multiprocessing toolchain-funcs
 
 DESCRIPTION="Low-level pixel manipulation routines"
 HOMEPAGE="http://www.pixman.org/ https://gitlab.freedesktop.org/pixman/pixman/"
@@ -45,15 +45,7 @@ multilib_src_configure() {
 	meson_src_configure
 }
 
-multilib_src_compile() {
-	meson_src_compile
-}
-
 multilib_src_test() {
 	export OMP_NUM_THREADS=$(makeopts_jobs)
-	meson test -v -C "${BUILD_DIR}" -t 100 || die "tests failed"
-}
-
-multilib_src_install() {
-	meson_src_install
+	meson_src_test -t 100
 }

--- a/x11-libs/pixman/pixman-9999.ebuild
+++ b/x11-libs/pixman/pixman-9999.ebuild
@@ -9,7 +9,7 @@ if [[ ${PV} = 9999* ]]; then
 	GIT_ECLASS="git-r3"
 fi
 
-inherit ${GIT_ECLASS} meson multilib-minimal multiprocessing toolchain-funcs
+inherit ${GIT_ECLASS} meson-multilib multiprocessing toolchain-funcs
 
 DESCRIPTION="Low-level pixel manipulation routines"
 HOMEPAGE="http://www.pixman.org/ https://gitlab.freedesktop.org/pixman/pixman/"
@@ -45,15 +45,7 @@ multilib_src_configure() {
 	meson_src_configure
 }
 
-multilib_src_compile() {
-	meson_src_compile
-}
-
 multilib_src_test() {
 	export OMP_NUM_THREADS=$(makeopts_jobs)
-	meson test -v -C "${BUILD_DIR}" -t 100 || die "tests failed"
-}
-
-multilib_src_install() {
-	meson_src_install
+	meson_src_test -t 100
 }

--- a/x11-misc/colord/colord-1.4.5-r1.ebuild
+++ b/x11-misc/colord/colord-1.4.5-r1.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 VALA_USE_DEPEND="vapigen"
 
-inherit bash-completion-r1 meson multilib-minimal systemd udev vala
+inherit bash-completion-r1 meson-multilib systemd udev vala
 
 DESCRIPTION="System service to accurately color manage input and output devices"
 HOMEPAGE="https://www.freedesktop.org/software/colord/"
@@ -83,18 +83,18 @@ src_prepare() {
 
 multilib_src_configure() {
 	local emesonargs=(
-		-Ddaemon=$(multilib_is_native_abi && echo true || echo false)
+		$(meson_native_true daemon)
 		-Dexamples=false
 		-Dbash_completion=false
 		$(meson_use udev udev_rules)
-		-Dsystemd=$(multilib_native_usex systemd true false)
+		$(meson_native_use_bool systemd)
 		-Dlibcolordcompat=true
-		-Dargyllcms_sensor=$(multilib_native_usex argyllcms true false)
+		$(meson_native_use_bool argyllcms argyllcms_sensor)
 		-Dreverse=false
-		-Dsane=$(multilib_native_usex scanner true false)
-		-Dintrospection=$(multilib_native_usex introspection true false)
-		-Dvapi=$(multilib_native_usex vala true false)
-		-Dprint_profiles=$(multilib_native_usex extra-print-profiles true false)
+		$(meson_native_use_bool scanner sane)
+		$(meson_native_use_bool introspection)
+		$(meson_native_use_bool vala vapi)
+		$(meson_native_use_bool extra-print-profiles print_profiles)
 		$(meson_use test tests)
 		-Dinstalled_tests=false
 		-Ddaemon_user=colord
@@ -103,18 +103,6 @@ multilib_src_configure() {
 		--localstatedir="${EPREFIX}"/var
 	)
 	meson_src_configure
-}
-
-multilib_src_compile() {
-	meson_src_compile
-}
-
-multilib_src_test() {
-	meson_src_test
-}
-
-multilib_src_install() {
-	meson_src_install
 }
 
 multilib_src_install_all() {


### PR DESCRIPTION
There are a lot of private (i.e. to individual ebuilds and/or packages) functions implementing the necessary `meson_use`/`meson_feature`-style functions for multilib.

This PR factors those out and shows how we can use them in existing packages.

Consider this an RFC. I'm open to all feedback and I don't feel strongly about anything I've written here.

A couple of unorganized thoughts:

- I feel like the function names are too long. Should we remove `multilib_` from the names?

- Trying to make the function names match `meson_use`/`meson_feature` exposes the fact that the `meson_use` name is weird. We want functions for the different meson options:
    - `feature` (enabled/disabled)
    - `bool` (true/false)
    - maybe something for yes/no (a common `combo` configuration).

Within those, we want multilib functions that operate with and without a USE flag. One natural way to name those functions differently is to put `_use` in the name of the ones that take a USE flag, e.g., could be something like `meson_multilib_native_use_enable` vs `meson_multilib_native_enable`. But if we already are using `_use` in a name like `meson_multilib_native_use` then adding another `_use` is kind of nonsensical. It's for that reason that I instead have `meson_multilib_native_use` and `meson_multilib_native_true`. Perhaps we should consider deprecating `meson_use` and replacing it with a `meson_bool`? :shrug:

