### PR TITLE
media-sound/pulseaudio-daemon: Call udev_reload in pkg_postrm too

### DIFF
--- a/media-sound/pulseaudio-daemon/pulseaudio-daemon-16.0-r1.ebuild
+++ b/media-sound/pulseaudio-daemon/pulseaudio-daemon-16.0-r1.ebuild
@@ -379,4 +379,5 @@ pkg_postinst() {
 
 pkg_postrm() {
 	gnome2_schemas_update
+	use udev && udev_reload
 }


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/851006
Signed-off-by: Igor V. Kovalenko <igor.v.kovalenko@gmail.com>