### PR TITLE
dev-libs/capstone: fix include paths and pkg-config file

### DIFF
--- a/dev-libs/capstone/capstone-5.0_rc2-r1.ebuild
+++ b/dev-libs/capstone/capstone-5.0_rc2-r1.ebuild
@@ -27,6 +27,10 @@ distutils_enable_tests setup.py
 
 S=${WORKDIR}/${P/_rc/-rc}
 
+PATCHES=(
+	"${FILESDIR}"/${P}-pkgconfig.patch
+)
+
 wrap_python() {
 	local phase=$1
 	shift

--- a/dev-libs/capstone/files/capstone-5.0_rc2-pkgconfig.patch
+++ b/dev-libs/capstone/files/capstone-5.0_rc2-pkgconfig.patch
@@ -1,0 +1,13 @@
+diff --git a/capstone.pc.in b/capstone.pc.in
+index 1b559eac..1ffcd354 100644
+--- a/capstone.pc.in
++++ b/capstone.pc.in
+@@ -5,7 +5,7 @@ includedir=${prefix}/include
+ 
+ Name: capstone
+ Description: Capstone disassembly engine
+-Version: @VERSION_MAJOR@.@VERSION_MINOR@.@VERSION_PATCH@
++Version: @PROJECT_VERSION_MAJOR@.@PROJECT_VERSION_MINOR@.@PROJECT_VERSION_PATCH@
+ URL: http://www.capstone-engine.org
+ archive=${libdir}/libcapstone.a
+ Libs: -L${libdir} -lcapstone

--- a/dev-util/radare2/radare2-5.6.8-r1.ebuild
+++ b/dev-util/radare2/radare2-5.6.8-r1.ebuild
@@ -37,7 +37,7 @@ RDEPEND="
 	dev-libs/xxhash
 	sys-apps/file
 	sys-libs/zlib
-	dev-libs/capstone:0=
+	<dev-libs/capstone-5:0=
 	ssl? ( dev-libs/openssl:0= )
 "
 DEPEND="

--- a/dev-util/rizin/rizin-0.3.4-r1.ebuild
+++ b/dev-util/rizin/rizin-0.3.4-r1.ebuild
@@ -1,0 +1,103 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+PYTHON_COMPAT=( python3_{8..10} )
+
+# This is the commit that the CI for the release commit used
+BINS_COMMIT="aa6a88dcdfaad54335e3935c16ce21a124ff861d"
+
+inherit meson python-any-r1
+
+DESCRIPTION="reverse engineering framework for binary analysis"
+HOMEPAGE="https://rizin.re/"
+
+SRC_URI="mirror+https://github.com/rizinorg/rizin/releases/download/v${PV}/rizin-src-v${PV}.tar.xz
+	test? ( https://github.com/rizinorg/rizin-testbins/archive/${BINS_COMMIT}.tar.gz -> rizin-testbins-${BINS_COMMIT}.tar.gz )"
+KEYWORDS="~amd64 ~arm64 ~x86"
+
+LICENSE="Apache-2.0 BSD LGPL-3 MIT"
+SLOT="0/${PV}"
+IUSE="test"
+
+# Need to audit licenses of the binaries used for testing
+RESTRICT="fetch !test? ( test )"
+
+RDEPEND="
+	sys-apps/file
+	app-arch/lz4:0=
+	<dev-libs/capstone-5:0=
+	dev-libs/libuv:0=
+	dev-libs/libzip:0=
+	dev-libs/openssl:0=
+	>=dev-libs/tree-sitter-0.19.0
+	dev-libs/xxhash
+	sys-libs/zlib:0=
+"
+DEPEND="${RDEPEND}"
+BDEPEND="${PYTHON_DEPS}"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-0.3.0-typedb-prefix.patch"
+	"${FILESDIR}/${PN}-0.3.2-never-rebuild-parser.patch"
+)
+
+S="${WORKDIR}/${PN}-v${PV}"
+
+src_prepare() {
+	default
+
+	local py_to_mangle=(
+		librz/core/cmd_descs/cmd_descs_generate.py
+		subprojects/lz4-1.9.3/contrib/meson/meson/GetLz4LibraryVersion.py
+		subprojects/lz4-1.9.3/contrib/meson/meson/InstallSymlink.py
+		subprojects/lz4-1.9.3/tests/test-lz4-list.py
+		subprojects/lz4-1.9.3/tests/test-lz4-speed.py
+		subprojects/lz4-1.9.3/tests/test-lz4-versions.py
+		sys/clang-format.py
+		test/fuzz/scripts/fuzz_rz_asm.py
+		test/scripts/gdbserver.py
+	)
+
+	python_fix_shebang "${py_to_mangle[@]}"
+
+	if use test; then
+		cp -r "${WORKDIR}/rizin-testbins-${BINS_COMMIT}" "${S}/test/bins" || die
+		cp -r "${WORKDIR}/rizin-testbins-${BINS_COMMIT}" "${S}" || die
+	fi
+}
+
+src_configure() {
+	local emesonargs=(
+		-Dcli=enabled
+		-Duse_sys_capstone=enabled
+		-Duse_sys_magic=enabled
+		-Duse_sys_libzip=enabled
+		-Duse_sys_zlib=enabled
+		-Duse_sys_lz4=enabled
+		-Duse_sys_xxhash=enabled
+		-Duse_sys_openssl=enabled
+		-Duse_sys_tree_sitter=enabled
+
+		$(meson_use test enable_tests)
+		$(meson_use test enable_rz_test)
+	)
+	meson_src_configure
+}
+
+src_test() {
+	# Rizin uses data files that it expects to be installed on the
+	# system. To hack around this, we create a tree of what it expects
+	# in ${T}, and patch the tests to support a prefix from the
+	# environment. https://github.com/rizinorg/rizin/issues/1789
+	mkdir -p "${T}/usr/share/${PN}/${PV}" || die
+	ln -sf "${BUILD_DIR}/librz/analysis/d" "${T}/usr/share/${PN}/${PV}/types" || die
+	ln -sf "${BUILD_DIR}/librz/syscall/d" "${T}/usr/share/${PN}/${PV}/syscall" || die
+	ln -sf "${BUILD_DIR}/librz/asm/d" "${T}/usr/share/${PN}/${PV}/opcodes" || die
+	# https://github.com/rizinorg/rizin/issues/1797
+	ln -sf "${BUILD_DIR}/librz/flag/d" "${T}/usr/share/${PN}/${PV}/flag" || die
+	export RZ_PREFIX="${T}/usr"
+
+	meson_src_test
+}

--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -105,12 +105,6 @@ sys-apps/xdg-desktop-portal-gnome
 # Masked for testing. Apparently causes crashes. Bug #841857.
 >=x11-libs/libX11-1.8
 
-# John Helmert III <ajak@gentoo.org> (2022-04-29)
-# New capstone rc installs broken pkgconfig and cmake build
-# configuration files, breaking reverse dependencies. #841716
-=dev-libs/capstone-5.0_rc2
-=dev-util/ROPgadget-6.7
-
 # Joonas Niilola <juippis@gentoo.org> (2022-04-29)
 # Apparently the "b" in version means "beta". 3.24 is available, we
 # should update to that. #841437


### PR DESCRIPTION
This PR restricts rev-deps of `dev-libs/capstone` to Capstone 4 if they don't build against newer versions of Capstone. Reason for the build failure are include directory changes (see https://github.com/capstone-engine/capstone/issues/1807)

Furthermore it fixes the missing version specification in the `pkg-config` file.