### PR TITLE
app-emulation/virt-manager: add fix for setuptools-61 b0rkage

### DIFF
--- a/app-emulation/virt-manager/files/virt-manager-4.0.0-setuptools-61-fix.patch
+++ b/app-emulation/virt-manager/files/virt-manager-4.0.0-setuptools-61-fix.patch
@@ -1,0 +1,34 @@
+From c6fc4524d4448259ea85f93f85898b64a4380154 Mon Sep 17 00:00:00 2001
+From: Peter Alfredsen <crabbedhaloablution@icloud.com>
+Date: Tue, 5 Apr 2022 22:04:20 +0200
+Subject: [PATCH] setup: add bits for setuptools-61
+
+Quoting https://github.com/pypa/setuptools/issues/3227
+"Setuptools >= 61, intentionally changes the way packages are built in the
+ sensec that it will try to find files and fail if something is weird.
+
+ Empty packages (like this one), are asked to explicitly add packages=[]
+ to their configuration.
+
+ This intentional change in behaviour is described in
+ https://setuptools.pypa.io/en/latest/history.html#v61-0-0."
+
+Bug: https://bugs.gentoo.org/836645
+Signed-off-by: Peter Alfredsen <crabbedhaloablution@icloud.com>
+---
+ setup.py | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/setup.py b/setup.py
+index e95acd39..7e47e7c7 100755
+--- a/setup.py
++++ b/setup.py
+@@ -547,4 +547,5 @@ setuptools.setup(
+     },
+ 
+     distclass=VMMDistribution,
++    packages=[],
+ )
+-- 
+2.35.1
+

--- a/app-emulation/virt-manager/virt-manager-4.0.0.ebuild
+++ b/app-emulation/virt-manager/virt-manager-4.0.0.ebuild
@@ -58,6 +58,7 @@ distutils_enable_tests pytest
 
 src_prepare() {
 	distutils-r1_src_prepare
+	eapply "${FILESDIR}/virt-manager-4.0.0-setuptools-61-fix.patch"
 }
 
 python_configure() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/836645
Package-Manager: Portage-3.0.30, Repoman-3.0.3
Signed-off-by: Peter Alfredsen <crabbedhaloablution@icloud.com>