### PR TITLE
sci-libs/rocSPARSE: fix data prepare under EAPI8

### DIFF
--- a/sci-libs/rocSPARSE/files/rocSPARSE-5.0.2-remove-incorrect-assert.patch
+++ b/sci-libs/rocSPARSE/files/rocSPARSE-5.0.2-remove-incorrect-assert.patch
@@ -1,0 +1,34 @@
+From 48b763f01b658dece7f71784fe4362e56167db2f Mon Sep 17 00:00:00 2001
+From: James Sandham <33790278+jsandham@users.noreply.github.com>
+Date: Fri, 28 Jan 2022 10:24:08 -0800
+Subject: [PATCH] remove incorrect assert from spmm_bell (#302)
+
+Co-authored-by: jsandham <james.sandham@amd.com>
+---
+ library/src/level3/rocsparse_bellmm_template_general.cpp | 7 +++----
+ 1 file changed, 3 insertions(+), 4 deletions(-)
+
+diff --git a/library/src/level3/rocsparse_bellmm_template_general.cpp b/library/src/level3/rocsparse_bellmm_template_general.cpp
+index 81f36a32..bbce9a17 100644
+--- a/library/src/level3/rocsparse_bellmm_template_general.cpp
++++ b/library/src/level3/rocsparse_bellmm_template_general.cpp
+@@ -1,6 +1,6 @@
+ /*! \file */
+ /* ************************************************************************
+- * Copyright (c) 2021 Advanced Micro Devices, Inc.
++ * Copyright (c) 2021-2022 Advanced Micro Devices, Inc.
+  *
+  * Permission is hereby granted, free of charge, to any person obtaining a copy
+  * of this software and associated documentation files (the "Software"), to deal
+@@ -101,9 +101,8 @@ rocsparse_status rocsparse_bellmm_template_general(rocsparse_handle          han
+                                                    I                         ldc)
+ {
+     hipStream_t stream = handle->stream;
+-    assert(block_dim > 32);
+-    dim3 bellmm_blocks((mb - 1) / 1 + 1, (n - 1) / 32 + 1);
+-    dim3 bellmm_threads(32, 32, 1);
++    dim3        bellmm_blocks((mb - 1) / 1 + 1, (n - 1) / 32 + 1);
++    dim3        bellmm_threads(32, 32, 1);
+     assert(trans_A == rocsparse_operation_none);
+     //
+     // What happends if A needs to be transposed?

--- a/sci-libs/rocSPARSE/rocSPARSE-5.0.2.ebuild
+++ b/sci-libs/rocSPARSE/rocSPARSE-5.0.2.ebuild
@@ -81,6 +81,8 @@ src_prepare() {
 	# use python interpreter specifyied by python-any-r1
 	sed -e "/COMMAND ..\/common\/rocsparse_gentest.py/s,COMMAND ,COMMAND ${EPYTHON} ," -i clients/tests/CMakeLists.txt || die
 
+	cmake_src_prepare
+
 	# Test need download data from https://sparse.tamu.edu (or other mirror site), check MD5, unpack and convert them into csr format
 	# This process is handled default by ${S}/cmake/ClientMatrices.cmake, but should be the responsibility of portage.
 	if use test; then
@@ -97,8 +99,6 @@ src_prepare() {
 				eend $?
 			done
 	fi
-
-	cmake_src_prepare
 }
 
 src_configure() {
@@ -125,7 +125,7 @@ src_test() {
 	addwrite /dev/kfd
 	addwrite /dev/dri/
 	cd "${BUILD_DIR}/clients/staging" || die
-	./rocsparse-test || die
+	LD_LIBRARY_PATH="${BUILD_DIR}/library" ./rocsparse-test || die
 }
 
 src_install() {

--- a/sci-libs/rocSPARSE/rocSPARSE-5.0.2.ebuild
+++ b/sci-libs/rocSPARSE/rocSPARSE-5.0.2.ebuild
@@ -59,7 +59,8 @@ RESTRICT="!test? ( test )"
 S="${WORKDIR}/rocSPARSE-rocm-${PV}"
 
 PATCHES=( "${FILESDIR}/${PN}-5.0.2-remove-matrices-unpacking.patch"
-	"${FILESDIR}/${PN}-5.0.2-enable-gfx1031.patch" )
+	"${FILESDIR}/${PN}-5.0.2-enable-gfx1031.patch"
+	"${FILESDIR}/${PN}-5.0.2-remove-incorrect-assert.patch" )
 
 python_check_deps() {
 	if use test; then


### PR DESCRIPTION
In EAPI=7 BUILD_DIR is set throghout src_prepare, while in
EAPI=8 BUILD_DIR is set after cmake_src_prepare. So run
cmake_src_prepare before converting test data.

Package-Manager: Portage-3.0.30, Repoman-3.0.3
Signed-off-by: Yiyang Wu <xgreenlandforwyy@gmail.com>