### PR TITLE
dev-lua/LuaBitOp: support lua5-3+

### DIFF
--- a/dev-lua/LuaBitOp/LuaBitOp-1.0.2-r103.ebuild
+++ b/dev-lua/LuaBitOp/LuaBitOp-1.0.2-r103.ebuild
@@ -1,0 +1,97 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+LUA_COMPAT=( lua5-{1..4} luajit )
+
+inherit flag-o-matic lua toolchain-funcs
+
+DESCRIPTION="Bit Operations Library for the Lua Programming Language"
+HOMEPAGE="http://bitop.luajit.org"
+SRC_URI="http://bitop.luajit.org/download/${P}.tar.gz"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86 ~x64-macos"
+REQUIRED_USE="${LUA_REQUIRED_USE}"
+
+RDEPEND="${LUA_DEPS}"
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+HTML_DOCS=( "doc/." )
+
+PATCHES=( "${FILESDIR}/${P}-support-lua5-3+.patch" )
+
+src_prepare() {
+	default
+
+	lua_copy_sources
+}
+
+lua_src_compile() {
+	pushd "${BUILD_DIR}" || die
+
+	local myemakeargs=(
+		"CC=$(tc-getCC)"
+		"CCOPT="
+		"INCLUDES=$(lua_get_CFLAGS)"
+	)
+
+	emake "${myemakeargs[@]}" all
+
+	popd
+}
+
+src_compile() {
+	if [[ $CHOST == *-darwin* ]] ; then
+		append-ldflags "-undefined dynamic_lookup"
+	fi
+	lua_foreach_impl lua_src_compile
+}
+
+lua_src_test() {
+	pushd "${BUILD_DIR}" || die
+
+	local mytests=(
+		"bitbench.lua"
+		"bittest.lua"
+		"md5test.lua"
+		"nsievebits.lua"
+	)
+
+	for mytest in ${mytests[@]}; do
+		LUA_CPATH="./?.so" ${ELUA} ${mytest}
+	done
+
+	popd
+}
+
+src_test() {
+	lua_foreach_impl lua_src_test
+}
+
+lua_src_install() {
+	pushd "${BUILD_DIR}" || die
+
+	mycmoddir="$(lua_get_cmod_dir)"
+	exeinto "${mycmoddir#$EPREFIX}"
+	doexe bit.so
+
+	popd
+
+	if [[ ${CHOST} == *-darwin* ]] ; then
+		local luav=$(lua_get_version)
+		# we only want the major version (e.g. 5.1)
+		local luamv=${luav:0:3}
+		local file="lua/${luamv}/bit.so"
+		install_name_tool -id "${EPREFIX}/usr/$(get_libdir)/${file}" "${ED}/usr/$(get_libdir)/${file}" || die "Failed to adjust install_name"
+	fi
+}
+
+src_install() {
+	lua_foreach_impl lua_src_install
+
+	einstalldocs
+}

--- a/dev-lua/LuaBitOp/files/LuaBitOp-1.0.2-support-lua5-3+.patch
+++ b/dev-lua/LuaBitOp/files/LuaBitOp-1.0.2-support-lua5-3+.patch
@@ -1,0 +1,78 @@
+This patch is a result of diff between upstream and bundled library in rspamd
+
+https://github.com/rspamd/rspamd/blob/30298909543453ebe969878f1406ee76ad148494/contrib/lua-bit/bit.c
+
+diff --git a/bit.c b/bit.c
+index 690df7d3c..01326c99a 100644
+--- a/bit.c
++++ b/bit.c
+@@ -46,7 +46,7 @@ typedef uint32_t UBits;
+ 
+ typedef union {
+   lua_Number n;
+-#ifdef LUA_NUMBER_DOUBLE
++#if defined(LUA_NUMBER_DOUBLE) || defined(LUA_FLOAT_DOUBLE)
+   uint64_t b;
+ #else
+   UBits b;
+@@ -63,24 +63,25 @@ static UBits barg(lua_State *L, int idx)
+ #else
+   bn.n = luaL_checknumber(L, idx);
+ #endif
+-#if defined(LUA_NUMBER_DOUBLE)
++#if defined(LUA_NUMBER_DOUBLE) || defined(LUA_FLOAT_DOUBLE)
+   bn.n += 6755399441055744.0;  /* 2^52+2^51 */
+ #ifdef SWAPPED_DOUBLE
+   b = (UBits)(bn.b >> 32);
+ #else
+   b = (UBits)bn.b;
+ #endif
+-#elif defined(LUA_NUMBER_INT) || defined(LUA_NUMBER_LONG) || \
+-      defined(LUA_NUMBER_LONGLONG) || defined(LUA_NUMBER_LONG_LONG) || \
+-      defined(LUA_NUMBER_LLONG)
++#elif defined(LUA_NUMBER_INT)       || defined(LUA_INT_INT) || \
++      defined(LUA_NUMBER_LONG)      || defined(LUA_INT_LONG) || \
++      defined(LUA_NUMBER_LONGLONG)  || defined(LUA_INT_LONGLONG) || \
++      defined(LUA_NUMBER_LONG_LONG) || defined(LUA_NUMBER_LLONG)
+   if (sizeof(UBits) == sizeof(lua_Number))
+     b = bn.b;
+   else
+     b = (UBits)(SBits)bn.n;
+-#elif defined(LUA_NUMBER_FLOAT)
++#elif defined(LUA_NUMBER_FLOAT) || defined(LUA_FLOAT_FLOAT)
+ #error "A 'float' lua_Number type is incompatible with this library"
+ #else
+-#error "Unknown number type, check LUA_NUMBER_* in luaconf.h"
++#error "Unknown number type, check LUA_NUMBER_*, LUA_FLOAT_*, LUA_INT_* in luaconf.h"
+ #endif
+ #if LUA_VERSION_NUM < 502
+   if (b == 0 && !lua_isnumber(L, idx)) {
+@@ -91,7 +92,11 @@ static UBits barg(lua_State *L, int idx)
+ }
+ 
+ /* Return bit type. */
++#if LUA_VERSION_NUM < 503
+ #define BRET(b)  lua_pushnumber(L, (lua_Number)(SBits)(b)); return 1;
++#else
++#define BRET(b)  lua_pushinteger(L, (lua_Integer)(SBits)(b)); return 1;
++#endif
+ 
+ static int bit_tobit(lua_State *L) { BRET(barg(L, 1)) }
+ static int bit_bnot(lua_State *L) { BRET(~barg(L, 1)) }
+@@ -163,11 +168,15 @@ static const struct luaL_Reg bit_funcs[] = {
+ LUALIB_API int luaopen_bit(lua_State *L)
+ {
+   UBits b;
++#if LUA_VERSION_NUM < 503
+   lua_pushnumber(L, (lua_Number)1437217655L);
++#else
++  lua_pushinteger(L, (lua_Integer)1437217655L);
++#endif
+   b = barg(L, -1);
+   if (b != (UBits)1437217655L || BAD_SAR) {  /* Perform a simple self-test. */
+     const char *msg = "compiled with incompatible luaconf.h";
+-#ifdef LUA_NUMBER_DOUBLE
++#if defined(LUA_NUMBER_DOUBLE) || defined(LUA_FLOAT_DOUBLE)
+ #ifdef _WIN32
+     if (b == (UBits)1610612736L)
+       msg = "use D3DCREATE_FPU_PRESERVE with DirectX";


### PR DESCRIPTION
This revision bump applies patch generated from rspamd bundled library in order to support `lua-5.3` and `lua-5.4`.

Btw, is `test` use flag needed here? It seems not, but maybe I overlooked somehting.
