### PR TITLE
Instruction update

### DIFF
--- a/media-video/pipewire/pipewire-0.3.40-r1.ebuild
+++ b/media-video/pipewire/pipewire-0.3.40-r1.ebuild
@@ -224,23 +224,26 @@ pkg_postinst() {
 	fi
 
 	if use systemd; then
-		elog "To use PipeWire for audio, the user units must be manually enabled"
+		elog "When switching from PulseAudio, you may need to disable PulseAudio:"
+		elog
+		elog "  systemctl --user disable pulseaudio.service pulseaudio.socket"
+		elog
+		elog "To use PipeWire, the user units must be manually enabled"
 		elog "by running this command as each user you use for desktop activities:"
 		elog
-		elog "  systemctl --user enable --now pipewire.socket pipewire-pulse.socket"
-		elog
-		elog "When switching from PulseAudio, do not forget to disable PulseAudio likewise:"
-		elog
-		elog "  systemctl --user disable --now pulseaudio.service pulseaudio.socket"
+		elog "  systemctl --user enable pipewire.socket pipewire-pulse.socket"
 		elog
 		elog "A reboot is recommended to avoid interferences from still running"
 		elog "PulseAudio daemon."
 		elog
-		elog "Both, new users and those upgrading, need to enable WirePlumber"
+		elog "Both new users and those upgrading need to enable WirePlumber"
 		elog "for relevant users:"
 		elog
-		elog "  systemctl --user enable --now wireplumber.service"
+		elog "  systemctl --user disable pipewire-media-session.service"
+		elog "  systemctl --user --force enable wireplumber.service"
 		elog
+		elog "Root user may replace --user with --global to change system default"
+		elog "configuration for all of the above commands."
 	else
 		ewarn "PipeWire daemon startup has been moved to a launcher script!"
 		ewarn "Make sure that ${EROOT}/etc/pipewire/pipewire.conf either does not exist or no"
@@ -273,6 +276,7 @@ pkg_postinst() {
 		elog "its config, please start by copying default config from ${EROOT}/usr/share/pipewire"
 		elog "and just override the sections you want to change."
 	fi
+	elog
 
 	elog "For latest tips and tricks, troubleshooting information and documentation"
 	elog "in general, please refer to https://wiki.gentoo.org/wiki/PipeWire"
@@ -284,7 +288,7 @@ pkg_postinst() {
 	if has_version 'net-misc/ofono' ; then
 		ewarn "Native backend has become default. Please disable oFono via:"
 		if systemd_is_booted ; then
-			ewarn "systemctl disable --now ofono"
+			ewarn "systemctl disable ofono"
 		else
 			ewarn "rc-update delete ofono"
 		fi

--- a/media-video/pipewire/pipewire-9999.ebuild
+++ b/media-video/pipewire/pipewire-9999.ebuild
@@ -224,23 +224,26 @@ pkg_postinst() {
 	fi
 
 	if use systemd; then
-		elog "To use PipeWire for audio, the user units must be manually enabled"
+		elog "When switching from PulseAudio, you may need to disable PulseAudio:"
+		elog
+		elog "  systemctl --user disable pulseaudio.service pulseaudio.socket"
+		elog
+		elog "To use PipeWire, the user units must be manually enabled"
 		elog "by running this command as each user you use for desktop activities:"
 		elog
-		elog "  systemctl --user enable --now pipewire.socket pipewire-pulse.socket"
-		elog
-		elog "When switching from PulseAudio, do not forget to disable PulseAudio likewise:"
-		elog
-		elog "  systemctl --user disable --now pulseaudio.service pulseaudio.socket"
+		elog "  systemctl --user enable pipewire.socket pipewire-pulse.socket"
 		elog
 		elog "A reboot is recommended to avoid interferences from still running"
 		elog "PulseAudio daemon."
 		elog
-		elog "Both, new users and those upgrading, need to enable WirePlumber"
+		elog "Both new users and those upgrading need to enable WirePlumber"
 		elog "for relevant users:"
 		elog
-		elog "  systemctl --user enable --now wireplumber.service"
+		elog "  systemctl --user disable pipewire-media-session.service"
+		elog "  systemctl --user --force enable wireplumber.service"
 		elog
+		elog "Root user may replace --user with --global to change system default"
+		elog "configuration for all of the above commands."
 	else
 		ewarn "PipeWire daemon startup has been moved to a launcher script!"
 		ewarn "Make sure that ${EROOT}/etc/pipewire/pipewire.conf either does not exist or no"
@@ -273,6 +276,7 @@ pkg_postinst() {
 		elog "its config, please start by copying default config from ${EROOT}/usr/share/pipewire"
 		elog "and just override the sections you want to change."
 	fi
+	elog
 
 	elog "For latest tips and tricks, troubleshooting information and documentation"
 	elog "in general, please refer to https://wiki.gentoo.org/wiki/PipeWire"
@@ -284,7 +288,7 @@ pkg_postinst() {
 	if has_version 'net-misc/ofono' ; then
 		ewarn "Native backend has become default. Please disable oFono via:"
 		if systemd_is_booted ; then
-			ewarn "systemctl disable --now ofono"
+			ewarn "systemctl disable ofono"
 		else
 			ewarn "rc-update delete ofono"
 		fi

--- a/media-video/wireplumber/wireplumber-0.4.5.ebuild
+++ b/media-video/wireplumber/wireplumber-0.4.5.ebuild
@@ -75,8 +75,8 @@ pkg_postinst() {
 	if systemd_is_booted ; then
 		ewarn "pipewire-media-session.service is no longer installed. You must switch"
 		ewarn "to wireplumber.service user unit before your next logout/reboot:"
-		ewarn "systemctl --user disable --now pipewire-media-session.service"
-		ewarn "systemctl --user enable --now wireplumber.service"
+		ewarn "systemctl --user disable pipewire-media-session.service"
+		ewarn "systemctl --user --force enable wireplumber.service"
 	else
 		ewarn "Switch to WirePlumber will happen the next time gentoo-pipewire-launcher"
 		ewarn "is started (a replacement for directly calling pipewire binary)."

--- a/media-video/wireplumber/wireplumber-9999.ebuild
+++ b/media-video/wireplumber/wireplumber-9999.ebuild
@@ -75,8 +75,8 @@ pkg_postinst() {
 	if systemd_is_booted ; then
 		ewarn "pipewire-media-session.service is no longer installed. You must switch"
 		ewarn "to wireplumber.service user unit before your next logout/reboot:"
-		ewarn "systemctl --user disable --now pipewire-media-session.service"
-		ewarn "systemctl --user enable --now wireplumber.service"
+		ewarn "systemctl --user disable pipewire-media-session.service"
+		ewarn "systemctl --user --force enable wireplumber.service"
 	else
 		ewarn "Switch to WirePlumber will happen the next time gentoo-pipewire-launcher"
 		ewarn "is started (a replacement for directly calling pipewire binary)."


### PR DESCRIPTION
This updates instructions for PipeWire and WirePlumber ebuilds to avoid using potentially dangerous --now flag and to use --force where there may be dangling symlinks, which would cause the enable command to fail.

To be extra clear, --now itself is not dangerous but the operator needs to understand that they must ensure that only matching daemons are being run together. I.e. in case of version upgrade, --now must be combined with first restarting all relevant daemons (which in turn first requires systemctl --user daemon-reload).

Finally I have decided that there is no merit for me to push forward with leio's idea of vendor presets, since for my purposes status quo works well enough without opening a huge can of worms about how it's all supposed to work together or what happens if other ebuilds also want to be vendor preset but in ways that conflict with another to be preset unit.