### PR TITLE
net-misc/sipp: add net-misc/lksctp-tools to DEPEND

### DIFF
--- a/net-misc/sipp/sipp-3.6.1.ebuild
+++ b/net-misc/sipp/sipp-3.6.1.ebuild
@@ -20,6 +20,7 @@ DEPEND="sys-libs/ncurses:=
 		net-libs/libpcap
 		net-libs/libnet:1.1
 	)
+	sctp? ( net-misc/lksctp-tools )
 	ssl? ( dev-libs/openssl:= )
 "
 RDEPEND="${DEPEND}"


### PR DESCRIPTION
Signed-off-by: Hank Leininger <hlein@korelogic.com>
Closes: https://bugs.gentoo.org/799230
Package-Manager: Portage-3.0.20, Repoman-3.0.3