### PR TITLE
mail-filter/rspamd: empty Toolset.cmake file

### DIFF
--- a/mail-filter/rspamd/rspamd-3.1.ebuild
+++ b/mail-filter/rspamd/rspamd-3.1.ebuild
@@ -68,6 +68,8 @@ src_prepare() {
 
 	rm -vrf contrib/{doctest,fmt,lua-bit,snowball,zstd} || die
 
+	> cmake/Toolset.cmake || die #827550
+
 	sed -i -e 's/User=_rspamd/User=rspamd/g' \
 		rspamd.service \
 		|| die

--- a/mail-filter/rspamd/rspamd-9999.ebuild
+++ b/mail-filter/rspamd/rspamd-9999.ebuild
@@ -68,6 +68,8 @@ src_prepare() {
 
 	rm -vrf contrib/{doctest,fmt,lua-bit,snowball,zstd} || die
 
+	> cmake/Toolset.cmake || die #827550
+
 	sed -i -e 's/User=_rspamd/User=rspamd/g' \
 		rspamd.service \
 		|| die


### PR DESCRIPTION
The Toolset.cmake file seems to be unnecessary, it tries to control flags which in Gentoo should be controlled by user. This applies a change suggested in https://bugs.gentoo.org/827550#c1.