### PR TITLE
dev-python/twisted: update deps for dev-python/h2

### DIFF
--- a/dev-python/twisted/twisted-22.4.0.ebuild
+++ b/dev-python/twisted/twisted-22.4.0.ebuild
@@ -46,7 +46,7 @@ RDEPEND="
 	serial? ( >=dev-python/pyserial-3.0[${PYTHON_USEDEP}] )
 	http2? (
 		>=dev-python/h2-3.0.0[${PYTHON_USEDEP}]
-		<dev-python/h2-4.0.0[${PYTHON_USEDEP}]
+		<dev-python/h2-5.0.0[${PYTHON_USEDEP}]
 		>=dev-python/priority-1.1.0[${PYTHON_USEDEP}]
 		<dev-python/priority-2.0[${PYTHON_USEDEP}]
 	)


### PR DESCRIPTION
Reviewing the setup.cfg file I have verified that the supported versions of dev-pyhthon/h2 range from version 3 to 4 both inclusive
Look at line 97 of the setup.cfg file

Package-Manager: Portage-3.0.30-r3, Repoman-3.0.3-r1
Signed-off-by: INODE64 <ffelix@inode64.com>