### PR TITLE
mail-filter/rspamd: correct LuaBitOp dependency rule

### DIFF
--- a/mail-filter/rspamd/rspamd-2.7-r103.ebuild
+++ b/mail-filter/rspamd/rspamd-2.7-r103.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-LUA_COMPAT=( lua5-{1..3} luajit )
+LUA_COMPAT=( lua5-{1..2} luajit )
 
 inherit cmake lua-single pax-utils systemd tmpfiles
 

--- a/mail-filter/rspamd/rspamd-3.0-r1.ebuild
+++ b/mail-filter/rspamd/rspamd-3.0-r1.ebuild
@@ -30,7 +30,7 @@ REQUIRED_USE="${LUA_REQUIRED_USE}
 RDEPEND="${LUA_DEPS}
 	$(lua_gen_cond_dep '
 		dev-lua/LuaBitOp[${LUA_USEDEP}]
-	' lua5-{1,2})
+	')
 	acct-group/rspamd
 	acct-user/rspamd
 	app-arch/zstd:=

--- a/mail-filter/rspamd/rspamd-9999.ebuild
+++ b/mail-filter/rspamd/rspamd-9999.ebuild
@@ -30,7 +30,7 @@ REQUIRED_USE="${LUA_REQUIRED_USE}
 RDEPEND="${LUA_DEPS}
 	$(lua_gen_cond_dep '
 		dev-lua/LuaBitOp[${LUA_USEDEP}]
-	' lua5-{1,2})
+	')
 	acct-group/rspamd
 	acct-user/rspamd
 	app-arch/zstd:=


### PR DESCRIPTION
Rspamd requires LuaBitOp dependency for all lua targets.