### PR TITLE
sys-libs/glibc: allow disabling clone3 sysflag (breaks older Electron)

### DIFF
--- a/sys-libs/glibc/files/glibc-2.34-disable-clone3-syscall.patch
+++ b/sys-libs/glibc/files/glibc-2.34-disable-clone3-syscall.patch
@@ -1,0 +1,38 @@
+We're disabling clone3 for now _CONDITIONALLY_ (not by default) to allow
+compatibility with applications using older Electron.
+
+This was impacting e.g. Discord and Skype. This patch stops glibc from using
+clone3 internally (which is the only real use of it) and falls back to the old
+behaviour.
+
+Specifically, we want https://github.com/electron/electron/pull/31091
+to work its way downstream to various Electron applications.
+
+https://bugs.gentoo.org/819045
+https://bugs.gentoo.org/827386
+
+https://git.launchpad.net/~ubuntu-core-dev/ubuntu/+source/glibc/plain/debian/patches/ubuntu/disable-clone3.patch
+
+This is the same as the patch that was considered but ultimately rejected
+for 2.34 because Docker got sorted out in time:
+https://patchwork.ozlabs.org/project/glibc/patch/87eebkf8ph.fsf@oldenburg.str.redhat.com/.
+--- a/sysdeps/unix/sysv/linux/clone-internal.c
++++ b/sysdeps/unix/sysv/linux/clone-internal.c
+@@ -48,17 +48,6 @@
+ 		  int (*func) (void *arg), void *arg)
+ {
+   int ret;
+-#ifdef HAVE_CLONE3_WRAPPER
+-  /* Try clone3 first.  */
+-  int saved_errno = errno;
+-  ret = __clone3 (cl_args, sizeof (*cl_args), func, arg);
+-  if (ret != -1 || errno != ENOSYS)
+-    return ret;
+-
+-  /* NB: Restore errno since errno may be checked against non-zero
+-     return value.  */
+-  __set_errno (saved_errno);
+-#endif
+ 
+   /* Map clone3 arguments to clone arguments.  NB: No need to check
+      invalid clone3 specific bits in flags nor exit_signal since this

--- a/sys-libs/glibc/glibc-2.34-r3.ebuild
+++ b/sys-libs/glibc/glibc-2.34-r3.ebuild
@@ -46,7 +46,7 @@ SRC_URI+=" https://gitweb.gentoo.org/proj/locale-gen.git/snapshot/locale-gen-${L
 SRC_URI+=" multilib-bootstrap? ( https://dev.gentoo.org/~dilfridge/distfiles/gcc-multilib-bootstrap-${GCC_BOOTSTRAP_VER}.tar.xz )"
 SRC_URI+=" systemd? ( https://gitweb.gentoo.org/proj/toolchain/glibc-systemd.git/snapshot/glibc-systemd-${GLIBC_SYSTEMD_VER}.tar.gz )"
 
-IUSE="audit caps cet compile-locales +crypt custom-cflags doc gd headers-only +multiarch multilib multilib-bootstrap nscd profile selinux +ssp +static-libs static-pie suid systemd systemtap test vanilla"
+IUSE="audit caps cet +clone3 compile-locales +crypt custom-cflags doc gd headers-only +multiarch multilib multilib-bootstrap nscd profile selinux +ssp +static-libs static-pie suid systemd systemtap test vanilla"
 
 # Minimum kernel version that glibc requires
 MIN_KERN_VER="3.2.0"
@@ -789,6 +789,13 @@ src_prepare() {
 		einfo "Applying Gentoo Glibc Patchset ${patchsetname}"
 		eapply "${WORKDIR}"/patches
 		einfo "Done."
+	fi
+
+	if ! use clone3 ; then
+		elog "Disabling the clone3 syscall for compatibility with older Electron apps."
+		elog "Please re-enable this flag before filing bugs!"
+		# See e.g. bug #827386, bug #819045.
+		eapply "${FILESDIR}"/${P}-disable-clone3-syscall.patch
 	fi
 
 	default

--- a/sys-libs/glibc/metadata.xml
+++ b/sys-libs/glibc/metadata.xml
@@ -7,6 +7,7 @@
 </maintainer>
 <use>
  <flag name="cet">Enable Intel Control-flow Enforcement Technology (needs binutils 2.29 and gcc 8)</flag>
+ <flag name="clone3">Enable the new clone3 syscall within glibc. Can be disabled to allow compatibility with older Electron applications.</flag>
  <flag name="compile-locales">build *all* locales in src_install; this is generally meant for stage building only as it ignores /etc/locale.gen file and can be pretty slow</flag>
  <flag name="crypt">build and install libcrypt and crypt.h</flag>
  <flag name="debug">When USE=hardened, allow fortify/stack violations to dump core (SIGABRT) and not kill self (SIGKILL)</flag>


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/827386
Bug: https://bugs.gentoo.org/819045
Signed-off-by: Sam James <sam@gentoo.org>