### PR TITLE
app-text/pelican: Keyword 4.7.2-r1 riscv, #840448 

### DIFF
--- a/app-text/pelican/pelican-4.7.2-r1.ebuild
+++ b/app-text/pelican/pelican-4.7.2-r1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://github.com/getpelican/pelican/archive/${PV}.tar.gz -> ${P}.tar.
 
 LICENSE="AGPL-3"
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~riscv ~x86"
 IUSE="doc examples markdown"
 
 RESTRICT="test"

--- a/dev-python/feedgenerator/feedgenerator-2.0.0.ebuild
+++ b/dev-python/feedgenerator/feedgenerator-2.0.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -12,7 +12,7 @@ SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="amd64 x86"
+KEYWORDS="amd64 ~riscv x86"
 
 RDEPEND="
 	dev-python/pytz[${PYTHON_USEDEP}]


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/840448

Signed-off-by: Yu Gu <guyu2876@gmail.com>