### PR TITLE
profiles/features/musl: mask net-misc/iputils[rarpd]

### DIFF
--- a/profiles/features/musl/package.use.mask
+++ b/profiles/features/musl/package.use.mask
@@ -1,6 +1,10 @@
 # Copyright 1999-2021 Gentoo Authors.
 # Distributed under the terms of the GNU General Public License v2
 
+# Stijn Tintel <stijn@linux-ipv6.be> (2021-12-02)
+# rarpd relies on ether_ntohost which is a stub in musl
+net-misc/iputils rarpd
+
 # Sam James <sam@gentoo.org> (2021-11-20)
 # Pulls in po4a which doesn't seem to work on musl (wants /usr/bin/locale)
 sys-apps/man-db nls


### PR DESCRIPTION
Running rarpd requires a working ether_ntohost. In musl, this is
implemented as a stub that returns -1, so rarpd always fails. Prevent
users from having to debug this by masking the rarpd USE flag on musl.