### PR TITLE
media-sound/pulseaudio: Pass through bluetooth use flag to dependency

### DIFF
--- a/media-sound/pulseaudio/pulseaudio-15.99.1-r1.ebuild
+++ b/media-sound/pulseaudio/pulseaudio-15.99.1-r1.ebuild
@@ -15,11 +15,14 @@ LICENSE="metapackage"
 
 SLOT="0"
 
-IUSE="+daemon +glib"
+# NOTE: bluetooth, native-headset and ofono-headset are passed through to
+# pulseaudio-daemon dependency to make sure users who have bluetooth enabled
+# just for pulseaudio package will also get these enabled via metapackage.
+IUSE="bluetooth +daemon +glib jack native-headset ofono-headset"
 
 RDEPEND="
 	>=media-libs/libpulse-${PV}[glib?,${MULTILIB_USEDEP}]
-	daemon? ( >=media-sound/pulseaudio-daemon-${PV} )
+	daemon? ( >=media-sound/pulseaudio-daemon-${PV}[bluetooth?,glib?,jack?,native-headset?,ofono-headset?] )
 "
 DEPEND="${RDEPEND}"
 


### PR DESCRIPTION
Pass bluetooth use flag to media-sound/pulseaudio-daemon to ease transition for users who have enabled bluetooth for pulseaudio package only.

Signed-off-by: Igor V. Kovalenko <igor.v.kovalenko@gmail.com>