### PR TITLE
db-use.eclass: add support for EAPI 8, die on unknown EAPI

### DIFF
--- a/eclass/db-use.eclass
+++ b/eclass/db-use.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 # This is a common location for functions that aid the use of sys-libs/db
 #
@@ -8,16 +8,17 @@
 # maintainer-needed@gentoo.org
 # @AUTHOR:
 # Paul de Vrieze <pauldv@gentoo.org>
-# @SUPPORTED_EAPIS: 5 6 7
+# @SUPPORTED_EAPIS: 5 6 7 8
 # @BLURB: This is a common location for functions that aid the use of sys-libs/db
 # @DESCRIPTION:
 # This eclass is designed to provide helpful functions for depending on
 # sys-libs/db.
 
 # multilib is used for get_libname in all EAPI
-case "${EAPI:-0}" in
-	0|1|2|3|4|5|6) inherit eapi7-ver multilib ;;
-	*) inherit multilib ;;
+case ${EAPI} in
+	5|6) inherit eapi7-ver ;& # fallthrough
+	7|8) inherit multilib ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
 
 #Convert a version to a db slot
@@ -40,7 +41,6 @@ db_ver_to_slot() {
 
 #Find the version that correspond to the given atom
 db_findver() {
-	has "${EAPI:-0}" 0 1 2 && ! use prefix && EPREFIX=
 	if [ $# -ne 1 ]; then
 		eerror "Function db_findver needs one argument" >&2
 		eerror "args given:" >&2
@@ -68,7 +68,6 @@ db_findver() {
 # to test for, it will aim to find the library corresponding to it.
 
 db_includedir() {
-	has "${EAPI:-0}" 0 1 2 && ! use prefix && EPREFIX=
 	if [ $# -eq 0 ]; then
 		VER="$(db_findver sys-libs/db)" || return 1
 		VER="$(db_ver_to_slot "$VER")"
@@ -102,7 +101,6 @@ db_includedir() {
 # packages to test for, it will aim to find the library corresponding to it.
 
 db_libname() {
-	has "${EAPI:-0}" 0 1 2 && ! use prefix && EPREFIX=
 	if [ $# -eq 0 ]; then
 		VER="$(db_findver sys-libs/db)" || return 1
 		if [ -e "${EPREFIX}/usr/$(get_libdir)/libdb-${VER}$(get_libname)" ]; then


### PR DESCRIPTION
Add support for EAPI 8 and drop support for EAPIs < 5. Also explicitly
die on unknown EAPI values. Note that this is a deviation from the
currenty approach that the eclass uses since 86416d2c4bf1 ("eclass:
db-use - Update to eapi7-ver"). But I argue that it is confusing that
your static ananlysis tools (pkgcheck, repoman) complain about an
unsupported EAPI in an eclass, while the ebuild works just fine. While I
also think it is likely that this eclass will support future EAPI
versions without any modifications, my conclusion is that this is actually
an argument to die on unknown EAPIs, since it is trivial to bump, while
on the other hand, you never know if it really works.