### PR TITLE
dev-qt/qtwebengine: fix build with sys-devel/clang[default-libcxx]

### DIFF
--- a/dev-qt/qtwebengine/files/qtwebengine-5.15.2_p20210521-clang-libc++.patch
+++ b/dev-qt/qtwebengine/files/qtwebengine-5.15.2_p20210521-clang-libc++.patch
@@ -1,0 +1,10 @@
+--- a/src/buildtools/gn.pro
++++ b/src/buildtools/gn.pro
+@@ -25,6 +25,7 @@
+             msvc:!clang_cl: gn_gen_args += --use-lto
+
+             gn_configure = $$system_quote($$gn_bootstrap) $$gn_gen_args
++            gn_configure += --no-static-libstdc++
+             macos {
+                 gn_configure += --isysroot \"$$QMAKE_MAC_SDK_PATH\"
+             }

--- a/dev-qt/qtwebengine/qtwebengine-5.15.2_p20210824-r1.ebuild
+++ b/dev-qt/qtwebengine/qtwebengine-5.15.2_p20210824-r1.ebuild
@@ -176,6 +176,11 @@ src_prepare() {
 		eapply "${FILESDIR}/qtwebengine-5.15.2_p20210824-harfbuzz-3.0.0.patch"
 	fi
 
+	# src/3rdparty/gn fails with libc++ due to passing of `-static-libstdc++`
+	if tc-is-clang && has_version 'sys-devel/clang[default-libcxx]'; then
+		eapply "${FILESDIR}/${PN}-5.15.2_p20210521-clang-libc++.patch"
+	fi
+
 	qt_use_disable_config alsa webengine-alsa src/buildtools/config/linux.pri
 	qt_use_disable_config pulseaudio webengine-pulseaudio src/buildtools/config/linux.pri
 


### PR DESCRIPTION
`dev-qt/qtwebengine` passes `-static-libstdc++` to the compiler when building `src/3rdparty/gn`. When using `libc++` as the defualt stdlib the build fails with `error: unable to find library -lc++`.

This issue is not able to be worked around with CXXFLAGS as all flags are stripped for the majority of the qtwebengine build. It's also why there is no check such as `is-flagq '-stdlib=libc++` in the ebuild. This issue only appears to exist when `sys-devel/clang` has been built with `[default-libcxx]` as the build system expects libstdc++ as the default stdlib.

With this change I am able to successfully build qtwebengine with `sys-devel/clang[default-libcxx]`

Closes: https://github.com/gentoo/gentoo/pull/14722