### PR TITLE
kde-apps/ark:  add test dep

### DIFF
--- a/kde-apps/ark/ark-21.08.3.ebuild
+++ b/kde-apps/ark/ark-21.08.3.ebuild
@@ -44,8 +44,11 @@ RDEPEND="
 "
 DEPEND="${RDEPEND}
 	>=dev-qt/qtconcurrent-${QTMIN}:5
+	test? ( >=dev-libs/libzip-1.2.0:= )
 "
-BDEPEND="sys-devel/gettext"
+BDEPEND="
+	sys-devel/gettext
+"
 
 src_configure() {
 	local mycmakeargs=(


### PR DESCRIPTION
`test? ( >=dev-libs/libzip-1.2.0:= )` is required for "kerfuffle-extracttest"

There was some discussion about making this into `REQUIRED_USE="test? ( zip )", but that requires manual interaction where as a test dependency is much simpler.