### PR TITLE
dev-python/eventlet: python 3.10 support

### DIFF
--- a/dev-python/eventlet/eventlet-0.33.0.ebuild
+++ b/dev-python/eventlet/eventlet-0.33.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{8..9} )
+PYTHON_COMPAT=( python3_{8..10} )
 inherit distutils-r1
 
 DESCRIPTION="Highly concurrent networking library"


### PR DESCRIPTION
needed to drop 3.9 from my install