### PR TITLE
app-emulation/cloud-init: Update package dependencies

### DIFF
--- a/app-emulation/cloud-init/cloud-init-9999.ebuild
+++ b/app-emulation/cloud-init/cloud-init-9999.ebuild
@@ -33,15 +33,15 @@ CDEPEND="
 	dev-python/requests[${PYTHON_USEDEP}]
 	dev-python/jsonpatch[${PYTHON_USEDEP}]
 	dev-python/jsonschema[${PYTHON_USEDEP}]
-	dev-python/six[${PYTHON_USEDEP}]
+	dev-python/netifaces[${PYTHON_USEDEP}]
+
 "
 DEPEND="
 		${CDEPEND}
 	test? (
 		>=dev-python/httpretty-0.7.1[${PYTHON_USEDEP}]
 		dev-python/mock[${PYTHON_USEDEP}]
-		dev-python/nose[${PYTHON_USEDEP}]
-		dev-python/coverage[${PYTHON_USEDEP}]
+		dev-python/setuptools[${PYTHON_USEDEP}]
 	)
 "
 RDEPEND="


### PR DESCRIPTION
Fixes https://bugs.gentoo.org/837329

The fix: 
- `nose`, `coverage`, and `six` are no longer direct dependencies, remove them.
- `pytest`, `pytest-cov`, and `setuptools` are test dependencies, add them.


To verify this, I did the following:

1. set up a new Gentoo LXC container
2. set up my own ebuild repo on the system using upstream repo as a base
3. edited my ebuild: diff between my ebuild and the current -9999 one in 00-cloud-init-changes.txt
4. configured the `test` USE flag for cloud-init
5. emerged cloud-init (01-emerge-cloud-init.txt)
6. verified that unit tests pass on main of the upstream repo (`tox -e py3`) (02-tox-unittest-run.txt)

[00-cloud-init-changes.txt](https://github.com/gentoo/gentoo/files/8456057/00-cloud-init-changes.txt)
[01-emerge-cloud-init.txt](https://github.com/gentoo/gentoo/files/8456056/01-emerge-cloud-init.txt)
[02-tox-unittest-run.txt](https://github.com/gentoo/gentoo/files/8456055/02-tox-unittest-run.txt)

Please let me know if I should provide further detail.
