### PR TITLE
dev-java/jackrabbit-webdav-2.10.1: Fix tests; use HTTPS for HOMEPAGE

### DIFF
--- a/dev-java/jackrabbit-webdav/jackrabbit-webdav-2.10.1-r2.ebuild
+++ b/dev-java/jackrabbit-webdav/jackrabbit-webdav-2.10.1-r2.ebuild
@@ -1,0 +1,51 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+JAVA_PKG_IUSE="doc source test"
+JAVA_TESTING_FRAMEWORKS="junit-4"
+
+inherit java-pkg-2 java-pkg-simple
+
+MY_PN="${PN/-*/}"
+
+DESCRIPTION="Fully conforming implementation of the JRC API (specified in JSR 170 and 283)"
+HOMEPAGE="https://jackrabbit.apache.org/"
+SRC_URI="mirror://apache/${MY_PN}/${PV}/${MY_PN}-${PV}-src.zip"
+
+LICENSE="Apache-2.0"
+SLOT="0"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~x86"
+
+S="${WORKDIR}/${MY_PN}-${PV}/${PN}"
+
+CP_DEPEND="dev-java/bndlib:0
+	dev-java/slf4j-api:0
+	dev-java/slf4j-nop:0
+	dev-java/commons-httpclient:3
+	java-virtuals/servlet-api:2.3"
+
+DEPEND=">=virtual/jdk-1.8:*
+	${CP_DEPEND}"
+
+RDEPEND=">=virtual/jre-1.8:*
+	${CP_DEPEND}"
+
+BDEPEND="app-arch/unzip"
+
+JAVA_SRC_DIR="src/main/java"
+JAVA_RESOURCE_DIRS=( "src/main/resources" )
+
+JAVA_TEST_GENTOO_CLASSPATH="junit-4"
+JAVA_TEST_SRC_DIR="src/test/java"
+JAVA_TEST_RESOURCE_DIRS=( "src/test/resources" )
+
+src_test() {
+	# Run only tests that would be executed by Maven as in ${S}/pom.xml:79
+	JAVA_TEST_RUN_ONLY=$(find "${JAVA_TEST_SRC_DIR}" -name "*TestAll.java" \
+		-exec realpath --relative-to="${JAVA_TEST_SRC_DIR}" {} \;)
+	JAVA_TEST_RUN_ONLY="${JAVA_TEST_RUN_ONLY//.java}"
+	JAVA_TEST_RUN_ONLY="${JAVA_TEST_RUN_ONLY//\//.}"
+	java-pkg-simple_src_test
+}


### PR DESCRIPTION
<https://bugs.gentoo.org/804594> is caused by tests being compiled with `servlet-api-4.0`, which is incompatible with the test code, instead of the supposed version `servlet-api-2.3`. This is because `servlet-api-4.0` is a transitive dependency of `dev-java/jackrabbit-webdav`, as suggested by the classpath generated by `java-ant-2.eclass` shown in `eclass-debug.log`:

<details>
<summary>eclass-debug.log snippet with java-ant-2.eclass showing classpath</summary>

```
Calling ant (GENTOO_VM: openjdk-8): -Dnoget=true -Dmaven.mode.offline=true -Dbuild.sysclasspath=ignore -DJunit.present=true -Dgentoo.classpath=/usr/share/bndlib/lib/bndlib.jar:/usr/share/libg/lib/libg.jar:/usr/share/osgi-compendium/lib/osgi-compendium.jar:/usr/share/osgi-core-api/lib/osgi-core-api.jar:/usr/share/osgi-enterprise-api/lib/osgi-enterprise-api.jar:/usr/share/glassfish-persistence/lib/glassfish-persistence.jar:/usr/share/osgi-foundation/lib/org.osgi.foundation.jar:/usr/share/tomcat-servlet-api-4.0/lib/servlet-api.jar:/usr/share/tomcat-servlet-api-4.0/lib/el-api.jar:/usr/share/tomcat-servlet-api-4.0/lib/jsp-api.jar:/usr/share/tomcat-servlet-api-2.5/lib/el-api.jar:/usr/share/tomcat-servlet-api-2.5/lib/jsp-api.jar:/usr/share/tomcat-servlet-api-2.5/lib/servlet-api.jar:/usr/share/commons-httpclient-3/lib/commons-httpclient.jar:/usr/share/commons-codec/lib/commons-codec.jar:/usr/share/commons-logging/lib/commons-logging.jar:/usr/share/commons-logging/lib/commons-logging-api.jar:/usr/share/commons-logging/lib/commons-logging-adapters.jar:/usr/share/log4j/lib/log4j.jar:/usr/share/tomcat-servlet-api-2.3/lib/servlet.jar:/usr/share/slf4j-api/lib/slf4j-api.jar:/usr/share/slf4j-nop/lib/slf4j-nop.jar:/usr/share/slf4j-api/lib/slf4j-api.jar:/usr/share/ant-junit/lib/ant-junit.jar:/usr/share/junit-4/lib/junit.jar:/usr/share/junit/lib/junit.jar:/usr/share/hamcrest-core-1.3/lib/hamcrest-core.jar -f
build.xml
test
```

