### PR TITLE
media-video/wireplumber: bump to EAPI 8 and update PW minimum version

### DIFF
--- a/media-video/wireplumber/wireplumber-9999.ebuild
+++ b/media-video/wireplumber/wireplumber-9999.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 LUA_COMPAT=( lua5-{3,4} )
 
@@ -40,7 +40,7 @@ BDEPEND="
 DEPEND="
 	${LUA_DEPS}
 	>=dev-libs/glib-2.62
-	>=media-video/pipewire-0.3.39
+	>=media-video/pipewire-0.3.41
 	virtual/libc
 	elogind? ( sys-auth/elogind )
 	systemd? ( sys-apps/systemd )


### PR DESCRIPTION
This PR bumps EAPI version to 8 which is what the ebuild was written as, before being downgraded to 7 for inclusion in the main tree. Since at this point anyone without EAPI 8 support is going to have problems upgrading anyway, there's probably no reason to shy away from EAPI 8 for WirePlumber ebuild.

The git master has now raised the libpipewire-0.3 version check to 0.3.41. And this PR does the same in ebuild, so that it fails at dependency resolution rather than during _src_configure_.