### PR TITLE
sci-libs/vtk: select desired Qt version

### DIFF
--- a/sci-libs/vtk/vtk-9.1.0.ebuild
+++ b/sci-libs/vtk/vtk-9.1.0.ebuild
@@ -457,7 +457,10 @@ src_configure() {
 	fi
 
 	if use qt5; then
-		mycmakeargs+=( -DVTK_MODULE_ENABLE_VTK_GUISupportQt="WANT" )
+		mycmakeargs+=(
+			-DVTK_MODULE_ENABLE_VTK_GUISupportQt="WANT"
+			-DVTK_QT_VERSION="5"
+		)
 		if use mysql || use postgres; then
 			mycmakeargs+=( -DVTK_MODULE_ENABLE_VTK_GUISupportQtSQL="WANT" )
 		fi


### PR DESCRIPTION
If both, Qt5 and Qt6 are installed and found, Qt6 is preferred. The
ebuild, however, does not build against Qt6. To ensure Qt5 is selected
we pass VTK_QT_VERSION to cmake.

Closes: https://bugs.gentoo.org/834595
Package-Manager: Portage-3.0.30, Repoman-3.0.3
Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>