### PR TITLE
package.mask: drop mask python for media-gfx/gimp:0/3

### DIFF
--- a/profiles/base/package.use.mask
+++ b/profiles/base/package.use.mask
@@ -150,10 +150,6 @@ media-plugins/mythplugins mythnetvision
 app-metrics/collectd collectd_plugins_onewire
 
 # Michał Górny <mgorny@gentoo.org> (2020-08-22)
-# These flags depend on dev-python/pygtk that is masked for removal.
-<media-gfx/gimp-3 python
-
-# Michał Górny <mgorny@gentoo.org> (2020-08-22)
 # These flags depend on packages masked for removal due to py2.
 sci-geosciences/qgis grass
 


### PR DESCRIPTION
`USE="python"` was droppped for `media-gfx/gimp:0/2`
as `dev-python/pygtk` package too that was the reason of masking.

`media-gfx[python]:0/3` doesn't depend of `dev-python/pygtk`.

Closes: https://bugs.gentoo.org/797583
