### PR TITLE
dev-lua: Update links to repositories migrated to lunarmodules org

### DIFF
--- a/dev-lua/ldoc/ldoc-1.4.6-r100.ebuild
+++ b/dev-lua/ldoc/ldoc-1.4.6-r100.ebuild
@@ -9,7 +9,7 @@ inherit lua-single
 
 DESCRIPTION="A LuaDoc-compatible documentation generation system"
 HOMEPAGE="https://stevedonovan.github.io/ldoc/"
-SRC_URI="https://github.com/stevedonovan/LDoc/archive/${PV}.tar.gz -> ${P}.tar.gz"
+SRC_URI="https://github.com/lunarmodules/LDoc/archive/${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0"

--- a/dev-lua/ldoc/metadata.xml
+++ b/dev-lua/ldoc/metadata.xml
@@ -3,6 +3,6 @@
 <pkgmetadata>
 	<!--maintainer-needed-->
 	<upstream>
-		<remote-id type="github">stevedonovan/LDoc</remote-id>
+		<remote-id type="github">lunarmodules/LDoc</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/dev-lua/luacheck/luacheck-0.25.0.ebuild
+++ b/dev-lua/luacheck/luacheck-0.25.0.ebuild
@@ -8,8 +8,8 @@ LUA_COMPAT=( lua5-{1..4} luajit )
 inherit lua toolchain-funcs
 
 DESCRIPTION="A tool for linting and static analysis of Lua code"
-HOMEPAGE="https://github.com/luarocks/luacheck"
-SRC_URI="https://github.com/luarocks/luacheck/archive/${PV}.tar.gz -> ${P}.tar.gz"
+HOMEPAGE="https://github.com/lunarmodules/luacheck"
+SRC_URI="https://github.com/lunarmodules/luacheck/archive/${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0"

--- a/dev-lua/luacheck/metadata.xml
+++ b/dev-lua/luacheck/metadata.xml
@@ -13,7 +13,7 @@
 		Luacheck itself is written in Lua and runs on all of mentioned Lua versions.
 	</longdescription>
 	<upstream>
-		<remote-id type="github">luarocks/luacheck</remote-id>
+		<remote-id type="github">lunarmodules/luacheck</remote-id>
 		<remote-id type="github">mpeterv/luacheck</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/dev-lua/luasocket/luasocket-3.0_rc1_p20200328-r103.ebuild
+++ b/dev-lua/luasocket/luasocket-3.0_rc1_p20200328-r103.ebuild
@@ -12,9 +12,9 @@ inherit lua toolchain-funcs
 DESCRIPTION="Networking support library for the Lua language"
 HOMEPAGE="
 	http://www.tecgraf.puc-rio.br/~diego/professional/luasocket/
-	https://github.com/diegonehab/luasocket
+	https://github.com/lunarmodules/luasocket
 "
-SRC_URI="https://github.com/diegonehab/${PN}/archive/${EGIT_COMMIT}.tar.gz -> ${P}.tar.gz"
+SRC_URI="https://github.com/lunarmodules/${PN}/archive/${EGIT_COMMIT}.tar.gz -> ${P}.tar.gz"
 S="${WORKDIR}/${MY_P}"
 
 LICENSE="MIT"

--- a/dev-lua/luasocket/metadata.xml
+++ b/dev-lua/luasocket/metadata.xml
@@ -14,6 +14,6 @@
 		<name>Conrad Kostecki</name>
 	</maintainer>
 	<upstream>
-		<remote-id type="github">diegonehab/luasocket</remote-id>
+		<remote-id type="github">lunarmodules/luasocket</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/dev-lua/penlight/metadata.xml
+++ b/dev-lua/penlight/metadata.xml
@@ -17,6 +17,6 @@
 		on tables and sequences.
 	</longdescription>
 	<upstream>
-		<remote-id type="github">Tieske/Penlight</remote-id>
+		<remote-id type="github">lunarmodules/Penlight</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/dev-lua/penlight/penlight-1.12.0.ebuild
+++ b/dev-lua/penlight/penlight-1.12.0.ebuild
@@ -10,7 +10,7 @@ inherit lua toolchain-funcs
 
 DESCRIPTION="Lua utility libraries loosely based on the Python standard libraries"
 HOMEPAGE="https://github.com/lunarmodules/Penlight"
-SRC_URI="https://github.com/Tieske/${MY_PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
+SRC_URI="https://github.com/lunarmodules/${MY_PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
 S="${WORKDIR}/${MY_PN}-${PV}"
 
 LICENSE="MIT"


### PR DESCRIPTION
No checksums were harmed in the making of this commit. All of these URL updates are links to repositories that have migrated to a (relatively) new GitHub org namespace.
