### PR TITLE
package.mask: re-mask bitcoin >=0.21.1

### DIFF
--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -636,6 +636,18 @@ net-libs/libsoup:3.0
 # breaks if not all at least many revdeps. #805011 for tracker bug.
 >=net-libs/mbedtls-3.0.0
 
+# Luke Dashjr <luke-jr+gentoobugs@utopios.org> (2021-11-04)
+# This release adds enforcement of the Taproot protocol change to the Bitcoin
+# rules, beginning in November. Protocol changes require user consent to be
+# effective, and if enforced inconsistently within the community may compromise
+# your security or others! If you do not know what you are doing, learn more
+# before November. (You must make a decision either way - simply not upgrading
+# is insecure in all scenarios.)
+# To learn more, see https://bitcointaproot.cc
+>=net-p2p/bitcoind-0.21.1
+>=net-p2p/bitcoin-qt-0.21.1
+>=net-libs/libbitcoinconsensus-0.21.1
+
 # Lars Wendler <polynomial-c@gentoo.org> (2021-07-10)
 # Masked for testing
 # bug #802186


### PR DESCRIPTION
Without a mask, automatic upgrades would trigger, which is unethical (at least at this time).

This reverts commit ae7251a476e1ea18a429bf012dcdf45ec59662a6.
