### PR TITLE
dev-python/cherrypy: Add the new CherryPy website to the metadata

### DIFF
--- a/dev-python/cherrypy/cherrypy-18.6.1.ebuild
+++ b/dev-python/cherrypy/cherrypy-18.6.1.ebuild
@@ -9,7 +9,7 @@ inherit distutils-r1
 MY_P="CherryPy-${PV}"
 
 DESCRIPTION="CherryPy is a pythonic, object-oriented HTTP framework"
-HOMEPAGE="https://pypi.org/project/CherryPy/"
+HOMEPAGE="https://cherrypy.dev https://pypi.org/project/CherryPy/"
 SRC_URI="mirror://pypi/C/CherryPy/${MY_P}.tar.gz"
 S="${WORKDIR}/${MY_P}"
 


### PR DESCRIPTION
This patch resurrects a link to the official CherryPy website originally
deleted by @mgorny in https://github.com/gentoo/gentoo/commit/c8b3d98d.

It is now https://cherrypy.dev.
Ref: https://twitter.com/cherrypy/status/1435583865024823297

Signed-Off-By: Sviatoslav Sydorenko <webknjaz@redhat.com>