### PR TITLE
sys-auth/seatd: Add builtin and server IUSE flags

### DIFF
--- a/sys-auth/seatd/metadata.xml
+++ b/sys-auth/seatd/metadata.xml
@@ -9,4 +9,8 @@
 	<email>proxy-maint@gentoo.org</email>
 	<name>Proxy Maintainers</name>
 </maintainer>
+<use>
+	<flag name="builtin">Enable embedded server in libseat</flag>
+	<flag name="server">Enable standalone seatd server</flag>
+</use>
 </pkgmetadata>

--- a/sys-auth/seatd/seatd-0.5.0-r1.ebuild
+++ b/sys-auth/seatd/seatd-0.5.0-r1.ebuild
@@ -11,7 +11,7 @@ if [[ ${PV} == 9999 ]]; then
 	inherit git-r3
 	EGIT_REPO_URI="https://git.sr.ht/~kennylevinsen/seatd"
 else
-	KEYWORDS="~amd64 ~arm64 ~ppc64 ~x86"
+	KEYWORDS="amd64 arm64 ~ppc64 ~riscv x86"
 	SRC_URI="https://git.sr.ht/~kennylevinsen/seatd/archive/${PV}.tar.gz -> ${P}.tar.gz"
 fi
 LICENSE="MIT"
@@ -30,7 +30,7 @@ src_configure() {
 	local emesonargs=(
 		-Dman-pages=enabled
 		-Dwerror=false
-		$(meson_feature builtin libseat-builtin)
+		$(meson_feature builtin)
 		$(meson_feature server)
 	)
 


### PR DESCRIPTION
I wanted to use the `builtin` backend in libseat but I saw that it was disabled at compile time. This PR adds an USE flag to enable it.

Also the standalone server can be disabled if it's not needed so while we're at it, I added a flag for that too. Let me know if that's not needed.