### PR TITLE
media-libs/codec2: fix freedv_callback_rx_sym typedef

### DIFF
--- a/media-libs/codec2/codec2-1.0.1-r1.ebuild
+++ b/media-libs/codec2/codec2-1.0.1-r1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 CMAKE_ECLASS=cmake
 inherit cmake-multilib
@@ -16,6 +16,10 @@ KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~riscv ~sparc ~x86"
 IUSE="examples test"
 # Not yet passing, but infrastructure added to run
 RESTRICT="test"
+
+PATCHES=(
+	"${FILESDIR}/${P}-fix-freedv-callback.patch" # Bug 816453
+)
 
 multilib_src_configure() {
 	local mycmakeargs=(

--- a/media-libs/codec2/files/codec2-1.0.1-fix-freedv-callback.patch
+++ b/media-libs/codec2/files/codec2-1.0.1-fix-freedv-callback.patch
@@ -1,0 +1,48 @@
+From 7a554bad2f28a4cf19cddf43c619fe5921ddaea3 Mon Sep 17 00:00:00 2001
+From: drowe67 <david@rowetel.com>
+Date: Sat, 2 Oct 2021 15:48:09 +0930
+Subject: [PATCH] moved freedv_callback_rx_sym typedef and function into
+ freedv_api_internal.h
+
+Project-Bug-URL: https://github.com/drowe67/codec2/pull/235
+Gentoo-Bug-URL: https://bugs.gentoo.org/816453
+---
+ src/freedv_api.h          | 2 --
+ src/freedv_api_internal.h | 4 ++++
+ 2 files changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/src/freedv_api.h b/src/freedv_api.h
+index 23c5fef8..9393bd80 100644
+--- a/src/freedv_api.h
++++ b/src/freedv_api.h
+@@ -145,7 +145,6 @@ struct freedv_advanced {
+ 
+ // Called when text message char is decoded
+ typedef void (*freedv_callback_rx)(void *, char);
+-typedef void (*freedv_callback_rx_sym)(void *, _Complex float, float);
+ // Called when new text message char is needed
+ typedef char (*freedv_callback_tx)(void *);
+ typedef void (*freedv_calback_error_pattern)
+@@ -212,7 +211,6 @@ int freedv_check_crc16_unpacked(unsigned char *unpacked_bits, int nbits);
+ // Set parameters ------------------------------------------------------------
+ 
+ void freedv_set_callback_txt            (struct freedv *freedv, freedv_callback_rx rx, freedv_callback_tx tx, void *callback_state);
+-void freedv_set_callback_txt_sym        (struct freedv *freedv, freedv_callback_rx_sym rx, void *callback_state);
+ void freedv_set_callback_protocol       (struct freedv *freedv, freedv_callback_protorx rx, freedv_callback_prototx tx, void *callback_state);
+ void freedv_set_callback_data           (struct freedv *freedv, freedv_callback_datarx datarx, freedv_callback_datatx datatx, void *callback_state);
+ void freedv_set_test_frames		        (struct freedv *freedv, int test_frames);
+diff --git a/src/freedv_api_internal.h b/src/freedv_api_internal.h
+index 0197e184..e7a9526c 100644
+--- a/src/freedv_api_internal.h
++++ b/src/freedv_api_internal.h
+@@ -230,6 +230,10 @@ int freedv_rx_fsk_ldpc_data(struct freedv *f, COMP demod_in[]);
+ 
+ int freedv_bits_to_speech(struct freedv *f, short speech_out[], short demod_in[], int rx_status);
+ 
++// for the reliable text protocol we need to pass symbols back rather than text
++typedef void (*freedv_callback_rx_sym)(void *, _Complex float, float);
++void freedv_set_callback_txt_sym (struct freedv *freedv, freedv_callback_rx_sym rx, void *callback_state);
++
+ #ifdef __cplusplus
+ }
+ #endif


### PR DESCRIPTION
Fix net-wireless/gnuradio (USE=vocoder)

Closes: https://bugs.gentoo.org/816453
Package-Manager: Portage-3.0.28, Repoman-3.0.3
Signed-off-by: Huang Rui <vowstar@gmail.com>