### PR TITLE
Add <name> tags to metadata for vapier, kensington, naota

### DIFF
--- a/acct-group/unrealircd/metadata.xml
+++ b/acct-group/unrealircd/metadata.xml
@@ -3,6 +3,7 @@
 <pkgmetadata>
 	<maintainer type="person">
 		<email>kensington@gentoo.org</email>
+		<name>Michael Palimaka</name>
 	</maintainer>
 	<maintainer type="person">
 		<email>sam@gentoo.org</email>

--- a/acct-user/unrealircd/metadata.xml
+++ b/acct-user/unrealircd/metadata.xml
@@ -3,6 +3,7 @@
 <pkgmetadata>
 	<maintainer type="person">
 		<email>kensington@gentoo.org</email>
+		<name>Michael Palimaka</name>
 	</maintainer>
 	<maintainer type="person">
 		<email>sam@gentoo.org</email>

--- a/app-admin/bitwarden-desktop-bin/metadata.xml
+++ b/app-admin/bitwarden-desktop-bin/metadata.xml
@@ -3,6 +3,7 @@
 <pkgmetadata>
 	<maintainer type="person">
 		<email>kensington@gentoo.org</email>
+		<name>Michael Palimaka</name>
 	</maintainer>
 	<upstream>
 		<remote-id type="github">bitwarden/desktop</remote-id>

--- a/app-admin/keepass/metadata.xml
+++ b/app-admin/keepass/metadata.xml
@@ -6,6 +6,7 @@
 	</maintainer>
 	<maintainer type="person">
 		<email>kensington@gentoo.org</email>
+		<name>Michael Palimaka</name>
 	</maintainer>
 	<maintainer type="project" proxied="proxy">
 		<email>proxy-maint@gentoo.org</email>

--- a/app-emacs/calfw/metadata.xml
+++ b/app-emacs/calfw/metadata.xml
@@ -1,19 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<maintainer type="person">
-  <email>naota@gentoo.org</email>
-</maintainer>
-<maintainer type="project">
-  <email>gnu-emacs@gentoo.org</email>
-  <name>Gentoo GNU Emacs project</name>
-</maintainer>
-<stabilize-allarches/>
-<use>
-  <flag name="howm">Add support for the <pkg>app-emacs/howm</pkg>
-    note-taking tool</flag>
-</use>
-<upstream>
-  <remote-id type="github">kiwanami/emacs-calfw</remote-id>
-</upstream>
+	<maintainer type="person">
+		<email>naota@gentoo.org</email>
+		<name>Naohiro Aota</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>gnu-emacs@gentoo.org</email>
+		<name>Gentoo GNU Emacs project</name>
+	</maintainer>
+	<stabilize-allarches/>
+	<use>
+		<flag name="howm">Add support for the <pkg>app-emacs/howm</pkg>
+			note-taking tool</flag>
+	</use>
+	<upstream>
+		<remote-id type="github">kiwanami/emacs-calfw</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/app-emacs/markdown-mode/metadata.xml
+++ b/app-emacs/markdown-mode/metadata.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<maintainer type="person">
-  <email>naota@gentoo.org</email>
-</maintainer>
-<maintainer type="project">
-  <email>gnu-emacs@gentoo.org</email>
-  <name>Gentoo GNU Emacs project</name>
-</maintainer>
-<stabilize-allarches/>
+	<maintainer type="person">
+		<email>naota@gentoo.org</email>
+		<name>Naohiro Aota</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>gnu-emacs@gentoo.org</email>
+		<name>Gentoo GNU Emacs project</name>
+	</maintainer>
+	<stabilize-allarches/>
 </pkgmetadata>

