### PR TITLE
eclass/kernel-2: fix USE=symlink

### DIFF
--- a/eclass/kernel-2.eclass
+++ b/eclass/kernel-2.eclass
@@ -962,7 +962,7 @@ postinst_sources() {
 			die "${EROOT%/}/usr/src/linux exist and is not a symlink"
 		fi
 
-		ln -sf linux-${KV_FULL} "${EROOT%/}"/usr/src/linux || die
+		ln -snf linux-${KV_FULL} "${EROOT%/}"/usr/src/linux || die
 	fi
 
 	# Don't forget to make directory for sysfs


### PR DESCRIPTION
the symlink to /usr/src/linux is longer removed bofore linking
(see 7446cb850c5e0412e4d88b3aa5d207751241fb02). the latter ln -sf
does not replace existing symlinks, since destination is a
directory.

Closes: https://bugs.gentoo.org/795057
Signed-off-by: Till Schäfer <till2.schaefer@uni-dortmund.de>