### PR TITLE
dev-java/lz4-java: Fix test error with --as-needed in LDFLAGS

### DIFF
--- a/dev-java/lz4-java/files/lz4-java-1.8.0-r1-Makefile
+++ b/dev-java/lz4-java/files/lz4-java-1.8.0-r1-Makefile
@@ -1,0 +1,47 @@
+# Gentoo custom Makefile for the JNI portion of lz4-java
+#
+# Adapted from the logic for target "compile-jni" in build.xml,
+# but uses lz4 installed on the system.  This Makefile respects
+# custom CFLAGS and LDFLAGS settings, whereas build.xml does not.
+
+# Java system properties read by build.xml
+PLATFORM ?= linux
+SRC ?= src
+BUILD ?= build
+JAVA_HOME ?=
+# Requires lz4-java-*-print-os-props.patch
+OS_ARCH := $(shell ant os-props 2>&1 > /dev/null && \
+		grep 'os\.arch=' os.properties | sed -e 's/os\.arch=//')
+
+MKDIR_P = mkdir -p
+
+SRC_DIR := $(SRC)/jni
+OBJS_DIR_PREFIX := $(BUILD)/objects
+OBJS_DIR := $(OBJS_DIR_PREFIX)/$(SRC_DIR)
+OUT_DIR := $(BUILD)/jni/net/jpountz/util/$(PLATFORM)/$(OS_ARCH)
+
+SRC_FILES := $(wildcard $(SRC_DIR)/*.c)
+OBJS := $(addprefix $(OBJS_DIR_PREFIX)/,$(SRC_FILES:.c=.o))
+SONAME = liblz4-java.so
+
+# C compiler arguments may be obtained by running 'ant -v compile-jni',
+# as long as dev-java/cpptasks is in the classpath
+CFLAGS := -fPIC $(CFLAGS)
+
+$(OUT_DIR)/$(SONAME): $(OBJS) | $(OUT_DIR)
+	# '-llz4' must be listed after this package's objects
+	# https://wiki.gentoo.org/wiki/Project:Quality_Assurance/As-needed#Importance_of_linking_order
+	$(CC) $(CFLAGS) -shared $(LDFLAGS) -Wl,-soname,$(SONAME) -o $@ $^ -llz4
+
+$(OBJS_DIR_PREFIX)/%.o: %.c | $(OBJS_DIR)
+	$(CC) $(CFLAGS) -c -o $@ \
+		-I$(JAVA_HOME)/../include -I$(JAVA_HOME)/../include/$(PLATFORM) \
+		-I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/$(PLATFORM) \
+		-I$(BUILD)/jni-headers \
+		$<
+
+$(OUT_DIR):
+	$(MKDIR_P) $@
+
+$(OBJS_DIR):
+	$(MKDIR_P) $@

--- a/dev-java/lz4-java/lz4-java-1.8.0-r1.ebuild
+++ b/dev-java/lz4-java/lz4-java-1.8.0-r1.ebuild
@@ -1,0 +1,101 @@
+# Copyright 2021-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+JAVA_PKG_IUSE="doc source test"
+MAVEN_ID="org.lz4:lz4-java:1.8.0"
+
+inherit java-pkg-2 java-ant-2 toolchain-funcs
+
+DESCRIPTION="LZ4 compression for Java"
+HOMEPAGE="https://github.com/lz4/lz4-java"
+SRC_URI="https://github.com/lz4/lz4-java/archive/refs/tags/${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="Apache-2.0"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~x86"
+
+# Tests require com.carrotsearch.randomizedtesting:junit4-ant, which is yet to
+# be packaged.  Some extra steps are required before running the tests:
+# 1. Download junit4-ant 2.7.x from https://mvnrepository.com/artifact/com.carrotsearch.randomizedtesting/junit4-ant
+# 2. Set EANT_GENTOO_CLASSPATH_EXTRA to the path to junit4-ant-2.7.*.jar
+# 3. ppc64 only: Install test dependencies that are unkeyworded
+# 4. Set ALLOW_TEST="all"
+RESTRICT="test"
+
+CDEPEND="
+	app-arch/lz4:=
+"
+
+# The version requirement on mvel is strict; mvel-2.4.* generates source files
+# incorrectly, which causes build failure of this package
+DEPEND="
+	>=virtual/jdk-1.8:*
+	dev-java/mvel:2.3
+	dev-libs/xxhash
+	test? (
+		dev-java/junit:4
+		!ppc64? (
+			dev-java/randomized-runner:0
+		)
+	)
+	${CDEPEND}
+"
+
+RDEPEND="
+	>=virtual/jre-1.8:*
+	${CDEPEND}
+"
+
+# Ant is only needed to generate JNI headers;
+# the JNI shared object will be built by the custom Makefile
+EANT_BUILD_TARGET="compile-java generate-headers"
+EANT_DOC_TARGET="docs"
+EANT_EXTRA_ARGS="-Djava.io.tmpdir=${T}"
+EANT_TEST_GENTOO_CLASSPATH="randomized-runner"
+
+pkg_setup() {
+	java-pkg-2_pkg_setup
+	local build_only_cp="$(java-pkg_getjars --build-only mvel-2.3)"
+	if [[ -z "${EANT_GENTOO_CLASSPATH_EXTRA}" ]]; then
+		EANT_GENTOO_CLASSPATH_EXTRA="${build_only_cp}"
+	else
+		EANT_GENTOO_CLASSPATH_EXTRA+=":${build_only_cp}"
+	fi
+}
+
+src_prepare() {
+	eapply "${FILESDIR}/${P}-print-os-props.patch"
+	eapply "${FILESDIR}/${P}-skip-ivy.patch"
+	cp "${FILESDIR}/${P}-r1-Makefile" Makefile || die "Failed to copy Makefile"
+	cp "${FILESDIR}/${P}-gentoo-classpath.xml" gentoo-classpath.xml ||
+		die "Failed to copy Gentoo classpath injection XML"
+	java-pkg-2_src_prepare
+	rm -r src/resources || die "Failed to remove pre-built shared libraries"
+}
+
+src_compile() {
+	java-pkg-2_src_compile
+	emake CC="$(tc-getCC)" JAVA_HOME="${JAVA_HOME}"
+	# JNI has already been built by the Makefile at this point
+	# Also pretend cpptasks is available, which is required by build.xml
+	EANT_EXTRA_ARGS+=" -Dcpptasks.available=true -Dskip.jni=true"
+	# Manually call 'ant jar' to include the JNI shared object in JAR
+	eant jar -f "${EANT_BUILD_XML}" ${EANT_EXTRA_ARGS}
+}
+
+src_test() {
+	java-pkg-2_src_test
+}
+
+src_install() {
+	java-pkg_newjar 'dist/${ivy.module}.jar'
+	java-pkg_doso $(find build/jni -name "*.so")
+	use doc && java-pkg_dojavadoc build/docs
+	# Ant project's 'sources' target generates a source JAR rather than a Zip
+	# archive; we simply let java-utils-2.eclass create the source Zip archive
+	# from the same source directories the 'sources' target would access
+	# https://github.com/lz4/lz4-java/blob/1.8.0/build.xml#L323-L330
+	use source && java-pkg_dosrc src/java/* src/java-unsafe/*
+}


### PR DESCRIPTION
After applying the fix described at <https://wiki.gentoo.org/wiki/Project:Quality_Assurance/As-needed#Importance_of_linking_order>, this package can now be built with `--as-needed` in `LDFLAGS`.