### PR TITLE
app-emulation/qemu: add PYTHON_USEDEP for sphinx bdeps

### DIFF
--- a/app-emulation/qemu/qemu-6.0.0-r3.ebuild
+++ b/app-emulation/qemu/qemu-6.0.0-r3.ebuild
@@ -242,7 +242,7 @@ BDEPEND="
 	dev-lang/perl
 	sys-apps/texinfo
 	virtual/pkgconfig
-	doc? ( dev-python/sphinx )
+	doc? ( dev-python/sphinx[${PYTHON_USEDEP}] )
 	gtk? ( nls? ( sys-devel/gettext ) )
 	test? (
 		dev-libs/glib[utils]

--- a/app-emulation/qemu/qemu-6.0.0-r53.ebuild
+++ b/app-emulation/qemu/qemu-6.0.0-r53.ebuild
@@ -243,7 +243,7 @@ BDEPEND="
 	dev-lang/perl
 	sys-apps/texinfo
 	virtual/pkgconfig
-	doc? ( dev-python/sphinx )
+	doc? ( dev-python/sphinx[${PYTHON_USEDEP}] )
 	gtk? ( nls? ( sys-devel/gettext ) )
 	test? (
 		dev-libs/glib[utils]

--- a/app-emulation/qemu/qemu-6.1.0.ebuild
+++ b/app-emulation/qemu/qemu-6.1.0.ebuild
@@ -241,8 +241,8 @@ BDEPEND="
 	sys-apps/texinfo
 	virtual/pkgconfig
 	doc? (
-		dev-python/sphinx
-		dev-python/sphinx_rtd_theme
+		dev-python/sphinx[${PYTHON_USEDEP}]
+		dev-python/sphinx_rtd_theme[${PYTHON_USEDEP}]
 	)
 	gtk? ( nls? ( sys-devel/gettext ) )
 	test? (


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/814650
Signed-off-by: John Helmert III <ajak@gentoo.org>

I wasn't actually able to reproduce this bug, but this would seem to be the obvious solution to it.