### PR TITLE
riscv: keyword dev-util/{distro-info,abi-dumper,astlye}, net-misc/mikutter, x11-terms/mlterm

### DIFF
--- a/app-i18n/skk-jisyo/skk-jisyo-202005.ebuild
+++ b/app-i18n/skk-jisyo/skk-jisyo-202005.ebuild
@@ -12,7 +12,7 @@ SRC_URI="mirror://gentoo/${P}.tar.xz
 
 LICENSE="CC-BY-SA-3.0 GPL-2+ public-domain unicode"
 SLOT="0"
-KEYWORDS="~amd64 ~arm ~hppa ~ppc ~ppc64 ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~sparc-solaris"
+KEYWORDS="~amd64 ~arm ~hppa ~ppc ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~sparc-solaris"
 IUSE="cdb"
 
 DEPEND="virtual/awk

--- a/app-i18n/skkserv/skkserv-9.6-r3.ebuild
+++ b/app-i18n/skkserv/skkserv-9.6-r3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"
@@ -11,7 +11,7 @@ SRC_URI="http://openlab.ring.gr.jp/skk/maintrunk/museum/${MY_P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 ppc x86 ~amd64-linux ~x86-linux ~ppc-macos"
+KEYWORDS="amd64 ppc ~riscv x86 ~amd64-linux ~x86-linux ~ppc-macos"
 IUSE=""
 
 DEPEND="app-i18n/skk-jisyo"

--- a/app-i18n/skktools/skktools-1.3.4.ebuild
+++ b/app-i18n/skktools/skktools-1.3.4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"
@@ -11,7 +11,7 @@ SRC_URI="https://github.com/skk-dev/skktools/archive/${P//./_}.tar.gz -> ${P}.ta
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~amd64 ~arm ~x86"
+KEYWORDS="~amd64 ~arm ~riscv ~x86"
 IUSE="emacs"
 
 RDEPEND="dev-libs/glib:2

--- a/app-i18n/uim/uim-1.8.9_pre20210103.ebuild
+++ b/app-i18n/uim/uim-1.8.9_pre20210103.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="7"
@@ -15,7 +15,7 @@ SRC_URI="https://github.com/${PN}/${PN}/archive/${EGIT_COMMIT}.tar.gz -> ${P}.ta
 
 LICENSE="BSD GPL-2 LGPL-2.1"
 SLOT="0"
-KEYWORDS="~amd64 ~arm ~hppa ~ppc ~ppc64 ~x86"
+KEYWORDS="~amd64 ~arm ~hppa ~ppc ~ppc64 ~riscv ~x86"
 IUSE="X +anthy curl eb emacs expat libffi gtk gtk2 kde l10n_ja l10n_ko l10n_zh-CN l10n_zh-TW libedit libnotify m17n-lib ncurses nls qt5 skk sqlite ssl static-libs xft"
 RESTRICT="test"
 REQUIRED_USE="gtk? ( X )

--- a/app-text/bdf2psf/bdf2psf-1.155.ebuild
+++ b/app-text/bdf2psf/bdf2psf-1.155.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -9,7 +9,7 @@ SRC_URI="mirror://debian/pool/main/c/console-setup/console-setup_${PV}.tar.xz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm ~ia64 ppc ppc64 ~s390 sparc x86"
+KEYWORDS="~alpha amd64 arm ~ia64 ppc ppc64 ~riscv ~s390 sparc x86"
 IUSE=""
 
 DEPEND=""

--- a/dev-libs/libcss/libcss-0.9.1-r1.ebuild
+++ b/dev-libs/libcss/libcss-0.9.1-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ SRC_URI="https://download.netsurf-browser.org/libs/releases/${P}-src.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~riscv ~x86"
 IUSE="test"
 
 RESTRICT="!test? ( test )"

