### PR TITLE
dev-java/icu4j: restrict tests for jdk-1.8

### DIFF
--- a/dev-java/icu4j/icu4j-70.1.ebuild
+++ b/dev-java/icu4j/icu4j-70.1.ebuild
@@ -176,6 +176,14 @@ src_compile() {
 	fi
 }
 
+src_test () {
+	# https://bugs.gentoo.org/827212
+	local vm_version="$(java-config -g PROVIDES_VERSION)"
+	if [[ "${vm_version}" != "1.8" ]] ; then
+		java-pkg-simple_src_test
+	fi
+}
+
 src_install() {
 	default
 	java-pkg_dojar "icu4j.jar"


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/827212
There were test failures which seem to be specific
for jdk-1.8 and seem not to happen on jdk-11 or jdk-17

Package-Manager: Portage-3.0.28, Repoman-3.0.3
Signed-off-by: Volkmar W. Pogatzki <gentoo@pogatzki.net>