### PR TITLE
sci-libs/vtk: let v9 build against ffmpeg-5

### DIFF
--- a/sci-libs/vtk/files/vtk-9.0.3-IO-FFMPEG-support-FFmpeg-5.0-API-changes.patch
+++ b/sci-libs/vtk/files/vtk-9.0.3-IO-FFMPEG-support-FFmpeg-5.0-API-changes.patch
@@ -1,0 +1,141 @@
+From https://gitlab.kitware.com/ben.boeckel/vtk/-/commit/bad8f3e9d0aad03e8f2aff9524cb3c5f2d10ccaf
+From: Ben Boeckel <ben.boeckel@kitware.com>
+Date: Fri, 28 Jan 2022 10:44:28 -0500
+Subject: [PATCH] IO/FFMPEG: support FFmpeg 5.0 API changes
+
+Fixes: #18445
+--- /dev/null
++++ b/Documentation/release/dev/ffmpeg-5.0.md
+@@ -0,0 +1,3 @@
++## FFmpeg 5.0 support
++
++FFmpeg 5.0 API changes are now supported.
+--- a/IO/FFMPEG/CMakeLists.txt
++++ b/IO/FFMPEG/CMakeLists.txt
+@@ -6,7 +6,9 @@ vtk_module_find_package(
+     avformat
+     avcodec
+     avutil
+-    swscale)
++    swscale
++  OPTIONAL_COMPONENTS
++    swresample)
+ 
+ set(classes
+   vtkFFMPEGWriter)
+@@ -21,6 +23,17 @@ if (NOT FFMPEG_VERSION VERSION_LESS "3.1")
+     vtkFFMPEGVideoSource)
+ endif ()
+ 
++set(ffmpeg_libraries)
++if (NOT FFMPEG_VERSION VERSION_LESS "5.0")
++  if (NOT FFMPEG_swresample_FOUND)
++    message(FATAL_ERROR
++      "FFMPEG 5.0 requires the `swresample` library.")
++  endif ()
++
++  list(APPEND ffmpeg_libraries
++    FFMPEG::swresample)
++endif ()
++
+ vtk_module_add_module(VTK::IOFFMPEG
+   CLASSES ${classes})
+ vtk_module_link(VTK::IOFFMPEG
+@@ -28,4 +41,5 @@ vtk_module_link(VTK::IOFFMPEG
+     FFMPEG::avformat
+     FFMPEG::avcodec
+     FFMPEG::avutil
+-    FFMPEG::swscale)
++    FFMPEG::swscale
++    ${ffmpeg_libraries})
+--- a/IO/FFMPEG/vtkFFMPEGVideoSource.cxx
++++ b/IO/FFMPEG/vtkFFMPEGVideoSource.cxx
+@@ -205,7 +205,7 @@ void vtkFFMPEGVideoSource::Initialize()
+ 
+   this->Internal->VideoStream = fcontext->streams[this->Internal->VideoStreamIndex];
+ 
+-  AVCodec* dec = avcodec_find_decoder(this->Internal->VideoStream->codecpar->codec_id);
++  const AVCodec* dec = avcodec_find_decoder(this->Internal->VideoStream->codecpar->codec_id);
+   if (!dec)
+   {
+     vtkErrorMacro("Failed to find codec for video");
+@@ -271,7 +271,7 @@ void vtkFFMPEGVideoSource::Initialize()
+   {
+     this->Internal->AudioStream = fcontext->streams[this->Internal->AudioStreamIndex];
+ 
+-    AVCodec* adec = avcodec_find_decoder(this->Internal->AudioStream->codecpar->codec_id);
++    const AVCodec* adec = avcodec_find_decoder(this->Internal->AudioStream->codecpar->codec_id);
+     if (!adec)
+     {
+       vtkErrorMacro("Failed to find codec for audio");
+--- a/IO/FFMPEG/vtkFFMPEGWriter.cxx
++++ b/IO/FFMPEG/vtkFFMPEGWriter.cxx
+@@ -21,10 +21,17 @@
+ 
+ extern "C"
+ {
++#include <libavcodec/avcodec.h>
+ #include <libavformat/avformat.h>
+ #include <libswscale/swscale.h>
+ }
+ 
++#if LIBAVFORMAT_VERSION_MAJOR < 59
++#define vtk_ff_const59
++#else
++#define vtk_ff_const59 const
++#endif
++
+ #if defined(LIBAVFORMAT_VERSION_MAJOR) && LIBAVFORMAT_VERSION_MAJOR >= 57
+ extern "C"
+ {
+@@ -51,7 +58,7 @@ private:
+ 
+   AVFormatContext* avFormatContext;
+ 
+-  AVOutputFormat* avOutputFormat;
++  vtk_ff_const59 AVOutputFormat* avOutputFormat;
+ 
+   AVStream* avStream;
+ 
+@@ -115,15 +122,9 @@ int vtkFFMPEGWriterInternal::Start()
+     return 0;
+   }
+ 
+-  if (this->Writer->GetCompression())
+-  {
+-    // choose a codec that is easily playable on windows
+-    this->avOutputFormat->video_codec = AV_CODEC_ID_MJPEG;
+-  }
+-  else
+-  {
+-    this->avOutputFormat->video_codec = AV_CODEC_ID_RAWVIDEO;
+-  }
++  enum AVCodecID video_codec = this->Writer->GetCompression()
++    ? AV_CODEC_ID_MJPEG // choose a codec that is easily playable on windows
++    : AV_CODEC_ID_RAWVIDEO;
+ 
+   // create the format context that wraps all of the media output structures
+   if (avformat_alloc_output_context2(
+@@ -133,8 +134,8 @@ int vtkFFMPEGWriterInternal::Start()
+     return 0;
+   }
+ 
+-  AVCodec* codec;
+-  if (!(codec = avcodec_find_encoder(this->avOutputFormat->video_codec)))
++  vtk_ff_const59 AVCodec* codec;
++  if (!(codec = avcodec_find_encoder(video_codec)))
+   {
+     vtkGenericWarningMacro(<< "Failed to get video codec.");
+     return 0;
+@@ -155,7 +156,7 @@ int vtkFFMPEGWriterInternal::Start()
+     return 0;
+   }
+ 
+-  this->avStream->codecpar->codec_id = static_cast<AVCodecID>(this->avOutputFormat->video_codec);
++  this->avStream->codecpar->codec_id = video_codec;
+   this->avStream->codecpar->codec_type = AVMEDIA_TYPE_VIDEO;
+   this->avStream->codecpar->width = this->Dim[0];
+   this->avStream->codecpar->height = this->Dim[1];
+-- 
+2.35.1
+

--- a/sci-libs/vtk/vtk-9.0.3-r4.ebuild
+++ b/sci-libs/vtk/vtk-9.0.3-r4.ebuild
@@ -134,6 +134,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-9.0.1-0001-fix-kepler-compute_arch-if-CUDA-toolkit-11-is-used.patch
 	"${FILESDIR}"/${PN}-8.2.0-freetype-2.10.3-provide-FT_CALLBACK_DEF.patch
 	"${FILESDIR}"/${PN}-9.0.1-limits-include-gcc11.patch
+	"${FILESDIR}"/${P}-IO-FFMPEG-support-FFmpeg-5.0-API-changes.patch
 )
 
 DOCS=( CONTRIBUTING.md README.md )

--- a/sci-libs/vtk/vtk-9.1.0.ebuild
+++ b/sci-libs/vtk/vtk-9.1.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -142,6 +142,7 @@ BDEPEND="
 PATCHES=(
 	"${FILESDIR}"/${PN}-9.0.1-0001-fix-kepler-compute_arch-if-CUDA-toolkit-11-is-used.patch
 	"${FILESDIR}"/${PN}-8.2.0-freetype-2.10.3-provide-FT_CALLBACK_DEF.patch
+	"${FILESDIR}"/${PN}-9.0.3-IO-FFMPEG-support-FFmpeg-5.0-API-changes.patch
 )
 
 DOCS=( CONTRIBUTING.md README.md )


### PR DESCRIPTION
Backports an upstream patch to successfully build against
media-video/ffmpeg-5.

Closes: https://bugs.gentoo.org/831595
Closes: https://bugs.gentoo.org/727338
Closes: https://bugs.gentoo.org/660582

Package-Manager: Portage-3.0.30, Repoman-3.0.3
Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>

Upstream CI is still running after 6 days. I've tested to build for both versions against ffmpeg-{4,5}.