### PR TITLE
dev-java/bcel: allow test on ppc64

### DIFF
--- a/dev-java/bcel/bcel-6.5.0-r2.ebuild
+++ b/dev-java/bcel/bcel-6.5.0-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # Skeleton command:
@@ -31,15 +31,13 @@ DEPEND="
 	>=virtual/jdk-1.8:*
 	!arm? (
 		!arm64? (
-			!ppc64? (
-				test? (
-					dev-java/commons-collections:4
-					dev-java/commons-io:1
-					dev-java/commons-lang:3.6
-					dev-java/jna:4
-					dev-java/jmh-core:0
-					dev-java/oracle-javamail:0
-				)
+			test? (
+				dev-java/commons-collections:4
+				dev-java/commons-io:1
+				dev-java/commons-lang:3.6
+				dev-java/jna:4
+				dev-java/jmh-core:0
+				dev-java/oracle-javamail:0
 			)
 		)
 	)


### PR DESCRIPTION
With dev-java/jmh-core keyworded on ppc64 it
shoulkd now be possible to run the tests.

Package-Manager: Portage-3.0.28, Repoman-3.0.3
RepoMan-Options: --force
Signed-off-by: Volkmar W. Pogatzki <gentoo@pogatzki.net>