### PR TITLE
app-misc/wcd-0.6.3-r2: fix docs installed into unexpected path

### DIFF
--- a/app-misc/wcd/files/wcd-6.0.3-doc-path.patch
+++ b/app-misc/wcd/files/wcd-6.0.3-doc-path.patch
@@ -1,0 +1,14 @@
+Install docs into /usr/share/doc/wcd-${PVR}.
+
+diff -Nuar a/src/Makefile b/src/Makefile
+--- a/src/Makefile	2019-08-14 10:07:15.000000000 +0000
++++ b/src/Makefile	2021-10-23 17:10:17.000000000 +0000
+@@ -61,7 +61,7 @@
+ datarootdir     = $(prefix)/share
+ datadir         = $(datarootdir)
+ 
+-docsubdir       = $(PACKAGE)-$(VERSION)
++docsubdir       = $(PACKAGE)-$(PVR)
+ docdir          = $(datarootdir)/doc/$(docsubdir)
+ localedir       = $(datarootdir)/locale
+ sysconfdir      = /etc

--- a/app-misc/wcd/wcd-6.0.3-r2.ebuild
+++ b/app-misc/wcd/wcd-6.0.3-r2.ebuild
@@ -1,0 +1,47 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit toolchain-funcs
+
+DESCRIPTION="Wherever Change Directory"
+HOMEPAGE="http://waterlan.home.xs4all.nl/#WCD_ANCHOR"
+SRC_URI="http://waterlan.home.xs4all.nl/${PN}/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~x86 ~amd64-linux ~x86-linux"
+IUSE="nls unicode"
+
+CDEPEND="
+	sys-libs/ncurses:=[unicode(+)?]
+	unicode? ( dev-libs/libunistring:= )"
+DEPEND="${CDEPEND}"
+BDEPEND="
+	app-text/ghostscript-gpl
+	virtual/pkgconfig
+"
+RDEPEND="${CDEPEND}"
+
+S="${WORKDIR}/${P}/src"
+
+src_prepare() {
+	eapply -p2 "${FILESDIR}"/${PN}-6.0.2-gentoo.patch
+	eapply -p2 "${FILESDIR}"/${P}-doc-path.patch
+	eapply_user
+	tc-export CC PKG_CONFIG
+}
+
+src_compile() {
+	local mycompile="LFS=1"
+	use nls || mycompile+=" ENABLE_NLS="
+	use unicode && mycompile+=" UCS=1 UNINORM=1"
+	emake ${mycompile}
+}
+
+src_install() {
+	local DOCS=( ../README.txt )
+	default
+	emake DESTDIR="${D}" DOTWCD=1 install-profile sysconfdir="/etc"
+}


### PR DESCRIPTION
Install docs into /usr/share/doc/wcd-${PVR}.
```
--- wcd-6.0.3-r1.ebuild	2021-10-18 06:05:33.720340852 +0000
+++ wcd-6.0.3-r2.ebuild	2021-10-23 17:15:56.358350983 +0000
@@ -28,6 +28,7 @@
 
 src_prepare() {
 	eapply -p2 "${FILESDIR}"/${PN}-6.0.2-gentoo.patch
+	eapply -p2 "${FILESDIR}"/${P}-doc-path.patch
 	eapply_user
 	tc-export CC PKG_CONFIG
 }

```