### PR TITLE
sys-devel/gdb: fix GCC/Clang build mixture

### DIFF
--- a/sys-devel/gdb/gdb-10.2-r1.ebuild
+++ b/sys-devel/gdb/gdb-10.2-r1.ebuild
@@ -188,6 +188,9 @@ src_configure() {
 	# source-highlight is detected with pkg-config: bug #716558
 	export ac_cv_path_pkg_config_prog_path="$(tc-getPKG_CONFIG)"
 
+	# ensure proper compiler is detected for Clang builds: bug #831202
+	export GCC_FOR_TARGET="${CC_FOR_TARGET:-$(tc-getCC)}"
+
 	econf "${myconf[@]}"
 }
 

--- a/sys-devel/gdb/gdb-11.1.ebuild
+++ b/sys-devel/gdb/gdb-11.1.ebuild
@@ -193,6 +193,9 @@ src_configure() {
 	# source-highlight is detected with pkg-config: bug #716558
 	export ac_cv_path_pkg_config_prog_path="$(tc-getPKG_CONFIG)"
 
+	# ensure proper compiler is detected for Clang builds: bug #831202
+	export GCC_FOR_TARGET="${CC_FOR_TARGET:-$(tc-getCC)}"
+
 	econf "${myconf[@]}"
 }
 

--- a/sys-devel/gdb/gdb-9999.ebuild
+++ b/sys-devel/gdb/gdb-9999.ebuild
@@ -192,6 +192,9 @@ src_configure() {
 	# source-highlight is detected with pkg-config: bug #716558
 	export ac_cv_path_pkg_config_prog_path="$(tc-getPKG_CONFIG)"
 
+	# ensure proper compiler is detected for Clang builds: bug #831202
+	export GCC_FOR_TARGET="${CC_FOR_TARGET:-$(tc-getCC)}"
+
 	econf "${myconf[@]}"
 }
 


### PR DESCRIPTION
GDB configure will use a mix of GCC and Clang due to
$GCC_FOR_TARGET defaulting to GCC in Clang-configured
builds, so set the var to ensure the proper compilers
are detected and to avoid mixing them.

Before setting the variable (example from ChromiumOS):
checking for x86_64-cros-linux-gnu-gcc... x86_64-cros-linux-gnu-gcc

After:
checking for gcc... (cached) x86_64-cros-linux-gnu-clang

Bug: https://bugs.gentoo.org/831202
Signed-off-by: Adrian Ratiu <adrian.ratiu@collabora.com>