</details>

Based on my understanding, when JVM searches for a class, it traverses the classpath in the declaration order of path elements.  Thus, if `servlet-api-4.0` is declared earlier than `servlet-api-2.3` in the classpath, it will be picked up, hence the incorrect version is used to compile the test classes.

`java-ant-2.eclass` seems to generate the classpath by doing a [DFS](https://en.wikipedia.org/wiki/Depth-first_search) traversal in the dependency tree of the package.  A succinct explanation of this behavior is that transitive dependencies (e.g. `servlet-api-4.0`) might show up in the classpath earlier than some direct dependencies (including `servlet-api-2.3`).

`java-pkg-simple.eclass`, on the other hand, does a [BFS](https://en.wikipedia.org/wiki/Breadth-first_search) traversal to build the classpath, which ensures all direct dependencies appear before any transitive dependencies, so using `java-pkg-simple.eclass` *magically* solved the problem.

<details>
<summary>eclass-debug.log snippet with java-pkg-simple.eclass showing classpath</summary>

```
java-pkg_getjars: entering function, parameters: --with-dependencies bndlib,slf4j-api,slf4j-nop,commons-httpclient-3,servlet-api-2.3
bndlib,slf4j-api,slf4j-nop,commons-httpclient-3,servlet-api-2.3:/usr/share/bndlib/lib/bndlib.jar:/usr/share/slf4j-api/lib/slf4j-api.jar:/usr/share/slf4j-nop/lib/slf4j-nop.jar:/usr/share/commons-httpclient-3/lib/commons-httpclient.jar:/usr/share/tomcat-servlet-api-2.3/lib/servlet.jar:/usr/share/libg/lib/libg.jar:/usr/share/osgi-compendium/lib/osgi-compendium.jar:/usr/share/osgi-core-api/lib/osgi-core-api.jar:/usr/share/osgi-enterprise-api/lib/osgi-enterprise-api.jar:/usr/share/glassfish-persistence/lib/glassfish-persistence.jar:/usr/share/tomcat-servlet-api-2.5/lib/el-api.jar:/usr/share/tomcat-servlet-api-2.5/lib/jsp-api.jar:/usr/share/tomcat-servlet-api-2.5/lib/servlet-api.jar:/usr/share/commons-codec/lib/commons-codec.jar:/usr/share/commons-logging/lib/commons-logging.jar:/usr/share/commons-logging/lib/commons-logging-api.jar:/usr/share/commons-logging/lib/commons-logging-adapters.jar:/usr/share/osgi-foundation/lib/org.osgi.foundation.jar:/usr/share/tomcat-servlet-api-4.0/lib/servlet-api.jar:/usr/share/tomcat-servlet-api-4.0/lib/el-api.jar:/usr/share/tomcat-servlet-api-4.0/lib/jsp-api.jar:/usr/share/log4j/lib/log4j.jar
```

</details>

Unfortunately, this means that fixing the bug relies on undocumented implementation detail of `java-pkg-simple.eclass`, which is discouraged in general.  **The same bug could resurface in the future if `java-pkg-simple.eclass` switches to DFS for building the classpath.**

However, using `java-pkg-simple.eclass` still has other benefits.  The `build.xml` used to build this package with `java-ant-2.eclass` is not provided by the upstream; instead, it is a Gentoo custom `build.xml` inside `FILESDIR`.  So, switching to `java-pkg-simple.eclass` eliminates the need to maintain the custom `build.xml`.

Neither patch in `-r1` would be applied because both of them only modify test sources under `src/test/java`, and the tests still pass without them.  In fact, `jackrabbit-webdav-2.10.1-OutputContextImplTest.java.patch` would actually do more harm than good since the methods it would add have the `@Override` annotation but do not exist in `servlet-api-2.3`, leading to new compiler errors.