### PR TITLE
distutils-r1.eclass: DISTUTILS_USE_PEP517=no, take two

### DIFF
--- a/dev-python/gpep517/gpep517-6-r1.ebuild
+++ b/dev-python/gpep517/gpep517-6-r1.ebuild
@@ -1,0 +1,41 @@
+# Copyright 2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+# please keep this ebuild at EAPI 7 -- sys-apps/portage dep
+EAPI=7
+
+DISTUTILS_USE_PEP517=no
+PYTHON_COMPAT=( pypy3 python3_{8..11} )
+
+inherit distutils-r1
+
+DESCRIPTION="A backend script to aid installing Python packages in Gentoo"
+HOMEPAGE="
+	https://pypi.org/project/gpep517/
+	https://github.com/mgorny/gpep517/
+"
+SRC_URI="
+	https://github.com/mgorny/gpep517/archive/v${PV}.tar.gz
+		-> ${P}.gh.tar.gz
+"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+
+RDEPEND="
+	>=dev-python/installer-0.5.0[${PYTHON_USEDEP}]
+	>=dev-python/tomli-1.2.3[${PYTHON_USEDEP}]
+"
+
+distutils_enable_tests pytest
+
+python_install() {
+	python_domodule gpep517
+	python_newscript - gpep517 <<-EOF
+		#!${EPREFIX}/usr/bin/python
+		import sys
+		from gpep517.__main__ import main
+		sys.exit(main())
+	EOF
+}

