### PR TITLE
linux-info.eclass: Call ebegin, properly close with eend

### DIFF
--- a/eclass/linux-info.eclass
+++ b/eclass/linux-info.eclass
@@ -781,7 +781,7 @@ check_extra_config() {
 		require_configured_kernel
 	fi
 
-	einfo "Checking for suitable kernel configuration options..."
+	ebegin "Checking for suitable kernel configuration options"
 
 	for config in ${CONFIG_CHECK}
 	do
@@ -857,6 +857,7 @@ check_extra_config() {
 	done
 
 	if [[ ${hard_errors_count} -gt 0 ]]; then
+		eend 1
 		eerror "Please check to make sure these options are set correctly."
 		eerror "Failure to do so may cause unexpected problems."
 		eerror "Once you have satisfied these options, please try merging"
@@ -864,6 +865,7 @@ check_extra_config() {
 		export LINUX_CONFIG_EXISTS_DONE="${old_LINUX_CONFIG_EXISTS_DONE}"
 		die "Incorrect kernel configuration options"
 	elif [[ ${soft_errors_count} -gt 0 ]]; then
+		eend 1
 		ewarn "Please check to make sure these options are set correctly."
 		ewarn "Failure to do so may cause unexpected problems."
 	else


### PR DESCRIPTION
A recent QA check added to portage informs of eend being called without
a preceding call to ebegin.

This warning was emitted during pkg_setup for net-vpn/openvpn, and was
traced back to the check_extra_config() function in linux-info.eclass.

The preference is here to call ebegin (instead of dropping the lone
eend) and in each of the possible exit branches for check_extra_config()
call eend appropriately.

Reported-by: Sam James <sam@gentoo.org>
Signed-off-by: Thomas Bracht Laumann Jespersen <t@laumann.xyz>