### PR TITLE
net-misc/networkmanager: add patch to fix VPN plugins

### DIFF
--- a/net-misc/networkmanager/files/network-manager-1.32.12-service-add-CAP_SETPCAP-capability.patch
+++ b/net-misc/networkmanager/files/network-manager-1.32.12-service-add-CAP_SETPCAP-capability.patch
@@ -1,0 +1,38 @@
+From 0a056943695c3d2c1cc5673fd38444781abf01de Mon Sep 17 00:00:00 2001
+From: Stijn Tintel <stijn@linux-ipv6.be>
+Date: Wed, 29 Dec 2021 02:07:44 +0200
+Subject: [PATCH] service: add CAP_SETPCAP capability
+
+The NetworkManager strongSwan and L2TP plugins fail due to not being
+able to drop capabilities:
+
+dec 29 01:42:36 sylvester charon-nm[15164]: 00[LIB] dropping capabilities failed: Operation not permitted
+dec 29 01:42:36 sylvester charon-nm[15164]: 00[DMN] capability dropping failed - aborting charon-nm
+
+dec 29 02:02:19 taz charon[2191488]: 00[LIB] dropping capabilities failed: Operation not permitted
+dec 29 02:02:19 taz charon[2191488]: 00[DMN] capability dropping failed - aborting charon
+
+Fix this by adding CAP_SETPCAP to the CapabilityBoundingSet parameter of
+the systemd unit file.
+
+Signed-off-by: Stijn Tintel <stijn@linux-ipv6.be>
+---
+ data/NetworkManager.service.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/data/NetworkManager.service.in b/data/NetworkManager.service.in
+index e23b3a5282..212817d787 100644
+--- a/data/NetworkManager.service.in
++++ b/data/NetworkManager.service.in
+@@ -16,7 +16,7 @@ Restart=on-failure
+ KillMode=process
+ 
+ # CAP_DAC_OVERRIDE: required to open /run/openvswitch/db.sock socket.
+-CapabilityBoundingSet=CAP_NET_ADMIN CAP_DAC_OVERRIDE CAP_NET_RAW CAP_NET_BIND_SERVICE CAP_SETGID CAP_SETUID CAP_SYS_MODULE CAP_AUDIT_WRITE CAP_KILL CAP_SYS_CHROOT
++CapabilityBoundingSet=CAP_NET_ADMIN CAP_DAC_OVERRIDE CAP_NET_RAW CAP_NET_BIND_SERVICE CAP_SETGID CAP_SETUID CAP_SYS_MODULE CAP_AUDIT_WRITE CAP_KILL CAP_SYS_CHROOT CAP_SETPCAP
+ 
+ ProtectSystem=true
+ ProtectHome=read-only
+-- 
+2.33.1
+

