### PR TITLE
systemd.eclass: drop deprecated tmpfiles functions

### DIFF
--- a/eclass/systemd.eclass
+++ b/eclass/systemd.eclass
@@ -237,48 +237,6 @@ systemd_install_serviced() {
 	)
 }
 
-# @FUNCTION: systemd_dotmpfilesd
-# @USAGE: <tmpfilesd>...
-# @DESCRIPTION:
-# Deprecated in favor of tmpfiles.eclass.
-#
-# Install systemd tmpfiles.d files. Uses doins, thus it is fatal
-# in EAPI 4 and non-fatal in earlier EAPIs.
-systemd_dotmpfilesd() {
-	debug-print-function ${FUNCNAME} "${@}"
-
-	for f; do
-		[[ ${f} == *.conf ]] \
-			|| die 'tmpfiles.d files need to have .conf suffix.'
-	done
-
-	(
-		insopts -m 0644
-		insinto /usr/lib/tmpfiles.d/
-		doins "${@}"
-	)
-}
-
-# @FUNCTION: systemd_newtmpfilesd
-# @USAGE: <old-name> <new-name>.conf
-# @DESCRIPTION:
-# Deprecated in favor of tmpfiles.eclass.
-#
-# Install systemd tmpfiles.d file under a new name. Uses newins, thus it
-# is fatal in EAPI 4 and non-fatal in earlier EAPIs.
-systemd_newtmpfilesd() {
-	debug-print-function ${FUNCNAME} "${@}"
-
-	[[ ${2} == *.conf ]] \
-		|| die 'tmpfiles.d files need to have .conf suffix.'
-
-	(
-		insopts -m 0644
-		insinto /usr/lib/tmpfiles.d/
-		newins "${@}"
-	)
-}
-
 # @FUNCTION: systemd_enable_service
 # @USAGE: <target> <service>
 # @DESCRIPTION:
