### PR TITLE
dev-python/pipenv: retain tomlkit in v2022.1.8

### DIFF
--- a/dev-python/pipenv/pipenv-2022.1.8.ebuild
+++ b/dev-python/pipenv/pipenv-2022.1.8.ebuild
@@ -81,9 +81,12 @@ src_prepare() {
 
 	# remove vendored versions
 	for pkgName in ${packages[@]}; do
-		 find ./pipenv/vendor/ -name "${pkgName}*" -prune -exec rm -rvf {} + || die
-		 # package names can be foo-bar, their module will be however foo_bar
-		 find ./pipenv/vendor/ -name "${pkgName/_/-}*" -prune -exec rm -rvf {} + || die
+		# remove all packages toml* also catches tomlkit. Remove this when tomlkit is stable
+		find ./pipenv/vendor -maxdepth 1 ! -name tomlkit -name "${pkgName}*" -prune -exec rm -rvf {} + || die
+		# find ./pipenv/vendor -maxdepth 1 ! -name tomlkit -name "${pkgName}*" -print
+
+		# package names can be foo-bar, their module will be however foo_bar
+		find ./pipenv/vendor/ -maxdepth 1 ! -name tomlkit -name "${pkgName/_/-}*" -prune -exec rm -rvf {} + || die
 
 	done
 


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/831101
Bug: https://bugs.gentoo.org/717666

Signed-off-by: Oz N Tiram <oz.tiram@gmail.com>