### PR TITLE
dev-java/zstd-jni: Allow CMake to find and use JNI without AWT

### DIFF
--- a/dev-java/zstd-jni/zstd-jni-1.4.9.1.ebuild
+++ b/dev-java/zstd-jni/zstd-jni-1.4.9.1.ebuild
@@ -26,6 +26,9 @@ JAVA_SRC_DIR="src/main/java"
 src_configure() {
 	local mycmakeargs=(
 		-DJAVA_HOME="$(java-config -g JAVA_HOME)"
+		# Resolve bug #776910
+		# Reference: https://stackoverflow.com/a/51764145
+		-DJAVA_AWT_LIBRARY="NotNeeded"
 	)
 	cmake_src_configure
 }

--- a/dev-java/zstd-jni/zstd-jni-1.5.0.4.ebuild
+++ b/dev-java/zstd-jni/zstd-jni-1.5.0.4.ebuild
@@ -37,6 +37,9 @@ src_prepare() {
 src_configure() {
 	local mycmakeargs=(
 		-DJAVA_HOME="$(java-config -g JAVA_HOME)"
+		# Resolve bug #776910
+		# Reference: https://stackoverflow.com/a/51764145
+		-DJAVA_AWT_LIBRARY="NotNeeded"
 	)
 	cmake_src_configure
 }


### PR DESCRIPTION
More details can be found in the commit message.  The modified ebuilds are installable with `dev-java/openjdk-bin-8.292_p10dev-java/openjdk-bin-8.292_p10` with USE flag `headless-awt` enabled as well as disabled.

Tests: https://github.com/Leo3418/gentoo/actions/runs/1075517154