### PR TITLE
media-libs/ftgl: added ftgl-2.1.3_rc5-clang.patch

### DIFF
--- a/media-libs/ftgl/files/ftgl-2.1.3_rc5-clang.patch
+++ b/media-libs/ftgl/files/ftgl-2.1.3_rc5-clang.patch
@@ -1,0 +1,24 @@
+--- a/demo/simple.cpp
++++ b/demo/simple.cpp
+@@ -105,14 +105,14 @@
+     float t2 = sin(n / 50 + 1);
+     float t3 = sin(n / 30 + 2);
+ 
+-    float ambient[4]  = { (t1 + 2.0) / 3,
+-                          (t2 + 2.0) / 3,
+-                          (t3 + 2.0) / 3, 0.3 };
+-    float diffuse[4]  = { 1.0, 0.9, 0.9, 1.0 };
+-    float specular[4] = { 1.0, 0.7, 0.7, 1.0 };
+-    float position[4] = { 100.0, 100.0, 0.0, 1.0 };
++    float ambient[4]  = { (t1 + 2.0f) / 3,
++                          (t2 + 2.0f) / 3,
++                          (t3 + 2.0f) / 3, 0.3 };
++    float diffuse[4]  = { 1.0f, 0.9f, 0.9f, 1.0f };
++    float specular[4] = { 1.0f, 0.7f, 0.7f, 1.0f };
++    float position[4] = { 100.0f, 100.0f, 0.0f, 1.0f };
+ 
+-    float front_ambient[4]  = { 0.7, 0.7, 0.7, 0.0 };
++    float front_ambient[4]  = { 0.7f, 0.7f, 0.7f, 0.0f };
+ 
+     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+ 

--- a/media-libs/ftgl/ftgl-2.1.3_rc5.ebuild
+++ b/media-libs/ftgl/ftgl-2.1.3_rc5.ebuild
@@ -31,6 +31,7 @@ PATCHES=(
 	"${FILESDIR}"/${P}-gentoo.patch
 	"${FILESDIR}"/${P}-underlink.patch
 	"${FILESDIR}"/${P}-freetype_pkgconfig.patch
+	"${FILESDIR}"/${P}-clang.patch
 )
 
 src_prepare() {


### PR DESCRIPTION
patch that fixes building with clang using c++11

Signed-off-by: Denis Pronin <dannftk@yandex.ru>