### PR TITLE
riscv: keyword PyQt and some additional media-libs, unmask USE=qt5

### DIFF
--- a/app-accessibility/espeak/espeak-1.48.04-r1.ebuild
+++ b/app-accessibility/espeak/espeak-1.48.04-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -11,7 +11,7 @@ DESCRIPTION="Speech synthesizer for English and other languages"
 HOMEPAGE="http://espeak.sourceforge.net/"
 LICENSE="GPL-3"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ppc ppc64 sparc x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ppc ppc64 ~riscv sparc x86 ~amd64-linux ~x86-linux"
 IUSE="portaudio pulseaudio"
 
 COMMON_DEPEND="portaudio? ( >=media-libs/portaudio-19_pre20071207 )

--- a/app-accessibility/flite/flite-2.2.ebuild
+++ b/app-accessibility/flite/flite-2.2.ebuild
@@ -43,7 +43,7 @@ SRC_URI="https://github.com/festvox/flite/archive/v${PV}.tar.gz -> ${P}.tar.gz
 
 LICENSE="BSD freetts public-domain regexp-UofT BSD-2"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 ~ia64 ppc ppc64 sparc x86"
+KEYWORDS="~alpha amd64 arm arm64 ~ia64 ppc ppc64 ~riscv sparc x86"
 IUSE="alsa oss pulseaudio voices"
 
 DEPEND="

--- a/app-accessibility/speech-dispatcher/speech-dispatcher-0.9.1.ebuild
+++ b/app-accessibility/speech-dispatcher/speech-dispatcher-0.9.1.ebuild
@@ -12,7 +12,7 @@ SRC_URI="https://github.com/brailcom/speechd/releases/download/${PV}/${P}.tar.gz
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ppc ppc64 sparc x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ppc ppc64 ~riscv sparc x86 ~amd64-linux ~x86-linux"
 IUSE="alsa ao +espeak flite nas pulseaudio python"
 
 REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"

--- a/app-text/rman/rman-3.2-r1.ebuild
+++ b/app-text/rman/rman-3.2-r1.ebuild
@@ -11,7 +11,7 @@ SRC_URI="mirror://sourceforge/polyglotman/${P}.tar.gz"
 
 LICENSE="Artistic"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~mips ppc ppc64 ~s390 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
+KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
 
 RESTRICT="test"
 

--- a/dev-libs/dotconf/dotconf-1.3-r1.ebuild
+++ b/dev-libs/dotconf/dotconf-1.3-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -11,7 +11,7 @@ SRC_URI="mirror://gentoo/${P}.tar.gz"
 
 LICENSE="LGPL-2.1"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ppc ppc64 sparc x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ppc ppc64 ~riscv sparc x86 ~amd64-linux ~x86-linux"
 IUSE=""
 
 DEPEND=">=sys-devel/autoconf-2.58"

--- a/dev-python/PyQt5-sip/PyQt5-sip-12.9.0.ebuild
+++ b/dev-python/PyQt5-sip/PyQt5-sip-12.9.0.ebuild
@@ -19,4 +19,4 @@ S=${WORKDIR}/${MY_P}
 
 LICENSE="|| ( GPL-2 GPL-3 SIP )"
 SLOT="0/$(ver_cut 1)"
-KEYWORDS="amd64 arm ~arm64 ~ppc ~ppc64 x86"
+KEYWORDS="amd64 arm ~arm64 ~ppc ~ppc64 ~riscv x86"

--- a/dev-python/PyQt5/PyQt5-5.15.4-r1.ebuild
+++ b/dev-python/PyQt5/PyQt5-5.15.4-r1.ebuild
@@ -19,7 +19,7 @@ S=${WORKDIR}/${MY_P}
 
 LICENSE="GPL-3"
 SLOT="0"
-KEYWORDS="amd64 arm ~arm64 ~ppc ~ppc64 x86"
+KEYWORDS="amd64 arm ~arm64 ~ppc ~ppc64 ~riscv x86"
 
 # TODO: QtNfc, QtQuick3D, QtRemoteObjects
 IUSE="bluetooth dbus debug declarative designer examples gles2-only gui help location

--- a/dev-python/sip/sip-4.19.25-r1.ebuild
+++ b/dev-python/sip/sip-4.19.25-r1.ebuild
@@ -20,7 +20,7 @@ S=${WORKDIR}/${MY_P}
 # Sub-slot based on SIP_API_MAJOR_NR from siplib/sip.h
 SLOT="0/12"
 LICENSE="|| ( GPL-2 GPL-3 SIP )"
-KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ppc ppc64 ~sparc x86"
+KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ppc ppc64 ~riscv ~sparc x86"
 IUSE="doc"
 
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"

--- a/dev-qt/designer/designer-5.15.2.ebuild
+++ b/dev-qt/designer/designer-5.15.2.ebuild
@@ -9,7 +9,7 @@ inherit desktop qt5-build xdg-utils
 DESCRIPTION="WYSIWYG tool for designing and building graphical user interfaces with QtWidgets"
 
 if [[ ${QT5_BUILD_TYPE} == release ]]; then
-	KEYWORDS="amd64 arm arm64 ~hppa ppc ppc64 x86"
+	KEYWORDS="amd64 arm arm64 ~hppa ppc ppc64 ~riscv x86"
 fi
 
 IUSE="declarative"

--- a/dev-qt/qtlocation/qtlocation-5.15.2-r1.ebuild
+++ b/dev-qt/qtlocation/qtlocation-5.15.2-r1.ebuild
@@ -8,7 +8,7 @@ inherit qt5-build
 DESCRIPTION="Location (places, maps, navigation) library for the Qt5 framework"
 
 if [[ ${QT5_BUILD_TYPE} == release ]]; then
-	KEYWORDS="amd64 arm arm64 x86"
+	KEYWORDS="amd64 arm arm64 ~riscv x86"
 fi
 
 IUSE=""

--- a/dev-qt/qtmultimedia/qtmultimedia-5.15.2.ebuild
+++ b/dev-qt/qtmultimedia/qtmultimedia-5.15.2.ebuild
@@ -7,7 +7,7 @@ inherit qt5-build
 DESCRIPTION="Multimedia (audio, video, radio, camera) library for the Qt5 framework"
 
 if [[ ${QT5_BUILD_TYPE} == release ]]; then
-	KEYWORDS="amd64 arm arm64 ~hppa ppc ppc64 ~sparc x86"
+	KEYWORDS="amd64 arm arm64 ~hppa ppc ppc64 ~riscv ~sparc x86"
 fi
 
 IUSE="alsa gles2-only gstreamer openal pulseaudio qml widgets"

--- a/dev-qt/qtopengl/qtopengl-5.15.2.ebuild
+++ b/dev-qt/qtopengl/qtopengl-5.15.2.ebuild
@@ -11,7 +11,7 @@ DESCRIPTION="OpenGL support library for the Qt5 framework (deprecated)"
 SRC_URI+=" https://dev.gentoo.org/~asturm/distfiles/qtbase-${PV}-gcc11.patch.xz"
 
 if [[ ${QT5_BUILD_TYPE} == release ]]; then
-	KEYWORDS="amd64 arm arm64 ~hppa ppc ppc64 ~sparc x86"
+	KEYWORDS="amd64 arm arm64 ~hppa ppc ppc64 ~riscv ~sparc x86"
 fi
 
 IUSE="gles2-only"

--- a/dev-qt/qtpositioning/qtpositioning-5.15.2.ebuild
+++ b/dev-qt/qtpositioning/qtpositioning-5.15.2.ebuild
@@ -8,7 +8,7 @@ inherit qt5-build
 DESCRIPTION="Physical position determination library for the Qt5 framework"
 
 if [[ ${QT5_BUILD_TYPE} == release ]]; then
-	KEYWORDS="amd64 arm arm64 ~hppa ppc ppc64 ~sparc x86"
+	KEYWORDS="amd64 arm arm64 ~hppa ppc ppc64 ~riscv ~sparc x86"
 fi
 
 IUSE="geoclue +qml"

--- a/dev-qt/qtsensors/qtsensors-5.15.2.ebuild
+++ b/dev-qt/qtsensors/qtsensors-5.15.2.ebuild
@@ -7,7 +7,7 @@ inherit qt5-build
 DESCRIPTION="Hardware sensor access library for the Qt5 framework"
 
 if [[ ${QT5_BUILD_TYPE} == release ]]; then
-	KEYWORDS="amd64 arm arm64 ~hppa ~ppc ppc64 ~sparc x86"
+	KEYWORDS="amd64 arm arm64 ~hppa ~ppc ppc64 ~riscv ~sparc x86"
 fi
 
 # TODO: simulator

--- a/dev-qt/qtserialport/qtserialport-5.15.2.ebuild
+++ b/dev-qt/qtserialport/qtserialport-5.15.2.ebuild
@@ -7,7 +7,7 @@ inherit qt5-build
 DESCRIPTION="Serial port abstraction library for the Qt5 framework"
 
 if [[ ${QT5_BUILD_TYPE} == release ]]; then
