### PR TITLE
sys-apps/busybox: fix some bugs

### DIFF
--- a/sys-apps/busybox/busybox-1.34.1-r1.ebuild
+++ b/sys-apps/busybox/busybox-1.34.1-r1.ebuild
@@ -286,6 +286,9 @@ src_install() {
 		insinto /etc
 		doins examples/udhcp/udhcpd.conf
 	fi
+	if busybox_config_enabled ASH && ! use make-symlinks; then
+		dosym -r /bin/busybox /bin/ash
+	fi
 
 	# bundle up the symlink files for use later
 	emake DESTDIR="${ED}" install

--- a/sys-apps/busybox/busybox-1.34.1-r1.ebuild
+++ b/sys-apps/busybox/busybox-1.34.1-r1.ebuild
@@ -131,6 +131,10 @@ src_configure() {
 	busybox_config_option n MONOTONIC_SYSCALL
 	busybox_config_option n USE_PORTABLE_CODE
 	busybox_config_option n WERROR
+	# CONFIG_MODPROBE_SMALL=y disables depmod.c and uses a smaller one that
+	# does not support -b. Setting this to no creates slightly larger and
+	# slightly more useful modutils
+	busybox_config_option n MODPROBE_SMALL #472464
 	# triming the BSS size may be dangerous
 	busybox_config_option n FEATURE_USE_BSS_TAIL
 

--- a/sys-apps/busybox/busybox-1.34.1-r1.ebuild
+++ b/sys-apps/busybox/busybox-1.34.1-r1.ebuild
@@ -291,7 +291,9 @@ src_install() {
 	rm _install/bin/busybox || die
 	# for compatibility, provide /usr/bin/env
 	mkdir -p _install/usr/bin || die
-	ln -s /bin/env _install/usr/bin/env || die
+	if [[ ! -e _install/usr/bin/env ]]; then
+		ln -s /bin/env _install/usr/bin/env || die
+	fi
 	tar cf busybox-links.tar -C _install . || : #;die
 	insinto /usr/share/${PN}
 	use make-symlinks && doins busybox-links.tar

--- a/sys-apps/busybox/busybox-1.34.1-r1.ebuild
+++ b/sys-apps/busybox/busybox-1.34.1-r1.ebuild
@@ -1,0 +1,348 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+# See `man savedconfig.eclass` for info on how to use USE=savedconfig.
+
+EAPI=7
+
+inherit flag-o-matic savedconfig toolchain-funcs
+
+DESCRIPTION="Utilities for rescue and embedded systems"
+HOMEPAGE="https://www.busybox.net/"
+if [[ ${PV} == "9999" ]] ; then
+	MY_P="${P}"
+	EGIT_REPO_URI="https://git.busybox.net/busybox"
+	inherit git-r3
+else
+	MY_P="${PN}-${PV/_/-}"
+	SRC_URI="https://www.busybox.net/downloads/${MY_P}.tar.bz2"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux"
+fi
+
+LICENSE="GPL-2" # GPL-2 only
+SLOT="0"
+IUSE="debug ipv6 livecd make-symlinks math mdev pam selinux sep-usr static syslog systemd"
+REQUIRED_USE="pam? ( !static )"
+RESTRICT="test"
+
+# TODO: Could make pkgconfig conditional on selinux? bug #782829
+RDEPEND="
+	virtual/libcrypt:=
+	!static? ( selinux? ( sys-libs/libselinux ) )
+	pam? ( sys-libs/pam )
+"
+DEPEND="${RDEPEND}
+	static? (
+		virtual/libcrypt[static-libs]
+		selinux? ( sys-libs/libselinux[static-libs(+)] )
+	)
+	sys-kernel/linux-headers"
+BDEPEND="virtual/pkgconfig"
+
+S="${WORKDIR}/${MY_P}"
+
+busybox_config_option() {
+	local flag=$1 ; shift
+	if [[ ${flag} != [yn] && ${flag} != \"* ]] ; then
+		busybox_config_option $(usex ${flag} y n) "$@"
+		return
+	fi
+	local expr
+	while [[ $# -gt 0 ]] ; do
+		case ${flag} in
+		y) expr="s:.*\<CONFIG_$1\>.*set:CONFIG_$1=y:g" ;;
+		n) expr="s:CONFIG_$1=y:# CONFIG_$1 is not set:g" ;;
+		*) expr="s:.*\<CONFIG_$1\>.*:CONFIG_$1=${flag}:g" ;;
+		esac
+		sed -i -e "${expr}" .config || die
+		einfo "$(grep "CONFIG_$1[= ]" .config || echo "Could not find CONFIG_$1 ...")"
+		shift
+	done
+}
+
+busybox_config_enabled() {
+	local val=$(sed -n "/^CONFIG_$1=/s:^[^=]*=::p" .config)
+	case ${val} in
+	"") return 1 ;;
+	y)  return 0 ;;
+	*)  echo "${val}" | sed -r 's:^"(.*)"$:\1:' ;;
+	esac
+}
+
+# patches go here!
+PATCHES=(
+	"${FILESDIR}"/${PN}-1.26.2-bb.patch
+	# "${FILESDIR}"/${P}-*.patch
+)
+
+src_prepare() {
+	default
+	unset KBUILD_OUTPUT #88088
+	append-flags -fno-strict-aliasing #310413
+	use ppc64 && append-flags -mminimal-toc #130943
+
+	cp "${FILESDIR}"/ginit.c init/ || die
+
+	# flag cleanup
+	sed -i -r \
+		-e 's:[[:space:]]?-(Werror|Os|falign-(functions|jumps|loops|labels)=1|fomit-frame-pointer)\>::g' \
+		Makefile.flags || die
+	#sed -i '/bbsh/s:^//::' include/applets.h
+	sed -i '/^#error Aborting compilation./d' applets/applets.c || die
+	use elibc_glibc && sed -i 's:-Wl,--gc-sections::' Makefile
+	sed -i \
+		-e "/^CROSS_COMPILE/s:=.*:= ${CHOST}-:" \
+		-e "/^AR\>/s:=.*:= $(tc-getAR):" \
+		-e "/^CC\>/s:=.*:= $(tc-getCC):" \
+		-e "/^HOSTCC/s:=.*:= $(tc-getBUILD_CC):" \
+		-e "/^PKG_CONFIG\>/s:=.*:= $(tc-getPKG_CONFIG):" \
+		Makefile || die
+	sed -i \
+		-e 's:-static-libgcc::' \
+		Makefile.flags || die
+}
+
+src_configure() {
+	# check for a busybox config before making one of our own.
+	# if one exist lets return and use it.
+
+	restore_config .config
+	if [ -f .config ]; then
+		yes "" | emake -j1 -s oldconfig >/dev/null
+		return 0
+	else
+		ewarn "Could not locate user configfile, so we will save a default one"
+	fi
+
+	# setup the config file
+	emake -j1 -s allyesconfig >/dev/null
+	# nommu forces a bunch of things off which we want on #387555
+	busybox_config_option n NOMMU
+	sed -i '/^#/d' .config
+	yes "" | emake -j1 -s oldconfig >/dev/null
+
+	# now turn off stuff we really don't want
+	busybox_config_option n DMALLOC
+	busybox_config_option n FEATURE_2_4_MODULES #607548
+	busybox_config_option n FEATURE_SUID_CONFIG
+	busybox_config_option n BUILD_AT_ONCE
+	busybox_config_option n BUILD_LIBBUSYBOX
+	busybox_config_option n FEATURE_CLEAN_UP
+	busybox_config_option n MONOTONIC_SYSCALL
+	busybox_config_option n USE_PORTABLE_CODE
+	busybox_config_option n WERROR
+	# triming the BSS size may be dangerous
+	busybox_config_option n FEATURE_USE_BSS_TAIL
+
+	# These cause trouble with musl.
+	if use elibc_musl; then
+		busybox_config_option n FEATURE_UTMP
+		busybox_config_option n EXTRA_COMPAT
+		busybox_config_option n FEATURE_VI_REGEX_SEARCH
+	fi
+
+	# Disable standalone shell mode when using make-symlinks, else Busybox calls its
+	# applets by default without looking up in PATH.
+	# This also enables users to disable a builtin by deleting the corresponding symlink.
+	if use make-symlinks; then
+		busybox_config_option n FEATURE_PREFER_APPLETS
+		busybox_config_option n FEATURE_SH_STANDALONE
+	fi
+
+	# If these are not set and we are using a busybox setup
+	# all calls to system() will fail.
+	busybox_config_option y ASH
+	busybox_config_option y SH_IS_ASH
+	busybox_config_option n HUSH
+	busybox_config_option n SH_IS_HUSH
+
+	busybox_config_option '"/run"' PID_FILE_PATH
+	busybox_config_option '"/run/ifstate"' IFUPDOWN_IFSTATE_PATH
+
+	# disable ipv6 applets
+	if ! use ipv6; then
+		busybox_config_option n FEATURE_IPV6
+		busybox_config_option n TRACEROUTE6
+		busybox_config_option n PING6
+		busybox_config_option n UDHCPC6
+	fi
+
+	busybox_config_option pam PAM
+	busybox_config_option static STATIC
+	busybox_config_option syslog {K,SYS}LOGD LOGGER
+	busybox_config_option systemd FEATURE_SYSTEMD
+	busybox_config_option math FEATURE_AWK_LIBM
+
+	# all the debug options are compiler related, so punt them
+	busybox_config_option n DEBUG_SANITIZE
+	busybox_config_option n DEBUG
+	busybox_config_option y NO_DEBUG_LIB
+	busybox_config_option n DMALLOC
+	busybox_config_option n EFENCE
+	busybox_config_option $(usex debug y n) TFTP_DEBUG
+
+	busybox_config_option selinux SELINUX
+
+	# this opt only controls mounting with <linux-2.6.23
+	busybox_config_option n FEATURE_MOUNT_NFS
+
+	# glibc-2.26 and later does not ship RPC implientation
+	busybox_config_option n FEATURE_HAVE_RPC
+	busybox_config_option n FEATURE_INETD_RPC
+
+	# default a bunch of uncommon options to off
+	local opt
+	for opt in \
+		ADD_SHELL \
+		BEEP BOOTCHARTD \
+		CRONTAB \
+		DC DEVFSD DNSD DPKG{,_DEB} \
+		FAKEIDENTD FBSPLASH FOLD FSCK_MINIX FTP{GET,PUT} \
+		FEATURE_DEVFS \
+		HOSTID HUSH \
+		INETD INOTIFYD IPCALC \
+		LOCALE_SUPPORT LOGNAME LPD \
+		MAKEMIME MKFS_MINIX MSH \
+		OD \
+		RDEV READPROFILE REFORMIME REMOVE_SHELL RFKILL RUN_PARTS RUNSV{,DIR} \
+		SLATTACH SMEMCAP SULOGIN SV{,LOGD} \
+		TASKSET TCPSVD \
+		RPM RPM2CPIO \
+		UDPSVD UUDECODE UUENCODE
+	do
+		busybox_config_option n ${opt}
+	done
+
+	emake -j1 oldconfig > /dev/null
+}
+
+src_compile() {
+	unset KBUILD_OUTPUT #88088
+	export SKIP_STRIP=y
+
+	emake V=1 busybox
+
+	# bug #701512
+	emake V=1 doc
+}
+
+src_install() {
+	unset KBUILD_OUTPUT #88088
+	save_config .config
+
+	into /
+	dodir /bin
+	if use sep-usr ; then
+		# install /ginit to take care of mounting stuff
+		exeinto /
+		newexe busybox_unstripped ginit
+		dosym /ginit /bin/bb
+		dosym bb /bin/busybox
+	else
+		newbin busybox_unstripped busybox
+		dosym busybox /bin/bb
+	fi
+	if use mdev ; then
+		dodir /$(get_libdir)/mdev/
+		use make-symlinks || dosym /bin/bb /sbin/mdev
+		cp "${S}"/examples/mdev_fat.conf "${ED}"/etc/mdev.conf || die
+		if [[ ! "$(get_libdir)" == "lib" ]]; then
+			sed -i -e "s:/lib/:/$(get_libdir)/:g" "${ED}"/etc/mdev.conf || die #831251 - replace lib with lib64 where appropriate
+		fi
+
+		exeinto /$(get_libdir)/mdev/
+		doexe "${FILESDIR}"/mdev/*
+
+		newinitd "${FILESDIR}"/mdev.initd mdev
+	fi
+	if use livecd ; then
+		dosym busybox /bin/vi
+	fi
+
+	# add busybox daemon's, bug #444718
+	if busybox_config_enabled FEATURE_NTPD_SERVER; then
+		newconfd "${FILESDIR}"/ntpd.confd busybox-ntpd
+		newinitd "${FILESDIR}"/ntpd.initd busybox-ntpd
+	fi
+	if busybox_config_enabled SYSLOGD; then
+		newconfd "${FILESDIR}"/syslogd.confd busybox-syslogd
+		newinitd "${FILESDIR}"/syslogd.initd busybox-syslogd
+	fi
+	if busybox_config_enabled KLOGD; then
+		newconfd "${FILESDIR}"/klogd.confd busybox-klogd
+		newinitd "${FILESDIR}"/klogd.initd busybox-klogd
+	fi
+	if busybox_config_enabled WATCHDOG; then
+		newconfd "${FILESDIR}"/watchdog.confd busybox-watchdog
+		newinitd "${FILESDIR}"/watchdog.initd busybox-watchdog
+	fi
+	if busybox_config_enabled UDHCPC; then
+		local path=$(busybox_config_enabled UDHCPC_DEFAULT_SCRIPT)
+		exeinto "${path%/*}"
+		newexe examples/udhcp/simple.script "${path##*/}"
+	fi
+	if busybox_config_enabled UDHCPD; then
+		insinto /etc
+		doins examples/udhcp/udhcpd.conf
+	fi
+
+	# bundle up the symlink files for use later
+	emake DESTDIR="${ED}" install
+	rm _install/bin/busybox || die
+	# for compatibility, provide /usr/bin/env
+	mkdir -p _install/usr/bin || die
+	ln -s /bin/env _install/usr/bin/env || die
+	tar cf busybox-links.tar -C _install . || : #;die
+	insinto /usr/share/${PN}
+	use make-symlinks && doins busybox-links.tar
+
+	dodoc AUTHORS README TODO
+
+	cd docs || die
+	doman busybox.1
+	docinto txt
+	dodoc *.txt
+	docinto pod
+	dodoc *.pod
+	docinto html
+	dodoc *.html
+
+	cd ../examples || die
+	docinto examples
+	dodoc inittab depmod.pl *.conf *.script undeb unrpm
+}
+
+pkg_preinst() {
+	if use make-symlinks && [[ ! ${VERY_BRAVE_OR_VERY_DUMB} == "yes" ]] && [[ -z "${ROOT}" ]] ; then
+		ewarn "setting USE=make-symlinks and emerging to / is very dangerous."
+		ewarn "it WILL overwrite lots of system programs like: ls bash awk grep (bug 60805 for full list)."
+		ewarn "If you are creating a binary only and not merging this is probably ok."
+		ewarn "set env VERY_BRAVE_OR_VERY_DUMB=yes if this is really what you want."
+		die "silly options will destroy your system"
+	fi
+
+	if use make-symlinks ; then
+		mv "${ED}"/usr/share/${PN}/busybox-links.tar "${T}"/ || die
+	fi
+}
+
+pkg_postinst() {
+	savedconfig_pkg_postinst
+
+	if use make-symlinks ; then
+		cd "${T}" || die
+		mkdir _install
+		tar xf busybox-links.tar -C _install || die
+		echo n | cp -ivpPR _install/* "${ROOT}"/ || die "copying links for ${x} failed"
+	fi
+
+	if use sep-usr ; then
+		elog "In order to use the sep-usr support, you have to update your"
+		elog "kernel command line.  Add the option:"
+		elog "     init=/ginit"
+		elog "To launch a different init than /sbin/init, use:"
+		elog "     init=/ginit /sbin/yourinit"
+		elog "To get a rescue shell, you may boot with:"
+		elog "     init=/ginit bb"
+	fi
+}

--- a/sys-apps/busybox/busybox-1.34.1-r1.ebuild
+++ b/sys-apps/busybox/busybox-1.34.1-r1.ebuild
@@ -310,6 +310,9 @@ src_install() {
 	cd ../examples || die
 	docinto examples
 	dodoc inittab depmod.pl *.conf *.script undeb unrpm
+
+	cd ../networking || die
+	dodoc httpd_indexcgi.c httpd_post_upload.cgi
 }
 
 pkg_preinst() {

--- a/sys-apps/busybox/busybox-1.34.1-r1.ebuild
+++ b/sys-apps/busybox/busybox-1.34.1-r1.ebuild
@@ -72,6 +72,7 @@ busybox_config_enabled() {
 # patches go here!
 PATCHES=(
 	"${FILESDIR}"/${PN}-1.26.2-bb.patch
+	"${FILESDIR}"/${PN}-1.34.1-skip-selinux-search.patch
 	# "${FILESDIR}"/${P}-*.patch
 )
 
@@ -114,12 +115,14 @@ src_configure() {
 		ewarn "Could not locate user configfile, so we will save a default one"
 	fi
 
+	# setting SKIP_SELINUX skips searching for selinux at this stage. We don't
+	# need to search now in case we end up not needing it after all.
 	# setup the config file
-	emake -j1 -s allyesconfig >/dev/null
+	emake -j1 -s allyesconfig SKIP_SELINUX=$(usex selinux n y) >/dev/null #620918
 	# nommu forces a bunch of things off which we want on #387555
 	busybox_config_option n NOMMU
 	sed -i '/^#/d' .config
-	yes "" | emake -j1 -s oldconfig >/dev/null
+	yes "" | emake -j1 -s oldconfig SKIP_SELINUX=$(usex selinux n y) >/dev/null #620918
 
 	# now turn off stuff we really don't want
 	busybox_config_option n DMALLOC

--- a/sys-apps/busybox/busybox-1.34.1-r1.ebuild
+++ b/sys-apps/busybox/busybox-1.34.1-r1.ebuild
@@ -277,6 +277,7 @@ src_install() {
 		newinitd "${FILESDIR}"/watchdog.initd busybox-watchdog
 	fi
 	if busybox_config_enabled UDHCPC; then
+		sed -i 's:$((metric++)):$metric; metric=$((metric + 1)):' examples/udhcp/simple.script || die #801535
 		local path=$(busybox_config_enabled UDHCPC_DEFAULT_SCRIPT)
 		exeinto "${path%/*}"
 		newexe examples/udhcp/simple.script "${path##*/}"

