### PR TITLE
profiles/arch/powerpc/ppc64: move stellarium[webengine] mask to 64le/

### DIFF
--- a/profiles/arch/powerpc/ppc64/64le/package.use.stable.mask
+++ b/profiles/arch/powerpc/ppc64/64le/package.use.stable.mask
@@ -1,6 +1,10 @@
 # Copyright 2019-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Alexey Sokolov <alexey+gentoo@asokolov.org> (2022-02-05)
+# dev-qt/qtwebengine not stable on ppc64 yet
+sci-astronomy/stellarium webengine
+
 # Georgy Yakovlev <gyakovlev@gentoo.org> (2021-05-07)
 # openjfx:8 will never be stabilized
 # openjfx:11 probably will neither

--- a/profiles/arch/powerpc/ppc64/package.use.stable.mask
+++ b/profiles/arch/powerpc/ppc64/package.use.stable.mask
@@ -17,10 +17,6 @@
 
 #--- END OF EXAMPLES ---
 
-# Alexey Sokolov <alexey+gentoo@asokolov.org> (2022-02-05)
-# dev-qt/qtwebengine not stable on ppc64 yet
-sci-astronomy/stellarium webengine
-
 # Marek Szuba <marecki@gentoo.org> (2021-12-31)
 # No stable dev-ruby/{thor,tty-editor} on this arch yet
 # and there are many dependencies to go through before there are


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/832728
Signed-off-by: Alexey Sokolov <alexey+gentoo@asokolov.org>