### PR TITLE
app-crypt/aescrypt: fix LDFLAGS in Makefile

### DIFF
--- a/app-crypt/aescrypt/aescrypt-3.14.ebuild
+++ b/app-crypt/aescrypt/aescrypt-3.14.ebuild
@@ -18,7 +18,10 @@ RDEPEND="X? (
 	)
 	"
 
-PATCHES=( "${FILESDIR}/${P}-iconv.patch" )
+PATCHES=(
+	"${FILESDIR}/${P}-iconv.patch"
+	"${FILESDIR}/${P}-ldflags.patch"
+)
 
 src_prepare() {
 	xdg_src_prepare

--- a/app-crypt/aescrypt/files/aescrypt-3.14-ldflags.patch
+++ b/app-crypt/aescrypt/files/aescrypt-3.14-ldflags.patch
@@ -1,0 +1,20 @@
+diff -Naru a/src/Makefile b/src/Makefile
+--- a/src/Makefile	2021-07-14 09:25:15.509797042 +0200
++++ b/src/Makefile	2021-07-14 09:25:46.689797121 +0200
+@@ -27,13 +27,13 @@
+ all: aescrypt aescrypt_keygen
+ 
+ aescrypt: $(AESCRYPT_OBJS)
+-	$(CC) $(CFLAGS) $(LIBS) -o $@ $(AESCRYPT_OBJS)
++	$(CC) $(CFLAGS) $(LIBS) $(LDFLAGS) -o $@ $(AESCRYPT_OBJS)
+ 
+ aescrypt_keygen: $(KEYGEN_OBJS)
+-	$(CC) $(CFLAGS) $(LIBS) -o $@ $(KEYGEN_OBJS)
++	$(CC) $(CFLAGS) $(LIBS) $(LDFLAGS) -o $@ $(KEYGEN_OBJS)
+ 
+ %.o: %.c %.h
+-	$(CC) $(CFLAGS) -c $*.c
++	$(CC) $(CFLAGS) $(LDFLAGS) -c $*.c
+ 
+ install: aescrypt
+ 	install -o root -g root -m 755 aescrypt /usr/bin


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/763660
Package-Manager: Portage-3.0.20, Repoman-3.0.2
Signed-off-by: Marco Genasci <fedeliallalinea@gmail.com>