### PR TITLE
sys-devel/llvm-roc: Fixed wrong patch

### DIFF
--- a/sys-devel/llvm-roc/llvm-roc-4.2.0.ebuild
+++ b/sys-devel/llvm-roc/llvm-roc-4.2.0.ebuild
@@ -24,7 +24,7 @@ S="${WORKDIR}/llvm-project-rocm-${PV}/llvm"
 
 PATCHES=(
 	"${FILESDIR}/${PN}-4.2.0-current_pos.patch"
-	"${FILESDIR}/${PN}-4.2.0-add_BinaryFormat.patch"
+	"${FILESDIR}/${PN}-4.2.0-add_Object.patch"
 )
 
 CMAKE_BUILD_TYPE=RelWithDebInfo


### PR DESCRIPTION
Signed-off-by: Wilfried Holzke <gentoo@holzke.net>
Package-Manager: Portage-3.0.20, Repoman-3.0.2
Closes: https://bugs.gentoo.org/798927