### PR TITLE
dev-util/desktop-file-utils: Backport support for spec 1.5

### DIFF
--- a/dev-util/desktop-file-utils/desktop-file-utils-0.26-r2.ebuild
+++ b/dev-util/desktop-file-utils/desktop-file-utils-0.26-r2.ebuild
@@ -1,0 +1,50 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+inherit elisp-common meson
+
+DESCRIPTION="Command line utilities to work with desktop menu entries"
+HOMEPAGE="https://freedesktop.org/wiki/Software/desktop-file-utils/"
+SRC_URI="https://www.freedesktop.org/software/${PN}/releases/${P}.tar.xz"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~x64-cygwin ~amd64-linux ~x86-linux ~x64-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
+IUSE="emacs"
+
+RDEPEND=">=dev-libs/glib-2.12:2"
+DEPEND="${RDEPEND}"
+BDEPEND="
+	app-arch/xz-utils
+	virtual/pkgconfig
+	emacs? ( >=app-editors/emacs-23.1:* )
+"
+
+SITEFILE="50${PN}-gentoo.el"
+
+DOCS=( AUTHORS ChangeLog HACKING NEWS README )
+
+# Will be in next release
+PATCHES=( "${FILESDIR}/${P}-support-version-1.5.patch" )
+
+src_compile() {
+	meson_src_compile
+	use emacs && elisp-compile misc/desktop-entry-mode.el
+}
+
+src_install() {
+	meson_src_install
+	if use emacs; then
+		elisp-install ${PN} misc/*.el misc/*.elc || die
+		elisp-site-file-install "${FILESDIR}"/${SITEFILE} || die
+	fi
+}
+
+pkg_postinst() {
+	use emacs && elisp-site-regen
+}
+
+pkg_postrm() {
+	use emacs && elisp-site-regen
+}

--- a/dev-util/desktop-file-utils/files/desktop-file-utils-0.26-support-version-1.5.patch
+++ b/dev-util/desktop-file-utils/files/desktop-file-utils-0.26-support-version-1.5.patch
@@ -1,0 +1,88 @@
+# Adds support for Desktop Entry Specification 1.5. Gentoo bug 795570.
+# Upstream commit URLs:
+#   https://gitlab.freedesktop.org/xdg/desktop-file-utils/-/commit/425177a28b6215e0745f95100160a08e810fd47c
+#   https://gitlab.freedesktop.org/xdg/desktop-file-utils/-/commit/56d220dd679c7c3a8f995a41a27a7d6f3df49dea
+
+From 425177a28b6215e0745f95100160a08e810fd47c Mon Sep 17 00:00:00 2001
+From: David King <amigadave@amigadave.com>
+Date: Tue, 15 Feb 2022 10:54:40 +0000
+Subject: [PATCH 1/2] validate: support SingleMainWindow key from 1.5
+
+Fixes https://gitlab.freedesktop.org/xdg/desktop-file-utils/-/issues/59
+---
+ src/validate.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/src/validate.c b/src/validate.c
+index 62406ab..ebb03b5 100644
+--- a/src/validate.c
++++ b/src/validate.c
+@@ -326,6 +326,9 @@ static DesktopKeyDefinition registered_desktop_keys[] = {
+   /* Since 1.4 */
+   { DESKTOP_BOOLEAN_TYPE,           "PrefersNonDefaultGPU", FALSE, FALSE, FALSE, NULL },
+ 
++  /* Since 1.5 */
++  { DESKTOP_BOOLEAN_TYPE,           "SingleMainWindow", FALSE, FALSE, FALSE, NULL },
++
+   /* Keys reserved for KDE */
+ 
+   /* since 0.9.4 */
+-- 
+GitLab
+
+
+From 56d220dd679c7c3a8f995a41a27a7d6f3df49dea Mon Sep 17 00:00:00 2001
+From: David King <amigadave@amigadave.com>
+Date: Tue, 15 Feb 2022 10:56:04 +0000
+Subject: [PATCH 2/2] validate: Support version 1.5
+
+Bump CURRENT_SPEC_VERSION to 1.5.
+---
+ man/desktop-file-validate.1 | 2 +-
+ src/validate.c              | 3 +++
+ src/validate.h              | 2 +-
+ 3 files changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/man/desktop-file-validate.1 b/man/desktop-file-validate.1
+index 8e17411..ce87c47 100644
+--- a/man/desktop-file-validate.1
++++ b/man/desktop-file-validate.1
+@@ -9,7 +9,7 @@ desktop-file-validate \- Validate desktop entry files
+ .B desktop-file-validate [\-\-no-hints] [\-\-no-warn-deprecated] [\-\-warn-kde] FILE...
+ .SH DESCRIPTION
+ The \fIdesktop-file-validate\fP program is a tool to validate desktop
+-entry files according to the Desktop Entry specification 1.4.
++entry files according to the Desktop Entry specification 1.5.
+ .PP
+ The specification describes a file format to provide information such as
+ name, icon and description for an application. Such a file can then be
+diff --git a/src/validate.c b/src/validate.c
+index ebb03b5..f9eedee 100644
+--- a/src/validate.c
++++ b/src/validate.c
+@@ -961,6 +961,9 @@ handle_version_key (kf_validator *kf,
+                     const char   *locale_key,
+                     const char   *value)
+ {
++  if (!strcmp (value, "1.5"))
++    return TRUE;
++
+   if (!strcmp (value, "1.4"))
+     return TRUE;
+ 
+diff --git a/src/validate.h b/src/validate.h
+index e6efd93..a7952cd 100644
+--- a/src/validate.h
++++ b/src/validate.h
+@@ -30,7 +30,7 @@
+ 
+ #include <glib.h>
+ 
+-#define CURRENT_SPEC_VERSION "1.4"
++#define CURRENT_SPEC_VERSION "1.5"
+ 
+ #define GROUP_KDE_DESKTOP_ENTRY "KDE Desktop Entry"
+ #define GROUP_DESKTOP_ACTION "Desktop Action "
+-- 
+GitLab
+


### PR DESCRIPTION
Add patch from upstream to enable support for version 1.5 of the Desktop
Entry Specification. Also bump EAPI and fix HOMEPAGE.

Upstream patch:
https://gitlab.freedesktop.org/xdg/desktop-file-utils/-/merge_requests/11 (copied
without modification).

Closes: https://bugs.gentoo.org/795570
Signed-off-by: Ronny (tastytea) Gutbrod <gentoo@tastytea.de>