### PR TITLE
net-misc/mosh: add patch to enable the compilation with clang

### DIFF
--- a/net-misc/mosh/files/mosh-1.3.2-bind-misinterpret.patch
+++ b/net-misc/mosh/files/mosh-1.3.2-bind-misinterpret.patch
@@ -1,0 +1,11 @@
+--- a/src/network/network.cc
++++ b/src/network/network.cc
+@@ -335,7 +335,7 @@ bool Connection::try_bind( const char *addr, int port_low, int port_high )
+       }
+     }
+ 
+-    if ( bind( sock(), &local_addr.sa, local_addr_len ) == 0 ) {
++    if ( ::bind( sock(), &local_addr.sa, local_addr_len ) == 0 ) {
+       set_MTU( local_addr.sa.sa_family );
+       return true;
+     } else if ( i == search_high ) { /* last port to search */

--- a/net-misc/mosh/mosh-1.3.2-r2.ebuild
+++ b/net-misc/mosh/mosh-1.3.2-r2.ebuild
@@ -37,6 +37,7 @@ DEPEND="${RDEPEND}
 # [0] - avoid sandbox-violation calling git describe in Makefile.
 PATCHES=(
 	"${FILESDIR}"/${PN}-1.2.5-git-version.patch
+	"${FILESDIR}"/${PN}-1.3.2-bind-misinterpret.patch
 )
 
 src_prepare() {


### PR DESCRIPTION
Fix is introduced to mosh official at:
https://github.com/mobile-shell/mosh/commit/e5f8a826ef9ff5da4cfce3bb8151f9526ec19db0

Signed-off-by: Yang Yang <geraint0923@gmail.com>