### PR TITLE
app-misc/klavaro: drop unneeded dependency to gtk-builder-convert.

### DIFF
--- a/app-misc/klavaro/klavaro-3.0.1-r1.ebuild
+++ b/app-misc/klavaro/klavaro-3.0.1-r1.ebuild
@@ -17,7 +17,6 @@ KEYWORDS="amd64 x86"
 
 BDEPEND="
 	dev-util/intltool
-	dev-util/gtk-builder-convert
 	>=sys-devel/gettext-0.18.3
 "
 RDEPEND="


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/793218
Signed-off-by: Roman Dobosz <gryf73@gmail.com>