### PR TITLE
dev-python/pillow: unmask USE=[imagequannt,test] for ARCH=riscv

### DIFF
--- a/app-arch/cabextract/cabextract-1.9.1.ebuild
+++ b/app-arch/cabextract/cabextract-1.9.1.ebuild
@@ -12,7 +12,7 @@ if [[ ${PV} == "9999" ]] ; then
 
 	LIBMSPACK_DEPEND="~dev-libs/libmspack-9999:="
 else
-	KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~mips ppc ppc64 ~s390 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
+	KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
 	MY_PV="${PV/_alpha/alpha}"
 	MY_P="${PN}-${MY_PV}"
 	SRC_URI="https://www.cabextract.org.uk/${P}.tar.gz"

--- a/app-text/djvu/djvu-3.5.28-r1.ebuild
+++ b/app-text/djvu/djvu-3.5.28-r1.ebuild
@@ -13,7 +13,7 @@ S="${WORKDIR}/${MY_P%%.3}"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~mips ppc ppc64 ~s390 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-solaris"
+KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-solaris"
 IUSE="debug doc jpeg tiff xml"
 
 RDEPEND="jpeg? ( virtual/jpeg:0 )

--- a/dev-libs/libmspack/libmspack-0.10.1_alpha.ebuild
+++ b/dev-libs/libmspack/libmspack-0.10.1_alpha.ebuild
@@ -10,7 +10,7 @@ if [[ ${PV} == "9999" ]] ; then
 	inherit git-r3
 	MY_P="${PN}-9999"
 else
-	KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ppc ppc64 ~s390 sparc x86 ~x64-macos ~x64-solaris"
+	KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ppc ppc64 ~riscv ~s390 sparc x86 ~x64-macos ~x64-solaris"
 	MY_PV="${PV/_alpha/alpha}"
 	MY_P="${PN}-${MY_PV}"
 	SRC_URI="https://www.cabextract.org.uk/libmspack/libmspack-${MY_PV}.tar.gz"

--- a/dev-libs/libzip/libzip-1.8.0.ebuild
+++ b/dev-libs/libzip/libzip-1.8.0.ebuild
@@ -11,7 +11,7 @@ SRC_URI="https://www.nih.at/libzip/${P}.tar.xz"
 
 LICENSE="BSD"
 SLOT="0/5"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~riscv ~sparc ~x86 ~amd64-linux ~x86-linux"
 IUSE="bzip2 gnutls lzma mbedtls ssl static-libs test tools"
 REQUIRED_USE="test? ( tools )"
 

--- a/media-fonts/corefonts/corefonts-1-r7.ebuild
+++ b/media-fonts/corefonts/corefonts-1-r7.ebuild
@@ -20,7 +20,7 @@ S="${WORKDIR}"
 
 LICENSE="MSttfEULA"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~mips ppc ppc64 ~s390 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~x64-solaris ~x86-solaris ~x86-winnt"
+KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~x64-solaris ~x86-solaris ~x86-winnt"
 IUSE="X tahoma"
 
 BDEPEND="app-arch/cabextract"

--- a/media-gfx/imagemagick/imagemagick-7.1.0.0.ebuild
+++ b/media-gfx/imagemagick/imagemagick-7.1.0.0.ebuild
@@ -13,7 +13,7 @@ else
 	MY_PV="$(ver_rs 3 '-')"
 	MY_P="ImageMagick-${MY_PV}"
 	SRC_URI="mirror://imagemagick/${MY_P}.tar.xz"
-	KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~mips ppc ppc64 ~s390 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
+	KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
 fi
 
 DESCRIPTION="A collection of tools and libraries for many image formats"

--- a/media-gfx/libimagequant/libimagequant-2.15.1.ebuild
+++ b/media-gfx/libimagequant/libimagequant-2.15.1.ebuild
@@ -11,7 +11,7 @@ SRC_URI="https://github.com/ImageOptim/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz
 
 LICENSE="GPL-3"
 SLOT="0/0"
-KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ppc ppc64 sparc x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ppc ppc64 ~riscv sparc x86 ~amd64-linux ~x86-linux"
 IUSE="cpu_flags_x86_sse2 openmp"
 
 PATCHES=(

--- a/media-gfx/potrace/potrace-1.16.ebuild
+++ b/media-gfx/potrace/potrace-1.16.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ SRC_URI="http://potrace.sourceforge.net/download/${PV}/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ppc ppc64 ~s390 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos"
+KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos"
 IUSE="metric"
 
 RDEPEND="sys-libs/zlib:="

--- a/media-libs/ilmbase/ilmbase-2.5.7.ebuild
+++ b/media-libs/ilmbase/ilmbase-2.5.7.ebuild
@@ -13,7 +13,7 @@ S="${WORKDIR}/openexr-${PV}/IlmBase"
 
 LICENSE="BSD"
 SLOT="0/25" # based on SONAME
-KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~x86-linux ~x64-macos ~x86-solaris"
+KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~riscv ~sparc ~x86 ~amd64-linux ~x86-linux ~x64-macos ~x86-solaris"
 IUSE="large-stack static-libs test"
 RESTRICT="!test? ( test )"
 

--- a/media-libs/libfpx/libfpx-1.3.1_p10.ebuild
+++ b/media-libs/libfpx/libfpx-1.3.1_p10.ebuild
@@ -10,7 +10,7 @@ SRC_URI="mirror://imagemagick/delegates/${P/_p/-}.tar.bz2"
 
 LICENSE="Flashpix"
 SLOT="0/1"
-KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~m68k ~mips ppc ppc64 ~s390 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-solaris"
+KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-solaris"
 IUSE="static-libs"
 
 S=${WORKDIR}/${P/_p/-}

--- a/media-libs/liblqr/liblqr-0.4.2-r1.ebuild
+++ b/media-libs/liblqr/liblqr-0.4.2-r1.ebuild
@@ -9,7 +9,7 @@ SRC_URI="https://liblqr.wikidot.com/local--files/en:download-page/${PN}-1-${PV}.
 
 LICENSE="|| ( GPL-3 LGPL-3 )"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 hppa ~mips ppc ppc64 x86"
+KEYWORDS="~alpha amd64 arm arm64 hppa ~mips ppc ppc64 ~riscv x86"
 
 RDEPEND="dev-libs/glib:2"
 DEPEND="${RDEPEND}"

--- a/media-libs/libraw/libraw-0.20.2.ebuild
+++ b/media-libs/libraw/libraw-0.20.2.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://www.libraw.org/data/${MY_P}.tar.gz"
 
 LICENSE="LGPL-2.1 CDDL"
 SLOT="0/20"
-KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~mips ppc ppc64 sparc x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~mips ppc ppc64 ~riscv sparc x86 ~amd64-linux ~x86-linux"
 IUSE="examples jpeg +lcms openmp"
 
 RDEPEND="jpeg? ( >=virtual/jpeg-0-r2:0[${MULTILIB_USEDEP}] )

--- a/net-libs/mbedtls/mbedtls-2.26.0.ebuild
+++ b/net-libs/mbedtls/mbedtls-2.26.0.ebuild
@@ -12,7 +12,7 @@ S=${WORKDIR}/${PN}-${P}
 
 LICENSE="Apache-2.0"
 SLOT="0/6.13.1" # ffmpeg subslot naming: SONAME tuple of {libmbedcrypto.so,libmbedtls.so,libmbedx509.so}
-KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~m68k ~mips ppc ppc64 ~s390 sparc x86"
+KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86"
 IUSE="cpu_flags_x86_sse2 doc havege programs static-libs test threads zlib"
 RESTRICT="!test? ( test )"
 

--- a/profiles/arch/riscv/package.use.mask
+++ b/profiles/arch/riscv/package.use.mask
@@ -1,6 +1,10 @@
 # Copyright 2019-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Ye Cao <ye.c@rioslab.org> (2021-06-24)
+# Dependencies not keyworded, not tested
+media-gfx/imagemagick fftw openexr wmf
+
 # Marek Szuba <marecki@gentoo.org> (2021-06-22)
 # Dependencies not keyworded here yet
 dev-python/pillow imagequant test tk

--- a/profiles/arch/riscv/package.use.mask
+++ b/profiles/arch/riscv/package.use.mask
@@ -7,7 +7,7 @@ media-gfx/imagemagick fftw openexr wmf
 
 # Marek Szuba <marecki@gentoo.org> (2021-06-22)
 # Dependencies not keyworded here yet
-dev-python/pillow imagequant test tk
+dev-python/pillow tk
 
 # Marek Szuba <marecki@gentoo.org> (2021-06-21)
 # net-libs/mbedtls not keyworded here, not tested


### PR DESCRIPTION
dev-python/pillow: unmask USE=[imagequannt,test] for ARCH=riscv
Also, keyworded ARCH=riscv on some dependent packages

Bug: https://bugs.gentoo.org/797334
Signed-off-by: Ye Cao <ye.c@rioslab.org>