### PR TITLE
media-libs/lilv: add python 3.10

### DIFF
--- a/media-libs/lilv/lilv-0.24.12.ebuild
+++ b/media-libs/lilv/lilv-0.24.12.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{8,9} )
+PYTHON_COMPAT=( python3_{8..10} )
 PYTHON_REQ_USE='threads(+)'
 
 inherit python-single-r1 waf-utils bash-completion-r1 multilib-build multilib-minimal


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/829439