### PR TITLE
dev-util/catalyst: keyword ~riscv.

### DIFF
--- a/dev-util/catalyst/catalyst-3.0.20.ebuild
+++ b/dev-util/catalyst/catalyst-3.0.20.ebuild
@@ -9,7 +9,7 @@ if [[ ${PV} == *9999* ]]; then
 	EGIT_BRANCH="master"
 else
 	SRC_URI="https://gitweb.gentoo.org/proj/catalyst.git/snapshot/${P}.tar.bz2"
-	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
 fi
 
 PYTHON_COMPAT=( python3_{8,9} )


### PR DESCRIPTION
I did a full run for all three stages natively to test.