### PR TITLE
media-sound/mumble: Added missing USE dependencies for poco

### DIFF
--- a/media-sound/mumble/mumble-1.4.230.ebuild
+++ b/media-sound/mumble/mumble-1.4.230.ebuild
@@ -32,7 +32,7 @@ RESTRICT="!test? ( test )"
 
 RDEPEND="
 	>=dev-libs/openssl-1.0.0b:0=
-	dev-libs/poco
+	dev-libs/poco[util,xml,zip]
 	>=dev-libs/protobuf-2.2.0:=
 	dev-qt/qtcore:5
 	dev-qt/qtgui:5

--- a/media-sound/mumble/mumble-9999.ebuild
+++ b/media-sound/mumble/mumble-9999.ebuild
@@ -30,7 +30,7 @@ RESTRICT="!test? ( test )"
 
 RDEPEND="
 	>=dev-libs/openssl-1.0.0b:0=
-	dev-libs/poco
+	dev-libs/poco[util,xml,zip]
 	>=dev-libs/protobuf-2.2.0:=
 	dev-qt/qtcore:5
 	dev-qt/qtgui:5


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/842576
Signed-off-by: Jaak Ristioja <jaak@ristioja.ee>