### PR TITLE
app-editors/qhexedit2: fix invalid use of distutils-r1

### DIFF
--- a/app-editors/qhexedit2/qhexedit2-0.8.6_p20190316-r2.ebuild
+++ b/app-editors/qhexedit2/qhexedit2-0.8.6_p20190316-r2.ebuild
@@ -3,10 +3,8 @@
 
 EAPI=8
 
-DISTUTILS_USE_PEP517=standalone
 PYTHON_COMPAT=( python3_{8..10} )
-
-inherit distutils-r1 qmake-utils
+inherit python-r1 qmake-utils
 
 EGIT_COMMIT="ba5af8616b3a6c916e718914225a483267c01356"
 DESCRIPTION="Hex editor library, Qt application written in C++ with Python bindings"

--- a/app-editors/qhexedit2/qhexedit2-0.8.9_p20210525-r2.ebuild
+++ b/app-editors/qhexedit2/qhexedit2-0.8.9_p20210525-r2.ebuild
@@ -3,10 +3,8 @@
 
 EAPI=8
 
-DISTUTILS_USE_PEP517=standalone
 PYTHON_COMPAT=( python3_{8..10} )
-
-inherit distutils-r1 qmake-utils
+inherit python-r1 qmake-utils
 
 EGIT_COMMIT="541139125be034b90b6811a84faa1413e357fd94"
 DESCRIPTION="Hex editor library, Qt application written in C++ with Python bindings"


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/850448