### PR TITLE
build fix and include support xxhash muxer for media-libs/dav1d

### DIFF
--- a/media-libs/dav1d/dav1d-0.8.2.ebuild
+++ b/media-libs/dav1d/dav1d-0.8.2.ebuild
@@ -19,15 +19,18 @@ HOMEPAGE="https://code.videolan.org/videolan/dav1d"
 
 LICENSE="BSD-2"
 SLOT="0/5"
-IUSE="+8bit +10bit +asm"
+IUSE="+8bit +10bit +asm xxhash"
 
-ASM_DEPEND=">=dev-lang/nasm-2.14.02"
+ASM_DEPEND=">=dev-lang/nasm-2.15.05"
 BDEPEND="asm? (
 		abi_x86_32? ( ${ASM_DEPEND} )
 		abi_x86_64? ( ${ASM_DEPEND} )
-	)"
+	)
+	xxhash? ( dev-libs/xxhash )
+	"
 
 DOCS=( README.md doc/PATENTS THANKS.md )
+PATCHES=( "${FILESDIR}"/build-avoid-meson-s-symbols_have_underscore_prefix.patch )
 
 multilib_src_configure() {
 	local -a bits=()
@@ -44,6 +47,8 @@ multilib_src_configure() {
 	local emesonargs=(
 		-D bitdepths=$(IFS=,; echo "${bits[*]}")
 		-D enable_asm=${enable_asm}
+		-D enable_tests=false
+		-D xxhash_muxer=$(usex xxhash enabled disabled)
 	)
 	meson_src_configure
 }

--- a/media-libs/dav1d/dav1d-0.9.0.ebuild
+++ b/media-libs/dav1d/dav1d-0.9.0.ebuild
@@ -19,15 +19,18 @@ HOMEPAGE="https://code.videolan.org/videolan/dav1d"
 
 LICENSE="BSD-2"
 SLOT="0/5"
-IUSE="+8bit +10bit +asm"
+IUSE="+8bit +10bit +asm xxhash"
 
-ASM_DEPEND=">=dev-lang/nasm-2.14.02"
+ASM_DEPEND=">=dev-lang/nasm-2.15.05"
 BDEPEND="asm? (
 		abi_x86_32? ( ${ASM_DEPEND} )
 		abi_x86_64? ( ${ASM_DEPEND} )
-	)"
+	)
+	xxhash? ( dev-libs/xxhash )
+	"
 
 DOCS=( README.md doc/PATENTS THANKS.md )
+PATCHES=( "${FILESDIR}"/build-avoid-meson-s-symbols_have_underscore_prefix.patch )
 
 multilib_src_configure() {
 	local -a bits=()
@@ -44,6 +47,8 @@ multilib_src_configure() {
 	local emesonargs=(
 		-D bitdepths=$(IFS=,; echo "${bits[*]}")
 		-D enable_asm=${enable_asm}
+		-D enable_tests=false
+		-D xxhash_muxer=$(usex xxhash enabled disabled)
 	)
 	meson_src_configure
 }

--- a/media-libs/dav1d/dav1d-0.9.1.ebuild
+++ b/media-libs/dav1d/dav1d-0.9.1.ebuild
@@ -19,15 +19,18 @@ HOMEPAGE="https://code.videolan.org/videolan/dav1d"
 
 LICENSE="BSD-2"
 SLOT="0/5"
-IUSE="+8bit +10bit +asm"
+IUSE="+8bit +10bit +asm xxhash"
 
-ASM_DEPEND=">=dev-lang/nasm-2.14.02"
+ASM_DEPEND=">=dev-lang/nasm-2.15.05"
 BDEPEND="asm? (
 		abi_x86_32? ( ${ASM_DEPEND} )
 		abi_x86_64? ( ${ASM_DEPEND} )
-	)"
+	)
+		xxhash? ( dev-libs/xxhash )
+	"
 
 DOCS=( README.md doc/PATENTS THANKS.md )
