### PR TITLE
net-misc/r8168: added use flags

### DIFF
--- a/net-misc/r8168/metadata.xml
+++ b/net-misc/r8168/metadata.xml
@@ -8,4 +8,13 @@
 	<longdescription>Official Realtek r8168 linux driver. The following cards are currently supported:
 RTL8111B RTL8168B RTL8111 RTL8168 RTL8111C RTL8111CP RTL8111D(L) RTL8168C
 RTL8111DP RTL8111E RTL8168E RTL8111F RTL8411</longdescription>
+	<use>
+		<flag name="aspm">Enable ASPM by default</flag>
+		<flag name="aspm-dynamic">Enable dynimic ASPM by default</flag>
+		<flag name="enable-eee">Enable Energy-Efficient Ethernet by default</flag>
+		<flag name="hw-acceleration">Enable use of hardware acceleration by default. HW acceleration may cause problems on Realtek NICs!</flag>
+		<flag name="s5-keep-mac">Keep set MAC address for S5 by default</flag>
+		<flag name="s5-wol">Enable wake from S5 by WOL by default</flag>
+		<flag name="use-firmware">Enable support for automatic firmware loading</flag>
+	</use>
 </pkgmetadata>

--- a/net-misc/r8168/r8168-8.049.02-r1.ebuild
+++ b/net-misc/r8168/r8168-8.049.02-r1.ebuild
@@ -1,0 +1,42 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit linux-info linux-mod
+
+DESCRIPTION="r8168 driver for Realtek 8111/8168 PCI-E NICs"
+HOMEPAGE="https://www.realtek.com/en/component/zoo/category/network-interface-controllers-10-100-1000m-gigabit-ethernet-pci-express-software"
+
+# "GBE Ethernet LINUX driver r8168 for kernel up to 5.6" from above link,
+# we need to mirror it to avoid users from needing to fill a captcha to
+# download
+SRC_URI="https://dev.gentoo.org/~pacho/${PN}/${P}.tar.bz2"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+MODULE_NAMES="r8168(net:${S}/src)"
+BUILD_TARGETS="modules"
+IUSE="+aspm +aspm-dynamic +enable-eee hw-acceleration s5-keep-mac +s5-wol use-firmware"
+REQUIRED_USE="
+    aspm-dynamic? ( aspm )
+"
+
+CONFIG_CHECK="~!R8169"
+WARNING_R8169="CONFIG_R8169 is enabled. ${P} will not be loaded unless kernel driver Realtek 8169 PCI Gigabit Ethernet (CONFIG_R8169) is DISABLED."
+
+pkg_setup() {
+    linux-mod_pkg_setup
+    BUILD_PARAMS="KERNELDIR=${KV_DIR}"
+    BUILD_PARAMS+=" CONFIG_ASPM=$(usex aspm y n) CONFIG_DYNAMIC_ASPM=$(usex aspm-dynamic y n)"
+    BUILD_PARAMS+=" ENABLE_EEE=$(usex enable-eee y n) CONFIG_SOC_LAN=$(usex hw-acceleration y n)"
+    BUILD_PARAMS+=" ENABLE_S5_KEEP_CURR_MAC=$(usex s5-keep-mac y n) ENABLE_S5WOL=$(usex s5-wol y n)"
+    BUILD_PARAMS+=" ENABLE_USE_FIRMWARE_FILE=$(usex use-firmware y n)"
+}
+
+src_install() {
+    linux-mod_src_install
+    einstalldocs
+}


### PR DESCRIPTION
* Added USE flags to control drivers defaults
Upstream has mechanism to control module defaults at compile-time. Added USE flag with same defaults as upstream.
* Added USE flag to enable firmware loading support
New compile-time parameter required to enable firmware loading support. Tested on my minicomputer with kernel dyn-debug and firmware loaded fine if USE flag is enabled. May help on old hardware or cheap hardware with outdated firmware.
* Demoted kernel config check from error to warning
If kernel parameter is enabled and module is compiled, nothing is failed. If both modules are enabled, kernel will load built-in module automatically. So instead of preventing of compilation of this module, simply warn user about required kernel configuration.