### PR TITLE
media-libs/quarter: find qhelpgenerator without qtchooser

### DIFF
--- a/media-libs/quarter/files/quarter-1.1.0-find-qhelpgenerator-binary.patch
+++ b/media-libs/quarter/files/quarter-1.1.0-find-qhelpgenerator-binary.patch
@@ -1,0 +1,22 @@
+From 04994984239e18ea68af04734c4c8a1324bc0ac6 Mon Sep 17 00:00:00 2001
+From: Bernd Waibel <waebbl-gentoo@posteo.net>
+Date: Sat, 2 Apr 2022 15:00:42 +0200
+Subject: [PATCH] find qhelpgenerator binary
+
+Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -204,7 +204,9 @@ if(QUARTER_BUILD_DOCUMENTATION)
+     endif()
+   endif()
+   if(QUARTER_BUILD_DOC_QTHELP)
+-    find_program(QHG_LOCATION NAMES qhelpgenerator qhelpgenerator-qt5 DOC "Qt qhelpgenerator")
++    get_target_property(qt_qmake_location Qt5::qmake LOCATION)
++    get_filename_component(qt_bin_dir "${qt_qmake_location}" PATH)
++    find_program(QHG_LOCATION NAMES qhelpgenerator qhelpgenerator-qt5 DOC "Qt qhelpgenerator" HINTS "${qt_bin_dir}")
+     if(NOT QHG_LOCATION)
+       message(FATAL_ERROR "Missing program Qt qhelpgenerator")
+     else()
+-- 
+2.35.1
+

--- a/media-libs/quarter/metadata.xml
+++ b/media-libs/quarter/metadata.xml
@@ -5,6 +5,10 @@
     <email>reavertm@gentoo.org</email>
     <description>Feel free to maintain/fix</description>
   </maintainer>
+  <maintainer type="person" proxied="yes">
+    <email>waebbl-gentoo@posteo.net</email>
+    <name>Bernd Waibel</name>
+  </maintainer>
   <longdescription lang="en">
   Quarter is a light-weight glue library that provides seamless
   integration between Systems in Motions's Coin high-level 3D

--- a/media-libs/quarter/quarter-1.1.0-r1.ebuild
+++ b/media-libs/quarter/quarter-1.1.0-r1.ebuild
@@ -1,0 +1,71 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit cmake flag-o-matic
+
+MY_P=${P/quarter/Quarter}
+
+HOMEPAGE="https://github.com/coin3d/coin/wiki"
+DESCRIPTION="GUI binding for using Coin/Open Inventor with Qt"
+SRC_URI="https://github.com/coin3d/quarter/releases/download/${MY_P}/${P}-src.tar.gz"
+S="${WORKDIR}/quarter"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="debug designer doc man qthelp"
+
+REQUIRED_USE="
+	man? ( doc )
+	qthelp? ( doc )
+"
+
+RDEPEND="
+	dev-qt/qtcore:5
+	dev-qt/qtgui:5
+	dev-qt/qtopengl:5
+	dev-qt/qtwidgets:5
+	media-libs/coin
+	virtual/opengl
+	designer? ( dev-qt/designer:5 )
+"
+DEPEND="${RDEPEND}"
+BDEPEND="
+	virtual/pkgconfig
+	doc? (
+		app-doc/doxygen[dot]
+		qthelp? ( dev-qt/qthelp:5 )
+	)
+"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-1.1.0-cmake.patch
+	"${FILESDIR}"/${PN}-1.1.0-find-qhelpgenerator-binary.patch
+)
+
+DOCS=(AUTHORS ChangeLog NEWS README)
+
+src_prepare() {
+	cmake_src_prepare
+	sed -e 's|/lib$|/lib@LIB_SUFFIX@|' \
+		-i Quarter.pc.cmake.in || die
+}
+
+src_configure() {
+	use debug && append-cppflags -DQUARTER_DEBUG=1
+	local mycmakeargs=(
+		-DCMAKE_INSTALL_DOCDIR="${EPREFIX}/usr/share/doc/${PF}"
+		-DQUARTER_BUILD_SHARED_LIBS=ON
+		-DQUARTER_BUILD_PLUGIN=$(usex designer)
+		-DQUARTER_BUILD_EXAMPLES=OFF
+		-DQUARTER_BUILD_DOCUMENTATION=$(usex doc)
+		-DQUARTER_BUILD_INTERNAL_DOCUMENTATION=OFF
+		-DQUARTER_BUILD_DOC_MAN=$(usex man)
+		-DQUARTER_BUILD_DOC_QTHELP=$(usex qthelp)
+		-DQUARTER_BUILD_DOC_CHM=OFF
+		-DQUARTER_USE_QT5=ON
+	)
+	cmake_src_configure
+}


### PR DESCRIPTION
Update to EAPI 8
Fix pkgconfig file

Closes: https://bugs.gentoo.org/836340
Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>