### PR TITLE
app-misc/wayland-utils: New package at version 1.0.0

### DIFF
--- a/app-misc/wayland-utils/metadata.xml
+++ b/app-misc/wayland-utils/metadata.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer type="person">
-		<email>asturm@gentoo.org</email>
-		<name>Andreas Sturmlechner</name>
+	<maintainer type="project">
+		<email>x11@gentoo.org</email>
+		<name>X11</name>
 	</maintainer>
 </pkgmetadata>


### PR DESCRIPTION
Standalone version of weston-info, required at runtime by >=Plasma-5.23.5.

Adding @chewi as weston-maintainer.