### PR TITLE
app-misc/anki: patch Python 3.9 incompatibility

### DIFF
--- a/app-misc/anki/anki-2.1.15-r1.ebuild
+++ b/app-misc/anki/anki-2.1.15-r1.ebuild
@@ -44,6 +44,7 @@ BDEPEND="test? (
 PATCHES=(
 	"${FILESDIR}"/${PN}-2.1.0_beta25-web-folder.patch
 	"${FILESDIR}"/${PN}-2.1.15-mpv-args.patch
+	"${FILESDIR}"/${PN}-2.1.15-unescape.patch
 )
 
 src_prepare() {

--- a/app-misc/anki/files/anki-2.1.15-unescape.patch
+++ b/app-misc/anki/files/anki-2.1.15-unescape.patch
@@ -1,0 +1,13 @@
+diff --git a/aqt/reviewer.py b/aqt/reviewer.py
+index f01fcbd9f..5aaf26669 100644
+--- a/aqt/reviewer.py
++++ b/aqt/reviewer.py
+@@ -359,7 +359,7 @@ Please run Tools>Empty Cards""")
+         cor = stripHTML(cor)
+         # ensure we don't chomp multiple whitespace
+         cor = cor.replace(" ", "&nbsp;")
+-        cor = parser.unescape(cor)
++        cor = html.unescape(cor)
+         cor = cor.replace("\xa0", " ")
+         cor = cor.strip()
+         given = self.typedAnswer


### PR DESCRIPTION
This commit modifies the existing anki-2.1.15 ebuild with a patch to
replace a deprecated, undocumented method available in Python 3.8[0] but
removed in Python 3.9[1]. Without the patch, anki throws a runtime error
(see bug for more details) as anki 2.1.15 pre-dates Python 3.9.

[0] https://github.com/python/cpython/blob/4844abdd700120120fc76c29d911bcb547700baf/Lib/html/parser.py#L466
[1] https://bugs.python.org/issue37328

Closes: https://bugs.gentoo.org/795309

Signed-off-by: Austin Ray <austin@austinray.io>