### PR TITLE
app-text/xapers: Use python_test() for testing

### DIFF
--- a/app-text/xapers/xapers-0.9.0.ebuild
+++ b/app-text/xapers/xapers-0.9.0.ebuild
@@ -18,6 +18,8 @@ LICENSE="GPL-3"
 SLOT="0"
 KEYWORDS="~amd64"
 
+DISTUTILS_USE_SETUPTOOLS=rdepend
+
 RDEPEND="app-text/poppler[utils]
 	dev-libs/xapian-bindings[python,${PYTHON_USEDEP}]
 	dev-python/pybtex[${PYTHON_USEDEP}]
@@ -28,7 +30,7 @@ RDEPEND="app-text/poppler[utils]
 
 BDEPEND="test? ( ${RDEPEND} )"
 
-src_test() {
+python_test() {
 	cd test || die
 	./all || die
 }


### PR DESCRIPTION
Changing src_test() to python_test() so the correct interpreter is used
for tests, instead of just using the latest selected python interpreter.
Also addresses QA notice by adding DISTUTILS_USE_SETUPTOOLS=rdepend

Closes: https://bugs.gentoo.org/803023
Package-Manager: Portage-3.0.20, Repoman-3.0.3
Signed-off-by: William Pettersson <william@ewpettersson.se>