### PR TITLE
app-cdr/cdrdao: new EAPI, new maintainer

### DIFF
--- a/app-cdr/cdrdao/cdrdao-1.2.4-r1.ebuild
+++ b/app-cdr/cdrdao/cdrdao-1.2.4-r1.ebuild
@@ -1,0 +1,51 @@
+# Copyright 2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools flag-o-matic
+
+DESCRIPTION="Burn CDs in disk-at-once mode -- with optional GUI frontend"
+HOMEPAGE="http://cdrdao.sourceforge.net/"
+SRC_URI="mirror://sourceforge/${PN}/${P}.tar.bz2"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~ia64 ~ppc ~ppc64 ~riscv ~sparc ~x86"
+IUSE="encode mad vorbis"
+
+DEPEND="app-cdr/cdrtools
+	encode? ( >=media-sound/lame-3.99 )
+	mad? (
+		media-libs/libao
+		media-libs/libmad
+	)
+	vorbis? (
+		media-libs/libao
+		media-libs/libvorbis
+	)"
+RDEPEND="${DEPEND}
+	!app-cdr/cue2toc"
+BDEPEND="gnome-base/gconf
+	virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}/${P}-ax_pthread.patch"
+	"${FILESDIR}/${P}-wformat-security.patch"
+)
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_configure() {
+	append-cxxflags -std=c++11
+	local myeconfargs=(
+		--without-gcdmaster
+		$(use_with vorbis ogg-support)
+		$(use_with mad mp3-support)
+		$(use_with encode lame)
+	)
+	econf "${myeconfargs[@]}"
+}

--- a/app-cdr/cdrdao/metadata.xml
+++ b/app-cdr/cdrdao/metadata.xml
@@ -1,10 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<!-- maintainer-needed -->
+	<maintainer type="person" proxied="yes">
+		<email>martin.dummer@gmx.net</email>
+		<name>Martin Dummer</name>
+	</maintainer>
+	<maintainer type="project" proxied="proxy">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
 	<longdescription>
-	CD command line recording, ripping and copying tool.	Especially ISOs- and
-	bin/cue-files are handled very well.
+		CD command line recording, ripping and copying tool. Especially ISOs and bin/cue-files are handled very well.
 	</longdescription>
 	<upstream>
 		<remote-id type="sourceforge">cdrdao</remote-id>


### PR DESCRIPTION
add dependency gnome-base/gconf
drop keyword hppa due to gnome-base/gconf
drop support for _rc ebuild

Closes: https://bugs.gentoo.org/745351
Package-Manager: Portage-3.0.30, Repoman-3.0.3
Signed-off-by: Martin Dummer <martin.dummer@gmx.net>