### PR TITLE
sys-fs/udev: rename 80-net-name-slot.rules when migrating from eudev

### DIFF
--- a/sys-fs/udev/udev-249.6-r1.ebuild
+++ b/sys-fs/udev/udev-249.6-r1.ebuild
@@ -299,5 +299,11 @@ pkg_postinst() {
 		ewarn
 		ewarn "If you wish to disable this, please see the above documentation, or set"
 		ewarn "net.ifnames=0 on the kernel command line."
+		if [[ -e ${EROOT}/etc/udev/rules.d/80-net-name-slot.rules ]]; then
+			ewarn
+			ewarn "Detected '${EROOT}/etc/udev/rules.d/80-net-name-slot.rules'"
+			ewarn "Renaming to '${EROOT}/etc/udev/rules.d/80-net-setup-link.rules'"
+			mv "${EROOT}"/etc/udev/rules.d/80-net-{name-slot,setup-link}.rules
+		fi
 	fi
 }

--- a/sys-fs/udev/udev-249.6.ebuild
+++ b/sys-fs/udev/udev-249.6.ebuild
@@ -292,5 +292,11 @@ pkg_postinst() {
 		ewarn
 		ewarn "If you wish to disable this, please see the above documentation, or set"
 		ewarn "net.ifnames=0 on the kernel command line."
+		if [[ -e ${EROOT}/etc/udev/rules.d/80-net-name-slot.rules ]]; then
+			ewarn
+			ewarn "Detected '${EROOT}/etc/udev/rules.d/80-net-name-slot.rules'"
+			ewarn "Renaming to '${EROOT}/etc/udev/rules.d/80-net-setup-link.rules'"
+			mv "${EROOT}"/etc/udev/rules.d/80-net-{name-slot,setup-link}.rules
+		fi
 	fi
 }

--- a/sys-fs/udev/udev-9999.ebuild
+++ b/sys-fs/udev/udev-9999.ebuild
@@ -299,5 +299,11 @@ pkg_postinst() {
 		ewarn
 		ewarn "If you wish to disable this, please see the above documentation, or set"
 		ewarn "net.ifnames=0 on the kernel command line."
+		if [[ -e ${EROOT}/etc/udev/rules.d/80-net-name-slot.rules ]]; then
+			ewarn
+			ewarn "Detected '${EROOT}/etc/udev/rules.d/80-net-name-slot.rules'"
+			ewarn "Renaming to '${EROOT}/etc/udev/rules.d/80-net-setup-link.rules'"
+			mv "${EROOT}"/etc/udev/rules.d/80-net-{name-slot,setup-link}.rules
+		fi
 	fi
 }


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/827937