### PR TITLE
[Bug 793092] x11-libs/xapps-2.0.6 fails to build on prefix

### DIFF
--- a/dev-python/xapp/metadata.xml
+++ b/dev-python/xapp/metadata.xml
@@ -2,10 +2,6 @@
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
 	<maintainer type="person" proxied="yes">
-		<email>olivier.laurantin@laposte.net</email>
-		<name>Olivier Laurantin</name>
-	</maintainer>
-	<maintainer type="person" proxied="yes">
 		<email>sparky@bluefang-logic.com</email>
 		<name>Matthew Turnbull</name>
 	</maintainer>

--- a/x11-libs/xapps/metadata.xml
+++ b/x11-libs/xapps/metadata.xml
@@ -2,10 +2,6 @@
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
 	<maintainer type="person" proxied="yes">
-		<email>olivier.laurantin@laposte.net</email>
-		<name>Olivier Laurantin</name>
-	</maintainer>
-	<maintainer type="person" proxied="yes">
 		<email>sparky@bluefang-logic.com</email>
 		<name>Matthew Turnbull</name>
 	</maintainer>

--- a/x11-libs/xapps/xapps-2.0.6.ebuild
+++ b/x11-libs/xapps/xapps-2.0.6.ebuild
@@ -74,9 +74,9 @@ src_install() {
 	install_pygobject_override() {
 		PYTHON_GI_OVERRIDESDIR=$("${EPYTHON}" -c 'import gi;print(gi._overridesdir)' || die)
 		einfo "gobject overrides directory: ${PYTHON_GI_OVERRIDESDIR}"
-		mkdir -p "${ED}/${PYTHON_GI_OVERRIDESDIR}/" || die
-		cp -r "${D}"/pygobject/* "${ED}/${PYTHON_GI_OVERRIDESDIR}/" || die
-		python_optimize "${ED}/${PYTHON_GI_OVERRIDESDIR}/"
+		mkdir -p "${D}/${PYTHON_GI_OVERRIDESDIR}/" || die
+		cp -r "${D}"/pygobject/* "${D}/${PYTHON_GI_OVERRIDESDIR}/" || die
+		python_optimize "${D}/${PYTHON_GI_OVERRIDESDIR}/"
 	}
 	python_foreach_impl install_pygobject_override
 	rm -r "${D}/pygobject" || die


### PR DESCRIPTION
https://bugs.gentoo.org/793092

`$PYTHON_GI_OVERRIDESDIR` contains the fully qualified python path, so no need to prefix it with `$ED`.

Also update xapp[s] maintainers after request from Olivier Laurantin:
```
When cinnamon was about to be removed from official gentoo tree, I was asked to be proxy maintainer of
dev-python/xapp and x11-libs/xapps because they were dependencies of another package I am maintaining
(net-wireless/blueberry). Now that you are here to maintain cinnamon packages, I think it would be better to
remove me from the proxy maintainers of those 2 packages. Is it ok for you? And can you deal with this bug?
```