### PR TITLE
media-gfx/openvdb-{7.1.0-r2,8.0.1-r1}: find numpy

### DIFF
--- a/media-gfx/openvdb/files/openvdb-8.0.1-add-consistency-for-NumPy-find_package-call.patch
+++ b/media-gfx/openvdb/files/openvdb-8.0.1-add-consistency-for-NumPy-find_package-call.patch
@@ -1,0 +1,21 @@
+From: Bernd Waibel <waebbl-gentoo@posteo.net>
+Date: Thu, 28 Oct 2021 11:34:16 +0200
+Subject: [PATCH] add consistency for NumPy find_package call
+
+Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>
+
+diff --git a/openvdb/openvdb/python/CMakeLists.txt b/openvdb/openvdb/python/CMakeLists.txt
+index b473beb..b468d4f 100644
+--- a/openvdb/openvdb/python/CMakeLists.txt
++++ b/openvdb/openvdb/python/CMakeLists.txt
+@@ -94,7 +94,7 @@ else()
+   OPENVDB_CHECK_PYTHON_VERSION(${Python_VERSION} ${Python_INCLUDE_DIRS})
+ 
+   if(USE_NUMPY)
+-    find_package(Python QUIET COMPONENTS NumPy)
++    find_package(Python QUIET COMPONENTS ${OPENVDB_PYTHON_REQUIRED_COMPONENTS} NumPy)
+     if(NOT TARGET Python::NumPy)
+         message(FATAL_ERROR "Could NOT find NumPy (Required is at least version "
+           "\"${MINIMUM_NUMPY_VERSION}\")"
+-- 
+2.33.1

--- a/media-gfx/openvdb/openvdb-7.1.0-r2.ebuild
+++ b/media-gfx/openvdb/openvdb-7.1.0-r2.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{7,8,9} )
 
-inherit cmake flag-o-matic python-single-r1
+inherit cmake python-single-r1
 
 DESCRIPTION="Library for the efficient manipulation of volumetric data"
 HOMEPAGE="https://www.openvdb.org"
@@ -91,9 +91,9 @@ src_configure() {
 		-DOPENVDB_ABI_VERSION_NUMBER="${version}"
 		-DOPENVDB_BUILD_DOCS=$(usex doc)
 		-DOPENVDB_BUILD_UNITTESTS=$(usex test)
-		-DOPENVDB_BUILD_VDB_LOD=$(usex !utils)
-		-DOPENVDB_BUILD_VDB_RENDER=$(usex !utils)
-		-DOPENVDB_BUILD_VDB_VIEW=$(usex !utils)
+		-DOPENVDB_BUILD_VDB_LOD=$(usex utils)
+		-DOPENVDB_BUILD_VDB_RENDER=$(usex utils)
+		-DOPENVDB_BUILD_VDB_VIEW=$(usex utils)
 		-DOPENVDB_CORE_SHARED=ON
 		-DOPENVDB_CORE_STATIC=$(usex static-libs)
 		-DOPENVDB_ENABLE_RPATH=OFF
@@ -109,6 +109,8 @@ src_configure() {
 			-DUSE_NUMPY=$(usex numpy)
 			-DPYOPENVDB_INSTALL_DIRECTORY="$(python_get_sitedir)"
 			-DPython_EXECUTABLE="${PYTHON}"
+			-DPython_INCLUDE_DIR="$(python_get_includedir)"
+			-DPython_LIBRARY="$(python_get_library_path)"
 		)
 	fi
 

--- a/media-gfx/openvdb/openvdb-8.0.1-r1.ebuild
+++ b/media-gfx/openvdb/openvdb-8.0.1-r1.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{7,8,9} )
 
-inherit cmake flag-o-matic python-single-r1
+inherit cmake python-single-r1
 
 DESCRIPTION="Library for the efficient manipulation of volumetric data"
 HOMEPAGE="https://www.openvdb.org"
@@ -66,6 +66,7 @@ BDEPEND="
 PATCHES=(
 	"${FILESDIR}/${PN}-7.1.0-0001-Fix-multilib-header-source.patch"
 	"${FILESDIR}/${P}-glfw-libdir.patch"
+	"${FILESDIR}/${P}-add-consistency-for-NumPy-find_package-call.patch"
 )
 
 pkg_setup() {
@@ -92,9 +93,9 @@ src_configure() {
 		-DOPENVDB_ABI_VERSION_NUMBER="${version}"
 		-DOPENVDB_BUILD_DOCS=$(usex doc)
 		-DOPENVDB_BUILD_UNITTESTS=$(usex test)
-		-DOPENVDB_BUILD_VDB_LOD=$(usex !utils)
-		-DOPENVDB_BUILD_VDB_RENDER=$(usex !utils)
-		-DOPENVDB_BUILD_VDB_VIEW=$(usex !utils)
+		-DOPENVDB_BUILD_VDB_LOD=$(usex utils)
+		-DOPENVDB_BUILD_VDB_RENDER=$(usex utils)
+		-DOPENVDB_BUILD_VDB_VIEW=$(usex utils)
 		-DOPENVDB_CORE_SHARED=ON
 		-DOPENVDB_CORE_STATIC=$(usex static-libs)
 		-DOPENVDB_ENABLE_RPATH=OFF
@@ -108,8 +109,10 @@ src_configure() {
 		mycmakeargs+=(
 			-DOPENVDB_BUILD_PYTHON_MODULE=ON
 			-DUSE_NUMPY=$(usex numpy)
+			-DOPENVDB_BUILD_PYTHON_UNITTESTS=$(usex test)
 			-DPYOPENVDB_INSTALL_DIRECTORY="$(python_get_sitedir)"
 			-DPython_EXECUTABLE="${PYTHON}"
+			-DPython_INCLUDE_DIR="$(python_get_includedir)"
 		)
 	fi
 


### PR DESCRIPTION
media-gfx/openvdb-8.0.1-r1:
- adds consistency in the find_package call for NumPy by adding the
	same components like in the find_package call for Python
- additionally pass -DPython_INCLUDE_DIR to cmake
- add an option for python unittests when USE=test is set
- remove flag-o-matic inherit, which isn't needed according to pkgcheck
- change the negation on the utils USE flag to build the utilities if
	the USE flag is set.

Bug: https://bugs.gentoo.org/788886

media-gfx/openvdb-7.1.0-r2:
- additionally pass -DPython_INCLUDE_DIR and -DPython_LIBRARY to help
	find numpy
- remove flag-o-matic inherit, which isn't needed according to pkgcheck
- change the negation of the utils USE flag use for building the utilities
	if the USE flag is set

Closes: https://bugs.gentoo.org/788886
Package-Manager: Portage-3.0.28, Repoman-3.0.3
Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>


@redchillipadi:
- If the option for python unittests in v8 was intentionally left out, please tell me, and I'm gonna remove it. I didn't checked whether the tests actually work, just saw the cmake variable in the cmakefile.
- Also, if I misunterstand the logic for the utility binaries and they work as expected with the negated setting, tell me and I'm gonna reset them.