### PR TITLE
sci-mathematics/coq: use a dependency default flag

### DIFF
--- a/sci-mathematics/coq/coq-8.11.2-r1.ebuild
+++ b/sci-mathematics/coq/coq-8.11.2-r1.ebuild
@@ -1,0 +1,90 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit desktop multilib
+
+MY_PV=${PV/_p/pl}
+MY_P=${PN}-${MY_PV}
+
+DESCRIPTION="Proof assistant written in O'Caml"
+HOMEPAGE="http://coq.inria.fr/"
+SRC_URI="https://github.com/coq/coq/archive/V${MY_PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="LGPL-2.1"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="gtk debug +ocamlopt doc"
+
+RESTRICT=test
+
+RDEPEND="
+	dev-ml/camlp5:=[ocamlopt?]
+	|| (
+		dev-ml/num
+		<dev-lang/ocaml-4.09.0[ocamlopt?]
+	)
+	gtk? (
+		dev-ml/lablgtk:3=[sourceview,ocamlopt?]
+		dev-ml/lablgtk-sourceview:3=[ocamlopt?]
+	)"
+DEPEND="${RDEPEND}
+	dev-ml/findlib
+	doc? (
+		media-libs/netpbm[png,postscript(+),zlib(+)]
+		virtual/latex-base
+		dev-tex/hevea
+		dev-texlive/texlive-latexrecommended
+		dev-texlive/texlive-pictures
+		dev-texlive/texlive-mathscience
+		dev-texlive/texlive-latexextra
+		)"
+
+S=${WORKDIR}/${MY_P}
+
+src_configure() {
+	ocaml_lib=$(ocamlc -where)
+	local myconf=(
+		-prefix /usr
+		-bindir /usr/bin
+		-libdir /usr/$(get_libdir)/coq
+		-mandir /usr/share/man
+		-coqdocdir /usr/$(get_libdir)/coq/coqdoc
+		-docdir /usr/share/doc/${PF}
+		-configdir /etc/xdg/${PN}
+		)
+
+	use debug && myconf+=( -debug )
+	use doc || myconf+=( -with-doc no )
+
+	if use gtk; then
+		if use ocamlopt; then
+			myconf+=( -coqide opt )
+		else
+			myconf+=( -coqide byte )
+		fi
+	else
+		myconf+=( -coqide no )
+	fi
+
+	use ocamlopt || myconf+=( -byte-only )
+
+	export CAML_LD_LIBRARY_PATH="${S}/kernel/byterun/"
+	./configure ${myconf[@]} || die "configure failed"
+}
+
+src_compile() {
+	emake STRIP="true" -j1 world VERBOSE=1
+}
+
+src_test() {
+	emake STRIP="true" check VERBOSE=1
+}
+
+src_install() {
+	emake STRIP="true" COQINSTALLPREFIX="${D}" install VERBOSE=1
+	dodoc README.md CREDITS
+
+	use gtk && make_desktop_entry "coqide" "Coq IDE" "${EPREFIX}/usr/share/coq/coq.png"
+}

--- a/sci-mathematics/coq/coq-8.12.0-r2.ebuild
+++ b/sci-mathematics/coq/coq-8.12.0-r2.ebuild
@@ -1,0 +1,90 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit desktop multilib
+
+MY_PV=${PV/_p/pl}
+MY_P=${PN}-${MY_PV}
+
+DESCRIPTION="Proof assistant written in O'Caml"
+HOMEPAGE="http://coq.inria.fr/"
+SRC_URI="https://github.com/coq/coq/archive/V${MY_PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="LGPL-2.1"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="gtk debug +ocamlopt doc"
+
+RESTRICT=test
+
+RDEPEND="
+	dev-ml/camlp5:=[ocamlopt?]
+	|| (
+		dev-ml/num
+		<dev-lang/ocaml-4.09.0[ocamlopt?]
+	)
+	gtk? (
+		dev-ml/lablgtk:3=[sourceview,ocamlopt?]
+		dev-ml/lablgtk-sourceview:3=[ocamlopt?]
+	)"
+DEPEND="${RDEPEND}
+	dev-ml/findlib
+	doc? (
+		media-libs/netpbm[png,postscript(+),zlib(+)]
+		virtual/latex-base
+		dev-tex/hevea
+		dev-texlive/texlive-latexrecommended
+		dev-texlive/texlive-pictures
+		dev-texlive/texlive-mathscience
+		dev-texlive/texlive-latexextra
+		)"
+
+S=${WORKDIR}/${MY_P}
+
+src_configure() {
+	ocaml_lib=$(ocamlc -where)
+	local myconf=(
+		-prefix /usr
+		-bindir /usr/bin
+		-libdir /usr/$(get_libdir)/coq
+		-mandir /usr/share/man
+		-coqdocdir /usr/$(get_libdir)/coq/coqdoc
+		-docdir /usr/share/doc/${PF}
+		-configdir /etc/xdg/${PN}
+		)
+
+	use debug && myconf+=( -debug )
+	use doc || myconf+=( -with-doc no )
+
+	if use gtk; then
+		if use ocamlopt; then
+			myconf+=( -coqide opt )
+		else
+			myconf+=( -coqide byte )
+		fi
+	else
+		myconf+=( -coqide no )
+	fi
+
+	use ocamlopt || myconf+=( -byte-only )
+
+	export CAML_LD_LIBRARY_PATH="${S}/kernel/byterun/"
+	./configure ${myconf[@]} || die "configure failed"
+}
+
+src_compile() {
+	emake STRIP="true" -j1 world VERBOSE=1
+}
+
+src_test() {
+	emake STRIP="true" check VERBOSE=1
+}
+
+src_install() {
+	emake STRIP="true" COQINSTALLPREFIX="${D}" install -j1 VERBOSE=1
+	dodoc README.md CREDITS
+
+	use gtk && make_desktop_entry "coqide" "Coq IDE" "${EPREFIX}/usr/share/coq/coq.png"
+}

