### PR TITLE
media-gfx/blender Fix live ebuild and add support for nanovdb.

### DIFF
--- a/media-gfx/blender/blender-2.93.0-r1.ebuild
+++ b/media-gfx/blender/blender-2.93.0-r1.ebuild
@@ -63,7 +63,7 @@ RDEPEND="${PYTHON_DEPS}
 	color-management? ( >=media-libs/opencolorio-2.0.0 )
 	cuda? ( dev-util/nvidia-cuda-toolkit:= )
 	embree? ( >=media-libs/embree-3.10.0[raymask] )
-	ffmpeg? ( media-video/ffmpeg:=[x264,mp3,encode,theora,jpeg2k,vpx,vorbis,opus,xvid] )
+	ffmpeg? ( media-video/ffmpeg:=[x264,mp3,encode,theora,jpeg2k?,vpx,vorbis,opus,xvid] )
 	fftw? ( sci-libs/fftw:3.0= )
 	gmp? ( dev-libs/gmp )
 	!headless? (

--- a/media-gfx/blender/blender-2.93.6.ebuild
+++ b/media-gfx/blender/blender-2.93.6.ebuild
@@ -64,7 +64,7 @@ RDEPEND="${PYTHON_DEPS}
 	color-management? ( >=media-libs/opencolorio-2.0.0 )
 	cuda? ( dev-util/nvidia-cuda-toolkit:= )
 	embree? ( >=media-libs/embree-3.10.0[raymask] )
-	ffmpeg? ( media-video/ffmpeg:=[x264,mp3,encode,theora,jpeg2k,vpx,vorbis,opus,xvid] )
+	ffmpeg? ( media-video/ffmpeg:=[x264,mp3,encode,theora,jpeg2k?,vpx,vorbis,opus,xvid] )
 	fftw? ( sci-libs/fftw:3.0= )
 	gmp? ( dev-libs/gmp )
 	!headless? (

--- a/media-gfx/blender/blender-2.93.8-r3.ebuild
+++ b/media-gfx/blender/blender-2.93.8-r3.ebuild
@@ -64,7 +64,7 @@ RDEPEND="${PYTHON_DEPS}
 	color-management? ( >=media-libs/opencolorio-2.1.1-r3:= )
 	cuda? ( dev-util/nvidia-cuda-toolkit:= )
 	embree? ( >=media-libs/embree-3.10.0[raymask] )
-	ffmpeg? ( media-video/ffmpeg:=[x264,mp3,encode,theora,jpeg2k,vpx,vorbis,opus,xvid] )
+	ffmpeg? ( media-video/ffmpeg:=[x264,mp3,encode,theora,jpeg2k?,vpx,vorbis,opus,xvid] )
 	fftw? ( sci-libs/fftw:3.0= )
 	gmp? ( dev-libs/gmp )
 	!headless? (

--- a/media-gfx/blender/blender-3.0.0-r1.ebuild
+++ b/media-gfx/blender/blender-3.0.0-r1.ebuild
@@ -65,7 +65,7 @@ RDEPEND="${PYTHON_DEPS}
 	color-management? ( >=media-libs/opencolorio-2.0.0 )
 	cuda? ( dev-util/nvidia-cuda-toolkit:= )
 	embree? ( >=media-libs/embree-3.10.0[raymask] )
-	ffmpeg? ( media-video/ffmpeg:=[x264,mp3,encode,theora,jpeg2k,vpx,vorbis,opus,xvid] )
+	ffmpeg? ( media-video/ffmpeg:=[x264,mp3,encode,theora,jpeg2k?,vpx,vorbis,opus,xvid] )
 	fftw? ( sci-libs/fftw:3.0= )
 	gmp? ( dev-libs/gmp )
 	!headless? (

--- a/media-gfx/blender/blender-3.0.1-r3.ebuild
+++ b/media-gfx/blender/blender-3.0.1-r3.ebuild
@@ -65,7 +65,7 @@ RDEPEND="${PYTHON_DEPS}
 	color-management? ( >=media-libs/opencolorio-2.1.1-r4:= )
 	cuda? ( dev-util/nvidia-cuda-toolkit:= )
 	embree? ( >=media-libs/embree-3.10.0[raymask] )
-	ffmpeg? ( media-video/ffmpeg:=[x264,mp3,encode,theora,jpeg2k,vpx,vorbis,opus,xvid] )
+	ffmpeg? ( media-video/ffmpeg:=[x264,mp3,encode,theora,jpeg2k?,vpx,vorbis,opus,xvid] )
 	fftw? ( sci-libs/fftw:3.0= )
 	gmp? ( dev-libs/gmp )
 	!headless? (

--- a/media-gfx/blender/blender-9999.ebuild
+++ b/media-gfx/blender/blender-9999.ebuild
@@ -27,7 +27,7 @@ LICENSE="|| ( GPL-3 BL )"
 IUSE="+bullet +dds +fluid +openexr +system-python +system-numpy +tbb \
 	alembic collada +color-management cuda +cycles \
 	debug doc +embree +ffmpeg +fftw +gmp headless jack jemalloc jpeg2k \
-	man ndof nls openal +oidn +openimageio +openmp +opensubdiv \
+	man +nanovdb ndof nls openal +oidn +openimageio +openmp +opensubdiv \
 	+openvdb +osl +pdf +potrace +pugixml pulseaudio sdl +sndfile standalone test +tiff valgrind"
 RESTRICT="!test? ( test )"
 
@@ -90,7 +90,7 @@ RDEPEND="${PYTHON_DEPS}
 	)
 	opensubdiv? ( >=media-libs/opensubdiv-3.4.0[cuda=] )
 	openvdb? (
-		>=media-gfx/openvdb-8.2.0-r2:=
+		>=media-gfx/openvdb-9.0.0:=[nanovdb?]
 		dev-libs/c-blosc:=
 	)
 	osl? ( >=media-libs/osl-1.11.16.0-r3:= )
@@ -239,7 +239,7 @@ src_configure() {
 		-DWITH_MEM_VALGRIND=$(usex valgrind)
 		-DWITH_MOD_FLUID=$(usex fluid)
 		-DWITH_MOD_OCEANSIM=$(usex fftw)
-		-DWITH_NANOVDB=OFF
+		-DWITH_NANOVDB=$(usex nanovdb)
 		-DWITH_OPENAL=$(usex openal)
 		-DWITH_OPENCOLLADA=$(usex collada)
 		-DWITH_OPENCOLORIO=$(usex color-management)

--- a/media-gfx/blender/blender-9999.ebuild
+++ b/media-gfx/blender/blender-9999.ebuild
@@ -123,11 +123,6 @@ BDEPEND="
 	nls? ( sys-devel/gettext )
 "
 
-PATCHES=(
-	"${FILESDIR}"/${PN}-3.0.1-openexr.patch
-	"${FILESDIR}"/${PN}-3.0.1-openimageio-2.3.patch
-)
-
 blender_check_requirements() {
 	[[ ${MERGE_TYPE} != binary ]] && use openmp && tc-check-openmp
 
@@ -234,7 +229,6 @@ src_configure() {
 		-DWITH_HEADLESS=$(usex headless)
 		-DWITH_INSTALL_PORTABLE=OFF
 		-DWITH_IMAGE_DDS=$(usex dds)
-		-DOPENEXR_ROOT_DIR="${ESYSROOT}/usr/$(get_libdir)/OpenEXR-3"
 		-DWITH_IMAGE_OPENEXR=$(usex openexr)
 		-DWITH_IMAGE_OPENJPEG=$(usex jpeg2k)
 		-DWITH_IMAGE_TIFF=$(usex tiff)
@@ -263,6 +257,7 @@ src_configure() {
 		-DWITH_SDL=$(usex sdl)
 		-DWITH_STATIC_LIBS=OFF
 		-DWITH_SYSTEM_EIGEN3=ON
+		-DWITH_SYSTEM_FREETYPE=ON
 		-DWITH_SYSTEM_GLEW=ON
 		-DWITH_SYSTEM_LZO=ON
 		-DWITH_TBB=$(usex tbb)

--- a/media-gfx/blender/blender-9999.ebuild
+++ b/media-gfx/blender/blender-9999.ebuild
@@ -65,7 +65,7 @@ RDEPEND="${PYTHON_DEPS}
 	color-management? ( >=media-libs/opencolorio-2.1.1-r3:= )
 	cuda? ( dev-util/nvidia-cuda-toolkit:= )
 	embree? ( >=media-libs/embree-3.10.0[raymask] )
-	ffmpeg? ( media-video/ffmpeg:=[x264,mp3,encode,theora,jpeg2k,vpx,vorbis,opus,xvid] )
+	ffmpeg? ( media-video/ffmpeg:=[x264,mp3,encode,theora,jpeg2k?,vpx,vorbis,opus,xvid] )
 	fftw? ( sci-libs/fftw:3.0= )
 	gmp? ( dev-libs/gmp )
 	!headless? (

--- a/media-gfx/blender/metadata.xml
+++ b/media-gfx/blender/metadata.xml
@@ -49,6 +49,9 @@
 		<flag name="headless">
 			Build without graphical support (renderfarm, server mode only).
 		</flag>
+		<flag name="nanovdb">
+			Enable nanoVDB support in Cycles. Uses less memory than regular openVDB when rendering.
+		</flag>
 		<flag name="ndof">
 			Enable NDOF input devices (SpaceNavigator and friends).
 		</flag>

--- a/media-gfx/openvdb/metadata.xml
+++ b/media-gfx/openvdb/metadata.xml
@@ -18,6 +18,9 @@
 		<flag name="blosc">
 			Allow using blosc compression via <pkg>dev-libs/c-blosc</pkg>
 		</flag>
+		<flag name="nanovdb">
+			A lightweight, header only, and GPU friendly version of VDB.
+		</flag>
 		<flag restrict="&gt;=media-gfx/openvdb-7.0.0" name="numpy">
 			Build pyopenvdb with support for <pkg>dev-python/numpy</pkg>
 		</flag>

--- a/media-gfx/openvdb/metadata.xml
+++ b/media-gfx/openvdb/metadata.xml
@@ -36,6 +36,9 @@
 		<flag restrict="&gt;=media-gfx/openvdb-8.0.0" name="abi8-compat">
 			Disables newer features to maintain compatibility with ABI8.
 		</flag>
+		<flag restrict="&gt;=media-gfx/openvdb-9.0.0" name="abi9-compat">
+			Disables newer features to maintain compatibility with ABI9.
+		</flag>
 		<flag restrict="&gt;=media-gfx/openvdb-7.0.0" name="utils">
 			Build utility binaries
 		</flag>

--- a/media-gfx/openvdb/metadata.xml
+++ b/media-gfx/openvdb/metadata.xml
@@ -18,6 +18,9 @@
 		<flag name="blosc">
 			Allow using blosc compression via <pkg>dev-libs/c-blosc</pkg>
 		</flag>
+		<flag name="cuda">
+			Enalbe support for CUDA in NanoVDB.
+		</flag>
 		<flag name="nanovdb">
 			A lightweight, header only, and GPU friendly version of VDB.
 		</flag>

--- a/media-gfx/openvdb/openvdb-9.0.0-r2.ebuild
+++ b/media-gfx/openvdb/openvdb-9.0.0-r2.ebuild
@@ -14,12 +14,12 @@ SRC_URI="https://github.com/AcademySoftwareFoundation/${PN}/archive/v${PV}.tar.g
 LICENSE="MPL-2.0"
 SLOT="0/9"
 KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~x86"
-IUSE="cpu_flags_x86_avx cpu_flags_x86_sse4_2 +blosc doc +nanovdb numpy python static-libs test utils zlib abi6-compat abi7-compat +abi8-compat"
+IUSE="cpu_flags_x86_avx cpu_flags_x86_sse4_2 +blosc doc +nanovdb numpy python static-libs test utils zlib abi6-compat abi7-compat abi8-compat +abi9-compat"
 RESTRICT="!test? ( test )"
 
 REQUIRED_USE="
 	numpy? ( python )
-	^^ ( abi6-compat abi7-compat abi8-compat )
+	^^ ( abi6-compat abi7-compat abi8-compat abi9-compat )
 	python? ( ${PYTHON_REQUIRED_USE} )
 "
 RDEPEND="
@@ -82,6 +82,8 @@ src_configure() {
 		version=7
 	elif use abi8-compat; then
 		version=8
+	elif use abi9-compat; then
+		version=9
 	else
 		die "OpenVDB ABI version is not compatible"
 	fi

--- a/media-gfx/openvdb/openvdb-9.0.0-r2.ebuild
+++ b/media-gfx/openvdb/openvdb-9.0.0-r2.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://github.com/AcademySoftwareFoundation/${PN}/archive/v${PV}.tar.g
 LICENSE="MPL-2.0"
 SLOT="0/9"
 KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~x86"
-IUSE="cpu_flags_x86_avx cpu_flags_x86_sse4_2 +blosc doc numpy python static-libs test utils zlib abi6-compat abi7-compat +abi8-compat"
+IUSE="cpu_flags_x86_avx cpu_flags_x86_sse4_2 +blosc doc +nanovdb numpy python static-libs test utils zlib abi6-compat abi7-compat +abi8-compat"
 RESTRICT="!test? ( test )"
 
 REQUIRED_USE="
@@ -86,8 +86,6 @@ src_configure() {
 		die "OpenVDB ABI version is not compatible"
 	fi
 
-	# TODO: add NanoVDB?
-	# https://academysoftwarefoundation.github.io/openvdb/NanoVDB_HowToBuild.html
 	local mycmakeargs=(
 		-DCMAKE_INSTALL_DOCDIR="share/doc/${PF}/"
 		-DOPENVDB_ABI_VERSION_NUMBER="${version}"
@@ -105,6 +103,7 @@ src_configure() {
 		-DUSE_COLORED_OUTPUT=ON
 		-DUSE_IMATH_HALF=ON
 		-DUSE_LOG4CPLUS=ON
+		-DUSE_NANOVDB=$(usex nanovdb)
 	)
 
 	if use python; then

--- a/media-gfx/openvdb/openvdb-9.0.0-r3.ebuild
+++ b/media-gfx/openvdb/openvdb-9.0.0-r3.ebuild
@@ -14,16 +14,18 @@ SRC_URI="https://github.com/AcademySoftwareFoundation/${PN}/archive/v${PV}.tar.g
 LICENSE="MPL-2.0"
 SLOT="0/9"
 KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~x86"
-IUSE="cpu_flags_x86_avx cpu_flags_x86_sse4_2 +blosc doc +nanovdb numpy python static-libs test utils zlib abi6-compat abi7-compat abi8-compat +abi9-compat"
+IUSE="cpu_flags_x86_avx cpu_flags_x86_sse4_2 +blosc cuda doc +nanovdb numpy python static-libs test utils zlib abi6-compat abi7-compat abi8-compat +abi9-compat"
 RESTRICT="!test? ( test )"
 
 REQUIRED_USE="
-	numpy? ( python )
 	^^ ( abi6-compat abi7-compat abi8-compat abi9-compat )
+	cuda? ( nanovdb )
+	numpy? ( python )
 	python? ( ${PYTHON_REQUIRED_USE} )
 "
+
 RDEPEND="
-	>=dev-cpp/tbb-2021.4.0:=
+	>=dev-cpp/tbb-2020.3
 	dev-libs/boost:=
 	dev-libs/jemalloc:=
 	dev-libs/log4cplus:=
@@ -37,6 +39,7 @@ RDEPEND="
 	x11-libs/libXinerama
 	x11-libs/libXrandr
 	blosc? ( dev-libs/c-blosc:= )
+	cuda? ( >=dev-util/nvidia-cuda-toolkit-11 )
 	python? (
 		${PYTHON_DEPS}
 		$(python_gen_cond_dep '
@@ -62,7 +65,6 @@ BDEPEND="
 "
 
 PATCHES=(
-	"${FILESDIR}/${PN}-7.1.0-0001-Fix-multilib-header-source.patch"
 	"${FILESDIR}/${PN}-8.1.0-glfw-libdir.patch"
 	"${FILESDIR}/${PN}-9.0.0-numpy.patch"
 	"${FILESDIR}/${PN}-9.0.0-unconditionally-search-Python-interpreter.patch"
@@ -107,6 +109,13 @@ src_configure() {
 		-DUSE_LOG4CPLUS=ON
 		-DUSE_NANOVDB=$(usex nanovdb)
 	)
+
+	if use nanovdb; then
+		mycmakeargs+=(
+			-DNANOVDB_BUILD_UNITTESTS=$(usex test)
+			-DNANOVDB_USE_CUDA=$(usex cuda)
+		)
+	fi
 
 	if use python; then
 		mycmakeargs+=(


### PR DESCRIPTION
@waebbl Do you have time to look into CUDA support for nanovdb?
I don't have and CUDA card to test and implement it myself.

I talked to Brecht (the main Cycles dev), the told me the only way to actually check if nanovdb support is working is to render a scene with volumes. If it works, the smoke should render, otherwise it should just be empty/corrupted.

You could be able to test this with the `tests/render/openvdb/openvdb_smoke.blend` in the automated test bundle.
The reason Blender uses nanovdb for rendering in cycles is that it should reduce memory usage by a bit.
So that is something you could look out for too.