### PR TITLE
toolchain.eclass: ensure thumb mode for armv6m

### DIFF
--- a/eclass/toolchain.eclass
+++ b/eclass/toolchain.eclass
@@ -1102,6 +1102,8 @@ toolchain_src_configure() {
 				fi
 			done
 
+			# Convert armv6m to armv6-m
+			[[ ${arm_arch} == armv6m ]] && arm_arch=armv6-m
 			# Convert armv7{a,r,m} to armv7-{a,r,m}
 			[[ ${arm_arch} == armv7? ]] && arm_arch=${arm_arch/7/7-}
 			# See if this is a valid --with-arch flag


### PR DESCRIPTION
Currently the eclass ensures thumb mode compilation for libgcc for
armv7m targets
with
```
  [[ ${arm_arch} == armv7? ]] && arm_arch=${arm_arch/7/7-}
  ...
  [[ ${arm_arch} == *-m ]] && confgcc+=( --with-mode=thumb )
```
But libgcc should also be compiled in thumb mode for the armv6m target.

Add the dash as is done for the armv7 case so that `--with-mode=thumb`
option is added for armv6m.

Signed-off-by: Marek Behún <kabel@kernel.org>