### PR TITLE
x11-wm/mutter: Fix typo: 'emsonargs' -> 'emesonargs'

### DIFF
--- a/x11-wm/mutter/mutter-40.5-r6.ebuild
+++ b/x11-wm/mutter/mutter-40.5-r6.ebuild
@@ -140,7 +140,7 @@ src_configure() {
 			-Dwayland_eglstream=true
 		)
 	else
-		emsonargs+=(
+		emesonargs+=(
 			-Degl_device=false
 			-Dwayland_eglstream=false
 		)

--- a/x11-wm/mutter/mutter-41.3.ebuild
+++ b/x11-wm/mutter/mutter-41.3.ebuild
@@ -142,7 +142,7 @@ src_configure() {
 			-Dwayland_eglstream=true
 		)
 	else
-		emsonargs+=(
+		emesonargs+=(
 			-Degl_device=false
 			-Dwayland_eglstream=false
 		)

--- a/x11-wm/mutter/mutter-41.4.ebuild
+++ b/x11-wm/mutter/mutter-41.4.ebuild
@@ -142,7 +142,7 @@ src_configure() {
 			-Dwayland_eglstream=true
 		)
 	else
-		emsonargs+=(
+		emesonargs+=(
 			-Degl_device=false
 			-Dwayland_eglstream=false
 		)


### PR DESCRIPTION
Currently, fixing this typo has no effect at all because the default values of `egl_device` and `wayland_eglstream` Meson options assigned by the upstream are `false` for every version we currently have. But just in case the upstream changes those options' default in a future release, or someone copies this block of script with the typo to use it elsewhere, fixing it right now could help avoid future gotchas.