### PR TITLE
sys-libs/liburing: pass --cxx parameter to configure

### DIFF
--- a/sys-libs/liburing/liburing-2.1-r1.ebuild
+++ b/sys-libs/liburing/liburing-2.1-r1.ebuild
@@ -45,6 +45,7 @@ multilib_src_configure() {
 		--libdevdir="${EPREFIX}/usr/$(get_libdir)"
 		--mandir="${EPREFIX}/usr/share/man"
 		--cc="$(tc-getCC)"
+		--cxx="$(tc-getCXX)"
 	)
 	# No autotools configure! "econf" will fail.
 	TMPDIR="${T}" ./configure "${myconf[@]}"

--- a/sys-libs/liburing/liburing-2.1-r2.ebuild
+++ b/sys-libs/liburing/liburing-2.1-r2.ebuild
@@ -51,6 +51,7 @@ multilib_src_configure() {
 		--libdevdir="${EPREFIX}/usr/$(get_libdir)"
 		--mandir="${EPREFIX}/usr/share/man"
 		--cc="$(tc-getCC)"
+		--cxx="$(tc-getCXX)"
 	)
 	# No autotools configure! "econf" will fail.
 	TMPDIR="${T}" ./configure "${myconf[@]}"

--- a/sys-libs/liburing/liburing-9999.ebuild
+++ b/sys-libs/liburing/liburing-9999.ebuild
@@ -40,6 +40,7 @@ multilib_src_configure() {
 		--libdevdir="${EPREFIX}/usr/$(get_libdir)"
 		--mandir="${EPREFIX}/usr/share/man"
 		--cc="$(tc-getCC)"
+		--cxx="$(tc-getCXX)"
 	)
 	# No autotools configure! "econf" will fail.
 	TMPDIR="${T}" ./configure "${myconf[@]}"


### PR DESCRIPTION
This is necessary to fix cross-compilation of liburing, as cxx (default g++) is used for linking applications that are built.

Bug: https://bugs.gentoo.org/836316