### PR TITLE
media-video/wireplumber: multiple fixes for runtime issues

### DIFF
--- a/media-video/wireplumber/files/wireplumber-0.4.2-bluez-add-basic-check-for-nil-monitor.patch
+++ b/media-video/wireplumber/files/wireplumber-0.4.2-bluez-add-basic-check-for-nil-monitor.patch
@@ -1,0 +1,42 @@
+From 32d96189b807ab53317a33217c661ce4b1ac8e49 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Nikl=C4=81vs=20Ko=C4=BCes=C5=86ikovs?=
+ <89q1r14hd@relay.firefox.com>
+Date: Wed, 15 Sep 2021 12:21:40 +0300
+Subject: [PATCH 3/5] bluez: add basic check for nil monitor
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+If PipeWire is built without Bluetooth support, then
+
+`monitor = SpaDevice("api.bluez5.enum.dbus", monitor_props)`
+
+will result in a nil monitor. This commit adds a basic sanity check
+to avoid further using the nil variable.
+
+Thanks-to: Pascal Flöschel (initial bug report)
+Thanks-to: George Kiagiadakis <george.kiagiadakis@collabora.com>
+Bug: https://bugs.gentoo.org/813043
+---
+ src/scripts/monitors/bluez.lua | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/src/scripts/monitors/bluez.lua b/src/scripts/monitors/bluez.lua
+index fc229fa..4066536 100644
+--- a/src/scripts/monitors/bluez.lua
++++ b/src/scripts/monitors/bluez.lua
+@@ -129,5 +129,9 @@ local monitor_props = config.properties or {}
+ monitor_props["api.bluez5.connection-info"] = true
+ 
+ monitor = SpaDevice("api.bluez5.enum.dbus", monitor_props)
+-monitor:connect("create-object", createDevice)
+-monitor:activate(Feature.SpaDevice.ENABLED)
++if monitor then
++  monitor:connect("create-object", createDevice)
++  monitor:activate(Feature.SpaDevice.ENABLED)
++else
++  Log.message("PipeWire's BlueZ SPA missing or broken. Bluetooth not supported.")
++end
+-- 
+2.33.0
+

