### PR TITLE
x11-misc/shutter: add missing dep

### DIFF
--- a/x11-misc/shutter/shutter-0.96-r1.ebuild
+++ b/x11-misc/shutter/shutter-0.96-r1.ebuild
@@ -15,6 +15,7 @@ KEYWORDS="~amd64 ~x86"
 
 RDEPEND="
 	dev-lang/perl
+	dev-perl/Carp-Always
 	dev-perl/libxml-perl
 	dev-perl/libwww-perl
 	dev-perl/Glib-Object-Introspection


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/795396
Package-Manager: Portage-3.0.18, Repoman-3.0.2
Signed-off-by: Alexey Sokolov <alexey+gentoo@asokolov.org>