### PR TITLE
media-video/wireplumber: patch 0.4.10 to default enable backends

### DIFF
--- a/media-video/wireplumber/files/wireplumber-0.4.10-config-fix-enabled-property-to-default-to-true-when.patch
+++ b/media-video/wireplumber/files/wireplumber-0.4.10-config-fix-enabled-property-to-default-to-true-when.patch
@@ -1,0 +1,129 @@
+https://gitlab.freedesktop.org/pipewire/wireplumber/-/commit/1f045309208ab5d927883b5adc2b7d1623fae162
+
+From 1f045309208ab5d927883b5adc2b7d1623fae162 Mon Sep 17 00:00:00 2001
+From: George Kiagiadakis <george.kiagiadakis@collabora.com>
+Date: Thu, 12 May 2022 12:19:38 +0300
+Subject: [PATCH] config: fix enabled property to default to "true" when not
+ defined
+
+Fixes backwards compatibility with older config files
+
+Fixes: #254
+---
+ src/config/bluetooth.lua.d/30-bluez-monitor.lua | 2 +-
+ src/config/main.lua.d/20-default-access.lua     | 2 +-
+ src/config/main.lua.d/30-alsa-monitor.lua       | 2 +-
+ src/config/main.lua.d/30-libcamera-monitor.lua  | 2 +-
+ src/config/main.lua.d/30-v4l2-monitor.lua       | 2 +-
+ src/config/main.lua.d/40-device-defaults.lua    | 2 +-
+ src/config/main.lua.d/40-stream-defaults.lua    | 2 +-
+ src/config/policy.lua.d/10-default-policy.lua   | 2 +-
+ 8 files changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/src/config/bluetooth.lua.d/30-bluez-monitor.lua b/src/config/bluetooth.lua.d/30-bluez-monitor.lua
+index b40026c2..a870aa5d 100644
+--- a/src/config/bluetooth.lua.d/30-bluez-monitor.lua
++++ b/src/config/bluetooth.lua.d/30-bluez-monitor.lua
+@@ -3,7 +3,7 @@ bluez_monitor.properties = {}
+ bluez_monitor.rules = {}
+ 
+ function bluez_monitor.enable()
+-  if not bluez_monitor.enabled then
++  if bluez_monitor.enabled == false then
+     return
+   end
+ 
+diff --git a/src/config/main.lua.d/20-default-access.lua b/src/config/main.lua.d/20-default-access.lua
+index a6ffb2ee..0a7eb955 100644
+--- a/src/config/main.lua.d/20-default-access.lua
++++ b/src/config/main.lua.d/20-default-access.lua
+@@ -3,7 +3,7 @@ default_access.properties = {}
+ default_access.rules = {}
+ 
+ function default_access.enable()
+-  if not default_access.enabled then
++  if default_access.enabled == false then
+     return
+   end
+ 
+diff --git a/src/config/main.lua.d/30-alsa-monitor.lua b/src/config/main.lua.d/30-alsa-monitor.lua
+index da0b2c70..8e45e434 100644
+--- a/src/config/main.lua.d/30-alsa-monitor.lua
++++ b/src/config/main.lua.d/30-alsa-monitor.lua
+@@ -3,7 +3,7 @@ alsa_monitor.properties = {}
+ alsa_monitor.rules = {}
+ 
+ function alsa_monitor.enable()
+-  if not alsa_monitor.enabled then
++  if alsa_monitor.enabled == false then
+     return
+   end
+ 
+diff --git a/src/config/main.lua.d/30-libcamera-monitor.lua b/src/config/main.lua.d/30-libcamera-monitor.lua
+index 4a8257ff..cd820a83 100644
+--- a/src/config/main.lua.d/30-libcamera-monitor.lua
++++ b/src/config/main.lua.d/30-libcamera-monitor.lua
+@@ -3,7 +3,7 @@ libcamera_monitor.properties = {}
+ libcamera_monitor.rules = {}
+ 
+ function libcamera_monitor.enable()
+-  if not libcamera_monitor.enabled then
++  if libcamera_monitor.enabled == false then
+     return
+   end
+ 
+diff --git a/src/config/main.lua.d/30-v4l2-monitor.lua b/src/config/main.lua.d/30-v4l2-monitor.lua
+index 7cfd4bcd..3fbdc9e7 100644
+--- a/src/config/main.lua.d/30-v4l2-monitor.lua
++++ b/src/config/main.lua.d/30-v4l2-monitor.lua
+@@ -3,7 +3,7 @@ v4l2_monitor.properties = {}
+ v4l2_monitor.rules = {}
+ 
+ function v4l2_monitor.enable()
+-  if not v4l2_monitor.enabled then
++  if v4l2_monitor.enabled == false then
+     return
+   end
+ 
+diff --git a/src/config/main.lua.d/40-device-defaults.lua b/src/config/main.lua.d/40-device-defaults.lua
+index 55aafe85..2204c4ac 100644
+--- a/src/config/main.lua.d/40-device-defaults.lua
++++ b/src/config/main.lua.d/40-device-defaults.lua
+@@ -38,7 +38,7 @@ device_defaults.persistent_profiles = {
+ }
+ 
+ function device_defaults.enable()
+-  if not device_defaults.enabled then
++  if device_defaults.enabled == false then
+     return
+   end
+ 
+diff --git a/src/config/main.lua.d/40-stream-defaults.lua b/src/config/main.lua.d/40-stream-defaults.lua
+index 2975f4f6..307d83df 100644
+--- a/src/config/main.lua.d/40-stream-defaults.lua
++++ b/src/config/main.lua.d/40-stream-defaults.lua
+@@ -25,7 +25,7 @@ stream_defaults.rules = {
+ }
+ 
+ function stream_defaults.enable()
+-  if not stream_defaults.enabled then
++  if stream_defaults.enabled == false then
+     return
+   end
+ 
+diff --git a/src/config/policy.lua.d/10-default-policy.lua b/src/config/policy.lua.d/10-default-policy.lua
+index 7b00e94e..edfdeb1c 100644
+--- a/src/config/policy.lua.d/10-default-policy.lua
++++ b/src/config/policy.lua.d/10-default-policy.lua
+@@ -38,7 +38,7 @@ bluetooth_policy.policy = {
+ }
+ 
+ function default_policy.enable()
+-  if not default_policy.enabled then
++  if default_policy.enabled == false then
+     return
+   end
+ 
+-- 
+GitLab
+

