### PR TITLE
remove obsolete selinux modules

### DIFF
--- a/sec-policy/selinux-base-policy/selinux-base-policy-2.20210203-r1.ebuild
+++ b/sec-policy/selinux-base-policy/selinux-base-policy-2.20210203-r1.ebuild
@@ -27,6 +27,7 @@ BDEPEND="
 	sys-apps/checkpolicy
 	sys-devel/m4"
 
+OLD_MODS="application authlogin bootloader clock consoletype cron dmesg fstools getty hostname hotplug init iptables libraries locallogin logging lvm miscfiles modutils mount mta netutils nscd portage raid rsync selinuxutil setrans ssh staff storage su sysadm sysnetwork systemd tmpfiles udev userdomain usermanage unprivuser xdg"
 MODS="application authlogin bootloader clock consoletype cron dmesg fstools getty hostname init iptables libraries locallogin logging lvm miscfiles modutils mount mta netutils nscd portage raid rsync selinuxutil setrans ssh staff storage su sysadm sysnetwork systemd tmpfiles udev userdomain usermanage unprivuser xdg"
 LICENSE="GPL-2"
 SLOT="0"
@@ -97,6 +98,7 @@ pkg_postinst() {
 
 	# Override the command from the eclass, we need to load in base as well here
 	local COMMAND="-i base.pp"
+	local DEL_MODS=""
 	if has_version "<sys-apps/policycoreutils-2.5"; then
 		COMMAND="-b base.pp"
 	fi
@@ -105,12 +107,26 @@ pkg_postinst() {
 		COMMAND="${COMMAND} -i ${i}.pp"
 	done
 
+	for i in ${OLD_MODS}; do
+		if [ -n "${MODS##*$i*}" ]; then
+			DEL_MODS="${DEL_MODS} ${i}"
+		fi
+	done
+
 	for i in ${POLICY_TYPES}; do
 		einfo "Inserting the following modules, with base, into the $i module store: ${MODS}"
 
 		cd "${ROOT}/usr/share/selinux/${i}"
 
 		semodule ${root_opts} -s ${i} ${COMMAND}
+
+		if [ -n "${DEL_MODS}" ];then
+			for mod in ${DEL_MODS}; do
+				if semodule ${root_opts} -s ${i} -l | grep -q "\b${mod}\b"; then
+					semodule ${root_opts} -s ${i} -r ${mod}
+				fi
+			done
+		fi
 	done
 
 	# Don't relabel when cross compiling

--- a/sec-policy/selinux-base-policy/selinux-base-policy-2.20210203-r1.ebuild
+++ b/sec-policy/selinux-base-policy/selinux-base-policy-2.20210203-r1.ebuild
@@ -27,8 +27,8 @@ BDEPEND="
 	sys-apps/checkpolicy
 	sys-devel/m4"
 
-DEL_MODS="hotplug"
 MODS="application authlogin bootloader clock consoletype cron dmesg fstools getty hostname init iptables libraries locallogin logging lvm miscfiles modutils mount mta netutils nscd portage raid rsync selinuxutil setrans ssh staff storage su sysadm sysnetwork systemd tmpfiles udev userdomain usermanage unprivuser xdg"
+DEL_MODS="hotplug"
 LICENSE="GPL-2"
 SLOT="0"
 S="${WORKDIR}/"

--- a/sec-policy/selinux-base-policy/selinux-base-policy-2.20210203-r1.ebuild
+++ b/sec-policy/selinux-base-policy/selinux-base-policy-2.20210203-r1.ebuild
@@ -27,7 +27,7 @@ BDEPEND="
 	sys-apps/checkpolicy
 	sys-devel/m4"
 
-OLD_MODS="application authlogin bootloader clock consoletype cron dmesg fstools getty hostname hotplug init iptables libraries locallogin logging lvm miscfiles modutils mount mta netutils nscd portage raid rsync selinuxutil setrans ssh staff storage su sysadm sysnetwork systemd tmpfiles udev userdomain usermanage unprivuser xdg"
+DEL_MODS="hotplug"
 MODS="application authlogin bootloader clock consoletype cron dmesg fstools getty hostname init iptables libraries locallogin logging lvm miscfiles modutils mount mta netutils nscd portage raid rsync selinuxutil setrans ssh staff storage su sysadm sysnetwork systemd tmpfiles udev userdomain usermanage unprivuser xdg"
 LICENSE="GPL-2"
 SLOT="0"
@@ -98,7 +98,6 @@ pkg_postinst() {
 
 	# Override the command from the eclass, we need to load in base as well here
 	local COMMAND="-i base.pp"
-	local DEL_MODS=""
 	if has_version "<sys-apps/policycoreutils-2.5"; then
 		COMMAND="-b base.pp"
 	fi
@@ -107,10 +106,8 @@ pkg_postinst() {
 		COMMAND="${COMMAND} -i ${i}.pp"
 	done
 
-	for i in ${OLD_MODS}; do
-		if [ -n "${MODS##*$i*}" ]; then
-			DEL_MODS="${DEL_MODS} ${i}"
-		fi
+	for i in ${DEL_MODS}; do
+		[[ "${MODS}" != "*${i}*" ]] || die "Duplicate module in MODS and DEL_MODS: ${i}"
 	done
 
 	for i in ${POLICY_TYPES}; do

--- a/sec-policy/selinux-base-policy/selinux-base-policy-2.20210908-r1.ebuild
+++ b/sec-policy/selinux-base-policy/selinux-base-policy-2.20210908-r1.ebuild
@@ -27,6 +27,7 @@ BDEPEND="
 	sys-apps/checkpolicy
 	sys-devel/m4"
 
+OLD_MODS="application authlogin bootloader clock consoletype cron dmesg fstools getty hostname hotplug init iptables libraries locallogin logging lvm miscfiles modutils mount mta netutils nscd portage raid rsync selinuxutil setrans ssh staff storage su sysadm sysnetwork systemd tmpfiles udev userdomain usermanage unprivuser xdg"
 MODS="application authlogin bootloader clock consoletype cron dmesg fstools getty hostname init iptables libraries locallogin logging lvm miscfiles modutils mount mta netutils nscd portage raid rsync selinuxutil setrans ssh staff storage su sysadm sysnetwork systemd tmpfiles udev userdomain usermanage unprivuser xdg"
 LICENSE="GPL-2"
 SLOT="0"
@@ -97,6 +98,7 @@ pkg_postinst() {
 
 	# Override the command from the eclass, we need to load in base as well here
 	local COMMAND="-i base.pp"
+	local DEL_MODS=""
 	if has_version "<sys-apps/policycoreutils-2.5"; then
 		COMMAND="-b base.pp"
 	fi
@@ -105,12 +107,26 @@ pkg_postinst() {
 		COMMAND="${COMMAND} -i ${i}.pp"
 	done
 
+	for i in ${OLD_MODS}; do
+		if [ -n "${MODS##*$i*}" ]; then
+			DEL_MODS="${DEL_MODS} ${i}"
+		fi
+	done
+
 	for i in ${POLICY_TYPES}; do
 		einfo "Inserting the following modules, with base, into the $i module store: ${MODS}"
 
 		cd "${ROOT}/usr/share/selinux/${i}"
 
 		semodule ${root_opts} -s ${i} ${COMMAND}
+
+		if [ -n "${DEL_MODS}" ];then
+			for mod in ${DEL_MODS}; do
+				if semodule ${root_opts} -s ${i} -l | grep -q "\b${mod}\b"; then
+					semodule ${root_opts} -s ${i} -r ${mod}
+				fi
+			done
+		fi
 	done
 
 	# Don't relabel when cross compiling

--- a/sec-policy/selinux-base-policy/selinux-base-policy-2.20210908-r1.ebuild
+++ b/sec-policy/selinux-base-policy/selinux-base-policy-2.20210908-r1.ebuild
@@ -27,8 +27,8 @@ BDEPEND="
 	sys-apps/checkpolicy
 	sys-devel/m4"
 
-DEL_MODS="hotplug"
 MODS="application authlogin bootloader clock consoletype cron dmesg fstools getty hostname init iptables libraries locallogin logging lvm miscfiles modutils mount mta netutils nscd portage raid rsync selinuxutil setrans ssh staff storage su sysadm sysnetwork systemd tmpfiles udev userdomain usermanage unprivuser xdg"
+DEL_MODS="hotplug"
 LICENSE="GPL-2"
 SLOT="0"
 S="${WORKDIR}/"

--- a/sec-policy/selinux-base-policy/selinux-base-policy-2.20210908-r1.ebuild
+++ b/sec-policy/selinux-base-policy/selinux-base-policy-2.20210908-r1.ebuild
@@ -27,7 +27,7 @@ BDEPEND="
 	sys-apps/checkpolicy
 	sys-devel/m4"
 
-OLD_MODS="application authlogin bootloader clock consoletype cron dmesg fstools getty hostname hotplug init iptables libraries locallogin logging lvm miscfiles modutils mount mta netutils nscd portage raid rsync selinuxutil setrans ssh staff storage su sysadm sysnetwork systemd tmpfiles udev userdomain usermanage unprivuser xdg"
+DEL_MODS="hotplug"
 MODS="application authlogin bootloader clock consoletype cron dmesg fstools getty hostname init iptables libraries locallogin logging lvm miscfiles modutils mount mta netutils nscd portage raid rsync selinuxutil setrans ssh staff storage su sysadm sysnetwork systemd tmpfiles udev userdomain usermanage unprivuser xdg"
 LICENSE="GPL-2"
 SLOT="0"
@@ -98,7 +98,6 @@ pkg_postinst() {
 
 	# Override the command from the eclass, we need to load in base as well here
 	local COMMAND="-i base.pp"
-	local DEL_MODS=""
 	if has_version "<sys-apps/policycoreutils-2.5"; then
 		COMMAND="-b base.pp"
 	fi
@@ -107,10 +106,8 @@ pkg_postinst() {
 		COMMAND="${COMMAND} -i ${i}.pp"
 	done
 
-	for i in ${OLD_MODS}; do
-		if [ -n "${MODS##*$i*}" ]; then
-			DEL_MODS="${DEL_MODS} ${i}"
-		fi
+	for i in ${DEL_MODS}; do
+		[[ "${MODS}" != "*${i}*" ]] || die "Duplicate module in MODS and DEL_MODS: ${i}"
 	done
 
 	for i in ${POLICY_TYPES}; do


### PR DESCRIPTION
Add cleanup actions to post installation step by identifying removed modules from OLD_MODS list, that is copy from previous ebuild and remove it from selinux module store if installed.

One must maintain OLD_MODS list on each new ebuild by copying it from previous MODS list.