### PR TITLE
dev-util/clippy: Fix clippy install with slibtool

### DIFF
--- a/dev-util/clippy/clippy-8.2.2-r1.ebuild
+++ b/dev-util/clippy/clippy-8.2.2-r1.ebuild
@@ -1,0 +1,46 @@
+# Copyright 2020-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+MY_P="frr-${PV}"
+PYTHON_COMPAT=( python3_{8..10} )
+inherit autotools python-single-r1
+
+DESCRIPTION="Standalone clippy tool built from FRR sources"
+HOMEPAGE="https://frrouting.org/"
+SRC_URI="https://github.com/FRRouting/frr/archive/${MY_P}.tar.gz -> ${P}.tar.gz"
+S="${WORKDIR}/frr-${MY_P}"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~arm64 ~x86"
+REQUIRED_USE="${PYTHON_REQUIRED_USE}"
+
+# standalone clippy does not have any tests
+# restrict to prevent bug 811753
+RESTRICT="test"
+
+DEPEND="
+	${PYTHON_DEPS}
+	virtual/libelf:=
+"
+RDEPEND="${DEPEND}"
+BDEPEND="sys-devel/flex"
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_configure() {
+	econf --enable-clippy-only
+}
+
+src_install() {
+	# 830087
+	find "lib" -type f -name "clippy" -print0 |
+		xargs -0 file | grep executable | grep ELF | cut -f 1 -d : |
+		xargs -I '{}' dobin '{}' ||
+		die "Failed to install 'lib/clippy'"
+}


### PR DESCRIPTION
Installing a file created by libtool is not portable for slibtool and this will result in installing the slibtool shell wrapper script for clippy and not the clippy binary.

This additionally fails when compiling net-misc/frr which will use the shell wrapper script that does not work outside of the build directory.

The 'make install' target is not appropriate for --enable-clippy-only and fixing that seems like significant work so just use shell instead to find the correct file.

I bumped the ebuild revision because this causes a build failure in frr.

Bug: https://bugs.gentoo.org/830087