### PR TITLE
net-wireless/crda: add python 3.10

### DIFF
--- a/net-wireless/crda/crda-4.14.ebuild
+++ b/net-wireless/crda/crda-4.14.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{7..9} )
+PYTHON_COMPAT=( python3_{8..10} )
 inherit toolchain-funcs python-any-r1 udev
 
 DESCRIPTION="Central Regulatory Domain Agent for wireless networks"


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/823152