### PR TITLE
media-radio/qsstv: Allow apulse as pulseaudio replacement

### DIFF
--- a/media-radio/qsstv/qsstv-9.5.3.ebuild
+++ b/media-radio/qsstv/qsstv-9.5.3.ebuild
@@ -24,9 +24,12 @@ CDEPEND="dev-qt/qtcore:5
 	media-libs/hamlib:=
 	media-libs/openjpeg:2
 	media-libs/alsa-lib
-	media-sound/pulseaudio
 	media-libs/libv4l
-	sci-libs/fftw:3.0="
+	sci-libs/fftw:3.0=
+	|| (
+		media-sound/pulseaudio
+		media-sound/apulse[sdk]
+	)"
 DEPEND="${CDEPEND}
 	virtual/pkgconfig"
 RDEPEND="${CDEPEND}

--- a/media-radio/qsstv/qsstv-9.5.8.ebuild
+++ b/media-radio/qsstv/qsstv-9.5.8.ebuild
@@ -24,9 +24,12 @@ CDEPEND="dev-qt/qtcore:5
 	media-libs/hamlib:=
 	media-libs/openjpeg:2
 	media-libs/alsa-lib
-	media-sound/pulseaudio
 	media-libs/libv4l
-	sci-libs/fftw:3.0="
+	sci-libs/fftw:3.0=
+	|| (
+		media-sound/pulseaudio
+		media-sound/apulse[sdk]
+	)"
 DEPEND="${CDEPEND}
 	virtual/pkgconfig"
 RDEPEND="${CDEPEND}


### PR DESCRIPTION
This patch allows to build QSSTV with USE="-pulseaudio".

Since I'm not the maintainer of the package I would like @dl1jbe to review and hopefully approve this patch.

Package-Manager: Portage-3.0.20, Repoman-3.0.3
Signed-off-by: Mario Haustein <mario.haustein@hrz.tu-chemnitz.de>