### PR TITLE
Libkms removal

### DIFF
--- a/sys-boot/plymouth/metadata.xml
+++ b/sys-boot/plymouth/metadata.xml
@@ -6,7 +6,7 @@
 		<name>Matthew Thode</name>
 	</maintainer>
 	<use>
-		<flag name="libkms">Provides abstraction to the DRM drivers (intel,
+		<flag name="drm">Provides abstraction to the DRM drivers (intel,
 			nouveau and vmwgfx at this moment)</flag>
 		<flag name="pango">Adds support for printing text on splash screen and
 			text prompts, e.g. for password</flag>

--- a/sys-boot/plymouth/plymouth-0.9.5-r2.ebuild
+++ b/sys-boot/plymouth/plymouth-0.9.5-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -10,29 +10,27 @@ if [[ ${PV} == 9999 ]]; then
 	inherit git-r3
 	EGIT_REPO_URI="https://gitlab.freedesktop.org/plymouth/plymouth"
 else
-	PRE_RELEASE_SHA="5b91b9ed84cc91759c986634a4d64d474e6092cf"
-	SRC_URI="${SRC_URI} https://gitlab.freedesktop.org/${PN}/${PN}/-/archive/${PRE_RELEASE_SHA}/${PN}-${PRE_RELEASE_SHA}.tar.gz"
+	SRC_URI="${SRC_URI} https://www.freedesktop.org/software/plymouth/releases/${P}.tar.xz"
 	KEYWORDS="~alpha amd64 arm arm64 ~ia64 ppc ppc64 ~riscv sparc x86"
-	S="${WORKDIR}/${PN}-${PRE_RELEASE_SHA}"
 fi
 
-inherit autotools readme.gentoo-r1 systemd
+inherit autotools readme.gentoo-r1 systemd toolchain-funcs
 
 DESCRIPTION="Graphical boot animation (splash) and logger"
 HOMEPAGE="https://cgit.freedesktop.org/plymouth/"
 
 LICENSE="GPL-2"
 SLOT="0"
-IUSE="debug +gtk +libkms +pango +split-usr static-libs +udev"
+IUSE="debug +drm +gtk +pango +split-usr static-libs +udev"
 
 CDEPEND="
 	>=media-libs/libpng-1.2.16:=
+	drm? ( x11-libs/libdrm )
 	gtk? (
 		dev-libs/glib:2
 		>=x11-libs/gtk+-3.14:3
 		x11-libs/cairo
 	)
-	libkms? ( x11-libs/libdrm[libkms] )
 	pango? ( >=x11-libs/pango-1.21 )
 "
 DEPEND="${CDEPEND}
@@ -73,8 +71,8 @@ src_configure() {
 		$(use_enable !static-libs shared)
 		$(use_enable static-libs static)
 		$(use_enable debug tracing)
-		$(use_enable gtk gtk)
-		$(use_enable libkms drm)
+		$(use_enable drm)
+		$(use_enable gtk)
 		$(use_enable pango)
 		$(use_with udev)
 	)

--- a/sys-boot/plymouth/plymouth-0.9.6_pre20211225-r1.ebuild
+++ b/sys-boot/plymouth/plymouth-0.9.6_pre20211225-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -10,27 +10,29 @@ if [[ ${PV} == 9999 ]]; then
 	inherit git-r3
 	EGIT_REPO_URI="https://gitlab.freedesktop.org/plymouth/plymouth"
 else
-	SRC_URI="${SRC_URI} https://www.freedesktop.org/software/plymouth/releases/${P}.tar.xz"
+	PRE_RELEASE_SHA="5b91b9ed84cc91759c986634a4d64d474e6092cf"
+	SRC_URI="${SRC_URI} https://gitlab.freedesktop.org/${PN}/${PN}/-/archive/${PRE_RELEASE_SHA}/${PN}-${PRE_RELEASE_SHA}.tar.gz"
 	KEYWORDS="~alpha amd64 arm arm64 ~ia64 ppc ppc64 ~riscv sparc x86"
+	S="${WORKDIR}/${PN}-${PRE_RELEASE_SHA}"
 fi
 
-inherit autotools readme.gentoo-r1 systemd toolchain-funcs
+inherit autotools readme.gentoo-r1 systemd
 
 DESCRIPTION="Graphical boot animation (splash) and logger"
 HOMEPAGE="https://cgit.freedesktop.org/plymouth/"
 
 LICENSE="GPL-2"
 SLOT="0"
-IUSE="debug +gtk +libkms +pango +split-usr static-libs +udev"
+IUSE="debug +drm +gtk +pango +split-usr static-libs +udev"
 
 CDEPEND="
 	>=media-libs/libpng-1.2.16:=
+	drm? ( x11-libs/libdrm )
 	gtk? (
 		dev-libs/glib:2
 		>=x11-libs/gtk+-3.14:3
 		x11-libs/cairo
 	)
-	libkms? ( x11-libs/libdrm[libkms] )
 	pango? ( >=x11-libs/pango-1.21 )
 "
 DEPEND="${CDEPEND}
@@ -71,8 +73,8 @@ src_configure() {
 		$(use_enable !static-libs shared)
 		$(use_enable static-libs static)
 		$(use_enable debug tracing)
-		$(use_enable gtk gtk)
-		$(use_enable libkms drm)
+		$(use_enable drm)
+		$(use_enable gtk)
 		$(use_enable pango)
 		$(use_with udev)
 	)

--- a/sys-boot/plymouth/plymouth-22.02.122-r1.ebuild
+++ b/sys-boot/plymouth/plymouth-22.02.122-r1.ebuild
@@ -21,16 +21,16 @@ HOMEPAGE="https://cgit.freedesktop.org/plymouth/"
 
 LICENSE="GPL-2"
 SLOT="0"
-IUSE="debug +gtk +libkms +pango +split-usr static-libs +udev"
+IUSE="debug +drm +gtk +pango +split-usr static-libs +udev"
 
 CDEPEND="
 	>=media-libs/libpng-1.2.16:=
+	drm? ( x11-libs/libdrm )
 	gtk? (
 		dev-libs/glib:2
 		>=x11-libs/gtk+-3.14:3
 		x11-libs/cairo
 	)
-	libkms? ( x11-libs/libdrm[libkms] )
 	pango? ( >=x11-libs/pango-1.21 )
 "
 DEPEND="${CDEPEND}
@@ -71,8 +71,8 @@ src_configure() {
 		$(use_enable !static-libs shared)
 		$(use_enable static-libs static)
 		$(use_enable debug tracing)
-		$(use_enable gtk gtk)
-		$(use_enable libkms drm)
+		$(use_enable drm)
+		$(use_enable gtk)
 		$(use_enable pango)
 		$(use_with udev)
 	)

--- a/sys-boot/plymouth/plymouth-9999.ebuild
+++ b/sys-boot/plymouth/plymouth-9999.ebuild
@@ -21,16 +21,16 @@ HOMEPAGE="https://cgit.freedesktop.org/plymouth/"
 
 LICENSE="GPL-2"
 SLOT="0"
-IUSE="debug +gtk +libkms +pango +split-usr static-libs +udev"
+IUSE="debug +drm +gtk +pango +split-usr static-libs +udev"
 
 CDEPEND="
 	>=media-libs/libpng-1.2.16:=
+	drm? ( x11-libs/libdrm )
 	gtk? (
 		dev-libs/glib:2
 		>=x11-libs/gtk+-3.14:3
 		x11-libs/cairo
 	)
-	libkms? ( x11-libs/libdrm[libkms] )
 	pango? ( >=x11-libs/pango-1.21 )
 "
 DEPEND="${CDEPEND}
@@ -71,8 +71,8 @@ src_configure() {
 		$(use_enable !static-libs shared)
 		$(use_enable static-libs static)
 		$(use_enable debug tracing)
-		$(use_enable gtk gtk)
-		$(use_enable libkms drm)
+		$(use_enable drm)
+		$(use_enable gtk)
 		$(use_enable pango)
 		$(use_with udev)
 	)

--- a/x11-drivers/xf86-video-vmware/xf86-video-vmware-13.3.0-r1.ebuild
+++ b/x11-drivers/xf86-video-vmware/xf86-video-vmware-13.3.0-r1.ebuild
@@ -12,7 +12,7 @@ KEYWORDS="amd64 x86"
 
 RDEPEND="
 	kernel_linux? (
-		x11-libs/libdrm[libkms,video_cards_vmware]
+		x11-libs/libdrm[video_cards_vmware]
 		media-libs/mesa[xa]
 	)"
 DEPEND="${RDEPEND}"

--- a/x11-libs/libdrm/libdrm-9999.ebuild
+++ b/x11-libs/libdrm/libdrm-9999.ebuild
@@ -26,7 +26,7 @@ for card in ${VIDEO_CARDS}; do
 	IUSE_VIDEO_CARDS+=" video_cards_${card}"
 done
 
-IUSE="${IUSE_VIDEO_CARDS} libkms valgrind"
+IUSE="${IUSE_VIDEO_CARDS} valgrind"
 RESTRICT="test" # see bug #236845
 LICENSE="MIT"
 SLOT="0"
@@ -58,7 +58,6 @@ multilib_src_configure() {
 		$(meson_use video_cards_vc4 vc4)
 		$(meson_use video_cards_vivante etnaviv)
 		$(meson_use video_cards_vmware vmwgfx)
-		$(meson_use libkms)
 		# valgrind installs its .pc file to the pkgconfig for the primary arch
 		-Dvalgrind=$(usex valgrind auto false)
 	)


### PR DESCRIPTION
Libkms has been removed upstream, it turns out nothing was actually needing this, so updated the dependencies and use flags

https://gitlab.freedesktop.org/mesa/drm/-/commit/2b997bb4bb688be00620887c8646ff24ccb9396b
