### PR TITLE
No sound and music in game

### DIFF
--- a/games-strategy/ufoai/ufoai-2.5.0_p20180603-r1.ebuild
+++ b/games-strategy/ufoai/ufoai-2.5.0_p20180603-r1.ebuild
@@ -39,7 +39,7 @@ RDEPEND="
 		media-libs/libsdl2[joystick,opengl,sound,threads,video]
 		media-libs/libtheora
 		media-libs/libvorbis
-		media-libs/sdl2-mixer
+		media-libs/sdl2-mixer[vorbis]
 		media-libs/sdl2-ttf
 		media-libs/xvid
 		virtual/jpeg:0


### PR DESCRIPTION
The solution is to add vorbis USE flag to media-libs/sdl2-mixer.

Here is Error at STDERR after $ ufo

```
------- sound initialization -------
SDL_mixer version: 2.0.4
... requested audio rate: 48000
... available audio driver alsa
... available audio driver disk
... available audio driver dummy
... actual audio driver: alsa
... audio rate: 48000
... audio channels: 2
could not load ogg vorbis support - sound initialization failed

```



Here is emerge --info



`Portage 3.0.28 (python 3.9.8-final-0, default/linux/amd64/17.1, gcc-11.2.0, glibc-2.33-r7, 5.10.76-gentoo-r1 x86_64)
=================================================================
System uname: Linux-5.10.76-gentoo-r1-x86_64-*-with-glibc2.33
KiB Mem:     4038840 total,   2055988 free
KiB Swap:    3145724 total,   3145724 free
Timestamp of repository gentoo: Tue, 11 Jan 2022 21:45:01 +0000
Head commit of repository gentoo: 29d7072cc03e73d7feb57105fce6a38e444f54f7
sh bash 5.1_p8
ld GNU ld (Gentoo 2.37_p1 p0) 2.37
app-misc/pax-utils:        1.3.3::gentoo
app-shells/bash:           5.1_p8::gentoo
dev-lang/perl:             5.34.0-r3::gentoo
dev-lang/python:           3.9.8::gentoo
dev-lang/rust:             1.56.1::gentoo
dev-util/cmake:            3.20.5::gentoo
dev-util/meson:            0.59.4::gentoo
sys-apps/baselayout:       2.7-r3::gentoo
sys-apps/openrc:           0.44.8::gentoo
sys-apps/sandbox:          2.25::gentoo
sys-devel/autoconf:        2.13-r1::gentoo, 2.71-r1::gentoo
sys-devel/automake:        1.16.4::gentoo
sys-devel/binutils:        2.37_p1::gentoo
sys-devel/binutils-config: 5.4::gentoo
sys-devel/clang:           13.0.0::gentoo
sys-devel/gcc:             11.2.0::gentoo
sys-devel/gcc-config:      2.4::gentoo
sys-devel/libtool:         2.4.6-r6::gentoo
sys-devel/lld:             13.0.0::gentoo
sys-devel/llvm:            13.0.0::gentoo
sys-devel/make:            4.3::gentoo
sys-kernel/linux-headers:  5.10-r1::gentoo (virtual/os-headers)
sys-libs/glibc:            2.33-r7::gentoo
Repositories:

gentoo
    location: /var/db/repos/gentoo
    sync-type: rsync
    sync-uri: rsync://rsync.pl.gentoo.org/gentoo-portage
    priority: -1000
    sync-rsync-verify-jobs: 1
    sync-rsync-verify-metamanifest: yes
    sync-rsync-verify-max-age: 24
    sync-rsync-extra-opts: 

ACCEPT_KEYWORDS="amd64"
ACCEPT_LICENSE="@FREE"
CBUILD="x86_64-pc-linux-gnu"
CFLAGS="-O2 -pipe -march=core2 -fomit-frame-pointer"
CHOST="x86_64-pc-linux-gnu"
CONFIG_PROTECT="/etc /usr/share/gnupg/qualified.txt"
CONFIG_PROTECT_MASK="/etc/ca-certificates.conf /etc/env.d /etc/fonts/fonts.conf /etc/gconf /etc/gentoo-release /etc/revdep-rebuild /etc/sandbox.d /etc/terminfo"
CXXFLAGS="-O2 -pipe -march=core2 -fomit-frame-pointer"
DISTDIR="/var/cache/distfiles"
ENV_UNSET="CARGO_HOME DBUS_SESSION_BUS_ADDRESS DISPLAY GOBIN GOPATH PERL5LIB PERL5OPT PERLPREFIX PERL_CORE PERL_MB_OPT PERL_MM_OPT XAUTHORITY XDG_CACHE_HOME XDG_CONFIG_HOME XDG_DATA_HOME XDG_RUNTIME_DIR"
FCFLAGS="-O2 -pipe -fomit-frame-pointer"
FEATURES="assume-digests binpkg-docompress binpkg-dostrip binpkg-logs config-protect-if-modified distlocks ebuild-locks fixlafiles ipc-sandbox merge-sync multilib-strict network-sandbox news parallel-fetch pid-sandbox preserve-libs protect-owned qa-unresolved-soname-deps sandbox sfperms strict unknown-features-warn unmerge-logs unmerge-orphans userfetch userpriv usersandbox usersync xattr"
FFLAGS="-O2 -pipe -fomit-frame-pointer"
GENTOO_MIRRORS="http://ftp.ntua.gr/pub/linux/gentoo/"
LANG="C.utf8"
LDFLAGS="-Wl,-O1 -Wl,--as-needed"
MAKEOPTS="-j2"
PKGDIR="/var/cache/binpkgs"
PORTAGE_CONFIGROOT="/"
PORTAGE_RSYNC_OPTS="--recursive --links --safe-links --perms --times --omit-dir-times --compress --force --whole-file --delete --stats --human-readable --timeout=180 --exclude=/distfiles --exclude=/local --exclude=/packages --exclude=/.git"
PORTAGE_TMPDIR="/var/tmp"
SHELL="/bin/bash"
USE="X acl alsa amd64 bzip2 caps cli crypt dri emacs fortran gdbm iconv ipv6 jpeg libglvnd libtirpc multilib ncurses nls nptl ogg openmp pam pcre png readline seccomp split-usr ssl unicode xattr zlib" ABI_X86="64 32" ADA_TARGET="gnat_2020" APACHE2_MODULES="authn_core authz_core socache_shmcb unixd actions alias auth_basic authn_alias authn_anon authn_dbm authn_default authn_file authz_dbm authz_default authz_groupfile authz_host authz_owner authz_user autoindex cache cgi cgid dav dav_fs dav_lock deflate dir disk_cache env expires ext_filter file_cache filter headers include info log_config logio mem_cache mime mime_magic negotiation rewrite setenvif speling status unique_id userdir usertrack vhost_alias" CALLIGRA_FEATURES="karbon sheets words" COLLECTD_PLUGINS="df interface irq load memory rrdtool swap syslog" CPU_FLAGS_X86="mmx mmxext sse sse2 sse3 sse4_1 ssse3" ELIBC="glibc" GPSD_PROTOCOLS="ashtech aivdm earthmate evermore fv18 garmin garmintxt gpsclock greis isync itrax mtk3301 nmea ntrip navcom oceanserver oldstyle oncore rtcm104v2 rtcm104v3 sirf skytraq superstar2 timing tsip tripmate tnt ublox ubx" INPUT_DEVICES="libinput" KERNEL="linux" L10N="en" LCD_DEVICES="bayrad cfontz cfontz633 glk hd44780 lb216 lcdm001 mtxorb ncurses text" LIBREOFFICE_EXTENSIONS="presenter-console presenter-minimizer" LUA_SINGLE_TARGET="lua5-1" LUA_TARGETS="lua5-1" OFFICE_IMPLEMENTATION="libreoffice" PHP_TARGETS="php7-3 php7-4" POSTGRES_TARGETS="postgres12 postgres13" PYTHON_SINGLE_TARGET="python3_9" PYTHON_TARGETS="python3_9" RUBY_TARGETS="ruby26 ruby27" USERLAND="GNU" VIDEO_CARDS="nouveau" XTABLES_ADDONS="quota2 psd pknock lscan length2 ipv4options ipset ipp2p iface geoip fuzzy condition tee tarpit sysrq proto steal rawnat logmark ipmark dhcpmac delude chaos account"
Unset:  ADDR2LINE, AR, ARFLAGS, AS, ASFLAGS, CC, CCLD, CONFIG_SHELL, CPP, CPPFLAGS, CTARGET, CXX, CXXFILT, ELFEDIT, EMERGE_DEFAULT_OPTS, EXTRA_ECONF, F77FLAGS, FC, GCOV, GPROF, INSTALL_MASK, LC_ALL, LD, LEX, LFLAGS, LIBTOOL, LINGUAS, MAKE, MAKEFLAGS, NM, OBJCOPY, OBJDUMP, PORTAGE_BINHOST, PORTAGE_BUNZIP2_COMMAND, PORTAGE_COMPRESS, PORTAGE_COMPRESS_FLAGS, PORTAGE_RSYNC_EXTRA_OPTS, RANLIB, READELF, RUSTFLAGS, SIZE, STRINGS, STRIP, YACC, YFLAGS

`