### PR TITLE
dev-libs/protobuf: fix Objective-C compiler selection

### DIFF
--- a/dev-libs/protobuf/protobuf-3.16.0.ebuild
+++ b/dev-libs/protobuf/protobuf-3.16.0.ebuild
@@ -74,6 +74,7 @@ src_configure() {
 
 multilib_src_configure() {
 	local options=(
+		OBJC="$(tc-getBUILD_CC)"
 		$(use_enable static-libs static)
 		$(use_with zlib)
 	)

--- a/dev-libs/protobuf/protobuf-3.17.0.ebuild
+++ b/dev-libs/protobuf/protobuf-3.17.0.ebuild
@@ -74,6 +74,7 @@ src_configure() {
 
 multilib_src_configure() {
 	local options=(
+		OBJC="$(tc-getBUILD_CC)"
 		$(use_enable static-libs static)
 		$(use_with zlib)
 	)

--- a/dev-libs/protobuf/protobuf-3.17.1.ebuild
+++ b/dev-libs/protobuf/protobuf-3.17.1.ebuild
@@ -74,6 +74,7 @@ src_configure() {
 
 multilib_src_configure() {
 	local options=(
+		OBJC="$(tc-getBUILD_CC)"
 		$(use_enable static-libs static)
 		$(use_with zlib)
 	)

--- a/dev-libs/protobuf/protobuf-3.17.2.ebuild
+++ b/dev-libs/protobuf/protobuf-3.17.2.ebuild
@@ -74,6 +74,7 @@ src_configure() {
 
 multilib_src_configure() {
 	local options=(
+		OBJC="$(tc-getBUILD_CC)"
 		$(use_enable static-libs static)
 		$(use_with zlib)
 	)

--- a/dev-libs/protobuf/protobuf-3.17.3.ebuild
+++ b/dev-libs/protobuf/protobuf-3.17.3.ebuild
@@ -74,6 +74,7 @@ src_configure() {
 
 multilib_src_configure() {
 	local options=(
+		OBJC="$(tc-getBUILD_CC)"
 		$(use_enable static-libs static)
 		$(use_with zlib)
 	)

--- a/dev-libs/protobuf/protobuf-3.19.1.ebuild
+++ b/dev-libs/protobuf/protobuf-3.19.1.ebuild
@@ -71,6 +71,7 @@ src_configure() {
 
 multilib_src_configure() {
 	local options=(
+		OBJC="$(tc-getBUILD_CC)"
 		$(use_enable static-libs static)
 		$(use_with zlib)
 	)

--- a/dev-libs/protobuf/protobuf-9999.ebuild
+++ b/dev-libs/protobuf/protobuf-9999.ebuild
@@ -52,6 +52,7 @@ src_configure() {
 
 multilib_src_configure() {
 	local options=(
+		OBJC="$(tc-getBUILD_CC)"
 		$(use_enable static-libs static)
 		$(use_with zlib)
 	)


### PR DESCRIPTION
During the protobuf configure phase, autotools gives priority
to GCC if $OBJC is unset, thus leading to cases where GCC is
used for Objective-C even though Clang is used for the rest
of the build, so we set OBJC to correctly picks up CC values.

Signed-off-by: Adrian Ratiu <adrian.ratiu@collabora.com>