### PR TITLE
ghc-package.eclass: Avoid reserved function name

### DIFF
--- a/eclass/ghc-package.eclass
+++ b/eclass/ghc-package.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: ghc-package.eclass
@@ -152,10 +152,10 @@ ghc-supports-parallel-make() {
 	$(ghc-getghc) --info | grep "Support parallel --make" | grep -q "YES"
 }
 
-# @FUNCTION: ghc-extractportageversion
+# @FUNCTION: ghc-extract-pm-version
 # @DESCRIPTION:
 # extract the version of a portage-installed package
-ghc-extractportageversion() {
+ghc-extract-pm-version() {
 	local pkg
 	local version
 	pkg="$(best_version $1)"

--- a/eclass/haskell-cabal.eclass
+++ b/eclass/haskell-cabal.eclass
@@ -183,7 +183,7 @@ cabal-version() {
 		else
 			# We ask portage, not ghc, so that we only pick up
 			# portage-installed cabal versions.
-			_CABAL_VERSION_CACHE="$(ghc-extractportageversion dev-haskell/cabal)"
+			_CABAL_VERSION_CACHE="$(ghc-extract-pm-version dev-haskell/cabal)"
 		fi
 	fi
 	echo "${_CABAL_VERSION_CACHE}"


### PR DESCRIPTION
Rename function ghc-extractportageversion to ghc-extract-pm-version.
    
Closes: https://bugs.gentoo.org/843713
