### PR TITLE
dev-embedded/srecord: fix missing dependency

### DIFF
--- a/dev-embedded/srecord/srecord-1.64.ebuild
+++ b/dev-embedded/srecord/srecord-1.64.ebuild
@@ -19,6 +19,7 @@ RDEPEND="dev-libs/libgcrypt:0"
 DEPEND="${RDEPEND}
 	dev-libs/boost
 	sys-apps/groff
+	app-text/ghostscript-gpl
 	test? ( app-arch/sharutils )"
 
 PATCHES=( "${FILESDIR}"/${PN}-1.57-libtool.patch )


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/505824

Signed-off-by: wjaskulski <wjaskulski@adva.com>