### PR TITLE
net-dialup/rp-pppoe: 3.15-r2 - remove MAX_INTERFACES limit.

### DIFF
--- a/net-dialup/rp-pppoe/files/rp-pppoe-3.15-no_max_interfaces.patch
+++ b/net-dialup/rp-pppoe/files/rp-pppoe-3.15-no_max_interfaces.patch
@@ -1,0 +1,91 @@
+pppoe-server: MAX_INTERFACES 64 is a problem for ULS.
+
+We currently require 77 interfaces, this code just lifts the limit entirely and
+will keep adding interfaces for as much RAM as you have to store an array as
+required.
+
+Signed-off-by: Jaco Kroon <jaco@uls.co.za>
+
+diff -rau rp-pppoe-3.15/src.o/pppoe-server.c rp-pppoe-3.15/src/pppoe-server.c
+--- rp-pppoe-3.15.o/src/pppoe-server.c	2021-05-07 15:18:00.000000000 +0200
++++ rp-pppoe-3.15/src/pppoe-server.c	2021-12-07 21:53:46.755693003 +0200
+@@ -115,8 +115,9 @@
+ ClientSession *BusySessions = NULL;
+ 
+ /* Interfaces we're listening on */
+-Interface interfaces[MAX_INTERFACES];
++Interface *interfaces = NULL;
+ int NumInterfaces = 0;
++int MaxInterfaces = 0;
+ 
+ /* The number of session slots */
+ size_t NumSessionSlots;
+@@ -1235,11 +1236,16 @@
+ 	exit(1);
+     }
+ 
+-    memset(interfaces, 0, sizeof(interfaces));
+-
+     /* Initialize syslog */
+     openlog("pppoe-server", LOG_PID, LOG_DAEMON);
+ 
++    MaxInterfaces = INIT_INTERFACES;
++    interfaces = malloc(sizeof(*interfaces) * INIT_INTERFACES);
++    if (!interfaces) {
++	fprintf(stderr, "Out of memory allocating initial interfaces.\n");
++	exit(1);
++    }
++
+     /* Default number of session slots */
+     NumSessionSlots = DEFAULT_MAX_SESSIONS;
+     MaxSessionsPerMac = 0; /* No limit */
+@@ -1406,10 +1412,14 @@
+ 	    break;
+ 
+ 	case 'I':
+-	    if (NumInterfaces >= MAX_INTERFACES) {
+-		fprintf(stderr, "Too many -I options (max %d)\n",
+-			MAX_INTERFACES);
+-		exit(EXIT_FAILURE);
++	    if (NumInterfaces >= MaxInterfaces) {
++		MaxInterfaces *= 2;
++		interfaces = realloc(interfaces, sizeof(*interfaces) * MaxInterfaces);
++		if (!interfaces) {
++		    fprintf(stderr, "Memory allocation failure trying to increase MaxInterfaces to %d\n",
++			    MaxInterfaces);
++		    exit(EXIT_FAILURE);
++		}
+ 	    }
+ 	    found = 0;
+ 	    for (i=0; i<NumInterfaces; i++) {
+@@ -1419,6 +1429,7 @@
+ 		}
+ 	    }
+ 	    if (!found) {
++		memset(&interfaces[NumInterfaces], 0, sizeof(*interfaces));
+ 		strncpy(interfaces[NumInterfaces].name, optarg, IFNAMSIZ);
+ 		NumInterfaces++;
+ 	    }
+diff -rau rp-pppoe-3.15/src.o/pppoe-server.h rp-pppoe-3.15/src/pppoe-server.h
+--- rp-pppoe-3.15/src.o/pppoe-server.h	2021-05-07 15:18:00.000000000 +0200
++++ rp-pppoe-3.15/src/pppoe-server.h	2021-12-07 21:44:09.945578094 +0200
+@@ -97,8 +97,8 @@
+ /* Hack for daemonizing */
+ #define CLOSEFD 64
+ 
+-/* Max. number of interfaces to listen on */
+-#define MAX_INTERFACES 64
++/* Initial Max. number of interfaces to listen on */
++#define INIT_INTERFACES 8
+ 
+ /* Max. 64 sessions by default */
+ #define DEFAULT_MAX_SESSIONS 64
+@@ -107,7 +107,7 @@
+ extern ClientSession *Sessions;
+ 
+ /* Interfaces we're listening on */
+-extern Interface interfaces[MAX_INTERFACES];
++extern Interface *interfaces;
+ extern int NumInterfaces;
+ 
+ /* The number of session slots */

