### PR TITLE
x11-terms/{st,st-terminfo}: add proxied maintainer

### DIFF
--- a/x11-terms/st-terminfo/metadata.xml
+++ b/x11-terms/st-terminfo/metadata.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
+	<maintainer type="person" proxied="yes">
+		<email>erkiferenc@gmail.com</email>
+		<name>Ferenc Erki</name>
+	</maintainer>
 	<maintainer type="person">
 		<email>gyakovlev@gentoo.org</email>
 		<name>Georgy Yakovlev</name>

--- a/x11-terms/st/metadata.xml
+++ b/x11-terms/st/metadata.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
+	<maintainer type="person" proxied="yes">
+		<email>erkiferenc@gmail.com</email>
+		<name>Ferenc Erki</name>
+	</maintainer>
 	<maintainer type="person">
 		<email>gyakovlev@gentoo.org</email>
 		<name>Georgy Yakovlev</name>

--- a/x11-terms/st/metadata.xml
+++ b/x11-terms/st/metadata.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
 	<maintainer type="person">
-			<email>gyakovlev@gentoo.org</email>
-			<name>Georgy Yakovlev</name>
+		<email>gyakovlev@gentoo.org</email>
+		<name>Georgy Yakovlev</name>
 	</maintainer>
 </pkgmetadata>


### PR DESCRIPTION
This PR is an attempt to add myself as proxied maintainer of x11-terms/st and x11-terms/st-terminfo (as briefly discussed with @gyakovlev via IRC). There's also a minor indent fix on a separate commit - take it or leave it :)

Please review and merge, or let me know how to improve it further.