### PR TITLE
net-fs/cifs-utils: introduce python USE flag

### DIFF
--- a/net-fs/cifs-utils/cifs-utils-6.13-r1.ebuild
+++ b/net-fs/cifs-utils/cifs-utils-6.13-r1.ebuild
@@ -16,10 +16,9 @@ SRC_URI+=" https://dev.gentoo.org/~polynomial-c/${P}-kerberos_mount_regression_f
 LICENSE="GPL-3"
 SLOT="0"
 KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~x86-linux"
-IUSE="+acl +ads +caps creds pam systemd"
+IUSE="+acl +ads +caps creds pam +python systemd"
 
 RDEPEND="
-	${PYTHON_DEPS}
 	!net-fs/mount-cifs
 	sys-apps/keyutils:=
 	ads? (
@@ -28,6 +27,7 @@ RDEPEND="
 	)
 	caps? ( sys-libs/libcap-ng )
 	pam? ( sys-libs/pam )
+	python? ( ${PYTHON_DEPS} )
 "
 DEPEND="${RDEPEND}"
 BDEPEND="dev-python/docutils"
@@ -37,7 +37,7 @@ PDEPEND="
 
 REQUIRED_USE="
 	acl? ( ads )
-	${PYTHON_REQUIRED_USE}
+	python? ( ${PYTHON_REQUIRED_USE} )
 "
 
 DOCS="doc/linux-cifs-client-guide.odt"
@@ -85,6 +85,7 @@ src_configure() {
 		$(use_enable creds cifscreds)
 		$(use_enable pam)
 		$(use_with pam pamdir $(getpam_mod_dir))
+		$(use_enable python pythontools)
 		# mount.cifs can get passwords from systemd
 		$(use_enable systemd)
 	)

--- a/net-fs/cifs-utils/metadata.xml
+++ b/net-fs/cifs-utils/metadata.xml
@@ -17,5 +17,6 @@
 		<flag name="ads">Enable Active Directory support and create cifs.idmap binary - idmap support</flag>
 		<flag name="caps">Enable <pkg>sys-libs/libcap-ng</pkg> support</flag>
 		<flag name="creds">cifs credentials support</flag>
+		<flag name="python">Enable support for python and install python tools</flag>
 	</use>
 </pkgmetadata>


### PR DESCRIPTION
To prevent cifs-utils from pulling in unnecessary python libs, we need to introduce a new USE flag `python`.
Doing that, `--enable-pythontools` will be enabled only if the python flag is turned on.
So we can disable pythontools when the flag is turned off.
