### PR TITLE
vdr-plugin-2.eclass: fix variable VDRPLUGIN

### DIFF
--- a/eclass/vdr-plugin-2.eclass
+++ b/eclass/vdr-plugin-2.eclass
@@ -15,10 +15,10 @@
 # Eclass for easing maintenance of vdr plugin ebuilds
 
 # @ECLASS-VARIABLE: VDRPLUGIN
-# @INTERNAL
+# @OUTPUT_VARIABLE
 # @DESCRIPTION:
 # The name of the vdr plugin, plain name without "vdr-" or "plugin" prefix or suffix.
-# This variable is derived from ${PN}
+# This variable is derived from ${PN} and is read-only for the ebuild.
 
 # @ECLASS-VARIABLE: VDR_CONFD_FILE
 # @DEFAULT_UNSET


### PR DESCRIPTION
Variable VDRPLUGIN: remove declaration @INTERNAL, instead declare as
@OUTPUT_VARIABLE as it is used in many packages
This fixes errors thrown by pkgcheck

Signed-off-by: Martin Dummer <martin.dummer@gmx.net>