### PR TITLE
net-misc/teamviewer: fix compression of doc files

### DIFF
--- a/net-misc/teamviewer/metadata.xml
+++ b/net-misc/teamviewer/metadata.xml
@@ -1,5 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<!-- maintainer-needed -->
+	<maintainer type="person" proxied="yes">
+		<email>martin.dummer@gmx.net</email>
+		<name>Martin Dummer</name>
+	</maintainer>
+	<maintainer type="project" proxied="proxy">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
 </pkgmetadata>

--- a/net-misc/teamviewer/teamviewer-15.19.3-r2.ebuild
+++ b/net-misc/teamviewer/teamviewer-15.19.3-r2.ebuild
@@ -24,7 +24,7 @@ RDEPEND="
 	dev-libs/nspr
 	media-libs/fontconfig
 	media-libs/freetype
-	media-libs/libglvnd
+	media-libs/libglvnd[X]
 	sys-apps/dbus
 	sys-apps/util-linux
 	sys-libs/zlib:0/1[minizip]
@@ -32,7 +32,7 @@ RDEPEND="
 	x11-libs/libICE
 	x11-libs/libSM
 	x11-libs/libxcb
-	x11-libs/libxkbcommon
+	x11-libs/libxkbcommon[X]
 	x11-libs/libXcomposite
 	x11-libs/libXcursor
 	x11-libs/libXdamage
@@ -112,7 +112,7 @@ src_install() {
 	dosym ../../usr/share/doc/${PF}/doc ${dst}/doc
 
 	# We need to keep docs uncompressed, bug #778617
-	docompress -x /usr/share/doc/${PF}/*
+	docompress -x /usr/share/doc/${PF}/.
 
 	keepdir /etc/${MY_P}
 	dosym ../../etc/${MY_P} ${dst}/config


### PR DESCRIPTION
When teamviewer starts on new installation, it likes to display a
license agreement dialogue. This fails when documentation files are
compressed. fixed.

Adopt package, change maintainer-needed -> @me

Additionally, adjust dependencies.

Closes: https://bugs.gentoo.org/798300
Package-Manager: Portage-3.0.20, Repoman-3.0.2
Signed-off-by: Martin Dummer <martin.dummer@gmx.net>