--- a/net-misc/networkmanager/networkmanager-1.32.12-r2.ebuild
+++ b/net-misc/networkmanager/networkmanager-1.32.12-r2.ebuild
@@ -1,0 +1,404 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+GNOME_ORG_MODULE="NetworkManager"
+VALA_USE_DEPEND="vapigen"
+PYTHON_COMPAT=( python3_{7..10} )
+
+inherit gnome.org linux-info meson-multilib python-any-r1 readme.gentoo-r1 systemd toolchain-funcs udev vala virtualx
+
+DESCRIPTION="A set of co-operative tools that make networking simple and straightforward"
+HOMEPAGE="https://wiki.gnome.org/Projects/NetworkManager"
+
+LICENSE="GPL-2+ LGPL-2.1+"
+SLOT="0"
+
+IUSE="audit bluetooth +concheck connection-sharing debug dhclient dhcpcd elogind gnutls +gtk-doc +introspection iptables iwd kernel_linux psl lto +nss nftables +modemmanager ofono ovs policykit +ppp resolvconf selinux syslog systemd teamd test +tools vala +wext +wifi"
+RESTRICT="!test? ( test )"
+
+REQUIRED_USE="
+	bluetooth? ( modemmanager )
+	connection-sharing? ( || ( iptables nftables ) )
+	gtk-doc? ( introspection )
+	iwd? ( wifi )
+	vala? ( introspection )
+	wext? ( wifi )
+	^^ ( gnutls nss )
+	?? ( elogind systemd )
+	?? ( dhclient dhcpcd )
+	?? ( syslog systemd )
+"
+
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~ia64 ~ppc ~ppc64 ~riscv ~sparc ~x86"
+
+COMMON_DEPEND="
+	sys-apps/util-linux[${MULTILIB_USEDEP}]
+	elogind? ( >=sys-auth/elogind-219 )
+	>=virtual/libudev-175:=[${MULTILIB_USEDEP}]
+	sys-apps/dbus
+	net-libs/libndp
+	systemd? ( >=sys-apps/systemd-209:0= )
+	>=dev-libs/glib-2.40:2[${MULTILIB_USEDEP}]
+	introspection? ( >=dev-libs/gobject-introspection-0.10.3:= )
+	selinux? ( sys-libs/libselinux )
+	audit? ( sys-process/audit )
+	teamd? (
+		>=dev-libs/jansson-2.7:=
+		>=net-misc/libteam-1.9
+	)
+	policykit? ( >=sys-auth/polkit-0.106 )
+	nss? ( >=dev-libs/nss-3.11:=[${MULTILIB_USEDEP}] )
+	gnutls? (
+		>=net-libs/gnutls-2.12:=[${MULTILIB_USEDEP}]
+	)
+	ppp? ( >=net-dialup/ppp-2.4.5:=[ipv6] )
+	modemmanager? (
+		net-misc/mobile-broadband-provider-info
+		>=net-misc/modemmanager-0.7.991:0=
+	)
+	bluetooth? ( >=net-wireless/bluez-5 )
+	ofono? ( net-misc/ofono )
+	dhclient? ( >=net-misc/dhcp-4[client] )
+	dhcpcd? ( >=net-misc/dhcpcd-9.3.3 )
+	ovs? ( >=dev-libs/jansson-2.7:= )
+	resolvconf? ( net-dns/openresolv )
+	connection-sharing? (
+		net-dns/dnsmasq[dbus,dhcp]
+		iptables? ( net-firewall/iptables )
+		nftables? ( net-firewall/nftables )
+	)
+	psl? ( net-libs/libpsl )
+	concheck? ( net-misc/curl )
+	tools? (
+		sys-libs/readline:0=
+		>=dev-libs/newt-0.52.15
+	)
+"
+RDEPEND="${COMMON_DEPEND}
+	acct-group/plugdev
+	|| (
+		net-misc/iputils[arping(+)]
+		net-analyzer/arping
+	)
+	wifi? (
+		!iwd? ( >=net-wireless/wpa_supplicant-0.7.3-r3[dbus] )
+		iwd? ( net-wireless/iwd )
+	)
+"
+DEPEND="${COMMON_DEPEND}
+	>=sys-kernel/linux-headers-3.18
+	net-libs/libndp[${MULTILIB_USEDEP}]
+"
+BDEPEND="
+	dev-util/gdbus-codegen
+	dev-util/glib-utils
+	gtk-doc? (
+		dev-util/gtk-doc
+		app-text/docbook-xml-dtd:4.1.2
+	)
+	>=dev-util/intltool-0.40
+	>=sys-devel/gettext-0.17
+	virtual/pkgconfig
+	introspection? (
+		$(python_gen_any_dep 'dev-python/pygobject:3[${PYTHON_USEDEP}]')
+		dev-lang/perl
+		dev-libs/libxslt
+	)
+	vala? ( $(vala_depend) )
+	test? (
+		>=dev-libs/jansson-2.7
+		$(python_gen_any_dep '
+			dev-python/dbus-python[${PYTHON_USEDEP}]
+			dev-python/pygobject:3[${PYTHON_USEDEP}]')
+	)
+"
+
+PATCHES=(
+	"${FILESDIR}/"
+)
+
+python_check_deps() {
+	if use introspection; then
+		has_version "dev-python/pygobject:3[${PYTHON_USEDEP}]" || return
+	fi
+	if use test; then
+		has_version "dev-python/dbus-python[${PYTHON_USEDEP}]" &&
+		has_version "dev-python/pygobject:3[${PYTHON_USEDEP}]"
+	fi
+}
+
+sysfs_deprecated_check() {
+	ebegin "Checking for SYSFS_DEPRECATED support"
+
+	if { linux_chkconfig_present SYSFS_DEPRECATED_V2; }; then
+		eerror "Please disable SYSFS_DEPRECATED_V2 support in your kernel config and recompile your kernel"
+		eerror "or NetworkManager will not work correctly."
+		eerror "See https://bugs.gentoo.org/333639 for more info."
+		die "CONFIG_SYSFS_DEPRECATED_V2 support detected!"
+	fi
+	eend $?
+}
+
+pkg_pretend() {
+	if use kernel_linux; then
+		get_version
+		if linux_config_exists; then
+			sysfs_deprecated_check
+		else
+			ewarn "Was unable to determine your kernel .config"
+			ewarn "Please note that if CONFIG_SYSFS_DEPRECATED_V2 is set in your kernel .config, NetworkManager will not work correctly."
+			ewarn "See https://bugs.gentoo.org/333639 for more info."
+		fi
+	fi
+}
+
+pkg_setup() {
+	if use connection-sharing; then
+		if kernel_is lt 5 1; then
+			CONFIG_CHECK="~NF_NAT_IPV4 ~NF_NAT_MASQUERADE_IPV4"
+		else
+			CONFIG_CHECK="~NF_NAT ~NF_NAT_MASQUERADE"
+		fi
+		linux-info_pkg_setup
+	fi
+
+	if use introspection || use test; then
+		python-any-r1_pkg_setup
+	fi
+
+	# bug 809695
+	if tc-is-clang && use lto; then
+		eerror "Clang does not support -flto-partition"
+		die "Please use gcc or turn off USE=lto flag when building with clang"
+	fi
+}
+
+src_prepare() {
+	DOC_CONTENTS="To modify system network connections without needing to enter the
+		root password, add your user account to the 'plugdev' group."
+
+	default
+	use vala && vala_src_prepare
+
+	sed -i \
+		-e 's#/usr/bin/sed#/bin/sed#' \
+		data/84-nm-drivers.rules \
+		|| die
+}
+
+meson_nm_program() {
+	usex "$1" "-D${2:-$1}=$3" "-D${2:-$1}=no"
+}
+
+meson_nm_native_program() {
+	multilib_native_usex "$1" "-D${2:-$1}=$3" "-D${2:-$1}=no"
+}
+
+multilib_src_configure() {
+	local emesonargs=(
+		--localstatedir="${EPREFIX}/var"
+
+		-Dsystemdsystemunitdir=$(systemd_get_systemunitdir)
+		-Dsystem_ca_path=/etc/ssl/certs
+		-Dudev_dir=$(get_udevdir)
+		-Ddbus_conf_dir=/usr/share/dbus-1/system.d
+		-Dkernel_firmware_dir=/lib/firmware
+		-Diptables=/sbin/iptables
+		-Dnft=/sbin/nft
+		-Ddnsmasq=/usr/sbin/dnsmasq
+		#-Ddnssec_trigger=
+
+		-Ddist_version=${PVR}
+		$(meson_native_use_bool policykit polkit)
+		$(meson_native_use_bool policykit config_auth_polkit_default)
+		-Dmodify_system=true
+		-Dpolkit_agent_helper_1=/usr/lib/polkit-1/polkit-agent-helper-1
+		$(meson_native_use_bool selinux)
+		$(meson_native_use_bool systemd systemd_journal)
+		-Dhostname_persist=gentoo
+		-Dlibaudit=$(multilib_native_usex audit)
+
+		$(meson_native_use_bool wext)
+		$(meson_native_use_bool wifi)
+		$(meson_native_use_bool iwd)
+		$(meson_native_use_bool ppp)
+		-Dpppd=/usr/sbin/pppd
+		$(meson_native_use_bool modemmanager modem_manager)
+		$(meson_native_use_bool ofono)
+		$(meson_native_use_bool concheck)
+		$(meson_native_use_bool teamd teamdctl)
+		$(meson_native_use_bool ovs)
+		$(meson_native_use_bool tools nmcli)
+		$(meson_native_use_bool tools nmtui)
+		$(meson_native_use_bool tools nm_cloud_setup)
+		$(meson_native_use_bool bluetooth bluez5_dun)
+		-Debpf=true
+
+		-Dconfig_plugins_default=keyfile
+		-Difcfg_rh=false
+		-Difupdown=false
+
+		$(meson_nm_native_program resolvconf "" /sbin/resolvconf)
+		-Dnetconfig=no
+		-Dconfig_dns_rc_manager_default=auto
+
+		$(meson_nm_program dhclient "" /sbin/dhclient)
+		-Ddhcpcanon=no
+		$(meson_nm_program dhcpcd "" /sbin/dhcpcd)
+
+		$(meson_native_use_bool introspection)
+		$(meson_native_use_bool vala vapi)
+		$(meson_native_use_bool gtk-doc docs)
+		-Dtests=$(multilib_native_usex test)
+		$(meson_native_true firewalld_zone)
+		-Dmore_asserts=0
+		$(meson_use debug more_logging)
+		-Dvalgrind=no
+		-Dvalgrind_suppressions=
+		-Dld_gc=false
+		$(meson_native_use_bool psl libpsl)
+		-Dqt=false
+
+		$(meson_use lto b_lto)
+	)
+
+	if multilib_is_native_abi && use systemd; then
+		emesonargs+=( -Dsession_tracking_consolekit=false )
+		emesonargs+=( -Dsession_tracking=systemd )
+		emesonargs+=( -Dsuspend_resume=systemd )
+	elif multilib_is_native_abi && use elogind; then
+		emesonargs+=( -Dsession_tracking_consolekit=false )
+		emesonargs+=( -Dsession_tracking=elogind )
+		emesonargs+=( -Dsuspend_resume=elogind )
+	else
+		emesonargs+=( -Dsession_tracking_consolekit=false )
+		emesonargs+=( -Dsession_tracking=no )
+		emesonargs+=( -Dsuspend_resume=auto )
+	fi
+
+	if multilib_is_native_abi && use syslog; then
+		emesonargs+=( -Dconfig_logging_backend_default=syslog )
+	elif multilib_is_native_abi && use systemd; then
+		emesonargs+=( -Dconfig_logging_backend_default=journal )
+	else
+		emesonargs+=( -Dconfig_logging_backend_default=default )
+	fi
+
+	if multilib_is_native_abi && use dhclient; then
+		emesonargs+=( -Dconfig_dhcp_default=dhclient )
+	elif multilib_is_native_abi && use dhcpcd; then
+		emesonargs+=( -Dconfig_dhcp_default=dhcpcd )
+	else
+		emesonargs+=( -Dconfig_dhcp_default=internal )
+	fi
+
+	if use nss; then
+		emesonargs+=( -Dcrypto=nss )
+	else
+		emesonargs+=( -Dcrypto=gnutls )
+	fi
+
+	# Same hack as net-dialup/pptpd to get proper plugin dir for ppp, bug #519986
+	if use ppp; then
+		local PPPD_VER=`best_version net-dialup/ppp`
+		PPPD_VER=${PPPD_VER#*/*-} #reduce it to ${PV}-${PR}
+		PPPD_VER=${PPPD_VER%%[_-]*} # main version without beta/pre/patch/revision
+		emesonargs+=( -Dpppd_plugin_dir=/usr/$(get_libdir)/pppd/${PPPD_VER} )
+	fi
+
+	meson_src_configure
+}
+
+multilib_src_test() {
+	if use test && multilib_is_native_abi; then
+		python_setup
+		virtx meson_src_test
+	fi
+}
+
+multilib_src_install() {
+	meson_src_install
+	if ! multilib_is_native_abi; then
+		rm -r "${ED}"/{etc,usr/{bin,lib/NetworkManager,share},var} || die
+	fi
+}
+
+multilib_src_install_all() {
+	! use systemd && readme.gentoo_create_doc
+
+	newinitd "${FILESDIR}/init.d.NetworkManager-r2" NetworkManager
+	newconfd "${FILESDIR}/conf.d.NetworkManager" NetworkManager
+
+	# Need to keep the /etc/NetworkManager/dispatched.d for dispatcher scripts
+	keepdir /etc/NetworkManager/dispatcher.d
+
+	# Provide openrc net dependency only when nm is connected
+	exeinto /etc/NetworkManager/dispatcher.d
+	newexe "${FILESDIR}/10-openrc-status-r4" 10-openrc-status
+	sed -e "s:@EPREFIX@:${EPREFIX}:g" \
+		-i "${ED}/etc/NetworkManager/dispatcher.d/10-openrc-status" || die
+
+	keepdir /etc/NetworkManager/system-connections
+	chmod 0600 "${ED}"/etc/NetworkManager/system-connections/.keep* # bug #383765, upstream bug #754594
+
+	# Allow users in plugdev group to modify system connections
+	insinto /usr/share/polkit-1/rules.d/
+	doins "${FILESDIR}"/01-org.freedesktop.NetworkManager.settings.modify.system.rules
+
+	insinto /usr/lib/NetworkManager/conf.d #702476
+	doins "${S}"/examples/nm-conf.d/31-mac-addr-change.conf
+
+	if use iwd; then
+		# This goes to $nmlibdir/conf.d/ and $nmlibdir is '${prefix}'/lib/$PACKAGE, thus always lib, not get_libdir
+		cat <<-EOF > "${ED}"/usr/lib/NetworkManager/conf.d/iwd.conf || die
+		[device]
+		wifi.backend=iwd
+		EOF
+	fi
+
+	mv "${ED}"/usr/share/doc/{NetworkManager/examples/,${PF}} || die
+	rmdir "${ED}"/usr/share/doc/NetworkManager || die
+
+	# Empty
+	rmdir "${ED}"/var{/lib{/NetworkManager,},} || die
+}
+
+pkg_postinst() {
+	systemd_reenable NetworkManager.service
+	! use systemd && readme.gentoo_print_elog
+
+	if [[ -e "${EROOT}/etc/NetworkManager/nm-system-settings.conf" ]]; then
+		ewarn "The ${PN} system configuration file has moved to a new location."
+		ewarn "You must migrate your settings from ${EROOT}/etc/NetworkManager/nm-system-settings.conf"
+		ewarn "to ${EROOT}/etc/NetworkManager/NetworkManager.conf"
+		ewarn
+		ewarn "After doing so, you can remove ${EROOT}/etc/NetworkManager/nm-system-settings.conf"
+	fi
+
+	# NM fallbacks to plugin specified at compile time (upstream bug #738611)
+	# but still show a warning to remember people to have cleaner config file
+	if [[ -e "${EROOT}/etc/NetworkManager/NetworkManager.conf" ]]; then
+		if grep plugins "${EROOT}/etc/NetworkManager/NetworkManager.conf" | grep -q ifnet; then
+			ewarn
+			ewarn "You seem to use 'ifnet' plugin in ${EROOT}/etc/NetworkManager/NetworkManager.conf"
+			ewarn "Since it won't be used, you will need to stop setting ifnet plugin there."
+			ewarn
+		fi
+	fi
+
+	# NM shows lots of errors making nmcli almost unusable, bug #528748 upstream bug #690457
+	if grep -r "psk-flags=1" "${EROOT}"/etc/NetworkManager/; then
+		ewarn "You have psk-flags=1 setting in above files, you will need to"
+		ewarn "either reconfigure affected networks or, at least, set the flag"
+		ewarn "value to '0'."
+	fi
+
+	if use dhclient || use dhcpcd; then
+		ewarn "You have enabled USE=dhclient and/or USE=dhcpcd, but NetworkManager since"
+		ewarn "version 1.20 defaults to the internal DHCP client. If the internal client"
+		ewarn "works for you, and you're happy with, the alternative USE flags can be"
+		ewarn "disabled. If you want to use dhclient or dhcpcd, then you need to tweak"
+		ewarn "the main.dhcp configuration option to use one of them instead of internal."
+	fi
+}


### PR DESCRIPTION
Upstream-PR: https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/merge_requests/1053/commits
Closes: https://bugs.gentoo.org/732708
Package-Manager: Portage-3.0.28, Repoman-3.0.3
Signed-off-by: Stijn Tintel <stijn@linux-ipv6.be>