### PR TITLE
media-sound/mumble: Prefer bundled rnnoise

### DIFF
--- a/media-sound/mumble/mumble-1.3.4.ebuild
+++ b/media-sound/mumble/mumble-1.3.4.ebuild
@@ -73,6 +73,7 @@ src_configure() {
 
 	local conf_add=(
 		bundled-celt
+		bundled-rnnoise
 		no-bundled-opus
 		no-bundled-speex
 		no-embed-qt-translations


### PR DESCRIPTION
rnnoise library doesn't have proper versioning, and its API is unstable. The rnnoise currently present in Gentoo is incompatible with Mumble, so ask it to prefer the bundled one.

Closes: https://bugs.gentoo.org/801961
Signed-off-by: Maxim Plotnikov wgh@torlan.ru