### PR TITLE
net-p2p/transmission: don't call clang-tidy needlessly

### DIFF
--- a/net-p2p/transmission/transmission-9999.ebuild
+++ b/net-p2p/transmission/transmission-9999.ebuild
@@ -96,6 +96,7 @@ src_configure() {
 		-DUSE_SYSTEM_NATPMP=ON
 		-DUSE_SYSTEM_UTP=OFF
 		-DUSE_SYSTEM_B64=OFF
+		-DRUN_CLANG_TIDY=OFF
 
 		-DWITH_CRYPTO=$(usex mbedtls polarssl openssl)
 		-DWITH_INOTIFY=ON


### PR DESCRIPTION
helps to prevent problems with clang failing to make sense of
gcc-specific CFLAGS like:
error: unknown argument: '-malign-data=cacheline' [clang-diagnostic-error]
error: unknown argument: '-mtls-dialect=gnu2' [clang-diagnostic-error]
Package-Manager: Portage-3.0.30, Repoman-3.0.3