### PR TITLE
net-p2p/mldomkey: Add systemd service unit and remove obsolete settings from the OpenRC script

### DIFF
--- a/net-p2p/mldonkey/files/mldonkey.confd
+++ b/net-p2p/mldonkey/files/mldonkey.confd
@@ -9,7 +9,7 @@
 USER="p2p"
 
 # mldonkey's working dir (must be existing)
-MLDONKEY_DIR="/home/p2p/mldonkey"
+MLDONKEY_DIR="/var/lib/mldonkey"
 
 # logfile (/dev/null for nowhere)
 LOG="/var/log/mldonkey.log"
@@ -18,25 +18,5 @@ LOG="/var/log/mldonkey.log"
 #     set log_to_syslog true
 USE_LOGGER=false
 
-# bandwidth control, values in kb/s
-LOW_DOWN="6"
-LOW_UP="2"
-HIGH_DOWN="30"
-HIGH_UP="10"
-
 # nice level, 0<x<19, more nice -> less cpuspeed consumed
 NICE="19"
-
-# mldonkey server ip, usually localhost
-SERVER="localhost"
-
-# port for webinterface, usually 4080
-PORT="4080"
-
-# port for telnet interface, usually 4000
-TELNET_PORT="4000"
-
-# to enable password restricted access,
-# uncomment and set BOTH following vars:
-#USERNAME="admin"
-#PASSWORD=""

--- a/net-p2p/mldonkey/files/mldonkey.initd
+++ b/net-p2p/mldonkey/files/mldonkey.initd
@@ -3,7 +3,6 @@
 extra_started_commands="reload slow fast info"
 
 MLDONKEY_BINARY=${MLDONKEY_BINARY:-/usr/bin/mlnet}
