### PR TITLE
dev-cpp/yaml-cpp: enable tests, take package

### DIFF
--- a/dev-cpp/yaml-cpp/files/yaml-cpp-0.6.3-gtest.patch
+++ b/dev-cpp/yaml-cpp/files/yaml-cpp-0.6.3-gtest.patch
@@ -1,0 +1,44 @@
+diff --git a/test/CMakeLists.txt b/test/CMakeLists.txt
+index 0a669d5..bc8bbdd 100644
+--- a/test/CMakeLists.txt
++++ b/test/CMakeLists.txt
+@@ -7,22 +7,7 @@ if(MSVC)
+     set(CMAKE_STATIC_LIBRARY_PREFIX "")
+ endif()
+ 
+-ExternalProject_Add(
+-	googletest_project
+-	SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/gtest-1.8.0"
+-	INSTALL_DIR "${CMAKE_CURRENT_BINARY_DIR}/prefix"
+-	CMAKE_ARGS
+-		-DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
+-		-DBUILD_GMOCK=ON
+-		-Dgtest_force_shared_crt=ON
+-)
+-
+-add_library(gmock UNKNOWN IMPORTED)
+-set_target_properties(gmock PROPERTIES
+-    IMPORTED_LOCATION
+-    ${PROJECT_BINARY_DIR}/test/prefix/lib/${CMAKE_STATIC_LIBRARY_PREFIX}gmock${CMAKE_STATIC_LIBRARY_SUFFIX}
+-)
+-
++find_package(GTest REQUIRED CONFIG)
+ find_package(Threads)
+ 
+ include_directories(SYSTEM "${PROJECT_BINARY_DIR}/test/prefix/include")
+@@ -56,14 +41,12 @@ set_target_properties(run-tests PROPERTIES
+     CXX_STANDARD_REQUIRED ON
+ )
+ 
+-add_dependencies(run-tests googletest_project)
+-
+ set_target_properties(run-tests PROPERTIES
+     COMPILE_FLAGS "${yaml_c_flags} ${yaml_cxx_flags} ${yaml_test_flags}"
+ )
+ target_link_libraries(run-tests
+     yaml-cpp
+-    gmock
++    GTest::gmock
+     ${CMAKE_THREAD_LIBS_INIT})
+ 
+ add_test(yaml-test ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/run-tests)

--- a/dev-cpp/yaml-cpp/metadata.xml
+++ b/dev-cpp/yaml-cpp/metadata.xml
@@ -1,7 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<!-- maintainer-needed -->
+	<maintainer type="person" proxied="yes">
+		<email>alexey+gentoo@asokolov.org</email>
+		<name>Alexey Sokolov</name>
+	</maintainer>
+	<maintainer type="project" proxied="proxy">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
 	<upstream>
 		<remote-id type="github">jbeder/yaml-cpp</remote-id>
 	</upstream>

--- a/dev-cpp/yaml-cpp/yaml-cpp-0.6.3-r4.ebuild
+++ b/dev-cpp/yaml-cpp/yaml-cpp-0.6.3-r4.ebuild
@@ -1,0 +1,46 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+CMAKE_ECLASS="cmake"
+inherit cmake-multilib
+
+DESCRIPTION="YAML parser and emitter in C++"
+HOMEPAGE="https://github.com/jbeder/yaml-cpp"
+SRC_URI="https://github.com/jbeder/yaml-cpp/archive/${P}.tar.gz"
+S="${WORKDIR}/yaml-cpp-${P}"
+
+LICENSE="MIT"
+SLOT="0/0.6"
+KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~x86-linux"
+IUSE="test"
+RESTRICT="!test? ( test )"
+
+DEPEND="test? ( dev-cpp/gtest[${MULTILIB_USEDEP}] )"
+
+PATCHES=(
+	"${FILESDIR}/${P}-abi-breakage.patch"
+	"${FILESDIR}/${P}-CVE-2017-11692.patch"
+	"${FILESDIR}/${P}-fix-overflows.patch"
+	"${FILESDIR}/${P}-gtest.patch"
+)
+
+src_prepare() {
+	sed -i \
+		-e 's:INCLUDE_INSTALL_ROOT_DIR:INCLUDE_INSTALL_DIR:g' \
+		yaml-cpp.pc.cmake || die
+	rm -r test/gtest-* || die
+
+	cmake_src_prepare
+}
+
+src_configure() {
+	local mycmakeargs=(
+		-DYAML_BUILD_SHARED_LIBS=ON
+		-DYAML_CPP_BUILD_TOOLS=OFF # Don't have install rule
+		-DYAML_CPP_BUILD_TESTS=$(usex test)
+	)
+
+	cmake-multilib_src_configure
+}


### PR DESCRIPTION
Package-Manager: Portage-3.0.18, Repoman-3.0.2
Signed-off-by: Alexey Sokolov <alexey+gentoo@asokolov.org>

```diff
--- yaml-cpp-0.6.3-r3.ebuild    2021-06-14 00:27:19.386823736 +0100
+++ yaml-cpp-0.6.3-r4.ebuild    2021-06-14 00:34:42.720628784 +0100
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,31 +8,31 @@ inherit cmake-multilib
 
 DESCRIPTION="YAML parser and emitter in C++"
 HOMEPAGE="https://github.com/jbeder/yaml-cpp"
-SRC_URI="https://github.com/jbeder/${PN}/archive/${P}.tar.gz"
+SRC_URI="https://github.com/jbeder/yaml-cpp/archive/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/0.6"
-KEYWORDS="amd64 ~arm arm64 ~hppa ppc ppc64 sparc x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~x86-linux"
 IUSE="test"
 
-# test breaks build
-#RESTRICT="!test? ( test )"
-RESTRICT+="test"
+RESTRICT="!test? ( test )"
 
-DEPEND="test? ( dev-cpp/gtest )"
+DEPEND="test? ( dev-cpp/gtest[${MULTILIB_USEDEP}] )"
 
-S="${WORKDIR}/${PN}-${P}"
+S="${WORKDIR}/yaml-cpp-${P}"
 
 PATCHES=(
        "${FILESDIR}/${P}-abi-breakage.patch"
        "${FILESDIR}/${P}-CVE-2017-11692.patch"
        "${FILESDIR}/${P}-fix-overflows.patch"
+       "${FILESDIR}/${P}-gtest.patch"
 )
 
 src_prepare() {
        sed -i \
                -e 's:INCLUDE_INSTALL_ROOT_DIR:INCLUDE_INSTALL_DIR:g' \
                yaml-cpp.pc.cmake || die
+       rm -r test/gtest-* || die
 
        cmake_src_prepare
 }
```