### PR TITLE
media-sound/ttaenc: fix build

### DIFF
--- a/media-sound/ttaenc/files/ttaenc-3.4.1-fix-hybrid-filter.patch
+++ b/media-sound/ttaenc/files/ttaenc-3.4.1-fix-hybrid-filter.patch
@@ -1,0 +1,13 @@
+https://bugs.gentoo.org/721988
+
+--- a/ttaenc.c
++++ b/ttaenc.c
+@@ -525,7 +525,7 @@ __inline void memshl (register int *pA, register int *pB) {
+ 	*pA   = *pB;
+ }
+ 
+-__inline void hybrid_filter (fltst *fs, int *in, int mode) {
++static void hybrid_filter (fltst *fs, int *in, int mode) {
+ 	register int *pA = fs->dl;
+ 	register int *pB = fs->qm;
+ 	register int *pM = fs->dx;

--- a/media-sound/ttaenc/ttaenc-3.4.1-r1.ebuild
+++ b/media-sound/ttaenc/ttaenc-3.4.1-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -14,7 +14,10 @@ SLOT="0"
 KEYWORDS="amd64 x86"
 
 S="${WORKDIR}/${P}-src"
-PATCHES=( "${FILESDIR}"/${P}-fix-build-system.patch )
+PATCHES=(
+	"${FILESDIR}"/${P}-fix-build-system.patch
+	"${FILESDIR}"/${P}-fix-hybrid-filter.patch
+)
 
 src_configure() {
 	tc-export CC


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/721988
Package-Manager: Portage-3.0.20, Repoman-3.0.3
Signed-off-by: Alexey Sokolov <alexey+gentoo@asokolov.org>