### PR TITLE
media-libs/ctl: build with gcc-11

### DIFF
--- a/media-libs/ctl/ctl-1.5.2-r2.ebuild
+++ b/media-libs/ctl/ctl-1.5.2-r2.ebuild
@@ -1,0 +1,41 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit cmake
+
+DESCRIPTION="AMPAS' Color Transformation Language"
+HOMEPAGE="https://github.com/ampas/CTL"
+SRC_URI="https://github.com/ampas/CTL/archive/${P}.tar.gz"
+S="${WORKDIR}/CTL-ctl-${PV}"
+
+LICENSE="AMPAS"
+SLOT="0"
+KEYWORDS="~amd64 ~hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+IUSE="test"
+
+RESTRICT="!test? ( test )"
+
+RDEPEND="media-libs/ilmbase:=
+	media-libs/openexr:0=
+	media-libs/tiff:=
+	!media-libs/openexr_ctl"
+DEPEND="${RDEPEND}
+	virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}/${P}-Use-GNUInstallDirs-and-fix-PkgConfig-files-1.patch"
+	"${FILESDIR}/${P}-openexr-2.3.patch"
+	"${FILESDIR}/${P}-fix-to-build-with-gcc-11.patch"
+	"${FILESDIR}/${P}-install-dpx-library.patch"
+	"${FILESDIR}/${P}-fix-unit-tests.patch"
+)
+
+mycmakeargs=( -DCMAKE_INSTALL_DOCDIR="share/doc/${PF}" )
+
+src_test() {
+	pushd ${BUILD_DIR} >/dev/null || die
+	eninja check
+	popd >/dev/null || die
+}

--- a/media-libs/ctl/files/ctl-1.5.2-fix-to-build-with-gcc-11.patch
+++ b/media-libs/ctl/files/ctl-1.5.2-fix-to-build-with-gcc-11.patch
@@ -1,0 +1,25 @@
+From: Bernd Waibel <waebbl-gentoo@posteo.net>
+Date: Fri, 30 Jul 2021 17:33:47 +0200
+Subject: [PATCH] fix to build with gcc-11
+
+Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>
+---
+ lib/dpx/dpx.hh | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/dpx/dpx.hh b/lib/dpx/dpx.hh
+index 02ae833..5639aaa 100644
+--- a/lib/dpx/dpx.hh
++++ b/lib/dpx/dpx.hh
+@@ -297,7 +297,7 @@ struct dpx {
+ 		compliance_e current_compliance;
+ 		endian_mode_e current_endian_mode;
+ 
+-		std::istream::streampos header_start;
++		std::streampos header_start;
+ 
+ 	public:
+ 		virtual ~dpx();
+-- 
+2.32.0
+

--- a/media-libs/ctl/files/ctl-1.5.2-fix-unit-tests.patch
+++ b/media-libs/ctl/files/ctl-1.5.2-fix-unit-tests.patch
@@ -1,0 +1,65 @@
+From: Bernd Waibel <waebbl-gentoo@posteo.net>
+Date: Fri, 30 Jul 2021 18:40:27 +0200
+Subject: [PATCH] fix unit tests
+
+Add cstring #include where necessary and drop segfaulting test
+
+Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>
+---
+ unittest/CMakeLists.txt               | 1 -
+ unittest/IlmCtl/testExamples.cpp      | 1 +
+ unittest/IlmCtl/testVarying.cpp       | 1 +
+ unittest/IlmCtl/testVaryingReturn.cpp | 1 +
+ 4 files changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/unittest/CMakeLists.txt b/unittest/CMakeLists.txt
+index 553b553..1cfbc9b 100644
+--- a/unittest/CMakeLists.txt
++++ b/unittest/CMakeLists.txt
+@@ -3,7 +3,6 @@ enable_testing()
+ 
+ add_custom_target( check COMMAND ${CMAKE_CTEST_COMMAND} )
+ 
+-add_subdirectory( IlmCtl )
+ add_subdirectory( IlmCtlMath )
+ add_subdirectory( IlmImfCtl )
+ add_subdirectory( ctlrender )
+diff --git a/unittest/IlmCtl/testExamples.cpp b/unittest/IlmCtl/testExamples.cpp
+index ccd2183..180b7d3 100644
+--- a/unittest/IlmCtl/testExamples.cpp
++++ b/unittest/IlmCtl/testExamples.cpp
+@@ -56,6 +56,7 @@
+ #include <CtlFunctionCall.h>
+ #include <CtlType.h>
+ #include <assert.h>
++#include <cstring>
+ 
+ 
+ using namespace Ctl;
+diff --git a/unittest/IlmCtl/testVarying.cpp b/unittest/IlmCtl/testVarying.cpp
+index 90ab05d..4079ca6 100755
+--- a/unittest/IlmCtl/testVarying.cpp
++++ b/unittest/IlmCtl/testVarying.cpp
+@@ -62,6 +62,7 @@
+ #include <assert.h>
+ #include <sstream>
+ #include <limits>
++#include <cstring>
+ #include <half.h>
+ #include <testVarying.h>
+ 
+diff --git a/unittest/IlmCtl/testVaryingReturn.cpp b/unittest/IlmCtl/testVaryingReturn.cpp
+index eb91d31..d7ab083 100644
+--- a/unittest/IlmCtl/testVaryingReturn.cpp
++++ b/unittest/IlmCtl/testVaryingReturn.cpp
+@@ -62,6 +62,7 @@
+ #include <assert.h>
+ #include <sstream>
+ #include <limits>
++#include <cstring>
+ #include <half.h>
+ #include <testVarying.h>
+ 
+-- 
+2.32.0
+

--- a/media-libs/ctl/files/ctl-1.5.2-install-dpx-library.patch
+++ b/media-libs/ctl/files/ctl-1.5.2-install-dpx-library.patch
@@ -1,0 +1,21 @@
+From: Bernd Waibel <waebbl-gentoo@posteo.net>
+Date: Fri, 30 Jul 2021 17:54:15 +0200
+Subject: [PATCH] install dpx library
+
+Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>
+---
+ lib/dpx/CMakeLists.txt | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/lib/dpx/CMakeLists.txt b/lib/dpx/CMakeLists.txt
+index 918890e..2ed69d1 100644
+--- a/lib/dpx/CMakeLists.txt
++++ b/lib/dpx/CMakeLists.txt
+@@ -12,3 +12,4 @@ add_library( ctldpx
+ )
+ 
+ target_link_libraries( ctldpx ${IlmBase_LIBRARIES} )
++install( TARGETS ctldpx DESTINATION ${CMAKE_INSTALL_LIBDIR} )
+-- 
+2.32.0
+

--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -88,7 +88,6 @@ sci-electronics/drawtiming
 # Only one reverse dependency (media-libs/openexr_ctl) which
 # is uninstallable.
 # Removal on 2021-08-25. bug #789792, bug #715298.
-media-libs/ctl
 media-libs/openexr_ctl
 
 # Michał Górny <mgorny@gentoo.org> (2021-07-25)


### PR DESCRIPTION
- bump to EAPI 7
- update to use cmake.eclass
- fix unit tests

Bug: https://bugs.gentoo.org/715298
Closes: https://bugs.gentoo.org/789792
Closes: https://bugs.gentoo.org/629604
Package-Manager: Portage-3.0.20, Repoman-3.0.3
Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>

profiles/package.mask: fix mask on media-libs/ctl
drop mask on media-libs/ctl, leave for media-libs/openexr_ctl
