### PR TITLE
sys-apps/fwupd: enable curl support

### DIFF
--- a/sys-apps/fwupd/fwupd-1.8.0-r1.ebuild
+++ b/sys-apps/fwupd/fwupd-1.8.0-r1.ebuild
@@ -135,7 +135,7 @@ src_configure() {
 		--localstatedir "${EPREFIX}"/var
 		-Dbuild="$(usex minimal standalone all)"
 		-Dconsolekit="disabled"
-		-Dcurl="disabled"
+		-Dcurl="enabled"
 		-Ddocs="$(usex gtk-doc gtkdoc none)"
 		-Defi_binary="false"
 		-Dsupported_build="true"


### PR DESCRIPTION
This PR is an attempt to (re-)enable curl support for fwupd-1.8.0 to fix `no libcurl support` error message during `fwupd refresh`.

Please review and merge, or let me know how to improve it.

Closes: https://bugs.gentoo.org/841836