### PR TITLE
gkrellm-plugin.eclass users: Bump to EAPI 8

### DIFF
--- a/x11-plugins/gkrellkam/files/gkrellkam-2.0.0-r1-pkgconfig.patch
+++ b/x11-plugins/gkrellkam/files/gkrellkam-2.0.0-r1-pkgconfig.patch
@@ -1,0 +1,13 @@
+--- a/Makefile
++++ b/Makefile
+@@ -12,8 +12,9 @@ DESTDIR =
+ # This should point to the GKrellM headers
+ GKRELLM_HDRS = /usr/include
+ 
++PKG_CONFIG ?= pkg-config
+ CC = $(CC)
+-GTKFLAGS := $(shell pkg-config gtk+-2.0 --cflags)
++GTKFLAGS := $(shell ${PKG_CONFIG} gtk+-2.0 --cflags)
+ CFLAGS := $(CFLAGS) -fPIC $(GTKFLAGS) -I$(GKRELLM_HDRS)
+ LFLAGS = -shared
+ INST_DIR := $(DESTDIR)/usr/lib/gkrellm2/plugins

--- a/x11-plugins/gkrellkam/gkrellkam-2.0.0-r1.ebuild
+++ b/x11-plugins/gkrellkam/gkrellkam-2.0.0-r1.ebuild
@@ -1,0 +1,40 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit gkrellm-plugin toolchain-funcs
+
+MY_P=${P/-/_}
+
+DESCRIPTION="an Image-Watcher-Plugin for GKrellM2"
+HOMEPAGE="http://gkrellkam.sourceforge.net"
+SRC_URI="mirror://sourceforge/gkrellkam/${MY_P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~ppc ~sparc ~x86"
+
+RDEPEND="
+	app-admin/gkrellm:2[X]
+	net-misc/wget"
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-makefile.patch
+	"${FILESDIR}"/${P}-r1-pkgconfig.patch
+)
+
+src_compile() {
+	tc-export PKG_CONFIG
+	emake CC="$(tc-getCC)" LDFLAGS="${LDFLAGS}"
+}
+
+src_install() {
+	local PLUGIN_SO=( ${PN}2$(get_modname) )
+	local PLUGIN_DOCS=( example.list )
+
+	gkrellm-plugin_src_install
+	doman gkrellkam-list.5
+}

--- a/x11-plugins/gkrellm-bgchanger/gkrellm-bgchanger-0.1.11-r3.ebuild
+++ b/x11-plugins/gkrellm-bgchanger/gkrellm-bgchanger-0.1.11-r3.ebuild
@@ -1,0 +1,32 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit gkrellm-plugin toolchain-funcs
+
+MY_PN="gkrellmbgchg2"
+MY_P="${MY_PN}-${PV}"
+
+DESCRIPTION="Plugin for GKrellM2 to change your desktop background"
+HOMEPAGE="http://www.bender-suhl.de/stefan/english/comp/gkrellmbgchg.html"
+SRC_URI="http://www.bender-suhl.de/stefan/comp/sources/${MY_P}.tar.gz"
+S="${WORKDIR}/${MY_P}"
+
+LICENSE="GPL-2"
+SLOT="2"
+KEYWORDS="~alpha ~amd64 ~ppc ~sparc ~x86"
+
+RDEPEND="app-admin/gkrellm:2[X]"
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+PATCHES=( "${FILESDIR}"/${PN}-0.1.11-fix-build-system.patch )
+
+PLUGIN_DOCS=( bgchg_info.sh kdewallpaper.sh )
+
+src_configure() {
+	tc-export CC PKG_CONFIG
+
+	PLUGIN_SO=( gkrellmbgchg$(get_modname) )
+}

--- a/x11-plugins/gkrellm-countdown/files/gkrellm-countdown-0.1.2-r2-pkgconfig.patch
+++ b/x11-plugins/gkrellm-countdown/files/gkrellm-countdown-0.1.2-r2-pkgconfig.patch
@@ -1,0 +1,16 @@
+Have Makefile respect user chosen PKG_CONFIG
+--- a/Makefile
++++ b/Makefile
+@@ -3,8 +3,10 @@
+ # You may want to rename the binary-file.
+ BIN_FILENAME = gkrellm-countdown
+ 
+-GTK_INCLUDE ?= `pkg-config gtk+-2.0 --cflags`
+-GTK_LIB ?= `pkg-config gtk+-2.0 --libs`
++PKG_CONFIG ?= pkg-config
++
++GTK_INCLUDE ?= $(shell ${PKG_CONFIG} gtk+-2.0 --cflags)
++GTK_LIB ?= $(shell ${PKG_CONFIG} gtk+-2.0 --libs)
+ IMLIB_INCLUDE ?= 
+ IMLIB_LIB ?= 
+ PLUGIN_DIR ?= /usr/local/lib/gkrellm2/plugins

--- a/x11-plugins/gkrellm-countdown/gkrellm-countdown-0.1.2-r2.ebuild
+++ b/x11-plugins/gkrellm-countdown/gkrellm-countdown-0.1.2-r2.ebuild
@@ -1,0 +1,29 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit gkrellm-plugin toolchain-funcs
+
+DESCRIPTION="A simple countdown clock for GKrellM2"
+HOMEPAGE="http://freshmeat.sourceforge.net/projects/gkrellm-countdown"
+SRC_URI="http://oss.pugsplace.net/${P}.tar.gz"
+S="${WORKDIR}/${PN}"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~sparc ~x86"
+
+RDEPEND="app-admin/gkrellm:2[X]"
+DEPEND="${RDEPEND}"
+BDPEND="virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-makefile.patch
+	"${FILESDIR}"/${P}-r2-pkgconfig.patch
+)
+
+src_compile() {
+	tc-export PKG_CONFIG
+	emake CC="$(tc-getCC)" LDFLAGS="${LDFLAGS}"
+}

--- a/x11-plugins/gkrellm-cpupower/files/gkrellm-cpupower-0.2-makefile.patch
+++ b/x11-plugins/gkrellm-cpupower/files/gkrellm-cpupower-0.2-makefile.patch
@@ -1,0 +1,45 @@
+--- a/Makefile
++++ b/Makefile
+@@ -1,22 +1,29 @@
+ # Makefile for gkrellm cpupower plugin
+ 
+-GTK_INCLUDE = `pkg-config gtk+-2.0 --cflags`
+-GTK_LIB = `pkg-config gtk+-2.0 --libs`
++PKG_CONFIG ?= pkg-config
+ 
+-FLAGS = -O2 -Wall -fPIC $(GTK_INCLUDE)
++GTK_INCLUDE = $(shell ${PKG_CONFIG} gtk+-2.0 --cflags)
++GTK_LIB = $(shell ${PKG_CONFIG} gtk+-2.0 --libs)
++
++FLAGS = -fPIC $(GTK_INCLUDE)
+ LIBS = $(GTK_LIB)
+ 
+ LFLAGS = -shared -lcpupower
+ 
+-CC = gcc $(CFLAGS) $(FLAGS)
++CC = $(CC)
+ 
+ OBJS = cpupower.o
+ 
++all: cpupower.so
++
++%.o: %.c
++	$(CC) $(CFLAGS) $(FLAGS) -c -o $@ $<
++
+ cpupower.so: $(OBJS)
+-	$(CC) $(OBJS) -o cpupower.so $(LFLAGS) $(LIBS)
++	$(CC) $(CFLAGS) $(LDFLAGS) $(FLAGS) $(OBJS) -o cpupower.so $(LFLAGS) $(LIBS)
+ 
+ install: cpupower.so
+-	install -D -m 755 -s cpupower.so $(DESTDIR)/usr/lib/gkrellm2/plugins/cpupower.so
++	install -D -m 755 cpupower.so $(DESTDIR)/usr/lib/gkrellm2/plugins/cpupower.so
+ 
+ install-sudo:
+ 	mkdir -p $(DESTDIR)/etc/sudoers.d
+@@ -25,6 +32,3 @@ install-sudo:
+ 
+ clean:
+ 	rm -f *.o core *.so* *.bak *~
+-
+-cpupower.o: cpupower.c
+-

