### PR TITLE
riscv: keyword some packages in kde-apps, dev-vcs/stgit and app-portage/layman

### DIFF
--- a/app-crypt/gentoo-keys/gentoo-keys-201901130136.ebuild
+++ b/app-crypt/gentoo-keys/gentoo-keys-201901130136.ebuild
@@ -10,7 +10,7 @@ SRC_URI="https://dev.gentoo.org/~dolsen/releases/keyrings/${P}.tar.xz"
 LICENSE="GPL-2"
 SLOT="0"
 
-KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~m68k ~mips ppc ppc64 ~s390 sparc x86 ~x64-cygwin ~amd64-linux"
+KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~x64-cygwin ~amd64-linux"
 
 S="${WORKDIR}"
 

--- a/app-portage/g-sorcery/g-sorcery-0.2.2.ebuild
+++ b/app-portage/g-sorcery/g-sorcery-0.2.2.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://gitweb.gentoo.org/proj/g-sorcery.git/snapshot/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~riscv ~sparc ~x86"
 IUSE="bson git test"
 RESTRICT="!test? ( test )"
 

--- a/app-portage/layman/layman-2.4.3.ebuild
+++ b/app-portage/layman/layman-2.4.3.ebuild
@@ -14,7 +14,7 @@ if [[ ${PV} == *9999 ]] ; then
 	inherit git-r3
 else
 	SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
-	KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~mips ppc ppc64 ~s390 sparc x86 ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
+	KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
 fi
 
 DESCRIPTION="Tool to manage Gentoo overlays"

--- a/app-portage/layman/layman-9999.ebuild
+++ b/app-portage/layman/layman-9999.ebuild
@@ -14,7 +14,7 @@ if [[ ${PV} == *9999 ]] ; then
 	inherit git-r3
 else
 	SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
-	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86 ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
 fi
 
 DESCRIPTION="Tool to manage Gentoo overlays"

--- a/dev-python/pyGPG/pyGPG-0.2.ebuild
+++ b/dev-python/pyGPG/pyGPG-0.2.ebuild
@@ -15,7 +15,7 @@ if [[ ${PV} == *9999 ]]; then
 	EGIT_BRANCH="master"
 else
 	SRC_URI="https://dev.gentoo.org/~dolsen/releases/pyGPG/${P}.tar.gz"
-	KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~mips ppc ppc64 ~s390 sparc x86"
+	KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~mips ppc ppc64 ~riscv ~s390 sparc x86"
 fi
 
 DESCRIPTION="A python interface wrapper for gnupg's gpg command"

--- a/dev-python/pyGPG/pyGPG-9999.ebuild
+++ b/dev-python/pyGPG/pyGPG-9999.ebuild
@@ -15,7 +15,7 @@ if [[ ${PV} == *9999 ]]; then
 	EGIT_BRANCH="master"
 else
 	SRC_URI="https://dev.gentoo.org/~dolsen/releases/pyGPG/${P}.tar.gz"
-	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
 fi
 
 DESCRIPTION="A python interface wrapper for gnupg's gpg command"

--- a/dev-vcs/stgit/stgit-1.1.ebuild
+++ b/dev-vcs/stgit/stgit-1.1.ebuild
@@ -19,7 +19,7 @@ SRC_URI="https://github.com/ctmarinas/stgit/archive/v${PV}.tar.gz -> ${P}.tar.gz
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 arm arm64 ppc ppc64 x86 ~amd64-linux ~x86-linux"
+KEYWORDS="amd64 arm arm64 ppc ppc64 ~riscv x86 ~amd64-linux ~x86-linux"
 IUSE="doc"
 
 RDEPEND=">=dev-vcs/git-1.6.3.3"

--- a/kde-apps/analitza/analitza-21.08.1.ebuild
+++ b/kde-apps/analitza/analitza-21.08.1.ebuild
@@ -12,7 +12,7 @@ DESCRIPTION="KDE library for mathematical features"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"
-KEYWORDS="~amd64 ~arm64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~riscv ~x86"
 IUSE="eigen nls"
 
 BDEPEND="

--- a/kde-apps/artikulate/artikulate-21.08.1.ebuild
+++ b/kde-apps/artikulate/artikulate-21.08.1.ebuild
@@ -13,7 +13,7 @@ HOMEPAGE="https://apps.kde.org/artikulate/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"
-KEYWORDS="~amd64 ~arm64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~riscv ~x86"
 IUSE=""
 
 DEPEND="

--- a/kde-apps/audiocd-kio/audiocd-kio-21.08.1.ebuild
+++ b/kde-apps/audiocd-kio/audiocd-kio-21.08.1.ebuild
@@ -13,7 +13,7 @@ DESCRIPTION="kioslave for accessing audio CDs"
 
 LICENSE="GPL-2+ handbook? ( FDL-1.2 )"
 SLOT="5"
-KEYWORDS="~amd64 ~arm64 ~ppc64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="flac vorbis"
 
 DEPEND="

--- a/kde-apps/blinken/blinken-21.08.1.ebuild
+++ b/kde-apps/blinken/blinken-21.08.1.ebuild
@@ -13,7 +13,7 @@ HOMEPAGE="https://apps.kde.org/blinken/ https://edu.kde.org/blinken/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"
-KEYWORDS="~amd64 ~arm64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~riscv ~x86"
 IUSE=""
 
 DEPEND="

