### PR TITLE
media-gfx/prusaslicer: fix build with cereal-1.3.1

### DIFF
--- a/media-gfx/prusaslicer/files/2.4.0-fix-build-with-cereal-1.3.1.patch
+++ b/media-gfx/prusaslicer/files/2.4.0-fix-build-with-cereal-1.3.1.patch
@@ -1,0 +1,47 @@
+https://bugs.gentoo.org/834005
+https://github.com/prusa3d/PrusaSlicer/commit/0ffcfd8393457fd035576436752267c9a1e6bbcc
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -506,6 +506,9 @@ endif ()
+ 
+ # Find the Cereal serialization library
+ find_package(cereal REQUIRED)
++if (NOT TARGET cereal::cereal)
++    add_library(cereal::cereal ALIAS cereal)
++endif ()
+ 
+ # l10n
+ set(L10N_DIR "${SLIC3R_RESOURCES_DIR}/localization")
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -126,7 +126,7 @@ if (NOT WIN32 AND NOT APPLE)
+     set_target_properties(PrusaSlicer PROPERTIES OUTPUT_NAME "prusa-slicer")
+ endif ()
+ 
+-target_link_libraries(PrusaSlicer libslic3r cereal)
++target_link_libraries(PrusaSlicer libslic3r cereal::cereal)
+ if (APPLE)
+ #    add_compile_options(-stdlib=libc++)
+ #    add_definitions(-DBOOST_THREAD_DONT_USE_CHRONO -DBOOST_NO_CXX11_RVALUE_REFERENCES -DBOOST_THREAD_USES_MOVE)
+--- a/src/libslic3r/CMakeLists.txt
++++ b/src/libslic3r/CMakeLists.txt
+@@ -358,7 +358,7 @@ find_package(JPEG REQUIRED)
+ target_link_libraries(libslic3r
+     libnest2d
+     admesh
+-    cereal
++    cereal::cereal
+     libigl
+     miniz
+     boost_libs
+--- a/src/slic3r/CMakeLists.txt
++++ b/src/slic3r/CMakeLists.txt
+@@ -270,7 +270,7 @@ endforeach()
+ 
+ encoding_check(libslic3r_gui)
+ 
+-target_link_libraries(libslic3r_gui libslic3r avrdude cereal imgui GLEW::GLEW OpenGL::GL hidapi libcurl ${wxWidgets_LIBRARIES})
++target_link_libraries(libslic3r_gui libslic3r avrdude cereal::cereal imgui GLEW::GLEW OpenGL::GL hidapi libcurl ${wxWidgets_LIBRARIES})
+ 
+ if (MSVC)
+     target_link_libraries(libslic3r_gui Setupapi.lib)

--- a/media-gfx/prusaslicer/prusaslicer-2.4.0-r2.ebuild
+++ b/media-gfx/prusaslicer/prusaslicer-2.4.0-r2.ebuild
@@ -49,6 +49,10 @@ DEPEND="${RDEPEND}
 	media-libs/qhull[static-libs]
 "
 
+PATCHES=(
+	"${FILESDIR}"/${PV}-fix-build-with-cereal-1.3.1.patch
+)
+
 S="${WORKDIR}/${MY_PN}-version_${PV}"
 
 src_prepare() {


### PR DESCRIPTION
Upstream patch on master branch, should make it in the new release.

Signed-off-by: Christophe Lermytte <gentoo@lermytte.be>
Closes: https://bugs.gentoo.org/834005