### PR TITLE
media-libs/libvpx: drop to ~sparc

### DIFF
--- a/media-libs/libvpx/libvpx-1.11.0.ebuild
+++ b/media-libs/libvpx/libvpx-1.11.0.ebuild
@@ -21,7 +21,7 @@ SRC_URI="https://github.com/webmproject/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.
 
 LICENSE="BSD"
 SLOT="0/7"
-KEYWORDS="amd64 arm arm64 ~ia64 ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux"
+KEYWORDS="amd64 arm arm64 ~ia64 ppc ppc64 ~riscv ~s390 ~sparc x86 ~amd64-linux ~x86-linux"
 IUSE="cpu_flags_ppc_vsx3 doc +highbitdepth postproc static-libs test +threads"
 
 REQUIRED_USE="test? ( threads )"

--- a/media-libs/libvpx/libvpx-1.9.0.ebuild
+++ b/media-libs/libvpx/libvpx-1.9.0.ebuild
@@ -21,7 +21,7 @@ SRC_URI="https://github.com/webmproject/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.
 
 LICENSE="BSD"
 SLOT="0/6"
-KEYWORDS="amd64 arm arm64 ~ia64 ppc ppc64 ~s390 sparc x86 ~amd64-linux ~x86-linux"
+KEYWORDS="amd64 arm arm64 ~ia64 ppc ppc64 ~s390 ~sparc x86 ~amd64-linux ~x86-linux"
 IUSE="doc +highbitdepth postproc static-libs test +threads"
 
 REQUIRED_USE="test? ( threads )"

--- a/net-fs/cifs-utils/cifs-utils-6.13-r1.ebuild
+++ b/net-fs/cifs-utils/cifs-utils-6.13-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -15,7 +15,7 @@ SRC_URI+=" https://dev.gentoo.org/~polynomial-c/${P}-kerberos_mount_regression_f
 
 LICENSE="GPL-3"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~x86-linux"
+KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~mips ~ppc ppc64 ~riscv ~s390 sparc x86 ~x86-linux"
 IUSE="+acl +ads +caps creds pam +python systemd"
 
 RDEPEND="

--- a/net-fs/cifs-utils/cifs-utils-6.13-r1.ebuild
+++ b/net-fs/cifs-utils/cifs-utils-6.13-r1.ebuild
@@ -15,7 +15,7 @@ SRC_URI+=" https://dev.gentoo.org/~polynomial-c/${P}-kerberos_mount_regression_f
 
 LICENSE="GPL-3"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~mips ~ppc ppc64 ~riscv ~s390 sparc x86 ~x86-linux"
+KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~mips ~ppc ppc64 ~riscv ~s390 ~sparc x86 ~x86-linux"
 IUSE="+acl +ads +caps creds pam +python systemd"
 
 RDEPEND="

--- a/profiles/arch/hppa/package.use.mask
+++ b/profiles/arch/hppa/package.use.mask
@@ -203,9 +203,8 @@ app-emacs/elscreen wanderlust
 net-im/pidgin gadu
 
 # Jeroen Roovers <jer@gentoo.org> (2020-01-28)
-# sys-apps/systemd is not stable
 # media-libs/libilbc has not been ported to HPPA
-net-analyzer/wireshark ilbc sdjournal
+net-analyzer/wireshark ilbc
 
 # Andreas Sturmlechner <asturm@gentoo.org> (2020-01-26)
 # media-libs/libheif is not keyworded

--- a/profiles/arch/hppa/package.use.stable.mask
+++ b/profiles/arch/hppa/package.use.stable.mask
@@ -98,10 +98,6 @@ sys-apps/iproute2 atm bpf iptables
 # dev-libs/libzip does not have stable keywords on hppa
 >=media-gfx/imagemagick-7 zip
 
-# Sam James <sam@gentoo.org> (2021-06-01)
-# sys-apps/systemd is not stable on hppa
-sys-auth/pambase homed
-
 # Sam James <sam@gentoo.org> (2021-02-18)
 # Requires dev-lang/vala to be stable
 gnome-base/librsvg vala
@@ -173,10 +169,6 @@ x11-base/xorg-server xorg
 # Rolf Eike Beer <eike@sf-mail.de> (2020-12-11)
 # not all needed sphinx modules are stable on hppa.
 dev-python/aiohttp doc
-
-# Sergei Trofimovich <slyfox@gentoo.org> (2020-11-14)
-# sys-apps/systemd has no stable keywords on hppa.
-sys-apps/ipmitool openbmc
 
 # Arfrever Frehtes Taifersar Arahesis <arfrever.fta@gmail.com> (2020-10-14)
 # app-i18n/fcitx:4 not stable.

--- a/profiles/arch/powerpc/ppc32/package.use.stable.mask
+++ b/profiles/arch/powerpc/ppc32/package.use.stable.mask
@@ -17,10 +17,12 @@
 
 #--- END OF EXAMPLES ---
 
-# Sam James <sam@gentoo.org> (2022-05-10)
+# Sam James <sam@gentoo.org> (2022-05-11)
 # sys-apps/keyutils not stable here (test failures)
+# ... and samba[client] pulls in cifs-utils which pulls in keyutils.
 # bug #636252
 net-fs/nfs-utils nfsv4
+net-fs/samba client
 
 # Sam James <sam@gentoo.org> (2022-03-03)
 # net-nds/openldap / dev-libs/cyrus-sasl not stable here

