### PR TITLE
net-misc/tmate-ssh-server: new package

### DIFF
--- a/games-roguelike/angband/angband-4.2.2-r1.ebuild
+++ b/games-roguelike/angband/angband-4.2.2-r1.ebuild
@@ -12,7 +12,7 @@ SRC_URI="https://github.com/angband/angband/archive/refs/tags/${PV}.tar.gz -> ${
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~riscv ~x86"
 IUSE="+ncurses sdl sound +X"
 
 REQUIRED_USE="sound? ( sdl )

--- a/games-roguelike/nethack/nethack-3.6.6.ebuild
+++ b/games-roguelike/nethack/nethack-3.6.6.ebuild
@@ -11,7 +11,7 @@ SRC_URI="https://nethack.org/download/${PV}/nethack-${PV//.}-src.tgz -> ${P}.tar
 
 LICENSE="nethack"
 SLOT="0"
-KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~riscv ~x86"
 IUSE="X"
 
 RDEPEND="

--- a/kde-apps/ark/ark-21.08.1.ebuild
+++ b/kde-apps/ark/ark-21.08.1.ebuild
@@ -15,7 +15,7 @@ HOMEPAGE="https://apps.kde.org/ark/ https://utils.kde.org/projects/ark/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"
-KEYWORDS="~amd64 ~arm64 ~ppc64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="zip"
 
 RDEPEND="

--- a/kde-apps/baloo-widgets/baloo-widgets-21.08.1.ebuild
+++ b/kde-apps/baloo-widgets/baloo-widgets-21.08.1.ebuild
@@ -12,7 +12,7 @@ DESCRIPTION="Widget library for baloo"
 
 LICENSE="LGPL-2+ LGPL-2.1+ || ( LGPL-2.1 LGPL-3 )"
 SLOT="5"
-KEYWORDS="~amd64 ~arm64 ~ppc64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 DEPEND="

--- a/kde-apps/dolphin-plugins-git/dolphin-plugins-git-21.08.1.ebuild
+++ b/kde-apps/dolphin-plugins-git/dolphin-plugins-git-21.08.1.ebuild
@@ -16,7 +16,7 @@ HOMEPAGE="https://apps.kde.org/dolphin_plugins/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"
-KEYWORDS="~amd64 ~arm64 ~ppc64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 DEPEND="

--- a/kde-apps/dolphin-plugins-mercurial/dolphin-plugins-mercurial-21.08.1.ebuild
+++ b/kde-apps/dolphin-plugins-mercurial/dolphin-plugins-mercurial-21.08.1.ebuild
@@ -16,7 +16,7 @@ HOMEPAGE="https://apps.kde.org/dolphin_plugins/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"
-KEYWORDS="~amd64 ~arm64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~riscv ~x86"
 IUSE=""
 
 DEPEND="

--- a/kde-apps/dolphin-plugins-subversion/dolphin-plugins-subversion-21.08.1.ebuild
+++ b/kde-apps/dolphin-plugins-subversion/dolphin-plugins-subversion-21.08.1.ebuild
@@ -16,7 +16,7 @@ HOMEPAGE="https://apps.kde.org/dolphin_plugins/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"
-KEYWORDS="~amd64 ~arm64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~riscv ~x86"
 IUSE=""
 
 DEPEND="

--- a/kde-apps/dolphin/dolphin-21.08.1.ebuild
+++ b/kde-apps/dolphin/dolphin-21.08.1.ebuild
@@ -16,7 +16,7 @@ HOMEPAGE="https://apps.kde.org/dolphin/ https://userbase.kde.org/Dolphin"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"
-KEYWORDS="~amd64 ~arm64 ~ppc64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="activities semantic-desktop telemetry"
 
 DEPEND="

--- a/kde-apps/kate/kate-21.08.1.ebuild
+++ b/kde-apps/kate/kate-21.08.1.ebuild
@@ -15,7 +15,7 @@ HOMEPAGE="https://kate-editor.org/ https://apps.kde.org/kate/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"
-KEYWORDS="~amd64 ~arm64 ~ppc64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="activities +filebrowser lspclient +projects plasma +snippets sql telemetry"
 
 # only addons/externaltools depends on kiconthemes, too small for USE

--- a/kde-apps/kcron/kcron-21.08.1.ebuild
+++ b/kde-apps/kcron/kcron-21.08.1.ebuild
@@ -13,7 +13,7 @@ HOMEPAGE="https://apps.kde.org/kcron/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"
-KEYWORDS="~amd64 ~arm64 ~ppc64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 DEPEND="

