### PR TITLE
dev-util/geany-plugins: restrict libgit2 to < 1.4.0

### DIFF
--- a/dev-util/geany-plugins/geany-plugins-1.38-r1.ebuild
+++ b/dev-util/geany-plugins/geany-plugins-1.38-r1.ebuild
@@ -25,7 +25,7 @@ DEPEND="
 	ctags? ( dev-util/ctags )
 	debugger? ( x11-libs/vte:2.91 )
 	enchant? ( app-text/enchant:= )
-	git? ( dev-libs/libgit2:= )
+	git? ( <dev-libs/libgit2-1.4.0:= )
 	gpg? ( app-crypt/gpgme:= )
 	gtkspell? ( app-text/gtkspell:3= )
 	lua? ( ${LUA_DEPS} )


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/833600
Package-Manager: Portage-3.0.30, Repoman-3.0.3
Signed-off-by: Chris Mayo <aklhfex@gmail.com>