### PR TITLE
dev-java/rxtx: keyword 2.2_pre2-r2 for ~ppc64

### DIFF
--- a/dev-java/rxtx/files/rxtx-2.1-7r2-ppcioh.diff
+++ b/dev-java/rxtx/files/rxtx-2.1-7r2-ppcioh.diff
@@ -1,0 +1,16 @@
+diff --git a/src/RawImp.c b/src/RawImp.c
+index 077f30e..813fcf9 100644
+--- a/src/RawImp.c
++++ b/src/RawImp.c
+@@ -99,10 +99,8 @@
+ #	include <linux/serial.h>
+ #	include <linux/version.h>
+ #endif
+-#ifndef __APPLE__  /* dima */
+-#ifndef PPC
++#if !defined(__APPLE__) && !defined(PPC) && !defined(__powerpc__) && !defined(__powerpc64__)  /* dima */
+ #include <sys/io.h>
+-#endif /* PPC */
+ #endif /* dima */
+ 
+ extern int errno;

--- a/dev-java/rxtx/files/rxtx-2.1-7r2-ttyPZ.diff
+++ b/dev-java/rxtx/files/rxtx-2.1-7r2-ttyPZ.diff
@@ -1,0 +1,20 @@
+diff --git a/src/gnu/io/RXTXCommDriver.java b/src/gnu/io/RXTXCommDriver.java
+index 3dce198..954b102 100644
+--- a/src/gnu/io/RXTXCommDriver.java
++++ b/src/gnu/io/RXTXCommDriver.java
+@@ -576,6 +576,7 @@ public class RXTXCommDriver implements CommDriver
+ 						String[] Temp = {
+ 						"ttyS", // linux Serial Ports
+ 						"ttySA", // for the IPAQs
++						"ttyPZ", // for G4/G5 RackMac
+ 						"ttyUSB", // for USB frobs
+ 						"rfcomm",       // bluetooth serial device
+ 						"ttyircomm", // linux IrCommdevices (IrDA serial emu)
+@@ -608,6 +609,7 @@ public class RXTXCommDriver implements CommDriver
+ 							// linux ISI serial card
+ 						"ttyMX",// linux Moxa Smart IO cards
+ 						"ttyP", // linux Hayes ESP serial card
++						"ttyPZ", // linux PPC/PPC64 Zilog serial ports
+ 						"ttyR", // linux comtrol cards
+ 							// linux Specialix RIO serial card
+ 						"ttyS", // linux Serial Ports

--- a/dev-java/rxtx/rxtx-2.2_pre2-r2.ebuild
+++ b/dev-java/rxtx/rxtx-2.2_pre2-r2.ebuild
@@ -17,7 +17,7 @@ HOMEPAGE="http://rxtx.qbang.org/"
 SRC_URI="ftp://ftp.qbang.org/pub/rxtx/${MY_P}.zip"
 LICENSE="LGPL-2.1+"
 SLOT="2"
-KEYWORDS="amd64 x86"
+KEYWORDS="amd64 ~ppc64 x86"
 IUSE="lfd"
 
 RDEPEND=">=virtual/jre-1.8:*
@@ -39,6 +39,8 @@ src_prepare() {
 
 	eapply -p0 "${FILESDIR}/${PN}-2.1-7r2-lfd.diff"
 	eapply -p0 "${FILESDIR}/${PN}-2.1-7r2-nouts.diff"
+	eapply "${FILESDIR}/${PN}-2.1-7r2-ppcioh.diff"
+	eapply "${FILESDIR}/${PN}-2.1-7r2-ttyPZ.diff"
 	eapply -p0 "${FILESDIR}/${P}-limits.patch"
 	eapply "${FILESDIR}/${P}-add-ttyACM.patch"
 	eapply "${FILESDIR}/${P}-format-security.patch"


### PR DESCRIPTION
This not only builds but works on ppc64.  I tested this on my system with serial ports in use using the below program:

```
$ cat Main.java
import gnu.io.*;
import java.util.*;

public class Main {
    /**
     * @return    A HashSet containing the CommPortIdentifier for all serial ports that are not currently being used.
     */
    public static HashSet<CommPortIdentifier> getAvailableSerialPorts() {
        HashSet<CommPortIdentifier> h = new HashSet<CommPortIdentifier>();
        Enumeration thePorts = CommPortIdentifier.getPortIdentifiers();
        while (thePorts.hasMoreElements()) {
            CommPortIdentifier com = (CommPortIdentifier) thePorts.nextElement();
            switch (com.getPortType()) {
            case CommPortIdentifier.PORT_SERIAL:
                try {
                    CommPort thePort = com.open("CommUtil", 50);
                    thePort.close();
                    h.add(com);
                } catch (PortInUseException e) {
                    System.out.println("Port, "  + com.getName() + ", is in use.");
                } catch (Exception e) {
                    System.err.println("Failed to open port " +  com.getName());
                    e.printStackTrace();
                }
            }
        }
        return h;
    }

    public static void main(String[] args) {
        for (CommPortIdentifier element : getAvailableSerialPorts())
        {
            System.out.println(element.getName());
        }
    }
}
$ javac -cp /usr/share/rxtx-2/lib/RXTXcomm.jar Main.java
$ java -Djava.library.path=/usr/lib64/rxtx-2 -cp .:/usr/share/rxtx-2/lib/RXTXcomm.jar Main
/dev/ttyUSB0
/dev/ttyUSB1
```