### PR TITLE
media-video/pipewire: instruct users to disable oFono

### DIFF
--- a/media-video/pipewire/pipewire-9999.ebuild
+++ b/media-video/pipewire/pipewire-9999.ebuild
@@ -5,7 +5,7 @@ EAPI="7"
 
 PYTHON_COMPAT=( python3_{8..10} )
 
-inherit meson-multilib optfeature python-any-r1 udev
+inherit meson-multilib optfeature python-any-r1 systemd udev
 
 if [[ ${PV} == 9999 ]]; then
 	EGIT_REPO_URI="https://gitlab.freedesktop.org/${PN}/${PN}.git"
@@ -273,9 +273,13 @@ pkg_postinst() {
 	optfeature_header "The following can be installed for optional runtime features:"
 	optfeature "restricted realtime capabilities via D-Bus" sys-auth/rtkit
 
-	# Once hsphfpd lands in tree, both it and ofono will need to be checked for presence here!
-	if use bluetooth; then
-		optfeature "better BT headset support (daemon startup required)" net-misc/ofono
-		#optfeature "an oFono alternative (not packaged)" foo-bar/hsphfpd
+	if has_version 'net-misc/ofono' ; then
+		ewarn "Native backend has become default. Please disable oFono via:"
+		if systemd_is_booted ; then
+			ewarn "systemctl disable --now ofono"
+		else
+			ewarn "rc-update delete ofono"
+		fi
+		ewarn
 	fi
 }


### PR DESCRIPTION
Upstream has changed the logic to no longer automatically use oFono
if it's found running. This is because other Linux distributions had
it running by default but not properly configured, which would also
break PipeWire's Bluetooth support. Unfortunately, this means that now
a running oFono is at risk of conflicting with the native backend,
which is the new default behavior.

Since most use cases are expected to work with the native backend, the
easiest solution is to advise users to disable oFono service, and that
is what this PR does.

Thanks-to: Jannik Glückert <jannik.glueckert@gmail.com> (systemd inst.)
Thanks-to: Sam James <sam@gentoo.org> (OpenRC instructions)
Signed-off-by: Niklāvs Koļesņikovs <89q1r14hd@relay.firefox.com>