### PR TITLE
media-libs/openjpeg: remove google-code upstream metadata

### DIFF
--- a/media-libs/openjpeg/metadata.xml
+++ b/media-libs/openjpeg/metadata.xml
@@ -3,7 +3,6 @@
 <pkgmetadata>
 	<!-- maintainer-needed -->
 	<upstream>
-		<remote-id type="google-code">openjpeg</remote-id>
 		<remote-id type="sourceforge">openjpeg.mirror</remote-id>
 		<remote-id type="github">uclouvain/openjpeg</remote-id>
 	</upstream>


### PR DESCRIPTION
Signed-off-by: Haowen Liu <liu.haowen.andy@gmail.com>