### PR TITLE
profiles/arch/hppa: un-stable-mask USE=introspection

### DIFF
--- a/profiles/arch/hppa/use.stable.mask
+++ b/profiles/arch/hppa/use.stable.mask
@@ -21,7 +21,6 @@ doc
 # Avoid stabling chunks of GNOME and such as much as possible.
 # bug #807637
 colord
-introspection
 
 # Hans de Graaff <graaff@gentoo.org> (2021-10-10)
 # Temporary entry to support the ruby27 stable bug 801289


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/807637
Signed-off-by: Sam James <sam@gentoo.org>