### PR TITLE
app-shells/fish: Keyword 3.4.1 for ~riscv and ~mips, #840236

### DIFF
--- a/app-shells/fish/fish-3.4.1.ebuild
+++ b/app-shells/fish/fish-3.4.1.ebuild
@@ -18,7 +18,7 @@ if [[ ${PV} == "9999" ]]; then
 	EGIT_REPO_URI="https://github.com/${PN}-shell/${PN}-shell.git"
 else
 	SRC_URI="https://github.com/${PN}-shell/${PN}-shell/releases/download/${MY_PV}/${MY_P}.tar.xz"
-	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-solaris"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-solaris"
 fi
 
 LICENSE="GPL-2"

--- a/app-shells/fish/fish-3.4.1.ebuild
+++ b/app-shells/fish/fish-3.4.1.ebuild
@@ -18,7 +18,7 @@ if [[ ${PV} == "9999" ]]; then
 	EGIT_REPO_URI="https://github.com/${PN}-shell/${PN}-shell.git"
 else
 	SRC_URI="https://github.com/${PN}-shell/${PN}-shell/releases/download/${MY_PV}/${MY_P}.tar.xz"
-	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-solaris"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-solaris"
 fi
 
 LICENSE="GPL-2"


### PR DESCRIPTION
Bugs: https://bugs.gentoo.org/840236

Signed-off-by: Raymond Wong <infiwang@pm.me>