### PR TITLE
dev-libs/liborcus: fix test failures with USE=-tools

### DIFF
--- a/dev-libs/liborcus/files/liborcus-0.16.1-test-fix.patch
+++ b/dev-libs/liborcus/files/liborcus-0.16.1-test-fix.patch
@@ -1,0 +1,51 @@
+# https://bugs.gentoo.org/713586
+
+[PATCH] Build orcus-env-dump unconditionally
+
+The rule for `orcus-env-dump.o` is guarded by `if WITH_TOOLS` however,
+the rule for the executable `orcus-env-dump` is not. This leads to
+linking errors when running the test suite without tools.
+
+Move the rule for `orcus-env-dump.o` out of the if WITH_TOOLS block to
+always build it.
+---
+ src/Makefile.am | 20 ++++++++++----------
+ 1 file changed, 10 insertions(+), 10 deletions(-)
+
+diff --git a/src/Makefile.am b/src/Makefile.am
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -25,6 +25,16 @@ orcus_test_xml_LDADD = \
+ 
+ orcus_test_xml_CPPFLAGS = -I$(top_builddir)/lib/liborcus/liborcus.la $(AM_CPPFLAGS) -DSRCDIR=\""$(top_srcdir)"\"
+ 
++#----------------------------------------------------------------------------
++
++# orcus-env-dump
++
++orcus_env_dump_SOURCES = orcus_env_dump.cpp
++orcus_env_dump_LDADD = \
++	parser/liborcus-parser-@ORCUS_API_VERSION@.la \
++	liborcus/liborcus-@ORCUS_API_VERSION@.la
++orcus_env_dump_CPPFLAGS = -I$(top_builddir)/lib/liborcus/liborcus.la $(AM_CPPFLAGS)
++
+ 
+ TESTS = \
+ 	orcus-test-xml \
+@@ -136,16 +146,6 @@ orcus_detect_CPPFLAGS = -I$(top_builddir)/lib/liborcus/liborcus.la $(AM_CPPFLAGS
+ 
+ #----------------------------------------------------------------------------
+ 
+-# orcus-env-dump
+-
+-orcus_env_dump_SOURCES = orcus_env_dump.cpp
+-orcus_env_dump_LDADD = \
+-	parser/liborcus-parser-@ORCUS_API_VERSION@.la \
+-	liborcus/liborcus-@ORCUS_API_VERSION@.la
+-orcus_env_dump_CPPFLAGS = -I$(top_builddir)/lib/liborcus/liborcus.la $(AM_CPPFLAGS)
+-
+-#----------------------------------------------------------------------------
+-
+ if BUILD_SPREADSHEET_MODEL
+ 
+ orcus_json_LDADD += \

--- a/dev-libs/liborcus/liborcus-0.16.1.ebuild
+++ b/dev-libs/liborcus/liborcus-0.16.1.ebuild
@@ -4,7 +4,8 @@
 EAPI=7
 
 PYTHON_COMPAT=( python3_{7,8,9} )
-inherit python-single-r1
+
+inherit autotools python-single-r1
 
 DESCRIPTION="Standalone file import filter library for spreadsheet documents"
 HOMEPAGE="https://gitlab.com/orcus/orcus/blob/master/README.md"
@@ -21,9 +22,10 @@ fi
 
 LICENSE="MIT"
 SLOT="0/0.16" # based on SONAME of liborcus.so
-IUSE="python +spreadsheet-model tools"
+IUSE="python +spreadsheet-model test tools"
 
 REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
+RESTRICT="!test? ( test )"
 
 RDEPEND="
 	dev-libs/boost:=[zlib(+)]
@@ -42,8 +44,11 @@ pkg_setup() {
 }
 
 src_prepare() {
+	# bug 713586
+	use test && eapply "${FILESDIR}/${PN}-0.16.1-test-fix.patch"
+
 	default
-	[[ ${PV} == *9999 ]] && eautoreconf
+	eautoreconf
 }
 
 src_configure() {

--- a/dev-libs/liborcus/liborcus-9999.ebuild
+++ b/dev-libs/liborcus/liborcus-9999.ebuild
@@ -4,7 +4,8 @@
 EAPI=7
 
 PYTHON_COMPAT=( python3_{7,8,9} )
-inherit python-single-r1
+
+inherit autotools python-single-r1
 
 DESCRIPTION="Standalone file import filter library for spreadsheet documents"
 HOMEPAGE="https://gitlab.com/orcus/orcus/blob/master/README.md"
@@ -16,14 +17,15 @@ if [[ ${PV} == *9999* ]]; then
 else
 	MDDS_SLOT="1/1.5"
 	SRC_URI="https://kohei.us/files/orcus/src/${P}.tar.xz"
-	KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~x86"
+	KEYWORDS="amd64 ~arm arm64 ~ppc ~ppc64 x86"
 fi
 
 LICENSE="MIT"
 SLOT="0/0.16" # based on SONAME of liborcus.so
-IUSE="python +spreadsheet-model tools"
+IUSE="python +spreadsheet-model test tools"
 
 REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
+RESTRICT="!test? ( test )"
 
 RDEPEND="
 	dev-libs/boost:=[zlib(+)]
@@ -35,13 +37,18 @@ DEPEND="${RDEPEND}
 	dev-util/mdds:${MDDS_SLOT}
 "
 
+PATCHES=( "${FILESDIR}/${PN}-0.15.4-gcc11.patch" ) # bug 764035
+
 pkg_setup() {
 	use python && python-single-r1_pkg_setup
 }
 
 src_prepare() {
+	# bug 713586
+	use test && eapply "${FILESDIR}/${PN}-0.16.1-test-fix.patch"
+
 	default
-	[[ ${PV} == *9999 ]] && eautoreconf
+	eautoreconf
 }
 
 src_configure() {

--- a/dev-libs/liborcus/liborcus-9999.ebuild
+++ b/dev-libs/liborcus/liborcus-9999.ebuild
@@ -17,7 +17,7 @@ if [[ ${PV} == *9999* ]]; then
 else
 	MDDS_SLOT="1/1.5"
 	SRC_URI="https://kohei.us/files/orcus/src/${P}.tar.xz"
-	KEYWORDS="amd64 ~arm arm64 ~ppc ~ppc64 x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~x86"
 fi
 
 LICENSE="MIT"


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/713586
Signed-off-by: James Beddek <telans@posteo.de>