### PR TITLE
dev-util/clazy: use llvm.eclass to declare compatibility

### DIFF
--- a/dev-util/clazy/clazy-1.10-r1.ebuild
+++ b/dev-util/clazy/clazy-1.10-r1.ebuild
@@ -3,7 +3,8 @@
 
 EAPI=7
 
-inherit cmake
+LLVM_MAX_SLOT=12
+inherit cmake llvm
 
 DESCRIPTION="Compiler plugin which allows clang to understand Qt semantics"
 HOMEPAGE="https://apps.kde.org/clazy"
@@ -14,11 +15,17 @@ SLOT="0"
 KEYWORDS="~amd64 arm64 ~x86"
 IUSE=""
 
-RDEPEND="
-	>=sys-devel/clang-8.0:=
-	>=sys-devel/llvm-8.0:=
-"
+RDEPEND="<sys-devel/clang-$((${LLVM_MAX_SLOT} + 1)):="
 DEPEND="${RDEPEND}"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-gcc-build.patch
+	"${FILESDIR}"/${P}-use-c++17.patch
+)
+
+llvm_check_deps() {
+	has_version "sys-devel/clang:${LLVM_SLOT}" && has_version "sys-devel/llvm:${LLVM_SLOT}"
+}
 
 src_prepare() {
 	cmake_src_prepare
@@ -28,12 +35,8 @@ src_prepare() {
 }
 
 src_configure() {
-	# this package requires both llvm and clang of the same version.
-	# clang pulls in the equivalent llvm version, but not vice versa.
-	# so, we must find llvm based on the installed clang version.
-	# bug #681568
-	local clang_version=$(best_version "sys-devel/clang")
-	export LLVM_ROOT="/usr/lib/llvm/$(ver_cut 1 ${clang_version##sys-devel/clang-})"
+	export LLVM_ROOT="$(get_llvm_prefix -d ${LLVM_MAX_SLOT})"
+
 	cmake_src_configure
 }
 

--- a/dev-util/clazy/clazy-1.10-r1.ebuild
+++ b/dev-util/clazy/clazy-1.10-r1.ebuild
@@ -4,7 +4,8 @@
 EAPI=7
 
 LLVM_MAX_SLOT=12
-inherit cmake llvm
+PYTHON_COMPAT=( python3_{8,9,10} )
+inherit cmake llvm python-any-r1
 
 DESCRIPTION="Compiler plugin which allows clang to understand Qt semantics"
 HOMEPAGE="https://apps.kde.org/clazy"
@@ -13,10 +14,12 @@ SRC_URI="mirror://kde/stable/${PN}/${PV}/src/${P}.tar.xz"
 LICENSE="LGPL-2+"
 SLOT="0"
 KEYWORDS="~amd64 arm64 ~x86"
-IUSE=""
+IUSE="test"
+RESTRICT="!test? ( test )"
 
 RDEPEND="<sys-devel/clang-$((${LLVM_MAX_SLOT} + 1)):="
 DEPEND="${RDEPEND}"
+BDEPEND="test? ( ${PYTHON_DEPS} )"
 
 PATCHES=(
 	"${FILESDIR}"/${P}-gcc-build.patch
@@ -25,6 +28,12 @@ PATCHES=(
 
 llvm_check_deps() {
 	has_version "sys-devel/clang:${LLVM_SLOT}" && has_version "sys-devel/llvm:${LLVM_SLOT}"
+}
+
+pkg_setup() {
+	use test && python-any-r1_pkg_setup
+
+	llvm_pkg_setup
 }
 
 src_prepare() {

--- a/dev-util/clazy/files/clazy-1.10-gcc-build.patch
+++ b/dev-util/clazy/files/clazy-1.10-gcc-build.patch
@@ -1,0 +1,44 @@
+https://invent.kde.org/sdk/clazy/-/commit/b74c8729b7b71528c1528579435cda7fdb5d31b4
+
+From: Sergio Martins <smartins@kde.org>
+Date: Thu, 2 Dec 2021 11:05:51 +0000
+Subject: [PATCH] Fix build with some newer gcc complaining about deleted Lexer
+
+--- a/src/SourceCompatibilityHelpers.h
++++ b/src/SourceCompatibilityHelpers.h
+@@ -117,17 +117,13 @@ inline auto getBuffer(const clang::SourceManager &sm, clang::FileID id, bool *in
+ }
+ 
+ #if LLVM_VERSION_MAJOR >= 12
+-inline clang::Lexer getLexer(clang::FileID id, llvm::Optional<llvm::MemoryBufferRef> inputFile,
+-                             const clang::SourceManager &sm, const clang::LangOptions &lo)
+-{
+-    return clang::Lexer(id, inputFile.getValue(), sm, lo);
+-}
++
++#define GET_LEXER(id, inputFile, sm, lo) \
++clang::Lexer(id, inputFile.getValue(), sm, lo)
++
+ #else
+-inline clang::Lexer getLexer(clang::FileID id, const llvm::MemoryBuffer *inputFile,
+-                             const clang::SourceManager &sm, const clang::LangOptions &lo)
+-{
+-    return clang::Lexer(id, inputFile, sm, lo);
+-}
++#define GET_LEXER(id, inputFile, sm, lo) \
++clang::Lexer(id, inputFile.getValue(), sm, lo)
+ #endif
+ 
+ inline bool isFinal(const clang::CXXRecordDecl *record)
+--- a/src/SuppressionManager.cpp
++++ b/src/SuppressionManager.cpp
+@@ -91,7 +91,7 @@ void SuppressionManager::parseFile(FileID id, const SourceManager &sm, const cla
+         return;
+     }
+ 
+-    auto lexer = clazy::getLexer(id, buffer, sm, lo);
++    auto lexer = GET_LEXER(id, buffer, sm, lo);
+     lexer.SetCommentRetentionState(true);
+ 
+     Token token;
+GitLab

--- a/dev-util/clazy/files/clazy-1.10-use-c++17.patch
+++ b/dev-util/clazy/files/clazy-1.10-use-c++17.patch
@@ -1,0 +1,20 @@
+https://invent.kde.org/sdk/clazy/-/commit/b0d831a6716229d18f2677c5d356b37f36d4dfd6
+
+From: Sergio Martins <smartins@kde.org>
+Date: Thu, 2 Dec 2021 11:31:58 +0000
+Subject: [PATCH] cmake: Require c++17
+
+Fixes build with newer compiler which were nagging about not
+finding std::filesystem
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -69,7 +69,7 @@ if(MSVC)
+   # disable trigger-happy warnings from Clang/LLVM headers
+   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4267 /wd4244 /wd4291 /wd4800 /wd4141 /wd4146 /wd4251")
+ elseif(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -fno-common -Woverloaded-virtual -Wcast-qual -fno-strict-aliasing -pedantic -Wno-long-long -Wall -W -Wno-unused-parameter -Wwrite-strings -fno-exceptions -fno-rtti")
++  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 -fno-common -Woverloaded-virtual -Wcast-qual -fno-strict-aliasing -pedantic -Wno-long-long -Wall -W -Wno-unused-parameter -Wwrite-strings -fno-exceptions -fno-rtti")
+ endif()
+ 
+ set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -Wl,-flat_namespace -Wl,-undefined -Wl,suppress")
+GitLab


### PR DESCRIPTION
We need to use llvm.eclass to ensure we don't use too new of
a version of LLVM and Clang.

Closes: https://bugs.gentoo.org/823726
Bug: https://bugs.gentoo.org/823726
Signed-off-by: Sam James <sam@gentoo.org>