### PR TITLE
net-p2p/go-ipfs: fix build error

### DIFF
--- a/net-p2p/go-ipfs/go-ipfs-0.12.2.ebuild
+++ b/net-p2p/go-ipfs/go-ipfs-0.12.2.ebuild
@@ -41,7 +41,7 @@ src_compile() {
 	go build "${mygoargs[@]}" -o ipfs ./cmd/ipfs || die
 	go build "${mygoargs[@]}" -o ipfswatch ./cmd/ipfswatch || die
 
-	./ipfs commands completion bash > ipfs-completion.bash || die
+	IPFS_PATH="" ./ipfs commands completion bash > ipfs-completion.bash || die
 }
 
 src_test() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/841988
Package-Manager: Portage-3.0.30, Repoman-3.0.3
Signed-off-by: David Roman <davidroman96@gmail.com>