### PR TITLE
EAPI 8 eclass updates

### DIFF
--- a/eclass/gnome.org.eclass
+++ b/eclass/gnome.org.eclass
@@ -7,13 +7,13 @@
 # @AUTHOR:
 # Authors: Spidler <spidler@gentoo.org> with help of carparski.
 # eclass variable additions and documentation: Gilles Dartiguelongue <eva@gentoo.org>
-# @SUPPORTED_EAPIS: 5 6 7
+# @SUPPORTED_EAPIS: 5 6 7 8
 # @BLURB: Helper eclass for gnome.org hosted archives
 # @DESCRIPTION:
 # Provide a default SRC_URI for tarball hosted on gnome.org mirrors.
 
-case ${EAPI:-0} in
-	[567]) ;;
+case ${EAPI} in
+	5|6|7|8) ;;
 	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
 
@@ -31,7 +31,7 @@ _GNOME_ORG_ECLASS=1
 # moving to only have xz tarballs for new releases.
 : ${GNOME_TARBALL_SUFFIX:="xz"}
 
-# Even though xz-utils are in @system, they must still be added to DEPEND; see
+# Even though xz-utils are in @system, they must still be added to BDEPEND; see
 # https://archives.gentoo.org/gentoo-dev/msg_a0d4833eb314d1be5d5802a3b710e0a4.xml
 if [[ ${GNOME_TARBALL_SUFFIX} == "xz" ]]; then
 	if [[ ${EAPI} != [56] ]]; then

--- a/eclass/meson-multilib.eclass
+++ b/eclass/meson-multilib.eclass
@@ -7,7 +7,7 @@
 # @AUTHOR:
 # Author: Michał Górny <mgorny@gentoo.org>
 # Author: Matt Turner <mattst88@gentoo.org>
-# @SUPPORTED_EAPIS: 7
+# @SUPPORTED_EAPIS: 7 8
 # @BLURB: meson wrapper for multilib builds
 # @DESCRIPTION:
 # The meson-multilib.eclass provides a glue between meson.eclass(5)
@@ -20,13 +20,13 @@
 # in multilib-minimal, yet they ought to call appropriate meson
 # phase rather than 'default'.
 
+case ${EAPI} in
+	7|8) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
+
 if [[ -z ${_MESON_MULTILIB_ECLASS} ]] ; then
 _MESON_MULTILIB_ECLASS=1
-
-case ${EAPI:-0} in
-	7) ;;
-	*) die "EAPI=${EAPI} is not supported" ;;
-esac
 
 inherit meson multilib-minimal
 

--- a/eclass/multilib-build.eclass
+++ b/eclass/multilib-build.eclass
@@ -6,7 +6,7 @@
 # Michał Górny <mgorny@gentoo.org>
 # @AUTHOR:
 # Author: Michał Górny <mgorny@gentoo.org>
-# @SUPPORTED_EAPIS: 4 5 6 7
+# @SUPPORTED_EAPIS: 5 6 7 8
 # @BLURB: flags and utility functions for building multilib packages
 # @DESCRIPTION:
 # The multilib-build.eclass exports USE flags and utility functions
@@ -17,15 +17,15 @@
 # dependencies shall use the USE dependency string in ${MULTILIB_USEDEP}
 # to properly request multilib enabled.
 
-if [[ ! ${_MULTILIB_BUILD} ]]; then
-
-# EAPI=4 is required for meaningful MULTILIB_USEDEP.
-case ${EAPI:-0} in
-	4|5|6|7) ;;
-	*) die "EAPI=${EAPI} is not supported" ;;
+case ${EAPI} in
+	5|6|7|8) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
 
-[[ ${EAPI} == [45] ]] && inherit eutils
+if [[ -z ${_MULTILIB_BUILD} ]]; then
+_MULTILIB_BUILD=1
+
+[[ ${EAPI} == 5 ]] && inherit eutils
 inherit multibuild multilib
 
 # @ECLASS-VARIABLE: _MULTILIB_FLAGS
