### PR TITLE
dev-libs/mimalloc: set MI_BUILD_{STATIC,OBJECT}=OFF

### DIFF
--- a/dev-libs/mimalloc/mimalloc-2.0.5-r2.ebuild
+++ b/dev-libs/mimalloc/mimalloc-2.0.5-r2.ebuild
@@ -1,0 +1,31 @@
+# Copyright 2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit cmake-multilib
+
+DESCRIPTION="mimalloc is a compact general purpose allocator with excellent performance"
+HOMEPAGE="https://github.com/microsoft/mimalloc"
+SRC_URI="https://github.com/microsoft/mimalloc/archive/refs/tags/v${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="MIT"
+SLOT="0/2"
+KEYWORDS="~amd64"
+IUSE="test"
+RESTRICT="!test? ( test )"
+
+src_configure() {
+	local mycmakeargs=(
+		# TODO: build hardened variant?
+		#-DMI_SECURE=$(usex hardened)
+
+		-DMI_INSTALL_TOPLEVEL=ON
+		-DMI_BUILD_TESTS=$(usex test)
+
+		-DMI_BUILD_OBJECT=OFF
+		-DMI_BUILD_STATIC=OFF
+	)
+
+	cmake-multilib_src_configure
+}


### PR DESCRIPTION
Needed for solvespace (and any other future CMake-using consumers).