### PR TITLE
net-misc/netkit-rsh: security fix, add myself as p-m

### DIFF
--- a/net-misc/netkit-rsh/files/patches/000_all_sectty.patch
+++ b/net-misc/netkit-rsh/files/patches/000_all_sectty.patch
@@ -1,0 +1,32 @@
+--- a/rexecd/rexecd.c
++++ b/rexecd/rexecd.c
+@@ -300,6 +300,7 @@
+        PAM_password = pass;
+        pam_error = pam_start("rexec", PAM_username, &PAM_conversation,&pamh);
+        PAM_BAIL;
++       (void) pam_set_item (pamh, PAM_TTY, "rexec");   /* we don't have a tty yet! */
+        pam_error = pam_authenticate(pamh, 0);
+        PAM_BAIL;
+        pam_error = pam_acct_mgmt(pamh, 0);
+--- a/rlogind/auth.c
++++ b/rlogind/auth.c
+@@ -123,7 +123,7 @@
+     pam_set_item(pamh, PAM_USER, localuser);
+     pam_set_item(pamh, PAM_RUSER, remoteuser);
+     pam_set_item(pamh, PAM_RHOST, host);
+-    pam_set_item(pamh, PAM_TTY, "tty");   /* ? */
++    pam_set_item(pamh, PAM_TTY, "rlogin");   /* we don't have a tty yet! */
+ 	
+     network_confirm();
+     retval = attempt_auth();
+--- a/rshd/rshd.c
++++ b/rshd/rshd.c
+@@ -243,7 +243,7 @@
+     }
+     pam_set_item (pamh, PAM_RUSER, remuser);
+     pam_set_item (pamh, PAM_RHOST, hostname);
+-    pam_set_item (pamh, PAM_TTY, "tty");
++    pam_set_item (pamh, PAM_TTY, "rsh");  /* we don't use a tty, so punt */
+     
+     retcode = pam_authenticate(pamh, 0);
+     if (retcode == PAM_SUCCESS) {

--- a/net-misc/netkit-rsh/files/patches/010_all_rexec.patch
+++ b/net-misc/netkit-rsh/files/patches/010_all_rexec.patch
@@ -1,0 +1,55 @@
+--- a/rexecd/rexecd.8
++++ b/rexecd/rexecd.8
+@@ -68,8 +68,9 @@
+ it is interpreted as the port number of a secondary
+ stream to be used for the 
+ .Em stderr .
+-A second connection is then created to the specified
+-port on the client's machine.
++A second connection will be created to the specified
++port on the client's machine after receiving and authenticating
++the user, password, and command from the client.
+ .It
+ A NUL terminated user name of at most 16 characters
+ is retrieved on the initial socket.
+--- a/rexec/Makefile
++++ b/rexec/Makefile
+@@ -1,30 +1,23 @@
+ 
+ SHELL = /bin/sh
+ 
+-BINDIR = /usr/local/bin
+-MANDIR = /usr/local/man/man1
++include ../MCONFIG
++include ../MRULES
+ 
+ # Uncomment this line if you get link errors under Solaris
+ #LDLIBS=-lsocket -lnsl
+ 
+ .PHONY: all
+ 
+-all: rexec install
++all: rexec
+ 
+ rexec: rexec.c
+ 
+ rexec.1:
+ 
++clean:
++	rm -f *.o rexec
++
+ install: rexec rexec.1
+-	@ echo "Installation:  Press enter for defaults."; \
+-	echo -n "Enter the location to install executable "; \
+-	echo -n " (default: $(BINDIR)): "; \
+-	read bindir; \
+-	bindir=$${bindir:-$(BINDIR)}; \
+-	echo -n "Enter the manpage location (default $(MANDIR)): ";\
+-	read mandir; \
+-	mandir=$${mandir:-$(MANDIR)}; \
+-	cp rexec $$bindir; \
+-	chmod a+rx $${bindir}/rexec; \
+-	cp rexec.1 $$mandir; \
+-	chmod a+r $${mandir}/rexec.1
++	install -m 0755 rexec $(INSTALLROOT)/$(BINDIR)/rexec
++	install -m 0644 rexec.1 $(INSTALLROOT)/$(MANDIR)/man1/rexec.1

--- a/net-misc/netkit-rsh/files/patches/020_all_stdarg.patch
+++ b/net-misc/netkit-rsh/files/patches/020_all_stdarg.patch
@@ -1,0 +1,43 @@
+--- a/rcp/rcp.c
++++ b/rcp/rcp.c
+@@ -836,19 +836,33 @@
+ error(const char *fmt, ...)
+ {
+ 	static FILE *fp;
+-	va_list ap;
+-
+-	va_start(ap, fmt);
++	char buf[1000];
+ 
+ 	++errs;
+ 	if (!fp && !(fp = fdopen(rem, "w")))
+ 		return;
+-	fprintf(fp, "%c", 0x01);
+-	vfprintf(fp, fmt, ap);
++	
++	/* (fmt,...) might need to go to two streams.
++	 *
++	 * In { va_start ; vfprintf ; vfprintf ; va_end }, second
++	 * vfprintf didn't restart (ie: vfprintf affects ap) (glibc)
++	 *
++	 * Is { va_start ; vfprintf ; va_end} * 2 even allowed?
++	 *
++	 * => Dump (fmt,...) to buffer.  */
++	
++	{
++	    va_list ap;
++	    va_start(ap, fmt);
++	    vsnprintf(buf, sizeof(buf), fmt, ap);
++	    buf[sizeof(buf)-1] = 0;
++	    va_end(ap);
++	}
++	
++	fprintf(fp, "%c%s", 0x01, buf);
+ 	fflush(fp);
+-	if (!iamremote)	vfprintf(stderr, fmt, ap);
+ 
+-	va_end(ap);
++	if (!iamremote)	fputs(buf, stderr);
+ }
+ 
+ static void 

--- a/net-misc/netkit-rsh/files/patches/030_all_jbj.patch
+++ b/net-misc/netkit-rsh/files/patches/030_all_jbj.patch
@@ -1,0 +1,33 @@
+--- a/rcp/Makefile
++++ b/rcp/Makefile
+@@ -7,7 +7,7 @@
+ 	$(CC) $(LDFLAGS) $^ $(LIBS) -o $@
+ 
+ install: rcp
+-	install -s -o root -m$(SUIDMODE) rcp $(INSTALLROOT)$(BINDIR)
++	install -s rcp $(INSTALLROOT)$(BINDIR)
+ 	install -m$(MANMODE) rcp.1 $(INSTALLROOT)$(MANDIR)/man1
+ 
+ clean:
+--- a/rlogin/Makefile
++++ a/rlogin/Makefile
+@@ -10,7 +10,7 @@
+ 	$(CC) $(LDFLAGS) $^ $(LIBS) -o $@
+ 
+ install: $(PROG)
+-	install -s -o root -m$(SUIDMODE) $(PROG) $(INSTALLROOT)$(BINDIR)
++	install -s $(PROG) $(INSTALLROOT)$(BINDIR)
+ 	install -m $(MANMODE) $(PROG).1 $(INSTALLROOT)$(MANDIR)/man1
+ 
+ clean:
+--- a/rsh/Makefile
++++ b/rsh/Makefile
+@@ -9,7 +9,7 @@
+ 	$(CC) $(LDFLAGS) $^ $(LIBS) -o $@
+ 
+ install: rsh
+-	install -s -o root -m$(SUIDMODE) rsh $(INSTALLROOT)$(BINDIR)
++	install -s rsh $(INSTALLROOT)$(BINDIR)
+ 	install -m$(MANMODE) rsh.1 $(INSTALLROOT)$(MANDIR)/man1
+ 
+ clean:

--- a/net-misc/netkit-rsh/files/patches/040_all_jbj4.patch
+++ b/net-misc/netkit-rsh/files/patches/040_all_jbj4.patch
@@ -1,0 +1,14 @@
+--- a/rshd/Makefile
++++ b/rshd/Makefile
+@@ -6,9 +6,8 @@
+ OBJS = rshd.o
+ 
+ ifeq ($(USE_PAM),1)
+-# ?
+-CFLAGS += # -DUSE_PAM
+-LIBS += -ldl # -lpam -lpam_misc
++CFLAGS += -DUSE_PAM
++LIBS += -ldl -lpam -lpam_misc
+ endif
+ 
+ rshd: $(OBJS)

--- a/net-misc/netkit-rsh/files/patches/050_all_prompt.patch
+++ b/net-misc/netkit-rsh/files/patches/050_all_prompt.patch
@@ -1,0 +1,37 @@
+--- a/rexec/rexec.c
++++ b/rexec/rexec.c
+@@ -164,12 +164,30 @@
+     user_name[strlen(user_name)-1] = '\0'; /* Hopefully fgets always adds
+ 					      a newline. */
+     passwd = getpass("Password: ");
++  } else {
++
++    if ( user_name == NULL )
++      user_name = getenv("REXEC_USER");
++    if ( user_name == NULL ) {
++      uid_t uid = getuid();
++      struct passwd *pw = getpwuid(uid);
++      if (!(pw && pw->pw_name)) {
++        fprintf(stderr, "Can't lookup uid %d\n", uid);
++	exit(1);
++      }
++      user_name = strdup(pw->pw_name);
++    }
++    if ( passwd == NULL )
++      passwd = getenv("REXEC_PASS");
++    if ( passwd == NULL )
++       passwd = getpass("Password: ");
+   }
+ 
+-  if ( user_name == NULL )
+-    user_name = getenv("REXEC_USER");
+-  if ( passwd == NULL )
+-    passwd = getenv("REXEC_PASS");
++  if (!(user_name && passwd)) {
++    fprintf(stderr, "Can't use %s without supplying a user and password\n",
++    	progname);
++    exit(1);
++  }
+ 
+   if ( (sock = rexec(&host, port_exec, user_name, passwd, command, 
+ 		     p_to_aux_sock)) < 0 )

