### PR TITLE
net-dns/getdns: assign myself as maintainer

### DIFF
--- a/net-dns/getdns/metadata.xml
+++ b/net-dns/getdns/metadata.xml
@@ -5,6 +5,10 @@
 		<email>blueness@gentoo.org</email>
 		<name>Anthony G. Basile</name>
 	</maintainer>
+	<maintainer type="person">
+		<email>gentoo@retornaz.com</email>
+		<name>Quentin Retornaz</name>
+	</maintainer>
 	<use>
 		<flag name="stubby">Add Stubby DNS Privacy Deamon</flag>
 		<flag name="getdns-query">Add getdns_query tool</flag>


### PR DESCRIPTION
Hello,
I did previously maintain net-dns/getdns package.
I gave up when they decided to drop definitely LibreSSL support.
Since that, Gentoo also decided to drop it, and I’ve started to switch some of my machines to OpenSSL.
I still keep some of them on LibreSSL to maintain the libressl overlay.
Now, I’m ready to maintain it again, if you agree with that._