### PR TITLE
Drop media-libs/mesa's IUSE=egl and IUSE=gbm

### DIFF
--- a/media-libs/mesa/mesa-9999.ebuild
+++ b/media-libs/mesa/mesa-9999.ebuild
@@ -33,18 +33,16 @@ for card in ${VIDEO_CARDS}; do
 done
 
 IUSE="${IUSE_VIDEO_CARDS}
-	+classic cpu_flags_x86_sse2 d3d9 debug +egl +gallium +gbm gles1 +gles2 +llvm
+	+classic cpu_flags_x86_sse2 d3d9 debug +gallium +gbm gles1 +gles2 +llvm
 	lm-sensors opencl osmesa selinux test unwind vaapi valgrind vdpau vulkan
 	vulkan-overlay wayland +X xa xvmc zink +zstd"
 
 REQUIRED_USE="
 	d3d9?   ( || ( video_cards_iris video_cards_r300 video_cards_r600 video_cards_radeonsi video_cards_nouveau video_cards_vmware ) )
-	gles1?  ( egl )
-	gles2?  ( egl )
 	osmesa? ( gallium )
 	vulkan? ( video_cards_radeonsi? ( llvm ) )
 	vulkan-overlay? ( vulkan )
-	wayland? ( egl gbm )
+	wayland? ( gbm )
 	video_cards_crocus? ( gallium )
 	video_cards_freedreno?  ( gallium )
 	video_cards_intel?  ( classic )
