### PR TITLE
dev-qt/qtnetwork: drop USE=bindist for OpenSSL changes

### DIFF
--- a/dev-qt/qtnetwork/qtnetwork-5.15.2-r13.ebuild
+++ b/dev-qt/qtnetwork/qtnetwork-5.15.2-r13.ebuild
@@ -13,7 +13,7 @@ if [[ ${QT5_BUILD_TYPE} == release ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~riscv ~sparc ~x86"
 fi
 
-IUSE="bindist connman gssapi libproxy networkmanager sctp +ssl"
+IUSE="connman gssapi libproxy networkmanager sctp +ssl"
 
 DEPEND="
 	=dev-qt/qtcore-${QT5_PV}*:5=
@@ -23,7 +23,7 @@ DEPEND="
 	libproxy? ( net-libs/libproxy )
 	networkmanager? ( =dev-qt/qtdbus-${QT5_PV}* )
 	sctp? ( kernel_linux? ( net-misc/lksctp-tools ) )
-	ssl? ( >=dev-libs/openssl-1.1.1:0=[bindist(-)=] )
+	ssl? ( >=dev-libs/openssl-1.1.1:0= )
 "
 RDEPEND="${DEPEND}
 	connman? ( net-misc/connman )


### PR DESCRIPTION
OpenSSL no longer has USE=bindist.

Bug: https://bugs.gentoo.org/762850
Signed-off-by: Sam James <sam@gentoo.org>