### PR TITLE
dev-util/gitlab-runner: drop dependency on acct-group/gitlab-runner

### DIFF
--- a/dev-util/gitlab-runner/gitlab-runner-14.9.1-r1.ebuild
+++ b/dev-util/gitlab-runner/gitlab-runner-14.9.1-r1.ebuild
@@ -14,8 +14,7 @@ LICENSE="MIT"
 SLOT="0"
 KEYWORDS="~amd64"
 
-COMMON_DEPEND="acct-group/gitlab-runner
-	acct-user/gitlab-runner"
+COMMON_DEPEND="acct-user/gitlab-runner"
 DEPEND="${COMMON_DEPEND}"
 RDEPEND="${COMMON_DEPEND}"
 BDEPEND="dev-go/gox"


### PR DESCRIPTION
There is no need that dev-util/gitlab-runner depends on
acct-group/gitlab-runner since acct-user/gitlab-runner already depends on
acct-group/gitlab-runner.

Signed-off-by: Florian Schmaus <flow@gentoo.org>