### PR TITLE
media-video/wireplumber: add 0.4.10-r2 and copy loong to 9999

### DIFF
--- a/media-video/wireplumber/files/wireplumber-0.4.10-alsa.lua-fix-device-name-deduplication-when-reserva.patch
+++ b/media-video/wireplumber/files/wireplumber-0.4.10-alsa.lua-fix-device-name-deduplication-when-reserva.patch
@@ -1,0 +1,117 @@
+https://gitlab.freedesktop.org/pipewire/wireplumber/-/commit/c00c5a6675b6640db13111c808eaa3251917c412
+
+From c00c5a6675b6640db13111c808eaa3251917c412 Mon Sep 17 00:00:00 2001
+From: Julian Bouzas <julian.bouzas@collabora.com>
+Date: Wed, 18 May 2022 10:51:41 -0400
+Subject: [PATCH] alsa.lua: fix device name deduplication when reservation is
+ enabled
+
+Fixes #241
+---
+ src/scripts/monitors/alsa.lua | 47 +++++++++++++++++++----------------
+ 1 file changed, 25 insertions(+), 22 deletions(-)
+
+diff --git a/src/scripts/monitors/alsa.lua b/src/scripts/monitors/alsa.lua
+index 01d241db..7beed3a8 100644
+--- a/src/scripts/monitors/alsa.lua
++++ b/src/scripts/monitors/alsa.lua
+@@ -11,6 +11,10 @@ local config = ... or {}
+ -- ensure config.properties is not nil
+ config.properties = config.properties or {}
+ 
++-- unique device/node name tables
++device_names_table = nil
++node_names_table = nil
++
+ -- preprocess rules and create Interest objects
+ for _, r in ipairs(config.rules or {}) do
+   r.interests = {}
+@@ -41,16 +45,6 @@ function rulesApplyProperties(properties)
+   end
+ end
+ 
+-function findDuplicate(parent, id, property, value)
+-  for i = 0, id - 1, 1 do
+-    local obj = parent:get_managed_object(i)
+-    if obj and obj.properties[property] == value then
+-      return true
+-    end
+-  end
+-  return false
+-end
+-
+ function nonempty(str)
+   return str ~= "" and str or nil
+ end
+@@ -125,11 +119,11 @@ function createNode(parent, id, type, factory, properties)
+ 
+     -- deduplicate nodes with the same name
+     for counter = 2, 99, 1 do
+-      if findDuplicate(parent, id, "node.name", properties["node.name"]) then
+-        properties["node.name"] = name .. "." .. counter
+-      else
++      if node_names_table[properties["node.name"]] ~= true then
++        node_names_table[properties["node.name"]] = true
+         break
+       end
++      properties["node.name"] = name .. "." .. counter
+     end
+   end
+ 
+@@ -186,6 +180,10 @@ function createDevice(parent, id, factory, properties)
+   local device = SpaDevice(factory, properties)
+   if device then
+     device:connect("create-object", createNode)
++    device:connect("object-removed", function (parent, id)
++      local node = parent:get_managed_object(id)
++      node_names_table[node.properties["node.name"]] = nil
++    end)
+     device:activate(Feature.SpaDevice.ENABLED | Feature.Proxy.BOUND)
+     parent:store_managed_object(id, device)
+   else
+@@ -205,11 +203,11 @@ function prepareDevice(parent, id, type, factory, properties)
+ 
+   -- deduplicate devices with the same name
+   for counter = 2, 99, 1 do
+-    if findDuplicate(parent, id, "device.name", properties["device.name"]) then
+-      properties["device.name"] = name .. "." .. counter
+-    else
++    if device_names_table[properties["device.name"]] ~= true then
++      device_names_table[properties["device.name"]] = true
+       break
+     end
++    properties["device.name"] = name .. "." .. counter
+   end
+ 
+   -- ensure the device has a description
+@@ -337,16 +335,21 @@ function createMonitor ()
+   -- handle create-object to prepare device
+   m:connect("create-object", prepareDevice)
+ 
+-  -- if dbus reservation, handle object-removed to destroy device reservations
+-  if rd_plugin then
+-    m:connect("object-removed", function (parent, id)
+-      local device = parent:get_managed_object(id)
++  -- handle object-removed to destroy device reservations and recycle device name
++  m:connect("object-removed", function (parent, id)
++    local device = parent:get_managed_object(id)
++    if rd_plugin then
+       local rd_name = device.properties["api.dbus.ReserveDevice1"]
+       if rd_name then
+         rd_plugin:call("destroy-reservation", rd_name)
+       end
+-    end)
+-  end
++    end
++    device_names_table[device.properties["device.name"]] = nil
++  end)
++
++  -- reset the name tables to make sure names are recycled
++  device_names_table = {}
++  node_names_table = {}
+ 
+   -- activate monitor
+   Log.info("Activating ALSA monitor")
+-- 
+GitLab
+

