### PR TITLE
sci-physics/vmc: Adapt to dropped `vmc`, `c++11` USE in `sci-physics/root`

### DIFF
--- a/sci-physics/vmc/metadata.xml
+++ b/sci-physics/vmc/metadata.xml
@@ -14,7 +14,6 @@
     <name>Proxy Maintainers</name>
   </maintainer>
   <use>
-    <flag name="c++11">Build using the C++11 standard</flag>
     <flag name="c++14">Build using the C++14 standard</flag>
     <flag name="c++17">Build using the C++17 standard</flag>
   </use>

--- a/sci-physics/vmc/vmc-1.1_p1.ebuild
+++ b/sci-physics/vmc/vmc-1.1_p1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -20,11 +20,11 @@ HOMEPAGE="https://vmc-project.github.io/ https://github.com/vmc-project/vmc"
 
 LICENSE="GPL-3"
 SLOT="0"
-IUSE="c++11 c++14 +c++17 doc"
+IUSE="c++14 +c++17 doc"
 
-REQUIRED_USE="^^ ( c++11 c++14 c++17 )"
+REQUIRED_USE="^^ ( c++14 c++17 )"
 
-RDEPEND="sci-physics/root:=[c++11?,c++14?,c++17?,-vmc]"
+RDEPEND="sci-physics/root:=[c++14?,c++17?,-vmc(-)]"
 DEPEND="${RDEPEND}"
 BDEPEND="doc? ( app-doc/doxygen[dot] )"
 

--- a/sci-physics/vmc/vmc-2.0.ebuild
+++ b/sci-physics/vmc/vmc-2.0.ebuild
@@ -20,11 +20,11 @@ HOMEPAGE="https://vmc-project.github.io/ https://github.com/vmc-project/vmc"
 
 LICENSE="GPL-3"
 SLOT="0"
-IUSE="c++11 c++14 +c++17 doc"
+IUSE="c++14 +c++17 doc"
 
-REQUIRED_USE="^^ ( c++11 c++14 c++17 )"
+REQUIRED_USE="^^ ( c++14 c++17 )"
 
-RDEPEND="sci-physics/root:=[c++11?,c++14?,c++17?,-vmc]"
+RDEPEND="sci-physics/root:=[c++14?,c++17?,-vmc(-)]"
 DEPEND="${RDEPEND}"
 BDEPEND="doc? ( app-doc/doxygen[dot] )"
 

--- a/sci-physics/vmc/vmc-9999.ebuild
+++ b/sci-physics/vmc/vmc-9999.ebuild
@@ -20,11 +20,11 @@ HOMEPAGE="https://vmc-project.github.io/ https://github.com/vmc-project/vmc"
 
 LICENSE="GPL-3"
 SLOT="0"
-IUSE="c++11 c++14 +c++17 doc"
+IUSE="c++14 +c++17 doc"
 
-REQUIRED_USE="^^ ( c++11 c++14 c++17 )"
+REQUIRED_USE="^^ ( c++14 c++17 )"
 
-RDEPEND=">=sci-physics/root-6.18:=[c++11?,c++14?,c++17?,-vmc]"
+RDEPEND="sci-physics/root:=[c++14?,c++17?,-vmc(-)]"
 DEPEND="${RDEPEND}"
 BDEPEND="doc? ( app-doc/doxygen[dot] )"
 


### PR DESCRIPTION
For simplicitly, this also drops the `c++11` USE completely from `sci-physics/vmc`. 

@amadio That one's probably for you, too. 

Package-Manager: Portage-3.0.30, Repoman-3.0.3
Signed-off-by: Oliver Freyermuth <o.freyermuth@googlemail.com>