### PR TITLE
app-portage/elicense: Allow python:3.10 and pypy3

### DIFF
--- a/app-portage/elicense/elicense-1.0.2.ebuild
+++ b/app-portage/elicense/elicense-1.0.2.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="7"
-PYTHON_COMPAT=( python3_{7,8,9} )
+PYTHON_COMPAT=( pypy3 python3_{8..10} )
 inherit distutils-r1
 
 if [[ ${PV} == "9999" ]]; then

--- a/app-portage/elicense/elicense-9999.ebuild
+++ b/app-portage/elicense/elicense-9999.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="7"
-PYTHON_COMPAT=( python3_{7,8,9} )
+PYTHON_COMPAT=( pypy3 python3_{8..10} )
 inherit distutils-r1
 
 if [[ ${PV} == "9999" ]]; then

--- a/profiles/features/selinux/package.use.mask
+++ b/profiles/features/selinux/package.use.mask
@@ -22,6 +22,7 @@ www-servers/uwsgi uwsgi_plugins_systemd_logger
 # Brian Dolbec <dolsen@gentoo.org> (2014-09-17)
 # mask pypy for several utilities due to incompatibility with libselinux
 sys-apps/portage python_targets_pypy3
+app-portage/elicense python_targets_pypy3
 app-portage/elogv python_targets_pypy3
 app-portage/gentoolkit python_targets_pypy3
 app-portage/layman python_targets_pypy3


### PR DESCRIPTION
Both pypy3 and python:3.10 are already supported by a stable version of sys-apps/portage.
Drop python:3.7.

Bug: https://bugs.gentoo.org/show_bug.cgi?id=842786

Signed-off-by: Jan Vesely <jano.vesely@gmail.com>