### PR TITLE
app-misc/g15daemon: properly close ebegin with eend

### DIFF
--- a/app-misc/g15daemon/g15daemon-1.9.5.3-r14.ebuild
+++ b/app-misc/g15daemon/g15daemon-1.9.5.3-r14.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -38,6 +38,7 @@ uinput_check() {
 	local rc=1
 	linux_config_exists && linux_chkconfig_present INPUT_UINPUT
 	rc=$?
+	eend ${rc}
 
 	if [[ ${rc} -ne 0 ]] ; then
 		eerror "To use g15daemon, you need to compile your kernel with uinput support."
@@ -126,7 +127,7 @@ src_install() {
 	doexe "${FILESDIR}"/20g15daemon
 
 	if use perl ; then
-		ebegin "Installing Perl Bindings (G15Daemon.pm)"
+		einfo "Installing Perl Bindings (G15Daemon.pm)"
 		cd "${WORKDIR}/G15Daemon-0.2" || die
 		docinto perl
 		perl-module_src_install

--- a/app-misc/g15daemon/g15daemon-1.9.5.3-r15.ebuild
+++ b/app-misc/g15daemon/g15daemon-1.9.5.3-r15.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -38,6 +38,7 @@ uinput_check() {
 	local rc=1
 	linux_config_exists && linux_chkconfig_present INPUT_UINPUT
 	rc=$?
+	eend ${rc}
 
 	if [[ ${rc} -ne 0 ]] ; then
 		eerror "To use g15daemon, you need to compile your kernel with uinput support."
@@ -127,7 +128,7 @@ src_install() {
 	doexe "${FILESDIR}"/20g15daemon
 
 	if use perl ; then
-		ebegin "Installing Perl Bindings (G15Daemon.pm)"
+		einfo "Installing Perl Bindings (G15Daemon.pm)"
 		cd "${WORKDIR}/G15Daemon-0.2" || die
 		docinto perl
 		perl-module_src_install

--- a/app-misc/g15daemon/g15daemon-9999.ebuild
+++ b/app-misc/g15daemon/g15daemon-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -39,6 +39,7 @@ uinput_check() {
 	local rc=1
 	linux_config_exists && linux_chkconfig_present INPUT_UINPUT
 	rc=$?
+	eend ${rc}
 
 	if [[ ${rc} -ne 0 ]] ; then
 		eerror "To use g15daemon, you need to compile your kernel with uinput support."
@@ -137,7 +138,7 @@ src_install() {
 	doexe "${FILESDIR}"/20g15daemon
 
 	if use perl ; then
-		ebegin "Installing Perl Bindings (G15Daemon.pm)"
+		einfo "Installing Perl Bindings (G15Daemon.pm)"
 		cd "${WORKDIR}/G15Daemon-0.2" || die
 		docinto perl
 		perl-module_src_install


### PR DESCRIPTION
Each ebuild had two instances of ebegin w/o a closing eend. In one case,
just add the missing eend, there's an error code can be used. In the
other case, change the ebegin to einfo.

Signed-off-by: Thomas Bracht Laumann Jespersen <t@laumann.xyz>