### PR TITLE
app-text/xapers: Python 3.9 support

### DIFF
--- a/app-text/xapers/xapers-0.9.0.ebuild
+++ b/app-text/xapers/xapers-0.9.0.ebuild
@@ -1,9 +1,9 @@
-# Copyright 2016-2020 Gentoo Authors
+# Copyright 2016-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{7,8} )
+PYTHON_COMPAT=( python3_{7..9} )
 DISTUTILS_USE_SETUPTOOLS=rdepend
 
 inherit distutils-r1


### PR DESCRIPTION
Also update copyright. Note that Python 3.10 support can't yet be tested as
xapers depends on xapian-bindings