### PR TITLE
app-admin/syslog-summary: python compat add 3.10

### DIFF
--- a/app-admin/syslog-summary/syslog-summary-1.14-r5.ebuild
+++ b/app-admin/syslog-summary/syslog-summary-1.14-r5.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{7,8,9} )
+PYTHON_COMPAT=( python3_{9,10} )
 
 inherit python-single-r1
 


### PR DESCRIPTION
    add python 3.10
    drop python 3.7 and 3.8

Bug: https://bugs.gentoo.org/845435
Signed-off-by: Paul Healy <lmiphay@gmail.com>