### PR TITLE
app-arch/lz4: Add USE=lib-only

### DIFF
--- a/app-arch/lz4/lz4-1.9.3-r2.ebuild
+++ b/app-arch/lz4/lz4-1.9.3-r2.ebuild
@@ -14,7 +14,7 @@ LICENSE="BSD-2 GPL-2"
 # https://abi-laboratory.pro/tracker/timeline/lz4/
 SLOT="0/r132"
 KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
-IUSE="static-libs"
+IUSE="lib-only static-libs"
 
 CMAKE_USE_DIR=${S}/build/cmake
 
@@ -24,6 +24,8 @@ PATCHES=(
 
 multilib_src_configure() {
 	local mycmakeargs=(
+		-DLZ4_BUILD_CLI=$(usex !lib-only)
+		-DLZ4_BUILD_LEGACY_LZ4C=$(usex !lib-only)
 		-DBUILD_STATIC_LIBS=$(usex static-libs)
 	)
 

--- a/app-arch/lz4/metadata.xml
+++ b/app-arch/lz4/metadata.xml
@@ -9,6 +9,9 @@
 		<email>amadio@gentoo.org</email>
 		<name>Guilherme Amadio</name>
 	</maintainer>
+	<use>
+		<flag name="lib-only">Don't build lz4 and lz4c programs</flag>
+	</use>
 	<upstream>
 		<remote-id type="github">lz4/lz4</remote-id>
 		<remote-id type="cpe">cpe:/a:lz4_project:lz4</remote-id>


### PR DESCRIPTION
* Add lib-only flag which provides a minimal lz4 build
  with only library and without other binaries. This is
  useful in e.g. embedded or stripped down systems where
  one might want just the core functionality of liblz4.

Signed-off-by: Jakov Smolić <jsmolic@gentoo.org>