### PR TITLE
dev-libs/openssl: rename USE=zlib to USE=tls-compression

### DIFF
--- a/dev-libs/openssl/metadata.xml
+++ b/dev-libs/openssl/metadata.xml
@@ -12,6 +12,7 @@
  <flag name="rfc3779">Enable support for RFC 3779 (X.509 Extensions for IP Addresses and AS Identifiers)</flag>
  <flag name="sslv2">Support for the old/insecure SSLv2 protocol -- note: not required for TLS/https</flag>
  <flag name="sslv3">Support for the old/insecure SSLv3 protocol -- note: not required for TLS/https</flag>
+ <flag name="tls-compression">Enable support for discouraged TLS compression</flag>
  <flag name="tls-heartbeat">Enable the Heartbeat Extension in TLS and DTLS</flag>
 </use>
 <upstream>

--- a/dev-libs/openssl/openssl-1.0.2u.ebuild
+++ b/dev-libs/openssl/openssl-1.0.2u.ebuild
@@ -38,14 +38,14 @@ SRC_URI="mirror://openssl/source/${MY_P}.tar.gz
 LICENSE="openssl"
 SLOT="0"
 KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~x86-linux"
-IUSE="+asm bindist gmp kerberos rfc3779 sctp cpu_flags_x86_sse2 sslv2 +sslv3 static-libs test +tls-heartbeat vanilla zlib"
+IUSE="+asm bindist gmp kerberos rfc3779 sctp cpu_flags_x86_sse2 sslv2 +sslv3 static-libs test tls-compression +tls-heartbeat vanilla"
 RESTRICT="!bindist? ( bindist )
 	!test? ( test )"
 
 RDEPEND=">=app-misc/c_rehash-1.7-r1
 	gmp? ( >=dev-libs/gmp-5.1.3-r1[static-libs(+)?,${MULTILIB_USEDEP}] )
 	kerberos? ( >=app-crypt/mit-krb5-1.11.4[${MULTILIB_USEDEP}] )
-	zlib? ( >=sys-libs/zlib-1.2.8-r1[static-libs(+)?,${MULTILIB_USEDEP}] )"
+	tls-compression? ( >=sys-libs/zlib-1.2.8-r1[static-libs(+)?,${MULTILIB_USEDEP}] )"
 DEPEND="${RDEPEND}"
 BDEPEND="
 	>=dev-lang/perl-5
@@ -197,8 +197,8 @@ multilib_src_configure() {
 		$(use_ssl sctp) \
 		$(use_ssl sslv2 ssl2) \
 		$(use_ssl sslv3 ssl3) \
+		$(use_ssl tls-compression zlib) \
 		$(use_ssl tls-heartbeat heartbeats) \
-		$(use_ssl zlib) \
 		--prefix="${EPREFIX}"/usr \
 		--openssldir="${EPREFIX}"${SSL_CNF_DIR} \
 		--libdir=$(get_libdir) \

--- a/dev-libs/openssl/openssl-1.1.1k.ebuild
+++ b/dev-libs/openssl/openssl-1.1.1k.ebuild
@@ -28,12 +28,12 @@ LICENSE="openssl"
 SLOT="0/1.1" # .so version of libssl/libcrypto
 [[ "${PV}" = *_pre* ]] || \
 KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~x86-linux"
-IUSE="+asm bindist elibc_musl rfc3779 sctp cpu_flags_x86_sse2 sslv3 static-libs test tls-heartbeat vanilla zlib"
+IUSE="+asm bindist elibc_musl rfc3779 sctp cpu_flags_x86_sse2 sslv3 static-libs test tls-compression tls-heartbeat vanilla"
 RESTRICT="!bindist? ( bindist )
 	!test? ( test )"
 
 RDEPEND=">=app-misc/c_rehash-1.7-r1
-	zlib? ( >=sys-libs/zlib-1.2.8-r1[static-libs(+)?,${MULTILIB_USEDEP}] )"
+	tls-compression? ( >=sys-libs/zlib-1.2.8-r1[static-libs(+)?,${MULTILIB_USEDEP}] )"
 DEPEND="${RDEPEND}"
 BDEPEND="
 	>=dev-lang/perl-5
@@ -222,8 +222,8 @@ multilib_src_configure() {
 		$(use_ssl asm) \
 		$(use_ssl rfc3779) \
 		$(use_ssl sctp) \
+		$(use_ssl tls-compression zlib) \
 		$(use_ssl tls-heartbeat heartbeats) \
-		$(use_ssl zlib) \
 		--prefix="${EPREFIX}"/usr \
 		--openssldir="${EPREFIX}"${SSL_CNF_DIR} \
 		--libdir=$(get_libdir) \

--- a/dev-libs/openssl/openssl-3.0.0_beta1.ebuild
+++ b/dev-libs/openssl/openssl-3.0.0_beta1.ebuild
@@ -22,12 +22,12 @@ fi
 LICENSE="Apache-2.0"
 SLOT="0/3" # .so version of libssl/libcrypto
 
-IUSE="+asm cpu_flags_x86_sse2 elibc_musl ktls rfc3779 sctp static-libs test vanilla zlib"
+IUSE="+asm cpu_flags_x86_sse2 elibc_musl ktls rfc3779 sctp static-libs test tls-compression vanilla"
 RESTRICT="!test? ( test )"
 
 COMMON_DEPEND="
 	>=app-misc/c_rehash-1.7-r1
-	zlib? ( >=sys-libs/zlib-1.2.8-r1[static-libs(+)?,${MULTILIB_USEDEP}] )
+	tls-compression? ( >=sys-libs/zlib-1.2.8-r1[static-libs(+)?,${MULTILIB_USEDEP}] )
 "
 
 BDEPEND="
@@ -176,7 +176,7 @@ multilib_src_configure() {
 		$(use_ssl ktls)
 		$(use_ssl rfc3779)
 		$(use_ssl sctp)
-		$(use_ssl zlib)
+		$(use_ssl tls-compression zlib)
 		--prefix="${EPREFIX}"/usr
 		--openssldir="${EPREFIX}"${SSL_CNF_DIR}
 		--libdir=$(get_libdir)


### PR DESCRIPTION
USE=zlib is a global USE flag and probably enabled by most users.
However, in OpenSSL, zlib is used for TLS compression which allows
for attacks like CRIME vulnerability. Its usage is discouraged and
banned in TLS 1.3+.

Renaming the USE flag allows us to opt-out from globally set USE=zlib.