### PR TITLE
sys-auth/fprintd: keyword 1.94.1 for ~riscv

### DIFF
--- a/sys-auth/fprintd/fprintd-1.94.1.ebuild
+++ b/sys-auth/fprintd/fprintd-1.94.1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://gitlab.freedesktop.org/libfprint/${PN}/-/archive/v${PV}/${MY_P}
 
 LICENSE="GPL-2+"
 SLOT="0"
-KEYWORDS="~amd64 ~arm ~ia64 ~ppc ~sparc ~x86"
+KEYWORDS="~amd64 ~arm ~ia64 ~ppc ~riscv ~sparc ~x86"
 IUSE="doc pam systemd test"
 RESTRICT="!test? ( test )"
 


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/825290
Signed-off-by: Yu Gu <guyu2876@gmail.com>