### PR TITLE
media-libs/opencolorio: respect python sitedir

### DIFF
--- a/media-libs/opencolorio/files/opencolorio-1.1.1-Gentoo-specific-OCIOMacros.cmake-remove-LIB_SUFFIX.patch
+++ b/media-libs/opencolorio/files/opencolorio-1.1.1-Gentoo-specific-OCIOMacros.cmake-remove-LIB_SUFFIX.patch
@@ -1,0 +1,38 @@
+From 80c08e5bee5bd9fc37a6aeff4b7b7bb8edb3c831 Mon Sep 17 00:00:00 2001
+From: Bernd Waibel <waebbl-gentoo@posteo.net>
+Date: Sun, 6 Jun 2021 20:42:48 +0200
+Subject: [PATCH] [Gentoo specific]OCIOMacros.cmake: remove LIB_SUFFIX
+
+We don't use LIB_SUFFIX for python's site-packages dir, so remove it
+from the PYTHON_VARIANT_PATH to ensure, python modules are installed
+to the correct location.
+
+Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>
+---
+ share/cmake/OCIOMacros.cmake | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/share/cmake/OCIOMacros.cmake b/share/cmake/OCIOMacros.cmake
+index b9fb239..0ce9e62 100644
+--- a/share/cmake/OCIOMacros.cmake
++++ b/share/cmake/OCIOMacros.cmake
+@@ -241,14 +241,14 @@ MACRO(OCIOFindPython)
+         if(WIN32)
+             set(PYTHON_VARIANT_PATH "lib${LIB_SUFFIX}/${PYTHON_UCS}/site-packages")
+         else()
+-            set(PYTHON_VARIANT_PATH "lib${LIB_SUFFIX}/python${PYTHON_VERSION}/${PYTHON_UCS}/site-packages")
++            set(PYTHON_VARIANT_PATH "lib/python${PYTHON_VERSION}/${PYTHON_UCS}/site-packages")
+         endif()
+     else()
+         # Ignore UCS value and install into lib/python2.6/site-packages dir
+         if(WIN32)
+             set(PYTHON_VARIANT_PATH "lib${LIB_SUFFIX}/site-packages")
+         else()
+-            set(PYTHON_VARIANT_PATH "lib${LIB_SUFFIX}/python${PYTHON_VERSION}/site-packages")
++            set(PYTHON_VARIANT_PATH "lib/python${PYTHON_VERSION}/site-packages")
+         endif()
+     endif()
+ 
+-- 
+2.31.1
+

--- a/media-libs/opencolorio/opencolorio-1.1.1.ebuild
+++ b/media-libs/opencolorio/opencolorio-1.1.1.ebuild
@@ -54,6 +54,7 @@ PATCHES=(
 	"${FILESDIR}/${PN}-1.1.1-yaml-cpp-boost-check.patch"
 	"${FILESDIR}/${P}-fix-self-assign-clang.patch"
 	"${FILESDIR}/${P}-no-werror.patch"
+	"${FILESDIR}/${P}-Gentoo-specific-OCIOMacros.cmake-remove-LIB_SUFFIX.patch"
 )
 
 pkg_setup() {
@@ -89,6 +90,13 @@ src_configure() {
 		-DOCIO_USE_SSE=$(usex cpu_flags_x86_sse2)
 		-DOCIO_BUILD_TESTS=$(usex test)
 	)
+
+	if use python; then
+		mycmakeargs+=(
+			-DPYTHON=${PYTHON}
+			-DPYTHON_LIBRARY=$(python_get_library_path)
+		)
+	fi
 
 	use doc && mycmakeargs+=( -DCMAKE_DISABLE_FIND_PACKAGE_LATEX=ON ) # broken
 	cmake_src_configure


### PR DESCRIPTION
Pass certain variables to cmake and add a patch to respect the python
site-packages dir.

Closes: https://bugs.gentoo.org/794604
Package-Manager: Portage-3.0.19, Repoman-3.0.3
Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>