### PR TITLE
games-arcade/fishsupper: fix build, bump eapi

### DIFF
--- a/games-arcade/fishsupper/files/fishsupper-0.1.6-int16.patch
+++ b/games-arcade/fishsupper/files/fishsupper-0.1.6-int16.patch
@@ -1,0 +1,14 @@
+Fix build with clang
+https://bugs.gentoo.org/739090
+
+--- a/src/SFont_gl.cpp
++++ b/src/SFont_gl.cpp
+@@ -223,7 +223,7 @@ void Mafferyew::SFont_gl::create_font_char(SDL_Surface* image,
+                                      0x000000ff, 0x0000ff00, 0x00ff0000, 0xff000000);
+ #endif
+     
+-    SDL_Rect src_rect = { begin_x, 1, font_char_w, font_height };
++    SDL_Rect src_rect = { (Sint16)begin_x, 1, (Uint16)font_char_w, (Uint16)font_height };
+     SDL_BlitSurface(image, &src_rect, converted, 0);
+     
+     GLuint texture;

--- a/games-arcade/fishsupper/fishsupper-0.1.6-r3.ebuild
+++ b/games-arcade/fishsupper/fishsupper-0.1.6-r3.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 inherit autotools desktop
 
@@ -27,6 +27,7 @@ PATCHES=(
 	"${FILESDIR}"/${P}-ovflfix.patch
 	"${FILESDIR}"/${P}-asneeded.patch
 	"${FILESDIR}"/${P}-gcc6.patch
+	"${FILESDIR}"/${P}-int16.patch
 )
 
 src_prepare() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/739090
Package-Manager: Portage-3.0.20, Repoman-3.0.3
Signed-off-by: Alexey Sokolov <alexey+gentoo@asokolov.org>