### PR TITLE
app-admin/evtxtools: EAPI 5 -> 8

### DIFF
--- a/app-admin/evtxtools/evtxtools-1.1.1-r2.ebuild
+++ b/app-admin/evtxtools/evtxtools-1.1.1-r2.ebuild
@@ -1,28 +1,30 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=8
 
 inherit perl-module
 
 MY_PN="Parse-Evtx"
-DESCRIPTION="Read, decode and dump Windows Vista/2008/7 event log file "
+DESCRIPTION="Read, decode and dump Windows Vista/2008/7 event log file"
 HOMEPAGE="http://computer.forensikblog.de/en/topics/windows/vista_event_log"
 SRC_URI="http://computer.forensikblog.de/files/evtx/${MY_PN}-${PV}.zip"
 
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="amd64 x86"
-IUSE=""
 
-DEPEND="app-arch/unzip
-	dev-perl/DateTime
+RDEPEND="
 	dev-perl/Digest-CRC
 	dev-perl/DateTime
 	dev-perl/Carp-Assert
-	dev-perl/Data-Hexify"
+	dev-perl/Data-Hexify
+"
 
-RDEPEND="${DEPEND}"
+BDEPEND="${RDEPEND}
+	app-arch/unzip
+	virtual/perl-ExtUtils-MakeMaker
+"
 
 S="${WORKDIR}/${MY_PN}-${PV}"
 


### PR DESCRIPTION
Update to EAPI 8, add virtual/perl-ExtUtils-MakeMaker BDEPEND, remove
duplicate dev-perl/DateTime dependency.

Package-Manager: Portage-3.0.20, Repoman-3.0.3
Signed-off-by: Oskari Pirhonen <xxc3ncoredxx@gmail.com>