### PR TITLE
media-sound/spotify: expand systray support

### DIFF
--- a/media-sound/spotify-tray/spotify-tray-1.3.2-r1.ebuild
+++ b/media-sound/spotify-tray/spotify-tray-1.3.2-r1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 2019-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 inherit autotools xdg
 
@@ -28,4 +28,10 @@ src_prepare() {
 	# Fix the name of the icon
 	sed -i -e 's/Icon=spotify/Icon=spotify-client/g' spotify-tray.desktop.in || die
 	eautoreconf
+}
+
+src_install() {
+	default
+	# remove desktop file, launching is handled in spotify ebuild
+	rm "${ED}/usr/share/applications/spotify-tray.desktop" || die
 }

--- a/media-sound/spotify/spotify-1.1.72-r1.ebuild
+++ b/media-sound/spotify/spotify-1.1.72-r1.ebuild
@@ -1,0 +1,133 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit desktop optfeature pax-utils unpacker xdg
+
+DESCRIPTION="Spotify is a social music platform"
+HOMEPAGE="https://www.spotify.com/download/linux/"
+SRC_BASE="http://repository.spotify.com/pool/non-free/s/${PN}-client/"
+BUILD_ID_AMD64="439.gc253025e"
+SRC_URI="${SRC_BASE}${PN}-client_${PV}.${BUILD_ID_AMD64}_amd64.deb"
+
+LICENSE="Spotify"
+SLOT="0"
+KEYWORDS="~amd64"
+IUSE="libnotify local-playback pax-kernel pulseaudio"
+RESTRICT="mirror strip"
+
+BDEPEND=">=dev-util/patchelf-0.10"
+RDEPEND="
+	dev-libs/nss
+	dev-python/dbus-python
+	libnotify? ( x11-libs/libnotify )
+	dev-libs/openssl:0=
+	media-libs/alsa-lib
+	media-libs/fontconfig
+	media-libs/harfbuzz
+	media-libs/mesa[X(+)]
+	net-misc/curl[ssl]
+	net-print/cups[ssl]
+	pulseaudio? ( media-sound/pulseaudio )
+	!pulseaudio? ( media-sound/apulse )
+	local-playback? ( media-video/ffmpeg:0/56.58.58 )
+	x11-libs/gtk+:3
+	app-accessibility/at-spi2-atk
+	x11-libs/libxkbcommon
+	x11-libs/libXScrnSaver
+	x11-libs/libXtst
+	x11-libs/libSM
+	x11-libs/libICE
+"
+	#sys-libs/glibc
+
+S="${WORKDIR}/"
+
+QA_PREBUILT="
+	opt/spotify/spotify-client/spotify
+	opt/spotify/spotify-client/libEGL.so
+	opt/spotify/spotify-client/libGLESv2.so
+	opt/spotify/spotify-client/libcef.so
+	opt/spotify/spotify-client/libvk_swiftshader.so
+	opt/spotify/spotify-client/libvulkan.so.1
+	opt/spotify/spotify-client/swiftshader/libEGL.so
+	opt/spotify/spotify-client/swiftshader/libGLESv2.so
+"
+
+src_prepare() {
+	default
+	# Spotify links against libcurl-gnutls.so.4, which does not exist in Gentoo.
+	patchelf --replace-needed libcurl-gnutls.so.4 libcurl.so.4 usr/bin/spotify \
+		|| die "failed to patch libcurl library dependency"
+}
+
+src_install() {
+	gunzip usr/share/doc/spotify-client/changelog.gz || die
+	dodoc usr/share/doc/spotify-client/changelog
+
+	SPOTIFY_PKG_HOME=usr/share/spotify
+	insinto /usr/share/pixmaps
+	doins ${SPOTIFY_PKG_HOME}/icons/*.png
+
+	# install in /opt/spotify
+	SPOTIFY_HOME=/opt/spotify/spotify-client
+	insinto ${SPOTIFY_HOME}
+	doins -r ${SPOTIFY_PKG_HOME}/*
+	fperms +x ${SPOTIFY_HOME}/spotify
+
+	dodir /usr/bin
+	cat <<EOF >"${D}"/usr/bin/spotify || die
+#! /bin/sh
+if command -v spotify-dbus.py &> /dev/null; then
+	echo "Launching spotify with Gnome systray integration"
+	LD_LIBRARY_PATH="/usr/$(get_libdir)/apulse" \\
+	spotify-dbus.py "\$@"
+elif command -v spotify-tray &> /dev/null; then
+	echo "Launching spotify with generic systray integration"
+	TRAY_ARGS=" --client-path=${SPOTIFY_HOME}/spotify --toggle "
+	# seperate out the --minimized argument, parse it to spotify-tray
+	# propagate the rest to the spotify client itself
+	if [[ "\$@" == *"--minimized"* ]]; then
+		TRAY_ARGS+=" --minimized "
+	fi
+	LD_LIBRARY_PATH="/usr/$(get_libdir)/apulse" \\
+	spotify-tray \${TRAY_ARGS} -- "\$@"
+else
+	echo "Neither gnome-integration-spotify or spotify-tray installed"
+	echo "Launching spotify without systray integration"
+	LD_LIBRARY_PATH="/usr/$(get_libdir)/apulse" \\
+	exec ${SPOTIFY_HOME}/spotify "\$@"
+fi
+EOF
+	fperms +x /usr/bin/spotify
+
+	local size
+	for size in 16 22 24 32 48 64 128 256 512; do
+		newicon -s ${size} "${S}${SPOTIFY_PKG_HOME}/icons/spotify-linux-${size}.png" \
+			"spotify-client.png"
+	done
+	domenu "${S}${SPOTIFY_PKG_HOME}/spotify.desktop"
+	if use pax-kernel; then
+		#create the headers, reset them to default, then paxmark -m them
+		pax-mark C "${ED}${SPOTIFY_HOME}/${PN}" || die
+		pax-mark z "${ED}${SPOTIFY_HOME}/${PN}" || die
+		pax-mark m "${ED}${SPOTIFY_HOME}/${PN}" || die
+		eqawarn "You have set USE=pax-kernel meaning that you intend to run"
+		eqawarn "${PN} under a PaX enabled kernel.	To do so, we must modify"
+		eqawarn "the ${PN} binary itself and this *may* lead to breakage!  If"
+		eqawarn "you suspect that ${PN} is being broken by this modification,"
+		eqawarn "please open a bug."
+	fi
+}
+
+pkg_postinst() {
+	xdg_pkg_postinst
+
+	ewarn "If Spotify crashes after an upgrade its cache may be corrupt."
+	ewarn "To remove the cache:"
+	ewarn "rm -rf ~/.cache/spotify"
+
+	optfeature "Gnome specific systray integration" gnome-extra/gnome-integration-spotify
+	optfeature "systray integration on non-Gnome DEs" media-sound/spotify-tray
+}


### PR DESCRIPTION
Still needs testing on Gnome with gnome-extra/gnome-integration-spotify, but it should just work.

- drop systray flag
- expand launch script to detect and use systray application if present
- add optfeature
- bump to EAPI 8

Closes: https://bugs.gentoo.org/825406
Closes: https://bugs.gentoo.org/825410
Package-Manager: Portage-3.0.30, Repoman-3.0.3
Signed-off-by: Andrew Ammerlaan <andrewammerlaan@gentoo.org>

@prometheanfire any thoughts or comments?

Diff between r0 and r1:
```
andrew@andrew-gentoo-pc spotify % diff spotify-1.1.72.ebuild spotify-1.1.72-r1.ebuild 
4,5c4,6
< EAPI=7
< inherit desktop pax-utils unpacker xdg
---
> EAPI=8
> 
> inherit desktop optfeature pax-utils unpacker xdg
11a13
> 
14,15c16,17
< KEYWORDS="amd64"
< IUSE="libnotify local-playback pax-kernel pulseaudio systray"
---
> KEYWORDS="~amd64"
> IUSE="libnotify local-playback pax-kernel pulseaudio"
33d34
<       systray? ( gnome-extra/gnome-integration-spotify )
44c45
< S=${WORKDIR}/
---
> S="${WORKDIR}/"
50a52,53
>       opt/spotify/spotify-client/libvk_swiftshader.so
>       opt/spotify/spotify-client/libvulkan.so.1
56,61d58
<       # Fix desktop entry to launch spotify-dbus.py for systray integration
<       if use systray ; then
<               sed -i \
<                       -e 's/spotify \%U/spotify-dbus.py \%U/g' \
<                       usr/share/spotify/spotify.desktop || die "sed failed"
<       fi
63d59
< 
84,88c80,102
<       cat <<-EOF >"${D}"/usr/bin/spotify || die
<               #! /bin/sh
<               LD_LIBRARY_PATH="/usr/$(get_libdir)/apulse" \\
<               exec ${SPOTIFY_HOME}/spotify "\$@"
<       EOF
---
>       cat <<EOF >"${D}"/usr/bin/spotify || die
> #! /bin/sh
> if command -v spotify-dbus.py &> /dev/null; then
>       echo "Launching spotify with Gnome systray integration"
>       LD_LIBRARY_PATH="/usr/$(get_libdir)/apulse" \\
>       spotify-dbus.py "\$@"
> elif command -v spotify-tray &> /dev/null; then
>       echo "Launching spotify with generic systray integration"
>       TRAY_ARGS=" --client-path=${SPOTIFY_HOME}/spotify --toggle "
>       # seperate out the --minimized argument, parse it to spotify-tray
>       # propagate the rest to the spotify client itself
>       if [[ "\$@" == *"--minimized"* ]]; then
>               TRAY_ARGS+=" --minimized "
>       fi
>       LD_LIBRARY_PATH="/usr/$(get_libdir)/apulse" \\
>       spotify-tray \${TRAY_ARGS} -- "\$@"
> else
>       echo "Neither gnome-integration-spotify or spotify-tray installed"
>       echo "Launching spotify without systray integration"
>       LD_LIBRARY_PATH="/usr/$(get_libdir)/apulse" \\
>       exec ${SPOTIFY_HOME}/spotify "\$@"
> fi
> EOF
115a130,132
>
>       optfeature "Gnome specific systray integration" gnome-extra/gnome-integration-spotify
>       optfeature "systray integration on non-Gnome DEs" media-sound/spotify-tray
```