### PR TITLE
sys-fs/ncdu: package can't respect LDFLAGS/CFLAGS/etc.

### DIFF
--- a/sys-fs/ncdu/ncdu-2.1.2.ebuild
+++ b/sys-fs/ncdu/ncdu-2.1.2.ebuild
@@ -18,6 +18,10 @@ BDEPEND="
 	virtual/pkgconfig
 "
 
+# see https://github.com/ziglang/zig/issues/3382
+# For now, Zig doesn't support CFLAGS/LDFLAGS/etc.
+QA_FLAGS_IGNORED="/usr/bin/ncdu"
+
 src_test() {
 	zig build test || die "Tests failed"
 }


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/850106
Closes: https://bugs.gentoo.org/850109
Signed-off-by: Eric Joldasov <bratishkaerik@getgoogleoff.me>