### PR TITLE
sci-astronomy/stellarium: fix test on x86

### DIFF
--- a/sci-astronomy/stellarium/files/stellarium-0.22.1-fix-conv.patch
+++ b/sci-astronomy/stellarium/files/stellarium-0.22.1-fix-conv.patch
@@ -1,0 +1,23 @@
+From dd65fdf5a332d62834ac1cfe9639e220ea635c55 Mon Sep 17 00:00:00 2001
+From: "Alexander V. Wolf" <alex.v.wolf@gmail.com>
+Date: Wed, 25 May 2022 20:55:15 +0700
+Subject: [PATCH] Fixed conversion tool radToHms(): avoiding possible negative
+ zero for value of seconds (see #2460)
+
+---
+ src/core/StelUtils.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/core/StelUtils.cpp b/src/core/StelUtils.cpp
+index 93a55ebb957..b03f55a68ec 100644
+--- a/src/core/StelUtils.cpp
++++ b/src/core/StelUtils.cpp
+@@ -140,7 +140,7 @@ void radToHms(double angle, unsigned int& h, unsigned int& m, double& s)
+ 
+ 	h = static_cast<unsigned int>(angle);
+ 	m = static_cast<unsigned int>((angle-h)*60);
+-	s = (angle-h)*3600.-60.*m;	
++	s = qAbs((angle-h)*3600.-60.*m);
+ }
+ 
+ /*************************************************************************

--- a/sci-astronomy/stellarium/files/stellarium-0.22.1-fix-test-x86.patch
+++ b/sci-astronomy/stellarium/files/stellarium-0.22.1-fix-test-x86.patch
@@ -1,0 +1,93 @@
+From 802065e025c8b435dc39b4fdd9262efdc1dcd2a8 Mon Sep 17 00:00:00 2001
+From: "Alexander V. Wolf" <alex.v.wolf@gmail.com>
+Date: Tue, 24 May 2022 14:47:50 +0700
+Subject: [PATCH]  Fixed something strange in radToHMSStr and radToHMSStrAdapt
+ convertors
+
+probably ancient bug (?), maybe related to issue #2460
+---
+ src/core/StelUtils.cpp        |  6 +++---
+ src/tests/testConversions.cpp | 16 ++++++----------
+ 2 files changed, 9 insertions(+), 13 deletions(-)
+
+diff --git a/src/core/StelUtils.cpp b/src/core/StelUtils.cpp
+index 521d538315e..93a55ebb957 100644
+--- a/src/core/StelUtils.cpp
++++ b/src/core/StelUtils.cpp
+@@ -225,9 +225,9 @@ QString radToHmsStr(const double angle, const bool decimal)
+ {
+ 	unsigned int h,m;
+ 	double s;
+-	StelUtils::radToHms(angle+0.005*M_PI/12/(60*60), h, m, s);
++	StelUtils::radToHms(angle, h, m, s);
+ 	int width, precision;
+-	QString carry, r;
++	QString carry;
+ 	if (decimal)
+ 	{
+ 		width=5;
+@@ -268,7 +268,7 @@ QString radToDmsStrAdapt(const double angle, const bool useD)
+ 	bool sign;
+ 	unsigned int d,m;
+ 	double s;
+-	StelUtils::radToDms(angle+0.005*M_PI/180/(60*60)*(angle<0?-1.:1.), sign, d, m, s); // NOTE: WTF???
++	StelUtils::radToDms(angle, sign, d, m, s);
+ 	QString str;
+ 	QTextStream os(&str);
+ 
+diff --git a/src/tests/testConversions.cpp b/src/tests/testConversions.cpp
+index a37db14307c..6e8a4c6f04c 100644
+--- a/src/tests/testConversions.cpp
++++ b/src/tests/testConversions.cpp
+@@ -248,12 +248,12 @@ void TestConversions::testRadToDMSStrAdapt()
+ 	data << 61*M_PI/360		<< "+30°30'"		<< false;
+ 	data << M_PI/648000		<< "+0°0'1\""		<< false;
+ 	data << 1213*M_PI/2400		<< "+90°58'30\""	<< false;
+-	data << 39599*M_PI/648000	<< "+10°59'59\""	<< false;
++	data << 39599*M_PI/648000	<< "+10°59'59.00\""	<< false;
+ 	data << -M_PI/36		<< "-5°"		<< false;
+ 	data << -7*M_PI/8		<< "-157°30'"		<< false;
+ 	data << -2*M_PI/5		<< "-72°"		<< false;
+ 	data << -M_PI			<< "-180°"		<< false;
+-	data << -10*M_PI/648		<< "-2°46'40\""		<< false;
++	data << -10*M_PI/648		<< "-2°46'40.00\""	<< false;
+ 
+ 	data << 0.			<< "+0d"		<< true;
+ 	data << M_PI/6			<< "+30d"		<< true;
+@@ -268,12 +268,12 @@ void TestConversions::testRadToDMSStrAdapt()
+ 	data << 61*M_PI/360		<< "+30d30'"		<< true;
+ 	data << M_PI/648000		<< "+0d0'1\""		<< true;
+ 	data << 1213*M_PI/2400		<< "+90d58'30\""	<< true;
+-	data << 39599*M_PI/648000	<< "+10d59'59\""	<< true;
++	data << 39599*M_PI/648000	<< "+10d59'59.00\""	<< true;
+ 	data << -M_PI/36		<< "-5d"		<< true;
+ 	data << -7*M_PI/8		<< "-157d30'"		<< true;
+ 	data << -2*M_PI/5		<< "-72d"		<< true;
+ 	data << -M_PI			<< "-180d"		<< true;
+-	data << -10*M_PI/648		<< "-2d46'40\""		<< true;
++	data << -10*M_PI/648		<< "-2d46'40.00\""	<< true;
+ 
+ 	while (data.count()>=3)
+ 	{
+@@ -282,9 +282,7 @@ void TestConversions::testRadToDMSStrAdapt()
+ 		bool flag	= data.takeFirst().toBool();
+ 		QString rdms	= StelUtils::radToDmsStrAdapt(rad, flag);
+ 		QVERIFY2(rdms==edms, qPrintable(QString("%1 radians = %2 (expected %3) [flag: %4]")
+-						.arg(QString::number(rad, 'f', 5))
+-						.arg(rdms)
+-						.arg(edms)
++						.arg(QString::number(rad, 'f', 5), rdms, edms)
+ 						.arg(flag)));
+ 	}
+ }
+@@ -381,9 +379,7 @@ void TestConversions::testRadToDMSStr()
+ 		bool useDF	= data.takeFirst().toBool();
+ 		QString rdms	= StelUtils::radToDmsStr(rad, decimalF, useDF);
+ 		QVERIFY2(rdms==edms, qPrintable(QString("%1 radians = %2 (expected %3) [flags: %4, %5]")
+-						.arg(QString::number(rad, 'f', 5))
+-						.arg(rdms)
+-						.arg(edms)
++						.arg(QString::number(rad, 'f', 5), rdms, edms)
+ 						.arg(decimalF)
+ 						.arg(useDF)));
+ 	}

--- a/sci-astronomy/stellarium/stellarium-0.22.1-r1.ebuild
+++ b/sci-astronomy/stellarium/stellarium-0.22.1-r1.ebuild
@@ -1,0 +1,148 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+PYTHON_COMPAT=( python3_{8..10} )
+inherit cmake desktop flag-o-matic python-any-r1 xdg virtualx
+
+DESCRIPTION="3D photo-realistic skies in real time"
+HOMEPAGE="https://stellarium.org/"
+MY_DSO_VERSION="3.15"
+SRC_URI="
+	https://github.com/Stellarium/stellarium/releases/download/v${PV}/${P}.tar.gz
+	deep-sky? (
+		https://github.com/Stellarium/stellarium-data/releases/download/dso-${MY_DSO_VERSION}/catalog-${MY_DSO_VERSION}.dat -> ${PN}-dso-catalog-${MY_DSO_VERSION}.dat
+	)
+	doc? (
+		https://github.com/Stellarium/stellarium/releases/download/v${PV}/stellarium_user_guide-${PV}-1.pdf
+	)
+	stars? (
+		https://github.com/Stellarium/stellarium-data/releases/download/stars-2.0/stars_4_1v0_2.cat
+		https://github.com/Stellarium/stellarium-data/releases/download/stars-2.0/stars_5_2v0_1.cat
+		https://github.com/Stellarium/stellarium-data/releases/download/stars-2.0/stars_6_2v0_1.cat
+		https://github.com/Stellarium/stellarium-data/releases/download/stars-2.0/stars_7_2v0_1.cat
+		https://github.com/Stellarium/stellarium-data/releases/download/stars-2.0/stars_8_2v0_1.cat
+	)"
+
+LICENSE="GPL-2+ SGI-B-2.0"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~ppc64 ~riscv ~x86"
+IUSE="debug deep-sky doc gps media nls stars telescope test webengine"
+
+# Python interpreter is used while building RemoteControl plugin
+BDEPEND="
+	${PYTHON_DEPS}
+	doc? ( app-doc/doxygen[dot] )
+	nls? ( dev-qt/linguist-tools:5 )
+"
+RDEPEND="
+	dev-libs/qtcompress:=
+	dev-qt/qtcharts:5
+	dev-qt/qtcore:5
+	dev-qt/qtgui:5
+	dev-qt/qtnetwork:5
+	dev-qt/qtopengl:5
+	dev-qt/qtprintsupport:5
+	dev-qt/qtscript:5
+	dev-qt/qtwidgets:5
+	media-fonts/dejavu
+	sys-libs/zlib
+	virtual/opengl
+	gps? (
+		dev-qt/qtpositioning:5
+		dev-qt/qtserialport:5
+		sci-geosciences/gpsd:=[cxx]
+	)
+	media? ( dev-qt/qtmultimedia:5[widgets] )
+	telescope? (
+		dev-qt/qtserialport:5
+		sci-libs/indilib:=
+	)
+	webengine? ( dev-qt/qtwebengine:5[widgets] )
+"
+DEPEND="${RDEPEND}
+	dev-qt/qtconcurrent:5
+	test? ( dev-qt/qttest:5 )
+"
+
+RESTRICT="!test? ( test )"
+
+PATCHES=(
+	"${FILESDIR}/stellarium-0.20.3-unbundle-indi.patch"
+	"${FILESDIR}/stellarium-0.20.3-unbundle-zlib.patch"
+	"${FILESDIR}/stellarium-0.22.1-fix-star-manager-segfault.patch"
+	"${FILESDIR}/stellarium-0.22.1-unbundle-qtcompress.patch"
+	"${FILESDIR}/stellarium-0.22.1-fix-test-x86.patch"
+	"${FILESDIR}/stellarium-0.22.1-fix-conv.patch"
+)
+
+src_prepare() {
+	cmake_src_prepare
+	use debug || append-cppflags -DQT_NO_DEBUG #415769
+
+	# Several libraries are bundled, remove them.
+	rm -r src/external/{libindi,qtcompress,zlib}/ || die
+
+	# qcustomplot can't be easily unbundled because it uses qcustomplot 1
+	# while we have qcustomplot 2 in tree which changed API a bit
+	# Also the license of the external qcustomplot is incompatible with stellarium
+
+	# for glues_stel aka libtess I couldn't find an upstream with the same API
+
+	# unbundling of qxlsx depends on https://github.com/QtExcel/QXlsx/pull/185
+
+	local remaining="$(cd src/external/ && echo */)"
+	if [[ "${remaining}" != "glues_stel/ qcustomplot/ qxlsx/" ]]; then
+		eqawarn "Need to unbundle more deps: ${remaining}"
+	fi
+}
+
+src_configure() {
+	local mycmakeargs=(
+		-DENABLE_GPS="$(usex gps)"
+		-DENABLE_MEDIA="$(usex media)"
+		-DENABLE_NLS="$(usex nls)"
+		-DENABLE_TESTING="$(usex test)"
+		-DUSE_PLUGIN_TELESCOPECONTROL="$(usex telescope)"
+		$(cmake_use_find_package webengine Qt5WebEngine)
+		$(cmake_use_find_package webengine Qt5WebEngineWidgets)
+	)
+	cmake_src_configure
+}
+
+src_test() {
+	virtx cmake_src_test
+}
+
+src_compile() {
+	cmake_src_compile
+
+	if use doc ; then
+		cmake_build apidoc
+	fi
+}
+
+src_install() {
+	if use doc ; then
+		local HTML_DOCS=( "${BUILD_DIR}/doc/html/." )
+		dodoc "${DISTDIR}/stellarium_user_guide-${PV}-1.pdf"
+	fi
+	cmake_src_install
+
+	# use the more up-to-date system fonts
+	rm "${ED}"/usr/share/stellarium/data/DejaVuSans{Mono,}.ttf || die
+	dosym ../../fonts/dejavu/DejaVuSans.ttf /usr/share/stellarium/data/DejaVuSans.ttf
+	dosym ../../fonts/dejavu/DejaVuSansMono.ttf /usr/share/stellarium/data/DejaVuSansMono.ttf
+
+	if use stars ; then
+		insinto /usr/share/${PN}/stars/default
+		doins "${DISTDIR}"/stars_4_1v0_2.cat
+		doins "${DISTDIR}"/stars_{5,6,7,8}_2v0_1.cat
+	fi
+	if use deep-sky ; then
+		insinto /usr/share/${PN}/nebulae/default
+		newins "${DISTDIR}/${PN}-dso-catalog-${MY_DSO_VERSION}.dat" catalog.dat
+	fi
+	newicon doc/images/stellarium-logo.png ${PN}.png
+}


