### PR TITLE
games-simulation/simutrans: Drop -* from KEYWORDS

### DIFF
--- a/games-simulation/simutrans/simutrans-0.122.0-r1.ebuild
+++ b/games-simulation/simutrans/simutrans-0.122.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -29,7 +29,7 @@ S=${WORKDIR}
 
 LICENSE="Artistic"
 SLOT="0"
-KEYWORDS="-* ~amd64 ~x86"
+KEYWORDS="~amd64 ~x86"
 IUSE="+pak128 +pak128-britain +pak128-german +pak192-comic truetype upnp zstd"
 
 RDEPEND="


### PR DESCRIPTION
Reason unclear, apparently not needed.

Bug: https://bugs.gentoo.org/827296
Signed-off-by: Ronny (tastytea) Gutbrod <gentoo@tastytea.de>