### PR TITLE
media-libs/libsdl2: add USE to enable hidapi-libusb flag

### DIFF
--- a/media-libs/libsdl2/libsdl2-2.0.16.ebuild
+++ b/media-libs/libsdl2/libsdl2-2.0.16.ebuild
@@ -14,7 +14,7 @@ LICENSE="ZLIB"
 SLOT="0"
 KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ppc ppc64 ~riscv sparc x86"
 
-IUSE="alsa aqua cpu_flags_ppc_altivec cpu_flags_x86_3dnow cpu_flags_x86_mmx cpu_flags_x86_sse cpu_flags_x86_sse2 custom-cflags dbus doc fcitx4 gles1 gles2 haptic ibus jack +joystick kms libsamplerate nas opengl oss pipewire pulseaudio sndio +sound static-libs +threads udev +video video_cards_vc4 vulkan wayland X xinerama xscreensaver"
+IUSE="alsa aqua cpu_flags_ppc_altivec cpu_flags_x86_3dnow cpu_flags_x86_mmx cpu_flags_x86_sse cpu_flags_x86_sse2 custom-cflags dbus doc fcitx4 gles1 gles2 haptic hidapi ibus jack +joystick kms libsamplerate libusb nas opengl oss pipewire pulseaudio sndio +sound static-libs +threads udev +video video_cards_vc4 vulkan wayland X xinerama xscreensaver"
 REQUIRED_USE="
 	alsa? ( sound )
 	fcitx4? ( dbus )
@@ -23,6 +23,7 @@ REQUIRED_USE="
 	haptic? ( joystick )
 	ibus? ( dbus )
 	jack? ( sound )
+	libusb? ( hidapi )
 	nas? ( sound )
 	opengl? ( video )
 	pulseaudio? ( sound )
@@ -38,6 +39,7 @@ CDEPEND="
 	fcitx4? ( app-i18n/fcitx:4 )
 	gles1? ( media-libs/mesa[${MULTILIB_USEDEP},gles1] )
 	gles2? ( >=media-libs/mesa-9.1.6[${MULTILIB_USEDEP},gles2] )
+	hidapi? ( dev-libs/hidapi[${MULTILIB_USEDEP}] )
 	ibus? ( app-i18n/ibus )
 	jack? ( virtual/jack[${MULTILIB_USEDEP}] )
 	kms? (
@@ -45,6 +47,7 @@ CDEPEND="
 		>=media-libs/mesa-9.0.0[${MULTILIB_USEDEP},gbm]
 	)
 	libsamplerate? ( media-libs/libsamplerate[${MULTILIB_USEDEP}] )
