### PR TITLE
dev-java/antlr-runtime: Enable tests for 4.9.3

### DIFF
--- a/dev-java/antlr-runtime/antlr-runtime-4.9.3.ebuild
+++ b/dev-java/antlr-runtime/antlr-runtime-4.9.3.ebuild
@@ -3,13 +3,9 @@
 
 EAPI=8
 
-# Without annotation processing using runtime-testsuite/processors,
-# the tests are bound to fail.  However, the annotation processor
-# has been dropped from the 'master' branch as of January 2022, so
-# when updating this package to a new upstream version, please
-# check if it is possible to enable the tests and pass them.
-JAVA_PKG_IUSE="doc source"
+JAVA_PKG_IUSE="doc source test"
 MAVEN_ID="org.antlr:antlr4-runtime:4.9.3"
+JAVA_TESTING_FRAMEWORKS="junit-4"
 
 inherit java-pkg-2 java-pkg-simple
 
@@ -26,6 +22,10 @@ KEYWORDS="amd64 ~arm arm64 ppc64 x86"
 
 DEPEND="
 	>=virtual/jdk-1.8:*
+	test? (
+		~dev-java/antlr-tool-${PV}:${SLOT}
+		dev-java/jol-core:0
+	)
 "
 
 RDEPEND="
@@ -35,3 +35,96 @@ RDEPEND="
 S="${WORKDIR}/${MY_PN}4-${PV}"
 
 JAVA_SRC_DIR="runtime/Java/src"
