### PR TITLE
sys-libs/basu: backport LLD 13 fixes

### DIFF
--- a/sys-libs/basu/basu-0.2.0-r1.ebuild
+++ b/sys-libs/basu/basu-0.2.0-r1.ebuild
@@ -1,0 +1,43 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+PYTHON_COMPAT=( python3_{8..10} )
+inherit meson python-any-r1
+
+DESCRIPTION="The sd-bus library, extracted from systemd"
+HOMEPAGE="https://sr.ht/~emersion/basu/"
+LICENSE="LGPL-2.1+"
+SLOT="0"
+
+SRC_URI="https://git.sr.ht/~emersion/basu/refs/download/v${PV}/basu-${PV}.tar.gz"
+KEYWORDS="~amd64"
+
+IUSE="audit caps"
+
+DEPEND="
+	audit? ( sys-process/audit )
+	caps? ( sys-libs/libcap )
+"
+
+RDEPEND="${DEPEND}"
+# Needed to generate hash tables
+BDEPEND="${PYTHON_DEPS}
+	dev-util/gperf
+"
+
+PATCHES=(
+	"${FILESDIR}"/0001-"${PN}"-0.2.0-meson-add-libcap-option.patch
+	"${FILESDIR}"/0002-"${PN}"-0.2.0-meson-convert-audit-option-to-feature-object.patch
+	"${FILESDIR}"/0001-"${PN}"-0.2.0-LLD-13-and-GNU-ld-2.37-support-z-start-stop-gc-which.patch
+	"${FILESDIR}"/0002-"${PN}"-0.2.0-meson-fix-linking-on-LLD-13-LD-2.37-and-older-CCs.patch
+)
+
+src_configure() {
+	local emesonargs=(
+		$(meson_feature audit)
+		$(meson_feature caps libcap)
+	)
+	meson_src_configure
+}

--- a/sys-libs/basu/files/0001-basu-0.2.0-LLD-13-and-GNU-ld-2.37-support-z-start-stop-gc-which.patch
+++ b/sys-libs/basu/files/0001-basu-0.2.0-LLD-13-and-GNU-ld-2.37-support-z-start-stop-gc-which.patch
@@ -1,0 +1,51 @@
+From baa3a54e019b8ba6161fe20943c897490f4bcde8 Mon Sep 17 00:00:00 2001
+From: Fangrui Song <i@maskray.me>
+Date: Sat, 27 Nov 2021 18:19:46 +0100
+Subject: [PATCH basu] LLD 13 and GNU ld 2.37 support -z start-stop-gc which
+ allows garbage collection of C identifier name sections despite the
+ __start_/__stop_ references.  Simply set the retain attribute so that GCC 11
+ (if configure-time binutils is 2.36 or newer)/Clang 13 will set the
+ SHF_GNU_RETAIN section attribute to prevent garbage collection.
+
+Without the patch, there are linker errors like the following with -z
+start-stop-gc.
+
+```
+ld: error: undefined symbol: __start_SYSTEMD_BUS_ERROR_MAP
+>>> referenced by bus-error.c:93 (../src/libsystemd/sd-bus/bus-error.c:93)
+>>>               sd-bus_bus-error.c.o:(bus_error_name_to_errno) in archive src/libsystemd/libsystemd_static.a
+```
+
+Co-authored-by: Evgeniy Khramtsov <evgeniy@khramtsov.org>
+---
+Upstream: https://git.sr.ht/~emersion/basu/commit/5fa970e868f25ebc79ccca9b1d9df4c030d97661
+Gentoo bug: https://bugs.gentoo.org/832045
+
+ src/libsystemd/sd-bus/bus-error.h | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/src/libsystemd/sd-bus/bus-error.h b/src/libsystemd/sd-bus/bus-error.h
+index 06c478a..883213f 100644
+--- a/src/libsystemd/sd-bus/bus-error.h
++++ b/src/libsystemd/sd-bus/bus-error.h
+@@ -28,11 +28,17 @@ int bus_error_set_errnofv(sd_bus_error *e, int error, const char *format, va_lis
+  * the bus error table, and BUS_ERROR_MAP_ELF_USE has to be used at
+  * least once per compilation unit (i.e. per library), to ensure that
+  * the error map is really added to the final binary.
++ *
++ * In addition, set the retain attribute so that the section cannot be
++ * discarded by ld --gc-sections -z start-stop-gc. Older compilers would
++ * warn for the unknown attribute, so just disable -Wattributes.
+  */
+ 
+ #define BUS_ERROR_MAP_ELF_REGISTER                                      \
++        _Pragma("GCC diagnostic ignored \"-Wattributes\"")              \
+         __attribute__ ((__section__("BUS_ERROR_MAP")))                  \
+         __attribute__ ((__used__))                                      \
++        __attribute__ ((retain))                                        \
+         __attribute__ ((aligned(8)))
+ 
+ #define BUS_ERROR_MAP_ELF_USE(errors)                                   \
+-- 
+2.34.1
+

--- a/sys-libs/basu/files/0002-basu-0.2.0-meson-fix-linking-on-LLD-13-LD-2.37-and-older-CCs.patch
+++ b/sys-libs/basu/files/0002-basu-0.2.0-meson-fix-linking-on-LLD-13-LD-2.37-and-older-CCs.patch
@@ -1,0 +1,44 @@
+From c4d9f5aac80d02b7e7447d2eda698e17a245071e Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Arsen=20Arsenovi=C4=87?= <arsen@aarsen.me>
+Date: Tue, 25 Jan 2022 18:36:36 +0100
+Subject: [PATCH basu] meson: fix linking on LLD 13/LD 2.37 and older CCs
+
+For compilers that do not support __attribute((retain)),
+-z no-start-stop-gc is a requirement.
+---
+Submitted at: https://lists.sr.ht/~emersion/public-inbox/patches/28722#%3C20220125192953.1781959-1-arsen@aarsen.me%3E
+Gentoo bug: https://bugs.gentoo.org/832045
+
+ meson.build | 16 ++++++++++++++++
+ 1 file changed, 16 insertions(+)
+
+diff --git a/meson.build b/meson.build
+index 1f29690..74e9934 100644
+--- a/meson.build
++++ b/meson.build
+@@ -101,6 +101,22 @@ if get_option('buildtype') != 'debug'
+         possible_link_flags += '-Wl,--gc-sections'
+ endif
+ 
++if cc.get_id() in ['gcc', 'clang']
++# XXX(arsen): remember to update with a future meson release
++        has_retain_attr = cc.compiles(
++                '__attribute__((retain)) int x;',
++                args : ['-Werror=attributes'],
++                name : 'compiler supports __attribute__((retain))'
++        )
++
++        if not has_retain_attr and cc.has_link_argument('-Wl,-z,start-stop-gc')
++                possible_link_flags += [
++                        '-Wl,-z,nostart-stop-gc'
++                ]
++        endif
++endif
++
++
+ add_project_arguments(cc.get_supported_arguments(possible_cc_flags), language : 'c')
+ add_project_link_arguments(cc.get_supported_link_arguments(possible_link_flags), language : 'c')
+ 
+-- 
+2.34.1
+


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/832045
Package-Manager: Portage-3.0.28, Repoman-3.0.3
Signed-off-by: Arsen Arsenović <arsen@aarsen.me>