### PR TITLE
sci-electronics/kicad-packages3d: Drop sci-libs/oce support

### DIFF
--- a/sci-electronics/kicad-packages3d/kicad-packages3d-5.1.12-r1.ebuild
+++ b/sci-electronics/kicad-packages3d/kicad-packages3d-5.1.12-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -12,11 +12,9 @@ SRC_URI="https://gitlab.com/kicad/libraries/kicad-packages3D/-/archive/${PV}/kic
 LICENSE="CC-BY-SA-4.0"
 SLOT="0"
 KEYWORDS="~amd64 ~arm64"
-IUSE="occ +oce"
+IUSE="+occ"
 
-REQUIRED_USE="|| ( occ oce )"
-
-RDEPEND=">=sci-electronics/kicad-5.1.0[occ=,oce(-)=]"
+RDEPEND=">=sci-electronics/kicad-5.1.0[occ=]"
 
 CHECKREQS_DISK_BUILD="11G"
 S="${WORKDIR}/${P/3d/3D}"

--- a/sci-electronics/kicad-packages3d/metadata.xml
+++ b/sci-electronics/kicad-packages3d/metadata.xml
@@ -19,9 +19,6 @@
 		<flag name="occ">
 			Use <pkg>sci-libs/opencascade</pkg> for data exchange
 		</flag>
-		<flag name="oce">
-			Use <pkg>sci-libs/oce</pkg> for data exchange
-		</flag>
 	</use>
 	<upstream>
 		<remote-id type="github">kicad/kicad-packages3d</remote-id>


### PR DESCRIPTION
sci-libs/oce is obsolete and being deprecated. Move people over to
sci-libs/opencascade instead.

Bug: https://bugs.gentoo.org/832625
Package-Manager: Portage-3.0.30, Repoman-3.0.3
Signed-off-by: Zoltan Puskas <zoltan@sinustrom.info>
