### PR TITLE
dev-python/logfury: Fix dash in setuptools variable

### DIFF
--- a/dev-python/logfury/files/logfury-0.1.2-fix-setuptools-dash.patch
+++ b/dev-python/logfury/files/logfury-0.1.2-fix-setuptools-dash.patch
@@ -1,0 +1,9 @@
+--- a/setup.cfg	2021-06-24 21:17:00.815577470 +0100
++++ b/setup.cfg	2021-06-24 21:17:04.775540043 +0100
+@@ -1,5 +1,5 @@
+ [metadata]
+-description-file=README.rst
++description_file=README.rst
+ 
+ [yapf]
+ based_on_style=facebook

--- a/dev-python/logfury/logfury-0.1.2-r1.ebuild
+++ b/dev-python/logfury/logfury-0.1.2-r1.ebuild
@@ -17,6 +17,7 @@ KEYWORDS="~amd64 ~x86"
 
 PATCHES=(
 	"${FILESDIR}/${P}-fix-requirements-remove-dev-tests.patch"
+	"${FILESDIR}/${P}-fix-setuptools-dash.patch"
 )
 
 RDEPEND="dev-python/six[${PYTHON_USEDEP}]"


### PR DESCRIPTION
Just changing description-file to description_file

Fixes #798057

Signed-off-by: William Pettersson <william@ewpettersson.se>