### PR TITLE
dev-libs/spdlog: fix dependency version

### DIFF
--- a/dev-libs/spdlog/spdlog-1.9.2.ebuild
+++ b/dev-libs/spdlog/spdlog-1.9.2.ebuild
@@ -25,7 +25,7 @@ BDEPEND="
 	virtual/pkgconfig
 "
 DEPEND="
-	>=dev-libs/libfmt-6.1.2:=
+	>=dev-libs/libfmt-8.0.0:=
 "
 RDEPEND="${DEPEND}"
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/810496
Package-Manager: Portage-3.0.22, Repoman-3.0.3
Signed-off-by: David Roman <davidroman96@gmail.com>