### PR TITLE
dev-libs/gom: support python-3.10

### DIFF
--- a/dev-libs/gom/gom-0.4.ebuild
+++ b/dev-libs/gom/gom-0.4.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 GCONF_DEBUG="yes"
-PYTHON_COMPAT=( python3_{7..9} )
+PYTHON_COMPAT=( python3_{7..10} )
 
 inherit gnome.org meson python-r1
 


### PR DESCRIPTION
dev-libs/gom now is compatible with python-3.10

Closes: https://github.com/gentoo/gentoo/pull/25041
Signed-off-by: Denis Pronin <dannftk@yandex.ru>