### PR TITLE
x11-misc/sddm: migrate to glep-81

### DIFF
--- a/acct-group/sddm/metadata.xml
+++ b/acct-group/sddm/metadata.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="project">
+		<email>lxqt@gentoo.org</email>
+		<name>LXQt</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>kde@gentoo.org</email>
+		<name>Gentoo KDE Project</name>
+	</maintainer>
+</pkgmetadata>

--- a/acct-group/sddm/sddm-0.ebuild
+++ b/acct-group/sddm/sddm-0.ebuild
@@ -1,0 +1,10 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit acct-group
+
+DESCRIPTION="A group for x11-misc/ssdm"
+
+ACCT_GROUP_ID="219"

--- a/acct-user/sddm/metadata.xml
+++ b/acct-user/sddm/metadata.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="project">
+		<email>lxqt@gentoo.org</email>
+		<name>LXQt</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>kde@gentoo.org</email>
+		<name>Gentoo KDE Project</name>
+	</maintainer>
+</pkgmetadata>

--- a/acct-user/sddm/sddm-0.ebuild
+++ b/acct-user/sddm/sddm-0.ebuild
@@ -1,0 +1,14 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit acct-user
+
+DESCRIPTION="A user for x11-misc/sddm"
+
+ACCT_USER_GROUPS=( "sddm" "video" )
+ACCT_USER_HOME="/var/lib/sddm"
+ACCT_USER_ID="219"
+
+acct-user_add_deps

--- a/x11-misc/sddm/files/sddm-0.18.1-cve-2020-28049.patch
+++ b/x11-misc/sddm/files/sddm-0.18.1-cve-2020-28049.patch
@@ -1,0 +1,94 @@
+From be202f533ab98a684c6a007e8d5b4357846bc222 Mon Sep 17 00:00:00 2001
+From: Fabian Vogt <fabian@ritter-vogt.de>
+Date: Tue, 6 Oct 2020 21:21:38 +0200
+Subject: [PATCH] Fix X not having access control on startup
+
+If the auth file is empty, X allows any local application (= any user on the
+system) to connect. This is currently the case until X wrote the display
+number to sddm and sddm used that to write the entry into the file.
+To work around this chicken-and-egg problem, make use of the fact that X
+doesn't actually look at the display number in the passed auth file and just
+use :0 unconditionally. Also make sure that writing the entry was actually
+successful.
+
+CVE-2020-28049
+---
+ src/daemon/XorgDisplayServer.cpp | 25 ++++++++++++++++++++-----
+ src/daemon/XorgDisplayServer.h   |  2 +-
+ 2 files changed, 21 insertions(+), 6 deletions(-)
+
+diff --git a/src/daemon/XorgDisplayServer.cpp b/src/daemon/XorgDisplayServer.cpp
+index d04f6344..df685b2d 100644
+--- a/src/daemon/XorgDisplayServer.cpp
++++ b/src/daemon/XorgDisplayServer.cpp
+@@ -88,7 +88,7 @@ namespace SDDM {
+         return m_cookie;
+     }
+ 
+-    void XorgDisplayServer::addCookie(const QString &file) {
++    bool XorgDisplayServer::addCookie(const QString &file) {
+         // log message
+         qDebug() << "Adding cookie to" << file;
+ 
+@@ -104,13 +104,13 @@ namespace SDDM {
+ 
+         // check file
+         if (!fp)
+-            return;
++            return false;
+         fprintf(fp, "remove %s\n", qPrintable(m_display));
+         fprintf(fp, "add %s . %s\n", qPrintable(m_display), qPrintable(m_cookie));
+         fprintf(fp, "exit\n");
+ 
+         // close pipe
+-        pclose(fp);
++        return pclose(fp) == 0;
+     }
+ 
+     bool XorgDisplayServer::start() {
+@@ -127,6 +127,15 @@ namespace SDDM {
+         // log message
+         qDebug() << "Display server starting...";
+ 
++        // generate auth file.
++        // For the X server's copy, the display number doesn't matter.
++        // An empty file would result in no access control!
++        m_display = QStringLiteral(":0");
++        if(!addCookie(m_authPath)) {
++            qCritical() << "Failed to write xauth file";
++            return false;
++        }
++
+         if (daemonApp->testing()) {
+             QStringList args;
+             QDir x11socketDir(QStringLiteral("/tmp/.X11-unix"));
+@@ -217,8 +226,14 @@ namespace SDDM {
+             emit started();
+         }
+ 
+-        // generate auth file
+-        addCookie(m_authPath);
++        // The file is also used by the greeter, which does care about the
++        // display number. Write the proper entry, if it's different.
++        if(m_display != QStringLiteral(":0")) {
++            if(!addCookie(m_authPath)) {
++                qCritical() << "Failed to write xauth file";
++                return false;
++            }
++        }
+         changeOwner(m_authPath);
+ 
+         // set flag
+diff --git a/src/daemon/XorgDisplayServer.h b/src/daemon/XorgDisplayServer.h
+index d2bdf6d4..e97a0b53 100644
+--- a/src/daemon/XorgDisplayServer.h
++++ b/src/daemon/XorgDisplayServer.h
+@@ -40,7 +40,7 @@ namespace SDDM {
+ 
+         const QString &cookie() const;
+ 
+-        void addCookie(const QString &file);
++        bool addCookie(const QString &file);
+ 
+     public slots:
+         bool start();

--- a/x11-misc/sddm/files/sddm.tmpfiles
+++ b/x11-misc/sddm/files/sddm.tmpfiles
@@ -1,0 +1,1 @@
+d /var/lib/sddm 0755 sddm sddm


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/802306
Signed-off-by: Conrad Kostecki <conikost@gentoo.org>

@gentoo/lxqt @gentoo/kde 
Since https://github.com/gentoo/gentoo/pull/18935 will take a longer time, can we just migrate the current ebuild to glep81 with current state?