### PR TITLE
net-libs/libotr: fix build with libgcrypt-1.10

### DIFF
--- a/net-libs/libotr/files/libotr-4.1.1-fix-build-with-libgcrypt-1.10.patch
+++ b/net-libs/libotr/files/libotr-4.1.1-fix-build-with-libgcrypt-1.10.patch
@@ -1,0 +1,11 @@
+https://bugs.gentoo.org/836572
+--- a/tests/regression/client/client.c
++++ b/tests/regression/client/client.c
+@@ -26,6 +26,7 @@
+ #include <stdlib.h>
+ #include <syscall.h>
+ #include <sys/epoll.h>
++#include <sys/socket.h>
+ #include <sys/types.h>
+ #include <sys/un.h>
+ #include <unistd.h>

--- a/net-libs/libotr/libotr-4.1.1.ebuild
+++ b/net-libs/libotr/libotr-4.1.1.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
 
 DESCRIPTION="(OTR) Messaging allows you to have private conversations over instant messaging"
 HOMEPAGE="https://otr.cypherpunks.ca"
@@ -10,21 +10,20 @@ SRC_URI="https://otr.cypherpunks.ca/${P}.tar.gz"
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos"
-IUSE=""
 
 RDEPEND="
 	dev-libs/libgcrypt:0=
 	dev-libs/libgpg-error:0="
 DEPEND="${RDEPEND}"
 
-src_configure() {
-	econf --disable-static
-}
+PATCHES=(
+	"${FILESDIR}/${PN}-4.1.1-fix-build-with-libgcrypt-1.10.patch"
+)
 
 src_install() {
 	default
 	dodoc UPGRADING
 
 	# no static archives, #465686
-	find "${D}" -name '*.la' -delete || die
+	find "${ED}" -name '*.la' -delete || die
 }


### PR DESCRIPTION
Signed-off-by: Christophe Lermytte <gentoo@lermytte.be>
Closes: https://bugs.gentoo.org/836572