### PR TITLE
gnome-extra/gnome-user-share: fix build with meson 0.61

### DIFF
--- a/gnome-extra/gnome-user-share/files/fix-build-with-meson-0.61.patch
+++ b/gnome-extra/gnome-user-share/files/fix-build-with-meson-0.61.patch
@@ -1,0 +1,11 @@
+https://bugs.gentoo.org/831939
+--- a/data/meson.build
++++ b/data/meson.build
+@@ -7,7 +7,6 @@ desktop_in = configure_file(
+ )
+ 
+ i18n.merge_file(
+-  desktop,
+   type: 'desktop',
+   input: desktop_in,
+   output: '@BASENAME@',

--- a/gnome-extra/gnome-user-share/files/gnome-user-share-3.18.1-no-prefork.patch
+++ b/gnome-extra/gnome-user-share/files/gnome-user-share-3.18.1-no-prefork.patch
@@ -1,5 +1,6 @@
---- gnome-user-share-3.14.2/data/dav_user_2.4.conf.orig 2015-06-03 20:21:27.512774376 -0600
-+++ gnome-user-share-3.14.2/data/dav_user_2.4.conf      2015-06-03 20:21:33.588774303 -0600
+https://bugs.gentoo.org/551012
+--- a/data/dav_user_2.4.conf
++++ b/data/dav_user_2.4.conf
 @@ -9,7 +9,6 @@
  LimitXMLRequestBody 100000
  

--- a/gnome-extra/gnome-user-share/gnome-user-share-3.34.0.ebuild
+++ b/gnome-extra/gnome-user-share/gnome-user-share-3.34.0.ebuild
@@ -33,6 +33,7 @@ PATCHES=(
 	# that is problematic for us (bug #551012)
 	# https://bugzilla.gnome.org/show_bug.cgi?id=750525#c2
 	"${FILESDIR}"/${PN}-3.18.1-no-prefork.patch
+	"${FILESDIR}"/fix-build-with-meson-0.61.patch
 )
 
 src_configure() {


### PR DESCRIPTION
Issue was logged upstream, but I don't expect things to move
quickly or at all, so adding this patch.

Also, scrubbed the existing patch

Signed-off-by: Christophe Lermytte <gentoo@lermytte.be>
Closes: https://bugs.gentoo.org/831939