### PR TITLE
app-crypt/libsecret: Create an emulated TPM2 for tests

### DIFF
--- a/app-crypt/libsecret/libsecret-0.20.5-r1.ebuild
+++ b/app-crypt/libsecret/libsecret-0.20.5-r1.ebuild
@@ -1,0 +1,141 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+PYTHON_COMPAT=( python3_{8..10} )
+VALA_USE_DEPEND=vapigen
+
+inherit bash-completion-r1 gnome2 meson-multilib python-any-r1 vala virtualx
+
+DESCRIPTION="GObject library for accessing the freedesktop.org Secret Service API"
+HOMEPAGE="https://wiki.gnome.org/Projects/Libsecret"
+
+LICENSE="LGPL-2.1+ Apache-2.0" # Apache-2.0 license is used for tests only
+SLOT="0"
+
+IUSE="+crypt gtk-doc +introspection test tpm +vala"
+RESTRICT="!test? ( test )"
+REQUIRED_USE="
+	vala? ( introspection )
+	gtk-doc? ( crypt )
+"
+
+KEYWORDS="~alpha amd64 arm arm64 ~ia64 ~mips ppc ppc64 ~riscv sparc x86"
+
+DEPEND="
+	>=dev-libs/glib-2.44:2[${MULTILIB_USEDEP}]
+	crypt? ( >=dev-libs/libgcrypt-1.2.2:0=[${MULTILIB_USEDEP}] )
+	tpm? ( >=app-crypt/tpm2-tss-3.0.3 )
+	introspection? ( >=dev-libs/gobject-introspection-1.54:= )
+"
+RDEPEND="${DEPEND}
+	virtual/secret-service"
+BDEPEND="
+	app-text/docbook-xml-dtd:4.2
+	dev-libs/libxslt
+	dev-util/gdbus-codegen
+	dev-util/glib-utils
+	>=sys-devel/gettext-0.19.8
+	virtual/pkgconfig
+	gtk-doc? (
+		app-text/docbook-xml-dtd:4.1.2
+		>=dev-util/gi-docgen-2021.7
+	)
+	test? (
+		$(python_gen_any_dep '
+			dev-python/mock[${PYTHON_USEDEP}]
+			dev-python/dbus-python[${PYTHON_USEDEP}]
+			introspection? ( dev-python/pygobject:3[${PYTHON_USEDEP}] )')
+		introspection? ( >=dev-libs/gjs-1.32 )
+		tpm? (	app-crypt/swtpm
+			app-crypt/tpm2-abrmd
+			>=app-crypt/tpm2-tss-3.2.0
+		)
+	)
+	vala? ( $(vala_depend) )
+"
+
+tpm2_run_with_emulator() {
+#	eval $(dbus-launch --sh-syntax) || die
+	export XDG_CONFIG_HOME=${T}/.config/swtpm
+	${BROOT}/usr/share/swtpm/swtpm-create-user-config-files || die
+
+	mkdir -p ${XDG_CONFIG_HOME}/mytpm1 || die
+	swtpm_setup_args=(
+		--tpm2
+		--tpmstate ${XDG_CONFIG_HOME}/mytpm1
+		--createek
+		--allow-signing
+		--decryption
+		--create-ek-cert
+		--create-platform-cert
+		--lock-nvram
+		--overwrite
+		--display
+	)
+	swtpm_setup "${swtpm_setup_args[@]}" || die
+
+	swtpm_socket_args=(
+		--tpm2
+		--tpmstate dir=${XDG_CONFIG_HOME}/mytpm1
+		--flags startup-clear
+		--ctrl type=unixio,path=${XDG_CONFIG_HOME}/mytpm1/swtpm.socket.ctrl
+		--server type=unixio,path=${XDG_CONFIG_HOME}/mytpm1/swtpm.socket
+		--pid file=${XDG_CONFIG_HOME}/mytpm1/swtpm.pid
+		--daemon
+	)
+	swtpm socket "${swtpm_socket_args[@]}" || die
+
+	tpm2_abrmd_args=(
+		--logger=stdout
+		--tcti=swtpm:path=${XDG_CONFIG_HOME}/mytpm1/swtpm.socket
+		--session
+		--flush-all
+	)
+	tpm2-abrmd "${tpm2_abrmd_args[@]}" &
+	export TCTI=tabrmd:bus_type=session
+
+	$1 $@ || die
+
+	# When swtpm dies, tmp2-abrmd will exit
+	kill $(< ${XDG_CONFIG_HOME}/mytpm1/swtpm.pid) || die
+}
+
+python_check_deps() {
+	if use introspection; then
+		has_version -b "dev-python/pygobject:3[${PYTHON_USEDEP}]" || return
+	fi
+	has_version -b "dev-python/mock[${PYTHON_USEDEP}]" &&
+	has_version -b "dev-python/dbus-python[${PYTHON_USEDEP}]"
+}
+
+pkg_setup() {
+	use test && python-any-r1_pkg_setup
+}
+
+src_prepare() {
+	use vala && vala_src_prepare
+	default
+}
+
+multilib_src_configure() {
+	local emesonargs=(
+		$(meson_native_true manpage)
+		$(meson_use crypt gcrypt)
+		$(meson_native_use_bool vala vapi)
+		$(meson_native_use_bool gtk-doc gtk_doc)
+		$(meson_native_use_bool introspection)
+		-Dbashcompdir="$(get_bashcompdir)"
+		$(meson_native_enabled bash_completion)
+		$(meson_native_use_bool tpm tpm2)
+	)
+	meson_src_configure
+}
+
+multilib_src_test() {
+	if use tpm; then
+		dbus-run-session tpm2_run_with_emulator virtx meson test -C "${BUILD_DIR}"
+	else
+		dbus-run-session virtx meson test -C "${BUILD_DIR}"
+	fi
+}


### PR DESCRIPTION
Libsecret runs tests against the TPM2 already in the machine and require tpm2-abrmd. Hence the tests will fail if the user does not have tpm2-abrmd installed or does not have a TPM2 in the machine. It shouldn't do this - it should provision a virtual TPM2 spawn an emulator (swtpm) and the use the swtpm TCTI with tpm2-abrmd. This isn't the first time I've encountered a package that assumed the TPM2 simulator environment was setup prior. 

However its not too difficult to setup the TPM2 simulator for the test, which is what this patch does. Note that neither swtpm, tpm2-abrmd, nor >=tpm2-tss-3.2.0 is currently stable however, and tpm2-abrmd doesn't have riscv keywords. Its possible to remove the dependency on >=tpm2-tss-3.2.0 by using TCP ports rather than domain sockets, if desired.  The problem with that the swtpm might fail if the port is already in use.