### PR TITLE
app-emulation/virt-manager: Update live ebuild

### DIFF
--- a/app-emulation/virt-manager/virt-manager-9999.ebuild
+++ b/app-emulation/virt-manager/virt-manager-9999.ebuild
@@ -16,6 +16,7 @@ if [[ ${PV} = *9999* ]]; then
 	inherit git-r3
 	SRC_URI=""
 	EGIT_REPO_URI="https://github.com/virt-manager/virt-manager.git"
+	EGIT_BRANCH="master"
 else
 	SRC_URI="http://virt-manager.org/download/sources/${PN}/${P}.tar.gz"
 	KEYWORDS="~amd64 ~ppc64 ~x86"
@@ -34,6 +35,7 @@ RDEPEND="${PYTHON_DEPS}
 		>=dev-python/libvirt-python-6.10.0[${PYTHON_MULTI_USEDEP}]
 		dev-python/pygobject:3[${PYTHON_MULTI_USEDEP}]
 		dev-python/requests[${PYTHON_MULTI_USEDEP}]
+		dev-python/tqdm[${PYTHON_MULTI_USEDEP}]
 	')
 	>=sys-libs/libosinfo-0.2.10[introspection]
 	gtk? (


### PR DESCRIPTION
There was a patch merged recently into the upstream repo
(v3.2.0-82-g2024068b) that introduced new dependency on
dev-python/tqdm. And while I'm at it - let's declare branch which
should be checked out (master).

Signed-off-by: Michal Privoznik <mprivozn@redhat.com>