### PR TITLE
app-emulation/libvirt: Fix libvirtd crash on domain restore

### DIFF
--- a/app-emulation/libvirt/files/libvirt-8.1.0-libxl-Fix-libvirtd-crash-on-domain-restore.patch
+++ b/app-emulation/libvirt/files/libvirt-8.1.0-libxl-Fix-libvirtd-crash-on-domain-restore.patch
@@ -1,0 +1,37 @@
+From 454b927d1e33a1fe9dca535db2c97300fdae62cc Mon Sep 17 00:00:00 2001
+Message-Id: <454b927d1e33a1fe9dca535db2c97300fdae62cc.1646730306.git.mprivozn@redhat.com>
+From: Jim Fehlig <jfehlig@suse.com>
+Date: Thu, 17 Feb 2022 11:48:13 -0700
+Subject: [PATCH] libxl: Fix libvirtd crash on domain restore
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Commit cc2a3c2a94 missed one case in the libxl driver where virDomainDef
+is returned from libxlDomainSaveImageOpen and a g_steal_pointer is needed.
+Without it, the virDomainDef object is freed and the driver crashes later
+in the restore process when accessing the object.
+
+Signed-off-by: Jim Fehlig <jfehlig@suse.com>
+Reviewed-by: Ján Tomko <jtomko@redhat.com>
+Signed-off-by: Michal Privoznik <mprivozn@redhat.com>
+---
+ src/libxl/libxl_domain.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/libxl/libxl_domain.c b/src/libxl/libxl_domain.c
+index c91e531a9a..ee031267ca 100644
+--- a/src/libxl/libxl_domain.c
++++ b/src/libxl/libxl_domain.c
+@@ -811,7 +811,7 @@ libxlDomainSaveImageOpen(libxlDriverPrivate *driver,
+                                         VIR_DOMAIN_DEF_PARSE_SKIP_VALIDATE)))
+         goto error;
+ 
+-    *ret_def = def;
++    *ret_def = g_steal_pointer(&def);
+     *ret_hdr = hdr;
+ 
+     return fd;
+-- 
+2.34.1
+

--- a/app-emulation/libvirt/libvirt-8.0.0-r2.ebuild
+++ b/app-emulation/libvirt/libvirt-8.0.0-r2.ebuild
@@ -135,6 +135,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-6.7.0-do-not-use-sysconfig.patch
 	"${FILESDIR}"/${PN}-6.7.0-fix-paths-for-apparmor.patch
 	"${FILESDIR}"/${PN}-8.1.0-docs-Fix-template-matching-in-page.xsl.patch
+	"${FILESDIR}"/${PN}-8.1.0-libxl-Fix-libvirtd-crash-on-domain-restore.patch
 )
 
 pkg_setup() {


### PR DESCRIPTION
In the libvirt-8.0.0 development cycle a commit was merged that
can potentially cause crash of libvirtd. This was fixed in the
next release. Backport the commit that fixes the problem.

Closes: https://bugs.gentoo.org/831447
Signed-off-by: Michal Privoznik <mprivozn@redhat.com>