### PR TITLE
sys-cluster/mpich2: Restore missing conf opts

### DIFF
--- a/sys-cluster/mpich2/mpich2-1.5.ebuild
+++ b/sys-cluster/mpich2/mpich2-1.5.ebuild
@@ -89,7 +89,7 @@ src_configure() {
 	c="${c} --docdir=${EPREFIX}/usr/share/doc/${PF}"
 
 	# Forcing Bash as there's quite a few bashisms in the build system
-	CONFIG_SHELL="${BROOT}/bin/bash" econf \
+	CONFIG_SHELL="${BROOT}/bin/bash" econf ${c} \
 		--with-pm=hydra \
 		--disable-mpe \
 		--disable-fast \


### PR DESCRIPTION
* Commit 4c2a5999 errantly removed use of a temporary variable when
  converting the calling method to use bash.

  Also related to:

  Bug 814548 - sys-cluster/mpich2-1.5 installs files into unexpected paths