### PR TITLE
python-r1.eclass: use python_has_version in examples of python_check_deps()

### DIFF
--- a/eclass/python-any-r1.eclass
+++ b/eclass/python-any-r1.eclass
@@ -139,7 +139,7 @@ EXPORT_FUNCTIONS pkg_setup
 # Example use:
 # @CODE
 # python_check_deps() {
-# 	has_version "dev-python/foo[${PYTHON_USEDEP}]"
+# 	python_has_version "dev-python/foo[${PYTHON_USEDEP}]"
 # }
 # @CODE
 #
@@ -161,7 +161,7 @@ EXPORT_FUNCTIONS pkg_setup
 # Example use:
 # @CODE
 # python_check_deps() {
-# 	has_version "dev-python/bar[${PYTHON_SINGLE_USEDEP}]"
+# 	python_has_version "dev-python/bar[${PYTHON_SINGLE_USEDEP}]"
 # }
 # @CODE
 #
@@ -228,9 +228,9 @@ if [[ ! ${_PYTHON_ANY_R1} ]]; then
 #		dev-python/baz[${PYTHON_USEDEP}] )')"
 #
 # python_check_deps() {
-#	has_version "dev-python/foo[${PYTHON_SINGLE_USEDEP}]" \
-#		&& { has_version "dev-python/bar[${PYTHON_USEDEP}]" \
-#			|| has_version "dev-python/baz[${PYTHON_USEDEP}]"; }
+# 	python_has_version "dev-python/foo[${PYTHON_SINGLE_USEDEP}]" &&
+# 		{ python_has_version "dev-python/bar[${PYTHON_USEDEP}]" ||
+# 			python_has_version "dev-python/baz[${PYTHON_USEDEP}]"; }
 # }
 # @CODE
 #

--- a/eclass/python-r1.eclass
+++ b/eclass/python-r1.eclass
@@ -163,7 +163,7 @@ fi
 # Example use:
 # @CODE
 # python_check_deps() {
-# 	has_version "dev-python/bar[${PYTHON_SINGLE_USEDEP}]"
+# 	python_has_version "dev-python/bar[${PYTHON_SINGLE_USEDEP}]"
 # }
 # @CODE
 #
@@ -483,9 +483,9 @@ python_gen_impl_dep() {
 #		dev-python/baz[${PYTHON_USEDEP}] )' -2)"
 #
 # python_check_deps() {
-#	has_version "dev-python/foo[${PYTHON_SINGLE_USEDEP}]" \
-#		&& { has_version "dev-python/bar[${PYTHON_USEDEP}]" \
-#			|| has_version "dev-python/baz[${PYTHON_USEDEP}]"; }
+# 	python_has_version "dev-python/foo[${PYTHON_SINGLE_USEDEP}]" &&
+# 		{ python_has_version "dev-python/bar[${PYTHON_USEDEP}]" ||
+# 			python_has_version "dev-python/baz[${PYTHON_USEDEP}]"; }
 # }
 #
 # src_compile() {
@@ -683,7 +683,7 @@ python_foreach_impl() {
 #	$(python_gen_any_dep 'dev-python/epydoc[${PYTHON_USEDEP}]' 'python2*') )"
 #
 # python_check_deps() {
-#	has_version "dev-python/epydoc[${PYTHON_USEDEP}]"
+# 	use !doc || python_has_version "dev-python/epydoc[${PYTHON_USEDEP}]"
 # }
 #
 # src_compile() {

--- a/eclass/scons-utils.eclass
+++ b/eclass/scons-utils.eclass
@@ -124,7 +124,7 @@ if [[ ${_PYTHON_ANY_R1} ]]; then
 	BDEPEND="$(python_gen_any_dep "${SCONS_DEPEND}[\${PYTHON_USEDEP}]")"
 
 	scons-utils_python_check_deps() {
-		has_version "${SCONS_DEPEND}[${PYTHON_USEDEP}]"
+		python_has_version "${SCONS_DEPEND}[${PYTHON_USEDEP}]"
 	}
 	python_check_deps() { scons-utils_python_check_deps; }
 elif [[ ${_PYTHON_SINGLE_R1} ]]; then


### PR DESCRIPTION
The `python_check_deps()` examples given in the documentation of several functions and variables in `python-r1.eclass` and `python-any-r1.eclass` are incorrect. The default behavior of `has_version()` is to check the *runtime* system (`RDEPEND`), but `python_check_deps()` is meant to check that the *build* system (`BDEPEND`) has a suitable Python environment. The examples fail to do this and thus likely are leading developers to write incorrect `python_check_deps()` functions in their ebuilds. Thankfully, `python-utils-r1.eclass` supplies a `python_has_version()` function that defaults to checking the build system and implements some other enhancements that make it nicer for use in `python_check_deps()`. Change the examples to use `python_has_version`.

This PR fixes [Bug 835462](https://bugs.gentoo.org/835462).