### PR TITLE
sci-mathematics/why3: fix race condition in parallel make doc

### DIFF
--- a/sci-mathematics/why3/why3-1.4.0-r2.ebuild
+++ b/sci-mathematics/why3/why3-1.4.0-r2.ebuild
@@ -50,6 +50,7 @@ src_prepare() {
 	sed -i 's/configure\.in/configure.ac/g' Makefile.in || die
 	sed -e '/^lib\/why3[a-z]*\$(EXE):/{n;s/-Wall/$(CFLAGS) $(LDFLAGS)/}' \
 		-e '/^%.o: %.c/{n;s/\$(CC).*-o/$(CC) $(CFLAGS) -o/}' \
+		-e '/\$(SPHINX)/s/ -d doc\/\.doctrees / /' \
 		-i Makefile.in || die
 
 	eautoreconf


### PR DESCRIPTION
"make doc" uses sphinx to build both latex and html documentation. Both
sphinx rules in the makefile include "-d doc/.doctrees", ie. the same
path for "the cached environment and doctree files". In a parallel make
build, the rules are called simulateously, which means the cached files
could be read by one process while they are still being written by the
other.

I believe this is what causes bug #831168, with the following error:

    Extension error (sphinx.environment.collectors.toctree):
    Handler <bound method TocTreeCollector.get_updated_docs of [...]>
    for event 'env-get-updated' threw an exception
    (exception: pickle data was truncated)

@xgqt I'm not familiar with sphinx, but I think this what causes the reported bug. What do you think?

I've not revbumped, because it wouldn't change installed files/dependencies, only fix the build in case this bug happens; but I can revbump if it's needed.