### PR TITLE
gnome-extra/gnome-documents-3.34.0-r1: fix build with meson-0.61

### DIFF
--- a/gnome-extra/gnome-documents/files/fix-build-with-meson-0.61.patch
+++ b/gnome-extra/gnome-documents/files/fix-build-with-meson-0.61.patch
@@ -1,0 +1,19 @@
+https://bugs.gentoo.org/833843
+--- a/data/meson.build
++++ b/data/meson.build
+@@ -56,7 +56,6 @@ foreach app: documents_apps
+   appdata = app + '.appdata.xml'
+ 
+   appdata_file = i18n.merge_file(
+-    appdata,
+     input: appdata + '.in',
+     output: appdata,
+     po_dir: po_dir,
+@@ -76,7 +75,6 @@ foreach app: documents_apps
+   desktop = app + '.desktop'
+ 
+   desktop_file = i18n.merge_file(
+-    desktop,
+     type: 'desktop',
+     input: desktop + '.in',
+     output: desktop,

--- a/gnome-extra/gnome-documents/gnome-documents-3.34.0-r1.ebuild
+++ b/gnome-extra/gnome-documents/gnome-documents-3.34.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -48,6 +48,10 @@ DEPEND="${COMMON_DEPEND}
 	dev-util/itstool
 	virtual/pkgconfig
 "
+
+PATCHES=(
+	"${FILESDIR}"/fix-build-with-meson-0.61.patch
+)
 
 src_configure() {
 	local emesonargs=(


### PR DESCRIPTION
Upstream looks abandoned, fixing in-tree.

Signed-off-by: Christophe Lermytte <gentoo@lermytte.be>
Closes: https://bugs.gentoo.org/833843