### PR TITLE
profiles/arch/riscv: clean up package.use.mask

### DIFF
--- a/app-text/nuspell/nuspell-5.1.0.ebuild
+++ b/app-text/nuspell/nuspell-5.1.0.ebuild
@@ -11,7 +11,7 @@ SRC_URI="https://github.com/nuspell/nuspell/archive/v${PV}.tar.gz -> ${P}.tar.gz
 
 LICENSE="LGPL-3+"
 SLOT="0/5"  # due to libnuspell.so.5
-KEYWORDS="amd64 x86"
+KEYWORDS="amd64 ~riscv x86"
 IUSE="doc test"
 
 RDEPEND=">=dev-libs/icu-60"

--- a/dev-python/pebble/pebble-4.6.3.ebuild
+++ b/dev-python/pebble/pebble-4.6.3.ebuild
@@ -17,6 +17,6 @@ S=${WORKDIR}/${P^}
 
 LICENSE="LGPL-3+"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~m68k ppc ppc64 ~s390 sparc x86"
+KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~m68k ppc ppc64 ~riscv ~s390 sparc x86"
 
 distutils_enable_tests pytest

--- a/kde-plasma/breeze-grub/breeze-grub-5.24.5.ebuild
+++ b/kde-plasma/breeze-grub/breeze-grub-5.24.5.ebuild
@@ -10,7 +10,7 @@ DESCRIPTION="Breeze theme for GRUB"
 
 LICENSE="GPL-3+"
 SLOT="5"
-KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 src_prepare() { default; }

--- a/profiles/arch/riscv/package.use.mask
+++ b/profiles/arch/riscv/package.use.mask
@@ -89,12 +89,13 @@ dev-python/backrefs doc
 dev-python/pyspelling doc
 dev-python/wcmatch doc
 
-# Alex Fan <alexfanqi@yahoo.com> (2021-09-13)
+# Alex Fan <alex.fan.q@gmail.com> (2022-05-16)
 # These depend on Haskell:
 #  - dev-vcs/darcs
 app-portage/layman darcs
 #  - app-text/pandoc
 sys-cluster/ceph pmdk
+app-text/nuspell doc
 
 # Alex Fan <alexfanqi@yahoo.com> (2021-09-15)
 # Marek Szuba <marecki@gentoo.org> (2021-09-07)

--- a/profiles/arch/riscv/package.use.mask
+++ b/profiles/arch/riscv/package.use.mask
@@ -147,7 +147,7 @@ gnome-base/gnome-shell browser-extension
 kde-plasma/plasma-meta plymouth
 
 # Marek Szuba <marecki@gentoo.org> (2021-08-17)
-# sys-libs/libfaketime does not work properly on this arch
+# sys-libs/libfaketime does not work properly on this arch, bug #844958
 sys-auth/sssd test
 
 # Marek Szuba <marecki@gentoo.org> (2021-08-11)
@@ -194,7 +194,7 @@ media-gfx/gimp lua
 www-servers/nginx nginx_modules_http_lua
 
 # Marek Szuba <marecki@gentoo.org> (2021-07-11)
-# Causes 35 tests to fail with "fatal llvm error"
+# Causes 35 tests to fail with "fatal llvm error", bug #844946
 dev-db/postgresql llvm
 
 # Marek Szuba <marecki@gentoo.org> (2021-07-05)
@@ -202,7 +202,7 @@ dev-db/postgresql llvm
 sys-cluster/slurm ucx
 
 # Marek Szuba <marecki@gentoo.org> (2021-07-05)
-# net-dialup/mgetty fails to compile on this arch
+# net-dialup/mgetty fails to compile on this arch, bug #844955
 mail-mta/courier fax
 
 # Marek Szuba <marecki@gentoo.org> (2021-07-05)

--- a/profiles/arch/riscv/package.use.mask
+++ b/profiles/arch/riscv/package.use.mask
@@ -114,12 +114,6 @@ dev-ruby/dalli test
 # Requires CPU with SSSE3 support
 net-analyzer/suricata hyperscan
 
