### PR TITLE
dev-java/commons-logging: REQUIRED_USE="doc?

### DIFF
--- a/dev-java/commons-logging/commons-logging-1.2-r3.ebuild
+++ b/dev-java/commons-logging/commons-logging-1.2-r3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -16,6 +16,7 @@ LICENSE="Apache-2.0"
 SLOT="0"
 KEYWORDS="amd64 ~arm arm64 ppc64 x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 IUSE="avalon-framework avalon-logkit log4j servletapi test"
+REQUIRED_USE="doc? ( avalon-framework avalon-logkit log4j servletapi )"
 RESTRICT="!test? ( test ) !servletapi? ( test )"
 
 CDEPEND="


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/820863
Package-Manager: Portage-3.0.30, Repoman-3.0.3
Signed-off-by: Volkmar W. Pogatzki <gentoo@pogatzki.net>