### PR TITLE
dev-java/miglayout: remove doc flag (broken)

### DIFF
--- a/dev-java/miglayout/miglayout-4.0-r2.ebuild
+++ b/dev-java/miglayout/miglayout-4.0-r2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-JAVA_PKG_IUSE="doc examples source"
+JAVA_PKG_IUSE="examples source"
 
 inherit java-pkg-2
 
@@ -49,16 +49,11 @@ src_compile() {
 	mkdir classes || die
 	ejavac "${classpath[@]}" -d classes @sources.lst || die
 	jar -cf ${PN}.jar -C classes . || die
-
-	if use doc; then
-		javadoc "${classpath[@]}" -author -version -d api @sources.lst || die
-	fi
 }
 
 src_install() {
 	java-pkg_dojar ${PN}.jar
 
-	use doc && java-pkg_dojavadoc api
 	use examples && java-pkg_doexamples examples
 	use source && java-pkg_dosrc net
 }


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/786732

No fix available, 
vbump might be possible later ( https://github.com/mikaelgrev/miglayout )