### PR TITLE
sys-apps/selinux-python: Make setools optional

### DIFF
--- a/sys-apps/selinux-python/metadata.xml
+++ b/sys-apps/selinux-python/metadata.xml
@@ -10,6 +10,9 @@
 		that are required for basic operation of a SELinux system. These
 		include semanage, sepolicy and sepolgen.
 	</longdescription>
+	<use>
+		<flag name="setools">Install the setools package</flag>
+	</use>
 	<upstream>
 		<remote-id type="github">SELinuxProject/selinux</remote-id>
 	</upstream>

--- a/sys-apps/selinux-python/selinux-python-3.2.ebuild
+++ b/sys-apps/selinux-python/selinux-python-3.2.ebuild
@@ -7,7 +7,7 @@ PYTHON_REQ_USE="xml"
 
 inherit python-r1 toolchain-funcs
 
-IUSE="test"
+IUSE="test setools"
 RESTRICT="!test? ( test )"
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 
@@ -29,8 +29,8 @@ SLOT="0"
 RDEPEND=">=sys-libs/libselinux-${PV}:=[python]
 	>=sys-libs/libsemanage-${PV}:=[python(+)]
 	>=sys-libs/libsepol-${PV}:=
-	>=app-admin/setools-4.2.0[${PYTHON_USEDEP}]
 	>=sys-process/audit-1.5.1[python,${PYTHON_USEDEP}]
+	setools? ( >=app-admin/setools-4.2.0[${PYTHON_USEDEP}] )
 	${PYTHON_DEPS}"
 DEPEND="${RDEPEND}"
 BDEPEND="


### PR DESCRIPTION
Make setools optional

Package-Manager: Portage-3.0.20, Repoman-3.0.3
Signed-off-by: @4D617278 <sel4@disroot.org>