### PR TITLE
x11-libs/cmrt: require video_cards_intel for dependency x11-libs/libdrm

### DIFF
--- a/x11-libs/cmrt/cmrt-1.0.6-r2.ebuild
+++ b/x11-libs/cmrt/cmrt-1.0.6-r2.ebuild
@@ -15,7 +15,7 @@ KEYWORDS="~amd64 ~x86 ~amd64-linux ~x86-linux"
 
 BDEPEND="virtual/pkgconfig"
 DEPEND="
-	>=x11-libs/libdrm-2.4.23
+	>=x11-libs/libdrm-2.4.23[video_cards_intel]
 	>=x11-libs/libva-2.0.0
 "
 RDEPEND="${DEPEND}"


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/847889
Closes: https://bugs.gentoo.org/847889
Signed-off-by: Kai-Chun Ning <kaichun.ning@gmail.com>