### PR TITLE
dev-games/openscenegraph-openmw: fix build with gcc 11

### DIFF
--- a/dev-games/openscenegraph-openmw/files/openscenegraph-3.4-gcc11.patch
+++ b/dev-games/openscenegraph-openmw/files/openscenegraph-3.4-gcc11.patch
@@ -1,0 +1,22 @@
+--- a/include/osgDB/ObjectCache
++++ b/include/osgDB/ObjectCache
+@@ -72,7 +72,7 @@ class OSGDB_EXPORT ObjectCache : public osg::Referenced
+ 
+         class ClassComp {
+         public:
+-            bool operator() (const ObjectCache::FileNameOptionsPair& lhs, const ObjectCache::FileNameOptionsPair& rhs);
++            bool operator() (const ObjectCache::FileNameOptionsPair& lhs, const ObjectCache::FileNameOptionsPair& rhs) const;
+         };
+ 
+         typedef std::pair<osg::ref_ptr<osg::Object>, double >           ObjectTimeStampPair;
+--- a/src/osgDB/ObjectCache.cpp
++++ b/src/osgDB/ObjectCache.cpp
+@@ -16,7 +16,7 @@
+ 
+ using namespace osgDB;
+ 
+-bool ObjectCache::ClassComp::operator() (const ObjectCache::FileNameOptionsPair& lhs, const ObjectCache::FileNameOptionsPair& rhs)
++bool ObjectCache::ClassComp::operator() (const ObjectCache::FileNameOptionsPair& lhs, const ObjectCache::FileNameOptionsPair& rhs) const
+ {
+     // check if filename are the same
+     if (lhs.first < rhs.first) return true;

--- a/dev-games/openscenegraph-openmw/openscenegraph-openmw-3.4_p20200425-r100.ebuild
+++ b/dev-games/openscenegraph-openmw/openscenegraph-openmw-3.4_p20200425-r100.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -87,6 +87,7 @@ PATCHES=(
 	"${FILESDIR}"/openscenegraph-3.4-cmake.patch
 	"${FILESDIR}"/openscenegraph-3.5.1-jpeg-9.patch
 	"${FILESDIR}"/openscenegraph-3.6.3-docdir.patch
+	"${FILESDIR}"/openscenegraph-3.4-gcc11.patch
 )
 
 pkg_setup() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/788301
Signed-off-by: Alexey Sokolov <sokolov@google.com>