### PR TITLE
net-print/cups: Don't use libtool

### DIFF
--- a/net-print/cups/cups-2.4.2-r1.ebuild
+++ b/net-print/cups/cups-2.4.2-r1.ebuild
@@ -188,6 +188,11 @@ multilib_src_configure() {
 	# makes more sense when facing multilib support.
 	sed -i -e 's:CUPS_SERVERBIN="$exec_prefix/lib/cups":CUPS_SERVERBIN="$exec_prefix/libexec/cups":g' configure ||die
 
+	# Don't use the libtool build
+	# https://bugs.gentoo.org/843638
+	# https://github.com/OpenPrinting/cups/pull/394
+	unset LIBTOOL
+
 	econf "${myeconfargs[@]}"
 
 	sed -i -e "s:SERVERBIN.*:SERVERBIN = \"\$\(BUILDROOT\)${EPREFIX}/usr/libexec/cups\":" Makedefs || die


### PR DESCRIPTION
When building cups with `LIBTOOL=rlibtool` exported in `make.conf` the build will fail. This happens because slibtool can't determine build information from the generated libtool script that doesn't exist.

Its better to just not use libtool at all in this build system.

Bug: https://bugs.gentoo.org/843638
~~Upstream-PR: https://github.com/OpenPrinting/cups/pull/392~~
Upstream-PR: https://github.com/OpenPrinting/cups/pull/394