### PR TITLE
sys-libs/libcxxabi: fix abi_x86_32 build & test failures

### DIFF
--- a/sys-libs/libcxxabi/files/libcxxabi-13.0.0-32-bit-build.patch
+++ b/sys-libs/libcxxabi/files/libcxxabi-13.0.0-32-bit-build.patch
@@ -1,0 +1,19 @@
+# https://bugs.gentoo.org/773604
+
+--- a/libcxxabi/CMakeLists.txt
++++ b/libcxxabi/CMakeLists.txt
+@@ -225,12 +225,8 @@
+ endif()
+ 
+ # Check that we can build with 32 bits if requested.
+-if (CMAKE_SIZEOF_VOID_P EQUAL 8 AND NOT WIN32)
+-  if (LIBCXXABI_BUILD_32_BITS AND NOT LLVM_BUILD_32_BITS) # Don't duplicate the output from LLVM
+-    message(STATUS "Building 32 bits executables and libraries.")
+-  endif()
+-elseif(LIBCXXABI_BUILD_32_BITS)
+-  message(FATAL_ERROR "LIBCXXABI_BUILD_32_BITS=ON is not supported on this platform.")
++if (LIBCXXABI_BUILD_32_BITS AND NOT LLVM_BUILD_32_BITS) # Don't duplicate the output from LLVM
++  message(STATUS "Building 32 bits executables and libraries.")
+ endif()
+ 
+ # Declare libc++abi configuration variables.

--- a/sys-libs/libcxxabi/libcxxabi-13.0.0.9999.ebuild
+++ b/sys-libs/libcxxabi/libcxxabi-13.0.0.9999.ebuild
@@ -31,6 +31,10 @@ BDEPEND="
 		$(python_gen_any_dep 'dev-python/lit[${PYTHON_USEDEP}]')
 	)"
 
+PATCHES=(
+    "${FILESDIR}"/${PN}-13.0.0-32-bit-build.patch
+)
+
 LLVM_COMPONENTS=( libcxx{abi,} llvm/cmake )
 llvm.org_set_globals
 
@@ -62,6 +66,10 @@ multilib_src_configure() {
 		fi
 	fi
 
+	# enable 32-bit build for abi_*_32
+	local want_32_bit=OFF
+	[[ ${ABI} == x86 ]] && local want_32_bit=ON
+
 	local libdir=$(get_libdir)
 	local mycmakeargs=(
 		-DLIBCXXABI_LIBDIR_SUFFIX=${libdir#lib}
@@ -70,6 +78,7 @@ multilib_src_configure() {
 		-DLIBCXXABI_USE_LLVM_UNWINDER=$(usex libunwind)
 		-DLIBCXXABI_INCLUDE_TESTS=$(usex test)
 		-DLIBCXXABI_USE_COMPILER_RT=${want_compiler_rt}
+		-DLIBCXXABI_BUILD_32_BITS=${want_32_bit}
 
 		-DLIBCXXABI_LIBCXX_INCLUDES="${BUILD_DIR}"/libcxx/include/c++/v1
 		# upstream is omitting standard search path for this

--- a/sys-libs/libcxxabi/libcxxabi-13.0.0.ebuild
+++ b/sys-libs/libcxxabi/libcxxabi-13.0.0.ebuild
@@ -31,6 +31,10 @@ BDEPEND="
 		$(python_gen_any_dep 'dev-python/lit[${PYTHON_USEDEP}]')
 	)"
 
+PATCHES=(
+    "${FILESDIR}"/${PN}-13.0.0-32-bit-build.patch
+)
+
 LLVM_COMPONENTS=( libcxx{abi,} llvm/cmake )
 llvm.org_set_globals
 
@@ -62,6 +66,10 @@ multilib_src_configure() {
 		fi
 	fi
 
+	# enable 32-bit build for abi_*_32
+	local want_32_bit=OFF
+	[[ ${ABI} == x86 ]] && local want_32_bit=ON
+
 	local libdir=$(get_libdir)
 	local mycmakeargs=(
 		-DLIBCXXABI_LIBDIR_SUFFIX=${libdir#lib}
@@ -70,6 +78,7 @@ multilib_src_configure() {
 		-DLIBCXXABI_USE_LLVM_UNWINDER=$(usex libunwind)
 		-DLIBCXXABI_INCLUDE_TESTS=$(usex test)
 		-DLIBCXXABI_USE_COMPILER_RT=${want_compiler_rt}
+		-DLIBCXXABI_BUILD_32_BITS=${want_32_bit}
 
 		-DLIBCXXABI_LIBCXX_INCLUDES="${BUILD_DIR}"/libcxx/include/c++/v1
 		# upstream is omitting standard search path for this

--- a/sys-libs/libcxxabi/libcxxabi-14.0.0.9999.ebuild
+++ b/sys-libs/libcxxabi/libcxxabi-14.0.0.9999.ebuild
@@ -31,6 +31,10 @@ BDEPEND="
 		$(python_gen_any_dep 'dev-python/lit[${PYTHON_USEDEP}]')
 	)"
 
+PATCHES=(
+    "${FILESDIR}"/${PN}-13.0.0-32-bit-build.patch
+)
+
 LLVM_COMPONENTS=( libcxx{abi,} llvm/cmake )
 llvm.org_set_globals
 
@@ -62,6 +66,10 @@ multilib_src_configure() {
 		fi
 	fi
 
+	# enable 32-bit build for abi_*_32
+	local want_32_bit=OFF
+	[[ ${ABI} == x86 ]] && local want_32_bit=ON
+
 	local libdir=$(get_libdir)
 	local mycmakeargs=(
 		-DLIBCXXABI_LIBDIR_SUFFIX=${libdir#lib}
@@ -70,6 +78,7 @@ multilib_src_configure() {
 		-DLIBCXXABI_USE_LLVM_UNWINDER=$(usex libunwind)
 		-DLIBCXXABI_INCLUDE_TESTS=$(usex test)
 		-DLIBCXXABI_USE_COMPILER_RT=${want_compiler_rt}
+		-DLIBCXXABI_BUILD_32_BITS=${want_32_bit}
 
 		-DLIBCXXABI_LIBCXX_INCLUDES="${BUILD_DIR}"/libcxx/include/c++/v1
 		# upstream is omitting standard search path for this


### PR DESCRIPTION
I'm not sure if you would want this for all libcxxabi versions because I imagine tests fail there too, however the build fails for `13.0.0` without this.

`sys-libs/libcxxabi-13.0.0[abi_x86_32]` now builds and completes tests without errors for me.

Closes: https://bugs.gentoo.org/773604
Signed-off-by: James Beddek <telans@posteo.de>