### PR TITLE
dev-scheme/chicken-5.3.0: keywording ~riscv and ~mips

### DIFF
--- a/dev-scheme/chicken/chicken-5.3.0.ebuild
+++ b/dev-scheme/chicken/chicken-5.3.0.ebuild
@@ -11,7 +11,7 @@ SRC_URI="https://code.call-cc.org/releases/${PV}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="~alpha amd64 ppc ppc64 ~riscv x86"
+KEYWORDS="~alpha amd64 ~mips ppc ppc64 ~riscv x86"
 IUSE="doc"
 
 RDEPEND=""

--- a/dev-scheme/chicken/chicken-5.3.0.ebuild
+++ b/dev-scheme/chicken/chicken-5.3.0.ebuild
@@ -11,7 +11,7 @@ SRC_URI="https://code.call-cc.org/releases/${PV}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="~alpha amd64 ppc ppc64 x86"
+KEYWORDS="~alpha amd64 ppc ppc64 ~riscv x86"
 IUSE="doc"
 
 RDEPEND=""


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/847103
Signed-off-by: Raymond Wong <infiwang@pm.me>