### PR TITLE
media-libs/gmmlib: added new subslot

### DIFF
--- a/media-libs/gmmlib/gmmlib-22.0.3-r1.ebuild
+++ b/media-libs/gmmlib/gmmlib-22.0.3-r1.ebuild
@@ -12,7 +12,10 @@ S="${WORKDIR}/${PN}-intel-${P}"
 
 KEYWORDS="~amd64"
 LICENSE="MIT"
-SLOT="0/12"
+# gmmlib version 22.0.3 made breaking ABI changes without changing the
+# soname, so the "_1" subslot suffix was added. There is no need to keep
+# this suffix after the next soname version bump.
+SLOT="0/12_1"
 IUSE="+custom-cflags test"
 RESTRICT="!test? ( test )"
 

--- a/media-libs/gmmlib/gmmlib-9999.ebuild
+++ b/media-libs/gmmlib/gmmlib-9999.ebuild
@@ -18,7 +18,10 @@ HOMEPAGE="https://github.com/intel/gmmlib"
 SRC_URI=""
 
 LICENSE="MIT"
-SLOT="0/12"
+# gmmlib version 22.0.3 made breaking ABI changes without changing the
+# soname, so the "_1" subslot suffix was added. There is no need to keep
+# this suffix after the next soname version bump.
+SLOT="0/12_1"
 IUSE="test +custom-cflags"
 RESTRICT="!test? ( test )"
 


### PR DESCRIPTION
While gmmlib version 2.0.3 has not introduced new so-name, it is required to rebuild dependent packages as otherwise they are crashing.

Closes: https://bugs.gentoo.org/834634
