### PR TITLE
media-gfx/freecad: add option to build designer plugin

### DIFF
--- a/media-gfx/freecad/freecad-9999.ebuild
+++ b/media-gfx/freecad/freecad-9999.ebuild
@@ -29,10 +29,9 @@ fi
 # examples are licensed CC-BY-SA (without note of specific version)
 LICENSE="LGPL-2 CC-BY-SA-4.0"
 SLOT="0"
-IUSE="debug headless pcl test"
-RESTRICT="!test? ( test )"
+IUSE="debug designer headless test"
 
-FREECAD_EXPERIMENTAL_MODULES="cloud plot ship"
+FREECAD_EXPERIMENTAL_MODULES="cloud pcl plot ship"
 FREECAD_STABLE_MODULES="addonmgr fem idf image inspection material
 	openscad part-design path points raytracing robot show surface
 	techdraw tux"
@@ -44,6 +43,8 @@ for module in ${FREECAD_EXPERIMENTAL_MODULES}; do
 	IUSE="${IUSE} ${module}"
 done
 unset module
+
+RESTRICT="!test? ( test )"
 
 RDEPEND="
 	${PYTHON_DEPS}
@@ -156,6 +157,7 @@ src_configure() {
 		-DBUILD_CLOUD=$(usex cloud)
 		-DBUILD_COMPLETE=OFF					# deprecated
 		-DBUILD_DRAFT=ON
+		-DBUILD_DESIGNER_PLUGIN=$(usex designer)
 		-DBUILD_DRAWING=ON
 		-DBUILD_ENABLE_CXX_STD:STRING="C++17"	# needed for current git master
 		-DBUILD_FEM=$(usex fem)

--- a/media-gfx/freecad/metadata.xml
+++ b/media-gfx/freecad/metadata.xml
@@ -18,6 +18,10 @@
 			Build the Cloud workbench, to access cloud providers (mostly
 			Amazon S3).
 		</flag>
+		<flag name="designer">
+			Build and install the Qt designer plugin, so the FreeCAD widgets
+			can be used from within designer.
+		</flag>
 		<flag name="drawing">
 			Build the Drawing workbench, a predecessor to the TechDraw workbench.
 			Users are encouraged to learn how to use the TechDraw workbench and


### PR DESCRIPTION
Add a USE flag to build and install the designer plugin of FreeCAD,
to be used from within the Qt designer application. The widgets are
prefixed with Gui:: within designer.

See https://forum.freecadweb.org/viewtopic.php?f=10&t=67706 and
https://github.com/FreeCAD/FreeCAD/pull/6711

Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>