### PR TITLE
gui-apps/waybar: fix compilation with libfmt-8

### DIFF
--- a/gui-apps/waybar/files/waybar-0.9.5-fmt-8.0.0.patch
+++ b/gui-apps/waybar/files/waybar-0.9.5-fmt-8.0.0.patch
@@ -1,0 +1,31 @@
+diff --git a/include/util/format.hpp b/include/util/format.hpp
+index 288d8f0..61e8c85 100644
+--- a/include/util/format.hpp
++++ b/include/util/format.hpp
+@@ -35,7 +35,11 @@ namespace fmt {
+             // The rationale for ignoring it is that the only reason to specify
+             // an alignment and a with is to get a fixed width bar, and ">" is
+             // sufficient in this implementation.
+-            width = parse_nonnegative_int(it, end, ctx);
++#if FMT_VERSION < 80000
++            width = parse_nonnegative_int(it, end, ctx); 
++#else
++            width = detail::parse_nonnegative_int(it, end, -1);
++#endif
+           }
+           return it;
+         }
+diff --git a/src/modules/clock.cpp b/src/modules/clock.cpp
+index 22bedc7..82c5701 100644
+--- a/src/modules/clock.cpp
++++ b/src/modules/clock.cpp
+@@ -196,6 +196,9 @@ template <>
+ struct fmt::formatter<waybar_time> : fmt::formatter<std::tm> {
+   template <typename FormatContext>
+   auto format(const waybar_time& t, FormatContext& ctx) {
++#if FMT_VERSION >= 80000
++	auto& tm_format = specs;
++#endif
+     return format_to(ctx.out(), "{}", date::format(t.locale, fmt::to_string(tm_format), t.ztime));
+   }
+ };

--- a/gui-apps/waybar/files/waybar-0.9.7-fmt-8.0.0.patch
+++ b/gui-apps/waybar/files/waybar-0.9.7-fmt-8.0.0.patch
@@ -1,0 +1,31 @@
+diff --git a/include/util/format.hpp b/include/util/format.hpp
+index 288d8f0..61e8c85 100644
+--- a/include/util/format.hpp
++++ b/include/util/format.hpp
+@@ -35,7 +35,11 @@ namespace fmt {
+             // The rationale for ignoring it is that the only reason to specify
+             // an alignment and a with is to get a fixed width bar, and ">" is
+             // sufficient in this implementation.
+-            width = parse_nonnegative_int(it, end, ctx);
++#if FMT_VERSION < 80000
++            width = parse_nonnegative_int(it, end, ctx); 
++#else
++            width = detail::parse_nonnegative_int(it, end, -1);
++#endif
+           }
+           return it;
+         }
+diff --git a/src/modules/clock.cpp b/src/modules/clock.cpp
+index 22bedc7..82c5701 100644
+--- a/src/modules/clock.cpp
++++ b/src/modules/clock.cpp
+@@ -196,6 +196,9 @@ template <>
+ struct fmt::formatter<waybar_time> : fmt::formatter<std::tm> {
+   template <typename FormatContext>
+   auto format(const waybar_time& t, FormatContext& ctx) {
++#if FMT_VERSION >= 80000
++	auto& tm_format = specs;
++#endif
+     return format_to(ctx.out(), "{}", date::format(t.locale, fmt::to_string(tm_format), t.ztime));
+   }
+ };

--- a/gui-apps/waybar/waybar-0.9.5-r1.ebuild
+++ b/gui-apps/waybar/waybar-0.9.5-r1.ebuild
@@ -50,6 +50,8 @@ DEPEND="
 "
 RDEPEND="${DEPEND}"
 
+PATCHES=( "${FILESDIR}/${P}-fmt-8.0.0.patch" )
+
 src_configure() {
 	local emesonargs=(
 		$(meson_feature mpd)

--- a/gui-apps/waybar/waybar-0.9.7-r1.ebuild
+++ b/gui-apps/waybar/waybar-0.9.7-r1.ebuild
@@ -50,6 +50,8 @@ DEPEND="
 "
 RDEPEND="${DEPEND}"
 
+PATCHES=( "${FILESDIR}/${P}-fmt-8.0.0.patch" )
+
 src_configure() {
 	local emesonargs=(
 		$(meson_feature mpd)


### PR DESCRIPTION
This PR applies a patch to waybar to build with libfmt-8.
The upstream fix is already accepted, but not merged.

Upstream: https://github.com/Alexays/Waybar/pull/1144
Closes: https://bugs.gentoo.org/797649
Signed-off-by: Jonas Toth <gentoo@jonas-toth.eu>