--- a/media-video/wireplumber/files/wireplumber-0.4.2-lib-wp-device-demote-missing-SPA-warning-to-message.patch
+++ b/media-video/wireplumber/files/wireplumber-0.4.2-lib-wp-device-demote-missing-SPA-warning-to-message.patch
@@ -1,0 +1,28 @@
+From 05334c1ec72af68f915ea18e32b230857918f600 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Nikl=C4=81vs=20Ko=C4=BCes=C5=86ikovs?=
+ <89q1r14hd@relay.firefox.com>
+Date: Wed, 15 Sep 2021 13:23:45 +0300
+Subject: [PATCH 5/5] lib/wp/device: demote missing SPA warning to message
+
+Warnings can be scary, so best not to scare users with what's likely
+intentional omission of a particular SPA plugin (currently V4L & BlueZ).
+---
+ lib/wp/device.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/wp/device.c b/lib/wp/device.c
+index f0c32af..9a0b995 100644
+--- a/lib/wp/device.c
++++ b/lib/wp/device.c
+@@ -617,7 +617,7 @@ wp_spa_device_new_from_spa_factory (WpCore * core,
+   handle = pw_context_load_spa_handle (pw_context, factory_name,
+       props ? wp_properties_peek_dict (props) : NULL);
+   if (!handle) {
+-    wp_warning ("SPA handle '%s' could not be loaded; is it installed?",
++    wp_message ("SPA handle '%s' could not be loaded; is it installed?",
+         factory_name);
+     return NULL;
+   }
+-- 
+2.33.0
+

--- a/media-video/wireplumber/files/wireplumber-0.4.2-lua-api-fix-object-constructors-to-fail-gracefully.patch
+++ b/media-video/wireplumber/files/wireplumber-0.4.2-lua-api-fix-object-constructors-to-fail-gracefully.patch
@@ -1,0 +1,100 @@
+From 2a5f9c51f2f8dd29cd19a14f165ca2b425a172fc Mon Sep 17 00:00:00 2001
+From: George Kiagiadakis <george.kiagiadakis@collabora.com>
+Date: Wed, 15 Sep 2021 12:51:47 +0300
+Subject: [PATCH 2/5] lua/api: fix object constructors to fail gracefully
+
+---
+ modules/module-lua-scripting/api.c | 35 ++++++++++++++++++------------
+ 1 file changed, 21 insertions(+), 14 deletions(-)
+
+diff --git a/modules/module-lua-scripting/api.c b/modules/module-lua-scripting/api.c
+index 5691b63..2830477 100644
+--- a/modules/module-lua-scripting/api.c
++++ b/modules/module-lua-scripting/api.c
+@@ -836,8 +836,9 @@ device_new (lua_State *L)
+ 
+   WpDevice *d = wp_device_new_from_factory (get_wp_export_core (L),
+       factory, properties);
+-  wplua_pushobject (L, d);
+-  return 1;
++  if (d)
++    wplua_pushobject (L, d);
++  return d ? 1 : 0;
+ }
+ 
+ /* WpSpaDevice */
+@@ -855,8 +856,9 @@ spa_device_new (lua_State *L)
+ 
+   WpSpaDevice *d = wp_spa_device_new_from_spa_factory (get_wp_export_core (L),
+       factory, properties);
+-  wplua_pushobject (L, d);
+-  return 1;
++  if (d)
++    wplua_pushobject (L, d);
++  return d ? 1 : 0;
+ }
+ 
+ static int
+@@ -903,8 +905,9 @@ node_new (lua_State *L)
+ 
+   WpNode *d = wp_node_new_from_factory (get_wp_export_core (L),
+       factory, properties);
+-  wplua_pushobject (L, d);
+-  return 1;
++  if (d)
++    wplua_pushobject (L, d);
++  return d ? 1 : 0;
+ }
+ 
+ static int
+@@ -1011,8 +1014,9 @@ impl_node_new (lua_State *L)
+ 
+   WpImplNode *d = wp_impl_node_new_from_pw_factory (get_wp_export_core (L),
+      factory, properties);
+-  wplua_pushobject (L, d);
+-  return 1;
++  if (d)
++    wplua_pushobject (L, d);
++  return d ? 1 : 0;
+ }
+ 
+ /* Port */
+@@ -1045,8 +1049,9 @@ link_new (lua_State *L)
+   }
+ 
+   WpLink *l = wp_link_new_from_factory (get_wp_core (L), factory, properties);
+-  wplua_pushobject (L, l);
+-  return 1;
++  if (l)
++    wplua_pushobject (L, l);
++  return l ? 1 : 0;
+ }
+ 
+ /* Client */
+@@ -1124,8 +1129,9 @@ session_item_new (lua_State *L)
+ {
+   const char *type = luaL_checkstring (L, 1);
+   WpSessionItem *si = wp_session_item_make (get_wp_core (L), type);
+-  wplua_pushobject (L, si);
+-  return 1;
++  if (si)
++    wplua_pushobject (L, si);
++  return si ? 1 : 0;
+ }
+ 
+ static int
+@@ -1135,8 +1141,9 @@ session_item_get_associated_proxy (lua_State *L)
+   const char *typestr = luaL_checkstring (L, 2);
+   WpProxy *proxy = wp_session_item_get_associated_proxy (si,
+       parse_gtype (typestr));
+-  wplua_pushobject (L, proxy);
+-  return 1;
++  if (proxy)
++    wplua_pushobject (L, proxy);
++  return proxy ? 1 : 0;
+ }
+ 
+ static int
+-- 
+2.33.0
+

