### PR TITLE
dev-libs/rocclr: prefixify installation location for gentoo prefix

### DIFF
--- a/dev-libs/rocclr/rocclr-4.1.0.ebuild
+++ b/dev-libs/rocclr/rocclr-4.1.0.ebuild
@@ -31,7 +31,7 @@ src_configure() {
 	local mycmakeargs=(
 		-DUSE_COMGR_LIBRARY=YES
 		-DOPENCL_DIR="${WORKDIR}/ROCm-OpenCL-Runtime-rocm-${PV}"
-		-DCMAKE_INSTALL_PREFIX="/usr"
+		-DCMAKE_INSTALL_PREFIX="${EPREFIX}/usr"
 	)
 	cmake_src_configure
 }
@@ -40,5 +40,5 @@ src_install() {
 	cmake_src_install
 
 	# This should be fixed in the CMakeLists.txt
-	sed -e "s:${BUILD_DIR}:${EPREFIX}/usr:" -i "${D}/usr/lib/cmake/rocclr/ROCclrConfig.cmake" || die
+	sed -e "s:${BUILD_DIR}:${EPREFIX}/usr:" -i "${ED}/usr/lib/cmake/rocclr/ROCclrConfig.cmake" || die
 }

--- a/dev-libs/rocclr/rocclr-4.2.0.ebuild
+++ b/dev-libs/rocclr/rocclr-4.2.0.ebuild
@@ -31,7 +31,7 @@ src_configure() {
 	local mycmakeargs=(
 		-DUSE_COMGR_LIBRARY=YES
 		-DOPENCL_DIR="${WORKDIR}/ROCm-OpenCL-Runtime-rocm-${PV}"
-		-DCMAKE_INSTALL_PREFIX="/usr"
+		-DCMAKE_INSTALL_PREFIX="${EPREFIX}/usr"
 	)
 	cmake_src_configure
 }
@@ -40,5 +40,5 @@ src_install() {
 	cmake_src_install
 
 	# This should be fixed in the CMakeLists.txt
-	sed -e "s:${BUILD_DIR}:${EPREFIX}/usr:" -i "${D}/usr/lib/cmake/rocclr/ROCclrConfig.cmake" || die
+	sed -e "s:${BUILD_DIR}:${EPREFIX}/usr:" -i "${ED}/usr/lib/cmake/rocclr/ROCclrConfig.cmake" || die
 }


### PR DESCRIPTION
rocclr-4.1 and 4.2 fails to merge in post-install phase because files are
installed outside gentoo prefix . This commit fixes this bug.

Package-Manager: Portage-3.0.20, Repoman-3.0.3
Signed-off-by: Yiyang Wu <xgreenlandforwyy@gmail.com>