### PR TITLE
sys-apps/i2c-tools: support python-3.10 in sys-apps/i2c-tools-4.2

### DIFF
--- a/sys-apps/i2c-tools/i2c-tools-4.2.ebuild
+++ b/sys-apps/i2c-tools/i2c-tools-4.2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python{3_7,3_8,3_9} )
+PYTHON_COMPAT=( python3_{7,8,9,10} )
 DISTUTILS_OPTIONAL="1"
 
 inherit distutils-r1 flag-o-matic toolchain-funcs


### PR DESCRIPTION
enabled opportunity for a user to use python-3.10 for
sys-apps/i2c-tools-4.2

Signed-off-by: Denis Pronin <dannftk@yandex.ru>