### PR TITLE
sci-libs/hdf5: fix cmake include dir regression

### DIFF
--- a/sci-libs/hdf5/hdf5-1.12.2-r1.ebuild
+++ b/sci-libs/hdf5/hdf5-1.12.2-r1.ebuild
@@ -64,6 +64,10 @@ pkg_setup() {
 src_configure() {
 	use sparc && tc-is-gcc && append-flags -fno-tree-ccp # bug 686620
 	local mycmakeargs=(
+		# Workaround needed to allow build with USE=fortran when an older
+		# version is installed. See bug #808633 and
+		# https://github.com/HDFGroup/hdf5/issues/1027 upstream.
+		-DCMAKE_INCLUDE_DIRECTORIES_PROJECT_BEFORE=ON
 		-DBUILD_STATIC_LIBS=OFF
 		-DONLY_SHARED_LIBS=ON
 		-DFETCHCONTENT_FULLY_DISCONNECTED=ON


### PR DESCRIPTION
An attempt to build `hdf5-1.12.2-r1` with `USE='fortran'` on a system where an older version of the package has already been installed will fail due to system headers taking precedence over the ones present in the source directory.

This exact [issue](https://bugs.gentoo.org/8086330) has already been fixed in 225b7ee for 1.12.1, the workaround though somehow hadn't make it into the new ebuild. This commit brings it in.