### PR TITLE
www-client/surf: desktop entry

### DIFF
--- a/www-client/surf/surf-2.1-r1.ebuild
+++ b/www-client/surf/surf-2.1-r1.ebuild
@@ -1,10 +1,11 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-inherit savedconfig toolchain-funcs
 
-DESCRIPTION="a simple web browser based on WebKit/GTK+"
+inherit desktop savedconfig toolchain-funcs xdg
+
+DESCRIPTION="A simple web browser based on WebKit/GTK+"
 HOMEPAGE="https://surf.suckless.org/"
 
 if [[ ${PV} == "9999" ]] ; then
@@ -73,4 +74,25 @@ src_install() {
 	fi
 
 	save_config config.h
+
+	newicon "${S}/${PN}.png" "${PN}.png"
+
+	local mime_types="text/html;text/xml;application/xhtml+xml;"
+	mime_types+="x-scheme-handler/http;x-scheme-handler/https;"
+	make_desktop_entry \
+		"surf %u" \
+		"Surf" \
+		"surf" \
+		"Network;WebBrowser" \
+		"MimeType=${mime_types}\nStartupWMClass=surf"
+}
+
+pkg_postinst() {
+	xdg_desktop_database_update
+	xdg_icon_cache_update
+}
+
+pkg_postrm() {
+	xdg_desktop_database_update
+	xdg_icon_cache_update
 }

--- a/www-client/surf/surf-9999.ebuild
+++ b/www-client/surf/surf-9999.ebuild
@@ -1,10 +1,11 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-inherit savedconfig toolchain-funcs desktop xdg
 
-DESCRIPTION="a simple web browser based on WebKit/GTK+"
+inherit desktop savedconfig toolchain-funcs xdg
+
+DESCRIPTION="A simple web browser based on WebKit/GTK+"
 HOMEPAGE="https://surf.suckless.org/"
 
 if [[ ${PV} == "9999" ]] ; then
@@ -74,12 +75,12 @@ src_install() {
 
 	save_config config.h
 
-	newicon "${S}"/"${PN}".png "${PN}".png
+	newicon "${S}/${PN}.png" "${PN}.png"
 
 	local mime_types="text/html;text/xml;application/xhtml+xml;"
 	mime_types+="x-scheme-handler/http;x-scheme-handler/https;"
 	make_desktop_entry \
-		"surf" \
+		"surf %u" \
 		"Surf" \
 		"surf" \
 		"Network;WebBrowser" \


### PR DESCRIPTION
Desktop entry creation was already present in live ebuild, I basically copied it to `2.1`. I believe it is ok to do just a revbum and preserve current `KEYWORDS`.