### PR TITLE
opencv-4.5.*: Fliter -O3 flags back down to -O2

### DIFF
--- a/media-libs/opencv/opencv-4.5.2-r3.ebuild
+++ b/media-libs/opencv/opencv-4.5.2-r3.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{7,8,9} )
 CMAKE_ECLASS=cmake
-inherit java-pkg-opt-2 java-ant-2 cmake-multilib python-r1 toolchain-funcs
+inherit flag-o-matic java-pkg-opt-2 java-ant-2 cmake-multilib python-r1 toolchain-funcs
 
 DESCRIPTION="A collection of algorithms and sample code for various computer vision problems"
 HOMEPAGE="https://opencv.org"
@@ -295,6 +295,9 @@ pkg_setup() {
 }
 
 src_prepare() {
+	# https://bugs.gentoo.org/838274
+	replace-flags -O3 -O2
+
 	cmake_src_prepare
 
 	# remove bundled stuff

--- a/media-libs/opencv/opencv-4.5.2-r5.ebuild
+++ b/media-libs/opencv/opencv-4.5.2-r5.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{7,8,9,10} )
 CMAKE_ECLASS=cmake
-inherit java-pkg-opt-2 java-ant-2 cmake-multilib python-r1 toolchain-funcs
+inherit flag-o-matic java-pkg-opt-2 java-ant-2 cmake-multilib python-r1 toolchain-funcs
 
 DESCRIPTION="A collection of algorithms and sample code for various computer vision problems"
 HOMEPAGE="https://opencv.org"
@@ -296,6 +296,9 @@ pkg_setup() {
 }
 
 src_prepare() {
+	# https://bugs.gentoo.org/838274
+	replace-flags -O3 -O2
+
 	cmake_src_prepare
 
 	# remove bundled stuff

--- a/media-libs/opencv/opencv-4.5.4.ebuild
+++ b/media-libs/opencv/opencv-4.5.4.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{8..10} )
 CMAKE_ECLASS=cmake
-inherit java-pkg-opt-2 java-ant-2 cmake-multilib python-r1 toolchain-funcs
+inherit flag-o-matic java-pkg-opt-2 java-ant-2 cmake-multilib python-r1 toolchain-funcs
 
 DESCRIPTION="A collection of algorithms and sample code for various computer vision problems"
 HOMEPAGE="https://opencv.org"
@@ -307,6 +307,9 @@ pkg_setup() {
 }
 
 src_prepare() {
+	# https://bugs.gentoo.org/838274
+	replace-flags -O3 -O2
+
 	cmake_src_prepare
 
 	# remove bundled stuff

--- a/media-libs/opencv/opencv-4.5.5-r1.ebuild
+++ b/media-libs/opencv/opencv-4.5.5-r1.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{8..10} )
 CMAKE_ECLASS=cmake
-inherit java-pkg-opt-2 java-ant-2 cmake-multilib python-r1 toolchain-funcs
+inherit flag-o-matic java-pkg-opt-2 java-ant-2 cmake-multilib python-r1 toolchain-funcs
 
 DESCRIPTION="A collection of algorithms and sample code for various computer vision problems"
 HOMEPAGE="https://opencv.org"
@@ -303,6 +303,9 @@ pkg_setup() {
 }
 
 src_prepare() {
+	# https://bugs.gentoo.org/838274
+	replace-flags -O3 -O2
+
 	cmake_src_prepare
 
 	# remove bundled stuff

--- a/media-libs/opencv/opencv-4.5.5.ebuild
+++ b/media-libs/opencv/opencv-4.5.5.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{8..10} )
 CMAKE_ECLASS=cmake
-inherit java-pkg-opt-2 java-ant-2 cmake-multilib python-r1 toolchain-funcs
+inherit flag-o-matic java-pkg-opt-2 java-ant-2 cmake-multilib python-r1 toolchain-funcs
 
 DESCRIPTION="A collection of algorithms and sample code for various computer vision problems"
 HOMEPAGE="https://opencv.org"
@@ -303,6 +303,9 @@ pkg_setup() {
 }
 
 src_prepare() {
+	# https://bugs.gentoo.org/838274
+	replace-flags -O3 -O2
+
 	cmake_src_prepare
 
 	# remove bundled stuff


### PR DESCRIPTION
`opencv-4.5.5-r1` stalls when building with `-O3` for hours, and when building with `-O2`, it  builds in about 10mins.

I did also test the other versions of `opencv` and they all stalled, so I applied the fix to all the available ebuilds.

Bug: https://bugs.gentoo.org/838274
Signed-off-by: Randall Vasquez <ran.dall@icloud.com>