### PR TITLE
app-emulation/virt-manager: Follow master branch rename

### DIFF
--- a/app-emulation/virt-manager/virt-manager-9999.ebuild
+++ b/app-emulation/virt-manager/virt-manager-9999.ebuild
@@ -16,7 +16,7 @@ if [[ ${PV} = *9999* ]]; then
 	inherit git-r3
 	SRC_URI=""
 	EGIT_REPO_URI="https://github.com/virt-manager/virt-manager.git"
-	EGIT_BRANCH="master"
+	EGIT_BRANCH="main"
 else
 	SRC_URI="http://virt-manager.org/download/sources/${PN}/${P}.tar.gz"
 	KEYWORDS="~amd64 ~arm64 ~ppc64 ~x86"


### PR DESCRIPTION
The master branch in the project's git was renamed to main [1].
Update our e-build to reflect that.

1: https://listman.redhat.com/archives/virt-tools-list/2022-February/msg00002.html
Signed-off-by: Michal Privoznik <mprivozn@redhat.com>