### PR TITLE
Add USE valgrind to pulseaudio-daemon and libpulse

### DIFF
--- a/media-libs/libpulse/libpulse-16.0.ebuild
+++ b/media-libs/libpulse/libpulse-16.0.ebuild
@@ -24,7 +24,7 @@ S="${WORKDIR}/${MY_P}"
 LICENSE="LGPL-2.1+"
 
 SLOT="0"
-IUSE="+asyncns dbus doc +glib gtk selinux systemd tcpd test X"
+IUSE="+asyncns dbus doc +glib gtk selinux systemd tcpd test valgrind X"
 RESTRICT="!test? ( test )"
 
 # NOTE: libpcre needed in some cases, bug #472228
@@ -40,6 +40,7 @@ RDEPEND="
 	selinux? ( sec-policy/selinux-pulseaudio )
 	systemd? ( sys-apps/systemd:= )
 	tcpd? ( sys-apps/tcp-wrappers )
+	valgrind? ( dev-util/valgrind )
 	X? (
 		x11-libs/libX11[${MULTILIB_USEDEP}]
 		>=x11-libs/libxcb-1.6[${MULTILIB_USEDEP}]
@@ -131,7 +132,7 @@ multilib_src_configure() {
 		$(meson_native_use_feature systemd)
 		$(meson_native_use_feature tcpd tcpwrap)
 		-Dudev=disabled
-		-Dvalgrind=auto
+		$(meson_native_use_feature valgrind)
 		$(meson_feature X x11)
 
 		# Echo cancellation

--- a/media-libs/libpulse/metadata.xml
+++ b/media-libs/libpulse/metadata.xml
@@ -13,5 +13,6 @@
     </flag>
     <flag name="asyncns">Use libasyncns for asynchronous name resolution.</flag>
     <flag name="doc">Build the doxygen-described API documentation.</flag>
+    <flag name="valgrind">Compile in valgrind memory hints</flag>
   </use>
 </pkgmetadata>

--- a/media-sound/pulseaudio-daemon/metadata.xml
+++ b/media-sound/pulseaudio-daemon/metadata.xml
@@ -56,6 +56,7 @@
       Build with <pkg>sys-apps/systemd</pkg> support to replace standalone
       ConsoleKit.
     </flag>
+    <flag name="valgrind">Compile in valgrind memory hints</flag>
     <flag name="native-headset">
       Build with native HSP backend for bluez 5.
     </flag>

--- a/media-sound/pulseaudio-daemon/pulseaudio-daemon-16.0.ebuild
+++ b/media-sound/pulseaudio-daemon/pulseaudio-daemon-16.0.ebuild
@@ -33,7 +33,7 @@ SLOT="0"
 # TODO: Find out why webrtc-aec is + prefixed - there's already the always available speexdsp-aec
 # NOTE: The current ebuild sets +X almost certainly just for the pulseaudio.desktop file
 IUSE="+alsa +alsa-plugin aptx +asyncns bluetooth dbus elogind equalizer +gdbm gstreamer +glib gtk ipv6 jack ldac lirc
-native-headset ofono-headset +orc oss selinux sox ssl systemd system-wide tcpd test +udev +webrtc-aec +X zeroconf"
+native-headset ofono-headset +orc oss selinux sox ssl systemd system-wide tcpd test +udev valgrind +webrtc-aec +X zeroconf"
 
 RESTRICT="!test? ( test )"
 
@@ -56,7 +56,7 @@ REQUIRED_USE="
 # - media-libs/speexdsp is providing echo canceller implementation and used in resampler
 # TODO: libatomic_ops is only needed on some architectures and conditions, and then at runtime too
 COMMON_DEPEND="
-	>=media-libs/libpulse-${PV}[dbus?,glib?,systemd?,tcpd?,X?]
+	>=media-libs/libpulse-${PV}[dbus?,glib?,systemd?,tcpd?,valgrind?,X?]
 	dev-libs/libatomic_ops
 	>=media-libs/libsndfile-1.0.20
 	>=media-libs/speexdsp-1.2
@@ -95,6 +95,7 @@ COMMON_DEPEND="
 	systemd? ( sys-apps/systemd:= )
 	tcpd? ( sys-apps/tcp-wrappers )
 	udev? ( >=virtual/udev-143[hwdb(+)] )
+	valgrind? ( dev-util/valgrind )
 	webrtc-aec? ( >=media-libs/webrtc-audio-processing-0.2:0 )
 	X? (
 		>=x11-libs/libxcb-1.6
@@ -211,7 +212,7 @@ src_configure() {
 		$(meson_feature systemd)
 		$(meson_feature tcpd tcpwrap) # TODO: This should technically be enabled for 32bit too, but at runtime it probably is never used without daemon?
 		$(meson_feature udev)
-		-Dvalgrind=auto
+		$(meson_feature valgrind)
 		$(meson_feature X x11)
 
 		# Echo cancellation


### PR DESCRIPTION
- replace valgrind auto dependency at build time with explicit `USE valgrind` and `DEPEND` on `dev-util/valgrind`
- correct `media-sound/pulseaudio-daemon` dependency on `media-libs/libpulse[valgrind?]`

This fixes build error in certain environments so no revbump.

Closes: https://bugs.gentoo.org/847541