### PR TITLE
net-mail/mu: Guile 3 + EAPI 8

### DIFF
--- a/net-mail/mu/files/mu-1.4.15-guile3-1.patch
+++ b/net-mail/mu/files/mu-1.4.15-guile3-1.patch
@@ -1,0 +1,141 @@
+From 623cf787ad009c42b2adf3767be5f01fec56ff5a Mon Sep 17 00:00:00 2001
+From: Danny O'Brien <danny@codetherapy.space>
+Date: Mon, 7 Sep 2020 19:52:17 -0700
+Subject: [PATCH] guile: support version 3.0.
+
+Includes an update to the guile m4 package, and tweaks the build so that
+both 2.2 and 3.0 should work fine.
+---
+ configure.ac                  | 14 +++++++-------
+ guile/Makefile.am             |  2 +-
+ guile/mu/Makefile.am          |  4 +---
+ m4/Makefile.am                |  2 +-
+ m4/{guile-2.2.m4 => guile.m4} | 15 +++++++++------
+ 5 files changed, 19 insertions(+), 18 deletions(-)
+ rename m4/{guile-2.2.m4 => guile.m4} (97%)
+
+diff --git a/configure.ac b/configure.ac
+index eb5629696..cc43f43db 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -212,22 +212,22 @@ AM_CONDITIONAL(BUILD_GUI,[test "x$have_webkit" = "xyes" -a "x$have_gtk" = "xyes"
+ ###############################################################################
+ 
+ ###############################################################################
+-# build with guile2.2 when available and not disabled.
++# build with guile 3.0/2.2 when available and not disabled.
+ AC_ARG_ENABLE([guile], AS_HELP_STRING([--disable-guile],[Disable guile]))
+ AS_IF([test "x$enable_guile" != "xno"],[
+-  PKG_CHECK_MODULES(GUILE22, guile-2.2, [have_guile22=yes],[have_guile22=no])
+-  # this is a bit hacky; GUILE_PKG
+-  AS_IF([test "x$have_guile22" = "xyes"],[
+-    GUILE_PKG([2.2])
++  PKG_CHECK_MODULES(GUILE, [guile-3.0], [have_guile=yes],[
++    PKG_CHECK_MODULES(GUILE, [guile-2.2], [have_guile=yes], [have_guile=no])])
++  AS_IF([test "x$have_guile" = "xyes"],[
++    GUILE_PKG([3.0 2.2])
+     GUILE_PROGS
+     GUILE_FLAGS
+     AC_DEFINE_UNQUOTED([GUILE_BINARY],"$GUILE",[guile binary])
+     AC_DEFINE(BUILD_GUILE,[1], [Do we support Guile?])
+     AC_SUBST(GUILE_SNARF, [guile-snarf])
+-    guile_version=$($PKG_CONFIG guile-2.2 --modversion)
++    guile_version=$($PKG_CONFIG guile-$GUILE_EFFECTIVE_VERSION --modversion)
+   ])
+ ])
+-AM_CONDITIONAL(BUILD_GUILE,[test "x$have_guile22" = "xyes"])
++AM_CONDITIONAL(BUILD_GUILE,[test "x$have_guile" = "xyes"])
+ ###############################################################################
+ 
+ ###############################################################################
+diff --git a/guile/Makefile.am b/guile/Makefile.am
+index ed613068b..5c06ccc95 100644
+--- a/guile/Makefile.am
++++ b/guile/Makefile.am
+@@ -69,7 +69,7 @@ SUFFIXES = .x .doc
+ 
+ # FIXME: GUILE_SITEDIR would be better, but that
+ # breaks 'make distcheck'
+-scmdir=${prefix}/share/guile/site/2.2/
++scmdir=${prefix}/share/guile/site/${GUILE_EFFECTIVE_VERSION}
+ scm_DATA=mu.scm
+ 
+ EXTRA_DIST=$(scm_DATA)
+diff --git a/guile/mu/Makefile.am b/guile/mu/Makefile.am
+index f531822cd..9339ad973 100644
+--- a/guile/mu/Makefile.am
++++ b/guile/mu/Makefile.am
+@@ -16,9 +16,7 @@
+ 
+ include $(top_srcdir)/gtest.mk
+ 
+-# FIXME: GUILE_SITEDIR would be better, but that
+-# breaks 'make distcheck'
+-scmdir=${prefix}/share/guile/site/2.2/mu/
++scmdir=${prefix}/share/guile/site/${GUILE_EFFECTIVE_VERSION}/mu/
+ 
+ scm_DATA=		\
+ 	stats.scm	\
+diff --git a/m4/Makefile.am b/m4/Makefile.am
+index eeb8a05a4..27a49eebe 100644
+--- a/m4/Makefile.am
++++ b/m4/Makefile.am
+@@ -41,7 +41,7 @@ EXTRA_DIST=				\
+ 	ax_lib_readline.m4		\
+ 	ax_require_defined.m4		\
+ 	ax_valgrind_check.m4		\
+-	guile-2.2.m4			\
++	guile.m4			\
+ 	lib-ld.m4			\
+ 	lib-link.m4			\
+ 	lib-prefix.m4
+diff --git a/m4/guile-2.2.m4 b/m4/guile.m4
+similarity index 97%
+rename from m4/guile-2.2.m4
+rename to m4/guile.m4
+index 89823e9c3..696897364 100644
+--- a/m4/guile-2.2.m4
++++ b/m4/guile.m4
+@@ -47,8 +47,8 @@
+ # for an available version of Guile.
+ #
+ # By default, this macro will search for the latest stable version of
+-# Guile (e.g. 2.2), falling back to the previous stable version
+-# (e.g. 2.0) if it is available.  If no guile-@var{VERSION}.pc file is
++# Guile (e.g. 3.0), falling back to the previous stable version
++# (e.g. 2.2) if it is available.  If no guile-@var{VERSION}.pc file is
+ # found, an error is signalled.  The found version is stored in
+ # @var{GUILE_EFFECTIVE_VERSION}.
+ #
+@@ -60,8 +60,11 @@
+ # @code{AC_SUBST}.
+ #
+ AC_DEFUN([GUILE_PKG],
+- [PKG_PROG_PKG_CONFIG
+-  _guile_versions_to_search="m4_default([$1], [2.2 2.0 1.8])"
++ [AC_REQUIRE([PKG_PROG_PKG_CONFIG])
++  if test "x$PKG_CONFIG" = x; then
++    AC_MSG_ERROR([pkg-config is missing, please install it])
++  fi
++  _guile_versions_to_search="m4_default([$1], [3.0 2.2 2.0])"
+   if test -n "$GUILE_EFFECTIVE_VERSION"; then
+     _guile_tmp=""
+     for v in $_guile_versions_to_search; do
+@@ -221,7 +224,7 @@ AC_DEFUN([GUILE_SITE_DIR],
+ # as well.
+ #
+ # By default, this macro will search for the latest stable version of
+-# Guile (e.g. 2.2). x.y or x.y.z versions can be specified. If an older
++# Guile (e.g. 3.0). x.y or x.y.z versions can be specified. If an older
+ # version is found, the macro will signal an error.
+ #
+ # The effective version of the found @code{guile} is set to
+@@ -237,7 +240,7 @@ AC_DEFUN([GUILE_SITE_DIR],
+ AC_DEFUN([GUILE_PROGS],
+  [_guile_required_version="m4_default([$1], [$GUILE_EFFECTIVE_VERSION])"
+   if test -z "$_guile_required_version"; then
+-    _guile_required_version=2.2
++    _guile_required_version=3.0
+   fi
+ 
+   _guile_candidates=guile

--- a/net-mail/mu/files/mu-1.4.15-guile3-2.patch
+++ b/net-mail/mu/files/mu-1.4.15-guile3-2.patch
@@ -1,0 +1,17 @@
+---
+ lib/mu-script.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/mu-script.c b/lib/mu-script.c
+index 1175a60e3..92a63992e 100644
+--- a/lib/mu-script.c
++++ b/lib/mu-script.c
+@@ -318,7 +318,7 @@ mu_script_guile_run (MuScriptInfo *msi, const char *muhome,
+ 	g_return_val_if_fail (muhome, FALSE);
+ 
+ 	argv = g_new0 (char*, 6);
+-	argv[0] = g_strdup("guile2.2");
++	argv[0] = g_strdup(GUILE_BINARY);
+ 	argv[1] = g_strdup("-l");
+ 
+ 	if (access (mu_script_info_path (msi), R_OK) != 0) {

--- a/net-mail/mu/mu-1.4.15-r2.ebuild
+++ b/net-mail/mu/mu-1.4.15-r2.ebuild
@@ -1,0 +1,72 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools elisp-common
+
+DESCRIPTION="Set of tools to deal with Maildirs, in particular, searching and indexing"
+HOMEPAGE="https://www.djcbsoftware.nl/code/mu/ https://github.com/djcb/mu"
+SRC_URI="https://github.com/djcb/mu/archives/refs/tags/${PV}.tar.gz -> mu-${PV}.tar.gz"
+
+LICENSE="GPL-3+"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~x86 ~x64-macos"
+IUSE="emacs guile mug"
+
+DEPEND="
+	dev-libs/glib:2=
+	dev-libs/gmime:3.0=
+	>=dev-libs/xapian-1.4:=
+	emacs? ( >=app-editors/emacs-24.4:* )
+	guile? ( >=dev-scheme/guile-2.2:* )
+	mug? (
+		net-libs/webkit-gtk:4=
+		x11-libs/gtk+:3=
+	)"
+RDEPEND="${DEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-1.4.15-guile3-1.patch
+	"${FILESDIR}"/${PN}-1.4.15-guile3-2.patch
+)
+
+SITEFILE="70mu-gentoo-autoload.el"
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_configure() {
+	local myeconfargs=(
+		$(use_enable emacs mu4e)
+		$(use_enable mug gtk)
+		$(use_enable mug webkit)
+		$(use_enable guile)
+	)
+
+	econf "${myeconfargs[@]}"
+}
+
+pkg_preinst() {
+	if [[ -n ${REPLACING_VERSIONS} ]]; then
+		elog "After upgrading from an old major version, you should"
+		elog "rebuild your mail index."
+	fi
+}
+
+pkg_postinst() {
+	if use emacs; then
+		einfo "To use mu4e you need to configure it in your .emacs file"
+		einfo "See the manual for more information:"
+		einfo "https://www.djcbsoftware.nl/code/mu/mu4e/"
+
+		elisp-site-regen
+	fi
+}
+
+pkg_postrm() {
+	use emacs && elisp-site-regen
+}


### PR DESCRIPTION
Add patches from upstream (with slight modification) to fix compatibility with Guile 3, and also bump to EAPI 8.

Closes: https://bugs.gentoo.org/755875
Package-Manager: Portage-3.0.20, Repoman-3.0.3
Signed-off-by: Matt Smith <matt@offtopica.uk>