### PR TITLE
media-libs/libvmaf: add bdep to embed models within the shared libs

### DIFF
--- a/media-libs/libvmaf/libvmaf-2.3.0-r1.ebuild
+++ b/media-libs/libvmaf/libvmaf-2.3.0-r1.ebuild
@@ -21,12 +21,13 @@ fi
 LICENSE="BSD-2-with-patent"
 SLOT="0"
 
-# upstream issue, see bug #835471
-RESTRICT="test"
-
 BDEPEND="
 	dev-lang/nasm
+	app-editors/vim-core
 "
+# The app-editors/vim-core dep is needed to embed models within the library
+# could be made into a useflag if someones express the need for it
+# see https://github.com/Netflix/vmaf/blob/master/libvmaf/meson_options.txt#L21
 
 RDEPEND="${BDEPEND}"
 


### PR DESCRIPTION
Devs upstream [pointed me towards](https://github.com/Netflix/vmaf/issues/998) the correct fix for bug https://bugs.gentoo.org/835471

Signed-off-by: Adel KARA SLIMANE <adel.ks@zegrapher.com>