### PR TITLE
Add sound server virtual package and allow configuring pipewire support for sound server

### DIFF
--- a/media-libs/libpulse/libpulse-16.1.ebuild
+++ b/media-libs/libpulse/libpulse-16.1.ebuild
@@ -67,6 +67,13 @@ BDEPEND="
 	virtual/pkgconfig
 	doc? ( app-doc/doxygen )
 "
+PDEPEND="
+	|| (
+		media-video/pipewire[sound-server(+)]
+		media-sound/pulseaudio-daemon
+		media-sound/pulseaudio[daemon(+)]
+	)
+"
 
 DOCS=( NEWS README )
 

--- a/media-sound/pulseaudio-daemon/pulseaudio-daemon-16.1.ebuild
+++ b/media-sound/pulseaudio-daemon/pulseaudio-daemon-16.1.ebuild
@@ -138,6 +138,7 @@ RDEPEND="
 		ldac? ( media-plugins/gst-plugins-ldac )
 		aptx? ( media-plugins/gst-plugins-openaptx )
 	)
+	!media-video/pipewire[sound-server(+)]
 "
 unset gstreamer_deps
 

--- a/media-video/pipewire/metadata.xml
+++ b/media-video/pipewire/metadata.xml
@@ -28,5 +28,6 @@
 		<flag name="ssl">Enable raop-sink support (needs <pkg>dev-libs/openssl</pkg>)</flag>
 		<flag name="system-service">Install systemd unit files for running as a system service. Not recommended.</flag>
 		<flag name="X">Enable audible bell for X11</flag>
+		<flag name="sound-server">Provide sound server using ALSA and bluetooth devices</flag>
 	</use>
 </pkgmetadata>

--- a/media-video/pipewire/pipewire-0.3.53.ebuild
+++ b/media-video/pipewire/pipewire-0.3.53.ebuild
@@ -28,7 +28,8 @@ HOMEPAGE="https://pipewire.org/"
 LICENSE="MIT LGPL-2.1+ GPL-2"
 # ABI was broken in 0.3.42 for https://gitlab.freedesktop.org/pipewire/wireplumber/-/issues/49
 SLOT="0/0.4"
-IUSE="bluetooth doc echo-cancel extra gstreamer jack-client jack-sdk lv2 pipewire-alsa ssl system-service systemd test udev v4l X zeroconf"
+IUSE="bluetooth doc echo-cancel extra gstreamer jack-client jack-sdk lv2 pipewire-alsa
+sound-server ssl system-service systemd test udev v4l X zeroconf"
 
 # Once replacing system JACK libraries is possible, it's likely that
 # jack-client IUSE will need blocking to avoid users accidentally
@@ -36,6 +37,7 @@ IUSE="bluetooth doc echo-cancel extra gstreamer jack-client jack-sdk lv2 pipewir
 # JACK's sink - doing so is likely to yield no audio, cause a CPU
 # cycles consuming loop (and may even cause GUI crashes)!
 
+# TODO: There should be "sound-server? ( || ( alsa bluetooth ) )" here, but ALSA is always enabled
 REQUIRED_USE="
 	jack-sdk? ( !jack-client )
 	system-service? ( systemd )
@@ -250,12 +252,26 @@ multilib_src_install_all() {
 		dosym ../../../usr/share/alsa/alsa.conf.d/99-pipewire-default-hook.conf /etc/alsa/conf.d/99-pipewire-default-hook.conf
 	fi
 
+	# Enable required wireplumber alsa and bluez monitors
+	if use sound-server; then
+		dodir /etc/wireplumber/main.lua.d
+		echo "alsa_monitor.enabled = true" > ${D}/etc/wireplumber/main.lua.d/89-gentoo-sound-server-enable-alsa-monitor.lua
+		dodir /etc/wireplumber/bluetooth.lua.d
+		echo "bluez_monitor.enabled = true" > ${D}/etc/wireplumber/bluetooth.lua.d/89-gentoo-sound-server-enable-bluez-monitor.lua
+	fi
+
 	if ! use systemd; then
 		insinto /etc/xdg/autostart
 		newins "${FILESDIR}"/pipewire.desktop-r1 pipewire.desktop
 
 		exeinto /usr/bin
 		newexe "${FILESDIR}"/gentoo-pipewire-launcher.in gentoo-pipewire-launcher
+
+		# Disable pipewire-pulse if sound-server is disabled.
+		if ! use sound-server ; then
+			sed -i -s '/pipewire -c pipewire-pulse.conf/s/^/#/' "${ED}"/usr/bin/gentoo-pipewire-launcher || die
+		fi
+
 		eprefixify "${ED}"/usr/bin/gentoo-pipewire-launcher
 	fi
 }
