### PR TITLE
java-virtuals/servlet-api: update EAPI 6 -> 8

### DIFF
--- a/dev-java/osgi-enterprise-api/osgi-enterprise-api-5.0.0-r2.ebuild
+++ b/dev-java/osgi-enterprise-api/osgi-enterprise-api-5.0.0-r2.ebuild
@@ -1,0 +1,37 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+JAVA_PKG_IUSE="doc source"
+
+inherit java-pkg-2 java-pkg-simple
+
+DESCRIPTION="OSGi Enterprise Release 5 Companion Code"
+HOMEPAGE="http://www.osgi.org/Main/HomePage"
+SRC_URI="https://docs.osgi.org/download/r5/osgi.enterprise-${PV}.jar"
+
+LICENSE="Apache-2.0 OSGi-Specification-2.0"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~x86"
+
+RESTRICT="bindist"
+
+CP_DEPEND="dev-java/glassfish-persistence:0
+	dev-java/osgi-core-api:0
+	dev-java/tomcat-servlet-api:2.5"
+
+RDEPEND="${CP_DEPEND}
+	>=virtual/jre-1.8:*"
+
+DEPEND="${CP_DEPEND}
+	>=virtual/jdk-1.8:*"
+
+BDEPEND="app-arch/unzip"
+
+JAVA_SRC_DIR="OSGI-OPT/src"
+
+src_prepare() {
+	default
+	rm -r org || die
+}

--- a/dev-java/reflections/reflections-0.9.12-r1.ebuild
+++ b/dev-java/reflections/reflections-0.9.12-r1.ebuild
@@ -1,0 +1,99 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+# Skeleton command:
+# java-ebuilder --generate-ebuild --workdir . --pom pom.xml --download-uri https://github.com/ronmamo/reflections/archive/0.9.12.tar.gz --slot 0 --keywords "~amd64 ~arm ~arm64 ~ppc64 ~x86" --ebuild reflections-0.9.12.ebuild
+
+EAPI=8
+
+JAVA_PKG_IUSE="doc source test"
+MAVEN_ID="org.reflections:reflections:0.9.12"
+JAVA_TESTING_FRAMEWORKS="junit-4"
+
+inherit java-pkg-2 java-pkg-simple
+
+DESCRIPTION="Reflections - a Java runtime metadata analysis"
+HOMEPAGE="https://github.com/ronmamo/reflections"
+SRC_URI="https://github.com/ronmamo/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="WTFPL-2 BSD-2"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~x86"
+
+# Common dependencies
+# POM: pom.xml
+# com.google.code.gson:gson:2.8.6 -> >=dev-java/gson-2.8.8:2.6
+# org.dom4j:dom4j:2.1.1 -> >=dev-java/dom4j-2.1.3:1
+# org.javassist:javassist:3.26.0-GA -> !!!suitable-mavenVersion-not-found!!!
+# org.slf4j:slf4j-api:1.7.30 -> >=dev-java/slf4j-api-1.7.30:0
+# org.slf4j:slf4j-simple:1.7.24 -> >=dev-java/slf4j-simple-1.7.30:0
+
+CP_DEPEND="
+	dev-java/dom4j:1
+	dev-java/gson:2.6
+	dev-java/javassist:3
+	dev-java/slf4j-api:0
+	dev-java/slf4j-simple:0
+"
+
+# Compile dependencies
+# POM: pom.xml
+# javax.servlet:servlet-api:2.5 -> java-virtuals/servlet-api:2.5
+# POM: pom.xml
+# test? junit:junit:4.13 -> >=dev-java/junit-4.13.2:4
+
+DEPEND="
+	dev-java/tomcat-servlet-api:2.5
+	>=virtual/jdk-1.8:*
+	${CP_DEPEND}
+"
+
+RDEPEND="
+	>=virtual/jre-1.8:*
+	${CP_DEPEND}"
+
+S="${WORKDIR}/${P}"
+
+JAVA_CLASSPATH_EXTRA="tomcat-servlet-api-2.5"
+JAVA_SRC_DIR=( "src/main/java" )
+
+JAVA_TEST_GENTOO_CLASSPATH="junit-4"
+JAVA_TEST_SRC_DIR=( "src/test/java" )
+JAVA_TEST_RESOURCE_DIRS=( "src/test/resources" )
+JAVA_TEST_EXCLUDES=(
+	# Upstream does not run this test
+	"org.reflections.TestModel"
+	# 1) testMethodParameterNames(org.reflections.ReflectionsCollectTest)
+	# org.reflections.ReflectionsException: Scanner MethodParameterNamesScanner was not configured
+	#         at org.reflections.Store.get(Store.java:39)
+	#         at org.reflections.Store.get(Store.java:61)
+	#         at org.reflections.Store.get(Store.java:46)
+	#         at org.reflections.Reflections.getMethodParamNames(Reflections.java:579)
+	#         at org.reflections.ReflectionsTest.testMethodParameterNames(ReflectionsTest.java:239)
+	org.reflections.ReflectionsCollectTest
+	# 2) testMethodParameterNames(org.reflections.ReflectionsParallelTest)
+	# org.reflections.ReflectionsException: Scanner MethodParameterNamesScanner was not configured
+	#         at org.reflections.Store.get(Store.java:39)
+	#         at org.reflections.Store.get(Store.java:61)
+	#         at org.reflections.Store.get(Store.java:46)
+	#         at org.reflections.Reflections.getMethodParamNames(Reflections.java:579)
+	#         at org.reflections.ReflectionsTest.testMethodParameterNames(ReflectionsTest.java:239)
+	org.reflections.ReflectionsParallelTest
+	# 3) testMethodParameterNames(org.reflections.ReflectionsTest)
+	# org.reflections.ReflectionsException: Scanner MethodParameterNamesScanner was not configured
+	#         at org.reflections.Store.get(Store.java:39)
+	#         at org.reflections.Store.get(Store.java:61)
+	#         at org.reflections.Store.get(Store.java:46)
+	#         at org.reflections.Reflections.getMethodParamNames(Reflections.java:579)
+	#         at org.reflections.ReflectionsTest.testMethodParameterNames(ReflectionsTest.java:239)
+	org.reflections.ReflectionsTest
+	#
+	# https://github.com/ronmamo/reflections/issues/277#issuecomment-927152981
+	# scanner was not configured exception - this is a known issue in 0.9.12, a simple workaround is to
+	# check if the getStore() contains index for the scanner before querying. next version 0.10 fixes this.
+)
+
+src_install() {
+	default # https://bugs.gentoo.org/789582
+	java-pkg-simple_src_install
+}

