### PR TITLE
sys-apps/systemd: warn when dbus-broker is needed

### DIFF
--- a/sys-apps/systemd/systemd-250.2.ebuild
+++ b/sys-apps/systemd/systemd-250.2.ebuild
@@ -510,6 +510,14 @@ pkg_postinst() {
 		eerror "systemd again."
 		eerror
 	fi
+
+	if use hostnamed-fallback; then
+		if ! systemctl --root="${ROOT:-/}" is-enabled --quiet dbus-broker.service 2>/dev/null; then
+			ewarn "dbus-broker.service is not enabled, systemd-hostnamed will fail to run."
+			ewarn "To enable dbus-broker.service run the next command as root:"
+			ewarn "systemctl enable dbus-broker.service"
+		fi
+	fi
 }
 
 pkg_prerm() {

--- a/sys-apps/systemd/systemd-250.3.ebuild
+++ b/sys-apps/systemd/systemd-250.3.ebuild
@@ -510,6 +510,14 @@ pkg_postinst() {
 		eerror "systemd again."
 		eerror
 	fi
+
+	if use hostnamed-fallback; then
+		if ! systemctl --root="${ROOT:-/}" is-enabled --quiet dbus-broker.service 2>/dev/null; then
+			ewarn "dbus-broker.service is not enabled, systemd-hostnamed will fail to run."
+			ewarn "To enable dbus-broker.service run the next command as root:"
+			ewarn "systemctl enable dbus-broker.service"
+		fi
+	fi
 }
 
 pkg_prerm() {


### PR DESCRIPTION
Warn if hostnamed-fallback workaround is used, but dbus-broker.service is not enabled. This should give users a strong hint of  what needs to be done.

See https://github.com/gentoo/gentoo/pull/22792#issuecomment-1065918296

No revbumps.