### PR TITLE
net-fs/davfs2-1.6.0: fix support for neon-0.32

### DIFF
--- a/net-fs/davfs2/davfs2-1.6.0.ebuild
+++ b/net-fs/davfs2/davfs2-1.6.0.ebuild
@@ -3,6 +3,8 @@
 
 EAPI=7
 
+inherit autotools
+
 DESCRIPTION="Linux FUSE (or coda) driver that allows you to mount a WebDAV resource"
 HOMEPAGE="https://savannah.nongnu.org/projects/davfs2"
 SRC_URI="mirror://nongnu/${PN}/${P}.tar.gz"
@@ -26,6 +28,10 @@ RDEPEND="${RDEPEND}
 	acct-user/davfs2
 "
 
+PATCHES=(
+	${FILESDIR}/${PF}-neon-0.32-support.patch
+)
+
 src_prepare() {
 	local f
 
@@ -35,6 +41,7 @@ src_prepare() {
 	done < <(find "${S}"/man -type f -name 'Makefile.in' -print0)
 
 	default
+	eautoreconf
 }
 
 src_configure() {

--- a/net-fs/davfs2/files/davfs2-1.6.0-neon-0.32-support.patch
+++ b/net-fs/davfs2/files/davfs2-1.6.0-neon-0.32-support.patch
@@ -1,0 +1,13 @@
+# Gentoo bug https://bugs.gentoo.org/816294
+
+--- a/configure.ac
++++ b/configure.ac
+@@ -36,7 +36,7 @@ AC_PROG_LN_S
+ # Checks for libraries.
+ AM_GNU_GETTEXT_VERSION(0.19.8)
+ AM_GNU_GETTEXT([external])
+-NE_REQUIRE_VERSIONS([0], [27 28 29 30 31])
++NE_REQUIRE_VERSIONS([0], [27 28 29 30 31 32])
+ DAV_CHECK_NEON
+ 
+ # Checks for header files.


### PR DESCRIPTION
Just making the configure script happy.

Signed-off-by: Christophe Lermytte <gentoo@lermytte.be>
Closes: https://bugs.gentoo.org/816294