### PR TITLE
sys-apps/man-db: replace su with su-exec

### DIFF
--- a/sys-apps/man-db/files/man-db.cron-r1
+++ b/sys-apps/man-db/files/man-db.cron-r1
@@ -8,4 +8,4 @@ if [ ! -d "${cachedir}" ]; then
 	chmod 0755 "${cachedir}"
 fi
 
-exec su man -s /bin/sh -c 'nice mandb --quiet' 2>/dev/null
+exec su-exec man nice mandb --quiet 2>/dev/null


### PR DESCRIPTION
su is deprecated in shadow v4.10 https://github.com/shadow-maint/shadow/releases/tag/v4.10