### PR TITLE
cvs.eclass: Fix CVS_RSH for app-shells/mksh

### DIFF
--- a/eclass/cvs.eclass
+++ b/eclass/cvs.eclass
@@ -4,7 +4,7 @@
 # @ECLASS: cvs.eclass
 # @MAINTAINER:
 # vapier@gentoo.org (and anyone who wants to help)
-# @SUPPORTED_EAPIS: 4 5 6 7
+# @SUPPORTED_EAPIS: 5 6 7
 # @BLURB: This eclass provides generic cvs fetching functions
 # @DESCRIPTION:
 # This eclass provides the generic cvs fetching functions. To use this from an
@@ -182,16 +182,11 @@ PROPERTIES+=" live"
 DEPEND="dev-vcs/cvs"
 
 if [[ ${ECVS_AUTH} == "ext" ]] ; then
-	#default to ssh
-	[[ -z ${CVS_RSH} ]] && export CVS_RSH="ssh"
-	if [[ ${CVS_RSH} != "ssh" ]] ; then
-		die "Support for ext auth with clients other than ssh has not been implemented yet"
-	fi
 	DEPEND+=" net-misc/openssh"
 fi
 
 case ${EAPI:-0} in
-	4|5|6) ;;
+	5|6) ;;
 	7) BDEPEND="${DEPEND}"; DEPEND="" ;;
 	*) die "${ECLASS}: EAPI ${EAPI:-0} is not supported" ;;
 esac
@@ -482,6 +477,12 @@ cvs_src_unpack() {
 	ECVS_LOCALNAME=${ECVS_LOCALNAME}"
 
 	[[ -z ${ECVS_MODULE} ]] && die "ERROR: CVS module not set, cannot continue."
+
+	#default to ssh
+	[[ -z ${CVS_RSH} ]] && export CVS_RSH="ssh"
+	if [[ ${CVS_RSH} != "ssh" ]] ; then
+		die "Support for ext auth with clients other than ssh has not been implemented yet"
+	fi
 
 	local ECVS_LOCALNAME=${ECVS_LOCALNAME:-${ECVS_MODULE}}
 


### PR DESCRIPTION
For some reason CVS_RSH wouldn't be set into cvs_src_unpack, app-shells/mksh
is also the only ebuild in ::gentoo one using it with ECVS_AUTH="ext"

I also removed EAPI-4 support as it's banned in ::gentoo

Signed-off-by: Haelwenn (lanodan) Monnier <contact@hacktivis.me>