### PR TITLE
sys-apps/busybox: Disable standalone shell mode with USE=make-symlinks

### DIFF
--- a/sys-apps/busybox/busybox-1.33.1-r2.ebuild
+++ b/sys-apps/busybox/busybox-1.33.1-r2.ebuild
@@ -141,6 +141,14 @@ src_configure() {
 		busybox_config_option n FEATURE_VI_REGEX_SEARCH
 	fi
 
+	# Disable standalone shell mode when using make-symlinks, else Busybox calls its
+	# applets by default without looking up in PATH.
+	# This also enables users to disable a builtin by deleting the corresponding symlink.
+	if use make-symlinks; then
+		busybox_config_option n FEATURE_PREFER_APPLETS
+		busybox_config_option n FEATURE_SH_STANDALONE
+	fi
+
 	# If these are not set and we are using a uclibc/busybox setup
 	# all calls to system() will fail.
 	busybox_config_option y ASH

--- a/sys-apps/busybox/busybox-9999.ebuild
+++ b/sys-apps/busybox/busybox-9999.ebuild
@@ -141,6 +141,14 @@ src_configure() {
 		busybox_config_option n FEATURE_VI_REGEX_SEARCH
 	fi
 
+	# Disable standalone shell mode when using make-symlinks, else Busybox calls its
+	# applets by default without looking up in PATH.
+	# This also enables users to disable a builtin by deleting the corresponding symlink.
+	if use make-symlinks; then
+		busybox_config_option n FEATURE_PREFER_APPLETS
+		busybox_config_option n FEATURE_SH_STANDALONE
+	fi
+
 	# If these are not set and we are using a uclibc/busybox setup
 	# all calls to system() will fail.
 	busybox_config_option y ASH


### PR DESCRIPTION
* Busybox has by default enabled CONFIG_FEATURE_PREFER_APPLETS
  and CONFIG_FEATURE_SH_STANDALONE which means it will
  bypass all PATH lookups and use its builtin applets.
  This is problematic as we sometimes might want to use the
  original program instead of Busybox applets, so let's
  disable those two options when building with USE=make-symlinks.
  This also enables users to disable a builtin by deleting the
  corresponding symlink.

Closes: https://bugs.gentoo.org/729184