### PR TITLE
*/*: drop stale GCC checks

### DIFF
--- a/app-crypt/pinentry/pinentry-1.1.1-r1.ebuild
+++ b/app-crypt/pinentry/pinentry-1.1.1-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -52,7 +52,7 @@ src_prepare() {
 }
 
 src_configure() {
-	[[ "$(gcc-major-version)" -ge 5 ]] && append-cxxflags -std=gnu++11
+	append-cxxflags -std=gnu++11
 
 	export QTLIB="$(qt5_get_libdir)"
 

--- a/app-crypt/pinentry/pinentry-1.2.0.ebuild
+++ b/app-crypt/pinentry/pinentry-1.2.0.ebuild
@@ -52,7 +52,7 @@ src_prepare() {
 }
 
 src_configure() {
-	[[ "$(gcc-major-version)" -ge 5 ]] && append-cxxflags -std=gnu++11
+	append-cxxflags -std=gnu++11
 
 	export QTLIB="$(qt5_get_libdir)"
 

--- a/app-editors/scite/scite-5.1.1.ebuild
+++ b/app-editors/scite/scite-5.1.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -35,24 +35,6 @@ BDEPEND="
 DOCS=("../README")
 
 S="${WORKDIR}/${PN}/gtk"
-
-pkg_pretend() {
-	if tc-is-clang ; then
-		# need c++17 features
-		[[ "${MERGE_TYPE}" != "binary" &&
-		$(clang-major-version) -lt 5 ]] &&
-		die "Sorry, SCiTE uses C++17 Features and needs >sys-devel/clang-5
-		($(clang-major-version))."
-
-	elif tc-is-gcc; then
-		# older gcc is not supported
-		[[ "${MERGE_TYPE}" != "binary" &&
-		$(gcc-major-version) -lt 7 ]] &&
-		die "Sorry, Scite uses C++17 Features, need >sys-devel/gcc-7."
-	else
-		die "Either gcc or clang should be configured for building scite"
-	fi
-}
 
 pkg_setup() {
 	use lua && lua-single_pkg_setup

--- a/app-editors/scite/scite-5.1.3.ebuild
+++ b/app-editors/scite/scite-5.1.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -35,24 +35,6 @@ BDEPEND="
 DOCS=("../README")
 
 S="${WORKDIR}/${PN}/gtk"
-
-pkg_pretend() {
-	if tc-is-clang ; then
-		# need c++17 features
-		[[ "${MERGE_TYPE}" != "binary" &&
-		$(clang-major-version) -lt 5 ]] &&
-		die "Sorry, SCiTE uses C++17 Features and needs >sys-devel/clang-5
-		($(clang-major-version))."
-
-	elif tc-is-gcc; then
-		# older gcc is not supported
-		[[ "${MERGE_TYPE}" != "binary" &&
-		$(gcc-major-version) -lt 7 ]] &&
-		die "Sorry, Scite uses C++17 Features, need >sys-devel/gcc-7."
-	else
-		die "Either gcc or clang should be configured for building scite"
-	fi
-}
 
 pkg_setup() {
 	use lua && lua-single_pkg_setup

--- a/app-editors/scite/scite-5.1.6.ebuild
+++ b/app-editors/scite/scite-5.1.6.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -35,24 +35,6 @@ BDEPEND="
 DOCS=("../README")
 
 S="${WORKDIR}/${PN}/gtk"
-
-pkg_pretend() {
-	if tc-is-clang ; then
-		# need c++17 features
-		[[ "${MERGE_TYPE}" != "binary" &&
-		$(clang-major-version) -lt 5 ]] &&
-		die "Sorry, SCiTE uses C++17 Features and needs >sys-devel/clang-5
-		($(clang-major-version))."
-
-	elif tc-is-gcc; then
-		# older gcc is not supported
-		[[ "${MERGE_TYPE}" != "binary" &&
-		$(gcc-major-version) -lt 7 ]] &&
-		die "Sorry, Scite uses C++17 Features, need >sys-devel/gcc-7."
-	else
-		die "Either gcc or clang should be configured for building scite"
-	fi
-}
 
 pkg_setup() {
 	use lua && lua-single_pkg_setup

--- a/app-office/gnucash/gnucash-4.4.ebuild
+++ b/app-office/gnucash/gnucash-4.4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -82,10 +82,6 @@ BDEPEND="
 	dev-lang/swig
 	dev-util/cmake
 	virtual/pkgconfig
-	|| (
-		>=sys-devel/gcc-8:*
-		>=sys-devel/clang-6:*
-	)
 "
 
 PDEPEND="doc? (
@@ -101,18 +97,6 @@ PATCHES=(
 )
 
 S="${WORKDIR}/${PN}-$(ver_cut 1-2)"
-
-pkg_pretend() {
-	if tc-is-gcc; then
-		if [[ $(gcc-major-version) -lt 8 ]]; then
-			die "GnuCash needs at least GCC version 8."
-		fi
-	elif tc-is-clang; then
-		if [[ $(clang-major-version) -lt 6 ]]; then
-			die "GnuCash needs at least clang version 6."
-		fi
-	fi
-}
 
 pkg_setup() {
 	use python && python-single-r1_pkg_setup

--- a/app-office/gnucash/gnucash-4.5.ebuild
+++ b/app-office/gnucash/gnucash-4.5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -86,10 +86,6 @@ BDEPEND="
 	dev-lang/swig
 	dev-util/cmake
 	virtual/pkgconfig
-	|| (
-		>=sys-devel/gcc-8:*
-		>=sys-devel/clang-6:*
-	)
 "
 
 PDEPEND="doc? (
@@ -103,18 +99,6 @@ PATCHES=(
 )
 
 S="${WORKDIR}/${PN}-$(ver_cut 1-2)"
-
-pkg_pretend() {
-	if tc-is-gcc; then
-		if [[ $(gcc-major-version) -lt 8 ]]; then
-			die "GnuCash needs at least GCC version 8."
-		fi
-	elif tc-is-clang; then
-		if [[ $(clang-major-version) -lt 6 ]]; then
-			die "GnuCash needs at least clang version 6."
-		fi
-	fi
-}
 
 pkg_setup() {
 	use python && python-single-r1_pkg_setup

--- a/app-office/gnucash/gnucash-4.8.ebuild
+++ b/app-office/gnucash/gnucash-4.8.ebuild
@@ -86,10 +86,6 @@ BDEPEND="
 	dev-lang/swig
 	dev-util/cmake
 	virtual/pkgconfig
-	|| (
-		>=sys-devel/gcc-8:*
-		>=sys-devel/clang-6:*
-	)
 "
 
 PDEPEND="doc? (
@@ -103,18 +99,6 @@ PATCHES=(
 )
 
 S="${WORKDIR}/${PN}-$(ver_cut 1-2)"
-
-pkg_pretend() {
-	if tc-is-gcc; then
-		if [[ $(gcc-major-version) -lt 8 ]]; then
-			die "GnuCash needs at least GCC version 8."
-		fi
-	elif tc-is-clang; then
-		if [[ $(clang-major-version) -lt 6 ]]; then
-			die "GnuCash needs at least clang version 6."
-		fi
-	fi
-}
 
 pkg_setup() {
 	use python && python-single-r1_pkg_setup

--- a/app-text/calibre/calibre-5.16.1-r1.ebuild
+++ b/app-text/calibre/calibre-5.16.1-r1.ebuild
@@ -109,14 +109,6 @@ DEPEND="${COMMON_DEPEND}
 	>=virtual/podofo-build-0.9.6_pre20171027
 	virtual/pkgconfig"
 
-pkg_pretend() {
-	if [[ ${MERGE_TYPE} != binary ]] && tc-is-gcc && [[ $(gcc-major-version) -lt 6 ]]; then
-		eerror "Calibre cannot be built with this version of gcc."
-		eerror "You need at least gcc-6.0"
-		die "Your C compiler is too old for this package."
-	fi
-}
-
 src_prepare() {
 	# no_updates: do not annoy user with "new version is availible all the time
 	# disable_plugins: walking sec-hole, wait for upstream to use GHNS interface

--- a/app-text/calibre/calibre-5.39.1.ebuild
+++ b/app-text/calibre/calibre-5.39.1.ebuild
@@ -134,14 +134,6 @@ PATCHES=(
 	"${FILESDIR}/${PN}-5.31.0-qt-image-test.patch"
 )
 
-pkg_pretend() {
-	if [[ ${MERGE_TYPE} != binary ]] && tc-is-gcc && [[ $(gcc-major-version) -lt 6 ]]; then
-		eerror "Calibre cannot be built with this version of gcc."
-		eerror "You need at least gcc-6.0"
-		die "Your C compiler is too old for this package."
-	fi
-}
-
 src_prepare() {
 	default
 

--- a/app-text/calibre/calibre-5.40.0.ebuild
+++ b/app-text/calibre/calibre-5.40.0.ebuild
@@ -134,14 +134,6 @@ PATCHES=(
 	"${FILESDIR}/${PN}-5.31.0-qt-image-test.patch"
 )
 
-pkg_pretend() {
-	if [[ ${MERGE_TYPE} != binary ]] && tc-is-gcc && [[ $(gcc-major-version) -lt 6 ]]; then
-		eerror "Calibre cannot be built with this version of gcc."
-		eerror "You need at least gcc-6.0"
-		die "Your C compiler is too old for this package."
-	fi
-}
-
 src_prepare() {
 	default
 

--- a/app-text/calibre/calibre-5.41.0.ebuild
+++ b/app-text/calibre/calibre-5.41.0.ebuild
@@ -134,14 +134,6 @@ PATCHES=(
 	"${FILESDIR}/${PN}-5.31.0-qt-image-test.patch"
 )
 
-pkg_pretend() {
-	if [[ ${MERGE_TYPE} != binary ]] && tc-is-gcc && [[ $(gcc-major-version) -lt 6 ]]; then
-		eerror "Calibre cannot be built with this version of gcc."
-		eerror "You need at least gcc-6.0"
-		die "Your C compiler is too old for this package."
-	fi
-}
-
 src_prepare() {
 	default
 

--- a/app-text/calibre/calibre-5.42.0-r1.ebuild
+++ b/app-text/calibre/calibre-5.42.0-r1.ebuild
@@ -135,14 +135,6 @@ PATCHES=(
 	"${FILESDIR}/${PN}-5.31.0-qt-image-test.patch"
 )
 
-pkg_pretend() {
-	if [[ ${MERGE_TYPE} != binary ]] && tc-is-gcc && [[ $(gcc-major-version) -lt 6 ]]; then
-		eerror "Calibre cannot be built with this version of gcc."
-		eerror "You need at least gcc-6.0"
-		die "Your C compiler is too old for this package."
-	fi
-}
-
 src_prepare() {
 	default
 

--- a/app-text/yodl/yodl-4.03.00.ebuild
+++ b/app-text/yodl/yodl-4.03.00.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -22,16 +22,6 @@ BDEPEND="
 		dev-texlive/texlive-plaingeneric
 	)
 "
-
-pkg_pretend() {
-	if [[ ${MERGE_TYPE} != "binary" ]]; then
-		if tc-is-gcc && [[ $(gcc-major-version) -lt 8 ]]; then
-			die "Your compiler doesn't fully support C++17. Use GCC 8 or newer."
-		elif tc-is-clang && [[ $(clang-major-version) -lt 6 ]]; then
-			die "Your compiler doesn't fully support C++17. Use Clang 6 or newer."
-		fi
-	fi
-}
 
 src_prepare() {
 	sed -e "/DOC.* =/s/yodl\(-doc\)\?/${PF}/" \

--- a/dev-db/cockroach/cockroach-19.1.1-r1.ebuild
+++ b/dev-db/cockroach/cockroach-19.1.1-r1.ebuild
@@ -32,11 +32,6 @@ QA_EXECSTACK="usr/bin/cockroach"
 
 pkg_pretend() {
 	check-reqs_pkg_pretend
-	if [[ ${MERGE_TYPE} != binary && $(gcc-major-version) -lt 6 ]]; then
-		eerror "Cockroach cannot be built with this version of gcc."
-		eerror "You need at least gcc-6.0"
-		die "Your C compiler is too old for this package."
-	fi
 }
 
 pkg_setup() {

--- a/dev-db/cockroach/cockroach-2.1.5-r1.ebuild
+++ b/dev-db/cockroach/cockroach-2.1.5-r1.ebuild
@@ -32,11 +32,6 @@ QA_EXECSTACK="usr/bin/cockroach"
 
 pkg_pretend() {
 	check-reqs_pkg_pretend
-	if [[ ${MERGE_TYPE} != binary && $(gcc-major-version) -lt 6 ]]; then
-		eerror "Cockroach cannot be built with this version of gcc."
-		eerror "You need at least gcc-6.0"
-		die "Your C compiler is too old for this package."
-	fi
 }
 
 pkg_setup() {

--- a/dev-db/mariadb/mariadb-10.2.41.ebuild
+++ b/dev-db/mariadb/mariadb-10.2.41.ebuild
@@ -81,9 +81,7 @@ COMMON_DEPEND="
 	>=dev-libs/libpcre-8.41-r1:3=
 	virtual/libcrypt:=
 "
-BDEPEND="virtual/yacc
-	|| ( >=sys-devel/gcc-3.4.6 >=sys-devel/gcc-apple-4.0 )
-"
+BDEPEND="virtual/yacc"
 DEPEND="static? ( sys-libs/ncurses[static-libs] )
 	server? (
 		extraengine? ( jdbc? ( >=virtual/jdk-1.8 ) )
@@ -185,25 +183,6 @@ mysql_init_vars() {
 
 pkg_setup() {
 	if [[ ${MERGE_TYPE} != binary ]] ; then
-		local GCC_MAJOR_SET=$(gcc-major-version)
-		local GCC_MINOR_SET=$(gcc-minor-version)
-
-		if use tokudb && [[ ${GCC_MAJOR_SET} -lt 4 || \
-			${GCC_MAJOR_SET} -eq 4 && ${GCC_MINOR_SET} -lt 7 ]] ; then
-			eerror "${PN} with tokudb needs to be built with gcc-4.7 or later."
-			eerror "Please use gcc-config to switch to gcc-4.7 or later version."
-			die
-		fi
-
-		# Bug 565584.  InnoDB now requires atomic functions introduced with gcc-4.7 on
-		# non x86{,_64} arches
-		if ! use amd64 && ! use x86 && [[ ${GCC_MAJOR_SET} -lt 4 || \
-			${GCC_MAJOR_SET} -eq 4 && ${GCC_MINOR_SET} -lt 7 ]] ; then
-			eerror "${PN} needs to be built with gcc-4.7 or later."
-			eerror "Please use gcc-config to switch to gcc-4.7 or later version."
-			die
-		fi
-
 		if has test ${FEATURES} ; then
 			# Bug #213475 - MySQL _will_ object strenuously if your machine is named
 			# localhost. Also causes weird failures.

--- a/dev-db/mariadb/mariadb-10.3.32.ebuild
+++ b/dev-db/mariadb/mariadb-10.3.32.ebuild
@@ -81,9 +81,7 @@ COMMON_DEPEND="
 	>=dev-libs/libpcre-8.41-r1:3=
 	virtual/libcrypt:=
 "
-BDEPEND="virtual/yacc
-	|| ( >=sys-devel/gcc-3.4.6 >=sys-devel/gcc-apple-4.0 )
-"
+BDEPEND="virtual/yacc"
 DEPEND="static? ( sys-libs/ncurses[static-libs] )
 	server? (
 		extraengine? ( jdbc? ( >=virtual/jdk-1.8 ) )
@@ -176,25 +174,6 @@ mysql_init_vars() {
 
 pkg_setup() {
 	if [[ ${MERGE_TYPE} != binary ]] ; then
-		local GCC_MAJOR_SET=$(gcc-major-version)
-		local GCC_MINOR_SET=$(gcc-minor-version)
-
-		if use tokudb && [[ ${GCC_MAJOR_SET} -lt 4 || \
-			${GCC_MAJOR_SET} -eq 4 && ${GCC_MINOR_SET} -lt 7 ]] ; then
-			eerror "${PN} with tokudb needs to be built with gcc-4.7 or later."
-			eerror "Please use gcc-config to switch to gcc-4.7 or later version."
-			die
-		fi
-
-		# Bug 565584.  InnoDB now requires atomic functions introduced with gcc-4.7 on
-		# non x86{,_64} arches
-		if ! use amd64 && ! use x86 && [[ ${GCC_MAJOR_SET} -lt 4 || \
-			${GCC_MAJOR_SET} -eq 4 && ${GCC_MINOR_SET} -lt 7 ]] ; then
-			eerror "${PN} needs to be built with gcc-4.7 or later."
-			eerror "Please use gcc-config to switch to gcc-4.7 or later version."
-			die
-		fi
-
 		if has test ${FEATURES} ; then
 			# Bug #213475 - MySQL _will_ object strenuously if your machine is named
 			# localhost. Also causes weird failures.

--- a/dev-db/mariadb/mariadb-10.4.22.ebuild
+++ b/dev-db/mariadb/mariadb-10.4.22.ebuild
@@ -81,9 +81,7 @@ COMMON_DEPEND="
 	>=dev-libs/libpcre-8.41-r1:3=
 	virtual/libcrypt:=
 "
-BDEPEND="virtual/yacc
-	|| ( >=sys-devel/gcc-3.4.6 >=sys-devel/gcc-apple-4.0 )
-"
+BDEPEND="virtual/yacc"
 DEPEND="static? ( sys-libs/ncurses[static-libs] )
 	server? (
 		extraengine? ( jdbc? ( >=virtual/jdk-1.8 ) )
@@ -177,25 +175,6 @@ mysql_init_vars() {
 
 pkg_setup() {
 	if [[ ${MERGE_TYPE} != binary ]] ; then
-		local GCC_MAJOR_SET=$(gcc-major-version)
-		local GCC_MINOR_SET=$(gcc-minor-version)
-
-		if use tokudb && [[ ${GCC_MAJOR_SET} -lt 4 || \
-			${GCC_MAJOR_SET} -eq 4 && ${GCC_MINOR_SET} -lt 7 ]] ; then
-			eerror "${PN} with tokudb needs to be built with gcc-4.7 or later."
-			eerror "Please use gcc-config to switch to gcc-4.7 or later version."
-			die
-		fi
-
-		# Bug 565584.  InnoDB now requires atomic functions introduced with gcc-4.7 on
-		# non x86{,_64} arches
-		if ! use amd64 && ! use x86 && [[ ${GCC_MAJOR_SET} -lt 4 || \
-			${GCC_MAJOR_SET} -eq 4 && ${GCC_MINOR_SET} -lt 7 ]] ; then
-			eerror "${PN} needs to be built with gcc-4.7 or later."
-			eerror "Please use gcc-config to switch to gcc-4.7 or later version."
-			die
-		fi
-
 		if has test ${FEATURES} ; then
 			# Bug #213475 - MySQL _will_ object strenuously if your machine is named
 			# localhost. Also causes weird failures.

--- a/dev-db/mariadb/mariadb-10.5.13.ebuild
+++ b/dev-db/mariadb/mariadb-10.5.13.ebuild
@@ -87,9 +87,7 @@ COMMON_DEPEND="
 		>=dev-libs/openssl-1.0.0:0=
 	)
 "
-BDEPEND="virtual/yacc
-	|| ( >=sys-devel/gcc-3.4.6 >=sys-devel/gcc-apple-4.0 )
-"
+BDEPEND="virtual/yacc"
 DEPEND="${COMMON_DEPEND}
 	server? (
 		extraengine? ( jdbc? ( >=virtual/jdk-1.8 ) )
@@ -185,18 +183,6 @@ mysql_init_vars() {
 
 pkg_setup() {
 	if [[ ${MERGE_TYPE} != binary ]] ; then
-		local GCC_MAJOR_SET=$(gcc-major-version)
-		local GCC_MINOR_SET=$(gcc-minor-version)
-
-		# Bug 565584.  InnoDB now requires atomic functions introduced with gcc-4.7 on
-		# non x86{,_64} arches
-		if ! use amd64 && ! use x86 && [[ ${GCC_MAJOR_SET} -lt 4 || \
-			${GCC_MAJOR_SET} -eq 4 && ${GCC_MINOR_SET} -lt 7 ]] ; then
-			eerror "${PN} needs to be built with gcc-4.7 or later."
-			eerror "Please use gcc-config to switch to gcc-4.7 or later version."
-			die
-		fi
-
 		if has test ${FEATURES} ; then
 			# Bug #213475 - MySQL _will_ object strenuously if your machine is named
 			# localhost. Also causes weird failures.

--- a/dev-db/mariadb/mariadb-10.5.15.ebuild
+++ b/dev-db/mariadb/mariadb-10.5.15.ebuild
@@ -87,9 +87,7 @@ COMMON_DEPEND="
 		>=dev-libs/openssl-1.0.0:0=
 	)
 "
-BDEPEND="virtual/yacc
-	|| ( >=sys-devel/gcc-3.4.6 >=sys-devel/gcc-apple-4.0 )
-"
+BDEPEND="virtual/yacc"
 DEPEND="${COMMON_DEPEND}
 	server? (
 		extraengine? ( jdbc? ( >=virtual/jdk-1.8 ) )
@@ -185,18 +183,6 @@ mysql_init_vars() {
 
 pkg_setup() {
 	if [[ ${MERGE_TYPE} != binary ]] ; then
-		local GCC_MAJOR_SET=$(gcc-major-version)
-		local GCC_MINOR_SET=$(gcc-minor-version)
-
-		# Bug 565584.  InnoDB now requires atomic functions introduced with gcc-4.7 on
-		# non x86{,_64} arches
-		if ! use amd64 && ! use x86 && [[ ${GCC_MAJOR_SET} -lt 4 || \
-			${GCC_MAJOR_SET} -eq 4 && ${GCC_MINOR_SET} -lt 7 ]] ; then
-			eerror "${PN} needs to be built with gcc-4.7 or later."
-			eerror "Please use gcc-config to switch to gcc-4.7 or later version."
-			die
-		fi
-
 		if has test ${FEATURES} ; then
 			# Bug #213475 - MySQL _will_ object strenuously if your machine is named
 			# localhost. Also causes weird failures.

--- a/dev-db/mariadb/mariadb-10.6.5-r1.ebuild
+++ b/dev-db/mariadb/mariadb-10.6.5-r1.ebuild
@@ -87,9 +87,7 @@ COMMON_DEPEND="
 		>=dev-libs/openssl-1.0.0:0=
 	)
 "
-BDEPEND="virtual/yacc
-	|| ( >=sys-devel/gcc-3.4.6 >=sys-devel/gcc-apple-4.0 )
-"
+BDEPEND="virtual/yacc"
 DEPEND="${COMMON_DEPEND}
 	server? (
 		extraengine? ( jdbc? ( >=virtual/jdk-1.8 ) )
@@ -185,18 +183,6 @@ mysql_init_vars() {
 
 pkg_setup() {
 	if [[ ${MERGE_TYPE} != binary ]] ; then
-		local GCC_MAJOR_SET=$(gcc-major-version)
-		local GCC_MINOR_SET=$(gcc-minor-version)
-
-		# Bug 565584.  InnoDB now requires atomic functions introduced with gcc-4.7 on
-		# non x86{,_64} arches
-		if ! use amd64 && ! use x86 && [[ ${GCC_MAJOR_SET} -lt 4 || \
-			${GCC_MAJOR_SET} -eq 4 && ${GCC_MINOR_SET} -lt 7 ]] ; then
-			eerror "${PN} needs to be built with gcc-4.7 or later."
-			eerror "Please use gcc-config to switch to gcc-4.7 or later version."
-			die
-		fi
-
 		if has test ${FEATURES} ; then
 			# Bug #213475 - MySQL _will_ object strenuously if your machine is named
 			# localhost. Also causes weird failures.

--- a/dev-lang/python/python-2.7.18_p15.ebuild
+++ b/dev-lang/python/python-2.7.18_p15.ebuild
@@ -142,9 +142,7 @@ src_configure() {
 		einfo "Disabled modules: ${PYTHON_DISABLE_MODULES}"
 	fi
 
-	if [[ "$(gcc-major-version)" -ge 4 ]]; then
-		append-flags -fwrapv
-	fi
+	append-flags -fwrapv
 
 	filter-flags -malign-double
 

--- a/dev-lang/python/python-3.10.4.ebuild
+++ b/dev-lang/python/python-3.10.4.ebuild
@@ -147,9 +147,7 @@ src_configure() {
 		einfo "Disabled modules: ${PYTHON_DISABLE_MODULES}"
 	fi
 
-	if [[ "$(gcc-major-version)" -ge 4 ]]; then
-		append-flags -fwrapv
-	fi
+	append-flags -fwrapv
 
 	filter-flags -malign-double
 

--- a/dev-lang/python/python-3.10.4_p1.ebuild
+++ b/dev-lang/python/python-3.10.4_p1.ebuild
@@ -147,9 +147,7 @@ src_configure() {
 		einfo "Disabled modules: ${PYTHON_DISABLE_MODULES}"
 	fi
 
-	if [[ "$(gcc-major-version)" -ge 4 ]]; then
-		append-flags -fwrapv
-	fi
+	append-flags -fwrapv
 
 	filter-flags -malign-double
 

--- a/dev-lang/python/python-3.11.0_beta1-r2.ebuild
+++ b/dev-lang/python/python-3.11.0_beta1-r2.ebuild
@@ -134,9 +134,7 @@ src_configure() {
 	# disable automagic bluetooth headers detection
 	use bluetooth || export ac_cv_header_bluetooth_bluetooth_h=no
 
-	if [[ "$(gcc-major-version)" -ge 4 ]]; then
-		append-flags -fwrapv
-	fi
+	append-flags -fwrapv
 
 	filter-flags -malign-double
 

--- a/dev-lang/python/python-3.7.13.ebuild
+++ b/dev-lang/python/python-3.7.13.ebuild
@@ -126,9 +126,7 @@ src_configure() {
 		einfo "Disabled modules: ${PYTHON_DISABLE_MODULES}"
 	fi
 
-	if [[ "$(gcc-major-version)" -ge 4 ]]; then
-		append-flags -fwrapv
-	fi
+	append-flags -fwrapv
 
 	filter-flags -malign-double
 

--- a/dev-lang/python/python-3.8.13.ebuild
+++ b/dev-lang/python/python-3.8.13.ebuild
@@ -130,9 +130,7 @@ src_configure() {
 		einfo "Disabled modules: ${PYTHON_DISABLE_MODULES}"
 	fi
 
-	if [[ "$(gcc-major-version)" -ge 4 ]]; then
-		append-flags -fwrapv
-	fi
+	append-flags -fwrapv
 
 	filter-flags -malign-double
 

--- a/dev-lang/python/python-3.8.13_p1.ebuild
+++ b/dev-lang/python/python-3.8.13_p1.ebuild
@@ -130,9 +130,7 @@ src_configure() {
 		einfo "Disabled modules: ${PYTHON_DISABLE_MODULES}"
 	fi
 
-	if [[ "$(gcc-major-version)" -ge 4 ]]; then
-		append-flags -fwrapv
-	fi
+	append-flags -fwrapv
 
 	filter-flags -malign-double
 

--- a/dev-lang/python/python-3.9.11.ebuild
+++ b/dev-lang/python/python-3.9.11.ebuild
@@ -131,9 +131,7 @@ src_configure() {
 		einfo "Disabled modules: ${PYTHON_DISABLE_MODULES}"
 	fi
 
-	if [[ "$(gcc-major-version)" -ge 4 ]]; then
-		append-flags -fwrapv
-	fi
+	append-flags -fwrapv
 
 	filter-flags -malign-double
 

--- a/dev-lang/python/python-3.9.12.ebuild
+++ b/dev-lang/python/python-3.9.12.ebuild
@@ -142,9 +142,7 @@ src_configure() {
 		einfo "Disabled modules: ${PYTHON_DISABLE_MODULES}"
 	fi
 
-	if [[ "$(gcc-major-version)" -ge 4 ]]; then
-		append-flags -fwrapv
-	fi
+	append-flags -fwrapv
 
 	filter-flags -malign-double
 

--- a/eclass/mozcoreconf-v5.eclass
+++ b/eclass/mozcoreconf-v5.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 #
 # @ECLASS: mozcoreconf-v5.eclass
@@ -105,12 +105,6 @@ moz_pkgsetup() {
 	# false positives when toplevel configure passes downwards.
 	export QA_CONFIGURE_OPTIONS=".*"
 
-	if [[ $(gcc-major-version) -eq 3 ]]; then
-		ewarn "Unsupported compiler detected, DO NOT file bugs for"
-		ewarn "outdated compilers. Bugs opened with gcc-3 will be closed"
-		ewarn "invalid."
-	fi
-
 	python-any-r1_pkg_setup
 }
 
@@ -157,9 +151,9 @@ mozconfig_init() {
 	####################################
 
 	# Set optimization level
-	if [[ $(gcc-major-version) -ge 7 ]]; then
-		mozconfig_annotate "Workaround known breakage" --enable-optimize=-O2
-	elif [[ ${ARCH} == hppa ]]; then
+	mozconfig_annotate "Workaround known breakage" --enable-optimize=-O2
+
+	if [[ ${ARCH} == hppa ]]; then
 		mozconfig_annotate "more than -O0 causes a segfault on hppa" --enable-optimize=-O0
 	elif [[ ${ARCH} == x86 ]]; then
 		mozconfig_annotate "less then -O2 causes a segfault on x86" --enable-optimize=-O2
@@ -214,10 +208,8 @@ mozconfig_init() {
 		;;
 	esac
 
-	# We need to append flags for gcc-6 support
-	if [[ $(gcc-major-version) -ge 6 ]]; then
-		append-cxxflags -fno-delete-null-pointer-checks -fno-lifetime-dse -fno-schedule-insns2
-	fi
+	# We need to append flags for >= gcc-6 support
+	append-cxxflags -fno-delete-null-pointer-checks -fno-lifetime-dse -fno-schedule-insns2
 
 	# Use the MOZILLA_FIVE_HOME for the rpath
 	append-ldflags -Wl,-rpath="${MOZILLA_FIVE_HOME}",--enable-new-dtags

--- a/games-emulation/pcsx2/pcsx2-1.6.0-r3.ebuild
+++ b/games-emulation/pcsx2/pcsx2-1.6.0-r3.ebuild
@@ -53,9 +53,7 @@ pkg_setup() {
 	if [[ ${MERGE_TYPE} != binary && $(tc-getCC) == *gcc* ]]; then
 		# -mxsave flag is needed when GCC >= 8.2 is used
 		# https://bugs.gentoo.org/685156
-		if [[ $(gcc-major-version) -gt 8 || $(gcc-major-version) == 8 && $(gcc-minor-version) -ge 2 ]]; then
-			append-flags -mxsave
-		fi
+		append-flags -mxsave
 	fi
 }
 

--- a/games-emulation/pcsx2/pcsx2-9999.ebuild
+++ b/games-emulation/pcsx2/pcsx2-9999.ebuild
@@ -64,9 +64,7 @@ pkg_setup() {
 	if [[ ${MERGE_TYPE} != binary && $(tc-getCC) == *gcc* ]]; then
 		# -mxsave flag is needed when GCC >= 8.2 is used
 		# https://bugs.gentoo.org/685156
-		if [[ $(gcc-major-version) -gt 8 || $(gcc-major-version) == 8 && $(gcc-minor-version) -ge 2 ]]; then
-			append-flags -mxsave
-		fi
+		append-flags -mxsave
 	fi
 }
 

--- a/games-strategy/wesnoth/wesnoth-1.16.0-r1.ebuild
+++ b/games-strategy/wesnoth/wesnoth-1.16.0-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit cmake flag-o-matic toolchain-funcs xdg
+inherit cmake flag-o-matic xdg
 
 DESCRIPTION="Battle for Wesnoth - A fantasy turn-based strategy game"
 HOMEPAGE="http://www.wesnoth.org
@@ -64,10 +64,6 @@ src_prepare() {
 
 src_configure() {
 	filter-flags -ftracer -fomit-frame-pointer
-	if [[ $(gcc-major-version) -eq 3 ]] ; then
-		filter-flags -fstack-protector
-		append-flags -fno-stack-protector
-	fi
 
 	if use dedicated || use server ; then
 		mycmakeargs=(

--- a/games-strategy/wesnoth/wesnoth-1.16.2.ebuild
+++ b/games-strategy/wesnoth/wesnoth-1.16.2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit cmake flag-o-matic toolchain-funcs xdg
+inherit cmake flag-o-matic xdg
 
 DESCRIPTION="Battle for Wesnoth - A fantasy turn-based strategy game"
 HOMEPAGE="http://www.wesnoth.org
@@ -64,10 +64,6 @@ src_prepare() {
 
 src_configure() {
 	filter-flags -ftracer -fomit-frame-pointer
-	if [[ $(gcc-major-version) -eq 3 ]] ; then
-		filter-flags -fstack-protector
-		append-flags -fno-stack-protector
-	fi
 
 	if use dedicated || use server ; then
 		mycmakeargs=(

--- a/media-video/mjpegtools/mjpegtools-2.2.1.ebuild
+++ b/media-video/mjpegtools/mjpegtools-2.2.1.ebuild
@@ -46,8 +46,6 @@ src_prepare() {
 }
 
 multilib_src_configure() {
-	[[ $(gcc-major-version) -eq 3 ]] && append-flags -mno-sse2
-
 	local myconf=(
 		--enable-compile-warnings
 		$(use_enable cpu_flags_x86_mmx simd-accel)

--- a/sci-libs/gsl/gsl-2.7.1-r1.ebuild
+++ b/sci-libs/gsl/gsl-2.7.1-r1.ebuild
@@ -25,11 +25,6 @@ PATCHES=(
 )
 
 src_prepare() {
-	# bug #349005
-	[[ $(tc-getCC)$ == *gcc* ]] && \
-		[[ $(tc-getCC)$ != *apple* ]] && \
-		[[ $(gcc-major-version)$(gcc-minor-version) -eq 44 ]] \
-		&& filter-mfpmath sse
 	filter-flags -ffast-math
 
 	default

--- a/sci-libs/gsl/gsl-2.7.ebuild
+++ b/sci-libs/gsl/gsl-2.7.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -24,11 +24,6 @@ PATCHES=(
 )
 
 src_prepare() {
-	# bug #349005
-	[[ $(tc-getCC)$ == *gcc* ]] && \
-		[[ $(tc-getCC)$ != *apple* ]] && \
-		[[ $(gcc-major-version)$(gcc-minor-version) -eq 44 ]] \
-		&& filter-mfpmath sse
 	filter-flags -ffast-math
 
 	default

--- a/sci-libs/pgplot/pgplot-5.2.2-r7.ebuild
+++ b/sci-libs/pgplot/pgplot-5.2.2-r7.ebuild
@@ -38,18 +38,6 @@ PATCHES=(
 
 src_prepare() {
 	default
-	# gfortran < 4.3 does not compile gif, pp and wd drivers
-	if [[ $(tc-getFC) == *gfortran* ]] &&
-		[[ $(gcc-major-version)$(gcc-minor-version) -lt 43 ]] ; then
-		ewarn "Warning!"
-		ewarn "gfortran < 4.3 selected: does not compile all drivers"
-		ewarn "disabling gif, wd, and ppd drivers"
-		ewarn "if you want more drivers, use gfortran >= 4.3"
-		sed -e 's/GIDRIV/! GIDRIV/g' \
-			-e 's/PPDRIV/! GIDRIV/g' \
-			-e 's/WDDRIV/! GIDRIV/g' \
-			-i drivers.list || die "sed drivers failed"
-	fi
 
 	# fix pointers for 64 bits
 	if use amd64 || use ia64; then

--- a/www-client/seamonkey/seamonkey-2.53.10.2.ebuild
+++ b/www-client/seamonkey/seamonkey-2.53.10.2.ebuild
@@ -417,12 +417,8 @@ src_configure() {
 	# Work around breakage in makeopts with --no-print-directory
 	MAKEOPTS="${MAKEOPTS/--no-print-directory/}"
 
-	if [[ $(gcc-major-version) -lt 4 ]] ; then
-		append-cxxflags -fno-stack-protector
-	elif [[ $(gcc-major-version) -gt 4 || $(gcc-minor-version) -gt 3 ]] ; then
-		if use amd64 || use x86 ; then
-			append-flags -mno-avx
-		fi
+	if use amd64 || use x86 ; then
+		append-flags -mno-avx
 	fi
 
 	# Pass $MAKEOPTS to build system

--- a/www-client/seamonkey/seamonkey-2.53.11-r1.ebuild
+++ b/www-client/seamonkey/seamonkey-2.53.11-r1.ebuild
@@ -412,12 +412,8 @@ src_configure() {
 	# Work around breakage in makeopts with --no-print-directory
 	MAKEOPTS="${MAKEOPTS/--no-print-directory/}"
 
-	if [[ $(gcc-major-version) -lt 4 ]] ; then
-		append-cxxflags -fno-stack-protector
-	elif [[ $(gcc-major-version) -gt 4 || $(gcc-minor-version) -gt 3 ]] ; then
-		if use amd64 || use x86 ; then
-			append-flags -mno-avx
-		fi
+	if use amd64 || use x86 ; then
+		append-flags -mno-avx
 	fi
 
 	# Pass $MAKEOPTS to build system

--- a/www-client/seamonkey/seamonkey-2.53.11.1.ebuild
+++ b/www-client/seamonkey/seamonkey-2.53.11.1.ebuild
@@ -402,12 +402,8 @@ src_configure() {
 	# Work around breakage in makeopts with --no-print-directory
 	MAKEOPTS="${MAKEOPTS/--no-print-directory/}"
 
-	if [[ $(gcc-major-version) -lt 4 ]] ; then
-		append-cxxflags -fno-stack-protector
-	elif [[ $(gcc-major-version) -gt 4 || $(gcc-minor-version) -gt 3 ]] ; then
-		if use amd64 || use x86 ; then
-			append-flags -mno-avx
-		fi
+	if use amd64 || use x86 ; then
+		append-flags -mno-avx
 	fi
 
 	# Pass $MAKEOPTS to build system

--- a/www-client/seamonkey/seamonkey-2.53.11.ebuild
+++ b/www-client/seamonkey/seamonkey-2.53.11.ebuild
@@ -412,12 +412,8 @@ src_configure() {
 	# Work around breakage in makeopts with --no-print-directory
 	MAKEOPTS="${MAKEOPTS/--no-print-directory/}"
 
-	if [[ $(gcc-major-version) -lt 4 ]] ; then
-		append-cxxflags -fno-stack-protector
-	elif [[ $(gcc-major-version) -gt 4 || $(gcc-minor-version) -gt 3 ]] ; then
-		if use amd64 || use x86 ; then
-			append-flags -mno-avx
-		fi
+	if use amd64 || use x86 ; then
+		append-flags -mno-avx
 	fi
 
 	# Pass $MAKEOPTS to build system

--- a/www-client/seamonkey/seamonkey-2.53.12.ebuild
+++ b/www-client/seamonkey/seamonkey-2.53.12.ebuild
@@ -433,12 +433,8 @@ src_configure() {
 	# Work around breakage in makeopts with --no-print-directory
 	MAKEOPTS="${MAKEOPTS/--no-print-directory/}"
 
-	if [[ $(gcc-major-version) -lt 4 ]] ; then
-		append-cxxflags -fno-stack-protector
-	elif [[ $(gcc-major-version) -gt 4 || $(gcc-minor-version) -gt 3 ]] ; then
-		if use amd64 || use x86 ; then
-			append-flags -mno-avx
-		fi
+	if use amd64 || use x86 ; then
+		append-flags -mno-avx
 	fi
 
 	# Pass $MAKEOPTS to build system


### PR DESCRIPTION
There's no way that GCC 3.x is usable on a modern system and it was released in
~2005.

Signed-off-by: Sam James <sam@gentoo.org>