### PR TITLE
dev-libs/spdlog: fix compiling with libfmt-8 installed

### DIFF
--- a/dev-libs/spdlog/files/spdlog-1.8.5-libfmt-8-fix.patch
+++ b/dev-libs/spdlog/files/spdlog-1.8.5-libfmt-8-fix.patch
@@ -1,0 +1,13 @@
+See upstream https://github.com/gabime/spdlog/issues/1975
+
+--- a/include/spdlog/common-inl.h	2021-06-21 17:15:26.695992698 -0600
++++ b/include/spdlog/common-inl.h	2021-06-21 17:15:52.205992496 -0600
+@@ -60,7 +60,7 @@
+ SPDLOG_INLINE spdlog_ex::spdlog_ex(const std::string &msg, int last_errno)
+ {
+     memory_buf_t outbuf;
+-    fmt::format_system_error(outbuf, last_errno, msg);
++    fmt::format_system_error(outbuf, last_errno, msg.c_str());
+     msg_ = fmt::to_string(outbuf);
+ }
+ 

--- a/dev-libs/spdlog/spdlog-1.8.5-r1.ebuild
+++ b/dev-libs/spdlog/spdlog-1.8.5-r1.ebuild
@@ -1,0 +1,49 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit cmake
+
+DESCRIPTION="Very fast, header only, C++ logging library"
+HOMEPAGE="https://github.com/gabime/spdlog"
+
+if [[ ${PV} == *9999 ]]; then
+	inherit git-r3
+	EGIT_REPO_URI="https://github.com/gabime/${PN}"
+else
+	SRC_URI="https://github.com/gabime/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+	KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~x86"
+fi
+
+LICENSE="MIT"
+SLOT="0/1"
+IUSE="test"
+RESTRICT="!test? ( test )"
+
+BDEPEND="
+	virtual/pkgconfig
+"
+DEPEND="
+	>=dev-libs/libfmt-6.1.2:=
+"
+RDEPEND="${DEPEND}"
+
+PATCHES=( "${FILESDIR}/${P}-libfmt-8-fix.patch" )
+
+src_prepare() {
+	cmake_src_prepare
+	rm -r include/spdlog/fmt/bundled || die "Failed to delete bundled libfmt"
+}
+
+src_configure() {
+	local mycmakeargs=(
+		-DSPDLOG_BUILD_BENCH=no
+		-DSPDLOG_BUILD_EXAMPLE=no
+		-DSPDLOG_FMT_EXTERNAL=yes
+		-DSPDLOG_BUILD_SHARED=yes
+		-DSPDLOG_BUILD_TESTS=$(usex test)
+	)
+
+	cmake_src_configure
+}


### PR DESCRIPTION
See also upstream https://github.com/gabime/spdlog/issues/1975

Signed-off-by: Hank Leininger <hlein@korelogic.com>
Closes: https://bugs.gentoo.org/797394
Package-Manager: Portage-3.0.20, Repoman-3.0.3