@@ -250,7 +250,7 @@ multilib_parallel_foreach_abi() {
 multilib_for_best_abi() {
 	debug-print-function ${FUNCNAME} "${@}"
 
-	[[ ${EAPI} == [45] ]] || die "${FUNCNAME} is banned in EAPI ${EAPI}, use multilib_is_native_abi() instead"
+	[[ ${EAPI} == 5 ]] || die "${FUNCNAME} is banned in EAPI ${EAPI}, use multilib_is_native_abi() instead"
 
 	eqawarn "QA warning: multilib_for_best_abi() function is deprecated and should"
 	eqawarn "not be used. The multilib_is_native_abi() check may be used instead."
@@ -588,7 +588,7 @@ multilib_is_native_abi() {
 multilib_build_binaries() {
 	debug-print-function ${FUNCNAME} "${@}"
 
-	[[ ${EAPI} == [45] ]] || die "${FUNCNAME} is banned in EAPI ${EAPI}, use multilib_is_native_abi() instead"
+	[[ ${EAPI} == 5 ]] || die "${FUNCNAME} is banned in EAPI ${EAPI}, use multilib_is_native_abi() instead"
 
 	eqawarn "QA warning: multilib_build_binaries is deprecated. Please use the equivalent"
 	eqawarn "multilib_is_native_abi function instead."
@@ -671,5 +671,4 @@ multilib_native_usex() {
 	fi
 }
 
-_MULTILIB_BUILD=1
 fi

--- a/eclass/multilib-minimal.eclass
+++ b/eclass/multilib-minimal.eclass
@@ -4,7 +4,7 @@
 # @ECLASS: multilib-minimal.eclass
 # @MAINTAINER:
 # Michał Górny <mgorny@gentoo.org>
-# @SUPPORTED_EAPIS: 4 5 6 7
+# @SUPPORTED_EAPIS: 5 6 7 8
 # @BLURB: wrapper for multilib builds providing convenient multilib_src_* functions
 # @DESCRIPTION:
 #
@@ -23,14 +23,13 @@
 # If you need generic install rules, use multilib_src_install_all function.
 
 
-# EAPI=4 is required for meaningful MULTILIB_USEDEP.
-case ${EAPI:-0} in
-	4|5|6|7) ;;
-	*) die "EAPI=${EAPI} is not supported" ;;
+case ${EAPI} in
+	5|6|7|8) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
 
 
-[[ ${EAPI} == [45] ]] && inherit eutils
+[[ ${EAPI} == 5 ]] && inherit eutils
 inherit multilib-build
 
 EXPORT_FUNCTIONS src_configure src_compile src_test src_install

--- a/eclass/systemd.eclass
+++ b/eclass/systemd.eclass
@@ -4,7 +4,7 @@
 # @ECLASS: systemd.eclass
 # @MAINTAINER:
 # systemd@gentoo.org
-# @SUPPORTED_EAPIS: 0 1 2 3 4 5 6 7
+# @SUPPORTED_EAPIS: 5 6 7 8
 # @BLURB: helper functions to install systemd units
 # @DESCRIPTION:
 # This eclass provides a set of functions to install unit files for
@@ -24,14 +24,14 @@
 # }
 # @CODE
 
-inherit toolchain-funcs
-
-case ${EAPI:-0} in
-	0|1|2|3|4|5|6|7) ;;
-	*) die "${ECLASS}.eclass API in EAPI ${EAPI} not yet established."
+case ${EAPI} in
+	5|6|7|8) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
 
-if [[ ${EAPI:-0} == [0123456] ]]; then
+inherit toolchain-funcs
+
+if [[ ${EAPI} == [56] ]]; then
 	DEPEND="virtual/pkgconfig"
 else
 	BDEPEND="virtual/pkgconfig"
