### PR TITLE
net-irc/quassel: add spell support without full kde

### DIFF
--- a/net-irc/quassel/quassel-0.13.1-r2.ebuild
+++ b/net-irc/quassel/quassel-0.13.1-r2.ebuild
@@ -20,7 +20,7 @@ HOMEPAGE="https://quassel-irc.org/"
 LICENSE="GPL-3"
 SLOT="0"
 IUSE="bundled-icons crypt +dbus debug kde ldap monolithic oxygen postgres +server
-snorenotify +ssl syslog urlpreview X"
+snorenotify spell +ssl syslog urlpreview X"
 
 SERVER_DEPEND="
 	acct-group/quassel
@@ -53,9 +53,9 @@ GUI_DEPEND="
 		kde-frameworks/ktextwidgets:5
 		kde-frameworks/kwidgetsaddons:5
 		kde-frameworks/kxmlgui:5
-		kde-frameworks/sonnet:5
 	)
 	snorenotify? ( >=x11-libs/snorenotify-0.7.0 )
+	spell? ( kde-frameworks/sonnet:5 )
 	urlpreview? ( dev-qt/qtwebengine:5[widgets] )
 "
 
@@ -83,10 +83,11 @@ DOCS=( AUTHORS ChangeLog README.md )
 REQUIRED_USE="
 	|| ( X server monolithic )
 	crypt? ( || ( server monolithic ) )
-	kde? ( || ( X monolithic ) dbus )
+	kde? ( dbus spell )
 	ldap? ( || ( server monolithic ) )
 	postgres? ( || ( server monolithic ) )
 	snorenotify? ( || ( X monolithic ) )
+	spell? ( || ( X monolithic ) )
 	syslog? ( || ( server monolithic ) )
 "
 
@@ -109,6 +110,7 @@ src_configure() {
 		-DWITH_OXYGEN_ICONS=$(usex oxygen)
 		-DWANT_CORE=$(usex server)
 		$(cmake_use_find_package snorenotify LibsnoreQt5)
+		$(cmake_use_find_package spell KF5Sonnet)
 		-DWITH_WEBENGINE=$(usex urlpreview)
 		-DWANT_QTCLIENT=$(usex X)
 	)


### PR DESCRIPTION
Add new use flag "spell" for enabling spell checking without full KDE integration. KF5Sonnet is categorized as "Optional KF5 tier1
component" and can be used without full KDE, if find_package finds it.
Using this new USE flag we disable automagic dependency on KF5Sonnet if it is installed during build. I have tested on my system, and if it is installed, it is linked into quassel.

Changed REQUIRED_USE so that kde depends on spell, and spell depends on some kind of gui.

I hope "spell" is a good name for this USE flag?