### PR TITLE
riscv: keyword www-apps/nanoc, net-analyzer/{httping,2ping}

### DIFF
--- a/dev-ruby/colored/colored-1.2-r1.ebuild
+++ b/dev-ruby/colored/colored-1.2-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -10,7 +10,7 @@ DESCRIPTION="Console coloring"
 HOMEPAGE="https://github.com/defunkt/colored"
 LICENSE="MIT"
 
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~riscv ~x86"
 SLOT="0"
 IUSE=""
 

--- a/dev-ruby/cri/cri-2.15.11-r1.ebuild
+++ b/dev-ruby/cri/cri-2.15.11-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -14,7 +14,7 @@ DESCRIPTION="Cri is a library for building easy-to-use commandline tools"
 HOMEPAGE="https://rubygems.org/gems/cri"
 LICENSE="MIT"
 
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~riscv ~x86"
 SLOT="0"
 IUSE=""
 

--- a/dev-ruby/ddmemoize/ddmemoize-1.0.0.ebuild
+++ b/dev-ruby/ddmemoize/ddmemoize-1.0.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -17,7 +17,7 @@ HOMEPAGE="https://github.com/ddfreyne/ddmemoize/"
 
 LICENSE="MIT"
 SLOT="1"
-KEYWORDS="~amd64"
+KEYWORDS="~amd64 ~riscv"
 IUSE=""
 
 ruby_add_rdepend "

--- a/dev-ruby/ddmetrics/ddmetrics-1.0.1-r1.ebuild
+++ b/dev-ruby/ddmetrics/ddmetrics-1.0.1-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -16,7 +16,7 @@ HOMEPAGE="https://github.com/ddfreyne/ddmetrics/"
 
 LICENSE="MIT"
 SLOT="1"
-KEYWORDS="~amd64"
+KEYWORDS="~amd64 ~riscv"
 IUSE=""
 
 ruby_add_bdepend "test? ( dev-ruby/rspec-its dev-ruby/timecop )"

--- a/dev-ruby/ddplugin/ddplugin-1.0.3.ebuild
+++ b/dev-ruby/ddplugin/ddplugin-1.0.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -14,7 +14,7 @@ HOMEPAGE="https://github.com/ddfreyne/ddplugin/"
 
 LICENSE="MIT"
 SLOT="1"