--- a/app-emacs/popwin/metadata.xml
+++ b/app-emacs/popwin/metadata.xml
@@ -1,15 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<maintainer type="person">
-  <email>naota@gentoo.org</email>
-</maintainer>
-<maintainer type="project">
-  <email>gnu-emacs@gentoo.org</email>
-  <name>Gentoo GNU Emacs project</name>
-</maintainer>
-<stabilize-allarches/>
-<upstream>
-  <remote-id type="github">m2ym/popwin-el</remote-id>
-</upstream>
+	<maintainer type="person">
+		<email>naota@gentoo.org</email>
+		<name>Naohiro Aota</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>gnu-emacs@gentoo.org</email>
+		<name>Gentoo GNU Emacs project</name>
+	</maintainer>
+	<stabilize-allarches/>
+	<upstream>
+		<remote-id type="github">m2ym/popwin-el</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/app-emacs/twittering-mode/metadata.xml
+++ b/app-emacs/twittering-mode/metadata.xml
@@ -1,15 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<maintainer type="person">
-  <email>naota@gentoo.org</email>
-</maintainer>
-<maintainer type="project">
-  <email>gnu-emacs@gentoo.org</email>
-  <name>Gentoo GNU Emacs project</name>
-</maintainer>
-<stabilize-allarches/>
-<upstream>
-  <remote-id type="sourceforge">twmode</remote-id>
-</upstream>
+	<maintainer type="person">
+		<email>naota@gentoo.org</email>
+		<name>Naohiro Aota</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>gnu-emacs@gentoo.org</email>
+		<name>Gentoo GNU Emacs project</name>
+	</maintainer>
+	<stabilize-allarches/>
+	<upstream>
+		<remote-id type="sourceforge">twmode</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/app-forensics/rkhunter/metadata.xml
+++ b/app-forensics/rkhunter/metadata.xml
@@ -3,6 +3,7 @@
 <pkgmetadata>
 	<maintainer type="person">
 		<email>kensington@gentoo.org</email>
+		<name>Michael Palimaka</name>
 	</maintainer>
 	<upstream>
 		<remote-id type="sourceforge">rkhunter</remote-id>

--- a/app-laptop/pommed/metadata.xml
+++ b/app-laptop/pommed/metadata.xml
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<maintainer type="person">
-  <email>naota@gentoo.org</email>
-</maintainer>
-<longdescription> pommed handles the hotkeys found on the Apple MacBook Pro,
-MacBook and PowerBook laptops and adjusts the LCD backlight, sound volume,
-keyboard backlight or ejects the CD-ROM drive accordingly.
-pommed also monitors the ambient light sensors to automatically light up the
-keyboard backlight on the MacBook Pro and the latest PowerBook.
-Optional support for the Apple Remote control is available.</longdescription>
+	<maintainer type="person">
+		<email>naota@gentoo.org</email>
+		<name>Naohiro Aota</name>
+	</maintainer>
+	<longdescription> pommed handles the hotkeys found on the Apple MacBook Pro,
+	MacBook and PowerBook laptops and adjusts the LCD backlight, sound volume,
+	keyboard backlight or ejects the CD-ROM drive accordingly.
+	pommed also monitors the ambient light sensors to automatically light up the
+	keyboard backlight on the MacBook Pro and the latest PowerBook.
+	Optional support for the Apple Remote control is available.</longdescription>
 </pkgmetadata>

--- a/app-misc/asciinema/metadata.xml
+++ b/app-misc/asciinema/metadata.xml
@@ -3,6 +3,7 @@
 <pkgmetadata>
 	<maintainer type="person">
 		<email>kensington@gentoo.org</email>
+		<name>Michael Palimaka</name>
 	</maintainer>
 	<upstream>
 		<remote-id type="github">asciinema/asciinema</remote-id>

--- a/app-misc/ytree/metadata.xml
+++ b/app-misc/ytree/metadata.xml
@@ -3,5 +3,6 @@
 <pkgmetadata>
 	<maintainer type="person">
 		<email>kensington@gentoo.org</email>
+		<name>Michael Palimaka</name>
 	</maintainer>
 </pkgmetadata>

--- a/app-portage/tatt/metadata.xml
+++ b/app-portage/tatt/metadata.xml
@@ -3,6 +3,7 @@
 <pkgmetadata>
   <maintainer type="person">
     <email>kensington@gentoo.org</email>
+    <name>Michael Palimaka</name>
   </maintainer>
   <use>
     <flag name="templates">Install template scripts to be used with tatt</flag>

--- a/app-text/ansifilter/metadata.xml
+++ b/app-text/ansifilter/metadata.xml
@@ -3,5 +3,6 @@
 <pkgmetadata>
 	<maintainer type="person">
 		<email>kensington@gentoo.org</email>
+		<name>Michael Palimaka</name>
 	</maintainer>
 </pkgmetadata>

--- a/dev-games/tiled/metadata.xml
+++ b/dev-games/tiled/metadata.xml
@@ -3,6 +3,7 @@
 <pkgmetadata>
 	<maintainer type="person">
 		<email>kensington@gentoo.org</email>
+		<name>Michael Palimaka</name>
 	</maintainer>
 	<upstream>
 		<remote-id type="github">bjorn/tiled</remote-id>

