### PR TITLE
kernel-build.eclass: Allow installation of vmlinux

### DIFF
--- a/eclass/kernel-build.eclass
+++ b/eclass/kernel-build.eclass
@@ -195,6 +195,11 @@ kernel-build_src_install() {
 	local image_path=$(dist-kernel_get_image_path)
 	cp -p "build/${image_path}" "${ED}/usr/src/linux-${ver}/${image_path}" || die
 
+	# Install the unstripped uncompressed vmlinux for use with systemtap
+	# etc.  Use mv rather than doins for the same reason as above --
+	# space and time.
+	use debug && mv build/vmlinux "/usr/src/linux-${ver}/"
+
 	# building modules fails with 'vmlinux has no symtab?' if stripped
 	use ppc64 && dostrip -x "/usr/src/linux-${ver}/${image_path}"
 


### PR DESCRIPTION
It is used by systemtap to reliably find kernel debuginfo. Thankfully
the build path is one of the searched ones so we do not need to install
it into /boot.  There is a use flag for compiling the kernel with
debuginfo, but it is not being installed.

Signed-off-by: Martin Kletzander <nert.pinx@gmail.com>