### PR TITLE
dev-util/clion: fix ninja detection error

### DIFF
--- a/dev-util/clion/clion-2022.1.1.ebuild
+++ b/dev-util/clion/clion-2022.1.1.ebuild
@@ -96,6 +96,7 @@ src_install() {
 		# Fix #763582
 		fperms 755 "${dir}"/jbr/lib/{chrome-sandbox,jcef_helper,jexec,jspawnhelper}
 	fi
+	dosym "${EPREFIX}/usr/bin/ninja" "${dir}"/bin/ninja/linux/ninja
 
 	make_wrapper "${PN}" "${dir}/bin/${PN}.sh"
 	newicon "bin/${PN}.svg" "${PN}.svg"


### PR DESCRIPTION
Clion 2022.1 fails to use system ninja executable, added symlink
installation to fix that.

Package-Manager: Portage-3.0.30, Repoman-3.0.3
Signed-off-by: Azamat H. Hackimov <azamat.hackimov@gmail.com>