### PR TITLE
sys-apps/dstat: add python 3.10 to python compat

### DIFF
--- a/sys-apps/dstat/dstat-0.7.4-r2.ebuild
+++ b/sys-apps/dstat/dstat-0.7.4-r2.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{7..9} )
+PYTHON_COMPAT=( python3_{9..10} )
 
 inherit python-r1
 


### PR DESCRIPTION
add python 3.10
drop python 3.7 and 3.8

Bug: https://bugs.gentoo.org/846308
Signed-off-by: Paul Healy <lmiphay@gmail.com>