### PR TITLE
Add "rexml" dependency

### DIFF
--- a/app-emulation/vagrant/vagrant-2.2.18.ebuild
+++ b/app-emulation/vagrant/vagrant-2.2.18.ebuild
@@ -44,6 +44,7 @@ ruby_add_rdepend "
 	>=dev-ruby/net-ssh-6.1.0
 	dev-ruby/rest-client:2
 	>=dev-ruby/vagrant_cloud-3.0.5
+	>=dev-ruby/rexml-3.2.5
 "
 
 ruby_add_bdepend "


### PR DESCRIPTION
Current ebuild causes ruby to complain about missing "rexml" dependency : 

```
/usr/lib64/ruby/site_ruby/2.6.0/rubygems/dependency.rb:313:in `to_specs': Could not find 'rexml' (>= 3.2) - did find: [rexml-3.1.9.1] (Gem::MissingSpecVersionError)
Checked in 'GEM_PATH=/home/*****/.local/share/gem/ruby/2.6.0:/usr/lib64/ruby/gems/2.6.0:/usr/local/lib64/ruby/gems/2.6.0' , execute `gem env` for more information
        from /usr/lib64/ruby/site_ruby/2.6.0/rubygems/dependency.rb:323:in `to_spec'
        from /usr/lib64/ruby/site_ruby/2.6.0/rubygems/core_ext/kernel_gem.rb:62:in `gem'
        from /usr/lib64/ruby/gems/2.6.0/gems/vagrant-2.2.18/bin/vagrant:95:in `block (2 levels) in <main>'
        from /usr/lib64/ruby/gems/2.6.0/gems/vagrant-2.2.18/bin/vagrant:94:in `each'
        from /usr/lib64/ruby/gems/2.6.0/gems/vagrant-2.2.18/bin/vagrant:94:in `block in <main>'
        from /usr/lib64/ruby/gems/2.6.0/gems/vagrant-2.2.18/bin/vagrant:105:in `<main>'
```