### PR TITLE
vdr-plugin-2.eclass: add EAPI8 support, EAPI7+ fixes

### DIFF
--- a/eclass/vdr-plugin-2.eclass
+++ b/eclass/vdr-plugin-2.eclass
@@ -73,18 +73,16 @@
 
 [[ ${EAPI} == [5] ]] && inherit multilib
 [[ ${EAPI} == [56] ]] && inherit eutils
-inherit flag-o-matic toolchain-funcs unpacker
+inherit flag-o-matic strip-linguas toolchain-funcs unpacker
 
-case ${EAPI:-0} in
-	5|6|7)
+case ${EAPI} in
+	5|6|7|8)
 	;;
-	*) die "EAPI ${EAPI} unsupported."
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported"
 	;;
 esac
 
 EXPORT_FUNCTIONS pkg_setup src_unpack src_prepare src_compile src_install pkg_postinst pkg_postrm pkg_config
-
-IUSE=""
 
 # Name of the plugin stripped from all vdrplugin-, vdr- and -cvs pre- and postfixes
 VDRPLUGIN="${PN/#vdrplugin-/}"
@@ -97,10 +95,16 @@ DESCRIPTION="vdr Plugin: ${VDRPLUGIN} (based on vdr-plugin-2.eclass)"
 S="${WORKDIR}/${VDRPLUGIN}-${PV}"
 
 # depend on headers for DVB-driver and vdr-scripts
-DEPEND=">=media-tv/gentoo-vdr-scripts-0.4.2
-	virtual/linuxtv-dvb-headers"
-RDEPEND=">=media-tv/gentoo-vdr-scripts-0.4.2
-	>=app-eselect/eselect-vdr-0.0.2"
+case ${EAPI} in
+	5|6)	DEPEND="media-tv/gentoo-vdr-scripts
+				virtual/linuxtv-dvb-headers
+				virtual/pkgconfig" ;;
+	*)		BDEPEND="virtual/pkgconfig"
+			DEPEND="media-tv/gentoo-vdr-scripts
+				virtual/linuxtv-dvb-headers" ;;
+esac
+RDEPEND="media-tv/gentoo-vdr-scripts
+	app-eselect/eselect-vdr"
 
 if [[ "${GENTOO_VDR_CONDITIONAL:-no}" = "yes" ]]; then
 	IUSE="${IUSE} vdr"
