### PR TITLE
meson.eclass: EAPI 8 support

### DIFF
--- a/eclass/eapi7-ver.eclass
+++ b/eclass/eapi7-ver.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: eapi7-ver.eclass
@@ -58,7 +58,7 @@
 
 case ${EAPI:-0} in
 	0|1|2|3|4|5|6) ;;
-	7) die "${ECLASS}: EAPI=${EAPI} includes all functions from this eclass" ;;
+	7|8) die "${ECLASS}: EAPI=${EAPI} includes all functions from this eclass" ;;
 	*) die "${ECLASS}: EAPI=${EAPI} unknown" ;;
 esac
 

--- a/eclass/meson.eclass
+++ b/eclass/meson.eclass
@@ -5,7 +5,7 @@
 # @MAINTAINER:
 # William Hubbs <williamh@gentoo.org>
 # Mike Gilbert <floppym@gentoo.org>
-# @SUPPORTED_EAPIS: 6 7
+# @SUPPORTED_EAPIS: 6 7 8
 # @BLURB: common ebuild functions for meson-based packages
 # @DESCRIPTION:
 # This eclass contains the default phase functions for packages which
@@ -15,7 +15,7 @@
 # Typical ebuild using meson.eclass:
 #
 # @CODE
-# EAPI=6
+# EAPI=8
 #
 # inherit meson
 #
@@ -23,7 +23,7 @@
 #
 # src_configure() {
 # 	local emesonargs=(
-# 		$(meson_use qt4)
+# 		$(meson_use qt5)
 # 		$(meson_feature threads)
 # 		$(meson_use bindist official_branding)
 # 	)
@@ -34,32 +34,25 @@
 #
 # @CODE
 
-case ${EAPI:-0} in
-	6|7) ;;
-	*) die "EAPI=${EAPI} is not supported" ;;
+case ${EAPI} in
+	6|7|8) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
 
 if [[ -z ${_MESON_ECLASS} ]]; then
+_MESON_ECLASS=1
 
+[[ ${EAPI} == 6 ]] && inherit eapi7-ver
 inherit multiprocessing ninja-utils python-utils-r1 toolchain-funcs
 
-if [[ ${EAPI} == 6 ]]; then
-	inherit eapi7-ver
-fi
-
-fi
-
 EXPORT_FUNCTIONS src_configure src_compile src_test src_install
-
-if [[ -z ${_MESON_ECLASS} ]]; then
-_MESON_ECLASS=1
 
 MESON_DEPEND=">=dev-util/meson-0.56.0
 	>=dev-util/ninja-1.8.2
 	dev-util/meson-format-array
 "
 
-if [[ ${EAPI:-0} == [6] ]]; then
+if [[ ${EAPI} == 6 ]]; then
 	DEPEND=${MESON_DEPEND}
 else
 	BDEPEND=${MESON_DEPEND}

--- a/eclass/ninja-utils.eclass
+++ b/eclass/ninja-utils.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: ninja-utils.eclass
@@ -8,7 +8,7 @@
 # @AUTHOR:
 # Michał Górny <mgorny@gentoo.org>
 # Mike Gilbert <floppym@gentoo.org>
-# @SUPPORTED_EAPIS: 2 4 5 6 7
+# @SUPPORTED_EAPIS: 5 6 7 8
 # @BLURB: common bits to run dev-util/ninja builder
 # @DESCRIPTION:
 # This eclass provides a single function -- eninja -- that can be used
@@ -18,14 +18,13 @@
 # be used indirectly by the eclasses for other build systems (CMake,
 # Meson).
 
-if [[ -z ${_NINJA_UTILS_ECLASS} ]]; then
-
-case ${EAPI:-0} in
-	0|1|3) die "EAPI=${EAPI:-0} is not supported (too old)";;
-	# copied from cmake-utils
-	2|4|5|6|7) ;;
-	*) die "EAPI=${EAPI} is not yet supported" ;;
+case ${EAPI} in
+	5|6|7|8) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
+
+if [[ -z ${_NINJA_UTILS_ECLASS} ]]; then
+_NINJA_UTILS_ECLASS=1
 
 # @ECLASS-VARIABLE: NINJAOPTS
 # @DEFAULT_UNSET
@@ -44,7 +43,7 @@ inherit multiprocessing
 # with EAPI 6, it also supports being called via 'nonfatal'.
 eninja() {
 	local nonfatal_args=()
-	[[ ${EAPI:-0} != [245] ]] && nonfatal_args+=( -n )
+	[[ ${EAPI} != 5 ]] && nonfatal_args+=( -n )
 
 	if [[ -z ${NINJAOPTS+set} ]]; then
 		NINJAOPTS="-j$(makeopts_jobs) -l$(makeopts_loadavg "${MAKEOPTS}" 0)"
@@ -54,5 +53,4 @@ eninja() {
 	"$@" || die "${nonfatal_args[@]}" "${*} failed"
 }
 
-_NINJA_UTILS_ECLASS=1
 fi


### PR DESCRIPTION
@floppym Here is an update to allow EAPI 8 with meson packages (excluding the `meson-multilib.eclass`, since that can be done with all of its multilib eclass dependencies).

This updates `meson.eclass` to conform to conventions that other eclasses seem to follow.  E.g. conditional inherits are first (presumably for function precedence), and defining the inherit guard at the end.  It also removes the split inherit guard.  The only reason I saw for it is [bug #619178 comment #4](https://bugs.gentoo.org/619178#c4) with no further details.  Are there actually any examples of this being a problem?  A couple Python eclasses seem to be the only other instances of this.