### PR TITLE
x11-libs/gtk+: Removed mesa from deps

### DIFF
--- a/x11-libs/gtk+/gtk+-3.24.29.ebuild
+++ b/x11-libs/gtk+/gtk+-3.24.29.ebuild
@@ -54,7 +54,6 @@ COMMON_DEPEND="
 	)
 	X? (
 		>=app-accessibility/at-spi2-atk-2.15.1[${MULTILIB_USEDEP}]
-		media-libs/mesa[X(+),${MULTILIB_USEDEP}]
 		x11-libs/libX11[${MULTILIB_USEDEP}]
 		x11-libs/libXcomposite[${MULTILIB_USEDEP}]
 		x11-libs/libXcursor[${MULTILIB_USEDEP}]


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/show_bug.cgi?id=733464

Fixes [Bug 733464](https://bugs.gentoo.org/show_bug.cgi?id=733464) and confusion with USE-flags on amd64 platform when emerging something depending on the gtk+:3:
```
The following USE changes are necessary to proceed:
 (see "package.use" in the portage(5) man page for more details)
# required by x11-libs/gtk+-3.24.29::gentoo
# required by x11-themes/adwaita-icon-theme-40.1.1::gentoo
>=media-libs/mesa-21.3.1 -abi_x86_32
```