### PR TITLE
dev-python/cryptography ~ia64 removal CI run

### DIFF
--- a/app-misc/ca-certificates/ca-certificates-20211016.3.72.ebuild
+++ b/app-misc/ca-certificates/ca-certificates-20211016.3.72.ebuild
@@ -62,8 +62,6 @@ CDEPEND="app-misc/c_rehash
 BDEPEND="${CDEPEND}"
 if ! ${PRECOMPILED} ; then
 	BDEPEND+=" ${PYTHON_DEPS}"
-	# See bug #821706
-	BDEPEND+=" $(python_gen_any_dep 'dev-python/cryptography[${PYTHON_USEDEP}]')"
 fi
 
 DEPEND=""
@@ -75,10 +73,6 @@ RDEPEND="${CDEPEND}
 	${DEPEND}"
 
 S=${WORKDIR}
-
-python_check_deps() {
-	has_version -b "dev-python/cryptography[${PYTHON_USEDEP}]"
-}
 
 pkg_setup() {
 	# For the conversion to having it in CONFIG_PROTECT_MASK,
@@ -126,6 +120,11 @@ src_prepare() {
 
 	default
 	eapply -p2 "${FILESDIR}"/${PN}-20150426-root.patch
+
+	pushd "${S}/${PN}-${DEB_VER}" >/dev/null || die
+	eapply "${FILESDIR}"/${P}-no-cryptography.patch
+	popd >/dev/null || die
+
 	local relp=$(echo "${EPREFIX}" | sed -e 's:[^/]\+:..:g')
 	sed -i \
 		-e '/="$ROOT/s:ROOT:ROOT'"${EPREFIX}"':' \

--- a/app-misc/ca-certificates/files/ca-certificates-20211016.3.72-no-cryptography.patch
+++ b/app-misc/ca-certificates/files/ca-certificates-20211016.3.72-no-cryptography.patch
@@ -1,0 +1,27 @@
+Remove the dependency on non-portable dev-python/cryptography.
+https://bugs.gentoo.org/821706#c4 by Alex Xu
+
+--- a/mozilla/certdata2pem.py
++++ b/mozilla/certdata2pem.py
+@@ -28,8 +28,6 @@
+ import textwrap
+ import io
+
+-from cryptography import x509
+-
+
+ objects = []
+
+@@ -122,12 +120,6 @@
+         if not obj['CKA_LABEL'] in trust or not trust[obj['CKA_LABEL']]:
+             continue
+
+-        cert = x509.load_der_x509_certificate(obj['CKA_VALUE'])
+-        if cert.not_valid_after < datetime.datetime.now():
+-            print('!'*74)
+-            print('Trusted but expired certificate found: %s' % obj['CKA_LABEL'])
+-            print('!'*74)
+-
+         bname = obj['CKA_LABEL'][1:-1].replace('/', '_')\
+                                       .replace(' ', '_')\
+                                       .replace('(', '=')\

--- a/dev-python/aiohttp/aiohttp-3.7.4-r2.ebuild
+++ b/dev-python/aiohttp/aiohttp-3.7.4-r2.ebuild
@@ -13,7 +13,7 @@ SRC_URI="mirror://pypi/${P:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="Apache-2.0"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ppc ppc64 ~riscv sparc x86"
+KEYWORDS="~alpha amd64 arm arm64 hppa ppc ppc64 ~riscv sparc x86"
 
 RDEPEND="
 	<dev-python/async_timeout-4[${PYTHON_USEDEP}]

--- a/dev-python/aiohttp/aiohttp-3.8.0.ebuild
+++ b/dev-python/aiohttp/aiohttp-3.8.0.ebuild
@@ -15,7 +15,7 @@ SRC_URI="mirror://pypi/${P:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="Apache-2.0"
 SLOT="0"
-KEYWORDS="~amd64 ~arm ~arm64 ~ia64 ~riscv ~sparc ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~riscv ~sparc ~x86"
 
 RDEPEND="
 	app-arch/brotli[python,${PYTHON_USEDEP}]

--- a/dev-python/aiohttp/aiohttp-3.8.1.ebuild
+++ b/dev-python/aiohttp/aiohttp-3.8.1.ebuild
@@ -37,7 +37,9 @@ BDEPEND="
 		dev-python/pytest-mock[${PYTHON_USEDEP}]
 		dev-python/pytest-xdist[${PYTHON_USEDEP}]
 		dev-python/re-assert[${PYTHON_USEDEP}]
-		dev-python/trustme[${PYTHON_USEDEP}]
+		!hppa? ( !ia64? (
+			dev-python/trustme[${PYTHON_USEDEP}]
+		) )
 	)
 "
 

--- a/dev-python/cheroot/cheroot-8.5.2.ebuild
+++ b/dev-python/cheroot/cheroot-8.5.2.ebuild
@@ -27,13 +27,15 @@ BDEPEND="
 		dev-python/jaraco-context[${PYTHON_USEDEP}]
 		dev-python/jaraco-text[${PYTHON_USEDEP}]
 		dev-python/portend[${PYTHON_USEDEP}]
-		dev-python/pyopenssl[${PYTHON_USEDEP}]
 		dev-python/pytest-forked[${PYTHON_USEDEP}]
 		>=dev-python/pytest-mock-1.11.0[${PYTHON_USEDEP}]
 		dev-python/requests-toolbelt[${PYTHON_USEDEP}]
 		dev-python/requests-unixsocket[${PYTHON_USEDEP}]
-		dev-python/trustme[${PYTHON_USEDEP}]
 		dev-python/urllib3[${PYTHON_USEDEP}]
+		!ia64? (
+			dev-python/pyopenssl[${PYTHON_USEDEP}]
+			dev-python/trustme[${PYTHON_USEDEP}]
+		)
 	)
 "
 