--- a/sys-apps/busybox/busybox-1.34.1-r1.ebuild
+++ b/sys-apps/busybox/busybox-1.34.1-r1.ebuild
@@ -293,6 +293,10 @@ src_install() {
 	if busybox_config_enabled ASH && ! use make-symlinks; then
 		dosym -r /bin/busybox /bin/ash
 	fi
+	if busybox_config_enabled CROND; then
+		newconfd "${FILESDIR}"/crond.confd busybox-crond
+		newinitd "${FILESDIR}"/crond.initd busybox-crond
+	fi
 
 	# bundle up the symlink files for use later
 	emake DESTDIR="${ED}" install

--- a/sys-apps/busybox/files/busybox-1.34.1-skip-selinux-search.patch
+++ b/sys-apps/busybox/files/busybox-1.34.1-skip-selinux-search.patch
@@ -1,0 +1,21 @@
+Setting SKIP_SELINUX skips searching for selinux.  The current ebuild calls
+make 3 times.  The first 2 times we don't need to search for selinux packages
+because we might end up not needing them and we get useless warnings.
+
+--- a/Makefile.flags
++++ b/Makefile.flags
+@@ -176,12 +176,14 @@
+ LDLIBS += pam pam_misc
+ endif
+ 
++ifneq ($(SKIP_SELINUX),y)
+ ifeq ($(CONFIG_SELINUX),y)
+ SELINUX_PC_MODULES = libselinux libsepol
+ $(eval $(call pkg_check_modules,SELINUX,$(SELINUX_PC_MODULES)))
+ CPPFLAGS += $(SELINUX_CFLAGS)
+ LDLIBS += $(if $(SELINUX_LIBS),$(SELINUX_LIBS:-l%=%),$(SELINUX_PC_MODULES:lib%=%))
+ endif
++endif
+ 
+ ifeq ($(CONFIG_FEATURE_NSLOOKUP_BIG),y)
+ ifneq (,$(findstring linux,$(shell $(CC) $(CFLAGS) -dumpmachine)))

--- a/sys-apps/busybox/files/crond.confd
+++ b/sys-apps/busybox/files/crond.confd
@@ -1,0 +1,2 @@
+# Config file for /etc/init.d/busybox-crond
+CRONDARGS=

--- a/sys-apps/busybox/files/crond.initd
+++ b/sys-apps/busybox/files/crond.initd
@@ -1,0 +1,12 @@
+#!/sbin/openrc-run
+# Copyright 1999-2021 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+command="/bin/busybox crond"
+command_args="${CRONDARGS}"
+pidfile="/run/crond.pid"
+
+depend() {
+	need clock logger
+	provide cron
+}

--- a/sys-apps/busybox/files/mdev/dvbdev
+++ b/sys-apps/busybox/files/mdev/dvbdev
@@ -8,11 +8,11 @@ DVB_DEV=${MDEV#*.}
 
 case "$ACTION" in
 	add|"")
-		mkdir -p dvb/adapter${N}
-		mv ${MDEV} dvb/adapter${N}/${DVB_DEV}
+		mkdir -p "dvb/adapter${N}"
+		mv "${MDEV}" "dvb/adapter${N}/${DVB_DEV}"
 		;;
 	remove)