--- a/dev-libs/liblzw/metadata.xml
+++ b/dev-libs/liblzw/metadata.xml
@@ -2,6 +2,7 @@
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
 	<maintainer type="person">
+		<name>Mike Frysinger</name>
 		<email>vapier@gentoo.org</email>
 	</maintainer>
 	<upstream>

--- a/dev-libs/mimetic/metadata.xml
+++ b/dev-libs/mimetic/metadata.xml
@@ -6,6 +6,7 @@
 	</maintainer>
 	<maintainer type="person">
 		<email>kensington@gentoo.org</email>
+		<name>Michael Palimaka</name>
 	</maintainer>
 	<upstream>
 		<remote-id type="github">tat/mimetic</remote-id>

--- a/dev-python/cachelib/metadata.xml
+++ b/dev-python/cachelib/metadata.xml
@@ -3,6 +3,7 @@
 <pkgmetadata>
 	<maintainer type="person">
 		<email>kensington@gentoo.org</email>
+		<name>Michael Palimaka</name>
 	</maintainer>
 	<maintainer type="project">
 		<email>python@gentoo.org</email>

--- a/dev-python/keep/metadata.xml
+++ b/dev-python/keep/metadata.xml
@@ -3,6 +3,7 @@
 <pkgmetadata>
 	<maintainer type="person">
 		<email>kensington@gentoo.org</email>
+		<name>Michael Palimaka</name>
 	</maintainer>
 	<stabilize-allarches/>
 	<upstream>

--- a/dev-ruby/delayer-deferred/metadata.xml
+++ b/dev-ruby/delayer-deferred/metadata.xml
@@ -3,6 +3,7 @@
 <pkgmetadata>
 	<maintainer type="person">
 		<email>naota@gentoo.org</email>
+		<name>Naohiro Aota</name>
 	</maintainer>
 	<maintainer type="project">
 		<email>ruby@gentoo.org</email>

--- a/dev-ruby/delayer/metadata.xml
+++ b/dev-ruby/delayer/metadata.xml
@@ -3,6 +3,7 @@
 <pkgmetadata>
 	<maintainer type="person">
 		<email>naota@gentoo.org</email>
+		<name>Naohiro Aota</name>
 	</maintainer>
 	<maintainer type="project">
 		<email>ruby@gentoo.org</email>

--- a/dev-ruby/diva/metadata.xml
+++ b/dev-ruby/diva/metadata.xml
@@ -3,6 +3,7 @@
 <pkgmetadata>
 	<maintainer type="person">
 		<email>naota@gentoo.org</email>
+		<name>Naohiro Aota</name>
 	</maintainer>
 	<maintainer type="project">
 		<email>ruby@gentoo.org</email>

--- a/dev-ruby/instance_storage/metadata.xml
+++ b/dev-ruby/instance_storage/metadata.xml
@@ -3,6 +3,7 @@
 <pkgmetadata>
 	<maintainer type="person">
 		<email>naota@gentoo.org</email>
+		<name>Naohiro Aota</name>
 	</maintainer>
 	<maintainer type="project">
 		<email>ruby@gentoo.org</email>

--- a/dev-ruby/memoist/metadata.xml
+++ b/dev-ruby/memoist/metadata.xml
@@ -3,6 +3,7 @@
 <pkgmetadata>
   <maintainer type="person">
     <email>naota@gentoo.org</email>
+    <name>Naohiro Aota</name>
   </maintainer>
   <maintainer type="project">
     <email>ruby@gentoo.org</email>

--- a/dev-ruby/memoize/metadata.xml
+++ b/dev-ruby/memoize/metadata.xml
@@ -3,6 +3,7 @@
 <pkgmetadata>
   <maintainer type="person">
     <email>naota@gentoo.org</email>
+    <name>Naohiro Aota</name>
   </maintainer>
   <maintainer type="project">
     <email>ruby@gentoo.org</email>

--- a/dev-ruby/pkg-config/metadata.xml
+++ b/dev-ruby/pkg-config/metadata.xml
@@ -3,6 +3,7 @@
 <pkgmetadata>
   <maintainer type="person">
     <email>naota@gentoo.org</email>
+    <name>Naohiro Aota</name>
   </maintainer>
   <maintainer type="project">
     <email>ruby@gentoo.org</email>

