### PR TITLE
sci-mathematics/petsc: fix configuration with USE=mumps

### DIFF
--- a/sci-mathematics/petsc/petsc-3.16.0.ebuild
+++ b/sci-mathematics/petsc/petsc-3.16.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -171,7 +171,7 @@ src_configure() {
 		[-lptesmumps,-lptscotch,-lptscotcherr,-lscotch,-lscotcherr]) \
 		$(petsc_with mumps scalapack \
 			/usr/include/scalapack -lscalapack) \
-		$(use_with mumps mumps \
+		$(petsc_with mumps mumps \
 			/usr/include \
 			[-lcmumps,-ldmumps,-lsmumps,-lzmumps,-lmumps_common,-lpord]) \
 		--with-imagemagick=0 \

--- a/sci-mathematics/petsc/petsc-3.17.1.ebuild
+++ b/sci-mathematics/petsc/petsc-3.17.1.ebuild
@@ -168,12 +168,12 @@ src_configure() {
 		$(petsc_with superlu superlu /usr/include/superlu -lsuperlu) \
 		$(petsc_with scotch ptscotch /usr/include/scotch [-lptesmumps,-lptscotch,-lptscotcherr,-lscotch,-lscotcherr]) \
 		$(petsc_with mumps scalapack /usr/include/scalapack -lscalapack) \
+		$(petsc_with mumps mumps /usr/include [-lcmumps,-ldmumps,-lsmumps,-lzmumps,-lmumps_common,-lpord]) \
 		$(use fortran && echo "$(petsc_select mpi fc mpif77 $(tc-getF77))") \
 		$(use int64 && echo "--with-index-size=64") \
 		$(use_with boost) \
 		$(use_with fftw) \
 		$(use_with hdf5) \
-		$(use_with mumps mumps /usr/include [-lcmumps,-ldmumps,-lsmumps,-lzmumps,-lmumps_common,-lpord]) \
 		$(use_with X x) \
 		$(use_with X x11)
 }


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/848789
Signed-off-by: Fabio Rossi <rossi.f@inwind.it>