### PR TITLE
dev-util/ostree: Removed deletion of 15_ostree script

### DIFF
--- a/dev-util/ostree/ostree-2021.3-r2.ebuild
+++ b/dev-util/ostree/ostree-2021.3-r2.ebuild
@@ -73,6 +73,8 @@ src_configure() {
 	local econfargs=(
 		--enable-man
 		--enable-shared
+		--with-grub2-mkconfig-path=grub-mkconfig
+		--with-modern-grub
 		$(use_with archive libarchive)
 		$(use_with curl)
 		$(use_with dracut)

--- a/dev-util/ostree/ostree-2021.3-r2.ebuild
+++ b/dev-util/ostree/ostree-2021.3-r2.ebuild
@@ -101,5 +101,4 @@ src_configure() {
 src_install() {
 	default
 	find "${D}" -name '*.la' -delete || die
-	rm -f "${ED}/etc/grub.d/15_ostree"
 }

--- a/dev-util/ostree/ostree-2021.4-r1.ebuild
+++ b/dev-util/ostree/ostree-2021.4-r1.ebuild
@@ -102,5 +102,4 @@ src_configure() {
 src_install() {
 	default
 	find "${D}" -name '*.la' -delete || die
-	rm -f "${ED}/etc/grub.d/15_ostree"
 }

--- a/dev-util/ostree/ostree-2021.4-r1.ebuild
+++ b/dev-util/ostree/ostree-2021.4-r1.ebuild
@@ -74,6 +74,8 @@ src_configure() {
 	local econfargs=(
 		--enable-man
 		--enable-shared
+		--with-grub2-mkconfig-path=grub-mkconfig
+		--with-modern-grub
 		$(use_with archive libarchive)
 		$(use_with curl)
 		$(use_with dracut dracut yesbutnoconf) #816867

--- a/dev-util/ostree/ostree-2021.5.ebuild
+++ b/dev-util/ostree/ostree-2021.5.ebuild
@@ -102,5 +102,4 @@ src_configure() {
 src_install() {
 	default
 	find "${D}" -name '*.la' -delete || die
-	rm -f "${ED}/etc/grub.d/15_ostree"
 }

--- a/dev-util/ostree/ostree-2021.5.ebuild
+++ b/dev-util/ostree/ostree-2021.5.ebuild
@@ -74,6 +74,8 @@ src_configure() {
 	local econfargs=(
 		--enable-man
 		--enable-shared
+		--with-grub2-mkconfig-path=grub-mkconfig
+		--with-modern-grub
 		$(use_with archive libarchive)
 		$(use_with curl)
 		$(use_with dracut dracut yesbutnoconf) #816867

--- a/dev-util/ostree/ostree-2022.1.ebuild
+++ b/dev-util/ostree/ostree-2022.1.ebuild
@@ -102,5 +102,4 @@ src_configure() {
 src_install() {
 	default
 	find "${D}" -name '*.la' -delete || die
-	rm -f "${ED}/etc/grub.d/15_ostree"
 }

--- a/dev-util/ostree/ostree-2022.1.ebuild
+++ b/dev-util/ostree/ostree-2022.1.ebuild
@@ -74,6 +74,8 @@ src_configure() {
 	local econfargs=(
 		--enable-man
 		--enable-shared
+		--with-grub2-mkconfig-path=grub-mkconfig
+		--with-modern-grub
 		$(use_with archive libarchive)
 		$(use_with curl)
 		$(use_with dracut dracut yesbutnoconf) #816867


### PR DESCRIPTION
This is essential for Gentoo-based ostree deployments and does nothing on non-ostree installs.