### PR TITLE
app-accessibility/espeak-ng: add fix for pulseaudio access violation bug

### DIFF
--- a/app-accessibility/espeak-ng/espeak-ng-1.50-r1.ebuild
+++ b/app-accessibility/espeak-ng/espeak-ng-1.50-r1.ebuild
@@ -48,6 +48,9 @@ src_prepare() {
 }
 
 src_configure() {
+	# https://bugs.gentoo.org/836646
+	export PULSE_SERVER=""
+
 	local econf_args
 	econf_args=(
 		$(use_with async)

--- a/app-accessibility/espeak-ng/espeak-ng-1.50-r2.ebuild
+++ b/app-accessibility/espeak-ng/espeak-ng-1.50-r2.ebuild
@@ -51,6 +51,9 @@ src_prepare() {
 }
 
 src_configure() {
+	# https://bugs.gentoo.org/836646
+	export PULSE_SERVER=""
+
 	local econf_args
 	econf_args=(
 		$(use_with async)

--- a/app-accessibility/espeak-ng/espeak-ng-1.50-r3.ebuild
+++ b/app-accessibility/espeak-ng/espeak-ng-1.50-r3.ebuild
@@ -51,6 +51,9 @@ src_prepare() {
 }
 
 src_configure() {
+	# https://bugs.gentoo.org/836646
+	export PULSE_SERVER=""
+
 	local econf_args
 	econf_args=(
 		$(use_with async)

--- a/app-accessibility/espeak-ng/espeak-ng-1.50.ebuild
+++ b/app-accessibility/espeak-ng/espeak-ng-1.50.ebuild
@@ -48,6 +48,9 @@ src_prepare() {
 }
 
 src_configure() {
+	# https://bugs.gentoo.org/836646
+	export PULSE_SERVER=""
+
 	local econf_args
 	econf_args=(
 		$(use_with async)

--- a/app-accessibility/espeak-ng/espeak-ng-9999.ebuild
+++ b/app-accessibility/espeak-ng/espeak-ng-9999.ebuild
@@ -50,6 +50,9 @@ src_prepare() {
 }
 
 src_configure() {
+	# https://bugs.gentoo.org/836646
+	export PULSE_SERVER=""
+
 	local econf_args
 	econf_args=(
 		$(use_with async)


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/836646
Package-Manager: Portage-3.0.30, Repoman-3.0.3
Signed-off-by: Peter Alfredsen <crabbedhaloablution@icloud.com>