### PR TITLE
sys-process/btop: Don't enforce g++ compiler

### DIFF
--- a/sys-process/btop/btop-1.2.7-r1.ebuild
+++ b/sys-process/btop/btop-1.2.7-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit xdg-utils
+inherit toolchain-funcs xdg-utils
 
 DESCRIPTION="A monitor of resources"
 HOMEPAGE="https://github.com/aristocratos/btop"
@@ -13,6 +13,10 @@ LICENSE="Apache-2.0"
 SLOT="0"
 KEYWORDS="~amd64 ~arm64 ~x86"
 
+PATCHES=(
+	"${FILESDIR}/${P}-respect-cxx-var-839318.patch"
+)
+
 src_prepare() {
 	default
 	# btop installs README.md to /usr/share/btop by default
@@ -21,7 +25,7 @@ src_prepare() {
 
 src_compile() {
 	# Disable btop optimization flags, since we have our flags in CXXFLAGS
-	emake OPTFLAGS=""
+	emake OPTFLAGS="" CXX="$(tc-getCXX)"
 }
 
 src_install() {

--- a/sys-process/btop/files/btop-1.2.7-respect-cxx-var-839318.patch
+++ b/sys-process/btop/files/btop-1.2.7-respect-cxx-var-839318.patch
@@ -1,0 +1,17 @@
+--- a/Makefile
++++ b/Makefile
+@@ -55,11 +55,11 @@ endif
+ 
+ #? Compiler and Linker
+ ifeq ($(shell command -v g++-11 >/dev/null; echo $$?),0)
+-	CXX := g++-11
++	CXX ?= g++-11
+ else ifeq ($(shell command -v g++11 >/dev/null; echo $$?),0)
+-	CXX := g++11
++	CXX ?= g++11
+ else ifeq ($(shell command -v g++ >/dev/null; echo $$?),0)
+-	CXX := g++
++	CXX ?= g++
+ endif
+ override CXX_VERSION := $(shell $(CXX) -dumpfullversion -dumpversion || echo 0)
+ 


### PR DESCRIPTION
Backport of [0]. The current build system enforces using the g++
binaries it finds in $PATH.

[0] https://github.com/aristocratos/btop/pull/353

Signed-off-by: Adrian Schollmeyer <nex+b-g-o@nexadn.de>
Closes: https://bugs.gentoo.org/839318