### PR TITLE
sys-apps/fwupd: add REQUIRED_USE on gusb for logitech

### DIFF
--- a/sys-apps/fwupd/fwupd-1.7.0.ebuild
+++ b/sys-apps/fwupd/fwupd-1.7.0.ebuild
@@ -19,6 +19,7 @@ REQUIRED_USE="${PYTHON_REQUIRED_USE}
 	^^ ( elogind minimal systemd )
 	dell? ( uefi )
 	minimal? ( !introspection )
+	logitech? ( gusb )
 	spi? ( lzma )
 	synaptics? ( gnutls )
 	uefi? ( gnutls )


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/818790
Signed-off-by: James Beddek <telans@posteo.de>