### PR TITLE
media-sound/pulseaudio-daemon: Untangle USE flags

### DIFF
--- a/media-sound/pulseaudio-daemon/metadata.xml
+++ b/media-sound/pulseaudio-daemon/metadata.xml
@@ -60,11 +60,8 @@
       ConsoleKit.
     </flag>
     <flag name="valgrind">Compile in valgrind memory hints</flag>
-    <flag name="native-headset">
-      Build with native HSP backend for bluez 5.
-    </flag>
     <flag name="ofono-headset">
-      Build with oFono HFP backend for bluez 5, requires <pkg>net-misc/ofono</pkg>.
+      Build with optional oFono HFP backend for bluez 5, requires <pkg>net-misc/ofono</pkg>.
     </flag>
     <flag name="gstreamer">
       Build GStreamer-based RTP protocol module which supports more advanced RTP features like OPUS payload encoding.

--- a/media-sound/pulseaudio-daemon/metadata.xml
+++ b/media-sound/pulseaudio-daemon/metadata.xml
@@ -64,8 +64,7 @@
       Build with oFono HFP backend for bluez 5, requires <pkg>net-misc/ofono</pkg>.
     </flag>
     <flag name="gstreamer">
-      Build with support for gstreamer including ability to use bluetooth codecs.
-      For bluetooth codecs see USE ldac and aptx.
+      Build GStreamer-based RTP protocol module which supports more advanced RTP features like OPUS payload encoding.
     </flag>
     <flag name="aptx">
       aptX (HD) over Bluetooth (many Android compatible headphones), requires <pkg>media-plugins/gst-plugins-openaptx</pkg>.

--- a/media-sound/pulseaudio-daemon/metadata.xml
+++ b/media-sound/pulseaudio-daemon/metadata.xml
@@ -36,7 +36,10 @@
     </flag>
     <flag name="asyncns">Use libasyncns for asynchronous name resolution.</flag>
     <flag name="equalizer">
-      Enable the equalizer module (requires <pkg>sci-libs/fftw</pkg>).
+      Enable the equalizer module (requires <pkg>sci-libs/fftw</pkg> and <pkg>sys-apps/dbus</pkg>).
+    </flag>
+    <flag name="fftw">
+      Enable the virtual surround sink module (requires <pkg>sci-libs/fftw</pkg>).
     </flag>
     <flag name="ssl">
       Use <pkg>dev-libs/openssl</pkg> to provide support for RAOP

--- a/media-sound/pulseaudio-daemon/pulseaudio-daemon-16.0.ebuild
+++ b/media-sound/pulseaudio-daemon/pulseaudio-daemon-16.0.ebuild
@@ -32,7 +32,7 @@ SLOT="0"
 # +alsa-plugin as discussed in bug #519530
 # TODO: Find out why webrtc-aec is + prefixed - there's already the always available speexdsp-aec
 # NOTE: The current ebuild sets +X almost certainly just for the pulseaudio.desktop file
-IUSE="+alsa +alsa-plugin aptx +asyncns bluetooth dbus elogind equalizer +gdbm +glib gstreamer gtk ipv6 jack ldac lirc
+IUSE="+alsa +alsa-plugin aptx +asyncns bluetooth dbus elogind equalizer fftw +gdbm +glib gstreamer gtk ipv6 jack ldac lirc
 native-headset ofono-headset +orc oss selinux sox ssl systemd system-wide tcpd test +udev valgrind +webrtc-aec +X zeroconf"
 
 RESTRICT="!test? ( test )"
@@ -83,7 +83,10 @@ COMMON_DEPEND="
 	dbus? ( >=sys-apps/dbus-1.4.12 )
 	elogind? ( sys-auth/elogind )
 	equalizer? (
-		sci-libs/fftw:3.0
+		sci-libs/fftw:3.0=
+	)
+	fftw? (
+		sci-libs/fftw:3.0=
 	)
 	gdbm? ( sys-libs/gdbm:= )
 	glib? ( >=dev-libs/glib-2.28.0:2 )