--- a/x11-plugins/gkrellm-cpupower/gkrellm-cpupower-0.2-r2.ebuild
+++ b/x11-plugins/gkrellm-cpupower/gkrellm-cpupower-0.2-r2.ebuild
@@ -1,0 +1,47 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit gkrellm-plugin toolchain-funcs
+
+MY_P="${P/gkrellm/gkrellm2}"
+
+DESCRIPTION="A Gkrellm2 plugin for displaying and manipulating CPU frequency"
+HOMEPAGE="https://github.com/sainsaar/gkrellm2-cpupower/"
+SRC_URI="https://github.com/sainsaar/gkrellm2-cpupower/archive/${PV}.tar.gz -> ${MY_P}.tar.gz"
+S="${WORKDIR}/${MY_P}"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+DEPEND="app-admin/gkrellm:2[X]"
+RDEPEND="
+	${DEPEND}
+	app-admin/sudo
+	sys-power/cpupower"
+BDEPEND="virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-makefile.patch
+)
+
+src_compile() {
+	tc-export PKG_CONFIG
+	emake CC="$(tc-getCC)" LDFLAGS="${LDFLAGS}"
+}
+
+src_install() {
+	local PLUGIN_SO=( cpupower$(get_modname) )
+	gkrellm-plugin_src_install
+	emake DESTDIR="${D}" install-sudo
+}
+
+pkg_postinst() {
+	einfo
+	einfo "For changing the governor and CPU frequencies as a user, create the \"trusted\""
+	einfo "group, and add those users to that group who should be allowed to perform"
+	einfo "these changes."
+	einfo
+}

--- a/x11-plugins/gkrellm-imonc/files/gkrellm-imonc-0.2-r2-pkgconfig.patch
+++ b/x11-plugins/gkrellm-imonc/files/gkrellm-imonc-0.2-r2-pkgconfig.patch
@@ -1,0 +1,15 @@
+Respect user's pkg-config
+--- a/Makefile
++++ b/Makefile
+@@ -6,8 +6,9 @@ DISTRIB_DIR= gkrellm-imonc-$(VERSION)
+ #
+ #
+ 
+-GTK_INCLUDE = $(shell pkg-config gtk+-2.0 --cflags)
+-GTK_LIB = $(shell pkg-config gtk+-2.0 --libs)
++PKG_CONFIG ?= pkg-config
++GTK_INCLUDE = $(shell ${PKG_CONFIG} gtk+-2.0 --cflags)
++GTK_LIB = $(shell ${PKG_CONFIG} gtk+-2.0 --libs)
+ 
+ FLAGS = -fPIC $(GTK_INCLUDE)
+ LIBS = $(GTK_LIB)

--- a/x11-plugins/gkrellm-imonc/gkrellm-imonc-0.2-r2.ebuild
+++ b/x11-plugins/gkrellm-imonc/gkrellm-imonc-0.2-r2.ebuild
@@ -1,0 +1,32 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit gkrellm-plugin toolchain-funcs
+
+DESCRIPTION="A GKrellM2 plugin to control a fli4l router"
+HOMEPAGE="http://gkrellm-imonc.sourceforge.net/"
+SRC_URI="mirror://sourceforge/${PN}/${PN}-src-${PV}.tar.bz2"
+S="${WORKDIR}/${PN}-src-${PV}"
+
+# The COPYING file contains the GPLv2, but the file headers say GPLv2+.
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+RDEPEND="app-admin/gkrellm:2[X]"
+DEPEND="
+	${RDEPEND}
+"
+BDEPEND="virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-makefile.patch
+	"${FILESDIR}"/${P}-r2-pkgconfig.patch
+)
+
+src_compile() {
+	tc-export PKG_CONFIG
+	emake CC="$(tc-getCC)" LDFLAGS="${LDFLAGS}"
+}

--- a/x11-plugins/gkrellm-mailwatch/files/gkrellm-mailwatch-2.4.3-pkgconfig.patch
+++ b/x11-plugins/gkrellm-mailwatch/files/gkrellm-mailwatch-2.4.3-pkgconfig.patch
@@ -1,0 +1,16 @@
+Have Makefile respect user-configured pkg-config
+--- a/Makefile
++++ b/Makefile
+@@ -1,10 +1,10 @@
+ # Makefile for the GKrellM mailwatch plugin
+ 
+-GTK_CONFIG ?=pkg-config gtk+-2.0
++PKG_CONFIG ?= pkg-config
+ PLUGIN_DIR ?=/usr/local/lib/gkrellm2/plugins
+ 
+-GTK_INCLUDE = `$(GTK_CONFIG) --cflags`
+-GTK_LIB = `$(GTK_CONFIG) --libs`
++GTK_INCLUDE = $(shell ${PKG_CONFIG} gtk+-2.0 --cflags)
++GTK_LIB = $(shell ${PKG_CONFIG} gtk+-2.0 --libs)
+ 
+ GKRELLM_INCLUDE= -I/usr/local/include

--- a/x11-plugins/gkrellm-mailwatch/gkrellm-mailwatch-2.4.3-r3.ebuild
+++ b/x11-plugins/gkrellm-mailwatch/gkrellm-mailwatch-2.4.3-r3.ebuild
@@ -1,0 +1,35 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit gkrellm-plugin toolchain-funcs
+
+DESCRIPTION="A GKrellM2 plugin that shows the status of additional mail boxes"
+HOMEPAGE="http://gkrellm.luon.net/mailwatch.php"
+SRC_URI="http://gkrellm.luon.net/files/${P}.tar.gz"
+S="${WORKDIR}/${PN}"
+
+LICENSE="GPL-2"
+SLOT="2"
+KEYWORDS="~alpha ~amd64 ~ppc ~sparc ~x86"
+
+RDEPEND="app-admin/gkrellm:2[X]"
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}"/2.4.3-0001-Respect-LDFLAGS.patch
+	"${FILESDIR}"/2.4.3-0002-Use-gkrellm_gkd_string_width.patch
+	"${FILESDIR}"/2.4.3-0003-Remove-a-few-more-GCC-warnings.patch
+	"${FILESDIR}"/2.4.3-0004-Do-not-force-O2-in-CFLAGS.patch
+	"${FILESDIR}/${P}"-pkgconfig.patch
+)
+
+src_configure() {
+	tc-export CC PKG_CONFIG
+
+	PLUGIN_SO=( mailwatch$(get_modname) )
+
+	default
+}

--- a/x11-plugins/gkrellm-radio/files/gkrellm-radio-2.0.4-r1-pkgconfig.patch
+++ b/x11-plugins/gkrellm-radio/files/gkrellm-radio-2.0.4-r1-pkgconfig.patch
@@ -1,0 +1,15 @@
+Respect user's pkg-config
+--- a/Makefile
++++ b/Makefile
+@@ -15,8 +15,9 @@ OBJS=gkrellm_radio.o radio.o
+ PLUGIN_DIR ?= /usr/local/lib/gkrellm2/plugins
+ INSTALL = install -c
+ INSTALL_PROGRAM = $(INSTALL) -s
+-GTK_CONFIG = pkg-config gtk+-2.0
+-CFLAGS := ${CFLAGS} -fPIC -I$(GKRELLMDIR)/include `$(GTK_CONFIG) --cflags`  -DVERSION=\"$(VERSION)\" -Wall
++PKG_CONFIG ?= pkg-config
++GTK_INCLUDE = $(shell ${PKG_CONFIG} gtk+-2.0 --cflags)
++CFLAGS := ${CFLAGS} -fPIC -I$(GKRELLMDIR)/include ${GTK_INCLUDE} -DVERSION=\"$(VERSION)\" -Wall
+ 
+ ifdef WITH_LIRC
+ CFLAGS := ${CFLAGS} -DHAVE_LIRC

--- a/x11-plugins/gkrellm-radio/gkrellm-radio-2.0.4-r1.ebuild
+++ b/x11-plugins/gkrellm-radio/gkrellm-radio-2.0.4-r1.ebuild
@@ -1,0 +1,36 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit gkrellm-plugin toolchain-funcs
+
+DESCRIPTION="A minimalistic GKrellM2 plugin to control radio tuners"
+HOMEPAGE="http://gkrellm.luon.net/gkrellm-radio.php"
+SRC_URI="http://gkrellm.luon.net/files/${P}.tar.gz"
+S="${WORKDIR}/${PN}"
+
+LICENSE="GPL-2"
+SLOT="2"
+KEYWORDS="~amd64 ~ppc ~sparc ~x86"
+IUSE="lirc"
+
+RDEPEND="
+	app-admin/gkrellm:2[X]
+	lirc? ( app-misc/lirc )"
+DEPEND="${RDEPEND}"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-makefile.patch
+	"${FILESDIR}"/${P}-r1-pkgconfig.patch
+)
+
+src_configure() {
+	PLUGIN_SO=( radio$(get_modname) )
+	default
+}
+
+src_compile() {
+	use lirc && myconf="${myconf} WITH_LIRC=1"
+	emake CC="$(tc-getCC)" LDFLAGS="${LDFLAGS}" ${myconf}
+}

