### PR TITLE
app-misc/openrgb-plugin-effects: depend on full gl

### DIFF
--- a/app-misc/openrgb-plugin-effects/openrgb-plugin-effects-0_p20220110.ebuild
+++ b/app-misc/openrgb-plugin-effects/openrgb-plugin-effects-0_p20220110.ebuild
@@ -18,8 +18,8 @@ SLOT="0"
 RDEPEND="
 	>=app-misc/openrgb-0.7:=
 	dev-qt/qtcore:5
-	dev-qt/qtgui:5
-	dev-qt/qtwidgets:5
+	dev-qt/qtgui:5[-gles2-only]
+	dev-qt/qtwidgets:5[-gles2-only]
 	media-libs/openal
 "
 DEPEND="


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/831558
Package-Manager: Portage-3.0.30, Repoman-3.0.3
Signed-off-by: Alexey Sokolov <alexey+gentoo@asokolov.org>