### PR TITLE
media-gfx/freecad: fix install location of shared files

### DIFF
--- a/media-gfx/freecad/freecad-0.19.4-r1.ebuild
+++ b/media-gfx/freecad/freecad-0.19.4-r1.ebuild
@@ -267,6 +267,7 @@ src_install() {
 
 	if ! use headless; then
 		dosym -r /usr/$(get_libdir)/${PN}/bin/FreeCAD /usr/bin/freecad
+		mv "${ED}"/usr/$(get_libdir)/${PN}/share/* "${ED}"/usr/share || die "failed to move shared resources"
 	fi
 	dosym -r /usr/$(get_libdir)/${PN}/bin/FreeCADCmd /usr/bin/freecadcmd
 


### PR DESCRIPTION
Shared files have been installed into /usr/$(get_libdir)/freecad/share
instead of /usr/share. This patch fixes this.

Closes: https://bugs.gentoo.org/837173
Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>