### PR TITLE
dev-db/mysql-init-scripts: update tmpfiles path

### DIFF
--- a/dev-db/mysql-init-scripts/files/mysql.conf
+++ b/dev-db/mysql-init-scripts/files/mysql.conf
@@ -1,1 +1,0 @@
-d /var/run/mysqld 0755 mysql mysql -

--- a/dev-db/mysql-init-scripts/files/mysql.conf-r1
+++ b/dev-db/mysql-init-scripts/files/mysql.conf-r1
@@ -1,0 +1,1 @@
+d /run/mysqld 0755 mysql mysql -

--- a/dev-db/mysql-init-scripts/mysql-init-scripts-2.3-r4.ebuild
+++ b/dev-db/mysql-init-scripts/mysql-init-scripts-2.3-r4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -49,7 +49,7 @@ src_install() {
 	doexe "${FILESDIR}"/mysqld-wait-ready
 	systemd_newunit "${FILESDIR}/mysqld-v2.service" "mysqld.service"
 	systemd_newunit "${FILESDIR}/mysqld_at-v2.service" "mysqld@.service"
-	dotmpfiles "${FILESDIR}/mysql.conf"
+	newtmpfiles "${FILESDIR}/mysql.conf-r1" "mysql.conf"
 
 	insinto /etc/logrotate.d
 	newins "${FILESDIR}/logrotate.mysql-2.3" "mysql"


### PR DESCRIPTION
The path '/var/run' is deprecated, as the following message is being
shown:

/usr/lib/tmpfiles.d/mysql.conf:1: Line references path below legacy
directory /var/run/, updating /var/run/mysqld  /run/mysqld;
please update the tmpfiles.d/ drop-in file accordingly.

Signed-off-by: Conrad Kostecki <conikost@gentoo.org>

@gentoo/mysql Please review for ack, thanks!