### PR TITLE
sci-libs/hdf5: Set H5_DEFAULT_PLUGINDIR.

### DIFF
--- a/sci-libs/hdf5/hdf5-1.12.2-r1.ebuild
+++ b/sci-libs/hdf5/hdf5-1.12.2-r1.ebuild
@@ -72,6 +72,7 @@ src_configure() {
 		-DONLY_SHARED_LIBS=ON
 		-DFETCHCONTENT_FULLY_DISCONNECTED=ON
 		-DHDF5_BUILD_EXAMPLES=OFF
+		-DH5_DEFAULT_PLUGINDIR="${EPREFIX}/usr/$(get_libdir)/hdf5/plugin"
 		-DALLOW_UNSUPPORTED=$(usex unsupported)
 		-DBUILD_TESTING=$(usex test)
 		-DHDF5_BUILD_CPP_LIB=$(usex cxx)


### PR DESCRIPTION
HDF5 sets is default plugin dir to /usr/local/hdf5/lib/plugin. It is
reasonable in most cases, but not very well for Gentoo.

In Gentoo, the lib directory is not always `lib`, and the prefix is not
always `/`. Therefore, it is more reasonable to set the default dir under
${EPREFIX}, and change `lib` to the right lib dir name.

Signed-off-by: Berrysoft <Strawberry_Str@hotmail.com>