### PR TITLE
sys-cluster/charliecloud: Fix configure with dash shell

### DIFF
--- a/sys-cluster/charliecloud/charliecloud-0.23.ebuild
+++ b/sys-cluster/charliecloud/charliecloud-0.23.ebuild
@@ -48,6 +48,7 @@ DEPEND="
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-0.22-sphinx-4.patch
+	"${FILESDIR}"/${PN}-0.24-dash.patch
 )
 
 src_prepare() {

--- a/sys-cluster/charliecloud/charliecloud-0.24.ebuild
+++ b/sys-cluster/charliecloud/charliecloud-0.24.ebuild
@@ -46,6 +46,10 @@ DEPEND="
 		net-misc/rsync
 	)"
 
+PATCHES=(
+	"${FILESDIR}"/${PN}-0.24-dash.patch
+)
+
 src_prepare() {
 	default
 	eautoreconf

--- a/sys-cluster/charliecloud/charliecloud-0.24.ebuild
+++ b/sys-cluster/charliecloud/charliecloud-0.24.ebuild
@@ -46,10 +46,6 @@ DEPEND="
 		net-misc/rsync
 	)"
 
-PATCHES=(
-	"${FILESDIR}"/${PN}-0.22-sphinx-4.patch
-)
-
 src_prepare() {
 	default
 	eautoreconf

--- a/sys-cluster/charliecloud/files/charliecloud-0.24-dash.patch
+++ b/sys-cluster/charliecloud/files/charliecloud-0.24-dash.patch
@@ -1,0 +1,25 @@
+From e540ad8148ba451349f4c4a7f983096ff0f6e60c Mon Sep 17 00:00:00 2001
+From: Oliver Freyermuth <o.freyermuth@googlemail.com>
+Date: Wed, 30 Jun 2021 21:38:54 +0200
+Subject: [PATCH] configure: Remove bashism from squashfuse version check.
+
+---
+ configure.ac | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index 1e4577d..7f43161 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -380,7 +380,7 @@ CH_CHECK_VERSION([SHELLCHECK], [$vmin_shellcheck],
+ vmin_squashfuse=0.1.100  # Ubuntu 16.04 (Xenial). CentOS 7 has 0.1.102.
+ AC_CHECK_PROG([SQUASHFUSE], [squashfuse], [squashfuse])
+ CH_CHECK_VERSION([SQUASHFUSE], [$vmin_squashfuse],
+-                 [--help |& head -1 | cut -d' ' -f2])
++                 [--help 2>&1 | head -1 | cut -d' ' -f2])
+ 
+ # sudo, generic
+ # Avoids prompting for password; see https://superuser.com/a/1183480.
+-- 
+2.31.1
+


### PR DESCRIPTION
The `configure` code contained a bashism, which broke `configure` when using `SHELL=/bin/dash` and `CONFIG_SHELL=/bin/dash`. 

Patch submitted to upstream at: https://github.com/hpc/charliecloud/pull/1111

Closes: https://bugs.gentoo.org/799377