--- a/java-virtuals/servlet-api/servlet-api-2.3-r1.ebuild
+++ b/java-virtuals/servlet-api/servlet-api-2.3-r1.ebuild
@@ -6,7 +6,7 @@ EAPI=8
 inherit java-virtuals-2
 
 DESCRIPTION="Virtual for servlet api"
-HOMEPAGE="http://java.sun.com/products/servlet/"
+HOMEPAGE="https://jcp.org/en/jsr/detail?id=340"
 SRC_URI=""
 
 LICENSE="public-domain"

--- a/java-virtuals/servlet-api/servlet-api-2.4-r1.ebuild
+++ b/java-virtuals/servlet-api/servlet-api-2.4-r1.ebuild
@@ -6,7 +6,7 @@ EAPI=8
 inherit java-virtuals-2
 
 DESCRIPTION="Virtual for servlet api"
-HOMEPAGE="http://java.sun.com/products/servlet/"
+HOMEPAGE="https://jcp.org/en/jsr/detail?id=340"
 
 LICENSE="public-domain"
 SLOT="${PV}"

--- a/java-virtuals/servlet-api/servlet-api-3.0-r3.ebuild
+++ b/java-virtuals/servlet-api/servlet-api-3.0-r3.ebuild
@@ -1,17 +1,16 @@
 # Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
 
 inherit java-virtuals-2
 
 DESCRIPTION="Virtual for servlet api"
-HOMEPAGE="http://java.sun.com/products/servlet/"
-SRC_URI=""
+HOMEPAGE="https://jcp.org/en/jsr/detail?id=340"
 
 LICENSE="public-domain"
 SLOT="${PV}"
-KEYWORDS="amd64 ~arm arm64 ppc64 x86 ~amd64-linux"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~x86 ~amd64-linux"
 
 RDEPEND="|| (
 		dev-java/tomcat-servlet-api:${SLOT}

--- a/java-virtuals/servlet-api/servlet-api-3.1-r2.ebuild
+++ b/java-virtuals/servlet-api/servlet-api-3.1-r2.ebuild
@@ -1,17 +1,16 @@
 # Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
 
 inherit java-virtuals-2
 
 DESCRIPTION="Virtual for servlet api"
-HOMEPAGE="http://java.sun.com/products/servlet/"
-SRC_URI=""
+HOMEPAGE="https://jcp.org/en/jsr/detail?id=340"
 
 LICENSE="public-domain"
 SLOT="${PV}"
-KEYWORDS="amd64 ~arm arm64 ppc64 x86 ~amd64-linux"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~x86"
 
 RDEPEND="|| (
 		dev-java/tomcat-servlet-api:${SLOT}


### PR DESCRIPTION
Since `java-virtuals/servlet-api:2.5` has only one provider I'd like to drop it.