### PR TITLE
net-misc/xmrig: Require newer hwloc

### DIFF
--- a/net-misc/xmrig/xmrig-6.16.0.ebuild
+++ b/net-misc/xmrig/xmrig-6.16.0.ebuild
@@ -22,7 +22,7 @@ IUSE="cpu_flags_x86_sse4_1 donate hwloc opencl +ssl"
 
 DEPEND="
 	dev-libs/libuv:=
-	hwloc? ( sys-apps/hwloc:= )
+	hwloc? ( >=sys-apps/hwloc-2.5.0:= )
 	opencl? ( virtual/opencl )
 	ssl? ( dev-libs/openssl:= )
 "

--- a/net-misc/xmrig/xmrig-6.16.1.ebuild
+++ b/net-misc/xmrig/xmrig-6.16.1.ebuild
@@ -22,7 +22,7 @@ IUSE="cpu_flags_x86_sse4_1 donate hwloc opencl +ssl"
 
 DEPEND="
 	dev-libs/libuv:=
-	hwloc? ( sys-apps/hwloc:= )
+	hwloc? ( >=sys-apps/hwloc-2.5.0:= )
 	opencl? ( virtual/opencl )
 	ssl? ( dev-libs/openssl:= )
 "

--- a/net-misc/xmrig/xmrig-6.16.2.ebuild
+++ b/net-misc/xmrig/xmrig-6.16.2.ebuild
@@ -22,7 +22,7 @@ IUSE="cpu_flags_x86_sse4_1 donate hwloc opencl +ssl"
 
 DEPEND="
 	dev-libs/libuv:=
-	hwloc? ( sys-apps/hwloc:= )
+	hwloc? ( >=sys-apps/hwloc-2.5.0:= )
 	opencl? ( virtual/opencl )
 	ssl? ( dev-libs/openssl:= )
 "

--- a/net-misc/xmrig/xmrig-9999.ebuild
+++ b/net-misc/xmrig/xmrig-9999.ebuild
@@ -22,7 +22,7 @@ IUSE="cpu_flags_x86_sse4_1 donate hwloc opencl +ssl"
 
 DEPEND="
 	dev-libs/libuv:=
-	hwloc? ( sys-apps/hwloc:= )
+	hwloc? ( >=sys-apps/hwloc-2.5.0:= )
 	opencl? ( virtual/opencl )
 	ssl? ( dev-libs/openssl:= )
 "


### PR DESCRIPTION
Since XMRig 6.16.0 with the GhostRider algo enabled, a newer version
of hwloc is required.

Closes: https://bugs.gentoo.org/828093
Signed-off-by: Matthew Smith <matt@offtopica.uk>