### PR TITLE
sci-libs/rocFFT: remove unused cmake variable

### DIFF
--- a/sci-libs/rocFFT/rocFFT-4.3.0-r1.ebuild
+++ b/sci-libs/rocFFT/rocFFT-4.3.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -23,6 +23,7 @@ DEPEND="${RDEPEND}
 BDEPEND="
 	test? ( dev-cpp/gtest dev-libs/boost
 	>=sci-libs/fftw-3
+	>=dev-util/cmake-3.22
 )"
 
 CHECKREQS_DISK_BUILD="7G"
@@ -87,7 +88,6 @@ src_configure() {
 		-DBUILD_CLIENTS_TESTS=$(usex test ON OFF)
 		-DBUILD_CLIENTS_SELFTEST=OFF  # rocFFT-4.3.0 self test fails. See https://github.com/ROCmSoftwarePlatform/rocFFT/issues/324. Enable it for rocFFT-4.4
 		${AMDGPU_TARGETS+-DAMDGPU_TARGETS="${AMDGPU_TARGETS}"}
-		-D__skip_rocmclang="ON" ## fix cmake-3.21 configuration issue caused by officialy support programming language "HIP"
 	)
 
 	cmake_src_configure


### PR DESCRIPTION
__skip_rocmclang is used to avoid configuration error for
cmake-3.21.(1|2), which don't exist among ebuilds anymore, so this flag
is not recognized.

Closes: https://bugs.gentoo.org/829326
Package-Manager: Portage-3.0.22, Repoman-3.0.3
Signed-off-by: Yiyang Wu <xgreenlandforwyy@gmail.com>