### PR TITLE
app-emulation/lxd: Add keepdir

### DIFF
--- a/app-emulation/lxd/lxd-4.0.7-r1.ebuild
+++ b/app-emulation/lxd/lxd-4.0.7-r1.ebuild
@@ -146,6 +146,8 @@ src_install() {
 	newconfd "${FILESDIR}"/lxd-4.0.0.confd lxd
 	newinitd "${FILESDIR}"/lxd-4.0.0.initd lxd
 
+        keepdir /var/log/lxd
+
 	systemd_dounit "${T}"/lxd.service
 
 	systemd_newunit "${FILESDIR}"/lxd-containers-4.0.0.service lxd-containers.service


### PR DESCRIPTION
Add keepdir function to create /var/log/lxd directory. Fixes bug https://bugs.gentoo.org/817287

Signed-off-by: Uzi Erdenebileg <lzijbuan@gmail.com>