### PR TITLE
sci-libs/cantera: Fix for >=pip-22.1.1. Restrict sundials[lapack] version support

### DIFF
--- a/sci-libs/cantera/cantera-2.5.1-r1.ebuild
+++ b/sci-libs/cantera/cantera-2.5.1-r1.ebuild
@@ -8,7 +8,7 @@ PYTHON_COMPAT=( python3_{8,9} )
 FORTRAN_NEEDED=fortran
 FORTRAN_STANDARD="77 90"
 
-inherit desktop fortran-2 python-single-r1 scons-utils toolchain-funcs
+inherit fortran-2 python-single-r1 scons-utils toolchain-funcs
 
 DESCRIPTION="Object-oriented tool suite for chemical kinetics, thermodynamics, and transport"
 HOMEPAGE="https://www.cantera.org"

--- a/sci-libs/cantera/cantera-2.5.1-r4.ebuild
+++ b/sci-libs/cantera/cantera-2.5.1-r4.ebuild
@@ -16,7 +16,7 @@ SRC_URI="https://github.com/Cantera/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="amd64 ~x86"
 IUSE="+cti fortran lapack +python test"
 RESTRICT="!test? ( test )"
 
@@ -39,7 +39,8 @@ RDEPEND="
 		')
 	)
 	dev-cpp/yaml-cpp
-	<sci-libs/sundials-5.9.0:0=[lapack?]
+	!lapack? ( <sci-libs/sundials-5.9.0:0= )
+	lapack? ( <sci-libs/sundials-5.3.0:0=[lapack] )
 "
 
 DEPEND="
