### PR TITLE
sys-devel/llvm-roc: locate bitcode correctly

### DIFF
--- a/sys-devel/llvm-roc/files/llvm-roc-4.3.0-hip-location.patch
+++ b/sys-devel/llvm-roc/files/llvm-roc-4.3.0-hip-location.patch
@@ -143,6 +143,15 @@ Author: Yiyang Wu <xgreenlandforwyy@gmail.com>
  }
  
  RocmInstallationDetector::RocmInstallationDetector(
+@@ -397,7 +272,7 @@ void RocmInstallationDetector::detectDev
+     // - ${ROCM_ROOT}/lib/bitcode/*
+     // so try to detect these layouts.
+     static constexpr std::array<const char *, 2> SubDirsList[] = {
+-        {"amdgcn", "bitcode"},
++        {"lib/amdgcn", "bitcode"},
+         {"lib", ""},
+         {"lib", "bitcode"},
+     };
 @@ -423,42 +298,7 @@ void RocmInstallationDetector::detectDev
  }
  


### PR DESCRIPTION
This fixes clang not able to find rocm-device-libs when calling from
rocm-comgr instead of commandline.

Closes: https://bugs.gentoo.org/830762
Package-Manager: Portage-3.0.30, Repoman-3.0.3
Signed-off-by: Yiyang Wu <xgreenlandforwyy@gmail.com>