### PR TITLE
kde-frameworks/ki18n: exclude failing tests requiring LANG fr_CH

### DIFF
--- a/kde-frameworks/ki18n/ki18n-5.88.0.ebuild
+++ b/kde-frameworks/ki18n/ki18n-5.88.0.ebuild
@@ -40,3 +40,9 @@ src_configure() {
 	)
 	ecm_src_configure
 }
+
+src_test() {
+	# requires LANG fr_CH. bug 823816
+	local myctestargs=( -E "(kcountrytest|kcountrysubdivisiontest)" )
+	ecm_src_test
+}


### PR DESCRIPTION
See: https://invent.kde.org/frameworks/ki18n/-/blob/master/autotests/kcountrysubdivisiontest.cpp#L16

Closes: https://bugs.gentoo.org/823816
Signed-off-by: James Beddek <telans@posteo.de>