### PR TITLE
app-emulation/xen: re-add accidentally removed patch

### DIFF
--- a/app-emulation/xen/files/xen-4.16-efi.patch
+++ b/app-emulation/xen/files/xen-4.16-efi.patch
@@ -1,0 +1,12 @@
+diff -urN a/xen/arch/x86/Makefile b/xen/arch/x86/Makefile
+--- a/xen/arch/x86/Makefile	2021-11-30 06:42:42.000000000 -0500
++++ b/xen/arch/x86/Makefile	2022-02-17 07:43:06.597244620 -0500
+@@ -127,7 +127,7 @@
+ CFLAGS-$(XEN_BUILD_EFI) += -DXEN_BUILD_EFI
+ 
+ # Check if the linker supports PE.
+-EFI_LDFLAGS = $(patsubst -m%,-mi386pep,$(XEN_LDFLAGS)) --subsystem=10
++EFI_LDFLAGS = -mi386pep $(patsubst -m%,-mi386pep,$(XEN_LDFLAGS)) --subsystem=10
+ XEN_BUILD_PE := $(if $(XEN_BUILD_EFI),$(call ld-option,$(EFI_LDFLAGS) --image-base=0x100000000 -o efi/check.efi efi/check.o))
+ # If the above failed, it may be merely because of the linker not dealing well
+ # with debug info. Try again with stripping it.

--- a/app-emulation/xen/xen-4.16.0-r3.ebuild
+++ b/app-emulation/xen/xen-4.16.0-r3.ebuild
@@ -93,6 +93,8 @@ src_prepare() {
 	# Gentoo's patchset
 	[[ -n ${GENTOO_VER} ]] && eapply "${WORKDIR}"/patches-gentoo
 
+	eapply "${FILESDIR}"/${PN}-4.16-efi.patch
+
 	# Symlinks do not work on fat32 volumes # 829765
 	if ! use boot-symlinks || use efi; then
 		eapply "${FILESDIR}"/${PN}-4.16-no-symlink.patch


### PR DESCRIPTION
This got lost when bumping to 4.16.0.

Thanks!