### PR TITLE
app-dicts/dictd-wn: install files into /usr/share

### DIFF
--- a/app-dicts/dictd-wn/dictd-wn-3.0_p33-r1.ebuild
+++ b/app-dicts/dictd-wn/dictd-wn-3.0_p33-r1.ebuild
@@ -1,0 +1,25 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit unpacker
+
+DESCRIPTION="WordNet for dict"
+HOMEPAGE="https://wordnet.princeton.edu"
+SRC_URI="mirror://debian/pool/main/w/wordnet/dict-wn_${PV/_p/-}_all.deb"
+S="${WORKDIR}"
+LICENSE="Princeton"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~ppc64 ~sparc ~x86"
+
+RDEPEND=">=app-text/dictd-1.5.5"
+
+src_unpack() {
+	unpack_deb ${A}
+}
+
+src_install() {
+	insinto /usr/share/dict
+	doins usr/share/dictd/{wn.dict.dz,wn.index}
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/790383
Package-Manager: Portage-3.0.19, Repoman-3.0.3
Signed-off-by: Alessandro Barbieri <lssndrbarbieri@gmail.com>