### PR TITLE
dev-lang/python: fix hardcoding C/LDFLAGS from build time

### DIFF
--- a/dev-lang/python/python-3.10.2-r1.ebuild
+++ b/dev-lang/python/python-3.10.2-r1.ebuild
@@ -1,0 +1,386 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="7"
+WANT_LIBTOOL="none"
+
+inherit autotools check-reqs flag-o-matic multiprocessing pax-utils \
+	python-utils-r1 toolchain-funcs verify-sig
+
+MY_PV=${PV/_rc/rc}
+MY_P="Python-${MY_PV%_p*}"
+PYVER=$(ver_cut 1-2)
+PATCHSET="python-gentoo-patches-${MY_PV}"
+
+DESCRIPTION="An interpreted, interactive, object-oriented programming language"
+HOMEPAGE="https://www.python.org/"
+SRC_URI="https://www.python.org/ftp/python/${PV%%_*}/${MY_P}.tar.xz
+	https://dev.gentoo.org/~mgorny/dist/python/${PATCHSET}.tar.xz
+	verify-sig? (
+		https://www.python.org/ftp/python/${PV%%_*}/${MY_P}.tar.xz.asc
+	)"
+S="${WORKDIR}/${MY_P}"
+
+LICENSE="PSF-2"
+SLOT="${PYVER}"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+IUSE="bluetooth build examples gdbm hardened libedit lto +ncurses pgo +readline +sqlite +ssl test tk wininst +xml"
+RESTRICT="!test? ( test )"
+
+# Do not add a dependency on dev-lang/python to this ebuild.
+# If you need to apply a patch which requires python for bootstrapping, please
+# run the bootstrap code on your dev box and include the results in the
+# patchset. See bug 447752.
+
+RDEPEND="app-arch/bzip2:=
+	app-arch/xz-utils:=
+	dev-lang/python-exec[python_targets_python3_10(-)]
+	dev-libs/libffi:=
+	sys-apps/util-linux:=
+	>=sys-libs/zlib-1.1.3:=
+	virtual/libcrypt:=
+	virtual/libintl
+	gdbm? ( sys-libs/gdbm:=[berkdb] )
+	ncurses? ( >=sys-libs/ncurses-5.2:= )
+	readline? (
+		!libedit? ( >=sys-libs/readline-4.1:= )
+		libedit? ( dev-libs/libedit:= )
+	)
+	sqlite? ( >=dev-db/sqlite-3.3.8:3= )
+	ssl? ( >=dev-libs/openssl-1.1.1:= )
+	tk? (
+		>=dev-lang/tcl-8.0:=
+		>=dev-lang/tk-8.0:=
+		dev-tcltk/blt:=
+		dev-tcltk/tix
+	)
+	xml? ( >=dev-libs/expat-2.1:= )
+	!!<sys-apps/sandbox-2.21"
+# bluetooth requires headers from bluez
+DEPEND="${RDEPEND}
+	bluetooth? ( net-wireless/bluez )
+	test? ( app-arch/xz-utils[extra-filters(+)] )"
+# autoconf-archive needed to eautoreconf
+BDEPEND="
+	sys-devel/autoconf-archive
+	virtual/awk
+	virtual/pkgconfig
+	verify-sig? ( sec-keys/openpgp-keys-python )
+	!sys-devel/gcc[libffi(-)]"
+RDEPEND+=" !build? ( app-misc/mime-types )"
+
+VERIFY_SIG_OPENPGP_KEY_PATH=${BROOT}/usr/share/openpgp-keys/python.org.asc
+
+# large file tests involve a 2.5G file being copied (duplicated)
+CHECKREQS_DISK_BUILD=5500M
+
+pkg_pretend() {
+	use test && check-reqs_pkg_pretend
+}
+
+pkg_setup() {
+	use test && check-reqs_pkg_setup
+}
+
+src_unpack() {
+	if use verify-sig; then
+		verify-sig_verify_detached "${DISTDIR}"/${MY_P}.tar.xz{,.asc}
+	fi
+	default
+}
+
+src_prepare() {
+	# Ensure that internal copies of expat, libffi and zlib are not used.
+	rm -fr Modules/expat || die
+	rm -fr Modules/_ctypes/libffi* || die
+	rm -fr Modules/zlib || die
+
+	local PATCHES=(
+		"${WORKDIR}/${PATCHSET}"
+	)
+
+	default
+
+	sed -i -e "s:@@GENTOO_LIBDIR@@:$(get_libdir):g" \
+		setup.py || die "sed failed to replace @@GENTOO_LIBDIR@@"
+
+	# force correct number of jobs
+	# https://bugs.gentoo.org/737660
+	local jobs=$(makeopts_jobs "${MAKEOPTS}" "$(get_nproc)")
+	sed -i -e "s:-j0:-j${jobs}:" Makefile.pre.in || die
+	sed -i -e "/self\.parallel/s:True:${jobs}:" setup.py || die
+
+	eautoreconf
+}
+
+src_configure() {
+	local disable
+	# disable automagic bluetooth headers detection
+	use bluetooth || export ac_cv_header_bluetooth_bluetooth_h=no
+	use gdbm      || disable+=" gdbm"
+	use ncurses   || disable+=" _curses _curses_panel"
+	use readline  || disable+=" readline"
+	use sqlite    || disable+=" _sqlite3"
+	use ssl       || export PYTHON_DISABLE_SSL="1"
+	use tk        || disable+=" _tkinter"
+	use xml       || disable+=" _elementtree pyexpat" # _elementtree uses pyexpat.
+	export PYTHON_DISABLE_MODULES="${disable}"
+
+	if ! use xml; then
+		ewarn "You have configured Python without XML support."
+		ewarn "This is NOT a recommended configuration as you"
+		ewarn "may face problems parsing any XML documents."
+	fi
+
+	if [[ -n "${PYTHON_DISABLE_MODULES}" ]]; then
+		einfo "Disabled modules: ${PYTHON_DISABLE_MODULES}"
+	fi
+
+	if [[ "$(gcc-major-version)" -ge 4 ]]; then
+		append-flags -fwrapv
+	fi
+
+	filter-flags -malign-double
+
+	# https://bugs.gentoo.org/show_bug.cgi?id=50309
+	if is-flagq -O3; then
+		is-flagq -fstack-protector-all && replace-flags -O3 -O2
+		use hardened && replace-flags -O3 -O2
+	fi
+
+	# https://bugs.gentoo.org/700012
+	if is-flagq -flto || is-flagq '-flto=*'; then
+		append-cflags $(test-flags-CC -ffat-lto-objects)
+	fi
+
+	# Export CXX so it ends up in /usr/lib/python3.X/config/Makefile.
+	tc-export CXX
+
+	# Fix implicit declarations on cross and prefix builds. Bug #674070.
+	use ncurses && append-cppflags -I"${ESYSROOT}"/usr/include/ncursesw
+
+	local dbmliborder
+	if use gdbm; then
+		dbmliborder+="${dbmliborder:+:}gdbm"
+	fi
+
+	if use pgo; then
+		local jobs=$(makeopts_jobs "${MAKEOPTS}" "$(get_nproc)")
+		export PROFILE_TASK="-m test -j${jobs} --pgo-extended -x test_gdb -u-network"
+
+		# All of these seem to occasionally hang for PGO inconsistently
+		# They'll even hang here but be fine in src_test sometimes.
+		# bug #828535 (and related: bug #788022)
+		PROFILE_TASK+=" -x test_socket -x test_asyncio -x test_httpservers -x test_logging -x test_multiprocessing_fork -x test_xmlrpc"
+
+		if has_version "app-arch/rpm" ; then
+			# Avoid sandbox failure (attempts to write to /var/lib/rpm)
+			PROFILE_TASK+=" -x test_distutils"
+		fi
+	fi
+
+	local myeconfargs=(
+		# glibc-2.30 removes it; since we can't cleanly force-rebuild
+		# Python on glibc upgrade, remove it proactively to give
+		# a chance for users rebuilding python before glibc
+		ac_cv_header_stropts_h=no
+
+		--enable-shared
+		--without-static-libpython
+		--enable-ipv6
+		--infodir='${prefix}/share/info'
+		--mandir='${prefix}/share/man'
+		--with-computed-gotos
+		--with-dbmliborder="${dbmliborder}"
+		--with-libc=
+		--enable-loadable-sqlite-extensions
+		--without-ensurepip
+		--with-system-expat
+		--with-system-ffi
+
+		$(use_with lto)
+		$(use_enable pgo optimizations)
+		$(use_with readline readline "$(usex libedit editline readline)")
+	)
+
+	# disable implicit optimization/debugging flags
+	local -x OPT=
+	# pass system CFLAGS & LDFLAGS as _NODIST, otherwise they'll get
+	# propagated to sysconfig for built extensions
+	local -x CFLAGS_NODIST=${CFLAGS}
+	local -x LDFLAGS_NODIST=${LDFLAGS}
+	local -x CFLAGS= LDFLAGS=
+
+	econf "${myeconfargs[@]}"
+
+	if grep -q "#define POSIX_SEMAPHORES_NOT_ENABLED 1" pyconfig.h; then
+		eerror "configure has detected that the sem_open function is broken."
+		eerror "Please ensure that /dev/shm is mounted as a tmpfs with mode 1777."
+		die "Broken sem_open function (bug 496328)"
+	fi
+}
+
+src_compile() {
+	# Ensure sed works as expected
+	# https://bugs.gentoo.org/594768
+	local -x LC_ALL=C
+	# Prevent using distutils bundled by setuptools.
+	# https://bugs.gentoo.org/823728
+	export SETUPTOOLS_USE_DISTUTILS=stdlib
+
+	if use pgo ; then
+		# bug 660358
+		local -x COLUMNS=80
+		local -x PYTHONDONTWRITEBYTECODE=
+
+		addpredict /usr/lib/python3.10/site-packages
+	fi
+
+	# also need to clear the flags explicitly here or they end up
+	# in _sysconfigdata*
+	emake CPPFLAGS= CFLAGS= LDFLAGS=
+
+	# Work around bug 329499. See also bug 413751 and 457194.
+	if has_version dev-libs/libffi[pax-kernel]; then
+		pax-mark E python
+	else
+		pax-mark m python
+	fi
+}
+
+src_test() {
+	# Tests will not work when cross compiling.
+	if tc-is-cross-compiler; then
+		elog "Disabling tests due to crosscompiling."
+		return
+	fi
+
+	# Skip failing tests.
+	local skipped_tests="gdb"
+
+	for test in ${skipped_tests}; do
+		mv "${S}"/Lib/test/test_${test}.py "${T}"
+	done
+
+	# bug 660358
+	local -x COLUMNS=80
+	local -x PYTHONDONTWRITEBYTECODE=
+	# workaround https://bugs.gentoo.org/775416
+	addwrite /usr/lib/python3.10/site-packages
+
+	local jobs=$(makeopts_jobs "${MAKEOPTS}" "$(get_nproc)")
+
+	emake test EXTRATESTOPTS="-u-network -j${jobs}" \
+		CPPFLAGS= CFLAGS= LDFLAGS= < /dev/tty
+	local result=$?
+
+	for test in ${skipped_tests}; do
+		mv "${T}/test_${test}.py" "${S}"/Lib/test
+	done
+
+	elog "The following tests have been skipped:"
+	for test in ${skipped_tests}; do
+		elog "test_${test}.py"
+	done
+
+	elog "If you would like to run them, you may:"
+	elog "cd '${EPREFIX}/usr/lib/python${PYVER}/test'"
+	elog "and run the tests separately."
+
+	if [[ ${result} -ne 0 ]]; then
+		die "emake test failed"
+	fi
+}
+
+src_install() {
+	local libdir=${ED}/usr/lib/python${PYVER}
+
+	emake DESTDIR="${D}" altinstall
+
+	# Fix collisions between different slots of Python.
+	rm "${ED}/usr/$(get_libdir)/libpython3.so" || die
+
+	# Cheap hack to get version with ABIFLAGS
+	local abiver=$(cd "${ED}/usr/include"; echo python*)
+	if [[ ${abiver} != python${PYVER} ]]; then
+		# Replace python3.X with a symlink to python3.Xm
+		rm "${ED}/usr/bin/python${PYVER}" || die
+		dosym "${abiver}" "/usr/bin/python${PYVER}"
+		# Create python3.X-config symlink
+		dosym "${abiver}-config" "/usr/bin/python${PYVER}-config"
+		# Create python-3.5m.pc symlink
+		dosym "python-${PYVER}.pc" "/usr/$(get_libdir)/pkgconfig/${abiver/${PYVER}/-${PYVER}}.pc"
+	fi
+
+	# python seems to get rebuilt in src_install (bug 569908)
+	# Work around it for now.
+	if has_version dev-libs/libffi[pax-kernel]; then
+		pax-mark E "${ED}/usr/bin/${abiver}"
+	else
+		pax-mark m "${ED}/usr/bin/${abiver}"
+	fi
+
+	use sqlite || rm -r "${libdir}/"{sqlite3,test/test_sqlite*} || die
+	use tk || rm -r "${ED}/usr/bin/idle${PYVER}" "${libdir}/"{idlelib,tkinter,test/test_tk*} || die
+
+	dodoc Misc/{ACKS,HISTORY,NEWS}
+
+	if use examples; then
+		docinto examples
+		find Tools -name __pycache__ -exec rm -fr {} + || die
+		dodoc -r Tools
+	fi
+	insinto /usr/share/gdb/auto-load/usr/$(get_libdir) #443510
+	local libname=$(printf 'e:\n\t@echo $(INSTSONAME)\ninclude Makefile\n' | \
+		emake --no-print-directory -s -f - 2>/dev/null)
+	newins "${S}"/Tools/gdb/libpython.py "${libname}"-gdb.py
+
+	newconfd "${FILESDIR}/pydoc.conf" pydoc-${PYVER}
+	newinitd "${FILESDIR}/pydoc.init" pydoc-${PYVER}
+	sed \
+		-e "s:@PYDOC_PORT_VARIABLE@:PYDOC${PYVER/./_}_PORT:" \
+		-e "s:@PYDOC@:pydoc${PYVER}:" \
+		-i "${ED}/etc/conf.d/pydoc-${PYVER}" \
+		"${ED}/etc/init.d/pydoc-${PYVER}" || die "sed failed"
+
+	local -x EPYTHON=python${PYVER}
+	# if not using a cross-compiler, use the fresh binary
+	if ! tc-is-cross-compiler; then
+		local -x PYTHON=./python
+		local -x LD_LIBRARY_PATH=${LD_LIBRARY_PATH+${LD_LIBRARY_PATH}:}${PWD}
+	else
+		local -x PYTHON=${EPREFIX}/usr/bin/${EPYTHON}
+	fi
+
+	echo "EPYTHON='${EPYTHON}'" > epython.py || die
+	python_domodule epython.py
+
+	# python-exec wrapping support
+	local pymajor=${PYVER%.*}
+	local scriptdir=${D}$(python_get_scriptdir)
+	mkdir -p "${scriptdir}" || die
+	# python and pythonX
+	ln -s "../../../bin/${abiver}" \
+		"${scriptdir}/python${pymajor}" || die
+	ln -s "python${pymajor}" "${scriptdir}/python" || die
+	# python-config and pythonX-config
+	# note: we need to create a wrapper rather than symlinking it due
+	# to some random dirname(argv[0]) magic performed by python-config
+	cat > "${scriptdir}/python${pymajor}-config" <<-EOF || die
+		#!/bin/sh
+		exec "${abiver}-config" "\${@}"
+	EOF
+	chmod +x "${scriptdir}/python${pymajor}-config" || die
+	ln -s "python${pymajor}-config" \
+		"${scriptdir}/python-config" || die
+	# 2to3, pydoc
+	ln -s "../../../bin/2to3-${PYVER}" \
+		"${scriptdir}/2to3" || die
+	ln -s "../../../bin/pydoc${PYVER}" \
+		"${scriptdir}/pydoc" || die
+	# idle
+	if use tk; then
+		ln -s "../../../bin/idle${PYVER}" \
+			"${scriptdir}/idle" || die
+	fi
+}