--- a/dev-python/installer/installer-0.5.1-r1.ebuild
+++ b/dev-python/installer/installer-0.5.1-r1.ebuild
@@ -1,0 +1,37 @@
+# Copyright 2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+# please keep this ebuild at EAPI 7 -- sys-apps/portage dep
+EAPI=7
+
+DISTUTILS_USE_PEP517=no
+PYTHON_COMPAT=( python3_{8..11} pypy3 )
+
+inherit distutils-r1
+
+DESCRIPTION="A library for installing Python wheels"
+HOMEPAGE="
+	https://pypi.org/project/installer/
+	https://github.com/pypa/installer/
+	https://installer.readthedocs.io/en/latest/
+"
+SRC_URI="
+	https://github.com/pypa/installer/archive/${PV}.tar.gz
+		-> ${P}.gh.tar.gz
+	https://files.pythonhosted.org/packages/py3/${PN::1}/${PN}/${P%_p*}-py3-none-any.whl
+		-> ${P%_p*}-py3-none-any.whl.zip
+"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+
+BDEPEND="
+	app-arch/unzip
+"
+
+distutils_enable_tests pytest
+
+python_compile() {
+	python_domodule src/installer "${WORKDIR}"/*.dist-info
+}

--- a/dev-python/tomli/tomli-2.0.1-r1.ebuild
+++ b/dev-python/tomli/tomli-2.0.1-r1.ebuild
@@ -1,0 +1,36 @@
+# Copyright 2021-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+# please keep this ebuild at EAPI 7 -- sys-apps/portage dep
+EAPI=7
+
+DISTUTILS_USE_PEP517=no
+PYTHON_COMPAT=( python3_{8..11} pypy3 )
+
+inherit distutils-r1
+
+DESCRIPTION="A lil' TOML parser"
+HOMEPAGE="
+	https://pypi.org/project/tomli/
+	https://github.com/hukkin/tomli/
+"
+SRC_URI="
+	https://github.com/hukkin/tomli/archive/${PV}.tar.gz
+		-> ${P}.gh.tar.gz
+	https://files.pythonhosted.org/packages/py3/${PN::1}/${PN}/${P}-py3-none-any.whl
+		-> ${P}-py3-none-any.whl.zip
+"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~ppc-macos ~x64-macos ~x64-solaris"
+
+BDEPEND="
+	app-arch/unzip
+"
+
+distutils_enable_tests unittest
+
+python_compile() {
+	python_domodule src/tomli "${WORKDIR}"/*.dist-info
+}

--- a/eclass/distutils-r1.eclass
+++ b/eclass/distutils-r1.eclass
@@ -1484,6 +1484,7 @@ distutils-r1_python_install() {
 	_python_check_EPYTHON
 
 	local scriptdir=${EPREFIX}/usr/bin
+	local merge_root=
 	if [[ ${DISTUTILS_USE_PEP517} ]]; then
 		local root=${BUILD_DIR}/install
 		# remove the altered bindir, executables from the package
@@ -1495,6 +1496,10 @@ distutils-r1_python_install() {
 				mv "${wrapped_scriptdir}" "${root}${scriptdir}" || die
 			fi
 		fi
+		# prune empty directories to see if ${root} contains anything
+		# to merge
+		find "${BUILD_DIR}"/install -type d -empty -delete || die
+		[[ -d ${BUILD_DIR}/install ]] && merge_root=1
 	else
 		local root=${D%/}/_${EPYTHON}
 		[[ ${DISTUTILS_SINGLE_IMPL} ]] && root=${D%/}
@@ -1521,6 +1526,8 @@ distutils-r1_python_install() {
 		addpredict /usr/local # bug 498232
 
 		if [[ ! ${DISTUTILS_SINGLE_IMPL} ]]; then
+			merge_root=1
+
 			# user may override --install-scripts
 			# note: this is poor but distutils argv parsing is dumb
 
@@ -1549,7 +1556,7 @@ distutils-r1_python_install() {
 		esetup.py "${args[@]}"
 	fi
 
-	if [[ ! ${DISTUTILS_SINGLE_IMPL} || ${DISTUTILS_USE_PEP517} ]]; then
+	if [[ ${merge_root} ]]; then
 		multibuild_merge_root "${root}" "${D%/}"
 		if [[ ${DISTUTILS_USE_PEP517} ]]; then
 			# we need to recompile everything here in order to embed

--- a/eclass/distutils-r1.eclass
+++ b/eclass/distutils-r1.eclass
@@ -106,6 +106,8 @@ esac
 #
 # - maturin - maturin backend
 #
+# - no - no PEP517 build system (see below)
+#
 # - pbr - pbr backend
 #
 # - pdm - pdm.pep517 backend
@@ -121,6 +123,17 @@ esac
 #
 # The variable needs to be set before the inherit line.  The eclass
 # adds appropriate build-time dependencies and verifies the value.
+#
+# The special value "no" indicates that the package has no build system.
+# This is not equivalent to unset DISTUTILS_USE_PEP517 (legacy mode).
+# It causes the eclass not to include any build system dependencies
+# and to disable default python_compile() and python_install()
+# implementations.  Baseline Python deps and phase functions will still
+# be set (depending on the value of DISTUTILS_OPTIONAL).  Most of
+# the other eclass functions will work.  Testing venv will be provided
+# in ${BUILD_DIR}/install after python_compile(), and if any (other)
+# files are found in ${BUILD_DIR}/install after python_install(), they
+# will be merged into ${D}.
 
 # @ECLASS_VARIABLE: DISTUTILS_USE_SETUPTOOLS
 # @DEFAULT_UNSET
@@ -211,6 +224,10 @@ _distutils_set_globals() {
 			maturin)
 				bdep+='
 					>=dev-util/maturin-0.12.7[${PYTHON_USEDEP}]'
+				;;
+			no)
+				# undo the generic deps added above
+				bdep=
 				;;
 			pbr)
 				bdep+='
@@ -792,7 +809,7 @@ distutils_install_for_testing() {
 distutils_write_namespace() {
 	debug-print-function ${FUNCNAME} "${@}"
 
-	if [[ ! ${DISTUTILS_USE_PEP517} ]]; then
+	if [[ ! ${DISTUTILS_USE_PEP517:-no} != no ]]; then
 		die "${FUNCNAME} is available only in PEP517 mode"
 	fi
 	if [[ ${EBUILD_PHASE} != test || ! ${BUILD_DIR} ]]; then
@@ -914,6 +931,9 @@ _distutils-r1_print_package_versions() {
 				packages+=(
 					dev-util/maturin
 				)
+				;;
+			no)
+				return
 				;;
 			pbr)
 				packages+=(
@@ -1216,6 +1236,10 @@ distutils_pep517_install() {
 	debug-print-function ${FUNCNAME} "${@}"
 	[[ ${#} -eq 1 ]] || die "${FUNCNAME} takes exactly one argument: root"
 
+	if [[ ! ${DISTUTILS_USE_PEP517:-no} != no ]]; then
+		die "${FUNCNAME} is available only in PEP517 mode"
+	fi
+
 	local root=${1}
 	local -x WHEEL_BUILD_DIR=${BUILD_DIR}/wheel
 	mkdir -p "${WHEEL_BUILD_DIR}" || die
@@ -1359,6 +1383,9 @@ distutils-r1_python_compile() {
 			# support cargo.eclass' IUSE=debug if available
 			in_iuse debug && use debug &&
 				MATURIN_PEP517_ARGS+=" --cargo-extra-args=--profile=dev"
+			;;
+		no)
+			return
 			;;
 	esac
 


### PR DESCRIPTION
The original changes needed to be reverted as moving merge-root logic post `python_install` broke ebuilds that were relying on being able to modify installed files in `python_install`. The new version:
- still moves venv creation to post-compile, as that should be safe
- moves optimization to post-install, as that should be safe and more convenient
- keeps merge-root and script wrapping logic in `distutils-r1_python_install` to preserve compatibility

This approach seems more logical overall. The difference for PEP517=no ebuilds is that if you use `python_compile()` to install stuff to `${BUILD_DIR}/install` and then redefine `python_install()`, you'll have to call the default.