### PR TITLE
gnome-extra/gnome-contacts: req =>vala-0.54

### DIFF
--- a/gnome-extra/gnome-contacts/gnome-contacts-42.0.ebuild
+++ b/gnome-extra/gnome-contacts/gnome-contacts-42.0.ebuild
@@ -3,6 +3,7 @@
 
 EAPI=8
 PYTHON_COMPAT=( python3_{8..10} )
+VALA_MIN_API_VERSION="0.54"
 
 inherit gnome.org gnome2-utils meson python-any-r1 vala xdg
 


### PR DESCRIPTION
Despite the maven.build upstream stating a minimum vala API of 0.40,
any builds with that API or any lower that 0.54 fail.

Closes: https://bugs.gentoo.org/838727
Package-Manager: Portage-3.0.30, Repoman-3.0.3
Signed-off-by: Jay Faulkner <jay@jvf.cc>