### PR TITLE
dev-scheme/guile-ncurses: Fix build with slibtool

### DIFF
--- a/dev-scheme/guile-ncurses/files/guile-ncurses-3.0-slibtool.patch
+++ b/dev-scheme/guile-ncurses/files/guile-ncurses-3.0-slibtool.patch
@@ -1,0 +1,38 @@
+commit 8c8327c8518508380bd68f52db19432b776833e5
+Author: orbea <orbea@riseup.net>
+Date:   Mon May 9 09:06:04 2022 -0700
+
+    build: Link with -ltinfow/-ltinfow to fix undefined references
+
+diff --git a/configure.ac b/configure.ac
+index f194166..954d9b2 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -200,6 +200,13 @@ AS_IF([test "$with_ncursesw" = check],
+                        with_ncursesw=yes],
+                       [AC_MSG_FAILURE([--with-ncursesw was given, but, test for ncursesw failed])])])
+ 
++AS_IF([test "$with_ncursesw" = yes],
++      [AC_SEARCH_LIBS([LINES], [tinfow],
++                      [AC_DEFINE([HAVE_TINFOW],
++                                 [1],
++                                 [Define if you have libtinfow])],
++                      [AC_MSG_FAILURE([--with-ncursesw was given, but, test for tinfow failed])])])
++
+ AS_IF([test "$with_ncursesw" = no],
+       [AC_SEARCH_LIBS([initscr], [ncurses],
+                       [AC_DEFINE([HAVE_NCURSES],
+@@ -207,6 +214,13 @@ AS_IF([test "$with_ncursesw" = no],
+                                  [Define if you have libncurses])],
+                       [AC_MSG_FAILURE([the ncurses library was not found])])])
+ 
++AS_IF([test "$with_ncursesw" = no],
++      [AC_SEARCH_LIBS([LINES], [tinfo],
++                      [AC_DEFINE([HAVE_TINFO],
++                                 [1],
++                                 [Define if you have libntinfo])],
++                      [AC_MSG_FAILURE([the tinfo library was not found])])])
++
+ AM_CONDITIONAL([WIDE], [test "$with_ncursesw" = yes])
+ 
+ AC_MSG_NOTICE([checking for term.h])

--- a/dev-scheme/guile-ncurses/guile-ncurses-3.0.ebuild
+++ b/dev-scheme/guile-ncurses/guile-ncurses-3.0.ebuild
@@ -23,6 +23,10 @@ BDEPEND="sys-apps/texinfo"
 # It's a portage's false positive. bug #677600
 QA_PREBUILT='*[.]go'
 
+PATCHES=(
+	"${FILESDIR}/${P}-slibtool.patch" # 843416
+)
+
 src_prepare() {
 	default
 


### PR DESCRIPTION
On Gentoo both `-lncurses` and `-ltinfow` are needed where the build misses the latter. Additionally GNU libtool silently ignores `-no-undefined` while slibtool does not.

Bug: https://bugs.gentoo.org/843416
Upstream ML: https://lists.gnu.org/archive/html/bug-guile-ncurses/2022-05/msg00000.html