### PR TITLE
sci-libs/rocBLAS: various fixes

### DIFF
--- a/sci-libs/rocBLAS/files/rocBLAS-4.3.0-remove-problematic-test-suites.patch
+++ b/sci-libs/rocBLAS/files/rocBLAS-4.3.0-remove-problematic-test-suites.patch
@@ -1,0 +1,22 @@
+Those tests will fail comparing rocblas vs openblas, because the testing program is so strict that it cannot tolerate the numerical differences which is actually OK.
+
+https://github.com/ROCmSoftwarePlatform/rocBLAS/issues/1202
+--- orig/clients/gtest/known_bugs.yaml
++++ rocBLAS-rocm-4.3.0/clients/gtest/known_bugs.yaml
+@@ -7,6 +7,16 @@ Known bugs:
+ - { function: gemm_ex, a_type: i8_r, b_type: i8_r, c_type: i32_r, d_type: i32_r, compute_type: i32_r, flags: 0, known_bug_platforms: "gfx900,gfx906,gfx1010,gfx1011,gfx1012,gfx1030" }
+ - { function: gemm_batched_ex, a_type: i8_r, b_type: i8_r, c_type: i32_r, d_type: i32_r, compute_type: i32_r, flags: 0, known_bug_platforms: "gfx900,gfx906,gfx90a,gfx1010,gfx1011,gfx1012,gfx1030" }
+ - { function: gemm_strided_batched_ex, a_type: i8_r, b_type: i8_r, c_type: i32_r, d_type: i32_r, compute_type: i32_r, flags: 0, known_bug_platforms: "gfx900,gfx906,gfx1010,gfx1011,gfx1012,gfx1030" }
++# gemv openblas reference differences due to summation order dependent roundoff accumulation with large M float complex
++# 8th significant digit difference vs CPU on single precision float math, leads to expected equality test failure
++# code needs to be changed to a tolerance test or reduce M for float complex type if using equality vs. CPU reference
++- { function: gemv, a_type: f32_c, transA: T, M: 131071 }
++- { function: gemv, a_type: f32_c, transA: C, M: 131071 }
++- { function: gemv_batched, a_type: f32_c, transA: T, M: 131071 }
++- { function: gemv_batched, a_type: f32_c, transA: C, M: 131071 }
++- { function: gemv_strided_batched, a_type: f32_c, transA: T, M: 131071 }
++- { function: gemv_strided_batched, a_type: f32_c, transA: C, M: 131071 }
++
+ 
+ #- { function: gemm_ex, a_type: bf16_r, b_type: bf16_r, c_type: bf16_r, d_type: bf16_r, compute_type: f32_r, transA: C, transB: N, M: 512, N: 512, K: 512, lda: 512, ldb: 512, ldc: 512, ldd: 512, alpha: 5.0, alphai: 0.0, beta: 0.0, betai: 0.0, known_bug_platforms: gfx908 }
+ #- { function: gemm_ex, a_type: bf16_r, b_type: bf16_r, c_type: bf16_r, d_type: bf16_r, compute_type: f32_r, transA: C, transB: N, M: 512, N: 512, K: 512, lda: 512, ldb: 512, ldc: 512, ldd: 512, alpha: 0.0, alphai: 0.0, beta: 3.0, betai: 0.0, known_bug_platforms: gfx908 }

--- a/sci-libs/rocBLAS/rocBLAS-4.3.0.ebuild
+++ b/sci-libs/rocBLAS/rocBLAS-4.3.0.ebuild
@@ -98,7 +98,6 @@ src_configure() {
 		-DBUILD_CLIENTS_TESTS=$(usex test ON OFF)
 		-DBUILD_CLIENTS_BENCHMARKS=$(usex benchmark ON OFF)
 		${AMDGPU_TARGETS+-DAMDGPU_TARGETS="${AMDGPU_TARGETS}"}
-		-D__skip_rocmclang="ON" ## fix cmake-3.21 configuration issue caused by officialy support programming language "HIP"
 	)
 
 	CXX="hipcc" cmake_src_configure

