### PR TITLE
profiles/base: drop obsolete boost[python, numpy] masks

### DIFF
--- a/profiles/base/package.use.stable.mask
+++ b/profiles/base/package.use.stable.mask
@@ -43,12 +43,6 @@ dev-php/theseer-Autoload test
 # Cinnamon is not stable on any architecture.
 x11-themes/arc-theme cinnamon
 
-# Sam James <sam@gentoo.org> (2020-10-09)
-# Depends on dev-libs/boost[python,numpy], not fully working atm
-# bug #733830, bug #746740, bug #753566
-media-gfx/openvdb python numpy
-media-libs/openimageio python
-
 # Pacho Ramos <pacho@gentoo.org> (2020-08-21)
 # app-text/pandoc is hard to stabilize #737612
 sys-apps/earlyoom docs


### PR DESCRIPTION
Fixes have landed upstream and are backported in Gentoo.

Bug: https://bugs.gentoo.org/733830
Bug: https://bugs.gentoo.org/746740
Bug: https://bugs.gentoo.org/753566
Signed-off-by: Sam James <sam@gentoo.org>