### PR TITLE
net-im/telegram-desktop-bin: disable internal updater again

### DIFF
--- a/net-im/telegram-desktop-bin/files/telegram-desktop-bin
+++ b/net-im/telegram-desktop-bin/files/telegram-desktop-bin
@@ -1,9 +1,0 @@
-#!/bin/sh
-# this wrapper disables the auto-updater of telegram-desktop
-# This program is licensed under the same license as telegram-desktop
-
-# telegram-desktop fails to set RestartCommand with the session manager
-# exclude it from session management to prevent restarts without the argument
-unset SESSION_MANAGER
-
-exec /usr/lib/telegram-desktop-bin/Telegram -externalupdater $@

--- a/net-im/telegram-desktop-bin/telegram-desktop-bin-3.0.1-r1.ebuild
+++ b/net-im/telegram-desktop-bin/telegram-desktop-bin-3.0.1-r1.ebuild
@@ -16,13 +16,16 @@ LICENSE="GPL-3-with-openssl-exception"
 SLOT="0"
 KEYWORDS="-* ~amd64"
 
-QA_PREBUILT="usr/lib/${PN}/Telegram"
+QA_PREBUILT="usr/bin/telegram-desktop"
 
 RDEPEND="
 	dev-libs/glib:2
 	>=media-libs/fontconfig-2.13
 	media-libs/freetype:2
+	sys-libs/zlib
 	virtual/opengl
+	x11-libs/libSM
+	x11-libs/libdrm
 	x11-libs/libX11
 	>=x11-libs/libxcb-1.10[xkb]
 "
@@ -30,9 +33,10 @@ RDEPEND="
 S="${WORKDIR}/Telegram"
 
 src_install() {
-	exeinto /usr/lib/${PN}
-	doexe "Telegram"
-	newbin "${FILESDIR}"/${PN} "telegram-desktop"
+	newbin Telegram telegram-desktop
+
+	insinto /etc/tdesktop
+	newins - externalupdater <<<"${EPREFIX}/usr/bin/telegram-desktop"
 
 	local icon_size
 	for icon_size in 16 32 48 64 128 256 512; do

--- a/net-im/telegram-desktop-bin/telegram-desktop-bin-3.1.0-r1.ebuild
+++ b/net-im/telegram-desktop-bin/telegram-desktop-bin-3.1.0-r1.ebuild
@@ -16,16 +16,13 @@ LICENSE="GPL-3-with-openssl-exception"
 SLOT="0"
 KEYWORDS="-* ~amd64"
 
-QA_PREBUILT="usr/lib/${PN}/Telegram"
+QA_PREBUILT="usr/bin/telegram-desktop"
 
 RDEPEND="
 	dev-libs/glib:2
 	>=media-libs/fontconfig-2.13
 	media-libs/freetype:2
-	sys-libs/zlib
 	virtual/opengl
-	x11-libs/libSM
-	x11-libs/libdrm
 	x11-libs/libX11
 	>=x11-libs/libxcb-1.10[xkb]
 "
@@ -33,9 +30,10 @@ RDEPEND="
 S="${WORKDIR}/Telegram"
 
 src_install() {
-	exeinto /usr/lib/${PN}
-	doexe "Telegram"
-	newbin "${FILESDIR}"/${PN} "telegram-desktop"
+	newbin Telegram telegram-desktop
+
+	insinto /etc/tdesktop
+	newins - externalupdater <<<"${EPREFIX}/usr/bin/telegram-desktop"
 
 	local icon_size
 	for icon_size in 16 32 48 64 128 256 512; do

--- a/net-im/telegram-desktop-bin/telegram-desktop-bin-3.1.1-r1.ebuild
+++ b/net-im/telegram-desktop-bin/telegram-desktop-bin-3.1.1-r1.ebuild
@@ -16,7 +16,7 @@ LICENSE="GPL-3-with-openssl-exception"
 SLOT="0"
 KEYWORDS="-* ~amd64"
 
-QA_PREBUILT="usr/lib/${PN}/Telegram"
+QA_PREBUILT="usr/bin/telegram-desktop"
 
 RDEPEND="
 	dev-libs/glib:2
@@ -30,9 +30,10 @@ RDEPEND="
 S="${WORKDIR}/Telegram"
 
 src_install() {
-	exeinto /usr/lib/${PN}
-	doexe "Telegram"
-	newbin "${FILESDIR}"/${PN} "telegram-desktop"
+	newbin Telegram telegram-desktop
+
+	insinto /etc/tdesktop
+	newins - externalupdater <<<"${EPREFIX}/usr/bin/telegram-desktop"
 
 	local icon_size
 	for icon_size in 16 32 48 64 128 256 512; do


### PR DESCRIPTION
Upstream silently dropped the "-externalupdater" switch. Instead we need
to create a file in /etc to disable the internal updater.

Closes: https://bugs.gentoo.org/814062
Signed-off-by: Henning Schild <henning@hennsch.de>