### PR TITLE
app-arch/libarchive: Add an e2fsprogs ABI dependency

### DIFF
--- a/app-arch/libarchive/libarchive-3.5.3.ebuild
+++ b/app-arch/libarchive/libarchive-3.5.3.ebuild
@@ -38,7 +38,7 @@ RDEPEND="
 DEPEND="${RDEPEND}
 	kernel_linux? (
 		virtual/os-headers
-		e2fsprogs? ( sys-fs/e2fsprogs )
+		e2fsprogs? ( sys-fs/e2fsprogs[${MULTILIB_USEDEP}] )
 	)
 "
 BDEPEND="

--- a/app-arch/libarchive/libarchive-3.6.0.ebuild
+++ b/app-arch/libarchive/libarchive-3.6.0.ebuild
@@ -38,7 +38,7 @@ RDEPEND="
 DEPEND="${RDEPEND}
 	kernel_linux? (
 		virtual/os-headers
-		e2fsprogs? ( sys-fs/e2fsprogs )
+		e2fsprogs? ( sys-fs/e2fsprogs[${MULTILIB_USEDEP}] )
 	)
 "
 BDEPEND="

--- a/app-arch/libarchive/libarchive-3.6.1.ebuild
+++ b/app-arch/libarchive/libarchive-3.6.1.ebuild
@@ -38,7 +38,7 @@ RDEPEND="
 DEPEND="${RDEPEND}
 	kernel_linux? (
 		virtual/os-headers
-		e2fsprogs? ( sys-fs/e2fsprogs )
+		e2fsprogs? ( sys-fs/e2fsprogs[${MULTILIB_USEDEP}] )
 	)
 "
 BDEPEND="


### PR DESCRIPTION
Without this I get compile errors about an unsupported abi_x86_32 when I
build libarchive on a system with an e2fsprogs built without
ABI_X86="32".

Signed-off-by: Palmer Dabbelt <palmer@rivosinc.com>

---

I haven't tried this one at all, I just pattern-matched the ABI
dependency from the other lines.  I already manually rebuilt my
e2fsprogs, so the problem is gone locally.

I haven't actually contributed to Gentoo before (or if I do, I don't remember having done so).  Github looks like a mirror, but the wiki suggests PRs are a viable way to go.  Happy to use email, though ;)