### PR TITLE
dev-python/furo: Add support for pypy3

### DIFF
--- a/dev-python/furo/furo-2021.10.9.ebuild
+++ b/dev-python/furo/furo-2021.10.9.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{8..10} )
+PYTHON_COMPAT=( pypy3 python3_{8..10} )
 DISTUTILS_USE_SETUPTOOLS=pyproject.toml
 inherit distutils-r1
 


### PR DESCRIPTION
A bunch of packages that could make use of dev-python/furo have support for pypy3. For example:
* dev-python/argon2_cffi
* dev-python/service_identity
* dev-python/urllib3

If we want to add furo as a build-time dependency for the projects' docs, we should consider adding pypy3 support to furo.

Closes: https://bugs.gentoo.org/817332
Package-Manager: Portage-3.0.28, Repoman-3.0.3
Signed-off-by: Michael Seifert <m.seifert@digitalernachschub.de>