### PR TITLE
media-video/wireplumber: fixes a possible 0.4.8 crash on tty switch

### DIFF
--- a/media-video/wireplumber/files/wireplumber-0.4.8-policy-bluetooth-fix-string.find-crash-with-nil-stri.patch
+++ b/media-video/wireplumber/files/wireplumber-0.4.8-policy-bluetooth-fix-string.find-crash-with-nil-stri.patch
@@ -1,0 +1,28 @@
+https://gitlab.freedesktop.org/pipewire/wireplumber/-/commit/c4c5ca8e2215e5fc295b39af4504c43ed3fe176f
+
+From c4c5ca8e2215e5fc295b39af4504c43ed3fe176f Mon Sep 17 00:00:00 2001
+From: George Kiagiadakis <george.kiagiadakis@collabora.com>
+Date: Mon, 14 Feb 2022 10:38:51 +0200
+Subject: [PATCH] policy-bluetooth: fix string.find crash with nil string
+
+Fixes #193
+---
+ src/scripts/policy-bluetooth.lua | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/scripts/policy-bluetooth.lua b/src/scripts/policy-bluetooth.lua
+index 24fbffbb..f8f69a14 100644
+--- a/src/scripts/policy-bluetooth.lua
++++ b/src/scripts/policy-bluetooth.lua
+@@ -118,7 +118,7 @@ local function isSwitched(device)
+ end
+ 
+ local function isBluez5AudioSink(sink_name)
+-  if string.find(sink_name, "bluez_output.") ~= nil then
++  if sink_name and string.find(sink_name, "bluez_output.") ~= nil then
+     return true
+   end
+   return false
+-- 
+GitLab
+

