### PR TITLE
app-emulation/libvirt: Rebase libvirt-6.7.0-do-not-use-sysconfig.patch

### DIFF
--- a/app-emulation/libvirt/files/libvirt-8.1.0-do-not-use-sysconfig.patch
+++ b/app-emulation/libvirt/files/libvirt-8.1.0-do-not-use-sysconfig.patch
@@ -1,0 +1,208 @@
+From e669d8bdc18a04154b10f0a21ee3f7c4141d2a42 Mon Sep 17 00:00:00 2001
+Message-Id: <e669d8bdc18a04154b10f0a21ee3f7c4141d2a42.1642669122.git.mprivozn@redhat.com>
+From: Michal Privoznik <mprivozn@redhat.com>
+Date: Thu, 20 Jan 2022 09:39:58 +0100
+Subject: [PATCH] do not use sysconfig
+
+Signed-off-by: Michal Privoznik <mprivozn@redhat.com>
+---
+ src/interface/virtinterfaced.service.in | 1 -
+ src/libxl/virtxend.service.in           | 1 -
+ src/locking/virtlockd.service.in        | 1 -
+ src/logging/virtlogd.service.in         | 1 -
+ src/lxc/virtlxcd.service.in             | 1 -
+ src/network/virtnetworkd.service.in     | 1 -
+ src/node_device/virtnodedevd.service.in | 1 -
+ src/nwfilter/virtnwfilterd.service.in   | 1 -
+ src/qemu/virtqemud.service.in           | 1 -
+ src/remote/libvirtd.service.in          | 1 -
+ src/remote/virtproxyd.service.in        | 1 -
+ src/secret/virtsecretd.service.in       | 1 -
+ src/storage/virtstoraged.service.in     | 1 -
+ src/vbox/virtvboxd.service.in           | 1 -
+ tools/libvirt-guests.service.in         | 1 -
+ 15 files changed, 15 deletions(-)
+
+diff --git a/src/interface/virtinterfaced.service.in b/src/interface/virtinterfaced.service.in
+index 3d944e17a9..1d94f3c943 100644
+--- a/src/interface/virtinterfaced.service.in
++++ b/src/interface/virtinterfaced.service.in
+@@ -14,7 +14,6 @@ Documentation=https://libvirt.org
+ [Service]
+ Type=notify
+ Environment=VIRTINTERFACED_ARGS="--timeout 120"
+-EnvironmentFile=-@sysconfdir@/sysconfig/virtinterfaced
+ ExecStart=@sbindir@/virtinterfaced $VIRTINTERFACED_ARGS
+ ExecReload=/bin/kill -HUP $MAINPID
+ Restart=on-failure
+diff --git a/src/libxl/virtxend.service.in b/src/libxl/virtxend.service.in
+index 2b5163e179..4edfdeb719 100644
+--- a/src/libxl/virtxend.service.in
++++ b/src/libxl/virtxend.service.in
+@@ -19,7 +19,6 @@ ConditionPathExists=/proc/xen/capabilities
+ [Service]
+ Type=notify
+ Environment=VIRTXEND_ARGS="--timeout 120"
+-EnvironmentFile=-@sysconfdir@/sysconfig/virtxend
+ ExecStart=@sbindir@/virtxend $VIRTXEND_ARGS
+ ExecReload=/bin/kill -HUP $MAINPID
+ Restart=on-failure
+diff --git a/src/locking/virtlockd.service.in b/src/locking/virtlockd.service.in
+index 19271d1e7d..87193952cb 100644
+--- a/src/locking/virtlockd.service.in
++++ b/src/locking/virtlockd.service.in
+@@ -8,7 +8,6 @@ Documentation=https://libvirt.org
+ 
+ [Service]
+ Environment=VIRTLOCKD_ARGS=
+-EnvironmentFile=-@sysconfdir@/sysconfig/virtlockd
+ ExecStart=@sbindir@/virtlockd $VIRTLOCKD_ARGS
+ ExecReload=/bin/kill -USR1 $MAINPID
+ # Losing the locks is a really bad thing that will
+diff --git a/src/logging/virtlogd.service.in b/src/logging/virtlogd.service.in
+index 8ab5478517..a734e0ef9d 100644
+--- a/src/logging/virtlogd.service.in
++++ b/src/logging/virtlogd.service.in
+@@ -7,7 +7,6 @@ Documentation=man:virtlogd(8)
+ Documentation=https://libvirt.org
+ 
+ [Service]
+-EnvironmentFile=-@sysconfdir@/sysconfig/virtlogd
+ ExecStart=@sbindir@/virtlogd $VIRTLOGD_ARGS
+ ExecReload=/bin/kill -USR1 $MAINPID
+ # Losing the logs is a really bad thing that will
+diff --git a/src/lxc/virtlxcd.service.in b/src/lxc/virtlxcd.service.in
+index d58bde9f5d..c5c2bb31e4 100644
+--- a/src/lxc/virtlxcd.service.in
++++ b/src/lxc/virtlxcd.service.in
+@@ -19,7 +19,6 @@ Documentation=https://libvirt.org
+ [Service]
+ Type=notify
+ Environment=VIRTLXCD_ARGS="--timeout 120"
+-EnvironmentFile=-@sysconfdir@/sysconfig/virtlxcd
+ ExecStart=@sbindir@/virtlxcd $VIRTLXCD_ARGS
+ ExecReload=/bin/kill -HUP $MAINPID
+ KillMode=process
+diff --git a/src/network/virtnetworkd.service.in b/src/network/virtnetworkd.service.in
+index 3decfbbf1d..c7c57fdd44 100644
+--- a/src/network/virtnetworkd.service.in
++++ b/src/network/virtnetworkd.service.in
+@@ -17,7 +17,6 @@ Documentation=https://libvirt.org
+ [Service]
+ Type=notify
+ Environment=VIRTNETWORKD_ARGS="--timeout 120"
+-EnvironmentFile=-@sysconfdir@/sysconfig/virtnetworkd
+ ExecStart=@sbindir@/virtnetworkd $VIRTNETWORKD_ARGS
+ ExecReload=/bin/kill -HUP $MAINPID
+ Restart=on-failure
+diff --git a/src/node_device/virtnodedevd.service.in b/src/node_device/virtnodedevd.service.in
+index 688cf89822..41c7a0f0f0 100644
+--- a/src/node_device/virtnodedevd.service.in
++++ b/src/node_device/virtnodedevd.service.in
+@@ -14,7 +14,6 @@ Documentation=https://libvirt.org
+ [Service]
+ Type=notify
+ Environment=VIRTNODEDEVD_ARGS="--timeout 120"
+-EnvironmentFile=-@sysconfdir@/sysconfig/virtnodedevd
+ ExecStart=@sbindir@/virtnodedevd $VIRTNODEDEVD_ARGS
+ ExecReload=/bin/kill -HUP $MAINPID
+ Restart=on-failure
+diff --git a/src/nwfilter/virtnwfilterd.service.in b/src/nwfilter/virtnwfilterd.service.in
+index 36d00b58f0..d422bfeca1 100644
+--- a/src/nwfilter/virtnwfilterd.service.in
++++ b/src/nwfilter/virtnwfilterd.service.in
+@@ -14,7 +14,6 @@ Documentation=https://libvirt.org
+ [Service]
+ Type=notify
+ Environment=VIRTNWFILTERD_ARGS="--timeout 120"
+-EnvironmentFile=-@sysconfdir@/sysconfig/virtnwfilterd
+ ExecStart=@sbindir@/virtnwfilterd $VIRTNWFILTERD_ARGS
+ ExecReload=/bin/kill -HUP $MAINPID
+ Restart=on-failure
+diff --git a/src/qemu/virtqemud.service.in b/src/qemu/virtqemud.service.in
+index 551eb4d405..4c0344aad2 100644
+--- a/src/qemu/virtqemud.service.in
++++ b/src/qemu/virtqemud.service.in
+@@ -21,7 +21,6 @@ Documentation=https://libvirt.org
+ [Service]
+ Type=notify
+ Environment=VIRTQEMUD_ARGS="--timeout 120"
+-EnvironmentFile=-@sysconfdir@/sysconfig/virtqemud
+ ExecStart=@sbindir@/virtqemud $VIRTQEMUD_ARGS
+ ExecReload=/bin/kill -HUP $MAINPID
+ KillMode=process
+diff --git a/src/remote/libvirtd.service.in b/src/remote/libvirtd.service.in
+index 5d4d412fcc..27cfc34b90 100644
+--- a/src/remote/libvirtd.service.in
++++ b/src/remote/libvirtd.service.in
+@@ -29,7 +29,6 @@ Documentation=https://libvirt.org
+ [Service]
+ Type=notify
+ Environment=LIBVIRTD_ARGS="--timeout 120"
+-EnvironmentFile=-@sysconfdir@/sysconfig/libvirtd
+ ExecStart=@sbindir@/libvirtd $LIBVIRTD_ARGS
+ ExecReload=/bin/kill -HUP $MAINPID
+ KillMode=process
+diff --git a/src/remote/virtproxyd.service.in b/src/remote/virtproxyd.service.in
+index 10e8cf7263..5fc887fe4a 100644
+--- a/src/remote/virtproxyd.service.in
++++ b/src/remote/virtproxyd.service.in
+@@ -14,7 +14,6 @@ Documentation=https://libvirt.org
+ [Service]
+ Type=notify
+ Environment=VIRTPROXYD_ARGS="--timeout 120"
+-EnvironmentFile=-@sysconfdir@/sysconfig/virtproxyd
+ ExecStart=@sbindir@/virtproxyd $VIRTPROXYD_ARGS
+ ExecReload=/bin/kill -HUP $MAINPID
+ Restart=on-failure
+diff --git a/src/secret/virtsecretd.service.in b/src/secret/virtsecretd.service.in
+index cbd63fe0b2..bdf96ea0b1 100644
+--- a/src/secret/virtsecretd.service.in
++++ b/src/secret/virtsecretd.service.in
+@@ -14,7 +14,6 @@ Documentation=https://libvirt.org
+ [Service]
+ Type=notify
+ Environment=VIRTSECRETD_ARGS="--timeout 120"
+-EnvironmentFile=-@sysconfdir@/sysconfig/virtsecretd
+ ExecStart=@sbindir@/virtsecretd $VIRTSECRETD_ARGS
+ ExecReload=/bin/kill -HUP $MAINPID
+ Restart=on-failure
+diff --git a/src/storage/virtstoraged.service.in b/src/storage/virtstoraged.service.in
+index f72f8426fd..6e865e53e7 100644
+--- a/src/storage/virtstoraged.service.in
++++ b/src/storage/virtstoraged.service.in
+@@ -16,7 +16,6 @@ Documentation=https://libvirt.org
+ [Service]
+ Type=notify
+ Environment=VIRTSTORAGED_ARGS="--timeout 120"
+-EnvironmentFile=-@sysconfdir@/sysconfig/virtstoraged
+ ExecStart=@sbindir@/virtstoraged $VIRTSTORAGED_ARGS
+ ExecReload=/bin/kill -HUP $MAINPID
+ Restart=on-failure
+diff --git a/src/vbox/virtvboxd.service.in b/src/vbox/virtvboxd.service.in
+index cfdafc39d2..a1108e60f8 100644
+--- a/src/vbox/virtvboxd.service.in
++++ b/src/vbox/virtvboxd.service.in
+@@ -15,7 +15,6 @@ Documentation=https://libvirt.org
+ [Service]
+ Type=notify
+ Environment=VIRTVBOXD_ARGS="--timeout 120"
+-EnvironmentFile=-@sysconfdir@/sysconfig/virtvboxd
+ ExecStart=@sbindir@/virtvboxd $VIRTVBOXD_ARGS
+ ExecReload=/bin/kill -HUP $MAINPID
+ Restart=on-failure
+diff --git a/tools/libvirt-guests.service.in b/tools/libvirt-guests.service.in
+index 1a9b233e11..765b777536 100644
+--- a/tools/libvirt-guests.service.in
++++ b/tools/libvirt-guests.service.in
+@@ -10,7 +10,6 @@ Documentation=man:libvirt-guests(8)
+ Documentation=https://libvirt.org
+ 
+ [Service]
+-EnvironmentFile=-@sysconfdir@/sysconfig/libvirt-guests
+ # Hack just call traditional service until we factor
+ # out the code
+ ExecStart=@libexecdir@/libvirt-guests.sh start
+-- 
+2.34.1
+

--- a/app-emulation/libvirt/libvirt-9999.ebuild
+++ b/app-emulation/libvirt/libvirt-9999.ebuild
@@ -132,8 +132,8 @@ DEPEND="${BDEPEND}
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-6.0.0-fix_paths_in_libvirt-guests_sh.patch
-	"${FILESDIR}"/${PN}-6.7.0-do-not-use-sysconfig.patch
 	"${FILESDIR}"/${PN}-6.7.0-fix-paths-for-apparmor.patch
+	"${FILESDIR}"/${PN}-8.1.0-do-not-use-sysconfig.patch
 )
 
 pkg_setup() {


### PR DESCRIPTION
The live ebuild applies libvirt-8.1.0-do-not-use-sysconfig.patch
which does no longer apply cleanly because of libvirt's commit
8eb4461645. Rebase the patch onto current master.

Signed-off-by: Michal Privoznik <mprivozn@redhat.com>