### PR TITLE
linux-mod.eclass: set CROSS_COMPILE in the environment

### DIFF
--- a/eclass/linux-mod.eclass
+++ b/eclass/linux-mod.eclass
@@ -673,6 +673,11 @@ linux-mod_src_compile() {
 
 	[[ -n ${KERNEL_DIR} ]] && addpredict "${KERNEL_DIR}/null.dwo"
 
+	# Set CROSS_COMPILE in the environment.
+	# This allows it to be overridden in local Makefiles.
+	# https://bugs.gentoo.org/550428
+	local -x CROSS_COMPILE=${CROSS_COMPILE-${CHOST}-}
+
 	BUILD_TARGETS=${BUILD_TARGETS:-clean module}
 	strip_modulenames;
 	cd "${S}"
@@ -705,12 +710,11 @@ linux-mod_src_compile() {
 			# inside the variables gets used as targets for Make, which then
 			# fails.
 			eval "emake HOSTCC=\"$(tc-getBUILD_CC)\" \
-						CROSS_COMPILE=${CHOST}- \
 						LDFLAGS=\"$(get_abi_LDFLAGS)\" \
 						${BUILD_FIXES} \
 						${BUILD_PARAMS} \
 						${BUILD_TARGETS} " \
-				|| die "Unable to emake HOSTCC="$(tc-getBUILD_CC)" CROSS_COMPILE=${CHOST}- LDFLAGS="$(get_abi_LDFLAGS)" ${BUILD_FIXES} ${BUILD_PARAMS} ${BUILD_TARGETS}"
+				|| die "Unable to emake HOSTCC="$(tc-getBUILD_CC)" LDFLAGS="$(get_abi_LDFLAGS)" ${BUILD_FIXES} ${BUILD_PARAMS} ${BUILD_TARGETS}"
 			cd "${OLDPWD}"
 			touch "${srcdir}"/.built
 		fi


### PR DESCRIPTION
This allows it to be overriden in local Makefiles.

Closes: https://bugs.gentoo.org/550428
Signed-off-by: Mike Gilbert <floppym@gentoo.org>