### PR TITLE
app-admin/mkosi: add missing firmware deps for booting with qemu

### DIFF
--- a/app-admin/mkosi/mkosi-12-r1.ebuild
+++ b/app-admin/mkosi/mkosi-12-r1.ebuild
@@ -18,7 +18,8 @@ RDEPEND="
 	dev-vcs/git
 	sys-apps/portage
 	sys-apps/systemd
-"
+	app-emulation/qemu
+	sys-firmware/edk2-ovmf"
 
 distutils_enable_tests pytest
 


### PR DESCRIPTION
Signed-off-by: Paymon MARANDI <darwinskernel@gmail.com>