### PR TITLE
dev-lang/ruby: drop upstreamed patch

### DIFF
--- a/dev-lang/ruby/ruby-3.1.1.ebuild
+++ b/dev-lang/ruby/ruby-3.1.1.ebuild
@@ -68,7 +68,6 @@ src_prepare() {
 	eapply "${FILESDIR}"/"${SLOT}"/010*.patch
 
 	if use elibc_musl ; then
-		eapply "${FILESDIR}"/3.0/900-musl-*.patch
 		eapply "${FILESDIR}"/2.7/901-musl-*.patch
 	fi
 

--- a/dev-lang/ruby/ruby-3.1.2.ebuild
+++ b/dev-lang/ruby/ruby-3.1.2.ebuild
@@ -68,7 +68,6 @@ src_prepare() {
 	eapply "${FILESDIR}"/"${SLOT}"/010*.patch
 
 	if use elibc_musl ; then
-		eapply "${FILESDIR}"/3.0/900-musl-*.patch
 		eapply "${FILESDIR}"/2.7/901-musl-*.patch
 	fi
 


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/840260
Package-Manager: Portage-3.0.30, Repoman-3.0.3
Signed-off-by: Han PuYu <w12101111@gmail.com>