### PR TITLE
dev-python/{grpcio, logbook, mysqlclient, pyu2f, keyring, unittest2}: add ~riscv keyword

### DIFF
--- a/dev-cpp/gtest/gtest-1.10.0_p20200702.ebuild
+++ b/dev-cpp/gtest/gtest-1.10.0_p20200702.ebuild
@@ -21,7 +21,7 @@ else
 		URI_PV=${MY_PV:=${GOOGLETEST_COMMIT}}
 	fi
 	SRC_URI="https://github.com/google/googletest/archive/${URI_PV}.tar.gz -> ${P}.tar.gz"
-	KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~m68k ~mips ppc ppc64 ~s390 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+	KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 	S="${WORKDIR}"/googletest-${MY_PV}
 fi
 

--- a/dev-db/mysql-connector-c/mysql-connector-c-8.0.25-r1.ebuild
+++ b/dev-db/mysql-connector-c/mysql-connector-c-8.0.25-r1.ebuild
@@ -18,7 +18,7 @@ if [[ ${PV} == "9999" ]]; then
 	inherit git-r3
 else
 	SRC_URI="https://dev.mysql.com/get/Downloads/MySQL-$(ver_cut 1-2)/mysql-boost-${PV}.tar.gz"
-	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
 
 	S="${WORKDIR}/mysql-${PV}"
 fi

