### PR TITLE
dev-util/bazel: remove hack for Gentoo prefix

### DIFF
--- a/dev-util/bazel/bazel-3.7.2.ebuild
+++ b/dev-util/bazel/bazel-3.7.2.ebuild
@@ -13,8 +13,7 @@ SRC_URI="https://github.com/bazelbuild/bazel/releases/download/${PV}/${P}-dist.z
 LICENSE="Apache-2.0"
 SLOT="0"
 KEYWORDS="~amd64"
-IUSE="examples tools prefix static-libs"
-REQUIRED_USE="prefix? ( static-libs )"
+IUSE="examples tools"
 # strip corrupts the bazel binary
 # test fails with network-sandbox: An error occurred during the fetch of repository 'io_bazel_skydoc' (bug 690794)
 RESTRICT="strip test"
@@ -71,9 +70,6 @@ src_prepare() {
 
 src_compile() {
 	export EXTRA_BAZEL_ARGS="--jobs=$(makeopts_jobs) $(bazel-get-flags) --host_javabase=@local_jdk//:jdk"
-	if use static-libs; then
-		export BAZEL_LINKOPTS=-static-libs:-static-libgcc BAZEL_LINKLIBS=-l%:libstdc++.a:-lm
-	fi
 	VERBOSE=yes ./compile.sh || die
 
 	./scripts/generate_bash_completion.sh \


### PR DESCRIPTION
In bazel-3.2 prefix and static-libs use flag is added concerning bug #773982

For bazel-3.7 the issue is gone and specifying static link flags causes build error.

Package-Manager: Portage-3.0.20, Repoman-3.0.3
Signed-off-by: Yiyang Wu <xgreenlandforwyy@gmail.com>