### PR TITLE
app-backup/burp: add missing queue-standalone dep for musl

### DIFF
--- a/app-backup/burp/burp-2.4.0.ebuild
+++ b/app-backup/burp/burp-2.4.0.ebuild
@@ -28,6 +28,7 @@ COMMON_DEPEND="acct-group/burp
 	acl? ( sys-apps/acl )
 	xattr? ( sys-apps/attr )"
 DEPEND="${COMMON_DEPEND}
+	elibc_musl? ( sys-libs/queue-standalone )
 	test? ( dev-libs/check )"
 BDEPEND=">=sys-devel/autoconf-2.71
 	virtual/pkgconfig"


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/833419

Signed-off-by: Anton Fischl <github@fischl-online.de>