### PR TITLE
sys-apps/fwupd: fix configure with USE=test,-gnutls

### DIFF
--- a/sys-apps/fwupd/files/fwupd-1.7.0-fix-test-configure.patch
+++ b/sys-apps/fwupd/files/fwupd-1.7.0-fix-test-configure.patch
@@ -1,0 +1,20 @@
+# https://bugs.gentoo.org/791760
+# https://github.com/fwupd/fwupd/pull/3921
+
+diff --git a/plugins/synaptics-rmi/meson.build b/plugins/synaptics-rmi/meson.build
+index acbb6b92..10ac3047 100644
+--- a/plugins/synaptics-rmi/meson.build
++++ b/plugins/synaptics-rmi/meson.build
+@@ -38,7 +38,6 @@ shared_module('fu_plugin_synaptics_rmi',
+     fwupdplugin,
+   ],
+ )
+-endif
+ 
+ if get_option('tests')
+   e = executable(
+@@ -67,3 +66,4 @@ if get_option('tests')
+   )
+   test('synaptics-rmi-self-test', e)
+ endif
++endif

--- a/sys-apps/fwupd/fwupd-1.7.0.ebuild
+++ b/sys-apps/fwupd/fwupd-1.7.0.ebuild
@@ -90,6 +90,7 @@ DEPEND="
 PATCHES=(
 	"${FILESDIR}"/${PN}-1.5.7-logind_plugin.patch
 	"${FILESDIR}"/${P}-elanfp-requires-gusb.patch
+	"${FILESDIR}"/${P}-fix-test-configure.patch # bug 791760
 )
 
 pkg_setup() {


### PR DESCRIPTION
See: https://github.com/fwupd/fwupd/pull/3921

Closes: https://bugs.gentoo.org/791760
Signed-off-by: James Beddek <telans@posteo.de>