### PR TITLE
app-text/calibre: support SIP v5

### DIFF
--- a/app-text/calibre/calibre-5.16.1.ebuild
+++ b/app-text/calibre/calibre-5.16.1.ebuild
@@ -123,8 +123,12 @@ src_prepare() {
 	# disable_plugins: walking sec-hole, wait for upstream to use GHNS interface
 	eapply \
 		"${FILESDIR}/${PN}-2.9.0-no_updates_dialog.patch" \
-		"${FILESDIR}/${PN}-disable_plugins.patch" \
-		"${WORKDIR}/${PN}-5.16.0-SIP-v4.patch"
+		"${FILESDIR}/${PN}-disable_plugins.patch"
+
+	if ! has_version ">=dev-python/sip-5"; then
+		einfo "Applying SIP v4 patch because SIP v5 was not detected"
+		eapply "${WORKDIR}/${PN}-5.16.0-SIP-v4.patch"
+	fi
 
 	eapply_user
 


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/793986
Package-Manager: Portage-3.0.19, Repoman-3.0.3
Signed-off-by: Zac Medico <zmedico@gentoo.org>