### PR TITLE
distutils-r1.eclass: Further optimizations (hidden under GPEP517_TESTING)

### DIFF
--- a/dev-python/ruamel-std-pathlib/ruamel-std-pathlib-0.9.2-r1.ebuild
+++ b/dev-python/ruamel-std-pathlib/ruamel-std-pathlib-0.9.2-r1.ebuild
@@ -30,11 +30,6 @@ python_compile() {
 }
 
 python_test() {
-	# this is needed to keep the tests working while
-	# dev-python/namespace-ruamel is still installed
-	cat > "${BUILD_DIR}/install$(python_get_sitedir)"/ruamel/__init__.py <<-EOF || die
-		__path__ = __import__('pkgutil').extend_path(__path__, __name__)
-	EOF
+	distutils_write_namespace ruamel
 	epytest
-	rm "${BUILD_DIR}/install$(python_get_sitedir)"/ruamel/__init__.py || die
 }

--- a/eclass/distutils-r1.eclass
+++ b/eclass/distutils-r1.eclass
@@ -1637,7 +1637,7 @@ _distutils-r1_check_namespace_pth() {
 		ewarn "read our documentation on reliable handling of namespaces and update"
 		ewarn "the ebuild accordingly:"
 		ewarn
-		ewarn "  https://wiki.gentoo.org/wiki/Project:Python/Namespace_packages"
+		ewarn "  https://projects.gentoo.org/python/guide/concept.html#namespace-packages"
 	fi
 }
 

--- a/eclass/distutils-r1.eclass
+++ b/eclass/distutils-r1.eclass
@@ -1115,7 +1115,13 @@ distutils-r1_python_compile() {
 	# call setup.py build when using setuptools (either via PEP517
 	# or in legacy mode)
 	if [[ ${DISTUTILS_USE_PEP517:-setuptools} == setuptools ]]; then
-		if [[ ! ${DISTUTILS_USE_PEP517} ]]; then
+		if [[ ${GPEP517_TESTING} ]]; then
+			if [[ -d build ]]; then
+				eqawarn "A 'build' directory exists already.  Artifacts from this directory may"
+				eqawarn "be picked up by setuptools when building for another interpreter."
+				eqawarn "Please remove this directory prior to building."
+			fi
+		else
 			_distutils-r1_copy_egg_info
 		fi
 

--- a/eclass/distutils-r1.eclass
+++ b/eclass/distutils-r1.eclass
@@ -196,23 +196,23 @@ _distutils_set_globals() {
 		case ${DISTUTILS_USE_PEP517} in
 			flit)
 				bdep+='
-					dev-python/flit_core[${PYTHON_USEDEP}]'
+					>=dev-python/flit_core-3.7.1[${PYTHON_USEDEP}]'
 				;;
 			hatchling)
 				bdep+='
-					dev-python/hatchling[${PYTHON_USEDEP}]'
+					>=dev-python/hatchling-0.22.0[${PYTHON_USEDEP}]'
 				;;
 			jupyter)
 				bdep+='
-					dev-python/jupyter_packaging[${PYTHON_USEDEP}]'
+					>=dev-python/jupyter_packaging-0.11.1[${PYTHON_USEDEP}]'
 				;;
 			pdm)
 				bdep+='
-					dev-python/pdm-pep517[${PYTHON_USEDEP}]'
+					>=dev-python/pdm-pep517-0.12.3[${PYTHON_USEDEP}]'
 				;;
 			poetry)
 				bdep+='
-					dev-python/poetry-core[${PYTHON_USEDEP}]'
+					>=dev-python/poetry-core-1.0.8[${PYTHON_USEDEP}]'
 				;;
 			setuptools)
 				bdep+='
