### PR TITLE
sys-cluster/charliecloud: Add argp compat on musl systems.

### DIFF
--- a/sys-cluster/charliecloud/charliecloud-0.24.ebuild
+++ b/sys-cluster/charliecloud/charliecloud-0.24.ebuild
@@ -30,7 +30,9 @@ RESTRICT="test"
 
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 
-RDEPEND="${PYTHON_DEPS}"
+RDEPEND="${PYTHON_DEPS}
+	elibc_musl? ( sys-libs/argp-standalone )
+"
 DEPEND="
 	ch-image? (
 		$(python_gen_cond_dep '
@@ -48,6 +50,7 @@ DEPEND="
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-0.24-dash.patch
+	"${FILESDIR}"/${PN}-0.24-musl-argp.patch
 )
 
 src_prepare() {

--- a/sys-cluster/charliecloud/charliecloud-0.25.ebuild
+++ b/sys-cluster/charliecloud/charliecloud-0.25.ebuild
@@ -30,7 +30,9 @@ RESTRICT="test"
 
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 
-RDEPEND="${PYTHON_DEPS}"
+RDEPEND="${PYTHON_DEPS}
+	elibc_musl? ( sys-libs/argp-standalone )
+"
 DEPEND="
 	ch-image? (
 		$(python_gen_cond_dep '
@@ -45,6 +47,10 @@ DEPEND="
 		')
 		net-misc/rsync
 	)"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-0.24-musl-argp.patch
+)
 
 src_prepare() {
 	default

--- a/sys-cluster/charliecloud/charliecloud-9999.ebuild
+++ b/sys-cluster/charliecloud/charliecloud-9999.ebuild
@@ -30,7 +30,9 @@ RESTRICT="test"
 
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 
-RDEPEND="${PYTHON_DEPS}"
+RDEPEND="${PYTHON_DEPS}
+	elibc_musl? ( sys-libs/argp-standalone )
+"
 DEPEND="
 	ch-image? (
 		$(python_gen_cond_dep '

--- a/sys-cluster/charliecloud/files/charliecloud-0.24-musl-argp.patch
+++ b/sys-cluster/charliecloud/files/charliecloud-0.24-musl-argp.patch
@@ -1,0 +1,43 @@
+From 1832d5ff905b16435efa64e458e2ca2f656f0ab5 Mon Sep 17 00:00:00 2001
+From: Oliver Freyermuth <o.freyermuth@googlemail.com>
+Date: Sun, 19 Dec 2021 16:30:27 +0100
+Subject: [PATCH] configure: Add musl compatibility (external argp).
+
+---
+ configure.ac | 20 ++++++++++++++++++++
+ 1 file changed, 20 insertions(+)
+
+diff --git a/configure.ac b/configure.ac
+index 687d4d4..9f708cf 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -109,6 +109,26 @@ AC_CHECK_LIB([rt], [shm_open], [LIBRT=-lrt], [
+ ])
+ AC_SUBST([LIBRT])
+ 
++# argp_parse, needed externally from libargp / argp_standalone e.g. with musl.
++# First, check if available in used libc out of the box.
++AC_LINK_IFELSE(
++  [AC_LANG_PROGRAM(
++    [#include <argp.h>],
++    [int argc=1; char **argv=NULL; argp_parse(0,argc,argv,0,0,0); return 0;]
++  )],
++  [libc_provides_argp="true"],
++  [libc_provides_argp="false"]
++)
++# If libc doesn't provide argp, test for libargp
++if test "$libc_provides_argp" = "false" ; then
++  AC_MSG_WARN("libc does not provide argp")
++  AC_CHECK_LIB([argp], [argp_parse], [have_largp="true"], [have_largp="false"])
++  if test "$have_largp" = "false"; then
++    AC_MSG_ERROR([*** argp functions not found - install libargp or argp_standalone])
++  else
++    CH_RUN_LIBS="-largp $CH_RUN_LIBS"
++  fi
++fi
+ 
+ ## Options
+ 
+-- 
+2.32.0
+


### PR DESCRIPTION
Patch also submitted to upstream:
https://github.com/hpc/charliecloud/pull/1258

Closes: https://bugs.gentoo.org/829607
Package-Manager: Portage-3.0.28, Repoman-3.0.3
Signed-off-by: Oliver Freyermuth <o.freyermuth@googlemail.com>