### PR TITLE
x11-plugins/gkrellm-leds: rename src_{configure,install}

### DIFF
--- a/x11-plugins/gkrellm-leds/gkrellm-leds-0.8.2-r2.ebuild
+++ b/x11-plugins/gkrellm-leds/gkrellm-leds-0.8.2-r2.ebuild
@@ -30,7 +30,7 @@ src_prepare() {
 	eautoreconf
 }
 
-src_configure() {
+src_install() {
 	PLUGIN_SO=( src/.libs/gkleds$(get_modname) )
-	default
+	gkrellm-plugin_src_install
 }


### PR DESCRIPTION
The PLUGIN_SO variable is only needed for the src_install phase, so
the only phase we really need to override here is src_install.

Signed-off-by: Thomas Bracht Laumann Jespersen <t@laumann.xyz>