### PR TITLE
Update zen-sources to version 5.16.5, current in repo is out of date

### DIFF
--- a/sys-kernel/zen-sources/zen-sources-5.16.5.ebuild
+++ b/sys-kernel/zen-sources/zen-sources-5.16.5.ebuild
@@ -1,0 +1,40 @@
+EAPI="8"
+ETYPE="sources"
+K_WANT_GENPATCHES="base extras"
+K_GENPATCHES_VER="1"
+K_SECURITY_UNSUPPORTED="1"
+K_NOSETEXTRAVERSION="1"
+
+inherit kernel-2
+detect_version
+detect_arch
+
+KEYWORDS="~amd64 ~arm64 ~x86"
+HOMEPAGE="https://github.com/zen-kernel"
+IUSE=""
+
+DESCRIPTION="The Zen Kernel Live Sources"
+
+ZEN_URI="https://github.com/zen-kernel/zen-kernel/releases/download/v${PV}-zen1/v${PV}-zen1.patch.xz"
+SRC_URI="${KERNEL_URI} ${GENPATCHES_URI} ${ARCH_URI} ${ZEN_URI}"
+
+UNIPATCH_LIST="${DISTDIR}/v${PV}-zen1.patch.xz"
+UNIPATCH_STRICTORDER="yes"
+
+K_EXTRAEINFO="For more info on zen-sources, and for how to report problems, see: \
+${HOMEPAGE}, also go to #zen-sources on oftc"
+
+pkg_setup() {
+	ewarn
+	ewarn "${PN} is *not* supported by the Gentoo Kernel Project in any way."
+	ewarn "If you need support, please contact the zen developers directly."
+	ewarn "Do *not* open bugs in Gentoo's bugzilla unless you have issues with"
+	ewarn "the ebuilds. Thank you."
+	ewarn
+	kernel-2_pkg_setup
+}
+
+pkg_postrm() {
+	kernel-2_pkg_postrm
+}
+

--- a/sys-kernel/zen-sources/zen-sources-5.16.5.ebuild
+++ b/sys-kernel/zen-sources/zen-sources-5.16.5.ebuild
@@ -1,3 +1,6 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
 EAPI="8"
 ETYPE="sources"
 K_WANT_GENPATCHES="base extras"


### PR DESCRIPTION
Hello, this is a new contributor here. I have found a discrepancy in versioning. You see, the Zen Kernel team has made a new release, v5.16.5. The release happened 2 hours ago, hence the repo is out of date. Zen kernel users need to be considered here. The kernel they are using had a new release. So the time has come for a version bump.