-		rm -f dvb/adapter${N}/${DVB_DEV}
-		rmdir dvb/adapter${N} 2>/dev/null
+		rm -f "dvb/adapter${N}/${DVB_DEV}"
+		rmdir "dvb/adapter${N}" 2>/dev/null
 		rmdir dvb/ 2>/dev/null
 esac

--- a/sys-apps/busybox/files/mdev/ide_links
+++ b/sys-apps/busybox/files/mdev/ide_links
@@ -1,23 +1,23 @@
 #!/bin/sh
 
-[ -f /proc/ide/$MDEV/media ] || exit
+[ -f /proc/ide/"${MDEV}"/media ] || exit
 
-media=`cat /proc/ide/$MDEV/media`
-for i in $media $media[0-9]* ; do
-	if [ "`readlink $i 2>/dev/null`" = $MDEV ] ; then
-		LINK=$i
+media=$(cat /proc/ide/"${MDEV}"/media)
+for i in "${media}" "${media}"[0-9]* ; do
+	if [ "$(readlink "$i" 2>/dev/null)" = "${MDEV}" ] ; then
+		LINK="$i"
 		break
 	fi
 done
 
 # link exist, remove if necessary and exit
-if [ "$LINK" ] ; then
-	[ "$ACTION" = remove ] && rm $LINK
+if [ "${LINK}" ] ; then
+	[ "${ACTION}" = remove ] && rm "${LINK}"
 	exit
 fi
 
 # create a link
