### PR TITLE
profiles: mark sys-libs/e2fsprogs-libs deprecated

### DIFF
--- a/profiles/package.deprecated
+++ b/profiles/package.deprecated
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # This file specifies packages that are considered deprecated (but not
@@ -16,6 +16,11 @@
 ## dev-foo/foo
 
 #--- END OF EXAMPLES ---
+
+# Sam James <sam@gentoo.org> (2022-02-18)
+# sys-libs/e2fsprogs-libs is merging into sys-fs/e2fsprogs
+# Please depend on that instead. bug #806875
+sys-libs/e2fsprogs-libs
 
 # Andreas K. Hüttel <dilfridge@gentoo.org> (2021-06-30)
 # Deprecated upstream, see HOMEPAGE


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/806875
Signed-off-by: Sam James <sam@gentoo.org>