### PR TITLE
media-libs/openjpeg: Fix mandir and docdir for generated pkgconfig

### DIFF
--- a/media-libs/openjpeg/files/openjpeg-2.4.0-r1-gnuinstalldirs.patch
+++ b/media-libs/openjpeg/files/openjpeg-2.4.0-r1-gnuinstalldirs.patch
@@ -1,0 +1,435 @@
+From fecc8e9e23f78de94c41bc641b3e5b9e9a84560b Mon Sep 17 00:00:00 2001
+From: Andreas Sturmlechner <asturm@gentoo.org>
+Date: Thu, 11 Apr 2019 13:10:57 +0200
+Subject: [PATCH] Use GNUInstallDirs for standard installation directories
+
+Raises minimum cmake version by a little.
+(Later rebased by sam@gentoo.org for 2.4.0)
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -7,7 +7,7 @@
+ # For this purpose you can define a CMake var: OPENJPEG_NAMESPACE to whatever you like
+ # e.g.:
+ # set(OPENJPEG_NAMESPACE "GDCMOPENJPEG")
+-cmake_minimum_required(VERSION 2.8.2)
++cmake_minimum_required(VERSION 2.8.5)
+ 
+ if(COMMAND CMAKE_POLICY)
+   cmake_policy(SET CMP0003 NEW)
+@@ -105,58 +105,27 @@ endif()
+ # --------------------------------------------------------------------------
+ # Install directories
+ # Build DOCUMENTATION (not in ALL target and only if Doxygen is found)
++include(GNUInstallDirs)
++
+ option(BUILD_DOC "Build the HTML documentation (with doxygen if available)." OFF)
+ 
+ string(TOLOWER ${PROJECT_NAME} projectname)
+ set(OPENJPEG_INSTALL_SUBDIR "${projectname}-${OPENJPEG_VERSION_MAJOR}.${OPENJPEG_VERSION_MINOR}")
+ 
+-if(NOT OPENJPEG_INSTALL_BIN_DIR)
+-  set(OPENJPEG_INSTALL_BIN_DIR "bin")
+-endif()
+-
+-if(NOT OPENJPEG_INSTALL_LIB_DIR)
+-  set(OPENJPEG_INSTALL_LIB_DIR "lib")
+-endif()
+-
+-if(NOT OPENJPEG_INSTALL_SHARE_DIR)
+-  set(OPENJPEG_INSTALL_SHARE_DIR "share")
+-endif()
+-
+-if(NOT OPENJPEG_INSTALL_DATA_DIR)
+-  set(OPENJPEG_INSTALL_DATA_DIR "${OPENJPEG_INSTALL_SHARE_DIR}/${OPENJPEG_INSTALL_SUBDIR}")
+-endif()
+-
+-if(NOT OPENJPEG_INSTALL_INCLUDE_DIR)
+-  set(OPENJPEG_INSTALL_INCLUDE_DIR "include/${OPENJPEG_INSTALL_SUBDIR}")
+-endif()
+-
+-if(BUILD_DOC)
+-if(NOT OPENJPEG_INSTALL_MAN_DIR)
+-  set(OPENJPEG_INSTALL_MAN_DIR "share/man/")
+-endif()
+-
+-if(NOT OPENJPEG_INSTALL_DOC_DIR)
+-  set(OPENJPEG_INSTALL_DOC_DIR "share/doc/${OPENJPEG_INSTALL_SUBDIR}")
+-endif()
+-endif()
+-
+ if(NOT OPENJPEG_INSTALL_JNI_DIR)
+   if(WIN32)
+-    set(OPENJPEG_INSTALL_JNI_DIR ${OPENJPEG_INSTALL_BIN_DIR})
++    set(OPENJPEG_INSTALL_JNI_DIR ${CMAKE_INSTALL_BINDIR})
+   else()
+-    set(OPENJPEG_INSTALL_JNI_DIR ${OPENJPEG_INSTALL_LIB_DIR})
++    set(OPENJPEG_INSTALL_JNI_DIR ${CMAKE_INSTALL_LIBDIR})
+   endif()
+ endif()
+ 
+ if(NOT OPENJPEG_INSTALL_PACKAGE_DIR)
+-  # We could install *.cmake files in share/ however those files contains
+-  # hardcoded path to libraries on a multi-arch system (fedora/debian) those
+-  # path will be different (lib/i386-linux-gnu vs lib/x86_64-linux-gnu)
+-  set(OPENJPEG_INSTALL_PACKAGE_DIR "${OPENJPEG_INSTALL_LIB_DIR}/${OPENJPEG_INSTALL_SUBDIR}")
++  set(OPENJPEG_INSTALL_PACKAGE_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/${OPENJPEG_INSTALL_SUBDIR}")
+ endif()
+ 
+ if (APPLE)
+-	list(APPEND OPENJPEG_LIBRARY_PROPERTIES INSTALL_NAME_DIR "${CMAKE_INSTALL_PREFIX}/${OPENJPEG_INSTALL_LIB_DIR}")
++	list(APPEND OPENJPEG_LIBRARY_PROPERTIES INSTALL_NAME_DIR "${CMAKE_INSTALL_FULL_LIBDIR}")
+ 	option(OPJ_USE_DSYMUTIL "Call dsymutil on binaries after build." OFF)
+ endif()
+ 
+@@ -342,14 +311,6 @@ install( FILES ${OPENJPEG_BINARY_DIR}/OpenJPEGConfig.cmake
+ )
+ 
+ #-----------------------------------------------------------------------------
+-# install CHANGES and LICENSE
+-if(BUILD_DOC)
+-if(EXISTS ${OPENJPEG_SOURCE_DIR}/CHANGES)
+-  install(FILES CHANGES DESTINATION ${OPENJPEG_INSTALL_DOC_DIR})
+-endif()
+-
+-install(FILES LICENSE DESTINATION ${OPENJPEG_INSTALL_DOC_DIR})
+-endif()
+ 
+ include (cmake/OpenJPEGCPack.cmake)
+ 
+@@ -366,14 +327,14 @@ if(BUILD_PKGCONFIG_FILES)
+   configure_file(${CMAKE_CURRENT_SOURCE_DIR}/src/lib/openjp2/libopenjp2.pc.cmake.in
+     ${CMAKE_CURRENT_BINARY_DIR}/libopenjp2.pc @ONLY)
+   install( FILES  ${CMAKE_CURRENT_BINARY_DIR}/libopenjp2.pc DESTINATION
+-    ${OPENJPEG_INSTALL_LIB_DIR}/pkgconfig )
++    ${CMAKE_INSTALL_LIBDIR}/pkgconfig )
+ #
+   if(BUILD_JPWL)
+   # install in lib and not share (see multi-arch note above)
+   configure_file(${CMAKE_CURRENT_SOURCE_DIR}/src/lib/openjpwl/libopenjpwl.pc.cmake.in
+     ${CMAKE_CURRENT_BINARY_DIR}/libopenjpwl.pc @ONLY)
+   install( FILES  ${CMAKE_CURRENT_BINARY_DIR}/libopenjpwl.pc DESTINATION
+-    ${OPENJPEG_INSTALL_LIB_DIR}/pkgconfig )
++    ${CMAKE_INSTALL_LIBDIR}/pkgconfig )
+   endif()
+ #
+   if(BUILD_JPIP)
+@@ -381,7 +342,7 @@ if(BUILD_PKGCONFIG_FILES)
+   configure_file(${CMAKE_CURRENT_SOURCE_DIR}/src/lib/openjpip/libopenjpip.pc.cmake.in
+     ${CMAKE_CURRENT_BINARY_DIR}/libopenjpip.pc @ONLY)
+   install( FILES  ${CMAKE_CURRENT_BINARY_DIR}/libopenjpip.pc DESTINATION
+-    ${OPENJPEG_INSTALL_LIB_DIR}/pkgconfig )
++    ${CMAKE_INSTALL_LIBDIR}/pkgconfig )
+   endif()
+ #
+   if(BUILD_JP3D)
+@@ -389,7 +350,7 @@ if(BUILD_PKGCONFIG_FILES)
+   configure_file(${CMAKE_CURRENT_SOURCE_DIR}/src/lib/openjp3d/libopenjp3d.pc.cmake.in
+     ${CMAKE_CURRENT_BINARY_DIR}/libopenjp3d.pc @ONLY)
+   install( FILES  ${CMAKE_CURRENT_BINARY_DIR}/libopenjp3d.pc DESTINATION
+-    ${OPENJPEG_INSTALL_LIB_DIR}/pkgconfig )
++    ${CMAKE_INSTALL_LIBDIR}/pkgconfig )
+   endif()
+ endif()
+ 
+--- a/cmake/OpenJPEGConfig.cmake.in
++++ b/cmake/OpenJPEGConfig.cmake.in
+@@ -27,7 +27,7 @@ if(EXISTS ${SELF_DIR}/OpenJPEGTargets.cmake)
+   # This is an install tree
+   include(${SELF_DIR}/OpenJPEGTargets.cmake)
+ 
+-  set(INC_DIR "@CMAKE_INSTALL_PREFIX@/@OPENJPEG_INSTALL_INCLUDE_DIR@")
++  set(INC_DIR "@CMAKE_INSTALL_FULL_INCLUDEDIR@/@OPENJPEG_INSTALL_SUBDIR@")
+   get_filename_component(OPENJPEG_INCLUDE_DIRS "${INC_DIR}" ABSOLUTE)
+ 
+ else()
+--- a/doc/CMakeLists.txt
++++ b/doc/CMakeLists.txt
+@@ -44,7 +44,7 @@ if(DOXYGEN_FOUND)
+ 
+   # install HTML documentation (install png files too):
+   install(DIRECTORY ${CMAKE_BINARY_DIR}/doc/html
+-    DESTINATION ${OPENJPEG_INSTALL_DOC_DIR}
++    DESTINATION ${CMAKE_INSTALL_DOCDIR}
+     PATTERN ".svn" EXCLUDE
+   )
+ else()
+--- a/src/bin/jp2/CMakeLists.txt
++++ b/src/bin/jp2/CMakeLists.txt
+@@ -67,7 +67,7 @@ foreach(exe opj_decompress opj_compress opj_dump)
+   # Install exe
+   install(TARGETS ${exe}
+     EXPORT OpenJPEGTargets
+-    DESTINATION ${OPENJPEG_INSTALL_BIN_DIR} COMPONENT Applications
++    DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT Applications
+   )
+   if(OPJ_USE_DSYMUTIL)
+     add_custom_command(TARGET ${exe} POST_BUILD
+@@ -83,6 +83,6 @@ install(
+   FILES       ${OPENJPEG_SOURCE_DIR}/doc/man/man1/opj_compress.1
+               ${OPENJPEG_SOURCE_DIR}/doc/man/man1/opj_decompress.1
+               ${OPENJPEG_SOURCE_DIR}/doc/man/man1/opj_dump.1
+-  DESTINATION ${OPENJPEG_INSTALL_MAN_DIR}/man1)
++  DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)
+ #
+ endif()
+--- a/src/bin/jp3d/CMakeLists.txt
++++ b/src/bin/jp3d/CMakeLists.txt
+@@ -36,6 +36,6 @@ foreach(exe opj_jp3d_compress opj_jp3d_decompress)
+   # Install exe
+   install(TARGETS ${exe}
+     EXPORT OpenJP3DTargets
+-    DESTINATION ${OPENJPEG_INSTALL_BIN_DIR} COMPONENT Applications
++    DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT Applications
+   )
+ endforeach()
+--- a/src/bin/jpip/CMakeLists.txt
++++ b/src/bin/jpip/CMakeLists.txt
+@@ -13,7 +13,7 @@ add_executable(opj_jpip_addxml opj_jpip_addxml.c)
+ # Install exe
+ install(TARGETS opj_jpip_addxml
+   EXPORT OpenJPEGTargets
+-  DESTINATION ${OPENJPEG_INSTALL_BIN_DIR} COMPONENT Applications
++  DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT Applications
+   )
+ 
+ if(BUILD_JPIP_SERVER)
+@@ -38,7 +38,7 @@ if(BUILD_JPIP_SERVER)
+   # Install exe
+   install(TARGETS opj_server
+     EXPORT OpenJPEGTargets
+-    DESTINATION ${OPENJPEG_INSTALL_BIN_DIR} COMPONENT Applications
++    DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT Applications
+     )
+ endif()
+ 
+@@ -52,7 +52,7 @@ add_executable(${exe} ${exe}.c)
+   target_link_libraries(${exe} openjpip)
+   install(TARGETS ${exe}
+     EXPORT OpenJPEGTargets
+-    DESTINATION ${OPENJPEG_INSTALL_BIN_DIR} COMPONENT Applications
++    DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT Applications
+     )
+ endforeach()
+ 
+@@ -123,7 +123,7 @@ if(Java_Development_FOUND AND Java_JAVAC_EXECUTABLE)
+       )
+ 
+     install(FILES ${LIBRARY_OUTPUT_PATH}/opj_jpip_viewer.jar
+-      DESTINATION ${OPENJPEG_INSTALL_SHARE_DIR} COMPONENT JavaModule
++      DESTINATION ${CMAKE_INSTALL_DATAROOTDIR} COMPONENT JavaModule
+       )
+   else()
+     # opj_viewer (simple, no xerces)
+@@ -153,7 +153,7 @@ if(Java_Development_FOUND AND Java_JAVAC_EXECUTABLE)
+       )
+ 
+     install(FILES ${LIBRARY_OUTPUT_PATH}/opj_jpip_viewer.jar
+-      DESTINATION ${OPENJPEG_INSTALL_SHARE_DIR} COMPONENT JavaModule
++      DESTINATION ${CMAKE_INSTALL_DATAROOTDIR} COMPONENT JavaModule
+       )
+   endif()
+ else()
+--- a/src/bin/jpwl/CMakeLists.txt
++++ b/src/bin/jpwl/CMakeLists.txt
+@@ -57,6 +57,6 @@ foreach(exe decompress compress)
+   endif()
+ 
+   install(TARGETS ${jpwl_exe}
+-    DESTINATION ${OPENJPEG_INSTALL_BIN_DIR} COMPONENT Applications
++    DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT Applications
+   )
+ endforeach()
+--- a/src/bin/mj2/CMakeLists.txt
++++ b/src/bin/mj2/CMakeLists.txt
+@@ -43,5 +43,5 @@ foreach(exe
+   endif()
+ 
+   install(TARGETS ${exe}
+-  	DESTINATION ${OPENJPEG_INSTALL_BIN_DIR})
++  	DESTINATION ${CMAKE_INSTALL_BINDIR})
+ endforeach()
+--- a/src/lib/openjp2/CMakeLists.txt
++++ b/src/lib/openjp2/CMakeLists.txt
+@@ -2,7 +2,7 @@ include_regular_expression("^.*$")
+ 
+ #
+ install( FILES  ${CMAKE_CURRENT_BINARY_DIR}/opj_config.h
+- DESTINATION ${OPENJPEG_INSTALL_INCLUDE_DIR} COMPONENT Headers)
++ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${OPENJPEG_INSTALL_SUBDIR} COMPONENT Headers)
+ 
+ include_directories(
+   ${${OPENJPEG_NAMESPACE}_BINARY_DIR}/src/lib/openjp2 # opj_config.h and opj_config_private.h
+@@ -114,21 +114,21 @@ endif()
+ # Install library
+ install(TARGETS ${INSTALL_LIBS}
+   EXPORT OpenJPEGTargets
+-  RUNTIME DESTINATION ${OPENJPEG_INSTALL_BIN_DIR} COMPONENT Applications
+-  LIBRARY DESTINATION ${OPENJPEG_INSTALL_LIB_DIR} COMPONENT Libraries
+-  ARCHIVE DESTINATION ${OPENJPEG_INSTALL_LIB_DIR} COMPONENT Libraries
++  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT Applications
++  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT Libraries
++  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT Libraries
+ )
+ 
+ # Install includes files
+ install(FILES openjpeg.h opj_stdint.h
+-  DESTINATION ${OPENJPEG_INSTALL_INCLUDE_DIR} COMPONENT Headers
++  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${OPENJPEG_INSTALL_SUBDIR} COMPONENT Headers
+ )
+ 
+ if(BUILD_DOC)
+ # install man page of the library
+ install(
+   FILES       ${OPENJPEG_SOURCE_DIR}/doc/man/man3/libopenjp2.3
+-  DESTINATION ${OPENJPEG_INSTALL_MAN_DIR}/man3)
++  DESTINATION ${CMAKE_INSTALL_MANDIR}/man3)
+ endif()
+ 
+ if(BUILD_LUTS_GENERATOR)
+--- a/src/lib/openjp2/libopenjp2.pc.cmake.in
++++ b/src/lib/openjp2/libopenjp2.pc.cmake.in
+@@ -1,9 +1,9 @@
+ prefix=@CMAKE_INSTALL_PREFIX@
+-bindir=${prefix}/@OPENJPEG_INSTALL_BIN_DIR@
+-mandir=${prefix}/@OPENJPEG_INSTALL_MAN_DIR@
+-docdir=${prefix}/@OPENJPEG_INSTALL_DOC_DIR@
+-libdir=${prefix}/@OPENJPEG_INSTALL_LIB_DIR@
+-includedir=${prefix}/@OPENJPEG_INSTALL_INCLUDE_DIR@
++bindir=${prefix}/@CMAKE_INSTALL_BINDIR@
++mandir=@CMAKE_INSTALL_MANDIR@
++docdir=@CMAKE_INSTALL_DOCDIR@
++libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
++includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@/@OPENJPEG_INSTALL_SUBDIR@
+ 
+ Name: openjp2
+ Description: JPEG2000 library (Part 1 and 2)
+--- a/src/lib/openjp3d/CMakeLists.txt
++++ b/src/lib/openjp3d/CMakeLists.txt
+@@ -34,12 +34,12 @@ endif()
+ # Install library
+ install(TARGETS ${OPENJP3D_LIBRARY_NAME}
+   EXPORT OpenJP3DTargets
+-  DESTINATION ${OPENJPEG_INSTALL_LIB_DIR}
++  DESTINATION ${CMAKE_INSTALL_LIBDIR}
+   COMPONENT Libraries
+ )
+ 
+ # Install includes files
+ install(FILES openjp3d.h
+-  DESTINATION ${OPENJPEG_INSTALL_INCLUDE_DIR}
++  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${OPENJPEG_INSTALL_SUBDIR}
+   COMPONENT Headers
+ )
+--- a/src/lib/openjp3d/libopenjp3d.pc.cmake.in
++++ b/src/lib/openjp3d/libopenjp3d.pc.cmake.in
+@@ -1,9 +1,9 @@
+ prefix=@CMAKE_INSTALL_PREFIX@
+-bindir=${prefix}/@OPENJPEG_INSTALL_BIN_DIR@
+-mandir=${prefix}/@OPENJPEG_INSTALL_MAN_DIR@
+-docdir=${prefix}/@OPENJPEG_INSTALL_DOC_DIR@
+-libdir=${prefix}/@OPENJPEG_INSTALL_LIB_DIR@
+-includedir=${prefix}/@OPENJPEG_INSTALL_INCLUDE_DIR@
++bindir=${prefix}/@CMAKE_INSTALL_BINDIR@
++mandir=@CMAKE_INSTALL_MANDIR@
++docdir=@CMAKE_INSTALL_DOCDIR@
++libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
++includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@/@OPENJPEG_INSTALL_SUBDIR@
+ 
+ Name: openjp3d
+ Description: JPEG2000 Extensions for three-dimensional data (Part 10)
+--- a/src/lib/openjpip/CMakeLists.txt
++++ b/src/lib/openjpip/CMakeLists.txt
+@@ -74,9 +74,9 @@ endif()
+ # Install library
+ install(TARGETS openjpip
+   EXPORT OpenJPEGTargets
+-  RUNTIME DESTINATION ${OPENJPEG_INSTALL_BIN_DIR} COMPONENT Applications
+-  LIBRARY DESTINATION ${OPENJPEG_INSTALL_LIB_DIR} COMPONENT Libraries
+-  ARCHIVE DESTINATION ${OPENJPEG_INSTALL_LIB_DIR} COMPONENT Libraries
++  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT Applications
++  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT Libraries
++  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT Libraries
+   )
+ 
+ if(BUILD_JPIP_SERVER)
+@@ -86,6 +86,6 @@ if(BUILD_JPIP_SERVER)
+     PROPERTIES COMPILE_FLAGS "-DSERVER")
+   install(TARGETS openjpip_server
+     EXPORT OpenJPEGTargets
+-    DESTINATION ${OPENJPEG_INSTALL_LIB_DIR} COMPONENT Libraries
++    DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT Libraries
+     )
+ endif()
+--- a/src/lib/openjpip/libopenjpip.pc.cmake.in
++++ b/src/lib/openjpip/libopenjpip.pc.cmake.in
+@@ -1,9 +1,9 @@
+ prefix=@CMAKE_INSTALL_PREFIX@
+-bindir=${prefix}/@OPENJPEG_INSTALL_BIN_DIR@
+-mandir=${prefix}/@OPENJPEG_INSTALL_MAN_DIR@
+-docdir=${prefix}/@OPENJPEG_INSTALL_DOC_DIR@
+-libdir=${prefix}/@OPENJPEG_INSTALL_LIB_DIR@
+-includedir=${prefix}/@OPENJPEG_INSTALL_INCLUDE_DIR@
++bindir=${prefix}/@CMAKE_INSTALL_BINDIR@
++mandir=@CMAKE_INSTALL_MANDIR@
++docdir=@CMAKE_INSTALL_DOCDIR@
++libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
++includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@/@OPENJPEG_INSTALL_SUBDIR@
+ 
+ Name: openjpip
+ Description: JPEG2000 Interactivity tools, APIs and protocols (Part 9)
+--- a/src/lib/openjpwl/CMakeLists.txt
++++ b/src/lib/openjpwl/CMakeLists.txt
+@@ -58,7 +58,7 @@ endif()
+ # Install library
+ install(TARGETS openjpwl
+   EXPORT OpenJPEGTargets
+-  RUNTIME DESTINATION ${OPENJPEG_INSTALL_BIN_DIR} COMPONENT Applications
+-  LIBRARY DESTINATION ${OPENJPEG_INSTALL_LIB_DIR} COMPONENT Libraries
+-  ARCHIVE DESTINATION ${OPENJPEG_INSTALL_LIB_DIR} COMPONENT Libraries
++  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT Applications
++  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT Libraries
++  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT Libraries
+ )
+--- a/src/lib/openjpwl/libopenjpwl.pc.cmake.in
++++ b/src/lib/openjpwl/libopenjpwl.pc.cmake.in
+@@ -1,9 +1,9 @@
+ prefix=@CMAKE_INSTALL_PREFIX@
+-bindir=${prefix}/@OPENJPEG_INSTALL_BIN_DIR@
+-mandir=${prefix}/@OPENJPEG_INSTALL_MAN_DIR@
+-docdir=${prefix}/@OPENJPEG_INSTALL_DOC_DIR@
+-libdir=${prefix}/@OPENJPEG_INSTALL_LIB_DIR@
+-includedir=${prefix}/@OPENJPEG_INSTALL_INCLUDE_DIR@
++bindir=${prefix}/@CMAKE_INSTALL_BINDIR@
++mandir=@CMAKE_INSTALL_MANDIR@
++docdir=@CMAKE_INSTALL_DOCDIR@
++libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
++includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@/@OPENJPEG_INSTALL_SUBDIR@
+ 
+ Name: openjpwl
+ Description: JPEG2000 Wireless library (Part 11)
+--- a/src/lib/openmj2/CMakeLists.txt
++++ b/src/lib/openmj2/CMakeLists.txt
+@@ -53,12 +53,12 @@ endif()
+ # Install library
+ install(TARGETS ${OPENMJ2_LIBRARY_NAME}
+   EXPORT OpenMJ2Targets
+-  DESTINATION ${OPENJPEG_INSTALL_LIB_DIR}
++  DESTINATION ${CMAKE_INSTALL_LIBDIR}
+   COMPONENT Libraries
+ )
+ 
+ # Install includes files
+ #install(FILES mj2.h
+-#  DESTINATION ${OPENJPEG_INSTALL_INCLUDE_DIR}/${subdir}
++#  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${OPENJPEG_INSTALL_SUBDIR}
+ #  COMPONENT Headers
+ #)
+--- a/wrapping/java/openjp2/CMakeLists.txt
++++ b/wrapping/java/openjp2/CMakeLists.txt
+@@ -69,5 +69,5 @@ add_custom_target(OpenJPEGJavaJar ALL
+ )
+ 
+ install(FILES ${LIBRARY_OUTPUT_PATH}/openjpeg.jar
+-  DESTINATION ${OPENJPEG_INSTALL_SHARE_DIR} COMPONENT JavaModule
++  DESTINATION ${CMAKE_INSTALL_DATAROOTDIR} COMPONENT JavaModule
+ )

