### PR TITLE
Backport upstream meson 0.61.1 fixes

### DIFF
--- a/app-text/evince/evince-41.3.ebuild
+++ b/app-text/evince/evince-41.3.ebuild
@@ -67,6 +67,10 @@ BDEPEND="
 	virtual/pkgconfig
 "
 
+PATCHES=(
+	"${FILESDIR}/${PV}"-fix-build-with-meson-0.61.1.patch
+)
+
 src_prepare() {
 	xdg_src_prepare
 

--- a/app-text/evince/files/41.3-fix-build-with-meson-0.61.1.patch
+++ b/app-text/evince/files/41.3-fix-build-with-meson-0.61.1.patch
@@ -1,0 +1,54 @@
+https://gitlab.gnome.org/GNOME/evince/-/commit/1060b24d051607f14220f148d2f7723b29897a54
+https://bugs.gentoo.org/831853
+
+From: r-value <i@rvalue.moe>
+Date: Wed, 17 Nov 2021 18:22:45 +0800
+Subject: [PATCH] Remove incorrect args for i18n.merge_file
+
+`i18n.merge_file` has been ignoring positional arguments for
+a time and explicitly rejects with error since meson 0.60.0
+---
+ backend/meson.build | 1 -
+ data/meson.build    | 1 -
+ meson.build         | 1 -
+ 3 files changed, 3 deletions(-)
+
+diff --git a/backend/meson.build b/backend/meson.build
+index e44c1d6d7..ab3df9acf 100644
+--- a/backend/meson.build
++++ b/backend/meson.build
+@@ -50,7 +50,6 @@ foreach backend, backend_mime_types: backends
+   )
+ 
+   i18n.merge_file(
+-    appstream,
+     input: appstream_in,
+     output: appstream,
+     po_dir: po_dir,
+diff --git a/data/meson.build b/data/meson.build
+index 8a308b853..afc302098 100644
+--- a/data/meson.build
++++ b/data/meson.build
+@@ -15,7 +15,6 @@ foreach desktop: desktops
+   )
+ 
+   i18n.merge_file(
+-    desktop,
+     type: 'desktop',
+     input: desktop_in,
+     output: desktop,
+diff --git a/meson.build b/meson.build
+index 34c86661f..f74efb3c4 100644
+--- a/meson.build
++++ b/meson.build
+@@ -492,7 +492,6 @@ install_headers(
+ appdata = ev_namespace + '.appdata.xml'
+ 
+ i18n.merge_file(
+-  appdata,
+   input: appdata + '.in',
+   output: appdata,
+   po_dir: po_dir,
+-- 
+GitLab
+

--- a/dev-vcs/gitg/files/41-fix-build-with-meson-0.61.1.patch
+++ b/dev-vcs/gitg/files/41-fix-build-with-meson-0.61.1.patch
@@ -1,0 +1,38 @@
+https://gitlab.gnome.org/GNOME/gitg/-/commit/1978973b12848741b08695ec2020bac98584d636
+https://bugs.gentoo.org/831666
+
+From: Jan Beich <jbeich@FreeBSD.org>
+Date: Mon, 24 Jan 2022 12:17:52 +0000
+Subject: [PATCH] meson: drop unused argument for i18n.merge_file()
+
+Ignored in Meson < 0.60.0, deprecated since 0.60.1 and fatal since 0.61.0.
+
+data/meson.build:8:0: ERROR: Function does not take positional arguments.
+data/meson.build:44:0: ERROR: Function does not take positional arguments.
+---
+ data/meson.build | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/data/meson.build b/data/meson.build
+index a8b90fd1..2413531d 100644
+--- a/data/meson.build
++++ b/data/meson.build
+@@ -6,7 +6,6 @@ desktop_config = configuration_data()
+ desktop_config.set('icon', application_id)
+ desktop_config.set('binary', gitg_name)
+ i18n.merge_file(
+-  desktop,
+   type: 'desktop',
+   input: configure_file(
+     input: desktop + '.in.in',
+@@ -42,7 +41,6 @@ appdata_config = configuration_data()
+ appdata_config.set('app-id', application_id)
+ appdata_config.set('gettext', gitg_name)
+ i18n.merge_file(
+-  appdata,
+   type: 'xml',
+   input: configure_file(
+     input: appdata + '.in.in',
+-- 
+GitLab
+

--- a/dev-vcs/gitg/gitg-41.ebuild
+++ b/dev-vcs/gitg/gitg-41.ebuild
@@ -48,6 +48,10 @@ DEPEND="${RDEPEND}
 	virtual/pkgconfig
 "
 
+PATCHES=(
+	"${FILESDIR}/${PV}"-fix-build-with-meson-0.61.1.patch
+)
+
 src_prepare() {
 	default
 	vala_src_prepare

--- a/games-puzzle/gnome-sudoku/files/40.2-fix-build-with-meson-0.61.1.patch
+++ b/games-puzzle/gnome-sudoku/files/40.2-fix-build-with-meson-0.61.1.patch
@@ -1,0 +1,40 @@
+https://gitlab.gnome.org/GNOME/gnome-sudoku/-/commit/7c9935a02b48f332f67bad3e4ee020b75591084a
+https://bugs.gentoo.org/831556
+
+From: Jan Beich <jbeich@FreeBSD.org>
+Date: Mon, 24 Jan 2022 11:44:06 +0000
+Subject: [PATCH] meson: drop unused argument for i18n.merge_file()
+
+Ignored in Meson < 0.60.0, deprecated since 0.60.1 and fatal since 0.61.0.
+
+data/meson.build:5:0: ERROR: Function does not take positional arguments.
+data/meson.build:24:0: ERROR: Function does not take positional arguments.
+---
+ data/meson.build | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/data/meson.build b/data/meson.build
+index f18f247..9c95e02 100644
+--- a/data/meson.build
++++ b/data/meson.build
+@@ -2,7 +2,7 @@ resource_files = files('gnome-sudoku.gresource.xml')
+ 
+ resources = gnome.compile_resources('gnome-sudoku', resource_files)
+ 
+-desktop_file = i18n.merge_file('desktop',
++desktop_file = i18n.merge_file(
+   input: '@0@.desktop.in'.format(application_id),
+   output: '@0@.desktop'.format(application_id),
+   install: true,
+@@ -21,7 +21,7 @@ if desktop_file_validate.found()
+   )
+ endif
+ 
+-appdata_file = i18n.merge_file('appdata',
++appdata_file = i18n.merge_file(
+   input: '@0@.appdata.xml.in'.format(application_id),
+   output: '@0@.appdata.xml'.format(application_id),
+   install: true,
+-- 
+GitLab
+

--- a/games-puzzle/gnome-sudoku/gnome-sudoku-40.2.ebuild
+++ b/games-puzzle/gnome-sudoku/gnome-sudoku-40.2.ebuild
@@ -33,6 +33,10 @@ BDEPEND="
 	virtual/pkgconfig
 "
 
+PATCHES=(
+	"${FILESDIR}/${PV}"-fix-build-with-meson-0.61.1.patch
+)
+
 src_prepare() {
 	xdg_src_prepare
 	vala_src_prepare

--- a/gnome-base/gnome-shell/files/41.3-fix-build-with-meson-0.61.1.patch
+++ b/gnome-base/gnome-shell/files/41.3-fix-build-with-meson-0.61.1.patch
@@ -1,0 +1,84 @@
+https://gitlab.gnome.org/GNOME/gnome-shell/-/commit/65450a836ee9e0722a2d4c3327f52345eae293c6
+https://bugs.gentoo.org/831921
+
+From: =?UTF-8?q?Florian=20M=C3=BCllner?= <fmuellner@gnome.org>
+Date: Thu, 23 Dec 2021 17:18:16 +0100
+Subject: [PATCH] build: Drop incorrect positional arg
+
+Unlike other targets that take a name, i18n.merge_file() does not.
+
+Part-of: <https://gitlab.gnome.org/GNOME/gnome-shell/-/merge_requests/2078>
+---
+ data/meson.build                                      | 2 +-
+ src/calendar-server/meson.build                       | 2 +-
+ subprojects/extensions-app/data/meson.build           | 2 +-
+ subprojects/extensions-app/data/metainfo/meson.build  | 2 +-
+ subprojects/extensions-tool/src/templates/meson.build | 2 +-
+ 5 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/data/meson.build b/data/meson.build
+index f924fdf806..76ae45c93a 100644
+--- a/data/meson.build
++++ b/data/meson.build
+@@ -16,7 +16,7 @@ desktopconf.set('bindir', bindir)
+ desktopconf.set('systemd_hidden', have_systemd ? 'true' : 'false')
+ 
+ foreach desktop_file : desktop_files
+-  i18n.merge_file('desktop',
++  i18n.merge_file(
+     input: configure_file(
+       input: desktop_file + '.in.in',
+       output: desktop_file + '.in',
+diff --git a/src/calendar-server/meson.build b/src/calendar-server/meson.build
+index 7363282a59..8b4ef411c8 100644
+--- a/src/calendar-server/meson.build
++++ b/src/calendar-server/meson.build
+@@ -27,7 +27,7 @@ configure_file(
+   install_dir: servicedir
+ )
+ 
+-i18n.merge_file('evolution-calendar.desktop',
++i18n.merge_file(
+   input: 'evolution-calendar.desktop.in',
+   output: 'evolution-calendar.desktop',
+   po_dir: po_dir,
+diff --git a/subprojects/extensions-app/data/meson.build b/subprojects/extensions-app/data/meson.build
+index d7e7d4001c..4b601e8bd1 100644
+--- a/subprojects/extensions-app/data/meson.build
++++ b/subprojects/extensions-app/data/meson.build
+@@ -14,7 +14,7 @@ desktopconf.set('bindir', bindir)
+ desktopconf.set('app_id', app_id)
+ desktopconf.set('prgname', prgname)
+ 
+-i18n.merge_file('desktop',
++i18n.merge_file(
+   input: configure_file(
+     input: base_id + '.desktop.in.in',
+     output: desktop_file + '.in',
+diff --git a/subprojects/extensions-app/data/metainfo/meson.build b/subprojects/extensions-app/data/metainfo/meson.build
+index c4962c0576..a19bfa80a4 100644
+--- a/subprojects/extensions-app/data/metainfo/meson.build
++++ b/subprojects/extensions-app/data/metainfo/meson.build
+@@ -1,5 +1,5 @@
+ metainfo = app_id + '.metainfo.xml'
+-i18n.merge_file(metainfo,
++i18n.merge_file(
+   input: base_id + '.metainfo.xml.in',
+   output: metainfo,
+   po_dir: po_dir,
+diff --git a/subprojects/extensions-tool/src/templates/meson.build b/subprojects/extensions-tool/src/templates/meson.build
+index 670e2bf448..d693bfaddb 100644
+--- a/subprojects/extensions-tool/src/templates/meson.build
++++ b/subprojects/extensions-tool/src/templates/meson.build
+@@ -4,7 +4,7 @@ template_metas = [
+ ]
+ template_deps = []
+ foreach template : template_metas
+-  template_deps += i18n.merge_file(template,
++  template_deps += i18n.merge_file(
+     input: template + '.in',
+     output: template,
+     po_dir: po_dir,
+-- 
+GitLab
+

--- a/gnome-base/gnome-shell/gnome-shell-41.3.ebuild
+++ b/gnome-base/gnome-shell/gnome-shell-41.3.ebuild
@@ -139,6 +139,7 @@ PATCHES=(
 	"${FILESDIR}"/40.0-optional-bluetooth.patch
 	# Change favorites defaults, bug #479918
 	"${FILESDIR}"/40.0-defaults.patch
+	"${FILESDIR}/${PV}"-fix-build-with-meson-0.61.1.patch
 )
 
 src_prepare() {

--- a/gnome-extra/gnome-boxes/files/41.3-fix-build-with-meson-0.61.1.patch
+++ b/gnome-extra/gnome-boxes/files/41.3-fix-build-with-meson-0.61.1.patch
@@ -1,0 +1,38 @@
+https://gitlab.gnome.org/GNOME/gnome-boxes/-/commit/fd0acfbe79444687c73dea182c2d1a5fa1c77324
+https://bugs.gentoo.org/831934
+
+From: Michal Vasilek <michal@vasilek.cz>
+Date: Sat, 15 Jan 2022 00:07:31 +0100
+Subject: [PATCH] build: remove positional i18n.merge_file arguments
+
+otherwise building with meson 0.61+ fails:
+
+    ERROR: Function does not take positional arguments.
+---
+ data/meson.build | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/data/meson.build b/data/meson.build
+index d32638a8..2dc1798b 100644
+--- a/data/meson.build
++++ b/data/meson.build
+@@ -20,7 +20,6 @@ resources = gnome.compile_resources ('org.gnome.Boxes',
+ desktop_conf = configuration_data ()
+ desktop_conf.set ('icon', application_id)
+ desktop = i18n.merge_file (
+-  'desktop',
+   input: configure_file (
+     input: files ('org.gnome.Boxes.desktop.in'),
+     output: 'org.gnome.Boxes.desktop.in',
+@@ -65,7 +64,7 @@ configure_file (
+ 
+ appdata_conf = configuration_data()
+ appdata_conf.set('appid', application_id)
+-appdata_file = i18n.merge_file ('appdata-file',
++appdata_file = i18n.merge_file (
+   input: configure_file (
+     input: files ('org.gnome.Boxes.appdata.xml.in'),
+     output: 'org.gnome.Boxes.appdata.xml.in',
+-- 
+GitLab
+

--- a/gnome-extra/gnome-boxes/gnome-boxes-41.3.ebuild
+++ b/gnome-extra/gnome-boxes/gnome-boxes-41.3.ebuild
@@ -76,6 +76,10 @@ BDEPEND="
 	virtual/pkgconfig
 "
 
+PATCHES=(
+	"${FILESDIR}/${PV}"-fix-build-with-meson-0.61.1.patch
+)
+
 DISABLE_AUTOFORMATTING="yes"
 DOC_CONTENTS="Before running gnome-boxes for local VMs, you will need to load the KVM modules.
 If you have an Intel Processor, run:

--- a/media-gfx/gnome-photos/files/40.0-fix-build-with-meson-0.61.1.patch
+++ b/media-gfx/gnome-photos/files/40.0-fix-build-with-meson-0.61.1.patch
@@ -1,0 +1,34 @@
+https://gitlab.gnome.org/GNOME/gnome-photos/-/commit/a0ac868a19d55dc52100e54fe4b2d29041bc6752
+https://bugs.gentoo.org/831933
+
+From: rvalue <i@rvalue.moe>
+Date: Fri, 21 Jan 2022 12:36:02 +0000
+Subject: [PATCH] meson: remove incorrect args for i18n.merge_file
+
+---
+ data/meson.build | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/data/meson.build b/data/meson.build
+index 6e7192e0..94271de2 100644
+--- a/data/meson.build
++++ b/data/meson.build
+@@ -3,7 +3,6 @@ subdir('icons')
+ appdata = photos_namespace + '.appdata.xml'
+ 
+ i18n.merge_file(
+-  appdata,
+   input: appdata + '.in',
+   output: appdata,
+   po_dir: po_dir,
+@@ -23,7 +22,6 @@ desktop_in = configure_file(
+ )
+ 
+ i18n.merge_file(
+-  desktop,
+   type: 'desktop',
+   input: desktop_in,
+   output: desktop,
+-- 
+GitLab
+

--- a/media-gfx/gnome-photos/gnome-photos-40.0.ebuild
+++ b/media-gfx/gnome-photos/gnome-photos-40.0.ebuild
@@ -59,6 +59,10 @@ BDEPEND="
 	test? ( $(python_gen_any_dep 'dev-util/dogtail[${PYTHON_USEDEP}]') )
 "
 
+PATCHES=(
+	"${FILESDIR}/${PV}"-fix-build-with-meson-0.61.1.patch
+)
+
 DOCS=() # meson installs docs itself
 
 python_check_deps() {

--- a/media-gfx/simple-scan/files/40.7-fix-build-with-meson-0.61.1.patch
+++ b/media-gfx/simple-scan/files/40.7-fix-build-with-meson-0.61.1.patch
@@ -1,0 +1,39 @@
+https://gitlab.gnome.org/GNOME/simple-scan/-/commit/da6626debe00be1a0660f30cf2bf7629186c01d5
+https://bugs.gentoo.org/831891
+
+From: r-value <i@rvalue.moe>
+Date: Tue, 16 Nov 2021 02:43:11 +0800
+Subject: [PATCH] Remove incorrect i18n.merge_file argument
+
+The positional argument was being silently ignored until meson 0.60.0 where
+it fails with "ERROR: Function does not take positional arguments".
+---
+ data/meson.build | 6 ++----
+ 1 file changed, 2 insertions(+), 4 deletions(-)
+
+diff --git a/data/meson.build b/data/meson.build
+index 2b5a0ee3..cf6e4ae1 100644
+--- a/data/meson.build
++++ b/data/meson.build
+@@ -8,16 +8,14 @@ install_data ('org.gnome.SimpleScan.gschema.xml',
+               install_dir: join_paths (datadir, 'glib-2.0', 'schemas'))
+ meson.add_install_script ('meson_compile_gschema.py')
+ 
+-i18n.merge_file ('desktop-file',
+-                 input: 'simple-scan.desktop.in',
++i18n.merge_file (input: 'simple-scan.desktop.in',
+                  output: 'simple-scan.desktop',
+                  install: true,
+                  install_dir: join_paths (datadir, 'applications'),
+                  po_dir: '../po',
+                  type: 'desktop')
+ 
+-i18n.merge_file ('appdata-file',
+-                 input: 'simple-scan.appdata.xml.in',
++i18n.merge_file (input: 'simple-scan.appdata.xml.in',
+                  output: 'simple-scan.appdata.xml',
+                  install: true,
+                  install_dir: join_paths (datadir, 'metainfo'),
+-- 
+GitLab
+

--- a/media-gfx/simple-scan/simple-scan-40.7.ebuild
+++ b/media-gfx/simple-scan/simple-scan-40.7.ebuild
@@ -47,6 +47,7 @@ BDEPEND="
 PATCHES=(
 	# Add control for optional dependencies
 	"${FILESDIR}"/40.0-add-control-optional-deps.patch
+	"${FILESDIR}/${PV}"-fix-build-with-meson-0.61.1.patch
 )
 
 src_prepare() {

--- a/media-sound/gnome-music/files/40.1.1-fix-build-with-meson-0.61.1.patch
+++ b/media-sound/gnome-music/files/40.1.1-fix-build-with-meson-0.61.1.patch
@@ -1,0 +1,24 @@
+https://gitlab.gnome.org/GNOME/gnome-music/-/commit/d9f35b542adbf6b0e1114c7c077df04212a98fc7
+https://bugs.gentoo.org/831936
+
+From: Jean Felder <jfelder@src.gnome.org>
+Date: Thu, 18 Nov 2021 12:09:26 +0100
+Subject: [PATCH] meson: Remove incorrect i18n.merge_file argument
+
+The positional argument was being silently ignored until meson 0.60.0
+where it returns a deprecation message:
+"DEPRECATION: i18n.merge_file does not take any positional
+arguments. This will become a hard error in the next Meson release."
+
+See: https://github.com/mesonbuild/meson/issues/9441
+--- a/data/meson.build
++++ b/data/meson.build
+@@ -47,7 +47,6 @@ appdata_conf.set('appid', APPLICATION_ID)
+ appdata_conf.set('package_url', PACKAGE_URL)
+ appdata_conf.set('package_url_bug', PACKAGE_URL_BUG)
+ i18n.merge_file(
+-  'appdata',
+   input: configure_file(
+     output: PROJECT_RDNN_NAME + '.appdata.xml.in',
+     input: PROJECT_RDNN_NAME + '.appdata.xml.in.in',
+GitLab

--- a/media-sound/gnome-music/gnome-music-40.1.1.ebuild
+++ b/media-sound/gnome-music/gnome-music-40.1.1.ebuild
@@ -53,6 +53,10 @@ BDEPEND="
 	virtual/pkgconfig
 "
 
+PATCHES=(
+	"${FILESDIR}/${PV}"-fix-build-with-meson-0.61.1.patch
+)
+
 RESTRICT="test" # only does desktop and appdata validation, and latter needs network to validate screenshot from https
 
 pkg_setup() {

--- a/media-sound/gnome-sound-recorder/files/40.0-fix-build-with-meson-0.61.1.patch
+++ b/media-sound/gnome-sound-recorder/files/40.0-fix-build-with-meson-0.61.1.patch
@@ -1,0 +1,43 @@
+https://gitlab.gnome.org/GNOME/gnome-sound-recorder/-/commit/1335b1b1aff61167f8648f7cb3c569764031960d.patch
+https://bugs.gentoo.org/831924
+
+From: Jan Beich <jbeich@FreeBSD.org>
+Date: Mon, 24 Jan 2022 11:37:06 +0000
+Subject: [PATCH] meson: drop unused argument for i18n.merge_file()
+
+Ignored in Meson < 0.60.0, deprecated since 0.60.1 and fatal since 0.61.0.
+
+data/appdata/meson.build:5:0: ERROR: Function does not take positional arguments.
+data/meson.build:16:0: ERROR: Function does not take positional arguments.
+---
+ data/appdata/meson.build | 1 -
+ data/meson.build         | 1 -
+ 2 files changed, 2 deletions(-)
+
+diff --git a/data/appdata/meson.build b/data/appdata/meson.build
+index 1f5744e..d2c2c3a 100644
+--- a/data/appdata/meson.build
++++ b/data/appdata/meson.build
+@@ -3,7 +3,6 @@ metainfo_conf.set('app-id', application_id)
+ metainfo_conf.set('gettext-package', gettext_package)
+ 
+ metainfo_file = i18n.merge_file(
+-  'metainfo-file',
+   input: configure_file(
+   	input: 'org.gnome.SoundRecorder.metainfo.xml.in.in',
+   	output: '@BASENAME@',
+diff --git a/data/meson.build b/data/meson.build
+index 44117ad..0ff8fa5 100644
+--- a/data/meson.build
++++ b/data/meson.build
+@@ -14,7 +14,6 @@ install_data(
+ desktop_conf = configuration_data()
+ desktop_conf.set('app-id', application_id)
+ desktop_file = i18n.merge_file(
+-  'desktop',
+   input: configure_file(
+   	input: 'org.gnome.SoundRecorder.desktop.in.in',
+   	output: '@BASENAME@',
+-- 
+GitLab
+

--- a/media-sound/gnome-sound-recorder/gnome-sound-recorder-40.0.ebuild
+++ b/media-sound/gnome-sound-recorder/gnome-sound-recorder-40.0.ebuild
@@ -35,6 +35,10 @@ BDEPEND="
 	virtual/pkgconfig
 "
 
+PATCHES=(
+	"${FILESDIR}/${PV}"-fix-build-with-meson-0.61.1.patch
+)
+
 pkg_setup() {
 	python-any-r1_pkg_setup
 }

--- a/media-video/totem/files/3.38.2-fix-build-with-meson-0.61.1.patch
+++ b/media-video/totem/files/3.38.2-fix-build-with-meson-0.61.1.patch
@@ -1,0 +1,41 @@
+https://gitlab.gnome.org/GNOME/totem/-/commit/61e3a957cb7339c6614e764fcf1120d967d687e9
+https://bugs.gentoo.org/831931
+
+From: Bastien Nocera <hadess@hadess.net>
+Date: Thu, 6 Jan 2022 17:21:28 +0100
+Subject: [PATCH] build: Remove unused i18n.merge_file() "name"
+
+data/meson.build:78:0: ERROR: Function does not take positional arguments.
+data/appdata/meson.build:3:0: ERROR: Function does not take positional arguments.
+---
+ data/appdata/meson.build | 1 -
+ data/meson.build         | 1 -
+ 2 files changed, 2 deletions(-)
+
+diff --git a/data/appdata/meson.build b/data/appdata/meson.build
+index c4d17e927..c2e646327 100644
+--- a/data/appdata/meson.build
++++ b/data/appdata/meson.build
+@@ -1,7 +1,6 @@
+ appdata = 'org.gnome.Totem.appdata.xml'
+ 
+ appdata_file = i18n.merge_file (
+-    'appdata',
+     input: appdata + '.in',
+     output: appdata,
+     install: true,
+diff --git a/data/meson.build b/data/meson.build
+index b31ce755c..8eebe3db1 100644
+--- a/data/meson.build
++++ b/data/meson.build
+@@ -76,7 +76,6 @@ desktop_in = configure_file(
+ )
+ 
+ desktop_file = i18n.merge_file (
+-    desktop,
+     type: 'desktop',
+     input: desktop_in,
+     output: desktop,
+-- 
+GitLab
+

--- a/media-video/totem/totem-3.38.2.ebuild
+++ b/media-video/totem/totem-3.38.2.ebuild
@@ -74,6 +74,7 @@ BDEPEND="
 
 PATCHES=(
 	"${FILESDIR}"/3.38.0-gst-inspect-sandbox.patch # Allow disabling calls to gst-inspect (sandbox issue)
+	"${FILESDIR}/${PV}"-fix-build-with-meson-0.61.1.patch
 )
 
 pkg_setup() {

--- a/net-irc/polari/files/40.0-fix-build-with-meson-0.61.1.patch
+++ b/net-irc/polari/files/40.0-fix-build-with-meson-0.61.1.patch
@@ -1,0 +1,45 @@
+https://gitlab.gnome.org/GNOME/polari/-/commit/0f0a4b54142d8b424969f0b6ace6fc8b53b1d05d
+https://bugs.gentoo.org/831922
+
+From: Jan Beich <jbeich@FreeBSD.org>
+Date: Mon, 24 Jan 2022 12:32:00 +0000
+Subject: [PATCH] meson: Drop unused argument for i18n.merge_file()
+
+Ignored in Meson < 0.60.0, deprecated since 0.60.1 and fatal since 0.61.0.
+
+data/appdata/meson.build:2:0: ERROR: Function does not take positional arguments.
+data/meson.build:5:0: ERROR: Function does not take positional arguments.
+
+Part-of: <https://gitlab.gnome.org/GNOME/polari/-/merge_requests/242>
+---
+ data/appdata/meson.build | 2 +-
+ data/meson.build         | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/data/appdata/meson.build b/data/appdata/meson.build
+index 88b4a0be..781ba22f 100644
+--- a/data/appdata/meson.build
++++ b/data/appdata/meson.build
+@@ -1,5 +1,5 @@
+ appdata_name = app_id + '.appdata.xml'
+-appdata = i18n.merge_file(appdata_name,
++appdata = i18n.merge_file(
+   input: appdata_name + '.in',
+   output: appdata_name,
+   po_dir: '../../po',
+diff --git a/data/meson.build b/data/meson.build
+index cedfd57b..655ae700 100644
+--- a/data/meson.build
++++ b/data/meson.build
+@@ -2,7 +2,7 @@ subdir('appdata')
+ subdir('icons')
+ 
+ desktop_filename = app_id + '.desktop'
+-desktop_file = i18n.merge_file(desktop_filename,
++desktop_file = i18n.merge_file(
+   input: desktop_filename + '.in',
+   output: desktop_filename,
+   po_dir: '../po',
+-- 
+GitLab
+

--- a/net-irc/polari/polari-40.0.ebuild
+++ b/net-irc/polari/polari-40.0.ebuild
@@ -43,6 +43,10 @@ BDEPEND="
 	)
 "
 
+PATCHES=(
+	"${FILESDIR}/${PV}"-fix-build-with-meson-0.61.1.patch
+)
+
 pkg_postinst() {
 	xdg_pkg_postinst
 	gnome2_schemas_update

--- a/www-client/epiphany/epiphany-41.3.ebuild
+++ b/www-client/epiphany/epiphany-41.3.ebuild
@@ -50,6 +50,7 @@ BDEPEND="
 PATCHES=(
 	# Allow /var/tmp prefixed recursive delete (due to package manager setting TMPDIR)
 	"${FILESDIR}"/var-tmp-tests.patch
+	"${FILESDIR}/${PV}"-fix-build-with-meson-0.61.1.patch
 )
 
 src_configure() {

--- a/www-client/epiphany/files/41.3-fix-build-with-meson-0.61.1.patch
+++ b/www-client/epiphany/files/41.3-fix-build-with-meson-0.61.1.patch
@@ -1,0 +1,35 @@
+https://gitlab.gnome.org/GNOME/epiphany/-/commit/bfbb5f7bab38301d8a4a444173acdae8d9692146
+https://bugs.gentoo.org/831923
+
+From: rvalue <i@rvalue.moe>
+Date: Wed, 24 Nov 2021 04:52:42 +0000
+Subject: [PATCH] Remove incorrect args for i18n.merge_file
+
+Part-of: <https://gitlab.gnome.org/GNOME/epiphany/-/merge_requests/1031>
+---
+ data/meson.build | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/data/meson.build b/data/meson.build
+index 46df3fd80..eac6b8224 100644
+--- a/data/meson.build
++++ b/data/meson.build
+@@ -16,7 +16,6 @@ install_data(
+ desktop_conf = configuration_data()
+ desktop_conf.set('icon', application_id)
+ desktop = i18n.merge_file(
+-  'desktop',
+   input: configure_file(
+     input: files('org.gnome.Epiphany.desktop.in.in'),
+     output: 'org.gnome.Epiphany.desktop.in',
+@@ -32,7 +31,6 @@ desktop = i18n.merge_file(
+ appdata_conf = configuration_data()
+ appdata_conf.set('appid', application_id)
+ appdata = i18n.merge_file(
+-  'appdata',
+   input: configure_file(
+     input: files('org.gnome.Epiphany.appdata.xml.in.in'),
+     output: 'org.gnome.Epiphany.appdata.xml.in',
+-- 
+GitLab
+

--- a/x11-terms/gnome-terminal/files/3.42.2-fix-build-with-meson-0.61.1.patch
+++ b/x11-terms/gnome-terminal/files/3.42.2-fix-build-with-meson-0.61.1.patch
@@ -1,0 +1,39 @@
+https://github.com/GNOME/gnome-terminal/commit/9a168cc23962ce9fa106dc8a40407d381a3db403
+https://bugs.gentoo.org/831940
+
+From: Christian Persch <chpe@src.gnome.org>
+Date: Fri, 14 Jan 2022 11:33:32 +0100
+Subject: [PATCH] build: Fix for newer meson
+--- a/data/meson.build
++++ b/data/meson.build
+@@ -18,7 +18,6 @@
+ metainfodir = gt_datadir / 'metainfo'
+ 
+ i18n.merge_file(
+-  gt_dns_name + '.metainfo.xml',
+   input: gt_dns_name + '.metainfo.xml.in',
+   output: '@BASENAME@',
+   po_dir: po_dir,
+@@ -27,7 +26,6 @@ i18n.merge_file(
+ )
+ 
+ i18n.merge_file(
+-  gt_dns_name + '.Nautilus.metainfo.xml',
+   input: gt_dns_name + '.Nautilus.metainfo.xml.in',
+   output: '@BASENAME@',
+   po_dir: po_dir,
+@@ -40,7 +38,6 @@ i18n.merge_file(
+ desktopdatadir = gt_datadir / 'applications'
+ 
+ i18n.merge_file(
+-  gt_dns_name + '.desktop',
+   input: gt_dns_name + '.desktop.in',
+   output: '@BASENAME@',
+   type: 'desktop',
+@@ -57,4 +54,4 @@ meson.add_install_script(
+ 
+ # Subdirs
+ 
+-subdir('icons')
+\ No newline at end of file
++subdir('icons')

--- a/x11-terms/gnome-terminal/gnome-terminal-3.42.2.ebuild
+++ b/x11-terms/gnome-terminal/gnome-terminal-3.42.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -39,6 +39,10 @@ BDEPEND="
 	>=sys-devel/gettext-0.19.8
 	virtual/pkgconfig
 "
+
+PATCHES=(
+	"${FILESDIR}/${PV}"-fix-build-with-meson-0.61.1.patch
+)
 
 DOC_CONTENTS="To get previous working directory inherited in new opened tab, or
 	notifications of long-running commands finishing, you will need


### PR DESCRIPTION
I'm going through the tracker @ https://bugs.gentoo.org/831474 , looking for upstream fixes to backport.

Commits still need love (patch names, check revision policy for stable versions etc)