### PR TITLE
app-emulation/libvirt: Fix build with >=dev-libs/libxslt-1.1.35

### DIFF
--- a/app-emulation/libvirt/files/libvirt-8.1.0-docs-Fix-template-matching-in-page.xsl.patch
+++ b/app-emulation/libvirt/files/libvirt-8.1.0-docs-Fix-template-matching-in-page.xsl.patch
@@ -1,0 +1,62 @@
+From 54814c87f3706cc8eb894634ebef0f9cf7dabae6 Mon Sep 17 00:00:00 2001
+Message-Id: <54814c87f3706cc8eb894634ebef0f9cf7dabae6.1645458252.git.mprivozn@redhat.com>
+From: Martin Kletzander <mkletzan@redhat.com>
+Date: Mon, 21 Feb 2022 09:26:13 +0100
+Subject: [PATCH] docs: Fix template matching in page.xsl
+
+Our last default template had a match of "node()" which incidentally matched
+everything, including text nodes.  Since this has the same priority according to
+the XSLT spec, section 5.5:
+
+  https://www.w3.org/TR/1999/REC-xslt-19991116#conflict
+
+this is an error.  Also according to the same spec section, the XSLT processor
+may signal the error or pick the last rule.
+
+This was uncovered with libxslt 1.1.35 which contains the following commit:
+
+  https://gitlab.gnome.org/GNOME/libxslt/-/commit/b0074eeca3c6b21b4da14fdf712b853900c51635
+
+which makes the build fail with:
+
+  runtime error: file ../docs/page.xsl line 223 element element
+  xsl:element: The effective name '' is not a valid QName.
+
+because our last rule also matches text nodes and we are trying to extract the
+node name out of them.
+
+To fix this we change the match to "*" which only matches elements and not all
+the nodes, and to avoid any possible errors with different XSLT processors we
+also bump the priority of the match="text()" rule a little higher, just in case
+someone needs to use an XSLT processor that chooses signalling the error instead
+of the optional recovery.
+
+https://bugs.gentoo.org/833586
+
+Signed-off-by: Martin Kletzander <mkletzan@redhat.com>
+Signed-off-by: Michal Privoznik <mprivozn@redhat.com>
+---
+ docs/page.xsl | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/docs/page.xsl b/docs/page.xsl
+index fd67918d3b..72a6fa0842 100644
+--- a/docs/page.xsl
++++ b/docs/page.xsl
+@@ -215,11 +215,11 @@
+     </xsl:element>
+   </xsl:template>
+ 
+-  <xsl:template match="text()" mode="copy">
++  <xsl:template match="text()" mode="copy" priority="0">
+     <xsl:value-of select="."/>
+   </xsl:template>
+ 
+-  <xsl:template match="node()" mode="copy">
++  <xsl:template match="*" mode="copy">
+     <xsl:element name="{name()}">
+       <xsl:copy-of select="./@*"/>
+       <xsl:apply-templates mode="copy" />
+-- 
+2.34.1
+

--- a/app-emulation/libvirt/libvirt-7.10.0-r3.ebuild
+++ b/app-emulation/libvirt/libvirt-7.10.0-r3.ebuild
@@ -136,6 +136,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-6.7.0-fix-paths-for-apparmor.patch
 	"${FILESDIR}"/${PN}-7.9.0-fix_cgroupv2.patch
 	"${FILESDIR}"/${PN}-7.10.0-fix_soname.patch
+	"${FILESDIR}"/${PN}-8.1.0-docs-Fix-template-matching-in-page.xsl.patch
 )
 
 pkg_setup() {

--- a/app-emulation/libvirt/libvirt-7.7.0-r2.ebuild
+++ b/app-emulation/libvirt/libvirt-7.7.0-r2.ebuild
@@ -134,6 +134,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-6.0.0-fix_paths_in_libvirt-guests_sh.patch
 	"${FILESDIR}"/${PN}-6.7.0-do-not-use-sysconfig.patch
 	"${FILESDIR}"/${PN}-6.7.0-fix-paths-for-apparmor.patch
+	"${FILESDIR}"/${PN}-8.1.0-docs-Fix-template-matching-in-page.xsl.patch
 )
 
 pkg_setup() {

--- a/app-emulation/libvirt/libvirt-8.0.0-r1.ebuild
+++ b/app-emulation/libvirt/libvirt-8.0.0-r1.ebuild
@@ -134,6 +134,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-6.0.0-fix_paths_in_libvirt-guests_sh.patch
 	"${FILESDIR}"/${PN}-6.7.0-do-not-use-sysconfig.patch
 	"${FILESDIR}"/${PN}-6.7.0-fix-paths-for-apparmor.patch
+	"${FILESDIR}"/${PN}-8.1.0-docs-Fix-template-matching-in-page.xsl.patch
 )
 
 pkg_setup() {


### PR DESCRIPTION
Libvirt failed to build with new libxslt because of a bug in one
of libvirt's xsl files. Backport the fix from upstream repo.

Closes: https://bugs.gentoo.org/833586
Signed-off-by: Michal Privoznik <mprivozn@redhat.com>