### PR TITLE
dev-util/gcovr: support python-3.10 in dev-util/gcovr-4.2

### DIFF
--- a/dev-util/gcovr/gcovr-4.2.ebuild
+++ b/dev-util/gcovr/gcovr-4.2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{7..9} )
+PYTHON_COMPAT=( python3_{7..10} )
 DISTUTILS_IN_SOURCE_BUILD=1
 
 inherit distutils-r1


### PR DESCRIPTION
enabled opportunity for a user to use python-3.10 for
dev-util/gcovr-4.2

Signed-off-by: Denis Pronin <dannftk@yandex.ru>