### PR TITLE
sys-apps/osinfo-db-tools: add python 3.10

### DIFF
--- a/sys-apps/osinfo-db-tools/osinfo-db-tools-1.9.0.ebuild
+++ b/sys-apps/osinfo-db-tools/osinfo-db-tools-1.9.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{7..9} )
+PYTHON_COMPAT=( python3_{8..10} )
 
 inherit meson python-any-r1
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/829363