-num=`ls $media[0-9]* 2>/dev/null | wc -l`
-ln -sf $MDEV "$media`echo $num`"
-[ -e "$media" ] || ln -sf $MDEV "$media"
+num=$(ls "${media}"[0-9]* 2>/dev/null | wc -l)
+ln -sf "${MDEV}" "${media}${num}"
+[ -e "${media}" ] || ln -sf "${MDEV}" "${media}"
 

--- a/sys-apps/busybox/files/mdev/usbdev
+++ b/sys-apps/busybox/files/mdev/usbdev
@@ -5,7 +5,7 @@
 
 # add zeros to device or bus
 add_zeros () {
-	case "$(echo $1 | wc -L)" in
+	case "$(echo "$1" | wc -L)" in
 		1)	echo "00$1" ;;
 		2)	echo "0$1" ;;
 		*)	echo "$1"
@@ -15,48 +15,48 @@ add_zeros () {
 
 
 # bus and device dirs in /sys
-USB_PATH=$(echo $MDEV | sed -e 's/usbdev\([0-9]\).[0-9]/usb\1/')
-USB_PATH=$(find /sys/devices -type d -name "$USB_PATH")
-USB_DEV_DIR=$(echo $MDEV | sed -e 's/usbdev\([0-9]\).\([0-9]\)/\1-\2/')
+USB_PATH=$(echo "${MDEV}" | sed -e 's/usbdev\([0-9]\).[0-9]/usb\1/')
+USB_PATH=$(find /sys/devices -type d -name "${USB_PATH}")
+USB_DEV_DIR=$(echo "${MDEV}" | sed -e 's/usbdev\([0-9]\).\([0-9]\)/\1-\2/')
 
 # dir names in /dev
-BUS=$(add_zeros $(echo $MDEV | sed -e 's/^usbdev\([0-9]\).[0-9]/\1/'))
-USB_DEV=$(add_zeros $(echo $MDEV | sed -e 's/^usbdev[0-9].\([0-9]\)/\1/'))
+BUS=$(add_zeros "$(echo "${MDEV}" | sed -e 's/^usbdev\([0-9]\).[0-9]/\1/')")
+USB_DEV=$(add_zeros "$(echo "${MDEV}" | sed -e 's/^usbdev[0-9].\([0-9]\)/\1/')")
 
 
 # try to load the proper driver for usb devices
-case "$ACTION" in
+case "${ACTION}" in
 	add|"")
 		# load usb bus driver
