### PR TITLE
dev-java/openjdk: improve MERGE_TYPE check in pkg_setup

### DIFF
--- a/dev-java/openjdk/openjdk-11.0.14_p9-r1.ebuild
+++ b/dev-java/openjdk/openjdk-11.0.14_p9-r1.ebuild
@@ -130,6 +130,8 @@ pkg_setup() {
 	openjdk_check_requirements
 	java-vm-2_pkg_setup
 
+	[[ ${MERGE_TYPE} == "binary" ]] && return
+
 	JAVA_PKG_WANT_BUILD_VM="openjdk-${SLOT} openjdk-bin-${SLOT}"
 	JAVA_PKG_WANT_SOURCE="${SLOT}"
 	JAVA_PKG_WANT_TARGET="${SLOT}"
@@ -142,7 +144,6 @@ pkg_setup() {
 			fi
 		done
 	else
-		[[ ${MERGE_TYPE} == "binary" ]] && return
 		local xpakvar="${ARCH^^}_XPAK"
 		export JDK_HOME="${WORKDIR}/openjdk-bootstrap-${!xpakvar}"
 	fi

--- a/dev-java/openjdk/openjdk-11.0.15_p10.ebuild
+++ b/dev-java/openjdk/openjdk-11.0.15_p10.ebuild
@@ -130,6 +130,8 @@ pkg_setup() {
 	openjdk_check_requirements
 	java-vm-2_pkg_setup
 
+	[[ ${MERGE_TYPE} == "binary" ]] && return
+
 	JAVA_PKG_WANT_BUILD_VM="openjdk-${SLOT} openjdk-bin-${SLOT}"
 	JAVA_PKG_WANT_SOURCE="${SLOT}"
 	JAVA_PKG_WANT_TARGET="${SLOT}"
@@ -142,7 +144,6 @@ pkg_setup() {
 			fi
 		done
 	else
-		[[ ${MERGE_TYPE} == "binary" ]] && return
 		local xpakvar="${ARCH^^}_XPAK"
 		export JDK_HOME="${WORKDIR}/openjdk-bootstrap-${!xpakvar}"
 	fi

--- a/dev-java/openjdk/openjdk-17.0.2_p8.ebuild
+++ b/dev-java/openjdk/openjdk-17.0.2_p8.ebuild
@@ -128,6 +128,8 @@ pkg_setup() {
 	openjdk_check_requirements
 	java-vm-2_pkg_setup
 
+	[[ ${MERGE_TYPE} == "binary" ]] && return
+
 	JAVA_PKG_WANT_BUILD_VM="openjdk-${SLOT} openjdk-bin-${SLOT}"
 	JAVA_PKG_WANT_SOURCE="${SLOT}"
 	JAVA_PKG_WANT_TARGET="${SLOT}"
@@ -154,13 +156,11 @@ pkg_setup() {
 		local xpakvar="${ARCH^^}_XPAK"
 		export JDK_HOME="${WORKDIR}/openjdk-bootstrap-${!xpakvar}"
 	else
-		if [[ ${MERGE_TYPE} != "binary" ]]; then
-			JDK_HOME=$(best_version dev-java/openjdk-bin:${SLOT})
-			[[ -n ${JDK_HOME} ]] || die "Build VM not found!"
-			JDK_HOME=${JDK_HOME#*/}
-			JDK_HOME=${EPREFIX}/opt/${JDK_HOME%-r*}
-			export JDK_HOME
-		fi
+		JDK_HOME=$(best_version dev-java/openjdk-bin:${SLOT})
+		[[ -n ${JDK_HOME} ]] || die "Build VM not found!"
+		JDK_HOME=${JDK_HOME#*/}
+		JDK_HOME=${EPREFIX}/opt/${JDK_HOME%-r*}
+		export JDK_HOME
 	fi
 }
 

--- a/dev-java/openjdk/openjdk-17.0.3_p7.ebuild
+++ b/dev-java/openjdk/openjdk-17.0.3_p7.ebuild
@@ -128,6 +128,8 @@ pkg_setup() {
 	openjdk_check_requirements
 	java-vm-2_pkg_setup
 
+	[[ ${MERGE_TYPE} == "binary" ]] && return
+
 	JAVA_PKG_WANT_BUILD_VM="openjdk-${SLOT} openjdk-bin-${SLOT}"
 	JAVA_PKG_WANT_SOURCE="${SLOT}"
 	JAVA_PKG_WANT_TARGET="${SLOT}"
@@ -154,13 +156,11 @@ pkg_setup() {
 		local xpakvar="${ARCH^^}_XPAK"
 		export JDK_HOME="${WORKDIR}/openjdk-bootstrap-${!xpakvar}"
 	else
-		if [[ ${MERGE_TYPE} != "binary" ]]; then
-			JDK_HOME=$(best_version dev-java/openjdk-bin:${SLOT})
-			[[ -n ${JDK_HOME} ]] || die "Build VM not found!"
-			JDK_HOME=${JDK_HOME#*/}
-			JDK_HOME=${EPREFIX}/opt/${JDK_HOME%-r*}
-			export JDK_HOME
-		fi
+		JDK_HOME=$(best_version dev-java/openjdk-bin:${SLOT})
+		[[ -n ${JDK_HOME} ]] || die "Build VM not found!"
+		JDK_HOME=${JDK_HOME#*/}
+		JDK_HOME=${EPREFIX}/opt/${JDK_HOME%-r*}
+		export JDK_HOME
 	fi
 }
 


### PR DESCRIPTION
We can return early in pkg_setup if MERGE_TYPE=binary.

Signed-off-by: Florian Schmaus <flow@gentoo.org>