--- a/dev-lang/python/python-3.6.15-r1.ebuild
+++ b/dev-lang/python/python-3.6.15-r1.ebuild
@@ -1,0 +1,342 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="7"
+WANT_LIBTOOL="none"
+
+inherit autotools flag-o-matic multiprocessing pax-utils \
+	python-utils-r1 toolchain-funcs verify-sig
+
+MY_P="Python-${PV%_p*}"
+PYVER=$(ver_cut 1-2)
+PATCHSET="python-gentoo-patches-${PV}"
+
+DESCRIPTION="An interpreted, interactive, object-oriented programming language"
+HOMEPAGE="https://www.python.org/"
+SRC_URI="https://www.python.org/ftp/python/${PV%_*}/${MY_P}.tar.xz
+	https://dev.gentoo.org/~mgorny/dist/python/${PATCHSET}.tar.xz
+	verify-sig? (
+		https://www.python.org/ftp/python/${PV%_*}/${MY_P}.tar.xz.asc
+	)"
+S="${WORKDIR}/${MY_P}"
+
+LICENSE="PSF-2"
+SLOT="${PYVER}/${PYVER}m"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86"
+IUSE="bluetooth build examples gdbm hardened +ncurses +readline +sqlite +ssl test tk wininst +xml"
+RESTRICT="!test? ( test )"
+
+# Do not add a dependency on dev-lang/python to this ebuild.
+# If you need to apply a patch which requires python for bootstrapping, please
+# run the bootstrap code on your dev box and include the results in the
+# patchset. See bug 447752.
+
+RDEPEND="app-arch/bzip2:=
+	app-arch/xz-utils:=
+	dev-libs/libffi:=
+	>=sys-libs/zlib-1.1.3:=
+	virtual/libcrypt:=
+	virtual/libintl
+	gdbm? ( sys-libs/gdbm:=[berkdb] )
+	ncurses? ( >=sys-libs/ncurses-5.2:= )
+	readline? ( >=sys-libs/readline-4.1:= )
+	sqlite? ( >=dev-db/sqlite-3.3.8:3= )
+	ssl? ( dev-libs/openssl:= )
+	tk? (
+		>=dev-lang/tcl-8.0:=
+		>=dev-lang/tk-8.0:=
+		dev-tcltk/blt:=
+		dev-tcltk/tix
+	)
+	xml? ( >=dev-libs/expat-2.1:= )"
+# bluetooth requires headers from bluez
+DEPEND="${RDEPEND}
+	bluetooth? ( net-wireless/bluez )
+	test? ( app-arch/xz-utils[extra-filters(+)] )"
+BDEPEND="
+	virtual/awk
+	virtual/pkgconfig
+	verify-sig? ( sec-keys/openpgp-keys-python )
+	!sys-devel/gcc[libffi(-)]"
+RDEPEND+=" !build? ( app-misc/mime-types )"
+
+VERIFY_SIG_OPENPGP_KEY_PATH=${BROOT}/usr/share/openpgp-keys/python.org.asc
+
+src_unpack() {
+	if use verify-sig; then
+		verify-sig_verify_detached "${DISTDIR}"/${MY_P}.tar.xz{,.asc}
+	fi
+	default
+}
+
+src_prepare() {
+	# Ensure that internal copies of expat, libffi and zlib are not used.
+	rm -fr Modules/expat || die
+	rm -fr Modules/_ctypes/libffi* || die
+	rm -fr Modules/zlib || die
+
+	local PATCHES=(
+		"${WORKDIR}/${PATCHSET}"
+	)
+
+	default
+
+	sed -i -e "s:@@GENTOO_LIBDIR@@:$(get_libdir):g" \
+		Lib/distutils/command/install.py \
+		Lib/distutils/sysconfig.py \
+		Lib/site.py \
+		Lib/sysconfig.py \
+		Lib/test/test_site.py \
+		Makefile.pre.in \
+		Modules/Setup.dist \
+		Modules/getpath.c \
+		configure.ac \
+		setup.py || die "sed failed to replace @@GENTOO_LIBDIR@@"
+
+	# force correct number of jobs
+	# https://bugs.gentoo.org/737660
+	local jobs=$(makeopts_jobs "${MAKEOPTS}" "$(get_nproc)")
+	sed -i -e "/self\.parallel/s:True:${jobs}:" setup.py || die
+
+	eautoreconf
+}
+
+src_configure() {
+	local disable
+	# disable automagic bluetooth headers detection
+	use bluetooth || export ac_cv_header_bluetooth_bluetooth_h=no
+	use gdbm      || disable+=" gdbm"
+	use ncurses   || disable+=" _curses _curses_panel"
+	use readline  || disable+=" readline"
+	use sqlite    || disable+=" _sqlite3"
+	use ssl       || export PYTHON_DISABLE_SSL="1"
+	use tk        || disable+=" _tkinter"
+	use xml       || disable+=" _elementtree pyexpat" # _elementtree uses pyexpat.
+	export PYTHON_DISABLE_MODULES="${disable}"
+
+	if ! use xml; then
+		ewarn "You have configured Python without XML support."
+		ewarn "This is NOT a recommended configuration as you"
+		ewarn "may face problems parsing any XML documents."
+	fi
+
+	if [[ -n "${PYTHON_DISABLE_MODULES}" ]]; then
+		einfo "Disabled modules: ${PYTHON_DISABLE_MODULES}"
+	fi
+
+	if [[ "$(gcc-major-version)" -ge 4 ]]; then
+		append-flags -fwrapv
+	fi
+
+	filter-flags -malign-double
+
+	# https://bugs.gentoo.org/show_bug.cgi?id=50309
+	if is-flagq -O3; then
+		is-flagq -fstack-protector-all && replace-flags -O3 -O2
+		use hardened && replace-flags -O3 -O2
+	fi
+
+	# Export CXX so it ends up in /usr/lib/python3.X/config/Makefile.
+	tc-export CXX
+
+	local dbmliborder
+	if use gdbm; then
+		dbmliborder+="${dbmliborder:+:}gdbm"
+	fi
+
+	local myeconfargs=(
+		# glibc-2.30 removes it; since we can't cleanly force-rebuild
+		# Python on glibc upgrade, remove it proactively to give
+		# a chance for users rebuilding python before glibc
+		ac_cv_header_stropts_h=no
+
+		--with-fpectl
+		--enable-shared
+		--enable-ipv6
+		--with-threads
+		--infodir='${prefix}/share/info'
+		--mandir='${prefix}/share/man'
+		--with-computed-gotos
+		--with-dbmliborder="${dbmliborder}"
+		--with-libc=
+		--enable-loadable-sqlite-extensions
+		--without-ensurepip
+		--with-system-expat
+		--with-system-ffi
+	)
+
+	# disable implicit optimization/debugging flags
+	local -x OPT=
+	# pass system CFLAGS & LDFLAGS as _NODIST, otherwise they'll get
+	# propagated to sysconfig for built extensions
+	local -x CFLAGS_NODIST=${CFLAGS}
+	local -x LDFLAGS_NODIST=${LDFLAGS}
+	local -x CFLAGS= LDFLAGS=
+
+	econf "${myeconfargs[@]}"
+
+	if grep -q "#define POSIX_SEMAPHORES_NOT_ENABLED 1" pyconfig.h; then
+		eerror "configure has detected that the sem_open function is broken."
+		eerror "Please ensure that /dev/shm is mounted as a tmpfs with mode 1777."
+		die "Broken sem_open function (bug 496328)"
+	fi
+}
+
+src_compile() {
+	# Ensure sed works as expected
+	# https://bugs.gentoo.org/594768
+	local -x LC_ALL=C
+
+	# also need to clear the flags explicitly here or they end up
+	# in _sysconfigdata*
+	emake CPPFLAGS= CFLAGS= LDFLAGS=
+
+	# Work around bug 329499. See also bug 413751 and 457194.
+	if has_version dev-libs/libffi[pax-kernel]; then
+		pax-mark E python
+	else
+		pax-mark m python
+	fi
+}
+
+src_test() {
+	# Tests will not work when cross compiling.
+	if tc-is-cross-compiler; then
+		elog "Disabling tests due to crosscompiling."
+		return
+	fi
+
+	# Skip failing tests.
+	local skipped_tests="gdb faulthandler"
+
+	for test in ${skipped_tests}; do
+		mv "${S}"/Lib/test/test_${test}.py "${T}"
+	done
+
+	# bug 660358
+	local -x COLUMNS=80
+	local -x PYTHONDONTWRITEBYTECODE=
+
+	local jobs=$(makeopts_jobs "${MAKEOPTS}" "$(get_nproc)")
+
+	emake test EXTRATESTOPTS="-u-network -j${jobs}" \
+		CPPFLAGS= CFLAGS= LDFLAGS= < /dev/tty
+	local result=$?
+
+	for test in ${skipped_tests}; do
+		mv "${T}/test_${test}.py" "${S}"/Lib/test
+	done
+
+	elog "The following tests have been skipped:"
+	for test in ${skipped_tests}; do
+		elog "test_${test}.py"
+	done
+
+	elog "If you would like to run them, you may:"
+	elog "cd '${EPREFIX}/usr/$(get_libdir)/python${PYVER}/test'"
+	elog "and run the tests separately."
+
+	if [[ ${result} -ne 0 ]]; then
+		die "emake test failed"
+	fi
+}
+
+src_install() {
+	local libdir=${ED}/usr/$(get_libdir)/python${PYVER}
+
+	emake DESTDIR="${D}" altinstall
+
+	# Remove static library
+	rm "${ED}"/usr/$(get_libdir)/libpython*.a || die
+
+	# Fix collisions between different slots of Python.
+	rm "${ED}/usr/$(get_libdir)/libpython3.so" || die
+
+	# Cheap hack to get version with ABIFLAGS
+	local abiver=$(cd "${ED}/usr/include"; echo python*)
+	if [[ ${abiver} != python${PYVER} ]]; then
+		# Replace python3.X with a symlink to python3.Xm
+		rm "${ED}/usr/bin/python${PYVER}" || die
+		dosym "${abiver}" "/usr/bin/python${PYVER}"
+		# Create python3.X-config symlink
+		dosym "${abiver}-config" "/usr/bin/python${PYVER}-config"
+		# Create python-3.5m.pc symlink
+		dosym "python-${PYVER}.pc" "/usr/$(get_libdir)/pkgconfig/${abiver/${PYVER}/-${PYVER}}.pc"
+	fi
+
+	# python seems to get rebuilt in src_install (bug 569908)
+	# Work around it for now.
+	if has_version dev-libs/libffi[pax-kernel]; then
+		pax-mark E "${ED}/usr/bin/${abiver}"
+	else
+		pax-mark m "${ED}/usr/bin/${abiver}"
+	fi
+
+	use sqlite || rm -r "${libdir}/"{sqlite3,test/test_sqlite*} || die
+	use tk || rm -r "${ED}/usr/bin/idle${PYVER}" "${libdir}/"{idlelib,tkinter,test/test_tk*} || die
+
+	use wininst || rm "${libdir}/distutils/command/"wininst-*.exe || die
+
+	dodoc Misc/{ACKS,HISTORY,NEWS}
+
+	if use examples; then
+		docinto examples
+		find Tools -name __pycache__ -exec rm -fr {} + || die
+		dodoc -r Tools
+	fi
+	insinto /usr/share/gdb/auto-load/usr/$(get_libdir) #443510
+	local libname=$(printf 'e:\n\t@echo $(INSTSONAME)\ninclude Makefile\n' | \
+		emake --no-print-directory -s -f - 2>/dev/null)
+	newins "${S}"/Tools/gdb/libpython.py "${libname}"-gdb.py
+
+	newconfd "${FILESDIR}/pydoc.conf" pydoc-${PYVER}
+	newinitd "${FILESDIR}/pydoc.init" pydoc-${PYVER}
+	sed \
+		-e "s:@PYDOC_PORT_VARIABLE@:PYDOC${PYVER/./_}_PORT:" \
+		-e "s:@PYDOC@:pydoc${PYVER}:" \
+		-i "${ED}/etc/conf.d/pydoc-${PYVER}" \
+		"${ED}/etc/init.d/pydoc-${PYVER}" || die "sed failed"
+
+	local -x EPYTHON=python${PYVER}
+	# if not using a cross-compiler, use the fresh binary
+	if ! tc-is-cross-compiler; then
+		local -x PYTHON=./python
+		local -x LD_LIBRARY_PATH=${LD_LIBRARY_PATH+${LD_LIBRARY_PATH}:}${PWD}
+	else
+		local -x PYTHON=${EPREFIX}/usr/bin/${EPYTHON}
+	fi
+
+	echo "EPYTHON='${EPYTHON}'" > epython.py || die
+	python_domodule epython.py
+
+	# python-exec wrapping support
+	local pymajor=${PYVER%.*}
+	local scriptdir=${D}$(python_get_scriptdir)
+	mkdir -p "${scriptdir}" || die
+	# python and pythonX
+	ln -s "../../../bin/${abiver}" \
+		"${scriptdir}/python${pymajor}" || die
+	ln -s "python${pymajor}" "${scriptdir}/python" || die
+	# python-config and pythonX-config
+	# note: we need to create a wrapper rather than symlinking it due
+	# to some random dirname(argv[0]) magic performed by python-config
+	cat > "${scriptdir}/python${pymajor}-config" <<-EOF || die
+		#!/bin/sh
+		exec "${abiver}-config" "\${@}"
+	EOF
+	chmod +x "${scriptdir}/python${pymajor}-config" || die
+	ln -s "python${pymajor}-config" \
+		"${scriptdir}/python-config" || die
+	# 2to3, pydoc, pyvenv
+	ln -s "../../../bin/2to3-${PYVER}" \
+		"${scriptdir}/2to3" || die
+	ln -s "../../../bin/pydoc${PYVER}" \
+		"${scriptdir}/pydoc" || die
+	ln -s "../../../bin/pyvenv-${PYVER}" \
+		"${scriptdir}/pyvenv" || die
+	# idle
+	if use tk; then
+		ln -s "../../../bin/idle${PYVER}" \
+			"${scriptdir}/idle" || die
+	fi
+}

