### PR TITLE
*/*: update kabel's maintainer e-mail address and name

### DIFF
--- a/acct-group/ftpproxy/metadata.xml
+++ b/acct-group/ftpproxy/metadata.xml
@@ -2,8 +2,8 @@
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
 	<maintainer type="person" proxied="yes">
-		<email>kabel@blackhole.sk</email>
-		<name>Marek Behun</name>
+		<email>kabel@kernel.org</email>
+		<name>Marek Behún</name>
 	</maintainer>
 	<maintainer type="project" proxied="proxy">
 		<email>proxy-maint@gentoo.org</email>

--- a/acct-user/ftpproxy/metadata.xml
+++ b/acct-user/ftpproxy/metadata.xml
@@ -2,8 +2,8 @@
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
 	<maintainer type="person" proxied="yes">
-		<email>kabel@blackhole.sk</email>
-		<name>Marek Behun</name>
+		<email>kabel@kernel.org</email>
+		<name>Marek Behún</name>
 	</maintainer>
 	<maintainer type="project" proxied="proxy">
 		<email>proxy-maint@gentoo.org</email>

--- a/net-ftp/frox/metadata.xml
+++ b/net-ftp/frox/metadata.xml
@@ -2,8 +2,8 @@
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
     <maintainer type="person" proxied="yes">
-        <email>kabel@blackhole.sk</email>
-        <name>Marek Behun</name>
+        <email>kabel@kernel.org</email>
+        <name>Marek Behún</name>
     </maintainer>
     <maintainer type="project" proxied="proxy">
         <email>proxy-maint@gentoo.org</email>


### PR DESCRIPTION
Update Marek Behún's e-mail address and name in net-ftp/frox,
acct-user/ftpproxy and acct-group/ftpproxy.

Bug: https://bugs.gentoo.org/632956
Signed-off-by: Marek Behún <kabel@kernel.org>