### PR TITLE
net-fs/autofs: rebase musl patches, fix musl build for 5.1.8

### DIFF
--- a/net-fs/autofs/autofs-5.1.8-r1.ebuild
+++ b/net-fs/autofs/autofs-5.1.8-r1.ebuild
@@ -40,10 +40,13 @@ BDEPEND="
 "
 
 PATCHES=(
-	"${FILESDIR}/${PN}-5.1.7-glibc.patch"
-	"${FILESDIR}/${PN}-5.1.6-musl.patch"
-	"${FILESDIR}/${PN}-5.1.6-pid.patch"
-	"${FILESDIR}/${PN}-5.1.6-pid.patch"
+	"${FILESDIR}"/0001-autofs-5.1.8-fix-missing-include-in-hash.h.patch
+	"${FILESDIR}"/0002-autofs-5.1.8-fix-bashism-in-configure.patch
+	"${FILESDIR}"/0003-autofs-5.1.8-define-fallback-dummy-NSS-config-path.patch
+	"${FILESDIR}"/0004-autofs-5.1.8-avoid-internal-stat.h-definitions.patch
+	"${FILESDIR}"/0005-autofs-5.1.8-add-missing-include-to-hash.h-for-_WORD.patch
+	"${FILESDIR}"/0006-autofs-5.1.8-add-missing-include-to-log.h-for-pid_t.patch
+	"${FILESDIR}"/0007-autofs-5.1.8-define-_SWORD_TYPE-for-musl.patch
 	"${FILESDIR}/${P}-dmalloc.patch"
 	"${FILESDIR}/${P}-nfsv4-mount.patch"
 )

--- a/net-fs/autofs/files/0001-autofs-5.1.8-fix-missing-include-in-hash.h.patch
+++ b/net-fs/autofs/files/0001-autofs-5.1.8-fix-missing-include-in-hash.h.patch
@@ -1,0 +1,48 @@
+From 7473e0680f4907fc4c2cf8918a1fbbbc51c4605e Mon Sep 17 00:00:00 2001
+From: Sam James <sam@gentoo.org>
+Date: Thu, 23 Dec 2021 03:26:14 +0000
+Subject: [PATCH 1/7] autofs-5.1.8 - fix missing include in hash.h
+
+Fixes a build failure with the musl libc:
+```
+../include/hash.h:74:8: error: unknown type name '__always_inline'
+   74 | static __always_inline uint32_t hash_64(uint64_t val, unsigned int bits)
+      |        ^~~~~~~~~~~~~~~
+```
+
+We need to include stddef.h from linux-headers to ensure _always_inline
+is always defined.
+
+Bug: https://bugs.gentoo.org/828918
+Signed-off-by: Sam James <sam@gentoo.org>
+---
+ CHANGELOG      | 3 +++
+ include/hash.h | 1 +
+ 2 files changed, 4 insertions(+)
+
+diff --git a/CHANGELOG b/CHANGELOG
+index 3be6119..e4e3362 100644
+--- a/CHANGELOG
++++ b/CHANGELOG
+@@ -1,3 +1,6 @@
++
++- musl: fix missing include in hash.h
++
+ 19/10/2021 autofs-5.1.8
+ - add xdr_exports().
+ - remove mount.x and rpcgen dependencies.
+diff --git a/include/hash.h b/include/hash.h
+index 2447f29..010acd7 100644
+--- a/include/hash.h
++++ b/include/hash.h
+@@ -3,6 +3,7 @@
+ /* Fast hashing routine for ints,  longs and pointers.
+    (C) 2002 Nadia Yvette Chambers, IBM */
+ 
++#include <linux/stddef.h>
+ #include <sys/types.h>
+ #include <stdint.h>
+ 
+-- 
+2.34.1
+

