### PR TITLE
riscv: keyword media-gfx/{krita,openvdb} sci-electronics/kicad and minor package.use.mask cleanup

### DIFF
--- a/app-doc/kicad-doc/kicad-doc-6.0.2.ebuild
+++ b/app-doc/kicad-doc/kicad-doc-6.0.2.ebuild
@@ -15,7 +15,7 @@ if [[ ${PV} == 9999 ]]; then
 	LIVE_DEPEND=">=x11-misc/util-macros-1.18"
 else
 	SRC_URI="https://gitlab.com/kicad/services/${PN}/-/archive/${PV}/${P}.tar.gz"
-	KEYWORDS="~amd64 ~arm64 ~x86"
+	KEYWORDS="~amd64 ~arm64 ~riscv ~x86"
 fi
 
 LICENSE="|| ( GPL-3+ CC-BY-3.0 ) GPL-2"

--- a/app-text/ronn-ng/ronn-ng-0.9.1-r1.ebuild
+++ b/app-text/ronn-ng/ronn-ng-0.9.1-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -14,7 +14,7 @@ HOMEPAGE="https://github.com/apjanke/ronn-ng"
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~riscv"
 
 IUSE=""
 

--- a/app-text/ronn/ronn-0.7.3-r4.ebuild
+++ b/app-text/ronn/ronn-0.7.3-r4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -14,7 +14,7 @@ HOMEPAGE="https://github.com/rtomayko/ronn/"
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="amd64 arm ~arm64 ~hppa ppc ppc64 sparc x86 ~amd64-linux ~x86-linux ~x64-macos ~x64-solaris"
+KEYWORDS="amd64 arm ~arm64 ~hppa ppc ppc64 ~riscv sparc x86 ~amd64-linux ~x86-linux ~x64-macos ~x64-solaris"
 
 IUSE=""
 

--- a/dev-cpp/pystring/pystring-1.1.3-r1.ebuild
+++ b/dev-cpp/pystring/pystring-1.1.3-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 Gentoo Authors
+# Copyright 2020-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -13,7 +13,7 @@ if [[ "${PV}" == "9999" ]];  then
 	EGIT_REPO_URI="https://github.com/imageworks/pystring.git"
 else
 	SRC_URI="https://github.com/imageworks/pystring/archive/v${PV}.tar.gz -> ${P}.tar.gz"
-	KEYWORDS="amd64 ~arm ~arm64 ~ppc64 ~x86"
+	KEYWORDS="amd64 ~arm ~arm64 ~ppc64 ~riscv ~x86"
 fi
 
 BDEPEND="

--- a/dev-cpp/robin-map/robin-map-0.6.3.ebuild
+++ b/dev-cpp/robin-map/robin-map-0.6.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -13,7 +13,7 @@ if [[ ${PV} == 9999 ]] ; then
 	EGIT_REPO_URI="https://github.com/Tessil/robin-map"
 else
 	SRC_URI="https://github.com/Tessil/robin-map/archive/v${PV}.tar.gz -> ${P}.tar.gz"
-	KEYWORDS="amd64 ~arm ~arm64 ~ppc64 x86"
+	KEYWORDS="amd64 ~arm ~arm64 ~ppc64 ~riscv x86"
 fi
 
 LICENSE="MIT"

--- a/dev-libs/log4cplus/log4cplus-2.0.7.ebuild
+++ b/dev-libs/log4cplus/log4cplus-2.0.7.ebuild
@@ -11,7 +11,7 @@ SRC_URI="mirror://sourceforge/project/${PN}/${PN}-stable/${PV}/${P}.tar.bz2"
 
 LICENSE="|| ( Apache-2.0 BSD-2 )"
 SLOT="0/3"
-KEYWORDS="amd64 ~arm ~arm64 ~ppc64 ~x86"
+KEYWORDS="amd64 ~arm ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="explicit-initialization iconv qt5 server test threads"
 RESTRICT="!test? ( test )"
 

