### PR TITLE
games-engines/devilutionx: use dynamic linking (fixes libsodium build)

### DIFF
--- a/games-engines/devilutionx/devilutionx-1.2.1-r1.ebuild
+++ b/games-engines/devilutionx/devilutionx-1.2.1-r1.ebuild
@@ -50,7 +50,9 @@ src_configure() {
 		-DASAN="OFF"
 		-DDEBUG="$(usex debug)"
 		-DDISABLE_LTO="$(usex !lto)"
-		-DDIST="ON"
+		# Must be off to force dynamic linking.
+		# See bug #791031
+		-DDIST="OFF"
 		-DUBSAN="OFF"
 	)
 

--- a/games-engines/devilutionx/devilutionx-1.2.1-r1.ebuild
+++ b/games-engines/devilutionx/devilutionx-1.2.1-r1.ebuild
@@ -28,7 +28,7 @@ SLOT="0"
 IUSE="debug lto"
 
 RDEPEND="
-	dev-libs/libsodium
+	dev-libs/libsodium:=
 	media-fonts/sil-charis
 	media-libs/libsdl2[haptic]
 	media-libs/sdl2-mixer

--- a/games-engines/devilutionx/devilutionx-9999.ebuild
+++ b/games-engines/devilutionx/devilutionx-9999.ebuild
@@ -50,7 +50,9 @@ src_configure() {
 		-DASAN="OFF"
 		-DDEBUG="$(usex debug)"
 		-DDISABLE_LTO="$(usex !lto)"
-		-DDIST="ON"
+		# Must be off to force dynamic linking.
+		# See bug #791031
+		-DDIST="OFF"
 		-DUBSAN="OFF"
 	)
 

--- a/games-engines/devilutionx/devilutionx-9999.ebuild
+++ b/games-engines/devilutionx/devilutionx-9999.ebuild
@@ -28,7 +28,7 @@ SLOT="0"
 IUSE="debug lto"
 
 RDEPEND="
-	dev-libs/libsodium
+	dev-libs/libsodium:=
 	media-fonts/sil-charis
 	media-libs/libsdl2[haptic]
 	media-libs/sdl2-mixer


### PR DESCRIPTION
```-DDIST``` controls whether devilutionx links dynamically to libraries
(only SDL 2 and glibc are linked dynamically otherwise).

For later versions of libsodium, FindSodium.cmake malfunctions and
does not correctly populate all the needed variables. For Gentoo's
purposes, we can ignore this problem, and instead force dynamic
linking (which is policy anyway).

A fix to use a supported method to detect libsodium (pkg-config)
is being pursued upstream.

Bug: https://github.com/diasurgical/devilutionX/issues/2615
Closes: https://bugs.gentoo.org/791031
Signed-off-by: Sam James <sam@gentoo.org>