### PR TITLE
app-i18n/transifex-client: skip tests depending on network connection.

### DIFF
--- a/app-i18n/transifex-client/transifex-client-1.0.0.ebuild
+++ b/app-i18n/transifex-client/transifex-client-1.0.0.ebuild
@@ -219,6 +219,8 @@ SLOT="0"
 KEYWORDS="~amd64 ~x86"
 
 src_test() {
+	# Skip tests depending on a network connection. Bug #831772
+	rm internal/txlib/update_test.go || die
 	go test ./... || die
 }
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/831772