### PR TITLE
gnome-extra/evolution-ews: add optfeature for oauth

### DIFF
--- a/gnome-extra/evolution-ews/evolution-ews-3.44.1.ebuild
+++ b/gnome-extra/evolution-ews/evolution-ews-3.44.1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit cmake gnome2
+inherit optfeature cmake gnome2
 
 DESCRIPTION="Evolution module for connecting to Microsoft Exchange Web Services"
 HOMEPAGE="https://wiki.gnome.org/Apps/Evolution"
@@ -65,4 +65,8 @@ src_test() {
 
 src_install() {
 	cmake_src_install
+}
+
+pkg_postinst() {
+	optfeature "oauth support" gnome-extra/evolution-data-server[oauth]
 }


### PR DESCRIPTION
Support for oauth is needed for an extremely common use
case (office365) and is currently an undocumented
optional dependency.

Package-Manager: Portage-3.0.30, Repoman-3.0.3