### PR TITLE
net-im/telegram-desktop: Apply openssl3 patch to 3.0.1

### DIFF
--- a/net-im/telegram-desktop/telegram-desktop-3.0.1-r1.ebuild
+++ b/net-im/telegram-desktop/telegram-desktop-3.0.1-r1.ebuild
@@ -75,6 +75,7 @@ S="${WORKDIR}/${MY_P}"
 
 PATCHES=(
 	"${FILESDIR}/tdesktop-2.9.3-jemalloc-only-telegram.patch"
+	"${FILESDIR}/tdesktop-3.1.0-fix-openssl3.patch"
 )
 
 pkg_pretend() {


### PR DESCRIPTION
@gyakovlev

Build-time exclusive fix, package will already be rebuilt when the
openssl version changes.

I want to stabilize this one soon, it's been too long.
