### PR TITLE
media-sound/spotify: Add libxkbcommon dependency

### DIFF
--- a/media-sound/spotify/spotify-1.1.56.ebuild
+++ b/media-sound/spotify/spotify-1.1.56.ebuild
@@ -34,6 +34,7 @@ RDEPEND="
 	systray? ( gnome-extra/gnome-integration-spotify )
 	x11-libs/gtk+:2
 	app-accessibility/at-spi2-atk
+	x11-libs/libxkbcommon
 	x11-libs/libXScrnSaver
 	x11-libs/libXtst
 	x11-libs/libSM


### PR DESCRIPTION
This pull request adds the `x11-libs/libxkbcommon` package to `=media-sound/spotify-1.1.56`. Not including this library will make it impossible to run Spotify unless `x11-libs/libxkbcommon` is manually installed (i.e. the shared library `libxkbcommon.so` cannot be found).

Signed-off-by: DelightedCat <bottledlactose@gmail.com>