### PR TITLE
net-misc/rsync: fix CVE-2020-14387

### DIFF
--- a/net-misc/rsync/files/rsync-3.2.3-verify-certificate.patch
+++ b/net-misc/rsync/files/rsync-3.2.3-verify-certificate.patch
@@ -1,0 +1,26 @@
+From c3f7414c450faaf6a8281cc4a4403529aeb7d859 Mon Sep 17 00:00:00 2001
+From: Matt McCutchen <matt@mattmccutchen.net>
+Date: Wed, 26 Aug 2020 12:16:08 -0400
+Subject: [PATCH] rsync-ssl: Verify the hostname in the certificate when using
+ openssl.
+
+---
+ rsync-ssl | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/rsync-ssl b/rsync-ssl
+index 8101975a..46701af1 100755
+--- a/rsync-ssl
++++ b/rsync-ssl
+@@ -129,7 +129,7 @@ function rsync_ssl_helper {
+     fi
+ 
+     if [[ $RSYNC_SSL_TYPE == openssl ]]; then
+-	exec $RSYNC_SSL_OPENSSL s_client $caopt $certopt -quiet -verify_quiet -servername $hostname -connect $hostname:$port
++	exec $RSYNC_SSL_OPENSSL s_client $caopt $certopt -quiet -verify_quiet -servername $hostname -verify_hostname $hostname -connect $hostname:$port
+     elif [[ $RSYNC_SSL_TYPE == gnutls ]]; then
+ 	exec $RSYNC_SSL_GNUTLS --logfile=/dev/null $gnutls_cert_opt $gnutls_opts $hostname:$port
+     else
+-- 
+2.25.1
+

--- a/net-misc/rsync/rsync-3.2.3-r5.ebuild
+++ b/net-misc/rsync/rsync-3.2.3-r5.ebuild
@@ -36,8 +36,10 @@ DEPEND="${RDEPEND}"
 
 src_prepare() {
 	local PATCHES=(
-		"${FILESDIR}/rsync-3.2.3-glibc-lchmod.patch"
-		"${FILESDIR}/rsync-3.2.3-cross.patch"
+		"${FILESDIR}/${P}-glibc-lchmod.patch"
+		"${FILESDIR}/${P}-cross.patch"
+		# Fix for (CVE-2020-14387) - net-misc/rsync: improper TLS validation in rsync-ssl script
+		"${FILESDIR}/${P}-verify-certificate.patch"
 	)
 	default
 	eautoconf -o configure.sh


### PR DESCRIPTION
Fix CVE-2020-14387 - the fix for the  CVE-2020-14387 is not released in 3.2.3. As per the https://download.samba.org/pub/rsync/NEWS, the last released version is over an year ago. Cherry-picking the fix to the current version.

Bug: https://bugs.gentoo.org/792576

Signed-off-by: Varsha Teratipally teratipally@google.com