### PR TITLE
dev-libs/intel-compute-runtime-22.*.*: Filter LTO flags

### DIFF
--- a/dev-libs/intel-compute-runtime/intel-compute-runtime-22.12.22749.ebuild
+++ b/dev-libs/intel-compute-runtime/intel-compute-runtime-22.12.22749.ebuild
@@ -7,7 +7,7 @@ CMAKE_BUILD_TYPE="Release"
 MY_PN="${PN/intel-/}"
 MY_P="${MY_PN}-${PV}"
 
-inherit cmake
+inherit cmake flag-o-matic
 
 DESCRIPTION="Intel Graphics Compute Runtime for oneAPI Level Zero and OpenCL Driver"
 HOMEPAGE="https://github.com/intel/compute-runtime"
@@ -44,6 +44,9 @@ DOCS=( "README.md" "FAQ.md" )
 PATCHES=( "${FILESDIR}/${PN}-22.12.22749-metrics.patch" )
 
 src_configure() {
+	# https://bugs.gentoo.org/838241
+	filter-flags -flto=* -flto
+
 	local mycmakeargs=(
 		-DCMAKE_INSTALL_PREFIX="${EPREFIX}/usr"
 		-DCMAKE_INSTALL_LIBDIR="$(get_libdir)"

--- a/dev-libs/intel-compute-runtime/intel-compute-runtime-22.13.22789.ebuild
+++ b/dev-libs/intel-compute-runtime/intel-compute-runtime-22.13.22789.ebuild
@@ -7,7 +7,7 @@ CMAKE_BUILD_TYPE="Release"
 MY_PN="${PN/intel-/}"
 MY_P="${MY_PN}-${PV}"
 
-inherit cmake
+inherit cmake flag-o-matic
 
 DESCRIPTION="Intel Graphics Compute Runtime for oneAPI Level Zero and OpenCL Driver"
 HOMEPAGE="https://github.com/intel/compute-runtime"
@@ -42,6 +42,9 @@ BDEPEND="virtual/pkgconfig"
 DOCS=( "README.md" "FAQ.md" )
 
 src_configure() {
+	# https://bugs.gentoo.org/838241
+	filter-flags -flto=* -flto
+
 	local mycmakeargs=(
 		-DCMAKE_INSTALL_PREFIX="${EPREFIX}/usr"
 		-DCMAKE_INSTALL_LIBDIR="$(get_libdir)"

--- a/dev-libs/intel-compute-runtime/intel-compute-runtime-22.14.22890.ebuild
+++ b/dev-libs/intel-compute-runtime/intel-compute-runtime-22.14.22890.ebuild
@@ -7,7 +7,7 @@ CMAKE_BUILD_TYPE="Release"
 MY_PN="${PN/intel-/}"
 MY_P="${MY_PN}-${PV}"
 
-inherit cmake
+inherit cmake flag-o-matic
 
 DESCRIPTION="Intel Graphics Compute Runtime for oneAPI Level Zero and OpenCL Driver"
 HOMEPAGE="https://github.com/intel/compute-runtime"
@@ -42,6 +42,9 @@ BDEPEND="virtual/pkgconfig"
 DOCS=( "README.md" "FAQ.md" )
 
 src_configure() {
+	# https://bugs.gentoo.org/838241
+	filter-flags -flto=* -flto
+
 	local mycmakeargs=(
 		-DCMAKE_INSTALL_PREFIX="${EPREFIX}/usr"
 		-DCMAKE_INSTALL_LIBDIR="$(get_libdir)"


### PR DESCRIPTION
Compiling any of the `dev-libs/intel-compute-runtime-22.*.*` ebuilds with LTO *FLAGS produces fail with `error: lto-wrapper failed`.

Bug: https://bugs.gentoo.org/838241
Bug: https://github.com/intel/compute-runtime/issues/531
Signed-off-by: Randall Vasquez <ran.dall@icloud.com>