### PR TITLE
media-libs/gegl[openexr]: fix build against >=dev-libs/glib-2.67.3, =media-libs/openexr-3.0.1

### DIFF
--- a/media-libs/gegl/files/gegl-0.4.26-fix-build-glib-2.67.3.patch
+++ b/media-libs/gegl/files/gegl-0.4.26-fix-build-glib-2.67.3.patch
@@ -1,0 +1,24 @@
+From 130cd583530dc41adfdec76d6662302f833e6033 Mon Sep 17 00:00:00 2001
+From: Olivier Tilloy <olivier.tilloy@canonical.com>
+Date: Fri, 5 Mar 2021 12:58:18 +0100
+Subject: [PATCH] Fix build with glib 2.67.3 (see
+ https://gitlab.gnome.org/GNOME/glib/-/issues/2331).
+
+---
+ operations/external/exr-load.cpp | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/operations/external/exr-load.cpp b/operations/external/exr-load.cpp
+index e864f7e3e..28403639c 100644
+--- a/operations/external/exr-load.cpp
++++ b/operations/external/exr-load.cpp
+@@ -29,9 +29,7 @@ property_file_path (path, "File", "")
+ #define GEGL_OP_NAME exr_load
+ #define GEGL_OP_C_FILE       "exr-load.cpp"
+ 
+-extern "C" {
+ #include "gegl-op.h"
+-}
+ 
+ #include <ImfInputFile.h>
+ #include <ImfChannelList.h>

--- a/media-libs/gegl/files/gegl-0.4.30-fix-build-openexr-3.patch
+++ b/media-libs/gegl/files/gegl-0.4.30-fix-build-openexr-3.patch
@@ -1,0 +1,22 @@
+From 499a239d158fadb3a04499255b5b282a8a6023bb Mon Sep 17 00:00:00 2001
+From: Antonio Rojas <arojas@archlinux.org>
+Date: Sat, 24 Apr 2021 10:51:09 +0000
+Subject: [PATCH] Fix build with OpenEXR 3
+
+Add a header that is no longer transitively included
+---
+ operations/external/exr-save.cc | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/operations/external/exr-save.cc b/operations/external/exr-save.cc
+index 1e8c09d96..87abed511 100644
+--- a/operations/external/exr-save.cc
++++ b/operations/external/exr-save.cc
+@@ -45,6 +45,7 @@ extern "C" {
+ #include <ImfChromaticities.h>
+ #include <ImfStandardAttributes.h>
+ #include <ImfArray.h>
++#include <ImfFrameBuffer.h>
+ #include "ImathRandom.h"
+ 
+ 

--- a/media-libs/gegl/gegl-0.4.26-r1.ebuild
+++ b/media-libs/gegl/gegl-0.4.26-r1.ebuild
@@ -37,7 +37,7 @@ RESTRICT="!test? ( test )"
 #       so there is no chance to support libav right now (Gentoo bug #567638)
 #       If it returns, please check prior GEGL ebuilds for how libav was integrated.  Thanks!
 RDEPEND="
-	>=dev-libs/glib-2.44:2
+	>=dev-libs/glib-2.68.2:2
 	>=dev-libs/json-glib-1.2.6
 	>=media-libs/babl-0.1.78[introspection?,lcms?,vala?]
 	media-libs/libnsgif
@@ -78,6 +78,7 @@ DOCS=( AUTHORS docs/ChangeLog docs/NEWS.txt )
 PATCHES=(
 	"${FILESDIR}"/${PN}-0.4.18-drop-failing-tests.patch
 	"${FILESDIR}"/${PN}-0.4.18-program-suffix.patch
+	"${FILESDIR}"/${P}-fix-build-glib-2.67.3.patch
 )
 
 python_check_deps() {

--- a/media-libs/gegl/gegl-0.4.26-r1.ebuild
+++ b/media-libs/gegl/gegl-0.4.26-r1.ebuild
@@ -79,6 +79,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-0.4.18-drop-failing-tests.patch
 	"${FILESDIR}"/${PN}-0.4.18-program-suffix.patch
 	"${FILESDIR}"/${P}-fix-build-glib-2.67.3.patch
+	"${FILESDIR}"/${PN}-0.4.30-fix-build-openexr-3.patch
 )
 
 python_check_deps() {

--- a/media-libs/gegl/gegl-0.4.28.ebuild
+++ b/media-libs/gegl/gegl-0.4.28.ebuild
@@ -79,6 +79,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-0.4.18-drop-failing-tests.patch
 	"${FILESDIR}"/${PN}-0.4.18-program-suffix.patch
 	"${FILESDIR}"/${PN}-0.4.26-fix-build-glib-2.67.3.patch
+	"${FILESDIR}"/${PN}-0.4.30-fix-build-openexr-3.patch
 )
 
 python_check_deps() {

--- a/media-libs/gegl/gegl-0.4.28.ebuild
+++ b/media-libs/gegl/gegl-0.4.28.ebuild
@@ -37,7 +37,7 @@ RESTRICT="!test? ( test )"
 #       so there is no chance to support libav right now (Gentoo bug #567638)
 #       If it returns, please check prior GEGL ebuilds for how libav was integrated.  Thanks!
 RDEPEND="
-	>=dev-libs/glib-2.44:2
+	>=dev-libs/glib-2.68.2:2
 	>=dev-libs/json-glib-1.2.6
 	>=media-libs/babl-0.1.84[introspection?,lcms?,vala?]
 	media-libs/libnsgif
@@ -78,6 +78,7 @@ DOCS=( AUTHORS docs/ChangeLog docs/NEWS.txt )
 PATCHES=(
 	"${FILESDIR}"/${PN}-0.4.18-drop-failing-tests.patch
 	"${FILESDIR}"/${PN}-0.4.18-program-suffix.patch
+	"${FILESDIR}"/${PN}-0.4.26-fix-build-glib-2.67.3.patch
 )
 
 python_check_deps() {

--- a/media-libs/gegl/gegl-0.4.30.ebuild
+++ b/media-libs/gegl/gegl-0.4.30.ebuild
@@ -75,6 +75,10 @@ BDEPEND="
 
 DOCS=( AUTHORS docs/ChangeLog docs/NEWS.txt )
 
+PATCHES=(
+	"${FILESDIR}"/${P}-fix-build-openexr-3.patch
+)
+
 python_check_deps() {
 	use test || return 0
 	has_version -b ">=dev-python/pygobject-3.2:3[${PYTHON_USEDEP}]"

--- a/media-libs/gegl/gegl-0.4.30.ebuild
+++ b/media-libs/gegl/gegl-0.4.30.ebuild
@@ -37,7 +37,7 @@ RESTRICT="!test? ( test )"
 #       so there is no chance to support libav right now (Gentoo bug #567638)
 #       If it returns, please check prior GEGL ebuilds for how libav was integrated.  Thanks!
 RDEPEND="
-	>=dev-libs/glib-2.44:2
+	>=dev-libs/glib-2.68.2:2
 	>=dev-libs/json-glib-1.2.6
 	>=media-libs/babl-0.1.84[introspection?,lcms?,vala?]
 	media-libs/libnsgif


### PR DESCRIPTION
This pull request fix two issues of built media-libs/gegl[openexr].

Closes: https://bugs.gentoo.org/793998  
Closes: https://bugs.gentoo.org/788400