### PR TITLE
net-p2p/transmission: keyword 3.00-r1 for ~riscv

### DIFF
--- a/net-libs/libnatpmp/libnatpmp-20150609.ebuild
+++ b/net-libs/libnatpmp/libnatpmp-20150609.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ SRC_URI="http://miniupnp.free.fr/files/download.php?file=${P}.tar.gz -> ${P}.tar
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="amd64 arm ~arm64 ~hppa ~mips ppc ppc64 sparc x86"
+KEYWORDS="amd64 arm ~arm64 ~hppa ~mips ppc ppc64 ~riscv sparc x86"
 
 PATCHES=( "${FILESDIR}"/${PN}-20150609-gentoo.patch )
 

--- a/net-p2p/transmission/transmission-3.00-r1.ebuild
+++ b/net-p2p/transmission/transmission-3.00-r1.ebuild
@@ -10,7 +10,7 @@ if [[ ${PV} == 9999 ]]; then
 	EGIT_REPO_URI="https://github.com/transmission/transmission"
 else
 	SRC_URI="https://dev.gentoo.org/~floppym/dist/${P}.tar.xz"
-	KEYWORDS="amd64 ~arm ~arm64 ~mips ppc ppc64 x86 ~amd64-linux"
+	KEYWORDS="amd64 ~arm ~arm64 ~mips ppc ppc64 ~riscv x86 ~amd64-linux"
 fi
 
 DESCRIPTION="A fast, easy, and free BitTorrent client"


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/836747