### PR TITLE
app-emulation/cloud init: Backport dependency changes

### DIFF
--- a/app-emulation/cloud-init/cloud-init-20.4.ebuild
+++ b/app-emulation/cloud-init/cloud-init-20.4.ebuild
@@ -32,14 +32,13 @@ CDEPEND="
 	dev-python/requests[${PYTHON_USEDEP}]
 	dev-python/jsonpatch[${PYTHON_USEDEP}]
 	dev-python/jsonschema[${PYTHON_USEDEP}]
-	dev-python/six[${PYTHON_USEDEP}]
 "
 DEPEND="
 	test? (
 		${CDEPEND}
 		>=dev-python/httpretty-0.7.1[${PYTHON_USEDEP}]
 		dev-python/mock[${PYTHON_USEDEP}]
-		dev-python/nose[${PYTHON_USEDEP}]
+		dev-python/pytest[${PYTHON_USEDEP}]
 		dev-python/coverage[${PYTHON_USEDEP}]
 	)
 "
@@ -69,8 +68,8 @@ python_prepare_all() {
 }
 
 python_test() {
-	# Do not use Makefile target as it does not setup environment correclty
-	esetup.py nosetests -v --where cloudinit --where tests/unittests || die
+	# Do not use Makefile target as it does not setup environment correctly
+	esetup.py pytest -v cloudinit/ tests/unittests || die
 }
 
 python_install() {

--- a/app-emulation/cloud-init/cloud-init-21.2.ebuild
+++ b/app-emulation/cloud-init/cloud-init-21.2.ebuild
@@ -32,14 +32,13 @@ CDEPEND="
 	dev-python/requests[${PYTHON_USEDEP}]
 	dev-python/jsonpatch[${PYTHON_USEDEP}]
 	dev-python/jsonschema[${PYTHON_USEDEP}]
-	dev-python/six[${PYTHON_USEDEP}]
 "
 DEPEND="
 		${CDEPEND}
 	test? (
 		>=dev-python/httpretty-0.7.1[${PYTHON_USEDEP}]
 		dev-python/mock[${PYTHON_USEDEP}]
-		dev-python/nose[${PYTHON_USEDEP}]
+		dev-python/pytest[${PYTHON_USEDEP}]
 		dev-python/coverage[${PYTHON_USEDEP}]
 	)
 "
@@ -69,8 +68,8 @@ python_prepare_all() {
 }
 
 python_test() {
-	# Do not use Makefile target as it does not setup environment correclty
-	esetup.py nosetests -v --where cloudinit --where tests/unittests || die
+	# Do not use Makefile target as it does not setup environment correctly
+	esetup.py pytest -v cloudinit tests/unittests || die
 }
 
 python_install() {

--- a/app-emulation/cloud-init/cloud-init-22.1.ebuild
+++ b/app-emulation/cloud-init/cloud-init-22.1.ebuild
@@ -33,14 +33,13 @@ CDEPEND="
 	dev-python/requests[${PYTHON_USEDEP}]
 	dev-python/jsonpatch[${PYTHON_USEDEP}]
 	dev-python/jsonschema[${PYTHON_USEDEP}]
-	dev-python/six[${PYTHON_USEDEP}]
+	dev-python/netifaces[${PYTHON_USEDEP}]
 "
 DEPEND="
 		${CDEPEND}
 	test? (
 		>=dev-python/httpretty-0.7.1[${PYTHON_USEDEP}]
 		dev-python/mock[${PYTHON_USEDEP}]
-		dev-python/nose[${PYTHON_USEDEP}]
 		dev-python/coverage[${PYTHON_USEDEP}]
 	)
 "
@@ -59,7 +58,7 @@ PATCHES=(
 	"${FILESDIR}"/22.1-add-support-for-package_upgrade.patch
 )
 
-distutils_enable_tests nose
+distutils_enable_tests pytest
 
 python_prepare_all() {
 	# Fix location of documentation installation


### PR DESCRIPTION
Dependencies were updated in #24960.

This backports the update to the current ebuilds.