### PR TITLE
dev-libs/imath: add header for f16c instructions on x86

### DIFF
--- a/dev-libs/imath/files/imath-3.1.4-half.h-include-intrinsics-for-f16c-capable.patch
+++ b/dev-libs/imath/files/imath-3.1.4-half.h-include-intrinsics-for-f16c-capable.patch
@@ -1,0 +1,26 @@
+From 41e7d468246440f30bc75e7a6a316a9a07e77b23 Mon Sep 17 00:00:00 2001
+From: Bernd Waibel <waebbl-gentoo@posteo.net>
+Date: Sun, 6 Mar 2022 10:07:09 +0100
+Subject: [PATCH] half.h: include intrinsics for f16c capable x86 targets
+
+Reported-by: bzoloid <bzoloid@gmail.com>
+Suggested-by: bzoloid <bzoloid@gmail.com>
+
+Bug: https://bugs.gentoo.org/834628
+Bug: https://github.com/AcademySoftwareFoundation/Imath/issues/239
+
+Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>
+--- a/src/Imath/half.h
++++ b/src/Imath/half.h
+@@ -181,6 +181,8 @@
+ #        include <intrin.h>
+ #elif defined(__x86_64__)
+ #        include <x86intrin.h>
++#elif defined(__F16C__)
++#		include <immintrin.h>
+ #endif
+ 
+ #include <stdint.h>
+-- 
+2.35.1
+

--- a/dev-libs/imath/imath-3.1.4-r4.ebuild
+++ b/dev-libs/imath/imath-3.1.4-r4.ebuild
@@ -1,0 +1,74 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+PYTHON_COMPAT=( python3_{8..10} )
+
+inherit cmake python-single-r1
+
+MY_PN="${PN^}"
+
+DESCRIPTION="Imath basic math package"
+HOMEPAGE="https://imath.readthedocs.io"
+SRC_URI="https://github.com/AcademySoftwareFoundation/${MY_PN}/archive/refs/tags/v${PV}.tar.gz -> ${P}.tar.gz"
+# re-keywording needed for (according to ilmbase keywords): ~x64-macos ~x86-solaris
+KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~riscv ~sparc ~x86 ~amd64-linux ~x86-linux"
+S="${WORKDIR}/${MY_PN}-${PV}"
+
+LICENSE="BSD"
+SLOT="3/29"
+IUSE="doc large-stack python test"
+REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
+RESTRICT="!test? ( test )"
+
+# blocker due to file collision #803347
+RDEPEND="
+	!dev-libs/imath:0
+	!media-libs/ilmbase
+	sys-libs/zlib
+	python? (
+		!dev-python/pyilmbase
+		${PYTHON_DEPS}
+		$(python_gen_cond_dep '
+			dev-libs/boost:=[python,${PYTHON_USEDEP}]
+			dev-python/numpy[${PYTHON_USEDEP}]
+		')
+	)
+"
+DEPEND="${RDEPEND}"
+BDEPEND="
+	virtual/pkgconfig
+	doc? ( $(python_gen_cond_dep 'dev-python/breathe[${PYTHON_USEDEP}]') )
+	python? ( ${PYTHON_DEPS} )
+"
+
+PATCHES=( "${FILESDIR}"/${P}-half.h-include-intrinsics-for-f16c-capable.patch )
+
+DOCS=( CHANGES.md CONTRIBUTORS.md README.md SECURITY.md docs/PortingGuide2-3.md )
+
+pkg_setup() {
+	use python && python-single-r1_pkg_setup
+}
+
+src_configure() {
+	local mycmakeargs=(
+		-DDOCS=$(usex doc)
+		-DIMATH_ENABLE_LARGE_STACK=$(usex large-stack)
+		-DIMATH_HALF_USE_LOOKUP_TABLE=ON
+		-DIMATH_INSTALL_PKG_CONFIG=ON
+		-DIMATH_USE_CLANG_TIDY=OFF
+		-DIMATH_USE_NOEXCEPT=ON
+	)
+	if use python; then
+		mycmakeargs+=(
+			-DBoost_NO_BOOST_CMAKE=OFF
+			-DPYTHON=ON
+			-DPython3_EXECUTABLE="${PYTHON}"
+			-DPython3_INCLUDE_DIR=$(python_get_includedir)
+			-DPython3_LIBRARY=$(python_get_library_path)
+		)
+	fi
+
+	cmake_src_configure
+}


### PR DESCRIPTION
On x86 targets supporting the f16c instructions, a header for the
__cvtss_sh / __cvtsh_ss intrinsics is missing, leading to a build
failure.

Reported-by: bzoloid <bzoloid@gmail.com>
Bug: https://github.com/AcademySoftwareFoundation/Imath/issues/239
Closes: https://bugs.gentoo.org/834628
Package-Manager: Portage-3.0.30, Repoman-3.0.3
Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>