### PR TITLE
profiles/package.mask: Mask ~dev-java/fop-2.0

### DIFF
--- a/profiles/base/package.use.mask
+++ b/profiles/base/package.use.mask
@@ -6,6 +6,12 @@
 # This file is only for generic masks. For arch-specific masks (i.e.
 # mask everywhere, unmask on arch/*) use arch/base.
 
+# Volkmar W. Pogatzki <gentoo@pogatzki.net> (2022-04-24)
+# Old version of dev-java/fop gets masked (bug #616474).
+# Remove this entry after stabilization of dev-java/fop:2.7 (bug #727504).
+dev-lang/logtalk fop
+net-fs/openafs doc
+
 # Matt Turner <mattst88@gentoo.org> (2022-03-25)
 # Depends on libsoup:3.0
 >=gnome-base/gvfs-1.50 http

--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -33,6 +33,12 @@
 
 #--- END OF EXAMPLES ---
 
+# Volkmar W. Pogatzki <gentoo@pogatzki.net> (2022-04-24)
+# Vulnerable (CVE-2017-5661), bug #616474.
+# Stabilization of newer version (bug #727504) presently blocked by bug #832824.
+<dev-java/fop-2.7
+<dev-java/fontbox-2.0.24
+
 # Alfredo Tupone <tupone@gentoo.org> (2022-04-24)
 # New release of janestreet packages need to tested
 dev-ml/sexplib0:0/0.15


### PR DESCRIPTION
Old version of `dev-java/fop:0` should no longer block `EAPI 5` removal or [unmasking jdk-17](https://bugs.gentoo.org/836135).