### PR TITLE
dev-util/bats: respect "makeopts_jobs" in test suite

### DIFF
--- a/dev-util/bats/bats-1.4.1.ebuild
+++ b/dev-util/bats/bats-1.4.1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit optfeature
+inherit multiprocessing optfeature
 
 MY_PN="bats-core"
 DESCRIPTION="Bats-core: Bash Automated Testing System"
@@ -20,7 +20,11 @@ RDEPEND="${DEPEND}"
 S="${WORKDIR}/${MY_PN}-${PV}"
 
 src_test() {
-	bin/bats --tap test || die "Tests failed"
+	local my_jobs=$(makeopts_jobs)
+	if ! command -v parallel; then
+		my_jobs=1
+	fi
+	bin/bats --tap --jobs "$my_jobs" test || die "Tests failed"
 }
 
 src_install() {


### PR DESCRIPTION
The fact that the testsuite might run a random number of jobs if
"sys-process/parallel" is installed was raised in a bug. While this
commit does not solve the bug in question, it makes the test respect
MAKEOPTS"-jX".

Related-to: https://bugs.gentoo.org/734358

Signed-off-by: Henning Schild <henning@hennsch.de>