--- a/media-video/wireplumber/files/wireplumber-0.4.8-spa-json-fix-va-list-APIs-for-different-architecture.patch
+++ b/media-video/wireplumber/files/wireplumber-0.4.8-spa-json-fix-va-list-APIs-for-different-architecture.patch
@@ -1,0 +1,214 @@
+https://gitlab.freedesktop.org/pipewire/wireplumber/-/commit/e429db7e8c266045aee25e153fb2308bd61fe233
+
+From e429db7e8c266045aee25e153fb2308bd61fe233 Mon Sep 17 00:00:00 2001
+From: Julian Bouzas <julian.bouzas@collabora.com>
+Date: Wed, 9 Feb 2022 07:59:59 -0500
+Subject: [PATCH] spa-json: fix va_list APIs for different architectures
+
+The va_list type might not always be a pointer in some architectures, so we
+cannot guarantee it will be modified after using it for a second time in another
+function. This fixes the issue by using macros so args does not get copied, and
+always gets modified when using it more than once.
+---
+ lib/wp/spa-json.c | 156 ++++++++++++++++++++++++----------------------
+ 1 file changed, 80 insertions(+), 76 deletions(-)
+
+diff --git a/lib/wp/spa-json.c b/lib/wp/spa-json.c
+index f14f395d..c5e59a3e 100644
+--- a/lib/wp/spa-json.c
++++ b/lib/wp/spa-json.c
+@@ -363,33 +363,33 @@ wp_spa_json_new_string (const gchar *value)
+       wp_spa_json_builder_new_formatted ("\"%s\"", value));
+ }
+ 
+-static void
+-wp_spa_json_builder_add_value (WpSpaJsonBuilder *self, const gchar *fmt,
+-    va_list args)
+-{
+-  switch (*fmt) {
+-    case 'n':
+-      wp_spa_json_builder_add_null (self);
+-      break;
+-    case 'b':
+-      wp_spa_json_builder_add_boolean (self, va_arg(args, gboolean));
+-      break;
+-    case 'i':
+-      wp_spa_json_builder_add_int (self, va_arg(args, gint));
+-      break;
+-    case 'f':
+-      wp_spa_json_builder_add_float (self, (float)va_arg(args, double));
+-      break;
+-    case 's':
+-      wp_spa_json_builder_add_string (self, va_arg(args, const gchar *));
+-      break;
+-    case 'J':
+-      wp_spa_json_builder_add_json (self, va_arg(args, WpSpaJson *));
+-      break;
+-    default:
+-      return;
+-  }
+-}
++/* Args is not a pointer in some architectures, so this needs to be a macro to
++ * avoid args being copied */
++#define wp_spa_json_builder_add_value(self,fmt,args)                           \
++do {                                                                           \
++  switch (*fmt) {                                                              \
++    case 'n':                                                                  \
++      wp_spa_json_builder_add_null (self);                                     \
++      break;                                                                   \
++    case 'b':                                                                  \
++      wp_spa_json_builder_add_boolean (self, va_arg(args, gboolean));          \
++      break;                                                                   \
++    case 'i':                                                                  \
++      wp_spa_json_builder_add_int (self, va_arg(args, gint));                  \
++      break;                                                                   \
++    case 'f':                                                                  \
++      wp_spa_json_builder_add_float (self, (float)va_arg(args, double));       \
++      break;                                                                   \
++    case 's':                                                                  \
++      wp_spa_json_builder_add_string (self, va_arg(args, const gchar *));      \
++      break;                                                                   \
++    case 'J':                                                                  \
++      wp_spa_json_builder_add_json (self, va_arg(args, WpSpaJson *));          \
++      break;                                                                   \
++    default:                                                                   \
++      break;                                                                   \
++  }								               \
++} while(false)
+ 
+ /*!
+  * \brief Creates a spa json of type array
+@@ -724,48 +724,46 @@ wp_spa_json_parse_object_valist (WpSpaJson *self, va_list args)
+   return res;
+ }
+ 
+-static gboolean
+-wp_spa_json_parse_value (const gchar *data, int len, const gchar *fmt,
+-    va_list args)
+-{
+-  switch (*fmt) {
+-    case 'n':
+-      if (!spa_json_is_null (data, len))
+-        return FALSE;
+-      break;
+-    case 'b':
+-      if (!wp_spa_json_parse_boolean_internal (data, len,
+-          va_arg(args, gboolean *)))
+-        return FALSE;
+-      break;
+-    case 'i':
+-      if (spa_json_parse_int (data, len, va_arg(args, gint *)) < 0)
+-        return FALSE;
+-      break;
+-    case 'f':
+-      if (spa_json_parse_float (data, len,
+-          (float *)va_arg(args, double *)) < 0)
+-        return FALSE;
+-      break;
+-    case 's': {
+-      gchar *str = wp_spa_json_parse_string_internal (data, len);
+-      if (!str)
+-        return FALSE;
+-      *va_arg(args, gchar **) = str;
+-      break;
+-    }
+-    case 'J': {
+-      WpSpaJson *j = wp_spa_json_new (data, len);
+-      if (!j)
+-        return FALSE;
+-      *va_arg(args, WpSpaJson **) = j;
+-      break;
+-    }
+-    default:
+-      return FALSE;
+-  }
+-  return TRUE;
+-}
++/* Args is not a pointer in some architectures, so this needs to be a macro to
++ * avoid args being copied */
++#define wp_spa_json_parse_value(data,len,fmt,args)                             \
++do {                                                                           \
++  switch (*fmt) {                                                              \
++    case 'n':                                                                  \
++      if (!spa_json_is_null (data, len))                                       \
++        return FALSE;                                                          \
++      break;                                                                   \
++    case 'b':                                                                  \
++      if (!wp_spa_json_parse_boolean_internal (data, len,                      \
++          va_arg(args, gboolean *)))                                           \
++        return FALSE;                                                          \
++      break;                                                                   \
++    case 'i':                                                                  \
++      if (spa_json_parse_int (data, len, va_arg(args, gint *)) < 0)            \
++        return FALSE;                                                          \
++      break;                                                                   \
++    case 'f':                                                                  \
++      if (spa_json_parse_float (data, len, va_arg(args, float *)) < 0)         \
++        return FALSE;                                                          \
++      break;                                                                   \
++    case 's': {                                                                \
++      gchar *str = wp_spa_json_parse_string_internal (data, len);              \
++      if (!str)                                                                \
++        return FALSE;                                                          \
++      *va_arg(args, gchar **) = str;                                           \
++      break;                                                                   \
++    }                                                                          \
++    case 'J': {                                                                \
++      WpSpaJson *j = wp_spa_json_new (data, len);                              \
++      if (!j)                                                                  \
++        return FALSE;                                                          \
++      *va_arg(args, WpSpaJson **) = j;                                         \
++      break;                                                                   \
++    }                                                                          \
++    default:                                                                   \
++      return FALSE;                                                            \
++  }                                                                            \
++} while(false)
+ 
+ /*!
+  * \brief Parses the object property values of a spa json object
+@@ -827,8 +825,7 @@ wp_spa_json_object_get_valist (WpSpaJson *self, va_list args)
+     value = g_value_get_boxed (&item);
+ 
+     if (g_strcmp0 (key_str, lookup_key) == 0) {
+-      if (!wp_spa_json_parse_value (value->data, value->size, lookup_fmt, args))
+-        return FALSE;
++      wp_spa_json_parse_value (value->data, value->size, lookup_fmt, args);
+       lookup_key = va_arg(args, const gchar *);
+       if (!lookup_key)
+         return TRUE;
+@@ -1366,9 +1363,12 @@ gboolean
+ wp_spa_json_parser_get_value (WpSpaJsonParser *self, const gchar *fmt,
+     va_list args)
+ {
+-  return wp_spa_json_parser_advance (self) &&
+-      wp_spa_json_parse_value (self->curr.cur,
+-          self->curr.end - self->curr.cur, fmt, args);
++  if (wp_spa_json_parser_advance (self)) {
++    wp_spa_json_parse_value (self->curr.cur, self->curr.end - self->curr.cur,
++        fmt, args);
++    return TRUE;
++  }
++  return FALSE;
+ }
+ 
+ /*!
+@@ -1419,9 +1419,13 @@ wp_spa_json_parser_get_valist (WpSpaJsonParser *self, va_list args)
+     if (!format)
+       return TRUE;
+ 
+-    /* parse value */
+-    if (!wp_spa_json_parser_get_value (self, format, args))
++    /* advance */
++    if (!wp_spa_json_parser_advance (self))
+       return FALSE;
++
++    /* parse value */
++    wp_spa_json_parse_value (self->curr.cur, self->curr.end - self->curr.cur,
++        format, args);
+   } while (TRUE);
+ 
+   return FALSE;
+-- 
+GitLab
+

