### PR TITLE
dev-util/qdevicemonitor: disable warnings as errors

### DIFF
--- a/dev-util/qdevicemonitor/files/qdevicemonitor-1.0.1-disable-warnings-as-errors.patch
+++ b/dev-util/qdevicemonitor/files/qdevicemonitor-1.0.1-disable-warnings-as-errors.patch
@@ -1,0 +1,31 @@
+From 06c05271298c5cc76d6bc65747928928f202dd9d Mon Sep 17 00:00:00 2001
+From: Alexander Lopatin <alopatindev@gmail.com>
+Date: Fri, 4 Feb 2022 02:59:59 +0300
+Subject: [PATCH] Disable warnings as errors https://bugs.gentoo.org/751349
+ https://bugs.gentoo.org/831575
+
+---
+ qdevicemonitor/qdevicemonitor.pro | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/qdevicemonitor/qdevicemonitor.pro b/qdevicemonitor/qdevicemonitor.pro
+index e76d266..6aa2ecf 100644
+--- a/qdevicemonitor/qdevicemonitor.pro
++++ b/qdevicemonitor/qdevicemonitor.pro
+@@ -61,11 +61,11 @@ FORMS += \
+ 
+ CONFIG += c++11 link_pkgconfig
+ 
+-QMAKE_CXXFLAGS += -Werror -Wfatal-errors -pedantic-errors -pedantic -Wextra -Wall
++QMAKE_CXXFLAGS += -pedantic-errors -pedantic -Wextra -Wall
+ QMAKE_CXXFLAGS_RELEASE -= -O2
+ QMAKE_CXXFLAGS_RELEASE += -O3
+ 
+-QMAKE_CFLAGS += -Werror -Wfatal-errors -pedantic-errors -pedantic -Wextra -Wall -std=c11
++QMAKE_CFLAGS += -pedantic-errors -pedantic -Wextra -Wall -std=c11
+ QMAKE_CFLAGS_RELEASE -= -O2
+ QMAKE_CFLAGS_RELEASE += -O3
+ 
+-- 
+2.34.1
+

--- a/dev-util/qdevicemonitor/qdevicemonitor-1.0.1-r2.ebuild
+++ b/dev-util/qdevicemonitor/qdevicemonitor-1.0.1-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -33,6 +33,7 @@ PATCHES=(
 	"${FILESDIR}"/${P}-crash-after-fresh-install.patch
 	"${FILESDIR}"/${P}-screen-geometry-is-deprecated.patch
 	"${FILESDIR}"/${P}-endl-is-deprecated.patch
+	"${FILESDIR}"/${P}-disable-warnings-as-errors.patch
 )
 
 src_configure() {


### PR DESCRIPTION
Package-Manager: Portage-3.0.30, Repoman-3.0.2
Closes: https://bugs.gentoo.org/751349
Closes: https://bugs.gentoo.org/831575