### PR TITLE
app-crypt/adcli: fix musl linking bug

### DIFF
--- a/app-crypt/adcli/adcli-0.9.1-r1.ebuild
+++ b/app-crypt/adcli/adcli-0.9.1-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2021 Gentoo Authors
+# Copyright 2021-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -27,6 +27,7 @@ BDEPEND="
 
 PATCHES=(
 	"${FILESDIR}"/${P}-glibc-2.34-resolv.patch
+	"${FILESDIR}"/${P}-library-include-endian.h-for-le32toh.patch
 )
 
 src_prepare() {

--- a/app-crypt/adcli/files/adcli-0.9.1-library-include-endian.h-for-le32toh.patch
+++ b/app-crypt/adcli/files/adcli-0.9.1-library-include-endian.h-for-le32toh.patch
@@ -1,0 +1,28 @@
+From dfbaa1b7f7cde281e23464ceb24699d4686651ab Mon Sep 17 00:00:00 2001
+From: Henning Schild <henning@hennsch.de>
+Date: Tue, 11 Jan 2022 08:22:55 +0100
+Subject: [PATCH] library: include endian.h for le32toh
+
+upstream commit 938065a751c0876eb837a27f8c1443fc7d0d2551
+
+linking against musl libc we need to include that specifically, actually
+also according to "man 3 endian".
+---
+ library/adutil.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/library/adutil.c b/library/adutil.c
+index 9b0c47f3b7e9..4bb06a3a7588 100644
+--- a/library/adutil.c
++++ b/library/adutil.c
+@@ -29,6 +29,7 @@
+ 
+ #include <assert.h>
+ #include <ctype.h>
++#include <endian.h>
+ #include <errno.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+-- 
+2.34.1
+


### PR DESCRIPTION
apply a patch which has been merged upstream

Closes: https://bugs.gentoo.org/830325
Signed-off-by: Henning Schild <henning@hennsch.de>