### PR TITLE
net-fs/samba: Add AES acceleration is cpu_flags_x86_aes set

### DIFF
--- a/net-fs/samba/samba-4.15.3-r1.ebuild
+++ b/net-fs/samba/samba-4.15.3-r1.ebuild
@@ -22,8 +22,8 @@ S="${WORKDIR}/${MY_P}"
 
 LICENSE="GPL-3"
 SLOT="0"
-IUSE="acl addc ads ceph client cluster cups debug dmapi fam glusterfs
-gpg iprint json ldap pam profiling-data python quota +regedit selinux
+IUSE="acl addc ads ceph client cluster cpu_flags_x86_aes cups debug dmapi fam
+glusterfs gpg iprint json ldap pam profiling-data python quota +regedit selinux
 snapper spotlight syslog system-heimdal +system-mitkrb5 systemd test winbind
 zeroconf"
 
@@ -210,6 +210,7 @@ multilib_src_configure() {
 		--nopyc
 		--nopyo
 		--without-winexe
+		--accel-aes=$(usex cpu_flags_x86_aes intelaesni none)
 		$(multilib_native_use_with acl acl-support)
 		$(multilib_native_usex addc '' '--without-ad-dc')
 		$(multilib_native_use_with ads)


### PR DESCRIPTION
This will enable AES acceleration if the cpu_flags_x86_aes USE flag is
set, otherwise "none" is passed

Signed-off-by: Mike Lothian <mike@fireburn.co.uk>
Bug: https://bugs.gentoo.org/821349