### PR TITLE
net-irc/weechat: Fix LIBDIR path on Prefix

### DIFF
--- a/net-irc/weechat/weechat-3.1.ebuild
+++ b/net-irc/weechat/weechat-3.1.ebuild
@@ -116,7 +116,7 @@ src_prepare() {
 
 src_configure() {
 	local mycmakeargs=(
-		-DLIBDIR=/usr/$(get_libdir)
+		-DLIBDIR="${EPREFIX}/usr/$(get_libdir)"
 		-DENABLE_JAVASCRIPT=OFF
 		-DENABLE_LARGEFILE=ON
 		-DENABLE_NCURSES=ON

--- a/net-irc/weechat/weechat-3.2.ebuild
+++ b/net-irc/weechat/weechat-3.2.ebuild
@@ -116,7 +116,7 @@ src_prepare() {
 
 src_configure() {
 	local mycmakeargs=(
-		-DLIBDIR=/usr/$(get_libdir)
+		-DLIBDIR="${EPREFIX}/usr/$(get_libdir)"
 		-DENABLE_JAVASCRIPT=OFF
 		-DENABLE_LARGEFILE=ON
 		-DENABLE_NCURSES=ON

--- a/net-irc/weechat/weechat-9999.ebuild
+++ b/net-irc/weechat/weechat-9999.ebuild
@@ -116,7 +116,7 @@ src_prepare() {
 
 src_configure() {
 	local mycmakeargs=(
-		-DLIBDIR=/usr/$(get_libdir)
+		-DLIBDIR="${EPREFIX}/usr/$(get_libdir)"
 		-DENABLE_JAVASCRIPT=OFF
 		-DENABLE_LARGEFILE=ON
 		-DENABLE_NCURSES=ON


### PR DESCRIPTION
`LIBDIR` for this package is not prefixed with `EPREFIX`, causing the following error during the postinst step in a Gentoo Prefix environment:

```
 * QA Notice: the following files are outside of the prefix:
 * /usr
 * /usr/lib64
 * /usr/lib64/pkgconfig
 * /usr/lib64/pkgconfig/weechat.pc
 * /usr/lib64/weechat
 * /usr/lib64/weechat/plugins
 * /usr/lib64/weechat/plugins/relay.so
 * /usr/lib64/weechat/plugins/fset.so
 * /usr/lib64/weechat/plugins/buflist.so
 * /usr/lib64/weechat/plugins/trigger.so
 * /usr/lib64/weechat/plugins/spell.so
 * /usr/lib64/weechat/plugins/logger.so
 * /usr/lib64/weechat/plugins/charset.so
 * /usr/lib64/weechat/plugins/alias.so
 * /usr/lib64/weechat/plugins/irc.so
 * /usr/lib64/weechat/plugins/xfer.so
 * /usr/lib64/weechat/plugins/script.so
 * /usr/lib64/weechat/plugins/python.so
 * /usr/lib64/weechat/plugins/exec.so
 * /usr/lib64/weechat/plugins/fifo.so
 * /usr/lib64/weechat/plugins/perl.so
 * ERROR: net-irc/weechat-3.1::gentoo failed:
 *   Aborting due to QA concerns: there are files installed outside the prefix
 * 
 * Call stack:
 *   misc-functions.sh, line 601:  Called install_qa_check
 *   misc-functions.sh, line 132:  Called source 'install_symlink_html_docs'
 *            05prefix, line 114:  Called install_qa_check_prefix
 *            05prefix, line  27:  Called die
 * The specific snippet of code:
 *   			die "Aborting due to QA concerns: there are files installed outside the prefix"
 * 
 * If you need support, post the output of `emerge --info '=net-irc/weechat-3.1::gentoo'`,
 * the complete build log and the output of `emerge -pqv '=net-irc/weechat-3.1::gentoo'`.
 * The complete build log is located at '/homes/iws/yuanliao/gentoo/var/tmp/portage/net-irc/weechat-3.1/temp/build.log'.
 * The ebuild environment file is located at '/homes/iws/yuanliao/gentoo/var/tmp/portage/net-irc/weechat-3.1/temp/environment'.
 * Working directory: '/homes/iws/yuanliao/gentoo/var/tmp/portage/net-irc/weechat-3.1/image/homes/iws/yuanliao/gentoo'
 * S: '/homes/iws/yuanliao/gentoo/var/tmp/portage/net-irc/weechat-3.1/work/weechat-3.1'
!!! post install failed; exiting.
```

The patch included in this pull request fixes the issue and makes the package installable on Prefix without breaking it on a standard, non-Prefix Gentoo system.