### PR TITLE
net-libs/gtk-vnc: add python 3.10

### DIFF
--- a/net-libs/gtk-vnc/gtk-vnc-1.2.0.ebuild
+++ b/net-libs/gtk-vnc/gtk-vnc-1.2.0.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-PYTHON_COMPAT=( python3_{7..9} )
+PYTHON_COMPAT=( python3_{8..10} )
 
 inherit gnome.org vala meson python-any-r1 xdg
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/829373