### PR TITLE
dev-python/*: bump to python 3.10

### DIFF
--- a/dev-python/aiohttp-jinja2/aiohttp-jinja2-1.4.2.ebuild
+++ b/dev-python/aiohttp-jinja2/aiohttp-jinja2-1.4.2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{7,8,9} )
+PYTHON_COMPAT=( python3_{8..10} )
 
 inherit distutils-r1
 

--- a/dev-python/aiohttp-jinja2/aiohttp-jinja2-1.4.2.ebuild
+++ b/dev-python/aiohttp-jinja2/aiohttp-jinja2-1.4.2.ebuild
@@ -14,25 +14,19 @@ SRC_URI="mirror://pypi/${P:0:1}/${PN}/${P}.tar.gz"
 LICENSE="Apache-2.0"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE="doc test"
-RESTRICT="!test? ( test )"
 
 RDEPEND="
 	>=dev-python/aiohttp-2.3.9[${PYTHON_USEDEP}]
 	>=dev-python/jinja-2.10[${PYTHON_USEDEP}]
 "
-DEPEND="
-	${RDEPEND}
-	doc? (
-		>=dev-python/alabaster-0.6.2[${PYTHON_USEDEP}]
-		dev-python/sphinx[${PYTHON_USEDEP}]
-	)
+BDEPEND="
 	test? ( >=dev-python/pytest-aiohttp-0.3.0[${PYTHON_USEDEP}] )
 "
 
 DOCS=( README.rst )
 
 distutils_enable_tests pytest
+distutils_enable_sphinx docs dev-python/alabaster
 
 src_prepare() {
 	default
@@ -42,14 +36,4 @@ src_prepare() {
 		setup.cfg || die
 
 	distutils-r1_src_prepare
-}
-
-python_compile_all() {
-	use doc && emake -C docs html
-}
-
-python_install_all() {
-	use doc && local HTML_DOCS=( docs/_build/html/. )
-
-	distutils-r1_python_install_all
 }

--- a/dev-python/aiohttp/aiohttp-3.7.4-r1.ebuild
+++ b/dev-python/aiohttp/aiohttp-3.7.4-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{8..9} )
+PYTHON_COMPAT=( python3_{8..10} )
 
 inherit distutils-r1 multiprocessing
 
@@ -42,6 +42,7 @@ BDEPEND="
 
 PATCHES=(
 	"${FILESDIR}"/aiohttp-3.7.4-brotli.patch
+	"${FILESDIR}"/aiohttp-3.7.4-fix-py3.10.patch
 )
 
 DOCS=( CHANGES.rst CONTRIBUTORS.txt README.rst )

--- a/dev-python/aiohttp/files/aiohttp-3.7.4-fix-py3.10.patch
+++ b/dev-python/aiohttp/files/aiohttp-3.7.4-fix-py3.10.patch
@@ -1,0 +1,73 @@
+commit ec87d9f2b6541599dd7fc8aaebf0fdfbb812ade7
+Author: Louis Sautier <sautier.louis@gmail.com>
+Date:   Tue Jul 20 23:37:27 2021 +0200
+
+    Remove deprecated loop argument from asyncio.sleep/gather calls
+
+diff --git a/aiohttp/web.py b/aiohttp/web.py
+index 557e3c3b..52dfdf93 100644
+--- a/aiohttp/web.py
++++ b/aiohttp/web.py
+@@ -441,7 +441,7 @@ def _cancel_tasks(
+         task.cancel()
+ 
+     loop.run_until_complete(
+-        asyncio.gather(*to_cancel, loop=loop, return_exceptions=True)
++        asyncio.gather(*to_cancel, return_exceptions=True)
+     )
+ 
+     for task in to_cancel:
+diff --git a/tests/test_locks.py b/tests/test_locks.py
+index 55fd2330..5f434eac 100644
+--- a/tests/test_locks.py
++++ b/tests/test_locks.py
+@@ -18,7 +18,7 @@ class TestEventResultOrError:
+             return 1
+ 
+         t = loop.create_task(c())
+-        await asyncio.sleep(0, loop=loop)
++        await asyncio.sleep(0)
+         e = Exception()
+         ev.set(exc=e)
+         assert (await t) == e
+@@ -31,7 +31,7 @@ class TestEventResultOrError:
+             return 1
+ 
+         t = loop.create_task(c())
+-        await asyncio.sleep(0, loop=loop)
++        await asyncio.sleep(0)
+         ev.set()
+         assert (await t) == 1
+ 
+@@ -43,7 +43,7 @@ class TestEventResultOrError:
+ 
+         t1 = loop.create_task(c())
+         t2 = loop.create_task(c())
+-        await asyncio.sleep(0, loop=loop)
++        await asyncio.sleep(0)
+         ev.cancel()
+         ev.set()
+ 
+diff --git a/tests/test_proxy_functional.py b/tests/test_proxy_functional.py
+index 68763cd4..65c773a1 100644
+--- a/tests/test_proxy_functional.py
++++ b/tests/test_proxy_functional.py
+@@ -238,7 +238,7 @@ async def test_proxy_http_multi_conn_limit(proxy_test_server, loop) -> None:
+         resp = await sess.get(url, proxy=proxy.url)
+ 
+         current_pid = pid
+-        await asyncio.sleep(0.2, loop=loop)
++        await asyncio.sleep(0.2)
+         assert current_pid == pid
+ 
+         await resp.release()
+@@ -443,7 +443,7 @@ async def xtest_proxy_https_multi_conn_limit(proxy_test_server, loop):
+         resp = await sess.get(url, proxy=proxy.url)
+ 
+         current_pid = pid
+-        await asyncio.sleep(0.2, loop=loop)
++        await asyncio.sleep(0.2)
+         assert current_pid == pid
+ 
+         await resp.release()
+

--- a/dev-python/async_timeout/async_timeout-3.0.1.ebuild
+++ b/dev-python/async_timeout/async_timeout-3.0.1.ebuild
@@ -2,7 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-PYTHON_COMPAT=( python3_{8..9} )
+
+PYTHON_COMPAT=( python3_{8..10} )
 
 inherit distutils-r1
 
@@ -20,7 +21,10 @@ BDEPEND="
 	dev-python/setuptools_scm[${PYTHON_USEDEP}]
 	test? (
 		dev-python/pytest-aiohttp[${PYTHON_USEDEP}]
+		dev-python/pytest-asyncio[${PYTHON_USEDEP}]
 	)"
+
+PATCHES=( "${FILESDIR}/${P}-fix-py3.10.patch" )
 
 distutils_enable_tests pytest
 

--- a/dev-python/async_timeout/files/async_timeout-3.0.1-fix-py3.10.patch
+++ b/dev-python/async_timeout/files/async_timeout-3.0.1-fix-py3.10.patch
@@ -1,0 +1,387 @@
+diff --git a/tests/test_py35.py b/tests/test_py35.py
+index 00bb7f0..7d88d99 100644
+--- a/tests/test_py35.py
++++ b/tests/test_py35.py
+@@ -4,30 +4,32 @@ import pytest
+ 
+ from async_timeout import timeout
+ 
+-pytestmark = pytest.mark.asyncio
+ 
+-
+-async def test_async_timeout(loop):
++@pytest.mark.asyncio
++async def test_async_timeout():
+     with pytest.raises(asyncio.TimeoutError):
+-        async with timeout(0.01, loop=loop) as cm:
+-            await asyncio.sleep(10, loop=loop)
++        async with timeout(0.01) as cm:
++            await asyncio.sleep(10)
+     assert cm.expired
+ 
+ 
+-async def test_async_no_timeout(loop):
+-    async with timeout(1, loop=loop) as cm:
+-        await asyncio.sleep(0, loop=loop)
++@pytest.mark.asyncio
++async def test_async_no_timeout():
++    async with timeout(1) as cm:
++        await asyncio.sleep(0)
+     assert not cm.expired
+ 
+ 
+-async def test_async_zero(loop):
++@pytest.mark.asyncio
++async def test_async_zero():
+     with pytest.raises(asyncio.TimeoutError):
+-        async with timeout(0, loop=loop) as cm:
+-            await asyncio.sleep(10, loop=loop)
++        async with timeout(0) as cm:
++            await asyncio.sleep(10)
+     assert cm.expired
+ 
+ 
+-async def test_async_zero_coro_not_started(loop):
++@pytest.mark.asyncio
++async def test_async_zero_coro_not_started():
+     coro_started = False
+ 
+     async def coro():
+@@ -35,8 +37,8 @@ async def test_async_zero_coro_not_started(loop):
+         coro_started = True
+ 
+     with pytest.raises(asyncio.TimeoutError):
+-        async with timeout(0, loop=loop) as cm:
+-            await asyncio.sleep(0, loop=loop)
++        async with timeout(0) as cm:
++            await asyncio.sleep(0)
+             await coro()
+ 
+     assert cm.expired
+diff --git a/tests/test_timeout.py b/tests/test_timeout.py
+index 8915546..b1cb3c7 100644
+--- a/tests/test_timeout.py
++++ b/tests/test_timeout.py
+@@ -6,89 +6,69 @@ import pytest
+ 
+ from async_timeout import timeout
+ 
+-from asyncio import ensure_future
+-
+-
+-def create_future(loop):
+-    """Compatibility wrapper for the loop.create_future() call introduced in
+-    3.5.2."""
+-    if hasattr(loop, 'create_future'):
+-        return loop.create_future()
+-    else:
+-        return asyncio.Future(loop=loop)
+-
+ 
+ @pytest.mark.asyncio
+-async def test_timeout(loop):
++async def test_timeout():
+     canceled_raised = False
+ 
+     async def long_running_task():
+         try:
+-            await asyncio.sleep(10, loop=loop)
++            await asyncio.sleep(10)
+         except asyncio.CancelledError:
+             nonlocal canceled_raised
+             canceled_raised = True
+             raise
+ 
+     with pytest.raises(asyncio.TimeoutError):
+-        with timeout(0.01, loop=loop) as t:
++        with timeout(0.01) as t:
+             await long_running_task()
+-            assert t._loop is loop
++            assert t._loop is asyncio.get_event_loop()
+     assert canceled_raised, 'CancelledError was not raised'
+ 
+ 
+ @pytest.mark.asyncio
+-async def test_timeout_finish_in_time(loop):
++async def test_timeout_finish_in_time():
+     async def long_running_task():
+-        await asyncio.sleep(0.01, loop=loop)
++        await asyncio.sleep(0.01)
+         return 'done'
+ 
+-    with timeout(0.1, loop=loop):
++    with timeout(0.1):
+         resp = await long_running_task()
+     assert resp == 'done'
+ 
+ 
+-def test_timeout_global_loop(loop):
+-    asyncio.set_event_loop(loop)
+-
+-    async def run():
+-        with timeout(10) as t:
+-            await asyncio.sleep(0.01)
+-            assert t._loop is loop
+-
+-    loop.run_until_complete(run())
+-
+-
+ @pytest.mark.asyncio
+-async def test_timeout_disable(loop):
++async def test_timeout_disable():
+     async def long_running_task():
+-        await asyncio.sleep(0.1, loop=loop)
++        await asyncio.sleep(0.1)
+         return 'done'
+ 
++    loop = asyncio.get_event_loop()
+     t0 = loop.time()
+-    with timeout(None, loop=loop):
++    with timeout(None):
+         resp = await long_running_task()
+     assert resp == 'done'
+     dt = loop.time() - t0
+     assert 0.09 < dt < 0.13, dt
+ 
+ 
+-def test_timeout_is_none_no_task(loop):
++def test_timeout_is_none_no_task():
++    loop = asyncio.get_event_loop()
+     with timeout(None, loop=loop) as cm:
+         assert cm._task is None
+ 
+ 
+ @pytest.mark.asyncio
+-async def test_timeout_enable_zero(loop):
++async def test_timeout_enable_zero():
+     with pytest.raises(asyncio.TimeoutError):
+-        with timeout(0, loop=loop) as cm:
+-            await asyncio.sleep(0.1, loop=loop)
++        with timeout(0) as cm:
++            await asyncio.sleep(0.1)
+ 
+     assert cm.expired
+ 
+ 
+ @pytest.mark.asyncio
+-async def test_timeout_enable_zero_coro_not_started(loop):
++async def test_timeout_enable_zero_coro_not_started():
+     coro_started = False
+ 
+     async def coro():
+@@ -96,8 +76,8 @@ async def test_timeout_enable_zero_coro_not_started(loop):
+         coro_started = True
+ 
+     with pytest.raises(asyncio.TimeoutError):
+-        with timeout(0, loop=loop) as cm:
+-            await asyncio.sleep(0, loop=loop)
++        with timeout(0) as cm:
++            await asyncio.sleep(0)
+             await coro()
+ 
+     assert cm.expired
+@@ -105,51 +85,52 @@ async def test_timeout_enable_zero_coro_not_started(loop):
+ 
+ 
+ @pytest.mark.asyncio
+-async def test_timeout_not_relevant_exception(loop):
+-    await asyncio.sleep(0, loop=loop)
++async def test_timeout_not_relevant_exception():
++    await asyncio.sleep(0)
+     with pytest.raises(KeyError):
+-        with timeout(0.1, loop=loop):
++        with timeout(0.1):
+             raise KeyError
+ 
+ 
+ @pytest.mark.asyncio
+-async def test_timeout_canceled_error_is_not_converted_to_timeout(loop):
+-    await asyncio.sleep(0, loop=loop)
++async def test_timeout_canceled_error_is_not_converted_to_timeout():
++    await asyncio.sleep(0)
+     with pytest.raises(asyncio.CancelledError):
+-        with timeout(0.001, loop=loop):
++        with timeout(0.001):
+             raise asyncio.CancelledError
+ 
+ 
+ @pytest.mark.asyncio
+-async def test_timeout_blocking_loop(loop):
++async def test_timeout_blocking_loop():
+     async def long_running_task():
+         time.sleep(0.1)
+         return 'done'
+ 
+-    with timeout(0.01, loop=loop):
++    with timeout(0.01):
+         result = await long_running_task()
+     assert result == 'done'
+ 
+ 
+ @pytest.mark.asyncio
+-async def test_for_race_conditions(loop):
+-    fut = create_future(loop)
++async def test_for_race_conditions():
++    loop = asyncio.get_event_loop()
++    fut = loop.create_future()
+     loop.call_later(0.1, fut.set_result('done'))
+-    with timeout(0.2, loop=loop):
++    with timeout(0.2):
+         resp = await fut
+     assert resp == 'done'
+ 
+ 
+ @pytest.mark.asyncio
+-async def test_timeout_time(loop):
++async def test_timeout_time():
+     foo_running = None
+-
++    loop = asyncio.get_event_loop()
+     start = loop.time()
+     with pytest.raises(asyncio.TimeoutError):
+-        with timeout(0.1, loop=loop):
++        with timeout(0.1):
+             foo_running = True
+             try:
+-                await asyncio.sleep(0.2, loop=loop)
++                await asyncio.sleep(0.2)
+             finally:
+                 foo_running = False
+ 
+@@ -160,26 +141,26 @@ async def test_timeout_time(loop):
+     assert not foo_running
+ 
+ 
+-def test_raise_runtimeerror_if_no_task(loop):
++def test_raise_runtimeerror_if_no_task():
+     with pytest.raises(RuntimeError):
+-        with timeout(0.1, loop=loop):
++        with timeout(0.1):
+             pass
+ 
+ 
+ @pytest.mark.asyncio
+-async def test_outer_coro_is_not_cancelled(loop):
++async def test_outer_coro_is_not_cancelled():
+ 
+     has_timeout = False
+ 
+     async def outer():
+         nonlocal has_timeout
+         try:
+-            with timeout(0.001, loop=loop):
+-                await asyncio.sleep(1, loop=loop)
++            with timeout(0.001):
++                await asyncio.sleep(1)
+         except asyncio.TimeoutError:
+             has_timeout = True
+ 
+-    task = ensure_future(outer(), loop=loop)
++    task = asyncio.ensure_future(outer())
+     await task
+     assert has_timeout
+     assert not task.cancelled()
+@@ -187,14 +168,15 @@ async def test_outer_coro_is_not_cancelled(loop):
+ 
+ 
+ @pytest.mark.asyncio
+-async def test_cancel_outer_coro(loop):
+-    fut = create_future(loop)
++async def test_cancel_outer_coro():
++    loop = asyncio.get_event_loop()
++    fut = loop.create_future()
+ 
+     async def outer():
+         fut.set_result(None)
+-        await asyncio.sleep(1, loop=loop)
++        await asyncio.sleep(1)
+ 
+-    task = ensure_future(outer(), loop=loop)
++    task = asyncio.ensure_future(outer())
+     await fut
+     task.cancel()
+     with pytest.raises(asyncio.CancelledError):
+@@ -204,57 +186,64 @@ async def test_cancel_outer_coro(loop):
+ 
+ 
+ @pytest.mark.asyncio
+-async def test_timeout_suppress_exception_chain(loop):
++async def test_timeout_suppress_exception_chain():
+     with pytest.raises(asyncio.TimeoutError) as ctx:
+-        with timeout(0.01, loop=loop):
+-            await asyncio.sleep(10, loop=loop)
++        with timeout(0.01):
++            await asyncio.sleep(10)
+     assert not ctx.value.__suppress_context__
+ 
+ 
+ @pytest.mark.asyncio
+-async def test_timeout_expired(loop):
++async def test_timeout_expired():
+     with pytest.raises(asyncio.TimeoutError):
+-        with timeout(0.01, loop=loop) as cm:
+-            await asyncio.sleep(10, loop=loop)
++        with timeout(0.01) as cm:
++            await asyncio.sleep(10)
+     assert cm.expired
+ 
+ 
+ @pytest.mark.asyncio
+-async def test_timeout_inner_timeout_error(loop):
++async def test_timeout_inner_timeout_error():
+     with pytest.raises(asyncio.TimeoutError):
+-        with timeout(0.01, loop=loop) as cm:
++        with timeout(0.01) as cm:
+             raise asyncio.TimeoutError
+     assert not cm.expired
+ 
+ 
+ @pytest.mark.asyncio
+-async def test_timeout_inner_other_error(loop):
++async def test_timeout_inner_other_error():
+     with pytest.raises(RuntimeError):
+-        with timeout(0.01, loop=loop) as cm:
++        with timeout(0.01) as cm:
+             raise RuntimeError
+     assert not cm.expired
+ 
+ 
+ @pytest.mark.asyncio
+-async def test_timeout_remaining(loop):
+-    with timeout(None, loop=loop) as cm:
++async def test_timeout_remaining():
++    with timeout(None) as cm:
+         assert cm.remaining is None
++    assert cm.remaining is None
++
++    t = timeout(None)
++    assert t.remaining is None
+ 
+-    t = timeout(1.0, loop=loop)
++    t = timeout(1.0)
+     assert t.remaining is None
+ 
+-    with timeout(1.0, loop=loop) as cm:
+-        await asyncio.sleep(0.1, loop=loop)
++    with timeout(1.0) as cm:
++        await asyncio.sleep(0.1)
+         assert cm.remaining < 1.0
++    r = cm.remaining
++    time.sleep(0.1)
++    assert abs(r - cm.remaining) < 1.0
+ 
+     with pytest.raises(asyncio.TimeoutError):
+-        with timeout(0.1, loop=loop) as cm:
+-            await asyncio.sleep(0.5, loop=loop)
++        with timeout(0.1) as cm:
++            await asyncio.sleep(0.5)
+ 
+     assert cm.remaining == 0.0
+ 
+ 
+-def test_cancel_without_starting(loop):
+-    tm = timeout(1, loop=loop)
++def test_cancel_without_starting():
++    tm = timeout(1)
+     tm._cancel_task()
+     tm._cancel_task()  # double call should success

--- a/dev-python/pytest-aiohttp/pytest-aiohttp-0.3.0-r1.ebuild
+++ b/dev-python/pytest-aiohttp/pytest-aiohttp-0.3.0-r1.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{7..9} )
+PYTHON_COMPAT=( python3_{8..10} )
 
 inherit distutils-r1
 

--- a/dev-python/uvloop/uvloop-0.15.3-r1.ebuild
+++ b/dev-python/uvloop/uvloop-0.15.3-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{8..9} )
+PYTHON_COMPAT=( python3_{8..10} )
 inherit distutils-r1
 
 DESCRIPTION="Ultra-fast implementation of asyncio event loop on top of libuv"

--- a/dev-python/uvloop/uvloop-0.15.3-r1.ebuild
+++ b/dev-python/uvloop/uvloop-0.15.3-r1.ebuild
@@ -37,10 +37,10 @@ PATCHES=(
 )
 
 python_prepare_all() {
-	cat <<EOF >> setup.cfg || die
-[build_ext]
-use-system-libuv=1
-EOF
+	cat <<-EOF >> setup.cfg || die
+		[build_ext]
+		use_system_libuv=1
+	EOF
 
 	# flake8 only
 	rm tests/test_sourcecode.py || die

--- a/dev-python/uvloop/uvloop-0.15.3.ebuild
+++ b/dev-python/uvloop/uvloop-0.15.3.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{8..9} )
+PYTHON_COMPAT=( python3_{8..10} )
 inherit distutils-r1
 
 DESCRIPTION="Ultra-fast implementation of asyncio event loop on top of libuv"

--- a/dev-python/uvloop/uvloop-0.15.3.ebuild
+++ b/dev-python/uvloop/uvloop-0.15.3.ebuild
@@ -32,10 +32,10 @@ BDEPEND="
 distutils_enable_tests setup.py
 
 python_prepare_all() {
-	cat <<EOF >> setup.cfg || die
-[build_ext]
-use-system-libuv=1
-EOF
+	cat <<-EOF >> setup.cfg || die
+		[build_ext]
+		use_system_libuv=1
+	EOF
 
 	# flake8 only
 	rm tests/test_sourcecode.py || die


### PR DESCRIPTION
@mgorny , well I'm back to bumping to python 3.10, so if you have the time, I will gladly continue.

In this PR I wanted to bump one circular dependency around `dev-python/aiohttp`. Therefore the first 3 commits can't be separated, and I recommend to test using all commits together.
Also, I try to make every change as a separate commit, so if you or the maintainer are against a change, it is easy to remove.

- For `dev-python/async_timeout`, it was fixed upstream, but by many partial commits. I have ran `git diff tests/` to tagged version and got this smallest fixing patch. It changes only tests, therefore should be safe to change even in stable ebuild.
- For `dev-python/pytest-aiohttp` a trivial bump. This one doesn't have test suite, so it was tested by testing `dev-python/aiohttp` which uses it.
- For `dev-python/aiohttp` imported a patch from [here](https://github.com/aio-libs/aiohttp/issues/5905).
- For `dev-python/aiohttp-jinja2` it was trivial bump, and then I tried to improve the doc generation
- For `dev-python/uvloop` it was also trivial bump, I tried to to improve the `setup.cfg` generation (make it more readable, and tested for correct result of course). I wanted to improve doc generation but it failed so haven't touched.

All those changes were tested using `ebuild * test` on a lxd container test machine, and on my main machine.