### PR TITLE
dev-python/platformdirs: keyword 2.5.2 for ~riscv, #843617

### DIFF
--- a/dev-python/hatch-vcs/hatch-vcs-0.2.0.ebuild
+++ b/dev-python/hatch-vcs/hatch-vcs-0.2.0.ebuild
@@ -20,7 +20,7 @@ SRC_URI="
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~amd64"
+KEYWORDS="~amd64 ~riscv"
 
 RDEPEND="
 	>=dev-python/setuptools_scm-6.4.0[${PYTHON_USEDEP}]

--- a/dev-python/platformdirs/platformdirs-2.5.2.ebuild
+++ b/dev-python/platformdirs/platformdirs-2.5.2.ebuild
@@ -20,7 +20,7 @@ SRC_URI="
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~amd64"
+KEYWORDS="~amd64 ~riscv"
 
 BDEPEND="
 	dev-python/hatch-vcs[${PYTHON_USEDEP}]


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/843617
Signed-off-by: Yu Gu <guyu2876@gmail.com>