### PR TITLE
app-text/mupdf: fixed unconditional BDEPEND

### DIFF
--- a/app-text/mupdf/mupdf-1.19.0.ebuild
+++ b/app-text/mupdf/mupdf-1.19.0.ebuild
@@ -39,7 +39,7 @@ RDEPEND="
 	)
 "
 DEPEND="${RDEPEND}"
-BDEPEND="x11-base/xorg-proto
+BDEPEND="X? ( x11-base/xorg-proto )
 	virtual/pkgconfig"
 
 PATCHES=(


### PR DESCRIPTION
The x11-base/xorg-proto is only needed if the X use flag is enabled.

Closes: https://bugs.gentoo.org/832628
Package-Manager: Portage-3.0.30, Repoman-3.0.3
Signed-off-by: Philipp Rösner <rndxelement@protonmail.com>