### PR TITLE
app-crypt/coolkey: don't parallel install

### DIFF
--- a/app-crypt/coolkey/coolkey-1.1.0-r7.ebuild
+++ b/app-crypt/coolkey/coolkey-1.1.0-r7.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2021 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -45,6 +45,11 @@ src_configure() {
 
 src_compile() {
 	emake CFLAGS+="-fno-strict-aliasing" -j1
+}
+
+src_install() {
+	emake DESTDIR="${D}" install -j1
+	einstalldocs
 }
 
 pkg_postinst() {


### PR DESCRIPTION
Something fishy going on in docs/Makefile

	install-data-hook:
		rm -f $(DESTDIR)$(libdir)/libckyapplet.a
		rm -f $(DESTDIR)$(libdir)/libckyapplet.la

but agreed with sam that it's not worth it to debug further
(seeing that upstream is dead and the src_compile is being
done -j1 as well.)

- Override src_install with its default but using '-j1'
- Update the copyright

Signed-off-by: Christophe Lermytte <gentoo@lermytte.be>