### PR TITLE
sci-misc/vitables: add support for python-3.9

### DIFF
--- a/sci-misc/vitables/vitables-3.0.0-r2.ebuild
+++ b/sci-misc/vitables/vitables-3.0.0-r2.ebuild
@@ -1,10 +1,10 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
 DISTUTILS_SINGLE_IMPL=1
-PYTHON_COMPAT=( python3_{7,8} )
+PYTHON_COMPAT=( python3_{7,8,9} )
 
 inherit distutils-r1
 


### PR DESCRIPTION
Bugday 2021-06-05

Package-Manager: Portage-3.0.19, Repoman-3.0.3
Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>