### PR TITLE
media-sound/pulseaudio: fixes unifdef failure

### DIFF
--- a/media-sound/pulseaudio/pulseaudio-15.0.ebuild
+++ b/media-sound/pulseaudio/pulseaudio-15.0.ebuild
@@ -268,7 +268,7 @@ multilib_src_install_all() {
 			use "${1}" && echo "-D${define}" || echo "-U${define}"
 		}
 
-		unifdef \
+		unifdef -x 1 \
 			$(use_define zeroconf AVAHI) \
 			$(use_define alsa) \
 			$(use_define bluetooth) \


### PR DESCRIPTION
This bug got introduced because no one tests system-wide setups.
This is still untested but according to Ionen unifdef call should now
fail if there wasn't anything to modify which is exactly what we want.

Thanks-to: Ionen Wolkens <ionen@gentoo.org>
Signed-off-by: Niklāvs Koļesņikovs <89q1r14hd@relay.firefox.com>