-MLDONKEY_TIMEOUT=${TIMEOUT:-10}
 
 depend() {
 	need localmount net
@@ -11,13 +10,16 @@ depend() {
 }
 
 start() {
+	if [ -n "${BASEDIR}${SUBDIR}${LOW_DOWN}${LOW_UP}${HIGH_DOWN}${HIGH_UP}${SERVER}${PORT}${TELNET_PORT}${USERNAME}${PASSWORD}${MLDONKEY_TIMEOUT}" ]; then
+		ewarn "The following settings are deprecated and will be ignored,"
+		ewarn "please remove them from /etc/conf.d/mldonkey:"
+		ewarn "LOW_DOWN LOW_UP HIGH_DOWN HIGH_UP SERVER PORT TELNET_PORT USERNAME PASSWORD MLDONKEY_TIMEOUT"
+	fi
+
 	if [ -z "${MLDONKEY_DIR}" ]; then
-		ewarn "mldonkey's start script has been changed. You should remove"
-		ewarn "BASEDIR and SUBDIR from /etc/conf.d/mldonkey and set MLDONKEY_DIR"
-		ewarn "to the correct value (you probably want"
-		ewarn "MLDONKEY_DIR=${BASEDIR}/${SUBDIR})"
-		MLDONKEY_DIR="${BASEDIR}/${SUBDIR}"
-		einfo "Using ${MLDONKEY_DIR} as working directory"
+		eerror "Please set MLDONKEY_DIR in /etc/conf.d/mldonkey to the directory"
+		eerror "where you want MLDonkey to save its files"
+		return 1
 	fi
 
 	if [ ! -d "${MLDONKEY_DIR}" ]; then
@@ -27,84 +29,16 @@ start() {
 	fi
 
 	ebegin "Starting ${SVCNAME}"
-	cd "${MLDONKEY_DIR}"
-	export MLDONKEY_DIR
 	start-stop-daemon --start --user "${USER}" --nice "${NICE}" \
 		--exec "${MLDONKEY_BINARY}" --pidfile /var/run/"${SVCNAME}".pid \
-		--background --make-pidfile
+		--env "MLDONKEY_DIR=${MLDONKEY_DIR}" --background --make-pidfile
 	eend $?
-}
-
-send_telnet_commands() {
-	if [ -z "${TELNET_PORT+x}" ]; then
-		return 1
-	fi
-	local cmds=
-	if [ -n "${USERNAME}" -a -n "${PASSWORD}" ]; then
-		cmds="auth ${USERNAME} ${PASSWORD}\n"
-	fi
-	cmds="$cmds\nansi false\n"
-	while [ $# -gt 0 ]; do
-		cmds="$cmds$1\n"
-		shift
-	done
-	printf "$cmds\nexit\n" | nc -w "${MLDONKEY_TIMEOUT}" localhost "${TELNET_PORT}" 2> /dev/null
-	return $?
-}
-
-send_http_commands() {
-	if [ -z "${PORT+x}" ]; then
-		return 1
-	fi
-	local base="http://"
-	if [ -n "${USERNAME}" -a -n "${PASSWORD}" ]; then
-		base="${base}${USERNAME}:${PASSWORD}@"
-	fi
-	base="${base}${SERVER}:${PORT}"
-	local retval=0
-	while [ $retval -eq 0 -a $# -gt 0 ]; do
-		wget -q -O /dev/stdout --timeout="${MLDONKEY_TIMEOUT}" "${base}/submit?q=${1// /+}" 2> /dev/null
-		retval=$?
-		shift
-	done
-	return $retval
-}
-
-send_commands() {
-	send_telnet_commands "$@" &> /dev/null || send_http_commands "$@" &> /dev/null
-	return $?
 }
 
 stop() {
-	ebegin "Stopping ${SVCNAME} -- please wait"
-
-	send_commands close_fds save kill
-
-	# give it a chance to die:
-	local timeout=${MLDONKEY_TIMEOUT}
-	while [ $timeout -gt 0 ]; do
-		if ! start-stop-daemon --test --quiet --quiet --stop \
-			--exec "${MLDONKEY_BINARY}" \
-			--pidfile /var/run/"${SVCNAME}".pid ; then
-			eend 0
-			return 0
-		fi
-		sleep 1
-		timeout=$((${timeout} - 1))
-	done
-
-	eend 1 "Failed to cleanly stop ${SVCNAME}"
-	ebegin "Forcing ${SVCNAME} to stop"
 	start-stop-daemon --stop --exec "${MLDONKEY_BINARY}" \
 		--pidfile /var/run/"${SVCNAME}".pid
 	eend $?
-}
-
-# This doesn't work for baselayout-2
-restart() {
-	svc_stop
-	sleep 5
-	svc_start
 }
 
 reload() {
@@ -112,30 +46,4 @@ reload() {
 	start-stop-daemon --stop --signal HUP --oknodo \
 		--exec "${MLDONKEY_BINARY}" --pidfile /var/run/"${SVCNAME}".pid
 	eend $?
-}
-
-slow() {
-	ebegin "Reducing bandwidth to ${LOW_DOWN}k/${LOW_UP}k"
-	send_commands "set max_hard_download_rate ${LOW_DOWN}" "set max_hard_upload_rate ${LOW_UP}"
-	eend $?
-}
-
-fast() {
-	ebegin "Increasing bandwidth to ${HIGH_DOWN}k/${HIGH_UP}k"
-	send_commands "set max_hard_upload_rate ${HIGH_UP}" "set max_hard_download_rate ${HIGH_DOWN}"
-	eend $?
-}
-
-
-info() {
-	set -o pipefail
-	local result=$(
-		send_telnet_commands "voo max_hard_upload_rate" | grep -a 'max_hard_upload_rate.* =' | cut -d \  -f 3 ||
-		send_http_commands "voo max_hard_upload_rate" | fgrep name=value | sed -e 's/.*value="//' -e 's/".*//'
-	)
-	if [ "${result}" = "${LOW_UP}" ]; then
-		einfo "${SVCNAME} runs slow"
-	else
-		einfo "${SVCNAME} runs fast"
-	fi
 }

--- a/net-p2p/mldonkey/files/mldonkey.service
+++ b/net-p2p/mldonkey/files/mldonkey.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=MLDonkey multi-network P2P client service
+After=network.target
+
+[Service]
+User=p2p
+LimitNICE=+19
+Environment=MLDONKEY_DIR=/var/lib/mldonkey
+ExecStart=/usr/bin/mlnet
+ExecReload=/bin/kill -HUP $MAINPID
+KillMode=process
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Sorry for the long PR message, but I want to unroll all the bits in this PR.

* It adds a systemd service unit.
  This service had a complex logic for its OpenRC script and a bunch of settings in a conf.d file which would be quite hard to port to systemd.
  Instead, I realized it would be much easier and convenient to simplify the OpenRC script and have a similar behaviour with OpenRC and systemd.
* The way the OpenRC script worked so far to stop the service was by sending the [`close_fds`](http://mldonkey.sourceforge.net/Close_fds), [`save`](http://mldonkey.sourceforge.net/Save) and [`kill`](http://mldonkey.sourceforge.net/Kill) commands to the process, first via telnet and then via HTTP, as an attempt to orderly shut it down before failing back to sending it a SIGTERM.
  However, this is unnecessary. Just sending a SIGTERM works because the process is able to catch it and orderly shutdown itself saving its configurations:
  ```
  2021/10/31 14:34:48 [dMain] Received SIGTERM, stopping MLDonkey...
  2021/10/31 14:34:49 [cCO] Options correctly saved
  2021/10/31 14:34:49 [cCO] Sources correctly saved
  2021/10/31 14:34:49 [cCO] Options backup as .tar.gz correctly saved
  2021/10/31 14:34:49 [dMain] Core stopped
  ```
  So, the whole telnet / HTTP complexity is now removed and now the service is stopped with a SIGTERM instead like any other regular service.
  This was made not only for the sake of simplicity but also because of the concerns raised (and discussed on #gentoo-dev-help) about calling wget and netcat from an OpenRC script and storing plaintext passwords in a conf.d file for the service to be able to use them to send those commands.
* By removing all netcat / HTTP stuff, the custom OpenRC commands `slow`, `fast` and `info` are also removed.
  Those commands were used to toggle MLDonkey between "slow" and "high" bandwidth configurations.
  However, this was implemented on OpenRC side conflicting with MLDonkey's own mechanism for this.
  MLDonkey supports two bandwidth configuration presets (`max_hard_upload_rate`, `max_hard_download_rate` and `max_opened_connections`, and `max_hard_upload_rate2`, `max_hard_download_rate2` and `max_opened_connections2`) and can switch between one or the other with the `bw_toggle` command.
  The OpenRC script ignored all that (or maybe it was not yet implemented on MLDonkey's side when the OpenRC script was made) and implemented its own bandwidth toggle mechanism conflicting with MLDonkey's own one by altering the values of `max_hard_upload_rate` and `max_hard_download_rate` to `LOW_UP` and `LOW_DOWN` values from the conf.d file respectively if the low preset was chosen or `HIGH_UP` and `HIGH_DOWN` for the high one, overriding MLDonkey's own ability to manage two bandwidth configuration presets.
* It has been changed how `MLDONKEY_DIR` conf.d setting is used.
  So far, the OpenRC script was first checking whether the directory existed. If it existed, it was starting MLDonkey there considering it an existing MLDonkey data directory. If it didn't exist, it created it and started MLDonkey there with the intention of using it as a new data directory for MLDonkey.
  This no longer works this way from MLDonkey version 2.6.2 (released 16 years ago!): https://github.com/ygrek/mldonkey/blob/master/docs/ChangeLog.old#L2459
  MLDonkey won't use an empty directory to store its data as the OpenRC script expects.
  Now, if MLDonkey doesn't find a `donwload.ini` file in the current directory, it will fail back to `~/.mldonkey` and won't use the directory where the process was started as it has been doing before.
  So, setting `MLDONKEY_DIR` to a non-existing directory with the hope that will be created and used to place MLDonkey files won't give the expected result as the OpenRC script was trying so far.
  The init script was modified to check if `MLDONKEY_DIR` was set and fail if it's set to a non-existing directory.
* For a similar reason, `acct-user/p2p` was modified to have a real home directory, otherwise new installations would fail trying to create ~/.mldonkey:
  ```
  [cO] MLDonkey is working in /dev/null/.mldonkey
  [cO] creating new MLDonkey base directory in /dev/null/.mldonkey
  [cO] Exception (Failure("/dev/null already exists but is not a directory")) trying to create dir /dev/null/.mldonkey
  ```
  I don't really like using `/home/p2p` as its home directory and this actually triggered a QA notice:
  ```
   * QA Notice: The ebuild is installing to one or more unexpected paths:
   * 
   *   /home
   * 
   * Please fix the ebuild to use correct FHS/Gentoo policy paths.
  ```
  But it was kept this way for consistency with the previous behaviour. Comments are welcome though.
* Lastly, since many options were removed from the conf.d file because they are no longer used (either because of the removed LOW/HIGH functionality or because they were required for wget / netcat) and, especially, since one of them was sensitive (the administrator password), both the ebuild and the OpenRC script will check for those retired settings and print a warning if they are still found in the conf.d file.

I know we don't like bundling more than one change per commit, but as you can see, all of them are interconnected.