### PR TITLE
media-plugins/gst-plugins-jack: Fix jack2 dependency

### DIFF
--- a/media-plugins/gst-plugins-jack/gst-plugins-jack-1.18.4-r1.ebuild
+++ b/media-plugins/gst-plugins-jack/gst-plugins-jack-1.18.4-r1.ebuild
@@ -7,8 +7,12 @@ GST_ORG_MODULE=gst-plugins-good
 inherit gstreamer-meson
 
 DESCRIPION="JACK audio server source/sink plugin for GStreamer"
-KEYWORDS="~amd64 ~arm ~arm64 ~ia64 ~ppc ~ppc64 ~riscv ~sparc ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~riscv ~x86"
 IUSE=""
 
-RDEPEND="virtual/jack[${MULTILIB_USEDEP}]"
+# >=jack-1.9.7 is provided by pipewire[jack-sdk] as well
+RDEPEND="|| (
+	media-sound/jack2[${MULTILIB_USEDEP}]
+	media-video/pipewire[jack-sdk(-),${MULTILIB_USEDEP}]
+)"
 DEPEND="${RDEPEND}"

--- a/media-plugins/gst-plugins-meta/gst-plugins-meta-1.18.4.ebuild
+++ b/media-plugins/gst-plugins-meta/gst-plugins-meta-1.18.4.ebuild
@@ -10,7 +10,7 @@ HOMEPAGE="https://gstreamer.freedesktop.org/"
 
 LICENSE="metapackage"
 SLOT="1.0"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~riscv ~sparc ~x86"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~mips ~ppc ~ppc64 ~riscv ~x86"
 IUSE="aac a52 alsa cdda dts dv dvb dvd ffmpeg flac http jack lame libass libvisual mms mp3 modplug mpeg ogg opus oss pulseaudio taglib theora v4l vaapi vcd vorbis vpx wavpack X x264"
 REQUIRED_USE="opus? ( ogg ) theora? ( ogg ) vorbis? ( ogg )"
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/804957
Signed-off-by: Haelwenn (lanodan) Monnier <contact@hacktivis.me>