### PR TITLE
app-misc/solaar: add missing python-evdev dependency

### DIFF
--- a/app-misc/solaar/solaar-1.1.2_rc2-r1.ebuild
+++ b/app-misc/solaar/solaar-1.1.2_rc2-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -28,6 +28,7 @@ RDEPEND="
 	$(python_gen_cond_dep '
 		dev-python/psutil[${PYTHON_USEDEP}]
 		dev-python/pygobject:3[${PYTHON_USEDEP}]
+		dev-python/python-evdev[${PYTHON_USEDEP}]
 		dev-python/python-xlib[${PYTHON_USEDEP}]
 		>=dev-python/pyudev-0.13[${PYTHON_USEDEP}]
 		dev-python/pyyaml[${PYTHON_USEDEP}]


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/835767
Signed-off-by: Florian Schmaus <flow@gentoo.org>