### PR TITLE
app-misc/hivex: Do not depend hardly on ruby

### DIFF
--- a/app-misc/hivex/hivex-1.3.20.ebuild
+++ b/app-misc/hivex/hivex-1.3.20.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -63,6 +63,12 @@ pkg_setup() {
 src_unpack() {
 	default
 	cp -prlP "${WORKDIR}/${P}" "${WORKDIR}"/all || die
+}
+
+src_prepare() {
+	default
+	use perl && perl-module_src_prepare
+	use ruby && ruby-ng_src_prepare
 }
 
 src_configure() {


### PR DESCRIPTION
The ruby-ng eclass exports src_prepare function and it should be only called
conditionally just like all the other functions, so add a better src_prepare
function as otherwise the build can fail if no compatible ruby target is
selected in RUBY_TARGETS even if hivex is emerging with -ruby.

Package-Manager: Portage-3.0.30, Repoman-3.0.3
Signed-off-by: Martin Kletzander <nert.pinx@gmail.com>