--- a/dev-ruby/pluggaloid/metadata.xml
+++ b/dev-ruby/pluggaloid/metadata.xml
@@ -3,6 +3,7 @@
 <pkgmetadata>
 	<maintainer type="person">
 		<email>naota@gentoo.org</email>
+		<name>Naohiro Aota</name>
 	</maintainer>
 	<maintainer type="project">
 		<email>ruby@gentoo.org</email>

--- a/dev-ruby/rubytter/metadata.xml
+++ b/dev-ruby/rubytter/metadata.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-  <maintainer type="person">
-  <email>naota@gentoo.org</email>
-</maintainer>
-<maintainer type="project">
-  <email>ruby@gentoo.org</email>
-  <name>Gentoo Ruby Project</name>
-  </maintainer>
+	<maintainer type="person">
+		<email>naota@gentoo.org</email>
+		<name>Naohiro Aota</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>ruby@gentoo.org</email>
+		<name>Gentoo Ruby Project</name>
+	</maintainer>
 </pkgmetadata>

--- a/dev-ruby/totoridipjp/metadata.xml
+++ b/dev-ruby/totoridipjp/metadata.xml
@@ -3,6 +3,7 @@
 <pkgmetadata>
 	<maintainer type="person">
 		<email>naota@gentoo.org</email>
+		<name>Naohiro Aota</name>
 	</maintainer>
 	<maintainer type="project">
 		<email>ruby@gentoo.org</email>

--- a/dev-ruby/typed-array/metadata.xml
+++ b/dev-ruby/typed-array/metadata.xml
@@ -3,6 +3,7 @@
 <pkgmetadata>
   <maintainer type="person">
     <email>naota@gentoo.org</email>
+    <name>Naohiro Aota</name>
   </maintainer>
   <maintainer type="project">
     <email>ruby@gentoo.org</email>

--- a/dev-util/cmake-fedora/metadata.xml
+++ b/dev-util/cmake-fedora/metadata.xml
@@ -3,5 +3,6 @@
 <pkgmetadata>
 	<maintainer type="person">
 		<email>naota@gentoo.org</email>
+		<name>Naohiro Aota</name>
 	</maintainer>
 </pkgmetadata>

--- a/dev-util/global/metadata.xml
+++ b/dev-util/global/metadata.xml
@@ -3,9 +3,10 @@
 <pkgmetadata>
 	<maintainer type="person">
 		<email>naota@gentoo.org</email>
+		<name>Naohiro Aota</name>
 	</maintainer>
 	<maintainer type="person" proxied="yes">
-		<email>arfrever.fta@gmail.com</email> 
+		<email>arfrever.fta@gmail.com</email>
 	</maintainer>
 	<use>
 		<flag name="vim">Integrate the GNU GLOBAL source code tag system with Vim</flag>

--- a/dev-util/gource/metadata.xml
+++ b/dev-util/gource/metadata.xml
@@ -3,6 +3,7 @@
 <pkgmetadata>
 	<maintainer type="person">
 		<email>kensington@gentoo.org</email>
+		<name>Michael Palimaka</name>
 	</maintainer>
 	<upstream>
 		<remote-id type="google-code">gource</remote-id>

--- a/dev-util/howdoi/metadata.xml
+++ b/dev-util/howdoi/metadata.xml
@@ -3,6 +3,7 @@
 <pkgmetadata>
 	<maintainer type="person">
 		<email>kensington@gentoo.org</email>
+		<name>Michael Palimaka</name>
 	</maintainer>
 	<stabilize-allarches/>
 	<upstream>

--- a/dev-util/perf/metadata.xml
+++ b/dev-util/perf/metadata.xml
@@ -3,6 +3,7 @@
 <pkgmetadata>
   <maintainer type="person">
     <email>naota@gentoo.org</email>
+    <name>Naohiro Aota</name>
   </maintainer>
   <maintainer type="person">
     <email>dlan@gentoo.org</email>

--- a/dev-util/rpmdevtools/metadata.xml
+++ b/dev-util/rpmdevtools/metadata.xml
@@ -3,5 +3,6 @@
 <pkgmetadata>
 	<maintainer type="person">
 		<email>kensington@gentoo.org</email>
+		<name>Michael Palimaka</name>
 	</maintainer>
 </pkgmetadata>

--- a/dev-vcs/repo/metadata.xml
+++ b/dev-vcs/repo/metadata.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<maintainer type="person">
-	<email>vapier@gentoo.org</email>
-</maintainer>
+	<maintainer type="person">
+		<name>Mike Frysinger</name>
+		<email>vapier@gentoo.org</email>
+	</maintainer>
 </pkgmetadata>

