### PR TITLE
net-misc/iputils, sys-apps/iproute2, net-firewall/iptables: remove obsolete USE=ipv6

### DIFF
--- a/app-containers/lxd/lxd-4.0.8-r3.ebuild
+++ b/app-containers/lxd/lxd-4.0.8-r3.ebuild
@@ -23,13 +23,13 @@ DEPEND="acct-group/lxd
 	dev-libs/lzo
 	dev-libs/raft[lz4]
 	>=dev-util/xdelta-3.0[lzma(+)]
-	net-dns/dnsmasq[dhcp,ipv6?]
+	net-dns/dnsmasq[dhcp,ipv6(+)?]
 	sys-libs/libcap
 	virtual/udev"
 RDEPEND="${DEPEND}
 	net-firewall/ebtables
-	net-firewall/iptables[ipv6?]
-	sys-apps/iproute2[ipv6?]
+	net-firewall/iptables[ipv6(+)?]
+	sys-apps/iproute2[ipv6(+)?]
 	sys-fs/fuse:*
 	sys-fs/lxcfs
 	sys-fs/squashfs-tools[lzma]

--- a/app-containers/lxd/lxd-4.0.9-r1.ebuild
+++ b/app-containers/lxd/lxd-4.0.9-r1.ebuild
@@ -23,13 +23,13 @@ DEPEND="acct-group/lxd
 	dev-libs/lzo
 	dev-libs/raft[lz4]
 	>=dev-util/xdelta-3.0[lzma(+)]
-	net-dns/dnsmasq[dhcp,ipv6?]
+	net-dns/dnsmasq[dhcp,ipv6(+)?]
 	sys-libs/libcap
 	virtual/udev"
 RDEPEND="${DEPEND}
 	net-firewall/ebtables
-	net-firewall/iptables[ipv6?]
-	sys-apps/iproute2[ipv6?]
+	net-firewall/iptables[ipv6(+)?]
+	sys-apps/iproute2[ipv6(+)?]
 	sys-fs/fuse:*
 	sys-fs/lxcfs
 	sys-fs/squashfs-tools[lzma]

--- a/app-emulation/libvirt/libvirt-7.10.0-r3.ebuild
+++ b/app-emulation/libvirt/libvirt-7.10.0-r3.ebuild
@@ -109,9 +109,9 @@ RDEPEND="
 	sasl? ( dev-libs/cyrus-sasl )
 	selinux? ( >=sys-libs/libselinux-2.0.85 )
 	virt-network? (
-		net-dns/dnsmasq[dhcp,ipv6,script]
+		net-dns/dnsmasq[dhcp,ipv6(+),script]
 		net-firewall/ebtables
-		>=net-firewall/iptables-1.4.10[ipv6]
+		>=net-firewall/iptables-1.4.10[ipv6(+)]
 		net-misc/radvd
 		sys-apps/iproute2[-minimal]
 	)

--- a/app-emulation/libvirt/libvirt-7.7.0-r2.ebuild
+++ b/app-emulation/libvirt/libvirt-7.7.0-r2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{8..10} )
+PYTHON_COMPAT=( python3_{7,8,9} )
 
 inherit meson bash-completion-r1 linux-info python-any-r1 readme.gentoo-r1 tmpfiles verify-sig
 
