### PR TITLE
dev-vcs/git fixes

### DIFF
--- a/dev-vcs/git/git-2.33.1-r1.ebuild
+++ b/dev-vcs/git/git-2.33.1-r1.ebuild
@@ -292,6 +292,7 @@ git_emake() {
 		perllibdir="$(use perl && perl_get_raw_vendorlib)" \
 		sysconfdir="${EPREFIX}"/etc \
 		GIT_TEST_OPTS="--no-color" \
+		INSTALL_SYMLINKS=1 \
 		OPTAR="$(tc-getAR)" \
 		OPTCC="$(tc-getCC)" \
 		OPTCFLAGS="${CFLAGS}" \

--- a/dev-vcs/git/git-9999-r1.ebuild
+++ b/dev-vcs/git/git-9999-r1.ebuild
@@ -292,6 +292,7 @@ git_emake() {
 		perllibdir="$(use perl && perl_get_raw_vendorlib)" \
 		sysconfdir="${EPREFIX}"/etc \
 		GIT_TEST_OPTS="--no-color" \
+		INSTALL_SYMLINKS=1 \
 		OPTAR="$(tc-getAR)" \
 		OPTCC="$(tc-getCC)" \
 		OPTCFLAGS="${CFLAGS}" \

--- a/dev-vcs/git/git-9999-r2.ebuild
+++ b/dev-vcs/git/git-9999-r2.ebuild
@@ -292,6 +292,7 @@ git_emake() {
 		perllibdir="$(use perl && perl_get_raw_vendorlib)" \
 		sysconfdir="${EPREFIX}"/etc \
 		GIT_TEST_OPTS="--no-color" \
+		INSTALL_SYMLINKS=1 \
 		OPTAR="$(tc-getAR)" \
 		OPTCC="$(tc-getCC)" \
 		OPTCFLAGS="${CFLAGS}" \

--- a/dev-vcs/git/git-9999-r3.ebuild
+++ b/dev-vcs/git/git-9999-r3.ebuild
@@ -292,6 +292,7 @@ git_emake() {
 		perllibdir="$(use perl && perl_get_raw_vendorlib)" \
 		sysconfdir="${EPREFIX}"/etc \
 		GIT_TEST_OPTS="--no-color" \
+		INSTALL_SYMLINKS=1 \
 		OPTAR="$(tc-getAR)" \
 		OPTCC="$(tc-getCC)" \
 		OPTCFLAGS="${CFLAGS}" \

--- a/dev-vcs/git/git-9999.ebuild
+++ b/dev-vcs/git/git-9999.ebuild
@@ -292,6 +292,7 @@ git_emake() {
 		perllibdir="$(use perl && perl_get_raw_vendorlib)" \
 		sysconfdir="${EPREFIX}"/etc \
 		GIT_TEST_OPTS="--no-color" \
+		INSTALL_SYMLINKS=1 \
 		OPTAR="$(tc-getAR)" \
 		OPTCC="$(tc-getCC)" \
 		OPTCFLAGS="${CFLAGS}" \


### PR DESCRIPTION
- Avoid using ${D} before src_install (PMS compliance)
- Install symlinks instead of hardlinks to fix FEATURES="splitdebug"

Bug: https://bugs.gentoo.org/820107