### PR TITLE
media-gfx/curaengine: fix find command usage in compile phase

### DIFF
--- a/media-gfx/curaengine/curaengine-4.9.1.ebuild
+++ b/media-gfx/curaengine/curaengine-4.9.1.ebuild
@@ -79,7 +79,7 @@ src_compile() {
 	if use doc; then
 		doxygen || die "generating docs failed"
 		mv docs/html . || die
-		find html -type f \(-name '*.md5' -o -name '*.map'\) -delete || die
+		find html -type f '(' -name '*.md5' -o -name '*.map' ')' -delete || die
 		HTML_DOCS=( html/. )
 	fi
 }


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/820701
Package-Manager: Portage-3.0.28, Repoman-3.0.3
Signed-off-by: Dennis Eisele mail@dennis-eisele.de