### PR TITLE
sys-libs/libxcrypt: fix cross + system dependencies

### DIFF
--- a/sys-libs/libxcrypt/libxcrypt-4.4.28.ebuild
+++ b/sys-libs/libxcrypt/libxcrypt-4.4.28.ebuild
@@ -39,10 +39,10 @@ is_cross() {
 
 DEPEND="system? (
 		elibc_glibc? (
-			sys-libs/glibc[-crypt(+)]
-			!sys-libs/glibc[crypt(+)]
+			${CATEGORY}/glibc[-crypt(+)]
+			!${CATEGORY}/glibc[crypt(+)]
 		)
-		!sys-libs/musl
+		!${CATEGORY}/musl
 	)
 "
 RDEPEND="${DEPEND}"


### PR DESCRIPTION
Starting with the v4.4.28 ebuild, libxcrypt supports cross-* builds
so we need to ensure the dependencies are properly specified, for
eg: aarch64-cros-linux-gnu/libxcrypt needs to depend on the
aarch64-cros-linux-gnu/glibc instead of plain sys-libs/glibc.

Bug: https://bugs.gentoo.org/842906
Signed-off-by: Adrian Ratiu <adrian.ratiu@collabora.com>