### PR TITLE
x11-misc/rofi: add missing x11-misc/xkeyboard-config dependency

### DIFF
--- a/x11-misc/rofi/rofi-1.6.1-r1.ebuild
+++ b/x11-misc/rofi/rofi-1.6.1-r1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 inherit autotools toolchain-funcs
 
@@ -31,6 +31,7 @@ RDEPEND="
 	x11-libs/xcb-util
 	x11-libs/xcb-util-wm
 	x11-libs/xcb-util-xrm
+	x11-misc/xkeyboard-config
 "
 DEPEND="
 	${RDEPEND}

--- a/x11-misc/rofi/rofi-1.7.0-r1.ebuild
+++ b/x11-misc/rofi/rofi-1.7.0-r1.ebuild
@@ -31,6 +31,7 @@ RDEPEND="
 	x11-libs/xcb-util
 	x11-libs/xcb-util-wm
 	x11-libs/xcb-util-xrm
+	x11-misc/xkeyboard-config
 "
 DEPEND="
 	${RDEPEND}

--- a/x11-misc/rofi/rofi-99999.ebuild
+++ b/x11-misc/rofi/rofi-99999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -28,6 +28,7 @@ RDEPEND="
 	x11-libs/xcb-util
 	x11-libs/xcb-util-wm
 	x11-libs/xcb-util-xrm
+	x11-misc/xkeyboard-config
 "
 DEPEND="
 	${RDEPEND}


### PR DESCRIPTION
Add the missing x11-misc/xkeyboard-config dependency. This fixes test failures reported by the tinderbox.

Closes: https://bugs.gentoo.org/760048
Package-Manager: Portage-3.0.26, Repoman-3.0.3
Signed-off-by: Petrus Zhao <petrus.zy.07@gmail.com>