### PR TITLE
Add more explicit assertions about invalid use to distutils-r1

### DIFF
--- a/eclass/distutils-r1.eclass
+++ b/eclass/distutils-r1.eclass
@@ -1752,6 +1752,7 @@ _distutils-r1_run_foreach_impl() {
 	set -- distutils-r1_run_phase "${@}"
 
 	if [[ ! ${DISTUTILS_SINGLE_IMPL} ]]; then
+		local _DISTUTILS_CALLING_FOREACH_IMPL=1
 		python_foreach_impl "${@}"
 	else
 		if [[ ! ${EPYTHON} ]]; then

--- a/eclass/distutils-r1.eclass
+++ b/eclass/distutils-r1.eclass
@@ -106,6 +106,8 @@ esac
 #
 # - maturin - maturin backend
 #
+# - meson-python - meson-python (mesonpy) backend
+#
 # - no - no PEP517 build system (see below)
 #
 # - pbr - pbr backend
@@ -228,6 +230,10 @@ _distutils_set_globals() {
 			no)
 				# undo the generic deps added above
 				bdep=
+				;;
+			meson-python)
+				bdep+='
+					dev-python/meson-python[${PYTHON_USEDEP}]'
 				;;
 			pbr)
 				bdep+='
@@ -936,6 +942,11 @@ _distutils-r1_print_package_versions() {
 			no)
 				return
 				;;
+			meson-python)
+				packages+=(
+					dev-python/meson-python
+				)
+				;;
 			pbr)
 				packages+=(
 					dev-python/pbr
@@ -1137,6 +1148,9 @@ _distutils-r1_backend_to_key() {
 			;;
 		maturin)
 			echo maturin
+			;;
+		mesonpy)
+			echo meson-python
 			;;
 		pbr.build)
 			echo pbr

--- a/eclass/distutils-r1.eclass
+++ b/eclass/distutils-r1.eclass
@@ -1319,7 +1319,7 @@ distutils_pep517_install() {
 	)
 	[[ -n ${wheel} ]] || die "No wheel name returned"
 
-	einfo "  Installing the wheel to ${root}"
+	einfo "  Installing ${wheel} to ${root}"
 	gpep517 install-wheel --destdir="${root}" --interpreter="${PYTHON}" \
 			--prefix="${EPREFIX}/usr" "${WHEEL_BUILD_DIR}/${wheel}" ||
 		die "Wheel install failed"

--- a/eclass/python-r1.eclass
+++ b/eclass/python-r1.eclass
@@ -625,6 +625,24 @@ _python_multibuild_wrapper() {
 python_foreach_impl() {
 	debug-print-function ${FUNCNAME} "${@}"
 
+	if [[ ${_DISTUTILS_R1} ]]; then
+		if has "${EBUILD_PHASE}" prepare configure compile test install &&
+			[[ ! ${_DISTUTILS_CALLING_FOREACH_IMPL} &&
+				! ${_DISTUTILS_FOREACH_IMPL_WARNED} ]]
+		then
+			eqawarn "python_foreach_impl has been called directly while using distutils-r1."
+			eqawarn "Please redefine python_*() phase functions to meet your expectations"
+			eqawarn "instead."
+			_DISTUTILS_FOREACH_IMPL_WARNED=1
+
+			if ! has "${EAPI}" 6 7 8; then
+				die "Calling python_foreach_impl from distutils-r1 is banned in EAPI ${EAPI}"
+			fi
+		fi
+		# undo the eclass-set value to catch nested calls
+		local _DISTUTILS_CALLING_FOREACH_IMPL=
+	fi
+
 	local MULTIBUILD_VARIANTS
 	_python_obtain_impls
 


### PR DESCRIPTION
1. Explicitly remove venv files — in case they weren't created (i.e. `distutils-r1_src_compile` wasn't called), people will get more specific errors rather than (possibly) incidentally removed `/usr/bin`.
2. Verify that bindir+wrapped scriptdir have the same file lists. Again, this verifies that `distutils-r1_src_compile` was called since it copies the dir) and that no weird stuff happened between it and install that could break stuff.
3. Add a QA warning for `python_foreach_impl` use when `python_*` phase should be used instead.

For 3. ,we should verify all existing users to see if they don't have a really valid use case:
- [x] app-crypt/gpgme
- [x] app-editors/qhexedit2
- [x] dev-libs/libnl
- [x] dev-libs/tre
- [x] dev-python/autobahn (postinst)
- [x] dev-python/nbdime
- [x] dev-python/pydevd
- [x] dev-python/pymetar
- [x] dev-python/qtawesome
- [x] dev-python/twisted (used in postinst/postrm)
- [x] dev-python/yara-python
- [x] dev-vcs/mercurial
- [x] net-misc/ntpsec
- [x] sci-astronomy/pyephem
- [x] sci-chemistry/modeller
- [x] sci-chemistry/pymol
- [x] sci-geosciences/GeographicLib
- [x] sci-geosciences/routino
- [x] sci-libs/keras
- [x] sci-libs/tensorflow
- [x] sci-libs/tensorflow-estimator
- [x] sci-mathematics/alectryon
- [x] sys-cluster/ceph
- [x] sys-libs/libapparmor
