### PR TITLE
app-editors/qhexedit2: fix PyQt5>=5.15.6 RDEPEND

### DIFF
--- a/app-editors/qhexedit2/qhexedit2-0.8.6_p20190316-r2.ebuild
+++ b/app-editors/qhexedit2/qhexedit2-0.8.6_p20190316-r2.ebuild
@@ -31,7 +31,7 @@ RDEPEND="
 	python? (
 		${PYTHON_DEPS}
 		$(python_gen_cond_dep '
-			dev-python/PyQt5[gui,widgets,${PYTHON_USEDEP}]
+			>=dev-python/PyQt5-5.15.6[gui,widgets,${PYTHON_USEDEP}]
 		')
 	)
 "

--- a/app-editors/qhexedit2/qhexedit2-0.8.9_p20210525-r2.ebuild
+++ b/app-editors/qhexedit2/qhexedit2-0.8.9_p20210525-r2.ebuild
@@ -33,7 +33,7 @@ RDEPEND="
 	python? (
 		${PYTHON_DEPS}
 		$(python_gen_cond_dep '
-			dev-python/PyQt5[gui,widgets,${PYTHON_USEDEP}]
+			>=dev-python/PyQt5-5.15.6[gui,widgets,${PYTHON_USEDEP}]
 		')
 	)
 "


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/820473