### PR TITLE
net-dialup/freeradius: Fix typo in ebuild

### DIFF
--- a/net-dialup/freeradius/freeradius-3.0.25-r2.ebuild
+++ b/net-dialup/freeradius/freeradius-3.0.25-r2.ebuild
@@ -129,15 +129,15 @@ src_prepare() {
 		raddb/radiusd.conf.in || die
 
 	# verbosity
-	# build shared libraries using jlibtool --shared
+	# build shared libraries using jlibtool -shared
 	sed -i \
 		-e '/$(LIBTOOL)/s|--quiet ||g' \
-		-e 's:--mode=\(compile\|link\):& --shared:g' \
+		-e 's:--mode=\(compile\|link\):& -shared:g' \
 		Make.inc.in || die
 
 	sed -i \
 		-e 's|--silent ||g' \
-		-e 's:--mode=\(compile\|link\):& --shared:g' \
+		-e 's:--mode=\(compile\|link\):& -shared:g' \
 		scripts/libtool.mk || die
 
 	# crude measure to stop jlibtool from running ranlib and ar


### PR DESCRIPTION
It should be -shared and not --shared and this typo causes the build to fail with slibtool.

Additionally it needs `slibtool-shared` and not `rlibtool`.

Bug: https://bugs.gentoo.org/786102