### PR TITLE
sys-libs/ncurses: Use `BUILD_CC` as `CC` when compiling tic.

### DIFF
--- a/sys-libs/ncurses/ncurses-6.2-r1.ebuild
+++ b/sys-libs/ncurses/ncurses-6.2-r1.ebuild
@@ -87,6 +87,7 @@ src_configure() {
 
 		# We can't re-use the multilib BUILD_DIR because we run outside of it.
 		BUILD_DIR="${WORKDIR}" \
+		CC=${BUILD_CC} \
 		CHOST=${CBUILD} \
 		CFLAGS=${BUILD_CFLAGS} \
 		CXXFLAGS=${BUILD_CXXFLAGS} \

--- a/sys-libs/ncurses/ncurses-6.2_p20210123.ebuild
+++ b/sys-libs/ncurses/ncurses-6.2_p20210123.ebuild
@@ -88,6 +88,7 @@ src_configure() {
 
 		# We can't re-use the multilib BUILD_DIR because we run outside of it.
 		BUILD_DIR="${WORKDIR}" \
+		CC=${BUILD_CC} \
 		CHOST=${CBUILD} \
 		CFLAGS=${BUILD_CFLAGS} \
 		CXXFLAGS=${BUILD_CXXFLAGS} \

--- a/sys-libs/ncurses/ncurses-6.2_p20210619.ebuild
+++ b/sys-libs/ncurses/ncurses-6.2_p20210619.ebuild
@@ -87,6 +87,7 @@ src_configure() {
 
 		# We can't re-use the multilib BUILD_DIR because we run outside of it.
 		BUILD_DIR="${WORKDIR}" \
+		CC=${BUILD_CC} \
 		CHOST=${CBUILD} \
 		CFLAGS=${BUILD_CFLAGS} \
 		CXXFLAGS=${BUILD_CXXFLAGS} \


### PR DESCRIPTION
Not having `CC` explictly set creates a problem in case of
cross-compilation as it can use host `CC` for tic.

Signed-off-by: Vaibhav Rustagi <vaibhavrustagi@google.com>