### PR TITLE
java-virtuals/servlet-api: remove glassfish

### DIFF
--- a/java-virtuals/servlet-api/servlet-api-2.5-r2.ebuild
+++ b/java-virtuals/servlet-api/servlet-api-2.5-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -13,10 +13,6 @@ LICENSE="public-domain"
 SLOT="${PV}"
 KEYWORDS="amd64 ~arm ppc64 x86 ~amd64-linux ~x86-linux ~x64-macos ~x64-solaris"
 
-RDEPEND="|| (
-		dev-java/tomcat-servlet-api:${SLOT}
-		dev-java/resin-servlet-api:${SLOT}
-		dev-java/glassfish-servlet-api:${SLOT}
-	)"
+RDEPEND="dev-java/tomcat-servlet-api:${SLOT}"
 
-JAVA_VIRTUAL_PROVIDES="tomcat-servlet-api-${SLOT} resin-servlet-api-${SLOT} glassfish-servlet-api-${SLOT}"
+JAVA_VIRTUAL_PROVIDES="tomcat-servlet-api-${SLOT}"


### PR DESCRIPTION
dev-java/glassfish-servlet-api:2.5 was removed years ago
Bug: https://bugs.gentoo.org/830680
Package-Manager: Portage-3.0.28, Repoman-3.0.3
Signed-off-by: Volkmar W. Pogatzki <gentoo@pogatzki.net>