### PR TITLE
dev-java/netty-buffer: inherit check-reqs

### DIFF
--- a/dev-java/netty-buffer/netty-buffer-4.0.36-r1.ebuild
+++ b/dev-java/netty-buffer/netty-buffer-4.0.36-r1.ebuild
@@ -10,7 +10,7 @@ JAVA_PKG_IUSE="doc source test"
 MAVEN_ID="io.netty:netty-buffer:4.0.36.Final"
 JAVA_TESTING_FRAMEWORKS="junit-4"
 
-inherit java-pkg-2 java-pkg-simple
+inherit java-pkg-2 java-pkg-simple check-reqs
 
 DESCRIPTION="Async event-driven framework for high performance network applications"
 HOMEPAGE="https://netty.io/"


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/830814
Package-Manager: Portage-3.0.28, Repoman-3.0.3
Signed-off-by: Volkmar W. Pogatzki <gentoo@pogatzki.net>