### PR TITLE
app-text/nfoview: enable pytest

### DIFF
--- a/app-text/nfoview/nfoview-1.28.ebuild
+++ b/app-text/nfoview/nfoview-1.28.ebuild
@@ -26,7 +26,8 @@ BDEPEND="${PYTHON_DEPS}
 	sys-devel/gettext"
 DEPEND="dev-python/pygobject:3[${PYTHON_USEDEP}]"
 RDEPEND="${DEPEND}
-	media-fonts/cascadia-code"
+	media-fonts/cascadia-code
+	x11-libs/gtk+:3[introspection]"
 
 distutils_enable_tests pytest
 

--- a/app-text/nfoview/nfoview-1.28.ebuild
+++ b/app-text/nfoview/nfoview-1.28.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -6,7 +6,7 @@ EAPI=7
 DISTUTILS_USE_SETUPTOOLS=no
 PYTHON_COMPAT=( python3_{7,8,9} )
 
-inherit distutils-r1 xdg
+inherit distutils-r1 virtualx xdg
 
 if [[ ${PV} == *9999 ]] ; then
 	EGIT_REPO_URI="https://github.com/otsaloma/nfoview.git"
@@ -27,3 +27,13 @@ BDEPEND="${PYTHON_DEPS}
 DEPEND="dev-python/pygobject:3[${PYTHON_USEDEP}]"
 RDEPEND="${DEPEND}
 	media-fonts/cascadia-code"
+
+distutils_enable_tests pytest
+
+python_test() {
+	local deselect=(
+		--deselect 'nfoview/test/test_util.py::TestModule::test_show_uri__unix'
+		--deselect 'nfoview/test/test_util.py::TestModule::test_show_uri__windows'
+	)
+	virtx epytest "${deselect[@]}"
+}


### PR DESCRIPTION
use distutils_enable_tests pytest

Closes: https://bugs.gentoo.org/796287
Package-Manager: Portage-3.0.18, Repoman-3.0.2
Signed-off-by: Till Schäfer <till2.schaefer@uni-dortmund.de>