### PR TITLE
dev-libs/boost: fix AR/RANLIB configuration

### DIFF
--- a/dev-libs/boost/boost-1.76.0-r1.ebuild
+++ b/dev-libs/boost/boost-1.76.0-r1.ebuild
@@ -89,7 +89,7 @@ create_user-config.jam() {
 	fi
 
 	cat > "${user_config_jam}" <<- __EOF__ || die
-		using ${compiler} : ${compiler_version} : ${compiler_executable} : <cflags>"${CFLAGS}" <cxxflags>"${CXXFLAGS}" <linkflags>"${LDFLAGS}" ;
+		using ${compiler} : ${compiler_version} : ${compiler_executable} : <cflags>"${CFLAGS}" <cxxflags>"${CXXFLAGS}" <linkflags>"${LDFLAGS}" <archiver>"$(tc-getAR)" <ranlib>"$(tc-getRANLIB)" ;
 		${mpi_configuration}
 	__EOF__
 

--- a/dev-libs/boost/boost-1.77.0-r4.ebuild
+++ b/dev-libs/boost/boost-1.77.0-r4.ebuild
@@ -91,7 +91,7 @@ create_user-config.jam() {
 	fi
 
 	cat > "${user_config_jam}" <<- __EOF__ || die
-		using ${compiler} : ${compiler_version} : ${compiler_executable} : <cflags>"${CFLAGS}" <cxxflags>"${CXXFLAGS}" <linkflags>"${LDFLAGS}" ;
+		using ${compiler} : ${compiler_version} : ${compiler_executable} : <cflags>"${CFLAGS}" <cxxflags>"${CXXFLAGS}" <linkflags>"${LDFLAGS}" <archiver>"$(tc-getAR)" <ranlib>"$(tc-getRANLIB)" ;
 		${mpi_configuration}
 	__EOF__
 


### PR DESCRIPTION
The ebuild jam configuration did not specify any values for the
archiver and ranlib so Boost.Build would end up using the default
GNU versions even when building with Clang++.

Setting the values ensures the proper llvm-ar / llvm-ranlib are
used in LLVM build configurations.

Signed-off-by: Adrian Ratiu <adrian.ratiu@collabora.com>