### PR TITLE
app-editors/neovim: fix lua patch for neovim git

### DIFF
--- a/app-editors/neovim/files/neovim-9999-cmake_lua_version.patch
+++ b/app-editors/neovim/files/neovim-9999-cmake_lua_version.patch
@@ -1,0 +1,11 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -384,7 +384,7 @@
+ option(PREFER_LUA "Prefer Lua over LuaJIT in the nvim executable." OFF)
+ 
+ if(PREFER_LUA)
+-  find_package(Lua 5.1 EXACT REQUIRED)
++  find_package(Lua ${PREFER_LUA} EXACT REQUIRED)
+   set(LUA_PREFERRED_INCLUDE_DIRS ${LUA_INCLUDE_DIR})
+   set(LUA_PREFERRED_LIBRARIES ${LUA_LIBRARIES})
+   # Passive (not REQUIRED): if LUAJIT_FOUND is not set, nvim-test is skipped.

--- a/app-editors/neovim/neovim-9999.ebuild
+++ b/app-editors/neovim/neovim-9999.ebuild
@@ -67,10 +67,14 @@ BDEPEND="
 "
 
 PATCHES=(
-	"${FILESDIR}/${PN}-0.4.4-cmake_lua_version.patch"
 	"${FILESDIR}/${PN}-0.4.4-cmake-release-type.patch"
 	"${FILESDIR}/${PN}-0.4.4-cmake-darwin.patch"
 )
+if [[ ${PV} == 9999 ]]; then
+	PATCHES+=("${FILESDIR}/${PN}-9999-cmake_lua_version.patch")
+else
+	PATCHES+=("${FILESDIR}/${PN}-0.4.4-cmake_lua_version.patch")
+fi
 
 src_prepare() {
 	# Use our system vim dir


### PR DESCRIPTION
Hi, from neovim git commit [802a23926d237139822dda0ab712de3e1a98e5f9](https://github.com/neovim/neovim/commit/802a23926d237139822dda0ab712de3e1a98e5f9), lua version setting in `CMakeLists.txt` has become to:
``` diff
- find_package(Lua 5.1 REQUIRED)
+ find_package(Lua 5.1 EXACT REQUIRED)
```
So the lua version patch for neovim-9999 should be modified to fit that. And that is what this PR does.
Thanks for taking a look!

Signed-off-by: Tianyang Zhou qsdrqs@gmail.com