### PR TITLE
app-admin/eclean-kernel: python 3.10 support, port to EAPI 8

### DIFF
--- a/app-admin/eclean-kernel/eclean-kernel-2.99.3.ebuild
+++ b/app-admin/eclean-kernel/eclean-kernel-2.99.3.ebuild
@@ -1,9 +1,11 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
-PYTHON_COMPAT=( python3_{8..9} )
+DISTUTILS_USE_PEP517=setuptools
+PYTHON_COMPAT=( python3_{8..10} )
+
 inherit distutils-r1
 
 DESCRIPTION="Remove outdated built kernels"

--- a/dev-python/pymountboot/pymountboot-0.2.3-r1.ebuild
+++ b/dev-python/pymountboot/pymountboot-0.2.3-r1.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{8..9} )
+PYTHON_COMPAT=( python3_{8..10} )
 
 inherit distutils-r1
 


### PR DESCRIPTION
also `dev-python/pymountboot: python 3.10 support, port to EAPI 8` (needed for `eclean-kernel`)

*(sorry for doing it in one commit but changes are minor, I hope it's fine)*