### PR TITLE
net-libs/nodejs: keyword 16.14.1 for ~riscv

### DIFF
--- a/net-libs/nodejs/nodejs-16.14.1.ebuild
+++ b/net-libs/nodejs/nodejs-16.14.1.ebuild
@@ -19,7 +19,7 @@ if [[ ${PV} == *9999 ]]; then
 else
 	SRC_URI="https://nodejs.org/dist/v${PV}/node-v${PV}.tar.xz"
 	SLOT="0/$(ver_cut 1)"
-	KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~x86 ~amd64-linux ~x64-macos"
+	KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux ~x64-macos"
 	S="${WORKDIR}/node-v${PV}"
 fi
 


### PR DESCRIPTION
> test/parallel/test-child-process-spawn-argv0.js
test/parallel/test-dgram-multicast-set-interface.js
test/parallel/test-memory-usage.js
test/parallel/test-memory-usage-emfile.js
test/parallel/test-setproctitle.js
test/parallel/test-worker-memory.js

above 6 tests failed in QEMU environment, but can pass on SiFive Unmatched boards.
In Unmatched boards, with FEATURES=network-sandbox will cause below one test failure

> test-dns-setserver-when-querying

Closes: https://bugs.gentoo.org/782913
Signed-off-by: Yu Gu <guyu2876@gmail.com>