### PR TITLE
Sndio pkgconfdir

### DIFF
--- a/media-sound/sndio/files/sndio-1.8.0-fix-hardcoded-pkgconfdir.patch
+++ b/media-sound/sndio/files/sndio-1.8.0-fix-hardcoded-pkgconfdir.patch
@@ -1,0 +1,12 @@
+diff -Naur a/configure b/configure
+--- a/configure	2021-05-07 10:49:58.000000000 +0300
++++ b/configure	2022-06-07 14:49:07.623069325 +0300
+@@ -205,7 +205,7 @@
+ datadir="${datadir:-$prefix/share}"
+ includedir="${includedir:-$prefix/include}"
+ libdir="${libdir:-$exec_prefix/lib}"
+-pkgconfdir="${pkgconfdir:-$prefix/lib/pkgconfig}"
++pkgconfdir="${pkgconfdir:-$libdir/pkgconfig}"
+ mandir="${mandir:-$prefix/share/man}"
+ 
+ #

--- a/media-sound/sndio/sndio-1.8.0-r1.ebuild
+++ b/media-sound/sndio/sndio-1.8.0-r1.ebuild
@@ -1,0 +1,55 @@
+# Copyright 2020-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit multilib-minimal toolchain-funcs
+
+DESCRIPTION="small audio and MIDI framework part of the OpenBSD project"
+HOMEPAGE="http://www.sndio.org/"
+if [[ "${PV}" == "9999" ]]; then
+	inherit git-r3
+	EGIT_REPO_URI="https://caoua.org/git/sndio"
+	EGIT_MIN_CLONE_TYPE="single+tags"
+else
+	SRC_URI="http://www.sndio.org/${P}.tar.gz"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~ppc ~ppc64 ~riscv ~sparc ~x86"
+fi
+
+LICENSE="ISC"
+SLOT="0/7.1"
+IUSE="alsa"
+
+DEPEND="
+	dev-libs/libbsd[${MULTILIB_USEDEP}]
+	alsa? ( media-libs/alsa-lib[${MULTILIB_USEDEP}] )
+"
+RDEPEND="
+	${DEPEND}
+	acct-user/sndiod
+"
+
+PATCHES=( "${FILESDIR}"/sndio-1.8.0-fix-hardcoded-pkgconfdir.patch )
+
+src_prepare() {
+	default
+	multilib_copy_sources
+}
+
+multilib_src_configure() {
+	tc-export CC
+
+	./configure \
+		--prefix="${EPREFIX}"/usr \
+		--libdir="${EPREFIX}"/usr/$(get_libdir) \
+		--privsep-user=sndiod \
+		--with-libbsd \
+		$(use_enable alsa) \
+	|| die "Configure failed"
+}
+
+src_install() {
+	multilib-minimal_src_install
+
+	doinitd "${FILESDIR}/sndiod"
+}

--- a/profiles/base/package.use.mask
+++ b/profiles/base/package.use.mask
@@ -33,10 +33,9 @@ dev-python/tempora doc
 dev-python/jupyter_server doc
 
 # Joonas Niilola <juippis@gentoo.org> (2022-05-03)
-# sndio is currently broken in Gentoo, #842420.
 # system-python-libs is HIGHLY EXPERIMENTAL according to upstream, and
 # still being worked on in Gentoo.
->=www-client/firefox-100.0 sndio system-python-libs
+>=www-client/firefox-100.0 system-python-libs
 
 # Piotr Karbowski <slashbeast@gentoo.org> (2022-04-29)
 # There's a bug with gnutls support leading TLS certificates


### PR DESCRIPTION
@gentoo/toolchain does this look sensible? Can confirm it looks to be working like it should now:
```
# equery f sndio | grep pc 
/usr/lib/pkgconfig/sndio.pc
/usr/lib64/pkgconfig/sndio.pc
```
```
# cat /usr/lib/pkgconfig/sndio.pc
prefix=/usr
exec_prefix=${prefix}
libdir=${exec_prefix}/lib
includedir=${prefix}/include

Name: sndio
Description: sndio library
Version: 1.8.0
Requires:
Libs: -L${libdir} -lsndio
Cflags: -I${includedir}
```
```
# cat /usr/lib64/pkgconfig/sndio.pc
prefix=/usr
exec_prefix=${prefix}
libdir=${exec_prefix}/lib64
includedir=${prefix}/include

Name: sndio
Description: sndio library
Version: 1.8.0
Requires:
Libs: -L${libdir} -lsndio
Cflags: -I${includedir}
```
`[ebuild   R    ] www-client/firefox-101.0:rapid::gentoo  USE="clang dbus gmp-autoupdate openh264 sndio system-av1 system-harfbuzz system-icu system-jpeg system-libevent system-libvpx system-webp -debug -eme-free -geckodriver -hardened -hwaccel -jack -libproxy -lto -pgo -pulseaudio -screencast (-selinux) -system-png -system-python-libs -wayland -wifi"`