### PR TITLE
vdr-plugin-2.eclass: fix content of @SUPPORTED_EAPIS

### DIFF
--- a/eclass/vdr-plugin-2.eclass
+++ b/eclass/vdr-plugin-2.eclass
@@ -9,7 +9,7 @@
 # Joerg Bornkessel <hd_brummy@gentoo.org>
 # Christian Ruppert <idl0r@gentoo.org>
 # (undisclosed contributors)
-# @SUPPORTED_EAPIS: 5 6 7
+# @SUPPORTED_EAPIS: 5 6 7 8
 # @BLURB: common vdr plugin ebuild functions
 # @DESCRIPTION:
 # Eclass for easing maintenance of vdr plugin ebuilds


### PR DESCRIPTION
The eclass variable @SUPPORTED_EAPIS does not contain EAPI 8, while the
eclass itself supports EAPI 8. This leads to wrong warnings by pkgcheck.

Signed-off-by: Martin Dummer <martin.dummer@gmx.net>