### PR TITLE
app-accessibility/at-spi2-atk: BDEPEND gnome-base/gsettings-desktop-schemas

### DIFF
--- a/app-accessibility/at-spi2-atk/at-spi2-atk-2.38.0.ebuild
+++ b/app-accessibility/at-spi2-atk/at-spi2-atk-2.38.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -23,6 +23,7 @@ RDEPEND="
 DEPEND="${RDEPEND}"
 BDEPEND="
 	virtual/pkgconfig
+	gnome-base/gsettings-desktop-schemas
 	test? ( >=dev-libs/libxml2-2.9.1 )
 "
 


### PR DESCRIPTION
On sparc, the old =app-accessibility/at-spi2-atk-2.34.2 failed to
compile, but it's gone from tree now and 2.38.0 is stable with the
exception of this missing BDEPEND, so closing the relevant bug (even
though this isn't really a "fix" for the bug in question, but does
confirm that the problematic bug is gone).