### PR TITLE
sys-fs/udev: depend on static libudev when also building static binaries

### DIFF
--- a/sys-fs/lvm2/lvm2-2.02.187-r3.ebuild
+++ b/sys-fs/lvm2/lvm2-2.02.187-r3.ebuild
@@ -41,6 +41,7 @@ DEPEND="${DEPEND_COMMON}
 	static? (
 		selinux? ( sys-libs/libselinux[static-libs] )
 		>=sys-apps/util-linux-2.16[static-libs]
+		udev? ( >=virtual/libudev-208:=[static-libs] )
 	)"
 BDEPEND="
 	sys-devel/autoconf-archive

--- a/sys-fs/lvm2/lvm2-2.02.188-r1.ebuild
+++ b/sys-fs/lvm2/lvm2-2.02.188-r1.ebuild
@@ -41,6 +41,7 @@ DEPEND="${DEPEND_COMMON}
 	static? (
 		selinux? ( sys-libs/libselinux[static-libs] )
 		>=sys-apps/util-linux-2.16[static-libs]
+		udev? ( >=virtual/libudev-208:=[static-libs] )"
 	)"
 BDEPEND="
 	sys-devel/autoconf-archive

--- a/sys-fs/lvm2/lvm2-2.03.13-r1.ebuild
+++ b/sys-fs/lvm2/lvm2-2.03.13-r1.ebuild
@@ -41,6 +41,7 @@ DEPEND="${DEPEND_COMMON}
 	static? (
 		selinux? ( sys-libs/libselinux[static-libs] )
 		>=sys-apps/util-linux-2.16[static-libs]
+		udev? ( >=virtual/libudev-208:=[static-libs] )"
 	)"
 BDEPEND="
 	sys-devel/autoconf-archive


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/811438
