### PR TITLE
sys-process/cronie: fix cronie pidfile path

### DIFF
--- a/sys-process/cronie/cronie-1.6.0-r1.ebuild
+++ b/sys-process/cronie/cronie-1.6.0-r1.ebuild
@@ -42,6 +42,10 @@ src_prepare() {
 
 src_configure() {
 	local myeconfargs=(
+		# This path gets embedded into cronie and is used for pidfile
+		# bug #835814
+		--runstatedir="${EPREFIX}"/run
+
 		$(use_with inotify)
 		$(use_with pam)
 		$(use_with selinux)


### PR DESCRIPTION
cronie's build system is using runstatedir to determine
where to place the PID file. On one of my systems,
this path _happens_ to exist because of thermald,
but it won't usually exist.

We should set runstatedir to be "${EPREFIX}"/run
to store the PID file in the place the init script expects
(cronie hardcodes the value of runstatedir into the binary
to find where its pidfile is).

Closes: https://bugs.gentoo.org/835814
Bug: https://bugs.gentoo.org/685306
Signed-off-by: Sam James <sam@gentoo.org>