### PR TITLE
dev-libs/collada-dom: keyword ~x86

### DIFF
--- a/dev-libs/collada-dom/collada-dom-2.5.0.ebuild
+++ b/dev-libs/collada-dom/collada-dom-2.5.0.ebuild
@@ -9,7 +9,7 @@ if [[ ${PV} == *9999 ]]; then
 	inherit git-r3
 	EGIT_REPO_URI="https://github.com/rdiankov/collada-dom"
 else
-	KEYWORDS="~amd64 ~arm ~hppa ~ppc ~ppc64"
+	KEYWORDS="~amd64 ~arm ~hppa ~ppc ~ppc64 ~x86"
 	SRC_URI="https://github.com/rdiankov/collada-dom/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 fi
 

--- a/dev-libs/collada-dom/collada-dom-9999.ebuild
+++ b/dev-libs/collada-dom/collada-dom-9999.ebuild
@@ -10,6 +10,7 @@ if [[ ${PV} == *9999 ]]; then
 	EGIT_REPO_URI="https://github.com/rdiankov/collada-dom"
 else
 	KEYWORDS="~amd64 ~arm ~hppa ~ppc ~ppc64"
+	KEYWORDS="~amd64 ~arm ~hppa ~ppc ~ppc64 ~x86"
 	SRC_URI="https://github.com/rdiankov/collada-dom/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 fi
 


### PR DESCRIPTION
Bug https://bugs.gentoo.org/798669

Package-Manager: Portage-3.0.20, Repoman-3.0.2
RepoMan-Options: --include-arches="x86"
Signed-off-by: Alexey Sokolov <alexey+gentoo@asokolov.org>