--- a/media-libs/openjpeg/openjpeg-2.4.0-r1.ebuild
+++ b/media-libs/openjpeg/openjpeg-2.4.0-r1.ebuild
@@ -1,0 +1,139 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+CMAKE_ECLASS=cmake
+inherit cmake-multilib flag-o-matic
+
+# Make sure that test data are not newer than release;
+# otherwise we will see "Found-But-No-Test" test failures!
+MY_TESTDATA_COMMIT="cd724fb1f93e6af41ebc68c4904f4bf2a4cd1e60"
+
+DESCRIPTION="Open-source JPEG 2000 library"
+HOMEPAGE="https://www.openjpeg.org"
+SRC_URI="https://github.com/uclouvain/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz
+	test? ( https://github.com/uclouvain/openjpeg-data/archive/${MY_TESTDATA_COMMIT}.tar.gz -> ${PN}-data_20201130.tar.gz )"
+
+LICENSE="BSD-2"
+SLOT="2/7" # based on SONAME
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+IUSE="doc static-libs test"
+RESTRICT="!test? ( test )"
+
+RDEPEND="
+	media-libs/lcms:2
+	media-libs/libpng:0=
+	media-libs/tiff:0
+	sys-libs/zlib:="
+DEPEND="${RDEPEND}"
+BDEPEND="
+	doc? ( app-doc/doxygen )"
+
+DOCS=( AUTHORS.md CHANGELOG.md NEWS.md README.md THANKS.md )
+
+PATCHES=(
+	"${FILESDIR}/${PN}-2.4.0-r1-gnuinstalldirs.patch" # bug 667150
+)
+
+src_prepare() {
+	if use test; then
+		mv "${WORKDIR}"/openjpeg-data-${MY_TESTDATA_COMMIT} "${WORKDIR}"/data ||
+			die "Failed to rename test data"
+	fi
+
+	cmake_src_prepare
+}
+
+multilib_src_configure() {
+	local mycmakeargs=(
+		-DBUILD_PKGCONFIG_FILES=ON # always build pkgconfig files, bug #539834
+		-DBUILD_TESTING="$(multilib_native_usex test)"
+		-DBUILD_DOC=$(multilib_native_usex doc ON OFF)
+		-DBUILD_CODEC=$(multilib_is_native_abi && echo ON || echo OFF)
+		-DBUILD_STATIC_LIBS=$(usex static-libs)
+	)
+
+	# Cheat a little bit and force disabling fixed point magic
+	# The test suite is extremely fragile to small changes
+	# bug 715130, bug 715422
+	# https://github.com/uclouvain/openjpeg/issues/1017
+	multilib_is_native_abi && use test && append-cflags "-ffp-contract=off"
+
+	cmake_src_configure
+}
+
+multilib_src_test() {
+	if ! multilib_is_native_abi ; then
+		elog "Cannot run tests for non-multilib abi."
+		return 0
+	fi
+
+	local myctestargs=
+
+	pushd "${BUILD_DIR}" > /dev/null || die
+	[[ -e CTestTestfile.cmake ]] || die "Test suite not available! Check source!"
+
+	[[ -n ${TEST_VERBOSE} ]] && myctestargs+=( --extra-verbose --output-on-failure )
+
+	echo ctest "${myctestargs[@]}" "$@"
+	if ctest "${myctestargs[@]}" "$@" ; then
+		einfo "Tests succeeded."
+		popd > /dev/null || die
+		return 0
+	else
+		local FAILEDTEST_LOG="${BUILD_DIR}/Testing/Temporary/LastTestsFailed.log"
+
+		if [[ ! -f "${FAILEDTEST_LOG}" ]] ; then
+			# Should never happen
+			die "Cannot analyze test failures: LastTestsFailed.log is missing!"
+		fi
+
+		echo ""
+		einfo "Note: Upstream is maintaining a list of known test failures."
+		einfo "We will now compare our test results against this list and sort out any known failure."
+
+		local KNOWN_FAILURES_LIST="${T}/known_failures_compiled.txt"
+		cat "${S}/tools/travis-ci/knownfailures-all.txt" > "${KNOWN_FAILURES_LIST}" || die
+
+		local ARCH_SPECIFIC_FAILURES=
+		if use amd64 ; then
+			ARCH_SPECIFIC_FAILURES="$(find "${S}/tools/travis-ci/" -name 'knownfailures-*x86_64*.txt' -print0 | sort -z | tail -z -n 1 | tr -d '\0')"
+		elif use x86 || use arm || use arm64; then
+			ARCH_SPECIFIC_FAILURES="$(find "${S}/tools/travis-ci/" -name 'knownfailures-*i386*.txt' -print0 | sort -z | tail -z -n 1 | tr -d '\0')"
+		fi
+
+		if [[ -f "${ARCH_SPECIFIC_FAILURES}" ]] ; then
+			einfo "Adding architecture specific failures (${ARCH_SPECIFIC_FAILURES}) to known failures list ..."
+			cat "${ARCH_SPECIFIC_FAILURES}" >> "${KNOWN_FAILURES_LIST}" || die
+		fi
+
+		# Logic copied from $S/tools/travis-ci/run.sh
+		local FAILEDTEST=
+		local FAILURES_LOG="${BUILD_DIR}/Testing/Temporary/failures.txt"
+		local HAS_UNKNOWN_TEST_FAILURES=0
+
+		echo ""
+
+		awk -F: '{ print $2 }' "${FAILEDTEST_LOG}" > "${FAILURES_LOG}"
+		while read FAILEDTEST; do
+			# is this failure known?
+			if grep -x "${FAILEDTEST}" "${KNOWN_FAILURES_LIST}" > /dev/null; then
+				ewarn "Test '${FAILEDTEST}' is known to fail, ignoring ..."
+				continue
+			fi
+
+			eerror "New/unknown test failure found: '${FAILEDTEST}'"
+			HAS_UNKNOWN_TEST_FAILURES=1
+		done < "${FAILURES_LOG}"
+
+		if [[ ${HAS_UNKNOWN_TEST_FAILURES} -ne 0 ]]; then
+			die "Test suite failed. New/unknown test failure(s) found!"
+		else
+			echo ""
+			einfo "Test suite passed. No new/unknown test failure(s) found!"
+		fi
+
+		return 0
+	fi
+}


### PR DESCRIPTION
Update the patch to remove the ${prefix} variable from mandir and docdir
as it results in incorrect paths.

Bug: https://bugs.gentoo.org/694776
Signed-off-by: Thomas Bracht Laumann Jespersen <t@laumann.xyz>
Package-Manager: Portage-3.0.28, Repoman-3.0.3