### PR TITLE
dev-vcs/tig: do not install tig-completion.zsh

### DIFF
--- a/dev-vcs/tig/tig-2.5.3-r1.ebuild
+++ b/dev-vcs/tig/tig-2.5.3-r1.ebuild
@@ -1,0 +1,62 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit bash-completion-r1
+
+if [[ ${PV} == "9999" ]] ; then
+	EGIT_REPO_URI="https://github.com/jonas/tig.git"
+	inherit git-r3 autotools
+else
+	SRC_URI="https://github.com/jonas/tig/releases/download/${P}/${P}.tar.gz"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
+fi
+
+DESCRIPTION="text mode interface for git"
+HOMEPAGE="https://jonas.github.io/tig/"
+
+LICENSE="GPL-2"
+SLOT="0"
+IUSE="test unicode"
+REQUIRED_USE="test? ( unicode )"
+
+DEPEND="
+	sys-libs/ncurses:0=[unicode?]
+	sys-libs/readline:0=
+"
+RDEPEND="
+	${DEPEND}
+	dev-vcs/git
+"
+[[ ${PV} == "9999" ]] && BDEPEND+=" app-text/asciidoc app-text/xmlto"
+
+# encoding/env issues
+RESTRICT="test"
+
+src_prepare() {
+	default
+	[[ ${PV} == "9999" ]] && eautoreconf
+}
+
+src_configure() {
+	econf $(use_with unicode ncursesw)
+}
+
+src_compile() {
+	emake V=1
+	[[ ${PV} == "9999" ]] && emake V=1 doc-man doc-html
+}
+
+src_test() {
+	# workaround parallel test failures
+	emake -j1 test
+}
+
+src_install() {
+	emake DESTDIR="${D}" install install-doc-man
+	dodoc doc/manual.html README.html NEWS.html
+	newbashcomp contrib/tig-completion.bash ${PN}
+
+	dodoc contrib/*.tigrc
+}


### PR DESCRIPTION
tig-completion.zsh (installed as /usr/share/zsh/site-functions/_tig)
doesn't work and interferes with '_git' from app-shell/zsh, which
already adds comletion for tig.
Don't install the file to make completion for tig in zsh work.

Package-Manager: Portage-3.0.19, Repoman-3.0.3
Signed-off-by: Stefan Strogin <steils@gentoo.org>

```
--- tig-2.5.3.ebuild    2021-06-04 06:59:40.689508268 +0300
+++ tig-2.5.3-r1.ebuild 2021-06-04 06:59:37.092841812 +0300
@@ -58,8 +58,5 @@
        dodoc doc/manual.html README.html NEWS.html
        newbashcomp contrib/tig-completion.bash ${PN}

-       insinto /usr/share/zsh/site-functions
-       newins contrib/tig-completion.zsh _${PN}
-
        dodoc contrib/*.tigrc
 }
```