### PR TITLE
dev-libs/tre: Skip postinst ewarn about agrep when USE=-agrep

### DIFF
--- a/dev-libs/tre/tre-0.8.0-r2.ebuild
+++ b/dev-libs/tre/tre-0.8.0-r2.ebuild
@@ -61,6 +61,7 @@ src_install() {
 }
 
 pkg_postinst() {
+	use agrep || return 0
 	ewarn "app-misc/glimpse, app-text/agrep and this package all provide agrep."
 	ewarn "If this causes any unforeseen incompatibilities please file a bug"
 	ewarn "on https://bugs.gentoo.org."

--- a/dev-libs/tre/tre-0.8.0_p20210321.ebuild
+++ b/dev-libs/tre/tre-0.8.0_p20210321.ebuild
@@ -100,6 +100,7 @@ src_install() {
 }
 
 pkg_postinst() {
+	use agrep || return 0
 	ewarn "app-misc/glimpse, app-text/agrep and this package all provide agrep."
 	ewarn "If this causes any unforeseen incompatibilities please file a bug"
 	ewarn "on https://bugs.gentoo.org."


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/843455
Signed-off-by: Jaak Ristioja <jaak@ristioja.ee>