### PR TITLE
dev-python/wxpython: apply upstream fix

### DIFF
--- a/dev-python/wxpython/files/wxpython-4.0.7-ultimatelistctrl.patch
+++ b/dev-python/wxpython/files/wxpython-4.0.7-ultimatelistctrl.patch
@@ -1,0 +1,85 @@
+From https://github.com/wxWidgets/Phoenix/commit/3eb9eb32dc3285435039f6c420c398665372a1ad
+From 3eb9eb32dc3285435039f6c420c398665372a1ad Mon Sep 17 00:00:00 2001
+From: Glen Whitney <glen@studioinfinity.org>
+Date: Tue, 31 Aug 2021 11:06:27 -0700
+Subject: [PATCH] fix: Correct types of arguments to
+ ScrolledWindow.SetScrollbars
+
+---
+ demo/Mask.py                   |  2 +-
+ demo/OGL.py                    |  2 +-
+ wx/lib/agw/ultimatelistctrl.py | 14 +++++++-------
+ 3 files changed, 9 insertions(+), 9 deletions(-)
+
+diff --git a/demo/Mask.py b/demo/Mask.py
+index 5f0c2cdde..109b8f30b 100644
+--- a/demo/Mask.py
++++ b/demo/Mask.py
+@@ -56,7 +56,7 @@ def __init__(self, parent):
+         mask = wx.Mask(self.bmp_withcolourmask, wx.WHITE)
+         self.bmp_withcolourmask.SetMask(mask)
+ 
+-        self.SetScrollbars(20, 20, 700/20, 460/20)
++        self.SetScrollbars(20, 20, 700//20, 460//20)
+ 
+         self.Bind(wx.EVT_PAINT, self.OnPaint)
+ 
+diff --git a/demo/OGL.py b/demo/OGL.py
+index 72ca543dd..d475e5011 100644
+--- a/demo/OGL.py
++++ b/demo/OGL.py
+@@ -272,7 +272,7 @@ def __init__(self, parent, log, frame):
+ 
+         maxWidth  = 1000
+         maxHeight = 1000
+-        self.SetScrollbars(20, 20, maxWidth/20, maxHeight/20)
++        self.SetScrollbars(20, 20, maxWidth//20, maxHeight//20)
+ 
+         self.log = log
+         self.frame = frame
+diff --git a/wx/lib/agw/ultimatelistctrl.py b/wx/lib/agw/ultimatelistctrl.py
+index c60867684..14fc41f86 100644
+--- a/wx/lib/agw/ultimatelistctrl.py
++++ b/wx/lib/agw/ultimatelistctrl.py
+@@ -9654,8 +9654,8 @@ def RecalculatePositions(self, noRefresh=False):
+                 self._linesPerPage = clientHeight//lineHeight
+ 
+                 self.SetScrollbars(SCROLL_UNIT_X, lineHeight,
+-                                   (self.GetHeaderWidth()-decrement)/SCROLL_UNIT_X,
+-                                   (entireHeight + lineHeight - 1)/lineHeight,
++                                   (self.GetHeaderWidth()-decrement)//SCROLL_UNIT_X,
++                                   (entireHeight + lineHeight - 1)//lineHeight,
+                                    self.GetScrollPos(wx.HORIZONTAL),
+                                    self.GetScrollPos(wx.VERTICAL),
+                                    True)
+@@ -9676,8 +9676,8 @@ def RecalculatePositions(self, noRefresh=False):
+                     decrement = SCROLL_UNIT_X
+ 
+                 self.SetScrollbars(SCROLL_UNIT_X, SCROLL_UNIT_Y,
+-                                   (self.GetHeaderWidth()-decrement)/SCROLL_UNIT_X,
+-                                   (entireHeight + SCROLL_UNIT_Y - 1)/SCROLL_UNIT_Y,
++                                   (self.GetHeaderWidth()-decrement)//SCROLL_UNIT_X,
++                                   (entireHeight + SCROLL_UNIT_Y - 1)//SCROLL_UNIT_Y,
+                                    self.GetScrollPos(wx.HORIZONTAL),
+                                    self.GetScrollPos(wx.VERTICAL),
+                                    True)
+@@ -9728,8 +9728,8 @@ def RecalculatePositions(self, noRefresh=False):
+                         line._gi.ExtendWidth(widthMax)
+ 
+                 self.SetScrollbars(SCROLL_UNIT_X, lineHeight,
+-                                   (x + SCROLL_UNIT_X)/SCROLL_UNIT_X,
+-                                   (y + lineHeight)/lineHeight,
++                                   (x + SCROLL_UNIT_X)//SCROLL_UNIT_X,
++                                   (y + lineHeight)//lineHeight,
+                                    self.GetScrollPos(wx.HORIZONTAL),
+                                    self.GetScrollPos(wx.VERTICAL),
+                                    True)
+@@ -9797,7 +9797,7 @@ def RecalculatePositions(self, noRefresh=False):
+                             break  # Everything fits, no second try required.
+ 
+                 self.SetScrollbars(SCROLL_UNIT_X, lineHeight,
+-                                   (entireWidth + SCROLL_UNIT_X)/SCROLL_UNIT_X,
++                                   (entireWidth + SCROLL_UNIT_X)//SCROLL_UNIT_X,
+                                    0,
+                                    self.GetScrollPos(wx.HORIZONTAL),
+                                    0,

--- a/dev-python/wxpython/wxpython-4.0.7-r2.ebuild
+++ b/dev-python/wxpython/wxpython-4.0.7-r2.ebuild
@@ -1,0 +1,92 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+PYTHON_COMPAT=( python3_{8..10} )
+WX_GTK_VER="3.0-gtk3"
+
+DISTUTILS_IN_SOURCE_BUILD="1"
+
+inherit distutils-r1 multiprocessing virtualx wxwidgets
+
+MY_PN="wxPython"
+MY_PV="${PV}.post2"
+
+DESCRIPTION="A blending of the wxWindows C++ class library with Python"
+HOMEPAGE="https://www.wxpython.org/"
+SRC_URI="mirror://pypi/${P:0:1}/${MY_PN}/${MY_PN}-${MY_PV}.tar.gz"
+
+LICENSE="wxWinLL-3"
+SLOT="4.0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~ppc ~ppc64 ~riscv ~sparc ~x86"
+IUSE="test webkit"
+# Tests broken: #726812, #722716
+RESTRICT="test"
+#RESTRICT="!test? ( test )"
+
+# wxPython doesn't seem to be able to optionally disable features. webkit is
+# optionally patched out because it's so huge, but other elements are not,
+# which makes us have to require all features from wxGTK
+RDEPEND="
+	>=x11-libs/wxGTK-3.0.4-r301:${WX_GTK_VER}=[gstreamer,libnotify,opengl,sdl,tiff,webkit?,X]
+	media-libs/libpng:0=
+	media-libs/tiff:0
+	media-libs/libjpeg-turbo:0"
+
+BDEPEND="${RDEPEND}
+	app-doc/doxygen
+	dev-python/setuptools[${PYTHON_USEDEP}]
+	dev-python/six[${PYTHON_USEDEP}]
+	test? (
+		${VIRTUALX_DEPEND}
+		dev-python/appdirs[${PYTHON_USEDEP}]
+		dev-python/numpy[${PYTHON_USEDEP}]
+		dev-python/pillow[${PYTHON_USEDEP}]
+		dev-python/pytest[${PYTHON_USEDEP}]
+	)"
+
+S="${WORKDIR}/${MY_PN}-${MY_PV}"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-4.0.6-skip-broken-tests.patch"
+	"${FILESDIR}/${P}-ultimatelistctrl.patch"
+)
+
+python_prepare_all() {
+	if ! use webkit; then
+		eapply "${FILESDIR}/${PN}-4.0.6-no-webkit.patch"
+		rm unittests/test_webview.py || die
+	fi
+	# Most of these tests disabled below fail because of the virtx/portage
+	# environment, but some fail for unknown reasons.
+	rm unittests/test_uiaction.py \
+		unittests/test_notifmsg.py \
+		unittests/test_mousemanager.py \
+		unittests/test_display.py \
+		unittests/test_pi_import.py \
+		unittests/test_lib_agw_thumbnailctrl.py \
+		unittests/test_sound.py || die
+
+	distutils-r1_python_prepare_all
+}
+
+src_configure() {
+	setup-wxwidgets
+}
+
+python_compile() {
+	DOXYGEN=/usr/bin/doxygen ${PYTHON} build.py dox etg --nodoc || die
+	${PYTHON} build.py build_py \
+		--use_syswx \
+		--no_magic \
+		--jobs=$(makeopts_jobs) \
+		--release || die
+}
+
+python_install() {
+	distutils-r1_python_install --skip-build
+}
+
+python_test() {
+	virtx epytest unittests
+}


### PR DESCRIPTION
Correct types of arguments to ScrolledWindow.SetScrollbars
Related: https://github.com/wxWidgets/Phoenix/pull/2005