### PR TITLE
app-shells/bash: 5.x: set SELinux context for /bin/sh.

### DIFF
--- a/app-shells/bash/bash-5.0_p18.ebuild
+++ b/app-shells/bash/bash-5.0_p18.ebuild
@@ -262,7 +262,7 @@ pkg_preinst() {
 		local target=$(readlink "${EROOT}"/bin/sh)
 		local tmp="${T}"/sh
 		ln -sf "${target}" "${tmp}"
-		mv -f "${tmp}" "${EROOT}"/bin/sh
+		mv -fZ "${tmp}" "${EROOT}"/bin/sh
 	fi
 }
 

--- a/app-shells/bash/bash-5.1_p8.ebuild
+++ b/app-shells/bash/bash-5.1_p8.ebuild
@@ -262,7 +262,7 @@ pkg_preinst() {
 		local target=$(readlink "${EROOT}"/bin/sh)
 		local tmp="${T}"/sh
 		ln -sf "${target}" "${tmp}"
-		mv -f "${tmp}" "${EROOT}"/bin/sh
+		mv -fZ "${tmp}" "${EROOT}"/bin/sh
 	fi
 }
 


### PR DESCRIPTION
Portage performs package builds under the portage_tmp_t label, and as
/bin/sh is not a part of the package file set, it's installed with that
temporary label and isn't assigned the correct label by the Portage
SELinux integration (causing system failures later). Adding the -Z option
installs the symlink with the correct label.