### PR TITLE
vim-{doc,plugin}.eclass: support EAPI 8

### DIFF
--- a/eclass/vim-doc.eclass
+++ b/eclass/vim-doc.eclass
@@ -1,10 +1,10 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: vim-doc.eclass
 # @MAINTAINER:
 # vim@gentoo.org
-# @SUPPORTED_EAPIS: 6 7
+# @SUPPORTED_EAPIS: 6 7 8
 # @BLURB: Eclass for vim{,-plugin}.eclass to update documentation tags.
 # @DESCRIPTION:
 # This eclass is used by vim.eclass and vim-plugin.eclass to update
@@ -16,8 +16,8 @@
 # DEPEND in vim-plugin or by whatever version of vim is being
 # installed by the eclass.
 
-case ${EAPI:-0} in
-	[67]) ;;
+case ${EAPI} in
+	6|7|8) ;;
 	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
 
@@ -30,12 +30,12 @@ update_vim_helptags() {
 	# This is where vim plugins are installed
 	vimfiles="${EROOT}"/usr/share/vim/vimfiles
 
-	if [[ $PN != vim-core ]]; then
+	if [[ ${PN} != vim-core ]]; then
 		# Find a suitable vim binary for updating tags :helptags
 		vim=$(type -P vim 2>/dev/null)
-		[[ -z "$vim" ]] && vim=$(type -P gvim 2>/dev/null)
-		[[ -z "$vim" ]] && vim=$(type -P kvim 2>/dev/null)
-		if [[ -z "$vim" ]]; then
+		[[ -z "${vim}" ]] && vim=$(type -P gvim 2>/dev/null)
+		[[ -z "${vim}" ]] && vim=$(type -P kvim 2>/dev/null)
+		if [[ -z "${vim}" ]]; then
 			ewarn "No suitable vim binary to rebuild documentation tags"
 		fi
 	fi
@@ -43,39 +43,39 @@ update_vim_helptags() {
 	# Make vim not try to connect to X. See :help gui-x11-start
 	# in vim for how this evil trickery works.
 	if [[ -n "${vim}" ]] ; then
-		ln -s "${vim}" "${T}/tagvim"
+		ln -s "${vim}" "${T}/tagvim" || die
 		vim="${T}/tagvim"
 	fi
 
 	# Install the documentation symlinks into the versioned vim
 	# directory and run :helptags
 	for d in "${EROOT%/}"/usr/share/vim/vim[0-9]*; do
-		[[ -d "$d/doc" ]] || continue	# catch a failed glob
+		[[ -d "${d}/doc" ]] || continue	# catch a failed glob
 
 		# Remove links, and possibly remove stale dirs
-		find $d/doc -name \*.txt -type l | while read s; do
-			[[ $(readlink "$s") = $vimfiles/* ]] && rm -f "$s"
+		find ${d}/doc -name \*.txt -type l | while read s; do
+			[[ $(readlink "${s}") = $vimfiles/* ]] && rm -f "${s}" || die
 		done
-		if [[ -f "$d/doc/tags" && $(find "$d" | wc -l | tr -d ' ') = 3 ]]; then
+		if [[ -f "${d}/doc/tags" && $(find "${d}" | wc -l | tr -d ' ') = 3 ]]; then
 			# /usr/share/vim/vim61
 			# /usr/share/vim/vim61/doc
 			# /usr/share/vim/vim61/doc/tags
-			einfo "Removing $d"
-			rm -r "$d"
+			einfo "Removing ${d}"
+			rm -r "${d}" || die
 			continue
 		fi
 
 		# Re-create / install new links
-		if [[ -d $vimfiles/doc ]]; then
-			ln -s $vimfiles/doc/*.txt $d/doc 2>/dev/null
+		if [[ -d "${vimfiles}"/doc ]]; then
+			ln -s "${vimfiles}"/doc/*.txt "${d}/doc" 2>/dev/null || die
 		fi
 
 		# Update tags; need a vim binary for this
-		if [[ -n "$vim" ]]; then
-			einfo "Updating documentation tags in $d"
-			DISPLAY= $vim -u NONE -U NONE -T xterm -X -n -f \
+		if [[ -n "${vim}" ]]; then
+			einfo "Updating documentation tags in ${d}"
+			DISPLAY= "${vim}" -u NONE -U NONE -T xterm -X -n -f \
 				'+set nobackup nomore' \
-				"+helptags $d/doc" \
+				"+helptags ${d}/doc" \
 				'+qa!' </dev/null &>/dev/null
 		fi
 	done

--- a/eclass/vim-plugin.eclass
+++ b/eclass/vim-plugin.eclass
@@ -1,10 +1,10 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: vim-plugin.eclass
 # @MAINTAINER:
 # vim@gentoo.org
-# @SUPPORTED_EAPIS: 6 7
+# @SUPPORTED_EAPIS: 6 7 8
 # @BLURB: used for installing vim plugins
 # @DESCRIPTION:
 # This eclass simplifies installation of app-vim plugins into
@@ -13,12 +13,11 @@
 # documentation, for which we make a special case via vim-doc.eclass.
 
 case ${EAPI} in
-	6|7);;
-	*) die "EAPI ${EAPI:-0} unsupported (too old)";;
+	6|7|8);;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} unsupported (too old)";;
 esac
 
 inherit vim-doc
-EXPORT_FUNCTIONS src_install pkg_postinst pkg_postrm
 
 VIM_PLUGIN_VIM_VERSION="${VIM_PLUGIN_VIM_VERSION:-7.3}"
 
@@ -32,13 +31,13 @@ fi
 SLOT="0"
 
 # @FUNCTION: vim-plugin_src_install
+# @USAGE:
 # @DESCRIPTION:
 # Overrides the default src_install phase. In order, this function:
 # * fixes file permission across all files in ${S}.
 # * installs help and documentation files.
 # * installs all files in "${ED}"/usr/share/vim/vimfiles.
 vim-plugin_src_install() {
-	has "${EAPI:-0}" 0 1 2 && ! use prefix && ED="${D}"
 
 	# Install non-vim-help-docs
 	einstalldocs
@@ -53,6 +52,7 @@ vim-plugin_src_install() {
 }
 
 # @FUNCTION: vim-plugin_pkg_postinst
+# @USAGE:
 # @DESCRIPTION:
 # Overrides the pkg_postinst phase for this eclass.
 # The following functions are called:
@@ -71,7 +71,6 @@ vim-plugin_pkg_postinst() {
 # This function calls the update_vim_helptags and update_vim_afterscripts
 # functions and eventually removes a bunch of empty directories.
 vim-plugin_pkg_postrm() {
-	has "${EAPI:-0}" 0 1 2 && ! use prefix && EPREFIX=
 	update_vim_helptags		# from vim-doc
 	update_vim_afterscripts	# see below
 
@@ -82,12 +81,11 @@ vim-plugin_pkg_postrm() {
 }
 
 # @FUNCTION: update_vim_afterscripts
+# @USAGE:
 # @DESCRIPTION:
 # Creates scripts in /usr/share/vim/vimfiles/after/*
 # comprised of the snippets in /usr/share/vim/vimfiles/after/*/*.d
 update_vim_afterscripts() {
-	has "${EAPI:-0}" 0 1 2 && ! use prefix && EROOT="${ROOT}"
-	has "${EAPI:-0}" 0 1 2 && ! use prefix && EPREFIX=
 	local d f afterdir="${EROOT}"/usr/share/vim/vimfiles/after
 
 	# Nothing to do if the dir isn't there
@@ -115,6 +113,7 @@ update_vim_afterscripts() {
 }
 
 # @FUNCTION: display_vim_plugin_help
+# @USAGE:
 # @DESCRIPTION:
 # Displays a message with the plugin's help file if one is available. Uses the
 # VIM_PLUGIN_HELPFILES env var. If multiple help files are available, they
@@ -160,3 +159,5 @@ display_vim_plugin_help() {
 		fi
 	fi
 }
+
+EXPORT_FUNCTIONS src_install pkg_postinst pkg_postrm


### PR DESCRIPTION
**vim-doc.eclass**

 * Replace instances of `$var` with `${var}`

**vim-plugin.eclass**
 * Drop EAPI 0, 1, 2 workarounds
 * Move EXPORT_FUNCTIONS to end of file
 * Add required `@USAGE:` on functions

Bug: https://bugs.gentoo.org/830867
Bug: https://bugs.gentoo.org/830866