### PR TITLE
dev-qt/qt-creator: add .desktop file

### DIFF
--- a/dev-qt/qt-creator/files/desktop-file.patch
+++ b/dev-qt/qt-creator/files/desktop-file.patch
@@ -1,0 +1,13 @@
+diff --git a/share/share.pro b/share/share.pro
+index 757e0ed..66a28c6 100644
+--- a/share/share.pro
++++ b/share/share.pro
+@@ -12,7 +12,7 @@ linux {
+     appstream.files = $$OUT_PWD/metainfo/org.qt-project.qtcreator.appdata.xml
+     appstream.path = $$QTC_PREFIX/share/metainfo/
+ 
+-    desktop.files = share/applications/org.qt-project.qtcreator.desktop
++    desktop.files = $$PWD/applications/org.qt-project.qtcreator.desktop
+     desktop.path = $$QTC_PREFIX/share/applications/
+ 
+     INSTALLS += appstream desktop

--- a/dev-qt/qt-creator/qt-creator-6.0.0.ebuild
+++ b/dev-qt/qt-creator/qt-creator-6.0.0.ebuild
@@ -119,6 +119,8 @@ pkg_setup() {
 src_prepare() {
 	default
 
+	eapply "${FILESDIR}/desktop-file.patch" # bug 828071
+
 	# disable unwanted plugins
 	for plugin in "${QTC_PLUGINS[@]#[+-]}"; do
 		if ! use ${plugin%:*}; then

--- a/dev-qt/qt-creator/qt-creator-9999.ebuild
+++ b/dev-qt/qt-creator/qt-creator-9999.ebuild
@@ -119,6 +119,8 @@ pkg_setup() {
 src_prepare() {
 	default
 
+	eapply "${FILESDIR}/desktop-file.patch" # bug 828071
+
 	# disable unwanted plugins
 	for plugin in "${QTC_PLUGINS[@]#[+-]}"; do
 		if ! use ${plugin%:*}; then


### PR DESCRIPTION
Hello,

This PR simply adds a .desktop file to the qt-creator package. I believe (I did not want to downgrade LLVM to test it out) version 4.15.1 adds a .desktop file but I don't know with which magic as the ebuild doesn't have any code related to such thing.

Closes: https://bugs.gentoo.org/828071

Signed-off-by: Adel KARA SLIMANE <adel.ks@zegrapher.com>