### PR TITLE
Add secadm module to build.

### DIFF
--- a/sec-policy/selinux-base-policy/selinux-base-policy-2.20220106-r1.ebuild
+++ b/sec-policy/selinux-base-policy/selinux-base-policy-2.20220106-r1.ebuild
@@ -27,7 +27,7 @@ BDEPEND="
 	sys-apps/checkpolicy
 	sys-devel/m4"
 
-MODS="application authlogin bootloader clock consoletype cron dmesg fstools getty hostname init iptables libraries locallogin logging lvm miscfiles modutils mount mta netutils nscd portage raid rsync selinuxutil setrans ssh staff storage su sysadm sysnetwork systemd tmpfiles udev userdomain usermanage unprivuser xdg"
+MODS="application authlogin bootloader clock consoletype cron dmesg fstools getty hostname init iptables libraries locallogin logging lvm miscfiles modutils mount mta netutils nscd portage raid rsync secadm selinuxutil setrans ssh staff storage su sysadm sysnetwork systemd tmpfiles udev userdomain usermanage unprivuser xdg"
 DEL_MODS="hotplug"
 LICENSE="GPL-2"
 SLOT="0"

--- a/sec-policy/selinux-base-policy/selinux-base-policy-2.20220106-r2.ebuild
+++ b/sec-policy/selinux-base-policy/selinux-base-policy-2.20220106-r2.ebuild
@@ -27,7 +27,7 @@ BDEPEND="
 	sys-apps/checkpolicy
 	sys-devel/m4"
 
-MODS="application authlogin bootloader clock consoletype cron dmesg fstools getty hostname init iptables libraries locallogin logging lvm miscfiles modutils mount mta netutils nscd portage raid rsync selinuxutil setrans ssh staff storage su sysadm sysnetwork systemd tmpfiles udev userdomain usermanage unprivuser xdg"
+MODS="application authlogin bootloader clock consoletype cron dmesg fstools getty hostname init iptables libraries locallogin logging lvm miscfiles modutils mount mta netutils nscd portage raid rsync secadm selinuxutil setrans ssh staff storage su sysadm sysnetwork systemd tmpfiles udev userdomain usermanage unprivuser xdg"
 DEL_MODS="hotplug"
 LICENSE="GPL-2"
 SLOT="0"

--- a/sec-policy/selinux-base-policy/selinux-base-policy-2.20220106-r3.ebuild
+++ b/sec-policy/selinux-base-policy/selinux-base-policy-2.20220106-r3.ebuild
@@ -27,7 +27,7 @@ BDEPEND="
 	sys-apps/checkpolicy
 	sys-devel/m4"
 
-MODS="application authlogin bootloader clock consoletype cron dmesg fstools getty hostname init iptables libraries locallogin logging lvm miscfiles modutils mount mta netutils nscd portage raid rsync selinuxutil setrans ssh staff storage su sysadm sysnetwork systemd tmpfiles udev userdomain usermanage unprivuser xdg"
+MODS="application authlogin bootloader clock consoletype cron dmesg fstools getty hostname init iptables libraries locallogin logging lvm miscfiles modutils mount mta netutils nscd portage raid rsync secadm selinuxutil setrans ssh staff storage su sysadm sysnetwork systemd tmpfiles udev userdomain usermanage unprivuser xdg"
 DEL_MODS="hotplug"
 LICENSE="GPL-2"
 SLOT="0"

--- a/sec-policy/selinux-base-policy/selinux-base-policy-9999.ebuild
+++ b/sec-policy/selinux-base-policy/selinux-base-policy-9999.ebuild
@@ -27,7 +27,7 @@ BDEPEND="
 	sys-apps/checkpolicy
 	sys-devel/m4"
 
-MODS="application authlogin bootloader clock consoletype cron dmesg fstools getty hostname init iptables libraries locallogin logging lvm miscfiles modutils mount mta netutils nscd portage raid rsync selinuxutil setrans ssh staff storage su sysadm sysnetwork systemd tmpfiles udev userdomain usermanage unprivuser xdg"
+MODS="application authlogin bootloader clock consoletype cron dmesg fstools getty hostname init iptables libraries locallogin logging lvm miscfiles modutils mount mta netutils nscd portage raid rsync secadm selinuxutil setrans ssh staff storage su sysadm sysnetwork systemd tmpfiles udev userdomain usermanage unprivuser xdg"
 DEL_MODS="hotplug"
 LICENSE="GPL-2"
 SLOT="0"


### PR DESCRIPTION
I believe secadm module is missing.
There is secadm_r in system, but without context:
staff_u:secadm_r:secadm_t:s0-s15:c0.c1023 is not a valid context

In patches (https://dev.gentoo.org/~perfinion/patches/${PN}/patchbundle-${PN}-${PVR}.tar.bz2") I can see version bump for secadm module:
+++ refpolicy/policy/modules/roles/secadm.te    2021-11-20 18:58:38.218997258 -0800

It goes further to missing aide module which I would also like to include.




Signed-off-by: Grzegorz Filo <gf578@wp.pl>