### PR TITLE
dev-python/virtualenv: PoC on unbundling seed wheels

### DIFF
--- a/dev-python/virtualenv/virtualenv-20.13.0-r1.ebuild
+++ b/dev-python/virtualenv/virtualenv-20.13.0-r1.ebuild
@@ -1,0 +1,138 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DISTUTILS_USE_PEP517=setuptools
+PYTHON_COMPAT=( python3_{8..10} pypy3 )
+
+inherit distutils-r1
+
+DESCRIPTION="Virtual Python Environment builder"
+HOMEPAGE="
+	https://virtualenv.pypa.io/en/stable/
+	https://pypi.org/project/virtualenv/
+	https://github.com/pypa/virtualenv/
+"
+SRC_URI="mirror://pypi/${PN::1}/${PN}/${P}.tar.gz"
+
+LICENSE="MIT"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+SLOT="0"
+
+RDEPEND="
+	>=dev-python/backports-entry_points_selectable-1.0.4[${PYTHON_USEDEP}]
+	>=dev-python/distlib-0.3.1[${PYTHON_USEDEP}]
+	>=dev-python/filelock-3[${PYTHON_USEDEP}]
+	>=dev-python/platformdirs-2[${PYTHON_USEDEP}]
+	>=dev-python/setuptools-41[${PYTHON_USEDEP}]
+	>=dev-python/six-1.9.0[${PYTHON_USEDEP}]
+"
+
+# wheels used to populate the initial virtualenv
+RDEPEND+="
+	>=dev-python/wheel-0.37.1-r2:=[${PYTHON_USEDEP}]
+"
+
+# coverage is used somehow magically in virtualenv, maybe it actually
+# tests something useful
+BDEPEND="
+	dev-python/setuptools_scm[${PYTHON_USEDEP}]
+	test? (
+		dev-python/coverage[${PYTHON_USEDEP}]
+		dev-python/flaky[${PYTHON_USEDEP}]
+		>=dev-python/pip-20.0.2[${PYTHON_USEDEP}]
+		>=dev-python/pytest-freezegun-0.4.1[${PYTHON_USEDEP}]
+		>=dev-python/pytest-mock-2.0.0[${PYTHON_USEDEP}]
+		>=dev-python/pytest-timeout-1.3.4[${PYTHON_USEDEP}]
+		>=dev-python/packaging-20.0[${PYTHON_USEDEP}]
+	)"
+
+# (unpackaged deps)
+#distutils_enable_sphinx docs \
+#	dev-python/sphinx-argparse \
+#	dev-python/sphinx_rtd_theme \
+#	dev-python/towncrier
+distutils_enable_tests pytest
+
+UNBUNDLE_WHEELS=(
+	wheel-0.37.1-py2.py3-none-any.whl
+)
+
+src_prepare() {
+	# replace some of the bundled wheels with the newest system versions
+	local orig_whl
+	local seed_dir=src/virtualenv/seed/wheels/embed
+	for orig_whl in "${UNBUNDLE_WHEELS[@]}"; do
+		rm "${seed_dir}/${orig_whl}" || die
+		local new_whl=(
+			"${BROOT}/usr/lib/virtualenv-seed-wheels/${orig_whl%%-*}"-*
+		)
+		[[ ${#new_whl[@]} -eq 1 ]] ||
+			die "Incorrect number of wheels matched (${#new_whl[@]}): ${new_whl[*]}"
+		ln -s "${new_whl[0]}" "${seed_dir}/" || die
+		# it is valid for this one not to change anything
+		QA_SED=n \
+		sed -e "s:${orig_whl}:${new_whl[0]##*/}:" \
+			-i "${seed_dir}/__init__.py" || die
+	done
+
+	distutils-r1_src_prepare
+	export SETUPTOOLS_SCM_PRETEND_VERSION=${PV}
+}
+
+python_test() {
+	local EPYTEST_DESELECT=(
+		tests/unit/activation/test_xonsh.py
+		tests/unit/seed/embed/test_bootstrap_link_via_app_data.py::test_seed_link_via_app_data
+		tests/unit/create/test_creator.py::test_cross_major
+	)
+	[[ ${EPYTHON} == pypy3 ]] && EPYTEST_DESELECT+=(
+		'tests/unit/create/test_creator.py::test_create_no_seed[root-pypy3-posix-copies-isolated]'
+		'tests/unit/create/test_creator.py::test_create_no_seed[root-pypy3-posix-copies-global]'
+		'tests/unit/create/test_creator.py::test_create_no_seed[venv-pypy3-posix-copies-isolated]'
+		'tests/unit/create/test_creator.py::test_create_no_seed[venv-pypy3-posix-copies-global]'
+		'tests/unit/create/test_creator.py::test_create_no_seed[root-venv-copies-isolated]'
+		'tests/unit/create/test_creator.py::test_create_no_seed[root-venv-copies-global]'
+		'tests/unit/create/test_creator.py::test_create_no_seed[venv-venv-copies-isolated]'
+		'tests/unit/create/test_creator.py::test_create_no_seed[venv-venv-copies-global]'
+		'tests/unit/create/test_creator.py::test_zip_importer_can_import_setuptools'
+		'tests/unit/discovery/py_info/test_py_info_exe_based_of.py::test_discover_ok[PyPy-3.7.9-64-bin-]'
+		'tests/unit/discovery/py_info/test_py_info_exe_based_of.py::test_discover_ok[PyPy-3.7.9--bin-]'
+		'tests/unit/discovery/py_info/test_py_info_exe_based_of.py::test_discover_ok[PyPy-3.7.10-64-bin-]'
+		'tests/unit/discovery/py_info/test_py_info_exe_based_of.py::test_discover_ok[PyPy-3.7.10--bin-]'
+		'tests/unit/discovery/py_info/test_py_info_exe_based_of.py::test_discover_ok[PyPy-3.7-64-bin-]'
+		'tests/unit/discovery/py_info/test_py_info_exe_based_of.py::test_discover_ok[PyPy-3.7--bin-]'
+		'tests/unit/discovery/py_info/test_py_info_exe_based_of.py::test_discover_ok[PyPy-3-64-bin-]'
+		'tests/unit/discovery/py_info/test_py_info_exe_based_of.py::test_discover_ok[PyPy-3--bin-]'
+		'tests/unit/discovery/py_info/test_py_info_exe_based_of.py::test_discover_ok[python-3.7.9-64-bin-]'
+		'tests/unit/discovery/py_info/test_py_info_exe_based_of.py::test_discover_ok[python-3.7.9--bin-]'
+		'tests/unit/discovery/py_info/test_py_info_exe_based_of.py::test_discover_ok[python-3.7.10-64-bin-]'
+		'tests/unit/discovery/py_info/test_py_info_exe_based_of.py::test_discover_ok[python-3.7.10--bin-]'
+		'tests/unit/discovery/py_info/test_py_info_exe_based_of.py::test_discover_ok[python-3.7-64-bin-]'
+		'tests/unit/discovery/py_info/test_py_info_exe_based_of.py::test_discover_ok[python-3.7--bin-]'
+		'tests/unit/discovery/py_info/test_py_info_exe_based_of.py::test_discover_ok[python-3-64-bin-]'
+		'tests/unit/discovery/py_info/test_py_info_exe_based_of.py::test_discover_ok[python-3--bin-]'
+	)
+
+	epytest -x
+}
+
+python_install() {
+	distutils-r1_python_install
+	# replace the wheels copied before with relative symlinks
+	local whl
+	local seed_dir=$(python_get_sitedir)/virtualenv/seed/wheels/embed
+	for whl in "${UNBUNDLE_WHEELS[@]}"; do
+		local target=${seed_dir}/${whl}
+		rm "${D}${target}" || die
+		dosym -r "/usr/lib/virtualenv-seed-wheels/${whl}" \
+			"${target#${EPREFIX}}"
+	done
+}
+
+pkg_postinst() {
+	elog "Please note that while virtualenv package no longer supports"
+	elog "Python 2.7, you can still create py2.7 virtualenvs via:"
+	elog "  $ virtualenv -p 2.7 ..."
+}

--- a/dev-python/wheel/wheel-0.37.1-r2.ebuild
+++ b/dev-python/wheel/wheel-0.37.1-r2.ebuild
@@ -1,0 +1,67 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+# please keep this ebuild at EAPI 7 -- sys-apps/portage dep
+EAPI=7
+
+DISTUTILS_USE_PEP517=flit
+PYTHON_COMPAT=( python3_{8..10} pypy3 )
+inherit distutils-r1
+
+DESCRIPTION="A built-package format for Python"
+HOMEPAGE="https://pypi.org/project/wheel/"
+SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
+SRC_URI="https://github.com/pypa/wheel/archive/${PV}.tar.gz -> ${P}.gh.tar.gz"
+
+LICENSE="MIT"
+SLOT="0/${PV}"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~x64-macos"
+
+RDEPEND="
+	dev-python/packaging[${PYTHON_USEDEP}]"
+BDEPEND="
+	test? (
+		dev-python/setuptools[${PYTHON_USEDEP}]
+	)"
+
+distutils_enable_tests pytest
+
+src_prepare() {
+	sed \
+		-e 's:--cov --cov-config=setup.cfg::g' \
+		-i setup.cfg || die
+
+	# unbundle packaging
+	rm -r src/wheel/vendored || die
+	sed -i -e 's:\.vendored\.::' src/wheel/*.py || die
+
+	distutils-r1_src_prepare
+}
+
+src_configure() {
+	[[ -e pyproject.toml ]] &&
+		die "Upstream added pyproject.toml, recheck"
+	# write a custom pyproject.toml to ease setuptools bootstrap
+	cat > pyproject.toml <<-EOF || die
+		[build-system]
+		requires = ["flit_core >=3.2,<4"]
+		build-backend = "flit_core.buildapi"
+
+		[project]
+		name = "wheel"
+		description = "A built-package format for Python"
+		dynamic = ["version"]
+
+		[project.scripts]
+		wheel = "wheel.cli:main"
+
+		[project.entry-points."distutils.commands"]
+		bdist_wheel = "wheel.bdist_wheel:bdist_wheel"
+	EOF
+}
+
+python_install() {
+	distutils-r1_python_install
+	insinto /usr/lib/virtualenv-seed-wheels
+	doins "${BUILD_DIR}"/wheel/*.whl
+}


### PR DESCRIPTION
virtualenv bundles a number of wheels to bootstrap packages inside the new venv. Let's try to install them as part of Gentoo packages and replace the bundled wheels with our ones (automatically bumping to the newest versions as a result).

We'll still have to keep the old versions for old Pythons though.

CC @gentoo/python 