@@ -16,7 +16,7 @@ if [[ ${PV} = *9999* ]]; then
 else
 	SRC_URI="https://libvirt.org/sources/${P}.tar.xz
 		verify-sig? ( https://libvirt.org/sources/${P}.tar.xz.asc )"
-	KEYWORDS="~amd64 ~arm64 ~ppc64 ~x86"
+	KEYWORDS="amd64 arm64 ~ppc64 x86"
 	SLOT="0/${PV}"
 fi
 
@@ -109,13 +109,13 @@ RDEPEND="
 	sasl? ( dev-libs/cyrus-sasl )
 	selinux? ( >=sys-libs/libselinux-2.0.85 )
 	virt-network? (
-		net-dns/dnsmasq[dhcp,ipv6,script]
+		net-dns/dnsmasq[dhcp,ipv6(+),script]
 		net-firewall/ebtables
-		>=net-firewall/iptables-1.4.10[ipv6]
+		>=net-firewall/iptables-1.4.10[ipv6(+)]
 		net-misc/radvd
 		sys-apps/iproute2[-minimal]
 	)
-	wireshark-plugins? ( net-analyzer/wireshark:= )
+	wireshark-plugins? ( <net-analyzer/wireshark-3.6.0:= )
 	xen? (
 		>=app-emulation/xen-4.9.0
 		app-emulation/xen-tools:=

--- a/app-emulation/libvirt/libvirt-8.0.0-r1.ebuild
+++ b/app-emulation/libvirt/libvirt-8.0.0-r1.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{7,8,9} )
+PYTHON_COMPAT=( python3_{8..10} )
 
 inherit meson bash-completion-r1 linux-info python-any-r1 readme.gentoo-r1 tmpfiles verify-sig
 
@@ -16,7 +16,7 @@ if [[ ${PV} = *9999* ]]; then
 else
 	SRC_URI="https://libvirt.org/sources/${P}.tar.xz
 		verify-sig? ( https://libvirt.org/sources/${P}.tar.xz.asc )"
-	KEYWORDS="amd64 arm64 ~ppc64 x86"
+	KEYWORDS="~amd64 ~arm64 ~ppc64 ~x86"
 	SLOT="0/${PV}"
 fi
 
@@ -109,13 +109,13 @@ RDEPEND="
 	sasl? ( dev-libs/cyrus-sasl )
 	selinux? ( >=sys-libs/libselinux-2.0.85 )
 	virt-network? (
-		net-dns/dnsmasq[dhcp,ipv6,script]
+		net-dns/dnsmasq[dhcp,ipv6(+),script]
 		net-firewall/ebtables
-		>=net-firewall/iptables-1.4.10[ipv6]
+		>=net-firewall/iptables-1.4.10[ipv6(+)]
 		net-misc/radvd
 		sys-apps/iproute2[-minimal]
 	)
-	wireshark-plugins? ( <net-analyzer/wireshark-3.6.0:= )
+	wireshark-plugins? ( net-analyzer/wireshark:= )
 	xen? (
 		>=app-emulation/xen-4.9.0
 		app-emulation/xen-tools:=

--- a/app-emulation/libvirt/libvirt-9999.ebuild
+++ b/app-emulation/libvirt/libvirt-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -109,9 +109,9 @@ RDEPEND="
 	sasl? ( dev-libs/cyrus-sasl )
 	selinux? ( >=sys-libs/libselinux-2.0.85 )
 	virt-network? (
-		net-dns/dnsmasq[dhcp,ipv6,script]
+		net-dns/dnsmasq[dhcp,ipv6(+),script]
 		net-firewall/ebtables
-		>=net-firewall/iptables-1.4.10[ipv6]
+		>=net-firewall/iptables-1.4.10[ipv6(+)]
 		net-misc/radvd
 		sys-apps/iproute2[-minimal]
 	)

--- a/dev-libs/libxml2/libxml2-2.9.12-r5.ebuild
+++ b/dev-libs/libxml2/libxml2-2.9.12-r5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -37,7 +37,7 @@ SLOT="2"
 # Dropped keywords for now because it's a minor LDFLAGS fix, and it will ease upgrades
 # bug #802210
 KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
-IUSE="debug examples icu ipv6 lzma +python readline static-libs test"
+IUSE="debug examples icu lzma +python readline static-libs test"
 RESTRICT="!test? ( test )"
 REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
 
@@ -148,11 +148,11 @@ multilib_src_configure() {
 
 	libxml2_configure() {
 		ECONF_SOURCE="${S}" econf \
+			--enable-ipv6 \
 			--with-html-subdir=${PF}/html \
 			$(use_with debug run-debug) \
 			$(use_with icu) \
 			$(use_with lzma) \
-			$(use_enable ipv6) \
 			$(use_enable static-libs static) \
 			$(multilib_native_use_with readline) \
 			$(multilib_native_use_with readline history) \

--- a/net-firewall/firehol/firehol-3.1.6-r3.ebuild
+++ b/net-firewall/firehol/firehol-3.1.6-r3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -12,12 +12,12 @@ SRC_URI="https://github.com/firehol/firehol/releases/download/v${PV}/${P}.tar.xz
 LICENSE="GPL-2"
 SLOT="0"
 IUSE="doc ipv6 ipset"
-KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~x86"
+KEYWORDS="amd64 arm ~arm64 ~ppc ~x86"
 
 RDEPEND="net-firewall/iptables
-	sys-apps/iproute2[-minimal,ipv6?]
+	sys-apps/iproute2[-minimal,ipv6(+)?]
 	sys-apps/kmod[tools]
-	net-misc/iputils[ipv6?]
+	net-misc/iputils[ipv6(+)?]
 	net-misc/iprange
 	net-analyzer/traceroute
 	app-arch/gzip

--- a/net-firewall/firehol/firehol-3.1.7-r1.ebuild
+++ b/net-firewall/firehol/firehol-3.1.7-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -12,12 +12,12 @@ SRC_URI="https://github.com/firehol/firehol/releases/download/v${PV}/${P}.tar.xz
 LICENSE="GPL-2"
 SLOT="0"
 IUSE="doc ipv6 ipset"
-KEYWORDS="amd64 arm ~arm64 ~ppc ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~x86"
 
 RDEPEND="net-firewall/iptables
-	sys-apps/iproute2[-minimal,ipv6?]
+	sys-apps/iproute2[-minimal,ipv6(+)?]
 	sys-apps/kmod[tools]
-	net-misc/iputils[ipv6?]
+	net-misc/iputils[ipv6(+)?]
 	net-misc/iprange
 	net-analyzer/traceroute
 	app-arch/gzip

--- a/net-firewall/firewalld/firewalld-1.0.2-r1.ebuild
+++ b/net-firewall/firewalld/firewalld-1.0.2-r1.ebuild
@@ -19,7 +19,7 @@ REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 RDEPEND="${PYTHON_DEPS}
 	!!net-firewall/gshield
 	iptables? (
-		net-firewall/iptables[ipv6]
+		net-firewall/iptables[ipv6(+)]
 		net-firewall/ebtables
 		net-firewall/ipset
 		nftables? ( net-firewall/nftables[xtables(+)] )

--- a/net-firewall/firewalld/firewalld-1.0.3-r1.ebuild
+++ b/net-firewall/firewalld/firewalld-1.0.3-r1.ebuild
@@ -19,7 +19,7 @@ REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 RDEPEND="${PYTHON_DEPS}
 	!!net-firewall/gshield
 	iptables? (
-		net-firewall/iptables[ipv6]
+		net-firewall/iptables[ipv6(+)]
 		net-firewall/ebtables
 		net-firewall/ipset
 		nftables? ( net-firewall/nftables[xtables(+)] )

--- a/net-firewall/sanewall/sanewall-1.1.6-r4.ebuild
+++ b/net-firewall/sanewall/sanewall-1.1.6-r4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -14,7 +14,7 @@ SLOT="0"
 KEYWORDS="~amd64 ~x86"
 
 RDEPEND="
-	net-firewall/iptables[ipv6]
+	net-firewall/iptables[ipv6(+)]
 	sys-apps/iproute2[-minimal]
 	sys-apps/kmod[tools]
 	sys-apps/net-tools

--- a/net-firewall/shorewall/shorewall-5.2.8-r1.ebuild
+++ b/net-firewall/shorewall/shorewall-5.2.8-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="7"
@@ -102,12 +102,12 @@ RDEPEND="
 	)
 	ipv6? (
 		>=dev-perl/Socket6-0.230.0
-		>=net-firewall/iptables-1.4.20[ipv6]
-		>=sys-apps/iproute2-3.8.0[ipv6]
+		>=net-firewall/iptables-1.4.20[ipv6(+)]
+		>=sys-apps/iproute2-3.8.0[ipv6(+)]
 	)
 	lite6? (
-		>=net-firewall/iptables-1.4.20[ipv6]
-		>=sys-apps/iproute2-3.8.0[ipv6]
+		>=net-firewall/iptables-1.4.20[ipv6(+)]
+		>=sys-apps/iproute2-3.8.0[ipv6(+)]
 	)
 	init? ( >=sys-apps/coreutils-8.20 )
 	selinux? ( >=sec-policy/selinux-shorewall-2.20161023-r3 )

--- a/net-firewall/ufw/ufw-0.36-r1.ebuild
+++ b/net-firewall/ufw/ufw-0.36-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -18,7 +18,7 @@ SLOT="0"
 KEYWORDS="amd64 ~arm arm64 ~ia64 ppc ppc64 ~riscv sparc x86"
 IUSE="examples ipv6"
 
-RDEPEND=">=net-firewall/iptables-1.4[ipv6?]
+RDEPEND=">=net-firewall/iptables-1.4[ipv6(+)?]
 	!<kde-misc/kcm-ufw-0.4.2
 	!<net-firewall/ufw-frontends-0.3.2"
 

--- a/net-misc/iputils/iputils-20210722-r1.ebuild
+++ b/net-misc/iputils/iputils-20210722-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # For released versions, we precompile the man/html pages and store
@@ -28,7 +28,7 @@ HOMEPAGE="https://wiki.linuxfoundation.org/networking/iputils"
 
 LICENSE="BSD GPL-2+ rdisc"
 SLOT="0"
-IUSE="+arping caps clockdiff doc gcrypt idn ipv6 nettle nls rarpd rdisc ssl static test tftpd tracepath traceroute6"
+IUSE="+arping caps clockdiff doc gcrypt idn nettle nls rarpd rdisc ssl static test tftpd tracepath traceroute6"
 RESTRICT="!test? ( test )"
 
 BDEPEND="
@@ -91,7 +91,7 @@ src_configure() {
 		-DENABLE_RDISC_SERVER="$(usex rdisc true false)"
 		-DBUILD_TFTPD="$(usex tftpd true false)"
 		-DBUILD_TRACEPATH="$(usex tracepath true false)"
-		-DBUILD_TRACEROUTE6="$(usex ipv6 $(usex traceroute6 true false) false)"
+		-DBUILD_TRACEROUTE6="$(usex traceroute6 true false)"
 		-DBUILD_NINFOD="false"
 		-DNINFOD_MESSAGES="false"
 		-DNO_SETCAP_OR_SUID="true"
@@ -138,18 +138,12 @@ src_install() {
 		mv "${ED}"/usr/bin/${my_bin} "${ED}"/bin/ || die
 	done
 	dosym ping /bin/ping4
+	dosym ping /bin/ping6
 
 	if use tracepath ; then
 		dosym tracepath /usr/bin/tracepath4
-	fi
-
-	if use ipv6 ; then
-		dosym ping /bin/ping6
-
-		if use tracepath ; then
-			dosym tracepath /usr/bin/tracepath6
-			dosym tracepath.8 /usr/share/man/man8/tracepath6.8
-		fi
+		dosym tracepath /usr/bin/tracepath6
+		dosym tracepath.8 /usr/share/man/man8/tracepath6.8
 	fi
 
 	if [[ "${PV}" != 99999999 ]] ; then

--- a/net-misc/iputils/iputils-99999999.ebuild
+++ b/net-misc/iputils/iputils-99999999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # For released versions, we precompile the man/html pages and store
@@ -28,7 +28,7 @@ HOMEPAGE="https://wiki.linuxfoundation.org/networking/iputils"
 
 LICENSE="BSD GPL-2+ rdisc"
 SLOT="0"
-IUSE="+arping caps clockdiff doc gcrypt idn ipv6 nettle nls rarpd rdisc ssl static test tftpd tracepath traceroute6"
+IUSE="+arping caps clockdiff doc gcrypt idn nettle nls rarpd rdisc ssl static test tftpd tracepath traceroute6"
 RESTRICT="!test? ( test )"
 
 BDEPEND="
@@ -84,7 +84,7 @@ src_configure() {
 		-DENABLE_RDISC_SERVER="$(usex rdisc true false)"
 		-DBUILD_TFTPD="$(usex tftpd true false)"
 		-DBUILD_TRACEPATH="$(usex tracepath true false)"
-		-DBUILD_TRACEROUTE6="$(usex ipv6 $(usex traceroute6 true false) false)"
+		-DBUILD_TRACEROUTE6="$(usex traceroute6 true false)"
 		-DBUILD_NINFOD="false"
 		-DNINFOD_MESSAGES="false"
 		-DNO_SETCAP_OR_SUID="true"
@@ -131,18 +131,12 @@ src_install() {
 		mv "${ED}"/usr/bin/${my_bin} "${ED}"/bin/ || die
 	done
 	dosym ping /bin/ping4
+	dosym ping /bin/ping6
 
 	if use tracepath ; then
 		dosym tracepath /usr/bin/tracepath4
-	fi
-
-	if use ipv6 ; then
-		dosym ping /bin/ping6
-
-		if use tracepath ; then
-			dosym tracepath /usr/bin/tracepath6
-			dosym tracepath.8 /usr/share/man/man8/tracepath6.8
-		fi
+		dosym tracepath /usr/bin/tracepath6
+		dosym tracepath.8 /usr/share/man/man8/tracepath6.8
 	fi
 
 	if [[ "${PV}" != 99999999 ]] ; then

--- a/net-misc/miniupnpd/miniupnpd-2.3.0-r1.ebuild
+++ b/net-misc/miniupnpd/miniupnpd-2.3.0-r1.ebuild
@@ -21,7 +21,7 @@ RDEPEND="
 	sys-apps/util-linux:=
 	dev-libs/openssl:0=
 	!nftables? (
-		>=net-firewall/iptables-1.4.6:0=[ipv6?]
+		>=net-firewall/iptables-1.4.6:0=[ipv6(+)?]
 		net-libs/libnfnetlink:=
 		net-libs/libmnl:=
 	)

--- a/net-vpn/mullvad-netns/mullvad-netns-0.2-r1.ebuild
+++ b/net-vpn/mullvad-netns/mullvad-netns-0.2-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 Gentoo Authors
+# Copyright 2020-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -20,12 +20,12 @@ SLOT="0"
 RDEPEND="
 	app-misc/jq
 	app-shells/bash
-	net-misc/curl[ipv6,ssl]
+	net-misc/curl[ipv6(+),ssl]
 	net-vpn/wireguard-tools
 	sys-apps/baselayout
 	sys-apps/coreutils
 	sys-apps/grep
-	sys-apps/iproute2[ipv6]
+	sys-apps/iproute2[ipv6(+)]
 	sys-apps/util-linux
 "
 BDEPEND="

--- a/net-vpn/mullvad-netns/mullvad-netns-0.3-r1.ebuild
+++ b/net-vpn/mullvad-netns/mullvad-netns-0.3-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2020 Gentoo Authors
+# Copyright 2020-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -20,12 +20,12 @@ SLOT="0"
 RDEPEND="
 	app-misc/jq
 	app-shells/bash
-	net-misc/curl[ipv6,ssl]
+	net-misc/curl[ipv6(+),ssl]
 	net-vpn/wireguard-tools
 	sys-apps/baselayout
 	sys-apps/coreutils
 	sys-apps/grep
-	sys-apps/iproute2[ipv6]
+	sys-apps/iproute2[ipv6(+)]
 	sys-apps/util-linux
 "
 BDEPEND="

--- a/net-vpn/mullvad-netns/mullvad-netns-9999.ebuild
+++ b/net-vpn/mullvad-netns/mullvad-netns-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2020 Gentoo Authors
+# Copyright 2020-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -22,12 +22,12 @@ IUSE=""
 RDEPEND="
 	app-misc/jq
 	app-shells/bash
-	net-misc/curl[ipv6,ssl]
+	net-misc/curl[ipv6(+),ssl]
 	net-vpn/wireguard-tools
 	sys-apps/baselayout
 	sys-apps/coreutils
 	sys-apps/grep
-	sys-apps/iproute2[ipv6]
+	sys-apps/iproute2[ipv6(+)]
 	sys-apps/util-linux
 "
 BDEPEND="

--- a/sys-apps/iproute2/iproute2-5.16.0.ebuild
+++ b/sys-apps/iproute2/iproute2-5.16.0.ebuild
@@ -18,7 +18,7 @@ HOMEPAGE="https://wiki.linuxfoundation.org/networking/iproute2"
 
 LICENSE="GPL-2"
 SLOT="0"
-IUSE="atm berkdb bpf caps elf +iptables ipv6 libbsd minimal selinux"
+IUSE="atm berkdb bpf caps elf +iptables libbsd minimal selinux"
 
 # We could make libmnl optional, but it's tiny, so eh
 RDEPEND="
@@ -59,12 +59,6 @@ doecho() {
 }
 
 src_prepare() {
-	if ! use ipv6 ; then
-		PATCHES+=(
-			"${FILESDIR}"/${PN}-4.20.0-no-ipv6.patch # bug #326849
-		)
-	fi
-
 	default
 
 	# Fix version if necessary

--- a/sys-apps/iproute2/iproute2-9999.ebuild
+++ b/sys-apps/iproute2/iproute2-9999.ebuild
@@ -18,7 +18,7 @@ HOMEPAGE="https://wiki.linuxfoundation.org/networking/iproute2"
 
 LICENSE="GPL-2"
 SLOT="0"
-IUSE="atm berkdb bpf caps elf +iptables ipv6 libbsd minimal selinux"
+IUSE="atm berkdb bpf caps elf +iptables libbsd minimal selinux"
 
 # We could make libmnl optional, but it's tiny, so eh
 RDEPEND="
@@ -58,12 +58,6 @@ doecho() {
 }
 
 src_prepare() {
-	if ! use ipv6 ; then
-		PATCHES+=(
-			"${FILESDIR}"/${PN}-4.20.0-no-ipv6.patch # bug #326849
-		)
-	fi
-
 	default
 
 	# Fix version if necessary


### PR DESCRIPTION
At this point, USE=ipv6 is only used to control creating "ping6" and "tracepath6" symlinks.  Just remove the flag and install the links unconditionally.