### PR TITLE
dev-lua/luasec: fix compilation with openssl-3.0

### DIFF
--- a/dev-lua/luasec/files/luasec-1.0.1_openssl3.patch
+++ b/dev-lua/luasec/files/luasec-1.0.1_openssl3.patch
@@ -1,0 +1,96 @@
+From 79bbc0bc3ed50303d0887f44137a1104ede3ea8f Mon Sep 17 00:00:00 2001
+From: Bruno Silvestre <brunoos@inf.ufg.br>
+Date: Mon, 2 Aug 2021 17:02:44 -0300
+Subject: [PATCH] Ignore SSL_OP_BIT(n) macro and update option.c #178
+
+---
+ src/options.c   | 20 +++++++++++++++++++-
+ src/options.lua |  9 ++++++---
+ 2 files changed, 25 insertions(+), 4 deletions(-)
+
+diff --git a/src/options.c b/src/options.c
+index 24fd2c9..7c6f21e 100644
+--- a/src/options.c
++++ b/src/options.c
+@@ -13,13 +13,16 @@
+ 
+ 
+ /* 
+-  OpenSSL version: OpenSSL 1.1.1
++  OpenSSL version: OpenSSL 3.0.0-beta2
+ */
+ 
+ static lsec_ssl_option_t ssl_options[] = {
+ #if defined(SSL_OP_ALL)
+   {"all", SSL_OP_ALL},
+ #endif
++#if defined(SSL_OP_ALLOW_CLIENT_RENEGOTIATION)
++  {"allow_client_renegotiation", SSL_OP_ALLOW_CLIENT_RENEGOTIATION},
++#endif
+ #if defined(SSL_OP_ALLOW_NO_DHE_KEX)
+   {"allow_no_dhe_kex", SSL_OP_ALLOW_NO_DHE_KEX},
+ #endif
+@@ -32,21 +35,33 @@ static lsec_ssl_option_t ssl_options[] = {
+ #if defined(SSL_OP_CISCO_ANYCONNECT)
+   {"cisco_anyconnect", SSL_OP_CISCO_ANYCONNECT},
+ #endif
++#if defined(SSL_OP_CLEANSE_PLAINTEXT)
++  {"cleanse_plaintext", SSL_OP_CLEANSE_PLAINTEXT},
++#endif
+ #if defined(SSL_OP_COOKIE_EXCHANGE)
+   {"cookie_exchange", SSL_OP_COOKIE_EXCHANGE},
+ #endif
+ #if defined(SSL_OP_CRYPTOPRO_TLSEXT_BUG)
+   {"cryptopro_tlsext_bug", SSL_OP_CRYPTOPRO_TLSEXT_BUG},
+ #endif
++#if defined(SSL_OP_DISABLE_TLSEXT_CA_NAMES)
++  {"disable_tlsext_ca_names", SSL_OP_DISABLE_TLSEXT_CA_NAMES},
++#endif
+ #if defined(SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS)
+   {"dont_insert_empty_fragments", SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS},
+ #endif
++#if defined(SSL_OP_ENABLE_KTLS)
++  {"enable_ktls", SSL_OP_ENABLE_KTLS},
++#endif
+ #if defined(SSL_OP_ENABLE_MIDDLEBOX_COMPAT)
+   {"enable_middlebox_compat", SSL_OP_ENABLE_MIDDLEBOX_COMPAT},
+ #endif
+ #if defined(SSL_OP_EPHEMERAL_RSA)
+   {"ephemeral_rsa", SSL_OP_EPHEMERAL_RSA},
+ #endif
++#if defined(SSL_OP_IGNORE_UNEXPECTED_EOF)
++  {"ignore_unexpected_eof", SSL_OP_IGNORE_UNEXPECTED_EOF},
++#endif
+ #if defined(SSL_OP_LEGACY_SERVER_CONNECT)
+   {"legacy_server_connect", SSL_OP_LEGACY_SERVER_CONNECT},
+ #endif
+@@ -89,6 +104,9 @@ static lsec_ssl_option_t ssl_options[] = {
+ #if defined(SSL_OP_NO_ENCRYPT_THEN_MAC)
+   {"no_encrypt_then_mac", SSL_OP_NO_ENCRYPT_THEN_MAC},
+ #endif
++#if defined(SSL_OP_NO_EXTENDED_MASTER_SECRET)
++  {"no_extended_master_secret", SSL_OP_NO_EXTENDED_MASTER_SECRET},
++#endif
+ #if defined(SSL_OP_NO_QUERY_MTU)
+   {"no_query_mtu", SSL_OP_NO_QUERY_MTU},
+ #endif
+diff --git a/src/options.lua b/src/options.lua
+index a757c8b..678e8d5 100644
+--- a/src/options.lua
++++ b/src/options.lua
+@@ -60,9 +60,12 @@ local function loadoptions(file)
+   local options = {}
+   local f = assert(io.open(file, "r"))
+   for line in f:lines() do
+-    local op = string.match(line, "define%s+(SSL_OP_%S+)")
+-    if op then
+-      table.insert(options, op)
++    local op = string.match(line, "define%s+(SSL_OP_BIT%()")
++    if not op then
++      op = string.match(line, "define%s+(SSL_OP_%S+)")
++      if op then
++        table.insert(options, op)
++      end
+     end
+   end
+   table.sort(options, function(a,b) return a<b end)

--- a/dev-lua/luasec/luasec-1.0.1-r1.ebuild
+++ b/dev-lua/luasec/luasec-1.0.1-r1.ebuild
@@ -1,0 +1,90 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+LUA_COMPAT=( lua5-{1..4} luajit )
+LUA_REQ_USE="deprecated(+)"
+
+inherit lua toolchain-funcs
+
+DESCRIPTION="Lua binding for OpenSSL library to provide TLS/SSL communication"
+HOMEPAGE="https://github.com/brunoos/luasec"
+SRC_URI="https://github.com/brunoos/luasec/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+REQUIRED_USE="${LUA_REQUIRED_USE}"
+
+RDEPEND="
+	dev-lua/luasocket[${LUA_USEDEP}]
+	dev-libs/openssl:0=
+	${LUA_DEPS}
+"
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}/${P}_openssl3.patch"
+)
+
+lua_src_prepare() {
+	pushd "${BUILD_DIR}" || die
+
+	${ELUA} src/options.lua -g /usr/include/openssl/ssl.h > src/options.c || die
+
+	popd
+}
+
+src_prepare() {
+	default
+
+	# Respect users CFLAGS
+	sed -e 's/-O2//g' -i src/Makefile || die
+
+	lua_copy_sources
+
+	lua_foreach_impl lua_src_prepare
+}
+
+lua_src_compile() {
+	pushd "${BUILD_DIR}" || die
+
+	local myemakeargs=(
+		"CC=$(tc-getCC)"
+		"LD=$(tc-getCC)"
+		"INC_PATH=-I$(lua_get_include_dir)"
+		"LIB_PATH=$(lua_get_CFLAGS)"
+		"MYCFLAGS=${CFLAGS}"
+		"MYLDFLAGS=${LDFLAGS}"
+	)
+
+	emake "${myemakeargs[@]}" linux
+
+	popd
+}
+
+src_compile() {
+	lua_foreach_impl lua_src_compile
+}
+
+lua_src_install() {
+	pushd "${BUILD_DIR}" || die
+
+	local emakeargs=(
+		"DESTDIR=${ED}"
+		"LUAPATH=$(lua_get_lmod_dir)"
+		"LUACPATH=$(lua_get_cmod_dir)"
+	)
+
+	emake "${emakeargs[@]}" install
+
+	popd
+}
+
+src_install() {
+	lua_foreach_impl lua_src_install
+
+	einstalldocs
+}


### PR DESCRIPTION
Applied upstream patch 79bbc0.
Closes: https://bugs.gentoo.org/805524
Package-Manager: Portage-3.0.20, Repoman-3.0.2
Signed-off-by: Azamat H. Hackimov <azamat.hackimov@gmail.com>