### PR TITLE
dev-python/matplotlib: fix for python 3.10

### DIFF
--- a/dev-python/matplotlib/matplotlib-3.4.3-r1.ebuild
+++ b/dev-python/matplotlib/matplotlib-3.4.3-r1.ebuild
@@ -73,7 +73,7 @@ RDEPEND="
 	wxwidgets? (
 		$(python_gen_cond_dep '
 			dev-python/wxpython:*[${PYTHON_USEDEP}]
-		' python3_{8,9})
+		')
 	)
 "
 

--- a/dev-python/matplotlib/matplotlib-3.5.1.ebuild
+++ b/dev-python/matplotlib/matplotlib-3.5.1.ebuild
@@ -75,7 +75,7 @@ RDEPEND="
 	wxwidgets? (
 		$(python_gen_cond_dep '
 			dev-python/wxpython:*[${PYTHON_USEDEP}]
-		' python3_{8,9})
+		')
 	)
 "
 


### PR DESCRIPTION
Fix consistency of deps:
dev-python/matplotlib[python_targets_python3_10] shall RDEPEND on dev-python/wxpython[python_targets_python3_10]

Closes: https://bugs.gentoo.org/829011