### PR TITLE
media-libs/sdl-net: EAPI8 bump, minor ebuild improvements

### DIFF
--- a/media-libs/sdl-net/sdl-net-1.2.8-r2.ebuild
+++ b/media-libs/sdl-net/sdl-net-1.2.8-r2.ebuild
@@ -1,0 +1,29 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit multilib-minimal
+
+MY_P="${P/sdl-/SDL_}"
+
+DESCRIPTION="Simple Direct Media Layer Network Support Library"
+HOMEPAGE="https://www.libsdl.org/projects/SDL_net/"
+SRC_URI="https://www.libsdl.org/projects/SDL_net/release/${MY_P}.tar.gz"
+S="${WORKDIR}/${MY_P}"
+
+LICENSE="ZLIB"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-solaris"
+
+RDEPEND="media-libs/libsdl[${MULTILIB_USEDEP}]"
+DEPEND="${RDEPEND}"
+
+multilib_src_configure() {
+	ECONF_SOURCE="${S}" econf --disable-gui
+}
+
+multilib_src_install_all() {
+	einstalldocs
+	find "${ED}" -name '*.la' -delete || die
+}


### PR DESCRIPTION
Package-Manager: Portage-3.0.20, Repoman-3.0.3
Signed-off-by: Michael Mair-Keimberger <mmk@levelnine.at>

I've looked into https://bugs.gentoo.org/730872 too and i think the problem was because it called `AS` directly. Please have a look. In the `config.status` file it now uses the correct tool, but i couldn't see anywhere in the logs that it was used.