### PR TITLE
app-shells/rc: fix bug preventing rc becoming login shell

### DIFF
--- a/app-shells/rc/rc-1.7.4-r2.ebuild
+++ b/app-shells/rc/rc-1.7.4-r2.ebuild
@@ -1,0 +1,42 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DESCRIPTION="A reimplementation of the Plan 9 shell"
+HOMEPAGE="http://static.tobold.org/"
+SRC_URI="http://static.tobold.org/${PN}/${P}.tar.gz"
+
+LICENSE="rc"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="libedit readline"
+
+RDEPEND="readline? ( sys-libs/readline:0 )
+	libedit? ( dev-libs/libedit )"
+DEPEND="${RDEPEND}"
+
+DOCS=( AUTHORS ChangeLog NEWS README )
+
+src_configure() {
+	local myconf="--with-history"
+	use readline && myconf="--with-edit=readline"
+	use libedit && myconf="--with-edit=edit"
+
+	econf "${myconf}"
+}
+
+src_install() {
+	into /usr
+	newbin "${PN}" "${PN}sh"
+	newman "${PN}.1" "${PN}sh.1"
+	einstalldocs
+}
+
+pkg_postinst() {
+	if ! grep -q '^/usr/bin/rcsh$' "${EROOT}"/etc/shells ; then
+		ebegin "Updating /etc/shells"
+		echo "/usr/bin/rcsh" >> "${EROOT}"/etc/shells
+		eend $?
+	fi
+}


### PR DESCRIPTION
Previously the path /bin/rcsh was appended to /etc/shells
despite the ebuild installing to /usr/bin/rcsh.
This new revision appends the proper path in /etc/shells

Closes: https://bugs.gentoo.org/830633
Package-Manager: Portage-3.0.30, Repoman-3.0.3
Signed-off-by: Richard Rogalski <rrogalski@tutanota.com>