--- a/kde-apps/dragon/dragon-21.08.1.ebuild
+++ b/kde-apps/dragon/dragon-21.08.1.ebuild
@@ -13,7 +13,7 @@ HOMEPAGE="https://apps.kde.org/dragonplayer/"
 
 LICENSE="GPL-2+ || ( GPL-2 GPL-3 ) handbook? ( FDL-1.2 )"
 SLOT="5"
-KEYWORDS="~amd64 ~arm64 ~ppc64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 BDEPEND="

--- a/kde-apps/gwenview/gwenview-21.08.1.ebuild
+++ b/kde-apps/gwenview/gwenview-21.08.1.ebuild
@@ -15,7 +15,7 @@ HOMEPAGE="https://apps.kde.org/gwenview/ https://userbase.kde.org/Gwenview"
 
 LICENSE="GPL-2+ handbook? ( FDL-1.2 )"
 SLOT="5"
-KEYWORDS="~amd64 ~arm64 ~ppc64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="activities fits kipi +mpris raw semantic-desktop share X"
 
 # requires running environment

--- a/kde-apps/juk/juk-21.08.1.ebuild
+++ b/kde-apps/juk/juk-21.08.1.ebuild
@@ -14,7 +14,7 @@ HOMEPAGE="https://apps.kde.org/juk/"
 
 LICENSE="GPL-2" # TODO: CHECK
 SLOT="5"
-KEYWORDS="~amd64 ~arm64 ~ppc64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND="

--- a/kde-apps/kamera/kamera-21.08.1.ebuild
+++ b/kde-apps/kamera/kamera-21.08.1.ebuild
@@ -13,7 +13,7 @@ HOMEPAGE="https://apps.kde.org/kamera/"
 
 LICENSE="GPL-2+ handbook? ( FDL-1.2 )"
 SLOT="5"
-KEYWORDS="~amd64 ~arm64 ~ppc64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 BDEPEND="

--- a/kde-apps/kipi-plugins/kipi-plugins-21.08.1.ebuild
+++ b/kde-apps/kipi-plugins/kipi-plugins-21.08.1.ebuild
@@ -14,7 +14,7 @@ HOMEPAGE="https://apps.kde.org/kipi_plugins/ https://userbase.kde.org/KIPI"
 
 LICENSE="GPL-2+"
 SLOT="5"
-KEYWORDS="~amd64 ~arm64 ~ppc64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="mediawiki +remotestorage"
 
 RDEPEND="

--- a/kde-apps/libkcddb/libkcddb-21.08.1.ebuild
+++ b/kde-apps/libkcddb/libkcddb-21.08.1.ebuild
@@ -13,7 +13,7 @@ DESCRIPTION="KDE library for CDDB"
 
 LICENSE="GPL-2+ handbook? ( FDL-1.2 )"
 SLOT="5"
-KEYWORDS="~amd64 ~arm64 ~ppc64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="musicbrainz"
 
 DEPEND="

--- a/kde-apps/libkcompactdisc/libkcompactdisc-21.08.1.ebuild
+++ b/kde-apps/libkcompactdisc/libkcompactdisc-21.08.1.ebuild
@@ -12,7 +12,7 @@ DESCRIPTION="Library for playing & ripping CDs"
 
 LICENSE="GPL-2+ LGPL-2+"
 SLOT="5"
-KEYWORDS="~amd64 ~arm64 ~ppc64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="alsa"
 
 DEPEND="

--- a/kde-apps/libkdcraw/libkdcraw-21.08.1.ebuild
+++ b/kde-apps/libkdcraw/libkdcraw-21.08.1.ebuild
@@ -10,7 +10,7 @@ DESCRIPTION="Digital camera raw image library wrapper"
 
 LICENSE="GPL-2+"
 SLOT="5"
-KEYWORDS="~amd64 ~arm64 ~ppc64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 DEPEND="

--- a/kde-apps/libkipi/libkipi-21.08.1.ebuild
+++ b/kde-apps/libkipi/libkipi-21.08.1.ebuild
@@ -11,7 +11,7 @@ DESCRIPTION="A library for image plugins accross KDE applications"
 
 LICENSE="GPL-2+"
 SLOT="5/32"
-KEYWORDS="~amd64 ~arm64 ~ppc64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 DEPEND="

--- a/kde-frameworks/kimageformats/kimageformats-5.86.0.ebuild
+++ b/kde-frameworks/kimageformats/kimageformats-5.86.0.ebuild
@@ -11,7 +11,7 @@ inherit ecm kde.org
 
 DESCRIPTION="Framework providing additional format plugins for Qt's image I/O system"
 LICENSE="LGPL-2+"
-KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="avif eps heif openexr"
 
 DEPEND="

--- a/net-libs/libmediawiki/libmediawiki-5.37.0-r1.ebuild
+++ b/net-libs/libmediawiki/libmediawiki-5.37.0-r1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="mirror://kde/stable/${PN}/${P}.tar.xz"
 
 LICENSE="GPL-2+"
 SLOT="5"
-KEYWORDS="~amd64 ~arm64 ~ppc64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 DEPEND="
 	>=dev-qt/qtnetwork-${QTMIN}:5

--- a/profiles/arch/riscv/package.use.mask
+++ b/profiles/arch/riscv/package.use.mask
@@ -1,6 +1,10 @@
 # Copyright 2019-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Alex Fan <alexfanqi@yahoo.com> (2021-09-13)
+# dev-vcs/darcs depends on haskell
+app-portage/layman darcs
+
 # Sam James <sam@gentoo.org> (2021-09-12)
 # dev-ruby/asciidoctor isn't keyworded here
 dev-util/ccache doc


### PR DESCRIPTION
mask darcs for app-portage/layman because it depends on haskell.