### PR TITLE
Misc bdeps

### DIFF
--- a/sys-apps/diffutils/diffutils-3.8.ebuild
+++ b/sys-apps/diffutils/diffutils-3.8.ebuild
@@ -4,7 +4,8 @@
 EAPI=7
 
 VERIFY_SIG_OPENPGP_KEY_PATH="${BROOT}"/usr/share/openpgp-keys/diffutils.asc
-inherit flag-o-matic verify-sig
+WANT_LIBTOOL=none
+inherit autotools flag-o-matic verify-sig
 
 DESCRIPTION="Tools to make diffs and compare files"
 HOMEPAGE="https://www.gnu.org/software/diffutils/"

--- a/sys-devel/m4/m4-1.4.19.ebuild
+++ b/sys-devel/m4/m4-1.4.19.ebuild
@@ -33,6 +33,7 @@ RDEPEND="
 DEPEND="${RDEPEND}"
 # Remember: cannot dep on autoconf since it needs us
 BDEPEND="app-arch/xz-utils
+	sys-apps/texinfo
 	nls? ( sys-devel/gettext )
 	verify-sig? ( sec-keys/openpgp-keys-m4 )"
 


### PR DESCRIPTION
```
>>> Compiling source in /var/tmp/portage/sys-apps/diffutils-3.8/work/diffutils-3.8 ...
make -j16 
CDPATH="${ZSH_VERSION+.}:" && cd . && /bin/sh '/var/tmp/portage/sys-apps/diffutils-3.8/work/diffutils-3.8/build-aux/missing' aclocal-1.16 -I m4
/var/tmp/portage/sys-apps/diffutils-3.8/work/diffutils-3.8/build-aux/missing: line 81: aclocal-1.16: command not found
WARNING: 'aclocal-1.16' is missing on your system.
         You should only need it if you modified 'acinclude.m4' or
         'configure.ac' or m4 files included by 'configure.ac'.
         The 'aclocal' program is part of the GNU Automake package:
         <https://www.gnu.org/software/automake>
         It also requires GNU Autoconf, GNU m4 and Perl in order to run:
         <https://www.gnu.org/software/autoconf>
         <https://www.gnu.org/software/m4/>
         <https://www.perl.org/>
make: *** [Makefile:1640: aclocal.m4] Error 127
 * ERROR: sys-apps/diffutils-3.8::gentoo failed (compile phase):
```
https://git.savannah.gnu.org/cgit/diffutils.git/tree/configure.ac


```
WARNING: 'makeinfo' is missing on your system.
         You should only need it if you modified a '.texi' file, or
         any other file indirectly affecting the aspect of the manual.
         You might want to install the Texinfo package:
         <https://www.gnu.org/software/texinfo/>
         The spurious makeinfo call might also be the consequence of
         using a buggy 'make' (AIX, DU, IRIX), in which case you might
         want to install GNU make:
         <https://www.gnu.org/software/make/>
make[2]: *** [Makefile:1982: m4.info] Error 127
make[2]: Leaving directory '/var/tmp/portage/sys-devel/m4-1.4.19/work/m4-1.4.19/doc'
make[1]: *** [Makefile:2018: install-recursive] Error 1
make[1]: Leaving directory '/var/tmp/portage/sys-devel/m4-1.4.19/work/m4-1.4.19'
make: *** [Makefile:2321: install] Error 2
 * ERROR: sys-devel/m4-1.4.19::gentoo failed (install phase):
 *   emake failed
```
Weirdly it fails in install phase. 

Please consider this as reporting a bug, and if you know a better way to fix the ebuilds, please go ahead and close this PR