### PR TITLE
app-vim/gentoo-syntax: remove MY_P from v1

### DIFF
--- a/app-vim/gentoo-syntax/gentoo-syntax-1.ebuild
+++ b/app-vim/gentoo-syntax/gentoo-syntax-1.ebuild
@@ -5,11 +5,9 @@ EAPI=7
 
 inherit vim-plugin
 
-MY_P=${P/0.}
 DESCRIPTION="vim plugin: Gentoo and Portage syntax highlighting"
 HOMEPAGE="https://github.com/gentoo/gentoo-syntax"
-SRC_URI="https://gitweb.gentoo.org/proj/gentoo-syntax.git/snapshot/${MY_P}.tar.bz2"
-S=${WORKDIR}/${MY_P}
+SRC_URI="https://gitweb.gentoo.org/proj/gentoo-syntax.git/snapshot/${P}.tar.bz2"
 
 LICENSE="vim"
 SLOT="0"


### PR DESCRIPTION
Recent "downgrade" from `20211208` to `0.20211208` made me look to the git history why it happened and I noticed that `MY_P` is not needed anymore in version `1`.