### PR TITLE
net-misc/turbovnc: Fix compilation on musl

### DIFF
--- a/net-misc/turbovnc/files/turbovnc-2.2.7-fix-musl-compilation.patch
+++ b/net-misc/turbovnc/files/turbovnc-2.2.7-fix-musl-compilation.patch
@@ -1,0 +1,51 @@
+See bug https://bugs.gentoo.org/836723
+
+There are 2 compilation errors:
+
+/var/tmp/portage/net-misc/turbovnc-2.2.7-r2/work/turbovnc-2.2.7/unix/Xvnc/programs/Xserver/os/access.c: In function 'GetLocalClientCreds':
+/var/tmp/portage/net-misc/turbovnc-2.2.7-r2/work/turbovnc-2.2.7/unix/Xvnc/programs/Xserver/os/access.c:1178:18: error: storage size of 'peercred' isn't known
+ 1178 |     struct ucred peercred;
+      |                  ^~~~~~~~
+
+/var/tmp/portage/net-misc/turbovnc-2.2.7-r2/work/turbovnc-2.2.7/unix/Xvnc/programs/Xserver/Xext/xf86bigfont.c:48:10: fatal error: asm/page.h: No such file or directory
+   48 | #include <asm/page.h>
+      |          ^~~~~~~~~~~~
+
+
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -69,6 +69,8 @@
+ boolean_number(TVNC_BUILDSERVER)
+ report_option(TVNC_BUILDSERVER "TurboVNC Server")
+ 
++option(BUILDING_ON_MUSL "Define GNU macros on musl" 0)
++
+ if(TVNC_BUILDNATIVE OR TVNC_BUILDSERVER)
+ 	set(USEC 1)
+ endif()
+--- a/unix/Xvnc/programs/Xserver/os/CMakeLists.txt
++++ b/unix/Xvnc/programs/Xserver/os/CMakeLists.txt
+@@ -13,6 +13,10 @@
+ 	add_definitions(-DBSD44SOCKETS)
+ endif()
+ 
++if(BUILDING_ON_MUSL)
++	add_definitions(-D_GNU_SOURCE)
++endif()
++
+ set(EXTRASRCS "")
+ if(CMAKE_SYSTEM_NAME STREQUAL "SunOS")
+ 	add_definitions(-DSECURE_RPC)
+--- a/unix/Xvnc/programs/Xserver/Xext/CMakeLists.txt
++++ b/unix/Xvnc/programs/Xserver/Xext/CMakeLists.txt
+@@ -8,6 +8,10 @@
+ 	endif()
+ endforeach()
+ 
++if(BUILDING_ON_MUSL)
++	add_definitions(-D__GNU_LIBRARY__=2)
++endif()
++
+ disable_compiler_warnings()
+ handle_type_puns()
+ 

--- a/net-misc/turbovnc/turbovnc-2.2.7-r2.ebuild
+++ b/net-misc/turbovnc/turbovnc-2.2.7-r2.ebuild
@@ -44,6 +44,8 @@ RDEPEND="
 	x11-apps/xkbcomp
 "
 
+PATCHES=( "${FILESDIR}"/"${P}"-fix-musl-compilation.patch )
+
 src_prepare() {
 	use java && java-pkg-opt-2_src_prepare
 	cmake_src_prepare
@@ -57,6 +59,7 @@ src_configure() {
 		-DTVNC_BUILDNATIVE=$(usex java)
 		-DXKB_BIN_DIRECTORY=/usr/bin
 		-DXKB_DFLT_RULES=base
+		-DBUILDING_ON_MUSL=$(usex elibc_musl)	# bug #836723
 	)
 
 	if use ssl ; then


### PR DESCRIPTION
I fixed this by defining GNU macros in 2 places.  Ugly but it compiles.