### PR TITLE
add missing ~arm64 keyword for sys-cluster/lmod

### DIFF
--- a/sys-cluster/lmod/lmod-8.5.6.ebuild
+++ b/sys-cluster/lmod/lmod-8.5.6.ebuild
@@ -15,7 +15,7 @@ if [[ ${PV} == 9999 ]]; then
 else
 	SRC_URI="https://github.com/TACC/Lmod/archive/${PV}.tar.gz -> ${P}.tar.gz"
 	S="${WORKDIR}"/Lmod-${PV}
-	KEYWORDS="~amd64 ~arm ~ppc ~ppc64 ~sparc ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~sparc ~x86"
 fi
 
 LICENSE="MIT"


### PR DESCRIPTION
We have been using Lmod for a while on `aarch64` systems, works fine there as it does on `ppc64le` (which is keyworded already).

cc @amadio