### PR TITLE
app-emulation/lxd: backport syscall_wrappers patch, use --syslog

### DIFF
--- a/app-emulation/lxd/files/lxd-4.0.7-r1.service
+++ b/app-emulation/lxd/files/lxd-4.0.7-r1.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=LXD - main daemon
+After=network-online.target lxcfs.service lxd.socket
+Requires=network-online.target lxcfs.service lxd.socket
+Documentation=man:lxd(1)
+
+[Service]
+EnvironmentFile=-/etc/environment
+ExecStart=/usr/sbin/lxd --group lxd --syslog
+ExecStartPost=/usr/sbin/lxd waitready --timeout=600
+KillMode=process
+TimeoutStartSec=600s
+TimeoutStopSec=30s
+Restart=on-failure
+LimitNOFILE=1048576
+LimitNPROC=infinity
+TasksMax=infinity
+
+[Install]
+Also=lxd-containers.service lxd.socket

--- a/app-emulation/lxd/files/lxd-syscall_wrappers-don-t-conflict-with-glibc-provided.patch
+++ b/app-emulation/lxd/files/lxd-syscall_wrappers-don-t-conflict-with-glibc-provided.patch
@@ -1,0 +1,58 @@
+From 9a128f32fc277dd0c07bc85c71dc25d123f8a831 Mon Sep 17 00:00:00 2001
+From: Christian Brauner <christian.brauner@ubuntu.com>
+Date: Wed, 4 Aug 2021 21:34:11 +0200
+Subject: [PATCH] syscall_wrappers: don't conflict with glibc provided
+ close_range()
+
+Newer glibc version's provide a wrapper for close_range().
+
+Fixes: #9084
+Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>
+---
+ lxd/include/syscall_wrappers.h | 2 +-
+ lxd/main_checkfeature.go       | 2 +-
+ lxd/main_forkexec.go           | 2 +-
+ 3 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/lxd/include/syscall_wrappers.h b/lxd/include/syscall_wrappers.h
+index 4405a622b801..25e56a5cefac 100644
+--- a/lxd/include/syscall_wrappers.h
++++ b/lxd/include/syscall_wrappers.h
+@@ -16,7 +16,7 @@
+ #define CLOSE_RANGE_UNSHARE (1U << 1)
+ #endif
+ 
+-static inline int close_range(unsigned int fd, unsigned int max_fd, unsigned int flags)
++static inline int lxd_close_range(unsigned int fd, unsigned int max_fd, unsigned int flags)
+ {
+ 	return syscall(__NR_close_range, fd, max_fd, flags);
+ }
+diff --git a/lxd/main_checkfeature.go b/lxd/main_checkfeature.go
+index 9511b684fa5d..0cc89207158d 100644
+--- a/lxd/main_checkfeature.go
++++ b/lxd/main_checkfeature.go
+@@ -496,7 +496,7 @@ static void is_close_range_aware(void)
+ 	if (fd < 0)
+ 		return;
+ 
+-	if (close_range(fd, fd, CLOSE_RANGE_UNSHARE))
++	if (lxd_close_range(fd, fd, CLOSE_RANGE_UNSHARE))
+ 		return;
+ 
+ 	close_range_aware = true;
+diff --git a/lxd/main_forkexec.go b/lxd/main_forkexec.go
+index 574f25eeb988..cfa4cd6bcda8 100644
+--- a/lxd/main_forkexec.go
++++ b/lxd/main_forkexec.go
+@@ -290,7 +290,7 @@ __attribute__ ((noinline)) static int __forkexec(void)
+ 	if (!argvp || !*argvp)
+ 		return log_error(EXIT_FAILURE, "No command specified");
+ 
+-	ret = close_range(EXEC_PIPE_FD + 1, UINT_MAX, CLOSE_RANGE_UNSHARE);
++	ret = lxd_close_range(EXEC_PIPE_FD + 1, UINT_MAX, CLOSE_RANGE_UNSHARE);
+ 	if (ret) {
+ 		// Fallback to close_inherited() when the syscall is not
+ 		// available or when CLOSE_RANGE_UNSHARE isn't supported.
+-- 
+2.32.0
+

--- a/app-emulation/lxd/lxd-4.0.7-r1.ebuild
+++ b/app-emulation/lxd/lxd-4.0.7-r1.ebuild
@@ -1,0 +1,170 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit bash-completion-r1 linux-info optfeature systemd verify-sig
+
+DESCRIPTION="Fast, dense and secure container management"
+HOMEPAGE="https://linuxcontainers.org/lxd/introduction/ https://github.com/lxc/lxd"
+SRC_URI="https://linuxcontainers.org/downloads/lxd/${P}.tar.gz
+	verify-sig? ( https://linuxcontainers.org/downloads/lxd/${P}.tar.gz.asc )"
+
+LICENSE="Apache-2.0"
+SLOT="0"
+KEYWORDS="~amd64"
+IUSE="apparmor ipv6 nls verify-sig"
+
+DEPEND="app-arch/xz-utils
+	>=app-emulation/lxc-3.0.0[apparmor?,seccomp(+)]
+	dev-libs/dqlite
+	dev-libs/lzo
+	dev-libs/raft[lz4]
+	>=dev-util/xdelta-3.0[lzma(+)]
+	net-dns/dnsmasq[dhcp,ipv6?]"
+RDEPEND="${DEPEND}
+	acct-group/lxd
+	net-firewall/ebtables
+	net-firewall/iptables[ipv6?]
+	sys-apps/iproute2[ipv6?]
+	sys-fs/fuse:*
+	sys-fs/lxcfs
+	sys-fs/squashfs-tools[lzma]
+	virtual/acl"
+BDEPEND="dev-lang/go
+	nls? ( sys-devel/gettext )
+	verify-sig? ( app-crypt/openpgp-keys-linuxcontainers )"
+
+CONFIG_CHECK="
+	~CGROUPS
+	~IPC_NS
+	~NET_NS
+	~PID_NS
+
+	~SECCOMP
+	~USER_NS
+	~UTS_NS
+"
+
+ERROR_IPC_NS="CONFIG_IPC_NS is required."
+ERROR_NET_NS="CONFIG_NET_NS is required."
+ERROR_PID_NS="CONFIG_PID_NS is required."
+ERROR_SECCOMP="CONFIG_SECCOMP is required."
+ERROR_UTS_NS="CONFIG_UTS_NS is required."
+
+# Go magic.
+QA_PREBUILT="/usr/bin/fuidshift
+	/usr/bin/lxc
+	/usr/bin/lxc-to-lxd
+	/usr/bin/lxd-agent
+	/usr/bin/lxd-benchmark
+	/usr/bin/lxd-p2c
+	/usr/sbin/lxd"
+
+EGO_PN="github.com/lxc/lxd"
+GOPATH="${S}/_dist" # this seems to reset every now and then, though
+
+VERIFY_SIG_OPENPGP_KEY_PATH=${BROOT}/usr/share/openpgp-keys/linuxcontainers.asc
+
+PATCHES=(
+	"${FILESDIR}/${PN}-syscall_wrappers-don-t-conflict-with-glibc-provided.patch"
+)
+
+src_prepare() {
+	default
+
+	export GOPATH="${S}/_dist"
+
+	sed -i \
+		-e "s:\./configure:./configure --prefix=/usr --libdir=${EPREFIX}/usr/lib/lxd:g" \
+		-e "s:make:make ${MAKEOPTS}:g" \
+		Makefile || die
+
+	# Fix hardcoded ovmf file path, see bug 763180
+	sed -i \
+		-e "s:/usr/share/OVMF:/usr/share/edk2-ovmf:g" \
+		-e "s:OVMF_VARS.ms.fd:OVMF_VARS.secboot.fd:g" \
+		doc/environment.md \
+		lxd/apparmor/instance_qemu.go \
+		lxd/instance/drivers/driver_qemu.go || die "Failed to fix hardcoded ovmf paths."
+
+	# Fix hardcoded virtfs-proxy-helper file path, see bug 798924
+	sed -i \
+		-e "s:/usr/lib/qemu/virtfs-proxy-helper:/usr/libexec/virtfs-proxy-helper:g" \
+		lxd/device/disk.go || die "Failed to fix virtfs-proxy-helper path."
+
+	cp "${FILESDIR}"/lxd-4.0.7-r1.service "${T}"/lxd.service || die
+	if use apparmor; then
+		sed -i \
+			'/^EnvironmentFile=.*/a ExecStartPre=\/usr\/libexec\/lxc\/lxc-apparmor-load' \
+			"${T}"/lxd.service || die
+	fi
+}
+
+src_configure() { :; }
+
+src_compile() {
+	export GOPATH="${S}/_dist"
+	export GO111MODULE=auto
+	export CGO_LDFLAGS_ALLOW="-Wl,-z,now"
+
+	cd "${S}" || die
+
+	for k in fuidshift lxd-benchmark lxc lxc-to-lxd; do
+		go install -v -x "${EGO_PN}/${k}" || die "failed compiling ${k}"
+	done
+
+	go install -v -x -tags libsqlite3 ${EGO_PN}/lxd || die "Failed to build the daemon"
+
+	# Needs to be built statically
+	CGO_ENABLED=0 go install -v -tags netgo "${EGO_PN}"/lxd-p2c
+	CGO_ENABLED=0 go install -v -tags agent,netgo "${EGO_PN}"/lxd-agent
+
+	use nls && emake build-mo
+}
+
+src_test() {
+	export GOPATH="${S}/_dist"
+	export GO111MODULE=off
+	go test -v ${EGO_PN}/lxd || die
+}
+
+src_install() {
+	local bindir="_dist/bin"
+	export GOPATH="${S}/_dist"
+
+	dosbin ${bindir}/lxd
+
+	for l in fuidshift lxd-agent lxd-benchmark lxd-p2c lxc lxc-to-lxd; do
+		dobin ${bindir}/${l}
+	done
+
+	cd "${S}" || die
+
+	newbashcomp scripts/bash/lxd-client lxc
+
+	newconfd "${FILESDIR}"/lxd-4.0.0.confd lxd
+	newinitd "${FILESDIR}"/lxd-4.0.0.initd lxd
+
+	systemd_dounit "${T}"/lxd.service
+
+	systemd_newunit "${FILESDIR}"/lxd-containers-4.0.0.service lxd-containers.service
+	systemd_newunit "${FILESDIR}"/lxd-4.0.0.socket lxd.socket
+
+	dodoc AUTHORS doc/*
+	use nls && domo po/*.mo
+}
+
+pkg_postinst() {
+	elog
+	elog "Consult https://wiki.gentoo.org/wiki/LXD for more information,"
+	elog "including a Quick Start."
+	elog
+	elog "Please run 'lxc-checkconfig' to see all optional kernel features."
+	elog
+	optfeature "btrfs storage backend" sys-fs/btrfs-progs
+	optfeature "lvm2 storage backend" sys-fs/lvm2
+	optfeature "zfs storage backend" sys-fs/zfs
+	elog
+	elog "Be sure to add your local user to the lxd group."
+}


### PR DESCRIPTION
This backports the lxd patch to avoid conflicts with glibc's
close_range(). Also use --syslog instead of
--logfile=/var/log/lxd/lxd.log in lxd's systemd service, so that lxd's
log messages are not logged to a file, but instead to the service's
journal.

The ebuild also no longer uses a dedicated apparmor service
file (files/lxd-4.0.0_apparmor.service), but instead patches the
existing service file if apparmor is used. This avoids maintaining two
systemd service files.

Also drop the unused autotools eclass.

Closes: https://bugs.gentoo.org/807268
Signed-off-by: Florian Schmaus <flow@gentoo.org>