### PR TITLE
app-editors/vim: remove warning due to missing defaults.vim

### DIFF
--- a/app-editors/vim-core/vim-core-8.2.0814.ebuild
+++ b/app-editors/vim-core/vim-core-8.2.0814.ebuild
@@ -191,6 +191,9 @@ src_install() {
 		rm -rv "${ED}${vimfiles}"/{macros,print,tools,tutor} || die "rm failed"
 		rm -v "${ED}"/usr/bin/vimtutor || die "rm failed"
 
+		# Delete defaults.vim to avoid conflicts with one from vim[minimal]
+		rm -v "${ED}${vimfiles}"/defaults.vim || die "rm failed"
+
 		local keep_colors="default"
 		ignore=$(rm -fr "${ED}${vimfiles}"/colors/!(${keep_colors}).vim )
 
@@ -198,6 +201,9 @@ src_install() {
 		# tinkering with the next line might make bad things happen ...
 		keep_syntax="${keep_syntax}|syntax|nosyntax|synload"
 		ignore=$(rm -fr "${ED}${vimfiles}"/syntax/!(${keep_syntax}).vim )
+
+		# Delete skip_defaults_vim config not supported by vim[minimal]
+		sed -i '/skip_defaults_vim/d' "${ED}"/etc/vim/vimrc || die "sed failed"
 
 		eshopts_pop
 	fi

--- a/app-editors/vim-core/vim-core-8.2.3428.ebuild
+++ b/app-editors/vim-core/vim-core-8.2.3428.ebuild
@@ -193,6 +193,9 @@ src_install() {
 		rm -rv "${ED}${vimfiles}"/{macros,print,tools,tutor} || die "rm failed"
 		rm -v "${ED}"/usr/bin/vimtutor || die "rm failed"
 
+		# Delete defaults.vim to avoid conflicts with one from vim[minimal]
+		rm -v "${ED}${vimfiles}"/defaults.vim || die "rm failed"
+
 		local keep_colors="default"
 		ignore=$(rm -fr "${ED}${vimfiles}"/colors/!(${keep_colors}).vim )
 
@@ -200,6 +203,9 @@ src_install() {
 		# tinkering with the next line might make bad things happen ...
 		keep_syntax="${keep_syntax}|syntax|nosyntax|synload"
 		ignore=$(rm -fr "${ED}${vimfiles}"/syntax/!(${keep_syntax}).vim )
+
+		# Delete skip_defaults_vim config not supported by vim[minimal]
+		sed -i '/skip_defaults_vim/d' "${ED}"/etc/vim/vimrc || die "sed failed"
 
 		eshopts_pop
 	fi

--- a/app-editors/vim-core/vim-core-8.2.3567.ebuild
+++ b/app-editors/vim-core/vim-core-8.2.3567.ebuild
@@ -193,6 +193,9 @@ src_install() {
 		rm -rv "${ED}${vimfiles}"/{macros,print,tools,tutor} || die "rm failed"
 		rm -v "${ED}"/usr/bin/vimtutor || die "rm failed"
 
+		# Delete defaults.vim to avoid conflicts with one from vim[minimal]
+		rm -v "${ED}${vimfiles}"/defaults.vim || die "rm failed"
+
 		local keep_colors="default"
 		ignore=$(rm -fr "${ED}${vimfiles}"/colors/!(${keep_colors}).vim )
 
@@ -200,6 +203,9 @@ src_install() {
 		# tinkering with the next line might make bad things happen ...
 		keep_syntax="${keep_syntax}|syntax|nosyntax|synload"
 		ignore=$(rm -fr "${ED}${vimfiles}"/syntax/!(${keep_syntax}).vim )
+
+		# Delete skip_defaults_vim config not supported by vim[minimal]
+		sed -i '/skip_defaults_vim/d' "${ED}"/etc/vim/vimrc || die "sed failed"
 
 		eshopts_pop
 	fi

--- a/app-editors/vim-core/vim-core-8.2.3582.ebuild
+++ b/app-editors/vim-core/vim-core-8.2.3582.ebuild
@@ -193,6 +193,9 @@ src_install() {
 		rm -rv "${ED}${vimfiles}"/{macros,print,tools,tutor} || die "rm failed"
 		rm -v "${ED}"/usr/bin/vimtutor || die "rm failed"
 
+		# Delete defaults.vim to avoid conflicts with one from vim[minimal]
+		rm -v "${ED}${vimfiles}"/defaults.vim || die "rm failed"
+
 		local keep_colors="default"
 		ignore=$(rm -fr "${ED}${vimfiles}"/colors/!(${keep_colors}).vim )
 
@@ -200,6 +203,9 @@ src_install() {
 		# tinkering with the next line might make bad things happen ...
 		keep_syntax="${keep_syntax}|syntax|nosyntax|synload"
 		ignore=$(rm -fr "${ED}${vimfiles}"/syntax/!(${keep_syntax}).vim )
+
+		# Delete skip_defaults_vim config not supported by vim[minimal]
+		sed -i '/skip_defaults_vim/d' "${ED}"/etc/vim/vimrc || die "sed failed"
 
 		eshopts_pop
 	fi

--- a/app-editors/vim-core/vim-core-9999.ebuild
+++ b/app-editors/vim-core/vim-core-9999.ebuild
@@ -193,6 +193,9 @@ src_install() {
 		rm -rv "${ED}${vimfiles}"/{macros,print,tools,tutor} || die "rm failed"
 		rm -v "${ED}"/usr/bin/vimtutor || die "rm failed"
 
+		# Delete defaults.vim to avoid conflicts with one from vim[minimal]
+		rm -v "${ED}${vimfiles}"/defaults.vim || die "rm failed"
+
 		local keep_colors="default"
 		ignore=$(rm -fr "${ED}${vimfiles}"/colors/!(${keep_colors}).vim )
 
@@ -200,6 +203,9 @@ src_install() {
 		# tinkering with the next line might make bad things happen ...
 		keep_syntax="${keep_syntax}|syntax|nosyntax|synload"
 		ignore=$(rm -fr "${ED}${vimfiles}"/syntax/!(${keep_syntax}).vim )
+
+		# Delete skip_defaults_vim config not supported by vim[minimal]
+		sed -i '/skip_defaults_vim/d' "${ED}"/etc/vim/vimrc || die "sed failed"
 
 		eshopts_pop
 	fi

--- a/app-editors/vim/vim-8.2.0814-r100.ebuild
+++ b/app-editors/vim/vim-8.2.0814-r100.ebuild
@@ -304,6 +304,12 @@ src_install() {
 		fperms a+x ${vimfiles}/macros/manpager.sh
 	fi
 
+	# Fix an issue of missing defaults.vim when USE=minimal.
+	if use minimal ; then
+		insinto ${vimfiles}
+		doins runtime/defaults.vim
+	fi
+
 	domenu runtime/vim.desktop
 
 	newbashcomp "${FILESDIR}"/${PN}-completion ${PN}

--- a/app-editors/vim/vim-8.2.3428-r1.ebuild
+++ b/app-editors/vim/vim-8.2.3428-r1.ebuild
@@ -316,6 +316,12 @@ src_install() {
 		fperms a+x ${vimfiles}/macros/manpager.sh
 	fi
 
+	# Fix an issue of missing defaults.vim when USE=minimal.
+	if use minimal ; then
+		insinto ${vimfiles}
+		doins runtime/defaults.vim
+	fi
+
 	domenu runtime/vim.desktop
 
 	newbashcomp "${FILESDIR}"/${PN}-completion ${PN}

--- a/app-editors/vim/vim-8.2.3567.ebuild
+++ b/app-editors/vim/vim-8.2.3567.ebuild
@@ -318,6 +318,12 @@ src_install() {
 		fperms a+x ${vimfiles}/macros/manpager.sh
 	fi
 
+	# Fix an issue of missing defaults.vim when USE=minimal.
+	if use minimal ; then
+		insinto ${vimfiles}
+		doins runtime/defaults.vim
+	fi
+
 	domenu runtime/vim.desktop
 
 	newbashcomp "${FILESDIR}"/${PN}-completion ${PN}

--- a/app-editors/vim/vim-8.2.3582.ebuild
+++ b/app-editors/vim/vim-8.2.3582.ebuild
@@ -318,6 +318,12 @@ src_install() {
 		fperms a+x ${vimfiles}/macros/manpager.sh
 	fi
 
+	# Fix an issue of missing defaults.vim when USE=minimal.
+	if use minimal ; then
+		insinto ${vimfiles}
+		doins runtime/defaults.vim
+	fi
+
 	domenu runtime/vim.desktop
 
 	newbashcomp "${FILESDIR}"/${PN}-completion ${PN}

--- a/app-editors/vim/vim-9999.ebuild
+++ b/app-editors/vim/vim-9999.ebuild
@@ -318,6 +318,12 @@ src_install() {
 		fperms a+x ${vimfiles}/macros/manpager.sh
 	fi
 
+	# Fix an issue of missing defaults.vim when USE=minimal.
+	if use minimal ; then
+		insinto ${vimfiles}
+		doins runtime/defaults.vim
+	fi
+
 	domenu runtime/vim.desktop
 
 	newbashcomp "${FILESDIR}"/${PN}-completion ${PN}


### PR DESCRIPTION
vim >= 8.2.3428 prints out a warning on missing file, when it is built with USE="minimal" and `app-editors/vim-core` is not installed.

```
$ vim
E1187: Failed to source defaults.vim
Press ENTER or type command to continue
```

To remove the warning, explicitly install /usr/share/vim/vim82/defaults.vim.

Closes: https://bugs.gentoo.org/820356
Signed-off-by: Dongsu Park <dpark@linux.microsoft.com>