### PR TITLE
media-video/wireplumber: add virtual/libintl RDEPEND

### DIFF
--- a/media-video/wireplumber/wireplumber-9999.ebuild
+++ b/media-video/wireplumber/wireplumber-9999.ebuild
@@ -43,6 +43,7 @@ DEPEND="
 	>=dev-libs/glib-2.62
 	>=media-video/pipewire-0.3.48:=
 	virtual/libc
+	virtual/libintl
 	elogind? ( sys-auth/elogind )
 	systemd? ( sys-apps/systemd )
 "


### PR DESCRIPTION
The in-development version has very recently started to provide
localized translations for user visible text and for that reason now
links against the intl library. On glibc systems this will likely
result in no observable change to the final binaries.
