### PR TITLE
app-office/gtg: update pdfjam test dependency

### DIFF
--- a/app-office/gtg/gtg-0.4.0.ebuild
+++ b/app-office/gtg/gtg-0.4.0.ebuild
@@ -40,7 +40,7 @@ BDEPEND="
 			dev-python/cheetah3[${PYTHON_USEDEP}]
 			dev-python/mock[${PYTHON_USEDEP}]
 		')
-		app-text/pdfjam
+		|| ( app-text/pdfjam >=app-text/texlive-core-2021 )
 		app-text/pdftk
 		dev-texlive/texlive-latex
 	)

--- a/app-office/gtg/gtg-0.5.ebuild
+++ b/app-office/gtg/gtg-0.5.ebuild
@@ -40,7 +40,7 @@ BDEPEND="
 			dev-python/cheetah3[${PYTHON_USEDEP}]
 			dev-python/mock[${PYTHON_USEDEP}]
 		')
-		app-text/pdfjam
+		|| ( app-text/pdfjam >=app-text/texlive-core-2021 )
 		app-text/pdftk
 		dev-texlive/texlive-latex
 	)


### PR DESCRIPTION
With recent texlive-core ebuilds providing the pdfjam binary, let's
allow them to satisfy the dependency

Signed-off-by: Christophe Lermytte <gentoo@lermytte.be>