--- a/sci-libs/rocBLAS/rocBLAS-4.3.0.ebuild
+++ b/sci-libs/rocBLAS/rocBLAS-4.3.0.ebuild
@@ -46,7 +46,8 @@ S="${WORKDIR}"/${PN}-rocm-${PV}
 
 PATCHES=("${FILESDIR}"/${PN}-4.3.0-fix-glibc-2.32-and-above.patch
 	"${FILESDIR}"/${PN}-4.3.0-change-default-Tensile-library-dir.patch
-	"${FILESDIR}"/${PN}-4.3.0-link-system-blas.patch )
+	"${FILESDIR}"/${PN}-4.3.0-link-system-blas.patch 
+	"${FILESDIR}"/${PN}-4.3.0-remove-problematic-test-suites.patch )
 
 src_prepare() {
 	eapply_user

--- a/sci-libs/rocBLAS/rocBLAS-4.3.0.ebuild
+++ b/sci-libs/rocBLAS/rocBLAS-4.3.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -12,7 +12,7 @@ HOMEPAGE="https://github.com/ROCmSoftwarePlatform/rocBLAS"
 SRC_URI="https://github.com/ROCmSoftwarePlatform/rocBLAS/archive/rocm-${PV}.tar.gz -> rocm-${P}.tar.gz
 	https://github.com/ROCmSoftwarePlatform/Tensile/archive/rocm-${PV}.tar.gz -> rocm-Tensile-${PV}.tar.gz"
 
-LICENSE="MIT"
+LICENSE="BSD"
 KEYWORDS="~amd64"
 IUSE="benchmark test"
 SLOT="0/$(ver_cut 1-2)"
@@ -46,7 +46,7 @@ S="${WORKDIR}"/${PN}-rocm-${PV}
 
 PATCHES=("${FILESDIR}"/${PN}-4.3.0-fix-glibc-2.32-and-above.patch
 	"${FILESDIR}"/${PN}-4.3.0-change-default-Tensile-library-dir.patch
-	"${FILESDIR}"/${PN}-4.3.0-link-system-blas.patch 
+	"${FILESDIR}"/${PN}-4.3.0-link-system-blas.patch
 	"${FILESDIR}"/${PN}-4.3.0-remove-problematic-test-suites.patch )
 
 src_prepare() {

--- a/sci-libs/rocBLAS/rocBLAS-4.3.0.ebuild
+++ b/sci-libs/rocBLAS/rocBLAS-4.3.0.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{6..9} )
 
-inherit cmake prefix python-any-r1
+inherit cmake multiprocessing prefix python-any-r1
 
 DESCRIPTION="AMD's library for BLAS on ROCm."
 HOMEPAGE="https://github.com/ROCmSoftwarePlatform/rocBLAS"
@@ -54,6 +54,7 @@ src_prepare() {
 	pushd "${WORKDIR}"/Tensile-rocm-${PV} || die
 	eapply "${FILESDIR}/Tensile-${PV}-hsaco-compile-specified-arch.patch" # backported from upstream, should remove after 4.3.0
 	eapply "${FILESDIR}/Tensile-4.3.0-output-commands.patch"
+	sed -e "/Number of parallel jobs to launch/s:default=-1:default=$(makeopts_jobs):" -i Tensile/TensileCreateLibrary.py || die
 	popd || die
 
 	# Fit for Gentoo FHS rule


### PR DESCRIPTION
This PR contains three commits:

let TensileCreateLibrary respects MAKEOPTS
Closes: https://bugs.gentoo.org/822828

common fix for unuesd cmake variable:
Bugs: https://bugs.gentoo.org/829326

fix test failures:
Closes: https://github.com/ROCmSoftwarePlatform/rocBLAS/issues/1202