--- a/net-fs/autofs/files/0002-autofs-5.1.8-fix-bashism-in-configure.patch
+++ b/net-fs/autofs/files/0002-autofs-5.1.8-fix-bashism-in-configure.patch
@@ -1,0 +1,61 @@
+From f504bb78f5825291a2f30fbde717bf0ac1ddefe6 Mon Sep 17 00:00:00 2001
+From: Sam James <sam@gentoo.org>
+Date: Thu, 23 Dec 2021 03:28:31 +0000
+Subject: [PATCH 2/7] autofs-5.1.8 - fix bashism in configure
+
+configure scripts need to work with a POSIX-compliant shell,
+so let's not use a bashism here.
+
+```
+checking for res_query in -lresolv... yes
+checking for libhesiod... no
+./configure: 4880: test: 0: unexpected operator
+checking how to run the C preprocessor... gcc -E
+```
+
+Signed-off-by: Sam James <sam@gentoo.org>
+---
+ CHANGELOG    | 1 +
+ configure.in | 6 +++---
+ 2 files changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/CHANGELOG b/CHANGELOG
+index e4e3362..93d8c83 100644
+--- a/CHANGELOG
++++ b/CHANGELOG
+@@ -1,4 +1,5 @@
+ 
++- fix bashism in configure
+ - musl: fix missing include in hash.h
+ 
+ 19/10/2021 autofs-5.1.8
+diff --git a/configure.in b/configure.in
+index 750ffb4..723bb30 100644
+--- a/configure.in
++++ b/configure.in
+@@ -262,7 +262,7 @@ if test -z "$HAVE_HESIOD" -o "$HAVE_HESIOD" != "0"
+ then
+ 	HAVE_HESIOD=0
+ 	AF_CHECK_LIBHESIOD()
+-	if test "$HAVE_HESIOD" == "1"; then
++	if test "$HAVE_HESIOD" = "1"; then
+ 		AC_DEFINE(WITH_HESIOD,1,
+ 			[Define if using Hesiod as a source of automount maps])
+ 	fi
+@@ -337,11 +337,11 @@ AC_ARG_WITH(sasl,
+ 		SASL_FLAGS="-I${withval}/include"
+ 	fi
+ )
+-if test -z "$HAVE_SASL" -o "$HAVE_SASL" != "0" -a "$HAVE_LIBXML" == "1"
++if test -z "$HAVE_SASL" -o "$HAVE_SASL" != "0" -a "$HAVE_LIBXML" = "1"
+ then
+ 	HAVE_SASL=0
+ 	AC_CHECK_LIB(sasl2, sasl_client_start, HAVE_SASL=1 LIBSASL="$LIBSASL -lsasl2", , -lsasl2 $LIBS)
+-	if test "$HAVE_SASL" == "1"; then
++	if test "$HAVE_SASL" = "1"; then
+ 		AC_DEFINE(WITH_SASL,1,
+ 			[Define if using SASL authentication with the LDAP module])
+ 	fi
+-- 
+2.34.1
+

