### PR TITLE
media-video/wireplumber: add a fix for PW 0.3.48

### DIFF
--- a/media-video/pipewire/pipewire-0.3.48.ebuild
+++ b/media-video/pipewire/pipewire-0.3.48.ebuild
@@ -108,7 +108,7 @@ DEPEND="${RDEPEND}"
 
 # TODO: Consider use cases where pipewire is not used for driving audio
 # Doing so with WirePlumber currently involves editing Lua scripts
-PDEPEND="media-video/wireplumber"
+PDEPEND=">=media-video/wireplumber-0.4.8-r3"
 
 # Present RDEPEND that are currently always disabled due to the PW
 # code using them being required to be disabled by Gentoo guidelines

--- a/media-video/pipewire/pipewire-9999.ebuild
+++ b/media-video/pipewire/pipewire-9999.ebuild
@@ -108,7 +108,7 @@ DEPEND="${RDEPEND}"
 
 # TODO: Consider use cases where pipewire is not used for driving audio
 # Doing so with WirePlumber currently involves editing Lua scripts
-PDEPEND="media-video/wireplumber"
+PDEPEND=">=media-video/wireplumber-0.4.8-r3"
 
 # Present RDEPEND that are currently always disabled due to the PW
 # code using them being required to be disabled by Gentoo guidelines

--- a/media-video/wireplumber/files/wireplumber-0.4.8-si-audio-adapter-relax-format-parsing.patch
+++ b/media-video/wireplumber/files/wireplumber-0.4.8-si-audio-adapter-relax-format-parsing.patch
@@ -1,0 +1,44 @@
+https://gitlab.freedesktop.org/pipewire/wireplumber/-/commit/afbc0ce57aac7aee8dc1651de4620f15c73dbace
+
+From afbc0ce57aac7aee8dc1651de4620f15c73dbace Mon Sep 17 00:00:00 2001
+From: Wim Taymans <wtaymans@redhat.com>
+Date: Mon, 21 Feb 2022 15:21:36 +0100
+Subject: [PATCH] si-audio-adapter: relax format parsing
+
+Some nodes can omit the format/rate/channels to indicate that they can
+deal with all possibilities and adapt to what they are linked to.
+
+See pipewire#876
+---
+ modules/module-si-audio-adapter.c | 11 ++---------
+ 1 file changed, 2 insertions(+), 9 deletions(-)
+
+diff --git a/modules/module-si-audio-adapter.c b/modules/module-si-audio-adapter.c
+index f1f6218..84e393f 100644
+--- a/modules/module-si-audio-adapter.c
++++ b/modules/module-si-audio-adapter.c
+@@ -158,19 +158,12 @@ si_audio_adapter_find_format (WpSiAudioAdapter * self, WpNode * node)
+       struct spa_pod *position = NULL;
+       wp_spa_pod_fixate (pod);
+ 
+-      /* defaults */
+       spa_zero(raw_format);
+-      raw_format.format = SPA_AUDIO_FORMAT_F32;
+-      raw_format.rate = si_audio_adapter_get_default_clock_rate (self);
+-      raw_format.channels = 2;
+-      raw_format.position[0] = SPA_AUDIO_CHANNEL_FL;
+-      raw_format.position[1] = SPA_AUDIO_CHANNEL_FR;
+-
+       if (spa_pod_parse_object(wp_spa_pod_get_spa_pod (pod),
+                                SPA_TYPE_OBJECT_Format, NULL,
+-                               SPA_FORMAT_AUDIO_format,   SPA_POD_Id(&raw_format.format),
++                               SPA_FORMAT_AUDIO_format,   SPA_POD_OPT_Id(&raw_format.format),
+                                SPA_FORMAT_AUDIO_rate,     SPA_POD_OPT_Int(&raw_format.rate),
+-                               SPA_FORMAT_AUDIO_channels, SPA_POD_Int(&raw_format.channels),
++                               SPA_FORMAT_AUDIO_channels, SPA_POD_OPT_Int(&raw_format.channels),
+                                SPA_FORMAT_AUDIO_position, SPA_POD_OPT_Pod(&position)) < 0)
+         continue;
+ 
+-- 
+2.35.1
+

