### PR TITLE
sci-geosciences/grass: bump dev version to 8.1

### DIFF
--- a/sci-geosciences/grass/grass-9999.ebuild
+++ b/sci-geosciences/grass/grass-9999.ebuild
@@ -9,15 +9,15 @@ WX_GTK_VER="3.0-gtk3"
 
 inherit autotools desktop git-r3 python-single-r1 toolchain-funcs wxwidgets xdg
 
-MY_P="${PN}8.1"
-MY_PM="${MY_P/.}"
-
 DESCRIPTION="A free GIS with raster and vector functionality, as well as 3D vizualization"
 HOMEPAGE="https://grass.osgeo.org/"
 EGIT_REPO_URI="https://github.com/OSGeo/grass.git"
 
 LICENSE="GPL-2"
 SLOT="0/8.1"
+GVERSION=${SLOT#*/}
+MY_P="${PN}${GVERSION}"
+MY_PM="${MY_P/.}"
 IUSE="blas cxx fftw geos lapack liblas mysql netcdf nls odbc opencl opengl openmp png postgres readline sqlite threads tiff truetype X zstd"
 REQUIRED_USE="
 	${PYTHON_REQUIRED_USE}
@@ -234,9 +234,9 @@ GISBASE = os.path.normpath(\"${gisbase}\"):" \
 os.environ\[\"GRASS_PYTHON\"\] = \"${EPYTHON}\":" \
 		-i "${ED}"/usr/bin/grass || die
 
-	# set proper GISDBASE directory path in the demolocation .grassrc80 file
+	# set proper GISDBASE directory path in the demolocation .grassrc${GVERSION//.} file
 	sed -e "s:GISDBASE\:.*$:GISDBASE\: ${gisbase}:" \
-		-i "${ED}"${gisbase}/demolocation/.grassrc81 || die
+		-i "${ED}"${gisbase}/demolocation/.grassrc${GVERSION//.} || die
 
 	if use X; then
 		local GUI="-gui"

--- a/sci-geosciences/grass/grass-9999.ebuild
+++ b/sci-geosciences/grass/grass-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -9,7 +9,7 @@ WX_GTK_VER="3.0-gtk3"
 
 inherit autotools desktop git-r3 python-single-r1 toolchain-funcs wxwidgets xdg
 
-MY_P="${PN}8.0"
+MY_P="${PN}8.1"
 MY_PM="${MY_P/.}"
 
 DESCRIPTION="A free GIS with raster and vector functionality, as well as 3D vizualization"
@@ -17,7 +17,7 @@ HOMEPAGE="https://grass.osgeo.org/"
 EGIT_REPO_URI="https://github.com/OSGeo/grass.git"
 
 LICENSE="GPL-2"
-SLOT="0/8.0"
+SLOT="0/8.1"
 IUSE="blas cxx fftw geos lapack liblas mysql netcdf nls odbc opencl opengl openmp png postgres readline sqlite threads tiff truetype X zstd"
 REQUIRED_USE="
 	${PYTHON_REQUIRED_USE}
@@ -236,7 +236,7 @@ os.environ\[\"GRASS_PYTHON\"\] = \"${EPYTHON}\":" \
 
 	# set proper GISDBASE directory path in the demolocation .grassrc80 file
 	sed -e "s:GISDBASE\:.*$:GISDBASE\: ${gisbase}:" \
-		-i "${ED}"${gisbase}/demolocation/.grassrc80 || die
+		-i "${ED}"${gisbase}/demolocation/.grassrc81 || die
 
 	if use X; then
 		local GUI="-gui"

--- a/sci-geosciences/grass/metadata.xml
+++ b/sci-geosciences/grass/metadata.xml
@@ -15,8 +15,8 @@
 	</maintainer>
 	<longdescription>
 		The original GIS, yes the first one, developed by the US
-		Army Corp of Engineers, now an active open source GIS. See the GRASS Documentation
-		Project for more info http://grass.itc.it/gdp/index.php
+		Army Corp of Engineers, now an active free and open source GIS. See the GRASS Documentation
+		Project for more info https://grass.osgeo.org/.
 	</longdescription>
 	<use>
 		<flag name="geos">Use <pkg>sci-libs/geos</pkg> for v.buffer and adds extended options to the v.select module</flag>


### PR DESCRIPTION
Bump [GRASS GIS dev version to 8.1](https://github.com/OSGeo/grass/commit/029cd8ea8e9c98b575f57f148b1552c8821a0494) and fix metadata long description.