-		for i in $USB_PATH/*/modalias ; do
-			modprobe `cat $i` 2>/dev/null
+		for i in "${USB_PATH}"/*/modalias ; do
+			modprobe "$(cat "$i")" 2>/dev/null
 		done
 		# load usb device driver if existent
-		if [ -d $USB_PATH/$USB_DEV_DIR ]; then
-			for i in $USB_PATH/$USB_DEV_DIR/*/modalias ; do
-				modprobe `cat $i` 2>/dev/null
+		if [ -d "${USB_PATH}/${USB_DEV_DIR}" ]; then
+			for i in "${USB_PATH}/${USB_DEV_DIR}"/*/modalias ; do
+				modprobe "$(cat "$i")" 2>/dev/null
 			done
 		fi
 		# move usb device file
-		mkdir -p bus/usb/$BUS
-		mv $MDEV bus/usb/$BUS/$USB_DEV
+		mkdir -p "bus/usb/${BUS}"
+		mv "${MDEV}" "bus/usb/${BUS}/${USB_DEV}"
 		;;
 	remove)
 		# unload device driver, if device dir is existent
-		if [ -d $USB_PATH/$USB_DEV_DIR ]; then
-			for i in $USB_PATH/$USB_DEV_DIR/*/modalias ; do
-				modprobe -r `cat $i` 2>/dev/null
+		if [ -d "${USB_PATH}/${USB_DEV_DIR}" ]; then
+			for i in "${USB_PATH}/${USB_DEV_DIR}"/*/modalias ; do
+				modprobe -r "$(cat "$i")" 2>/dev/null
 		done
 		fi
 		# unload usb bus driver. Does this make sense?
 		# what happens, if two usb devices are plugged in
 		# and one is removed?
