### PR TITLE
profiles/base/package.use.mask: mask rust 1.61.0 with miri

### DIFF
--- a/profiles/base/package.use.mask
+++ b/profiles/base/package.use.mask
@@ -6,6 +6,12 @@
 # This file is only for generic masks. For arch-specific masks (i.e.
 # mask everywhere, unmask on arch/*) use arch/base.
 
+# Miezhiko <miezhiko@gmail.org> (2022-05-26)
+# miri will fail to build with 1.61.0 release
+# it's not supported to work with releases but sometimes it works
+# could be patched or just ignored on this release
+=dev-lang/rust-1.61.0* miri
+
 # Michał Górny <mgorny@gentoo.org> (2022-05-25)
 # dev-python/sphinxcontrib-openapi is masked for removal.
 dev-python/jupyter_server doc


### PR DESCRIPTION
can't build miri with this release, it's designed only to work on nightly, sometimes works on releases

I'd just mask the USE flag, at least awhile there is no patch.

```
error[E0308]: mismatched types
   --> src/tools/miri/src/helpers.rs:513:54
    |
513 |         let last_error = if target.families.contains(&"unix".to_owned()) {
    |                                                      ^^^^^^^^^^^^^^^^^^ expected enum `Cow`, found struct `std::string::String`
    |
    = note: expected reference `&Cow<'_, str>`
               found reference `&std::string::String`

error[E0308]: mismatched types
   --> src/tools/miri/src/helpers.rs:537:44
    |
537 |         } else if target.families.contains(&"windows".to_owned()) {
    |                                            ^^^^^^^^^^^^^^^^^^^^^ expected enum `Cow`, found struct `std::string::String`
    |
    = note: expected reference `&Cow<'_, str>`
               found reference `&std::string::String`

error[E0599]: no method named `as_str` found for enum `Cow<'static, str>` in the current scope
   --> src/tools/miri/src/machine.rs:230:39
    |
230 |         match this.tcx.sess.target.os.as_str() {
    |                                       ^^^^^^ help: there is an associated function with a similar name: `as_ptr`

error[E0599]: no method named `as_str` found for enum `Cow<'static, str>` in the current scope
  --> src/tools/miri/src/shims/foreign_items.rs:49:57
   |
49 |         let min_align = match this.tcx.sess.target.arch.as_str() {
   |                                                         ^^^^^^ help: there is an associated function with a similar name: `as_ptr`

error[E0599]: no method named `as_str` found for enum `Cow<'static, str>` in the current scope
   --> src/tools/miri/src/shims/foreign_items.rs:698:48
    |
698 |             _ => match this.tcx.sess.target.os.as_str() {
    |                                                ^^^^^^ help: there is an associated function with a similar name: `as_ptr`

error[E0599]: no method named `as_str` found for enum `Cow<'static, str>` in the current scope
   --> src/tools/miri/src/shims/posix/foreign_items.rs:465:47
    |
465 |                 match this.tcx.sess.target.os.as_str() {
    |                                               ^^^^^^ help: there is an associated function with a similar name: `as_ptr`

error[E0599]: no method named `as_str` found for enum `Cow<'static, str>` in the current scope
  --> src/tools/miri/src/shims/env.rs:44:48
   |
44 |         let target_os = ecx.tcx.sess.target.os.as_str();
   |                                                ^^^^^^ help: there is an associated function with a similar name: `as_ptr`

Some errors have detailed explanations: E0308, E0599.
For more information about an error, try `rustc --explain E0308`.
```