### PR TITLE
app-emulation/cloud-init: Drop patches

### DIFF
--- a/app-emulation/cloud-init/cloud-init-9999.ebuild
+++ b/app-emulation/cloud-init/cloud-init-9999.ebuild
@@ -51,13 +51,6 @@ RDEPEND="
 	virtual/logger
 "
 
-PATCHES=(
-	# Fix Gentoo support
-	# https://code.launchpad.net/~gilles-dartiguelongue/cloud-init/+git/cloud-init/+merge/358777
-	"${FILESDIR}"/22.1-fix-update_package_sources-function.patch
-	"${FILESDIR}"/22.1-add-support-for-package_upgrade.patch
-)
-
 distutils_enable_tests pytest
 
 python_prepare_all() {


### PR DESCRIPTION
Patches were upstreamed yesterday. Emerging 9999 now fails. Drop patches in 9999.

Failed emerge log: [patch-fail-to-apply.txt](https://github.com/gentoo/gentoo/files/8474508/patch-fail-to-apply.txt)

Emerge with test log: [remove-patch-emerge-test.txt](https://github.com/gentoo/gentoo/files/8474531/remove-patch-emerge-test.txt)