### PR TITLE
media-video/ffmpeg: fix mixed strip usage

### DIFF
--- a/media-video/ffmpeg/ffmpeg-4.2.4-r1.ebuild
+++ b/media-video/ffmpeg/ffmpeg-4.2.4-r1.ebuild
@@ -463,6 +463,7 @@ multilib_src_configure() {
 		--cc="$(tc-getCC)" \
 		--cxx="$(tc-getCXX)" \
 		--ar="$(tc-getAR)" \
+		--strip="$(tc-getSTRIP)" \
 		--optflags="${CFLAGS}" \
 		$(use_enable static-libs static) \
 		"${myconf[@]}"

--- a/media-video/ffmpeg/ffmpeg-4.3.1-r1.ebuild
+++ b/media-video/ffmpeg/ffmpeg-4.3.1-r1.ebuild
@@ -464,6 +464,7 @@ multilib_src_configure() {
 		--cxx="$(tc-getCXX)" \
 		--ar="$(tc-getAR)" \
 		--nm="$(tc-getNM)" \
+		--strip="$(tc-getSTRIP)" \
 		--ranlib="$(tc-getRANLIB)" \
 		--pkg-config="$(tc-getPKG_CONFIG)" \
 		--optflags="${CFLAGS}" \

--- a/media-video/ffmpeg/ffmpeg-4.3.2-r1.ebuild
+++ b/media-video/ffmpeg/ffmpeg-4.3.2-r1.ebuild
@@ -464,6 +464,7 @@ multilib_src_configure() {
 		--cxx="$(tc-getCXX)" \
 		--ar="$(tc-getAR)" \
 		--nm="$(tc-getNM)" \
+		--strip="$(tc-getSTRIP)" \
 		--ranlib="$(tc-getRANLIB)" \
 		--pkg-config="$(tc-getPKG_CONFIG)" \
 		--optflags="${CFLAGS}" \

--- a/media-video/ffmpeg/ffmpeg-4.4-r1.ebuild
+++ b/media-video/ffmpeg/ffmpeg-4.4-r1.ebuild
@@ -469,6 +469,7 @@ multilib_src_configure() {
 		--cxx="$(tc-getCXX)" \
 		--ar="$(tc-getAR)" \
 		--nm="$(tc-getNM)" \
+		--strip="$(tc-getSTRIP)" \
 		--ranlib="$(tc-getRANLIB)" \
 		--pkg-config="$(tc-getPKG_CONFIG)" \
 		--optflags="${CFLAGS}" \

--- a/media-video/ffmpeg/ffmpeg-4.4.1-r1.ebuild
+++ b/media-video/ffmpeg/ffmpeg-4.4.1-r1.ebuild
@@ -472,6 +472,7 @@ multilib_src_configure() {
 		--cxx="$(tc-getCXX)" \
 		--ar="$(tc-getAR)" \
 		--nm="$(tc-getNM)" \
+		--strip="$(tc-getSTRIP)" \
 		--ranlib="$(tc-getRANLIB)" \
 		--pkg-config="$(tc-getPKG_CONFIG)" \
 		--optflags="${CFLAGS}" \

--- a/media-video/ffmpeg/ffmpeg-9999.ebuild
+++ b/media-video/ffmpeg/ffmpeg-9999.ebuild
@@ -471,6 +471,7 @@ multilib_src_configure() {
 		--cxx="$(tc-getCXX)" \
 		--ar="$(tc-getAR)" \
 		--nm="$(tc-getNM)" \
+		--strip="$(tc-getSTRIP)" \
 		--ranlib="$(tc-getRANLIB)" \
 		--pkg-config="$(tc-getPKG_CONFIG)" \
 		--optflags="${CFLAGS}" \


### PR DESCRIPTION
Even though stripping is disabled for compiled binaries
(--disable-stripping), some configure phase test binaries
get stripped and this causes Clang builds to use the GNU
strip instead of LLLVM strip.

Fix this by specifying to configure the proper version of
strip to be used via --strip="$(tc-getSTRIP)"

Bug: https://bugs.gentoo.org/831128
Signed-off-by: Adrian Ratiu <adrian.ratiu@collabora.com>