--- a/net-fs/autofs/files/0003-autofs-5.1.8-define-fallback-dummy-NSS-config-path.patch
+++ b/net-fs/autofs/files/0003-autofs-5.1.8-define-fallback-dummy-NSS-config-path.patch
@@ -1,0 +1,51 @@
+From f95ec13a2c4db124005d20e6b9d8e370d8a9c395 Mon Sep 17 00:00:00 2001
+From: Sam James <sam@gentoo.org>
+Date: Thu, 23 Dec 2021 03:32:26 +0000
+Subject: [PATCH 3/7] autofs-5.1.8 - define fallback dummy NSS config path
+
+On musl, _PATH_NSSWITCH_CONF won't be defined (it doesn't support NSS),
+so let's give it a dummy path when it's not defined by glibc.
+
+Fixes build failures like:
+```
+../include/nsswitch.h:27:23: error: '_PATH_NSSWITCH_CONF' undeclared (first use in this function)
+   27 | #define NSSWITCH_FILE _PATH_NSSWITCH_CONF
+      |                       ^~~~~~~~~~~~~~~~~~~
+```
+
+Signed-off-by: Sam James <sam@gentoo.org>
+---
+ CHANGELOG          | 1 +
+ include/nsswitch.h | 4 ++++
+ 2 files changed, 5 insertions(+)
+
+diff --git a/CHANGELOG b/CHANGELOG
+index 93d8c83..0eabf30 100644
+--- a/CHANGELOG
++++ b/CHANGELOG
+@@ -1,6 +1,7 @@
+ 
+ - fix bashism in configure
+ - musl: fix missing include in hash.h
++- musl: define fallback dummy NSS config path
+ 
+ 19/10/2021 autofs-5.1.8
+ - add xdr_exports().
+diff --git a/include/nsswitch.h b/include/nsswitch.h
+index d3e4027..8376113 100644
+--- a/include/nsswitch.h
++++ b/include/nsswitch.h
+@@ -24,6 +24,10 @@
+ #include <netdb.h>
+ #include "list.h"
+ 
++#ifndef _PATH_NSSWITCH_CONF
++#define _PATH_NSSWITCH_CONF "/dev/null"
++#endif
++
+ #define NSSWITCH_FILE _PATH_NSSWITCH_CONF
+ 
+ enum nsswitch_status {
+-- 
+2.34.1
+

--- a/net-fs/autofs/files/0004-autofs-5.1.8-avoid-internal-stat.h-definitions.patch
+++ b/net-fs/autofs/files/0004-autofs-5.1.8-avoid-internal-stat.h-definitions.patch
@@ -1,0 +1,80 @@
+From f45af12edfefe522b115bc42888407d7baafd24d Mon Sep 17 00:00:00 2001
+From: Sam James <sam@gentoo.org>
+Date: Thu, 23 Dec 2021 03:35:24 +0000
+Subject: [PATCH 4/7] autofs-5.1.8 - avoid internal stat.h definitions
+
+Signed-off-by: Sam James <sam@gentoo.org>
+---
+ CHANGELOG              | 1 +
+ daemon/lookup.c        | 6 +++---
+ modules/lookup_multi.c | 4 ++--
+ 3 files changed, 6 insertions(+), 5 deletions(-)
+
+diff --git a/CHANGELOG b/CHANGELOG
+index 0eabf30..3b11b79 100644
+--- a/CHANGELOG
++++ b/CHANGELOG
+@@ -2,6 +2,7 @@
+ - fix bashism in configure
+ - musl: fix missing include in hash.h
+ - musl: define fallback dummy NSS config path
++- musl: avoid internal stat.h definitions
+ 
+ 19/10/2021 autofs-5.1.8
+ - add xdr_exports().
+diff --git a/daemon/lookup.c b/daemon/lookup.c
+index 0b281f8..4a286d6 100644
+--- a/daemon/lookup.c
++++ b/daemon/lookup.c
+@@ -397,7 +397,7 @@ static int read_file_source_instance(struct autofs_point *ap, struct map_source
+ 		return NSS_STATUS_NOTFOUND;
+ 	}
+ 
+-	if (st.st_mode & __S_IEXEC)
++	if (st.st_mode & S_IEXEC)
+ 		type = src_prog;
+ 	else
+ 		type = src_file;
+@@ -930,7 +930,7 @@ static int lookup_name_file_source_instance(struct autofs_point *ap, struct map_
+ 		return NSS_STATUS_NOTFOUND;
+ 	}
+ 
+-	if (st.st_mode & __S_IEXEC)
++	if (st.st_mode & S_IEXEC)
+ 		type = src_prog;
+ 	else
+ 		type = src_file;
+@@ -1077,7 +1077,7 @@ static struct map_source *lookup_get_map_source(struct master_mapent *entry)
+ 	if (!S_ISREG(st.st_mode))
+ 		return NULL;
+ 
+-	if (st.st_mode & __S_IEXEC)
++	if (st.st_mode & S_IEXEC)
+ 		type = "program";
+ 	else
+ 		type = "file";
+diff --git a/modules/lookup_multi.c b/modules/lookup_multi.c
+index fadd2ea..cf109de 100644
+--- a/modules/lookup_multi.c
++++ b/modules/lookup_multi.c
+@@ -247,7 +247,7 @@ static struct lookup_mod *nss_open_lookup(const char *format, int argc, const ch
+ 				continue;
+ 			}
+ 
+-			if (st.st_mode & __S_IEXEC)
++			if (st.st_mode & S_IEXEC)
+ 				type = src_prog;
+ 			else
+ 				type = src_file;
+@@ -452,7 +452,7 @@ int lookup_reinit(const char *my_mapfmt,
+ 					continue;
+ 				}
+ 
+-				if (st.st_mode & __S_IEXEC)
++				if (st.st_mode & S_IEXEC)
+ 					type = src_prog;
+ 				else
+ 					type = src_file;
+-- 
+2.34.1
+

--- a/net-fs/autofs/files/0005-autofs-5.1.8-add-missing-include-to-hash.h-for-_WORD.patch
+++ b/net-fs/autofs/files/0005-autofs-5.1.8-add-missing-include-to-hash.h-for-_WORD.patch
@@ -1,0 +1,50 @@
+From 42aced26b633904cdb71c8feca4d48bfc0d57652 Mon Sep 17 00:00:00 2001
+From: Sam James <sam@gentoo.org>
+Date: Thu, 23 Dec 2021 03:39:39 +0000
+Subject: [PATCH 5/7] autofs-5.1.8 - add missing include to hash.h for
+ _WORDSIZE
+
+Fixes build failure on musl like:
+```
+../include/hash.h:22:2: error: #error Wordsize not 32 or 64
+   22 | #error Wordsize not 32 or 64
+      |  ^~~~~
+```
+
+Signed-off-by: Sam James <sam@gentoo.org>
+---
+ CHANGELOG      | 1 +
+ include/hash.h | 5 +++++
+ 2 files changed, 6 insertions(+)
+
+diff --git a/CHANGELOG b/CHANGELOG
+index 3b11b79..edf2d30 100644
+--- a/CHANGELOG
++++ b/CHANGELOG
+@@ -3,6 +3,7 @@
+ - musl: fix missing include in hash.h
+ - musl: define fallback dummy NSS config path
+ - musl: avoid internal stat.h definitions
++- musl: add missing include to hash.h for _WORDSIZE
+ 
+ 19/10/2021 autofs-5.1.8
+ - add xdr_exports().
+diff --git a/include/hash.h b/include/hash.h
+index 010acd7..0f1d7b5 100644
+--- a/include/hash.h
++++ b/include/hash.h
+@@ -3,6 +3,11 @@
+ /* Fast hashing routine for ints,  longs and pointers.
+    (C) 2002 Nadia Yvette Chambers, IBM */
+ 
++#ifdef __GLIBC__
++#include <bits/wordsize.h>
++#else
++#include <bits/reg.h>
++#endif
+ #include <linux/stddef.h>
+ #include <sys/types.h>
+ #include <stdint.h>
+-- 
+2.34.1
+

--- a/net-fs/autofs/files/0006-autofs-5.1.8-add-missing-include-to-log.h-for-pid_t.patch
+++ b/net-fs/autofs/files/0006-autofs-5.1.8-add-missing-include-to-log.h-for-pid_t.patch
@@ -1,0 +1,50 @@
+From 7bc1c15035df2ff3ffe4fb407c4ff942345acf8b Mon Sep 17 00:00:00 2001
+From: Sam James <sam@gentoo.org>
+Date: Thu, 23 Dec 2021 03:42:17 +0000
+Subject: [PATCH 6/7] autofs-5.1.8 - add missing include to log.h for pid_t
+
+Fixes build failures on musl like:
+```
+../include/log.h:49:8: error: unknown type name 'pid_t'
+   49 | extern pid_t log_pidinfo(struct autofs_point *ap, pid_t pid, char *label);
+      |        ^~~~~
+../include/log.h:49:51: error: unknown type name 'pid_t'; did you mean 'gid_t'?
+   49 | extern pid_t log_pidinfo(struct autofs_point *ap, pid_t pid, char *label);
+      |                                                   ^~~~~
+      |                                                   gid_t
+```
+
+Signed-off-by: Sam James <sam@gentoo.org>
+---
+ CHANGELOG     | 1 +
+ include/log.h | 2 ++
+ 2 files changed, 3 insertions(+)
+
+diff --git a/CHANGELOG b/CHANGELOG
+index edf2d30..56b9cd9 100644
+--- a/CHANGELOG
++++ b/CHANGELOG
+@@ -4,6 +4,7 @@
+ - musl: define fallback dummy NSS config path
+ - musl: avoid internal stat.h definitions
+ - musl: add missing include to hash.h for _WORDSIZE
++- musl: add missing include to log.h for pid_t
+ 
+ 19/10/2021 autofs-5.1.8
+ - add xdr_exports().
+diff --git a/include/log.h b/include/log.h
+index 69eed96..a7b09f9 100644
+--- a/include/log.h
++++ b/include/log.h
+@@ -17,6 +17,8 @@
+ #ifndef LOG_H
+ #define LOG_H
+ 
++#include <unistd.h>
++
+ /* Define logging functions */
+ 
+ #define LOGOPT_NONE	0x0000
+-- 
+2.34.1
+

--- a/net-fs/autofs/files/0007-autofs-5.1.8-define-_SWORD_TYPE-for-musl.patch
+++ b/net-fs/autofs/files/0007-autofs-5.1.8-define-_SWORD_TYPE-for-musl.patch
@@ -1,0 +1,46 @@
+From 8799654fa398bdcb4d51a15a679929c39fbbf3dd Mon Sep 17 00:00:00 2001
+From: Sam James <sam@gentoo.org>
+Date: Thu, 23 Dec 2021 03:44:40 +0000
+Subject: [PATCH 7/7] autofs-5.1.8 - define _SWORD_TYPE for musl
+
+Copy the definition from glibc. Fixes build failures like:
+```
+automount.c:280:35: error: '__SWORD_TYPE' undeclared (first use in this function)
+  280 |                 if (fs.f_type != (__SWORD_TYPE) AUTOFS_SUPER_MAGIC) {
+      |                                   ^~~~~~~~~~~~
+automount.c:280:35: note: each undeclared identifier is reported only once for each function it appears in
+automount.c:280:48: error: expected ')' before numeric constant
+  280 |                 if (fs.f_type != (__SWORD_TYPE) AUTOFS_SUPER_MAGIC) {
+      |                    ~                           ^
+      |                                                )
+```
+
+Signed-off-by: Sam James <sam@gentoo.org>
+---
+ daemon/automount.c | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/daemon/automount.c b/daemon/automount.c
+index cc28689..5dffce0 100644
+--- a/daemon/automount.c
++++ b/daemon/automount.c
+@@ -48,6 +48,16 @@
+ #endif
+ #endif
+ 
++#ifndef __SWORD_TYPE
++#if __WORDSIZE == 32
++# define __SWORD_TYPE	int
++#elif __WORDSIZE == 64
++# define __SWORD_TYPE	long int
++#else
++#error
++#endif
++#endif
++
+ const char *program;		/* Initialized with argv[0] */
+ const char *version = VERSION_STRING;	/* Program version */
+ const char *libdir = AUTOFS_LIB_DIR;	/* Location of library modules */
+-- 
+2.34.1
+


### PR DESCRIPTION
These patches are also ready to be upstreamed once runtime tested.

Closes: https://bugs.gentoo.org/828918
Signed-off-by: Sam James <sam@gentoo.org>