### PR TITLE
net-misc/rabbitmq-server: remove net dep from init

### DIFF
--- a/net-misc/rabbitmq-server/files/rabbitmq-server.init-r4
+++ b/net-misc/rabbitmq-server/files/rabbitmq-server.init-r4
@@ -3,7 +3,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 depend() {
-	need net epmd
+	need epmd
 	use dns
 }
 


### PR DESCRIPTION
rabbitmq does not have a hard requirement on the net service
therefore remove the dependency which causes the service to
fail to start if net has not been started or is running in an env
where there is not explicit net service (e.g. in a container).
Closes: https://bugs.gentoo.org/787815
Signed-off-by: Tom Gillespie <tgbugs@gmail.com>