### PR TITLE
dev-python/lz4: Bump to 3.10

### DIFF
--- a/dev-python/lz4/files/lz4-3.1.3-310-readall.patch
+++ b/dev-python/lz4/files/lz4-3.1.3-310-readall.patch
@@ -1,0 +1,32 @@
+diff --git a/lz4/frame/__init__.py b/lz4/frame/__init__.py
+index 5fa03ce..b77c425 100644
+--- a/lz4/frame/__init__.py
++++ b/lz4/frame/__init__.py
+@@ -617,6 +617,17 @@ class LZ4FrameFile(_compression.BaseStream):
+         # returns at least one byte (except at EOF)
+         return self._buffer.peek(size)
+ 
++    def readall(self):
++        chunks = bytearray()
++
++        while True:
++            data = self.read(io.DEFAULT_BUFFER_SIZE)
++            chunks += data
++            if not data:
++                break
++
++        return bytes(chunks)
++
+     def read(self, size=-1):
+         """Read up to ``size`` uncompressed bytes from the file.
+ 
+@@ -632,6 +643,9 @@ class LZ4FrameFile(_compression.BaseStream):
+ 
+         """
+         self._check_can_read()
++
++        if size < 0 and sys.version_info >= (3, 10):
++            return self.readall()
+         return self._buffer.read(size)
+ 
+     def read1(self, size=-1):

--- a/dev-python/lz4/lz4-3.1.3.ebuild
+++ b/dev-python/lz4/lz4-3.1.3.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{7..9} )
+PYTHON_COMPAT=( python3_{7..10} )
 
 inherit distutils-r1
 
@@ -24,5 +24,9 @@ BDEPEND="
 		dev-python/psutil[${PYTHON_USEDEP}]
 	)
 "
+
+PATCHES=(
+	"${FILESDIR}/${P}-310-readall.patch"
+)
 
 distutils_enable_tests pytest


### PR DESCRIPTION
Continuation from #21053. @mgorny, for now I just limited `max_size` when on 3.10 to 8192. This makes things works as expected. We'll have to wait a bit on what upstream says they'll do about it, but for now this should do fine.