### PR TITLE
sci-libs/vtk: fix build with USE=offscreen

### DIFF
--- a/sci-libs/vtk/vtk-9.0.3-r4.ebuild
+++ b/sci-libs/vtk/vtk-9.0.3-r4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -47,6 +47,7 @@ REQUIRED_USE="
 	qt5? ( X rendering )
 	tk? ( X rendering python )
 	web? ( python )
+	^^ ( X offscreen )
 "
 
 RDEPEND="
@@ -358,9 +359,9 @@ src_configure() {
 
 	if use offscreen; then
 		mycmakeargs+=(
-			-DVTK_OPENGL_HAS_OSMESA=ON
 			-DVTK_DEFAULT_RENDER_WINDOW_OFFSCREEN=ON
 			-DVTK_DEFAULT_RENDER_WINDOW_HEADLESS=ON
+			-DVTK_OPENGL_HAS_OSMESA=ON
 		)
 	fi
 


### PR DESCRIPTION
The package can be built with either USE=offscreen, or with USE=X
enabled, but not with both simultaneously.

Closes: https://bugs.gentoo.org/830774
Package-Manager: Portage-3.0.30, Repoman-3.0.3
Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>