### PR TITLE
kde-apps/kalarmcal: force TZ=UTC for tests

### DIFF
--- a/kde-apps/kalarmcal/kalarmcal-21.08.3.ebuild
+++ b/kde-apps/kalarmcal/kalarmcal-21.08.3.ebuild
@@ -31,5 +31,7 @@ DEPEND="${RDEPEND}
 "
 
 src_test() {
-	LC_TIME="C" ecm_src_test #bug 665626
+	# LC_TIME bug 665626
+	# TZ bug https://bugs.kde.org/show_bug.cgi?id=445734
+	LC_TIME="C" TZ=UTC ecm_src_test
 }


### PR DESCRIPTION
See: https://bugs.kde.org/show_bug.cgi?id=445734

Signed-off-by: James Beddek <telans@posteo.de>