### PR TITLE
gnome-base/gnome-keyring: add python 3.10

### DIFF
--- a/gnome-base/gnome-keyring/gnome-keyring-40.0-r1.ebuild
+++ b/gnome-base/gnome-keyring/gnome-keyring-40.0-r1.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-PYTHON_COMPAT=( python3_{7..9} )
+PYTHON_COMPAT=( python3_{8..10} )
 
 inherit gnome2 pam python-any-r1 virtualx
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/829424