--- a/dev-lang/python/python-3.7.12_p1-r1.ebuild
+++ b/dev-lang/python/python-3.7.12_p1-r1.ebuild
@@ -1,0 +1,335 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="7"
+WANT_LIBTOOL="none"
+
+inherit autotools flag-o-matic multiprocessing pax-utils \
+	python-utils-r1 toolchain-funcs verify-sig
+
+MY_P="Python-${PV%_p*}"
+PYVER=$(ver_cut 1-2)
+PATCHSET="python-gentoo-patches-${PV}"
+
+DESCRIPTION="An interpreted, interactive, object-oriented programming language"
+HOMEPAGE="https://www.python.org/"
+SRC_URI="https://www.python.org/ftp/python/${PV%_*}/${MY_P}.tar.xz
+	https://dev.gentoo.org/~floppym/python/${PATCHSET}.tar.xz
+	verify-sig? (
+		https://www.python.org/ftp/python/${PV%_*}/${MY_P}.tar.xz.asc
+	)"
+S="${WORKDIR}/${MY_P}"
+
+LICENSE="PSF-2"
+SLOT="${PYVER}/${PYVER}m"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+IUSE="bluetooth build examples gdbm hardened +ncurses +readline +sqlite +ssl test tk wininst +xml"
+RESTRICT="!test? ( test )"
+
+# Do not add a dependency on dev-lang/python to this ebuild.
+# If you need to apply a patch which requires python for bootstrapping, please
+# run the bootstrap code on your dev box and include the results in the
+# patchset. See bug 447752.
+
+RDEPEND="app-arch/bzip2:=
+	app-arch/xz-utils:=
+	dev-libs/libffi:=
+	sys-apps/util-linux:=
+	>=sys-libs/zlib-1.1.3:=
+	virtual/libcrypt:=
+	virtual/libintl
+	gdbm? ( sys-libs/gdbm:=[berkdb] )
+	ncurses? ( >=sys-libs/ncurses-5.2:= )
+	readline? ( >=sys-libs/readline-4.1:= )
+	sqlite? ( >=dev-db/sqlite-3.3.8:3= )
+	ssl? ( >=dev-libs/openssl-1.1.1:= )
+	tk? (
+		>=dev-lang/tcl-8.0:=
+		>=dev-lang/tk-8.0:=
+		dev-tcltk/blt:=
+		dev-tcltk/tix
+	)
+	xml? ( >=dev-libs/expat-2.1:= )"
+# bluetooth requires headers from bluez
+DEPEND="${RDEPEND}
+	bluetooth? ( net-wireless/bluez )
+	test? ( app-arch/xz-utils[extra-filters(+)] )"
+BDEPEND="
+	virtual/awk
+	virtual/pkgconfig
+	verify-sig? ( sec-keys/openpgp-keys-python )
+	!sys-devel/gcc[libffi(-)]"
+RDEPEND+=" !build? ( app-misc/mime-types )"
+
+VERIFY_SIG_OPENPGP_KEY_PATH=${BROOT}/usr/share/openpgp-keys/python.org.asc
+
+src_unpack() {
+	if use verify-sig; then
+		verify-sig_verify_detached "${DISTDIR}"/${MY_P}.tar.xz{,.asc}
+	fi
+	default
+}
+
+src_prepare() {
+	# Ensure that internal copies of expat, libffi and zlib are not used.
+	rm -fr Modules/expat || die
+	rm -fr Modules/_ctypes/libffi* || die
+	rm -fr Modules/zlib || die
+
+	local PATCHES=(
+		"${WORKDIR}/${PATCHSET}"
+	)
+
+	default
+
+	sed -i -e "s:@@GENTOO_LIBDIR@@:$(get_libdir):g" \
+		setup.py || die "sed failed to replace @@GENTOO_LIBDIR@@"
+
+	# force correct number of jobs
+	# https://bugs.gentoo.org/737660
+	local jobs=$(makeopts_jobs "${MAKEOPTS}" "$(get_nproc)")
+	sed -i -e "/self\.parallel/s:True:${jobs}:" setup.py || die
+
+	eautoreconf
+}
+
+src_configure() {
+	local disable
+	# disable automagic bluetooth headers detection
+	use bluetooth || export ac_cv_header_bluetooth_bluetooth_h=no
+	use gdbm      || disable+=" gdbm"
+	use ncurses   || disable+=" _curses _curses_panel"
+	use readline  || disable+=" readline"
+	use sqlite    || disable+=" _sqlite3"
+	use ssl       || export PYTHON_DISABLE_SSL="1"
+	use tk        || disable+=" _tkinter"
+	use xml       || disable+=" _elementtree pyexpat" # _elementtree uses pyexpat.
+	export PYTHON_DISABLE_MODULES="${disable}"
+
+	if ! use xml; then
+		ewarn "You have configured Python without XML support."
+		ewarn "This is NOT a recommended configuration as you"
+		ewarn "may face problems parsing any XML documents."
+	fi
+
+	if [[ -n "${PYTHON_DISABLE_MODULES}" ]]; then
+		einfo "Disabled modules: ${PYTHON_DISABLE_MODULES}"
+	fi
+
+	if [[ "$(gcc-major-version)" -ge 4 ]]; then
+		append-flags -fwrapv
+	fi
+
+	filter-flags -malign-double
+
+	# https://bugs.gentoo.org/show_bug.cgi?id=50309
+	if is-flagq -O3; then
+		is-flagq -fstack-protector-all && replace-flags -O3 -O2
+		use hardened && replace-flags -O3 -O2
+	fi
+
+	# Export CXX so it ends up in /usr/lib/python3.X/config/Makefile.
+	tc-export CXX
+
+	# Fix implicit declarations on cross and prefix builds. Bug #674070.
+	use ncurses && append-cppflags -I"${ESYSROOT}"/usr/include/ncursesw
+
+	local dbmliborder
+	if use gdbm; then
+		dbmliborder+="${dbmliborder:+:}gdbm"
+	fi
+
+	local myeconfargs=(
+		# glibc-2.30 removes it; since we can't cleanly force-rebuild
+		# Python on glibc upgrade, remove it proactively to give
+		# a chance for users rebuilding python before glibc
+		ac_cv_header_stropts_h=no
+
+		--enable-shared
+		--enable-ipv6
+		--infodir='${prefix}/share/info'
+		--mandir='${prefix}/share/man'
+		--with-computed-gotos
+		--with-dbmliborder="${dbmliborder}"
+		--with-libc=
+		--enable-loadable-sqlite-extensions
+		--without-ensurepip
+		--with-system-expat
+		--with-system-ffi
+	)
+
+	# disable implicit optimization/debugging flags
+	local -x OPT=
+	# pass system CFLAGS & LDFLAGS as _NODIST, otherwise they'll get
+	# propagated to sysconfig for built extensions
+	local -x CFLAGS_NODIST=${CFLAGS}
+	local -x LDFLAGS_NODIST=${LDFLAGS}
+	local -x CFLAGS= LDFLAGS=
+
+	econf "${myeconfargs[@]}"
+
+	if grep -q "#define POSIX_SEMAPHORES_NOT_ENABLED 1" pyconfig.h; then
+		eerror "configure has detected that the sem_open function is broken."
+		eerror "Please ensure that /dev/shm is mounted as a tmpfs with mode 1777."
+		die "Broken sem_open function (bug 496328)"
+	fi
+}
+
+src_compile() {
+	# Ensure sed works as expected
+	# https://bugs.gentoo.org/594768
+	local -x LC_ALL=C
+
+	# also need to clear the flags explicitly here or they end up
+	# in _sysconfigdata*
+	emake CPPFLAGS= CFLAGS= LDFLAGS=
+
+	# Work around bug 329499. See also bug 413751 and 457194.
+	if has_version dev-libs/libffi[pax-kernel]; then
+		pax-mark E python
+	else
+		pax-mark m python
+	fi
+}
+
+src_test() {
+	# Tests will not work when cross compiling.
+	if tc-is-cross-compiler; then
+		elog "Disabling tests due to crosscompiling."
+		return
+	fi
+
+	# Skip failing tests.
+	local skipped_tests="gdb"
+
+	for test in ${skipped_tests}; do
+		mv "${S}"/Lib/test/test_${test}.py "${T}"
+	done
+
+	# bug 660358
+	local -x COLUMNS=80
+	local -x PYTHONDONTWRITEBYTECODE=
+
+	local jobs=$(makeopts_jobs "${MAKEOPTS}" "$(get_nproc)")
+
+	emake test EXTRATESTOPTS="-u-network -j${jobs}" \
+		CPPFLAGS= CFLAGS= LDFLAGS= < /dev/tty
+	local result=$?
+
+	for test in ${skipped_tests}; do
+		mv "${T}/test_${test}.py" "${S}"/Lib/test
+	done
+
+	elog "The following tests have been skipped:"
+	for test in ${skipped_tests}; do
+		elog "test_${test}.py"
+	done
+
+	elog "If you would like to run them, you may:"
+	elog "cd '${EPREFIX}/usr/lib/python${PYVER}/test'"
+	elog "and run the tests separately."
+
+	if [[ ${result} -ne 0 ]]; then
+		die "emake test failed"
+	fi
+}
+
+src_install() {
+	local libdir=${ED}/usr/lib/python${PYVER}
+
+	emake DESTDIR="${D}" altinstall
+
+	# Remove static library
+	rm "${ED}"/usr/$(get_libdir)/libpython*.a || die
+
+	# Fix collisions between different slots of Python.
+	rm "${ED}/usr/$(get_libdir)/libpython3.so" || die
+
+	# Cheap hack to get version with ABIFLAGS
+	local abiver=$(cd "${ED}/usr/include"; echo python*)
+	if [[ ${abiver} != python${PYVER} ]]; then
+		# Replace python3.X with a symlink to python3.Xm
+		rm "${ED}/usr/bin/python${PYVER}" || die
+		dosym "${abiver}" "/usr/bin/python${PYVER}"
+		# Create python3.X-config symlink
+		dosym "${abiver}-config" "/usr/bin/python${PYVER}-config"
+		# Create python-3.5m.pc symlink
+		dosym "python-${PYVER}.pc" "/usr/$(get_libdir)/pkgconfig/${abiver/${PYVER}/-${PYVER}}.pc"
+	fi
+
+	# python seems to get rebuilt in src_install (bug 569908)
+	# Work around it for now.
+	if has_version dev-libs/libffi[pax-kernel]; then
+		pax-mark E "${ED}/usr/bin/${abiver}"
+	else
+		pax-mark m "${ED}/usr/bin/${abiver}"
+	fi
+
+	use sqlite || rm -r "${libdir}/"{sqlite3,test/test_sqlite*} || die
+	use tk || rm -r "${ED}/usr/bin/idle${PYVER}" "${libdir}/"{idlelib,tkinter,test/test_tk*} || die
+
+	use wininst || rm "${libdir}/distutils/command/"wininst-*.exe || die
+
+	dodoc Misc/{ACKS,HISTORY,NEWS}
+
+	if use examples; then
+		docinto examples
+		find Tools -name __pycache__ -exec rm -fr {} + || die
+		dodoc -r Tools
+	fi
+	insinto /usr/share/gdb/auto-load/usr/$(get_libdir) #443510
+	local libname=$(printf 'e:\n\t@echo $(INSTSONAME)\ninclude Makefile\n' | \
+		emake --no-print-directory -s -f - 2>/dev/null)
+	newins "${S}"/Tools/gdb/libpython.py "${libname}"-gdb.py
+
+	newconfd "${FILESDIR}/pydoc.conf" pydoc-${PYVER}
+	newinitd "${FILESDIR}/pydoc.init" pydoc-${PYVER}
+	sed \
+		-e "s:@PYDOC_PORT_VARIABLE@:PYDOC${PYVER/./_}_PORT:" \
+		-e "s:@PYDOC@:pydoc${PYVER}:" \
+		-i "${ED}/etc/conf.d/pydoc-${PYVER}" \
+		"${ED}/etc/init.d/pydoc-${PYVER}" || die "sed failed"
+
+	local -x EPYTHON=python${PYVER}
+	# if not using a cross-compiler, use the fresh binary
+	if ! tc-is-cross-compiler; then
+		local -x PYTHON=./python
+		local -x LD_LIBRARY_PATH=${LD_LIBRARY_PATH+${LD_LIBRARY_PATH}:}${PWD}
+	else
+		local -x PYTHON=${EPREFIX}/usr/bin/${EPYTHON}
+	fi
+
+	echo "EPYTHON='${EPYTHON}'" > epython.py || die
+	python_domodule epython.py
+
+	# python-exec wrapping support
+	local pymajor=${PYVER%.*}
+	local scriptdir=${D}$(python_get_scriptdir)
+	mkdir -p "${scriptdir}" || die
+	# python and pythonX
+	ln -s "../../../bin/${abiver}" \
+		"${scriptdir}/python${pymajor}" || die
+	ln -s "python${pymajor}" "${scriptdir}/python" || die
+	# python-config and pythonX-config
+	# note: we need to create a wrapper rather than symlinking it due
+	# to some random dirname(argv[0]) magic performed by python-config
+	cat > "${scriptdir}/python${pymajor}-config" <<-EOF || die
+		#!/bin/sh
+		exec "${abiver}-config" "\${@}"
+	EOF
+	chmod +x "${scriptdir}/python${pymajor}-config" || die
+	ln -s "python${pymajor}-config" \
+		"${scriptdir}/python-config" || die
+	# 2to3, pydoc, pyvenv
+	ln -s "../../../bin/2to3-${PYVER}" \
+		"${scriptdir}/2to3" || die
+	ln -s "../../../bin/pydoc${PYVER}" \
+		"${scriptdir}/pydoc" || die
+	ln -s "../../../bin/pyvenv-${PYVER}" \
+		"${scriptdir}/pyvenv" || die
+	# idle
+	if use tk; then
+		ln -s "../../../bin/idle${PYVER}" \
+			"${scriptdir}/idle" || die
+	fi
+}

