### PR TITLE
app-text/xapers: Enable py3.10

### DIFF
--- a/app-text/xapers/xapers-0.9.0.ebuild
+++ b/app-text/xapers/xapers-0.9.0.ebuild
@@ -1,9 +1,9 @@
-# Copyright 2016-2021 Gentoo Authors
+# Copyright 2016-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{7..9} )
+PYTHON_COMPAT=( python3_{7..10} )
 
 inherit distutils-r1
 


### PR DESCRIPTION
Enables python 3.10 support. Tested locally, tests run and use appears
fine. Also update copyright date

Closes: https://bugs.gentoo.org/845612
Signed-off-by: William Pettersson <william@ewpettersson.se>