### PR TITLE
eclass/libtool.eclass: Allow forcing the slibtool wrapper

### DIFF
--- a/dev-util/dialog/dialog-1.3.20220728.ebuild
+++ b/dev-util/dialog/dialog-1.3.20220728.ebuild
@@ -3,6 +3,8 @@
 
 EAPI=8
 
+inherit libtool
+
 MY_P=${PN}-$(ver_rs 2 -)
 VERIFY_SIG_OPENPGP_KEY_PATH="${BROOT}"/usr/share/openpgp-keys/thomasdickey.asc
 inherit verify-sig
@@ -31,6 +33,8 @@ BDEPEND="
 
 src_prepare() {
 	default
+
+	eslibtool -shared
 
 	sed -i -e '/LIB_CREATE=/s:${CC}:& ${LDFLAGS}:g' configure || die
 	sed -i '/$(LIBTOOL_COMPILE)/s:$: $(LIBTOOL_OPTS):' makefile.in || die


### PR DESCRIPTION
With most builds the r{d,c,dc}libtool symlinks will result in the
correct behavior. These symlinks will use the builds own local copy
of the GNU libtool script created by the configure process to see
if the build enabled shared, static or both. However some builds do
not have a standard configure process and lack this script where these
slibtool varieties will then fail with flow errors.

The solution is to force the correct slibtool variety that the build
expects and this adds a new elibtool() function and LIBTOOL eclass
variable to accomplish that. Users should set their desired libtool
implementation via the LIBTOOL, MAKE and MAKEFLAGS variable as
described in the gentoo wiki and the eslibtool() function with modify
these variables if set accordingly by using the -shared, -static or no
argument.

In most cases where the build systems uses the standard configure
process the eslibtool() should not be used and in the case the LIBTOOL
variable is unset or a blank variable it will be a no opt.

The second commit fixes the issue for dev-util/dialog as a POC, but there
are several others that can also be fixed with this change.

Reference: https://wiki.gentoo.org/wiki/Slibtool#Usage

Bug: https://bugs.gentoo.org/778047