### PR TITLE
dev-vcs/subversion: add 'plaintext-password-storage' USE flag

### DIFF
--- a/dev-vcs/subversion/metadata.xml
+++ b/dev-vcs/subversion/metadata.xml
@@ -12,5 +12,6 @@
 	<use>
 		<flag name="extras">Install extra scripts (examples, tools, hooks)</flag>
 		<flag name="kwallet">Enable encrypted storage of passwords with <pkg>kde-frameworks/kwallet</pkg></flag>
+		<flag name="plaintext-password-storage">Enable on-disk caching of plaintext passwords and passphrases. (Enabling this functionality will not force Subversion to store passwords in plaintext, but does permit users to explicitly allow that behavior via runtime configuration.)</flag>
 	</use>
 </pkgmetadata>

--- a/dev-vcs/subversion/subversion-1.14.1.ebuild
+++ b/dev-vcs/subversion/subversion-1.14.1.ebuild
@@ -22,7 +22,7 @@ LICENSE="Apache-2.0 BSD MIT BSD-2 FSFAP unicode"
 SLOT="0"
 [[ "${PV}" = *_rc* ]] || \
 KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ppc ppc64 ~riscv sparc x86 ~amd64-linux ~x86-linux"
-IUSE="apache2 berkdb debug doc extras gnome-keyring java kwallet nls perl ruby sasl test"
+IUSE="apache2 berkdb debug doc extras gnome-keyring java kwallet nls perl plaintext-password-storage ruby sasl test"
 RESTRICT="!test? ( test )"
 
 COMMON_DEPEND="
@@ -184,6 +184,7 @@ src_configure() {
 		$(use_with java jdk "${JAVA_HOME}")
 		$(use_with kwallet)
 		$(use_enable nls)
+		$(use_enable plaintext-password-storage)
 		$(use_with sasl)
 		--with-serf
 		--with-apr="${EPREFIX}/usr/bin/apr-1-config"


### PR DESCRIPTION
This allows the user to opt into insecure password storage if they truly
desire it.