### PR TITLE
sci-physics/vgm: update dependency on sci-physics/geant

### DIFF
--- a/sci-physics/vgm/vgm-4.8-r1.ebuild
+++ b/sci-physics/vgm/vgm-4.8-r1.ebuild
@@ -24,12 +24,12 @@ IUSE="doc examples +geant4 +root test"
 
 RDEPEND="
 	sci-physics/clhep:=
-	geant4? ( sci-physics/geant[c++17] )
+	geant4? ( <sci-physics/geant-4.11[c++17] )
 	root? ( sci-physics/root:=[c++17] )"
 DEPEND="${RDEPEND}
 	doc? ( app-doc/doxygen[dot] )
 	test? (
-		sci-physics/geant[gdml]
+		<sci-physics/geant-4.11[gdml]
 		sci-physics/geant4_vmc[g4root]
 	)"
 RESTRICT="

--- a/sci-physics/vgm/vgm-4.9-r1.ebuild
+++ b/sci-physics/vgm/vgm-4.9-r1.ebuild
@@ -24,12 +24,12 @@ IUSE="doc examples +geant4 +root test"
 
 RDEPEND="
 	sci-physics/clhep:=
-	geant4? ( sci-physics/geant[c++17] )
+	geant4? ( <sci-physics/geant-4.11[c++17] )
 	root? ( sci-physics/root:=[c++17] )"
 DEPEND="${RDEPEND}
 	doc? ( app-doc/doxygen[dot] )
 	test? (
-		sci-physics/geant[gdml]
+		<sci-physics/geant-4.11[gdml]
 		sci-physics/geant4_vmc[g4root]
 	)"
 RESTRICT="


### PR DESCRIPTION
Does not compile against >=sci-physics/geant-4.11.0_beta1.

Closes: https://bugs.gentoo.org/811435
Package-Manager: Portage-3.0.20, Repoman-3.0.2
Signed-off-by: Oliver Freyermuth <o.freyermuth@googlemail.com>