### PR TITLE
dev-python/dkimpy: delete DISTUTILS_USE_SETUPTOOLS

### DIFF
--- a/dev-python/dkimpy/dkimpy-1.0.5.ebuild
+++ b/dev-python/dkimpy/dkimpy-1.0.5.ebuild
@@ -4,7 +4,6 @@
 EAPI=7
 
 PYTHON_COMPAT=( python3_{8..10} )
-DISTUTILS_USE_SETUPTOOLS=rdepend
 
 inherit distutils-r1 optfeature
 


### PR DESCRIPTION
Due to the removal of python 3.7, DISTUTILS_USE_SETUPTOOLS is no longer
needed.

Closes:https://bugs.gentoo.org/811471

Package-Manager: Portage-3.0.20, Repoman-3.0.3
Signed-off-by: David Denoncin <ddenoncin@gmail.com>