### PR TITLE
Fix icon_cache_update in several ebuilds

### DIFF
--- a/app-text/zathura-djvu/zathura-djvu-0.2.9.ebuild
+++ b/app-text/zathura-djvu/zathura-djvu-0.2.9.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit meson xdg-utils
+inherit meson xdg
 
 if [[ ${PV} == *9999 ]]; then
 	inherit git-r3
@@ -28,13 +28,3 @@ RDEPEND="app-text/djvu
 
 DEPEND="${RDEPEND}
 	virtual/pkgconfig"
-
-pkg_postinst() {
-	xdg_icon_cache_update
-	xdg_desktop_database_update
-}
-
-pkg_postrm() {
-	xdg_icon_cache_update
-	xdg_desktop_database_update
-}

--- a/app-text/zathura-djvu/zathura-djvu-9999.ebuild
+++ b/app-text/zathura-djvu/zathura-djvu-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit gnome2-utils meson xdg-utils
+inherit meson xdg
 
 if [[ ${PV} == *9999 ]]; then
 	inherit git-r3
@@ -28,13 +28,3 @@ RDEPEND="app-text/djvu
 
 DEPEND="${RDEPEND}
 	virtual/pkgconfig"
-
-pkg_postinst() {
-	gnome2_icon_cache_update
-	xdg_desktop_database_update
-}
-
-pkg_postrm() {
-	gnome2_icon_cache_update
-	xdg_desktop_database_update
-}

--- a/games-fps/sauerbraten/sauerbraten-2013.02.03-r2.ebuild
+++ b/games-fps/sauerbraten/sauerbraten-2013.02.03-r2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit desktop flag-o-matic gnome2-utils toolchain-funcs vcs-clean wrapper
+inherit desktop flag-o-matic toolchain-funcs vcs-clean wrapper xdg
 
 EDITION="collect_edition"
 DESCRIPTION="Sauerbraten is a FOSS game engine (Cube 2) with freeware game data (Sauerbraten)"
@@ -118,17 +118,9 @@ src_install() {
 	dodoc -r README.html docs/*
 }
 
-pkg_preinst() {
-	gnome2_icon_savelist
-}
-
 pkg_postinst() {
-	gnome2_icon_cache_update
+	xdg_pkg_postinst
 
 	elog "If you plan to use map editor feature copy all map data from ${DATADIR}"
 	elog "to corresponding folder in your HOME/.${PN}"
-}
-
-pkg_postrm() {
-	gnome2_icon_cache_update
 }

--- a/media-sound/gmtp/gmtp-1.3.11-r2.ebuild
+++ b/media-sound/gmtp/gmtp-1.3.11-r2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit gnome2-utils
+inherit gnome2-utils xdg
 
 DESCRIPTION="A simple MTP client for MP3 players"
 HOMEPAGE="http://gmtp.sourceforge.net/"
@@ -32,16 +32,16 @@ src_configure() {
 }
 
 pkg_preinst() {
-	gnome2_icon_savelist
+	xdg_pkg_preinst
 	gnome2_schemas_savelist
 }
 
 pkg_postinst() {
-	gnome2_icon_cache_update
+	xdg_pkg_postinst
 	gnome2_schemas_update
 }
 
 pkg_postrm() {
-	gnome2_icon_cache_update
+	xdg_pkg_postrm
 	gnome2_schemas_update
 }

--- a/net-misc/tigervnc/tigervnc-1.9.0-r2.ebuild
+++ b/net-misc/tigervnc/tigervnc-1.9.0-r2.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 CMAKE_IN_SOURCE_BUILD=1
 
-inherit autotools cmake flag-o-matic java-pkg-opt-2 systemd xdg-utils gnome2-utils
+inherit autotools cmake flag-o-matic java-pkg-opt-2 systemd xdg
 
 XSERVER_VERSION="1.20.0"
 
@@ -185,14 +185,4 @@ src_install() {
 			rm usr/share/man/man1/$f.1 || die
 		done
 	fi
-}
-
-pkg_postinst() {
-	xdg_desktop_database_update
-	gnome2_icon_cache_update
-}
-
-pkg_postrm() {
-	xdg_desktop_database_update
-	gnome2_icon_cache_update
 }

--- a/x11-themes/gartoon-redux/gartoon-redux-1.10-r1.ebuild
+++ b/x11-themes/gartoon-redux/gartoon-redux-1.10-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit gnome2-utils
+inherit xdg
 
 DESCRIPTION="A massively improved variant of the well-known Gartoon theme"
 HOMEPAGE="https://gnome-look.org/content/show.php/?content=74841"
@@ -39,16 +39,4 @@ src_compile() {
 src_install() {
 	emake icondir="${D}"/usr/share/icons/GartoonRedux install
 	dodoc AUTHORS changelog README TODO
-}
-
-pkg_preinst() {
-	gnome2_icon_savelist
-}
-
-pkg_postinst() {
-	gnome2_icon_cache_update
-}
-
-pkg_postrm() {
-	gnome2_icon_cache_update
 }

--- a/x11-themes/gnome-colors-common/gnome-colors-common-5.5.1-r1.ebuild
+++ b/x11-themes/gnome-colors-common/gnome-colors-common-5.5.1-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit gnome2-utils
+inherit xdg
 
 DESCRIPTION="Colorized icons shared between all gnome-colors iconsets"
 HOMEPAGE="https://code.google.com/p/gnome-colors/"
@@ -43,16 +43,4 @@ src_install() {
 	doins -r "${WORKDIR}/${PN}"
 
 	einstalldocs
-}
-
-pkg_preinst() {
-	gnome2_icon_savelist
-}
-
-pkg_postinst() {
-	gnome2_icon_cache_update
-}
-
-pkg_postrm() {
-	gnome2_icon_cache_update
 }

--- a/x11-themes/gnome-colors-themes/gnome-colors-themes-5.5.1.ebuild
+++ b/x11-themes/gnome-colors-themes/gnome-colors-themes-5.5.1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit gnome2-utils
+inherit xdg
 
 DESCRIPTION="Some gnome-colors iconsets including a Gentoo one"
 HOMEPAGE="https://code.google.com/p/gnome-colors/"
@@ -30,16 +30,4 @@ src_install() {
 	done
 
 	einstalldocs
-}
-
-pkg_preinst() {
-	gnome2_icon_savelist
-}
-
-pkg_postinst() {
-	gnome2_icon_cache_update
-}
-
-pkg_postrm() {
-	gnome2_icon_cache_update
 }


### PR DESCRIPTION
There are several ebuilds at EAPI 7 which incorrectly use gnome2_icon_cache_update which isnt enabled for EAPI 7 https://github.com/gentoo/gentoo/commit/1b183b8fb6e5c0ce2265265556fe5d061b959f79. This pull request updates any that I found with `grep -lr "gnome2_icon_cache_update" | xargs grep -l "EAPI=[78]"`. With most I just went with using xdg.eclass and removing pkg_{preinst,post{inst,rm}} where I could as being redundant.

With zathura-djvu-0.2.9 i gave it same treatment as zathura-djvu-9999 even though it didnt use gnome2_icon_cache_update.