### PR TITLE
dev-tex/latex2html: fix pstoimg.pl PNMCROPOPT

### DIFF
--- a/dev-tex/latex2html/files/latex2html-2021.2-fix-PNMCROPOPT.patch
+++ b/dev-tex/latex2html/files/latex2html-2021.2-fix-PNMCROPOPT.patch
@@ -1,0 +1,31 @@
+From ea0ae1cf6789cf8f29bf07406ef6e91918b6bfc3 Mon Sep 17 00:00:00 2001
+From: Matthew White <mehw.is.me@inventati.org>
+Date: Wed, 10 Nov 2021 00:32:14 +0000
+Subject: [PATCH] fix pnmcrop duplicated -sides option (aka PNMCROPOPT)
+
+If the variable PNMCROPOPT is defined as "-sides" via config/config.pl
+in pstoimg.bin, calling `pnmcrop -bot -sides $PNMCROPOPT` will give an
+error, due to the duplicated option.
+---
+ pstoimg.pin | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/pstoimg.pin b/pstoimg.pin
+index 2c4f3e4..588b987 100755
+--- a/pstoimg.pin
++++ b/pstoimg.pin
+@@ -1300,9 +1300,9 @@ sub crop_scale_etc {
+     my $edge = $1;
+     my $croparg = '';
+     if($edge =~ /b/i) {
+-      $croparg = "-bot -sides $PNMCROPOPT ";
++      $croparg = "-bot -sides ";
+     } elsif($edge =~ /[tlr]/i) {
+-      $croparg = "-$edge -sides $PNMCROPOPT ";
++      $croparg = "-$edge -sides ";
+     } elsif($edge =~ /s/i) {
+       #RRM: shave at most 1-2 rows of white from the bottom
+ #if @pipes@
+-- 
+2.32.0
+

--- a/dev-tex/latex2html/latex2html-2021.2-r2.ebuild
+++ b/dev-tex/latex2html/latex2html-2021.2-r2.ebuild
@@ -1,0 +1,82 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="Convertor written in Perl that converts LaTeX documents to HTML"
+HOMEPAGE="https://www.latex2html.org/"
+SRC_URI="https://github.com/latex2html/latex2html/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
+IUSE="gif png"
+
+DEPEND="
+	app-text/ghostscript-gpl
+	virtual/latex-base
+	>=media-libs/netpbm-10.86.24
+	dev-lang/perl
+	gif? ( media-libs/giflib )
+	png? ( media-libs/libpng:0 )"
+RDEPEND="${DEPEND}"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-2021.2-fix-PNMCROPOPT.patch
+	"${FILESDIR}"/${PN}-2021.2-respect-DESTDIR.patch
+)
+
+src_prepare() {
+	default
+
+	sed -i -e 's%@PERL@%'"${EPREFIX}"'/usr/bin/perl%g' wrapper/unix.pin || die
+}
+
+src_configure() {
+	local myconf
+
+	use gif || use png || myconf+=" --disable-images"
+
+	econf \
+		--libdir="${EPREFIX}"/usr/$(get_libdir)/latex2html \
+		--shlibdir="${EPREFIX}"/usr/$(get_libdir)/latex2html \
+		--enable-pk \
+		--enable-eps \
+		--enable-reverse \
+		--enable-pipes \
+		--enable-paths \
+		--enable-wrapper \
+		--with-texpath="${EPREFIX}"/usr/share/texmf-site/tex/latex/html \
+		--without-mktexlsr \
+		$(use_enable gif) \
+		$(use_enable png) \
+		${myconf}
+}
+
+src_install() {
+	emake DESTDIR="${D}" install
+
+	# make /usr/share/latex2html sticky
+	keepdir /usr/share/latex2html
+
+	# clean the perl scripts up to remove references to the sandbox
+	local dir="${ED}/usr/$(get_libdir)/latex2html"
+	if use png || use gif; then
+		# pstoimg isn't built unless gif or png useflags are enabled
+		sed -i -e "s:${T}:/tmp:g" "${dir}"/pstoimg.pl || die
+	fi
+
+	sed -i -e "s:${S}::g" "${dir}"/latex2html.pl || die
+	sed -i -e "s:${T}:/tmp:g" "${dir}"/cfgcache.pm || die
+	sed -i -e "s:${T}:/tmp:g" "${dir}"/l2hconf.pm || die
+
+	dodoc BUGS Changes FAQ MANIFEST README.md TODO
+}
+
+pkg_postinst() {
+	"${EROOT}"/usr/bin/mktexlsr
+}
+
+pkg_postrm() {
+	"${EROOT}"/usr/bin/mktexlsr
+}


### PR DESCRIPTION
Apply upstream patch.

`pstoimg.pl` should not call `pnmcrop` with a duplicated `-sides` option.

Refer to upstream PR https://github.com/latex2html/latex2html/pull/73.
```
diff -u latex2html-2021.2-r1.ebuild latex2html/latex2html-2021.2-r2.ebuild
--- latex2html-2021.2-r1.ebuild	2021-11-11 23:21:44.836997159 +0100
+++ latex2html-2021.2-r2.ebuild	2021-11-11 23:25:19.358060912 +0100
@@ -22,6 +22,7 @@
 RDEPEND="${DEPEND}"
 
 PATCHES=(
+	"${FILESDIR}"/${PN}-2021.2-fix-PNMCROPOPT.patch
 	"${FILESDIR}"/${PN}-2021.2-respect-DESTDIR.patch
 )
 
```