### PR DESCRIPTION
Patch from https://github.com/Stellarium/stellarium/issues/2460

Closes: https://bugs.gentoo.org/847064
Package-Manager: Portage-3.0.30, Repoman-3.0.3
Signed-off-by: Alexey Sokolov <alexey+gentoo@asokolov.org>

```diff
--- stellarium-0.22.1.ebuild	2022-05-24 22:42:13.648556452 +0100
+++ stellarium-0.22.1-r1.ebuild	2022-05-24 22:45:30.482002494 +0100
@@ -27,7 +27,7 @@ SRC_URI="
 
 LICENSE="GPL-2+ SGI-B-2.0"
 SLOT="0"
-KEYWORDS="amd64 ppc ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~ppc ~ppc64 ~riscv ~x86"
 IUSE="debug deep-sky doc gps media nls stars telescope test webengine"
 
 # Python interpreter is used while building RemoteControl plugin
@@ -73,6 +73,7 @@ PATCHES=(
 	"${FILESDIR}/stellarium-0.20.3-unbundle-zlib.patch"
 	"${FILESDIR}/stellarium-0.22.1-fix-star-manager-segfault.patch"
 	"${FILESDIR}/stellarium-0.22.1-unbundle-qtcompress.patch"
+	"${FILESDIR}/stellarium-0.22.1-fix-test-x86.patch"
 )
 
 src_prepare() {
```