### PR TITLE
sys-cluster/pacemaker: force remove /etc/init.d

### DIFF
--- a/sys-cluster/pacemaker/pacemaker-2.1.2.ebuild
+++ b/sys-cluster/pacemaker/pacemaker-2.1.2.ebuild
@@ -65,7 +65,7 @@ src_install() {
 	python_optimize
 
 	# remove provided initd file as we need support for OpenRC
-	rm -r "${ED}/etc/init.d" || die "Failed to remove old initd"
+	rm -rf "${ED}/etc/init.d" || die "Failed to remove old initd"
 	newinitd "${FILESDIR}/${PN}.initd" "${PN}"
 
 	keepdir /var/lib/pacemaker/{blackbox,cib,cores,pengine}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/830406
Signed-off-by: Alessandro Barbieri <lssndrbarbieri@gmail.com>