### PR TITLE
dev-lang/python: save/restore PYTHONDONTWRITEBYTECODE for USE=pgo

### DIFF
--- a/dev-lang/python/python-3.10.3.ebuild
+++ b/dev-lang/python/python-3.10.3.ebuild
@@ -236,6 +236,11 @@ src_compile() {
 	# https://bugs.gentoo.org/823728
 	export SETUPTOOLS_USE_DISTUTILS=stdlib
 
+	# Save PYTHONDONTWRITEBYTECODE so that 'has_version' doesn't
+	# end up writing bytecode & violating sandbox.
+	# bug #831897
+	local -x _PYTHONDONTWRITEBYTECODE=${PYTHONDONTWRITEBYTECODE}
+
 	if use pgo ; then
 		# bug 660358
 		local -x COLUMNS=80
@@ -247,6 +252,9 @@ src_compile() {
 	# also need to clear the flags explicitly here or they end up
 	# in _sysconfigdata*
 	emake CPPFLAGS= CFLAGS= LDFLAGS=
+
+	# Restore saved value from above.
+	local -x PYTHONDONTWRITEBYTECODE=${_PYTHONDONTWRITEBYTECODE}
 
 	# Work around bug 329499. See also bug 413751 and 457194.
 	if has_version dev-libs/libffi[pax-kernel]; then

--- a/dev-lang/python/python-3.11.0_alpha6.ebuild
+++ b/dev-lang/python/python-3.11.0_alpha6.ebuild
@@ -226,6 +226,11 @@ src_compile() {
 	export SETUPTOOLS_USE_DISTUTILS=stdlib
 	export PYTHONSTRICTEXTENSIONBUILD=1
 
+	# Save PYTHONDONTWRITEBYTECODE so that 'has_version' doesn't
+	# end up writing bytecode & violating sandbox.
+	# bug #831897
+	local -x _PYTHONDONTWRITEBYTECODE=${PYTHONDONTWRITEBYTECODE}
+
 	if use pgo ; then
 		# bug 660358
 		local -x COLUMNS=80
@@ -237,6 +242,9 @@ src_compile() {
 	# also need to clear the flags explicitly here or they end up
 	# in _sysconfigdata*
 	emake CPPFLAGS= CFLAGS= LDFLAGS=
+
+	# Restore saved value from above.
+	local -x PYTHONDONTWRITEBYTECODE=${_PYTHONDONTWRITEBYTECODE}
 
 	# Work around bug 329499. See also bug 413751 and 457194.
 	if has_version dev-libs/libffi[pax-kernel]; then

--- a/dev-lang/python/python-3.9.11.ebuild
+++ b/dev-lang/python/python-3.9.11.ebuild
@@ -221,6 +221,11 @@ src_compile() {
 	# https://bugs.gentoo.org/823728
 	export SETUPTOOLS_USE_DISTUTILS=stdlib
 
+	# Save PYTHONDONTWRITEBYTECODE so that 'has_version' doesn't
+	# end up writing bytecode & violating sandbox.
+	# bug #831897
+	local -x _PYTHONDONTWRITEBYTECODE=${PYTHONDONTWRITEBYTECODE}
+
 	if use pgo ; then
 		# bug 660358
 		local -x COLUMNS=80
@@ -232,6 +237,9 @@ src_compile() {
 	# also need to clear the flags explicitly here or they end up
 	# in _sysconfigdata*
 	emake CPPFLAGS= CFLAGS= LDFLAGS=
+
+	# Restore saved value from above.
+	local -x PYTHONDONTWRITEBYTECODE=${_PYTHONDONTWRITEBYTECODE}
 
 	# Work around bug 329499. See also bug 413751 and 457194.
 	if has_version dev-libs/libffi[pax-kernel]; then


### PR DESCRIPTION
This avoids writing bytecode when we call has_version (or make
any other calls). But we do need it on for the 'emake' call
when building w/ USE=pgo.

Save & restore the value from the environment before/after
emake if building with PGO.

Closes: https://bugs.gentoo.org/831897
Signed-off-by: Sam James <sam@gentoo.org>