### PR TITLE
net-misc/nyx: Allowed for python3_9 support

### DIFF
--- a/net-misc/nyx/nyx-2.1.0-r3.ebuild
+++ b/net-misc/nyx/nyx-2.1.0-r3.ebuild
@@ -1,0 +1,29 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+PYTHON_COMPAT=(python3_{7,8,9} pypy3)
+PYTHON_REQ_USE='ncurses,sqlite(-)'
+DISTUTILS_USE_SETUPTOOLS=rdepend
+
+inherit distutils-r1
+
+DESCRIPTION="Utility to monitor real time Tor status information"
+HOMEPAGE="https://nyx.torproject.org"
+if [[ ${PV} == *9999* ]]; then
+	EGIT_REPO_URI="https://git.torproject.org/nyx.git"
+	inherit git-r3
+else
+	SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
+	KEYWORDS="~amd64 ~arm ~mips ~ppc ~ppc64 ~x86"
+fi
+
+LICENSE="GPL-3"
+SLOT="0"
+IUSE="test"
+RESTRICT="!test? ( test )"
+
+RDEPEND="
+	net-libs/stem[${PYTHON_USEDEP}]
+	net-vpn/tor"


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/793827
Package-Manager: Portage-3.0.18, Repoman-3.0.2
Signed-off-by: Andrew Foster <gentoothings@liquid.me.uk>