### PR TITLE
profiles/base: remove ruby26 from default RUBY_TARGETS

### DIFF
--- a/profiles/base/make.defaults
+++ b/profiles/base/make.defaults
@@ -102,7 +102,7 @@ LCD_DEVICES="bayrad cfontz cfontz633 glk hd44780 lb216 lcdm001 mtxorb ncurses te
 # Manuel Rüger <mrueg@gentoo.org> (2015-09-09)
 # Default Ruby build target(s)
 # Updated to include ruby27 on 2021-10-10
-RUBY_TARGETS="ruby26 ruby27"
+RUBY_TARGETS="ruby27"
 
 # Enable extended filesystem attribute support by default.
 # https://archives.gentoo.org/gentoo-dev/message/ba0e3457e4b807e79816f0df03566af0


### PR DESCRIPTION
ruby26 is EOL since 2022-04-12 as per https://www.ruby-lang.org/en/downloads/branches.

Bug: https://bugs.gentoo.org/849383
Signed-off-by: Bertrand Jacquin <bertrand@jacquin.bzh>