### PR TITLE
dev-util/hip: add missing BDEPEND providing GL/glx.h

### DIFF
--- a/dev-util/hip/hip-5.0.2.ebuild
+++ b/dev-util/hip/hip-5.0.2.ebuild
@@ -28,6 +28,7 @@ DEPEND="
 RDEPEND="${DEPEND}
 	dev-perl/URI-Encode
 	dev-libs/roct-thunk-interface:${SLOT}"
+BDEPEND="media-libs/libglvnd"
 
 PATCHES=(
 	"${FILESDIR}/${PN}-5.0.1-DisableTest.patch"


### PR DESCRIPTION
Previously this is the (build-time) dependency of rocclr, which has
DEPEND="virtual/opengl" to make sure GL/glx.h is present. Now hip-5
bundles rocclr and this BDEPEND shuold be added. Turned out headers
are provided by media-libs/libglvnd

Closes: https://bugs.gentoo.org/836136
Package-Manager: Portage-3.0.30, Repoman-3.0.3
Signed-off-by: Yiyang Wu <xgreenlandforwyy@gmail.com>