### PR TITLE
distutils-r1.eclass: support maturin backend + more build_ext optimizations 

### DIFF
--- a/dev-python/adblock/adblock-0.5.2-r1.ebuild
+++ b/dev-python/adblock/adblock-0.5.2-r1.ebuild
@@ -1,0 +1,99 @@
+# Copyright 2021-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+CRATES="
+	adblock-0.4.3
+	addr-0.14.0
+	adler-1.0.2
+	aho-corasick-0.7.18
+	autocfg-1.1.0
+	base64-0.13.0
+	bitflags-1.3.2
+	byteorder-1.4.3
+	cfg-if-1.0.0
+	crc32fast-1.3.2
+	either-1.6.1
+	flate2-1.0.22
+	form_urlencoded-1.0.1
+	idna-0.2.3
+	indoc-0.3.6
+	indoc-impl-0.3.6
+	instant-0.1.12
+	itertools-0.10.3
+	libc-0.2.118
+	lock_api-0.4.6
+	matches-0.1.9
+	memchr-2.4.1
+	miniz_oxide-0.4.4
+	num-traits-0.2.14
+	once_cell-1.9.0
+	parking_lot-0.11.2
+	parking_lot_core-0.8.5
+	paste-0.1.18
+	paste-impl-0.1.18
+	percent-encoding-2.1.0
+	proc-macro-hack-0.5.19
+	proc-macro2-1.0.36
+	psl-2.0.71
+	psl-types-2.0.10
+	pyo3-0.15.1
+	pyo3-build-config-0.15.1
+	pyo3-macros-0.15.1
+	pyo3-macros-backend-0.15.1
+	quote-1.0.15
+	redox_syscall-0.2.10
+	regex-1.5.4
+	regex-syntax-0.6.25
+	rmp-0.8.10
+	rmp-serde-0.13.7
+	rmp-serde-0.15.5
+	scopeguard-1.1.0
+	seahash-3.0.7
+	serde-1.0.136
+	serde_derive-1.0.136
+	smallvec-1.8.0
+	syn-1.0.86
+	tinyvec-1.5.1
+	tinyvec_macros-0.1.0
+	twoway-0.2.2
+	unchecked-index-0.2.2
+	unicode-bidi-0.3.7
+	unicode-normalization-0.1.19
+	unicode-xid-0.2.2
+	unindent-0.1.7
+	url-2.2.2
+	winapi-0.3.9
+	winapi-i686-pc-windows-gnu-0.4.0
+	winapi-x86_64-pc-windows-gnu-0.4.0"
+DISTUTILS_USE_PEP517=maturin
+PYTHON_COMPAT=( python3_{8..10} )
+inherit cargo distutils-r1
+
+DESCRIPTION="Python wrapper for Brave's adblocking library, which is written in Rust"
+HOMEPAGE="https://github.com/ArniDagur/python-adblock"
+SRC_URI="
+	https://github.com/ArniDagur/python-adblock/archive/refs/tags/${PV}.tar.gz -> ${P}.tar.gz
+	$(cargo_crate_uris)"
+S="${WORKDIR}/python-${P}"
+
+LICENSE="Apache-2.0 BSD MIT MPL-2.0"
+SLOT="0"
+KEYWORDS="~amd64 ~arm64 ~x86"
+
+BDEPEND="test? ( dev-python/toml[${PYTHON_USEDEP}] )"
+
+distutils_enable_tests pytest
+
+QA_FLAGS_IGNORED=".*/adblock.*.so"
+
+DOCS=( CHANGELOG.md README.md )
+
+src_compile() {
+	distutils-r1_src_compile
+
+	# tests try to find Cargo.toml + adblock/adblock.pyi in current
+	# directory but will fail if pytest finds init in ./adblock
+	rm adblock/__init__.py || die
+}