-		for i in $USB_PATH/*/modalias ; do
-			modprobe -r `cat $i` 2>/dev/null
+		for i in "${USB_PATH}"/*/modalias ; do
+			modprobe -r "$(cat "$i")" 2>/dev/null
 		done
 		# remove device file and possible empty dirs
-		rm -f bus/usb/$BUS/$USB_DEV
-		rmdir bus/usb/$BUS/ 2>/dev/null
+		rm -f "bus/usb/${BUS}/${USB_DEV}"
+		rmdir "bus/usb/${BUS}/" 2>/dev/null
 		rmdir bus/usb/ 2>/dev/null
 		rmdir bus/ 2>/dev/null
 esac

--- a/sys-apps/busybox/files/mdev/usbdisk_link
+++ b/sys-apps/busybox/files/mdev/usbdisk_link
@@ -4,31 +4,35 @@
 
 current=$(readlink usbdisk)
 
-if [ "$current" = "$MDEV" ] && [ "$ACTION" = "remove" ]; then
+if [ "${current}" = "${MDEV}" ] && [ "${ACTION}" = "remove" ]; then
 	rm -f usbdisk usba1 
 fi
-[ -n "$current" ] && exit
+[ -n "${current}" ] && exit
 
-if [ -e /sys/block/$MDEV ]; then
-	SYSDEV=$(readlink -f /sys/block/$MDEV/device)
+if [ -e /sys/block/"${MDEV}" ]; then
+	SYSDEV=$(readlink -f /sys/block/"${MDEV}"/device)
 	# if /sys device path contains '/usb[0-9]' then we assume its usb
 	# also, if it's a usb without partitions we require FAT
