### PR TITLE
dev-libs/libtomcrypt: fix paths in libtomcrypt.pc

### DIFF
--- a/dev-libs/libtomcrypt/libtomcrypt-1.18.2-r3.ebuild
+++ b/dev-libs/libtomcrypt/libtomcrypt-1.18.2-r3.ebuild
@@ -82,10 +82,14 @@ mymake() {
 		LIBPATH="${ESYSROOT}/usr/$(get_libdir)" \
 		INCPATH="${ESYSROOT}/usr/include" \
 		IGNORE_SPEED=1 \
+		PREFIX="${EPREFIX}/usr" \
 		"${@}"
 }
 
 src_compile() {
+	# Replace hard-coded libdir=${exec_prefix}/lib.
+	sed -i -e "/libdir=/s:/lib:/$(get_libdir):" libtomcrypt.pc.in || die
+
 	mymake -f makefile.shared library
 }
 


### PR DESCRIPTION
libtomcrypt.pc looks like this:

```
prefix=/usr/local
exec_prefix=${prefix}
libdir=${exec_prefix}/lib
includedir=${prefix}/include
```

Set the correct PREFIX and replace the hard-coded "/lib" in libdir.

Signed-off-by: Mike Gilbert <floppym@gentoo.org>