### PR TITLE
dev-util/catalyst: keyword ~riscv.

### DIFF
--- a/dev-python/diskcache/diskcache-5.2.1-r1.ebuild
+++ b/dev-python/diskcache/diskcache-5.2.1-r1.ebuild
@@ -18,7 +18,7 @@ S=${WORKDIR}/python-diskcache-${PV}
 
 LICENSE="Apache-2.0"
 SLOT="0"
-KEYWORDS="~alpha amd64 ~arm arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sparc x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~alpha amd64 ~arm arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc x86 ~amd64-linux ~x86-linux"
 
 distutils_enable_sphinx docs
 distutils_enable_tests pytest

--- a/dev-python/fasteners/fasteners-0.16.3.ebuild
+++ b/dev-python/fasteners/fasteners-0.16.3.ebuild
@@ -14,7 +14,7 @@ SRC_URI="
 
 LICENSE="Apache-2.0"
 SLOT="0"
-KEYWORDS="~alpha amd64 ~arm arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sparc x86 ~amd64-linux ~x86-linux ~x64-macos"
+KEYWORDS="~alpha amd64 ~arm arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc x86 ~amd64-linux ~x86-linux ~x64-macos"
 
 RDEPEND="
 	dev-python/six[${PYTHON_USEDEP}]"


### PR DESCRIPTION
I ran the tests.