### PR TITLE
sys-fs/udisks: Fix undefined references

### DIFF
--- a/sys-fs/udisks/files/udisks-2.9.4-undefined.patch
+++ b/sys-fs/udisks/files/udisks-2.9.4-undefined.patch
@@ -1,0 +1,30 @@
+Upstream-PR: https://github.com/storaged-project/udisks/pull/978
+From 362cc8f1613193f8e68d13a416421bb36fd7f713 Mon Sep 17 00:00:00 2001
+From: orbea <orbea@riseup.net>
+Date: Tue, 10 May 2022 09:29:10 -0700
+Subject: [PATCH] modules/btrfs: Add missing dependency
+
+When building udisks with --enable-btrfs using slibtool instead of GNU
+libtool the build will fail with undefined references.
+
+This is because of a missing dependency for libudisks2_btrfs_la_LIBADD
+and GNU libtool will hide this issue by silently ignoring -no-undefined
+while slibtool does not.
+
+Gentoo Bug: https://bugs.gentoo.org/782061
+---
+ modules/btrfs/Makefile.am | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/modules/btrfs/Makefile.am b/modules/btrfs/Makefile.am
+index ac8c941849..f96cd16186 100644
+--- a/modules/btrfs/Makefile.am
++++ b/modules/btrfs/Makefile.am
+@@ -73,6 +73,7 @@ libudisks2_btrfs_la_LDFLAGS =                                                  \
+ 	$(NULL)
+ 
+ libudisks2_btrfs_la_LIBADD =                                                   \
++	$(top_builddir)/src/libudisks-daemon.la                                \
+ 	$(GLIB_LIBS)                                                           \
+ 	$(GIO_LIBS)                                                            \
+ 	$(GUDEV_LIBS)                                                          \

--- a/sys-fs/udisks/udisks-2.9.4.ebuild
+++ b/sys-fs/udisks/udisks-2.9.4.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-inherit bash-completion-r1 linux-info systemd tmpfiles udev xdg-utils
+inherit autotools bash-completion-r1 linux-info systemd tmpfiles udev xdg-utils
 
 DESCRIPTION="Daemon providing interfaces to work with storage devices"
 HOMEPAGE="https://www.freedesktop.org/wiki/Software/udisks"
@@ -61,6 +61,10 @@ BDEPEND="
 
 DOCS=( AUTHORS HACKING NEWS README.md )
 
+PATCHES=(
+	"${FILESDIR}/${P}-undefined.patch" # 782061
+)
+
 pkg_setup() {
 	# Listing only major arch's here to avoid tracking kernel's defconfig
 	if use amd64 || use arm || use ppc || use ppc64 || use x86; then
@@ -79,6 +83,9 @@ src_prepare() {
 	if ! use systemd ; then
 		sed -i -e 's:libsystemd-login:&disable:' configure || die
 	fi
+
+	# Added for bug # 782061
+	eautoreconf
 }
 
 src_configure() {


### PR DESCRIPTION
When building with slibtool the build fails with undefined references. This is because slibtool respects `-no-undefined` while GNU libtool silently ignores it.

Adding the missing dependency fixes the issue.

Bug: https://bugs.gentoo.org/782061
Upstream-PR: https://github.com/storaged-project/udisks/pull/978