### PR TITLE
profiles/package.mask: keep dev-java/jmdns

### DIFF
--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -105,7 +105,6 @@ dev-java/jcommon
 dev-java/jdynamite
 dev-java/jfreesvg
 dev-java/jgrapht
-dev-java/jmdns
 dev-java/jsr225
 dev-java/jsr311-api
 dev-java/jsr322


### PR DESCRIPTION
dev-java/jmdns is in the dependency tree of log4j-2.15.0

Signed-off-by: Volkmar W. Pogatzki <gentoo@pogatzki.net>