### PR TITLE
app-misc/tprint: ~amd64 keywording

### DIFF
--- a/app-misc/tprint/tprint-1.1.0-r1.ebuild
+++ b/app-misc/tprint/tprint-1.1.0-r1.ebuild
@@ -1,24 +1,24 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 inherit toolchain-funcs
 
 DESCRIPTION="Transparent Print Utility for terminals"
-HOMEPAGE="https://sourceforge.net/projects/tprint/"
+HOMEPAGE="https://sourceforge.net/projects/tprint"
 SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~ppc ~x86"
+KEYWORDS="~amd64 ~ppc ~x86"
 
 src_prepare() {
 	default
 
 	sed -i Makefile \
-		-e 's:cc:$(CC):g' \
-		-e 's:-g -O2:$(CFLAGS) $(LDFLAGS):g' \
+		-e 's|cc|$(CC)|g' \
+		-e 's|-g -O2|$(CFLAGS) $(LDFLAGS)|g' \
 		|| die "sed failed"
 }
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/794805
Package-Manager: Portage-3.0.20, Repoman-3.0.3
Signed-off-by: Alessandro Barbieri <lssndrbarbieri@gmail.com>