### PR TITLE
sys-devel/gcc: add USE=cet to metadata.xml && toolchain.eclass

### DIFF
--- a/eclass/toolchain.eclass
+++ b/eclass/toolchain.eclass
@@ -188,6 +188,7 @@ if [[ ${PN} != "kgcc64" && ${PN} != gcc-* ]] ; then
 		IUSE+=" systemtap" TC_FEATURES+=(systemtap)
 	tc_version_is_at_least 9.0 && IUSE+=" d"
 	tc_version_is_at_least 9.1 && IUSE+=" lto"
+	tc_version_is_at_least 10 && IUSE+=" cet"
 	tc_version_is_at_least 10 && IUSE+=" zstd" TC_FEATURES+=(zstd)
 	tc_version_is_at_least 11 && IUSE+=" valgrind" TC_FEATURES+=(valgrind)
 	tc_version_is_at_least 11 && IUSE+=" custom-cflags"
@@ -1160,6 +1161,10 @@ toolchain_src_configure() {
 
 	if in_iuse ada ; then
 		confgcc+=( --disable-libada )
+	fi
+
+	if in_iuse cet ; then
+		confgcc+=( $(use_enable cet) )
 	fi
 
 	if in_iuse cilk ; then

--- a/sys-devel/gcc/metadata.xml
+++ b/sys-devel/gcc/metadata.xml
@@ -9,6 +9,7 @@
     <flag name="ada">Build the ADA language (GNAT) frontend</flag>
     <flag name="awt">Useful only when building GCJ, this enables Abstract Window Toolkit
       (AWT) peer support on top of GTK+</flag>
+    <flag name="cet">Enable support for Intel Control Flow Enforcement Technology</flag>
     <flag name="cilk">Support the Cilk Plus language (C/C++ based languages for parallel programming)</flag>
     <flag name="d">Enable support for the D programming language</flag>
     <flag name="fixed-point">Enable fixed-point arithmetic support for MIPS targets 


### PR DESCRIPTION
As per title - add USE=cet to gcc via toolchain.eclass.

Optionally fcf-protection (CET) can be enabled by default in gcc via a patch similar to stack-clash-protection and link_now for USE=hardened, see https://pastebin.com/raw/q9HFsLuc

I've been using this in production for months now with no issues to note. Ubuntu are using the same/similar patch for their gcc.

Package-Manager: Portage-3.0.20, Repoman-3.0.3
Signed-off-by: Dave Hughes <davidhughes205@gmail.com>

@zorry @thesamesam 

edit: This is amd64 only, so will require masking by default and then unmasked on amd64.