### PR TITLE
gui-apps/mako: Add sys-libs/basu sd-bus-provider

### DIFF
--- a/gui-apps/mako/mako-1.6-r1.ebuild
+++ b/gui-apps/mako/mako-1.6-r1.ebuild
@@ -27,6 +27,7 @@ DEPEND="
 	|| (
 		sys-apps/systemd
 		sys-auth/elogind
+		sys-libs/basu
 	)
 	sys-apps/dbus
 	icons? (

--- a/gui-apps/mako/mako-9999.ebuild
+++ b/gui-apps/mako/mako-9999.ebuild
@@ -27,6 +27,7 @@ DEPEND="
 	|| (
 		sys-apps/systemd
 		sys-auth/elogind
+		sys-libs/basu
 	)
 	sys-apps/dbus
 	icons? (


### PR DESCRIPTION
Add sys-libs/basu as alternative sd-bus-provider besides elogind and
systemd

Bug: https://bugs.gentoo.org/783156
Package-Manager: Portage-3.0.28, Repoman-3.0.3
Signed-off-by: Michael Kupfer <mkupfer99@gmail.com>