### PR TITLE
media-gfx/gimp: 9999 fix fail due to migration from gtk-doc to gi-docgen

### DIFF
--- a/media-gfx/gimp/gimp-2.99.6-r1.ebuild
+++ b/media-gfx/gimp/gimp-2.99.6-r1.ebuild
@@ -30,6 +30,7 @@ RESTRICT="!test? ( test )"
 COMMON_DEPEND="
 	>=app-text/poppler-0.90.1[cairo]
 	>=app-text/poppler-data-0.4.9
+	>=dev-libs/appstream-glib-0.7.16
 	>=dev-libs/atk-2.34.1
 	>=dev-libs/glib-2.62.6:2
 	>=dev-libs/json-glib-1.4.4
@@ -51,8 +52,8 @@ COMMON_DEPEND="
 	sys-libs/zlib
 	virtual/jpeg
 	>=x11-libs/cairo-1.16.0
-	>=x11-libs/gdk-pixbuf-2.40.0:2
-	>=x11-libs/gtk+-3.24.16:3
+	>=x11-libs/gdk-pixbuf-2.40.0:2[introspection]
+	>=x11-libs/gtk+-3.24.16:3[introspection]
 	x11-libs/libXcursor
 	>=x11-libs/pango-1.44.7
 	aalib? ( media-libs/aalib )
@@ -92,7 +93,6 @@ RDEPEND="
 DEPEND="
 	${COMMON_DEPEND}
 	>=dev-lang/perl-5.30.3
-	>=dev-libs/appstream-glib-0.7.16
 	dev-util/gdbus-codegen
 	dev-util/gtk-update-icon-cache
 	>=dev-util/intltool-0.51.0

--- a/media-gfx/gimp/gimp-2.99.8.ebuild
+++ b/media-gfx/gimp/gimp-2.99.8.ebuild
@@ -30,6 +30,7 @@ RESTRICT="!test? ( test )"
 COMMON_DEPEND="
 	>=app-text/poppler-0.90.1[cairo]
 	>=app-text/poppler-data-0.4.9
+	>=dev-libs/appstream-glib-0.7.16
 	>=dev-libs/atk-2.34.1
 	>=dev-libs/glib-2.68.0:2
 	>=dev-libs/json-glib-1.4.4
@@ -51,8 +52,8 @@ COMMON_DEPEND="
 	sys-libs/zlib
 	virtual/jpeg
 	>=x11-libs/cairo-1.16.0
-	>=x11-libs/gdk-pixbuf-2.40.0:2
-	>=x11-libs/gtk+-3.24.16:3
+	>=x11-libs/gdk-pixbuf-2.40.0:2[introspection]
+	>=x11-libs/gtk+-3.24.16:3[introspection]
 	x11-libs/libXcursor
 	>=x11-libs/pango-1.44.7
 	aalib? ( media-libs/aalib )
@@ -92,7 +93,6 @@ RDEPEND="
 DEPEND="
 	${COMMON_DEPEND}
 	>=dev-lang/perl-5.30.3
-	>=dev-libs/appstream-glib-0.7.16
 	dev-util/gdbus-codegen
 	dev-util/gtk-update-icon-cache
 	>=dev-util/intltool-0.51.0

--- a/media-gfx/gimp/gimp-9999.ebuild
+++ b/media-gfx/gimp/gimp-9999.ebuild
@@ -38,10 +38,10 @@ COMMON_DEPEND="
 	dev-libs/libxslt
 	>=gnome-base/librsvg-2.40.21:2
 	>=media-gfx/mypaint-brushes-2.0.2:=
-	>=media-libs/babl-0.1.86[introspection,lcms,vala?]
+	>=media-libs/babl-0.1.88[introspection,lcms,vala?]
 	>=media-libs/fontconfig-2.12.6
 	>=media-libs/freetype-2.10.2
