### PR TITLE
x11-terms/kitty: fix live ebuild and update python compatibility

### DIFF
--- a/x11-terms/kitty/files/kitty-9999-flags.patch
+++ b/x11-terms/kitty/files/kitty-9999-flags.patch
@@ -17,7 +17,7 @@ index f751107f..69bf39d4 100755
              f'-Wextra {float_conversion} -Wno-missing-field-initializers -Wall -Wstrict-prototypes {std}'
 -            f' {werror} {optimize} {sanitize_flag} -fwrapv {stack_protector} {missing_braces}'
 -            f' -pipe {march} -fvisibility=hidden {fortify_source}'
-+            f' -pedantic-errors {optimize} {sanitize_flag} -fwrapv {stack_protector} {missing_braces}'
++            f' {optimize} {sanitize_flag} -fwrapv {stack_protector} {missing_braces}'
 +            f' {march} -fvisibility=hidden {fortify_source}'
          )
      )
@@ -31,14 +31,15 @@ index f751107f..69bf39d4 100755
      )
      ldflags = shlex.split(ldflags_)
      ldflags.append('-shared')
-@@ -789,9 +789,7 @@ def safe_makedirs(path: str) -> None:
- 
- 
+@@ -789,10 +789,7 @@
+
+
  def build_launcher(args: Options, launcher_dir: str = '.', bundle_type: str = 'source') -> None:
--    cflags = '-Wall -Werror -fpie'.split()
+-    werror = '' if args.ignore_compiler_warnings else '-pedantic-errors -Werror'
+-    cflags = f'-Wall {werror} -fpie'.split()
 -    if args.build_universal_binary:
 -        cflags += '-arch x86_64 -arch arm64'.split()
-+    cflags = '-Wall -fpie'.split()
++    cflags = f'-Wall -fpie'.split()
      cppflags = []
      libs: List[str] = []
      if args.profile or args.sanitize:

--- a/x11-terms/kitty/files/kitty-9999-remove-terminfo.patch
+++ b/x11-terms/kitty/files/kitty-9999-remove-terminfo.patch
@@ -1,0 +1,16 @@
+diff --git a/setup.py b/setup.py
+index ce5309ee..02f38c61 100755
+--- a/setup.py
++++ a/setup.py
+@@ -1082,11 +1082,6 @@
+     else:
+         build_launcher(args, launcher_dir, bundle_type)
+     os.makedirs(os.path.join(libdir, 'logo'))
+-    build_terminfo = runpy.run_path('build-terminfo', run_name='import_build')
+-    for x in (libdir, os.path.join(ddir, 'share')):
+-        odir = os.path.join(x, 'terminfo')
+-        safe_makedirs(odir)
+-        build_terminfo['compile_terminfo'](odir)
+     shutil.copy2('__main__.py', libdir)
+     shutil.copy2('logo/kitty-128.png', os.path.join(libdir, 'logo'))
+     shutil.copy2('logo/kitty.png', os.path.join(libdir, 'logo'))

--- a/x11-terms/kitty/kitty-9999.ebuild
+++ b/x11-terms/kitty/kitty-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{7,8} )
+PYTHON_COMPAT=( python3_{7,8,9} )
 
 inherit optfeature python-single-r1 toolchain-funcs xdg
 
@@ -58,7 +58,7 @@ BDEPEND="virtual/pkgconfig"
 
 PATCHES=(
 	"${FILESDIR}"/${P}-flags.patch
-	"${FILESDIR}"/kitty-0.20.1-remove-terminfo.patch
+	"${FILESDIR}"/${P}-remove-terminfo.patch
 	"${FILESDIR}"/${PN}-0.14.4-svg-icon.patch
 )
 


### PR DESCRIPTION
Signed-off-by: Pablo Orduna <pabloorduna98@gmail.com>

Closes: https://bugs.gentoo.org/789285