### PR TITLE
package.mask: last-rite dev-java/xmlrpc (CVE-2016-5002, CVE-2016-5003, CVE-2019-17570)

### DIFF
--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -32,6 +32,11 @@
 
 #--- END OF EXAMPLES ---
 
+# Volkmar W. Pogatzki <gentoo@pogatzki.net> (2021-07-16)
+# library with no consumer, multiple vulnerabilities
+# removal in 30 days (bug #713098)
+dev-java/xmlrpc
+
 # Kai Krakow <hurikhan77+bgo@gmail.com> (2021-07-16)
 # To be replaced by net-p2p/go-ipfs, no migration needed.
 # Simply deselect the masked package and install the replacement.


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/713098

Signed-off-by: Volkmar W. Pogatzki <gentoo@pogatzki.net>