### PR TITLE
sys-libs/newlib: fix `libm_nano.a` installation

### DIFF
--- a/sys-libs/newlib/newlib-4.1.0.ebuild
+++ b/sys-libs/newlib/newlib-4.1.0.ebuild
@@ -136,7 +136,7 @@ src_install() {
 		emake -j1 DESTDIR="${NEWLIBNANOTMPINSTALL}" install
 		# Rename nano lib* files to lib*_nano and move to the real ${D}
 		local nanolibfiles=""
-		nanolibfiles=$(find "${NEWLIBNANOTMPINSTALL}" -regex ".*/lib\(c\|g\|rdimon\)\.a" -print)
+		nanolibfiles=$(find "${NEWLIBNANOTMPINSTALL}" -regex ".*/lib\(c\|g\|m\|rdimon\)\.a" -print)
 		for f in ${nanolibfiles}; do
 			local l="${f##${NEWLIBNANOTMPINSTALL}}"
 			mv -v "${f}" "${D}/${l%%\.a}_nano.a" || die


### PR DESCRIPTION
Add `libm_nano.a` installation in case of `nano` USE flag on, as it's now required in `nano.specs` for RISC V targets, in particular. Currently it leads to toolchain sanity check failure when using C++ compiler (apparently it links to `libm` implicitly).

See also:
riscv/riscv-newlib@f289cef6be67da67b2d97a47d6576fa7e6b4c858
riscv/riscv-gnu-toolchain@2922650dd095747b07d6ced1b746d1faae07a01c

Signed-off-by: Alexey Chernov <4ernov@gmail.com>