### PR TITLE
x11-misc/clipmenu: add USE-flags to select launcher

### DIFF
--- a/x11-misc/clipmenu/clipmenu-6.2.0-r1.ebuild
+++ b/x11-misc/clipmenu/clipmenu-6.2.0-r1.ebuild
@@ -13,6 +13,7 @@ LICENSE="Unlicense"
 SLOT="0"
 KEYWORDS="amd64 x86"
 IUSE="+dmenu rofi fzf"
+REQUIRED_USE="?? ( dmenu rofi fzf )"
 
 RDEPEND="
 	x11-misc/clipnotify
@@ -21,15 +22,14 @@ RDEPEND="
 	rofi? ( x11-misc/rofi )
 	fzf? ( app-shells/fzf )
 "
-REQUIRED_USE="?? ( dmenu rofi fzf )"
 
 src_prepare() {
 	default
 
 	if use rofi ; then
-		sed -i 's|CM_LAUNCHER=dmenu|CM_LAUNCHER=rofi' clipmenu || die "sed failed"
+		sed -i 's|CM_LAUNCHER=dmenu|CM_LAUNCHER=rofi|' clipmenu || die "sed failed"
 	elif use fzf ; then
-		sed -i 's|CM_LAUNCHER=dmenu|CM_LAUNCHER=fzf' clipmenu || die "sed failed"
+		sed -i 's|CM_LAUNCHER=dmenu|CM_LAUNCHER=fzf|' clipmenu || die "sed failed"
 	fi
 }
 

--- a/x11-misc/clipmenu/clipmenu-6.2.0-r1.ebuild
+++ b/x11-misc/clipmenu/clipmenu-6.2.0-r1.ebuild
@@ -12,13 +12,26 @@ SRC_URI="https://github.com/cdown/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
 LICENSE="Unlicense"
 SLOT="0"
 KEYWORDS="amd64 x86"
-IUSE="+launcher"
+IUSE="+dmenu rofi fzf"
 
 RDEPEND="
 	x11-misc/clipnotify
 	x11-misc/xsel
-	launcher? ( || ( x11-misc/dmenu x11-misc/rofi app-shells/fzf ) )
+	dmenu? ( x11-misc/dmenu )
+	rofi? ( x11-misc/rofi )
+	fzf? ( app-shells/fzf )
 "
+REQUIRED_USE="?? ( dmenu rofi fzf )"
+
+src_prepare() {
+	default
+
+	if use rofi ; then
+		sed -i 's|CM_LAUNCHER=dmenu|CM_LAUNCHER=rofi' clipmenu || die "sed failed"
+	elif use fzf ; then
+		sed -i 's|CM_LAUNCHER=dmenu|CM_LAUNCHER=fzf' clipmenu || die "sed failed"
+	fi
+}
 
 src_compile() {
 	:
@@ -36,7 +49,7 @@ src_install() {
 }
 
 pkg_postinst() {
-	if ! use launcher ; then
+	if ! use dmenu && ! use rofi && ! use fzf ; then
 		ewarn "Clipmenu has been installed without a launcher."
 		ewarn "You will need to set \$CM_LAUNCHER to a dmenu-compatible app for clipmenu to work."
 		ewarn "Please refer to the documents for more info."

--- a/x11-misc/clipmenu/clipmenu-6.2.0-r1.ebuild
+++ b/x11-misc/clipmenu/clipmenu-6.2.0-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit systemd optfeature
+inherit systemd
 
 DESCRIPTION="Clipboard management using dmenu"
 HOMEPAGE="https://github.com/cdown/clipmenu"
@@ -12,11 +12,12 @@ SRC_URI="https://github.com/cdown/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
 LICENSE="Unlicense"
 SLOT="0"
 KEYWORDS="amd64 x86"
-IUSE=""
+IUSE="+launcher"
 
 RDEPEND="
 	x11-misc/clipnotify
 	x11-misc/xsel
+	launcher? ( || ( x11-misc/dmenu x11-misc/rofi app-shells/fzf ) )
 "
 
 src_compile() {
@@ -29,10 +30,15 @@ src_install() {
 		dobin ${binfile}
 	done
 
+	dodoc README.md
+
 	systemd_douserunit "init/clipmenud.service"
 }
 
 pkg_postinst() {
-	optfeature_header "Install optional menu frontends:"
-	optfeature "menu support" x11-misc/dmenu x11-misc/rofi app-shells/fzf
+	if ! use launcher ; then
+		ewarn "Clipmenu has been installed without a launcher."
+		ewarn "You will need to set \$CM_LAUNCHER to a dmenu-compatible app for clipmenu to work."
+		ewarn "Please refer to the documents for more info."
+	fi
 }

--- a/x11-misc/clipmenu/clipmenu-6.2.0-r1.ebuild
+++ b/x11-misc/clipmenu/clipmenu-6.2.0-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit systemd
+inherit systemd optfeature
 
 DESCRIPTION="Clipboard management using dmenu"
 HOMEPAGE="https://github.com/cdown/clipmenu"
@@ -16,7 +16,6 @@ IUSE=""
 
 RDEPEND="
 	x11-misc/clipnotify
-	x11-misc/dmenu
 	x11-misc/xsel
 "
 
@@ -31,4 +30,9 @@ src_install() {
 	done
 
 	systemd_douserunit "init/clipmenud.service"
+}
+
+pkg_postinst() {
+	optfeature_header "Install optional menu frontends:"
+	optfeature "menu support" x11-misc/dmenu x11-misc/rofi app-shells/fzf
 }

--- a/x11-misc/clipmenu/metadata.xml
+++ b/x11-misc/clipmenu/metadata.xml
@@ -10,6 +10,8 @@
 		<name>Proxy Maintainers</name>
 	</maintainer>
 	<use>
-		<flag name="launcher">Add launcher support for clipmenu</flag>
+		<flag name="dmenu">Use dmenu as default launcher</flag>
+		<flag name="rofi">Use rofi as default launcher</flag>
+		<flag name="fzf">Use fzf as default launcher</flag>
 	</use>
 </pkgmetadata>

--- a/x11-misc/clipmenu/metadata.xml
+++ b/x11-misc/clipmenu/metadata.xml
@@ -9,4 +9,7 @@
 		<email>proxy-maint@gentoo.org</email>
 		<name>Proxy Maintainers</name>
 	</maintainer>
+	<use>
+		<flag name="launcher">Add launcher support for clipmenu</flag>
+	</use>
 </pkgmetadata>


### PR DESCRIPTION
while the default menu/frontend for clipmenu is dmenu, it can also work
with rofi, fzf or any other "menu" application and thus dmenu should not
be pulled in as a hard dep.