### PR TITLE
profiles/arch/alpha: drop py3.10 masks

### DIFF
--- a/profiles/arch/alpha/use.mask
+++ b/profiles/arch/alpha/use.mask
@@ -15,8 +15,6 @@ nftables
 # Unresolved keywordreqs are getting in the way.
 # https://bugs.gentoo.org/773451
 # https://bugs.gentoo.org/789606
-python_targets_python3_10
-python_single_target_python3_10
 
 # Andreas Sturmlechner <asturm@gentoo.org> (2020-11-12)
 # media-sound/jack-audio-connection-kit re-keywording timeout, bug #736725


### PR DESCRIPTION
Signed-off-by: Sam James <sam@gentoo.org>