@@ -173,6 +176,11 @@ src_configure() {
 		enable_bluez5_gstreamer="enabled"
 	fi
 
+	local enable_fftw="disabled"
+	if use equalizer || use fftw ; then
+		enable_fftw="enabled"
+	fi
+
 	local emesonargs=(
 		--localstatedir="${EPREFIX}"/var
 
@@ -203,7 +211,7 @@ src_configure() {
 		$(meson_use ofono-headset bluez5-ofono-headset)
 		$(meson_feature dbus)
 		$(meson_feature elogind)
-		$(meson_feature equalizer fftw)
+		-Dfftw=${enable_fftw}
 		$(meson_feature glib) # WARNING: toggling this likely changes ABI
 		$(meson_feature glib gsettings) # Supposedly correct?
 		$(meson_feature gstreamer)

--- a/media-sound/pulseaudio-daemon/pulseaudio-daemon-16.0.ebuild
+++ b/media-sound/pulseaudio-daemon/pulseaudio-daemon-16.0.ebuild
@@ -33,7 +33,7 @@ SLOT="0"
 # TODO: Find out why webrtc-aec is + prefixed - there's already the always available speexdsp-aec
 # NOTE: The current ebuild sets +X almost certainly just for the pulseaudio.desktop file
 IUSE="+alsa +alsa-plugin aptx +asyncns bluetooth dbus elogind equalizer fftw +gdbm +glib gstreamer gtk ipv6 jack ldac lirc
-native-headset ofono-headset +orc oss selinux sox ssl systemd system-wide tcpd test +udev valgrind +webrtc-aec +X zeroconf"
+ofono-headset +orc oss selinux sox ssl systemd system-wide tcpd test +udev valgrind +webrtc-aec +X zeroconf"
 
 RESTRICT="!test? ( test )"
 
@@ -47,7 +47,6 @@ REQUIRED_USE="
 	bluetooth? ( dbus )
 	equalizer? ( dbus )
 	ldac? ( bluetooth )
-	native-headset? ( bluetooth )
 	ofono-headset? ( bluetooth )
 	udev? ( || ( alsa oss ) )
 	zeroconf? ( dbus )
@@ -207,7 +206,7 @@ src_configure() {
 		$(meson_feature zeroconf avahi)
 		$(meson_feature bluetooth bluez5)
 		-Dbluez5-gstreamer=${enable_bluez5_gstreamer}
-		$(meson_use native-headset bluez5-native-headset)
+		$(meson_use bluetooth bluez5-native-headset)
 		$(meson_use ofono-headset bluez5-ofono-headset)
 		$(meson_feature dbus)
 		$(meson_feature elogind)
@@ -329,7 +328,20 @@ pkg_postinst() {
 		elog ""
 	fi
 
-	if use native-headset && use ofono-headset; then
+	if use bluetooth; then
+		elog "You have enabled bluetooth USE flag for pulseaudio. Daemon will now handle"
+		elog "bluetooth Headset (HSP HS and HSP AG) and Handsfree (HFP HF) profiles using"
+		elog "native headset backend by default. This can be selectively disabled"
+		elog "via runtime configuration arguments to module-bluetooth-discover"
+		elog "in /etc/pulse/default.pa"
+		elog "To disable HFP HF append enable_native_hfp_hf=false"
+		elog "To disable HSP HS append enable_native_hsp_hs=false"
+		elog "To disable HSP AG append headset=auto or headset=ofono"
+		elog "(note this does NOT require enabling USE ofono)"
+		elog ""
+	fi
+
+	if use ofono-headset; then
 		elog "You have enabled both native and ofono headset profiles. The runtime decision"
 		elog "which to use is done via the 'headset' argument of module-bluetooth-discover."
 		elog ""

--- a/media-sound/pulseaudio/pulseaudio-16.0.ebuild
+++ b/media-sound/pulseaudio/pulseaudio-16.0.ebuild
@@ -15,14 +15,14 @@ LICENSE="metapackage"
 
 SLOT="0"
 
-# NOTE: bluetooth, native-headset and ofono-headset are passed through to
+# NOTE: bluetooth and ofono-headset are passed through to
 # pulseaudio-daemon dependency to make sure users who have bluetooth enabled
 # just for pulseaudio package will also get these enabled via metapackage.
-IUSE="bluetooth +daemon +glib jack native-headset ofono-headset"
+IUSE="bluetooth +daemon +glib jack ofono-headset"
 
 RDEPEND="
 	>=media-libs/libpulse-${PV}[glib?,${MULTILIB_USEDEP}]
-	daemon? ( >=media-sound/pulseaudio-daemon-${PV}[bluetooth?,glib?,jack?,native-headset?,ofono-headset?] )
+	daemon? ( >=media-sound/pulseaudio-daemon-${PV}[bluetooth?,glib?,jack?,ofono-headset?] )
 "
 DEPEND="${RDEPEND}"
 


### PR DESCRIPTION
As suggested by @leio on irc

- Require USE `bluetooth` for codecs selected via USE `ldac` or `aptx`, and pull required `gstreamer` packages as build dependency but keep respective gstreamer plugins runtime dependency.
- Handle USE `gstreamer` to enable GStreamer-based RTP implementation only, and suggest `media-plugins/gst-plugins-opus` for RTP OPUS payload.
- Require USE `dbus` for USE `equalizer`, and pull required `sys-apps/dbus` as build and runtime dependency.
- Add USE `fftw` to enable `module-virtual-surround-sink`.

Additionally, native backend for HSP and HFP bluetooth profiles has no reported issues, therefore
- drop USE `native-headset` and enable native backend support for HSP and HFP bluetooth profiles unconditionally if USE `bluetooth`. This adds microphone support for most bluetooth headsets by default, and can be disabled by user via runtime configuration if needed (see added `elog`.)