### PR TITLE
dev-python/argon2-cffi-bindings: Added dev-python/setuptools_scm to BDEPEND

### DIFF
--- a/dev-python/argon2-cffi-bindings/argon2-cffi-bindings-21.2.0.ebuild
+++ b/dev-python/argon2-cffi-bindings/argon2-cffi-bindings-21.2.0.ebuild
@@ -16,7 +16,10 @@ KEYWORDS="amd64 arm arm64 hppa ~ia64 ppc ~ppc64 ~riscv ~s390 ~sparc x86"
 IUSE="cpu_flags_x86_sse2"
 
 DEPEND="app-crypt/argon2:="
-BDEPEND="virtual/python-cffi[${PYTHON_USEDEP}]"
+BDEPEND="
+	>=dev-python/setuptools_scm-6.2[${PYTHON_USEDEP}]
+	virtual/python-cffi[${PYTHON_USEDEP}]
+"
 RDEPEND="
 	${DEPEND}
 	${BDEPEND}


### PR DESCRIPTION
dev-python/setuptools_scm is a build-time dependency for argon2-cffi-bindings-21.2.0 [1] and it's missing.

[1] https://github.com/hynek/argon2-cffi-bindings/blob/21.2.0/pyproject.toml#L2
