### PR TITLE
net-fs/samba: conditionalise dependency on dev-python/subunit

### DIFF
--- a/net-fs/samba/samba-4.13.10-r1.ebuild
+++ b/net-fs/samba/samba-4.13.10-r1.ebuild
@@ -68,24 +68,19 @@ COMMON_DEPEND="
 	>=net-libs/gnutls-3.4.7[${MULTILIB_USEDEP}]
 	net-libs/libnsl:=[${MULTILIB_USEDEP}]
 	sys-libs/e2fsprogs-libs[${MULTILIB_USEDEP}]
-	>=sys-libs/ldb-2.3.0[ldap(+)?,${MULTILIB_USEDEP}]
-	<sys-libs/ldb-2.4.0[ldap(+)?,${MULTILIB_USEDEP}]
+	>=sys-libs/ldb-2.2.1[ldap(+)?,${MULTILIB_USEDEP}]
+	<sys-libs/ldb-2.3.0[ldap(+)?,${MULTILIB_USEDEP}]
 	sys-libs/libcap[${MULTILIB_USEDEP}]
 	sys-libs/liburing:=[${MULTILIB_USEDEP}]
 	sys-libs/ncurses:0=
 	sys-libs/readline:0=
-	>=sys-libs/talloc-2.3.2[${MULTILIB_USEDEP}]
+	>=sys-libs/talloc-2.3.1[${MULTILIB_USEDEP}]
 	>=sys-libs/tdb-1.4.3[${MULTILIB_USEDEP}]
 	>=sys-libs/tevent-0.10.2[${MULTILIB_USEDEP}]
 	sys-libs/zlib[${MULTILIB_USEDEP}]
 	virtual/libcrypt:=[${MULTILIB_USEDEP}]
 	virtual/libiconv
 	$(python_gen_cond_dep "
-		dev-python/subunit[\${PYTHON_MULTI_USEDEP},${MULTILIB_USEDEP}]
-		addc? (
-			dev-python/dnspython:=[\${PYTHON_MULTI_USEDEP}]
-			dev-python/markdown[\${PYTHON_MULTI_USEDEP}]
-		)
 		addns? (
 			dev-python/dnspython:=[\${PYTHON_MULTI_USEDEP}]
 			net-dns/bind-tools[gssapi]
@@ -124,6 +119,7 @@ DEPEND="${COMMON_DEPEND}
 	)
 	spotlight? ( dev-libs/glib )
 	test? (
+		$(python_gen_cond_dep "dev-python/subunit[\${PYTHON_USEDEP},${MULTILIB_USEDEP}]" )
 		!system-mitkrb5? (
 			>=net-dns/resolv_wrapper-1.1.4
 			>=net-libs/socket_wrapper-1.1.9

--- a/net-fs/samba/samba-4.13.9-r2.ebuild
+++ b/net-fs/samba/samba-4.13.9-r2.ebuild
@@ -16,7 +16,7 @@ if [[ ${PV} = *_rc* ]]; then
 	SRC_URI="mirror://samba/rc/${MY_P}.tar.gz"
 else
 	SRC_URI="mirror://samba/stable/${MY_P}.tar.gz"
-	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+	KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ppc ppc64 sparc x86"
 fi
 S="${WORKDIR}/${MY_P}"
 
@@ -68,24 +68,19 @@ COMMON_DEPEND="
 	>=net-libs/gnutls-3.4.7[${MULTILIB_USEDEP}]
 	net-libs/libnsl:=[${MULTILIB_USEDEP}]
 	sys-libs/e2fsprogs-libs[${MULTILIB_USEDEP}]
-	>=sys-libs/ldb-2.3.0[ldap(+)?,${MULTILIB_USEDEP}]
-	<sys-libs/ldb-2.4.0[ldap(+)?,${MULTILIB_USEDEP}]
+	>=sys-libs/ldb-2.2.1[ldap(+)?,${MULTILIB_USEDEP}]
+	<sys-libs/ldb-2.3.0[ldap(+)?,${MULTILIB_USEDEP}]
 	sys-libs/libcap[${MULTILIB_USEDEP}]
 	sys-libs/liburing:=[${MULTILIB_USEDEP}]
 	sys-libs/ncurses:0=
 	sys-libs/readline:0=
-	>=sys-libs/talloc-2.3.2[${MULTILIB_USEDEP}]
+	>=sys-libs/talloc-2.3.1[${MULTILIB_USEDEP}]
 	>=sys-libs/tdb-1.4.3[${MULTILIB_USEDEP}]
 	>=sys-libs/tevent-0.10.2[${MULTILIB_USEDEP}]
 	sys-libs/zlib[${MULTILIB_USEDEP}]
 	virtual/libcrypt:=[${MULTILIB_USEDEP}]
 	virtual/libiconv
 	$(python_gen_cond_dep "
-		dev-python/subunit[\${PYTHON_MULTI_USEDEP},${MULTILIB_USEDEP}]
-		addc? (
-			dev-python/dnspython:=[\${PYTHON_MULTI_USEDEP}]
-			dev-python/markdown[\${PYTHON_MULTI_USEDEP}]
-		)
 		addns? (
 			dev-python/dnspython:=[\${PYTHON_MULTI_USEDEP}]
 			net-dns/bind-tools[gssapi]
@@ -124,6 +119,7 @@ DEPEND="${COMMON_DEPEND}
 	)
 	spotlight? ( dev-libs/glib )
 	test? (
+		$(python_gen_cond_dep "dev-python/subunit[\${PYTHON_USEDEP},${MULTILIB_USEDEP}]" )
 		!system-mitkrb5? (
 			>=net-dns/resolv_wrapper-1.1.4
 			>=net-libs/socket_wrapper-1.1.9

--- a/net-fs/samba/samba-4.14.4-r2.ebuild
+++ b/net-fs/samba/samba-4.14.4-r2.ebuild
@@ -68,20 +68,23 @@ COMMON_DEPEND="
 	>=net-libs/gnutls-3.4.7[${MULTILIB_USEDEP}]
 	net-libs/libnsl:=[${MULTILIB_USEDEP}]
 	sys-libs/e2fsprogs-libs[${MULTILIB_USEDEP}]
-	>=sys-libs/ldb-2.2.1[ldap(+)?,${MULTILIB_USEDEP}]
-	<sys-libs/ldb-2.3.0[ldap(+)?,${MULTILIB_USEDEP}]
+	>=sys-libs/ldb-2.3.0[ldap(+)?,${MULTILIB_USEDEP}]
+	<sys-libs/ldb-2.4.0[ldap(+)?,${MULTILIB_USEDEP}]
 	sys-libs/libcap[${MULTILIB_USEDEP}]
 	sys-libs/liburing:=[${MULTILIB_USEDEP}]
 	sys-libs/ncurses:0=
 	sys-libs/readline:0=
-	>=sys-libs/talloc-2.3.1[${MULTILIB_USEDEP}]
+	>=sys-libs/talloc-2.3.2[${MULTILIB_USEDEP}]
 	>=sys-libs/tdb-1.4.3[${MULTILIB_USEDEP}]
 	>=sys-libs/tevent-0.10.2[${MULTILIB_USEDEP}]
 	sys-libs/zlib[${MULTILIB_USEDEP}]
 	virtual/libcrypt:=[${MULTILIB_USEDEP}]
 	virtual/libiconv
 	$(python_gen_cond_dep "
-		dev-python/subunit[\${PYTHON_MULTI_USEDEP},${MULTILIB_USEDEP}]
+		addc? (
+			dev-python/dnspython:=[\${PYTHON_MULTI_USEDEP}]
+			dev-python/markdown[\${PYTHON_MULTI_USEDEP}]
+		)
 		addns? (
 			dev-python/dnspython:=[\${PYTHON_MULTI_USEDEP}]
 			net-dns/bind-tools[gssapi]
@@ -120,6 +123,7 @@ DEPEND="${COMMON_DEPEND}
 	)
 	spotlight? ( dev-libs/glib )
 	test? (
+		$(python_gen_cond_dep "dev-python/subunit[\${PYTHON_USEDEP},${MULTILIB_USEDEP}]" )
 		!system-mitkrb5? (
 			>=net-dns/resolv_wrapper-1.1.4
 			>=net-libs/socket_wrapper-1.1.9

--- a/net-fs/samba/samba-4.14.5-r2.ebuild
+++ b/net-fs/samba/samba-4.14.5-r2.ebuild
@@ -16,7 +16,7 @@ if [[ ${PV} = *_rc* ]]; then
 	SRC_URI="mirror://samba/rc/${MY_P}.tar.gz"
 else
 	SRC_URI="mirror://samba/stable/${MY_P}.tar.gz"
-	KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ppc ppc64 sparc x86"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86"
 fi
 S="${WORKDIR}/${MY_P}"
 
@@ -68,20 +68,23 @@ COMMON_DEPEND="
 	>=net-libs/gnutls-3.4.7[${MULTILIB_USEDEP}]
 	net-libs/libnsl:=[${MULTILIB_USEDEP}]
 	sys-libs/e2fsprogs-libs[${MULTILIB_USEDEP}]
-	>=sys-libs/ldb-2.2.1[ldap(+)?,${MULTILIB_USEDEP}]
-	<sys-libs/ldb-2.3.0[ldap(+)?,${MULTILIB_USEDEP}]
+	>=sys-libs/ldb-2.3.0[ldap(+)?,${MULTILIB_USEDEP}]
+	<sys-libs/ldb-2.4.0[ldap(+)?,${MULTILIB_USEDEP}]
 	sys-libs/libcap[${MULTILIB_USEDEP}]
 	sys-libs/liburing:=[${MULTILIB_USEDEP}]
 	sys-libs/ncurses:0=
 	sys-libs/readline:0=
-	>=sys-libs/talloc-2.3.1[${MULTILIB_USEDEP}]
+	>=sys-libs/talloc-2.3.2[${MULTILIB_USEDEP}]
 	>=sys-libs/tdb-1.4.3[${MULTILIB_USEDEP}]
 	>=sys-libs/tevent-0.10.2[${MULTILIB_USEDEP}]
 	sys-libs/zlib[${MULTILIB_USEDEP}]
 	virtual/libcrypt:=[${MULTILIB_USEDEP}]
 	virtual/libiconv
 	$(python_gen_cond_dep "
-		dev-python/subunit[\${PYTHON_MULTI_USEDEP},${MULTILIB_USEDEP}]
+		addc? (
+			dev-python/dnspython:=[\${PYTHON_MULTI_USEDEP}]
+			dev-python/markdown[\${PYTHON_MULTI_USEDEP}]
+		)
 		addns? (
 			dev-python/dnspython:=[\${PYTHON_MULTI_USEDEP}]
 			net-dns/bind-tools[gssapi]
@@ -120,6 +123,7 @@ DEPEND="${COMMON_DEPEND}
 	)
 	spotlight? ( dev-libs/glib )
 	test? (
+		$(python_gen_cond_dep "dev-python/subunit[\${PYTHON_USEDEP},${MULTILIB_USEDEP}]" )
 		!system-mitkrb5? (
 			>=net-dns/resolv_wrapper-1.1.4
 			>=net-libs/socket_wrapper-1.1.9

--- a/net-fs/samba/samba-4.14.6-r1.ebuild
+++ b/net-fs/samba/samba-4.14.6-r1.ebuild
@@ -22,16 +22,18 @@ S="${WORKDIR}/${MY_P}"
 
 LICENSE="GPL-3"
 SLOT="0"
-IUSE="acl addc ads ceph client cluster cups debug dmapi fam glusterfs
-gpg iprint json ldap pam profiling-data python quota +regedit selinux
+IUSE="acl addc addns ads ceph client cluster cups debug dmapi fam glusterfs
+gpg iprint json ldap ntvfs pam profiling-data python quota +regedit selinux
 snapper spotlight syslog system-heimdal +system-mitkrb5 systemd test winbind
 zeroconf"
 
 REQUIRED_USE="${PYTHON_REQUIRED_USE}
 	addc? ( python json winbind )
-	ads? ( acl ldap python winbind )
+	addns? ( python )
+	ads? ( acl ldap winbind )
 	cluster? ( ads )
 	gpg? ( addc )
+	ntvfs? ( addc )
 	spotlight? ( json )
 	test? ( python )
 	!ads? ( !addc )
@@ -66,25 +68,24 @@ COMMON_DEPEND="
 	>=net-libs/gnutls-3.4.7[${MULTILIB_USEDEP}]
 	net-libs/libnsl:=[${MULTILIB_USEDEP}]
 	sys-libs/e2fsprogs-libs[${MULTILIB_USEDEP}]
-	>=sys-libs/ldb-2.4.0[ldap(+)?,${MULTILIB_USEDEP}]
-	<sys-libs/ldb-2.5.0[ldap(+)?,${MULTILIB_USEDEP}]
+	>=sys-libs/ldb-2.3.0[ldap(+)?,${MULTILIB_USEDEP}]
+	<sys-libs/ldb-2.4.0[ldap(+)?,${MULTILIB_USEDEP}]
 	sys-libs/libcap[${MULTILIB_USEDEP}]
 	sys-libs/liburing:=[${MULTILIB_USEDEP}]
 	sys-libs/ncurses:0=
 	sys-libs/readline:0=
-	>=sys-libs/talloc-2.3.3[${MULTILIB_USEDEP}]
-	>=sys-libs/tdb-1.4.4[${MULTILIB_USEDEP}]
-	>=sys-libs/tevent-0.11.0[${MULTILIB_USEDEP}]
+	>=sys-libs/talloc-2.3.2[${MULTILIB_USEDEP}]
+	>=sys-libs/tdb-1.4.3[${MULTILIB_USEDEP}]
+	>=sys-libs/tevent-0.10.2[${MULTILIB_USEDEP}]
 	sys-libs/zlib[${MULTILIB_USEDEP}]
 	virtual/libcrypt:=[${MULTILIB_USEDEP}]
 	virtual/libiconv
 	$(python_gen_cond_dep "
-		dev-python/subunit[\${PYTHON_MULTI_USEDEP},${MULTILIB_USEDEP}]
 		addc? (
 			dev-python/dnspython:=[\${PYTHON_MULTI_USEDEP}]
 			dev-python/markdown[\${PYTHON_MULTI_USEDEP}]
 		)
-		ads? (
+		addns? (
 			dev-python/dnspython:=[\${PYTHON_MULTI_USEDEP}]
 			net-dns/bind-tools[gssapi]
 		)
@@ -122,6 +123,7 @@ DEPEND="${COMMON_DEPEND}
 	)
 	spotlight? ( dev-libs/glib )
 	test? (
+		$(python_gen_cond_dep "dev-python/subunit[\${PYTHON_USEDEP},${MULTILIB_USEDEP}]" )
 		!system-mitkrb5? (
 			>=net-dns/resolv_wrapper-1.1.4
 			>=net-libs/socket_wrapper-1.1.9
@@ -210,6 +212,7 @@ multilib_src_configure() {
 		--without-winexe
 		$(multilib_native_use_with acl acl-support)
 		$(multilib_native_usex addc '' '--without-ad-dc')
+		$(multilib_native_use_with addns dnsupdate)
 		$(multilib_native_use_with ads)
 		$(multilib_native_use_enable ceph cephfs)
 		$(multilib_native_use_with cluster cluster-support)
@@ -220,6 +223,7 @@ multilib_src_configure() {
 		$(multilib_native_use_with gpg gpgme)
 		$(multilib_native_use_with json)
 		$(multilib_native_use_enable iprint)
+		$(multilib_native_use_with ntvfs ntvfs-fileserver)
 		$(multilib_native_use_with pam)
 		$(multilib_native_usex pam "--with-pammodulesdir=${EPREFIX}/$(get_libdir)/security" '')
 		$(multilib_native_use_with quota quotas)
@@ -327,9 +331,7 @@ pkg_postinst() {
 		elog "controller work previously known as 'samba4'."
 		elog
 	fi
-	if [[ "${PV}" != *_rc* ]] ; then
-		elog "For further information and migration steps make sure to read "
-		elog "https://samba.org/samba/history/${P}.html "
-		elog "https://wiki.samba.org/index.php/Samba4/HOWTO "
-	fi
+	elog "For further information and migration steps make sure to read "
+	elog "https://samba.org/samba/history/${P}.html "
+	elog "https://wiki.samba.org/index.php/Samba4/HOWTO "
 }


### PR DESCRIPTION
Samba seems to configure + build + install fine without subunit
installed.

Revbumping to allow users to depclean subunit itself but also
a bunch of assorted Python dependencies. Also, to ensure that
users upgrading without dynamic deps enabled don't get stuck
on the "EAPI 8" trap discussed in the bug.

Closes: https://bugs.gentoo.org/801637
Signed-off-by: Sam James <sam@gentoo.org>