### PR TITLE
app-office/gnumeric: Fix build with slibtool

### DIFF
--- a/app-office/gnumeric/files/gnumeric-1.12.52-slibtool.patch
+++ b/app-office/gnumeric/files/gnumeric-1.12.52-slibtool.patch
@@ -1,0 +1,36 @@
+Upstream-PR: https://gitlab.gnome.org/GNOME/gnumeric/-/merge_requests/25
+From 3031cc85718dde12a34be46330ef3b8c885f4f9e Mon Sep 17 00:00:00 2001
+From: orbea <orbea@riseup.net>
+Date: Tue, 10 May 2022 15:52:57 -0700
+Subject: [PATCH] plugins/excelplugins: Remove erroneous .libs
+
+The .libs directory is for internal usage by the libtool
+implementation only.
+
+When build gnumeric with slibtool instead of GNU libtool this
+will be a failure where slibtool is far more strict about user
+errors.
+
+rdlibtool: error logged in slbt_exec_link_create_dep_file(), line 1091: path not found: ../../src/.libs/.libs/libspreadsheet.a.disabled.
+
+Gentoo Bug: https://bugs.gentoo.org/791610
+---
+ plugins/excelplugins/Makefile.am | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/plugins/excelplugins/Makefile.am b/plugins/excelplugins/Makefile.am
+index 3bc8f70b0..91e2fa765 100644
+--- a/plugins/excelplugins/Makefile.am
++++ b/plugins/excelplugins/Makefile.am
+@@ -7,7 +7,7 @@ gnumeric_plugin_excelpluginsdir = $(gnumeric_plugindir)/excelplugins
+ xmldir = $(gnumeric_plugin_excelpluginsdir)
+ gnumeric_plugin_excelplugins_LTLIBRARIES = plugin.la xlcall32.la
+ plugin_la_LDFLAGS = -module $(GNUMERIC_PLUGIN_LDFLAGS)
+-plugin_la_LIBADD = ../../src/.libs/libspreadsheet.la
++plugin_la_LIBADD = ../../src/libspreadsheet.la
+ plugin_la_SOURCES = excelplugins.c
+ xlcall32_la_LDFLAGS = -module $(GNUMERIC_PLUGIN_LDFLAGS)
+ xlcall32_la_SOURCES = xlcall32_emulation.c win32replacements.h xlcall.h
+-- 
+GitLab
+

--- a/app-office/gnumeric/gnumeric-1.12.52.ebuild
+++ b/app-office/gnumeric/gnumeric-1.12.52.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 PYTHON_COMPAT=( python3_{7..10} )
 
-inherit gnome.org libtool python-r1 xdg
+inherit autotools gnome.org python-r1 xdg
 
 DESCRIPTION="The GNOME Spreadsheet"
 HOMEPAGE="http://www.gnumeric.org/"
@@ -56,12 +56,18 @@ BDEPEND="
 	>=dev-util/intltool-0.35.0
 	virtual/pkgconfig"
 
+PATCHES=(
+	"${FILESDIR}/${P}-slibtool.patch" # 791610
+)
+
 src_prepare() {
 	default
 
 	# Manage gi overrides ourselves
 	sed '/SUBDIRS/ s/introspection//' -i Makefile.{am,in} || die
-	elibtoolize
+
+	# Changed from 'elibtoolize' for bug # 791610
+	eautoreconf
 }
 
 src_configure() {


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/791610
Upstream-PR: https://gitlab.gnome.org/GNOME/gnumeric/-/merge_requests/25

The `.libs` directory is for internal use by the libtool implementation only.