### PR TITLE
dev-libs/skalibs: respect user provided flags

### DIFF
--- a/dev-libs/skalibs/files/skalibs-2.11.1.0-respect-user-provided-flags.patch
+++ b/dev-libs/skalibs/files/skalibs-2.11.1.0-respect-user-provided-flags.patch
@@ -1,0 +1,33 @@
+From: Laurent Bercot <ska-skaware@skarnet.org>
+Date: Mon, 24 Jan 2022 11:44:29 +0000
+Subject: [PATCH]  Apply user-provided CPPFLAGS, CFLAGS and LDFLAGS during
+ autodetection
+
+Upstream-commit: d9f541c2b3af (" Apply user-provided CPPFLAGS, CFLAGS and LDFLAGS during autodetection")
+See-also: http://skarnet.org/lists/skaware/1656.html
+---
+diff --git a/configure b/configure
+index 1aa8fc7..430e57e 100755
+--- a/configure
++++ b/configure
+@@ -99,7 +99,7 @@ stripdir () {
+ tryflag () {
+   echo "Checking whether compiler accepts $2 ..."
+   echo "typedef int x;" > "$tmpc"
+-  if $CC_AUTO "$2" -c -o "$tmpo" "$tmpc" >/dev/null 2>&1 ; then
++  if $CC_AUTO $CPPFLAGS_POST $CFLAGS_POST "$2" -c -o "$tmpo" "$tmpc" >/dev/null 2>&1 ; then
+     echo "  ... yes"
+     eval "$1=\"\${$1} \$2\""
+     eval "$1=\${$1# }"
+@@ -113,7 +113,7 @@ tryflag () {
+ tryldflag () {
+   echo "Checking whether linker accepts $2 ..."
+   echo "typedef int x;" > "$tmpc"
+-  if $CC_AUTO -nostdlib "$2" -o "$tmpe" "$tmpc" >/dev/null 2>&1 ; then
++  if $CC_AUTO $CPPFLAGS_POST $CFLAGS_POST $LDFLAGS_POST -nostdlib "$2" -o "$tmpe" "$tmpc" >/dev/null 2>&1 ; then
+     echo "  ... yes"
+     eval "$1=\"\${$1} \$2\""
+     eval "$1=\${$1# }"
+-- 
+2.34.1
+

--- a/dev-libs/skalibs/files/skalibs-2.9.3.0-respect-user-provided-flags.patch
+++ b/dev-libs/skalibs/files/skalibs-2.9.3.0-respect-user-provided-flags.patch
@@ -1,0 +1,33 @@
+From: Laurent Bercot <ska-skaware@skarnet.org>
+Date: Mon, 24 Jan 2022 11:44:29 +0000
+Subject: [PATCH]  Apply user-provided CPPFLAGS, CFLAGS and LDFLAGS during
+ autodetection
+
+Backported-from: d9f541c2b3af (" Apply user-provided CPPFLAGS, CFLAGS and LDFLAGS during autodetection")
+See-also: http://skarnet.org/lists/skaware/1656.html
+---
+diff --git a/configure b/configure
+index 55f34f8..49b3678 100755
+--- a/configure
++++ b/configure
+@@ -99,7 +99,7 @@ stripdir () {
+ tryflag () {
+   echo "Checking whether compiler accepts $2 ..."
+   echo "typedef int x;" > "$tmpc"
+-  if $CC_AUTO "$2" -c -o /dev/null "$tmpc" >/dev/null 2>&1 ; then
++  if $CC_AUTO $CPPFLAGS_POST $CFLAGS_POST "$2" -c -o /dev/null "$tmpc" >/dev/null 2>&1 ; then
+     echo "  ... yes"
+     eval "$1=\"\${$1} \$2\""
+     eval "$1=\${$1# }"
+@@ -113,7 +113,7 @@ tryflag () {
+ tryldflag () {
+   echo "Checking whether linker accepts $2 ..."
+   echo "typedef int x;" > "$tmpc"
+-  if $CC_AUTO -nostdlib "$2" -o /dev/null "$tmpc" >/dev/null 2>&1 ; then
++  if $CC_AUTO $CPPFLAGS_POST $CFLAGS_POST $LDFLAGS_POST -nostdlib "$2" -o /dev/null "$tmpc" >/dev/null 2>&1 ; then
+     echo "  ... yes"
+     eval "$1=\"\${$1} \$2\""
+     eval "$1=\${$1# }"
+-- 
+2.34.1
+

--- a/dev-libs/skalibs/skalibs-2.11.1.0.ebuild
+++ b/dev-libs/skalibs/skalibs-2.11.1.0.ebuild
@@ -16,6 +16,8 @@ IUSE="doc ipv6 static-libs"
 
 HTML_DOCS=( doc/. )
 
+PATCHES=( "${FILESDIR}/${P}-respect-user-provided-flags.patch" )
+
 src_prepare() {
 	default
 

--- a/dev-libs/skalibs/skalibs-2.9.3.0.ebuild
+++ b/dev-libs/skalibs/skalibs-2.9.3.0.ebuild
@@ -16,6 +16,8 @@ IUSE="doc ipv6 static-libs"
 
 HTML_DOCS=( doc/. )
 
+PATCHES=( "${FILESDIR}/${P}-respect-user-provided-flags.patch" )
+
 src_prepare() {
 	default
 


### PR DESCRIPTION
The patch is taken from upstream for 2.11.1.0 and backported to 2.9.3.0.