### PR TITLE
*/*: mdds & friends keywording

### DIFF
--- a/app-text/libetonyek/libetonyek-0.1.10-r1.ebuild
+++ b/app-text/libetonyek/libetonyek-0.1.10-r1.ebuild
@@ -10,8 +10,7 @@ if [[ ${PV} == *9999 ]]; then
 else
 	MDDS_VER="2.0"
 	SRC_URI="https://dev-www.libreoffice.org/src/libetonyek/${P}.tar.xz"
-	# Unkeyworded while libreoffice has no release making use of this slot
-	# KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~x86"
 fi
 DESCRIPTION="Library parsing Apple Keynote presentations"
 HOMEPAGE="https://wiki.documentfoundation.org/DLP/Libraries/libetonyek"

--- a/dev-libs/libixion/libixion-0.17.0.ebuild
+++ b/dev-libs/libixion/libixion-0.17.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{8,9} )
+PYTHON_COMPAT=( python3_{8..10} )
 inherit python-single-r1
 
 DESCRIPTION="General purpose formula parser & interpreter"
@@ -16,8 +16,7 @@ if [[ ${PV} == *9999 ]]; then
 else
 	MDDS_SLOT="1/2.0"
 	SRC_URI="https://kohei.us/files/ixion/src/${P}.tar.xz"
-	# Unkeyworded while libreoffice has no release making use of this slot
-	# KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~x86"
 fi
 
 LICENSE="MIT"

--- a/dev-libs/liborcus/liborcus-0.17.0.ebuild
+++ b/dev-libs/liborcus/liborcus-0.17.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{8,9} )
+PYTHON_COMPAT=( python3_{8..10} )
 
 inherit autotools python-single-r1
 
@@ -17,8 +17,7 @@ if [[ ${PV} == *9999* ]]; then
 else
 	MDDS_SLOT="1/2.0"
 	SRC_URI="https://kohei.us/files/orcus/src/${P}.tar.xz"
-	# Unkeyworded while libreoffice has no release making use of this slot
-	# KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~x86"
 fi
 
 LICENSE="MIT"

--- a/dev-util/mdds/mdds-2.0.0.ebuild
+++ b/dev-util/mdds/mdds-2.0.0.ebuild
@@ -8,8 +8,7 @@ if [[ ${PV} == *9999* ]]; then
 	inherit git-r3
 else
 	SRC_URI="https://kohei.us/files/${PN}/src/${P}.tar.xz"
-	# Unkeyworded while libreoffice has no release making use of this slot
-	# KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~x86 ~amd64-linux ~x86-linux"
+	KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~x86 ~amd64-linux ~x86-linux"
 fi
 inherit autotools toolchain-funcs
 


### PR DESCRIPTION
This must be merged before libreoffice 7.3 has a proper release or is keyworded. The python compat updates are just syncs between the ebuilds.