### PR TITLE
profiles/base: unmask dev-perl/Net-Netmask tests

### DIFF
--- a/profiles/base/package.use.stable.mask
+++ b/profiles/base/package.use.stable.mask
@@ -19,14 +19,6 @@ x11-wm/xpra doc
 # all of which are not stable anywhere.
 sys-cluster/ceph pmdk rbd-rwl
 
-# Andreas K. Hüttel <dilfridge@gentoo.org> (2021-05-30)
-# dev-perl/Net-Netmask-2.0.100 needs ... and ... which ends
-# up pulling in a Test-Simple version newer than 5.32.
-# Not something we want to add to all stable users' Perl.
-# Stable-masking the test useflag until Perl 5.34 goes stable too.
-# Bug 779163
-dev-perl/Net-Netmask test
-
 # Mart Raudsepp <leio@gentoo.org> (2021-02-21)
 # Enabling sysprof causes consumers to include sysprof-capture-4
 # headers, but we still have stable consumers that themselves want


### PR DESCRIPTION
Perl 5.34 is stable now.

Bug: https://bugs.gentoo.org/779163
Signed-off-by: Sam James <sam@gentoo.org>