### PR TITLE
sys-block/fio: support python-3.10 in all fio ebuilds

### DIFF
--- a/sys-block/fio/fio-3.27-r2.ebuild
+++ b/sys-block/fio/fio-3.27-r2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{7,8,9} )
+PYTHON_COMPAT=( python3_{7,8,9,10} )
 
 inherit python-r1 toolchain-funcs
 

--- a/sys-block/fio/fio-3.27-r3.ebuild
+++ b/sys-block/fio/fio-3.27-r3.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{7,8,9} )
+PYTHON_COMPAT=( python3_{7,8,9,10} )
 
 inherit python-r1 toolchain-funcs
 


### PR DESCRIPTION
enabled opportunity for a user to use python-3.10 for
sys-block/fio

Signed-off-by: Denis Pronin <dannftk@yandex.ru>