### PR TITLE
sys-devel/gcc-config: warn on obsolete gcj wrapper

### DIFF
--- a/sys-devel/gcc-config/gcc-config-2.5-r1.ebuild
+++ b/sys-devel/gcc-config/gcc-config-2.5-r1.ebuild
@@ -49,4 +49,12 @@ pkg_postinst() {
 	if [[ ! ${ROOT} && -f ${EPREFIX}/usr/share/eselect/modules/compiler-shadow.eselect ]] ; then
 		eselect compiler-shadow update all
 	fi
+
+	if ! has_version "sys-devel/gcc[gcj(-)]" && [[ -x "${EROOT}"/usr/bin/gcj ]] ; then
+		# Warn about obsolete /usr/bin/gcj for bug #804178
+		ewarn "Obsolete GCJ wrapper found: ${EROOT}/usr/bin/gcj!"
+		ewarn "Please delete this file unless you know it is needed (e.g. custom gcj install)."
+		ewarn "If you have no idea what this means, please delete the file:"
+		ewarn " rm ${EROOT}/usr/bin/gcj"
+	fi
 }

--- a/sys-devel/gcc-config/gcc-config-9999.ebuild
+++ b/sys-devel/gcc-config/gcc-config-9999.ebuild
@@ -7,7 +7,7 @@ if [[ ${PV} == 9999 ]]; then
 	EGIT_REPO_URI="https://anongit.gentoo.org/git/proj/gcc-config.git"
 	inherit git-r3
 else
-	SRC_URI="https://dev.gentoo.org/~sam/distfiles/${P}.tar.xz"
+	SRC_URI="https://dev.gentoo.org/~sam/distfiles/${CATEGORY}/${PN}/${P}.tar.xz"
 	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
 fi
 
@@ -39,15 +39,6 @@ src_install() {
 }
 
 pkg_postinst() {
-	# Scrub eselect-compiler remains.
-	# To be removed in 2021.
-	rm -f "${ROOT}"/etc/env.d/05compiler
-
-	# We not longer use the /usr/include/g++-v3 hacks, as
-	# it is not needed ...
-	# To be removed in 2021.
-	rm -f "${ROOT}"/usr/include/g++{,-v3}
-
 	# Do we have a valid multi ver setup ?
 	local x
 	for x in $(gcc-config -C -l 2>/dev/null | awk '$NF == "*" { print $2 }') ; do
@@ -57,5 +48,13 @@ pkg_postinst() {
 	# USE flag change can add or delete files in /usr/bin worth recaching
 	if [[ ! ${ROOT} && -f ${EPREFIX}/usr/share/eselect/modules/compiler-shadow.eselect ]] ; then
 		eselect compiler-shadow update all
+	fi
+
+	if ! has_version "sys-devel/gcc[gcj(-)]" && [[ -x "${EROOT}"/usr/bin/gcj ]] ; then
+		# Warn about obsolete /usr/bin/gcj for bug #804178
+		ewarn "Obsolete GCJ wrapper found: ${EROOT}/usr/bin/gcj!"
+		ewarn "Please delete this file unless you know it is needed (e.g. custom gcj install)."
+		ewarn "If you have no idea what this means, please delete the file:"
+		ewarn " rm ${EROOT}/usr/bin/gcj"
 	fi
 }


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/804178
Signed-off-by: Sam James <sam@gentoo.org>