--- a/eclass/distutils-r1.eclass
+++ b/eclass/distutils-r1.eclass
@@ -1196,7 +1196,7 @@ distutils-r1_python_compile() {
 			#
 			# see extension.py for list of suffixes
 			# .pyx is added for Cython
-			if [[ 2 -eq $(
+			if [[ 1 -ne ${jobs} && 2 -eq $(
 				find '(' -name '*.c' -o -name '*.cc' -o -name '*.cpp' \
 					-o -name '*.cxx' -o -name '*.c++' -o -name '*.m' \
 					-o -name '*.mm' -o -name '*.pyx' ')' -printf '\n' |

--- a/eclass/distutils-r1.eclass
+++ b/eclass/distutils-r1.eclass
@@ -1189,14 +1189,18 @@ distutils-r1_python_compile() {
 		fi
 
 		if [[ ${DISTUTILS_USE_PEP517} && ${GPEP517_TESTING} ]]; then
-			# issue build_ext only if it looks like we have something
-			# to build; setuptools is expensive to start
+			# issue build_ext only if it looks like we have at least
+			# two source files to build; setuptools is expensive
+			# to start and parallel builds can only benefit us if we're
+			# compiling at least two files
+			#
 			# see extension.py for list of suffixes
 			# .pyx is added for Cython
-			if [[ -n $(
+			if [[ 2 -eq $(
 				find '(' -name '*.c' -o -name '*.cc' -o -name '*.cpp' \
 					-o -name '*.cxx' -o -name '*.c++' -o -name '*.m' \
-					-o -name '*.mm' -o -name '*.pyx' ')' -print -quit
+					-o -name '*.mm' -o -name '*.pyx' ')' -printf '\n' |
+					head -n 2 | wc -l
 			) ]]; then
 				esetup.py build_ext -j "${jobs}" "${@}"
 			fi

--- a/eclass/distutils-r1.eclass
+++ b/eclass/distutils-r1.eclass
@@ -104,6 +104,8 @@ esac
 #
 # - jupyter - jupyter_packaging backend
 #
+# - maturin - maturin backend
+#
 # - pdm - pdm.pep517 backend
 #
 # - poetry - poetry-core backend
@@ -211,6 +213,10 @@ _distutils_set_globals() {
 			jupyter)
 				bdep+='
 					>=dev-python/jupyter_packaging-0.11.1[${PYTHON_USEDEP}]'
+				;;
+			maturin)
+				bdep+='
+					>=dev-util/maturin-0.12.7[${PYTHON_USEDEP}]'
 				;;
 			pdm)
 				bdep+='
@@ -992,6 +998,9 @@ _distutils-r1_backend_to_key() {
 		jupyter_packaging.build_api)
 			echo jupyter
 			;;
+		maturin)
+			echo maturin
+			;;
 		pdm.pep517.api)
 			echo pdm
 			;;
@@ -1209,6 +1218,14 @@ distutils-r1_python_compile() {
 			else
 				esetup.py build -j "${jobs}" "${@}"
 			fi
+			;;
+		maturin)
+			# auditwheel may attempt to auto-bundle libraries, bug #831171
+			local -x MATURIN_PEP517_ARGS=--skip-auditwheel
+
+			# support cargo.eclass' IUSE=debug if available
+			in_iuse debug && use debug &&
+				MATURIN_PEP517_ARGS+=" --cargo-extra-args=--profile=dev"
 			;;
 	esac
 

--- a/eclass/distutils-r1.eclass
+++ b/eclass/distutils-r1.eclass
@@ -159,13 +159,6 @@ esac
 #     ${DISTUTILS_DEPS}"
 # @CODE
 
-# @ECLASS_VARIABLE: GPEP517_TESTING
-# @USER_VARIABLE
-# @DESCRIPTION:
-# Enable in make.conf to test building via dev-python/gpep517 instead of
-# inline Python snippets.  dev-python/gpep517 needs to be installed
-# first.
-
 if [[ ! ${_DISTUTILS_R1} ]]; then
 
 [[ ${EAPI} == 6 ]] && inherit eutils xdg-utils
@@ -192,11 +185,8 @@ _distutils_set_globals() {
 			die "DISTUTILS_USE_SETUPTOOLS is not used in PEP517 mode"
 		fi
 
-		# installer is used to install the wheel
-		# tomli is used to read build-backend from pyproject.toml
 		bdep='
-			>=dev-python/installer-0.4.0_p20220124[${PYTHON_USEDEP}]
-			>=dev-python/tomli-1.2.3[${PYTHON_USEDEP}]'
+			>=dev-python/gpep517-3[${PYTHON_USEDEP}]'
 		case ${DISTUTILS_USE_PEP517} in
 			flit)
 				bdep+='
@@ -1028,20 +1018,7 @@ _distutils-r1_get_backend() {
 	if [[ -f pyproject.toml ]]; then
 		# if pyproject.toml exists, try getting the backend from it
 		# NB: this could fail if pyproject.toml doesn't list one
-		if [[ ${GPEP517_TESTING} ]]; then
-			build_backend=$(gpep517 get-backend)
-		else
-			build_backend=$(
-				"${EPYTHON}" - 3>&1 <<-EOF
-					import os
-					import tomli
-					print(tomli.load(open("pyproject.toml", "rb"))
-							.get("build-system", {})
-							.get("build-backend", ""),
-						file=os.fdopen(3, "w"))
-				EOF
-			)
-		fi
+		build_backend=$(gpep517 get-backend)
 	fi
 	if [[ -z ${build_backend} && ${DISTUTILS_USE_PEP517} == setuptools &&
 		-f setup.py ]]
@@ -1107,45 +1084,18 @@ distutils_pep517_install() {
 
 	local build_backend=$(_distutils-r1_get_backend)
 	einfo "  Building the wheel for ${PWD#${WORKDIR}/} via ${build_backend}"
-	if [[ ${GPEP517_TESTING} ]]; then
-		local wheel=$(
-			gpep517 build-wheel --backend "${build_backend}" \
-					--output-fd 3 \
-					--wheel-dir "${WHEEL_BUILD_DIR}" 3>&1 >&2 ||
-				die "Wheel build failed"
-		)
-	else
-		local wheel=$(
-			"${EPYTHON}" - 3>&1 >&2 <<-EOF || die "Wheel build failed"
-				import ${build_backend%:*}
-				import os
-				print(${build_backend/:/.}.build_wheel(os.environ['WHEEL_BUILD_DIR']),
-					file=os.fdopen(3, 'w'))
-			EOF
-		)
-	fi
+	local wheel=$(
+		gpep517 build-wheel --backend "${build_backend}" \
+				--output-fd 3 \
+				--wheel-dir "${WHEEL_BUILD_DIR}" 3>&1 >&2 ||
+			die "Wheel build failed"
+	)
 	[[ -n ${wheel} ]] || die "No wheel name returned"
 
 	einfo "  Installing the wheel to ${root}"
-	if [[ ${GPEP517_TESTING} ]]; then
-		gpep517 install-wheel --destdir="${root}" --interpreter="${PYTHON}" \
-				--prefix="${EPREFIX}/usr" "${WHEEL_BUILD_DIR}/${wheel}" ||
-			die "Wheel install failed"
-	else
-		# NB: --compile-bytecode does not produce the correct paths,
-		# and python_optimize doesn't handle being called outside D,
-		# so we just defer compiling until the final merge
-		# NB: we override sys.prefix & sys.exec_prefix because otherwise
-		# installer would use virtualenv's prefix
-		local -x PYTHON_PREFIX=${EPREFIX}/usr
-		"${EPYTHON}" - -d "${root}" "${WHEEL_BUILD_DIR}/${wheel}" --no-compile-bytecode \
-				<<-EOF || die "installer failed"
-			import os, sys
-			sys.prefix = sys.exec_prefix = os.environ["PYTHON_PREFIX"]
-			from installer.__main__ import main
-			main(sys.argv[1:])
-		EOF
-	fi
+	gpep517 install-wheel --destdir="${root}" --interpreter="${PYTHON}" \
+			--prefix="${EPREFIX}/usr" "${WHEEL_BUILD_DIR}/${wheel}" ||
+		die "Wheel install failed"
 
 	# remove installed licenses
 	find "${root}$(python_get_sitedir)" \
@@ -1155,11 +1105,7 @@ distutils_pep517_install() {
 	# clean the build tree; otherwise we may end up with PyPy3
 	# extensions duplicated into CPython dists
 	if [[ ${DISTUTILS_USE_PEP517:-setuptools} == setuptools ]]; then
-		if [[ ${GPEP517_TESTING} ]]; then
-			rm -rf build || die
-		else
-			esetup.py clean -a
-		fi
+		rm -rf build || die
 	fi
 }
 
@@ -1182,13 +1128,13 @@ distutils-r1_python_compile() {
 			# call setup.py build when using setuptools (either via PEP517
 			# or in legacy mode)
 
-			if [[ ${GPEP517_TESTING} && ${DISTUTILS_USE_PEP517} ]]; then
+			if [[ ${DISTUTILS_USE_PEP517} ]]; then
 				if [[ -d build ]]; then
 					eqawarn "A 'build' directory exists already.  Artifacts from this directory may"
 					eqawarn "be picked up by setuptools when building for another interpreter."
 					eqawarn "Please remove this directory prior to building."
 				fi
-			elif [[ ! ${DISTUTILS_USE_PEP517} ]]; then
+			else
 				_distutils-r1_copy_egg_info
 			fi
 
@@ -1199,7 +1145,7 @@ distutils-r1_python_compile() {
 				jobs=$(( nproc + 1 ))
 			fi
 
-			if [[ ${DISTUTILS_USE_PEP517} && ${GPEP517_TESTING} ]]; then
+			if [[ ${DISTUTILS_USE_PEP517} ]]; then
 				# issue build_ext only if it looks like we have at least
 				# two source files to build; setuptools is expensive
 				# to start and parallel builds can only benefit us if we're

--- a/eclass/distutils-r1.eclass
+++ b/eclass/distutils-r1.eclass
@@ -1182,7 +1182,7 @@ distutils-r1_python_compile() {
 		fi
 
 		# distutils is parallel-capable since py3.5
-		local jobs=$(makeopts_jobs "${MAKEOPTS}" INF)
+		local jobs=$(makeopts_jobs "${MAKEOPTS} ${*}" INF)
 		if [[ ${jobs} == INF ]]; then
 			local nproc=$(get_nproc)
 			jobs=$(( nproc + 1 ))


### PR DESCRIPTION
Trying this again with the new MATURIN_PEP517_ARGS support in >=0.12.7.

Unsure how python@ would rather cargo.eclass' IUSE=debug be handled, for some options:
- in_iuse debug && use debug (current less invasive approach)
- inherit cargo in distutils-r1 for rust backends
- set IUSE=debug for rust backends
- do nothing, makes IUSE=debug a no-op and maturin defaults to release profile in pep517 mode
(USE=debug notably makes compilation 2-5x faster, useful when testing).

Not adamant about adding maturin given I only use for one ebuild, but others may want it (it'd close https://bugs.gentoo.org/799383 as obsolete fwiw).

Included migrated ebuild to allow testing.