### PR TITLE
net-analyzer/hydra/hydra-9999999.ebuild

### DIFF
--- a/net-analyzer/hydra/hydra-9999999.ebuild
+++ b/net-analyzer/hydra/hydra-9999999.ebuild
@@ -117,5 +117,5 @@ src_compile() {
 src_install() {
 	dobin hydra pw-inspector
 	use gtk && dobin hydra-gtk/src/xhydra
-	dodoc CHANGES README.md
+	dodoc CHANGES README
 }


### PR DESCRIPTION
Use README instead of README.md in dodoc

Closes: https://bugs.gentoo.org/776670
Package-Manager: Portage-3.0.28, Repoman-3.0.3
Signed-off-by: Emilien Mottet <emilien.mottet@grenoble-inp.org>