### PR TITLE
dev-db/redis: rework src_test

### DIFF
--- a/dev-db/redis/redis-5.0.14.ebuild
+++ b/dev-db/redis/redis-5.0.14.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit autotools flag-o-matic systemd toolchain-funcs tmpfiles
+inherit autotools edo flag-o-matic multiprocessing systemd tmpfiles toolchain-funcs
 
 DESCRIPTION="A persistent caching system, key-value and data structures database"
 HOMEPAGE="https://redis.io"
@@ -125,6 +125,10 @@ src_compile() {
 
 	tc-export AR CC RANLIB
 	emake V=1 ${myconf} AR="${AR}" CC="${CC}" RANLIB="${RANLIB}"
+}
+
+src_test() {
+	edo ./runtest --clients "$(makeopts_jobs)"
 }
 
 src_install() {

--- a/dev-db/redis/redis-6.0.16.ebuild
+++ b/dev-db/redis/redis-6.0.16.ebuild
@@ -11,7 +11,7 @@ EAPI=7
 #    because lua_open became lua_newstate in 5.2
 LUA_COMPAT=( lua5-1 luajit )
 
-inherit autotools edo flag-o-matic lua-single systemd tmpfiles toolchain-funcs
+inherit autotools edo flag-o-matic lua-single multiprocessing systemd tmpfiles toolchain-funcs
 
 DESCRIPTION="A persistent caching system, key-value and data structures database"
 HOMEPAGE="https://redis.io"
@@ -133,6 +133,10 @@ src_compile() {
 }
 
 src_test() {
+	local runtestargs=(
+		--clients "$(makeopts_jobs)" # see bug #649868
+	)
+
 	# Known to fail with FEATURES=usersandbox
 	if has usersandbox ${FEATURES}; then
 		ewarn "You are emerging ${P} with 'usersandbox' enabled." \
@@ -141,10 +145,10 @@ src_test() {
 
 	if use ssl; then
 		edo ./utils/gen-test-certs.sh
-		edo ./runtest --tls
-	else
-		edo ./runtest
+		runtestargs+=( --tls )
 	fi
+
+	edo ./runtest "${runtestargs[@]}"
 }
 
 src_install() {

--- a/dev-db/redis/redis-6.0.16.ebuild
+++ b/dev-db/redis/redis-6.0.16.ebuild
@@ -65,9 +65,6 @@ PATCHES=(
 src_prepare() {
 	default
 
-	# unstable on jemalloc
-	> tests/unit/memefficiency.tcl || die
-
 	# Copy lua modules into build dir
 	cp "${S}"/deps/lua/src/{fpconv,lua_bit,lua_cjson,lua_cmsgpack,lua_struct,strbuf}.c "${S}"/src || die
 	cp "${S}"/deps/lua/src/{fpconv,strbuf}.h "${S}"/src || die
@@ -135,6 +132,12 @@ src_compile() {
 src_test() {
 	local runtestargs=(
 		--clients "$(makeopts_jobs)" # see bug #649868
+
+		# unstable on jemalloc, see https://github.com/gentoo/gentoo/pull/15924
+		--skiptest "Active defrag"
+		--skiptest "Active defrag big keys"
+		--skiptest "Active defrag big list"
+		--skiptest "Active defrag edge case"
 	)
 
 	# Known to fail with FEATURES=usersandbox

--- a/dev-db/redis/redis-6.0.16.ebuild
+++ b/dev-db/redis/redis-6.0.16.ebuild
@@ -140,10 +140,12 @@ src_test() {
 		--skiptest "Active defrag edge case"
 	)
 
-	# Known to fail with FEATURES=usersandbox
-	if has usersandbox ${FEATURES}; then
-		ewarn "You are emerging ${P} with 'usersandbox' enabled." \
-			"Expect some test failures or emerge with 'FEATURES=-usersandbox'!"
+	if has usersandbox ${FEATURES} || ! has userpriv ${FEATURES}; then
+		ewarn "unit/oom-score-adj test will be skipped." \
+			"It is known to fail with FEATURES usersandbox or -userpriv. See bug #756382."
+
+		# unit/oom-score-adj was introduced in version 6.2.0 and it was later backported to 6.0.7
+		runtestargs+=( --skipunit unit/oom-score-adj ) # see bug #756382
 	fi
 
 	if use ssl; then

--- a/dev-db/redis/redis-6.0.16.ebuild
+++ b/dev-db/redis/redis-6.0.16.ebuild
@@ -11,7 +11,7 @@ EAPI=7
 #    because lua_open became lua_newstate in 5.2
 LUA_COMPAT=( lua5-1 luajit )
 
-inherit autotools flag-o-matic lua-single systemd toolchain-funcs tmpfiles
+inherit autotools edo flag-o-matic lua-single systemd tmpfiles toolchain-funcs
 
 DESCRIPTION="A persistent caching system, key-value and data structures database"
 HOMEPAGE="https://redis.io"
@@ -140,10 +140,10 @@ src_test() {
 	fi
 
 	if use ssl; then
-		./utils/gen-test-certs.sh
-		./runtest --tls
+		edo ./utils/gen-test-certs.sh
+		edo ./runtest --tls
 	else
-		./runtest
+		edo ./runtest
 	fi
 }
 

--- a/dev-db/redis/redis-6.2.6.ebuild
+++ b/dev-db/redis/redis-6.2.6.ebuild
@@ -11,7 +11,7 @@ EAPI=7
 #    because lua_open became lua_newstate in 5.2
 LUA_COMPAT=( lua5-1 luajit )
 
-inherit autotools edo flag-o-matic lua-single systemd tmpfiles toolchain-funcs
+inherit autotools edo flag-o-matic lua-single multiprocessing systemd tmpfiles toolchain-funcs
 
 DESCRIPTION="A persistent caching system, key-value and data structures database"
 HOMEPAGE="https://redis.io"
@@ -133,6 +133,10 @@ src_compile() {
 }
 
 src_test() {
+	local runtestargs=(
+		--clients "$(makeopts_jobs)" # see bug #649868
+	)
+
 	# Known to fail with FEATURES=usersandbox
 	if has usersandbox ${FEATURES}; then
 		ewarn "You are emerging ${P} with 'usersandbox' enabled." \
@@ -141,10 +145,10 @@ src_test() {
 
 	if use ssl; then
 		edo ./utils/gen-test-certs.sh
-		edo ./runtest --tls
-	else
-		edo ./runtest
+		runtestargs+=( --tls )
 	fi
+
+	edo ./runtest "${runtestargs[@]}"
 }
 
 src_install() {

--- a/dev-db/redis/redis-6.2.6.ebuild
+++ b/dev-db/redis/redis-6.2.6.ebuild
@@ -11,7 +11,7 @@ EAPI=7
 #    because lua_open became lua_newstate in 5.2
 LUA_COMPAT=( lua5-1 luajit )
 
-inherit autotools flag-o-matic lua-single systemd toolchain-funcs tmpfiles
+inherit autotools edo flag-o-matic lua-single systemd tmpfiles toolchain-funcs
 
 DESCRIPTION="A persistent caching system, key-value and data structures database"
 HOMEPAGE="https://redis.io"
@@ -140,10 +140,10 @@ src_test() {
 	fi
 
 	if use ssl; then
-		./utils/gen-test-certs.sh
-		./runtest --tls
+		edo ./utils/gen-test-certs.sh
+		edo ./runtest --tls
 	else
-		./runtest
+		edo ./runtest
 	fi
 }
 

--- a/dev-db/redis/redis-6.2.6.ebuild
+++ b/dev-db/redis/redis-6.2.6.ebuild
@@ -134,10 +134,12 @@ src_test() {
 		--clients "$(makeopts_jobs)" # see bug #649868
 	)
 
-	# Known to fail with FEATURES=usersandbox
-	if has usersandbox ${FEATURES}; then
-		ewarn "You are emerging ${P} with 'usersandbox' enabled." \
-			"Expect some test failures or emerge with 'FEATURES=-usersandbox'!"
+	if has usersandbox ${FEATURES} || ! has userpriv ${FEATURES}; then
+		ewarn "unit/oom-score-adj test will be skipped." \
+			"It is known to fail with FEATURES usersandbox or -userpriv. See bug #756382."
+
+		# unit/oom-score-adj was introduced in version 6.2.0
+		runtestargs+=( --skipunit unit/oom-score-adj ) # see bug #756382
 	fi
 
 	if use ssl; then

--- a/dev-db/redis/redis-6.2.6.ebuild
+++ b/dev-db/redis/redis-6.2.6.ebuild
@@ -65,9 +65,6 @@ PATCHES=(
 src_prepare() {
 	default
 
-	# unstable on jemalloc
-	> tests/unit/memefficiency.tcl || die
-
 	# Copy lua modules into build dir
 	cp "${S}"/deps/lua/src/{fpconv,lua_bit,lua_cjson,lua_cmsgpack,lua_struct,strbuf}.c "${S}"/src || die
 	cp "${S}"/deps/lua/src/{fpconv,strbuf}.h "${S}"/src || die

--- a/dev-db/redis/redis-6.2.7-r1.ebuild
+++ b/dev-db/redis/redis-6.2.7-r1.ebuild
@@ -136,10 +136,12 @@ src_test() {
 		--clients "$(makeopts_jobs)" # see bug #649868
 	)
 
-	# Known to fail with FEATURES=usersandbox
-	if has usersandbox ${FEATURES}; then
-		ewarn "You are emerging ${P} with 'usersandbox' enabled." \
-			"Expect some test failures or emerge with 'FEATURES=-usersandbox'!"
+	if has usersandbox ${FEATURES} || ! has userpriv ${FEATURES}; then
+		ewarn "unit/oom-score-adj test will be skipped." \
+			"It is known to fail with FEATURES usersandbox or -userpriv. See bug #756382."
+
+		# unit/oom-score-adj was introduced in version 6.2.0
+		runtestargs+=( --skipunit unit/oom-score-adj ) # see bug #756382
 	fi
 
 	if use ssl; then

--- a/dev-db/redis/redis-6.2.7-r1.ebuild
+++ b/dev-db/redis/redis-6.2.7-r1.ebuild
@@ -14,7 +14,7 @@ LUA_COMPAT=( lua5-1 luajit )
 # Upstream have deviated too far from vanilla Lua, adding their own APIs
 # like lua_enablereadonlytable, but we still need the eclass and such
 # for bug #841422.
-inherit autotools flag-o-matic systemd toolchain-funcs lua-single tmpfiles
+inherit autotools edo flag-o-matic lua-single systemd tmpfiles toolchain-funcs
 
 DESCRIPTION="A persistent caching system, key-value, and data structures database"
 HOMEPAGE="https://redis.io"
@@ -142,10 +142,10 @@ src_test() {
 	fi
 
 	if use ssl; then
-		./utils/gen-test-certs.sh
-		./runtest --tls
+		edo ./utils/gen-test-certs.sh
+		edo ./runtest --tls
 	else
-		./runtest
+		edo ./runtest
 	fi
 }
 

--- a/dev-db/redis/redis-6.2.7-r1.ebuild
+++ b/dev-db/redis/redis-6.2.7-r1.ebuild
@@ -14,7 +14,7 @@ LUA_COMPAT=( lua5-1 luajit )
 # Upstream have deviated too far from vanilla Lua, adding their own APIs
 # like lua_enablereadonlytable, but we still need the eclass and such
 # for bug #841422.
-inherit autotools edo flag-o-matic lua-single systemd tmpfiles toolchain-funcs
+inherit autotools edo flag-o-matic lua-single multiprocessing systemd tmpfiles toolchain-funcs
 
 DESCRIPTION="A persistent caching system, key-value, and data structures database"
 HOMEPAGE="https://redis.io"
@@ -135,6 +135,10 @@ src_compile() {
 }
 
 src_test() {
+	local runtestargs=(
+		--clients "$(makeopts_jobs)" # see bug #649868
+	)
+
 	# Known to fail with FEATURES=usersandbox
 	if has usersandbox ${FEATURES}; then
 		ewarn "You are emerging ${P} with 'usersandbox' enabled." \
@@ -143,10 +147,10 @@ src_test() {
 
 	if use ssl; then
 		edo ./utils/gen-test-certs.sh
-		edo ./runtest --tls
-	else
-		edo ./runtest
+		runtestargs+=( --tls )
 	fi
+
+	edo ./runtest "${runtestargs[@]}"
 }
 
 src_install() {

--- a/dev-db/redis/redis-6.2.7-r1.ebuild
+++ b/dev-db/redis/redis-6.2.7-r1.ebuild
@@ -67,9 +67,6 @@ PATCHES=(
 src_prepare() {
 	default
 
-	# unstable on jemalloc
-	> tests/unit/memefficiency.tcl || die
-
 	# Copy lua modules into build dir
 	#cp "${S}"/deps/lua/src/{fpconv,lua_bit,lua_cjson,lua_cmsgpack,lua_struct,strbuf}.c "${S}"/src || die
 	#cp "${S}"/deps/lua/src/{fpconv,strbuf}.h "${S}"/src || die

--- a/dev-db/redis/redis-7.0.0-r1.ebuild
+++ b/dev-db/redis/redis-7.0.0-r1.ebuild
@@ -6,7 +6,7 @@ EAPI=8
 # N.B.: It is no clue in porting to Lua eclasses, as upstream have deviated
 # too far from vanilla Lua, adding their own APIs like lua_enablereadonlytable
 
-inherit autotools flag-o-matic systemd toolchain-funcs tmpfiles
+inherit autotools edo flag-o-matic systemd tmpfiles toolchain-funcs
 
 DESCRIPTION="A persistent caching system, key-value, and data structures database"
 HOMEPAGE="https://redis.io"
@@ -123,10 +123,10 @@ src_test() {
 	fi
 
 	if use ssl; then
-		./utils/gen-test-certs.sh
-		./runtest --tls
+		edo ./utils/gen-test-certs.sh
+		edo ./runtest --tls
 	else
-		./runtest
+		edo ./runtest
 	fi
 }
 

--- a/dev-db/redis/redis-7.0.0-r1.ebuild
+++ b/dev-db/redis/redis-7.0.0-r1.ebuild
@@ -6,7 +6,7 @@ EAPI=8
 # N.B.: It is no clue in porting to Lua eclasses, as upstream have deviated
 # too far from vanilla Lua, adding their own APIs like lua_enablereadonlytable
 
-inherit autotools edo flag-o-matic systemd tmpfiles toolchain-funcs
+inherit autotools edo flag-o-matic multiprocessing systemd tmpfiles toolchain-funcs
 
 DESCRIPTION="A persistent caching system, key-value, and data structures database"
 HOMEPAGE="https://redis.io"
@@ -116,6 +116,10 @@ src_compile() {
 }
 
 src_test() {
+	local runtestargs=(
+		--clients "$(makeopts_jobs)" # see bug #649868
+	)
+
 	# Known to fail with FEATURES=usersandbox
 	if has usersandbox ${FEATURES}; then
 		ewarn "You are emerging ${P} with 'usersandbox' enabled." \
@@ -124,10 +128,10 @@ src_test() {
 
 	if use ssl; then
 		edo ./utils/gen-test-certs.sh
-		edo ./runtest --tls
-	else
-		edo ./runtest
+		runtestargs+=( --tls )
 	fi
+
+	edo ./runtest "${runtestargs[@]}"
 }
 
 src_install() {

--- a/dev-db/redis/redis-7.0.0-r1.ebuild
+++ b/dev-db/redis/redis-7.0.0-r1.ebuild
@@ -117,10 +117,18 @@ src_test() {
 		--clients "$(makeopts_jobs)" # see bug #649868
 	)
 
-	# Known to fail with FEATURES=usersandbox
-	if has usersandbox ${FEATURES}; then
-		ewarn "You are emerging ${P} with 'usersandbox' enabled." \
-			"Expect some test failures or emerge with 'FEATURES=-usersandbox'!"
+	if has usersandbox ${FEATURES} || ! has userpriv ${FEATURES}; then
+		ewarn "oom-score-adj related tests will be skipped." \
+			"They are known to fail with FEATURES usersandbox or -userpriv. See bug #756382."
+
+		runtestargs+=(
+			# unit/oom-score-adj was introduced in version 6.2.0
+			--skipunit unit/oom-score-adj # see bug #756382
+
+			# Following test was added in version 7.0.0 to unit/introspection.
+			# It also tries to adjust OOM score.
+			--skiptest "CONFIG SET rollback on apply error"
+		)
 	fi
 
 	if use ssl; then

--- a/dev-db/redis/redis-7.0.0-r1.ebuild
+++ b/dev-db/redis/redis-7.0.0-r1.ebuild
@@ -55,9 +55,6 @@ PATCHES=(
 src_prepare() {
 	default
 
-	# unstable on jemalloc
-	> tests/unit/memefficiency.tcl || die
-
 	# Append cflag for lua_cjson
 	# https://github.com/antirez/redis/commit/4fdcd213#diff-3ba529ae517f6b57803af0502f52a40bL61
 	append-cflags "-DENABLE_CJSON_GLOBAL"

--- a/dev-db/redis/redis-7.0.0.ebuild
+++ b/dev-db/redis/redis-7.0.0.ebuild
@@ -14,7 +14,7 @@ LUA_COMPAT=( lua5-1 luajit )
 # Upstream have deviated too far from vanilla Lua, adding their own APIs
 # like lua_enablereadonlytable, but we still need the eclass and such
 # for bug #841422.
-inherit autotools flag-o-matic systemd toolchain-funcs lua-single tmpfiles
+inherit autotools edo flag-o-matic lua-single systemd tmpfiles toolchain-funcs
 
 DESCRIPTION="A persistent caching system, key-value, and data structures database"
 HOMEPAGE="https://redis.io"
@@ -142,10 +142,10 @@ src_test() {
 	fi
 
 	if use ssl; then
-		./utils/gen-test-certs.sh
-		./runtest --tls
+		edo ./utils/gen-test-certs.sh
+		edo ./runtest --tls
 	else
-		./runtest
+		edo ./runtest
 	fi
 }
 

--- a/dev-db/redis/redis-7.0.0.ebuild
+++ b/dev-db/redis/redis-7.0.0.ebuild
@@ -14,7 +14,7 @@ LUA_COMPAT=( lua5-1 luajit )
 # Upstream have deviated too far from vanilla Lua, adding their own APIs
 # like lua_enablereadonlytable, but we still need the eclass and such
 # for bug #841422.
-inherit autotools edo flag-o-matic lua-single systemd tmpfiles toolchain-funcs
+inherit autotools edo flag-o-matic lua-single multiprocessing systemd tmpfiles toolchain-funcs
 
 DESCRIPTION="A persistent caching system, key-value, and data structures database"
 HOMEPAGE="https://redis.io"
@@ -135,6 +135,10 @@ src_compile() {
 }
 
 src_test() {
+	local runtestargs=(
+		--clients "$(makeopts_jobs)" # see bug #649868
+	)
+
 	# Known to fail with FEATURES=usersandbox
 	if has usersandbox ${FEATURES}; then
 		ewarn "You are emerging ${P} with 'usersandbox' enabled." \
@@ -143,10 +147,10 @@ src_test() {
 
 	if use ssl; then
 		edo ./utils/gen-test-certs.sh
-		edo ./runtest --tls
-	else
-		edo ./runtest
+		runtestargs+=( --tls )
 	fi
+
+	edo ./runtest "${runtestargs[@]}"
 }
 
 src_install() {

--- a/dev-db/redis/redis-7.0.0.ebuild
+++ b/dev-db/redis/redis-7.0.0.ebuild
@@ -136,10 +136,18 @@ src_test() {
 		--clients "$(makeopts_jobs)" # see bug #649868
 	)
 
-	# Known to fail with FEATURES=usersandbox
-	if has usersandbox ${FEATURES}; then
-		ewarn "You are emerging ${P} with 'usersandbox' enabled." \
-			"Expect some test failures or emerge with 'FEATURES=-usersandbox'!"
+	if has usersandbox ${FEATURES} || ! has userpriv ${FEATURES}; then
+		ewarn "oom-score-adj related tests will be skipped." \
+			"They are known to fail with FEATURES usersandbox or -userpriv. See bug #756382."
+
+		runtestargs+=(
+			# unit/oom-score-adj was introduced in version 6.2.0
+			--skipunit unit/oom-score-adj # see bug #756382
+
+			# Following test was added in version 7.0.0 to unit/introspection.
+			# It also tries to adjust OOM score.
+			--skiptest "CONFIG SET rollback on apply error"
+		)
 	fi
 
 	if use ssl; then

--- a/dev-db/redis/redis-7.0.0.ebuild
+++ b/dev-db/redis/redis-7.0.0.ebuild
@@ -67,9 +67,6 @@ PATCHES=(
 src_prepare() {
 	default
 
-	# unstable on jemalloc
-	> tests/unit/memefficiency.tcl || die
-
 	# Copy lua modules into build dir
 	#cp "${S}"/deps/lua/src/{fpconv,lua_bit,lua_cjson,lua_cmsgpack,lua_struct,strbuf}.c "${S}"/src || die
 	#cp "${S}"/deps/lua/src/{fpconv,strbuf}.h "${S}"/src || die

--- a/dev-db/redis/redis-7.0.1.ebuild
+++ b/dev-db/redis/redis-7.0.1.ebuild
@@ -6,7 +6,7 @@ EAPI=8
 # N.B.: It is no clue in porting to Lua eclasses, as upstream have deviated
 # too far from vanilla Lua, adding their own APIs like lua_enablereadonlytable
 
-inherit autotools flag-o-matic systemd toolchain-funcs tmpfiles
+inherit autotools edo flag-o-matic systemd tmpfiles toolchain-funcs
 
 DESCRIPTION="A persistent caching system, key-value, and data structures database"
 HOMEPAGE="https://redis.io"
@@ -123,10 +123,10 @@ src_test() {
 	fi
 
 	if use ssl; then
-		./utils/gen-test-certs.sh
-		./runtest --tls
+		edo ./utils/gen-test-certs.sh
+		edo ./runtest --tls
 	else
-		./runtest
+		edo ./runtest
 	fi
 }
 

--- a/dev-db/redis/redis-7.0.1.ebuild
+++ b/dev-db/redis/redis-7.0.1.ebuild
@@ -6,7 +6,7 @@ EAPI=8
 # N.B.: It is no clue in porting to Lua eclasses, as upstream have deviated
 # too far from vanilla Lua, adding their own APIs like lua_enablereadonlytable
 
-inherit autotools edo flag-o-matic systemd tmpfiles toolchain-funcs
+inherit autotools edo flag-o-matic multiprocessing systemd tmpfiles toolchain-funcs
 
 DESCRIPTION="A persistent caching system, key-value, and data structures database"
 HOMEPAGE="https://redis.io"
@@ -116,6 +116,10 @@ src_compile() {
 }
 
 src_test() {
+	local runtestargs=(
+		--clients "$(makeopts_jobs)" # see bug #649868
+	)
+
 	# Known to fail with FEATURES=usersandbox
 	if has usersandbox ${FEATURES}; then
 		ewarn "You are emerging ${P} with 'usersandbox' enabled." \
@@ -124,10 +128,10 @@ src_test() {
 
 	if use ssl; then
 		edo ./utils/gen-test-certs.sh
-		edo ./runtest --tls
-	else
-		edo ./runtest
+		runtestargs+=( --tls )
 	fi
+
+	edo ./runtest "${runtestargs[@]}"
 }
 
 src_install() {

--- a/dev-db/redis/redis-7.0.1.ebuild
+++ b/dev-db/redis/redis-7.0.1.ebuild
@@ -117,10 +117,18 @@ src_test() {
 		--clients "$(makeopts_jobs)" # see bug #649868
 	)
 
-	# Known to fail with FEATURES=usersandbox
-	if has usersandbox ${FEATURES}; then
-		ewarn "You are emerging ${P} with 'usersandbox' enabled." \
-			"Expect some test failures or emerge with 'FEATURES=-usersandbox'!"
+	if has usersandbox ${FEATURES} || ! has userpriv ${FEATURES}; then
+		ewarn "oom-score-adj related tests will be skipped." \
+			"They are known to fail with FEATURES usersandbox or -userpriv. See bug #756382."
+
+		runtestargs+=(
+			# unit/oom-score-adj was introduced in version 6.2.0
+			--skipunit unit/oom-score-adj # see bug #756382
+
+			# Following test was added in version 7.0.0 to unit/introspection.
+			# It also tries to adjust OOM score.
+			--skiptest "CONFIG SET rollback on apply error"
+		)
 	fi
 
 	if use ssl; then

--- a/dev-db/redis/redis-7.0.1.ebuild
+++ b/dev-db/redis/redis-7.0.1.ebuild
@@ -55,9 +55,6 @@ PATCHES=(
 src_prepare() {
 	default
 
-	# unstable on jemalloc
-	> tests/unit/memefficiency.tcl || die
-
 	# Append cflag for lua_cjson
 	# https://github.com/antirez/redis/commit/4fdcd213#diff-3ba529ae517f6b57803af0502f52a40bL61
 	append-cflags "-DENABLE_CJSON_GLOBAL"


### PR DESCRIPTION
I think `die` should be used with all those scripts or is there a reason why it shouldn't?