### PR TITLE
media-gfx/hydrus: Bump to python 3.9

### DIFF
--- a/media-gfx/hydrus/hydrus-441.ebuild
+++ b/media-gfx/hydrus/hydrus-441.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{7..8} )
+PYTHON_COMPAT=( python3_{7..9} )
 PYTHON_REQ_USE="sqlite"
 
 inherit python-single-r1 desktop optfeature


### PR DESCRIPTION
Now that QtPy and Pyside2 support 3.9, this does too

Signed-off-by: Ekaterina Vaartis <vaartis@kotobank.ch>