--- a/kde-apps/kfind/kfind-21.08.1.ebuild
+++ b/kde-apps/kfind/kfind-21.08.1.ebuild
@@ -13,7 +13,7 @@ HOMEPAGE="https://apps.kde.org/kfind/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"
-KEYWORDS="~amd64 ~arm64 ~ppc64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND="

--- a/kde-apps/kidentitymanagement/kidentitymanagement-21.08.1.ebuild
+++ b/kde-apps/kidentitymanagement/kidentitymanagement-21.08.1.ebuild
@@ -14,7 +14,7 @@ DESCRIPTION="Library for managing identitites"
 
 LICENSE="GPL-2+ LGPL-2.1+"
 SLOT="5"
-KEYWORDS="~amd64 ~arm64 ~ppc64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 DEPEND="

--- a/kde-apps/kompare/kompare-21.08.1.ebuild
+++ b/kde-apps/kompare/kompare-21.08.1.ebuild
@@ -14,7 +14,7 @@ HOMEPAGE="https://apps.kde.org/kompare/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"
-KEYWORDS="~amd64 ~arm64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~riscv ~x86"
 IUSE=""
 
 DEPEND="

--- a/kde-apps/kopete/kopete-21.08.1.ebuild
+++ b/kde-apps/kopete/kopete-21.08.1.ebuild
@@ -15,7 +15,7 @@ HOMEPAGE="https://apps.kde.org/kopete/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"
-KEYWORDS="~amd64 ~arm64 ~ppc64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="ssl v4l"
 
 # Available plugins

--- a/kde-apps/kpimtextedit/kpimtextedit-21.08.1.ebuild
+++ b/kde-apps/kpimtextedit/kpimtextedit-21.08.1.ebuild
@@ -14,7 +14,7 @@ DESCRIPTION="Extended text editor for PIM applications"
 
 LICENSE="LGPL-2.1+"
 SLOT="5"
-KEYWORDS="~amd64 ~arm64 ~ppc64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RESTRICT="test"

--- a/kde-apps/krdc/krdc-21.08.1.ebuild
+++ b/kde-apps/krdc/krdc-21.08.1.ebuild
@@ -13,7 +13,7 @@ HOMEPAGE="https://apps.kde.org/krdc/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"
-KEYWORDS="~amd64 ~arm64 ~ppc64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="+rdp +vnc"
 
 #nx? ( >=net-misc/nxcl-0.9-r1 ) disabled upstream, last checked 2016-01-24

--- a/kde-apps/krfb/krfb-21.08.1.ebuild
+++ b/kde-apps/krfb/krfb-21.08.1.ebuild
@@ -13,7 +13,7 @@ HOMEPAGE="https://apps.kde.org/krfb/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"
-KEYWORDS="~amd64 ~arm64 ~ppc64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="wayland"
 
 DEPEND="

--- a/kde-apps/ksystemlog/ksystemlog-21.08.1.ebuild
+++ b/kde-apps/ksystemlog/ksystemlog-21.08.1.ebuild
@@ -15,7 +15,7 @@ HOMEPAGE="https://apps.kde.org/ksystemlog/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"
-KEYWORDS="~amd64 ~arm64 ~ppc64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="audit kdesu systemd"
 
 DEPEND="

--- a/kde-apps/ktp-approver/ktp-approver-21.08.1.ebuild
+++ b/kde-apps/ktp-approver/ktp-approver-21.08.1.ebuild
@@ -13,7 +13,7 @@ HOMEPAGE="https://community.kde.org/KTp"
 
 LICENSE="LGPL-2.1"
 SLOT="5"
-KEYWORDS="~amd64 ~arm64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~riscv ~x86"
 IUSE=""
 
 DEPEND="

--- a/kde-apps/ktp-common-internals/ktp-common-internals-21.08.1.ebuild
+++ b/kde-apps/ktp-common-internals/ktp-common-internals-21.08.1.ebuild
@@ -14,7 +14,7 @@ HOMEPAGE="https://community.kde.org/KTp"
 
 LICENSE="LGPL-2.1"
 SLOT="5"
-KEYWORDS="~amd64 ~arm64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~riscv ~x86"
 IUSE="otr +sso"
 
 RDEPEND="

