### PR TITLE
dev-libs/userspace-rcu: Fix relink of libraries for cross-compilation.

### DIFF
--- a/dev-libs/userspace-rcu/userspace-rcu-0.13.0.ebuild
+++ b/dev-libs/userspace-rcu/userspace-rcu-0.13.0.ebuild
@@ -3,6 +3,8 @@
 
 EAPI=7
 
+inherit autotools
+
 DESCRIPTION="userspace RCU (read-copy-update) library"
 HOMEPAGE="https://liburcu.org/"
 SRC_URI="https://lttng.org/files/urcu/${P}.tar.bz2"
@@ -14,6 +16,12 @@ IUSE="static-libs regression-test test"
 RESTRICT="!test? ( test )"
 
 DEPEND="test? ( sys-process/time )"
+
+src_prepare() {
+	default
+
+	eautoreconf
+}
 
 src_configure() {
 	local myeconfargs=(


### PR DESCRIPTION
In the install phase, there are certain libraries which are re-linked
using "/usr/lib64". This creates a problem when cross-compilation is
done.

Snippet from logs:

libtool: relink: aarch64-cros-linux-gnu-clang -shared  -fPIC -DPIC
.libs/liburcu_la-urcu.o .libs/liburcu_la-urcu-pointer.o
.libs/liburcu_la-compat_arch.o .libs/liburcu_la-compat_futex.o
-L/build/lakitu-arm64/tmp/portage/dev-libs/userspace-rcu-0.13.0/image/usr/lib64
-L/usr/lib64 -lurcu-common  -pthread -Os -march=armv8-a+crc
-mtune=cortex-a57 -g -Wl,-O2 -Wl,--as-needed -Wl,--gc-sections
-Wl,--icf=all   -pthread -Wl,-soname -Wl,liburcu.so.8 -o
.libs/liburcu.so.8.0.0

The patch adds "sysroot" so that correct path is used during relink.

Signed-off-by: Vaibhav Rustagi <vaibhavrustagi@google.com>