### PR TITLE
media-gfx/yafaray: fix build with clang

### DIFF
--- a/media-gfx/yafaray/files/yafaray-3.5.1-add-missing-limits-header.patch
+++ b/media-gfx/yafaray/files/yafaray-3.5.1-add-missing-limits-header.patch
@@ -1,0 +1,21 @@
+From f947af314bdfb8c5d5cb79a2a7877d9ad4d2f087 Mon Sep 17 00:00:00 2001
+From: Bernd Waibel <waebbl-gentoo@posteo.net>
+Date: Fri, 22 Apr 2022 08:23:48 +0200
+Subject: [PATCH] add missing limits header
+
+Bug: https://github.com/YafaRay/libYafaRay/issues/9
+Bug: https://bugs.gentoo.org/830949
+Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>
+--- a/include/core_api/surface.h
++++ b/include/core_api/surface.h
+@@ -24,6 +24,7 @@
+ #define Y_SURFACE_H
+ 
+ #include <yafray_constants.h>
++#include <limits>
+ #include "vector3d.h"
+ #include "color.h"
+ 
+-- 
+2.35.1
+

--- a/media-gfx/yafaray/yafaray-3.5.1-r1.ebuild
+++ b/media-gfx/yafaray/yafaray-3.5.1-r1.ebuild
@@ -45,7 +45,11 @@ BDEPEND="
 	)
 "
 
-PATCHES=( "${FILESDIR}"/${P}-0001-respect-distribution-CFLAGS.patch )
+PATCHES=(
+	"${FILESDIR}"/${P}-0001-respect-distribution-CFLAGS.patch
+	"${FILESDIR}"/${P}-add-missing-limits-header.patch
+)
+
 DOCS=( AUTHORS.md CHANGELOG.md CODING.md INSTALL.md README.md )
 
 pkg_setup() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/830949
Bug: https://github.com/YafaRay/libYafaRay/issues/9
Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>