### PR TITLE
dev-libs/raft: update lz4 patch to define LZ4_AVAILABLE

### DIFF
--- a/dev-libs/raft/files/raft-0.11.3-disable-automagic-check-for-lz4.patch
+++ b/dev-libs/raft/files/raft-0.11.3-disable-automagic-check-for-lz4.patch
@@ -1,7 +1,30 @@
-diff -Naur a/configure.ac b/configure.ac
---- a/configure.ac	2021-12-14 18:47:55.000000000 +0200
-+++ b/configure.ac	2022-02-14 10:51:19.908763437 +0200
-@@ -23,47 +23,12 @@
+diff --git a/Makefile.am b/Makefile.am
+index e0dbfc8..e595cb7 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -80,7 +80,9 @@ libraft_la_LDFLAGS += $(LZ4_LIBS)
+ endif # LZ4_AVAILABLE
+ if LZ4_ENABLED
+ test_unit_core_CFLAGS += -DLZ4_ENABLED
++test_unit_core_LDFLAGS = $(LZ4_LIBS)
+ libraft_la_CFLAGS += -DLZ4_ENABLED
++libraft_la_LDFLAGS += $(LZ4_LIBS)
+ endif # LZ4_ENABLED
+ 
+ if FIXTURE_ENABLED
+@@ -210,6 +212,7 @@ test_integration_uv_LDFLAGS += $(LZ4_LIBS)
+ endif # LZ4_AVAILABLE
+ if LZ4_ENABLED
+ test_integration_uv_CFLAGS += -DLZ4_ENABLED
++test_integration_uv_LDFLAGS += $(LZ4_LIBS)
+ endif # LZ4_ENABLED
+ 
+ endif # UV_ENABLED
+diff --git a/configure.ac b/configure.ac
+index df7bea9..0e2949f 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -23,47 +23,13 @@ AM_CONDITIONAL(UV_ENABLED, test "x$have_uv" = "xyes")
  # explicitly disabled.
  AC_ARG_ENABLE(lz4, AS_HELP_STRING([--disable-lz4], [do not use lz4 compression]))
  
@@ -50,41 +73,7 @@ diff -Naur a/configure.ac b/configure.ac
  # compression by default.
 -AM_CONDITIONAL(LZ4_ENABLED, test "x$enable_lz4" != "xno" -a "x$have_lz4" = "xyes")
 +AM_CONDITIONAL(LZ4_ENABLED, test "x$enable_lz4" != "xno")
++AM_CONDITIONAL(LZ4_AVAILABLE, test "x$enable_lz4" != "xno")
  
  # The fake I/O implementation and associated fixture is built by default, unless
  # explicitly disabled.
-diff -Naur a/Makefile.am b/Makefile.am
---- a/Makefile.am	2021-12-14 18:47:55.000000000 +0200
-+++ b/Makefile.am	2022-02-14 10:55:37.467978443 +0200
-@@ -72,15 +72,11 @@
- test_unit_core_CFLAGS = $(AM_CFLAGS) -Wno-conversion
- test_unit_core_LDADD = libtest.la
- 
--if LZ4_AVAILABLE
--test_unit_core_CFLAGS += -DLZ4_AVAILABLE
--test_unit_core_LDFLAGS = $(LZ4_LIBS)
--libraft_la_CFLAGS += -DLZ4_AVAILABLE
--libraft_la_LDFLAGS += $(LZ4_LIBS)
--endif # LZ4_AVAILABLE
- if LZ4_ENABLED
- test_unit_core_CFLAGS += -DLZ4_ENABLED
-+test_unit_core_LDFLAGS = $(LZ4_LIBS)
- libraft_la_CFLAGS += -DLZ4_ENABLED
-+libraft_la_LDFLAGS += $(LZ4_LIBS)
- endif # LZ4_ENABLED
- 
- if FIXTURE_ENABLED
-@@ -204,12 +200,9 @@
- 
- AM_CFLAGS += $(UV_CFLAGS)
- 
--if LZ4_AVAILABLE
--test_integration_uv_CFLAGS += -DLZ4_AVAILABLE
--test_integration_uv_LDFLAGS += $(LZ4_LIBS)
--endif # LZ4_AVAILABLE
- if LZ4_ENABLED
- test_integration_uv_CFLAGS += -DLZ4_ENABLED
-+test_integration_uv_LDFLAGS += $(LZ4_LIBS)
- endif # LZ4_ENABLED
- 
- endif # UV_ENABLED

--- a/dev-libs/raft/raft-0.11.3-r1.ebuild
+++ b/dev-libs/raft/raft-0.11.3-r1.ebuild
@@ -1,0 +1,56 @@
+# Copyright 2020-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools
+
+DESCRIPTION="C implementation of the Raft consensus protocol"
+HOMEPAGE="https://github.com/canonical/raft"
+SRC_URI="https://github.com/canonical/raft/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="LGPL-3-with-linking-exception"
+SLOT="0"
+KEYWORDS="~amd64 ~arm64 ~x86"
+IUSE="lz4 test zfs"
+RESTRICT="!test? ( test )"
+
+DEPEND="dev-libs/libuv:=
+	lz4? ( app-arch/lz4:= )"
+RDEPEND="${DEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}"/raft-0.9.25-Always-skip-init-oom-test.patch
+	"${FILESDIR}"/raft-0.10.0-toggle-zfs.patch
+	"${FILESDIR}"/raft-0.11.3-disable-automagic-check-for-lz4.patch
+)
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_configure() {
+	local myeconfargs=(
+		--enable-uv
+
+		--disable-benchmark
+		--disable-debug
+		--disable-example
+		--disable-sanitize
+		--disable-static
+
+		$(use_enable lz4)
+		$(use_enable test fixture)
+
+		$(use_with zfs)
+	)
+
+	econf "${myeconfargs[@]}"
+}
+
+src_install() {
+	default
+	find "${ED}" -name '*.la' -delete || die
+}


### PR DESCRIPTION
Re-added LZ4_AVAILABLE hunks

fixes LZ4 usage
fixes test failure

Closes: https://bugs.gentoo.org/833445
Signed-off-by: James Beddek <telans@posteo.de>