### PR TITLE
games-engines/devilutionx: fix automagic ccache usage

### DIFF
--- a/games-engines/devilutionx/devilutionx-1.2.1-r1.ebuild
+++ b/games-engines/devilutionx/devilutionx-1.2.1-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -41,6 +41,7 @@ BDEPEND="
 
 PATCHES=(
 	"${FILESDIR}/${PN}-1.2.0_pre-no_bundled_font.patch" #704508
+	"${FILESDIR}/${PN}-1.2.1-disable-ccache.patch" #813768
 )
 
 DOCS=( docs/CHANGELOG.md )

--- a/games-engines/devilutionx/devilutionx-9999.ebuild
+++ b/games-engines/devilutionx/devilutionx-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -41,6 +41,7 @@ BDEPEND="
 
 PATCHES=(
 	"${FILESDIR}/${PN}-1.2.0_pre-no_bundled_font.patch" #704508
+	"${FILESDIR}/${PN}-1.2.1-disable-ccache.patch" #813768
 )
 
 DOCS=( docs/CHANGELOG.md )

--- a/games-engines/devilutionx/files/devilutionx-1.2.1-disable-ccache.patch
+++ b/games-engines/devilutionx/files/devilutionx-1.2.1-disable-ccache.patch
@@ -1,0 +1,17 @@
+We let users enable ccache by themselves. Avoids sandbox violation.
+
+https://bugs.gentoo.org/813768
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -54,11 +54,6 @@ if(NOT VERSION_NUM)
+   endif()
+ endif()
+ 
+-find_program(CCACHE_PROGRAM ccache)
+-if(CCACHE_PROGRAM)
+-  set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CCACHE_PROGRAM}")
+-endif()
+-
+ if(VERSION_NUM MATCHES untagged)
+   project(DevilutionX
+     LANGUAGES C CXX)


### PR DESCRIPTION
We let users enable this by themselves via e.g. FEATURES=ccache.

Closes: https://bugs.gentoo.org/813768
Signed-off-by: Sam James <sam@gentoo.org>