### PR TITLE
dev-util/hip: cleanup unnecessary patch and sed commands

### DIFF
--- a/dev-util/hip/hip-4.1.0.ebuild
+++ b/dev-util/hip/hip-4.1.0.ebuild
@@ -26,7 +26,6 @@ PATCHES=(
 	"${FILESDIR}/${PN}-4.1.0-DisableTest.patch"
 	"${FILESDIR}/${PN}-3.9.0-add-include-directories.patch"
 	"${FILESDIR}/${PN}-3.5.1-config-cmake-in.patch"
-	"${FILESDIR}/${PN}-3.5.1-hip_vector_types.patch"
 	"${FILESDIR}/${PN}-3.9.0-lpl_ca-add-include.patch"
 )
 
@@ -40,18 +39,14 @@ src_prepare() {
 	sed -e "/set (HIP_LIB_VERSION_STRING/cset (HIP_LIB_VERSION_STRING ${PVR})" -i CMakeLists.txt || die
 
 	# disable PCH, because it results in a build error in ROCm 4.0.0
-	sed -e "s:option(__HIP_ENABLE_PCH:#option(__HIP_ENABLE_PCH:" -i "${S}/CMakeLists.txt" || die
+	sed -e "s:option(__HIP_ENABLE_PCH:#option(__HIP_ENABLE_PCH:" -i CMakeLists.txt || die
 
 	# "hcc" is deprecated and not installed, new platform is "rocclr";
 	# Setting HSA_PATH to "/usr" results in setting "-isystem /usr/include"
 	# which makes "stdlib.h" not found when using "#include_next" in header files;
-	sed -e "/HIP_PLATFORM.*HIP_COMPILER.*clang/s:hcc:rocclr:" \
-		-e "/FLAGS .= \" -isystem \$HSA_PATH/d" \
+	sed -e "/FLAGS .= \" -isystem \$HSA_PATH/d" \
 		-e "s:\$ENV{'DEVICE_LIB_PATH'}:'/usr/lib/amdgcn/bitcode':" \
 		-i bin/hipcc || die
-
-	# replace hcc remnants with modern rocclr.
-	sed -e "/HIP_PLATFORM.*STREQUAL/s:hcc:rocclr:" -i cmake/FindHIP/run_hipcc.cmake || die
 
 	# correctly find HIP_CLANG_INCLUDE_PATH using cmake
 	sed -e "/set(HIP_CLANG_ROOT/s:\"\${ROCM_PATH}/llvm\":/usr/lib/llvm/roc:" -i hip-config.cmake.in || die


### PR DESCRIPTION
hip now use HIP_PLATFORM=amd and HIP_RUNTIME=amd, therefore some sed
commands are not necessary anymore.

And every patch is rechecked, too. Rremoving hip-3.5.1-hip_vector_types.patch
seems to have no impact on compile and running hipcc, so it is stripped, too.

Related Topic: https://github.com/justxi/rocm/issues/192
Package-Manager: Portage-3.0.20, Repoman-3.0.3
Signed-off-by: Yiyang Wu <xgreenlandforwyy@gmail.com>