@@ -384,12 +382,6 @@ multilib_src_configure() {
 	use wayland && platforms+=",wayland"
 	emesonargs+=(-Dplatforms=${platforms#,})
 
-	if use X || use egl; then
-		emesonargs+=(-Dglvnd=true)
-	else
-		emesonargs+=(-Dglvnd=false)
-	fi
-
 	if use gallium; then
 		emesonargs+=(
 			$(meson_feature llvm)
@@ -512,7 +504,8 @@ multilib_src_configure() {
 		-Dglx=$(usex X dri disabled)
 		-Dshared-glapi=enabled
 		-Ddri3=enabled
-		$(meson_feature egl)
+		-Degl=true
+		-Dglvnd=true
 		$(meson_feature gbm)
 		$(meson_feature gles1)
 		$(meson_feature gles2)

--- a/media-libs/mesa/mesa-9999.ebuild
+++ b/media-libs/mesa/mesa-9999.ebuild
@@ -33,7 +33,7 @@ for card in ${VIDEO_CARDS}; do
 done
 
 IUSE="${IUSE_VIDEO_CARDS}
-	+classic cpu_flags_x86_sse2 d3d9 debug +gallium +gbm gles1 +gles2 +llvm
+	+classic cpu_flags_x86_sse2 d3d9 debug +gallium gles1 +gles2 +llvm
 	lm-sensors opencl osmesa selinux test unwind vaapi valgrind vdpau vulkan
 	vulkan-overlay wayland +X xa xvmc zink +zstd"
 
@@ -42,7 +42,6 @@ REQUIRED_USE="
 	osmesa? ( gallium )
 	vulkan? ( video_cards_radeonsi? ( llvm ) )
 	vulkan-overlay? ( vulkan )
-	wayland? ( gbm )
 	video_cards_crocus? ( gallium )
 	video_cards_freedreno?  ( gallium )
 	video_cards_intel?  ( classic )
@@ -62,7 +61,7 @@ REQUIRED_USE="
 	video_cards_v3d? ( gallium )
 	video_cards_vc4? ( gallium )
 	video_cards_virgl? ( gallium )
-	video_cards_vivante? ( gallium gbm )
+	video_cards_vivante? ( gallium )
 	video_cards_vmware? ( gallium )
 	xa? ( X )
 	xvmc? ( X )
@@ -505,8 +504,8 @@ multilib_src_configure() {
 		-Dshared-glapi=enabled
 		-Ddri3=enabled
 		-Degl=true
+		-Dgbm=true
 		-Dglvnd=true
-		$(meson_feature gbm)
 		$(meson_feature gles1)
 		$(meson_feature gles2)
 		$(meson_use osmesa)

--- a/www-client/vivaldi-snapshot/vivaldi-snapshot-4.4.2473.3-r1.ebuild
+++ b/www-client/vivaldi-snapshot/vivaldi-snapshot-4.4.2473.3-r1.ebuild
@@ -118,7 +118,7 @@ RDEPEND="
 	dev-libs/nspr
 	dev-libs/nss
 	media-libs/alsa-lib
-	media-libs/mesa[gbm]
+	media-libs/mesa[gbm(+)]
 	net-print/cups
 	sys-apps/dbus
 	x11-libs/cairo

--- a/www-client/vivaldi-snapshot/vivaldi-snapshot-4.4.2482.13-r1.ebuild
+++ b/www-client/vivaldi-snapshot/vivaldi-snapshot-4.4.2482.13-r1.ebuild
@@ -118,7 +118,7 @@ RDEPEND="
 	dev-libs/nspr
 	dev-libs/nss
 	media-libs/alsa-lib
-	media-libs/mesa[gbm]
+	media-libs/mesa[gbm(+)]
 	net-print/cups
 	sys-apps/dbus
 	x11-libs/cairo

--- a/www-client/vivaldi-snapshot/vivaldi-snapshot-4.4.2488.3-r1.ebuild
+++ b/www-client/vivaldi-snapshot/vivaldi-snapshot-4.4.2488.3-r1.ebuild
@@ -118,7 +118,7 @@ RDEPEND="
 	dev-libs/nspr
 	dev-libs/nss
 	media-libs/alsa-lib
-	media-libs/mesa[gbm]
+	media-libs/mesa[gbm(+)]
 	net-print/cups
 	sys-apps/dbus
 	x11-libs/cairo

--- a/www-client/vivaldi/vivaldi-4.3.2439.63-r1.ebuild
+++ b/www-client/vivaldi/vivaldi-4.3.2439.63-r1.ebuild
@@ -118,7 +118,7 @@ RDEPEND="
 	dev-libs/nspr
 	dev-libs/nss
 	media-libs/alsa-lib
-	media-libs/mesa[gbm]
+	media-libs/mesa[gbm(+)]
 	net-print/cups
 	sys-apps/dbus
 	x11-libs/cairo

--- a/www-client/vivaldi/vivaldi-4.3.2439.65-r1.ebuild
+++ b/www-client/vivaldi/vivaldi-4.3.2439.65-r1.ebuild
@@ -118,7 +118,7 @@ RDEPEND="
 	dev-libs/nspr
 	dev-libs/nss
 	media-libs/alsa-lib
-	media-libs/mesa[gbm]
+	media-libs/mesa[gbm(+)]
 	net-print/cups
 	sys-apps/dbus
 	x11-libs/cairo

--- a/www-client/vivaldi/vivaldi-4.3.2439.71-r1.ebuild
+++ b/www-client/vivaldi/vivaldi-4.3.2439.71-r1.ebuild
@@ -118,7 +118,7 @@ RDEPEND="
 	dev-libs/nspr
 	dev-libs/nss
 	media-libs/alsa-lib
-	media-libs/mesa[gbm]
+	media-libs/mesa[gbm(+)]
 	net-print/cups
 	sys-apps/dbus
 	x11-libs/cairo


### PR DESCRIPTION
Neither USE flag adds a dependency and both are small (the E in EGL stands for "Embedded"!)

I'd prefer to avoid revbumps for all of these packages to add `(+)` to their `RDEPEND`s, so this is really just a heads-up for maintainers: Please add `(+)` to `media-libs/mesa[egl]` and `media-libs/mesa[gbm]` in your packages on the next revbump.

When you do, please leave a comment here and I'll drop the patch to your package.