### PR TITLE
net-p2p/mldonkey: Patch for C++17 support.

### DIFF
--- a/net-p2p/mldonkey/files/cpp17-byte-namespace.patch
+++ b/net-p2p/mldonkey/files/cpp17-byte-namespace.patch
@@ -1,0 +1,63 @@
+diff -ur a/src/utils/lib/CryptoPP.cc b/src/utils/lib/CryptoPP.cc
+--- a/src/utils/lib/CryptoPP.cc	2021-07-06 22:20:46.675183781 +0200
++++ b/src/utils/lib/CryptoPP.cc	2021-07-06 22:20:51.025182789 +0200
+@@ -9482,7 +9482,7 @@
+ #define PRIVKEYSIZE 384
+ 
+ static Signer* s_signer = NULL;   
+-static byte m_publicKey[MAXPUBKEYSIZE+1];
++static CryptoPP::byte m_publicKey[MAXPUBKEYSIZE+1];
+ static unsigned long m_publicKeyLen = 0;
+ 
+ void cc_lprintf_nl(const char * msg, bool verb);
+@@ -9555,7 +9555,7 @@
+ 
+ 
+ // return signatureSize (buf)
+-int createSignature(byte *buf, int maxLen, byte *key, int keyLen, uint32_t cInt, uint8_t ipType, uint32_t ip) {
++int createSignature(CryptoPP::byte *buf, int maxLen, CryptoPP::byte *key, int keyLen, uint32_t cInt, uint8_t ipType, uint32_t ip) {
+ 
+ 	int result = 0;
+ 
+@@ -9570,7 +9570,7 @@
+ 		CryptoPP::SecByteBlock sBB(s_signer->SignatureLength());
+ 		CryptoPP::AutoSeededRandomPool rng;
+ 	
+-		byte bArray[MAXPUBKEYSIZE+9];
++		CryptoPP::byte bArray[MAXPUBKEYSIZE+9];
+ 
+ 		memcpy(bArray,key,keyLen);
+ 		PokeUInt32(bArray+keyLen,cInt);   
+@@ -9597,7 +9597,7 @@
+ 
+ }
+ 
+-int verifySignature(byte *key, int keyLen, byte *sig, int sigLen, uint32_t cInt, uint8_t ipType, uint32_t ip) {
++int verifySignature(CryptoPP::byte *key, int keyLen, CryptoPP::byte *sig, int sigLen, uint32_t cInt, uint8_t ipType, uint32_t ip) {
+   using namespace CryptoPP;
+ 
+ 	bool result = false;
+@@ -9607,7 +9607,7 @@
+ 		StringSource ss_Pubkey(key, keyLen,true,0);
+ 		Verifier pubKey(ss_Pubkey);
+ 
+-		byte bArray[MAXPUBKEYSIZE+9];
++		CryptoPP::byte bArray[MAXPUBKEYSIZE+9];
+ 	
+ 		memcpy(bArray,m_publicKey,m_publicKeyLen);
+ 		PokeUInt32(bArray+m_publicKeyLen,cInt); 
+diff -ur a/src/utils/lib/CryptoPP.h b/src/utils/lib/CryptoPP.h
+--- a/src/utils/lib/CryptoPP.h	2021-07-06 22:20:46.675183781 +0200
++++ b/src/utils/lib/CryptoPP.h	2021-07-06 22:20:56.271848200 +0200
+@@ -181,10 +181,9 @@
+ #	define __USE_W32_SOCKETS
+ #endif
+ 
+-typedef unsigned char byte;		// put in global namespace to avoid ambiguity with other byte typedefs
+-
+ NAMESPACE_BEGIN(CryptoPP)
+ 
++typedef unsigned char byte;		// put in global namespace to avoid ambiguity with other byte typedefs
+ typedef unsigned short word16;
+ typedef unsigned int word32;
+ 

--- a/net-p2p/mldonkey/mldonkey-3.1.7-r2.ebuild
+++ b/net-p2p/mldonkey/mldonkey-3.1.7-r2.ebuild
@@ -51,6 +51,8 @@ DEPEND="${COMMON_DEPEND}
 
 RESTRICT="!ocamlopt? ( strip )"
 
+PATCHES=( "${FILESDIR}/cpp17-byte-namespace.patch" )
+
 S="${WORKDIR}/${P}-2"
 
 pkg_setup() {


### PR DESCRIPTION
This fixes the `byte` type clash between Crypto++ global definition and C++17 one in [#790134](https://bugs.gentoo.org/790134) by moving their definition to the `CryptoPP` namespace.

Since their definition is just an alias for `unsigned char`, @SoapGentoo recommended in #gentoo-dev-help replacing their use of `byte` with `unsigned char`. However, that would require a patch modifying ~500 lines of code while this other solution modifies less than 10 lines.

Also, more importantly, moving Crypto++ definition of `byte` to `CryptoPP` namespace was also the solution adopted upstream: https://github.com/weidai11/cryptopp/commit/00f9818b5d8e5aeb6c1057aa395317635bae07a3
So I decided to follow upstream and this patch just adapts upstream Crypto++'s patch to MLDonkey's bundled version of Crypto++.

Crypto++ also has a wiki page where they discussed this same issue: https://www.cryptopp.com/wiki/Std::byte

I also submitted this same patch to MLDonkey: https://github.com/ygrek/mldonkey/pull/66
But since it seems it's taking the maintainer some time to review it, I'm just already adding it to Portage to fix the compilation error with sys-devel/gcc:11 ASAP.

I've been using net-p2p/mldonkey with this patch for a week with no apparent issues.