### PR TITLE
dev-python/*: bump to python 3.10

### DIFF
--- a/dev-python/easyprocess/easyprocess-0.3-r1.ebuild
+++ b/dev-python/easyprocess/easyprocess-0.3-r1.ebuild
@@ -1,15 +1,16 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
-PYTHON_COMPAT=( python3_{7,8,9} )
+PYTHON_COMPAT=( python3_{8..10} )
 
 inherit distutils-r1
 
 DESCRIPTION="Easy to use Python subprocess interface"
 HOMEPAGE="https://github.com/ponty/EasyProcess"
 SRC_URI="https://github.com/ponty/EasyProcess/archive/${PV}.tar.gz -> ${P}.tar.gz"
+S="${WORKDIR}/EasyProcess-${PV}"
 
 LICENSE="BSD-2"
 SLOT="0"
@@ -21,7 +22,5 @@ BDEPEND="test? (
 	dev-python/six[${PYTHON_USEDEP}]
 	x11-base/xorg-server[xvfb]
 )"
-
-S="${WORKDIR}/EasyProcess-${PV}"
 
 distutils_enable_tests pytest

--- a/dev-python/easyprocess/metadata.xml
+++ b/dev-python/easyprocess/metadata.xml
@@ -8,5 +8,6 @@
 	<stabilize-allarches/>
 	<upstream>
 		<remote-id type="pypi">EasyProcess</remote-id>
+		<remote-id type="github">ponty/EasyProcess</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/dev-python/entrypoint2/entrypoint2-0.2.4.ebuild
+++ b/dev-python/entrypoint2/entrypoint2-0.2.4.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{7,8,9} )
+PYTHON_COMPAT=( python3_{8..10} )
 
 inherit distutils-r1
 

--- a/dev-python/entrypoint2/metadata.xml
+++ b/dev-python/entrypoint2/metadata.xml
@@ -8,5 +8,6 @@
 	<stabilize-allarches/>
 	<upstream>
 		<remote-id type="pypi">entrypoint2</remote-id>
+		<remote-id type="github">ponty/entrypoint2</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/dev-python/pyscreenshot/metadata.xml
+++ b/dev-python/pyscreenshot/metadata.xml
@@ -12,5 +12,6 @@
 	<stabilize-allarches/>
 	<upstream>
 		<remote-id type="pypi">pyscreenshot</remote-id>
+		<remote-id type="github">ponty/pyscreenshot</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/dev-python/pyscreenshot/pyscreenshot-3.0.ebuild
+++ b/dev-python/pyscreenshot/pyscreenshot-3.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{7,8,9} )
+PYTHON_COMPAT=( python3_{8..10} )
 
 inherit distutils-r1 virtualx
 

--- a/dev-python/pytest-xvfb/metadata.xml
+++ b/dev-python/pytest-xvfb/metadata.xml
@@ -8,5 +8,6 @@
 	<stabilize-allarches/>
 	<upstream>
 		<remote-id type="pypi">pytest-xvfb</remote-id>
+		<remote-id type="github">The-Compiler/pytest-xvfb</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/dev-python/pytest-xvfb/pytest-xvfb-2.0.0-r1.ebuild
+++ b/dev-python/pytest-xvfb/pytest-xvfb-2.0.0-r1.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 
 PYTHON_REQ_USE="tk"
-PYTHON_COMPAT=( python3_{7,8,9} )
+PYTHON_COMPAT=( python3_{8..10} )
 
 inherit distutils-r1
 
@@ -22,13 +22,4 @@ RDEPEND="
 	x11-base/xorg-server[xvfb]
 "
 
-distutils_enable_tests pytest
-
-python_test() {
-	local -x PYTHONPATH="${BUILD_DIR}/install/lib"
-	esetup.py install \
-		--root="${BUILD_DIR}/install" \
-		--install-lib=lib
-
-	pytest -vv || die "Tests fail with ${EPYTHON}"
-}
+distutils_enable_tests --install pytest

--- a/dev-python/pyvirtualdisplay/metadata.xml
+++ b/dev-python/pyvirtualdisplay/metadata.xml
@@ -12,5 +12,6 @@
 	<stabilize-allarches/>
 	<upstream>
 		<remote-id type="pypi">PyVirtualDisplay</remote-id>
+		<remote-id type="github">ponty/PyVirtualDisplay</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/dev-python/pyvirtualdisplay/pyvirtualdisplay-2.2.ebuild
+++ b/dev-python/pyvirtualdisplay/pyvirtualdisplay-2.2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{7..9} )
+PYTHON_COMPAT=( python3_{8..10} )
 
 inherit distutils-r1
 
@@ -26,8 +26,9 @@ RESTRICT="test"
 RDEPEND="dev-python/easyprocess[${PYTHON_USEDEP}]"
 BDEPEND="
 	test? (
-		$(python_gen_cond_dep \
-			'dev-python/backports-tempfile[${PYTHON_USEDEP}]' python3_7 python3_8 )
+		$(python_gen_cond_dep '
+			dev-python/backports-tempfile[${PYTHON_USEDEP}]
+		' python3_8 )
 		dev-python/entrypoint2[${PYTHON_USEDEP}]
 		dev-python/path-py[${PYTHON_USEDEP}]
 		dev-python/pillow[${PYTHON_USEDEP}]

--- a/dev-python/vncdotool/metadata.xml
+++ b/dev-python/vncdotool/metadata.xml
@@ -8,5 +8,6 @@
 	<stabilize-allarches/>
 	<upstream>
 		<remote-id type="pypi">vncdotool</remote-id>
+		<remote-id type="github">sibson/vncdotool</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/dev-python/vncdotool/vncdotool-0.13.0.ebuild
+++ b/dev-python/vncdotool/vncdotool-0.13.0.ebuild
@@ -1,11 +1,9 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{7,8,9} )
-DISTUTILS_USE_SETUPTOOLS=rdepend
-
+PYTHON_COMPAT=( python3_{8..10} )
 inherit distutils-r1
 
 DESCRIPTION="Command line VNC client"
@@ -16,8 +14,9 @@ LICENSE="MIT"
 SLOT="0"
 KEYWORDS="amd64 x86"
 
-# No clue why this happens:
+# A lot of errors such as the following appear
 # pexpect.exceptions.ExceptionPexpect: The command was not found or was not executable: vncev.
+# to install those, a manual compile and install of examples from net-libs/libvncserver is needed
 RESTRICT="test"
 
 BDEPEND="test? (
@@ -30,8 +29,7 @@ BDEPEND="test? (
 	dev-python/tox[${PYTHON_USEDEP}]
 	dev-python/virtualenv[${PYTHON_USEDEP}]
 )"
-
-DEPEND="
+RDEPEND="
 	dev-python/pillow[${PYTHON_USEDEP}]
 	dev-python/twisted[${PYTHON_USEDEP}]
 	dev-python/zope-interface[${PYTHON_USEDEP}]

--- a/dev-python/vncdotool/vncdotool-1.0.0.ebuild
+++ b/dev-python/vncdotool/vncdotool-1.0.0.ebuild
@@ -3,9 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{7..10} )
-DISTUTILS_USE_SETUPTOOLS=rdepend
-
+PYTHON_COMPAT=( python3_{8..10} )
 inherit distutils-r1
 
 DESCRIPTION="Command line VNC client"
@@ -16,8 +14,9 @@ LICENSE="MIT"
 SLOT="0"
 KEYWORDS="amd64 x86"
 
-# No clue why this happens:
+# A lot of errors such as the following appear
 # pexpect.exceptions.ExceptionPexpect: The command was not found or was not executable: vncev.
+# to install those, a manual compile and install of examples from net-libs/libvncserver is needed
 RESTRICT="test"
 
 BDEPEND="test? (
@@ -30,8 +29,7 @@ BDEPEND="test? (
 	dev-python/tox[${PYTHON_USEDEP}]
 	dev-python/virtualenv[${PYTHON_USEDEP}]
 )"
-
-DEPEND="
+RDEPEND="
 	dev-python/pillow[${PYTHON_USEDEP}]
 	dev-python/twisted[${PYTHON_USEDEP}]
 	dev-python/zope-interface[${PYTHON_USEDEP}]


### PR DESCRIPTION
Hi again @AndrewAmmerlaan 
In this PR, I have bumped to python 3.10 all packages needed for `dev-python/pytest-xvfb`.
Do note that there is a 4 package circular dependency here.
Also added the GitHub remote-id to the metadata.xml

---

Found why and how to run the test suite of `dev-python/vncdotool`, and must say it is one of the worst I saw till today. The package expects the examples from `net-libs/libvncserver`. But those aren't intended to be installed (CMake skips them from install). By manually configuring and manually calling ninja build example, and manually installing, the test suite can be ran and work. It isn't worth it to fix the test suite in ebuild.

---

For `dev-python/pyvirtualdisplay`, managed to run tests by defining:
``` 
EPYTEST_DESELECT=(
    tests/test_smart.py::test_empty
)
```
But I'm not sure on which system you got a hang and on which test, so preferred to not enable the tests.

---

As this quite a big bump, with packages that have not an excellent upstream test suite, wanted your ACK before merging.