### PR TITLE
net-misc/httpie: update metadata

### DIFF
--- a/net-misc/httpie/httpie-2.5.0.ebuild
+++ b/net-misc/httpie/httpie-2.5.0.ebuild
@@ -10,8 +10,8 @@ PYTHON_REQ_USE="ssl(+)"
 inherit bash-completion-r1 distutils-r1
 
 DESCRIPTION="Modern command line HTTP client"
-HOMEPAGE="https://httpie.org/ https://pypi.org/project/httpie/"
-SRC_URI="https://github.com/jakubroztocil/httpie/archive/${PV}.tar.gz -> ${P}.tar.gz"
+HOMEPAGE="https://httpie.io/ https://pypi.org/project/httpie/"
+SRC_URI="https://github.com/httpie/httpie/archive/${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0"
@@ -28,7 +28,6 @@ RDEPEND="
 BDEPEND="
 	test? (
 		${RDEPEND}
-		dev-python/mock[${PYTHON_USEDEP}]
 		dev-python/pyopenssl[${PYTHON_USEDEP}]
 		dev-python/pytest-httpbin[${PYTHON_USEDEP}]
 		dev-python/responses[${PYTHON_USEDEP}]
@@ -38,18 +37,7 @@ BDEPEND="
 distutils_enable_tests pytest
 
 python_test() {
-	local skipped_tests=()
-
-	skipped_tests+=(
-		tests/test_uploads.py::test_chunked_json
-		tests/test_uploads.py::test_chunked_form
-		tests/test_uploads.py::test_chunked_stdin
-		tests/test_uploads.py::TestMultipartFormDataFileUpload::test_multipart_chunked
-		tests/test_uploads.py::TestRequestBodyFromFilePath::test_request_body_from_file_by_path_chunked
-		tests/test_tokens.py::test_verbose_chunked
-	)
-
-	pytest -v ${skipped_tests[@]/#/--deselect } || die "Tests failed with ${EPYTHON}"
+	pytest -v || die "Tests failed with ${EPYTHON}"
 }
 
 python_install_all() {

--- a/net-misc/httpie/metadata.xml
+++ b/net-misc/httpie/metadata.xml
@@ -1,7 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<!-- maintainer-needed -->
+	<maintainer type="person" proxied="yes">
+		<email>mickael@apible.io</email>
+		<name>Mickaël Schoentgen</name>
+	</maintainer>
+	<maintainer type="project" proxied="proxy">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
 	<longdescription lang="en">
 		HTTPie (pronounced aitch-tee-tee-pie) is a command line HTTP
 		client. Its goal is to make CLI interaction with web services as
@@ -12,7 +19,10 @@
 		servers.
 	</longdescription>
 	<upstream>
-		<remote-id type="github">jakubroztocil/httpie</remote-id>
+		<bugs-to>https://github.com/httpie/httpie/issues</bugs-to>
+		<changelog>https://raw.githubusercontent.com/httpie/httpie/master/CHANGELOG.md</changelog>
+		<doc>https://httpie.io/docs</doc>
+		<remote-id type="github">httpie/httpie</remote-id>
 		<remote-id type="pypi">httpie</remote-id>
 	</upstream>
 </pkgmetadata>


### PR DESCRIPTION
* Remove obsolete `dev-python/mock` dependency.
* Simplify tests: skipped tests due to required network access are now handled at the upstream level.
* Also take ownership (I am working for the compagny behind HTTPie).

Signed-off-by: Mickaël Schoentgen <contact@tiger-222.fr>