### PR TITLE
tree-sitter-grammar.eclass: Fix compatibility with lld

### DIFF
--- a/eclass/tree-sitter-grammar.eclass
+++ b/eclass/tree-sitter-grammar.eclass
@@ -77,7 +77,7 @@ tree-sitter-grammar_src_compile() {
 	${link} ${LDFLAGS} \
 			-shared \
 			*.o \
-			-Wl,-soname ${soname} \
+			-Wl,--soname=${soname} \
 			-o "${WORKDIR}"/${soname} || die
 }
 


### PR DESCRIPTION
-soname <soname> is only accepted by GNU ld, but --soname=<soname> is
accepted by both GNU ld and LLVM lld.

Closes: https://bugs.gentoo.org/828093
Closes: https://bugs.gentoo.org/829668
Closes: https://bugs.gentoo.org/829669
Closes: https://bugs.gentoo.org/829670
Closes: https://bugs.gentoo.org/829671
Closes: https://bugs.gentoo.org/829672
Closes: https://bugs.gentoo.org/829673
Closes: https://bugs.gentoo.org/829674
Closes: https://bugs.gentoo.org/829675
Closes: https://bugs.gentoo.org/829676
Closes: https://bugs.gentoo.org/829677
Signed-off-by: Matthew Smith <matt@offtopica.uk>