### PR TITLE
PCSX2 wont build without enabling DSDL2_API first

### DIFF
--- a/games-emulation/pcsx2/pcsx2-9999.ebuild
+++ b/games-emulation/pcsx2/pcsx2-9999.ebuild
@@ -103,6 +103,7 @@ src_configure() {
 		-DCMAKE_LIBRARY_PATH="/usr/$(get_libdir)/${PN}"
 		-DUSE_SYSTEM_YAML=TRUE
 		-DUSE_VTUNE=FALSE
+		-DSDL2_API=TRUE
 	)
 
 	setup-wxwidgets


### PR DESCRIPTION
`CMake Error at cmake/ApiValidation.cmake:113 (message):
  wxWidgets is linked to SDL2.  Please use -DSDL2_API=TRUE Call Stack (most recent call first):
  cmake/SearchForStuff.cmake:188 (WX_vs_SDL)
  CMakeLists.txt:27 (include)`



this change in the cmake flags seems to fix it.