### PR TITLE
net-voip/telepathy-gabble: add python 3.10

### DIFF
--- a/net-voip/telepathy-gabble/telepathy-gabble-0.18.4-r4.ebuild
+++ b/net-voip/telepathy-gabble/telepathy-gabble-0.18.4-r4.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 # Python is used during build for some scripted source files generation (and twisted tests)
-PYTHON_COMPAT=( python3_{7..9} )
+PYTHON_COMPAT=( python3_{8..10} )
 
 inherit gnome2 python-any-r1
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/829467