### PR TITLE
dev-util/its4: Avoid calling g++ directly + fix build for clang/LLVM toolchain

### DIFF
--- a/dev-util/its4/files/its4-1.1.1-r2-cpp-headers-and-opt-flags.patch
+++ b/dev-util/its4/files/its4-1.1.1-r2-cpp-headers-and-opt-flags.patch
@@ -1,0 +1,43 @@
+From 71d766c506c62aa0ad88836e3c10443b90f46898 Mon Sep 17 00:00:00 2001
+From: Thomas Bracht Laumann Jespersen <t@laumann.xyz>
+Date: Sat, 19 Feb 2022 07:17:17 +0100
+Subject: [PATCH] Adjust configure and Makefile.in
+
+---
+ Makefile.in | 4 ++--
+ configure   | 2 +-
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/Makefile.in b/Makefile.in
+index 564e13c..66fbb31 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -4,10 +4,10 @@ OBJECTS=token.o lex.o main.o scanner.o resultsdb.o vulndb.o handlers.o \
+  $(EXTRA_OBJS)
+ 
+ all:  $(OBJECTS)
+-	$(CC) -o $(PROGNAME) $(OBJECTS)
++	$(CC) $(OPTIMIZATION) $(EXTRA_FLAGS) -o $(PROGNAME) $(OBJECTS)
+ 
+ pure: $(OBJECTS)
+-	purify 	$(CC) -o $(PROGNAME) $(OBJECTS)
++	purify 	$(CC) $(OPTIMIZATION) $(EXTRA_FLAGS) -o $(PROGNAME) $(OBJECTS)
+ 
+ .C.o:
+ 	$(CC) -c -DDATA_DIR=$(INSTALL_DATADIR) $(EXTRA_FLAGS) ${OPTIMIZATION} $<
+diff --git a/configure b/configure
+index e85410f..12626c4 100755
+--- a/configure
++++ b/configure
+@@ -117,7 +117,7 @@ if test -z "${QUIET}"; then exec 5>&1; else exec 5>/dev/null; fi
+ 
+ ###### Can we invoke the compiler?
+ cat >tmp.c <<EOF 
+-#include <iostream.h>
++#include <iostream>
+ int main(){return 0;}
+ EOF
+ if test -n "${CC}"; then
+-- 
+2.34.1
+

--- a/dev-util/its4/files/its4-1.1.1-r2-ensure-spaces-in-string-literals.patch
+++ b/dev-util/its4/files/its4-1.1.1-r2-ensure-spaces-in-string-literals.patch
@@ -1,0 +1,47 @@
+From 2f0f98aff51bad9474671e73aa29080c541ca055 Mon Sep 17 00:00:00 2001
+From: Thomas Bracht Laumann Jespersen <t@laumann.xyz>
+Date: Sat, 19 Feb 2022 07:19:34 +0100
+Subject: [PATCH] Ensure spaces between string literals
+
+---
+ config.C | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/config.C b/config.C
+index 61282e8..c4cf375 100644
+--- a/config.C
++++ b/config.C
+@@ -103,8 +103,8 @@ NEWLINE
+ "         Ignore instances of a particular function name." NEWLINE
+ "         This flag can be used as many times as you like." NEWLINE
+ "  -I, --ignore-file=filename" NEWLINE
+-"         Specify a file to read ignore info from, causing ITS4 to not"NEWLINE
+-"         report instances of those functions.  Each function to ignore"NEWLINE
++"         Specify a file to read ignore info from, causing ITS4 to not" NEWLINE
++"         report instances of those functions.  Each function to ignore" NEWLINE
+ "         should be on its own line." NEWLINE
+ "  -l, --limit=function" NEWLINE
+ "         Tells ITS4 not to scan for any functions, except those" NEWLINE
+@@ -112,7 +112,7 @@ NEWLINE
+ "         times as you want." NEWLINE
+ "  -m, --input-mode"
+ NEWLINE
+-"         Tells ITS4 to print out all non-argv spots at which input can"NEWLINE
++"         Tells ITS4 to print out all non-argv spots at which input can" NEWLINE
+ "         enter.  This option causes some other options to be ignored." NEWLINE
+ "         Most importantly, the regular scan does not happen, no" NEWLINE
+ "         severities are visibly reported, and the cutoff is ignored." NEWLINE
+@@ -347,8 +347,8 @@ void ParseOptions(int argc, char **argv, int &index)
+       case 'o':
+ 	if(!optarg)
+ 	  {
+-	    fprintf(stderr, "Warning: option 'o' needs an argument."NEWLINE);
+-	    fprintf(stderr, "Writing to stdout."NEWLINE);
++	    fprintf(stderr, "Warning: option 'o' needs an argument." NEWLINE);
++	    fprintf(stderr, "Writing to stdout." NEWLINE);
+ 	    continue;
+ 	  }
+ 	SetOutputFile(optarg);
+-- 
+2.34.1
+

