### PR TITLE
dev-util/cppcheck: add a missing dependecy from qt5

### DIFF
--- a/dev-util/cppcheck/cppcheck-2.4.1.ebuild
+++ b/dev-util/cppcheck/cppcheck-2.4.1.ebuild
@@ -22,6 +22,7 @@ RDEPEND="
 		dev-qt/qtgui:5
 		dev-qt/qthelp
 		dev-qt/qtprintsupport:5
+		dev-qt/linguist-tools:5
 	)
 "
 DEPEND="${RDEPEND}


### PR DESCRIPTION
Fixes the following build issue I had:

```
>>> Emerging (4 of 4) dev-util/cppcheck-2.4.1::gentoo
 * cppcheck-2.4.1.tar.gz BLAKE2B SHA512 size ;-) ...                                                                                                                                                                                                                                                                                                                                 [ ok ]
>>> Unpacking source...
>>> Unpacking cppcheck-2.4.1.tar.gz to /var/tmp/portage/dev-util/cppcheck-2.4.1/work
>>> Source unpacked in /var/tmp/portage/dev-util/cppcheck-2.4.1/work
>>> Preparing source in /var/tmp/portage/dev-util/cppcheck-2.4.1/work/cppcheck-2.4.1 ...
 * Source directory (CMAKE_USE_DIR): "/var/tmp/portage/dev-util/cppcheck-2.4.1/work/cppcheck-2.4.1"
 * Build directory  (BUILD_DIR):     "/var/tmp/portage/dev-util/cppcheck-2.4.1/work/cppcheck-2.4.1_build"
 * Applying cppcheck-2.4.1-limits.patch ...                                                                                                                                                                                                                                                                                                                                          [ ok ]
>>> Source prepared.
>>> Configuring source in /var/tmp/portage/dev-util/cppcheck-2.4.1/work/cppcheck-2.4.1 ...
 * Source directory (CMAKE_USE_DIR): "/var/tmp/portage/dev-util/cppcheck-2.4.1/work/cppcheck-2.4.1"
 * Build directory  (BUILD_DIR):     "/var/tmp/portage/dev-util/cppcheck-2.4.1/work/cppcheck-2.4.1_build"
cmake -C /var/tmp/portage/dev-util/cppcheck-2.4.1/work/cppcheck-2.4.1_build/gentoo_common_config.cmake -G Ninja -DCMAKE_INSTALL_PREFIX=/usr -DHAVE_RULES=yes -DBUILD_GUI=yes -DUSE_Z3=yes -DFILESDIR=/usr/share/cppcheck/ -DENABLE_OSS_FUZZ=OFF -DCMAKE_BUILD_TYPE=Gentoo -DCMAKE_TOOLCHAIN_FILE=/var/tmp/portage/dev-util/cppcheck-2.4.1/work/cppcheck-2.4.1_build/gentoo_toolchain.cmake  /var/tmp/portage/dev-util/cppcheck-2.4.1/work/cppcheck-2.4.1
loading initial cache file /var/tmp/portage/dev-util/cppcheck-2.4.1/work/cppcheck-2.4.1_build/gentoo_common_config.cmake
-- The C compiler identification is GNU 10.3.0
-- The CXX compiler identification is GNU 10.3.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/x86_64-pc-linux-gnu-gcc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/x86_64-pc-linux-gnu-g++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
CMake Error at /usr/lib64/cmake/Qt5/Qt5Config.cmake:28 (find_package):
  Could not find a package configuration file provided by "Qt5LinguistTools"
  with any of the following names:

    Qt5LinguistToolsConfig.cmake
    qt5linguisttools-config.cmake

  Add the installation prefix of "Qt5LinguistTools" to CMAKE_PREFIX_PATH or
  set "Qt5LinguistTools_DIR" to a directory containing one of the above
  files.  If "Qt5LinguistTools" provides a separate development package or
  SDK, be sure it has been installed.
Call Stack (most recent call first):
  cmake/findDependencies.cmake:3 (find_package)
  CMakeLists.txt:10 (include)


-- Configuring incomplete, errors occurred!
See also "/var/tmp/portage/dev-util/cppcheck-2.4.1/work/cppcheck-2.4.1_build/CMakeFiles/CMakeOutput.log".
 * ERROR: dev-util/cppcheck-2.4.1::gentoo failed (configure phase):
 *   cmake failed
 * 
 * Call stack:
 *     ebuild.sh, line  127:  Called src_configure
 *   environment, line 3777:  Called cmake_src_configure
 *   environment, line 1559:  Called die
 * The specific snippet of code:
 *       "${CMAKE_BINARY}" "${cmakeargs[@]}" "${CMAKE_USE_DIR}" || die "cmake failed";
 * 
 * If you need support, post the output of `emerge --info '=dev-util/cppcheck-2.4.1::gentoo'`,
 * the complete build log and the output of `emerge -pqv '=dev-util/cppcheck-2.4.1::gentoo'`.
 * The complete build log is located at '/var/tmp/portage/dev-util/cppcheck-2.4.1/temp/build.log'.
 * The ebuild environment file is located at '/var/tmp/portage/dev-util/cppcheck-2.4.1/temp/environment'.
 * Working directory: '/var/tmp/portage/dev-util/cppcheck-2.4.1/work/cppcheck-2.4.1_build'
 * S: '/var/tmp/portage/dev-util/cppcheck-2.4.1/work/cppcheck-2.4.1'

>>> Failed to emerge dev-util/cppcheck-2.4.1, Log file:

>>>  '/var/tmp/portage/dev-util/cppcheck-2.4.1/temp/build.log'

 * Messages for package dev-util/cppcheck-2.4.1:

 * ERROR: dev-util/cppcheck-2.4.1::gentoo failed (configure phase):
 *   cmake failed
 * 
 * Call stack:
 *     ebuild.sh, line  127:  Called src_configure
 *   environment, line 3777:  Called cmake_src_configure
 *   environment, line 1559:  Called die
 * The specific snippet of code:
 *       "${CMAKE_BINARY}" "${cmakeargs[@]}" "${CMAKE_USE_DIR}" || die "cmake failed";
 * 
 * If you need support, post the output of `emerge --info '=dev-util/cppcheck-2.4.1::gentoo'`,
 * the complete build log and the output of `emerge -pqv '=dev-util/cppcheck-2.4.1::gentoo'`.
 * The complete build log is located at '/var/tmp/portage/dev-util/cppcheck-2.4.1/temp/build.log'.
 * The ebuild environment file is located at '/var/tmp/portage/dev-util/cppcheck-2.4.1/temp/environment'.
 * Working directory: '/var/tmp/portage/dev-util/cppcheck-2.4.1/work/cppcheck-2.4.1_build'
 * S: '/var/tmp/portage/dev-util/cppcheck-2.4.1/work/cppcheck-2.4.1'

 * GNU info directory index is up-to-date.

```