### PR TITLE
sci-libs/opencascade: restrict dependency on sci-libs/vtk

### DIFF
--- a/sci-libs/opencascade/opencascade-7.5.1-r1.ebuild
+++ b/sci-libs/opencascade/opencascade-7.5.1-r1.ebuild
@@ -53,7 +53,7 @@ RDEPEND="
 	freeimage? ( media-libs/freeimage )
 	json? ( dev-libs/rapidjson )
 	tbb? ( dev-cpp/tbb )
-	vtk? ( >=sci-libs/vtk-8.1.0[rendering] )
+	vtk? ( <sci-libs/vtk-9[rendering] )
 "
 DEPEND="${RDEPEND}"
 BDEPEND="


### PR DESCRIPTION
Restrict to <sci-libs/vtk-9. The package does not easily build with
the latest version. This is the simple way to solve it for now.
I'm currently preparing a bump to 7.5.2 which will work with vtk-9.

Closes: https://bugs.gentoo.org/794031
Package-Manager: Portage-3.0.19, Repoman-3.0.3
Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>