### PR TITLE
app-crypt/mit-krb5: add python 3.10

### DIFF
--- a/app-crypt/mit-krb5/mit-krb5-1.19.2.ebuild
+++ b/app-crypt/mit-krb5/mit-krb5-1.19.2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{7,8,9} )
+PYTHON_COMPAT=( python3_{8..10} )
 inherit autotools flag-o-matic multilib-minimal python-any-r1 systemd toolchain-funcs
 
 MY_P="${P/mit-}"


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/830005