### PR TITLE
sys-kernel/gentoo-kernel-bin: use "Gentoo patches" in DESCRIPTION

### DIFF
--- a/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-5.10.109.ebuild
+++ b/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-5.10.109.ebuild
@@ -9,7 +9,7 @@ MY_P=linux-${PV%.*}
 GENPATCHES_P=genpatches-${PV%.*}-$(( ${PV##*.} + 8 ))
 BINPKG=${P/-bin/}-1
 
-DESCRIPTION="Pre-built Linux kernel with genpatches"
+DESCRIPTION="Pre-built Linux kernel with Gentoo patches"
 HOMEPAGE="https://www.kernel.org/"
 SRC_URI+="
 	https://cdn.kernel.org/pub/linux/kernel/v$(ver_cut 1).x/${MY_P}.tar.xz

--- a/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-5.10.112-r1.ebuild
+++ b/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-5.10.112-r1.ebuild
@@ -9,7 +9,7 @@ MY_P=linux-${PV%.*}
 GENPATCHES_P=genpatches-${PV%.*}-$(( ${PV##*.} + 9 ))
 BINPKG=${P/-bin/}-r1-1
 
-DESCRIPTION="Pre-built Linux kernel with genpatches"
+DESCRIPTION="Pre-built Linux kernel with Gentoo patches"
 HOMEPAGE="https://www.kernel.org/"
 SRC_URI+="
 	https://cdn.kernel.org/pub/linux/kernel/v$(ver_cut 1).x/${MY_P}.tar.xz

--- a/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-5.10.113.ebuild
+++ b/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-5.10.113.ebuild
@@ -9,7 +9,7 @@ MY_P=linux-${PV%.*}
 GENPATCHES_P=genpatches-${PV%.*}-$(( ${PV##*.} + 9 ))
 BINPKG=${P/-bin/}-1
 
-DESCRIPTION="Pre-built Linux kernel with genpatches"
+DESCRIPTION="Pre-built Linux kernel with Gentoo patches"
 HOMEPAGE="https://www.kernel.org/"
 SRC_URI+="
 	https://cdn.kernel.org/pub/linux/kernel/v$(ver_cut 1).x/${MY_P}.tar.xz

--- a/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-5.10.114.ebuild
+++ b/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-5.10.114.ebuild
@@ -9,7 +9,7 @@ MY_P=linux-${PV%.*}
 GENPATCHES_P=genpatches-${PV%.*}-$(( ${PV##*.} + 9 ))
 BINPKG=${P/-bin/}-1
 
-DESCRIPTION="Pre-built Linux kernel with genpatches"
+DESCRIPTION="Pre-built Linux kernel with Gentoo patches"
 HOMEPAGE="https://www.kernel.org/"
 SRC_URI+="
 	https://cdn.kernel.org/pub/linux/kernel/v$(ver_cut 1).x/${MY_P}.tar.xz

--- a/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-5.15.32-r1.ebuild
+++ b/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-5.15.32-r1.ebuild
@@ -9,7 +9,7 @@ MY_P=linux-${PV%.*}
 GENPATCHES_P=genpatches-${PV%.*}-$(( ${PV##*.} + 3 ))
 BINPKG=${P/-bin/}-r1-1
 
-DESCRIPTION="Pre-built Linux kernel with genpatches"
+DESCRIPTION="Pre-built Linux kernel with Gentoo patches"
 HOMEPAGE="https://www.kernel.org/"
 SRC_URI+="
 	https://cdn.kernel.org/pub/linux/kernel/v$(ver_cut 1).x/${MY_P}.tar.xz

--- a/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-5.15.35-r1.ebuild
+++ b/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-5.15.35-r1.ebuild
@@ -9,7 +9,7 @@ MY_P=linux-${PV%.*}
 GENPATCHES_P=genpatches-${PV%.*}-$(( ${PV##*.} + 4 ))
 BINPKG=${P/-bin/}-r1-1
 
-DESCRIPTION="Pre-built Linux kernel with genpatches"
+DESCRIPTION="Pre-built Linux kernel with Gentoo patches"
 HOMEPAGE="https://www.kernel.org/"
 SRC_URI+="
 	https://cdn.kernel.org/pub/linux/kernel/v$(ver_cut 1).x/${MY_P}.tar.xz

--- a/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-5.15.36.ebuild
+++ b/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-5.15.36.ebuild
@@ -9,7 +9,7 @@ MY_P=linux-${PV%.*}
 GENPATCHES_P=genpatches-${PV%.*}-$(( ${PV##*.} + 4 ))
 BINPKG=${P/-bin/}-1
 
-DESCRIPTION="Pre-built Linux kernel with genpatches"
+DESCRIPTION="Pre-built Linux kernel with Gentoo patches"
 HOMEPAGE="https://www.kernel.org/"
 SRC_URI+="
 	https://cdn.kernel.org/pub/linux/kernel/v$(ver_cut 1).x/${MY_P}.tar.xz

--- a/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-5.15.37.ebuild
+++ b/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-5.15.37.ebuild
@@ -9,7 +9,7 @@ MY_P=linux-${PV%.*}
 GENPATCHES_P=genpatches-${PV%.*}-$(( ${PV##*.} + 4 ))
 BINPKG=${P/-bin/}-1
 
-DESCRIPTION="Pre-built Linux kernel with genpatches"
+DESCRIPTION="Pre-built Linux kernel with Gentoo patches"
 HOMEPAGE="https://www.kernel.org/"
 SRC_URI+="
 	https://cdn.kernel.org/pub/linux/kernel/v$(ver_cut 1).x/${MY_P}.tar.xz

--- a/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-5.15.38.ebuild
+++ b/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-5.15.38.ebuild
@@ -9,7 +9,7 @@ MY_P=linux-${PV%.*}
 GENPATCHES_P=genpatches-${PV%.*}-$(( ${PV##*.} + 4 ))
 BINPKG=${P/-bin/}-1
 
-DESCRIPTION="Pre-built Linux kernel with genpatches"
+DESCRIPTION="Pre-built Linux kernel with Gentoo patches"
 HOMEPAGE="https://www.kernel.org/"
 SRC_URI+="
 	https://cdn.kernel.org/pub/linux/kernel/v$(ver_cut 1).x/${MY_P}.tar.xz

--- a/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-5.17.4-r1.ebuild
+++ b/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-5.17.4-r1.ebuild
@@ -9,7 +9,7 @@ MY_P=linux-${PV%.*}
 GENPATCHES_P=genpatches-${PV%.*}-$(( ${PV##*.} + 4 ))
 BINPKG=${P/-bin/}-r1-1
 
-DESCRIPTION="Pre-built Linux kernel with genpatches"
+DESCRIPTION="Pre-built Linux kernel with Gentoo patches"
 HOMEPAGE="https://www.kernel.org/"
 SRC_URI+="
 	https://cdn.kernel.org/pub/linux/kernel/v$(ver_cut 1).x/${MY_P}.tar.xz

--- a/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-5.17.5.ebuild
+++ b/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-5.17.5.ebuild
@@ -9,7 +9,7 @@ MY_P=linux-${PV%.*}
 GENPATCHES_P=genpatches-${PV%.*}-$(( ${PV##*.} + 4 ))
 BINPKG=${P/-bin/}-1
 
-DESCRIPTION="Pre-built Linux kernel with genpatches"
+DESCRIPTION="Pre-built Linux kernel with Gentoo patches"
 HOMEPAGE="https://www.kernel.org/"
 SRC_URI+="
 	https://cdn.kernel.org/pub/linux/kernel/v$(ver_cut 1).x/${MY_P}.tar.xz

--- a/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-5.17.6.ebuild
+++ b/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-5.17.6.ebuild
@@ -9,7 +9,7 @@ MY_P=linux-${PV%.*}
 GENPATCHES_P=genpatches-${PV%.*}-$(( ${PV##*.} + 4 ))
 BINPKG=${P/-bin/}-1
 
-DESCRIPTION="Pre-built Linux kernel with genpatches"
+DESCRIPTION="Pre-built Linux kernel with Gentoo patches"
 HOMEPAGE="https://www.kernel.org/"
 SRC_URI+="
 	https://cdn.kernel.org/pub/linux/kernel/v$(ver_cut 1).x/${MY_P}.tar.xz

--- a/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-5.4.188.ebuild
+++ b/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-5.4.188.ebuild
@@ -9,7 +9,7 @@ MY_P=linux-${PV%.*}
 GENPATCHES_P=genpatches-${PV%.*}-$(( ${PV##*.} + 4 ))
 BINPKG=${P/-bin/}-1
 
-DESCRIPTION="Pre-built Linux kernel with genpatches"
+DESCRIPTION="Pre-built Linux kernel with Gentoo patches"
 HOMEPAGE="https://www.kernel.org/"
 SRC_URI+="
 	https://cdn.kernel.org/pub/linux/kernel/v$(ver_cut 1).x/${MY_P}.tar.xz

--- a/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-5.4.190.ebuild
+++ b/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-5.4.190.ebuild
@@ -9,7 +9,7 @@ MY_P=linux-${PV%.*}
 GENPATCHES_P=genpatches-${PV%.*}-$(( ${PV##*.} + 4 ))
 BINPKG=${P/-bin/}-1
 
-DESCRIPTION="Pre-built Linux kernel with genpatches"
+DESCRIPTION="Pre-built Linux kernel with Gentoo patches"
 HOMEPAGE="https://www.kernel.org/"
 SRC_URI+="
 	https://cdn.kernel.org/pub/linux/kernel/v$(ver_cut 1).x/${MY_P}.tar.xz

--- a/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-5.4.191.ebuild
+++ b/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-5.4.191.ebuild
@@ -9,7 +9,7 @@ MY_P=linux-${PV%.*}
 GENPATCHES_P=genpatches-${PV%.*}-$(( ${PV##*.} + 4 ))
 BINPKG=${P/-bin/}-1
 
-DESCRIPTION="Pre-built Linux kernel with genpatches"
+DESCRIPTION="Pre-built Linux kernel with Gentoo patches"
 HOMEPAGE="https://www.kernel.org/"
 SRC_URI+="
 	https://cdn.kernel.org/pub/linux/kernel/v$(ver_cut 1).x/${MY_P}.tar.xz

--- a/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-5.4.192.ebuild
+++ b/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-5.4.192.ebuild
@@ -9,7 +9,7 @@ MY_P=linux-${PV%.*}
 GENPATCHES_P=genpatches-${PV%.*}-$(( ${PV##*.} + 4 ))
 BINPKG=${P/-bin/}-1
 
-DESCRIPTION="Pre-built Linux kernel with genpatches"
+DESCRIPTION="Pre-built Linux kernel with Gentoo patches"
 HOMEPAGE="https://www.kernel.org/"
 SRC_URI+="
 	https://cdn.kernel.org/pub/linux/kernel/v$(ver_cut 1).x/${MY_P}.tar.xz


### PR DESCRIPTION
The average user is probably unfamiliar with the term "genpatches".