### PR TITLE
gui-apps/foot*: fix bad dependency

### DIFF
--- a/gui-apps/foot-terminfo/foot-terminfo-1.11.0-r1.ebuild
+++ b/gui-apps/foot-terminfo/foot-terminfo-1.11.0-r1.ebuild
@@ -12,7 +12,7 @@ LICENSE="MIT"
 SLOT="0"
 KEYWORDS="~amd64"
 
-RDEPEND="!>=sys-libs/ncurses-6.3"
+RDEPEND="!>=sys-libs/ncurses-6.3[-minimal]"
 BDEPEND="sys-libs/ncurses"
 
 src_prepare() {

--- a/gui-apps/foot/foot-1.11.0-r1.ebuild
+++ b/gui-apps/foot/foot-1.11.0-r1.ebuild
@@ -34,7 +34,7 @@ DEPEND="
 RDEPEND="
 	${COMMON_DEPEND}
 	|| (
-		>=sys-libs/ncurses-6.3
+		>=sys-libs/ncurses-6.3[-minimal]
 		~gui-apps/foot-terminfo-${PV}
 	)
 "


### PR DESCRIPTION
ncurses[minimal] does not install foot terminfo, so we need to change to ncurses[-minimal]