### PR TITLE
dev-python/gmpy: remove broken mpir useflag

### DIFF
--- a/dev-python/gmpy/gmpy-2.1.0_beta5.ebuild
+++ b/dev-python/gmpy/gmpy-2.1.0_beta5.ebuild
@@ -17,13 +17,12 @@ S="${WORKDIR}"/${MY_P}
 LICENSE="LGPL-3+"
 SLOT="2"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos"
-IUSE="mpir"
 
 RDEPEND="
 	>=dev-libs/mpc-1.0.2:=
 	>=dev-libs/mpfr-3.1.2:=
-	!mpir? ( dev-libs/gmp:0= )
-	mpir? ( sci-libs/mpir:= )"
+	dev-libs/gmp:0=
+"
 DEPEND="${RDEPEND}"
 
 PATCHES=(
@@ -39,13 +38,6 @@ PATCHES=(
 )
 
 distutils_enable_sphinx docs
-
-python_configure_all() {
-	mydistutilsargs=(
-		# GMP is the default, add mpir if the USE flag is set
-		$(usex mpir --mpir "")
-	)
-}
 
 python_test() {
 	cd test || die

--- a/dev-python/gmpy/metadata.xml
+++ b/dev-python/gmpy/metadata.xml
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-  <maintainer type="project">
-    <email>python@gentoo.org</email>
-    <name>Python</name>
-  </maintainer>
-  <longdescription lang="en">
-  gmpy2 is a C-coded Python extension module that supports
-  multiple-precision arithmetic. gmpy2 supports the GMP multi-precision
-  library, the MPFR (correctly rounded real floating-point arithmetic) and MPC
-  (correctly rounded complex floating-point arithmetic) libraries.
-</longdescription>
-  <upstream>
-    <remote-id type="pypi">gmpy2</remote-id>
-    <remote-id type="github">aleaxit/gmpy</remote-id>
-  </upstream>
-  <use>
-    <flag name="mpir">Use <pkg>sci-libs/mpir</pkg> as gmp implementation</flag>
-  </use>
+	<maintainer type="project">
+		<email>python@gentoo.org</email>
+		<name>Python</name>
+	</maintainer>
+	<longdescription lang="en">
+		gmpy2 is a C-coded Python extension module that supports
+		multiple-precision arithmetic. gmpy2 supports the GMP multi-precision
+		library, the MPFR (correctly rounded real floating-point arithmetic) and MPC
+		(correctly rounded complex floating-point arithmetic) libraries.
+	</longdescription>
+	<use>
+		<flag name="mpir">Use <pkg>sci-libs/mpir</pkg> as gmp implementation</flag>
+	</use>
+	<upstream>
+		<remote-id type="pypi">gmpy2</remote-id>
+		<remote-id type="github">aleaxit/gmpy</remote-id>
+	</upstream>
 </pkgmetadata>


### PR DESCRIPTION
Upstream doesn't seem to even support it anymore.

Plus reformat metadata.xml with tabs

Closes: https://bugs.gentoo.org/791124

Signed-off-by: Ekaterina Vaartis <vaartis@kotobank.ch>