### PR TITLE
dev-db/etcd: fix tmpfile permission for /var/lib

### DIFF
--- a/dev-db/etcd/files/etcd.tmpfiles.d.conf
+++ b/dev-db/etcd/files/etcd.tmpfiles.d.conf
@@ -1,2 +1,2 @@
-d    /var/lib/etcd 0755 etcd etcd - -
+d    /var/lib/etcd 0700 etcd etcd - -
 d    /var/run/etcd 0755 etcd etcd - -


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/761954
Package-Manager: Portage-3.0.30, Repoman-3.0.3
Signed-off-by: Marcos Rodrigues Gonzalez <mrgonzalez1275@gmail.com>