--- a/x11-plugins/gkrellm-trayicons/files/gkrellm-trayicons-1.03-pkgconfig.patch
+++ b/x11-plugins/gkrellm-trayicons/files/gkrellm-trayicons-1.03-pkgconfig.patch
@@ -1,0 +1,18 @@
+Have Makefile respect user-configured pkg-config
+--- a/Makefile
++++ b/Makefile
+@@ -1,11 +1,11 @@
+ 
+ VERSION = `cat VERSION`
+ PREFIX ?= /usr/local
+-GTK_CONFIG = pkg-config gtk+-2.0
++PKG_CONFIG ?= pkg-config
+ PLUGIN_DIR ?= $(PREFIX)/lib/gkrellm2/plugins
+ GKRELLM_INCLUDE = -I$(PREFIX)/include
+-GTK_CFLAGS = `$(GTK_CONFIG) --cflags` 
+-GTK_LIB = `$(GTK_CONFIG) --libs`
++GTK_CFLAGS = $(shell ${PKG_CONFIG} gtk+-2.0 --cflags)
++GTK_LIB = $(shell ${PKG_CONFIG} gtk+-2.0 --libs)
+ FLAGS = -fPIC $(GTK_CFLAGS) $(GKRELLM_INCLUDE)
+ CFLAGS += $(FLAGS)
+ CFLAGS += -DVERSION=\"$(VERSION)\"

--- a/x11-plugins/gkrellm-trayicons/gkrellm-trayicons-1.03-r2.ebuild
+++ b/x11-plugins/gkrellm-trayicons/gkrellm-trayicons-1.03-r2.ebuild
@@ -1,0 +1,33 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit gkrellm-plugin toolchain-funcs
+
+DESCRIPTION="Configurable Tray Icons for GKrellM"
+HOMEPAGE="http://gkrellm.srcbox.net/Plugins.html"
+SRC_URI="mirror://gentoo/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~sparc ~x86"
+
+RDEPEND="app-admin/gkrellm:2[X]"
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-ldflags.patch
+	"${FILESDIR}"/${P}-pkgconfig.patch
+)
+
+src_configure() {
+	PLUGIN_SO=( trayicons$(get_modname) )
+	default
+}
+
+src_compile() {
+	tc-export PKG_CONFIG
+	emake CC="$(tc-getCC)" LDFLAGS="${LDFLAGS}"
+}

--- a/x11-plugins/gkrellm-vaiobright/gkrellm-vaiobright-2.5-r3.ebuild
+++ b/x11-plugins/gkrellm-vaiobright/gkrellm-vaiobright-2.5-r3.ebuild
@@ -1,0 +1,33 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit gkrellm-plugin toolchain-funcs
+
+MY_P=${P/gkrellm-/}
+
+DESCRIPTION="Superslim VAIO LCD Brightness Control Plugin for Gkrellm"
+SRC_URI="http://nerv-un.net/~dragorn/code/${MY_P}.tar.gz"
+HOMEPAGE="http://nerv-un.net/~dragorn/"
+S="${WORKDIR}"/${MY_P}
+
+LICENSE="GPL-2"
+SLOT="2"
+KEYWORDS="~amd64 ~x86"
+
+RDEPEND="app-admin/gkrellm:2[X]"
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-textrel.patch
+	"${FILESDIR}"/${P}-fixinfo.patch
+)
+
+src_configure() {
+	tc-export CC PKG_CONFIG
+
+	PLUGIN_SO=( vaiobright$(get_modname) )
+	default
+}

--- a/x11-plugins/gkrellm-volume/files/gkrellm-volume-2.1.13-r3-pkgconfig.patch
+++ b/x11-plugins/gkrellm-volume/files/gkrellm-volume-2.1.13-r3-pkgconfig.patch
@@ -1,0 +1,27 @@
+Respect user's pkg-config
+--- a/Makefile
++++ b/Makefile
+@@ -6,13 +6,13 @@ LOCALEDIR ?= /usr/local/share/locale
+ CFLAGS += -DPACKAGE="\"$(PACKAGE)\"" 
+ export PACKAGE LOCALEDIR
+ 
+-GTK_CONFIG = pkg-config gtk+-2.0
++PKG_CONFIG ?= pkg-config
+ 
+ PLUGIN_DIR ?= /usr/local/lib/gkrellm2/plugins
+ GKRELLM_INCLUDE = -I/usr/local/include
+ 
+-GTK_CFLAGS = `$(GTK_CONFIG) --cflags` 
+-GTK_LIB = `$(GTK_CONFIG) --libs`
++GTK_CFLAGS = $(shell ${PKG_CONFIG} gtk+-2.0 --cflags)
++GTK_LIB = $(shell ${PKG_CONFIG} gtk+-2.0 --libs)
+ 
+ CFLAGS := $(CFLAGS) -fPIC $(GTK_CFLAGS) $(GKRELLM_INCLUDE)
+ LIBS = $(GTK_LIB)
+@@ -51,4 +51,4 @@ install:
+ 	(cd po && ${MAKE} install)
+ 	$(INSTALL_PROGRAM) volume.so $(PLUGIN_DIR)
+ 
+-%.c.o: %.c
+\ No newline at end of file
++%.c.o: %.c

--- a/x11-plugins/gkrellm-volume/gkrellm-volume-2.1.13-r3.ebuild
+++ b/x11-plugins/gkrellm-volume/gkrellm-volume-2.1.13-r3.ebuild
@@ -1,0 +1,38 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+inherit gkrellm-plugin toolchain-funcs
+
+DESCRIPTION="A mixer control plugin for gkrellm"
+HOMEPAGE="http://gkrellm.luon.net/volume.php"
+SRC_URI="http://gkrellm.luon.net/files/${P}.tar.gz"
+S="${WORKDIR}/${PN}"
+
+LICENSE="GPL-2"
+SLOT="2"
+KEYWORDS="~alpha ~amd64 ~ppc ~sparc ~x86"
+IUSE="alsa"
+
+RDEPEND="
+	app-admin/gkrellm:2[X]
+	alsa? ( media-libs/alsa-lib )"
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}/${P}-reenable.patch"
+	"${FILESDIR}/${P}-makefile.patch"
+	"${FILESDIR}/${P}-r3-pkgconfig.patch"
+)
+
+src_configure() {
+	PLUGIN_SO=( volume$(get_modname) )
+	default
+}
+
+src_compile() {
+	tc-export PKG_CONFIG
+	use alsa && local myconf="enable_alsa=1"
+	emake CC="$(tc-getCC)" LDFLAGS="${LDFLAGS}" ${myconf}
+}

--- a/x11-plugins/gkrellm-xkb/files/gkrellm-xkb-1.05-r2-pkgconfig.patch
+++ b/x11-plugins/gkrellm-xkb/files/gkrellm-xkb-1.05-r2-pkgconfig.patch
@@ -1,0 +1,30 @@
+From f4cd320421d80075c280dc23115d00ecefb8501c Mon Sep 17 00:00:00 2001
+From: Thomas Bracht Laumann Jespersen <t@laumann.xyz>
+Date: Sat, 26 Mar 2022 16:08:49 +0100
+Subject: [PATCH] pkgconfig
+
+---
+ Makefile | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 13f2dd3..a63b4ab 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1,10 +1,10 @@
+ 
+ PREFIX ?= /usr/local
+-GTK_CONFIG = pkg-config gtk+-2.0
++PKG_CONFIG ?= pkg-config
+ PLUGIN_DIR ?= $(PREFIX)/lib/gkrellm2/plugins
+ GKRELLM_INCLUDE = -I$(PREFIX)/include
+-GTK_CFLAGS = `$(GTK_CONFIG) --cflags` 
+-GTK_LIB = `$(GTK_CONFIG) --libs`
++GTK_CFLAGS = $(shell ${PKG_CONFIG} gtk+-2.0 --cflags)
++GTK_LIB = $(shell ${PKG_CONFIG} gtk+-2.0 --libs)
+ FLAGS = -fPIC $(GTK_CFLAGS) $(GKRELLM_INCLUDE)
+ LIBS = $(GTK_LIB)
+ LFLAGS = -shared
+-- 
+2.34.1
+

