### PR TITLE
mail-filter/rspamd: mask jemalloc use-flag

### DIFF
--- a/profiles/base/package.use.mask
+++ b/profiles/base/package.use.mask
@@ -6,6 +6,12 @@
 # This file is only for generic masks. For arch-specific masks (i.e.
 # mask everywhere, unmask on arch/*) use arch/base.
 
+# Petr Vanek <arkamar@atlas.cz> (2021-09-12)
+# rspamd-3.0 segfaults a lot with jemalloc enabled (Bug #810337)
+# It is caused by -Wl,--as-needed linker flag,
+# see also: https://github.com/rspamd/rspamd/issues/3871
+~mail-filter/rspamd-3.0 jemalloc
+
 # James Le Cuirot <chewi@gentoo.org> (2021-09-04)
 # Currently requires an unreleased version of FFmpeg. If you really want it,
 # unmask the flag and emerge ffmpeg-9999 with this environment variable set:


### PR DESCRIPTION
- mask `jemalloc` due to the bug [#810337](https://bugs.gentoo.org/show_bug.cgi?id=810337)
- ~introduce `lto` use flag, it was disabled by default~