### PR TITLE
sci-libs/opencascade[vtk]: prevent name collision

### DIFF
--- a/sci-libs/opencascade/files/opencascade-7.5.1-fix-AllValues-name-collision-with-vtk-9.0.patch
+++ b/sci-libs/opencascade/files/opencascade-7.5.1-fix-AllValues-name-collision-with-vtk-9.0.patch
@@ -1,0 +1,172 @@
+From f624c55d7b75ccbe3fdfef0db141fdbe1f6b383a Mon Sep 17 00:00:00 2001
+From: anv <anv@opencascade.com>
+Date: Tue, 27 Apr 2021 21:33:54 +0300
+Subject: [PATCH 1/2] 0032331: Visualization - Exception when trying to display
+ some surfaces using iVtk with VTK 9
+
+Updated memory allocation for vtkPolyData to use more suited method for VTK versions after 9.0
+---
+ src/IVtkDraw/IVtkDraw_Interactor.cxx          |  7 +++
+ src/IVtkTools/IVtkTools_SubPolyDataFilter.cxx | 50 ++++++++++++++++++-
+ 2 files changed, 56 insertions(+), 1 deletion(-)
+
+diff --git a/src/IVtkDraw/IVtkDraw_Interactor.cxx b/src/IVtkDraw/IVtkDraw_Interactor.cxx
+index f9f68c37b6..1b68c959f5 100644
+--- a/src/IVtkDraw/IVtkDraw_Interactor.cxx
++++ b/src/IVtkDraw/IVtkDraw_Interactor.cxx
+@@ -20,6 +20,13 @@
+ #include <vtkWin32OpenGLRenderWindow.h>
+ #else
+ #include <GL/glx.h>
++
++// Preventing naming collisions between
++// GLX and VTK versions 9.0 and above
++#ifdef AllValues
++#undef AllValues
++#endif
++
+ #include <vtkXRenderWindowInteractor.h>
+ #include <vtkXOpenGLRenderWindow.h>
+ #endif
+diff --git a/src/IVtkTools/IVtkTools_SubPolyDataFilter.cxx b/src/IVtkTools/IVtkTools_SubPolyDataFilter.cxx
+index 26ded68af5..bd289d2b51 100644
+--- a/src/IVtkTools/IVtkTools_SubPolyDataFilter.cxx
++++ b/src/IVtkTools/IVtkTools_SubPolyDataFilter.cxx
+@@ -87,6 +87,11 @@ int IVtkTools_SubPolyDataFilter::RequestData (vtkInformation *vtkNotUsed(theRequ
+ 
+     // Prepare the list of ids from the set of ids.
+     // Iterate on input cells.
++#if (VTK_MAJOR_VERSION >= 9)
++    // Count number of different cells.
++    int aNbVerts = 0, aNbLines = 0, aNbPolys = 0, aNbStrips = 0;
++    int aNbVertPts = 0, aNbLinePts = 0, aNbPolyPts = 0, aNbStripPts = 0;
++#endif
+     if (!myIdsSet.IsEmpty())
+     {
+       for (vtkIdType anI = 0; anI < aSize; anI++)
+@@ -95,13 +100,56 @@ int IVtkTools_SubPolyDataFilter::RequestData (vtkInformation *vtkNotUsed(theRequ
+         {
+           // Add a cell id to output if it's value is in the set.
+           anIdList->InsertNextId (anI);
++#if (VTK_MAJOR_VERSION >= 9)
++          switch (anInput->GetCellType(anI))
++          {
++            case VTK_VERTEX:
++              aNbVerts++;
++              aNbVertPts++;
++              break;
++            case VTK_POLY_VERTEX:
++              aNbVerts++;
++              aNbVertPts += anInput->GetCell(anI)->GetNumberOfPoints();
++              break;
++            case VTK_LINE:
++              aNbLines++;
++              aNbLinePts += 2;
++              break;
++            case VTK_POLY_LINE:
++              aNbLines++;
++              aNbLinePts += anInput->GetCell(anI)->GetNumberOfPoints();
++              break;
++            case VTK_TRIANGLE:
++              aNbPolys++;
++              aNbPolyPts += 3;
++              break;
++            case VTK_QUAD:
++              aNbPolys++;
++              aNbPolyPts += 4;
++              break;
++            case VTK_POLYGON:
++              aNbPolys++;
++              aNbPolyPts += anInput->GetCell(anI)->GetNumberOfPoints();
++              break;
++            case VTK_TRIANGLE_STRIP:
++              aNbStrips++;
++              aNbStripPts += anInput->GetCell(anI)->GetNumberOfPoints();
++              break;
++          }
++#endif
+         }
+       }
+     }
+ 
+     // Copy cells with their points according to the prepared list of cell ids.
+     anOutput->GetCellData()->AllocateArrays(anInput->GetCellData()->GetNumberOfArrays());
+-    anOutput->Allocate(anInput, anIdList->GetNumberOfIds());  // Allocate output cells
++    // Allocate output cells
++#if (VTK_MAJOR_VERSION >= 9)
++    anOutput->AllocateExact (aNbVerts, aNbVertPts, aNbLines, aNbLinePts, aNbPolys, aNbPolyPts, aNbStrips, aNbStripPts);
++#else
++    anOutput->Allocate (anInput, anIdList->GetNumberOfIds());
++#endif
++
+     // Pass data arrays.
+     // Create new arrays for output data 
+     vtkSmartPointer<vtkCellData> anInData = anInput->GetCellData();
+-- 
+2.31.1
+
+
+From 3a0d59614378af258b285c7a3cab66c4bb7cecd3 Mon Sep 17 00:00:00 2001
+From: Roman Beranek <roman.beranek@prusa3d.com>
+Date: Thu, 3 Jun 2021 15:41:45 +0200
+Subject: [PATCH 2/2] undef AllValues after inclusion of GL/glx.h
+
+Replicate the measure from 0032331 also for IVtkDraw.cxx and InterfaceGraphic.hxx
+---
+ src/IVtkDraw/IVtkDraw.cxx                 | 17 +++++++++++------
+ src/InterfaceGraphic/InterfaceGraphic.hxx |  4 +++-
+ 2 files changed, 14 insertions(+), 7 deletions(-)
+
+diff --git a/src/IVtkDraw/IVtkDraw.cxx b/src/IVtkDraw/IVtkDraw.cxx
+index 93d4a2fd1a..84bacdc55a 100644
+--- a/src/IVtkDraw/IVtkDraw.cxx
++++ b/src/IVtkDraw/IVtkDraw.cxx
+@@ -52,6 +52,17 @@
+ 
+ // prevent disabling some MSVC warning messages by VTK headers 
+ #include <Standard_WarningsDisable.hxx>
++#ifndef _WIN32
++  #include <X11/X.h>
++  #include <X11/Shell.h>
++  #include <X11/Xlib.h>
++  #include <X11/Xutil.h>
++  #include <GL/glx.h>
++  #include <Xw_Window.hxx>
++  #ifdef AllValues
++  #undef AllValues
++  #endif
++#endif
+ #include <vtkAlgorithmOutput.h>
+ #include <vtkAppendPolyData.h>
+ #include <vtkBMPWriter.h>
+@@ -75,12 +86,6 @@
+ #include <vtkTIFFWriter.h>
+ #include <vtkWindowToImageFilter.h>
+ #ifndef _WIN32
+-  #include <X11/X.h>
+-  #include <X11/Shell.h>
+-  #include <X11/Xlib.h>
+-  #include <X11/Xutil.h>
+-  #include <GL/glx.h>
+-  #include <Xw_Window.hxx>
+   #include <vtkXRenderWindowInteractor.h>
+   #include <vtkXOpenGLRenderWindow.h>
+   #include <tk.h>
+diff --git a/src/InterfaceGraphic/InterfaceGraphic.hxx b/src/InterfaceGraphic/InterfaceGraphic.hxx
+index c533f68cd5..bf02b3f397 100644
+--- a/src/InterfaceGraphic/InterfaceGraphic.hxx
++++ b/src/InterfaceGraphic/InterfaceGraphic.hxx
+@@ -39,7 +39,9 @@
+ #include <X11/Xutil.h>
+ #include <X11/Xatom.h>
+ #include <GL/glx.h>
+-
++#ifdef AllValues
++#undef AllValues
++#endif
+ #endif
+ 
+ #endif // __INTERFACE_GRAPHIC_HXX
+-- 
+2.31.1
+

--- a/sci-libs/opencascade/opencascade-7.5.1-r1.ebuild
+++ b/sci-libs/opencascade/opencascade-7.5.1-r1.ebuild
@@ -68,6 +68,7 @@ PATCHES=(
 	"${FILESDIR}"/${P}-0004-fix-installation-of-cmake-config-files.patch
 	"${FILESDIR}"/${P}-0005-fix-write-permissions-on-scripts.patch
 	"${FILESDIR}"/${P}-0006-fix-creation-of-custom.sh-script.patch
+	"${FILESDIR}"/${P}-fix-AllValues-name-collision-with-vtk-9.0.patch
 )
 
 src_prepare() {


### PR DESCRIPTION
VTK-9.0 declares in their headers 'struct AllValues' which collides with
a macro defined by GLX.

This has been only partially fixed in the upstream:
https://git.dev.opencascade.org/gitweb/?p=occt.git;a=commit;h=2c276f91da0

It was necessary to put `#undef`s in a few other places.

Closes: https://bugs.gentoo.org/794031
Signed-off-by: Roman Beranek <roman.beranek@prusa3d.com>