### PR TITLE
media-libs/libsidplay: Added 2.1.1-r6

### DIFF
--- a/media-libs/libsidplay/files/libsidplay-2.1.1-autoconf.patch
+++ b/media-libs/libsidplay/files/libsidplay-2.1.1-autoconf.patch
@@ -1,0 +1,172 @@
+From 426bebc250c24cb4482c85131927303cbf7c606d Mon Sep 17 00:00:00 2001
+From: orbea <orbea@riseup.net>
+Date: Sat, 7 May 2022 13:47:57 -0700
+Subject: [PATCH 1/2] build: Fix autoreconf
+
+---
+ builders/hardsid-builder/configure.ac |   1 +
+ builders/resid-builder/configure.ac   |   1 +
+ configure.ac                          |  75 ++----
+ libsidplay/configure.ac               |   1 +
+ libsidutils/configure.ac              |   1 +
+ resid/{configure.in => configure.ac}  |   0
+ 6 files changed, 30 insertions(+), 49 deletions(-)
+ rename resid/{configure.in => configure.ac} (100%)
+ create mode 100644 unix/ax_subdirs_configure.m4
+
+diff --git a/builders/hardsid-builder/configure.ac b/builders/hardsid-builder/configure.ac
+index a54cf26..bdc2bd0 100644
+--- a/builders/hardsid-builder/configure.ac
++++ b/builders/hardsid-builder/configure.ac
+@@ -2,6 +2,7 @@ dnl Process this file with autoconf to produce a configure script.
+ AC_INIT(Makefile.am)
+ AC_CONFIG_AUX_DIR(unix)
+ AM_CONFIG_HEADER(unix/config.h)
++AC_CONFIG_MACRO_DIR([unix])
+ 
+ dnl Setup library CURRENT, REVISION and AGE
+ LIBCUR=0
+diff --git a/builders/resid-builder/configure.ac b/builders/resid-builder/configure.ac
+index 4a98801..5f5561b 100644
+--- a/builders/resid-builder/configure.ac
++++ b/builders/resid-builder/configure.ac
+@@ -2,6 +2,7 @@ dnl Process this file with autoconf to produce a configure script.
+ AC_INIT(Makefile.am)
+ AC_CONFIG_AUX_DIR(unix)
+ AM_CONFIG_HEADER(unix/config.h)
++AC_CONFIG_MACRO_DIR([unix])
+ 
+ dnl Setup library CURRENT, REVISION and AGE
+ LIBCUR=0
+diff --git a/configure.ac b/configure.ac
+index 5724156..d622982 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -3,70 +3,47 @@ AC_INIT(Makefile.am)
+ #Variables
+ pwd=`pwd`
+ builders='${libdir}'/sidplay/builders
+-ac_configure_args="$ac_configure_args --disable-library-checks"
+ 
+ AC_CONFIG_AUX_DIR(unix)
++AC_CONFIG_MACRO_DIR([unix])
+ AM_INIT_AUTOMAKE(sidplay-libs,2.1.1)
+ AC_CANONICAL_HOST
+ 
+ hardsid=false
+ case "$host" in
+-    *linux*) hardsid=true
+-        ;;
++    *linux*) hardsid=true ;;
+ esac
+-AM_CONDITIONAL(HARDSID, test x$hardsid = xtrue)
+ 
+-echo; echo "Configuring libsidplay..."
+-cd $pwd/libsidplay
+-if ! eval ./configure $ac_configure_args \
+---with-sidbuilders=$builders;
+-then
+-exit
+-fi
++AX_SUBDIRS_CONFIGURE([libsidplay], [
++        [--disable-library-checks],
++        [--with-sidbuilders=$builders]])
+ 
+-echo; echo "Configuring resid..."
+-cd "$pwd/resid"
+-if ! eval ./configure $ac_configure_args \
+---disable-resid-install;
+-then
+-exit
+-fi
++AX_SUBDIRS_CONFIGURE([resid], [
++       [--disable-library-checks],
++       [--disable-resid-install]])
+ 
+-echo; echo "Configuring resid-builder..."
+-cd $pwd/builders/resid-builder
+-if ! eval ./configure $ac_configure_args \
+---with-sidplay2-includes=$pwd/libsidplay/include \
+---with-sidplay2-library=$pwd/libsidplay/src \
+---with-resid-includes=$pwd/resid \
+---with-resid-library=$pwd/resid \
+---libdir=$builders;
+-then
+-exit
+-fi
++AX_SUBDIRS_CONFIGURE([builders/resid-builder], [
++        [--disable-library-checks],
++        [--with-sidplay2-includes=$pwd/libsidplay/include],
++        [--with-sidplay2-library=$pwd/libsidplay/src],
++        [--with-resid-includes=$pwd/resid],
++        [--with-resid-library=$pwd/resid],
++        [--libdir=$builders]])
+ 
+-if test x$hardsid = xtrue; then
+-    echo; echo "Configuring hardsid-builder..."
+-    cd $pwd/builders/hardsid-builder
+-    if ! eval ./configure $ac_configure_args \
+-        --with-sidplay2-includes=$pwd/libsidplay/include \
+-        --with-sidplay2-library=$pwd/libsidplay/src \
+-        --libdir=$builders;
+-    then
+-    exit
+-    fi
+-fi
++AM_CONDITIONAL(HARDSID, test x$hardsid = xtrue)
+ 
+-echo; echo "Configuring libsidutils..."
+-cd $pwd/libsidutils
+-if ! eval ./configure $ac_configure_args \
+---with-sidplay2-includes=$pwd/libsidplay/include \
+---with-sidplay2-library=$pwd/libsidplay/src;
+-then
+-exit
++if test x$hardsid = xtrue; then
++    AX_SUBDIRS_CONFIGURE([builders/hardsid-builder], [
++            [--disable-library-checks],
++            [--with-sidplay2-includes=$pwd/libsidplay/include],
++            [--with-sidplay2-library=$pwd/libsidplay/src],
++            [--libdir=$builders]])
+ fi
+ 
+-echo
+-cd $pwd
++AX_SUBDIRS_CONFIGURE([libsidutils], [
++        [--disable-library-checks],
++        [--with-sidplay2-includes=$pwd/libsidplay/include],
++        [--with-sidplay2-library=$pwd/libsidplay/src]])
+ 
+ AC_OUTPUT(
+ Makefile \
+diff --git a/libsidplay/configure.ac b/libsidplay/configure.ac
+index 1946508..9c9d808 100644
+--- a/libsidplay/configure.ac
++++ b/libsidplay/configure.ac
+@@ -8,6 +8,7 @@ AC_INIT(libsidplay,2.LIBCUR.LIBREV)
+ AC_CONFIG_HEADER(unix/config.h)
+ AC_CONFIG_SRCDIR(Makefile.am)
+ AC_CONFIG_AUX_DIR(unix)
++AC_CONFIG_MACRO_DIR([unix])
+ AM_INIT_AUTOMAKE(no-define)
+ 
+ dnl libtool-style version-info number
+diff --git a/libsidutils/configure.ac b/libsidutils/configure.ac
+index 1e38d14..4461aa1 100644
+--- a/libsidutils/configure.ac
++++ b/libsidutils/configure.ac
+@@ -2,6 +2,7 @@ dnl Process this file with autoconf to produce a configure script.
+ AC_INIT(Makefile.am)
+ AC_CONFIG_AUX_DIR(unix)
+ AM_CONFIG_HEADER(unix/config.h)
++AC_CONFIG_MACRO_DIR([unix])
+ 
+ dnl Setup library CURRENT, REVISION and AGE
+ LIBCUR=0
+diff --git a/resid/configure.in b/resid/configure.ac
+similarity index 100%
+rename from resid/configure.in
+rename to resid/configure.ac
+-- 
+2.35.1
+

--- a/media-libs/libsidplay/files/libsidplay-2.1.1-slibtool.patch
+++ b/media-libs/libsidplay/files/libsidplay-2.1.1-slibtool.patch
@@ -1,0 +1,39 @@
+From 6536bf3ceb05e4d32f985a896354b98310c49b5b Mon Sep 17 00:00:00 2001
+From: orbea <orbea@riseup.net>
+Date: Sat, 7 May 2022 14:04:08 -0700
+Subject: [PATCH 2/2] resid: Fix build with slibtool
+
+---
+ resid/Makefile.am | 9 ++-------
+ 1 file changed, 2 insertions(+), 7 deletions(-)
+
+diff --git a/resid/Makefile.am b/resid/Makefile.am
+index bbec226..0a32647 100644
+--- a/resid/Makefile.am
++++ b/resid/Makefile.am
+@@ -7,20 +7,15 @@ if INSTALL_RESID
+ lib_LTLIBRARIES = libresid.la
+ pkginclude_HEADERS = $(resid_headers)
+ else
+-noinst_LTLIBRARIES = libresidc.la
++noinst_LTLIBRARIES = libresid.la
+ noinst_HEADERS = $(resid_headers)
+-
+-all-local:
+-	ln -sf libresidc.la libresid.la
+-
+ endif
+ 
+ ## Make sure these will be cleaned even when they're not built by
+ ## default.
+-CLEANFILES = libresid.la libresidc.la
++CLEANFILES = libresid.la
+ 
+ libresid_la_SOURCES = $(resid_sources)
+-libresidc_la_SOURCES = $(resid_sources)
+ 
+ BUILT_SOURCES = $(noinst_DATA:.dat=.cc)
+ 
+-- 
+2.35.1
+

--- a/media-libs/libsidplay/libsidplay-2.1.1-r6.ebuild
+++ b/media-libs/libsidplay/libsidplay-2.1.1-r6.ebuild
@@ -1,0 +1,81 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools multilib-minimal
+
+MY_P=sidplay-libs-${PV}
+
+DESCRIPTION="C64 SID player library"
+HOMEPAGE="http://sidplay2.sourceforge.net/"
+SRC_URI="mirror://sourceforge/sidplay2/${MY_P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="2"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~mips ~ppc ~ppc64 ~riscv ~sparc ~x86"
+IUSE="static-libs"
+
+BDEPEND="sys-devel/autoconf-archive"
+
+MULTILIB_WRAPPED_HEADERS=(
+	/usr/include/sidplay/sidconfig.h
+)
+
+PATCHES=(
+	"${FILESDIR}"/${P}-gcc41.patch
+	"${FILESDIR}"/${P}-fbsd.patch
+	"${FILESDIR}"/${P}-gcc43.patch
+	"${FILESDIR}"/${P}-no_libtool_reference.patch
+	"${FILESDIR}"/${P}-gcc6.patch
+	"${FILESDIR}"/${P}-autoconf.patch
+	"${FILESDIR}"/${P}-slibtool.patch
+)
+
+S="${WORKDIR}/${MY_P}"
+
+src_prepare() {
+	default
+
+	local subdirs=(
+		builders/hardsid-builder
+		builders/resid-builder
+		libsidplay
+		libsidutils
+		resid
+		.
+	)
+
+	for i in ${subdirs[@]}; do
+		(
+			cd "$i" || die
+			eautoreconf
+		)
+	done
+
+	multilib_copy_sources
+}
+
+multilib_src_configure() {
+	local myeconfargs=(
+		--enable-shared
+		--with-pic
+		$(use_enable static-libs static)
+	)
+	econf "${myeconfargs[@]}"
+}
+
+multilib_src_install_all() {
+	docinto libsidplay
+	dodoc libsidplay/{AUTHORS,ChangeLog,README,TODO}
+
+	docinto libsidutils
+	dodoc libsidutils/{AUTHORS,ChangeLog,README,TODO}
+
+	docinto resid
+	dodoc resid/{AUTHORS,ChangeLog,NEWS,README,THANKS,TODO}
+
+	doenvd "${FILESDIR}"/65resid
+
+	find "${D}" -name '*.la' -delete || die
+}


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/778929

* I bumped the revision to `r6` because the fixes entail significant changes.
* This contains two patches to fix `autoreconf` and the build with `slibtool`.
* The `eautoreconf` hack in the ebuild is unfortunate, but it seems the best that can be done. 
   * `AC_CONFIG_SUBDIRS` doesn't work because it doesn't accept configure arguments.
   *  Neither `autoreconf` or `eautoreconf` recognize `AX_SUBDIRS_CONFIGURE`.
   * The current legacy hack in `configure.ac` is just bad.
* The slibtool build issue is because the build system symlinks two `.la` files which breaks the internal slibtool logic. Its better to just not do this since it offers no benefits.
* I am unsure if upstream is active anymore and their code hasn't been updated in many years.