### PR TITLE
media-libs/imlib2: fix multilib problem with eps

### DIFF
--- a/media-libs/imlib2/imlib2-1.9.0.ebuild
+++ b/media-libs/imlib2/imlib2-1.9.0.ebuild
@@ -59,7 +59,7 @@ multilib_src_configure() {
 		$(use_with zlib)
 		$(use_with svg)
 		$(use_with heif)
-		$(use_with eps ps)
+		$(multilib_native_use_with eps ps)
 		$(use_with jpeg2k j2k)
 		$(use_with jpegxl jxl)
 	)

--- a/media-libs/imlib2/metadata.xml
+++ b/media-libs/imlib2/metadata.xml
@@ -10,7 +10,7 @@
 		<flag name="bzip2">Bzip2 loader support</flag>
 		<flag name="gif">Gif image loader support</flag>
 		<flag name="jpeg">Jpeg image loader support</flag>
-		<flag name="heif">Hief and Avif image loader support</flag>
+		<flag name="heif">Heif and Avif image loader support</flag>
 		<flag name="eps">Eps image loader support</flag>
 		<flag name="jpegxl">Jxl image loader support</flag>
 		<flag name="mp3">ID3 loader support</flag>


### PR DESCRIPTION
also fix a small tupo in the metadata.

Closes: https://bugs.gentoo.org/show_bug.cgi?id=841359