### PR TITLE
app-forensics/chkrootkit: add systemd timer, new maintainer

### DIFF
--- a/app-forensics/chkrootkit/chkrootkit-0.55-r1.ebuild
+++ b/app-forensics/chkrootkit/chkrootkit-0.55-r1.ebuild
@@ -1,0 +1,68 @@
+# Copyright 2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit systemd toolchain-funcs
+
+GENTOO_PATCH="${PN}-0.55-gentoo.patch"
+
+DESCRIPTION="Tool to locally check for signs of a rootkit"
+HOMEPAGE="http://www.chkrootkit.org/"
+SRC_URI="ftp://ftp.pangeia.com.br/pub/seg/pac/${P}.tar.gz"
+SRC_URI+=" https://dev.gentoo.org/~sam/distfiles/${CATEGORY}/${PN}/${GENTOO_PATCH}.bz2"
+
+LICENSE="BSD-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86"
+IUSE="+cron systemd"
+
+DEPEND="systemd? ( sys-apps/systemd )"
+RDEPEND="${DEPEND}
+	cron? ( virtual/cron )"
+
+PATCHES=(
+	"${WORKDIR}/${GENTOO_PATCH}"
+	"${FILESDIR}/${P}-fcntl_h.patch"
+	"${FILESDIR}/${P}-limits_h.patch"
+)
+
+src_prepare() {
+	default
+	sed -e 's:/var/adm/:/var/log/:g' \
+		-i chklastlog.c || die
+}
+
+src_compile() {
+	emake CC="$(tc-getCC)" STRIP=true sense
+}
+
+src_install() {
+	dosbin chkdirs chklastlog chkproc chkrootkit chkwtmp chkutmp ifpromisc strings-static
+	dodoc ACKNOWLEDGMENTS README*
+
+	if use cron ; then
+		exeinto /etc/cron.weekly
+		newexe "${FILESDIR}"/${PN}.cron ${PN}
+	fi
+	systemd_dounit "${FILESDIR}/${PN}.timer" "${FILESDIR}/${PN}.service"
+}
+
+pkg_postinst() {
+	if use cron ; then
+		elog
+		elog "Edit /etc/cron.weekly/chkrootkit to activate chkrootkit!"
+		elog
+	fi
+	if use systemd ; then
+		elog
+		elog "To enable the systemd timer, run the following command:"
+		elog "   systemctl enable --now chkrootkit.timer"
+		elog
+	fi
+	elog
+	elog "Some applications, such as portsentry, will cause chkrootkit"
+	elog "to produce false positives.  Read the chkrootkit FAQ at"
+	elog "http://www.chkrootkit.org/ for more information."
+	elog
+}

--- a/app-forensics/chkrootkit/files/chkrootkit.service
+++ b/app-forensics/chkrootkit/files/chkrootkit.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=local check for signs of a rootkit
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/chkrootkit -q
+SyslogIdentifier=chkrootkit

--- a/app-forensics/chkrootkit/files/chkrootkit.timer
+++ b/app-forensics/chkrootkit/files/chkrootkit.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Periodic check for signs of a rootkit
+
+[Timer]
+# Run on Sunday at 3:20am, to avoid running afoul of DST changes
+OnCalendar=Sun *-*-* 03:20:00
+RandomizedDelaySec=120
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/app-forensics/chkrootkit/metadata.xml
+++ b/app-forensics/chkrootkit/metadata.xml
@@ -1,7 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<!-- maintainer-needed -->
+	<maintainer type="person" proxied="yes">
+		<email>martin.dummer@gmx.net</email>
+		<name>Martin Dummer</name>
+	</maintainer>
+	<maintainer type="project" proxied="proxy">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
 	<use>
 		<flag name="cron">Install cron script for weekly rootkit scans</flag>
 	</use>


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/773280
Package-Manager: Portage-3.0.30, Repoman-3.0.3
Signed-off-by: Martin Dummer <martin.dummer@gmx.net>