### PR TITLE
net-im/element-desktop-bin: RESTRICT splitdebug

### DIFF
--- a/net-im/element-desktop-bin/element-desktop-bin-1.7.29.ebuild
+++ b/net-im/element-desktop-bin/element-desktop-bin-1.7.29.ebuild
@@ -47,6 +47,8 @@ RDEPEND="app-accessibility/at-spi2-atk:2
 	emoji? ( media-fonts/noto-emoji )"
 DEPEND="${RDEPEND}"
 
+RESTRICT="splitdebug"
+
 QA_PREBUILT="
 	/opt/Element/chrome-sandbox
 	/opt/Element/element-desktop


### PR DESCRIPTION
Avoids debug file collision with net-im/signal-desktop-bin

Closes: https://bugs.gentoo.org/792309