### PR TITLE
sci-libs/rocBLAS-4.3.0-r1: re-enable Tensile library

### DIFF
--- a/sci-libs/rocBLAS/files/rocBLAS-4.3.0-unbundle-Tensile.patch
+++ b/sci-libs/rocBLAS/files/rocBLAS-4.3.0-unbundle-Tensile.patch
@@ -20,25 +20,3 @@ index 4c29c94..f9838c2 100644
      )
      if(rc)
          message(FATAL_ERROR ${rc})
-diff --git a/library/src/CMakeLists.txt b/library/src/CMakeLists.txt
-index a34ee87..bf94988 100755
---- a/library/src/CMakeLists.txt
-+++ b/library/src/CMakeLists.txt
-@@ -99,9 +99,6 @@ if( BUILD_WITH_TENSILE )
-     # Create a unique name for TensileHost compiled for rocBLAS
-     set_target_properties( TensileHost PROPERTIES OUTPUT_NAME rocblas-tensile CXX_EXTENSIONS NO )
-     target_compile_definitions( TensileHost PUBLIC USE_TENSILE_HOST )
--
--    # Tensile host depends on libs build target
--    add_dependencies( TensileHost TENSILE_LIBRARY_TARGET )
-   else()
-     # Create a unique name for Tensile compiled for rocBLAS
-     set_target_properties( Tensile PROPERTIES OUTPUT_NAME rocblas-tensile CXX_EXTENSIONS NO )
-@@ -520,7 +517,6 @@ rocm_install_targets(
- if( BUILD_WITH_TENSILE )
-   if( BUILD_WITH_TENSILE_HOST )
-     set( ROCBLAS_TENSILE_LIBRARY_DIR "\${CPACK_PACKAGING_INSTALL_PREFIX}rocblas/lib" CACHE PATH "path to tensile library" )
--    install(DIRECTORY ${CMAKE_BINARY_DIR}/Tensile/library DESTINATION ${ROCBLAS_TENSILE_LIBRARY_DIR})
-   endif()
- endif()
- 

--- a/sci-libs/rocBLAS/rocBLAS-4.3.0-r1.ebuild
+++ b/sci-libs/rocBLAS/rocBLAS-4.3.0-r1.ebuild
@@ -76,7 +76,6 @@ src_configure() {
 	addpredict /dev/random
 
 	export PATH="${EPREFIX}/usr/lib/llvm/roc/bin:${PATH}"
-	export TENSILE_SKIP_LIBRARY=1
 
 	local mycmakeargs=(
 		-DTensile_LOGIC="asm_full"
@@ -130,7 +129,7 @@ src_test() {
 	addwrite /dev/kfd
 	addwrite /dev/dri/
 	cd "${BUILD_DIR}/clients/staging" || die
-	./rocblas-test || die "Tests failed"
+	LD_LIBRARY_PATH="${BUILD_DIR}/clients:${BUILD_DIR}/library/src" ROCBLAS_TENSILE_LIBPATH="${BUILD_DIR}/Tensile/library" ./rocblas-test || die "Tests failed"
 }
 
 src_install() {


### PR DESCRIPTION
890148bb81f517304f86f41303534b0abaa7c77c disables compiling Tensile
library (maybe due to dev-util/Tensile not properly configured). After
correcting paths in Tensile, compiling libraries ican be re-enabled.

Also fix test fail due to library not found

Package-Manager: Portage-3.0.30, Repoman-3.0.3
Signed-off-by: Yiyang Wu <xgreenlandforwyy@gmail.com>