### PR TITLE
gstreamer-meson.eclass: fix ninja compilation issue

### DIFF
--- a/eclass/gstreamer-meson.eclass
+++ b/eclass/gstreamer-meson.eclass
@@ -384,6 +384,7 @@ gstreamer_multilib_src_compile() {
 
 		for plugin_dir in ${GST_PLUGINS_BUILD_DIR} ; do
 			plugin=$(_gstreamer_get_target_filename $(gstreamer_get_plugin_dir ${plugin_dir}))
+			plugin=`echo "${plugin}" | sed -e 's/"${BUILD_DIR}"//'`
 			plugin_path="${plugin%%:*}"
 			eninja "${plugin_path/"${BUILD_DIR}/"}"
 		done


### PR DESCRIPTION
Closes: [https://bugs.gentoo.org/820416](https://bugs.gentoo.org/820416)
Closes: [https://bugs.gentoo.org/805020](https://bugs.gentoo.org/805020)
Signed-off-by: Tony Lee [tonylee100100@gmail.com](tonylee100100@gmail.com)

Issue with gstreamer-bad-plugins ebuild not being able to compile. Initially I thought it was the ebuild that had issues. But after unsuccessfully trying to install other plugins in the same version. It ended up being a eclass issue instead.
### Issue
Ninja not set to correct target
`ninja -v -j6 -l0 /home/tmp-portage/media-plugins/gst-plugins-srtp-1.18.4/work/gst-plugins-bad-1.18.4-abi_x86_64.amd64/ext/srtp/libgstsrtp.so`
`ninja: error: unknown target '/home/tmp-portage/media-plugins/gst-plugins-srtp-1.18.4/work/gst-plugins-bad-1.18.4-abi_x86_64.amd64/ext/srtp/libgstsrtp.so'`
### Fix
Change to correct target.
`ninja -v -j6 -l0 ext/srtp/libgstsrtp.so`