### PR TITLE
fcaps.eclass: EAPI 8

### DIFF
--- a/eclass/fcaps.eclass
+++ b/eclass/fcaps.eclass
@@ -1,9 +1,10 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: fcaps.eclass
 # @MAINTAINER:
 # base-system@gentoo.org
+# @SUPPORTED_EAPIS: 6 7 8
 # @BLURB: function to set POSIX file-based capabilities
 # @DESCRIPTION:
 # This eclass provides a function to set file-based capabilities on binaries.
@@ -28,20 +29,21 @@
 # )
 # @CODE
 
+case ${EAPI} in
+	6|7|8) ;;
+	*) die "EAPI ${EAPI:-0} is unsupported" ;;
+esac
+
 if [[ -z ${_FCAPS_ECLASS} ]]; then
 _FCAPS_ECLASS=1
 
 IUSE="+filecaps"
 
-# Since it is needed in pkg_postinst() it must be in RDEPEND
-case "${EAPI:-0}" in
-	[0-6])
-		RDEPEND="filecaps? ( sys-libs/libcap )"
-	;;
-	*)
-		BDEPEND="filecaps? ( sys-libs/libcap )"
-		RDEPEND="${BDEPEND}"
-	;;
+# Since it is needed in pkg_postinst() it must be in IDEPEND
+case ${EAPI} in
+	7) BDEPEND="filecaps? ( sys-libs/libcap )" ;& # fallthrough
+	6) RDEPEND="filecaps? ( sys-libs/libcap )" ;;
+	*) IDEPEND="filecaps? ( sys-libs/libcap )" ;;
 esac
 
 # @ECLASS-VARIABLE: FILECAPS

--- a/sys-apps/intel-performance-counter-monitor/intel-performance-counter-monitor-2.10.ebuild
+++ b/sys-apps/intel-performance-counter-monitor/intel-performance-counter-monitor-2.10.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=8
 
 inherit fcaps
 
@@ -19,28 +19,22 @@ KEYWORDS="~amd64"
 
 RDEPEND=">=sys-devel/gcc-4:*"
 
-DEPEND="${RDEPEND}
-	sys-apps/sed"
+DEPEND="${RDEPEND}"
 
 CONFIG_CHECK="~X86_MSR ~PERF_EVENTS"
 ERROR_X86_MSR="Intel Performance Counter Monitor, requires X86_MSR to be set in kernel config."
 
 S="${WORKDIR}/${MY_PN}-${MY_PV}"
 
-src_prepare() {
-	sed -i 's/^#CXXFLAGS += -DPCM_USE_PERF/CXXFLAGS += -DPCM_USE_PERF/'  Makefile || die
-}
-
 src_install() {
-	exeinto /usr/bin
-		newexe pcm.x pcm
-		newexe pcm-memory.x pcm-memory
-		newexe pcm-msr.x pcm-msr
-		newexe pcm-numa.x pcm-numa
-		newexe pcm-pcie.x pcm-pcie
-		newexe pcm-power.x pcm-power
-		newexe pcm-sensor.x pcm-sensor
-		newexe pcm-tsx.x pcm-tsx
+	newbin pcm.x pcm
+	newbin pcm-memory.x pcm-memory
+	newbin pcm-msr.x pcm-msr
+	newbin pcm-numa.x pcm-numa
+	newbin pcm-pcie.x pcm-pcie
+	newbin pcm-power.x pcm-power
+	newbin pcm-sensor.x pcm-sensor
+	newbin pcm-tsx.x pcm-tsx
 }
 
 pkg_postinst() {


### PR DESCRIPTION
@floppym This updates fcaps.eclass to EAPI 8 so it can finally correctly define its dependency with `IDEPEND`.  In particular, this will fix a dependency loop with PAM.

The list of supported EAPIs was being added to eclasses a while ago, but this one was skipped, so I added it here.  I can drop it if it's preferable for this eclass to be EAPI-agnostic.  Since there were only two ebuilds using EAPI 5, this updates those and declares eclass compatibility with EAPIs 6-8 (and takes advantage of bash 4 syntax that comes with that).

This should probably wait to be merged after the stalled stablereq [bug #756946](https://bugs.gentoo.org/756946) so all arches have a stable EAPI 7 arping version.  There is also [bug #632225](https://bugs.gentoo.org/632225) to replace intel-performance-counter-monitor, but it can be trivially updated until then.