### PR TITLE
sys-process/lsof: backport arm sigbus fix

### DIFF
--- a/sys-process/lsof/files/lsof-4.94-arm-sigbus-fix.patch
+++ b/sys-process/lsof/files/lsof-4.94-arm-sigbus-fix.patch
@@ -1,0 +1,102 @@
+From 21cb1dad1243f4c0a427d893babab12e48b60f0e Mon Sep 17 00:00:00 2001
+From: Masatake YAMATO <yamato@redhat.com>
+Date: Sun, 20 Jun 2021 21:40:55 +0900
+Subject: [PATCH] Adjust alignment of buffer passed to stat()
+
+Close #160.
+
+The original code passes char[] buffer to stat().
+This can be cause a SIGBUS.
+
+#160 reported an actual crash on armv7a + glibc-2.33 platform.
+See also https://sourceware.org/bugzilla/show_bug.cgi?id=27993.
+
+The issue is reported by @10ne1.
+
+Signed-off-by: Masatake YAMATO <yamato@redhat.com>
+[Adrian: Backported to 4.94]
+Signed-off-by: Adrian Ratiu <adrian.ratiu@collabora.com>
+---
+ 00CREDITS |  5 +++--
+ 00DIST    |  7 +++++++
+ misc.c    | 18 +++++++++++++-----
+ 3 files changed, 23 insertions(+), 7 deletions(-)
+
+diff --git a/00CREDITS b/00CREDITS
+index 370d4c0..8f43b14 100644
+--- a/00CREDITS
++++ b/00CREDITS
+@@ -554,8 +554,9 @@ provided test systems where I was able to do development work.
+ 	@albert-github
+ 	Tobias Geerinckx-Rice
+ 	Andres Salomon
+-	Nicholas Bamber and
+-	Grisha Levit
++	Nicholas Bamber
++	Grisha Levit and
++	@10ne1 (github account)
+ 
+ If I have omitted a contributor's name, the fault is wholly mine,
+ and I apologize for the error.
+diff --git a/00DIST b/00DIST
+index 2f836fe..a679673 100644
+--- a/00DIST
++++ b/00DIST
+@@ -5246,5 +5246,12 @@ July 14, 2018
+ 		Provided by @algorythmic (Grisha Levit) in #158.
+ 
+ 
++		Adjust alignment of buffer passed to stat().
++		The original code passes char[] buffer to stat(). This can be cause
++		a SIGBUS. #160 reported an actual crash on armv7a + glibc-2.33 platform.
++		See also https://sourceware.org/bugzilla/show_bug.cgi?id=27993.
++		Reported by @10ne1 in #160.
++
++
+ The lsof-org team at GitHub
+ November 11, 2020
+diff --git a/misc.c b/misc.c
+index 3bebdc5..bebaac6 100644
+--- a/misc.c
++++ b/misc.c
+@@ -293,7 +293,15 @@ doinchild(fn, fp, rbuf, rbln)
+ 		 */
+ 
+ 		    int r_al, r_rbln;
+-		    char r_arg[MAXPATHLEN+1], r_rbuf[MAXPATHLEN+1];
++		    char r_arg[MAXPATHLEN+1];
++		    union {
++			    char r_rbuf[MAXPATHLEN+1];
++			    /*
++			     * This field is only for adjusting the alignment of r_rbuf that
++			     * can be used as an argument for stat().
++			     */
++			    struct stat _;
++		    } r;
+ 		    int (*r_fn)();
+ 		/*
+ 		 * Close sufficient open file descriptors except Pipes[0] and
+@@ -358,16 +366,16 @@ doinchild(fn, fp, rbuf, rbln)
+ 			||  read(Pipes[0], r_arg, r_al) != r_al
+ 			||  read(Pipes[0], (char *)&r_rbln, sizeof(r_rbln))
+ 			    != (int)sizeof(r_rbln)
+-			||  r_rbln < 1 || r_rbln > (int)sizeof(r_rbuf))
++			||  r_rbln < 1 || r_rbln > (int)sizeof(r.r_rbuf))
+ 			    break;
+-			zeromem (r_rbuf, r_rbln);
+-			rv = r_fn(r_arg, r_rbuf, r_rbln);
++			zeromem (r.r_rbuf, r_rbln);
++			rv = r_fn(r_arg, r.r_rbuf, r_rbln);
+ 			en = errno;
+ 			if (write(Pipes[3], (char *)&rv, sizeof(rv))
+ 			    != sizeof(rv)
+ 			||  write(Pipes[3], (char *)&en, sizeof(en))
+ 			    != sizeof(en)
+-			||  write(Pipes[3], r_rbuf, r_rbln) != r_rbln)
++			||  write(Pipes[3], r.r_rbuf, r_rbln) != r_rbln)
+ 			    break;
+ 		    }
+ 		    (void) _exit(0);
+-- 
+2.32.0
+

--- a/sys-process/lsof/lsof-4.94.0-r1.ebuild
+++ b/sys-process/lsof/lsof-4.94.0-r1.ebuild
@@ -28,6 +28,7 @@ RESTRICT="test"
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-4.85-cross.patch #432120
+	"${FILESDIR}"/${PN}-4.94-arm-sigbus-fix.patch
 )
 
 src_prepare() {


### PR DESCRIPTION
    sys-process/lsof: backport arm sigbus crash fix
    
    This backports an upstream fix for a crash which happens on
    armv7a + glibc 2.33 due to a buffer misalignment.
    
    Upstream issue: https://github.com/lsof-org/lsof/issues/160
    Upstream commit: 21cb1dad1243f4c0a427d893babab12e48b60f0e
    
    Bug: https://bugs.gentoo.org/797358
    
    Signed-off-by: Adrian Ratiu <adrian.ratiu@collabora.com>