### PR TITLE
sci-libs/opencascade: allow some exceptions

### DIFF
--- a/sci-libs/opencascade/opencascade-7.5.2-r6.ebuild
+++ b/sci-libs/opencascade/opencascade-7.5.2-r6.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=8
+EAPI=7
 
 inherit cmake flag-o-matic
 
@@ -15,7 +15,7 @@ S="${WORKDIR}/occt-V${MY_PV}"
 
 LICENSE="|| ( Open-CASCADE-LGPL-2.1-Exception-1.0 LGPL-2.1 )"
 SLOT="0/${PV_MAJ}"
-KEYWORDS="amd64 ~arm64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE="debug doc examples ffmpeg freeimage gles2-only json optimize tbb vtk"
 
 REQUIRED_USE="?? ( optimize tbb )"
@@ -89,6 +89,7 @@ src_configure() {
 	local mycmakeargs=(
 		-DBUILD_DOC_Overview=$(usex doc)
 		-DBUILD_Inspector=$(usex examples)
+		-DBUILD_RELEASE_DISABLE_EXCEPTIONS=OFF # bug #847916
 
 		-DINSTALL_DIR_BIN="$(get_libdir)/${PN}/bin"
 		-DINSTALL_DIR_CMAKE="$(get_libdir)/cmake/${PN}"

--- a/sci-libs/opencascade/opencascade-7.5.3-r7.ebuild
+++ b/sci-libs/opencascade/opencascade-7.5.3-r7.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 inherit cmake flag-o-matic
 
@@ -15,7 +15,7 @@ S="${WORKDIR}/occt-V${MY_PV}"
 
 LICENSE="|| ( Open-CASCADE-LGPL-2.1-Exception-1.0 LGPL-2.1 )"
 SLOT="0/${PV_MAJ}"
-KEYWORDS="~amd64 ~arm64 ~x86"
+KEYWORDS="amd64 ~arm64 ~x86"
 IUSE="debug doc examples ffmpeg freeimage gles2-only json optimize tbb vtk"
 
 REQUIRED_USE="?? ( optimize tbb )"
@@ -89,6 +89,7 @@ src_configure() {
 	local mycmakeargs=(
 		-DBUILD_DOC_Overview=$(usex doc)
 		-DBUILD_Inspector=$(usex examples)
+		-DBUILD_RELEASE_DISABLE_EXCEPTIONS=OFF # bug #847916
 
 		-DINSTALL_DIR_BIN="$(get_libdir)/${PN}/bin"
 		-DINSTALL_DIR_CMAKE="$(get_libdir)/cmake/${PN}"

--- a/sci-libs/opencascade/opencascade-7.6.0-r4.ebuild
+++ b/sci-libs/opencascade/opencascade-7.6.0-r4.ebuild
@@ -84,6 +84,7 @@ src_configure() {
 	local mycmakeargs=(
 		-DBUILD_DOC_Overview=$(usex doc)
 		-DBUILD_Inspector=$(usex examples)
+		-DBUILD_RELEASE_DISABLE_EXCEPTIONS=OFF # bug #847916
 
 		-DINSTALL_DIR_BIN="$(get_libdir)/${PN}/bin"
 		-DINSTALL_DIR_CMAKE="$(get_libdir)/cmake/${PN}"

--- a/sci-libs/opencascade/opencascade-7.6.1-r1.ebuild
+++ b/sci-libs/opencascade/opencascade-7.6.1-r1.ebuild
@@ -84,6 +84,7 @@ src_configure() {
 	local mycmakeargs=(
 		-DBUILD_DOC_Overview=$(usex doc)
 		-DBUILD_Inspector=$(usex examples)
+		-DBUILD_RELEASE_DISABLE_EXCEPTIONS=OFF # bug #847916
 
 		-DINSTALL_DIR_BIN="$(get_libdir)/${PN}/bin"
 		-DINSTALL_DIR_CMAKE="$(get_libdir)/cmake/${PN}"


### PR DESCRIPTION
Disabling some of the exceptions (BUILD_RELEASE_DISABLE_EXCEPTIONS=ON),
which is the default, can lead to crashes of consumer applications. This
patch disables this option, so those exceptions are enabled.

Bug: https://github.com/FreeCAD/FreeCAD/issues/6200
Closes: https://bugs.gentoo.org/847916
Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>