### PR TITLE
sys-libs/musl: Replaced mv in ldconfig with cp/rm dance 

### DIFF
--- a/sys-libs/musl/files/ldconfig.in-r2
+++ b/sys-libs/musl/files/ldconfig.in-r2
@@ -1,0 +1,157 @@
+#!/bin/bash -e
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+ROOT="/"
+LDSO_CONF="/etc/ld.so.conf"
+
+VERBOSE=0
+
+UPDATE_LINKS=1
+
+get_options() {
+	while getopts "vnNXf:C:r:p" opt "$@"; do
+		case $opt in
+		v)
+			echo "ldconfig for musl in Gentoo"
+			VERBOSE=1
+			;;
+		r)
+			ROOT=${OPTARG}
+			LDSO_CONF=${ROOT}${LDSO_CONF}
+			LDSO_CONF_DIR=$(dirname ${LDSO_CONF})
+			;;
+		f)
+			LDSO_CONF=${OPTARG}
+			;;
+		X)
+			UPDATE_LINKS=0
+			;;
+		\?)
+			echo "Invalid option: -${opt}" >&2
+			exit 1
+			;;
+		n|N|C|p)
+			echo "Unimplemented option: -${opt}" >&2
+			exit 1
+			;;
+		esac
+	done
+
+	if [[ ${UPDATE_LINKS} == 1 ]]; then
+		echo "Updating links is not implemented."
+	fi
+}
+
+
+repeated() {
+	local l=${1}
+	local drs="${@:2}"
+	for m in ${drs}; do
+		[[ ${m} == ${l} ]] && return 0
+	done
+	return 1
+}
+
+expand() {
+	# We are assuming the ld.so.conf's 'include' is not recursive
+	local f line l
+	local glob="${LDSO_CONF_DIR}/${1}"
+	local drs="${@:2} "
+
+	for f in ${glob}; do
+		[[ ! -f ${f} ]] && continue
+		while read line; do
+			line=${line%%#*}
+			line=${line//:/ }
+			line=${line//,/ }
+			for l in ${line}; do
+				# We must add this whether or not the directory exists
+				repeated ${l} ${drs} && continue
+				drs+=" ${l} "
+			done
+		done < ${f}
+	done
+
+	echo ${drs}
+}
+
+read_ldso_conf() {
+	local drs=" "
+
+	while read line; do
+		# Sanitize the line - see ldconfig(8) for delimiters
+		# Note: bash read turns tabs into spaces and read already
+		# delimits on newlines with the default $IFS
+		line=${line%%#*}   # Remove comments
+		line=${line//:/ }  # Change colon delimiter to space
+		line=${line//,/ }  # Change comma delimiter to space
+
+		next=0
+		for l in ${line}; do
+			if [[ ${next} == 1 ]]; then
+				next=0
+				drs=$(expand ${l} ${drs})
+			elif [[ ${l} == "include" ]]; then
+				next=1
+			else
+				# glibc's ldconfig silently skips non directories
+				if [[ -d ${l} ]]; then
+					repeated ${l} ${drs} && continue
+					drs+=" ${l} "
+				fi
+			fi
+		done
+	done < ${1}
+
+	echo ${drs}
+}
+
+sanitize() {
+	local drs=$@
+
+	repeated "/lib" ${drs} || drs="/lib ${drs}"
+	repeated "/usr/lib" ${drs} || drs="/usr/lib ${drs}"
+
+	echo ${drs}
+}
+
+changed() {
+	[[ -f ${ETC_LDSO_PATH} ]] || return 0
+	local current=$(<${ETC_LDSO_PATH})
+	current=${current//$'\n'/ }
+	[[ ${current} != ${drs} ]] || return 1
+}
+
+get_options "$@"
+
+if [[ ! -e ${LDSO_CONF} ]]; then
+        echo "${LDSO_CONF} not found" >&2
+        exit 1
+fi
+
+LDSO_CONF_DIR=$(dirname ${LDSO_CONF})
+
+drs=$(read_ldso_conf "${LDSO_CONF}")
+drs=$(sanitize ${drs})
+
+ARCH=@@ARCH@@
+LDSO_PATH="${ROOT}/lib/ld-musl-${ARCH}.so.1"
+if [[ ! -e ${LDSO_PATH} ]]; then
+	echo "${LDSO_PATH} not found" >&2
+	exit 1
+fi
+
+LDSO_ARCH=$(basename ${LDSO_PATH})
+LDSO_NAME=${LDSO_ARCH%.so.1}
+ETC_LDSO_PATH="${ROOT}/etc/${LDSO_NAME}.path"
+
+changed || exit 0
+X=$(mktemp -p /tmp ${LDSO_NAME}.XXXXXX)
+for d in ${drs}; do
+	echo ${d} >> ${X}
+done
+chmod 644 ${X}
+# busybox doesn't support mz -Z
+cp ${X} ${ETC_LDSO_PATH}
+rm ${X}

--- a/sys-libs/musl/musl-1.2.2-r7.ebuild
+++ b/sys-libs/musl/musl-1.2.2-r7.ebuild
@@ -1,0 +1,167 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit eapi8-dosym flag-o-matic toolchain-funcs
+if [[ ${PV} == "9999" ]] ; then
+	EGIT_REPO_URI="git://git.musl-libc.org/musl"
+	inherit git-r3
+else
+	SRC_URI="http://www.musl-libc.org/releases/${P}.tar.gz"
+	KEYWORDS="-* ~amd64 ~arm ~arm64 ~mips ~ppc ~ppc64 ~x86"
+fi
+GETENT_COMMIT="93a08815f8598db442d8b766b463d0150ed8e2ab"
+GETENT_FILE="musl-getent-${GETENT_COMMIT}.c"
+SRC_URI+="
+	https://dev.gentoo.org/~blueness/musl-misc/getconf.c
+	https://gitlab.alpinelinux.org/alpine/aports/-/raw/${GETENT_COMMIT}/main/musl/getent.c -> ${GETENT_FILE}
+	https://dev.gentoo.org/~blueness/musl-misc/iconv.c
+"
+
+export CBUILD=${CBUILD:-${CHOST}}
+export CTARGET=${CTARGET:-${CHOST}}
+if [[ ${CTARGET} == ${CHOST} ]] ; then
+	if [[ ${CATEGORY} == cross-* ]] ; then
+		export CTARGET=${CATEGORY#cross-}
+	fi
+fi
+
+DESCRIPTION="Light, fast and simple C library focused on standards-conformance and safety"
+HOMEPAGE="https://musl.libc.org"
+LICENSE="MIT LGPL-2 GPL-2"
+SLOT="0"
+IUSE="headers-only"
+
+QA_SONAME="/usr/lib/libc.so"
+QA_DT_NEEDED="/usr/lib/libc.so"
+
+is_crosscompile() {
+	[[ ${CHOST} != ${CTARGET} ]]
+}
+
+just_headers() {
+	use headers-only && is_crosscompile
+}
+
+pkg_setup() {
+	if [ ${CTARGET} == ${CHOST} ] ; then
+		case ${CHOST} in
+		*-musl*) ;;
+		*) die "Use sys-devel/crossdev to build a musl toolchain" ;;
+		esac
+	fi
+
+	# fix for #667126, copied from glibc ebuild
+	# make sure host make.conf doesn't pollute us
+	if is_crosscompile || tc-is-cross-compiler ; then
+		CHOST=${CTARGET} strip-unsupported-flags
+	fi
+}
+
+src_unpack() {
+	if [[ ${PV} == 9999 ]]; then
+		git-r3_src_unpack
+	else
+		unpack "${P}.tar.gz"
+	fi
+	mkdir misc || die
+	cp "${DISTDIR}"/getconf.c misc/getconf.c || die
+	cp "${DISTDIR}/${GETENT_FILE}" misc/getent.c || die
+	cp "${DISTDIR}"/iconv.c misc/iconv.c || die
+}
+
+src_prepare() {
+	default
+
+	# Expand gethostid instead of being just a stub
+	eapply "${FILESDIR}/${PN}-1.2.2-gethostid.patch"
+}
+
+src_configure() {
+	tc-getCC ${CTARGET}
+	just_headers && export CC=true
+
+	local sysroot
+	is_crosscompile && sysroot="${EPREFIX}"/usr/${CTARGET}
+	./configure \
+		--target=${CTARGET} \
+		--prefix=${sysroot}/usr \
+		--syslibdir=${sysroot}/lib \
+		--disable-gcc-wrapper || die
+}
+
+src_compile() {
+	emake obj/include/bits/alltypes.h
+	just_headers && return 0
+
+	emake
+	if [[ ${CATEGORY} != cross-* ]] ; then
+		emake -C "${T}" getconf getent iconv \
+			CC="$(tc-getCC)" \
+			CFLAGS="${CFLAGS}" \
+			CPPFLAGS="${CPPFLAGS}" \
+			LDFLAGS="${LDFLAGS}" \
+			VPATH="${WORKDIR}/misc"
+	fi
+
+	$(tc-getCC) ${CFLAGS} -c -o libssp_nonshared.o  "${FILESDIR}"/stack_chk_fail_local.c || die
+	$(tc-getAR) -rcs libssp_nonshared.a libssp_nonshared.o || die
+}
+
+src_install() {
+	local target="install"
+	just_headers && target="install-headers"
+	emake DESTDIR="${D}" ${target}
+	just_headers && return 0
+
+	# musl provides ldd via a sym link to its ld.so
+	local sysroot
+	is_crosscompile && sysroot=/usr/${CTARGET}
+	local ldso=$(basename "${D}"${sysroot}/lib/ld-musl-*)
+	dosym ${sysroot}/lib/${ldso} ${sysroot}/usr/bin/ldd
+
+	if [[ ${CATEGORY} != cross-* ]] ; then
+		# Fish out of config:
+		#   ARCH = ...
+		#   SUBARCH = ...
+		# and print $(ARCH)$(SUBARCH).
+		local arch=$(awk '{ k[$1] = $3 } END { printf("%s%s", k["ARCH"], k["SUBARCH"]); }' config.mak)
+
+		if [[ ! -e "${ED}"/lib/ld-musl-${arch}.so.1 ]] ; then
+			# During cross (using crossdev), when emerging sys-libs/musl,
+			# if /usr/lib/libc.so.1 doesn't exist on the system, installation
+			# would fail.
+			#
+			# The musl build system seems to create a symlink:
+			# ${D}/lib/ld-musl-${arch}.so.1 -> /usr/lib/libc.so.1 (absolute)
+			# During cross, there's no guarantee that the host is using musl
+			# so that file may not exist. Use a relative symlink within ${D}
+			# instead.
+			dosym8 -r /usr/lib/libc.so /lib/ld-musl-${arch}.so.1
+
+			# If it's still a dead symlnk, OK, we really do need to abort.
+			[[ -e "${ED}"/lib/ld-musl-${arch}.so.1 ]] || die
+		fi
+
+		cp "${FILESDIR}"/ldconfig.in-r2 "${T}"/ldconfig.in || die
+		sed -e "s|@@ARCH@@|${arch}|" "${T}"/ldconfig.in > "${T}"/ldconfig || die
+		into /
+		dosbin "${T}"/ldconfig
+		into /usr
+		dobin "${T}"/getconf
+		dobin "${T}"/getent
+		dobin "${T}"/iconv
+		echo 'LDPATH="include ld.so.conf.d/*.conf"' > "${T}"/00musl || die
+		doenvd "${T}"/00musl
+		dolib.a libssp_nonshared.a
+	fi
+}
+
+pkg_postinst() {
+	is_crosscompile && return 0
+
+	[ "${ROOT}" != "/" ] && return 0
+
+	ldconfig || die
+}


### PR DESCRIPTION
This is so the correct SELinux label is applied to the resulting file and the system
doesn't brick itself instantly.\