### PR TITLE
net-analyzer/netdata: fix fcaps

### DIFF
--- a/net-analyzer/netdata/netdata-1.31.0.ebuild
+++ b/net-analyzer/netdata/netdata-1.31.0.ebuild
@@ -138,6 +138,10 @@ src_install() {
 pkg_postinst() {
 	fcaps_pkg_postinst
 
+	if use nfacct ; then
+		fcaps 'cap_net_admin' 'usr/libexec/netdata/plugins.d/nfacct.plugin'
+	fi
+
 	if use xen ; then
 		fcaps 'cap_dac_override' 'usr/libexec/netdata/plugins.d/xenstat.plugin'
 	fi


### PR DESCRIPTION
net-analyzer/netdata: nfacct.plugin needs cap_net_admin (or suid root)

Signed-off-by: Christian W. Zuckschwerdt <christian@zuckschwerdt.org>