### PR TITLE
dev-java/netty-common: restrict tests

### DIFF
--- a/dev-java/netty-common/netty-common-4.0.36-r1.ebuild
+++ b/dev-java/netty-common/netty-common-4.0.36-r1.ebuild
@@ -16,7 +16,9 @@ LICENSE="Apache-2.0"
 SLOT="0"
 KEYWORDS="~amd64 ~arm64 ~ppc64 ~x86"
 IUSE="test"
-RESTRICT="!test? ( test )"
+
+# Same test failures as before the revbump still occur. See https://bugs.gentoo.org/827221
+RESTRICT="test"
 
 CDEPEND="dev-java/commons-logging:0
 	dev-java/javassist:3


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/829823
Package-Manager: Portage-3.0.28, Repoman-3.0.3
Signed-off-by: Volkmar W. Pogatzki <gentoo@pogatzki.net>