-	if [ "${SYSDEV##*/usb[0-9]}" != "$SYSDEV" ]; then
+	if [ "${SYSDEV##*/usb[0-9]}" != "${SYSDEV}" ]; then
 		# do not create link if there is not FAT
-		dd if=/dev/$MDEV bs=512 count=1 2>/dev/null | strings | grep FAT >/dev/null || exit 0
+		dd if=/dev/"${MDEV}" bs=512 count=1 2>/dev/null | strings | grep FAT >/dev/null || exit 0
 
-		ln -sf $MDEV usbdisk
+		ln -sf "${MDEV}" usbdisk
 		# keep this for compat. people have it in fstab
-		ln -sf $MDEV usba1
+		ln -sf "${MDEV}" usba1
 	fi
 
-elif [ -e /sys/block/*/$MDEV ] ; then
-	PARENT=$(dirname /sys/block/*/$MDEV)
-	SYSDEV=$(readlink -f $PARENT/device)
-	if [ "${SYSDEV##*/usb[0-9]}" != "$SYSDEV" ]; then
-		ln -sf $MDEV usbdisk
-		# keep this for compat. people have it in fstab
-		ln -sf $MDEV usba1
-	fi
+else
+	for i in /sys/block/*/"${MDEV}"; do
+		if [ -e "$i" ]; then
+			PARENT=$(dirname "$i")
+			SYSDEV=$(readlink -f "${PARENT}"/device)
+			if [ "${SYSDEV##*/usb[0-9]}" != "${SYSDEV}" ]; then
+				ln -sf "${MDEV}" usbdisk
+				# keep this for compat. people have it in fstab
+				ln -sf "${MDEV}" usba1
+			fi
+		fi
+	done
 fi
 


### PR DESCRIPTION
I made some bugfixes.

1.34.1 is stable, I made all changes in 1.34.1-r1.

Remaining bugs:
- https://bugs.gentoo.org/824222 - this requires only clean-up.  I deleted 3 older versions but the diff on github looks very chaotic, so I reverted it.  They can be removed later in a different PR.
- https://bugs.gentoo.org/836920 - security bug.  I looked upstream and nothing.  There is one question about this on their mailing list and no answer.  If upstream does not fix them properly we can apply the patches from alpine, but I think we should wait for upstream for a reasonable amount of time.