### PR TITLE
meson.eclass: add EMESON_BUILDTYPE variable

### DIFF
--- a/eclass/meson.eclass
+++ b/eclass/meson.eclass
@@ -64,6 +64,11 @@ fi
 # Build directory, location where all generated files should be placed.
 # If this isn't set, it defaults to ${WORKDIR}/${P}-build.
 
+# @ECLASS-VARIABLE: EMESON_BUILDTYPE
+# @DESCRIPTION:
+# The buildtype value to pass to meson setup.
+: ${EMESON_BUILDTYPE=plain}
+
 # @ECLASS-VARIABLE: EMESON_SOURCE
 # @DEFAULT_UNSET
 # @DESCRIPTION:
@@ -310,7 +315,6 @@ meson_src_configure() {
 
 	local mesonargs=(
 		meson setup
-		--buildtype plain
 		--libdir "$(get_libdir)"
 		--localstatedir "${EPREFIX}/var/lib"
 		--prefix "${EPREFIX}/usr"
@@ -320,6 +324,10 @@ meson_src_configure() {
 		--pkg-config-path "${PKG_CONFIG_PATH}${PKG_CONFIG_PATH:+:}${EPREFIX}/usr/share/pkgconfig"
 		--native-file "$(_meson_create_native_file)"
 	)
+
+	if [[ -n ${EMESON_BUILDTYPE} ]]; then
+		mesonargs+=( --buildtype "${EMESON_BUILDTYPE}" )
+	fi
 
 	if tc-is-cross-compiler; then
 		mesonargs+=( --cross-file "$(_meson_create_cross_file)" )


### PR DESCRIPTION
This allows the buildtype to be overridden or omitted. This may be
necessary if an ebuild makes use of the 'debug' built-in option.