--- a/kde-apps/ktp-contact-list/ktp-contact-list-21.08.1.ebuild
+++ b/kde-apps/ktp-contact-list/ktp-contact-list-21.08.1.ebuild
@@ -13,7 +13,7 @@ HOMEPAGE="https://community.kde.org/KTp"
 
 LICENSE="GPL-2"
 SLOT="5"
-KEYWORDS="~amd64 ~arm64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND="

--- a/kde-apps/libkleo/libkleo-21.08.1.ebuild
+++ b/kde-apps/libkleo/libkleo-21.08.1.ebuild
@@ -13,7 +13,7 @@ DESCRIPTION="Library for encryption handling"
 
 LICENSE="GPL-2+"
 SLOT="5"
-KEYWORDS="~amd64 ~arm64 ~ppc64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="+fancyviewer"
 
 RDEPEND="

--- a/kde-apps/libkomparediff2/libkomparediff2-21.08.1.ebuild
+++ b/kde-apps/libkomparediff2/libkomparediff2-21.08.1.ebuild
@@ -12,7 +12,7 @@ DESCRIPTION="KDE library to compare files and strings"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"
-KEYWORDS="~amd64 ~arm64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~riscv ~x86"
 IUSE=""
 
 DEPEND="

--- a/kde-frameworks/kcontacts/kcontacts-5.85.0.ebuild
+++ b/kde-frameworks/kcontacts/kcontacts-5.85.0.ebuild
@@ -11,7 +11,7 @@ inherit ecm kde.org
 
 DESCRIPTION="Address book API based on KDE Frameworks"
 LICENSE="GPL-2+"
-KEYWORDS="~amd64 ~arm64 ~ppc64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 DEPEND="

--- a/media-libs/sdl2-image/sdl2-image-2.0.5_p20210328.ebuild
+++ b/media-libs/sdl2-image/sdl2-image-2.0.5_p20210328.ebuild
@@ -12,7 +12,7 @@ SRC_URI="https://github.com/libsdl-org/SDL_image/archive/${MY_COMMIT}.tar.gz -> 
 
 LICENSE="ZLIB"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ppc ~ppc64 sparc x86"
+KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ppc ~ppc64 ~riscv sparc x86"
 IUSE="gif jpeg png static-libs tiff webp"
 
 RDEPEND="

--- a/media-libs/sdl2-mixer/sdl2-mixer-2.0.4-r1.ebuild
+++ b/media-libs/sdl2-mixer/sdl2-mixer-2.0.4-r1.ebuild
@@ -12,7 +12,7 @@ SRC_URI="https://www.libsdl.org/projects/SDL_mixer/release/${MY_P}.tar.gz"
 
 LICENSE="ZLIB"
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~riscv ~sparc ~x86"
 IUSE="flac fluidsynth mad midi mikmod mod modplug mp3 opus playtools static-libs timidity tremor vorbis +wav"
 REQUIRED_USE="
 	midi? ( || ( timidity fluidsynth ) )

--- a/media-libs/sdl2-ttf/sdl2-ttf-2.0.15.ebuild
+++ b/media-libs/sdl2-ttf/sdl2-ttf-2.0.15.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ SRC_URI="http://www.libsdl.org/projects/SDL_ttf/release/${MY_P}.tar.gz"
 
 LICENSE="ZLIB"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ppc ~ppc64 sparc x86"
+KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ppc ~ppc64 ~riscv sparc x86"
 IUSE="static-libs X"
 
 RDEPEND="X? ( >=x11-libs/libXt-1.1.4[${MULTILIB_USEDEP}] )

--- a/media-sound/timidity++/timidity++-2.15.0-r1.ebuild
+++ b/media-sound/timidity++/timidity++-2.15.0-r1.ebuild
@@ -15,7 +15,7 @@ S="${WORKDIR}/${MY_P}"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 arm arm64 ~hppa ppc ppc64 sparc x86"
+KEYWORDS="amd64 arm arm64 ~hppa ppc ppc64 ~riscv sparc x86"
 IUSE="alsa ao emacs flac gtk jack motif nas ncurses oss selinux slang speex tk vorbis X"
 
 REQUIRED_USE="tk? ( X )"

--- a/media-video/mpv/mpv-0.33.1-r1.ebuild
+++ b/media-video/mpv/mpv-0.33.1-r1.ebuild
@@ -16,7 +16,7 @@ HOMEPAGE="https://mpv.io/ https://github.com/mpv-player/mpv"
 
 if [[ ${PV} != *9999* ]]; then
 	SRC_URI="https://github.com/mpv-player/mpv/archive/v${PV}.tar.gz -> ${P}.tar.gz"
