### PR TITLE
net-firewall/iptables: Remove obsolete option from init script

### DIFF
--- a/net-firewall/iptables/files/iptables-r3.init
+++ b/net-firewall/iptables/files/iptables-r3.init
@@ -1,0 +1,165 @@
+#!/sbin/openrc-run
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+extra_commands="check save panic"
+extra_started_commands="reload"
+
+iptables_lock_wait_time=${IPTABLES_LOCK_WAIT_TIME:-"60"}
+iptables_lock_wait_interval=${IPTABLES_LOCK_WAIT_INTERVAL:-"1000"}
+
+iptables_name=${SVCNAME}
+case ${iptables_name} in
+	iptables|ip6tables) ;;
+	*) iptables_name="iptables" ;;
+esac
+
+iptables_bin="/sbin/${iptables_name}"
+case ${iptables_name} in
+	iptables)  iptables_proc="/proc/net/ip_tables_names"
+	           iptables_save=${IPTABLES_SAVE};;
+	ip6tables) iptables_proc="/proc/net/ip6_tables_names"
+	           iptables_save=${IP6TABLES_SAVE};;
+esac
+
+depend() {
+	need localmount #434774
+	before net
+}
+
+set_table_policy() {
+	local has_errors=0 chains table=$1 policy=$2
+	case ${table} in
+		nat)    chains="PREROUTING POSTROUTING OUTPUT";;
+		mangle) chains="PREROUTING INPUT FORWARD OUTPUT POSTROUTING";;
+		filter) chains="INPUT FORWARD OUTPUT";;
+		*)      chains="";;
+	esac
+
+	local chain
+	for chain in ${chains} ; do
+		${iptables_bin} --wait ${iptables_lock_wait_time} -t ${table} -P ${chain} ${policy}
+		[ $? -ne 0 ] && has_errors=1
+	done
+
+	return ${has_errors}
+}
+
+checkkernel() {
+	if [ ! -e ${iptables_proc} ] ; then
+		eerror "Your kernel lacks ${iptables_name} support, please load"
+		eerror "appropriate modules and try again."
+		return 1
+	fi
+	return 0
+}
+
+checkconfig() {
+	if [ -z "${iptables_save}" -o ! -f "${iptables_save}" ] ; then
+		eerror "Not starting ${iptables_name}.  First create some rules then run:"
+		eerror "/etc/init.d/${iptables_name} save"
+		return 1
+	fi
+	return 0
+}
+
+start_pre() {
+	checkconfig || return 1
+}
+
+start() {
+	ebegin "Loading ${iptables_name} state and starting firewall"
+	${iptables_bin}-restore --wait ${iptables_lock_wait_time} ${SAVE_RESTORE_OPTIONS} < "${iptables_save}"
+	eend $?
+}
+
+stop_pre() {
+	checkkernel || return 1
+}
+
+stop() {
+	if [ "${SAVE_ON_STOP}" = "yes" ] ; then
+		save || return 1
+	fi
+
+	ebegin "Stopping firewall"
+	local has_errors=0 a
+	for a in $(cat ${iptables_proc}) ; do
+		set_table_policy $a ACCEPT
+		[ $? -ne 0 ] && has_errors=1
+
+		${iptables_bin} --wait ${iptables_lock_wait_time} -F -t $a
+		[ $? -ne 0 ] && has_errors=1
+
+		${iptables_bin} --wait ${iptables_lock_wait_time} -X -t $a
+		[ $? -ne 0 ] && has_errors=1
+	done
+	eend ${has_errors}
+}
+
+reload() {
+	checkkernel || return 1
+	checkrules || return 1
+	ebegin "Flushing firewall"
+	local has_errors=0 a
+	for a in $(cat ${iptables_proc}) ; do
+		${iptables_bin} --wait ${iptables_lock_wait_time} -F -t $a
+		[ $? -ne 0 ] && has_errors=1
+
+		${iptables_bin} --wait ${iptables_lock_wait_time} -X -t $a
+		[ $? -ne 0 ] && has_errors=1
+	done
+	eend ${has_errors}
+
+	start
+}
+
+checkrules() {
+	ebegin "Checking rules"
+	${iptables_bin}-restore --test ${SAVE_RESTORE_OPTIONS} < "${iptables_save}"
+	eend $?
+}
+
+check() {
+	# Short name for users of init.d script.
+	checkrules
+}
+
+save() {
+	ebegin "Saving ${iptables_name} state"
+	checkpath -q -d "$(dirname "${iptables_save}")"
+	checkpath -q -m 0600 -f "${iptables_save}"
+	${iptables_bin}-save ${SAVE_RESTORE_OPTIONS} > "${iptables_save}"
+	eend $?
+}
+
+panic() {
+	# use iptables autoload capability to load at least all required
+	# modules and filter table
+	${iptables_bin} --wait ${iptables_lock_wait_time} -S >/dev/null
+	if [ $? -ne 0 ] ; then
+		eerror "${iptables_bin} failed to load"
+		return 1
+	fi
+
+	if service_started ${iptables_name}; then
+		rc-service ${iptables_name} stop
+	fi
+
+	local has_errors=0 a
+	ebegin "Dropping all packets"
+	for a in $(cat ${iptables_proc}) ; do
+		${iptables_bin} --wait ${iptables_lock_wait_time} -F -t $a
+		[ $? -ne 0 ] && has_errors=1
+
+		${iptables_bin} --wait ${iptables_lock_wait_time} -X -t $a
+		[ $? -ne 0 ] && has_errors=1
+
+		if [ "${a}" != "nat" ]; then
+			# The "nat" table is not intended for filtering, the use of DROP is therefore inhibited.
+			set_table_policy $a DROP
+			[ $? -ne 0 ] && has_errors=1
+		fi
+	done
+	eend ${has_errors}
+}

