### PR TITLE
www-apps/tt-rss: Add PHP 8.0 support and drop PHP 7.2

### DIFF
--- a/www-apps/tt-rss/tt-rss-20200922.ebuild
+++ b/www-apps/tt-rss/tt-rss-20200922.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -13,7 +13,7 @@ KEYWORDS="~amd64 ~arm ~mips ~x86"
 IUSE="+acl daemon gd +mysqli postgres"
 REQUIRED_USE="|| ( mysqli postgres )"
 
-PHP_SLOTS="7.4 7.3 7.2"
+PHP_SLOTS="7.4 7.3"
 PHP_USE="gd?,mysqli?,postgres?,curl,fileinfo,intl,json(+),pdo,unicode,xml"
 
 php_rdepend() {

--- a/www-apps/tt-rss/tt-rss-99999999.ebuild
+++ b/www-apps/tt-rss/tt-rss-99999999.ebuild
@@ -13,7 +13,7 @@ SLOT="${PV}" # Single live slot.
 IUSE="+acl daemon gd +mysqli postgres"
 REQUIRED_USE="|| ( mysqli postgres )"
 
-PHP_SLOTS="8.0 7.4 7.3 7.2"
+PHP_SLOTS="8.0 7.4 7.3"
 PHP_USE="gd?,mysqli?,postgres?,curl,fileinfo,intl,json(+),pdo,unicode,xml"
 
 php_rdepend() {

--- a/www-apps/tt-rss/tt-rss-99999999.ebuild
+++ b/www-apps/tt-rss/tt-rss-99999999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -13,7 +13,7 @@ SLOT="${PV}" # Single live slot.
 IUSE="+acl daemon gd +mysqli postgres"
 REQUIRED_USE="|| ( mysqli postgres )"
 
-PHP_SLOTS="7.4 7.3 7.2"
+PHP_SLOTS="8.0 7.4 7.3 7.2"
 PHP_USE="gd?,mysqli?,postgres?,curl,fileinfo,intl,json(+),pdo,unicode,xml"
 
 php_rdepend() {


### PR DESCRIPTION
[According to upstream](https://community.tt-rss.org/t/support-for-php-8-1/5089/13), the live Git version has supported PHP 8.0 for a while, but not 8.1 yet. I have been running my server on PHP 8.0 for a few months, without issue. Update the `-99999999` live Ebuild to include PHP 8.0 support.

Also remove the PHP 7.2 support from all versions, since PHP 7.2 is no longer in the tree, so supporting it makes Repoman unhappy.

Neither of these should require revbumps, IMHO: users of the live ebuild will update frequently anyway, and nobody should be running PHP 7.2 since it's no longer in the tree.