### PR TITLE
riscv: keyword app-emulation/qemu

### DIFF
--- a/app-emulation/qemu/qemu-6.2.0-r3.ebuild
+++ b/app-emulation/qemu/qemu-6.2.0-r3.ebuild
@@ -23,7 +23,7 @@ if [[ ${PV} = *9999* ]]; then
 	SRC_URI=""
 else
 	SRC_URI="https://download.qemu.org/${P}.tar.xz"
-	KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~riscv ~x86"
 fi
 
 DESCRIPTION="QEMU + Kernel-based Virtual Machine userland tools"

--- a/app-emulation/spice/spice-0.15.0.ebuild
+++ b/app-emulation/spice/spice-0.15.0.ebuild
@@ -13,7 +13,7 @@ SRC_URI+=" https://dev.gentoo.org/~sam/distfiles/${CATEGORY}/${PN}/${P}-pthread-
 
 LICENSE="LGPL-2.1"
 SLOT="0"
-KEYWORDS="~amd64 ~arm64 ~ppc64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="lz4 sasl smartcard static-libs gstreamer test"
 
 RESTRICT="!test? ( test )"

--- a/dev-lang/orc/orc-0.4.31.ebuild
+++ b/dev-lang/orc/orc-0.4.31.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ SRC_URI="https://gstreamer.freedesktop.org/src/${PN}/${P}.tar.xz"
 
 LICENSE="BSD BSD-2"
 SLOT="0"
-KEYWORDS="amd64 arm arm64 ~hppa ppc ppc64 x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+KEYWORDS="amd64 arm arm64 ~hppa ppc ppc64 ~riscv x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 RESTRICT="!test? ( test )"
 IUSE="gtk-doc static-libs test"
 

--- a/dev-libs/capstone/capstone-4.0.2-r2.ebuild
+++ b/dev-libs/capstone/capstone-4.0.2-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -14,7 +14,7 @@ SRC_URI="https://github.com/aquynh/${PN}/archive/${PV/_rc/-rc}.tar.gz -> ${P}.ta
 
 LICENSE="BSD"
 SLOT="0/4" # libcapstone.so.4
-KEYWORDS="amd64 ~arm ~arm64 x86"
+KEYWORDS="amd64 ~arm ~arm64 ~riscv x86"
 
 # A few disassembly outputs need an update
 RESTRICT="test"

--- a/media-libs/virglrenderer/virglrenderer-0.9.1.ebuild
+++ b/media-libs/virglrenderer/virglrenderer-0.9.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="7"
@@ -10,7 +10,7 @@ if [[ ${PV} == "9999" ]] ; then
 	inherit git-r3
 else
 	SRC_URI="https://gitlab.freedesktop.org/virgl/${PN}/-/archive/${P}/${PN}-${P}.tar.gz -> ${P}.tar.gz"
-	KEYWORDS="~amd64 ~arm64 ~x86"
+	KEYWORDS="~amd64 ~arm64 ~riscv ~x86"
 fi
 
 DESCRIPTION="library used implement a virtual 3D GPU used by qemu"

--- a/profiles/arch/riscv/package.use.mask
+++ b/profiles/arch/riscv/package.use.mask
@@ -6,6 +6,7 @@
 app-emulation/qemu xen
 # untested useflag: rbd glusterfs
 app-emulation/qemu rbd glusterfs
+sys-fs/multipath-tools rbd
 
 # Georgy Yakovlev <gyakovlev@gentoo.org> (2022-01-16)
 # requires sys-apps/dbus-broker, which is keyworded here.

--- a/profiles/arch/riscv/package.use.mask
+++ b/profiles/arch/riscv/package.use.mask
@@ -1,6 +1,12 @@
 # Copyright 2019-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Yongxinag Liang <tanekliang@gmail.com> (2022-01-09)
+# app-emulation/xen-tools doesn't support riscv yet
+app-emulation/qemu xen
+# untested useflag: rbd glusterfs
+app-emulation/qemu rbd glusterfs
+
 # Georgy Yakovlev <gyakovlev@gentoo.org> (2022-01-16)
 # requires sys-apps/dbus-broker, which is keyworded here.
 sys-apps/systemd -hostnamed-fallback

--- a/sys-apps/usbredir/usbredir-0.9.0.ebuild
+++ b/sys-apps/usbredir/usbredir-0.9.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -13,7 +13,7 @@ SRC_URI="https://gitlab.freedesktop.org/spice/${PN}/-/archive/${P}/${PN}-${P}.ta
 
 LICENSE="GPL-2 LGPL-2.1"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 ~ia64 ppc ppc64 ~sparc x86"
