### PR TITLE
media-libs/glfw: rename wayland useflag to wayland-only

### DIFF
--- a/media-libs/glfw/glfw-3.3.3.ebuild
+++ b/media-libs/glfw/glfw-3.3.3.ebuild
@@ -12,11 +12,11 @@ SRC_URI="https://github.com/glfw/glfw/archive/${PV}.tar.gz -> ${P}.tar.gz"
 LICENSE="ZLIB"
 SLOT="0"
 KEYWORDS="amd64 ~arm ~arm64 ~hppa ~ppc64 x86"
-IUSE="wayland"
+IUSE="wayland-only"
 
 RDEPEND="
 	x11-libs/libxkbcommon
-	!wayland? (
+	!wayland-only? (
 		virtual/opengl
 		x11-libs/libX11
 		x11-libs/libXcursor
@@ -24,24 +24,24 @@ RDEPEND="
 		x11-libs/libXrandr
 		x11-libs/libXxf86vm
 	)
-	wayland? (
+	wayland-only? (
 		dev-libs/wayland
 		media-libs/mesa[egl,wayland]
 	)
 "
 DEPEND="
 	${RDEPEND}
-	!wayland? ( x11-libs/libXi )
-	wayland? ( dev-libs/wayland-protocols )
+	!wayland-only? ( x11-libs/libXi )
+	wayland-only? ( dev-libs/wayland-protocols )
 "
 BDEPEND="
-	wayland? ( kde-frameworks/extra-cmake-modules )
+	wayland-only? ( kde-frameworks/extra-cmake-modules )
 "
 
 src_configure() {
 	local mycmakeargs=(
 		-DGLFW_BUILD_EXAMPLES=no
-		-DGLFW_USE_WAYLAND="$(usex wayland)"
+		-DGLFW_USE_WAYLAND="$(usex wayland-only wayland)"
 		-DBUILD_SHARED_LIBS=1
 	)
 	cmake_src_configure

--- a/media-libs/glfw/glfw-3.3.4-r1.ebuild
+++ b/media-libs/glfw/glfw-3.3.4-r1.ebuild
@@ -13,11 +13,11 @@ SRC_URI="https://github.com/glfw/glfw/archive/${PV}.tar.gz -> ${P}.tar.gz"
 LICENSE="ZLIB"
 SLOT="0"
 KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc64 ~x86"
-IUSE="wayland"
+IUSE="wayland-only"
 
 RDEPEND="
 	x11-libs/libxkbcommon[${MULTILIB_USEDEP}]
-	!wayland? (
+	!wayland-only? (
 		virtual/opengl[${MULTILIB_USEDEP}]
 		x11-libs/libX11[${MULTILIB_USEDEP}]
 		x11-libs/libXcursor[${MULTILIB_USEDEP}]
@@ -25,21 +25,21 @@ RDEPEND="
 		x11-libs/libXrandr[${MULTILIB_USEDEP}]
 		x11-libs/libXxf86vm[${MULTILIB_USEDEP}]
 	)
-	wayland? (
+	wayland-only? (
 		dev-libs/wayland[${MULTILIB_USEDEP}]
 		media-libs/mesa[egl,wayland,${MULTILIB_USEDEP}]
 	)
 "
 DEPEND="
 	${RDEPEND}
-	!wayland? (
+	!wayland-only? (
 		x11-base/xorg-proto
 		x11-libs/libXi[${MULTILIB_USEDEP}]
 	)
-	wayland? ( dev-libs/wayland-protocols )
+	wayland-only? ( dev-libs/wayland-protocols )
 "
 BDEPEND="
-	wayland? (
+	wayland-only? (
 		dev-util/wayland-scanner
 		kde-frameworks/extra-cmake-modules
 	)
@@ -48,7 +48,7 @@ BDEPEND="
 src_configure() {
 	local mycmakeargs=(
 		-DGLFW_BUILD_EXAMPLES=no
-		-DGLFW_USE_WAYLAND="$(usex wayland)"
+		-DGLFW_USE_WAYLAND="$(usex wayland-only wayland)"
 		-DBUILD_SHARED_LIBS=1
 	)
 	cmake-multilib_src_configure

--- a/media-libs/glfw/glfw-3.3.4.ebuild
+++ b/media-libs/glfw/glfw-3.3.4.ebuild
@@ -12,11 +12,11 @@ SRC_URI="https://github.com/glfw/glfw/archive/${PV}.tar.gz -> ${P}.tar.gz"
 LICENSE="ZLIB"
 SLOT="0"
 KEYWORDS="amd64 ~arm ~arm64 ~hppa ~ppc64 x86"
-IUSE="wayland"
+IUSE="wayland-only"
 
 RDEPEND="
 	x11-libs/libxkbcommon
-	!wayland? (
+	!wayland-only? (
 		virtual/opengl
 		x11-libs/libX11
 		x11-libs/libXcursor
@@ -24,24 +24,24 @@ RDEPEND="
 		x11-libs/libXrandr
 		x11-libs/libXxf86vm
 	)
-	wayland? (
+	wayland-only? (
 		dev-libs/wayland
 		media-libs/mesa[egl,wayland]
 	)
 "
 DEPEND="
 	${RDEPEND}
-	!wayland? ( x11-libs/libXi )
-	wayland? ( dev-libs/wayland-protocols )
+	!wayland-only? ( x11-libs/libXi )
+	wayland-only? ( dev-libs/wayland-protocols )
 "
 BDEPEND="
-	wayland? ( kde-frameworks/extra-cmake-modules )
+	wayland-only? ( kde-frameworks/extra-cmake-modules )
 "
 
 src_configure() {
 	local mycmakeargs=(
 		-DGLFW_BUILD_EXAMPLES=no
-		-DGLFW_USE_WAYLAND="$(usex wayland)"
+		-DGLFW_USE_WAYLAND="$(usex wayland-only wayland)"
 		-DBUILD_SHARED_LIBS=1
 	)
 	cmake_src_configure

--- a/media-libs/glfw/metadata.xml
+++ b/media-libs/glfw/metadata.xml
@@ -9,4 +9,7 @@
 		<remote-id type="github">glfw/glfw</remote-id>
 		<changelog>https://www.glfw.org/changelog.html</changelog>
 	</upstream>
+	<use>
+		<flag name="wayland-only">Enable wayland support and disable X11 support</flag>
+	</use>
 </pkgmetadata>


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/616968
Signed-off-by: Alessandro Barbieri <lssndrbarbieri@gmail.com>