### PR TITLE
dev-lang/lua: Use libtool from EROOT

### DIFF
--- a/dev-lang/lua/lua-5.1.5-r107.ebuild
+++ b/dev-lang/lua/lua-5.1.5-r107.ebuild
@@ -1,0 +1,157 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+inherit multilib multilib-minimal portability toolchain-funcs
+
+DESCRIPTION="A powerful light-weight programming language designed for extending applications"
+HOMEPAGE="https://www.lua.org/"
+SRC_URI="https://www.lua.org/ftp/${P}.tar.gz"
+
+LICENSE="MIT"
+SLOT="5.1"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+IUSE="+deprecated readline"
+
+COMMON_DEPEND="
+	>=app-eselect/eselect-lua-3
+	readline? ( >=sys-libs/readline-6.2_p5-r1:0=[${MULTILIB_USEDEP}] )
+	!dev-lang/lua:0"
+# Cross-compiling note:
+# Must use libtool from the target system (DEPEND) because
+# libtool from the build system (BDEPEND) is for building
+# native binaries.
+DEPEND="
+	${COMMON_DEPEND}
+	sys-devel/libtool"
+RDEPEND="${COMMON_DEPEND}"
+
+MULTILIB_WRAPPED_HEADERS=(
+	/usr/include/lua${SLOT}/luaconf.h
+)
+
+src_prepare() {
+	PATCHES=(
+		"${FILESDIR}/lua-5.1.5-make.patch"
+		"${FILESDIR}/${PN}-$(ver_cut 1-2)-module_paths.patch"
+	)
+	if ! use deprecated ; then
+		# patches from 5.1.4 still apply
+		PATCHES+=(
+			"${FILESDIR}"/${PN}-5.1.4-deprecated.patch
+			"${FILESDIR}"/${PN}-5.1.4-test.patch
+		)
+	fi
+	if ! use readline ; then
+		PATCHES+=(
+			"${FILESDIR}"/${PN}-$(ver_cut 1-2)-readline.patch
+		)
+	fi
+
+	default
+
+	# use glibtool on Darwin (versus Apple libtool)
+	if [[ ${CHOST} == *-darwin* ]] ; then
+		sed -i -e '/LIBTOOL = /s:libtool:glibtool:' \
+			Makefile src/Makefile || die
+	fi
+
+	# correct lua versioning
+	sed -i -e 's/\(LIB_VERSION = \)6:1:1/\16:5:1/' src/Makefile
+
+	sed -i -e 's:\(/README\)\("\):\1.gz\2:g' doc/readme.html
+
+	# Using dynamic linked lua is not recommended for performance
+	# reasons. http://article.gmane.org/gmane.comp.lang.lua.general/18519
+	# Mainly, this is of concern if your arch is poor with GPRs, like x86
+	# Note that this only affects the interpreter binary (named lua), not the lua
+	# compiler (built statically) nor the lua libraries.
+
+	# A slotted Lua uses different directories for headers & names for
+	# libraries, and pkgconfig should reflect that.
+	sed -r -i \
+		-e "/^INSTALL_INC=/s,(/include)$,\1/lua${SLOT}," \
+		-e "/^includedir=/s,(/include)$,\1/lua${SLOT}," \
+		-e "/^Libs:/s,((-llua)($| )),\2${SLOT}\3," \
+		"${S}"/etc/lua.pc
+
+	# custom Makefiles
+	multilib_copy_sources
+}
+
+multilib_src_configure() {
+	# We want packages to find our things...
+	sed -i \
+		-e 's:/usr/local:'${EPREFIX}'/usr:' \
+		-e "s:\([/\"]\)\<lib\>:\1$(get_libdir):g" \
+		etc/lua.pc src/luaconf.h || die
+}
+
+multilib_src_compile() {
+	tc-export CC
+	myflags=
+	# what to link to liblua
+	liblibs="-lm"
+	liblibs="${liblibs} $(dlopen_lib)"
+
+	# what to link to the executables
+	mylibs=
+	if use readline; then
+		mylibs="-lreadline"
+	fi
+
+	cd src
+	emake CC="${CC}" CFLAGS="-DLUA_USE_LINUX ${CFLAGS}" \
+			RPATH="${EPREFIX}/usr/$(get_libdir)/" \
+			LUA_LIBS="${mylibs}" \
+			LIB_LIBS="${liblibs}" \
+			V=$(ver_cut 1-2) \
+			LIBTOOL="${ESYSROOT}/usr/bin/libtool" \
+			gentoo_all
+
+	mv lua_test ../test/lua.static
+}
+
+multilib_src_install() {
+	emake INSTALL_TOP="${ED}/usr" INSTALL_LIB="${ED}/usr/$(get_libdir)" \
+			V=${SLOT} gentoo_install
+
+	insinto /usr/$(get_libdir)/pkgconfig
+	newins etc/lua.pc lua${SLOT}.pc
+}
+
+multilib_src_install_all() {
+	DOCS="HISTORY README"
+	HTML_DOCS="doc/*.html doc/*.png doc/*.css doc/*.gif"
+	einstalldocs
+	newman doc/lua.1 lua${SLOT}.1
+	newman doc/luac.1 luac${SLOT}.1
+	find "${ED}" -name '*.la' -delete || die
+	find "${ED}" -name 'liblua*.a' -delete || die
+}
+
+multilib_src_test() {
+	local positive="bisect cf echo env factorial fib fibfor hello printf sieve
+	sort trace-calls trace-globals"
+	local negative="readonly"
+	local test
+
+	cd "${BUILD_DIR}" || die
+	for test in ${positive}; do
+		test/lua.static test/${test}.lua || die "test $test failed"
+	done
+
+	for test in ${negative}; do
+		test/lua.static test/${test}.lua && die "test $test failed"
+	done
+}
+
+pkg_postinst() {
+	eselect lua set --if-unset "${PN}${SLOT}"
+
+	if has_version "app-editor/emacs"; then
+		if ! has_version "app-emacs/lua-mode"; then
+			einfo "Install app-emacs/lua-mode for lua support for emacs"
+		fi
+	fi
+}