--- a/dev-python/cherrypy/cherrypy-18.6.1.ebuild
+++ b/dev-python/cherrypy/cherrypy-18.6.1.ebuild
@@ -15,7 +15,7 @@ S="${WORKDIR}/${MY_P}"
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="amd64 arm arm64 ~ia64 ppc ~ppc64 x86"
+KEYWORDS="amd64 arm arm64 ppc ~ppc64 x86"
 IUSE="ssl test"
 
 RDEPEND="

--- a/dev-python/cryptography/cryptography-3.4.7-r2.ebuild
+++ b/dev-python/cryptography/cryptography-3.4.7-r2.ebuild
@@ -16,7 +16,7 @@ SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz
 
 LICENSE="|| ( Apache-2.0 BSD )"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+KEYWORDS="~alpha amd64 arm arm64 hppa ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 
 RDEPEND="
 	$(python_gen_cond_dep '

--- a/dev-python/dnspython/dnspython-1.16.0-r2.ebuild
+++ b/dev-python/dnspython/dnspython-1.16.0-r2.ebuild
@@ -13,7 +13,7 @@ SRC_URI="https://github.com/rthalley/dnspython/archive/v${PV}.tar.gz -> ${P}.tar
 
 LICENSE="ISC"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-solaris"
+KEYWORDS="~alpha amd64 arm arm64 ~hppa ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-solaris"
 IUSE="examples"
 
 RDEPEND="dev-python/pycryptodome[${PYTHON_USEDEP}]

--- a/dev-python/dnspython/dnspython-2.1.0.ebuild
+++ b/dev-python/dnspython/dnspython-2.1.0.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://github.com/rthalley/dnspython/archive/v${PV}.tar.gz -> ${P}.tar
 
 LICENSE="ISC"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-solaris"
+KEYWORDS="~alpha amd64 arm arm64 ~hppa ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-solaris"
 IUSE="examples"
 
 RDEPEND="

--- a/dev-python/fs/fs-2.4.13.ebuild
+++ b/dev-python/fs/fs-2.4.13.ebuild
@@ -24,7 +24,7 @@ S="${WORKDIR}/${MY_P}"
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~m68k ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~alpha amd64 arm arm64 hppa ~m68k ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux"
 
 RDEPEND="
 	>=dev-python/appdirs-1.4.3[${PYTHON_USEDEP}]

--- a/dev-python/keyring/keyring-23.2.1.ebuild
+++ b/dev-python/keyring/keyring-23.2.1.ebuild
@@ -12,7 +12,7 @@ SRC_URI="https://github.com/jaraco/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 SLOT="0"
 LICENSE="PSF-2"
-KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ppc ppc64 ~riscv sparc x86 ~x64-macos"
+KEYWORDS="~alpha amd64 arm arm64 hppa ppc ppc64 ~riscv sparc x86 ~x64-macos"
 
 RDEPEND="
 	dev-python/secretstorage[${PYTHON_USEDEP}]

--- a/dev-python/keyring/keyring-23.3.0.ebuild
+++ b/dev-python/keyring/keyring-23.3.0.ebuild
@@ -12,7 +12,7 @@ SRC_URI="https://github.com/jaraco/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 SLOT="0"
 LICENSE="PSF-2"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~riscv ~sparc ~x86 ~x64-macos"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~riscv ~sparc ~x86 ~x64-macos"
 
 RDEPEND="
 	dev-python/secretstorage[${PYTHON_USEDEP}]

--- a/dev-python/ndg-httpsclient/ndg-httpsclient-0.5.1.ebuild
+++ b/dev-python/ndg-httpsclient/ndg-httpsclient-0.5.1.ebuild
@@ -15,7 +15,7 @@ S="${WORKDIR}/${P/-/_}"
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~m68k ~mips ppc ppc64 ~s390 sparc x86 ~x64-macos"
+KEYWORDS="~alpha amd64 arm arm64 ~hppa ~m68k ~mips ppc ppc64 ~s390 sparc x86 ~x64-macos"
 
 RDEPEND="
 	dev-python/pyaes[${PYTHON_USEDEP}]

--- a/dev-python/paramiko/paramiko-2.8.0.ebuild
+++ b/dev-python/paramiko/paramiko-2.8.0.ebuild
@@ -16,7 +16,7 @@ SRC_URI="https://github.com/${PN}/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="LGPL-2.1"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris"
+KEYWORDS="~alpha amd64 arm arm64 ~hppa ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris"
 IUSE="examples server"
 
 RDEPEND="

--- a/dev-python/passlib/passlib-1.7.4-r1.ebuild
+++ b/dev-python/passlib/passlib-1.7.4-r1.ebuild
@@ -19,8 +19,10 @@ IUSE="doc"
 BDEPEND="
 	test? (
 		dev-python/bcrypt[${PYTHON_USEDEP}]
-		dev-python/cryptography[${PYTHON_USEDEP}]
 		dev-python/scrypt[${PYTHON_USEDEP}]
+		!alpha? ( !hppa? ( !ia64? (
+			dev-python/cryptography[${PYTHON_USEDEP}]
+		) ) )
 	)"
 
 distutils_enable_tests nose

--- a/dev-python/passlib/passlib-1.7.4.ebuild
+++ b/dev-python/passlib/passlib-1.7.4.ebuild
@@ -21,8 +21,10 @@ RDEPEND="bcrypt? ( dev-python/bcrypt[${PYTHON_USEDEP}] )
 BDEPEND="
 	test? (
 		dev-python/bcrypt[${PYTHON_USEDEP}]
-		dev-python/cryptography[${PYTHON_USEDEP}]
 		dev-python/scrypt[${PYTHON_USEDEP}]
+		!alpha? ( !hppa? ( !ia64? (
+			dev-python/cryptography[${PYTHON_USEDEP}]
+		) ) )
 	)"
 
 distutils_enable_tests nose

--- a/dev-python/pip/pip-21.3.1-r1.ebuild
+++ b/dev-python/pip/pip-21.3.1-r1.ebuild
@@ -43,7 +43,6 @@ RDEPEND="
 BDEPEND="
 	${RDEPEND}
 	test? (
-		dev-python/cryptography[${PYTHON_USEDEP}]
 		dev-python/freezegun[${PYTHON_USEDEP}]
 		dev-python/pretend[${PYTHON_USEDEP}]
 		dev-python/pytest[${PYTHON_USEDEP}]
@@ -51,6 +50,9 @@ BDEPEND="
 		dev-python/tomli-w[${PYTHON_USEDEP}]
 		dev-python/werkzeug[${PYTHON_USEDEP}]
 		dev-python/wheel[${PYTHON_USEDEP}]
+		!alpha? ( !hppa? ( !ia64? (
+			dev-python/cryptography[${PYTHON_USEDEP}]
+		) ) )
 	)
 "
 

--- a/dev-python/pip/pip-21.3.1.ebuild
+++ b/dev-python/pip/pip-21.3.1.ebuild
@@ -43,13 +43,15 @@ RDEPEND="
 BDEPEND="
 	${RDEPEND}
 	test? (
-		dev-python/cryptography[${PYTHON_USEDEP}]
 		dev-python/freezegun[${PYTHON_USEDEP}]
 		dev-python/pretend[${PYTHON_USEDEP}]
 		dev-python/pytest[${PYTHON_USEDEP}]
 		dev-python/scripttest[${PYTHON_USEDEP}]
 		dev-python/werkzeug[${PYTHON_USEDEP}]
 		dev-python/wheel[${PYTHON_USEDEP}]
+		!alpha? ( !hppa? ( !ia64? (
+			dev-python/cryptography[${PYTHON_USEDEP}]
+		) ) )
 	)
 "
 

--- a/dev-python/pyftpdlib/pyftpdlib-1.5.6-r1.ebuild
+++ b/dev-python/pyftpdlib/pyftpdlib-1.5.6-r1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris"
+KEYWORDS="~alpha amd64 arm arm64 hppa ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris"
 IUSE="examples ssl"
 
 RDEPEND="

--- a/dev-python/pyopenssl/pyopenssl-20.0.1.ebuild
+++ b/dev-python/pyopenssl/pyopenssl-20.0.1.ebuild
@@ -22,7 +22,7 @@ S=${WORKDIR}/${MY_P}
 
 LICENSE="Apache-2.0"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+KEYWORDS="~alpha amd64 arm arm64 hppa ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 
 RDEPEND="
 	>=dev-python/six-1.5.2[${PYTHON_USEDEP}]

--- a/dev-python/pypiserver/pypiserver-1.4.2.ebuild
+++ b/dev-python/pypiserver/pypiserver-1.4.2.ebuild
@@ -24,8 +24,10 @@ BDEPEND="
 		${RDEPEND}
 		dev-python/passlib[${PYTHON_USEDEP}]
 		>=dev-python/pytest-2.3[${PYTHON_USEDEP}]
-		dev-python/twine[${PYTHON_USEDEP}]
 		dev-python/webtest[${PYTHON_USEDEP}]
+		!alpha? ( !hppa? ( !ia64? (
+			dev-python/twine[${PYTHON_USEDEP}]
+		) ) )
 	)"
 
 DOCS=( README.rst )

