### PR TITLE
dev-libs/tvision: avoid pre-stripping

### DIFF
--- a/dev-libs/tvision/tvision-2.2.3.ebuild
+++ b/dev-libs/tvision/tvision-2.2.3.ebuild
@@ -56,6 +56,8 @@ src_configure() {
 	myconf+=(
 		--fhs
 		--prefix="${EPREFIX}/usr"
+		# avoid stripping
+		--with-debug
 		--with-pthread
 		--without-static
 		--x-include="${EPREFIX}/usr/include/X11"


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/797454
Package-Manager: Portage-3.0.20, Repoman-3.0.3
Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>