### PR TITLE
mail-filter/rspamd: add missing zlib dependency

### DIFF
--- a/mail-filter/rspamd/rspamd-2.7-r104.ebuild
+++ b/mail-filter/rspamd/rspamd-2.7-r104.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-LUA_COMPAT=( lua5-{1..3} luajit )
+LUA_COMPAT=( lua5-{1..2} luajit )
 
 inherit cmake lua-single pax-utils systemd tmpfiles
 
@@ -12,36 +12,32 @@ if [[ ${PV} == *9999 ]] ; then
 	inherit git-r3
 else
 	SRC_URI="https://github.com/rspamd/rspamd/archive/${PV}.tar.gz -> ${P}.tar.gz"
-	KEYWORDS="~amd64 ~x86"
+	KEYWORDS="amd64 x86"
 fi
 
 DESCRIPTION="Rapid spam filtering system"
 HOMEPAGE="https://rspamd.com https://github.com/rspamd/rspamd"
 LICENSE="Apache-2.0 Boost-1.0 BSD BSD-1 BSD-2 CC0-1.0 LGPL-3 MIT public-domain unicode ZLIB"
 SLOT="0"
-IUSE="blas cpu_flags_x86_ssse3 jemalloc +jit pcre2 test"
-RESTRICT="!test? ( test )"
+IUSE="blas cpu_flags_x86_ssse3 jemalloc +jit pcre2"
 
