### PR TITLE
net-firewall/ufw: warn about possible conflicts

### DIFF
--- a/net-firewall/ufw/ufw-0.36.ebuild
+++ b/net-firewall/ufw/ufw-0.36.ebuild
@@ -166,6 +166,27 @@ pkg_postinst() {
 	local print_check_req_warn
 	print_check_req_warn=false
 
+	local found=()
+	local apps=("${CATEGORY}/arno-iptables-firewall"
+		    "${CATEGORY}/ferm"
+		    "${CATEGORY}/firehol"
+		    "${CATEGORY}/firewalld"
+		    "${CATEGORY}/ipkungfu")
+
+	for exe in "${apps[@]}"
+	do
+		if has_version ''"${exe}"''; then
+			found+=( "${exe}" )
+		fi
+	done
+
+	if [ -n "$found" ]; then
+		echo
+		ewarn "WARNING: Detected other firewall applications:"
+		ewarn "${found[@]}"
+		ewarn "If enabled, these applications may interfere with ufw!"
+	fi
+
 	if [[ -z "${REPLACING_VERSIONS}" ]]; then
 		echo
 		elog "To enable ufw, add it to boot sequence and activate it:"


### PR DESCRIPTION
Warn about applications that may interfere with ufw. Edited in place without dropping stable keywords. If really re-stabilization needed please ignore this PR, not worth it. Cheers my old friend juippis :)

Package-Manager: Portage-3.0.20, Repoman-3.0.2
Signed-off-by: Hasan ÇALIŞIR <hasan.calisir@psauxit.com>