### PR TITLE
sci-libs/opencascade: fixes for building revdeps

### DIFF
--- a/sci-libs/opencascade/opencascade-7.5.2-r5.ebuild
+++ b/sci-libs/opencascade/opencascade-7.5.2-r5.ebuild
@@ -16,7 +16,7 @@ S="${WORKDIR}/occt-V${MY_PV}"
 LICENSE="|| ( Open-CASCADE-LGPL-2.1-Exception-1.0 LGPL-2.1 )"
 SLOT="0/${PV_MAJ}"
 KEYWORDS="~amd64 ~arm64 ~x86"
-IUSE="debug doc examples ffmpeg freeimage gles2 json optimize tbb vtk"
+IUSE="debug doc examples ffmpeg freeimage gles2-only json optimize tbb vtk"
 
 REQUIRED_USE="?? ( optimize tbb )"
 

--- a/sci-libs/opencascade/opencascade-7.5.2-r5.ebuild
+++ b/sci-libs/opencascade/opencascade-7.5.2-r5.ebuild
@@ -88,15 +88,20 @@ src_configure() {
 	local mycmakeargs=(
 		-DBUILD_DOC_Overview=$(usex doc)
 		-DBUILD_Inspector=$(usex examples)
-		-DBUILD_WITH_DEBUG=$(usex debug)
-		-DINSTALL_DIR_BIN="$(get_libdir)/${P}/bin"
-		-DINSTALL_DIR_CMAKE="$(get_libdir)/cmake/${P}"
+
+		-DINSTALL_DIR_BIN="$(get_libdir)/${PN}/bin"
+		-DINSTALL_DIR_CMAKE="$(get_libdir)/cmake/${PN}"
+		-DINSTALL_DIR_DATA="share/${PN}/data"
 		-DINSTALL_DIR_DOC="share/doc/${PF}"
-		-DINSTALL_DIR_LIB="$(get_libdir)/${P}"
-		-DINSTALL_DIR_SCRIPT="$(get_libdir)/${P}/bin"
-		-DINSTALL_DIR_WITH_VERSION=ON
+		-DINSTALL_DIR_INCLUDE="include/${PN}"
+		-DINSTALL_DIR_LIB="$(get_libdir)/${PN}"
+		-DINSTALL_DIR_RESOURCE="share/${PN}/resources"
+		-DINSTALL_DIR_SAMPLES="share/${PN}/samples"
+		-DINSTALL_DIR_SCRIPT="$(get_libdir)/${PN}/bin"
+		-DINSTALL_DIR_WITH_VERSION=OFF
 		-DINSTALL_SAMPLES=$(usex examples)
 		-DINSTALL_TEST_CASES=NO
+
 		-DUSE_D3D=NO
 		-DUSE_FFMPEG=$(usex ffmpeg)
 		-DUSE_FREEIMAGE=$(usex freeimage)
@@ -160,7 +165,7 @@ src_install() {
 
 	# remove examples
 	if use !examples; then
-		rm -r "${ED}/usr/share/${P}/samples" || die
+		rm -r "${ED}/usr/share/${PN}/samples" || die
 	fi
 
 	docompress -x /usr/share/doc/${PF}/overview/html

--- a/sci-libs/opencascade/opencascade-7.5.3-r6.ebuild
+++ b/sci-libs/opencascade/opencascade-7.5.3-r6.ebuild
@@ -16,7 +16,7 @@ S="${WORKDIR}/occt-V${MY_PV}"
 LICENSE="|| ( Open-CASCADE-LGPL-2.1-Exception-1.0 LGPL-2.1 )"
 SLOT="0/${PV_MAJ}"
 KEYWORDS="~amd64 ~arm64 ~x86"
-IUSE="debug doc examples ffmpeg freeimage gles2 json optimize tbb vtk"
+IUSE="debug doc examples ffmpeg freeimage gles2-only json optimize tbb vtk"
 
 REQUIRED_USE="?? ( optimize tbb )"
 

--- a/sci-libs/opencascade/opencascade-7.5.3-r6.ebuild
+++ b/sci-libs/opencascade/opencascade-7.5.3-r6.ebuild
@@ -88,15 +88,20 @@ src_configure() {
 	local mycmakeargs=(
 		-DBUILD_DOC_Overview=$(usex doc)
 		-DBUILD_Inspector=$(usex examples)
-		-DBUILD_WITH_DEBUG=$(usex debug)
-		-DINSTALL_DIR_BIN="$(get_libdir)/${P}/bin"
-		-DINSTALL_DIR_CMAKE="$(get_libdir)/cmake/${P}"
+
+		-DINSTALL_DIR_BIN="$(get_libdir)/${PN}/bin"
+		-DINSTALL_DIR_CMAKE="$(get_libdir)/cmake/${PN}"
+		-DINSTALL_DIR_DATA="share/${PN}/data"
 		-DINSTALL_DIR_DOC="share/doc/${PF}"
-		-DINSTALL_DIR_LIB="$(get_libdir)/${P}"
-		-DINSTALL_DIR_SCRIPT="$(get_libdir)/${P}/bin"
-		-DINSTALL_DIR_WITH_VERSION=ON
+		-DINSTALL_DIR_INCLUDE="include/${PN}"
+		-DINSTALL_DIR_LIB="$(get_libdir)/${PN}"
+		-DINSTALL_DIR_RESOURCE="share/${PN}/resources"
+		-DINSTALL_DIR_SAMPLES="share/${PN}/samples"
+		-DINSTALL_DIR_SCRIPT="$(get_libdir)/${PN}/bin"
+		-DINSTALL_DIR_WITH_VERSION=OFF
 		-DINSTALL_SAMPLES=$(usex examples)
 		-DINSTALL_TEST_CASES=NO
+
 		-DUSE_D3D=NO
 		-DUSE_FFMPEG=$(usex ffmpeg)
 		-DUSE_FREEIMAGE=$(usex freeimage)
@@ -160,7 +165,7 @@ src_install() {
 
 	# remove examples
 	if use !examples; then
-		rm -r "${ED}/usr/share/${P}/samples" || die
+		rm -r "${ED}/usr/share/${PN}/samples" || die
 	fi
 
 	docompress -x /usr/share/doc/${PF}/overview/html

--- a/sci-libs/opencascade/opencascade-7.6.0-r1.ebuild
+++ b/sci-libs/opencascade/opencascade-7.6.0-r1.ebuild
@@ -105,7 +105,6 @@ src_configure() {
 		-DUSE_FREEIMAGE=$(usex freeimage)
 		-DUSE_FREETYPE=ON
 		-DUSE_GLES2=$(usex gles2)
-		-DUSE_OPENGL=$(usex !gles2)
 		# no package in tree
 		-DUSE_OPENVR=OFF
 		-DUSE_RAPIDJSON=$(usex json)


### PR DESCRIPTION
- fix installation paths for 7.5
Use the same path as for the 7.6 series /usr/$(get_libdir)/${PN}
instead of /usr/$(get_libdir)/${P}, so the changed environment
files works for all versions.
Bugs: https://bugs.gentoo.org/831054
Bugs: https://bugs.gentoo.org/831069

- don't pass USE_OPENGL option (7.6.0)
The option defaults to on and was erroneously passed as with the
invert value of the gles2 USE flag, which lead to only libTKOpenGles
library being built, but no libTKOpenGL library, resulting in build
failures in revdeps.
Closes: https://bugs.gentoo.rog/831069

- rename gles2 USE flag to gles2-only (7.5)
Bugs: https://bugs.gentoo.org/831069
Bugs: https://bugs.gentoo.org/831126

Package-Manager: Portage-3.0.30, Repoman-3.0.3
Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>
