### PR TITLE
media-tv/v4l-dvb-saa716x: fix pkgcheck VariableScope error

### DIFF
--- a/media-tv/v4l-dvb-saa716x/v4l-dvb-saa716x-0.0.1_p20170225-r5.ebuild
+++ b/media-tv/v4l-dvb-saa716x/v4l-dvb-saa716x-0.0.1_p20170225-r5.ebuild
@@ -1,7 +1,7 @@
-# Copyright 2020 Gentoo Authors
+# Copyright 2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 inherit linux-info linux-mod
 
@@ -45,6 +45,6 @@ src_compile() {
 	kernel_is le 5 0 && BUILD_PARAMS="SUBDIRS" || BUILD_PARAMS="M"
 	BUILD_PARAMS+="=${S}/linux/drivers/media/common/saa716x CONFIG_SAA716X_CORE=m \
 		CONFIG_DVB_SAA716X_FF=m CONFIG_DVB_SAA716X_BUDGET=m CONFIG_DVB_SAA716X_HYBRID=m"
-	addpredict "${EROOT}"/usr/src/linux/
+	addpredict /usr/src/linux/
 	linux-mod_src_compile
 }


### PR DESCRIPTION
remove use of variable 'EROOT' in 'src_compile'
EAPI 8

Closes: https://bugs.gentoo.org/836080
Package-Manager: Portage-3.0.30, Repoman-3.0.3
Signed-off-by: Martin Dummer <martin.dummer@gmx.net>