### PR TITLE
ecm.eclass: set KDE_DEBUG=1 for ecm_src_test

### DIFF
--- a/eclass/ecm.eclass
+++ b/eclass/ecm.eclass
@@ -508,7 +508,8 @@ ecm_src_test() {
 			export $(dbus-launch)
 		fi
 
-		cmake_src_test
+		# KDE_DEBUG stops crash handlers from launching and hanging the test phase
+		KDE_DEBUG=1 cmake_src_test
 	}
 
 	# When run as normal user during ebuild development with the ebuild command,


### PR DESCRIPTION
The KDE_DEBUG variable [1] prevents crash handlers such as DrKonqi from launching
if a test were to segfault.

This prevents a hanging test phase where DrKonqi has launched and is waiting
for input on the virtx display.

[1]: https://userbase.kde.org/KDE_System_Administration/Environment_Variables#KDE_DEBUG

Signed-off-by: James Beddek <telans@posteo.de>