### PR TITLE
app-shells/{gentoo-zsh-completions, zsh-completions, zsh-syntax-highlighting}: keyword for ~riscv

### DIFF
--- a/app-shells/gentoo-zsh-completions/gentoo-zsh-completions-20220112.ebuild
+++ b/app-shells/gentoo-zsh-completions/gentoo-zsh-completions-20220112.ebuild
@@ -8,7 +8,7 @@ if [[ ${PV} == 9999* ]] ; then
 	EGIT_REPO_URI="https://github.com/gentoo/gentoo-zsh-completions.git"
 else
 	SRC_URI="https://github.com/gentoo/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
-	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc64-solaris"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc64-solaris"
 fi
 
 DESCRIPTION="Gentoo specific zsh completion support (includes emerge and ebuild commands)"

--- a/app-shells/zsh-completions/zsh-completions-0.33.0.ebuild
+++ b/app-shells/zsh-completions/zsh-completions-0.33.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,7 +8,7 @@ if [[ ${PV} == 9999* ]] ; then
 	EGIT_REPO_URI="https://github.com/zsh-users/zsh-completions.git"
 else
 	SRC_URI="https://github.com/zsh-users/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
-	KEYWORDS="amd64 arm arm64 ppc ppc64 sparc x86 ~x64-macos"
+	KEYWORDS="amd64 arm arm64 ppc ppc64 ~riscv sparc x86 ~x64-macos"
 fi
 
 DESCRIPTION="Additional completion definitions for Zsh"

--- a/app-shells/zsh-syntax-highlighting/zsh-syntax-highlighting-0.7.1.ebuild
+++ b/app-shells/zsh-syntax-highlighting/zsh-syntax-highlighting-0.7.1.ebuild
@@ -11,7 +11,7 @@ if [[ -z ${PV%%*9999} ]]; then
 else
 	MY_PV=$(ver_rs 3 -)
 	SRC_URI="https://github.com/zsh-users/zsh-syntax-highlighting/archive/${MY_PV}.tar.gz -> ${P}.tar.gz"
-	KEYWORDS="amd64 ~arm x86"
+	KEYWORDS="amd64 ~arm ~riscv x86"
 	S="${WORKDIR}/${PN}-${MY_PV}"
 fi
 


### PR DESCRIPTION
Keyword them for more convenient use on riscv, it's necessary.

Signed-off-by: Yu Gu <guyu2876@gmail.com>