### PR TITLE
lxde-base/lxterminal: bug 818211 automake mismatch

### DIFF
--- a/lxde-base/lxterminal/lxterminal-0.4.0.ebuild
+++ b/lxde-base/lxterminal/lxterminal-0.4.0.ebuild
@@ -31,6 +31,9 @@ BDEPEND="
 
 src_prepare() {
 	xdg_src_prepare
+
+	rm aclocal.m4
+
 	eautoreconf
 }
 


### PR DESCRIPTION
Per the instructions in the QA project wiki page, I removed
the aclocal.m4 file from the upstream package during the build
phase. That resulted in a successful compilation of the package.

Closes: https://bugs.gentoo.org/818211
Package-Manager: Portage-3.0.28, Repoman-3.0.3
Signed-off-by: Jay Faulkner <jay@jvf.cc>