--- a/dev-lang/lua/lua-5.3.6-r3.ebuild
+++ b/dev-lang/lua/lua-5.3.6-r3.ebuild
@@ -1,0 +1,206 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+inherit autotools multilib multilib-minimal portability toolchain-funcs
+
+DESCRIPTION="A powerful light-weight programming language designed for extending applications"
+HOMEPAGE="https://www.lua.org/"
+TEST_PV="5.3.4"
+TEST_P="${PN}-${TEST_PV}-tests"
+SRC_URI="
+	https://www.lua.org/ftp/${P}.tar.gz
+	test? ( https://www.lua.org/tests/${TEST_P}.tar.gz )"
+
+LICENSE="MIT"
+SLOT="5.3"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+IUSE="+deprecated readline test test-complete"
+
+COMMON_DEPEND="
+	>=app-eselect/eselect-lua-3
+	readline? ( sys-libs/readline:0= )
+	!dev-lang/lua:0"
+# Cross-compiling note:
+# Must use libtool from the target system (DEPEND) because
+# libtool from the build system (BDEPEND) is for building
+# native binaries.
+DEPEND="
+	${COMMON_DEPEND}
+	sys-devel/libtool"
+RDEPEND="${COMMON_DEPEND}"
+
+RESTRICT="!test? ( test )"
+
+MULTILIB_WRAPPED_HEADERS=(
+	/usr/include/lua${SLOT}/luaconf.h
+)
+
+PATCHES=(
+	"${FILESDIR}/lua-5.3.6-make.patch"
+)
+
+src_prepare() {
+	default
+	# use glibtool on Darwin (versus Apple libtool)
+	if [[ ${CHOST} == *-darwin* ]] ; then
+		sed -i -e '/LIBTOOL = /s:/libtool:/glibtool:' \
+			Makefile src/Makefile || die
+	fi
+
+	# correct lua versioning
+	sed -i -e 's/\(LIB_VERSION = \)6:1:1/\10:0:0/' src/Makefile || die
+
+	sed -i -e 's:\(/README\)\("\):\1.gz\2:g' doc/readme.html || die
+
+	if ! use readline ; then
+		sed -i -e '/#define LUA_USE_READLINE/d' src/luaconf.h || die
+	fi
+
+	# Using dynamic linked lua is not recommended for performance
+	# reasons. http://article.gmane.org/gmane.comp.lang.lua.general/18519
+	# Mainly, this is of concern if your arch is poor with GPRs, like x86
+	# Note that this only affects the interpreter binary (named lua), not the lua
+	# compiler (built statically) nor the lua libraries.
+
+	# upstream does not use libtool, but we do (see bug #336167)
+	cp "${FILESDIR}/configure.in" "${S}/configure.ac" || die
+	eautoreconf
+
+	# custom Makefiles
+	multilib_copy_sources
+}
+
+multilib_src_configure() {
+	sed -i \
+		-e 's:\(define LUA_ROOT\s*\).*:\1"'${EPREFIX}'/usr/":' \
+		-e "s:\(define LUA_CDIR\s*LUA_ROOT \"\)lib:\1$(get_libdir):" \
+		src/luaconf.h \
+	|| die "failed patching luaconf.h"
+
+	econf
+}
+
+multilib_src_compile() {
+	tc-export CC
+
+	# what to link to liblua
+	liblibs="-lm"
+	liblibs="${liblibs} $(dlopen_lib)"
+
+	# what to link to the executables
+	mylibs=
+	use readline && mylibs="-lreadline"
+
+	cd src
+
+	local myCFLAGS=""
+	use deprecated && myCFLAGS="-DLUA_COMPAT_5_1 -DLUA_COMPAT_5_2"
+
+	case "${CHOST}" in
+		*-mingw*) : ;;
+		*) myCFLAGS+=" -DLUA_USE_LINUX" ;;
+	esac
+
+	emake CC="${CC}" CFLAGS="${myCFLAGS} ${CFLAGS}" \
+			SYSLDFLAGS="${LDFLAGS}" \
+			RPATH="${EPREFIX}/usr/$(get_libdir)/" \
+			LUA_LIBS="${mylibs}" \
+			LIB_LIBS="${liblibs}" \
+			V=$(ver_cut 1-2) \
+			LIBTOOL="${ESYSROOT}/usr/bin/libtool" \
+			gentoo_all
+}
+
+multilib_src_install() {
+	emake INSTALL_TOP="${ED}/usr" INSTALL_LIB="${ED}/usr/$(get_libdir)" \
+			V=${SLOT} gentoo_install
+
+	case $SLOT in
+		0)
+			LIBNAME="lua"
+			INCLUDEDIR_SUFFIX=''
+			;;
+		*)	LIBNAME="lua${SLOT}"
+			INCLUDEDIR_SUFFIX="/lua${SLOT}"
+			;;
+	esac
+
+	# We want packages to find our things...
+	# A slotted Lua uses different directories for headers & names for
+	# libraries, and pkgconfig should reflect that.
+	local PATCH_PV=$(ver_cut 1-2)
+	cp "${FILESDIR}/lua.pc" "${WORKDIR}" || die
+	sed -r -i \
+		-e "/^INSTALL_INC=/s,(/include)$,\1/lua${SLOT}," \
+		-e "s:^prefix= :prefix= ${EPREFIX}:" \
+		-e "s:^V=.*:V= ${PATCH_PV}:" \
+		-e "s:^R=.*:R= ${PV}:" \
+		-e "s:/,lib,:/$(get_libdir):g" \
+		-e "/^Libs:/s:( )(-llua)($| ):\1-l${LIBNAME}\3:" \
+		-e "/^includedir=/s:include$:include${INCLUDEDIR_SUFFIX}:" \
+		"${WORKDIR}/lua.pc" || die
+
+	insinto "/usr/$(get_libdir)/pkgconfig"
+	newins "${WORKDIR}/lua.pc" "lua${SLOT}.pc"
+	# Copy Debian's symlink support:
+	# https://salsa.debian.org/lua-team/lua5.3/blob/master/debian/rules#L19
+	# FreeBSD calls the pkgconfig 'lua-5.3.pc'
+	# Older systems called it 'lua53.pc'
+	dosym "lua${SLOT}.pc" "/usr/$(get_libdir)/pkgconfig/lua-${SLOT}.pc"
+	dosym "lua${SLOT}.pc" "/usr/$(get_libdir)/pkgconfig/lua${SLOT/.}.pc"
+}
+
+multilib_src_install_all() {
+	DOCS="README"
+	HTML_DOCS="doc/*.html doc/*.png doc/*.css doc/*.gif"
+	einstalldocs
+	newman doc/lua.1 lua${SLOT}.1
+	newman doc/luac.1 luac${SLOT}.1
+	find "${ED}" -name '*.la' -delete || die
+	find "${ED}" -name 'liblua*.a' -delete || die
+}
+
+# Makefile contains a dummy target that doesn't do tests
+# but causes issues with slotted lua (bug #510360)
+src_test() {
+	debug-print-function ${FUNCNAME} "$@"
+	cd "${WORKDIR}/lua-${TEST_PV}-tests" || die
+	# https://www.lua.org/tests/
+	# There are two sets:
+	# basic
+	# complete.
+	#
+	# The basic subset is selected by passing -e'_U=true'
+	# The complete set is noted to contain tests that may consume too much memory or have non-portable tests.
+	# attrib.lua for example needs some multilib customization (have to compile the stuff in libs/ for each ABI)
+	TEST_OPTS="$(usex test-complete '' '-e_U=true')"
+	TEST_MARKER="${T}/test.failed"
+	rm -f "${TEST_MARKER}"
+
+	# If we are failing, set the marker file, and only check it after done all ABIs
+	abi_src_test() {
+		debug-print-function ${FUNCNAME} "$@"
+		TEST_LOG="${T}/test.${MULTIBUILD_ID}.log"
+		eval "${BUILD_DIR}"/src/lua${SLOT} ${TEST_OPTS} all.lua 2>&1 | tee "${TEST_LOG}" || die
+		grep -sq -e "final OK" "${TEST_LOG}" || echo "FAIL ${MULTIBUILD_ID}" >>"${TEST_MARKER}"
+		return 0
+	}
+
+	multilib_foreach_abi abi_src_test
+
+	if [ -e "${TEST_MARKER}" ]; then
+		cat "${TEST_MARKER}"
+		die "Tests failed"
+	fi
+}
+
+pkg_postinst() {
+	eselect lua set --if-unset "${PN}${SLOT}"
+
+	if has_version "app-editor/emacs"; then
+		if ! has_version "app-emacs/lua-mode"; then
+			einfo "Install app-emacs/lua-mode for lua support for emacs"
+		fi
+	fi
+}

