### PR TITLE
mail-filter/opendmarc: Recompile opendmarc when glibc is updated 

### DIFF
--- a/mail-filter/opendmarc/opendmarc-1.4.1.1-r2.ebuild
+++ b/mail-filter/opendmarc/opendmarc-1.4.1.1-r2.ebuild
@@ -23,7 +23,8 @@ RDEPEND="${DEPEND}
 		dev-perl/HTTP-Message
 		dev-perl/Switch
 	)
-	spf? ( mail-filter/libspf2 )"
+	spf? ( mail-filter/libspf2 )
+	virtual/libc"
 
 S=${WORKDIR}/OpenDMARC-rel-${PN}-${PV//./-}
 


### PR DESCRIPTION
Recompile opendmarc when glibc is updated otherwise applications that use it (example mail-mta/exim) generate an error when compiling

<pre>
x86_64-pc-linux-gnu-ranlib pdkim.a
make[2]: Leaving directory '/var/tmp/portage/mail-mta/exim-4.94.2-r7/work/exim-4.94.2/build-exim-gentoo/pdkim'

x86_64-pc-linux-gnu-gcc rf_set_ugid.c
x86_64-pc-linux-gnu-gcc -c -O2 -pipe -march=native -fomit-frame-pointer -I/usr/include/db5.3  rf_set_ugid.c
x86_64-pc-linux-gnu-gcc lookups/lf_quote.c
x86_64-pc-linux-gnu-gcc -c -O2 -pipe -march=native -fomit-frame-pointer -I/usr/include/db5.3 -I.    lookups/lf_quote.c
x86_64-pc-linux-gnu-ar cq auths.a
x86_64-pc-linux-gnu-ar cq auths.a auth-spa.o call_pam.o call_pwcheck.o call_radius.o check_serv_cond.o cram_md5.o cyrus_sasl.o dovecot.o external.o get_data.o get_no64_data.o gsasl_exim.o heimdal_gssapi.o plaintext.o pwcheck.o spa.o tls.o xtextdecode.o xtextencode.o
x86_64-pc-linux-gnu-ranlib auths.a
make[2]: Leaving directory '/var/tmp/portage/mail-mta/exim-4.94.2-r7/work/exim-4.94.2/build-exim-gentoo/auths'

x86_64-pc-linux-gnu-gcc lookups/lf_check_file.c
x86_64-pc-linux-gnu-gcc -c -O2 -pipe -march=native -fomit-frame-pointer -I/usr/include/db5.3 -I.    lookups/lf_check_file.c
x86_64-pc-linux-gnu-gcc lookups/lf_sqlperform.c
x86_64-pc-linux-gnu-gcc -c -O2 -pipe -march=native -fomit-frame-pointer -I/usr/include/db5.3 -I.    lookups/lf_sqlperform.c
x86_64-pc-linux-gnu-gcc local_scan.c
x86_64-pc-linux-gnu-gcc -DLOCAL_SCAN -c -O2 -pipe -march=native -fomit-frame-pointer -I/usr/include/db5.3 -I.  -o local_scan.o ../src/local_scan.c
x86_64-pc-linux-gnu-ar cq routers.a
x86_64-pc-linux-gnu-ranlib routers.a
make[2]: Leaving directory '/var/tmp/portage/mail-mta/exim-4.94.2-r7/work/exim-4.94.2/build-exim-gentoo/routers'

x86_64-pc-linux-gnu-ar cq transports.a
x86_64-pc-linux-gnu-ranlib transports.a
make[2]: Leaving directory '/var/tmp/portage/mail-mta/exim-4.94.2-r7/work/exim-4.94.2/build-exim-gentoo/transports'

x86_64-pc-linux-gnu-gcc -o exim
x86_64-pc-linux-gnu-gcc -o exim -Wl,-O1 -Wl,--as-needed -lssl -lcrypto  acl.o base64.o child.o crypt16.o daemon.o dbfn.o debug.o deliver.o directory.o dns.o drtables.o enq.o exim.o expand.o filter.o filtertest.o globals.o dkim.o dkim_transport.o hash.o header.o host.o ip.o log.o lss.o match.o md5.o moan.o os.o parse.o priv.o queue.o rda.o readconf.o receive.o retry.o rewrite.o rfc2047.o route.o search.o sieve.o smtp_in.o smtp_out.o spool_in.o spool_out.o std-crypto.o store.o string.o tls.o tod.o transport.o tree.o verify.o environment.o macro.o lookups/lf_quote.o lookups/lf_check_file.o lookups/lf_sqlperform.o local_scan.o  malware.o mime.o regex.o spam.o spool_mbox.o arc.o bmi_spam.o dane.o dcc.o dmarc.o imap_utf7.o spf.o srs.o utf8.o version.o \
  routers/routers.a transports/transports.a lookups/lookups.a \
  auths/auths.a pdkim/pdkim.a \
  -lresolv -lcrypt -lm    \
  -lidn -lidn2 -lopendmarc -lspf2 -lsrs_alt -ldb-5.3   \
   -lssl -lcrypto  -L/usr/lib64 -lpcre -rdynamic -ldl
/usr/lib/gcc/x86_64-pc-linux-gnu/9.4.0/../../../../x86_64-pc-linux-gnu/bin/ld: /usr/lib64/libopendmarc.so: undefined reference to `__dn_expand'
/usr/lib/gcc/x86_64-pc-linux-gnu/9.4.0/../../../../x86_64-pc-linux-gnu/bin/ld: /usr/lib64/libopendmarc.so: undefined reference to `__res_nquery'
collect2: error: ld returned 1 exit status
make[1]: *** [Makefile:640: exim] Error 1
make[1]: Leaving directory '/var/tmp/portage/mail-mta/exim-4.94.2-r7/work/exim-4.94.2/build-exim-gentoo'
make: *** [Makefile:35: all] Error 2
 * ERROR: mail-mta/exim-4.94.2-r7::gentoo failed (compile phase):
 *   emake failed
 *
 * If you need support, post the output of `emerge --info '=mail-mta/exim-4.94.2-r7::gentoo'`,
 * the complete build log and the output of `emerge -pqv '=mail-mta/exim-4.94.2-r7::gentoo'`.
 * The complete build log is located at '/var/tmp/portage/mail-mta/exim-4.94.2-r7/temp/build.log'.
 * The ebuild environment file is located at '/var/tmp/portage/mail-mta/exim-4.94.2-r7/temp/environment'.
 * Working directory: '/var/tmp/portage/mail-mta/exim-4.94.2-r7/work/exim-4.94.2'
 * S: '/var/tmp/portage/mail-mta/exim-4.94.2-r7/work/exim-4.94.2'
</pre>

Package-Manager: Portage-3.0.30-r1, Repoman-3.0.3-r1
Signed-off-by: Fco Javier Felix <ffelix@inode64.com>