### PR TITLE
dev-python/argon2-cffi: Added missing doc dependency and bumped to 21.1.0-r1

### DIFF
--- a/dev-python/argon2-cffi/argon2-cffi-21.1.0-r1.ebuild
+++ b/dev-python/argon2-cffi/argon2-cffi-21.1.0-r1.ebuild
@@ -1,0 +1,34 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+PYTHON_COMPAT=( python3_{8..10} pypy3 )
+inherit distutils-r1
+
+DESCRIPTION="CFFI bindings to the Argon2 password hashing library"
+HOMEPAGE="https://github.com/hynek/argon2-cffi"
+SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+
+DEPEND="
+	app-crypt/argon2:=
+	virtual/python-cffi[${PYTHON_USEDEP}]
+"
+RDEPEND="${DEPEND}"
+BDEPEND="
+	test? (
+		dev-python/hypothesis[${PYTHON_USEDEP}]
+	)
+"
+
+DOCS=( AUTHORS.rst CHANGELOG.rst FAQ.rst README.rst )
+
+distutils_enable_sphinx docs \
+	dev-python/furo
+distutils_enable_tests pytest
+
+export ARGON2_CFFI_USE_SYSTEM=1

--- a/profiles/arch/powerpc/package.use.mask
+++ b/profiles/arch/powerpc/package.use.mask
@@ -1,6 +1,10 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Michael Seifert <m.seifert@digitalernachschub.de> (2021-10-23)
+# dev-python/furo isn't keyworded here
+dev-python/argon2-cffi doc
+
 # David Seifert <soap@gentoo.org> (2021-09-04)
 # dev-lang/go not keyworded here
 sys-libs/libcap tools

--- a/profiles/arch/riscv/package.use.mask
+++ b/profiles/arch/riscv/package.use.mask
@@ -1,6 +1,10 @@
 # Copyright 2019-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Michael Seifert <m.seifert@digitalernachschub.de> (2021-10-23)
+# dev-python/furo isn't keyworded here
+dev-python/argon2-cffi doc
+
 # Alex Fan <alexfanqi@yahoo.com> (2021-10-11)
 # sci-libs/sundials fails several tests #817680
 sci-mathematics/octave sundials

--- a/profiles/arch/sparc/package.use.mask
+++ b/profiles/arch/sparc/package.use.mask
@@ -1,6 +1,10 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Michael Seifert <m.seifert@digitalernachschub.de> (2021-10-23)
+# dev-python/furo isn't keyworded here
+dev-python/argon2-cffi doc
+
 # Sam James <sam@gentoo.org> (2021-10-16)
 # Requires dev-db/mariadb which, at last check, was broken on sparc.
 # bug #814719


### PR DESCRIPTION
Masked USE=doc on architectures where dev-python/furo has no keyword.

I'm unsure whether I'm eligible to make entries to `package.use.mask`. Is this okay or is there a process for masking USE flags on specific architectures?