--- a/dev-libs/libnsfb/libnsfb-0.2.2-r1.ebuild
+++ b/dev-libs/libnsfb/libnsfb-0.2.2-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ SRC_URI="https://download.netsurf-browser.org/libs/releases/${P}-src.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~riscv ~x86"
 IUSE="sdl test vnc wayland X"
 
 RESTRICT="!test? ( test )"

--- a/dev-libs/libnsutils/libnsutils-0.1.0-r1.ebuild
+++ b/dev-libs/libnsutils/libnsutils-0.1.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ SRC_URI="https://download.netsurf-browser.org/libs/releases/${P}-src.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~riscv ~x86"
 IUSE=""
 
 BDEPEND="dev-util/netsurf-buildsystem"

--- a/dev-libs/libparserutils/libparserutils-0.2.4-r3.ebuild
+++ b/dev-libs/libparserutils/libparserutils-0.2.4-r3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ SRC_URI="https://download.netsurf-browser.org/libs/releases/${P}-src.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 arm arm64 ppc ~ppc64 x86"
+KEYWORDS="amd64 arm arm64 ppc ~ppc64 ~riscv x86"
 IUSE="iconv test"
 RESTRICT="!test? ( test )"
 

--- a/dev-libs/libwapcaplet/libwapcaplet-0.4.3-r1.ebuild
+++ b/dev-libs/libwapcaplet/libwapcaplet-0.4.3-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ SRC_URI="https://download.netsurf-browser.org/libs/releases/${P}-src.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~riscv ~x86"
 IUSE="test"
 
 RESTRICT="!test? ( test )"

--- a/dev-libs/nsgenbind/nsgenbind-0.8-r1.ebuild
+++ b/dev-libs/nsgenbind/nsgenbind-0.8-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ SRC_URI="https://download.netsurf-browser.org/libs/releases/${P}-src.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~riscv ~x86"
 IUSE=""
 
 BDEPEND="

--- a/dev-ruby/delayer-deferred/delayer-deferred-2.2.0.ebuild
+++ b/dev-ruby/delayer-deferred/delayer-deferred-2.2.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -15,7 +15,7 @@ HOMEPAGE="https://github.com/toshia/delayer-deferred"
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~riscv ~x86"
 IUSE=""
 
 ruby_add_rdepend "dev-ruby/delayer:1"

