### PR TITLE
Massive update for dev-util/pycharm-professional and dev-util/pycharm-community

### DIFF
--- a/dev-util/pycharm-community/pycharm-community-2021.1.2.ebuild
+++ b/dev-util/pycharm-community/pycharm-community-2021.1.2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit desktop readme.gentoo-r1 xdg-utils
+inherit desktop readme.gentoo-r1 wrapper xdg-utils
 
 DESCRIPTION="Intelligent Python IDE with unique code assistance and analysis"
 HOMEPAGE="http://www.jetbrains.com/pycharm/"
@@ -14,39 +14,104 @@ SLOT="0"
 KEYWORDS="amd64 x86"
 IUSE="+bundled-jdk"
 
+BDEPEND="dev-util/patchelf"
+
 RDEPEND="!bundled-jdk? ( >=virtual/jre-1.8 )
+	app-arch/brotli
+	app-arch/zstd
+	app-crypt/p11-kit
+	dev-libs/fribidi
+	dev-libs/glib
+	dev-libs/json-c
+	dev-libs/libbsd
 	dev-libs/libdbusmenu
-	dev-python/pip"
+	dev-libs/nss
+	dev-python/pip
+	media-fonts/dejavu
+	media-gfx/graphite2
+	media-libs/alsa-lib
+	media-libs/fontconfig
+	media-libs/freetype:2=
+	media-libs/harfbuzz
+	media-libs/libglvnd
+	media-libs/libpng:0=
+	net-libs/gnutls
+	net-print/cups
+	sys-apps/dbus
+	sys-libs/libcap
+	sys-libs/zlib
+	virtual/jpeg:0=
+	x11-libs/libX11
+	x11-libs/libxcb
+	x11-libs/libXext
+	x11-libs/libXi
+	x11-libs/libXrandr
+	x11-libs/libXrender
+	x11-libs/libXtst
+	x11-libs/pango
+"
 
-RESTRICT="mirror strip"
+RESTRICT="mirror"
 
-QA_PREBUILT="*"
+QA_PREBUILT="opt/${P}/*"
 
 MY_PN=${PN/-community/}
 