--- a/x11-plugins/gkrellm-xkb/gkrellm-xkb-1.05-r2.ebuild
+++ b/x11-plugins/gkrellm-xkb/gkrellm-xkb-1.05-r2.ebuild
@@ -1,0 +1,33 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit gkrellm-plugin toolchain-funcs
+
+DESCRIPTION="XKB keyboard switcher for gkrellm2"
+HOMEPAGE="http://tripie.sweb.cz/gkrellm/xkb/"
+SRC_URI="http://tripie.sweb.cz/gkrellm/xkb/dist/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+RDEPEND="app-admin/gkrellm:2[X]"
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-makefile.patch
+	"${FILESDIR}"/${P}-r2-pkgconfig.patch
+)
+
+src_configure() {
+	PLUGIN_SO=( xkb$(get_modname) )
+	default
+}
+
+src_compile() {
+	tc-export PKG_CONFIG
+	emake CC="$(tc-getCC)" LDFLAGS="${LDFLAGS}"
+}

--- a/x11-plugins/gkrellmlaunch/files/gkrellmlaunch-0.5-r1-pkgconfig.patch
+++ b/x11-plugins/gkrellmlaunch/files/gkrellmlaunch-0.5-r1-pkgconfig.patch
@@ -1,0 +1,20 @@
+--- a/Makefile
++++ b/Makefile
+@@ -1,7 +1,8 @@
+ # Sample Makefile for a GKrellM plugin
+ 
+-GTK_INCLUDE = `pkg-config gtk+-2.0 --cflags`
+-GTK_LIB = `pkg-config gtk+-2.0 --libs`
++PKG_CONFIG ?= pkg-config
++GTK_INCLUDE = $(shell ${PKG_CONFIG} gtk+-2.0 --cflags)
++GTK_LIB = $(shell ${PKG_CONFIG} gtk+-2.0 --libs)
+ 
+ 
+ FLAGS = -fPIC $(GTK_INCLUDE)
+@@ -25,4 +26,4 @@ gkrellmlaunch.so: $(OBJS)
+ clean:
+ 	rm -f *.o core *.so* *.bak *~
+ 
+-gkrellmlaunch.o: gkrellmlaunch.c
+\ No newline at end of file
++gkrellmlaunch.o: gkrellmlaunch.c

--- a/x11-plugins/gkrellmlaunch/gkrellmlaunch-0.5-r1.ebuild
+++ b/x11-plugins/gkrellmlaunch/gkrellmlaunch-0.5-r1.ebuild
@@ -1,0 +1,28 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit gkrellm-plugin toolchain-funcs
+
+DESCRIPTION="A Program-Launcher Plugin for GKrellM2"
+SRC_URI="mirror://sourceforge/gkrellmlaunch/${P}.tar.gz"
+HOMEPAGE="http://gkrellmlaunch.sourceforge.net/"
+
+LICENSE="GPL-2"
+SLOT="2"
+KEYWORDS="~alpha ~amd64 ~ppc ~sparc ~x86"
+
+RDEPEND="app-admin/gkrellm:2[X]"
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-makefile.patch
+	"${FILESDIR}"/${P}-r1-pkgconfig.patch
+)
+
+src_compile() {
+	tc-export PKG_CONFIG
+	emake CC="$(tc-getCC)" LDFLAGS="${LDFLAGS}"
+}

--- a/x11-plugins/gkrellmoon/files/gkrellmoon-0.6-r3-include-stringh.patch
+++ b/x11-plugins/gkrellmoon/files/gkrellmoon-0.6-r3-include-stringh.patch
@@ -1,0 +1,14 @@
+Include string.h
+--- a/CalcEphem.h
++++ b/CalcEphem.h
+@@ -13,6 +13,7 @@
+ #include <glib.h>
+ 
+ #include <stdio.h>
++#include <string.h>
+ #include <math.h>
+ 
+ #define DegPerRad       57.29577951308232087680
+-- 
+2.34.1
+

--- a/x11-plugins/gkrellmoon/files/gkrellmoon-0.6-r3-pkgconfig.patch
+++ b/x11-plugins/gkrellmoon/files/gkrellmoon-0.6-r3-pkgconfig.patch
@@ -1,0 +1,12 @@
+Respect user's pkg-config
+--- a/Makefile
++++ b/Makefile
+@@ -1,5 +1,6 @@
+-GTK_INCLUDE = `pkg-config gtk+-2.0 --cflags`
+-GTK_LIB = `pkg-config gtk+-2.0 --libs`
++PKG_CONFIG ?= pkg-config
++GTK_INCLUDE = $(shell ${PKG_CONFIG} gtk+-2.0 --cflags)
++GTK_LIB = $(shel ${PKG_CONFIG} gtk+-2.0 --libs)
+ 
+ INSTALLDIR = ${DESTDIR}/usr/lib/gkrellm2/plugins
+ 

--- a/x11-plugins/gkrellmoon/gkrellmoon-0.6-r3.ebuild
+++ b/x11-plugins/gkrellmoon/gkrellmoon-0.6-r3.ebuild
@@ -1,0 +1,31 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit gkrellm-plugin toolchain-funcs
+
+DESCRIPTION="A GKrellM2 plugin of the famous wmMoonClock dockapp"
+HOMEPAGE="http://gkrellmoon.sourceforge.net/"
+SRC_URI="mirror://sourceforge/gkrellmoon/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="2"
+KEYWORDS="~alpha ~amd64 ~ppc ~sparc ~x86"
+
+RDEPEND="
+	app-admin/gkrellm:2[X]
+	media-libs/imlib2"
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-makefile.patch
+	"${FILESDIR}"/${P}-r3-pkgconfig.patch
+	"${FILESDIR}"/${P}-r3-include-stringh.patch
+)
+
+src_compile() {
+	tc-export PKG_CONFIG
+	emake CC="$(tc-getCC)" LDFLAGS="${LDFLAGS}"
+}

--- a/x11-plugins/gkrellmss/files/gkrellmss-2.6-r5-configure-makefile-fixes.patch
+++ b/x11-plugins/gkrellmss/files/gkrellmss-2.6-r5-configure-makefile-fixes.patch
@@ -1,0 +1,61 @@
+Respect the user's pkg-config, don't call cc directly, respect CFLAGS
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -7,9 +7,9 @@ endif
+ INSTALLDIR ?= $(INSTALLROOT)/lib/gkrellm2/plugins
+ INSTALL ?= install
+ 
+-
+-GTK_INCLUDE = `pkg-config gtk+-2.0 --cflags`
+-GTK_LIB = `pkg-config gtk+-2.0 --libs`
++PKG_CONFIG ?= pkg-config
++GTK_INCLUDE = $(shell ${PKG_CONFIG} gtk+-2.0 --cflags)
++GTK_LIB = $(shell ${PKG_CONFIG} gtk+-2.0 --libs)
+ 
+ OS_NAME=$(shell uname -s)
+ 
+@@ -92,7 +92,7 @@ ifeq ($(alsa),1)
+ 	FLAGS += -DGKRELLM_ALSA
+ endif
+ 
+-CC = gcc $(FLAGS) $(CFLAGS)
++CC = $(CC)
+ 
+ OBJS = gkrellmss.o oscope.o spectrum.o sdlib.o option.o
+ 
+@@ -101,7 +101,7 @@ all:	gkrellmss.so
+ warn: ; $(WARN)
+ 
+ gkrellmss.so: $(OBJS) warn
+-	$(CC) $(OBJS) -o gkrellmss.so $(LFLAGS) $(LIBS)
++	$(CC) $(FLAGS) $(CFLAGS) $(OBJS) -o gkrellmss.so $(LFLAGS) $(LIBS)
+ 
+ 
+ clean:
+@@ -121,7 +121,12 @@ help:
+ 	@echo ""
+ 
+ gkrellmss.o: gkrellmss.c gkrellmss.h configure
++	$(CC) $(CFLAGS) $(FLAGS) -c -o $@ $<
+ oscope.o: oscope.c gkrellmss.h configure
++	$(CC) $(CFLAGS) $(FLAGS) -c -o $@ $<
+ spectrum.o: spectrum.c gkrellmss.h configure
++	$(CC) $(CFLAGS) $(FLAGS) -c -o $@ $<
+ sdlib.o: sdlib.c gkrellmss.h sdlib-esd.c sdlib-alsa.c configure
++	$(CC) $(CFLAGS) $(FLAGS) -c -o $@ $<
+ option.o: option.c gkrellmss.h configure
++	$(CC) $(CFLAGS) $(FLAGS) -c -o $@ $<
+--- a/src/configure
++++ b/src/configure
+@@ -18,8 +18,9 @@ do
+ done
+ 
+ 
+-PKG_INCLUDE=`pkg-config gtk+-2.0 --cflags`
+-PKG_LIB=`pkg-config gtk+-2.0 --libs`
++PKG_CONFIG=${PKG_CONFIG-pkg-config}
++PKG_INCLUDE=$(${PKG_CONFIG} gtk+-2.0 --cflags)
++PKG_LIB=$(${PKG_CONFIG} gtk+-2.0 --libs)
+ 
+ rm -f configure.h configure.log test test.o test.c
+ 