--- a/net-misc/netkit-rsh/files/patches/060_all_rlogin-rsh.patch
+++ b/net-misc/netkit-rsh/files/patches/060_all_rlogin-rsh.patch
@@ -1,0 +1,10 @@
+--- a/rlogin/rlogin.c
++++ b/rlogin/rlogin.c
+@@ -194,6 +194,7 @@
+ 		p = argv[0];
+ 
+ 	if (strcmp(p, "rlogin"))
++	if (strcmp(p, "rsh"))
+ 		host = p;
+ 
+ 	/* handle "rlogin host flags" */

--- a/net-misc/netkit-rsh/files/patches/070_all_nokrb.patch
+++ b/net-misc/netkit-rsh/files/patches/070_all_nokrb.patch
@@ -1,0 +1,231 @@
+diff -uNr a/rcp/rcp.1 a/rcp/rcp.1
+--- a/rcp/rcp.1
++++ b/rcp/rcp.1
+@@ -41,12 +41,10 @@
+ .Sh SYNOPSIS
+ .Nm rcp
+ .Op Fl px
+-.Op Fl k Ar realm
+ .Ar file1 file2
+ .Nm rcp
+ .Op Fl px
+ .Op Fl r
+-.Op Fl k Ar realm
+ .Ar file ...
+ .Ar directory
+ .Sh DESCRIPTION
+@@ -79,27 +77,6 @@
+ modified by the
+ .Xr umask  2
+ on the destination host is used.
+-.It Fl k
+-The
+-.Fl k
+-option requests
+-.Nm rcp
+-to obtain tickets
+-for the remote host in realm
+-.Ar realm
+-instead of the remote host's realm as determined by
+-.Xr krb_realmofhost  3  .
+-.It Fl x
+-The
+-.Fl x
+-option turns on
+-.Tn DES
+-encryption for all data passed by
+-.Nm rcp .
+-This may impact response time and
+-.Tn CPU
+-utilization, but provides
+-increased security.
+ .El
+ .Pp
+ If
+@@ -134,11 +111,6 @@
+ .Nm rcp
+ command appeared in
+ .Bx 4.2 .
+-The version of
+-.Nm rcp
+-described here
+-has been reimplemented with Kerberos in
+-.Bx 4.3 Reno .
+ .Sh BUGS
+ Doesn't detect all cases where the target of a copy might
+ be a file in cases where only a directory should be legal.
+diff -uNr a/rlogin/rlogin.1 a/rlogin/rlogin.1
+--- a/rlogin/rlogin.1
++++ b/rlogin/rlogin.1
+@@ -42,7 +42,6 @@
+ .Ar rlogin
+ .Op Fl 8EKLdx
+ .Op Fl e Ar char
+-.Op Fl k Ar realm
+ .Op Fl l Ar username
+ .Ar host
+ .Sh DESCRIPTION
+@@ -50,9 +49,7 @@
+ starts a terminal session on a remote host
+ .Ar host  .
+ .Pp
+-.Nm Rlogin
+-first attempts to use the Kerberos authorization mechanism, described below.
+-If the remote host does not supporting Kerberos the standard Berkeley
++The standard Berkeley
+ .Pa rhosts
+ authorization mechanism is used.
+ The options are as follows:
+@@ -71,10 +68,6 @@
+ When used with the
+ .Fl 8
+ option, this provides a completely transparent connection.
+-.It Fl K
+-The
+-.Fl K
+-option turns off all Kerberos authentication.
+ .It Fl L
+ The
+ .Fl L
+@@ -94,25 +87,6 @@
+ ``~'' by default.
+ This specification may be as a literal character, or as an octal
+ value in the form \ennn.
+-.It Fl k
+-The
+-.FL k
+-option requests rlogin to obtain tickets for the remote host
+-in realm
+-.Ar realm
+-instead of the remote host's realm as determined by
+-.Xr krb_realmofhost  3  .
+-.It Fl x
+-The
+-.Fl x
+-option turns on
+-.Tn DES
+-encryption for all data passed via the
+-rlogin session.
+-This may impact response time and
+-.Tn CPU
+-utilization, but provides
+-increased security.
+ .El
+ .Pp
+ A line of the form ``<escape char>.'' disconnects from the remote host.
+@@ -129,35 +103,6 @@
+ is transparent.
+ Flow control via ^S/^Q and flushing of input and output on interrupts
+ are handled properly.
+-.Sh KERBEROS AUTHENTICATION
+-Each user may have a private authorization list in the file
+-.Pa .klogin
+-in their home directory.
+-Each line in this file should contain a Kerberos principal name of the
+-form
+-.Ar principal.instance@realm  .
+-If the originating user is authenticated to one of the principals named
+-in
+-.Pa .klogin ,
+-access is granted to the account.
+-The principal
+-.Ar accountname.@localrealm
+-is granted access if
+-there is no
+-.Pa .klogin
+-file.
+-Otherwise a login and password will be prompted for on the remote machine
+-as in
+-.Xr login  1  .
+-To avoid certain security problems, the
+-.Pa .klogin
+-file must be owned by
+-the remote user.
+-.Pp
+-If Kerberos authentication fails, a warning message is printed and the
+-standard Berkeley
+-.Nm rlogin
+-is used instead.
+ .Sh ENVIRONMENT
+ The following environment variable is utilized by
+ .Nm rlogin :
+@@ -167,9 +112,6 @@
+ .El
+ .Sh SEE ALSO
+ .Xr rsh 1 ,
+-.Xr kerberos 3 ,
+-.Xr krb_sendauth 3 ,
+-.Xr krb_realmofhost 3
+ .Sh HISTORY
+ The
+ .Nm rlogin
+diff -uNr a/rsh/rsh.1 a/rsh/rsh.1
+--- a/rsh/rsh.1
++++ b/rsh/rsh.1
+@@ -41,7 +41,6 @@
+ .Sh SYNOPSIS
+ .Nm rsh
+ .Op Fl Kdnx
+-.Op Fl k Ar realm
+ .Op Fl l Ar username
+ .Ar host
+ .Op command
+@@ -62,10 +61,6 @@
+ normally terminates when the remote command does.
+ The options are as follows:
+ .Bl -tag -width flag
+-.It Fl K
+-The
+-.Fl K
+-option turns off all Kerberos authentication.
+ .It Fl d
+ The
+ .Fl d
+@@ -74,23 +69,11 @@
+ on the
+ .Tn TCP
+ sockets used for communication with the remote host.
+-.It Fl k
+-The
+-.Fl k
+-option causes
+-.Nm rsh
+-to obtain tickets for the remote host in
+-.Ar realm
+-instead of the remote host's realm as determined by
+-.Xr krb_realmofhost  3  .
+ .It Fl l
+ By default, the remote username is the same as the local username.
+ The
+ .Fl l
+ option allows the remote name to be specified.
+-Kerberos authentication is used, and authorization is determined
+-as in
+-.Xr rlogin  1  .
+ .It Fl n
+ The
+ .Fl n
+@@ -99,13 +82,6 @@
+ (see the
+ .Sx BUGS
+ section of this manual page).
+-.It Fl x
+-The
+-.Fl x
+-option turns on
+-.Tn DES
+-encryption for all data exchange.
+-This may introduce a significant delay in response time.
+ .El
+ .Pp
+ If no
+@@ -142,9 +118,6 @@
+ .El
+ .Sh SEE ALSO
+ .Xr rlogin 1 ,
+-.Xr kerberos 3 ,
+-.Xr krb_sendauth 3 ,
+-.Xr krb_realmofhost 3
+ .Sh HISTORY
+ The
+ .Nm rsh

