### PR TITLE
net-p2p/rtorrent: Remove dependency on screen for daemonising.

### DIFF
--- a/net-p2p/rtorrent/files/rtorrent-r1.init
+++ b/net-p2p/rtorrent/files/rtorrent-r1.init
@@ -6,6 +6,7 @@ description="rTorrent BitTorrent client"
 command="/usr/bin/rtorrent"
 command_args="-o system.daemon.set=true"
 command_background=true
+command_user="${USER}"
 pidfile="/run/rtorrent.pid"
 
 depend()

--- a/net-p2p/rtorrent/files/rtorrent-r1.init
+++ b/net-p2p/rtorrent/files/rtorrent-r1.init
@@ -1,0 +1,15 @@
+#!/sbin/openrc-run
+# Distributed under the terms of the GNU General Public License v2
+
+description="rTorrent BitTorrent client"
+
+command="/usr/bin/rtorrent"
+command_args="-o system.daemon.set=true"
+command_background=true
+pidfile="/run/rtorrent.pid"
+
+depend()
+{
+   use net ypbind nis
+   after slapd mysqld postgresql
+}

--- a/net-p2p/rtorrent/files/rtorrentd_at-r1.service
+++ b/net-p2p/rtorrent/files/rtorrentd_at-r1.service
@@ -1,0 +1,17 @@
+# This configuration file is taken from the Arch wiki.
+# https://wiki.archlinux.org/title/RTorrent#Systemd_service_as_a_daemon_for_a_user
+
+[Unit]
+Description=rTorrent for %i
+After=network.target
+
+[Service]
+Type=simple
+User=%i
+Group=%i
+WorkingDirectory=/home/%i
+# Modify the next line to the absolute path for rtorrent.lock, for example
+ExecStartPre=-/bin/rm -f /home/%i/.session/rtorrent.lock
+ExecStart=/usr/bin/rtorrent -o system.daemon.set=true
+Restart=on-failure
+RestartSec=3

--- a/net-p2p/rtorrent/rtorrent-0.9.8-r1.ebuild
+++ b/net-p2p/rtorrent/rtorrent-0.9.8-r1.ebuild
@@ -59,6 +59,7 @@ src_install() {
 	default
 	doman doc/rtorrent.1
 
-	newinitd ${FILESDIR}/rtorrent-r1.init rtorrent
+	newinitd "${FILESDIR}/rtorrent-r1.init" rtorrent
+	newconfd "${FILESDIR}/rtorrentd.conf" rtorrent
 	systemd_newunit "${FILESDIR}/rtorrentd_at-r1.service" "rtorrentd@.service"
 }

--- a/net-p2p/rtorrent/rtorrent-0.9.8-r1.ebuild
+++ b/net-p2p/rtorrent/rtorrent-0.9.8-r1.ebuild
@@ -1,0 +1,64 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+inherit autotools linux-info systemd
+
+DESCRIPTION="BitTorrent Client using libtorrent"
+HOMEPAGE="https://rakshasa.github.io/rtorrent/"
+SRC_URI="http://rtorrent.net/downloads/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~x64-solaris"
+IUSE="debug selinux test xmlrpc"
+RESTRICT="!test? ( test )"
+
+COMMON_DEPEND="~net-libs/libtorrent-0.13.${PV##*.}
+	>=net-misc/curl-7.19.1
+	sys-libs/ncurses:0=
+	xmlrpc? ( dev-libs/xmlrpc-c:= )"
+RDEPEND="${COMMON_DEPEND}
+	selinux? ( sec-policy/selinux-rtorrent )
+"
+DEPEND="${COMMON_DEPEND}
+	dev-util/cppunit
+	virtual/pkgconfig"
+
+DOCS=( doc/rtorrent.rc )
+
+pkg_setup() {
+	if ! linux_config_exists || ! linux_chkconfig_present IPV6; then
+		ewarn "rtorrent will not start without IPv6 support in your kernel"
+		ewarn "without further configuration. Please set bind=0.0.0.0 or"
+		ewarn "similar in your rtorrent.rc"
+		ewarn "Upstream bug: https://github.com/rakshasa/rtorrent/issues/732"
+	fi
+}
+
+src_prepare() {
+	default
+
+	# https://github.com/rakshasa/rtorrent/issues/332
+	cp "${FILESDIR}"/rtorrent.1 "${S}"/doc/ || die
+
+	eautoreconf
+}
+
+src_configure() {
+	default
+
+	# configure needs bash or script bombs out on some null shift, bug #291229
+	CONFIG_SHELL=${BASH} econf \
+		$(use_enable debug) \
+		$(use_with xmlrpc xmlrpc-c)
+}
+
+src_install() {
+	default
+	doman doc/rtorrent.1
+
+	newinitd ${FILESDIR}/rtorrent-r1.init rtorrent
+	systemd_newunit "${FILESDIR}/rtorrentd_at-r1.service" "rtorrentd@.service"
+}


### PR DESCRIPTION
Since rtorrent version 0.9.7, there is a built-in option for daemonising the program. This means that the old method of using screen is outdated. This also means that we can remove the screen dependency by using the new daemonising method.

I have tested the new openrc-related changes on my own PC and it works fine, but I have not tested the systemd-related changes.