### PR TITLE
distutils-r1.eclass: Fix paths for dosym -r

### DIFF
--- a/eclass/distutils-r1.eclass
+++ b/eclass/distutils-r1.eclass
@@ -778,8 +778,8 @@ _distutils-r1_wrap_scripts() {
 			debug-print "${FUNCNAME}: installing wrapper at ${bindir}/${basename}"
 			local dosym=dosym
 			[[ ${EAPI} == [67] ]] && dosym=dosym8
-			"${dosym}" -r "${path#${D}}"/usr/lib/python-exec/python-exec2 \
-				"${path#${D}}${bindir#${EPREFIX}}/${basename}"
+			"${dosym}" -r "${path#${D%/}}"/usr/lib/python-exec/python-exec2 \
+				"${path#${D%/}}${bindir#${EPREFIX}}/${basename}"
 		done
 
 		for f in "${non_python_files[@]}"; do


### PR DESCRIPTION
In EAPI 6, variable D has a trailing slash, so "${path#${D}}" will end up with one slash too many removed. Fix it by using "${path#${D%/}}" instead.
