### PR TITLE
dev-libs/openssl: add `fips` support

### DIFF
--- a/dev-libs/openssl/metadata.xml
+++ b/dev-libs/openssl/metadata.xml
@@ -8,6 +8,7 @@
 <use>
  <flag name="asm">Support assembly hand optimized crypto functions (i.e. faster run time)</flag>
  <flag name="bindist">Disable/Restrict EC algorithms (as they seem to be patented) -- note: changes the ABI</flag>
+ <flag name="fips">Enable FIPS provider</flag>
  <flag name="ktls">Enable support for Kernel implementation of TLS (kTLS)</flag>
  <flag name="rfc3779">Enable support for RFC 3779 (X.509 Extensions for IP Addresses and AS Identifiers)</flag>
  <flag name="sslv2">Support for the old/insecure SSLv2 protocol -- note: not required for TLS/https</flag>

--- a/dev-libs/openssl/openssl-3.0.0.ebuild
+++ b/dev-libs/openssl/openssl-3.0.0.ebuild
@@ -22,7 +22,7 @@ fi
 LICENSE="Apache-2.0"
 SLOT="0/3" # .so version of libssl/libcrypto
 
-IUSE="+asm cpu_flags_x86_sse2 elibc_musl ktls rfc3779 sctp static-libs test tls-compression vanilla"
+IUSE="+asm cpu_flags_x86_sse2 elibc_musl fips ktls rfc3779 sctp static-libs test tls-compression vanilla"
 RESTRICT="!test? ( test )"
 
 COMMON_DEPEND="
@@ -171,6 +171,7 @@ multilib_src_configure() {
 		enable-idea
 		enable-mdc2
 		enable-rc5
+		$(use fips && echo "enable-fips")
 		$(use_ssl asm)
 		$(use_ssl ktls)
 		$(use_ssl rfc3779)


### PR DESCRIPTION
`FIPS` provider is not enabled by default with OpenSSL version 3. Let's
make it optional by adding conditional `fips` internal useflag.

See also: https://github.com/openssl/openssl/blob/master/README-FIPS.md

Bug: https://bugs.gentoo.org/820173
Package-Manager: Portage-3.0.20, Repoman-3.0.3
Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>