### PR TITLE
mail-filter/rspamd: make USE=jit to control only PCRE JIT support

### DIFF
--- a/mail-filter/rspamd/metadata.xml
+++ b/mail-filter/rspamd/metadata.xml
@@ -18,5 +18,6 @@
   </upstream>
   <use>
     <flag name="pcre2">Use dev-libs/libpcre2</flag>
+    <flag name="jit">Enable PCRE JIT support</flag>
   </use>
 </pkgmetadata>

--- a/mail-filter/rspamd/rspamd-2.7-r103.ebuild
+++ b/mail-filter/rspamd/rspamd-2.7-r103.ebuild
@@ -21,8 +21,7 @@ LICENSE="Apache-2.0 Boost-1.0 BSD BSD-1 BSD-2 CC0-1.0 LGPL-3 MIT public-domain u
 SLOT="0"
 IUSE="blas cpu_flags_x86_ssse3 jemalloc +jit pcre2"
 
-REQUIRED_USE="${LUA_REQUIRED_USE}
-	jit? ( lua_single_target_luajit )"
+REQUIRED_USE="${LUA_REQUIRED_USE}"
 
 RDEPEND="${LUA_DEPS}
 	$(lua_gen_cond_dep '

--- a/mail-filter/rspamd/rspamd-3.0-r3.ebuild
+++ b/mail-filter/rspamd/rspamd-3.0-r3.ebuild
@@ -24,7 +24,6 @@ RESTRICT="!test? ( test )"
 
 # A part of tests use ffi luajit extension
 REQUIRED_USE="${LUA_REQUIRED_USE}
-	jit? ( lua_single_target_luajit )
 	test? ( lua_single_target_luajit )"
 
 RDEPEND="${LUA_DEPS}

--- a/mail-filter/rspamd/rspamd-3.1.ebuild
+++ b/mail-filter/rspamd/rspamd-3.1.ebuild
@@ -24,7 +24,6 @@ RESTRICT="!test? ( test )"
 
 # A part of tests use ffi luajit extension
 REQUIRED_USE="${LUA_REQUIRED_USE}
-	jit? ( lua_single_target_luajit )
 	test? ( lua_single_target_luajit )"
 
 RDEPEND="${LUA_DEPS}

--- a/mail-filter/rspamd/rspamd-9999.ebuild
+++ b/mail-filter/rspamd/rspamd-9999.ebuild
@@ -24,7 +24,6 @@ RESTRICT="!test? ( test )"
 
 # A part of tests use ffi luajit extension
 REQUIRED_USE="${LUA_REQUIRED_USE}
-	jit? ( lua_single_target_luajit )
 	test? ( lua_single_target_luajit )"
 
 RDEPEND="${LUA_DEPS}


### PR DESCRIPTION
It is valid configuration to use JIT enabled PCRE with non-JIT Lua and
vice versa, as it was pointed out in a bug report. Therefore, this
change removes
```
jit? ( lua_single_target_luajit )
```
restriction from all available ebuilds.

I have tested in runtime all possible combinations `jit`, `pcre`, `lua5-{1,4}` and `luajit` for `rspamd-{2.7,3.1}`, all seems to run correctly.