--- a/media-fonts/ttf-bitstream-vera/metadata.xml
+++ b/media-fonts/ttf-bitstream-vera/metadata.xml
@@ -3,6 +3,7 @@
 <pkgmetadata>
 	<maintainer type="person">
 		<email>kensington@gentoo.org</email>
+		<name>Michael Palimaka</name>
 	</maintainer>
 	<stabilize-allarches/>
 </pkgmetadata>

--- a/media-gfx/evoluspencil/metadata.xml
+++ b/media-gfx/evoluspencil/metadata.xml
@@ -3,6 +3,7 @@
 <pkgmetadata>
 	<maintainer type="person">
 		<email>kensington@gentoo.org</email>
+		<name>Michael Palimaka</name>
 	</maintainer>
 	<upstream>
 		<remote-id type="github">evolus/pencil</remote-id>

--- a/media-sound/mp3diags/metadata.xml
+++ b/media-sound/mp3diags/metadata.xml
@@ -3,6 +3,7 @@
 <pkgmetadata>
 	<maintainer type="person">
 		<email>kensington@gentoo.org</email>
+		<name>Michael Palimaka</name>
 	</maintainer>
 	<upstream>
 		<remote-id type="sourceforge">mp3diags</remote-id>

--- a/net-analyzer/testssl/metadata.xml
+++ b/net-analyzer/testssl/metadata.xml
@@ -3,6 +3,7 @@
 <pkgmetadata>
 	<maintainer type="person">
 		<email>kensington@gentoo.org</email>
+		<name>Michael Palimaka</name>
 	</maintainer>
 	<use>
 		<flag name="bundled-openssl">Install precompiled versions of OpenSSL for greater testing coverage</flag>

--- a/net-irc/unrealircd/metadata.xml
+++ b/net-irc/unrealircd/metadata.xml
@@ -3,6 +3,7 @@
 <pkgmetadata>
 	<maintainer type="person">
 		<email>kensington@gentoo.org</email>
+		<name>Michael Palimaka</name>
 	</maintainer>
 	<maintainer type="person">
 		<email>sam@gentoo.org</email>

--- a/net-misc/chrome-remote-desktop/metadata.xml
+++ b/net-misc/chrome-remote-desktop/metadata.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<maintainer type="person">
-	<email>vapier@gentoo.org</email>
-</maintainer>
+	<maintainer type="person">
+		<name>Mike Frysinger</name>
+		<email>vapier@gentoo.org</email>
+	</maintainer>
 </pkgmetadata>

--- a/net-misc/mikutter/metadata.xml
+++ b/net-misc/mikutter/metadata.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<maintainer type="person">
-  <email>naota@gentoo.org</email>
-</maintainer>
+	<maintainer type="person">
+		<email>naota@gentoo.org</email>
+		<name>Naohiro Aota</name>
+	</maintainer>
 </pkgmetadata>

--- a/net-misc/sslh/metadata.xml
+++ b/net-misc/sslh/metadata.xml
@@ -3,6 +3,7 @@
 <pkgmetadata>
 	<maintainer type="person">
 		<email>kensington@gentoo.org</email>
+		<name>Michael Palimaka</name>
 	</maintainer>
 	<maintainer type="person">
 		<email>candrews@gentoo.org</email>

--- a/sec-policy/apparmor-profiles/metadata.xml
+++ b/sec-policy/apparmor-profiles/metadata.xml
@@ -3,6 +3,7 @@
 <pkgmetadata>
 	<maintainer type="person">
 		<email>kensington@gentoo.org</email>
+		<name>Michael Palimaka</name>
 	</maintainer>
 	<maintainer type="project">
 		<email>hardened@gentoo.org</email>

--- a/sys-apps/apparmor-utils/metadata.xml
+++ b/sys-apps/apparmor-utils/metadata.xml
@@ -3,6 +3,7 @@
 <pkgmetadata>
 	<maintainer type="person">
 		<email>kensington@gentoo.org</email>
+		<name>Michael Palimaka</name>
 	</maintainer>
 	<maintainer type="project">
 		<email>hardened@gentoo.org</email>

--- a/sys-apps/apparmor/metadata.xml
+++ b/sys-apps/apparmor/metadata.xml
@@ -3,6 +3,7 @@
 <pkgmetadata>
 	<maintainer type="person">
 		<email>kensington@gentoo.org</email>
