### PR TITLE
app-backup/pdumpfs: bump to EAPI 8

### DIFF
--- a/app-backup/pdumpfs/files/pdumpfs-in-r3.patch
+++ b/app-backup/pdumpfs/files/pdumpfs-in-r3.patch
@@ -1,0 +1,40 @@
+patch by proxy maintainer, P. Healy, April 2015
+# Bug 509960
+--- a/pdumpfs.in_orig	2004-12-21 02:43:12.000000000 +0000
++++ b/pdumpfs.in	2015-04-01 10:58:22.671131947 +0100
+@@ -48,7 +48,7 @@
+ #
+ 
+ require 'find'
+-require 'ftools'
++require 'fileutils'
+ require 'getoptlong'
+ require 'date'
+ 
+@@ -868,7 +868,7 @@
+       today  = File.join(dest, datedir(start_time), base)
+ 
+       File.umask(0077)
+-      File.mkpath(today) unless @dry_run
++      FileUtils.mkpath(today) unless @dry_run
+       if latest
+         update_snapshot(src, latest, today)
+       else
+@@ -1018,7 +1018,7 @@
+ 
+       case type
+       when "directory"
+-        File.mkpath(today)
++        FileUtils.mkpath(today)
+       when "unchanged"
+         File.force_link(latest, today)
+       when "updated"
+@@ -1089,7 +1089,7 @@
+ 
+           case type
+           when "directory"
+-            File.mkpath(t)
++            FileUtils.mkpath(t)
+           when "new_file"
+             copy(s, t)
+           when "symlink"

--- a/app-backup/pdumpfs/files/pdumpfs-test-r3.patch
+++ b/app-backup/pdumpfs/files/pdumpfs-test-r3.patch
@@ -1,0 +1,12 @@
+patch by proxy maintainer, P. Healy, April 2015
+# Bug 509960
+--- a/tests/pdumpfs-test_orig	2004-08-10 07:54:28.000000000 +0100
++++ b/tests/pdumpfs-test	2015-04-01 11:24:35.948633870 +0100
+@@ -17,6 +17,7 @@
+ 
+ ../pdumpfs src dest > tmp.log || exit 1
+ diff -r src dest/$today/src || exit 1
++mkdir -p dest/$yesterday && rmdir dest/$yesterday
+ mv dest/$today dest/$yesterday
+ 
+ echo update > src/foo

--- a/app-backup/pdumpfs/pdumpfs-1.3-r3.ebuild
+++ b/app-backup/pdumpfs/pdumpfs-1.3-r3.ebuild
@@ -1,0 +1,44 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DESCRIPTION="A daily backup system similar to Plan9's dumpfs"
+HOMEPAGE="http://0xcc.net/pdumpfs/"
+SRC_URI="http://0xcc.net/pdumpfs/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~sparc ~x86"
+IUSE="l10n_ja"
+
+DEPEND=">=dev-lang/ruby-2.7.4"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-in-r3.patch"
+	"${FILESDIR}/${PN}-test-r3.patch"
+)
+
+src_compile() {
+	emake pdumpfs
+}
+
+src_test() {
+	# RUBYOPT=-rauto_gem without rubygems installed will cause ruby to fail, bug #158455 and #163473.
+	export RUBYOPT="${GENTOO_RUBYOPT}"
+	emake check
+}
+
+src_install() {
+	dobin pdumpfs
+
+	doman man/man8/pdumpfs.8
+	dodoc -r doc/*
+
+	if use l10n_ja; then
+		insinto /usr/share/man/ja/man8
+		doins man/ja/man8/pdumpfs.8
+	fi
+
+	dodoc ChangeLog README
+}


### PR DESCRIPTION
Replace epatch, dohtml
Bump the minimum ruby version to >=ruby-2.7.4

Bug: https://bugs.gentoo.org/819687
Signed-off-by: Paul Healy <lmiphay@gmail.com>