### PR TITLE
dev-python/commentjson: keyword 0.9.0 for ~riscv

### DIFF
--- a/dev-python/commentjson/commentjson-0.9.0.ebuild
+++ b/dev-python/commentjson/commentjson-0.9.0.ebuild
@@ -16,7 +16,7 @@ SRC_URI="
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="amd64 ~arm arm64 ~ppc64 x86"
+KEYWORDS="amd64 ~arm arm64 ~ppc64 ~riscv x86"
 
 RDEPEND="
 	dev-python/lark-parser[${PYTHON_USEDEP}]"


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/834857
Signed-off-by: Yu Gu <guyu2876@gmail.com>