### PR TITLE
dev-java/fontbox: skip test classes without tests

### DIFF
--- a/dev-java/fontbox/fontbox-1.7.1-r2.ebuild
+++ b/dev-java/fontbox/fontbox-1.7.1-r2.ebuild
@@ -42,6 +42,14 @@ src_prepare() {
 }
 
 src_test() {
+	# junit.framework.AssertionFailedError:
+	# No tests found in org.apache.fontbox.cff.Type1CharStringTest
+	rm src/test/java/org/apache/fontbox/cff/Type1CharStringTest.java || die
+
+	# junit.framework.AssertionFailedError:
+	# No tests found in org.apache.fontbox.cff.Type1FontUtilTest
+	rm src/test/java/org/apache/fontbox/cff/Type1FontUtilTest.java || die
+
 	java-pkg-2_src_test
 }
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/803503

Signed-off-by: Volkmar W. Pogatzki <gentoo@pogatzki.net>