### PR TITLE
dev-java/glassfish-xmlrpc-api: Fix build error on Java 11+; EAPI 8

### DIFF
--- a/dev-java/glassfish-xmlrpc-api/glassfish-xmlrpc-api-1.1.1-r1.ebuild
+++ b/dev-java/glassfish-xmlrpc-api/glassfish-xmlrpc-api-1.1.1-r1.ebuild
@@ -1,0 +1,42 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+JAVA_PKG_IUSE="doc source"
+
+inherit java-pkg-2 java-ant-2
+
+DESCRIPTION="Project GlassFish XML RPC API"
+HOMEPAGE="https://glassfish.java.net/"
+SRC_URI="https://dev.gentoo.org/~tomwij/files/dist/${P}.tar.xz"
+
+LICENSE="Apache-2.0"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+CP_DEPEND="
+	dev-java/jakarta-xml-soap-api:1
+	java-virtuals/servlet-api:3.0
+"
+
+DEPEND="
+	>=virtual/jdk-1.8:*
+	${CP_DEPEND}
+"
+
+RDEPEND="
+	>=virtual/jre-1.8:*
+	${CP_DEPEND}
+"
+
+JAVA_ANT_REWRITE_CLASSPATH="true"
+JAVA_ANT_CLASSPATH_TAGS="javac javadoc"
+JAVA_PKG_BSFIX_NAME="maven-build.xml"
+
+src_install() {
+	java-pkg_newjar "target/javax.xml.rpc-api-${PV}.jar"
+
+	use doc && java-pkg_dojavadoc target/site/apidocs
+	use source && java-pkg_dosrc src/main/java/javax
+}


### PR DESCRIPTION
Successor of #23822.  `dev-java/glassfish-xmlrpc-api` requires Java package `javax.xml.soap`, which is no longer in the JDK proper as of Java 11.  This PR declares the provider of `javax.xml.soap` as a dependency so it can be built on JDK 11.