--- a/media-video/wireplumber/files/wireplumber-0.4.2-meson-Build-tests-conditionally.patch
+++ b/media-video/wireplumber/files/wireplumber-0.4.2-meson-Build-tests-conditionally.patch
@@ -1,0 +1,41 @@
+From 3b24c419b497c283e64df23b3b5eecd4c3d51927 Mon Sep 17 00:00:00 2001
+From: Sam James <sam@gentoo.org>
+Date: Tue, 14 Sep 2021 05:07:41 +0100
+Subject: [PATCH 1/5] meson: Build tests conditionally
+
+It's useful downstream to be able to control building
+tests, as there's not much use building them if we're
+not going to run them.
+
+Signed-off-by: Sam James <sam@gentoo.org>
+---
+ meson.build       | 5 ++++-
+ meson_options.txt | 2 ++
+ 2 files changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/meson.build b/meson.build
+index 3712a82..5f87ade 100644
+--- a/meson.build
++++ b/meson.build
+@@ -109,4 +109,7 @@ subdir('lib')
+ subdir('docs')
+ subdir('modules')
+ subdir('src')
+-subdir('tests')
++
++if get_option('tests')
++  subdir('tests')
++endif
+diff --git a/meson_options.txt b/meson_options.txt
+index a7a0a89..4008864 100644
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -24,3 +24,5 @@ option('systemd-user-unit-dir',
+        description : 'Directory for user systemd units')
+ option('glib-supp', type : 'string', value : '',
+        description: 'The glib.supp valgrind suppressions file to be used when running valgrind')
++option('tests', type : 'boolean', value : 'true',
++       description : 'Build the test suite')
+-- 
+2.33.0
+

--- a/media-video/wireplumber/files/wireplumber-0.4.2-v4l-add-basic-check-for-nil-monitor.patch
+++ b/media-video/wireplumber/files/wireplumber-0.4.2-v4l-add-basic-check-for-nil-monitor.patch
@@ -1,0 +1,42 @@
+From 3b41df35a885b4db04528d839b87e88bf1345240 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Nikl=C4=81vs=20Ko=C4=BCes=C5=86ikovs?=
+ <89q1r14hd@relay.firefox.com>
+Date: Wed, 15 Sep 2021 13:08:04 +0300
+Subject: [PATCH 4/5] v4l: add basic check for nil monitor
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+If PipeWire is built without V4L support, then
+
+`monitor = SpaDevice("api.v4l2.enum.udev", config.properties or {})`
+
+will result in a nil monitor. This commit adds a basic sanity check
+to avoid further using the nil variable.
+
+Thanks-to: Pascal Flöschel (initial bug report)
+Thanks-to: George Kiagiadakis <george.kiagiadakis@collabora.com>
+Bug: https://bugs.gentoo.org/813043
+---
+ src/scripts/monitors/v4l2.lua | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/src/scripts/monitors/v4l2.lua b/src/scripts/monitors/v4l2.lua
+index e698cd7..fd9a20d 100644
+--- a/src/scripts/monitors/v4l2.lua
++++ b/src/scripts/monitors/v4l2.lua
+@@ -131,5 +131,9 @@ function createDevice(parent, id, type, factory, properties)
+ end
+ 
+ monitor = SpaDevice("api.v4l2.enum.udev", config.properties or {})
+-monitor:connect("create-object", createDevice)
+-monitor:activate(Feature.SpaDevice.ENABLED)
++if monitor then
++  monitor:connect("create-object", createDevice)
++  monitor:activate(Feature.SpaDevice.ENABLED)
++else
++  Log.message("PipeWire's V4L SPA missing or broken. Video4Linux not supported.")
++end
+-- 
+2.33.0
+

--- a/media-video/wireplumber/wireplumber-0.4.2-r1.ebuild
+++ b/media-video/wireplumber/wireplumber-0.4.2-r1.ebuild
@@ -35,7 +35,7 @@ BDEPEND="
 DEPEND="
 	${LUA_DEPS}
 	>=dev-libs/glib-2.62
-	>=media-video/pipewire-0.3.26
+	>=media-video/pipewire-0.3.32
 	virtual/libc
 	systemd? ( sys-apps/systemd )
 "

--- a/media-video/wireplumber/wireplumber-0.4.2-r1.ebuild
+++ b/media-video/wireplumber/wireplumber-0.4.2-r1.ebuild
@@ -21,9 +21,11 @@ HOMEPAGE="https://gitlab.freedesktop.org/pipewire/wireplumber"
 
 LICENSE="MIT"
 SLOT="0/0.4"
-IUSE="systemd"
+IUSE="systemd test"
 
 REQUIRED_USE="${LUA_REQUIRED_USE}"
+
+RESTRICT="!test? ( test )"
 
 # introspection? ( dev-libs/gobject-introspection ) is valid but likely only used for doc building
 BDEPEND="