--- a/x11-plugins/gkrellmss/gkrellmss-2.6-r5.ebuild
+++ b/x11-plugins/gkrellmss/gkrellmss-2.6-r5.ebuild
@@ -1,0 +1,37 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit gkrellm-plugin
+
+DESCRIPTION="A plugin for GKrellM2 that has a VU meter and a sound chart"
+HOMEPAGE="http://members.dslextreme.com/users/billw/gkrellmss/gkrellmss.html"
+SRC_URI="http://web.wt.net/~billw/gkrellmss/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~ppc ~sparc ~x86"
+IUSE="nls"
+
+RDEPEND="
+	app-admin/gkrellm:2[X]
+	media-libs/alsa-lib
+	sci-libs/fftw:3.0="
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-Respect-LDFLAGS.patch
+	"${FILESDIR}"/${P}-fno-common.patch
+	"${FILESDIR}"/${P}-r5-configure-makefile-fixes.patch
+)
+
+PLUGIN_DOCS=( Themes )
+
+src_compile() {
+	tc-export PKG_CONFIG
+	PLUGIN_SO=( src/gkrellmss$(get_modname) )
+	addpredict /dev/snd
+	emake CC="$(tc-getCC)" enable_nls=$(usex nls 1 0) without-esd=yes
+}

--- a/x11-plugins/gkrellmwireless/files/gkrellmwireless-2.0.3-r3-pkgconfig.patch
+++ b/x11-plugins/gkrellmwireless/files/gkrellmwireless-2.0.3-r3-pkgconfig.patch
@@ -1,0 +1,27 @@
+Respect user's pkg-config
+--- a/Makefile
++++ b/Makefile
+@@ -1,20 +1,10 @@
+ # Depends on gmake..
+ #
+ OS = $(shell uname)
++PKG_CONFIG ?= pkg-config
+ 
+-ifeq ($(OS),FreeBSD)
+-	GTK_CONFIG = pkg-config gtk+-2.0
+-	INCLUDE = -I/usr/src/sys
+-elseif eq ($(OS),NetBSD)
+-	GTK_CONFIG = pkg-config gtk+-2.0
+-else
+-# default to the linux 
+-	GTK_CONFIG = pkg-config gtk+-2.0
+-endif
+-
+-
+-GTK_CFLAGS = `$(GTK_CONFIG) --cflags` 
+-GTK_LIB = `$(GTK_CONFIG) --libs`
++GTK_CFLAGS = $(shell ${PKG_CONFIG} gtk+-2.0 --cflags)
++GTK_LIB = $(shell ${PKG_CONFIG} gtk+-2.0 --libs)
+ 
+ CFLAGS += -Wall -fPIC
+ CPPFLAGS += $(GTK_CFLAGS) $(GKRELLM_INCLUDE)

--- a/x11-plugins/gkrellmwireless/gkrellmwireless-2.0.3-r3.ebuild
+++ b/x11-plugins/gkrellmwireless/gkrellmwireless-2.0.3-r3.ebuild
@@ -1,0 +1,31 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit gkrellm-plugin toolchain-funcs
+
+DESCRIPTION="A plugin for GKrellM that monitors your wireless network card"
+HOMEPAGE="http://gkrellm.luon.net/gkrellmwireless.php"
+SRC_URI="http://gkrellm.luon.net/files/${P}.tar.gz"
+S="${WORKDIR}/${PN}"
+
+LICENSE="GPL-2"
+SLOT="2"
+KEYWORDS="~amd64 ~ppc ~sparc ~x86"
+
+RDEPEND="app-admin/gkrellm:2[X]"
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-2.0.3-fix-build-system.patch
+	"${FILESDIR}"/${PN}-2.0.3-r3-pkgconfig.patch
+)
+
+src_configure() {
+	tc-export CC PKG_CONFIG
+
+	PLUGIN_SO=( wireless$(get_modname) )
+	default
+}

--- a/x11-plugins/gkrellshoot/files/gkrellshoot-0.4.4-r4-pkgconfig.patch
+++ b/x11-plugins/gkrellshoot/files/gkrellshoot-0.4.4-r4-pkgconfig.patch
@@ -1,0 +1,25 @@
+From 47a80a178b4ab0225ff0540376be5b5c740530a7 Mon Sep 17 00:00:00 2001
+From: Thomas Bracht Laumann Jespersen <t@laumann.xyz>
+Date: Sat, 26 Mar 2022 10:32:18 +0100
+Subject: [PATCH] pkgconfig
+
+---
+ Makefile | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index e5a4895..296f807 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1,5 +1,6 @@
+-GTK_INCLUDE = `pkg-config gtk+-2.0 --cflags`
+-GTK_LIB = `pkg-config gtk+-2.0 --libs`
++PKG_CONFIG ?= pkg-config
++GTK_INCLUDE = $(shell ${PKG_CONFIG} gtk+-2.0 --cflags)
++GTK_LIB = $(shell ${PKG_CONFIG} gtk+-2.0 --libs)
+ 
+ FLAGS = -fPIC $(GTK_INCLUDE) 
+ LIBS = $(GTK_LIB) 
+-- 
+2.34.1
+

--- a/x11-plugins/gkrellshoot/gkrellshoot-0.4.4-r4.ebuild
+++ b/x11-plugins/gkrellshoot/gkrellshoot-0.4.4-r4.ebuild
@@ -1,0 +1,31 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit gkrellm-plugin toolchain-funcs
+
+DESCRIPTION="GKrellm2 plugin to take screen shots and lock screen"
+HOMEPAGE="http://gkrellshoot.sourceforge.net/"
+SRC_URI="mirror://sourceforge/gkrellshoot/${P}.tar.gz"
+S="${WORKDIR}/${P/s/S}"
+
+LICENSE="GPL-2"
+SLOT="2"
+KEYWORDS="~alpha ~amd64 ~ppc ~sparc ~x86"
+
+DEPEND="app-admin/gkrellm:2[X]"
+RDEPEND="
+	${DEPEND}
+	virtual/imagemagick-tools"
+BDEPEND="virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}"/makefile-respect-flags.patch
+	"${FILESDIR}/${P}"-r4-pkgconfig.patch
+)
+
+src_compile() {
+	tc-export PKG_CONFIG
+	default
+}

--- a/x11-plugins/gkrellstock/files/gkrellstock-0.5.1-r2-makefile-fixes.patch
+++ b/x11-plugins/gkrellstock/files/gkrellstock-0.5.1-r2-makefile-fixes.patch
@@ -1,0 +1,26 @@
+Respect the user's pkg-config, remove "-O2 -Wall" flags, don't call gcc directly
+--- a/Makefile
++++ b/Makefile
+@@ -1,16 +1,17 @@
+-GTK_INCLUDE = `pkg-config gtk+-2.0 --cflags`
+-GTK_LIB = `pkg-config gtk+-2.0 --libs`
++PKG_CONFIG ?= pkg-config
++GTK_INCLUDE = $(shell ${PKG_CONFIG} gtk+-2.0 --cflags)
++GTK_LIB = $(shell ${PKG_CONFIG} gtk+-2.0 --libs)
+ 
+-FLAGS = -O2 -Wall -fPIC $(GTK_INCLUDE)
++FLAGS = -fPIC $(GTK_INCLUDE)
+ LIBS = $(GTK_LIB)
+ LFLAGS = -shared
+ 
+-CC = gcc $(CFLAGS) $(FLAGS)
++CC = $(CC)
+ 
+ OBJS = gkrellstock.o
+ 
+ gkrellstock.so: $(OBJS)
+-	$(CC) $(LDFLAGS) $(OBJS) -o gkrellstock.so $(LFLAGS) $(LIBS) 
++	$(CC) $(CFLAGS) $(FLAGS) $(LDFLAGS) $(OBJS) -o gkrellstock.so $(LFLAGS) $(LIBS)
+ 
+ clean:
+ 	rm -f *.o core *.so* *.bak *~

