### PR TITLE
profiles/base: mask sys-apps/exa[man] in base

### DIFF
--- a/profiles/base/package.use.mask
+++ b/profiles/base/package.use.mask
@@ -6,6 +6,11 @@
 # This file is only for generic masks. For arch-specific masks (i.e.
 # mask everywhere, unmask on arch/*) use arch/base.
 
+# Wolfgang E. Sanyer <ezzieyguywuf@gmail.com> (2021-12-01)
+# Requires pandoc, which is unstable due to various haskell dependencies
+# (including ghc)
+>=sys-apps/exa-0.10.1 man
+
 # Sam James <sam@gentoo.org> (2021-11-26)
 # Needs unpackaged asciidoctor-pdf for now
 # bug #827290


### PR DESCRIPTION
This pulls in pandoc, which for the moment will remain unstable until a
plan is in place for stabilizing ghc and other haskell dependencies.

Signed-off-by: Wolfgang E. Sanyer <ezzieyguywuf@gmail.com>