+PATCHES=( "${FILESDIR}"/build-avoid-meson-s-symbols_have_underscore_prefix.patch )
 
 multilib_src_configure() {
 	local -a bits=()
@@ -44,6 +47,8 @@ multilib_src_configure() {
 	local emesonargs=(
 		-D bitdepths=$(IFS=,; echo "${bits[*]}")
 		-D enable_asm=${enable_asm}
+		-D enable_tests=false
+		-D xxhash_muxer=$(usex xxhash enabled disabled)
 	)
 	meson_src_configure
 }

--- a/media-libs/dav1d/dav1d-0.9.2.ebuild
+++ b/media-libs/dav1d/dav1d-0.9.2.ebuild
@@ -19,15 +19,18 @@ HOMEPAGE="https://code.videolan.org/videolan/dav1d"
 
 LICENSE="BSD-2"
 SLOT="0/5"
-IUSE="+8bit +10bit +asm"
+IUSE="+8bit +10bit +asm xxhash"
 
-ASM_DEPEND=">=dev-lang/nasm-2.14.02"
+ASM_DEPEND=">=dev-lang/nasm-2.15.05"
 BDEPEND="asm? (
 		abi_x86_32? ( ${ASM_DEPEND} )
 		abi_x86_64? ( ${ASM_DEPEND} )
-	)"
+	)
+		xxhash? ( dev-libs/xxhash )
+	"
 
 DOCS=( README.md doc/PATENTS THANKS.md )
+PATCHES=( "${FILESDIR}"/build-avoid-meson-s-symbols_have_underscore_prefix.patch )
 
 multilib_src_configure() {
 	local -a bits=()
@@ -44,6 +47,8 @@ multilib_src_configure() {
 	local emesonargs=(
 		-D bitdepths=$(IFS=,; echo "${bits[*]}")
 		-D enable_asm=${enable_asm}
+		-D enable_tests=false
+		-D xxhash_muxer=$(usex xxhash enabled disabled)
 	)
 	meson_src_configure
 }

--- a/media-libs/dav1d/dav1d-9999.ebuild
+++ b/media-libs/dav1d/dav1d-9999.ebuild
@@ -19,13 +19,15 @@ HOMEPAGE="https://code.videolan.org/videolan/dav1d"
 
 LICENSE="BSD-2"
 SLOT="0/5"
-IUSE="+8bit +10bit +asm"
+IUSE="+8bit +10bit +asm xxhash"
 
-ASM_DEPEND=">=dev-lang/nasm-2.14.02"
+ASM_DEPEND=">=dev-lang/nasm-2.15.05"
 BDEPEND="asm? (
 		abi_x86_32? ( ${ASM_DEPEND} )
 		abi_x86_64? ( ${ASM_DEPEND} )
-	)"
+	)
+	xxhash? ( dev-libs/xxhash )
+	"
 
 DOCS=( README.md doc/PATENTS THANKS.md )
 
@@ -44,6 +46,8 @@ multilib_src_configure() {
 	local emesonargs=(
 		-D bitdepths=$(IFS=,; echo "${bits[*]}")
 		-D enable_asm=${enable_asm}
+		-D enable_tests=false
+		-D xxhash_muxer=$(usex xxhash enabled disabled)
 	)
 	meson_src_configure
 }

--- a/media-libs/dav1d/files/build-avoid-meson-s-symbols_have_underscore_prefix.patch
+++ b/media-libs/dav1d/files/build-avoid-meson-s-symbols_have_underscore_prefix.patch
@@ -1,0 +1,32 @@
+From c6a08b3aa1ee99dade53e5e32033bc1d14455a22 Mon Sep 17 00:00:00 2001
+From: Janne Grunau <janne-vlc@jannau.net>
+Date: Tue, 21 Sep 2021 09:30:14 +0200
+Subject: [PATCH 1/5] build: avoid meson's symbols_have_underscore_prefix
+
+Meson's dynamic check is unreliable when additional compiler flags are
+passed via CFLAGS. For example '-fprofile-instr-generate' in oss-fuzz'
+coverage build. Fixes #370.
+---
+ meson.build | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/meson.build b/meson.build
+index 1bf69ab..1a7c409 100644
+--- a/meson.build
++++ b/meson.build
+@@ -382,7 +382,11 @@ endif
+ 
+ cdata.set10('ARCH_PPC64LE', host_machine.cpu() == 'ppc64le')
+ 
+-if cc.symbols_have_underscore_prefix()
++# meson's cc.symbols_have_underscore_prefix() is unfortunately unrelieably
++# when additional flags like '-fprofile-instr-generate' are passed via CFLAGS
++# see following meson issue https://github.com/mesonbuild/meson/issues/5482
++if (host_machine.system() == 'darwin' or
++   (host_machine.system() == 'windows' and host_machine.cpu_family() == 'x86'))
+     cdata.set10('PREFIX', true)
+     cdata_asm.set10('PREFIX', true)
+ endif
+-- 
+2.32.0
+

