### PR TITLE
dev-php/composer: v1 dep on dev-php/semver constraints fix.

### DIFF
--- a/dev-php/composer/composer-1.10.22-r1.ebuild
+++ b/dev-php/composer/composer-1.10.22-r1.ebuild
@@ -21,7 +21,7 @@ RDEPEND="
 	>=dev-php/json-schema-5.2.10
 	>=dev-php/jsonlint-1.7.1
 	>=dev-php/phar-utils-1.0.1
-	>=dev-php/semver-1.4.2
+	<dev-php/semver-3.0
 	>=dev-php/spdx-licenses-1.5.0
 	>=dev-php/symfony-console-2.8.48
 	>=dev-php/symfony-filesystem-2.8.48


### PR DESCRIPTION
Whilst we all want old software to "just go away", this is one that is
required to be kept around for a while longer.

Closes: https://bugs.gentoo.org/795957
Bug: https://bugs.gentoo.org/813045

I'll apply same to SLOT PR.

Package-Manager: Portage-3.0.20, Repoman-3.0.3
Signed-off-by: Jaco Kroon <jaco@uls.co.za>