### PR TITLE
dev-util/bear: support python-3.10 in dev-util/bear-2.4.4-r1

### DIFF
--- a/dev-util/bear/bear-2.4.4-r1.ebuild
+++ b/dev-util/bear/bear-2.4.4-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{7,8,9} )
+PYTHON_COMPAT=( python3_{7,8,9,10} )
 
 inherit bash-completion-r1 cmake python-single-r1
 


### PR DESCRIPTION
enabled opportunity for a user to use python-3.10 for
dev-util/bear-2.4.4-r1

Signed-off-by: Denis Pronin <dannftk@yandex.ru>