### PR TITLE
sci-physics/geant4_vmc: Depend on sci-physics/geant[gdml] for test.

### DIFF
--- a/sci-physics/geant4_vmc/geant4_vmc-6.0.ebuild
+++ b/sci-physics/geant4_vmc/geant4_vmc-6.0.ebuild
@@ -27,7 +27,8 @@ RDEPEND="
 	sci-physics/root:=[c++17,-vmc]
 	>=sci-physics/vmc-2.0:=[c++17]
 	vgm? ( sci-physics/vgm:= )"
-DEPEND="${RDEPEND}"
+DEPEND="${RDEPEND}
+	test? ( >=sci-physics/geant-4.11[gdml] )"
 BDEPEND="doc? ( app-doc/doxygen[dot] )"
 RESTRICT="
 	!examples? ( test )

--- a/sci-physics/geant4_vmc/geant4_vmc-9999.ebuild
+++ b/sci-physics/geant4_vmc/geant4_vmc-9999.ebuild
@@ -27,7 +27,8 @@ RDEPEND="
 	sci-physics/root:=[c++17,-vmc]
 	sci-physics/vmc:=[c++17]
 	vgm? ( sci-physics/vgm:= )"
-DEPEND="${RDEPEND}"
+DEPEND="${RDEPEND}
+	test? ( >=sci-physics/geant-4.11[gdml] )"
 BDEPEND="doc? ( app-doc/doxygen[dot] )"
 RESTRICT="
 	!examples? ( test )


### PR DESCRIPTION
The latest release has added a silent dependency on
`sci-physics/geant[gdml]` for `USE=test`.

Closes: https://bugs.gentoo.org/833117
Package-Manager: Portage-3.0.30, Repoman-3.0.3
Signed-off-by: Oliver Freyermuth <o.freyermuth@googlemail.com>