### PR TITLE
app-editors/qhexedit2: fix compile problem and add BDEPEND

### DIFF
--- a/app-editors/qhexedit2/files/qhexedit2-0.8.6-sip.patch
+++ b/app-editors/qhexedit2/files/qhexedit2-0.8.6-sip.patch
@@ -1,0 +1,35 @@
+https://bugs.gentoo.org/820473
+From bdb22d3542099d7e1933aaffa80e044375466914 Mon Sep 17 00:00:00 2001
+From: Huang Rui <vowstar@gmail.com>
+Date: Sat, 7 May 2022 14:49:35 +0800
+Subject: [PATCH] setup.py: fix pyqt_sip_dir on modern Linux distributions
+
+QtCore/QtCoremod.sip may be installed to:
+/usr/lib/python3.9/site-packages/PyQt5/bindings/QtCore/QtCoremod.sip
+See also: https://github.com/qgis/QGIS/blob/master/cmake/FindPyQt5.py
+
+Closes: https://bugs.gentoo.org/820473
+Signed-off-by: Huang Rui <vowstar@gmail.com>
+---
+ setup.py | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/setup.py b/setup.py
+index 1a0d912..1906a07 100644
+--- a/setup.py
++++ b/setup.py
+@@ -10,6 +10,14 @@
+ 
+ cfg = sipconfig.Configuration()
+ pyqt_sip_dir = cfg.default_sip_dir
++for p in (os.path.join(pyqt_sip_dir, "PyQt5"),
++          os.path.join(pyqt_sip_dir, "PyQt5-3"),
++          os.path.join(pyqt_sip_dir, "PyQt4"),
++          pyqt_sip_dir,
++          os.path.join(cfg.default_mod_dir, "PyQt5", "bindings")):
++    if os.path.exists(os.path.join(p, "QtCore", "QtCoremod.sip")):
++        pyqt_sip_dir = p
++        break
+ 
+ try:
+     import PyQt5

--- a/app-editors/qhexedit2/files/qhexedit2-0.8.6-sip5.patch
+++ b/app-editors/qhexedit2/files/qhexedit2-0.8.6-sip5.patch
@@ -1,0 +1,82 @@
+https://bugs.gentoo.org/820473
+https://bugs.gentoo.org/815133
+https://github.com/Simsys/qhexedit2/pull/137
+https://src.fedoraproject.org/rpms/qhexedit2/blob/rawhide/f/sip5.patch
+From ce17d35586de1b9fdc21e3f8450dd1d2b76d5bcc Mon Sep 17 00:00:00 2001
+From: Scott Talbert <swt@techie.net>
+Date: Mon, 18 Jan 2021 21:06:46 -0500
+Subject: [PATCH] Add support for building with sip 5
+
+---
+ project.py       | 29 +++++++++++++++++++++++++++++
+ pyproject.toml   | 14 ++++++++++++++
+ src/qhexedit.sip |  2 +-
+ 3 files changed, 44 insertions(+), 1 deletion(-)
+ create mode 100644 project.py
+ create mode 100644 pyproject.toml
+
+diff --git a/project.py b/project.py
+new file mode 100644
+index 0000000..c9ee67f
+--- /dev/null
++++ b/project.py
+@@ -0,0 +1,29 @@
++"""The build configuration file for QHexEdit, used by sip."""
++
++import os
++from os.path import abspath, join
++from sipbuild import Option
++from pyqtbuild import PyQtBindings, PyQtProject
++import PyQt5
++
++
++class QHexEditProject(PyQtProject):
++    """The QHexEdit Project class."""
++
++    def __init__(self):
++        super().__init__()
++        self.bindings_factories = [QHexEditBindings]
++
++    def update(self, tool):
++        """Allows SIP to find PyQt5 .sip files."""
++        super().update(tool)
++        self.sip_include_dirs.append(join(PyQt5.__path__[0], 'bindings'))
++
++
++class QHexEditBindings(PyQtBindings):
++    """The QHexEdit Bindings class."""
++
++    def __init__(self, project):
++        super().__init__(project, name='QHexEdit',
++                         sip_file='qhexedit.sip',
++                         qmake_QT=['widgets'])
+diff --git a/pyproject.toml b/pyproject.toml
+new file mode 100644
+index 0000000..b5edaa4
+--- /dev/null
++++ b/pyproject.toml
+@@ -0,0 +1,14 @@
++[build-system]
++requires = ["sip >=5, <7", "PyQt-builder >=1.1.0, <2", "PyQt5"]
++build-backend = "sipbuild.api"
++
++[tool.sip.metadata]
++name = "QHexEdit"
++version = "0.8.9"
++
++[tools.sip]
++abi-version = "12.8"
++project-factory = "pyqtbuild:PyQtProject"
++
++[tool.sip.project]
++sip-files-dir = "src"
+diff --git a/src/qhexedit.sip b/src/qhexedit.sip
+index f7db293..6d4ebae 100644
+--- a/src/qhexedit.sip
++++ b/src/qhexedit.sip
+@@ -1,4 +1,4 @@
+-%Module(name=qhexedit, version=1)
++%Module(name=qhexedit)
+ 
+ %Import QtCore/QtCoremod.sip
+ %Import QtGui/QtGuimod.sip

