### PR TITLE
dev-java/swingx-ws: Use EAPI 8, set minimum Java version to 1.8

### DIFF
--- a/dev-java/swingx-ws/files/swingx-ws-1.0_p20110515-replace-sun.misc-classes-for-java-9+.patch
+++ b/dev-java/swingx-ws/files/swingx-ws-1.0_p20110515-replace-sun.misc-classes-for-java-9+.patch
@@ -1,0 +1,40 @@
+From 803016b9b4bd6cc96efb6cba8c37befaf410be61 Mon Sep 17 00:00:00 2001
+From: Yuan Liao <liaoyuan@gmail.com>
+Date: Sun, 20 Feb 2022 11:07:41 -0800
+Subject: [PATCH] Replace use of sun.misc.BASE64{En,De}coder for Java 9+
+
+Signed-off-by: Yuan Liao <liaoyuan@gmail.com>
+---
+ java/org/jdesktop/http/Request.java | 7 +++----
+ 1 file changed, 3 insertions(+), 4 deletions(-)
+
+diff --git a/java/org/jdesktop/http/Request.java b/java/org/jdesktop/http/Request.java
+index ff72322..57c4bf8 100644
+--- a/java/org/jdesktop/http/Request.java
++++ b/java/org/jdesktop/http/Request.java
+@@ -30,8 +30,7 @@ import org.jdesktop.beans.AbstractBean;
+ import org.jdesktop.http.Header.Element;
+ import org.jdesktop.xpath.XPathUtils;
+ import org.w3c.dom.Document;
+-import sun.misc.BASE64Decoder;
+-import sun.misc.BASE64Encoder;
++import java.util.Base64;
+ 
+ /**
+  * <p>Represents an http request. A <code>Request</code> is constructed and then
+@@ -613,10 +612,10 @@ public class Request extends AbstractBean {
+     }
+ 
+     private static String base64Encode(String s) throws Exception {
+-        return new String(new BASE64Encoder().encode(s.getBytes()));
++        return Base64.getEncoder().encodeToString(s.getBytes());
+     }
+     
+     private static String base64Decode(String s) throws Exception {
+-        return new String(new BASE64Decoder().decodeBuffer(s));
++        return new String(Base64.getDecoder().decode(s));
+     }
+ }
+-- 
+2.34.1
+

--- a/dev-java/swingx-ws/swingx-ws-1.0_p20110515-r2.ebuild
+++ b/dev-java/swingx-ws/swingx-ws-1.0_p20110515-r2.ebuild
@@ -1,0 +1,74 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+MY_P="${PN}-2011_05_15-src"
+JAVA_PKG_IUSE="doc source"
+
+inherit java-pkg-2 java-pkg-simple
+
+DESCRIPTION="Utilities and widgets to integrate Swing GUIs with web applications"
+HOMEPAGE="https://java.net/projects/swingx-ws/"
+SRC_URI="mirror://sourceforge/bt747/Development/${MY_P}.zip"
+LICENSE="LGPL-2.1"
+SLOT="bt747"
+KEYWORDS="~amd64 ~x86"
+
+CP_DEPEND="
+	dev-java/jakarta-xml-soap-api:1
+	dev-java/jdom:0
+	dev-java/json:0
+	dev-java/rome:0
+	dev-java/jtidy:0
+	dev-java/xerces:2
+	dev-java/swingx:1.6
+	dev-java/swing-layout:1
+	dev-java/swingx-beaninfo:0
+	dev-java/commons-httpclient:3
+	dev-java/xml-commons-external:1.4"
+
+RDEPEND="
+	${CP_DEPEND}
+	>=virtual/jre-1.8:*"
+
+DEPEND="
+	${CP_DEPEND}
+	>=virtual/jdk-1.8:*"
+
+BDEPEND="
+	app-arch/unzip"
+
+S="${WORKDIR}/${MY_P}/src"
+JAVA_SRC_DIR=( "beaninfo" "java" )
+
+PATCHES=(
+	"${FILESDIR}/${P}-replace-sun.misc-classes-for-java-9+.patch"
+)
+
+src_prepare() {
+	default
+	java-pkg_clean "${WORKDIR}"
+
+	# SwingWorker has been built-in since Java 6.
+	find java -name "*.java" -exec sed -i -r "s:org\.jdesktop\.swingworker\.:javax.swing.:g" {} + || die
+
+	# Fixes for newer swingx-beaninfo.
+	sed -i "s:BeanInfoSupport:org.jdesktop.beans.\0:g" beaninfo/org/jdesktop/swingx/*.java || die
+	find beaninfo -name "*.java" -exec sed -i -r "s:org\.jdesktop\.swingx\.(editors|BeanInfoSupport|EnumerationValue):org.jdesktop.beans.\1:g" {} + || die
+
+	# GraphicsUtilities moved in later SwingX versions.
+	sed -i "s:org\.jdesktop\.swingx\.graphics\.GraphicsUtilities:org.jdesktop.swingx.util.GraphicsUtilities:g" \
+		java/org/jdesktop/swingx/mapviewer/AbstractTileFactory.java || die
+
+	java-pkg-2_src_prepare
+}
+
+src_compile() {
+	java-pkg-simple_src_compile
+
+	local DIR
+	for DIR in "${JAVA_SRC_DIR[@]}"; do
+		java-pkg_addres ${PN}.jar ${DIR}
+	done
+}


### PR DESCRIPTION
Fix build failure with JDK 11+, which has not been reported yet.