### PR TITLE
sys-kernel/dracut: fix usr mount regression

### DIFF
--- a/sys-kernel/dracut/dracut-055-r2.ebuild
+++ b/sys-kernel/dracut/dracut-055-r2.ebuild
@@ -62,6 +62,7 @@ QA_MULTILIB_PATHS="usr/lib/dracut/.*"
 PATCHES=(
 	"${FILESDIR}"/055-fix-crypt-remove-quotes-from-cryptsetupopts.patch
 	"${FILESDIR}"/055-fix-base-do-not-quote-initargs-for-switch_root.patch
+	"${FILESDIR}"/055-fix-usrmount-do-not-empty-_dev-variable.patch
 	"${FILESDIR}"/gentoo-ldconfig-paths-r1.patch
 )
 

--- a/sys-kernel/dracut/files/055-fix-usrmount-do-not-empty-_dev-variable.patch
+++ b/sys-kernel/dracut/files/055-fix-usrmount-do-not-empty-_dev-variable.patch
@@ -1,0 +1,36 @@
+From 4afdcba212793f136aea012b30dd7bdb5b641a5a Mon Sep 17 00:00:00 2001
+From: Alexander Tsoy <alexander@tsoy.me>
+Date: Mon, 16 Aug 2021 18:54:34 +0300
+Subject: [PATCH] fix(usrmount): do not empty _dev variable
+
+Currently $_dev is always overridden with the value returned by
+label_uuid_to_dev(). This results in an empty value if $_dev is a
+device path. Fix this by calling label_uuid_to_dev() conditionally.
+
+Bug: https://bugs.gentoo.org/807971
+Fixes: d3532978de04c78f53664dad7b37705a49a7ee54
+---
+ modules.d/98usrmount/mount-usr.sh | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/modules.d/98usrmount/mount-usr.sh b/modules.d/98usrmount/mount-usr.sh
+index 23ed06aa..c8e1893b 100755
+--- a/modules.d/98usrmount/mount-usr.sh
++++ b/modules.d/98usrmount/mount-usr.sh
+@@ -55,7 +55,12 @@ mount_usr() {
+     while read -r _dev _mp _fs _opts _freq _passno || [ -n "$_dev" ]; do
+         [ "${_dev%%#*}" != "$_dev" ] && continue
+         if [ "$_mp" = "/usr" ]; then
+-            _dev="$(label_uuid_to_dev "$_dev")"
++            case "$_dev" in
++                LABEL=* | UUID=* | PARTUUID=* | PARTLABEL=*)
++                    _dev="$(label_uuid_to_dev "$_dev")"
++                    ;;
++                *) ;;
++            esac
+ 
+             if strstr "$_opts" "subvol=" \
+                 && [ "${root#block:}" -ef "$_dev" ] \
+-- 
+2.31.1
+


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/807971