--- a/dev-python/requests-toolbelt/requests-toolbelt-0.9.1.ebuild
+++ b/dev-python/requests-toolbelt/requests-toolbelt-0.9.1.ebuild
@@ -19,9 +19,11 @@ RDEPEND="<dev-python/requests-3.0.0[${PYTHON_USEDEP}]"
 DEPEND="${RDEPEND}
 	test? (
 		dev-python/betamax[${PYTHON_USEDEP}]
-		dev-python/cryptography[${PYTHON_USEDEP}]
 		dev-python/mock[${PYTHON_USEDEP}]
-		dev-python/pyopenssl[${PYTHON_USEDEP}]
+		!alpha? ( !hppa? ( !ia64? (
+			dev-python/cryptography[${PYTHON_USEDEP}]
+			dev-python/pyopenssl[${PYTHON_USEDEP}]
+		) ) )
 	)"
 
 DOCS=( AUTHORS.rst HISTORY.rst README.rst )

--- a/dev-python/requests/requests-2.26.0.ebuild
+++ b/dev-python/requests/requests-2.26.0.ebuild
@@ -30,8 +30,10 @@ BDEPEND="
 	test? (
 		dev-python/pytest-httpbin[${PYTHON_USEDEP}]
 		dev-python/pytest-mock[${PYTHON_USEDEP}]
-		dev-python/trustme[${PYTHON_USEDEP}]
 		>=dev-python/PySocks-1.5.6[${PYTHON_USEDEP}]
+		!alpha? ( !hppa? ( !ia64? (
+			dev-python/trustme[${PYTHON_USEDEP}]
+		) ) )
 	)
 "
 

