### PR TITLE
dev-ml/camlbz2: add ocamlopt USE flag

### DIFF
--- a/dev-ml/camlbz2/camlbz2-0.7.0.ebuild
+++ b/dev-ml/camlbz2/camlbz2-0.7.0.ebuild
@@ -13,7 +13,7 @@ SRC_URI="https://gitlab.com/irill/camlbz2/-/archive/${PV}/${P}.tar.gz"
 LICENSE="LGPL-2.1"
 SLOT="0/${PV}"
 KEYWORDS="amd64 arm arm64 ppc ppc64 x86"
-IUSE="doc"
+IUSE="doc +ocamlopt"
 
 DEPEND="
 	app-arch/bzip2


### PR DESCRIPTION
Package-Manager: Portage-3.0.20, Repoman-3.0.2
Signed-off-by: Pierre-Nicolas Clauss <pinicarus@protonmail.com>

Without this USE flag, emerge-ing the package fails with this error:

masked by: invalid: RDEPEND: USE flag 'ocamlopt' referenced in conditional 'ocamlopt?' in atom 'dev-lang/ocaml:=[ocamlopt?]' is not in IUSE