### PR TITLE
dev-java/xml-commons-external: Fix Javadoc on JDK 11+ for 1.4.01-r2

### DIFF
--- a/dev-java/xml-commons-external/xml-commons-external-1.4.01-r2.ebuild
+++ b/dev-java/xml-commons-external/xml-commons-external-1.4.01-r2.ebuild
@@ -22,3 +22,5 @@ KEYWORDS="amd64 ~arm arm64 ppc64 x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-mac
 RDEPEND=">=virtual/jre-1.8:*"
 DEPEND=">=virtual/jdk-1.8:*"
 BDEPEND="source? ( app-arch/zip )"
+
+JAVADOC_ARGS="-source 8"


### PR DESCRIPTION
By passing `-source 8` to `javadoc` from JDK 11, there is no need to patch the original source files to eliminate uses of `_` as an identifier.  This will be good enough until `javadoc` no longer supports the `-source 8` option.