--- a/net-misc/netkit-rsh/files/patches/080_all_jbj5.patch
+++ b/net-misc/netkit-rsh/files/patches/080_all_jbj5.patch
@@ -1,0 +1,29 @@
+--- a/rlogind/auth.c
++++ b/rlogind/auth.c
+@@ -37,6 +37,7 @@
+ #include "rlogind.h"
+ 
+ #ifdef USE_PAM
++#include <grp.h>
+ 
+ /*
+  * Modifications for Linux-PAM: Al Longyear <longyear@netcom.com>
+@@ -158,18 +159,14 @@
+     pwd = getpwnam(localuser);
+     if (pwd==NULL) {
+         syslog(LOG_ERR, "user returned by PAM does not exist\n");
+-	/* don't print this - it tells people which accounts exist */
+-	/*fprintf(stderr, "rlogind: internal error\n");*/
+ 	return -1;
+     }
+     if (setgid(pwd->pw_gid) != 0) {
+         syslog(LOG_ERR, "cannot assume gid for user returned by PAM\n");
+-	fprintf(stderr, "rlogind: internal error\n");
+ 	return -1;
+     }
+     if (initgroups(localuser, pwd->pw_gid) != 0) {
+         syslog(LOG_ERR, "initgroups failed for user returned by PAM\n");
+-	fprintf(stderr, "rlogind: internal error\n");
+ 	return -1;
+     }
+     retval = pam_setcred(pamh, PAM_ESTABLISH_CRED);

