### PR TITLE
dev-util/hip: fix missing rocm-comgr dependency

### DIFF
--- a/dev-util/hip/hip-5.0.2.ebuild
+++ b/dev-util/hip/hip-5.0.2.ebuild
@@ -23,6 +23,7 @@ IUSE="debug profile"
 DEPEND="
 	dev-util/rocminfo:${SLOT}
 	=sys-devel/llvm-roc-${PV}*[runtime]
+	dev-libs/rocm-comgr:${SLOT}
 "
 RDEPEND="${DEPEND}
 	dev-perl/URI-Encode


### PR DESCRIPTION
Package-Manager: Portage-3.0.30, Repoman-3.0.3
Signed-off-by: Yiyang Wu <xgreenlandforwyy@gmail.com>