### PR TITLE
profiles/arch/powerpc/ppc64: drop jdk/jre mask

### DIFF
--- a/profiles/arch/powerpc/ppc64/package.mask
+++ b/profiles/arch/powerpc/ppc64/package.mask
@@ -1,20 +1,9 @@
 # Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-# Florian Schmaus <flow@gentoo.org (2022-05-03)
-# >=dev-java/stax2-api-4.2.1-r1 depends on masked >=virtual/{jdk,jre}-11
->=dev-java/stax2-api-4.2.1-r1
-
 # Sam James <sam@gentoo.org> (2022-01-18)
 # No bootstrap binary available on big endian PPC64 right now
 dev-lisp/sbcl
-
-# Miroslav Šulc <fordfrog@gentoo.org> (2020-02-27)
-# >=dev-java/ant-eclipse-ecj-4.10 depends on masked >=virtual/{jdk,jre}-11
-# www-servers/tomcat >= 9 depends on masked dev-java/eclipse-ecj
->=dev-java/ant-eclipse-ecj-4.10
->=dev-java/eclipse-ecj-4.10
->=www-servers/tomcat-9
 
 # Sam James <sam@gentoo.org> (2021-10-16)
 # Mask for media-libs/openexr and its reverse dependencies.

--- a/profiles/arch/powerpc/ppc64/package.mask
+++ b/profiles/arch/powerpc/ppc64/package.mask
@@ -16,11 +16,6 @@ dev-lisp/sbcl
 >=dev-java/eclipse-ecj-4.10
 >=www-servers/tomcat-9
 
-# Sam James <sam@gentoo.org> (2022-01-09)
-# No provider (e.g. OpenJDK) available on big endian PPC64 right now
-virtual/jdk:11
-virtual/jre:11
-
 # Sam James <sam@gentoo.org> (2021-10-16)
 # Mask for media-libs/openexr and its reverse dependencies.
 # Broken on big endian.


### PR DESCRIPTION
Due to the work of arthurzam, we now have working JDKs and JREs for
PPC64.

Signed-off-by: Florian Schmaus <flow@gentoo.org>