### PR TITLE
sys-devel/dev86: support compiling sys-devel/dev86-0.16.21-r3 with clang

### DIFF
--- a/sys-devel/dev86/dev86-0.16.21-r3.ebuild
+++ b/sys-devel/dev86/dev86-0.16.21-r3.ebuild
@@ -22,6 +22,7 @@ PATCHES=(
 	"${FILESDIR}/${PN}-0.16.19-fortify.patch"
 	"${FILESDIR}/${P}-non-void-return-clang.patch"
 	"${FILESDIR}/${PN}-0.16.21-make.patch"
+	"${FILESDIR}/${P}-void-return-check-msdos-clang-fix.patch"
 )
 
 src_prepare() {

--- a/sys-devel/dev86/files/dev86-0.16.21-void-return-check-msdos-clang-fix.patch
+++ b/sys-devel/dev86/files/dev86-0.16.21-void-return-check-msdos-clang-fix.patch
@@ -1,0 +1,20 @@
+--- a/bootblocks/makeboot.c	2020-11-30 00:28:40.383078094 +0300
++++ b/bootblocks/makeboot.c	2020-11-30 00:28:26.969025659 +0300
+@@ -183,6 +183,8 @@
+ unsigned char bpb_flags[100];
+ int has_bpb_overrides = 0;
+
++static void check_msdos();
++
+ main(argc, argv)
+ int argc;
+ char ** argv;
+@@ -1122,7 +1124,7 @@
+
+ /**************************************************************************/
+
+-check_msdos()
++static void check_msdos()
+ {
+    decode_super(buffer);
+    if( dosflds[DOS_CLUST].value == 0 )	/* MSDOS v1.0 */


### PR DESCRIPTION
patched bootblocks/makeboot.c of sys-devel/dev86-0.16.21-r3

Signed-off-by: Denis Pronin <dannftk@yandex.ru>