-	KEYWORDS="amd64 arm arm64 ~hppa ppc ppc64 ~sparc x86"
+	KEYWORDS="amd64 arm arm64 ~hppa ppc ppc64 ~riscv ~sparc x86"
 fi
 
 IUSE=""

--- a/dev-qt/qtspeech/qtspeech-5.15.2.ebuild
+++ b/dev-qt/qtspeech/qtspeech-5.15.2.ebuild
@@ -7,7 +7,7 @@ inherit qt5-build
 DESCRIPTION="Text-to-speech library for the Qt5 framework"
 
 if [[ ${QT5_BUILD_TYPE} == release ]]; then
-	KEYWORDS="amd64 arm arm64 ~ppc64 x86"
+	KEYWORDS="amd64 arm arm64 ~ppc64 ~riscv x86"
 fi
 
 # TODO: flite plugin - needs 2.0.0 (not yet in tree)

--- a/dev-qt/qtwebchannel/qtwebchannel-5.15.2.ebuild
+++ b/dev-qt/qtwebchannel/qtwebchannel-5.15.2.ebuild
@@ -7,7 +7,7 @@ inherit qt5-build
 DESCRIPTION="Qt5 module for integrating C++ and QML applications with HTML/JavaScript clients"
 
 if [[ ${QT5_BUILD_TYPE} == release ]]; then
-	KEYWORDS="amd64 arm arm64 ~ppc ppc64 x86"
+	KEYWORDS="amd64 arm arm64 ~ppc ppc64 ~riscv x86"
 fi
 
 IUSE="qml"

--- a/dev-qt/qtwebsockets/qtwebsockets-5.15.2.ebuild
+++ b/dev-qt/qtwebsockets/qtwebsockets-5.15.2.ebuild
@@ -7,7 +7,7 @@ inherit qt5-build
 DESCRIPTION="Implementation of the WebSocket protocol for the Qt5 framework"
 
 if [[ ${QT5_BUILD_TYPE} == release ]]; then
-	KEYWORDS="amd64 arm arm64 ~hppa ~ppc ppc64 ~sparc x86"
+	KEYWORDS="amd64 arm arm64 ~hppa ~ppc ppc64 ~riscv ~sparc x86"
 fi
 
 IUSE="qml +ssl"

--- a/dev-qt/qtxmlpatterns/qtxmlpatterns-5.15.2.ebuild
+++ b/dev-qt/qtxmlpatterns/qtxmlpatterns-5.15.2.ebuild
@@ -8,7 +8,7 @@ inherit qt5-build
 DESCRIPTION="XPath, XQuery, XSLT, and XML Schema validation library for the Qt5 framework"
 
 if [[ ${QT5_BUILD_TYPE} == release ]]; then
-	KEYWORDS="amd64 arm arm64 ~hppa ppc ppc64 ~sparc x86"
+	KEYWORDS="amd64 arm arm64 ~hppa ppc ppc64 ~riscv ~sparc x86"
 fi
 
 IUSE="qml"

--- a/media-libs/gst-plugins-bad/gst-plugins-bad-1.18.4-r1.ebuild
+++ b/media-libs/gst-plugins-bad/gst-plugins-bad-1.18.4-r1.ebuild
@@ -10,7 +10,7 @@ DESCRIPTION="Less plugins for GStreamer"
 HOMEPAGE="https://gstreamer.freedesktop.org/"
 
 LICENSE="LGPL-2"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~riscv ~sparc ~x86"
 
 # TODO: egl and gtk IUSE only for transition
 IUSE="X bzip2 +egl gles2 gtk +introspection +opengl +orc vnc wayland" # Keep default IUSE mirrored with gst-plugins-base where relevant

--- a/media-libs/ladspa-sdk/ladspa-sdk-1.15-r1.ebuild
+++ b/media-libs/ladspa-sdk/ladspa-sdk-1.15-r1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="http://www.ladspa.org/download/${MY_P}.tgz"
 
 LICENSE="LGPL-2.1"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ppc ppc64 sparc x86"
+KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ppc ppc64 ~riscv sparc x86"
 IUSE=""
 
 RDEPEND=""

