### PR TITLE
media-libs/libilbc: Keyword 3.0.4 ia64, #610546

### DIFF
--- a/media-libs/libilbc/files/libilbc-3.0.4-support-ia64.patch
+++ b/media-libs/libilbc/files/libilbc-3.0.4-support-ia64.patch
@@ -1,0 +1,32 @@
+From b9d5baa0c7daca577b5c846504bc6f5f71087582 Mon Sep 17 00:00:00 2001
+From: matoro <matoro@users.noreply.github.com>
+Date: Mon, 2 May 2022 14:02:37 -0400
+Subject: [PATCH] add platform definition for IA64
+
+How I tested:
+    * built ffmpeg with libilbc enabled
+    * obtained a sample file from
+      https://web.archive.org/web/2016*/http://www.andrews-corner.org/samples/luckynight.lbc
+    * converted it to wav using ffmpeg on ia64 host
+    * compared to file converted on amd64 host
+    * did the same in reverse (converted wav to lbc)
+
+All comparisons were identical and sounded the same.
+---
+ rtc_base/system/arch.h | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/rtc_base/system/arch.h b/rtc_base/system/arch.h
+index be2367b85f..e00150b65f 100644
+--- a/rtc_base/system/arch.h
++++ b/rtc_base/system/arch.h
+@@ -79,6 +79,9 @@
+ #elif defined(__EMSCRIPTEN__)
+ #define WEBRTC_ARCH_32_BITS
+ #define WEBRTC_ARCH_LITTLE_ENDIAN
++#elif defined(_M_IA64) || defined(__ia64__) || defined(__ia64)
++#define WEBRTC_ARCH_64_BITS
++#define WEBRTC_ARCH_LITTLE_ENDIAN
+ #else
+ #error Please add support for your architecture in rtc_base/system/arch.h
+ #endif

--- a/media-libs/libilbc/libilbc-3.0.4.ebuild
+++ b/media-libs/libilbc/libilbc-3.0.4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ if [[ ${PV} == *9999 ]]; then
 	EGIT_REPO_URI="https://github.com/TimothyGu/${PN}"
 else
 	SRC_URI="https://github.com/TimothyGu/${PN}/releases/download/v${PV}/${P}.tar.gz"
-	KEYWORDS="amd64 arm arm64 ppc ppc64 ~riscv ~sparc x86"
+	KEYWORDS="amd64 arm arm64 ~ia64 ppc ppc64 ~riscv ~sparc x86"
 fi
 
 DESCRIPTION="Packaged version of iLBC codec from the WebRTC project"
@@ -22,4 +22,5 @@ SLOT="0/3"
 
 PATCHES=(
 	"${FILESDIR}/${PN}-3.0.4-respect-CFLAGS.patch"
+	"${FILESDIR}/${P}-support-ia64.patch"
 )

--- a/media-libs/libilbc/libilbc-9999.ebuild
+++ b/media-libs/libilbc/libilbc-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ if [[ ${PV} == *9999 ]]; then
 	EGIT_REPO_URI="https://github.com/TimothyGu/${PN}"
 else
 	SRC_URI="https://github.com/TimothyGu/${PN}/releases/download/v${PV}/${P}.tar.gz"
-	KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~sparc ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~ia64 ~ppc ~ppc64 ~sparc ~x86"
 fi
 
 DESCRIPTION="Packaged version of iLBC codec from the WebRTC project"
@@ -22,4 +22,5 @@ SLOT="0/3"
 
 PATCHES=(
 	"${FILESDIR}/${PN}-3.0.4-respect-CFLAGS.patch"
+	"${FILESDIR}/${P}-support-ia64.patch"
 )


### PR DESCRIPTION
How I tested:
    * built ffmpeg with libilbc enabled
    * obtained a sample file from
      https://web.archive.org/web/2016*/http://www.andrews-corner.org/samples/luckynight.lbc
    * converted it to wav using ffmpeg on ia64 host
    * compared to file converted on amd64 host
    * did the same in reverse (converted wav to lbc)