### PR TITLE
media-libs/opensubdiv: use cuda eclass

### DIFF
--- a/media-libs/opensubdiv/files/opensubdiv-3.4.4-add-CUDA11-compatibility.patch
+++ b/media-libs/opensubdiv/files/opensubdiv-3.4.4-add-CUDA11-compatibility.patch
@@ -1,0 +1,19 @@
+From: "Alexander Golubev" <fatzer2@gmail.com>
+
+Set correct default minimal -arch for CUDA 9 and 11
+--- OpenSubdiv-3_4_4/CMakeLists.txt     2021-11-07 02:01:07.899484952 +0300
++++ OpenSubdiv-3_4_4/CMakeLists.txt.new 2021-11-07 02:01:23.402764409 +0300
+@@ -587,8 +587,12 @@
+         if (NOT DEFINED OSD_CUDA_NVCC_FLAGS)
+             if (CUDA_VERSION_MAJOR LESS 6)
+                 set( OSD_CUDA_NVCC_FLAGS --gpu-architecture compute_11 )
+-            else()
++            elseif (CUDA_VERSION_MAJOR LESS 9)
+                 set( OSD_CUDA_NVCC_FLAGS --gpu-architecture compute_20 )
++            elseif (CUDA_VERSION_MAJOR LESS 11)
++                set( OSD_CUDA_NVCC_FLAGS --gpu-architecture compute_30 )
++            else()
++                set( OSD_CUDA_NVCC_FLAGS --gpu-architecture compute_35 )
+             endif()
+         endif()
+     endif()

--- a/media-libs/opensubdiv/opensubdiv-3.4.4-r2.ebuild
+++ b/media-libs/opensubdiv/opensubdiv-3.4.4-r2.ebuild
@@ -1,0 +1,93 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+CMAKE_MAKEFILE_GENERATOR=emake
+
+inherit cmake cuda toolchain-funcs
+
+MY_PV="$(ver_rs "1-3" '_')"
+DESCRIPTION="An Open-Source subdivision surface library"
+HOMEPAGE="https://graphics.pixar.com/opensubdiv/docs/intro.html"
+SRC_URI="https://github.com/PixarAnimationStudios/OpenSubdiv/archive/v${MY_PV}.tar.gz -> ${P}.tar.gz"
+S="${WORKDIR}/OpenSubdiv-${MY_PV}"
+
+# Modfied Apache-2.0 license, where section 6 has been replaced.
+# See for example CMakeLists.txt for details.
+LICENSE="Apache-2.0"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~x86"
+IUSE="cuda examples opencl openmp ptex tbb test tutorials"
+RESTRICT="!test? ( test )"
+
+RDEPEND="
+	media-libs/glew:=
+	media-libs/glfw:=
+	x11-libs/libXinerama
+	cuda? ( dev-util/nvidia-cuda-toolkit:* )
+	opencl? ( virtual/opencl )
+	ptex? ( media-libs/ptex )
+"
+DEPEND="
+	${RDEPEND}
+	tbb? ( <dev-cpp/tbb-2021.4.0:= )
+"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-3.3.0-use-gnuinstalldirs.patch"
+	"${FILESDIR}/${PN}-3.4.3-install-tutorials-into-bin.patch"
+	"${FILESDIR}/${P}-add-CUDA11-compatibility.patch"
+)
+
+pkg_pretend() {
+	[[ ${MERGE_TYPE} != binary ]] && use openmp && tc-check-openmp
+}
+
+pkg_setup() {
+	[[ ${MERGE_TYPE} != binary ]] && use openmp && tc-check-openmp
+}
+
+src_prepare() {
+	cmake_src_prepare
+
+	use cuda && cuda_src_prepare
+}
+
+src_configure() {
+	# GLTESTS are disabled as portage is unable to open a display during test phase
+	# TODO: virtx work?
+	local mycmakeargs=(
+		-DGLEW_LOCATION="${ESYSROOT}/usr/$(get_libdir)"
+		-DGLFW_LOCATION="${ESYSROOT}/usr/$(get_libdir)"
+		-DNO_CLEW=ON
+		-DNO_CUDA=$(usex !cuda)
+		# Docs needed Python 2 so disabled
+		# bug #815172
+		-DNO_DOC=ON
+		-DNO_EXAMPLES=$(usex !examples)
+		-DNO_GLTESTS=ON
+		-DNO_OMP=$(usex !openmp)
+		-DNO_OPENCL=$(usex !opencl)
+		-DNO_PTEX=$(usex !ptex)
+		-DNO_REGRESSION=$(usex !test)
+		-DNO_TBB=$(usex !tbb)
+		-DNO_TESTS=$(usex !test)
+		-DNO_TUTORIALS=$(usex !tutorials)
+	)
+
+	if use cuda; then
+		# old cmake CUDA module doesn't use environment variable to initialize flags
+		mycmakeargs+=( -DCUDA_NVCC_FLAGS="${NVCCFLAGS}" )
+
+		# check if user provided --gpu-architecture/-arch flag and prevent cmake from overriding it if so
+		for f in ${NVCCFLAGS}; do
+			if [[ ${f} == -arch* || ${f} == --gpu-architecture* ]]; then
+				mycmakeargs+=( -DOSD_CUDA_NVCC_FLAGS="" )
+				break
+			fi
+		done
+	fi
+
+	cmake_src_configure
+}


### PR DESCRIPTION
* Utilize cuda eclass and let it handle gcc selection instead of forcing
  an outdated version.
* Add a fix to provide sane defaults when compiling against a recent
  enough CUDA versions.
* Add an option to pass user-specified NVCCFLAGS and prevent cmake from
  overriding them.

Closes: https://bugs.gentoo.org/744517
Closes: https://bugs.gentoo.org/751382
Signed-off-by: Alexander Golubev <fatzer2@gmail.com>