### PR TITLE
x11-misc/xpad: add xdg_icon_cache_update

### DIFF
--- a/x11-misc/xpad/xpad-5.7.0.ebuild
+++ b/x11-misc/xpad/xpad-5.7.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit autotools
+inherit autotools xdg-utils
 
 DESCRIPTION="A sticky note application for GTK"
 HOMEPAGE="https://launchpad.net/xpad"
@@ -33,4 +33,12 @@ src_prepare() {
 	default
 
 	eautoreconf
+}
+
+pkg_postinst() {
+	xdg_icon_cache_update
+}
+
+pkg_postrm() {
+	xdg_icon_cache_update
 }


### PR DESCRIPTION
The ebuild for xpad-5.7.0 was missing calls of xdg_icon_cache_update.

Closes: https://bugs.gentoo.org/835924
Package-Manager: Portage-3.0.30, Repoman-3.0.3
Signed-off-by: Philipp Rösner <rndxelement@protonmail.com>