### PR TITLE
>=media-video/pipewire-0.3.43-r3: Filter -fno-semantic-interposition

### DIFF
--- a/media-video/pipewire/pipewire-0.3.43-r3.ebuild
+++ b/media-video/pipewire/pipewire-0.3.43-r3.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 PYTHON_COMPAT=( python3_{8..10} )
 
-inherit meson-multilib optfeature prefix python-any-r1 systemd udev
+inherit flag-o-matic meson-multilib optfeature prefix python-any-r1 systemd udev
 
 if [[ ${PV} == 9999 ]]; then
 	EGIT_REPO_URI="https://gitlab.freedesktop.org/${PN}/${PN}.git"
@@ -119,6 +119,9 @@ python_check_deps() {
 }
 
 src_prepare() {
+	# https://bugs.gentoo.org/838301
+	filter-flags -fno-semantic-interposition
+
 	default
 
 	einfo "Generating ${limitsdfile}"
@@ -132,6 +135,9 @@ src_prepare() {
 }
 
 multilib_src_configure() {
+	# https://bugs.gentoo.org/838301
+	filter-flags -fno-semantic-interposition
+
 	local emesonargs=(
 		-Ddocdir="${EPREFIX}"/usr/share/doc/${PF}
 		$(meson_native_use_feature zeroconf avahi)

--- a/media-video/pipewire/pipewire-0.3.44-r1.ebuild
+++ b/media-video/pipewire/pipewire-0.3.44-r1.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 PYTHON_COMPAT=( python3_{8..10} )
 
-inherit meson-multilib optfeature prefix python-any-r1 systemd udev
+inherit flag-o-matic meson-multilib optfeature prefix python-any-r1 systemd udev
 
 if [[ ${PV} == 9999 ]]; then
 	EGIT_REPO_URI="https://gitlab.freedesktop.org/${PN}/${PN}.git"
@@ -122,6 +122,9 @@ python_check_deps() {
 }
 
 src_prepare() {
+	# https://bugs.gentoo.org/838301
+	filter-flags -fno-semantic-interposition
+
 	default
 
 	einfo "Generating ${limitsdfile}"
@@ -135,6 +138,9 @@ src_prepare() {
 }
 
 multilib_src_configure() {
+	# https://bugs.gentoo.org/838301
+	filter-flags -fno-semantic-interposition
+
 	local emesonargs=(
 		-Ddocdir="${EPREFIX}"/usr/share/doc/${PF}
 

--- a/media-video/pipewire/pipewire-0.3.45_p20220205.ebuild
+++ b/media-video/pipewire/pipewire-0.3.45_p20220205.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 PYTHON_COMPAT=( python3_{8..10} )
 
-inherit meson-multilib optfeature prefix python-any-r1 systemd udev
+inherit flag-o-matic meson-multilib optfeature prefix python-any-r1 systemd udev
 
 if [[ ${PV} == 9999 ]]; then
 	EGIT_REPO_URI="https://gitlab.freedesktop.org/${PN}/${PN}.git"
@@ -153,6 +153,9 @@ src_prepare() {
 }
 
 multilib_src_configure() {
+	# https://bugs.gentoo.org/838301
+	filter-flags -fno-semantic-interposition
+
 	local emesonargs=(
 		-Ddocdir="${EPREFIX}"/usr/share/doc/${PF}
 

--- a/media-video/pipewire/pipewire-0.3.47-r1.ebuild
+++ b/media-video/pipewire/pipewire-0.3.47-r1.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 PYTHON_COMPAT=( python3_{8..10} )
 
-inherit meson-multilib optfeature prefix python-any-r1 systemd udev
+inherit flag-o-matic meson-multilib optfeature prefix python-any-r1 systemd udev
 
 if [[ ${PV} == 9999 ]]; then
 	EGIT_REPO_URI="https://gitlab.freedesktop.org/${PN}/${PN}.git"
@@ -156,6 +156,9 @@ src_prepare() {
 }
 
 multilib_src_configure() {
+	# https://bugs.gentoo.org/838301
+	filter-flags -fno-semantic-interposition
+
 	local emesonargs=(
 		-Ddocdir="${EPREFIX}"/usr/share/doc/${PF}
 

--- a/media-video/pipewire/pipewire-0.3.48-r1.ebuild
+++ b/media-video/pipewire/pipewire-0.3.48-r1.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 PYTHON_COMPAT=( python3_{8..10} )
 
-inherit meson-multilib optfeature prefix python-any-r1 systemd udev
+inherit flag-o-matic meson-multilib optfeature prefix python-any-r1 systemd udev
 
 if [[ ${PV} == 9999 ]]; then
 	EGIT_REPO_URI="https://gitlab.freedesktop.org/${PN}/${PN}.git"
@@ -154,6 +154,9 @@ src_prepare() {
 }
 
 multilib_src_configure() {
+	# https://bugs.gentoo.org/838301
+	filter-flags -fno-semantic-interposition
+
 	local emesonargs=(
 		-Ddocdir="${EPREFIX}"/usr/share/doc/${PF}
 

--- a/media-video/pipewire/pipewire-0.3.49.ebuild
+++ b/media-video/pipewire/pipewire-0.3.49.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 PYTHON_COMPAT=( python3_{8..10} )
 
-inherit meson-multilib optfeature prefix python-any-r1 systemd udev
+inherit flag-o-matic meson-multilib optfeature prefix python-any-r1 systemd udev
 
 if [[ ${PV} == 9999 ]]; then
 	EGIT_REPO_URI="https://gitlab.freedesktop.org/${PN}/${PN}.git"
@@ -154,6 +154,9 @@ src_prepare() {
 }
 
 multilib_src_configure() {
+	# https://bugs.gentoo.org/838301
+	filter-flags -fno-semantic-interposition
+
 	local emesonargs=(
 		-Ddocdir="${EPREFIX}"/usr/share/doc/${PF}
 

--- a/media-video/pipewire/pipewire-0.3.50.ebuild
+++ b/media-video/pipewire/pipewire-0.3.50.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 PYTHON_COMPAT=( python3_{8..10} )
 
-inherit meson-multilib optfeature prefix python-any-r1 systemd udev
+inherit flag-o-matic meson-multilib optfeature prefix python-any-r1 systemd udev
 
 if [[ ${PV} == 9999 ]]; then
 	EGIT_REPO_URI="https://gitlab.freedesktop.org/${PN}/${PN}.git"
@@ -154,6 +154,9 @@ src_prepare() {
 }
 
 multilib_src_configure() {
+	# https://bugs.gentoo.org/838301
+	filter-flags -fno-semantic-interposition
+
 	local emesonargs=(
 		-Ddocdir="${EPREFIX}"/usr/share/doc/${PF}
 

--- a/media-video/pipewire/pipewire-9999.ebuild
+++ b/media-video/pipewire/pipewire-9999.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 PYTHON_COMPAT=( python3_{8..10} )
 
-inherit meson-multilib optfeature prefix python-any-r1 systemd udev
+inherit flag-o-matic meson-multilib optfeature prefix python-any-r1 systemd udev
 
 if [[ ${PV} == 9999 ]]; then
 	EGIT_REPO_URI="https://gitlab.freedesktop.org/${PN}/${PN}.git"
@@ -154,6 +154,9 @@ src_prepare() {
 }
 
 multilib_src_configure() {
+	# https://bugs.gentoo.org/838301
+	filter-flags -fno-semantic-interposition
+
 	local emesonargs=(
 		-Ddocdir="${EPREFIX}"/usr/share/doc/${PF}
 


### PR DESCRIPTION
Since `0.3.39`, it's been observed that media-video/pipewire, won't build with the CFLAG -fno-semantic-interposition enabled

Ref: https://github.com/InBetweenNames/gentooLTO/pull/798
Bug: https://bugs.gentoo.org/838301
Signed-off-by: Randall Vasquez <ran.dall@icloud.com>