### PR TITLE
profiles/base: mask sys-libs/db[java]

### DIFF
--- a/profiles/base/package.use.mask
+++ b/profiles/base/package.use.mask
@@ -1,10 +1,15 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # New entries go on top.
 
 # This file is only for generic masks. For arch-specific masks (i.e.
 # mask everywhere, unmask on arch/*) use arch/base.
+
+# Sam James <sam@gentoo.org> (2022-01-23)
+# Java bindings are broken with OpenJDK 11+ and we're not
+# aware of any consumers. bug #713866
+sys-libs/db java
 
 # Sam James <sam@gentoo.org> (2022-01-12)
 # Unmask PCH for now for GCC to avoid unnecessary rebuilds


### PR DESCRIPTION
Broken with OpenJDK 11+ and we're not aware of anybody actually
needing these anyway.

Bug: https://bugs.gentoo.org/713866
Signed-off-by: Sam James <sam@gentoo.org>