### PR TITLE
gnome-extra/libgda: fix "my_bool" error with "mysql" USE flag

### DIFF
--- a/gnome-extra/libgda/files/libgda-5.2-my_bool-error.patch
+++ b/gnome-extra/libgda/files/libgda-5.2-my_bool-error.patch
@@ -1,0 +1,138 @@
+diff --git a/providers/mysql/gda-mysql-provider.c b/providers/mysql/gda-mysql-provider.c
+index 39aea5f95..424d83d6b 100644
+--- a/providers/mysql/gda-mysql-provider.c
++++ b/providers/mysql/gda-mysql-provider.c
+@@ -1835,7 +1835,7 @@ real_prepare (GdaServerProvider *provider, GdaConnection *cnc, GdaStatement *stm
+ 		return FALSE;
+ 	}
+ 
+-	my_bool update_max_length = 1;
++	_Bool update_max_length = 1;
+ 	if (mysql_stmt_attr_set (mysql_stmt, STMT_ATTR_UPDATE_MAX_LENGTH, (const void *) &update_max_length)) {
+ 		_gda_mysql_make_error (cnc, NULL, mysql_stmt, error);
+ 		mysql_stmt_close (mysql_stmt);
+@@ -1941,7 +1941,7 @@ prepare_stmt_simple (MysqlConnectionData  *cdata,
+ 		return FALSE;
+ 	}
+ 
+-	my_bool update_max_length = 1;
++	_Bool update_max_length = 1;
+ 	if (mysql_stmt_attr_set (mysql_stmt, STMT_ATTR_UPDATE_MAX_LENGTH, (const void *) &update_max_length)) {
+ 		_gda_mysql_make_error (cdata->cnc, NULL, mysql_stmt, error);
+ 		mysql_stmt_close (mysql_stmt);
+@@ -2327,7 +2327,7 @@ gda_mysql_provider_statement_execute (GdaServerProvider               *provider,
+ 			if (allow_noparam) {
+                                 /* bind param to NULL */
+ 				mysql_bind_param[i].buffer_type = MYSQL_TYPE_NULL;
+-				mysql_bind_param[i].is_null = (my_bool*)1;
++				mysql_bind_param[i].is_null = (_Bool *) 1;
+                                 empty_rs = TRUE;
+                                 continue;
+ 			}
+@@ -2347,7 +2347,7 @@ gda_mysql_provider_statement_execute (GdaServerProvider               *provider,
+ 			if (allow_noparam) {
+                                 /* bind param to NULL */
+ 				mysql_bind_param[i].buffer_type = MYSQL_TYPE_NULL;
+-				mysql_bind_param[i].is_null = (my_bool*)1;
++				mysql_bind_param[i].is_null = (_Bool *) 1;
+                                 empty_rs = TRUE;
+                                 continue;
+ 			}
+@@ -2399,7 +2399,7 @@ gda_mysql_provider_statement_execute (GdaServerProvider               *provider,
+ 			GdaStatement *rstmt;
+ 			if (! gda_rewrite_statement_for_null_parameters (stmt, params, &rstmt, error)) {
+ 				mysql_bind_param[i].buffer_type = MYSQL_TYPE_NULL;
+-				mysql_bind_param[i].is_null = (my_bool*)1;
++				mysql_bind_param[i].is_null = (_Bool *) 1;
+ 			}
+ 			else if (!rstmt)
+ 				return NULL;
+@@ -2459,7 +2459,7 @@ gda_mysql_provider_statement_execute (GdaServerProvider               *provider,
+ 			ts = (GdaTimestamp*) gda_value_get_timestamp (value);
+ 			if (!ts) {
+ 				mysql_bind_param[i].buffer_type = MYSQL_TYPE_NULL;
+-				mysql_bind_param[i].is_null = (my_bool*)1;
++				mysql_bind_param[i].is_null = (_Bool *) 1;
+ 			}
+ 			else {
+ 				gboolean tofree = FALSE;
+@@ -2495,7 +2495,7 @@ gda_mysql_provider_statement_execute (GdaServerProvider               *provider,
+ 			ts = (GdaTime*) gda_value_get_time (value);
+ 			if (!ts) {
+ 				mysql_bind_param[i].buffer_type = MYSQL_TYPE_NULL;
+-				mysql_bind_param[i].is_null = (my_bool*)1;
++				mysql_bind_param[i].is_null = (_Bool *) 1;
+ 			}
+ 			else {
+ 				gboolean tofree = FALSE;
+@@ -2528,7 +2528,7 @@ gda_mysql_provider_statement_execute (GdaServerProvider               *provider,
+ 			ts = (GDate*) g_value_get_boxed (value);
+ 			if (!ts) {
+ 				mysql_bind_param[i].buffer_type = MYSQL_TYPE_NULL;
+-				mysql_bind_param[i].is_null = (my_bool*)1;
++				mysql_bind_param[i].is_null = (_Bool *) 1;
+ 			}
+ 			else {
+ 				MYSQL_TIME *mtime;
+@@ -2548,7 +2548,7 @@ gda_mysql_provider_statement_execute (GdaServerProvider               *provider,
+ 			str = g_value_get_string (value);
+ 			if (!str) {
+ 				mysql_bind_param[i].buffer_type = MYSQL_TYPE_NULL;
+-				mysql_bind_param[i].is_null = (my_bool*)1;
++				mysql_bind_param[i].is_null = (_Bool *) 1;
+ 			}
+ 			else {
+ 				mysql_bind_param[i].buffer_type= MYSQL_TYPE_STRING;
+@@ -2624,7 +2624,7 @@ gda_mysql_provider_statement_execute (GdaServerProvider               *provider,
+ 			bin = ((GdaBinary*) blob);
+ 			if (!bin) {
+ 				mysql_bind_param[i].buffer_type = MYSQL_TYPE_NULL;
+-				mysql_bind_param[i].is_null = (my_bool*)1;
++				mysql_bind_param[i].is_null = (_Bool *) 1;
+ 			}
+ 			else {
+ 				gchar *str = NULL;
+@@ -2665,7 +2665,7 @@ gda_mysql_provider_statement_execute (GdaServerProvider               *provider,
+ 			bin = gda_value_get_binary (value);
+ 			if (!bin) {
+ 				mysql_bind_param[i].buffer_type = MYSQL_TYPE_NULL;
+-				mysql_bind_param[i].is_null = (my_bool*)1;
++				mysql_bind_param[i].is_null = (_Bool *) 1;
+ 			}
+ 			else {
+ 				mysql_bind_param[i].buffer_type= MYSQL_TYPE_BLOB;
+diff --git a/providers/mysql/gda-mysql-recordset.c b/providers/mysql/gda-mysql-recordset.c
+index e47b69661..1f36b6cd2 100644
+--- a/providers/mysql/gda-mysql-recordset.c
++++ b/providers/mysql/gda-mysql-recordset.c
+@@ -627,7 +627,7 @@ gda_mysql_recordset_new (GdaConnection            *cnc,
+ 		/* binding results with types */
+ 		mysql_bind_result[i].buffer_type = field->type;
+ 		mysql_bind_result[i].is_unsigned = field->flags & UNSIGNED_FLAG ? TRUE : FALSE;
+-		mysql_bind_result[i].is_null = g_malloc0 (sizeof (my_bool));
++		mysql_bind_result[i].is_null = g_malloc0 (sizeof (_Bool));
+ 		
+ 		switch (mysql_bind_result[i].buffer_type) {
+ 		case MYSQL_TYPE_TINY:
+@@ -753,7 +753,7 @@ new_row_from_mysql_stmt (GdaMysqlRecordset *imodel, G_GNUC_UNUSED gint rownum, G
+ 
+ 		gint col;
+ 		for (col = 0; col < ((GdaDataSelect *) imodel)->prep_stmt->ncols; ++col) {
+-			my_bool truncated;
++			_Bool truncated;
+ 			mysql_bind_result[col].error = &truncated;
+ 			mysql_stmt_fetch_column (imodel->priv->mysql_stmt, &(mysql_bind_result[col]),
+ 						 (unsigned int)col, 0);
+@@ -784,10 +784,10 @@ new_row_from_mysql_stmt (GdaMysqlRecordset *imodel, G_GNUC_UNUSED gint rownum, G
+ 		
+ 		/*g_print ("%s: #%d : TYPE=%d, GTYPE=%s\n", __func__, i, mysql_bind_result[i].buffer_type, g_type_name (type));*/
+ 
+-		my_bool is_null = FALSE;
++		_Bool is_null = FALSE;
+ 		unsigned long length;
+ 		
+-		memmove (&is_null, mysql_bind_result[i].is_null, sizeof (my_bool));
++		memmove (&is_null, mysql_bind_result[i].is_null, sizeof (_Bool));
+ 		if (is_null) {
+ 			gda_value_set_null (value);
+ 			continue;

--- a/gnome-extra/libgda/libgda-5.2.9.ebuild
+++ b/gnome-extra/libgda/libgda-5.2.9.ebuild
@@ -84,6 +84,9 @@ src_prepare() {
 		-e '/SUBDIRS =/ s/trml2pdf//' \
 		-i libgda-report/RML/Makefile.{am,in} || die
 
+	# replace my_bool with _Bool
+	eapply "${FILESDIR}/${PN}-5.2-my_bool-error.patch"
+
 	# Prevent file collisions with libgda:4
 	eapply "${FILESDIR}/${PN}-4.99.1-gda-browser-doc-collision.patch"
 	eapply "${FILESDIR}/${PN}-4.99.1-control-center-icon-collision.patch"


### PR DESCRIPTION
This PR fixes "my_bool" error with "mysql" USE flag in v5.2.x.
See also: #15398 

Closes: https://bugs.gentoo.org/692672
Signed-off-by: shimataro <shimataro@zelkova.cc>