### PR TITLE
dev-qt/qtwayland: fixed building with clang

### DIFF
--- a/dev-qt/qtwayland/files/qtwayland-5.15.3-clang.patch
+++ b/dev-qt/qtwayland/files/qtwayland-5.15.3-clang.patch
@@ -1,0 +1,11 @@
+--- a/src/hardwareintegration/compositor/linux-dmabuf-unstable-v1/linuxdmabuf.h
++++ b/src/hardwareintegration/compositor/linux-dmabuf-unstable-v1/linuxdmabuf.h
+@@ -44,6 +44,8 @@
+ #include <EGL/egl.h>
+ #include <EGL/eglext.h>
+ 
++#include <array>
++
+ // compatibility with libdrm <= 2.4.74
+ #ifndef DRM_FORMAT_RESERVED
+ #define DRM_FORMAT_RESERVED           ((1ULL << 56) - 1)

--- a/dev-qt/qtwayland/qtwayland-5.15.3-r1.ebuild
+++ b/dev-qt/qtwayland/qtwayland-5.15.3-r1.ebuild
@@ -33,7 +33,10 @@ BDEPEND="
 	dev-util/wayland-scanner
 "
 
-PATCHES=( "${FILESDIR}/${PN}-5.15.2-QTBUG-90037-QTBUG-91264.patch" ) # upstream pending
+PATCHES=(
+	"${FILESDIR}/${PN}-5.15.2-QTBUG-90037-QTBUG-91264.patch" # upstream pending
+	"${FILESDIR}/${PN}-5.15.3-clang.patch"
+)
 
 src_configure() {
 	local myqmakeargs=(


### PR DESCRIPTION
added qtwayland-5.15.3-clang.patch that fixes building with clang

Closes: https://github.com/gentoo/gentoo/pull/25030
Signed-off-by: Denis Pronin <dannftk@yandex.ru>