### PR TITLE
app-emulation/libvirt: Fix a typo on postinst message

### DIFF
--- a/app-emulation/libvirt/files/README.gentoo-r3
+++ b/app-emulation/libvirt/files/README.gentoo-r3
@@ -5,7 +5,7 @@ host. In order to reenable client handling, edit /etc/conf.d/libvirt-guests
 and enable the service and start it:
 
 	$ rc-update add libvirt-guests
-	$ service libvirt-guests start
+	$ rc-service libvirt-guests start
 
 
 For the basic networking support (bridged and routed networks) you don't


### PR DESCRIPTION
There's a typo in the postinst message as it suggests using
'service' to start libvirtd service, while in fact the correct
binary is 'rc-service'.

Closes: https://bugs.gentoo.org/833622
Signed-off-by: Michal Privoznik <mprivozn@redhat.com>