-	>=media-libs/gegl-0.4.32:0.4[cairo,introspection,lcms,vala?]
+	>=media-libs/gegl-0.4.34:0.4[cairo,introspection,lcms,vala?]
 	>=media-libs/gexiv2-0.10.10
 	>=media-libs/harfbuzz-2.6.5:=
 	>=media-libs/lcms-2.9:2
@@ -101,10 +101,7 @@ DEPEND="
 	>=sys-devel/automake-1.11
 	>=sys-devel/gettext-0.21
 	>=sys-devel/libtool-2.4.6
-	doc? (
-		>=dev-util/gtk-doc-1.32
-		dev-util/gtk-doc-am
-	)
+	doc? ( dev-util/gi-docgen )
 	vala? ( $(vala_depend) )
 "
 
@@ -131,14 +128,6 @@ src_prepare() {
 
 	sed -i -e 's/== "xquartz"/= "xquartz"/' configure.ac || die #494864
 	sed 's:-DGIMP_DISABLE_DEPRECATED:-DGIMP_protect_DISABLE_DEPRECATED:g' -i configure.ac || die #615144
-
-	# Fix checking of gtk-doc.make if USE="-doc" like autogen.sh
-	# USE="doc" is currently broken for gimp-9999 due to absence of appropriate *.m4 file
-	if ! use doc ; then
-		echo "EXTRA_DIST = missing-gtk-doc" > gtk-doc.make
-		sed -i -e "/CLEANFILES/s/^/#/g" \
-		"${S}"/devel-docs/{libgimp,libgimpbase,libgimpcolor,libgimpconfig,libgimpmath,libgimpmodule,libgimpthumb,libgimpwidgets}/Makefile.am || die
-	fi
 
 	gnome2_src_prepare  # calls eautoreconf
 
@@ -184,7 +173,7 @@ src_configure() {
 		$(use_enable cpu_flags_ppc_altivec altivec)
 		$(use_enable cpu_flags_x86_mmx mmx)
 		$(use_enable cpu_flags_x86_sse sse)
-		$(use_enable doc gtk_doc)
+		$(use_enable doc gi-docgen)
 		$(use_enable vector-icons)
 		$(use_with aalib aa)
 		$(use_with alsa)

--- a/media-gfx/gimp/gimp-9999.ebuild
+++ b/media-gfx/gimp/gimp-9999.ebuild
@@ -31,6 +31,7 @@ RESTRICT="!test? ( test )"
 COMMON_DEPEND="
 	>=app-text/poppler-0.90.1[cairo]
 	>=app-text/poppler-data-0.4.9
+	>=dev-libs/appstream-glib-0.7.16
 	>=dev-libs/atk-2.34.1
 	>=dev-libs/glib-2.68.0:2
 	>=dev-libs/json-glib-1.4.4
@@ -52,8 +53,8 @@ COMMON_DEPEND="
 	sys-libs/zlib
 	virtual/jpeg
 	>=x11-libs/cairo-1.16.0
-	>=x11-libs/gdk-pixbuf-2.40.0:2
-	>=x11-libs/gtk+-3.24.16:3
+	>=x11-libs/gdk-pixbuf-2.40.0:2[introspection]
+	>=x11-libs/gtk+-3.24.16:3[introspection]
 	x11-libs/libXcursor
 	>=x11-libs/pango-1.44.7
 	aalib? ( media-libs/aalib )
@@ -93,7 +94,6 @@ RDEPEND="
 DEPEND="
 	${COMMON_DEPEND}
 	>=dev-lang/perl-5.30.3
-	>=dev-libs/appstream-glib-0.7.16
 	dev-util/gdbus-codegen
 	dev-util/gtk-update-icon-cache
 	>=dev-util/intltool-0.51.0


### PR DESCRIPTION
Fixes `media-gfx/gimp-9999` with `USE="doc"` due to changes of appropriate dependencies.
Closes: https://bugs.gentoo.org/830429

Additional DEPEND/RDEPEND small fixes:
Closes: https://bugs.gentoo.org/826578
Closes: https://bugs.gentoo.org/824218