### PR TITLE
sys-auth/elogind: add patch to enable clang-13 compilation

### DIFF
--- a/sys-auth/elogind/elogind-246.10-r3.ebuild
+++ b/sys-auth/elogind/elogind-246.10-r3.ebuild
@@ -52,6 +52,7 @@ PATCHES=(
 	"${FILESDIR}/${PN}-243.7-nodocs.patch"
 	"${FILESDIR}/${PN}-241.4-broken-test.patch" # bug 699116
 	"${FILESDIR}/${P}-revert-polkit-automagic.patch"
+	"${FILESDIR}/${P}-clang-undefined-symbol.patch"
 )
 
 pkg_setup() {

--- a/sys-auth/elogind/files/elogind-246.10-clang-undefined-symbol.patch
+++ b/sys-auth/elogind/files/elogind-246.10-clang-undefined-symbol.patch
@@ -1,0 +1,20 @@
+--- a/src/libelogind/sd-bus/bus-error.h
++++ b/src/libelogind/sd-bus/bus-error.h
+@@ -28,11 +28,17 @@ int bus_error_set_errnofv(sd_bus_error *e, int error, const char *format, va_lis
+  * the bus error table, and BUS_ERROR_MAP_ELF_USE has to be used at
+  * least once per compilation unit (i.e. per library), to ensure that
+  * the error map is really added to the final binary.
++ *
++ * In addition, set the retain attribute so that the section cannot be
++ * discarded by ld --gc-sections -z start-stop-gc. Older compilers would
++ * warn for the unknown attribute, so just disable -Wattributes.
+  */
+ 
+ #define BUS_ERROR_MAP_ELF_REGISTER                                      \
++        _Pragma("GCC diagnostic ignored \"-Wattributes\"")              \
+         _section_("SYSTEMD_BUS_ERROR_MAP")                              \
+         _used_                                                          \
++        __attribute__((retain))                                         \
+         _alignptr_                                                      \
+         _variable_no_sanitize_address_
+


### PR DESCRIPTION
The patch is extract from upstream:
https://github.com/elogind/elogind/commit/cd5390335303da11f3aeaa5431dd7a88c5a9b3e9

The related error is discussed at:
https://githubmemory.com/repo/elogind/elogind/issues/215

Signed-off-by: Yang Yang <geraint0923@gmail.com>