### PR TITLE
Stepping down as proxied maintainer for packages of the Elastic stack

### DIFF
--- a/app-admin/logstash-bin/metadata.xml
+++ b/app-admin/logstash-bin/metadata.xml
@@ -5,10 +5,6 @@
 		<email>hydrapolic@gmail.com</email>
 		<name>Tomáš Mózes</name>
 	</maintainer>
-	<maintainer type="person" proxied="yes">
-		<email>erkiferenc@gmail.com</email>
-		<name>Ferenc Erki</name>
-	</maintainer>
 	<maintainer type="project" proxied="proxy">
 		<email>proxy-maint@gentoo.org</email>
 		<name>Proxy Maintainers</name>

--- a/app-misc/elasticsearch/metadata.xml
+++ b/app-misc/elasticsearch/metadata.xml
@@ -5,10 +5,6 @@
 		<email>hydrapolic@gmail.com</email>
 		<name>Tomáš Mózes</name>
 	</maintainer>
-	<maintainer type="person" proxied="yes">
-		<email>erkiferenc@gmail.com</email>
-		<name>Ferenc Erki</name>
-	</maintainer>
 	<maintainer type="project" proxied="proxy">
 		<email>proxy-maint@gentoo.org</email>
 		<name>Proxy Maintainers</name>

--- a/dev-python/elasticsearch-py/metadata.xml
+++ b/dev-python/elasticsearch-py/metadata.xml
@@ -1,14 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer type="person" proxied="yes">
-		<email>erkiferenc@gmail.com</email>
-		<name>Ferenc Erki</name>
-	</maintainer>
-	<maintainer type="project" proxied="proxy">
-		<email>proxy-maint@gentoo.org</email>
-		<name>Proxy Maintainers</name>
-	</maintainer>
+	<!-- maintainer-needed -->
 	<upstream>
 		<remote-id type="github">elastic/elasticsearch-py</remote-id>
 		<remote-id type="pypi">elasticsearch7</remote-id>

--- a/www-apps/kibana-bin/metadata.xml
+++ b/www-apps/kibana-bin/metadata.xml
@@ -5,10 +5,6 @@
 		<email>hydrapolic@gmail.com</email>
 		<name>Tomáš Mózes</name>
 	</maintainer>
-	<maintainer type="person" proxied="yes">
-		<email>erkiferenc@gmail.com</email>
-		<name>Ferenc Erki</name>
-	</maintainer>
 	<maintainer type="project" proxied="proxy">
 		<email>proxy-maint@gentoo.org</email>
 		<name>Proxy Maintainers</name>


### PR DESCRIPTION
(Mostly) due to not having an active use case for the Elastic stack
anymore, I have decided to step down as proxied maintainer for
the related packages.

Thank you, @hydrapolic, for taking care of most of the affected packages
reliably over a long time. I feel assured the stack will be in a great
shape if and when I have a use case again. Also thank you for all the
proxy maintainers behind @gentoo/proxy-maint who have helped with all
the reviews and merges. Keep up the great work, folks!

This PR would leave dev-python/elasticsearch-py with a
`maintainer-needed` status. @parona-source has already signaled interest
in taking it over via #22248.

Please review and merge, or let me know if there's anything else to do
here.