### PR TITLE
app-emulation/libvirt: Drop ncurses dependency and move net-libs/rpcs…

### DIFF
--- a/app-emulation/libvirt/libvirt-7.10.0-r3.ebuild
+++ b/app-emulation/libvirt/libvirt-7.10.0-r3.ebuild
@@ -48,6 +48,7 @@ BDEPEND="
 	dev-perl/XML-XPath
 	dev-python/docutils
 	virtual/pkgconfig
+	net-libs/rpcsvc-proto
 	bash-completion? ( >=app-shells/bash-completion-2.0 )
 	verify-sig? ( sec-keys/openpgp-keys-libvirt )"
 
@@ -67,12 +68,10 @@ RDEPEND="
 	>=net-libs/gnutls-1.0.25:0=
 	net-libs/libssh2
 	net-libs/libtirpc
-	net-libs/rpcsvc-proto
 	>=net-misc/curl-7.18.0
 	sys-apps/dbus
 	sys-apps/dmidecode
 	sys-devel/gettext
-	sys-libs/ncurses:0=
 	sys-libs/readline:=
 	virtual/acl
 	apparmor? ( sys-libs/libapparmor )

--- a/app-emulation/libvirt/libvirt-7.7.0-r2.ebuild
+++ b/app-emulation/libvirt/libvirt-7.7.0-r2.ebuild
@@ -48,6 +48,7 @@ BDEPEND="
 	dev-perl/XML-XPath
 	dev-python/docutils
 	virtual/pkgconfig
+	net-libs/rpcsvc-proto
 	bash-completion? ( >=app-shells/bash-completion-2.0 )
 	verify-sig? ( sec-keys/openpgp-keys-libvirt )"
 
@@ -67,12 +68,10 @@ RDEPEND="
 	>=net-libs/gnutls-1.0.25:0=
 	net-libs/libssh2
 	net-libs/libtirpc
-	net-libs/rpcsvc-proto
 	>=net-misc/curl-7.18.0
 	sys-apps/dbus
 	sys-apps/dmidecode
 	sys-devel/gettext
-	sys-libs/ncurses:0=
 	sys-libs/readline:=
 	virtual/acl
 	apparmor? ( sys-libs/libapparmor )

--- a/app-emulation/libvirt/libvirt-8.0.0-r2.ebuild
+++ b/app-emulation/libvirt/libvirt-8.0.0-r2.ebuild
@@ -48,6 +48,7 @@ BDEPEND="
 	dev-perl/XML-XPath
 	dev-python/docutils
 	virtual/pkgconfig
+	net-libs/rpcsvc-proto
 	bash-completion? ( >=app-shells/bash-completion-2.0 )
 	verify-sig? ( sec-keys/openpgp-keys-libvirt )"
 
@@ -67,12 +68,10 @@ RDEPEND="
 	>=net-libs/gnutls-1.0.25:0=
 	net-libs/libssh2
 	net-libs/libtirpc
-	net-libs/rpcsvc-proto
 	>=net-misc/curl-7.18.0
 	sys-apps/dbus
 	sys-apps/dmidecode
 	sys-devel/gettext
-	sys-libs/ncurses:0=
 	sys-libs/readline:=
 	virtual/acl
 	apparmor? ( sys-libs/libapparmor )

--- a/app-emulation/libvirt/libvirt-8.1.0.ebuild
+++ b/app-emulation/libvirt/libvirt-8.1.0.ebuild
@@ -50,6 +50,7 @@ BDEPEND="
 	dev-perl/XML-XPath
 	dev-python/docutils
 	virtual/pkgconfig
+	net-libs/rpcsvc-proto
 	bash-completion? ( >=app-shells/bash-completion-2.0 )
 	verify-sig? ( sec-keys/openpgp-keys-libvirt )"
 
@@ -69,12 +70,10 @@ RDEPEND="
 	>=net-libs/gnutls-1.0.25:0=
 	net-libs/libssh2
 	net-libs/libtirpc
-	net-libs/rpcsvc-proto
 	>=net-misc/curl-7.18.0
 	sys-apps/dbus
 	sys-apps/dmidecode
 	sys-devel/gettext
-	sys-libs/ncurses:0=
 	sys-libs/readline:=
 	virtual/acl
 	apparmor? ( sys-libs/libapparmor )

--- a/app-emulation/libvirt/libvirt-8.2.0.ebuild
+++ b/app-emulation/libvirt/libvirt-8.2.0.ebuild
@@ -47,6 +47,7 @@ BDEPEND="
 	dev-perl/XML-XPath
 	dev-python/docutils
 	virtual/pkgconfig
+	net-libs/rpcsvc-proto
 	bash-completion? ( >=app-shells/bash-completion-2.0 )
 	verify-sig? ( sec-keys/openpgp-keys-libvirt )"
 
@@ -65,12 +66,10 @@ RDEPEND="
 	>=net-analyzer/openbsd-netcat-1.105-r1
 	>=net-libs/gnutls-3.2.0:=
 	net-libs/libtirpc:=
-	net-libs/rpcsvc-proto
 	>=net-misc/curl-7.18.0
 	sys-apps/dbus
 	sys-apps/dmidecode
 	sys-devel/gettext
-	sys-libs/ncurses:=
 	>=sys-libs/readline-7.0:=
 	virtual/acl
 	apparmor? ( sys-libs/libapparmor )

--- a/app-emulation/libvirt/libvirt-9999.ebuild
+++ b/app-emulation/libvirt/libvirt-9999.ebuild
@@ -47,6 +47,7 @@ BDEPEND="
 	dev-perl/XML-XPath
 	dev-python/docutils
 	virtual/pkgconfig
+	net-libs/rpcsvc-proto
 	bash-completion? ( >=app-shells/bash-completion-2.0 )
 	verify-sig? ( sec-keys/openpgp-keys-libvirt )"
 
@@ -65,12 +66,10 @@ RDEPEND="
 	>=net-analyzer/openbsd-netcat-1.105-r1
 	>=net-libs/gnutls-3.2.0:=
 	net-libs/libtirpc:=
-	net-libs/rpcsvc-proto
 	>=net-misc/curl-7.18.0
 	sys-apps/dbus
 	sys-apps/dmidecode
 	sys-devel/gettext
-	sys-libs/ncurses:=
 	>=sys-libs/readline-7.0:=
 	virtual/acl
 	apparmor? ( sys-libs/libapparmor )


### PR DESCRIPTION
…vc-proto dependency

Libvirt never actually used ncurses as mentioned in the upstream
commit:

  https://gitlab.com/libvirt/libvirt/-/commit/588d2834d7997a97ffd93ec138acef488883aab1

And net-libs/rpcsvc-proto dependency is needed only when building
libvirt (that's when rpcgen is ran to generate some source
files). It's not needed at runtime.

Therefore, remove sys-libs/ncurses from RDEPEND and move
net-libs/rpcsvc-proto into BDEPEND, in all ebuilds.

Signed-off-by: Michal Privoznik <mprivozn@redhat.com>