--- a/dev-libs/libpthread-stubs/libpthread-stubs-0.4-r1.ebuild
+++ b/dev-libs/libpthread-stubs/libpthread-stubs-0.4-r1.ebuild
@@ -11,7 +11,7 @@ SRC_URI="https://xcb.freedesktop.org/dist/${P}.tar.bz2"
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~m68k ~mips ppc ppc64 ~s390 sparc x86 ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 IUSE=""
 
 multilib_src_configure() {

--- a/dev-libs/protobuf-c/protobuf-c-1.3.3.ebuild
+++ b/dev-libs/protobuf-c/protobuf-c-1.3.3.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://github.com/${PN}/${PN}/releases/download/v${MY_PV}/${MY_P}.tar.
 LICENSE="BSD-2"
 # Subslot == SONAME version
 SLOT="0/1.0.0"
-KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~mips ppc ppc64 ~s390 sparc x86"
+KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~mips ppc ppc64 ~riscv ~s390 sparc x86"
 IUSE="static-libs test"
 RESTRICT="!test? ( test )"
 

--- a/dev-libs/protobuf/protobuf-3.17.3.ebuild
+++ b/dev-libs/protobuf/protobuf-3.17.3.ebuild
@@ -22,7 +22,7 @@ fi
 
 LICENSE="BSD"
 SLOT="0/28"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~x64-macos"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~x64-macos"
 IUSE="emacs examples static-libs test zlib"
 RESTRICT="!test? ( test )"
 

--- a/dev-libs/re2/re2-0.2021.06.01.ebuild
+++ b/dev-libs/re2/re2-0.2021.06.01.ebuild
@@ -18,7 +18,7 @@ LICENSE="BSD"
 # https://abi-laboratory.pro/tracker/timeline/re2/
 SONAME="9"
 SLOT="0/${SONAME}"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~s390 ~sparc ~x86"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
 IUSE="icu"
 
 BDEPEND="icu? ( virtual/pkgconfig )"

--- a/dev-python/backcall/backcall-0.2.0.ebuild
+++ b/dev-python/backcall/backcall-0.2.0.ebuild
@@ -13,6 +13,6 @@ SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="amd64 ~arm arm64 ~ppc ppc64 ~sparc x86 ~amd64-linux ~x86-linux"
+KEYWORDS="amd64 ~arm arm64 ~ppc ppc64 ~riscv ~sparc x86 ~amd64-linux ~x86-linux"
 
 distutils_enable_tests pytest

--- a/dev-python/entrypoints/entrypoints-0.3-r2.ebuild
+++ b/dev-python/entrypoints/entrypoints-0.3-r2.ebuild
@@ -13,7 +13,7 @@ SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~mips ppc ppc64 ~s390 sparc x86 ~x64-macos"
+KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~x64-macos"
 
 distutils_enable_tests pytest
 

--- a/dev-python/grpcio/grpcio-1.38.1.ebuild
+++ b/dev-python/grpcio/grpcio-1.38.1.ebuild
@@ -13,7 +13,7 @@ SRC_URI="mirror://pypi/${PN::1}/${PN}/${P}.tar.gz"
 
 LICENSE="Apache-2.0"
 SLOT="0"
-KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND="
 	>=dev-libs/openssl-1.0.2:0=[-bindist(-)]

--- a/dev-python/ipython_genutils/ipython_genutils-0.2.0-r2.ebuild
+++ b/dev-python/ipython_genutils/ipython_genutils-0.2.0-r2.ebuild
@@ -14,7 +14,7 @@ SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="amd64 ~arm arm64 ~ppc ppc64 ~sparc x86"
+KEYWORDS="amd64 ~arm arm64 ~ppc ppc64 ~riscv ~sparc x86"
 
 # Needed because package provides decorators which use nose
 RDEPEND="dev-python/nose[${PYTHON_USEDEP}]"

--- a/dev-python/jedi/jedi-0.18.0.ebuild
+++ b/dev-python/jedi/jedi-0.18.0.ebuild
@@ -23,7 +23,7 @@ SRC_URI="
 LICENSE="MIT
 	test? ( Apache-2.0 )"
 SLOT="0"
-KEYWORDS="amd64 ~arm arm64 ~ppc ppc64 ~sparc x86"
+KEYWORDS="amd64 ~arm arm64 ~ppc ppc64 ~riscv ~sparc x86"
 
 RDEPEND="=dev-python/parso-0.8*[${PYTHON_USEDEP}]"
 

--- a/dev-python/jeepney/jeepney-0.6.0.ebuild
+++ b/dev-python/jeepney/jeepney-0.6.0.ebuild
@@ -14,7 +14,7 @@ SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ppc ppc64 sparc x86 ~x64-macos"
+KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ppc ppc64 ~riscv sparc x86 ~x64-macos"
 IUSE="examples"
 
 BDEPEND="

--- a/dev-python/keyring/keyring-23.0.1.ebuild
+++ b/dev-python/keyring/keyring-23.0.1.ebuild
@@ -12,7 +12,7 @@ SRC_URI="https://github.com/jaraco/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 SLOT="0"
 LICENSE="PSF-2"
-KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ppc ppc64 sparc x86 ~x64-macos"
+KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ppc ppc64 ~riscv sparc x86 ~x64-macos"
 
 RDEPEND="
 	dev-python/secretstorage[${PYTHON_USEDEP}]

--- a/dev-python/linecache2/linecache2-1.0.0-r1.ebuild
+++ b/dev-python/linecache2/linecache2-1.0.0-r1.ebuild
@@ -13,7 +13,7 @@ SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="PSF-2"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~m68k ~mips ppc ppc64 ~s390 sparc x86"
+KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86"
 IUSE="test"
 RESTRICT="!test? ( test )"
 

--- a/dev-python/logbook/logbook-1.5.3.ebuild
+++ b/dev-python/logbook/logbook-1.5.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -15,7 +15,7 @@ SRC_URI="https://github.com/getlogbook/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="amd64 x86"
+KEYWORDS="amd64 ~riscv x86"
 IUSE=""
 
 BDEPEND="

--- a/dev-python/mysqlclient/mysqlclient-1.4.6-r1.ebuild
+++ b/dev-python/mysqlclient/mysqlclient-1.4.6-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -13,7 +13,7 @@ SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 SLOT="0"
 LICENSE="GPL-2"
-KEYWORDS="amd64 ~arm ~arm64 ~hppa ~ia64 ppc ppc64 ~s390 sparc x86 ~amd64-linux ~x86-linux"
+KEYWORDS="amd64 ~arm ~arm64 ~hppa ~ia64 ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux"
 IUSE="doc"
 
 RDEPEND="

--- a/dev-python/namespace-google/namespace-google-1-r1.ebuild
+++ b/dev-python/namespace-google/namespace-google-1-r1.ebuild
@@ -12,7 +12,7 @@ SRC_URI=""
 
 LICENSE="public-domain"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm ~arm64 ~hppa ~ia64 ~m68k ~mips ppc ppc64 ~s390 ~sparc x86 ~amd64-linux ~x86-linux ~x64-macos"
+KEYWORDS="~alpha amd64 arm ~arm64 ~hppa ~ia64 ~m68k ~mips ppc ppc64 ~riscv ~s390 ~sparc x86 ~amd64-linux ~x86-linux ~x64-macos"
 IUSE=""
 
 RDEPEND="dev-python/setuptools[${PYTHON_USEDEP}]

--- a/dev-python/parso/parso-0.8.2.ebuild
+++ b/dev-python/parso/parso-0.8.2.ebuild
@@ -13,7 +13,7 @@ SRC_URI="https://github.com/davidhalter/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="amd64 ~arm arm64 ~ppc ppc64 ~sparc x86"
+KEYWORDS="amd64 ~arm arm64 ~ppc ppc64 ~riscv ~sparc x86"
 
 distutils_enable_sphinx docs
 distutils_enable_tests pytest

--- a/dev-python/pickleshare/pickleshare-0.7.5.ebuild
+++ b/dev-python/pickleshare/pickleshare-0.7.5.ebuild
@@ -11,7 +11,7 @@ SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="amd64 ~arm arm64 ~ppc ppc64 ~sparc x86"
+KEYWORDS="amd64 ~arm arm64 ~ppc ppc64 ~riscv ~sparc x86"
 
 RDEPEND="
 	>=dev-python/path-py-6.2[${PYTHON_USEDEP}]"

--- a/dev-python/prompt_toolkit/prompt_toolkit-3.0.19.ebuild
+++ b/dev-python/prompt_toolkit/prompt_toolkit-3.0.19.ebuild
@@ -13,7 +13,7 @@ SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~sparc ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~riscv ~sparc ~x86"
 IUSE=""
 
 RDEPEND="

--- a/dev-python/protobuf-python/protobuf-python-3.17.3.ebuild
+++ b/dev-python/protobuf-python/protobuf-python-3.17.3.ebuild
@@ -24,7 +24,7 @@ fi
 
 LICENSE="BSD"
 SLOT="0/28"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~x86-linux ~x64-macos"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~riscv ~sparc ~x86 ~amd64-linux ~x86-linux ~x64-macos"
 IUSE=""
 
 BDEPEND="${PYTHON_DEPS}

--- a/dev-python/pyu2f/pyu2f-0.1.4-r1.ebuild
+++ b/dev-python/pyu2f/pyu2f-0.1.4-r1.ebuild
@@ -13,7 +13,7 @@ SRC_URI="https://github.com/google/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="Apache-2.0"
 SLOT="0"
-KEYWORDS="amd64 ~arm ~arm64 x86"
+KEYWORDS="amd64 ~arm ~arm64 ~riscv x86"
 IUSE="test"
 RESTRICT="!test? ( test )"
 

--- a/dev-python/pyzmq/pyzmq-20.0.0.ebuild
+++ b/dev-python/pyzmq/pyzmq-20.0.0.ebuild
@@ -19,7 +19,7 @@ SRC_URI="
 
 LICENSE="LGPL-3"
 SLOT="0"
-KEYWORDS="amd64 arm arm64 ~mips ~ppc ppc64 ~sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos"
+KEYWORDS="amd64 arm arm64 ~mips ~ppc ppc64 ~riscv ~sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos"
 IUSE="+draft"
 
 DEPEND="

--- a/dev-python/retry-decorator/retry-decorator-1.1.1.ebuild
+++ b/dev-python/retry-decorator/retry-decorator-1.1.1.ebuild
@@ -12,7 +12,7 @@ SRC_URI="https://github.com/pnpnpn/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="amd64 arm x86"
+KEYWORDS="amd64 arm ~riscv x86"
 
 DOCS=( README.rst )
 

--- a/dev-python/secretstorage/secretstorage-3.3.1.ebuild
+++ b/dev-python/secretstorage/secretstorage-3.3.1.ebuild
@@ -16,7 +16,7 @@ S="${WORKDIR}/${MY_PN}-${PV}"
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ppc ppc64 sparc x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ppc ppc64 ~riscv sparc x86 ~amd64-linux ~x86-linux"
 
 RDEPEND="
 	dev-python/cryptography[${PYTHON_USEDEP}]

--- a/dev-python/sqlalchemy/sqlalchemy-1.4.19.ebuild
+++ b/dev-python/sqlalchemy/sqlalchemy-1.4.19.ebuild
@@ -18,7 +18,7 @@ S="${WORKDIR}/${MY_P}"
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x64-solaris"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x64-solaris"
 IUSE="examples +sqlite test"
 
 RDEPEND="

--- a/dev-python/testpath/testpath-0.5.0.ebuild
+++ b/dev-python/testpath/testpath-0.5.0.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://github.com/jupyter/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ppc ppc64 ~s390 sparc x86 ~x64-macos"
+KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ppc ppc64 ~riscv ~s390 sparc x86 ~x64-macos"
 
 BDEPEND=">=dev-python/pyproject2setuppy-15"
 

--- a/dev-python/traceback2/traceback2-1.4.0-r1.ebuild
+++ b/dev-python/traceback2/traceback2-1.4.0-r1.ebuild
@@ -13,7 +13,7 @@ SRC_URI="mirror://pypi/${P:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="PSF-2"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~m68k ~mips ppc ppc64 ~s390 sparc x86"
+KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86"
 
 RDEPEND="
 	dev-python/linecache2[${PYTHON_USEDEP}]"

--- a/dev-python/traitlets/traitlets-5.0.5.ebuild
+++ b/dev-python/traitlets/traitlets-5.0.5.ebuild
@@ -14,7 +14,7 @@ SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="amd64 ~arm arm64 ~ppc ppc64 ~sparc x86"
+KEYWORDS="amd64 ~arm arm64 ~ppc ppc64 ~riscv ~sparc x86"
 
 RDEPEND="
 	dev-python/ipython_genutils[${PYTHON_USEDEP}]

--- a/dev-python/unittest2/unittest2-1.1.0-r1.ebuild
+++ b/dev-python/unittest2/unittest2-1.1.0-r1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~m68k ~mips ppc ppc64 ~s390 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos"
+KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos"
 
 RDEPEND="
 	dev-python/linecache2[${PYTHON_USEDEP}]

--- a/dev-python/wcwidth/wcwidth-0.2.5-r1.ebuild
+++ b/dev-python/wcwidth/wcwidth-0.2.5-r1.ebuild
@@ -15,7 +15,7 @@ SRC_URI="
 
 SLOT="0"
 LICENSE="MIT"
-KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~mips ppc ppc64 ~s390 sparc x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux"
 
 RDEPEND="
 	$(python_gen_cond_dep '

--- a/net-libs/zeromq/zeromq-4.3.4-r1.ebuild
+++ b/net-libs/zeromq/zeromq-4.3.4-r1.ebuild
@@ -11,7 +11,7 @@ SRC_URI="https://github.com/zeromq/libzmq/releases/download/v${PV}/${P}.tar.gz"
 
 LICENSE="LGPL-3"
 SLOT="0/5"
-KEYWORDS="amd64 arm arm64 ~hppa ~ia64 ~mips ppc ppc64 sparc x86 ~amd64-linux ~x86-linux ~x64-macos"
+KEYWORDS="amd64 arm arm64 ~hppa ~ia64 ~mips ppc ppc64 ~riscv sparc x86 ~amd64-linux ~x86-linux ~x64-macos"
 IUSE="doc drafts +libbsd pgm +sodium static-libs test unwind elibc_Darwin"
 RESTRICT="!test? ( test )"
 

--- a/profiles/arch/riscv/package.use.mask
+++ b/profiles/arch/riscv/package.use.mask
@@ -7,6 +7,7 @@ dev-python/pyzmq test
 net-libs/zeromq unwind sodium
 dev-python/linecache2 test
 dev-python/traceback2 test
+dev-db/mysql-connector-c ldap
 
 # Ye Cao <ye.c@rioslab.org> (2021-06-24)
 # Dependencies not keyworded, not tested

--- a/profiles/arch/riscv/package.use.mask
+++ b/profiles/arch/riscv/package.use.mask
@@ -1,6 +1,10 @@
 # Copyright 2019-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Ye Cao <ye.c@rioslab.org> (2021-06-26)
+# Dependencies not keyworded, not tested
+dev-python/pyzmq test
+
 # Ye Cao <ye.c@rioslab.org> (2021-06-24)
 # Dependencies not keyworded, not tested
 media-gfx/imagemagick fftw openexr wmf

--- a/profiles/arch/riscv/package.use.mask
+++ b/profiles/arch/riscv/package.use.mask
@@ -6,6 +6,7 @@
 dev-python/pyzmq test
 net-libs/zeromq unwind sodium
 dev-python/linecache2 test
+dev-python/traceback2 test
 
 # Ye Cao <ye.c@rioslab.org> (2021-06-24)
 # Dependencies not keyworded, not tested

--- a/profiles/arch/riscv/package.use.mask
+++ b/profiles/arch/riscv/package.use.mask
@@ -5,6 +5,7 @@
 # Dependencies not keyworded, not tested
 dev-python/pyzmq test
 net-libs/zeromq unwind sodium
+dev-python/linecache2 test
 
 # Ye Cao <ye.c@rioslab.org> (2021-06-24)
 # Dependencies not keyworded, not tested

--- a/profiles/arch/riscv/package.use.mask
+++ b/profiles/arch/riscv/package.use.mask
@@ -4,6 +4,7 @@
 # Ye Cao <ye.c@rioslab.org> (2021-06-26)
 # Dependencies not keyworded, not tested
 dev-python/pyzmq test
+net-libs/zeromq unwind sodium
 
 # Ye Cao <ye.c@rioslab.org> (2021-06-24)
 # Dependencies not keyworded, not tested


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/798783

Also add ~riscv keyword to some related packages