### PR TITLE
app-text/zathura-pdf-mupdf: fix sed call

### DIFF
--- a/app-text/zathura-pdf-mupdf/files/zathura-pdf-mupdf-0.3.8-meson-mupdfthird.patch
+++ b/app-text/zathura-pdf-mupdf/files/zathura-pdf-mupdf-0.3.8-meson-mupdfthird.patch
@@ -1,0 +1,23 @@
+--- a/meson.build
++++ b/meson.build
+@@ -20,7 +20,6 @@ girara = dependency('girara-gtk3')
+ glib = dependency('glib-2.0')
+ cairo = dependency('cairo')
+ mupdf = dependency('mupdf', required: false)
+-mupdfthird = cc.find_library('mupdf-third')
+ 
+ build_dependencies = [
+   zathura,
+@@ -32,10 +31,10 @@ build_dependencies = [
+ if not mupdf.found()
+   # normal build of mupdf
+   mupdf = cc.find_library('mupdf')
+-  build_dependencies += [mupdf, mupdfthird]
++  build_dependencies += [mupdf]
+ else
+   # build from Debian's libmupdf-dev
+-  build_dependencies += [mupdf, mupdfthird]
++  build_dependencies += [mupdf]
+ 
+   libjpeg = dependency('libjpeg')
+   libjbig2dec = cc.find_library('jbig2dec')

--- a/app-text/zathura-pdf-mupdf/zathura-pdf-mupdf-0.3.8-r1.ebuild
+++ b/app-text/zathura-pdf-mupdf/zathura-pdf-mupdf-0.3.8-r1.ebuild
@@ -33,8 +33,6 @@ BDEPEND="app-text/tesseract
 	media-libs/leptonica
 	virtual/pkgconfig"
 
-src_prepare() {
-	sed -i -e '/mupdfthird/d' meson.build || die "Failed removing mupdfthird from meson.build"
-
-	default
-}
+PATCHES=(
+	"${FILESDIR}/zathura-pdf-mupdf-0.3.8-meson-mupdfthird.patch"
+)

--- a/app-text/zathura-pdf-mupdf/zathura-pdf-mupdf-9999.ebuild
+++ b/app-text/zathura-pdf-mupdf/zathura-pdf-mupdf-9999.ebuild
@@ -33,8 +33,6 @@ BDEPEND="app-text/tesseract
 	media-libs/leptonica
 	dev-lang/mujs"
 
-src_prepare() {
-	sed -i -e '/mupdfthird/d' meson.build || die "Failed removing mupdfthird from meson.build"
-
-	default
-}
+PATCHES=(
+	"${FILESDIR}/zathura-pdf-mupdf-0.3.8-meson-mupdfthird.patch"
+)


### PR DESCRIPTION
Fix sed call removing all lines mentioning mupdfthid in src_prepare()

Closes: https://bugs.gentoo.org/835592
Package-Manager: Portage-3.0.30, Repoman-3.0.3
Signed-off-by: Philipp Rösner <rndxelement@protonmail.com>