### PR TITLE
net-im/telepathy-mission-control: add python 3.10

### DIFF
--- a/net-im/telepathy-mission-control/telepathy-mission-control-5.16.6.ebuild
+++ b/net-im/telepathy-mission-control/telepathy-mission-control-5.16.6.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-PYTHON_COMPAT=( python3_{7..9} )
+PYTHON_COMPAT=( python3_{8..10} )
 
 inherit gnome2 python-any-r1
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/829462