### PR TITLE
enable pypy3 on smart-live-rebuild

### DIFF
--- a/app-portage/gentoopm/gentoopm-0.4.ebuild
+++ b/app-portage/gentoopm/gentoopm-0.4.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=flit
-PYTHON_COMPAT=( python3_{8..10} )
+PYTHON_COMPAT=( python3_{8..10} pypy3 )
 
 inherit distutils-r1
 

--- a/app-portage/gentoopm/gentoopm-9999.ebuild
+++ b/app-portage/gentoopm/gentoopm-9999.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=flit
-PYTHON_COMPAT=( python3_{8..10} )
+PYTHON_COMPAT=( python3_{8..10} pypy3 )
 
 inherit distutils-r1 git-r3
 

--- a/app-portage/smart-live-rebuild/smart-live-rebuild-1.4.0.ebuild
+++ b/app-portage/smart-live-rebuild/smart-live-rebuild-1.4.0.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=flit
-PYTHON_COMPAT=( python3_{8..10} )
+PYTHON_COMPAT=( python3_{8..10} pypy3 )
 
 inherit distutils-r1
 

--- a/app-portage/smart-live-rebuild/smart-live-rebuild-9999.ebuild
+++ b/app-portage/smart-live-rebuild/smart-live-rebuild-9999.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=flit
-PYTHON_COMPAT=( python3_{8..10} )
+PYTHON_COMPAT=( python3_{8..10} pypy3 )
 
 inherit distutils-r1 git-r3
 

--- a/profiles/features/selinux/package.use.mask
+++ b/profiles/features/selinux/package.use.mask
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # Georgy Yakovlev <gyakovlev@gentoo.org> (2020-10-21)
@@ -26,3 +26,5 @@ app-portage/elogv python_targets_pypy3
 app-portage/gentoolkit python_targets_pypy3
 app-portage/layman python_targets_pypy3
 app-portage/repoman python_targets_pypy3
+app-portage/smart-live-rebuild python_targets_pypy3
+app-portage/gentoopm python_targets_pypy3


### PR DESCRIPTION
this enables smart-live-rebuild to be used when pypy3 is used to run emerge

NOTE: I didn't try FEATURES=test due to being out of time right now, I can do that before merging if so desired.