### PR TITLE
sys-apps/iproute2: handle "bpf" USE flag for supported arches

### DIFF
--- a/profiles/arch/amd64/package.use.mask
+++ b/profiles/arch/amd64/package.use.mask
@@ -17,6 +17,10 @@
 
 #--- END OF EXAMPLES ---
 
+# Lars Wendler <polynomial-c@gentoo.org> (2021-07-09)
+# dev-libs/libbpf has amd64 keyword
+sys-apps/iproute2 -bpf
+
 # Ionen Wolkens <ionen@gentoo.org> (2021-07-01)
 # gui-libs/egl-wayland with nvidia-drivers is supported on this arch.
 x11-base/xwayland -video_cards_nvidia

--- a/profiles/arch/arm64/package.use.mask
+++ b/profiles/arch/arm64/package.use.mask
@@ -1,6 +1,10 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Lars Wendler <polynomial-c@gentoo.org> (2021-07-09)
+# dev-libs/libbpf has arm64 keyword
+sys-apps/iproute2 -bpf
+
 # Ionen Wolkens <ionen@gentoo.org> (2021-07-04)
 # Needed until media-libs/libsdl2[vulkan] is unmasked on this arch.
 games-fps/yamagi-quake2 vulkan

--- a/profiles/arch/base/package.use.mask
+++ b/profiles/arch/base/package.use.mask
@@ -1,6 +1,10 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Lars Wendler <polynomial-c@gentoo.org> (2021-07-09)
+# dev-libs/libbpf lacks keywords for most arches
+sys-apps/iproute2 bpf
+
 # Ionen Wolkens <ionen@gentoo.org> (2021-07-01)
 # gui-libs/egl-wayland with nvidia-drivers is only usable on some arches.
 x11-base/xwayland video_cards_nvidia

--- a/profiles/arch/x86/package.use.mask
+++ b/profiles/arch/x86/package.use.mask
@@ -1,6 +1,10 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Lars Wendler <polynomial-c@gentoo.org> (2021-07-09)
+# dev-libs/libbpf has x86 keyword
+sys-apps/iproute2 -bpf
+
 # Ionen Wolkens <ionen@gentoo.org> (2021-07-04)
 # Needed until media-libs/libsdl2[vulkan] is unmasked on this arch.
 games-fps/yamagi-quake2 vulkan

--- a/sys-apps/iproute2/iproute2-5.12.0.ebuild
+++ b/sys-apps/iproute2/iproute2-5.12.0.ebuild
@@ -10,7 +10,7 @@ if [[ ${PV} == "9999" ]] ; then
 	inherit git-r3
 else
 	SRC_URI="https://www.kernel.org/pub/linux/utils/net/${PN}/${P}.tar.xz"
-	#KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
 fi
 
 DESCRIPTION="kernel routing and traffic control utilities"

--- a/sys-apps/iproute2/iproute2-5.13.0.ebuild
+++ b/sys-apps/iproute2/iproute2-5.13.0.ebuild
@@ -10,7 +10,7 @@ if [[ ${PV} == "9999" ]] ; then
 	inherit git-r3
 else
 	SRC_URI="https://www.kernel.org/pub/linux/utils/net/${PN}/${P}.tar.xz"
-	#KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
 fi
 
 DESCRIPTION="kernel routing and traffic control utilities"


### PR DESCRIPTION
This is needed so we can finally restore keywords for >=sys-apps/iproute2-5.12