### PR TITLE
net-wireless/crda: update ldflags patch to fix Clang build

### DIFF
--- a/net-wireless/crda/files/crda-ldflags.patch
+++ b/net-wireless/crda/files/crda-ldflags.patch
@@ -1,11 +1,18 @@
---- /Makefile
-+++ /Makefile
-@@ -115,7 +115,7 @@
+# https://git.kernel.org/pub/scm/linux/kernel/git/mcgrof/crda.git/patch/?id=9856751feaf7b102547cea678a5da6c94252d83d
+# https://bugs.gentoo.org/678450
+# https://bugs.gentoo.org/596352
+
+--- a/Makefile
++++ b/Makefile
+@@ -114,9 +114,9 @@ keys-%.c: utils/key2pub.py $(wildcard $(PUBKEY_DIR)/*.pem)
+ 	$(NQ) '  Trusted pubkeys:' $(wildcard $(PUBKEY_DIR)/*.pem)
+ 	$(Q)./utils/key2pub.py --$* $(wildcard $(PUBKEY_DIR)/*.pem) $@
  
- $(LIBREG): regdb.h reglib.h reglib.c
+-$(LIBREG): regdb.h reglib.h reglib.c
++$(LIBREG): reglib.c regdb.h reglib.h
  	$(NQ) '  CC  ' $@
 -	$(Q)$(CC) $(CFLAGS) $(CPPFLAGS) -o $@ -shared -Wl,-soname,$(LIBREG) $^ $(filter-out -lreg,$(LDLIBS))
-+	$(Q)$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) -o $@ -shared -Wl,-soname,$(LIBREG) $^ $(filter-out -lreg,$(LDLIBS))
++	$(Q)$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) -o $@ -shared -Wl,-soname,$(LIBREG) $< $(filter-out -lreg,$(LDLIBS))
  
  install-libreg-headers:
  	$(NQ) '  INSTALL  libreg-headers'


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/596352
Signed-off-by: James Beddek <telans@posteo.de>