--- a/net-misc/netkit-rsh/files/patches/090_all_userandhost.patch
+++ b/net-misc/netkit-rsh/files/patches/090_all_userandhost.patch
@@ -1,0 +1,70 @@
+--- a/rlogind/rlogind.c
++++ b/rlogind/rlogind.c
+@@ -333,9 +333,10 @@
+ 
+ 
+ static void child(const char *hname, const char *termtype,
+-		  const char *localuser, int authenticated)
++		  const char *localuser, int authenticated,
++		  const char *rusername)
+ {
+-    char *termenv[2];
++    char *termenv[4];
+ 
+     setup_term(0, termtype);
+ 
+@@ -344,7 +345,17 @@
+ 	strcpy(termenv[0], "TERM=");
+ 	strcat(termenv[0], termtype);
+     }
+-    termenv[1] = NULL;
++    termenv[1] = malloc(strlen(rusername)+12);
++    if (termenv[1]) {   /* shouldn't ever fail, mind you */
++	strcpy(termenv[1], "REMOTEUSER=");
++	strcat(termenv[1], rusername);
++    }
++    termenv[2] = malloc(strlen(hname)+12);
++    if (termenv[2]) {   /* shouldn't ever fail, mind you */
++	strcpy(termenv[2], "REMOTEHOST=");
++	strcat(termenv[2], hname);
++    }
++    termenv[3] = NULL;
+ 
+     if (authenticated) {
+ 	auth_finish();
+@@ -420,7 +431,7 @@
+     if (pid == 0) {
+ 	/* netfd should always be 0, but... */ 
+ 	if (netfd > 2) close(netfd);
+-	child(hname, termtype, lusername, authenticated);
++	child(hname, termtype, lusername, authenticated, rusername);
+     }
+     on = 1;
+     ioctl(netfd, FIONBIO, &on);
+--- a/rshd/rshd.c
++++ b/rshd/rshd.c
+@@ -102,8 +102,10 @@
+ char	homedir[64] = "HOME=";
+ char	shell[64] = "SHELL=";
+ char	path[100] = "PATH=";
++char	remoteuser[20] = "REMOTEUSER=";
++char	remotehost[50] = "REMOTEHOST=";
+ char	*envinit[] =
+-	    {homedir, shell, path, username, 0};
++	    {homedir, shell, path, username, remoteuser, remotehost, 0};
+ extern	char	**environ;
+ 
+ static void error(const char *fmt, ...);
+@@ -460,6 +462,12 @@
+ 	strncat(homedir, pwd->pw_dir, sizeof(homedir)-6);
+ 	homedir[sizeof(homedir)-1] = 0;
+ 
++	strncat(remoteuser, remuser, sizeof(remoteuser)-12);
++	remoteuser[sizeof(remoteuser)-1] = 0;
++
++	strncat(remotehost, hostname, sizeof(remotehost)-12);
++	remotehost[sizeof(remotehost)-1] = 0;
++
+ 	strcat(path, _PATH_DEFPATH);
+ 
+ 	strncat(shell, theshell, sizeof(shell)-7);

--- a/net-misc/netkit-rsh/files/patches/100_all_strip.patch
+++ b/net-misc/netkit-rsh/files/patches/100_all_strip.patch
@@ -1,0 +1,66 @@
+--- a/rcp/Makefile
++++ b/rcp/Makefile
+@@ -7,7 +7,7 @@
+ 	$(CC) $(LDFLAGS) $^ $(LIBS) -o $@
+ 
+ install: rcp
+-	install -s rcp $(INSTALLROOT)$(BINDIR)
++	install rcp $(INSTALLROOT)$(BINDIR)
+ 	install -m$(MANMODE) rcp.1 $(INSTALLROOT)$(MANDIR)/man1
+ 
+ clean:
+--- a/rexecd/Makefile
++++ b/rexecd/Makefile
+@@ -27,7 +27,7 @@
+ 	$(CC) $(LDFLAGS) $^ $(LIBS) -o $@
+ 
+ install: rexecd
+-	install -s -m$(DAEMONMODE) rexecd $(INSTALLROOT)$(SBINDIR)/in.rexecd
++	install -m$(DAEMONMODE) rexecd $(INSTALLROOT)$(SBINDIR)/in.rexecd
+ 	install -m$(MANMODE) rexecd.8 $(INSTALLROOT)$(MANDIR)/man8/in.rexecd.8
+ 	ln -sf in.rexecd.8 $(INSTALLROOT)$(MANDIR)/man8/rexecd.8
+ ifeq ($(USE_PAM),1)
+--- a/rlogin/Makefile
++++ b/rlogin/Makefile
+@@ -10,7 +10,7 @@
+ 	$(CC) $(LDFLAGS) $^ $(LIBS) -o $@
+ 
+ install: $(PROG)
+-	install -s $(PROG) $(INSTALLROOT)$(BINDIR)
++	install $(PROG) $(INSTALLROOT)$(BINDIR)
+ 	install -m $(MANMODE) $(PROG).1 $(INSTALLROOT)$(MANDIR)/man1
+ 
+ clean:
+--- a/rlogind/Makefile
++++ b/rlogind/Makefile
+@@ -20,7 +20,7 @@
+ auth.o network.o: rlogind.h
+ 
+ install: rlogind
+-	install -s -m$(DAEMONMODE) rlogind $(INSTALLROOT)$(SBINDIR)/in.rlogind
++	install -m$(DAEMONMODE) rlogind $(INSTALLROOT)$(SBINDIR)/in.rlogind
+ 	install -m$(MANMODE) rlogind.8 $(INSTALLROOT)$(MANDIR)/man8/in.rlogind.8
+ 	ln -sf in.rlogind.8 $(INSTALLROOT)$(MANDIR)/man8/rlogind.8
+ 
+--- a/rsh/Makefile
++++ b/rsh/Makefile
+@@ -9,7 +9,7 @@
+ 	$(CC) $(LDFLAGS) $^ $(LIBS) -o $@
+ 
+ install: rsh
+-	install -s rsh $(INSTALLROOT)$(BINDIR)
++	install rsh $(INSTALLROOT)$(BINDIR)
+ 	install -m$(MANMODE) rsh.1 $(INSTALLROOT)$(MANDIR)/man1
+ 
+ clean:
+--- a/rshd/Makefile
++++ b/rshd/Makefile
+@@ -14,7 +14,7 @@
+ 	$(CC) $(LDFLAGS) $^ $(LIBS) -o $@
+ 
+ install: rshd
+-	install -s -m$(DAEMONMODE) rshd $(INSTALLROOT)$(SBINDIR)/in.rshd
++	install -m$(DAEMONMODE) rshd $(INSTALLROOT)$(SBINDIR)/in.rshd
+ 	install -m$(MANMODE) rshd.8 $(INSTALLROOT)$(MANDIR)/man8/in.rshd.8
+ 	ln -sf in.rshd.8 $(INSTALLROOT)$(MANDIR)/man8/rshd.8
+ 

--- a/net-misc/netkit-rsh/files/patches/110_all_lfs.patch
+++ b/net-misc/netkit-rsh/files/patches/110_all_lfs.patch
@@ -1,0 +1,25 @@
+--- a/rcp/rcp.c
++++ b/rcp/rcp.c
+@@ -482,7 +482,7 @@
+ 			}
+ 		}
+ 		(void)snprintf(buf, sizeof(buf),
+-		    "C%04o %ld %s\n", stb.st_mode&07777, stb.st_size, last);
++		    "C%04o %lld %s\n", stb.st_mode&07777, (long long)(stb.st_size), last);
+ 		(void)write(rem, buf, (int)strlen(buf));
+ 		if (response() < 0) {
+ 			(void)close(f);
+@@ -614,11 +614,11 @@
+ 	struct timeval tv[2];
+ 	enum { YES, NO, DISPLAYED } wrerr;
+ 	BUF *bp;
+-	off_t i, j;
++	off_t i, j, size;
+ 	char ch, *targ;
+ 	const char *why;
+ 	int amt, count, exists, first, mask, mode;
+-	int ofd, setimes, size, targisdir;
++	int ofd, setimes, targisdir;
+ 	char *np, *vect[1], buf[BUFSIZ];
+ 
+ #define	atime	tv[0]

--- a/net-misc/netkit-rsh/files/patches/120_all_chdir.patch
+++ b/net-misc/netkit-rsh/files/patches/120_all_chdir.patch
@@ -1,0 +1,57 @@
+--- a/rshd/rshd.c
++++ b/rshd/rshd.c
+@@ -388,15 +388,6 @@
+ 		     remuser, hostname, locuser, cmdbuf);
+ 	}
+ 
+-	if (chdir(pwd->pw_dir) < 0) {
+-		chdir("/");
+-		/*
+-		 * error("No remote directory.\n");
+-		 * exit(1);
+-		 */
+-	}
+-
+-
+ 	if (pwd->pw_uid != 0 && !access(_PATH_NOLOGIN, F_OK)) {
+ 		error("Logins currently disabled.\n");
+ 		exit(1);
+@@ -456,6 +447,14 @@
+ 		exit(1);
+ 	}
+ 	environ = envinit;
++
++	if (chdir(pwd->pw_dir) < 0) {
++		chdir("/");
++		/*
++		 * error("No remote directory.\n");
++		 * exit(1);
++		 */
++	}
+ 
+ 	strncat(homedir, pwd->pw_dir, sizeof(homedir)-6);
+ 	homedir[sizeof(homedir)-1] = 0;
+--- a/rexecd/rexecd.c
++++ b/rexecd/rexecd.c
+@@ -375,10 +375,6 @@
+ 	/* Log successful attempts. */
+ 	syslog(LOG_INFO, "login from %.128s as %s", remote, user);
+ 
+-	if (chdir(pwd->pw_dir) < 0) {
+-		fatal("No remote directory.\n");
+-	}
+-
+ 	write(2, "\0", 1);
+ 	if (port) {
+ 		/* If we have a port, dup STDERR on that port KRH */
+@@ -408,6 +404,10 @@
+ 	if (setuid(pwd->pw_uid)) {
+ 		perror("setuid");
+ 		exit(1);
++	}
++
++	if (chdir(pwd->pw_dir) < 0) {
++		fatal("No remote directory.\n");
+ 	}
+ 
+ 	strcat(path, _PATH_DEFPATH);

--- a/net-misc/netkit-rsh/files/patches/130_all_pam-nologin.patch
+++ b/net-misc/netkit-rsh/files/patches/130_all_pam-nologin.patch
@@ -1,0 +1,14 @@
+--- a/rlogind/auth.c
++++ b/rlogind/auth.c
+@@ -127,7 +127,10 @@
+ 	
+     network_confirm();
+     retval = attempt_auth();
+-    if (retval != PAM_SUCCESS) {
++    if ((retval == PAM_ACCT_EXPIRED) || (retval == PAM_PERM_DENIED)) {
++	syslog(LOG_ERR, "PAM authentication denied for in.rlogind");
++	exit(1);
++    } else if (retval != PAM_SUCCESS) {
+ 	syslog(LOG_ERR, "PAM authentication failed for in.rlogind");
+ 	return -1;
+     }

--- a/net-misc/netkit-rsh/files/patches/140_all_nohostcheck.patch
+++ b/net-misc/netkit-rsh/files/patches/140_all_nohostcheck.patch
@@ -1,0 +1,134 @@
+--- a/rlogind/network.c
++++ b/rlogind/network.c
+@@ -90,7 +90,7 @@
+ 
+ 
+ static char *
+-find_hostname(const struct sockaddr_in *fromp, int *hostokp)
++find_hostname(const struct sockaddr_in *fromp, int no_host_check, int *hostokp)
+ {
+ 	struct hostent *hop;
+ 	char *hname;
+@@ -102,7 +102,7 @@
+ 		hname = strdup(inet_ntoa(fromp->sin_addr));
+ 		hostok = 1;
+ 	} 
+-	else if (check_all || local_domain(hop->h_name)) {
++	else if ((check_all || local_domain(hop->h_name )) && !no_host_check ) {
+ 		/*
+ 		 * If name returned by gethostbyaddr is in our domain,
+ 		 * attempt to verify that we haven't been fooled by someone
+@@ -143,7 +143,7 @@
+ 
+ 
+ char * 
+-network_init(int f, int *hostokp)
++network_init(int f, int no_host_check, int *hostokp)
+ {
+ 	struct sockaddr_in from, *fromp;
+ 	socklen_t fromlen;
+@@ -177,7 +177,7 @@
+ 
+ 	alarm(0);
+ 
+-	hname = find_hostname(fromp, hostokp);
++	hname = find_hostname(fromp,no_host_check, hostokp);
+ 
+ 	port = ntohs(fromp->sin_port);
+ 	if (fromp->sin_family != AF_INET ||
+--- a/rlogind/rlogind.c
++++ b/rlogind/rlogind.c
+@@ -84,6 +84,7 @@
+ int use_rhosts = 1;
+ int allow_root_rhosts = 0;
+ int deny_all_rhosts_hequiv = 0;
++static int no_host_check = 0;
+ 
+ static char oobdata[] = {(char)TIOCPKT_WINDOW};
+ static char line[MAXPATHLEN];
+@@ -386,7 +387,7 @@
+     int hostok;
+     char lusername[32], rusername[32], termtype[256];
+ 
+-    hname = network_init(netfd, &hostok);
++    hname = network_init(netfd, no_host_check, &hostok);
+ 
+     getstr(rusername, sizeof(rusername), "remuser too long");
+     getstr(lusername, sizeof(lusername), "locuser too long");
+@@ -439,15 +440,16 @@
+     openlog("rlogind", LOG_PID | LOG_CONS, LOG_AUTH);
+ 
+     opterr = 0;
+-    while ((ch = getopt(argc, argv, "ahLln")) != EOF) {
++    while ((ch = getopt(argc, argv, "ahLlDn")) != EOF) {
+ 	switch (ch) {
+ 	    case 'a': check_all = 1; break;
+ 	    case 'h': allow_root_rhosts = 1; break;
+ 	    case 'L': deny_all_rhosts_hequiv = 1; break;
+ 	    case 'l': use_rhosts = 0; break;
++	    case 'D': no_host_check = 1; break;			      
+ 	    case 'n': keepalive = 0; break;
+ 	    case '?': default:
+-		syslog(LOG_ERR, "usage: rlogind [-ahLln]");
++		syslog(LOG_ERR, "usage: rlogind [-ahLlDn]");
+ 		break;
+ 	}
+     }
+--- a/rlogind/rlogind.h
++++ b/rlogind/rlogind.h
+@@ -3,7 +3,7 @@
+ void fatal(int f, const char *msg, int syserr);
+ 
+ /* network.c */
+-char *network_init(int fd, int *hostokp);
++char *network_init(int fd, int no_host_check, int *hostokp);
+ void network_confirm(void);
+ void network_anticonfirm(void);
+ void network_close(void);
+--- a/rshd/rshd.c
++++ b/rshd/rshd.c
+@@ -90,13 +90,14 @@
+ static pam_handle_t *pamh;
+ #endif /* USE_PAM */
+ 
+-#define	OPTIONS	"ahlLn"
++#define	OPTIONS	"ahlLnD"
+ 
+ static int keepalive = 1;
+ static int check_all = 0;
+ static int paranoid = 0;
+ static int sent_null;
+-static int allow_root_rhosts=0;
++static int allow_root_rhosts = 0;
++static int no_host_check = 0;
+ 
+ char	username[20] = "USER=";
+ char	homedir[64] = "HOME=";
+@@ -305,6 +306,7 @@
+ 	/*
+ 	 * Attempt to confirm the DNS. 
+ 	 */
++
+ #ifdef	RES_DNSRCH
+ 	_res.options &= ~RES_DNSRCH;
+ #endif
+@@ -323,6 +325,8 @@
+ 	}
+ 	syslog(LOG_NOTICE, "Host addr %s not listed for host %s",
+ 	       inet_ntoa(fromp->sin_addr), hp->h_name);
++	if ( no_host_check == 1 ) 
++		return hostname;
+ 	fail("Host address mismatch for %s\n", 
+ 	     remuser, inet_ntoa(fromp->sin_addr), locuser, cmdbuf);
+ 	return NULL; /* not reachable */
+@@ -596,6 +600,10 @@
+ 			paranoid = 1;
+ 			break;
+ 
++		case 'D':
++			no_host_check = 1;
++			break;	
++			
+ 		case '?':
+ 		default:
+ 			syslog(LOG_ERR, "usage: rshd [-%s]", OPTIONS);

--- a/net-misc/netkit-rsh/files/patches/150_all_rexec-netrc.patch
+++ b/net-misc/netkit-rsh/files/patches/150_all_rexec-netrc.patch
@@ -1,0 +1,251 @@
+--- a/rexec/ruserpass.c
++++ b/rexec/ruserpass.c
+@@ -0,0 +1,214 @@
++/*
++ * Copyright (c) 1985 Regents of the University of California.
++ * All rights reserved.
++ *
++ * Redistribution and use in source and binary forms, with or without
++ * modification, are permitted provided that the following conditions
++ * are met:
++ * 1. Redistributions of source code must retain the above copyright
++ *    notice, this list of conditions and the following disclaimer.
++ * 2. Redistributions in binary form must reproduce the above copyright
++ *    notice, this list of conditions and the following disclaimer in the
++ *    documentation and/or other materials provided with the distribution.
++ * 3. All advertising materials mentioning features or use of this software
++ *    must display the following acknowledgement:
++ *	This product includes software developed by the University of
++ *	California, Berkeley and its contributors.
++ * 4. Neither the name of the University nor the names of its contributors
++ *    may be used to endorse or promote products derived from this software
++ *    without specific prior written permission.
++ *
++ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
++ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
++ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
++ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
++ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
++ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
++ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
++ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
++ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
++ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
++ * SUCH DAMAGE.
++ */
++
++/*
++ * from: @(#)ruserpass.c	5.3 (Berkeley) 3/1/91
++ */
++char ruserpass_rcsid[] = 
++  "$Id: 150_all_rexec-netrc.patch,v 1.1 2006/10/14 23:09:28 drizzt Exp $";
++
++#include <stdio.h>
++#include <stdlib.h>
++#include <utmp.h>
++#include <ctype.h>
++#include <sys/stat.h>
++#include <sys/param.h>
++#include <errno.h>
++#include <string.h>
++#include <unistd.h>
++
++static FILE *cfile;
++static int token(void);
++
++#define MACBUF_LEN 4096
++
++#define	DEFAULT	1
++#define	LOGIN	2
++#define	PASSWD	3
++#define	ACCOUNT 4
++#define MACDEF  5
++#define	ID	10
++#define	MACH	11
++
++static char tokval[100];
++
++static struct toktab {
++	const char *tokstr;
++	int tval;
++} toktab[]= {
++	{ "default",	DEFAULT },
++	{ "login",	LOGIN },
++	{ "password",	PASSWD },
++	{ "passwd",	PASSWD },
++	{ "account",	ACCOUNT },
++	{ "machine",	MACH },
++	{ "macdef",	MACDEF },
++	{ NULL,		0 }
++};
++
++int
++xruserpass(const char *host, char **aname, char **apass)
++{
++	const char *hdir;
++	char buf[BUFSIZ], *tmp;
++	char myname[MAXHOSTNAMELEN];
++	const char *mydomain;
++	int t, usedefault = 0;
++	struct stat stb;
++
++	hdir = getenv("HOME");
++	if (hdir == NULL)
++		hdir = ".";
++	snprintf(buf, sizeof(buf), "%s/.netrc", hdir);
++	cfile = fopen(buf, "r");
++	if (cfile == NULL) {
++		if (errno != ENOENT)
++			perror(buf);
++		return(0);
++	}
++	if (gethostname(myname, sizeof(myname)) < 0)
++		myname[0] = '\0';
++	if ((mydomain = strchr(myname, '.')) == NULL)
++		mydomain = "";
++next:
++	while ((t = token())) switch(t) {
++
++	case DEFAULT:
++		usedefault = 1;
++		/* FALL THROUGH */
++
++	case MACH:
++		if (!usedefault) {
++			if (token() != ID)
++				continue;
++			/*
++			 * Allow match of incompletely-specified host in 
++			 * local domain.
++			 */
++			if (strcasecmp(host, tokval) == 0)
++				goto match;
++			if ((tmp = index(host, '.')) != NULL &&
++			    strcasecmp(tmp, mydomain) == 0 &&
++			    strncasecmp(host, tokval, tmp - host) == 0 &&
++			    tokval[tmp - host] == '\0')
++				goto match;
++			continue;
++		}
++	match:
++		while ((t = token()) && t != MACH && t != DEFAULT) switch(t) {
++
++		case LOGIN:
++			if (token()) {
++				if (*aname == 0) { 
++					*aname = malloc((unsigned) strlen(tokval) + 1);
++					(void) strcpy(*aname, tokval);
++				} else {
++					if (strcmp(*aname, tokval))
++						goto next;
++				}
++			}
++			break;
++		case PASSWD:
++			if (*aname==NULL) {
++	fprintf(stderr, "Error: `password' must follow `login' in .netrc\n");
++				goto bad;
++			}
++			if (strcmp(*aname, "anonymous") &&
++			    fstat(fileno(cfile), &stb) >= 0 &&
++			    (stb.st_mode & 077) != 0) {
++	fprintf(stderr, "Error - .netrc file not correct permissions.\n");
++	fprintf(stderr, "Remove password or correct mode (should be 600).\n");
++				goto bad;
++			}
++			if (token() && *apass == 0) {
++				*apass = malloc((unsigned) strlen(tokval) + 1);
++				(void) strcpy(*apass, tokval);
++			}
++			break;
++		case ACCOUNT:
++			break;
++		case MACDEF:
++			break;
++		default:
++	fprintf(stderr, "Unknown .netrc keyword %s\n", tokval);
++			break;
++		}
++		goto done;
++	}
++done:
++	(void) fclose(cfile);
++	return(0);
++bad:
++	(void) fclose(cfile);
++	return(-1);
++}
++
++static 
++int
++token(void)
++{
++	char *cp;
++	int c;
++	struct toktab *t;
++
++	if (feof(cfile))
++		return (0);
++	while ((c = getc(cfile)) != EOF &&
++	    (c == '\n' || c == '\t' || c == ' ' || c == ','))
++		continue;
++	if (c == EOF)
++		return (0);
++	cp = tokval;
++	if (c == '"') {
++		while ((c = getc(cfile)) != EOF && c != '"') {
++			if (c == '\\')
++				c = getc(cfile);
++			*cp++ = c;
++		}
++	} else {
++		*cp++ = c;
++		while ((c = getc(cfile)) != EOF
++		    && c != '\n' && c != '\t' && c != ' ' && c != ',') {
++			if (c == '\\')
++				c = getc(cfile);
++			*cp++ = c;
++		}
++	}
++	*cp = 0;
++	if (tokval[0] == 0)
++		return (0);
++	for (t = toktab; t->tokstr; t++)
++		if (!strcmp(t->tokstr, tokval))
++			return (t->tval);
++	return (ID);
++}
+--- a/rexec/rexec.c
++++ b/rexec/rexec.c
+@@ -100,6 +100,8 @@
+ void echo_sig(int sig);
+ void safe_write_error(const char *message);
+ 
++int xruserpass(const char *host, char **aname, char **apass);
++
+ /* These need to be global for signal passing. */
+ int aux_sock=-1; /* Socket for auxiliary channel. */
+ int extra_error = 1; /* Setup special channel for standard error? */
+@@ -165,7 +167,10 @@
+ 					      a newline. */
+     passwd = getpass("Password: ");
+   } else {
+-
++    if (xruserpass(host, &user_name, &passwd) < 0) {
++	user_name = NULL;
++	passwd = NULL;
++    }
+     if ( user_name == NULL )
+       user_name = getenv("REXEC_USER");
+     if ( user_name == NULL ) {
+--- a/rexec/Makefile.netrc
++++ b/rexec/Makefile
+@@ -11,7 +11,7 @@
+ 
+ all: rexec
+ 
+-rexec: rexec.c
++rexec: rexec.o ruserpass.o
+ 
+ rexec.1:
+ 

--- a/net-misc/netkit-rsh/files/patches/160_all_pam-sess.patch
+++ b/net-misc/netkit-rsh/files/patches/160_all_pam-sess.patch
@@ -1,0 +1,12 @@
+--- a/rexecd/rexecd.c
++++ b/rexecd/rexecd.c
+@@ -307,6 +307,9 @@
+        PAM_BAIL;
+        pam_error = pam_setcred(pamh, PAM_ESTABLISH_CRED);
+        PAM_BAIL;
++       pam_error = pam_open_session(pamh, 0);
++       PAM_BAIL;
++       pam_close_session(pamh, 0);
+        pam_end(pamh, PAM_SUCCESS);
+        /* If this point is reached, the user has been authenticated. */
+        setpwent();

--- a/net-misc/netkit-rsh/files/patches/170_all_errno.patch
+++ b/net-misc/netkit-rsh/files/patches/170_all_errno.patch
@@ -1,0 +1,51 @@
+--- a/rcp/rcp.c
++++ b/rcp/rcp.c
+@@ -613,6 +613,7 @@
+ 	struct stat stb;
+ 	struct timeval tv[2];
+ 	enum { YES, NO, DISPLAYED } wrerr;
++	int werrno = 0;
+ 	BUF *bp;
+ 	off_t i, j, size;
+ 	char ch, *targ;
+@@ -766,6 +767,7 @@
+ 		cp = bp->buf;
+ 		count = 0;
+ 		wrerr = NO;
++		werrno = 0;
+ 		for (i = 0; i < size; i += BUFSIZ) {
+ 			amt = BUFSIZ;
+ 			if (i + amt > size)
+@@ -784,16 +786,20 @@
+ 			} while (amt > 0);
+ 			if (count == bp->cnt) {
+ 				if (wrerr == NO &&
+-				    write(ofd, bp->buf, count) != count)
++				    write(ofd, bp->buf, count) != count) {
+ 					wrerr = YES;
++					werrno = errno;
++				}
+ 				count = 0;
+ 				cp = bp->buf;
+ 			}
+ 		}
+ 		if (count != 0 && wrerr == NO &&
+-		    write(ofd, bp->buf, count) != count)
++		    write(ofd, bp->buf, count) != count) {
+ 			wrerr = YES;
+-		if (ftruncate(ofd, size)) {
++			werrno = errno;
++		}
++		if (wrerr == NO && ftruncate(ofd, size)) {
+ 			error("rcp: can't truncate %s: %s\n", np,
+ 			    strerror(errno));
+ 			wrerr = DISPLAYED;
+@@ -810,7 +816,7 @@
+ 		}
+ 		switch(wrerr) {
+ 		case YES:
+-			error("rcp: %s: %s\n", np, strerror(errno));
++			error("rcp: %s: %s\n", np, strerror(werrno));
+ 			break;
+ 		case NO:
+ 			(void)write(rem, "", 1);

--- a/net-misc/netkit-rsh/files/patches/180_all_rexec-sig.patch
+++ b/net-misc/netkit-rsh/files/patches/180_all_rexec-sig.patch
@@ -1,0 +1,17 @@
+--- a/rexec/rexec.c
++++ b/rexec/rexec.c
+@@ -434,10 +434,10 @@
+     break;
+   default:
+     if ( sigaction(sig, NULL, &action) < 0 )
+-    {
+-      perror(progname);
+-      exit(1);
+-    }
++	    /* in the signal(7) you can found "...except SIGKILL and SIGSTOP",
++	     * but we detect problems with more signals...
++	     */
++	    return;
+     if ( action.sa_handler != SIG_IGN )
+     {
+       action.sa_handler = handler;

--- a/net-misc/netkit-rsh/files/patches/190_all_nohost.patch
+++ b/net-misc/netkit-rsh/files/patches/190_all_nohost.patch
@@ -1,0 +1,63 @@
+--- a/rexecd/rexecd.8
++++ b/rexecd/rexecd.8
+@@ -40,6 +40,16 @@
+ .Nd remote execution server
+ .Sh SYNOPSIS
+ .Nm rexecd
++[
++\fB\-D\fP
++]
++.Sh OPTIONS
++.Nm Rexec
++accepts one option:
++.Pp
++.Bl -tag -width Ds
++.It Sy -D
++Disable reverse DNS look up and in the log will be used client IP addresses.
+ .Sh DESCRIPTION
+ .Nm Rexecd
+ is the server for the 
+--- a/rexecd/rexecd.c
++++ b/rexecd/rexecd.c
+@@ -82,7 +82,9 @@
+ #include <string.h>
+ #include <paths.h>
+ #include <grp.h>
+-
++#include <arpa/inet.h>
++  
++  
+ #ifdef USE_SHADOW
+ #include <shadow.h>
+ #endif
+@@ -141,16 +143,22 @@
+ 		refuse(&from_host);
+ 	remote = hosts_info(&from_host);
+ #else
++	if (argc > 1 && argv[1] && strcmp(argv[1], "-D")==0)
+ 	{
+-	struct hostent *h = gethostbyaddr((const char *)&from.sin_addr,
+-					  sizeof(struct in_addr),
+-					  AF_INET);
+-	if (!h || !h->h_name) {
+-		write(0, "\1Where are you?\n", 16);
+-		return 1;
++		/* use IP in logs -- this is workaround */
++		remote = strdup(inet_ntoa(from.sin_addr));
+ 	}
+-	/* Be advised that this may be utter nonsense. */
+-	remote = strdup(h->h_name);
++	else
++	{
++		struct hostent *h = gethostbyaddr((const char *)&from.sin_addr,
++				  sizeof(struct in_addr),
++				  AF_INET);
++		if (!h || !h->h_name) {
++			write(0, "\1Where are you?\n", 16);
++			return 1;
++		}
++		/* Be advised that this may be utter nonsense. */
++		remote = strdup(h->h_name);
+ 	}
+ #endif
+ 	syslog(allow_severity, "connect from %.128s", remote);

--- a/net-misc/netkit-rsh/files/patches/200_all_ignchld.patch
+++ b/net-misc/netkit-rsh/files/patches/200_all_ignchld.patch
@@ -1,0 +1,22 @@
+--- a/rlogind/rlogind.c
++++ b/rlogind/rlogind.c
+@@ -440,7 +440,7 @@
+     ioctl(master, TIOCPKT, &on);
+     signal(SIGCHLD, cleanup);
+     protocol(netfd, master);
+-    signal(SIGCHLD, SIG_IGN);
++    signal(SIGCHLD, SIG_DFL);
+     cleanup(0);
+ }
+ 
+--- a/rlogin/rlogin.c
++++ b/rlogin/rlogin.c
+@@ -523,7 +523,7 @@
+ stop(char cmdc)
+ {
+ 	mode(0);
+-	signal(SIGCHLD, SIG_IGN);
++	signal(SIGCHLD, SIG_DFL);
+ 	kill(cmdc == defsusp ? 0 : getpid(), SIGTSTP);
+ 	signal(SIGCHLD, catch_child);
+ 	mode(1);

--- a/net-misc/netkit-rsh/files/patches/210_all_checkdir-r1.patch
+++ b/net-misc/netkit-rsh/files/patches/210_all_checkdir-r1.patch
@@ -1,0 +1,23 @@
+--- a/rcp/rcp.c
++++ b/rcp/rcp.c
+@@ -716,6 +716,11 @@
+ 			size = size * 10 + (*cp++ - '0');
+ 		if (*cp++ != ' ')
+ 			SCREWUP("size not delimited");
++		if (*cp == '\0' || strchr(cp, '/') != NULL ||
++		    strcmp(cp, ".") == 0 || strcmp(cp, "..") == 0) {
++			error("error: unexpected filename: %s", cp);
++			exit(1);
++		}
+ 		if (targisdir) {
+ 			static char *namebuf;
+ 			static int cursize;
+@@ -735,6 +739,8 @@
+ 			np = targ;
+ 		exists = stat(np, &stb) == 0;
+ 		if (buf[0] == 'D') {
++			if (!iamrecursive)
++				SCREWUP("received directory without -r");
+ 			if (exists) {
+ 				if ((stb.st_mode&S_IFMT) != S_IFDIR) {
+ 					errno = ENOTDIR;

--- a/net-misc/netkit-rsh/files/patches/220_all_fbsd.patch
+++ b/net-misc/netkit-rsh/files/patches/220_all_fbsd.patch
@@ -1,0 +1,222 @@
+--- a/configure
++++ b/configure
+@@ -368,9 +368,35 @@
+ 
+ ##################################################
+ 
++echo -n 'Checking for rexec... '
++cat <<EOF >__conftest.c
++int main() { rexec(0, 0, 0, 0, 0, 0); }
++
++EOF
++
++if (
++      $CC $CFLAGS  __conftest.c  -o __conftest || exit 1
++   ) >/dev/null 2>&1; then
++    echo 'yes'
++else
++    if (
++          $CC $CFLAGS  __conftest.c -lcompat -o __conftest || exit 1
++       ) >/dev/null 2>&1; then
++        echo '-lcompat'
++        LIBS="$LIBS -lcompat"
++    else
++            echo 'no'
++            echo 'This package requires rexec.'
++            rm -f __conftest*
++            exit
++    fi
++fi
++rm -f __conftest*
++
++##################################################
++
+ echo -n 'Checking for forkpty... '
+ cat <<EOF >__conftest.c
+-#include <pty.h>
+ int main() { forkpty(0, 0, 0, 0); }
+ 
+ EOF
+--- a/rcp/rcp.c
++++ b/rcp/rcp.c
+@@ -50,6 +50,7 @@
+ #include <sys/ioctl.h>
+ #include <sys/socket.h>
+ #include <sys/wait.h>
++#include <netinet/in_systm.h>
+ #include <netinet/in.h>
+ #include <netinet/ip.h>
+ #include <dirent.h>
+@@ -100,7 +101,7 @@
+ static void error(const char *fmt, ...);
+ 
+ int
+-main(int argc, char *argv[])
++main(int argc, char *argv[], char **env)
+ {
+ 	struct servent *sp;
+ 	int ch, fflag, tflag;
+@@ -108,8 +109,8 @@
+ 	const char *shell;
+ 	char *null = NULL;
+ 
+-	saved_environ = __environ;
+-	__environ = &null;
++	saved_environ = env;
++	env = &null;
+ 
+ 	fflag = tflag = 0;
+ 	while ((ch = getopt(argc, argv, OPTIONS)) != EOF)
+--- a/rexec/Makefile
++++ b/rexec/Makefile
+@@ -12,6 +12,7 @@
+ all: rexec
+ 
+ rexec: rexec.o ruserpass.o
++	$(CC) $(CFLAGS) $(LDFLAGS) $^ $(LIBS) -o $@
+ 
+ rexec.1:
+ 
+--- a/rexec/ruserpass.c
++++ b/rexec/ruserpass.c
+@@ -39,6 +39,7 @@
+ 
+ #include <stdio.h>
+ #include <stdlib.h>
++#include <sys/types.h>
+ #include <utmp.h>
+ #include <ctype.h>
+ #include <sys/stat.h>
+--- a/rexecd/rexecd.c
++++ b/rexecd/rexecd.c
+@@ -76,7 +76,9 @@
+ #include <errno.h>
+ #include <syslog.h>
+ #include <unistd.h>
++#if defined(__GLIBC__)
+ #include <crypt.h>    /* apparently necessary in some glibcs */
++#endif
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>
+--- a/rlogin/rlogin.c
++++ b/rlogin/rlogin.c
+@@ -56,6 +56,7 @@
+ #include <sys/resource.h>
+ #include <sys/wait.h>
+ #include <sys/ioctl.h>
++#include <netinet/in_systm.h>
+ #include <netinet/in.h>
+ #include <netinet/ip.h>
+ #include <netdb.h>
+@@ -96,6 +97,13 @@
+ #define	SIGUSR1	30
+ #endif
+ 
++#ifndef TABDLY
++#define TABDLY OXTABS
++#endif
++#ifndef TAB3
++#define TAB3 OXTABS
++#endif
++
+ struct termios defmodes;
+ struct termios ixon_state;
+ static int eight, litout, rem;
+@@ -172,7 +180,7 @@
+ }
+ 
+ int
+-main(int argc, char **argv)
++main(int argc, char **argv, char **env)
+ {
+ 	struct passwd *pw;
+ 	struct servent *sp;
+@@ -265,7 +273,7 @@
+   	}
+ 	else snprintf(term, sizeof(term), "%.256s", t);
+ 
+-	__environ = &null;
++	env = &null;
+ 
+ 	get_window_size(0, &winsize);
+ 
+@@ -421,7 +429,7 @@
+ void
+ catch_child(int ignore)
+ {
+-	union wait status;
++	int status;
+ 	int pid;
+ 
+ 	(void)ignore;
+@@ -432,7 +440,7 @@
+ 			return;
+ 		/* if the child (reader) dies, just quit */
+ 		if (pid < 0 || (pid == childpid && !WIFSTOPPED(status)))
+-			done((int)(status.w_termsig | status.w_retcode));
++			done((int)(WTERMSIG(status) | WEXITSTATUS(status)));
+ 	}
+ 	/* NOTREACHED */
+ }
+--- a/rlogind/auth.c
++++ b/rlogind/auth.c
+@@ -31,6 +31,7 @@
+  * SUCH DAMAGE.
+  */
+ 
++#include <stdio.h>
+ #include <sys/types.h>
+ #include <pwd.h>
+ 
+@@ -190,7 +191,7 @@
+ #include <sys/socket.h>   /* for ruserok() in libc5 (!) */
+ #include <netdb.h>        /* for ruserok() in glibc (!) */
+ 
+-#if defined(__GLIBC__) && (__GLIBC__ >= 2)
++#if !(defined(__GLIBC__) && (__GLIBC__ < 2))
+ #define _check_rhosts_file  __check_rhosts_file
+ #endif
+ extern int _check_rhosts_file;
+--- a/rsh/rsh.c
++++ b/rsh/rsh.c
+@@ -69,7 +69,7 @@
+ static void usage(void);
+ 
+ int
+-main(int argc, char *argv[])
++main(int argc, char *argv[], char **env)
+ {
+ 	struct passwd *pw;
+ 	struct servent *sp;
+@@ -80,8 +80,8 @@
+ 	char *null = NULL;
+ 	char **saved_environ;
+ 
+-	saved_environ = __environ;
+-	__environ = &null;
++	saved_environ = env;
++	env = &null;
+ 
+ 	argoff = asrsh = dflag = nflag = 0;
+ 	one = 1;
+--- a/rshd/rshd.c
++++ b/rshd/rshd.c
+@@ -80,7 +80,7 @@
+ #include <ctype.h>
+ #include <assert.h>
+ 
+-#if defined(__GLIBC__) && (__GLIBC__ >= 2)
++#if !(defined(__GLIBC__) && (__GLIBC__ < 2))
+ #define _check_rhosts_file  __check_rhosts_file
+ #endif
+ 
+@@ -420,7 +420,7 @@
+ 			stderr_parent(sock, pv[0], pid);
+ 			/* NOTREACHED */
+ 		}
+-		setpgrp();
++		setpgid(0,0);
+ 		close(sock); 
+ 		close(pv[0]);
+ 		dup2(pv[1], 2);

--- a/net-misc/netkit-rsh/files/patches/230_all_MAX_ARG.patch
+++ b/net-misc/netkit-rsh/files/patches/230_all_MAX_ARG.patch
@@ -1,0 +1,96 @@
+fix building when ARG_MAX is not defined
+
+patch by Tom-Steve Watzke
+
+http://bugs.gentoo.org/225341
+
+--- a/rexecd/rexecd.c
++++ b/rexecd/rexecd.c
+@@ -85,6 +85,7 @@ char rcsid[] =
+ #include <paths.h>
+ #include <grp.h>
+ #include <arpa/inet.h>
++#include <limits.h>
+   
+   
+ #ifdef USE_SHADOW
+@@ -233,7 +234,8 @@ static struct pam_conv PAM_conversation = {
+ static void
+ doit(struct sockaddr_in *fromp)
+ {
+-	char cmdbuf[ARG_MAX+1];
++	char *cmdbuf;
++	int cmdbuflen;
+ 	char user[16], pass[16];
+ 	struct passwd *pwd;
+ 	int s = -1;
+@@ -252,6 +254,15 @@ doit(struct sockaddr_in *fromp)
+ #endif
+ #endif /* USE_PAM */
+ 
++	cmdbuflen = sysconf(_SC_ARG_MAX);
++	if (cmdbuflen < _POSIX_ARG_MAX)
++		cmdbuflen = _POSIX_ARG_MAX;
++	cmdbuf = malloc(cmdbuflen);
++	if (cmdbuf == NULL) {
++		syslog(LOG_ERR, "unable to malloc(%i) for command buffer: %s", cmdbuflen, strerror(errno));
++		fatal("out of memory\n");
++	}
++
+ 	signal(SIGINT, SIG_DFL);
+ 	signal(SIGQUIT, SIG_DFL);
+ 	signal(SIGTERM, SIG_DFL);
+@@ -301,7 +312,7 @@ doit(struct sockaddr_in *fromp)
+ 
+ 	getstr(user, sizeof(user), "username too long\n");
+ 	getstr(pass, sizeof(pass), "password too long\n");
+-	getstr(cmdbuf, sizeof(cmdbuf), "command too long\n");
++	getstr(cmdbuf, cmdbuflen, "command too long\n");
+ #ifdef USE_PAM
+        #define PAM_BAIL if (pam_error != PAM_SUCCESS) { \
+ 	       pam_end(pamh, pam_error); exit(1); \
+--- a/rshd/rshd.c
++++ b/rshd/rshd.c
+@@ -79,6 +79,7 @@ char rcsid[] =
+ #include <stdarg.h>
+ #include <ctype.h>
+ #include <assert.h>
++#include <limits.h>
+ 
+ #if !(defined(__GLIBC__) && (__GLIBC__ < 2))
+ #define _check_rhosts_file  __check_rhosts_file
+@@ -337,7 +338,8 @@ static const char *findhostname(struct sockaddr_in *fromp,
+ static void
+ doit(struct sockaddr_in *fromp)
+ {
+-	char cmdbuf[ARG_MAX+1];
++	char *cmdbuf;
++	int cmdbuflen;
+ 	const char *theshell, *shellname;
+ 	char locuser[16], remuser[16];
+ 	struct passwd *pwd;
+@@ -346,6 +348,15 @@ doit(struct sockaddr_in *fromp)
+ 	u_short port;
+ 	int pv[2], pid, ifd;
+ 
++	cmdbuflen = sysconf(_SC_ARG_MAX);
++	if (cmdbuflen < _POSIX_ARG_MAX)
++		cmdbuflen = _POSIX_ARG_MAX;
++	cmdbuf = malloc(cmdbuflen);
++	if (cmdbuf == NULL) {
++		syslog(LOG_ERR, "unable to malloc(%i) for command buffer: %s", cmdbuflen, strerror(errno));
++		exit(1);
++	}
++
+ 	signal(SIGINT, SIG_DFL);
+ 	signal(SIGQUIT, SIG_DFL);
+ 	signal(SIGTERM, SIG_DFL);
+@@ -382,7 +393,7 @@ doit(struct sockaddr_in *fromp)
+ 
+ 	getstr(remuser, sizeof(remuser), "remuser");
+ 	getstr(locuser, sizeof(locuser), "locuser");
+-	getstr(cmdbuf, sizeof(cmdbuf), "command");
++	getstr(cmdbuf, cmdbuflen, "command");
+ 	if (!strcmp(locuser, "root")) paranoid = 1;
+ 
+ 	hostname = findhostname(fromp, remuser, locuser, cmdbuf);

--- a/net-misc/netkit-rsh/metadata.xml
+++ b/net-misc/netkit-rsh/metadata.xml
@@ -1,5 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<!-- maintainer-needed -->
+	<maintainer type="person" proxied="yes">
+		<email>hlein@korelogic.com</email>
+		<name>Hank Leininger</name>
+	</maintainer>
+	<maintainer type="project" proxied="proxy">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
 </pkgmetadata>

--- a/net-misc/netkit-rsh/netkit-rsh-0.17-r12.ebuild
+++ b/net-misc/netkit-rsh/netkit-rsh-0.17-r12.ebuild
@@ -1,0 +1,78 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit pam toolchain-funcs fcaps
+
+DESCRIPTION="Netkit's Remote Shell Suite: rexec{,d} rlogin{,d} rsh{,d}"
+HOMEPAGE="ftp://ftp.uk.linux.org/pub/linux/Networking/netkit/"
+SRC_URI="ftp://ftp.uk.linux.org/pub/linux/Networking/netkit/${P}.tar.gz
+	mirror://gentoo/rexec-1.5.tar.gz"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux"
+IUSE="pam"
+
+RDEPEND="
+	sys-libs/ncurses:=
+	pam? ( >=sys-auth/pambase-20080219.1 )"
+DEPEND="${RDEPEND}"
+BDEPEND="app-arch/xz-utils"
+
+PATCHES=(
+	"${FILESDIR}"/patches/
+)
+
+FILECAPS=( cap_net_bind_service usr/bin/r{cp,login,sh} )
+
+src_prepare() {
+	# This must happen before patches are applied
+	rm -r rexec || die
+	mv ../rexec rexec || die
+
+	default
+
+	if tc-is-cross-compiler ; then
+		# Can't do runtime tests when cross-compiling
+		sed -i -e "s|./__conftest|: ./__conftest|" configure || die
+	fi
+}
+
+src_configure() {
+	tc-export CC
+	${CONFIG_SHELL:-/bin/sh} ./configure $(usex pam '' '--without-pam') || die
+
+	sed -i \
+		-e "s|-pipe -O2|${CFLAGS}|" \
+		-e "/^LDFLAGS=$/d" \
+		-e "s|-Wpointer-arith||" \
+		MCONFIG || die
+}
+
+src_install() {
+	insinto /etc/xinetd.d
+
+	local b
+	for b in rcp rexec{,d} rlogin{,d} rsh{,d} ; do
+		if [[ ${b} == *d ]] ; then
+			dosbin ${b}/${b}
+			dosym ${b} /usr/sbin/in.${b}
+			doman ${b}/${b}.8
+		else
+			dobin ${b}/${b}
+			doman ${b}/${b}.1
+			if [[ ${b} != rcp ]]; then
+				newins "${FILESDIR}"/${b}.xinetd ${b}
+
+				if use pam; then
+					newpamd "${FILESDIR}/${b}.pamd-pambase" ${b}
+				fi
+			fi
+		fi
+	done
+
+	dodoc README ChangeLog BUGS
+	newdoc rexec/README README.rexec
+}

--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -62,10 +62,6 @@ dev-java/jibx-tools
 # Removal on 2021-07-19.  Bug #786279.
 app-misc/rq
 
-# John Helmert III <ajak@gentoo.org> (2021-06-19)
-# Unmaintained, open security bug.
-# Removal on 2021-07-19.  Bug #717794.
-net-misc/netkit-rsh
 
 # Michał Górny <mgorny@gentoo.org> (2021-06-19)
 # Conflicts with app-arch/brotli[python].  Discontinued in favor


### PR DESCRIPTION
This updates one of our existing patches with Debian's fix for
CVE-2019-7282 and CVE-2019-7283.

Signed-off-by: Hank Leininger <hlein@korelogic.com>
Bug: https://bugs.gentoo.org/717794
Package-Manager: Portage-3.0.20, Repoman-3.0.3