### PR TITLE
sci-geosciences/grass: bump dev version to 8.3

### DIFF
--- a/sci-geosciences/grass/grass-9999.ebuild
+++ b/sci-geosciences/grass/grass-9999.ebuild
@@ -13,7 +13,7 @@ DESCRIPTION="A free GIS with raster and vector functionality, as well as 3D vizu
 HOMEPAGE="https://grass.osgeo.org/"
 
 LICENSE="GPL-2"
-SLOT="0/8.1"
+SLOT="0/8.3"
 
 GVERSION=${SLOT#*/}
 MY_PM="${PN}${GVERSION}"


### PR DESCRIPTION
Bump [GRASS GIS dev version to 8.3](https://github.com/OSGeo/grass/pull/2334).