### PR TITLE
dev-libs/gjs: fix compatibiliy with meson 0.60.2

### DIFF
--- a/dev-libs/gjs/files/gjs-1.70.0-meson602.patch
+++ b/dev-libs/gjs/files/gjs-1.70.0-meson602.patch
@@ -1,0 +1,76 @@
+From 59bbb5e4795d2b6e41ce27ae3b18257e75b71a19 Mon Sep 17 00:00:00 2001
+From: Jan Beich <jbeich@FreeBSD.org>
+Date: Sat, 27 Nov 2021 22:57:11 +0000
+Subject: [PATCH] build: disable gir install via list to pacify meson >= 0.60.2
+
+meson.build:580:0: ERROR: "install_dir" must be specified when installing a target
+installed-tests/js/meson.build:73:0: ERROR: "install_dir" must be specified when installing a target
+installed-tests/js/meson.build:91:4: ERROR: "install_dir" must be specified when installing a target
+installed-tests/js/meson.build:104:0: ERROR: "install_dir" must be specified when installing a target
+installed-tests/js/libgjstesttools/meson.build:13:0: ERROR: "install_dir" must be specified when installing a target
+---
+ installed-tests/js/libgjstesttools/meson.build | 2 +-
+ installed-tests/js/meson.build                 | 6 +++---
+ meson.build                                    | 2 +-
+ 3 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/installed-tests/js/libgjstesttools/meson.build b/installed-tests/js/libgjstesttools/meson.build
+index 2e57483a..3ca4d7ed 100644
+--- a/installed-tests/js/libgjstesttools/meson.build
++++ b/installed-tests/js/libgjstesttools/meson.build
+@@ -14,7 +14,7 @@ gjstest_tools_gir = gnome.generate_gir(libgjstesttools,
+     includes: ['GObject-2.0', 'Gio-2.0'], sources: gjstest_tools_sources,
+     namespace: 'GjsTestTools', nsversion: '1.0',
+     symbol_prefix: 'gjs_test_tools_', extra_args: '--warn-error',
+-    install: get_option('installed_tests'), install_dir_gir: false,
++    install: get_option('installed_tests'), install_dir_gir: [false],
+     install_dir_typelib: installed_tests_execdir)
+ gjstest_tools_typelib = gjstest_tools_gir[1]
+ libgjstesttools_dep = declare_dependency(
+diff --git a/installed-tests/js/meson.build b/installed-tests/js/meson.build
+index 2f007351..16b59660 100644
+--- a/installed-tests/js/meson.build
++++ b/installed-tests/js/meson.build
+@@ -74,7 +74,7 @@ regress_gir = gnome.generate_gir(libregress, includes: regress_gir_includes,
+     sources: regress_sources, namespace: 'Regress', nsversion: '1.0',
+     identifier_prefix: 'Regress', symbol_prefix: 'regress_',
+     extra_args: ['--warn-all', '--warn-error'] + regress_gir_c_args,
+-    install: get_option('installed_tests'), install_dir_gir: false,
++    install: get_option('installed_tests'), install_dir_gir: [false],
+     install_dir_typelib: installed_tests_execdir)
+ regress_typelib = regress_gir[1]
+ 
+@@ -91,7 +91,7 @@ if not skip_warnlib
+     warnlib_gir = gnome.generate_gir(libwarnlib, includes: ['Gio-2.0'],
+         sources: warnlib_sources, namespace: 'WarnLib', nsversion: '1.0',
+         symbol_prefix: 'warnlib_', header: 'warnlib.h',
+-        install: get_option('installed_tests'), install_dir_gir: false,
++        install: get_option('installed_tests'), install_dir_gir: [false],
+         install_dir_typelib: installed_tests_execdir)
+     warnlib_typelib = warnlib_gir[1]
+ endif
+@@ -105,7 +105,7 @@ gimarshallingtests_gir = gnome.generate_gir(libgimarshallingtests,
+     includes: ['Gio-2.0'], sources: gimarshallingtests_sources,
+     namespace: 'GIMarshallingTests', nsversion: '1.0',
+     symbol_prefix: 'gi_marshalling_tests_', extra_args: '--warn-error',
+-    install: get_option('installed_tests'), install_dir_gir: false,
++    install: get_option('installed_tests'), install_dir_gir: [false],
+     install_dir_typelib: installed_tests_execdir)
+ gimarshallingtests_typelib = gimarshallingtests_gir[1]
+ 
+diff --git a/meson.build b/meson.build
+index 437b3fd3..73d0eaca 100644
+--- a/meson.build
++++ b/meson.build
+@@ -581,7 +581,7 @@ gjs_private_gir = gnome.generate_gir(libgjs,
+     includes: ['GObject-2.0', 'Gio-2.0'], sources: libgjs_private_sources,
+     namespace: 'GjsPrivate', nsversion: '1.0', identifier_prefix: 'Gjs',
+     symbol_prefix: 'gjs_', extra_args: '--warn-error', install: true,
+-    install_dir_gir: false, install_dir_typelib: pkglibdir / 'girepository-1.0')
++    install_dir_gir: [false], install_dir_typelib: pkglibdir / 'girepository-1.0')
+ gjs_private_typelib = gjs_private_gir[1]
+ 
+ ### Build gjs-console interpreter ##############################################
+-- 
+GitLab
+

--- a/dev-libs/gjs/gjs-1.70.0.ebuild
+++ b/dev-libs/gjs/gjs-1.70.0.ebuild
@@ -31,6 +31,10 @@ BDEPEND="
 	virtual/pkgconfig
 "
 
+PATCHES="
+	"${FILESDIR}/${P}-meson602.patch"
+"
+
 src_configure() {
 	append-cppflags -DG_DISABLE_CAST_CHECKS
 


### PR DESCRIPTION
Added patch from upstream to gjs 1.70.0, tested on ~amd64

related bug: https://bugs.gentoo.org/827538