### PR TITLE
profiles/base: Remove mate-base/mate[bluetooth] stable USE mask

### DIFF
--- a/profiles/base/package.use.stable.mask
+++ b/profiles/base/package.use.stable.mask
@@ -94,10 +94,6 @@ app-emulation/xen-tools doc
 # dev-util/shellcheck (dev-lang/ghc) has no stable keywords.
 app-emulation/winetricks test
 
-# Adam Feldman <NP-Hardass@gentoo.org> (2020-04-12)
-# Dependency (net-wireless/blueman) has no stable keywords
-mate-base/mate bluetooth
-
 # Georgy Yakovlev <gyakovlev@gentoo.org> (2019-12-21)
 # For bleeding edge features and testing, not generally suitable
 # for stable systems


### PR DESCRIPTION
The only dependency of this USE flag (net-wireless/blueman) has been stabilized on every architecture where mate-base/mate has a stable version, so this USE stable mask is obsolete.