### PR TITLE
app-misc/piper-0.5.1-r1 installs icons but does not update icon cache

### DIFF
--- a/app-misc/piper/piper-0.5.1-r2.ebuild
+++ b/app-misc/piper/piper-0.5.1-r2.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{7..9} )
 
-inherit meson python-single-r1 udev
+inherit meson python-single-r1 udev xdg
 
 DESCRIPTION="GTK configuration application for libratbag"
 HOMEPAGE="https://github.com/libratbag/piper"


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/795714
Signed-off-by: Alex Barker alex@1stleg.com