### PR TITLE
app-i18n/scim-bridge: Build fixes

### DIFF
--- a/app-i18n/scim-bridge/files/scim-bridge-0.4.16-fixes-send-function-call.patch
+++ b/app-i18n/scim-bridge/files/scim-bridge-0.4.16-fixes-send-function-call.patch
@@ -1,0 +1,15 @@
+From Fedora:
+https://src.fedoraproject.org/rpms/scim-bridge/c/0532ab48617e02f5bfb1edaba17b22e88d9beaf4
+Index: scim-bridge-0.4.16/agent/scim-bridge-agent-signal-listener.cpp
+===================================================================
+--- scim-bridge-0.4.16.orig/agent/scim-bridge-agent-signal-listener.cpp
++++ scim-bridge-0.4.16/agent/scim-bridge-agent-signal-listener.cpp
+@@ -64,7 +64,7 @@ static void sig_quit (int sig)
+ {
+     if (!signal_occurred) {
+         signal_occurred = true;
+-        send (pipe_in, '\0', sizeof (char), MSG_NOSIGNAL);
++        send (pipe_in, "", sizeof (char), MSG_NOSIGNAL);
+     }
+ }
+ 

--- a/app-i18n/scim-bridge/files/scim-bridge-0.4.16-slibtool.patch
+++ b/app-i18n/scim-bridge/files/scim-bridge-0.4.16-slibtool.patch
@@ -1,0 +1,58 @@
+From 9b46a64aea5adac5b992b4133065b52f527ec881 Mon Sep 17 00:00:00 2001
+From: orbea <orbea@riseup.net>
+Date: Sun, 15 May 2022 10:46:17 -0700
+Subject: [PATCH] client-gtk: Fix X11 undefined references
+
+With slibtool the client-gtk build fails with undefined references for
+-lx11. This happens because the build includes -no-undefined and then
+fails to test for the libX11 pkgconfig file.
+
+GNU libtool silently ignores -no-undefined and hides this issue while
+slibtool does not do this.
+---
+ client-gtk/Makefile.am | 7 ++++---
+ configure.ac           | 6 ++++++
+ 2 files changed, 10 insertions(+), 3 deletions(-)
+
+diff --git a/client-gtk/Makefile.am b/client-gtk/Makefile.am
+index 4318519..27728b8 100644
+--- a/client-gtk/Makefile.am
++++ b/client-gtk/Makefile.am
+@@ -33,13 +33,14 @@ im_scim_bridge_la_SOURCES = im-scim-bridge-gtk.c \
+ 							scim-bridge-client-imcontext-gtk.c \
+ 							scim-bridge-client-key-event-utility-gtk.c
+ 
+-im_scim_bridge_la_CXXFLAGS=@GTK2_CFLAGS@
+-im_scim_bridge_la_CFLAGS  =@GTK2_CFLAGS@
++im_scim_bridge_la_CXXFLAGS=@GTK2_CFLAGS@ @X11_CFLAGS@
++im_scim_bridge_la_CFLAGS  =@GTK2_CFLAGS@ @X11_CFLAGS@
+ 
+ im_scim_bridge_la_LDFLAGS = -rpath $(moduledir) \
+ 		     -avoid-version -no-undefined \
+ 		     -module \
+-		     @GTK2_LIBS@
++		     @GTK2_LIBS@ \
++		     @X11_LIBS@
+ 
+ im_scim_bridge_la_LIBADD  = $(top_srcdir)/common/libscimbridgecommon.la \
+ 							$(top_srcdir)/client-common/libscimbridgeclientcommon.la
+diff --git a/configure.ac b/configure.ac
+index 4c4b1fb..8b2a7a8 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -205,6 +205,12 @@ else
+   enable_qt4_immodule=no
+ fi
+ 
++if test "$SCIM_BRIDGE_BUILD_IMMODULE" = "1"; then
++  PKG_CHECK_MODULES(X11, [x11])
++  AC_SUBST(X11_LIBS)
++  AC_SUBST(X11_CFLAGS)
++fi
++
+ AM_CONDITIONAL(SCIM_BRIDGE_BUILD_TESTS,
+ 		[test "$enable_tests" = "yes"])
+ 
+-- 
+2.35.1
+

--- a/app-i18n/scim-bridge/scim-bridge-0.4.16-r3.ebuild
+++ b/app-i18n/scim-bridge/scim-bridge-0.4.16-r3.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="6"
+EAPI=8
 
 inherit autotools gnome2-utils readme.gentoo-r1
 
@@ -42,6 +42,7 @@ PATCHES=(
 	"${FILESDIR}/${P}+gcc-4.4.patch"
 	"${FILESDIR}/${P}+gcc-4.7.patch"
 	"${FILESDIR}/${P}-configure.ac.patch" #280887
+	"${FILESDIR}/${P}-fixes-send-function-call.patch" # 645168
 )
 
 src_prepare() {

--- a/app-i18n/scim-bridge/scim-bridge-0.4.16-r3.ebuild
+++ b/app-i18n/scim-bridge/scim-bridge-0.4.16-r3.ebuild
@@ -43,6 +43,7 @@ PATCHES=(
 	"${FILESDIR}/${P}+gcc-4.7.patch"
 	"${FILESDIR}/${P}-configure.ac.patch" #280887
 	"${FILESDIR}/${P}-fixes-send-function-call.patch" # 645168
+	"${FILESDIR}/${P}-slibtool.patch" # 779121
 )
 
 src_prepare() {


### PR DESCRIPTION
This fixes two unrelated build issues with `app-i18n/scim-bridge`.

1. Uses a Fedora patch to fix a `-fpermissive` build issue.
2. Uses pkg-config to find `-lx11` and fix `-no-undefined` build issues that GNU libtool silently ignores.

Bug: https://bugs.gentoo.org/645168
Bug: https://bugs.gentoo.org/779121
Fedora Commit: https://src.fedoraproject.org/rpms/scim-bridge/c/0532ab48617e02f5bfb1edaba17b22e88d9beaf4
Upstream PR: https://sourceforge.net/p/scim/patches/15/