### PR TITLE
dev-java/cpptasks: Fix Javadoc generation on JDK 11+

### DIFF
--- a/dev-java/cpptasks/cpptasks-1.0_beta5-r1.ebuild
+++ b/dev-java/cpptasks/cpptasks-1.0_beta5-r1.ebuild
@@ -36,6 +36,7 @@ RDEPEND="
 "
 
 JAVA_ANT_REWRITE_CLASSPATH="yes"
+JAVA_ANT_CLASSPATH_TAGS="javac javadoc"
 
 EANT_BUILD_TARGET="jars"
 EANT_TEST_TARGET="run-tests -Djunit-available=true"


### PR DESCRIPTION
On JDK 11+, dependencies should be added to the classpath for `javadoc` to ensure successful doc generation.  This is the root cause of the bug ticket fixed by this PR and might have something to do with the bugs tracked by https://bugs.gentoo.org/820869 too.