### PR TITLE
kde-plasma/kde-cli-tools: Bring kde-cli-tools-5.12.80-tests-optional.patch back

### DIFF
--- a/kde-plasma/kde-cli-tools/files/kde-cli-tools-5.12.80-tests-optional.patch
+++ b/kde-plasma/kde-cli-tools/files/kde-cli-tools-5.12.80-tests-optional.patch
@@ -1,0 +1,10 @@
+--- a/keditfiletype/CMakeLists.txt	2018-02-14 22:09:07.341549164 -0700
++++ b/keditfiletype/CMakeLists.txt	2018-02-14 23:02:11.126749356 -0700
+@@ -1,4 +1,6 @@
+-add_subdirectory(tests)
++if(BUILD_TESTING)
++    add_subdirectory(tests)
++endif()
+ 
+ # KI18N Translation Domain for this library
+ add_definitions(-DTRANSLATION_DOMAIN=\"kcm5_filetypes\")


### PR DESCRIPTION
The kde-cli-tools-5.12.80-tests-optional.patch file was removed
prematurely. It's still in use by kde-cli-tools-5.22.5.ebuild.

Signed-off-by: Michal Privoznik <mprivozn@redhat.com>