### PR TITLE
sys-fs/udisks: Fix more undefined refeferences

### DIFF
--- a/sys-fs/udisks/files/udisks-2.9.4-undefined.patch
+++ b/sys-fs/udisks/files/udisks-2.9.4-undefined.patch
@@ -1,8 +1,12 @@
 Upstream-PR: https://github.com/storaged-project/udisks/pull/978
+Upstream-PR: https://github.com/storaged-project/udisks/pull/979
+Upstream-Commit: 362cc8f1613193f8e68d13a416421bb36fd7f713
+Upstream-Commit: 6cbce6602ce447127cb4f77706870b6706bf1c5f
+Upstream-Commit: 97bb17425e52ee6b2f11b13b3764d0dd6e8cfc97
 From 362cc8f1613193f8e68d13a416421bb36fd7f713 Mon Sep 17 00:00:00 2001
 From: orbea <orbea@riseup.net>
 Date: Tue, 10 May 2022 09:29:10 -0700
-Subject: [PATCH] modules/btrfs: Add missing dependency
+Subject: [PATCH 1/3] modules/btrfs: Add missing dependency
 
 When building udisks with --enable-btrfs using slibtool instead of GNU
 libtool the build will fail with undefined references.
@@ -24,6 +28,115 @@ index ac8c941849..f96cd16186 100644
  	$(NULL)
  
  libudisks2_btrfs_la_LIBADD =                                                   \
++	$(top_builddir)/src/libudisks-daemon.la                                \
+ 	$(GLIB_LIBS)                                                           \
+ 	$(GIO_LIBS)                                                            \
+ 	$(GUDEV_LIBS)                                                          \
+
+From 6cbce6602ce447127cb4f77706870b6706bf1c5f Mon Sep 17 00:00:00 2001
+From: orbea <orbea@riseup.net>
+Date: Wed, 11 May 2022 07:55:13 -0700
+Subject: [PATCH 2/3] modules/bcache: Add missing dependency
+
+---
+ modules/bcache/Makefile.am | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/modules/bcache/Makefile.am b/modules/bcache/Makefile.am
+index 571541a6d4..7509205ba2 100644
+--- a/modules/bcache/Makefile.am
++++ b/modules/bcache/Makefile.am
+@@ -71,6 +71,7 @@ libudisks2_bcache_la_LDFLAGS =                                                \
+ 	$(NULL)
+ 
+ libudisks2_bcache_la_LIBADD =                                                 \
++	$(top_builddir)/src/libudisks-daemon.la                               \
+ 	$(GLIB_LIBS)                                                          \
+ 	$(GIO_LIBS)                                                           \
+ 	$(GUDEV_LIBS)                                                         \
+
+From 97bb17425e52ee6b2f11b13b3764d0dd6e8cfc97 Mon Sep 17 00:00:00 2001
+From: orbea <orbea@riseup.net>
+Date: Wed, 11 May 2022 07:55:25 -0700
+Subject: [PATCH 3/3] modules/lvm2: Add missing dependency
+
+---
+ modules/lvm2/Makefile.am | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/modules/lvm2/Makefile.am b/modules/lvm2/Makefile.am
+index 3342ad8e9b..67b8aa6b3f 100644
+--- a/modules/lvm2/Makefile.am
++++ b/modules/lvm2/Makefile.am
+@@ -76,6 +76,7 @@ libudisks2_lvm2_la_LDFLAGS =                                                   \
+ 	$(NULL)
+ 
+ libudisks2_lvm2_la_LIBADD =                                                    \
++	$(top_builddir)/src/libudisks-daemon.la                                \
+ 	$(GLIB_LIBS)                                                           \
+ 	$(GIO_LIBS)                                                            \
+ 	$(GUDEV_LIBS)                                                          \
+From 663f8194eeac75ec26fbfbd8855c5873315c495c Mon Sep 17 00:00:00 2001
+From: Tomas Bzatek <tbzatek@redhat.com>
+Date: Fri, 13 May 2022 17:04:52 +0200
+Subject: [PATCH 1/3] modules/iscsi: Add missing linker dependency
+
+---
+ modules/iscsi/Makefile.am | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/modules/iscsi/Makefile.am b/modules/iscsi/Makefile.am
+index 05af5ece29..2cecc300e9 100644
+--- a/modules/iscsi/Makefile.am
++++ b/modules/iscsi/Makefile.am
+@@ -77,6 +77,7 @@ libudisks2_iscsi_la_LDFLAGS =                                                  \
+ 	$(NULL)
+ 
+ libudisks2_iscsi_la_LIBADD =                                                   \
++	$(top_builddir)/src/libudisks-daemon.la                                \
+ 	$(GLIB_LIBS)                                                           \
+ 	$(GIO_LIBS)                                                            \
+ 	$(GUDEV_LIBS)                                                          \
+
+From 8ff2214d740f9819d6ede02534d7d0f23d6a3818 Mon Sep 17 00:00:00 2001
+From: Tomas Bzatek <tbzatek@redhat.com>
+Date: Fri, 13 May 2022 17:05:26 +0200
+Subject: [PATCH 2/3] modules/lsm: Add missing linker dependency
+
+---
+ modules/lsm/Makefile.am | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/modules/lsm/Makefile.am b/modules/lsm/Makefile.am
+index 2193115417..b77a9013fa 100644
+--- a/modules/lsm/Makefile.am
++++ b/modules/lsm/Makefile.am
+@@ -71,6 +71,7 @@ libudisks2_lsm_la_LDFLAGS =                                                    \
+ 	$(NULL)
+ 
+ libudisks2_lsm_la_LIBADD =                                                     \
++	$(top_builddir)/src/libudisks-daemon.la                                \
+ 	$(GLIB_LIBS)                                                           \
+ 	$(GIO_LIBS)                                                            \
+ 	$(GUDEV_LIBS)                                                          \
+
+From 4f59e7fd5b9ad94091230713c28f6a818269d48c Mon Sep 17 00:00:00 2001
+From: Tomas Bzatek <tbzatek@redhat.com>
+Date: Fri, 13 May 2022 17:05:43 +0200
+Subject: [PATCH 3/3] modules/zram: Add missing linker dependency
+
+---
+ modules/zram/Makefile.am | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/modules/zram/Makefile.am b/modules/zram/Makefile.am
+index 9e5e9a6315..40f929583d 100644
+--- a/modules/zram/Makefile.am
++++ b/modules/zram/Makefile.am
+@@ -78,6 +78,7 @@ libudisks2_zram_la_LDFLAGS =                                                   \
+ 	$(NULL)
+ 
+ libudisks2_zram_la_LIBADD =                                                    \
 +	$(top_builddir)/src/libudisks-daemon.la                                \
  	$(GLIB_LIBS)                                                           \
  	$(GIO_LIBS)                                                            \


### PR DESCRIPTION
Follow up to PR https://github.com/gentoo/gentoo/pull/25433

This should solve the undefined references with all of the available modules.

Bug: https://bugs.gentoo.org/782061
Upstream-PR: https://github.com/storaged-project/udisks/pull/978
Upstream-PR: https://github.com/storaged-project/udisks/pull/979
Upstream-Commit: https://github.com/storaged-project/udisks/commit/362cc8f1613193f8e68d13a416421bb36fd7f713
Upstream-Commit: https://github.com/storaged-project/udisks/commit/6cbce6602ce447127cb4f77706870b6706bf1c5f
Upstream-Commit: https://github.com/storaged-project/udisks/commit/97bb17425e52ee6b2f11b13b3764d0dd6e8cfc97