### PR TITLE
dev-java/pdfbox: fix compile error when "-tools"

### DIFF
--- a/dev-java/pdfbox/pdfbox-2.0.24.ebuild
+++ b/dev-java/pdfbox/pdfbox-2.0.24.ebuild
@@ -182,8 +182,8 @@ src_compile() {
 	fi
 
 	JAVA_SRC_DIR=(
-		"${S}/pdfbox"
-		"${S}/debugger"
+		"${S}/pdfbox/src/main/java"
+		"${S}/debugger/src/main/java"
 	)
 	if use tools; then
 		JAVA_SRC_DIR+=( "${S}/tools" )


### PR DESCRIPTION
Package-Manager: Portage-3.0.28, Repoman-3.0.3
Signed-off-by: Volkmar W. Pogatzki <gentoo@pogatzki.net>