### PR TITLE
dev-java/ant-eclipse-ecj:SRC_URI

### DIFF
--- a/dev-java/ant-eclipse-ecj/ant-eclipse-ecj-4.15-r1.ebuild
+++ b/dev-java/ant-eclipse-ecj/ant-eclipse-ecj-4.15-r1.ebuild
@@ -10,8 +10,8 @@ inherit java-pkg-2 java-pkg-simple prefix
 DMF="R-${PV}-202003050155"
 
 DESCRIPTION="Ant Compiler Adapter for Eclipse Java Compiler"
-HOMEPAGE="http://www.eclipse.org/"
-SRC_URI="http://download.eclipse.org/eclipse/downloads/drops4/${DMF}/ecjsrc-${PV}.jar"
+HOMEPAGE="https://www.eclipse.org/"
+SRC_URI="https://archive.eclipse.org/eclipse/downloads/drops4/${DMF}/ecjsrc-${PV}.jar"
 
 LICENSE="EPL-1.0"
 KEYWORDS="amd64 ~ppc64 x86 ~amd64-linux ~x86-linux ~x86-solaris"

--- a/dev-java/ant-eclipse-ecj/ant-eclipse-ecj-4.5.1.ebuild
+++ b/dev-java/ant-eclipse-ecj/ant-eclipse-ecj-4.5.1.ebuild
@@ -10,8 +10,8 @@ inherit java-pkg-2 java-pkg-simple prefix
 DMF="R-${PV}-201509040015"
 
 DESCRIPTION="Ant Compiler Adapter for Eclipse Java Compiler"
-HOMEPAGE="http://www.eclipse.org/"
-SRC_URI="http://download.eclipse.org/eclipse/downloads/drops4/${DMF}/ecjsrc-${PV}.jar"
+HOMEPAGE="https://www.eclipse.org/"
+SRC_URI="https://archive.eclipse.org/eclipse/downloads/drops4/${DMF}/ecjsrc-${PV}.jar"
 
 LICENSE="EPL-1.0"
 KEYWORDS="amd64 ~ppc64 x86 ~amd64-linux ~x86-linux ~x86-solaris"


### PR DESCRIPTION
The versions 4.15 and 4.5.1 are moved to archive and so the SRC_URI
has changed. This pull request fixes the URIs.

Signed-off-by: Madhu Priya Murugan <madhu.murugan@rohde-schwarz.com>