### PR TITLE
media-gfx/freecad: depend on boost-1.77.0

### DIFF
--- a/media-gfx/freecad/freecad-0.19.2-r6.ebuild
+++ b/media-gfx/freecad/freecad-0.19.2-r6.ebuild
@@ -82,7 +82,7 @@ RDEPEND="
 	openscad? ( media-gfx/openscad )
 	pcl? ( >=sci-libs/pcl-1.8.1:=[opengl,openni2(+),qt5(+),vtk(+)] )
 	$(python_gen_cond_dep '
-		dev-libs/boost:=[python,threads(+),${PYTHON_USEDEP}]
+		~dev-libs/boost-1.77.0:=[python,threads(+),${PYTHON_USEDEP}]
 		dev-python/matplotlib[${PYTHON_USEDEP}]
 		dev-python/numpy[${PYTHON_USEDEP}]
 		>=dev-python/pivy-0.6.5[${PYTHON_USEDEP}]


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/834991
Package-Manager: Portage-3.0.30, Repoman-3.0.3
Signed-off-by: Alessandro Barbieri <lssndrbarbieri@gmail.com>