### PR TITLE
media-video/wireplumber: raise minimum pipewire version requirement

### DIFF
--- a/media-video/wireplumber/wireplumber-9999.ebuild
+++ b/media-video/wireplumber/wireplumber-9999.ebuild
@@ -37,7 +37,7 @@ BDEPEND="
 DEPEND="
 	${LUA_DEPS}
 	>=dev-libs/glib-2.62
-	>=media-video/pipewire-0.3.32
+	>=media-video/pipewire-0.3.37
 	virtual/libc
 	systemd? ( sys-apps/systemd )
 "


### PR DESCRIPTION
As the title suggests, this bumps the minimum media-video/pipewire version that got increased in a git commit today and will ship with the next WirePlumber release.