--- a/dev-libs/pugixml/pugixml-1.12.ebuild
+++ b/dev-libs/pugixml/pugixml-1.12.ebuild
@@ -10,7 +10,7 @@ if [[ ${PV} == *9999 ]] ; then
 	inherit git-r3
 else
 	SRC_URI="https://github.com/zeux/${PN}/releases/download/v${PV}/${P}.tar.gz"
-	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~x86-linux"
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~riscv ~sparc ~x86 ~amd64-linux ~x86-linux"
 fi
 
 DESCRIPTION="Light-weight, simple, and fast XML parser for C++ with XPath support"

--- a/dev-libs/utfcpp/utfcpp-3.2.1.ebuild
+++ b/dev-libs/utfcpp/utfcpp-3.2.1.ebuild
@@ -26,7 +26,7 @@ fi
 
 LICENSE="Boost-1.0"
 SLOT="0"
-KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~sparc ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~riscv ~sparc ~x86"
 IUSE="test"
 RESTRICT="!test? ( test )"
 

--- a/dev-python/pygame/pygame-2.1.2-r1.ebuild
+++ b/dev-python/pygame/pygame-2.1.2-r1.ebuild
@@ -15,7 +15,7 @@ SRC_URI="
 
 LICENSE="LGPL-2.1"
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~riscv ~sparc ~x86"
 IUSE="examples midi opengl test X"
 RESTRICT="!test? ( test )"
 

--- a/dev-python/pyopengl/pyopengl-3.1.6.ebuild
+++ b/dev-python/pyopengl/pyopengl-3.1.6.ebuild
@@ -19,7 +19,7 @@ S="${WORKDIR}/${MY_P}"
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~riscv ~sparc ~x86 ~amd64-linux ~x86-linux"
 IUSE="tk"
 
 RDEPEND="

--- a/dev-ruby/fast_xs/fast_xs-0.8.0-r3.ebuild
+++ b/dev-ruby/fast_xs/fast_xs-0.8.0-r3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -18,7 +18,7 @@ HOMEPAGE="https://github.com/brianmario/fast_xs"
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="amd64 arm ~arm64 ~hppa ppc ppc64 sparc x86 ~amd64-linux ~x86-linux ~x64-macos ~x64-solaris ~x86-solaris"
+KEYWORDS="amd64 arm ~arm64 ~hppa ppc ppc64 ~riscv sparc x86 ~amd64-linux ~x86-linux ~x64-macos ~x64-solaris ~x86-solaris"
 IUSE=""
 
 ruby_add_bdepend "test? ( dev-ruby/rack )"

--- a/dev-ruby/hpricot/hpricot-0.8.6-r6.ebuild
+++ b/dev-ruby/hpricot/hpricot-0.8.6-r6.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -17,7 +17,7 @@ HOMEPAGE="https://wiki.github.com/hpricot/hpricot"
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="amd64 arm ~arm64 ~hppa ppc ppc64 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x64-solaris ~x86-solaris"
+KEYWORDS="amd64 arm ~arm64 ~hppa ppc ppc64 ~riscv sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x64-solaris ~x86-solaris"
 IUSE=""
 
 ruby_add_bdepend "dev-ruby/rake

--- a/dev-ruby/kramdown/kramdown-2.3.1-r1.ebuild
+++ b/dev-ruby/kramdown/kramdown-2.3.1-r1.ebuild
@@ -16,7 +16,7 @@ HOMEPAGE="https://kramdown.gettalong.org/"
 LICENSE="MIT"
 
 SLOT="$(ver_cut 1)"
-KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~sparc ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~riscv ~sparc ~x86"
 IUSE="latex"
 
 LATEX_DEPS="latex? ( dev-texlive/texlive-latex dev-texlive/texlive-latexextra )"

--- a/dev-ruby/mustache/mustache-1.1.1.ebuild
+++ b/dev-ruby/mustache/mustache-1.1.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -17,7 +17,7 @@ HOMEPAGE="https://mustache.github.com/"
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="amd64 arm ~arm64 ~hppa ppc ppc64 sparc x86 ~amd64-linux ~x86-linux ~x64-macos ~x64-solaris"
+KEYWORDS="amd64 arm ~arm64 ~hppa ppc ppc64 ~riscv sparc x86 ~amd64-linux ~x86-linux ~x64-macos ~x64-solaris"
 IUSE=""
 
 PATCHES=( "${FILESDIR}/${P}-test-ordering.patch" )

