### PR TITLE
media-video/x264-encoder: gpac.patch not needed for 9999

### DIFF
--- a/media-video/x264-encoder/x264-encoder-9999.ebuild
+++ b/media-video/x264-encoder/x264-encoder-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -36,8 +36,6 @@ DEPEND="${RDEPEND}
 	x86? ( ${ASM_DEP} )
 	x86-fbsd? ( ${ASM_DEP} )"
 BDEPEND="virtual/pkgconfig"
-
-PATCHES=( "${FILESDIR}/gpac.patch" )
 
 src_configure() {
 	tc-export CC


### PR DESCRIPTION
[upstream now uses pkg-config for gpac detection.](https://code.videolan.org/videolan/x264/-/commit/979044a6595c7d01d14bca0360f0e94bb815af70)

Bug: https://bugs.gentoo.org/803182
Package-Manager: Portage-3.0.18, Repoman-3.0.2
Signed-off-by: James McClain <jmcclain2020@protonmail.com>