### PR TITLE
profiles/features/musl/package.mask: mask net-misc/teamviewer

### DIFF
--- a/profiles/features/musl/package.mask
+++ b/profiles/features/musl/package.mask
@@ -1,6 +1,10 @@
 # Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Martin Dummer <martin.dummer@gmx.net> (2022-03-26)
+# Binary package linked to glibc
+net-misc/teamviewer
+
 # Mike Pagano <mpagano@gentoo.org> (2022-03-21)
 # Binary package linked to glibc
 dev-util/idea-community


### PR DESCRIPTION
net-misc/teamviewer is a binary package linked to glibc

Closes: https://bugs.gentoo.org/832558
Signed-off-by: Martin Dummer <martin.dummer@gmx.net>