### PR TITLE
media-video/vlc: patch for failed to build

### DIFF
--- a/media-video/vlc/files/vlc-3.0.17.3-fix-getConnectionEndpointAddress.patch
+++ b/media-video/vlc/files/vlc-3.0.17.3-fix-getConnectionEndpointAddress.patch
@@ -1,0 +1,50 @@
+From 94845266b705dc9de7921408531b9d7704f4458f Mon Sep 17 00:00:00 2001
+From: Dominic Mayers <dominic.mayers@meditationstudies.org>
+Date: Sun, 28 Mar 2021 04:37:54 -0400
+Subject: [PATCH] Get addr by ref. from getConnectionEndpointAddress.
+
+Fixes issue #25473 in code.videolan.org. The maintainers of live555 changed
+connectionEndpointAddresss to getConnectionEndpointAddress, which now provides
+the address value by reference. Before, connectionEndpointAddresss returned
+the value. So, in modules/access/live555.cpp, we must first get the value and
+then pass it to IsMulticastAddress.  The code will not compile with the recent
+live555 unless we also modify modules/access/Makefile.am - a different patch.
+---
+ modules/access/live555.cpp | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/modules/access/live555.cpp b/modules/access/live555.cpp
+index 01c535ca5b..95e15e35d9 100644
+--- a/modules/access/live555.cpp
++++ b/modules/access/live555.cpp
+@@ -60,6 +60,7 @@
+ #include <liveMedia.hh>
+ #include <liveMedia_version.hh>
+ #include <Base64.hh>
++#include <NetAddress.hh>
+ 
+ extern "C" {
+ #include "../access/mms/asf.h"  /* Who said ugly ? */
+@@ -727,7 +728,8 @@ static int SessionsSetup( demux_t *p_demux )
+     unsigned const thresh = 200000; /* RTP reorder threshold .2 second (default .1) */
+     const char     *p_sess_lang = NULL;
+     const char     *p_lang;
+-
++    struct sockaddr_storage addr;
++    
+     b_rtsp_tcp    = var_CreateGetBool( p_demux, "rtsp-tcp" ) ||
+                     var_GetBool( p_demux, "rtsp-http" );
+     i_client_port = var_InheritInteger( p_demux, "rtp-client-port" );
+@@ -850,7 +852,8 @@ static int SessionsSetup( demux_t *p_demux )
+             if( !p_sys->b_multicast )
+             {
+                 /* We need different rollover behaviour for multicast */
+-                p_sys->b_multicast = IsMulticastAddress( sub->connectionEndpointAddress() );
++                sub->getConnectionEndpointAddress(addr);
++                p_sys->b_multicast = IsMulticastAddress( addr );
+             }
+ 
+             tk = (live_track_t*)malloc( sizeof( live_track_t ) );
+-- 
+2.25.1
+

--- a/media-video/vlc/vlc-3.0.17.3.ebuild
+++ b/media-video/vlc/vlc-3.0.17.3.ebuild
@@ -230,6 +230,8 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-2.2.8-freerdp-2.patch # bug 590164
 	"${FILESDIR}"/${PN}-3.0.6-fdk-aac-2.0.0.patch # bug 672290
 	"${FILESDIR}"/${PN}-3.0.11.1-configure_lua_version.patch
+	"${FILESDIR}"/${PN}-3.0.14-fix-live-address-api.patch # bug 835072
+	"${FILESDIR}"/${PN}-3.0.17.3-fix-getConnectionEndpointAddress.patch
 )
 
 DOCS=( AUTHORS THANKS NEWS README doc/fortunes.txt )


### PR DESCRIPTION
As described in https://code.videolan.org/videolan/vlc/-/issues/25473#note_303245 the current version fails to build due to changes in interfaces. Dominic Mayers created a patch which fixes it.

- added patch from videolan/vlc issue 25473
- applied patch