--- a/dev-ruby/stringex/stringex-2.8.5.ebuild
+++ b/dev-ruby/stringex/stringex-2.8.5.ebuild
@@ -13,7 +13,7 @@ HOMEPAGE="https://github.com/rsl/stringex"
 LICENSE="MIT"
 
 SLOT="0"
-KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~sparc ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~riscv ~sparc ~x86"
 IUSE="test"
 
 # we could rely on activerecord[sqlite3], but since we do not remove the

--- a/dev-tcltk/itcl/itcl-4.2.2.ebuild
+++ b/dev-tcltk/itcl/itcl-4.2.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ SRC_URI="https://github.com/tcltk/${PN}/archive/refs/tags/${MYP}.tar.gz"
 
 SLOT="0"
 LICENSE="BSD"
-KEYWORDS="~alpha ~amd64 ~arm64 ~ia64 ~ppc ~sparc ~x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~alpha ~amd64 ~arm64 ~ia64 ~ppc ~riscv ~sparc ~x86 ~amd64-linux ~x86-linux"
 IUSE=""
 
 RDEPEND=">=dev-lang/tcl-8.6:0="

--- a/dev-tcltk/itk/itk-4.1.0.ebuild
+++ b/dev-tcltk/itk/itk-4.1.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -14,7 +14,7 @@ SRC_URI="mirror://sourceforge/project/incrtcl/%5Bincr%20Tcl_Tk%5D-4-source/itk%2
 IUSE=""
 SLOT="0"
 LICENSE="BSD"
-KEYWORDS="amd64 ~arm64 ~ia64 ppc sparc x86 ~amd64-linux ~x86-linux"
+KEYWORDS="amd64 ~arm64 ~ia64 ppc ~riscv sparc x86 ~amd64-linux ~x86-linux"
 RESTRICT="!test? ( test )"
 
 DEPEND="

--- a/dev-tcltk/togl/togl-2.0-r3.ebuild
+++ b/dev-tcltk/togl/togl-2.0-r3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ SRC_URI="mirror://sourceforge/${PN}/${MY_P}-src.tar.gz"
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~mips ppc ppc64 sparc x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~mips ppc ppc64 ~riscv sparc x86 ~amd64-linux ~x86-linux"
 IUSE="debug +threads"
 
 RDEPEND="

--- a/media-gfx/krita/krita-5.0.2.ebuild
+++ b/media-gfx/krita/krita-5.0.2.ebuild
@@ -12,7 +12,7 @@ inherit ecm kde.org python-single-r1
 
 if [[ ${KDE_BUILD_TYPE} = release ]]; then
 	SRC_URI="mirror://kde/stable/${PN}/${PV}/${P}.tar.xz"
-	KEYWORDS="~amd64 ~arm64 ~ppc64 ~x86"
+	KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 fi
 
 DESCRIPTION="Free digital painting application. Digital Painting, Creative Freedom!"

--- a/media-gfx/openvdb/openvdb-9.0.0-r4.ebuild
+++ b/media-gfx/openvdb/openvdb-9.0.0-r4.ebuild
@@ -13,7 +13,7 @@ SRC_URI="https://github.com/AcademySoftwareFoundation/${PN}/archive/v${PV}.tar.g
 
 LICENSE="MPL-2.0"
 SLOT="0/9"
-KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="cpu_flags_x86_avx cpu_flags_x86_sse4_2 +blosc cuda doc +nanovdb numpy python static-libs test utils +zlib abi6-compat abi7-compat abi8-compat +abi9-compat"
 RESTRICT="!test? ( test )"
 

--- a/media-libs/glfw/glfw-3.3.6.ebuild
+++ b/media-libs/glfw/glfw-3.3.6.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -11,7 +11,7 @@ SRC_URI="https://github.com/glfw/glfw/archive/${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="ZLIB"
 SLOT="0"
-KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc64 ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc64 ~riscv ~x86"
 IUSE="wayland-only"
 
 RDEPEND="

--- a/media-libs/opencolorio/opencolorio-2.1.1-r7.ebuild
+++ b/media-libs/opencolorio/opencolorio-2.1.1-r7.ebuild
@@ -16,7 +16,7 @@ LICENSE="BSD"
 # TODO: drop .1 on next SONAME bump (2.1 -> 2.2?) as we needed to nudge it
 # to force rebuild of consumers due to changing to openexr 3 changing API.
 SLOT="0/$(ver_cut 1-2).1"
-KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="cpu_flags_x86_sse2 doc opengl python static-libs test"
 REQUIRED_USE="
 	doc? ( python )

--- a/media-libs/openimageio/openimageio-2.3.12.0-r3.ebuild
+++ b/media-libs/openimageio/openimageio-2.3.12.0-r3.ebuild
@@ -23,7 +23,7 @@ LICENSE="BSD"
 # TODO: drop .1 on next SONAME change (2.3 -> 2.4?) as we needed to nudge it
 # for changing to openexr 3 which broke ABI.
 SLOT="0/$(ver_cut 1-2).1"
-KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~riscv ~x86"
 
 X86_CPU_FEATURES=(
 	aes:aes sse2:sse2 sse3:sse3 ssse3:ssse3 sse4_1:sse4.1 sse4_2:sse4.2

--- a/media-libs/ptex/ptex-2.3.2.ebuild
+++ b/media-libs/ptex/ptex-2.3.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ SRC_URI="https://github.com/wdas/ptex/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="amd64 ~arm ~arm64 x86"
+KEYWORDS="amd64 ~arm ~arm64 ~riscv x86"
 IUSE="static-libs"
 
 BDEPEND="app-doc/doxygen"

--- a/media-libs/sdl-ttf/sdl-ttf-2.0.11-r1.ebuild
+++ b/media-libs/sdl-ttf/sdl-ttf-2.0.11-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -11,7 +11,7 @@ SRC_URI="http://www.libsdl.org/projects/SDL_ttf/release/${MY_P}.tar.gz"
 
 LICENSE="ZLIB"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ppc ppc64 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-solaris"
+KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ppc ppc64 ~riscv sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-solaris"
 IUSE="static-libs X"
 
 RDEPEND="

--- a/media-libs/smpeg2/smpeg2-2.0.0-r4.ebuild
+++ b/media-libs/smpeg2/smpeg2-2.0.0-r4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -14,7 +14,7 @@ S="${WORKDIR}/${MY_P}"
 
 LICENSE="LGPL-2+"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ppc ppc64 sparc x86"
+KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ppc ppc64 ~riscv sparc x86"
 IUSE="cpu_flags_x86_mmx"
 
 DEPEND="media-libs/libsdl2[${MULTILIB_USEDEP}]"

--- a/profiles/arch/riscv/package.use.mask
+++ b/profiles/arch/riscv/package.use.mask
@@ -1,6 +1,11 @@
 # Copyright 2019-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Alex Fan <alex.fan.q@gmail.com> (2022-02-28)
+# dev-libs/vc is a dummy implementation on this arch
+# krita fails to build with it
+media-gfx/krita vc
+
 # Adel Kara Slimane <adel.ks@zegrapher.com> (2022-02-17)
 # Mask AMF keyword on non-amd64 arches
 # It is unusable, for now, in other arches

--- a/profiles/arch/riscv/package.use.mask
+++ b/profiles/arch/riscv/package.use.mask
@@ -190,6 +190,7 @@ mail-mta/courier fax
 # Dependencies not keyworded here yet:
 #  - dev-cpp/glog, sci-libs/vtk
 media-libs/opencv contribsfm glog vtk
+sci-libs/opencascade vtk
 #  - dev-util/aruba
 sys-block/thin-provisioning-tools test
 

--- a/profiles/arch/riscv/package.use.mask
+++ b/profiles/arch/riscv/package.use.mask
@@ -6,10 +6,6 @@
 # It is unusable, for now, in other arches
 media-video/ffmpeg amf
 
-# Sam James <sam@gentoo.org> (2022-01-29)
-# app-text/ronn-ng not keyworded here, bug #801103
-app-accessibility/espeak-ng man
-
 # Yongxinag Liang <tanekliang@gmail.com> (2022-01-09)
 # app-emulation/xen-tools doesn't support riscv yet
 app-emulation/qemu xen

--- a/profiles/arch/riscv/package.use.mask
+++ b/profiles/arch/riscv/package.use.mask
@@ -42,10 +42,6 @@ dev-python/anyio test
 # depends on dev-lang/ocaml
 app-accessibility/brltty ocaml ocamlopt
 
-# Alex Fan <alex.fan.q@gmail.com> (2021-11-19)
-# opengl -> dev-python/pygame is not keyworded yet
-dev-python/sympy opengl
-
 # Sam James <sam@gentoo.org> (2021-10-26)
 # sys-libs/libhugetlbfs is not keyworded on ~riscv right now
 sys-apps/nvme-cli hugepages

--- a/profiles/arch/riscv/package.use.mask
+++ b/profiles/arch/riscv/package.use.mask
@@ -21,10 +21,6 @@ sys-fs/multipath-tools rbd
 # requires sys-apps/dbus-broker, which is keyworded here.
 sys-apps/systemd -hostnamed-fallback
 
-# Andrey Grozin <grozin@gentoo.org> (2022-01-03)
-# dev-libs/utfcpp is not keyworded yet
-media-gfx/asymptote lsp
-
 # Yongxinag Liang <tanekliang@gmail.com> (2021-12-30)
 # untested.
 net-misc/vinagre spice

--- a/sci-electronics/electronics-menu/electronics-menu-1.0-r1.ebuild
+++ b/sci-electronics/electronics-menu/electronics-menu-1.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,4 +11,4 @@ SRC_URI="http://geda.seul.org/dist/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 ~arm64 ppc ppc64 sparc x86"
+KEYWORDS="amd64 ~arm64 ppc ppc64 ~riscv sparc x86"

--- a/sci-electronics/kicad-footprints/kicad-footprints-6.0.2.ebuild
+++ b/sci-electronics/kicad-footprints/kicad-footprints-6.0.2.ebuild
@@ -17,7 +17,7 @@ else
 	SRC_URI="https://gitlab.com/kicad/libraries/${PN}/-/archive/${MY_PV}/${MY_P}.tar.gz -> ${P}.tar.gz"
 
 	if [[ ${PV} != *_rc* ]] ; then
-		KEYWORDS="~amd64 ~arm64 ~x86"
+		KEYWORDS="~amd64 ~arm64 ~riscv ~x86"
 	fi
 
 	S="${WORKDIR}/${PN}-${MY_PV}"

--- a/sci-electronics/kicad-meta/kicad-meta-6.0.2.ebuild
+++ b/sci-electronics/kicad-meta/kicad-meta-6.0.2.ebuild
@@ -11,7 +11,7 @@ LICENSE="metapackage"
 SLOT="0"
 
 if [[ ${PV} != *_rc* ]] ; then
-	KEYWORDS="~amd64 ~arm64 ~x86"
+	KEYWORDS="~amd64 ~arm64 ~riscv ~x86"
 fi
 
 IUSE="doc minimal"

--- a/sci-electronics/kicad-packages3d/kicad-packages3d-6.0.2.ebuild
+++ b/sci-electronics/kicad-packages3d/kicad-packages3d-6.0.2.ebuild
@@ -17,7 +17,7 @@ else
 	SRC_URI="https://gitlab.com/kicad/libraries/${PN}/-/archive/${MY_PV}/${MY_P}.tar.gz -> ${P}.tar.gz"
 
 	if [[ ${PV} != *_rc* ]] ; then
-		KEYWORDS="~amd64 ~arm64 ~x86"
+		KEYWORDS="~amd64 ~arm64 ~riscv ~x86"
 	fi
 
 	S="${WORKDIR}/${PN/3d/3D}-${MY_PV}-02c0df0309784b30de2d65ca2c7385942591135c"

--- a/sci-electronics/kicad-symbols/kicad-symbols-6.0.2.ebuild
+++ b/sci-electronics/kicad-symbols/kicad-symbols-6.0.2.ebuild
@@ -15,7 +15,7 @@ else
 	SRC_URI="https://gitlab.com/kicad/libraries/${PN}/-/archive/${PV}/${P}.tar.gz"
 
 	if [[ ${PV} != *_rc* ]] ; then
-		KEYWORDS="~amd64 ~arm64 ~x86"
+		KEYWORDS="~amd64 ~arm64 ~riscv ~x86"
 	fi
 fi
 

--- a/sci-electronics/kicad-templates/kicad-templates-6.0.2.ebuild
+++ b/sci-electronics/kicad-templates/kicad-templates-6.0.2.ebuild
@@ -16,7 +16,7 @@ else
 	SRC_URI="https://gitlab.com/kicad/libraries/${PN}/-/archive/${MY_PV}/${MY_P}.tar.gz -> ${P}.tar.gz"
 
 	if [[ ${PV} != *_rc* ]] ; then
-		KEYWORDS="~amd64 ~arm64 ~x86"
+		KEYWORDS="~amd64 ~arm64 ~riscv ~x86"
 	fi
 
 	S="${WORKDIR}/${PN}-${MY_PV}"

--- a/sci-electronics/kicad/kicad-6.0.2.ebuild
+++ b/sci-electronics/kicad/kicad-6.0.2.ebuild
@@ -21,7 +21,7 @@ else
 	S="${WORKDIR}/${PN}-${MY_PV}"
 
 	if [[ ${PV} != *_rc* ]] ; then
-		KEYWORDS="~amd64 ~arm64 ~x86"
+		KEYWORDS="~amd64 ~arm64 ~riscv ~x86"
 	fi
 fi
 

--- a/sci-electronics/ngspice/ngspice-36.ebuild
+++ b/sci-electronics/ngspice/ngspice-36.ebuild
@@ -13,7 +13,7 @@ LICENSE="BSD GPL-2"
 
 SLOT="0"
 IUSE="X debug deprecated doc examples fftw openmp +readline +shared tcl"
-KEYWORDS="~amd64 ~arm64 ~ppc ~sparc ~x86 ~x64-macos"
+KEYWORDS="~amd64 ~arm64 ~ppc ~riscv ~sparc ~x86 ~x64-macos"
 
 RESTRICT="!test? ( test )"
 

--- a/sci-libs/dcmtk/dcmtk-3.6.5.ebuild
+++ b/sci-libs/dcmtk/dcmtk-3.6.5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -10,7 +10,7 @@ HOMEPAGE="https://dicom.offis.de/dcmtk.php.en"
 SRC_URI="https://dicom.offis.de/download/dcmtk/release/${P}.tar.gz"
 
 LICENSE="OFFIS"
-KEYWORDS="amd64 ~arm ~arm64 ~ppc64 x86"
+KEYWORDS="amd64 ~arm ~arm64 ~ppc64 ~riscv x86"
 SLOT="0"
 IUSE="doc png ssl tcpd tiff +threads xml zlib"
 

--- a/sci-libs/opencascade/opencascade-7.6.0-r2.ebuild
+++ b/sci-libs/opencascade/opencascade-7.6.0-r2.ebuild
@@ -15,7 +15,7 @@ S="${WORKDIR}/occt-V${MY_PV}"
 
 LICENSE="|| ( Open-CASCADE-LGPL-2.1-Exception-1.0 LGPL-2.1 )"
 SLOT="0/${MY_SLOT}"
-KEYWORDS="~amd64 ~arm64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~riscv ~x86"
 IUSE="doc eigen examples ffmpeg freeimage gles2 json optimize tbb vtk"
 
 REQUIRED_USE="?? ( optimize tbb )"


### PR DESCRIPTION
tested on sifive unmatched (rv64d)