### PR TITLE
media-libs/openexr: destabilize 2.5.6 for ~ppc64

### DIFF
--- a/media-libs/ctl/ctl-1.5.2-r1.ebuild
+++ b/media-libs/ctl/ctl-1.5.2-r1.ebuild
@@ -11,7 +11,7 @@ SRC_URI="https://github.com/ampas/CTL/archive/${P}.tar.gz"
 
 LICENSE="AMPAS"
 SLOT="0"
-KEYWORDS="amd64 ~ia64 ppc64 x86"
+KEYWORDS="amd64 ~ia64 ~ppc64 x86"
 
 RDEPEND="media-libs/ilmbase:=
 	media-libs/openexr:=

--- a/media-libs/ctl/ctl-1.5.2-r2.ebuild
+++ b/media-libs/ctl/ctl-1.5.2-r2.ebuild
@@ -12,7 +12,7 @@ S="${WORKDIR}/CTL-ctl-${PV}"
 
 LICENSE="AMPAS"
 SLOT="0"
-KEYWORDS="amd64 ~ia64 ppc64 x86"
+KEYWORDS="amd64 ~ia64 ~ppc64 x86"
 IUSE="test"
 
 RESTRICT="!test? ( test )"

--- a/media-libs/openexr/openexr-2.5.6.ebuild
+++ b/media-libs/openexr/openexr-2.5.6.ebuild
@@ -14,7 +14,7 @@ S="${WORKDIR}/${P}/OpenEXR"
 LICENSE="BSD"
 SLOT="0/25" # based on SONAME
 # -ppc -sparc because broken on big endian, bug #818424
-KEYWORDS="amd64 ~arm arm64 ~ia64 -ppc ppc64 -sparc x86 ~amd64-linux ~x86-linux ~x64-macos ~x86-solaris"
+KEYWORDS="amd64 ~arm arm64 ~ia64 -ppc ~ppc64 -sparc x86 ~amd64-linux ~x86-linux ~x64-macos ~x86-solaris"
 IUSE="cpu_flags_x86_avx doc examples static-libs utils test"
 RESTRICT="!test? ( test )"
 

--- a/profiles/arch/powerpc/ppc64/64le/use.stable.mask
+++ b/profiles/arch/powerpc/ppc64/64le/use.stable.mask
@@ -1,6 +1,11 @@
 # Copyright 2019-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Sam James <sam@gentoo.org> (2021-11-14)
+# media-libs/openexr is not marked stable on ppc64
+# (it's broken on BE and it's more convenient to keep it at ~arch here for now)
+openexr
+
 # Michał Górny <mgorny@gentoo.org> (2021-05-04)
 # Python 3.10 is not yet stable (and will not be until it's out of beta,
 # around September.

--- a/profiles/arch/powerpc/ppc64/use.stable.mask
+++ b/profiles/arch/powerpc/ppc64/use.stable.mask
@@ -4,6 +4,11 @@
 # This file requires eapi 5 or later. New entries go on top.
 # Please use the same syntax as in use.mask
 
+# Sam James <sam@gentoo.org> (2021-11-14)
+# media-libs/openexr is not marked stable on ppc64
+# (it's broken on BE and it's more convenient to keep it at ~arch here for now)
+openexr
+
 # Michał Górny <mgorny@gentoo.org> (2021-05-04)
 # Python 3.10 is not yet stable (and will not be until it's out of beta,
 # around September.


### PR DESCRIPTION
We already had to mask this on ppc64be and mark it -ppc
entirely and I don't usually do testing on ppc64le.

Let's see if we can drop the stable keyword
entirely here to make life easier.

Bug: https://bugs.gentoo.org/787452
Signed-off-by: Sam James <sam@gentoo.org>