### PR TITLE
Remove circular deps on gcc when using clang

### DIFF
--- a/sys-libs/libcxx/libcxx-12.0.0.ebuild
+++ b/sys-libs/libcxx/libcxx-12.0.0.ebuild
@@ -140,6 +140,7 @@ multilib_src_configure() {
 		-DLIBCXX_HAS_GCC_S_LIB=${want_gcc_s}
 		-DLIBCXX_INCLUDE_TESTS=$(usex test)
 		-DLIBCXX_USE_COMPILER_RT=${want_compiler_rt}
+		-DLIBCXX_HAS_ATOMIC_LIB=${want_gcc_s}
 		-DCMAKE_SHARED_LINKER_FLAGS="${extra_libs[*]} ${LDFLAGS}"
 	)
 

--- a/sys-libs/llvm-libunwind/llvm-libunwind-12.0.0.ebuild
+++ b/sys-libs/llvm-libunwind/llvm-libunwind-12.0.0.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 CMAKE_ECLASS=cmake
 PYTHON_COMPAT=( python3_{7..9} )
-inherit cmake-multilib llvm llvm.org python-any-r1
+inherit cmake-multilib llvm llvm.org toolchain-funcs python-any-r1
 
 DESCRIPTION="C++ runtime stack unwinder from LLVM"
 HOMEPAGE="https://github.com/llvm-mirror/libunwind"
@@ -38,7 +38,17 @@ pkg_setup() {
 }
 
 multilib_src_configure() {
+	local use_compiler_rt=OFF
 	local libdir=$(get_libdir)
+
+	# link to compiler-rt
+	if tc-is-clang; then
+		local compiler-rt=$($(tc-getCC) ${CFLAGS} ${CPPFLAGS} \
+		   ${LD_FLAGS} -print-libgcc-file-name)
+		if [[ ${compiler_rt} == *libclang_rt* ]]; then
+			use_compiler_rt=ON
+		fi
+	fi
 
 	local mycmakeargs=(
 		-DLLVM_LIBDIR_SUFFIX=${libdir#lib}
@@ -49,6 +59,9 @@ multilib_src_configure() {
 		# support non-native unwinding; given it's small enough,
 		# enable it unconditionally
 		-DLIBUNWIND_ENABLE_CROSS_UNWINDING=ON
+
+		# avoid dependency on libgcc_s if compiler-rt is used
+		-DLIBUNWIND_USE_COMPILER_RT=${use_compiler_rt}
 	)
 	if use test; then
 		local clang_path=$(type -P "${CHOST:+${CHOST}-}clang" 2>/dev/null)


### PR DESCRIPTION
This change allows to have cleanly linked `libcxx`, `libcxxabi` and `libunwind` libs when using Clang as a main system compiler:

```
$ ldd /usr/lib/libc++abi.so 
	ldd (0x7f9741fbc000)
	libunwind.so.1 => /usr/lib/libunwind.so.1 (0x7f9741f6e000)
	libc.so => ldd (0x7f9741fbc000)
```

```
$ ldd /usr/lib/libunwind.so 
	ldd (0x7f18a9723000)
	libc.so => ldd (0x7f18a9723000)
```

Default configuration mentioned on the [wiki](https://wiki.gentoo.org/wiki/Clang#Bootstrapping_the_Clang_toolchain) results in these libs linking either to `libgcc_s`, `libatomic`, or both. Final USE flags are:

```
sys-devel/clang compiler-rt default-compiler-rt default-lld default-libcxx llvm-libunwind
sys-devel/clang-runtime compiler-rt libcxx
sys-libs/compiler-rt clang
sys-libs/compiler-rt-sanitizers clang
sys-libs/libcxx libunwind libcxxabi
sys-libs/libcxxabi libunwind
sys-libs/llvm-libunwind compiler-rt
```