### PR TITLE
app-editors/vim: fix QA notice "eend called w/o ebegin"

### DIFF
--- a/app-editors/vim/vim-8.2.0814-r100.ebuild
+++ b/app-editors/vim/vim-8.2.0814-r100.ebuild
@@ -280,7 +280,7 @@ src_test() {
 # Call eselect vi update with --if-unset
 # to respect user's choice (bug 187449)
 eselect_vi_update() {
-	einfo "Calling eselect vi update..."
+	ebegin "Calling eselect vi update"
 	eselect vi update --if-unset
 	eend $?
 }

--- a/app-editors/vim/vim-8.2.3428-r1.ebuild
+++ b/app-editors/vim/vim-8.2.3428-r1.ebuild
@@ -292,7 +292,7 @@ src_test() {
 # Call eselect vi update with --if-unset
 # to respect user's choice (bug 187449)
 eselect_vi_update() {
-	einfo "Calling eselect vi update..."
+	ebegin "Calling eselect vi update"
 	eselect vi update --if-unset
 	eend $?
 }

--- a/app-editors/vim/vim-8.2.3567.ebuild
+++ b/app-editors/vim/vim-8.2.3567.ebuild
@@ -294,7 +294,7 @@ src_test() {
 # Call eselect vi update with --if-unset
 # to respect user's choice (bug #187449)
 eselect_vi_update() {
-	einfo "Calling eselect vi update..."
+	ebegin "Calling eselect vi update"
 	eselect vi update --if-unset
 	eend $?
 }

--- a/app-editors/vim/vim-8.2.3582.ebuild
+++ b/app-editors/vim/vim-8.2.3582.ebuild
@@ -294,7 +294,7 @@ src_test() {
 # Call eselect vi update with --if-unset
 # to respect user's choice (bug #187449)
 eselect_vi_update() {
-	einfo "Calling eselect vi update..."
+	ebegin "Calling eselect vi update"
 	eselect vi update --if-unset
 	eend $?
 }

--- a/app-editors/vim/vim-8.2.3669.ebuild
+++ b/app-editors/vim/vim-8.2.3669.ebuild
@@ -294,7 +294,7 @@ src_test() {
 # Call eselect vi update with --if-unset
 # to respect user's choice (bug #187449)
 eselect_vi_update() {
-	einfo "Calling eselect vi update..."
+	ebegin "Calling eselect vi update"
 	eselect vi update --if-unset
 	eend $?
 }

--- a/app-editors/vim/vim-8.2.3741.ebuild
+++ b/app-editors/vim/vim-8.2.3741.ebuild
@@ -294,7 +294,7 @@ src_test() {
 # Call eselect vi update with --if-unset
 # to respect user's choice (bug #187449)
 eselect_vi_update() {
-	einfo "Calling eselect vi update..."
+	ebegin "Calling eselect vi update"
 	eselect vi update --if-unset
 	eend $?
 }

--- a/app-editors/vim/vim-8.2.3950.ebuild
+++ b/app-editors/vim/vim-8.2.3950.ebuild
@@ -294,7 +294,7 @@ src_test() {
 # Call eselect vi update with --if-unset
 # to respect user's choice (bug #187449)
 eselect_vi_update() {
-	einfo "Calling eselect vi update..."
+	ebegin "Calling eselect vi update"
 	eselect vi update --if-unset
 	eend $?
 }

--- a/app-editors/vim/vim-8.2.4285.ebuild
+++ b/app-editors/vim/vim-8.2.4285.ebuild
@@ -294,7 +294,7 @@ src_test() {
 # Call eselect vi update with --if-unset
 # to respect user's choice (bug #187449)
 eselect_vi_update() {
-	einfo "Calling eselect vi update..."
+	ebegin "Calling eselect vi update"
 	eselect vi update --if-unset
 	eend $?
 }

--- a/app-editors/vim/vim-8.2.4328-r1.ebuild
+++ b/app-editors/vim/vim-8.2.4328-r1.ebuild
@@ -295,7 +295,7 @@ src_test() {
 # Call eselect vi update with --if-unset
 # to respect user's choice (bug #187449)
 eselect_vi_update() {
-	einfo "Calling eselect vi update..."
+	ebegin "Calling eselect vi update"
 	eselect vi update --if-unset
 	eend $?
 }

--- a/app-editors/vim/vim-8.2.4586.ebuild
+++ b/app-editors/vim/vim-8.2.4586.ebuild
@@ -295,7 +295,7 @@ src_test() {
 # Call eselect vi update with --if-unset
 # to respect user's choice (bug #187449)
 eselect_vi_update() {
-	einfo "Calling eselect vi update..."
+	ebegin "Calling eselect vi update"
 	eselect vi update --if-unset
 	eend $?
 }

--- a/app-editors/vim/vim-9999.ebuild
+++ b/app-editors/vim/vim-9999.ebuild
@@ -295,7 +295,7 @@ src_test() {
 # Call eselect vi update with --if-unset
 # to respect user's choice (bug #187449)
 eselect_vi_update() {
-	einfo "Calling eselect vi update..."
+	ebegin "Calling eselect vi update"
 	eselect vi update --if-unset
 	eend $?
 }


### PR DESCRIPTION
A recent QA notice was added to portage to check that calls to eend $?
have been preceded by a call to ebegin (in the same phase).

This is basically running this line:

    sed -i -e 's/einfo "Calling eselect vi update..."/ebegin "Calling eselect vi update"/g' *.ebuild

on all the ebuilds in app-editors/vim. The trailing "..." are also
removed, as ebegin adds these automatically.

Signed-off-by: Thomas Bracht Laumann Jespersen <t@laumann.xyz>