### PR TITLE
x11-drivers/nvidia-drivers: revamp 495.44 ebuild (wip)

### DIFF
--- a/x11-drivers/nvidia-drivers/files/nvidia-settings-390.144-desktop.patch
+++ b/x11-drivers/nvidia-drivers/files/nvidia-settings-390.144-desktop.patch
@@ -1,0 +1,12 @@
+For icon: https://github.com/NVIDIA/nvidia-settings/pull/56
+--- a/nvidia-settings/doc/nvidia-settings.desktop
++++ b/nvidia-settings/doc/nvidia-settings.desktop
+@@ -5,5 +5,5 @@
+ Comment=Configure NVIDIA X Server Settings
+-Exec=__UTILS_PATH__/nvidia-settings
+-Icon=__PIXMAP_PATH__/nvidia-settings.png
+-Categories=__NVIDIA_SETTINGS_DESKTOP_CATEGORIES__
++Exec=nvidia-settings
++Icon=nvidia-settings
++Categories=System;HardwareSettings;
+ 

--- a/x11-drivers/nvidia-drivers/files/nvidia-settings-390.144-no-gtk2.patch
+++ b/x11-drivers/nvidia-drivers/files/nvidia-settings-390.144-no-gtk2.patch
@@ -1,0 +1,11 @@
+--- a/nvidia-settings/src/Makefile
++++ b/nvidia-settings/src/Makefile
+@@ -132,3 +132,2 @@
+ GTK2LIB_DIR  = $(OUTPUTDIR)/gtk2
+-GTK2LIB = $(OUTPUTDIR)/$(GTK2LIB_NAME)
+ GTK2LIB_SONAME = $(GTK2LIB_NAME).$(NVIDIA_SETTINGS_VERSION)
+@@ -276,4 +275,2 @@
+ 	$(MKDIR) $(LIBDIR)
+-	$(INSTALL) $(INSTALL_LIB_ARGS) $(GTK2LIB) \
+-	    $(LIBDIR)/$(GTK2LIB_SONAME)
+ ifdef BUILD_GTK3LIB

--- a/x11-drivers/nvidia-drivers/files/nvidia-settings-390.144-raw-ldflags.patch
+++ b/x11-drivers/nvidia-drivers/files/nvidia-settings-390.144-raw-ldflags.patch
@@ -1,0 +1,9 @@
+Currently need to pass ABI flags if LD is ld.lld for USE=tools
+ld.lld: error: target emulation unknown: -m or at least one .o file required
+--- a/nvidia-settings/utils.mk
++++ b/nvidia-settings/utils.mk
+@@ -477,3 +477,3 @@
+ 	$(at_if_quiet)cd $$(dir $(1)); \
+-	$$(call quiet_cmd_no_at,LD) -r -z noexecstack --format=binary \
++	$$(call quiet_cmd_no_at,LD) $$(RAW_LDFLAGS) -r -z noexecstack --format=binary \
+ 	    $$(notdir $(1)) -o $$(OUTPUTDIR_ABSOLUTE)/$$(notdir $$@)

--- a/x11-drivers/nvidia-drivers/metadata.xml
+++ b/x11-drivers/nvidia-drivers/metadata.xml
@@ -11,6 +11,7 @@
 	</maintainer>
 	<use>
 		<flag name="driver">Install kernel driver modules</flag>
+		<flag name="persistenced">Install the persistence daemon for keeping devices state when unused</flag>
 		<flag name="tools">Install additional tools such as nvidia-settings</flag>
 	</use>
 	<upstream>

