### PR TITLE
media-libs/libwmf: do not install .la files

### DIFF
--- a/media-libs/libwmf/libwmf-0.2.8.4-r8.ebuild
+++ b/media-libs/libwmf/libwmf-0.2.8.4-r8.ebuild
@@ -89,6 +89,7 @@ src_install() {
 	MAKEOPTS=-j1
 
 	default
+	find "${D}" -name '*.la' -delete || die
 }
 
 pkg_preinst() {


### PR DESCRIPTION
Signed-off-by: Paolo Pedroni <paolo.pedroni@iol.it>
Closes: https://bugs.gentoo.org/827894