--- a/x11-plugins/gkrellstock/gkrellstock-0.5.1-r2.ebuild
+++ b/x11-plugins/gkrellstock/gkrellstock-0.5.1-r2.ebuild
@@ -1,0 +1,44 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit flag-o-matic gkrellm-plugin toolchain-funcs
+
+DESCRIPTION="Get Stock quotes plugin for Gkrellm2"
+HOMEPAGE="http://gkrellstock.sourceforge.net/"
+SRC_URI="mirror://sourceforge/gkrellstock/${P}.tar.gz"
+S="${WORKDIR}/${P/s/S}"
+
+LICENSE="GPL-2"
+SLOT="2"
+KEYWORDS="~amd64 ~ppc ~x86"
+
+RDEPEND="
+	app-admin/gkrellm:2[X]
+	dev-libs/glib:2
+	x11-libs/gtk+:2
+	dev-perl/libwww-perl
+	dev-perl/Finance-Quote"
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-0.5-ldflags.patch
+	"${FILESDIR}"/${PN}-0.5.1-r2-makefile-fixes.patch
+)
+
+src_configure() {
+	tc-export PKG_CONFIG
+	append-cppflags $($(tc-getPKG_CONFIG) --cflags gtk+-2.0)
+	append-flags -fPIC
+}
+
+src_compile() {
+	emake CC="$(tc-getCC)"
+}
+
+src_install() {
+	gkrellm-plugin_src_install
+	dobin GetQuote2
+}

--- a/x11-plugins/gkrellsun/files/gkrellsun-1.0.0-r5-makefile-fixes.patch
+++ b/x11-plugins/gkrellsun/files/gkrellsun-1.0.0-r5-makefile-fixes.patch
@@ -1,0 +1,56 @@
+Don't call gcc directly, remove -O2 -Wall flags, respect user's pkg-config
+--- a/src20/Makefile
++++ b/src20/Makefile
+@@ -1,8 +1,8 @@
+ PACKAGE ?= gkrellsun
+ 
+-GTK_CONFIG ?=pkg-config gtk+-2.0
+-GTK_INCLUDE ?= `pkg-config gtk+-2.0 --cflags`
+-GTK_LIB ?= `pkg-config gtk+-2.0 --libs`
++PKG_CONFIG ?= pkg-config
++GTK_INCLUDE ?= $(shell ${PKG_CONFIG} gtk+-2.0 --cflags)
++GTK_LIB ?= $(shell ${PKG_CONFIG} gtk+-2.0 --libs)
+ 
+ INSTALL ?= install
+ 
+@@ -11,7 +11,7 @@ INSTALLDIR ?= $(DESTDIR)$(PREFIX)
+ PLUGINDIR ?= $(INSTALLDIR)/lib/gkrellm2/plugins
+ LOCALEDIR ?= $(INSTALLDIR)/share/locale
+ 
+-FLAGS = -O2 -Wall -fPIC $(GTK_INCLUDE)
++FLAGS = -fPIC $(GTK_INCLUDE)
+ #FLAGS = -g -Wall -fPIC $(GTK_INCLUDE)
+ LIBS = $(GTK_LIB)
+ LFLAGS = -shared
+@@ -25,7 +25,7 @@ endif
+ FLAGS += -DPACKAGE="\"$(PACKAGE)\""
+ export PACKAGE LOCALEDIR
+ 
+-CC = gcc $(CFLAGS) $(FLAGS)
++CC = $(CC)
+ 
+ OBJS = gkrellsun.o CalcEphem.o Moon.o MoonRise.o
+ 
+@@ -37,10 +37,10 @@ all: gkrellsun.so
+ 
+ gkrellsun.so: $(OBJS)
+ 	(cd po && ${MAKE})
+-	$(CC) $(OBJS) -o gkrellsun.so $(LFLAGS) $(LIBS)
++	$(CC) $(CFLAGS) $(FLAGS) $(OBJS) -o gkrellsun.so $(LFLAGS) $(LIBS)
+ 
+ suninfo: suninfo.o CalcEphem.o Moon.o MoonRise.o
+-	$(CC) $^ -o suninfo -lm $(LIBS)
++	$(CC) $(CFLAGS) $(FLAGS) $^ -o suninfo -lm $(LIBS)
+ 
+ clean:
+ 	rm -f *.o core *.so* *.bak *~
+@@ -49,7 +49,8 @@ gkrellsun.o: gkrellsun.c $(IMAGES)
+ 
+ $(OBJS): CalcEphem.h Moon.h MoonRise.h
+ 
+-#%.o: %.c
++%.o: %.c
++	$(CC) $(CFLAGS) $(FLAGS) -c -o $@ $<
+ 
+ install: gkrellsun.so
+ 	(cd po && ${MAKE} install )

--- a/x11-plugins/gkrellsun/gkrellsun-1.0.0-r5.ebuild
+++ b/x11-plugins/gkrellsun/gkrellsun-1.0.0-r5.ebuild
@@ -1,0 +1,37 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit gkrellm-plugin toolchain-funcs
+
+DESCRIPTION="A GKrellM plugin that shows sunrise and sunset times"
+HOMEPAGE="http://gkrellsun.sourceforge.net/"
+SRC_URI="mirror://sourceforge/gkrellsun/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="1"
+KEYWORDS="~alpha ~amd64 ~hppa ~ia64 ~ppc ~sparc ~x86"
+IUSE="nls"
+
+RDEPEND="app-admin/gkrellm:2[X]"
+DEPEND="${RDEPEND}
+	nls? ( sys-devel/gettext )"
+BDEPEND="virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-reenable.patch
+	"${FILESDIR}"/${P}-Respect-LDFLAGS.patch
+	"${FILESDIR}"/${P}-r5-makefile-fixes.patch
+)
+
+src_configure() {
+	PLUGIN_SO=( src20/gkrellsun$(get_modname) )
+	default
+}
+
+src_compile() {
+	tc-export PKG_CONFIG
+	use nls && local myconf="enable_nls=1"
+	emake CC="$(tc-getCC)" ${myconf}
+}

