### PR TITLE
vdr-plugin-2.eclass: prefix qa notices with "QA Notice:"

### DIFF
--- a/eclass/vdr-plugin-2.eclass
+++ b/eclass/vdr-plugin-2.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: vdr-plugin-2.eclass
@@ -179,7 +179,7 @@ vdr_create_header_checksum_file() {
 # Plugins failed on compile with wrong path of libsi includes,
 # this can be fixed by 'function + space separated list of files'
 fix_vdr_libsi_include() {
-	eqawarn "Fixing include of libsi-headers"
+	eqawarn "QA Notice: Fixing include of libsi-headers"
 	local f
 	for f; do
 		sed -i "${f}" \
@@ -264,7 +264,7 @@ vdr_gettext_missing() {
 
 	local GETTEXT_MISSING=$( grep xgettext Makefile )
 	if [[ -z ${GETTEXT_MISSING} ]]; then
-		eqawarn "Plugin isn't converted to gettext handling!"
+		eqawarn "QA Notice: Plugin isn't converted to gettext handling!"
 	fi
 }
 
@@ -326,11 +326,11 @@ vdr_i18n() {
 	if [[ -n ${I18N_OBJECT} ]]; then
 
 		if [[ "${KEEP_I18NOBJECT:-no}" = "yes" ]]; then
-			eqawarn "Forced to keep i18n.o"
+			eqawarn "QA Notice: Forced to keep i18n.o"
 		else
 			sed -i "s:i18n.o::g" Makefile \
 				|| die "sed failed to remove i18n from Makefile"
-			eqawarn "OBJECT i18n.o found, removed per sed"
+			eqawarn "QA Notice: OBJECT i18n.o found, removed per sed"
 		fi
 	fi
 
@@ -338,7 +338,7 @@ vdr_i18n() {
 	if [[ -n ${I18N_STRING} ]]; then
 		sed -i "s:^extern[[:space:]]*const[[:space:]]*tI18nPhrase://static const tI18nPhrase:" i18n.h \
 			|| die "sed failed to replace tI18nPhrase"
-		eqawarn "obsolete tI18nPhrase found, disabled per sed, please recheck"
+		eqawarn "QA Notice: obsolete tI18nPhrase found, disabled per sed, please recheck"
 	fi
 }
 
@@ -357,7 +357,7 @@ vdr_remove_i18n_include() {
 		|| die "sed failed to remove i18n_include"
 	done
 
-	eqawarn "removed i18n.h include in ${@}"
+	eqawarn "QA Notice: removed i18n.h include in ${@}"
 }
 
 # @FUNCTION: vdr-plugin-2_print_enable_command
@@ -593,7 +593,7 @@ vdr-plugin-2_src_install() {
 		DESTDIR="${D%/}" \
 		|| die "emake install (makefile target) failed"
 	else
-		eqawarn "Plugin use still the old Makefile handling"
+		eqawarn "QA Notice: Plugin use still the old Makefile handling"
 		insinto "${VDR_PLUGIN_DIR}"
 		doins libvdr-*.so.*
 	fi


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/813363
Signed-off-by: Martin Dummer <martin.dummer@gmx.net>