### PR TITLE
sys-libs/zlib: Update archive URL for 1.2.11

### DIFF
--- a/sys-libs/zlib/zlib-1.2.11-r4.ebuild
+++ b/sys-libs/zlib/zlib-1.2.11-r4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -14,6 +14,7 @@ CYGWINPATCHES=(
 DESCRIPTION="Standard (de)compression library"
 HOMEPAGE="https://zlib.net/"
 SRC_URI="https://zlib.net/${P}.tar.gz
+	https://zlib.net/fossils/${P}.tar.gz
 	http://www.gzip.org/zlib/${P}.tar.gz
 	http://www.zlib.net/current/beta/${P}.tar.gz
 	elibc_Cygwin? ( ${CYGWINPATCHES[*]} )"

--- a/sys-libs/zlib/zlib-1.2.11-r5.ebuild
+++ b/sys-libs/zlib/zlib-1.2.11-r5.ebuild
@@ -14,6 +14,7 @@ CYGWINPATCHES=(
 DESCRIPTION="Standard (de)compression library"
 HOMEPAGE="https://zlib.net/"
 SRC_URI="https://zlib.net/${P}.tar.gz
+	https://zlib.net/fossils/${P}.tar.gz
 	http://www.gzip.org/zlib/${P}.tar.gz
 	http://www.zlib.net/current/beta/${P}.tar.gz
 	elibc_Cygwin? ( ${CYGWINPATCHES[*]} )"


### PR DESCRIPTION
1.2.11 tarball is not available at https://zlib.net/${P}, so fetch it
  from https://zlib.net/fossils instead

```
>>> Downloading 'https://zlib.net/zlib-1.2.11.tar.gz'
--2022-04-04 13:07:42--  https://zlib.net/zlib-1.2.11.tar.gz
Resolving zlib.net... 85.187.148.2
Connecting to zlib.net|85.187.148.2|:443... connected.
HTTP request sent, awaiting response... 404 Not Found
```

Signed-off-by: Jakov Smolić <jsmolic@gentoo.org>