### PR TITLE
kde-frameworks/kpackage: skip failing testpackage-appstream test

### DIFF
--- a/kde-frameworks/kpackage/kpackage-5.88.0.ebuild
+++ b/kde-frameworks/kpackage/kpackage-5.88.0.ebuild
@@ -33,7 +33,8 @@ src_configure() {
 }
 
 src_test() {
-	#bug 650214
-	local myctestargs=( -E "(plasma-plasmoidpackagetest)" )
+	# plasma-plasmoidpackagetest bug 650214 
+	# testpackage-appstream requires network access
+	local myctestargs=( -E "(plasma-plasmoidpackagetest|testpackage-appstream)" )
 	ecm_src_test
 }


### PR DESCRIPTION
only runs when the command 'appstreamcli' is installed
requires network access

		https://www.kde.org/donate.php?app=org.kde.testpackage - Failed to download file:
      	Couldn't connect to server

Signed-off-by: James Beddek <telans@posteo.de>