### PR TITLE
app-emulation/libvirt: Update live ebuild

### DIFF
--- a/app-emulation/libvirt/libvirt-9999.ebuild
+++ b/app-emulation/libvirt/libvirt-9999.ebuild
@@ -10,6 +10,7 @@ inherit meson bash-completion-r1 linux-info python-any-r1 readme.gentoo-r1 tmpfi
 if [[ ${PV} = *9999* ]]; then
 	inherit git-r3
 	EGIT_REPO_URI="https://gitlab.com/libvirt/libvirt.git"
+	EGIT_BRANCH="master"
 	SRC_URI=""
 	SLOT="0"
 else
@@ -225,7 +226,7 @@ src_prepare() {
 src_configure() {
 	local emesonargs=(
 		$(meson_feature apparmor)
-		$(meson_use apparmor apparmor_profiles)
+		$(meson_feature apparmor apparmor_profiles)
 		$(meson_feature audit)
 		$(meson_feature caps capng)
 		$(meson_feature dtrace)


### PR DESCRIPTION
There was some movement in the libvirt upstream and our live
ebuild needs some updates. Firstly, since libvirt commit of
v7.4.0-21-g08c13484da the 'apparmor_profiles' is a feature not an
-Doption. Secondly, specify which branch is the master branch.

Signed-off-by: Michal Privoznik <mprivozn@redhat.com>