### PR TITLE
x11-plugins/pidgin-gpg: update ebuild

### DIFF
--- a/x11-plugins/pidgin-gpg/pidgin-gpg-0.9.3.ebuild
+++ b/x11-plugins/pidgin-gpg/pidgin-gpg-0.9.3.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=8
 
 inherit autotools
 
@@ -9,19 +9,19 @@ DESCRIPTION="Pidgin GPG/OpenPGP (XEP-0027) plugin"
 HOMEPAGE="https://github.com/Draghtnod/Pidgin-GPG"
 SRC_URI="https://github.com/Draghtnod/Pidgin-GPG/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
-LICENSE="GPL-3"
+LICENSE="GPL-3+"
 SLOT="0"
 KEYWORDS="~amd64 ~riscv ~x86"
-IUSE=""
 
 RDEPEND="app-crypt/gpgme
 	net-im/pidgin"
-DEPEND="${RDEPEND}
-	virtual/pkgconfig"
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
 
 S="${WORKDIR}/Pidgin-GPG-${PV}"
 
 src_prepare() {
+	default
 	eautoreconf
 }
 


### PR DESCRIPTION
Migrate to EAPI=8, update license to GPL-3+, ebuild cleanup.
Closes: https://bugs.gentoo.org/819147

Package-Manager: Portage-3.0.20, Repoman-3.0.3
Signed-off-by: Azamat H. Hackimov <azamat.hackimov@gmail.com>