### PR TITLE
dev-php/PEAR-Mail_mimeDecode: add patch for PHP8 compatibility.

### DIFF
--- a/dev-php/PEAR-Mail_mimeDecode/PEAR-Mail_mimeDecode-1.5.6-r3.ebuild
+++ b/dev-php/PEAR-Mail_mimeDecode/PEAR-Mail_mimeDecode-1.5.6-r3.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
 
 inherit php-pear-r2
 
@@ -14,6 +14,10 @@ RESTRICT="!test? ( test )"
 
 RDEPEND=">=dev-php/PEAR-Mail_Mime-1.5.2"
 DEPEND="test? ( ${RDEPEND} dev-php/PEAR-PEAR )"
+
+PATCHES=(
+	"${FILESDIR}/PEAR-Mail_mimeDecode-1.5.6-r3-php8_compat.diff"
+)
 
 src_test() {
 	pear run-tests tests || die

--- a/dev-php/PEAR-Mail_mimeDecode/files/PEAR-Mail_mimeDecode-1.5.6-r3-php8_compat.diff
+++ b/dev-php/PEAR-Mail_mimeDecode/files/PEAR-Mail_mimeDecode-1.5.6-r3-php8_compat.diff
@@ -1,0 +1,12 @@
+diff -bru a/Mail/mimeDecode.php b/Mail/mimeDecode.php
+--- a/Mail/mimeDecode.php	2016-08-29 05:04:25.000000000 +0200
++++ b/Mail/mimeDecode.php	2022-02-10 12:25:54.140741592 +0200
+@@ -834,7 +834,7 @@
+ 
+         // Replace encoded characters
+ 		 
+-        $cb = create_function('$matches',  ' return chr(hexdec($matches[0]));');
++        $cb = function($matches) { return chr(hexdec($matches[0])); };
+          
+         $input = preg_replace_callback( '/=([a-f0-9]{2})/i', $cb, $input);
+ 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/833075
Package-Manager: Portage-3.0.30, Repoman-3.0.3
Signed-off-by: Jaco Kroon <jaco@uls.co.za>