### PR TITLE
dev-qt/qt-creator: add 'baremetal' as required dep for 'mcu'

### DIFF
--- a/dev-qt/qt-creator/qt-creator-4.15.1.ebuild
+++ b/dev-qt/qt-creator/qt-creator-4.15.1.ebuild
@@ -35,7 +35,7 @@ RESTRICT="!test? ( test )"
 REQUIRED_USE="
 	boot2qt? ( remotelinux )
 	clang? ( test? ( qbs ) )
-	mcu? ( cmake )
+	mcu? ( baremetal cmake )
 	python? ( lsp )
 	qmldesigner? ( qmljs )
 	qnx? ( remotelinux )

--- a/dev-qt/qt-creator/qt-creator-9999.ebuild
+++ b/dev-qt/qt-creator/qt-creator-9999.ebuild
@@ -35,7 +35,7 @@ RESTRICT="!test? ( test )"
 REQUIRED_USE="
 	boot2qt? ( remotelinux )
 	clang? ( test? ( qbs ) )
-	mcu? ( cmake )
+	mcu? ( baremetal cmake )
 	python? ( lsp )
 	qmldesigner? ( qmljs )
 	qnx? ( remotelinux )


### PR DESCRIPTION
MCU depends on **baremetal**, but it is not currently set as a required USE.
`make[2]: *** No rule to make target 'baremetal-make_first', needed by 'sub-mcusupport-make_first'.  Stop.`