### PR TITLE
sci-electronics/kicad: fix cmake flags for occ

### DIFF
--- a/sci-electronics/kicad/kicad-6.0.0_rc1.ebuild
+++ b/sci-electronics/kicad/kicad-6.0.0_rc1.ebuild
@@ -109,10 +109,10 @@ src_configure() {
 		-DPYTHON_INCLUDE_DIR="$(python_get_includedir)"
 		-DPYTHON_LIBRARY="$(python_get_library_path)"
 	)
+	local OCC_P=$(best_version sci-libs/opencascade)
+	OCC_P=${OCC_P#sci-libs/}
+	OCC_P=${OCC_P%-r*}
 	use occ && mycmakeargs+=(
-		local OCC_P=$(best_version sci-libs/opencascade)
-		OCC_P=${OCC_P#sci-libs/}
-		OCC_P=${OCC_P%-r*}
 		-DOCC_INCLUDE_DIR="${CASROOT}"/include/${OCC_P}
 		-DOCC_LIBRARY_DIR="${CASROOT}"/$(get_libdir)/${OCC_P}
 


### PR DESCRIPTION
Package-Manager: Portage-3.0.28, Repoman-3.0.3
Signed-off-by: Yehoshua Pesach Wallach <yehoshuapw@gmail.com>

No bug _yet_, but kicad failed to compile with use flag occ - since things that didn't need to ended up as part of the cmake flags.
