### PR TITLE
[WIP] x11-libs/gdk-pixbuf: Enable gi-docgen generated documentation

### DIFF
--- a/x11-libs/gdk-pixbuf/gdk-pixbuf-2.42.6.ebuild
+++ b/x11-libs/gdk-pixbuf/gdk-pixbuf-2.42.6.ebuild
@@ -30,8 +30,10 @@ BDEPEND="
 	dev-libs/glib:2
 	dev-libs/libxslt
 	dev-util/glib-utils
-	gtk-doc? ( >=dev-util/gtk-doc-1.20
-		app-text/docbook-xml-dtd:4.3 )
+	gtk-doc? (
+		app-text/docbook-xml-dtd:4.3
+		dev-util/gi-docgen
+	)
 	>=sys-devel/gettext-0.19.8
 	virtual/pkgconfig
 	>=dev-util/meson-0.55.3
@@ -71,7 +73,7 @@ multilib_src_configure() {
 	)
 	if multilib_is_native_abi; then
 		emesonargs+=(
-			$(meson_use gtk-doc gtk_docs)
+			$(meson_use gtk-doc gtk_doc)
 			$(meson_feature introspection)
 			-Dman=true
 		)
@@ -95,6 +97,15 @@ multilib_src_test() {
 
 multilib_src_install() {
 	meson_src_install
+}
+
+multilib_src_install_all() {
+	einstalldocs
+	if use gtk-doc; then
+		mkdir "${ED}"/usr/share/doc/${PF}/html || die
+		mv "${ED}"/usr/share/doc/{${PN}/,${PF}/html/} || die
+		mv "${ED}"/usr/share/doc/{gdk-pixdata/,${PF}/html/} || die
+	fi
 }
 
 pkg_preinst() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/779142
Signed-off-by: Chris Mayo <aklhfex@gmail.com>

---

[WIP] because alpha, hppa and riscv are not supported by required dev-util/gi-docgen-2021.6

@mattst88 the original gi-docgen conversion. No reference subdirectory from the source.