### PR TITLE
dev-cpp/termcolor: Change LICENSE to BSD.

### DIFF
--- a/dev-cpp/termcolor/termcolor-2.0.0.ebuild
+++ b/dev-cpp/termcolor/termcolor-2.0.0.ebuild
@@ -9,7 +9,7 @@ DESCRIPTION="A header-only C++ library for printing colored messages to the term
 HOMEPAGE="https://github.com/ikalnytskyi/termcolor https://termcolor.readthedocs.io"
 SRC_URI="https://github.com/ikalnytskyi/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
-LICENSE="MIT"
+LICENSE="BSD"
 SLOT="0"
 KEYWORDS="~amd64"
 IUSE="test"


### PR DESCRIPTION
Evidence:
- https://github.com/ikalnytskyi/termcolor/blob/v2.0.0/include/termcolor/termcolor.hpp#L9
- https://github.com/ikalnytskyi/termcolor/blob/v2.0.0/LICENSE
- https://termcolor.readthedocs.io/

The LICENSE file has a slight modification in the preamble to explicitly
include documentation.

Signed-off-by: Ronny (tastytea) Gutbrod <gentoo@tastytea.de>