### PR TITLE
dev-python/soupsieve: keyword 2.3.2 for ~riscv, #837074

### DIFF
--- a/dev-python/editables/editables-0.2.ebuild
+++ b/dev-python/editables/editables-0.2.ebuild
@@ -20,6 +20,6 @@ SRC_URI="
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~amd64"
+KEYWORDS="~amd64 ~riscv"
 
 distutils_enable_tests pytest

--- a/dev-python/hatchling/hatchling-0.22.0.ebuild
+++ b/dev-python/hatchling/hatchling-0.22.0.ebuild
@@ -23,7 +23,7 @@ S=${WORKDIR}/${MY_P}/backend
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~amd64"
+KEYWORDS="~amd64 ~riscv"
 
 RDEPEND="
 	>=dev-python/editables-0.2[${PYTHON_USEDEP}]

--- a/dev-python/soupsieve/soupsieve-2.3.2.ebuild
+++ b/dev-python/soupsieve/soupsieve-2.3.2.ebuild
@@ -20,7 +20,7 @@ SRC_URI="
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~amd64"
+KEYWORDS="~amd64 ~riscv"
 
 BDEPEND="
 	test? (


### PR DESCRIPTION
Signed-off-by: Yu Gu <guyu2876@gmail.com>