### PR TITLE
net-p2p/freenet: Fix build and runtime errors with JNA 5.x

### DIFF
--- a/net-p2p/freenet/files/0.7.5_p1491-update-for-jna-5.x.patch
+++ b/net-p2p/freenet/files/0.7.5_p1491-update-for-jna-5.x.patch
@@ -1,0 +1,31 @@
+From 830b4bb3948bd69fbd9b10001940f1775051114a Mon Sep 17 00:00:00 2001
+From: Yuan Liao <liaoyuan@gmail.com>
+Date: Sun, 23 Jan 2022 10:09:17 -0800
+Subject: [PATCH] Replace Pointer.SIZE with Native.POINTER_SIZE for JNA 5.x
+
+This patch is backward compatible with JNA 4.x because
+Native.POINTER_SIZE is present in both 4.x and 5.x.
+
+Bug: https://github.com/kaitoy/pcap4j/issues/191
+Bug: https://bugs.gentoo.org/830847
+Signed-off-by: Yuan Liao <liaoyuan@gmail.com>
+---
+ src/freenet/io/comm/UdpSocketHandler.java | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/freenet/io/comm/UdpSocketHandler.java b/src/freenet/io/comm/UdpSocketHandler.java
+index 0cd975f16..c004613a9 100644
+--- a/src/freenet/io/comm/UdpSocketHandler.java
++++ b/src/freenet/io/comm/UdpSocketHandler.java
+@@ -120,7 +120,7 @@ public class UdpSocketHandler implements PrioRunnable, PacketSocketHandler, Port
+ 			    return false;
+ 			int ret = -1;
+ 			try {
+-			    ret = socketOptionsHolder.setsockopt(fd, SOCKET_level.IPPROTO_IPV6.linux, p.option_name.linux, new IntByReference(p.linux).getPointer(), Pointer.SIZE);
++			    ret = socketOptionsHolder.setsockopt(fd, SOCKET_level.IPPROTO_IPV6.linux, p.option_name.linux, new IntByReference(p.linux).getPointer(), Native.POINTER_SIZE);
+ 			} catch(Exception e) { Logger.normal(UdpSocketHandler.class, e.getMessage(),e); } //if it fails that's fine
+ 			return (ret == 0 ? true : false);
+ 		}
+-- 
+2.34.1
+

--- a/net-p2p/freenet/files/freenet-0.7.5_p1491-wrapper.conf
+++ b/net-p2p/freenet/files/freenet-0.7.5_p1491-wrapper.conf
@@ -1,0 +1,30 @@
+wrapper.java.command=java
+wrapper.working.dir=/var/freenet/
+wrapper.java.mainclass=freenet.node.NodeStarter
+wrapper.java.library.path.1=/usr/lib
+wrapper.java.initmemory=60
+wrapper.java.maxmemory=1024
+wrapper.java.additional.1=-Dnetworkaddress.cache.ttl=0
+wrapper.java.additional.2=-Dnetworkaddress.cache.negative.ttl=0
+wrapper.java.additional.3=-enableassertions:freenet
+# You might want to set the following line if you have changed java.maxmemory
+wrapper.java.additional.4=-XX:MaxPermSize=1024M
+# Required since JNA 5.0.0, which changed the default JNI library search path
+# https://github.com/java-native-access/jna/issues/384
+wrapper.java.additional.5=-Djna.nosys=false
+
+wrapper.app.parameter.1=freenet.ini
+wrapper.console.format=PM
+wrapper.console.loglevel=INFO
+wrapper.logfile=wrapper.log
+wrapper.logfile.format=LPTM
+wrapper.logfile.loglevel=INFO
+wrapper.logfile.maxsize=2M
+wrapper.logfile.maxfiles=3
+wrapper.syslog.loglevel=NONE
+wrapper.console.title=Freenet 0.7
+wrapper.jvm_exit.timeout=120
+wrapper.restart.reload_configuration=TRUE
+wrapper.filter.trigger.1=java.lang.OutOfMemoryError
+wrapper.filter.action.1=RESTART
+