@@ -310,7 +326,8 @@ pkg_postinst() {
 		ewarn "now on start ${EROOT}/usr/bin/gentoo-pipewire-launcher instead! It is highly"
 		ewarn "advised that a D-Bus user session is set up before starting the script."
 		ewarn
-		if has_version 'media-sound/pulseaudio[daemon]' || has_version 'media-sound/pulseaudio-daemon'; then
+
+		if use sound-server && ( has_version 'media-sound/pulseaudio[daemon]' || has_version 'media-sound/pulseaudio-daemon' ) ; then
 			elog "This ebuild auto-enables PulseAudio replacement. Because of that, users"
 			elog "are recommended to edit pulseaudio client configuration files:"
 			elog "${EROOT}/etc/pulse/client.conf and ${EROOT}/etc/pulse/client.conf.d/enable-autospawn.conf"

--- a/media-video/pipewire/pipewire-0.3.53.ebuild
+++ b/media-video/pipewire/pipewire-0.3.53.ebuild
@@ -38,9 +38,14 @@ sound-server ssl system-service systemd test udev v4l X zeroconf"
 # cycles consuming loop (and may even cause GUI crashes)!
 
 # TODO: There should be "sound-server? ( || ( alsa bluetooth ) )" here, but ALSA is always enabled
+# TODO: Pulseaudio alsa plugin performs runtime check that pulseaudio server connection will work
+# which provides adequate guarantee that alsa-lib will be able to provide audio services.
+# If that works, pulseaudio defaults are loaded into alsa-lib runtime replacing default PCM and CTL.
+# When pipewire-alsa will be able to perform similar check, pipewire-alsa can be enabled unconditionally.
 REQUIRED_USE="
 	jack-sdk? ( !jack-client )
 	system-service? ( systemd )
+	!sound-server? ( !pipewire-alsa )
 "
 
 RESTRICT="!test? ( test )"

--- a/media-video/pipewire/pipewire-0.3.53.ebuild
+++ b/media-video/pipewire/pipewire-0.3.53.ebuild
@@ -89,6 +89,10 @@ RDEPEND="
 		>=media-libs/alsa-lib-1.1.7[${MULTILIB_USEDEP}]
 	)
 	!pipewire-alsa? ( media-plugins/alsa-plugins[${MULTILIB_USEDEP},pulseaudio] )
+	sound-server? (
+		!media-sound/pulseaudio[daemon(+)]
+		!media-sound/pulseaudio-daemon
+	)
 	ssl? ( dev-libs/openssl:= )
 	systemd? ( sys-apps/systemd )
 	system-service? (

--- a/media-video/wireplumber/files/wireplumber-0.4.10-config-disable-sound-server-parts.patch
+++ b/media-video/wireplumber/files/wireplumber-0.4.10-config-disable-sound-server-parts.patch
@@ -1,0 +1,26 @@
+commit 3d86f51d2c43fd76be2450a8c27836fdd8619cfa
+Author: Igor V. Kovalenko <igor.v.kovalenko@gmail.com>
+Date:   Sun May 15 18:19:03 2022 +0300
+
+    config: Disable alsa and bluez monitors by default
+
+diff --git a/src/config/bluetooth.lua.d/50-bluez-config.lua b/src/config/bluetooth.lua.d/50-bluez-config.lua
+index d5727d3..938eae0 100644
+--- a/src/config/bluetooth.lua.d/50-bluez-config.lua
++++ b/src/config/bluetooth.lua.d/50-bluez-config.lua
+@@ -1,4 +1,4 @@
+-bluez_monitor.enabled = true
++bluez_monitor.enabled = false
+ 
+ bluez_monitor.properties = {
+   -- These features do not work on all headsets, so they are enabled
+diff --git a/src/config/main.lua.d/50-alsa-config.lua b/src/config/main.lua.d/50-alsa-config.lua
+index 3468333..d4c065b 100644
+--- a/src/config/main.lua.d/50-alsa-config.lua
++++ b/src/config/main.lua.d/50-alsa-config.lua
+@@ -1,4 +1,4 @@
+-alsa_monitor.enabled = true
++alsa_monitor.enabled = false
+ 
+ alsa_monitor.properties = {
+   -- Create a JACK device. This is not enabled by default because

--- a/media-video/wireplumber/wireplumber-0.4.10-r3.ebuild
+++ b/media-video/wireplumber/wireplumber-0.4.10-r3.ebuild
@@ -68,6 +68,7 @@ PATCHES=(
 	"${FILESDIR}"/${P}-alsa.lua-fix-device-name-deduplication-when-reserva.patch
 	"${FILESDIR}"/${P}-m-default-nodes-don-t-check-if-all-device-nodes-are.patch
 	"${FILESDIR}"/${P}-m-lua-scripting-fix-object-refcounting.patch
+	"${FILESDIR}"/${P}-config-disable-sound-server-parts.patch # defer enabling sound server parts to media-video/pipewire
 )
 
 src_configure() {


### PR DESCRIPTION
These changes work with `pipewire-0.3.53` and `wireplumber-0.4.10-r3` and
- `media-video/wireplumber`: by default disable alsa and bluetooth monitors
- `media-video/pipewire` add USE `sound-server` to pipewire package and conditionally enable wireplumber alsa and bluetooth monitors
- add mutual blockers between `media-video/pipewire[sound-server]` and (`pulseaudio[daemon]` or `pulseaudio-daemon` )
- add new `virtual/sound-server` which can be installed to have any audio server handling `alsa` and/or `bluetooth` devices
- `media-video/pipewire` only allows USE `pipewire-alsa` together with USE `sound-server` to prevent broken alsa output without sound server

With these changes applied and `virtual/sound-server` installed
- `emerge` is able to solve `pulseaudio-daemon` or `pipewire[sound-server]` depending on pipewire USE sound-server value.
- there should be no runtime conflict with pulseaudio anymore (since only one sound server is installed)

NOTE
1. `virtual/sound-server` is optional, but with pure `libpulse` dependencies nothing pulls in any sound server
2. may be a better idea is to not add USE `sound-server` to `media-video/pipewire` but instead create new `media-sound/pipewire-sound-server` package which would depend on both pipewire and wireplumber and will install required configuration parts enabling wireplumber alsa and bluetooth monitors.
3. The mutual blockers are optional, if these are not applied then user still have an option to configure `pipewire+wireplumber` without sound server support.

TODO: maybe fit virtual/sound-server into some profiles