### PR TITLE
dev-libs/rocm-comgr: correct LLVM_PATH and HIP_PATH

### DIFF
--- a/dev-libs/rocm-comgr/rocm-comgr-4.3.0-r1.ebuild
+++ b/dev-libs/rocm-comgr/rocm-comgr-4.3.0-r1.ebuild
@@ -29,6 +29,12 @@ RDEPEND=">=dev-libs/rocm-device-libs-${PV}
 	>=sys-devel/llvm-roc-${PV}:="
 DEPEND="${RDEPEND}"
 
+src_prepare() {
+	sed '/sys::path::append(HIPPath/s,"hip","lib/hip",' -i src/comgr-env.cpp || die
+	sed '/sys::path::append(LLVMPath/s,"llvm","lib/llvm/roc",' -i src/comgr-env.cpp || die
+	cmake_src_prepare
+}
+
 src_configure() {
 	local mycmakeargs=(
 		-DLLD_DIR="${EPREFIX}/usr/lib/llvm/roc/lib/cmake/lld"


### PR DESCRIPTION
Fixes comgr cannot find correct hipcc and llvm-roc clang include path.

Closes: https://bugs.gentoo.org/834674
Package-Manager: Portage-3.0.30, Repoman-3.0.3
Signed-off-by: Yiyang Wu <xgreenlandforwyy@gmail.com>