### PR TITLE
sci-libs/superlu_mt: fix int64 not taking effect

### DIFF
--- a/sci-libs/superlu_mt/files/superlu_mt-3.1-fix-predefs.patch
+++ b/sci-libs/superlu_mt/files/superlu_mt-3.1-fix-predefs.patch
@@ -1,0 +1,26 @@
+diff --git a/INSTALL/Makefile b/INSTALL/Makefile
+index 55977b0..fe565e5 100644
+--- a/INSTALL/Makefile
++++ b/INSTALL/Makefile
+@@ -19,7 +19,7 @@ slamch.o: slamch.c ; $(CC) $(NOOPTS) -c $<
+ dlamch.o: dlamch.c ; $(CC) $(NOOPTS) -c $<
+ superlu_timer.o: superlu_timer.c; $(CC) $(NOOPTS) -c $<
+ 
+-.c.o: ; $(CC) $(CFLAGS) -c $<
++.c.o: ; $(CC) $(PREDEFS) $(CFLAGS) -c $<
+ 
+ clean:
+ 	rm -f *.o test* *.out
+diff --git a/SRC/Makefile b/SRC/Makefile
+index 81209e5..42dd28b 100644
+--- a/SRC/Makefile
++++ b/SRC/Makefile
+@@ -130,7 +130,7 @@ await.o: await.c
+ 	$(CC) -c $(NOOPTS) $< $(VERBOSE)
+ 
+ .c.o:
+-	$(CC) $(CFLAGS) $(CDEFS) $(BLASDEF) -c $< $(VERBOSE)
++	$(CC) ${PREDEFS} $(CFLAGS) $(CDEFS) $(BLASDEF) -c $< $(VERBOSE)
+ 
+ clean:	
+ 	rm -f *.o core ../lib/$(SUPERLULIB)

--- a/sci-libs/superlu_mt/superlu_mt-3.1.ebuild
+++ b/sci-libs/superlu_mt/superlu_mt-3.1.ebuild
@@ -61,8 +61,7 @@ src_prepare() {
 		TMGLIB=libtmglib.a
 	EOF
 	SONAME=lib${PN}.so.${SOVERSION}
-	sed -e 's|../make.inc|make.inc|' \
-		-e "s|../SRC|${EPREFIX}/usr/include/${PN}|" \
+	sed -e "s|../SRC|${EPREFIX}/usr/include/${PN}|" \
 		-e '/:.*$(SUPERLULIB)/s|../lib/$(SUPERLULIB)||g' \
 		-e 's|../lib/$(SUPERLULIB)|-lsuperlu_mt|g' \
 		-i EXAMPLE/Makefile || die


### PR DESCRIPTION
tested on riscv64 and amd64

USE=int64 doesn't actually take effect. int_t is still typedefed as int instead of long long on machines with 32 bit int like RISC-V lp64 ABI. PREDEFS should be appended to CFLAGS. This is also the case in upstream.

and there is no make.inc under EXAMPLE/, EXAMPLE/Makefile should read ../make.inc
