### PR TITLE
app-arch/upx{,-bin}: add app-arch/xz-utils to BDEPEND

### DIFF
--- a/app-arch/upx-bin/upx-bin-3.96.ebuild
+++ b/app-arch/upx-bin/upx-bin-3.96.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -23,6 +23,7 @@ KEYWORDS="~amd64 ~arm ~arm64 ~mips ~ppc ~ppc64 ~x86"
 RESTRICT="strip"
 
 RDEPEND="!app-arch/upx"
+BDEPEND="app-arch/xz-utils[extra-filters]"
 
 S="${WORKDIR}"
 

--- a/app-arch/upx/upx-3.96-r2.ebuild
+++ b/app-arch/upx/upx-3.96-r2.ebuild
@@ -18,7 +18,9 @@ DEPEND=">=dev-libs/ucl-1.03
 	sys-libs/zlib"
 RDEPEND="${RDEPEND}
 	!app-arch/upx-bin"
-BDEPEND="dev-lang/perl"
+BDEPEND="
+	app-arch/xz-utils[extra-filters]
+	dev-lang/perl"
 
 S="${WORKDIR}/${P}-src"
 


### PR DESCRIPTION
Original tarball requires app-arch/xz-utils[extra-filters] for extraction.

Bug: https://bugs.gentoo.org/797361

Package-Manager: Portage-3.0.20, Repoman-3.0.2
Signed-off-by: Azamat H. Hackimov <azamat.hackimov@gmail.com>