### PR TITLE
app-crypt/tpm2-tss-engine: fix HOMEPAGE

### DIFF
--- a/app-crypt/tpm2-tss-engine/tpm2-tss-engine-1.1.0.ebuild
+++ b/app-crypt/tpm2-tss-engine/tpm2-tss-engine-1.1.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -6,7 +6,7 @@ EAPI=7
 inherit autotools bash-completion-r1
 
 DESCRIPTION="OpenSSL Engine for TPM2 devices"
-HOMEPAGE="https://github.com/tpm2-software/tpm2-tools"
+HOMEPAGE="https://github.com/tpm2-software/tpm2-tss-engine"
 SRC_URI="https://github.com/tpm2-software/${PN}/releases/download/v${PV}/${P}.tar.gz"
 
 LICENSE="BSD"


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/792231
Signed-off-by: Bertrand Jacquin <bertrand@jacquin.bzh>
Package-Manager: Portage-3.0.18, Repoman-3.0.2