### PR TITLE
app-text/calibre: fix compilation with >=zeroconf-0.32

### DIFF
--- a/app-text/calibre/calibre-5.16.1.ebuild
+++ b/app-text/calibre/calibre-5.16.1.ebuild
@@ -123,7 +123,8 @@ src_prepare() {
 	# disable_plugins: walking sec-hole, wait for upstream to use GHNS interface
 	eapply \
 		"${FILESDIR}/${PN}-2.9.0-no_updates_dialog.patch" \
-		"${FILESDIR}/${PN}-disable_plugins.patch"
+		"${FILESDIR}/${PN}-disable_plugins.patch" \
+		"${FILESDIR}/${P}-zeroconf.patch"
 
 	if ! has_version ">=dev-python/sip-5"; then
 		einfo "Applying SIP v4 patch because SIP v5 was not detected"

--- a/app-text/calibre/files/calibre-5.16.1-zeroconf.patch
+++ b/app-text/calibre/files/calibre-5.16.1-zeroconf.patch
@@ -1,0 +1,30 @@
+diff --color -Naru a/src/calibre/devices/smart_device_app/driver.py b/src/calibre/devices/smart_device_app/driver.py
+--- a/src/calibre/devices/smart_device_app/driver.py	2021-08-08 08:32:03.104016444 +0200
++++ b/src/calibre/devices/smart_device_app/driver.py	2021-08-08 08:33:30.699018403 +0200
+@@ -2040,13 +2040,6 @@
+ # Function to monkeypatch zeroconf to remove the 15 character name length restriction.
+ # Copied from https://github.com/jstasiak/python-zeroconf version 0.28.1
+ 
+-
+-from zeroconf import (BadTypeInNameException, _HAS_A_TO_Z,
+-                      _HAS_ONLY_A_TO_Z_NUM_HYPHEN_UNDERSCORE,
+-                      _HAS_ASCII_CONTROL_CHARS,
+-                      _HAS_ONLY_A_TO_Z_NUM_HYPHEN)
+-
+-
+ def service_type_name(type_: str, *, allow_underscores: bool = False) -> str:
+     """
+     Validate a fully qualified service name, instance or subtype. [rfc6763]
+@@ -2087,6 +2080,12 @@
+     :param type_: Type, SubType or service name to validate
+     :return: fully qualified service name (eg: _http._tcp.local.)
+     """
++
++    from zeroconf import (BadTypeInNameException, _HAS_A_TO_Z,
++                      _HAS_ONLY_A_TO_Z_NUM_HYPHEN_UNDERSCORE,
++                      _HAS_ASCII_CONTROL_CHARS,
++                      _HAS_ONLY_A_TO_Z_NUM_HYPHEN)
++
+     if not (type_.endswith('._tcp.local.') or type_.endswith('._udp.local.')):
+         raise BadTypeInNameException("Type '%s' must end with '._tcp.local.' or '._udp.local.'" % type_)
+ 


### PR DESCRIPTION
Backported upstream patch 4f9e83

Closes: https://bugs.gentoo.org/800233
Package-Manager: Portage-3.0.20, Repoman-3.0.2
Signed-off-by: Marco Genasci <fedeliallalinea@gmail.com>