### PR TITLE
sys-fs/zfs-kmod: set CROSS_COMPILE in the environment

### DIFF
--- a/sys-fs/zfs-kmod/zfs-kmod-0.8.6.ebuild
+++ b/sys-fs/zfs-kmod/zfs-kmod-0.8.6.ebuild
@@ -121,8 +121,12 @@ src_configure() {
 
 	filter-ldflags -Wl,*
 
+	# Set CROSS_COMPILE in the environment.
+	# This allows the user to override it via make.conf or via a local Makefile.
+	# https://bugs.gentoo.org/811600
+	export CROSS_COMPILE=${CROSS_COMPILE-${CHOST}-}
+
 	local myconf=(
-		CROSS_COMPILE="${CHOST}-"
 		HOSTCC="$(tc-getBUILD_CC)"
 		--bindir="${EPREFIX}/bin"
 		--sbindir="${EPREFIX}/sbin"
@@ -139,7 +143,6 @@ src_compile() {
 	set_arch_to_kernel
 
 	myemakeargs=(
-		CROSS_COMPILE="${CHOST}-"
 		HOSTCC="$(tc-getBUILD_CC)"
 		V=1
 	)

--- a/sys-fs/zfs-kmod/zfs-kmod-2.0.5.ebuild
+++ b/sys-fs/zfs-kmod/zfs-kmod-2.0.5.ebuild
@@ -122,8 +122,12 @@ src_configure() {
 
 	filter-ldflags -Wl,*
 
+	# Set CROSS_COMPILE in the environment.
+	# This allows the user to override it via make.conf or via a local Makefile.
+	# https://bugs.gentoo.org/811600
+	export CROSS_COMPILE=${CROSS_COMPILE-${CHOST}-}
+
 	local myconf=(
-		CROSS_COMPILE="${CHOST}-"
 		HOSTCC="$(tc-getBUILD_CC)"
 		--bindir="${EPREFIX}/bin"
 		--sbindir="${EPREFIX}/sbin"
@@ -140,7 +144,6 @@ src_compile() {
 	set_arch_to_kernel
 
 	myemakeargs=(
-		CROSS_COMPILE="${CHOST}-"
 		HOSTCC="$(tc-getBUILD_CC)"
 		V=1
 	)

--- a/sys-fs/zfs-kmod/zfs-kmod-2.1.0.ebuild
+++ b/sys-fs/zfs-kmod/zfs-kmod-2.1.0.ebuild
@@ -122,8 +122,12 @@ src_configure() {
 
 	filter-ldflags -Wl,*
 
+	# Set CROSS_COMPILE in the environment.
+	# This allows the user to override it via make.conf or via a local Makefile.
+	# https://bugs.gentoo.org/811600
+	export CROSS_COMPILE=${CROSS_COMPILE-${CHOST}-}
+
 	local myconf=(
-		CROSS_COMPILE="${CHOST}-"
 		HOSTCC="$(tc-getBUILD_CC)"
 		--bindir="${EPREFIX}/bin"
 		--sbindir="${EPREFIX}/sbin"
@@ -140,7 +144,6 @@ src_compile() {
 	set_arch_to_kernel
 
 	myemakeargs=(
-		CROSS_COMPILE="${CHOST}-"
 		HOSTCC="$(tc-getBUILD_CC)"
 		V=1
 	)

--- a/sys-fs/zfs-kmod/zfs-kmod-9999.ebuild
+++ b/sys-fs/zfs-kmod/zfs-kmod-9999.ebuild
@@ -122,8 +122,12 @@ src_configure() {
 
 	filter-ldflags -Wl,*
 
+	# Set CROSS_COMPILE in the environment.
+	# This allows the user to override it via make.conf or via a local Makefile.
+	# https://bugs.gentoo.org/811600
+	export CROSS_COMPILE=${CROSS_COMPILE-${CHOST}-}
+
 	local myconf=(
-		CROSS_COMPILE="${CHOST}-"
 		HOSTCC="$(tc-getBUILD_CC)"
 		--bindir="${EPREFIX}/bin"
 		--sbindir="${EPREFIX}/sbin"
@@ -140,7 +144,6 @@ src_compile() {
 	set_arch_to_kernel
 
 	myemakeargs=(
-		CROSS_COMPILE="${CHOST}-"
 		HOSTCC="$(tc-getBUILD_CC)"
 		V=1
 	)


### PR DESCRIPTION
This allows it to be overriden in a local Makefile.

Closes: https://bugs.gentoo.org/811600
Signed-off-by: Mike Gilbert <floppym@gentoo.org>