-# A part of tests use ffi luajit extension
-REQUIRED_USE="${LUA_REQUIRED_USE}
-	test? ( lua_single_target_luajit )"
+REQUIRED_USE="${LUA_REQUIRED_USE}"
 
 RDEPEND="${LUA_DEPS}
 	$(lua_gen_cond_dep '
 		dev-lua/LuaBitOp[${LUA_USEDEP}]
-	')
+	' lua5-{1,2})
 	acct-group/rspamd
 	acct-user/rspamd
 	app-arch/zstd:=
 	dev-db/sqlite:3
-	dev-cpp/doctest
 	dev-libs/glib:2
 	dev-libs/icu:=
 	dev-libs/libev
-	dev-libs/libfmt:=
 	dev-libs/libsodium:=
 	dev-libs/snowball-stemmer:=
 	sys-apps/file
+	sys-libs/zlib
 	blas? (
 		virtual/blas
 		virtual/lapack
@@ -58,18 +54,16 @@ BDEPEND="
 "
 
 PATCHES=(
-	"${FILESDIR}/${P}-cmake-lua-version.patch"
-	"${FILESDIR}/${P}-system-libfmt.patch"
-	"${FILESDIR}/${P}-system-doctest.patch"
-	"${FILESDIR}/${P}-fix-null-dereference.patch"
-	"${FILESDIR}/${PN}-2.6-unbundle-lua.patch"
-	"${FILESDIR}/${PN}-2.5-unbundle-snowball.patch"
+	"${FILESDIR}/rspamd-2.7-cmake-lua-version.patch"
+	"${FILESDIR}/rspamd-2.6-unbundle-lua.patch"
+	"${FILESDIR}/rspamd-2.7-unbundle-zstd.patch"
+	"${FILESDIR}/rspamd-2.5-unbundle-snowball.patch"
 )
 
 src_prepare() {
 	cmake_src_prepare
 
-	rm -vrf contrib/{doctest,fmt,lua-bit,snowball,zstd} || die
+	rm -vrf contrib/{lua-bit,snowball,zstd} || die
 
 	sed -i -e 's/User=_rspamd/User=rspamd/g' \
 		rspamd.service \
@@ -82,11 +76,6 @@ src_configure() {
 		-DRUNDIR=/var/run/rspamd
 		-DDBDIR=/var/lib/rspamd
 		-DLOGDIR=/var/log/rspamd
-
-		-DSYSTEM_DOCTEST=ON
-		-DSYSTEM_FMT=ON
-		-DSYSTEM_ZSTD=ON
-
 		-DENABLE_BLAS=$(usex blas ON OFF)
 		-DENABLE_HYPERSCAN=$(usex cpu_flags_x86_ssse3 ON OFF)
 		-DENABLE_JEMALLOC=$(usex jemalloc ON OFF)
@@ -97,7 +86,7 @@ src_configure() {
 }
 
 src_test() {
-	cmake_build run-test
+	cmake_src_test
 }
 
 src_install() {

--- a/mail-filter/rspamd/rspamd-3.0-r4.ebuild
+++ b/mail-filter/rspamd/rspamd-3.0-r4.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-LUA_COMPAT=( lua5-{1..2} luajit )
+LUA_COMPAT=( lua5-{1..3} luajit )
 
 inherit cmake lua-single pax-utils systemd tmpfiles
 
@@ -12,31 +12,37 @@ if [[ ${PV} == *9999 ]] ; then
 	inherit git-r3
 else
 	SRC_URI="https://github.com/rspamd/rspamd/archive/${PV}.tar.gz -> ${P}.tar.gz"
-	KEYWORDS="amd64 x86"
+	KEYWORDS="~amd64 ~x86"
 fi
 
 DESCRIPTION="Rapid spam filtering system"
 HOMEPAGE="https://rspamd.com https://github.com/rspamd/rspamd"
 LICENSE="Apache-2.0 Boost-1.0 BSD BSD-1 BSD-2 CC0-1.0 LGPL-3 MIT public-domain unicode ZLIB"
 SLOT="0"
-IUSE="blas cpu_flags_x86_ssse3 jemalloc +jit pcre2"
+IUSE="blas cpu_flags_x86_ssse3 jemalloc +jit pcre2 test"
+RESTRICT="!test? ( test )"
 
-REQUIRED_USE="${LUA_REQUIRED_USE}"
+# A part of tests use ffi luajit extension
+REQUIRED_USE="${LUA_REQUIRED_USE}
+	test? ( lua_single_target_luajit )"
 
 RDEPEND="${LUA_DEPS}
 	$(lua_gen_cond_dep '
 		dev-lua/LuaBitOp[${LUA_USEDEP}]
-	' lua5-{1,2})
+	')
 	acct-group/rspamd
 	acct-user/rspamd
 	app-arch/zstd:=
 	dev-db/sqlite:3
+	dev-cpp/doctest
 	dev-libs/glib:2
 	dev-libs/icu:=
 	dev-libs/libev
+	dev-libs/libfmt:=
 	dev-libs/libsodium:=
 	dev-libs/snowball-stemmer:=
 	sys-apps/file
+	sys-libs/zlib
 	blas? (
 		virtual/blas
 		virtual/lapack
@@ -53,16 +59,18 @@ BDEPEND="
 "
 
 PATCHES=(
-	"${FILESDIR}/rspamd-2.7-cmake-lua-version.patch"
-	"${FILESDIR}/rspamd-2.6-unbundle-lua.patch"
-	"${FILESDIR}/rspamd-2.7-unbundle-zstd.patch"
-	"${FILESDIR}/rspamd-2.5-unbundle-snowball.patch"
+	"${FILESDIR}/${P}-cmake-lua-version.patch"
+	"${FILESDIR}/${P}-system-libfmt.patch"
+	"${FILESDIR}/${P}-system-doctest.patch"
+	"${FILESDIR}/${P}-fix-null-dereference.patch"
+	"${FILESDIR}/${PN}-2.6-unbundle-lua.patch"
+	"${FILESDIR}/${PN}-2.5-unbundle-snowball.patch"
 )
 
 src_prepare() {
 	cmake_src_prepare
 
-	rm -vrf contrib/{lua-bit,snowball,zstd} || die
+	rm -vrf contrib/{doctest,fmt,lua-bit,snowball,zstd} || die
 
 	sed -i -e 's/User=_rspamd/User=rspamd/g' \
 		rspamd.service \
@@ -75,6 +83,11 @@ src_configure() {
 		-DRUNDIR=/var/run/rspamd
 		-DDBDIR=/var/lib/rspamd
 		-DLOGDIR=/var/log/rspamd
+
+		-DSYSTEM_DOCTEST=ON
+		-DSYSTEM_FMT=ON
+		-DSYSTEM_ZSTD=ON
+
 		-DENABLE_BLAS=$(usex blas ON OFF)
 		-DENABLE_HYPERSCAN=$(usex cpu_flags_x86_ssse3 ON OFF)
 		-DENABLE_JEMALLOC=$(usex jemalloc ON OFF)
@@ -85,7 +98,7 @@ src_configure() {
 }
 
 src_test() {
-	cmake_src_test
+	cmake_build run-test
 }
 
 src_install() {

--- a/mail-filter/rspamd/rspamd-3.1-r2.ebuild
+++ b/mail-filter/rspamd/rspamd-3.1-r2.ebuild
@@ -41,6 +41,7 @@ RDEPEND="${LUA_DEPS}
 	dev-libs/libsodium:=
 	dev-libs/snowball-stemmer:=
 	sys-apps/file
+	sys-libs/zlib
 	blas? (
 		virtual/blas
 		virtual/lapack


### PR DESCRIPTION
This follows a change from commit 8bf75c7b9949 - `mail-filter/rspamd: add missing zlib dependency`. The zlib was integrated to rspamd-1.7.0, this dependency is missing for quite some time.