### PR TITLE
www-client/seamonkey: Do not enable system-sqlite by default

### DIFF
--- a/www-client/seamonkey/seamonkey-2.53.8.1.ebuild
+++ b/www-client/seamonkey/seamonkey-2.53.8.1.ebuild
@@ -49,7 +49,7 @@ SRC_URI+="
 
 LICENSE="MPL-2.0 GPL-2 LGPL-2.1"
 SLOT="0"
-SYSTEM_IUSE=( +system-{av1,harfbuzz,icu,jpeg,libevent,libvpx,sqlite} )
+SYSTEM_IUSE=( +system-{av1,harfbuzz,icu,jpeg,libevent,libvpx} system-sqlite )
 IUSE="+chatzilla cpu_flags_arm_neon +crypt dbus debug +gmp-autoupdate +ipc jack
 lto pulseaudio +roaming selinux startup-notification test wifi"
 IUSE+=" ${SYSTEM_IUSE[@]}"

--- a/www-client/seamonkey/seamonkey-2.53.9.1.ebuild
+++ b/www-client/seamonkey/seamonkey-2.53.9.1.ebuild
@@ -48,7 +48,7 @@ SRC_URI+="
 
 LICENSE="MPL-2.0 GPL-2 LGPL-2.1"
 SLOT="0"
-SYSTEM_IUSE=( +system-{av1,harfbuzz,icu,jpeg,libevent,libvpx,sqlite} )
+SYSTEM_IUSE=( +system-{av1,harfbuzz,icu,jpeg,libevent,libvpx} system-sqlite )
 IUSE="+chatzilla cpu_flags_arm_neon +crypt dbus debug +gmp-autoupdate +ipc jack
 lto pulseaudio +roaming selinux startup-notification test wifi"
 IUSE+=" ${SYSTEM_IUSE[@]}"

--- a/www-client/seamonkey/seamonkey-2.53.9.ebuild
+++ b/www-client/seamonkey/seamonkey-2.53.9.ebuild
@@ -48,7 +48,7 @@ SRC_URI+="
 
 LICENSE="MPL-2.0 GPL-2 LGPL-2.1"
 SLOT="0"
-SYSTEM_IUSE=( +system-{av1,harfbuzz,icu,jpeg,libevent,libvpx,sqlite} )
+SYSTEM_IUSE=( +system-{av1,harfbuzz,icu,jpeg,libevent,libvpx} system-sqlite )
 IUSE="+chatzilla cpu_flags_arm_neon +crypt dbus debug +gmp-autoupdate +ipc jack
 lto pulseaudio +roaming selinux startup-notification test wifi"
 IUSE+=" ${SYSTEM_IUSE[@]}"


### PR DESCRIPTION
Using system-sqlite requires enabling secure-delete flag on SQLite3.
This flag is not required by any other package in Gentoo, and enabling
it could lead to both decreased performance and increased disk wear.
Let's not enable it by default.

Closes: https://bugs.gentoo.org/825274
Signed-off-by: Michał Górny <mgorny@gentoo.org>