--- a/dev-python/secretstorage/secretstorage-3.3.1.ebuild
+++ b/dev-python/secretstorage/secretstorage-3.3.1.ebuild
@@ -16,7 +16,7 @@ S="${WORKDIR}/${MY_PN}-${PV}"
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ppc ppc64 ~riscv sparc x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~alpha amd64 arm arm64 hppa ppc ppc64 ~riscv sparc x86 ~amd64-linux ~x86-linux"
 
 RDEPEND="
 	dev-python/cryptography[${PYTHON_USEDEP}]

--- a/dev-python/service_identity/service_identity-21.1.0.ebuild
+++ b/dev-python/service_identity/service_identity-21.1.0.ebuild
@@ -14,7 +14,7 @@ S=${WORKDIR}/${P/_/-}
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux ~x64-macos"
+KEYWORDS="~alpha amd64 arm arm64 hppa ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux ~x64-macos"
 
 # TODO: upstream made pyopenssl optional
 RDEPEND="

--- a/dev-python/trustme/trustme-0.9.0.ebuild
+++ b/dev-python/trustme/trustme-0.9.0.ebuild
@@ -12,7 +12,7 @@ SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="|| ( Apache-2.0 MIT )"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~x64-cygwin ~amd64-linux ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+KEYWORDS="~alpha amd64 arm arm64 hppa ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~x64-cygwin ~amd64-linux ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 
 RDEPEND="dev-python/cryptography[${PYTHON_USEDEP}]
 	dev-python/idna[${PYTHON_USEDEP}]"