--- a/dev-lang/python/python-3.8.12_p1-r2.ebuild
+++ b/dev-lang/python/python-3.8.12_p1-r2.ebuild
@@ -1,0 +1,345 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="7"
+WANT_LIBTOOL="none"
+
+inherit autotools flag-o-matic multiprocessing pax-utils \
+	python-utils-r1 toolchain-funcs verify-sig
+
+MY_PV=${PV/_rc/rc}
+MY_P="Python-${MY_PV%_p*}"
+PYVER=$(ver_cut 1-2)
+PATCHSET="python-gentoo-patches-${MY_PV}"
+
+DESCRIPTION="An interpreted, interactive, object-oriented programming language"
+HOMEPAGE="https://www.python.org/"
+SRC_URI="https://www.python.org/ftp/python/${PV%_*}/${MY_P}.tar.xz
+	https://dev.gentoo.org/~floppym/python/${PATCHSET}.tar.xz
+	verify-sig? (
+		https://www.python.org/ftp/python/${PV%_*}/${MY_P}.tar.xz.asc
+	)"
+S="${WORKDIR}/${MY_P}"
+
+LICENSE="PSF-2"
+SLOT="${PYVER}"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+IUSE="bluetooth build examples gdbm hardened +ncurses +readline +sqlite +ssl test tk wininst +xml"
+RESTRICT="!test? ( test )"
+
+# Do not add a dependency on dev-lang/python to this ebuild.
+# If you need to apply a patch which requires python for bootstrapping, please
+# run the bootstrap code on your dev box and include the results in the
+# patchset. See bug 447752.
+
+RDEPEND="app-arch/bzip2:=
+	app-arch/xz-utils:=
+	dev-lang/python-exec[python_targets_python3_8(-)]
+	dev-libs/libffi:=
+	sys-apps/util-linux:=
+	>=sys-libs/zlib-1.1.3:=
+	virtual/libcrypt:=
+	virtual/libintl
+	gdbm? ( sys-libs/gdbm:=[berkdb] )
+	ncurses? ( >=sys-libs/ncurses-5.2:= )
+	readline? ( >=sys-libs/readline-4.1:= )
+	sqlite? ( >=dev-db/sqlite-3.3.8:3= )
+	ssl? ( >=dev-libs/openssl-1.1.1:= )
+	tk? (
+		>=dev-lang/tcl-8.0:=
+		>=dev-lang/tk-8.0:=
+		dev-tcltk/blt:=
+		dev-tcltk/tix
+	)
+	xml? ( >=dev-libs/expat-2.1:= )"
+# bluetooth requires headers from bluez
+DEPEND="${RDEPEND}
+	bluetooth? ( net-wireless/bluez )
+	test? ( app-arch/xz-utils[extra-filters(+)] )"
+BDEPEND="
+	virtual/awk
+	virtual/pkgconfig
+	sys-devel/autoconf-archive
+	verify-sig? ( sec-keys/openpgp-keys-python )
+	!sys-devel/gcc[libffi(-)]"
+RDEPEND+=" !build? ( app-misc/mime-types )"
+
+VERIFY_SIG_OPENPGP_KEY_PATH=${BROOT}/usr/share/openpgp-keys/python.org.asc
+
+src_unpack() {
+	if use verify-sig; then
+		verify-sig_verify_detached "${DISTDIR}"/${MY_P}.tar.xz{,.asc}
+	fi
+	default
+}
+
+src_prepare() {
+	# Ensure that internal copies of expat, libffi and zlib are not used.
+	rm -fr Modules/expat || die
+	rm -fr Modules/_ctypes/libffi* || die
+	rm -fr Modules/zlib || die
+
+	local PATCHES=(
+		"${WORKDIR}/${PATCHSET}"
+	)
+
+	default
+
+	sed -i -e "s:@@GENTOO_LIBDIR@@:$(get_libdir):g" \
+		setup.py || die "sed failed to replace @@GENTOO_LIBDIR@@"
+
+	# force correct number of jobs
+	# https://bugs.gentoo.org/737660
+	local jobs=$(makeopts_jobs "${MAKEOPTS}" "$(get_nproc)")
+	sed -i -e "s:-j0:-j${jobs}:" Makefile.pre.in || die
+	sed -i -e "/self\.parallel/s:True:${jobs}:" setup.py || die
+
+	eautoreconf
+}
+
+src_configure() {
+	local disable
+	# disable automagic bluetooth headers detection
+	use bluetooth || export ac_cv_header_bluetooth_bluetooth_h=no
+	use gdbm      || disable+=" gdbm"
+	use ncurses   || disable+=" _curses _curses_panel"
+	use readline  || disable+=" readline"
+	use sqlite    || disable+=" _sqlite3"
+	use ssl       || export PYTHON_DISABLE_SSL="1"
+	use tk        || disable+=" _tkinter"
+	use xml       || disable+=" _elementtree pyexpat" # _elementtree uses pyexpat.
+	export PYTHON_DISABLE_MODULES="${disable}"
+
+	if ! use xml; then
+		ewarn "You have configured Python without XML support."
+		ewarn "This is NOT a recommended configuration as you"
+		ewarn "may face problems parsing any XML documents."
+	fi
+
+	if [[ -n "${PYTHON_DISABLE_MODULES}" ]]; then
+		einfo "Disabled modules: ${PYTHON_DISABLE_MODULES}"
+	fi
+
+	if [[ "$(gcc-major-version)" -ge 4 ]]; then
+		append-flags -fwrapv
+	fi
+
+	filter-flags -malign-double
+
+	# https://bugs.gentoo.org/show_bug.cgi?id=50309
+	if is-flagq -O3; then
+		is-flagq -fstack-protector-all && replace-flags -O3 -O2
+		use hardened && replace-flags -O3 -O2
+	fi
+
+	# https://bugs.gentoo.org/700012
+	if is-flagq -flto || is-flagq '-flto=*'; then
+		append-cflags $(test-flags-CC -ffat-lto-objects)
+	fi
+
+	# Export CXX so it ends up in /usr/lib/python3.X/config/Makefile.
+	tc-export CXX
+
+	# Fix implicit declarations on cross and prefix builds. Bug #674070.
+	use ncurses && append-cppflags -I"${ESYSROOT}"/usr/include/ncursesw
+
+	local dbmliborder
+	if use gdbm; then
+		dbmliborder+="${dbmliborder:+:}gdbm"
+	fi
+
+	local myeconfargs=(
+		# glibc-2.30 removes it; since we can't cleanly force-rebuild
+		# Python on glibc upgrade, remove it proactively to give
+		# a chance for users rebuilding python before glibc
+		ac_cv_header_stropts_h=no
+
+		--enable-shared
+		--enable-ipv6
+		--infodir='${prefix}/share/info'
+		--mandir='${prefix}/share/man'
+		--with-computed-gotos
+		--with-dbmliborder="${dbmliborder}"
+		--with-libc=
+		--enable-loadable-sqlite-extensions
+		--without-ensurepip
+		--with-system-expat
+		--with-system-ffi
+	)
+
+	# disable implicit optimization/debugging flags
+	local -x OPT=
+	# pass system CFLAGS & LDFLAGS as _NODIST, otherwise they'll get
+	# propagated to sysconfig for built extensions
+	local -x CFLAGS_NODIST=${CFLAGS}
+	local -x LDFLAGS_NODIST=${LDFLAGS}
+	local -x CFLAGS= LDFLAGS=
+
+	econf "${myeconfargs[@]}"
+
+	if grep -q "#define POSIX_SEMAPHORES_NOT_ENABLED 1" pyconfig.h; then
+		eerror "configure has detected that the sem_open function is broken."
+		eerror "Please ensure that /dev/shm is mounted as a tmpfs with mode 1777."
+		die "Broken sem_open function (bug 496328)"
+	fi
+}
+
+src_compile() {
+	# Ensure sed works as expected
+	# https://bugs.gentoo.org/594768
+	local -x LC_ALL=C
+	# Prevent using distutils bundled by setuptools.
+	# https://bugs.gentoo.org/823728
+	export SETUPTOOLS_USE_DISTUTILS=stdlib
+
+	# also need to clear the flags explicitly here or they end up
+	# in _sysconfigdata*
+	emake CPPFLAGS= CFLAGS= LDFLAGS=
+
+	# Work around bug 329499. See also bug 413751 and 457194.
+	if has_version dev-libs/libffi[pax-kernel]; then
+		pax-mark E python
+	else
+		pax-mark m python
+	fi
+}
+
+src_test() {
+	# Tests will not work when cross compiling.
+	if tc-is-cross-compiler; then
+		elog "Disabling tests due to crosscompiling."
+		return
+	fi
+
+	# Skip failing tests.
+	local skipped_tests="gdb"
+
+	for test in ${skipped_tests}; do
+		mv "${S}"/Lib/test/test_${test}.py "${T}"
+	done
+
+	# bug 660358
+	local -x COLUMNS=80
+	local -x PYTHONDONTWRITEBYTECODE=
+
+	local jobs=$(makeopts_jobs "${MAKEOPTS}" "$(get_nproc)")
+
+	emake test EXTRATESTOPTS="-u-network -j${jobs}" \
+		CPPFLAGS= CFLAGS= LDFLAGS= < /dev/tty
+	local result=$?
+
+	for test in ${skipped_tests}; do
+		mv "${T}/test_${test}.py" "${S}"/Lib/test
+	done
+
+	elog "The following tests have been skipped:"
+	for test in ${skipped_tests}; do
+		elog "test_${test}.py"
+	done
+
+	elog "If you would like to run them, you may:"
+	elog "cd '${EPREFIX}/usr/lib/python${PYVER}/test'"
+	elog "and run the tests separately."
+
+	if [[ ${result} -ne 0 ]]; then
+		die "emake test failed"
+	fi
+}
+
+src_install() {
+	local libdir=${ED}/usr/lib/python${PYVER}
+
+	emake DESTDIR="${D}" altinstall
+
+	# Remove static library
+	rm "${ED}"/usr/$(get_libdir)/libpython*.a || die
+
+	# Fix collisions between different slots of Python.
+	rm "${ED}/usr/$(get_libdir)/libpython3.so" || die
+
+	# Cheap hack to get version with ABIFLAGS
+	local abiver=$(cd "${ED}/usr/include"; echo python*)
+	if [[ ${abiver} != python${PYVER} ]]; then
+		# Replace python3.X with a symlink to python3.Xm
+		rm "${ED}/usr/bin/python${PYVER}" || die
+		dosym "${abiver}" "/usr/bin/python${PYVER}"
+		# Create python3.X-config symlink
+		dosym "${abiver}-config" "/usr/bin/python${PYVER}-config"
+		# Create python-3.5m.pc symlink
+		dosym "python-${PYVER}.pc" "/usr/$(get_libdir)/pkgconfig/${abiver/${PYVER}/-${PYVER}}.pc"
+	fi
+
+	# python seems to get rebuilt in src_install (bug 569908)
+	# Work around it for now.
+	if has_version dev-libs/libffi[pax-kernel]; then
+		pax-mark E "${ED}/usr/bin/${abiver}"
+	else
+		pax-mark m "${ED}/usr/bin/${abiver}"
+	fi
+
+	use sqlite || rm -r "${libdir}/"{sqlite3,test/test_sqlite*} || die
+	use tk || rm -r "${ED}/usr/bin/idle${PYVER}" "${libdir}/"{idlelib,tkinter,test/test_tk*} || die
+
+	use wininst || rm "${libdir}/distutils/command/"wininst-*.exe || die
+
+	dodoc Misc/{ACKS,HISTORY,NEWS}
+
+	if use examples; then
+		docinto examples
+		find Tools -name __pycache__ -exec rm -fr {} + || die
+		dodoc -r Tools
+	fi
+	insinto /usr/share/gdb/auto-load/usr/$(get_libdir) #443510
+	local libname=$(printf 'e:\n\t@echo $(INSTSONAME)\ninclude Makefile\n' | \
+		emake --no-print-directory -s -f - 2>/dev/null)
+	newins "${S}"/Tools/gdb/libpython.py "${libname}"-gdb.py
+
+	newconfd "${FILESDIR}/pydoc.conf" pydoc-${PYVER}
+	newinitd "${FILESDIR}/pydoc.init" pydoc-${PYVER}
+	sed \
+		-e "s:@PYDOC_PORT_VARIABLE@:PYDOC${PYVER/./_}_PORT:" \
+		-e "s:@PYDOC@:pydoc${PYVER}:" \
+		-i "${ED}/etc/conf.d/pydoc-${PYVER}" \
+		"${ED}/etc/init.d/pydoc-${PYVER}" || die "sed failed"
+
+	local -x EPYTHON=python${PYVER}
+	# if not using a cross-compiler, use the fresh binary
+	if ! tc-is-cross-compiler; then
+		local -x PYTHON=./python
+		local -x LD_LIBRARY_PATH=${LD_LIBRARY_PATH+${LD_LIBRARY_PATH}:}${PWD}
+	else
+		local -x PYTHON=${EPREFIX}/usr/bin/${EPYTHON}
+	fi
+
+	echo "EPYTHON='${EPYTHON}'" > epython.py || die
+	python_domodule epython.py
+
+	# python-exec wrapping support
+	local pymajor=${PYVER%.*}
+	local scriptdir=${D}$(python_get_scriptdir)
+	mkdir -p "${scriptdir}" || die
+	# python and pythonX
+	ln -s "../../../bin/${abiver}" \
+		"${scriptdir}/python${pymajor}" || die
+	ln -s "python${pymajor}" "${scriptdir}/python" || die
+	# python-config and pythonX-config
+	# note: we need to create a wrapper rather than symlinking it due
+	# to some random dirname(argv[0]) magic performed by python-config
+	cat > "${scriptdir}/python${pymajor}-config" <<-EOF || die
+		#!/bin/sh
+		exec "${abiver}-config" "\${@}"
+	EOF
+	chmod +x "${scriptdir}/python${pymajor}-config" || die
+	ln -s "python${pymajor}-config" \
+		"${scriptdir}/python-config" || die
+	# 2to3, pydoc
+	ln -s "../../../bin/2to3-${PYVER}" \
+		"${scriptdir}/2to3" || die
+	ln -s "../../../bin/pydoc${PYVER}" \
+		"${scriptdir}/pydoc" || die
+	# idle
+	if use tk; then
+		ln -s "../../../bin/idle${PYVER}" \
+			"${scriptdir}/idle" || die
+	fi
+}

