### PR TITLE
app-emulation/xen-tools: fix xenstat python bindings in 4.15

### DIFF
--- a/app-emulation/xen-tools/files/xen-tools-4.15.0-fix-xenstat-python-bindings.patch
+++ b/app-emulation/xen-tools/files/xen-tools-4.15.0-fix-xenstat-python-bindings.patch
@@ -1,0 +1,18 @@
+--- a/tools/libs/stat/Makefile  2021-07-01 19:32:50.696318503 +0200
++++ b/tools/libs/stat/Makefile  2021-07-01 00:16:15.102473301 +0200
+@@ -51,12 +51,13 @@
+ .PHONY: uninstall-bindings
+ uninstall-bindings: uninstall-perl-bindings uninstall-python-bindings
+ 
+-$(BINDINGS): $(SHLIB) $(SHLIB_LINKS) include/xenstat.h
++$(BINDINGS): $(SHLIB) $(SHLIB_LINKS) ../../include/xenstat.h
+ 
+-SWIG_FLAGS=-module xenstat -Iinclude -I.
++SWIG_FLAGS=-module xenstat -Iinclude -I. -I../../include/
+ 
+ # Python bindings
+ PYTHON_FLAGS=`$(PYTHON) -c 'import distutils.sysconfig; print("-I" + distutils.sysconfig.get_python_inc(True) + " " + distutils.sysconfig.get_config_var("BLDLIBRARY"))'`
++PYTHON_FLAGS+=-Wno-error=missing-prototypes -fPIC -lxenstat
+ $(PYMOD): $(PYSRC)
+ $(PYSRC): bindings/swig/xenstat.i
+        swig -python $(SWIG_FLAGS) -outdir $(@D) -o $(PYSRC) $<

--- a/app-emulation/xen-tools/xen-tools-4.15.0-r2.ebuild
+++ b/app-emulation/xen-tools/xen-tools-4.15.0-r2.ebuild
@@ -181,6 +181,8 @@ QA_PREBUILT="
 
 RESTRICT="test"
 
+PATCHES=( "${FILESDIR}/${P}-fix-xenstat-python-bindings.patch" )
+
 pkg_setup() {
 	python_setup
 	export "CONFIG_LOMOUNT=y"
@@ -419,8 +421,7 @@ src_configure() {
 src_compile() {
 	local myopt
 	use debug && myopt="${myopt} debug=y"
-	# Currently broken
-	#use python && myopt="${myopt} XENSTAT_PYTHON_BINDINGS=y"
+	use python && myopt="${myopt} XENSTAT_PYTHON_BINDINGS=y"
 
 	if test-flag-CC -fno-strict-overflow; then
 		append-flags -fno-strict-overflow
@@ -499,11 +500,10 @@ src_install() {
 	keepdir /var/lib/xenstored
 	keepdir /var/log/xen
 
-	# Currently broken
-	#if use python; then
-		#python_domodule "${S}/tools/libs/stat/bindings/swig/python/xenstat.py"
-		#python_domodule "${S}/tools/libs/stat/bindings/swig/python/_xenstat.so"
-	#fi
+	if use python; then
+		python_domodule "${S}/tools/libs/stat/bindings/swig/python/xenstat.py"
+		python_domodule "${S}/tools/libs/stat/bindings/swig/python/_xenstat.so"
+	fi
 
 	python_optimize
 }


### PR DESCRIPTION
Package-Manager: Portage-3.0.20, Repoman-3.0.2
Signed-off-by: Jonas Licht <jonas.licht@fem.tu-ilmenau.de>