### PR TITLE
net-misc/rsync:  Passing --disable-asm to myeconfargs array [ADVA]

### DIFF
--- a/net-misc/rsync/rsync-3.2.3-r4.ebuild
+++ b/net-misc/rsync/rsync-3.2.3-r4.ebuild
@@ -76,6 +76,11 @@ src_configure() {
 		$(use_enable zstd)
 	)
 
+	if [ ! ${ARCH} == "amd64" ]; then
+		# the optimization works properly only for x86_64 arch
+		myeconfargs+=( --disable-asm )
+	fi
+
 	if tc-is-cross-compiler; then
 		# configure check is broken when cross-compiling.
 		myeconfargs+=( --disable-simd )

--- a/net-misc/rsync/rsync-9999.ebuild
+++ b/net-misc/rsync/rsync-9999.ebuild
@@ -73,6 +73,11 @@ src_configure() {
 		$(use_enable zstd)
 	)
 
+	if [ ! ${ARCH} == "amd64" ]; then
+		# the optimization works properly only for x86_64 arch
+		myeconfargs+=( --disable-asm )
+	fi
+
 	if tc-is-cross-compiler; then
 		# configure check is broken when cross-compiling.
 		myeconfargs+=( --disable-simd )


### PR DESCRIPTION
The optimization works properly only for x86_64 arch, so there is no need to use asm for other archs.
Comparing the output of present compiler, use of asm has no impact on performance.

Here are the results of cross-compilation with unchagned ebuild (amd64 - native):
powerpc64         x86_64-vm         armv7                   aarch64                i686        
fail                      ok                       fail                        fail                        fail

native
ok

From the logs of failed compilation:

./lib/md5-asm-x86_64.S:698: Error: unrecognized opcode: `pop'
./lib/md5-asm-x86_64.S:699: Error: unrecognized opcode: `ret'
./lib/md5-asm-x86_64.S:65: Error: unsupported relocation against %rdi
./lib/md5-asm-x86_64.S:683: Error: unsupported relocation against $64
./lib/md5-asm-x86_64.S:684: Error: unsupported relocation against %rdi
If you can't fix the issue, re-run ./configure with --disable-asm.

And here the results with changed ebuild (amd64 - native):
powerpc64         x86_64-vm         armv7                   aarch64                i686        
ok                       ok                       ok                         ok                        ok

native
ok

As it was suggested in the discussion: https://github.com/gentoo/gentoo/pull/22354#discussion_r713165617  https://github.com/gentoo/gentoo/pull/22354#discussion_r713152951 of my previous pull request i added --disable-asm in the myeconfargs array,
i also applied it conditionally for the x86_64.