--- a/x11-plugins/gkrelltop/files/gkrelltop-2.2.13-r3-pkgconfig.patch
+++ b/x11-plugins/gkrelltop/files/gkrelltop-2.2.13-r3-pkgconfig.patch
@@ -1,0 +1,67 @@
+Makefile and configure should respect user's pkg-config
+--- a/Makefile
++++ b/Makefile
+@@ -28,9 +28,10 @@
+ OSFLAG = $(shell uname | tr '[:lower:]' '[:upper:]')
+ SHELL=/bin/sh
+ 
++PKG_CONFIG ?= pkg-config
+ GKRELL1FLAG=1
+ #find out if we have gkrellm 2 or 1 (from the gtk+ version)
+-GKRELL1FLAG=$(shell bash -c 'pkg-config gtk+-2.0 --cflags &>/dev/null && echo 0')
++GKRELL1FLAG=$(shell bash -c "${PKG_CONFIG} gtk+-2.0 --cflags &>/dev/null && echo 0")
+ GKRELLTOP = gkrelltop.so
+ OBJ = top_three.o gkrelltop.o 
+ EXTRA = krell_panel1.xpm
+@@ -43,7 +44,8 @@ endif
+ 
+ ifeq ($(GKRELL1FLAG),0)
+ # Parameters for gkrellm version 2.*
+-CFLAGS2 = -g -D$(OSFLAG) -DGKRELLM2 -fPIC -Wall `pkg-config gtk+-2.0 --cflags`
++GTK_INCLUDE=$(shell ${PKG_CONFIG} gtk+-2.0 --cflags)
++CFLAGS2 = -g -D$(OSFLAG) -DGKRELLM2 -fPIC -Wall ${GTK_INCLUDE}
+ LIBS =  
+ CC += $(CFLAGS) $(CFLAGS2)
+ 
+@@ -69,8 +71,9 @@ LIBSD = `glib-config --libs`
+ LIBSD = 
+ CONFIGURE_ARGS += --with-glib12
+ else
+-CFLAGSD = -D$(OSFLAG) -fPIC -Wall `pkg-config glib-2.0 --cflags`
+-LIBSD = `pkg-config glib-2.0 --libs`
++GLIB_INCLUDE=$(shell ${PKG_CONFIG} glib-2.0 --cflags)
++CFLAGSD = -D$(OSFLAG) -fPIC -Wall ${GLIB_INCLUDE}
++LIBSD = $(shell ${PKG_CONFIG} glib-2.0 --libs)
+ LIBSD = 
+ endif
+ INSTALLDIRD ?= $(PREFIXD)/$(DESTDIR)
+diff --git a/configure b/configure
+index f0b7366..99f58d8 100755
+--- a/configure
++++ b/configure
+@@ -4,8 +4,9 @@
+ # There is no need to run this configure before doing a make.
+ #
+ 
+-GLIB_INCLUDE=`pkg-config --cflags glib-2.0`
+-GLIB_LIBS=`pkg-config --libs glib-2.0`
++PKG_CONFIG=${PKG_CONFIG-pkg-config}
++GLIB_INCLUDE=$(${PKG_CONFIG} --cflags glib-2.0)
++GLIB_LIBS=$(${PKG_CONFIG} --libs glib-2.0)
+ 
+ for i
+ do
+@@ -17,8 +18,8 @@ do
+ done
+ 
+ 
+-PKG_INCLUDE=`pkg-config gkrellm --cflags --silence-errors`
+-PKG_LIBS=`pkg-config gkrellm --libs --silence-errors`
++PKG_INCLUDE=$(${PKG_CONFIG} gkrellm --cflags --silence-errors)
++PKG_LIBS=$(${PKG_CONFIG} gkrellm --libs --silence-errors)
+ 
+ if [ "$PKG_INCLUDE" = "" ]
+ then
+-- 
+2.34.1
+

--- a/x11-plugins/gkrelltop/gkrelltop-2.2.13-r3.ebuild
+++ b/x11-plugins/gkrelltop/gkrelltop-2.2.13-r3.ebuild
@@ -1,0 +1,47 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+inherit gkrellm-plugin toolchain-funcs
+
+DESCRIPTION="a GKrellM2 plugin which displays the top three processes"
+HOMEPAGE="https://sourceforge.net/projects/gkrelltop"
+SRC_URI="mirror://sourceforge/${PN}/${PN}_${PV}.orig.tar.gz"
+S="${WORKDIR}/${P}.orig"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86"
+IUSE="X"
+
+RDEPEND="
+	app-admin/gkrellm:2[X]
+	dev-libs/glib:2
+	x11-libs/gtk+:2"
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-2.2.13-fix-build-system.patch
+	"${FILESDIR}"/${PN}-2.2.13-r3-pkgconfig.patch
+)
+
+src_configure() {
+	tc-export CC PKG_CONFIG
+
+	PLUGIN_SERVER_SO=( gkrelltopd$(get_modname) )
+	PLUGIN_SO=( gkrelltop$(get_modname) )
+
+	default
+}
+
+src_compile() {
+	use X || local target="server"
+	emake ${target}
+}
+
+pkg_postinst() {
+	einfo "To enable the gkrelltopd server plugin, you must add the following"
+	einfo "line to /etc/gkrellmd.conf:"
+	einfo "\tplugin-enable gkrelltopd"
+}

--- a/x11-plugins/gkrellweather/files/gkrellweather-2.0.8-r2-makefile-fixes.patch
+++ b/x11-plugins/gkrellweather/files/gkrellweather-2.0.8-r2-makefile-fixes.patch
@@ -1,0 +1,24 @@
+Respect user's pkg-config, don't call gcc directly
+--- a/Makefile
++++ b/Makefile
+@@ -1,7 +1,9 @@
+ PKGNAME = gkrellweather
+ VERSION = 2.0.8
+-CFLAGS = -O2 -std=gnu99 -Wall -fPIC `pkg-config gtk+-2.0 --cflags`
+-LIBS = `pkg-config gtk+-2.0 --libs`
++PKG_CONFIG ?= pkg-config
++GTK_INCLUDE = $(shell ${PKG_CONFIG} gtk+-2.0 --cflags)
++CFLAGS = -std=gnu99 -fPIC $(GTK_INCLUDE)
++LIBS =  $(shell ${PKG_CONFIG} gtk+-2.0 --libs)
+ LFLAGS = -shared
+ PREFIX = /usr/local
+ 
+@@ -16,7 +18,7 @@ endif
+ CFLAGS += -DPACKAGE="\"$(PKGNAME)\""
+ export PKGNAME LOCALEDIR
+ 
+-CC = gcc
++CC = $(CC)
+ 
+ OBJS = gkrellweather.o
+ 

--- a/x11-plugins/gkrellweather/gkrellweather-2.0.8-r2.ebuild
+++ b/x11-plugins/gkrellweather/gkrellweather-2.0.8-r2.ebuild
@@ -1,0 +1,46 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit flag-o-matic gkrellm-plugin toolchain-funcs
+
+DESCRIPTION="GKrellM2 Plugin that monitors a METAR station and displays weatherinfo"
+HOMEPAGE="https://sites.google.com/site/makovick/gkrellm-plugins"
+SRC_URI="https://sites.google.com/site/makovick/projects/${P}.tgz"
+
+LICENSE="GPL-2"
+SLOT="2"
+KEYWORDS="~alpha ~amd64 ~ppc ~sparc ~x86"
+
+RDEPEND="
+	app-admin/gkrellm:2[X]
+	dev-lang/perl
+	net-misc/wget
+	x11-libs/gtk+:2"
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-Respect-LDFLAGS.patch
+	"${FILESDIR}"/${P}-Move-GrabWeather.patch
+	"${FILESDIR}"/${P}-update-locations.patch
+	"${FILESDIR}"/${P}-r2-makefile-fixes.patch
+)
+
+src_configure() {
+	append-cflags $($(tc-getPKG_CONFIG) --cflags gtk+-2.0)
+	append-flags -fPIC
+}
+
+src_compile() {
+	tc-export PKG_CONFIG
+	emake PREFIX="${EPREFIX}"/usr CC="$(tc-getCC)" CFLAGS="${CFLAGS}"
+}
+
+src_install() {
+	gkrellm-plugin_src_install
+
+	exeinto /usr/libexec/gkrellweather
+	doexe GrabWeather
+}

--- a/x11-plugins/i8krellm/files/i8krellm-2.5-r3-makefile-fixes.patch
+++ b/x11-plugins/i8krellm/files/i8krellm-2.5-r3-makefile-fixes.patch
@@ -1,0 +1,42 @@
+Respect user's pkg-config, don't call gcc directly, respect CFLAGS
+--- a/Makefile
++++ b/Makefile
+@@ -8,14 +8,14 @@ LFLAGS += $(LDFLAGS)
+ 
+ ## Support for GKrellM 2.0
+ #
+-GTK2_INCLUDE = `pkg-config gtk+-2.0 --cflags`
+-GTK2_LIB = `pkg-config gtk+-2.0 --libs`
++PKG_CONFIG ?= pkg-config
++GTK2_INCLUDE = $(shell ${PKG_CONFIG} gtk+-2.0 --cflags)
++GTK2_LIB = $(shell ${PKG_CONFIG} gtk+-2.0 --libs)
+ SINSTALLDIR2 = /usr/share/gkrellm2/plugins
+ UINSTALLDIR2 = $(HOME)/.gkrellm2/plugins
+-FLAGS2 = -O2 -Wall -fPIC -I. $(GTK2_INCLUDE)
++FLAGS2 = -fPIC -I. $(GTK2_INCLUDE)
+ LIBS2 = $(GTK2_LIB)
+-CC2 = gcc $(FLAGS2) -DGKRELLM2
+-CC2F = gcc $(FLAGS2) -DFAKE -DGKRELLM2
++CC = $(CC)
+ OBJS2 = i8krellm.o
+ 
+ # seems to barf without the @echo....
+@@ -23,14 +23,14 @@ i8krellm: i8krellm.so
+ 	@echo ""
+ 
+ i8krellm.so: $(OBJS2)
+-	$(CC2) $(OBJS2) -o i8krellm.so $(LFLAGS) $(LIBS2)
++	$(CC) $(CFLAGS) $(CFLAGS) $(FLAGS2) -DGKRELLM2 $(OBJS2) -o i8krellm.so $(LFLAGS) $(LIBS2)
+ 
+ fake: i8krellm.c prop-anim.xpm
+-	$(CC2F) -c -o i8krellm.o i8krellm.c
+-	$(CC2F) $(OBJS2) -o i8krellm.so $(LFLAGS) $(LIBS2)
++	$(CC) $(CFLAGS) $(FLAGS2) -DFAKE -DGKRELLM2 -c -o i8krellm.o i8krellm.c
++	$(CC) $(CFLAGS) $(FLAGS2) -DFAKE -DGKRELLM2 $(OBJS2) -o i8krellm.so $(LFLAGS) $(LIBS2)
+ 
+ i8krellm.o: i8krellm.c prop-anim.xpm
+-	$(CC2) -c -o i8krellm.o i8krellm.c
++	$(CC) $(CFLAGS) $(FLAGS2) -DGKRELLM2 -c -o i8krellm.o i8krellm.c
+ 
+ site_install: i8krellm.so
+ 	install -c -s -m 644 i8krellm.so $(SINSTALLDIR2)

