### PR TITLE
dev-python/*: bump to python 3.10

### DIFF
--- a/dev-python/joblib/joblib-1.0.1.ebuild
+++ b/dev-python/joblib/joblib-1.0.1.ebuild
@@ -2,7 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-PYTHON_COMPAT=( python3_{7..9} )
+
+PYTHON_COMPAT=( python3_{8..10} )
 
 inherit distutils-r1
 

--- a/dev-python/loky/files/loky-2.9.0-fix-process_executor.patch
+++ b/dev-python/loky/files/loky-2.9.0-fix-process_executor.patch
@@ -1,0 +1,132 @@
+From 71d7f5ea07453ce23c97651e67dd880ee72f26d3 Mon Sep 17 00:00:00 2001
+From: Thomas Moreau <thomas.moreau.2010@gmail.com>
+Date: Fri, 8 Jan 2021 10:43:18 +0100
+Subject: [PATCH] FIX skip test on win32+py38+ failing due to #279 (#282)
+
+---
+ loky/process_executor.py        | 27 ++++++++++++++++++++-------
+ tests/test_reusable_executor.py | 13 ++++++++++++-
+ 2 files changed, 32 insertions(+), 8 deletions(-)
+
+diff --git a/loky/process_executor.py b/loky/process_executor.py
+index 41e4a2b5..f2fc167f 100644
+--- a/loky/process_executor.py
++++ b/loky/process_executor.py
+@@ -115,7 +115,9 @@ def _get_memory_usage(pid, force_gc=False):
+         if force_gc:
+             gc.collect()
+ 
+-        return Process(pid).memory_info().rss
++        mem_size = Process(pid).memory_info().rss
++        mp.util.debug('psutil return memory size: {}'.format(mem_size))
++        return mem_size
+ 
+ except ImportError:
+     _USE_PSUTIL = False
+@@ -421,11 +423,13 @@ def _process_worker(call_queue, result_queue, initializer, initargs,
+                 # If we cannot format correctly the exception, at least print
+                 # the traceback.
+                 print(previous_tb)
++            mp.util.debug('Exiting with code 1')
+             sys.exit(1)
+         if call_item is None:
+             # Notify queue management thread about clean worker shutdown
+             result_queue.put(pid)
+             with worker_exit_lock:
++                mp.util.debug('Exited cleanly')
+                 return
+         try:
+             r = call_item()
+@@ -467,6 +471,7 @@ def _process_worker(call_queue, result_queue, initializer, initargs,
+                 mp.util.info("Memory leak detected: shutting down worker")
+                 result_queue.put(pid)
+                 with worker_exit_lock:
++                    mp.util.debug('Exit due to memory leak')
+                     return
+         else:
+             # if psutil is not installed, trigger gc.collect events
+@@ -645,7 +650,13 @@ def wait_result_broken_or_wakeup(self):
+                 # unstable, therefore they are not appended in the exception
+                 # message.
+                 exit_codes = "\nThe exit codes of the workers are {}".format(
+-                    get_exitcodes_terminated_worker(self.processes))
++                    get_exitcodes_terminated_worker(self.processes)
++                )
++            mp.util.debug('A worker unexpectedly terminated. Workers that '
++                          'might have caused the breakage: '
++                          + str({p.name: p.exitcode
++                                 for p in list(self.processes.values())
++                                 if p is not None and p.sentinel in ready}))
+             bpe = TerminatedWorkerError(
+                 "A worker process managed by the executor was unexpectedly "
+                 "terminated. This could be caused by a segmentation fault "
+@@ -733,7 +744,7 @@ def terminate_broken(self, bpe):
+ 
+         # Terminate remaining workers forcibly: the queues or their
+         # locks may be in a dirty state and block forever.
+-        self.kill_workers()
++        self.kill_workers(reason="broken executor")
+ 
+         # clean up resources
+         self.join_executor_internals()
+@@ -753,15 +764,16 @@ def flag_executor_shutting_down(self):
+                 del work_item
+ 
+             # Kill the remaining worker forcibly to no waste time joining them
+-            self.kill_workers()
++            self.kill_workers(reason="executor shutting down")
+ 
+-    def kill_workers(self):
++    def kill_workers(self, reason=''):
+         # Terminate the remaining workers using SIGKILL. This function also
+         # terminates descendant workers of the children in case there is some
+         # nested parallelism.
+         while self.processes:
+             _, p = self.processes.popitem()
+-            mp.util.debug('terminate process {}'.format(p.name))
++            mp.util.debug("terminate process {}, reason: {}"
++                          .format(p.name, reason))
+             try:
+                 recursive_terminate(p)
+             except ProcessLookupError:  # pragma: no cover
+@@ -1152,7 +1164,8 @@ def map(self, fn, *iterables, **kwargs):
+ 
+         results = super(ProcessPoolExecutor, self).map(
+             partial(_process_chunk, fn), _get_chunks(chunksize, *iterables),
+-            timeout=timeout)
++            timeout=timeout
++        )
+         return _chain_from_iterable_of_lists(results)
+ 
+     def shutdown(self, wait=True, kill_workers=False):
+diff --git a/tests/test_reusable_executor.py b/tests/test_reusable_executor.py
+index 6d4c26f7..1ff5b8b8 100644
+--- a/tests/test_reusable_executor.py
++++ b/tests/test_reusable_executor.py
+@@ -224,7 +224,8 @@ class TestExecutorDeadLock(ReusableExecutorMixin):
+         # on workers
+         (return_instance, (CrashAtPickle,), TerminatedWorkerError, r"SIGSEGV"),
+         (return_instance, (ExitAtPickle,), SystemExit, None),
+-        (return_instance, (CExitAtPickle,), TerminatedWorkerError, r"EXIT\(0\)"),
++        (return_instance, (CExitAtPickle,), TerminatedWorkerError,
++         r"EXIT\(0\)"),
+         (return_instance, (ErrorAtPickle,), PicklingError, None),
+         # Check problem occuring while unpickling a task in
+         # the result_handler thread
+@@ -344,6 +345,16 @@ def test_deadlock_kill(self):
+     @pytest.mark.parametrize("n_proc", [1, 2, 5, 13])
+     def test_crash_races(self, n_proc):
+         """Test the race conditions in reusable_executor crash handling"""
++
++        if (sys.platform == 'win32' and sys.version_info >= (3, 8)
++                and n_proc > 5):
++            pytest.skip(
++                "On win32, the paging size can be too small to import numpy "
++                "multiple times in the sub-processes (imported when loading "
++                "this file). Skipping while no better solution is found. See "
++                "https://github.com/joblib/loky/issues/279 for more details."
++            )
++
+         # Test for external crash signal comming from neighbor
+         # with various race setup
+         executor = get_reusable_executor(max_workers=n_proc, timeout=None)

--- a/dev-python/loky/files/loky-2.9.0-fix-py3.10-tests.patch
+++ b/dev-python/loky/files/loky-2.9.0-fix-py3.10-tests.patch
@@ -1,0 +1,41 @@
+From 0d31dc24ca9688c11d1fe53fa1283728ecc50706 Mon Sep 17 00:00:00 2001
+From: Arthur Zamarin <arthurzam@gmail.com>
+Date: Mon, 2 Aug 2021 18:35:31 +0300
+Subject: [PATCH] Fix no attribute import_module for python 3.10
+
+In python 3.10, the `import_module` has moved from the
+`test.support` module to `test.support.import_helper`.
+
+As fix, try to import the from the new place and if unknown try from
+the old place.
+---
+ tests/_test_process_executor.py | 11 +++++++----
+ 1 file changed, 7 insertions(+), 4 deletions(-)
+
+diff --git a/tests/_test_process_executor.py b/tests/_test_process_executor.py
+index 65d9a2c9..3bd0b12d 100644
+--- a/tests/_test_process_executor.py
++++ b/tests/_test_process_executor.py
+@@ -1,15 +1,18 @@
+ from __future__ import print_function
+ try:
+-    import test.support
++    try:
++        from test.support.import_helper import import_module
++    except ImportError:
++        from test.support import import_module
+ 
+     # Skip tests if _multiprocessing wasn't built.
+-    test.support.import_module('_multiprocessing')
++    import_module('_multiprocessing')
+     # Skip tests if sem_open implementation is broken.
+-    test.support.import_module('multiprocessing.synchronize')
++    import_module('multiprocessing.synchronize')
+     # import threading after _multiprocessing to raise a more revelant error
+     # message: "No module named _multiprocessing" if multiprocessing is not
+     # compiled without thread support.
+-    test.support.import_module('threading')
++    import_module('threading')
+ except ImportError:
+     pass
+ 

--- a/dev-python/loky/loky-2.9.0.ebuild
+++ b/dev-python/loky/loky-2.9.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{7..9} )
+PYTHON_COMPAT=( python3_{8..10} )
 inherit distutils-r1
 
 DESCRIPTION="Robust and reusable Executor for joblib"
@@ -26,7 +26,9 @@ BDEPEND="
 distutils_enable_tests pytest
 
 PATCHES=(
-	"${FILESDIR}"/${P}-libc.patch
+	"${FILESDIR}/${P}-libc.patch"
+	"${FILESDIR}/${P}-fix-py3.10-tests.patch"
+	"${FILESDIR}/${P}-fix-process_executor.patch"
 )
 
 python_test() {

--- a/dev-python/minimock/minimock-1.3.0.ebuild
+++ b/dev-python/minimock/minimock-1.3.0.ebuild
@@ -3,12 +3,11 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{7,8,9} )
+PYTHON_COMPAT=( python3_{8..10} )
 
 inherit distutils-r1
 
-MY_PN="MiniMock"
-MY_P="${MY_PN}-${PV}"
+MY_P="MiniMock-${PV}"
 
 DESCRIPTION="The simplest possible mock library"
 HOMEPAGE="https://pypi.org/project/MiniMock/"
@@ -21,3 +20,8 @@ KEYWORDS="amd64 arm ~arm64 ppc x86"
 DOCS=( CHANGELOG.txt README.rst )
 
 distutils_enable_tests nose
+
+src_prepare() {
+	sed -i -e '/cov/d' setup.cfg || die
+	default
+}


### PR DESCRIPTION
@mgorny Another batch of python bumps

1. `app-crypt/gpgme` - trivial bump and tests pass
2. `dev-python/dulwich` - trivial bump and tests pass. One note is that the package is in the middle of [stabilization](https://bugs.gentoo.org/799977), so maybe better to wait.
3. `dev-python/minimock` - trivial bump and tests pass
4. `dev-python/loky` - this one needed a fix, so I created one and put as a PR upstream (linked in the commit message).
5. `dev-python/joblib` - trivial bump and tests pass
6. `dev-python/lockfile` - trivial bump and tests pass
7. `dev-python/libcloud` - added dependency on `dev-python/pyopenssl` as it is used in the installed part (not tests). The bump was trivial and tests pass.
8. `dev-python/cheetah3` - imported small patch from upstream merged one and now all pass

I think my next goal would be bumping `app-admin/salt`, but I see too many packages and part of them will need custom patch, so only the future me will know.