### PR TITLE
app-cdr/cdrtools: Don't quote "$(MAKE)"

### DIFF
--- a/app-cdr/cdrtools/cdrtools-3.02_alpha09-r4.ebuild
+++ b/app-cdr/cdrtools/cdrtools-3.02_alpha09-r4.ebuild
@@ -71,6 +71,11 @@ src_prepare() {
 		$(find ./ -type f -exec grep -l '^include.\+rules\.lib' '{}' '+') \
 		|| die "sed rules"
 
+	# Don't quote $(MAKE)
+	sed -i -e 's|"$(MAKE)"|$(MAKE)|' \
+		$(find ./RULES -type f -exec grep -l '"$(MAKE)"' '{}' '+') \
+		|| die "sed RULES/"
+
 	# Enable verbose build.
 	sed -i -e '/@echo.*==>.*;/s:@echo[^;]*;:&set -x;:' \
 		RULES/*.rul RULES/rules.prg RULES/rules.inc \


### PR DESCRIPTION
This issue is not related to slibtool, but for when setting arguments within the MAKE variable. Its standard to not quote it so that it doesn't blow up in these cases.

Bug: https://bugs.gentoo.org/792759