### PR TITLE
sys-apps/texinfo: enable Carp in the Texinfo::Config namespace - amend 879158d

### DIFF
--- a/sys-apps/texinfo/files/texinfo-6.8-enable-Carp.patch
+++ b/sys-apps/texinfo/files/texinfo-6.8-enable-Carp.patch
@@ -1,20 +1,18 @@
-This fixes
+Enable Carp in the Texinfo::Config namespace.
+
+Fixes bulding media-video/ffmpeg-4.4 docs.
 
 makeinfo: warning: error loading ./doc/t2h.pm: Undefined subroutine &Texinfo::Config::carp called at /usr/share/texinfo/Texinfo/Convert/HTML.pm line 7308.
-Compilation failed in require at /usr/bin/makeinfo line 342.
-
-when building media-video/ffmpeg-4.4 docs.
 
 diff -Nuar a/tp/texi2any.pl b/tp/texi2any.pl
 --- a/tp/texi2any.pl	2021-06-30 16:25:37.000000000 +0200
-+++ b/tp/texi2any.pl	2021-11-11 04:17:32.000000000 +0100
-@@ -34,7 +34,7 @@
- #use Cwd;
- use Getopt::Long qw(GetOptions);
- # for carp
++++ b/tp/texi2any.pl	2021-11-12 17:31:20.000000000 +0100
+@@ -322,7 +322,7 @@
+ {
+ package Texinfo::Config;
+ 
 -#use Carp;
 +use Carp;
  
- Getopt::Long::Configure("gnu_getopt");
- 
-
+ # passed from main program
+ my $cmdline_options;


### PR DESCRIPTION
I'm sorry everyone, I need to amend the patch I presented in #22908, to build ffmpeg docs, **Carp** needs to be enabled in the **Texinfo::Config** namespace... Long story short, I manually fixed `texi2any` correctly on my system but prepared the wrong patch (there's more than one `"use Carp"` line)...

`makeinfo: warning: error loading ./doc/t2h.pm: Undefined subroutine &Texinfo::Config::carp called at /usr/share/texinfo/Texinfo/Convert/HTML.pm line 7308.`

I checked that the fix works correctly, and I hope that you may forgive my mistake...