@@ -48,6 +50,10 @@ RDEPEND="${DEPEND}"
 
 DOCS=( {NEWS,README}.rst )
 
+PATCHES=(
+        "${FILESDIR}"/${PN}-0.4.2-meson-Build-tests-conditionally.patch
+)
+
 src_configure() {
 	local emesonargs=(
 		-Dintrospection=disabled # Only used for Sphinx doc generation
@@ -58,6 +64,7 @@ src_configure() {
 		$(meson_use systemd systemd-user-service)
 		-Dsystemd-system-unit-dir=$(systemd_get_systemunitdir)
 		-Dsystemd-user-unit-dir=$(systemd_get_userunitdir)
+		$(meson_use test tests)
 	)
 
 	meson_src_configure

--- a/media-video/wireplumber/wireplumber-0.4.2-r1.ebuild
+++ b/media-video/wireplumber/wireplumber-0.4.2-r1.ebuild
@@ -51,7 +51,11 @@ RDEPEND="${DEPEND}"
 DOCS=( {NEWS,README}.rst )
 
 PATCHES=(
-        "${FILESDIR}"/${PN}-0.4.2-meson-Build-tests-conditionally.patch
+	"${FILESDIR}"/${PN}-0.4.2-meson-Build-tests-conditionally.patch
+	"${FILESDIR}"/${PN}-0.4.2-lua-api-fix-object-constructors-to-fail-gracefully.patch
+	"${FILESDIR}"/${PN}-0.4.2-bluez-add-basic-check-for-nil-monitor.patch
+	"${FILESDIR}"/${PN}-0.4.2-v4l-add-basic-check-for-nil-monitor.patch
+	"${FILESDIR}"/${PN}-0.4.2-lib-wp-device-demote-missing-SPA-warning-to-message.patch
 )
 
 src_configure() {

--- a/media-video/wireplumber/wireplumber-9999.ebuild
+++ b/media-video/wireplumber/wireplumber-9999.ebuild
@@ -35,7 +35,7 @@ BDEPEND="
 DEPEND="
 	${LUA_DEPS}
 	>=dev-libs/glib-2.62
-	>=media-video/pipewire-0.3.26
+	>=media-video/pipewire-0.3.32
 	virtual/libc
 	systemd? ( sys-apps/systemd )
 "

--- a/media-video/wireplumber/wireplumber-9999.ebuild
+++ b/media-video/wireplumber/wireplumber-9999.ebuild
@@ -21,9 +21,11 @@ HOMEPAGE="https://gitlab.freedesktop.org/pipewire/wireplumber"
 
 LICENSE="MIT"
 SLOT="0/0.4"
-IUSE="systemd"
+IUSE="systemd test"
 
 REQUIRED_USE="${LUA_REQUIRED_USE}"
+
+RESTRICT="!test? ( test )"
 
 # introspection? ( dev-libs/gobject-introspection ) is valid but likely only used for doc building
 BDEPEND="
@@ -58,6 +60,7 @@ src_configure() {
 		$(meson_use systemd systemd-user-service)
 		-Dsystemd-system-unit-dir=$(systemd_get_systemunitdir)
 		-Dsystemd-user-unit-dir=$(systemd_get_userunitdir)
+		$(meson_use test tests)
 	)
 
 	meson_src_configure


### PR DESCRIPTION
Two of the commits have not yet been accepted upstream but they
were prepared with the help of upstream and should be in acceptably
good quality to use until a fixed release is made.

https://gitlab.freedesktop.org/pipewire/wireplumber/-/merge_requests/214

Thanks-to: Pascal Flöschel (initial bug report)
Thanks-to: George Kiagiadakis <george.kiagiadakis@collabora.com>
Bug: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=994085
Closes: https://bugs.gentoo.org/813043

Even though the build system still checks for and requires PipeWire
0.3.26, the [NEWS.rst](https://gitlab.freedesktop.org/pipewire/wireplumber/-/blob/0.4.2/NEWS.rst#L6) file for 0.4.2 suggests that the actual runtime minimum
is 0.3.32. In theory this would mean different DEPEND and RDEPEND
versions but we can probably just raise the DEPEND one and not worry
too much about the small stuff.