### PR TITLE
media-fonts/terminus-font: move build time depends to BDEPEND

### DIFF
--- a/media-fonts/terminus-font/terminus-font-4.49.1.ebuild
+++ b/media-fonts/terminus-font/terminus-font-4.49.1.ebuild
@@ -16,7 +16,7 @@ KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~mips ppc ppc64 ~s390 ~sparc x86 ~a
 IUSE="a-like-o +center-tilde distinct-l +otf +pcf +pcf-unicode-only +psf quote
 	ru-dv +ru-g ru-i ru-k"
 
-DEPEND="app-arch/gzip
+BDEPEND="app-arch/gzip
 	${PYTHON_DEPS}
 	virtual/awk
 	pcf? ( x11-apps/bdftopcf )"


### PR DESCRIPTION
Reported-by: Matt Turner
Closes: https://bugs.gentoo.org/801130
Package-Manager: Portage-3.0.20, Repoman-3.0.3
Signed-off-by: Sergei Trofimovich <slyfox@gentoo.org>