### PR TITLE
ww-misc/awstats include support for geoip2 and fix CVE

### DIFF
--- a/www-misc/awstats/awstats-7.8-r1.ebuild
+++ b/www-misc/awstats/awstats-7.8-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ SRC_URI="https://www.awstats.org/files/${P}.tar.gz"
 S=${WORKDIR}/${MY_P}
 LICENSE="GPL-3"
 KEYWORDS="~alpha ~amd64 ~hppa ~ppc ~sparc ~x86"
-IUSE="geoip ipv6"
+IUSE="geoip geoip2 ipv6"
 
 SLOT="0"
 
@@ -21,6 +21,9 @@ RDEPEND="
 	virtual/perl-Time-Local
 	geoip? (
 		dev-perl/Geo-IP
+	)
+	geoip2? (
+		dev-perl/GeoIP2
 	)
 	ipv6? (
 		dev-perl/Net-DNS
@@ -32,6 +35,7 @@ DEPEND=""
 src_prepare() {
 	eapply "${FILESDIR}"/${PN}-7.1-gentoo.diff
 	eapply "${FILESDIR}"/${P}-mime.patch
+	eapply "${FILESDIR}"/${P}-Only-look-for-configuration-in-dedicated-awstats-dir.patch
 
 	# change default installation directory
 	find . -type f -exec sed \
@@ -50,12 +54,12 @@ src_prepare() {
 
 	if use ipv6; then
 		sed -e "s|^#\(LoadPlugin=\"ipv6\"\)$|\1|" \
-		-i "${S}"/wwwroot/cgi-bin/awstats.model.conf || die "sed failed"
+			-i "${S}"/wwwroot/cgi-bin/awstats.model.conf || die "sed failed"
 	fi
 
 	if use geoip; then
 		sed -e '/LoadPlugin="geoip /aLoadPlugin="geoip GEOIP_STANDARD /usr/share/GeoIP/GeoIP.dat"' \
-		-i "${S}"/wwwroot/cgi-bin/awstats.model.conf || die "sed failed"
+			-i "${S}"/wwwroot/cgi-bin/awstats.model.conf || die "sed failed"
 	fi
 
 	find "${S}" '(' -type f -not -name '*.pl' ')' -exec chmod -x {} + || die
@@ -106,5 +110,5 @@ pkg_postinst() {
 	ewarn "This ebuild does no longer use webapp-config to install"
 	ewarn "instead you should point your configuration to the stable"
 	ewarn "directory tree in the following path:"
-	ewarn "    /usr/share/awstats"
+	ewarn "	   /usr/share/awstats"
 }

--- a/www-misc/awstats/files/awstats-7.8-Only-look-for-configuration-in-dedicated-awstats-dir.patch
+++ b/www-misc/awstats/files/awstats-7.8-Only-look-for-configuration-in-dedicated-awstats-dir.patch
@@ -1,0 +1,34 @@
+From 0d4d4c05f8e73be8f71dd361dc55cbd52858b823 Mon Sep 17 00:00:00 2001
+From: Beuc <beuc@beuc.net>
+Date: Thu, 17 Dec 2020 18:14:43 +0100
+Subject: [PATCH 18/20] Only look for configuration in dedicated awstats
+ directories
+
+Fixes #195/CVE-2020-35176
+---
+ wwwroot/cgi-bin/awstats.pl | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/wwwroot/cgi-bin/awstats.pl b/wwwroot/cgi-bin/awstats.pl
+index e709b7f5..8341c0a5 100755
+--- a/wwwroot/cgi-bin/awstats.pl
++++ b/wwwroot/cgi-bin/awstats.pl
+@@ -1711,13 +1711,13 @@ sub Read_Config {
+ 	# Check config file in common possible directories :
+ 	# Windows :                   				"$DIR" (same dir than awstats.pl)
+ 	# Standard, Mandrake and Debian package :	"/etc/awstats"
+-	# Other possible directories :				"/usr/local/etc/awstats", "/etc"
++	# Other possible directories :				"/usr/local/etc/awstats",
+ 	# FHS standard, Suse package : 				"/etc/opt/awstats"
+ 	my $configdir         = shift;
+ 	my @PossibleConfigDir = (
+ 			"$DIR",
+ 			"/etc/awstats",
+-			"/usr/local/etc/awstats", "/etc",
++			"/usr/local/etc/awstats",
+ 			"/etc/opt/awstats"
+ 		); 
+ 
+-- 
+2.34.1
+

--- a/www-misc/awstats/metadata.xml
+++ b/www-misc/awstats/metadata.xml
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<maintainer type="project">
-    <email>web-apps@gentoo.org</email>
-    <name>Gentoo Webapps</name>
-  </maintainer>
+    <maintainer type="project">
+        <email>web-apps@gentoo.org</email>
+        <name>Gentoo Webapps</name>
+    </maintainer>
+    <use>
+        <flag name="geoip2">Enable GeoIP2 API from MaxMind</flag>
+    </use>
 </pkgmetadata>


### PR DESCRIPTION
* include support for geoip2
* Reformat code
* Include fix for cve

Closes: https://bugs.gentoo.org/723864
Closes: https://bugs.gentoo.org/759544

Package-Manager: Portage-3.0.28, Repoman-3.0.3
Signed-off-by: Fco. Javier Félix ffelix@inode64.com
