### PR TITLE
media-sound/a2jmidid: return python support

### DIFF
--- a/media-sound/a2jmidid/a2jmidid-9.ebuild
+++ b/media-sound/a2jmidid/a2jmidid-9.ebuild
@@ -1,9 +1,12 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-inherit meson
+PYTHON_COMPAT=( python3_{6..10} )
+PYTHON_REQ_USE="threads(+)"
+
+inherit meson python-single-r1
 
 DESCRIPTION="Daemon for exposing legacy ALSA sequencer applications in JACK MIDI system"
 HOMEPAGE="https://github.com/linuxaudio/a2jmidid"
@@ -12,7 +15,8 @@ SRC_URI="https://github.com/linuxaudio/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="amd64 ~arm x86"
-IUSE="dbus"
+IUSE="dbus python"
+REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
 
 BDEPEND="
 	virtual/pkgconfig
@@ -21,6 +25,7 @@ CDEPEND="
 	media-libs/alsa-lib
 	virtual/jack
 	dbus? ( sys-apps/dbus )
+	python? ( ${PYTHON_DEPS} )
 "
 RDEPEND="${CDEPEND}"
 DEPEND="${RDEPEND}"
@@ -33,4 +38,14 @@ src_configure() {
 	)
 
 	meson_src_configure
+}
+
+src_install() {
+	meson_src_install
+
+	if use python; then
+		python_fix_shebang "${ED}"
+	else
+		rm "${ED}/usr/bin/a2j_control"
+	fi
 }

--- a/media-sound/a2jmidid/a2jmidid-9999.ebuild
+++ b/media-sound/a2jmidid/a2jmidid-9999.ebuild
@@ -1,9 +1,12 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-inherit meson git-r3
+PYTHON_COMPAT=( python3_{6..10} )
+PYTHON_REQ_USE="threads(+)"
+
+inherit meson python-single-r1 git-r3
 
 DESCRIPTION="Daemon for exposing legacy ALSA sequencer applications in JACK MIDI system"
 HOMEPAGE="https://github.com/linuxaudio/a2jmidid"
@@ -12,7 +15,8 @@ EGIT_REPO_URI="https://github.com/linuxaudio/a2jmidid.git"
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS=""
-IUSE="dbus"
+IUSE="dbus python"
+REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
 
 BDEPEND="
 	virtual/pkgconfig
@@ -21,6 +25,7 @@ CDEPEND="
 	media-libs/alsa-lib
 	virtual/jack
 	dbus? ( sys-apps/dbus )
+	python? ( ${PYTHON_DEPS} )
 "
 RDEPEND="${CDEPEND}"
 DEPEND="${RDEPEND}"
@@ -33,4 +38,14 @@ src_configure() {
 	)
 
 	meson_src_configure
+}
+
+src_install() {
+	meson_src_install
+
+	if use python; then
+		python_fix_shebang "${ED}"
+	else
+		rm "${ED}/usr/bin/a2j_control"
+	fi
 }


### PR DESCRIPTION
Fixes bug https://bugs.gentoo.org/798411
Also adds USE=python to make this dependency optional (just by not installing a2j_control if off)