### PR TITLE
profiles/features/musl: mask net-im/mattermost-desktop-bin

### DIFF
--- a/profiles/features/musl/package.mask
+++ b/profiles/features/musl/package.mask
@@ -1,6 +1,10 @@
 # Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Viorel Munteanu <ceamac.paragon@gmail.com> (2022-02-01)
+# Binary package linked to glibc
+net-im/mattermost-desktop-bin
+
 # Ulrich Müller <ulm@gentoo.org> (2022-01-25)
 # Binary package linked to glibc
 media-gfx/brscan4


### PR DESCRIPTION
Mask binary package linked against glibc on musl profile