### PR TITLE
media-video/droidcam: support Clang and Clang+LTO built kernels OOTB

### DIFF
--- a/media-video/droidcam/droidcam-1.8.0-r1.ebuild
+++ b/media-video/droidcam/droidcam-1.8.0-r1.ebuild
@@ -84,7 +84,7 @@ src_compile() {
 			fi
 		fi
 	fi
-	linux-mod_src_compile
+	KERNEL_DIR="/usr/src/linux" linux-mod_src_compile
 }
 
 src_test() {

--- a/media-video/droidcam/droidcam-1.8.0-r1.ebuild
+++ b/media-video/droidcam/droidcam-1.8.0-r1.ebuild
@@ -1,0 +1,155 @@
+# Copyright 2019-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit desktop linux-mod xdg
+
+DESCRIPTION="Use your phone or tablet as webcam with a v4l device driver and app"
+HOMEPAGE="https://www.dev47apps.com/droidcam/linux/"
+SRC_URI="https://github.com/dev47apps/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+
+KEYWORDS="~amd64"
+LICENSE="GPL-2"
+SLOT="0"
+
+IUSE="gtk"
+
+# Requires connection to phone/tablet
+RESTRICT="test"
+
+DEPEND="
+	app-pda/libplist
+	app-pda/libusbmuxd
+	dev-libs/glib
+	dev-libs/libappindicator:3
+	dev-libs/libxml2
+	dev-util/android-tools
+	media-libs/alsa-lib
+	media-libs/libjpeg-turbo
+	>=media-libs/speex-1.2.0-r1
+	media-video/ffmpeg
+	gtk? (
+		dev-cpp/gtkmm:3.0
+		x11-libs/gdk-pixbuf
+		x11-libs/gtk+:3
+		x11-libs/libX11
+		x11-libs/pango
+	)
+"
+RDEPEND="${DEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+BUILD_TARGETS="all"
+MODULE_NAMES="v4l2loopback-dc(video:${S}/v4l2loopback:${S}/v4l2loopback)"
+MODULESD_V4L2LOOPBACK_DC_ENABLED="yes"
+
+CONFIG_CHECK="~SND_ALOOP VIDEO_DEV MEDIA_SUPPORT MEDIA_CAMERA_SUPPORT"
+ERROR_SND_ALOOP="CONFIG_SND_ALOOP is optionally required for audio support"
+
+PATCHES="${FILESDIR}/${PN}-makefile-fixes.patch"
+
+src_prepare() {
+	if ! use gtk; then
+		sed -i -e '/cflags gtk+/d' Makefile || die
+		default
+	else
+		# remove path and extension from Icon and Exec entry
+		sed -i -e 's/Icon=\/opt\/droidcam-icon.png/Icon=droidcam/g' \
+			-e 's/\/usr\/local\/bin\/droidcam/droidcam/g' \
+			droidcam.desktop || die
+		sed -i -e 's%/opt/droidcam-icon.png%/usr/share/icons/hicolor/96x96/apps/droidcam.png%g' src/droidcam.c || die
+		xdg_src_prepare
+	fi
+}
+
+src_configure() {
+	set_arch_to_kernel
+	default
+}
+
+src_compile() {
+	if use gtk; then
+		emake droidcam
+	fi
+	emake droidcam-cli
+
+	if linux_chkconfig_present CC_IS_CLANG; then
+		BUILD_PARAMS+=' CC=${CHOST}-clang'
+		if linux_chkconfig_present LD_IS_LLD; then
+			BUILD_PARAMS+=' LD=ld.lld'
+			if linux_chkconfig_present LTO_CLANG_THIN; then
+				# kernel enables cache by default leading to sandbox violations
+				BUILD_PARAMS+=' ldflags-y=--thinlto-cache-dir= LDFLAGS_MODULE=--thinlto-cache-dir='
+			fi
+		fi
+	fi
+	linux-mod_src_compile
+}
+
+src_test() {
+	pushd "v4l2loopback" || die
+	default
+	./test || die
+	popd || die
+}
+
+src_install() {
+	if use gtk; then
+		dobin droidcam
+		newicon -s 32 icon.png droidcam.png
+		newicon -s 96 icon2.png droidcam.png
+		domenu droidcam.desktop
+	fi
+	dobin droidcam-cli
+
+	# The cli and gui do not auto load the module if unloaded (why not though?)
+	# so we just put it in modules-load.d to make sure it always works
+	insinto /etc/modules-load.d
+	if linux_config_exists; then
+		if linux_chkconfig_module SND_ALOOP; then
+			newins - "${PN}.conf" <<-EOF
+				v4l2loopback-dc
+				snd_aloop
+			EOF
+		else
+			newins - "${PN}.conf" <<-EOF
+				v4l2loopback-dc
+			EOF
+		fi
+	fi
+
+	einstalldocs
+	linux-mod_src_install
+}
+
+pkg_preinst() {
+	if use gtk; then
+		xdg_pkg_preinst
+	fi
+	linux-mod_pkg_preinst
+}
+
+pkg_postinst() {
+	linux-mod_pkg_postinst
+	if use gtk; then
+		xdg_pkg_postinst
+	else
+		elog
+		elog "Only droidcam-cli has been installed since 'gtk' flag was not set"
+		elog
+	fi
+
+	elog "The default resolution for v4l2loopback-dc (i.e. droidcam) is 640x480."
+	elog "You can change this value in /etc/modprobe.d/v4l2loopback-dc.conf"
+	elog
+	elog "Links to the Android/iPhone/iPad apps can be found at"
+	elog "https://www.dev47apps.com/"
+}
+
+pkg_postrm() {
+	if use gtk; then
+		xdg_pkg_postrm
+	fi
+	linux-mod_pkg_postrm
+}

--- a/media-video/droidcam/droidcam-1.8.0-r1.ebuild
+++ b/media-video/droidcam/droidcam-1.8.0-r1.ebuild
@@ -84,7 +84,8 @@ src_compile() {
 			fi
 		fi
 	fi
-	KERNEL_DIR="/usr/src/linux" linux-mod_src_compile
+	export KERNEL_DIR
+	linux-mod_src_compile
 }
 
 src_test() {


### PR DESCRIPTION
Hello,

I use regularly droidcam but every time I want to use it I need to reboot into a GCC built kernel... I could not figure out the right environment variables to give the ebuild to make it successfully emerge on my Clang+LTO built kernels. Changing the ebuild with code from `nvidia-drivers` makes it work flawlessly (to basically switch to `clang` and `ld.lld` when needed).

Also, I removed `KERNELRELEASE="${KV_FULL}"` in the line 76, I believe it is not needed as the ebuild emerges fine without it, for any chosen kernel (not restricted to the running kernel). Although the ["linux-info" eclass](https://devmanual.gentoo.org/eclass-reference/linux-info.eclass/index.html) (that defines that variable) was not inherited, so maybe the variable was simply empty ?

Hopefully this will be useful to others.

Adel