### PR TITLE
sci-libs/vtk: find qt binaries with qt-5.15.3

### DIFF
--- a/sci-libs/vtk/files/vtk-9.1.0-adjust-to-find-binaries.patch
+++ b/sci-libs/vtk/files/vtk-9.1.0-adjust-to-find-binaries.patch
@@ -1,0 +1,25 @@
+From e59b8ff7b83cd6a58c226cb4f5d9661bcb29002b Mon Sep 17 00:00:00 2001
+From: Bernd Waibel <waebbl-gentoo@posteo.net>
+Date: Thu, 31 Mar 2022 08:05:17 +0200
+Subject: [PATCH] adjust to find binaries
+
+Add compatibility for qt-5.15.3 with no qtchooser installed. QtCore exports
+Qt5::{qmake,moc,rcc} which we use to get the path for binaries.
+
+Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>
+--- a/GUISupport/QtQuick/qml/CMakeLists.txt
++++ b/GUISupport/QtQuick/qml/CMakeLists.txt
+@@ -60,8 +60,8 @@ file(GENERATE
+ # Generate the qmltypes file for the VTK QML plugin
+ 
+ # First, find the qmlplugindump executable
+-get_target_property(qt_core_location "Qt${vtk_qt_major_version}::Core" LOCATION)
+-get_filename_component(qt_bin_dir "${qt_core_location}" PATH)
++get_target_property(qt_qmake_location "Qt${vtk_qt_major_version}::qmake" LOCATION)
++get_filename_component(qt_bin_dir "${qt_qmake_location}" PATH)
+ if (APPLE)
+   get_filename_component(qt_bin_dir "${qt_bin_dir}" PATH)
+ endif ()
+-- 
+2.35.1
+

--- a/sci-libs/vtk/vtk-9.1.0-r1.ebuild
+++ b/sci-libs/vtk/vtk-9.1.0-r1.ebuild
@@ -143,6 +143,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-9.0.1-0001-fix-kepler-compute_arch-if-CUDA-toolkit-11-is-used.patch
 	"${FILESDIR}"/${PN}-8.2.0-freetype-2.10.3-provide-FT_CALLBACK_DEF.patch
 	"${FILESDIR}"/${PN}-9.0.3-IO-FFMPEG-support-FFmpeg-5.0-API-changes.patch
+	"${FILESDIR}"/${P}-adjust-to-find-binaries.patch
 )
 
 DOCS=( CONTRIBUTING.md README.md )


### PR DESCRIPTION
Use the path for qmake as a reference for finding the path to Qt binaries
with Qt 5.15.3 and no qtchooser installed.

Closes: https://bugs.gentoo.org/836343
Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>