### PR TITLE
kernel-build.eclass: Use install directory

### DIFF
--- a/eclass/kernel-build.eclass
+++ b/eclass/kernel-build.eclass
@@ -199,7 +199,7 @@ kernel-build_src_install() {
 	# etc.  Use mv rather than doins for the same reason as above --
 	# space and time.
 	if use debug; then
-		mv build/vmlinux "/usr/src/linux-${ver}/" || die
+		mv build/vmlinux "${ED}/usr/src/linux-${ver}/" || die
 	fi
 
 	# building modules fails with 'vmlinux has no symtab?' if stripped


### PR DESCRIPTION
Unfortunately commit ad3b55e32736 forgot to specify the install
directory path, so fix that.

See: https://github.com/gentoo/gentoo/pull/25789
Package-Manager: Portage-3.0.30, Repoman-3.0.3
Signed-off-by: Martin Kletzander <nert.pinx@gmail.com>