### PR TITLE
games-misc/sex: EAPI8, minor improvements

### DIFF
--- a/games-misc/sex/sex-1.0-r2.ebuild
+++ b/games-misc/sex/sex-1.0-r2.ebuild
@@ -1,7 +1,9 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
+
+inherit toolchain-funcs
 
 DESCRIPTION="Spouts silly mad-lib-style porn-like text"
 HOMEPAGE="http://spatula.net/software/sex/"
@@ -10,7 +12,6 @@ SRC_URI="http://spatula.net/software/sex/${P}.tar.gz"
 LICENSE="BSD"
 SLOT="0"
 KEYWORDS="~alpha ~amd64 ~ppc64 ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
-IUSE=""
 
 RDEPEND="!sci-astronomy/sextractor"
 
@@ -20,6 +21,7 @@ src_prepare() {
 }
 
 src_compile() {
+	tc-export CC
 	emake sex
 }
 


### PR DESCRIPTION
@ionenwks 
This seems to be simply EAPI bump. I've only added `tc-export CC` since it was calling `cc` directly.
BTW, somehow related. There is a open bug about a file collision with `sci-astronomy/sextractor`: https://bugs.gentoo.org/596968
However this seems to be already fixed 5 years ago with commit: e2c302f09eee6d172696ae49db977758f8ee6736
Since both packages were bumped with this commit i guess this bug can be closed too (the bug for `games-misc/sex` was already closed)

Package-Manager: Portage-3.0.28, Repoman-3.0.3
Signed-off-by: Michael Mair-Keimberger <mmk@levelnine.at>