### PR TITLE
mail-filter/spamdyke: fix bug 719974

### DIFF
--- a/mail-filter/spamdyke/files/patch-for-openssl-1.1.patch
+++ b/mail-filter/spamdyke/files/patch-for-openssl-1.1.patch
@@ -1,0 +1,29 @@
+This patch file updates the autoconfigure script so that it works when using OpenSSL >= 1.1.0, as SSL_library_init
+is deprecated, and has been replaced by OPENSSL_init_ssl.
+In addition to this, no call to the init function is needed, as this is now done automatically.
+
+
+diff -u ./tls.c.orig ./tls.c
+--- ./tls.c.orig        2020-04-29 03:50:32.700402228 +0100
++++ ./tls.c     2020-04-29 03:51:18.758402228 +0100
+@@ -186,7 +186,7 @@
+
+   if (!initialized)
+     {
+-    SSL_library_init();
++//    SSL_library_init();
+
+     if (!RAND_status())
+       {
+diff -u ./configure.ac.orig ./configure.ac
+--- ./configure.ac.orig 2020-04-29 05:08:56.046402228 +0100
++++ ./configure.ac      2020-04-29 05:09:23.864402228 +0100
+@@ -149,7 +149,7 @@
+                        [
+                          AC_MSG_RESULT([yes])
+                          AC_SEARCH_LIBS([RSA_sign], [ssl crypto], [], [ AC_MSG_FAILURE([--enable-tls was given but OpenSSL was not found]) ])
+-                         AC_SEARCH_LIBS([SSL_library_init],
++                         AC_SEARCH_LIBS([OPENSSL_init_ssl],
+                                         [ssl crypto],
+                                         [ LIBS="$LIBS -lssl"
+                                           AC_DEFINE([HAVE_LIBSSL], [1])

--- a/mail-filter/spamdyke/metadata.xml
+++ b/mail-filter/spamdyke/metadata.xml
@@ -1,18 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
-<pkgmetadata>
-<!-- maintainer-needed -->
-<longdescription lang="en">
-spamdyke is a filter for monitoring and intercepting SMTP connections between a
-remote host and a qmail server. Spam is blocked while the remote server
-(spammer) is still connected; no additional processing or storage is needed.
+	<pkgmetadata>
+		<!-- maintainer-needed -->
+	<longdescription lang="en">
+		spamdyke is a filter for monitoring and intercepting SMTP connections between a
+		remote host and a qmail server. Spam is blocked while the remote server
+		(spammer) is still connected; no additional processing or storage is needed.
 
-In addition to all of its anti-spam filters, spamdyke also includes a number of
-features to enhance qmail.
+		In addition to all of its anti-spam filters, spamdyke also includes a number of
+		features to enhance qmail.
 
-Best of all, using spamdyke does not require patching or recompiling qmail!
-</longdescription>
-<use>
-	<flag name="ssl">Enables TLS protocol for spamdyke</flag>
-</use>
+		Best of all, using spamdyke does not require patching or recompiling qmail!
+	</longdescription>
 </pkgmetadata>


### PR DESCRIPTION
This PR release a fix for mail-filter/spamdyke that can't be
built with openssl >=1.1.0

Closes: https://bugs.gentoo.org/719974
Package-Manager: Portage-3.0.20, Repoman-3.0.3
Signed-off-by: Marco Scardovi <marco@scardovi.com>