### PR TITLE
dev-python/libvirt-python: Reflect repo move

### DIFF
--- a/dev-python/libvirt-python/libvirt-python-7.10.0.ebuild
+++ b/dev-python/libvirt-python/libvirt-python-7.10.0.ebuild
@@ -13,7 +13,7 @@ inherit distutils-r1 verify-sig
 
 if [[ ${PV} = *9999* ]]; then
 	inherit git-r3
-	EGIT_REPO_URI="https://libvirt.org/git/libvirt-python.git"
+	EGIT_REPO_URI="https://gitlab.com/libvirt/libvirt-python.git"
 	RDEPEND="app-emulation/libvirt:=[-python(-)]"
 else
 	SRC_URI="https://libvirt.org/sources/python/${MY_P}.tar.gz

--- a/dev-python/libvirt-python/libvirt-python-7.7.0.ebuild
+++ b/dev-python/libvirt-python/libvirt-python-7.7.0.ebuild
@@ -13,7 +13,7 @@ inherit distutils-r1 verify-sig
 
 if [[ ${PV} = *9999* ]]; then
 	inherit git-r3
-	EGIT_REPO_URI="https://libvirt.org/git/libvirt-python.git"
+	EGIT_REPO_URI="https://gitlab.com/libvirt/libvirt-python.git"
 	RDEPEND="app-emulation/libvirt:=[-python(-)]"
 else
 	SRC_URI="https://libvirt.org/sources/python/${MY_P}.tar.gz

--- a/dev-python/libvirt-python/libvirt-python-8.0.0.ebuild
+++ b/dev-python/libvirt-python/libvirt-python-8.0.0.ebuild
@@ -13,7 +13,7 @@ inherit distutils-r1 verify-sig
 
 if [[ ${PV} = *9999* ]]; then
 	inherit git-r3
-	EGIT_REPO_URI="https://libvirt.org/git/libvirt-python.git"
+	EGIT_REPO_URI="https://gitlab.com/libvirt/libvirt-python.git"
 	RDEPEND="app-emulation/libvirt:=[-python(-)]"
 else
 	SRC_URI="https://libvirt.org/sources/python/${MY_P}.tar.gz

--- a/dev-python/libvirt-python/libvirt-python-8.1.0.ebuild
+++ b/dev-python/libvirt-python/libvirt-python-8.1.0.ebuild
@@ -13,7 +13,7 @@ inherit distutils-r1 verify-sig
 
 if [[ ${PV} = *9999* ]]; then
 	inherit git-r3
-	EGIT_REPO_URI="https://libvirt.org/git/libvirt-python.git"
+	EGIT_REPO_URI="https://gitlab.com/libvirt/libvirt-python.git"
 	RDEPEND="app-emulation/libvirt:=[-python(-)]"
 else
 	SRC_URI="https://libvirt.org/sources/python/${MY_P}.tar.gz

--- a/dev-python/libvirt-python/libvirt-python-9999.ebuild
+++ b/dev-python/libvirt-python/libvirt-python-9999.ebuild
@@ -13,7 +13,7 @@ inherit distutils-r1 verify-sig
 
 if [[ ${PV} = *9999* ]]; then
 	inherit git-r3
-	EGIT_REPO_URI="https://libvirt.org/git/libvirt-python.git"
+	EGIT_REPO_URI="https://gitlab.com/libvirt/libvirt-python.git"
 	RDEPEND="app-emulation/libvirt:=[-python(-)]"
 else
 	SRC_URI="https://libvirt.org/sources/python/${MY_P}.tar.gz


### PR DESCRIPTION
It's been a while now that the main upstream repository moved to
gitlab leaving the old one as a read-only mirror. Reflect this
change in eboulds.

https://gitlab.com/libvirt/libvirt-python/-/commit/6088ce10b9afad415ebe3fc96cb40e271a0cf910

Signed-off-by: Michal Privoznik <mprivozn@redhat.com>