### PR TITLE
sys-fs/cryptsetup: wait for source to appear

### DIFF
--- a/sys-fs/cryptsetup/cryptsetup-2.4.0_rc1-r100.ebuild
+++ b/sys-fs/cryptsetup/cryptsetup-2.4.0_rc1-r100.ebuild
@@ -1,0 +1,133 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit autotools linux-info tmpfiles
+
+DESCRIPTION="Tool to setup encrypted devices with dm-crypt"
+HOMEPAGE="https://gitlab.com/cryptsetup/cryptsetup/blob/master/README.md"
+SRC_URI="https://www.kernel.org/pub/linux/utils/${PN}/v$(ver_cut 1-2)/${P/_/-}.tar.xz"
+
+LICENSE="GPL-2+"
+SLOT="0/12" # libcryptsetup.so version
+[[ ${PV} != *_rc* ]] && \
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+CRYPTO_BACKENDS="gcrypt kernel nettle +openssl"
+# we don't support nss since it doesn't allow cryptsetup to be built statically
+# and it's missing ripemd160 support so it can't provide full backward compatibility
+IUSE="${CRYPTO_BACKENDS} +argon2 nls pwquality reencrypt ssh static static-libs +udev urandom"
+REQUIRED_USE="^^ ( ${CRYPTO_BACKENDS//+/} )
+	static? ( !gcrypt )" #496612
+
+LIB_DEPEND="
+	dev-libs/json-c:=[static-libs(+)]
+	dev-libs/libgpg-error[static-libs(+)]
+	dev-libs/popt[static-libs(+)]
+	>=sys-apps/util-linux-2.31-r1[static-libs(+)]
+	argon2? ( app-crypt/argon2:=[static-libs(+)] )
+	gcrypt? ( dev-libs/libgcrypt:0=[static-libs(+)] )
+	nettle? ( >=dev-libs/nettle-2.4[static-libs(+)] )
+	openssl? ( dev-libs/openssl:0=[static-libs(+)] )
+	pwquality? ( dev-libs/libpwquality[static-libs(+)] )
+	ssh? ( net-libs/libssh[static-libs(+)] )
+	sys-fs/lvm2[static-libs(+)]
+	udev? ( virtual/libudev[static-libs(-)] )"
+# We have to always depend on ${LIB_DEPEND} rather than put behind
+# !static? () because we provide a shared library which links against
+# these other packages. #414665
+RDEPEND="static-libs? ( ${LIB_DEPEND} )
+	${LIB_DEPEND//\[static-libs\([+-]\)\]}"
+DEPEND="${RDEPEND}
+	static? ( ${LIB_DEPEND} )"
+BDEPEND="
+	virtual/pkgconfig
+"
+
+S="${WORKDIR}/${P/_/-}"
+
+PATCHES=( "${FILESDIR}"/${PN}-2.0.4-fix-static-pwquality-build.patch )
+
+pkg_setup() {
+	local CONFIG_CHECK="~DM_CRYPT ~CRYPTO ~CRYPTO_CBC ~CRYPTO_SHA256"
+	local WARNING_DM_CRYPT="CONFIG_DM_CRYPT:\tis not set (required for cryptsetup)\n"
+	local WARNING_CRYPTO_SHA256="CONFIG_CRYPTO_SHA256:\tis not set (required for cryptsetup)\n"
+	local WARNING_CRYPTO_CBC="CONFIG_CRYPTO_CBC:\tis not set (required for kernel 2.6.19)\n"
+	local WARNING_CRYPTO="CONFIG_CRYPTO:\tis not set (required for cryptsetup)\n"
+	check_extra_config
+}
+
+src_prepare() {
+	sed -i '/^LOOPDEV=/s:$: || exit 0:' tests/{compat,mode}-test || die
+	default
+	eautoreconf
+}
+
+src_configure() {
+	if use kernel ; then
+		ewarn "Note that kernel backend is very slow for this type of operation"
+		ewarn "and is provided mainly for embedded systems wanting to avoid"
+		ewarn "userspace crypto libraries."
+	fi
+
+	local myeconfargs=(
+		--disable-internal-argon2
+		--enable-shared
+		--sbindir=/sbin
+		# for later use
+		--with-default-luks-format=LUKS2
+		--with-tmpfilesdir="${EPREFIX}/usr/lib/tmpfiles.d"
+		--with-crypto_backend=$(for x in ${CRYPTO_BACKENDS//+/} ; do usev ${x} ; done)
+		$(use_enable argon2 libargon2)
+		$(use_enable nls)
+		$(use_enable pwquality)
+		$(use_enable reencrypt cryptsetup-reencrypt)
+		$(use_enable static static-cryptsetup)
+		$(use_enable static-libs static)
+		$(use_enable udev)
+		$(use_enable !urandom dev-random)
+		$(use_enable ssh ssh-token)
+		$(usex argon2 '' '--with-luks2-pbkdf=pbkdf2')
+	)
+	econf "${myeconfargs[@]}"
+}
+
+src_test() {
+	if [[ ! -e /dev/mapper/control ]] ; then
+		ewarn "No /dev/mapper/control found -- skipping tests"
+		return 0
+	fi
+
+	local p
+	for p in /dev/mapper /dev/loop* ; do
+		addwrite ${p}
+	done
+
+	default
+}
+
+src_install() {
+	default
+
+	if use static ; then
+		mv "${ED}"/sbin/cryptsetup{.static,} || die
+		mv "${ED}"/sbin/veritysetup{.static,} || die
+		mv "${ED}"/sbin/integritysetup{.static,} || die
+		if use ssh ; then
+			mv "${ED}"/sbin/cryptsetup-ssh{.static,} || die
+		fi
+		if use reencrypt ; then
+			mv "${ED}"/sbin/cryptsetup-reencrypt{.static,} || die
+		fi
+	fi
+	find "${ED}" -type f -name "*.la" -delete || die
+
+	dodoc docs/v*ReleaseNotes
+
+	newconfd "${FILESDIR}"/2.4.0-dmcrypt.confd dmcrypt
+	newinitd "${FILESDIR}"/2.4.0-dmcrypt.rc dmcrypt
+}
+
+pkg_postinst() {
+	tmpfiles_process cryptsetup.conf
+}

--- a/sys-fs/cryptsetup/files/2.4.0-dmcrypt.confd
+++ b/sys-fs/cryptsetup/files/2.4.0-dmcrypt.confd
@@ -1,0 +1,112 @@
+# /etc/conf.d/dmcrypt
+
+# For people who run dmcrypt on top of some other layer (like raid),
+# use rc_need to specify that requirement.  See the runscript(8) man
+# page for more information.
+
+#--------------------
+# Instructions
+#--------------------
+
+# Note regarding the syntax of this file.  This file is *almost* bash,
+# but each line is evaluated separately.  Separate swaps/targets can be
+# specified.  The init-script which reads this file assumes that a
+# swap= or target= line starts a new section, similar to lilo or grub
+# configuration.
+
+# Note when using gpg keys and /usr on a separate partition, you will
+# have to copy /usr/bin/gpg to /bin/gpg so that it will work properly
+# and ensure that gpg has been compiled statically.
+# See http://bugs.gentoo.org/90482 for more information.
+
+# Note that the init-script which reads this file detects whether your
+# partition is LUKS or not. No mkfs is run unless you specify a makefs
+# option.
+
+# Global options:
+#----------------
+
+# How long to wait for each timeout (in seconds).
+dmcrypt_key_timeout=1
+
+# Max number of checks to perform (see dmcrypt_key_timeout).
+#dmcrypt_max_timeout=300
+
+# Number of password retries.
+dmcrypt_retries=5
+
+# Arguments:
+#-----------
+# target=<name>                      == Mapping name for partition.
+# swap=<name>                        == Mapping name for swap partition.
+# source='<dev>'                     == Real device for partition.
+#                                    Note: You can (and should) specify a tag like UUID
+#                                    for blkid (see -t option).  This is safer than using
+#                                    the full path to the device.
+# key='</path/to/keyfile>[:<mode>]'  == Fullpath from / or from inside removable media.
+# remdev='<dev>'                     == Device that will be assigned to removable media.
+# gpg_options='<opts>'               == Default are --quiet --decrypt
+# options='<opts>'                   == cryptsetup, for LUKS you can only use --readonly
+# loop_file='<file>'                 == Loopback file.
+#                                    Note: If you omit $source, then a free loopback will
+#                                    be looked up automatically.
+# pre_mount='cmds'                   == commands to execute before mounting partition.
+# post_mount='cmds'                  == commands to execute after mounting partition.
+# wait=5                             == wait given amount of seconds for source to appear
+#-----------
+# Supported Modes
+# gpg					== decrypt and pipe key into cryptsetup.
+#						Note: new-line character must not be part of key.
+#						Command to erase \n char: 'cat key | tr -d '\n' > cleanKey'
+
+#--------------------
+# dm-crypt examples
+#--------------------
+
+## swap
+# Swap partitions. These should come first so that no keys make their
+# way into unencrypted swap.
+# If no options are given, they will default to: -c aes -h sha1 -d /dev/urandom
+# If no makefs is given then mkswap will be assumed
+#swap=crypt-swap
+#source='/dev/hda2'
+
+## /home with passphrase
+#target=crypt-home
+#source='/dev/hda5'
+
+## /home with regular keyfile
+#target=crypt-home
+#source='/dev/hda5'
+#key='/full/path/to/homekey'
+
+## /home with gpg protected key
+#target=crypt-home
+#source='/dev/hda5'
+#key='/full/path/to/homekey:gpg'
+
+## /home with regular keyfile on removable media(such as usb-stick)
+#target=crypt-home
+#source='/dev/hda5'
+#key='/full/path/to/homekey'
+#remdev='/dev/sda1'
+
+## /home with gpg protected key on removable media(such as usb-stick)
+#target=crypt-home
+#source='/dev/hda5'
+#key='/full/path/to/homekey:gpg'
+#remdev='/dev/sda1'
+
+## /tmp with regular keyfile
+#target=crypt-tmp
+#source='/dev/hda6'
+#key='/full/path/to/tmpkey'
+#pre_mount='/sbin/mkreiserfs -f -f ${dev}'
+#post_mount='chown root:root ${mount_point}; chmod 1777 ${mount_point}'
+
+## Loopback file example
+#target='crypt-loop-home'
+#source='/dev/loop0'
+#loop_file='/mnt/crypt/home'
+
+# The file must be terminated by a newline.  Or leave this comment last.

--- a/sys-fs/cryptsetup/files/2.4.0-dmcrypt.rc
+++ b/sys-fs/cryptsetup/files/2.4.0-dmcrypt.rc
@@ -1,0 +1,350 @@
+#!/sbin/openrc-run
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+depend() {
+	use modules
+	before checkfs fsck
+
+	if grep -qs ^swap= "${conf_file}" ; then
+		before swap
+	fi
+}
+
+# We support multiple dmcrypt instances based on $SVCNAME
+conf_file="/etc/conf.d/${SVCNAME}"
+
+# Get splash helpers if available.
+if [ -e /sbin/splash-functions.sh ] ; then
+	. /sbin/splash-functions.sh
+fi
+
+# Setup mappings for an individual target/swap
+# Note: This relies on variables localized in the main body below.
+dm_crypt_execute() {
+	local dev ret mode foo source_dev
+
+	if [ -z "${target}" -a -z "${swap}" ] ; then
+		return
+	fi
+
+	# Set up default values.
+	: ${dmcrypt_key_timeout:=1}
+	: ${dmcrypt_max_timeout:=300}
+	: ${dmcrypt_retries:=5}
+	: ${wait:=5}
+
+	# Handle automatic look up of the source path.
+	if [ -z "${source}" -a -n "${loop_file}" ] ; then
+		source=$(losetup --show -f "${loop_file}")
+	fi
+	case ${source} in
+	*=*)
+		i=0
+		while [ ${i} -lt ${wait} ]; do
+			if source_dev="$(blkid -l -t "${source}" -o device)"; then
+				source="${source_dev}"
+				break
+			fi
+			: $((i += 1))
+			einfo "waiting for source \"${source}\" for ${target}..."
+			sleep 1
+		done
+		;;
+	esac
+	if [ -z "${source}" ] || [ ! -e "${source}" ] ; then
+		ewarn "source \"${source}\" for ${target} missing, skipping..."
+		return
+	fi
+
+	if [ -n "${target}" ] ; then
+		# let user set options, otherwise leave empty
+		: ${options:=' '}
+	elif [ -n "${swap}" ] ; then
+		if cryptsetup isLuks ${source} 2>/dev/null ; then
+			ewarn "The swap you have defined is a LUKS partition. Aborting crypt-swap setup."
+			return
+		fi
+		target=${swap}
+		# swap contents do not need to be preserved between boots, luks not required.
+		# suspend2 users should have initramfs's init handling their swap partition either way.
+		: ${options:='-c aes -h sha1 -d /dev/urandom'}
+		: ${pre_mount:='mkswap ${dev}'}
+	fi
+
+	if [ -n "${loop_file}" ] ; then
+		dev="/dev/mapper/${target}"
+		ebegin "  Setting up loop device ${source}"
+		losetup ${source} ${loop_file}
+	fi
+
+	# cryptsetup:
+	# open   <device> <name>      # <device> is $source
+	# create <name>   <device>    # <name>   is $target
+	local arg1="create" arg2="${target}" arg3="${source}"
+	if cryptsetup isLuks ${source} 2>/dev/null ; then
+		arg1="open"
+		arg2="${source}"
+		arg3="${target}"
+	fi
+
+	# Older versions reported:
+	#	${target} is active:
+	# Newer versions report:
+	#	${target} is active[ and is in use.]
+	if cryptsetup status ${target} | egrep -q ' is active' ; then
+		einfo "dm-crypt mapping ${target} is already configured"
+		return
+	fi
+	splash svc_input_begin ${SVCNAME} >/dev/null 2>&1
+
+	# Handle keys
+	if [ -n "${key}" ] ; then
+		read_abort() {
+			# some colors
+			local ans savetty resettty
+			[ -z "${NORMAL}" ] && eval $(eval_ecolors)
+			einfon "  $1? (${WARN}yes${NORMAL}/${GOOD}No${NORMAL}) "
+			shift
+			# This is ugly as s**t.  But POSIX doesn't provide `read -t`, so
+			# we end up having to implement our own crap with stty/etc...
+			savetty=$(stty -g)
+			resettty='stty ${savetty}; trap - EXIT HUP INT TERM'
+			trap 'eval "${resettty}"' EXIT HUP INT TERM
+			stty -icanon
+			stty min 0 time "$(( $2 * 10 ))"
+			ans=$(dd count=1 bs=1 2>/dev/null) || ans=''
+			eval "${resettty}"
+			if [ -z "${ans}" ] ; then
+				printf '\r'
+			else
+				echo
+			fi
+			case ${ans} in
+				[yY]) return 0;;
+				*) return 1;;
+			esac
+		}
+
+		# Notes: sed not used to avoid case where /usr partition is encrypted.
+		mode=${key##*:} && ( [ "${mode}" = "${key}" ] || [ -z "${mode}" ] ) && mode=reg
+		key=${key%:*}
+		case "${mode}" in
+		gpg|reg)
+			# handle key on removable device
+			if [ -n "${remdev}" ] ; then
+				# temp directory to mount removable device
+				local mntrem="${RC_SVCDIR}/dm-crypt-remdev.$$"
+				if [ ! -d "${mntrem}" ] ; then
+					if ! mkdir -p "${mntrem}" ; then
+						ewarn "${source} will not be decrypted ..."
+						einfo "Reason: Unable to create temporary mount point '${mntrem}'"
+						return
+					fi
+				fi
+				i=0
+				einfo "Please insert removable device for ${target}"
+				while [ ${i} -lt ${dmcrypt_max_timeout} ] ; do
+					foo=""
+					if mount -n -o ro "${remdev}" "${mntrem}" 2>/dev/null >/dev/null ; then
+						# keyfile exists?
+						if [ ! -e "${mntrem}${key}" ] ; then
+							umount -n "${mntrem}"
+							rmdir "${mntrem}"
+							einfo "Cannot find ${key} on removable media."
+							read_abort "Abort" ${dmcrypt_key_timeout} && return
+						else
+							key="${mntrem}${key}"
+							break
+						fi
+					else
+						[ -e "${remdev}" ] \
+							&& foo="mount failed" \
+							|| foo="mount source not found"
+					fi
+					: $((i += 1))
+					read_abort "Stop waiting after $i attempts (${foo})" -t 1 && return
+				done
+			else    # keyfile ! on removable device
+				if [ ! -e "${key}" ] ; then
+					ewarn "${source} will not be decrypted ..."
+					einfo "Reason: keyfile ${key} does not exist."
+					return
+				fi
+			fi
+			;;
+		*)
+			ewarn "${source} will not be decrypted ..."
+			einfo "Reason: mode ${mode} is invalid."
+			return
+			;;
+		esac
+	else
+		mode=none
+	fi
+	ebegin "  ${target} using: ${options} ${arg1} ${arg2} ${arg3}"
+	if [ "${mode}" = "gpg" ] ; then
+		: ${gpg_options:='-q -d'}
+		# gpg available ?
+		if command -v gpg >/dev/null ; then
+			i=0
+			while [ ${i} -lt ${dmcrypt_retries} ] ; do
+				# paranoid, don't store key in a variable, pipe it so it stays very little in ram unprotected.
+				# save stdin stdout stderr "values"
+				timeout ${dmcrypt_max_timeout} gpg ${gpg_options} ${key} 2>/dev/null | \
+					cryptsetup --key-file - ${options} ${arg1} ${arg2} ${arg3}
+				ret=$?
+				# The timeout command exits 124 when it times out.
+				[ ${ret} -eq 0 -o ${ret} -eq 124 ] && break
+				: $(( i += 1 ))
+			done
+			eend ${ret} "failure running cryptsetup"
+		else
+			ewarn "${source} will not be decrypted ..."
+			einfo "Reason: cannot find gpg application."
+			einfo "You have to install app-crypt/gnupg first."
+			einfo "If you have /usr on its own partition, try copying gpg to /bin ."
+		fi
+	else
+		if [ "${mode}" = "reg" ] ; then
+			cryptsetup ${options} -d ${key} ${arg1} ${arg2} ${arg3}
+			ret=$?
+			eend ${ret} "failure running cryptsetup"
+		else
+			cryptsetup ${options} ${arg1} ${arg2} ${arg3}
+			ret=$?
+			eend ${ret} "failure running cryptsetup"
+		fi
+	fi
+	if [ -d "${mntrem}" ] ; then
+		umount -n ${mntrem} 2>/dev/null >/dev/null
+		rmdir ${mntrem} 2>/dev/null >/dev/null
+	fi
+	splash svc_input_end ${SVCNAME} >/dev/null 2>&1
+
+	if [ ${ret} -ne 0 ] ; then
+		cryptfs_status=1
+	else
+		if [ -n "${pre_mount}" ] ; then
+			dev="/dev/mapper/${target}"
+			eval ebegin \""    pre_mount: ${pre_mount}"\"
+			eval "${pre_mount}" > /dev/null
+			ewend $? || cryptfs_status=1
+		fi
+	fi
+}
+
+# Lookup optional bootparams
+get_bootparam_val() {
+	# We're given something like:
+	#    foo=bar=cow
+	# Return the "bar=cow" part.
+	case $1 in
+	*=*)
+		echo "${1#*=}"
+		;;
+	esac
+}
+
+start() {
+	local header=true cryptfs_status=0
+	local gpg_options key loop_file target targetline options pre_mount post_mount source swap remdev
+
+	local x
+	for x in $(cat /proc/cmdline) ; do
+		case "${x}" in
+		key_timeout=*)
+			dmcrypt_key_timeout=$(get_bootparam_val "${x}")
+			;;
+		esac
+	done
+
+	while read targetline <&3 ; do
+		case ${targetline} in
+		# skip comments and blank lines
+		""|"#"*) continue ;;
+		# skip service-specific openrc configs #377927
+		rc_*) continue ;;
+		esac
+
+		${header} && ebegin "Setting up dm-crypt mappings"
+		header=false
+
+		# check for the start of a new target/swap
+		case ${targetline} in
+		target=*|swap=*)
+			# If we have a target queued up, then execute it
+			dm_crypt_execute
+
+			# Prepare for the next target/swap by resetting variables
+			unset gpg_options key loop_file target options pre_mount post_mount source swap remdev wait
+			;;
+
+		gpg_options=*|remdev=*|key=*|loop_file=*|options=*|pre_mount=*|post_mount=*|wait=*|source=*)
+			if [ -z "${target}${swap}" ] ; then
+				ewarn "Ignoring setting outside target/swap section: ${targetline}"
+				continue
+			fi
+			;;
+
+		dmcrypt_*=*)
+			# ignore global options
+			continue
+			;;
+
+		*)
+			ewarn "Skipping invalid line in ${conf_file}: ${targetline}"
+			;;
+		esac
+
+		# Queue this setting for the next call to dm_crypt_execute
+		eval "${targetline}"
+	done 3< ${conf_file}
+
+	# If we have a target queued up, then execute it
+	dm_crypt_execute
+
+	ewend ${cryptfs_status} "Failed to setup dm-crypt devices"
+}
+
+stop() {
+	local line header
+
+	# Break down all mappings
+	header=true
+	egrep "^(target|swap)=" ${conf_file} | \
+	while read line ; do
+		${header} && einfo "Removing dm-crypt mappings"
+		header=false
+
+		target= swap=
+		eval ${line}
+
+		[ -n "${swap}" ] && target=${swap}
+		if [ -z "${target}" ] ; then
+			ewarn "invalid line in ${conf_file}: ${line}"
+			continue
+		fi
+
+		ebegin "  ${target}"
+		cryptsetup remove ${target}
+		eend $?
+	done
+
+	# Break down loop devices
+	header=true
+	grep '^source=./dev/loop' ${conf_file} | \
+	while read line ; do
+		${header} && einfo "Detaching dm-crypt loop devices"
+		header=false
+
+		source=
+		eval ${line}
+
+		ebegin "  ${source}"
+		losetup -d "${source}"
+		eend $?
+	done
+
+	return 0
+}


### PR DESCRIPTION
Devices that are primarily hotplug are commonly initialized little bit
later when init is already started. This can be either because they
require module or because they are just slow to initialize or because
they are just last in the line. No matter the reason the expectation
that source is always immediately available to open does not apply.

Real live example is all time plugged in SD card on some embedded
devices serving as extension storage. It is removable and thus it is
highly desirable to encrypt it but it is initialized asynchronously thus
it is not available immediately after boot.

This adds new argument `wait`. It is in default set to 5 seconds. It can
be set to zero for devices that are not expected to be present during
the boot process (although such usage seems to me like a hack). Any
other device should be present and thus wait is skipped or it benefits
from wait.

Signed-off-by: Karel Kočí <cynerd@email.cz>