### PR TITLE
net-misc/memcached: riscv keywording

### DIFF
--- a/net-misc/memcached/memcached-1.6.15.ebuild
+++ b/net-misc/memcached/memcached-1.6.15.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://www.memcached.org/files/${MY_P}.tar.gz
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
 IUSE="debug sasl seccomp selinux slabs-reassign ssl test" # hugetlbfs later
 
 RDEPEND=">=dev-libs/libevent-1.4:=


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/811477
Signed-off-by: Han Gao <rabenda.cn@gmail.com>