### PR TITLE
media-video/jellyfin-media-player: clarify license

### DIFF
--- a/media-video/jellyfin-media-player/jellyfin-media-player-1.6.1.ebuild
+++ b/media-video/jellyfin-media-player/jellyfin-media-player-1.6.1.ebuild
@@ -12,7 +12,15 @@ HOMEPAGE="https://github.com/jellyfin/jellyfin-media-player"
 SRC_URI="
 	https://github.com/jellyfin/${PN}/archive/refs/tags/v${PV}.tar.gz -> ${P}.tar.gz
 "
-LICENSE="GPL-2"
+# GPL-2.0 for JMP itself
+# licenses for code in external/:
+#   MIT for qhttp
+#   BSD for qslog
+LICENSE="
+	GPL-2
+	BSD
+	MIT
+"
 SLOT="0"
 
 KEYWORDS="~amd64"


### PR DESCRIPTION
JMP includes various vendored libraries, clarify the licenses of them

Package-Manager: Portage-3.0.28, Repoman-3.0.3
Signed-off-by: Arsen Arsenović <arsen@aarsen.me>