### PR TITLE
sys-power/thermald: add doc USE flag, make dep on dev-util/gtk-doc optional

### DIFF
--- a/sys-power/thermald/files/thermald-no-docs.patch
+++ b/sys-power/thermald/files/thermald-no-docs.patch
@@ -1,0 +1,41 @@
+--- a/Makefile.am	2021-07-07 10:08:41.193127800 +0200
++++ b/Makefile.am	2021-07-07 10:08:49.336489915 +0200
+@@ -1,6 +1,6 @@
+ include $(GLIB_MAKEFILE)
+ 
+-SUBDIRS = . docs data
++SUBDIRS = . data
+ 
+ ACLOCAL_AMFLAGS =
+ 
+--- a/autogen.sh	2021-07-07 10:12:43.853933437 +0200
++++ b/autogen.sh	2021-07-07 10:12:52.917295964 +0200
+@@ -7,7 +7,6 @@
+ cd "$srcdir"
+ 
+ aclocal --install || exit 1
+-gtkdocize --copy --flavour no-tmpl || exit 1
+ autoreconf --install --verbose || exit 1
+ 
+ cd "$olddir"
+
+--- a/configure.ac	2021-07-07 10:19:20.028548056 +0200
++++ b/configure.ac	2021-07-07 10:20:42.425482481 +0200
+@@ -15,8 +15,6 @@
+ AM_INIT_AUTOMAKE([1.11 foreign no-define subdir-objects])
+ AM_MAINTAINER_MODE([enable])
+ 
+-GTK_DOC_CHECK([1.11],[--flavour no-tmpl])
+-
+ AC_ARG_WITH(dbus-sys-dir, AS_HELP_STRING([--with-dbus-sys-dir=DIR], [where D-BUS system.d directory is]))
+ if test -n "$with_dbus_sys_dir" ; then
+     DBUS_SYS_DIR="$with_dbus_sys_dir"
+@@ -118,8 +116,6 @@
+ AS_IF([test "x$enable_werror" != "xno"], [CXXFLAGS="$CXXFLAGS -Werror"])
+ 
+ AC_CONFIG_FILES([Makefile
+-                 docs/Makefile
+-                 docs/version.xml
+                  data/Makefile])
+ 
+ AC_OUTPUT

--- a/sys-power/thermald/thermald-2.4.5-r1.ebuild
+++ b/sys-power/thermald/thermald-2.4.5-r1.ebuild
@@ -12,7 +12,7 @@ SRC_URI="https://github.com/intel/thermal_daemon/archive/v${PV}.tar.gz -> ${P}.t
 LICENSE="GPL-2+"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE=""
+IUSE="-doc"
 
 RDEPEND="
 	dev-libs/dbus-glib:=
@@ -22,16 +22,16 @@ RDEPEND="
 	sys-power/upower
 	sys-apps/dbus:="
 DEPEND="${RDEPEND}
-	dev-util/gtk-doc
+	doc? ( dev-util/gtk-doc )
 	dev-util/glib-utils"
 
 S=${WORKDIR}/thermal_daemon-${PV}
 DOCS=( thermal_daemon_usage.txt README.txt )
-
 src_prepare() {
 	sed -i -e "/group=/s/power/wheel/g" \
 		data/org.freedesktop.thermald.conf || die
 
+	use doc || PATCHES+=("${FILESDIR}/${PN}-no-docs.patch")
 	default
 	eautoreconf
 }


### PR DESCRIPTION
On one of my systems, this is the only package that unconditionally depends on dev-util/gtk-doc.

This makes this dependency optional by way of a `doc` USE flag.

Signed-off-by: Peter Gantner <gentoo@nephros.org>