### PR TITLE
app-admin/pass-otp: Unconditionally depend on qrencode

### DIFF
--- a/app-admin/pass-otp/pass-otp-1.2.0-r1.ebuild
+++ b/app-admin/pass-otp/pass-otp-1.2.0-r1.ebuild
@@ -1,0 +1,32 @@
+# Copyright 2018-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit bash-completion-r1
+
+DESCRIPTION="A pass extension for managing one-time-password (OTP) tokens"
+HOMEPAGE="https://github.com/tadfisher/pass-otp"
+SRC_URI="https://github.com/tadfisher/pass-otp/releases/download/v${PV}/${P}.tar.gz"
+
+LICENSE="GPL-3"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc64 ~x86"
+IUSE="test"
+RESTRICT="!test? ( test )"
+
+DEPEND="test? ( dev-tcltk/expect:* )"
+
+RDEPEND="
+	>=app-admin/pass-1.7
+	sys-auth/oath-toolkit
+	media-gfx/qrencode
+"
+
+src_compile() {
+	:
+}
+
+src_install() {
+	emake install DESTDIR="${D}" BASHCOMPDIR="$(get_bashcompdir)"
+}


### PR DESCRIPTION
As pointed out by mgorny on IRC,
app-admin/pass already hard-depends on it so the USE flag is useless.

Signed-off-by: Haelwenn (lanodan) Monnier <contact@hacktivis.me>