### PR TITLE
app-office/gnumeric: py 3.10 support

### DIFF
--- a/app-office/gnumeric/gnumeric-1.12.50.ebuild
+++ b/app-office/gnumeric/gnumeric-1.12.50.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{7..9} )
+PYTHON_COMPAT=( python3_{7..10} )
 
 inherit gnome.org libtool python-r1 xdg
 


### PR DESCRIPTION
needed to drop py 3.9 from my install