### PR TITLE
sys-kernel/installkernel-systemd-boot: revbump with machine-id dir fix

### DIFF
--- a/sys-kernel/installkernel-systemd-boot/files/00-00machineid-directory.install
+++ b/sys-kernel/installkernel-systemd-boot/files/00-00machineid-directory.install
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+COMMAND="${1}"
+ENTRY_DIR_ABS="${3}"
+
+# this is exported by kernel-install
+if ! [[ $KERNEL_INSTALL_MACHINE_ID ]]; then
+    exit 0
+fi
+
+if [[ $COMMAND != add ]]; then
+    exit 0
+fi
+
+# If the machine-id dir does not exist (e.g. $ESP/<machine-id>)
+# create it. It receives values directly from kernel-install.
+# This is the only function of this plugin.
+MACHINE_ID_DIR="${ENTRY_DIR_ABS%/*}"
+if ! [[ -d "${MACHINE_ID_DIR}" ]]; then
+	if [[ "${KERNEL_INSTALL_VERBOSE}" -gt 0 ]]; then
+    		echo "+mkdir -v -p ${MACHINE_ID_DIR}"
+    		exec mkdir -v -p "${MACHINE_ID_DIR}"
+	else
+    		exec mkdir -p "${MACHINE_ID_DIR}"
+	fi
+fi

--- a/sys-kernel/installkernel-systemd-boot/files/00-00machineid-directory.install
+++ b/sys-kernel/installkernel-systemd-boot/files/00-00machineid-directory.install
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 COMMAND="${1}"
 ENTRY_DIR_ABS="${3}"

--- a/sys-kernel/installkernel-systemd-boot/files/00-00machineid-directory.install
+++ b/sys-kernel/installkernel-systemd-boot/files/00-00machineid-directory.install
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+# this file is installed by sys-kernel/installkernel-systemd-boot
+
 COMMAND="${1}"
 ENTRY_DIR_ABS="${3}"
 

--- a/sys-kernel/installkernel-systemd-boot/files/00-00machineid-directory.install
+++ b/sys-kernel/installkernel-systemd-boot/files/00-00machineid-directory.install
@@ -19,8 +19,8 @@ MACHINE_ID_DIR="${ENTRY_DIR_ABS%/*}"
 if ! [[ -d "${MACHINE_ID_DIR}" ]]; then
 	if [[ "${KERNEL_INSTALL_VERBOSE}" -gt 0 ]]; then
     		echo "+mkdir -v -p ${MACHINE_ID_DIR}"
-    		exec mkdir -v -p "${MACHINE_ID_DIR}"
+    		mkdir -v -p "${MACHINE_ID_DIR}"
 	else
-    		exec mkdir -p "${MACHINE_ID_DIR}"
+    		mkdir -p "${MACHINE_ID_DIR}"
 	fi
 fi

--- a/sys-kernel/installkernel-systemd-boot/installkernel-systemd-boot-0-r1.ebuild
+++ b/sys-kernel/installkernel-systemd-boot/installkernel-systemd-boot-0-r1.ebuild
@@ -1,0 +1,30 @@
+# Copyright 2019-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="Wrap kernel-install from systemd-boot as installkernel"
+HOMEPAGE="https://wiki.gentoo.org/wiki/No_homepage"
+SRC_URI=""
+S=${WORKDIR}
+
+LICENSE="public-domain"
+SLOT="0"
+KEYWORDS="amd64 arm64 ppc64 x86"
+
+RDEPEND="|| ( sys-apps/systemd sys-boot/systemd-boot )
+	!<sys-apps/debianutils-4.9-r1[installkernel(+)]
+	!sys-kernel/installkernel-gentoo"
+
+src_install() {
+	# we could technically use a symlink here but it would require
+	# us to know the correct path, and that implies /usr merge problems
+	into /
+	newsbin - installkernel <<-EOF
+		#!/bin/sh
+		exec kernel-install add "\${1}" "\${2}"
+	EOF
+
+	exeinto /usr/lib/kernel/install.d/
+	doexe "${FILESDIR}/00-00machineid-directory.install"
+}

--- a/sys-kernel/installkernel-systemd-boot/installkernel-systemd-boot-0-r1.ebuild
+++ b/sys-kernel/installkernel-systemd-boot/installkernel-systemd-boot-0-r1.ebuild
@@ -1,11 +1,10 @@
-# Copyright 2019-2020 Gentoo Authors
+# Copyright 2019-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
 DESCRIPTION="Wrap kernel-install from systemd-boot as installkernel"
 HOMEPAGE="https://wiki.gentoo.org/wiki/No_homepage"
-SRC_URI=""
 S=${WORKDIR}
 
 LICENSE="public-domain"

--- a/sys-kernel/installkernel-systemd-boot/installkernel-systemd-boot-0-r1.ebuild
+++ b/sys-kernel/installkernel-systemd-boot/installkernel-systemd-boot-0-r1.ebuild
@@ -20,7 +20,7 @@ src_install() {
 	# us to know the correct path, and that implies /usr merge problems
 	into /
 	newsbin - installkernel <<-EOF
-		#!/bin/sh
+		#!/usr/bin/env sh
 		exec kernel-install add "\${1}" "\${2}"
 	EOF
 


### PR DESCRIPTION
helpful links

https://github.com/systemd/systemd/blob/7ad9bad71b077f6a4629f4e48fb9ad26e1784809/src/kernel-install/kernel-install#L88-L95

https://github.com/systemd/systemd/blob/7ad9bad71b077f6a4629f4e48fb9ad26e1784809/src/kernel-install/kernel-install#L102-L114


and whole https://github.com/systemd/systemd/blob/main/src/kernel-install/00-entry-directory.install