### PR TITLE
dev-util/clazy: stabilize 1.11-r1 for x86

### DIFF
--- a/dev-util/clazy/clazy-1.11-r1.ebuild
+++ b/dev-util/clazy/clazy-1.11-r1.ebuild
@@ -13,7 +13,7 @@ SRC_URI="mirror://kde/stable/${PN}/${PV}/src/${P}.tar.xz"
 
 LICENSE="LGPL-2+"
 SLOT="0"
-KEYWORDS="~amd64 ~arm64 ~x86"
+KEYWORDS="~amd64 ~arm64 x86"
 IUSE="test"
 RESTRICT="!test? ( test )"
 


### PR DESCRIPTION
I conducted architecture testing for dev-util/clazy-1.11-r1 for x86 ([833842](https://bugs.gentoo.org/833842))

I can't reproduce bug [811723](https://bugs.gentoo.org/811723); it seems fixed.

clazy-833842.report:
```
USE tests started on Sat May 21 12:30:09 AM CEST 2022

FEATURES=' test' USE='' succeeded for =dev-util/clazy-1.11-r1
USE='' succeeded for =dev-util/clazy-1.11-r1
```

Signed-off-by: Philipp Rösner <rndxelement@protonmail.com>