### PR TITLE
x11-plugins/gkwebmon: update EAPI 6 -> 8

### DIFF
--- a/x11-plugins/gkwebmon/gkwebmon-0.2-r3.ebuild
+++ b/x11-plugins/gkwebmon/gkwebmon-0.2-r3.ebuild
@@ -1,0 +1,32 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit gkrellm-plugin toolchain-funcs
+
+DESCRIPTION="A web monitor plugin for GKrellM2"
+HOMEPAGE="http://gkwebmon.sourceforge.net/"
+SRC_URI="mirror://sourceforge/${PN}/${P}.tgz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~ppc ~sparc ~x86"
+
+# The Makefile links with -lssl.
+RDEPEND="
+	app-admin/gkrellm:2[X]
+	dev-libs/openssl"
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-cc-cflags-ldflags.patch
+	"${FILESDIR}"/${P}-fno-common.patch
+)
+
+src_compile() {
+	tc-export PKG_CONFIG
+
+	emake CC="$(tc-getCC)"
+}


### PR DESCRIPTION
Changes:

 * { -> B}DEPEND="virtual/pkgconfig". The dependency is also provided by the eclass, but asking on #gentoo-dev it was recommended to keep it, because the ebuild explicitly does tc-export PKG_CONFIG.  

Signed-off-by: Thomas Bracht Laumann Jespersen <t@laumann.xyz>