### PR TITLE
net-voip/captagent: revision bump to fix clang compile

### DIFF
--- a/net-voip/captagent/captagent-6.3.1-r1.ebuild
+++ b/net-voip/captagent/captagent-6.3.1-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -15,8 +15,10 @@ KEYWORDS="~amd64 ~x86"
 IUSE="ipv6 mysql pcre redis ssl"
 
 PATCHES=(
-	# https://github.com/sipcapture/captagent/pull/239 (should be accepted).
+	# https://github.com/sipcapture/captagent/pull/239 (merged).
 	"${FILESDIR}/${P}-gcc10.patch"
+	# https://github.com/sipcapture/captagent/pull/245 (merged).
+	"${FILESDIR}/${P}-captagent-6.3.1-r1-clang.patch"
 	# Already upstreamed for next version.
 	"${FILESDIR}/${P}-configure.patch"
 )

--- a/net-voip/captagent/files/captagent-6.3.1-r1-clang.patch
+++ b/net-voip/captagent/files/captagent-6.3.1-r1-clang.patch
@@ -1,0 +1,63 @@
+From a4b5cc7806861b75b03ea0d31e1413e3e293770c Mon Sep 17 00:00:00 2001
+From: Jaco Kroon <jaco@uls.co.za>
+Date: Thu, 20 Jan 2022 07:07:40 +0200
+Subject: [PATCH] Move declaration of usage() function to avoid conflicting
+ implicit declaration.
+
+Signed-off-by: Jaco Kroon <jaco@uls.co.za>
+---
+ src/captagent.c | 31 +++++++++++++++----------------
+ 1 file changed, 15 insertions(+), 16 deletions(-)
+
+diff --git a/src/captagent.c b/src/captagent.c
+index 6f5f533..052b0bb 100644
+--- a/src/captagent.c
++++ b/src/captagent.c
+@@ -108,6 +108,21 @@ void handler(int value) {
+ 	exit(0);
+ }
+ 
++void usage(int8_t e)
++{
++	printf(
++        "usage: Captagent <-vh> <-f config>\n"
++        "   -h  display help/usage\n"
++        "   -a  print a list of all availlable devices\n"
++        "   -v  display version information\n"
++        "   -c  validate configuration and exit\n"
++        "   -d  enable daemon mode\n"
++        "   -n  enable foreground mode\n"
++        "   -f  [/path/to/rtpagent.xml] to specify a config file\n"
++        "   -D  [/path/to/file.pcap] to specify a pcap file as input\n"
++        "   -x  [1 - 10] set debug level\n");
++	exit(e);
++}
+ 
+ // Print the list of availlable devices
+ static void print_all_devices()
+@@ -230,22 +245,6 @@ int daemonize(int nofork)
+ 	error: return -1;
+ }
+ 
+-void usage(int8_t e)
+-{
+-	printf(
+-        "usage: Captagent <-vh> <-f config>\n"
+-        "   -h  display help/usage\n"
+-        "   -a  print a list of all availlable devices\n"
+-        "   -v  display version information\n"
+-        "   -c  validate configuration and exit\n"
+-        "   -d  enable daemon mode\n"
+-        "   -n  enable foreground mode\n"
+-        "   -f  [/path/to/rtpagent.xml] to specify a config file\n"
+-        "   -D  [/path/to/file.pcap] to specify a pcap file as input\n"
+-        "   -x  [1 - 10] set debug level\n");
+-	exit(e);
+-}
+-
+ void print_hw() {
+ 
+ 	char k[33];
+-- 
+2.33.1
+


### PR DESCRIPTION
Upstream: https://github.com/sipcapture/captagent/pull/245

Not expecting a new release soon.

Closes: https://bugs.gentoo.org/831391
Package-Manager: Portage-3.0.28, Repoman-3.0.3
Signed-off-by: Jaco Kroon <jaco@uls.co.za>