### PR TITLE
Add media-libs/liblrdf to gst-plugins-ladspa-1.18.4 dependencies

### DIFF
--- a/media-libs/liblrdf/liblrdf-0.6.1-r1.ebuild
+++ b/media-libs/liblrdf/liblrdf-0.6.1-r1.ebuild
@@ -1,0 +1,46 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit autotools multilib-minimal
+
+DESCRIPTION="Library for manipulation of RDF files in LADSPA plugins"
+HOMEPAGE="https://github.com/swh/LRDF"
+SRC_URI="https://github.com/swh/LRDF/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~hppa ~ppc ~ppc64 ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
+IUSE="static-libs"
+
+RDEPEND="
+	media-libs/ladspa-sdk[${MULTILIB_USEDEP}]
+	media-libs/raptor:2[${MULTILIB_USEDEP}]
+"
+DEPEND="${RDEPEND}
+	virtual/pkgconfig"
+
+DOCS=( AUTHORS ChangeLog README )
+
+S="${WORKDIR}/LRDF-${PV}"
+
+src_prepare() {
+	default
+	sed -i -e 's:usr/local:usr:' examples/{instances,remove}_test.c || die #392221
+	eautoreconf
+	multilib_copy_sources
+}
+
+multilib_src_configure() {
+	econf $(use_enable static-libs static)
+}
+
+multilib_src_test() {
+	has_version media-plugins/swh-plugins && default #392221
+}
+
+multilib_src_install() {
+	default
+	find "${D}" -name '*.la' -delete || die
+}

--- a/media-libs/raptor/raptor-2.0.15-r4.ebuild
+++ b/media-libs/raptor/raptor-2.0.15-r4.ebuild
@@ -1,0 +1,76 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit autotools libtool multilib-minimal
+
+MY_PN=${PN}2
+MY_P=${MY_PN}-${PV}
+
+DESCRIPTION="The RDF Parser Toolkit"
+HOMEPAGE="http://librdf.org/raptor/"
+SRC_URI="http://download.librdf.org/source/${MY_P}.tar.gz"
+
+LICENSE="Apache-2.0 GPL-2 LGPL-2.1"
+SLOT="2"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+IUSE="+curl debug json static-libs unicode"
+
+DEPEND="
+	dev-libs/libxml2[${MULTILIB_USEDEP}]
+	dev-libs/libxslt[${MULTILIB_USEDEP}]
+	curl? ( net-misc/curl[${MULTILIB_USEDEP}] )
+	json? ( dev-libs/yajl[${MULTILIB_USEDEP}] )
+	unicode? ( dev-libs/icu:=[${MULTILIB_USEDEP}] )
+"
+RDEPEND="${DEPEND}
+	!media-libs/raptor:0
+"
+BDEPEND="
+	>=sys-devel/bison-3
+	>=sys-devel/flex-2.5.36
+	virtual/pkgconfig
+"
+
+S="${WORKDIR}/${MY_P}"
+
+DOCS=( AUTHORS ChangeLog NEWS NOTICE README )
+HTML_DOCS=( {NEWS,README,RELEASE,UPGRADING}.html )
+
+PATCHES=(
+	"${FILESDIR}/${P}-heap-overflow.patch"
+	"${FILESDIR}/${P}-dont_use_curl-config.patch" #552474
+	"${FILESDIR}/0001-CVE-2020-25713-raptor2-malformed-input-file-can-lead.patch"
+)
+
+src_prepare() {
+	default
+	eautoreconf #552474
+	elibtoolize # Keep this for ~*-fbsd
+	multilib_copy_sources
+}
+
+multilib_src_configure() {
+	# FIXME: It should be possible to use net-nntp/inn for libinn.h and -linn!
+
+	local myeconfargs=(
+		--with-html-dir="${EPREFIX}"/usr/share/gtk-doc/html
+		$(usex curl --with-www=curl --with-www=xml)
+		$(use_enable debug)
+		$(use_with json yajl)
+		$(use_enable static-libs static)
+		$(usex unicode --with-icu-config="${EPREFIX}"/usr/bin/icu-config '')
+	)
+
+	econf "${myeconfargs[@]}"
+}
+
+multilib_src_test() {
+	emake -j1 test
+}
+
+multilib_src_install() {
+	default
+	find "${ED}" -name '*.la' -delete || die
+}

--- a/media-plugins/gst-plugins-ladspa/gst-plugins-ladspa-1.18.4.ebuild
+++ b/media-plugins/gst-plugins-ladspa/gst-plugins-ladspa-1.18.4.ebuild
@@ -10,5 +10,8 @@ DESCRIPTION="Ladspa elements for Gstreamer"
 KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~x86"
 IUSE=""
 
-RDEPEND=">=media-libs/ladspa-sdk-1.13-r2[${MULTILIB_USEDEP}]"
+RDEPEND="
+	>=media-libs/ladspa-sdk-1.13-r2[${MULTILIB_USEDEP}]
+	media-libs/liblrdf[${MULTILIB_USEDEP}]
+"
 DEPEND="${RDEPEND}"


### PR DESCRIPTION
This also means making media-libs/liblrdf and media-libs/raptor multilib as gstreamer is.