--- a/dev-python/twine/twine-3.4.2.ebuild
+++ b/dev-python/twine/twine-3.4.2.ebuild
@@ -13,7 +13,7 @@ SRC_URI="https://github.com/pypa/twine/archive/${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="Apache-2.0"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ppc ppc64 ~riscv sparc x86 ~x64-macos"
+KEYWORDS="~alpha amd64 arm arm64 hppa ppc ppc64 ~riscv sparc x86 ~x64-macos"
 
 RDEPEND="
 	>=dev-python/colorama-0.4.3[${PYTHON_USEDEP}]

--- a/dev-python/twine/twine-3.6.0.ebuild
+++ b/dev-python/twine/twine-3.6.0.ebuild
@@ -13,7 +13,7 @@ SRC_URI="https://github.com/pypa/twine/archive/${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="Apache-2.0"
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~riscv ~sparc ~x86 ~x64-macos"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~riscv ~sparc ~x86 ~x64-macos"
 
 RDEPEND="
 	>=dev-python/colorama-0.4.3[${PYTHON_USEDEP}]

--- a/dev-python/twisted/twisted-21.7.0.ebuild
+++ b/dev-python/twisted/twisted-21.7.0.ebuild
@@ -48,16 +48,6 @@ RDEPEND="
 		>=dev-python/priority-1.1.0[${PYTHON_USEDEP}]
 		<dev-python/priority-2.0[${PYTHON_USEDEP}]
 	)
-	!dev-python/twisted-core
-	!dev-python/twisted-conch
-	!dev-python/twisted-lore
-	!dev-python/twisted-mail
-	!dev-python/twisted-names
-	!dev-python/twisted-news
-	!dev-python/twisted-pair
-	!dev-python/twisted-runner
-	!dev-python/twisted-words
-	!dev-python/twisted-web
 "
 BDEPEND="
 	>=dev-python/incremental-21.3.0[${PYTHON_USEDEP}]

--- a/dev-python/twisted/twisted-21.7.0.ebuild
+++ b/dev-python/twisted/twisted-21.7.0.ebuild
@@ -65,15 +65,17 @@ BDEPEND="
 		>=dev-python/appdirs-1.4.0[${PYTHON_USEDEP}]
 		dev-python/bcrypt[${PYTHON_USEDEP}]
 		>=dev-python/constantly-15.1.0[${PYTHON_USEDEP}]
