### PR TITLE
dev-libs/nss: remove prelink files

### DIFF
--- a/dev-libs/nss/nss-3.68.2-r1.ebuild
+++ b/dev-libs/nss/nss-3.68.2-r1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=8
+EAPI=7
 
 inherit flag-o-matic multilib toolchain-funcs multilib-minimal
 
@@ -15,7 +15,7 @@ SRC_URI="https://archive.mozilla.org/pub/security/nss/releases/${RTM_NAME}/src/$
 
 LICENSE="|| ( MPL-2.0 GPL-2 LGPL-2.1 )"
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~x64-solaris ~x86-solaris"
+KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux ~x64-solaris ~x86-solaris"
 IUSE="cacert utils cpu_flags_ppc_altivec cpu_flags_ppc_vsx"
 # pkg-config called by nss-config -> virtual/pkgconfig in RDEPEND
 RDEPEND="
@@ -335,12 +335,6 @@ multilib_src_install() {
 		done
 		popd >/dev/null || die
 	fi
-
-	# Prelink breaks the CHK files. We don't have any reliable way to run
-	# shlibsign after prelink.
-	dodir /etc/prelink.conf.d
-	printf -- "-b ${EPREFIX}/usr/$(get_libdir)/lib%s.so\n" ${NSS_CHK_SIGN_LIBS} \
-		> "${ED}"/etc/prelink.conf.d/nss.conf
 }
 
 pkg_postinst() {

--- a/dev-libs/nss/nss-3.75-r1.ebuild
+++ b/dev-libs/nss/nss-3.75-r1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 inherit flag-o-matic multilib toolchain-funcs multilib-minimal
 
@@ -15,7 +15,7 @@ SRC_URI="https://archive.mozilla.org/pub/security/nss/releases/${RTM_NAME}/src/$
 
 LICENSE="|| ( MPL-2.0 GPL-2 LGPL-2.1 )"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux ~x64-solaris ~x86-solaris"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~x64-solaris ~x86-solaris"
 IUSE="cacert utils cpu_flags_ppc_altivec cpu_flags_ppc_vsx"
 # pkg-config called by nss-config -> virtual/pkgconfig in RDEPEND
 RDEPEND="
@@ -335,12 +335,6 @@ multilib_src_install() {
 		done
 		popd >/dev/null || die
 	fi
-
-	# Prelink breaks the CHK files. We don't have any reliable way to run
-	# shlibsign after prelink.
-	dodir /etc/prelink.conf.d
-	printf -- "-b ${EPREFIX}/usr/$(get_libdir)/lib%s.so\n" ${NSS_CHK_SIGN_LIBS} \
-		> "${ED}"/etc/prelink.conf.d/nss.conf
 }
 
 pkg_postinst() {

--- a/dev-libs/nss/nss-3.76-r1.ebuild
+++ b/dev-libs/nss/nss-3.76-r1.ebuild
@@ -335,12 +335,6 @@ multilib_src_install() {
 		done
 		popd >/dev/null || die
 	fi
-
-	# Prelink breaks the CHK files. We don't have any reliable way to run
-	# shlibsign after prelink.
-	dodir /etc/prelink.conf.d
-	printf -- "-b ${EPREFIX}/usr/$(get_libdir)/lib%s.so\n" ${NSS_CHK_SIGN_LIBS} \
-		> "${ED}"/etc/prelink.conf.d/nss.conf
 }
 
 pkg_postinst() {


### PR DESCRIPTION
Since prelink has been last-rited, removing all prelink related stuff,
which is being installed.

@gentoo/mozilla ok for merge?

Signed-off-by: Conrad Kostecki <conikost@gentoo.org>