### PR TITLE
dev-util/packer: keyword 1.7.10 for ~riscv

### DIFF
--- a/dev-util/packer/packer-1.7.10.ebuild
+++ b/dev-util/packer/packer-1.7.10.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://github.com/hashicorp/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz
 
 LICENSE="Apache-2.0 BSD-2 BSD-4 MIT MPL-2.0 unicode"
 SLOT="0"
-KEYWORDS="~amd64"
+KEYWORDS="~amd64 ~riscv"
 
 DOCS=( {README,CHANGELOG}.md )
 


### PR DESCRIPTION
Signed-off-by: Chris Su <chris@lesscrowds.org>
