### PR TITLE
media-plugins/alsa-plugins: Clean up unnecessary sed

### DIFF
--- a/media-plugins/alsa-plugins/alsa-plugins-1.2.2.ebuild
+++ b/media-plugins/alsa-plugins/alsa-plugins-1.2.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -78,11 +78,6 @@ multilib_src_install_all() {
 		doins "${FILESDIR}"/pulse-default.conf
 		insinto /usr/share/alsa/alsa.conf.d
 		doins "${FILESDIR}"/51-pulseaudio-probe.conf
-		# bug #410261, comment 5+
-		# seems to work fine without any path
-		sed \
-			-e "s:/usr/lib/alsa-lib/::" \
-			-i "${ED}"/usr/share/alsa/alsa.conf.d/51-pulseaudio-probe.conf || die #410261
 		dosym ../../../usr/share/alsa/alsa.conf.d/51-pulseaudio-probe.conf \
 			/etc/alsa/conf.d/51-pulseaudio-probe.conf #670960
 	fi

--- a/media-plugins/alsa-plugins/alsa-plugins-1.2.5.ebuild
+++ b/media-plugins/alsa-plugins/alsa-plugins-1.2.5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -78,11 +78,6 @@ multilib_src_install_all() {
 		doins "${FILESDIR}"/pulse-default.conf
 		insinto /usr/share/alsa/alsa.conf.d
 		doins "${FILESDIR}"/51-pulseaudio-probe.conf
-		# bug #410261, comment 5+
-		# seems to work fine without any path
-		sed \
-			-e "s:/usr/lib/alsa-lib/::" \
-			-i "${ED}"/usr/share/alsa/alsa.conf.d/51-pulseaudio-probe.conf || die #410261
 		dosym ../../../usr/share/alsa/alsa.conf.d/51-pulseaudio-probe.conf \
 			/etc/alsa/conf.d/51-pulseaudio-probe.conf #670960
 	fi

--- a/media-plugins/alsa-plugins/alsa-plugins-1.2.6.ebuild
+++ b/media-plugins/alsa-plugins/alsa-plugins-1.2.6.ebuild
@@ -78,11 +78,6 @@ multilib_src_install_all() {
 		doins "${FILESDIR}"/pulse-default.conf
 		insinto /usr/share/alsa/alsa.conf.d
 		doins "${FILESDIR}"/51-pulseaudio-probe.conf
-		# bug #410261, comment 5+
-		# seems to work fine without any path
-		sed \
-			-e "s:/usr/lib/alsa-lib/::" \
-			-i "${ED}"/usr/share/alsa/alsa.conf.d/51-pulseaudio-probe.conf || die #410261
 		dosym ../../../usr/share/alsa/alsa.conf.d/51-pulseaudio-probe.conf \
 			/etc/alsa/conf.d/51-pulseaudio-probe.conf #670960
 	fi

--- a/media-plugins/alsa-plugins/files/51-pulseaudio-probe.conf
+++ b/media-plugins/alsa-plugins/files/51-pulseaudio-probe.conf
@@ -2,7 +2,7 @@
 # default output for applications using alsa when pulseaudio is running.
 
 hook_func.pulse_load_if_running {
-	lib "/usr/lib/alsa-lib/libasound_module_conf_pulse.so"
+	lib "libasound_module_conf_pulse.so"
 	func "conf_pulse_hook_load_if_running"
 }
 


### PR DESCRIPTION
Drop remaining sed from #410261 and change installed conf file instead.

Bug: https://bugs.gentoo.org/410261
Signed-off-by: Igor V. Kovalenko <igor.v.kovalenko@gmail.com>