### PR TITLE
games-engines/openmw: 0.46 requires OSG 3.4

### DIFF
--- a/games-engines/openmw/openmw-0.46.0-r1.ebuild
+++ b/games-engines/openmw/openmw-0.46.0-r1.ebuild
@@ -38,7 +38,7 @@ RDEPEND="
 	media-video/ffmpeg:=
 	>=sci-physics/bullet-2.86:=[-double-precision]
 	virtual/opengl
-	osg-fork? ( dev-games/openscenegraph-openmw:=[ffmpeg,jpeg,png,sdl,svg,truetype,zlib] )
+	osg-fork? ( =dev-games/openscenegraph-openmw-3.4*:=[ffmpeg,jpeg,png,sdl,svg,truetype,zlib] )
 	!osg-fork? ( >=dev-games/openscenegraph-3.5.5:=[ffmpeg,jpeg,png,sdl,svg,truetype,zlib] )
 	qt5? (
 		app-arch/unshield


### PR DESCRIPTION
This is in preparation for future 0.47. The discussion with upstream
revealed that 0.46 works best with the forked OSG 3.4, 3.6 is not
recommended for it. But 0.47 needs 3.6, also with a preference to use
the forked OSG.

Package-Manager: Portage-3.0.18, Repoman-3.0.2
Signed-off-by: Alexey Sokolov <alexey+gentoo@asokolov.org>