### PR TITLE
vdr-plugin-2.eclass: fix variable VDRPLUGIN

### DIFF
--- a/eclass/vdr-plugin-2.eclass
+++ b/eclass/vdr-plugin-2.eclass
@@ -15,7 +15,6 @@
 # Eclass for easing maintenance of vdr plugin ebuilds
 
 # @ECLASS-VARIABLE: VDRPLUGIN
-# @INTERNAL
 # @DESCRIPTION:
 # The name of the vdr plugin, plain name without "vdr-" or "plugin" prefix or suffix.
 # This variable is derived from ${PN}


### PR DESCRIPTION
Variable VDRPLUGIN: remove declaration @INTERNAL as it is used in many
packages. This fixes errors thrown by pkgcheck.

Signed-off-by: Martin Dummer <martin.dummer@gmx.net>