### PR TITLE
mail-client/aerc: missing space between variables in live ebuild and metadata indentation

### DIFF
--- a/mail-client/aerc/aerc-9999.ebuild
+++ b/mail-client/aerc/aerc-9999.ebuild
@@ -39,7 +39,7 @@ src_unpack() {
 src_compile() {
 	LDFLAGS= \
 	emake GOFLAGS="-mod=vendor $(usex notmuch "-tags=notmuch" "")" \
-		PREFIX="${EPREFIX}/usr"VERSION=${PV}  all
+		PREFIX="${EPREFIX}/usr" VERSION=${PV}  all
 }
 
 src_install() {

--- a/mail-client/aerc/metadata.xml
+++ b/mail-client/aerc/metadata.xml
@@ -3,8 +3,8 @@
 <pkgmetadata>
 	<maintainer type="person">
 		<email>williamh@gentoo.org</email>
-			<name>William Hubbs</name>
-				</maintainer>
+		<name>William Hubbs</name>
+	</maintainer>
 	<use>
 		<flag name="notmuch">Enable support for <pkg>net-mail/notmuch</pkg></flag>
 	</use>


### PR DESCRIPTION
Those are just two simple fixes.