### PR TITLE
app-misc/datovka: Add missing libdatovka dep

### DIFF
--- a/app-misc/datovka/datovka-4.17.0-r1.ebuild
+++ b/app-misc/datovka/datovka-4.17.0-r1.ebuild
@@ -1,0 +1,57 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit qmake-utils xdg-utils
+
+DESCRIPTION="GUI to access the Czech data box e-government system"
+HOMEPAGE="https://www.datovka.cz/"
+SRC_URI="https://secure.nic.cz/files/datove_schranky/${PV}/${P}.tar.xz"
+
+LICENSE="GPL-3"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE=""
+
+# minimum Qt version required
+QT_PV="5.14.0:5"
+
+RDEPEND="
+	>=dev-libs/openssl-1.0.2:0=
+	>=dev-qt/qtcore-${QT_PV}
+	>=dev-qt/qtgui-${QT_PV}
+	>=dev-qt/qtnetwork-${QT_PV}
+	>=dev-qt/qtprintsupport-${QT_PV}
+	>=dev-qt/qtsql-${QT_PV}[sqlite]
+	>=dev-qt/qtsvg-${QT_PV}
+	>=dev-qt/qtwidgets-${QT_PV}
+	>=net-libs/libisds-0.11
+"
+DEPEND="
+	${RDEPEND}
+	>=dev-qt/linguist-tools-${QT_PV}
+	app-misc/libdatovka
+"
+BDEPEND="
+	virtual/pkgconfig
+"
+DOCS=( ChangeLog README )
+
+src_configure() {
+	lrelease datovka.pro || die
+	eqmake5 PREFIX="/usr" DISABLE_VERSION_NOTIFICATION=1 TEXT_FILES_INST_DIR="/usr/share/${PN}/"
+}
+
+src_install() {
+	emake install INSTALL_ROOT="${D}"
+	einstalldocs
+}
+
+pkg_postinst() {
+	xdg_icon_cache_update
+}
+
+pkg_postrm() {
+	xdg_icon_cache_update
+}


### PR DESCRIPTION
Fixes failure to compile due to missing header file provided by `app-misc/libdatovka`

```
x86_64-pc-linux-gnu-g++ -c -g -O0 -std=c++11 -Wall -Wextra -pedantic -Wdate-time -Wformat -Werror=format-security -Wall -Wextra -D_REENTRANT -fPIC -DDEBUG=1 -DVERSION=\"4.17.0\" -DAPP_NAME=\"datovka\" -DAPP_ORG_DOMAIN=\"cz.nic\" -DAPP_ORG_NAME=\"CZ.NIC\" -DDATADIR=\"/usr/share\" -DPKGDATADIR=\"\" -DLOCALE_INST_DIR="\"/usr/share/datovka/localisations\"" -DTEXT_FILES_INST_DIR="\"/usr/share/datovka/\"" -DDISABLE_VERSION_NOTIFICATION=1 -DQT_NO_DEBUG -DQT_SVG_LIB -DQT_PRINTSUPPORT_LIB -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_SQL_LIB -DQT_CORE_LIB -I. -I/usr/include/libxml2 -I/usr/include/qt5 -I/usr/include/qt5/QtSvg -I/usr/include/qt5/QtPrintSupport -I/usr/include/qt5/QtWidgets -I/usr/include/qt5/QtGui -I/usr/include/qt5/QtNetwork -I/usr/include/qt5/QtSql -I/usr/include/qt5/QtCore -Igen_moc -I/usr/include/libdrm -Igen_ui -I/usr/lib64/qt5/mkspecs/linux-g++ -o gen_objects/src/common.o src/common.cpp
src/about.cpp:32:10: fatal error: libdatovka/isds.h: No such file or directory
   32 | #include <libdatovka/isds.h>
      |          ^~~~~~~~~~~~~~~~~~~
compilation terminated.
```

- Added `app-misc/libdatovka` to DEPEND
- Moved `virtual/pkgconfig` to BDEPEND as recommended by EAPI7

Not sure if the previous ebuild revision `datovka-4.17.0.ebuild` should be removed

Closes: https://bugs.gentoo.org/807241