### PR TITLE
Mask net-print/libgnomecups for removal

### DIFF
--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -32,6 +32,11 @@
 
 #--- END OF EXAMPLES ---
 
+# Andreas Sturmlechner <asturm@gentoo.org> (2021-08-10)
+# EAPI-5, dead, unused; last consumer dropped in bug #352952
+# Removal on 2021-09-09.
+net-print/libgnomecups
+
 # Joshua Kinard <kumba@gentoo.org> (2021-08-09)
 # Dead upstream and has build issues in modern times.
 # See bugs #551786 and #715846.  Removal in 30 days.


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/352952