@@ -50,17 +51,14 @@ DEPEND="
 	python? (
 		$(python_gen_cond_dep '
 			dev-python/cython[${PYTHON_USEDEP}]
-			dev-python/pip[${PYTHON_USEDEP}]
 		')
 	)
 	test? (
-		>=dev-cpp/gtest-1.11.0
+		>=dev-cpp/gtest-1.8.0
 		python? (
 			$(python_gen_cond_dep '
 				dev-python/h5py[${PYTHON_USEDEP}]
 				dev-python/pandas[${PYTHON_USEDEP}]
-				dev-python/pytest[${PYTHON_USEDEP}]
-				dev-python/scipy[${PYTHON_USEDEP}]
 			')
 		)
 	)
@@ -120,7 +118,7 @@ src_test() {
 }
 
 src_install() {
-	escons install stage_dir="${D}" libdirname="$(get_libdir)"
+	escons install stage_dir="${D}" libdirname="$(get_libdir)" python_prefix="$(python_get_sitedir)"
 	if ! use cti ; then
 		rm -r "${D}/usr/share/man" || die "Can't remove man files."
 	else

--- a/sci-libs/cantera/cantera-2.6.0-r1.ebuild
+++ b/sci-libs/cantera/cantera-2.6.0-r1.ebuild
@@ -16,7 +16,7 @@ SRC_URI="https://github.com/Cantera/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="amd64 ~x86"
+KEYWORDS="~amd64 ~x86"
 IUSE="+cti fortran lapack +python test"
 RESTRICT="!test? ( test )"
 
@@ -39,7 +39,8 @@ RDEPEND="
 		')
 	)
 	dev-cpp/yaml-cpp
-	<sci-libs/sundials-5.9.0:0=[lapack?]
+	!lapack? ( sci-libs/sundials:0= )
+	lapack? ( <sci-libs/sundials-5.3.0:0=[lapack?] )
 "
 
 DEPEND="
@@ -50,14 +51,17 @@ DEPEND="
 	python? (
 		$(python_gen_cond_dep '
 			dev-python/cython[${PYTHON_USEDEP}]
+			dev-python/pip[${PYTHON_USEDEP}]
 		')
 	)
 	test? (
-		>=dev-cpp/gtest-1.8.0
+		>=dev-cpp/gtest-1.11.0
 		python? (
 			$(python_gen_cond_dep '
 				dev-python/h5py[${PYTHON_USEDEP}]
 				dev-python/pandas[${PYTHON_USEDEP}]
+				dev-python/pytest[${PYTHON_USEDEP}]
+				dev-python/scipy[${PYTHON_USEDEP}]
 			')
 		)
 	)
@@ -117,7 +121,7 @@ src_test() {
 }
 
 src_install() {
-	escons install stage_dir="${D}" libdirname="$(get_libdir)" python_prefix="$(python_get_sitedir)"
+	escons install stage_dir="${D}" libdirname="$(get_libdir)"
 	if ! use cti ; then
 		rm -r "${D}/usr/share/man" || die "Can't remove man files."
 	else

--- a/sci-libs/cantera/files/cantera-2.5.1_env.patch
+++ b/sci-libs/cantera/files/cantera-2.5.1_env.patch
@@ -32,6 +32,33 @@ diff -Naur old/SConstruct new/SConstruct
  
  # Print values of all build options:
  print("Configuration variables read from 'cantera.conf' and command line:")
+@@ -1149,10 +1149,24 @@
+         if retcode == 0:
+             config_error("Failed to determine Sundials BLAS/LAPACK.")
+         env['has_sundials_lapack'] = int(has_sundials_lapack.strip())
+-    else:
+-        # In Sundials 2.6, SUNDIALS_BLAS_LAPACK is either defined or undefined
++    elif sundials_ver < parse_version('5.5'):
++        # In Sundials 2.6-5.5, SUNDIALS_BLAS_LAPACK is either defined or undefined
+         env['has_sundials_lapack'] = conf.CheckDeclaration('SUNDIALS_BLAS_LAPACK',
+                 '#include "sundials/sundials_config.h"', 'C++')
++    else:
++        # In Sundials 5.5 and higher, two defines are included specific to the
++        # SUNLINSOL packages indicating whether SUNDIALS has been built with LAPACK
++        lapackband = conf.CheckDeclaration(
++            "SUNDIALS_SUNLINSOL_LAPACKBAND",
++            '#include "sundials/sundials_config.h"',
++            "C++",
++        )
++        lapackdense = conf.CheckDeclaration(
++            "SUNDIALS_SUNLINSOL_LAPACKDENSE",
++            '#include "sundials/sundials_config.h"',
++            "C++",
++        )
++        env["has_sundials_lapack"] = lapackband and lapackdense
+ 
+     # In the case where a user is trying to link Cantera to an external BLAS/LAPACK
+     # library, but Sundials was configured without this support, print a Warning.
 diff -Naur old/interfaces/cython/SConscript new/interfaces/cython/SConscript
 --- old/interfaces/cython/SConscript	2021-03-21 01:18:43.000000000 +0300
 +++ new/interfaces/cython/SConscript	2021-03-21 01:59:29.000000000 +0300

--- a/sci-libs/cantera/files/cantera-2.6.0_env.patch
+++ b/sci-libs/cantera/files/cantera-2.6.0_env.patch
@@ -43,6 +43,27 @@ diff -Naur old/SConstruct new/SConstruct
  
  # Print values of all build options:
  # the (updated) "cantera.conf" combines all options that were specified by the user
+diff -Naur old/interfaces/cython/SConscript new/interfaces/cython/SConscript
+--- old/interfaces/cython/SConscript
++++ new/interfaces/cython/SConscript
+@@ -107,7 +107,7 @@
+                               obj, LIBPREFIX="", SHLIBSUFFIX=module_ext,
+                               SHLIBPREFIX="", LIBSUFFIXES=[module_ext])
+ 
+-build_cmd = ("$python_cmd_esc -m pip wheel -v --no-build-isolation --use-feature=in-tree-build --no-deps "
++build_cmd = ("$python_cmd_esc -m pip wheel -v --no-build-isolation --no-deps "
+              "--wheel-dir=build/python/dist build/python")
+ plat = info['plat'].replace('-', '_').replace('.', '_')
+ wheel_name = (f"Cantera-{env['cantera_version']}-cp{py_version_nodot}"
+@@ -172,7 +172,7 @@
+ 
+     install_cmd.append(f"--root={stage_dir.resolve()}")
+ 
+-install_cmd.extend(("--no-build-isolation", "--use-feature=in-tree-build", "--no-deps", "-v", "--force-reinstall",
++install_cmd.extend(("--no-build-isolation", "--no-deps", "-v", "--force-reinstall",
+                     "build/python"))
+ if localenv['PYTHON_INSTALLER'] == 'direct':
+     mod_inst = install(localenv.Command, 'dummy', mod,
 diff -Naur old/test_problems/SConscript new/test_problems/SConscript
 --- old/test_problems/SConscript
 +++ new/test_problems/SConscript


### PR DESCRIPTION
1. Fix installation using `>=dev-python/pip-22.1.1`

Closes: https://bugs.gentoo.org/849938

2. Restrict `sci-libs/sundials` version to build `sci-libs/cantera[lapack]`

It seems that `>=sci-libs/cantera-2.5.1-r3[lapack]` tests 
are currently broken if build against `>=sci-libs/sundials-5.8.0[lapack]`.

The `cantera-2.5.1_env.patch` is updated here to proper check if `>=sundials-5.5` is build with lapack support.

This change doesn't affect `cantera-2.5.1-r1` at all and allow to build `cantera-2.5.1-r3` 
against `sundials[lapack]` but in `cantera-2.5.1-r4` restriction of sundials is used (doesn't affect too but fix for future).
So revbump is assumed to keep stablized.
