### PR TITLE
media-sound/strawberry: Fix URLs and remove unused dependencies

### DIFF
--- a/media-sound/strawberry/strawberry-1.0.0-r2.ebuild
+++ b/media-sound/strawberry/strawberry-1.0.0-r2.ebuild
@@ -8,12 +8,12 @@ inherit cmake flag-o-matic plocale xdg
 PLOCALES="ca cs de es fi fr hu id it ja ko nb nl pl pt_BR ru sv uk zh_CN"
 
 DESCRIPTION="Modern music player and library organizer based on Clementine and Qt"
-HOMEPAGE="https://www.strawbs.org/"
+HOMEPAGE="https://www.strawberrymusicplayer.org/"
 if [[ ${PV} == *9999* ]]; then
-	EGIT_REPO_URI="https://github.com/jonaski/strawberry.git"
+	EGIT_REPO_URI="https://github.com/strawberrymusicplayer/strawberry"
 	inherit git-r3
 else
-	SRC_URI="https://github.com/jonaski/strawberry/releases/download/${PV}/${P}.tar.xz"
+	SRC_URI="https://github.com/strawberrymusicplayer/strawberry/releases/download/${PV}/${P}.tar.xz"
 	KEYWORDS="amd64 ~ppc64 x86"
 fi
 
@@ -27,10 +27,8 @@ BDEPEND="
 	virtual/pkgconfig
 "
 COMMON_DEPEND="
-	app-crypt/qca:2[qt5(+)]
 	dev-db/sqlite:=
 	dev-libs/glib:2
-	dev-libs/libxml2
 	dev-libs/protobuf:=
 	dev-qt/qtconcurrent:5
 	dev-qt/qtcore:5
@@ -40,10 +38,8 @@ COMMON_DEPEND="
 	dev-qt/qtsql:5[sqlite]
 	dev-qt/qtwidgets:5
 	media-libs/alsa-lib
-	>=media-libs/libmygpo-qt-1.0.9[qt5(+)]
 	>=media-libs/taglib-1.11.1_p20181028
 	sys-libs/zlib
-	virtual/glu
 	x11-libs/libX11
 	cdda? ( dev-libs/libcdio:= )
 	gstreamer? (
@@ -70,10 +66,8 @@ RDEPEND="${COMMON_DEPEND}
 DEPEND="${COMMON_DEPEND}
 	>=dev-cpp/gtest-1.8.0
 	dev-libs/boost
-	dev-qt/qtopengl:5
 	dev-qt/qttest:5
 	dev-qt/qtx11extras:5
-	dev-qt/qtxml:5
 "
 
 DOCS=( Changelog README.md )


### PR DESCRIPTION
The homepage and git URL's point to the old ones that might stop working any time, they should be updated to the new ones:
Homepage: https://www.strawberrymusicplayer.org/
Git: https://github.com/strawberrymusicplayer/strawberry

The package have depends on quite few libraries that aren't required, some have never been required by strawberry and has nothing to do with strawberry at all.

qca - This is a Qt cryptographic library, strawberry does not use this, and have depended on it.
libmygpo - Strawberry does not use this, and have never depended on it.
glu - There were a couple of glu included headers in the very early versions (<= 0.3), these are long gone, there is no need for this anymore.
qtopengl - This dependency was removed in version 0.4.2. Strawberry does not need this Qt module.
libxml2 - Strawberry uses the Qt Core XML API and does not need this.
qtxml - This is the old deprecated Qt XML module. Dependency was removed in version 0.5.1, (only liblastfm used it previously), Strawberry doesn't use the old liblastfm anymore and uses the new XML functionality found in Qt Core for everything.

I didn't address this:
- gnutls, strawberry directly depends on gnutls so I'm not sure why it's not listed, but one or more of the other packages probably depends on this already since it works.
- Not sure why it depends on a patched taglib 1.11.1 from 2018 when taglib 1.12 have been available for quite some time.

Fixes https://bugs.gentoo.org/830468