### PR TITLE
keyword app-text/writerperfect for riscv

### DIFF
--- a/app-text/libabw/libabw-0.1.3.ebuild
+++ b/app-text/libabw/libabw-0.1.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ SRC_URI="https://dev-www.libreoffice.org/src/${PN}/${P}.tar.xz"
 
 LICENSE="MPL-2.0"
 SLOT="0"
-KEYWORDS="amd64 ~arm arm64 ~ppc64 x86"
+KEYWORDS="amd64 ~arm arm64 ~ppc64 ~riscv x86"
 IUSE="doc static-libs"
 
 BDEPEND="

--- a/app-text/libebook/libebook-0.1.3-r2.ebuild
+++ b/app-text/libebook/libebook-0.1.3-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -12,7 +12,7 @@ SRC_URI="mirror://sourceforge/${PN}/${MY_P}.tar.bz2"
 
 LICENSE="MPL-2.0"
 SLOT="0"
-KEYWORDS="amd64 ~arm arm64 ~ppc64 x86"
+KEYWORDS="amd64 ~arm arm64 ~ppc64 ~riscv x86"
 IUSE="doc test tools"
 
 RESTRICT="!test? ( test )"

--- a/app-text/libepubgen/libepubgen-0.1.1.ebuild
+++ b/app-text/libepubgen/libepubgen-0.1.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -9,7 +9,7 @@ SRC_URI="mirror://sourceforge/${PN}/${P}.tar.xz"
 
 LICENSE="MPL-2.0"
 SLOT="0"
-KEYWORDS="amd64 ~arm arm64 ~ppc64 x86"
+KEYWORDS="amd64 ~arm arm64 ~ppc64 ~riscv x86"
 IUSE="debug doc test"
 RESTRICT="!test? ( test )"
 

--- a/app-text/libmspub/libmspub-0.1.4.ebuild
+++ b/app-text/libmspub/libmspub-0.1.4.ebuild
@@ -10,7 +10,7 @@ if [[ ${PV} = *9999 ]]; then
 	inherit git-r3
 else
 	SRC_URI="https://dev-www.libreoffice.org/src/libmspub/${P}.tar.xz"
-	KEYWORDS="amd64 ~arm arm64 ~hppa ppc ppc64 ~sparc x86"
+	KEYWORDS="amd64 ~arm arm64 ~hppa ppc ppc64 ~riscv ~sparc x86"
 fi
 DESCRIPTION="Library parsing Microsoft Publisher documents"
 HOMEPAGE="https://wiki.documentfoundation.org/DLP/Libraries/libmspub"

--- a/app-text/libmwaw/libmwaw-0.3.21.ebuild
+++ b/app-text/libmwaw/libmwaw-0.3.21.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -10,7 +10,7 @@ if [[ ${PV} == *9999* ]]; then
 	inherit git-r3
 else
 	SRC_URI="mirror://sourceforge/${PN}/${P}.tar.xz"
-	KEYWORDS="amd64 ~arm arm64 ~ppc64 x86"
+	KEYWORDS="amd64 ~arm arm64 ~ppc64 ~riscv x86"
 fi
 
 DESCRIPTION="Library parsing many pre-OSX MAC text formats"

--- a/app-text/libqxp/libqxp-0.0.2.ebuild
+++ b/app-text/libqxp/libqxp-0.0.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -9,7 +9,7 @@ SRC_URI="https://dev-www.libreoffice.org/src/${PN}/${P}.tar.xz"
 
 LICENSE="MPL-2.0"
 SLOT="0"
-KEYWORDS="amd64 ~arm arm64 ppc ppc64 x86"
+KEYWORDS="amd64 ~arm arm64 ppc ppc64 ~riscv x86"
 IUSE="debug doc test tools"
 RESTRICT="!test? ( test )"
 

--- a/app-text/writerperfect/writerperfect-0.9.6.ebuild
+++ b/app-text/writerperfect/writerperfect-0.9.6.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -9,7 +9,7 @@ SRC_URI="mirror://sourceforge/libwpd/${P}.tar.xz"
 
 LICENSE="|| ( LGPL-2.1 MPL-2.0 )"
 SLOT="0"
-KEYWORDS="amd64 x86 ~x86-linux ~x86-solaris"
+KEYWORDS="amd64 ~riscv x86 ~x86-linux ~x86-solaris"
 IUSE="abiword +cdr debug ebook epub freehand gsf keynote +mspub +mwaw pagemaker qxp +visio +wpd +wpg +wps zmf"
 
 # configure fails if no import library is selected...

--- a/media-libs/libeot/libeot-0.01.ebuild
+++ b/media-libs/libeot/libeot-0.01.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -14,7 +14,7 @@ HOMEPAGE="https://github.com/umanwizard/libeot"
 LICENSE="MPL-2.0"
 SLOT="0"
 [[ ${PV} == 9999 ]] || \
-KEYWORDS="amd64 x86"
+KEYWORDS="amd64 ~riscv x86"
 IUSE=""
 
 RDEPEND=""

--- a/media-libs/libfreehand/libfreehand-0.1.2.ebuild
+++ b/media-libs/libfreehand/libfreehand-0.1.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -15,7 +15,7 @@ HOMEPAGE="https://wiki.documentfoundation.org/DLP/Libraries/libfreehand"
 LICENSE="MPL-2.0"
 SLOT="0"
 [[ ${PV} == 9999 ]] || \
-KEYWORDS="amd64 ~arm arm64 ~hppa ppc ppc64 ~sparc x86"
+KEYWORDS="amd64 ~arm arm64 ~hppa ppc ppc64 ~riscv ~sparc x86"
 IUSE="doc static-libs test"
 RESTRICT="!test? ( test )"
 

--- a/media-libs/libpagemaker/libpagemaker-0.0.4.ebuild
+++ b/media-libs/libpagemaker/libpagemaker-0.0.4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -14,7 +14,7 @@ LICENSE="MPL-2.0"
 SLOT="0"
 
 [[ ${PV} == 9999 ]] || \
-KEYWORDS="amd64 ~arm arm64 ~hppa ppc ppc64 ~sparc x86 ~amd64-linux ~x86-linux"
+KEYWORDS="amd64 ~arm arm64 ~hppa ppc ppc64 ~riscv ~sparc x86 ~amd64-linux ~x86-linux"
 IUSE="debug doc tools"
 
 RDEPEND="

--- a/media-libs/libzmf/libzmf-0.0.2.ebuild
+++ b/media-libs/libzmf/libzmf-0.0.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -13,7 +13,7 @@ HOMEPAGE="https://wiki.documentfoundation.org/DLP/Libraries/libzmf"
 LICENSE="MPL-2.0"
 SLOT="0"
 [[ ${PV} == 9999 ]] || \
-KEYWORDS="amd64 ~arm arm64 ppc ppc64 x86"
+KEYWORDS="amd64 ~arm arm64 ppc ppc64 ~riscv x86"
 
 IUSE="debug doc test tools"
 RESTRICT="!test? ( test )"


### PR DESCRIPTION
tatt report(with 'test' USE enabled):
[atoms.report.txt](https://github.com/gentoo/gentoo/files/8308357/atoms.report.txt)

running test:
![Screenshot_20220318_140418](https://user-images.githubusercontent.com/6622239/159101073-34c6a912-5e5f-4a17-9ee6-9255c0a3a55b.png)

known potential upstream bug:
https://bugs.gentoo.org/835525