### PR TITLE
app-emulation/docker-cli: use `${PV}` for CLI version

### DIFF
--- a/app-emulation/docker-cli/docker-cli-20.10.7.ebuild
+++ b/app-emulation/docker-cli/docker-cli-20.10.7.ebuild
@@ -37,7 +37,7 @@ src_compile() {
 	export CGO_LDFLAGS="-L${ESYSROOT}/usr/$(get_libdir)"
 		emake \
 		LDFLAGS="$(usex hardened '-extldflags -fno-PIC' '')" \
-		VERSION="$(cat VERSION)" \
+		VERSION="${PV}"  \
 		GITCOMMIT="${GIT_COMMIT}" \
 		dynbinary
 

--- a/app-emulation/docker-cli/docker-cli-20.10.8.ebuild
+++ b/app-emulation/docker-cli/docker-cli-20.10.8.ebuild
@@ -39,7 +39,7 @@ src_compile() {
 	export CGO_LDFLAGS="-L${ESYSROOT}/usr/$(get_libdir)"
 		emake \
 		LDFLAGS="$(usex hardened '-extldflags -fno-PIC' '')" \
-		VERSION="$(cat VERSION)" \
+		VERSION="${PV}" \
 		GITCOMMIT="${GIT_COMMIT}" \
 		dynbinary
 


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/815658
Package-Manager: Portage-3.0.20, Repoman-3.0.3
Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>