-		>=dev-python/cryptography-0.9.1[${PYTHON_USEDEP}]
 		dev-python/cython-test-exception-raiser[${PYTHON_USEDEP}]
 		dev-python/gmpy[${PYTHON_USEDEP}]
 		dev-python/idna[${PYTHON_USEDEP}]
 		dev-python/pyasn1[${PYTHON_USEDEP}]
-		>=dev-python/pyopenssl-0.13[${PYTHON_USEDEP}]
 		dev-python/pyserial[${PYTHON_USEDEP}]
-		dev-python/service_identity[${PYTHON_USEDEP}]
 		net-misc/openssh
+		!alpha? ( !hppa? ( !ia64? (
+			>=dev-python/cryptography-0.9.1[${PYTHON_USEDEP}]
+			>=dev-python/pyopenssl-0.13[${PYTHON_USEDEP}]
+			dev-python/service_identity[${PYTHON_USEDEP}]
+		) ) )
 	)
 "
 

--- a/dev-python/werkzeug/werkzeug-1.0.1-r1.ebuild
+++ b/dev-python/werkzeug/werkzeug-1.0.1-r1.ebuild
@@ -26,10 +26,12 @@ RDEPEND="dev-python/simplejson[${PYTHON_USEDEP}]"
 DEPEND="
 	test? (
 		dev-python/click[${PYTHON_USEDEP}]
-		dev-python/cryptography[${PYTHON_USEDEP}]
 		dev-python/requests[${PYTHON_USEDEP}]
 		dev-python/pytest-timeout[${PYTHON_USEDEP}]
 		dev-python/pytest-xprocess[${PYTHON_USEDEP}]
+		!alpha? ( !hppa? ( !ia64? (
+			dev-python/cryptography[${PYTHON_USEDEP}]
+		) ) )
 	)"
 
 distutils_enable_tests pytest

--- a/dev-python/werkzeug/werkzeug-2.0.2.ebuild
+++ b/dev-python/werkzeug/werkzeug-2.0.2.ebuild
@@ -21,7 +21,6 @@ KEYWORDS="amd64 arm arm64 ~hppa ~ia64 ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x
 
 BDEPEND="
 	test? (
-		dev-python/cryptography[${PYTHON_USEDEP}]
 		!hppa? ( !ia64? (
 			$(python_gen_cond_dep '
 				dev-python/greenlet[${PYTHON_USEDEP}]
@@ -30,6 +29,9 @@ BDEPEND="
 		dev-python/pytest-timeout[${PYTHON_USEDEP}]
 		dev-python/pytest-xprocess[${PYTHON_USEDEP}]
 		dev-python/watchdog[${PYTHON_USEDEP}]
+		!alpha? ( !hppa? ( !ia64? (
+			dev-python/cryptography[${PYTHON_USEDEP}]
+		) ) )
 	)"
 
 distutils_enable_tests pytest

--- a/profiles/arch/ia64/package.use.mask
+++ b/profiles/arch/ia64/package.use.mask
@@ -1,6 +1,14 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Michał Górny <mgorny@gentoo.org> (2021-11-26)
+# These package flags require dev-python/cryptography which -- due
+# to the dependency on Rust -- is no longer portable to ia64.
+dev-python/passlib totp
+dev-python/twisted conch crypt
+dev-python/urllib3 test
+net-fs/samba addc addns ads
+
 # Sam James <sam@gentoo.org> (2021-11-05)
 # Avoid keywording unnecessary depenencies for now, bug #804115
 dev-python/scipy pythran


### PR DESCRIPTION
So it happened and cryptography upstream has made a release requiring Rust. This means that long-term we're losing this package at least for alpha, hppa and ia64. Other arches (e.g. ppc) are heavily depending on Gentoo maintainers finally making Rust work on them (it's apparently supported upstream).

`~ia64` should have the lowest number of keywords on Python packages, so let's start estimating the damage by dekeywording cryptography there.