### PR TITLE
x11-plugins/gkrellm-leds: update EAPI 6 -> 8

### DIFF
--- a/x11-plugins/gkrellm-leds/files/gkrellm-leds-0.8.2-r2-ldflags-typo.patch
+++ b/x11-plugins/gkrellm-leds/files/gkrellm-leds-0.8.2-r2-ldflags-typo.patch
@@ -1,0 +1,12 @@
+src/Makefile.am: fix type GK_FLAGS -> GKM_FLAGS
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -10,7 +10,7 @@ gkleds_la_CFLAGS = -Wall -O2 -I../pixmaps @X_CFLAGS@ @GTK_CFLAGS@ @GKM_CFLAGS@
+ gkleds_la_LIBADD = @X_PRE_LIBS@ @X_LIBS@ @X_EXTRA_LIBS@ @GTK_LIBS@ @GKM_EXTRA_SRCS@
+ 
+ ## linker flags, we are building a plugin so skip lib prefix and lib versions
+-gkleds_la_LDFLAGS = -module -avoid-version @GK_LDFLAGS@
++gkleds_la_LDFLAGS = -module -avoid-version @GKM_LDFLAGS@
+ 
+ ## gkleds.la sources
+ gkleds_la_SOURCES = gkleds.c gkleds.h

--- a/x11-plugins/gkrellm-leds/gkrellm-leds-0.8.2-r2.ebuild
+++ b/x11-plugins/gkrellm-leds/gkrellm-leds-0.8.2-r2.ebuild
@@ -1,0 +1,36 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit gkrellm-plugin autotools
+
+MY_P="${P/rellm-/}"
+
+DESCRIPTION="GKrellM2 plugin for monitoring keyboard LEDs"
+HOMEPAGE="http://heim.ifi.uio.no/~oyvinha/gkleds/"
+SRC_URI="http://heim.ifi.uio.no/~oyvinha/e107_files/downloads/${MY_P}.tar.gz"
+S="${WORKDIR}/${MY_P}"
+
+LICENSE="GPL-2"
+SLOT="2"
+KEYWORDS="~alpha ~amd64 ~ppc ~sparc ~x86"
+
+RDEPEND="
+	app-admin/gkrellm:2[X]
+	x11-libs/libXtst"
+DEPEND="${RDEPEND}
+	x11-base/xorg-proto"
+BDEPEND="virtual/pkgconfig"
+
+PATCHES=( "${FILESDIR}/${P}-r2-ldflags-typo.patch" )
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_configure() {
+	PLUGIN_SO=( src/.libs/gkleds$(get_modname) )
+	default
+}


### PR DESCRIPTION
Besides the EAPI bump, there's a bug for the referenced bug. The issue
seems to be simply a typo in src/Makefile.am resulting in a variable
@GK_LDFLAGS@ not being replaced appropriately.

Closes: https://bugs.gentoo.org/799176
Signed-off-by: Thomas Bracht Laumann Jespersen <t@laumann.xyz>

---
TODO
 - [x] `ebuild install` -r1 and -r2 and compare the image folders