+src_prepare() {
+	default
+
+	rm -vf "${S}"/help/ReferenceCardForMac.pdf || die
+
+	rm -vf "${S}"/bin/fsnotifier || die
+	rm -vf "${S}"/bin/phpstorm.vmoptions || die
+
+	rm -vf "${S}"/plugins/performanceTesting/bin/libyjpagent.so || die
+	rm -vf "${S}"/plugins/performanceTesting/bin/*.dll || die
+	rm -vf "${S}"/plugins/performanceTesting/bin/libyjpagent.dylib || die
+	rm -vrf "${S}"/lib/pty4j-native/linux/{aarch64,mips64el,ppc64le,x86} || die
+	rm -vf "${S}"/plugins/python-ce/helpers/pydev/pydevd_attach_to_process/attach_linux_x86.so
+
+	sed -i \
+		-e "\$a\\\\" \
+		-e "\$a#-----------------------------------------------------------------------" \
+		-e "\$a# Disable automatic updates as these are handled through Gentoo's" \
+		-e "\$a# package manager. See bug #704494" \
+		-e "\$a#-----------------------------------------------------------------------" \
+		-e "\$aide.no.platform.update=Gentoo" bin/idea.properties
+
+	for file in "jbr/lib/"/{libjcef.so,jcef_helper}
+	do
+		if [[ -f "${file}" ]]; then
+			patchelf --set-rpath '$ORIGIN' ${file} || die
+		fi
+	done
+}
+
 src_install() {
-	insinto /opt/${PN}
+	local DIR="/opt/${PN}"
+	local JRE_DIR="jbr"
+
+	insinto ${DIR}
 	doins -r *
 
-	if use bundled-jdk; then
-		fperms -R a+x /opt/pycharm-community/jbr/bin/
-	else
-		rm -r "${D}"/opt/pycharm-community/jbr/ || die
+	if ! use bundled-jdk; then
+		rm -r "${JRE_DIR}" || die
 	fi
 
-	local rub
+	fperms 755 "${DIR}"/bin/{format.sh,fsnotifier64,inspect.sh,ltedit.sh,pycharm.sh,printenv.py,restart.py}
 
-	for rub in aarch64 mips64el ppc64le; do
-		rm -r "${D}"/opt/pycharm-community/lib/pty4j-native/linux/${rub} || die
-	done
+	fperms 755 "${DIR}"/"${JRE_DIR}"/bin/{jaotc,java,javac,jcmd,jdb,jfr,jhsdb,jjs,jmap,jps,jrunscript,jstack,jstat,keytool,pack200,rmid,rmiregistry,serialver,unpack200}
+	fperms 755 "${DIR}"/"${JRE_DIR}"/lib/{chrome-sandbox,jcef_helper,jexec,jspawnhelper}
 
-	fperms a+x /opt/${PN}/bin/{pycharm.sh,fsnotifier{,64},inspect.sh}
-
-	dosym ../../opt/${PN}/bin/pycharm.sh /usr/bin/${PN}
+	make_wrapper "${PN}" "${DIR}/bin/pycharm.sh"
 	newicon bin/${MY_PN}.png ${PN}.png
 	make_desktop_entry ${PN} ${PN} ${PN}
 
 	readme.gentoo_create_doc
+
+	# recommended by: https://confluence.jetbrains.com/display/IDEADEV/Inotify+Watches+Limit
+	dodir /etc/sysctl.d/
+	echo "fs.inotify.max_user_watches = 524288" > "${D}/etc/sysctl.d/30-idea-inotify-watches.conf" || die
 }
 
 pkg_postinst() {

--- a/dev-util/pycharm-professional/pycharm-professional-2021.1.2.ebuild
+++ b/dev-util/pycharm-professional/pycharm-professional-2021.1.2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit desktop readme.gentoo-r1 xdg-utils
+inherit desktop readme.gentoo-r1 wrapper xdg-utils
 
 DESCRIPTION="Intelligent Python IDE with unique code assistance and analysis"
 HOMEPAGE="http://www.jetbrains.com/pycharm/"
@@ -14,40 +14,105 @@ SLOT="0"
 KEYWORDS="amd64 x86"
 IUSE="+bundled-jdk"
 
+BDEPEND="dev-util/patchelf"
+
 RDEPEND="!bundled-jdk? ( >=virtual/jre-1.8 )
+	app-arch/brotli
+	app-arch/zstd
+	app-crypt/p11-kit
+	dev-libs/fribidi
+	dev-libs/glib
+	dev-libs/json-c
+	dev-libs/libbsd
 	dev-libs/libdbusmenu
-	dev-python/pip"
+	dev-libs/nss
+	dev-python/pip
+	media-fonts/dejavu
+	media-gfx/graphite2
+	media-libs/alsa-lib
+	media-libs/fontconfig
+	media-libs/freetype:2=
+	media-libs/harfbuzz
+	media-libs/libglvnd
+	media-libs/libpng:0=
+	net-libs/gnutls
+	net-print/cups
+	sys-apps/dbus
+	sys-libs/libcap
+	sys-libs/zlib
+	virtual/jpeg:0=
+	x11-libs/libX11
+	x11-libs/libxcb
+	x11-libs/libXext
+	x11-libs/libXi
+	x11-libs/libXrandr
+	x11-libs/libXrender
+	x11-libs/libXtst
+	x11-libs/pango
+"
 
-RESTRICT="mirror strip"
+RESTRICT="mirror"
 
-QA_PREBUILT="*"
+QA_PREBUILT="opt/${P}/*"
 
 MY_PN=${PN/-professional/}
 S="${WORKDIR}/${MY_PN}-${PV}"
 
+src_prepare() {
+	default
+
+	rm -vf "${S}"/help/ReferenceCardForMac.pdf || die
+
+	rm -vf "${S}"/bin/fsnotifier || die
+	rm -vf "${S}"/bin/phpstorm.vmoptions || die
+
+	rm -vf "${S}"/plugins/performanceTesting/bin/libyjpagent.so || die
+	rm -vf "${S}"/plugins/performanceTesting/bin/*.dll || die
+	rm -vf "${S}"/plugins/performanceTesting/bin/libyjpagent.dylib || die
+	rm -vrf "${S}"/lib/pty4j-native/linux/{aarch64,mips64el,ppc64le,x86} || die
+	rm -vf "${S}"/plugins/python-ce/helpers/pydev/pydevd_attach_to_process/attach_linux_x86.so
+
+	sed -i \
+		-e "\$a\\\\" \
+		-e "\$a#-----------------------------------------------------------------------" \
+		-e "\$a# Disable automatic updates as these are handled through Gentoo's" \
+		-e "\$a# package manager. See bug #704494" \
+		-e "\$a#-----------------------------------------------------------------------" \
+		-e "\$aide.no.platform.update=Gentoo" bin/idea.properties
+
+	for file in "jbr/lib/"/{libjcef.so,jcef_helper}
+	do
+		if [[ -f "${file}" ]]; then
+			patchelf --set-rpath '$ORIGIN' ${file} || die
+		fi
+	done
+}
+
 src_install() {
-	insinto /opt/${PN}
+	local DIR="/opt/${PN}"
+	local JRE_DIR="jbr"
+
+	insinto ${DIR}
 	doins -r *
 
-	if use bundled-jdk; then
-		fperms -R a+x /opt/pycharm-professional/jbr/bin/
-	else
-		rm -r "${D}"/opt/pycharm-professional/jbr/ || die
+	if ! use bundled-jdk; then
+		rm -r "${JRE_DIR}" || die
 	fi
 
-	fperms a+x /opt/${PN}/bin/{pycharm.sh,fsnotifier{,64},inspect.sh}
+	fperms 755 "${DIR}"/bin/{format.sh,fsnotifier64,inspect.sh,ltedit.sh,pycharm.sh,printenv.py,restart.py}
 
-	dosym ../../opt/${PN}/bin/pycharm.sh /usr/bin/${PN}
+	fperms 755 "${DIR}"/"${JRE_DIR}"/bin/{jaotc,java,javac,jcmd,jdb,jfr,jhsdb,jjs,jmap,jps,jrunscript,jstack,jstat,keytool,pack200,rmid,rmiregistry,serialver,unpack200}
+	fperms 755 "${DIR}"/"${JRE_DIR}"/lib/{chrome-sandbox,jcef_helper,jexec,jspawnhelper}
+
+	make_wrapper "${PN}" "${DIR}/bin/pycharm.sh"
 	newicon bin/${MY_PN}.png ${PN}.png
 	make_desktop_entry ${PN} ${PN} ${PN}
 
-	local rub
-
-	for rub in aarch64 mips64el ppc64le; do
-		rm -r "${D}"/opt/pycharm-professional/lib/pty4j-native/linux/${rub} || die
-	done
-
 	readme.gentoo_create_doc
+
+	# recommended by: https://confluence.jetbrains.com/display/IDEADEV/Inotify+Watches+Limit
+	dodir /etc/sysctl.d/
+	echo "fs.inotify.max_user_watches = 524288" > "${D}/etc/sysctl.d/30-idea-inotify-watches.conf" || die
 }
 
 pkg_postinst() {


### PR DESCRIPTION
* Fix rpath_security_checks
* Fix crash when opening a markdown
* Remove files from other architectures
* Include missing deps
* Use wrapper
* Include recommended fs.inotify.max_user_watches

Closes: https://bugs.gentoo.org/798765
Closes: https://bugs.gentoo.org/798762
Closes: https://bugs.gentoo.org/795258
Closes: https://bugs.gentoo.org/792516
Closes: https://bugs.gentoo.org/792459
Closes: https://bugs.gentoo.org/792393
Closes: https://bugs.gentoo.org/787536
Closes: https://bugs.gentoo.org/763879
Closes: https://bugs.gentoo.org/733058
Closes: https://bugs.gentoo.org/733042

Package-Manager: Portage-3.0.20, Repoman-3.0.2
Signed-off-by: INODE64 <ffelix@inode64.com>