### PR TITLE
gnome-base/{gnome, gnome-core-apps, gnome-core-libs, gnome-extra-apps, gnome-shell}, gnome-extra/{gnome-boxes, gnome-search-tool, gnome-shell-frippery, gnome-tweaks}, x11-misc/libinput-gestures, x11-wm/mutter: Update gnome description

### DIFF
--- a/gnome-base/gnome-core-apps/gnome-core-apps-40.0.ebuild
+++ b/gnome-base/gnome-core-apps/gnome-core-apps-40.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-DESCRIPTION="Sub-meta package for the core applications integrated with GNOME 3"
+DESCRIPTION="Sub-meta package for the core applications integrated with GNOME 4"
 HOMEPAGE="https://www.gnome.org/"
 LICENSE="metapackage"
 SLOT="3.0"

--- a/gnome-base/gnome-core-libs/gnome-core-libs-40.0.ebuild
+++ b/gnome-base/gnome-core-libs/gnome-core-libs-40.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-DESCRIPTION="Sub-meta package for the core libraries of GNOME 3"
+DESCRIPTION="Sub-meta package for the core libraries of GNOME 4"
 HOMEPAGE="https://www.gnome.org/"
 LICENSE="metapackage"
 SLOT="3.0"
@@ -14,7 +14,7 @@ IUSE="cups python"
 KEYWORDS="amd64 ~arm ~arm64 ~ppc64 x86"
 
 # Note to developers:
-# This is a wrapper for the core libraries used by GNOME 3
+# This is a wrapper for the core libraries used by GNOME 4
 RDEPEND="
 	>=dev-libs/glib-2.68.0:2
 	>=x11-libs/gdk-pixbuf-2.42.4:2

--- a/gnome-base/gnome-extra-apps/gnome-extra-apps-40.0.ebuild
+++ b/gnome-base/gnome-extra-apps/gnome-extra-apps-40.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-DESCRIPTION="Sub-meta package for the applications of GNOME 3"
+DESCRIPTION="Sub-meta package for the applications of GNOME 4"
 HOMEPAGE="https://www.gnome.org/"
 LICENSE="metapackage"
 SLOT="3.0"
@@ -12,7 +12,7 @@ IUSE="+games share +shotwell +tracker"
 KEYWORDS="amd64 ~arm64 x86"
 
 # Note to developers:
-# This is a wrapper for the extra apps integrated with GNOME 3
+# This is a wrapper for the extra apps integrated with GNOME 4
 # Keep pkg order within a USE flag as upstream releng versions file
 # TODO: Should we keep these here: gnome-dictionary, gucharmap, sound-juicer, vinagre; replace gucharmap with gnome-characters?
 # TODO: Add gnome-remote-desktop as replacement for vino that was removed from meta in 3.36?

--- a/gnome-base/gnome-shell/gnome-shell-40.1-r1.ebuild
+++ b/gnome-base/gnome-shell/gnome-shell-40.1-r1.ebuild
@@ -6,7 +6,7 @@ PYTHON_COMPAT=( python3_{7,8,9} )
 
 inherit gnome.org gnome2-utils meson python-single-r1 virtualx xdg
 
-DESCRIPTION="Provides core UI functions for the GNOME 3 desktop"
+DESCRIPTION="Provides core UI functions for the GNOME 4 desktop"
 HOMEPAGE="https://wiki.gnome.org/Projects/GnomeShell"
 SRC_URI+=" https://dev.gentoo.org/~leio/distfiles/${PF}-patchset.tar.xz"
 

--- a/gnome-base/gnome-shell/gnome-shell-40.1.ebuild
+++ b/gnome-base/gnome-shell/gnome-shell-40.1.ebuild
@@ -6,7 +6,7 @@ PYTHON_COMPAT=( python3_{7,8,9} )
 
 inherit gnome.org gnome2-utils meson python-single-r1 virtualx xdg
 
-DESCRIPTION="Provides core UI functions for the GNOME 3 desktop"
+DESCRIPTION="Provides core UI functions for the GNOME 4 desktop"
 HOMEPAGE="https://wiki.gnome.org/Projects/GnomeShell"
 
 LICENSE="GPL-2+ LGPL-2+"

