### PR TITLE
dev-ruby/rubygems: Fix non-root bin dir

### DIFF
--- a/dev-ruby/rubygems/files/gentoo-defaults-5.rb
+++ b/dev-ruby/rubygems/files/gentoo-defaults-5.rb
@@ -13,7 +13,7 @@ module Gem
     end
 
     def gentoo_bindir
-      Process.euid.zero? ? '@GENTOO_PORTAGE_EPREFIX@/usr/local/bin' : File.join(user_home, 'bin')
+      Process.euid.zero? ? '@GENTOO_PORTAGE_EPREFIX@/usr/local/bin' : File.join(user_dir, 'bin')
     end
 
     def gentoo_local_dir


### PR DESCRIPTION
It seems the gem binary install path has changed with the new gentoo-defaults-5 configuration. 

Previously, gems were installed to `~/.gem/ruby/<version>/gem/bin`, now they are installed to `~/bin`. 
This seems like a bad idea, and I couldn't find the change documented anywhere, so I figured it might be a typo.

@graaff What do you think?