### PR TITLE
extundelete/extundelete: support clang in extundelete/extundelete-0.2.4-r1

### DIFF
--- a/sys-fs/extundelete/extundelete-0.2.4-r1.ebuild
+++ b/sys-fs/extundelete/extundelete-0.2.4-r1.ebuild
@@ -14,4 +14,4 @@ KEYWORDS="amd64 ~arm ~sparc x86"
 RDEPEND="sys-fs/e2fsprogs"
 DEPEND=${RDEPEND}
 
-PATCHES=( "${FILESDIR}/${P}-e2fsprogs.patch" )
+PATCHES=( "${FILESDIR}/${P}-e2fsprogs.patch" "${FILESDIR}/${P}-clang.patch" )

--- a/sys-fs/extundelete/files/extundelete-0.2.4-clang.patch
+++ b/sys-fs/extundelete/files/extundelete-0.2.4-clang.patch
@@ -1,0 +1,11 @@
+--- a/src/extundelete.cc
++++ b/src/extundelete.cc
+@@ -1268,7 +1268,7 @@
+ 	*new_ino = 0;
+ 	priv->ret_ino = new_ino;
+ 	priv->curr_name = curr_part;
+-	struct dir_context ctx = {search_flags, DIRENT_FLAG_INCLUDE_REMOVED,
++	struct dir_context ctx = {static_cast<unsigned int>(search_flags), DIRENT_FLAG_INCLUDE_REMOVED,
+ 			buf, match_name2, priv, 0};
+ 	errcode_t code = extundelete_block_iterate3(fs, *inode, BLOCK_FLAG_DATA_ONLY,
+ 			NULL, match_ino, &ctx);


### PR DESCRIPTION
patched src/extundelete.cc so that clang is not swearing on
implicit narrowing

Signed-off-by: Denis Pronin <dannftk@yandex.ru>