### PR TITLE
app-mobilephone/scrcpy: add missing dep dev-libs/libusb

### DIFF
--- a/app-mobilephone/scrcpy/scrcpy-1.20.ebuild
+++ b/app-mobilephone/scrcpy/scrcpy-1.20.ebuild
@@ -16,7 +16,8 @@ SLOT="0"
 KEYWORDS="~amd64 ~ppc64 ~x86"
 
 RDEPEND="media-libs/libsdl2[X]
-	media-video/ffmpeg"
+	media-video/ffmpeg
+	virtual/libusb:1"
 DEPEND="${RDEPEND}"
 BDEPEND=""
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/823910
Package-Manager: Portage-3.0.28, Repoman-3.0.3
Signed-off-by: Marco Genasci <fedeliallalinea@gmail.com>