### PR TITLE
net-im/gajim: fix nbxmpp dependency

### DIFF
--- a/net-im/gajim/gajim-1.3.3-r1.ebuild
+++ b/net-im/gajim/gajim-1.3.3-r1.ebuild
@@ -36,7 +36,7 @@ RDEPEND="${COMMON_DEPEND}
 		dev-python/pycurl[${PYTHON_USEDEP}]
 		dev-python/pygobject:3[cairo,${PYTHON_USEDEP}]
 		dev-python/pyopenssl[${PYTHON_USEDEP}]
-		>=dev-python/python-nbxmpp-2.0.2[${PYTHON_USEDEP}]
+		>=dev-python/python-nbxmpp-2.0.4[${PYTHON_USEDEP}]
 		x11-libs/libXScrnSaver
 		app-crypt/libsecret[crypt,introspection]
 		dev-python/keyring[${PYTHON_USEDEP}]


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/818976
Signed-off-by: Florian Schmaus <flow@gentoo.org>