### PR TITLE
dev-libs/poco: fix file collision

### DIFF
--- a/dev-libs/poco/poco-1.11.2.ebuild
+++ b/dev-libs/poco/poco-1.11.2.ebuild
@@ -32,6 +32,7 @@ REQUIRED_USE="
 BDEPEND="virtual/pkgconfig"
 RDEPEND="
 	>=dev-libs/libpcre-8.42
+	activerecord? ( !app-arch/arc )
 	mysql? ( !mariadb? ( dev-db/mysql-connector-c:0= )
 		 mariadb? ( dev-db/mariadb-connector-c:0= ) )
 	odbc? ( iodbc? ( dev-db/libiodbc )


### PR DESCRIPTION
Given that is not likely that someone will need both activerecord feature of  POCO and app-arch/arc (which seems to be unmaintained for many years) at the same time I prefer to block app-arch/arc conditionally than to rename poco binary. I think this is the best way to avoid impacting negatively on potential users that may be used or may have bash scripts using /usr/bin/arc binary.