### PR TITLE
app-admin/puppet-agent: symlink fix

### DIFF
--- a/app-admin/puppet-agent/puppet-agent-6.19.1-r1.ebuild
+++ b/app-admin/puppet-agent/puppet-agent-6.19.1-r1.ebuild
@@ -72,7 +72,16 @@ src_install() {
 	dosym ../../opt/puppetlabs/bin/hiera /usr/bin/hiera
 	dosym ../../opt/puppetlabs/bin/puppet /usr/bin/puppet
 	dosym ../../opt/puppetlabs/puppet/bin/virt-what /usr/bin/virt-what
-	dosym ../../../../usr/lib64/xcrypt/libcrypt.so.1 /opt/puppetlabs/puppet/lib/libcrypt.so.1
+
+	# Handling of the path to the crypt library during the ongoing migration
+	# from glibc[crypt] to libxcrypt
+	# https://www.gentoo.org/support/news-items/2021-07-23-libxcrypt-migration.html
+	if has_version "sys-libs/glibc[crypt]"; then
+		local crypt_target='../../../../usr/lib64/xcrypt/libcrypt.so.1'
+	else
+		local crypt_target='../../../../usr/lib/libcrypt.so.1'
+	fi
+	dosym $crypt_target /opt/puppetlabs/puppet/lib/libcrypt.so.1
 }
 
 pkg_postinst() {

--- a/app-admin/puppet-agent/puppet-agent-7.10.0.ebuild
+++ b/app-admin/puppet-agent/puppet-agent-7.10.0.ebuild
@@ -70,7 +70,7 @@ src_install() {
 	dosym ../../opt/puppetlabs/bin/facter /usr/bin/facter
 	dosym ../../opt/puppetlabs/bin/hiera /usr/bin/hiera
 	dosym ../../opt/puppetlabs/bin/puppet /usr/bin/puppet
-	dosym ../../../../usr/lib/libcrypt.so.1 /opt/puppetlabs/puppet/lib/libcrypt.so.1
+	dosym ../../../../usr/lib64/xcrypt/libcrypt.so.1 /opt/puppetlabs/puppet/lib/libcrypt.so.1
 }
 
 pkg_postinst() {

--- a/app-admin/puppet-agent/puppet-agent-7.10.0.ebuild
+++ b/app-admin/puppet-agent/puppet-agent-7.10.0.ebuild
@@ -70,7 +70,16 @@ src_install() {
 	dosym ../../opt/puppetlabs/bin/facter /usr/bin/facter
 	dosym ../../opt/puppetlabs/bin/hiera /usr/bin/hiera
 	dosym ../../opt/puppetlabs/bin/puppet /usr/bin/puppet
-	dosym ../../../../usr/lib64/xcrypt/libcrypt.so.1 /opt/puppetlabs/puppet/lib/libcrypt.so.1
+
+	# Handling of the path to the crypt library during the ongoing migration
+	# from glibc[crypt] to libxcrypt
+	# https://www.gentoo.org/support/news-items/2021-07-23-libxcrypt-migration.html
+	if has_version "sys-libs/glibc[crypt]"; then
+		local crypt_target='../../../../usr/lib64/xcrypt/libcrypt.so.1'
+	else
+		local crypt_target='../../../../usr/lib/libcrypt.so.1'
+	fi
+	dosym $crypt_target /opt/puppetlabs/puppet/lib/libcrypt.so.1
 }
 
 pkg_postinst() {

--- a/app-admin/puppet-agent/puppet-agent-7.11.0.ebuild
+++ b/app-admin/puppet-agent/puppet-agent-7.11.0.ebuild
@@ -70,7 +70,7 @@ src_install() {
 	dosym ../../opt/puppetlabs/bin/facter /usr/bin/facter
 	dosym ../../opt/puppetlabs/bin/hiera /usr/bin/hiera
 	dosym ../../opt/puppetlabs/bin/puppet /usr/bin/puppet
-	dosym ../../../../usr/lib/libcrypt.so.1 /opt/puppetlabs/puppet/lib/libcrypt.so.1
+	dosym ../../../../usr/lib64/xcrypt/libcrypt.so.1 /opt/puppetlabs/puppet/lib/libcrypt.so.1
 }
 
 pkg_postinst() {

--- a/app-admin/puppet-agent/puppet-agent-7.11.0.ebuild
+++ b/app-admin/puppet-agent/puppet-agent-7.11.0.ebuild
@@ -70,7 +70,16 @@ src_install() {
 	dosym ../../opt/puppetlabs/bin/facter /usr/bin/facter
 	dosym ../../opt/puppetlabs/bin/hiera /usr/bin/hiera
 	dosym ../../opt/puppetlabs/bin/puppet /usr/bin/puppet
-	dosym ../../../../usr/lib64/xcrypt/libcrypt.so.1 /opt/puppetlabs/puppet/lib/libcrypt.so.1
+
+	# Handling of the path to the crypt library during the ongoing migration
+	# from glibc[crypt] to libxcrypt
+	# https://www.gentoo.org/support/news-items/2021-07-23-libxcrypt-migration.html
+	if has_version "sys-libs/glibc[crypt]"; then
+		local crypt_target='../../../../usr/lib64/xcrypt/libcrypt.so.1'
+	else
+		local crypt_target='../../../../usr/lib/libcrypt.so.1'
+	fi
+	dosym $crypt_target /opt/puppetlabs/puppet/lib/libcrypt.so.1
 }
 
 pkg_postinst() {


### PR DESCRIPTION
Both 7.9 and 7.10 installed a broken symlink to the libcrypt.so.1
library which cause the agent to fail. There may be some systems where
the appropriate library still appears first in the system search path,
however, on my system the glibc version is selected and it does not
contain `XCRYPT_2.0` which ruby apparently requires.

Closes: https://bugs.gentoo.org/809263
Package-Manager: Portage-3.0.20, Repoman-3.0.3
Signed-off-by: Philip DeMonaco <phil@demona.co>