### PR TITLE
dev-python/kafka-python: add test dependency on dev-python/mock

### DIFF
--- a/dev-python/kafka-python/kafka-python-2.0.2.ebuild
+++ b/dev-python/kafka-python/kafka-python-2.0.2.ebuild
@@ -19,6 +19,7 @@ RDEPEND="dev-python/xxhash[${PYTHON_USEDEP}]"
 BDEPEND="
 	test? (
 		dev-python/lz4[${PYTHON_USEDEP}]
+		dev-python/mock[${PYTHON_USEDEP}]
 		dev-python/pytest-mock[${PYTHON_USEDEP}]
 		dev-python/snappy[${PYTHON_USEDEP}]
 		dev-python/zstandard[${PYTHON_USEDEP}]


### PR DESCRIPTION
@mgorny I'm really sorry for missing it - here I added it. (It was indeed needed)
Also, bacause this is a test dep only, we don't need a revbump (because of failing without, passing now, unneeded for regular runtime).

Closes: https://bugs.gentoo.org/806136
Signed-off-by: Arthur Zamarin <arthurzam@gmail.com>