### PR TITLE
sys-libs/zlib: add patch to fix configure AR/RANLIB/NM detection

### DIFF
--- a/sys-libs/zlib/files/zlib-1.2.11-configure-fix-AR-RANLIB-NM-detection.patch
+++ b/sys-libs/zlib/files/zlib-1.2.11-configure-fix-AR-RANLIB-NM-detection.patch
@@ -1,0 +1,88 @@
+From 4232e67ee1440634af8209c7022dfc64cf862819 Mon Sep 17 00:00:00 2001
+From: Adrian Ratiu <adrian.ratiu@collabora.com>
+Date: Mon, 17 Jan 2022 10:49:58 +0200
+Subject: [PATCH v3] configure: fix AR/RANLIB/NM detection
+
+Taken from zlib-devel ML:
+https://madler.net/pipermail/zlib-devel_madler.net/2022-January/003322.html
+
+Bug: https://bugs.gentoo.org/831628
+
+Scenarios where ${CROSS_PREFIX}ar & co are set but not desired
+are possible, for example in ChromiumOS we use the GNU binutils
+tools & GCC to build glibc but LLVM/Clang is used for the rest
+of the system.
+
+This allows $AR/$RANLIB/$NM to override default CROSS_PREFIX
+tools so they can be set to llvm-ar/ranlib/nm.
+
+Suggested-by: Manoj Gupta <manojgupta@chromium.org>
+Signed-off-by: Adrian Ratiu <adrian.ratiu@collabora.com>
+---
+
+Changes in v3:
+  * Whitespace style fixes
+  * Fixed top level variable tests (eg -z AR -> -z $AR)
+  * Review and testing as part of Gentoo PR:
+    https://github.com/gentoo/gentoo/pull/23888
+Changes in v2:
+  * Fixed a typo in the "unset NM" case
+---
+ configure | 38 ++++++++++++++++++++++----------------
+ 1 file changed, 22 insertions(+), 16 deletions(-)
+
+diff --git a/configure b/configure
+index e974d1f..045c616 100755
+--- a/configure
++++ b/configure
+@@ -46,25 +46,31 @@ VER2=`sed -n -e '/VERSION "/s/.*"\([0-9]*\\.[0-9]*\)\\..*/\1/p' < ${SRCDIR}zlib.
+ VER1=`sed -n -e '/VERSION "/s/.*"\([0-9]*\)\\..*/\1/p' < ${SRCDIR}zlib.h`
+ 
+ # establish commands for library building
+-if "${CROSS_PREFIX}ar" --version >/dev/null 2>/dev/null || test $? -lt 126; then
+-    AR=${AR-"${CROSS_PREFIX}ar"}
+-    test -n "${CROSS_PREFIX}" && echo Using ${AR} | tee -a configure.log
+-else
+-    AR=${AR-"ar"}
+-    test -n "${CROSS_PREFIX}" && echo Using ${AR} | tee -a configure.log
++if [ -z "$AR" ]; then
++    if "${CROSS_PREFIX}ar" --version >/dev/null 2>/dev/null || test $? -lt 126; then
++        AR=${AR-"${CROSS_PREFIX}ar"}
++        test -n "${CROSS_PREFIX}" && echo Using ${AR} | tee -a configure.log
++    else
++        AR="ar"
++        test -n "${CROSS_PREFIX}" && echo Using ${AR} | tee -a configure.log
++    fi
+ fi
+ ARFLAGS=${ARFLAGS-"rc"}
+-if "${CROSS_PREFIX}ranlib" --version >/dev/null 2>/dev/null || test $? -lt 126; then
+-    RANLIB=${RANLIB-"${CROSS_PREFIX}ranlib"}
+-    test -n "${CROSS_PREFIX}" && echo Using ${RANLIB} | tee -a configure.log
+-else
+-    RANLIB=${RANLIB-"ranlib"}
++if [ -z "$RANLIB" ]; then
++    if "${CROSS_PREFIX}ranlib" --version >/dev/null 2>/dev/null || test $? -lt 126; then
++        RANLIB=${RANLIB-"${CROSS_PREFIX}ranlib"}
++        test -n "${CROSS_PREFIX}" && echo Using ${RANLIB} | tee -a configure.log
++    else
++        RANLIB="ranlib"
++    fi
+ fi
+-if "${CROSS_PREFIX}nm" --version >/dev/null 2>/dev/null || test $? -lt 126; then
+-    NM=${NM-"${CROSS_PREFIX}nm"}
+-    test -n "${CROSS_PREFIX}" && echo Using ${NM} | tee -a configure.log
+-else
+-    NM=${NM-"nm"}
++if [ -z "$NM" ]; then
++    if "${CROSS_PREFIX}nm" --version >/dev/null 2>/dev/null || test $? -lt 126;   then
++        NM=${NM-"${CROSS_PREFIX}nm"}
++        test -n "${CROSS_PREFIX}" && echo Using ${NM} | tee -a configure.log
++    else
++        NM="nm"
++    fi
+ fi
+ 
+ # set defaults before processing command line options
+-- 
+2.35.0
+

--- a/sys-libs/zlib/zlib-1.2.11-r4.ebuild
+++ b/sys-libs/zlib/zlib-1.2.11-r4.ebuild
@@ -34,6 +34,7 @@ DEPEND="${RDEPEND}"
 PATCHES=(
 	"${FILESDIR}"/${PN}-1.2.11-fix-deflateParams-usage.patch
 	"${FILESDIR}"/${PN}-1.2.11-minizip-drop-crypt-header.patch #658536
+	"${FILESDIR}"/${PN}-1.2.11-configure-fix-AR-RANLIB-NM-detection.patch #831628
 )
 
 src_prepare() {


### PR DESCRIPTION
This adds a patch from the zlib-devel ML to fix a minor
build inconsistency leading to GNU tools usage in LLVM
configured builds.

The reason we're adding it directly here is zlib upstream
takes forever to release new versions and there's not much
activity for some time (last release was in Jan 2017).

Bug: https://bugs.gentoo.org/831628
Signed-off-by: Adrian Ratiu <adrian.ratiu@collabora.com>