### PR TITLE
dev-libs/snowball-stemmer-2.2.0: stabilization

### DIFF
--- a/dev-libs/snowball-stemmer/snowball-stemmer-2.2.0.ebuild
+++ b/dev-libs/snowball-stemmer/snowball-stemmer-2.2.0.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://github.com/snowballstem/snowball/archive/v${PV}.tar.gz -> ${P}.
 
 LICENSE="BSD"
 SLOT="0/$(ver_cut 1)"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~riscv ~s390 ~sparc x86 ~amd64-linux ~ppc-macos ~sparc-solaris ~sparc64-solaris"
+KEYWORDS="~alpha amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~riscv ~s390 ~sparc x86 ~amd64-linux ~ppc-macos ~sparc-solaris ~sparc64-solaris"
 IUSE="static-libs test"
 
 DEPEND=""

--- a/dev-libs/snowball-stemmer/snowball-stemmer-2.2.0.ebuild
+++ b/dev-libs/snowball-stemmer/snowball-stemmer-2.2.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -14,7 +14,7 @@ SRC_URI="https://github.com/snowballstem/snowball/archive/v${PV}.tar.gz -> ${P}.
 
 LICENSE="BSD"
 SLOT="0/$(ver_cut 1)"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~ppc-macos ~sparc-solaris ~sparc64-solaris"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~riscv ~s390 ~sparc x86 ~amd64-linux ~ppc-macos ~sparc-solaris ~sparc64-solaris"
 IUSE="static-libs test"
 
 DEPEND=""


### PR DESCRIPTION
I conducted architecture testing for dev-libs/snowball-stemmer-2.2.0 ([bug](https://bugs.gentoo.org/835650)) on x86 and amd64 via tatt.
I didn't encounter any issues.

**x86:**
snowball-stemmer-835650.report
```
USE tests started on Tue May 24 09:41:28 PM CEST 2022

FEATURES=' test' USE='' succeeded for =dev-libs/snowball-stemmer-2.2.0
USE='-static-libs' succeeded for =dev-libs/snowball-stemmer-2.2.0
USE='static-libs' succeeded for =dev-libs/snowball-stemmer-2.2.0
```

**amd64:**
snowball-stemmer-835650.report
```
USE tests started on Tue May 24 10:00:59 PM CEST 2022

FEATURES=' test' USE='' succeeded for =dev-libs/snowball-stemmer-2.2.0
USE='-static-libs' succeeded for =dev-libs/snowball-stemmer-2.2.0
USE='static-libs' succeeded for =dev-libs/snowball-stemmer-2.2.0

```