### PR TITLE
sys-apps/policycoreutils: update the right store

### DIFF
--- a/sys-apps/policycoreutils/policycoreutils-3.1-r2.ebuild
+++ b/sys-apps/policycoreutils/policycoreutils-3.1-r2.ebuild
@@ -162,7 +162,7 @@ pkg_postinst() {
 	for POLICY_TYPE in ${POLICY_TYPES} ; do
 		# There have been some changes to the policy store, rebuilding now.
 		# https://marc.info/?l=selinux&m=143757277819717&w=2
-		einfo "Rebuilding store ${POLICY_TYPE} (without re-loading)."
-		semodule -s "${POLICY_TYPE}" -n -B || die "Failed to rebuild policy store ${POLICY_TYPE}"
+		einfo "Rebuilding store ${POLICY_TYPE} in '${ROOT:-/}' (without re-loading)."
+		semodule -S "${ROOT:-/}" -s "${POLICY_TYPE}" -n -B || die "Failed to rebuild policy store ${POLICY_TYPE}"
 	done
 }

--- a/sys-apps/policycoreutils/policycoreutils-3.2.ebuild
+++ b/sys-apps/policycoreutils/policycoreutils-3.2.ebuild
@@ -156,7 +156,7 @@ pkg_postinst() {
 	for POLICY_TYPE in ${POLICY_TYPES} ; do
 		# There have been some changes to the policy store, rebuilding now.
 		# https://marc.info/?l=selinux&m=143757277819717&w=2
-		einfo "Rebuilding store ${POLICY_TYPE} (without re-loading)."
-		semodule -s "${POLICY_TYPE}" -n -B || die "Failed to rebuild policy store ${POLICY_TYPE}"
+		einfo "Rebuilding store ${POLICY_TYPE} in '${ROOT:-/}' (without re-loading)."
+		semodule -S "${ROOT:-/}" -s "${POLICY_TYPE}" -n -B || die "Failed to rebuild policy store ${POLICY_TYPE}"
 	done
 }

--- a/sys-apps/policycoreutils/policycoreutils-3.3.ebuild
+++ b/sys-apps/policycoreutils/policycoreutils-3.3.ebuild
@@ -156,7 +156,7 @@ pkg_postinst() {
 	for POLICY_TYPE in ${POLICY_TYPES} ; do
 		# There have been some changes to the policy store, rebuilding now.
 		# https://marc.info/?l=selinux&m=143757277819717&w=2
-		einfo "Rebuilding store ${POLICY_TYPE} (without re-loading)."
-		semodule -s "${POLICY_TYPE}" -n -B || die "Failed to rebuild policy store ${POLICY_TYPE}"
+		einfo "Rebuilding store ${POLICY_TYPE} in '${ROOT:-/}' (without re-loading)."
+		semodule -S "${ROOT:-/}" -s "${POLICY_TYPE}" -n -B || die "Failed to rebuild policy store ${POLICY_TYPE}"
 	done
 }

--- a/sys-apps/policycoreutils/policycoreutils-9999.ebuild
+++ b/sys-apps/policycoreutils/policycoreutils-9999.ebuild
@@ -156,7 +156,7 @@ pkg_postinst() {
 	for POLICY_TYPE in ${POLICY_TYPES} ; do
 		# There have been some changes to the policy store, rebuilding now.
 		# https://marc.info/?l=selinux&m=143757277819717&w=2
-		einfo "Rebuilding store ${POLICY_TYPE} (without re-loading)."
-		semodule -s "${POLICY_TYPE}" -n -B || die "Failed to rebuild policy store ${POLICY_TYPE}"
+		einfo "Rebuilding store ${POLICY_TYPE} in '${ROOT:-/}' (without re-loading)."
+		semodule -S "${ROOT:-/}" -s "${POLICY_TYPE}" -n -B || die "Failed to rebuild policy store ${POLICY_TYPE}"
 	done
 }


### PR DESCRIPTION
The policycoreutils ebuild calls `semodule` in `postinst` to update SELinux stores. It does not, however, tells semodule the correct ROOT to use, so installing `policycoreutils` in a crossdev environment will actually update the **host's** store.

This patch adds `-S "${ROOT:-/}"` to the `semodule` call so the correct environment is updated.

First seen + fixed in Flatcar Container Linux: https://github.com/flatcar-linux/coreos-overlay/pull/1502