### PR TITLE
net-analyzer/pnp4nagios: add php 7.4 compatibility

### DIFF
--- a/net-analyzer/pnp4nagios/files/pnp4nagios-0.6.26-magic-quotes.patch
+++ b/net-analyzer/pnp4nagios/files/pnp4nagios-0.6.26-magic-quotes.patch
@@ -1,0 +1,23 @@
+# https://github.com/lingej/pnp4nagios/commit/08ce9e26171b888c8e3b036b6693fd8f751970a8
+diff --git a/lib/kohana/system/libraries/Input.php b/lib/kohana/system/libraries/Input.php
+index 0e23c80..b0b24f8 100644
+--- a/lib/kohana/system/libraries/Input.php
++++ b/lib/kohana/system/libraries/Input.php
+@@ -54,14 +54,14 @@ public function __construct()
+ 		if (Input::$instance === NULL)
+ 		{
+ 			// magic_quotes_runtime is enabled
+-			if (get_magic_quotes_runtime())
++			if (function_exists('get_magic_quotes_runtime'))
+ 			{
+-				set_magic_quotes_runtime(0);
++				ini_set('magic_quotes_runtime', 0);
+ 				Kohana::log('debug', 'Disable magic_quotes_runtime! It is evil and deprecated: http://php.net/magic_quotes');
+ 			}
+ 
+ 			// magic_quotes_gpc is enabled
+-			if (get_magic_quotes_gpc())
++			if (function_exists('get_magic_quotes_gpc'))
+ 			{
+ 				$this->magic_quotes_gpc = TRUE;
+ 				Kohana::log('debug', 'Disable magic_quotes_gpc! It is evil and deprecated: http://php.net/magic_quotes');

--- a/net-analyzer/pnp4nagios/files/pnp4nagios-0.6.26-sizeof.patch
+++ b/net-analyzer/pnp4nagios/files/pnp4nagios-0.6.26-sizeof.patch
@@ -1,0 +1,357 @@
+# https://github.com/lingej/pnp4nagios/commit/d5e04540d52238dfcb877d7116316ba1be8c1963
+diff --git a/share/pnp/application/controllers/ajax.php b/share/pnp/application/controllers/ajax.php
+index 9e0428d..c5f89e2 100644
+--- a/share/pnp/application/controllers/ajax.php
++++ b/share/pnp/application/controllers/ajax.php
+@@ -59,7 +59,7 @@ public function basket($action=FALSE){
+ 
+         if($action == "list"){
+             $basket = $this->session->get("basket");
+-            if(is_array($basket) && sizeof($basket) > 0){
++            if(is_array($basket) && (!empty($basket))){
+                 foreach($basket as $item){
+                 printf("<li class=\"ui-state-default %s\" id=\"%s\"><a title=\"%s\" id=\"%s\"><img width=12px height=12px src=\"%smedia/images/remove.png\"></a>%s</li>\n",
+                         "basket_action_remove",
+@@ -135,7 +135,7 @@ public function basket($action=FALSE){
+             echo "Action $action not known";
+         }
+         $basket = $this->session->get("basket");
+-        if(is_array($basket) && sizeof($basket) == 0){
++        if(is_array($basket) && empty($basket)){
+             echo Kohana::lang('common.basket-empty');
+         }else{
+             echo "<div align=\"center\" class=\"p2\">\n";
+diff --git a/share/pnp/application/controllers/image.php b/share/pnp/application/controllers/image.php
+index b41ca83..869435c 100644
+--- a/share/pnp/application/controllers/image.php
++++ b/share/pnp/application/controllers/image.php
+@@ -47,7 +47,7 @@ public function index()
+                 $this->rrdtool->streamImage("ERROR: NOT_AUTHORIZED"); 
+ 
+             #print Kohana::debug($this->data->STRUCT);
+-            if(sizeof($this->data->STRUCT) > 0){
++            if(!empty($this->data->STRUCT)){
+                 $image = $this->rrdtool->doImage($this->data->STRUCT[0]['RRD_CALL']);
+             }else{
+                 $image = FALSE;
+diff --git a/share/pnp/application/controllers/page.php b/share/pnp/application/controllers/page.php
+index 7bd877e..fcfffe8 100644
+--- a/share/pnp/application/controllers/page.php
++++ b/share/pnp/application/controllers/page.php
+@@ -58,7 +58,7 @@ public function index(){
+ 
+     public function basket(){
+         $basket = $this->session->get("basket");
+-        if(is_array($basket) && sizeof($basket) > 0){
++        if(is_array($basket) && (!empty($basket))){
+             $this->data->buildBasketStruct($basket,$this->view);
+             $this->template->page->basket_box         = $this->add_view('basket_box');
+             $this->template->page->header->title      = Kohana::lang('common.page-basket');
+diff --git a/share/pnp/application/controllers/pdf.php b/share/pnp/application/controllers/pdf.php
+index 15f2ab4..d590859 100644
+--- a/share/pnp/application/controllers/pdf.php
++++ b/share/pnp/application/controllers/pdf.php
+@@ -202,7 +202,7 @@ public function basket(){
+         }
+         $this->data->getTimeRange($this->start,$this->end,$this->view);
+         $basket = $this->session->get("basket");
+-        if(is_array($basket) && sizeof($basket) > 0){
++        if(is_array($basket) && (!empty($basket))){
+              $this->data->buildBasketStruct($basket,$this->view);
+         }
+         //echo Kohana::debug($this->data->STRUCT);
+diff --git a/share/pnp/application/helpers/rrd.php b/share/pnp/application/helpers/rrd.php
+index 81bb257..ea9f99b 100644
+--- a/share/pnp/application/helpers/rrd.php
++++ b/share/pnp/application/helpers/rrd.php
+@@ -207,7 +207,7 @@ public static function gprint($vname=FALSE, $cf="AVERAGE", $text="%6.2lf %s"){
+         if(is_array($cf)){
+             foreach($cf as $key => $val){
+                 $line .= sprintf("GPRINT:%s:%s:",$vname,$val);
+-                if($key == sizeof($cf)-1){
++                if($key == count($cf)-1){
+                     $line .= '"'.$text.' '.ucfirst(strtolower($val)).'\\l" ';
+                 }else{
+                     $line .= '"'.$text.' '.ucfirst(strtolower($val)).'" ';
+@@ -234,7 +234,7 @@ public static function gprinta($vname=FALSE, $cf="AVERAGE", $text="%6.2lf %s", $
+         if(is_array($cf)){
+             foreach($cf as $key => $val){
+                 $line .= sprintf("GPRINT:%s:%s:",$vname,$val);
+-                if(($key == sizeof($cf)-1)and($align != "")){
++                if(($key == count($cf)-1)and($align != "")){
+                     $line .= '"'.$text.' '.ucfirst(strtolower($val)).$align.'" ';
+                 }else{
+                     $line .= '"'.$text.' '.ucfirst(strtolower($val)).'" ';
+diff --git a/share/pnp/application/lib/json.php b/share/pnp/application/lib/json.php
+index 0cddbdd..d0e3171 100644
+--- a/share/pnp/application/lib/json.php
++++ b/share/pnp/application/lib/json.php
+@@ -375,7 +375,7 @@ function encode($var)
+                 */
+ 
+                 // treat as a JSON object
+-                if (is_array($var) && count($var) && (array_keys($var) !== range(0, sizeof($var) - 1))) {
++                if (is_array($var) && count($var) && (array_keys($var) !== range(0, count($var) - 1))) {
+                     $properties = array_map(array($this, 'name_value'),
+                                             array_keys($var),
+                                             array_values($var));
+diff --git a/share/pnp/application/models/auth.php b/share/pnp/application/models/auth.php
+index 77f28d2..11d785a 100644
+--- a/share/pnp/application/models/auth.php
++++ b/share/pnp/application/models/auth.php
+@@ -116,11 +116,7 @@ public function is_authorized($host = FALSE, $service = NULL){
+             $result = $this->queryLivestatus($query);
+         }
+ 
+-        if(sizeof($result) > 0){
+-            return TRUE;
+-        }else{
+-            return FALSE;
+-        }
++        return (!empty($result));
+     }
+ 
+ 
+diff --git a/share/pnp/application/models/config.php b/share/pnp/application/models/config.php
+index 44e3d12..7a6b8e0 100644
+--- a/share/pnp/application/models/config.php
++++ b/share/pnp/application/models/config.php
+@@ -68,7 +68,7 @@ public function read_config(){
+                 $views = array();
+                 include ($config_file);
+                 $array_b = $views;
+-                if(sizeof($views) == 0 ){
++                if(empty($views)){
+                     $views = $array_a;
+                 }
+             }
+diff --git a/share/pnp/application/models/data.php b/share/pnp/application/models/data.php
+index 63b0e24..74e8821 100644
+--- a/share/pnp/application/models/data.php
++++ b/share/pnp/application/models/data.php
+@@ -45,11 +45,11 @@ public function getSpecialTemplates(){
+                 }
+             }
+         }
+-        if(sizeof($templates) > 0){
++        if(empty($templates)){
++            return FALSE;
++        }else{
+             sort($templates);
+             return $templates;
+-        }else{
+-            return FALSE;
+         }
+     }
+ 
+@@ -97,7 +97,9 @@ public function getHosts() {
+                     throw new Kohana_User_Exception('Perfdata Dir', "Can not open $path");
+                }
+            }
+-        if(sizeof($hosts)>0){
++        if(empty($hosts)){
++            throw new Kohana_Exception('error.perfdata-dir-empty', $conf['rrdbase'] );
++        }else{
+             # Obtain a list of columns
+             foreach ($hosts as $key => $row) {
+                 $sort[$key]  = $row['sort'];
+@@ -105,8 +107,6 @@ public function getHosts() {
+             # Sort the data with volume descending, edition ascending
+             # Add $data as the last parameter, to sort by the common key
+             array_multisort($sort, SORT_ASC, $hosts);
+-        }else{
+-            throw new Kohana_Exception('error.perfdata-dir-empty', $conf['rrdbase'] );
+         }
+         return $hosts;
+     }
+@@ -147,7 +147,7 @@ function getRawServices($hostname) {
+         }else{
+             throw new Kohana_Exception('error.perfdata-dir-for-host', $path, $hostname );
+         }
+-        if( is_array($services) && sizeof($services) > 0){
++        if( is_array($services) && (!empty($services))){
+             # Obtain a list of columns
+             foreach ($services as $key => $row) {
+                 $sort[$key]  = $row['name'];
+@@ -205,7 +205,7 @@ function getServices($hostname) {
+             $i++;
+         }
+         #print Kohana::debug($services);
+-        if( is_array($services) && sizeof($services) > 0){
++        if( is_array($services) && (!empty($services))){
+             # Obtain a list of columns
+             foreach ($services as $key => $row) {
+                 $sort[$key]  = $row['sort'];
+@@ -214,7 +214,7 @@ function getServices($hostname) {
+             # Add $data as the last parameter, to sort by the common key
+             array_multisort($sort, SORT_STRING, $services);
+         }        
+-        if(is_array($host) && sizeof($host) > 0 ){
++        if(is_array($host) && (!empty($host))){
+             array_unshift($services, $host[0]);
+         }
+         return $services;
+@@ -232,7 +232,7 @@ public function getFirstService($hostname) {
+                 break;
+             }
+         }
+-        if(sizeof($srv) == 0){
++        if(empty($srv)){
+             throw new Kohana_Exception('error.get-first-service', $hostname );
+         }
+         return $srv['name'];
+@@ -250,7 +250,7 @@ public function getFirstHost() {
+                 break;
+             }
+         }
+-        if(sizeof($host) == 0){
++        if(empty($host)){
+             throw new Kohana_Exception('error.get-first-host');
+         }
+         return $host['name'];
+@@ -693,7 +693,7 @@ public function getTimeRange($start=FALSE ,$end=FALSE ,$view="") {
+         }
+         
+            $view=intval( pnp::clean($view) );
+-           if($view >= sizeof($this->config->views)){
++           if($view >= count($this->config->views)){
+                $view = 1;
+            }
+ 
+@@ -735,7 +735,7 @@ public function getTimeRange($start=FALSE ,$end=FALSE ,$view="") {
+            $timerange['f_end']   = date($this->config->conf['date_fmt'],$end);
+            $timerange['cmd']     = " --start $start --end $end ";
+            $timerange['type']    = "views";
+-           for ($i = 0; $i < sizeof($this->config->views); $i++) {
++           for ($i = 0; $i < count($this->config->views); $i++) {
+                $timerange[$i]['title']   = $this->config->views[$i]['title'];
+                $timerange[$i]['start']   = $end - $this->config->views[$i]['start'];
+                $timerange[$i]['f_start'] = date($this->config->conf['date_fmt'],$end - $this->config->views[$i]['start']);
+@@ -747,7 +747,7 @@ public function getTimeRange($start=FALSE ,$end=FALSE ,$view="") {
+     }
+ 
+     public function buildBasketStruct($basket,$view = NULL){
+-        if(is_array($basket) && sizeof($basket) > 0){
++        if(is_array($basket) && (!empty($basket))){
+ 	    if($view == ""){
+                  $views = array_keys($this->config->views);
+             }else{
+@@ -757,9 +757,9 @@ public function buildBasketStruct($basket,$view = NULL){
+                 foreach($basket as $item){
+                     # explode host::service::source
+                     $slices = explode("::",$item);
+-                    if(sizeof($slices) == 2)
++                    if(count($slices) == 2)
+                         $this->buildDataStruct($slices[0], $slices[1], $view);
+-                    if(sizeof($slices) == 3)
++                    if(count($slices) == 3)
+                         $this->buildDataStruct($slices[0], $slices[1], $view, $slices[2]);
+                 }
+                 # break on custom time ranges
+@@ -806,12 +806,12 @@ public function buildPageStruct($page,$view){
+             }
+         }
+         #print Kohana::debug($servicelist);
+-        if(sizeof($servicelist) > 0 ){
++        if(empty($servicelist)){
++            $this->ERROR = "ERROR: ". Kohana::lang('error.no-data-for-page', $page.".cfg" );
++        }else{
+             foreach($servicelist as $s){
+                 $this->buildDataStruct($s['host'],$s['service'],$view,$s['source']);
+             }
+-        }else{
+-            $this->ERROR = "ERROR: ". Kohana::lang('error.no-data-for-page', $page.".cfg" );
+         }
+     }
+ 
+@@ -962,11 +962,11 @@ public function getPages() {
+                 die("Cannot open directory:  $path");
+             }
+         }
+-        if(sizeof($pages)>0){
++        if(empty($pages)){
++            return FALSE; 
++        }else{
+             
+             natsort($pages);
+-        }else{
+-            return FALSE; 
+         }
+         return $pages;
+     }
+@@ -976,10 +976,10 @@ public function getPages() {
+     */
+     public function getFirstPage(){
+         $pages = $this->getPages();
+-        if(sizeof($pages) > 0 ){
+-            return urldecode($pages[0]);
+-        }else{
++        if(empty($pages)){
+             return FALSE;
++        }else{
++            return urldecode($pages[0]);
+         }
+     }
+ 
+@@ -1093,7 +1093,7 @@ public function tplGetServices ($hostregex=FALSE, $serviceregex = ''){
+             }
+         }
+ 
+-        if(sizeof($new_hosts) == 0){
++        if(empty($new_hosts)){
+             throw new Kohana_Exception('error.tpl-no-hosts-found', $hostregex);
+         }
+ 
+@@ -1101,7 +1101,7 @@ public function tplGetServices ($hostregex=FALSE, $serviceregex = ''){
+         $new_services = array();
+         foreach($new_hosts as $host){
+             $services = $this->getRawServices($host);
+-            if(sizeof($services) == 0){
++            if(empty($services)){
+                 throw new Kohana_Exception('error.tpl-no-services-found', $serviceregex);
+             }
+             foreach($services as $service){
+@@ -1115,7 +1115,7 @@ public function tplGetServices ($hostregex=FALSE, $serviceregex = ''){
+             }
+         }
+ 
+-        if(sizeof($new_services) == 0){
++        if(empty($new_services)){
+             throw new Kohana_Exception('error.tpl-no-services-found', $serviceregex);
+         }
+ 
+diff --git a/share/pnp/application/views/basket_box.php b/share/pnp/application/views/basket_box.php
+index ea8a72c..2a4e0e6 100644
+--- a/share/pnp/application/views/basket_box.php
++++ b/share/pnp/application/views/basket_box.php
+@@ -6,7 +6,7 @@
+ echo Kohana::lang('common.basket-box-header')."</div>\n";
+ echo "<div class=\"p4 ui-widget-content ui-corner-bottom\">\n";
+ echo "<div id=\"basket_items\">\n";
+-if(is_array($basket) && sizeof($basket) > 0 ){
++if(is_array($basket) && !empty($basket)){
+ 	foreach($basket as $key=>$item){
+ 		echo "<li class=\"ui-state-default basket_action_remove\" id=\"".
+                      $item."\"><a title=\"".Kohana::lang('common.basket-remove', $item)."\"".
+@@ -16,7 +16,7 @@
+                      pnp::shorten($item)."</li>\n";
+ 	}
+ }
+-if(is_array($basket) && sizeof($basket) > 0 ){
++if(is_array($basket) && !empty($basket)){
+     echo "<div align=\"center\" class=\"p2\">\n";
+     echo "<button id=\"basket-show\">".Kohana::lang('common.basket-show')."</button>\n";
+     echo "<button id=\"basket-clear\">".Kohana::lang('common.basket-clear')."</button>\n";
+diff --git a/share/pnp/templates.dist/pnp-runtime.php b/share/pnp/templates.dist/pnp-runtime.php
+index 21c4ae3..a668fdc 100644
+--- a/share/pnp/templates.dist/pnp-runtime.php
++++ b/share/pnp/templates.dist/pnp-runtime.php
+@@ -34,7 +34,7 @@
+ #
+ $ds_name[2] = "Errors and updates";
+ $def[2] = '';
+-for($i=2; $i <= sizeof($DS); $i++) {
++for($i=2; $i <= count($DS); $i++) {
+ $def[2] .=  rrd::def("var$i", $RRDFILE[$i], $DS[$i] , "AVERAGE") ;
+ $def[2] .= rrd::line1("var$i", rrd::color($i), rrd::cut(ucfirst($LABEL[$i]),12) );
+ $def[2] .= rrd::gprint("var$i", array('LAST', 'MAX', 'AVERAGE'), "%4.0lf$UNIT[$i]");

--- a/net-analyzer/pnp4nagios/pnp4nagios-0.6.26-r11.ebuild
+++ b/net-analyzer/pnp4nagios/pnp4nagios-0.6.26-r11.ebuild
@@ -1,0 +1,104 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+DESCRIPTION="A performance data analyzer for nagios"
+HOMEPAGE="http://www.pnp4nagios.org/"
+SRC_URI="mirror://sourceforge/${PN}/PNP-0.6/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+IUSE="apache2 icinga +nagios"
+KEYWORDS="~amd64 ~ppc ~ppc64 ~sparc ~x86"
+
+REQUIRED_USE="^^ ( icinga nagios )"
+
+# Some things (sync mode, for one) are broken with nagios-4.x, but since
+# nagios-3.x has been end-of-life'd, we don't have much choice here but
+# to accept it.
+DEPEND="
+	dev-lang/php:*[filter,gd,json(+),simplexml,xml,zlib]
+	net-analyzer/rrdtool[graph,perl]
+	icinga? ( net-analyzer/icinga2 )
+	nagios? ( net-analyzer/nagios-core )"
+
+# A list of modules used in our Apache config file.
+APACHE_MODS="apache2_modules_alias,"       # "Alias" directive
+APACHE_MODS+="apache2_modules_authz_core," # "Require" directive
+APACHE_MODS+="apache2_modules_rewrite"     # "RewriteEngine" and friends
+
+RDEPEND="${DEPEND}
+	virtual/perl-Getopt-Long
+	virtual/perl-Time-HiRes
+	media-fonts/dejavu
+	apache2? ( >=www-servers/apache-2.4[${APACHE_MODS}] )"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-0.6.14-makefile.patch"
+	"${FILESDIR}/${PN}-0.6.26-magic-quotes.patch"
+	"${FILESDIR}/${PN}-0.6.26-sizeof.patch"
+)
+
+src_configure() {
+	local user_group=nagios
+	use icinga && user_group=icinga
+
+	econf \
+		--sysconfdir="${EPREFIX}"/etc/pnp \
+		--datarootdir="${EPREFIX}"/usr/share/pnp \
+		--localstatedir="${EPREFIX}"/var/lib/pnp \
+		--with-nagios-user="${user_group}" \
+		--with-nagios-group="${user_group}" \
+		--with-perfdata-logfile="${EPREFIX}"/var/log/pnp/process_perfdata.log
+}
+
+src_compile() {
+	# The default target just shows a help
+	emake all
+}
+
+src_install() {
+	# Don't use INSTALL_OPTS because they set insecure permissions on
+	# all of /etc/pnp (https://github.com/lingej/pnp4nagios/issues/140).
+	emake INSTALL_OPTS="" DESTDIR="${D}" install install-config
+	einstalldocs
+	newinitd "${FILESDIR}"/npcd.initd npcd
+	rm "${ED%/}/usr/share/pnp/install.php" || \
+		die "unable to remove ${ED%/}/usr/share/pnp/install.php"
+
+	# Fix CVE-2012-3457 (Gentoo bug 430358)
+	fperms o-rwx /etc/pnp/process_perfdata.cfg
+
+	if use apache2 ; then
+		insinto /etc/apache2/modules.d
+		newins "${FILESDIR}"/98_pnp4nagios-2.4.conf 98_pnp4nagios.conf
+	fi
+
+	# The nagios or icinga user needs to write performance data to the
+	# perfdata-dir...
+	local user_group=nagios
+	use icinga && user_group=icinga
+	fowners ":${user_group}" /var/lib/pnp/{,perfdata,spool}
+	fperms g+rwx /var/lib/pnp/{,perfdata,spool}
+
+	# and likewise for its logs...
+	dodir /var/log/pnp
+	fowners ":${user_group}" /var/log/pnp
+	fperms g+rwx /var/log/pnp
+
+	# and its statistics. This one is arguably the responsibility of the
+	# build system, since process_perfdata.cfg refers to this location.
+	dodir /var/lib/pnp/stats
+	fowners ":${user_group}" /var/lib/pnp/stats
+	fperms g+rwx /var/lib/pnp/stats
+}
+
+pkg_postinst() {
+	elog "To enable the pnp4nagios web front-end, please visit"
+	elog "${EROOT%/}/etc/conf.d/apache2 and add \"-D PNP -D PHP\""
+	elog "to APACHE2_OPTS. Then pnp4nagios will be available at,"
+	elog
+	elog "  http://localhost/pnp4nagios"
+	elog
+}


### PR DESCRIPTION
Adding two upstream patches to fix php 7.4 compatibility:

```
--- pnp4nagios-0.6.26-r10.ebuild        2021-06-19 15:30:16.387215562 +0000
+++ pnp4nagios-0.6.26-r11.ebuild        2021-06-19 15:30:48.813651782 +0000
@@ -10,7 +10,7 @@
 LICENSE="GPL-2"
 SLOT="0"
 IUSE="apache2 icinga +nagios"
-KEYWORDS="amd64 ppc ppc64 ~sparc x86"
+KEYWORDS="~amd64 ~ppc ~ppc64 ~sparc ~x86"
 
 REQUIRED_USE="^^ ( icinga nagios )"
 
@@ -34,7 +34,11 @@
        media-fonts/dejavu
        apache2? ( >=www-servers/apache-2.4[${APACHE_MODS}] )"
 
-PATCHES=( "${FILESDIR}/${PN}-0.6.14-makefile.patch" )
+PATCHES=(
+       "${FILESDIR}/${PN}-0.6.14-makefile.patch"
+       "${FILESDIR}/${PN}-0.6.26-magic-quotes.patch"
+       "${FILESDIR}/${PN}-0.6.26-sizeof.patch"
+)
 
 src_configure() {
        local user_group=nagios
```