### PR TITLE
profiles/features/musl: unmask www-client/firefox

### DIFF
--- a/profiles/features/musl/package.mask
+++ b/profiles/features/musl/package.mask
@@ -234,12 +234,6 @@ sys-apps/systemd
 # systemd sources fail to build without glibc
 sys-boot/systemd-boot
 
-# Ian Stakenvicius <axs@gentoo.org> (2017-06-14)
-# (on behalf of <mozilla@gentoo.org>)
-# Mask firefox-54 and above as it requires rust
-# now, and rust reportedly will not build yet.
->=www-client/firefox-54.0
-
 # rust-bin requires a glibc system
 dev-lang/rust-bin
 mail-client/thunderbird-bin


### PR DESCRIPTION
`rust` seems to work with `musl` for quite some time. I currently use `dev-lang/rust::musl`, but I also used to have `dev-lang/rust::gentoo` installed in my system, therefore I think we should unmask `www-client/firefox`. I successfully installed `firefox-91.7.1` yesterday and it runs just fine.

Just a note, I had to disable `-clang` use flag, with `+clang` `firefox-{91.7.0,91.7.1,98.0.1}` failed to compile, so we can mask just this flag, but maybe this is related only to my box.