### PR TITLE
sys-apps/etckeeper: install conf-update.d hook

### DIFF
--- a/sys-apps/etckeeper/etckeeper-1.18.16-r1.ebuild
+++ b/sys-apps/etckeeper/etckeeper-1.18.16-r1.ebuild
@@ -71,6 +71,11 @@ if [ -e /etc/etckeeper/daily ] && [ -e /etc/etckeeper/etckeeper.conf ]; then
 fi
 _EOF_
 	fi
+
+	local conf_update_dir="/etc/portage/conf-update.d"
+	insinto "${conf_update_dir}"
+	newins "${FILESDIR}/${PN}-conf-update-hook" "${PN}"
+	fperms 755 "${conf_update_dir}/${PN}"
 }
 
 pkg_postinst() {

--- a/sys-apps/etckeeper/files/etckeeper-conf-update-hook
+++ b/sys-apps/etckeeper/files/etckeeper-conf-update-hook
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -eu
+
+# etckeeper hook for portage's conf-update hooks (e.g. invoked by
+# dispatch-conf). Requires portage > 3.0.22.
+
+# Do nothing if etckeeper is not initialized.
+if [[ ! -f "/etc/etckeeper/etckeeper.conf" ]]; then
+	exit
+fi
+
+echo "conf-update.d ${@}"
+
+case "${1}" in
+	pre-session)
+		echo "Commiting uncommited changes before starting a configuration update session"
+		etckeeper pre-install
+		;;
+	post-session)
+		echo "Commiting uncommited changes before after finishing a configuration update session"
+		etckeeper post-install
+		;;
+	post-update)
+		ACTION=${1}
+		FILE_PATH=${2}
+		FILE=$(basename "${FILE_PATH}")
+
+		echo "Commiting changes for ${FILE}"
+		etckeeper vcs add "${FILE_PATH}"
+		etckeeper vcs commit -m "${FILE}: ${ACTION} (conf-update.d hook)"
+	;;
+esac


### PR DESCRIPTION
In newer versions of portage (> 3.0.22), dispatch-conf will invoke
hooks found in /etc/portage/update-conf.d. See also portage commit
6e86186244d0 ("dispatch-conf: Add support for conf-update.d hook
directory") [1].

1:
https://gitweb.gentoo.org/proj/portage.git/commit/?id=6e86186244d048e3edd5c11c18cfb4eee98a0d56

Signed-off-by: Florian Schmaus <flow@gentoo.org>