### PR TITLE
app-emulation/xen-tools: fix building with gcc-11

### DIFF
--- a/app-emulation/xen-tools/files/gentoo-patches.conf
+++ b/app-emulation/xen-tools/files/gentoo-patches.conf
@@ -76,7 +76,6 @@ _gpv_xen_tools_4143_0="
 	xen-tools-4.14-ar-cc.patch
 	xen-tools-4.14-qemu-bridge.patch
 	xen-tools-4.15.0-disable-werror.patch
-	xen-tools-4.15.0-gcc11.patch
 	xen-tools-4.4.1-tinfo.patch
 	xen-tools-4.6-increase-stack-size.patch
 	xen-tools-4-anti-ovmf-download.patch


### PR DESCRIPTION
The patch is not needed any more. Tested with gcc-10 and gcc-11.