### PR TITLE
profiles: remove pcl mask of ~media-gfx/freecad-0.19

### DIFF
--- a/profiles/arch/base/package.use.mask
+++ b/profiles/arch/base/package.use.mask
@@ -11,11 +11,6 @@ dev-util/diffoscope haskell
 x11-base/xwayland video_cards_nvidia
 x11-wm/mutter video_cards_nvidia
 
-# Bernd Waibel <waebbl-gentoo@posteo.net> (2021-06-16)
-# sci-libs/pcl-1.11.1 is missing support for >=sci-libs/vtk-9
-# bug #796368
-~media-gfx/freecad-0.19.2 pcl
-
 # Bernd Waibel <waebbl-gentoo@posteo.net> (2021-06-11)
 # Has unpackaged depdencies, bug #795459
 >=media-libs/opencolorio-2.0.0 doc


### PR DESCRIPTION
sci-libs/pcl-1.12.0 now builds against vtk-9

Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>