### PR TITLE
games-rpg/lure: EAPI8 bump, ebuild improvements

### DIFF
--- a/games-rpg/lure/lure-1.1-r1.ebuild
+++ b/games-rpg/lure/lure-1.1-r1.ebuild
@@ -1,110 +1,50 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
 
-inherit eutils
+inherit desktop wrapper
 
-DAT_PV=0.13.1
-DESCRIPTION="Lure of the Temptress"
-HOMEPAGE="http://www.revolution.co.uk/_display.php?id=10"
+DAT_PV="0.13.1"
+
+DESCRIPTION="Play as the young peasant named Diermot who has to overthrow an evil sorceress"
+HOMEPAGE="https://revolution.co.uk/games_catalog/lure-of-the-temptress-copy/"
 SRC_URI="
 	https://raw.githubusercontent.com/scummvm/scummvm/266aef932a8a052df897e4d79b4572e5d169916f/dists/engine-data/lure.dat -> lure-${DAT_PV}.dat
-	!l10n_en? ( !l10n_es? ( !l10n_fr? ( !l10n_de? ( !l10n_it?
-		( mirror://sourceforge/scummvm/${P}.zip -> ${PN}-en-${PV}.zip ) ) ) ) )
-	l10n_en? ( mirror://sourceforge/scummvm/${P}.zip  -> ${PN}-en-${PV}.zip )
+	l10n_en? ( mirror://sourceforge/scummvm/${P}.zip -> ${PN}-en-${PV}.zip )
 	l10n_es? ( mirror://sourceforge/scummvm/${PN}-es-${PV}.zip )
 	l10n_fr? ( mirror://sourceforge/scummvm/${PN}-fr-${PV}.zip )
 	l10n_de? ( mirror://sourceforge/scummvm/${PN}-de-${PV}.zip )
-	l10n_it? ( mirror://sourceforge/scummvm/${PN}-it-${PV}.zip )"
+	l10n_it? ( mirror://sourceforge/scummvm/${PN}-it-${PV}.zip )
+	!l10n_en? ( !l10n_es? ( !l10n_fr? ( !l10n_de? ( !l10n_it?
+		( mirror://sourceforge/scummvm/${P}.zip -> ${PN}-en-${PV}.zip ) ) ) ) )"
+S="${WORKDIR}"
 
 LICENSE="lure"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-LANGS_IUSE="l10n_en l10n_es l10n_de l10n_fr l10n_it"
-IUSE=${LANGS_IUSE}
-RESTRICT="mirror"
+IUSE="l10n_de +l10n_en l10n_es l10n_fr l10n_it"
 
-RDEPEND=">=games-engines/scummvm-0.13.1"
-DEPEND="${RDEPEND}
-	app-arch/unzip"
-
-S=${WORKDIR}
-
-any_l10n() {
-	use l10n_en || use l10n_es || use l10n_de || use l10n_fr || use l10n_it
-}
-
-src_unpack() {
-	local lang
-
-	if any_l10n ; then
-		for lang in ${LANGS_IUSE}
-		do
-			use ${lang} && unpack ${PN}-${lang/l10n_}-${PV}.zip
-		done
-		mv lure lure-en 2> /dev/null
-	else
-		unpack ${PN}-en-${PV}.zip
-	fi
-}
-
-src_prepare() {
-	local lang f
-
-	default
-
-	find . \
-		\( -iname "*exe" \
-		-o -iname "*ega" \
-		-o -iname LICENSE.txt \) \
-		-exec rm -f '{}' +
-	mkdir docs
-	if any_l10n ; then
-		for lang in ${LANGS_IUSE}
-		do
-			mkdir docs/${lang}
-			find lure-${lang/l10n_} \
-				\( -iname "*pdf" \
-				-o -iname README \
-				-o -iname "*txt" \) \
-				-exec mv '{}' docs/${lang} \; 2> /dev/null
-		done
-	else
-		find lure \
-			\( -iname "*pdf" \
-			-o -iname README \
-			-o -iname "*txt" \) \
-			-exec mv '{}' docs \; 2> /dev/null
-	fi
-	for f in $(find docs -type f)
-	do
-		mv ${f} ${f%.*}.$(echo ${f#*.} | tr '[[:upper:]]' '[[:lower:]]') 2> /dev/null
-	done
-}
+RDEPEND="games-engines/scummvm"
+BDEPEND="app-arch/unzip"
 
 src_install() {
-	local lang
+	local my_l10n=( $(usev l10n_es) $(usev l10n_de) $(usev l10n_en) $(usev l10n_fr) $(usev l10n_it) )
+	[[ ${my_l10n} ]] || my_l10n=( l10n_en )
 
-	if any_l10n ; then
-		for lang in ${LANGS_IUSE}
-		do
-			if use ${lang} ; then
-				lang=${lang/l10n_}
-				insinto "/usr/share/${PN}-${lang}"
-				newins "${DISTDIR}"/lure-${DAT_PV}.dat lure.dat
-				doins -r ${PN}-${lang}/*
-				make_wrapper ${PN}-${lang} "scummvm -q ${lang} -f -p \"/usr/share/${PN}-${lang}\" lure" .
-				make_desktop_entry ${PN}-${lang} "Lure of the Temptress (${lang})" ${PN}
-				docinto l10n_${lang}
-				dodoc docs/l10n_${lang}/*
-			fi
-		done
-	else
-		insinto "/usr/share/${PN}"
-		newins "${DISTDIR}"/lure-${DAT_PV}.dat lure.dat
-		doins -r ${PN}/*
-		make_wrapper ${PN} "scummvm -f -p \"/usr/share/${PN}\" lure" .
-		make_desktop_entry ${PN} "Lure of the Temptress"
-	fi
+	local lang name
+	for lang in "${my_l10n[@]//l10n_/}"; do
+		[[ ${lang} == en ]] && name=${PN} || name=${PN}-${lang}
+
+		insinto /usr/share/${PN}/${lang}
+		newins "${DISTDIR}"/${PN}-${DAT_PV}.dat ${PN}.dat
+		doins ${name}/D*[1-4].[vV][gG][aA]
+
+		docinto ${lang}
+		dodoc ${name}/{Manual.pdf,README}
+		newdoc ${name}/PROTECT.PDF PROTECT.pdf
+
+		make_wrapper ${PN}-${lang} "scummvm -q ${lang} -f -p \"${EPREFIX}/usr/share/${PN}/${lang}\" lure"
+		make_desktop_entry ${PN}-${lang} "Lure of the Temptress (${lang})" applications-games
+	done
 }


### PR DESCRIPTION
Package-Manager: Portage-3.0.20, Repoman-3.0.3
Signed-off-by: Michael Mair-Keimberger <mmk@levelnine.at>

@ionenwks 

Some notes:
* I've decided to not install the `notes.txt` file since i don't think it's relevant on linux (and makes it easier for the ebuild ;))
* Initially i even had the ebuild without a `src_prepare`. However, in case of `PROTECT.PDF` the file would have been compressed which is why i had to rename it. (i guess it's required for doc files that extension are lowercase?) Anyway, I couldn't find any rules about the file extension need to be lowercase which is why i keep it for the other files.

