### PR TITLE
Quote CC variables in various packages to allow spaces

### DIFF
--- a/app-arch/p7zip/p7zip-16.02-r8.ebuild
+++ b/app-arch/p7zip/p7zip-16.02-r8.ebuild
@@ -88,14 +88,14 @@ src_prepare() {
 	if use kde || use wxwidgets; then
 		setup-wxwidgets unicode
 		einfo "Preparing dependency list"
-		emake CC=$(tc-getCC) CXX=$(tc-getCXX) depend
+		emake CC="$(tc-getCC)" CXX="$(tc-getCXX)" depend
 	fi
 }
 
 src_compile() {
-	emake CC=$(tc-getCC) CXX=$(tc-getCXX) all3
+	emake CC="$(tc-getCC)" CXX="$(tc-getCXX)" all3
 	if use kde || use wxwidgets; then
-		emake CC=$(tc-getCC) CXX=$(tc-getCXX) -- 7zG
+		emake CC="$(tc-getCC)" CXX="$(tc-getCXX)" -- 7zG
 	fi
 }
 

--- a/app-emulation/virtualbox-modules/virtualbox-modules-6.1.24.ebuild
+++ b/app-emulation/virtualbox-modules/virtualbox-modules-6.1.24.ebuild
@@ -31,7 +31,7 @@ MODULESD_VBOXNETFLT_ENABLED="no"
 
 pkg_setup() {
 	linux-mod_pkg_setup
-	BUILD_PARAMS="CC=$(tc-getBUILD_CC) KERN_DIR=${KV_DIR} KERN_VER=${KV_FULL} O=${KV_OUT_DIR} V=1 KBUILD_VERBOSE=1"
+	BUILD_PARAMS="CC=\"$(tc-getBUILD_CC)\" KERN_DIR=${KV_DIR} KERN_VER=${KV_FULL} O=${KV_OUT_DIR} V=1 KBUILD_VERBOSE=1"
 }
 
 src_prepare() {

--- a/app-emulation/virtualbox-modules/virtualbox-modules-6.1.28.ebuild
+++ b/app-emulation/virtualbox-modules/virtualbox-modules-6.1.28.ebuild
@@ -31,7 +31,7 @@ MODULESD_VBOXNETFLT_ENABLED="no"
 
 pkg_setup() {
 	linux-mod_pkg_setup
-	BUILD_PARAMS="CC=$(tc-getBUILD_CC) KERN_DIR=${KV_DIR} KERN_VER=${KV_FULL} O=${KV_OUT_DIR} V=1 KBUILD_VERBOSE=1"
+	BUILD_PARAMS="CC=\"$(tc-getBUILD_CC)\" KERN_DIR=${KV_DIR} KERN_VER=${KV_FULL} O=${KV_OUT_DIR} V=1 KBUILD_VERBOSE=1"
 }
 
 src_prepare() {

--- a/app-emulation/virtualbox-modules/virtualbox-modules-6.1.30-r1.ebuild
+++ b/app-emulation/virtualbox-modules/virtualbox-modules-6.1.30-r1.ebuild
@@ -31,7 +31,7 @@ MODULESD_VBOXNETFLT_ENABLED="no"
 
 pkg_setup() {
 	linux-mod_pkg_setup
-	BUILD_PARAMS="CC=$(tc-getBUILD_CC) KERN_DIR=${KV_DIR} KERN_VER=${KV_FULL} O=${KV_OUT_DIR} V=1 KBUILD_VERBOSE=1"
+	BUILD_PARAMS="CC=\"$(tc-getBUILD_CC)\" KERN_DIR=${KV_DIR} KERN_VER=${KV_FULL} O=${KV_OUT_DIR} V=1 KBUILD_VERBOSE=1"
 	if linux_chkconfig_present CC_IS_CLANG; then
 		ewarn "Warning: building ${PN} with a clang-built kernel is experimental."
 

--- a/app-emulation/virtualbox-modules/virtualbox-modules-6.1.30.ebuild
+++ b/app-emulation/virtualbox-modules/virtualbox-modules-6.1.30.ebuild
@@ -31,7 +31,7 @@ MODULESD_VBOXNETFLT_ENABLED="no"
 
 pkg_setup() {
 	linux-mod_pkg_setup
-	BUILD_PARAMS="CC=$(tc-getBUILD_CC) KERN_DIR=${KV_DIR} KERN_VER=${KV_FULL} O=${KV_OUT_DIR} V=1 KBUILD_VERBOSE=1"
+	BUILD_PARAMS="CC=\"$(tc-getBUILD_CC)\" KERN_DIR=${KV_DIR} KERN_VER=${KV_FULL} O=${KV_OUT_DIR} V=1 KBUILD_VERBOSE=1"
 }
 
 src_prepare() {

--- a/app-emulation/virtualbox-modules/virtualbox-modules-6.1.32.ebuild
+++ b/app-emulation/virtualbox-modules/virtualbox-modules-6.1.32.ebuild
@@ -31,7 +31,7 @@ MODULESD_VBOXNETFLT_ENABLED="no"
 
 pkg_setup() {
 	linux-mod_pkg_setup
-	BUILD_PARAMS="CC=$(tc-getBUILD_CC) KERN_DIR=${KV_DIR} KERN_VER=${KV_FULL} O=${KV_OUT_DIR} V=1 KBUILD_VERBOSE=1"
+	BUILD_PARAMS="CC=\"$(tc-getBUILD_CC)\" KERN_DIR=${KV_DIR} KERN_VER=${KV_FULL} O=${KV_OUT_DIR} V=1 KBUILD_VERBOSE=1"
 	if linux_chkconfig_present CC_IS_CLANG; then
 		ewarn "Warning: building ${PN} with a clang-built kernel is experimental."
 

--- a/app-emulation/virtualbox/virtualbox-6.1.24-r2.ebuild
+++ b/app-emulation/virtualbox/virtualbox-6.1.24-r2.ebuild
@@ -262,7 +262,7 @@ src_configure() {
 		myconf+=( --disable-vmmraw )
 	fi
 	# not an autoconf script
-	doecho ./configure ${myconf[@]}
+	doecho ./configure "${myconf[@]}"
 }
 
 src_compile() {

--- a/app-emulation/virtualbox/virtualbox-6.1.28-r2.ebuild
+++ b/app-emulation/virtualbox/virtualbox-6.1.28-r2.ebuild
@@ -264,7 +264,7 @@ src_configure() {
 		myconf+=( --disable-vmmraw )
 	fi
 	# not an autoconf script
-	doecho ./configure ${myconf[@]}
+	doecho ./configure "${myconf[@]}"
 }
 
 src_compile() {

--- a/app-emulation/virtualbox/virtualbox-6.1.30-r1.ebuild
+++ b/app-emulation/virtualbox/virtualbox-6.1.30-r1.ebuild
@@ -265,7 +265,7 @@ src_configure() {
 		myconf+=( --disable-vmmraw )
 	fi
 	# not an autoconf script
-	doecho ./configure ${myconf[@]}
+	doecho ./configure "${myconf[@]}"
 }
 
 src_compile() {

--- a/app-emulation/virtualbox/virtualbox-6.1.32-r1.ebuild
+++ b/app-emulation/virtualbox/virtualbox-6.1.32-r1.ebuild
@@ -265,7 +265,7 @@ src_configure() {
 		myconf+=( --disable-vmmraw )
 	fi
 	# not an autoconf script
-	doecho ./configure ${myconf[@]}
+	doecho ./configure "${myconf[@]}"
 }
 
 src_compile() {

--- a/eclass/fortran-2.eclass
+++ b/eclass/fortran-2.eclass
@@ -229,11 +229,11 @@ _fortran_test_function() {
 	: ${FORTRAN_STANDARD:=77}
 	for dialect in ${FORTRAN_STANDARD}; do
 		case ${dialect} in
-			77) _fortran_compile_test $(tc-getF77) || \
+			77) _fortran_compile_test "$(tc-getF77)" || \
 				_fortran_die_msg ;;
-			90|95) _fortran_compile_test $(tc-getFC) 90 || \
+			90|95) _fortran_compile_test "$(tc-getFC)" 90 || \
 				_fortran_die_msg ;;
-			2003) _fortran_compile_test $(tc-getFC) 03 || \
+			2003) _fortran_compile_test "$(tc-getFC)" 03 || \
 				_fortran_die_msg ;;
 			2008) die "Future" ;;
 			*) die "${dialect} is not a Fortran dialect." ;;

--- a/x11-misc/dmenu/dmenu-5.0.ebuild
+++ b/x11-misc/dmenu/dmenu-5.0.ebuild
@@ -40,7 +40,7 @@ src_prepare() {
 }
 
 src_compile() {
-	emake CC=$(tc-getCC) \
+	emake CC="$(tc-getCC)" \
 		"FREETYPEINC=$( $(tc-getPKG_CONFIG) --cflags x11 fontconfig xft 2>/dev/null )" \
 		"FREETYPELIBS=$( $(tc-getPKG_CONFIG) --libs x11 fontconfig xft 2>/dev/null )" \
 		"X11INC=$( $(tc-getPKG_CONFIG) --cflags x11 2>/dev/null )" \

--- a/x11-misc/dmenu/dmenu-5.1.ebuild
+++ b/x11-misc/dmenu/dmenu-5.1.ebuild
@@ -40,7 +40,7 @@ src_prepare() {
 }
 
 src_compile() {
-	emake CC=$(tc-getCC) \
+	emake CC="$(tc-getCC)" \
 		"FREETYPEINC=$( $(tc-getPKG_CONFIG) --cflags x11 fontconfig xft 2>/dev/null )" \
 		"FREETYPELIBS=$( $(tc-getPKG_CONFIG) --libs x11 fontconfig xft 2>/dev/null )" \
 		"X11INC=$( $(tc-getPKG_CONFIG) --cflags x11 2>/dev/null )" \

--- a/x11-misc/dmenu/dmenu-9999.ebuild
+++ b/x11-misc/dmenu/dmenu-9999.ebuild
@@ -40,7 +40,7 @@ src_prepare() {
 }
 
 src_compile() {
-	emake CC=$(tc-getCC) \
+	emake CC="$(tc-getCC)" \
 		"FREETYPEINC=$( $(tc-getPKG_CONFIG) --cflags x11 fontconfig xft 2>/dev/null )" \
 		"FREETYPELIBS=$( $(tc-getPKG_CONFIG) --libs x11 fontconfig xft 2>/dev/null )" \
 		"X11INC=$( $(tc-getPKG_CONFIG) --cflags x11 2>/dev/null )" \

--- a/x11-wm/dwm/dwm-6.2.ebuild
+++ b/x11-wm/dwm/dwm-6.2.ebuild
@@ -37,9 +37,9 @@ src_prepare() {
 
 src_compile() {
 	if use xinerama; then
-		emake CC=$(tc-getCC) dwm
+		emake CC="$(tc-getCC)" dwm
 	else
-		emake CC=$(tc-getCC) XINERAMAFLAGS="" XINERAMALIBS="" dwm
+		emake CC="$(tc-getCC)" XINERAMAFLAGS="" XINERAMALIBS="" dwm
 	fi
 }
 

--- a/x11-wm/dwm/dwm-6.3.ebuild
+++ b/x11-wm/dwm/dwm-6.3.ebuild
@@ -46,9 +46,9 @@ src_prepare() {
 
 src_compile() {
 	if use xinerama; then
-		emake CC=$(tc-getCC) dwm
+		emake CC="$(tc-getCC)" dwm
 	else
-		emake CC=$(tc-getCC) XINERAMAFLAGS="" XINERAMALIBS="" dwm
+		emake CC="$(tc-getCC)" XINERAMAFLAGS="" XINERAMALIBS="" dwm
 	fi
 }
 

--- a/x11-wm/dwm/dwm-9999.ebuild
+++ b/x11-wm/dwm/dwm-9999.ebuild
@@ -46,9 +46,9 @@ src_prepare() {
 
 src_compile() {
 	if use xinerama; then
-		emake CC=$(tc-getCC) dwm
+		emake CC="$(tc-getCC)" dwm
 	else
-		emake CC=$(tc-getCC) XINERAMAFLAGS="" XINERAMALIBS="" dwm
+		emake CC="$(tc-getCC)" XINERAMAFLAGS="" XINERAMALIBS="" dwm
 	fi
 }
 


### PR DESCRIPTION
A common use case for this is things like "gcc -m32" or "gcc --sysroot=...".

This does not cover all packages, but rather (most of) the packages I've installed that fail to build in such situation.