### PR TITLE
dev-java/jna-5.10.0: DEPEND on x11-libs/libXt

### DIFF
--- a/dev-java/jna/jna-5.10.0.ebuild
+++ b/dev-java/jna/jna-5.10.0.ebuild
@@ -35,6 +35,7 @@ DEPEND="
 		dev-java/reflections:0
 	)
 	${CDEPEND}
+	x11-libs/libXt
 "
 
 RDEPEND="


### PR DESCRIPTION
Resolves <https://bugs.gentoo.org/830812>