--- a/media-libs/libao/libao-1.2.2-r2.ebuild
+++ b/media-libs/libao/libao-1.2.2-r2.ebuild
@@ -13,7 +13,7 @@ SRC_URI="https://github.com/xiph/libao/archive/${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~mips ppc ppc64 sparc x86 ~amd64-linux ~ppc-macos ~x64-macos ~x86-solaris"
+KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~mips ppc ppc64 ~riscv sparc x86 ~amd64-linux ~ppc-macos ~x64-macos ~x86-solaris"
 IUSE="alsa nas mmap pulseaudio sndio"
 
 RDEPEND="

--- a/media-libs/libmad/libmad-0.15.1b-r10.ebuild
+++ b/media-libs/libmad/libmad-0.15.1b-r10.ebuild
@@ -11,7 +11,7 @@ SRC_URI="mirror://sourceforge/mad/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~mips ppc ppc64 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~x86-solaris"
+KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~mips ppc ppc64 ~riscv sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~x86-solaris"
 IUSE="debug static-libs"
 
 DEPEND=""

--- a/media-libs/openal/openal-1.21.1-r1.ebuild
+++ b/media-libs/openal/openal-1.21.1-r1.ebuild
@@ -16,7 +16,7 @@ SRC_URI="https://www.openal-soft.org/openal-releases/${MY_P}.tar.bz2"
 # Some components are under BSD
 LICENSE="LGPL-2+ BSD"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~mips ppc ppc64 sparc x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~mips ppc ppc64 ~riscv sparc x86 ~amd64-linux ~x86-linux"
 IUSE="
 	alsa coreaudio debug jack oss portaudio pulseaudio sdl sndio qt5
 	cpu_flags_x86_sse cpu_flags_x86_sse2 cpu_flags_x86_sse4_1

--- a/media-libs/opencore-amr/opencore-amr-0.1.5-r1.ebuild
+++ b/media-libs/opencore-amr/opencore-amr-0.1.5-r1.ebuild
@@ -11,7 +11,7 @@ SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
 
 LICENSE="Apache-2.0"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm ~arm64 ~hppa ~ia64 ppc ppc64 sparc x86 ~ppc-macos ~x64-macos"