--- a/dev-lang/lua/lua-5.4.2-r2.ebuild
+++ b/dev-lang/lua/lua-5.4.2-r2.ebuild
@@ -1,0 +1,203 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+inherit autotools multilib multilib-minimal portability toolchain-funcs
+
+DESCRIPTION="A powerful light-weight programming language designed for extending applications"
+HOMEPAGE="https://www.lua.org/"
+TEST_PV="5.4.2"
+TEST_P="${PN}-${TEST_PV}-tests"
+SRC_URI="
+	https://www.lua.org/ftp/${P}.tar.gz
+	test? ( https://www.lua.org/tests/${TEST_P}.tar.gz )"
+
+LICENSE="MIT"
+SLOT="5.4"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+IUSE="+deprecated readline test test-complete"
+
+COMMON_DEPEND="
+	>=app-eselect/eselect-lua-3
+	readline? ( sys-libs/readline:0= )
+	!dev-lang/lua:0"
+# Cross-compiling note:
+# Must use libtool from the target system (DEPEND) because
+# libtool from the build system (BDEPEND) is for building
+# native binaries.
+DEPEND="
+	${COMMON_DEPEND}
+	sys-devel/libtool"
+RDEPEND="${COMMON_DEPEND}"
+
+RESTRICT="!test? ( test )"
+
+MULTILIB_WRAPPED_HEADERS=(
+	/usr/include/lua${SLOT}/luaconf.h
+)
+
+PATCHES=(
+	"${FILESDIR}"/lua-5.4.2-make.patch
+)
+
+src_prepare() {
+	default
+	# use glibtool on Darwin (versus Apple libtool)
+	if [[ ${CHOST} == *-darwin* ]] ; then
+		sed -i -e '/LIBTOOL = /s:/libtool:/glibtool:' \
+			Makefile src/Makefile || die
+	fi
+
+	# correct lua versioning
+	sed -i -e 's/\(LIB_VERSION = \)6:1:1/\10:0:0/' src/Makefile || die
+
+	sed -i -e 's:\(/README\)\("\):\1.gz\2:g' doc/readme.html || die
+
+	# Using dynamic linked lua is not recommended for performance
+	# reasons. http://article.gmane.org/gmane.comp.lang.lua.general/18519
+	# Mainly, this is of concern if your arch is poor with GPRs, like x86
+	# Note that this only affects the interpreter binary (named lua), not the lua
+	# compiler (built statically) nor the lua libraries.
+
+	# upstream does not use libtool, but we do (see bug #336167)
+	cp "${FILESDIR}/configure.in" "${S}/configure.ac" || die
+	eautoreconf
+
+	# custom Makefiles
+	multilib_copy_sources
+}
+
+multilib_src_configure() {
+	sed -i \
+		-e 's:\(define LUA_ROOT\s*\).*:\1"'${EPREFIX}'/usr/":' \
+		-e "s:\(define LUA_CDIR\s*LUA_ROOT \"\)lib:\1$(get_libdir):" \
+		src/luaconf.h \
+	|| die "failed patching luaconf.h"
+
+	econf
+}
+
+multilib_src_compile() {
+	tc-export CC
+
+	# what to link to liblua
+	liblibs="-lm"
+	liblibs="${liblibs} $(dlopen_lib)"
+
+	# what to link to the executables
+	mylibs=
+	use readline && mylibs="-lreadline"
+
+	cd src
+
+	local myCFLAGS=""
+	use deprecated && myCFLAGS+="-DLUA_COMPAT_5_3 "
+	use readline && myCFLAGS+="-DLUA_USE_READLINE "
+
+	case "${CHOST}" in
+		*-mingw*) : ;;
+		*) myCFLAGS+="-DLUA_USE_LINUX " ;;
+	esac
+
+	emake CC="${CC}" CFLAGS="${myCFLAGS} ${CFLAGS}" \
+			SYSLDFLAGS="${LDFLAGS}" \
+			RPATH="${EPREFIX}/usr/$(get_libdir)/" \
+			LUA_LIBS="${mylibs}" \
+			LIB_LIBS="${liblibs}" \
+			V=$(ver_cut 1-2) \
+			LIBTOOL="${ESYSROOT}/usr/bin/libtool" \
+			gentoo_all
+}
+
+multilib_src_install() {
+	emake INSTALL_TOP="${ED}/usr" INSTALL_LIB="${ED}/usr/$(get_libdir)" \
+			V=${SLOT} gentoo_install
+
+	case $SLOT in
+		0)
+			LIBNAME="lua"
+			INCLUDEDIR_SUFFIX=''
+			;;
+		*)	LIBNAME="lua${SLOT}"
+			INCLUDEDIR_SUFFIX="/lua${SLOT}"
+			;;
+	esac
+
+	# We want packages to find our things...
+	# A slotted Lua uses different directories for headers & names for
+	# libraries, and pkgconfig should reflect that.
+	local PATCH_PV=$(ver_cut 1-2)
+	cp "${FILESDIR}/lua.pc" "${WORKDIR}" || die
+	sed -r -i \
+		-e "/^INSTALL_INC=/s,(/include)$,\1/lua${SLOT}," \
+		-e "s:^prefix= :prefix= ${EPREFIX}:" \
+		-e "s:^V=.*:V= ${PATCH_PV}:" \
+		-e "s:^R=.*:R= ${PV}:" \
+		-e "s:/,lib,:/$(get_libdir):g" \
+		-e "/^Libs:/s:( )(-llua)($| ):\1-l${LIBNAME}\3:" \
+		-e "/^includedir=/s:include$:include${INCLUDEDIR_SUFFIX}:" \
+		"${WORKDIR}/lua.pc" || die
+
+	insinto "/usr/$(get_libdir)/pkgconfig"
+	newins "${WORKDIR}/lua.pc" "lua${SLOT}.pc"
+	# Copy Debian's symlink support:
+	# https://salsa.debian.org/lua-team/lua5.3/blob/master/debian/rules#L19
+	# FreeBSD calls the pkgconfig 'lua-5.3.pc'
+	# Older systems called it 'lua53.pc'
+	dosym "lua${SLOT}.pc" "/usr/$(get_libdir)/pkgconfig/lua-${SLOT}.pc"
+	dosym "lua${SLOT}.pc" "/usr/$(get_libdir)/pkgconfig/lua${SLOT/.}.pc"
+}
+
+multilib_src_install_all() {
+	DOCS="README"
+	HTML_DOCS="doc/*.html doc/*.png doc/*.css doc/*.gif"
+	einstalldocs
+	newman doc/lua.1 lua${SLOT}.1
+	newman doc/luac.1 luac${SLOT}.1
+	find "${ED}" -name '*.la' -delete || die
+	find "${ED}" -name 'liblua*.a' -delete || die
+}
+
+# Makefile contains a dummy target that doesn't do tests
+# but causes issues with slotted lua (bug #510360)
+src_test() {
+	debug-print-function ${FUNCNAME} "$@"
+	cd "${WORKDIR}/lua-${TEST_PV}-tests" || die
+	# https://www.lua.org/tests/
+	# There are two sets:
+	# basic
+	# complete.
+	#
+	# The basic subset is selected by passing -e'_U=true'
+	# The complete set is noted to contain tests that may consume too much memory or have non-portable tests.
+	# attrib.lua for example needs some multilib customization (have to compile the stuff in libs/ for each ABI)
+	TEST_OPTS="$(usex test-complete '' '-e_U=true')"
+	TEST_MARKER="${T}/test.failed"
+	rm -f "${TEST_MARKER}"
+
+	# If we are failing, set the marker file, and only check it after done all ABIs
+	abi_src_test() {
+		debug-print-function ${FUNCNAME} "$@"
+		TEST_LOG="${T}/test.${MULTIBUILD_ID}.log"
+		eval "${BUILD_DIR}"/src/lua${SLOT} ${TEST_OPTS} all.lua 2>&1 | tee "${TEST_LOG}" || die
+		grep -sq -e "final OK" "${TEST_LOG}" || echo "FAIL ${MULTIBUILD_ID}" >>"${TEST_MARKER}"
+		return 0
+	}
+
+	multilib_foreach_abi abi_src_test
+
+	if [ -e "${TEST_MARKER}" ]; then
+		cat "${TEST_MARKER}"
+		die "Tests failed"
+	fi
+}
+
+pkg_postinst() {
+	eselect lua set --if-unset "${PN}${SLOT}"
+
+	if has_version "app-editor/emacs"; then
+		if ! has_version "app-emacs/lua-mode"; then
+			einfo "Install app-emacs/lua-mode for lua support for emacs"
+		fi
+	fi
+}


