### PR TITLE
dev-cpp/doctest: fix gcc-11 related compilation error

### DIFF
--- a/dev-cpp/doctest/doctest-2.4.6.ebuild
+++ b/dev-cpp/doctest/doctest-2.4.6.ebuild
@@ -15,6 +15,8 @@ KEYWORDS="~amd64 ~x86"
 IUSE="test"
 RESTRICT="!test? ( test )"
 
+PATCHES=( "${FILESDIR}/${P}-remove-unused-bla2.patch" )
+
 src_configure() {
 	local mycmakeargs=(
 		-DDOCTEST_WITH_TESTS=$(usex test)

--- a/dev-cpp/doctest/files/doctest-2.4.6-remove-unused-bla2.patch
+++ b/dev-cpp/doctest/files/doctest-2.4.6-remove-unused-bla2.patch
@@ -1,0 +1,23 @@
+This patch follows proposed fixes to upstream.
+
+PR-1: https://github.com/onqtam/doctest/pull/505
+PR-2: https://github.com/onqtam/doctest/pull/520
+
+
+diff --git a/examples/all_features/stringification.cpp b/examples/all_features/stringification.cpp
+index a8b5d5b..492e1ec 100644
+--- a/examples/all_features/stringification.cpp
++++ b/examples/all_features/stringification.cpp
+@@ -103,9 +103,6 @@ TEST_CASE("all asserts should fail and show how the objects get stringified") {
+     MyTypeInherited<int> bla1;
+     bla1.one = 5;
+     bla1.two = 4u;
+-    MyTypeInherited<int> bla2;
+-    bla2.one = 5;
+-    bla2.two = 6u;
+ 
+     Bar::Foo f1;
+     Bar::Foo f2;
+-- 
+2.32.0
+


### PR DESCRIPTION
Apply patch in order to fix gcc-11 related compilation error. The patch follows proposed fixes to upstream [1,2].

[1] https://github.com/onqtam/doctest/pull/505
[2] https://github.com/onqtam/doctest/pull/520