### PR TITLE
dev-util/perf-5.12: allow python 3.10

### DIFF
--- a/dev-util/perf/perf-5.12.ebuild
+++ b/dev-util/perf/perf-5.12.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{7,8,9} )
+PYTHON_COMPAT=( python3_{7..10} )
 inherit bash-completion-r1 estack llvm toolchain-funcs prefix python-r1 linux-info
 
 DESCRIPTION="Userland tools for Linux Performance Counters"


### PR DESCRIPTION
Hi,
the current dev-util/perf ebuild allows python 3.7 to 3.9.
May I ask to allow 3.10?
Upstream I was not able to found any specific python version dependency/test.

Thanks