### PR TITLE
Handle packages which require pulseaudio daemon or conflict with libpulse

### DIFF
--- a/media-sound/apulse/apulse-0.1.13-r2.ebuild
+++ b/media-sound/apulse/apulse-0.1.13-r2.ebuild
@@ -19,7 +19,7 @@ RESTRICT="!test? ( test )"
 
 DEPEND="dev-libs/glib:2[${MULTILIB_USEDEP}]
 	media-libs/alsa-lib[${MULTILIB_USEDEP}]
-	sdk? ( !media-sound/pulseaudio ) "
+	sdk? ( !media-libs/libpulse !media-sound/pulseaudio ) "
 RDEPEND="${DEPEND}
 	!media-plugins/alsa-plugins[pulseaudio]"
 

--- a/media-sound/cadence/cadence-0.9.1-r1.ebuild
+++ b/media-sound/cadence/cadence-0.9.1-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -34,7 +34,7 @@ CDEPEND="
 	media-sound/jack_capture
 	virtual/jack
 	a2jmidid? ( media-sound/a2jmidid[dbus] )
-	pulseaudio? ( media-sound/pulseaudio[jack] )
+	pulseaudio? ( || ( media-sound/pulseaudio-daemon[jack] media-sound/pulseaudio[daemon(+),jack] ) )
 "
 RDEPEND="${CDEPEND}"
 DEPEND="${CDEPEND}"

--- a/media-sound/paprefs/paprefs-1.2-r1.ebuild
+++ b/media-sound/paprefs/paprefs-1.2-r1.ebuild
@@ -17,7 +17,7 @@ RDEPEND="dev-cpp/atkmm:0
 	dev-cpp/gtkmm:3.0
 	dev-libs/glib:2
 	dev-libs/libsigc++:2
-	media-sound/pulseaudio[glib]
+	|| ( media-sound/pulseaudio-daemon[glib] media-sound/pulseaudio[daemon(+),glib] )
 	x11-libs/gtk+:3
 	|| (
 		x11-themes/tango-icon-theme

--- a/media-sound/pulseaudio-ctl/pulseaudio-ctl-1.70-r1.ebuild
+++ b/media-sound/pulseaudio-ctl/pulseaudio-ctl-1.70-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 Gentoo Authors
+# Copyright 2019-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -14,7 +14,7 @@ IUSE=""
 
 # Optional runtime deps: dbus-send for KDE OSD, notify-send for libnotify
 # in both cases they should be already present if DE supports them
-RDEPEND="media-sound/pulseaudio"
+RDEPEND="|| ( media-sound/pulseaudio-daemon media-sound/pulseaudio[daemon(+)] )"
 
 src_install() {
 	emake install PREFIX="${EPREFIX}/usr" DESTDIR="${D}"

--- a/media-sound/pulseaudio-modules-bt/pulseaudio-modules-bt-1.4-r3.ebuild
+++ b/media-sound/pulseaudio-modules-bt/pulseaudio-modules-bt-1.4-r3.ebuild
@@ -26,7 +26,10 @@ DEPEND="
 	>=net-wireless/bluez-5
 	>=sys-apps/dbus-1.0.0
 	ofono-headset? ( >=net-misc/ofono-1.13 )
-	>=media-sound/pulseaudio-${PULSE_VER}[-bluetooth,daemon(+)]
+	|| (
+		>=media-sound/pulseaudio-daemon-${PULSE_VER}[-bluetooth]
+		>=media-sound/pulseaudio-${PULSE_VER}[-bluetooth,daemon(+)]
+	)
 	!media-sound/pulseaudio[bluetooth]
 "
 # Ordinarily media-libs/libldac should be in DEPEND too, but for now upstream repo is using a ldac submodule instead.

--- a/net-misc/pulseaudio-dlna/pulseaudio-dlna-9999.ebuild
+++ b/net-misc/pulseaudio-dlna/pulseaudio-dlna-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -56,7 +56,7 @@ RDEPEND=">=dev-python/protobuf-python-2.5.0[${PYTHON_USEDEP}]
 
 DEPEND="${RDEPEND}
 	dev-python/setuptools[${PYTHON_USEDEP}]
-	media-sound/pulseaudio"
+	|| ( media-sound/pulseaudio-daemon media-sound/pulseaudio[daemon(+)] )"
 
 python_prepare_all() {
 	sed -i '/dbus-python/d' setup.py || die

--- a/net-wireless/blueman/blueman-2.2.3-r1.ebuild
+++ b/net-wireless/blueman/blueman-2.2.3-r1.ebuild
@@ -64,6 +64,8 @@ RDEPEND="${DEPEND}
 	policykit? ( sys-auth/polkit )
 	pulseaudio? (
 		|| (
+			media-sound/pulseaudio-daemon[bluetooth]
+			media-video/pipewire[bluetooth]
 			media-sound/pulseaudio[bluetooth]
 			media-sound/pulseaudio-modules-bt
 		)

--- a/net-wireless/blueman/blueman-9999.ebuild
+++ b/net-wireless/blueman/blueman-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="7"
@@ -64,6 +64,8 @@ RDEPEND="${DEPEND}
 	policykit? ( sys-auth/polkit )
 	pulseaudio? (
 		|| (
+			media-sound/pulseaudio-daemon[bluetooth]
+			media-video/pipewire[bluetooth]
 			media-sound/pulseaudio[bluetooth]
 			media-sound/pulseaudio-modules-bt
 		)


### PR DESCRIPTION
* Some packages would require actual pulseaudio daemon to operate, allow these to depend on media-sound/pulseaudio-daemon
* media-sound/apulse: Conflict with media-libs/libpulse if USE=sdk