### PR TITLE
app-admin/lnav: Unbundle doctest

### DIFF
--- a/app-admin/lnav/files/lnav-0.10.0-use-system-doctest.patch
+++ b/app-admin/lnav/files/lnav-0.10.0-use-system-doctest.patch
@@ -1,0 +1,73 @@
+From 85515b2c196f2e361e93c158201f74177dc4ae37 Mon Sep 17 00:00:00 2001
+From: Randy Barlow <randy@electronsweatshop.com>
+Date: Sat, 18 Sep 2021 21:56:19 -0400
+Subject: [PATCH] Provide a configure flag to use the system doctest
+
+This will allow distributions to more easily maintain
+incompatibilies between doctest and the rest of their software.
+
+Fixes #912
+
+Signed-off-by: Randy Barlow <randy@electronsweatshop.com>
+---
+ configure.ac            |   21 +
+ src/Makefile.am         |    4 +
+ src/doctest.hh          | 5502 +--------------------------------------
+ src/doctest_vendored.hh | 5464 ++++++++++++++++++++++++++++++++++++++
+ 4 files changed, 5527 insertions(+), 5464 deletions(-)
+ create mode 100644 src/doctest_vendored.hh
+
+diff --git a/configure.ac b/configure.ac
+index f2127def..33746d1e 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -153,6 +153,27 @@ AS_IF([test "x$enable_simd" = "xyes"], [
+ ])
+ 
+ 
++AC_ARG_WITH([system_doctest],
++    AS_HELP_STRING(
++        [--with-system-doctest],
++        [Use the system provided doctest library rather than the bundled one]
++    ),
++    [], []
++)
++
++AS_IF([test "x$with_system_doctest" = "xyes"], [
++    AC_CHECK_HEADERS(doctest/doctest.h)
++    AS_IF([test "x$ac_cv_header_doctest_doctest_h" != "xyes"], [
++        AC_MSG_ERROR([system doctest not found])dnl
++    ])
++    AC_DEFINE([DOCTEST_HEADER], ["doctest/doctest.h"], [doctest include path])
++])
++AS_IF([test "x$with_system_doctest" != "xyes"], [
++    AC_DEFINE([DOCTEST_HEADER], ["doctest_vendored.hh"], [doctest include path])
++    AS_VAR_SET(doctest_vendored_h, "doctest_vendored.hh")
++    AC_SUBST(doctest_vendored_h)
++])
++
+ 
+ LNAV_WITH_JEMALLOC
+ 
+diff --git a/src/Makefile.am b/src/Makefile.am
+index 9be9168e..8dc0cd94 100644
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -151,6 +151,9 @@ dist_noinst_DATA = \
+ 	$(FORMAT_FILES) \
+ 	xterm-palette.json
+ 
++EXTRA_HEADERS = \
++	doctest_vendored.hh
++
+ noinst_HEADERS = \
+ 	all_logs_vtab.hh \
+ 	ansi_scrubber.hh \
+@@ -174,6 +177,7 @@ noinst_HEADERS = \
+ 	db_sub_source.hh \
+ 	doc_status_source.hh \
+ 	doctest.hh \
++	$(doctest_vendored_h) \
+ 	elem_to_json.hh \
+ 	environ_vtab.hh \
+ 	field_overlay_source.hh \

--- a/app-admin/lnav/lnav-0.10.0-r2.ebuild
+++ b/app-admin/lnav/lnav-0.10.0-r2.ebuild
@@ -1,0 +1,62 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit autotools
+
+DESCRIPTION="A curses-based tool for viewing and analyzing log files"
+HOMEPAGE="https://lnav.org"
+SRC_URI="https://github.com/tstack/${PN}/archive/refs/tags/v${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="BSD-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="unicode test"
+RESTRICT="!test? ( test )"
+
+RDEPEND="
+	app-arch/bzip2:0=
+	app-arch/libarchive:=
+	test? ( dev-cpp/doctest )
+	>=dev-db/sqlite-3.9.0
+	dev-libs/libpcre[cxx]
+	>=net-misc/curl-7.23.0
+	sys-libs/ncurses:=[unicode(+)?]
+	sys-libs/readline:0=
+	sys-libs/zlib:0="
+DEPEND="${RDEPEND}"
+
+DOCS=( AUTHORS NEWS README )
+PATCHES=(
+	"${FILESDIR}"/${PN}-0.10.0-disable-tests.patch
+	"${FILESDIR}"/${PN}-0.10.0-disable-remote-tests.patch
+	# This allows us to use the --with-system-doctest configure flag, and should not be needed in
+	# the next release of lnav. See https://github.com/tstack/lnav/pull/915
+	# This patch isn't completely identical to the one in PR #915 because that patch was too large
+	# for repoman's tastes. See the comment in src_prepare() for how I applied the rest of this
+	# patch with rm and a heredoc.
+	# https://bugs.gentoo.org/812353
+	"${FILESDIR}"/${PN}-0.10.0-use-system-doctest.patch
+)
+
+src_prepare() {
+	# repoman didn't like having a ~500 kiB patch file, so I'm just manually removing the doctest we
+	# don't want (the bundled one) and putting the one we do want here.
+	# We won't need this once we get rid of lnav-0.10.0-use-system-doctest.patch
+	cat <<EOF > src/doctest.hh
+#include "config.h"
+#include DOCTEST_HEADER
+EOF
+	# We won't need this once we get rid of lnav-0.10.0-use-system-doctest.patch
+	touch src/doctest_vendored.hh
+	default
+	eautoreconf
+}
+
+src_configure() {
+	econf \
+		--disable-static \
+		$(use_with test system-doctest) \
+		$(use_with unicode ncursesw)
+}


### PR DESCRIPTION
Backport https://github.com/tstack/lnav/pull/915 so we can use
the system doctest while we wait on a new lnav upstream release.

Closes: https://bugs.gentoo.org/809752
Closes: https://bugs.gentoo.org/812353
Signed-off-by: Randy Barlow <randy@electronsweatshop.com>