### PR TITLE
x11-misc/qps: loosen version constraint on lxqt-base/liblxqt

### DIFF
--- a/x11-misc/qps/qps-2.4.0-r1.ebuild
+++ b/x11-misc/qps/qps-2.4.0-r1.ebuild
@@ -18,13 +18,12 @@ BDEPEND="
 	>=dev-util/lxqt-build-tools-0.10.0
 "
 DEPEND="
-	=lxqt-base/liblxqt-1*:=
 	>=dev-qt/qtcore-5.15:5
 	>=dev-qt/qtdbus-5.15:5
 	>=dev-qt/qtgui-5.15:5
 	>=dev-qt/qtwidgets-5.15:5
 	>=dev-qt/qtx11extras-5.15:5
-	=lxqt-base/liblxqt-1*:=
+	>=lxqt-base/liblxqt-1:=
 "
 RDEPEND="${DEPEND}"
 


### PR DESCRIPTION
So one can use lxqt-base/liblxqt-9999

Closes: https://bugs.gentoo.org/831886

Signed-off-by: Adel KARA SLIMANE <adel.ks@zegrapher.com>