### PR TITLE
net-misc/youtube-dl: Inherit git-r3 for live ebuild

### DIFF
--- a/net-misc/youtube-dl/youtube-dl-9999.ebuild
+++ b/net-misc/youtube-dl/youtube-dl-9999.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 
 PYTHON_COMPAT=( python3_{8..10} )
-inherit bash-completion-r1 distutils-r1 readme.gentoo-r1
+inherit bash-completion-r1 distutils-r1 readme.gentoo-r1 git-r3
 
 DESCRIPTION="Download videos from YouTube.com (and more sites...)"
 HOMEPAGE="https://youtube-dl.org/ https://github.com/ytdl-org/youtube-dl/"


### PR DESCRIPTION
The interit of git-r3 eclass was mistakenly removed in
a27a5dfb92de4aed3922446d5521aaf0cafc475e. Without this,
the ebuild fails to fetch and unpack the source.

Signed-off-by: Michal Privoznik <mprivozn@redhat.com>