### PR TITLE
allow systemd-networkd to set hostname without polkit

### DIFF
--- a/acct-group/systemd-hostname/metadata.xml
+++ b/acct-group/systemd-hostname/metadata.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="project">
+		<email>systemd@gentoo.org</email>
+	</maintainer>
+</pkgmetadata>

--- a/acct-group/systemd-hostname/systemd-hostname-0.ebuild
+++ b/acct-group/systemd-hostname/systemd-hostname-0.ebuild
@@ -1,0 +1,8 @@
+# Copyright 2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit acct-group
+
+ACCT_GROUP_ID=66

--- a/profiles/arch/amd64/package.use.mask
+++ b/profiles/arch/amd64/package.use.mask
@@ -17,6 +17,10 @@
 
 #--- END OF EXAMPLES ---
 
+# Georgy Yakovlev <gyakovlev@gentoo.org> (2021-11-01)
+# requires sys-apps/dbus-broker, which keyworded here.
+sys-apps/systemd -hostnamed-fallback
+
 # James Le Cuirot <chewi@gentoo.org> (2021-10-22)
 # The JIT feature only works on amd64 and x86.
 app-emulation/fs-uae -jit

--- a/profiles/arch/amd64/package.use.stable.mask
+++ b/profiles/arch/amd64/package.use.stable.mask
@@ -17,6 +17,10 @@
 
 #--- END OF EXAMPLES ---
 
+# Georgy Yakovlev <gyakovlev@gentoo.org> (2021-11-01)
+# requires sys-apps/dbus-broker, which is unstable here.
+sys-apps/systemd hostnamed-fallback
+
 # Joonas Niilola <juippis@gentoo.org> (2021-08-13)
 # dev-libs/efl is stabilized on amd64.
 app-crypt/pinentry -efl

--- a/profiles/arch/base/package.use.mask
+++ b/profiles/arch/base/package.use.mask
@@ -1,6 +1,10 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Georgy Yakovlev <gyakovlev@gentoo.org> (2021-11-01)
+# requires sys-apps/dbus-broker, which is not widely keyworded yet.
+sys-apps/systemd hostnamed-fallback
+
 # James Le Cuirot <chewi@gentoo.org> (2021-10-22)
 # Only available on some architectures.
 app-emulation/fs-uae jit

--- a/profiles/arch/powerpc/ppc64/package.use.mask
+++ b/profiles/arch/powerpc/ppc64/package.use.mask
@@ -1,6 +1,10 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Georgy Yakovlev <gyakovlev@gentoo.org> (2021-11-01)
+# requires sys-apps/dbus-broker, which is keyworded here.
+sys-apps/systemd -hostnamed-fallback
+
 # Sam James <sam@gentoo.org> (2021-10-17)
 # Go doesn't support pie on ppc64, bug #818529
 net-dns/dnscrypt-proxy pie

--- a/profiles/arch/powerpc/ppc64/package.use.stable.mask
+++ b/profiles/arch/powerpc/ppc64/package.use.stable.mask
@@ -17,6 +17,10 @@
 
 #--- END OF EXAMPLES ---
 
+# Georgy Yakovlev <gyakovlev@gentoo.org> (2021-11-01)
+# requires sys-apps/dbus-broker, which is unstable here.
+sys-apps/systemd hostnamed-fallback
+
 # Georgy Yakovlev <gyakovlev@gentoo.org (2021-06-25)
 # ceph is not going to be stable on ppc64
 # https://bugs.gentoo.org/798744

--- a/sys-apps/systemd/files/00-hostnamed-network-user.conf
+++ b/sys-apps/systemd/files/00-hostnamed-network-user.conf
@@ -1,0 +1,6 @@
+[Service]
+# By running with these options instead of root, networkd is allowed to request
+# a hostname change via DBUS when policykit is not present
+User=systemd-network
+Group=systemd-hostname
+AmbientCapabilities=CAP_SYS_ADMIN

