### PR TITLE
verify-sig.eclass: Handle SHA512 checksums

### DIFF
--- a/eclass/verify-sig.eclass
+++ b/eclass/verify-sig.eclass
@@ -229,6 +229,10 @@ verify-sig_verify_unsigned_checksums() {
 			chksum_prog=sha256sum
 			chksum_len=64
 			;;
+		sha512)
+			chksum_prog=sha512sum
+			chksum_len=128
+			;;
 		*)
 			die "${FUNCNAME}: unknown checksum algo ${algo}"
 			;;


### PR DESCRIPTION
Needed as weechat.org only publish these.