### PR TITLE
dev-qt/qtdeclarative: riscv: fix missing atomic library

### DIFF
--- a/dev-qt/qtdeclarative/files/qtdeclarative-5.15.2-riscv-atomic.patch
+++ b/dev-qt/qtdeclarative/files/qtdeclarative-5.15.2-riscv-atomic.patch
@@ -1,0 +1,12 @@
+diff --git a/src/qml/qml.pro b/src/qml/qml.pro
+index 7d5a92a..01f3b79 100644
+--- a/src/qml/qml.pro
++++ b/src/qml/qml.pro
+@@ -19,6 +19,7 @@ solaris-cc*:QMAKE_CXXFLAGS_RELEASE -= -O2
+ 
+ # Ensure this gcc optimization is switched off for mips platforms to avoid trouble with JIT.
+ gcc:isEqual(QT_ARCH, "mips"): QMAKE_CXXFLAGS += -fno-reorder-blocks
++gcc:isEqual(QT_ARCH, "riscv64"): LIBS += -latomic
+ 
+ DEFINES += QT_NO_FOREACH
+

--- a/dev-qt/qtdeclarative/qtdeclarative-5.15.2.ebuild
+++ b/dev-qt/qtdeclarative/qtdeclarative-5.15.2.ebuild
@@ -31,6 +31,7 @@ RDEPEND="${DEPEND}
 PATCHES=(
 	"${FILESDIR}/${PN}-5.14.2-QQuickItemView-fix-maxXY-extent.patch" # QTBUG-83890
 	"${FILESDIR}/${P}-gcc11.patch" # bug 752093
+	"${FILESDIR}/${P}-riscv-atomic.patch" #bug 790689
 )
 
 src_prepare() {


### PR DESCRIPTION
this will fix the build error in ARCH=riscv, tested with gcc-11

Closes: https://bugs.gentoo.org/790689
Package-Manager: Portage-3.0.19, Repoman-3.0.3
Signed-off-by: Yixun Lan <dlan@gentoo.org>