### PR TITLE
sys-libs/gdbm: call elibtoolize in src_prepare

### DIFF
--- a/sys-libs/gdbm/gdbm-1.23.ebuild
+++ b/sys-libs/gdbm/gdbm-1.23.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 
 VERIFY_SIG_OPENPGP_KEY_PATH="${BROOT}"/usr/share/openpgp-keys/gdbm.asc
-inherit multilib-minimal verify-sig
+inherit autotools multilib-minimal verify-sig
 
 DESCRIPTION="Standard GNU database libraries"
 HOMEPAGE="https://www.gnu.org/software/gdbm/"
@@ -19,6 +19,13 @@ IUSE="+berkdb nls +readline static-libs"
 DEPEND="readline? ( sys-libs/readline:=[${MULTILIB_USEDEP}] )"
 RDEPEND="${DEPEND}"
 BDEPEND="verify-sig? ( sec-keys/openpgp-keys-gdbm )"
+
+src_prepare() {
+	default
+	# gdbm ships with very old libtool files, regen to avoid
+	# errors when cross-compiling.
+	elibtoolize
+}
 
 multilib_src_configure() {
 	# gdbm doesn't appear to use either of these libraries


### PR DESCRIPTION
gdbm's default libtool file causes to link with /usr/lib directory
i.e. -L/usr/lib which causes linker (LLD) to complain when
cross-compiling building for arm32.

Call elibtoolize in src_prepare to regen files to avoid the
linker errors.