### PR TITLE
Revert the removal of _python_ln_rel

### DIFF
--- a/eclass/distutils-r1.eclass
+++ b/eclass/distutils-r1.eclass
@@ -776,10 +776,8 @@ _distutils-r1_wrap_scripts() {
 			local basename=${f##*/}
 
 			debug-print "${FUNCNAME}: installing wrapper at ${bindir}/${basename}"
-			local dosym=dosym
-			[[ ${EAPI} == [67] ]] && dosym=dosym8
-			"${dosym}" -r "${path#${D}}"/usr/lib/python-exec/python-exec2 \
-				"${path#${D}}${bindir#${EPREFIX}}/${basename}"
+			_python_ln_rel "${path}${EPREFIX}"/usr/lib/python-exec/python-exec2 \
+				"${path}${bindir}/${basename}" || die
 		done
 
 		for f in "${non_python_files[@]}"; do

--- a/eclass/python-utils-r1.eclass
+++ b/eclass/python-utils-r1.eclass
@@ -549,6 +549,46 @@ python_get_scriptdir() {
 	echo "${PYTHON_SCRIPTDIR}"
 }
 
+# @FUNCTION: _python_ln_rel
+# @USAGE: <from> <to>
+# @INTERNAL
+# @DESCRIPTION:
+# Create a relative symlink.
+_python_ln_rel() {
+	debug-print-function ${FUNCNAME} "${@}"
+
+	local target=${1}
+	local symname=${2}
+
+	local tgpath=${target%/*}/
+	local sympath=${symname%/*}/
+	local rel_target=
+
+	while [[ ${sympath} ]]; do
+		local tgseg= symseg=
+
+		while [[ ! ${tgseg} && ${tgpath} ]]; do
+			tgseg=${tgpath%%/*}
+			tgpath=${tgpath#${tgseg}/}
+		done
+
+		while [[ ! ${symseg} && ${sympath} ]]; do
+			symseg=${sympath%%/*}
+			sympath=${sympath#${symseg}/}
+		done
+
+		if [[ ${tgseg} != ${symseg} ]]; then
+			rel_target=../${rel_target}${tgseg:+${tgseg}/}
+		fi
+	done
+	rel_target+=${tgpath}${target##*/}
+
+	debug-print "${FUNCNAME}: ${symname} -> ${target}"
+	debug-print "${FUNCNAME}: rel_target = ${rel_target}"
+
+	ln -fs "${rel_target}" "${symname}"
+}
+
 # @FUNCTION: python_optimize
 # @USAGE: [<directory>...]
 # @DESCRIPTION:


### PR DESCRIPTION
This breaks installation of scripts when EPREFIX is non-empty.

_distutils-r1_wrap_scripts should create a symlink like this:

"${D}/_${EPYTHON}${EPREFIX}/usr/bin/myscript"

The "dosym" version of this code creates the following instead:

"${D}${EPREFIX}/_${EPYTHON}/usr/bin/myscript"

Reverts: 9f831e240a9804a996fc80015f64d5e102ced740
Closes: https://bugs.gentoo.org/798456