### PR TITLE
sci-libs/ceres-solver: add python-3.9 support

### DIFF
--- a/sci-libs/ceres-solver/ceres-solver-1.14.0.ebuild
+++ b/sci-libs/ceres-solver/ceres-solver-1.14.0.ebuild
@@ -1,10 +1,10 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
 CMAKE_ECLASS=cmake
-PYTHON_COMPAT=( python3_{7,8} )
+PYTHON_COMPAT=( python3_{7,8,9} )
 inherit cmake-multilib python-any-r1 toolchain-funcs
 
 DESCRIPTION="Nonlinear least-squares minimizer"


### PR DESCRIPTION
Bugday 2021-06-05

Package-Manager: Portage-3.0.19, Repoman-3.0.3
Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>