### PR TITLE
dev-lang/mujs: cleaned up src_install

### DIFF
--- a/dev-lang/mujs/mujs-1.2.0.ebuild
+++ b/dev-lang/mujs/mujs-1.2.0.ebuild
@@ -55,14 +55,7 @@ src_install() {
 		prefix=/usr \
 		install-shared
 
-	# TODO: Tidy up this logic, improve readability
-	if [[ ${CHOST} == *-darwin* ]] ; then
-		mv -v "${ED}"/usr/$(get_libdir)/lib${PN}.so "${ED}"/usr/$(get_libdir)/lib${PN}.${PV}.dylib || die
-		dosym lib${PN}.${PV}.dylib /usr/$(get_libdir)/lib${PN}.dylib
-		dosym lib${PN}.${PV}.dylib /usr/$(get_libdir)/lib${PN}.${PV:0:1}.dylib
-	else
-		mv -v "${ED}"/usr/$(get_libdir)/lib${PN}.so{,.${PV}} || die
-		dosym lib${PN}.so.${PV} /usr/$(get_libdir)/lib${PN}.so
-		dosym lib${PN}.so.${PV} /usr/$(get_libdir)/lib${PN}.so.${PV:0:1}
-	fi
+	mv -v "${ED}"/usr/$(get_libdir)/lib${PN}$(get_libname) "${ED}"/usr/$(get_libdir)/lib${PN}$(get_libname ${PV}) || die "Failed adding version suffix to mujs shared library"
+	dosym lib${PN}$(get_libname ${PV}) /usr/$(get_libdir)/lib${PN}$(get_libname)
+	dosym lib${PN}$(get_libname ${PV}) /usr/$(get_libdir)/lib${PN}$(get_libname ${PV:0:1})
 }


### PR DESCRIPTION
The section in src_install which handled renaming and symlinking the
mujs shared library is now shorter and easier to read.
I used a function from multilib.eclass as pointed out in https://github.com/gentoo/gentoo/pull/23350.