### PR TITLE
media-plugins/vdr-*: pkgcheck fixes on misc. vdr plugins

### DIFF
--- a/media-plugins/vdr-actuator/vdr-actuator-1.2.1.ebuild
+++ b/media-plugins/vdr-actuator/vdr-actuator-1.2.1.ebuild
@@ -1,13 +1,13 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
 inherit vdr-plugin-2
 
-DESCRIPTION="VDR plugin: control an linear or horizon actuator attached trough the parallel port"
-HOMEPAGE="http://ventoso.org/luca/vdr/"
-SRC_URI="http://ventoso.org/luca/vdr/${P}.tgz"
+DESCRIPTION="VDR plugin: control a horz. or vert. actuator attached through the parallel port"
+HOMEPAGE="https://ventoso.org/luca/vdr/"
+SRC_URI="https://ventoso.org/luca/vdr/${P}.tgz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/media-plugins/vdr-actuator/vdr-actuator-2.4.1_pre20181025.ebuild
+++ b/media-plugins/vdr-actuator/vdr-actuator-2.4.1_pre20181025.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -7,8 +7,8 @@ inherit vdr-plugin-2
 
 GIT_VERSION="c810abffbf6dc6f1f354b0c545abe65311203fd8"
 
-DESCRIPTION="VDR plugin: control an hor. or ver. actuator attached trough the parallel port"
-HOMEPAGE="http://ventoso.org/luca/vdr/"
+DESCRIPTION="VDR plugin: control a horz. or vert. actuator attached through the parallel port"
+HOMEPAGE="https://ventoso.org/luca/vdr/"
 SRC_URI="https://github.com/olivluca/vdr-actuator-plugin/archive/${GIT_VERSION}.tar.gz -> ${PF}.tar.gz"
 
 LICENSE="GPL-2"

--- a/media-plugins/vdr-devstatus/vdr-devstatus-0.4.1-r1.ebuild
+++ b/media-plugins/vdr-devstatus/vdr-devstatus-0.4.1-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 Gentoo Authors
+# Copyright 2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -6,8 +6,8 @@ EAPI=7
 inherit vdr-plugin-2
 
 DESCRIPTION="VDR plugin: display the usage status of the available DVB devices"
-HOMEPAGE="http://www.u32.de/vdr.html"
-SRC_URI="http://www.u32.de/download/${P}.tgz"
+HOMEPAGE="https://www.u32.de/vdr.html"
+SRC_URI="https://www.u32.de/download/${P}.tgz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/media-plugins/vdr-epgsync/vdr-epgsync-1.0.1-r1.ebuild
+++ b/media-plugins/vdr-epgsync/vdr-epgsync-1.0.1-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -6,8 +6,8 @@ EAPI=7
 inherit vdr-plugin-2
 
 DESCRIPTION="VDR Plugin: Import the EPG of another VDR via vdr-svdrpservice"
-HOMEPAGE="http://vdr.schmirler.de/"
-SRC_URI="http://vdr.schmirler.de/epgsync/${P}.tgz"
+HOMEPAGE="https://vdr.schmirler.de/"
+SRC_URI="https://vdr.schmirler.de/epgsync/${P}.tgz"
 
 SLOT="0"
 LICENSE="GPL-2"

--- a/media-plugins/vdr-epgsync/vdr-epgsync-1.0.1.ebuild
+++ b/media-plugins/vdr-epgsync/vdr-epgsync-1.0.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -6,8 +6,8 @@ EAPI=7
 inherit vdr-plugin-2
 
 DESCRIPTION="VDR Plugin: Import the EPG of another VDR via vdr-svdrpservice"
-HOMEPAGE="http://vdr.schmirler.de/"
-SRC_URI="http://vdr.schmirler.de/epgsync/${P}.tgz"
+HOMEPAGE="https://vdr.schmirler.de/"
+SRC_URI="https://vdr.schmirler.de/epgsync/${P}.tgz"
 
 SLOT="0"
 LICENSE="GPL-2"

--- a/media-plugins/vdr-loadepg/vdr-loadepg-0.2.7.ebuild
+++ b/media-plugins/vdr-loadepg/vdr-loadepg-0.2.7.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -6,8 +6,9 @@ EAPI=7
 inherit vdr-plugin-2
 
 DESCRIPTION="VDR : Loadepg Plugin; Canal+ group (Mediahighway)"
-HOMEPAGE="http://lukkinosat.altervista.org/"
-SRC_URI="http://lukkinosat.altervista.org/${P}.tgz"
+HOMEPAGE="https://lukkinosat.altervista.org/"
+SRC_URI="https://lukkinosat.altervista.org/${P}.tgz"
+S="${WORKDIR}/${P}"
 
 KEYWORDS="~amd64 ~x86"
 SLOT="0"
@@ -15,8 +16,6 @@ LICENSE="GPL-2"
 
 DEPEND="media-video/vdr"
 RDEPEND="${DEPEND}"
