### PR TITLE
sys-apps/razercfg: bump PYTHON_COMPAT to 3.10

### DIFF
--- a/sys-apps/razercfg/razercfg-0.42-r1.ebuild
+++ b/sys-apps/razercfg/razercfg-0.42-r1.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
-PYTHON_COMPAT=( python3_{7..9} )
+PYTHON_COMPAT=( python3_{8..10} )
 
 inherit cmake python-single-r1 systemd tmpfiles udev xdg-utils
 


### PR DESCRIPTION
... and EAPI to 8

https://bugs.gentoo.org/846311