### PR TITLE
python-utils-r1: python_has_version helper

### DIFF
--- a/dev-libs/libwacom/libwacom-1.12.ebuild
+++ b/dev-libs/libwacom/libwacom-1.12.ebuild
@@ -35,9 +35,10 @@ BDEPEND="
 "
 
 python_check_deps() {
-	has_version -b "dev-python/python-libevdev[${PYTHON_USEDEP}]" &&
-	has_version -b "dev-python/pyudev[${PYTHON_USEDEP}]" &&
-	has_version -b "dev-python/pytest[${PYTHON_USEDEP}]"
+	python_has_version \
+		"dev-python/python-libevdev[${PYTHON_USEDEP}]" \
+		"dev-python/pyudev[${PYTHON_USEDEP}]" \
+		"dev-python/pytest[${PYTHON_USEDEP}]"
 }
 
 pkg_setup() {

--- a/eclass/distutils-r1.eclass
+++ b/eclass/distutils-r1.eclass
@@ -424,11 +424,9 @@ distutils_enable_sphinx() {
 		python_check_deps() {
 			use doc || return 0
 
-			local hasv_args=( -b )
-			[[ ${EAPI} == 6 ]] && hasv_args=( --host-root )
 			local p
 			for p in dev-python/sphinx "${_DISTUTILS_SPHINX_PLUGINS[@]}"; do
-				has_version "${hasv_args[@]}" "${p}[${PYTHON_USEDEP}]" ||
+				python_has_version "${p}[${PYTHON_USEDEP}]" ||
 					return 1
 			done
 		}

--- a/eclass/python-utils-r1.eclass
+++ b/eclass/python-utils-r1.eclass
@@ -1397,5 +1397,47 @@ _python_run_check_deps() {
 	eend ${?}
 }
 
+# @FUNCTION: python_has_version
+# @USAGE: [-b|-d|-r] <atom>...
+# @DESCRIPTION:
+# A convenience wrapper for has_version() with verbose output and better
+# defaults for use in python_check_deps().
+#
+# The wrapper accepts EAPI 7+-style -b/-d/-r options to indicate
+# the root to perform the lookup on.  Unlike has_version, the default
+# is -b.  In EAPI 6, -b and -d are translated to --host-root
+# for compatibility.
+#
+# The wrapper accepts multiple package specifications.  For the check
+# to succeed, *all* specified atoms must match.
+python_has_version() {
+	debug-print-function ${FUNCNAME} "${@}"
+
+	local root_arg=( -b )
+	case ${1} in
+		-b|-d|-r)
+			root_arg=( "${1}" )
+			shift
+			;;
+	esac
+
+	if [[ ${EAPI} == 6 ]]; then
+		if [[ ${root_arg} == -r ]]; then
+			root_arg=()
+		else
+			root_arg=( --host-root )
+		fi
+	fi
+
+	local pkg
+	for pkg; do
+		ebegin "    ${pkg}"
+		has_version "${root_arg[@]}" "${pkg}"
+		eend ${?} || return
+	done
+
+	return 0
+}
+
 _PYTHON_UTILS_R1=1
 fi


### PR DESCRIPTION
The rough idea is to collect as much as possible in one batch, to avoid more cache regens in the neat time.

So far, besides various cleanups and refactorings:
1. New `distutils_pep517_installer` helper, for special cases where we need to install additional packages.
2. Much more verbosity in any-r1-style interpreter choice, to help users understand what's happening.
3. `python_has_version` wrapper with verbose output suitable for the above.
4. Regression fix for `build_sphinx`.
5. stdlib version matching for `python_gen*` and `python_setup`.

Will explain in greater detail when I send the patches to the ml.

CC @gentoo/python 