--- a/media-video/wireplumber/wireplumber-0.4.8-r2.ebuild
+++ b/media-video/wireplumber/wireplumber-0.4.8-r2.ebuild
@@ -1,0 +1,122 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+LUA_COMPAT=( lua5-{3,4} )
+
+inherit lua-single meson systemd
+
+if [[ ${PV} == 9999 ]]; then
+	EGIT_REPO_URI="https://gitlab.freedesktop.org/pipewire/${PN}.git"
+	EGIT_BRANCH="master"
+	inherit git-r3
+else
+	SRC_URI="https://gitlab.freedesktop.org/pipewire/${PN}/-/archive/${PV}/${P}.tar.gz"
+	KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~riscv ~sparc ~x86"
+fi
+
+DESCRIPTION="Replacement for pipewire-media-session"
+HOMEPAGE="https://gitlab.freedesktop.org/pipewire/wireplumber"
+
+LICENSE="MIT"
+SLOT="0/0.4"
+IUSE="elogind system-service systemd test"
+
+REQUIRED_USE="
+	${LUA_REQUIRED_USE}
+	?? ( elogind systemd )
+	system-service? ( systemd )
+"
+
+RESTRICT="!test? ( test )"
+
+# introspection? ( dev-libs/gobject-introspection ) is valid but likely only used for doc building
+BDEPEND="
+	dev-libs/glib
+	dev-util/gdbus-codegen
+	dev-util/glib-utils
+"
+
+DEPEND="
+	${LUA_DEPS}
+	>=dev-libs/glib-2.62
+	>=media-video/pipewire-0.3.45:=
+	virtual/libc
+	elogind? ( sys-auth/elogind )
+	systemd? ( sys-apps/systemd )
+"
+
+# Any dev-lua/* deps get declared like this inside RDEPEND:
+#	$(lua_gen_cond_dep '
+#		dev-lua/<NAME>[${LUA_USEDEP}]
+#	')
+RDEPEND="${DEPEND}
+	system-service? (
+		acct-user/pipewire
+		acct-group/pipewire
+	)
+"
+
+DOCS=( {NEWS,README}.rst )
+
+PATCHES=(
+	"${FILESDIR}"/${P}-restore-stream-do-not-crash-if-config.properties-is-.patch
+	"${FILESDIR}"/${P}-spa-json-fix-va-list-APIs-for-different-architecture.patch
+	"${FILESDIR}"/${P}-policy-bluetooth-fix-string.find-crash-with-nil-stri.patch
+)
+
+src_configure() {
+	local emesonargs=(
+		-Ddoc=disabled # Ebuild not wired up yet (Sphinx, Doxygen?)
+		-Dintrospection=disabled # Only used for Sphinx doc generation
+		-Dsystem-lua=true # We always unbundle everything we can
+		-Dsystem-lua-version=$(ver_cut 1-2 $(lua_get_version))
+		$(meson_feature elogind)
+		$(meson_feature systemd)
+		$(meson_use system-service systemd-system-service)
+		$(meson_use systemd systemd-user-service)
+		-Dsystemd-system-unit-dir=$(systemd_get_systemunitdir)
+		-Dsystemd-user-unit-dir=$(systemd_get_userunitdir)
+		$(meson_use test tests)
+	)
+
+	meson_src_configure
+}
+
+src_install() {
+	meson_src_install
+
+	# We copy the default config, so that Gentoo tools can pick up on any
+	# updates and /etc does not end up with stale overrides.
+	# If a reflinking CoW filesystem is used (e.g. Btrfs), then the files
+	# will not actually get stored twice until modified.
+	insinto /etc
+	doins -r ${ED}/usr/share/wireplumber
+}
+
+pkg_postinst() {
+	if systemd_is_booted ; then
+		ewarn "pipewire-media-session.service is no longer installed. You must switch"
+		ewarn "to wireplumber.service user unit before your next logout/reboot:"
+		ewarn "systemctl --user disable pipewire-media-session.service"
+		ewarn "systemctl --user --force enable wireplumber.service"
+	else
+		ewarn "Switch to WirePlumber will happen the next time gentoo-pipewire-launcher"
+		ewarn "is started (a replacement for directly calling pipewire binary)."
+		ewarn
+		ewarn "Please ensure that ${EROOT}/etc/pipewire/pipewire.conf either does not exist"
+		ewarn "or, if it does exist, that any reference to"
+		ewarn "${EROOT}/usr/bin/pipewire-media-session is commented out (begins with a #)."
+	fi
+	if use system-service; then
+		ewarn
+		ewarn "WARNING: you have enabled the system-service USE flag, which installs"
+		ewarn "the system-wide systemd units that enable WirePlumber to run as a system"
+		ewarn "service. This is more than likely NOT what you want. You are strongly"
+		ewarn "advised not to enable this mode and instead stick with systemd user"
+		ewarn "units. The default configuration files will likely not work out of"
+		ewarn "box, and you are on your own with configuration."
+		ewarn
+	fi
+}


### PR DESCRIPTION
This commit backports one upstream patch to fix a crash inside Bluetooth
module when the user switches to tty.

Additionally it adds another backport that changes the internal API to
fix support for some unknown architectures (perhaps embedded?). It does
not appear that the API change would leak to outside of WP itself.