### PR TITLE
dev-python/pipenv: remove some bundled packages

### DIFF
--- a/dev-python/pipenv/pipenv-2021.5.29-r1.ebuild
+++ b/dev-python/pipenv/pipenv-2021.5.29-r1.ebuild
@@ -1,0 +1,56 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DISTUTILS_USE_SETUPTOOLS=rdepend
+PYTHON_COMPAT=( python3_{7,8,9} )
+
+inherit distutils-r1
+
+MY_PV=${PV/_beta/b}
+DESCRIPTION="Python Development Workflow for Humans"
+HOMEPAGE="https://github.com/pypa/pipenv https://pypi.org/project/pipenv/"
+SRC_URI="https://github.com/pypa/pipenv/archive/v${MY_PV}.tar.gz -> ${P}.tar.gz"
+S="${WORKDIR}"/${PN}-${MY_PV}
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~amd64 ~x86 ~amd64-linux ~x86-linux"
+IUSE="test"
+RESTRICT="!test? ( test )"
+
+RDEPEND="
+	${PYTHON_DEPS}
+	dev-python/certifi[${PYTHON_USEDEP}]
+	dev-python/pip[${PYTHON_USEDEP}]
+	>=dev-python/virtualenv-20.0.35[${PYTHON_USEDEP}]
+	dev-python/virtualenv-clone[${PYTHON_USEDEP}]
+"
+BDEPEND="
+	${RDEPEND}
+	test? (
+		dev-python/flaky[${PYTHON_USEDEP}]
+		dev-python/mock[${PYTHON_USEDEP}]
+		dev-python/pytest[${PYTHON_USEDEP}]
+		dev-python/pytz[${PYTHON_USEDEP}]
+	)
+"
+
+src_prepare() {
+	# remove vendored version of PyYAML that is backported to Python2
+	# this should be removed when upstream removes support for Python2
+	rm -vR "${S}/${PN}/patched/yaml2/" || die
+	# remove vendored versions
+	# see https://bugs.gentoo.org/717666
+	rm -vR "${S}/${PN}/vendor/attr/" || die
+	rm -vR "${S}/${PN}/vendor/jinja2/" || die
+	# disable running of unittests in parallel with xdist
+	sed -i 's/addopts = -ra -n auto/;&/g' setup.cfg || die
+	sed -i 's/plugins = xdist/;&/g' setup.cfg || die
+	distutils-r1_src_prepare
+}
+
+python_test() {
+	pytest -vvv -x -m "not cli and not needs_internet" tests/unit/ || die
+}


### PR DESCRIPTION
Since pipenv bundles tons of packages, these will be
removed in a slow pace. If no bugs are reported, the
removal of bundled packages and addition of dependencies
can continue.

Bug: https://bugs.gentoo.org/717666

Signed-off-by: Oz N Tiram <oz.tiram@gmail.com>