### PR TITLE
media-gfx/freecad - don't fail if oce and occ are both installed

### DIFF
--- a/media-gfx/freecad/freecad-0.19.2-r5.ebuild
+++ b/media-gfx/freecad/freecad-0.19.2-r5.ebuild
@@ -223,17 +223,6 @@ src_configure() {
 		# Use the version of shiboken2 that matches the selected python version
 		-DPYTHON_CONFIG_SUFFIX="-${EPYTHON}"
 		-DPython3_EXECUTABLE=${PYTHON}
-
-		-DOCCT_CMAKE_FALLBACK=ON				# don't use occt-config which isn't included in opencascade for Gentoo
-	)
-
-	# bug https://bugs.gentoo.org/788274
-	local OCC_P=$(best_version sci-libs/opencascade[vtk])
-	OCC_P=${OCC_P#sci-libs/}
-	OCC_P=${OCC_P%-r*}
-	mycmakeargs+=(
-		-DOCC_INCLUDE_DIR="${CASROOT}"/include/${OCC_P}
-		-DOCC_LIBRARY_DIR="${CASROOT}"/$(get_libdir)/${OCC_P}
 	)
 
 	if use debug; then

--- a/media-gfx/freecad/freecad-9999.ebuild
+++ b/media-gfx/freecad/freecad-9999.ebuild
@@ -234,17 +234,6 @@ src_configure() {
 		# Use the version of shiboken2 that matches the selected python version
 		-DPYTHON_CONFIG_SUFFIX="-${EPYTHON}"
 		-DPython3_EXECUTABLE=${PYTHON}
-
-		-DOCCT_CMAKE_FALLBACK=ON				# don't use occt-config which isn't included in opencascade for Gentoo
-	)
-
-	# bug https://bugs.gentoo.org/788274
-	local OCC_P=$(best_version sci-libs/opencascade[vtk])
-	OCC_P=${OCC_P#sci-libs/}
-	OCC_P=${OCC_P%-r*}
-	mycmakeargs+=(
-		-DOCC_INCLUDE_DIR="${CASROOT}"/include/${OCC_P}
-		-DOCC_LIBRARY_DIR="${CASROOT}"/$(get_libdir)/${OCC_P}
 	)
 
 	if use debug; then


### PR DESCRIPTION
**media-gfx/freecad-0.19.2-r5: don't fail if oce and occ are both installed**
Switch a cmake option, to allow proper configuration if both
sci-libs/oce and sci-libs/opencascade are installed.
This allows to further simplify opencascade related logic.

Closes: https://bugs.gentoo.org/827936
Package-Manager: Portage-3.0.28, Repoman-3.0.3
Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>

**media-gfx/freecad-9999: port changes from v0.19 to live ebuild**
Switch a cmake option, to allow proper configuration, if both,
sci-libs/oce and sci-libs/opencascade are being installed.
This allow to further simplify opencascade related logic.

Package-Manager: Portage-3.0.28, Repoman-3.0.3
Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>
