### PR TITLE
[do not merge] mail-mta/sendmail: fixes for 8.16.1 plus cleanups

### DIFF
--- a/acct-user/smmsp/smmsp-0-r2.ebuild
+++ b/acct-user/smmsp/smmsp-0-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -7,6 +7,6 @@ inherit acct-user
 
 DESCRIPTION="user for sendmail daemon"
 ACCT_USER_ID=209
-ACCT_USER_GROUPS=( mail )
+ACCT_USER_GROUPS=( smmsp )
 
 acct-user_add_deps

--- a/mail-filter/libmilter/libmilter-1.0.2_p1-r2.ebuild
+++ b/mail-filter/libmilter/libmilter-1.0.2_p1-r2.ebuild
@@ -21,6 +21,8 @@ SLOT="0/${PV}"
 #KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86"
 IUSE="ipv6 poll"
 
+RDEPEND="!<mail-mta/sendmail-8.16.1"
+
 # build system patch copied from sendmail ebuild
 PATCHES=(
 	"${FILESDIR}/sendmail-8.16.1-build-system.patch"

--- a/mail-filter/libmilter/libmilter-1.0.2_p1-r2.ebuild
+++ b/mail-filter/libmilter/libmilter-1.0.2_p1-r2.ebuild
@@ -55,7 +55,7 @@ src_prepare() {
 
 src_compile() {
 	pushd libmilter
-	emake -j1 MILTER_SOVER=${PV}
+	emake -j1 AR="$(tc-getAR)" MILTER_SOVER=${PV}
 	popd
 }
 

--- a/mail-mta/sendmail/sendmail-8.16.1-r1.ebuild
+++ b/mail-mta/sendmail/sendmail-8.16.1-r1.ebuild
@@ -16,18 +16,17 @@ IUSE="ipv6 ldap mbox nis sasl sockets ssl tcpd"
 
 BDEPEND="sys-devel/m4"
 DEPEND="net-mail/mailbase
+	nis? ( net-libs/libnsl:= )
 	sasl? ( >=dev-libs/cyrus-sasl-2.1.10 )
 	tcpd? ( sys-apps/tcp-wrappers )
 	ssl? (
 		dev-libs/openssl:0=
 	)
 	ldap? ( net-nds/openldap )
-	>=sys-libs/db-3.2:=
-	!net-mail/vacation"
+	>=sys-libs/db-3.2:="
 RDEPEND="${DEPEND}
 	acct-group/smmsp
-	acct-user/smmsp
-	>=net-mail/mailbase-0.00
+	>=acct-user/smmsp-0-r2
 	>=mail-filter/libmilter-1.0.2_p1-r1
 	!mail-mta/courier
 	!mail-mta/esmtp
@@ -39,7 +38,8 @@ RDEPEND="${DEPEND}
 	!mail-mta/postfix
 	!mail-mta/opensmtpd
 	!mail-mta/qmail-ldap
-	!>=mail-mta/ssmtp-2.64-r2[mta]"
+	!>=mail-mta/ssmtp-2.64-r2[mta]
+	!net-mail/vacation"
 
 PDEPEND="!mbox? ( mail-filter/procmail )"
 

--- a/mail-mta/sendmail/sendmail-8.16.1-r1.ebuild
+++ b/mail-mta/sendmail/sendmail-8.16.1-r1.ebuild
@@ -3,7 +3,9 @@
 
 EAPI=7
 
-inherit multilib systemd toolchain-funcs
+# Note: please bump this together with mail-filter/libmilter
+
+inherit systemd toolchain-funcs
 
 DESCRIPTION="Widely-used Mail Transport Agent (MTA)"
 HOMEPAGE="https://www.sendmail.org/"
@@ -11,20 +13,23 @@ SRC_URI="ftp://ftp.sendmail.org/pub/${PN}/${PN}.${PV}.tar.gz"
 
 LICENSE="Sendmail GPL-2" # GPL-2 is here for initscript
 SLOT="0"
+# TODO: restore keywords soon for bug 730890 after testing
 #KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86"
 IUSE="ipv6 ldap mbox nis sasl sockets ssl tcpd"
 
-BDEPEND="sys-devel/m4"
-DEPEND="net-mail/mailbase
+BDEPEND="
+	sys-devel/m4
+	virtual/pkgconfig"
+DEPEND="
+	net-mail/mailbase
+	>=sys-libs/db-3.2:=
+	ldap? ( net-nds/openldap )
 	nis? ( net-libs/libnsl:= )
 	sasl? ( >=dev-libs/cyrus-sasl-2.1.10 )
-	tcpd? ( sys-apps/tcp-wrappers )
-	ssl? (
-		dev-libs/openssl:0=
-	)
-	ldap? ( net-nds/openldap )
-	>=sys-libs/db-3.2:="
-RDEPEND="${DEPEND}
+	ssl? ( dev-libs/openssl:0= )
+	tcpd? ( sys-apps/tcp-wrappers )"
+RDEPEND="
+	${DEPEND}
 	acct-group/smmsp
 	>=acct-user/smmsp-0-r2
 	>=mail-filter/libmilter-1.0.2_p1-r1
@@ -35,62 +40,65 @@ RDEPEND="${DEPEND}
 	!mail-mta/msmtp[mta]
 	!mail-mta/netqmail
 	!mail-mta/nullmailer
-	!mail-mta/postfix
 	!mail-mta/opensmtpd
+	!mail-mta/postfix
 	!mail-mta/qmail-ldap
 	!>=mail-mta/ssmtp-2.64-r2[mta]
 	!net-mail/vacation"
-
 PDEPEND="!mbox? ( mail-filter/procmail )"
 
 src_prepare() {
-	eapply "${FILESDIR}"/"${PN}"-8.16.1-build-system.patch
-	eapply -p0 "${FILESDIR}"/sendmail-delivered_hdr.patch
-
-	local confCC="$(tc-getCC)"
-	local confCCOPTS="${CFLAGS}"
-	local confLDOPTS="${LDFLAGS}"
-	local confMAPDEF="-DMAP_REGEX"
-	local confENVDEF="-DMAXDAEMONS=64"
-	local conf_sendmail_LIBS=""
-
-	confENVDEF="${confLIBS} -DHAS_GETHOSTBYNAME2=1"
-
-	use sasl && confLIBS="${confLIBS} -lsasl2"  \
-		&& confENVDEF="${confENVDEF} -DSASL=2" \
-		&& confCCOPTS="${confCCOPTS} -I/usr/include/sasl" \
-		&& conf_sendmail_LIBS="${conf_sendmail_LIBS} -lsasl2"
-
-	use tcpd && confENVDEF="${confENVDEF} -DTCPWRAPPERS" \
-		&& confLIBS="${confLIBS} -lwrap"
-
-	# Bug #542370 - lets add support for modern crypto (PFS)
-	use ssl && confENVDEF="${confENVDEF} -DSTARTTLS -D_FFR_DEAL_WITH_ERROR_SSL" \
-		&& confENVDEF="${confENVDEF} -D_FFR_TLS_1 -D_FFR_TLS_EC" \
-		&& confLIBS="${confLIBS} -lssl -lcrypto" \
-		&& conf_sendmail_LIBS="${conf_sendmail_LIBS} -lssl -lcrypto"
-
-	use ldap && confMAPDEF="${confMAPDEF} -DLDAPMAP" \
-		&& confLIBS="${confLIBS} -lldap -llber"
-
-	use ipv6 && confENVDEF="${confENVDEF} -DNETINET6"
-
-	use nis && confENVDEF="${confENVDEF} -DNIS"
-
-	use sockets && confENVDEF="${confENVDEF} -DSOCKETMAP"
-
-	sed -e "s:@@confCCOPTS@@:${confCCOPTS}:" \
-		-e "s/@@confLDOPTS@@/${confLDOPTS}/" \
-		-e "s/@@confCC@@/${confCC}/" \
-		-e "s/@@confMAPDEF@@/${confMAPDEF}/" \
-		-e "s/@@confENVDEF@@/${confENVDEF}/" \
-		-e "s/@@confLIBS@@/${confLIBS}/" \
-		-e "s/@@conf_sendmail_LIBS@@/${conf_sendmail_LIBS}/" \
-		"${FILESDIR}"/site.config.m4 > devtools/Site/site.config.m4 || die "sed failed"
-
-	echo "APPENDDEF(\`confLIBDIRS', \`-L${EPREFIX}/usr/$(get_libdir)')" >> devtools/Site/site.config.m4 || die "echo failed"
-
+	eapply "${FILESDIR}"/${PN}-8.16.1-build-system.patch
+	eapply -p0 "${FILESDIR}"/${PN}-delivered_hdr.patch
 	eapply_user
+
+	local confCCOPTS="${CFLAGS}"
+	local confENVDEF="-DMAXDAEMONS=64 -DHAS_GETHOSTBYNAME2=1"
+	local confLDOPTS="${LDFLAGS}"
+	local confLIBS=
+	local confMAPDEF="-DMAP_REGEX"
+	local conf_sendmail_LIBS=
+
+	if use ldap; then
+		confMAPDEF+=" -DLDAPMAP"
+		confLIBS+=" -lldap -llber"
+	fi
+
+	if use sasl; then
+		confCCOPTS+=" $($(tc-getPKG_CONFIG) --cflags libsasl2)"
+		confENVDEF+=" -DSASL=2"
+		conf_sendmail_LIBS+=" $($(tc-getPKG_CONFIG) --libs libsasl2)"
+	fi
+
+	if use ssl; then
+		# Bug #542370 - lets add support for modern crypto (PFS)
+		confCCOPTS+=" $($(tc-getPKG_CONFIG) --cflags openssl)"
+		confENVDEF+=" -DSTARTTLS -D_FFR_DEAL_WITH_ERROR_SSL"
+		confENVDEF+=" -D_FFR_TLS_1 -D_FFR_TLS_EC"
+		conf_sendmail_LIBS+=" $($(tc-getPKG_CONFIG) --libs openssl)"
+	fi
+
+	if use tcpd; then
+		confENVDEF+=" -DTCPWRAPPERS"
+		confLIBS+=" -lwrap"
+	fi
+
+	use ipv6 && confENVDEF+=" -DNETINET6"
+	use nis && confENVDEF+=" -DNIS"
+	use sockets && confENVDEF+=" -DSOCKETMAP"
+
+	sed -e "s|@@confCC@@|$(tc-getCC)|" \
+		-e "s|@@confCCOPTS@@|${confCCOPTS}|" \
+		-e "s|@@confENVDEF@@|${confENVDEF}|" \
+		-e "s|@@confLDOPTS@@|${confLDOPTS}|" \
+		-e "s|@@confLIBS@@|${confLIBS}|" \
+		-e "s|@@confMAPDEF@@|${confMAPDEF}|" \
+		-e "s|@@conf_sendmail_LIBS@@|${conf_sendmail_LIBS}|" \
+		"${FILESDIR}"/site.config.m4 > devtools/Site/site.config.m4 \
+		|| die "failed to generate site.config.m4"
+
+	echo "APPENDDEF(\`confLIBDIRS', \`-L${EPREFIX}/usr/$(get_libdir)')" \
+		>> devtools/Site/site.config.m4 || die "failed adding to site.config.m4"
 }
 
 src_compile() {
@@ -98,35 +106,27 @@ src_compile() {
 }
 
 src_install() {
-	local MY_LIBDIR=/usr/$(get_libdir)
-	local MY_OBJDIR="obj.`uname -s`.`uname -r`.`uname -m`"
-
-	dodir /usr/bin ${MY_LIBDIR}
+	dodir /usr/{bin,$(get_libdir)}
 	dodir /usr/share/man/man{1,5,8} /usr/sbin /usr/share/sendmail-cf
 	dodir /var/spool/{mqueue,clientmqueue} /etc/conf.d
 
 	keepdir /var/spool/{clientmqueue,mqueue}
 
-	for dir in libsmutil sendmail mailstats praliases smrsh makemap vacation editmap
-	do
-		make DESTDIR="${D}" LIBDIR="${MY_LIBDIR}" MANROOT=/usr/share/man/man \
-			SBINOWN=root SBINGRP=root UBINOWN=root UBINGRP=root \
-			MANOWN=root MANGRP=root INCOWN=root INCGRP=root \
-			LIBOWN=root LIBGRP=root GBINOWN=root GBINGRP=root \
-			MSPQOWN=root CFOWN=root CFGRP=root \
-			install -C "${MY_OBJDIR}/${dir}" \
-			|| die "install 1 failed"
-	done
+	local emakeargs=(
+		DESTDIR="${D}" LIBDIR="/usr/$(get_libdir)"
+		MANROOT=/usr/share/man/man
+		SBINOWN=root SBINGRP=root UBINOWN=root UBINGRP=root
+		MANOWN=root MANGRP=root INCOWN=root INCGRP=root
+		LIBOWN=root LIBGRP=root GBINOWN=root GBINGRP=root
+		MSPQOWN=root CFOWN=root CFGRP=root
+	)
 
-	for dir in rmail mail.local
-	do
-		make DESTDIR="${D}" LIBDIR="${MY_LIBDIR}" MANROOT=/usr/share/man/man \
-			SBINOWN=root SBINGRP=root UBINOWN=root UBINGRP=root \
-			MANOWN=root MANGRP=root INCOWN=root INCGRP=root \
-			LIBOWN=root LIBGRP=root GBINOWN=root GBINGRP=root \
-			MSPQOWN=root CFOWN=root CFGRP=root \
-			force-install -C "${MY_OBJDIR}/${dir}" \
-			|| die "install 2 failed"
+	local dir
+	for dir in libsmutil sendmail mailstats praliases smrsh makemap vacation editmap; do
+		emake -j1 -C obj.*/${dir} "${emakeargs[@]}" install
+	done
+	for dir in rmail mail.local; do
+		emake -j1 -C obj.*/${dir} "${emakeargs[@]}" force-install
 	done
 
 	fowners root:smmsp /usr/sbin/sendmail
@@ -137,21 +137,18 @@ src_install() {
 	dosym ../sbin/makemap /usr/bin/makemap
 	dodoc FAQ KNOWNBUGS README RELEASE_NOTES doc/op/op.ps
 
+	dodoc sendmail/{SECURITY,TUNING}
 	newdoc sendmail/README README.sendmail
-	newdoc sendmail/SECURITY SECURITY
-	newdoc sendmail/TUNING TUNING
 	newdoc smrsh/README README.smrsh
 
 	newdoc cf/README README.cf
 	newdoc cf/cf/README README.install-cf
 
-	cp -pPR cf/* "${ED}"/usr/share/sendmail-cf || die "copy failed"
+	dodoc -r contrib
 
-	docinto contrib
-	dodoc contrib/*
+	cp -pPR cf/. "${ED}"/usr/share/sendmail-cf || die
 
 	insinto /etc/mail
-
 	if use mbox; then
 		newins "${FILESDIR}"/sendmail.mc-r1 sendmail.mc
 	else
@@ -160,23 +157,24 @@ src_install() {
 
 	# See discussion on bug #730890
 	m4 "${ED}"/usr/share/sendmail-cf/m4/cf.m4 \
-	        <(grep -v "${EPREFIX}"/usr/share/sendmail-cf/m4/cf.m4 "${ED}"/etc/mail/sendmail.mc) \
-	        > "${ED}"/etc/mail/sendmail.cf || die "cf.m4 failed"
+		<(grep -v "${EPREFIX}"/usr/share/sendmail-cf/m4/cf.m4 "${ED}"/etc/mail/sendmail.mc) \
+		> "${ED}"/etc/mail/sendmail.cf || die "cf.m4 failed"
 
 	echo "include(\`/usr/share/sendmail-cf/m4/cf.m4')dnl" \
-		> "${ED}"/etc/mail/submit.mc || die "echo failed"
+		> "${ED}"/etc/mail/submit.mc || die "submit.mc echo failed"
 
-	cat "${ED}"/usr/share/sendmail-cf/cf/submit.mc >> "${ED}"/etc/mail/submit.mc || die "submit.mc cat failed"
+	cat "${ED}"/usr/share/sendmail-cf/cf/submit.mc \
+		>> "${ED}"/etc/mail/submit.mc || die "submit.mc cat failed"
 
 	echo "# local-host-names - include all aliases for your machine here" \
-		> "${D}"/etc/mail/local-host-names || die "local-host-names echo failed"
+		> "${ED}"/etc/mail/local-host-names || die "local-host-names echo failed"
 
-	cat <<- EOF > "${ED}"/etc/mail/trusted-users
+	cat <<- EOF > "${ED}"/etc/mail/trusted-users || die "trusted-users cat failed"
 		# trusted-users - users that can send mail as others without a warning
 		# apache, mailman, majordomo, uucp are good candidates
 	EOF
 
-	cat <<- EOF > "${ED}"/etc/mail/access
+	cat <<- EOF > "${ED}"/etc/mail/access || die "access cat failed"
 		# Check the /usr/share/doc/sendmail/README.cf file for a description
 		# of the format of this file. (search for access_db in that file)
 		# The /usr/share/doc/sendmail/README.cf is part of the sendmail-doc
@@ -185,7 +183,7 @@ src_install() {
 
 	EOF
 
-	cat <<- EOF > "${ED}"/etc/conf.d/sendmail
+	cat <<- EOF > "${ED}"/etc/conf.d/sendmail || die "sendmail cat failed"
 		# Config file for /etc/init.d/sendmail
 		# add start-up options here
 		SENDMAIL_OPTS="-bd -q30m -L sm-mta" # default daemon mode
@@ -196,9 +194,9 @@ src_install() {
 
 	if use sasl; then
 		dodir /etc/sasl2
-		cat <<- EOF > "${ED}"/etc/sasl2/Sendmail.conf
-		pwcheck_method: saslauthd
-		mech_list: PLAIN LOGIN
+		cat <<- EOF > "${ED}"/etc/sasl2/Sendmail.conf || die "Sendmail.conf cat ailed"
+			pwcheck_method: saslauthd
+			mech_list: PLAIN LOGIN
 
 		EOF
 	fi


### PR DESCRIPTION
As far as making it work again wrt [bug #730890](https://bugs.gentoo.org/730890), essential of it is just the first two commits.

Given that was trivial, felt could additionally do a bit of extra fixes/cleanups (not exhaustive but should make these easier to work with), should hopefully introduce no regressions.

Left out keyword restoration, be nice to get some feedback from the user from the bug and there's other things that worry me, e.g. the `$(<grep's ${EPREFIX}` that I left alone given I know little about what it's changing (all I did was convert leading spaces to tabs).

wrt [bug #681232](https://bugs.gentoo.org/681232) I think this covers everything that was left, so closing it.