+KEYWORDS="~alpha amd64 arm arm64 ~ia64 ppc ppc64 ~riscv ~sparc x86"
 IUSE="static-libs"
 
 RDEPEND="virtual/libusb:1"

--- a/sys-firmware/edk2-ovmf/edk2-ovmf-202105-r2.ebuild
+++ b/sys-firmware/edk2-ovmf/edk2-ovmf-202105-r2.ebuild
@@ -31,7 +31,7 @@ SRC_URI="
 
 LICENSE="BSD-2 MIT"
 SLOT="0"
-KEYWORDS="amd64 arm64 ~ppc ppc64 x86"
+KEYWORDS="amd64 arm64 ~ppc ppc64 ~riscv x86"
 
 IUSE="+binary"
 REQUIRED_USE+="

--- a/sys-firmware/ipxe/ipxe-1.21.1.ebuild
+++ b/sys-firmware/ipxe/ipxe-1.21.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -14,7 +14,7 @@ S="${WORKDIR}/${P}/src"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~alpha amd64 ~arm arm64 ~hppa ~ia64 ~mips ~ppc ppc64 x86"
+KEYWORDS="~alpha amd64 ~arm arm64 ~hppa ~ia64 ~mips ~ppc ppc64 ~riscv x86"
 IUSE="+binary efi ipv6 iso lkrn +qemu undi usb vmware"
 REQUIRED_USE="!amd64? ( !x86? ( binary ) )"
 

--- a/sys-firmware/seabios/seabios-1.14.0-r2.ebuild
+++ b/sys-firmware/seabios/seabios-1.14.0-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="7"
@@ -20,7 +20,7 @@ if [[ ${PV} == *9999* || -n "${EGIT_COMMIT}" ]] ; then
 	EGIT_REPO_URI="git://git.seabios.org/seabios.git"
 	inherit git-r3
 else
-	KEYWORDS="~alpha amd64 ~arm arm64 ~hppa ~ia64 ~m68k ~mips ppc ppc64 ~s390 ~sparc x86"
+	KEYWORDS="~alpha amd64 ~arm arm64 ~hppa ~ia64 ~m68k ~mips ppc ppc64 ~riscv ~s390 ~sparc x86"
 
 	SRC_URI="
 		!binary? ( https://www.seabios.org/downloads/${P}.tar.gz )

--- a/sys-firmware/sgabios/sgabios-0.1_pre10.ebuild
+++ b/sys-firmware/sgabios/sgabios-0.1_pre10.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -16,7 +16,7 @@ S="${WORKDIR}/sgabios-a85446a"
 
 LICENSE="Apache-2.0"
 SLOT="0"
-KEYWORDS="~alpha amd64 ~arm arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ppc64 ~s390 ~sparc x86"
+KEYWORDS="~alpha amd64 ~arm arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ppc64 ~riscv ~s390 ~sparc x86"
 IUSE="+binary"
 REQUIRED_USE="!amd64? ( !x86? ( binary ) )"
 

--- a/sys-fs/multipath-tools/multipath-tools-0.8.8.ebuild
+++ b/sys-fs/multipath-tools/multipath-tools-0.8.8.ebuild
@@ -12,7 +12,7 @@ SRC_URI+=" https://dev.gentoo.org/~sam/distfiles/${CATEGORY}/${PN}/${PN}-0.8.8-n
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~ia64 ~ppc ~ppc64 ~x86"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~ia64 ~ppc ~ppc64 ~riscv ~x86"
 IUSE="systemd rbd test"
 RESTRICT="!test? ( test )"
 


### PR DESCRIPTION
# qemu user

These architectures test [busybox](https://kos.to/linux-user-busyboxes-0.1.tar.xz) from [qemu-testing](https://wiki.qemu.org/Testing) in qemu user mode and can work:
```
arm armeb cris i386 m68k mips mipsel ppc ppc64abi32 sh4 sh4eb sparc32plus
```

test faild:
```
aarch64 alpha microblazeel mips64 mips64el ppc64 riscv64 s390x sparc sparc64 x86_64 xtensa xtensaeb
```

# qemu system

Tested qemu-systemd-x86_6 based on gentoo amd64 stage3 and [crowz openbox](https://archiveos.org/tag/openbox/) also works

