### PR TITLE
media-libs/mesa-9999: Add USE flag to enable proprietary codecs

### DIFF
--- a/media-libs/mesa/mesa-9999.ebuild
+++ b/media-libs/mesa/mesa-9999.ebuild
@@ -33,9 +33,8 @@ for card in ${VIDEO_CARDS}; do
 done
 
 IUSE="${IUSE_VIDEO_CARDS}
-	cpu_flags_x86_sse2 d3d9 debug gles1 +gles2 +llvm
-	lm-sensors opencl osmesa selinux test unwind vaapi valgrind vdpau vulkan
-	vulkan-overlay wayland +X xa xvmc zink +zstd"
+	cpu_flags_x86_sse2 d3d9 debug gles1 +gles2 +llvm lm-sensors opencl osmesa +proprietary-codecs
+	selinux test unwind vaapi valgrind vdpau vulkan vulkan-overlay wayland +X xa xvmc zink +zstd"
 
 REQUIRED_USE="
 	d3d9?   ( || ( video_cards_intel video_cards_r300 video_cards_r600 video_cards_radeonsi video_cards_nouveau video_cards_vmware ) )
@@ -434,6 +433,7 @@ multilib_src_configure() {
 		$(meson_feature zstd)
 		$(meson_use cpu_flags_x86_sse2 sse2)
 		-Dvalgrind=$(usex valgrind auto disabled)
+		-Dvideo-codecs=$(usex proprietary-codecs "h264dec,h264enc,h265dec,h265enc,vc1dec" "")
 		-Dgallium-drivers=$(driver_list "${GALLIUM_DRIVERS[*]}")
 		-Dvulkan-drivers=$(driver_list "${VULKAN_DRIVERS[*]}")
 		--buildtype $(usex debug debug plain)

--- a/media-libs/mesa/metadata.xml
+++ b/media-libs/mesa/metadata.xml
@@ -17,6 +17,7 @@
 		<flag name="lm-sensors">Enable Gallium HUD lm-sensors support.</flag>
 		<flag name="opencl">Enable the Clover Gallium OpenCL state tracker.</flag>
 		<flag name="osmesa">Build the Mesa library for off-screen rendering.</flag>
+		<flag name="proprietary-codecs">Enable codecs for patent-encumbered audio and video formats.</flag>
 		<flag name="valgrind">Compile in valgrind memory hints</flag>
 		<flag name="vdpau">Enable the VDPAU acceleration interface for the Gallium3D Video Layer.</flag>
 		<flag name="vulkan">Enable Vulkan drivers</flag>


### PR DESCRIPTION
I'm not sure if 

`-Dvideo-codecs=$(usex proprietary-codecs "h264dec,h264enc,h265dec,h265enc,vc1dec" "")`

is the best way to do this, or if you'd prefer something more akin to the vulkan layers

Sending this in because I'm using it locally

Since https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/15258
patent encumbered codes have been disabled as default

Use the chromium flag proprietary-codecs to reenable them for those that
want them

Signed-off-by: Mike Lothian <mike@fireburn.co.uk>