### PR TITLE
curl/curl-7.82.0: fixed "out of memory error"

### DIFF
--- a/net-misc/curl/curl-7.82.0-r2.ebuild
+++ b/net-misc/curl/curl-7.82.0-r2.ebuild
@@ -93,6 +93,7 @@ MULTILIB_CHOST_TOOLS=(
 PATCHES=(
 	"${FILESDIR}"/${PN}-7.30.0-prefix.patch
 	"${FILESDIR}"/${PN}-respect-cflags-3.patch
+	"${FILESDIR}"/${P}-certs-processing.patch
 )
 
 src_prepare() {

--- a/net-misc/curl/files/curl-7.82.0-certs-processing.patch
+++ b/net-misc/curl/files/curl-7.82.0-certs-processing.patch
@@ -1,0 +1,30 @@
+From 911714d617c106ed5d553bf003e34ec94ab6a136 Mon Sep 17 00:00:00 2001
+From: Daniel Stenberg <daniel@haxx.se>
+Date: Tue, 8 Mar 2022 13:38:13 +0100
+Subject: [PATCH] openssl: fix CN check error code
+
+Due to a missing 'else' this returns error too easily.
+
+Regressed in: d15692ebb
+
+Reported-by: Kristoffer Gleditsch
+Fixes #8559
+Closes #8560
+---
+ lib/vtls/openssl.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/lib/vtls/openssl.c b/lib/vtls/openssl.c
+index 0b79fc50a9c5..4618beeb3867 100644
+--- a/lib/vtls/openssl.c
++++ b/lib/vtls/openssl.c
+@@ -1817,7 +1817,8 @@ CURLcode Curl_ossl_verifyhost(struct Curl_easy *data, struct connectdata *conn,
+               memcpy(peer_CN, ASN1_STRING_get0_data(tmp), peerlen);
+               peer_CN[peerlen] = '\0';
+             }
+-            result = CURLE_OUT_OF_MEMORY;
++            else
++              result = CURLE_OUT_OF_MEMORY;
+           }
+         }
+         else /* not a UTF8 name */


### PR DESCRIPTION
Upstream bug: https://github.com/curl/curl/issues/8559

Closes: https://bugs.gentoo.org/836629
