### PR TITLE
net-im/discord-bin: Update depedencies

### DIFF
--- a/net-im/discord-bin/discord-bin-0.0.16-r1.ebuild
+++ b/net-im/discord-bin/discord-bin-0.0.16-r1.ebuild
@@ -3,14 +3,15 @@
 
 EAPI=8
 
-MY_PN=${PN/-bin/}
-MY_BIN="D${MY_PN/d/}"
+MY_PN="${PN%-bin}"
+MY_BIN="${MY_PN^}"
 
-inherit desktop linux-info optfeature pax-utils unpacker xdg
+inherit desktop linux-info optfeature pax-utils unpacker
 
 DESCRIPTION="All-in-one voice and text chat for gamers"
 HOMEPAGE="https://discordapp.com"
 SRC_URI="https://dl.discordapp.net/apps/linux/${PV}/${MY_PN}-${PV}.deb"
+S="${WORKDIR}"
 
 LICENSE="all-rights-reserved"
 SLOT="0"
@@ -18,16 +19,32 @@ KEYWORDS="~amd64"
 RESTRICT="mirror bindist"
 
 RDEPEND="
+	app-accessibility/at-spi2-atk:2
+	app-accessibility/at-spi2-core:2
+	dev-libs/atk
+	dev-libs/expat
+	dev-libs/glib:2
 	dev-libs/nspr
 	dev-libs/nss
-	gnome-base/gconf
 	media-libs/alsa-lib
-	x11-libs/libXScrnSaver
-	x11-libs/libXtst
-	x11-libs/libnotify
+	media-libs/mesa
+	net-print/cups
+	sys-apps/dbus
+	x11-libs/cairo
+	x11-libs/gdk-pixbuf:2
+	x11-libs/gtk+:3
+	x11-libs/libX11
+	x11-libs/libXcomposite
+	x11-libs/libXdamage
+	x11-libs/libXext
+	x11-libs/libXfixes
+	x11-libs/libXrandr
+	x11-libs/libdrm
+	x11-libs/libxcb
+	x11-libs/libxkbcommon
+	x11-libs/libxshmfence
+	x11-libs/pango
 "
-
-S="${WORKDIR}"
 
 QA_PREBUILT="
 	opt/discord/${MY_BIN}
@@ -49,7 +66,7 @@ src_prepare() {
 	default
 
 	sed -i \
-		-e "s:/usr/share/discord/Discord:/opt/${MY_PN}/${MY_BIN}:g" \
+		-e "s:/usr/share/discord/Discord:discord:" \
 		usr/share/${MY_PN}/${MY_PN}.desktop || die
 }
 
@@ -60,7 +77,7 @@ src_install() {
 	insinto /opt/${MY_PN}
 	doins -r usr/share/${MY_PN}/.
 	fperms +x /opt/${MY_PN}/${MY_BIN}
-	dosym ../../opt/${MY_PN}/${MY_BIN} usr/bin/${MY_PN}
+	dosym -r /opt/${MY_PN}/${MY_BIN} /usr/bin/${MY_PN}
 
 	pax-mark -m "${ED}"/opt/${MY_PN}/${MY_PN}
 }


### PR DESCRIPTION
net-im/discord-bin had a few dependencies that are no longer required so I've updated them to be equal to the dependencies in the deb provided from discord.

I've added dev-libs/libappindicator as an optional feature as it's only required if the user wishes to use the system tray and in that case, libappindicator is probably already present anyway. 

I've also added pulseaudio as an optional feature as whilst it's not in the dependencies listed in the deb, https://bugs.gentoo.org/722668 states it's required so I felt it probably doesn't hurt to at least mention it at install time. It could be added as a dependency but there are multiple packages which provides the pulse api (pulseaudio, apulse, pipewire, etc), and most of the time the user will have one of those installed anyway, so I feel it is cleaner just to have it as an optfeature.  

Lastly I also bumped the eapi to version 8.

If possible, I wouldn't mind proxy maintaining net-im/discord-bin going forward as it's something I rely on daily. This would be my first time proxy maintaining.