### PR TITLE
net-im/dino: Add net-libs/libnice and net-libs/libsrtp to dependencies

### DIFF
--- a/net-im/dino/dino-9999.ebuild
+++ b/net-im/dino/dino-9999.ebuild
@@ -29,7 +29,9 @@ RDEPEND="
 	dev-libs/icu
 	dev-libs/libgee:0.8
 	net-libs/glib-networking
+	>=net-libs/libnice-0.1.15
 	net-libs/libsignal-protocol-c
+	net-libs/libsrtp:2
 	x11-libs/cairo
 	x11-libs/gdk-pixbuf:2
 	x11-libs/gtk+:3


### PR DESCRIPTION
Fix 2 missing dependencies:
```
CMake Error at /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:165 (message):
  Could NOT find Srtp2 (missing: Srtp2_LIBRARY)
CMake Error at /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:165 (message):
  Could NOT find Nice (missing: Nice_LIBRARY) (Required is at least version
  "0.1.15")
```

Closes: https://bugs.gentoo.org/790143
Signed-off-by: Benjamin Neff <benjamin@coding4coffee.ch>