### PR TITLE
games-puzzle/amoebax: EAPI8, minor improvements

### DIFF
--- a/games-puzzle/amoebax/amoebax-0.2.1-r2.ebuild
+++ b/games-puzzle/amoebax/amoebax-0.2.1-r2.ebuild
@@ -1,40 +1,40 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
+
 inherit autotools
 
-DESCRIPTION="A cute and addictive action-puzzle game, similar to tetris"
-HOMEPAGE="http://www.emma-soft.com/games/amoebax/"
-SRC_URI="http://www.emma-soft.com/games/amoebax/download/${P}.tar.bz2"
+DESCRIPTION="Cute and addictive action-puzzle game, similar to tetris"
+HOMEPAGE="https://www.emma-soft.com/games/amoebax/"
+SRC_URI="https://www.emma-soft.com/games/amoebax/download/${P}.tar.bz2"
 
 LICENSE="Free-Art-1.2 GPL-2+"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE=""
 
-DEPEND="media-libs/libsdl[sound,joystick,video]
+DEPEND="
+	media-libs/libsdl[sound,joystick,video]
 	media-libs/sdl-image[png]
 	media-libs/sdl-mixer[vorbis]"
-RDEPEND=${DEPEND}
+RDEPEND="${DEPEND}"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-aclocal.patch
+	"${FILESDIR}"/${P}-clang.patch
+	"${FILESDIR}"/${P}-compile.patch
+)
 
 src_prepare() {
 	default
 
-	eapply \
-		"${FILESDIR}"/${P}-aclocal.patch \
-		"${FILESDIR}"/${P}-compile.patch
-
 	sed -i \
-		-e "/^SUBDIRS/s:doc ::" \
+		-e "/^SUBDIRS/s|doc ||" \
 		Makefile.am || die
-	sed -i \
-		-e "/^iconsdir/s:=.*:=/usr/share/pixmaps:" \
-		-e "/^desktopdir/s:=.*:=/usr/share/applications:" \
-		data/Makefile.am || die
 	sed -i \
 		-e '/Encoding/d' \
 		-e '/Icon/s/.svg//' \
 		data/amoebax.desktop || die
+
 	AT_M4DIR=m4 eautoreconf
 }

--- a/games-puzzle/amoebax/files/amoebax-0.2.1-clang.patch
+++ b/games-puzzle/amoebax/files/amoebax-0.2.1-clang.patch
@@ -1,0 +1,14 @@
+Fixes building with clang:
+Gentoo-Bug: https://bugs.gentoo.org/739286
+
+--- a/src/NewHighScoreState.cxx
++++ b/src/NewHighScoreState.cxx
+@@ -396,7 +396,7 @@ NewHighScoreState::unicodeCharacterPress
+     // FIXME: We are only interessted with ASCII values.
+     if ( 0 == (code & 0xff80) )
+     {
+-        char character[2] = {toupper (static_cast<char>(code & 0x7f)), '\0'};
++        char character[2] = {static_cast<char>(toupper (static_cast<char>(code & 0x7f)), '\0')};
+         std::string::size_type characterPos =
+             m_CursorValues.find (std::string (character));
+         if ( std::string::npos != characterPos )


### PR DESCRIPTION
Package-Manager: Portage-3.0.23, Repoman-3.0.3
Signed-off-by: Michael Mair-Keimberger <mmk@levelnine.at>

@ionenwks 
This should be a pretty simply `EAPI=8` conversation. 
However, there is a bug open for this game (bug #739286). I've looked into it and i _guess_ it's not so difficult to fix. However, I'm not a programmer, and I have no clue how to fix this correctly.