--- a/sci-mathematics/coq/coq-8.13.0-r1.ebuild
+++ b/sci-mathematics/coq/coq-8.13.0-r1.ebuild
@@ -1,0 +1,88 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit desktop findlib
+
+MY_PV=${PV/_p/pl}
+MY_P=${PN}-${MY_PV}
+
+DESCRIPTION="Proof assistant written in O'Caml"
+HOMEPAGE="http://coq.inria.fr/"
+SRC_URI="https://github.com/coq/coq/archive/V${MY_PV}.tar.gz -> ${P}.tar.gz"
+S="${WORKDIR}/${MY_P}"
+
+LICENSE="LGPL-2.1"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="gtk debug +ocamlopt doc"
+
+RESTRICT="test"
+
+RDEPEND="
+	dev-ml/zarith
+	|| (
+		dev-ml/num
+		<dev-lang/ocaml-4.09.0[ocamlopt?]
+	)
+	gtk? (
+		dev-ml/lablgtk:3=[sourceview,ocamlopt?]
+		dev-ml/lablgtk-sourceview:3=[ocamlopt?]
+	)"
+DEPEND="${RDEPEND}
+	doc? (
+		media-libs/netpbm[png,postscript(+),zlib(+)]
+		virtual/latex-base
+		dev-tex/hevea
+		dev-texlive/texlive-latexrecommended
+		dev-texlive/texlive-pictures
+		dev-texlive/texlive-mathscience
+		dev-texlive/texlive-latexextra
+		)"
+
+src_configure() {
+	ocaml_lib=$(ocamlc -where)
+	local myconf=(
+		-prefix /usr
+		-bindir /usr/bin
+		-libdir /usr/$(get_libdir)/coq
+		-mandir /usr/share/man
+		-coqdocdir /usr/$(get_libdir)/coq/coqdoc
+		-docdir /usr/share/doc/${PF}
+		-configdir /etc/xdg/${PN}
+	)
+
+	use debug && myconf+=( -debug )
+	use doc || myconf+=( -with-doc no )
+
+	if use gtk; then
+		if use ocamlopt; then
+			myconf+=( -coqide opt )
+		else
+			myconf+=( -coqide byte )
+		fi
+	else
+		myconf+=( -coqide no )
+	fi
+
+	use ocamlopt || myconf+=( -byte-only )
+
+	export CAML_LD_LIBRARY_PATH="${S}/kernel/byterun/"
+	./configure ${myconf[@]} || die "configure failed"
+}
+
+src_compile() {
+	emake STRIP="true" -j1 world VERBOSE=1
+}
+
+src_test() {
+	emake STRIP="true" check VERBOSE=1
+}
+
+src_install() {
+	emake STRIP="true" COQINSTALLPREFIX="${D}" install -j1 VERBOSE=1
+	dodoc README.md CREDITS
+
+	use gtk && make_desktop_entry "coqide" "Coq IDE" "${EPREFIX}/usr/share/coq/coq.png"
+}


### PR DESCRIPTION
media-libs/netpbm is dropping zlib USE flag, so add it with `(+)`.
Starting with media-libs/netpbm-10.76.00, `pnmtops` is controlled by `postscript` flag instead of `zlib` (but requires `zlib` too).
media-libs/netpbm-10.70.00 had no `postscript` USE flag, so I've added it with `(+)` as well.