--- a/net-dialup/rp-pppoe/rp-pppoe-3.15-r2.ebuild
+++ b/net-dialup/rp-pppoe/rp-pppoe-3.15-r2.ebuild
@@ -1,0 +1,93 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit autotools readme.gentoo-r1 toolchain-funcs
+
+PATCHSET="${PN}-3.14-patches-01"
+PATCHES=(
+	"${FILESDIR}/rp-pppoe-3.15-no_max_interfaces.patch"
+)
+
+DESCRIPTION="A user-mode PPPoE client and server suite for Linux"
+HOMEPAGE="https://dianne.skoll.ca/projects/rp-pppoe/"
+SRC_URI="https://dianne.skoll.ca/projects/rp-pppoe/download/${P}.tar.gz
+	https://dev.gentoo.org/~polynomial-c/dist/${PATCHSET}.tar.xz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86"
+IUSE="tk"
+
+RDEPEND="
+	net-dialup/ppp:=
+	sys-apps/iproute2
+	tk? ( dev-lang/tk:= )
+"
+DEPEND=">=sys-kernel/linux-headers-2.6.25
+	${RDEPEND}"
+
+DOC_CONTENTS="Use pppoe-setup to configure your dialup connection"
+
+pkg_setup() {
+	# This is needed in multiple phases
+	PPPD_VER="$(best_version net-dialup/ppp)"
+	PPPD_VER="${PPPD_VER#*/*-}" #reduce it to ${PV}-${PR}
+	PPPD_VER="${PPPD_VER%%-*}" #reduce it to ${PV}
+
+	PPPD_PLUGIN_DIR="/usr/$(get_libdir)/pppd/${PPPD_VER}"
+}
+
+src_prepare() {
+	if ! use elibc_musl ; then
+		rm "${WORKDIR}/patches/${PN}-3.14-musl.patch" || die
+	fi
+
+	rm "${WORKDIR}/patches/${PN}-3.14-ifconfig-path.patch" || die
+
+	eapply "${WORKDIR}/patches"
+	eapply "${PATCHES[@]}"
+	eapply_user
+
+	cd "${S}"/src || die
+	eautoreconf
+}
+
+src_configure() {
+	addpredict /dev/ppp
+
+	cd src || die
+
+	econf --enable-plugin=/usr/include/pppd
+}
+
+src_compile() {
+	cd src || die
+	emake AR="$(tc-getAR)" PLUGIN_PATH=rp-pppoe.so PLUGIN_DIR="${PPPD_PLUGIN_DIR}"
+
+	if use tk ; then
+		emake -C "${S}/gui"
+	fi
+}
+
+src_install() {
+	cd src || die
+	emake DESTDIR="${D}" docdir="/usr/share/doc/${PF}" PLUGIN_DIR="${PPPD_PLUGIN_DIR}" install
+
+	# We don't need this README file here.
+	rm "${ED}${PPPD_PLUGIN_DIR}/README" || die "Error removing ${PPPD_PLUGIN_DIR}/README from installation"
+
+	if use tk ; then
+		emake -C "${S}/gui" \
+			DESTDIR="${D}" \
+			datadir=/usr/share/doc/${PF}/ \
+			install
+		dosym doc/${PF}/tkpppoe /usr/share/tkpppoe
+	fi
+
+	newinitd "${FILESDIR}"/pppoe-server.initd pppoe-server
+	newconfd "${FILESDIR}"/pppoe-server.confd pppoe-server
+
+	readme.gentoo_create_doc
+}


### PR DESCRIPTION
The 64 MAX_INTERFACES is a problem for us.  To make matters worse the
number of interfaces we need to listen on are climbing at an alarming
rate.  Need a single pppoe-server instance to share IP pool.

Package-Manager: Portage-3.0.28, Repoman-3.0.3
Signed-off-by: Jaco Kroon <jaco@uls.co.za>