### PR TITLE
dev-libs/libpwquality: support python-3.10 in libpwquality-1.4.4

### DIFF
--- a/dev-libs/libpwquality/libpwquality-1.4.4.ebuild
+++ b/dev-libs/libpwquality/libpwquality-1.4.4.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{7..9} )
+PYTHON_COMPAT=( python3_{7..10} )
 
 inherit pam python-r1 usr-ldscript
 


### PR DESCRIPTION
python-3.10 compatibility in the libpwquality-1.4.4 package

Closes: https://github.com/gentoo/gentoo/pull/25040

Signed-off-by: Denis Pronin <dannftk@yandex.ru>