### PR TITLE
x11-apps/igt-gpu-tools: Fix libunwind dependency

### DIFF
--- a/x11-apps/igt-gpu-tools/igt-gpu-tools-1.26-r2.ebuild
+++ b/x11-apps/igt-gpu-tools/igt-gpu-tools-1.26-r2.ebuild
@@ -36,7 +36,6 @@ RDEPEND="
 	dev-libs/elfutils
 	dev-libs/glib:2
 	sys-apps/kmod:=
-	sys-libs/libunwind:=
 	sys-libs/zlib:=
 	sys-process/procps:=
 	virtual/libudev:=
@@ -58,7 +57,7 @@ RDEPEND="
 		)
 	)
 	runner? ( dev-libs/json-c:= )
-	unwind? ( sys-libs/libunwind )
+	unwind? ( sys-libs/libunwind:= )
 	valgrind? ( dev-util/valgrind )
 	"
 DEPEND="${RDEPEND}

--- a/x11-apps/igt-gpu-tools/igt-gpu-tools-9999.ebuild
+++ b/x11-apps/igt-gpu-tools/igt-gpu-tools-9999.ebuild
@@ -36,7 +36,6 @@ RDEPEND="
 	dev-libs/elfutils
 	dev-libs/glib:2
 	sys-apps/kmod:=
-	sys-libs/libunwind:=
 	sys-libs/zlib:=
 	sys-process/procps:=
 	virtual/libudev:=
@@ -58,7 +57,7 @@ RDEPEND="
 		)
 	)
 	runner? ( dev-libs/json-c:= )
-	unwind? ( sys-libs/libunwind )
+	unwind? ( sys-libs/libunwind:= )
 	valgrind? ( dev-util/valgrind )
 	"
 DEPEND="${RDEPEND}


### PR DESCRIPTION
Currently igt-gpu-tools cannot be installed if llvm-libunwind is installed