### PR TITLE
eclass: Add support for dev-util/samurai

### DIFF
--- a/eclass/cmake.eclass
+++ b/eclass/cmake.eclass
@@ -136,7 +136,7 @@ case ${CMAKE_MAKEFILE_GENERATOR} in
 		BDEPEND="sys-devel/make"
 		;;
 	ninja)
-		BDEPEND="dev-util/ninja"
+		BDEPEND="${NINJA_DEPEND}"
 		;;
 	*)
 		eerror "Unknown value for \${CMAKE_MAKEFILE_GENERATOR}"
@@ -361,13 +361,6 @@ cmake_src_prepare() {
 		eerror "\"${CMAKE_USE_DIR}/CMakeLists.txt\""
 		eerror "Consider not inheriting the cmake eclass."
 		die "FATAL: Unable to find CMakeLists.txt"
-	fi
-
-	# if ninja is enabled but not installed, the build could fail
-	# this could happen if ninja is manually enabled (eg. make.conf) but not installed
-	if [[ ${CMAKE_MAKEFILE_GENERATOR} == ninja ]] && ! has_version -b dev-util/ninja; then
-		eerror "CMAKE_MAKEFILE_GENERATOR is set to ninja, but ninja is not installed."
-		die "Please install dev-util/ninja or unset CMAKE_MAKEFILE_GENERATOR."
 	fi
 
 	local modules_list
@@ -705,11 +698,7 @@ cmake_src_test() {
 cmake_src_install() {
 	debug-print-function ${FUNCNAME} "$@"
 
-	_cmake_check_build_dir
-	pushd "${BUILD_DIR}" > /dev/null || die
-	DESTDIR="${D}" ${CMAKE_MAKEFILE_GENERATOR} install "$@" ||
-		die "died running ${CMAKE_MAKEFILE_GENERATOR} install"
-	popd > /dev/null || die
+	DESTDIR="${D}" cmake_build install "$@"
 
 	if [[ ${EAPI} == 7 ]]; then
 		pushd "${S}" > /dev/null || die

--- a/sys-devel/clang/clang-12.0.1.ebuild
+++ b/sys-devel/clang/clang-12.0.1.ebuild
@@ -130,7 +130,7 @@ check_distribution_components() {
 
 				all_targets+=( "${l}" )
 			fi
-		done < <(ninja -t targets all)
+		done < <(${NINJA} -t targets all)
 
 		while read -r l; do
 			my_targets+=( "${l}" )

--- a/sys-devel/clang/clang-13.0.1.ebuild
+++ b/sys-devel/clang/clang-13.0.1.ebuild
@@ -118,7 +118,7 @@ check_distribution_components() {
 
 				all_targets+=( "${l}" )
 			fi
-		done < <(ninja -t targets all)
+		done < <(${NINJA} -t targets all)
 
 		while read -r l; do
 			my_targets+=( "${l}" )

--- a/sys-devel/clang/clang-14.0.1-r1.ebuild
+++ b/sys-devel/clang/clang-14.0.1-r1.ebuild
@@ -120,7 +120,7 @@ check_distribution_components() {
 
 				all_targets+=( "${l}" )
 			fi
-		done < <(ninja -t targets all)
+		done < <(${NINJA} -t targets all)
 
 		while read -r l; do
 			my_targets+=( "${l}" )

--- a/sys-devel/clang/clang-14.0.3.ebuild
+++ b/sys-devel/clang/clang-14.0.3.ebuild
@@ -127,7 +127,7 @@ check_distribution_components() {
 
 				all_targets+=( "${l}" )
 			fi
-		done < <(ninja -t targets all)
+		done < <(${NINJA} -t targets all)
 
 		while read -r l; do
 			my_targets+=( "${l}" )

--- a/sys-devel/clang/clang-14.0.4.ebuild
+++ b/sys-devel/clang/clang-14.0.4.ebuild
@@ -127,7 +127,7 @@ check_distribution_components() {
 
 				all_targets+=( "${l}" )
 			fi
-		done < <(ninja -t targets all)
+		done < <(${NINJA} -t targets all)
 
 		while read -r l; do
 			my_targets+=( "${l}" )

--- a/sys-devel/clang/clang-14.0.5.ebuild
+++ b/sys-devel/clang/clang-14.0.5.ebuild
@@ -127,7 +127,7 @@ check_distribution_components() {
 
 				all_targets+=( "${l}" )
 			fi
-		done < <(ninja -t targets all)
+		done < <(${NINJA} -t targets all)
 
 		while read -r l; do
 			my_targets+=( "${l}" )

--- a/sys-devel/clang/clang-15.0.0.9999.ebuild
+++ b/sys-devel/clang/clang-15.0.0.9999.ebuild
@@ -127,7 +127,7 @@ check_distribution_components() {
 
 				all_targets+=( "${l}" )
 			fi
-		done < <(ninja -t targets all)
+		done < <(${NINJA} -t targets all)
 
 		while read -r l; do
 			my_targets+=( "${l}" )

--- a/sys-devel/llvm/llvm-12.0.1.ebuild
+++ b/sys-devel/llvm/llvm-12.0.1.ebuild
@@ -141,7 +141,7 @@ check_distribution_components() {
 
 				all_targets+=( "${l}" )
 			fi
-		done < <(ninja -t targets all)
+		done < <(${NINJA} -t targets all)
 
 		while read -r l; do
 			my_targets+=( "${l}" )

--- a/sys-devel/llvm/llvm-13.0.1.ebuild
+++ b/sys-devel/llvm/llvm-13.0.1.ebuild
@@ -134,7 +134,7 @@ check_distribution_components() {
 
 				all_targets+=( "${l}" )
 			fi
-		done < <(ninja -t targets all)
+		done < <(${NINJA} -t targets all)
 
 		while read -r l; do
 			my_targets+=( "${l}" )

--- a/sys-devel/llvm/llvm-14.0.1.ebuild
+++ b/sys-devel/llvm/llvm-14.0.1.ebuild
@@ -131,7 +131,7 @@ check_distribution_components() {
 
 				all_targets+=( "${l}" )
 			fi
-		done < <(ninja -t targets all)
+		done < <(${NINJA} -t targets all)
 
 		while read -r l; do
 			my_targets+=( "${l}" )

--- a/sys-devel/llvm/llvm-14.0.3.ebuild
+++ b/sys-devel/llvm/llvm-14.0.3.ebuild
@@ -142,7 +142,7 @@ check_distribution_components() {
 
 				all_targets+=( "${l}" )
 			fi
-		done < <(ninja -t targets all)
+		done < <(${NINJA} -t targets all)
 
 		while read -r l; do
 			my_targets+=( "${l}" )

--- a/sys-devel/llvm/llvm-14.0.4.ebuild
+++ b/sys-devel/llvm/llvm-14.0.4.ebuild
@@ -142,7 +142,7 @@ check_distribution_components() {
 
 				all_targets+=( "${l}" )
 			fi
-		done < <(ninja -t targets all)
+		done < <(${NINJA} -t targets all)
 
 		while read -r l; do
 			my_targets+=( "${l}" )

--- a/sys-devel/llvm/llvm-14.0.5.ebuild
+++ b/sys-devel/llvm/llvm-14.0.5.ebuild
@@ -142,7 +142,7 @@ check_distribution_components() {
 
 				all_targets+=( "${l}" )
 			fi
-		done < <(ninja -t targets all)
+		done < <(${NINJA} -t targets all)
 
 		while read -r l; do
 			my_targets+=( "${l}" )

--- a/sys-devel/llvm/llvm-15.0.0.9999.ebuild
+++ b/sys-devel/llvm/llvm-15.0.0.9999.ebuild
@@ -139,7 +139,7 @@ check_distribution_components() {
 
 				all_targets+=( "${l}" )
 			fi
-		done < <(ninja -t targets all)
+		done < <(${NINJA} -t targets all)
 
 		while read -r l; do
 			my_targets+=( "${l}" )


### PR DESCRIPTION
This adds support for using `dev-util/samurai` instead of `dev-util/ninja` which works almost everywhere except for a few cases that need not yet implemented features (i.e. https://github.com/michaelforney/samurai/issues/36).

This can be controlled by the user setting `NINJA=ninja` (Default) or `NINJA=samu` in their environment and can be forced in an ebuild by setting the variable before inheriting any eclasses.

There are three cases which should work:

* both samurai and ninja are installed and the user might use either
* only samurai is installed
* only ninja is installed

The last two commits get rid of hardcoded instances of `ninja` in `sys-devel/llvm` and `sys-devel/clang`.