### PR TITLE
Drop alsa-plugins blocker from pipewire ebuild

### DIFF
--- a/media-plugins/alsa-plugins/alsa-plugins-1.2.6-r1.ebuild
+++ b/media-plugins/alsa-plugins/alsa-plugins-1.2.6-r1.ebuild
@@ -1,0 +1,98 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+inherit autotools flag-o-matic multilib multilib-minimal
+
+DESCRIPTION="ALSA extra plugins"
+HOMEPAGE="https://alsa-project.org/wiki/Main_Page"
+SRC_URI="https://www.alsa-project.org/files/pub/plugins/${P}.tar.bz2"
+
+LICENSE="GPL-2 LGPL-2.1"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~riscv ~sparc ~x86 ~amd64-linux"
+IUSE="arcam_av debug ffmpeg jack libsamplerate +mix oss pulseaudio speex +usb_stream"
+
+RDEPEND="
+	>=media-libs/alsa-lib-${PV}:=[${MULTILIB_USEDEP}]
+	ffmpeg? ( media-video/ffmpeg:0=[${MULTILIB_USEDEP}] )
+	jack? ( virtual/jack[${MULTILIB_USEDEP}] )
+	libsamplerate? ( >=media-libs/libsamplerate-0.1.8-r1:=[${MULTILIB_USEDEP}] )
+	pulseaudio? ( >=media-sound/pulseaudio-2.1-r1[${MULTILIB_USEDEP}] )
+	speex? (
+		>=media-libs/speex-1.2.0:=[${MULTILIB_USEDEP}]
+		media-libs/speexdsp[${MULTILIB_USEDEP}]
+	)
+"
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+src_prepare() {
+	default
+
+	# For some reasons the polyp/pulse plugin does fail with alsaplayer with a
+	# failed assert. As the code works just fine with asserts disabled, for now
+	# disable them waiting for a better solution.
+	sed \
+		-e '/AM_CFLAGS/s:-Wall:-DNDEBUG -Wall:' \
+		-i pulse/Makefile.am || die
+
+	eautoreconf
+}
+
+multilib_src_configure() {
+	use debug || append-cppflags -DNDEBUG
+
+	local myeconfargs=(
+		# default does not contain $prefix: bug #673464
+		--with-alsalconfdir="${EPREFIX}"/etc/alsa/conf.d
+
+		--with-speex="$(usex speex lib no)"
+		$(use_enable arcam_av arcamav)
+		$(use_enable ffmpeg libav)
+		$(use_enable jack)
+		$(use_enable libsamplerate samplerate)
+		$(use_enable mix)
+		$(use_enable oss)
+		$(use_enable pulseaudio)
+		$(use_enable speex speexdsp)
+		$(use_enable usb_stream usbstream)
+	)
+	ECONF_SOURCE="${S}" econf "${myeconfargs[@]}"
+}
+
+multilib_src_install_all() {
+	einstalldocs
+
+	cd doc || die
+	dodoc upmix.txt vdownmix.txt README-pcm-oss
+	use jack && dodoc README-jack
+	use libsamplerate && dodoc samplerate.txt
+	use ffmpeg && dodoc lavrate.txt a52.txt
+
+	if use pulseaudio; then
+
+		local alsaconf_probe_hook=99-pulseaudio-probe.conf
+
+		dodoc README-pulse
+		# install ALSA configuration files
+		# making PA to be used by alsa clients
+		insinto /usr/share/alsa
+		doins "${FILESDIR}"/pulse-default.conf
+		insinto /usr/share/alsa/alsa.conf.d
+		doins "${FILESDIR}"/"${alsaconf_probe_hook}"
+		dosym ../../../usr/share/alsa/alsa.conf.d/"${alsaconf_probe_hook}" \
+			/etc/alsa/conf.d/"${alsaconf_probe_hook}" #670960
+	fi
+
+	find "${ED}" -type f \( -name '*.a' -o -name '*.la' \) -delete || die
+}
+
+pkg_postinst() {
+	if use pulseaudio; then
+		einfo "The PulseAudio device is now set as the default device if the"
+		einfo "PulseAudio server is found to be running. Any custom"
+		einfo "configuration in /etc/asound.conf or ~/.asoundrc for this"
+		einfo "purpose should now be unnecessary."
+	fi
+}

--- a/media-plugins/alsa-plugins/files/99-pulseaudio-probe.conf
+++ b/media-plugins/alsa-plugins/files/99-pulseaudio-probe.conf
@@ -1,0 +1,19 @@
+# PulseAudio alsa plugin configuration file to set the pulseaudio plugin as
+# default output for applications using alsa when pulseaudio is running.
+
+hook_func.pulse_load_if_running {
+	lib "libasound_module_conf_pulse.so"
+	func "conf_pulse_hook_load_if_running"
+}
+
+@hooks [
+	{
+		func pulse_load_if_running
+		files [
+			"/usr/share/alsa/pulse-default.conf"
+			"/etc/asound.conf"
+			"~/.asoundrc"
+		]
+		errors false
+	}
+]

--- a/media-video/pipewire/pipewire-0.3.51-r1.ebuild
+++ b/media-video/pipewire/pipewire-0.3.51-r1.ebuild
@@ -83,10 +83,7 @@ RDEPEND="
 		!media-sound/jack2
 	)
 	lv2? ( media-libs/lilv )
-	pipewire-alsa? (
-		>=media-libs/alsa-lib-1.1.7[${MULTILIB_USEDEP}]
-		!media-plugins/alsa-plugins[${MULTILIB_USEDEP},pulseaudio]
-	)
+	pipewire-alsa? ( !<media-plugins/alsa-plugins-1.2.6-r1 )
 	!pipewire-alsa? ( media-plugins/alsa-plugins[${MULTILIB_USEDEP},pulseaudio] )
 	ssl? ( dev-libs/openssl:= )
 	systemd? ( sys-apps/systemd )


### PR DESCRIPTION
Pulseaudio probe hook historically is named `51-pulseaudio-probe.conf` which orders it lexicographically before pipewire defaults hook `99-pipewire-default.conf` so pulseaudio probe hook runs first.

Turned out that if pulseaudio probe hook successfully detects available pulseaudio server, that would prevent selecting pipewire audio if that is available too. This is only a problem in a setup which enables pipewire-pulse so both pulseaudio server connection and pipewire audio connection are functional.

Fix this by reordering pulseaudio probe hook to run after pipewire can be probed and used if successful, and this blocker can be dropped in favor of requiring more recent `media-plugins/alsa-plugins` package.

While at it, drop remaining no-op sed from #410261