--- a/profiles/arch/powerpc/ppc32/package.use.stable.mask
+++ b/profiles/arch/powerpc/ppc32/package.use.stable.mask
@@ -17,6 +17,11 @@
 
 #--- END OF EXAMPLES ---
 
+# Sam James <sam@gentoo.org> (2022-05-10)
+# sys-apps/keyutils not stable here (test failures)
+# bug #636252
+net-fs/nfs-utils nfsv4
+
 # Sam James <sam@gentoo.org> (2022-03-03)
 # net-nds/openldap / dev-libs/cyrus-sasl not stable here
 dev-lang/php ldap-sasl

--- a/profiles/arch/powerpc/ppc32/package.use.stable.mask
+++ b/profiles/arch/powerpc/ppc32/package.use.stable.mask
@@ -23,6 +23,9 @@
 # bug #636252
 net-fs/nfs-utils nfsv4
 net-fs/samba client
+gnome-base/gvfs samba
+media-video/ffmpeg samba
+media-video/vlc samba
 
 # Sam James <sam@gentoo.org> (2022-03-03)
 # net-nds/openldap / dev-libs/cyrus-sasl not stable here

--- a/profiles/arch/sparc/package.use.stable.mask
+++ b/profiles/arch/sparc/package.use.stable.mask
@@ -7,6 +7,9 @@
 # bug #636252
 net-fs/nfs-utils nfsv4
 net-fs/samba client
+gnome-base/gvfs samba
+media-video/ffmpeg samba
+media-video/vlc samba
 
 # Sam James <sam@gentoo.org> (2022-05-10)
 # sys-apps/keyutils not stable here, because of

--- a/profiles/arch/sparc/package.use.stable.mask
+++ b/profiles/arch/sparc/package.use.stable.mask
@@ -1,6 +1,11 @@
 # Copyright 2019-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Sam James <sam@gentoo.org> (2022-05-11)
+# sys-apps/keyutils not stable here (test failures)
+# bug #636252
+net-fs/nfs-utils nfsv4
+
 # Sam James <sam@gentoo.org> (2022-05-10)
 # sys-apps/keyutils not stable here, because of
 # test failures. bug #636252

--- a/profiles/arch/sparc/package.use.stable.mask
+++ b/profiles/arch/sparc/package.use.stable.mask
@@ -1,5 +1,10 @@
-# Copyright 2019-2021 Gentoo Authors
+# Copyright 2019-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
+
+# Sam James <sam@gentoo.org> (2022-05-10)
+# sys-apps/keyutils not stable here, because of
+# test failures. bug #636252
+app-crypt/mit-krb5 keyutils
 
 # Sam James <sam@gentoo.org> (2022-03-07)
 # sys-cluster/torque not marked stable on sparc

--- a/profiles/arch/sparc/package.use.stable.mask
+++ b/profiles/arch/sparc/package.use.stable.mask
@@ -3,8 +3,10 @@
 
 # Sam James <sam@gentoo.org> (2022-05-11)
 # sys-apps/keyutils not stable here (test failures)
+# ... and samba[client] pulls in cifs-utils which pulls in keyutils.
 # bug #636252
 net-fs/nfs-utils nfsv4
+net-fs/samba client
 
 # Sam James <sam@gentoo.org> (2022-05-10)
 # sys-apps/keyutils not stable here, because of

--- a/sys-apps/keyutils/keyutils-1.6.1.ebuild
+++ b/sys-apps/keyutils/keyutils-1.6.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ SRC_URI="https://git.kernel.org/pub/scm/linux/kernel/git/dhowells/keyutils.git/s
 
 LICENSE="GPL-2 LGPL-2.1"
 SLOT="0/1.9"
-KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~m68k ~mips ppc ppc64 ~riscv ~s390 ~sparc x86 ~amd64-linux ~x86-linux"
 IUSE="static static-libs test"
 RESTRICT="!test? ( test )"
 

--- a/sys-apps/keyutils/keyutils-1.6.1.ebuild
+++ b/sys-apps/keyutils/keyutils-1.6.1.ebuild
@@ -11,7 +11,7 @@ SRC_URI="https://git.kernel.org/pub/scm/linux/kernel/git/dhowells/keyutils.git/s
 
 LICENSE="GPL-2 LGPL-2.1"
 SLOT="0/1.9"
-KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~m68k ~mips ppc ppc64 ~riscv ~s390 ~sparc x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~m68k ~mips ~ppc ppc64 ~riscv ~s390 ~sparc x86 ~amd64-linux ~x86-linux"
 IUSE="static static-libs test"
 RESTRICT="!test? ( test )"
 

--- a/sys-apps/keyutils/keyutils-1.6.3.ebuild
+++ b/sys-apps/keyutils/keyutils-1.6.3.ebuild
@@ -11,7 +11,7 @@ SRC_URI="https://git.kernel.org/pub/scm/linux/kernel/git/dhowells/keyutils.git/s
 
 LICENSE="GPL-2 LGPL-2.1"
 SLOT="0/1.9"
-KEYWORDS="~alpha amd64 ~arm arm64 hppa ~ia64 ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 ~sparc x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~alpha amd64 ~arm arm64 hppa ~ia64 ~loong ~m68k ~mips ~ppc ppc64 ~riscv ~s390 ~sparc x86 ~amd64-linux ~x86-linux"
 IUSE="static static-libs test"
 RESTRICT="!test? ( test )"
 


### PR DESCRIPTION
Too many test failures. Unclear if it truly works at runtime.

Bug: https://bugs.gentoo.org/833741
Bug: https://bugs.gentoo.org/700902
Signed-off-by: Sam James <sam@gentoo.org>