### PR DESCRIPTION
Using libtool from build system picks the wrong linker:

    /usr/bin/libtool --quiet --tag=CC --mode=link
    arm-unknown-linux-gnueabihf-gcc -version-info 0:0:0 \
                -rpath /usr/lib/ -Wl,--as-needed -fno-lto  -o
                liblua5.4.la lapi.lo lcode.lo lctype.lo ldebug.lo ldo.lo
                ldump.lo lfunc.lo lgc.lo llex.lo lmem.lo lobject.lo
                lopcodes.lo lparser.lo lstate.lo lstring.lo ltable.lo
                ltm.lo lundump.lo lvm.lo lzio.lo lauxlib.lo lbaselib.lo
                lcorolib.lo ldblib.lo liolib.lo lmathlib.lo loadlib.lo
                loslib.lo lstrlib.lo ltablib.lo lutf8lib.lo linit.lo -lm
                -ldl
    /usr/lib/gcc/x86_64-pc-linux-gnu/11.2.1/../../../../x86_64-pc-linux-gnu/bin/ld:
    .libs/lapi.o: relocations in generic ELF (EM: 40)
    /usr/lib/gcc/x86_64-pc-linux-gnu/11.2.1/../../../../x86_64-pc-linux-gnu/bin/ld:
    .libs/lapi.o: error adding symbols: file in wrong format
    collect2: error: ld returned 1 exit status

