### PR TITLE
x11-wm/awesome: enable lua5-4

### DIFF
--- a/x11-wm/awesome/awesome-9999.ebuild
+++ b/x11-wm/awesome/awesome-9999.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-LUA_COMPAT=( lua5-{1..3} luajit )
+LUA_COMPAT=( lua5-{1..4} luajit )
 
 inherit cmake desktop lua-single pax-utils
 


### PR DESCRIPTION
Because 9999 is the git version, the syntax of lua5.3 can no longer match and cannot run the wm. So we need to add lua5.4 support.

Signed-off-by: Yu Gu <guyu2876@gmail.com>