### PR TITLE
ros-catkin.eclass: enable py3.10 (CI test)

### DIFF
--- a/eclass/ros-catkin.eclass
+++ b/eclass/ros-catkin.eclass
@@ -44,7 +44,7 @@ fi
 # ROS only really works with one global python version and the target
 # version depends on the release. Noetic targets 3.7 and 3.8.
 # py3.9 or later are ok to add there as long as dev-ros/* have their deps satisfied.
-PYTHON_COMPAT=( python3_{7,8,9} )
+PYTHON_COMPAT=( python3_{8..10} )
 
 inherit ${SCM} python-single-r1 cmake flag-o-matic
 


### PR DESCRIPTION
- CI passes for this bump
- Have ran all tests for packages depending on this eclass, all of
  them passed.

Acked-by: Alexis Ballier <aballier@gentoo.org>
Signed-off-by: Arthur Zamarin <arthurzam@gentoo.org>