### PR TITLE
net-libs/rpcsvc: Change path of rpcgen in Makefile.in [ADVA]

### DIFF
--- a/net-libs/rpcsvc-proto/rpcsvc-proto-1.4.2.ebuild
+++ b/net-libs/rpcsvc-proto/rpcsvc-proto-1.4.2.ebuild
@@ -28,6 +28,7 @@ src_prepare() {
 	# Use ${CHOST}-cpp, not 'cpp': bug #718138
 	# Ideally we should use @CPP@ but rpcgen makes it hard to use '${CHOST}-gcc -E'
 	sed -i -s "s/CPP = \"cpp\";/CPP = \"${CHOST}-cpp\";/" rpcgen/rpc_main.c || die
+	sed -i -e 's|\$(top_builddir)/rpcgen/||' "${S}/rpcsvc/Makefile.in"
 }
 
 src_install() {


### PR DESCRIPTION
Default path of rpcgen in Makefile.in: $(top_builddir)/rpcgen/rpcgen is not a proper path to rpcgen for cross compilation on powerpc64, armv7 and aarch64.
While cross compiling rpcsvc-proto package, there is an error:

../rpcgen/rpcgen -h -o klm_prot.h klm_prot.x
../rpcgen/rpcgen -h -o nlm_prot.h nlm_prot.x
../rpcgen/rpcgen -h -o rstat.h rstat.x
../rpcgen/rpcgen: ../rpcgen/rpcgen: cannot execute binary file

Results of cross compilation (with unchanged  rpcgen path):                                   
powerpc64         x86_64-vm         armv7                   aarch64                i686        
fail                         ok                           fail                         fail                          ok
Result of native compilation (with unchanged  rpcgen path):
amd64
ok

Results of cross compilation (with changed rpcgen path):
powerpc64         x86_64-vm         armv7                   aarch64                i686        
ok                          ok                           ok                          ok                           ok
Result of native compilation (with changed rpcgen path):
amd64
ok
