### PR TITLE
net-proxy/squid: add sys-libs/tdb, remove sys-libs/db

### DIFF
--- a/net-proxy/squid/squid-5.4.1-r1.ebuild
+++ b/net-proxy/squid/squid-5.4.1-r1.ebuild
@@ -52,8 +52,8 @@ COMMON_DEPEND="acct-group/squid
 	esi? ( dev-libs/expat dev-libs/libxml2 )
 	gnutls? ( >=net-libs/gnutls-3.1.5:= )
 	logrotate? ( app-admin/logrotate )
-	>=sys-libs/db-4:*
-	dev-libs/libltdl:0"
+	dev-libs/libltdl:0
+	sys-libs/tdb"
 
 DEPEND="${COMMON_DEPEND}
 	${BDEPEND}


### PR DESCRIPTION
http://www.squid-cache.org/Versions/v5/squid-5.4.1-RELEASENOTES.html#ss2.4

"This release deprecates use of BerkleyDB in favour of TrivialDB."