### PR TITLE
dev-lang/lua: fix 5.4 build on prefix

### DIFF
--- a/dev-lang/lua/files/lua-5.4.2-r2-make.patch
+++ b/dev-lang/lua/files/lua-5.4.2-r2-make.patch
@@ -1,0 +1,99 @@
+diff --git a/Makefile b/Makefile
+index 1797df9..90284d8 100644
+--- a/Makefile
++++ b/Makefile
+@@ -10,11 +10,11 @@ PLAT= guess
+ # so take care if INSTALL_TOP is not an absolute path. See the local target.
+ # You may want to make INSTALL_LMOD and INSTALL_CMOD consistent with
+ # LUA_ROOT, LUA_LDIR, and LUA_CDIR in luaconf.h.
+-INSTALL_TOP= /usr/local
++INSTALL_TOP= /usr
+ INSTALL_BIN= $(INSTALL_TOP)/bin
+-INSTALL_INC= $(INSTALL_TOP)/include
++INSTALL_INC= $(INSTALL_TOP)/include/lua$V
+ INSTALL_LIB= $(INSTALL_TOP)/lib
+-INSTALL_MAN= $(INSTALL_TOP)/man/man1
++INSTALL_MAN= $(INSTALL_TOP)/share/man/man1
+ INSTALL_LMOD= $(INSTALL_TOP)/share/lua/$V
+ INSTALL_CMOD= $(INSTALL_TOP)/lib/lua/$V
+ 
+@@ -104,3 +104,18 @@ pc:
+ .PHONY: all $(PLATS) help test clean install uninstall local dummy echo pc
+ 
+ # (end of Makefile)
++
++# Use libtool for binary installs, etc.
++
++export V
++export LIBTOOL = libtool --quiet --tag=CC
++# See libtool manual about how to set this
++
++gentoo_clean:
++	cd src; $(MAKE) $@
++
++gentoo_install:
++	mkdir -p $(INSTALL_BIN) $(INSTALL_INC) $(INSTALL_LIB)
++	cd src; $(LIBTOOL) --mode=install $(INSTALL_EXEC) lua$V luac$V $(INSTALL_BIN)
++	cd src; $(INSTALL_DATA) $(TO_INC) $(INSTALL_INC)
++	cd src; $(LIBTOOL) --mode=install $(INSTALL_DATA) liblua$V.la $(INSTALL_LIB)
+diff --git a/src/Makefile b/src/Makefile
+index 514593d..8af8f99 100644
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -37,10 +37,10 @@ CORE_O=	lapi.o lcode.o lctype.o ldebug.o ldo.o ldump.o lfunc.o lgc.o llex.o lmem
+ LIB_O=	lauxlib.o lbaselib.o lcorolib.o ldblib.o liolib.o lmathlib.o loadlib.o loslib.o lstrlib.o ltablib.o lutf8lib.o linit.o
+ BASE_O= $(CORE_O) $(LIB_O) $(MYOBJS)
+ 
+-LUA_T=	lua
++LUA_T=	lua$V
+ LUA_O=	lua.o
+ 
+-LUAC_T=	luac
++LUAC_T=	luac$V
+ LUAC_O=	luac.o
+ 
+ ALL_O= $(BASE_O) $(LUA_O) $(LUAC_O)
+@@ -60,10 +60,10 @@ $(LUA_A): $(BASE_O)
+ 	$(AR) $@ $(BASE_O)
+ 	$(RANLIB) $@
+ 
+-$(LUA_T): $(LUA_O) $(LUA_A)
++origin$(LUA_T): $(LUA_O) $(LUA_A)
+ 	$(CC) -o $@ $(LDFLAGS) $(LUA_O) $(LUA_A) $(LIBS)
+ 
+-$(LUAC_T): $(LUAC_O) $(LUA_A)
++origin$(LUAC_T): $(LUAC_O) $(LUA_A)
+ 	$(CC) -o $@ $(LDFLAGS) $(LUAC_O) $(LUA_A) $(LIBS)
+ 
+ test:
+@@ -218,3 +218,30 @@ lzio.o: lzio.c lprefix.h lua.h luaconf.h llimits.h lmem.h lstate.h \
+  lobject.h ltm.h lzio.h
+ 
+ # (end of Makefile)
++
++export LIBTOOL = libtool --quiet --tag=CC
++export LIB_VERSION = 6:1:1
++
++# The following rules use libtool for compiling and linking in order to
++# provide shared library support.
++
++LIB_NAME = liblua$V.la
++LIB_OBJS = $(CORE_O:.o=.lo) $(LIB_O:.o=.lo)
++
++%.lo %.o: %.c
++	$(LIBTOOL) --mode=compile $(CC) -c $(CPPFLAGS) $(CFLAGS) -o $@ $<
++
++$(LIB_NAME): $(LIB_OBJS)
++	$(LIBTOOL) --mode=link $(CC) -version-info $(LIB_VERSION) \
++            -rpath $(RPATH) $(LDFLAGS) -o $(LIB_NAME) $(LIB_OBJS) $(LIB_LIBS)
++
++$(LUA_T): $(LUA_O:.o=.lo) $(LIB_NAME)
++	$(LIBTOOL) --mode=link $(CC) -static -export-dynamic $(LDFLAGS) -o $@ $(LUA_O:.o=.lo) $(LIB_NAME) $(LUA_LIBS)
++
++$(LUAC_T): $(LUAC_O:.o=.lo) $(LIB_NAME)
++	$(LIBTOOL) --mode=link $(CC) -static $(LDFLAGS) -o $@ $(LUAC_O:.o=.lo) $(LIB_NAME)
++
++gentoo_clean:
++	$(LIBTOOL) --mode=clean $(RM) $(ALL_O:.o=.lo) $(LIB_NAME) lua$V luac$V
++
++gentoo_all: $(LIB_NAME) $(LUA_T) $(LUAC_T)

--- a/dev-lang/lua/lua-5.4.2-r2.ebuild
+++ b/dev-lang/lua/lua-5.4.2-r2.ebuild
@@ -6,7 +6,7 @@ inherit autotools multilib multilib-minimal portability toolchain-funcs
 
 DESCRIPTION="A powerful light-weight programming language designed for extending applications"
 HOMEPAGE="https://www.lua.org/"
-TEST_PV="5.4.4"
+TEST_PV="5.4.2"
 TEST_P="${PN}-${TEST_PV}-tests"
 SRC_URI="
 	https://www.lua.org/ftp/${P}.tar.gz


### PR DESCRIPTION
Similar to how it was fixed for lua 5.3

Bug: https://bugs.gentoo.org/739764
Package-Manager: Portage-3.0.30, Repoman-3.0.3
Signed-off-by: Alexey Sokolov <alexey+gentoo@asokolov.org>