### PR TITLE
dev-libs/poco: fix collision with app-arch/arc

### DIFF
--- a/dev-libs/poco/poco-1.11.2.ebuild
+++ b/dev-libs/poco/poco-1.11.2.ebuild
@@ -91,6 +91,7 @@ src_configure() {
 		-DPOCO_UNBUNDLED=ON
 		-DENABLE_APACHECONNECTOR=OFF
 		-DENABLE_ACTIVERECORD="$(usex activerecord)"
+		-DENABLE_ACTIVERECORD_COMPILER="$(usex activerecord)"
 		-DENABLE_CPPPARSER="$(usex cppparser)"
 		-DENABLE_CRYPTO="$(usex ssl)"
 		-DENABLE_DATA="$(usex data)"


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/847067
Signed-off-by: David Roman <davidroman96@gmail.com>