### PR TITLE
app-crypt/tpm2-tools: Add missing test dependency

### DIFF
--- a/app-crypt/tpm2-tools/tpm2-tools-5.1.1-r1.ebuild
+++ b/app-crypt/tpm2-tools/tpm2-tools-5.1.1-r1.ebuild
@@ -24,6 +24,7 @@ DEPEND="${RDEPEND}
 		app-crypt/swtpm
 		app-crypt/tpm2-abrmd
 		app-editors/vim-core
+		dev-tcltk/expect
 		dev-util/cmocka
 		dev-python/pyyaml
 	)"


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/802120
Package-Manager: Portage-3.0.20, Repoman-3.0.2
Signed-off-by: Christopher Byrne <salah.coronya@gmail.com>