### PR TITLE
media-gfx/librecad: keywording ~riscv

### DIFF
--- a/media-gfx/librecad/librecad-2.1.3-r6.ebuild
+++ b/media-gfx/librecad/librecad-2.1.3-r6.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ SRC_URI="https://github.com/LibreCAD/LibreCAD/archive/${PV/_/}.tar.gz -> ${P}.ta
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 ~ppc64 x86 ~amd64-linux ~x86-linux"
+KEYWORDS="amd64 ~ppc64 ~riscv x86 ~amd64-linux ~x86-linux"
 IUSE="debug doc tools"
 
 RDEPEND="

--- a/media-gfx/librecad/librecad-9999.ebuild
+++ b/media-gfx/librecad/librecad-9999.ebuild
@@ -14,7 +14,7 @@ if [[ ${PV} == *9999* ]]; then
 else
 	SRC_URI="https://github.com/LibreCAD/LibreCAD/archive/${PV/_/}.tar.gz -> ${P}.tar.gz"
 	S="${WORKDIR}/LibreCAD-${PV}"
-	KEYWORDS="~amd64 ~ppc64 ~x86 ~amd64-linux ~x86-linux"
+	KEYWORDS="~amd64 ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux"
 fi
 
 LICENSE="GPL-2"


### PR DESCRIPTION
Tested librecad on unmatched hardware.

Package-Manager: Portage-3.0.28, Repoman-3.0.3
Signed-off-by: Jer Sun <sjj991212@gmail.com>