### PR TITLE
sys-libs/llvm-libunwind: Fix typo in variable name

### DIFF
--- a/sys-libs/llvm-libunwind/llvm-libunwind-13.0.0.9999.ebuild
+++ b/sys-libs/llvm-libunwind/llvm-libunwind-13.0.0.9999.ebuild
@@ -44,7 +44,7 @@ multilib_src_configure() {
 	# link to compiler-rt
 	# https://github.com/gentoo/gentoo/pull/21516
 	if tc-is-clang; then
-		local compiler-rt=$($(tc-getCC) ${CFLAGS} ${CPPFLAGS} \
+		local compiler_rt=$($(tc-getCC) ${CFLAGS} ${CPPFLAGS} \
 		   ${LD_FLAGS} -print-libgcc-file-name)
 		if [[ ${compiler_rt} == *libclang_rt* ]]; then
 			use_compiler_rt=ON

--- a/sys-libs/llvm-libunwind/llvm-libunwind-13.0.0.ebuild
+++ b/sys-libs/llvm-libunwind/llvm-libunwind-13.0.0.ebuild
@@ -44,7 +44,7 @@ multilib_src_configure() {
 	# link to compiler-rt
 	# https://github.com/gentoo/gentoo/pull/21516
 	if tc-is-clang; then
-		local compiler-rt=$($(tc-getCC) ${CFLAGS} ${CPPFLAGS} \
+		local compiler_rt=$($(tc-getCC) ${CFLAGS} ${CPPFLAGS} \
 		   ${LD_FLAGS} -print-libgcc-file-name)
 		if [[ ${compiler_rt} == *libclang_rt* ]]; then
 			use_compiler_rt=ON

--- a/sys-libs/llvm-libunwind/llvm-libunwind-14.0.0.9999.ebuild
+++ b/sys-libs/llvm-libunwind/llvm-libunwind-14.0.0.9999.ebuild
@@ -44,7 +44,7 @@ multilib_src_configure() {
 	# link to compiler-rt
 	# https://github.com/gentoo/gentoo/pull/21516
 	if tc-is-clang; then
-		local compiler-rt=$($(tc-getCC) ${CFLAGS} ${CPPFLAGS} \
+		local compiler_rt=$($(tc-getCC) ${CFLAGS} ${CPPFLAGS} \
 		   ${LD_FLAGS} -print-libgcc-file-name)
 		if [[ ${compiler_rt} == *libclang_rt* ]]; then
 			use_compiler_rt=ON


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/770868
Package-Manager: Portage-3.0.26, Repoman-3.0.3
Signed-off-by: Han PuYu <w12101111@gmail.com>