### PR TITLE
x11-base/xorg-server: restore setuid for non-systemd/logind meson build

### DIFF
--- a/x11-base/xorg-server/xorg-server-21.1.1-r3.ebuild
+++ b/x11-base/xorg-server/xorg-server-21.1.1-r3.ebuild
@@ -1,0 +1,187 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+XORG_DOC=doc
+XORG_TARBALL_SUFFIX="xz"
+XORG_EAUTORECONF="no"
+inherit xorg-3 meson
+EGIT_REPO_URI="https://gitlab.freedesktop.org/xorg/xserver.git"
+
+DESCRIPTION="X.Org X servers"
+SLOT="0/${PV}"
+if [[ ${PV} != 9999* ]]; then
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux"
+fi
+
+IUSE_SERVERS="xephyr xnest xorg xvfb"
+IUSE="${IUSE_SERVERS} debug +elogind minimal selinux suid systemd test +udev unwind xcsecurity"
+RESTRICT="!test? ( test )"
+
+CDEPEND="
+	media-libs/libglvnd[X]
+	dev-libs/openssl:0=
+	>=x11-apps/iceauth-1.0.2
+	>=x11-apps/rgb-1.0.3
+	>=x11-apps/xauth-1.0.3
+	x11-apps/xkbcomp
+	>=x11-libs/libdrm-2.4.89
+	>=x11-libs/libpciaccess-0.12.901
+	>=x11-libs/libXau-1.0.4
+	>=x11-libs/libXdmcp-1.0.2
+	>=x11-libs/libXfont2-2.0.1
+	>=x11-libs/libxcvt-0.1.0
+	>=x11-libs/libxkbfile-1.0.4
+	>=x11-libs/libxshmfence-1.1
+	>=x11-libs/pixman-0.27.2
+	>=x11-misc/xbitmaps-1.0.1
+	>=x11-misc/xkeyboard-config-2.4.1-r3
+	>=x11-libs/libXext-1.0.5
+	x11-libs/libXv
+	xephyr? (
+		x11-libs/libxcb[xkb]
+		x11-libs/xcb-util
+		x11-libs/xcb-util-image
+		x11-libs/xcb-util-keysyms
+		x11-libs/xcb-util-renderutil
+		x11-libs/xcb-util-wm
+	)
+	!minimal? (
+		>=x11-libs/libX11-1.1.5
+		>=x11-libs/libXext-1.0.5
+		>=media-libs/mesa-18[X(+),egl(+),gbm(+)]
+		>=media-libs/libepoxy-1.5.4[X,egl(+)]
+	)
+	udev? ( virtual/libudev:= )
+	unwind? ( sys-libs/libunwind )
+	>=x11-apps/xinit-1.3.3-r1
+	selinux? ( sys-libs/libselinux )
+	systemd? (
+		sys-apps/dbus
+		sys-apps/systemd
+	)
+	elogind? (
+		sys-apps/dbus
+		sys-auth/elogind[pam]
+		sys-auth/pambase[elogind]
+	)
+	!!x11-drivers/nvidia-drivers[-libglvnd(+)]
+"
+DEPEND="${CDEPEND}
+	>=x11-base/xorg-proto-2021.4.99.2
+	>=x11-libs/xtrans-1.3.5
+	doc? (
+		x11-base/xorg-sgml-doctools
+	)
+"
+RDEPEND="${CDEPEND}
+	!systemd? ( gui-libs/display-manager-init )
+	selinux? ( sec-policy/selinux-xserver )
+"
+BDEPEND="
+	sys-devel/flex
+"
+PDEPEND="
+	xorg? ( >=x11-base/xorg-drivers-$(ver_cut 1-2) )"
+
+REQUIRED_USE="!minimal? (
+		|| ( ${IUSE_SERVERS} )
+	)
+	elogind? ( udev )
+	?? ( elogind systemd )"
+
+UPSTREAMED_PATCHES=(
+	"${FILESDIR}"/${P}-DPI-revert.patch
+)
+
+PATCHES=(
+	"${UPSTREAMED_PATCHES[@]}"
+	"${FILESDIR}"/${PN}-1.12-unloadsubmodule.patch
+	# needed for new eselect-opengl, bug #541232
+	"${FILESDIR}"/${PN}-1.18-support-multiple-Files-sections.patch
+)
+
+src_configure() {
+	# localstatedir is used for the log location; we need to override the default
+	#	from ebuild.sh
+	# sysconfdir is used for the xorg.conf location; same applies
+	# NOTE: fop is used for doc generating; and I have no idea if Gentoo
+	#	package it somewhere
+
+	local emesonargs=(
+		--localstatedir "${EPREFIX}/var"
+		--sysconfdir "${EPREFIX}/etc/X11"
+		--buildtype $(usex debug debug plain)
+		-Db_ndebug=$(usex debug false true)
+		$(meson_use doc docs)
+		$(meson_use !minimal dri1)
+		$(meson_use !minimal dri2)
+		$(meson_use !minimal dri3)
+		$(meson_use !minimal glamor)
+		$(meson_use !minimal glx)
+		$(meson_use udev)
+		$(meson_use udev udev_kms)
+		$(meson_use unwind libunwind)
+		$(meson_use xcsecurity)
+		$(meson_use xephyr)
+		$(meson_use xnest)
+		$(meson_use xorg)
+		$(meson_use xvfb)
+		-Ddefault_font_path="${EPREFIX}"/usr/share/fonts
+		-Ddrm=true
+		-Ddtrace=false
+		-Dipv6=true
+		-Dhal=false
+		-Dlinux_acpi=false
+		-Dlinux_apm=false
+		-Dsha1=libcrypto
+		-Dxkb_output_dir="${EPREFIX}/var/lib/xkb"
+	)
+
+	if use systemd || use elogind; then
+		emesonargs+=(
+			-Dsystemd_logind=true
+			$(meson_use suid suid_wrapper)
+		)
+	else
+		emesonargs+=(
+			-Dsystemd_logind=false
+			-Dsuid_wrapper=false
+		)
+	fi
+
+	meson_src_configure
+}
+
+src_install() {
+	meson_src_install
+
+	#The new meson build system do not leave X symlink
+	ln -s Xorg "${ED}"/usr/bin/X
+
+	#The new meson build system does not support install-setuid
+	if ! use systemd || ! use elogind; then
+		if use suid; then
+			chmod u+s "${ED}"/usr/bin/Xorg
+		fi
+	fi
+
+	if ! use xorg; then
+		rm -f "${ED}"/usr/share/man/man1/Xserver.1x \
+			"${ED}"/usr/$(get_libdir)/xserver/SecurityPolicy \
+			"${ED}"/usr/$(get_libdir)/pkgconfig/xorg-server.pc \
+			"${ED}"/usr/share/man/man1/Xserver.1x || die
+	fi
+
+	# install the @x11-module-rebuild set for Portage
+	insinto /usr/share/portage/config/sets
+	newins "${FILESDIR}"/xorg-sets.conf xorg.conf
+}
+
+pkg_postrm() {
+	# Get rid of module dir to ensure opengl-update works properly
+	if [[ -z ${REPLACED_BY_VERSION} && -e ${EROOT}/usr/$(get_libdir)/xorg/modules ]]; then
+		rm -rf "${EROOT}"/usr/$(get_libdir)/xorg/modules
+	fi
+}


### PR DESCRIPTION
The meson build does not support the autotools build option install-setuid and when not using systemd or logind the suid_wrapper is not equivalent as it does not resolve tty or input device permissions unless /etc/X11/Xwrapper.config is created with;

allowed_users = anybody
needs_root_rights = yes

(Note _needs_root_rights=auto_ only checks video card permissions and nothing else.)

In which case you can skip the wrapper as this would be the default preference when using startx or xinit without systemd or logind from the console or init scripts. So revert to previous autotools build behaviour.

Signed-off-by: Alan Swanson <reiver@improbability.net>