### PR TITLE
media-gfx/openvdb: fix issue if imath and ilmbase are both installed

### DIFF
--- a/media-gfx/openvdb/files/openvdb-8.2.0-fix-finding-ilmbase-if-imath-and-ilmbase-are-installed.patch
+++ b/media-gfx/openvdb/files/openvdb-8.2.0-fix-finding-ilmbase-if-imath-and-ilmbase-are-installed.patch
@@ -1,0 +1,37 @@
+From: Bernd Waibel <waebbl-gentoo@posteo.net>
+Date: Sat, 4 Dec 2021 20:16:42 +0100
+Subject: [PATCH] fix finding ilmbase if imath and ilmbase are installed
+
+If both, ilmbase-2.5 and imath-3 are installed, the configuration fails
+if OPENVDB_BUILD_BINARIES and OPENVDB_BUILD_RENDER are set.
+The patch adds an additional guard based on the USE_IMATH_HALF option
+being set and thus decide whether to search for and use imath or ilmbase.
+
+Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>
+--- a/openvdb/openvdb/cmd/CMakeLists.txt
++++ b/openvdb/openvdb/cmd/CMakeLists.txt
+@@ -81,12 +81,17 @@ endif()
+ #### vdb_render
+ 
+ if(OPENVDB_BUILD_VDB_RENDER)
+-  find_package(Imath CONFIG)
+-  if (NOT TARGET Imath::Imath)
++  if(USE_IMATH_HALF)
++    find_package(Imath CONFIG)
++    if (NOT TARGET Imath::Imath)
++      find_package(IlmBase ${MINIMUM_ILMBASE_VERSION} REQUIRED COMPONENTS Half Iex IlmThread Imath)
++      find_package(OpenEXR ${MINIMUM_OPENEXR_VERSION} REQUIRED COMPONENTS IlmImf)
++    else()
++      find_package(OpenEXR CONFIG)
++    endif()
++  else()
+     find_package(IlmBase ${MINIMUM_ILMBASE_VERSION} REQUIRED COMPONENTS Half Iex IlmThread Imath)
+     find_package(OpenEXR ${MINIMUM_OPENEXR_VERSION} REQUIRED COMPONENTS IlmImf)
+-  else()
+-    find_package(OpenEXR CONFIG)
+   endif()
+ 
+   set(VDB_RENDER_SOURCE_FILES openvdb_render.cc)
+-- 
+2.34.1
+

--- a/media-gfx/openvdb/files/openvdb-8.2.0-unconditionally-search-Python-interpreter.patch
+++ b/media-gfx/openvdb/files/openvdb-8.2.0-unconditionally-search-Python-interpreter.patch
@@ -1,0 +1,34 @@
+From: Bernd Waibel <waebbl-gentoo@posteo.net>
+Date: Sat, 4 Dec 2021 20:45:49 +0100
+Subject: [PATCH] unconditionally search Python interpreter
+
+When setting PYOPENVDB_INSTALL_DIRECTORY, CMake would fail with:
+```
+-- Could NOT find Python (missing: Python_LIBRARIES Development Development.Module Development.Embed) (found version "3.9.9")
+CMake Error at openvdb/openvdb/python/CMakeLists.txt:65 (message):
+  Could NOT find Python::Module (Required is at least version "2.7")
+Call Stack (most recent call first):
+  openvdb/openvdb/python/CMakeLists.txt:112 (openvdb_check_python_version)
+  ```
+
+It seems like we always need to search for the interpreter.
+
+Bug: https://bugs.gentoo.org/790350
+Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>
+--- a/openvdb/openvdb/python/CMakeLists.txt
++++ b/openvdb/openvdb/python/CMakeLists.txt
+@@ -73,10 +73,7 @@ endfunction()
+ #   target but this was only added in CMake 3.15. See:
+ #      https://github.com/AcademySoftwareFoundation/openvdb/issues/886
+ set(OPENVDB_PYTHON_DEPS)
+-set(OPENVDB_PYTHON_REQUIRED_COMPONENTS Development)
+-if(NOT DEFINED PYOPENVDB_INSTALL_DIRECTORY)
+-    list(APPEND OPENVDB_PYTHON_REQUIRED_COMPONENTS Interpreter)
+-endif()
++set(OPENVDB_PYTHON_REQUIRED_COMPONENTS Development Interpreter)
+ 
+ if(${CMAKE_VERSION} VERSION_LESS 3.14)
+   find_package(Python QUIET COMPONENTS ${OPENVDB_PYTHON_REQUIRED_COMPONENTS})
+-- 
+2.34.1
+


### PR DESCRIPTION
The patch fixes an issue when OPENVDB_BUILD_BINARIES and OPENVDB_BUILD_RENDER
are set and both, dev-libs/imath and media-libs/ilmbase are being installed
and allows the package to configure properly in this case.

Additionally it fixes the installation location of the python module.

Bug: https://bugs.gentoo.org/790350
Package-Manager: Portage-3.0.28, Repoman-3.0.3
Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>