--- a/media-libs/dav1d/metadata.xml
+++ b/media-libs/dav1d/metadata.xml
@@ -8,6 +8,7 @@
 		<flag name="8bit">Add support for decoding 8-bit AV1.</flag>
 		<flag name="10bit">Add support for building 10-bit and 12-bit AV1.</flag>
 		<flag name="asm">Enable custom assembly for faster decoding.</flag>
+		<flag name="xxhash">Enable <pkg>dev-libs/xxhash</pkg> support for hashing muxer</flag>
 	</use>
 	<upstream>
 		<bugs-to>https://code.videolan.org/videolan/dav1d/issues</bugs-to>


### PR DESCRIPTION
* Require minimum nasm 2.15.05
* Disable test by default
* Fix build, see bug https://code.videolan.org/videolan/dav1d/-/issues/370 and patch https://code.videolan.org/videolan/dav1d/-/commit/c6a08b3aa1ee99dade53e5e32033bc1d14455a22 , the same problem with versions of gcc 10.3.0 and gcc 11.2.0, from dav1d 0.8.2 to 0.9.2

------

<pre>
/usr/lib/gcc/x86_64-pc-linux-gnu/10.3.0/../../../../x86_64-pc-linux-gnu/bin/ld: src/libdav1d.so.5.1.1.p/film_grain16_sse.obj: warning: relocation against `_dav1d_gaussian_sequence' in read-only section `.text'
/usr/lib/gcc/x86_64-pc-linux-gnu/10.3.0/../../../../x86_64-pc-linux-gnu/bin/ld: /var/tmp/portage/media-libs/dav1d-0.9.2/temp/checkasm.SEvpfC.ltrans0.ltrans.o: in function `check_cdef_filter':
<artificial>:(.text+0x2421): undefined reference to `checkasm_stack_clobber'
/usr/lib/gcc/x86_64-pc-linux-gnu/10.3.0/../../../../x86_64-pc-linux-gnu/bin/ld: <artificial>:(.text+0x248d): undefined reference to `checkasm_checked_call'
/usr/lib/gcc/x86_64-pc-linux-gnu/10.3.0/../../../../x86_64-pc-linux-gnu/bin/ld: <artificial>:(.text+0x2d72): undefined reference to `checkasm_stack_clobber'
/usr/lib/gcc/x86_64-pc-linux-gnu/10.3.0/../../../../x86_64-pc-linux-gnu/bin/ld: <artificial>:(.text+0x2dd2): undefined reference to `checkasm_checked_call'
/usr/lib/gcc/x86_64-pc-linux-gnu/10.3.0/../../../../x86_64-pc-linux-gnu/bin/ld: /var/tmp/portage/media-libs/dav1d-0.9.2/temp/checkasm.SEvpfC.ltrans0.ltrans.o: in function `check_pal_pred':
<artificial>:(.text+0x3cad): undefined reference to `checkasm_stack_clobber'
/usr/lib/gcc/x86_64-pc-linux-gnu/10.3.0/../../../../x86_64-pc-linux-gnu/bin/ld: <artificial>:(.text+0x3cf6): undefined reference to `checkasm_checked_call'
/usr/lib/gcc/x86_64-pc-linux-gnu/10.3.0/../../../../x86_64-pc-linux-gnu/bin/ld: <artificial>:(.text+0x408c): undefined reference to `checkasm_stack_clobber'
/usr/lib/gcc/x86_64-pc-linux-gnu/10.3.0/../../../../x86_64-pc-linux-gnu/bin/ld: <artificial>:(.text+0x40db): undefined reference to `checkasm_checked_call'
/usr/lib/gcc/x86_64-pc-linux-gnu/10.3.0/../../../../x86_64-pc-linux-gnu/bin/ld: /var/tmp/portage/media-libs/dav1d-0.9.2/temp/checkasm.SEvpfC.ltrans0.ltrans.o: in function `check_cfl_ac':
</pre>

Closes: https://bugs.gentoo.org/738726
Closes: https://bugs.gentoo.org/791544
Package-Manager: Portage-3.0.20, Repoman-3.0.3
Signed-off-by: Fco. Javier Felix web@inode64.com