--- a/x11-drivers/nvidia-drivers/nvidia-drivers-390.144-r100.ebuild
+++ b/x11-drivers/nvidia-drivers/nvidia-drivers-390.144-r100.ebuild
@@ -1,0 +1,427 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+MODULES_OPTIONAL_USE="driver"
+inherit desktop linux-mod readme.gentoo-r1 systemd toolchain-funcs unpacker
+
+NV_KERNEL_MAX="5.13"
+NV_URI="https://download.nvidia.com/XFree86/"
+
+DESCRIPTION="NVIDIA Accelerated Graphics Driver"
+HOMEPAGE="https://www.nvidia.com/download/index.aspx"
+SRC_URI="
+	amd64? ( ${NV_URI}Linux-x86_64/${PV}/NVIDIA-Linux-x86_64-${PV}.run )
+	x86? ( ${NV_URI}Linux-x86/${PV}/NVIDIA-Linux-x86-${PV}.run )
+	$(printf "${NV_URI}%s/%s-${PV}.tar.bz2 " \
+		nvidia-{installer,modprobe,persistenced,settings,xconfig}{,})"
+# nvidia-installer is unused but here for GPL-2's "distribute sources"
+S="${WORKDIR}"
+
+LICENSE="NVIDIA-r2 BSD BSD-2 GPL-2 MIT"
+SLOT="0/${PV%%.*}"
+KEYWORDS="-* ~amd64 ~x86"
+IUSE="+X abi_x86_32 abi_x86_64 +driver static-libs +tools"
+
+COMMON_DEPEND="
+	acct-group/video
+	acct-user/nvpd
+	net-libs/libtirpc:=
+	tools? (
+		dev-libs/atk
+		dev-libs/glib:2
+		dev-libs/jansson:=
+		media-libs/harfbuzz:=
+		x11-libs/cairo
+		x11-libs/gdk-pixbuf:2
+		x11-libs/gtk+:3
+		x11-libs/libX11
+		x11-libs/libXext
+		x11-libs/libXxf86vm
+		x11-libs/pango
+	)"
+RDEPEND="
+	${COMMON_DEPEND}
+	X? (
+		media-libs/libglvnd[X,abi_x86_32(-)?]
+		x11-libs/libX11[abi_x86_32(-)?]
+		x11-libs/libXext[abi_x86_32(-)?]
+	)"
+DEPEND="
+	${COMMON_DEPEND}
+	static-libs? (
+		x11-libs/libX11
+		x11-libs/libXext
+	)
+	tools? (
+		media-libs/libglvnd
+		sys-apps/dbus
+		x11-base/xorg-proto
+		x11-libs/libXrandr
+		x11-libs/libXv
+		x11-libs/libvdpau
+	)"
+BDEPEND="
+	sys-devel/m4
+	virtual/pkgconfig"
+PDEPEND="X? ( <x11-base/xorg-server-1.21 )"
+
+QA_PREBUILT="opt/bin/* usr/lib*"
+
+PATCHES=(
+	"${FILESDIR}"/nvidia-settings-390.141-fno-common.patch
+	"${FILESDIR}"/nvidia-modprobe-390.141-uvm-perms.patch
+)
+
+pkg_setup() {
+	use driver || return
+
+	local CONFIG_CHECK="
+		PROC_FS
+		~DRM_KMS_HELPER
+		~SYSVIPC
+		~!AMD_MEM_ENCRYPT_ACTIVE_BY_DEFAULT
+		~!DRM_SIMPLEDRM
+		~!LOCKDEP
+		!DEBUG_MUTEXES"
+	local ERROR_DRM_KMS_HELPER="CONFIG_DRM_KMS_HELPER: is not set but needed for Xorg auto-detection
+	of drivers (no custom config), and optional nvidia-drm.modeset=1.
+	With 390.xx drivers, also used by a GLX workaround needed for OpenGL.
+	Cannot be directly selected in the kernel's menuconfig, and may need
+	selection of a DRM device even if unused, e.g. CONFIG_DRM_AMDGPU=m or
+	DRM_I915=y, DRM_NOUVEAU=m also acceptable if a module and not built-in.
+	Note: DRM_SIMPLEDRM may cause issues and is better disabled for now."
+
+	kernel_is -ge 5 8 && CONFIG_CHECK+=" X86_PAT" #817764
+
+	MODULE_NAMES="
+		nvidia(video:kernel)
+		nvidia-drm(video:kernel)
+		nvidia-modeset(video:kernel)
+		$(usex x86 '' 'nvidia-uvm(video:kernel)')"
+
+	linux-mod_pkg_setup
+
+	[[ ${MERGE_TYPE} == binary ]] && return
+
+	BUILD_PARAMS='NV_VERBOSE=1 IGNORE_CC_MISMATCH=yes SYSSRC="${KV_DIR}" SYSOUT="${KV_OUT_DIR}"'
+	use x86 && BUILD_PARAMS+=' ARCH=i386'
+	BUILD_TARGETS="modules"
+
+	if linux_chkconfig_present CC_IS_CLANG; then
+		ewarn "Warning: building ${PN} with a clang-built kernel is experimental"
+
+		BUILD_PARAMS+=' CC=${CHOST}-clang'
+		if linux_chkconfig_present LD_IS_LLD; then
+			BUILD_PARAMS+=' LD=ld.lld'
+			if linux_chkconfig_present LTO_CLANG_THIN; then
+				# kernel enables cache by default leading to sandbox violations
+				BUILD_PARAMS+=' ldflags-y=--thinlto-cache-dir= LDFLAGS_MODULE=--thinlto-cache-dir='
+			fi
+		fi
+	fi
+
+	if kernel_is -gt ${NV_KERNEL_MAX/./ }; then
+		ewarn "Kernel ${KV_MAJOR}.${KV_MINOR} is either known to break this version of ${PN}"
+		ewarn "or was not tested with it. It is recommended to use one of:"
+		ewarn "  <=sys-kernel/gentoo-kernel-${NV_KERNEL_MAX}"
+		ewarn "  <=sys-kernel/gentoo-sources-${NV_KERNEL_MAX}"
+		ewarn "You are free to try or use /etc/portage/patches, but support will"
+		ewarn "not be given and issues wait until NVIDIA releases a fixed version."
+		ewarn
+		ewarn "Do _not_ file a bug report if run into issues."
+		ewarn
+	fi
+}
+
+src_prepare() {
+	# make patches usable across versions
+	rm nvidia-modprobe && mv nvidia-modprobe{-${PV},} || die
+	rm nvidia-persistenced && mv nvidia-persistenced{-${PV},} || die
+	rm nvidia-settings && mv nvidia-settings{-${PV},} || die
+	rm nvidia-xconfig && mv nvidia-xconfig{-${PV},} || die
+
+	default
+
+	# prevent detection of incomplete kernel DRM support (bug #603818)
+	sed 's/defined(CONFIG_DRM/defined(CONFIG_DRM_KMS_HELPER/g' \
+		-i kernel/conftest.sh || die
+
+	sed -e '/Exec=\|Icon=/s/_.*/nvidia-settings/' \
+		-e '/Categories=/s/_.*/System;HardwareSettings;/' \
+		-i nvidia-settings/doc/nvidia-settings.desktop || die
+
+	# remove gtk2 support (bug #592730)
+	sed '/^GTK2LIB = /d;/INSTALL.*GTK2LIB/,+1d' \
+		-i nvidia-settings/src/Makefile || die
+
+	sed 's/__USER__/nvpd/' \
+		nvidia-persistenced/init/systemd/nvidia-persistenced.service.template \
+		> "${T}"/nvidia-persistenced.service || die
+
+	sed 's/__NV_VK_ICD__/libGLX_nvidia.so.0/' \
+		nvidia_icd.json.template > nvidia_icd.json || die
+
+	# 390 has legacy glx needing a modified .conf (bug #713546)
+	# directory is not quite right, but kept for any existing custom xorg.conf
+	sed "s|@LIBDIR@|${EPREFIX}/usr/$(get_libdir)|" \
+		"${FILESDIR}"/nvidia-drm-outputclass-390.conf > nvidia-drm-outputclass.conf || die
+}
+
+src_compile() {
+	tc-export AR CC LD OBJCOPY
+
+	NV_ARGS=(
+		PREFIX="${EPREFIX}"/usr
+		HOST_CC="$(tc-getBUILD_CC)"
+		HOST_LD="$(tc-getBUILD_LD)"
+		NV_USE_BUNDLED_LIBJANSSON=0
+		NV_VERBOSE=1 DO_STRIP= MANPAGE_GZIP= OUTPUTDIR=out
+	)
+
+	use driver && linux-mod_src_compile
+
+	# 390.xx persistenced does not auto-detect libtirpc
+	LIBS=$($(tc-getPKG_CONFIG) --libs libtirpc || die) \
+		common_cflags=$($(tc-getPKG_CONFIG) --cflags libtirpc || die) \
+		emake "${NV_ARGS[@]}" -C nvidia-persistenced
+
+	emake "${NV_ARGS[@]}" -C nvidia-modprobe
+	use X && emake "${NV_ARGS[@]}" -C nvidia-xconfig
+
+	if use tools; then
+		# avoid filling up logs, only use here and set first to allow override
+		CFLAGS="-Wno-deprecated-declarations ${CFLAGS}" \
+			emake "${NV_ARGS[@]}" -C nvidia-settings
+	elif use static-libs; then
+		emake "${NV_ARGS[@]}" -C nvidia-settings/src build-xnvctrl
+	fi
+}
+
+src_install() {
+	local libdir=$(get_libdir) libdir32=$(ABI=x86 get_libdir)
+
+	NV_ARGS+=( DESTDIR="${D}" LIBDIR="${ED}"/usr/${libdir} )
+
+	local -A paths=(
+		[APPLICATION_PROFILE]=/usr/share/nvidia
+		[CUDA_ICD]=/etc/OpenCL/vendors
+		[EGL_EXTERNAL_PLATFORM_JSON]=/usr/share/egl/egl_external_platform.d
+		[GLVND_EGL_ICD_JSON]=/usr/share/glvnd/egl_vendor.d
+		[VULKAN_ICD_JSON]=/usr/share/vulkan/icd.d
+		[XORG_OUTPUTCLASS_CONFIG]=/usr/share/X11/xorg.conf.d
+
+		[GLX_MODULE_SHARED_LIB]=/usr/${libdir}/xorg/modules/extensions
+		[GLX_MODULE_SYMLINK]=/usr/${libdir}/extensions/nvidia
+		[XMODULE_NEWSYM]=/usr/${libdir}/extensions/nvidia
+		[XMODULE_SHARED_LIB]=/usr/${libdir}/xorg/modules
+		[XMODULE_SYMLINK]=/usr/${libdir}/xorg/modules
+	)
+
+	local skip_files=(
+		$(usex X '' '
+			libGLX_nvidia libglx
+			libnvidia-ifr
+			nvidia_icd.json')
+		libGLX_indirect # non-glvnd unused fallback
+		libnvidia-gtk nvidia-{settings,xconfig} # built from source
+		libnvidia-egl-wayland 10_nvidia_wayland # gui-libs/egl-wayland
+	)
+	local skip_modules=(
+		$(usex X '' 'nvfbc vdpau xdriver')
+		installer nvpd # handled separately / built from source
+	)
+	local skip_types=(
+		GLVND_LIB GLVND_SYMLINK EGL_CLIENT.\* GLX_CLIENT.\* # media-libs/libglvnd
+		OPENCL_WRAPPER.\* # virtual/opencl
+		DOCUMENTATION DOT_DESKTOP # handled separately
+		.\*_SRC DKMS_CONF LIBGL_LA OPENGL_HEADER # unused
+	)
+
+	local DOCS=(
+		README.txt NVIDIA_Changelog
+		nvidia-settings/doc/{FRAMELOCK,NV-CONTROL-API}.txt
+	)
+	local HTML_DOCS=( html/. )
+	einstalldocs
+
+	local DISABLE_AUTOFORMATTING=yes
+	local DOC_CONTENTS="\
+Trusted users should be in the 'video' group to use NVIDIA devices.
+You can add yourself by using: gpasswd -a my-user video
+
+See '${EPREFIX}/etc/modprobe.d/nvidia.conf' for modules options.\
+$(use amd64 && usex abi_x86_32 '' "
+
+Note that without USE=abi_x86_32 on ${PN}, 32bit applications
+(typically using wine / steam) will not be able to use GPU acceleration.")\
+$(usex X "
+
+390.xx libglvnd support is partial and requires different Xorg modules
+for working OpenGL/GLX. If using the default Xorg configuration these
+should be used automatically, otherwise manually add the ModulePath
+from: '${EPREFIX}/${paths[XORG_OUTPUTCLASS_CONFIG]#/}/nvidia-drm-outputclass.conf'" '')\
+$(usex x86 '
+
+Note that NVIDIA is no longer offering support for the unified memory
+module (nvidia-uvm) on x86 (32bit), as such the module is missing.
+This means OpenCL/CUDA (and related, like nvenc) cannot be used.
+Other functions, like OpenGL, will continue to work.' '')
+
+Support from NVIDIA for 390.xx will end in December 2022, how long
+Gentoo will be able to reasonably support it beyond that is unknown.
+If wish to continue using this hardware, should consider switching
+to the Nouveau open source driver.
+https://nvidia.custhelp.com/app/answers/detail/a_id/3142/
+
+For general information on using ${PN}, please see:
+https://wiki.gentoo.org/wiki/NVIDIA/nvidia-drivers"
+	readme.gentoo_create_doc
+
+	if use driver; then
+		linux-mod_src_install
+
+		insinto /etc/modprobe.d
+		newins "${FILESDIR}"/nvidia-390.conf nvidia.conf
+	fi
+
+	# nvidia-modprobe
+	emake "${NV_ARGS[@]}" -C nvidia-modprobe install
+	fowners :video /usr/bin/nvidia-modprobe #505092
+	fperms 4710 /usr/bin/nvidia-modprobe
+
+	# nvidia-persistenced
+	emake "${NV_ARGS[@]}" -C nvidia-persistenced install
+	newconfd "${FILESDIR}"/nvidia-persistenced.confd nvidia-persistenced
+	newinitd "${FILESDIR}"/nvidia-persistenced.initd nvidia-persistenced
+	systemd_dounit "${T}"/nvidia-persistenced.service
+
+	# nvidia-settings
+	if use tools; then
+		emake "${NV_ARGS[@]}" -C nvidia-settings install
+
+		doicon nvidia-settings/doc/nvidia-settings.png
+		domenu nvidia-settings/doc/nvidia-settings.desktop
+
+		exeinto /etc/X11/xinit/xinitrc.d
+		newexe "${FILESDIR}"/95-nvidia-settings-r1 95-nvidia-settings
+	fi
+
+	if use static-libs; then
+		dolib.a nvidia-settings/src/libXNVCtrl/libXNVCtrl.a
+
+		insinto /usr/include/NVCtrl
+		doins nvidia-settings/src/libXNVCtrl/NVCtrl{Lib,}.h
+	fi
+
+	# nvidia-xconfig
+	use X && emake "${NV_ARGS[@]}" -C nvidia-xconfig install
+
+	# mimic nvidia-installer by reading .manifest to install files
+	# 0:file 1:perms 2:type 3+:subtype/arguments -:module
+	local m into
+	while IFS=' ' read -ra m; do
+		! [[ ${#m[@]} -ge 2 && ${m[-1]} =~ MODULE: ]] ||
+			eval '[[ " ${m[0]##*/}" =~ ^(\ '${skip_files[*]/%/.*|\\}' )$ ]]' ||
+			eval '[[ " ${m[2]}" =~ ^(\ '${skip_types[*]/%/|\\}' )$ ]]' ||
+			has ${m[-1]#MODULE:} "${skip_modules[@]}" && continue
+
+		case ${m[2]} in
+			MANPAGE)
+				gzip -dc ${m[0]} | newman - ${m[0]%.gz}; assert
+				continue
+			;;
+			GLX_MODULE_SYMLINK|XMODULE_NEWSYM)
+				# messy symlinks for non-glvnd xorg modules overrides put
+				# in a different directory to avoid collisions (390-only)
+				m[4]=../../xorg/modules/${m[3]#/}${m[4]}
+				m[3]=/
+			;;
+			TLS_LIB) [[ ${m[4]} == CLASSIC ]] && continue;; # segfaults (bug #785289)
+			VDPAU_SYMLINK) m[4]=vdpau/; m[5]=${m[5]#vdpau/};; # .so to vdpau/
+			VULKAN_ICD_JSON) m[0]=${m[0]%.template};;
+		esac
+
+		if [[ -v paths[${m[2]}] ]]; then
+			into=${paths[${m[2]}]}
+		elif [[ ${m[2]} =~ _BINARY$ ]]; then
+			into=/opt/bin
+		elif [[ ${m[3]} == COMPAT32 ]]; then
+			use abi_x86_32 || continue
+			into=/usr/${libdir32}
+		elif [[ ${m[2]} =~ _LIB$|_SYMLINK$ ]]; then
+			into=/usr/${libdir}
+		else
+			die "No known installation path for ${m[0]}"
+		fi
+		[[ ${m[3]: -2} == ?/ ]] && into+=/${m[3]%/}
+		[[ ${m[4]: -2} == ?/ ]] && into+=/${m[4]%/}
+
+		if [[ ${m[2]} =~ _SYMLINK$|_NEWSYM$ ]]; then
+			[[ ${m[4]: -1} == / ]] && m[4]=${m[5]}
+			dosym ${m[4]} ${into}/${m[0]}
+			continue
+		fi
+
+		printf -v m[1] %o $((m[1] | 0200)) # 444->644
+		insopts -m${m[1]}
+		insinto ${into}
+		doins ${m[0]}
+	done < .manifest || die
+
+	# MODULE:installer non-skipped extras
+	dolib.so libnvidia-cfg.so.${PV}
+	dosym libnvidia-cfg.so.${PV} /usr/${libdir}/libnvidia-cfg.so.1
+	dosym libnvidia-cfg.so.${PV} /usr/${libdir}/libnvidia-cfg.so
+
+	dobin nvidia-bug-report.sh
+}
+
+pkg_preinst() {
+	has_version "${CATEGORY}/${PN}[abi_x86_32]" && NV_HAD_ABI32=
+
+	use driver || return
+	linux-mod_pkg_preinst
+
+	# set video group id based on live system (bug #491414)
+	local g=$(getent group video | cut -d: -f3)
+	[[ ${g} ]] || die "Failed to determine video group id"
+	sed -i "s/@VIDEOGID@/${g}/" "${ED}"/etc/modprobe.d/nvidia.conf || die
+}
+
+pkg_postinst() {
+	use driver && linux-mod_pkg_postinst
+
+	readme.gentoo_print_elog
+
+	if [[ -r /proc/driver/nvidia/version &&
+		$(</proc/driver/nvidia/version) != *"  ${PV}  "* ]]; then
+		ewarn "Currently loaded NVIDIA modules do not match the newly installed"
+		ewarn "libraries and may prevent launching GPU-accelerated applications."
+		use driver && ewarn "The easiest way to fix this is usually to reboot."
+	fi
+
+	if use !abi_x86_32 && [[ -v NV_HAD_ABI32 ]]; then
+		elog
+		elog "USE=abi_x86_32 is disabled, 32bit applications will not be able to"
+		elog "use nvidia-drivers for acceleration without it (e.g. commonly used"
+		elog "with app-emulation/wine-* or steam). Re-enable if needed."
+	fi
+
+	# Try to show this message only to users that may really need it
+	# given the workaround is discouraged and usage isn't widespread.
+	if use X && [[ ${REPLACING_VERSIONS} ]] &&
+		ver_test ${REPLACING_VERSIONS} -lt 390.143 &&
+		grep -qr Coolbits "${EROOT}"/etc/X11/{xorg.conf,xorg.conf.d/*.conf} 2>/dev/null; then
+		elog
+		elog "Coolbits support with ${PN} has been restricted to require Xorg"
+		elog "with root privilege by NVIDIA (being in video group is not sufficient)."
+		elog "e.g. attempting to change fan speed with nvidia-settings would fail."
+		elog
+		elog "Depending on your display manager (e.g. sddm starts X as root, gdm doesn't)"
+		elog "or if using startx, it may be necessary to emerge x11-base/xorg-server with"
+		elog 'USE="suid -elogind -systemd" if wish to keep using this feature.'
+		elog "Bug: https://bugs.gentoo.org/784248"
+	fi
+}

--- a/x11-drivers/nvidia-drivers/nvidia-drivers-390.144-r100.ebuild
+++ b/x11-drivers/nvidia-drivers/nvidia-drivers-390.144-r100.ebuild
@@ -4,7 +4,8 @@
 EAPI=7
 
 MODULES_OPTIONAL_USE="driver"
-inherit desktop linux-mod readme.gentoo-r1 systemd toolchain-funcs unpacker
+inherit desktop flag-o-matic linux-mod multilib readme.gentoo-r1 \
+	systemd toolchain-funcs unpacker
 
 NV_KERNEL_MAX="5.13"
 NV_URI="https://download.nvidia.com/XFree86/"
@@ -72,8 +73,9 @@ PDEPEND="X? ( <x11-base/xorg-server-1.21 )"
 QA_PREBUILT="opt/bin/* usr/lib*"
 
 PATCHES=(
-	"${FILESDIR}"/nvidia-settings-390.141-fno-common.patch
 	"${FILESDIR}"/nvidia-modprobe-390.141-uvm-perms.patch
+	"${FILESDIR}"/nvidia-settings-390.141-fno-common.patch
+	"${FILESDIR}"/nvidia-settings-390.144-raw-ldflags.patch
 )
 
 pkg_setup() {
@@ -195,8 +197,10 @@ src_compile() {
 	use X && emake "${NV_ARGS[@]}" -C nvidia-xconfig
 
 	if use tools; then
-		# avoid filling up logs, only use here and set first to allow override
+		# cflags: avoid noisy logs, only use here and set first to let override
+		# ldflags: abi currently needed if LD=ld.lld
 		CFLAGS="-Wno-deprecated-declarations ${CFLAGS}" \
+			RAW_LDFLAGS="$(get_abi_LDFLAGS) $(raw-ldflags)" \
 			emake "${NV_ARGS[@]}" -C nvidia-settings
 	elif use static-libs; then
 		emake "${NV_ARGS[@]}" -C nvidia-settings/src build-xnvctrl

--- a/x11-drivers/nvidia-drivers/nvidia-drivers-390.144-r100.ebuild
+++ b/x11-drivers/nvidia-drivers/nvidia-drivers-390.144-r100.ebuild
@@ -75,6 +75,8 @@ QA_PREBUILT="opt/bin/* usr/lib*"
 PATCHES=(
 	"${FILESDIR}"/nvidia-modprobe-390.141-uvm-perms.patch
 	"${FILESDIR}"/nvidia-settings-390.141-fno-common.patch
+	"${FILESDIR}"/nvidia-settings-390.144-desktop.patch
+	"${FILESDIR}"/nvidia-settings-390.144-no-gtk2.patch
 	"${FILESDIR}"/nvidia-settings-390.144-raw-ldflags.patch
 )
 
@@ -151,14 +153,6 @@ src_prepare() {
 	# prevent detection of incomplete kernel DRM support (bug #603818)
 	sed 's/defined(CONFIG_DRM/defined(CONFIG_DRM_KMS_HELPER/g' \
 		-i kernel/conftest.sh || die
-
-	sed -e '/Exec=\|Icon=/s/_.*/nvidia-settings/' \
-		-e '/Categories=/s/_.*/System;HardwareSettings;/' \
-		-i nvidia-settings/doc/nvidia-settings.desktop || die
-
-	# remove gtk2 support (bug #592730)
-	sed '/^GTK2LIB = /d;/INSTALL.*GTK2LIB/,+1d' \
-		-i nvidia-settings/src/Makefile || die
 
 	sed 's/__USER__/nvpd/' \
 		nvidia-persistenced/init/systemd/nvidia-persistenced.service.template \

--- a/x11-drivers/nvidia-drivers/nvidia-drivers-460.91.03-r100.ebuild
+++ b/x11-drivers/nvidia-drivers/nvidia-drivers-460.91.03-r100.ebuild
@@ -4,7 +4,8 @@
 EAPI=7
 
 MODULES_OPTIONAL_USE="driver"
-inherit desktop linux-mod readme.gentoo-r1 systemd toolchain-funcs unpacker
+inherit desktop flag-o-matic linux-mod multilib readme.gentoo-r1 \
+	systemd toolchain-funcs unpacker
 
 NV_KERNEL_MAX="5.13"
 NV_URI="https://download.nvidia.com/XFree86/"
@@ -73,6 +74,7 @@ QA_PREBUILT="opt/bin/* usr/lib*"
 
 PATCHES=(
 	"${FILESDIR}"/nvidia-modprobe-390.141-uvm-perms.patch
+	"${FILESDIR}"/nvidia-settings-390.144-raw-ldflags.patch
 )
 
 pkg_setup() {
@@ -177,8 +179,10 @@ src_compile() {
 	use X && emake "${NV_ARGS[@]}" -C nvidia-xconfig
 
 	if use tools; then
-		# avoid filling up logs, only use here and set first to allow override
+		# cflags: avoid noisy logs, only use here and set first to let override
+		# ldflags: abi currently needed if LD=ld.lld
 		CFLAGS="-Wno-deprecated-declarations ${CFLAGS}" \
+			RAW_LDFLAGS="$(get_abi_LDFLAGS) $(raw-ldflags)" \
 			emake "${NV_ARGS[@]}" -C nvidia-settings
 	elif use static-libs; then
 		emake "${NV_ARGS[@]}" -C nvidia-settings/src out/libXNVCtrl.a

--- a/x11-drivers/nvidia-drivers/nvidia-drivers-460.91.03-r100.ebuild
+++ b/x11-drivers/nvidia-drivers/nvidia-drivers-460.91.03-r100.ebuild
@@ -22,12 +22,14 @@ S="${WORKDIR}"
 LICENSE="NVIDIA-r2 BSD BSD-2 GPL-2 MIT ZLIB curl openssl"
 SLOT="0/${PV%%.*}"
 KEYWORDS="-* ~amd64"
-IUSE="+X abi_x86_32 abi_x86_64 +driver static-libs +tools"
+IUSE="+X abi_x86_32 abi_x86_64 +driver persistenced static-libs +tools"
 
 COMMON_DEPEND="
 	acct-group/video
-	acct-user/nvpd
-	net-libs/libtirpc:=
+	persistenced? (
+		acct-user/nvpd
+		net-libs/libtirpc:=
+	)
 	tools? (
 		dev-libs/atk
 		dev-libs/glib:2
@@ -171,7 +173,7 @@ src_compile() {
 	use driver && linux-mod_src_compile
 
 	emake "${NV_ARGS[@]}" -C nvidia-modprobe
-	emake "${NV_ARGS[@]}" -C nvidia-persistenced
+	use persistenced && emake "${NV_ARGS[@]}" -C nvidia-persistenced
 	use X && emake "${NV_ARGS[@]}" -C nvidia-xconfig
 
 	if use tools; then
@@ -253,18 +255,17 @@ https://wiki.gentoo.org/wiki/NVIDIA/nvidia-drivers"
 		doins supported-gpus/supported-gpus.json
 	fi
 
-	# nvidia-modprobe
 	emake "${NV_ARGS[@]}" -C nvidia-modprobe install
 	fowners :video /usr/bin/nvidia-modprobe #505092
 	fperms 4710 /usr/bin/nvidia-modprobe
 
-	# nvidia-persistenced
-	emake "${NV_ARGS[@]}" -C nvidia-persistenced install
-	newconfd "${FILESDIR}"/nvidia-persistenced.confd nvidia-persistenced
-	newinitd "${FILESDIR}"/nvidia-persistenced.initd nvidia-persistenced
-	systemd_dounit "${T}"/nvidia-persistenced.service
+	if use persistenced; then
+		emake "${NV_ARGS[@]}" -C nvidia-persistenced install
+		newconfd "${FILESDIR}"/nvidia-persistenced.confd nvidia-persistenced
+		newinitd "${FILESDIR}"/nvidia-persistenced.initd nvidia-persistenced
+		systemd_dounit "${T}"/nvidia-persistenced.service
+	fi
 
-	# nvidia-settings
 	if use tools; then
 		emake "${NV_ARGS[@]}" -C nvidia-settings install
 
@@ -282,7 +283,6 @@ https://wiki.gentoo.org/wiki/NVIDIA/nvidia-drivers"
 		doins nvidia-settings/src/libXNVCtrl/NVCtrl{Lib,}.h
 	fi
 
-	# nvidia-xconfig
 	use X && emake "${NV_ARGS[@]}" -C nvidia-xconfig install
 
 	# mimic nvidia-installer by reading .manifest to install files

--- a/x11-drivers/nvidia-drivers/nvidia-drivers-460.91.03-r100.ebuild
+++ b/x11-drivers/nvidia-drivers/nvidia-drivers-460.91.03-r100.ebuild
@@ -74,6 +74,8 @@ QA_PREBUILT="opt/bin/* usr/lib*"
 
 PATCHES=(
 	"${FILESDIR}"/nvidia-modprobe-390.141-uvm-perms.patch
+	"${FILESDIR}"/nvidia-settings-390.144-desktop.patch
+	"${FILESDIR}"/nvidia-settings-390.144-no-gtk2.patch
 	"${FILESDIR}"/nvidia-settings-390.144-raw-ldflags.patch
 )
 
@@ -147,14 +149,6 @@ src_prepare() {
 	# prevent detection of incomplete kernel DRM support (bug #603818)
 	sed 's/defined(CONFIG_DRM/defined(CONFIG_DRM_KMS_HELPER/g' \
 		-i kernel/conftest.sh || die
-
-	sed -e '/Exec=\|Icon=/s/_.*/nvidia-settings/' \
-		-e '/Categories=/s/_.*/System;HardwareSettings;/' \
-		-i nvidia-settings/doc/nvidia-settings.desktop || die
-
-	# remove gtk2 support (bug #592730)
-	sed '/^GTK2LIB = /d;/INSTALL.*GTK2LIB/,+1d' \
-		-i nvidia-settings/src/Makefile || die
 
 	sed 's/__USER__/nvpd/' \
 		nvidia-persistenced/init/systemd/nvidia-persistenced.service.template \

--- a/x11-drivers/nvidia-drivers/nvidia-drivers-460.91.03-r100.ebuild
+++ b/x11-drivers/nvidia-drivers/nvidia-drivers-460.91.03-r100.ebuild
@@ -1,0 +1,418 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+MODULES_OPTIONAL_USE="driver"
+inherit desktop linux-mod readme.gentoo-r1 systemd toolchain-funcs unpacker
+
+NV_KERNEL_MAX="5.13"
+NV_URI="https://download.nvidia.com/XFree86/"
+
+DESCRIPTION="NVIDIA Accelerated Graphics Driver"
+HOMEPAGE="https://www.nvidia.com/download/index.aspx"
+SRC_URI="
+	amd64? ( ${NV_URI}Linux-x86_64/${PV}/NVIDIA-Linux-x86_64-${PV}.run )
+	arm64? ( ${NV_URI}Linux-aarch64/${PV}/NVIDIA-Linux-aarch64-${PV}.run )
+	$(printf "${NV_URI}%s/%s-${PV}.tar.bz2 " \
+		nvidia-{installer,modprobe,persistenced,settings,xconfig}{,})"
+# nvidia-installer is unused but here for GPL-2's "distribute sources"
+S="${WORKDIR}"
+
+LICENSE="NVIDIA-r2 BSD BSD-2 GPL-2 MIT ZLIB curl openssl"
+SLOT="0/${PV%%.*}"
+KEYWORDS="-* ~amd64"
+IUSE="+X abi_x86_32 abi_x86_64 +driver static-libs +tools"
+
+COMMON_DEPEND="
+	acct-group/video
+	acct-user/nvpd
+	net-libs/libtirpc:=
+	tools? (
+		dev-libs/atk
+		dev-libs/glib:2
+		dev-libs/jansson:=
+		media-libs/harfbuzz:=
+		x11-libs/cairo
+		x11-libs/gdk-pixbuf:2
+		x11-libs/gtk+:3
+		x11-libs/libX11
+		x11-libs/libXext
+		x11-libs/libXxf86vm
+		x11-libs/pango
+	)"
+RDEPEND="
+	${COMMON_DEPEND}
+	X? (
+		media-libs/libglvnd[X,abi_x86_32(-)?]
+		x11-libs/libX11[abi_x86_32(-)?]
+		x11-libs/libXext[abi_x86_32(-)?]
+	)"
+DEPEND="
+	${COMMON_DEPEND}
+	static-libs? (
+		x11-libs/libX11
+		x11-libs/libXext
+	)
+	tools? (
+		media-libs/libglvnd
+		sys-apps/dbus
+		x11-base/xorg-proto
+		x11-libs/libXrandr
+		x11-libs/libXv
+		x11-libs/libvdpau
+	)"
+BDEPEND="
+	sys-devel/m4
+	virtual/pkgconfig"
+PDEPEND="X? ( <x11-base/xorg-server-1.21 )"
+
+QA_PREBUILT="opt/bin/* usr/lib*"
+
+PATCHES=(
+	"${FILESDIR}"/nvidia-modprobe-390.141-uvm-perms.patch
+)
+
+pkg_setup() {
+	use driver || return
+
+	local CONFIG_CHECK="
+		PROC_FS
+		~DRM_KMS_HELPER
+		~SYSVIPC
+		~!DRM_SIMPLEDRM
+		~!LOCKDEP
+		!DEBUG_MUTEXES"
+	local ERROR_DRM_KMS_HELPER="CONFIG_DRM_KMS_HELPER: is not set but needed for Xorg auto-detection
+	of drivers (no custom config), and for wayland / nvidia-drm.modeset=1.
+	Cannot be directly selected in the kernel's menuconfig, and may need
+	selection of a DRM device even if unused, e.g. CONFIG_DRM_AMDGPU=m or
+	DRM_I915=y, DRM_NOUVEAU=m also acceptable if a module and not built-in.
+	Note: DRM_SIMPLEDRM may cause issues and is better disabled for now."
+
+	use amd64 && kernel_is -ge 5 8 && CONFIG_CHECK+=" X86_PAT" #817764
+
+	MODULE_NAMES="
+		nvidia(video:kernel)
+		nvidia-drm(video:kernel)
+		nvidia-modeset(video:kernel)
+		nvidia-uvm(video:kernel)"
+
+	linux-mod_pkg_setup
+
+	[[ ${MERGE_TYPE} == binary ]] && return
+
+	BUILD_PARAMS='NV_VERBOSE=1 IGNORE_CC_MISMATCH=yes SYSSRC="${KV_DIR}" SYSOUT="${KV_OUT_DIR}"'
+	BUILD_TARGETS="modules"
+
+	if linux_chkconfig_present CC_IS_CLANG; then
+		ewarn "Warning: building ${PN} with a clang-built kernel is experimental"
+
+		BUILD_PARAMS+=' CC=${CHOST}-clang'
+		if linux_chkconfig_present LD_IS_LLD; then
+			BUILD_PARAMS+=' LD=ld.lld'
+			if linux_chkconfig_present LTO_CLANG_THIN; then
+				# kernel enables cache by default leading to sandbox violations
+				BUILD_PARAMS+=' ldflags-y=--thinlto-cache-dir= LDFLAGS_MODULE=--thinlto-cache-dir='
+			fi
+		fi
+	fi
+
+	if kernel_is -gt ${NV_KERNEL_MAX/./ }; then
+		ewarn "Kernel ${KV_MAJOR}.${KV_MINOR} is either known to break this version of ${PN}"
+		ewarn "or was not tested with it. It is recommended to use one of:"
+		ewarn "  <=sys-kernel/gentoo-kernel-${NV_KERNEL_MAX}"
+		ewarn "  <=sys-kernel/gentoo-sources-${NV_KERNEL_MAX}"
+		ewarn "You are free to try or use /etc/portage/patches, but support will"
+		ewarn "not be given and issues wait until NVIDIA releases a fixed version."
+		ewarn
+		ewarn "Do _not_ file a bug report if run into issues."
+		ewarn
+	fi
+}
+
+src_prepare() {
+	# make patches usable across versions
+	rm nvidia-modprobe && mv nvidia-modprobe{-${PV},} || die
+	rm nvidia-persistenced && mv nvidia-persistenced{-${PV},} || die
+	rm nvidia-settings && mv nvidia-settings{-${PV},} || die
+	rm nvidia-xconfig && mv nvidia-xconfig{-${PV},} || die
+
+	default
+
+	# prevent detection of incomplete kernel DRM support (bug #603818)
+	sed 's/defined(CONFIG_DRM/defined(CONFIG_DRM_KMS_HELPER/g' \
+		-i kernel/conftest.sh || die
+
+	sed -e '/Exec=\|Icon=/s/_.*/nvidia-settings/' \
+		-e '/Categories=/s/_.*/System;HardwareSettings;/' \
+		-i nvidia-settings/doc/nvidia-settings.desktop || die
+
+	# remove gtk2 support (bug #592730)
+	sed '/^GTK2LIB = /d;/INSTALL.*GTK2LIB/,+1d' \
+		-i nvidia-settings/src/Makefile || die
+
+	sed 's/__USER__/nvpd/' \
+		nvidia-persistenced/init/systemd/nvidia-persistenced.service.template \
+		> "${T}"/nvidia-persistenced.service || die
+}
+
+src_compile() {
+	tc-export AR CC LD OBJCOPY
+
+	NV_ARGS=(
+		PREFIX="${EPREFIX}"/usr
+		HOST_CC="$(tc-getBUILD_CC)"
+		HOST_LD="$(tc-getBUILD_LD)"
+		NV_USE_BUNDLED_LIBJANSSON=0
+		NV_VERBOSE=1 DO_STRIP= MANPAGE_GZIP= OUTPUTDIR=out
+	)
+
+	use driver && linux-mod_src_compile
+
+	emake "${NV_ARGS[@]}" -C nvidia-modprobe
+	emake "${NV_ARGS[@]}" -C nvidia-persistenced
+	use X && emake "${NV_ARGS[@]}" -C nvidia-xconfig
+
+	if use tools; then
+		# avoid filling up logs, only use here and set first to allow override
+		CFLAGS="-Wno-deprecated-declarations ${CFLAGS}" \
+			emake "${NV_ARGS[@]}" -C nvidia-settings
+	elif use static-libs; then
+		emake "${NV_ARGS[@]}" -C nvidia-settings/src out/libXNVCtrl.a
+	fi
+}
+
+src_install() {
+	local libdir=$(get_libdir) libdir32=$(ABI=x86 get_libdir)
+
+	NV_ARGS+=( DESTDIR="${D}" LIBDIR="${ED}"/usr/${libdir} )
+
+	local -A paths=(
+		[APPLICATION_PROFILE]=/usr/share/nvidia
+		[CUDA_ICD]=/etc/OpenCL/vendors
+		[EGL_EXTERNAL_PLATFORM_JSON]=/usr/share/egl/egl_external_platform.d
+		[GLVND_EGL_ICD_JSON]=/usr/share/glvnd/egl_vendor.d
+		[VULKAN_ICD_JSON]=/usr/share/vulkan
+		[XORG_OUTPUTCLASS_CONFIG]=/usr/share/X11/xorg.conf.d
+
+		[GLX_MODULE_SHARED_LIB]=/usr/${libdir}/xorg/modules/extensions
+		[GLX_MODULE_SYMLINK]=/usr/${libdir}/xorg/modules
+		[XMODULE_SHARED_LIB]=/usr/${libdir}/xorg/modules
+	)
+
+	local skip_files=(
+		$(usex X '' '
+			libGLX_nvidia libglxserver_nvidia
+			libnvidia-ifr
+			nvidia_icd.json nvidia_layers.json')
+		libGLX_indirect # non-glvnd unused fallback
+		libnvidia-gtk nvidia-{settings,xconfig} # built from source
+		libnvidia-egl-wayland 10_nvidia_wayland # gui-libs/egl-wayland
+	)
+	local skip_modules=(
+		$(usex X '' 'nvfbc vdpau xdriver')
+		installer nvpd # handled separately / built from source
+	)
+	local skip_types=(
+		GLVND_LIB GLVND_SYMLINK EGL_CLIENT.\* GLX_CLIENT.\* # media-libs/libglvnd
+		OPENCL_WRAPPER.\* # virtual/opencl
+		DOCUMENTATION DOT_DESKTOP .\*_SRC DKMS_CONF # handled separately / unused
+	)
+
+	local DOCS=(
+		README.txt NVIDIA_Changelog supported-gpus/supported-gpus.json
+		nvidia-settings/doc/{FRAMELOCK,NV-CONTROL-API}.txt
+	)
+	local HTML_DOCS=( html/. )
+	einstalldocs
+
+	local DISABLE_AUTOFORMATTING=yes
+	local DOC_CONTENTS="\
+Trusted users should be in the 'video' group to use NVIDIA devices.
+You can add yourself by using: gpasswd -a my-user video
+
+See '${EPREFIX}/etc/modprobe.d/nvidia.conf' for modules options.\
+$(use amd64 && usex abi_x86_32 '' "
+
+Note that without USE=abi_x86_32 on ${PN}, 32bit applications
+(typically using wine / steam) will not be able to use GPU acceleration.")
+
+For general information on using ${PN}, please see:
+https://wiki.gentoo.org/wiki/NVIDIA/nvidia-drivers"
+	readme.gentoo_create_doc
+
+	if use driver; then
+		linux-mod_src_install
+
+		insinto /etc/modprobe.d
+		newins "${FILESDIR}"/nvidia-470.conf nvidia.conf
+
+		# used for gpu verification with binpkgs (not kept, see pkg_preinst)
+		insinto /usr/share/nvidia
+		doins supported-gpus/supported-gpus.json
+	fi
+
+	# nvidia-modprobe
+	emake "${NV_ARGS[@]}" -C nvidia-modprobe install
+	fowners :video /usr/bin/nvidia-modprobe #505092
+	fperms 4710 /usr/bin/nvidia-modprobe
+
+	# nvidia-persistenced
+	emake "${NV_ARGS[@]}" -C nvidia-persistenced install
+	newconfd "${FILESDIR}"/nvidia-persistenced.confd nvidia-persistenced
+	newinitd "${FILESDIR}"/nvidia-persistenced.initd nvidia-persistenced
+	systemd_dounit "${T}"/nvidia-persistenced.service
+
+	# nvidia-settings
+	if use tools; then
+		emake "${NV_ARGS[@]}" -C nvidia-settings install
+
+		doicon nvidia-settings/doc/nvidia-settings.png
+		domenu nvidia-settings/doc/nvidia-settings.desktop
+
+		exeinto /etc/X11/xinit/xinitrc.d
+		newexe "${FILESDIR}"/95-nvidia-settings-r1 95-nvidia-settings
+	fi
+
+	if use static-libs; then
+		dolib.a nvidia-settings/src/out/libXNVCtrl.a
+
+		insinto /usr/include/NVCtrl
+		doins nvidia-settings/src/libXNVCtrl/NVCtrl{Lib,}.h
+	fi
+
+	# nvidia-xconfig
+	use X && emake "${NV_ARGS[@]}" -C nvidia-xconfig install
+
+	# mimic nvidia-installer by reading .manifest to install files
+	# 0:file 1:perms 2:type 3+:subtype/arguments -:module
+	local m into
+	while IFS=' ' read -ra m; do
+		! [[ ${#m[@]} -ge 2 && ${m[-1]} =~ MODULE: ]] ||
+			eval '[[ " ${m[0]##*/}" =~ ^(\ '${skip_files[*]/%/.*|\\}' )$ ]]' ||
+			eval '[[ " ${m[2]}" =~ ^(\ '${skip_types[*]/%/|\\}' )$ ]]' ||
+			has ${m[-1]#MODULE:} "${skip_modules[@]}" && continue
+
+		case ${m[2]} in
+			MANPAGE)
+				gzip -dc ${m[0]} | newman - ${m[0]%.gz}; assert
+				continue
+			;;
+			VDPAU_SYMLINK) m[4]=vdpau/; m[5]=${m[5]#vdpau/};; # .so to vdpau/
+		esac
+
+		if [[ -v paths[${m[2]}] ]]; then
+			into=${paths[${m[2]}]}
+		elif [[ ${m[2]} =~ _BINARY$ ]]; then
+			into=/opt/bin
+		elif [[ ${m[3]} == COMPAT32 ]]; then
+			use abi_x86_32 || continue
+			into=/usr/${libdir32}
+		elif [[ ${m[2]} =~ _LIB$|_SYMLINK$ ]]; then
+			into=/usr/${libdir}
+		else
+			die "No known installation path for ${m[0]}"
+		fi
+		[[ ${m[3]: -2} == ?/ ]] && into+=/${m[3]%/}
+		[[ ${m[4]: -2} == ?/ ]] && into+=/${m[4]%/}
+
+		if [[ ${m[2]} =~ _SYMLINK$ ]]; then
+			[[ ${m[4]: -1} == / ]] && m[4]=${m[5]}
+			dosym ${m[4]} ${into}/${m[0]}
+			continue
+		fi
+		[[ ${m[0]} =~ ^libnvidia-ngx.so ]] &&
+			dosym ${m[0]} ${into}/${m[0]%.so*}.so.1 # soname not in .manifest
+
+		printf -v m[1] %o $((m[1] | 0200)) # 444->644
+		insopts -m${m[1]}
+		insinto ${into}
+		doins ${m[0]}
+	done < .manifest || die
+
+	# MODULE:installer non-skipped extras
+	exeinto /lib/systemd/system-sleep
+	doexe nvidia
+	dobin nvidia-sleep.sh
+	systemd_dounit nvidia-{hibernate,resume,suspend}.service
+
+	dobin nvidia-bug-report.sh
+}
+
+pkg_preinst() {
+	has_version "${CATEGORY}/${PN}[abi_x86_32]" && NV_HAD_ABI32=
+
+	use driver || return
+	linux-mod_pkg_preinst
+
+	# set video group id based on live system (bug #491414)
+	local g=$(getent group video | cut -d: -f3)
+	[[ ${g} ]] || die "Failed to determine video group id"
+	sed -i "s/@VIDEOGID@/${g}/" "${ED}"/etc/modprobe.d/nvidia.conf || die
+
+	# try to find driver mismatches using temporary supported-gpus.json
+	for g in $(grep -l 0x10de /sys/bus/pci/devices/*/vendor 2>/dev/null); do
+		g=$(grep -io "\"devid\":\"$(<${g%vendor}device)\"[^}]*branch\":\"[0-9]*" \
+			"${ED}"/usr/share/nvidia/supported-gpus.json 2>/dev/null)
+		if [[ ${g} ]]; then
+			g=$((${g##*\"}+1))
+			if ver_test -ge ${g}; then
+				NV_LEGACY_MASK=">=${CATEGORY}/${PN}-${g}"
+				break
+			fi
+		fi
+	done
+	rm "${ED}"/usr/share/nvidia/supported-gpus.json || die
+}
+
+pkg_postinst() {
+	use driver && linux-mod_pkg_postinst
+
+	readme.gentoo_print_elog
+
+	if [[ -r /proc/driver/nvidia/version &&
+		$(</proc/driver/nvidia/version) != *"  ${PV}  "* ]]; then
+		ewarn "Currently loaded NVIDIA modules do not match the newly installed"
+		ewarn "libraries and may prevent launching GPU-accelerated applications."
+		use driver && ewarn "The easiest way to fix this is usually to reboot."
+	fi
+
+	if [[ -v NV_LEGACY_MASK ]]; then
+		ewarn
+		ewarn "***WARNING***"
+		ewarn
+		ewarn "You are installing a version of ${PN} known not to work"
+		ewarn "with a GPU of the current system. If unwanted, add the mask:"
+		if [[ -d ${EROOT}/etc/portage/package.mask ]]; then
+			ewarn "  echo '${NV_LEGACY_MASK}' > ${EROOT}/etc/portage/package.mask/${PN}"
+		else
+			ewarn "  echo '${NV_LEGACY_MASK}' >> ${EROOT}/etc/portage/package.mask"
+		fi
+		ewarn "...then downgrade to a legacy branch if possible. For details, see:"
+		ewarn "https://www.nvidia.com/object/IO_32667.html"
+	fi
+
+	if use !abi_x86_32 && [[ -v NV_HAD_ABI32 ]]; then
+		elog
+		elog "USE=abi_x86_32 is disabled, 32bit applications will not be able to"
+		elog "use nvidia-drivers for acceleration without it (e.g. commonly used"
+		elog "with app-emulation/wine-* or steam). Re-enable if needed."
+	fi
+
+	# Try to show this message only to users that may really need it
+	# given the workaround is discouraged and usage isn't widespread.
+	if use X && [[ ${REPLACING_VERSIONS} ]] &&
+		ver_test ${REPLACING_VERSIONS} -lt 460.73.01 &&
+		grep -qr Coolbits "${EROOT}"/etc/X11/{xorg.conf,xorg.conf.d/*.conf} 2>/dev/null; then
+		elog
+		elog "Coolbits support with ${PN} has been restricted to require Xorg"
+		elog "with root privilege by NVIDIA (being in video group is not sufficient)."
+		elog "e.g. attempting to change fan speed with nvidia-settings would fail."
+		elog
+		elog "Depending on your display manager (e.g. sddm starts X as root, gdm doesn't)"
+		elog "or if using startx, it may be necessary to emerge x11-base/xorg-server with"
+		elog 'USE="suid -elogind -systemd" if wish to keep using this feature.'
+		elog "Bug: https://bugs.gentoo.org/784248"
+	fi
+}

--- a/x11-drivers/nvidia-drivers/nvidia-drivers-470.62.13-r100.ebuild
+++ b/x11-drivers/nvidia-drivers/nvidia-drivers-470.62.13-r100.ebuild
@@ -4,7 +4,8 @@
 EAPI=7
 
 MODULES_OPTIONAL_USE="driver"
-inherit desktop linux-mod readme.gentoo-r1 systemd toolchain-funcs unpacker
+inherit desktop flag-o-matic linux-mod multilib readme.gentoo-r1 \
+	systemd toolchain-funcs unpacker
 
 NV_KERNEL_MAX="5.15"
 NV_URI="https://download.nvidia.com/XFree86/"
@@ -76,6 +77,7 @@ QA_PREBUILT="lib/firmware/* opt/bin/* usr/lib*"
 
 PATCHES=(
 	"${FILESDIR}"/nvidia-modprobe-390.141-uvm-perms.patch
+	"${FILESDIR}"/nvidia-settings-390.144-raw-ldflags.patch
 )
 
 pkg_setup() {
@@ -186,8 +188,10 @@ src_compile() {
 	use X && emake "${NV_ARGS[@]}" -C nvidia-xconfig
 
 	if use tools; then
-		# avoid filling up logs, only use here and set first to allow override
+		# cflags: avoid noisy logs, only use here and set first to let override
+		# ldflags: abi currently needed if LD=ld.lld
 		CFLAGS="-Wno-deprecated-declarations ${CFLAGS}" \
+			RAW_LDFLAGS="$(get_abi_LDFLAGS) $(raw-ldflags)" \
 			emake "${NV_ARGS[@]}" -C nvidia-settings
 	elif use static-libs; then
 		emake "${NV_ARGS[@]}" -C nvidia-settings/src out/libXNVCtrl.a

--- a/x11-drivers/nvidia-drivers/nvidia-drivers-470.62.13-r100.ebuild
+++ b/x11-drivers/nvidia-drivers/nvidia-drivers-470.62.13-r100.ebuild
@@ -22,12 +22,14 @@ S="${WORKDIR}"
 LICENSE="NVIDIA-r2 BSD BSD-2 GPL-2 MIT ZLIB curl openssl"
 SLOT="0/vulkan"
 KEYWORDS="-* ~amd64"
-IUSE="+X abi_x86_32 abi_x86_64 +driver static-libs +tools wayland"
+IUSE="+X abi_x86_32 abi_x86_64 +driver persistenced static-libs +tools wayland"
 
 COMMON_DEPEND="
 	acct-group/video
-	acct-user/nvpd
-	net-libs/libtirpc:=
+	persistenced? (
+		acct-user/nvpd
+		net-libs/libtirpc:=
+	)
 	tools? (
 		dev-libs/atk
 		dev-libs/glib:2
@@ -180,7 +182,7 @@ src_compile() {
 	use driver && linux-mod_src_compile
 
 	emake "${NV_ARGS[@]}" -C nvidia-modprobe
-	emake "${NV_ARGS[@]}" -C nvidia-persistenced
+	use persistenced && emake "${NV_ARGS[@]}" -C nvidia-persistenced
 	use X && emake "${NV_ARGS[@]}" -C nvidia-xconfig
 
 	if use tools; then
@@ -266,18 +268,17 @@ https://wiki.gentoo.org/wiki/NVIDIA/nvidia-drivers"
 		doins supported-gpus/supported-gpus.json
 	fi
 
-	# nvidia-modprobe
 	emake "${NV_ARGS[@]}" -C nvidia-modprobe install
 	fowners :video /usr/bin/nvidia-modprobe #505092
 	fperms 4710 /usr/bin/nvidia-modprobe
 
-	# nvidia-persistenced
-	emake "${NV_ARGS[@]}" -C nvidia-persistenced install
-	newconfd "${FILESDIR}"/nvidia-persistenced.confd nvidia-persistenced
-	newinitd "${FILESDIR}"/nvidia-persistenced.initd nvidia-persistenced
-	systemd_dounit "${T}"/nvidia-persistenced.service
+	if use persistenced; then
+		emake "${NV_ARGS[@]}" -C nvidia-persistenced install
+		newconfd "${FILESDIR}"/nvidia-persistenced.confd nvidia-persistenced
+		newinitd "${FILESDIR}"/nvidia-persistenced.initd nvidia-persistenced
+		systemd_dounit "${T}"/nvidia-persistenced.service
+	fi
 
-	# nvidia-settings
 	if use tools; then
 		emake "${NV_ARGS[@]}" -C nvidia-settings install
 
@@ -295,7 +296,6 @@ https://wiki.gentoo.org/wiki/NVIDIA/nvidia-drivers"
 		doins nvidia-settings/src/libXNVCtrl/NVCtrl{Lib,}.h
 	fi
 
-	# nvidia-xconfig
 	use X && emake "${NV_ARGS[@]}" -C nvidia-xconfig install
 
 	# mimic nvidia-installer by reading .manifest to install files

--- a/x11-drivers/nvidia-drivers/nvidia-drivers-470.62.13-r100.ebuild
+++ b/x11-drivers/nvidia-drivers/nvidia-drivers-470.62.13-r100.ebuild
@@ -1,0 +1,451 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+MODULES_OPTIONAL_USE="driver"
+inherit desktop linux-mod readme.gentoo-r1 systemd toolchain-funcs unpacker
+
+NV_KERNEL_MAX="5.15"
+NV_URI="https://download.nvidia.com/XFree86/"
+NV_PIN="470.86"
+
+DESCRIPTION="NVIDIA Accelerated Graphics Driver"
+HOMEPAGE="https://developer.nvidia.com/vulkan-driver"
+SRC_URI="
+	https://developer.nvidia.com/vulkan-beta-${PV//.}-linux -> NVIDIA-Linux-x86_64-${PV}.run
+	$(printf "${NV_URI}%s/%s-${NV_PIN}.tar.bz2 " \
+		nvidia-{installer,modprobe,persistenced,settings,xconfig}{,})"
+# nvidia-installer is unused but here for GPL-2's "distribute sources"
+S="${WORKDIR}"
+
+LICENSE="NVIDIA-r2 BSD BSD-2 GPL-2 MIT ZLIB curl openssl"
+SLOT="0/vulkan"
+KEYWORDS="-* ~amd64"
+IUSE="+X abi_x86_32 abi_x86_64 +driver static-libs +tools wayland"
+
+COMMON_DEPEND="
+	acct-group/video
+	acct-user/nvpd
+	net-libs/libtirpc:=
+	tools? (
+		dev-libs/atk
+		dev-libs/glib:2
+		dev-libs/jansson:=
+		media-libs/harfbuzz:=
+		x11-libs/cairo
+		x11-libs/gdk-pixbuf:2
+		x11-libs/gtk+:3
+		x11-libs/libX11
+		x11-libs/libXext
+		x11-libs/libXxf86vm
+		x11-libs/pango
+	)"
+RDEPEND="
+	${COMMON_DEPEND}
+	X? (
+		media-libs/libglvnd[X,abi_x86_32(-)?]
+		x11-libs/libX11[abi_x86_32(-)?]
+		x11-libs/libXext[abi_x86_32(-)?]
+	)
+	wayland? (
+		>=gui-libs/egl-wayland-1.1.7-r1
+		media-libs/libglvnd
+	)"
+DEPEND="
+	${COMMON_DEPEND}
+	static-libs? (
+		x11-libs/libX11
+		x11-libs/libXext
+	)
+	tools? (
+		media-libs/libglvnd
+		sys-apps/dbus
+		x11-base/xorg-proto
+		x11-libs/libXrandr
+		x11-libs/libXv
+		x11-libs/libvdpau
+	)"
+BDEPEND="
+	sys-devel/m4
+	virtual/pkgconfig"
+
+QA_PREBUILT="lib/firmware/* opt/bin/* usr/lib*"
+
+PATCHES=(
+	"${FILESDIR}"/nvidia-modprobe-390.141-uvm-perms.patch
+)
+
+pkg_setup() {
+	use driver || return
+
+	local CONFIG_CHECK="
+		PROC_FS
+		~DRM_KMS_HELPER
+		~SYSVIPC
+		~!DRM_SIMPLEDRM
+		~!LOCKDEP
+		~!SLUB_DEBUG_ON
+		!DEBUG_MUTEXES"
+	local ERROR_DRM_KMS_HELPER="CONFIG_DRM_KMS_HELPER: is not set but needed for Xorg auto-detection
+	of drivers (no custom config), and for wayland / nvidia-drm.modeset=1.
+	Cannot be directly selected in the kernel's menuconfig, and may need
+	selection of a DRM device even if unused, e.g. CONFIG_DRM_AMDGPU=m or
+	DRM_I915=y, DRM_NOUVEAU=m also acceptable if a module and not built-in.
+	Note: DRM_SIMPLEDRM may cause issues and is better disabled for now."
+
+	use amd64 && kernel_is -ge 5 8 && CONFIG_CHECK+=" X86_PAT" #817764
+
+	MODULE_NAMES="
+		nvidia(video:kernel)
+		nvidia-drm(video:kernel)
+		nvidia-modeset(video:kernel)
+		nvidia-peermem(video:kernel)
+		nvidia-uvm(video:kernel)"
+
+	linux-mod_pkg_setup
+
+	[[ ${MERGE_TYPE} == binary ]] && return
+
+	BUILD_PARAMS='NV_VERBOSE=1 IGNORE_CC_MISMATCH=yes SYSSRC="${KV_DIR}" SYSOUT="${KV_OUT_DIR}"'
+	BUILD_TARGETS="modules"
+
+	if linux_chkconfig_present CC_IS_CLANG; then
+		ewarn "Warning: building ${PN} with a clang-built kernel is experimental"
+
+		BUILD_PARAMS+=' CC=${CHOST}-clang'
+		if linux_chkconfig_present LD_IS_LLD; then
+			BUILD_PARAMS+=' LD=ld.lld'
+			if linux_chkconfig_present LTO_CLANG_THIN; then
+				# kernel enables cache by default leading to sandbox violations
+				BUILD_PARAMS+=' ldflags-y=--thinlto-cache-dir= LDFLAGS_MODULE=--thinlto-cache-dir='
+			fi
+		fi
+	fi
+
+	if kernel_is -gt ${NV_KERNEL_MAX/./ }; then
+		ewarn "Kernel ${KV_MAJOR}.${KV_MINOR} is either known to break this version of ${PN}"
+		ewarn "or was not tested with it. It is recommended to use one of:"
+		ewarn "  <=sys-kernel/gentoo-kernel-${NV_KERNEL_MAX}"
+		ewarn "  <=sys-kernel/gentoo-sources-${NV_KERNEL_MAX}"
+		ewarn "You are free to try or use /etc/portage/patches, but support will"
+		ewarn "not be given and issues wait until NVIDIA releases a fixed version."
+		ewarn
+		ewarn "Do _not_ file a bug report if run into issues."
+		ewarn
+	fi
+}
+
+src_prepare() {
+	# make patches usable across versions
+	rm nvidia-modprobe && mv nvidia-modprobe{-${NV_PIN},} || die
+	rm nvidia-persistenced && mv nvidia-persistenced{-${NV_PIN},} || die
+	rm nvidia-settings && mv nvidia-settings{-${NV_PIN},} || die
+	rm nvidia-xconfig && mv nvidia-xconfig{-${NV_PIN},} || die
+
+	default
+
+	# prevent detection of incomplete kernel DRM support (bug #603818)
+	sed 's/defined(CONFIG_DRM/defined(CONFIG_DRM_KMS_HELPER/g' \
+		-i kernel/conftest.sh || die
+
+	sed -e '/Exec=\|Icon=/s/_.*/nvidia-settings/' \
+		-e '/Categories=/s/_.*/System;HardwareSettings;/' \
+		-i nvidia-settings/doc/nvidia-settings.desktop || die
+
+	# remove gtk2 support (bug #592730)
+	sed '/^GTK2LIB = /d;/INSTALL.*GTK2LIB/,+1d' \
+		-i nvidia-settings/src/Makefile || die
+
+	sed 's/__USER__/nvpd/' \
+		nvidia-persistenced/init/systemd/nvidia-persistenced.service.template \
+		> "${T}"/nvidia-persistenced.service || die
+
+	# enable nvidia-drm.modeset=1 by default with USE=wayland
+	cp "${FILESDIR}"/nvidia-470.conf "${T}"/nvidia.conf || die
+	use !wayland || sed -i '/^#.*modeset=1$/s/^#//' "${T}"/nvidia.conf || die
+}
+
+src_compile() {
+	tc-export AR CC LD OBJCOPY
+
+	NV_ARGS=(
+		PREFIX="${EPREFIX}"/usr
+		HOST_CC="$(tc-getBUILD_CC)"
+		HOST_LD="$(tc-getBUILD_LD)"
+		NV_USE_BUNDLED_LIBJANSSON=0
+		NV_VERBOSE=1 DO_STRIP= MANPAGE_GZIP= OUTPUTDIR=out
+	)
+
+	use driver && linux-mod_src_compile
+
+	emake "${NV_ARGS[@]}" -C nvidia-modprobe
+	emake "${NV_ARGS[@]}" -C nvidia-persistenced
+	use X && emake "${NV_ARGS[@]}" -C nvidia-xconfig
+
+	if use tools; then
+		# avoid filling up logs, only use here and set first to allow override
+		CFLAGS="-Wno-deprecated-declarations ${CFLAGS}" \
+			emake "${NV_ARGS[@]}" -C nvidia-settings
+	elif use static-libs; then
+		emake "${NV_ARGS[@]}" -C nvidia-settings/src out/libXNVCtrl.a
+	fi
+}
+
+src_install() {
+	local libdir=$(get_libdir) libdir32=$(ABI=x86 get_libdir)
+
+	NV_ARGS+=( DESTDIR="${D}" LIBDIR="${ED}"/usr/${libdir} )
+
+	local -A paths=(
+		[APPLICATION_PROFILE]=/usr/share/nvidia
+		[CUDA_ICD]=/etc/OpenCL/vendors
+		[EGL_EXTERNAL_PLATFORM_JSON]=/usr/share/egl/egl_external_platform.d
+		[FIRMWARE]=/lib/firmware/nvidia/${PV}
+		[GLVND_EGL_ICD_JSON]=/usr/share/glvnd/egl_vendor.d
+		[VULKAN_ICD_JSON]=/usr/share/vulkan
+		[WINE_LIB]=/usr/${libdir}/nvidia/wine
+		[XORG_OUTPUTCLASS_CONFIG]=/usr/share/X11/xorg.conf.d
+
+		[GLX_MODULE_SHARED_LIB]=/usr/${libdir}/xorg/modules/extensions
+		[GLX_MODULE_SYMLINK]=/usr/${libdir}/xorg/modules
+		[XMODULE_SHARED_LIB]=/usr/${libdir}/xorg/modules
+	)
+
+	local skip_files=(
+		$(usex X '' '
+			libGLX_nvidia libglxserver_nvidia
+			libnvidia-ifr
+			nvidia_icd.json nvidia_layers.json')
+		$(usex wayland '' 'libnvidia-vulkan-producer')
+		libGLX_indirect # non-glvnd unused fallback
+		libnvidia-gtk nvidia-{settings,xconfig} # built from source
+		libnvidia-egl-wayland 10_nvidia_wayland # gui-libs/egl-wayland
+	)
+	local skip_modules=(
+		$(usex X '' 'nvfbc vdpau xdriver')
+		$(usex driver '' 'gsp')
+		installer nvpd # handled separately / built from source
+	)
+	local skip_types=(
+		GLVND_LIB GLVND_SYMLINK EGL_CLIENT.\* GLX_CLIENT.\* # media-libs/libglvnd
+		OPENCL_WRAPPER.\* # virtual/opencl
+		DOCUMENTATION DOT_DESKTOP .\*_SRC DKMS_CONF # handled separately / unused
+	)
+
+	local DOCS=(
+		README.txt NVIDIA_Changelog supported-gpus/supported-gpus.json
+		nvidia-settings/doc/{FRAMELOCK,NV-CONTROL-API}.txt
+	)
+	local HTML_DOCS=( html/. )
+	einstalldocs
+
+	local DISABLE_AUTOFORMATTING=yes
+	local DOC_CONTENTS="\
+Trusted users should be in the 'video' group to use NVIDIA devices.
+You can add yourself by using: gpasswd -a my-user video
+
+See '${EPREFIX}/etc/modprobe.d/nvidia.conf' for modules options.\
+$(use amd64 && usex abi_x86_32 '' "
+
+Note that without USE=abi_x86_32 on ${PN}, 32bit applications
+(typically using wine / steam) will not be able to use GPU acceleration.")
+
+For general information on using ${PN}, please see:
+https://wiki.gentoo.org/wiki/NVIDIA/nvidia-drivers"
+	readme.gentoo_create_doc
+
+	if use driver; then
+		linux-mod_src_install
+
+		insinto /etc/modprobe.d
+		doins "${T}"/nvidia.conf
+
+		# used for gpu verification with binpkgs (not kept, see pkg_preinst)
+		insinto /usr/share/nvidia
+		doins supported-gpus/supported-gpus.json
+	fi
+
+	# nvidia-modprobe
+	emake "${NV_ARGS[@]}" -C nvidia-modprobe install
+	fowners :video /usr/bin/nvidia-modprobe #505092
+	fperms 4710 /usr/bin/nvidia-modprobe
+
+	# nvidia-persistenced
+	emake "${NV_ARGS[@]}" -C nvidia-persistenced install
+	newconfd "${FILESDIR}"/nvidia-persistenced.confd nvidia-persistenced
+	newinitd "${FILESDIR}"/nvidia-persistenced.initd nvidia-persistenced
+	systemd_dounit "${T}"/nvidia-persistenced.service
+
+	# nvidia-settings
+	if use tools; then
+		emake "${NV_ARGS[@]}" -C nvidia-settings install
+
+		doicon nvidia-settings/doc/nvidia-settings.png
+		domenu nvidia-settings/doc/nvidia-settings.desktop
+
+		exeinto /etc/X11/xinit/xinitrc.d
+		newexe "${FILESDIR}"/95-nvidia-settings-r1 95-nvidia-settings
+	fi
+
+	if use static-libs; then
+		dolib.a nvidia-settings/src/out/libXNVCtrl.a
+
+		insinto /usr/include/NVCtrl
+		doins nvidia-settings/src/libXNVCtrl/NVCtrl{Lib,}.h
+	fi
+
+	# nvidia-xconfig
+	use X && emake "${NV_ARGS[@]}" -C nvidia-xconfig install
+
+	# mimic nvidia-installer by reading .manifest to install files
+	# 0:file 1:perms 2:type 3+:subtype/arguments -:module
+	local m into
+	while IFS=' ' read -ra m; do
+		! [[ ${#m[@]} -ge 2 && ${m[-1]} =~ MODULE: ]] ||
+			eval '[[ " ${m[0]##*/}" =~ ^(\ '${skip_files[*]/%/.*|\\}' )$ ]]' ||
+			eval '[[ " ${m[2]}" =~ ^(\ '${skip_types[*]/%/|\\}' )$ ]]' ||
+			has ${m[-1]#MODULE:} "${skip_modules[@]}" && continue
+
+		case ${m[2]} in
+			MANPAGE)
+				gzip -dc ${m[0]} | newman - ${m[0]%.gz}; assert
+				continue
+			;;
+			VDPAU_SYMLINK) m[4]=vdpau/; m[5]=${m[5]#vdpau/};; # .so to vdpau/
+		esac
+
+		if [[ -v paths[${m[2]}] ]]; then
+			into=${paths[${m[2]}]}
+		elif [[ ${m[2]} =~ _BINARY$ ]]; then
+			into=/opt/bin
+		elif [[ ${m[3]} == COMPAT32 ]]; then
+			use abi_x86_32 || continue
+			into=/usr/${libdir32}
+		elif [[ ${m[2]} =~ _LIB$|_SYMLINK$ ]]; then
+			into=/usr/${libdir}
+		else
+			die "No known installation path for ${m[0]}"
+		fi
+		[[ ${m[3]: -2} == ?/ ]] && into+=/${m[3]%/}
+		[[ ${m[4]: -2} == ?/ ]] && into+=/${m[4]%/}
+
+		if [[ ${m[2]} =~ _SYMLINK$ ]]; then
+			[[ ${m[4]: -1} == / ]] && m[4]=${m[5]}
+			dosym ${m[4]} ${into}/${m[0]}
+			continue
+		fi
+		[[ ${m[0]} =~ ^libnvidia-ngx.so ]] &&
+			dosym ${m[0]} ${into}/${m[0]%.so*}.so.1 # soname not in .manifest
+
+		printf -v m[1] %o $((m[1] | 0200)) # 444->644
+		insopts -m${m[1]}
+		insinto ${into}
+		doins ${m[0]}
+	done < .manifest || die
+
+	# MODULE:installer non-skipped extras
+	exeinto /lib/systemd/system-sleep
+	doexe systemd/system-sleep/nvidia
+	dobin systemd/nvidia-sleep.sh
+	systemd_dounit systemd/system/nvidia-{hibernate,resume,suspend}.service
+
+	dobin nvidia-bug-report.sh
+}
+
+pkg_preinst() {
+	has_version "${CATEGORY}/${PN}[abi_x86_32]" && NV_HAD_ABI32=
+	has_version "${CATEGORY}/${PN}[wayland]" && NV_HAD_WAYLAND=
+
+	use driver || return
+	linux-mod_pkg_preinst
+
+	# set video group id based on live system (bug #491414)
+	local g=$(getent group video | cut -d: -f3)
+	[[ ${g} ]] || die "Failed to determine video group id"
+	sed -i "s/@VIDEOGID@/${g}/" "${ED}"/etc/modprobe.d/nvidia.conf || die
+
+	# try to find driver mismatches using temporary supported-gpus.json
+	for g in $(grep -l 0x10de /sys/bus/pci/devices/*/vendor 2>/dev/null); do
+		g=$(grep -io "\"devid\":\"$(<${g%vendor}device)\"[^}]*branch\":\"[0-9]*" \
+			"${ED}"/usr/share/nvidia/supported-gpus.json 2>/dev/null)
+		if [[ ${g} ]]; then
+			g=$((${g##*\"}+1))
+			if ver_test -ge ${g}; then
+				NV_LEGACY_MASK=">=${CATEGORY}/${PN}-${g}"
+				break
+			fi
+		fi
+	done
+	rm "${ED}"/usr/share/nvidia/supported-gpus.json || die
+}
+
+pkg_postinst() {
+	use driver && linux-mod_pkg_postinst
+
+	readme.gentoo_print_elog
+
+	if [[ -r /proc/driver/nvidia/version &&
+		$(</proc/driver/nvidia/version) != *"  ${PV}  "* ]]; then
+		ewarn "Currently loaded NVIDIA modules do not match the newly installed"
+		ewarn "libraries and may prevent launching GPU-accelerated applications."
+		use driver && ewarn "The easiest way to fix this is usually to reboot."
+	fi
+
+	if [[ $(</proc/cmdline) == *slub_debug=[!-]* ]]; then
+		ewarn "Detected that the current kernel command line is using 'slub_debug=',"
+		ewarn "this may lead to system instability/freezes with this version of"
+		ewarn "${PN}. Bug: https://bugs.gentoo.org/796329"
+	fi
+
+	if [[ -v NV_LEGACY_MASK ]]; then
+		ewarn
+		ewarn "***WARNING***"
+		ewarn
+		ewarn "You are installing a version of ${PN} known not to work"
+		ewarn "with a GPU of the current system. If unwanted, add the mask:"
+		if [[ -d ${EROOT}/etc/portage/package.mask ]]; then
+			ewarn "  echo '${NV_LEGACY_MASK}' > ${EROOT}/etc/portage/package.mask/${PN}"
+		else
+			ewarn "  echo '${NV_LEGACY_MASK}' >> ${EROOT}/etc/portage/package.mask"
+		fi
+		ewarn "...then downgrade to a legacy branch if possible. For details, see:"
+		ewarn "https://www.nvidia.com/object/IO_32667.html"
+	fi
+
+	if use !abi_x86_32 && [[ -v NV_HAD_ABI32 ]]; then
+		elog
+		elog "USE=abi_x86_32 is disabled, 32bit applications will not be able to"
+		elog "use nvidia-drivers for acceleration without it (e.g. commonly used"
+		elog "with app-emulation/wine-* or steam). Re-enable if needed."
+	fi
+
+	if use wayland && use driver && [[ ! -v NV_HAD_WAYLAND ]]; then
+		elog
+		elog "With USE=wayland, this version of ${PN} sets nvidia-drm.modeset=1"
+		elog "in '${EROOT}/etc/modprobe.d/nvidia.conf'. This feature is considered"
+		elog "experimental but is required for wayland."
+		elog
+		elog "If you experience issues, either disable wayland or edit nvidia.conf."
+		elog "Of note, may possibly cause issues with SLI and Reverse PRIME."
+		elog
+		elog "This version of ${PN} only supports EGLStream which is only"
+		elog "supported by a few wayland compositors (e.g. kwin / mutter, not sway)."
+	fi
+
+	# Try to show this message only to users that may really need it
+	# given the workaround is discouraged and usage isn't widespread.
+	if use X && [[ ${REPLACING_VERSIONS} ]] &&
+		ver_test ${REPLACING_VERSIONS} -lt 460.73.01 &&
+		grep -qr Coolbits "${EROOT}"/etc/X11/{xorg.conf,xorg.conf.d/*.conf} 2>/dev/null; then
+		elog
+		elog "Coolbits support with ${PN} has been restricted to require Xorg"
+		elog "with root privilege by NVIDIA (being in video group is not sufficient)."
+		elog "e.g. attempting to change fan speed with nvidia-settings would fail."
+		elog
+		elog "Depending on your display manager (e.g. sddm starts X as root, gdm doesn't)"
+		elog "or if using startx, it may be necessary to emerge x11-base/xorg-server with"
+		elog 'USE="suid -elogind -systemd" if wish to keep using this feature.'
+		elog "Bug: https://bugs.gentoo.org/784248"
+	fi
+}

--- a/x11-drivers/nvidia-drivers/nvidia-drivers-470.62.13-r100.ebuild
+++ b/x11-drivers/nvidia-drivers/nvidia-drivers-470.62.13-r100.ebuild
@@ -77,6 +77,8 @@ QA_PREBUILT="lib/firmware/* opt/bin/* usr/lib*"
 
 PATCHES=(
 	"${FILESDIR}"/nvidia-modprobe-390.141-uvm-perms.patch
+	"${FILESDIR}"/nvidia-settings-390.144-desktop.patch
+	"${FILESDIR}"/nvidia-settings-390.144-no-gtk2.patch
 	"${FILESDIR}"/nvidia-settings-390.144-raw-ldflags.patch
 )
 
@@ -152,14 +154,6 @@ src_prepare() {
 	# prevent detection of incomplete kernel DRM support (bug #603818)
 	sed 's/defined(CONFIG_DRM/defined(CONFIG_DRM_KMS_HELPER/g' \
 		-i kernel/conftest.sh || die
-
-	sed -e '/Exec=\|Icon=/s/_.*/nvidia-settings/' \
-		-e '/Categories=/s/_.*/System;HardwareSettings;/' \
-		-i nvidia-settings/doc/nvidia-settings.desktop || die
-
-	# remove gtk2 support (bug #592730)
-	sed '/^GTK2LIB = /d;/INSTALL.*GTK2LIB/,+1d' \
-		-i nvidia-settings/src/Makefile || die
 
 	sed 's/__USER__/nvpd/' \
 		nvidia-persistenced/init/systemd/nvidia-persistenced.service.template \

--- a/x11-drivers/nvidia-drivers/nvidia-drivers-470.86-r100.ebuild
+++ b/x11-drivers/nvidia-drivers/nvidia-drivers-470.86-r100.ebuild
@@ -4,7 +4,8 @@
 EAPI=7
 
 MODULES_OPTIONAL_USE="driver"
-inherit desktop linux-mod readme.gentoo-r1 systemd toolchain-funcs unpacker
+inherit desktop flag-o-matic linux-mod multilib readme.gentoo-r1 \
+	systemd toolchain-funcs unpacker
 
 NV_KERNEL_MAX="5.15"
 NV_URI="https://download.nvidia.com/XFree86/"
@@ -76,6 +77,7 @@ QA_PREBUILT="lib/firmware/* opt/bin/* usr/lib*"
 
 PATCHES=(
 	"${FILESDIR}"/nvidia-modprobe-390.141-uvm-perms.patch
+	"${FILESDIR}"/nvidia-settings-390.144-raw-ldflags.patch
 )
 
 pkg_setup() {
@@ -186,8 +188,10 @@ src_compile() {
 	use X && emake "${NV_ARGS[@]}" -C nvidia-xconfig
 
 	if use tools; then
-		# avoid filling up logs, only use here and set first to allow override
+		# cflags: avoid noisy logs, only use here and set first to let override
+		# ldflags: abi currently needed if LD=ld.lld
 		CFLAGS="-Wno-deprecated-declarations ${CFLAGS}" \
+			RAW_LDFLAGS="$(get_abi_LDFLAGS) $(raw-ldflags)" \
 			emake "${NV_ARGS[@]}" -C nvidia-settings
 	elif use static-libs; then
 		emake "${NV_ARGS[@]}" -C nvidia-settings/src out/libXNVCtrl.a

--- a/x11-drivers/nvidia-drivers/nvidia-drivers-470.86-r100.ebuild
+++ b/x11-drivers/nvidia-drivers/nvidia-drivers-470.86-r100.ebuild
@@ -1,0 +1,451 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+MODULES_OPTIONAL_USE="driver"
+inherit desktop linux-mod readme.gentoo-r1 systemd toolchain-funcs unpacker
+
+NV_KERNEL_MAX="5.15"
+NV_URI="https://download.nvidia.com/XFree86/"
+
+DESCRIPTION="NVIDIA Accelerated Graphics Driver"
+HOMEPAGE="https://www.nvidia.com/download/index.aspx"
+SRC_URI="
+	amd64? ( ${NV_URI}Linux-x86_64/${PV}/NVIDIA-Linux-x86_64-${PV}.run )
+	arm64? ( ${NV_URI}Linux-aarch64/${PV}/NVIDIA-Linux-aarch64-${PV}.run )
+	$(printf "${NV_URI}%s/%s-${PV}.tar.bz2 " \
+		nvidia-{installer,modprobe,persistenced,settings,xconfig}{,})"
+# nvidia-installer is unused but here for GPL-2's "distribute sources"
+S="${WORKDIR}"
+
+LICENSE="NVIDIA-r2 BSD BSD-2 GPL-2 MIT ZLIB curl openssl"
+SLOT="0/${PV%%.*}"
+KEYWORDS="-* ~amd64"
+IUSE="+X abi_x86_32 abi_x86_64 +driver static-libs +tools wayland"
+
+COMMON_DEPEND="
+	acct-group/video
+	acct-user/nvpd
+	net-libs/libtirpc:=
+	tools? (
+		dev-libs/atk
+		dev-libs/glib:2
+		dev-libs/jansson:=
+		media-libs/harfbuzz:=
+		x11-libs/cairo
+		x11-libs/gdk-pixbuf:2
+		x11-libs/gtk+:3
+		x11-libs/libX11
+		x11-libs/libXext
+		x11-libs/libXxf86vm
+		x11-libs/pango
+	)"
+RDEPEND="
+	${COMMON_DEPEND}
+	X? (
+		media-libs/libglvnd[X,abi_x86_32(-)?]
+		x11-libs/libX11[abi_x86_32(-)?]
+		x11-libs/libXext[abi_x86_32(-)?]
+	)
+	wayland? (
+		>=gui-libs/egl-wayland-1.1.7-r1
+		media-libs/libglvnd
+	)"
+DEPEND="
+	${COMMON_DEPEND}
+	static-libs? (
+		x11-libs/libX11
+		x11-libs/libXext
+	)
+	tools? (
+		media-libs/libglvnd
+		sys-apps/dbus
+		x11-base/xorg-proto
+		x11-libs/libXrandr
+		x11-libs/libXv
+		x11-libs/libvdpau
+	)"
+BDEPEND="
+	sys-devel/m4
+	virtual/pkgconfig"
+
+QA_PREBUILT="lib/firmware/* opt/bin/* usr/lib*"
+
+PATCHES=(
+	"${FILESDIR}"/nvidia-modprobe-390.141-uvm-perms.patch
+)
+
+pkg_setup() {
+	use driver || return
+
+	local CONFIG_CHECK="
+		PROC_FS
+		~DRM_KMS_HELPER
+		~SYSVIPC
+		~!DRM_SIMPLEDRM
+		~!LOCKDEP
+		~!SLUB_DEBUG_ON
+		!DEBUG_MUTEXES"
+	local ERROR_DRM_KMS_HELPER="CONFIG_DRM_KMS_HELPER: is not set but needed for Xorg auto-detection
+	of drivers (no custom config), and for wayland / nvidia-drm.modeset=1.
+	Cannot be directly selected in the kernel's menuconfig, and may need
+	selection of a DRM device even if unused, e.g. CONFIG_DRM_AMDGPU=m or
+	DRM_I915=y, DRM_NOUVEAU=m also acceptable if a module and not built-in.
+	Note: DRM_SIMPLEDRM may cause issues and is better disabled for now."
+
+	use amd64 && kernel_is -ge 5 8 && CONFIG_CHECK+=" X86_PAT" #817764
+
+	MODULE_NAMES="
+		nvidia(video:kernel)
+		nvidia-drm(video:kernel)
+		nvidia-modeset(video:kernel)
+		nvidia-peermem(video:kernel)
+		nvidia-uvm(video:kernel)"
+
+	linux-mod_pkg_setup
+
+	[[ ${MERGE_TYPE} == binary ]] && return
+
+	BUILD_PARAMS='NV_VERBOSE=1 IGNORE_CC_MISMATCH=yes SYSSRC="${KV_DIR}" SYSOUT="${KV_OUT_DIR}"'
+	BUILD_TARGETS="modules"
+
+	if linux_chkconfig_present CC_IS_CLANG; then
+		ewarn "Warning: building ${PN} with a clang-built kernel is experimental"
+
+		BUILD_PARAMS+=' CC=${CHOST}-clang'
+		if linux_chkconfig_present LD_IS_LLD; then
+			BUILD_PARAMS+=' LD=ld.lld'
+			if linux_chkconfig_present LTO_CLANG_THIN; then
+				# kernel enables cache by default leading to sandbox violations
+				BUILD_PARAMS+=' ldflags-y=--thinlto-cache-dir= LDFLAGS_MODULE=--thinlto-cache-dir='
+			fi
+		fi
+	fi
+
+	if kernel_is -gt ${NV_KERNEL_MAX/./ }; then
+		ewarn "Kernel ${KV_MAJOR}.${KV_MINOR} is either known to break this version of ${PN}"
+		ewarn "or was not tested with it. It is recommended to use one of:"
+		ewarn "  <=sys-kernel/gentoo-kernel-${NV_KERNEL_MAX}"
+		ewarn "  <=sys-kernel/gentoo-sources-${NV_KERNEL_MAX}"
+		ewarn "You are free to try or use /etc/portage/patches, but support will"
+		ewarn "not be given and issues wait until NVIDIA releases a fixed version."
+		ewarn
+		ewarn "Do _not_ file a bug report if run into issues."
+		ewarn
+	fi
+}
+
+src_prepare() {
+	# make patches usable across versions
+	rm nvidia-modprobe && mv nvidia-modprobe{-${PV},} || die
+	rm nvidia-persistenced && mv nvidia-persistenced{-${PV},} || die
+	rm nvidia-settings && mv nvidia-settings{-${PV},} || die
+	rm nvidia-xconfig && mv nvidia-xconfig{-${PV},} || die
+
+	default
+
+	# prevent detection of incomplete kernel DRM support (bug #603818)
+	sed 's/defined(CONFIG_DRM/defined(CONFIG_DRM_KMS_HELPER/g' \
+		-i kernel/conftest.sh || die
+
+	sed -e '/Exec=\|Icon=/s/_.*/nvidia-settings/' \
+		-e '/Categories=/s/_.*/System;HardwareSettings;/' \
+		-i nvidia-settings/doc/nvidia-settings.desktop || die
+
+	# remove gtk2 support (bug #592730)
+	sed '/^GTK2LIB = /d;/INSTALL.*GTK2LIB/,+1d' \
+		-i nvidia-settings/src/Makefile || die
+
+	sed 's/__USER__/nvpd/' \
+		nvidia-persistenced/init/systemd/nvidia-persistenced.service.template \
+		> "${T}"/nvidia-persistenced.service || die
+
+	# enable nvidia-drm.modeset=1 by default with USE=wayland
+	cp "${FILESDIR}"/nvidia-470.conf "${T}"/nvidia.conf || die
+	use !wayland || sed -i '/^#.*modeset=1$/s/^#//' "${T}"/nvidia.conf || die
+}
+
+src_compile() {
+	tc-export AR CC LD OBJCOPY
+
+	NV_ARGS=(
+		PREFIX="${EPREFIX}"/usr
+		HOST_CC="$(tc-getBUILD_CC)"
+		HOST_LD="$(tc-getBUILD_LD)"
+		NV_USE_BUNDLED_LIBJANSSON=0
+		NV_VERBOSE=1 DO_STRIP= MANPAGE_GZIP= OUTPUTDIR=out
+	)
+
+	use driver && linux-mod_src_compile
+
+	emake "${NV_ARGS[@]}" -C nvidia-modprobe
+	emake "${NV_ARGS[@]}" -C nvidia-persistenced
+	use X && emake "${NV_ARGS[@]}" -C nvidia-xconfig
+
+	if use tools; then
+		# avoid filling up logs, only use here and set first to allow override
+		CFLAGS="-Wno-deprecated-declarations ${CFLAGS}" \
+			emake "${NV_ARGS[@]}" -C nvidia-settings
+	elif use static-libs; then
+		emake "${NV_ARGS[@]}" -C nvidia-settings/src out/libXNVCtrl.a
+	fi
+}
+
+src_install() {
+	local libdir=$(get_libdir) libdir32=$(ABI=x86 get_libdir)
+
+	NV_ARGS+=( DESTDIR="${D}" LIBDIR="${ED}"/usr/${libdir} )
+
+	local -A paths=(
+		[APPLICATION_PROFILE]=/usr/share/nvidia
+		[CUDA_ICD]=/etc/OpenCL/vendors
+		[EGL_EXTERNAL_PLATFORM_JSON]=/usr/share/egl/egl_external_platform.d
+		[FIRMWARE]=/lib/firmware/nvidia/${PV}
+		[GLVND_EGL_ICD_JSON]=/usr/share/glvnd/egl_vendor.d
+		[VULKAN_ICD_JSON]=/usr/share/vulkan
+		[WINE_LIB]=/usr/${libdir}/nvidia/wine
+		[XORG_OUTPUTCLASS_CONFIG]=/usr/share/X11/xorg.conf.d
+
+		[GLX_MODULE_SHARED_LIB]=/usr/${libdir}/xorg/modules/extensions
+		[GLX_MODULE_SYMLINK]=/usr/${libdir}/xorg/modules
+		[XMODULE_SHARED_LIB]=/usr/${libdir}/xorg/modules
+	)
+
+	local skip_files=(
+		$(usex X '' '
+			libGLX_nvidia libglxserver_nvidia
+			libnvidia-ifr
+			nvidia_icd.json nvidia_layers.json')
+		$(usex wayland '' 'libnvidia-vulkan-producer')
+		libGLX_indirect # non-glvnd unused fallback
+		libnvidia-gtk nvidia-{settings,xconfig} # built from source
+		libnvidia-egl-wayland 10_nvidia_wayland # gui-libs/egl-wayland
+	)
+	local skip_modules=(
+		$(usex X '' 'nvfbc vdpau xdriver')
+		$(usex driver '' 'gsp')
+		installer nvpd # handled separately / built from source
+	)
+	local skip_types=(
+		GLVND_LIB GLVND_SYMLINK EGL_CLIENT.\* GLX_CLIENT.\* # media-libs/libglvnd
+		OPENCL_WRAPPER.\* # virtual/opencl
+		DOCUMENTATION DOT_DESKTOP .\*_SRC DKMS_CONF # handled separately / unused
+	)
+
+	local DOCS=(
+		README.txt NVIDIA_Changelog supported-gpus/supported-gpus.json
+		nvidia-settings/doc/{FRAMELOCK,NV-CONTROL-API}.txt
+	)
+	local HTML_DOCS=( html/. )
+	einstalldocs
+
+	local DISABLE_AUTOFORMATTING=yes
+	local DOC_CONTENTS="\
+Trusted users should be in the 'video' group to use NVIDIA devices.
+You can add yourself by using: gpasswd -a my-user video
+
+See '${EPREFIX}/etc/modprobe.d/nvidia.conf' for modules options.\
+$(use amd64 && usex abi_x86_32 '' "
+
+Note that without USE=abi_x86_32 on ${PN}, 32bit applications
+(typically using wine / steam) will not be able to use GPU acceleration.")
+
+For general information on using ${PN}, please see:
+https://wiki.gentoo.org/wiki/NVIDIA/nvidia-drivers"
+	readme.gentoo_create_doc
+
+	if use driver; then
+		linux-mod_src_install
+
+		insinto /etc/modprobe.d
+		doins "${T}"/nvidia.conf
+
+		# used for gpu verification with binpkgs (not kept, see pkg_preinst)
+		insinto /usr/share/nvidia
+		doins supported-gpus/supported-gpus.json
+	fi
+
+	# nvidia-modprobe
+	emake "${NV_ARGS[@]}" -C nvidia-modprobe install
+	fowners :video /usr/bin/nvidia-modprobe #505092
+	fperms 4710 /usr/bin/nvidia-modprobe
+
+	# nvidia-persistenced
+	emake "${NV_ARGS[@]}" -C nvidia-persistenced install
+	newconfd "${FILESDIR}"/nvidia-persistenced.confd nvidia-persistenced
+	newinitd "${FILESDIR}"/nvidia-persistenced.initd nvidia-persistenced
+	systemd_dounit "${T}"/nvidia-persistenced.service
+
+	# nvidia-settings
+	if use tools; then
+		emake "${NV_ARGS[@]}" -C nvidia-settings install
+
+		doicon nvidia-settings/doc/nvidia-settings.png
+		domenu nvidia-settings/doc/nvidia-settings.desktop
+
+		exeinto /etc/X11/xinit/xinitrc.d
+		newexe "${FILESDIR}"/95-nvidia-settings-r1 95-nvidia-settings
+	fi
+
+	if use static-libs; then
+		dolib.a nvidia-settings/src/out/libXNVCtrl.a
+
+		insinto /usr/include/NVCtrl
+		doins nvidia-settings/src/libXNVCtrl/NVCtrl{Lib,}.h
+	fi
+
+	# nvidia-xconfig
+	use X && emake "${NV_ARGS[@]}" -C nvidia-xconfig install
+
+	# mimic nvidia-installer by reading .manifest to install files
+	# 0:file 1:perms 2:type 3+:subtype/arguments -:module
+	local m into
+	while IFS=' ' read -ra m; do
+		! [[ ${#m[@]} -ge 2 && ${m[-1]} =~ MODULE: ]] ||
+			eval '[[ " ${m[0]##*/}" =~ ^(\ '${skip_files[*]/%/.*|\\}' )$ ]]' ||
+			eval '[[ " ${m[2]}" =~ ^(\ '${skip_types[*]/%/|\\}' )$ ]]' ||
+			has ${m[-1]#MODULE:} "${skip_modules[@]}" && continue
+
+		case ${m[2]} in
+			MANPAGE)
+				gzip -dc ${m[0]} | newman - ${m[0]%.gz}; assert
+				continue
+			;;
+			VDPAU_SYMLINK) m[4]=vdpau/; m[5]=${m[5]#vdpau/};; # .so to vdpau/
+		esac
+
+		if [[ -v paths[${m[2]}] ]]; then
+			into=${paths[${m[2]}]}
+		elif [[ ${m[2]} =~ _BINARY$ ]]; then
+			into=/opt/bin
+		elif [[ ${m[3]} == COMPAT32 ]]; then
+			use abi_x86_32 || continue
+			into=/usr/${libdir32}
+		elif [[ ${m[2]} =~ _LIB$|_SYMLINK$ ]]; then
+			into=/usr/${libdir}
+		else
+			die "No known installation path for ${m[0]}"
+		fi
+		[[ ${m[3]: -2} == ?/ ]] && into+=/${m[3]%/}
+		[[ ${m[4]: -2} == ?/ ]] && into+=/${m[4]%/}
+
+		if [[ ${m[2]} =~ _SYMLINK$ ]]; then
+			[[ ${m[4]: -1} == / ]] && m[4]=${m[5]}
+			dosym ${m[4]} ${into}/${m[0]}
+			continue
+		fi
+		[[ ${m[0]} =~ ^libnvidia-ngx.so ]] &&
+			dosym ${m[0]} ${into}/${m[0]%.so*}.so.1 # soname not in .manifest
+
+		printf -v m[1] %o $((m[1] | 0200)) # 444->644
+		insopts -m${m[1]}
+		insinto ${into}
+		doins ${m[0]}
+	done < .manifest || die
+
+	# MODULE:installer non-skipped extras
+	exeinto /lib/systemd/system-sleep
+	doexe systemd/system-sleep/nvidia
+	dobin systemd/nvidia-sleep.sh
+	systemd_dounit systemd/system/nvidia-{hibernate,resume,suspend}.service
+
+	dobin nvidia-bug-report.sh
+}
+
+pkg_preinst() {
+	has_version "${CATEGORY}/${PN}[abi_x86_32]" && NV_HAD_ABI32=
+	has_version "${CATEGORY}/${PN}[wayland]" && NV_HAD_WAYLAND=
+
+	use driver || return
+	linux-mod_pkg_preinst
+
+	# set video group id based on live system (bug #491414)
+	local g=$(getent group video | cut -d: -f3)
+	[[ ${g} ]] || die "Failed to determine video group id"
+	sed -i "s/@VIDEOGID@/${g}/" "${ED}"/etc/modprobe.d/nvidia.conf || die
+
+	# try to find driver mismatches using temporary supported-gpus.json
+	for g in $(grep -l 0x10de /sys/bus/pci/devices/*/vendor 2>/dev/null); do
+		g=$(grep -io "\"devid\":\"$(<${g%vendor}device)\"[^}]*branch\":\"[0-9]*" \
+			"${ED}"/usr/share/nvidia/supported-gpus.json 2>/dev/null)
+		if [[ ${g} ]]; then
+			g=$((${g##*\"}+1))
+			if ver_test -ge ${g}; then
+				NV_LEGACY_MASK=">=${CATEGORY}/${PN}-${g}"
+				break
+			fi
+		fi
+	done
+	rm "${ED}"/usr/share/nvidia/supported-gpus.json || die
+}
+
+pkg_postinst() {
+	use driver && linux-mod_pkg_postinst
+
+	readme.gentoo_print_elog
+
+	if [[ -r /proc/driver/nvidia/version &&
+		$(</proc/driver/nvidia/version) != *"  ${PV}  "* ]]; then
+		ewarn "Currently loaded NVIDIA modules do not match the newly installed"
+		ewarn "libraries and may prevent launching GPU-accelerated applications."
+		use driver && ewarn "The easiest way to fix this is usually to reboot."
+	fi
+
+	if [[ $(</proc/cmdline) == *slub_debug=[!-]* ]]; then
+		ewarn "Detected that the current kernel command line is using 'slub_debug=',"
+		ewarn "this may lead to system instability/freezes with this version of"
+		ewarn "${PN}. Bug: https://bugs.gentoo.org/796329"
+	fi
+
+	if [[ -v NV_LEGACY_MASK ]]; then
+		ewarn
+		ewarn "***WARNING***"
+		ewarn
+		ewarn "You are installing a version of ${PN} known not to work"
+		ewarn "with a GPU of the current system. If unwanted, add the mask:"
+		if [[ -d ${EROOT}/etc/portage/package.mask ]]; then
+			ewarn "  echo '${NV_LEGACY_MASK}' > ${EROOT}/etc/portage/package.mask/${PN}"
+		else
+			ewarn "  echo '${NV_LEGACY_MASK}' >> ${EROOT}/etc/portage/package.mask"
+		fi
+		ewarn "...then downgrade to a legacy branch if possible. For details, see:"
+		ewarn "https://www.nvidia.com/object/IO_32667.html"
+	fi
+
+	if use !abi_x86_32 && [[ -v NV_HAD_ABI32 ]]; then
+		elog
+		elog "USE=abi_x86_32 is disabled, 32bit applications will not be able to"
+		elog "use nvidia-drivers for acceleration without it (e.g. commonly used"
+		elog "with app-emulation/wine-* or steam). Re-enable if needed."
+	fi
+
+	if use wayland && use driver && [[ ! -v NV_HAD_WAYLAND ]]; then
+		elog
+		elog "With USE=wayland, this version of ${PN} sets nvidia-drm.modeset=1"
+		elog "in '${EROOT}/etc/modprobe.d/nvidia.conf'. This feature is considered"
+		elog "experimental but is required for wayland."
+		elog
+		elog "If you experience issues, either disable wayland or edit nvidia.conf."
+		elog "Of note, may possibly cause issues with SLI and Reverse PRIME."
+		elog
+		elog "This version of ${PN} only supports EGLStream which is only"
+		elog "supported by a few wayland compositors (e.g. kwin / mutter, not sway)."
+	fi
+
+	# Try to show this message only to users that may really need it
+	# given the workaround is discouraged and usage isn't widespread.
+	if use X && [[ ${REPLACING_VERSIONS} ]] &&
+		ver_test ${REPLACING_VERSIONS} -lt 460.73.01 &&
+		grep -qr Coolbits "${EROOT}"/etc/X11/{xorg.conf,xorg.conf.d/*.conf} 2>/dev/null; then
+		elog
+		elog "Coolbits support with ${PN} has been restricted to require Xorg"
+		elog "with root privilege by NVIDIA (being in video group is not sufficient)."
+		elog "e.g. attempting to change fan speed with nvidia-settings would fail."
+		elog
+		elog "Depending on your display manager (e.g. sddm starts X as root, gdm doesn't)"
+		elog "or if using startx, it may be necessary to emerge x11-base/xorg-server with"
+		elog 'USE="suid -elogind -systemd" if wish to keep using this feature.'
+		elog "Bug: https://bugs.gentoo.org/784248"
+	fi
+}

--- a/x11-drivers/nvidia-drivers/nvidia-drivers-470.86-r100.ebuild
+++ b/x11-drivers/nvidia-drivers/nvidia-drivers-470.86-r100.ebuild
@@ -77,6 +77,8 @@ QA_PREBUILT="lib/firmware/* opt/bin/* usr/lib*"
 
 PATCHES=(
 	"${FILESDIR}"/nvidia-modprobe-390.141-uvm-perms.patch
+	"${FILESDIR}"/nvidia-settings-390.144-desktop.patch
+	"${FILESDIR}"/nvidia-settings-390.144-no-gtk2.patch
 	"${FILESDIR}"/nvidia-settings-390.144-raw-ldflags.patch
 )
 
@@ -152,14 +154,6 @@ src_prepare() {
 	# prevent detection of incomplete kernel DRM support (bug #603818)
 	sed 's/defined(CONFIG_DRM/defined(CONFIG_DRM_KMS_HELPER/g' \
 		-i kernel/conftest.sh || die
-
-	sed -e '/Exec=\|Icon=/s/_.*/nvidia-settings/' \
-		-e '/Categories=/s/_.*/System;HardwareSettings;/' \
-		-i nvidia-settings/doc/nvidia-settings.desktop || die
-
-	# remove gtk2 support (bug #592730)
-	sed '/^GTK2LIB = /d;/INSTALL.*GTK2LIB/,+1d' \
-		-i nvidia-settings/src/Makefile || die
 
 	sed 's/__USER__/nvpd/' \
 		nvidia-persistenced/init/systemd/nvidia-persistenced.service.template \

--- a/x11-drivers/nvidia-drivers/nvidia-drivers-470.86-r100.ebuild
+++ b/x11-drivers/nvidia-drivers/nvidia-drivers-470.86-r100.ebuild
@@ -22,12 +22,14 @@ S="${WORKDIR}"
 LICENSE="NVIDIA-r2 BSD BSD-2 GPL-2 MIT ZLIB curl openssl"
 SLOT="0/${PV%%.*}"
 KEYWORDS="-* ~amd64"
-IUSE="+X abi_x86_32 abi_x86_64 +driver static-libs +tools wayland"
+IUSE="+X abi_x86_32 abi_x86_64 +driver persistenced static-libs +tools wayland"
 
 COMMON_DEPEND="
 	acct-group/video
-	acct-user/nvpd
-	net-libs/libtirpc:=
+	persistenced? (
+		acct-user/nvpd
+		net-libs/libtirpc:=
+	)
 	tools? (
 		dev-libs/atk
 		dev-libs/glib:2
@@ -180,7 +182,7 @@ src_compile() {
 	use driver && linux-mod_src_compile
 
 	emake "${NV_ARGS[@]}" -C nvidia-modprobe
-	emake "${NV_ARGS[@]}" -C nvidia-persistenced
+	use persistenced && emake "${NV_ARGS[@]}" -C nvidia-persistenced
 	use X && emake "${NV_ARGS[@]}" -C nvidia-xconfig
 
 	if use tools; then
@@ -266,18 +268,17 @@ https://wiki.gentoo.org/wiki/NVIDIA/nvidia-drivers"
 		doins supported-gpus/supported-gpus.json
 	fi
 
-	# nvidia-modprobe
 	emake "${NV_ARGS[@]}" -C nvidia-modprobe install
 	fowners :video /usr/bin/nvidia-modprobe #505092
 	fperms 4710 /usr/bin/nvidia-modprobe
 
-	# nvidia-persistenced
-	emake "${NV_ARGS[@]}" -C nvidia-persistenced install
-	newconfd "${FILESDIR}"/nvidia-persistenced.confd nvidia-persistenced
-	newinitd "${FILESDIR}"/nvidia-persistenced.initd nvidia-persistenced
-	systemd_dounit "${T}"/nvidia-persistenced.service
+	if use persistenced; then
+		emake "${NV_ARGS[@]}" -C nvidia-persistenced install
+		newconfd "${FILESDIR}"/nvidia-persistenced.confd nvidia-persistenced
+		newinitd "${FILESDIR}"/nvidia-persistenced.initd nvidia-persistenced
+		systemd_dounit "${T}"/nvidia-persistenced.service
+	fi
 
-	# nvidia-settings
 	if use tools; then
 		emake "${NV_ARGS[@]}" -C nvidia-settings install
 
@@ -295,7 +296,6 @@ https://wiki.gentoo.org/wiki/NVIDIA/nvidia-drivers"
 		doins nvidia-settings/src/libXNVCtrl/NVCtrl{Lib,}.h
 	fi
 
-	# nvidia-xconfig
 	use X && emake "${NV_ARGS[@]}" -C nvidia-xconfig install
 
 	# mimic nvidia-installer by reading .manifest to install files

--- a/x11-drivers/nvidia-drivers/nvidia-drivers-495.44-r100.ebuild
+++ b/x11-drivers/nvidia-drivers/nvidia-drivers-495.44-r100.ebuild
@@ -22,12 +22,14 @@ S="${WORKDIR}"
 LICENSE="NVIDIA-r2 BSD BSD-2 GPL-2 MIT ZLIB curl openssl"
 SLOT="0/${PV%%.*}"
 KEYWORDS="-* ~amd64"
-IUSE="+X abi_x86_32 abi_x86_64 +driver static-libs +tools wayland"
+IUSE="+X abi_x86_32 abi_x86_64 +driver persistenced static-libs +tools wayland"
 
 COMMON_DEPEND="
 	acct-group/video
-	acct-user/nvpd
-	net-libs/libtirpc:=
+	persistenced? (
+		acct-user/nvpd
+		net-libs/libtirpc:=
+	)
 	tools? (
 		dev-libs/atk
 		dev-libs/glib:2
@@ -182,7 +184,7 @@ src_compile() {
 	use driver && linux-mod_src_compile
 
 	emake "${NV_ARGS[@]}" -C nvidia-modprobe
-	emake "${NV_ARGS[@]}" -C nvidia-persistenced
+	use persistenced && emake "${NV_ARGS[@]}" -C nvidia-persistenced
 	use X && emake "${NV_ARGS[@]}" -C nvidia-xconfig
 
 	if use tools; then
@@ -270,18 +272,17 @@ https://wiki.gentoo.org/wiki/NVIDIA/nvidia-drivers"
 		doins supported-gpus/supported-gpus.json
 	fi
 
-	# nvidia-modprobe
 	emake "${NV_ARGS[@]}" -C nvidia-modprobe install
 	fowners :video /usr/bin/nvidia-modprobe #505092
 	fperms 4710 /usr/bin/nvidia-modprobe
 
-	# nvidia-persistenced
-	emake "${NV_ARGS[@]}" -C nvidia-persistenced install
-	newconfd "${FILESDIR}"/nvidia-persistenced.confd nvidia-persistenced
-	newinitd "${FILESDIR}"/nvidia-persistenced.initd nvidia-persistenced
-	systemd_dounit "${T}"/nvidia-persistenced.service
+	if use persistenced; then
+		emake "${NV_ARGS[@]}" -C nvidia-persistenced install
+		newconfd "${FILESDIR}"/nvidia-persistenced.confd nvidia-persistenced
+		newinitd "${FILESDIR}"/nvidia-persistenced.initd nvidia-persistenced
+		systemd_dounit "${T}"/nvidia-persistenced.service
+	fi
 
-	# nvidia-settings
 	if use tools; then
 		emake "${NV_ARGS[@]}" -C nvidia-settings install
 
@@ -299,7 +300,6 @@ https://wiki.gentoo.org/wiki/NVIDIA/nvidia-drivers"
 		doins nvidia-settings/src/libXNVCtrl/NVCtrl{Lib,}.h
 	fi
 
-	# nvidia-xconfig
 	use X && emake "${NV_ARGS[@]}" -C nvidia-xconfig install
 
 	# mimic nvidia-installer by reading .manifest to install files

--- a/x11-drivers/nvidia-drivers/nvidia-drivers-495.44-r100.ebuild
+++ b/x11-drivers/nvidia-drivers/nvidia-drivers-495.44-r100.ebuild
@@ -1,0 +1,466 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+MODULES_OPTIONAL_USE="driver"
+inherit desktop linux-mod readme.gentoo-r1 systemd toolchain-funcs unpacker
+
+NV_KERNEL_MAX="5.15"
+NV_URI="https://download.nvidia.com/XFree86/"
+
+DESCRIPTION="NVIDIA Accelerated Graphics Driver"
+HOMEPAGE="https://www.nvidia.com/download/index.aspx"
+SRC_URI="
+	amd64? ( ${NV_URI}Linux-x86_64/${PV}/NVIDIA-Linux-x86_64-${PV}.run )
+	arm64? ( ${NV_URI}Linux-aarch64/${PV}/NVIDIA-Linux-aarch64-${PV}.run )
+	$(printf "${NV_URI}%s/%s-${PV}.tar.bz2 " \
+		nvidia-{installer,modprobe,persistenced,settings,xconfig}{,})"
+# nvidia-installer is unused but here for GPL-2's "distribute sources"
+S="${WORKDIR}"
+
+LICENSE="NVIDIA-r2 BSD BSD-2 GPL-2 MIT ZLIB curl openssl"
+SLOT="0/${PV%%.*}"
+KEYWORDS="-* ~amd64"
+IUSE="+X abi_x86_32 abi_x86_64 +driver static-libs +tools wayland"
+
+COMMON_DEPEND="
+	acct-group/video
+	acct-user/nvpd
+	net-libs/libtirpc:=
+	tools? (
+		dev-libs/atk
+		dev-libs/glib:2
+		dev-libs/jansson:=
+		media-libs/harfbuzz:=
+		x11-libs/cairo
+		x11-libs/gdk-pixbuf:2
+		x11-libs/gtk+:3
+		x11-libs/libX11
+		x11-libs/libXext
+		x11-libs/libXxf86vm
+		x11-libs/pango
+	)"
+RDEPEND="
+	${COMMON_DEPEND}
+	X? (
+		media-libs/libglvnd[X,abi_x86_32(-)?]
+		x11-libs/libX11[abi_x86_32(-)?]
+		x11-libs/libXext[abi_x86_32(-)?]
+	)
+	wayland? (
+		>=gui-libs/egl-wayland-1.1.7-r1
+		media-libs/libglvnd
+		>=media-libs/mesa-21.2[gbm(+)]
+		x11-libs/libdrm
+	)"
+DEPEND="
+	${COMMON_DEPEND}
+	static-libs? (
+		x11-libs/libX11
+		x11-libs/libXext
+	)
+	tools? (
+		media-libs/libglvnd
+		sys-apps/dbus
+		x11-base/xorg-proto
+		x11-libs/libXrandr
+		x11-libs/libXv
+		x11-libs/libvdpau
+	)"
+BDEPEND="
+	sys-devel/m4
+	virtual/pkgconfig"
+
+QA_PREBUILT="lib/firmware/* opt/bin/* usr/lib*"
+
+PATCHES=(
+	"${FILESDIR}"/nvidia-modprobe-390.141-uvm-perms.patch
+)
+
+pkg_setup() {
+	use driver || return
+
+	local CONFIG_CHECK="
+		PROC_FS
+		~DRM_KMS_HELPER
+		~SYSVIPC
+		~!DRM_SIMPLEDRM
+		~!LOCKDEP
+		~!SLUB_DEBUG_ON
+		!DEBUG_MUTEXES"
+	local ERROR_DRM_KMS_HELPER="CONFIG_DRM_KMS_HELPER: is not set but needed for Xorg auto-detection
+	of drivers (no custom config), and for wayland / nvidia-drm.modeset=1.
+	Cannot be directly selected in the kernel's menuconfig, and may need
+	selection of a DRM device even if unused, e.g. CONFIG_DRM_AMDGPU=m or
+	DRM_I915=y, DRM_NOUVEAU=m also acceptable if a module and not built-in.
+	Note: DRM_SIMPLEDRM may cause issues and is better disabled for now."
+
+	use amd64 && kernel_is -ge 5 8 && CONFIG_CHECK+=" X86_PAT" #817764
+
+	MODULE_NAMES="
+		nvidia(video:kernel)
+		nvidia-drm(video:kernel)
+		nvidia-modeset(video:kernel)
+		nvidia-peermem(video:kernel)
+		nvidia-uvm(video:kernel)"
+
+	linux-mod_pkg_setup
+
+	[[ ${MERGE_TYPE} == binary ]] && return
+
+	BUILD_PARAMS='NV_VERBOSE=1 IGNORE_CC_MISMATCH=yes SYSSRC="${KV_DIR}" SYSOUT="${KV_OUT_DIR}"'
+	BUILD_TARGETS="modules"
+
+	if linux_chkconfig_present CC_IS_CLANG; then
+		ewarn "Warning: building ${PN} with a clang-built kernel is experimental"
+
+		BUILD_PARAMS+=' CC=${CHOST}-clang'
+		if linux_chkconfig_present LD_IS_LLD; then
+			BUILD_PARAMS+=' LD=ld.lld'
+			if linux_chkconfig_present LTO_CLANG_THIN; then
+				# kernel enables cache by default leading to sandbox violations
+				BUILD_PARAMS+=' ldflags-y=--thinlto-cache-dir= LDFLAGS_MODULE=--thinlto-cache-dir='
+			fi
+		fi
+	fi
+
+	if kernel_is -gt ${NV_KERNEL_MAX/./ }; then
+		ewarn "Kernel ${KV_MAJOR}.${KV_MINOR} is either known to break this version of ${PN}"
+		ewarn "or was not tested with it. It is recommended to use one of:"
+		ewarn "  <=sys-kernel/gentoo-kernel-${NV_KERNEL_MAX}"
+		ewarn "  <=sys-kernel/gentoo-sources-${NV_KERNEL_MAX}"
+		ewarn "You are free to try or use /etc/portage/patches, but support will"
+		ewarn "not be given and issues wait until NVIDIA releases a fixed version."
+		ewarn
+		ewarn "Do _not_ file a bug report if run into issues."
+		ewarn
+	fi
+}
+
+src_prepare() {
+	# make patches usable across versions
+	rm nvidia-modprobe && mv nvidia-modprobe{-${PV},} || die
+	rm nvidia-persistenced && mv nvidia-persistenced{-${PV},} || die
+	rm nvidia-settings && mv nvidia-settings{-${PV},} || die
+	rm nvidia-xconfig && mv nvidia-xconfig{-${PV},} || die
+
+	default
+
+	# prevent detection of incomplete kernel DRM support (bug #603818)
+	sed 's/defined(CONFIG_DRM/defined(CONFIG_DRM_KMS_HELPER/g' \
+		-i kernel/conftest.sh || die
+
+	sed -e '/Exec=\|Icon=/s/_.*/nvidia-settings/' \
+		-e '/Categories=/s/_.*/System;HardwareSettings;/' \
+		-i nvidia-settings/doc/nvidia-settings.desktop || die
+
+	# remove gtk2 support (bug #592730)
+	sed '/^GTK2LIB = /d;/INSTALL.*GTK2LIB/,+1d' \
+		-i nvidia-settings/src/Makefile || die
+
+	sed 's/__USER__/nvpd/' \
+		nvidia-persistenced/init/systemd/nvidia-persistenced.service.template \
+		> "${T}"/nvidia-persistenced.service || die
+
+	# enable nvidia-drm.modeset=1 by default with USE=wayland
+	cp "${FILESDIR}"/nvidia-470.conf "${T}"/nvidia.conf || die
+	use !wayland || sed -i '/^#.*modeset=1$/s/^#//' "${T}"/nvidia.conf || die
+}
+
+src_compile() {
+	tc-export AR CC LD OBJCOPY
+
+	NV_ARGS=(
+		PREFIX="${EPREFIX}"/usr
+		HOST_CC="$(tc-getBUILD_CC)"
+		HOST_LD="$(tc-getBUILD_LD)"
+		NV_USE_BUNDLED_LIBJANSSON=0
+		NV_VERBOSE=1 DO_STRIP= MANPAGE_GZIP= OUTPUTDIR=out
+	)
+
+	use driver && linux-mod_src_compile
+
+	emake "${NV_ARGS[@]}" -C nvidia-modprobe
+	emake "${NV_ARGS[@]}" -C nvidia-persistenced
+	use X && emake "${NV_ARGS[@]}" -C nvidia-xconfig
+
+	if use tools; then
+		# avoid filling up logs, only use here and set first to allow override
+		CFLAGS="-Wno-deprecated-declarations ${CFLAGS}" \
+			emake "${NV_ARGS[@]}" -C nvidia-settings
+	elif use static-libs; then
+		emake "${NV_ARGS[@]}" -C nvidia-settings/src out/libXNVCtrl.a
+	fi
+}
+
+src_install() {
+	local libdir=$(get_libdir) libdir32=$(ABI=x86 get_libdir)
+
+	NV_ARGS+=( DESTDIR="${D}" LIBDIR="${ED}"/usr/${libdir} )
+
+	local -A paths=(
+		[APPLICATION_PROFILE]=/usr/share/nvidia
+		[CUDA_ICD]=/etc/OpenCL/vendors
+		[EGL_EXTERNAL_PLATFORM_JSON]=/usr/share/egl/egl_external_platform.d
+		[FIRMWARE]=/lib/firmware/nvidia/${PV}
+		[GBM_BACKEND_LIB_SYMLINK]=/usr/${libdir}/gbm
+		[GLVND_EGL_ICD_JSON]=/usr/share/glvnd/egl_vendor.d
+		[VULKAN_ICD_JSON]=/usr/share/vulkan
+		[WINE_LIB]=/usr/${libdir}/nvidia/wine
+		[XORG_OUTPUTCLASS_CONFIG]=/usr/share/X11/xorg.conf.d
+
+		[GLX_MODULE_SHARED_LIB]=/usr/${libdir}/xorg/modules/extensions
+		[GLX_MODULE_SYMLINK]=/usr/${libdir}/xorg/modules
+		[XMODULE_SHARED_LIB]=/usr/${libdir}/xorg/modules
+	)
+
+	local skip_files=(
+		$(usex X '' '
+			libGLX_nvidia libglxserver_nvidia
+			nvidia_icd.json nvidia_layers.json')
+		$(usex wayland '' '
+			libnvidia-egl-gbm 15_nvidia_gbm
+			libnvidia-vulkan-producer')
+		libGLX_indirect # non-glvnd unused fallback
+		libnvidia-gtk nvidia-{settings,xconfig} # built from source
+		libnvidia-egl-wayland 10_nvidia_wayland # gui-libs/egl-wayland
+	)
+	local skip_modules=(
+		$(usex X '' 'nvfbc vdpau xdriver')
+		$(usex driver '' 'gsp')
+		installer nvpd # handled separately / built from source
+	)
+	local skip_types=(
+		GLVND_LIB GLVND_SYMLINK EGL_CLIENT.\* GLX_CLIENT.\* # media-libs/libglvnd
+		OPENCL_WRAPPER.\* # virtual/opencl
+		DOCUMENTATION DOT_DESKTOP .\*_SRC DKMS_CONF # handled separately / unused
+	)
+
+	local DOCS=(
+		README.txt NVIDIA_Changelog supported-gpus/supported-gpus.json
+		nvidia-settings/doc/{FRAMELOCK,NV-CONTROL-API}.txt
+	)
+	local HTML_DOCS=( html/. )
+	einstalldocs
+
+	local DISABLE_AUTOFORMATTING=yes
+	local DOC_CONTENTS="\
+Trusted users should be in the 'video' group to use NVIDIA devices.
+You can add yourself by using: gpasswd -a my-user video
+
+See '${EPREFIX}/etc/modprobe.d/nvidia.conf' for modules options.\
+$(use amd64 && usex abi_x86_32 '' "
+
+Note that without USE=abi_x86_32 on ${PN}, 32bit applications
+(typically using wine / steam) will not be able to use GPU acceleration.")
+
+For general information on using ${PN}, please see:
+https://wiki.gentoo.org/wiki/NVIDIA/nvidia-drivers"
+	readme.gentoo_create_doc
+
+	if use driver; then
+		linux-mod_src_install
+
+		insinto /etc/modprobe.d
+		doins "${T}"/nvidia.conf
+
+		# used for gpu verification with binpkgs (not kept, see pkg_preinst)
+		insinto /usr/share/nvidia
+		doins supported-gpus/supported-gpus.json
+	fi
+
+	# nvidia-modprobe
+	emake "${NV_ARGS[@]}" -C nvidia-modprobe install
+	fowners :video /usr/bin/nvidia-modprobe #505092
+	fperms 4710 /usr/bin/nvidia-modprobe
+
+	# nvidia-persistenced
+	emake "${NV_ARGS[@]}" -C nvidia-persistenced install
+	newconfd "${FILESDIR}"/nvidia-persistenced.confd nvidia-persistenced
+	newinitd "${FILESDIR}"/nvidia-persistenced.initd nvidia-persistenced
+	systemd_dounit "${T}"/nvidia-persistenced.service
+
+	# nvidia-settings
+	if use tools; then
+		emake "${NV_ARGS[@]}" -C nvidia-settings install
+
+		doicon nvidia-settings/doc/nvidia-settings.png
+		domenu nvidia-settings/doc/nvidia-settings.desktop
+
+		exeinto /etc/X11/xinit/xinitrc.d
+		newexe "${FILESDIR}"/95-nvidia-settings-r1 95-nvidia-settings
+	fi
+
+	if use static-libs; then
+		dolib.a nvidia-settings/src/out/libXNVCtrl.a
+
+		insinto /usr/include/NVCtrl
+		doins nvidia-settings/src/libXNVCtrl/NVCtrl{Lib,}.h
+	fi
+
+	# nvidia-xconfig
+	use X && emake "${NV_ARGS[@]}" -C nvidia-xconfig install
+
+	# mimic nvidia-installer by reading .manifest to install files
+	# 0:file 1:perms 2:type 3+:subtype/arguments -:module
+	local m into
+	while IFS=' ' read -ra m; do
+		! [[ ${#m[@]} -ge 2 && ${m[-1]} =~ MODULE: ]] ||
+			eval '[[ " ${m[0]##*/}" =~ ^(\ '${skip_files[*]/%/.*|\\}' )$ ]]' ||
+			eval '[[ " ${m[2]}" =~ ^(\ '${skip_types[*]/%/|\\}' )$ ]]' ||
+			has ${m[-1]#MODULE:} "${skip_modules[@]}" && continue
+
+		case ${m[2]} in
+			MANPAGE)
+				gzip -dc ${m[0]} | newman - ${m[0]%.gz}; assert
+				continue
+			;;
+			GBM_BACKEND_LIB_SYMLINK) m[4]=../${m[4]};; # missing ../
+			VDPAU_SYMLINK) m[4]=vdpau/; m[5]=${m[5]#vdpau/};; # .so to vdpau/
+		esac
+
+		if [[ -v paths[${m[2]}] ]]; then
+			into=${paths[${m[2]}]}
+		elif [[ ${m[2]} =~ _BINARY$ ]]; then
+			into=/opt/bin
+		elif [[ ${m[3]} == COMPAT32 ]]; then
+			use abi_x86_32 || continue
+			into=/usr/${libdir32}
+		elif [[ ${m[2]} =~ _LIB$|_SYMLINK$ ]]; then
+			into=/usr/${libdir}
+		else
+			die "No known installation path for ${m[0]}"
+		fi
+		[[ ${m[3]: -2} == ?/ ]] && into+=/${m[3]%/}
+		[[ ${m[4]: -2} == ?/ ]] && into+=/${m[4]%/}
+
+		if [[ ${m[2]} =~ _SYMLINK$ ]]; then
+			[[ ${m[4]: -1} == / ]] && m[4]=${m[5]}
+			dosym ${m[4]} ${into}/${m[0]}
+			continue
+		fi
+		[[ ${m[0]} =~ ^libnvidia-ngx.so|^libnvidia-egl-gbm.so ]] &&
+			dosym ${m[0]} ${into}/${m[0]%.so*}.so.1 # soname not in .manifest
+
+		printf -v m[1] %o $((m[1] | 0200)) # 444->644
+		insopts -m${m[1]}
+		insinto ${into}
+		doins ${m[0]}
+	done < .manifest || die
+
+	# MODULE:installer non-skipped extras
+	exeinto /lib/systemd/system-sleep
+	doexe systemd/system-sleep/nvidia
+	dobin systemd/nvidia-sleep.sh
+	systemd_dounit systemd/system/nvidia-{hibernate,resume,suspend}.service
+
+	dobin nvidia-bug-report.sh
+}
+
+pkg_preinst() {
+	has_version "${CATEGORY}/${PN}[abi_x86_32]" && NV_HAD_ABI32=
+	has_version "${CATEGORY}/${PN}[wayland]" && NV_HAD_WAYLAND=
+
+	use driver || return
+	linux-mod_pkg_preinst
+
+	# set video group id based on live system (bug #491414)
+	local g=$(getent group video | cut -d: -f3)
+	[[ ${g} ]] || die "Failed to determine video group id"
+	sed -i "s/@VIDEOGID@/${g}/" "${ED}"/etc/modprobe.d/nvidia.conf || die
+
+	# try to find driver mismatches using temporary supported-gpus.json
+	for g in $(grep -l 0x10de /sys/bus/pci/devices/*/vendor 2>/dev/null); do
+		g=$(grep -io "\"devid\":\"$(<${g%vendor}device)\"[^}]*branch\":\"[0-9]*" \
+			"${ED}"/usr/share/nvidia/supported-gpus.json 2>/dev/null)
+		if [[ ${g} ]]; then
+			g=$((${g##*\"}+1))
+			if ver_test -ge ${g}; then
+				NV_LEGACY_MASK=">=${CATEGORY}/${PN}-${g}"
+				break
+			fi
+		fi
+	done
+	rm "${ED}"/usr/share/nvidia/supported-gpus.json || die
+}
+
+pkg_postinst() {
+	use driver && linux-mod_pkg_postinst
+
+	readme.gentoo_print_elog
+
+	if [[ -r /proc/driver/nvidia/version &&
+		$(</proc/driver/nvidia/version) != *"  ${PV}  "* ]]; then
+		ewarn "Currently loaded NVIDIA modules do not match the newly installed"
+		ewarn "libraries and may prevent launching GPU-accelerated applications."
+		use driver && ewarn "The easiest way to fix this is usually to reboot."
+	fi
+
+	if [[ $(</proc/cmdline) == *slub_debug=[!-]* ]]; then
+		ewarn "Detected that the current kernel command line is using 'slub_debug=',"
+		ewarn "this may lead to system instability/freezes with this version of"
+		ewarn "${PN}. Bug: https://bugs.gentoo.org/796329"
+	fi
+
+	if [[ -v NV_LEGACY_MASK ]]; then
+		ewarn
+		ewarn "***WARNING***"
+		ewarn
+		ewarn "You are installing a version of ${PN} known not to work"
+		ewarn "with a GPU of the current system. If unwanted, add the mask:"
+		if [[ -d ${EROOT}/etc/portage/package.mask ]]; then
+			ewarn "  echo '${NV_LEGACY_MASK}' > ${EROOT}/etc/portage/package.mask/${PN}"
+		else
+			ewarn "  echo '${NV_LEGACY_MASK}' >> ${EROOT}/etc/portage/package.mask"
+		fi
+		ewarn "...then downgrade to a legacy branch if possible. For details, see:"
+		ewarn "https://www.nvidia.com/object/IO_32667.html"
+	fi
+
+	if use !abi_x86_32 && [[ -v NV_HAD_ABI32 ]]; then
+		elog
+		elog "USE=abi_x86_32 is disabled, 32bit applications will not be able to"
+		elog "use nvidia-drivers for acceleration without it (e.g. commonly used"
+		elog "with app-emulation/wine-* or steam). Re-enable if needed."
+	fi
+
+	if use wayland && use driver && [[ ! -v NV_HAD_WAYLAND ]]; then
+		elog
+		elog "With USE=wayland, this version of ${PN} sets nvidia-drm.modeset=1"
+		elog "in '${EROOT}/etc/modprobe.d/nvidia.conf'. This feature is considered"
+		elog "experimental but is required for wayland."
+		elog
+		elog "If you experience issues, either disable wayland or edit nvidia.conf."
+		elog "Of note, may possibly cause issues with SLI and Reverse PRIME."
+	fi
+
+	if use wayland && [[ ${REPLACING_VERSIONS} ]] &&
+		ver_test ${REPLACING_VERSIONS} -lt 495.29.05; then
+		elog
+		elog "While this version of ${PN} adds GBM support (allowing a"
+		elog "wider range of wayland compositors, such as sway), be warned it is"
+		elog "very experimental and many applications are known to have issues."
+		elog
+		elog "While not essential, some features also need >=egl-wayland-1.1.8"
+		elog "which is known to cause regressions with EGLStream (GBM alternative)."
+		elog
+		elog "If lacking a cursor with wlroots, try WLR_NO_HARDWARE_CURSORS=1"
+	fi
+
+	# Try to show this message only to users that may really need it
+	# given the workaround is discouraged and usage isn't widespread.
+	if use X && [[ ${REPLACING_VERSIONS} ]] &&
+		ver_test ${REPLACING_VERSIONS} -lt 460.73.01 &&
+		grep -qr Coolbits "${EROOT}"/etc/X11/{xorg.conf,xorg.conf.d/*.conf} 2>/dev/null; then
+		elog
+		elog "Coolbits support with ${PN} has been restricted to require Xorg"
+		elog "with root privilege by NVIDIA (being in video group is not sufficient)."
+		elog "e.g. attempting to change fan speed with nvidia-settings would fail."
+		elog
+		elog "Depending on your display manager (e.g. sddm starts X as root, gdm doesn't)"
+		elog "or if using startx, it may be necessary to emerge x11-base/xorg-server with"
+		elog 'USE="suid -elogind -systemd" if wish to keep using this feature.'
+		elog "Bug: https://bugs.gentoo.org/784248"
+	fi
+}

--- a/x11-drivers/nvidia-drivers/nvidia-drivers-495.44-r100.ebuild
+++ b/x11-drivers/nvidia-drivers/nvidia-drivers-495.44-r100.ebuild
@@ -4,7 +4,8 @@
 EAPI=7
 
 MODULES_OPTIONAL_USE="driver"
-inherit desktop linux-mod readme.gentoo-r1 systemd toolchain-funcs unpacker
+inherit desktop flag-o-matic linux-mod multilib readme.gentoo-r1 \
+	systemd toolchain-funcs unpacker
 
 NV_KERNEL_MAX="5.15"
 NV_URI="https://download.nvidia.com/XFree86/"
@@ -78,6 +79,7 @@ QA_PREBUILT="lib/firmware/* opt/bin/* usr/lib*"
 
 PATCHES=(
 	"${FILESDIR}"/nvidia-modprobe-390.141-uvm-perms.patch
+	"${FILESDIR}"/nvidia-settings-390.144-raw-ldflags.patch
 )
 
 pkg_setup() {
@@ -188,8 +190,10 @@ src_compile() {
 	use X && emake "${NV_ARGS[@]}" -C nvidia-xconfig
 
 	if use tools; then
-		# avoid filling up logs, only use here and set first to allow override
+		# cflags: avoid noisy logs, only use here and set first to let override
+		# ldflags: abi currently needed if LD=ld.lld
 		CFLAGS="-Wno-deprecated-declarations ${CFLAGS}" \
+			RAW_LDFLAGS="$(get_abi_LDFLAGS) $(raw-ldflags)" \
 			emake "${NV_ARGS[@]}" -C nvidia-settings
 	elif use static-libs; then
 		emake "${NV_ARGS[@]}" -C nvidia-settings/src out/libXNVCtrl.a

--- a/x11-drivers/nvidia-drivers/nvidia-drivers-495.44-r100.ebuild
+++ b/x11-drivers/nvidia-drivers/nvidia-drivers-495.44-r100.ebuild
@@ -79,6 +79,8 @@ QA_PREBUILT="lib/firmware/* opt/bin/* usr/lib*"
 
 PATCHES=(
 	"${FILESDIR}"/nvidia-modprobe-390.141-uvm-perms.patch
+	"${FILESDIR}"/nvidia-settings-390.144-desktop.patch
+	"${FILESDIR}"/nvidia-settings-390.144-no-gtk2.patch
 	"${FILESDIR}"/nvidia-settings-390.144-raw-ldflags.patch
 )
 
@@ -154,14 +156,6 @@ src_prepare() {
 	# prevent detection of incomplete kernel DRM support (bug #603818)
 	sed 's/defined(CONFIG_DRM/defined(CONFIG_DRM_KMS_HELPER/g' \
 		-i kernel/conftest.sh || die
-
-	sed -e '/Exec=\|Icon=/s/_.*/nvidia-settings/' \
-		-e '/Categories=/s/_.*/System;HardwareSettings;/' \
-		-i nvidia-settings/doc/nvidia-settings.desktop || die
-
-	# remove gtk2 support (bug #592730)
-	sed '/^GTK2LIB = /d;/INSTALL.*GTK2LIB/,+1d' \
-		-i nvidia-settings/src/Makefile || die
 
 	sed 's/__USER__/nvpd/' \
 		nvidia-persistenced/init/systemd/nvidia-persistenced.service.template \

--- a/x11-drivers/nvidia-drivers/nvidia-drivers-495.44-r102.ebuild
+++ b/x11-drivers/nvidia-drivers/nvidia-drivers-495.44-r102.ebuild
@@ -80,6 +80,8 @@ QA_PREBUILT="lib/firmware/* opt/bin/* usr/lib*"
 
 PATCHES=(
 	"${FILESDIR}"/nvidia-modprobe-390.141-uvm-perms.patch
+	"${FILESDIR}"/nvidia-settings-390.144-desktop.patch
+	"${FILESDIR}"/nvidia-settings-390.144-no-gtk2.patch
 	"${FILESDIR}"/nvidia-settings-390.144-raw-ldflags.patch
 )
 
@@ -155,14 +157,6 @@ src_prepare() {
 	# prevent detection of incomplete kernel DRM support (bug #603818)
 	sed 's/defined(CONFIG_DRM/defined(CONFIG_DRM_KMS_HELPER/g' \
 		-i kernel/conftest.sh || die
-
-	sed -e '/Exec=\|Icon=/s/_.*/nvidia-settings/' \
-		-e '/Categories=/s/_.*/System;HardwareSettings;/' \
-		-i nvidia-settings/doc/nvidia-settings.desktop || die
-
-	# remove gtk2 support (bug #592730)
-	sed '/^GTK2LIB = /d;/INSTALL.*GTK2LIB/,+1d' \
-		-i nvidia-settings/src/Makefile || die
 
 	sed 's/__USER__/nvpd/' \
 		nvidia-persistenced/init/systemd/nvidia-persistenced.service.template \

--- a/x11-drivers/nvidia-drivers/nvidia-drivers-495.44-r102.ebuild
+++ b/x11-drivers/nvidia-drivers/nvidia-drivers-495.44-r102.ebuild
@@ -22,13 +22,15 @@ S="${WORKDIR}"
 LICENSE="NVIDIA-r2 BSD BSD-2 GPL-2 MIT ZLIB curl openssl"
 SLOT="0/${PV%%.*}"
 KEYWORDS="-* ~amd64"
-IUSE="+X abi_x86_32 abi_x86_64 +driver static-libs +tools wayland"
+IUSE="+X abi_x86_32 abi_x86_64 +driver persistenced static-libs +tools wayland"
 RESTRICT="bindist"
 
 COMMON_DEPEND="
 	acct-group/video
-	acct-user/nvpd
-	net-libs/libtirpc:=
+	persistenced? (
+		acct-user/nvpd
+		net-libs/libtirpc:=
+	)
 	tools? (
 		dev-libs/atk
 		dev-libs/glib:2
@@ -193,7 +195,7 @@ src_compile() {
 	use driver && linux-mod_src_compile
 
 	emake "${NV_ARGS[@]}" -C nvidia-modprobe
-	emake "${NV_ARGS[@]}" -C nvidia-persistenced
+	use persistenced && emake "${NV_ARGS[@]}" -C nvidia-persistenced
 	use X && emake "${NV_ARGS[@]}" -C nvidia-xconfig
 
 	if use tools; then
@@ -281,18 +283,17 @@ https://wiki.gentoo.org/wiki/NVIDIA/nvidia-drivers"
 		doins supported-gpus/supported-gpus.json
 	fi
 
-	# nvidia-modprobe
 	emake "${NV_ARGS[@]}" -C nvidia-modprobe install
 	fowners :video /usr/bin/nvidia-modprobe #505092
 	fperms 4710 /usr/bin/nvidia-modprobe
 
-	# nvidia-persistenced
-	emake "${NV_ARGS[@]}" -C nvidia-persistenced install
-	newconfd "${FILESDIR}"/nvidia-persistenced.confd nvidia-persistenced
-	newinitd "${FILESDIR}"/nvidia-persistenced.initd nvidia-persistenced
-	systemd_dounit "${T}"/nvidia-persistenced.service
+	if use persistenced; then
+		emake "${NV_ARGS[@]}" -C nvidia-persistenced install
+		newconfd "${FILESDIR}"/nvidia-persistenced.confd nvidia-persistenced
+		newinitd "${FILESDIR}"/nvidia-persistenced.initd nvidia-persistenced
+		systemd_dounit "${T}"/nvidia-persistenced.service
+	fi
 
-	# nvidia-settings
 	if use tools; then
 		emake "${NV_ARGS[@]}" -C nvidia-settings install
 
@@ -310,7 +311,6 @@ https://wiki.gentoo.org/wiki/NVIDIA/nvidia-drivers"
 		doins nvidia-settings/src/libXNVCtrl/NVCtrl{Lib,}.h
 	fi
 
-	# nvidia-xconfig
 	use X && emake "${NV_ARGS[@]}" -C nvidia-xconfig install
 
 	# mimic nvidia-installer by reading .manifest to install files

--- a/x11-drivers/nvidia-drivers/nvidia-drivers-495.44-r102.ebuild
+++ b/x11-drivers/nvidia-drivers/nvidia-drivers-495.44-r102.ebuild
@@ -4,7 +4,8 @@
 EAPI=7
 
 MODULES_OPTIONAL_USE="driver"
-inherit desktop linux-mod readme.gentoo-r1 systemd toolchain-funcs unpacker
+inherit desktop flag-o-matic linux-mod multilib readme.gentoo-r1 \
+	systemd toolchain-funcs unpacker
 
 NV_KERNEL_MAX="5.15"
 NV_URI="https://download.nvidia.com/XFree86/"
@@ -79,6 +80,7 @@ QA_PREBUILT="lib/firmware/* opt/bin/* usr/lib*"
 
 PATCHES=(
 	"${FILESDIR}"/nvidia-modprobe-390.141-uvm-perms.patch
+	"${FILESDIR}"/nvidia-settings-390.144-raw-ldflags.patch
 )
 
 pkg_setup() {
@@ -199,8 +201,10 @@ src_compile() {
 	use X && emake "${NV_ARGS[@]}" -C nvidia-xconfig
 
 	if use tools; then
-		# avoid filling up logs, only use here and set first to allow override
+		# cflags: avoid noisy logs, only use here and set first to let override
+		# ldflags: abi currently needed if LD=ld.lld
 		CFLAGS="-Wno-deprecated-declarations ${CFLAGS}" \
+			RAW_LDFLAGS="$(get_abi_LDFLAGS) $(raw-ldflags)" \
 			emake "${NV_ARGS[@]}" -C nvidia-settings
 	elif use static-libs; then
 		emake "${NV_ARGS[@]}" -C nvidia-settings/src out/libXNVCtrl.a

--- a/x11-drivers/nvidia-drivers/nvidia-drivers-495.44-r102.ebuild
+++ b/x11-drivers/nvidia-drivers/nvidia-drivers-495.44-r102.ebuild
@@ -1,0 +1,482 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+MODULES_OPTIONAL_USE="driver"
+inherit desktop linux-mod readme.gentoo-r1 systemd toolchain-funcs unpacker
+
+NV_KERNEL_MAX="5.15"
+NV_URI="https://download.nvidia.com/XFree86/"
+
+DESCRIPTION="NVIDIA Accelerated Graphics Driver"
+HOMEPAGE="https://www.nvidia.com/download/index.aspx"
+SRC_URI="
+	amd64? ( ${NV_URI}Linux-x86_64/${PV}/NVIDIA-Linux-x86_64-${PV}.run )
+	arm64? ( ${NV_URI}Linux-aarch64/${PV}/NVIDIA-Linux-aarch64-${PV}.run )
+	$(printf "${NV_URI}%s/%s-${PV}.tar.bz2 " \
+		nvidia-{installer,modprobe,persistenced,settings,xconfig}{,})"
+# nvidia-installer is unused but here for GPL-2's "distribute sources"
+S="${WORKDIR}"
+
+LICENSE="NVIDIA-r2 BSD BSD-2 GPL-2 MIT ZLIB curl openssl"
+SLOT="0/${PV%%.*}"
+KEYWORDS="-* ~amd64"
+IUSE="+X abi_x86_32 abi_x86_64 +driver static-libs +tools wayland"
+RESTRICT="bindist"
+
+COMMON_DEPEND="
+	acct-group/video
+	acct-user/nvpd
+	net-libs/libtirpc:=
+	tools? (
+		dev-libs/atk
+		dev-libs/glib:2
+		dev-libs/jansson:=
+		media-libs/harfbuzz:=
+		x11-libs/cairo
+		x11-libs/gdk-pixbuf:2
+		x11-libs/gtk+:3
+		x11-libs/libX11
+		x11-libs/libXext
+		x11-libs/libXxf86vm
+		x11-libs/pango
+	)"
+RDEPEND="
+	${COMMON_DEPEND}
+	X? (
+		media-libs/libglvnd[X,abi_x86_32(-)?]
+		x11-libs/libX11[abi_x86_32(-)?]
+		x11-libs/libXext[abi_x86_32(-)?]
+	)
+	wayland? (
+		>=gui-libs/egl-wayland-1.1.7-r1
+		media-libs/libglvnd
+		>=media-libs/mesa-21.2[gbm(+)]
+		x11-libs/libdrm
+	)"
+DEPEND="
+	${COMMON_DEPEND}
+	static-libs? (
+		x11-libs/libX11
+		x11-libs/libXext
+	)
+	tools? (
+		media-libs/libglvnd
+		sys-apps/dbus
+		x11-base/xorg-proto
+		x11-libs/libXrandr
+		x11-libs/libXv
+		x11-libs/libvdpau
+	)"
+BDEPEND="
+	sys-devel/m4
+	virtual/pkgconfig"
+
+QA_PREBUILT="lib/firmware/* opt/bin/* usr/lib*"
+
+PATCHES=(
+	"${FILESDIR}"/nvidia-modprobe-390.141-uvm-perms.patch
+)
+
+pkg_setup() {
+	use driver || return
+
+	local CONFIG_CHECK="
+		PROC_FS
+		~DRM_KMS_HELPER
+		~SYSVIPC
+		~!DRM_SIMPLEDRM
+		~!LOCKDEP
+		~!SLUB_DEBUG_ON
+		!DEBUG_MUTEXES"
+	local ERROR_DRM_KMS_HELPER="CONFIG_DRM_KMS_HELPER: is not set but needed for Xorg auto-detection
+	of drivers (no custom config), and for wayland / nvidia-drm.modeset=1.
+	Cannot be directly selected in the kernel's menuconfig, and may need
+	selection of a DRM device even if unused, e.g. CONFIG_DRM_AMDGPU=m or
+	DRM_I915=y, DRM_NOUVEAU=m also acceptable if a module and not built-in.
+	Note: DRM_SIMPLEDRM may cause issues and is better disabled for now."
+
+	use amd64 && kernel_is -ge 5 8 && CONFIG_CHECK+=" X86_PAT" #817764
+
+	MODULE_NAMES="
+		nvidia(video:kernel)
+		nvidia-drm(video:kernel)
+		nvidia-modeset(video:kernel)
+		nvidia-peermem(video:kernel)
+		nvidia-uvm(video:kernel)"
+
+	linux-mod_pkg_setup
+
+	[[ ${MERGE_TYPE} == binary ]] && return
+
+	BUILD_PARAMS='NV_VERBOSE=1 IGNORE_CC_MISMATCH=yes SYSSRC="${KV_DIR}" SYSOUT="${KV_OUT_DIR}"'
+	BUILD_TARGETS="modules"
+
+	if linux_chkconfig_present CC_IS_CLANG; then
+		ewarn "Warning: building ${PN} with a clang-built kernel is experimental"
+
+		BUILD_PARAMS+=' CC=${CHOST}-clang'
+		if linux_chkconfig_present LD_IS_LLD; then
+			BUILD_PARAMS+=' LD=ld.lld'
+			if linux_chkconfig_present LTO_CLANG_THIN; then
+				# kernel enables cache by default leading to sandbox violations
+				BUILD_PARAMS+=' ldflags-y=--thinlto-cache-dir= LDFLAGS_MODULE=--thinlto-cache-dir='
+			fi
+		fi
+	fi
+
+	if kernel_is -gt ${NV_KERNEL_MAX/./ }; then
+		ewarn "Kernel ${KV_MAJOR}.${KV_MINOR} is either known to break this version of ${PN}"
+		ewarn "or was not tested with it. It is recommended to use one of:"
+		ewarn "  <=sys-kernel/gentoo-kernel-${NV_KERNEL_MAX}"
+		ewarn "  <=sys-kernel/gentoo-sources-${NV_KERNEL_MAX}"
+		ewarn "You are free to try or use /etc/portage/patches, but support will"
+		ewarn "not be given and issues wait until NVIDIA releases a fixed version."
+		ewarn
+		ewarn "Do _not_ file a bug report if run into issues."
+		ewarn
+	fi
+}
+
+src_prepare() {
+	# make patches usable across versions
+	rm nvidia-modprobe && mv nvidia-modprobe{-${PV},} || die
+	rm nvidia-persistenced && mv nvidia-persistenced{-${PV},} || die
+	rm nvidia-settings && mv nvidia-settings{-${PV},} || die
+	rm nvidia-xconfig && mv nvidia-xconfig{-${PV},} || die
+
+	default
+
+	# prevent detection of incomplete kernel DRM support (bug #603818)
+	sed 's/defined(CONFIG_DRM/defined(CONFIG_DRM_KMS_HELPER/g' \
+		-i kernel/conftest.sh || die
+
+	sed -e '/Exec=\|Icon=/s/_.*/nvidia-settings/' \
+		-e '/Categories=/s/_.*/System;HardwareSettings;/' \
+		-i nvidia-settings/doc/nvidia-settings.desktop || die
+
+	# remove gtk2 support (bug #592730)
+	sed '/^GTK2LIB = /d;/INSTALL.*GTK2LIB/,+1d' \
+		-i nvidia-settings/src/Makefile || die
+
+	sed 's/__USER__/nvpd/' \
+		nvidia-persistenced/init/systemd/nvidia-persistenced.service.template \
+		> "${T}"/nvidia-persistenced.service || die
+
+	# enable nvidia-drm.modeset=1 by default with USE=wayland
+	cp "${FILESDIR}"/nvidia-470.conf "${T}"/nvidia.conf || die
+	use !wayland || sed -i '/^#.*modeset=1$/s/^#//' "${T}"/nvidia.conf || die
+
+	# temporary workaround for dbus powerd spam in 495 series
+	# (jz -> jmp after nvidia.powerd.server, need RESTRICT=bindist)
+	# https://forums.developer.nvidia.com/t/bug-nvidia-v495-29-05-driver-spamming-dbus-enabled-applications-with-invalid-messages/192892/14
+	if use amd64; then
+		sed 's/\x0f\x84\[\x01\x00\x00\x4c\x8d/\xe9\x5c\x01\x00\x00\x00\x4c\x8d/' \
+			-i libnvidia-glcore.so.495.44 || die
+		sed 's/\x0f\x84\x65\x01\x00\x00\x83\xec\x08\x89/\xe9\x66\x01\x00\x00\x00\x83\xec\x08\x89/' \
+			-i 32/libnvidia-glcore.so.495.44 || die
+	fi
+}
+
+src_compile() {
+	tc-export AR CC LD OBJCOPY
+
+	NV_ARGS=(
+		PREFIX="${EPREFIX}"/usr
+		HOST_CC="$(tc-getBUILD_CC)"
+		HOST_LD="$(tc-getBUILD_LD)"
+		NV_USE_BUNDLED_LIBJANSSON=0
+		NV_VERBOSE=1 DO_STRIP= MANPAGE_GZIP= OUTPUTDIR=out
+	)
+
+	use driver && linux-mod_src_compile
+
+	emake "${NV_ARGS[@]}" -C nvidia-modprobe
+	emake "${NV_ARGS[@]}" -C nvidia-persistenced
+	use X && emake "${NV_ARGS[@]}" -C nvidia-xconfig
+
+	if use tools; then
+		# avoid filling up logs, only use here and set first to allow override
+		CFLAGS="-Wno-deprecated-declarations ${CFLAGS}" \
+			emake "${NV_ARGS[@]}" -C nvidia-settings
+	elif use static-libs; then
+		emake "${NV_ARGS[@]}" -C nvidia-settings/src out/libXNVCtrl.a
+	fi
+}
+
+src_install() {
+	local libdir=$(get_libdir) libdir32=$(ABI=x86 get_libdir)
+
+	NV_ARGS+=( DESTDIR="${D}" LIBDIR="${ED}"/usr/${libdir} )
+
+	local -A paths=(
+		[APPLICATION_PROFILE]=/usr/share/nvidia
+		[CUDA_ICD]=/etc/OpenCL/vendors
+		[EGL_EXTERNAL_PLATFORM_JSON]=/usr/share/egl/egl_external_platform.d
+		[FIRMWARE]=/lib/firmware/nvidia/${PV}
+		[GBM_BACKEND_LIB_SYMLINK]=/usr/${libdir}/gbm
+		[GLVND_EGL_ICD_JSON]=/usr/share/glvnd/egl_vendor.d
+		[VULKAN_ICD_JSON]=/usr/share/vulkan
+		[WINE_LIB]=/usr/${libdir}/nvidia/wine
+		[XORG_OUTPUTCLASS_CONFIG]=/usr/share/X11/xorg.conf.d
+
+		[GLX_MODULE_SHARED_LIB]=/usr/${libdir}/xorg/modules/extensions
+		[GLX_MODULE_SYMLINK]=/usr/${libdir}/xorg/modules
+		[XMODULE_SHARED_LIB]=/usr/${libdir}/xorg/modules
+	)
+
+	local skip_files=(
+		$(usex X '' '
+			libGLX_nvidia libglxserver_nvidia
+			nvidia_icd.json nvidia_layers.json')
+		$(usex wayland '' '
+			libnvidia-egl-gbm 15_nvidia_gbm
+			libnvidia-vulkan-producer')
+		libGLX_indirect # non-glvnd unused fallback
+		libnvidia-gtk nvidia-{settings,xconfig} # built from source
+		libnvidia-egl-wayland 10_nvidia_wayland # gui-libs/egl-wayland
+	)
+	local skip_modules=(
+		$(usex X '' 'nvfbc vdpau xdriver')
+		$(usex driver '' 'gsp')
+		installer nvpd # handled separately / built from source
+	)
+	local skip_types=(
+		GLVND_LIB GLVND_SYMLINK EGL_CLIENT.\* GLX_CLIENT.\* # media-libs/libglvnd
+		OPENCL_WRAPPER.\* # virtual/opencl
+		DOCUMENTATION DOT_DESKTOP .\*_SRC DKMS_CONF # handled separately / unused
+	)
+
+	local DOCS=(
+		README.txt NVIDIA_Changelog supported-gpus/supported-gpus.json
+		nvidia-settings/doc/{FRAMELOCK,NV-CONTROL-API}.txt
+	)
+	local HTML_DOCS=( html/. )
+	einstalldocs
+
+	local DISABLE_AUTOFORMATTING=yes
+	local DOC_CONTENTS="\
+Trusted users should be in the 'video' group to use NVIDIA devices.
+You can add yourself by using: gpasswd -a my-user video
+
+See '${EPREFIX}/etc/modprobe.d/nvidia.conf' for modules options.\
+$(use amd64 && usex abi_x86_32 '' "
+
+Note that without USE=abi_x86_32 on ${PN}, 32bit applications
+(typically using wine / steam) will not be able to use GPU acceleration.")
+
+For general information on using ${PN}, please see:
+https://wiki.gentoo.org/wiki/NVIDIA/nvidia-drivers"
+	readme.gentoo_create_doc
+
+	if use driver; then
+		linux-mod_src_install
+
+		insinto /etc/modprobe.d
+		doins "${T}"/nvidia.conf
+
+		# used for gpu verification with binpkgs (not kept, see pkg_preinst)
+		insinto /usr/share/nvidia
+		doins supported-gpus/supported-gpus.json
+	fi
+
+	# nvidia-modprobe
+	emake "${NV_ARGS[@]}" -C nvidia-modprobe install
+	fowners :video /usr/bin/nvidia-modprobe #505092
+	fperms 4710 /usr/bin/nvidia-modprobe
+
+	# nvidia-persistenced
+	emake "${NV_ARGS[@]}" -C nvidia-persistenced install
+	newconfd "${FILESDIR}"/nvidia-persistenced.confd nvidia-persistenced
+	newinitd "${FILESDIR}"/nvidia-persistenced.initd nvidia-persistenced
+	systemd_dounit "${T}"/nvidia-persistenced.service
+
+	# nvidia-settings
+	if use tools; then
+		emake "${NV_ARGS[@]}" -C nvidia-settings install
+
+		doicon nvidia-settings/doc/nvidia-settings.png
+		domenu nvidia-settings/doc/nvidia-settings.desktop
+
+		exeinto /etc/X11/xinit/xinitrc.d
+		newexe "${FILESDIR}"/95-nvidia-settings-r1 95-nvidia-settings
+	fi
+
+	if use static-libs; then
+		dolib.a nvidia-settings/src/out/libXNVCtrl.a
+
+		insinto /usr/include/NVCtrl
+		doins nvidia-settings/src/libXNVCtrl/NVCtrl{Lib,}.h
+	fi
+
+	# nvidia-xconfig
+	use X && emake "${NV_ARGS[@]}" -C nvidia-xconfig install
+
+	# mimic nvidia-installer by reading .manifest to install files
+	# 0:file 1:perms 2:type 3+:subtype/arguments -:module
+	local m into
+	while IFS=' ' read -ra m; do
+		! [[ ${#m[@]} -ge 2 && ${m[-1]} =~ MODULE: ]] ||
+			eval '[[ " ${m[0]##*/}" =~ ^(\ '${skip_files[*]/%/.*|\\}' )$ ]]' ||
+			eval '[[ " ${m[2]}" =~ ^(\ '${skip_types[*]/%/|\\}' )$ ]]' ||
+			has ${m[-1]#MODULE:} "${skip_modules[@]}" && continue
+
+		case ${m[2]} in
+			MANPAGE)
+				gzip -dc ${m[0]} | newman - ${m[0]%.gz}; assert
+				continue
+			;;
+			GBM_BACKEND_LIB_SYMLINK) m[4]=../${m[4]};; # missing ../
+			VDPAU_SYMLINK) m[4]=vdpau/; m[5]=${m[5]#vdpau/};; # .so to vdpau/
+		esac
+
+		if [[ -v paths[${m[2]}] ]]; then
+			into=${paths[${m[2]}]}
+		elif [[ ${m[2]} =~ _BINARY$ ]]; then
+			into=/opt/bin
+		elif [[ ${m[3]} == COMPAT32 ]]; then
+			use abi_x86_32 || continue
+			into=/usr/${libdir32}
+		elif [[ ${m[2]} =~ _LIB$|_SYMLINK$ ]]; then
+			into=/usr/${libdir}
+		else
+			die "No known installation path for ${m[0]}"
+		fi
+		[[ ${m[3]: -2} == ?/ ]] && into+=/${m[3]%/}
+		[[ ${m[4]: -2} == ?/ ]] && into+=/${m[4]%/}
+
+		if [[ ${m[2]} =~ _SYMLINK$ ]]; then
+			[[ ${m[4]: -1} == / ]] && m[4]=${m[5]}
+			dosym ${m[4]} ${into}/${m[0]}
+			continue
+		fi
+		[[ ${m[0]} =~ ^libnvidia-ngx.so|^libnvidia-egl-gbm.so ]] &&
+			dosym ${m[0]} ${into}/${m[0]%.so*}.so.1 # soname not in .manifest
+
+		printf -v m[1] %o $((m[1] | 0200)) # 444->644
+		insopts -m${m[1]}
+		insinto ${into}
+		doins ${m[0]}
+	done < .manifest || die
+
+	# MODULE:installer non-skipped extras
+	exeinto /lib/systemd/system-sleep
+	doexe systemd/system-sleep/nvidia
+	dobin systemd/nvidia-sleep.sh
+	systemd_dounit systemd/system/nvidia-{hibernate,resume,suspend}.service
+
+	dobin nvidia-bug-report.sh
+}
+
+pkg_preinst() {
+	has_version "${CATEGORY}/${PN}[abi_x86_32]" && NV_HAD_ABI32=
+	has_version "${CATEGORY}/${PN}[wayland]" && NV_HAD_WAYLAND=
+
+	use driver || return
+	linux-mod_pkg_preinst
+
+	# set video group id based on live system (bug #491414)
+	local g=$(getent group video | cut -d: -f3)
+	[[ ${g} ]] || die "Failed to determine video group id"
+	sed -i "s/@VIDEOGID@/${g}/" "${ED}"/etc/modprobe.d/nvidia.conf || die
+
+	# try to find driver mismatches using temporary supported-gpus.json
+	for g in $(grep -l 0x10de /sys/bus/pci/devices/*/vendor 2>/dev/null); do
+		g=$(grep -io "\"devid\":\"$(<${g%vendor}device)\"[^}]*branch\":\"[0-9]*" \
+			"${ED}"/usr/share/nvidia/supported-gpus.json 2>/dev/null)
+		if [[ ${g} ]]; then
+			g=$((${g##*\"}+1))
+			if ver_test -ge ${g}; then
+				NV_LEGACY_MASK=">=${CATEGORY}/${PN}-${g}"
+				break
+			fi
+		fi
+	done
+	rm "${ED}"/usr/share/nvidia/supported-gpus.json || die
+}
+
+pkg_postinst() {
+	use driver && linux-mod_pkg_postinst
+
+	readme.gentoo_print_elog
+
+	if [[ -r /proc/driver/nvidia/version &&
+		$(</proc/driver/nvidia/version) != *"  ${PV}  "* ]]; then
+		ewarn "Currently loaded NVIDIA modules do not match the newly installed"
+		ewarn "libraries and may prevent launching GPU-accelerated applications."
+		use driver && ewarn "The easiest way to fix this is usually to reboot."
+	fi
+
+	if [[ $(</proc/cmdline) == *slub_debug=[!-]* ]]; then
+		ewarn "Detected that the current kernel command line is using 'slub_debug=',"
+		ewarn "this may lead to system instability/freezes with this version of"
+		ewarn "${PN}. Bug: https://bugs.gentoo.org/796329"
+	fi
+
+	if [[ -v NV_LEGACY_MASK ]]; then
+		ewarn
+		ewarn "***WARNING***"
+		ewarn
+		ewarn "You are installing a version of ${PN} known not to work"
+		ewarn "with a GPU of the current system. If unwanted, add the mask:"
+		if [[ -d ${EROOT}/etc/portage/package.mask ]]; then
+			ewarn "  echo '${NV_LEGACY_MASK}' > ${EROOT}/etc/portage/package.mask/${PN}"
+		else
+			ewarn "  echo '${NV_LEGACY_MASK}' >> ${EROOT}/etc/portage/package.mask"
+		fi
+		ewarn "...then downgrade to a legacy branch if possible. For details, see:"
+		ewarn "https://www.nvidia.com/object/IO_32667.html"
+	fi
+
+	if use !abi_x86_32 && [[ -v NV_HAD_ABI32 ]]; then
+		elog
+		elog "USE=abi_x86_32 is disabled, 32bit applications will not be able to"
+		elog "use nvidia-drivers for acceleration without it (e.g. commonly used"
+		elog "with app-emulation/wine-* or steam). Re-enable if needed."
+	fi
+
+	if use wayland && use driver && [[ ! -v NV_HAD_WAYLAND ]]; then
+		elog
+		elog "With USE=wayland, this version of ${PN} sets nvidia-drm.modeset=1"
+		elog "in '${EROOT}/etc/modprobe.d/nvidia.conf'. This feature is considered"
+		elog "experimental but is required for wayland."
+		elog
+		elog "If you experience issues, either disable wayland or edit nvidia.conf."
+		elog "Of note, may possibly cause issues with SLI and Reverse PRIME."
+	fi
+
+	if use wayland && [[ ${REPLACING_VERSIONS} ]] &&
+		ver_test ${REPLACING_VERSIONS} -lt 495.29.05; then
+		elog
+		elog "While this version of ${PN} adds GBM support (allowing a"
+		elog "wider range of wayland compositors, such as sway), be warned it is"
+		elog "very experimental and many applications are known to have issues."
+		elog
+		elog "While not essential, some features also need >=egl-wayland-1.1.8"
+		elog "which is known to cause regressions with EGLStream (GBM alternative)."
+		elog
+		elog "If lacking a cursor with wlroots, try WLR_NO_HARDWARE_CURSORS=1"
+	fi
+
+	# Try to show this message only to users that may really need it
+	# given the workaround is discouraged and usage isn't widespread.
+	if use X && [[ ${REPLACING_VERSIONS} ]] &&
+		ver_test ${REPLACING_VERSIONS} -lt 460.73.01 &&
+		grep -qr Coolbits "${EROOT}"/etc/X11/{xorg.conf,xorg.conf.d/*.conf} 2>/dev/null; then
+		elog
+		elog "Coolbits support with ${PN} has been restricted to require Xorg"
+		elog "with root privilege by NVIDIA (being in video group is not sufficient)."
+		elog "e.g. attempting to change fan speed with nvidia-settings would fail."
+		elog
+		elog "Depending on your display manager (e.g. sddm starts X as root, gdm doesn't)"
+		elog "or if using startx, it may be necessary to emerge x11-base/xorg-server with"
+		elog 'USE="suid -elogind -systemd" if wish to keep using this feature.'
+		elog "Bug: https://bugs.gentoo.org/784248"
+	fi
+
+	ewarn
+	ewarn "This revision of ${PN} is applying a binary patch to prevent heavy"
+	ewarn "dbus spamming while using OpenGL. If you experience issues, please try to"
+	ewarn "mask =${CATEGORY}/${PN}-${PVR} to use NVIDIA's intended version."
+}


### PR DESCRIPTION
Attempt at ~complicating~ simplifying things by replicating nvidia-installer and using the .manifest file rather a full manual install (plus some other small changes).

Just throwing this here to ponder whether to use this or not... feedback welcome if anyone happen to look.

pros:
- no need to maintain a list of files to install otherwise requiring close inspection every bumps
- no need to run scanelf on every libraries (removes pax-utils dep fwiw)
- more precise installation (no generic library symlinks)
- easier compatibility with x86/aarch64's .run, if something is amd64-only then it won't be in the .manifest
- mostly-in-one-place list of install paths (top of src_install along with arrays to skip files)
- no more multilib eclass or figuring which libraries have compat32 or not
- inherits fit on one line :eyes:

cons:
- feels like a bad hack and not ebuild-like
- ebuild only barely smaller
- still need some workarounds to handle .manifest inconsistencies that feel a bit fragile
- future maintainers may not know how to handle this whenever it'll need updates, may feel like they are trying to fix kernel-2.eclass
- if partially breaks, files could silently go missing (previously it had to be 1:1 with ebuild save for docs)