-
-S="${WORKDIR}/${P}"
 
 src_prepare() {
 	# remove untranslated po files

--- a/media-plugins/vdr-mplayer/vdr-mplayer-0.10.2-r2.ebuild
+++ b/media-plugins/vdr-mplayer/vdr-mplayer-0.10.2-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -6,8 +6,8 @@ EAPI=7
 inherit vdr-plugin-2
 
 DESCRIPTION="VDR Plugin: Play video files not supported by VDR with mplayer (divx and more)"
-HOMEPAGE="http://www.muempf.de/"
-SRC_URI="http://www.muempf.de/down/vdr-mp3-${PV}.tar.gz"
+HOMEPAGE="https://www.muempf.de/"
+SRC_URI="https://www.muempf.de/down/vdr-mp3-${PV}.tar.gz"
 
 SLOT="0"
 LICENSE="GPL-2"

--- a/media-plugins/vdr-osdserver/vdr-osdserver-0.1.3.ebuild
+++ b/media-plugins/vdr-osdserver/vdr-osdserver-0.1.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -6,8 +6,8 @@ EAPI=7
 inherit vdr-plugin-2
 
 DESCRIPTION="VDR plugin: VDR OSD access for ext. programs through a TCP/IP socket connection"
-HOMEPAGE="http://www.udo-richter.de/vdr/osdserver.en.html"
-SRC_URI=" http://www.udo-richter.de/vdr/files/${P}.tgz"
+HOMEPAGE="https://www.udo-richter.de/vdr/osdserver.en.html"
+SRC_URI=" https://www.udo-richter.de/vdr/files/${P}.tgz"
 
 SLOT="0"
 LICENSE="GPL-2"

--- a/media-plugins/vdr-peer/vdr-peer-0.0.1.ebuild
+++ b/media-plugins/vdr-peer/vdr-peer-0.0.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -6,8 +6,8 @@ EAPI=7
 inherit vdr-plugin-2
 
 DESCRIPTION="VDR Plugin: peer-to-peer between multiple VDRs"
-HOMEPAGE="http://vdr.schmirler.de/"
-SRC_URI="http://vdr.schmirler.de/peer/${P}.tgz"
+HOMEPAGE="https://vdr.schmirler.de/"
+SRC_URI="https://vdr.schmirler.de/peer/${P}.tgz"
 
 SLOT="0"
 LICENSE="GPL-2"

--- a/media-plugins/vdr-remoteosd/vdr-remoteosd-1.0.0-r1.ebuild
+++ b/media-plugins/vdr-remoteosd/vdr-remoteosd-1.0.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -6,8 +6,8 @@ EAPI=7
 inherit vdr-plugin-2
 
 DESCRIPTION="VDR Plugin: server/client remoteosd"
-HOMEPAGE="http://vdr.schmirler.de/"
-SRC_URI="http://vdr.schmirler.de/remoteosd/${P}.tgz"
+HOMEPAGE="https://vdr.schmirler.de/"
+SRC_URI="https://vdr.schmirler.de/remoteosd/${P}.tgz"
 
 SLOT="0"
 LICENSE="GPL-2"

--- a/media-plugins/vdr-remoteosd/vdr-remoteosd-1.0.0.ebuild
+++ b/media-plugins/vdr-remoteosd/vdr-remoteosd-1.0.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -6,8 +6,8 @@ EAPI=7
 inherit vdr-plugin-2
 
 DESCRIPTION="VDR Plugin: server/client remoteosd"
-HOMEPAGE="http://vdr.schmirler.de/"
-SRC_URI="http://vdr.schmirler.de/remoteosd/${P}.tgz"
+HOMEPAGE="https://vdr.schmirler.de/"
+SRC_URI="https://vdr.schmirler.de/remoteosd/${P}.tgz"
 
 SLOT="0"
 LICENSE="GPL-2"

--- a/media-plugins/vdr-remotetimers/vdr-remotetimers-1.0.2-r1.ebuild
+++ b/media-plugins/vdr-remotetimers/vdr-remotetimers-1.0.2-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -6,8 +6,8 @@ EAPI=7
 inherit vdr-plugin-2
 
 DESCRIPTION="VDR plugin: edit timers on remote vdr instances"
-HOMEPAGE="http://vdr.schmirler.de/"
-SRC_URI="http://vdr.schmirler.de/${PN#vdr-}/${P}.tgz"
+HOMEPAGE="https://vdr.schmirler.de/"
+SRC_URI="https://vdr.schmirler.de/${PN#vdr-}/${P}.tgz"
 
 SLOT="0"
 LICENSE="GPL-2"

--- a/media-plugins/vdr-remotetimers/vdr-remotetimers-1.0.2.ebuild
+++ b/media-plugins/vdr-remotetimers/vdr-remotetimers-1.0.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -6,8 +6,8 @@ EAPI=7
 inherit vdr-plugin-2
 
 DESCRIPTION="VDR plugin: edit timers on remote vdr instances"
-HOMEPAGE="http://vdr.schmirler.de/"
-SRC_URI="http://vdr.schmirler.de/${PN#vdr-}/${P}.tgz"
+HOMEPAGE="https://vdr.schmirler.de/"
+SRC_URI="https://vdr.schmirler.de/${PN#vdr-}/${P}.tgz"
 
 SLOT="0"
 LICENSE="GPL-2"

--- a/media-plugins/vdr-svdrposd/vdr-svdrposd-1.0.0.ebuild
+++ b/media-plugins/vdr-svdrposd/vdr-svdrposd-1.0.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -6,8 +6,8 @@ EAPI=7
 inherit vdr-plugin-2
 
 DESCRIPTION="VDR plugin: export OSD via TCP to vdr-remoteosd"
-HOMEPAGE="http://vdr.schmirler.de/"
-SRC_URI="http://vdr.schmirler.de/svdrpext/${P}.tgz"
+HOMEPAGE="https://vdr.schmirler.de/"
+SRC_URI="https://vdr.schmirler.de/svdrposd/${P}.tgz"
 
 SLOT="0"
 LICENSE="GPL-2"

--- a/media-plugins/vdr-svdrpservice/vdr-svdrpservice-1.0.0-r1.ebuild
+++ b/media-plugins/vdr-svdrpservice/vdr-svdrpservice-1.0.0-r1.ebuild
@@ -6,8 +6,8 @@ EAPI=7
 inherit vdr-plugin-2
 
 DESCRIPTION="VDR Plugin: offers SVDRP connections as a service to other plugins"
-HOMEPAGE="http://vdr.schmirler.de/"
-SRC_URI="http://vdr.schmirler.de/svdrpservice/${P}.tgz"
+HOMEPAGE="https://vdr.schmirler.de/"
+SRC_URI="https://vdr.schmirler.de/svdrpservice/${P}.tgz"
 
 SLOT="0"
 LICENSE="GPL-2"

--- a/media-plugins/vdr-svdrpservice/vdr-svdrpservice-1.0.0.ebuild
+++ b/media-plugins/vdr-svdrpservice/vdr-svdrpservice-1.0.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -6,8 +6,8 @@ EAPI=5
 inherit vdr-plugin-2
 
 DESCRIPTION="VDR Plugin: offers SVDRP connections as a service to other plugins"
-HOMEPAGE="http://vdr.schmirler.de/"
-SRC_URI="http://vdr.schmirler.de/svdrpservice/${P}.tgz"
+HOMEPAGE="https://vdr.schmirler.de/"
+SRC_URI="https://vdr.schmirler.de/svdrpservice/${P}.tgz"
 
 SLOT="0"
 LICENSE="GPL-2"

--- a/media-plugins/vdr-vompserver/vdr-vompserver-0.4.1-r1.ebuild
+++ b/media-plugins/vdr-vompserver/vdr-vompserver-0.4.1-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -6,8 +6,8 @@ EAPI=6
 inherit vdr-plugin-2
 
 DESCRIPTION="VDR Plugin: server part for MediaMVP device"
-HOMEPAGE="http://www.loggytronic.com/vomp.php"
-SRC_URI="http://www.loggytronic.com/dl/${P}.tgz"
+HOMEPAGE="https://www.loggytronic.com/vomp.php"
+SRC_URI="https://www.loggytronic.com/dl/${P}.tgz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/media-plugins/vdr-vompserver/vdr-vompserver-0.4.1.ebuild
+++ b/media-plugins/vdr-vompserver/vdr-vompserver-0.4.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -6,8 +6,8 @@ EAPI=7
 inherit vdr-plugin-2
 
 DESCRIPTION="VDR Plugin: server part for MediaMVP device"
-HOMEPAGE="http://www.loggytronic.com/vomp.php"
-SRC_URI="http://www.loggytronic.com/dl/${P}.tgz"
+HOMEPAGE="https://www.loggytronic.com/vomp.php"
+SRC_URI="https://www.loggytronic.com/dl/${P}.tgz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/media-plugins/vdr-vompserver/vdr-vompserver-0.5.1.ebuild
+++ b/media-plugins/vdr-vompserver/vdr-vompserver-0.5.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -6,8 +6,8 @@ EAPI=7
 inherit vdr-plugin-2
 
 DESCRIPTION="VDR Plugin: server part for MediaMVP device"
-HOMEPAGE="http://www.loggytronic.com/vomp.php"
-SRC_URI="http://www.loggytronic.com/dl/${P}.tgz"
+HOMEPAGE="https://www.loggytronic.com/vomp.php"
+SRC_URI="https://www.loggytronic.com/dl/${P}.tgz"
 
 LICENSE="GPL-2"
 SLOT="0"


### PR DESCRIPTION
fix some packages where pkgcheck reports `HttpsUrlAvailable`, and update their copyright headers