### PR TITLE
net-misc/bfgminer: Upstream patch to fix build failure with USE=-cpumining

### DIFF
--- a/net-misc/bfgminer/bfgminer-5.5.0-r2.ebuild
+++ b/net-misc/bfgminer/bfgminer-5.5.0-r2.ebuild
@@ -120,6 +120,7 @@ DEPEND="${DEPEND}
 
 PATCHES=(
 	"${FILESDIR}/${PN}-5.5.0-fno-common.patch"
+	"${FILESDIR}/${PN}-5.5.0-cpus-undefined.patch"
 )
 
 src_configure() {

--- a/net-misc/bfgminer/files/bfgminer-5.5.0-cpus-undefined.patch
+++ b/net-misc/bfgminer/files/bfgminer-5.5.0-cpus-undefined.patch
@@ -1,0 +1,21 @@
+commit 83f83d2cbc5e3044b314b914beb32dbb83a0055e
+Author: Luke Dashjr <luke-jr+git@utopios.org>
+Date:   Tue Feb 9 15:39:56 2021 +0000
+
+    Bugfix: miner: Can't free cpus in non-cpumining builds anymore
+
+diff --git a/miner.c b/miner.c
+index 075ea4655..de62f13a0 100644
+--- a/miner.c
++++ b/miner.c
+@@ -11197,8 +11197,10 @@ void _bfg_clean_up(bool restarting)
+ 			print_summary();
+ 	}
+ 
++#ifdef USE_CPUMINING
+ 	if (opt_n_threads > 0)
+ 		free(cpus);
++#endif
+ 
+ 	curl_global_cleanup();
+ 	


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/775560

No revbump because only changes anything in scenarios where the build failed previously.