### PR TITLE
dev-tex/rubber-1.5.1: declare Python 3.9 compatibility

### DIFF
--- a/dev-tex/rubber/rubber-1.5.1.ebuild
+++ b/dev-tex/rubber/rubber-1.5.1.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-PYTHON_COMPAT=( python3_{7,8} )
+PYTHON_COMPAT=( python3_{7,8,9} )
 
 inherit distutils-r1
 


### PR DESCRIPTION
I did some rudiementary testing with Rubber 1.5.1 and Python 3.9. This
combination was able to compile all presented .tex files. I am also
not aware of anything that causes Rubber 1.5/1.6 to be incompatible
with Python 3.9.

So, instead of stabilizing Rubber 1.6.1-alpha1 (bug #793332), sam and
I decided to have rubber 1.5.1 declare Python 3.9 support.

Bug: https://bugs.gentoo.org/793332
Signed-off-by: Florian Schmaus <flo@geekplace.eu>