### PR TITLE
sci-mathematics/why3: add missing latex dependencies

### DIFF
--- a/sci-mathematics/why3/why3-1.4.0-r2.ebuild
+++ b/sci-mathematics/why3/why3-1.4.0-r2.ebuild
@@ -37,7 +37,9 @@ BDEPEND="
 		dev-python/sphinx
 		dev-python/sphinxcontrib-bibtex
 		media-gfx/graphviz
-		|| ( dev-texlive/texlive-latex dev-tex/latexmk dev-tex/rubber )
+		dev-texlive/texlive-latex
+		dev-texlive/texlive-fontsrecommended
+		dev-texlive/texlive-latexextra
 	)
 "
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/828997

@xgqt