### PR TITLE
dev-python/zope-*: bump to python 3.10

### DIFF
--- a/dev-python/zope-configuration/zope-configuration-4.4.0.ebuild
+++ b/dev-python/zope-configuration/zope-configuration-4.4.0.ebuild
@@ -1,10 +1,10 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
 DISTUTILS_USE_SETUPTOOLS=rdepend
-PYTHON_COMPAT=( python3_{7..9} )
+PYTHON_COMPAT=( python3_{7..10} )
 
 inherit distutils-r1
 

--- a/dev-python/zope-schema/zope-schema-6.1.0.ebuild
+++ b/dev-python/zope-schema/zope-schema-6.1.0.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 
 DISTUTILS_USE_SETUPTOOLS=rdepend
-PYTHON_COMPAT=( python3_{7..9} pypy3 )
+PYTHON_COMPAT=( python3_{7..10} pypy3 )
 
 inherit distutils-r1
 


### PR DESCRIPTION
@mgorny Here is a small batch of packages from Zope family to bump to python 3.10.
As always all of them were tested, and some of them needed patches (one of them I sent as a [PR](https://github.com/zopefoundation/zope.exceptions/pull/19) upstream) to adapt to new SyntaxError.
Every commit description has more info about that specific bump.