### PR TITLE
sci-physics/geant4_vmc: Do not compile tests if USE=-test.

### DIFF
--- a/sci-physics/geant4_vmc/files/geant4_vmc-6.0-cmake-g4root-tests.patch
+++ b/sci-physics/geant4_vmc/files/geant4_vmc-6.0-cmake-g4root-tests.patch
@@ -1,0 +1,31 @@
+From 5d25b7fd6d53b620b25bed3a72d739d1644b5731 Mon Sep 17 00:00:00 2001
+From: Oliver Freyermuth <o.freyermuth@googlemail.com>
+Date: Fri, 11 Feb 2022 17:22:13 +0100
+Subject: [PATCH] CMake: Fix G4Root_BUILD_TEST option in main CMakeLists.
+
+The option was not correctly inherited for use by the g4root
+subdirectory. Fixed by:
+- Setting it before add_subdirectory().
+- Storing the value in CACHE (otherwise, not seen in subdirectory).
+
+Pull Request: https://github.com/vmc-project/geant4_vmc/pull/28
+Bug: https://bugs.gentoo.org/833126
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -60,8 +60,8 @@ include(VMCInstallLibDir)
+ #--- Add the packages sources --------------------------------------------------
+ #
+ if(Geant4VMC_BUILD_G4Root)
++  set(G4Root_BUILD_TEST ${Geant4VMC_BUILD_G4Root_TEST} CACHE BOOL "Build G4Root test")
+   add_subdirectory(g4root)
+-  set(G4Root_BUILD_TEST ${Geant4VMC_BUILD_G4Root_TEST})
+ endif(Geant4VMC_BUILD_G4Root)
+ 
+ if(Geant4VMC_BUILD_Geant4VMC)
+-- 
+2.34.1
+

--- a/sci-physics/geant4_vmc/geant4_vmc-6.0-r1.ebuild
+++ b/sci-physics/geant4_vmc/geant4_vmc-6.0-r1.ebuild
@@ -39,6 +39,11 @@ RESTRICT="
 
 DOCS=(history README.md)
 
+PATCHES=(
+	# https://github.com/vmc-project/geant4_vmc/pull/28
+	"${FILESDIR}"/${PN}-6.0-cmake-g4root-tests.patch
+)
+
 src_configure() {
 	local mycmakeargs=(
 		-DGeant4VMC_USE_VGM="$(usex vgm)"
@@ -46,6 +51,7 @@ src_configure() {
 		-DGeant4VMC_USE_G4Root="$(usex g4root)"
 		-DGeant4VMC_BUILD_EXAMPLES="$(usex test)"
 		-DGeant4VMC_INSTALL_EXAMPLES="$(usex examples)"
+		-DGeant4VMC_BUILD_G4Root_TEST="$(usex test)"
 	)
 	cmake_src_configure
 }

--- a/sci-physics/geant4_vmc/geant4_vmc-9999.ebuild
+++ b/sci-physics/geant4_vmc/geant4_vmc-9999.ebuild
@@ -46,6 +46,7 @@ src_configure() {
 		-DGeant4VMC_USE_G4Root="$(usex g4root)"
 		-DGeant4VMC_BUILD_EXAMPLES="$(usex test)"
 		-DGeant4VMC_INSTALL_EXAMPLES="$(usex examples)"
+		-DGeant4VMC_BUILD_G4Root_TEST="$(usex test)"
 	)
 	cmake_src_configure
 }


### PR DESCRIPTION
This fixes upstream's build system to honour enabling/disabling of tests,
and uses the now functional CMake option.
PRed upstream at: https://github.com/vmc-project/geant4_vmc/pull/28

Closes: https://bugs.gentoo.org/833126
Package-Manager: Portage-3.0.30, Repoman-3.0.3
Signed-off-by: Oliver Freyermuth <o.freyermuth@googlemail.com>