### PR TITLE
net-vpn/strongswan: change dependencies so openssl3 isn't used

### DIFF
--- a/net-vpn/strongswan/strongswan-5.9.2-r2.ebuild
+++ b/net-vpn/strongswan/strongswan-5.9.2-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="7"
@@ -32,7 +32,7 @@ COMMON_DEPEND="non-root? (
 	caps? ( sys-libs/libcap )
 	curl? ( net-misc/curl )
 	ldap? ( net-nds/openldap )
-	openssl? ( >=dev-libs/openssl-0.9.8:=[-bindist(-)] )
+	openssl? ( >=dev-libs/openssl-0.9.8:=[-bindist(-)] <dev-libs/openssl-3:= )
 	mysql? ( dev-db/mysql-connector-c:= )
 	sqlite? ( >=dev-db/sqlite-3.3.1 )
 	systemd? ( sys-apps/systemd )


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/806178
Signed-off-by: Dennis Eisele <kernlpanic@dennis-eisele.de>