### PR TITLE
dev-cpp/highway: Fix detection of AVX512 for IceLake Client CPUs

### DIFF
--- a/dev-cpp/highway/files/highway-0.16.0-fix-AVX512-detection-on-IceLakeClient.patch
+++ b/dev-cpp/highway/files/highway-0.16.0-fix-AVX512-detection-on-IceLakeClient.patch
@@ -1,0 +1,15 @@
+diff --git a/hwy/targets.cc b/hwy/targets.cc
+index 2a0ab4ef..7e7e2d79 100644
+--- a/hwy/targets.cc
++++ b/hwy/targets.cc
+@@ -328,8 +328,8 @@ uint32_t SupportedTargets() {
+     if (!IsBitSet(xcr0, 2)) {
+       bits &= ~uint32_t(HWY_AVX2 | HWY_AVX3 | HWY_AVX3_DL);
+     }
+-    // ZMM + opmask
+-    if ((xcr0 & 0x70) != 0x70) {
++    // opmask, ZMM lo/hi
++    if (!IsBitSet(xcr0, 5) || !IsBitSet(xcr0, 6) || !IsBitSet(xcr0, 7)) {
+       bits &= ~uint32_t(HWY_AVX3 | HWY_AVX3_DL);
+     }
+   }

--- a/dev-cpp/highway/highway-0.16.0-r1.ebuild
+++ b/dev-cpp/highway/highway-0.16.0-r1.ebuild
@@ -25,6 +25,10 @@ DEPEND="test? ( dev-cpp/gtest[${MULTILIB_USEDEP}] )"
 
 RESTRICT="!test? ( test )"
 
+PATCHES=(
+	"${FILESDIR}"/${P}-fix-AVX512-detection-on-IceLakeClient.patch
+)
+
 multilib_src_configure() {
 	local mycmakeargs=(
 		-DBUILD_TESTING=$(usex test)


### PR DESCRIPTION
Signed-off-by: Paolo Pedroni <paolo.pedroni@iol.it>
Closes: https://bugs.gentoo.org/836373
Package-Manager: Portage-3.0.30, Repoman-3.0.3