### PR TITLE
net-misc/csync: fix libssh-version detection

### DIFF
--- a/net-misc/csync/csync-0.50.0-r2.ebuild
+++ b/net-misc/csync/csync-0.50.0-r2.ebuild
@@ -1,0 +1,49 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit cmake
+
+DESCRIPTION="lightweight file synchronizer utility"
+HOMEPAGE="https://www.csync.org/"
+SRC_URI="https://open.cryptomilk.org/attachments/download/27/${P}.tar.xz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="doc iconv samba +sftp test"
+RESTRICT="!test? ( test )"
+
+RDEPEND=">=dev-db/sqlite-3.4:3
+	net-libs/neon[ssl]
+	iconv? ( virtual/libiconv )
+	samba? ( >=net-fs/samba-3.5 )
+	sftp? ( >=net-libs/libssh-0.5 )
+	!net-misc/ocsync"
+DEPEND="${RDEPEND}
+	app-text/asciidoc
+	doc? ( app-doc/doxygen )
+	test? ( dev-util/cmocka )"
+
+PATCHES=( "${FILESDIR}"/${P}-gcc_5_and_8.patch
+	  "${FILESDIR}"/${P}-libssh-version.patch )
+src_prepare() {
+	cmake_src_prepare
+
+	# proper docdir
+	sed -e "s:/doc/${PN}:/doc/${PF}:" \
+		-i doc/CMakeLists.txt || die
+}
+
+src_configure() {
+	local mycmakeargs=(
+		-DSYSCONF_INSTALL_DIR="${EPREFIX}"/etc
+		-DWITH_ICONV="$(usex iconv)"
+		-DUNIT_TESTING="$(usex test)"
+		$(cmake_use_find_package doc Doxygen)
+		$(cmake_use_find_package samba SMBClient)
+		$(cmake_use_find_package sftp LibSSH)
+	)
+	cmake_src_configure
+}

--- a/net-misc/csync/files/csync-0.50.0-libssh-version.patch
+++ b/net-misc/csync/files/csync-0.50.0-libssh-version.patch
@@ -1,0 +1,41 @@
+Index: csync-0.50.0/cmake/Modules/FindLibSSH.cmake
+===================================================================
+--- csync-0.50.0.orig/cmake/Modules/FindLibSSH.cmake
++++ csync-0.50.0/cmake/Modules/FindLibSSH.cmake
+@@ -20,7 +20,7 @@ else (LIBSSH_LIBRARIES AND LIBSSH_INCLUD
+ 
+   find_path(LIBSSH_INCLUDE_DIR
+     NAMES
+-      libssh/libssh.h
++      libssh/libssh_version.h
+     PATHS
+       /usr/include
+       /usr/local/include
+@@ -58,15 +58,15 @@ else (LIBSSH_LIBRARIES AND LIBSSH_INCLUD
+     )
+ 
+     if (LibSSH_FIND_VERSION)
+-      file(STRINGS ${LIBSSH_INCLUDE_DIR}/libssh/libssh.h LIBSSH_VERSION_MAJOR
++      file(STRINGS ${LIBSSH_INCLUDE_DIR}/libssh/libssh_version.h LIBSSH_VERSION_MAJOR
+         REGEX "#define[ ]+LIBSSH_VERSION_MAJOR[ ]+[0-9]+")
+       # Older versions of libssh like libssh-0.2 have LIBSSH_VERSION but not LIBSSH_VERSION_MAJOR
+       if (LIBSSH_VERSION_MAJOR)
+         string(REGEX MATCH "[0-9]+" LIBSSH_VERSION_MAJOR ${LIBSSH_VERSION_MAJOR})
+-	file(STRINGS ${LIBSSH_INCLUDE_DIR}/libssh/libssh.h LIBSSH_VERSION_MINOR
++	file(STRINGS ${LIBSSH_INCLUDE_DIR}/libssh/libssh_version.h LIBSSH_VERSION_MINOR
+           REGEX "#define[ ]+LIBSSH_VERSION_MINOR[ ]+[0-9]+")
+ 	string(REGEX MATCH "[0-9]+" LIBSSH_VERSION_MINOR ${LIBSSH_VERSION_MINOR})
+-	file(STRINGS ${LIBSSH_INCLUDE_DIR}/libssh/libssh.h LIBSSH_VERSION_PATCH
++	file(STRINGS ${LIBSSH_INCLUDE_DIR}/libssh/libssh_version.h LIBSSH_VERSION_PATCH
+           REGEX "#define[ ]+LIBSSH_VERSION_MICRO[ ]+[0-9]+")
+ 	string(REGEX MATCH "[0-9]+" LIBSSH_VERSION_PATCH ${LIBSSH_VERSION_PATCH})
+ 
+@@ -75,7 +75,7 @@ else (LIBSSH_LIBRARIES AND LIBSSH_INCLUD
+ 	include(FindPackageVersionCheck)
+ 	find_package_version_check(LibSSH DEFAULT_MSG)
+       else (LIBSSH_VERSION_MAJOR)
+-        message(STATUS "LIBSSH_VERSION_MAJOR not found in ${LIBSSH_INCLUDE_DIR}/libssh/libssh.h, assuming libssh is too old")
++        message(STATUS "LIBSSH_VERSION_MAJOR not found in ${LIBSSH_INCLUDE_DIR}/libssh/libssh_version.h, assuming libssh is too old")
+         set(LIBSSH_FOUND FALSE)
+       endif (LIBSSH_VERSION_MAJOR)
+     endif (LibSSH_FIND_VERSION)


### PR DESCRIPTION
Signed-off-by: Ervin Peters coder@ervnet.de
Bug: https://bugs.gentoo.org/819945
Closes: https://bugs.gentoo.org/819945
Package-Manager: Portage-3.0.20, Repoman-3.0.3