### PR TITLE
Fixed dependencies in app-admin/perl-cleaner package.

### DIFF
--- a/app-admin/perl-cleaner/perl-cleaner-2.30.ebuild
+++ b/app-admin/perl-cleaner/perl-cleaner-2.30.ebuild
@@ -24,10 +24,6 @@ IUSE=""
 
 RDEPEND="app-shells/bash
 	dev-lang/perl
-	|| (
-		( sys-apps/portage app-portage/portage-utils )
-		sys-apps/pkgcore
-	)
 "
 
 src_prepare() {


### PR DESCRIPTION
The defined runtime dependencies: sys-apps/portage app-portage/portage-utils sys-apps/pkgcore are not needed.
It was tested while the package was cross-compiled. 
