### PR TITLE
fix issue with gstreamer-plugins-bad not compiling

### DIFF
--- a/eclass/gstreamer-meson.eclass
+++ b/eclass/gstreamer-meson.eclass
@@ -384,6 +384,7 @@ gstreamer_multilib_src_compile() {
 
 		for plugin_dir in ${GST_PLUGINS_BUILD_DIR} ; do
 			plugin=$(_gstreamer_get_target_filename $(gstreamer_get_plugin_dir ${plugin_dir}))
+			plugin=`echo "${plugin}" | sed -e 's/"${BUILD_DIR}"//'`
 			plugin_path="${plugin%%:*}"
 			eninja "${plugin_path/"${BUILD_DIR}/"}"
 		done


### PR DESCRIPTION
### Bug
- Bug: [https://bugs.gentoo.org/820416](https://bugs.gentoo.org/820416)
- Bug: [https://bugs.gentoo.org/805020](https://bugs.gentoo.org/805020)
Issue with gstreamer-bad-plugins plugins not being able to compile. Initially I thought it was the ebuild that had issues. But after trying to install other plugins of the same version, I've concluded it was an eclass bug.
### Issue
ninja -v -j6 -l0 /home/tmp-portage/media-plugins/gst-plugins-srtp-1.18.4/work/gst-plugins-bad-1.18.4-abi_x86_64.amd64/ext/srtp/libgstsrtp.so
ninja: error: unknown target '/home/tmp-portage/media-plugins/gst-plugins-srtp-1.18.4/work/gst-plugins-bad-1.18.4-abi_x86_64.amd64/ext/srtp/libgstsrtp.so'
### Fix
Shortened ninja target for compilation fixes issue.
ninja -v -j6 -l0 ext/srtp/libgstsrtp.so