### PR TITLE
dev-python/async_generator: fix installation for python3_9

### DIFF
--- a/dev-python/async_generator/async_generator-1.10-r1.ebuild
+++ b/dev-python/async_generator/async_generator-1.10-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -18,10 +18,3 @@ KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ppc ppc64 ~riscv sparc x86 ~x64-maco
 DOCS=( README.rst )
 
 distutils_enable_tests pytest
-
-python_test() {
-	pushd "${BUILD_DIR}/lib" >/dev/null || die
-	epytest
-	rm -rf .hypothesis .pytest_cache || die
-	popd >/dev/null || die
-}


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/835090
Signed-off-by: James Beddek <telans@posteo.de>

Does not fix tests linked in bug, only installation.