### PR TITLE
profiles: drop mask for >=openexr-3

### DIFF
--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -593,10 +593,6 @@ dev-java/werken-xpath
 # bug #731266
 >=net-mail/cyrus-imapd-3.4.0
 
-# David Seifert <soap@gentoo.org> (2021-05-05)
-# Causes unsolvable package conflicts, bug #788310
->=media-libs/openexr-3
-
 # Eray Aslan <eras@gentoo.org> (2021-04-29)
 # Mask experimental software
 =mail-mta/postfix-3.7*


### PR DESCRIPTION
With slots for :0 and :3 in place, there should be no need to block
`>=media-libs/openexr-3` any longer.

Closes: https://bugs.gentoo.org/788310
Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>