+	libusb? ( virtual/libusb:1[${MULTILIB_USEDEP}] )
 	nas? (
 		>=media-libs/nas-1.9.4[${MULTILIB_USEDEP}]
 		>=x11-libs/libXt-1.1.4[${MULTILIB_USEDEP}]
@@ -150,6 +153,8 @@ multilib_src_configure() {
 		$(use_enable alsa)
 		--disable-alsa-shared
 		$(use_enable jack)
+		$(use_enable hidapi)
+		$(use_enable libusb hidapi-libusb)
 		--disable-jack-shared
 		--disable-esd
 		$(use_enable pipewire)

--- a/media-libs/libsdl2/metadata.xml
+++ b/media-libs/libsdl2/metadata.xml
@@ -28,9 +28,11 @@
 		<flag name="gles1">include OpenGL ES 1.0 support</flag>
 		<flag name="gles2">include OpenGL ES 2.0 support</flag>
 		<flag name="haptic">Enable the haptic (force feedback) subsystem</flag>
+		<flag name="hidapi">Enable HID support via <pkg>dev-libs/hidapi</pkg></flag>
 		<flag name="ibus">Enable support for <pkg>app-i18n/ibus</pkg></flag>
 		<flag name="joystick">Control joystick support (disable at your own risk)</flag>
 		<flag name="kms">Build the KMSDRM video driver</flag>
+		<flag name="libusb">Enable raw HID access via <pkg>virtual/libusb</pkg></flag>
 		<flag name="sndio">Enable support for the <pkg>media-sound/sndio</pkg> backend</flag>
 		<flag name="pipewire">Enable support for the <pkg>media-video/pipewire</pkg> audio backend</flag>
 		<flag name="sound">Control audio support (disable at your own risk)</flag>

--- a/profiles/arch/alpha/package.use.mask
+++ b/profiles/arch/alpha/package.use.mask
@@ -489,3 +489,7 @@ net-dialup/ppp atm
 
 # Needs nut and qstat respectively, neither is keyworded on alpha.
 net-analyzer/nagios-plugins nagios-game
+
+# Andrew Udvare <audvare@gmail.com> (2021-10-13)
+# missing keyword for dev-libs/hidapi
+media-libs/libsdl2 hidapi

--- a/profiles/arch/arm/package.use.mask
+++ b/profiles/arch/arm/package.use.mask
@@ -497,3 +497,7 @@ dev-qt/qtscript -jit
 
 # missing keywords
 media-plugins/gst-plugins-meta aac dts dv lame libvisual modplug vcd wavpack
+
+# Andrew Udvare <audvare@gmail.com) (2021-10-13)
+# missing stable for dev-libs/hidapi
+media-libs/libsdl2 hidapi

--- a/profiles/arch/arm64/package.use.mask
+++ b/profiles/arch/arm64/package.use.mask
@@ -424,3 +424,7 @@ sci-libs/linux-gpib firmware
 # Mask flags of calligra and dependencies due to lack of keywords
 app-office/calligra spacenav
 media-gfx/pstoedit emf
+
+# Andrew Udvare <audvare@gmail.com> (2021-10-13)
+# missing stable for dev-libs/hidapi
+media-libs/libsdl2 hidapi

--- a/profiles/arch/hppa/package.use.mask
+++ b/profiles/arch/hppa/package.use.mask
@@ -355,3 +355,7 @@ media-video/mplayer cpudetection
 # Mart Raudsepp <leio@gentoo.org> (2008-04-02)
 # media-plugins/gst-plugins-{dvb,fluendo-mpegdemux,bad} not keyworded
 media-plugins/gst-plugins-meta dvb
+
+# Andrew Udvare <audvare@gmail.com> (2021-10-13)
+# missing keyword for dev-libs/hidapi
+media-libs/libsdl2 hidapi

--- a/profiles/arch/ia64/package.use.mask
+++ b/profiles/arch/ia64/package.use.mask
@@ -290,7 +290,7 @@ gnome-extra/nm-applet teamd
 # Opt-out of ofono support until there is a user request,
 # see also pulseaudio/connman
 net-misc/networkmanager ofono
- 
+
 # Thomas Deutschmann <whissi@gentoo.org> (2016-08-26)
 # Enable numa support on supported architectures
 dev-db/mysql -numa
@@ -469,3 +469,7 @@ media-plugins/gst-plugins-meta dts dv lame libvisual modplug mms taglib vcd wavp
 # Marius Brehler <marfbre@linux.sungazer.de> (2015-08-13)
 # missing keyword
 >=sci-misc/boinc-7.4.42-r1 X
+
+# Andrew Udvare <audvare@gmail.com> (2021-10-13)
+# missing keyword for dev-libs/hidapi
+media-libs/libsdl2 hidapi

--- a/profiles/arch/mips/package.use.mask
+++ b/profiles/arch/mips/package.use.mask
@@ -190,3 +190,7 @@ dev-vcs/git cgi
 # Matt Turner <mattst88@gentoo.org> (2012-02-09)
 # mips only use flags
 >=sci-libs/fftw-3 -zbus
+
+# Andrew Udvare <audvare@gmail.com> (2021-10-13)
+# missing keyword for dev-libs/hidapi
+media-libs/libsdl2 hidapi

--- a/profiles/arch/powerpc/package.use.mask
+++ b/profiles/arch/powerpc/package.use.mask
@@ -379,3 +379,7 @@ media-tv/mythtv vdpau
 # Brent Baude <ranger@gentoo.org>
 # masking zephyr USE on pidgin
 net-im/pidgin zephyr
+
+# Andrew Udvare <audvare@gmail.com> (2021-10-13)
+# missing stable for dev-libs/hidapi
+media-libs/libsdl2 hidapi

--- a/profiles/arch/s390/package.use.mask
+++ b/profiles/arch/s390/package.use.mask
@@ -80,3 +80,7 @@ dev-libs/boost mpi
 >=dev-db/mysql-5.5 tcmalloc
 >=dev-db/mariadb-5.5 tcmalloc
 >=dev-db/percona-server-5.5 tcmalloc
+
+# Andrew Udvare <audvare@gmail.com> (2021-10-13)
+# missing keyword for dev-libs/hidapi
+media-libs/libsdl2 hidapi

--- a/profiles/arch/sparc/package.use.mask
+++ b/profiles/arch/sparc/package.use.mask
@@ -547,3 +547,7 @@ app-admin/rsyslog zeromq
 # Marius Brehler <marfbre@linux.sungazer.de> (2015-08-13)
 # missing keyword
 >=sci-misc/boinc-7.4.42-r1 X
+
+# Andrew Udvare <audvare@gmail.com> (2021-10-13)
+# missing keyword for dev-libs/hidapi
+media-libs/libsdl2 hidapi


### PR DESCRIPTION
Package-Manager: Portage-3.0.28, Repoman-3.0.3

[Yuzu](https://yuzu-emu.org/) and other emulators need this flag enabled if SDL is to be used as a shared library. Without it, motion controls silently fail.

Yuzu is also in GURU but only builds from Git master and submodules for the time being.

[My Yuzu ebuild](https://github.com/Tatsh/tatsh-overlay/blob/master/games-emulation/yuzu)
