### PR TITLE
dev-util/ninja: dep on media-gfx/graphviz

### DIFF
--- a/dev-util/ninja/ninja-1.11.0.ebuild
+++ b/dev-util/ninja/ninja-1.11.0.ebuild
@@ -31,6 +31,7 @@ BDEPEND="
 		app-text/asciidoc
 		app-doc/doxygen
 		dev-libs/libxslt
+		media-gfx/graphviz
 	)
 	test? ( dev-cpp/gtest )
 "


### PR DESCRIPTION
When USE=doc is set, graphviz dot is used as part of building the
documentation.

Closes: https://bugs.gentoo.org/846539
Signed-off-by: Thomas Bracht Laumann Jespersen <t@laumann.xyz>