### PR TITLE
dev-vcs/gitstats: bump python to 3.9

### DIFF
--- a/dev-vcs/gitstats/gitstats-0_pre20201124.ebuild
+++ b/dev-vcs/gitstats/gitstats-0_pre20201124.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{7,8} )
+PYTHON_COMPAT=( python3_{8,9} )
 
 inherit python-r1
 


### PR DESCRIPTION
Signed-off-by: Gergely Nagy <ngg@ngg.hu>