--- a/media-video/wireplumber/wireplumber-0.4.10-r1.ebuild
+++ b/media-video/wireplumber/wireplumber-0.4.10-r1.ebuild
@@ -1,0 +1,122 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+LUA_COMPAT=( lua5-{3,4} )
+
+inherit lua-single meson systemd
+
+if [[ ${PV} == 9999 ]]; then
+	EGIT_REPO_URI="https://gitlab.freedesktop.org/pipewire/${PN}.git"
+	EGIT_BRANCH="master"
+	inherit git-r3
+else
+	SRC_URI="https://gitlab.freedesktop.org/pipewire/${PN}/-/archive/${PV}/${P}.tar.gz"
+	KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~riscv ~sparc ~x86"
+fi
+
+DESCRIPTION="Replacement for pipewire-media-session"
+HOMEPAGE="https://gitlab.freedesktop.org/pipewire/wireplumber"
+
+LICENSE="MIT"
+SLOT="0/0.4"
+IUSE="elogind system-service systemd test"
+
+REQUIRED_USE="
+	${LUA_REQUIRED_USE}
+	?? ( elogind systemd )
+	system-service? ( systemd )
+"
+
+RESTRICT="!test? ( test )"
+
+# introspection? ( dev-libs/gobject-introspection ) is valid but likely only used for doc building
+BDEPEND="
+	dev-libs/glib
+	dev-util/gdbus-codegen
+	dev-util/glib-utils
+	sys-devel/gettext
+"
+
+DEPEND="
+	${LUA_DEPS}
+	>=dev-libs/glib-2.62
+	>=media-video/pipewire-0.3.48:=
+	virtual/libc
+	virtual/libintl
+	elogind? ( sys-auth/elogind )
+	systemd? ( sys-apps/systemd )
+"
+
+# Any dev-lua/* deps get declared like this inside RDEPEND:
+#	$(lua_gen_cond_dep '
+#		dev-lua/<NAME>[${LUA_USEDEP}]
+#	')
+RDEPEND="${DEPEND}
+	system-service? (
+		acct-user/pipewire
+		acct-group/pipewire
+	)
+"
+
+DOCS=( {NEWS,README}.rst )
+
+PATCHES=(
+	"${FILESDIR}"/${P}-config-fix-enabled-property-to-default-to-true-when.patch
+)
+
+src_configure() {
+	local emesonargs=(
+		-Ddoc=disabled # Ebuild not wired up yet (Sphinx, Doxygen?)
+		-Dintrospection=disabled # Only used for Sphinx doc generation
+		-Dsystem-lua=true # We always unbundle everything we can
+		-Dsystem-lua-version=$(ver_cut 1-2 $(lua_get_version))
+		$(meson_feature elogind)
+		$(meson_feature systemd)
+		$(meson_use system-service systemd-system-service)
+		$(meson_use systemd systemd-user-service)
+		-Dsystemd-system-unit-dir=$(systemd_get_systemunitdir)
+		-Dsystemd-user-unit-dir=$(systemd_get_userunitdir)
+		$(meson_use test tests)
+	)
+
+	meson_src_configure
+}
+
+src_install() {
+	meson_src_install
+
+	# We copy the default config, so that Gentoo tools can pick up on any
+	# updates and /etc does not end up with stale overrides.
+	# If a reflinking CoW filesystem is used (e.g. Btrfs), then the files
+	# will not actually get stored twice until modified.
+	insinto /etc
+	doins -r ${ED}/usr/share/wireplumber
+}
+
+pkg_postinst() {
+	if systemd_is_booted ; then
+		ewarn "pipewire-media-session.service is no longer installed. You must switch"
+		ewarn "to wireplumber.service user unit before your next logout/reboot:"
+		ewarn "systemctl --user disable pipewire-media-session.service"
+		ewarn "systemctl --user --force enable wireplumber.service"
+	else
+		ewarn "Switch to WirePlumber will happen the next time gentoo-pipewire-launcher"
+		ewarn "is started (a replacement for directly calling pipewire binary)."
+		ewarn
+		ewarn "Please ensure that ${EROOT}/etc/pipewire/pipewire.conf either does not exist"
+		ewarn "or, if it does exist, that any reference to"
+		ewarn "${EROOT}/usr/bin/pipewire-media-session is commented out (begins with a #)."
+	fi
+	if use system-service; then
+		ewarn
+		ewarn "WARNING: you have enabled the system-service USE flag, which installs"
+		ewarn "the system-wide systemd units that enable WirePlumber to run as a system"
+		ewarn "service. This is more than likely NOT what you want. You are strongly"
+		ewarn "advised not to enable this mode and instead stick with systemd user"
+		ewarn "units. The default configuration files will likely not work out of"
+		ewarn "box, and you are on your own with configuration."
+		ewarn
+	fi
+}


### PR DESCRIPTION
Due to significant number of people having outdated copies of
WirePlumber scripts, upstream chose to change the default behavior of
WP monitors (essentially PW backends) and to enable them by default,
so that they work with the older scripts.

Gentoo already duplicates to /etc/wireplumber which would trigger the
usual config protection mechanism but users could also have copied them
to ~/.config/wireplumber. Therefore it's still a nice thing to apply this
change.

Bug: https://gitlab.freedesktop.org/pipewire/wireplumber/-/issues/254