### PR TITLE
dev-java/jnr-ffi: restrict tests

### DIFF
--- a/dev-java/jnr-ffi/jnr-ffi-2.0.2-r1.ebuild
+++ b/dev-java/jnr-ffi/jnr-ffi-2.0.2-r1.ebuild
@@ -15,6 +15,9 @@ LICENSE="|| ( Apache-2.0 LGPL-3 )"
 SLOT="2"
 KEYWORDS="~ppc64"
 
+# Fixing https://bugs.gentoo.org/736830 would cost too much time.
+RESTRICT="test"
+
 COMMON_DEP="
 	~dev-java/jffi-1.2.9:1.2
 	dev-java/jnr-x86asm:1.0


### PR DESCRIPTION
Package-Manager: Portage-3.0.28, Repoman-3.0.3
Signed-off-by: Volkmar W. Pogatzki <gentoo@pogatzki.net>