### PR TITLE
dev-games/poker-eval: fix HOMEPAGE, LICENSE

### DIFF
--- a/dev-games/poker-eval/poker-eval-138.0.ebuild
+++ b/dev-games/poker-eval/poker-eval-138.0.ebuild
@@ -1,13 +1,13 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-DESCRIPTION="A fast C library for evaluating poker hands"
-HOMEPAGE="http://gna.org/projects/pokersource/"
+DESCRIPTION="Fast C library for evaluating poker hands"
+HOMEPAGE="http://pokersource.sourceforge.net/"
 SRC_URI="http://download.gna.org/pokersource/sources/${P}.tar.gz"
 
-LICENSE="GPL-3"
+LICENSE="GPL-3+"
 SLOT="0"
 KEYWORDS="amd64 x86"
 


### PR DESCRIPTION
Hi,

This fixes the `HOMEPAGE` of poker-eval. However the `SRC_URI` is still broken - i couldn't find any replacement and sourceforge doesn't provide the files.

Package-Manager: Portage-3.0.30, Repoman-3.0.3
Signed-off-by: Michael Mair-Keimberger <mmk@levelnine.at>