### PR TITLE
net-vpn/i2pd: fix logrotate #795123

### DIFF
--- a/net-vpn/i2pd/files/i2pd-2.38.0-r1.logrotate
+++ b/net-vpn/i2pd/files/i2pd-2.38.0-r1.logrotate
@@ -5,7 +5,9 @@
         notifempty
         create 640 i2pd i2pd
         postrotate
-                /bin/kill -HUP $(cat /run/i2pd/i2pd.pid)
+                if [ -f /run/i2pd/i2pd.pid ]; then
+                    /bin/kill -HUP $(/bin/cat /run/i2pd/i2pd.pid)
+                fi
         endscript
 }
 

--- a/net-vpn/i2pd/i2pd-2.38.0-r1.ebuild
+++ b/net-vpn/i2pd/i2pd-2.38.0-r1.ebuild
@@ -79,7 +79,7 @@ src_install() {
 
 	# logrotate
 	insinto /etc/logrotate.d
-	newins "${FILESDIR}/i2pd-2.6.0-r3.logrotate" i2pd
+	newins "${FILESDIR}/i2pd-2.38.0-r1.logrotate" i2pd
 }
 
 pkg_postinst() {


### PR DESCRIPTION
Logrotate may misbehave if the pid file does not exist, like if the daemon is not running.
https://bugs.gentoo.org/795123