### PR TITLE
dev-python/resolvelib: keyword 0.8.1 for ~riscv

### DIFF
--- a/dev-python/resolvelib/resolvelib-0.8.1.ebuild
+++ b/dev-python/resolvelib/resolvelib-0.8.1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="
 
 LICENSE="ISC"
 SLOT="0"
-KEYWORDS="amd64 ~arm arm64 ~ppc64 x86"
+KEYWORDS="amd64 ~arm arm64 ~ppc64 ~riscv x86"
 
 BDEPEND="
 	test? (


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/834857
Signed-off-by: Yu Gu <guyu2876@gmail.com>