### PR TITLE
app-text/nfoview: revert PEP 517 migration

### DIFF
--- a/app-text/nfoview/nfoview-1.28.1-r1.ebuild
+++ b/app-text/nfoview/nfoview-1.28.1-r1.ebuild
@@ -3,8 +3,8 @@
 
 EAPI=8
 
+DISTUTILS_USE_SETUPTOOLS=no
 PYTHON_COMPAT=( python3_{8..10} )
-DISTUTILS_USE_PEP517=setuptools
 
 inherit distutils-r1 virtualx xdg
 


### PR DESCRIPTION
causes location errors for include files

Closes: https://bugs.gentoo.org/846563
Package-Manager: Portage-3.0.30, Repoman-3.0.3
Signed-off-by: Till Schäfer <till2.schaefer@uni-dortmund.de>