--- a/dev-util/its4/its4-1.1.1-r2.ebuild
+++ b/dev-util/its4/its4-1.1.1-r2.ebuild
@@ -22,6 +22,11 @@ src_prepare() {
 	sed -i \
 		-e 's/$(CC) -o/$(CC) $(OPTIMIZATION) $(EXTRA_FLAGS) -o/' \
 		"${S}"/Makefile.in || die
+
+	# Bug 738936 fails to compile with clang/LLVM toolchain
+	sed -i \
+		-e 's/"NEWLINE/" NEWLINE/g'\
+		"${S}"/config.C || die
 	eapply_user
 }
 

--- a/dev-util/its4/its4-1.1.1-r2.ebuild
+++ b/dev-util/its4/its4-1.1.1-r2.ebuild
@@ -15,20 +15,10 @@ KEYWORDS="~amd64 ~ppc ~x86"
 
 S="${WORKDIR}/${PN}"
 
-src_prepare() {
-	sed -i \
-		-e 's,iostream.h,iostream,g'\
-		"${S}"/configure || die
-	sed -i \
-		-e 's/$(CC) -o/$(CC) $(OPTIMIZATION) $(EXTRA_FLAGS) -o/' \
-		"${S}"/Makefile.in || die
-
-	# Bug 738936 fails to compile with clang/LLVM toolchain
-	sed -i \
-		-e 's/"NEWLINE/" NEWLINE/g'\
-		"${S}"/config.C || die
-	eapply_user
-}
+PATCHES=(
+	"${FILESDIR}/${PN}-1.1.1-r2-cpp-headers-and-opt-flags.patch"
+	"${FILESDIR}/${PN}-1.1.1-r2-ensure-spaces-in-string-literals.patch" # bug 738936
+)
 
 src_configure() {
 	# WARNING

--- a/dev-util/its4/its4-1.1.1-r2.ebuild
+++ b/dev-util/its4/its4-1.1.1-r2.ebuild
@@ -1,0 +1,43 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs
+
+DESCRIPTION="ITS4: Software Security Tool"
+HOMEPAGE="http://www.cigital.com/its4/"
+SRC_URI="https://dev.gentoo.org/~robbat2/distfiles/${P}.tgz"
+
+LICENSE="ITS4"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86"
+
+S="${WORKDIR}/${PN}"
+
+src_prepare() {
+	sed -i \
+		-e 's,iostream.h,iostream,g'\
+		"${S}"/configure || die
+	sed -i \
+		-e 's/$(CC) -o/$(CC) $(OPTIMIZATION) $(EXTRA_FLAGS) -o/' \
+		"${S}"/Makefile.in || die
+	eapply_user
+}
+
+src_configure() {
+	# WARNING
+	# non-standard configure
+	# do NOT use econf
+	./configure --with-cpp=$(tc-getCXX) --prefix=/usr --mandir=/usr/share/man --datadir=/usr/share/its4 || die "configure failed"
+}
+
+src_compile() {
+	emake CC="$(tc-getCXX)" OPTIMIZATION="${CXXFLAGS}" EXTRA_FLAGS="${LDFLAGS}"
+}
+
+src_install() {
+	# WARNING
+	# non-standard, do NOT use einstall or 'make install DESTDIR=...'
+	make install INSTALL_BINDIR="${D}/usr/bin" INSTALL_MANDIR="${D}/usr/share/man" INSTALL_DATADIR="${D}/usr/share/its4" || die "install failed"
+}


### PR DESCRIPTION
This revbump accomplishes two things:

 * Bump EAPI=8 from 5. The biggest change is adding `eapply_user` in
   `src_prepare()`

 * Use `--with-cpp` argument for call to `./configure`, so the script
   doesn't try to find a compiler

Signed-off-by: Thomas Bracht Laumann Jespersen <t@laumann.xyz>
Closes: https://bugs.gentoo.org/724268
Package-Manager: Portage-3.0.30, Repoman-3.0.3

---

The config.C file has five instances of string literals being
immediately followed by NEWLINE (a macro that expands to another string
literal). C++11 requires a space between string literals.

Signed-off-by: Thomas Bracht Laumann Jespersen <t@laumann.xyz>
Closes: https://bugs.gentoo.org/738936
Package-Manager: Portage-3.0.30, Repoman-3.0.3