### PR TITLE
dev-db/hsqldb: min java 1.8

### DIFF
--- a/acct-group/hsqldb/hsqldb-0.ebuild
+++ b/acct-group/hsqldb/hsqldb-0.ebuild
@@ -1,0 +1,9 @@
+# Copyright 2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit acct-group
+
+DESCRIPTION="Group for hsqldb"
+ACCT_GROUP_ID=217

--- a/acct-group/hsqldb/metadata.xml
+++ b/acct-group/hsqldb/metadata.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="project">
+		<email>java@gentoo.org</email>
+	</maintainer>
+</pkgmetadata>

--- a/acct-user/hsqldb/hsqldb-0.ebuild
+++ b/acct-user/hsqldb/hsqldb-0.ebuild
@@ -1,0 +1,12 @@
+# Copyright 2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit acct-user
+
+DESCRIPTION="User for hsqldb"
+ACCT_USER_ID=217
+ACCT_USER_GROUPS=( hsqldb )
+
+acct-user_add_deps

--- a/acct-user/hsqldb/metadata.xml
+++ b/acct-user/hsqldb/metadata.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="project">
+		<email>java@gentoo.org</email>
+	</maintainer>
+</pkgmetadata>

--- a/dev-db/hsqldb/hsqldb-1.8.1.3-r3.ebuild
+++ b/dev-db/hsqldb/hsqldb-1.8.1.3-r3.ebuild
@@ -1,0 +1,174 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+JAVA_PKG_IUSE="doc source test"
+
+inherit java-pkg-2 java-ant-2
+
+MY_PV=$(ver_rs 1- '_')
+MY_P="${PN}_${MY_PV}"
+
+DESCRIPTION="The leading SQL relational database engine written in Java"
+HOMEPAGE="http://hsqldb.org"
+SRC_URI="mirror://sourceforge/${PN}/${MY_P}.zip"
+
+LICENSE="BSD GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~ppc64 ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
+
+CDEPEND="
+	acct-group/hsqldb
+	acct-user/hsqldb
+	java-virtuals/servlet-api:2.5"
+RDEPEND="${CDEPEND}
+	virtual/jre:1.8"
+DEPEND="${CDEPEND}
+	virtual/jdk:1.8
+	test? ( dev-java/junit:0 )"
+BDEPEND="app-arch/unzip"
+
+PATCHES=(
+	"${FILESDIR}/resolve-config-softlinks.patch"
+	"${FILESDIR}/${P}-java7.patch"
+)
+
+S="${WORKDIR}/${PN}"
+
+HSQLDB_JAR=/usr/share/hsqldb/lib/hsqldb.jar
+HSQLDB_HOME=/var/lib/hsqldb
+
+pkg_setup() {
+	java-pkg-2_pkg_setup
+}
+
+src_prepare() {
+	default
+	rm -v lib/*.jar || die
+
+	sed -i -r \
+		-e "s#/etc/sysconfig#${EPREFIX}/etc/conf.d#g" \
+		bin/hsqldb || die
+
+	java-pkg_filter-compiler jikes
+
+	eant -q -f "${EANT_BUILD_XML}" cleanall > /dev/null
+
+	mkdir conf
+	sed -e "s/^HSQLDB_JAR_PATH=.*$/HSQLDB_JAR_PATH=${EPREFIX//\//\\/}${HSQLDB_JAR//\//\\/}/g" \
+		-e "s/^SERVER_HOME=.*$/SERVER_HOME=${EPREFIX//\//\\/}\/var\/lib\/hsqldb/g" \
+		-e "s/^HSQLDB_OWNER=.*$/HSQLDB_OWNER=hsqldb/g" \
+		-e 's/^#AUTH_FILE=.*$/AUTH_FILE=${SERVER_HOME}\/sqltool.rc/g' \
+		src/org/hsqldb/sample/sample-hsqldb.cfg > conf/hsqldb || die
+	cp "${FILESDIR}/server.properties" conf/ || die
+	cp "${FILESDIR}/sqltool.rc" conf/ || die
+
+	# Missing source file - needed for tests
+	# https://sourceforge.net/p/hsqldb/svn/HEAD/tree/base/trunk/src/org/hsqldb/lib/StringComparator.java
+	# https://sourceforge.net/p/hsqldb/bugs/815/
+	cp "${FILESDIR}/StringComparator.java" src/org/hsqldb/lib || die
+	cp "${FILESDIR}/TestBug1191815.java" src/org/hsqldb/test/ || die
+}
+
+JAVA_ANT_REWRITE_CLASSPATH="yes"
+
+# EANT_BUILD_XML used also in src_prepare
+EANT_BUILD_XML="build/build.xml"
+EANT_BUILD_TARGET="jar jarclient jarsqltool jarutil"
+EANT_DOC_TARGET="javadocdev"
+EANT_GENTOO_CLASSPATH="servlet-api-2.5"
+
+src_test() {
+	java-pkg_jar-from --into lib junit
+	eant -f ${EANT_BUILD_XML} jartest
+	cd testrun/hsqldb || die
+	./runTest.sh TestSelf || die "TestSelf hsqldb tests failed"
+	# TODO. These fail. Investigate why.
+	#cd "${S}/testrun/sqltool" || die
+	#CLASSPATH="${S}/lib/hsqldb.jar" ./runtests.bash || die "sqltool test failed"
+}
+
+src_install() {
+	java-pkg_dojar lib/hsql*.jar
+
+	if use doc; then
+		dodoc doc/*.txt
+		docinto html
+		dodoc -r doc/{src,zaurus}
+	fi
+	use source && java-pkg_dosrc src/*
+
+	echo "CONFIG_PROTECT=\"${HSQLDB_HOME}\"" > "${T}"/35hsqldb || die
+	doenvd "${T}"/35hsqldb
+
+	# Put init, configuration and authorization files in /etc
+	doinitd "${FILESDIR}/hsqldb"
+	doconfd conf/hsqldb
+#	dodir /etc/hsqldb
+	insinto /etc/hsqldb
+	# Change the ownership of server.properties and sqltool.rc
+	# files to hsqldb:hsqldb. (resolves Bug #111963)
+	use prefix || insopts -m0600 -o hsqldb -g hsqldb
+	doins conf/server.properties
+	use prefix || insopts -m0600 -o hsqldb -g hsqldb
+	doins conf/sqltool.rc
+
+	# Install init script
+	dodir "${HSQLDB_HOME}/bin"
+	keepdir "${HSQLDB_HOME}"
+	exeinto "${HSQLDB_HOME}/bin"
+	doexe bin/hsqldb
+
+	# Make sure that files have correct permissions
+	use prefix || chown -R hsqldb:hsqldb "${ED}${HSQLDB_HOME}"
+	chmod o-rwx "${ED}${HSQLDB_HOME}"
+
+	# Create symlinks to authorization files in the server home dir
+	# (required by the hqldb init script)
+	insinto "${HSQLDB_HOME}"
+	dosym ../../../etc/hsqldb/server.properties "${HSQLDB_HOME}/server.properties"
+	dosym ../../../etc/hsqldb/sqltool.rc "${HSQLDB_HOME}/sqltool.rc"
+}
+
+pkg_postinst() {
+	ewarn "If you intend to run Hsqldb in Server mode and you want to create"
+	ewarn "additional databases, remember to put correct information in both"
+	ewarn "'server.properties' and 'sqltool.rc' files."
+	ewarn "(read the 'Init script Setup Procedure' section of the 'Chapter 3."
+	ewarn "UNIX Quick Start' in the Hsqldb docs for more information)"
+	echo
+	elog "Example:"
+	echo
+	elog "${EPREFIX}/etc/hsqldb/server.properties"
+	elog "============================="
+	elog "server.database.1=file:xdb/xdb"
+	elog "server.dbname.1=xdb"
+	elog "server.urlid.1=xdb"
+	elog
+	elog "${EPREFIX}/etc/hsqldb/sqltool.rc"
+	elog "======================"
+	elog "urlid xdb"
+	elog "url jdbc:hsqldb:hsql://localhost/xdb"
+	elog "username sa"
+	elog "password "
+	echo
+	elog "Also note that each hsqldb server can serve only up to 10"
+	elog "different databases simultaneously (with consecutive {0-9}"
+	elog "suffixes in the 'server.properties' file)."
+	echo
+	ewarn "For data manipulation use:"
+	ewarn
+	ewarn "# java -classpath ${EPREFIX}${HSQLDB_JAR} org.hsqldb.util.DatabaseManager"
+	ewarn "# java -classpath ${EPREFIX}${HSQLDB_JAR} org.hsqldb.util.DatabaseManagerSwing"
+	ewarn "# java -classpath ${EPREFIX}${HSQLDB_JAR} org.hsqldb.util.SqlTool \\"
+	ewarn "  --rcFile ${EPREFIX}/var/lib/hsqldb/sqltool.rc <dbname>"
+	echo
+	elog "The Hsqldb can be run in multiple modes - read 'Chapter 1. Running'"
+	elog "and Using Hsqldb' in the Hsqldb docs at:"
+	elog "  http://hsqldb.org/web/hsqlDocsFrame.html"
+	elog "If you intend to run it in the Server mode, it is suggested to add the"
+	elog "init script to your start-up scripts, this should be done like this:"
+	elog "  \`rc-update add hsqldb default\`"
+	echo
+}


### PR DESCRIPTION
fails with 1.8:*
Bug: https://bugs.gentoo.org/784380

No version bump here.  I am working on a bump to 2.6.0 which doesn't support java8. For java 8 we can keep the present version.
Also tried building [2.5.2](https://sourceforge.net/p/hsqldb/news/2021/04/maven-releases-of-version-260/) for `java 8` but with no success.

Help needed for GLEP81