### PR TITLE
app-forensics/sleuthkit: simplify virtual/jre dependency

### DIFF
--- a/app-forensics/sleuthkit/sleuthkit-4.10.1-r2.ebuild
+++ b/app-forensics/sleuthkit/sleuthkit-4.10.1-r2.ebuild
@@ -64,12 +64,7 @@ DEPEND="
 # "
 
 RDEPEND="${DEPEND}
-	java? (
-		|| (
-			virtual/jre:1.8
-			virtual/jdk:1.8
-		)
-	)
+	java? ( virtual/jre:1.8 )
 "
 DEPEND="${DEPEND}
 	java? ( virtual/jdk:1.8 )

--- a/app-forensics/sleuthkit/sleuthkit-4.10.1-r3.ebuild
+++ b/app-forensics/sleuthkit/sleuthkit-4.10.1-r3.ebuild
@@ -62,12 +62,7 @@ DEPEND="
 # "
 
 RDEPEND="${DEPEND}
-	java? (
-		|| (
-			virtual/jre:1.8
-			virtual/jdk:1.8
-		)
-	)
+	java? ( virtual/jre:1.8 )
 "
 DEPEND="${DEPEND}
 	java? ( virtual/jdk:1.8 )

--- a/app-forensics/sleuthkit/sleuthkit-4.9.0-r1.ebuild
+++ b/app-forensics/sleuthkit/sleuthkit-4.9.0-r1.ebuild
@@ -71,12 +71,7 @@ DEPEND="
 # "
 
 RDEPEND="${DEPEND}
-	java? (
-		|| (
-			virtual/jre:1.8
-			virtual/jdk:1.8
-		)
-	)
+	java? ( virtual/jre:1.8 )
 "
 DEPEND="${DEPEND}
 	java? ( virtual/jdk:1.8 )


### PR DESCRIPTION
There is no need for a any-of-many dependency including JRE and JDK,
since virtual/jre already has such a any-of-many dependency declared.

Signed-off-by: Florian Schmaus <flow@gentoo.org>