### PR TITLE
Update solaar-1.1.2_rc2-r1.ebuild for python3.10

### DIFF
--- a/app-misc/solaar/solaar-1.1.2_rc2-r1.ebuild
+++ b/app-misc/solaar/solaar-1.1.2_rc2-r1.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 
 DISTUTILS_SINGLE_IMPL=1
-PYTHON_COMPAT=( python3_{7..9} )
+PYTHON_COMPAT=( python3_{7..10} )
 
 inherit linux-info udev xdg distutils-r1
 


### PR DESCRIPTION
This updates the 1.1.2_rc2 ebuild to allow for python3.10, as otherwise it breaks python single target if set to 3.10, which is required by some packages like blender-3.1.0 

(Possibly should be done for 1.1.1, but that's in amd, and not ~amd64) 