### PR TITLE
app-editors/vim,vim-core: Fix conflicts in installation of defaults.vim

### DIFF
--- a/app-editors/vim-core/vim-core-8.2.0814.ebuild
+++ b/app-editors/vim-core/vim-core-8.2.0814.ebuild
@@ -191,9 +191,6 @@ src_install() {
 		rm -rv "${ED}${vimfiles}"/{macros,print,tools,tutor} || die "rm failed"
 		rm -v "${ED}"/usr/bin/vimtutor || die "rm failed"
 
-		# Delete defaults.vim to avoid conflicts with one from vim[minimal]
-		rm -v "${ED}${vimfiles}"/defaults.vim || die "rm failed"
-
 		local keep_colors="default"
 		ignore=$(rm -fr "${ED}${vimfiles}"/colors/!(${keep_colors}).vim )
 
@@ -206,6 +203,13 @@ src_install() {
 		sed -i '/skip_defaults_vim/d' "${ED}"/etc/vim/vimrc || die "sed failed"
 
 		eshopts_pop
+	fi
+
+	# Delete defaults.vim to avoid conflicts with one from vim.
+	# If defaults.vim already exists in files installed from vim,
+	# do not install defaults.vim.
+	if [[ -f "${vimfiles}/defaults.vim" ]]; then
+		rm -v "${ED}${vimfiles}"/defaults.vim || die "rm failed"
 	fi
 
 	newbashcomp "${FILESDIR}"/xxd-completion xxd

--- a/app-editors/vim-core/vim-core-8.2.3428.ebuild
+++ b/app-editors/vim-core/vim-core-8.2.3428.ebuild
@@ -193,9 +193,6 @@ src_install() {
 		rm -rv "${ED}${vimfiles}"/{macros,print,tools,tutor} || die "rm failed"
 		rm -v "${ED}"/usr/bin/vimtutor || die "rm failed"
 
-		# Delete defaults.vim to avoid conflicts with one from vim[minimal]
-		rm -v "${ED}${vimfiles}"/defaults.vim || die "rm failed"
-
 		local keep_colors="default"
 		ignore=$(rm -fr "${ED}${vimfiles}"/colors/!(${keep_colors}).vim )
 
@@ -208,6 +205,13 @@ src_install() {
 		sed -i '/skip_defaults_vim/d' "${ED}"/etc/vim/vimrc || die "sed failed"
 
 		eshopts_pop
+	fi
+
+	# Delete defaults.vim to avoid conflicts with one from vim.
+	# If defaults.vim already exists in files installed from vim,
+	# do not install defaults.vim.
+	if [[ -f "${vimfiles}/defaults.vim" ]]; then
+		rm -v "${ED}${vimfiles}"/defaults.vim || die "rm failed"
 	fi
 
 	newbashcomp "${FILESDIR}"/xxd-completion xxd

--- a/app-editors/vim-core/vim-core-8.2.3567.ebuild
+++ b/app-editors/vim-core/vim-core-8.2.3567.ebuild
@@ -193,9 +193,6 @@ src_install() {
 		rm -rv "${ED}${vimfiles}"/{macros,print,tools,tutor} || die "rm failed"
 		rm -v "${ED}"/usr/bin/vimtutor || die "rm failed"
 
-		# Delete defaults.vim to avoid conflicts with one from vim[minimal]
-		rm -v "${ED}${vimfiles}"/defaults.vim || die "rm failed"
-
 		local keep_colors="default"
 		ignore=$(rm -fr "${ED}${vimfiles}"/colors/!(${keep_colors}).vim )
 
@@ -208,6 +205,13 @@ src_install() {
 		sed -i '/skip_defaults_vim/d' "${ED}"/etc/vim/vimrc || die "sed failed"
 
 		eshopts_pop
+	fi
+
+	# Delete defaults.vim to avoid conflicts with one from vim.
+	# If defaults.vim already exists in files installed from vim,
+	# do not install defaults.vim.
+	if [[ -f "${vimfiles}/defaults.vim" ]]; then
+		rm -v "${ED}${vimfiles}"/defaults.vim || die "rm failed"
 	fi
 
 	newbashcomp "${FILESDIR}"/xxd-completion xxd

--- a/app-editors/vim-core/vim-core-8.2.3582.ebuild
+++ b/app-editors/vim-core/vim-core-8.2.3582.ebuild
@@ -193,9 +193,6 @@ src_install() {
 		rm -rv "${ED}${vimfiles}"/{macros,print,tools,tutor} || die "rm failed"
 		rm -v "${ED}"/usr/bin/vimtutor || die "rm failed"
 
-		# Delete defaults.vim to avoid conflicts with one from vim[minimal]
-		rm -v "${ED}${vimfiles}"/defaults.vim || die "rm failed"
-
 		local keep_colors="default"
 		ignore=$(rm -fr "${ED}${vimfiles}"/colors/!(${keep_colors}).vim )
 
@@ -208,6 +205,13 @@ src_install() {
 		sed -i '/skip_defaults_vim/d' "${ED}"/etc/vim/vimrc || die "sed failed"
 
 		eshopts_pop
+	fi
+
+	# Delete defaults.vim to avoid conflicts with one from vim.
+	# If defaults.vim already exists in files installed from vim,
+	# do not install defaults.vim.
+	if [[ -f "${vimfiles}/defaults.vim" ]]; then
+		rm -v "${ED}${vimfiles}"/defaults.vim || die "rm failed"
 	fi
 
 	newbashcomp "${FILESDIR}"/xxd-completion xxd

--- a/app-editors/vim-core/vim-core-8.2.3669.ebuild
+++ b/app-editors/vim-core/vim-core-8.2.3669.ebuild
@@ -193,9 +193,6 @@ src_install() {
 		rm -rv "${ED}${vimfiles}"/{macros,print,tools,tutor} || die "rm failed"
 		rm -v "${ED}"/usr/bin/vimtutor || die "rm failed"
 
-		# Delete defaults.vim to avoid conflicts with one from vim[minimal]
-		rm -v "${ED}${vimfiles}"/defaults.vim || die "rm failed"
-
 		local keep_colors="default"
 		ignore=$(rm -fr "${ED}${vimfiles}"/colors/!(${keep_colors}).vim )
 
@@ -208,6 +205,13 @@ src_install() {
 		sed -i '/skip_defaults_vim/d' "${ED}"/etc/vim/vimrc || die "sed failed"
 
 		eshopts_pop
+	fi
+
+	# Delete defaults.vim to avoid conflicts with one from vim.
+	# If defaults.vim already exists in files installed from vim,
+	# do not install defaults.vim.
+	if [[ -f "${vimfiles}/defaults.vim" ]]; then
+		rm -v "${ED}${vimfiles}"/defaults.vim || die "rm failed"
 	fi
 
 	newbashcomp "${FILESDIR}"/xxd-completion xxd

--- a/app-editors/vim-core/vim-core-8.2.3741.ebuild
+++ b/app-editors/vim-core/vim-core-8.2.3741.ebuild
@@ -193,9 +193,6 @@ src_install() {
 		rm -rv "${ED}${vimfiles}"/{macros,print,tools,tutor} || die "rm failed"
 		rm -v "${ED}"/usr/bin/vimtutor || die "rm failed"
 
-		# Delete defaults.vim to avoid conflicts with one from vim[minimal]
-		rm -v "${ED}${vimfiles}"/defaults.vim || die "rm failed"
-
 		local keep_colors="default"
 		ignore=$(rm -fr "${ED}${vimfiles}"/colors/!(${keep_colors}).vim )
 
@@ -208,6 +205,13 @@ src_install() {
 		sed -i '/skip_defaults_vim/d' "${ED}"/etc/vim/vimrc || die "sed failed"
 
 		eshopts_pop
+	fi
+
+	# Delete defaults.vim to avoid conflicts with one from vim.
+	# If defaults.vim already exists in files installed from vim,
+	# do not install defaults.vim.
+	if [[ -f "${vimfiles}/defaults.vim" ]]; then
+		rm -v "${ED}${vimfiles}"/defaults.vim || die "rm failed"
 	fi
 
 	newbashcomp "${FILESDIR}"/xxd-completion xxd

--- a/app-editors/vim-core/vim-core-8.2.3950.ebuild
+++ b/app-editors/vim-core/vim-core-8.2.3950.ebuild
@@ -193,9 +193,6 @@ src_install() {
 		rm -rv "${ED}${vimfiles}"/{macros,print,tools,tutor} || die "rm failed"
 		rm -v "${ED}"/usr/bin/vimtutor || die "rm failed"
 
-		# Delete defaults.vim to avoid conflicts with one from vim[minimal]
-		rm -v "${ED}${vimfiles}"/defaults.vim || die "rm failed"
-
 		local keep_colors="default"
 		ignore=$(rm -fr "${ED}${vimfiles}"/colors/!(${keep_colors}).vim )
 
@@ -208,6 +205,13 @@ src_install() {
 		sed -i '/skip_defaults_vim/d' "${ED}"/etc/vim/vimrc || die "sed failed"
 
 		eshopts_pop
+	fi
+
+	# Delete defaults.vim to avoid conflicts with one from vim.
+	# If defaults.vim already exists in files installed from vim,
+	# do not install defaults.vim.
+	if [[ -f "${vimfiles}/defaults.vim" ]]; then
+		rm -v "${ED}${vimfiles}"/defaults.vim || die "rm failed"
 	fi
 
 	newbashcomp "${FILESDIR}"/xxd-completion xxd

--- a/app-editors/vim-core/vim-core-9999.ebuild
+++ b/app-editors/vim-core/vim-core-9999.ebuild
@@ -193,9 +193,6 @@ src_install() {
 		rm -rv "${ED}${vimfiles}"/{macros,print,tools,tutor} || die "rm failed"
 		rm -v "${ED}"/usr/bin/vimtutor || die "rm failed"
 
-		# Delete defaults.vim to avoid conflicts with one from vim[minimal]
-		rm -v "${ED}${vimfiles}"/defaults.vim || die "rm failed"
-
 		local keep_colors="default"
 		ignore=$(rm -fr "${ED}${vimfiles}"/colors/!(${keep_colors}).vim )
 
@@ -208,6 +205,13 @@ src_install() {
 		sed -i '/skip_defaults_vim/d' "${ED}"/etc/vim/vimrc || die "sed failed"
 
 		eshopts_pop
+	fi
+
+	# Delete defaults.vim to avoid conflicts with one from vim.
+	# If defaults.vim already exists in files installed from vim,
+	# do not install defaults.vim.
+	if [[ -f "${vimfiles}/defaults.vim" ]]; then
+		rm -v "${ED}${vimfiles}"/defaults.vim || die "rm failed"
 	fi
 
 	newbashcomp "${FILESDIR}"/xxd-completion xxd

--- a/app-editors/vim/vim-8.2.0814-r100.ebuild
+++ b/app-editors/vim/vim-8.2.0814-r100.ebuild
@@ -306,8 +306,10 @@ src_install() {
 
 	# Fix an issue of missing defaults.vim when USE=minimal.
 	if use minimal ; then
-		insinto ${vimfiles}
-		doins runtime/defaults.vim
+		if [[ ! -f "${vimfiles}/defaults.vim" ]]; then
+			insinto ${vimfiles}
+			doins runtime/defaults.vim
+		fi
 	fi
 
 	domenu runtime/vim.desktop

--- a/app-editors/vim/vim-8.2.3428-r1.ebuild
+++ b/app-editors/vim/vim-8.2.3428-r1.ebuild
@@ -318,8 +318,10 @@ src_install() {
 
 	# Fix an issue of missing defaults.vim when USE=minimal.
 	if use minimal ; then
-		insinto ${vimfiles}
-		doins runtime/defaults.vim
+		if [[ ! -f "${vimfiles}/defaults.vim" ]]; then
+			insinto ${vimfiles}
+			doins runtime/defaults.vim
+		fi
 	fi
 
 	domenu runtime/vim.desktop

--- a/app-editors/vim/vim-8.2.3567.ebuild
+++ b/app-editors/vim/vim-8.2.3567.ebuild
@@ -320,8 +320,10 @@ src_install() {
 
 	# Fix an issue of missing defaults.vim when USE=minimal.
 	if use minimal ; then
-		insinto ${vimfiles}
-		doins runtime/defaults.vim
+		if [[ ! -f "${vimfiles}/defaults.vim" ]]; then
+			insinto ${vimfiles}
+			doins runtime/defaults.vim
+		fi
 	fi
 
 	domenu runtime/vim.desktop

--- a/app-editors/vim/vim-8.2.3582.ebuild
+++ b/app-editors/vim/vim-8.2.3582.ebuild
@@ -320,8 +320,10 @@ src_install() {
 
 	# Fix an issue of missing defaults.vim when USE=minimal.
 	if use minimal ; then
-		insinto ${vimfiles}
-		doins runtime/defaults.vim
+		if [[ ! -f "${vimfiles}/defaults.vim" ]]; then
+			insinto ${vimfiles}
+			doins runtime/defaults.vim
+		fi
 	fi
 
 	domenu runtime/vim.desktop

--- a/app-editors/vim/vim-8.2.3669.ebuild
+++ b/app-editors/vim/vim-8.2.3669.ebuild
@@ -320,8 +320,10 @@ src_install() {
 
 	# Fix an issue of missing defaults.vim when USE=minimal.
 	if use minimal ; then
-		insinto ${vimfiles}
-		doins runtime/defaults.vim
+		if [[ ! -f "${vimfiles}/defaults.vim" ]]; then
+			insinto ${vimfiles}
+			doins runtime/defaults.vim
+		fi
 	fi
 
 	domenu runtime/vim.desktop

--- a/app-editors/vim/vim-8.2.3741.ebuild
+++ b/app-editors/vim/vim-8.2.3741.ebuild
@@ -320,8 +320,10 @@ src_install() {
 
 	# Fix an issue of missing defaults.vim when USE=minimal.
 	if use minimal ; then
-		insinto ${vimfiles}
-		doins runtime/defaults.vim
+		if [[ ! -f "${vimfiles}/defaults.vim" ]]; then
+			insinto ${vimfiles}
+			doins runtime/defaults.vim
+		fi
 	fi
 
 	domenu runtime/vim.desktop

--- a/app-editors/vim/vim-8.2.3950.ebuild
+++ b/app-editors/vim/vim-8.2.3950.ebuild
@@ -320,8 +320,10 @@ src_install() {
 
 	# Fix an issue of missing defaults.vim when USE=minimal.
 	if use minimal ; then
-		insinto ${vimfiles}
-		doins runtime/defaults.vim
+		if [[ ! -f "${vimfiles}/defaults.vim" ]]; then
+			insinto ${vimfiles}
+			doins runtime/defaults.vim
+		fi
 	fi
 
 	domenu runtime/vim.desktop

--- a/app-editors/vim/vim-9999.ebuild
+++ b/app-editors/vim/vim-9999.ebuild
@@ -320,8 +320,10 @@ src_install() {
 
 	# Fix an issue of missing defaults.vim when USE=minimal.
 	if use minimal ; then
-		insinto ${vimfiles}
-		doins runtime/defaults.vim
+		if [[ ! -f "${vimfiles}/defaults.vim" ]]; then
+			insinto ${vimfiles}
+			doins runtime/defaults.vim
+		fi
 	fi
 
 	domenu runtime/vim.desktop


### PR DESCRIPTION
When `app-editors/vim` has `minimal` USE flag set, while `app-editors/vim-core` does not set that, installation of packages fails like that:

```
* This package will overwrite one or more files that may belong to other
 * packages (see list below).
 * 
 * Detected file collision(s):
 * 
 *      /usr/share/vim/vim82/defaults.vim
 * 
 * Searching all installed packages for file collisions...
 * 
 * Press Ctrl-C to Stop
 * 
 * app-editors/vim-8.2.3741:0::gentoo
 *      /usr/share/vim/vim82/defaults.vim
 * 
 * Package 'app-editors/vim-core-8.2.3741' NOT merged due to file
 * collisions. If necessary, refer to your elog messages for the whole
 * content of the above message.
```

To fix that, on the vim side, install `defaults.vim` only if the file is not installed already from vim-core.
On the vim-core side, do not install `defaults.vim` when the file is already installed from vim.