### PR TITLE
Move python-exec deps from eclasses to dev-lang/python

### DIFF
--- a/dev-lang/python/python-3.10.0_p1-r1.ebuild
+++ b/dev-lang/python/python-3.10.0_p1-r1.ebuild
@@ -15,7 +15,7 @@ PATCHSET="python-gentoo-patches-${MY_PV}"
 DESCRIPTION="An interpreted, interactive, object-oriented programming language"
 HOMEPAGE="https://www.python.org/"
 SRC_URI="https://www.python.org/ftp/python/${PV%%_*}/${MY_P}.tar.xz
-	https://dev.gentoo.org/~mgorny/dist/python/${PATCHSET}.tar.xz
+	https://dev.gentoo.org/~floppym/python/${PATCHSET}.tar.xz
 	verify-sig? (
 		https://www.python.org/ftp/python/${PV%%_*}/${MY_P}.tar.xz.asc
 	)"
@@ -23,7 +23,7 @@ S="${WORKDIR}/${MY_P}"
 
 LICENSE="PSF-2"
 SLOT="${PYVER}"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86"
 IUSE="bluetooth build examples gdbm hardened lto +ncurses pgo +readline +sqlite +ssl test tk wininst +xml"
 RESTRICT="!test? ( test )"
 
@@ -34,6 +34,7 @@ RESTRICT="!test? ( test )"
 
 RDEPEND="app-arch/bzip2:=
 	app-arch/xz-utils:=
+	dev-lang/python-exec[python_targets_python3_10(-)]
 	dev-libs/libffi:=
 	sys-apps/util-linux:=
 	>=sys-libs/zlib-1.1.3:=
@@ -162,12 +163,7 @@ src_configure() {
 
 	if use pgo; then
 		local jobs=$(makeopts_jobs "${MAKEOPTS}" "$(get_nproc)")
-		export PROFILE_TASK="-m test -j${jobs} --pgo-extended -x test_gdb -u-network"
-
-		# All of these seem to occasionally hang for PGO inconsistently
-		# They'll even hang here but be fine in src_test sometimes.
-		# bug #828535 (and related: bug #788022)
-		PROFILE_TASK+=" -x test_socket -x test_asyncio -x test_httpservers -x test_logging -x test_multiprocessing_fork -x test_xmlrpc"
+		export PROFILE_TASK="-m test -j${jobs} --pgo-extended -x test_gdb"
 
 		if has_version "app-arch/rpm" ; then
 			# Avoid sandbox failure (attempts to write to /var/lib/rpm)

--- a/dev-lang/python/python-3.10.1-r2.ebuild
+++ b/dev-lang/python/python-3.10.1-r2.ebuild
@@ -4,7 +4,7 @@
 EAPI="7"
 WANT_LIBTOOL="none"
 
-inherit autotools flag-o-matic multiprocessing pax-utils \
+inherit autotools check-reqs flag-o-matic multiprocessing pax-utils \
 	python-utils-r1 toolchain-funcs verify-sig
 
 MY_PV=${PV/_rc/rc}
@@ -14,17 +14,17 @@ PATCHSET="python-gentoo-patches-${MY_PV}"
 
 DESCRIPTION="An interpreted, interactive, object-oriented programming language"
 HOMEPAGE="https://www.python.org/"
-SRC_URI="https://www.python.org/ftp/python/${PV%_*}/${MY_P}.tar.xz
-	https://dev.gentoo.org/~floppym/python/${PATCHSET}.tar.xz
+SRC_URI="https://www.python.org/ftp/python/${PV%%_*}/${MY_P}.tar.xz
+	https://dev.gentoo.org/~mgorny/dist/python/${PATCHSET}.tar.xz
 	verify-sig? (
-		https://www.python.org/ftp/python/${PV%_*}/${MY_P}.tar.xz.asc
+		https://www.python.org/ftp/python/${PV%%_*}/${MY_P}.tar.xz.asc
 	)"
 S="${WORKDIR}/${MY_P}"
 
 LICENSE="PSF-2"
 SLOT="${PYVER}"
-KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86"
-IUSE="bluetooth build examples gdbm hardened +ncurses +readline +sqlite +ssl test tk wininst +xml"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+IUSE="bluetooth build examples gdbm hardened lto +ncurses pgo +readline +sqlite +ssl test tk wininst +xml"
 RESTRICT="!test? ( test )"
 
 # Do not add a dependency on dev-lang/python to this ebuild.
@@ -34,6 +34,7 @@ RESTRICT="!test? ( test )"
 
 RDEPEND="app-arch/bzip2:=
 	app-arch/xz-utils:=
+	dev-lang/python-exec[python_targets_python3_10(-)]
 	dev-libs/libffi:=
 	sys-apps/util-linux:=
 	>=sys-libs/zlib-1.1.3:=
@@ -50,20 +51,33 @@ RDEPEND="app-arch/bzip2:=
 		dev-tcltk/blt:=
 		dev-tcltk/tix
 	)
