### PR TITLE
net-misc/dhcpcd: Add check for CONFIG_PACKET requirement

### DIFF
--- a/net-misc/dhcpcd/dhcpcd-9.4.0-r1.ebuild
+++ b/net-misc/dhcpcd/dhcpcd-9.4.0-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit systemd toolchain-funcs
+inherit systemd toolchain-funcs linux-info
 
 if [[ ${PV} == "9999" ]]; then
 	inherit git-r3
@@ -39,6 +39,8 @@ PATCHES=(
 	"${FILESDIR}/${P}-unlink_socket.patch"
 	"${FILESDIR}/${P}-sparc_privsep.patch" #776178
 )
+
+CONFIG_CHECK="~PACKET"
 
 src_configure() {
 	local myeconfargs=(

--- a/net-misc/dhcpcd/dhcpcd-9999.ebuild
+++ b/net-misc/dhcpcd/dhcpcd-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit systemd toolchain-funcs
+inherit systemd toolchain-funcs linux-info
 
 if [[ ${PV} == "9999" ]]; then
 	inherit git-r3
@@ -33,6 +33,8 @@ RDEPEND="
 		acct-user/dhcpcd
 	)
 "
+
+CONFIG_CHECK="~PACKET"
 
 src_configure() {
 	local myeconfargs=(


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/815064
Package-Manager: Portage-3.0.20, Repoman-3.0.3
Signed-off-by: Anthony Ryan <anthonyryan1@gmail.com>