### PR TITLE
gnome-extra/nautilus-sendto: fix build with meson 0.61

### DIFF
--- a/gnome-extra/nautilus-sendto/files/fix-build-with-meson-0.61.patch
+++ b/gnome-extra/nautilus-sendto/files/fix-build-with-meson-0.61.patch
@@ -1,0 +1,12 @@
+https://bugs.gentoo.org/831837
+--- a/src/meson.build
++++ b/src/meson.build
+@@ -7,7 +7,7 @@ executable('nautilus-sendto',
+ 
+ po_dir = join_paths(meson.source_root(), 'po')
+ 
+-i18n.merge_file ('appdata',
++i18n.merge_file (
+                  input: 'nautilus-sendto.metainfo.xml.in',
+                  output: 'nautilus-sendto.metainfo.xml',
+                  install: true,

--- a/gnome-extra/nautilus-sendto/nautilus-sendto-3.8.6.ebuild
+++ b/gnome-extra/nautilus-sendto/nautilus-sendto-3.8.6.ebuild
@@ -19,6 +19,10 @@ DEPEND="${RDEPEND}
 	virtual/pkgconfig
 "
 
+PATCHES=(
+	"${FILESDIR}"/fix-build-with-meson-0.61.patch
+)
+
 pkg_postinst() {
 	if ! has_version "gnome-base/nautilus[sendto]"; then
 		einfo "Note that ${CATEGORY}/${PN} is meant to be used as a helper by gnome-base/nautilus[sendto]"


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/831837
Signed-off-by: Christophe Lermytte <gentoo@lermytte.be>