### PR TITLE
gui-wm/sway: introduce grimshot: utility for taking screenshots

### DIFF
--- a/gui-wm/sway/metadata.xml
+++ b/gui-wm/sway/metadata.xml
@@ -26,6 +26,7 @@
 		something else.
 	</longdescription>
 	<use>
+		<flag name="grimshot">Install 'grimshot': script for taking screenshots</flag>
 		<flag name="swaybar">Install 'swaybar': sway's status bar component</flag>
 		<flag name="swaybg">Install 'swaybg': allows to set a desktop background image</flag>
 		<flag name="swayidle">Install 'swayidle': idle manager to run commands when user is inactive</flag>

--- a/gui-wm/sway/sway-1.7-r1.ebuild
+++ b/gui-wm/sway/sway-1.7-r1.ebuild
@@ -14,7 +14,7 @@ if [[ ${PV} == 9999 ]]; then
 else
 	MY_PV=${PV/_rc/-rc}
 	SRC_URI="https://github.com/swaywm/${PN}/archive/${MY_PV}.tar.gz -> ${P}.tar.gz"
-	KEYWORDS="~amd64 ~arm64"
+	KEYWORDS="~amd64 ~arm64 ~loong ~ppc64 ~riscv ~x86"
 	S="${WORKDIR}/${PN}-${MY_PV}"
 fi
 
@@ -37,6 +37,11 @@ DEPEND="
 	swaybg? ( gui-apps/swaybg )
 	swayidle? ( gui-apps/swayidle )
 	swaylock? ( gui-apps/swaylock )
+	tray? ( || (
+		sys-apps/systemd
+		sys-auth/elogind
+		sys-libs/basu
+	) )
 	wallpapers? ( x11-libs/gdk-pixbuf:2[jpeg] )
 	X? ( x11-libs/libxcb:0= )
 "
@@ -69,6 +74,7 @@ if [[ ${PV} == 9999 ]]; then
 else
 	BDEPEND+="man? ( >=app-text/scdoc-1.9.3 )"
 fi
