### PR TITLE
dev-python/berkeleydb: add ~ia64

### DIFF
--- a/dev-python/berkeleydb/berkeleydb-18.1.4.ebuild
+++ b/dev-python/berkeleydb/berkeleydb-18.1.4.ebuild
@@ -17,7 +17,7 @@ SRC_URI="https://dev.gentoo.org/~arthurzam/distfiles/dev-python/${PN}/${P}.tar.x
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="amd64 arm arm64 ~hppa ppc ppc64 ~riscv sparc x86"
+KEYWORDS="amd64 arm arm64 ~hppa ~ia64 ppc ppc64 ~riscv sparc x86"
 
 RDEPEND="
 	|| (


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/829925

Needed for PR https://github.com/gentoo/gentoo/pull/23494