### PR TITLE
app-cdr/cdrdao: new EAPI, new maintainer

### DIFF
--- a/app-cdr/cdrdao/cdrdao-1.2.4-r1.ebuild
+++ b/app-cdr/cdrdao/cdrdao-1.2.4-r1.ebuild
@@ -1,0 +1,56 @@
+# Copyright 2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools flag-o-matic
+
+DESCRIPTION="Burn CDs in disk-at-once mode -- with optional GUI frontend"
+HOMEPAGE="http://cdrdao.sourceforge.net/"
+SRC_URI="mirror://sourceforge/${PN}/${P}.tar.bz2"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~ia64 ~ppc ~ppc64 ~riscv ~sparc ~x86"
+IUSE="encode mad vorbis"
+
+COMMON_DEPEND="
+	app-cdr/cdrtools
+	encode? ( >=media-sound/lame-3.99 )
+	mad? (
+		media-libs/libao
+		media-libs/libmad
+	)
+	vorbis? (
+		media-libs/libao
+		media-libs/libvorbis
+	)"
+DEPEND="${COMMON_DEPEND}
+	virtual/pkgconfig"
+RDEPEND="${COMMON_DEPEND}
+	!app-cdr/cue2toc"
+BDEPEND="gnome-base/gconf"
+
+PATCHES=(
+	"${FILESDIR}/${P}-ax_pthread.patch"
+	"${FILESDIR}/${P}-wformat-security.patch"
+)
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_configure() {
+	# Fix building with latest libsigc++
+	append-cxxflags -std=c++11
+	find -name '*.h' -exec sed -i '/sigc++\/object.h/d' {} + || die
+
+	local myeconfargs=(
+		--without-gcdmaster
+		$(use_with vorbis ogg-support)
+		$(use_with mad mp3-support)
+		$(use_with encode lame)
+	)
+	econf "${myeconfargs[@]}"
+}

--- a/app-cdr/cdrdao/metadata.xml
+++ b/app-cdr/cdrdao/metadata.xml
@@ -1,10 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<!-- maintainer-needed -->
+	<maintainer type="person" proxied="yes">
+		<email>martin.dummer@gmx.net</email>
+		<name>Martin Dummer</name>
+	</maintainer>
+	<maintainer type="project" proxied="proxy">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
 	<longdescription>
-	CD command line recording, ripping and copying tool.	Especially ISOs- and
-	bin/cue-files are handled very well.
+		CD command line recording, ripping and copying tool. Especially ISO- and
+		bin/cue-files are handled very well.
 	</longdescription>
 	<upstream>
 		<remote-id type="sourceforge">cdrdao</remote-id>

--- a/app-forensics/chkrootkit/chkrootkit-0.55-r1.ebuild
+++ b/app-forensics/chkrootkit/chkrootkit-0.55-r1.ebuild
@@ -1,0 +1,68 @@
+# Copyright 2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit systemd toolchain-funcs
+
+GENTOO_PATCH="${PN}-0.55-gentoo.patch"
+
+DESCRIPTION="Tool to locally check for signs of a rootkit"
+HOMEPAGE="http://www.chkrootkit.org/"
+SRC_URI="ftp://ftp.pangeia.com.br/pub/seg/pac/${P}.tar.gz"
+SRC_URI+=" https://dev.gentoo.org/~sam/distfiles/${CATEGORY}/${PN}/${GENTOO_PATCH}.bz2"
+
+LICENSE="BSD-2"
+SLOT="0"
+KEYWORDS="~alpha amd64 arm ~hppa ~ia64 ~mips ppc ppc64 ~s390 sparc x86"
+IUSE="+cron systemd"
+
+DEPEND="systemd? ( sys-apps/systemd )"
+RDEPEND="${DEPEND}
+	cron? ( virtual/cron )"
+
+PATCHES=(
+	"${WORKDIR}/${GENTOO_PATCH}"
+	"${FILESDIR}/${P}-fcntl_h.patch"
+	"${FILESDIR}/${P}-limits_h.patch"
+)
+
+src_prepare() {
+	default
+	sed -e 's:/var/adm/:/var/log/:g' \
+		-i chklastlog.c || die
+}
+
+src_compile() {
+	emake CC="$(tc-getCC)" STRIP=true sense
+}
+
+src_install() {
+	dosbin chkdirs chklastlog chkproc chkrootkit chkwtmp chkutmp ifpromisc strings-static
+	dodoc ACKNOWLEDGMENTS README*
+
+	if use cron ; then
+		exeinto /etc/cron.weekly
+		newexe "${FILESDIR}"/${PN}.cron ${PN}
+	fi
+	systemd_dounit "${FILESDIR}/${PN}.timer" "${FILESDIR}/${PN}.service"
+}
+
+pkg_postinst() {
+	if use cron ; then
+		elog
+		elog "Edit /etc/cron.weekly/chkrootkit to activate chkrootkit!"
+		elog
+	fi
+	if use systemd ; then
+		elog
+		elog "To enable the systemd timer, run the following command:"
+		elog "   systemctl enable --now chkrootkit.timer"
+		elog
+	fi
+	elog
+	elog "Some applications, such as portsentry, will cause chkrootkit"
+	elog "to produce false positives.  Read the chkrootkit FAQ at"
+	elog "http://www.chkrootkit.org/ for more information."
+	elog
+}

--- a/app-forensics/chkrootkit/files/chkrootkit.service
+++ b/app-forensics/chkrootkit/files/chkrootkit.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=local check for signs of a rootkit
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/chkrootkit -q
+SyslogIdentifier=chkrootkit

--- a/app-forensics/chkrootkit/files/chkrootkit.timer
+++ b/app-forensics/chkrootkit/files/chkrootkit.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Periodic check for signs of a rootkit
+
+[Timer]
+# Run on Sunday at 3:20am, to avoid running afoul of DST changes
+OnCalendar=Sun *-*-* 03:20:00
+RandomizedDelaySec=60
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/app-forensics/chkrootkit/metadata.xml
+++ b/app-forensics/chkrootkit/metadata.xml
@@ -1,7 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<!-- maintainer-needed -->
+	<maintainer type="person" proxied="yes">
+		<email>martin.dummer@gmx.net</email>
+		<name>Martin Dummer</name>
+	</maintainer>
+	<maintainer type="project" proxied="proxy">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
 	<use>
 		<flag name="cron">Install cron script for weekly rootkit scans</flag>
 	</use>


### PR DESCRIPTION
add dependency gnome-base/gconf
drop keyword hppa due to gnome-base/gconf
drop support for _rc ebuild

Closes: https://bugs.gentoo.org/745351
Package-Manager: Portage-3.0.30, Repoman-3.0.3
Signed-off-by: Martin Dummer <martin.dummer@gmx.net>