### PR TITLE
net-libs/NativeThread: min java 1.8

### DIFF
--- a/net-libs/NativeThread/NativeThread-0_pre20190914-r1.ebuild
+++ b/net-libs/NativeThread/NativeThread-0_pre20190914-r1.ebuild
@@ -1,0 +1,30 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit flag-o-matic java-pkg-2 toolchain-funcs
+
+DESCRIPTION="NativeThread for priorities on linux for freenet"
+HOMEPAGE="http://www.freenetproject.org/"
+SRC_URI="mirror://gentoo/${P}.tar.bz2"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+DEPEND=">=net-p2p/freenet-0.7
+	virtual/jdk:1.8"
+
+S="${WORKDIR}"
+
+src_compile() {
+	append-flags -fPIC
+	tc-export CC
+	emake
+}
+
+src_install() {
+	dolib.so lib${PN}.so
+	dosym lib${PN}.so /usr/$(get_libdir)/libnative.so
+}


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/787629
restricted to :1.8 as it doesn't work with java 11

Package-Manager: Portage-3.0.20, Repoman-3.0.2
Signed-off-by: Volkmar W. Pogatzki <gentoo@pogatzki.net>