### PR TITLE
dev-libs/libffi: use preserve-libs.eclass

### DIFF
--- a/dev-libs/libffi/libffi-3.4.2-r1.ebuild
+++ b/dev-libs/libffi/libffi-3.4.2-r1.ebuild
@@ -2,7 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-inherit multilib-minimal
+
+inherit multilib-minimal preserve-libs
 
 MY_PV=${PV/_rc/-rc}
 MY_P=${PN}-${MY_PV}
@@ -10,21 +11,21 @@ MY_P=${PN}-${MY_PV}
 DESCRIPTION="a portable, high level programming interface to various calling conventions"
 HOMEPAGE="https://sourceware.org/libffi/"
 SRC_URI="https://github.com/libffi/libffi/releases/download/v${MY_PV}/${MY_P}.tar.gz"
+S="${WORKDIR}"/${MY_P}
 
 LICENSE="MIT"
+# This is a core package which is depended on by e.g. Python
+# Please use preserve-libs.eclass in pkg_{pre,post}inst to cover users
+# with FEATURES="-preserved-libs" or another package manager if SONAME
+# changes.
 SLOT="0/8" # SONAME=libffi.so.8
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 IUSE="debug exec-static-trampoline pax-kernel static-libs test"
 
 RESTRICT="!test? ( test )"
-
-RDEPEND=""
-DEPEND=""
 BDEPEND="test? ( dev-util/dejagnu )"
 
 DOCS="ChangeLog* README.md"
-
-S=${WORKDIR}/${MY_P}
 
 ECONF_SOURCE=${S}
 
@@ -62,4 +63,12 @@ multilib_src_configure() {
 multilib_src_install_all() {
 	find "${ED}" -name "*.la" -delete || die
 	einstalldocs
+}
+
+pkg_preinst() {
+	preserve_old_lib /usr/$(get_libdir)/libffi.so.7
+}
+
+pkg_postinst() {
+	preserve_old_lib_notify /usr/$(get_libdir)/libffi.so.7
 }


### PR DESCRIPTION
1. Revision bump to re-install libffi now that
   glibc definitely has the correct version bounds
   on pax-utils. See linked bug for more information.

   This is unrelated to the preserve-libs eclass change,
   but we figured we should do this just as a nudge
   to help people in a "damaged" situation (see bug).

2. Use preserved-libs.eclass because SONAME of libffi
   changed from 7 -> 8. FEATURES="preserved-libs" (distinct from
   the eclass) is not required to be used (even if encouraged)
   and is not part of PMS, so alternative package managers
   to Portage don't have to implement it.

   Use the eclass to perserve libffi.so.7 to keep dev-lang/python
   working. Runtime failures will occur without Python being rebuilt
   in time.

   (Unfortunately, the same is true for the rewritten-in-Python
   revdep-rebuild, so revdep-rebuild.sh may help folks who are
   already bitten by this.)

Bug: https://bugs.gentoo.org/811462
Signed-off-by: Sam James <sam@gentoo.org>