### PR TITLE
profiles/arch/arm*: drop now-obsolete USE=selinux stable-mask

### DIFF
--- a/profiles/arch/arm/use.stable.mask
+++ b/profiles/arch/arm/use.stable.mask
@@ -4,10 +4,6 @@
 # This file requires eapi 5 or later. New entries go on top.
 # Please use the same syntax as in use.mask
 
-# Jonathan Davies (2021-08-30)
-# sec-policy/selinux-* not stable yet
-selinux
-
 # Michał Górny <mgorny@gentoo.org> (2021-05-04)
 # Python 3.10 is not yet stable (and will not be until it's out of beta,
 # around September.

--- a/profiles/arch/arm64/use.stable.mask
+++ b/profiles/arch/arm64/use.stable.mask
@@ -4,10 +4,6 @@
 # This file requires eapi 5 or later. New entries go on top.
 # Please use the same syntax as in use.mask
 
-# Jonathan Davies (2021-08-30)
-# sec-policy/selinux-* not stable yet
-selinux
-
 # Michał Górny <mgorny@gentoo.org> (2021-05-04)
 # Python 3.10 is not yet stable (and will not be until it's out of beta,
 # around September.


### PR DESCRIPTION
Signed-off-by: Sam James <sam@gentoo.org>