### PR TITLE
java-utils-2.eclass: introduce JAVA_TEST_RUNNER_EXTRA_ARGS

### DIFF
--- a/eclass/java-utils-2.eclass
+++ b/eclass/java-utils-2.eclass
@@ -139,6 +139,20 @@ JAVA_PKG_ALLOW_VM_CHANGE=${JAVA_PKG_ALLOW_VM_CHANGE:="yes"}
 #	)
 # @CODE
 
+# @ECLASS-VARIABLE: JAVA_TEST_RUNNER_EXTRA_ARGS
+# @DEFAULT_UNSET
+# @DESCRIPTION:
+# Array of extra arguments that should be passed to the test runner when running tests.
+# It is useful when you need to pass an extra argument to the test runner.
+#
+# It is used only when running tests.
+#
+# @CODE
+#	JAVA_TEST_RUNNER_EXTRA_ARGS=(
+#		-verbose 3
+#	)
+# @CODE
+
 # @ECLASS_VARIABLE: JAVA_PKG_DEBUG
 # @DEFAULT_UNSET
 # @DESCRIPTION:
@@ -1807,8 +1821,18 @@ ejunit_() {
 	if [[ "${junit}" == "junit-4" ]] ; then
 		runner=org.junit.runner.JUnitCore
 	fi
-	debug-print "Calling: java -cp \"${cp}\" -Djava.io.tmpdir=\"${T}\" -Djava.awt.headless=true ${JAVA_TEST_EXTRA_ARGS[@]} ${runner} ${@}"
-	java -cp "${cp}" -Djava.io.tmpdir="${T}/" -Djava.awt.headless=true ${JAVA_TEST_EXTRA_ARGS[@]} ${runner} "${@}" || die "Running junit failed"
+
+	local args=(
+		-cp ${cp}
+		-Djava.io.tmpdir="${T}"
+		-Djava.awt.headless=true
+		${JAVA_TEST_EXTRA_ARGS[@]}
+		${runner}
+		${JAVA_TEST_RUNNER_EXTRA_ARGS[@]}
+		${@}
+	)
+	debug-print "Calling: java ${args[@]}"
+	java "${args[@]}" || die "Running junit failed"
 }
 
 # @FUNCTION: ejunit
@@ -1886,12 +1910,21 @@ etestng() {
 		tests+="${test},"
 	done
 
-	debug-print "java -cp \"${cp}\" -Djava.io.tmpdir=\"${T}\""\
-		"-Djava.awt.headless=true ${JAVA_TEST_EXTRA_ARGS[@]} ${runner}"\
-		"-usedefaultlisteners false -testclass ${tests}"
-	java -cp "${cp}" -Djava.io.tmpdir=\"${T}\" -Djava.awt.headless=true ${JAVA_TEST_EXTRA_ARGS[@]}\
-		${runner} -usedefaultlisteners false -testclass ${tests}\
-		|| die "Running TestNG failed."
+	local args=(
+		-cp ${cp}
+		-Djava.io.tmpdir="${T}"
+		-Djava.awt.headless=true
+		${JAVA_TEST_EXTRA_ARGS[@]}
+		${runner}
+		${JAVA_TEST_RUNNER_EXTRA_ARGS[@]}
+	)
+
+	[[ ! "${JAVA_TEST_RUNNER_EXTRA_ARGS[@]}" =~ "-usedefaultlisteners" ]] && args+=( -usedefaultlisteners false )
+
+	args+=( -testclass ${tests} )
+
+	debug-print "java ${args[@]}"
+	java ${args[@]} || die "Running TestNG failed."
 }
 
 # @FUNCTION: java-utils-2_src_prepare


### PR DESCRIPTION
Also add special handling wrt -usedfaultlisteners for TestNG, see
bug #801694.

Signed-off-by: Florian Schmaus <flow@gentoo.org>
Co-authored-by: Miroslav Šulc <fordfrog@gentoo.org>
Bug: https://bugs.gentoo.org/801694