### PR TITLE
mail-client/thunderbird,www-client/firefox: fix typo

### DIFF
--- a/mail-client/thunderbird/metadata.xml
+++ b/mail-client/thunderbird/metadata.xml
@@ -7,7 +7,7 @@
 </maintainer>
 <use>
 	<flag name="clang">Use Clang compiler instead of GCC</flag>
-	<flag name="eme-free">Disable EME (DRM plugin) cabability at build time</flag>
+	<flag name="eme-free">Disable EME (DRM plugin) capability at build time</flag>
 	<flag name="hwaccel">Force-enable hardware-accelerated rendering (Mozilla bug 594876)</flag>
 	<flag name="lto">Enable Link Time Optimization (LTO). Requires Gold linker when using GCC
 		or LDD linker when using Clang</flag>

--- a/www-client/firefox/metadata.xml
+++ b/www-client/firefox/metadata.xml
@@ -7,7 +7,7 @@
 </maintainer>
 <use>
 	<flag name="clang">Use Clang compiler instead of GCC</flag>
-	<flag name="eme-free">Disable EME (DRM plugin) cabability at build time</flag>
+	<flag name="eme-free">Disable EME (DRM plugin) capability at build time</flag>
 	<flag name="geckodriver">Enable WebDriver support</flag>
 	<flag name="gmp-autoupdate">Allow Gecko Media Plugins (binary blobs) to be automatically
 		downloaded and kept up-to-date in user profiles</flag>


### PR DESCRIPTION
Substitute cabability with capability.

Signed-off-by: Eva Dengler <eva.dengler@fau.de>