### PR TITLE
app-text/gnome-doc-utils: add python 3.10

### DIFF
--- a/app-text/gnome-doc-utils/gnome-doc-utils-0.20.10-r2.ebuild
+++ b/app-text/gnome-doc-utils/gnome-doc-utils-0.20.10-r2.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-PYTHON_COMPAT=( python3_{7..9} )
+PYTHON_COMPAT=( python3_{8..10} )
 
 inherit gnome2 multibuild python-r1
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/830034