### PR TITLE
www-servers/pound: fails to compile if static-libs is enabled

### DIFF
--- a/dev-libs/nanomsg/metadata.xml
+++ b/dev-libs/nanomsg/metadata.xml
@@ -1,7 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<!-- maintainer-needed -->
+	<maintainer type="person" proxied="yes">
+		<email>marco@scardovi.com</email>
+		<name>Marco Scardovi</name>
+	</maintainer>
+	<maintainer type="project" proxied="proxy">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
 	<upstream>
 		<remote-id type="github">nanomsg/nanomsg</remote-id>
 	</upstream>

--- a/dev-libs/nanomsg/nanomsg-1.1.5-r1.ebuild
+++ b/dev-libs/nanomsg/nanomsg-1.1.5-r1.ebuild
@@ -17,6 +17,14 @@ IUSE="doc"
 
 DEPEND="doc? ( dev-ruby/asciidoctor )"
 
+multilib_src_prepare() {
+	eapply_user
+	# Old CPUs like HPPA fails test because of timeout
+	sed -i -e 's/inproc_shutdown 5/inproc_shutdown 10/' CMakeLists.txt || die
+	sed -i -e 's/ws_async_shutdown 5/ws_async_shutdown 10/' CMakeLists.txt || die
+	sed -i -e 's/ipc_shutdown 30/ipc_shutdown 40/' CMakeLists.txt || die
+}
+
 multilib_src_configure() {
 	if multilib_is_native_abi; then
 		mycmakeargs+=( -DNN_ENABLE_DOC=$(usex doc ON OFF) )

--- a/dev-libs/nanomsg/nanomsg-1.1.5-r1.ebuild
+++ b/dev-libs/nanomsg/nanomsg-1.1.5-r1.ebuild
@@ -1,0 +1,31 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+CMAKE_ECLASS=cmake
+inherit cmake-multilib
+
+DESCRIPTION="High-performance messaging interface for distributed applications"
+HOMEPAGE="https://nanomsg.org/"
+SRC_URI="https://github.com/nanomsg/nanomsg/archive/${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="MIT"
+SLOT="0/5.0.0"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~x86"
+IUSE="doc"
+
+DEPEND="doc? ( dev-ruby/asciidoctor )"
+
+multilib_src_configure() {
+	if multilib_is_native_abi; then
+		mycmakeargs+=( -DNN_ENABLE_DOC=$(usex doc ON OFF) )
+	else
+		mycmakeargs+=(
+			-DNN_ENABLE_DOC=OFF
+			-DNN_ENABLE_TOOLS=OFF
+			-DNN_ENABLE-NANOCAT=OFF
+		)
+	fi
+	cmake_src_configure
+}

--- a/www-servers/pound/metadata.xml
+++ b/www-servers/pound/metadata.xml
@@ -1,7 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<!-- maintainer-needed -->
+	<maintainer type="person" proxied="yes">
+		<email>marco@scardovi.com</email>
+		<name>Marco Scardovi</name>
+	</maintainer>
+	<maintainer type="project" proxied="proxy">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
 	<longdescription lang="en">
 		The Pound program is a reverse proxy, load balancer
 		and HTTPS front-end for Web server(s). Pound was developed to enable


### PR DESCRIPTION
Added IUSE="-static-libs" because it fails to compile if that USEFLAG is enabled.

Closes: https://bugs.gentoo.org/795228

Package-Manager: Portage-3.0.19, Repoman-3.0.3
Signed-off-by: Marco Scardovi <marco@scardovi.com>