### PR TITLE
Keyword tuigreet, wayfire and deps for ~riscv

### DIFF
--- a/gui-apps/tuigreet/tuigreet-0.6.1.ebuild
+++ b/gui-apps/tuigreet/tuigreet-0.6.1.ebuild
@@ -124,6 +124,6 @@ QA_FLAGS_IGNORED="usr/bin/tuigreet"
 
 LICENSE="Apache-2.0 Boost-1.0 GPL-3 MIT"
 SLOT="0"
-KEYWORDS="~amd64 ~ppc64"
+KEYWORDS="~amd64 ~ppc64 ~riscv"
 
 RDEPEND="gui-libs/greetd"

--- a/gui-libs/gtk-layer-shell/gtk-layer-shell-0.1.0-r1.ebuild
+++ b/gui-libs/gtk-layer-shell/gtk-layer-shell-0.1.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2020 Gentoo Authors
+# Copyright 2020-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -10,7 +10,7 @@ if [[ ${PV} == 9999 ]]; then
 	EGIT_REPO_URI="https://github.com/wmww/${PN}"
 else
 	SRC_URI="https://github.com/wmww/${PN}/releases/download/v${PV}/${P}.tar.xz"
-	KEYWORDS="amd64 ~arm ~arm64 ~ppc64 x86"
+	KEYWORDS="amd64 ~arm ~arm64 ~ppc64 ~riscv x86"
 fi
 
 DESCRIPTION="Library to create desktop components for Wayland using the Layer Shell protocol"

--- a/gui-libs/wf-config/wf-config-0.7.1-r1.ebuild
+++ b/gui-libs/wf-config/wf-config-0.7.1-r1.ebuild
@@ -13,7 +13,7 @@ if [[ ${PV} == 9999 ]]; then
 	EGIT_REPO_URI="https://github.com/WayfireWM/wf-config.git"
 else
 	SRC_URI="https://github.com/WayfireWM/wf-config/releases/download/v${PV}/${P}.tar.xz"
-	KEYWORDS="amd64 ~arm64 ~x86"
+	KEYWORDS="amd64 ~arm64 ~riscv ~x86"
 fi
 
 LICENSE="MIT"

--- a/gui-wm/wayfire/wayfire-0.7.2.ebuild
+++ b/gui-wm/wayfire/wayfire-0.7.2.ebuild
@@ -13,7 +13,7 @@ if [[ ${PV} == 9999 ]]; then
 	EGIT_REPO_URI="https://github.com/WayfireWM/${PN}.git"
 else
 	SRC_URI="https://github.com/WayfireWM/${PN}/releases/download/v${PV}/${P}.tar.xz"
-	KEYWORDS="amd64 ~arm64 ~x86"
+	KEYWORDS="amd64 ~arm64 ~riscv ~x86"
 fi
 
 LICENSE="MIT"


### PR DESCRIPTION
Tested on HiFive Unmatched with gui-apps/qtgreet from the wayland-desktop overlay.