@@ -434,29 +392,6 @@ systemd_is_booted() {
 
 	debug-print "${FUNCNAME}: [[ -d /run/systemd/system ]] -> ${ret}"
 	return ${ret}
-}
-
-# @FUNCTION: systemd_tmpfiles_create
-# @USAGE: <tmpfilesd> ...
-# @DESCRIPTION:
-# Deprecated in favor of tmpfiles.eclass.
-#
-# Invokes systemd-tmpfiles --create with given arguments.
-# Does nothing if ROOT != / or systemd-tmpfiles is not in PATH.
-# This function should be called from pkg_postinst.
-#
-# Generally, this function should be called with the names of any tmpfiles
-# fragments which have been installed, either by the build system or by a
-# previous call to systemd_dotmpfilesd. This ensures that any tmpfiles are
-# created without the need to reboot the system.
-systemd_tmpfiles_create() {
-	debug-print-function ${FUNCNAME} "${@}"
-
-	[[ ${EBUILD_PHASE} == postinst ]] || die "${FUNCNAME}: Only valid in pkg_postinst"
-	[[ ${#} -gt 0 ]] || die "${FUNCNAME}: Must specify at least one filename"
-	[[ ${ROOT:-/} == / ]] || return 0
-	type systemd-tmpfiles &> /dev/null || return 0
-	systemd-tmpfiles --create "${@}"
 }
 
 # @FUNCTION: systemd_reenable

--- a/eclass/toolchain-glibc.eclass
+++ b/eclass/toolchain-glibc.eclass
@@ -12,8 +12,10 @@
 
 if [[ -z ${_TOOLCHAIN_GLIBC_ECLASS} ]]; then
 
+TMPFILES_OPTIONAL=1
+
 inherit eutils versionator toolchain-funcs flag-o-matic gnuconfig \
-	multilib systemd unpacker multiprocessing prefix
+	multilib systemd tmpfiles unpacker multiprocessing prefix
 
 case ${EAPI:-0} in
 	0|1|2|3) EXPORT_FUNCTIONS pkg_setup src_unpack src_compile src_test \
@@ -1348,10 +1350,10 @@ toolchain-glibc_do_src_install() {
 		# TODO: Drop the $FILESDIR copy once 2.19 goes stable.
 		if version_is_at_least 2.19 ; then
 			systemd_dounit nscd/nscd.service || die
-			systemd_newtmpfilesd nscd/nscd.tmpfiles nscd.conf || die
+			newtmpfiles nscd/nscd.tmpfiles nscd.conf || die
 		else
 			systemd_dounit "${FILESDIR}"/nscd.service || die
-			systemd_newtmpfilesd "${FILESDIR}"/nscd.tmpfilesd nscd.conf || die
+			newtmpfiles "${FILESDIR}"/nscd.tmpfilesd nscd.conf || die
 		fi
 	else
 		# Do this since extra/etc/*.conf above might have nscd.conf.

--- a/media-sound/pulseaudio/pulseaudio-14.99.2_pre1.ebuild
+++ b/media-sound/pulseaudio/pulseaudio-14.99.2_pre1.ebuild
@@ -6,7 +6,7 @@ EAPI="7"
 MY_PV="${PV/_pre*}"
 MY_P="${PN}-${MY_PV}"
 
-inherit bash-completion-r1 gnome2-utils meson-multilib optfeature systemd udev
+inherit bash-completion-r1 gnome2-utils meson-multilib optfeature systemd tmpfiles udev
 
 DESCRIPTION="A networked sound server with an advanced plugin system"
 HOMEPAGE="https://www.freedesktop.org/wiki/Software/PulseAudio/"
@@ -287,7 +287,7 @@ multilib_src_install_all() {
 		systemd_dounit "${FILESDIR}"/${PN}.service
 
 		# We need /var/run/pulse, bug 442852
-		systemd_newtmpfilesd "${FILESDIR}"/${PN}.tmpfiles ${PN}.conf
+		newtmpfiles "${FILESDIR}"/${PN}.tmpfiles ${PN}.conf
 	else
 		# Prevent warnings when system-wide is not used, bug 447694
 		if use dbus && use daemon; then

--- a/net-analyzer/zabbix/zabbix-5.0.10-r1.ebuild
+++ b/net-analyzer/zabbix/zabbix-5.0.10-r1.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 # needed to make webapp-config dep optional
 WEBAPP_OPTIONAL="yes"
-inherit webapp java-pkg-opt-2 systemd toolchain-funcs go-module user-info
+inherit webapp java-pkg-opt-2 systemd tmpfiles toolchain-funcs go-module user-info
 EGO_SUM=(
 	"github.com/BurntSushi/locker v0.0.0-20171006230638-a6e239ea1c69 h1:+tu3HOoMXB7RXEINRVIpxJCT+KdYiI7LAEAUrOw3dIU="
 	"github.com/BurntSushi/locker v0.0.0-20171006230638-a6e239ea1c69/go.mod h1:L1AbZdiDllfyYH5l5OkAaZtk7VkWe89bPJFmnDBNHxg="
@@ -421,7 +421,7 @@ src_install() {
 		doins -r "${S}"/database/
 
 		systemd_dounit "${FILESDIR}"/zabbix-server.service
-		systemd_newtmpfilesd "${FILESDIR}"/zabbix-server.tmpfiles zabbix-server.conf
+		newtmpfiles "${FILESDIR}"/zabbix-server.tmpfiles zabbix-server.conf
 	fi
 
 	if use proxy; then
@@ -438,7 +438,7 @@ src_install() {
 		doins -r "${S}"/database/
 
 		systemd_dounit "${FILESDIR}"/zabbix-proxy.service
-		systemd_newtmpfilesd "${FILESDIR}"/zabbix-proxy.tmpfiles zabbix-proxy.conf
+		newtmpfiles "${FILESDIR}"/zabbix-proxy.tmpfiles zabbix-proxy.conf
 	fi
 
 	if use agent; then
@@ -455,7 +455,7 @@ src_install() {
 			src/zabbix_get/zabbix_get
 
 		systemd_dounit "${FILESDIR}"/zabbix-agentd.service
-		systemd_newtmpfilesd "${FILESDIR}"/zabbix-agentd.tmpfiles zabbix-agentd.conf
+		newtmpfiles "${FILESDIR}"/zabbix-agentd.tmpfiles zabbix-agentd.conf
 	fi
 
 	if use agent2; then
@@ -469,7 +469,7 @@ src_install() {
 		dosbin src/go/bin/zabbix_agent2
 
 		systemd_dounit "${FILESDIR}"/zabbix-agent2.service
-		systemd_newtmpfilesd "${FILESDIR}"/zabbix-agent2.tmpfiles zabbix-agent2.conf
+		newtmpfiles "${FILESDIR}"/zabbix-agent2.tmpfiles zabbix-agent2.conf
 	fi
 
 	fowners root:zabbix /etc/zabbix

--- a/net-analyzer/zabbix/zabbix-5.0.11-r1.ebuild
+++ b/net-analyzer/zabbix/zabbix-5.0.11-r1.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 # needed to make webapp-config dep optional
 WEBAPP_OPTIONAL="yes"
-inherit webapp java-pkg-opt-2 systemd toolchain-funcs go-module user-info
+inherit webapp java-pkg-opt-2 systemd tmpfiles toolchain-funcs go-module user-info
 EGO_SUM=(
 	"github.com/BurntSushi/locker v0.0.0-20171006230638-a6e239ea1c69 h1:+tu3HOoMXB7RXEINRVIpxJCT+KdYiI7LAEAUrOw3dIU="
 	"github.com/BurntSushi/locker v0.0.0-20171006230638-a6e239ea1c69/go.mod h1:L1AbZdiDllfyYH5l5OkAaZtk7VkWe89bPJFmnDBNHxg="
@@ -421,7 +421,7 @@ src_install() {
 		doins -r "${S}"/database/
 
 		systemd_dounit "${FILESDIR}"/zabbix-server.service
-		systemd_newtmpfilesd "${FILESDIR}"/zabbix-server.tmpfiles zabbix-server.conf
+		newtmpfiles "${FILESDIR}"/zabbix-server.tmpfiles zabbix-server.conf
 	fi
 
 	if use proxy; then
@@ -438,7 +438,7 @@ src_install() {
 		doins -r "${S}"/database/
 
 		systemd_dounit "${FILESDIR}"/zabbix-proxy.service
-		systemd_newtmpfilesd "${FILESDIR}"/zabbix-proxy.tmpfiles zabbix-proxy.conf
+		newtmpfiles "${FILESDIR}"/zabbix-proxy.tmpfiles zabbix-proxy.conf
 	fi
 
 	if use agent; then
@@ -455,7 +455,7 @@ src_install() {
 			src/zabbix_get/zabbix_get
 
 		systemd_dounit "${FILESDIR}"/zabbix-agentd.service
-		systemd_newtmpfilesd "${FILESDIR}"/zabbix-agentd.tmpfiles zabbix-agentd.conf
+		newtmpfiles "${FILESDIR}"/zabbix-agentd.tmpfiles zabbix-agentd.conf
 	fi
 
 	if use agent2; then
@@ -469,7 +469,7 @@ src_install() {
 		dosbin src/go/bin/zabbix_agent2
 
 		systemd_dounit "${FILESDIR}"/zabbix-agent2.service
-		systemd_newtmpfilesd "${FILESDIR}"/zabbix-agent2.tmpfiles zabbix-agent2.conf
+		newtmpfiles "${FILESDIR}"/zabbix-agent2.tmpfiles zabbix-agent2.conf
 	fi
 
 	fowners root:zabbix /etc/zabbix

--- a/net-analyzer/zabbix/zabbix-5.0.12-r1.ebuild
+++ b/net-analyzer/zabbix/zabbix-5.0.12-r1.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 # needed to make webapp-config dep optional
 WEBAPP_OPTIONAL="yes"
-inherit webapp java-pkg-opt-2 systemd toolchain-funcs go-module user-info
+inherit webapp java-pkg-opt-2 systemd tmpfiles toolchain-funcs go-module user-info
 EGO_SUM=(
 	"github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU="
 	"github.com/cockroachdb/apd v1.1.0 h1:3LFP3629v+1aKXU5Q37mxmRxX/pIu1nijXydLShEq5I="
@@ -419,7 +419,7 @@ src_install() {
 		doins -r "${S}"/database/
 
 		systemd_dounit "${FILESDIR}"/zabbix-server.service
-		systemd_newtmpfilesd "${FILESDIR}"/zabbix-server.tmpfiles zabbix-server.conf
+		newtmpfiles "${FILESDIR}"/zabbix-server.tmpfiles zabbix-server.conf
 	fi
 
 	if use proxy; then
@@ -436,7 +436,7 @@ src_install() {
 		doins -r "${S}"/database/
 
 		systemd_dounit "${FILESDIR}"/zabbix-proxy.service
-		systemd_newtmpfilesd "${FILESDIR}"/zabbix-proxy.tmpfiles zabbix-proxy.conf
+		newtmpfiles "${FILESDIR}"/zabbix-proxy.tmpfiles zabbix-proxy.conf
 	fi
 
 	if use agent; then
@@ -453,7 +453,7 @@ src_install() {
 			src/zabbix_get/zabbix_get
 
 		systemd_dounit "${FILESDIR}"/zabbix-agentd.service
-		systemd_newtmpfilesd "${FILESDIR}"/zabbix-agentd.tmpfiles zabbix-agentd.conf
+		newtmpfiles "${FILESDIR}"/zabbix-agentd.tmpfiles zabbix-agentd.conf
 	fi
 
 	if use agent2; then
@@ -467,7 +467,7 @@ src_install() {
 		dosbin src/go/bin/zabbix_agent2
 
 		systemd_dounit "${FILESDIR}"/zabbix-agent2.service
-		systemd_newtmpfilesd "${FILESDIR}"/zabbix-agent2.tmpfiles zabbix-agent2.conf
+		newtmpfiles "${FILESDIR}"/zabbix-agent2.tmpfiles zabbix-agent2.conf
 	fi
 
 	fowners root:zabbix /etc/zabbix

--- a/net-analyzer/zabbix/zabbix-5.2.6-r1.ebuild
+++ b/net-analyzer/zabbix/zabbix-5.2.6-r1.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 # needed to make webapp-config dep optional
 WEBAPP_OPTIONAL="yes"
-inherit webapp java-pkg-opt-2 systemd toolchain-funcs go-module user-info
+inherit webapp java-pkg-opt-2 systemd tmpfiles toolchain-funcs go-module user-info
 # content of src/go/go.sum
 EGO_SUM=(
 	"github.com/BurntSushi/locker v0.0.0-20171006230638-a6e239ea1c69 h1:+tu3HOoMXB7RXEINRVIpxJCT+KdYiI7LAEAUrOw3dIU="
@@ -428,7 +428,7 @@ src_install() {
 		doins -r "${S}"/database/
 
 		systemd_dounit "${FILESDIR}"/zabbix-server.service
-		systemd_newtmpfilesd "${FILESDIR}"/zabbix-server.tmpfiles zabbix-server.conf
+		newtmpfiles "${FILESDIR}"/zabbix-server.tmpfiles zabbix-server.conf
 	fi
 
 	if use proxy; then
@@ -445,7 +445,7 @@ src_install() {
 		doins -r "${S}"/database/
 
 		systemd_dounit "${FILESDIR}"/zabbix-proxy.service
-		systemd_newtmpfilesd "${FILESDIR}"/zabbix-proxy.tmpfiles zabbix-proxy.conf
+		newtmpfiles "${FILESDIR}"/zabbix-proxy.tmpfiles zabbix-proxy.conf
 	fi
 
 	if use agent; then
@@ -462,7 +462,7 @@ src_install() {
 			src/zabbix_get/zabbix_get
 
 		systemd_dounit "${FILESDIR}"/zabbix-agentd.service
-		systemd_newtmpfilesd "${FILESDIR}"/zabbix-agentd.tmpfiles zabbix-agentd.conf
+		newtmpfiles "${FILESDIR}"/zabbix-agentd.tmpfiles zabbix-agentd.conf
 	fi
 	if use agent2; then
 		insinto /etc/zabbix
@@ -475,7 +475,7 @@ src_install() {
 		dosbin src/go/bin/zabbix_agent2
 
 		systemd_dounit "${FILESDIR}"/zabbix-agent2.service
-		systemd_newtmpfilesd "${FILESDIR}"/zabbix-agent2.tmpfiles zabbix-agent2.conf
+		newtmpfiles "${FILESDIR}"/zabbix-agent2.tmpfiles zabbix-agent2.conf
 	fi
 
 	fowners root:zabbix /etc/zabbix

--- a/net-analyzer/zabbix/zabbix-5.4.0-r1.ebuild
+++ b/net-analyzer/zabbix/zabbix-5.4.0-r1.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 # needed to make webapp-config dep optional
 WEBAPP_OPTIONAL="yes"
-inherit webapp java-pkg-opt-2 systemd toolchain-funcs go-module user-info
+inherit webapp java-pkg-opt-2 systemd tmpfiles toolchain-funcs go-module user-info
 # content of src/go/go.sum
 EGO_SUM=(
 	"github.com/BurntSushi/locker v0.0.0-20171006230638-a6e239ea1c69 h1:+tu3HOoMXB7RXEINRVIpxJCT+KdYiI7LAEAUrOw3dIU="
@@ -444,7 +444,7 @@ src_install() {
 		doins -r "${S}"/database/
 
 		systemd_dounit "${FILESDIR}"/zabbix-server.service
-		systemd_newtmpfilesd "${FILESDIR}"/zabbix-server.tmpfiles zabbix-server.conf
+		newtmpfiles "${FILESDIR}"/zabbix-server.tmpfiles zabbix-server.conf
 	fi
 
 	if use proxy; then
@@ -461,7 +461,7 @@ src_install() {
 		doins -r "${S}"/database/
 
 		systemd_dounit "${FILESDIR}"/zabbix-proxy.service
-		systemd_newtmpfilesd "${FILESDIR}"/zabbix-proxy.tmpfiles zabbix-proxy.conf
+		newtmpfiles "${FILESDIR}"/zabbix-proxy.tmpfiles zabbix-proxy.conf
 	fi
 
 	if use agent; then
@@ -478,7 +478,7 @@ src_install() {
 			src/zabbix_get/zabbix_get
 
 		systemd_dounit "${FILESDIR}"/zabbix-agentd.service
-		systemd_newtmpfilesd "${FILESDIR}"/zabbix-agentd.tmpfiles zabbix-agentd.conf
+		newtmpfiles "${FILESDIR}"/zabbix-agentd.tmpfiles zabbix-agentd.conf
 	fi
 	if use agent2; then
 		insinto /etc/zabbix
@@ -491,7 +491,7 @@ src_install() {
 		dosbin src/go/bin/zabbix_agent2
 
 		systemd_dounit "${FILESDIR}"/zabbix-agent2.service
-		systemd_newtmpfilesd "${FILESDIR}"/zabbix-agent2.tmpfiles zabbix-agent2.conf
+		newtmpfiles "${FILESDIR}"/zabbix-agent2.tmpfiles zabbix-agent2.conf
 	fi
 
 	fowners root:zabbix /etc/zabbix

--- a/net-analyzer/zabbix/zabbix-5.4.1-r1.ebuild
+++ b/net-analyzer/zabbix/zabbix-5.4.1-r1.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 # needed to make webapp-config dep optional
 WEBAPP_OPTIONAL="yes"
-inherit webapp java-pkg-opt-2 systemd toolchain-funcs go-module user-info
+inherit webapp java-pkg-opt-2 systemd tmpfiles toolchain-funcs go-module user-info
 # content of src/go/go.sum
 EGO_SUM=(
 	"github.com/BurntSushi/locker v0.0.0-20171006230638-a6e239ea1c69 h1:+tu3HOoMXB7RXEINRVIpxJCT+KdYiI7LAEAUrOw3dIU="
@@ -444,7 +444,7 @@ src_install() {
 		doins -r "${S}"/database/
 
 		systemd_dounit "${FILESDIR}"/zabbix-server.service
-		systemd_newtmpfilesd "${FILESDIR}"/zabbix-server.tmpfiles zabbix-server.conf
+		newtmpfiles "${FILESDIR}"/zabbix-server.tmpfiles zabbix-server.conf
 	fi
 
 	if use proxy; then
@@ -461,7 +461,7 @@ src_install() {
 		doins -r "${S}"/database/
 
 		systemd_dounit "${FILESDIR}"/zabbix-proxy.service
-		systemd_newtmpfilesd "${FILESDIR}"/zabbix-proxy.tmpfiles zabbix-proxy.conf
+		newtmpfiles "${FILESDIR}"/zabbix-proxy.tmpfiles zabbix-proxy.conf
 	fi
 
 	if use agent; then
@@ -478,7 +478,7 @@ src_install() {
 			src/zabbix_get/zabbix_get
 
 		systemd_dounit "${FILESDIR}"/zabbix-agentd.service
-		systemd_newtmpfilesd "${FILESDIR}"/zabbix-agentd.tmpfiles zabbix-agentd.conf
+		newtmpfiles "${FILESDIR}"/zabbix-agentd.tmpfiles zabbix-agentd.conf
 	fi
 	if use agent2; then
 		insinto /etc/zabbix
@@ -491,7 +491,7 @@ src_install() {
 		dosbin src/go/bin/zabbix_agent2
 
 		systemd_dounit "${FILESDIR}"/zabbix-agent2.service
-		systemd_newtmpfilesd "${FILESDIR}"/zabbix-agent2.tmpfiles zabbix-agent2.conf
+		newtmpfiles "${FILESDIR}"/zabbix-agent2.tmpfiles zabbix-agent2.conf
 	fi
 
 	fowners root:zabbix /etc/zabbix

--- a/net-dns/coredns/coredns-1.8.3.ebuild
+++ b/net-dns/coredns/coredns-1.8.3.ebuild
@@ -834,7 +834,7 @@ EGO_SUM=(
 	"sourcegraph.com/sourcegraph/appdash v0.0.0-20190731080439-ebfcffb1b5c0/go.mod"
 )
 
-inherit fcaps go-module systemd
+inherit fcaps go-module systemd tmpfiles
 go-module_set_globals
 
 ARCHIVE_URI="https://github.com/${PN}/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
@@ -874,7 +874,7 @@ src_install() {
 	newins "${FILESDIR}"/coredns.logrotated coredns
 
 	systemd_dounit "${FILESDIR}"/coredns.service
-	systemd_newtmpfilesd "${FILESDIR}"/coredns.tmpfiles "${PN}.conf"
+	newtmpfiles "${FILESDIR}"/coredns.tmpfiles "${PN}.conf"
 }
 
 src_test() {


### PR DESCRIPTION
@floppym So oddly, the old versions of these packages used `tmpfiles.eclass` correctly and then downgraded to the deprecated functions in newer versions.  I omitted `TMPFILES_OPTIONAL=1` on them because the old versions didn't use it, but I did add it to the eclass since all other glibc versions use it due to [bug #774855](https://bugs.gentoo.org/774855).