### PR TITLE
dev-qt/qtwayland: More fine-grained subslot

### DIFF
--- a/dev-qt/qtwayland/qtwayland-5.15.2-r14.ebuild
+++ b/dev-qt/qtwayland/qtwayland-5.15.2-r14.ebuild
@@ -7,6 +7,7 @@ KDE_ORG_COMMIT=efe6edcaf8eba601dff99ec6ad4457c8a4442f86
 inherit qt5-build
 
 DESCRIPTION="Wayland platform plugin for Qt"
+SLOT=5/${QT5_PV} # bug 815646
 
 if [[ ${QT5_BUILD_TYPE} == release ]]; then
 	KEYWORDS="amd64 arm arm64 ~hppa ~ppc ~ppc64 ~riscv ~sparc x86"


### PR DESCRIPTION
If the observation in the bug is indeed correct, then at least this time we can get away with simply doing the same as in qtcore/qtgui/qtsql.