### PR TITLE
apache-2.eclass: remove eend with no ebegin

### DIFF
--- a/eclass/apache-2.eclass
+++ b/eclass/apache-2.eclass
@@ -650,7 +650,6 @@ apache-2_src_install() {
 	mv -f "${ED%/}/var/www/localhost/icons" \
 		"${ED%/}/usr/share/apache2/icons" || die
 	rm -rf "${ED%/}/var/www/localhost/" || die
-	eend $?
 
 	# set some sane permissions for suexec
 	if use suexec ; then


### PR DESCRIPTION
Found by scanning for eclasses with 'eend' but no occurrences of
'ebegin'. The following QA notice was also generated when installing
www-servers/apache:

    * QA Notice: eend called without preceding ebegin (phase: install)

Fix by just removing the line.

Signed-off-by: Thomas Bracht Laumann Jespersen <t@laumann.xyz>