### PR TITLE
dev-python/pipenv: fix missing sed command

### DIFF
--- a/dev-python/pipenv/pipenv-2021.11.23.ebuild
+++ b/dev-python/pipenv/pipenv-2021.11.23.ebuild
@@ -61,7 +61,8 @@ src_prepare() {
 			sed --in-place \
 				-e 's/from pipenv.vendor import '"${pkgName}"'/import '"${pkgName}"'/g' \
 				-e 's/from pipenv.vendor.'"${pkgName}"'\(.*\) import \(\w*\)/from '"${pkgName}"'\1 import \2/g' \
-				-e 's/import pipenv.vendor.'"${pkgName}"' as '"${pkgName}"'/import '"${pkgName}"'/g'
+				-e 's/import pipenv.vendor.'"${pkgName}"' as '"${pkgName}"'/import '"${pkgName}"'/g' \
+				-e 's/from .vendor import '"${pkgName}"'/import '"${pkgName}"'/g'
 	done
 	assert "Failed to sed sources"
 


### PR DESCRIPTION
Unfortunately, shells.py has one path not covered
by unit tests. Hence, this was not caught earlier.

The last sed added handels such cases:

```
from .vendor import pexpect
```

Signed-off-by: Oz N Tiram <oz.tiram@gmail.com>