### PR TITLE
app-misc/inputlircd: EAPI8 bump

### DIFF
--- a/app-misc/inputlircd/inputlircd-0.0.1_pre15-r3.ebuild
+++ b/app-misc/inputlircd/inputlircd-0.0.1_pre15-r3.ebuild
@@ -1,0 +1,37 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs
+
+DESCRIPTION="Inputlirc daemon to utilize /dev/input/event*"
+HOMEPAGE="https://github.com/gsliepen/inputlirc"
+SRC_URI="http://gentooexperimental.org/~genstef/dist/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~ia64 ~ppc ~ppc64 ~riscv ~x86"
+
+src_prepare() {
+	local ver="$(best_version sys-kernel/linux-headers)"
+	ver=${ver#sys-kernel/linux-headers-}
+	if ver_test 4.4 -ge ${ver}; then
+		eapply "${FILESDIR}/inputlircd-linux-4.4-fix.patch"
+	fi
+
+	sed -e 's|$(CFLAGS)|$(CFLAGS) $(LDFLAGS)|' -i Makefile || die
+
+	default
+}
+
+src_compile() {
+	emake CC="$(tc-getCC)"
+}
+
+src_install() {
+	emake DESTDIR="${D}" PREFIX=/usr install
+
+	newinitd "${FILESDIR}"/inputlircd.init.2 inputlircd
+	newconfd "${FILESDIR}"/inputlircd.conf inputlircd
+}


### PR DESCRIPTION
Simple EAPI8 bump for `app-misc/inputlircd`
I've also changed the Homepage as the  actual doesn't seemed to be correct. However, even on the correct Homepage we don't have any tarballs there, which is why i kept `SRC_URI`

Package-Manager: Portage-3.0.30, Repoman-3.0.3
Signed-off-by: Michael Mair-Keimberger <mmk@levelnine.at>