@@ -151,7 +155,7 @@ vdr_create_header_checksum_file() {
 	local CHKSUM="header-md5-vdr"
 
 	if [[ -f ${VDR_CHECKSUM_DIR}/header-md5-vdr ]]; then
-		cp "${VDR_CHECKSUM_DIR}/header-md5-vdr" "${CHKSUM}"
+		cp "${VDR_CHECKSUM_DIR}/header-md5-vdr" "${CHKSUM}" || die "Could not copy header-md5-vdr"
 	elif type -p md5sum >/dev/null 2>&1; then
 		(
 			cd "${VDR_INCLUDE_DIR}"
@@ -179,7 +183,8 @@ fix_vdr_libsi_include() {
 	for f; do
 		sed -i "${f}" \
 			-e '/#include/s:"\(.*libsi.*\)":<\1>:' \
-			-e '/#include/s:<.*\(libsi/.*\)>:<vdr/\1>:'
+			-e '/#include/s:<.*\(libsi/.*\)>:<vdr/\1>:' \
+			|| die "sed failed while fixing include of libsi-headers"
 	done
 }
 
@@ -192,7 +197,7 @@ fix_vdr_libsi_include() {
 vdr_patchmakefile() {
 	einfo "Patching Makefile"
 	[[ -e Makefile ]] || die "Makefile of plugin can not be found!"
-	cp Makefile "${WORKDIR}"/Makefile.before
+	cp Makefile "${WORKDIR}"/Makefile.before || die "Failed to copy Makefile"
 
 	# plugin makefiles use VDRDIR in strange ways
 	# assumptions:
@@ -216,14 +221,16 @@ vdr_patchmakefile() {
 		-e '/VDRINCDIR.*=/!s:$(VDRDIR)/include:$(VDRINCDIR):' \
 		\
 		-e 's:-I$(DVBDIR)/include::' \
-		-e 's:-I$(DVBDIR)::'
+		-e 's:-I$(DVBDIR)::' \
+		|| die "sed failed to set \$VDRDIR"
 
 	if ! grep -q APIVERSION Makefile; then
 		ebegin "  Converting to APIVERSION"
 		sed -i Makefile \
 			-e 's:^APIVERSION = :APIVERSION ?= :' \
 			-e 's:$(LIBDIR)/$@.$(VDRVERSION):$(LIBDIR)/$@.$(APIVERSION):' \
-			-e '/VDRVERSION =/a\APIVERSION = $(shell sed -ne '"'"'/define APIVERSION/s/^.*"\\(.*\\)".*$$/\\1/p'"'"' $(VDRDIR)/config.h)'
+			-e '/VDRVERSION =/a\APIVERSION = $(shell sed -ne '"'"'/define APIVERSION/s/^.*"\\(.*\\)".*$$/\\1/p'"'"' $(VDRDIR)/config.h)' \
+			|| die "sed failed to change APIVERSION"
 		eend $?
 	fi
 
@@ -231,13 +238,15 @@ vdr_patchmakefile() {
 	# Do not overwrite CXXFLAGS, add LDFLAGS if missing
 	sed -i Makefile \
 		-e '/^CXXFLAGS[[:space:]]*=/s/=/?=/' \
-		-e '/LDFLAGS/!s:-shared:$(LDFLAGS) -shared:'
+		-e '/LDFLAGS/!s:-shared:$(LDFLAGS) -shared:' \
+		|| die "sed failed to fix compile-flags"
 
 	# Disabling file stripping, the package manager takes care of it
 	sed -i Makefile \
 		-e '/@.*strip/d' \
 		-e '/strip \$(LIBDIR)\/\$@/d' \
-		-e 's/STRIP.*=.*$/STRIP = true/'
+		-e 's/STRIP.*=.*$/STRIP = true/' \
+		|| die "sed failed to fix file stripping"
 
 	# Use a file instead of a variable as single-stepping via ebuild
 	# destroys environment.
@@ -318,14 +327,15 @@ vdr_i18n() {
 		if [[ "${KEEP_I18NOBJECT:-no}" = "yes" ]]; then
 			eqawarn "Forced to keep i18n.o"
 		else
-			sed -i "s:i18n.o::g" Makefile
+			sed -i "s:i18n.o::g" Makefile || die "sed failed to remove i18n from Makefile"
 			eqawarn "OBJECT i18n.o found, removed per sed"
 		fi
 	fi
 
 	local I18N_STRING=$( [[ -e i18n.h ]] && grep tI18nPhrase i18n.h )
 	if [[ -n ${I18N_STRING} ]]; then
-		sed -i "s:^extern[[:space:]]*const[[:space:]]*tI18nPhrase://static const tI18nPhrase:" i18n.h
+		sed -i "s:^extern[[:space:]]*const[[:space:]]*tI18nPhrase://static const tI18nPhrase:" i18n.h \
+			|| die "sed failed to replace tI18nPhrase"
 		eqawarn "obsolete tI18nPhrase found, disabled per sed, please recheck"
 	fi
 }
@@ -341,7 +351,8 @@ vdr_remove_i18n_include() {
 	local f
 	for f; do
 		sed -i "${f}" \
-		-e "s:^#include[[:space:]]*\"i18n.h\"://:"
+		-e "s:^#include[[:space:]]*\"i18n.h\"://:" \
+		|| die "sed failed to remove i18n_include"
 	done
 
 	eqawarn "removed i18n.h include in ${@}"
@@ -393,7 +404,8 @@ vdr-plugin-2_pkg_setup() {
 	append-cxxflags -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE
 
 	# Where should the plugins live in the filesystem
-	VDR_PLUGIN_DIR=$(pkg-config --variable=libdir vdr)
+	local PKG__CONFIG=$(tc-getPKG_CONFIG)
+	VDR_PLUGIN_DIR=$(${PKG__CONFIG} --variable=libdir vdr)
 
 	VDR_CHECKSUM_DIR="${VDR_PLUGIN_DIR%/plugins}/checksums"
 
@@ -405,7 +417,7 @@ vdr-plugin-2_pkg_setup() {
 
 	TMP_LOCALE_DIR="${T}/tmp-locale"
 
-	LOCDIR=$(pkg-config --variable=locdir vdr)
+	LOCDIR=$(${PKG__CONFIG} --variable=locdir vdr)
 
 	if ! has_vdr; then
 		# set to invalid values to detect abuses
@@ -422,7 +434,7 @@ vdr-plugin-2_pkg_setup() {
 	fi
 
 	VDRVERSION=$(awk -F'"' '/define VDRVERSION/ {print $2}' "${VDR_INCLUDE_DIR}"/config.h)
-	APIVERSION=$(pkg-config --variable=apiversion vdr)
+	APIVERSION=$(${PKG__CONFIG} --variable=apiversion vdr)
 
 	einfo "Compiling against"
 	einfo "\tvdr-${VDRVERSION} [API version ${APIVERSION}]"
@@ -551,10 +563,11 @@ vdr-plugin-2_src_install() {
 
 	if [[ -n ${VDR_MAINTAINER_MODE} ]]; then
 		local mname="${P}-Makefile"
-		cp "${S}"/Makefile "${mname}.patched"
-		cp Makefile.before "${mname}.before"
+		cp "${S}"/Makefile "${mname}.patched" || die "could not copy to Makefile.patched"
+		cp Makefile.before "${mname}.before" || die "could not copy to Makefile.before"
 
 		diff -u "${mname}.before" "${mname}.patched" > "${mname}.diff"
+		[[ $? -ge 2 ]] && die "problem with diff"
 
 		insinto "/usr/share/vdr/maintainer-data/makefile-changes"
 		doins "${mname}.diff"
@@ -564,7 +577,6 @@ vdr-plugin-2_src_install() {
 
 		insinto "/usr/share/vdr/maintainer-data/makefile-patched"
 		doins "${mname}.patched"
-
 	fi
 
 	cd "${S}" || die "could not change to plugin source directory (src_install)"
@@ -589,11 +601,11 @@ vdr-plugin-2_src_install() {
 		local linguas
 		for linguas in ${LINGUAS[*]}; do
 		insinto "${LOCDIR}"
-		cp -r --parents ${linguas}* ${D%/}/${LOCDIR}
+		cp -r --parents ${linguas}* ${D%/}/${LOCDIR} || die "could not copy linguas files"
 		done
 	fi
 
-	cd "${D%/}/usr/$(get_libdir)/vdr/plugins" || die "could not change to D/usr/libdir/vdr/plugins"
+	cd "${D%/}/usr/$(get_libdir)/vdr/plugins" || die "could not change to \$D/usr/libdir/vdr/plugins"
 
 	# create list of all created plugin libs
 	vdr_plugin_list=""


### PR DESCRIPTION
- add EAPI8 support, no changes necessary
- add BDEPEND=pkgconfig
- remove outdated version numbers from (R)DEPEND
- fix calling of pkg-config
- add many "|| die" which should have been here already for EAPI7

Signed-off-by: Martin Dummer <martin.dummer@gmx.net>