### PR TITLE
dev-perl/Socket6: Fix the compiling problem when crypt.h is missing

### DIFF
--- a/dev-perl/Socket6/Socket6-0.290.0.ebuild
+++ b/dev-perl/Socket6/Socket6-0.290.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -12,6 +12,10 @@ DESCRIPTION="IPv6 related part of the C socket.h defines and structure manipulat
 LICENSE="BSD"
 SLOT="0"
 KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+
+RDEPEND="
+	virtual/libcrypt
+"
 
 src_unpack() {
 	default


### PR DESCRIPTION
<pre>
 * Package:    dev-perl/Socket6-0.290.0
 * Repository: gentoo
 * Maintainer: perl@gentoo.org
 * USE:        abi_x86_64 amd64 elibc_glibc kernel_linux userland_GNU
 * FEATURES:   network-sandbox preserve-libs sandbox userpriv usersandbox
>>> Unpacking source...
>>> Unpacking Socket6-0.29.tar.gz to /var/tmp/portage/dev-perl/Socket6-0.290.0/work
>>> Source unpacked in /var/tmp/portage/dev-perl/Socket6-0.290.0/work
>>> Preparing source in /var/tmp/portage/dev-perl/Socket6-0.290.0/work/Socket6-0.29 ...
>>> Source prepared.
>>> Configuring source in /var/tmp/portage/dev-perl/Socket6-0.290.0/work/Socket6-0.29 ...
 * Using ExtUtils::MakeMaker
 * perl Makefile.PL PREFIX=/usr INSTALLDIRS=vendor INSTALLMAN3DIR=none DESTDIR=/var/tmp/portage/dev-perl/Socket6-0.290.0/image
checking for gcc... x86_64-pc-linux-gnu-gcc
checking whether the C compiler works... yes
checking for C compiler default output file name... a.out
checking for suffix of executables...
checking whether we are cross compiling... no
checking for suffix of object files... o
checking whether we are using the GNU C compiler... yes
checking whether x86_64-pc-linux-gnu-gcc accepts -g... yes
checking for x86_64-pc-linux-gnu-gcc option to accept ISO C89... none needed
checking whether your Perl5 have PL_sv_undef... no
checking how to run the C preprocessor... x86_64-pc-linux-gnu-gcc -E
checking for grep that handles long lines and -e... /bin/grep
checking for egrep... /bin/grep -E
checking for getaddrinfo... yes
checking for getnameinfo... yes
checking for gethostbyname2... yes
checking for getipnodebyname... no
checking for getipnodebyname in -lsocket... no
checking whether your system has IPv6 directory... no
checking for getipnodebyaddr... no
checking for getipnodebyaddr in -lsocket... no
checking whether your system has IPv6 directory... (cached) no
checking for inet_pton... yes
checking for inet_ntop... yes
checking for working inet_ntop... yes
checking whether you have sa_len in struct sockaddr... no
checking whether you have sin6_scope_id in struct sockaddr_in6... yes
checking for socklen_t... yes
configure: creating ./config.status
config.status: creating config.pl
config.status: creating gailookup.pl
config.status: creating config.h
Checking if your kit is complete...
Looks good
Generating a Unix-style Makefile
Writing Makefile for Socket6
Writing MYMETA.yml and MYMETA.json
>>> Source configured.
>>> Compiling source in /var/tmp/portage/dev-perl/Socket6-0.290.0/work/Socket6-0.29 ...
 * emake OTHERLDFLAGS=-Wl,-O1 -Wl,--as-needed OPTIMIZE=-O2 -pipe -march=native -fomit-frame-pointer
make -j5 'OTHERLDFLAGS=-Wl,-O1 -Wl,--as-needed' 'OPTIMIZE=-O2 -pipe -march=native -fomit-frame-pointer'
"/usr/bin/perl" "/usr/lib64/perl5/5.34/ExtUtils/xsubpp" -noprototypes -typemap '/usr/lib64/perl5/5.34/ExtUtils/typemap'  Socket6.xs > Socket6.xsc
Running Mkbootstrap for Socket6 ()
chmod 644 "Socket6.bs"
"/usr/bin/perl" -MExtUtils::Command::MM -e 'cp_nonempty' -- Socket6.bs blib/arch/auto/Socket6/Socket6.bs 644
cp Socket6.pm blib/lib/Socket6.pm
mv Socket6.xsc Socket6.c
x86_64-pc-linux-gnu-gcc -c   -D_REENTRANT -D_GNU_SOURCE -fwrapv -fno-strict-aliasing -pipe -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -O2 -pipe -march=native -fomit-frame-pointer   -DVERSION=\"0.29\" -DXS_VERSION=\"0.29\" -fPIC "-I/usr/lib64/perl5/5.34/x86_64-linux-thread-multi/CORE"   Socket6.c
In file included from /usr/lib64/perl5/5.34/x86_64-linux-thread-multi/CORE/op.h:673,
                 from /usr/lib64/perl5/5.34/x86_64-linux-thread-multi/CORE/perl.h:4086,
                 from Socket6.xs:80:
/usr/lib64/perl5/5.34/x86_64-linux-thread-multi/CORE/reentr.h:124:16: fatal error: crypt.h: No such file or directory
  124 | #      include <crypt.h>
      |                ^~~~~~~~~
compilation terminated.
make: *** [Makefile:348: Socket6.o] Error 1
 * ERROR: dev-perl/Socket6-0.290.0::gentoo failed (compile phase):
 *   emake failed
 *
 * If you need support, post the output of `emerge --info '=dev-perl/Socket6-0.290.0::gentoo'`,
 * the complete build log and the output of `emerge -pqv '=dev-perl/Socket6-0.290.0::gentoo'`.
 * The complete build log is located at '/var/tmp/portage/dev-perl/Socket6-0.290.0/temp/build.log'.
 * The ebuild environment file is located at '/var/tmp/portage/dev-perl/Socket6-0.290.0/temp/environment'.
 * Working directory: '/var/tmp/portage/dev-perl/Socket6-0.290.0/work/Socket6-0.29'
 * S: '/var/tmp/portage/dev-perl/Socket6-0.290.0/work/Socket6-0.29'
</pre>

Package-Manager: Portage-3.0.30-r1, Repoman-3.0.3-r1
Signed-off-by: Fco Javier Felix <ffelix@inode64.com>