--- a/gnome-base/gnome-shell/gnome-shell-40.2.ebuild
+++ b/gnome-base/gnome-shell/gnome-shell-40.2.ebuild
@@ -6,7 +6,7 @@ PYTHON_COMPAT=( python3_{7,8,9} )
 
 inherit gnome.org gnome2-utils meson python-single-r1 virtualx xdg
 
-DESCRIPTION="Provides core UI functions for the GNOME 3 desktop"
+DESCRIPTION="Provides core UI functions for the GNOME 4 desktop"
 HOMEPAGE="https://wiki.gnome.org/Projects/GnomeShell"
 
 LICENSE="GPL-2+ LGPL-2+"

--- a/gnome-base/gnome/gnome-40.0.ebuild
+++ b/gnome-base/gnome/gnome-40.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-DESCRIPTION="Meta package for GNOME 3, merge this package to install"
+DESCRIPTION="Meta package for GNOME 4, merge this package to install"
 HOMEPAGE="https://www.gnome.org/"
 
 LICENSE="metapackage"

--- a/gnome-extra/gnome-boxes/gnome-boxes-40.1.ebuild
+++ b/gnome-extra/gnome-boxes/gnome-boxes-40.1.ebuild
@@ -7,7 +7,7 @@ VALA_MIN_API_VERSION="0.40"
 
 inherit gnome.org gnome2-utils linux-info meson readme.gentoo-r1 vala xdg
 
-DESCRIPTION="Simple GNOME 3 application to access remote or virtual systems"
+DESCRIPTION="Simple GNOME 4 application to access remote or virtual systems"
 HOMEPAGE="https://wiki.gnome.org/Apps/Boxes"
 
 LICENSE="LGPL-2+ CC-BY-2.0"

--- a/gnome-extra/gnome-boxes/gnome-boxes-40.2.ebuild
+++ b/gnome-extra/gnome-boxes/gnome-boxes-40.2.ebuild
@@ -7,7 +7,7 @@ VALA_MIN_API_VERSION="0.40"
 
 inherit gnome.org gnome2-utils linux-info meson readme.gentoo-r1 vala xdg
 
-DESCRIPTION="Simple GNOME 3 application to access remote or virtual systems"
+DESCRIPTION="Simple GNOME 4 application to access remote or virtual systems"
 HOMEPAGE="https://wiki.gnome.org/Apps/Boxes"
 
 LICENSE="LGPL-2+ CC-BY-2.0"

--- a/gnome-extra/gnome-search-tool/gnome-search-tool-3.6.0.ebuild
+++ b/gnome-extra/gnome-search-tool/gnome-search-tool-3.6.0.ebuild
@@ -7,7 +7,7 @@ GNOME2_LA_PUNT="yes"
 
 inherit gnome2
 
-DESCRIPTION="Search tool for GNOME 3"
+DESCRIPTION="Search tool for GNOME 4"
 HOMEPAGE="https://wiki.gnome.org/Apps/Attic/GnomeUtils"
 
 LICENSE="GPL-2 FDL-1.1"

--- a/gnome-extra/gnome-shell-frippery/gnome-shell-frippery-40.0.ebuild
+++ b/gnome-extra/gnome-shell-frippery/gnome-shell-frippery-40.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-DESCRIPTION="Unofficial extension pack providing GNOME 2-like features for GNOME 3"
+DESCRIPTION="Unofficial extension pack providing GNOME 2-like features for GNOME 4"
 HOMEPAGE="http://frippery.org/extensions/index.html"
 SRC_URI="http://frippery.org/extensions/${P}.tgz"
 

--- a/gnome-extra/gnome-tweaks/gnome-tweaks-40.0.ebuild
+++ b/gnome-extra/gnome-tweaks/gnome-tweaks-40.0.ebuild
@@ -6,7 +6,7 @@ PYTHON_COMPAT=( python3_{7..9} )
 
 inherit gnome.org meson python-single-r1 xdg
 
