### PR TITLE
net-irc/quasselgrep: Port to EAPI 8, fix DISTUTILS_USE_SETUPTOOLS

### DIFF
--- a/net-irc/quasselgrep/quasselgrep-0_p20200830.ebuild
+++ b/net-irc/quasselgrep/quasselgrep-0_p20200830.ebuild
@@ -1,11 +1,10 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
-PYTHON_COMPAT=( python3_{7..9} )
-PYTHON_REQ_USE=( sqlite )
-DISTUTILS_USE_SETUPTOOLS=rdepend
+PYTHON_COMPAT=( python3_{8..9} )
+PYTHON_REQ_USE="sqlite"
 
 inherit distutils-r1 optfeature
 
@@ -15,14 +14,16 @@ HOMEPAGE="https://github.com/fish-face/quasselgrep"
 MY_COMMIT="9b6b0bc1252daa6e574363d87d04eebd981215a5"
 SRC_URI="https://github.com/fish-face/quasselgrep/archive/${MY_COMMIT}.tar.gz -> ${P}.tar.gz"
 S="${WORKDIR}/${PN}-${MY_COMMIT}"
-KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 
 LICENSE="GPL-2"
 SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 
-RDEPEND="dev-python/future[${PYTHON_USEDEP}]
+RDEPEND="
+	dev-python/future[${PYTHON_USEDEP}]
 	dev-python/pycryptodome[${PYTHON_USEDEP}]
-	dev-python/python-dateutil[${PYTHON_USEDEP}]"
+	dev-python/python-dateutil[${PYTHON_USEDEP}]
+"
 
 pkg_postinst() {
 	optfeature "access postgres db" dev-python/psycopg:2


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/809128