### PR TITLE
www-servers/apache: Fix runtime defines for proxy deps

### DIFF
--- a/www-servers/apache/apache-2.4.51.ebuild
+++ b/www-servers/apache/apache-2.4.51.ebuild
@@ -112,7 +112,9 @@ MODULE_DEFINES="
 	proxy_ftp:PROXY
 	proxy_html:PROXY
 	proxy_http:PROXY
+	proxy_http2:PROXY
 	proxy_fcgi:PROXY
+	proxy_uwsgi:PROXY
 	proxy_scgi:PROXY
 	proxy_wstunnel:PROXY
 	socache_shmcb:SSL


### PR DESCRIPTION
The proxy_http2 and proxy_uwsgi modules depend on the proxy module
which is masked by the PROXY runtime define. As a result, systems
compiled with either module would fail to run unless either the
appropriate IfDefine directives were added to http2.conf or the
-DPROXY directive was added on apache2.conf so that the proxy
module was loaded.

This patch fixes the MODULE_DEFINES variable to correctly keep
track of that. Since this only affects configuration files and
nobody has reported the issue since June when the uwsgi module
was added, the ebuild is not revbumped in this commit.

Affected users can either manually patch the http2.conf or
reemerge the ebuild and run etc-config to see the changes.

Package-Manager: Portage-3.0.20, Repoman-3.0.2
RepoMan-Options: --force
Signed-off-by: Francisco Blas Izquierdo Riera (klondike) <klondike@gentoo.org>