### PR TITLE
net-proxy/squid: use system libltdl (avoid maintainer mode automake)

### DIFF
--- a/net-proxy/squid/files/squid-4.17-use-system-libltdl.patch
+++ b/net-proxy/squid/files/squid-4.17-use-system-libltdl.patch
@@ -1,0 +1,16 @@
+https://bugs.gentoo.org/830099
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -6,11 +6,8 @@
+ ##
+ 
+ AUTOMAKE_OPTIONS = dist-bzip2 1.5 foreign
+-DIST_SUBDIRS	= compat lib libltdl scripts icons errors contrib doc src test-suite tools
++DIST_SUBDIRS	= compat lib scripts icons errors contrib doc src test-suite tools
+ SUBDIRS		= compat lib
+-if ENABLE_LOADABLE_MODULES
+-SUBDIRS += libltdl
+-endif
+ SUBDIRS += scripts icons errors doc src tools test-suite
+ 
+ DISTCLEANFILES = include/stamp-h include/stamp-h[0-9]*

--- a/net-proxy/squid/squid-4.17.ebuild
+++ b/net-proxy/squid/squid-4.17.ebuild
@@ -81,6 +81,7 @@ pkg_pretend() {
 
 src_prepare() {
 	eapply "${FILESDIR}/${PN}-4.3-gentoo.patch"
+	eapply "${FILESDIR}/${PN}-4.17-use-system-libltdl.patch"
 
 	sed -i -e 's:/usr/local/squid/etc:/etc/squid:' \
 		INSTALL QUICKSTART \
@@ -208,8 +209,9 @@ src_configure() {
 		--with-build-environment=default \
 		--disable-strict-error-checking \
 		--disable-arch-native \
-		--with-included-ltdl=/usr/include \
-		--with-ltdl-libdir=/usr/$(get_libdir) \
+		--without-included-ltdl \
+		--with-ltdl-include="${ESYSROOT}"/usr/include \
+		--with-ltdl-lib="${ESYSROOT}"/usr/$(get_libdir) \
 		$(use_with caps libcap) \
 		$(use_enable ipv6) \
 		$(use_enable snmp) \


### PR DESCRIPTION
This bug has quite a long story, apparently, but it seems to be
enough here to just drop the subdir & force usage of the system version
with configure arguments (previous arguments weren't quite right).

Closes: https://bugs.gentoo.org/830099
Signed-off-by: Sam James <sam@gentoo.org>