-	KEYWORDS="~alpha amd64 ~arm ~arm64 ~hppa ppc ppc64 x86 ~amd64-linux"
+	KEYWORDS="~alpha amd64 ~arm ~arm64 ~hppa ppc ppc64 ~riscv x86 ~amd64-linux"
 	DOCS=( RELEASE_NOTES )
 else
 	EGIT_REPO_URI="https://github.com/mpv-player/mpv.git"

--- a/media-video/mpv/mpv-9999.ebuild
+++ b/media-video/mpv/mpv-9999.ebuild
@@ -16,7 +16,7 @@ HOMEPAGE="https://mpv.io/ https://github.com/mpv-player/mpv"
 
 if [[ ${PV} != *9999* ]]; then
 	SRC_URI="https://github.com/mpv-player/mpv/archive/v${PV}.tar.gz -> ${P}.tar.gz"
-	KEYWORDS="~alpha amd64 ~arm ~arm64 ~hppa ppc ppc64 x86 ~amd64-linux"
+	KEYWORDS="~alpha amd64 ~arm ~arm64 ~hppa ppc ppc64 ~riscv x86 ~amd64-linux"
 	DOCS=( RELEASE_NOTES )
 else
 	EGIT_REPO_URI="https://github.com/mpv-player/mpv.git"

--- a/media-video/transcode/transcode-1.1.7-r6.ebuild
+++ b/media-video/transcode/transcode-1.1.7-r6.ebuild
@@ -12,7 +12,7 @@ SRC_URI="https://www.bitbucket.org/france/${PN}-tcforge/downloads/${P}.tar.bz2
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~alpha amd64 ~arm64 ppc ppc64 sparc x86"
+KEYWORDS="~alpha amd64 ~arm64 ppc ppc64 ~riscv sparc x86"
 IUSE="cpu_flags_x86_3dnow a52 aac alsa altivec dv dvd +iconv imagemagick jpeg lzo mjpeg cpu_flags_x86_mmx mp3 mpeg nuv ogg oss pic postproc quicktime sdl cpu_flags_x86_sse cpu_flags_x86_sse2 theora truetype v4l vorbis X x264 xml xvid"
 
 RDEPEND="

--- a/media-video/xine-ui/xine-ui-0.99.12.ebuild
+++ b/media-video/xine-ui/xine-ui-0.99.12.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -11,7 +11,7 @@ SRC_URI="mirror://sourceforge/xine/${P}.tar.xz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 ~hppa ppc ppc64 x86"
+KEYWORDS="amd64 ~hppa ppc ppc64 ~riscv x86"
 IUSE="aalib curl debug libcaca lirc nls readline vdr X xinerama"
 
 RDEPEND="

--- a/net-im/telepathy-logger/telepathy-logger-0.8.2-r1.ebuild
+++ b/net-im/telepathy-logger/telepathy-logger-0.8.2-r1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://telepathy.freedesktop.org/releases/${PN}/${P}.tar.bz2
 
 LICENSE="LGPL-2.1+"
 SLOT="0/3"
-KEYWORDS="~alpha amd64 ~arm arm64 ~ia64 ~ppc ~ppc64 ~sparc x86 ~x86-linux"
+KEYWORDS="~alpha amd64 ~arm arm64 ~ia64 ~ppc ~ppc64 ~riscv ~sparc x86 ~x86-linux"
 IUSE="+introspection"
 
 RDEPEND="

--- a/net-im/telepathy-mission-control/telepathy-mission-control-5.16.6.ebuild
+++ b/net-im/telepathy-mission-control/telepathy-mission-control-5.16.6.ebuild
@@ -12,7 +12,7 @@ SRC_URI="https://telepathy.freedesktop.org/releases/${PN}/${P}.tar.gz"
 
 LICENSE="LGPL-2.1+"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 ~ia64 ppc ppc64 sparc x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~alpha amd64 arm arm64 ~ia64 ppc ppc64 ~riscv sparc x86 ~amd64-linux ~x86-linux"
 IUSE="debug networkmanager"
 
 RDEPEND="

--- a/net-libs/libsignon-glib/libsignon-glib-2.1.ebuild
+++ b/net-libs/libsignon-glib/libsignon-glib-2.1.ebuild
@@ -12,7 +12,7 @@ SRC_URI="https://gitlab.com/accounts-sso/${PN}/-/archive/VERSION_${PV}/${PN}-VER
 
 LICENSE="LGPL-2.1"
 SLOT="0"
