### PR TITLE
sys-libs/musl: fix HOMEPAGE

### DIFF
--- a/sys-libs/musl/musl-1.2.2-r2.ebuild
+++ b/sys-libs/musl/musl-1.2.2-r2.ebuild
@@ -28,7 +28,7 @@ if [[ ${CTARGET} == ${CHOST} ]] ; then
 fi
 
 DESCRIPTION="Light, fast and simple C library focused on standards-conformance and safety"
-HOMEPAGE="http://www.musl-libc.org/"
+HOMEPAGE="https://musl.libc.org"
 LICENSE="MIT LGPL-2 GPL-2"
 SLOT="0"
 IUSE="headers-only"

--- a/sys-libs/musl/musl-9999.ebuild
+++ b/sys-libs/musl/musl-9999.ebuild
@@ -28,7 +28,7 @@ if [[ ${CTARGET} == ${CHOST} ]] ; then
 fi
 
 DESCRIPTION="Light, fast and simple C library focused on standards-conformance and safety"
-HOMEPAGE="http://www.musl-libc.org/"
+HOMEPAGE="https://musl.libc.org"
 LICENSE="MIT LGPL-2 GPL-2"
 SLOT="0"
 IUSE="headers-only"


### PR DESCRIPTION
As per http://www.musl-libc.org/, "musl has moved to a new domain:
musl.libc.org"

Bug: https://bugs.gentoo.org/794484
Signed-off-by: Bertrand Jacquin <bertrand@jacquin.bzh>
Package-Manager: Portage-3.0.18, Repoman-3.0.2