### PR TITLE
profiles/package.mask: last-rite games-strategy/freecol

### DIFF
--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -32,6 +32,11 @@
 
 #--- END OF EXAMPLES ---
 
+# Volkmar W. Pogatzki <gentoo@pogatzki.net> (2021-06-13)
+# blocks removal of dev-java/miglayout which blocks jdk-11
+# see bug https://bugs.gentoo.org/795765
+games-strategy/freecol
+
 # Miroslav Šulc <fordfrog@gentoo.org> (2021-06-13)
 # no consumer, removal in 30 days
 # see bug: https://bugs.gentoo.org/785856


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/795765

Package-Manager: Portage-3.0.18, Repoman-3.0.2
Signed-off-by: Volkmar W. Pogatzki <gentoo@pogatzki.net>