### PR TITLE
sci-mathematics/relational: add support for python-3.9

### DIFF
--- a/sci-mathematics/relational/relational-2.5-r2.ebuild
+++ b/sci-mathematics/relational/relational-2.5-r2.ebuild
@@ -1,15 +1,16 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{7,8} )
+PYTHON_COMPAT=( python3_{7,8,9} )
 
 inherit python-single-r1
 
 DESCRIPTION="Educational tool for relational algebra"
 HOMEPAGE="https://ltworf.github.io/relational/"
 SRC_URI="https://github.com/ltworf/${PN}/releases/download/${PV}/${PN}_${PV}.orig.tar.gz"
+S="${WORKDIR}/${PN}"
 
 LICENSE="GPL-3"
 SLOT="0"
@@ -24,8 +25,6 @@ DEPEND="${PYTHON_DEPS}
 	')
 "
 RDEPEND="${DEPEND}"
-
-S="${WORKDIR}/${PN}"
 
 PATCHES=( "${FILESDIR}/${P}-no-qtwebkit.patch" )
 


### PR DESCRIPTION
Bugday 2021-06-05

Package-Manager: Portage-3.0.19, Repoman-3.0.3
Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>