### PR TITLE
app-arch/snappy: remove -fno-rtti option

### DIFF
--- a/app-arch/snappy/files/snappy-1.1.9_remove-no-rtti.patch
+++ b/app-arch/snappy/files/snappy-1.1.9_remove-no-rtti.patch
@@ -1,0 +1,35 @@
+From 516fdcca6606502e2d562d20c01b225c8d066739 Mon Sep 17 00:00:00 2001
+From: holmes1412 <liyingxin1412@gmail.com>
+Date: Fri, 28 May 2021 21:46:53 +0800
+Subject: [PATCH] remove Disable-RTTI flags for the convenient of derivation
+
+---
+ CMakeLists.txt | 8 --------
+ 1 file changed, 8 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 672561e..31afaa0 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -51,10 +51,6 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+   string(REGEX REPLACE "/EH[a-z]+" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHs-c-")
+   add_definitions(-D_HAS_EXCEPTIONS=0)
+-
+-  # Disable RTTI.
+-  string(REGEX REPLACE "/GR" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /GR-")
+ else(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+   # Use -Wall for clang and gcc.
+   if(NOT CMAKE_CXX_FLAGS MATCHES "-Wall")
+@@ -76,10 +72,6 @@ else(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+   # Disable C++ exceptions.
+   string(REGEX REPLACE "-fexceptions" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-exceptions")
+-
+-  # Disable RTTI.
+-  string(REGEX REPLACE "-frtti" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")
+ endif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+ 
+ # BUILD_SHARED_LIBS is a standard CMake variable, but we declare it here to make

--- a/app-arch/snappy/snappy-1.1.9-r1.ebuild
+++ b/app-arch/snappy/snappy-1.1.9-r1.ebuild
@@ -1,0 +1,45 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit cmake-multilib
+
+DESCRIPTION="A high-speed compression/decompression library by Google"
+HOMEPAGE="https://github.com/google/snappy"
+SRC_URI="https://github.com/google/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="BSD"
+SLOT="0/${PV%%.*}"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~x64-macos"
+IUSE="test"
+RESTRICT="!test? ( test )"
+
+DEPEND="test? ( dev-cpp/gtest )"
+
+DOCS=( format_description.txt framing_format.txt NEWS README.md )
+
+PATCHES=(
+	"${FILESDIR}/${P}_gcc_inline.patch"
+	"${FILESDIR}/${P}_external_gtest.patch"
+	"${FILESDIR}/${P}-clang-werror.patch"
+	"${FILESDIR}/${P}_remove-no-rtti.patch"
+)
+
+multilib_src_configure() {
+	local mycmakeargs=(
+		-DSNAPPY_BUILD_TESTS=$(usex test)
+		-DSNAPPY_BUILD_BENCHMARKS=OFF
+		# Options below are related to benchmarking, that we disable.
+		-DHAVE_LIBZ=NO
+		-DHAVE_LIBLZO2=NO
+		-DHAVE_LIBLZ4=NO
+	)
+	cmake_src_configure
+}
+
+multilib_src_test() {
+	# run tests directly to get verbose output
+	cd "${S}" || die
+	"${BUILD_DIR}"/snappy_unittest || die
+}


### PR DESCRIPTION
Remove -fno-rtti option which may broke compilation of dependant packages. Migrate to EAPI=8, minor cleanups.
Closes: https://bugs.gentoo.org/819909