### PR TITLE
dev-lua/luaposix: add virtual/libcrypt:= to DEPEND

### DIFF
--- a/dev-lua/luaposix/luaposix-35.0-r103.ebuild
+++ b/dev-lua/luaposix/luaposix-35.0-r103.ebuild
@@ -20,7 +20,9 @@ REQUIRED_USE="${LUA_REQUIRED_USE}"
 # Requires specl, which is not in the tree yet
 RESTRICT="test"
 
-DEPEND="${LUA_DEPS}"
+DEPEND="${LUA_DEPS}
+	virtual/libcrypt:=
+"
 RDEPEND="${DEPEND}
 	lua_targets_lua5-1? ( dev-lua/lua-bit32[lua_targets_lua5-1(-)] )
 	lua_targets_luajit? ( dev-lua/lua-bit32[lua_targets_luajit(-)] )


### PR DESCRIPTION
Fix Portage QA warning.
Closes: https://bugs.gentoo.org/799050
Package-Manager: Portage-3.0.20, Repoman-3.0.2
Signed-off-by: Azamat H. Hackimov <azamat.hackimov@gmail.com>