+KEYWORDS="~alpha amd64 arm ~arm64 ~hppa ~ia64 ppc ppc64 ~riscv sparc x86 ~ppc-macos ~x64-macos"
 
 multilib_src_configure() {
 	ECONF_SOURCE=${S} econf --disable-static

--- a/media-libs/opusfile/opusfile-0.12.ebuild
+++ b/media-libs/opusfile/opusfile-0.12.ebuild
@@ -9,7 +9,7 @@ SRC_URI="https://downloads.xiph.org/releases/opus/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ppc ppc64 sparc x86"
+KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ppc ppc64 ~riscv sparc x86"
 IUSE="doc fixed-point +float +http static-libs"
 
 RDEPEND="media-libs/libogg

--- a/media-sound/gsm/gsm-1.0.13-r1.ebuild
+++ b/media-sound/gsm/gsm-1.0.13-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ SRC_URI="mirror://gentoo/${P}.tar.gz"
 
 LICENSE="gsm"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~mips ppc ppc64 ~s390 sparc x86"
+KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~mips ppc ppc64 ~riscv ~s390 sparc x86"
 
 S="${WORKDIR}/${PN}-$(ver_rs 2 '-pl' )"
 

--- a/media-sound/lame/lame-3.100-r3.ebuild
+++ b/media-sound/lame/lame-3.100-r3.ebuild
@@ -10,7 +10,7 @@ SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
 
 LICENSE="LGPL-2.1"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~mips ppc ppc64 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
+KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~mips ppc ppc64 ~riscv sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
 IUSE="debug cpu_flags_x86_mmx +frontend mp3rtp sndfile static-libs"
 
 # These deps are without MULTILIB_USEDEP and are correct since we only build

--- a/media-sound/sox/sox-14.4.2_p20200803.ebuild
+++ b/media-sound/sox/sox-14.4.2_p20200803.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -19,7 +19,7 @@ S="${WORKDIR}/${MY_P}"
 
 LICENSE="LGPL-2.1"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~mips ppc ppc64 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-solaris"
+KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~mips ppc ppc64 ~riscv sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-solaris"
 IUSE="alsa amr ao debug encode flac id3tag ladspa mad ogg openmp oss opus png pulseaudio sndfile static-libs twolame wavpack"
 
 BDEPEND="

--- a/media-sound/twolame/twolame-0.4.0.ebuild
+++ b/media-sound/twolame/twolame-0.4.0.ebuild
@@ -11,7 +11,7 @@ SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~mips ppc ppc64 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~x86-solaris"
+KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~mips ppc ppc64 ~riscv sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~x86-solaris"
 IUSE="+sndfile static-libs test"
 
 RDEPEND="sndfile? ( >=media-libs/libsndfile-1.0.25[${MULTILIB_USEDEP}] )"

--- a/media-sound/wavpack/wavpack-5.4.0.ebuild
+++ b/media-sound/wavpack/wavpack-5.4.0.ebuild
@@ -11,7 +11,7 @@ SRC_URI="https://github.com/dbry/WavPack/releases/download/${PV}/${P}.tar.xz"
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~mips ppc ppc64 sparc x86 ~amd64-linux ~x86-linux ~x86-solaris"
+KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~mips ppc ppc64 ~riscv sparc x86 ~amd64-linux ~x86-linux ~x86-solaris"
 IUSE="test"
 RESTRICT="!test? ( test )"
 

--- a/profiles/arch/riscv/package.use.mask
+++ b/profiles/arch/riscv/package.use.mask
@@ -1,6 +1,10 @@
 # Copyright 2019-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Alex Fan <alexfanqi@yahoo.com> (2021-08-08)
+# portaudio & pulseaudio are not tested yet
+media-libs/openal portaudio pulseaudio
+
 # Alex Fan <alexfanqi@yahoo.com> (2021-08-05)
 # pdfannotextractor depends on java, not (sustainably) supported yet
 app-text/texlive pdfannotextractor

--- a/profiles/arch/riscv/package.use.mask
+++ b/profiles/arch/riscv/package.use.mask
@@ -3,6 +3,10 @@
 
 # Alex Fan <alexfanqi@yahoo.com> (2021-08-08)
 # portaudio & pulseaudio are not tested yet
+app-accessibility/espeak portaudio
+
+# Alex Fan <alexfanqi@yahoo.com> (2021-08-08)
+# portaudio & pulseaudio are not tested yet
 media-libs/openal portaudio pulseaudio
 
 # Alex Fan <alexfanqi@yahoo.com> (2021-08-05)

--- a/profiles/arch/riscv/package.use.mask
+++ b/profiles/arch/riscv/package.use.mask
@@ -1,6 +1,12 @@
 # Copyright 2019-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Alex Fan <alexfanqi@yahoo.com> (2021-08-09)
+# ipython[qt5] depends on qtconsole, which depends on QtPy.
+# QtPy cannot be tested atm because QtPy[test] has a hard
+# dependency on PyQt5[bluetooth].
+dev-python/ipython qt5
+
 # Alex Fan <alexfanqi@yahoo.com> (2021-08-08)
 # portaudio & pulseaudio are not tested yet
 app-accessibility/espeak portaudio

--- a/profiles/arch/riscv/use.mask
+++ b/profiles/arch/riscv/use.mask
@@ -7,6 +7,10 @@
 # Unmask systemd
 -systemd
 
+# Alex Fan <alexfanqi@yahoo.com> (2021-08-09)
+# media-libs/nas failed to compile
+nas
+
 # Yixun Lan <dlan@gentoo.org> (2021-05-19)
 # Unmask for more testing
 -elogind

--- a/profiles/arch/riscv/use.mask
+++ b/profiles/arch/riscv/use.mask
@@ -41,7 +41,6 @@ libedit
 mono
 motif
 opencl
-qt5
 pulseaudio
 rsh
 slang

--- a/x11-misc/gccmakedep/gccmakedep-1.0.3-r1.ebuild
+++ b/x11-misc/gccmakedep/gccmakedep-1.0.3-r1.ebuild
@@ -13,7 +13,7 @@ if [[ ${PV} == 9999 ]]; then
 	LIVE_DEPEND=">=x11-misc/util-macros-1.18"
 else
 	SRC_URI="https://www.x.org/releases/individual/util/${P}.tar.bz2"
-	KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~mips ppc ppc64 ~s390 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
+	KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
 fi
 
 LICENSE="MIT"

--- a/x11-misc/gccmakedep/gccmakedep-9999.ebuild
+++ b/x11-misc/gccmakedep/gccmakedep-9999.ebuild
@@ -13,7 +13,7 @@ if [[ ${PV} == 9999 ]]; then
 	LIVE_DEPEND=">=x11-misc/util-macros-1.18"
 else
 	SRC_URI="https://www.x.org/releases/individual/util/${P}.tar.bz2"
-	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
 fi
 
 LICENSE="MIT"


### PR DESCRIPTION
mask nas (ie network audio system) due to compilation failure. See https://bugs.gentoo.org/807232