### PR TITLE
media-video/pipewire: Drop alsa-plugins[pulseaudio] blocker

### DIFF
--- a/media-video/pipewire/files/99-pipewire-default-hook.conf
+++ b/media-video/pipewire/files/99-pipewire-default-hook.conf
@@ -1,0 +1,17 @@
+# Load pipewire configuration at conf hook processing time. This allows to
+# override pulseaudio defaults configuration which is also applied via hook.
+#
+# Note since hooks are run after /etc/asound.conf and ~/.asoundrc are applied,
+# we load these again here make sure that user configuration takes precedence.
+
+@hooks [
+	{
+		func load
+		files [
+			"/usr/share/alsa/alsa.conf.d/99-pipewire-default.conf"
+			"/etc/asound.conf"
+			"~/.asoundrc"
+		]
+		errors false
+	}
+]

--- a/media-video/pipewire/pipewire-0.3.51-r1.ebuild
+++ b/media-video/pipewire/pipewire-0.3.51-r1.ebuild
@@ -85,7 +85,6 @@ RDEPEND="
 	lv2? ( media-libs/lilv )
 	pipewire-alsa? (
 		>=media-libs/alsa-lib-1.1.7[${MULTILIB_USEDEP}]
-		!media-plugins/alsa-plugins[${MULTILIB_USEDEP},pulseaudio]
 	)
 	!pipewire-alsa? ( media-plugins/alsa-plugins[${MULTILIB_USEDEP},pulseaudio] )
 	ssl? ( dev-libs/openssl:= )
@@ -237,10 +236,15 @@ multilib_src_install_all() {
 
 	if use pipewire-alsa; then
 		dodir /etc/alsa/conf.d
+
+		# Install pipewire conf loader hook
+		insinto /usr/share/alsa/alsa.conf.d
+		doins "${FILESDIR}"/99-pipewire-default-hook.conf
+
 		# These will break if someone has /etc that is a symbolic link to a subfolder! See #724222
 		# And the current dosym8 -r implementation is likely affected by the same issue, too.
 		dosym ../../../usr/share/alsa/alsa.conf.d/50-pipewire.conf /etc/alsa/conf.d/50-pipewire.conf
-		dosym ../../../usr/share/alsa/alsa.conf.d/99-pipewire-default.conf /etc/alsa/conf.d/99-pipewire-default.conf
+		dosym ../../../usr/share/alsa/alsa.conf.d/99-pipewire-default-hook.conf /etc/alsa/conf.d/99-pipewire-default-hook.conf
 	fi
 
 	if ! use systemd; then


### PR DESCRIPTION
Currently `alsa-plugins[pulseaudio]` installs pulse plugin which is only enabled
in alsa lib configuration if plugin can access pulseaudio server in runtime.
This is implemented using a runtime conf hook in `51-pulseaudio-probe.conf`

Alsa lib runtime conf hooks are run after all static configuration is applied.
This causes a problem to coexistence of `pipewire-alsa` and `pulse` plugin:
- normally, `pipewire-pulse` is enabled which provides pulseaudio server
  connection to libpulse users
- since pulseaudio server is accessible, pulse conf hook will override alsa
  `pcm.!default` and `ctl.!default` to use pulse plugin.

To work around this, change `pipewire-alsa` plugin configuration from static conf
to conf hook which will run after pulse conf hook. To make sure user can still
override default device, make sure this new conf hook will also load
`/etc/asound.conf` and `~/.asoundrc` again like it is done by pulse conf hook.

Since pipewire plugin will take precedence now if `pipewire-alsa` is installed,
drop the blocker with `media-sound/alsa-plugins[pulseaudio]`

Closes: https://bugs.gentoo.org/799881
Closes: https://bugs.gentoo.org/791499
Signed-off-by: Igor V. Kovalenko <igor.v.kovalenko@gmail.com>