### PR TITLE
dev-libs/spdlog: force use of external fmt lib

### DIFF
--- a/dev-libs/spdlog/files/spdlog-force_external_fmt.patch
+++ b/dev-libs/spdlog/files/spdlog-force_external_fmt.patch
@@ -1,0 +1,15 @@
+diff --git a/include/spdlog/tweakme.h b/include/spdlog/tweakme.h
+index 24361f30..6b4fc14c 100644
+--- a/include/spdlog/tweakme.h
++++ b/include/spdlog/tweakme.h
+@@ -71,7 +71,9 @@
+ // In this case spdlog will try to include <fmt/format.h> so set your -I flag
+ // accordingly.
+ //
+-// #define SPDLOG_FMT_EXTERNAL
++#ifndef SPDLOG_FMT_EXTERNAL
++#define SPDLOG_FMT_EXTERNAL
++#endif
+ ///////////////////////////////////////////////////////////////////////////////
+ 
+ ///////////////////////////////////////////////////////////////////////////////

--- a/dev-libs/spdlog/spdlog-1.9.2-r1.ebuild
+++ b/dev-libs/spdlog/spdlog-1.9.2-r1.ebuild
@@ -1,0 +1,53 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit cmake
+
+DESCRIPTION="Very fast, header only, C++ logging library"
+HOMEPAGE="https://github.com/gabime/spdlog"
+
+if [[ ${PV} == *9999 ]]; then
+	inherit git-r3
+	EGIT_REPO_URI="https://github.com/gabime/${PN}"
+else
+	SRC_URI="https://github.com/gabime/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+	# Temporary for bug #811750
+	SRC_URI+=" test? ( https://dev.gentoo.org/~sam/distfiles/${CATEGORY}/${PN}/${P}-update-catch-glibc-2.34.patch.bz2 )"
+	KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~x86"
+fi
+
+LICENSE="MIT"
+SLOT="0/1"
+IUSE="test"
+RESTRICT="!test? ( test )"
+
+BDEPEND="
+	virtual/pkgconfig
+"
+DEPEND="
+	>=dev-libs/libfmt-8.0.0:=
+"
+RDEPEND="${DEPEND}"
+
+PATCHES=( "${FILESDIR}/${PN}-force_external_fmt.patch" )
+
+src_prepare() {
+	use test && eapply "${WORKDIR}"/${P}-update-catch-glibc-2.34.patch
+
+	cmake_src_prepare
+	rm -r include/spdlog/fmt/bundled || die "Failed to delete bundled libfmt"
+}
+
+src_configure() {
+	local mycmakeargs=(
+		-DSPDLOG_BUILD_BENCH=no
+		-DSPDLOG_BUILD_EXAMPLE=no
+		-DSPDLOG_FMT_EXTERNAL=yes
+		-DSPDLOG_BUILD_SHARED=yes
+		-DSPDLOG_BUILD_TESTS=$(usex test)
+	)
+
+	cmake_src_configure
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/827889
Package-Manager: Portage-3.0.30, Repoman-3.0.3
Signed-off-by: David Roman <davidroman96@gmail.com>