### PR TITLE
dev-java/bcpkix: solve OutOfMemoryError | dev-java/bcprov: fix OutOfMemoryError

### DIFF
--- a/dev-java/bcpkix/bcpkix-1.69.ebuild
+++ b/dev-java/bcpkix/bcpkix-1.69.ebuild
@@ -66,7 +66,7 @@ JAVA_TEST_RUN_ONLY=(
 check_env() {
 	if use test; then
 		# this is needed only for tests
-		CHECKREQS_MEMORY="1200M"
+		CHECKREQS_MEMORY="2048M"
 		check-reqs_pkg_pretend
 	fi
 }

--- a/dev-java/bcprov/bcprov-1.69.ebuild
+++ b/dev-java/bcprov/bcprov-1.69.ebuild
@@ -58,7 +58,7 @@ JAVA_TEST_RUN_ONLY=(
 check_env() {
 	if use test; then
 		# this is needed only for tests
-		CHECKREQS_MEMORY="1200M"
+		CHECKREQS_MEMORY="2048M"
 		check-reqs_pkg_pretend
 	fi
 }


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/827082
Package-Manager: Portage-3.0.28, Repoman-3.0.3
Signed-off-by: Volkmar W. Pogatzki <gentoo@pogatzki.net>