### PR TITLE
sys-boot/syslinux: Adding bios flag

### DIFF
--- a/sys-boot/syslinux/metadata.xml
+++ b/sys-boot/syslinux/metadata.xml
@@ -11,4 +11,7 @@
 <upstream>
 	<remote-id type="cpe">cpe:/a:gentoo:syslinux</remote-id>
 </upstream>
+<use>
+        <flag name="bios">Build installers for BIOS</flag>
+</use>
 </pkgmetadata>

--- a/sys-boot/syslinux/metadata.xml
+++ b/sys-boot/syslinux/metadata.xml
@@ -12,6 +12,6 @@
 	<remote-id type="cpe">cpe:/a:gentoo:syslinux</remote-id>
 </upstream>
 <use>
-        <flag name="bios">Build installers for BIOS</flag>
+	<flag name="bios">Build installers for BIOS</flag>
 </use>
 </pkgmetadata>

--- a/sys-boot/syslinux/syslinux-6.04_pre1-r2.ebuild
+++ b/sys-boot/syslinux/syslinux-6.04_pre1-r2.ebuild
@@ -20,7 +20,7 @@ SRC_URI="https://www.kernel.org/pub/linux/utils/boot/syslinux/${SRC_URI_DIR}/${P
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="-* amd64 x86"
-IUSE="custom-cflags"
+IUSE="custom-cflags bios"
 
 RDEPEND="sys-apps/util-linux
 	sys-fs/mtools
@@ -74,8 +74,8 @@ src_prepare() {
 			"
 	fi
 	case ${ARCH} in
-		amd64)	loaderarch="efi64" ;;
-		x86)	loaderarch="efi32" ;;
+		amd64)	loaderarch=$(usex bios bios efi64) ;;
+		x86)	loaderarch=$(usex bios bios efi32) ;;
 		*)	ewarn "Unsupported architecture, building installers only." ;;
 	esac
 


### PR DESCRIPTION
Adding bios flag for sys-boot/syslinux, to allow building installers for BIOS, according to https://wiki.syslinux.org/wiki/index.php?title=Doc/building.


Signed-off-by: Wiktor Jaskulski <wjaskulski@adva.com>