--- a/dev-lang/python/python-3.9.10-r1.ebuild
+++ b/dev-lang/python/python-3.9.10-r1.ebuild
@@ -1,0 +1,380 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="7"
+WANT_LIBTOOL="none"
+
+inherit autotools check-reqs flag-o-matic multiprocessing pax-utils \
+	python-utils-r1 toolchain-funcs verify-sig
+
+MY_PV=${PV/_rc/rc}
+MY_P="Python-${MY_PV%_p*}"
+PYVER=$(ver_cut 1-2)
+PATCHSET="python-gentoo-patches-${MY_PV}"
+
+DESCRIPTION="An interpreted, interactive, object-oriented programming language"
+HOMEPAGE="https://www.python.org/"
+SRC_URI="https://www.python.org/ftp/python/${PV%_*}/${MY_P}.tar.xz
+	https://dev.gentoo.org/~mgorny/dist/python/${PATCHSET}.tar.xz
+	verify-sig? (
+		https://www.python.org/ftp/python/${PV%_*}/${MY_P}.tar.xz.asc
+	)"
+S="${WORKDIR}/${MY_P}"
+
+LICENSE="PSF-2"
+SLOT="${PYVER}"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+IUSE="bluetooth build examples gdbm hardened lto +ncurses pgo +readline +sqlite +ssl test tk wininst +xml"
+RESTRICT="!test? ( test )"
+
+# Do not add a dependency on dev-lang/python to this ebuild.
+# If you need to apply a patch which requires python for bootstrapping, please
+# run the bootstrap code on your dev box and include the results in the
+# patchset. See bug 447752.
+
+RDEPEND="app-arch/bzip2:=
+	app-arch/xz-utils:=
+	dev-lang/python-exec[python_targets_python3_9(-)]
+	dev-libs/libffi:=
+	sys-apps/util-linux:=
+	>=sys-libs/zlib-1.1.3:=
+	virtual/libcrypt:=
+	virtual/libintl
+	gdbm? ( sys-libs/gdbm:=[berkdb] )
+	ncurses? ( >=sys-libs/ncurses-5.2:= )
+	readline? ( >=sys-libs/readline-4.1:= )
+	sqlite? ( >=dev-db/sqlite-3.3.8:3= )
+	ssl? ( >=dev-libs/openssl-1.1.1:= )
+	tk? (
+		>=dev-lang/tcl-8.0:=
+		>=dev-lang/tk-8.0:=
+		dev-tcltk/blt:=
+		dev-tcltk/tix
+	)
+	xml? ( >=dev-libs/expat-2.1:= )"
+# bluetooth requires headers from bluez
+DEPEND="${RDEPEND}
+	bluetooth? ( net-wireless/bluez )
+	test? ( app-arch/xz-utils[extra-filters(+)] )"
+BDEPEND="
+	virtual/awk
+	virtual/pkgconfig
+	sys-devel/autoconf-archive
+	verify-sig? ( sec-keys/openpgp-keys-python )
+	!sys-devel/gcc[libffi(-)]"
+RDEPEND+=" !build? ( app-misc/mime-types )"
+
+VERIFY_SIG_OPENPGP_KEY_PATH=${BROOT}/usr/share/openpgp-keys/python.org.asc
+
+# large file tests involve a 2.5G file being copied (duplicated)
+CHECKREQS_DISK_BUILD=5500M
+
+pkg_pretend() {
+	use test && check-reqs_pkg_pretend
+}
+
+pkg_setup() {
+	use test && check-reqs_pkg_setup
+}
+
+src_unpack() {
+	if use verify-sig; then
+		verify-sig_verify_detached "${DISTDIR}"/${MY_P}.tar.xz{,.asc}
+	fi
+	default
+}
+
+src_prepare() {
+	# Ensure that internal copies of expat, libffi and zlib are not used.
+	rm -fr Modules/expat || die
+	rm -fr Modules/_ctypes/libffi* || die
+	rm -fr Modules/zlib || die
+
+	local PATCHES=(
+		"${WORKDIR}/${PATCHSET}"
+	)
+
+	default
+
+	sed -i -e "s:@@GENTOO_LIBDIR@@:$(get_libdir):g" \
+		setup.py || die "sed failed to replace @@GENTOO_LIBDIR@@"
+
+	# force correct number of jobs
+	# https://bugs.gentoo.org/737660
+	local jobs=$(makeopts_jobs "${MAKEOPTS}" "$(get_nproc)")
+	sed -i -e "s:-j0:-j${jobs}:" Makefile.pre.in || die
+	sed -i -e "/self\.parallel/s:True:${jobs}:" setup.py || die
+
+	eautoreconf
+}
+
+src_configure() {
+	local disable
+	# disable automagic bluetooth headers detection
+	use bluetooth || export ac_cv_header_bluetooth_bluetooth_h=no
+	use gdbm      || disable+=" gdbm"
+	use ncurses   || disable+=" _curses _curses_panel"
+	use readline  || disable+=" readline"
+	use sqlite    || disable+=" _sqlite3"
+	use ssl       || export PYTHON_DISABLE_SSL="1"
+	use tk        || disable+=" _tkinter"
+	use xml       || disable+=" _elementtree pyexpat" # _elementtree uses pyexpat.
+	export PYTHON_DISABLE_MODULES="${disable}"
+
+	if ! use xml; then
+		ewarn "You have configured Python without XML support."
+		ewarn "This is NOT a recommended configuration as you"
+		ewarn "may face problems parsing any XML documents."
+	fi
+
+	if [[ -n "${PYTHON_DISABLE_MODULES}" ]]; then
+		einfo "Disabled modules: ${PYTHON_DISABLE_MODULES}"
+	fi
+
+	if [[ "$(gcc-major-version)" -ge 4 ]]; then
+		append-flags -fwrapv
+	fi
+
+	filter-flags -malign-double
+
+	# https://bugs.gentoo.org/show_bug.cgi?id=50309
+	if is-flagq -O3; then
+		is-flagq -fstack-protector-all && replace-flags -O3 -O2
+		use hardened && replace-flags -O3 -O2
+	fi
+
+	# https://bugs.gentoo.org/700012
+	if is-flagq -flto || is-flagq '-flto=*'; then
+		append-cflags $(test-flags-CC -ffat-lto-objects)
+	fi
+
+	# Export CXX so it ends up in /usr/lib/python3.X/config/Makefile.
+	tc-export CXX
+
+	# Fix implicit declarations on cross and prefix builds. Bug #674070.
+	use ncurses && append-cppflags -I"${ESYSROOT}"/usr/include/ncursesw
+
+	local dbmliborder
+	if use gdbm; then
+		dbmliborder+="${dbmliborder:+:}gdbm"
+	fi
+
+	if use pgo; then
+		local jobs=$(makeopts_jobs "${MAKEOPTS}" "$(get_nproc)")
+		export PROFILE_TASK="-m test -j${jobs} --pgo-extended -x test_gdb -u-network"
+
+		# All of these seem to occasionally hang for PGO inconsistently
+		# They'll even hang here but be fine in src_test sometimes.
+		# bug #828535 (and related: bug #788022)
+		PROFILE_TASK+=" -x test_socket -x test_asyncio -x test_httpservers -x test_logging -x test_multiprocessing_fork -x test_xmlrpc"
+
+		if has_version "app-arch/rpm" ; then
+			# Avoid sandbox failure (attempts to write to /var/lib/rpm)
+			PROFILE_TASK+=" -x test_distutils"
+		fi
+	fi
+
+	local myeconfargs=(
+		# glibc-2.30 removes it; since we can't cleanly force-rebuild
+		# Python on glibc upgrade, remove it proactively to give
+		# a chance for users rebuilding python before glibc
+		ac_cv_header_stropts_h=no
+
+		--enable-shared
+		--enable-ipv6
+		--infodir='${prefix}/share/info'
+		--mandir='${prefix}/share/man'
+		--with-computed-gotos
+		--with-dbmliborder="${dbmliborder}"
+		--with-libc=
+		--enable-loadable-sqlite-extensions
+		--without-ensurepip
+		--with-system-expat
+		--with-system-ffi
+
+		$(use_with lto)
+		$(use_enable pgo optimizations)
+	)
+
+	# disable implicit optimization/debugging flags
+	local -x OPT=
+	# pass system CFLAGS & LDFLAGS as _NODIST, otherwise they'll get
+	# propagated to sysconfig for built extensions
+	local -x CFLAGS_NODIST=${CFLAGS}
+	local -x LDFLAGS_NODIST=${LDFLAGS}
+	local -x CFLAGS= LDFLAGS=
+
+	econf "${myeconfargs[@]}"
+
+	if grep -q "#define POSIX_SEMAPHORES_NOT_ENABLED 1" pyconfig.h; then
+		eerror "configure has detected that the sem_open function is broken."
+		eerror "Please ensure that /dev/shm is mounted as a tmpfs with mode 1777."
+		die "Broken sem_open function (bug 496328)"
+	fi
+}
+
+src_compile() {
+	# Ensure sed works as expected
+	# https://bugs.gentoo.org/594768
+	local -x LC_ALL=C
+	# Prevent using distutils bundled by setuptools.
+	# https://bugs.gentoo.org/823728
+	export SETUPTOOLS_USE_DISTUTILS=stdlib
+
+	if use pgo ; then
+		# bug 660358
+		local -x COLUMNS=80
+		local -x PYTHONDONTWRITEBYTECODE=
+
+		addpredict /usr/lib/python3.9/site-packages
+	fi
+
+	# also need to clear the flags explicitly here or they end up
+	# in _sysconfigdata*
+	emake CPPFLAGS= CFLAGS= LDFLAGS=
+
+	# Work around bug 329499. See also bug 413751 and 457194.
+	if has_version dev-libs/libffi[pax-kernel]; then
+		pax-mark E python
+	else
+		pax-mark m python
+	fi
+}
+
+src_test() {
+	# Tests will not work when cross compiling.
+	if tc-is-cross-compiler; then
+		elog "Disabling tests due to crosscompiling."
+		return
+	fi
+
+	# Skip failing tests.
+	local skipped_tests="gdb"
+
+	for test in ${skipped_tests}; do
+		mv "${S}"/Lib/test/test_${test}.py "${T}"
+	done
+
+	# bug 660358
+	local -x COLUMNS=80
+	local -x PYTHONDONTWRITEBYTECODE=
+
+	local jobs=$(makeopts_jobs "${MAKEOPTS}" "$(get_nproc)")
+
+	emake test EXTRATESTOPTS="-u-network -j${jobs}" \
+		CPPFLAGS= CFLAGS= LDFLAGS= < /dev/tty
+	local result=$?
+
+	for test in ${skipped_tests}; do
+		mv "${T}/test_${test}.py" "${S}"/Lib/test
+	done
+
+	elog "The following tests have been skipped:"
+	for test in ${skipped_tests}; do
+		elog "test_${test}.py"
+	done
+
+	elog "If you would like to run them, you may:"
+	elog "cd '${EPREFIX}/usr/lib/python${PYVER}/test'"
+	elog "and run the tests separately."
+
+	if [[ ${result} -ne 0 ]]; then
+		die "emake test failed"
+	fi
+}
+
+src_install() {
+	local libdir=${ED}/usr/lib/python${PYVER}
+
+	emake DESTDIR="${D}" altinstall
+
+	# Remove static library
+	rm "${ED}"/usr/$(get_libdir)/libpython*.a || die
+
+	# Fix collisions between different slots of Python.
+	rm "${ED}/usr/$(get_libdir)/libpython3.so" || die
+
+	# Cheap hack to get version with ABIFLAGS
+	local abiver=$(cd "${ED}/usr/include"; echo python*)
+	if [[ ${abiver} != python${PYVER} ]]; then
+		# Replace python3.X with a symlink to python3.Xm
+		rm "${ED}/usr/bin/python${PYVER}" || die
+		dosym "${abiver}" "/usr/bin/python${PYVER}"
+		# Create python3.X-config symlink
+		dosym "${abiver}-config" "/usr/bin/python${PYVER}-config"
+		# Create python-3.5m.pc symlink
+		dosym "python-${PYVER}.pc" "/usr/$(get_libdir)/pkgconfig/${abiver/${PYVER}/-${PYVER}}.pc"
+	fi
+
+	# python seems to get rebuilt in src_install (bug 569908)
+	# Work around it for now.
+	if has_version dev-libs/libffi[pax-kernel]; then
+		pax-mark E "${ED}/usr/bin/${abiver}"
+	else
+		pax-mark m "${ED}/usr/bin/${abiver}"
+	fi
+
+	use sqlite || rm -r "${libdir}/"{sqlite3,test/test_sqlite*} || die
+	use tk || rm -r "${ED}/usr/bin/idle${PYVER}" "${libdir}/"{idlelib,tkinter,test/test_tk*} || die
+
+	dodoc Misc/{ACKS,HISTORY,NEWS}
+
+	if use examples; then
+		docinto examples
+		find Tools -name __pycache__ -exec rm -fr {} + || die
+		dodoc -r Tools
+	fi
+	insinto /usr/share/gdb/auto-load/usr/$(get_libdir) #443510
+	local libname=$(printf 'e:\n\t@echo $(INSTSONAME)\ninclude Makefile\n' | \
+		emake --no-print-directory -s -f - 2>/dev/null)
+	newins "${S}"/Tools/gdb/libpython.py "${libname}"-gdb.py
+
+	newconfd "${FILESDIR}/pydoc.conf" pydoc-${PYVER}
+	newinitd "${FILESDIR}/pydoc.init" pydoc-${PYVER}
+	sed \
+		-e "s:@PYDOC_PORT_VARIABLE@:PYDOC${PYVER/./_}_PORT:" \
+		-e "s:@PYDOC@:pydoc${PYVER}:" \
+		-i "${ED}/etc/conf.d/pydoc-${PYVER}" \
+		"${ED}/etc/init.d/pydoc-${PYVER}" || die "sed failed"
+
+	local -x EPYTHON=python${PYVER}
+	# if not using a cross-compiler, use the fresh binary
+	if ! tc-is-cross-compiler; then
+		local -x PYTHON=./python
+		local -x LD_LIBRARY_PATH=${LD_LIBRARY_PATH+${LD_LIBRARY_PATH}:}${PWD}
+	else
+		local -x PYTHON=${EPREFIX}/usr/bin/${EPYTHON}
+	fi
+
+	echo "EPYTHON='${EPYTHON}'" > epython.py || die
+	python_domodule epython.py
+
+	# python-exec wrapping support
+	local pymajor=${PYVER%.*}
+	local scriptdir=${D}$(python_get_scriptdir)
+	mkdir -p "${scriptdir}" || die
+	# python and pythonX
+	ln -s "../../../bin/${abiver}" \
+		"${scriptdir}/python${pymajor}" || die
+	ln -s "python${pymajor}" "${scriptdir}/python" || die
+	# python-config and pythonX-config
+	# note: we need to create a wrapper rather than symlinking it due
+	# to some random dirname(argv[0]) magic performed by python-config
+	cat > "${scriptdir}/python${pymajor}-config" <<-EOF || die
+		#!/bin/sh
+		exec "${abiver}-config" "\${@}"
+	EOF
+	chmod +x "${scriptdir}/python${pymajor}-config" || die
+	ln -s "python${pymajor}-config" \
+		"${scriptdir}/python-config" || die
+	# 2to3, pydoc
+	ln -s "../../../bin/2to3-${PYVER}" \
+		"${scriptdir}/2to3" || die
+	ln -s "../../../bin/pydoc${PYVER}" \
+		"${scriptdir}/pydoc" || die
+	# idle
+	if use tk; then
+		ln -s "../../../bin/idle${PYVER}" \
+			"${scriptdir}/idle" || die
+	fi
+}


### PR DESCRIPTION
So apparently we've been building CPython wrong and patching distutils to fix our mistake. Since py3.11 / setuptools vendored distutils no longer carry our patch, let's fix building Python so that CFLAGS and LDFLAGS from build time aren't embedded in sysconfig.

TODO: check pypy3