### PR TITLE
dev-java/eclipse-ecj: SRC_URI

### DIFF
--- a/dev-java/eclipse-ecj/eclipse-ecj-4.15.ebuild
+++ b/dev-java/eclipse-ecj/eclipse-ecj-4.15.ebuild
@@ -11,8 +11,8 @@ MY_PN="ecj"
 DMF="R-${PV}-202003050155"
 
 DESCRIPTION="Eclipse Compiler for Java"
-HOMEPAGE="http://www.eclipse.org/"
-SRC_URI="http://download.eclipse.org/eclipse/downloads/drops4/${DMF}/${MY_PN}src-${PV}.jar"
+HOMEPAGE="https://www.eclipse.org/"
+SRC_URI="https://archive.eclipse.org/eclipse/downloads/drops4/${DMF}/${MY_PN}src-${PV}.jar"
 
 LICENSE="EPL-1.0"
 KEYWORDS="amd64 ~ppc64 x86 ~amd64-linux ~x86-linux ~x86-solaris"

--- a/dev-java/eclipse-ecj/eclipse-ecj-4.5.1.ebuild
+++ b/dev-java/eclipse-ecj/eclipse-ecj-4.5.1.ebuild
@@ -11,8 +11,8 @@ MY_PN="ecj"
 DMF="R-${PV}-201509040015"
 
 DESCRIPTION="Eclipse Compiler for Java"
-HOMEPAGE="http://www.eclipse.org/"
-SRC_URI="http://download.eclipse.org/eclipse/downloads/drops4/${DMF}/${MY_PN}src-${PV}.jar"
+HOMEPAGE="https://www.eclipse.org/"
+SRC_URI="https://archive.eclipse.org/eclipse/downloads/drops4/${DMF}/${MY_PN}src-${PV}.jar"
 
 LICENSE="EPL-1.0"
 KEYWORDS="amd64 ~ppc64 x86 ~amd64-linux ~x86-linux ~x86-solaris"


### PR DESCRIPTION
The versions 4.15 and 4.5.1 are moved to archive and so the SRC_URI
has changed. This pull request fixes the URIs.

Signed-off-by: Madhu Priya Murugan <madhu.murugan@rohde-schwarz.com>