### PR TITLE
app-text/poppler: add upstream patch for -png use flag compilation

### DIFF
--- a/app-text/poppler/files/poppler-21.12.0-include-csetjmp.patch
+++ b/app-text/poppler/files/poppler-21.12.0-include-csetjmp.patch
@@ -1,0 +1,24 @@
+From 3ea6bca90d87d3f91556205c4e58ca425c6ac437 Mon Sep 17 00:00:00 2001
+From: Marco Genasci <fedeliallalinea@gmail.com>
+Date: Sun, 12 Dec 2021 10:23:37 +0100
+Subject: [PATCH] Include setjmp.h when WITH_JPEG=yes and WITH_PNG=no
+
+---
+ poppler/ImageEmbeddingUtils.cc | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/poppler/ImageEmbeddingUtils.cc b/poppler/ImageEmbeddingUtils.cc
+index 5c50f1269..c26b9eb2a 100644
+--- a/poppler/ImageEmbeddingUtils.cc
++++ b/poppler/ImageEmbeddingUtils.cc
+@@ -16,6 +16,7 @@
+ extern "C" {
+ #    include <jpeglib.h>
+ }
++#    include <csetjmp>
+ #endif
+ #ifdef ENABLE_LIBPNG
+ #    include <png.h>
+-- 
+GitLab
+

--- a/app-text/poppler/poppler-21.12.0.ebuild
+++ b/app-text/poppler/poppler-21.12.0.ebuild
@@ -63,6 +63,7 @@ PATCHES=(
 	"${FILESDIR}/${PN}-20.12.1-qt5-deps.patch"
 	"${FILESDIR}/${PN}-21.09.0-respect-cflags.patch"
 	"${FILESDIR}/${PN}-0.57.0-disable-internal-jpx.patch"
+	"${FILESDIR}/${P}-include-csetjmp.patch"
 )
 
 src_prepare() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/828578
Package-Manager: Portage-3.0.28, Repoman-3.0.3
Signed-off-by: Marco Genasci <fedeliallalinea@gmail.com>