### PR TITLE
dev-perl/Term-ReadLine-Gnu: DEPEND on ncurses

### DIFF
--- a/dev-perl/Term-ReadLine-Gnu/Term-ReadLine-Gnu-1.360.0-r1.ebuild
+++ b/dev-perl/Term-ReadLine-Gnu/Term-ReadLine-Gnu-1.360.0-r1.ebuild
@@ -14,7 +14,10 @@ SLOT="0"
 KEYWORDS="~alpha amd64 ~arm ~arm64 ~ia64 ppc ~ppc64 ~s390 sparc x86 ~amd64-linux ~x86-linux"
 IUSE=""
 
-RDEPEND=">=sys-libs/readline-6.2:0="
+RDEPEND="
+	>=sys-libs/readline-6.2:0=
+	sys-libs/ncurses:0=
+"
 DEPEND="${RDEPEND}
 	virtual/perl-ExtUtils-MakeMaker
 "

--- a/dev-perl/Term-ReadLine-Gnu/Term-ReadLine-Gnu-1.420.0-r1.ebuild
+++ b/dev-perl/Term-ReadLine-Gnu/Term-ReadLine-Gnu-1.420.0-r1.ebuild
@@ -14,7 +14,10 @@ SLOT="0"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~ia64 ~ppc ~ppc64 ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux"
 IUSE=""
 
-RDEPEND=">=sys-libs/readline-6.2:0="
+RDEPEND="
+	>=sys-libs/readline-6.2:0=
+	sys-libs/ncurses:0=
+"
 DEPEND="
 	${RDEPEND}
 "
@@ -22,3 +25,12 @@ BDEPEND="
 	${RDEPEND}
 	virtual/perl-ExtUtils-MakeMaker
 "
+
+src_prepare() {
+	default
+	# search_termlib() selects termcap when sys-libs/libtermcap-compat is installed
+	# despite the absence of libtermcap.so symlink
+	sed -i -e \
+		"s/search_termlib()/search_lib('-ltinfo') || search_lib('-lncurses')/" \
+		Makefile.PL || die
+}


### PR DESCRIPTION
And prevent Term-ReadLine-Gnu-1.420.0 from trying to link to -ltermcap
when sys-libs/libtermcap-compat is installed.

Signed-off-by: Roman Beranek <roman.beranek@prusa3d.com>