### PR TITLE
dev-util/rt-tests: Avoid CC in install

### DIFF
--- a/dev-util/rt-tests/files/rt-tests-2.2-avoid_cc_in_install.patch
+++ b/dev-util/rt-tests/files/rt-tests-2.2-avoid_cc_in_install.patch
@@ -1,0 +1,25 @@
+diff --git a/Makefile b/Makefile
+index 569adc1..508d7a7 100644
+--- a/Makefile
++++ b/Makefile
+@@ -38,15 +38,12 @@ else
+ 	CFLAGS	+= -O0 -g
+ endif
+
+-# We make some gueses on how to compile rt-tests based on the machine type
+-# and the ostype. These can often be overridden.
+-dumpmachine := $(shell $(CC) -dumpmachine)
+-
++# We make some guesses on how to compile rt-tests based on the machine type
++# and the ostype.
+ # The ostype is typically something like linux or android
+-ostype := $(lastword $(subst -, ,$(dumpmachine)))
+-
+-machinetype := $(shell echo $(dumpmachine)| \
+-    sed -e 's/-.*//' -e 's/i.86/i386/' -e 's/mips.*/mips/' -e 's/ppc.*/powerpc/')
++ostype := $(shell uname -o | sed -nr 's/(.*)\/.*/\1/p')
++machinetype := $(shell uname -m | \
++    sed -e 's/i.86/i386/' -e 's/mips.*/mips/' -e 's/ppc.*/powerpc/')
+
+ # The default is to assume you have libnuma installed, which is fine to do
+ # even on non-numa machines. If you don't want to install the numa libs, for

--- a/dev-util/rt-tests/rt-tests-2.2.ebuild
+++ b/dev-util/rt-tests/rt-tests-2.2.ebuild
@@ -22,6 +22,10 @@ DEPEND="${PYTHON_DEPS}
 	sys-process/numactl"
 RDEPEND="${DEPEND}"
 
+PATCHES=(
+	"${FILESDIR}/${P}-avoid_cc_in_install.patch"
+)
+
 src_prepare() {
 	default
 	use elibc_musl && eapply "${FILESDIR}/${P}-musl.patch"


### PR DESCRIPTION
The ostype and machinetype are currently retrieved by `$(CC)
-dumpmachine`. The $(CC) dependency can be avoided by using `uname`.