--- a/sys-apps/systemd/files/org.freedesktop.hostname1_no_polkit.conf
+++ b/sys-apps/systemd/files/org.freedesktop.hostname1_no_polkit.conf
@@ -1,0 +1,11 @@
+<?xml version="1.0"?> <!--*-nxml-*-->
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+        "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+
+<busconfig>
+        <policy group="systemd-hostname">
+                <allow own="org.freedesktop.hostname1"/>
+                <allow send_destination="org.freedesktop.hostname1"/>
+                <allow receive_sender="org.freedesktop.hostname1"/>
+        </policy>
+</busconfig>

--- a/sys-apps/systemd/metadata.xml
+++ b/sys-apps/systemd/metadata.xml
@@ -20,6 +20,7 @@
 		<flag name="fido2">Enable FIDO2 support</flag>
 		<flag name="gcrypt">Enable sealing of journal files using gcrypt</flag>
 		<flag name="homed">Enable portable home directories</flag>
+		<flag name="hostnamed-fallback">Enable setting hostname with networkd/hostnamed without polkit (requires running <pkg>sys-apps/dbus-broker</pkg>)</flag>
 		<flag name="http">Enable embedded HTTP server in journald</flag>
 		<flag name="hwdb">Enable support for the hardware database</flag>
 		<flag name="importd">Enable import daemon</flag>

--- a/sys-apps/systemd/systemd-9999.ebuild
+++ b/sys-apps/systemd/systemd-9999.ebuild
@@ -30,11 +30,12 @@ HOMEPAGE="https://www.freedesktop.org/wiki/Software/systemd"
 
 LICENSE="GPL-2 LGPL-2.1 MIT public-domain"
 SLOT="0/2"
-IUSE="acl apparmor audit build cgroup-hybrid cryptsetup curl dns-over-tls elfutils fido2 +gcrypt gnuefi homed http +hwdb idn importd +kmod +lz4 lzma nat pam pcre pkcs11 policykit pwquality qrcode repart +resolvconf +seccomp selinux split-usr +sysv-utils test tpm vanilla xkb +zstd"
+IUSE="acl apparmor audit build cgroup-hybrid cryptsetup curl dns-over-tls elfutils fido2 +gcrypt gnuefi homed hostnamed-fallback http +hwdb idn importd +kmod +lz4 lzma nat pam pcre pkcs11 policykit pwquality qrcode repart +resolvconf +seccomp selinux split-usr +sysv-utils test tpm vanilla xkb +zstd"
 
 REQUIRED_USE="
 	homed? ( cryptsetup pam )
 	importd? ( curl gcrypt lzma )
+	policykit? ( !hostnamed-fallback )
 	pwquality? ( homed )
 "
 RESTRICT="!test? ( test )"
@@ -117,6 +118,10 @@ RDEPEND="${COMMON_DEPEND}
 	>=acct-user/systemd-resolve-0-r1
 	>=acct-user/systemd-timesync-0-r1
 	>=sys-apps/baselayout-2.2
+	hostnamed-fallback? (
+		acct-group/systemd-hostname
+		sys-apps/dbus-broker
+	)
 	selinux? ( sec-policy/selinux-base-policy[systemd] )
 	sysv-utils? (
 		!sys-apps/openrc[sysv-utils(-)]
@@ -398,6 +403,16 @@ multilib_src_install_all() {
 		# Avoid breaking boot/reboot
 		dosym ../../../lib/systemd/systemd /usr/lib/systemd/systemd
 		dosym ../../../lib/systemd/systemd-shutdown /usr/lib/systemd/systemd-shutdown
+	fi
+
+	# workaround for https://github.com/systemd/systemd/issues/13501
+	if use hostnamed-fallback; then
+		# this file requires dbus-broker
+		insinto /usr/share/dbus-1/system.d/
+		doins "${FILESDIR}/org.freedesktop.hostname1_no_polkit.conf"
+
+		insinto "${rootprefix}/lib/systemd/system/systemd-hostnamed.service.d/"
+		doins "${FILESDIR}/00-hostnamed-network-user.conf"
 	fi
 
 	gen_usr_ldscript -a systemd udev


### PR DESCRIPTION
@floppym as discussed on irc.

still WIP, not tested, just opening for visibility and initial feedback.
ofc it'll require a bit of keywording on dbus-broker, new GID assignement and flag masking and better comments, but later with that.
just drafting systemd change here.

not sure if it's ok to use `systemd_get_systemunitdir` here.