### PR TITLE
media-video/libva-utils: fixed required USE flags combination

### DIFF
--- a/media-video/libva-utils/libva-utils-2.11.1.ebuild
+++ b/media-video/libva-utils/libva-utils-2.11.1.ebuild
@@ -26,6 +26,7 @@ RESTRICT="!test? ( test )"
 REQUIRED_USE="
 	|| ( drm wayland X )
 	putsurface? ( || ( wayland X ) )
+	putsurface? ( drm )
 	|| ( examples putsurface test-va-api vainfo )
 "
 

--- a/media-video/libva-utils/libva-utils-2.12.0.ebuild
+++ b/media-video/libva-utils/libva-utils-2.12.0.ebuild
@@ -26,6 +26,7 @@ RESTRICT="!test? ( test )"
 REQUIRED_USE="
 	|| ( drm wayland X )
 	putsurface? ( || ( wayland X ) )
+	putsurface? ( drm )
 	|| ( examples putsurface test-va-api vainfo )
 "
 

--- a/media-video/libva-utils/libva-utils-9999.ebuild
+++ b/media-video/libva-utils/libva-utils-9999.ebuild
@@ -26,6 +26,7 @@ RESTRICT="!test? ( test )"
 REQUIRED_USE="
 	|| ( drm wayland X )
 	putsurface? ( || ( wayland X ) )
+	putsurface? ( drm )
 	|| ( examples putsurface test-va-api vainfo )
 "
 


### PR DESCRIPTION
`putsurface` tool require DRM.

No revbump as if it was successfully compiled then no re-compilation needed.

Closes: https://bugs.gentoo.org/806998
