### PR TITLE
Rework the eselect-fontconfig dependency

### DIFF
--- a/app-eselect/eselect-fontconfig/eselect-fontconfig-1.1-r1.ebuild
+++ b/app-eselect/eselect-fontconfig/eselect-fontconfig-1.1-r1.ebuild
@@ -10,14 +10,12 @@ SRC_URI="mirror://gentoo/fontconfig.eselect-${PV}.bz2"
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
-IUSE=""
 
-RDEPEND=">=app-admin/eselect-1.2.3
-		 >=media-libs/fontconfig-2.4"
+RDEPEND=">=app-admin/eselect-1.2.3"
 
 S=${WORKDIR}
 
 src_install() {
 	insinto /usr/share/eselect/modules
-	newins "${S}"/fontconfig.eselect-${PV} fontconfig.eselect
+	newins fontconfig.eselect-${PV} fontconfig.eselect
 }

--- a/media-libs/fontconfig/fontconfig-2.13.93.ebuild
+++ b/media-libs/fontconfig/fontconfig-2.13.93.ebuild
@@ -41,8 +41,11 @@ RDEPEND=">=dev-libs/expat-2.1.0-r3[${MULTILIB_USEDEP}]
 	elibc_SunOS? ( sys-libs/libuuid )
 	virtual/libintl[${MULTILIB_USEDEP}]"
 DEPEND="${RDEPEND}"
-PDEPEND="!x86-winnt? ( app-eselect/eselect-fontconfig )
-	virtual/ttf-fonts"
+PDEPEND="virtual/ttf-fonts"
+# Put the eselect module in BDEPEND until EAPI 8 is ready for IDEPEND, so that
+# it is natively usable in BROOT to update ROOT when cross-compiling.
+BDEPEND+=" !x86-winnt? ( app-eselect/eselect-fontconfig )"
+RDEPEND+=" !x86-winnt? ( app-eselect/eselect-fontconfig )"
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-2.10.2-docbook.patch # 310157


### PR DESCRIPTION
Currently `app-eselect/eselect-fontconfig` is installed via `PDEPEND`, which always installs it in `$ROOT`.  It needs to installed in `$BROOT` to be natively executable on the build system, e.g. to configure a staging root when cross-compiling.

It seems that nothing calls `eselect fontconfig` anywhere, so maybe the dependency could just be dropped, and users could install it as needed since it's only intended to be manually called.

If it needs to continue being installed automatically, it probably belongs in `IDEPEND` so it is available in `$BROOT` at install time so `$ROOT` can be configured on the build system.  Since `autotools.eclass` is blocking most of the distro from using EAPI 8, it would have to use the EAPI 7 convention of `RDEPEND`+`BDEPEND` to get close enough.  That's what this PR does.

See also [bug #799758](https://bugs.gentoo.org/799758).