### PR TITLE
games-engines/odamex: Remove client dependency for odalaunch

### DIFF
--- a/games-engines/odamex/odamex-0.9.5.ebuild
+++ b/games-engines/odamex/odamex-0.9.5.ebuild
@@ -22,10 +22,10 @@ RDEPEND="
 		media-libs/libsdl2[joystick,sound,video]
 		media-libs/sdl2-mixer
 		net-misc/curl
-		odalaunch? ( x11-libs/wxGTK:${WX_GTK_VER}[X] )
 		portmidi? ( media-libs/portmidi )
 		X? ( x11-libs/libX11 )
 	)
+	odalaunch? ( x11-libs/wxGTK:${WX_GTK_VER}[X] )
 	server? (
 		upnp? ( net-libs/miniupnpc:= )
 	)"


### PR DESCRIPTION
The Odamex launcher does not depend on the Odamex client and can be
built independently.

Closes: https://bugs.gentoo.org/827266
Signed-off-by: William Breathitt Gray <vilhelm.gray@gmail.com>