### PR TITLE
net-wireless/aircrack-ng: move deps from PDEPEND to RDEPEND

### DIFF
--- a/net-wireless/aircrack-ng/aircrack-ng-1.6_p20200722.ebuild
+++ b/net-wireless/aircrack-ng/aircrack-ng-1.6_p20200722.ebuild
@@ -36,8 +36,8 @@ DEPEND="net-libs/libpcap
 	airgraph-ng? ( ${PYTHON_DEPS} )
 	experimental? ( sys-libs/zlib )
 	sqlite? ( >=dev-db/sqlite-3.4 )"
-RDEPEND="${DEPEND}"
-PDEPEND="kernel_linux? (
+RDEPEND="${DEPEND}
+	kernel_linux? (
 		net-wireless/iw
 		net-wireless/wireless-tools
 		sys-apps/ethtool

--- a/net-wireless/aircrack-ng/aircrack-ng-9999.ebuild
+++ b/net-wireless/aircrack-ng/aircrack-ng-9999.ebuild
@@ -34,8 +34,8 @@ DEPEND="net-libs/libpcap
 	airgraph-ng? ( ${PYTHON_DEPS} )
 	experimental? ( sys-libs/zlib )
 	sqlite? ( >=dev-db/sqlite-3.4 )"
-RDEPEND="${DEPEND}"
-PDEPEND="kernel_linux? (
+RDEPEND="${DEPEND}
+	kernel_linux? (
 		net-wireless/iw
 		net-wireless/wireless-tools
 		sys-apps/ethtool


### PR DESCRIPTION
PDEPEND is meant for breaking circular dependencies. I don't see any
circular dependencies here.