### PR TITLE
kernel-2.eclass: Respect portage CC variable

### DIFF
--- a/eclass/kernel-2.eclass
+++ b/eclass/kernel-2.eclass
@@ -692,7 +692,7 @@ env_setup_xmakeopts() {
 	elif type -p ${CHOST}-ar >/dev/null; then
 		xmakeopts="${xmakeopts} CROSS_COMPILE=${CHOST}-"
 	fi
-	xmakeopts="${xmakeopts} HOSTCC=$(tc-getBUILD_CC)"
+	xmakeopts="${xmakeopts} HOSTCC=$(tc-getBUILD_CC) CC=$(tc-getCC) LD=$(tc-getLD) AR=$(tc-getAR) NM=$(tc-getNM) NM=$(tc-getNM) OBOBJCOPY=$(tc-getOBJCOPY) READELF=$(tc-getREADELF) STRIP=$(tc-getSTRIP)"
 	export xmakeopts
 }
 


### PR DESCRIPTION
kernel-2.eclass: Respect portage CC & AR variables

Starting with kernel>=v5.7 the build system can override the
tools vars by setting LLVM=1 [1], but older kernels still use
the default GNU tools, so to be able to use a full LLVM/Clang
build, CC should be set together with AR to the portage set
values.

Doing this avoids situations like building the kernel with
clang (using the set HOSTCC) but using gcc/gnu-ar for headers.

[1] a0d1c951ef08 kbuild: support LLVM=1 to switch the default tools to Clang/LLVM

Co-authored-by: Manoj Gupta <manojgupta@chromium.org>
Signed-off-by: Adrian Ratiu <adrian.ratiu@collabora.com>