### PR TITLE
dev-texlive/texlive-xetex: Force run fc-cache to populate .uuid files

### DIFF
--- a/dev-texlive/texlive-xetex/texlive-xetex-2021-r1.ebuild
+++ b/dev-texlive/texlive-xetex/texlive-xetex-2021-r1.ebuild
@@ -32,6 +32,11 @@ src_install() {
 pkg_postinst() {
 	texlive-module_pkg_postinst
 	font_pkg_postinst
+
+	# Force additional run of fc-cache to populate .uuid files
+	# in non-standard font dirs listed in 09-texlive.conf
+	# Bug: 812401
+	fc-cache -fs "${EROOT}"/usr/share/texmf-dist/fonts/opentype "${EROOT}"/usr/share/texmf-dist/fonts/truetype
 }
 
 pkg_postrm() {


### PR DESCRIPTION
Force additional run of `fc-cache` in `pkg_postinst()` to populate `.uuid` files
in non-standard font dirs listed in `09-texlive.conf`.

Closes: https://bugs.gentoo.org/812401