### PR TITLE
profiles: remove default ALSA_CARDS setting from arch profiles

### DIFF
--- a/profiles/arch/alpha/make.defaults
+++ b/profiles/arch/alpha/make.defaults
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 ARCH="alpha"
@@ -22,11 +22,6 @@ LIBDIR_alpha="lib"
 # Donnie Berkholz <dberkholz@gentoo.org> (2006-08-18)
 # Defaults for video drivers
 VIDEO_CARDS="fbdev glint mga nv r128 radeon"
-
-# Chris Gianelloni <wolf31o2@gentoo.org> (2007-02-05)
-# Defaults for audio drivers. These are copied from x86 (minus modems), since
-# Alpha supports the same busses.
-ALSA_CARDS="ali5451 als4000 bt87x ca0106 cmipci emu10k1 ens1370 ens1371 es1938 es1968 fm801 hda-intel intel8x0 maestro3 trident usb-audio via82xx ymfpci"
 
 # Tobias Klausmann <klausman@gentoo.org> (2018-06-25)
 # Enable USE=libtirpc by default, to ease dependency resolution during

--- a/profiles/arch/amd64/make.defaults
+++ b/profiles/arch/amd64/make.defaults
@@ -50,10 +50,6 @@ ABI_X86="64"
 # Defaults for video drivers
 VIDEO_CARDS="amdgpu fbdev intel nouveau radeon radeonsi vesa"
 
-# Danny van Dyk <kugelfang@gentoo.org> (2006-12-22)
-# Default for ALSA_CARDS USE_EXPAND variable.
-ALSA_CARDS="ali5451 als4000 atiixp atiixp-modem bt87x ca0106 cmipci emu10k1x ens1370 ens1371 es1938 es1968 fm801 hda-intel intel8x0 intel8x0m maestro3 trident usb-audio via82xx via82xx-modem ymfpci"
-
 # Michał Górny <mgorny@gentoo.org> (2013-01-26)
 # Unhide the x86-specific USE_EXPANDs.
 USE_EXPAND_HIDDEN="-ABI_X86 -CPU_FLAGS_X86"

--- a/profiles/arch/ia64/make.defaults
+++ b/profiles/arch/ia64/make.defaults
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 ARCH="ia64"
@@ -27,7 +27,3 @@ CHOST_ia64="${CHOST}"
 # Donnie Berkholz <dberkholz@gentoo.org> (2006-08-18)
 # Defaults for video drivers
 VIDEO_CARDS="fbdev glint mga nv r128 radeon"
-
-# Diego Pettenò <flameeyes@gentoo.org> (2006-12-23)
-# Defaults for audio drivers - Took from x86 profile
-ALSA_CARDS="ali5451 als4000 atiixp atiixp-modem bt87x ca0106 cmipci emu10k1x ens1370 ens1371 es1938 es1968 fm801 hda-intel intel8x0 intel8x0m maestro3 trident usb-audio via82xx via82xx-modem ymfpci"

--- a/profiles/arch/mips/make.defaults
+++ b/profiles/arch/mips/make.defaults
@@ -1,4 +1,4 @@
-# Copyright 2008-2019 Gentoo Authors
+# Copyright 2008-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # Donnie Berkholz <dberkholz@gentoo.org> (2006-08-18)
@@ -15,7 +15,3 @@ USE="-fortran -openmp"
 LIBDIR_o32="lib"
 LIBDIR_n32="lib32"
 LIBDIR_n64="lib64"
-
-# Matt Turner <mattst88@gentoo.org> (2010-12-06)
-# Probably missing a bunch for various SGI systems.
-ALSA_CARDS="au1x00"

--- a/profiles/arch/powerpc/ppc32/make.defaults
+++ b/profiles/arch/powerpc/ppc32/make.defaults
@@ -17,10 +17,6 @@ FCFLAGS="${CFLAGS}"
 # Defaults for video drivers
 VIDEO_CARDS="fbdev glint mga nv r128 radeon"
 
-# Diego Pettenò <flameeyes@gentoo.org> (2006-12-06)
-# Defaults for PowerPC sound driver
-ALSA_CARDS="aoa aoa-fabric-layout aoa-onyx aoa-soundbus aoa-soundbus-i2s aoa-tas aoa-toonie powermac usb-audio via82xx"
-
 # Michał Górny <mgorny@gentoo.org> (2014-06-27)
 # Multilib-related setup for compatibility with future multilib.
 ABI="ppc"

--- a/profiles/arch/x86/make.defaults
+++ b/profiles/arch/x86/make.defaults
@@ -30,10 +30,6 @@ LIBDIR_x86="lib"
 # Defaults for video drivers
 VIDEO_CARDS="amdgpu fbdev intel nouveau radeon radeonsi vesa"
 
-# Andrej Kacian <ticho@gentoo.org> (2006-12-21)
-# Defaults for audio drivers
-ALSA_CARDS="ali5451 als4000 atiixp atiixp-modem bt87x ca0106 cmipci emu10k1 emu10k1x ens1370 ens1371 es1938 es1968 fm801 hda-intel intel8x0 intel8x0m maestro3 trident usb-audio via82xx via82xx-modem ymfpci"
-
 # Michał Górny <mgorny@gentoo.org> (2014-06-25)
 # Make the native ABI implicit so that MULTILIB_USEDEP can be satisfied
 # by non-multilib ebuilds when non-native ABIs are disabled.


### PR DESCRIPTION
These have not been reviewed for several years and contain many
obsolete/invalid values.

Currently only two packages utilize these flags:

media-sound/alsa-tools optionally installs several card-specific
utilities. It is unlikely that anything will break if these are
uninstalled by accident.

sys-firmware/alsa-firmware installs firmware for niche hardware
and is probably needed by very few users.

It probably makes more sense for the user to set ALSA_CARDS explicitly.