### PR TITLE
mail-client/clawsker-1.3.5: remove failed test

### DIFF
--- a/mail-client/clawsker/clawsker-1.3.5.ebuild
+++ b/mail-client/clawsker/clawsker-1.3.5.ebuild
@@ -24,6 +24,11 @@ RDEPEND="
 "
 BDEPEND="test? ( dev-perl/Test-Exception )"
 
+PATCHES=(
+	# TODO: add Test::NeedsDisplay Perl package and remove this patch (bug #841707)
+	"${FILESDIR}/${PN}-remove-get_screen_height-test.patch"
+)
+
 src_install() {
 	emake install DESTDIR="${D}" PREFIX=/usr
 }

--- a/mail-client/clawsker/files/clawsker-remove-get_screen_height-test.patch
+++ b/mail-client/clawsker/files/clawsker-remove-get_screen_height-test.patch
@@ -1,0 +1,23 @@
+deleted file mode 100644
+--- a/t/get_screen_height.t
++++ /dev/null
+@@ -1,19 +0,0 @@
+-use 5.010_000;
+-use strict;
+-use utf8;
+-use Test::NeedsDisplay;
+-use Test::More tests => 3;
+-use Gtk3;
+-
+-require_ok ('Clawsker');
+-
+-use Clawsker;
+-
+-Gtk3->init;
+-
+-ok ( defined &Clawsker::get_screen_height, 'has function' );
+-
+-my $height = Clawsker::get_screen_height();
+-
+-ok ( $height > 0, "has $height pixels" );
+-


### PR DESCRIPTION
Remove `get_screen_height` test as it requires absent Test::NeedsDisplay Perl package
See: https://bugs.gentoo.org/841707