### PR TITLE
dev-util/rt-tests: Specify C compiler in install

### DIFF
--- a/dev-util/rt-tests/rt-tests-2.2.ebuild
+++ b/dev-util/rt-tests/rt-tests-2.2.ebuild
@@ -32,7 +32,7 @@ src_compile() {
 }
 
 src_install() {
-	emake prefix=/usr DESTDIR="${ED}" install
+	emake CC="$(tc-getCC)" prefix=/usr DESTDIR="${ED}" install
 	python_fix_shebang "${ED}"
 	python_optimize
 }


### PR DESCRIPTION
The ostype and machinetype are retrieved by `$(CC) -dumpmachine`. We
need to specify it also in the `src_install`.

Signed-off-by: Eddy Hsu <c.c.hsu01@gmail.com>