### PR TITLE
Add required workload definition file

### DIFF
--- a/dev-dotnet/dotnet-sdk-bin/dotnet-sdk-bin-6.0.100.ebuild
+++ b/dev-dotnet/dotnet-sdk-bin/dotnet-sdk-bin-6.0.100.ebuild
@@ -37,6 +37,12 @@ src_install() {
 	local dest="opt/${PN}-${SLOT}"
 	dodir "${dest%/*}"
 
+	# 6.0.100 is SDK feature band which will not change between minor increases, so 6.0.101, 6.102
+	# will still have same 6.0.100 SDK feature band in the name. Thus I have to hard code this
+	# https://github.com/dotnet/sdk/pull/18823#issuecomment-915603684
+	local workloads="metadata/workloads/${SLOT}.100"
+
+	{ mkdir -p "${S}/${workloads}" && touch "${S}/${workloads}/userlocal"; } || die
 	{ mv "${S}" "${ED}/${dest}" && mkdir "${S}" && fperms 0755 "/${dest}"; } || die
 	dosym "../../${dest}/dotnet" "/usr/bin/dotnet-bin-${SLOT}"
 


### PR DESCRIPTION
I add /opt/dotnet-sdk-bin-6.0/metadata/workloads/6.0.100/userlocal file
which used to indicate which workloads are installed.
Without that file Nuget think this is broken installation and attempt to create that file
which become a problem for ebuilds which depends on dotnet.

Closes: https://bugs.gentoo.org/827712
Signed-off-by: Andrii Kurdiumov <kant2002@gmail.com>