### PR TITLE
sys-fs/cryptsetup: add fips useflag

### DIFF
--- a/sys-fs/cryptsetup/cryptsetup-2.4.3-r2.ebuild
+++ b/sys-fs/cryptsetup/cryptsetup-2.4.3-r2.ebuild
@@ -1,0 +1,137 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit linux-info tmpfiles
+
+DESCRIPTION="Tool to setup encrypted devices with dm-crypt"
+HOMEPAGE="https://gitlab.com/cryptsetup/cryptsetup/blob/master/README.md"
+SRC_URI="https://www.kernel.org/pub/linux/utils/${PN}/v$(ver_cut 1-2)/${P/_/-}.tar.xz"
+
+LICENSE="GPL-2+"
+SLOT="0/12" # libcryptsetup.so version
+[[ ${PV} != *_rc* ]] && \
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+CRYPTO_BACKENDS="gcrypt kernel nettle +openssl"
+# we don't support nss since it doesn't allow cryptsetup to be built statically
+# and it's missing ripemd160 support so it can't provide full backward compatibility
+IUSE="${CRYPTO_BACKENDS} +argon2 fips nls pwquality reencrypt ssh static static-libs test +udev urandom"
+RESTRICT="!test? ( test )"
+REQUIRED_USE="^^ ( ${CRYPTO_BACKENDS//+/} )
+	static? ( !gcrypt !ssh !udev !fips )" # 496612, 832711
+
+LIB_DEPEND="
+	dev-libs/json-c:=[static-libs(+)]
+	dev-libs/popt[static-libs(+)]
+	>=sys-apps/util-linux-2.31-r1[static-libs(+)]
+	argon2? ( app-crypt/argon2:=[static-libs(+)] )
+	gcrypt? (
+		dev-libs/libgcrypt:0=[static-libs(+)]
+		dev-libs/libgpg-error[static-libs(+)]
+	)
+	nettle? ( >=dev-libs/nettle-2.4[static-libs(+)] )
+	openssl? ( dev-libs/openssl:0=[static-libs(+)] )
+	pwquality? ( dev-libs/libpwquality[static-libs(+)] )
+	ssh? ( net-libs/libssh[static-libs(+)] )
+	sys-fs/lvm2[static-libs(+)]"
+# We have to always depend on ${LIB_DEPEND} rather than put behind
+# !static? () because we provide a shared library which links against
+# these other packages. #414665
+RDEPEND="static-libs? ( ${LIB_DEPEND} )
+	${LIB_DEPEND//\[static-libs\([+-]\)\]}
+	udev? ( virtual/libudev:= )"
+# vim-core needed for xxd in tests
+DEPEND="${RDEPEND}
+	static? ( ${LIB_DEPEND} )
+	test? ( app-editors/vim-core )"
+BDEPEND="
+	virtual/pkgconfig
+"
+
+S="${WORKDIR}/${P/_/-}"
+
+pkg_setup() {
+	local CONFIG_CHECK="~DM_CRYPT ~CRYPTO ~CRYPTO_CBC ~CRYPTO_SHA256"
+	local WARNING_DM_CRYPT="CONFIG_DM_CRYPT:\tis not set (required for cryptsetup)\n"
+	local WARNING_CRYPTO_SHA256="CONFIG_CRYPTO_SHA256:\tis not set (required for cryptsetup)\n"
+	local WARNING_CRYPTO_CBC="CONFIG_CRYPTO_CBC:\tis not set (required for kernel 2.6.19)\n"
+	local WARNING_CRYPTO="CONFIG_CRYPTO:\tis not set (required for cryptsetup)\n"
+	check_extra_config
+}
+
+src_prepare() {
+	sed -i '/^LOOPDEV=/s:$: || exit 0:' tests/{compat,mode}-test || die
+	default
+}
+
+src_configure() {
+	if use kernel ; then
+		ewarn "Note that kernel backend is very slow for this type of operation"
+		ewarn "and is provided mainly for embedded systems wanting to avoid"
+		ewarn "userspace crypto libraries."
+	fi
+
+	local myeconfargs=(
+		--disable-internal-argon2
+		--enable-shared
+		--sbindir=/sbin
+		# for later use
+		--with-default-luks-format=LUKS2
+		--with-tmpfilesdir="${EPREFIX}/usr/lib/tmpfiles.d"
+		--with-crypto_backend=$(for x in ${CRYPTO_BACKENDS//+/} ; do usev ${x} ; done)
+		$(use_enable argon2 libargon2)
+		$(use_enable nls)
+		$(use_enable pwquality)
+		$(use_enable reencrypt cryptsetup-reencrypt)
+		$(use_enable !static external-tokens)
+		$(use_enable static static-cryptsetup)
+		$(use_enable static-libs static)
+		$(use_enable udev)
+		$(use_enable !urandom dev-random)
+		$(use_enable ssh ssh-token)
+		$(usex argon2 '' '--with-luks2-pbkdf=pbkdf2')
+		$(use_enable fips)
+	)
+	econf "${myeconfargs[@]}"
+}
+
+src_test() {
+	if [[ ! -e /dev/mapper/control ]] ; then
+		ewarn "No /dev/mapper/control found -- skipping tests"
+		return 0
+	fi
+
+	local p
+	for p in /dev/mapper /dev/loop* ; do
+		addwrite ${p}
+	done
+
+	default
+}
+
+src_install() {
+	default
+
+	if use static ; then
+		mv "${ED}"/sbin/cryptsetup{.static,} || die
+		mv "${ED}"/sbin/veritysetup{.static,} || die
+		mv "${ED}"/sbin/integritysetup{.static,} || die
+		if use ssh ; then
+			mv "${ED}"/sbin/cryptsetup-ssh{.static,} || die
+		fi
+		if use reencrypt ; then
+			mv "${ED}"/sbin/cryptsetup-reencrypt{.static,} || die
+		fi
+	fi
+	find "${ED}" -type f -name "*.la" -delete || die
+
+	dodoc docs/v*ReleaseNotes
+
+	newconfd "${FILESDIR}"/2.4.3-dmcrypt.confd dmcrypt
+	newinitd "${FILESDIR}"/2.4.3-dmcrypt.rc dmcrypt
+}
+
+pkg_postinst() {
+	tmpfiles_process cryptsetup.conf
+}

--- a/sys-fs/cryptsetup/metadata.xml
+++ b/sys-fs/cryptsetup/metadata.xml
@@ -7,6 +7,7 @@
 </maintainer>
 <use>
 	<flag name="argon2">Enable password hashing algorithm from <pkg>app-crypt/argon2</pkg></flag>
+	<flag name="fips">Enable FIPS mode restrictions</flag>
 	<flag name="gcrypt">Use <pkg>dev-libs/libgcrypt</pkg> crypto backend</flag>
 	<flag name="kernel">Use kernel crypto backend (mainly for embedded systems)</flag>
 	<flag name="nettle">Use <pkg>dev-libs/nettle</pkg> crypto backend</flag>


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/834920
Package-Manager: Portage-3.0.30, Repoman-3.0.3
Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>

<hr>

High-level changes:
* do not authorize `static` + `fips` to be enabled at the same time ([configure.ac](https://gitlab.com/cryptsetup/cryptsetup/-/blob/master/configure.ac#L170-172))