### PR TITLE
media-sound/pulseaudio: Require xice, xsm and xtst for daemon only

### DIFF
--- a/media-sound/pulseaudio/files/pulseaudio-15.0-xice-xsm-xtst-daemon-only.patch
+++ b/media-sound/pulseaudio/files/pulseaudio-15.0-xice-xsm-xtst-daemon-only.patch
@@ -1,0 +1,25 @@
+commit 42af3ee08381faa5807fde68d4c8ec0d7ad5e9a5
+Author: Igor V. Kovalenko <igor.v.kovalenko@gmail.com>
+Date:   Tue Aug 3 09:43:32 2021 +0300
+
+    build-sys: meson: Require xice, xsm and xtst for daemon only
+    
+    Part-of: <https://gitlab.freedesktop.org/pulseaudio/pulseaudio/-/merge_requests/613>
+
+diff --git a/meson.build b/meson.build
+index d7e468cab..a95fefcd4 100644
+--- a/meson.build
++++ b/meson.build
+@@ -681,9 +681,9 @@ endif
+ x11_dep = dependency('x11-xcb', required : get_option('x11'))
+ if x11_dep.found()
+   xcb_dep  = dependency('xcb',  required : true, version : '>= 1.6')
+-  ice_dep  = dependency('ice',  required : true)
+-  sm_dep   = dependency('sm',   required : true)
+-  xtst_dep = dependency('xtst', required : true)
++  ice_dep  = dependency('ice',  required : get_option('daemon'))
++  sm_dep   = dependency('sm',   required : get_option('daemon'))
++  xtst_dep = dependency('xtst', required : get_option('daemon'))
+   cdata.set('HAVE_X11', 1)
+   if cc.has_function('XSetIOErrorExitHandler', dependencies: x11_dep)
+     cdata.set('HAVE_XSETIOERROREXITHANDLER', 1)

--- a/media-sound/pulseaudio/pulseaudio-15.0.ebuild
+++ b/media-sound/pulseaudio/pulseaudio-15.0.ebuild
@@ -165,6 +165,10 @@ DOCS=( NEWS README )
 
 S="${WORKDIR}/${MY_P}"
 
+PATCHES=(
+	"${FILESDIR}"/pulseaudio-15.0-xice-xsm-xtst-daemon-only.patch
+)
+
 src_prepare() {
 	default
 


### PR DESCRIPTION
Backport change 42af3ee08381faa5807fde68d4c8ec0d7ad5e9a5 from upstream master.

Closes: https://bugs.gentoo.org/806052
Signed-off-by: Igor V. Kovalenko <igor.v.kovalenko@gmail.com>