### PR TITLE
net-proxy/dante: Fix build with slibtool

### DIFF
--- a/net-proxy/dante/dante-1.4.1-r6.ebuild
+++ b/net-proxy/dante/dante-1.4.1-r6.ebuild
@@ -48,6 +48,9 @@ PATCHES=(
 src_prepare() {
 	default
 
+	# 780039
+	sed -e 's/-all-dynamic//' -i dlib/Makefile.am dlib64/Makefile.am || die
+
 	sed \
 		-e 's:/etc/socks\.conf:"${EPREFIX}"/etc/socks/socks.conf:' \
 		-e 's:/etc/sockd\.conf:"${EPREFIX}"/etc/socks/sockd.conf:' \


### PR DESCRIPTION
Removing `-all-dynamic` is the easiest choice as nothing seems to actually provide that argument. GNU libtool of course will ignore the issue.

Bug: https://bugs.gentoo.org/780039