### PR TITLE
dev-ml/merlin: remove unneeded emacs dependencies

### DIFF
--- a/dev-ml/merlin/merlin-4.1-r1.ebuild
+++ b/dev-ml/merlin/merlin-4.1-r1.ebuild
@@ -16,8 +16,6 @@ KEYWORDS="~amd64"
 IUSE="emacs +ocamlopt"
 
 RDEPEND="
-	app-emacs/auto-complete
-	app-emacs/company-mode
 	dev-ml/csexp:=
 	dev-ml/yojson:=
 	dev-ml/menhir:=


### PR DESCRIPTION
Package-Manager: Portage-3.0.20, Repoman-3.0.2
Signed-off-by: Pierre-Nicolas Clauss <pinicarus@protonmail.com>

Dependency to app-emacs/auto-complete and app-emacs/company-mode are already tracked within the emacs? conditional block