### PR TITLE
app-editors/{vim,vim-core}: fix defaults.vim conflicts in 8.2.{4285,4328}

### DIFF
--- a/app-editors/vim-core/vim-core-8.2.4285.ebuild
+++ b/app-editors/vim-core/vim-core-8.2.4285.ebuild
@@ -193,9 +193,6 @@ src_install() {
 		rm -rv "${ED}${vimfiles}"/{macros,print,tools,tutor} || die "rm failed"
 		rm -v "${ED}"/usr/bin/vimtutor || die "rm failed"
 
-		# Delete defaults.vim to avoid conflicts with one from vim[minimal]
-		rm -v "${ED}${vimfiles}"/defaults.vim || die "rm failed"
-
 		local keep_colors="default"
 		ignore=$(rm -fr "${ED}${vimfiles}"/colors/!(${keep_colors}).vim )
 
@@ -208,6 +205,13 @@ src_install() {
 		sed -i '/skip_defaults_vim/d' "${ED}"/etc/vim/vimrc || die "sed failed"
 
 		eshopts_pop
+	fi
+
+	# Delete defaults.vim to avoid conflicts with one from vim.
+	# If defaults.vim already exists in files installed from vim,
+	# do not install defaults.vim.
+	if [[ -f "${vimfiles}/defaults.vim" ]]; then
+		rm -v "${ED}${vimfiles}"/defaults.vim || die "rm failed"
 	fi
 
 	newbashcomp "${FILESDIR}"/xxd-completion xxd

--- a/app-editors/vim-core/vim-core-8.2.4328.ebuild
+++ b/app-editors/vim-core/vim-core-8.2.4328.ebuild
@@ -193,9 +193,6 @@ src_install() {
 		rm -rv "${ED}${vimfiles}"/{macros,print,tools,tutor} || die "rm failed"
 		rm -v "${ED}"/usr/bin/vimtutor || die "rm failed"
 
-		# Delete defaults.vim to avoid conflicts with one from vim[minimal]
-		rm -v "${ED}${vimfiles}"/defaults.vim || die "rm failed"
-
 		local keep_colors="default"
 		ignore=$(rm -fr "${ED}${vimfiles}"/colors/!(${keep_colors}).vim )
 
@@ -208,6 +205,13 @@ src_install() {
 		sed -i '/skip_defaults_vim/d' "${ED}"/etc/vim/vimrc || die "sed failed"
 
 		eshopts_pop
+	fi
+
+	# Delete defaults.vim to avoid conflicts with one from vim.
+	# If defaults.vim already exists in files installed from vim,
+	# do not install defaults.vim.
+	if [[ -f "${vimfiles}/defaults.vim" ]]; then
+		rm -v "${ED}${vimfiles}"/defaults.vim || die "rm failed"
 	fi
 
 	newbashcomp "${FILESDIR}"/xxd-completion xxd

--- a/app-editors/vim/vim-8.2.4285.ebuild
+++ b/app-editors/vim/vim-8.2.4285.ebuild
@@ -320,8 +320,10 @@ src_install() {
 
 	# Fix an issue of missing defaults.vim when USE=minimal.
 	if use minimal ; then
-		insinto ${vimfiles}
-		doins runtime/defaults.vim
+		if [[ ! -f "${vimfiles}/defaults.vim" ]]; then
+			insinto ${vimfiles}
+			doins runtime/defaults.vim
+		fi
 	fi
 
 	domenu runtime/vim.desktop

--- a/app-editors/vim/vim-8.2.4328.ebuild
+++ b/app-editors/vim/vim-8.2.4328.ebuild
@@ -320,8 +320,10 @@ src_install() {
 
 	# Fix an issue of missing defaults.vim when USE=minimal.
 	if use minimal ; then
-		insinto ${vimfiles}
-		doins runtime/defaults.vim
+		if [[ ! -f "${vimfiles}/defaults.vim" ]]; then
+			insinto ${vimfiles}
+			doins runtime/defaults.vim
+		fi
 	fi
 
 	domenu runtime/vim.desktop


### PR DESCRIPTION
We fixed defaults.vim installation conflicts in 49adc5f0272e40ac608a89d268ee12811fcca384 and e4c6279825a758f660237211dfcdfd83399887f4, but not for 8.2.4285 and 8.2.4328.
Fix the issue for the versions.
