### PR TITLE
app-misc/anki: bump python to 3.9

### DIFF
--- a/app-misc/anki/anki-2.1.15.ebuild
+++ b/app-misc/anki/anki-2.1.15.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{7,8} )
+PYTHON_COMPAT=( python3_{7,8,9} )
 PYTHON_REQ_USE="sqlite"
 
 inherit desktop optfeature python-single-r1 xdg


### PR DESCRIPTION
With `PYTHON_SINGLE_TARGET=python3_9 FEATURES=test`
 - tests pass when I emerge
 - I've run the program and used my own data with it