### PR TITLE
media-libs/libglvnd: Apply -DEGL_NO_X11 fix

### DIFF
--- a/media-libs/libglvnd/files/libglvnd-1.3.3-egl-no-x11.patch
+++ b/media-libs/libglvnd/files/libglvnd-1.3.3-egl-no-x11.patch
@@ -1,0 +1,60 @@
+From 3670d645f4a26a0a9e87e7f3a8608e7cc1d53b5b Mon Sep 17 00:00:00 2001
+From: Kyle Brenneman <kbrenneman@nvidia.com>
+Date: Wed, 12 Aug 2020 14:04:17 -0600
+Subject: [PATCH] Don't use Xlib headers by default.
+
+Conceptually, defining EGLNativeDisplayType to Display* is simply incorrect,
+because it's not always going to be an Xlib display.
+
+In practice, more and more programs and libraries are being built with EGL but
+without Xlib, and end up breaking when the Xlib headers are missing.
+
+Rather than requiring every such program to define EGL_NO_X11, use the (void*)
+typedef by default. The existing USE_X11 header can still preserve the current
+behavior.
+
+The change to EGLNativeDisplayType will be fine for eglGetDisplay, since you
+can always pass a (Display *) as a (void *) parameter.
+
+The EGLNativePixmapType and EGLNativeWindowType types don't change, because
+khronos_uintptr_t and XID are both typedefs to unsigned long.
+
+The only things that might break are calls to eglQueryNativeDisplayNV, or
+programs that do need the Xlib headers and expect egl.h to include them. Both
+of those cases would be trivial to fix.
+---
+ api/EGL/eglplatform.h | 14 +++++++-------
+ 1 file changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/api/EGL/eglplatform.h b/api/EGL/eglplatform.h
+index 1edbafa..99362a2 100644
+--- a/include/EGL/eglplatform.h
++++ b/include/EGL/eglplatform.h
+@@ -103,13 +103,7 @@ typedef intptr_t EGLNativeDisplayType;
+ typedef intptr_t EGLNativePixmapType;
+ typedef intptr_t EGLNativeWindowType;
+ 
+-#elif defined(__unix__) && defined(EGL_NO_X11)
+-
+-typedef void             *EGLNativeDisplayType;
+-typedef khronos_uintptr_t EGLNativePixmapType;
+-typedef khronos_uintptr_t EGLNativeWindowType;
+-
+-#elif defined(__unix__) || defined(USE_X11)
++#elif defined(USE_X11)
+ 
+ /* X11 (tentative)  */
+ #include <X11/Xlib.h>
+@@ -119,6 +113,12 @@ typedef Display *EGLNativeDisplayType;
+ typedef Pixmap   EGLNativePixmapType;
+ typedef Window   EGLNativeWindowType;
+ 
++#elif defined(__unix__)
++
++typedef void             *EGLNativeDisplayType;
++typedef khronos_uintptr_t EGLNativePixmapType;
++typedef khronos_uintptr_t EGLNativeWindowType;
++
+ #elif defined(__APPLE__)
+ 
+ typedef int   EGLNativeDisplayType;

--- a/media-libs/libglvnd/libglvnd-1.3.3-r1.ebuild
+++ b/media-libs/libglvnd/libglvnd-1.3.3-r1.ebuild
@@ -1,0 +1,69 @@
+# Copyright 2018-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+EGIT_REPO_URI="https://gitlab.freedesktop.org/glvnd/libglvnd.git"
+
+if [[ ${PV} = 9999* ]]; then
+	GIT_ECLASS="git-r3"
+fi
+
+PYTHON_COMPAT=( python3_{7..9} )
+VIRTUALX_REQUIRED=manual
+
+inherit ${GIT_ECLASS} meson-multilib python-any-r1 virtualx
+
+DESCRIPTION="The GL Vendor-Neutral Dispatch library"
+HOMEPAGE="https://gitlab.freedesktop.org/glvnd/libglvnd"
+if [[ ${PV} = 9999* ]]; then
+	SRC_URI=""
+else
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~riscv ~sparc ~x86"
+	SRC_URI="https://gitlab.freedesktop.org/glvnd/${PN}/-/archive/v${PV}/${PN}-v${PV}.tar.bz2 -> ${P}.tar.bz2"
+	S=${WORKDIR}/${PN}-v${PV}
+fi
+
+LICENSE="MIT"
+SLOT="0"
+IUSE="test X"
+RESTRICT="!test? ( test )"
+
+BDEPEND="${PYTHON_DEPS}
+	test? ( X? ( ${VIRTUALX_DEPEND} ) )"
+RDEPEND="
+	!media-libs/mesa[-libglvnd(+)]
+	X? (
+		x11-libs/libX11[${MULTILIB_USEDEP}]
+		x11-libs/libXext[${MULTILIB_USEDEP}]
+	)"
+DEPEND="${RDEPEND}
+	X? ( x11-base/xorg-proto )"
+
+PATCHES=(
+	"${FILESDIR}/${P}-egl-no-x11.patch"
+)
+
+src_prepare() {
+	default
+	sed -i -e "/^PLATFORM_SYMBOLS/a '__gentoo_check_ldflags__'," \
+		bin/symbols-check.py || die
+}
+
+multilib_src_configure() {
+	local emesonargs=(
+		$(meson_feature X x11)
+		$(meson_feature X glx)
+	)
+	use elibc_musl && emesonargs+=( -Dtls=disabled )
+
+	meson_src_configure
+}
+
+multilib_src_test() {
+	if use X; then
+		virtx meson_src_test
+	else
+		meson_src_test
+	fi
+}


### PR DESCRIPTION
Upstream MR: https://gitlab.freedesktop.org/glvnd/libglvnd/-/merge_requests/246

Signed-off-by: Haelwenn (lanodan) Monnier <contact@hacktivis.me>

----

btw this fixes building at least `libwpe wpebackend-fdo mpv gtk+:3 gtk:4` without having to add `-DEGL_NO_X11` to their cflags, which I did before via `package.env`