### PR TITLE
dev-util/spirv-tools: fix gentoo prefix cmake configure issue

### DIFF
--- a/dev-util/spirv-tools/spirv-tools-2021.1.ebuild
+++ b/dev-util/spirv-tools/spirv-tools-2021.1.ebuild
@@ -34,7 +34,7 @@ BDEPEND="${PYTHON_DEPS}
 
 multilib_src_configure() {
 	local mycmakeargs=(
-		"-DSPIRV-Headers_SOURCE_DIR=/usr/"
+		"-DSPIRV-Headers_SOURCE_DIR=${ESYSROOT}/usr/"
 		"-DSPIRV_WERROR=OFF"
 		"-DSPIRV_TOOLS_BUILD_STATIC=OFF"
 		"-DBUILD_SHARED_LIBS=ON"


### PR DESCRIPTION
during cmake configuration, SPIRV-Headers_SOURCE_DIR sets to /usr
causing cmake cannot find /usr/include/spirv/unified1/spirv.core.grammar.json

Closes: https://bugs.gentoo.org/802240
Package-Manager: Portage-3.0.20, Repoman-3.0.3
Signed-off-by: Yiyang Wu <xgreenlandforwyy@gmail.com>