### PR TITLE
sci-electronics/kicad: remove dev-docs from build

### DIFF
--- a/sci-electronics/kicad/kicad-6.0.0.ebuild
+++ b/sci-electronics/kicad/kicad-6.0.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -123,7 +123,7 @@ src_configure() {
 src_compile() {
 	cmake_src_compile
 	if use doc; then
-		cmake_src_compile dev-docs doxygen-docs
+		cmake_src_compile doxygen-docs
 	fi
 }
 
@@ -142,7 +142,7 @@ src_install() {
 	if use doc ; then
 		dodoc uncrustify.cfg
 		cd Documentation || die
-		dodoc -r *.txt kicad_doxygen_logo.png notes_about_pcbnew_new_file_format.odt doxygen/. development/doxygen/.
+		dodoc -r *.txt kicad_doxygen_logo.png notes_about_pcbnew_new_file_format.odt doxygen/.
 	fi
 }
 


### PR DESCRIPTION
It seems in kicad-6.0.0, there is no more "dev-docs" target in the ninja
doc built.

(I did not find any different version of that in the list of targets, but this clearly is not there anymore.)

Closes: https://bugs.gentoo.org/827442
Package-Manager: Portage-3.0.28, Repoman-3.0.3
Signed-off-by: Yehoshua Pesach Wallach <yehoshuapw@gmail.com>