### PR TITLE
dev-util/maxcso: Add patch to support LDFLAGS

### DIFF
--- a/dev-util/maxcso/files/maxcso-1.13.0-ldflags.patch
+++ b/dev-util/maxcso/files/maxcso-1.13.0-ldflags.patch
@@ -1,0 +1,26 @@
+From 29458b4586c8bec1a025a71eab06146fc646ccc4 Mon Sep 17 00:00:00 2001
+From: orbea <orbea@riseup.net>
+Date: Tue, 7 Dec 2021 07:17:28 -0800
+Subject: [PATCH] build: Support LDFLAGS
+
+Fixes the gentoo issue: https://bugs.gentoo.org/828416
+---
+ Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index 4a93ec74..1cc7fc63 100644
+--- a/Makefile
++++ b/Makefile
+@@ -32,7 +32,7 @@ ZOPFLI_C_OBJ = $(ZOPFLI_C_SRC:.c=.o)
+ 
+ # TODO: Perhaps detect and use system libdeflate if available.
+ maxcso: $(SRC_CXX_OBJ) $(CLI_CXX_OBJ) $(ZOPFLI_C_OBJ) 7zip/7zip.a libdeflate/libdeflate.a
+-	$(CXX) -o $@ $(SRC_CXXFLAGS) $(CXXFLAGS) $^ -luv -llz4 -lz
++	$(CXX) $(LDFLAGS) -o $@ $(SRC_CXXFLAGS) $(CXXFLAGS) $^ -luv -llz4 -lz
+ 
+ 7zip/7zip.a:
+ 	$(MAKE) -C 7zip 7zip.a
+-- 
+2.32.0
+

--- a/dev-util/maxcso/maxcso-1.13.0.ebuild
+++ b/dev-util/maxcso/maxcso-1.13.0.ebuild
@@ -26,6 +26,8 @@ RDEPEND="
 "
 DEPEND="${RDEPEND}"
 
+PATCHES=("${FILESDIR}/${P}-ldflags.patch")
+
 src_compile() {
 	emake CC="$(tc-getCC)" CXX="$(tc-getCXX)"
 }


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/828416
Upstream-PR: https://github.com/unknownbrackets/maxcso/pull/58
Upstream commit: https://github.com/unknownbrackets/maxcso/commit/a97c03ef16bffe535a05d01d5ab856d40a70863b