### PR TITLE
app-office/libreoffice: add LLVM 13 deps

### DIFF
--- a/app-office/libreoffice/libreoffice-7.1.5.2.ebuild
+++ b/app-office/libreoffice/libreoffice-7.1.5.2.ebuild
@@ -185,6 +185,9 @@ COMMON_DEPEND="${PYTHON_DEPS}
 	)
 	clang? (
 		|| (
+			(	sys-devel/clang:13
+				sys-devel/llvm:13
+				=sys-devel/lld-13*	)
 			(	sys-devel/clang:12
 				sys-devel/llvm:12
 				=sys-devel/lld-12*	)

--- a/app-office/libreoffice/libreoffice-7.1.6.2.ebuild
+++ b/app-office/libreoffice/libreoffice-7.1.6.2.ebuild
@@ -188,6 +188,9 @@ COMMON_DEPEND="${PYTHON_DEPS}
 	)
 	clang? (
 		|| (
+			(	sys-devel/clang:13
+				sys-devel/llvm:13
+				=sys-devel/lld-13*	)
 			(	sys-devel/clang:12
 				sys-devel/llvm:12
 				=sys-devel/lld-12*	)

--- a/app-office/libreoffice/libreoffice-7.1.9999.ebuild
+++ b/app-office/libreoffice/libreoffice-7.1.9999.ebuild
@@ -188,6 +188,9 @@ COMMON_DEPEND="${PYTHON_DEPS}
 	)
 	clang? (
 		|| (
+			(	sys-devel/clang:13
+				sys-devel/llvm:13
+				=sys-devel/lld-13*	)
 			(	sys-devel/clang:12
 				sys-devel/llvm:12
 				=sys-devel/lld-12*	)

--- a/app-office/libreoffice/libreoffice-9999.ebuild
+++ b/app-office/libreoffice/libreoffice-9999.ebuild
@@ -187,6 +187,9 @@ COMMON_DEPEND="${PYTHON_DEPS}
 	)
 	clang? (
 		|| (
+			(	sys-devel/clang:13
+				sys-devel/llvm:13
+				=sys-devel/lld-13*	)
 			(	sys-devel/clang:12
 				sys-devel/llvm:12
 				=sys-devel/lld-12*	)


### PR DESCRIPTION
Hello,

I could not install `lld` 13 because of `libreoffice` hard-locking `lld` 12, I had a look at the ebuild and the version constraints are added by hand: clang and lld are forced to have the same version, but version 13 hasn't been added yet. This PR adds that.

I think it is good to check for matching `clang`/`lld` versions although if there is a mismatch nothing can compile afaik, not only `libreoffice` ? Maybe the versions can be relaxed and the ebuild can depend only on `clang` and `lld` without constraints on the version ?

Another thing, are `lld` and `clang` needed as runtime dependencies ?

Cheers,

Adel