### PR TITLE
dev-util/watchman: added python 3.9 support in watchman-4.9.0.ebuild

### DIFF
--- a/dev-util/watchman/watchman-4.9.0.ebuild
+++ b/dev-util/watchman/watchman-4.9.0.ebuild
@@ -1,8 +1,8 @@
-# Copyright 2020 Gentoo Authors
+# Copyright 2020-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-PYTHON_COMPAT=( python3_{7,8} )
+PYTHON_COMPAT=( python3_{7,8,9} )
 inherit autotools distutils-r1
 
 COMMIT="8e0ba724d85de2c89f48161807e878667b9ed089"  # v4.9.0 tag


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/795087
Package-Manager: Portage-3.0.18, Repoman-3.0.2
Signed-off-by: Andrew Foster <gentoothings@liquid.me.uk>