### PR TITLE
dev-ruby/rdoc: remove the hprefixify command on shebangs.

### DIFF
--- a/dev-ruby/rdoc/rdoc-6.3.2.ebuild
+++ b/dev-ruby/rdoc/rdoc-6.3.2.ebuild
@@ -13,7 +13,7 @@ RUBY_FAKEGEM_BINDIR="exe"
 
 RUBY_FAKEGEM_GEMSPEC="rdoc.gemspec"
 
-inherit prefix ruby-fakegem
+inherit ruby-fakegem
 
 DESCRIPTION="An extended version of the RDoc library from Ruby 1.8"
 HOMEPAGE="https://github.com/ruby/rdoc/"
@@ -82,7 +82,6 @@ all_ruby_install() {
 				ruby_fakegem_binwrapper $bin /usr/bin/${bin}${version}
 				sed -i -e "1s/env ruby/ruby${version}/" \
 					"${ED}/usr/bin/${bin}${version}" || die
-				use prefix && hprefixify "${ED}/usr/bin/${bin}${version}"
 			fi
 		done
 	done

--- a/dev-ruby/rdoc/rdoc-6.3.3-r1.ebuild
+++ b/dev-ruby/rdoc/rdoc-6.3.3-r1.ebuild
@@ -13,7 +13,7 @@ RUBY_FAKEGEM_BINDIR="exe"
 
 RUBY_FAKEGEM_GEMSPEC="rdoc.gemspec"
 
-inherit prefix ruby-fakegem
+inherit ruby-fakegem
 
 DESCRIPTION="An extended version of the RDoc library from Ruby 1.8"
 HOMEPAGE="https://github.com/ruby/rdoc/"
@@ -82,7 +82,6 @@ all_ruby_install() {
 				ruby_fakegem_binwrapper $bin /usr/bin/${bin}${version}
 				sed -i -e "1s/env ruby/ruby${version}/" \
 					"${ED}/usr/bin/${bin}${version}" || die
-				use prefix && hprefixify "${ED}/usr/bin/${bin}${version}"
 			fi
 		done
 	done

--- a/dev-ruby/rdoc/rdoc-6.3.3.ebuild
+++ b/dev-ruby/rdoc/rdoc-6.3.3.ebuild
@@ -13,7 +13,7 @@ RUBY_FAKEGEM_BINDIR="exe"
 
 RUBY_FAKEGEM_GEMSPEC="rdoc.gemspec"
 
-inherit prefix ruby-fakegem
+inherit ruby-fakegem
 
 DESCRIPTION="An extended version of the RDoc library from Ruby 1.8"
 HOMEPAGE="https://github.com/ruby/rdoc/"
@@ -82,7 +82,6 @@ all_ruby_install() {
 				ruby_fakegem_binwrapper $bin /usr/bin/${bin}${version}
 				sed -i -e "1s/env ruby/ruby${version}/" \
 					"${ED}/usr/bin/${bin}${version}" || die
-				use prefix && hprefixify "${ED}/usr/bin/${bin}${version}"
 			fi
 		done
 	done

--- a/eclass/ruby-fakegem.eclass
+++ b/eclass/ruby-fakegem.eclass
@@ -382,7 +382,7 @@ ruby_fakegem_binwrapper() {
 				# if another implementation already arrived, then make
 				# it generic and break out of the loop. This ensures
 				# that we do at most two iterations.
-				rubycmd="/usr/bin/env ruby"
+				rubycmd="${EPREFIX}/usr/bin/env ruby"
 				break
 			fi
 		done


### PR DESCRIPTION
If two ruby targets are specified, the scripts get `/usr/bin/env ruby`
shebangs.  "env ruby" is then replaced in the ebuilds to be
"ruby${ver}" (ruby27 or ruby30).  They needs to be prefixified.

Contrastingly, when there is one ruby target, the shebang is the
correct EPREFIX/usr/bin/ruby${ver}.  No prefixify should be applied.

To unify the two cases, the shebangs for the two-ruby-target case are
changed to be `EPREFIX/usr/bin/env ruby`.

Reference: https://github.com/gentoo/gentoo/pull/21046
Package-Manager: Portage-3.0.28, Repoman-3.0.3
Signed-off-by: Benda Xu <heroxbd@gentoo.org>