+		<name>Michael Palimaka</name>
 	</maintainer>
 	<maintainer type="project">
 		<email>hardened@gentoo.org</email>

--- a/sys-apps/daisydog/metadata.xml
+++ b/sys-apps/daisydog/metadata.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<maintainer type="person">
-	<email>vapier@gentoo.org</email>
-</maintainer>
+	<maintainer type="person">
+		<name>Mike Frysinger</name>
+		<email>vapier@gentoo.org</email>
+	</maintainer>
 </pkgmetadata>

--- a/sys-apps/gpet/metadata.xml
+++ b/sys-apps/gpet/metadata.xml
@@ -3,6 +3,7 @@
 <pkgmetadata>
   <maintainer type="person">
     <email>naota@gentoo.org</email>
+    <name>Naohiro Aota</name>
   </maintainer>
   <upstream>
     <remote-id type="sourceforge-jp">gpet</remote-id>

--- a/sys-apps/msr-tools/metadata.xml
+++ b/sys-apps/msr-tools/metadata.xml
@@ -3,5 +3,6 @@
 <pkgmetadata>
 	<maintainer type="person">
 		<email>kensington@gentoo.org</email>
+		<name>Michael Palimaka</name>
 	</maintainer>
 </pkgmetadata>

--- a/sys-apps/nosig/metadata.xml
+++ b/sys-apps/nosig/metadata.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<maintainer type="person">
-	<email>vapier@gentoo.org</email>
-	<description>Primary maintainer</description>
-</maintainer>
+	<maintainer type="person">
+		<name>Mike Frysinger</name>
+		<email>vapier@gentoo.org</email>
+		<description>Primary maintainer</description>
+	</maintainer>
 </pkgmetadata>

--- a/sys-apps/tomoyo-tools/metadata.xml
+++ b/sys-apps/tomoyo-tools/metadata.xml
@@ -3,6 +3,7 @@
 <pkgmetadata>
 	<maintainer type="person">
 		<email>naota@gentoo.org</email>
+		<name>Naohiro Aota</name>
 	</maintainer>
 	<upstream>
 		<remote-id type="sourceforge-jp">tomoyo</remote-id>

--- a/sys-auth/elogind/metadata.xml
+++ b/sys-auth/elogind/metadata.xml
@@ -6,6 +6,7 @@
 	</maintainer>
 	<maintainer type="person">
 		<email>kensington@gentoo.org</email>
+		<name>Michael Palimaka</name>
 	</maintainer>
 	<maintainer type="person">
 		<email>slashbeast@gentoo.org</email>

--- a/sys-fs/nilfs-utils/metadata.xml
+++ b/sys-fs/nilfs-utils/metadata.xml
@@ -3,6 +3,7 @@
 <pkgmetadata>
 	<maintainer type="person">
 		<email>naota@gentoo.org</email>
+		<name>Naohiro Aota</name>
 	</maintainer>
 	<longdescription lang="en">
 NILFS is a new implementation of a log-structured file system for the

--- a/sys-libs/libapparmor/metadata.xml
+++ b/sys-libs/libapparmor/metadata.xml
@@ -3,6 +3,7 @@
 <pkgmetadata>
 	<maintainer type="person">
 		<email>kensington@gentoo.org</email>
+		<name>Michael Palimaka</name>
 	</maintainer>
 	<maintainer type="project">
 		<email>hardened@gentoo.org</email>

--- a/sys-libs/mtdev/metadata.xml
+++ b/sys-libs/mtdev/metadata.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<maintainer type="person">
-  <email>naota@gentoo.org</email>
-</maintainer>
-<maintainer type="project">
-  <email>x11@gentoo.org</email>
-  <name>X11</name>
-</maintainer>
+	<maintainer type="person">
+		<email>naota@gentoo.org</email>
+		<name>Naohiro Aota</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>x11@gentoo.org</email>
+		<name>X11</name>
+	</maintainer>
 </pkgmetadata>


### PR DESCRIPTION
These are not the only developers that lack <name> tags in some of their packages, but these three developers seem to be the only ones that have no <name> tags, as I noticed from [packages.gentoo.org](https://packages.gentoo.org/maintainers/gentoo-developers). I've added <name> tags to their packages, and also fixed indentation where it was very wrong.

A couple miscellaneous lines have also changed thanks to my editor dropping trailing whitespaces, and I didn't see any reason to revert that change.