### PR TITLE
games-emulation/dolphin: added USE=mgba

### DIFF
--- a/games-emulation/dolphin/dolphin-9999.ebuild
+++ b/games-emulation/dolphin/dolphin-9999.ebuild
@@ -25,7 +25,7 @@ HOMEPAGE="https://www.dolphin-emu.org/"
 
 LICENSE="GPL-2"
 SLOT="0"
-IUSE="alsa bluetooth discord-presence doc +evdev ffmpeg log lto profile pulseaudio +qt5 systemd upnp vulkan"
+IUSE="alsa bluetooth discord-presence doc +evdev ffmpeg log lto mgba profile pulseaudio +qt5 systemd upnp vulkan"
 
 RDEPEND="
 	dev-libs/hidapi:0=
@@ -153,6 +153,7 @@ src_configure() {
 		-DENCODE_FRAMEDUMPS=$(usex ffmpeg)
 		-DENABLE_LLVM=OFF
 		-DENABLE_LTO=$(usex lto)
+		-DUSE_MGBA=$(usex mgba)
 		-DENABLE_PULSEAUDIO=$(usex pulseaudio)
 		-DENABLE_QT=$(usex qt5)
 		-DENABLE_SDL=OFF # not supported: #666558

--- a/games-emulation/dolphin/metadata.xml
+++ b/games-emulation/dolphin/metadata.xml
@@ -9,6 +9,7 @@
 		<flag name="evdev">Enable evdev input support</flag>
 		<flag name="log">Increase logging output</flag>
 		<flag name="lto">Add support for link-time optimizations.</flag>
+		<flag name="mgba">Enables GBA controllers emulation using libmgba.</flag>
 		<flag name="vulkan">Enable support for Vulkan-based video backend.</flag>
 	</use>
 	<longdescription lang="en">


### PR DESCRIPTION
Here's the new pull request I mentioned [here](https://github.com/gentoo/gentoo/pull/21813#issuecomment-889357466) for making mgba optional. 

The reasons are the same as in the previous pull request:
Only relatively few games support gba input ([only 63](https://wiki.dolphin-emu.org/index.php?title=Category:Game_Boy_Advance_(Input_supported))). From those 63 most don't really require it but have it more as a 'nice bonus' eg. for maps, bonus items or sending game-data from gba to gamecube ([as seen here](https://en.m.wikipedia.org/wiki/GameCube_%E2%80%93_Game_Boy_Advance_link_cable#Games)). That's why I believe most users wouldn't need this feature and if they did they could still enable it.