### PR TITLE
net-im/bitlbee: enable py3.10, disable py3.7 and EAPI bump in live ebuild

### DIFF
--- a/net-im/bitlbee/bitlbee-3.6-r1.ebuild
+++ b/net-im/bitlbee/bitlbee-3.6-r1.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{7..9} )
+PYTHON_COMPAT=( python3_{7..10} )
 
 inherit python-any-r1 systemd toolchain-funcs
 

--- a/net-im/bitlbee/bitlbee-3.6-r1.ebuild
+++ b/net-im/bitlbee/bitlbee-3.6-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{7..10} )
+PYTHON_COMPAT=( python3_{8..10} )
 
 inherit python-any-r1 systemd toolchain-funcs
 

--- a/net-im/bitlbee/bitlbee-9999.ebuild
+++ b/net-im/bitlbee/bitlbee-9999.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 PYTHON_COMPAT=( python3_{7..10} )
 

--- a/net-im/bitlbee/bitlbee-9999.ebuild
+++ b/net-im/bitlbee/bitlbee-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{7..10} )
+PYTHON_COMPAT=( python3_{8..10} )
 
 inherit python-any-r1 systemd toolchain-funcs
 

--- a/net-im/bitlbee/bitlbee-9999.ebuild
+++ b/net-im/bitlbee/bitlbee-9999.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{7..9} )
+PYTHON_COMPAT=( python3_{7..10} )
 
 inherit python-any-r1 systemd toolchain-funcs
 


### PR DESCRIPTION
- enable py3.10 and disable py3.7 in both  `3.6-r1` and live ebuild
- bump to EAPI 8 in live ebuild