### PR TITLE
make sci-libs/vtk[mpi] independent of a specific mpi implementation

### DIFF
--- a/sci-libs/vtk/vtk-9.0.3-r4.ebuild
+++ b/sci-libs/vtk/vtk-9.0.3-r4.ebuild
@@ -79,7 +79,7 @@ RDEPEND="
 	json? ( dev-libs/jsoncpp:= )
 	mpi? (
 		sci-libs/h5part
-		sys-cluster/openmpi[cxx,romio]
+		virtual/mpi[cxx,romio]
 	)
 	mysql? ( dev-db/mariadb-connector-c )
 	odbc? ( dev-db/unixODBC )

--- a/sci-libs/vtk/vtk-9.1.0-r2.ebuild
+++ b/sci-libs/vtk/vtk-9.1.0-r2.ebuild
@@ -83,7 +83,7 @@ RDEPEND="
 	java? ( >=virtual/jdk-1.8:* )
 	mpi? (
 		media-libs/glew:=
-		sys-cluster/openmpi[cxx,romio]
+		virtual/mpi[cxx,romio]
 		virtual/opengl
 	)
 	mysql? ( dev-db/mariadb-connector-c )


### PR DESCRIPTION
One may use a different implementation of mpi. According to the [official documentation ](https://gitlab.kitware.com/vtk/vtk/-/blob/master/Documentation/dev/build.md#mpi) vtk supports different mpi implementations.