### PR TITLE
sci-geoscience/gnome-maps: mask for various arm arches

### DIFF
--- a/profiles/arch/arm/armv4/package.mask
+++ b/profiles/arch/arm/armv4/package.mask
@@ -5,6 +5,10 @@
 # This package states supports for arm >= v6
 dev-lang/nim
 
+# Marco Scardovi <marco@scardovi.com> (2021-06-17)
+# This package requires dev-libs/gjs to be unmasked
+sci-geosciences/gnome-maps
+
 # There is no prebuilt rustc for armv4 by upstream
 dev-lang/rust-bin
 dev-lang/rust

--- a/profiles/arch/arm/armv4t/package.mask
+++ b/profiles/arch/arm/armv4t/package.mask
@@ -5,6 +5,10 @@
 # This package states supports for arm >= v6
 dev-lang/nim
 
+# Marco Scardovi <marco@scardovi.com> (2021-06-17)
+# This package requires dev-libs/gjs to be unmasked
+sci-geosciences/gnome-maps
+
 # There is no prebuilt rustc for armv4 by upstream
 dev-lang/rust-bin
 dev-lang/rust

--- a/profiles/arch/arm/armv5te/package.mask
+++ b/profiles/arch/arm/armv5te/package.mask
@@ -5,6 +5,10 @@
 # This package states supports for arm >= v6
 dev-lang/nim
 
+# Marco Scardovi <marco@scardovi.com> (2021-06-17)
+# This package requires dev-libs/gjs to be unmasked
+sci-geosciences/gnome-maps
+
 # There is no prebuilt rustc for armv5 by upstream
 dev-lang/rust-bin
 dev-lang/rust


### PR DESCRIPTION
These arches requires dev-libs/gjs to be unmasked

Signed-off-by: Marco Scardovi <marco@scardovi.com>