### PR TITLE
dev-libs/nanomsg: fix sed

### DIFF
--- a/dev-libs/nanomsg/nanomsg-1.1.5.ebuild
+++ b/dev-libs/nanomsg/nanomsg-1.1.5.ebuild
@@ -20,9 +20,10 @@ DEPEND="doc? ( dev-ruby/asciidoctor )"
 multilib_src_prepare() {
 	eapply_user
 	# Old CPUs like HPPA fails test because of timeout
-	sed -i -e 's/inproc_shutdown 5/inproc_shutdown 10/' \
-		-e 's/ws_async_shutdown 5/ws_async_shutdown 10/' \
-		-e 's/ipc_shutdown 30/ipc_shutdown 40/' -i CMakeLists.txt || die
+	sed -i \
+		-e '/inproc_shutdown/s/5/80/' \
+		-e '/ws_async_shutdown/s/5/80/' \
+		-e '/ipc_shutdown/s/30/80/' CMakeLists.txt || die
 }
 
 multilib_src_configure() {


### PR DESCRIPTION
As posted by @DerDakon here https://github.com/nanomsg/nanomsg/pull/1064 we need a lot more time on HPPA

Package-Manager: Portage-3.0.19, Repoman-3.0.3
Signed-off-by: Marco Scardovi <marco@scardovi.com>