-# Marek Szuba <marecki@gentoo.org> (2021-09-02)
-# dev-python/pebble not keyworded here due to failing tests.
-# That said, with pebble-4.6.3 installed manually
-# (and without testing) all nbconvert-6.0.7 tests passed.
-dev-python/nbconvert test
-
 # Yixun Lan <dlan@gentoo.org> (2021-08-29)
 #  sys-apps/fwupd not tested, USE=spi,uefi,dell
 #  sys-apps/flashrom no risc-v support, bug 810880

--- a/profiles/arch/riscv/package.use.mask
+++ b/profiles/arch/riscv/package.use.mask
@@ -228,8 +228,3 @@ sys-block/thin-provisioning-tools test
 dev-libs/libpcre2 jit
 dev-libs/libpcre jit
 www-servers/nginx pcre-jit
-
-# app-shells/fish not keyworded due to failing tests (Bug #807742).
-# That said, with fish-3.3.1-r1 installed manually (and without testing)
-# all argcomplete-1.12.3 tests passed.
-dev-python/argcomplete test

--- a/profiles/arch/riscv/package.use.mask
+++ b/profiles/arch/riscv/package.use.mask
@@ -93,10 +93,6 @@ dev-python/backrefs doc
 dev-python/pyspelling doc
 dev-python/wcmatch doc
 
-# Marek Szuba <marecki@gentoo.org> (2021-09-19)
-# media-gfx/nvidia-texture-tools reports arch as unknown, fails to build
-media-libs/devil nvtt
-
 # Alex Fan <alexfanqi@yahoo.com> (2021-09-13)
 # These depend on Haskell:
 #  - dev-vcs/darcs

--- a/profiles/arch/riscv/package.use.mask
+++ b/profiles/arch/riscv/package.use.mask
@@ -151,7 +151,7 @@ gnome-base/gnome-shell browser-extension
 
 # Alex Fan <alexfanqi@yahoo.com> (2021-08-17)
 # dependencies not keyworded/tested
-kde-plasma/plasma-meta grub plymouth
+kde-plasma/plasma-meta plymouth
 
 # Marek Szuba <marecki@gentoo.org> (2021-08-17)
 # sys-libs/libfaketime does not work properly on this arch

--- a/profiles/arch/riscv/package.use.mask
+++ b/profiles/arch/riscv/package.use.mask
@@ -213,8 +213,6 @@ mail-mta/courier fax
 #  - sci-libs/vtk
 media-libs/opencv vtk
 sci-libs/opencascade vtk
-#  - dev-util/aruba
-sys-block/thin-provisioning-tools test
 
 # This doesn't work for (any) riscv yet.
 dev-libs/libpcre2 jit

--- a/profiles/arch/riscv/package.use.mask
+++ b/profiles/arch/riscv/package.use.mask
@@ -24,10 +24,6 @@ net-ftp/proftpd memcache
 # so avoid keywording 4.8 slot
 dev-lisp/clisp berkdb
 
-# Matt Turner <mattst88@gentoo.org> (2022-04-18)
-# app-text/nuspell is not keyworded
-app-text/enchant nuspell
-
 # Jakov Smolić <jsmolic@gentoo.org> (2022-04-07)
 # Depends on sys-cluster/ceph which pulls in valgrind, which is
 # unavailable on riscv currently

--- a/profiles/arch/riscv/package.use.mask
+++ b/profiles/arch/riscv/package.use.mask
@@ -82,10 +82,6 @@ sci-astronomy/stellarium webengine
 # but with it installed, anyio passes all tests
 dev-python/anyio test
 
-# Alex Fan <alex.fan.q@gmail.com> (2021-11-19)
-# depends on dev-lang/ocaml
-app-accessibility/brltty ocaml ocamlopt
-
 # Marek Szuba <marecki@gentoo.org> (2021-09-23)
 # mkdocs ecosystem only partly keyworded on riscv, has rather messy
 # Python-target requirements.


### PR DESCRIPTION
Tested on qemu user and sifive unmatched. 

Add reference bug number to some masks

This also resolves these keywording bug:
Bug: https://bugs.gentoo.org/show_bug.cgi?id=844934
Bug: https://bugs.gentoo.org/show_bug.cgi?id=844940