### PR TITLE
sci-electronics/kicad.*: Mask vulnerable versions

### DIFF
--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -33,6 +33,20 @@
 
 #--- END OF EXAMPLES ---
 
+# Zoltan Puskas <zoltan@sinustrom.info> (2022-02-18)
+# Multiple vulnerabilities (CVE-2022-{23803,23804,23946,23947})
+# 5.X series is masked to avoid accidental use, but it's kept for
+# industrial users who are in the process of migrating to the new
+# format of the 6.X series.
+<sci-electronics/kicad-6.0.2
+<sci-electronics/kicad-footprints-6.0.2
+<sci-electronics/kicad-i18n-6.0.2
+<sci-electronics/kicad-meta-6.0.2
+<sci-electronics/kicad-packages3d-6.0.2
+<sci-electronics/kicad-symbols-6.0.2
+<sci-electronics/kicad-templates-6.0.2
+<app-doc/kicad-doc-6.0.2
+
 # Sam James <sam@gentoo.org> (2022-02-18)
 # Breaks some reverse dependencies w/ stricter(?)
 # parsing. bug #833586.


### PR DESCRIPTION
Signed-off-by: Zoltan Puskas <zoltan@sinustrom.info>
Closes: https://bugs.gentoo.org/833426
