### PR TITLE
media-gfx/freecad: add py39 support to live ebuild

### DIFF
--- a/media-gfx/freecad/freecad-9999.ebuild
+++ b/media-gfx/freecad/freecad-9999.ebuild
@@ -3,8 +3,7 @@
 
 EAPI=7
 
-# vtk needs updating to use 3.9
-PYTHON_COMPAT=( python3_{7,8} )
+PYTHON_COMPAT=( python3_{7,8,9} )
 
 inherit check-reqs cmake desktop eapi8-dosym optfeature python-single-r1 xdg
 
@@ -69,7 +68,7 @@ RDEPEND="
 	sci-libs/flann[openmp]
 	sci-libs/hdf5:=[fortran,zlib]
 	>=sci-libs/med-4.0.0-r1[python,${PYTHON_SINGLE_USEDEP}]
-	sci-libs/opencascade:=[vtk(+)]
+	<sci-libs/opencascade-7.5.2:=[vtk(+)]
 	sci-libs/orocos_kdl:=
 	sys-libs/zlib
 	virtual/glu


### PR DESCRIPTION
Also restrict dependency on sci-libs/opencascade.

Package-Manager: Portage-3.0.20, Repoman-3.0.3
Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>

@fordfrog: note it doesn't correctly show Pivy in configuration output, but it builds. If you encounter pivy issues, please inform me.