--- a/dev-ruby/delayer/delayer-1.2.1.ebuild
+++ b/dev-ruby/delayer/delayer-1.2.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -14,7 +14,7 @@ HOMEPAGE="https://rubygems.org/gems/delayer"
 
 LICENSE="MIT"
 SLOT="1"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~riscv ~x86"
 IUSE=""
 
 all_ruby_prepare() {

--- a/dev-ruby/diva/diva-1.1.0.ebuild
+++ b/dev-ruby/diva/diva-1.1.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -19,7 +19,7 @@ SRC_URI="https://github.com/toshia/diva/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~amd64"
+KEYWORDS="~amd64 ~riscv"
 IUSE=""
 
 ruby_add_rdepend "<dev-ruby/addressable-2.9"

--- a/dev-ruby/docile/docile-1.4.0.ebuild
+++ b/dev-ruby/docile/docile-1.4.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -19,7 +19,7 @@ SRC_URI="https://github.com/ms-ati/docile/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~amd64"
+KEYWORDS="~amd64 ~riscv"
 IUSE=""
 
 all_ruby_prepare() {

--- a/dev-ruby/httpclient/httpclient-2.8.3-r1.ebuild
+++ b/dev-ruby/httpclient/httpclient-2.8.3-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -23,7 +23,7 @@ SRC_URI="https://github.com/nahi/httpclient/archive/v${PV}.tar.gz -> ${P}.tgz"
 LICENSE="Ruby"
 SLOT="0"
 
-KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x64-solaris ~x86-solaris"
+KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~riscv ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x64-solaris ~x86-solaris"
 IUSE=""
 
 ruby_add_rdepend "virtual/ruby-ssl"

--- a/dev-ruby/idn-ruby/idn-ruby-0.1.4.ebuild
+++ b/dev-ruby/idn-ruby/idn-ruby-0.1.4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -15,7 +15,7 @@ HOMEPAGE="https://github.com/deepfryed/idn-ruby"
 
 LICENSE="Apache-2.0"
 SLOT="0"
-KEYWORDS="~amd64"
+KEYWORDS="~amd64 ~riscv"
 IUSE=""
 
 RDEPEND+=" net-dns/libidn:0"

--- a/dev-ruby/instance_storage/instance_storage-1.0.0-r1.ebuild
+++ b/dev-ruby/instance_storage/instance_storage-1.0.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -13,7 +13,7 @@ HOMEPAGE="https://rubygems.org/gems/instance_storage/"
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~riscv ~x86"
 IUSE=""
 
 all_ruby_prepare() {

--- a/dev-ruby/locale/locale-2.1.3.ebuild
+++ b/dev-ruby/locale/locale-2.1.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -20,7 +20,7 @@ HOMEPAGE="https://github.com/ruby-gettext/locale"
 LICENSE="|| ( Ruby GPL-2 )"
 SRC_URI="https://github.com/ruby-gettext/locale/archive/${PV}.tar.gz -> ${P}-git.tgz"
 
-KEYWORDS="~alpha amd64 arm arm64 ~hppa ppc ppc64 sparc x86"
+KEYWORDS="~alpha amd64 arm arm64 ~hppa ppc ppc64 ~riscv sparc x86"
 SLOT="0"
 IUSE=""
 

--- a/dev-ruby/memoist/memoist-0.16.2.ebuild
+++ b/dev-ruby/memoist/memoist-0.16.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -13,7 +13,7 @@ HOMEPAGE="https://github.com/matthewrudy/memoist"
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="amd64 ~x86"
+KEYWORDS="amd64 ~riscv ~x86"
 IUSE=""
 
 ruby_add_bdepend "test? ( dev-ruby/minitest )"

--- a/dev-ruby/moneta/moneta-1.4.1.ebuild
+++ b/dev-ruby/moneta/moneta-1.4.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -23,7 +23,7 @@ SRC_URI="https://github.com/${GITHUB_USER}/moneta/archive/v${PV}.tar.gz -> ${P}.
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~riscv ~x86"
 IUSE=""
 
 all_ruby_prepare() {

--- a/dev-ruby/multi_json/multi_json-1.15.0.ebuild
+++ b/dev-ruby/multi_json/multi_json-1.15.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -20,7 +20,7 @@ DESCRIPTION="A gem to provide swappable JSON backends"
 HOMEPAGE="https://github.com/intridea/multi_json"
 LICENSE="MIT"
 
-KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 SLOT="0"
 IUSE=""
 

--- a/dev-ruby/oauth/oauth-0.5.8.ebuild
+++ b/dev-ruby/oauth/oauth-0.5.8.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -17,7 +17,7 @@ RUBY_S="${PN}-ruby-${PV}"
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~amd64 ~ppc ~x86"
+KEYWORDS="~amd64 ~ppc ~riscv ~x86"
 IUSE=""
 
 ruby_add_bdepend "test? (

--- a/dev-ruby/pluggaloid/pluggaloid-1.7.0.ebuild
+++ b/dev-ruby/pluggaloid/pluggaloid-1.7.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -13,7 +13,7 @@ HOMEPAGE="https://rubygems.org/gems/pluggaloid/"
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~riscv ~x86"
 IUSE=""
 
 ruby_add_rdepend "

--- a/dev-ruby/rcairo/rcairo-1.17.5.ebuild
+++ b/dev-ruby/rcairo/rcairo-1.17.5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -24,7 +24,7 @@ IUSE=""
 
 SLOT="0"
 LICENSE="|| ( Ruby GPL-2 )"
-KEYWORDS="~amd64 ~ppc ~x86"
+KEYWORDS="~amd64 ~ppc ~riscv ~x86"
 
 RDEPEND="${RDEPEND}
 	>=x11-libs/cairo-1.2.0[svg]"

--- a/dev-ruby/red-colors/red-colors-0.3.0-r1.ebuild
+++ b/dev-ruby/red-colors/red-colors-0.3.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -17,4 +17,4 @@ IUSE=""
 
 SLOT="0"
 LICENSE="MIT"
-KEYWORDS="~amd64 ~ppc ~x86"
+KEYWORDS="~amd64 ~ppc ~riscv ~x86"

--- a/dev-ruby/ruby-atk/ruby-atk-3.4.3.ebuild
+++ b/dev-ruby/ruby-atk/ruby-atk-3.4.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -7,7 +7,7 @@ USE_RUBY="ruby24 ruby25 ruby26 ruby27"
 inherit ruby-ng-gnome2
 
 DESCRIPTION="Ruby Atk bindings"
-KEYWORDS="amd64 ~ppc ~x86"
+KEYWORDS="amd64 ~ppc ~riscv ~x86"
 IUSE=""
 DEPEND+=" dev-libs/atk[introspection]"
 RDEPEND+=" dev-libs/atk[introspection]"

--- a/dev-ruby/ruby-cairo-gobject/ruby-cairo-gobject-3.4.3.ebuild
+++ b/dev-ruby/ruby-cairo-gobject/ruby-cairo-gobject-3.4.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -7,7 +7,7 @@ USE_RUBY="ruby24 ruby25 ruby26 ruby27"
 inherit ruby-ng-gnome2
 
 DESCRIPTION="Ruby cairo-gobject bindings"
-KEYWORDS="amd64 ~ppc ~x86"
+KEYWORDS="amd64 ~ppc ~riscv ~x86"
 IUSE=""
 
 DEPEND+=" x11-libs/cairo"

--- a/dev-ruby/ruby-gdkpixbuf2/ruby-gdkpixbuf2-3.4.3.ebuild
+++ b/dev-ruby/ruby-gdkpixbuf2/ruby-gdkpixbuf2-3.4.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ inherit ruby-ng-gnome2
 RUBY_S=ruby-gnome-${PV}/gdk_pixbuf2
 
 DESCRIPTION="Ruby GdkPixbuf2 bindings"
-KEYWORDS="amd64 ~ppc ~x86"
+KEYWORDS="amd64 ~ppc ~riscv ~x86"
 IUSE=""
 
 DEPEND+=" test? ( x11-libs/gdk-pixbuf[jpeg] )"

--- a/dev-ruby/ruby-gettext/ruby-gettext-3.3.7.ebuild
+++ b/dev-ruby/ruby-gettext/ruby-gettext-3.3.7.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -20,7 +20,7 @@ inherit ruby-fakegem
 DESCRIPTION="Native Language Support Library and Tools modeled after GNU gettext package"
 HOMEPAGE="https://ruby-gettext.github.io/"
 
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~sparc ~x86"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~riscv ~sparc ~x86"
 IUSE="doc test"
 SLOT="0"
 LICENSE="|| ( Ruby LGPL-3+ )"

--- a/dev-ruby/ruby-gettext/ruby-gettext-3.4.1.ebuild
+++ b/dev-ruby/ruby-gettext/ruby-gettext-3.4.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -20,7 +20,7 @@ inherit ruby-fakegem
 DESCRIPTION="Native Language Support Library and Tools modeled after GNU gettext package"
 HOMEPAGE="https://ruby-gettext.github.io/"
 
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~sparc ~x86"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~riscv ~sparc ~x86"
 IUSE="doc test"
 SLOT="0"
 LICENSE="|| ( Ruby LGPL-3+ )"

--- a/dev-ruby/ruby-gio2/ruby-gio2-3.4.3.ebuild
+++ b/dev-ruby/ruby-gio2/ruby-gio2-3.4.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -7,7 +7,7 @@ USE_RUBY="ruby24 ruby25 ruby26 ruby27"
 inherit ruby-ng-gnome2
 
 DESCRIPTION="Ruby binding of gio-2"
-KEYWORDS="amd64 ~ppc ~x86"
+KEYWORDS="amd64 ~ppc ~riscv ~x86"
 IUSE=""
 
 DEPEND+=" dev-libs/glib

--- a/dev-ruby/ruby-glib2/ruby-glib2-3.4.3.ebuild
+++ b/dev-ruby/ruby-glib2/ruby-glib2-3.4.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -7,7 +7,7 @@ USE_RUBY="ruby24 ruby25 ruby26 ruby27"
 inherit ruby-ng-gnome2
 
 DESCRIPTION="Ruby Glib2 bindings"
-KEYWORDS="amd64 ~ppc ~ppc64 x86"
+KEYWORDS="amd64 ~ppc ~ppc64 ~riscv x86"
 IUSE=""
 RDEPEND+=" >=dev-libs/glib-2"
 DEPEND+=" >=dev-libs/glib-2"

--- a/dev-ruby/ruby-gobject-introspection/ruby-gobject-introspection-3.4.3.ebuild
+++ b/dev-ruby/ruby-gobject-introspection/ruby-gobject-introspection-3.4.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -7,7 +7,7 @@ USE_RUBY="ruby24 ruby25 ruby26 ruby27"
 inherit ruby-ng-gnome2
 
 DESCRIPTION="Ruby GObjectIntrospection bindings"
-KEYWORDS="amd64 ~ppc ~x86"
+KEYWORDS="amd64 ~ppc ~riscv ~x86"
 IUSE=""
 
 DEPEND+=" dev-libs/glib

--- a/dev-ruby/ruby-gtk2/ruby-gtk2-3.4.3.ebuild
+++ b/dev-ruby/ruby-gtk2/ruby-gtk2-3.4.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -9,7 +9,7 @@ RUBY_GNOME2_NEED_VIRTX=yes
 inherit ruby-ng-gnome2
 
 DESCRIPTION="Ruby Gtk2 bindings"
-KEYWORDS="amd64 ~ppc ~x86"
+KEYWORDS="amd64 ~ppc ~riscv ~x86"
 IUSE=""
 
 DEPEND+=" dev-libs/glib

--- a/dev-ruby/ruby-pango/ruby-pango-3.4.3.ebuild
+++ b/dev-ruby/ruby-pango/ruby-pango-3.4.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -7,7 +7,7 @@ USE_RUBY="ruby24 ruby25 ruby26 ruby27"
 inherit ruby-ng-gnome2
 
 DESCRIPTION="Ruby Pango bindings"
-KEYWORDS="amd64 ~ppc ~x86"
+KEYWORDS="amd64 ~ppc ~riscv ~x86"
 IUSE=""
 DEPEND+=" dev-libs/glib
 	>=x11-libs/pango-1.2.1[introspection]"

--- a/dev-ruby/ruby-poppler/ruby-poppler-3.4.3.ebuild
+++ b/dev-ruby/ruby-poppler/ruby-poppler-3.4.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -7,7 +7,7 @@ USE_RUBY="ruby24 ruby25 ruby26 ruby27"
 inherit ruby-ng-gnome2
 
 DESCRIPTION="Ruby poppler-glib bindings"
-KEYWORDS="amd64 ~ppc ~x86"
+KEYWORDS="amd64 ~ppc ~riscv ~x86"
 IUSE=""
 
 RDEPEND+=" app-text/poppler[cairo,introspection]"

--- a/dev-ruby/shoulda-matchers/shoulda-matchers-5.0.0.ebuild
+++ b/dev-ruby/shoulda-matchers/shoulda-matchers-5.0.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -21,7 +21,7 @@ SRC_URI="https://github.com/thoughtbot/shoulda-matchers/archive/v${PV}.tar.gz ->
 
 LICENSE="MIT"
 SLOT="$(ver_cut 1)"
-KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~sparc ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~riscv ~sparc ~x86"
 IUSE=""
 
 ruby_add_rdepend ">=dev-ruby/activesupport-4.2.0:*"

--- a/dev-ruby/simplecov-html/simplecov-html-0.12.3.ebuild
+++ b/dev-ruby/simplecov-html/simplecov-html-0.12.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -18,6 +18,6 @@ DESCRIPTION="Generates a HTML report of your SimpleCov ruby code coverage result
 HOMEPAGE="https://github.com/colszowka/simplecov"
 LICENSE="MIT"
 
-KEYWORDS="~amd64"
+KEYWORDS="~amd64 ~riscv"
 SLOT="$(ver_cut 1-2)"
 IUSE="doc"

--- a/dev-ruby/simplecov/simplecov-0.19.1.ebuild
+++ b/dev-ruby/simplecov/simplecov-0.19.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -19,7 +19,7 @@ HOMEPAGE="https://github.com/simplecov-ruby/simplecov"
 SRC_URI="https://github.com/simplecov-ruby/simplecov/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 LICENSE="MIT"
 
-KEYWORDS="~amd64"
+KEYWORDS="~amd64 ~riscv"
 SLOT="0.8"
 IUSE="doc"
 

--- a/dev-ruby/text/text-1.3.1-r1.ebuild
+++ b/dev-ruby/text/text-1.3.1-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -14,5 +14,5 @@ HOMEPAGE="https://github.com/threedaymonk/text"
 LICENSE="MIT"
 
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 ~hppa ppc ppc64 sparc x86"
+KEYWORDS="~alpha amd64 arm arm64 ~hppa ppc ppc64 ~riscv sparc x86"
 IUSE=""

--- a/dev-ruby/twitter-text/twitter-text-3.1.0-r1.ebuild
+++ b/dev-ruby/twitter-text/twitter-text-3.1.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -17,7 +17,7 @@ HOMEPAGE="https://github.com/twitter/twitter-text"
 
 LICENSE="MIT"
 SLOT="$(ver_cut 1-2)"
-KEYWORDS="~amd64"
+KEYWORDS="~amd64 ~riscv"
 IUSE=""
 
 ruby_add_rdepend "

--- a/dev-ruby/typed-array/typed-array-0.1.2-r2.ebuild
+++ b/dev-ruby/typed-array/typed-array-0.1.2-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -15,7 +15,7 @@ HOMEPAGE="https://github.com/yaauie/typed-array"
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~riscv ~x86"
 IUSE=""
 
 all_ruby_prepare() {

--- a/dev-ruby/yajl-ruby/yajl-ruby-1.4.1-r1.ebuild
+++ b/dev-ruby/yajl-ruby/yajl-ruby-1.4.1-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -21,7 +21,7 @@ HOMEPAGE="https://github.com/brianmario/yajl-ruby"
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 IUSE=""
 
 RDEPEND="${RDEPEND} dev-libs/yajl"

--- a/dev-util/abi-dumper/abi-dumper-1.2.ebuild
+++ b/dev-util/abi-dumper/abi-dumper-1.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -9,7 +9,7 @@ SRC_URI="https://github.com/lvc/abi-dumper/archive/${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 ~x86"
+KEYWORDS="amd64 ~riscv ~x86"
 
 DEPEND="dev-lang/perl"
 RDEPEND="${DEPEND}

--- a/dev-util/astyle/astyle-3.1-r2.ebuild
+++ b/dev-util/astyle/astyle-3.1-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -11,7 +11,7 @@ SRC_URI="mirror://sourceforge/astyle/astyle_${PV}_linux.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/3.1"
-KEYWORDS="amd64 ~arm64 ppc ppc64 x86 ~amd64-linux ~x86-linux ~ppc-macos"
+KEYWORDS="amd64 ~arm64 ppc ppc64 ~riscv x86 ~amd64-linux ~x86-linux ~ppc-macos"
 IUSE="examples java static-libs"
 
 DEPEND="app-arch/xz-utils

--- a/dev-util/distro-info-data/distro-info-data-0.46.ebuild
+++ b/dev-util/distro-info-data/distro-info-data-0.46.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -10,7 +10,7 @@ SRC_URI="mirror://debian/pool/main/d/${PN}/${PN}_${PV}.tar.xz"
 LICENSE="ISC"
 SLOT="0"
 
-KEYWORDS="amd64 x86"
+KEYWORDS="amd64 ~riscv x86"
 IUSE=""
 # Package provides only csv data and test script
 # written in python

--- a/dev-util/distro-info/distro-info-1.0.ebuild
+++ b/dev-util/distro-info/distro-info-1.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -14,7 +14,7 @@ SRC_URI="mirror://debian/pool/main/d/${PN}/${PN}_${PV}.tar.xz"
 
 LICENSE="ISC"
 SLOT="0"
-KEYWORDS="amd64 x86"
+KEYWORDS="amd64 ~riscv x86"
 IUSE="python test"
 RESTRICT="!test? ( test )"
 

--- a/dev-util/shunit2/shunit2-2.1.8.ebuild
+++ b/dev-util/shunit2/shunit2-2.1.8.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -9,7 +9,7 @@ SRC_URI="https://github.com/kward/shunit2/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="Apache-2.0"
 SLOT="0"
-KEYWORDS="~amd64 ~ppc ~ppc64 ~x86"
+KEYWORDS="~amd64 ~ppc ~ppc64 ~riscv ~x86"
 IUSE="test"
 RESTRICT="!test? ( test )"
 

--- a/dev-util/vtable-dumper/vtable-dumper-1.2.ebuild
+++ b/dev-util/vtable-dumper/vtable-dumper-1.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -11,7 +11,7 @@ SRC_URI="https://github.com/lvc/vtable-dumper/archive/${PV}.tar.gz -> ${P}.tar.g
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 ~x86"
+KEYWORDS="amd64 ~riscv ~x86"
 
 DEPEND="dev-libs/elfutils:0="
 RDEPEND="${DEPEND}"

--- a/media-fonts/unifont/unifont-13.0.01-r1.ebuild
+++ b/media-fonts/unifont/unifont-13.0.01-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2003-2021 Gentoo Authors
+# Copyright 2003-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ SRC_URI="mirror://gnu/${PN}/${P}/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm ~ia64 ppc ppc64 ~s390 sparc x86"
+KEYWORDS="~alpha amd64 arm ~ia64 ppc ppc64 ~riscv ~s390 sparc x86"
 IUSE="fontforge utils"
 
 BDEPEND="

--- a/media-libs/libnsbmp/libnsbmp-0.1.6-r1.ebuild
+++ b/media-libs/libnsbmp/libnsbmp-0.1.6-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ SRC_URI="https://download.netsurf-browser.org/libs/releases/${P}-src.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~riscv ~x86"
 IUSE=""
 
 BDEPEND="

--- a/media-libs/libnspsl/libnspsl-0.1.6-r1.ebuild
+++ b/media-libs/libnspsl/libnspsl-0.1.6-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ SRC_URI="https://download.netsurf-browser.org/libs/releases/${P}-src.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~riscv ~x86"
 IUSE=""
 
 BDEPEND="

--- a/media-libs/librosprite/librosprite-0.1.3-r2.ebuild
+++ b/media-libs/librosprite/librosprite-0.1.3-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ SRC_URI="https://download.netsurf-browser.org/libs/releases/${P}-src.tar.gz"
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~riscv ~x86"
 IUSE=""
 
 DEPEND="dev-util/netsurf-buildsystem"

--- a/media-libs/libsvgtiny/libsvgtiny-0.1.7-r2.ebuild
+++ b/media-libs/libsvgtiny/libsvgtiny-0.1.7-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ SRC_URI="https://download.netsurf-browser.org/libs/releases/${P}-src.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND="

--- a/net-libs/libdom/libdom-0.4.1-r1.ebuild
+++ b/net-libs/libdom/libdom-0.4.1-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ SRC_URI="https://download.netsurf-browser.org/libs/releases/${P}-src.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~riscv ~x86"
 IUSE="expat test xml"
 
 RESTRICT="!test? ( test )"

--- a/net-libs/libhubbub/libhubbub-0.3.7.ebuild
+++ b/net-libs/libhubbub/libhubbub-0.3.7.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ SRC_URI="https://download.netsurf-browser.org/libs/releases/${P}-src.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 arm arm64 ppc ~ppc64 x86"
+KEYWORDS="amd64 arm arm64 ppc ~ppc64 ~riscv x86"
 IUSE="doc test"
 
 BDEPEND="

--- a/net-misc/mikutter/mikutter-4.1.7.ebuild
+++ b/net-misc/mikutter/mikutter-4.1.7.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -18,7 +18,7 @@ if [ "${PV}" = "9999" ]; then
 else
 	SRC_URI="http://mikutter.hachune.net/bin/${P}.tar.gz
 		https://raw.githubusercontent.com/toshia/twitter_api_keys/${PLUGIN_HASH}/twitter_api_keys.rb"
-	KEYWORDS="~amd64"
+	KEYWORDS="~amd64 ~riscv"
 fi
 
 DESCRIPTION="Simple, powerful and moeful twitter client"

--- a/virtual/skkserv/skkserv-0-r1.ebuild
+++ b/virtual/skkserv/skkserv-0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -6,7 +6,7 @@ EAPI=7
 DESCRIPTION="Virtual for SKK server"
 
 SLOT="0"
-KEYWORDS="amd64 ppc x86 ~amd64-linux ~x86-linux ~ppc-macos"
+KEYWORDS="amd64 ppc ~riscv x86 ~amd64-linux ~x86-linux ~ppc-macos"
 
 RDEPEND="|| (
 		app-i18n/skkserv

--- a/www-client/netsurf/netsurf-3.10-r6.ebuild
+++ b/www-client/netsurf/netsurf-3.10-r6.ebuild
@@ -11,7 +11,7 @@ SRC_URI="http://download.netsurf-browser.org/netsurf/releases/source/${P}-src.ta
 
 LICENSE="GPL-2 MIT"
 SLOT="0"
-KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~riscv ~x86"
 IUSE="bmp fbcon truetype +gif +gtk gtk2 +javascript +jpeg mng
 	+png +psl rosprite +svg +svgtiny +webp"
 

--- a/x11-terms/mlterm/mlterm-3.9.2.ebuild
+++ b/x11-terms/mlterm/mlterm-3.9.2.ebuild
@@ -11,7 +11,7 @@ SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="~amd64 ~ppc ~ppc64 ~x86"
+KEYWORDS="~amd64 ~ppc ~ppc64 ~riscv ~x86"
 IUSE="+X bidi brltty cairo debug fbcon fcitx freewnn gtk harfbuzz ibus libssh2 m17n-lib nls regis scim skk static-libs uim utempter wayland xft"
 REQUIRED_USE="|| ( X fbcon wayland )"
 


### PR DESCRIPTION
known bugs:
https://bugs.gentoo.org/786585 dev-util/distro-info-1.0: fails tests
https://bugs.gentoo.org/807727 dev-ruby/httpclient-2.8.3: fail test on riscv
https://bugs.gentoo.org/817296 dev-ruby/httpclient-2.8.3 fails tests
https://bugs.gentoo.org/830856 dev-ruby/httpclient-2.8.3-r1: EAPI-8 bump, then stabilisation
https://bugs.gentoo.org/803527 dev-ruby/ruby-gobject-introspection-3.4.3 fails tests: - Failure: test_may_return_null?(TestCallableInfo):
https://bugs.gentoo.org/728518 dev-ruby/ruby-gio2-3.3.2 fails tests: "TypeError: String isn't supported"

my newly reported bugs:
https://bugs.gentoo.org/835621 dev-ruby/multi_json-1.15.0 fails test
https://bugs.gentoo.org/835620 dev-ruby/simplecov-0.19.1 fails test



