### PR TITLE
games-simulation/openttd: Fix init script filename

### DIFF
--- a/games-simulation/openttd/openttd-12.2.ebuild
+++ b/games-simulation/openttd/openttd-12.2.ebuild
@@ -91,7 +91,7 @@ src_install() {
 	cmake_src_install
 	if use dedicated ; then
 		newconfd "${FILESDIR}"/openttd.confd openttd
-		newinitd "${FILESDIR}"/openttd.initd-r1 openttd
+		newinitd "${FILESDIR}"/openttd.initd-r2 openttd
 	fi
 }
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/837989

Signed-off-by: David King <amigadave@amigadave.com>