### PR TITLE
dev-libs/gf2x: add missing includes

### DIFF
--- a/dev-libs/gf2x/files/gf2x-1.3.0-0001-src-tunefft.c-add-include-statement-for-MIN-and-MAX.patch
+++ b/dev-libs/gf2x/files/gf2x-1.3.0-0001-src-tunefft.c-add-include-statement-for-MIN-and-MAX.patch
@@ -1,0 +1,29 @@
+From 292b5784d907f420886e50d5683517b8fe1abe3c Mon Sep 17 00:00:00 2001
+From: Bernd Waibel <waebbl-gentoo@posteo.net>
+Date: Sat, 5 Jun 2021 18:29:08 +0200
+Subject: [PATCH] src/tunefft.c: add include statement for MIN and MAX
+
+Add #include <sys/param.h> to have MIN and MAX available
+for next_step function.
+
+Bug: https://bugs.gentoo.org/719982
+Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>
+---
+ src/tunefft.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/tunefft.c b/src/tunefft.c
+index a08d82a..f5abc82 100644
+--- a/src/tunefft.c
++++ b/src/tunefft.c
+@@ -65,6 +65,7 @@
+ #include <float.h>		/* for DBL_MAX */
+ #include <time.h>
+ #include <sys/utsname.h>	/* for uname */
++#include <sys/param.h>		/* for MIN, MAX */
+ #include "gf2x.h"
+ #include "gf2x/gf2x-impl.h"
+ #include "timing.h"
+-- 
+2.31.1
+

--- a/dev-libs/gf2x/gf2x-1.3.0.ebuild
+++ b/dev-libs/gf2x/gf2x-1.3.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -17,7 +17,10 @@ IUSE="fft static-libs custom-tune"
 IUSE_CPU_FLAGS=" pclmul sse2 sse3 sse4_1 ssse3"
 IUSE+=" ${IUSE_CPU_FLAGS// / cpu_flags_x86_}"
 
-PATCHES=( "${FILESDIR}/fno-common.patch" )
+PATCHES=(
+	"${FILESDIR}/fno-common.patch"
+	"${FILESDIR}/${P}-0001-src-tunefft.c-add-include-statement-for-MIN-and-MAX.patch"
+)
 
 src_prepare() {
 	default


### PR DESCRIPTION
Add include statement for MIN and MAX declarations

Closes: https://bugs.gentoo.org/719982
Package-Manager: Portage-3.0.19, Repoman-3.0.3
Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>