### PR TITLE
acct-group/opendmarc: fix trailing space and bump to EAPI 8

### DIFF
--- a/acct-group/opendmarc/opendmarc-1.ebuild
+++ b/acct-group/opendmarc/opendmarc-1.ebuild
@@ -1,0 +1,9 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit acct-group
+
+DESCRIPTION="Group for mail-filter/opendmarc"
+ACCT_GROUP_ID=244


### PR DESCRIPTION
Signed-off-by: Marco Scardovi <marco@scardovi.com>