### PR TITLE
app-benchmarks/ramspeed: Fix build with slibtool

### DIFF
--- a/app-benchmarks/ramspeed/ramspeed-3.5.0-r2.ebuild
+++ b/app-benchmarks/ramspeed/ramspeed-3.5.0-r2.ebuild
@@ -31,7 +31,7 @@ src_configure() {
 	append-ldflags -Wl,-z,noexecstack
 	obj=( ramsmp.o ${arch_prefix}{fltmark,fltmem,intmark,intmem}.o )
 
-	use pic && append-ldflags -nopie
+	use pic && append-ldflags -no-pie
 
 	if use amd64; then
 		sed -i \


### PR DESCRIPTION
It should be `-no-pie` and not `-nopie`, GNU libtool silently hides the typo.

Bug: https://bugs.gentoo.org/798735