### PR TITLE
x11-themes/papirus-icon-theme: skip pantheon variants by default

### DIFF
--- a/x11-themes/papirus-icon-theme/metadata.xml
+++ b/x11-themes/papirus-icon-theme/metadata.xml
@@ -7,4 +7,9 @@
 		<bugs-to>https://github.com/PapirusDevelopmentTeam/papirus-icon-theme/issues</bugs-to>
 		<remote-id type="github">PapirusDevelopmentTeam/papirus-icon-theme</remote-id>
 	</upstream>
+	<use>
+		<flag name="pantheon">
+			Install variant designed for Pantheon DE (elementary OS)
+		</flag>
+	</use>
 </pkgmetadata>

--- a/x11-themes/papirus-icon-theme/papirus-icon-theme-20211001-r1.ebuild
+++ b/x11-themes/papirus-icon-theme/papirus-icon-theme-20211001-r1.ebuild
@@ -1,0 +1,23 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit xdg
+
+DESCRIPTION="Free and open source SVG icon theme"
+HOMEPAGE="https://github.com/PapirusDevelopmentTeam/papirus-icon-theme"
+SRC_URI="https://github.com/PapirusDevelopmentTeam/papirus-icon-theme/archive/${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="GPL-3"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+IUSE="pantheon"
+
+src_compile() { :; }
+
+src_install() {
+	insinto /usr/share/icons
+	doins -r Papirus{,-Dark,-Light}
+	use pantheon && doins -r ePapirus{,-Dark}
+}


### PR DESCRIPTION
ePapirus and ePapirus-Dark are variants designed for elementaryOS and Pantheon DE.

Signed-off-by: Alexey Zapparov <alexey@zapparov.com>