### PR TITLE
dev-python/jsonschema: keyword 4.4.0-r2 for ~riscv

### DIFF
--- a/dev-python/jsonschema/jsonschema-4.4.0-r2.ebuild
+++ b/dev-python/jsonschema/jsonschema-4.4.0-r2.ebuild
@@ -17,7 +17,7 @@ SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~amd64"
+KEYWORDS="~amd64 ~riscv"
 
 RDEPEND="
 	dev-python/attrs[${PYTHON_USEDEP}]

--- a/dev-python/uri_template/uri_template-1.1.0.ebuild
+++ b/dev-python/uri_template/uri_template-1.1.0.ebuild
@@ -16,7 +16,7 @@ S="${WORKDIR}/${MY_P}"
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~amd64"
+KEYWORDS="~amd64 ~riscv"
 
 python_test() {
 	"${EPYTHON}" "test.py" || die "Tests fail with ${EPYTHON}."


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/836003
Signed-off-by: Yu Gu <guyu2876@gmail.com>