-DESCRIPTION="Customize advanced GNOME 3 options"
+DESCRIPTION="Customize advanced GNOME 4 options"
 HOMEPAGE="https://wiki.gnome.org/Apps/Tweaks"
 
 LICENSE="GPL-3+ CC0-1.0"

--- a/x11-misc/libinput-gestures/libinput-gestures-2.56.ebuild
+++ b/x11-misc/libinput-gestures/libinput-gestures-2.56.ebuild
@@ -45,7 +45,7 @@ pkg_postinst() {
 	elog "You must be in the input group to read the touchpad device."
 
 	if ! has_version x11-libs/gtk+:3 ; then
-		elog "${PN}-setup script supports Gnome 3 via x11-libs/gtk+:3."
+		elog "${PN}-setup script supports Gnome 4 via x11-libs/gtk+:3."
 	fi
 	if ! has_version kde-plasma/kde-cli-tools:5 ; then
 		elog "${PN}-setup script supports Plasma 5 via kde-plasma/kde-cli-tools:5."

--- a/x11-misc/libinput-gestures/libinput-gestures-9999.ebuild
+++ b/x11-misc/libinput-gestures/libinput-gestures-9999.ebuild
@@ -45,7 +45,7 @@ pkg_postinst() {
 	elog "You must be in the input group to read the touchpad device."
 
 	if ! has_version x11-libs/gtk+:3 ; then
-		elog "${PN}-setup script supports Gnome 3 via x11-libs/gtk+:3."
+		elog "${PN}-setup script supports Gnome 4 via x11-libs/gtk+:3."
 	fi
 	if ! has_version kde-plasma/kde-cli-tools:5 ; then
 		elog "${PN}-setup script supports Plasma 5 via kde-plasma/kde-cli-tools:5."

--- a/x11-wm/mutter/mutter-40.1-r2.ebuild
+++ b/x11-wm/mutter/mutter-40.1-r2.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 inherit gnome.org gnome2-utils meson udev virtualx xdg
 
-DESCRIPTION="GNOME 3 compositing window manager based on Clutter"
+DESCRIPTION="GNOME 4 compositing window manager based on Clutter"
 HOMEPAGE="https://gitlab.gnome.org/GNOME/mutter/"
 
 LICENSE="GPL-2+"

--- a/x11-wm/mutter/mutter-40.1-r4.ebuild
+++ b/x11-wm/mutter/mutter-40.1-r4.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 inherit gnome.org gnome2-utils meson udev virtualx xdg
 
-DESCRIPTION="GNOME 3 compositing window manager based on Clutter"
+DESCRIPTION="GNOME 4 compositing window manager based on Clutter"
 HOMEPAGE="https://gitlab.gnome.org/GNOME/mutter/"
 SRC_URI+=" https://dev.gentoo.org/~leio/distfiles/${P}-r1-patchset.tar.xz"
 

--- a/x11-wm/mutter/mutter-40.2-r1.ebuild
+++ b/x11-wm/mutter/mutter-40.2-r1.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 inherit gnome.org gnome2-utils meson udev virtualx xdg
 
-DESCRIPTION="GNOME 3 compositing window manager based on Clutter"
+DESCRIPTION="GNOME 4 compositing window manager based on Clutter"
 HOMEPAGE="https://gitlab.gnome.org/GNOME/mutter/"
 
 LICENSE="GPL-2+"

--- a/x11-wm/mutter/mutter-40.2.1.ebuild
+++ b/x11-wm/mutter/mutter-40.2.1.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 inherit gnome.org gnome2-utils meson udev virtualx xdg
 
-DESCRIPTION="GNOME 3 compositing window manager based on Clutter"
+DESCRIPTION="GNOME 4 compositing window manager based on Clutter"
 HOMEPAGE="https://gitlab.gnome.org/GNOME/mutter/"
 
 LICENSE="GPL-2+"


### PR DESCRIPTION
GNOME 3 in so longer available in repo.
Signed-off-by: Jakub Ternka ternka122@gmail.com