### PR TITLE
dev-java/jython: Drop dependency on script-api | profiles/package.mask: Last-rite dev-java/jsr223

### DIFF
--- a/dev-java/jython/jython-2.7.0-r4.ebuild
+++ b/dev-java/jython/jython-2.7.0-r4.ebuild
@@ -33,7 +33,6 @@ CP_DEPEND="dev-java/antlr:3
 	dev-java/jnr-netdb:1.0
 	dev-java/stringtemplate:0
 	dev-java/xerces:2
-	java-virtuals/script-api:0
 	java-virtuals/servlet-api:3.0"
 RDEPEND="${CP_DEPEND}
 	>=virtual/jre-1.8:*"

--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -33,6 +33,12 @@
 
 #--- END OF EXAMPLES ---
 
+# Volkmar W. Pogatzki <gentoo@pogatzki.net> (2022-01-27)
+# Java-library + java-virtual with no consumers.
+# Removal in 30 days.
+java-virtuals/script-api
+dev-java/jsr223
+
 # Volkmar W. Pogatzki <gentoo@pogatzki.net> (2022-01-23)
 # Java-libraries with no consumers and depending on virtual/{jdk,jre}-1.6
 # Removal in 30 days.


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/831464
Package-Manager: Portage-3.0.28, Repoman-3.0.3
Signed-off-by: Volkmar W. Pogatzki <gentoo@pogatzki.net>