### PR TITLE
sci-geosciences/grass: fix applying patch

### DIFF
--- a/sci-geosciences/grass/grass-8.0.1-r1.ebuild
+++ b/sci-geosciences/grass/grass-8.0.1-r1.ebuild
@@ -93,7 +93,7 @@ BDEPEND="
 PATCHES=(
 	# bug 746590
 	"${FILESDIR}/${PN}-flock.patch"
-	"${FILESDIR}/${PN}-lib_imagery.patch"
+	"${FILESDIR}/${P}-lib_imagery.patch"
 )
 
 pkg_setup() {


### PR DESCRIPTION
Seems to be a simply typo ;)

Otherwise, the ebuild fails at `configure`:
```
 * Applying grass-lib_imagery.patch ...
/var/tmp/portage/sci-geosciences/grass-8.0.1-r1/temp/environment: line 1574: /var/tmp/portage/sci-geosciences/grass-8.0.1-r1/files/grass-lib_imagery.patch: No such file or directory
/var/tmp/portage/sci-geosciences/grass-8.0.1-r1/temp/environment: line 1577: /var/tmp/portage/sci-geosciences/grass-8.0.1-r1/files/grass-lib_imagery.patch: No such file or directory                                                                                              [ !! ]
 * ERROR: sci-geosciences/grass-8.0.1-r1::gentoo failed (prepare phase):
 *   patch -p1  failed with /var/tmp/portage/sci-geosciences/grass-8.0.1-r1/files/grass-lib_imagery.patch
```


Package-Manager: Portage-3.0.30, Repoman-3.0.3
Signed-off-by: Michael Mair-Keimberger <mmk@levelnine.at>