### PR TITLE
net-misc/xmrig: add self as proxy-maintainer

### DIFF
--- a/net-misc/xmrig/metadata.xml
+++ b/net-misc/xmrig/metadata.xml
@@ -1,7 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-  <maintainer type="person">
+  <maintainer type="person" proxied="yes">
+    <email>telans@posteo.de</email>
+    <name>Theo Anderson</name>
+  </maintainer>
+  <maintainer type="person" proxied="proxy">
     <email>candrews@gentoo.org</email>
     <name>Craig Andrews</name>
   </maintainer>


### PR DESCRIPTION
From what I see in present metadata.xml files, the proxied goes before the proxy. Cheers

@candrews

Signed-off-by: Theo Anderson <telans@posteo.de>