### PR TITLE
dev-cpp/pystring: Don't use hardcoded g++, bug #795168

### DIFF
--- a/dev-cpp/pystring/files/cmake.patch
+++ b/dev-cpp/pystring/files/cmake.patch
@@ -1,0 +1,84 @@
+From 4f653fc35421129eae8a2c424901ca7170059370 Mon Sep 17 00:00:00 2001
+From: Harry Mallon <harry.mallon@codex.online>
+Date: Thu, 15 Apr 2021 15:50:22 +0100
+Subject: [PATCH] Add a CMake configuration
+
+---
+ CMakeLists.txt                | 56 +++++++++++++++++++++++++++++++++++
+ cmake/pystringConfig.cmake.in |  4 +++
+ 2 files changed, 60 insertions(+)
+ create mode 100644 CMakeLists.txt
+ create mode 100644 cmake/pystringConfig.cmake.in
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+new file mode 100644
+index 0000000..0081a83
+--- /dev/null
++++ b/CMakeLists.txt
+@@ -0,0 +1,56 @@
++cmake_minimum_required(VERSION 3.2)
++
++option(BUILD_SHARED_LIBS "Create shared libraries if ON" OFF)
++
++project(pystring LANGUAGES CXX)
++
++# pystring library ======
++
++add_library(pystring
++    pystring.cpp
++    pystring.h
++)
++set_target_properties(pystring
++    PROPERTIES
++        PUBLIC_HEADER pystring.h
++        SOVERSION 0.0)
++
++set(EXPORT_NAME "${PROJECT_NAME}Targets")
++set(NAMESPACE "${PROJECT_NAME}::")
++
++# test ======
++
++include(CTest)
++
++if(BUILD_TESTING)
++    add_executable(pystring_test
++        test.cpp
++        unittest.h
++    )
++
++    target_link_libraries(pystring_test pystring)
++
++    add_test(NAME pystring_test COMMAND pystring_test)
++endif()
++
++# install and cmake configs ======
++
++include(GNUInstallDirs)
++install(TARGETS pystring
++        EXPORT "${EXPORT_NAME}"
++        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
++        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
++        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
++        PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/pystring)
++
++include(CMakePackageConfigHelpers)
++configure_package_config_file(cmake/pystringConfig.cmake.in
++    ${CMAKE_CURRENT_BINARY_DIR}/pystringConfig.cmake
++    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/pystring)
++
++install(FILES ${CMAKE_CURRENT_BINARY_DIR}/pystringConfig.cmake
++    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/pystring)
++
++install(EXPORT "${EXPORT_NAME}"
++        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/pystring
++        NAMESPACE "${NAMESPACE}")
+diff --git a/cmake/pystringConfig.cmake.in b/cmake/pystringConfig.cmake.in
+new file mode 100644
+index 0000000..82e3995
+--- /dev/null
++++ b/cmake/pystringConfig.cmake.in
+@@ -0,0 +1,4 @@
++@PACKAGE_INIT@
++
++include("${CMAKE_CURRENT_LIST_DIR}/@EXPORT_NAME@.cmake")
++check_required_components("@PROJECT_NAME@")

--- a/dev-cpp/pystring/pystring-1.1.3-r1.ebuild
+++ b/dev-cpp/pystring/pystring-1.1.3-r1.ebuild
@@ -3,6 +3,8 @@
 
 EAPI=7
 
+inherit cmake
+
 DESCRIPTION="C++ functions matching the interface and behavior of python string methods"
 HOMEPAGE="https://github.com/imageworks/pystring"
 
@@ -23,16 +25,8 @@ RESTRICT="mirror"
 LICENSE="BSD"
 SLOT="0"
 
-src_compile() {
-	sed -i -e "s|-O3|${CXXFLAGS}|g" Makefile || die
-	emake LIBDIR="${S}" install
-
-	# Fix header location
-	mkdir ${S}/pystring || die
-	mv ${S}/pystring.h ${S}/pystring || die
-}
-
-src_install() {
-	dolib.so ${S}/libpystring.so{,.0{,.0.0}}
-	doheader -r ${S}/pystring
-}
+PATCHES=(
+	# Patch to convert the project into cmake. Taken from:
+	# https://github.com/imageworks/pystring/pull/29
+	"${FILESDIR}/cmake.patch"
+)


### PR DESCRIPTION
Convert the project into cmake so we get compiler switching for free.