--- a/media-video/wireplumber/wireplumber-0.4.8-r3.ebuild
+++ b/media-video/wireplumber/wireplumber-0.4.8-r3.ebuild
@@ -1,0 +1,123 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+LUA_COMPAT=( lua5-{3,4} )
+
+inherit lua-single meson systemd
+
+if [[ ${PV} == 9999 ]]; then
+	EGIT_REPO_URI="https://gitlab.freedesktop.org/pipewire/${PN}.git"
+	EGIT_BRANCH="master"
+	inherit git-r3
+else
+	SRC_URI="https://gitlab.freedesktop.org/pipewire/${PN}/-/archive/${PV}/${P}.tar.gz"
+	KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~riscv ~sparc ~x86"
+fi
+
+DESCRIPTION="Replacement for pipewire-media-session"
+HOMEPAGE="https://gitlab.freedesktop.org/pipewire/wireplumber"
+
+LICENSE="MIT"
+SLOT="0/0.4"
+IUSE="elogind system-service systemd test"
+
+REQUIRED_USE="
+	${LUA_REQUIRED_USE}
+	?? ( elogind systemd )
+	system-service? ( systemd )
+"
+
+RESTRICT="!test? ( test )"
+
+# introspection? ( dev-libs/gobject-introspection ) is valid but likely only used for doc building
+BDEPEND="
+	dev-libs/glib
+	dev-util/gdbus-codegen
+	dev-util/glib-utils
+"
+
+DEPEND="
+	${LUA_DEPS}
+	>=dev-libs/glib-2.62
+	>=media-video/pipewire-0.3.45:=
+	virtual/libc
+	elogind? ( sys-auth/elogind )
+	systemd? ( sys-apps/systemd )
+"
+
+# Any dev-lua/* deps get declared like this inside RDEPEND:
+#	$(lua_gen_cond_dep '
+#		dev-lua/<NAME>[${LUA_USEDEP}]
+#	')
+RDEPEND="${DEPEND}
+	system-service? (
+		acct-user/pipewire
+		acct-group/pipewire
+	)
+"
+
+DOCS=( {NEWS,README}.rst )
+
+PATCHES=(
+	"${FILESDIR}"/${P}-restore-stream-do-not-crash-if-config.properties-is-.patch
+	"${FILESDIR}"/${P}-spa-json-fix-va-list-APIs-for-different-architecture.patch
+	"${FILESDIR}"/${P}-policy-bluetooth-fix-string.find-crash-with-nil-stri.patch
+	"${FILESDIR}"/${P}-si-audio-adapter-relax-format-parsing.patch
+)
+
+src_configure() {
+	local emesonargs=(
+		-Ddoc=disabled # Ebuild not wired up yet (Sphinx, Doxygen?)
+		-Dintrospection=disabled # Only used for Sphinx doc generation
+		-Dsystem-lua=true # We always unbundle everything we can
+		-Dsystem-lua-version=$(ver_cut 1-2 $(lua_get_version))
+		$(meson_feature elogind)
+		$(meson_feature systemd)
+		$(meson_use system-service systemd-system-service)
+		$(meson_use systemd systemd-user-service)
+		-Dsystemd-system-unit-dir=$(systemd_get_systemunitdir)
+		-Dsystemd-user-unit-dir=$(systemd_get_userunitdir)
+		$(meson_use test tests)
+	)
+
+	meson_src_configure
+}
+
+src_install() {
+	meson_src_install
+
+	# We copy the default config, so that Gentoo tools can pick up on any
+	# updates and /etc does not end up with stale overrides.
+	# If a reflinking CoW filesystem is used (e.g. Btrfs), then the files
+	# will not actually get stored twice until modified.
+	insinto /etc
+	doins -r ${ED}/usr/share/wireplumber
+}
+
+pkg_postinst() {
+	if systemd_is_booted ; then
+		ewarn "pipewire-media-session.service is no longer installed. You must switch"
+		ewarn "to wireplumber.service user unit before your next logout/reboot:"
+		ewarn "systemctl --user disable pipewire-media-session.service"
+		ewarn "systemctl --user --force enable wireplumber.service"
+	else
+		ewarn "Switch to WirePlumber will happen the next time gentoo-pipewire-launcher"
+		ewarn "is started (a replacement for directly calling pipewire binary)."
+		ewarn
+		ewarn "Please ensure that ${EROOT}/etc/pipewire/pipewire.conf either does not exist"
+		ewarn "or, if it does exist, that any reference to"
+		ewarn "${EROOT}/usr/bin/pipewire-media-session is commented out (begins with a #)."
+	fi
+	if use system-service; then
+		ewarn
+		ewarn "WARNING: you have enabled the system-service USE flag, which installs"
+		ewarn "the system-wide systemd units that enable WirePlumber to run as a system"
+		ewarn "service. This is more than likely NOT what you want. You are strongly"
+		ewarn "advised not to enable this mode and instead stick with systemd user"
+		ewarn "units. The default configuration files will likely not work out of"
+		ewarn "box, and you are on your own with configuration."
+		ewarn
+	fi
+}


### PR DESCRIPTION
PW 0.3.48 contains a change that may break PulseAudio support without
a fix on WP side. This commit adds that fix as wireplumber-0.4.8-r3
ebuild. Because ~testing only needs to work with ~testing, it has not
been verified that the r3 works as intended with PW versions older than
the current ~testing version. However there's no reason to believe it
would not, so the version minimum is not being bumped up.

Bug: https://gitlab.freedesktop.org/pipewire/pipewire/-/issues/2189