### PR TITLE
app-crypt/trousers: Fix permissions and ownership of /etc/tcsd.conf

### DIFF
--- a/app-crypt/trousers/trousers-0.3.14-r3.ebuild
+++ b/app-crypt/trousers/trousers-0.3.14-r3.ebuild
@@ -64,5 +64,7 @@ src_install() {
 	systemd_dounit "${FILESDIR}"/tcsd.service
 	udev_dorules "${FILESDIR}"/61-trousers.rules
 	fowners tss:tss /var/lib/tpm
+	fowners :tss /etc/tcsd.conf
+	fperms 640 /etc/tcsd.conf
 	readme.gentoo_create_doc
 }

--- a/app-crypt/trousers/trousers-0.3.15.ebuild
+++ b/app-crypt/trousers/trousers-0.3.15.ebuild
@@ -61,5 +61,7 @@ src_install() {
 	systemd_dounit "${FILESDIR}"/tcsd.service
 	udev_dorules "${FILESDIR}"/61-trousers.rules
 	fowners tss:tss /var/lib/tpm
+	fowners :tss /etc/tcsd.conf
+	fperms 640 /etc/tcsd.conf
 	readme.gentoo_create_doc
 }


### PR DESCRIPTION
tcsd will not start as-is until the permissions and ownership is changed on /etc/tcsd.conf, this fixes the ebuild to set the permissions and ownership correctly so it works "out of the box"