### PR TITLE
net-firewall/nfacct: add init script

### DIFF
--- a/net-firewall/nfacct/files/nfacct.confd
+++ b/net-firewall/nfacct/files/nfacct.confd
@@ -1,0 +1,7 @@
+# /etc/conf.d/nfacct
+
+# Location for nfacct initscript to save and restore the counters
+NFACCT_SAVE="/var/lib/nfacct/counters-save"
+
+# Save counters on stopping nfacct
+SAVE_ON_STOP="yes"

--- a/net-firewall/nfacct/files/nfacct.initd
+++ b/net-firewall/nfacct/files/nfacct.initd
@@ -1,0 +1,42 @@
+#!/sbin/openrc-run
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+extra_commands="save"
+
+NFACCT_SAVE=${NFACCT_SAVE:-/var/lib/nfacct/counters-save}
+
+depend() {
+	before iptables ip6tables
+}
+
+checkconfig() {
+	if [ ! -f "${NFACCT_SAVE}" ] ; then
+		eerror "Not starting ${SVCNAME}. First create some counters then run:"
+		eerror "/etc/init.d/${SVCNAME} save"
+		return 1
+	fi
+	return 0
+}
+
+start() {
+	checkconfig || return 1
+	ebegin "Loading nfacct counters"
+	nfacct restore < "${NFACCT_SAVE}"
+	eend $?
+}
+
+stop() {
+	if [ "${SAVE_ON_STOP}" = "yes" ] ; then
+		save || return 1
+	fi
+	ebegin "Removing nfacct counters"
+	nfacct flush
+	eend $?
+}
+
+save() {
+	ebegin "Saving nfacct counters"
+	nfacct list > "${NFACCT_SAVE}"
+	eend $?
+}

--- a/net-firewall/nfacct/nfacct-1.0.2-r1.ebuild
+++ b/net-firewall/nfacct/nfacct-1.0.2-r1.ebuild
@@ -22,3 +22,11 @@ DEPEND="
 "
 
 CONFIG_CHECK="~NETFILTER_NETLINK_ACCT"
+
+src_install() {
+	default_src_install
+
+	keepdir /var/lib/nfacct
+	newinitd "${FILESDIR}"/${PN}.initd nfacct
+	newconfd "${FILESDIR}"/${PN}.confd nfacct
+}


### PR DESCRIPTION
Save and restore nfacct accounting objects.

Signed-off-by: Christian W. Zuckschwerdt <christian@zuckschwerdt.org>