### PR TITLE
app-editors/neovim: Fix log level to match release build

### DIFF
--- a/app-editors/neovim/neovim-0.4.4-r100.ebuild
+++ b/app-editors/neovim/neovim-0.4.4-r100.ebuild
@@ -87,6 +87,7 @@ src_configure() {
 		-DFEAT_TUI=$(usex tui)
 		-DPREFER_LUA=$(usex lua_single_target_luajit no "$(lua_get_version)")
 		-DLUA_PRG="${ELUA}"
+		-DMIN_LOG_LEVEL=3
 	)
 	cmake_src_configure
 }

--- a/app-editors/neovim/neovim-9999.ebuild
+++ b/app-editors/neovim/neovim-9999.ebuild
@@ -86,6 +86,7 @@ src_configure() {
 		-DFEAT_TUI=$(usex tui)
 		-DPREFER_LUA=$(usex lua_single_target_luajit no "$(lua_get_version)")
 		-DLUA_PRG="${ELUA}"
+		-DMIN_LOG_LEVEL=3
 	)
 	cmake_src_configure
 }


### PR DESCRIPTION
The current ebuild uses a custom `CMAKE_BUILD_TYPE=Gentoo`, which results in debug logging. 

This PR sets the compilation flag `MIN_LOG_LEVEL` to match the upstream `CMAKE_BUILD_TYPE=Release` intended behavior for releases.

Package-Manager: Portage-3.0.18, Repoman-3.0.2
Signed-off-by: Eric Zhao <21zhaoe@protonmail.com>