### PR TITLE
mail-client/neomutt: Add use flags for header cache compression

### DIFF
--- a/mail-client/neomutt/metadata.xml
+++ b/mail-client/neomutt/metadata.xml
@@ -27,6 +27,9 @@
 			traditional/inline PGP</flag>
 		<flag name="smime-classic">Build classic-smime backend to support
 			S/MIME</flag>
+		<flag name="lz4">Add lz4 support for header cache compression</flag>
+		<flag name="zlib">Add zlib support for header cache compression</flag>
+		<flag name="zstd">Add zstd support for header cache compression</flag>
 	</use>
 	<upstream>
 		<remote-id type="github">neomutt/neomutt</remote-id>

--- a/mail-client/neomutt/neomutt-20210205-r1.ebuild
+++ b/mail-client/neomutt/neomutt-20210205-r1.ebuild
@@ -22,8 +22,8 @@ HOMEPAGE="https://neomutt.org/"
 LICENSE="GPL-2"
 SLOT="0"
 IUSE="autocrypt berkdb doc gdbm gnutls gpgme idn kerberos kyotocabinet
-	lmdb nls notmuch pgp-classic qdbm sasl selinux slang smime-classic
-	ssl tokyocabinet test"
+	lmdb lz4 nls notmuch pgp-classic qdbm sasl selinux slang smime-classic
+	ssl tokyocabinet test zlib zstd"
 REQUIRED_USE="
 	autocrypt? ( gpgme )"
 
@@ -53,6 +53,9 @@ CDEPEND="
 	!slang? ( sys-libs/ncurses:0= )
 	slang? ( sys-libs/slang )
 	ssl? ( >=dev-libs/openssl-1.0.2u:0= )
+	lz4? ( app-arch/lz4 )
+	zlib? ( sys-libs/zlib )
+	zstd? ( app-arch/zstd )
 "
 DEPEND="${CDEPEND}
 	dev-lang/tcl:=
@@ -95,6 +98,11 @@ src_configure() {
 		"$(use_enable kyotocabinet)"
 		"$(use_enable qdbm)"
 		"$(use_enable tokyocabinet)"
+
+		# Header compression.
+		"$(use_enable lz4)"
+		"$(use_enable zlib)"
+		"$(use_enable zstd)"
 
 		"$(use_enable idn)"
 		"$(use_enable kerberos gss)"

--- a/mail-client/neomutt/neomutt-99999999.ebuild
+++ b/mail-client/neomutt/neomutt-99999999.ebuild
@@ -22,8 +22,8 @@ HOMEPAGE="https://neomutt.org/"
 LICENSE="GPL-2"
 SLOT="0"
 IUSE="autocrypt berkdb doc gdbm gnutls gpgme idn kerberos kyotocabinet
-	lmdb nls notmuch pgp-classic qdbm sasl selinux slang smime-classic
-	ssl tokyocabinet test"
+	lmdb lz4 nls notmuch pgp-classic qdbm sasl selinux slang smime-classic
+	ssl tokyocabinet test zlib zstd"
 REQUIRED_USE="
 	autocrypt? ( gpgme )"
 
@@ -53,6 +53,9 @@ CDEPEND="
 	!slang? ( sys-libs/ncurses:0= )
 	slang? ( sys-libs/slang )
 	ssl? ( >=dev-libs/openssl-1.0.2u:0= )
+	lz4? ( app-arch/lz4 )
+	zlib? ( sys-libs/zlib )
+	zstd? ( app-arch/zstd )
 "
 DEPEND="${CDEPEND}
 	dev-lang/tcl:=
@@ -91,6 +94,11 @@ src_configure() {
 		"$(use_enable kyotocabinet)"
 		"$(use_enable qdbm)"
 		"$(use_enable tokyocabinet)"
+
+		# Header compression.
+		"$(use_enable lz4)"
+		"$(use_enable zlib)"
+		"$(use_enable zstd)"
 
 		"$(use_enable idn)"
 		"$(use_enable kerberos gss)"


### PR DESCRIPTION
Neomutt upstream supports header cache compression via lz4, zlib, and zstd since release 2020-03-13. However, the current ebuilds don't offer the relevant use flags to activate this feature. Adding lz4, zlib, and zstd use flags works well out-of-the-box on my system (tested with all three compression algorithms on amd64 for both 20210205-r1 and 99999999, using the gdbm backend).

release notes: https://neomutt.org/2020/03/13/release
docs: https://neomutt.org/guide/optionalfeatures.html#8-1-%C2%A0header-caching
upstream pull request: https://github.com/neomutt/neomutt/pull/1922

Closes: https://bugs.gentoo.org/815187
Package-Manager: Portage-3.0.20, Repoman-3.0.3
Signed-off-by: Jan Krieg <git@jankrieg.anonaddy.com>