### PR TITLE
vala.eclass : fix EAPI 8 support (src_prepare to call vala_setup)

### DIFF
--- a/eclass/vala.eclass
+++ b/eclass/vala.eclass
@@ -180,7 +180,7 @@ vala_setup() {
 # @FUNCTION: vala_src_prepare
 # @DESCRIPTION:
 # For backwards compatibility in EAPIs 6 and 7.  Calls vala_setup.
-if [[ ${EAPI} == [67] ]]; then
+if [[ ${EAPI} == [678] ]]; then
 	vala_src_prepare() { vala_setup "$@"; }
 fi
 


### PR DESCRIPTION
fixes building evolution-data-server-3.44.0