-KEYWORDS="~amd64"
+KEYWORDS="~amd64 ~riscv"
 IUSE=""
 
 all_ruby_prepare() {

--- a/dev-ruby/ecma-re-validator/ecma-re-validator-0.4.0.ebuild
+++ b/dev-ruby/ecma-re-validator/ecma-re-validator-0.4.0.ebuild
@@ -15,7 +15,7 @@ HOMEPAGE="https://github.com/gjtorikian/ecma-re-validator"
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~amd64"
+KEYWORDS="~amd64 ~riscv"
 IUSE=""
 
 ruby_add_rdepend "dev-ruby/regexp_parser:2"

--- a/dev-ruby/fuubar/fuubar-2.5.1.ebuild
+++ b/dev-ruby/fuubar/fuubar-2.5.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -20,7 +20,7 @@ SRC_URI="https://github.com/thekompanee/fuubar/archive/releases/v${PV}.tar.gz ->
 
 LICENSE="MIT"
 SLOT="2"
-KEYWORDS="~amd64 ~hppa ~ppc ~ppc64 ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+KEYWORDS="~amd64 ~hppa ~ppc ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 IUSE=""
 
 RUBY_S="${PN}-releases-v${PV}"

--- a/dev-ruby/hamster/hamster-3.0.0-r2.ebuild
+++ b/dev-ruby/hamster/hamster-3.0.0-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -14,7 +14,7 @@ HOMEPAGE="https://github.com/hamstergem/hamster"
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~amd64"
+KEYWORDS="~amd64 ~riscv"
 IUSE=""
 
 ruby_add_rdepend "dev-ruby/concurrent-ruby:1"

--- a/dev-ruby/json_schema/json_schema-0.20.9.ebuild
+++ b/dev-ruby/json_schema/json_schema-0.20.9.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -18,7 +18,7 @@ SRC_URI="https://github.com/brandur/json_schema/archive/v${PV}.tar.gz -> ${P}.ta
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~amd64"
+KEYWORDS="~amd64 ~riscv"
 IUSE=""
 
 ruby_add_bdepend "test? ( dev-ruby/ecma-re-validator )"

--- a/dev-ruby/parallel/parallel-1.21.0.ebuild
+++ b/dev-ruby/parallel/parallel-1.21.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -18,7 +18,7 @@ HOMEPAGE="https://github.com/grosser/parallel"
 LICENSE="MIT"
 SRC_URI="https://github.com/grosser/parallel/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
-KEYWORDS="~amd64"
+KEYWORDS="~amd64 ~riscv"
 SLOT="1"
 IUSE="test"
 

--- a/dev-ruby/ref/ref-2.0.0-r1.ebuild
+++ b/dev-ruby/ref/ref-2.0.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -18,7 +18,7 @@ SRC_URI="https://github.com/ruby-concurrency/ref/archive/v${PV}.tar.gz -> ${P}.t
 
 LICENSE="MIT"
 SLOT="2"
-KEYWORDS="~amd64"
+KEYWORDS="~amd64 ~riscv"
 IUSE=""
 
 all_ruby_prepare() {

--- a/dev-ruby/rspectacular/rspectacular-0.70.8-r1.ebuild
+++ b/dev-ruby/rspectacular/rspectacular-0.70.8-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -16,7 +16,7 @@ HOMEPAGE="https://github.com/thekompanee/rspectacular"
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="amd64 ~hppa ~ppc ~ppc64 ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+KEYWORDS="amd64 ~hppa ~ppc ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 IUSE=""
 
 ruby_add_rdepend ">=dev-ruby/rspec-3.1:3 dev-ruby/fuubar:2 dev-ruby/shoulda-matchers:3"

--- a/dev-ruby/ruby-progressbar/ruby-progressbar-1.11.0.ebuild
+++ b/dev-ruby/ruby-progressbar/ruby-progressbar-1.11.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -22,7 +22,7 @@ RUBY_S="ruby-progressbar-releases-v${PV}"
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~amd64 ~hppa ~ppc ~ppc64 ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+KEYWORDS="~amd64 ~hppa ~ppc ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 
 IUSE="test"
 

--- a/dev-ruby/rubypants/rubypants-0.7.1.ebuild
+++ b/dev-ruby/rubypants/rubypants-0.7.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -16,7 +16,7 @@ HOMEPAGE="https://leahneukirchen.org/repos/rubypants/README"
 
 LICENSE="Ruby"
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~riscv ~x86"
 IUSE=""
 
 all_ruby_prepare() {

--- a/dev-ruby/shoulda-matchers/shoulda-matchers-3.1.3-r1.ebuild
+++ b/dev-ruby/shoulda-matchers/shoulda-matchers-3.1.3-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -18,7 +18,7 @@ HOMEPAGE="https://github.com/thoughtbot/shoulda-matchers"
 
 LICENSE="MIT"
 SLOT="3"
-KEYWORDS="amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~sparc ~x86"
+KEYWORDS="amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~riscv ~sparc ~x86"
 IUSE=""
 
 ruby_add_rdepend ">=dev-ruby/activesupport-4.0.0:*"

--- a/dev-ruby/slow_enumerator_tools/slow_enumerator_tools-1.1.0-r1.ebuild
+++ b/dev-ruby/slow_enumerator_tools/slow_enumerator_tools-1.1.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -16,7 +16,7 @@ HOMEPAGE="https://github.com/ddfreyne/slow_enumerator_tools/"
 
 LICENSE="MIT"
 SLOT="1"
-KEYWORDS="~amd64"
+KEYWORDS="~amd64 ~riscv"
 IUSE=""
 
 all_ruby_prepare() {

--- a/dev-ruby/systemu/systemu-2.6.5-r1.ebuild
+++ b/dev-ruby/systemu/systemu-2.6.5-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -16,7 +16,7 @@ HOMEPAGE="http://codeforpeople.com/lib/ruby/systemu/"
 
 LICENSE="Ruby"
 SLOT="0"
-KEYWORDS="amd64 x86"
+KEYWORDS="amd64 ~riscv x86"
 IUSE=""
 
 all_ruby_install() {

--- a/dev-ruby/tty-command/tty-command-0.10.1-r1.ebuild
+++ b/dev-ruby/tty-command/tty-command-0.10.1-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -20,7 +20,7 @@ SRC_URI="https://github.com/piotrmurach/tty-command/archive/v${PV}.tar.gz -> ${P
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~amd64"
+KEYWORDS="~amd64 ~riscv"
 IUSE=""
 
 ruby_add_rdepend ">=dev-ruby/pastel-0.8:0"

--- a/dev-ruby/tty-platform/tty-platform-0.3.0-r1.ebuild
+++ b/dev-ruby/tty-platform/tty-platform-0.3.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -18,7 +18,7 @@ SRC_URI="https://github.com/piotrmurach/tty-platform/archive/v${PV}.tar.gz -> ${
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~amd64"
+KEYWORDS="~amd64 ~riscv"
 IUSE=""
 
 all_ruby_prepare() {

--- a/dev-ruby/tty-which/tty-which-0.5.0.ebuild
+++ b/dev-ruby/tty-which/tty-which-0.5.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -18,7 +18,7 @@ SRC_URI="https://github.com/piotrmurach/tty-which/archive/v${PV}.tar.gz -> ${P}.
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~amd64"
+KEYWORDS="~amd64 ~riscv"
 IUSE=""
 
 all_ruby_prepare() {

--- a/dev-ruby/vcr/vcr-6.0.0.ebuild
+++ b/dev-ruby/vcr/vcr-6.0.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -15,7 +15,7 @@ HOMEPAGE="https://github.com/vcr/vcr/"
 SRC_URI="https://github.com/vcr/vcr/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 LICENSE="MIT"
 
-KEYWORDS="~amd64 ~arm ~ppc ~ppc64 ~x86"
+KEYWORDS="~amd64 ~arm ~ppc ~ppc64 ~riscv ~x86"
 SLOT="$(ver_cut 1)"
 IUSE="json test"
 

--- a/net-analyzer/2ping/2ping-4.5.1.ebuild
+++ b/net-analyzer/2ping/2ping-4.5.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="7"
@@ -13,7 +13,7 @@ SRC_URI="https://www.finnie.org/software/2ping/${P}.tar.gz"
 
 LICENSE="GPL-2+"
 SLOT="0"
-KEYWORDS="~amd64 ~arm ~mips ~ppc ~ppc64 ~x86"
+KEYWORDS="~amd64 ~arm ~mips ~ppc ~ppc64 ~riscv ~x86"
 IUSE="server"
 
 src_install() {

--- a/net-analyzer/fping/fping-5.0.ebuild
+++ b/net-analyzer/fping/fping-5.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -10,7 +10,7 @@ SRC_URI="https://fping.org/dist/${P}.tar.gz"
 
 LICENSE="fping"
 SLOT="0"
-KEYWORDS="~alpha amd64 ~arm ~arm64 ~hppa ~ia64 ppc ppc64 sparc x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~alpha amd64 ~arm ~arm64 ~hppa ~ia64 ppc ppc64 ~riscv sparc x86 ~amd64-linux ~x86-linux"
 IUSE="ipv6 suid"
 
 FILECAPS=( cap_net_raw+ep usr/sbin/fping )

--- a/net-analyzer/httping/httping-2.5.ebuild
+++ b/net-analyzer/httping/httping-2.5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ SRC_URI="https://www.vanheusden.com/${PN}/${P}.tgz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 ~arm64 ~hppa ~mips ~ppc ppc64 ~sparc x86"
+KEYWORDS="amd64 ~arm64 ~hppa ~mips ~ppc ppc64 ~riscv ~sparc x86"
 IUSE="debug fftw l10n_nl ncurses ssl +tfo"
 
 RDEPEND="

--- a/www-apps/nanoc-checking/nanoc-checking-1.0.1.ebuild
+++ b/www-apps/nanoc-checking/nanoc-checking-1.0.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -16,7 +16,7 @@ DESCRIPTION="Provides checking functionality for Nanoc"
 HOMEPAGE="https://nanoc.ws/"
 LICENSE="MIT"
 
-KEYWORDS="~amd64"
+KEYWORDS="~amd64 ~riscv"
 SLOT="$(ver_cut 1)"
 IUSE=""
 

--- a/www-apps/nanoc-cli/nanoc-cli-4.12.3.ebuild
+++ b/www-apps/nanoc-cli/nanoc-cli-4.12.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -15,7 +15,7 @@ HOMEPAGE="https://nanoc.ws/"
 SRC_URI="https://github.com/nanoc/nanoc/archive/${PV}.tar.gz -> nanoc-${PV}.tar.gz"
 LICENSE="MIT"
 
-KEYWORDS="~amd64"
+KEYWORDS="~amd64 ~riscv"
 SLOT="0"
 IUSE="${IUSE} minimal"
 

--- a/www-apps/nanoc-core/nanoc-core-4.12.3.ebuild
+++ b/www-apps/nanoc-core/nanoc-core-4.12.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -15,7 +15,7 @@ HOMEPAGE="https://nanoc.ws/"
 SRC_URI="https://github.com/nanoc/nanoc/archive/${PV}.tar.gz -> ${P}.tar.gz"
 LICENSE="MIT"
 
-KEYWORDS="~amd64"
+KEYWORDS="~amd64 ~riscv"
 SLOT="0"
 IUSE="${IUSE} minimal"
 

--- a/www-apps/nanoc-deploying/nanoc-deploying-1.0.1.ebuild
+++ b/www-apps/nanoc-deploying/nanoc-deploying-1.0.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -16,7 +16,7 @@ DESCRIPTION="Provides deploying functionality for Nanoc"
 HOMEPAGE="https://nanoc.ws/"
 LICENSE="MIT"
 
-KEYWORDS="~amd64"
+KEYWORDS="~amd64 ~riscv"
 SLOT="$(ver_cut 1)"
 IUSE=""
 

--- a/www-apps/nanoc-spec/nanoc-spec-0.0.2.ebuild
+++ b/www-apps/nanoc-spec/nanoc-spec-0.0.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -14,7 +14,7 @@ DESCRIPTION="Provides Nanoc::Spec, containing functionality for writing tests fo
 HOMEPAGE="https://nanoc.ws/"
 LICENSE="MIT"
 
-KEYWORDS="~amd64"
+KEYWORDS="~amd64 ~riscv"
 SLOT="0"
 IUSE="${IUSE} minimal"
 

--- a/www-servers/adsf/adsf-1.4.6.ebuild
+++ b/www-servers/adsf/adsf-1.4.6.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -18,7 +18,7 @@ SRC_URI="https://github.com/ddfreyne/adsf/archive/${PV}.tar.gz -> ${P}.tar.gz"
 RUBY_S="${P}/adsf"
 LICENSE="MIT"
 
-KEYWORDS="~amd64"
+KEYWORDS="~amd64 ~riscv"
 SLOT="0"
 IUSE=""
 


### PR DESCRIPTION
knowns:
https://bugs.gentoo.org/738716  dev-ruby/parallel-1.19.2 fails tests
https://bugs.gentoo.org/801661 www-apps/nanoc-cli-4.12.2 fails tests