### PR TITLE
mail-filter/postsrsd fixes initd

### DIFF
--- a/mail-filter/postsrsd/files/postsrsd.init-r2
+++ b/mail-filter/postsrsd/files/postsrsd.init-r2
@@ -1,10 +1,10 @@
 #!/sbin/openrc-run
-# Copyright 2015 Gentoo Foundation
+# Copyright 2015-2022 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 PIDFILE=/var/run/$SVCNAME.pid
-SRS_DOMAIN=`postconf -h mydomain || true`
-SRS_EXCLUDE_DOMAINS=
+SRS_DOMAIN="${SRS_DOMAIN:-`postconf -h mydomain || true`}"
+SRS_EXCLUDE_DOMAINS="${SRS_EXCLUDE_DOMAINS:-''}"
 
 depend() {
 	need net
@@ -18,6 +18,7 @@ start() {
 						-- -f "$SRS_FORWARD_PORT" -r "$SRS_REVERSE_PORT" \
 							-d "$SRS_DOMAIN" -s "$SRS_SECRET" -a "$SRS_SEPARATOR" \
 							-u "$RUN_AS" -p "$PIDFILE" -c "$CHROOT" \
+							-n "$SRS_HASHLENGTH" -N "$SRS_HASHMIN" -l "$SRS_LISTEN_ADDR" \
 							-D -X"$SRS_EXCLUDE_DOMAINS"
 	eend $?
 }

--- a/mail-filter/postsrsd/postsrsd-1.11-r1.ebuild
+++ b/mail-filter/postsrsd/postsrsd-1.11-r1.ebuild
@@ -1,0 +1,35 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit cmake
+
+DESCRIPTION="Postfix Sender Rewriting Scheme daemon"
+SRC_URI="https://github.com/roehling/postsrsd/archive/${PV}.tar.gz -> ${P}.tar.gz"
+HOMEPAGE="https://github.com/roehling/postsrsd"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE=""
+
+BDEPEND=">=dev-util/cmake-2.4"
+RDEPEND=""
+
+CHROOT_DIR="${EPREFIX}/var/lib/postsrsd"
+
+src_configure() {
+	local mycmakeargs=(
+		-DCHROOT_DIR=${CHROOT_DIR}
+		-DDOC_DIR="${EPREFIX}/usr/share/doc/${PF}"
+	)
+	cmake_src_configure
+}
+
+src_install() {
+	cmake_src_install
+	newinitd "${FILESDIR}/postsrsd.init-r2" postsrsd
+	newconfd "${BUILD_DIR}/postsrsd.default" postsrsd
+	keepdir ${CHROOT_DIR}
+}


### PR DESCRIPTION
pass SRS_HASHLENGTH, SRS_HASHMIN, SRS_LISTEN_ADDR vars from confd into
initd
remove old unused init
EAPI 8 the new ebuild

Closes: https://bugs.gentoo.org/836390
Package-Manager: Portage-3.0.30, Repoman-3.0.3
Signed-off-by: Nic Boet <nic@boet.cc>