+
+JAVA_TEST_GENTOO_CLASSPATH="
+	junit-4
+	antlr-tool-${SLOT}
+	jol-core
+"
+JAVA_TEST_SRC_DIR=(
+	runtime-testsuite/test
+	runtime-testsuite/annotations
+)
+JAVA_TEST_RESOURCE_DIRS=(
+	runtime-testsuite/resources
+)
+
+src_prepare() {
+	java-pkg_clean
+	eapply "${FILESDIR}/${PV}-test-fixes.patch"
+	java-pkg-2_src_prepare
+}
+
+src_test() {
+	# Build classpath for tests
+	# The JAR created during src_compile must appear in the classpath *before*
+	# any dependencies to ensure that *it* is the JAR being tested; otherwise,
+	# because the test suite depends on antlr-tool, which depends on this
+	# package, the copy of this package's JAR installed on the system would be
+	# tested instead when it appears earlier in the classpath, which might
+	# cause test failures when the version being built differs from the version
+	# already installed on the system, like https://bugs.gentoo.org/834138
+	local CP="${S}/${JAVA_JAR_FILENAME}"
+	local test_dep res_dir
+	for test_dep in ${JAVA_TEST_GENTOO_CLASSPATH}; do
+		CP+=":$(java-pkg_getjars --with-dependencies "${test_dep}")"
+	done
+	for res_dir in "${JAVA_TEST_RESOURCE_DIRS[@]}"; do
+		CP+=":${res_dir}"
+	done
+
+	pushd "${JAVA_TEST_SRC_DIR[0]}" > /dev/null ||
+		die "Failed to enter test source directory for ${PN}"
+
+	einfo "Removing tests for non-Java runtimes ..."
+	find org/antlr/v4/test/runtime/* -maxdepth 0 -type d \
+		-not -name category -not -name descriptors -not -name java \
+		-exec einfo "  {}" \; -exec rm -r "{}" + ||
+		die "Failed to remove tests for non-Java runtimes"
+
+	einfo "Generating ANTLR 4 parsers for tests ..."
+	local java_exe="$(java-config -J)"
+	local g4_files=( $(find * -name "*.g4") )
+	local file
+	for file in "${g4_files[@]}"; do
+		local java_pkg="${file%/*.g4}"
+		java_pkg="${java_pkg//\//.}"
+		"${java_exe}" -cp "${CP}" org.antlr.v4.Tool \
+			-visitor -package "${java_pkg}" "${file}" ||
+			die "Failed to generate ANTLR 4 parser from ${file}"
+	done
+
+	# Create a list of tests to run
+	# https://github.com/antlr/antlr4/blob/4.9.3/runtime-testsuite/pom.xml#L100
+	# Excluding classes with "No runnable methods"
+	local TESTS=$(find * -type f -name "Test*.java" \
+		-not -name "TestContext.java" \
+		-not -name "TestOutputReading.java"
+	)
+	TESTS="${TESTS//.java}"
+	TESTS="${TESTS//\//.}"
+
+	popd > /dev/null || die "Failed to leave test source directory for ${PN}"
+
+	local classes="target/classes"
+
+	# Compile the annotation processor of @CommentHasStringValue
+	# before the test sources (requires tools.jar)
+	ejavac -d "${classes}" -cp "${CP}:$(java-config -t)" \
+		$(find runtime-testsuite/{annotations,processors} -name "*.java")
+	local processor_cp="${classes}:runtime-testsuite/processors/resources"
+
+	# Compile Java test sources, and process @CommentHasStringValue
+	# annotations at the same time
+	local javac_extra_args=()
+	if ver_test "$(java-config -g PROVIDES_VERSION)" -ge 17; then
+		javac_extra_args+=(
+			-J--add-opens=jdk.compiler/com.sun.tools.javac.{main,model,tree,util}=ALL-UNNAMED
+		)
+	fi
+	ejavac -d "${classes}" -cp "${CP}:${processor_cp}" \
+		"${javac_extra_args[@]}" \
+		$(find "${JAVA_TEST_SRC_DIR[@]}" -name "*.java")
+
+	ejunit4 -classpath "${classes}:${CP}" ${TESTS}
+}

--- a/dev-java/antlr-runtime/files/4.9.3-test-fixes.patch
+++ b/dev-java/antlr-runtime/files/4.9.3-test-fixes.patch
@@ -1,0 +1,26 @@
+From 3eabbddff69dcbcaf9a59f407cc8bef4be8e215b Mon Sep 17 00:00:00 2001
+From: Yuan Liao <liaoyuan@gmail.com>
+Date: Thu, 3 Feb 2022 11:51:53 -0800
+Subject: [PATCH] Use 1.8 as javac -source/-target for running tests on Java 17
+
+Signed-off-by: Yuan Liao <liaoyuan@gmail.com>
+---
+ .../test/org/antlr/v4/test/runtime/java/BaseJavaTest.java       | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/runtime-testsuite/test/org/antlr/v4/test/runtime/java/BaseJavaTest.java b/runtime-testsuite/test/org/antlr/v4/test/runtime/java/BaseJavaTest.java
+index cc03bdc11..82061135e 100644
+--- a/runtime-testsuite/test/org/antlr/v4/test/runtime/java/BaseJavaTest.java
++++ b/runtime-testsuite/test/org/antlr/v4/test/runtime/java/BaseJavaTest.java
+@@ -137,7 +137,7 @@ public class BaseJavaTest extends BaseRuntimeTestSupport implements RuntimeTestS
+ 			fileManager.getJavaFileObjectsFromFiles(files);
+ 
+ 		Iterable<String> compileOptions =
+-			Arrays.asList("-g", "-source", "1.6", "-target", "1.6", "-implicit:class", "-Xlint:-options", "-d", getTempDirPath(), "-cp", getTempDirPath() + PATH_SEP + CLASSPATH);
++			Arrays.asList("-g", "-source", "1.8", "-target", "1.8", "-implicit:class", "-Xlint:-options", "-d", getTempDirPath(), "-cp", getTempDirPath() + PATH_SEP + CLASSPATH);
+ 
+ 		JavaCompiler.CompilationTask task =
+ 			compiler.getTask(null, fileManager, null, compileOptions, null,
+-- 
+2.34.1
+


### PR DESCRIPTION
The tests were not enabled when I wrote the initial version of this ebuild because they required use of an annotation processor, which I did not know how to handle.  Now, with the knowledge on annotation processor invocation I have gained from fixing the missing files issue of dev-java/log4j-core, I am able to let this ebuild run ANTLR runtime test suite's annotation processor and hence enable its tests too.