### PR TITLE
Libffi compat 7

### DIFF
--- a/app-office/wps-office/wps-office-11.1.0.10161-r2.ebuild
+++ b/app-office/wps-office/wps-office-11.1.0.10161-r2.ebuild
@@ -31,7 +31,7 @@ RDEPEND="
 	dev-libs/expat
 	dev-libs/glib:2
 	dev-libs/libbsd
-	dev-libs/libffi:0/7
+	|| ( dev-libs/libffi:0/7 dev-libs/libffi-compat:7 )
 	dev-libs/libgcrypt:0
 	dev-libs/libgpg-error
 	dev-libs/libpcre:3

--- a/dev-python/pypy-exe-bin/pypy-exe-bin-7.3.4-r1.ebuild
+++ b/dev-python/pypy-exe-bin/pypy-exe-bin-7.3.4-r1.ebuild
@@ -1,0 +1,48 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit pax-utils
+
+MY_P=pypy-exe-${PV}-1
+DESCRIPTION="PyPy executable (pre-built version)"
+HOMEPAGE="https://www.pypy.org/"
+SRC_URI="
+	amd64? (
+		https://dev.gentoo.org/~mgorny/binpkg/amd64/pypy/dev-python/pypy-exe/${MY_P}.xpak
+			-> ${MY_P}.amd64.xpak
+	)
+	x86? (
+		https://dev.gentoo.org/~mgorny/binpkg/x86/pypy/dev-python/pypy-exe/${MY_P}.xpak
+			-> ${MY_P}.x86.xpak
+	)"
+S="${WORKDIR}"
+
+LICENSE="MIT"
+SLOT="${PV%_p*}"
+KEYWORDS="~amd64 ~x86"
+
+RDEPEND=">=sys-libs/zlib-1.1.3:0/1
+	|| ( dev-libs/libffi:0/7 dev-libs/libffi-compat:7 )
+	virtual/libintl:0/0
+	dev-libs/expat:0/0
+	app-arch/bzip2:0/1
+	sys-libs/ncurses:0/6
+	!dev-python/pypy-exe:${SLOT}"
+
+QA_PREBUILT="
+	usr/lib/pypy2.7/pypy-c-${SLOT}"
+
+src_unpack() {
+	ebegin "Unpacking ${MY_P}.${ARCH}.xpak"
+	tar -x < <(xz -c -d --single-stream "${DISTDIR}/${MY_P}.${ARCH}.xpak")
+	eend ${?} || die "Unpacking ${MY_P} failed"
+}
+
+src_install() {
+	insinto /
+	doins -r usr
+	fperms +x "/usr/lib/pypy2.7/pypy-c-${SLOT}"
+	pax-mark m "${ED}/usr/lib/pypy2.7/pypy-c-${SLOT}"
+}

--- a/dev-python/pypy3-exe-bin/pypy3-exe-bin-7.3.4-r1.ebuild
+++ b/dev-python/pypy3-exe-bin/pypy3-exe-bin-7.3.4-r1.ebuild
@@ -1,0 +1,49 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit pax-utils
+
+MY_P=pypy3-exe-${PV}-1
+DESCRIPTION="PyPy3 executable (pre-built version)"
+HOMEPAGE="https://www.pypy.org/"
+SRC_URI="
+	amd64? (
+		https://dev.gentoo.org/~mgorny/binpkg/amd64/pypy/dev-python/pypy3-exe/${MY_P}.xpak
+			-> ${MY_P}.amd64.xpak
+	)
+	x86? (
+		https://dev.gentoo.org/~mgorny/binpkg/x86/pypy/dev-python/pypy3-exe/${MY_P}.xpak
+			-> ${MY_P}.x86.xpak
+	)"
+S="${WORKDIR}"
+
+LICENSE="MIT"
+SLOT="${PV%_p*}"
+KEYWORDS="~amd64 ~x86"
+
+RDEPEND=">=sys-libs/zlib-1.1.3:0/1
+	|| ( dev-libs/libffi:0/7 dev-libs/libffi-compat:7 )
+	virtual/libintl:0/0
+	dev-libs/expat:0/0
+	app-arch/bzip2:0/1
+	sys-libs/ncurses:0/6
+	!dev-python/pypy-exe:${SLOT}"
+
+PYPY_PV=${SLOT%_p*}
+QA_PREBUILT="
+	usr/lib/pypy3.7/pypy3-c-${PYPY_PV}"
+
+src_unpack() {
+	ebegin "Unpacking ${MY_P}.${ARCH}.xpak"
+	tar -x < <(xz -c -d --single-stream "${DISTDIR}/${MY_P}.${ARCH}.xpak")
+	eend ${?} || die "Unpacking ${MY_P} failed"
+}
+
+src_install() {
+	insinto /
+	doins -r usr
+	fperms +x "/usr/lib/pypy3.7/pypy3-c-${PYPY_PV}"
+	pax-mark m "${ED}/usr/lib/pypy3.7/pypy3-c-${PYPY_PV}"
+}

--- a/games-action/minecraft-launcher/minecraft-launcher-928-r3.ebuild
+++ b/games-action/minecraft-launcher/minecraft-launcher-928-r3.ebuild
@@ -21,7 +21,7 @@ RDEPEND="
 	app-crypt/libsecret
 	dev-libs/nss
 	dev-libs/libbsd
-	dev-libs/libffi:0/7
+	|| ( dev-libs/libffi:0/7 dev-libs/libffi-compat:7 )
 	dev-libs/libpcre
 	media-libs/alsa-lib
 	media-libs/openal


### PR DESCRIPTION
Allow libffi-compat:7 alternative

Allow libffi.so.8 from dev-libs/libffi and libffi.so.7 from
libffi-compat:7 to coexist in a single system.

Otherwise this binary package install attempts to downgrade libffi.

Bug: https://bugs.gentoo.org/804660