### PR TITLE
profiles: mask doc use flag, bug #795459

### DIFF
--- a/media-libs/opencolorio/opencolorio-2.0.0.ebuild
+++ b/media-libs/opencolorio/opencolorio-2.0.0.ebuild
@@ -49,6 +49,7 @@ BDEPEND="
 	doc? (
 		$(python_gen_cond_dep '
 			dev-python/sphinx[${PYTHON_USEDEP}]
+			dev-python/testresources[${PYTHON_USEDEP}]
 		')
 	)
 "

--- a/profiles/arch/base/package.use.mask
+++ b/profiles/arch/base/package.use.mask
@@ -1,6 +1,10 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Bernd Waibel <waebbl-gentoo@posteo.net> (2021-06-11)
+# Has unpackaged depdencies, bug #795459
+>=media-libs/opencolorio-2.0.0 doc
+
 # Mike Gilbert <floppym@gentoo.org> (2021-03-29)
 # TPM only exists on some archs.
 sys-apps/systemd tpm


### PR DESCRIPTION
Mask the doc USE flag on >=media-libs/opencolorio-2.0.0.
Has currently unpackaged dependencies

Bug: https://bugs.gentoo.org/795459
Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>