### PR TITLE
app-admin/integrit: update to EAPI 8

### DIFF
--- a/app-admin/integrit/integrit-4.2_rc1.ebuild
+++ b/app-admin/integrit/integrit-4.2_rc1.ebuild
@@ -22,6 +22,8 @@ S="${WORKDIR}/${PN}-${MY_PV}"
 
 PATCHES=( "${FILESDIR}/${PN}"-4.1-fix-build-system.patch )
 
+BDEPEND="sys-apps/texinfo"
+
 src_prepare() {
 	default
 	mv configure.{in,ac} || die "Failed to move configure.in into .ac"

--- a/app-admin/integrit/integrit-4.2_rc1.ebuild
+++ b/app-admin/integrit/integrit-4.2_rc1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 inherit autotools
 
@@ -14,19 +14,18 @@ SRC_URI="https://github.com/integrit/integrit/archive/v${MY_PV}.tar.gz -> ${P}.t
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~amd64 ~ppc ~x86"
-IUSE=""
 
 # Tests don't work in 4.2_rc1. Please re-check on version bump!
 RESTRICT="test"
 
 S="${WORKDIR}/${PN}-${MY_PV}"
 
-PATCHES=( "${FILESDIR}"/${PN}-4.1-fix-build-system.patch )
+PATCHES=( "${FILESDIR}/${PN}"-4.1-fix-build-system.patch )
 
 src_prepare() {
 	default
-	mv configure.{in,ac} || die
-	mv hashtbl/configure.{in,ac} || die
+	mv configure.{in,ac} || die "Failed to move configure.in into .ac"
+	mv hashtbl/configure.{in,ac} || die "Failed to move hashtbl/configure.in into .ac"
 
 	eautoreconf
 	touch ar-lib || die #775746

--- a/app-admin/integrit/metadata.xml
+++ b/app-admin/integrit/metadata.xml
@@ -1,7 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<!-- maintainer-needed -->
+	<maintainer type="person" proxied="yes">
+		<email>marco@scardovi.com</email>
+		<name>Marco Scardovi</name>
+	</maintainer>
+	<maintainer type="project" proxied="proxy">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
 	<upstream>
 		<remote-id type="github">integrit/integrit</remote-id>
 		<remote-id type="sourceforge">integrit</remote-id>


### PR DESCRIPTION
Summary:
Bump to EAPI 8 (tested before push)
Integrit-4.0 does not exist anymore and now it compiles correctly so I'm gonna clos the bug below
Add myself as maintainer
Drop old version

Closes: https://bugs.gentoo.org/450752

Package-Manager: Portage-3.0.30, Repoman-3.0.3
Signed-off-by: Marco Scardovi <marco@scardovi.com>