### PR TITLE
media-libs/opencolorio: fix OCIO_PYTHON_VERSION

### DIFF
--- a/media-libs/opencolorio/opencolorio-2.0.2.ebuild
+++ b/media-libs/opencolorio/opencolorio-2.0.2.ebuild
@@ -77,7 +77,7 @@ src_configure() {
 		-DOCIO_BUILD_DOCS=$(usex doc)
 		-DOCIO_BUILD_APPS=$(usex opengl)
 		-DOCIO_BUILD_PYTHON=$(usex python)
-		-DOCIO_PYTHON_VERSION="${EPYTHON}"
+		-DOCIO_PYTHON_VERSION="${EPYTHON/python/}"
 		-DOCIO_BUILD_JAVA=OFF
 		-DOCIO_USE_SSE=$(usex cpu_flags_x86_sse2)
 		-DOCIO_BUILD_TESTS=$(usex test)


### PR DESCRIPTION
The OCIO_PYTHON_VERSION cmake argument needs to contain only the version
number (i.e. 3.9), not EPYTHON (i.e. python3.9).

Bug: https://bugs.gentoo.org/819132
Signed-off-by: Marek Behún <kabel@kernel.org>