+REQUIRED_USE="grimshot? ( swaymsg )"
 
 src_configure() {
 	local emesonargs=(
@@ -82,7 +88,6 @@ src_configure() {
 		-Dfish-completions=true
 		-Dzsh-completions=true
 		-Dbash-completions=true
-		-Dwerror=false
 	)
 
 	meson_src_configure

--- a/gui-wm/sway/sway-1.7-r1.ebuild
+++ b/gui-wm/sway/sway-1.7-r1.ebuild
@@ -1,0 +1,98 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit meson
+
+DESCRIPTION="i3-compatible Wayland window manager"
+HOMEPAGE="https://swaywm.org"
+
+if [[ ${PV} == 9999 ]]; then
+	inherit git-r3
+	EGIT_REPO_URI="https://github.com/swaywm/${PN}.git"
+else
+	MY_PV=${PV/_rc/-rc}
+	SRC_URI="https://github.com/swaywm/${PN}/archive/${MY_PV}.tar.gz -> ${P}.tar.gz"
+	KEYWORDS="~amd64 ~arm64"
+	S="${WORKDIR}/${PN}-${MY_PV}"
+fi
+
+LICENSE="MIT"
+SLOT="0"
+IUSE="grimshot +man +swaybar +swaybg +swayidle +swaylock +swaymsg +swaynag tray wallpapers X"
+
+DEPEND="
+	>=dev-libs/json-c-0.13:0=
+	>=dev-libs/libinput-1.6.0:0=
+	sys-auth/seatd:=
+	dev-libs/libpcre
+	>=dev-libs/wayland-1.20.0
+	x11-libs/cairo
+	x11-libs/libxkbcommon
+	x11-libs/pango
+	x11-libs/pixman
+	media-libs/mesa[gles2,libglvnd(+)]
+	swaybar? ( x11-libs/gdk-pixbuf:2 )
+	swaybg? ( gui-apps/swaybg )
+	swayidle? ( gui-apps/swayidle )
+	swaylock? ( gui-apps/swaylock )
+	wallpapers? ( x11-libs/gdk-pixbuf:2[jpeg] )
+	X? ( x11-libs/libxcb:0= )
+"
+if [[ ${PV} == 9999 ]]; then
+	DEPEND+="~gui-libs/wlroots-9999:=[X=]"
+else
+	DEPEND+="
+		>=gui-libs/wlroots-0.15:=[X=]
+		<gui-libs/wlroots-0.16:=[X=]
+	"
+fi
+RDEPEND="
+	x11-misc/xkeyboard-config
+	grimshot? (
+		app-misc/jq
+		gui-apps/grim
+		gui-apps/slurp
+		gui-apps/wl-clipboard
+		x11-libs/libnotify
+	)
+	${DEPEND}
+"
+BDEPEND="
+	>=dev-libs/wayland-protocols-1.24
+	>=dev-util/meson-0.60.0
+	virtual/pkgconfig
+"
+if [[ ${PV} == 9999 ]]; then
+	BDEPEND+="man? ( ~app-text/scdoc-9999 )"
+else
+	BDEPEND+="man? ( >=app-text/scdoc-1.9.3 )"
+fi
+
+src_configure() {
+	local emesonargs=(
+		$(meson_feature man man-pages)
+		$(meson_feature tray)
+		$(meson_feature X xwayland)
+		$(meson_feature swaybar gdk-pixbuf)
+		$(meson_use swaynag)
+		$(meson_use swaybar)
+		$(meson_use wallpapers default-wallpaper)
+		-Dfish-completions=true
+		-Dzsh-completions=true
+		-Dbash-completions=true
+		-Dwerror=false
+	)
+
+	meson_src_configure
+}
+
+src_install() {
+	meson_src_install
+
+	if use grimshot; then
+		doman contrib/grimshot.1
+		dobin contrib/grimshot
+	fi
+}

--- a/gui-wm/sway/sway-9999.ebuild
+++ b/gui-wm/sway/sway-9999.ebuild
@@ -20,7 +20,7 @@ fi
 
 LICENSE="MIT"
 SLOT="0"
-IUSE="+man +swaybar +swaybg +swayidle +swaylock +swaymsg +swaynag tray wallpapers X"
+IUSE="grimshot +man +swaybar +swaybg +swayidle +swaylock +swaymsg +swaynag tray wallpapers X"
 
 DEPEND="
 	>=dev-libs/json-c-0.13:0=
@@ -55,6 +55,13 @@ else
 fi
 RDEPEND="
 	x11-misc/xkeyboard-config
+	grimshot? (
+		app-misc/jq
+		gui-apps/grim
+		gui-apps/slurp
+		gui-apps/wl-clipboard
+		x11-libs/libnotify
+	)
 	${DEPEND}
 "
 BDEPEND="
@@ -67,6 +74,7 @@ if [[ ${PV} == 9999 ]]; then
 else
 	BDEPEND+="man? ( >=app-text/scdoc-1.9.3 )"
 fi
+REQUIRED_USE="grimshot? ( swaymsg )"
 
 src_configure() {
 	local emesonargs=(
@@ -83,4 +91,13 @@ src_configure() {
 	)
 
 	meson_src_configure
+}
+
+src_install() {
+	meson_src_install
+
+	if use grimshot; then
+		doman contrib/grimshot.1
+		dobin contrib/grimshot
+	fi
 }


### PR DESCRIPTION
Hi,

This PR introduces the `grimshot` utility which comes with the `sway` package. This wasn't installed yet so i've modified the ebuild to install it. It's a simply bash script which depends on a view other tools in order to work (which is why i didn't enabled it by default).
Unfortunately I also had to remove `ppc64 riscv x86` keywords because some of the tools miss keywords.

I've also checked the `meson.build` file in order to install the script via meson, but as far as I could see there is no option for `grimshot`.

Please review.
