### PR TITLE
sys-devel/binutils: use econf

### DIFF
--- a/sys-devel/binutils-hppa64/binutils-hppa64-2.38-r2.ebuild
+++ b/sys-devel/binutils-hppa64/binutils-hppa64-2.38-r2.ebuild
@@ -70,19 +70,19 @@ BDEPEND="
 
 RESTRICT="!test? ( test )"
 
-MY_BUILDDIR=${WORKDIR}/build
-S=${WORKDIR}/${P/-hppa64/}
+MY_BUILDDIR="${WORKDIR}"/build
+S="${WORKDIR}"/${P/-hppa64/}
 
 src_unpack() {
 	if [[ ${PV} == 9999* ]] ; then
 		EGIT_REPO_URI="https://anongit.gentoo.org/git/proj/toolchain/binutils-patches.git"
-		EGIT_CHECKOUT_DIR=${WORKDIR}/patches-git
+		EGIT_CHECKOUT_DIR="${WORKDIR}"/patches-git
 		git-r3_src_unpack
 		mv patches-git/9999 patch || die
 
+		S="${WORKDIR}"/binutils
 		EGIT_REPO_URI="https://sourceware.org/git/binutils-gdb.git"
-		S=${WORKDIR}/binutils
-		EGIT_CHECKOUT_DIR=${S}
+		EGIT_CHECKOUT_DIR="${S}"
 		git-r3_src_unpack
 	else
 		unpack ${P/-hppa64/}.tar.xz
@@ -94,7 +94,7 @@ src_unpack() {
 		local dir=${P%_p?}
 		dir=${dir/-hppa64/}
 
-		S=${WORKDIR}/${dir}
+		S="${WORKDIR}"/${dir}
 	fi
 
 	cd "${WORKDIR}" || die
@@ -178,7 +178,7 @@ src_configure() {
 	done
 	echo
 
-	cd "${MY_BUILDDIR}"
+	cd "${MY_BUILDDIR}" || die
 	local myconf=()
 
 	if use plugins ; then
@@ -251,7 +251,6 @@ src_configure() {
 		--with-bugurl="$(toolchain-binutils_bugurl)"
 		--with-pkgversion="$(toolchain-binutils_pkgversion)"
 		$(use_enable static-libs static)
-		${EXTRA_ECONF}
 		# Disable modules that are in a combined binutils/gdb tree. bug #490566
 		--disable-{gdb,libdecnumber,readline,sim}
 		# Strip out broken static link flags.
@@ -281,8 +280,7 @@ src_configure() {
 		fi
 	fi
 
-	echo ./configure "${myconf[@]}"
-	"${S}"/configure "${myconf[@]}" || die
+	ECONF_SOURCE="${S}" econf "${myconf[@]}" || die
 
 	# Prevent makeinfo from running if doc is unset.
 	if ! use doc ; then
@@ -309,7 +307,7 @@ src_compile() {
 }
 
 src_test() {
-	cd "${MY_BUILDDIR}"
+	cd "${MY_BUILDDIR}" || die
 
 	# bug #637066
 	filter-flags -Wall -Wreturn-type

--- a/sys-devel/binutils/binutils-2.38-r2.ebuild
+++ b/sys-devel/binutils/binutils-2.38-r2.ebuild
@@ -7,6 +7,7 @@ inherit libtool flag-o-matic gnuconfig strip-linguas toolchain-funcs
 
 DESCRIPTION="Tools necessary to build programs"
 HOMEPAGE="https://sourceware.org/binutils/"
+
 LICENSE="GPL-3+"
 IUSE="cet default-gold doc +gold multitarget +nls pgo +plugins static-libs test vanilla"
 REQUIRED_USE="default-gold? ( gold )"
@@ -76,9 +77,9 @@ src_unpack() {
 		git-r3_src_unpack
 		mv patches-git/9999 patch || die
 
+		S="${WORKDIR}"/binutils
 		EGIT_REPO_URI="https://sourceware.org/git/binutils-gdb.git"
-		S=${WORKDIR}/binutils
-		EGIT_CHECKOUT_DIR=${S}
+		EGIT_CHECKOUT_DIR="${S}"
 		git-r3_src_unpack
 	else
 		unpack ${P/-hppa64/}.tar.xz
@@ -90,7 +91,7 @@ src_unpack() {
 		local dir=${P%_p?}
 		dir=${dir/-hppa64/}
 
-		S=${WORKDIR}/${dir}
+		S="${WORKDIR}"/${dir}
 	fi
 
 	cd "${WORKDIR}" || die
@@ -113,13 +114,13 @@ src_prepare() {
 		fi
 	fi
 
-	# Make sure our explicit libdir paths don't get clobbered. #562460
+	# Make sure our explicit libdir paths don't get clobbered, bug #562460
 	sed -i \
 		-e 's:@bfdlibdir@:@libdir@:g' \
 		-e 's:@bfdincludedir@:@includedir@:g' \
 		{bfd,opcodes}/Makefile.in || die
 
-	# Fix locale issues if possible #122216
+	# Fix locale issues if possible, bug #122216
 	if [[ -e ${FILESDIR}/binutils-configure-LANG.patch ]] ; then
 		einfo "Fixing misc issues in configure files"
 		for f in $(find "${S}" -name configure -exec grep -l 'autoconf version 2.13' {} +) ; do
@@ -128,11 +129,6 @@ src_prepare() {
 				|| eerror "Please file a bug about this"
 			eend $?
 		done
-	fi
-
-	# Fix conflicts with newer glibc #272594
-	if [[ -e libiberty/testsuite/test-demangle.c ]] ; then
-		sed -i 's:\<getline\>:get_line:g' libiberty/testsuite/test-demangle.c
 	fi
 
 	# Apply things from PATCHES and user dirs
@@ -164,7 +160,7 @@ src_configure() {
 	BINPATH=${TOOLPATH}/binutils-bin/${PV}
 
 	# Make sure we filter $LINGUAS so that only ones that
-	# actually work make it through #42033
+	# actually work make it through, bug #42033
 	strip-linguas -u */po
 
 	# Keep things sane
@@ -179,7 +175,7 @@ src_configure() {
 	done
 	echo
 
-	cd "${MY_BUILDDIR}"
+	cd "${MY_BUILDDIR}" || die
 	local myconf=()
 
 	if use plugins ; then
@@ -201,9 +197,10 @@ src_configure() {
 
 	myconf+=( --with-system-zlib )
 
-	# For bi-arch systems, enable a 64bit bfd.  This matches
-	# the bi-arch logic in toolchain.eclass. #446946
-	# We used to do it for everyone, but it's slow on 32bit arches. #438522
+	# For bi-arch systems, enable a 64bit bfd. This matches the bi-arch
+	# logic in toolchain.eclass. bug #446946
+	#
+	# We used to do it for everyone, but it's slow on 32bit arches. bug #438522
 	case $(tc-arch) in
 		ppc|sparc|x86) myconf+=( --enable-64-bit-bfd ) ;;
 	esac
@@ -217,10 +214,7 @@ src_configure() {
 		--enable-poison-system-directories
 	)
 
-	# glibc-2.3.6 lacks support for this ... so rather than force glibc-2.5+
-	# on everyone in alpha (for now), we'll just enable it when possible
-	has_version ">=${CATEGORY}/glibc-2.5" && myconf+=( --enable-secureplt )
-	has_version ">=sys-libs/glibc-2.5" && myconf+=( --enable-secureplt )
+	myconf+=( --enable-secureplt )
 
 	# mips can't do hash-style=gnu ...
 	if [[ $(tc-arch) != mips ]] ; then
@@ -244,24 +238,23 @@ src_configure() {
 		--enable-threads
 		# Newer versions (>=2.27) offer a configure flag now.
 		--enable-relro
-		# Newer versions (>=2.24) make this an explicit option. #497268
+		# Newer versions (>=2.24) make this an explicit option, bug #497268
 		--enable-install-libiberty
 		# Available from 2.35 on
 		--enable-textrel-check=warning
-		# Works better than vapier's patch... #808787
+		# Works better than vapier's patch, bug #808787
 		--enable-new-dtags
 		--disable-werror
 		--with-bugurl="$(toolchain-binutils_bugurl)"
 		--with-pkgversion="$(toolchain-binutils_pkgversion)"
 		$(use_enable static-libs static)
-		${EXTRA_ECONF}
-		# Disable modules that are in a combined binutils/gdb tree. #490566
+		# Disable modules that are in a combined binutils/gdb tree, bug #490566
 		--disable-{gdb,libdecnumber,readline,sim}
 		# Strip out broken static link flags.
 		# https://gcc.gnu.org/PR56750
 		--without-stage1-ldflags
 		# Change SONAME to avoid conflict across
-		# {native,cross}/binutils, binutils-libs. #666100
+		# {native,cross}/binutils, binutils-libs. bug #666100
 		--with-extra-soversion-suffix=gentoo-${CATEGORY}-${PN}-$(usex multitarget mt st)
 
 		# avoid automagic dependency on (currently prefix) systems
@@ -282,8 +275,7 @@ src_configure() {
 		fi
 	fi
 
-	echo ./configure "${myconf[@]}"
-	"${S}"/configure "${myconf[@]}" || die
+	ECONF_SOURCE="${S}" econf "${myconf[@]}" || die
 
 	# Prevent makeinfo from running if doc is unset.
 	if ! use doc ; then
@@ -294,7 +286,8 @@ src_configure() {
 }
 
 src_compile() {
-	cd "${MY_BUILDDIR}"
+	cd "${MY_BUILDDIR}" || die
+
 	# see Note [tooldir hack for ldscripts]
 	emake tooldir="${EPREFIX}${TOOLPATH}" all
 
@@ -309,9 +302,9 @@ src_compile() {
 }
 
 src_test() {
-	cd "${MY_BUILDDIR}"
+	cd "${MY_BUILDDIR}" || die
 
-	# bug 637066
+	# bug #637066
 	filter-flags -Wall -Wreturn-type
 
 	emake -k check
@@ -320,14 +313,15 @@ src_test() {
 src_install() {
 	local x d
 
-	cd "${MY_BUILDDIR}"
+	cd "${MY_BUILDDIR}" || die
+
 	# see Note [tooldir hack for ldscripts]
 	emake DESTDIR="${D}" tooldir="${EPREFIX}${LIBPATH}" install
-	rm -rf "${ED}"/${LIBPATH}/bin
+	rm -rf "${ED}"/${LIBPATH}/bin || die
 	use static-libs || find "${ED}" -name '*.la' -delete
 
-	# Newer versions of binutils get fancy with ${LIBPATH} #171905
-	cd "${ED}"/${LIBPATH}
+	# Newer versions of binutils get fancy with ${LIBPATH}, bug #171905
+	cd "${ED}"/${LIBPATH} || die
 	for d in ../* ; do
 		[[ ${d} == ../${PV} ]] && continue
 		mv ${d}/* . || die
@@ -338,9 +332,9 @@ src_install() {
 	# When something is built to cross-compile, it installs into
 	# /usr/$CHOST/ by default ... we have to 'fix' that :)
 	if is_cross ; then
-		cd "${ED}"/${BINPATH}
+		cd "${ED}"/${BINPATH} || die
 		for x in * ; do
-			mv ${x} ${x/${CTARGET}-}
+			mv ${x} ${x/${CTARGET}-} || die
 		done
 
 		if [[ -d ${ED}/usr/${CHOST}/${CTARGET} ]] ; then
@@ -349,6 +343,7 @@ src_install() {
 			rm -r "${ED}"/usr/${CHOST}/{include,lib}
 		fi
 	fi
+
 	insinto ${INCPATH}
 	local libiberty_headers=(
 		# Not all the libiberty headers.  See libiberty/Makefile.in:install_to_libdir.
@@ -362,8 +357,8 @@ src_install() {
 	)
 	doins "${libiberty_headers[@]/#/${S}/include/}"
 	if [[ -d ${ED}/${LIBPATH}/lib ]] ; then
-		mv "${ED}"/${LIBPATH}/lib/* "${ED}"/${LIBPATH}/
-		rm -r "${ED}"/${LIBPATH}/lib
+		mv "${ED}"/${LIBPATH}/lib/* "${ED}"/${LIBPATH}/ || die
+		rm -r "${ED}"/${LIBPATH}/lib || die
 	fi
 
 	# Generate an env.d entry for this binutils
@@ -377,29 +372,36 @@ src_install() {
 
 	# Handle documentation
 	if ! is_cross ; then
-		cd "${S}"
+		cd "${S}" || die
 		dodoc README
+
 		docinto bfd
 		dodoc bfd/ChangeLog* bfd/README bfd/PORTING bfd/TODO
+
 		docinto binutils
 		dodoc binutils/ChangeLog binutils/NEWS binutils/README
+
 		docinto gas
 		dodoc gas/ChangeLog* gas/CONTRIBUTORS gas/NEWS gas/README*
+
 		docinto gprof
 		dodoc gprof/ChangeLog* gprof/TEST gprof/TODO gprof/bbconv.pl
+
 		docinto ld
 		dodoc ld/ChangeLog* ld/README ld/NEWS ld/TODO
+
 		docinto libiberty
 		dodoc libiberty/ChangeLog* libiberty/README
+
 		docinto opcodes
 		dodoc opcodes/ChangeLog*
 	fi
 
 	# Remove shared info pages
-	rm -f "${ED}"/${DATAPATH}/info/{dir,configure.info,standards.info}
+	rm -f "${ED}"/${DATAPATH}/info/{dir,configure.info,standards.info} || die
 
 	# Trim all empty dirs
-	find "${ED}" -depth -type d -exec rmdir {} + 2>/dev/null
+	find "${ED}" -depth -type d -exec rmdir {} + 2>/dev/null || die
 }
 
 pkg_postinst() {

--- a/sys-devel/binutils/binutils-9999.ebuild
+++ b/sys-devel/binutils/binutils-9999.ebuild
@@ -175,7 +175,7 @@ src_configure() {
 	done
 	echo
 
-	cd "${MY_BUILDDIR}"
+	cd "${MY_BUILDDIR}" || die
 	local myconf=()
 
 	if use plugins ; then
@@ -248,7 +248,6 @@ src_configure() {
 		--with-bugurl="$(toolchain-binutils_bugurl)"
 		--with-pkgversion="$(toolchain-binutils_pkgversion)"
 		$(use_enable static-libs static)
-		${EXTRA_ECONF}
 		# Disable modules that are in a combined binutils/gdb tree, bug #490566
 		--disable-{gdb,libdecnumber,readline,sim}
 		# Strip out broken static link flags.
@@ -276,8 +275,7 @@ src_configure() {
 		fi
 	fi
 
-	echo ./configure "${myconf[@]}"
-	"${S}"/configure "${myconf[@]}" || die
+	ECONF_SOURCE="${S}" econf "${myconf[@]}" || die
 
 	# Prevent makeinfo from running if doc is unset.
 	if ! use doc ; then

--- a/sys-devel/gdb/gdb-11.2.ebuild
+++ b/sys-devel/gdb/gdb-11.2.ebuild
@@ -53,10 +53,10 @@ fi
 IUSE="cet guile lzma multitarget nls +python +server source-highlight test vanilla xml xxhash"
 REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
 
-# ia64 kernel crashes when gdb testsuite is running
-# in fact, gdb's test suite needs some work to get passing.
+# In fact, gdb's test suite needs some work to get passing.
 # See e.g. https://sourceware.org/gdb/wiki/TestingGDB.
 # As of 11.2, on amd64: "# of unexpected failures    8600"
+# ia64 kernel crashes when gdb testsuite is running
 RESTRICT="
 	ia64? ( test )
 	!test? ( test )
@@ -103,9 +103,8 @@ src_prepare() {
 	default
 
 	strip-linguas -u bfd/po opcodes/po
-	export CC_FOR_BUILD="$(tc-getBUILD_CC)"
 
-	# avoid using ancient termcap from host on Prefix systems
+	# Avoid using ancient termcap from host on Prefix systems
 	sed -i -e 's/termcap tinfow/tinfow/g' \
 		gdb/configure{.ac,} || die
 }
@@ -134,7 +133,7 @@ src_configure() {
 		--with-pkgversion="$(gdb_branding)"
 		--with-bugurl='https://bugs.gentoo.org/'
 		--disable-werror
-		# Disable modules that are in a combined binutils/gdb tree. #490566
+		# Disable modules that are in a combined binutils/gdb tree. bug #490566
 		--disable-{binutils,etc,gas,gold,gprof,ld}
 
 		# avoid automagic dependency on (currently prefix) systems
@@ -197,6 +196,8 @@ src_configure() {
 	# source-highlight is detected with pkg-config: bug #716558
 	export ac_cv_path_pkg_config_prog_path="$(tc-getPKG_CONFIG)"
 
+	export CC_FOR_BUILD="$(tc-getBUILD_CC)"
+
 	# ensure proper compiler is detected for Clang builds: bug #831202
 	export GCC_FOR_TARGET="${CC_FOR_TARGET:-$(tc-getCC)}"
 
@@ -208,7 +209,7 @@ src_install() {
 
 	find "${ED}"/usr -name libiberty.a -delete || die
 
-	# Delete translations that conflict with binutils-libs. #528088
+	# Delete translations that conflict with binutils-libs. bug #528088
 	# Note: Should figure out how to store these in an internal gdb dir.
 	if use nls ; then
 		find "${ED}" \
@@ -252,7 +253,7 @@ src_install() {
 	# Remove shared info pages
 	rm -f "${ED}"/usr/share/info/{annotate,bfd,configure,standards}.info*
 
-	if use python; then
+	if use python ; then
 		python_optimize "${ED}"/usr/share/gdb/python/gdb
 	fi
 }

--- a/sys-devel/gdb/gdb-9999.ebuild
+++ b/sys-devel/gdb/gdb-9999.ebuild
@@ -53,10 +53,14 @@ fi
 IUSE="cet guile lzma multitarget nls +python +server source-highlight test vanilla xml xxhash"
 REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
 
+# In fact, gdb's test suite needs some work to get passing.
+# See e.g. https://sourceware.org/gdb/wiki/TestingGDB.
+# As of 11.2, on amd64: "# of unexpected failures    8600"
 # ia64 kernel crashes when gdb testsuite is running
 RESTRICT="
 	ia64? ( test )
 	!test? ( test )
+	test
 "
 
 RDEPEND="
@@ -98,9 +102,8 @@ src_prepare() {
 	default
 
 	strip-linguas -u bfd/po opcodes/po
-	export CC_FOR_BUILD="$(tc-getBUILD_CC)"
 
-	# avoid using ancient termcap from host on Prefix systems
+	# Avoid using ancient termcap from host on Prefix systems
 	sed -i -e 's/termcap tinfow/tinfow/g' \
 		gdb/configure{.ac,} || die
 }
@@ -129,7 +132,7 @@ src_configure() {
 		--with-pkgversion="$(gdb_branding)"
 		--with-bugurl='https://bugs.gentoo.org/'
 		--disable-werror
-		# Disable modules that are in a combined binutils/gdb tree. #490566
+		# Disable modules that are in a combined binutils/gdb tree. bug #490566
 		--disable-{binutils,etc,gas,gold,gprof,ld}
 
 		# avoid automagic dependency on (currently prefix) systems
@@ -192,6 +195,8 @@ src_configure() {
 	# source-highlight is detected with pkg-config: bug #716558
 	export ac_cv_path_pkg_config_prog_path="$(tc-getPKG_CONFIG)"
 
+	export CC_FOR_BUILD="$(tc-getBUILD_CC)"
+
 	# ensure proper compiler is detected for Clang builds: bug #831202
 	export GCC_FOR_TARGET="${CC_FOR_TARGET:-$(tc-getCC)}"
 
@@ -203,7 +208,7 @@ src_install() {
 
 	find "${ED}"/usr -name libiberty.a -delete || die
 
-	# Delete translations that conflict with binutils-libs. #528088
+	# Delete translations that conflict with binutils-libs. bug #528088
 	# Note: Should figure out how to store these in an internal gdb dir.
 	if use nls ; then
 		find "${ED}" \
@@ -247,7 +252,7 @@ src_install() {
 	# Remove shared info pages
 	rm -f "${ED}"/usr/share/info/{annotate,bfd,configure,standards}.info*
 
-	if use python; then
+	if use python ; then
 		python_optimize "${ED}"/usr/share/gdb/python/gdb
 	fi
 }

--- a/sys-libs/binutils-libs/binutils-libs-2.38-r2.ebuild
+++ b/sys-libs/binutils-libs/binutils-libs-2.38-r2.ebuild
@@ -123,8 +123,7 @@ multilib_src_configure() {
 			"${S}"/opcodes/Makefile.in || die
 	fi
 
-	ECONF_SOURCE=${S} \
-	econf "${myconf[@]}"
+	ECONF_SOURCE="${S}" econf "${myconf[@]}"
 
 	# Prevent makeinfo from running as we don't build docs here.
 	# bug #622652


### PR DESCRIPTION
Sync more with binutils-libs by using econf instead of raw ./configure call;
means we benefit from some of the default arguments it passes, in particular
thinking of silent rules which upstream are starting to support more now too
(and enable by default) which econf disables.

Also, we use it fine in binutils-libs w/o issue.

Signed-off-by: Sam James <sam@gentoo.org>