### PR TITLE
eclass/ruby-fakegem.eclass: updated extensions dir according to formula from rubygems

### DIFF
--- a/eclass/ruby-fakegem.eclass
+++ b/eclass/ruby-fakegem.eclass
@@ -561,7 +561,10 @@ ruby_fakegem_extensions_installed() {
 # The directory where rubygems expects extensions for this package
 # version.
 ruby_fakegem_extensionsdir() {
-	echo "$(ruby_fakegem_gemsdir)/extensions/$(ruby_rbconfig_value 'arch')/$(ruby_rbconfig_value 'ruby_version')/${RUBY_FAKEGEM_NAME}-${RUBY_FAKEGEM_VERSION}"
+	# Using formula from ruby src/lib/rubygems/basic_specification.
+	extensions_dir=$(${RUBY} --disable=did_you_mean -e "puts File.join('extensions', Gem::Platform.local.to_s, Gem.extension_api_version)")
+
+	echo "$(ruby_fakegem_gemsdir)/${extensions_dir}/${RUBY_FAKEGEM_NAME}-${RUBY_FAKEGEM_VERSION}"
 }
 
 # @FUNCTION: each_fakegem_install


### PR DESCRIPTION
Hello. There is an [old bug 423589](https://bugs.gentoo.org/423589) about failing `rdoc` installation on i686 systems for ruby <= 2.6. I've reproduced it and found inconsistency between ruby fakegem and native ruby gem functionality.

Please review original extensions formula from ruby [source/lib/rubygems/basic_specification](https://github.com/ruby/ruby/blob/master/lib/rubygems/basic_specification.rb#L104-L108).
Today ruby fakegem uses `RbConfig::CONFIG['arch']` instead of `Gem::Platform.local.to_s`. `Gem::Platform.local.to_s` won't always equal to `RbConfig::CONFIG['arch']`. For example on i686 system:

```
Gem::Platform.local.to_s = 'x86-linux'
RbConfig::CONFIG['arch'] = 'i686-linux'
```

We can see that `ruby-fakegem` uses wrong `i686-linux` folder for extensions.

I've investigated ruby releases from v2_1 to 3_0: extensions directory formula is the same. So I am proposing to use it for ruby-fakegem eclass.

Thank you.