### PR TITLE
games-fps/freedoom-data: Requires games-util/deutex[png]

### DIFF
--- a/games-fps/freedm-data/freedm-data-0.12.1-r1.ebuild
+++ b/games-fps/freedm-data/freedm-data-0.12.1-r1.ebuild
@@ -18,7 +18,7 @@ KEYWORDS="~amd64 ~arm ~x86"
 BDEPEND="
 	$(python_gen_any_dep 'dev-python/pillow[${PYTHON_USEDEP},zlib]')
 	app-text/asciidoc
-	games-util/deutex"
+	games-util/deutex[png]"
 
 S="${WORKDIR}/freedoom-${PV}"
 
@@ -44,7 +44,7 @@ src_install() {
 	emake install-freedm \
 		prefix="${ED}/usr/" \
 		bindir="bin/" \
-		docdir="share/doc/${P}" \
+		docdir="share/doc/${PF}" \
 		mandir="share/man/" \
 		waddir="${DOOMWADPATH}/"
 }

--- a/games-fps/freedm/freedm-0.12.1.ebuild
+++ b/games-fps/freedm/freedm-0.12.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -15,6 +15,7 @@ RDEPEND="
 	|| (
 		games-fps/gzdoom[nonfree(+)]
 		games-engines/odamex
+		games-fps/chocolate-doom
 		games-fps/doomsday
 		games-fps/prboom-plus
 	)

--- a/games-fps/freedoom-data/freedoom-data-0.12.1-r1.ebuild
+++ b/games-fps/freedoom-data/freedoom-data-0.12.1-r1.ebuild
@@ -18,7 +18,7 @@ KEYWORDS="~amd64 ~arm ~x86"
 BDEPEND="
 	$(python_gen_any_dep 'dev-python/pillow[${PYTHON_USEDEP},zlib]')
 	app-text/asciidoc
-	games-util/deutex"
+	games-util/deutex[png]"
 
 S="${WORKDIR}/freedoom-${PV}"
 
@@ -44,7 +44,7 @@ src_install() {
 	emake install-freedoom \
 		prefix="${ED}/usr/" \
 		bindir="bin/" \
-		docdir="share/doc/${P}" \
+		docdir="share/doc/${PF}" \
 		mandir="share/man/" \
 		waddir="${DOOMWADPATH}/"
 }

--- a/games-fps/freedoom/freedoom-0.12.1.ebuild
+++ b/games-fps/freedoom/freedoom-0.12.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -15,6 +15,7 @@ RDEPEND="
 	|| (
 		games-fps/gzdoom[nonfree(+)]
 		games-engines/odamex
+		games-fps/chocolate-doom
 		games-fps/doomsday
 		games-fps/prboom-plus
 	)

--- a/games-util/deutex/deutex-5.2.2.ebuild
+++ b/games-util/deutex/deutex-5.2.2.ebuild
@@ -12,7 +12,7 @@ SRC_URI="https://github.com/Doom-Utils/${PN}/releases/download/v${PV}/${P}.tar.z
 LICENSE="GPL-2+ LGPL-2+ HPND"
 SLOT="0"
 KEYWORDS="~amd64 ~arm ~x86"
-IUSE="man png"
+IUSE="man +png"
 
 DEPEND="png? ( media-libs/libpng:0= )"
 RDEPEND="${DEPEND}"


### PR DESCRIPTION
This adds the `png` USE flag requirement to the `games-util/deutex` dependency for `games-fps/freedoom-data` and `games-fps/freedm-data`; the `games-util/deutex` is updated to default enable PNG support.

In addition, I noticed the `games-fps/freedoom` and `games-fps/freedm` ebuilds were missing `games-fps/chocolate-doom` as an optional source port, so I've updated them accordingly.