### PR TITLE
net-libs/libmicrohttpd: fixed missing multilib dep

### DIFF
--- a/net-libs/libmicrohttpd/libmicrohttpd-0.9.68-r1.ebuild
+++ b/net-libs/libmicrohttpd/libmicrohttpd-0.9.68-r1.ebuild
@@ -19,7 +19,7 @@ KEYWORDS="amd64 x86"
 IUSE="+epoll ssl static-libs test"
 RESTRICT="!test? ( test )"
 
-RDEPEND="ssl? ( >net-libs/gnutls-2.12.20:= )"
+RDEPEND="ssl? ( >net-libs/gnutls-2.12.20:=[${MULTILIB_USEDEP}] )"
 
 # We disable tests below because they're broken,
 # but if enabled, we'll need this.

--- a/net-libs/libmicrohttpd/libmicrohttpd-0.9.72.ebuild
+++ b/net-libs/libmicrohttpd/libmicrohttpd-0.9.72.ebuild
@@ -17,7 +17,7 @@ KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~mips ppc ppc64 ~riscv sparc x86"
 IUSE="+epoll ssl static-libs test thread-names"
 RESTRICT="!test? ( test )"
 
-RDEPEND="ssl? ( >net-libs/gnutls-2.12.20:= )"
+RDEPEND="ssl? ( >net-libs/gnutls-2.12.20:=[${MULTILIB_USEDEP}] )"
 
 DEPEND="${RDEPEND}
 	test?	( net-misc/curl[ssl?] )

--- a/net-libs/libmicrohttpd/libmicrohttpd-0.9.73.ebuild
+++ b/net-libs/libmicrohttpd/libmicrohttpd-0.9.73.ebuild
@@ -20,7 +20,7 @@ KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~mips ppc ppc64 ~riscv sparc x86"
 IUSE="+epoll ssl static-libs test thread-names"
 RESTRICT="!test? ( test )"
 
-RDEPEND="ssl? ( >net-libs/gnutls-2.12.20:= )"
+RDEPEND="ssl? ( >net-libs/gnutls-2.12.20:=[${MULTILIB_USEDEP}] )"
 # libcurl and the curl binary are used during tests on CHOST
 DEPEND="${RDEPEND}
 	test? ( net-misc/curl[ssl?] )"

--- a/net-libs/libmicrohttpd/libmicrohttpd-0.9.74.ebuild
+++ b/net-libs/libmicrohttpd/libmicrohttpd-0.9.74.ebuild
@@ -18,7 +18,7 @@ KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~riscv ~sparc 
 IUSE="+epoll ssl static-libs test +thread-names"
 RESTRICT="!test? ( test )"
 
-RDEPEND="ssl? ( >net-libs/gnutls-2.12.20:= )"
+RDEPEND="ssl? ( >net-libs/gnutls-2.12.20:=[${MULTILIB_USEDEP}] )"
 # libcurl and the curl binary are used during tests on CHOST
 DEPEND="${RDEPEND}
 	test? ( net-misc/curl[ssl?] )"

--- a/net-libs/libmicrohttpd/libmicrohttpd-0.9.75.ebuild
+++ b/net-libs/libmicrohttpd/libmicrohttpd-0.9.75.ebuild
@@ -18,7 +18,7 @@ KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~riscv ~sparc 
 IUSE="+epoll ssl static-libs test +thread-names"
 RESTRICT="!test? ( test )"
 
-RDEPEND="ssl? ( >net-libs/gnutls-2.12.20:= )"
+RDEPEND="ssl? ( >net-libs/gnutls-2.12.20:=[${MULTILIB_USEDEP}] )"
 # libcurl and the curl binary are used during tests on CHOST
 DEPEND="${RDEPEND}
 	test? ( net-misc/curl[ssl?] )"


### PR DESCRIPTION

Closes: https://bugs.gentoo.org/830555
