### PR TITLE
dev-python/cloudscraper: Add nodejs as a test dependency

### DIFF
--- a/dev-python/cloudscraper/cloudscraper-1.2.58.ebuild
+++ b/dev-python/cloudscraper/cloudscraper-1.2.58.ebuild
@@ -20,7 +20,7 @@ RDEPEND="
 	dev-python/requests-toolbelt[${PYTHON_USEDEP}]
 	dev-python/requests[${PYTHON_USEDEP}]
 "
-BDEPEND="${RDEPEND}
+BDEPEND="
 	test? (
 		dev-python/js2py[${PYTHON_USEDEP}]
 		dev-python/pytest-forked[${PYTHON_USEDEP}]

--- a/dev-python/cloudscraper/cloudscraper-1.2.58.ebuild
+++ b/dev-python/cloudscraper/cloudscraper-1.2.58.ebuild
@@ -26,6 +26,7 @@ BDEPEND="${RDEPEND}
 		dev-python/pytest-forked[${PYTHON_USEDEP}]
 		dev-python/pytest-timeout[${PYTHON_USEDEP}]
 		dev-python/responses[${PYTHON_USEDEP}]
+		net-libs/nodejs
 	)
 "
 

--- a/profiles/arch/amd64/x32/package.use.mask
+++ b/profiles/arch/amd64/x32/package.use.mask
@@ -1,6 +1,10 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Ekaterina Vaartis <vaartis@kotobank.ch> (2021-08-10)
+# Requies net-libs/nodejs for tests
+dev-python/cloudscraper test
+
 # Andreas Sturmlechner <asturm@gentoo.org> (2021-02-09)
 # Requires net-libs/nodejs, plus mask all reverse-dependencies.
 app-i18n/fcitx-libpinyin dictionary-manager


### PR DESCRIPTION
Discovered by tinderbox: https://bugs.gentoo.org/807454