### PR TITLE
distutils-r1.eclass: More build_ext optimizations

### DIFF
--- a/eclass/distutils-r1.eclass
+++ b/eclass/distutils-r1.eclass
@@ -1196,7 +1196,7 @@ distutils-r1_python_compile() {
 			#
 			# see extension.py for list of suffixes
 			# .pyx is added for Cython
-			if [[ 2 -eq $(
+			if [[ 1 -ne ${jobs} && 2 -eq $(
 				find '(' -name '*.c' -o -name '*.cc' -o -name '*.cpp' \
 					-o -name '*.cxx' -o -name '*.c++' -o -name '*.m' \
 					-o -name '*.mm' -o -name '*.pyx' ')' -printf '\n' |

--- a/eclass/distutils-r1.eclass
+++ b/eclass/distutils-r1.eclass
@@ -1189,14 +1189,18 @@ distutils-r1_python_compile() {
 		fi
 
 		if [[ ${DISTUTILS_USE_PEP517} && ${GPEP517_TESTING} ]]; then
-			# issue build_ext only if it looks like we have something
-			# to build; setuptools is expensive to start
+			# issue build_ext only if it looks like we have at least
+			# two source files to build; setuptools is expensive
+			# to start and parallel builds can only benefit us if we're
+			# compiling at least two files
+			#
 			# see extension.py for list of suffixes
 			# .pyx is added for Cython
-			if [[ -n $(
+			if [[ 2 -eq $(
 				find '(' -name '*.c' -o -name '*.cc' -o -name '*.cpp' \
 					-o -name '*.cxx' -o -name '*.c++' -o -name '*.m' \
-					-o -name '*.mm' -o -name '*.pyx' ')' -print -quit
+					-o -name '*.mm' -o -name '*.pyx' ')' -printf '\n' |
+					head -n 2 | wc -l
 			) ]]; then
 				esetup.py build_ext -j "${jobs}" "${@}"
 			fi

--- a/eclass/distutils-r1.eclass
+++ b/eclass/distutils-r1.eclass
@@ -1182,7 +1182,7 @@ distutils-r1_python_compile() {
 		fi
 
 		# distutils is parallel-capable since py3.5
-		local jobs=$(makeopts_jobs "${MAKEOPTS}" INF)
+		local jobs=$(makeopts_jobs "${MAKEOPTS} ${*}" INF)
 		if [[ ${jobs} == INF ]]; then
 			local nproc=$(get_nproc)
 			jobs=$(( nproc + 1 ))


### PR DESCRIPTION
Since the `build_ext` call is expensive and doesn't benefit unless we parallel-build, avoid it if:

- there is only 1 source file found
- `--jobs 1` would be used

CC @gentoo/python