### PR TITLE
sys-cluster/charliecloud: Fix Python shebang.

### DIFF
--- a/sys-cluster/charliecloud/charliecloud-0.26-r1.ebuild
+++ b/sys-cluster/charliecloud/charliecloud-0.26-r1.ebuild
@@ -66,6 +66,8 @@ src_configure() {
 		--enable-buggy-build
 		# Do not use bundled version of dev-python/lark-parser.
 		--disable-bundled-lark
+		# Use correct shebang.
+		--with-python=${PYTHON}
 	)
 	econf "${econf_args[@]}"
 }

--- a/sys-cluster/charliecloud/charliecloud-9999.ebuild
+++ b/sys-cluster/charliecloud/charliecloud-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -66,6 +66,8 @@ src_configure() {
 		--enable-buggy-build
 		# Do not use bundled version of dev-python/lark-parser.
 		--disable-bundled-lark
+		# Use correct shebang.
+		--with-python=${PYTHON}
 	)
 	econf "${econf_args[@]}"
 }


### PR DESCRIPTION
Previously, `/usr/bin/env python3` was used (upstream default),
which is generic and hence should not be used on Gentoo.

Package-Manager: Portage-3.0.30, Repoman-3.0.3
Signed-off-by: Oliver Freyermuth <o.freyermuth@googlemail.com>