### PR TITLE
app-emulation/wine-staging: backport AR RANLIB handling from wine-van…

### DIFF
--- a/app-emulation/wine-staging/wine-staging-6.12.ebuild
+++ b/app-emulation/wine-staging/wine-staging-6.12.ebuild
@@ -528,10 +528,9 @@ multilib_src_configure() {
 		$(use_with vaapi va)
 	)
 
-	local PKG_CONFIG AR RANLIB
+	local PKG_CONFIG
 	# Avoid crossdev's i686-pc-linux-gnu-pkg-config if building wine32 on amd64; #472038
-	# set AR and RANLIB to make QA scripts happy; #483342
-	tc-export PKG_CONFIG AR RANLIB
+	tc-export PKG_CONFIG
 
 	if use amd64; then
 		if [[ ${ABI} == amd64 ]]; then

--- a/app-emulation/wine-staging/wine-staging-9999.ebuild
+++ b/app-emulation/wine-staging/wine-staging-9999.ebuild
@@ -528,10 +528,9 @@ multilib_src_configure() {
 		$(use_with vaapi va)
 	)
 
-	local PKG_CONFIG AR RANLIB
+	local PKG_CONFIG
 	# Avoid crossdev's i686-pc-linux-gnu-pkg-config if building wine32 on amd64; #472038
-	# set AR and RANLIB to make QA scripts happy; #483342
-	tc-export PKG_CONFIG AR RANLIB
+	tc-export PKG_CONFIG
 
 	if use amd64; then
 		if [[ ${ABI} == amd64 ]]; then


### PR DESCRIPTION
…illa

Before the change binutils-config[-native-symlinks] build failed
in attempt to use unprefixed `ar`. The fix is present in wine-vanilla
for a while.

This change backports it to wine-staging.

Package-Manager: Portage-3.0.20, Repoman-3.0.3
Signed-off-by: Sergei Trofimovich <slyfox@gentoo.org>