### PR TITLE
vulkan-sdk: Use the upstream sdk version

### DIFF
--- a/dev-util/vulkan-headers/vulkan-headers-9999.ebuild
+++ b/dev-util/vulkan-headers/vulkan-headers-9999.ebuild
@@ -10,9 +10,9 @@ if [[ ${PV} == *9999* ]]; then
 	EGIT_REPO_URI="https://github.com/KhronosGroup/${MY_PN}.git"
 	inherit git-r3
 else
-	SRC_URI="https://github.com/KhronosGroup/${MY_PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+	SRC_URI="https://github.com/KhronosGroup/${MY_PN}/archive/sdk-${PV}.tar.gz -> ${P}.tar.gz"
 	KEYWORDS="~amd64 ~ppc64 ~x86"
-	S="${WORKDIR}"/${MY_PN}-${PV}
+	S="${WORKDIR}"/${MY_PN}-sdk-${PV}
 fi
 
 DESCRIPTION="Vulkan Header files and API registry"

--- a/dev-util/vulkan-tools/vulkan-tools-9999.ebuild
+++ b/dev-util/vulkan-tools/vulkan-tools-9999.ebuild
@@ -13,9 +13,9 @@ if [[ ${PV} == *9999* ]]; then
 	EGIT_SUBMODULES=()
 	inherit git-r3
 else
-	SRC_URI="https://github.com/KhronosGroup/${MY_PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+	SRC_URI="https://github.com/KhronosGroup/${MY_PN}/archive/sdk-${PV}.tar.gz -> ${P}.tar.gz"
 	KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~riscv"
-	S="${WORKDIR}"/${MY_PN}-${PV}
+	S="${WORKDIR}"/${MY_PN}-sdk-${PV}
 fi
 
 DESCRIPTION="Official Vulkan Tools and Utilities for Windows, Linux, Android, and MacOS"

--- a/media-libs/vulkan-layers/vulkan-layers-9999.ebuild
+++ b/media-libs/vulkan-layers/vulkan-layers-9999.ebuild
@@ -13,9 +13,9 @@ if [[ ${PV} == *9999* ]]; then
 	EGIT_SUBMODULES=()
 	inherit git-r3
 else
-	SRC_URI="https://github.com/KhronosGroup/${MY_PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+	SRC_URI="https://github.com/KhronosGroup/${MY_PN}/archive/sdk-${PV}.tar.gz -> ${P}.tar.gz"
 	KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~riscv ~x86"
-	S="${WORKDIR}"/${MY_PN}-${PV}
+	S="${WORKDIR}"/${MY_PN}-sdk-${PV}
 fi
 
 DESCRIPTION="Vulkan Validation Layers"

--- a/media-libs/vulkan-loader/vulkan-loader-9999.ebuild
+++ b/media-libs/vulkan-loader/vulkan-loader-9999.ebuild
@@ -12,9 +12,9 @@ if [[ ${PV} == *9999* ]]; then
 	EGIT_SUBMODULES=()
 	inherit git-r3
 else
-	SRC_URI="https://github.com/KhronosGroup/${MY_PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+	SRC_URI="https://github.com/KhronosGroup/${MY_PN}/archive/sdk-${PV}.tar.gz -> ${P}.tar.gz"
 	KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~riscv ~x86"
-	S="${WORKDIR}"/${MY_PN}-${PV}
+	S="${WORKDIR}"/${MY_PN}-sdk-${PV}
 fi
 
 DESCRIPTION="Vulkan Installable Client Driver (ICD) Loader"


### PR DESCRIPTION
This changes all of the applicable vulkan-sdk ebuilds to use the upstream vulkan-sdk versions and git tags.

Most of the projects associated with the vulkan-sdk all follow the sdk version and have corresponding git tags like `sdk-1.2.189.0`. These projects often have other release tags that may or may not correspond to stable vulkan-sdk version like `v1.2.189` or `v1.2.191` in the case of vulkan-tools (https://github.com/KhronosGroup/Vulkan-Tools/tags). In the past Gentoo has updated to versions that do not correspond to the upstream stable versions which can have unintended consequences (https://gitweb.gentoo.org/repo/gentoo.git/commit/dev-util/vulkan-tools?id=fc0c7ffef2e01b2599211b144d8fba270e1cad97). For example when I noticed this it was because I could not build gfxreconstruct (https://github.com/LunarG/gfxreconstruct/tags) which ships sdk tags as well as a second unrelated versioning scheme that doesn't necessarily correspond to the rest of the vulkan-sdk.

The best way to ensure Gentoo only ships the correct stable versions is use the sdk tags to have better consistency with upstream as recorded at vulkan.lunarg.com. Upstream has been consistent with this versioning scheme for a long time and there should be no worries of incompatibilities. Users should not notice any difference with this update.

https://vulkan.lunarg.com/sdk/home#linux

Some projects that follow a different versioning scheme are glslang, spirv-tools and spirv-headers, but they should not have an issue here. In the past it was required to look at the `known_good.json` files in the vulkan-sdk projects as well in glslang to find the compatible commit hashes, but this seems to have largely improved in the recent past where the latest stable tags work.