### PR TITLE
gnome-extra/gnome-characters: fix build with meson 0.61

### DIFF
--- a/gnome-extra/gnome-characters/files/fix-build-with-meson-0.61.patch
+++ b/gnome-extra/gnome-characters/files/fix-build-with-meson-0.61.patch
@@ -1,0 +1,20 @@
+Part of https://gitlab.gnome.org/GNOME/gnome-characters/-/commit/3b84cc750b70482a1cc30864dc51cde60df0332d
+https://bugs.gentoo.org/831471
+--- a/data/meson.build
++++ b/data/meson.build
+@@ -47,7 +47,6 @@
+ desktop_conf.set('bindir', characters_bindir)
+ 
+ i18n.merge_file(
+-  'desktop-file',
+   type: 'desktop',
+   input: configure_file (
+     input: characters_name + '.desktop.in',
+@@ -61,7 +60,6 @@
+ )
+ 
+ appdata_file = i18n.merge_file(
+-  'appdata-file',
+   input: characters_name + '.appdata.xml.in',
+   output: characters_application_id + '.appdata.xml',
+   po_dir: po_dir,

--- a/gnome-extra/gnome-characters/gnome-characters-41.0.ebuild
+++ b/gnome-extra/gnome-characters/gnome-characters-41.0.ebuild
@@ -31,6 +31,10 @@ BDEPEND="
 	virtual/pkgconfig
 "
 
+PATCHES=(
+	"${FILESDIR}"/fix-build-with-meson-0.61.patch
+)
+
 pkg_postinst() {
 	xdg_pkg_postinst
 	gnome2_schemas_update


### PR DESCRIPTION
Fix in upstream master but together with other things that I
did not want to pull in, so just fixing the build problem in
anticipation of a new upstream release.

Signed-off-by: Christophe Lermytte <gentoo@lermytte.be>
Closes: https://bugs.gentoo.org/831471