-	xml? ( >=dev-libs/expat-2.1:= )"
+	xml? ( >=dev-libs/expat-2.1:= )
+	!!<sys-apps/sandbox-2.21"
 # bluetooth requires headers from bluez
 DEPEND="${RDEPEND}
 	bluetooth? ( net-wireless/bluez )
 	test? ( app-arch/xz-utils[extra-filters(+)] )"
+# autoconf-archive needed to eautoreconf
 BDEPEND="
+	sys-devel/autoconf-archive
 	virtual/awk
 	virtual/pkgconfig
-	sys-devel/autoconf-archive
 	verify-sig? ( sec-keys/openpgp-keys-python )
 	!sys-devel/gcc[libffi(-)]"
 RDEPEND+=" !build? ( app-misc/mime-types )"
 
 VERIFY_SIG_OPENPGP_KEY_PATH=${BROOT}/usr/share/openpgp-keys/python.org.asc
+
+# large file tests involve a 2.5G file being copied (duplicated)
+CHECKREQS_DISK_BUILD=5500M
+
+pkg_pretend() {
+	use test && check-reqs_pkg_pretend
+}
+
+pkg_setup() {
+	use test && check-reqs_pkg_setup
+}
 
 src_unpack() {
 	if use verify-sig; then
@@ -147,6 +161,21 @@ src_configure() {
 		dbmliborder+="${dbmliborder:+:}gdbm"
 	fi
 
+	if use pgo; then
+		local jobs=$(makeopts_jobs "${MAKEOPTS}" "$(get_nproc)")
+		export PROFILE_TASK="-m test -j${jobs} --pgo-extended -x test_gdb -u-network"
+
+		# All of these seem to occasionally hang for PGO inconsistently
+		# They'll even hang here but be fine in src_test sometimes.
+		# bug #828535 (and related: bug #788022)
+		PROFILE_TASK+=" -x test_socket -x test_asyncio -x test_httpservers -x test_logging -x test_multiprocessing_fork -x test_xmlrpc"
+
+		if has_version "app-arch/rpm" ; then
+			# Avoid sandbox failure (attempts to write to /var/lib/rpm)
+			PROFILE_TASK+=" -x test_distutils"
+		fi
+	fi
+
 	local myeconfargs=(
 		# glibc-2.30 removes it; since we can't cleanly force-rebuild
 		# Python on glibc upgrade, remove it proactively to give
@@ -154,6 +183,7 @@ src_configure() {
 		ac_cv_header_stropts_h=no
 
 		--enable-shared
+		--without-static-libpython
 		--enable-ipv6
 		--infodir='${prefix}/share/info'
 		--mandir='${prefix}/share/man'
@@ -164,6 +194,9 @@ src_configure() {
 		--without-ensurepip
 		--with-system-expat
 		--with-system-ffi
+
+		$(use_with lto)
+		$(use_enable pgo optimizations)
 	)
 
 	OPT="" econf "${myeconfargs[@]}"
@@ -182,6 +215,14 @@ src_compile() {
 	# Prevent using distutils bundled by setuptools.
 	# https://bugs.gentoo.org/823728
 	export SETUPTOOLS_USE_DISTUTILS=stdlib
+
+	if use pgo ; then
+		# bug 660358
+		local -x COLUMNS=80
+		local -x PYTHONDONTWRITEBYTECODE=
+
+		addpredict /usr/lib/python3.10/site-packages
+	fi
 
 	emake CPPFLAGS= CFLAGS= LDFLAGS=
 
@@ -210,6 +251,7 @@ src_test() {
 	# bug 660358
 	local -x COLUMNS=80
 	local -x PYTHONDONTWRITEBYTECODE=
+	addpredict /usr/lib/python3.10/site-packages
 
 	local jobs=$(makeopts_jobs "${MAKEOPTS}" "$(get_nproc)")
 
@@ -239,9 +281,6 @@ src_install() {
 	local libdir=${ED}/usr/lib/python${PYVER}
 
 	emake DESTDIR="${D}" altinstall
-
-	# Remove static library
-	rm "${ED}"/usr/$(get_libdir)/libpython*.a || die
 
 	sed \
 		-e "s/\(CONFIGURE_LDFLAGS=\).*/\1/" \
@@ -273,8 +312,6 @@ src_install() {
 
 	use sqlite || rm -r "${libdir}/"{sqlite3,test/test_sqlite*} || die
 	use tk || rm -r "${ED}/usr/bin/idle${PYVER}" "${libdir}/"{idlelib,tkinter,test/test_tk*} || die
-
-	use wininst || rm "${libdir}/distutils/command/"wininst-*.exe || die
 
 	dodoc Misc/{ACKS,HISTORY,NEWS}
 

--- a/dev-lang/python/python-3.8.12_p1-r1.ebuild
+++ b/dev-lang/python/python-3.8.12_p1-r1.ebuild
@@ -4,7 +4,7 @@
 EAPI="7"
 WANT_LIBTOOL="none"
 
-inherit autotools check-reqs flag-o-matic multiprocessing pax-utils \
+inherit autotools flag-o-matic multiprocessing pax-utils \
 	python-utils-r1 toolchain-funcs verify-sig
 
 MY_PV=${PV/_rc/rc}
@@ -14,17 +14,17 @@ PATCHSET="python-gentoo-patches-${MY_PV}"
 
 DESCRIPTION="An interpreted, interactive, object-oriented programming language"
 HOMEPAGE="https://www.python.org/"
-SRC_URI="https://www.python.org/ftp/python/${PV%%_*}/${MY_P}.tar.xz
-	https://dev.gentoo.org/~mgorny/dist/python/${PATCHSET}.tar.xz
+SRC_URI="https://www.python.org/ftp/python/${PV%_*}/${MY_P}.tar.xz
+	https://dev.gentoo.org/~floppym/python/${PATCHSET}.tar.xz
 	verify-sig? (
-		https://www.python.org/ftp/python/${PV%%_*}/${MY_P}.tar.xz.asc
+		https://www.python.org/ftp/python/${PV%_*}/${MY_P}.tar.xz.asc
 	)"
 S="${WORKDIR}/${MY_P}"
 
 LICENSE="PSF-2"
 SLOT="${PYVER}"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
-IUSE="bluetooth build examples gdbm hardened libedit lto +ncurses pgo +readline +sqlite +ssl test tk wininst +xml"
+KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86"
+IUSE="bluetooth build examples gdbm hardened +ncurses +readline +sqlite +ssl test tk wininst +xml"
 RESTRICT="!test? ( test )"
 
 # Do not add a dependency on dev-lang/python to this ebuild.
@@ -34,6 +34,7 @@ RESTRICT="!test? ( test )"
 
 RDEPEND="app-arch/bzip2:=
 	app-arch/xz-utils:=
+	dev-lang/python-exec[python_targets_python3_8(-)]
 	dev-libs/libffi:=
 	sys-apps/util-linux:=
 	>=sys-libs/zlib-1.1.3:=
@@ -41,10 +42,7 @@ RDEPEND="app-arch/bzip2:=
 	virtual/libintl
 	gdbm? ( sys-libs/gdbm:=[berkdb] )
 	ncurses? ( >=sys-libs/ncurses-5.2:= )
-	readline? (
-		!libedit? ( >=sys-libs/readline-4.1:= )
-		libedit? ( dev-libs/libedit:= )
-	)
+	readline? ( >=sys-libs/readline-4.1:= )
 	sqlite? ( >=dev-db/sqlite-3.3.8:3= )
 	ssl? ( >=dev-libs/openssl-1.1.1:= )
 	tk? (
@@ -53,33 +51,20 @@ RDEPEND="app-arch/bzip2:=
 		dev-tcltk/blt:=
 		dev-tcltk/tix
 	)
-	xml? ( >=dev-libs/expat-2.1:= )
-	!!<sys-apps/sandbox-2.21"
+	xml? ( >=dev-libs/expat-2.1:= )"
 # bluetooth requires headers from bluez
 DEPEND="${RDEPEND}
 	bluetooth? ( net-wireless/bluez )
 	test? ( app-arch/xz-utils[extra-filters(+)] )"
-# autoconf-archive needed to eautoreconf
 BDEPEND="
-	sys-devel/autoconf-archive
 	virtual/awk
 	virtual/pkgconfig
+	sys-devel/autoconf-archive
 	verify-sig? ( sec-keys/openpgp-keys-python )
 	!sys-devel/gcc[libffi(-)]"
 RDEPEND+=" !build? ( app-misc/mime-types )"
 
 VERIFY_SIG_OPENPGP_KEY_PATH=${BROOT}/usr/share/openpgp-keys/python.org.asc
-
-# large file tests involve a 2.5G file being copied (duplicated)
-CHECKREQS_DISK_BUILD=5500M
-
-pkg_pretend() {
-	use test && check-reqs_pkg_pretend
-}
-
-pkg_setup() {
-	use test && check-reqs_pkg_setup
-}
 
 src_unpack() {
 	if use verify-sig; then
@@ -163,21 +148,6 @@ src_configure() {
 		dbmliborder+="${dbmliborder:+:}gdbm"
 	fi
 
-	if use pgo; then
-		local jobs=$(makeopts_jobs "${MAKEOPTS}" "$(get_nproc)")
-		export PROFILE_TASK="-m test -j${jobs} --pgo-extended -x test_gdb -u-network"
-
-		# All of these seem to occasionally hang for PGO inconsistently
-		# They'll even hang here but be fine in src_test sometimes.
-		# bug #828535 (and related: bug #788022)
-		PROFILE_TASK+=" -x test_socket -x test_asyncio -x test_httpservers -x test_logging -x test_multiprocessing_fork -x test_xmlrpc"
-
-		if has_version "app-arch/rpm" ; then
-			# Avoid sandbox failure (attempts to write to /var/lib/rpm)
-			PROFILE_TASK+=" -x test_distutils"
-		fi
-	fi
-
 	local myeconfargs=(
 		# glibc-2.30 removes it; since we can't cleanly force-rebuild
 		# Python on glibc upgrade, remove it proactively to give
@@ -185,7 +155,6 @@ src_configure() {
 		ac_cv_header_stropts_h=no
 
 		--enable-shared
-		--without-static-libpython
 		--enable-ipv6
 		--infodir='${prefix}/share/info'
 		--mandir='${prefix}/share/man'
@@ -196,10 +165,6 @@ src_configure() {
 		--without-ensurepip
 		--with-system-expat
 		--with-system-ffi
-
-		$(use_with lto)
-		$(use_enable pgo optimizations)
-		$(use_with readline readline "$(usex libedit editline readline)")
 	)
 
 	OPT="" econf "${myeconfargs[@]}"
@@ -218,14 +183,6 @@ src_compile() {
 	# Prevent using distutils bundled by setuptools.
 	# https://bugs.gentoo.org/823728
 	export SETUPTOOLS_USE_DISTUTILS=stdlib
-
-	if use pgo ; then
-		# bug 660358
-		local -x COLUMNS=80
-		local -x PYTHONDONTWRITEBYTECODE=
-
-		addpredict /usr/lib/python3.10/site-packages
-	fi
 
 	emake CPPFLAGS= CFLAGS= LDFLAGS=
 
@@ -254,7 +211,6 @@ src_test() {
 	# bug 660358
 	local -x COLUMNS=80
 	local -x PYTHONDONTWRITEBYTECODE=
-	addpredict /usr/lib/python3.10/site-packages
 
 	local jobs=$(makeopts_jobs "${MAKEOPTS}" "$(get_nproc)")
 
@@ -284,6 +240,9 @@ src_install() {
 	local libdir=${ED}/usr/lib/python${PYVER}
 
 	emake DESTDIR="${D}" altinstall
+
+	# Remove static library
+	rm "${ED}"/usr/$(get_libdir)/libpython*.a || die
 
 	sed \
 		-e "s/\(CONFIGURE_LDFLAGS=\).*/\1/" \
@@ -315,6 +274,8 @@ src_install() {
 
 	use sqlite || rm -r "${libdir}/"{sqlite3,test/test_sqlite*} || die
 	use tk || rm -r "${ED}/usr/bin/idle${PYVER}" "${libdir}/"{idlelib,tkinter,test/test_tk*} || die
+
+	use wininst || rm "${libdir}/distutils/command/"wininst-*.exe || die
 
 	dodoc Misc/{ACKS,HISTORY,NEWS}
 

--- a/dev-lang/python/python-3.9.9-r1.ebuild
+++ b/dev-lang/python/python-3.9.9-r1.ebuild
@@ -34,6 +34,7 @@ RESTRICT="!test? ( test )"
 
 RDEPEND="app-arch/bzip2:=
 	app-arch/xz-utils:=
+	dev-lang/python-exec[python_targets_python3_9(-)]
 	dev-libs/libffi:=
 	sys-apps/util-linux:=
 	>=sys-libs/zlib-1.1.3:=

--- a/dev-python/pypy3/pypy3-7.3.7-r1.ebuild
+++ b/dev-python/pypy3/pypy3-7.3.7-r1.ebuild
@@ -30,6 +30,7 @@ RDEPEND="
 		>=dev-python/pypy3-exe-${PYPY_PV}:${PYPY_PV}[bzip2?,ncurses?]
 		>=dev-python/pypy3-exe-bin-${PYPY_PV}:${PYPY_PV}
 	)
+	dev-lang/python-exec[python_targets_pypy3(-)]
 	dev-libs/openssl:0=
 	gdbm? ( sys-libs/gdbm:0= )
 	sqlite? ( dev-db/sqlite:3= )

--- a/eclass/distutils-r1.eclass
+++ b/eclass/distutils-r1.eclass
@@ -405,7 +405,7 @@ distutils_enable_tests() {
 			test_pkg=">=dev-python/nose-1.3.7-r4"
 			;;
 		pytest)
-			test_pkg=">=dev-python/pytest-4.5.0"
+			test_pkg=">=dev-python/pytest-6.2.5-r2"
 			;;
 		setup.py)
 			;;

--- a/eclass/python-r1.eclass
+++ b/eclass/python-r1.eclass
@@ -125,7 +125,6 @@ fi
 #
 # Example value:
 # @CODE
-# dev-lang/python-exec:=
 # python_targets_python2_7? ( dev-lang/python:2.7[gdbm] )
 # python_targets_pypy? ( dev-python/pypy[gdbm] )
 # @CODE
@@ -206,12 +205,6 @@ _python_set_globals() {
 	local optflags=${flags[@]/%/(-)?}
 	local requse="|| ( ${flags[*]} )"
 	local usedep=${optflags// /,}
-
-	# 1) well, python-exec would suffice as an RDEP
-	# but no point in making this overcomplex, BDEP doesn't hurt anyone
-	# 2) python-exec should be built with all targets forced anyway
-	# but if new targets were added, we may need to force a rebuild
-	deps+=">=dev-lang/python-exec-2:=[${usedep}]"
 
 	if [[ ${PYTHON_DEPS+1} ]]; then
 		# IUSE is magical, so we can't really check it

--- a/eclass/python-single-r1.eclass
+++ b/eclass/python-single-r1.eclass
@@ -136,7 +136,6 @@ EXPORT_FUNCTIONS pkg_setup
 #
 # Example value:
 # @CODE
-# dev-lang/python-exec:=
 # python_single_target_python2_7? ( dev-lang/python:2.7[gdbm] )
 # python_single_target_pypy? ( dev-python/pypy[gdbm] )
 # @CODE
@@ -219,13 +218,8 @@ _python_single_set_globals() {
 	local deps= i PYTHON_PKG_DEP
 	for i in "${_PYTHON_SUPPORTED_IMPLS[@]}"; do
 		_python_export "${i}" PYTHON_PKG_DEP
-		# 1) well, python-exec would suffice as an RDEP
-		# but no point in making this overcomplex, BDEP doesn't hurt anyone
-		# 2) python-exec should be built with all targets forced anyway
-		# but if new targets were added, we may need to force a rebuild
 		deps+="python_single_target_${i}? (
 			${PYTHON_PKG_DEP}
-			>=dev-lang/python-exec-2:=[python_targets_${i}]
 		) "
 	done
 

--- a/eclass/python-utils-r1.eclass
+++ b/eclass/python-utils-r1.eclass
@@ -416,12 +416,18 @@ _python_export() {
 				case ${impl} in
 					python2.7)
 						PYTHON_PKG_DEP='>=dev-lang/python-2.7.5-r2:2.7';;
+					python3.8)
+						PYTHON_PKG_DEP=">=dev-lang/python-3.8.12_p1-r1:3.8";;
+					python3.9)
+						PYTHON_PKG_DEP=">=dev-lang/python-3.9.9-r1:3.9";;
+					python3.10)
+						PYTHON_PKG_DEP=">=dev-lang/python-3.10.0_p1-r1:3.10";;
 					python*)
 						PYTHON_PKG_DEP="dev-lang/python:${impl#python}";;
 					pypy)
 						PYTHON_PKG_DEP='>=dev-python/pypy-7.3.0:0=';;
 					pypy3)
-						PYTHON_PKG_DEP='>=dev-python/pypy3-7.3.7:0=';;
+						PYTHON_PKG_DEP='>=dev-python/pypy3-7.3.7-r1:0=';;
 					*)
 						die "Invalid implementation: ${impl}"
 				esac

--- a/eclass/tests/distutils-r1.sh
+++ b/eclass/tests/distutils-r1.sh
@@ -97,7 +97,7 @@ tend
 einfo distutils_enable_tests
 eindent
 BASE_IUSE="python_targets_python3_8"
-BASE_DEPS="python_targets_python3_8? ( dev-lang/python:3.8 ) >=dev-lang/python-exec-2:=[python_targets_python3_8(-)?]"
+BASE_DEPS="python_targets_python3_8? ( >=dev-lang/python-3.8.12_p1-r1:3.8 ) >=dev-lang/python-exec-2:=[python_targets_python3_8(-)?]"
 TEST_RESTRICT="!test? ( test )"
 
 einfo "empty RDEPEND"

--- a/eclass/tests/distutils-r1.sh
+++ b/eclass/tests/distutils-r1.sh
@@ -97,7 +97,7 @@ tend
 einfo distutils_enable_tests
 eindent
 BASE_IUSE="python_targets_python3_8"
-BASE_DEPS="python_targets_python3_8? ( >=dev-lang/python-3.8.12_p1-r1:3.8 ) >=dev-lang/python-exec-2:=[python_targets_python3_8(-)?]"
+BASE_DEPS="python_targets_python3_8? ( >=dev-lang/python-3.8.12_p1-r1:3.8 )"
 TEST_RESTRICT="!test? ( test )"
 
 einfo "empty RDEPEND"

--- a/eclass/tests/distutils-r1_single.sh
+++ b/eclass/tests/distutils-r1_single.sh
@@ -77,7 +77,7 @@ inherit distutils-r1
 einfo distutils_enable_tests
 eindent
 BASE_IUSE="+python_single_target_python3_8"
-BASE_DEPS="python_single_target_python3_8? ( dev-lang/python:3.8 >=dev-lang/python-exec-2:=[python_targets_python3_8] )"
+BASE_DEPS="python_single_target_python3_8? ( >=dev-lang/python-3.8.12_p1-r1:3.8 >=dev-lang/python-exec-2:=[python_targets_python3_8] )"
 TEST_RESTRICT="!test? ( test )"
 
 einfo "empty RDEPEND"

--- a/eclass/tests/distutils-r1_single.sh
+++ b/eclass/tests/distutils-r1_single.sh
@@ -77,7 +77,7 @@ inherit distutils-r1
 einfo distutils_enable_tests
 eindent
 BASE_IUSE="+python_single_target_python3_8"
-BASE_DEPS="python_single_target_python3_8? ( >=dev-lang/python-3.8.12_p1-r1:3.8 >=dev-lang/python-exec-2:=[python_targets_python3_8] )"
+BASE_DEPS="python_single_target_python3_8? ( >=dev-lang/python-3.8.12_p1-r1:3.8 )"
 TEST_RESTRICT="!test? ( test )"
 
 einfo "empty RDEPEND"


### PR DESCRIPTION
CC @gentoo/python 

The rough idea is that instead of adding python-exec deps everywhere which pollutes the depgraph and increases metadata size, we just put them into dev-lang/python and >=-require versions that have the deps.