### PR TITLE
app-crypt/tpm2-tss: Add missing BDEPEND sys-apps/acl

### DIFF
--- a/app-crypt/tpm2-tss/tpm2-tss-3.1.0.ebuild
+++ b/app-crypt/tpm2-tss/tpm2-tss-3.1.0.ebuild
@@ -27,7 +27,8 @@ RDEPEND="acct-group/tss
 	openssl? ( dev-libs/openssl:= )"
 DEPEND="${RDEPEND}
 	test? ( dev-util/cmocka )"
-BDEPEND="virtual/pkgconfig
+BDEPEND="sys-apps/acl
+	virtual/pkgconfig
 	doc? ( app-doc/doxygen )"
 
 PATCHES=(


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/795423
Package-Manager: Portage-3.0.18, Repoman-3.0.2
Signed-off-by: Christopher Byrne <salah.coronya@gmail.com>