### PR TITLE
dev-libs/elfutils: backport patches fixing clang build

### DIFF
--- a/dev-libs/elfutils/elfutils-0.185.ebuild
+++ b/dev-libs/elfutils/elfutils-0.185.ebuild
@@ -34,6 +34,8 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-0.177-disable-large.patch
 	"${FILESDIR}"/${PN}-0.180-PaX-support.patch
 	"${FILESDIR}"/${PN}-0.185-static-inline.patch
+	"${FILESDIR}"/${PN}-0.185-pull-advance_pc-in-file-scope.patch
+	"${FILESDIR}"/${PN}-0.185-configure.ac-rework-gnu99-ext-check-to-allow-clang.patch
 )
 
 src_prepare() {

--- a/dev-libs/elfutils/files/elfutils-0.185-configure.ac-rework-gnu99-ext-check-to-allow-clang.patch
+++ b/dev-libs/elfutils/files/elfutils-0.185-configure.ac-rework-gnu99-ext-check-to-allow-clang.patch
@@ -1,0 +1,146 @@
+From c9ff5c53c319f963cac34a41c86cd43edf902459 Mon Sep 17 00:00:00 2001
+From: Adrian Ratiu <adrian.ratiu@collabora.com>
+Date: Mon, 30 Aug 2021 18:43:13 +0300
+Subject: [PATCH] configure.ac: rework gnu99 ext check to allow clang
+
+It is true that Clang does not support all gnu99 extensions [1],
+but not all of them are used in the codebase and over time there
+have been code cleanup efforts to improve Clang support.
+
+For example after commit 779c57ea ("readelf: Pull advance_pc()
+in file scope") there are no more nested function declarations
+and elfutils now builds fine with Clang.
+
+So in the interest of enabling Clang builds we remove the only
+remaining blocker: the configure checks for nested functions and
+variable length arrays which are also unused.
+
+Considering mixed decls and code is also part of c99 standard,
+the entire check becomes redundant and we can just replace
+AC_PROG_CC -> AC_PROG_CC_C99.
+
+Upstream-Status: Backport [master commit 6eb991a9]
+
+[1] https://sourceware.org/bugzilla/show_bug.cgi?id=24964
+[Adrian: backported to v0.185]
+Signed-off-by: Adrian Ratiu <adrian.ratiu@collabora.com>
+---
+ configure    | 48 ------------------------------------------------
+ configure.ac | 35 +----------------------------------
+ 2 files changed, 1 insertion(+), 82 deletions(-)
+
+diff --git a/configure b/configure
+index 4ea75ee..22bda6c 100755
+--- a/configure
++++ b/configure
+@@ -5162,54 +5162,6 @@ else
+ fi
+ 
+ 
+-# We use -std=gnu99 but have explicit checks for some language constructs
+-# and GNU extensions since some compilers claim GNU99 support, but don't
+-# really support all language extensions. In particular we need
+-# Mixed Declarations and Code
+-# https://gcc.gnu.org/onlinedocs/gcc/Mixed-Declarations.html
+-# Nested Functions
+-# https://gcc.gnu.org/onlinedocs/gcc/Nested-Functions.html
+-# Arrays of Variable Length
+-# https://gcc.gnu.org/onlinedocs/gcc/Variable-Length.html
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for gcc with GNU99 support" >&5
+-$as_echo_n "checking for gcc with GNU99 support... " >&6; }
+-if ${ac_cv_c99+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
+-  old_CFLAGS="$CFLAGS"
+-CFLAGS="$CFLAGS -std=gnu99"
+-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+-/* end confdefs.h.  */
+-int foo (int a)
+-{
+-  for (int i = 0; i < a; ++i) if (i % 4) break; int s = a; return s;
+-}
+-
+-double bar (double a, double b)
+-{
+-  double square (double z) { return z * z; }
+-  return square (a) + square (b);
+-}
+-
+-void baz (int n)
+-{
+-  struct S { int x[n]; };
+-}
+-_ACEOF
+-if ac_fn_c_try_compile "$LINENO"; then :
+-  ac_cv_c99=yes
+-else
+-  ac_cv_c99=no
+-fi
+-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+-CFLAGS="$old_CFLAGS"
+-fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_c99" >&5
+-$as_echo "$ac_cv_c99" >&6; }
+-if test "x$ac_cv_c99" != xyes; then :
+-  as_fn_error $? "gcc with GNU99 support required" "$LINENO" 5
+-fi
+-
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether gcc supports __attribute__((visibility()))" >&5
+ $as_echo_n "checking whether gcc supports __attribute__((visibility()))... " >&6; }
+ if ${ac_cv_visibility+:} false; then :
+diff --git a/configure.ac b/configure.ac
+index b348a71..6298547 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -87,7 +87,7 @@ AS_IF([test "$use_locks" = yes],
+ 
+ AH_TEMPLATE([USE_LOCKS], [Defined if libraries should be thread-safe.])
+ 
+-AC_PROG_CC
++AC_PROG_CC_C99
+ AC_PROG_RANLIB
+ AC_PROG_YACC
+ AM_PROG_LEX
+@@ -96,39 +96,6 @@ m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
+ AC_CHECK_TOOL([READELF], [readelf])
+ AC_CHECK_TOOL([NM], [nm])
+ 
+-# We use -std=gnu99 but have explicit checks for some language constructs
+-# and GNU extensions since some compilers claim GNU99 support, but don't
+-# really support all language extensions. In particular we need
+-# Mixed Declarations and Code
+-# https://gcc.gnu.org/onlinedocs/gcc/Mixed-Declarations.html
+-# Nested Functions
+-# https://gcc.gnu.org/onlinedocs/gcc/Nested-Functions.html
+-# Arrays of Variable Length
+-# https://gcc.gnu.org/onlinedocs/gcc/Variable-Length.html
+-AC_CACHE_CHECK([for gcc with GNU99 support], ac_cv_c99, [dnl
+-old_CFLAGS="$CFLAGS"
+-CFLAGS="$CFLAGS -std=gnu99"
+-AC_COMPILE_IFELSE([AC_LANG_SOURCE([dnl
+-int foo (int a)
+-{
+-  for (int i = 0; i < a; ++i) if (i % 4) break; int s = a; return s;
+-}
+-
+-double bar (double a, double b)
+-{
+-  double square (double z) { return z * z; }
+-  return square (a) + square (b);
+-}
+-
+-void baz (int n)
+-{
+-  struct S { int x[[n]]; };
+-}])],
+-		  ac_cv_c99=yes, ac_cv_c99=no)
+-CFLAGS="$old_CFLAGS"])
+-AS_IF([test "x$ac_cv_c99" != xyes],
+-      AC_MSG_ERROR([gcc with GNU99 support required]))
+-
+ AC_CACHE_CHECK([whether gcc supports __attribute__((visibility()))],
+ 	ac_cv_visibility, [dnl
+ save_CFLAGS="$CFLAGS"
+-- 
+2.33.0
+

--- a/dev-libs/elfutils/files/elfutils-0.185-pull-advance_pc-in-file-scope.patch
+++ b/dev-libs/elfutils/files/elfutils-0.185-pull-advance_pc-in-file-scope.patch
@@ -1,0 +1,70 @@
+From 779c57ea864d104bad88455535df9b26336349fd Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Timm=20B=C3=A4der?= <tbaeder@redhat.com>
+Date: Thu, 18 Mar 2021 10:25:24 +0100
+Subject: [PATCH] readelf: Pull advance_pc() in file scope
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Make advance_pc() a static function so we can get rid of another nested
+function. Rename it to run_advance_pc() and use a local advance_pc()
+macro to pass all the local variables. This is similar to what the
+equivalent code in libdw/dwarf_getsrclines.c is doing.
+
+Upstream-Status: Backport [master commit 779c57ea]
+
+Signed-off-by: Timm Bäder <tbaeder@redhat.com>
+[Adrian: backported to v0.185]
+Signed-off-by: Adrian Ratiu <adrian.ratiu@collabora.com>
+---
+ src/ChangeLog |  7 +++++++
+ src/readelf.c | 26 +++++++++++++++++++-------
+ 2 files changed, 26 insertions(+), 7 deletions(-)
+
+diff --git a/src/readelf.c b/src/readelf.c
+index 161d7e65..8191bde2 100644
+--- a/src/readelf.c
++++ b/src/readelf.c
+@@ -8373,6 +8373,23 @@ print_form_data (Dwarf *dbg, int form, const unsigned char *readp,
+   return readp;
+ }
+ 
++/* Only used via run_advance_pc() macro */
++static inline void
++run_advance_pc (unsigned int op_advance,
++                unsigned int minimum_instr_len,
++                unsigned int max_ops_per_instr,
++                unsigned int *op_addr_advance,
++                Dwarf_Word *address,
++                unsigned int *op_index)
++{
++  const unsigned int advanced_op_index = (*op_index) + op_advance;
++
++  *op_addr_advance = minimum_instr_len * (advanced_op_index
++                                         / max_ops_per_instr);
++  *address = *address + *op_addr_advance;
++  *op_index = advanced_op_index % max_ops_per_instr;
++}
++
+ static void
+ print_debug_line_section (Dwfl_Module *dwflmod, Ebl *ebl, GElf_Ehdr *ehdr,
+ 			  Elf_Scn *scn, GElf_Shdr *shdr, Dwarf *dbg)
+@@ -8763,13 +8780,8 @@ print_debug_line_section (Dwfl_Module *dwflmod, Ebl *ebl, GElf_Ehdr *ehdr,
+       /* Apply the "operation advance" from a special opcode
+ 	 or DW_LNS_advance_pc (as per DWARF4 6.2.5.1).  */
+       unsigned int op_addr_advance;
+-      inline void advance_pc (unsigned int op_advance)
+-      {
+-	op_addr_advance = minimum_instr_len * ((op_index + op_advance)
+-					       / max_ops_per_instr);
+-	address += op_addr_advance;
+-	op_index = (op_index + op_advance) % max_ops_per_instr;
+-      }
++#define advance_pc(op_advance) run_advance_pc(op_advance, minimum_instr_len, \
++                      max_ops_per_instr, &op_addr_advance, &address, &op_index)
+ 
+       if (max_ops_per_instr == 0)
+ 	{
+-- 
+2.32.0
+


### PR DESCRIPTION
Latest elfutils mainline development branch contains the
last two patches required for building elfutils with clang.

This backports the two patches onto v0.185 so we can get
it built with clang and should be dropped when Gentoo
eventually upgrades to v0.186 or later.

Signed-off-by: Adrian Ratiu <adrian.ratiu@collabora.com>