### PR TITLE
media-libs/netpbm: Fix test failure with USE -png

### DIFF
--- a/media-libs/netpbm/netpbm-10.86.22.ebuild
+++ b/media-libs/netpbm/netpbm-10.86.22.ebuild
@@ -112,6 +112,7 @@ src_prepare() {
 			-e 's:(pamrgbatopng|pngtopnm).*::' \
 			test/legacy-names.{ok,test} || die
 		sed -i -e '/^$/d' test/legacy-names.ok || die
+		sed -i -e 's:png-roundtrip.*::' test/Test-Order || die
 	fi
 }
 


### PR DESCRIPTION
Skip `png-roundtrip*` tests when not compiling with *png* USE flag