### PR TITLE
games-fps/rott: EAPI8 bump, use HTTPS, fix calling cc directly

### DIFF
--- a/games-fps/rott/rott-1.1.2-r1.ebuild
+++ b/games-fps/rott/rott-1.1.2-r1.ebuild
@@ -1,24 +1,27 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
+
+inherit toolchain-funcs
 
 DESCRIPTION="Rise of the Triad for Linux!"
-HOMEPAGE="http://www.icculus.org/rott/"
-SRC_URI="http://www.icculus.org/rott/releases/${P}.tar.gz
+HOMEPAGE="https://www.icculus.org/rott/"
+SRC_URI="https://www.icculus.org/rott/releases/${P}.tar.gz
 	demo? ( http://filesingularity.timedoctor.org/swdata.zip )"
 
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
 IUSE="demo"
 
-RDEPEND="media-libs/libsdl[sound,joystick,video]
+RDEPEND="
+	media-libs/libsdl[sound,joystick,video]
 	media-libs/sdl-mixer"
 DEPEND="${RDEPEND}
 	app-arch/unzip"
 
-S=${WORKDIR}/${P}/rott
+S="${WORKDIR}/${P}/rott"
 
 src_prepare() {
 	default
@@ -30,6 +33,7 @@ src_prepare() {
 }
 
 src_compile() {
+	tc-export CC
 	emake -j1 \
 		EXTRACFLAGS="${CFLAGS} -DDATADIR=\\\"/usr/share/${PN}/\\\"" \
 		SHAREWARE=$(usex demo "1" "0")


### PR DESCRIPTION
Again, a simple EAPI bump, also fixes calling `cc` directly.

Package-Manager: Portage-3.0.30, Repoman-3.0.3
Signed-off-by: Michael Mair-Keimberger <mmk@levelnine.at>