### PR TITLE
app-shells/bash: remove /bin/sh logic from pkg_preinst

### DIFF
--- a/app-shells/bash/bash-5.0_p18.ebuild
+++ b/app-shells/bash/bash-5.0_p18.ebuild
@@ -255,15 +255,6 @@ pkg_preinst() {
 		mkdir -p "${EROOT}"/etc/bash
 		mv -f "${EROOT}"/etc/bashrc "${EROOT}"/etc/bash/
 	fi
-
-	if [[ -L ${EROOT}/bin/sh ]] ; then
-		# rewrite the symlink to ensure that its mtime changes. having /bin/sh
-		# missing even temporarily causes a fatal error with paludis.
-		local target=$(readlink "${EROOT}"/bin/sh)
-		local tmp="${T}"/sh
-		ln -sf "${target}" "${tmp}"
-		mv -f "${tmp}" "${EROOT}"/bin/sh
-	fi
 }
 
 pkg_postinst() {

--- a/app-shells/bash/bash-5.1_p8.ebuild
+++ b/app-shells/bash/bash-5.1_p8.ebuild
@@ -255,15 +255,6 @@ pkg_preinst() {
 		mkdir -p "${EROOT}"/etc/bash
 		mv -f "${EROOT}"/etc/bashrc "${EROOT}"/etc/bash/
 	fi
-
-	if [[ -L ${EROOT}/bin/sh ]] ; then
-		# Rewrite the symlink to ensure that its mtime changes. Having /bin/sh
-		# missing even temporarily causes a fatal error with paludis.
-		local target=$(readlink "${EROOT}"/bin/sh)
-		local tmp="${T}"/sh
-		ln -sf "${target}" "${tmp}"
-		mv -f "${tmp}" "${EROOT}"/bin/sh
-	fi
 }
 
 pkg_postinst() {


### PR DESCRIPTION
This was added back in 2008 to handle some migration in file ownership.
I expect all users have upgraded many times since then.

Closes: https://bugs.gentoo.org/778311
Signed-off-by: Mike Gilbert <floppym@gentoo.org>