@@ -425,7 +425,7 @@ distutils_enable_sphinx() {
 	_DISTUTILS_SPHINX_PLUGINS=( "${@}" )
 
 	local deps autodoc=1 d
-	deps="dev-python/sphinx[\${PYTHON_USEDEP}]"
+	deps=">=dev-python/sphinx-4.4.0[\${PYTHON_USEDEP}]"
 	for d; do
 		if [[ ${d} == --no-autodoc ]]; then
 			autodoc=
@@ -449,13 +449,15 @@ distutils_enable_sphinx() {
 			use doc || return 0
 
 			local p
-			for p in dev-python/sphinx "${_DISTUTILS_SPHINX_PLUGINS[@]}"; do
+			for p in ">=dev-python/sphinx-4.4.0" \
+				"${_DISTUTILS_SPHINX_PLUGINS[@]}"
+			do
 				python_has_version "${p}[${PYTHON_USEDEP}]" ||
 					return 1
 			done
 		}
 	else
-		deps="dev-python/sphinx"
+		deps=">=dev-python/sphinx-4.4.0"
 	fi
 
 	sphinx_compile_all() {
@@ -538,7 +540,7 @@ distutils_enable_tests() {
 			test_pkg=">=dev-python/nose-1.3.7-r4"
 			;;
 		pytest)
-			test_pkg=">=dev-python/pytest-6.2.5-r2"
+			test_pkg=">=dev-python/pytest-7.0.1"
 			;;
 		setup.py)
 			;;

--- a/eclass/distutils-r1.eclass
+++ b/eclass/distutils-r1.eclass
@@ -1090,7 +1090,11 @@ distutils_pep517_install() {
 	# clean the build tree; otherwise we may end up with PyPy3
 	# extensions duplicated into CPython dists
 	if [[ ${DISTUTILS_USE_PEP517:-setuptools} == setuptools ]]; then
-		esetup.py clean -a
+		if [[ ${GPEP517_TESTING} ]]; then
+			rm -rf build || die
+		else
+			esetup.py clean -a
+		fi
 	fi
 }
 

--- a/eclass/distutils-r1.eclass
+++ b/eclass/distutils-r1.eclass
@@ -1132,7 +1132,11 @@ distutils-r1_python_compile() {
 			jobs=$(( nproc + 1 ))
 		fi
 
-		esetup.py build -j "${jobs}" "${@}"
+		if [[ ${DISTUTILS_USE_PEP517} && ${GPEP517_TESTING} ]]; then
+			esetup.py build_ext -j "${jobs}" "${@}"
+		else
+			esetup.py build -j "${jobs}" "${@}"
+		fi
 	fi
 
 	if [[ ${DISTUTILS_USE_PEP517} ]]; then

--- a/eclass/distutils-r1.eclass
+++ b/eclass/distutils-r1.eclass
@@ -1133,7 +1133,17 @@ distutils-r1_python_compile() {
 		fi
 
 		if [[ ${DISTUTILS_USE_PEP517} && ${GPEP517_TESTING} ]]; then
-			esetup.py build_ext -j "${jobs}" "${@}"
+			# issue build_ext only if it looks like we have something
+			# to build; setuptools is expensive to start
+			# see extension.py for list of suffixes
+			# .pyx is added for Cython
+			if [[ -n $(
+				find '(' -name '*.c' -o -name '*.cc' -o -name '*.cpp' \
+					-o -name '*.cxx' -o -name '*.c++' -o -name '*.m' \
+					-o -name '*.mm' -o -name '*.pyx' ')' -print -quit
+			) ]]; then
+				esetup.py build_ext -j "${jobs}" "${@}"
+			fi
 		else
 			esetup.py build -j "${jobs}" "${@}"
 		fi

--- a/eclass/distutils-r1.eclass
+++ b/eclass/distutils-r1.eclass
@@ -867,6 +867,15 @@ distutils-r1_python_prepare_all() {
 	if [[ ! ${DISTUTILS_USE_PEP517} ]]; then
 		_distutils-r1_disable_ez_setup
 		_distutils-r1_handle_pyproject_toml
+
+		case ${DISTUTILS_USE_SETUPTOOLS} in
+			no)
+				eqawarn "Non-PEP517 builds are deprecated for ebuilds using plain distutils."
+				eqawarn "Please migrate to DISTUTILS_USE_PEP517=setuptools."
+				eqawarn "Please see Python Guide for more details:"
+				eqawarn "  https://projects.gentoo.org/python/guide/distutils.html"
+				;;
+		esac
 	fi
 
 	if [[ ${DISTUTILS_IN_SOURCE_BUILD} && ! ${DISTUTILS_SINGLE_IMPL} ]]


### PR DESCRIPTION
Some ideas to make PEP517 builds faster. For example, it gets `dev-python/jaraco-logging` (with `USE=-test`) from 50 s to 28 s. It still sucks but I don't think we can get setuptools to go any faster.

CC @gentoo/python 