### PR TITLE
app-admin/keepassxc: add missing dependencies

### DIFF
--- a/app-admin/keepassxc/keepassxc-2.7.0-r2.ebuild
+++ b/app-admin/keepassxc/keepassxc-2.7.0-r2.ebuild
@@ -31,7 +31,7 @@ RESTRICT="!test? ( test )"
 
 RDEPEND="
 	app-crypt/argon2:=
-	dev-libs/botan:2
+	dev-libs/botan:2=
 	dev-qt/qtconcurrent:5
 	dev-qt/qtcore:5
 	dev-qt/qtdbus:5

--- a/app-admin/keepassxc/keepassxc-2.7.0-r2.ebuild
+++ b/app-admin/keepassxc/keepassxc-2.7.0-r2.ebuild
@@ -25,7 +25,7 @@ fi
 
 LICENSE="LGPL-2.1 GPL-2 GPL-3"
 SLOT="0"
-IUSE="autotype browser ccache doc keeshare +network test yubikey"
+IUSE="autotype browser doc keeshare +network test yubikey"
 
 RESTRICT="!test? ( test )"
 
@@ -60,7 +60,6 @@ DEPEND="
 	dev-qt/qttest:5
 "
 BDEPEND="
-	ccache? ( dev-util/ccache )
 	doc? ( dev-ruby/asciidoctor )
 "
 
@@ -77,7 +76,9 @@ src_configure() {
 	filter-flags -flto*
 
 	local mycmakeargs=(
-		-DWITH_CCACHE="$(usex ccache)"
+		# Gentoo users enable ccache via e.g. FEATURES=ccache or
+		# other means. We don't want the build system to enable it for us.
+		-DWITH_CCACHE=OFF
 		-DWITH_GUI_TESTS=OFF
 		-DWITH_TESTS="$(usex test)"
 		-DWITH_XC_AUTOTYPE="$(usex autotype)"

--- a/app-admin/keepassxc/keepassxc-9999.ebuild
+++ b/app-admin/keepassxc/keepassxc-9999.ebuild
@@ -31,7 +31,7 @@ RESTRICT="!test? ( test )"
 
 RDEPEND="
 	app-crypt/argon2:=
-	dev-libs/botan:2
+	dev-libs/botan:2=
 	dev-qt/qtconcurrent:5
 	dev-qt/qtcore:5
 	dev-qt/qtdbus:5

--- a/app-admin/keepassxc/keepassxc-9999.ebuild
+++ b/app-admin/keepassxc/keepassxc-9999.ebuild
@@ -25,7 +25,7 @@ fi
 
 LICENSE="LGPL-2.1 GPL-2 GPL-3"
 SLOT="0"
-IUSE="autotype browser ccache doc keeshare +network test yubikey"
+IUSE="autotype browser doc keeshare +network test yubikey"
 
 RESTRICT="!test? ( test )"
 
@@ -60,7 +60,6 @@ DEPEND="
 	dev-qt/qttest:5
 "
 BDEPEND="
-	ccache? ( dev-util/ccache )
 	doc? ( dev-ruby/asciidoctor )
 "
 
@@ -77,7 +76,9 @@ src_configure() {
 	filter-flags -flto*
 
 	local mycmakeargs=(
-		-DWITH_CCACHE="$(usex ccache)"
+		# Gentoo users enable ccache via e.g. FEATURES=ccache or
+		# other means. We don't want the build system to enable it for us.
+		-DWITH_CCACHE=OFF
 		-DWITH_GUI_TESTS=OFF
 		-DWITH_TESTS="$(usex test)"
 		-DWITH_XC_AUTOTYPE="$(usex autotype)"


### PR DESCRIPTION
- Botan exposes a subslot for its ABI so a subslot (:=) dep should be used
- Add missing argon2 dependency
- autotype: add missing libXi dependency

(Note that for autotype, it seems to always end up being built
(and finding dependencies?) even if the option is off?)

Signed-off-by: Sam James <sam@gentoo.org>