### PR TITLE
profiles/features/musl/package.mask: mask net-misc/netkit-rsh, bug #715898

### DIFF
--- a/profiles/features/musl/package.mask
+++ b/profiles/features/musl/package.mask
@@ -65,3 +65,7 @@ www-client/firefox-bin
 # Mikle Kolyada <zlogene@gentoo.org> (2020-03-20)
 #  No source builds for musl
 app-emulation/firecracker
+
+# Hank Leininger <hlein@korelogic.com> (2021-07-14)
+# Uses glibc-specific rexec(3) function, bug #715898
+net-misc/netkit-rsh


### PR DESCRIPTION
Signed-off-by: Hank Leininger <hlein@korelogic.com>
Closes: https://bugs.gentoo.org/715898