### PR TITLE
x11-misc/revelation: Fix build for =>meson-0.60

### DIFF
--- a/x11-misc/revelation/files/revelation-0.5.4-issue87-fix-meson-0.60.patch
+++ b/x11-misc/revelation/files/revelation-0.5.4-issue87-fix-meson-0.60.patch
@@ -1,0 +1,11 @@
+https://github.com/mikelolasagasti/revelation/issues/87
+--- a/data/meson.build
++++ b/data/meson.build
+@@ -59,7 +59,6 @@ rvl_appstreamdir = join_paths(rvl_datadir, 'metainfo')
+ 
+ # Merge the translations with the appdata file
+ i18n.merge_file(
+-  appdata,
+   input: appdata + '.in',
+   output: appdata,
+   po_dir: join_paths(meson.source_root(), 'po'),

--- a/x11-misc/revelation/revelation-0.5.4-r1.ebuild
+++ b/x11-misc/revelation/revelation-0.5.4-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -32,6 +32,8 @@ RDEPEND="${PYTHON_DEPS}
 "
 
 DEPEND="${RDEPEND}"
+
+PATCHES=( "${FILESDIR}"/revelation-0.5.4-issue87-fix-meson-0.60.patch )
 
 src_prepare() {
 	find -name '*.py' -exec \


### PR DESCRIPTION
Patches out a deprecated use of positional argument in
i18n.merge_files to ensure build can succeed on
meson 0.60 and newer. This change should not break support
for meson 0.59.4, as this usage was already deprecated but
only throwing warnings at that release.

Upstream is tracking this issue at
https://github.com/mikelolasagasti/revelation/issues/87

Package-Manager: Portage-3.0.30, Repoman-3.0.3
Signed-off-by: Jay Faulkner <jay@jvf.cc>