### PR TITLE
media-gfx/freecad: drop environment file

### DIFF
--- a/media-gfx/freecad/files/99freecad
+++ b/media-gfx/freecad/files/99freecad
@@ -1,1 +1,0 @@
-PYTHONPATH=/usr/lib64/freecad/Ext:/usr/lib64/freecad/Mod:/usr/lib64/freecad/lib64

--- a/media-gfx/freecad/freecad-0.19.2-r7.ebuild
+++ b/media-gfx/freecad/freecad-0.19.2-r7.ebuild
@@ -273,8 +273,6 @@ src_install() {
 	python_optimize "${ED}"/usr/share/${PN}/data/Mod/Start/StartPage "${ED}"/usr/$(get_libdir)/${PN}{/Ext,/Mod}/
 	# compile main package in python site-packages as well
 	python_optimize
-
-	doenvd "${FILESDIR}/99${PN}"
 }
 
 pkg_postinst() {

--- a/media-gfx/freecad/freecad-9999.ebuild
+++ b/media-gfx/freecad/freecad-9999.ebuild
@@ -87,7 +87,7 @@ RDEPEND="
 		dev-python/numpy[${PYTHON_USEDEP}]
 		>=dev-python/pivy-0.6.5[${PYTHON_USEDEP}]
 		dev-python/pybind11[${PYTHON_USEDEP}]
-		dev-python/pyside2[gui,svg,${PYTHON_USEDEP}]
+		dev-python/pyside2[gui,svg,webchannel,webengine,${PYTHON_USEDEP}]
 		dev-python/shiboken2[${PYTHON_USEDEP}]
 		addonmgr? ( dev-python/GitPython[${PYTHON_USEDEP}] )
 		fem? ( dev-python/ply[${PYTHON_USEDEP}] )
@@ -270,8 +270,6 @@ src_install() {
 	python_optimize "${ED}"/usr/share/${PN}/data/Mod/Start/StartPage "${ED}"/usr/$(get_libdir)/${PN}{/Ext,/Mod}/
 	# compile main package in python site-packages as well
 	python_optimize
-
-	doenvd "${FILESDIR}/99${PN}"
 }
 
 pkg_postinst() {


### PR DESCRIPTION
media-gfx/freecad: drop environment file for 0.19.2

Setting PYTHONPATH seems no longer be needed and raises incompatibilities
with other packages.

Closes: https://bugs.gentoo.org/835331
Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>

media-gfx/freecad: drop environment file for 9999

Setting PYTHONPATH seems no longer be needed and raises incompatibilities
with other packages.

AddonManager plugin now needs webchannel and webengine support for pyside2,
thus the USEDEP string has been updated to include USE flags for these.

Bug: https://bugs.gentoo.org/835331
Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>
