### PR TITLE
app-shells/mksh: Switch to git mirror

### DIFF
--- a/app-shells/mksh/mksh-9999.ebuild
+++ b/app-shells/mksh/mksh-9999.ebuild
@@ -6,13 +6,11 @@ EAPI=7
 inherit toolchain-funcs
 
 if [[ ${PV} == *9999 ]] ; then
-	ECVS_SERVER="anoncvs.mirbsd.org:/cvs"
-	ECVS_MODULE="mksh"
-	ECVS_USER="_anoncvs"
-	ECVS_AUTH="ext"
-	inherit cvs
+	inherit git-r3
+	EGIT_REPO_URI="https://github.com/MirBSD/mksh.git"
 else
 	SRC_URI="https://www.mirbsd.org/MirOS/dist/mir/mksh/${PN}-R${PV}.tgz"
+	S="${WORKDIR}/${PN}"
 	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~sparc ~x86 ~amd64-linux ~x86-linux"
 fi
 
@@ -36,8 +34,6 @@ DEPEND="
 		sys-apps/ed
 	)
 "
-
-S="${WORKDIR}/${PN}"
 
 src_prepare() {
 	default


### PR DESCRIPTION
It seems like there is an issue with cvs on the authentication,
ECVS_AUTH=ext seems specific to mksh and I don't think there is a strong
reason to keep using CVS, at the moment only 4 ebuilds are using it,
including mksh.

Signed-off-by: Haelwenn (lanodan) Monnier <contact@hacktivis.me>

Draft: I asked mirabilos on the status of the github mirror.