### PR TITLE
dev-python/tpm2-pytss: Avoid dance in python_test via upsteam patch

### DIFF
--- a/dev-python/tpm2-pytss/files/tpm2-pytss-1.1.0-src-move-package-under-src-directory.patch
+++ b/dev-python/tpm2-pytss/files/tpm2-pytss-1.1.0-src-move-package-under-src-directory.patch
@@ -1,0 +1,239 @@
+From a03b66dd73a2ff58ebf847864102585aa3d11af7 Mon Sep 17 00:00:00 2001
+From: William Roberts <william.c.roberts@intel.com>
+Date: Wed, 11 May 2022 17:07:53 -0500
+Subject: [PATCH] src: move package under src directory
+
+Issue #341 reports that building a wheel and running the tests fails. I
+was able to reproduce this behavior with the following commands:
+
+python3 -Bm build -w --no-isolation
+python3 -m installer --destdir=installation dist/*.whl
+export PYTHONPATH="/home/wcrobert/tmp/installation/usr/lib/python3.8/site-packages"
+pytest test/test_types.py
+
+Note:
+  - Current Working Directory is the repo clone, so tpm2-pytss
+  - The export command may need to be updated for your specific version
+    of python.
+
+It fails with:
+ImportError while importing test module '/home/wcrobert/workspace/tpm2-pytss/test/test_types.py'.
+<snip>
+E   ModuleNotFoundError: No module named 'tpm2_pytss._libtpm2_pytss'
+
+However, this issue is a red herring. This really has to do with the
+fact that the relative import in the test code tries to resolve to
+non-built package in that directory rather then the built one on
+PYTHONPATH.
+
+Proposed solutions to use full package names also don't work, becuase it
+has to resolve to the built package and it will still attempt to resolve
+the non-built package. The least finicky solution to fix this, was to
+match what bcrypt was doing and move it under a src directory so it
+forces the resolution to not occur on that directory and inplace (pip
+install -e .) installations still work as well.
+
+Fixes: #341
+
+Signed-off-by: William Roberts <william.c.roberts@intel.com>
+---
+ .gitignore                                           | 4 ++--
+ MANIFEST.in                                          | 8 ++++----
+ scripts/prepare_headers.py                           | 2 +-
+ setup.cfg                                            | 6 ++++--
+ setup.py                                             | 8 +++++---
+ {tpm2_pytss => src/tpm2_pytss}/ESAPI.py              | 0
+ {tpm2_pytss => src/tpm2_pytss}/FAPI.py               | 0
+ {tpm2_pytss => src/tpm2_pytss}/TCTI.py               | 0
+ {tpm2_pytss => src/tpm2_pytss}/TCTILdr.py            | 0
+ {tpm2_pytss => src/tpm2_pytss}/TSS2_Exception.py     | 0
+ {tpm2_pytss => src/tpm2_pytss}/__init__.py           | 0
+ {tpm2_pytss => src/tpm2_pytss}/callbacks.py          | 0
+ {tpm2_pytss => src/tpm2_pytss}/constants.py          | 0
+ {tpm2_pytss => src/tpm2_pytss}/encoding.py           | 0
+ {tpm2_pytss => src/tpm2_pytss}/fapi_info.py          | 0
+ src/tpm2_pytss/internal/__init__.py                  | 0
+ {tpm2_pytss => src/tpm2_pytss}/internal/constants.py | 0
+ {tpm2_pytss => src/tpm2_pytss}/internal/crypto.py    | 0
+ {tpm2_pytss => src/tpm2_pytss}/internal/templates.py | 0
+ {tpm2_pytss => src/tpm2_pytss}/internal/utils.py     | 0
+ {tpm2_pytss => src/tpm2_pytss}/tsskey.py             | 0
+ {tpm2_pytss => src/tpm2_pytss}/types.py              | 0
+ {tpm2_pytss => src/tpm2_pytss}/utils.py              | 0
+ 23 files changed, 16 insertions(+), 12 deletions(-)
+ rename {tpm2_pytss => src/tpm2_pytss}/ESAPI.py (100%)
+ rename {tpm2_pytss => src/tpm2_pytss}/FAPI.py (100%)
+ rename {tpm2_pytss => src/tpm2_pytss}/TCTI.py (100%)
+ rename {tpm2_pytss => src/tpm2_pytss}/TCTILdr.py (100%)
+ rename {tpm2_pytss => src/tpm2_pytss}/TSS2_Exception.py (100%)
+ rename {tpm2_pytss => src/tpm2_pytss}/__init__.py (100%)
+ rename {tpm2_pytss => src/tpm2_pytss}/callbacks.py (100%)
+ rename {tpm2_pytss => src/tpm2_pytss}/constants.py (100%)
+ rename {tpm2_pytss => src/tpm2_pytss}/encoding.py (100%)
+ rename {tpm2_pytss => src/tpm2_pytss}/fapi_info.py (100%)
+ create mode 100644 src/tpm2_pytss/internal/__init__.py
+ rename {tpm2_pytss => src/tpm2_pytss}/internal/constants.py (100%)
+ rename {tpm2_pytss => src/tpm2_pytss}/internal/crypto.py (100%)
+ rename {tpm2_pytss => src/tpm2_pytss}/internal/templates.py (100%)
+ rename {tpm2_pytss => src/tpm2_pytss}/internal/utils.py (100%)
+ rename {tpm2_pytss => src/tpm2_pytss}/tsskey.py (100%)
+ rename {tpm2_pytss => src/tpm2_pytss}/types.py (100%)
+ rename {tpm2_pytss => src/tpm2_pytss}/utils.py (100%)
+
+diff --git a/.gitignore b/.gitignore
+index 07e277e..396cfdb 100644
+--- a/.gitignore
++++ b/.gitignore
+@@ -40,5 +40,5 @@ public/
+ *.rej
+ htmlcov
+ /.pytest_cache/
+-tpm2_pytss/internal/type_mapping.py
+-tpm2_pytss/internal/versions.py
++src/tpm2_pytss/internal/type_mapping.py
++src/tpm2_pytss/internal/versions.py
+diff --git a/MANIFEST.in b/MANIFEST.in
+index 6bc43ab..7bbc96a 100644
+--- a/MANIFEST.in
++++ b/MANIFEST.in
+@@ -1,8 +1,8 @@
+ include README.md
+ include LICENSE
+-include tpm2_pytss/version
+-include tpm2_pytss/config.json
+-recursive-include tpm2_pytss/swig *
++include src/tpm2_pytss/version
++include src/tpm2_pytss/config.json
++recursive-include src/tpm2_pytss/swig *
+ recursive-include tests *
+ recursive-include examples *
+-exclude tpm2_pytss/internal/type_mapping.py
++exclude src/tpm2_pytss/internal/type_mapping.py
+diff --git a/scripts/prepare_headers.py b/scripts/prepare_headers.py
+index 0864a3d..7eb0a57 100644
+--- a/scripts/prepare_headers.py
++++ b/scripts/prepare_headers.py
+@@ -11,7 +11,7 @@ import textwrap
+ 
+ # import tpm2_pytss.constants
+ constants_spec = importlib.util.spec_from_file_location(
+-    "tpm2_pytss.internal.constants", "tpm2_pytss/internal/constants.py"
++    "tpm2_pytss.internal.constants", "src/tpm2_pytss/internal/constants.py"
+ )
+ constants = importlib.util.module_from_spec(constants_spec)
+ constants_spec.loader.exec_module(constants)
+diff --git a/setup.cfg b/setup.cfg
+index 89a3c7a..5426a07 100644
+--- a/setup.cfg
++++ b/setup.cfg
+@@ -18,9 +18,11 @@ classifiers =
+     Programming Language :: Python :: 3.10
+ 
+ [options]
+-packages =
++package_dir=
++    =src
++packages=
+     tpm2_pytss
+-    tpm2_pytss/internal
++    tpm2_pytss.internal
+ setup_requires =
+     setuptools_scm[toml]>=3.4.3
+     cffi>=1.0.0
+diff --git a/setup.py b/setup.py
+index f10fe73..b7f1c96 100644
+--- a/setup.py
++++ b/setup.py
+@@ -200,13 +200,15 @@ class type_generator(build_ext):
+ 
+         p = os.path.join(self.build_lib, "tpm2_pytss/internal/type_mapping.py")
+         sp = os.path.join(
+-            os.path.dirname(__file__), "tpm2_pytss/internal/type_mapping.py"
++            os.path.dirname(__file__), "src/tpm2_pytss/internal/type_mapping.py"
+         )
+ 
+         vp = os.path.join(self.build_lib, "tpm2_pytss/internal/versions.py")
+-        svp = os.path.join(os.path.dirname(__file__), "tpm2_pytss/internal/versions.py")
++        svp = os.path.join(
++            os.path.dirname(__file__), "src/tpm2_pytss/internal/versions.py"
++        )
+ 
+-        print(f"generated _type_map with {len(type_map)} mappings")
++        print(f"generated _type_map with {len(type_map)} mappings in {p} and {sp}")
+         print(f"generated _element_type_map with {len(element_type_map)} mappings")
+         print(f"generated _versions with {len(versions)} versions")
+ 
+diff --git a/tpm2_pytss/ESAPI.py b/src/tpm2_pytss/ESAPI.py
+similarity index 100%
+rename from tpm2_pytss/ESAPI.py
+rename to src/tpm2_pytss/ESAPI.py
+diff --git a/tpm2_pytss/FAPI.py b/src/tpm2_pytss/FAPI.py
+similarity index 100%
+rename from tpm2_pytss/FAPI.py
+rename to src/tpm2_pytss/FAPI.py
+diff --git a/tpm2_pytss/TCTI.py b/src/tpm2_pytss/TCTI.py
+similarity index 100%
+rename from tpm2_pytss/TCTI.py
+rename to src/tpm2_pytss/TCTI.py
+diff --git a/tpm2_pytss/TCTILdr.py b/src/tpm2_pytss/TCTILdr.py
+similarity index 100%
+rename from tpm2_pytss/TCTILdr.py
+rename to src/tpm2_pytss/TCTILdr.py
+diff --git a/tpm2_pytss/TSS2_Exception.py b/src/tpm2_pytss/TSS2_Exception.py
+similarity index 100%
+rename from tpm2_pytss/TSS2_Exception.py
+rename to src/tpm2_pytss/TSS2_Exception.py
+diff --git a/tpm2_pytss/__init__.py b/src/tpm2_pytss/__init__.py
+similarity index 100%
+rename from tpm2_pytss/__init__.py
+rename to src/tpm2_pytss/__init__.py
+diff --git a/tpm2_pytss/callbacks.py b/src/tpm2_pytss/callbacks.py
+similarity index 100%
+rename from tpm2_pytss/callbacks.py
+rename to src/tpm2_pytss/callbacks.py
+diff --git a/tpm2_pytss/constants.py b/src/tpm2_pytss/constants.py
+similarity index 100%
+rename from tpm2_pytss/constants.py
+rename to src/tpm2_pytss/constants.py
+diff --git a/tpm2_pytss/encoding.py b/src/tpm2_pytss/encoding.py
+similarity index 100%
+rename from tpm2_pytss/encoding.py
+rename to src/tpm2_pytss/encoding.py
+diff --git a/tpm2_pytss/fapi_info.py b/src/tpm2_pytss/fapi_info.py
+similarity index 100%
+rename from tpm2_pytss/fapi_info.py
+rename to src/tpm2_pytss/fapi_info.py
+diff --git a/src/tpm2_pytss/internal/__init__.py b/src/tpm2_pytss/internal/__init__.py
+new file mode 100644
+index 0000000..e69de29
+diff --git a/tpm2_pytss/internal/constants.py b/src/tpm2_pytss/internal/constants.py
+similarity index 100%
+rename from tpm2_pytss/internal/constants.py
+rename to src/tpm2_pytss/internal/constants.py
+diff --git a/tpm2_pytss/internal/crypto.py b/src/tpm2_pytss/internal/crypto.py
+similarity index 100%
+rename from tpm2_pytss/internal/crypto.py
+rename to src/tpm2_pytss/internal/crypto.py
+diff --git a/tpm2_pytss/internal/templates.py b/src/tpm2_pytss/internal/templates.py
+similarity index 100%
+rename from tpm2_pytss/internal/templates.py
+rename to src/tpm2_pytss/internal/templates.py
+diff --git a/tpm2_pytss/internal/utils.py b/src/tpm2_pytss/internal/utils.py
+similarity index 100%
+rename from tpm2_pytss/internal/utils.py
+rename to src/tpm2_pytss/internal/utils.py
+diff --git a/tpm2_pytss/tsskey.py b/src/tpm2_pytss/tsskey.py
+similarity index 100%
+rename from tpm2_pytss/tsskey.py
+rename to src/tpm2_pytss/tsskey.py
+diff --git a/tpm2_pytss/types.py b/src/tpm2_pytss/types.py
+similarity index 100%
+rename from tpm2_pytss/types.py
+rename to src/tpm2_pytss/types.py
+diff --git a/tpm2_pytss/utils.py b/src/tpm2_pytss/utils.py
+similarity index 100%
+rename from tpm2_pytss/utils.py
+rename to src/tpm2_pytss/utils.py
+-- 
+2.35.1
+

--- a/dev-python/tpm2-pytss/tpm2-pytss-1.1.0.ebuild
+++ b/dev-python/tpm2-pytss/tpm2-pytss-1.1.0.ebuild
@@ -7,8 +7,11 @@ PYTHON_COMPAT=( python3_{8..10} )
 inherit distutils-r1
 
 DESCRIPTION="Python bindings for TSS"
-HOMEPAGE="https://pypi.org/project/tpm2-pytss/"
-SRC_URI="https://github.com/tpm2-software/${PN}/archive/refs/tags/${PV}.tar.gz -> ${P}.tar.gz"
+HOMEPAGE="
+	https://pypi.org/project/tpm2-pytss
+	https://github.com/tpm2-software/tpm2-pytss
+"
+SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="BSD-2"
 SLOT="0"
@@ -29,12 +32,10 @@ DEPEND="${RDEPEND}
 BDEPEND="dev-python/setuptools_scm[${PYTHON_USEDEP}]
 	dev-python/pkgconfig[${PYTHON_USEDEP}]"
 
-distutils_enable_tests pytest
+PATCHES=(
+	"${FILESDIR}/${PN}-1.1.0-src-move-package-under-src-directory.patch"
+	)
 
 export SETUPTOOLS_SCM_PRETEND_VERSION=${PV}
 
-python_test() {
-	cd ${T}
-	PYTHONPATH="${BUILD_DIR}/install/$(python_get_sitedir):${S}:${PYTHONPATH}" \
-	epytest ${S}/test --import-mode=importlib
-}
+distutils_enable_tests pytest


### PR DESCRIPTION
Also update HOMEPAGE and SRC_URI. Build changes only, no functional
changes.Change from Github upstream to PyPi, but the files are identical anyway.