### PR TITLE
sys-devel/slibtool: Fix build with self-hosted clang

### DIFF
--- a/sys-devel/slibtool/slibtool-0.5.34.ebuild
+++ b/sys-devel/slibtool/slibtool-0.5.34.ebuild
@@ -32,5 +32,6 @@ src_configure() {
 		--compiler="$(tc-getCC)" \
 		--host=${CHOST} \
 		--prefix="${EPREFIX}"/usr \
+		--libdir="$(get_libdir)" \
 			|| die
 }

--- a/sys-devel/slibtool/slibtool-9999.ebuild
+++ b/sys-devel/slibtool/slibtool-9999.ebuild
@@ -32,5 +32,6 @@ src_configure() {
 		--compiler="$(tc-getCC)" \
 		--host=${CHOST} \
 		--prefix="${EPREFIX}"/usr \
+		--libdir="$(get_libdir)" \
 			|| die
 }


### PR DESCRIPTION
When building slibtool with a self-hosted clang as documented on the gentoo wiki the build will fail with many undefined references.

The problem is because the ebuild has neglected to use `--libdir` and the sofort build system will then append `-L/usr/lib` instead of the correct `-L/usr/lib64`.

Reference: https://wiki.gentoo.org/wiki/Clang#Bootstrapping_the_Clang_toolchain