### PR TITLE
sys-cluster/onesis: last rites

### DIFF
--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -33,6 +33,12 @@
 
 #--- END OF EXAMPLES ---
 
+# Marco Scardovi <marco@scardovi.com> (2022-01-01)
+# Dead upstream (also sourceforge page is dead)
+# We are the only one who still supports it
+# Removing in 30 days. # Bug 830389
+sys-cluster/onesis
+
 # Florian Schmaus <flow@gentoo.org> (2022-01-04)
 # Outdated, unmaintained, and has multiple open bugs (bug #732582, bug
 # #739398, bug #756715). As discussed at


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/830389

Signed-Off-By: Marco Scardovi <marco@scardovi.com>