### PR TITLE
dev-util/bats: Stabilize 1.5.0 ALLARCHES, #828355

### DIFF
--- a/dev-util/bats/bats-1.5.0.ebuild
+++ b/dev-util/bats/bats-1.5.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -12,7 +12,7 @@ SRC_URI="https://github.com/${MY_PN}/${MY_PN}/archive/v${PV}.tar.gz -> ${P}.tar.
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="amd64 arm arm64 ppc64 ~riscv x86"
 
 DEPEND="app-shells/bash:*"
 RDEPEND="${DEPEND}"


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/828355
Signed-off-by: Henning Schild <henning@hennsch.de>