### PR TITLE
dev-util/bear: add libfmt subslot dep

### DIFF
--- a/dev-util/bear/bear-3.0.11-r1.ebuild
+++ b/dev-util/bear/bear-3.0.11-r1.ebuild
@@ -19,7 +19,7 @@ IUSE="test"
 RDEPEND="
 	>=dev-cpp/nlohmann_json-3.7:=
 	>=dev-db/sqlite-3.14:=
-	>=dev-libs/libfmt-6.2
+	>=dev-libs/libfmt-6.2:=
 	dev-libs/protobuf:=
 	>=dev-libs/spdlog-1.5
 	>=net-libs/grpc-1.26:=

--- a/dev-util/bear/bear-3.0.12.ebuild
+++ b/dev-util/bear/bear-3.0.12.ebuild
@@ -19,7 +19,7 @@ IUSE="test"
 RDEPEND="
 	>=dev-cpp/nlohmann_json-3.7:=
 	>=dev-db/sqlite-3.14:=
-	>=dev-libs/libfmt-6.2
+	>=dev-libs/libfmt-6.2:=
 	dev-libs/protobuf:=
 	>=dev-libs/spdlog-1.5
 	>=net-libs/grpc-1.26:=


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/797715
Package-Manager: Portage-3.0.20, Repoman-3.0.3
Signed-off-by: Daniel M. Weeks <dan@danweeks.net>