### PR TITLE
mail-client/evolution: remove prelink files

### DIFF
--- a/mail-client/evolution/evolution-3.40.4-r1.ebuild
+++ b/mail-client/evolution/evolution-3.40.4-r1.ebuild
@@ -135,13 +135,6 @@ src_test() {
 src_install() {
 	cmake_src_install
 
-	# Problems with prelink:
-	# https://bugzilla.gnome.org/show_bug.cgi?id=731680
-	# https://bugzilla.gnome.org/show_bug.cgi?id=732148
-	# https://bugzilla.redhat.com/show_bug.cgi?id=1114538
-	echo PRELINK_PATH_MASK=/usr/bin/evolution > ${T}/99${PN}
-	doenvd "${T}"/99${PN}
-
 	readme.gentoo_create_doc
 }
 

--- a/mail-client/evolution/evolution-3.42.3-r1.ebuild
+++ b/mail-client/evolution/evolution-3.42.3-r1.ebuild
@@ -135,13 +135,6 @@ src_test() {
 src_install() {
 	cmake_src_install
 
-	# Problems with prelink:
-	# https://bugzilla.gnome.org/show_bug.cgi?id=731680
-	# https://bugzilla.gnome.org/show_bug.cgi?id=732148
-	# https://bugzilla.redhat.com/show_bug.cgi?id=1114538
-	echo PRELINK_PATH_MASK=/usr/bin/evolution > ${T}/99${PN}
-	doenvd "${T}"/99${PN}
-
 	readme.gentoo_create_doc
 }
 

--- a/mail-client/evolution/evolution-3.42.4-r1.ebuild
+++ b/mail-client/evolution/evolution-3.42.4-r1.ebuild
@@ -135,13 +135,6 @@ src_test() {
 src_install() {
 	cmake_src_install
 
-	# Problems with prelink:
-	# https://bugzilla.gnome.org/show_bug.cgi?id=731680
-	# https://bugzilla.gnome.org/show_bug.cgi?id=732148
-	# https://bugzilla.redhat.com/show_bug.cgi?id=1114538
-	echo PRELINK_PATH_MASK=/usr/bin/evolution > ${T}/99${PN}
-	doenvd "${T}"/99${PN}
-
 	readme.gentoo_create_doc
 }
 


### PR DESCRIPTION
Since prelink has been last-rited, removing all prelink related stuff,
which is being installed.

@gentoo/gnome: ok for merge?

Signed-off-by: Conrad Kostecki <conikost@gentoo.org>