### PR TITLE
media-libs/grok: new ebuild

### DIFF
--- a/media-libs/grok/grok-9.7.6.ebuild
+++ b/media-libs/grok/grok-9.7.6.ebuild
@@ -1,0 +1,17 @@
+# Copyright 2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+inherit cmake
+
+DESCRIPTION="World's Leading Open Source JPEG 2000 Codec"
+HOMEPAGE="https://github.com/GrokImageCompression/grok"
+SRC_URI="https://github.com/GrokImageCompression/${PN}/archive/refs/tags/v${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="GPL-3"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+DEPEND=""
+RDEPEND="${DEPEND}"
+BDEPEND="dev-util/cmake"


### PR DESCRIPTION
World's Leading Open Source JPEG 2000 Codec

Features

*    support for new High Throughput JPEG 2000 (HTJ2K) standard
*    fast random-access sub-image decoding using TLM and PLT markers
*    full encode/decode support for ICC colour profiles
*    full encode/decode support for XML,IPTC, XMP and EXIF meta-data
*    full encode/decode support for monochrome, sRGB, palette, YCC, extended YCC, CIELab and CMYK colour spaces
*    full encode/decode support for JPEG,PNG,BMP,TIFF,RAW,PNM and PAM image formats
*    full encode/decode support for 1-16 bit precision images

Signed-off-by: Guido Jäkel <g.jaekel@dnb.de>