### PR TITLE
net-misc/r8125-9.008.00: fixed build with Linux Kernel 5.17.x

### DIFF
--- a/net-misc/r8125/files/r8125-9.008.00-linux-5.17.patch
+++ b/net-misc/r8125/files/r8125-9.008.00-linux-5.17.patch
@@ -1,0 +1,115 @@
+Added compatibility with Linux Kernel 5.17+.
+
+Author: Karlson2k (Evgeny Grin)
+Gentoo bug: https://bugs.gentoo.org/839282
+
+diff --git a/src/r8125_n.c b/src/r8125_n.c
+--- a/src/r8125_n.c
++++ b/src/r8125_n.c
+@@ -349,7 +349,7 @@ static int rtl8125_change_mtu(struct net_device *dev, int new_mtu);
+ static void rtl8125_down(struct net_device *dev);
+ 
+ static int rtl8125_set_mac_address(struct net_device *dev, void *p);
+-static void rtl8125_rar_set(struct rtl8125_private *tp, uint8_t *addr);
++static void rtl8125_rar_set(struct rtl8125_private *tp, const uint8_t *addr);
+ static void rtl8125_desc_addr_fill(struct rtl8125_private *);
+ static void rtl8125_tx_desc_init(struct rtl8125_private *tp);
+ static void rtl8125_rx_desc_init(struct rtl8125_private *tp);
+@@ -1750,7 +1750,13 @@ static void rtl8125_proc_module_init(void)
+ static int rtl8125_proc_open(struct inode *inode, struct file *file)
+ {
+         struct net_device *dev = proc_get_parent_data(inode);
+-        int (*show)(struct seq_file *, void *) = PDE_DATA(inode);
++        int (*show)(struct seq_file *, void *) =
++#if LINUX_VERSION_CODE < KERNEL_VERSION(5,17,0)
++            PDE_DATA(inode);
++#else
++            pde_data(inode);
++#endif
++
+ 
+         return single_open(file, show, dev);
+ }
+@@ -5234,8 +5240,15 @@ rtl8125_set_ring_size(struct rtl8125_private *tp, u32 rx, u32 tx)
+ }
+ 
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,0)
++#if LINUX_VERSION_CODE < KERNEL_VERSION(5,17,0)
+ static void rtl8125_get_ringparam(struct net_device *dev,
+                                   struct ethtool_ringparam *ring)
++#else
++static void rtl8125_get_ringparam(struct net_device* dev,
++                                  struct ethtool_ringparam* ring,
++                                  struct kernel_ethtool_ringparam* kernel_ring,
++                                  struct netlink_ext_ack* extack)
++#endif
+ {
+         struct rtl8125_private *tp = netdev_priv(dev);
+ 
+@@ -5245,8 +5258,15 @@ static void rtl8125_get_ringparam(struct net_device *dev,
+         ring->tx_pending = tp->tx_ring[0].num_tx_desc;
+ }
+ 
++#if LINUX_VERSION_CODE < KERNEL_VERSION(5,17,0)
+ static int rtl8125_set_ringparam(struct net_device *dev,
+                                  struct ethtool_ringparam *ring)
++#else
++static int rtl8125_set_ringparam(struct net_device* dev,
++                                 struct ethtool_ringparam* ring,
++                                 struct kernel_ethtool_ringparam* kernel_ring,
++                                 struct netlink_ext_ack* extack)
++#endif
+ {
+         struct rtl8125_private *tp = netdev_priv(dev);
+         u32 new_rx_count, new_tx_count;
+@@ -10889,6 +10909,9 @@ rtl8125_get_mac_address(struct net_device *dev)
+         struct rtl8125_private *tp = netdev_priv(dev);
+         int i;
+         u8 mac_addr[MAC_ADDR_LEN];
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,17,0)
++        u8 addr[ETH_ALEN];
++#endif
+ 
+         for (i = 0; i < MAC_ADDR_LEN; i++)
+                 mac_addr[i] = RTL_R8(tp, MAC0 + i);
+@@ -10916,9 +10939,17 @@ rtl8125_get_mac_address(struct net_device *dev)
+         rtl8125_rar_set(tp, mac_addr);
+ 
+         for (i = 0; i < MAC_ADDR_LEN; i++) {
++#if LINUX_VERSION_CODE < KERNEL_VERSION(5,17,0)
+                 dev->dev_addr[i] = RTL_R8(tp, MAC0 + i);
+                 tp->org_mac_addr[i] = dev->dev_addr[i]; /* keep the original MAC address */
++#else
++                addr[i] = RTL_R8(tp, MAC0 + i);
++                tp->org_mac_addr[i] = addr[i]; /* keep the original MAC address */
++#endif
+         }
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,17,0)
++        eth_hw_addr_set(dev, addr);
++#endif
+ #if LINUX_VERSION_CODE > KERNEL_VERSION(2,6,13)
+         memcpy(dev->perm_addr, dev->dev_addr, dev->addr_len);
+ #endif
+@@ -10944,7 +10975,11 @@ rtl8125_set_mac_address(struct net_device *dev,
+         if (!is_valid_ether_addr(addr->sa_data))
+                 return -EADDRNOTAVAIL;
+ 
++#if LINUX_VERSION_CODE < KERNEL_VERSION(5,17,0)
+         memcpy(dev->dev_addr, addr->sa_data, dev->addr_len);
++#else
++        eth_hw_addr_set(dev, addr->sa_data);
++#endif
+ 
+         rtl8125_rar_set(tp, dev->dev_addr);
+ 
+@@ -10959,7 +10994,7 @@ rtl8125_set_mac_address(struct net_device *dev,
+  *****************************************************************************/
+ void
+ rtl8125_rar_set(struct rtl8125_private *tp,
+-                uint8_t *addr)
++                const uint8_t *addr)
+ {
+         uint32_t rar_low = 0;
+         uint32_t rar_high = 0;
+
+

--- a/net-misc/r8125/r8125-9.007.01.ebuild
+++ b/net-misc/r8125/r8125-9.007.01.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 inherit linux-info linux-mod
 

--- a/net-misc/r8125/r8125-9.008.00.ebuild
+++ b/net-misc/r8125/r8125-9.008.00.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 inherit linux-info linux-mod
 

--- a/net-misc/r8125/r8125-9.008.00.ebuild
+++ b/net-misc/r8125/r8125-9.008.00.ebuild
@@ -20,6 +20,10 @@ MODULE_NAMES="r8125(net:${S}/src)"
 BUILD_TARGETS="modules"
 IUSE="+multi-tx-q ptp +rss use-firmware"
 
+PATCHES=(
+    "${FILESDIR}/${PN}-9.008.00-linux-5.17.patch" # bug 839282
+)
+
 CONFIG_CHECK="~!R8169"
 WARNING_R8169="CONFIG_R8169 is enabled. ${PN} will not be loaded unless kernel driver Realtek 8169 PCI Gigabit Ethernet (CONFIG_R8169) is DISABLED."
 


### PR DESCRIPTION
No revbump, no need to rebuild if module works.

Closes: https://bugs.gentoo.org/839282