--- a/net-p2p/freenet/freenet-0.7.5_p1488-r2.ebuild
+++ b/net-p2p/freenet/freenet-0.7.5_p1488-r2.ebuild
@@ -1,0 +1,169 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+JAVA_PKG_IUSE="doc source"
+
+inherit epatch java-pkg-2 java-ant-2 systemd
+
+DESCRIPTION="An encrypted network without censorship"
+HOMEPAGE="https://freenetproject.org/"
+#	https://github.com/${PN}/seedrefs/archive/build0${PV#*p}.zip -> seednodes-${PV}.zip
+SRC_URI="
+	https://github.com/${PN}/fred/archive/build0${PV#*p}.zip -> ${P}.zip
+	https://github.com/${PN}/seedrefs/archive/build01480.zip -> seednodes-0.7.5_p1480.zip
+	mirror://gentoo/freenet-ant-1.7.1.jar"
+
+LICENSE="GPL-2+ GPL-2 MIT BSD-2 Apache-2.0"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="+nss test"
+
+CDEPEND="dev-java/bcprov:0
+	dev-java/commons-compress:0
+	dev-java/fec:0
+	dev-java/java-service-wrapper:0
+	dev-java/jbitcollider-core:0
+	dev-java/jna:4
+	dev-java/lzma:0
+	dev-java/lzmajio:0
+	dev-java/mersennetwister:0
+	nss? ( dev-libs/nss )"
+
+DEPEND="
+	app-arch/unzip
+	>=virtual/jdk-1.8
+	${CDEPEND}
+	test? (
+		dev-java/junit:0
+		dev-java/ant-junit:0
+	)
+	dev-java/ant-core:0"
+
+RDEPEND="
+	>=virtual/jre-1.8
+	net-libs/nativebiginteger:0
+	${CDEPEND}
+	acct-user/freenet
+	acct-group/freenet"
+
+PDEPEND="net-libs/NativeThread:0"
+
+JAVA_PKG_BSFIX_NAME+=" build-clean.xml"
+JAVA_ANT_REWRITE_CLASSPATH="yes"
+JAVA_ANT_CLASSPATH_TAGS+=" javadoc"
+JAVA_ANT_ENCODING="utf8"
+
+EANT_BUILD_TARGET="package"
+EANT_TEST_TARGET="unit"
+EANT_BUILD_XML="build-clean.xml"
+EANT_GENTOO_CLASSPATH="bcprov,commons-compress,fec,java-service-wrapper,jbitcollider-core,jna-4,lzma,lzmajio,mersennetwister"
+EANT_EXTRA_ARGS="-Dsuppress.gjs=true -Dlib.contrib.present=true -Dlib.bouncycastle.present=true -Dlib.junit.present=true -Dtest.skip=true"
+
+S="${WORKDIR}/fred-build0${PV#*p}"
+
+RESTRICT="test" # they're broken in the last release.
+
+MY_PATCHES=(
+	"${FILESDIR}"/0.7.5_p1491-update-for-jna-5.x.patch
+	"${FILESDIR}"/0.7.5_p1483-ext.patch
+	"${FILESDIR}/"0.7.5_p1475-remove-git.patch
+)
+
+pkg_setup() {
+	has_version dev-java/icedtea[cacao] && {
+		ewarn "dev-java/icedtea was built with cacao USE flag."
+		ewarn "freenet may compile with it, but it will refuse to run."
+		ewarn "Please remerge dev-java/icedtea without cacao USE flag,"
+		ewarn "if you plan to use it for running freenet."
+	}
+	java-pkg-2_pkg_setup
+}
+
+src_unpack() {
+#	unpack ${P}.zip seednodes-${PV}.zip
+	unpack ${P}.zip seednodes-0.7.5_p1480.zip
+}
+
+src_prepare() {
+#	cat "${WORKDIR}"/seedrefs-build0${PV#*p}/* > "${S}"/seednodes.fref
+	cat "${WORKDIR}"/seedrefs-build01480/* > "${S}"/seednodes.fref
+	cp "${FILESDIR}"/freenet-0.7.5_p1491-wrapper.conf freenet-wrapper.conf || die
+	cp "${FILESDIR}"/run.sh-20090501 run.sh || die
+	cp "${FILESDIR}"/build-clean.xml build-clean.xml || die
+	cp "${FILESDIR}"/build.properties build.properties || die
+
+	epatch "${MY_PATCHES[@]}"
+
+	sed -i -e "s:=/usr/lib:=/usr/$(get_libdir):g" \
+		freenet-wrapper.conf || die "sed failed"
+
+	echo "wrapper.java.classpath.1=/usr/share/freenet/lib/freenet.jar" >> freenet-wrapper.conf || die
+	if use nss; then
+		echo "wrapper.java.additional.6=-Dfreenet.jce.use.NSS=true" >> freenet-wrapper.conf || die
+	fi
+	local i=2 pkg jars jar
+	local ifs_original=${IFS}
+	IFS=","
+	for pkg in ${EANT_GENTOO_CLASSPATH} ; do
+		jars="$(java-pkg_getjars ${pkg})"
+		for jar in ${jars} ; do
+			echo "wrapper.java.classpath.$((i++))=${jar}" >> freenet-wrapper.conf || die
+		done
+	done
+	IFS=${ifs_original}
+	echo "wrapper.java.classpath.$((i++))=/usr/share/freenet/lib/ant.jar" >> freenet-wrapper.conf || die
+	echo "wrapper.java.library.path.2=/usr/$(get_libdir)/java-service-wrapper" >> freenet-wrapper.conf || die
+	echo "wrapper.java.library.path.3=/usr/$(get_libdir)/jna-4" >> freenet-wrapper.conf || die
+
+	cp "${DISTDIR}"/freenet-ant-1.7.1.jar lib/ant.jar || die
+	eapply_user
+}
+
+EANT_TEST_EXTRA_ARGS="-Dtest.skip=false"
+
+src_test() {
+	java-pkg-2_src_test
+}
+
+src_install() {
+	java-pkg_dojar dist/freenet.jar
+	java-pkg_newjar "${DISTDIR}"/freenet-ant-1.7.1.jar ant.jar
+
+	if has_version =sys-apps/baselayout-2*; then
+		doinitd "${FILESDIR}"/freenet
+	else
+		newinitd "${FILESDIR}"/freenet.old freenet
+	fi
+
+	systemd_dounit "${FILESDIR}"/freenet.service
+
+	dodoc AUTHORS
+	newdoc README.md README
+	insinto /etc
+	doins freenet-wrapper.conf
+	insinto /var/freenet
+	doins run.sh seednodes.fref
+	fperms +x /var/freenet/run.sh
+	use doc && java-pkg_dojavadoc javadoc
+	use source && java-pkg_dosrc src
+}
+
+pkg_postinst() {
+	elog " "
+	elog "1. Start freenet with /etc/init.d/freenet start."
+	elog "2. Open localhost:8888 in your browser for the web interface."
+	#workaround for previously existing freenet user
+	[[ $(stat --format="%U" /var/freenet) == "freenet" ]] || chown \
+		freenet:freenet /var/freenet
+}
+
+pkg_postrm() {
+	if ! [[ -e /usr/share/freenet/lib/freenet.jar ]] ; then
+		elog " "
+		elog "If you dont want to use freenet any more"
+		elog "and dont want to keep your identity/other stuff"
+		elog "remember to do 'rm -rf /var/freenet' to remove everything"
+	fi
+}

--- a/net-p2p/freenet/freenet-0.7.5_p1491-r1.ebuild
+++ b/net-p2p/freenet/freenet-0.7.5_p1491-r1.ebuild
@@ -1,0 +1,165 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+JAVA_PKG_IUSE="doc source"
+
+inherit java-pkg-2 java-ant-2 systemd
+
+DESCRIPTION="An encrypted network without censorship"
+HOMEPAGE="https://freenetproject.org/"
+#	https://github.com/${PN}/seedrefs/archive/build0${PV#*p}.zip -> seednodes-${PV}.zip
+SRC_URI="
+	https://github.com/${PN}/fred/archive/build0${PV#*p}.zip -> ${P}.zip
+	https://github.com/${PN}/seedrefs/archive/build01480.zip -> seednodes-0.7.5_p1480.zip
+	mirror://gentoo/freenet-ant-1.7.1.jar"
+
+LICENSE="GPL-2+ GPL-2 MIT BSD-2 Apache-2.0"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="+nss test"
+
+CDEPEND="dev-java/bcprov:0
+	dev-java/commons-compress:0
+	dev-java/fec:0
+	dev-java/java-service-wrapper:0
+	dev-java/jbitcollider-core:0
+	dev-java/jna:4
+	dev-java/lzma:0
+	dev-java/lzmajio:0
+	dev-java/mersennetwister:0
+	nss? ( dev-libs/nss )"
+
+DEPEND="
+	app-arch/unzip
+	>=virtual/jdk-1.8
+	${CDEPEND}
+	test? (
+		dev-java/junit:0
+		dev-java/ant-junit:0
+	)
+	dev-java/ant-core:0"
+
+RDEPEND="
+	>=virtual/jre-1.8
+	net-libs/nativebiginteger:0
+	${CDEPEND}
+	acct-user/freenet
+	acct-group/freenet"
+
+PDEPEND="net-libs/NativeThread:0"
+
+JAVA_PKG_BSFIX_NAME+=" build-clean.xml"
+JAVA_ANT_REWRITE_CLASSPATH="yes"
+JAVA_ANT_CLASSPATH_TAGS+=" javadoc"
+JAVA_ANT_ENCODING="utf8"
+
+EANT_BUILD_TARGET="package"
+EANT_TEST_TARGET="unit"
+EANT_BUILD_XML="build-clean.xml"
+EANT_GENTOO_CLASSPATH="bcprov,commons-compress,fec,java-service-wrapper,jbitcollider-core,jna-4,lzma,lzmajio,mersennetwister"
+EANT_EXTRA_ARGS="-Dsuppress.gjs=true -Dlib.contrib.present=true -Dlib.bouncycastle.present=true -Dlib.junit.present=true -Dtest.skip=true"
+
+S="${WORKDIR}/fred-build0${PV#*p}"
+
+RESTRICT="test" # they're broken in the last release.
+
+pkg_setup() {
+	has_version dev-java/icedtea[cacao] && {
+		ewarn "dev-java/icedtea was built with cacao USE flag."
+		ewarn "freenet may compile with it, but it will refuse to run."
+		ewarn "Please remerge dev-java/icedtea without cacao USE flag,"
+		ewarn "if you plan to use it for running freenet."
+	}
+	java-pkg-2_pkg_setup
+}
+
+src_unpack() {
+#	unpack ${P}.zip seednodes-${PV}.zip
+	unpack ${P}.zip seednodes-0.7.5_p1480.zip
+}
+
+src_prepare() {
+#	cat "${WORKDIR}"/seedrefs-build0${PV#*p}/* > "${S}"/seednodes.fref
+	cat "${WORKDIR}"/seedrefs-build01480/* > "${S}"/seednodes.fref
+	cp "${FILESDIR}"/freenet-0.7.5_p1491-wrapper.conf freenet-wrapper.conf || die
+	cp "${FILESDIR}"/run.sh-20090501 run.sh || die
+	cp "${FILESDIR}"/build-clean.xml build-clean.xml || die
+	cp "${FILESDIR}"/build.properties build.properties || die
+
+	eapply -p1 "${FILESDIR}/"0.7.5_p1491-update-for-jna-5.x.patch
+	eapply -p0 "${FILESDIR}"/0.7.5_p1483-ext.patch
+	eapply -p1 "${FILESDIR}/"0.7.5_p1475-remove-git.patch
+
+	sed -i -e "s:=/usr/lib:=/usr/$(get_libdir):g" \
+		freenet-wrapper.conf || die "sed failed"
+
+	echo "wrapper.java.classpath.1=/usr/share/freenet/lib/freenet.jar" >> freenet-wrapper.conf || die
+	if use nss; then
+		echo "wrapper.java.additional.6=-Dfreenet.jce.use.NSS=true" >> freenet-wrapper.conf || die
+	fi
+	local i=2 pkg jars jar
+	local ifs_original=${IFS}
+	IFS=","
+	for pkg in ${EANT_GENTOO_CLASSPATH} ; do
+		jars="$(java-pkg_getjars ${pkg})"
+		for jar in ${jars} ; do
+			echo "wrapper.java.classpath.$((i++))=${jar}" >> freenet-wrapper.conf || die
+		done
+	done
+	IFS=${ifs_original}
+	echo "wrapper.java.classpath.$((i++))=/usr/share/freenet/lib/ant.jar" >> freenet-wrapper.conf || die
+	echo "wrapper.java.library.path.2=/usr/$(get_libdir)/java-service-wrapper" >> freenet-wrapper.conf || die
+	echo "wrapper.java.library.path.3=/usr/$(get_libdir)/jna-4" >> freenet-wrapper.conf || die
+
+	cp "${DISTDIR}"/freenet-ant-1.7.1.jar lib/ant.jar || die
+	eapply_user
+}
+
+EANT_TEST_EXTRA_ARGS="-Dtest.skip=false"
+
+src_test() {
+	java-pkg-2_src_test
+}
+
+src_install() {
+	java-pkg_dojar dist/freenet.jar
+	java-pkg_newjar "${DISTDIR}"/freenet-ant-1.7.1.jar ant.jar
+
+	if has_version =sys-apps/baselayout-2*; then
+		doinitd "${FILESDIR}"/freenet
+	else
+		newinitd "${FILESDIR}"/freenet.old freenet
+	fi
+
+	systemd_dounit "${FILESDIR}"/freenet.service
+
+	dodoc AUTHORS
+	newdoc README.md README
+	insinto /etc
+	doins freenet-wrapper.conf
+	insinto /var/freenet
+	doins run.sh seednodes.fref
+	fperms +x /var/freenet/run.sh
+	use doc && java-pkg_dojavadoc javadoc
+	use source && java-pkg_dosrc src
+}
+
+pkg_postinst() {
+	elog " "
+	elog "1. Start freenet with /etc/init.d/freenet start."
+	elog "2. Open localhost:8888 in your browser for the web interface."
+	#workaround for previously existing freenet user
+	[[ $(stat --format="%U" /var/freenet) == "freenet" ]] || chown \
+		freenet:freenet /var/freenet
+}
+
+pkg_postrm() {
+	if ! [[ -e /usr/share/freenet/lib/freenet.jar ]] ; then
+		elog " "
+		elog "If you dont want to use freenet any more"
+		elog "and dont want to keep your identity/other stuff"
+		elog "remember to do 'rm -rf /var/freenet' to remove everything"
+	fi
+}


### PR DESCRIPTION
`dev-java/jna` has been updated to 5.10.0, which requires updates to this package:

- This package uses JNA's `Pointer.SIZE` API, which has been removed since JNA 5.0.0.  A replacement of the API is `Native.POINTER_SIZE`, which is present in both JNA 4.x and 5.x. (https://bugs.gentoo.org/830847, https://github.com/kaitoy/pcap4j/issues/191)

- Since JNA 5.0.0, the default JNI library loading mechanism has been changed, which would cause this package to crash upon launch, unless system property `jna.nosys` is set to `false`, which restores the 4.x library loading behavior compatible with this package. (https://github.com/java-native-access/jna/issues/384)