### PR TITLE
net-fs/nfs-utils: fix killall usage in init script

### DIFF
--- a/net-fs/nfs-utils/files/nfs.initd
+++ b/net-fs/nfs-utils/files/nfs.initd
@@ -51,7 +51,7 @@ mount_nfsd() {
 		fi
 		# Restart idmapd if needed #220747
 		if grep -qs nfsd /proc/modules ; then
-			killall -q -HUP rpc.idmapd
+			killall -q --signal=HUP rpc.idmapd
 		fi
 	fi
 


### PR DESCRIPTION
Bug 664066 has surfaced again. Fix it properly by calling killall with
"--signal=HUP" rather than the short form that keeps being broken.

Closes: https://bugs.gentoo.org/664066
Signed-off-by: Stijn Tintel <stijn@linux-ipv6.be>