### PR TITLE
dev-perl/Locale-gettext: Fix the compiling problem when crypt.h is missing

### DIFF
--- a/dev-perl/Locale-gettext/Locale-gettext-1.70.0-r1.ebuild
+++ b/dev-perl/Locale-gettext/Locale-gettext-1.70.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -14,6 +14,7 @@ SLOT="0"
 KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 
 RDEPEND="
+	virtual/libcrypt
 	sys-devel/gettext
 "
 BDEPEND="${RDEPEND}


### PR DESCRIPTION
<pre>
 * Package:    dev-perl/Locale-gettext-1.70.0-r1
 * Repository: gentoo
 * Maintainer: perl@gentoo.org
 * USE:        abi_x86_64 amd64 elibc_glibc kernel_linux userland_GNU
 * FEATURES:   network-sandbox preserve-libs sandbox userpriv usersandbox
>>> Unpacking source...
>>> Unpacking gettext-1.07.tar.gz to /var/tmp/portage/dev-perl/Locale-gettext-1.70.0-r1/work
>>> Source unpacked in /var/tmp/portage/dev-perl/Locale-gettext-1.70.0-r1/work
>>> Preparing source in /var/tmp/portage/dev-perl/Locale-gettext-1.70.0-r1/work/Locale-gettext-1.07 ...
 * Applying Locale-gettext-1.70.0-no-dot-inc.patch ...                                                                                                                                                      [ ok ]
>>> Source prepared.
>>> Configuring source in /var/tmp/portage/dev-perl/Locale-gettext-1.70.0-r1/work/Locale-gettext-1.07 ...
 * Using ExtUtils::MakeMaker
 * perl Makefile.PL PREFIX=/usr INSTALLDIRS=vendor INSTALLMAN3DIR=none DESTDIR=/var/tmp/portage/dev-perl/Locale-gettext-1.70.0-r1/image
checking for gettext... yes
checking for dgettext... yes
checking for ngettext... yes
checking for bind_textdomain_codeset... yes
Checking if your kit is complete...
Looks good
Generating a Unix-style Makefile
Writing Makefile for Locale::gettext
Writing MYMETA.yml and MYMETA.json
>>> Source configured.
>>> Compiling source in /var/tmp/portage/dev-perl/Locale-gettext-1.70.0-r1/work/Locale-gettext-1.07 ...
 * emake OTHERLDFLAGS=-Wl,-O1 -Wl,--as-needed OPTIMIZE=-O2 -pipe -march=native -fomit-frame-pointer
make -j5 'OTHERLDFLAGS=-Wl,-O1 -Wl,--as-needed' 'OPTIMIZE=-O2 -pipe -march=native -fomit-frame-pointer'
Running Mkbootstrap for gettext ()
"/usr/bin/perl" "/usr/lib64/perl5/5.34/ExtUtils/xsubpp"  -typemap '/usr/lib64/perl5/5.34/ExtUtils/typemap'  gettext.xs > gettext.xsc
chmod 644 "gettext.bs"
cp gettext.pm blib/lib/Locale/gettext.pm
"/usr/bin/perl" -MExtUtils::Command::MM -e 'cp_nonempty' -- gettext.bs blib/arch/auto/Locale/gettext/gettext.bs 644
Please specify prototyping behavior for gettext.xs (see perlxs manual)
mv gettext.xsc gettext.c
x86_64-pc-linux-gnu-gcc -c   -D_REENTRANT -D_GNU_SOURCE -fwrapv -fno-strict-aliasing -pipe -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -O2 -pipe -march=native -fomit-frame-pointer   -DVERSION=\"1.07\" -DXS_VERSION=\"1.07\" -fPIC "-I/usr/lib64/perl5/5.34/x86_64-linux-thread-multi/CORE"   gettext.c
In file included from /usr/lib64/perl5/5.34/x86_64-linux-thread-multi/CORE/op.h:673,
                 from /usr/lib64/perl5/5.34/x86_64-linux-thread-multi/CORE/perl.h:4086,
                 from gettext.xs:2:
/usr/lib64/perl5/5.34/x86_64-linux-thread-multi/CORE/reentr.h:124:16: fatal error: crypt.h: No such file or directory
  124 | #      include <crypt.h>
      |                ^~~~~~~~~
compilation terminated.
make: *** [Makefile:335: gettext.o] Error 1
 * ERROR: dev-perl/Locale-gettext-1.70.0-r1::gentoo failed (compile phase):
 *   emake failed
 *
 * If you need support, post the output of `emerge --info '=dev-perl/Locale-gettext-1.70.0-r1::gentoo'`,
 * the complete build log and the output of `emerge -pqv '=dev-perl/Locale-gettext-1.70.0-r1::gentoo'`.
 * The complete build log is located at '/var/tmp/portage/dev-perl/Locale-gettext-1.70.0-r1/temp/build.log'.
 * The ebuild environment file is located at '/var/tmp/portage/dev-perl/Locale-gettext-1.70.0-r1/temp/environment'.
 * Working directory: '/var/tmp/portage/dev-perl/Locale-gettext-1.70.0-r1/work/Locale-gettext-1.07'
 * S: '/var/tmp/portage/dev-perl/Locale-gettext-1.70.0-r1/work/Locale-gettext-1.07'
</pre>

Package-Manager: Portage-3.0.30-r1, Repoman-3.0.3-r1
Signed-off-by: Fco Javier Felix <ffelix@inode64.com>