### PR TITLE
media-gfx/ebdftopcf: don't install manpage

### DIFF
--- a/media-gfx/ebdftopcf/ebdftopcf-2-r1.ebuild
+++ b/media-gfx/ebdftopcf/ebdftopcf-2-r1.ebuild
@@ -1,0 +1,23 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="Optimally generate PCF files from BDF files"
+HOMEPAGE="https://wiki.gentoo.org/wiki/No_homepage"
+SRC_URI="mirror://gentoo/${P}.tar.bz2"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos"
+IUSE=""
+
+# these apps are used at runtime by ebdftopcf
+RDEPEND="x11-apps/bdftopcf
+	app-arch/gzip"
+
+src_install() {
+	insinto /usr/share/ebdftopcf
+	doins Makefile.ebdftopcf
+	dodoc README
+}


### PR DESCRIPTION
Don't install the font-ebdftopcf.eclass.5 manual page to avoid a
collision with recent app-doc/eclass-manpages package.

Closes: https://bugs.gentoo.org/801943
Package-Manager: Portage-3.0.20, Repoman-3.0.3
Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>