### PR TITLE
x11-misc/albert: add dev-qt/qtgraphicaleffects:5 to RDEPEND

### DIFF
--- a/x11-misc/albert/albert-0.17.2-r1.ebuild
+++ b/x11-misc/albert/albert-0.17.2-r1.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 inherit cmake xdg-utils
 
@@ -41,6 +41,7 @@ RDEPEND="
 	dev-qt/qtcore:5
 	dev-qt/qtdbus:5
 	dev-qt/qtdeclarative:5
+	dev-qt/qtgraphicaleffects:5
 	dev-qt/qtgui:5
 	dev-qt/qtnetwork:5
 	dev-qt/qtsql:5[sqlite]


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/794928