--- a/x11-plugins/i8krellm/files/i8krellm-2.5-r3-rm-gkrellm1-support.patch
+++ b/x11-plugins/i8krellm/files/i8krellm-2.5-r3-rm-gkrellm1-support.patch
@@ -1,0 +1,50 @@
+Remove support for gkrellm1
+--- a/Makefile
++++ b/Makefile
+@@ -1,5 +1,4 @@
+ # To build for GKrellM v2, just type 'make' and 'make install'
+-# For GKrellM v1, type 'make i8krellm1' and 'make install1'
+ # 
+ 
+ LFLAGS = -shared
+@@ -43,40 +42,3 @@ install: i8krellm.so
+ 
+ clean:
+ 	rm -f *.o core *.so
+-
+-
+-## Support for GKrellM 1.2
+-#
+-GTK_INCLUDE = `gtk-config --cflags`
+-GTK_LIB = `gtk-config --libs` -lpthread
+-IMLIB_INCLUDE = `imlib-config --cflags-gdk`
+-IMLIB_LIB = `imlib-config --libs-gdk`
+-SINSTALLDIR = /usr/share/gkrellm/plugins
+-UINSTALLDIR = $(HOME)/.gkrellm/plugins
+-FLAGS = -O2 -Wall -fPIC -I. $(GTK_INCLUDE) $(IMLIB_INCLUDE)
+-LIBS = $(GTK_LIB) $(IMLIB_LIB)
+-CC = gcc $(FLAGS)
+-CCF = gcc $(FLAGS) -DFAKE
+-OBJS = i8krellm.o
+-
+-i8krellm1.so: $(OBJS)
+-#	@echo "========> i8krellm1.so"
+-	$(CC) $(OBJS) -o i8krellm1.so $(LFLAGS) $(LIBS)
+-
+-i8krellm1.o: i8krellm.c prop-anim.xpm
+-#	@echo "========> i8krellm1.o"
+-	$(CC) -c -o i8krellm1.o i8krellm.c
+-
+-fake1: i8krellm.c prop-anim.xpm
+-	$(CCF) -c -o i8krellm1.o i8krellm.c
+-	$(CCF) $(OBJS) -o i8krellm1.so $(LFLAGS) $(LIBS)
+-
+-site_install1: i8krellm1.so
+-	install -c -s -m 644 i8krellm1.so $(SINSTALLDIR)
+-
+-user_install1: i8krellm1.so
+-	install -c -s -m 644 i8krellm1.so $(UINSTALLDIR)
+-
+-install1: i8krellm1.so
+-	install -c -s -m 644 i8krellm1.so $(UINSTALLDIR)
+-

--- a/x11-plugins/i8krellm/i8krellm-2.5-r3.ebuild
+++ b/x11-plugins/i8krellm/i8krellm-2.5-r3.ebuild
@@ -1,0 +1,31 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit gkrellm-plugin toolchain-funcs
+
+DESCRIPTION="GKrellM2 Plugin for the Dell Inspiron and Latitude notebooks"
+SRC_URI="http://www.coding-zone.com/${P}.tar.gz"
+HOMEPAGE="http://www.coding-zone.com/?page=i8krellm"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+RDEPEND="
+	app-admin/gkrellm:2[X]
+	>=app-laptop/i8kutils-1.5"
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-Respect-LDFLAGS.patch
+	"${FILESDIR}"/${P}-r3-makefile-fixes.patch
+	"${FILESDIR}"/${P}-r3-rm-gkrellm1-support.patch
+)
+
+src_compile() {
+	tc-export PKG_CONFIG
+	emake CC="$(tc-getCC)"
+}


### PR DESCRIPTION
@thesamesam Here's a big PR to track all the users of gkrellm-plugin.eclass, and bumping them to EAPI=8. I'll tick them off as I go, and maybe add comments as well.

 - [x] x11-plugins/gkrellm-cpupower-0.2-r1 - Add patch for Makefile, heavily inspired by the patch file for [x11-plugins/gkrellshoot](https://github.com/gentoo/gentoo/blob/master/x11-plugins/gkrellshoot/files/makefile-respect-flags.patch) by @Flowdalic 
 - [x] x11-plugins/gkrellshoot-0.4.4-r3 - plus PKG_CONFIG
 - [x] x11-plugins/gkrellm-countdown-0.1.2-r1 - plus PKG_CONFIG
 - [x] x11-plugins/gkrellmlaunch-0.5 - plus PKG_CONFIG
 - [x] x11-plugins/gkrellm-mailwatch-2.4.3-r2 -  plus PKG_CONFIG
 - [x] x11-plugins/gkrellm-trayicons-1.03-r1 - plus PKG_CONFIG
 - [x] x11-plugins/gkrellm-vaiobright-2.5-r2
 - [x] x11-plugins/gkrellkam-2.0.0 - plus PKG_CONFIG
 - [x] x11-plugins/gkrellm-xkb-1.05-r1 - plus PKG_CONFIG
 - [x] x11-plugins/gkrellmoon-0.6-r2 - converted `sed` line to patch, plus PKG_CONFIG
 - [ ] x11-plugins/gkrellfire-0.4.2-r1
 - [x] x11-plugins/gkrellsun-1.0.0-r4 - fixes: Don't call `gcc` directly, respect pkgconfig, ensure $(CC) and $(CFLAGS) are used
 - [x] x11-plugins/gkrellweather-2.0.8-r1 - fixes: Don't call `gcc` directly, respect pkgconfig. Suspect that flag-o-matic is not needed
 - [x] x11-plugins/gkrellm-bgchanger-0.1.11-r2
 - [x] x11-plugins/gkrellm-radio-2.0.4 - plus PKG_CONFIG
 - [x] x11-plugins/gkrelltop-2.2.13-r2 - plus PKG_CONFIG
 - [x] x11-plugins/gkrellm-imonc-0.2-r1 - plus PKG_CONFIG
 - [x] x11-plugins/gkrellstock-0.5.1-r1 - plus PKG_CONFIG, rm "-O2 -Wall" flags, don't call gcc directly
 - [x] x11-plugins/gkrellm-volume-2.1.13-r2 - plus PKG_CONFIG
 - [x] x11-plugins/gkrellmss-2.6-r4 - plus PKG_CONFIG, don't call cc directly, respect CFLAGS
 - [x] x11-plugins/i8krellm-2.5-r2 - plus PKG_CONFIG, don't call gcc directly, respect CFLAGS, remove makefile support for gkrellm1
 - [x] x11-plugins/gkrellmwireless-2.0.3-r2 - plus PKG_CONFIG
 - [ ] x11-plugins/gkrellm-bluez-0.2-r2
 - [ ] x11-plugins/gkrellaclock-0.3.4-r1 - bug [742836 (does not respect CFLAGS)](https://bugs.gentoo.org/742836). The compiled .so file fails to load with "gkrellm -p" - it expects a function: `Error: /var/tmp/portage/x11-plugins/gkrellaclock-0.3.4-r2/image/usr/lib64/gkrellm2/plugins/gkrellaclock.so: cannot open shared object file: No such file or directory`



--- 
Overall changes
 - Adjusting Makefiles where appropriate to use user-defined `PKG_CONFIG`
