### PR TITLE
arch/x86/package.mask: Unmask eclipse-ecj and tomcat 

### DIFF
--- a/profiles/arch/x86/package.mask
+++ b/profiles/arch/x86/package.mask
@@ -1,9 +1,3 @@
 # Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-# Miroslav Šulc <fordfrog@gentoo.org> (2020-02-27)
-# >=dev-java/ant-eclipse-ecj-4.10 depends on masked >=virtual/{jdk,jre}-11
-# www-servers/tomcat >= 9 depends on masked dev-java/eclipse-ecj
->=dev-java/ant-eclipse-ecj-4.10
->=dev-java/eclipse-ecj-4.10
->=www-servers/tomcat-9


### PR DESCRIPTION

Bug: https://bugs.gentoo.org/835417
Signed-off-by: Volkmar W. Pogatzki <gentoo@pogatzki.net>