### PR TITLE
dev-libs/spdlog: fix clone async test

### DIFF
--- a/dev-libs/spdlog/files/spdlog-1.9.2-fix-clone-test.patch
+++ b/dev-libs/spdlog/files/spdlog-1.9.2-fix-clone-test.patch
@@ -1,0 +1,13 @@
+See https://bugs.gentoo.org/840764
+
+--- a/tests/test_misc.cpp
++++ b/tests/test_misc.cpp
+@@ -131,7 +131,7 @@ TEST_CASE("clone async", "[clone]")
+     logger->info("Some message 1");
+     cloned->info("Some message 2");
+ 
+-    spdlog::details::os::sleep_for_millis(10);
++    spdlog::details::os::sleep_for_millis(100);
+ 
+     REQUIRE(test_sink->lines().size() == 2);
+     REQUIRE(test_sink->lines()[0] == "Some message 1");

--- a/dev-libs/spdlog/spdlog-1.9.2-r1.ebuild
+++ b/dev-libs/spdlog/spdlog-1.9.2-r1.ebuild
@@ -31,7 +31,10 @@ DEPEND="
 "
 RDEPEND="${DEPEND}"
 
-PATCHES=( "${FILESDIR}/${PN}-force_external_fmt.patch" )
+PATCHES=(
+	"${FILESDIR}/${PN}-force_external_fmt.patch"
+	"${FILESDIR}/${P}-fix-clone-test.patch"
+)
 
 src_prepare() {
 	use test && eapply "${WORKDIR}"/${P}-update-catch-glibc-2.34.patch


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/840764
Package-Manager: Portage-3.0.30, Repoman-3.0.3
Signed-off-by: David Roman <davidroman96@gmail.com>