### PR TITLE
games-arcade/lbreakout: use https

### DIFF
--- a/games-arcade/lbreakout/lbreakout-010315-r1.ebuild
+++ b/games-arcade/lbreakout/lbreakout-010315-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -6,7 +6,7 @@ EAPI=8
 inherit desktop toolchain-funcs
 
 DESCRIPTION="Breakout clone written with the SDL library"
-HOMEPAGE="http://lgames.sourceforge.net/LBreakout/"
+HOMEPAGE="https://lgames.sourceforge.io/LBreakout/"
 SRC_URI="
 	mirror://sourceforge/lgames/${P}.tar.gz
 	https://dev.gentoo.org/~ionen/distfiles/${PN}.png"


### PR DESCRIPTION
Simple HOMEPAGE update to use https instead of http.

Package-Manager: Portage-3.0.30, Repoman-3.0.3
Signed-off-by: Michael Mair-Keimberger <mmk@levelnine.at>