### PR TITLE
dev-lisp/sbcl: Add linkable-runtime use flag

### DIFF
--- a/dev-lisp/sbcl/metadata.xml
+++ b/dev-lisp/sbcl/metadata.xml
@@ -19,6 +19,9 @@
 	available for the x86 and amd64 platforms using an NPTL enabled
 	GLIBC. SBCL 0.8.17 and later support Unicode.
 </longdescription>
+	<use>
+		<flag name="linkable-runtime">Install sbcl.o to allow linking the runtime with extra object files</flag>
+	</use>
 	<upstream>
 		<remote-id type="sourceforge">sbcl</remote-id>
 	</upstream>

--- a/dev-lisp/sbcl/sbcl-2.2.0.ebuild
+++ b/dev-lisp/sbcl/sbcl-2.2.0.ebuild
@@ -40,7 +40,7 @@ SRC_URI="mirror://sourceforge/sbcl/${P}-source.tar.bz2
 LICENSE="MIT"
 SLOT="0/${PV}"
 KEYWORDS="-* amd64 ppc ppc64 ~sparc x86 ~amd64-linux ~x86-linux ~x64-macos ~x86-solaris"
-IUSE="debug doc source +threads +unicode zlib"
+IUSE="debug doc linkable-runtime source +threads +unicode zlib"
 
 CDEPEND=">=dev-lisp/asdf-3.3:="
 BDEPEND="${CDEPEND}
@@ -80,6 +80,7 @@ sbcl_apply_features() {
 	sbcl_feature "$(usep unicode)" ":sb-unicode"
 	sbcl_feature "$(usep zlib)" ":sb-core-compression"
 	sbcl_feature "$(usep debug)" ":sb-xref-for-internals"
+	sbcl_feature "$(usep linkable-runtime)" ":sb-linkable-runtime"
 	sed 's/^X//' >> "${CONFIG}" <<-'EOF'
 	X    )
 	X  list)

--- a/dev-lisp/sbcl/sbcl-2.2.3.ebuild
+++ b/dev-lisp/sbcl/sbcl-2.2.3.ebuild
@@ -40,7 +40,7 @@ SRC_URI="mirror://sourceforge/sbcl/${P}-source.tar.bz2
 LICENSE="MIT"
 SLOT="0/${PV}"
 KEYWORDS="-* ~amd64 ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~x86-linux ~x64-macos ~x86-solaris"
-IUSE="debug doc source +threads +unicode zlib"
+IUSE="debug doc linkable-runtime source +threads +unicode zlib"
 
 CDEPEND=">=dev-lisp/asdf-3.3:="
 BDEPEND="${CDEPEND}
@@ -80,6 +80,7 @@ sbcl_apply_features() {
 	sbcl_feature "$(usep unicode)" ":sb-unicode"
 	sbcl_feature "$(usep zlib)" ":sb-core-compression"
 	sbcl_feature "$(usep debug)" ":sb-xref-for-internals"
+	sbcl_feature "$(usep linkable-runtime)" ":sb-linkable-runtime"
 	sed 's/^X//' >> "${CONFIG}" <<-'EOF'
 	X    )
 	X  list)

--- a/dev-lisp/sbcl/sbcl-2.2.4.ebuild
+++ b/dev-lisp/sbcl/sbcl-2.2.4.ebuild
@@ -40,7 +40,7 @@ SRC_URI="mirror://sourceforge/sbcl/${P}-source.tar.bz2
 LICENSE="MIT"
 SLOT="0/${PV}"
 KEYWORDS="-* ~amd64 ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~x86-linux ~x64-macos ~x86-solaris"
-IUSE="debug doc source +threads +unicode zlib"
+IUSE="debug doc linkable-runtime source +threads +unicode zlib"
 
 CDEPEND=">=dev-lisp/asdf-3.3:="
 BDEPEND="${CDEPEND}
@@ -80,6 +80,7 @@ sbcl_apply_features() {
 	sbcl_feature "$(usep unicode)" ":sb-unicode"
 	sbcl_feature "$(usep zlib)" ":sb-core-compression"
 	sbcl_feature "$(usep debug)" ":sb-xref-for-internals"
+	sbcl_feature "$(usep linkable-runtime)" ":sb-linkable-runtime"
 	sed 's/^X//' >> "${CONFIG}" <<-'EOF'
 	X    )
 	X  list)


### PR DESCRIPTION
Useful for building executables with CFFI's STATIC-PROGRAM-OP, which links CFFI
generated wrappers into the runtime.

Signed-off-by: Eric Timmons <eric@timmons.dev>