### PR TITLE
sys-libs/libtermcap-compat: install .so symlink

### DIFF
--- a/sys-libs/libtermcap-compat/libtermcap-compat-2.0.8-r5.ebuild
+++ b/sys-libs/libtermcap-compat/libtermcap-compat-2.0.8-r5.ebuild
@@ -61,6 +61,7 @@ src_configure() {
 multilib_src_install() {
 	dolib.so libtermcap.so.${PV}
 	dosym libtermcap.so.${PV} /usr/$(get_libdir)/libtermcap.so.2
+	dosym libtermcap.so.${PV} /usr/$(get_libdir)/libtermcap.so
 }
 
 multilib_src_install_all() {


### PR DESCRIPTION
Linker fails to find '-ltermcap' unless there's a .so symlink to it.