### PR TITLE
net-mail/queue-repair: Allowed for python 3.9 compatability

### DIFF
--- a/net-mail/queue-repair/queue-repair-0.9.0-r2.ebuild
+++ b/net-mail/queue-repair/queue-repair-0.9.0-r2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{7,8} )
+PYTHON_COMPAT=( python3_{7,8,9} )
 
 inherit python-single-r1
 


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/793212
Package-Manager: Portage-3.0.18, Repoman-3.0.2
Signed-off-by: Andrew Foster <gentoothings@liquid.me.uk>