### PR TITLE
media-gfx/blender: Update python targets

### DIFF
--- a/media-gfx/blender/blender-2.93.0-r1.ebuild
+++ b/media-gfx/blender/blender-2.93.0-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_9 )
+PYTHON_COMPAT=( python3_9 python3_10 )
 
 inherit check-reqs cmake flag-o-matic pax-utils python-single-r1 toolchain-funcs xdg-utils
 

--- a/media-gfx/blender/blender-2.93.6.ebuild
+++ b/media-gfx/blender/blender-2.93.6.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_9 )
+PYTHON_COMPAT=( python3_9 python3_10 )
 
 inherit check-reqs cmake flag-o-matic pax-utils python-single-r1 toolchain-funcs xdg-utils
 

--- a/media-gfx/blender/blender-2.93.8-r4.ebuild
+++ b/media-gfx/blender/blender-2.93.8-r4.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_9 )
+PYTHON_COMPAT=( python3_9 python3_10 )
 
 inherit check-reqs cmake flag-o-matic pax-utils python-single-r1 toolchain-funcs xdg-utils
 

--- a/media-gfx/blender/blender-3.0.0-r1.ebuild
+++ b/media-gfx/blender/blender-3.0.0-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_9 )
+PYTHON_COMPAT=( python3_9 python3_10 )
 
 inherit check-reqs cmake flag-o-matic pax-utils python-single-r1 toolchain-funcs xdg-utils
 

--- a/media-gfx/blender/blender-3.0.1-r4.ebuild
+++ b/media-gfx/blender/blender-3.0.1-r4.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_9 )
+PYTHON_COMPAT=( python3_9 python3_10 )
 
 inherit check-reqs cmake flag-o-matic pax-utils python-single-r1 toolchain-funcs xdg-utils
 

--- a/media-gfx/blender/blender-9999.ebuild
+++ b/media-gfx/blender/blender-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_9 )
+PYTHON_COMPAT=( python3_10 )
 
 inherit check-reqs cmake flag-o-matic pax-utils python-single-r1 toolchain-funcs xdg-utils
 
@@ -377,11 +377,11 @@ pkg_postinst() {
 	ewarn "  https://developer.blender.org/"
 	ewarn
 
-	if ! use python_single_target_python3_9; then
+	if ! use python_single_target_python3_10; then
 		elog "You are building Blender with a newer python version than"
 		elog "supported by this version upstream."
 		elog "If you experience breakages with e.g. plugins, please switch to"
-		elog "python_single_target_python3_9 instead."
+		elog "python_single_target_python3_10 instead."
 		elog "Bug: https://bugs.gentoo.org/737388"
 		elog
 	fi


### PR DESCRIPTION
Blender >=3.1 (9999 ebuild) now requires python >=3.10 with 3.10 being the officially supported version.

I also bumped the versions for the older ebuilds so people can use newer but unsupported versions if they like.

I grepped the portage tree and it seems like most packages stops at python 3.10, so that is why I didn't include 3.11 here.