### PR TITLE
app-editors/qhexedit2: support python-3.10 in qhexedit2-0.8.6_p20190316

### DIFF
--- a/app-editors/qhexedit2/qhexedit2-0.8.6_p20190316.ebuild
+++ b/app-editors/qhexedit2/qhexedit2-0.8.6_p20190316.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{7,8,9} )
+PYTHON_COMPAT=( python3_{7..10} )
 
 DISTUTILS_OPTIONAL=1
 


### PR DESCRIPTION
qhexedit2-0.8.6_p20190316 now is compatible with python-3.10

Closes: https://github.com/gentoo/gentoo/pull/25042
Signed-off-by: Denis Pronin <dannftk@yandex.ru>