### PR TITLE
media-libs/mlt: fix build for USE=python

### DIFF
--- a/media-libs/mlt/mlt-7.0.1.ebuild
+++ b/media-libs/mlt/mlt-7.0.1.ebuild
@@ -144,7 +144,7 @@ src_configure() {
 	# Not done: java perl php ruby tcl
 	# Handled separately: lua
 	for i in python; do
-		use ${i} && mycmakeargs+=( -DSWIG_${i}=ON )
+		use ${i} && mycmakeargs+=( -DSWIG_${i^^}=ON )
 	done
 
 	cmake_src_configure
@@ -196,12 +196,7 @@ src_install() {
 	fi
 
 	if use python; then
-		cd "${S}"/src/swig/python || die
-
-		python_domodule mlt.py _mlt.so
-		chmod +x "${D}$(python_get_sitedir)/_mlt.so" || die
-		dodoc play.py
-
+		dodoc "${S}"/src/swig/python/play.py
 		python_optimize
 	fi
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/806484

Package-Manager: Portage-3.0.20, Repoman-3.0.3
Signed-off-by: Felix Neumärker <xdch47@posteo.de>