This patch doesn't modify the makefile, just overrides LIBTOOL during the make
invocation. It uses EROOT which according to ebuild(5) includes the prefix. It
also makes libtool a DEPEND rather than a BDEPEND which should satisfy [#739764](https://bugs.gentoo.org/739764)
(right?).

AFAICT you can't tell libtool "use this other compiler". Even if it sees
`libtool --mode=link arm-gcc ...` it won't deduce that it should `arm-ld
...`. The libtool in the host will though.

This patch makes the same change to the 5.1, 5.3, and 5.4 versions in a new revision:

```patch
--- lua-5.1.5-r106.ebuild       2022-01-29 11:31:34.407974578 -0800
+++ lua-5.1.5-r107.ebuild       2022-01-29 12:22:42.079920921 -0800
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -10,16 +10,17 @@
 
 LICENSE="MIT"
 SLOT="5.1"
-KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 IUSE="+deprecated readline"
 
 COMMON_DEPEND="
        >=app-eselect/eselect-lua-3
        readline? ( >=sys-libs/readline-6.2_p5-r1:0=[${MULTILIB_USEDEP}] )
        !dev-lang/lua:0"
-DEPEND="${COMMON_DEPEND}"
+DEPEND="
+       ${COMMON_DEPEND}
+       sys-devel/libtool"
 RDEPEND="${COMMON_DEPEND}"
-BDEPEND="sys-devel/libtool"
 
 MULTILIB_WRAPPED_HEADERS=(
        /usr/include/lua${SLOT}/luaconf.h
@@ -101,6 +102,7 @@
                        LUA_LIBS="${mylibs}" \
                        LIB_LIBS="${liblibs}" \
                        V=$(ver_cut 1-2) \
+                       LIBTOOL="${EROOT%/}/usr/bin/libtool" \
                        gentoo_all
 
        mv lua_test ../test/lua.static
```