--- a/media-video/wireplumber/files/wireplumber-0.4.10-m-lua-scripting-allow-converting-GValue-holding-NUL.patch
+++ b/media-video/wireplumber/files/wireplumber-0.4.10-m-lua-scripting-allow-converting-GValue-holding-NUL.patch
@@ -1,0 +1,36 @@
+https://gitlab.freedesktop.org/pipewire/wireplumber/-/commit/c2f31bb550755acba31da2e9f5bbdf646ed5e805
+
+From c2f31bb550755acba31da2e9f5bbdf646ed5e805 Mon Sep 17 00:00:00 2001
+From: Julian Bouzas <julian.bouzas@collabora.com>
+Date: Mon, 16 May 2022 15:41:10 -0400
+Subject: [PATCH] m-lua-scripting: allow converting GValue holding NULL objects
+ to Lua
+
+---
+ modules/module-lua-scripting/wplua/value.c | 9 +++++++--
+ 1 file changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/modules/module-lua-scripting/wplua/value.c b/modules/module-lua-scripting/wplua/value.c
+index 133051a4..e31ae4ac 100644
+--- a/modules/module-lua-scripting/wplua/value.c
++++ b/modules/module-lua-scripting/wplua/value.c
+@@ -314,9 +314,14 @@ wplua_gvalue_to_lua (lua_State *L, const GValue *v)
+       wplua_pushboxed (L, G_VALUE_TYPE (v), g_value_dup_boxed (v));
+     break;
+   case G_TYPE_OBJECT:
+-  case G_TYPE_INTERFACE:
+-    wplua_pushobject (L, g_value_dup_object (v));
++  case G_TYPE_INTERFACE: {
++    GObject *object = g_value_dup_object (v);
++    if (object)
++      wplua_pushobject (L, g_value_dup_object (v));
++    else
++      lua_pushnil (L);
+     break;
++  }
+   case G_TYPE_ENUM:
+     wplua_enum_to_lua (L, g_value_get_enum (v), G_VALUE_TYPE (v));
+     break;
+-- 
+GitLab
+

--- a/media-video/wireplumber/files/wireplumber-0.4.10-m-lua-scripting-fix-object-refcounting.patch
+++ b/media-video/wireplumber/files/wireplumber-0.4.10-m-lua-scripting-fix-object-refcounting.patch
@@ -1,0 +1,32 @@
+https://gitlab.freedesktop.org/pipewire/wireplumber/-/commit/7908b8d7be2a2992c57cd549054eda7ce46e4b44
+
+From 13b85bd4a25ab374f5e5e90b7288e6987996856e Mon Sep 17 00:00:00 2001
+From: Michael Olbrich <m.olbrich@pengutronix.de>
+Date: Tue, 24 May 2022 11:35:15 +0200
+Subject: [PATCH] m-lua-scripting: fix object refcounting
+
+7908b8d7be2a2992c57cd549054eda7ce46e4b44 ("m-lua-scripting: allow
+converting GValue holding NULL objects to Lua") accidentally added a second
+refcount. As a result, the objects are never freeded.
+
+Remove the second refcount to fix this.
+---
+ modules/module-lua-scripting/wplua/value.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/modules/module-lua-scripting/wplua/value.c b/modules/module-lua-scripting/wplua/value.c
+index e31ae4a..a7927dc 100644
+--- a/modules/module-lua-scripting/wplua/value.c
++++ b/modules/module-lua-scripting/wplua/value.c
+@@ -317,7 +317,7 @@ wplua_gvalue_to_lua (lua_State *L, const GValue *v)
+   case G_TYPE_INTERFACE: {
+     GObject *object = g_value_dup_object (v);
+     if (object)
+-      wplua_pushobject (L, g_value_dup_object (v));
++      wplua_pushobject (L, object);
+     else
+       lua_pushnil (L);
+     break;
+-- 
+2.35.1
+

--- a/media-video/wireplumber/wireplumber-0.4.10-r2.ebuild
+++ b/media-video/wireplumber/wireplumber-0.4.10-r2.ebuild
@@ -62,6 +62,12 @@ RDEPEND="${DEPEND}
 
 DOCS=( {NEWS,README}.rst )
 
+PATCHES=(
+	"${FILESDIR}"/${P}-m-lua-scripting-allow-converting-GValue-holding-NUL.patch
+	"${FILESDIR}"/${P}-alsa.lua-fix-device-name-deduplication-when-reserva.patch
+	"${FILESDIR}"/${P}-m-lua-scripting-fix-object-refcounting.patch
+)
+
 src_configure() {
 	local emesonargs=(
 		-Ddoc=disabled # Ebuild not wired up yet (Sphinx, Doxygen?)


### PR DESCRIPTION
This commit backports a fix for device reservation protocol where
multiple devices may get clashing name because they all get the same
name assigned to them while being reserved. It appears the fix may
need another commit to function, so adding the NULL fix per-emptively.

Finally 0.4.10-r1 was keyworded for ~loong but that's liable to getting
lost on version bumps, so copying it to the 9999 in an inactive state.