### PR TITLE
dev-java/glassfish-xmlrpc-api: EAPI 8, restrict to java 1.8

### DIFF
--- a/dev-java/glassfish-xmlrpc-api/glassfish-xmlrpc-api-1.1.1-r1.ebuild
+++ b/dev-java/glassfish-xmlrpc-api/glassfish-xmlrpc-api-1.1.1-r1.ebuild
@@ -1,0 +1,38 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+JAVA_PKG_IUSE="doc source"
+
+inherit java-pkg-2 java-ant-2
+
+TOMEE_PV="1.5.2"
+
+DESCRIPTION="Project GlassFish XML RPC API"
+HOMEPAGE="https://glassfish.java.net/"
+SRC_URI="https://dev.gentoo.org/~tomwij/files/dist/${P}.tar.xz"
+
+LICENSE="Apache-2.0"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+CDEPEND="java-virtuals/servlet-api:3.0"
+
+# Fails to compile with java-11, https://bugs.gentoo.org/831295
+DEPEND="virtual/jdk:1.8
+	${CDEPEND}"
+
+RDEPEND="virtual/jre:1.8
+	${CDEPEND}"
+
+JAVA_ANT_REWRITE_CLASSPATH="true"
+EANT_GENTOO_CLASSPATH="servlet-api-3.0"
+JAVA_PKG_BSFIX_NAME="maven-build.xml"
+
+src_install() {
+	java-pkg_newjar target/javax.xml.rpc-api-${PV}.jar
+
+	use doc && java-pkg_dojavadoc target/site/apidocs
+	use source && java-pkg_dosrc src/main/java/javax
+}


### PR DESCRIPTION
Do not merge.  There might be a way to make it work with java-11

Bug: https://bugs.gentoo.org/831295
Package-Manager: Portage-3.0.28, Repoman-3.0.3
Signed-off-by: Volkmar W. Pogatzki <gentoo@pogatzki.net>