### PR TITLE
net-analyzer/monitoring-plugins: fix check_disk on btrfs

### DIFF
--- a/net-analyzer/monitoring-plugins/files/monitoring-plugins-fix-check-disk-on-btrfs.patch
+++ b/net-analyzer/monitoring-plugins/files/monitoring-plugins-fix-check-disk-on-btrfs.patch
@@ -1,0 +1,20 @@
+https://bugs.gentoo.org/830249
+https://github.com/monitoring-plugins/monitoring-plugins/issues/1357
+https://github.com/monitoring-plugins/monitoring-plugins/commit/e17c1e9ed95b8b9681dccd5a909ac5a02a04416c
+
+diff --git a/plugins/check_disk.c b/plugins/check_disk.c
+index 844e625f..a2735195 100644
+--- a/plugins/check_disk.c
++++ b/plugins/check_disk.c
+@@ -1068,10 +1068,7 @@ get_stats (struct parameter_list *p, struct fs_usage *fsp) {
+ 
+ void
+ get_path_stats (struct parameter_list *p, struct fs_usage *fsp) {
+-  /* 2007-12-08 - Workaround for Gnulib reporting insanely high available
+-  * space on BSD (the actual value should be negative but fsp->fsu_bavail
+-  * is unsigned) */
+-  p->available = fsp->fsu_bavail > fsp->fsu_bfree ? 0 : fsp->fsu_bavail;
++  p->available = fsp->fsu_bavail;
+   p->available_to_root = fsp->fsu_bfree;
+   p->used = fsp->fsu_blocks - fsp->fsu_bfree;
+   if (freespace_ignore_reserved) {

--- a/net-analyzer/monitoring-plugins/monitoring-plugins-2.3.1-r1.ebuild
+++ b/net-analyzer/monitoring-plugins/monitoring-plugins-2.3.1-r1.ebuild
@@ -1,0 +1,108 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="8"
+
+inherit flag-o-matic
+
+DESCRIPTION="50+ standard plugins for Icinga, Naemon, Nagios, Shinken, Sensu"
+HOMEPAGE="https://www.monitoring-plugins.org/"
+SRC_URI="https://www.monitoring-plugins.org/download/${P}.tar.gz"
+
+LICENSE="GPL-3"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~sparc ~x86"
+IUSE="curl gnutls ipv6 ldap mysql dns fping game postgres radius samba snmp ssh +ssl"
+
+# Most of the plugins use automagic dependencies, i.e. the plugin will
+# get built if the binary it uses is installed. For example, check_snmp
+# will be built only if snmpget from net-analyzer/net-snmp[-minimal] is
+# installed. End result: most of our runtime dependencies are required
+# at build time as well.
+#
+# REAL_DEPEND contains the dependencies that are actually needed to
+# build. DEPEND contains those plus the automagic dependencies.
+#
+REAL_DEPEND="dev-lang/perl
+	curl? (
+		dev-libs/uriparser
+		net-misc/curl
+	)
+	ldap? ( net-nds/openldap )
+	mysql? ( || ( dev-db/mysql-connector-c dev-db/mariadb-connector-c ) )
+	postgres? ( dev-db/postgresql:= )
+	ssl? (
+		!gnutls? (
+			dev-libs/openssl:0=
+		)
+		gnutls? ( net-libs/gnutls )
+	)
+	radius? ( net-dialup/freeradius-client )"
+
+DEPEND="${REAL_DEPEND}
+	dns? ( net-dns/bind-tools )
+	game? ( games-util/qstat )
+	fping? ( net-analyzer/fping )
+	samba? ( net-fs/samba )
+	ssh? ( net-misc/openssh )
+	snmp? ( dev-perl/Net-SNMP
+			net-analyzer/net-snmp[-minimal] )"
+
+# Basically everything collides with nagios-plugins.
+RDEPEND="${DEPEND}
+	acct-group/nagios
+	acct-user/nagios
+	!net-analyzer/nagios-plugins"
+
+# At least one test is interactive.
+RESTRICT="test"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-fix-check-disk-on-btrfs.patch" #830249
+)
+
+src_configure() {
+	append-flags -fno-strict-aliasing
+
+	# Use an array to prevent econf from mangling the ping args.
+	local myconf=()
+
+	if use ssl; then
+		myconf+=( $(use_with !gnutls openssl /usr)
+				  $(use_with gnutls gnutls /usr) )
+	else
+		myconf+=( --without-openssl )
+		myconf+=( --without-gnutls )
+	fi
+
+	# The autodetection for these two commands can hang if localhost is
+	# down or ICMP traffic is filtered. Bug #468296.
+	myconf+=( --with-ping-command="/bin/ping -4 -n -U -w %d -c %d %s" )
+
+	if use ipv6; then
+		myconf+=( --with-ping6-command="/bin/ping -6 -n -U -w %d -c %d %s" )
+	fi
+
+	econf \
+		$(use_with curl libcurl) \
+		$(use_with curl uriparser) \
+		$(use_with mysql) \
+		$(use_with ipv6) \
+		$(use_with ldap) \
+		$(use_with postgres pgsql /usr) \
+		$(use_with radius) \
+		"${myconf[@]}" \
+		--libexecdir="/usr/$(get_libdir)/nagios/plugins" \
+		--sysconfdir="/etc/nagios"
+}
+
+DOCS=( ACKNOWLEDGEMENTS AUTHORS CODING ChangeLog FAQ \
+		NEWS README REQUIREMENTS SUPPORT THANKS )
+
+pkg_postinst() {
+	elog "This ebuild has a number of USE flags that determine what you"
+	elog "are able to monitor. Depending on what you want to monitor, some"
+	elog "or all of these USE flags need to be set."
+	elog
+	elog "The plugins are installed in ${EROOT}/usr/$(get_libdir)/nagios/plugins"
+}


### PR DESCRIPTION
Added the btrfs patch from upstream and removed the mariadb patch (fixed in https://github.com/monitoring-plugins/monitoring-plugins/pull/1522)

```
--- monitoring-plugins-2.3.1.ebuild     2021-07-27 10:50:35.947755047 +0000
+++ monitoring-plugins-2.3.1-r1.ebuild  2022-01-08 14:05:05.423394368 +0000
@@ -1,7 +1,7 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI="8"
 
 inherit flag-o-matic
 
@@ -11,7 +11,7 @@
 
 LICENSE="GPL-3"
 SLOT="0"
-KEYWORDS="amd64 ~arm ~arm64 sparc x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~sparc ~x86"
 IUSE="curl gnutls ipv6 ldap mysql dns fping game postgres radius samba snmp ssh +ssl"
 
 # Most of the plugins use automagic dependencies, i.e. the plugin will
@@ -57,7 +57,9 @@
 # At least one test is interactive.
 RESTRICT="test"
 
-PATCHES=( "${FILESDIR}/define-own-mysql-port-constant.patch" )
+PATCHES=(
+       "${FILESDIR}/${PN}-fix-check-disk-on-btrfs.patch" #830249
+)
 
 src_configure() {
        append-flags -fno-strict-aliasing
```