--- a/app-editors/qhexedit2/files/qhexedit2-0.8.9-fix-crash.patch
+++ b/app-editors/qhexedit2/files/qhexedit2-0.8.9-fix-crash.patch
@@ -1,0 +1,37 @@
+https://github.com/Simsys/qhexedit2/pull/139
+From d314aab25eeab0db131fc87f20daf7c4ad587ee2 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?=E8=AF=B7=E5=8F=AB=E6=88=91=E8=88=B9=E9=95=BF?=
+ <38233142+thinkSJ@users.noreply.github.com>
+Date: Sat, 13 Nov 2021 18:35:25 +0800
+Subject: [PATCH] Update qhexedit.cpp
+
+crashed when press ctrl alt keys....
+---
+ src/qhexedit.cpp | 14 +++++++++-----
+ 1 file changed, 9 insertions(+), 5 deletions(-)
+
+diff --git a/src/qhexedit.cpp b/src/qhexedit.cpp
+index d7e532c..4137192 100644
+--- a/src/qhexedit.cpp
++++ b/src/qhexedit.cpp
+@@ -766,11 +766,15 @@ void QHexEdit::keyPressEvent(QKeyEvent *event)
+             (QApplication::keyboardModifiers() == Qt::GroupSwitchModifier))
+         {
+             /* Hex and ascii input */
+-            int key;
+-            if (_editAreaIsAscii)
+-                key = (uchar)event->text().at(0).toLatin1();
+-            else
+-                key = int(event->text().at(0).toLower().toLatin1());
++            int key = 0;
++            QString text = event->text();
++            if (!text.isEmpty())
++            {
++                if (_editAreaIsAscii)
++                    key = (uchar)text.at(0).toLatin1();
++                else
++                    key = int(text.at(0).toLower().toLatin1());
++            }
+ 
+             if ((((key >= '0' && key <= '9') || (key >= 'a' && key <= 'f')) && _editAreaIsAscii == false)
+                 || (key >= ' ' && _editAreaIsAscii))

--- a/app-editors/qhexedit2/metadata.xml
+++ b/app-editors/qhexedit2/metadata.xml
@@ -1,7 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-    <!-- maintainer-needed -->
+    <maintainer type="person">
+            <email>vowstar@gmail.com</email>
+            <name>Huang Rui</name>
+    </maintainer>
+    <maintainer type="project">
+            <email>proxy-maint@gentoo.org</email>
+            <name>Proxy Maintainers</name>
+    </maintainer>
     <use>
         <flag name="gui">Install Qt5 hex editor</flag>
     </use>

--- a/app-editors/qhexedit2/qhexedit2-0.8.6_p20190316-r1.ebuild
+++ b/app-editors/qhexedit2/qhexedit2-0.8.6_p20190316-r1.ebuild
@@ -1,0 +1,108 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DISTUTILS_USE_PEP517=standalone
+PYTHON_COMPAT=( python3_{8..10} )
+
+inherit distutils-r1 qmake-utils
+
+EGIT_COMMIT="ba5af8616b3a6c916e718914225a483267c01356"
+DESCRIPTION="Hex editor library, Qt application written in C++ with Python bindings"
+HOMEPAGE="https://github.com/lancos/qhexedit2/"
+SRC_URI="https://github.com/lancos/${PN}/archive/${EGIT_COMMIT}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~riscv ~x86"
+IUSE="doc +gui python"
+REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-0.8.4-setup.py.patch"
+	"${FILESDIR}/${PN}-0.8.6-sip5.patch" #820473
+)
+
+RDEPEND="
+	dev-qt/qtcore:5
+	dev-qt/qtgui:5
+	dev-qt/qtwidgets:5
+	python? (
+		${PYTHON_DEPS}
+		$(python_gen_cond_dep '
+			dev-python/PyQt5[gui,widgets,${PYTHON_USEDEP}]
+		')
+	)
+"
+DEPEND="${RDEPEND}"
+BDEPEND="
+	python? (
+		$(python_gen_cond_dep '
+			>=dev-python/PyQt-builder-1.10[${PYTHON_USEDEP}]
+			>=dev-python/sip-5:=[${PYTHON_USEDEP}]
+		')
+	)
+"
+
+S="${WORKDIR}/${PN}-${EGIT_COMMIT}"
+
+src_prepare() {
+	default
+	sed -i -e '/^unix:DESTDIR/ d' -e "\$atarget.path = /usr/$(get_libdir)" \
+		-e "\$aINSTALLS += target" src/qhexedit.pro \
+		|| die "src/qhexedit.pro: sed failed"
+}
+
+src_configure() {
+	eqmake5 src/qhexedit.pro
+	if use gui; then
+		cd example || die "can't cd example"
+		eqmake5 qhexedit.pro
+	fi
+}
+
+src_compile() {
+	emake
+	use gui && emake -C example
+	if use python; then
+		export PATH="$(qt5_get_bindir):${PATH}"
+		python_build() {
+			pushd ${S} || die
+			sip-build || die
+			popd || die
+		}
+		python_foreach_impl run_in_build_dir python_build
+	fi
+}
+
+src_test() {
+	cd test || die "can't cd test"
+	mkdir logs || die "can't create logs dir"
+	eqmake5 chunks.pro
+	emake
+	./chunks || die "test run failed"
+	grep -q "^NOK" logs/Summary.log && die "test failed"
+}
+
+src_install() {
+	doheader src/*.h
+	dolib.so libqhexedit.so*
+	if use python; then
+		python_install() {
+			pushd ${S}/build || die
+			emake INSTALL_ROOT="${D}" install
+			popd || die
+		}
+		python_foreach_impl run_in_build_dir python_install
+	fi
+	if use gui; then
+		dobin example/qhexedit
+		insinto /usr/share/${PN}/
+		doins example/translations/*.qm
+	fi
+	if use doc; then
+		dodoc -r doc/html
+		dodoc doc/release.txt
+	fi
+}

--- a/app-editors/qhexedit2/qhexedit2-0.8.9_p20210525-r1.ebuild
+++ b/app-editors/qhexedit2/qhexedit2-0.8.9_p20210525-r1.ebuild
@@ -1,0 +1,110 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DISTUTILS_USE_PEP517=standalone
+PYTHON_COMPAT=( python3_{8..10} )
+
+inherit distutils-r1 qmake-utils
+
+EGIT_COMMIT="541139125be034b90b6811a84faa1413e357fd94"
+DESCRIPTION="Hex editor library, Qt application written in C++ with Python bindings"
+HOMEPAGE="https://github.com/Simsys/qhexedit2/"
+SRC_URI="https://github.com/Simsys/${PN}/archive/${EGIT_COMMIT}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~riscv ~x86"
+IUSE="doc +gui python"
+REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-0.8.4-setup.py.patch"
+	"${FILESDIR}/${PN}-0.8.6-sip.patch" #820473
+	"${FILESDIR}/${PN}-0.8.6-sip5.patch" #820473
+	"${FILESDIR}/${PN}-0.8.9-fix-crash.patch"
+)
+
+RDEPEND="
+	dev-qt/qtcore:5
+	dev-qt/qtgui:5
+	dev-qt/qtwidgets:5
+	python? (
+		${PYTHON_DEPS}
+		$(python_gen_cond_dep '
+			dev-python/PyQt5[gui,widgets,${PYTHON_USEDEP}]
+		')
+	)
+"
+DEPEND="${RDEPEND}"
+BDEPEND="
+	python? (
+		$(python_gen_cond_dep '
+			>=dev-python/PyQt-builder-1.10[${PYTHON_USEDEP}]
+			>=dev-python/sip-5:=[${PYTHON_USEDEP}]
+		')
+	)
+"
+
+S="${WORKDIR}/${PN}-${EGIT_COMMIT}"
+
+src_prepare() {
+	default
+	sed -i -e '/^unix:DESTDIR/ d' -e "\$atarget.path = /usr/$(get_libdir)" \
+		-e "\$aINSTALLS += target" src/qhexedit.pro \
+		|| die "src/qhexedit.pro: sed failed"
+}
+
+src_configure() {
+	eqmake5 src/qhexedit.pro
+	if use gui; then
+		cd example || die "can't cd example"
+		eqmake5 qhexedit.pro
+	fi
+}
+
+src_compile() {
+	emake
+	use gui && emake -C example
+	if use python; then
+		export PATH="$(qt5_get_bindir):${PATH}"
+		python_build() {
+			pushd ${S} || die
+			sip-build || die
+			popd || die
+		}
+		python_foreach_impl run_in_build_dir python_build
+	fi
+}
+
+src_test() {
+	cd test || die "can't cd test"
+	mkdir logs || die "can't create logs dir"
+	eqmake5 chunks.pro
+	emake
+	./chunks || die "test run failed"
+	grep -q "^NOK" logs/Summary.log && die "test failed"
+}
+
+src_install() {
+	doheader src/*.h
+	dolib.so libqhexedit.so*
+	if use python; then
+		python_install() {
+			pushd ${S}/build || die
+			emake INSTALL_ROOT="${D}" install
+			popd || die
+		}
+		python_foreach_impl run_in_build_dir python_install
+	fi
+	if use gui; then
+		dobin example/qhexedit
+		insinto /usr/share/${PN}/
+		doins example/translations/*.qm
+	fi
+	if use doc; then
+		dodoc -r doc/html
+		dodoc doc/release.txt
+	fi
+}


### PR DESCRIPTION
sip-4 no longer supports the latest PyQt5 syntax,
so it needs to be changed to sip-5
Fix unable to find file "QtCore/QtCoremod.sip"
Switched the build system to use sip-build + PyQt-builder
Add dev-python/sip-5 as RDEPEND
New maintainer by Proxy Maint

Closes: https://bugs.gentoo.org/820473
Closes: https://bugs.gentoo.org/758260