### PR TITLE
net-ftp/ncftp: bump to EAPI 8 and fix bugs

### DIFF
--- a/net-ftp/ncftp/metadata.xml
+++ b/net-ftp/ncftp/metadata.xml
@@ -1,8 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<!-- maintainer-needed -->
-<longdescription>
+	<maintainer type="person" proxied="yes">
+		<email>ceamac.paragon@gmail.com</email>
+		<name>Viorel Munteanu</name>
+	</maintainer>
+	<maintainer type="project" proxied="proxy">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
+	<longdescription>
 NcFTP Client (also known as just NcFTP) is a set of FREE application 
 programs implementing the File Transfer Protocol (FTP).
 
@@ -11,5 +18,5 @@ popular alternative to the FTP program, /usr/bin/ftp. NcFTP offers many
 ease-of-use and performance enhancements over the stock ftp client, and 
 runs on a wide variety of UNIX platforms as well as operating systems 
 such as Microsoft Windows and Apple Mac OS X.
-</longdescription>
+	</longdescription>
 </pkgmetadata>

--- a/net-ftp/ncftp/ncftp-3.2.6-r4.ebuild
+++ b/net-ftp/ncftp/ncftp-3.2.6-r4.ebuild
@@ -1,0 +1,55 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+inherit autotools toolchain-funcs
+
+DESCRIPTION="An extremely configurable ftp client"
+HOMEPAGE="https://www.ncftp.com/"
+SRC_URI="
+	https://ftp.mirrorservice.org/sites/ftp.${PN}.com/${PN}/${P}-src.tar.xz
+"
+
+LICENSE="Clarified-Artistic"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~x86-solaris"
+IUSE="pch"
+
+DEPEND="
+	sys-libs/ncurses:=
+"
+RDEPEND="
+	${DEPEND}
+"
+BDEPEND="virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-3.2.6-fno-common.patch
+)
+
+src_prepare() {
+	default
+
+	sed -i -e '/^AR=/d' autoconf_local/aclocal.m4 || die
+	# 727774
+	sed -i -e 's/STRIP=".*"/STRIP=":"/' autoconf_local/aclocal.m4 || die
+
+	AT_M4DIR=autoconf_local/ eautoreconf
+}
+
+src_configure() {
+	tc-export AR CC
+	LC_ALL="C" \
+	LIBS="$( $(tc-getPKG_CONFIG) --libs ncurses)" \
+		econf \
+		$(use_enable pch precomp) \
+		--disable-ccdv \
+		--disable-universal
+}
+
+src_install() {
+	default
+	dodoc README.txt doc/*.txt
+	docinto html
+	dodoc doc/html/*.html
+}


### PR DESCRIPTION
Rename `configure.in` to `configure.ac` and disable `strip`