### PR TITLE
media-sound/spotify: wrapper script should send spotify links with dbus to already running spotify instance

### DIFF
--- a/media-sound/spotify/files/spotify-wrapper
+++ b/media-sound/spotify/files/spotify-wrapper
@@ -3,21 +3,36 @@
 export LD_LIBRARY_PATH="/usr/$LIBDIR/apulse"
 
 if command -v spotify-dbus.py > /dev/null; then
-	echo "Launching spotify with Gnome systray integration."
-	spotify-dbus.py "$@"
+        echo "Launching spotify with Gnome systray integration."
+        spotify-dbus.py "$@"
 elif command -v spotify-tray > /dev/null; then
-	echo "Launching spotify with generic systray integration."
-	minimized=
-	for arg; do
-		if [ "$arg" = --minimized ]; then
-			minimized=$arg
-			break
-		fi
-	done
-	spotify-tray \
-		--client-path="$SPOTIFY_HOME/spotify" --toggle $minimized -- "$@"
+        echo "Launching spotify with generic systray integration."
+        minimized=
+        for arg; do
+                if [ "$arg" = --minimized ]; then
+                        minimized=$arg
+                        break
+                fi
+        done
+        spotify-tray \
+                --client-path="$SPOTIFY_HOME/spotify" --toggle $minimized -- "$@"
 else
-	echo "Neither gnome-integration-spotify nor spotify-tray are installed."
-	echo "Launching spotify without systray integration."
-	exec "$SPOTIFY_HOME/spotify" "$@"
+    if pgrep -f "Spotify/[0-9].[0-9].[0-9]" > /dev/null; then
+        busline="org.mpris.MediaPlayer2.spotify /org/mpris/MediaPlayer2 org.mpris.MediaPlayer2.Player.OpenUri ${1}"
+        echo "Spotify is already running"
+        echo "Sending ${busline} to dbus"
+        if command -v qdbus &> /dev/null; then
+            qdbus $busline
+            exit
+        fi
+        if command -v dbus-send &> /dev/null; then
+            dbus-send $busline
+            exit
+        fi
+        echo "No bus dispatcher found."
+    else
+        echo "Neither gnome-integration-spotify nor spotify-tray are installed."
+        echo "Launching spotify without systray integration."
+        exec "$SPOTIFY_HOME/spotify" "$@"
+    fi
 fi


### PR DESCRIPTION
Current wrapper launches new instances of spotify-client when an attempt is made to open a spotify URL.

This replacement launcher properly passes the URL with dbus

Bug: https://bugs.gentoo.org/848948

Signed-off-by: Henry Paradiz <henry.paradiz@gmail.com>
