### PR TITLE
sci-mathematics/z3: fix link atomic in riscv

### DIFF
--- a/sci-mathematics/z3/files/z3-4.8.14-libatomic.patch
+++ b/sci-mathematics/z3/files/z3-4.8.14-libatomic.patch
@@ -1,0 +1,60 @@
+https://github.com/Z3Prover/z3/commit/3d87d86c2825437780167ae6ff8f5b203f15ee7f.patch
+https://bugs.gentoo.org/835003
+
+From b2b407cdedc586f8d11f9dd029e1c3016c80bba7 Mon Sep 17 00:00:00 2001
+From: Revy <rabenda.cn@gmail.com>
+Date: Tue, 15 Mar 2022 02:11:40 +0800
+Subject: [PATCH] fix: build on non-x86 platform
+
+Signed-off-by: Revy <rabenda.cn@gmail.com>
+---
+ CMakeLists.txt                |  5 +++++
+ cmake/check_link_atomic.cmake | 23 +++++++++++++++++++++++
+ 2 files changed, 28 insertions(+)
+ create mode 100644 cmake/check_link_atomic.cmake
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index be300607dd..477410ba8d 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -431,6 +431,11 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+   string(APPEND CMAKE_SHARED_LINKER_FLAGS " /RELEASE")
+ endif()
+ 
++################################################################################
++# Check atomic linking as needed
++################################################################################
++include(${PROJECT_SOURCE_DIR}/cmake/check_link_atomic.cmake)
++
+ ################################################################################
+ # Report default CMake flags
+ ################################################################################
+diff --git a/cmake/check_link_atomic.cmake b/cmake/check_link_atomic.cmake
+new file mode 100644
+index 0000000000..d462191a0b
+--- /dev/null
++++ b/cmake/check_link_atomic.cmake
+@@ -0,0 +1,23 @@
++set(ATOMIC_TEST_SOURCE "
++#include <atomic>
++std::atomic<int> x;
++std::atomic<short> y;
++std::atomic<char> z;
++std::atomic<long long> w;
++int main() {
++	++z;
++	++y;
++    ++w;
++	return ++x;
++}")
++CHECK_CXX_SOURCE_COMPILES("${ATOMIC_TEST_SOURCE}" BUILTIN_ATOMIC)
++if (NOT BUILTIN_ATOMIC)
++  set(CMAKE_REQUIRED_LIBRARIES atomic)
++  CHECK_CXX_SOURCE_COMPILES("${ATOMIC_TEST_SOURCE}" ATOMICS_REQUIRE_LIBATOMIC)
++  unset(CMAKE_REQUIRED_LIBRARIES)
++  if (ATOMICS_REQUIRE_LIBATOMIC)
++    list(APPEND Z3_DEPENDENT_LIBS atomic)
++  else()
++    message(FATAL_ERROR "Host compiler must support std::atomic!")
++  endif()
++endif()

--- a/sci-mathematics/z3/z3-4.8.14.ebuild
+++ b/sci-mathematics/z3/z3-4.8.14.ebuild
@@ -26,6 +26,10 @@ DEPEND="${RDEPEND}
 BDEPEND="
 	doc? ( app-doc/doxygen )"
 
+PATCHES=(
+	"${FILESDIR}/${P}-libatomic.patch" #bug 835003
+)
+
 CMAKE_BUILD_TYPE=RelWithDebInfo
 
 src_prepare() {


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/835003
Package-Manager: Portage-3.0.30, Repoman-3.0.3
Signed-off-by: Han Gao <rabenda.cn@gmail.com>