### PR TITLE
dev-util/gn: fix build error on ARCH=riscv

### DIFF
--- a/dev-util/gn/files/gn-0.1807-riscv.patch
+++ b/dev-util/gn/files/gn-0.1807-riscv.patch
@@ -1,0 +1,14 @@
+diff --git a/src/util/build_config.h b/src/util/build_config.h
+index f7cc991..aaf4114 100644
+--- a/src/util/build_config.h
++++ b/src/util/build_config.h
+@@ -161,6 +161,9 @@
+ #define ARCH_CPU_32_BITS 1
+ #define ARCH_CPU_BIG_ENDIAN 1
+ #endif
++#elif defined(__riscv) && (__riscv_xlen == 64)
++#define ARCH_CPU_64_BITS 1
++#define ARCH_CPU_LITTLE_ENDIAN 1
+ #else
+ #error Please add support for your architecture in build_config.h
+ #endif

--- a/dev-util/gn/gn-0.1807.ebuild
+++ b/dev-util/gn/gn-0.1807.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2018-2020 Gentoo Authors
+# Copyright 2018-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -22,6 +22,7 @@ BDEPEND="
 
 PATCHES=(
 	"${FILESDIR}"/gn-gen-r4.patch
+	"${FILESDIR}"/${P}-riscv.patch
 )
 
 pkg_setup() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/821400
Package-Manager: Portage-3.0.28, Repoman-3.0.3
Signed-off-by: Yixun Lan <dlan@gentoo.org>