### PR TITLE
profiles/arch: drop python3_10 masks

### DIFF
--- a/profiles/arch/amd64/use.stable.mask
+++ b/profiles/arch/amd64/use.stable.mask
@@ -4,12 +4,6 @@
 # This file requires eapi 5 or later. New entries go on top.
 # Please use the same syntax as in use.mask
 
-# Michał Górny <mgorny@gentoo.org> (2021-05-04)
-# Python 3.10 is not yet stable (and will not be until it's out of beta,
-# around September.
-python_single_target_python3_10
-python_targets_python3_10
-
 # Andreas Sturmlechner <asturm@gentoo.org> (2020-06-06)
 # sci-libs/mkl is not stable, needs online registration to even run pkg_setup
 mkl


### PR DESCRIPTION
Signed-off-by: John Helmert III <ajak@gentoo.org>