-KEYWORDS="amd64 arm64 x86"
+KEYWORDS="amd64 arm64 ~riscv x86"
 IUSE="debug doc +introspection python test"
 
 REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} introspection )"

--- a/net-libs/telepathy-accounts-signon/telepathy-accounts-signon-2.1.ebuild
+++ b/net-libs/telepathy-accounts-signon/telepathy-accounts-signon-2.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ SRC_URI="https://gitlab.com/accounts-sso/${PN}/-/archive/${PV}/${P}.tar.bz2"
 
 LICENSE="LGPL-2.1"
 SLOT="0"
-KEYWORDS="amd64 arm64 x86"
+KEYWORDS="amd64 arm64 ~riscv x86"
 IUSE=""
 
 DEPEND="

--- a/net-libs/telepathy-farstream/telepathy-farstream-0.6.2.ebuild
+++ b/net-libs/telepathy-farstream/telepathy-farstream-0.6.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
@@ -12,7 +12,7 @@ SRC_URI="https://telepathy.freedesktop.org/releases/${PN}/${P}.tar.gz"
 
 LICENSE="LGPL-2.1"
 SLOT="0/3"
-KEYWORDS="~alpha amd64 ~arm arm64 ~ia64 ~ppc ~ppc64 x86"
+KEYWORDS="~alpha amd64 ~arm arm64 ~ia64 ~ppc ~ppc64 ~riscv x86"
 IUSE="examples +introspection"
 
 RDEPEND="

--- a/net-libs/telepathy-glib/telepathy-glib-0.24.2.ebuild
+++ b/net-libs/telepathy-glib/telepathy-glib-0.24.2.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://telepathy.freedesktop.org/releases/${PN}/${P}.tar.gz"
 
 LICENSE="LGPL-2.1+"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 ~ia64 ppc ppc64 sparc x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~alpha amd64 arm arm64 ~ia64 ppc ppc64 ~riscv sparc x86 ~amd64-linux ~x86-linux"
 
 IUSE="debug +introspection +vala"
 REQUIRED_USE="vala? ( introspection )"

--- a/net-libs/telepathy-logger-qt/telepathy-logger-qt-17.09.0.ebuild
+++ b/net-libs/telepathy-logger-qt/telepathy-logger-qt-17.09.0.ebuild
@@ -12,7 +12,7 @@ HOMEPAGE="https://invent.kde.org/network/telepathy-logger-qt"
 
 if [[ ${KDE_BUILD_TYPE} = release ]]; then
 	SRC_URI="mirror://kde/stable/telepathy-logger-qt/${PV%.*}/src/${P}.tar.xz"
-	KEYWORDS="amd64 arm64 x86"
+	KEYWORDS="amd64 arm64 ~riscv x86"
 fi
 
 LICENSE="LGPL-2.1"

--- a/net-libs/telepathy-qt/telepathy-qt-0.9.8.ebuild
+++ b/net-libs/telepathy-qt/telepathy-qt-0.9.8.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -12,7 +12,7 @@ SRC_URI="https://telepathy.freedesktop.org/releases/${PN}/${P}.tar.gz"
 
 LICENSE="LGPL-2.1"
 SLOT="0"
-KEYWORDS="amd64 ~arm arm64 x86"
+KEYWORDS="amd64 ~arm arm64 ~riscv x86"
 IUSE="debug farstream test"
 
 REQUIRED_USE="test? ( farstream )"

--- a/net-libs/telepathy-qt/telepathy-qt-9999.ebuild
+++ b/net-libs/telepathy-qt/telepathy-qt-9999.ebuild
@@ -10,7 +10,7 @@ if [[ ${PV} = *9999* ]]; then
 	inherit git-r3
 else
 	SRC_URI="https://telepathy.freedesktop.org/releases/${PN}/${P}.tar.gz"
-	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~riscv ~x86"
 fi
 inherit python-any-r1 cmake virtualx
 


### PR DESCRIPTION
Signed-off-by: Alex Fan <alexfanqi@yahoo.com>

It works for me on amd64 and riscv.

It includes systemd and openrc service file. But it will require user to set specificly certain config variables to work.

In pkg_preinst phase, it will generate RSA and ED25519 keys in /etc/tmate-ssh-server

There is one optional dependency on utempter. The build system will use it if it is found. 
I am not sure how to make it a USE flag to optionally hide utempter from the build system though.