### PR TITLE
sci-geosciences/mapserver: added patch to find oracle libnnz21 library

### DIFF
--- a/sci-geosciences/mapserver/files/mapserver-oracle21.patch
+++ b/sci-geosciences/mapserver/files/mapserver-oracle21.patch
@@ -1,0 +1,12 @@
+diff -Naru a/cmake/FindOracle.cmake b/cmake/FindOracle.cmake
+--- a/cmake/FindOracle.cmake	2021-10-20 17:50:27.817205162 +0200
++++ b/cmake/FindOracle.cmake	2021-10-20 17:52:04.977205742 +0200
+@@ -37,7 +37,7 @@
+     ${ORACLE_HOME}/OCI/include) # Oracle XE on Windows
+ 
+   set(ORACLE_OCI_NAMES clntsh libclntsh oci)
+-  set(ORACLE_NNZ_NAMES nnz10 libnnz10 nnz11 libnnz11 nnz12 libnnz12 nnz18 libnnz18 ociw32 nnz19 libnnz19)
++  set(ORACLE_NNZ_NAMES nnz10 libnnz10 nnz11 libnnz11 nnz12 libnnz12 nnz18 libnnz18 ociw32 nnz19 libnnz19 nnz21 libnnz21)
+   set(ORACLE_OCCI_NAMES libocci occi oraocci10 oraocci11 oraocci12)
+ 
+   set(ORACLE_LIB_DIR 

--- a/sci-geosciences/mapserver/mapserver-7.6.2-r1.ebuild
+++ b/sci-geosciences/mapserver/mapserver-7.6.2-r1.ebuild
@@ -88,6 +88,7 @@ BDEPEND="
 
 PATCHES=(
 	"${FILESDIR}"/${P}-proj8.patch
+	"${FILESDIR}"/${PN}-oracle21.patch
 )
 
 want_apache2 apache

--- a/sci-geosciences/mapserver/mapserver-7.6.4.ebuild
+++ b/sci-geosciences/mapserver/mapserver-7.6.4.ebuild
@@ -86,6 +86,10 @@ BDEPEND="
 	)
 "
 
+PATCHES=(
+    "${FILESDIR}"/${PN}-oracle21.patch
+)
+
 want_apache2 apache
 
 pkg_setup() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/819042
Package-Manager: Portage-3.0.20, Repoman-3.0.3
Signed-off-by: Marco Genasci <fedeliallalinea@gmail.com>