### PR TITLE
games-emulation/desmume: fix build with clang

### DIFF
--- a/games-emulation/desmume/desmume-0.9.11_p20210409-r1.ebuild
+++ b/games-emulation/desmume/desmume-0.9.11_p20210409-r1.ebuild
@@ -36,6 +36,7 @@ DEPEND="
 PATCHES=(
 	"${FILESDIR}"/${P}-fix-gtk-cliopts.patch
 	"${FILESDIR}"/${P}-openal-automagic.patch
+	"${FILESDIR}"/${P}-clang.patch
 )
 
 DOCS=( ${PN}/{AUTHORS,ChangeLog,README,README.LIN,doc/.} )

--- a/games-emulation/desmume/files/desmume-0.9.11_p20210409-clang.patch
+++ b/games-emulation/desmume/files/desmume-0.9.11_p20210409-clang.patch
@@ -1,0 +1,15 @@
+Fix build with clang https://bugs.gentoo.org/739144
+
+--- a/desmume/src/texcache.cpp
++++ b/desmume/src/texcache.cpp
+@@ -1165,8 +1165,8 @@ void NDSTextureUnpack4x4(const size_t sr
+ 	
+ 	for (size_t y = 0, d = 0; y < yTmpSize; y++)
+ 	{
+-		u32 tmpPos[4]={(y<<2)*sizeX,((y<<2)+1)*sizeX,
+-			((y<<2)+2)*sizeX,((y<<2)+3)*sizeX};
++		u32 tmpPos[4]={u32(y<<2)*sizeX,u32((y<<2)+1)*sizeX,
++			u32((y<<2)+2)*sizeX,u32((y<<2)+3)*sizeX};
+ 		for (size_t x = 0; x < xTmpSize; x++, d++)
+ 		{
+ 			if (d >= limit)


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/739144
Package-Manager: Portage-3.0.20, Repoman-3.0.3
Signed-off-by: Alexey Sokolov <alexey+gentoo@asokolov.org>