### PR TITLE
sci-libs/libsigrokdecode: Added support for Python 3.9.

### DIFF
--- a/sci-libs/libsigrokdecode/files/libsigrokdecode-0.5.3-configure.ac-Add-support-for-Python-3.9.patch
+++ b/sci-libs/libsigrokdecode/files/libsigrokdecode-0.5.3-configure.ac-Add-support-for-Python-3.9.patch
@@ -1,0 +1,25 @@
+From 37e8ceb857f99cb9beeb9aae073e8b5a9b8c4f40 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Dan=20Hor=C3=A1k?= <dan@danny.cz>
+Date: Tue, 4 Aug 2020 09:19:44 +0200
+Subject: [PATCH] configure.ac: Add support for Python 3.9.
+
+---
+ configure.ac | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index 5b432eae62e2..4802f35ca656 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -93,7 +93,7 @@ SR_PKG_CHECK_SUMMARY([srd_pkglibs_summary])
+ # first, since usually only that variant will add "-lpython3.8".
+ # https://docs.python.org/3/whatsnew/3.8.html#debug-build-uses-the-same-abi-as-release-build
+ SR_PKG_CHECK([python3], [SRD_PKGLIBS],
+-	[python-3.8-embed], [python-3.8 >= 3.8], [python-3.7 >= 3.7], [python-3.6 >= 3.6], [python-3.5 >= 3.5], [python-3.4 >= 3.4], [python-3.3 >= 3.3], [python-3.2 >= 3.2], [python3 >= 3.2])
++	[python-3.9-embed], [python-3.8-embed], [python-3.8 >= 3.8], [python-3.7 >= 3.7], [python-3.6 >= 3.6], [python-3.5 >= 3.5], [python-3.4 >= 3.4], [python-3.3 >= 3.3], [python-3.2 >= 3.2], [python3 >= 3.2])
+ AS_IF([test "x$sr_have_python3" = xno],
+ 	[AC_MSG_ERROR([Cannot find Python 3 development headers.])])
+ 
+-- 
+2.32.0
+

--- a/sci-libs/libsigrokdecode/libsigrokdecode-0.5.3-r1.ebuild
+++ b/sci-libs/libsigrokdecode/libsigrokdecode-0.5.3-r1.ebuild
@@ -1,0 +1,59 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+PYTHON_COMPAT=( python3_{7,8,9} )
+inherit python-single-r1 autotools
+
+if [[ ${PV} == *9999* ]]; then
+	EGIT_REPO_URI="git://sigrok.org/${PN}"
+	inherit git-r3
+else
+	SRC_URI="https://sigrok.org/download/source/${PN}/${P}.tar.gz"
+	KEYWORDS="~amd64 ~x86"
+fi
+
+DESCRIPTION="Provide (streaming) protocol decoding functionality"
+HOMEPAGE="https://sigrok.org/wiki/Libsigrokdecode"
+
+LICENSE="GPL-3"
+SLOT="0/4"
+IUSE="static-libs"
+REQUIRED_USE="${PYTHON_REQUIRED_USE}"
+
+RDEPEND="${PYTHON_DEPS}
+	>=dev-libs/glib-2.34.0
+"
+DEPEND="${RDEPEND}"
+BDEPEND="
+	virtual/pkgconfig
+"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-${PV}-configure.ac-Add-support-for-Python-3.9.patch"
+)
+
+src_prepare() {
+	default
+	eautoreconf
+
+	# Only a test program (not installed, and not used by src_test)
+	# is used by libsigrok, so disable it to avoid the compile.
+	sed -i \
+		-e '/build_runtc=/s:yes:no:' \
+		configure || die
+}
+
+src_configure() {
+	econf $(use_enable static-libs static)
+}
+
+src_test() {
+	emake check
+}
+
+src_install() {
+	default
+	find "${D}" -name '*.la' -type f -delete || die
+}


### PR DESCRIPTION
This just imports a patch from https://github.com/sigrokproject/libsigrokdecode/commit/9b0ad5177bd692f7556a4756bdbd2da81d9c34ce
Bug: https://bugs.gentoo.org/801196