### PR TITLE
dev-python/logfury: Allow Python3.9

### DIFF
--- a/dev-python/logfury/logfury-0.1.2-r1.ebuild
+++ b/dev-python/logfury/logfury-0.1.2-r1.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
-PYTHON_COMPAT=( python3_7 python3_8 )
+PYTHON_COMPAT=( python3_{7..9} )
 
 inherit distutils-r1
 
@@ -21,7 +21,7 @@ PATCHES=(
 
 RDEPEND="dev-python/six[${PYTHON_USEDEP}]"
 
-DEPEND="${RDEPEND}
+BDEPEND="${RDEPEND}
 	test? (
 		dev-python/testfixtures[${PYTHON_USEDEP}]
 		dev-python/nose[${PYTHON_USEDEP}]


### PR DESCRIPTION
Allows building of logfury for python 3.9

Tests and the package itself both run fine on my PC

Package-Manager: Portage-3.0.18, Repoman-3.0.2
Signed-off-by: William Pettersson <william@ewpettersson.se>