--- a/net-firewall/iptables/iptables-1.8.8-r2.ebuild
+++ b/net-firewall/iptables/iptables-1.8.8-r2.ebuild
@@ -1,0 +1,177 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit systemd toolchain-funcs autotools flag-o-matic usr-ldscript
+
+DESCRIPTION="Linux kernel (2.4+) firewall, NAT and packet mangling tools"
+HOMEPAGE="https://www.netfilter.org/projects/iptables/"
+SRC_URI="https://www.netfilter.org/projects/iptables/files/${P}.tar.bz2"
+
+LICENSE="GPL-2"
+# Subslot reflects PV when libxtables and/or libip*tc was changed
+# the last time.
+SLOT="0/1.8.3"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+IUSE="conntrack netlink nftables pcap static-libs"
+
+BUILD_DEPEND="
+	>=app-eselect/eselect-iptables-20220320
+"
+COMMON_DEPEND="
+	conntrack? ( >=net-libs/libnetfilter_conntrack-1.0.6 )
+	netlink? ( net-libs/libnfnetlink )
+	nftables? (
+		>=net-libs/libmnl-1.0:0=
+		>=net-libs/libnftnl-1.1.6:0=
+	)
+	pcap? ( net-libs/libpcap )
+"
+DEPEND="${COMMON_DEPEND}
+	virtual/os-headers
+	>=sys-kernel/linux-headers-4.4:0
+"
+BDEPEND="${BUILD_DEPEND}
+	virtual/pkgconfig
+	nftables? (
+		sys-devel/flex
+		virtual/yacc
+	)
+"
+RDEPEND="${COMMON_DEPEND}
+	${BUILD_DEPEND}
+	nftables? ( net-misc/ethertypes )
+	!<net-firewall/ebtables-2.0.11-r1
+	!<net-firewall/arptables-0.0.5-r1
+"
+
+PATCHES=(
+	"${FILESDIR}/iptables-1.8.4-no-symlinks.patch"
+	"${FILESDIR}/iptables-1.8.2-link.patch"
+
+	"${FILESDIR}/${P}-format-security.patch"
+	"${FILESDIR}/${P}-uint-musl.patch"
+)
+
+src_prepare() {
+	# use the saner headers from the kernel
+	rm include/linux/{kernel,types}.h || die
+
+	default
+	eautoreconf
+}
+
+src_configure() {
+	# Some libs use $(AR) rather than libtool to build #444282
+	tc-export AR
+
+	# Hack around struct mismatches between userland & kernel for some ABIs. #472388
+	use amd64 && [[ ${ABI} == "x32" ]] && append-flags -fpack-struct
+
+	sed -i \
+		-e "/nfnetlink=[01]/s:=[01]:=$(usex netlink 1 0):" \
+		-e "/nfconntrack=[01]/s:=[01]:=$(usex conntrack 1 0):" \
+		configure || die
+
+	local myeconfargs=(
+		--sbindir="${EPREFIX}/sbin"
+		--libexecdir="${EPREFIX}/$(get_libdir)"
+		--enable-devel
+		--enable-ipv6
+		--enable-shared
+		$(use_enable nftables)
+		$(use_enable pcap bpf-compiler)
+		$(use_enable pcap nfsynproxy)
+		$(use_enable static-libs static)
+	)
+	econf "${myeconfargs[@]}"
+}
+
+src_compile() {
+	emake V=1
+}
+
+src_install() {
+	default
+	dodoc INCOMPATIBILITIES iptables/iptables.xslt
+
+	# all the iptables binaries are in /sbin, so might as well
+	# put these small files in with them
+	into /
+	dosbin iptables/iptables-apply
+	dosym iptables-apply /sbin/ip6tables-apply
+	doman iptables/iptables-apply.8
+
+	insinto /usr/include
+	doins include/ip{,6}tables.h
+	insinto /usr/include/iptables
+	doins include/iptables/internal.h
+
+	keepdir /var/lib/ip{,6}tables
+	newinitd "${FILESDIR}"/${PN}-r3.init iptables
+	newconfd "${FILESDIR}"/${PN}-r1.confd iptables
+	dosym iptables /etc/init.d/ip6tables
+	newconfd "${FILESDIR}"/ip6tables-r1.confd ip6tables
+
+	if use nftables; then
+		# Bug 647458
+		rm "${ED}"/etc/ethertypes || die
+
+		# Bugs 660886 and 669894
+		rm "${ED}"/sbin/{arptables,ebtables}{,-{save,restore}} || die
+	fi
+
+	systemd_dounit "${FILESDIR}"/systemd/ip{,6}tables-{re,}store.service
+
+	# Move important libs to /lib #332175
+	gen_usr_ldscript -a ip{4,6}tc xtables
+
+	find "${ED}" -type f -name "*.la" -delete || die
+}
+
+pkg_postinst() {
+	local default_iptables="xtables-legacy-multi"
+	if ! eselect iptables show &>/dev/null; then
+		elog "Current iptables implementation is unset, setting to ${default_iptables}"
+		eselect iptables set "${default_iptables}"
+	fi
+
+	if use nftables; then
+		local tables
+		for tables in {arp,eb}tables; do
+			if ! eselect ${tables} show &>/dev/null; then
+				elog "Current ${tables} implementation is unset, setting to ${default_iptables}"
+				eselect ${tables} set xtables-nft-multi
+			fi
+		done
+	fi
+
+	eselect iptables show
+}
+
+pkg_prerm() {
+	if [[ -z ${REPLACED_BY_VERSION} ]]; then
+		elog "Unsetting iptables symlinks before removal"
+		eselect iptables unset
+	fi
+
+	if ! has_version 'net-firewall/ebtables'; then
+		elog "Unsetting ebtables symlinks before removal"
+		eselect ebtables unset
+	elif [[ -z ${REPLACED_BY_VERSION} ]]; then
+		elog "Resetting ebtables symlinks to ebtables-legacy"
+		eselect ebtables set ebtables-legacy
+	fi
+
+	if ! has_version 'net-firewall/arptables'; then
+		elog "Unsetting arptables symlinks before removal"
+		eselect arptables unset
+	elif [[ -z ${REPLACED_BY_VERSION} ]]; then
+		elog "Resetting arptables symlinks to arptables-legacy"
+		eselect arptables set arptables-legacy
+	fi
+
+	# the eselect module failing should not be fatal
+	return 0
+}


### PR DESCRIPTION
Upstream changed how locking is handled and removed --wait-interval.

Signed-off-by: Hank Leininger <hlein@korelogic.com>
Closes: https://bugs.gentoo.org/846518
Package-Manager: Portage-3.0.30, Repoman-3.0.3