### PR TITLE
net-fs/nfs-utils: pull sqlite if nfsv4

### DIFF
--- a/net-fs/nfs-utils/nfs-utils-2.5.4-r3.ebuild
+++ b/net-fs/nfs-utils/nfs-utils-2.5.4-r3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -28,7 +28,6 @@ RESTRICT="test" #315573
 # so don't depend on virtual/krb.
 # (04 Feb 2005 agriffis)
 COMMON_DEPEND="
-	dev-db/sqlite:3
 	dev-libs/libxml2
 	net-libs/libtirpc:=
 	>=net-nds/rpcbind-0.2.4
@@ -43,6 +42,7 @@ COMMON_DEPEND="
 	)
 	libmount? ( sys-apps/util-linux )
 	nfsv4? (
+		dev-db/sqlite:3
 		dev-libs/libevent:=
 		>=sys-apps/keyutils-1.5.9:=
 		kerberos? (


### PR DESCRIPTION
from `./configure.ac`, it seems that this dependency is only required if
`nfsv4` compilation option is enabled.

Bug: https://bugs.gentoo.org/696250
Package-Manager: Portage-3.0.30, Repoman-3.0.3
Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>

<hr>

See also: http://git.linux-nfs.org/?p=steved/nfs-utils.git;a=blob;f=configure.ac;h=50e9b321dcf3d144e998b7d2318af9197c307a34;hb=HEAD#l359