### PR TITLE
net-misc/openssh: Upstream fix for CVE-2021-41617 for v8.5

### DIFF
--- a/net-misc/openssh/files/openssh-8.5_p1-upstream-cve-2021-41617.patch
+++ b/net-misc/openssh/files/openssh-8.5_p1-upstream-cve-2021-41617.patch
@@ -1,0 +1,26 @@
+diff --git a/misc.c b/misc.c
+index d988ce3b..33eca1c1 100644
+--- a/misc.c
++++ b/misc.c
+@@ -56,6 +56,7 @@
+ #ifdef HAVE_PATHS_H
+ # include <paths.h>
+ #include <pwd.h>
++#include <grp.h>
+ #endif
+ #ifdef SSH_TUN_OPENBSD
+ #include <net/if.h>
+@@ -2629,6 +2630,13 @@ subprocess(const char *tag, const char *command,
+ 		}
+ 		closefrom(STDERR_FILENO + 1);
+ 
++		if (geteuid() == 0 &&
++		    initgroups(pw->pw_name, pw->pw_gid) == -1) {
++			error("%s: initgroups(%s, %u): %s", tag,
++			    pw->pw_name, (u_int)pw->pw_gid, strerror(errno));
++			_exit(1);
++		}
++
+ 		if (setresgid(pw->pw_gid, pw->pw_gid, pw->pw_gid) == -1) {
+ 			error("%s: setresgid %u: %s", tag, (u_int)pw->pw_gid,
+ 			    strerror(errno));

--- a/net-misc/openssh/openssh-8.5_p1-r3.ebuild
+++ b/net-misc/openssh/openssh-8.5_p1-r3.ebuild
@@ -132,6 +132,7 @@ src_prepare() {
 	eapply "${FILESDIR}"/${PN}-7.5_p1-disable-conch-interop-tests.patch
 	eapply "${FILESDIR}"/${PN}-8.0_p1-fix-putty-tests.patch
 	eapply "${FILESDIR}"/${PN}-8.0_p1-deny-shmget-shmat-shmdt-in-preauth-privsep-child.patch
+	eapply "${FILESDIR}"/${PN}-8.5_p1-upstream-cve-2021-41617.patch
 
 	# workaround for https://bugs.gentoo.org/734984
 	use X509 || eapply "${FILESDIR}"/${PN}-8.3_p1-sha2-include.patch


### PR DESCRIPTION
Patch source: https://src.fedoraproject.org/rpms/openssh/blob/f33/f/openssh-8.7p1-upstream-cve-2021-41617.patch