@@ -72,7 +72,6 @@ _systemd_get_systemunitdir() {
 # ${D}).  This function always succeeds, even if systemd is not
 # installed.
 systemd_get_systemunitdir() {
-	has "${EAPI:-0}" 0 1 2 && ! use prefix && EPREFIX=
 	debug-print-function ${FUNCNAME} "${@}"
 
 	echo "${EPREFIX}$(_systemd_get_systemunitdir)"
@@ -82,7 +81,7 @@ systemd_get_systemunitdir() {
 # @DESCRIPTION:
 # Deprecated alias for systemd_get_systemunitdir.
 systemd_get_unitdir() {
-	[[ ${EAPI} == [012345] ]] || die "${FUNCNAME} is banned in EAPI 6, use systemd_get_systemunitdir instead"
+	[[ ${EAPI} == 5 ]] || die "${FUNCNAME} is banned in EAPI 6, use systemd_get_systemunitdir instead"
 
 	systemd_get_systemunitdir
 }
@@ -101,7 +100,6 @@ _systemd_get_userunitdir() {
 # ${D}). This function always succeeds, even if systemd is not
 # installed.
 systemd_get_userunitdir() {
-	has "${EAPI:-0}" 0 1 2 && ! use prefix && EPREFIX=
 	debug-print-function ${FUNCNAME} "${@}"
 
 	echo "${EPREFIX}$(_systemd_get_userunitdir)"
@@ -121,7 +119,6 @@ _systemd_get_utildir() {
 # ${D}). This function always succeeds, even if systemd is not
 # installed.
 systemd_get_utildir() {
-	has "${EAPI:-0}" 0 1 2 && ! use prefix && EPREFIX=
 	debug-print-function ${FUNCNAME} "${@}"
 
 	echo "${EPREFIX}$(_systemd_get_utildir)"
@@ -138,10 +135,8 @@ _systemd_get_systemgeneratordir() {
 # @FUNCTION: systemd_get_systemgeneratordir
 # @DESCRIPTION:
 # Output the path for the systemd system generator directory (not including
-# ${D}). This function always succeeds, even if systemd is not
-# installed.
+# ${D}). This function always succeeds, even if systemd is not installed.
 systemd_get_systemgeneratordir() {
-	has "${EAPI:-0}" 0 1 2 && ! use prefix && EPREFIX=
 	debug-print-function ${FUNCNAME} "${@}"
 
 	echo "${EPREFIX}$(_systemd_get_systemgeneratordir)"
@@ -150,8 +145,7 @@ systemd_get_systemgeneratordir() {
 # @FUNCTION: systemd_dounit
 # @USAGE: <unit>...
 # @DESCRIPTION:
-# Install systemd unit(s). Uses doins, thus it is fatal in EAPI 4
-# and non-fatal in earlier EAPIs.
+# Install systemd unit(s). Uses doins, thus it is fatal.
 systemd_dounit() {
 	debug-print-function ${FUNCNAME} "${@}"
 
@@ -165,8 +159,7 @@ systemd_dounit() {
 # @FUNCTION: systemd_newunit
 # @USAGE: <old-name> <new-name>
 # @DESCRIPTION:
-# Install systemd unit with a new name. Uses newins, thus it is fatal
-# in EAPI 4 and non-fatal in earlier EAPIs.
+# Install systemd unit with a new name. Uses newins, thus it is fatal.
 systemd_newunit() {
 	debug-print-function ${FUNCNAME} "${@}"
 
@@ -180,8 +173,7 @@ systemd_newunit() {
 # @FUNCTION: systemd_douserunit
 # @USAGE: <unit>...
 # @DESCRIPTION:
-# Install systemd user unit(s). Uses doins, thus it is fatal in EAPI 4
-# and non-fatal in earlier EAPIs.
+# Install systemd user unit(s). Uses doins, thus it is fatal.
 systemd_douserunit() {
 	debug-print-function ${FUNCNAME} "${@}"
 
@@ -196,7 +188,7 @@ systemd_douserunit() {
 # @USAGE: <old-name> <new-name>
 # @DESCRIPTION:
 # Install systemd user unit with a new name. Uses newins, thus it
-# is fatal in EAPI 4 and non-fatal in earlier EAPIs.
+# is fatal.
 systemd_newuserunit() {
 	debug-print-function ${FUNCNAME} "${@}"
 
@@ -241,8 +233,7 @@ systemd_install_serviced() {
 # @USAGE: <target> <service>
 # @DESCRIPTION:
 # Enable service in desired target, e.g. install a symlink for it.
-# Uses dosym, thus it is fatal in EAPI 4 and non-fatal in earlier
-# EAPIs.
+# Uses dosym, thus it is fatal.
 systemd_enable_service() {
 	debug-print-function ${FUNCNAME} "${@}"
 
@@ -265,8 +256,7 @@ systemd_enable_service() {
 # and name, while the remaining arguments list service units that will
 # be added to that file.
 #
-# Uses doins, thus it is fatal in EAPI 4 and non-fatal in earlier
-# EAPIs.
+# Uses doins, thus it is fatal.
 #
 # Doc: https://www.freedesktop.org/wiki/Software/systemd/timedated/
 systemd_enable_ntpunit() {
@@ -321,7 +311,7 @@ systemd_enable_ntpunit() {
 # argument to this function (`$(systemd_with_unitdir systemdunitdir)'). Please
 # remember to report a bug upstream as well.
 systemd_with_unitdir() {
-	[[ ${EAPI:-0} != [012345] ]] && die "${FUNCNAME} is banned in EAPI ${EAPI}, use --with-${1:-systemdsystemunitdir}=\"\$(systemd_get_systemunitdir)\" instead"
+	[[ ${EAPI} == 5 ]] || die "${FUNCNAME} is banned in EAPI ${EAPI}, use --with-${1:-systemdsystemunitdir}=\"\$(systemd_get_systemunitdir)\" instead"
 
 	debug-print-function ${FUNCNAME} "${@}"
 	local optname=${1:-systemdsystemunitdir}
@@ -338,7 +328,7 @@ systemd_with_unitdir() {
 # systemd helpers. This function always succeeds. Its output may be quoted
 # in order to preserve whitespace in paths.
 systemd_with_utildir() {
-	[[ ${EAPI:-0} != [012345] ]] && die "${FUNCNAME} is banned in EAPI ${EAPI}, use --with-systemdutildir=\"\$(systemd_get_utildir)\" instead"
+	[[ ${EAPI} == 5 ]] || die "${FUNCNAME} is banned in EAPI ${EAPI}, use --with-systemdutildir=\"\$(systemd_get_utildir)\" instead"
 
 	debug-print-function ${FUNCNAME} "${@}"
 

--- a/eclass/udev.eclass
+++ b/eclass/udev.eclass
@@ -1,10 +1,10 @@
-# Copyright 1999-2018 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: udev.eclass
 # @MAINTAINER:
 # udev-bugs@gentoo.org
-# @SUPPORTED_EAPIS: 0 1 2 3 4 5 6 7
+# @SUPPORTED_EAPIS: 5 6 7 8
 # @BLURB: Default eclass for determining udev directories.
 # @DESCRIPTION:
 # Default eclass for determining udev directories.
@@ -28,18 +28,17 @@
 # }
 # @CODE
 
+case ${EAPI} in
+	5|6|7|8) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
+
 if [[ -z ${_UDEV_ECLASS} ]]; then
 _UDEV_ECLASS=1
 
 inherit toolchain-funcs
 
-case ${EAPI:-0} in
-	0|1|2|3|4|5|6|7) ;;
-	*) die "${ECLASS}.eclass API in EAPI ${EAPI} not yet established."
-esac
-
-if [[ ${EAPI:-0} == [0123456] ]]; then
-	RDEPEND=""
+if [[ ${EAPI} == [56] ]]; then
 	DEPEND="virtual/pkgconfig"
 else
 	BDEPEND="virtual/pkgconfig"
@@ -82,8 +81,7 @@ get_udevdir() {
 # @FUNCTION: udev_dorules
 # @USAGE: <rule> [...]
 # @DESCRIPTION:
-# Install udev rule(s). Uses doins, thus it is fatal in EAPI 4
-# and non-fatal in earlier EAPIs.
+# Install udev rule(s). Uses doins, thus it is fatal.
 udev_dorules() {
 	debug-print-function ${FUNCNAME} "${@}"
 
@@ -97,8 +95,7 @@ udev_dorules() {
 # @FUNCTION: udev_newrules
 # @USAGE: <oldname> <newname>
 # @DESCRIPTION:
-# Install udev rule with a new name. Uses newins, thus it is fatal
-# in EAPI 4 and non-fatal in earlier EAPIs.
+# Install udev rule with a new name. Uses newins, thus it is fatal.
 udev_newrules() {
 	debug-print-function ${FUNCNAME} "${@}"
 
@@ -113,7 +110,7 @@ udev_newrules() {
 # @DESCRIPTION:
 # Run udevadm control --reload to refresh rules and databases
 udev_reload() {
-	if [[ ${ROOT} != "" ]] && [[ ${ROOT} != "/" ]]; then
+	if [[ -n ${ROOT%/} ]]; then
 		return 0
 	fi
 

--- a/eclass/xdg-utils.eclass
+++ b/eclass/xdg-utils.eclass
@@ -1,4 +1,4 @@
-# Copyright 2004-2019 Gentoo Authors
+# Copyright 2004-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: xdg-utils.eclass
@@ -7,7 +7,7 @@
 # freedesktop-bugs@gentoo.org
 # @AUTHOR:
 # Original author: Gilles Dartiguelongue <eva@gentoo.org>
-# @SUPPORTED_EAPIS: 0 1 2 3 4 5 6 7
+# @SUPPORTED_EAPIS: 5 6 7 8
 # @BLURB: Auxiliary functions commonly used by XDG compliant packages.
 # @DESCRIPTION:
 # This eclass provides a set of auxiliary functions needed by most XDG
@@ -17,9 +17,9 @@
 #  * XDG .desktop files cache management
 #  * XDG mime information database management
 
-case "${EAPI:-0}" in
-	0|1|2|3|4|5|6|7) ;;
-	*) die "EAPI=${EAPI} is not supported" ;;
+case ${EAPI} in
+	5|6|7|8) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
 
 # @ECLASS-VARIABLE: DESKTOP_DATABASE_DIR
@@ -57,7 +57,7 @@ xdg_environment_reset() {
 # Updates the .desktop files database.
 # Generates a list of mimetypes linked to applications that can handle them
 xdg_desktop_database_update() {
-	if [[ ${EBUILD_PHASE} != post* ]] ; then
+	if [[ ${EBUILD_PHASE} != post* ]]; then
 		die "xdg_desktop_database_update must be used in pkg_post* phases."
 	fi
 
@@ -76,7 +76,7 @@ xdg_desktop_database_update() {
 # Updates icon theme cache files under /usr/share/icons.
 # This function should be called from pkg_postinst and pkg_postrm.
 xdg_icon_cache_update() {
-	if [[ ${EBUILD_PHASE} != post* ]] ; then
+	if [[ ${EBUILD_PHASE} != post* ]]; then
 		die "xdg_icon_cache_update must be used in pkg_post* phases."
 	fi
 
@@ -86,21 +86,17 @@ xdg_icon_cache_update() {
 	fi
 
 	ebegin "Updating icons cache"
-	local dir f retval=0
-	local fails=( )
-	for dir in "${EROOT%/}"/usr/share/icons/*
-	do
-		if [[ -f "${dir}/index.theme" ]] ; then
-			local rv=0
-			gtk-update-icon-cache -qf "${dir}"
-			rv=$?
-			if [[ ! $rv -eq 0 ]] ; then
+	local dir retval=0
+	local fails=()
+	for dir in "${EROOT%/}"/usr/share/icons/*; do
+		if [[ -f ${dir}/index.theme ]]; then
+			if ! gtk-update-icon-cache -qf "${dir}"; then
 				debug-print "Updating cache failed on ${dir}"
 				# Add to the list of failures
-				fails+=( "${dir}" )
+				fails+=("${dir}")
 				retval=2
 			fi
-		elif [[ $(ls "${dir}") = "icon-theme.cache" ]]; then
+		elif [[ $(ls "${dir}") = icon-theme.cache ]]; then
 			# Clear stale cache files after theme uninstallation
 			rm "${dir}/icon-theme.cache"
 		fi
@@ -110,8 +106,8 @@ xdg_icon_cache_update() {
 		fi
 	done
 	eend ${retval}
-	for f in "${fails[@]}" ; do
-		eerror "Failed to update cache with icon $f"
+	for dir in "${fails[@]}"; do
+		eerror "Failed to update cache with icon ${dir}"
 	done
 }
 
@@ -120,7 +116,7 @@ xdg_icon_cache_update() {
 # Update the mime database.
 # Creates a general list of mime types from several sources
 xdg_mimeinfo_database_update() {
-	if [[ ${EBUILD_PHASE} != post* ]] ; then
+	if [[ ${EBUILD_PHASE} != post* ]]; then
 		die "xdg_mimeinfo_database_update must be used in pkg_post* phases."
 	fi
 


### PR DESCRIPTION
@mgorny Here are the last few eclass updates.  The `meson-multilib.eclass` change has a dependency on #21409.

Aside from just adding EAPI 8 to the list of supported EAPIs, most of these changes fall into:
  - Dropping support for EAPIs that are not supported in inherited eclasses.
  - Moving the EAPI check before the inherit guard so using newer bash functionality won't result in syntax errors for old versions.
  - Setting the inherit guard variable before inherits so it prevents loops.
  - Trivial formatting unification where different styles are mixed in the same file.

@mattst88 @floppym @SoapGentoo