### PR TITLE
net-dns/unbound: specify dependency location from sysroot

### DIFF
--- a/net-dns/unbound/unbound-1.13.2-r1.ebuild
+++ b/net-dns/unbound/unbound-1.13.2-r1.ebuild
@@ -111,12 +111,12 @@ multilib_src_configure() {
 		--disable-rpath \
 		--enable-event-api \
 		--enable-ipsecmod \
-		--with-libevent="${EPREFIX}"/usr \
-		$(multilib_native_usex redis --with-libhiredis="${EPREFIX}/usr" --without-libhiredis) \
+		--with-libevent="${ESYSROOT}"/usr \
+		$(multilib_native_usex redis --with-libhiredis="${ESYSROOT}/usr" --without-libhiredis) \
 		--with-pidfile="${EPREFIX}"/run/unbound.pid \
 		--with-rootkey-file="${EPREFIX}"/etc/dnssec/root-anchors.txt \
-		--with-ssl="${EPREFIX}"/usr \
-		--with-libexpat="${EPREFIX}"/usr
+		--with-ssl="${ESYSROOT}"/usr \
+		--with-libexpat="${ESYSROOT}"/usr
 
 		# http://unbound.nlnetlabs.nl/pipermail/unbound-users/2011-April/001801.html
 		# $(use_enable debug lock-checks) \


### PR DESCRIPTION
configure needs to find the location of libevent and other build time
and runtime dependencies from sysroot instead of build host to allow
cross compilation.

This can be replicated by having dev-libs/libevent not installed on the
build host and cross compiling net-dns/unbound, leading to error like:

  ..
  ./configure .. --with-libevent=/usr ..--with-ssl=/usr --with-libexpat=/usr
  ..
  checking for libevent... configure: error: Cannot find the libevent library in /usr

Bug: https://bugs.gentoo.org/836214
Signed-off-by: Bertrand Jacquin <bertrand@jacquin.bzh>
Package-Manager: Portage-3.0.30, Repoman-3.0.3