### PR TITLE
games-puzzle/pipewalker: fix deps, bump eapi

### DIFF
--- a/games-puzzle/pipewalker/pipewalker-0.9.4-r2.ebuild
+++ b/games-puzzle/pipewalker/pipewalker-0.9.4-r2.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
-inherit desktop flag-o-matic
+EAPI=8
+inherit autotools desktop flag-o-matic toolchain-funcs
 
 DESCRIPTION="Rotating pieces puzzle game"
 HOMEPAGE="http://pipewalker.sourceforge.net/"
@@ -11,16 +11,23 @@ SRC_URI="mirror://sourceforge/pipewalker/${P}.tar.gz"
 LICENSE="GPL-3"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE=""
 
-DEPEND="media-libs/libsdl[opengl,video]
+DEPEND="
+	media-libs/libpng:=
+	media-libs/libsdl[opengl,sound,video]
 	virtual/opengl
-	virtual/glu"
+"
 RDEPEND="${DEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+src_prepare() {
+	default
+	eautoreconf
+}
 
 src_configure() {
-	append-flags $(sdl-config --cflags)
-	econf --datadir="/usr/share"
+	append-cppflags $($(tc-getPKG_CONFIG) --cflags sdl || die)
+	default
 }
 
 src_install() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/739316
Package-Manager: Portage-3.0.20, Repoman-3.0.3
Signed-off-by: Alexey Sokolov <alexey+gentoo@asokolov.org>