### PR TITLE
dev-util/kbuild: workaround build failure with Bison 3.7

### DIFF
--- a/dev-util/kbuild/kbuild-9999.ebuild
+++ b/dev-util/kbuild/kbuild-9999.ebuild
@@ -67,8 +67,26 @@ src_prepare() {
 }
 
 src_compile() {
-	kBuild/env.sh --full \
-		emake -f bootstrap.gmk AUTORECONF=true AR="$(tc-getAR)" \
+	if [[ -z ${YACC} ]] ; then
+		# If the user hasn't picked one, let's prefer byacc > yacc > old bison for now.
+		# See bug #734354 - bison doesn't work here.
+		# We can remove this once Bison works again!
+		if has_version "dev-util/byacc" ; then
+			export YACC=byacc
+		elif has_version "dev-util/yacc" ; then
+			export YACC=yacc
+		elif has_version "<sys-devel/bison-3.7" ; then
+			export YACC=bison
+		else
+			die "This case shouldn't be possible; no suitable YACC impl installed."
+		fi
+
+		einfo "Chosen YACC=${YACC} for build..."
+	else
+		einfo "Chosen user-provided YACC=${YACC} for build..."
+	fi
+
+	kBuild/env.sh --full emake -f bootstrap.gmk AUTORECONF=true AR="$(tc-getAR)" YACC="${YACC}" \
 		|| die "bootstrap failed"
 }
 


### PR DESCRIPTION
Force usage of either byacc or yacc or older-not-in-tree Bison (< 3.7);
it's not enough to just depend on these because we can't really be sure
what kbuild will try to use, especially if a newer Bison is installed
(it'll just try to use it and die).

We choose byacc > yacc > older Bison but allow the user to override
it via the environment if they wish.

Right now, manual intervention seems to be required for people
to install this if, as is likely, users have modern Bison
installed (they'd need to unmerge (ugh!) Bison and then
install byacc or yacc & hope the build system picks it up).

Bug: https://bugs.gentoo.org/734354
Signed-off-by: Sam James <sam@gentoo.org>