### PR TITLE
app-emulation/virt-manager: Update live ebuild

### DIFF
--- a/app-emulation/virt-manager/virt-manager-9999.ebuild
+++ b/app-emulation/virt-manager/virt-manager-9999.ebuild
@@ -72,8 +72,6 @@ python_install() {
 src_install() {
 	local mydistutilsargs=( --no-update-icon-cache --no-compile-schemas )
 	distutils-r1_src_install
-
-	python_fix_shebang "${ED}"/usr/share/virt-manager
 }
 
 pkg_preinst() {


### PR DESCRIPTION
There was a patch merged recently into upstream repo
(v3.2.0-110-geb6b7939) that removes shebangs from library paths.
Thus we no longed need to fix them during install phase.

Signed-off-by: Michal Privoznik <mprivozn@redhat.com>