### PR TITLE
x11-themes/silver-xcursors: fix cursor installation

### DIFF
--- a/x11-themes/silver-xcursors/silver-xcursors-0.4-r4.ebuild
+++ b/x11-themes/silver-xcursors/silver-xcursors-0.4-r4.ebuild
@@ -17,7 +17,7 @@ KEYWORDS="~alpha amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ppc ~ppc64 ~s390 sparc x86"
 RDEPEND="x11-libs/libXcursor"
 
 src_install() {
-	insinto /usr/share/cursors/xorg-x11/
+	insinto /usr/share/cursors/xorg-x11/Silver
 	doins -r Silver/cursors/
 	dodoc README "${FILESDIR}"/README.gentoo
 }


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/794778
Signed-off-by: Yongxiang Liang <tanekliang@gmail.com>