### PR TITLE
dev-python/python-slugify-4.0.1: fix incorrect usage of DISTUTILS_USE_SETUPTOOLS

### DIFF
--- a/dev-python/python-slugify/python-slugify-4.0.1.ebuild
+++ b/dev-python/python-slugify/python-slugify-4.0.1.ebuild
@@ -1,10 +1,9 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 PYTHON_COMPAT=( python3_{7..9} )
-DISTUTILS_USE_SETUPTOOLS=rdepend
 
 inherit distutils-r1
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/829082