### PR TITLE
Bug 848474 - media-video/mjpg-streamer-0_pre20200524-r1 installs shell script that uses non-POSIX features

### DIFF
--- a/media-video/mjpg-streamer/files/mjpg-streamer.initd
+++ b/media-video/mjpg-streamer/files/mjpg-streamer.initd
@@ -1,9 +1,9 @@
 #!/sbin/openrc-run
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 MJPG_STREAMER_PIDFILE="${MJPG_STREAMER_PIDFILE:-/var/run/${SVCNAME}.pid}"
-MY_NAME=${SVCNAME//-/_}
+MY_NAME="${SVCNAME//-/_}"
 
 depend() {
 	use logger
@@ -13,13 +13,13 @@ depend() {
 checkconfig() {
 	local vars
 
-	[[ ${INPUT_PLUGIN} ]] || vars+=\ INPUT_PLUGIN
-	[[ ${OUTPUT_PLUGIN} ]] || vars+=\ OUTPUT_PLUGIN
-	[[ ${MJPG_STREAMER_USER} ]] || vars+=\ MJPG_STREAMER_USER
-	[[ ${MJPG_STREAMER_GROUP} ]] || vars+=\ MJPG_STREAMER_GROUP
+	[ "${INPUT_PLUGIN}" ] || vars+=\ INPUT_PLUGIN
+	[ "${OUTPUT_PLUGIN}" ] || vars+=\ OUTPUT_PLUGIN
+	[ "${MJPG_STREAMER_USER}" ] || vars+=\ MJPG_STREAMER_USER
+	[ "${MJPG_STREAMER_GROUP}" ] || vars+=\ MJPG_STREAMER_GROUP
 	vars="${vars# }"
 
-	if [[ ${vars} ]]; then
+	if [ "${vars}" ]; then
 		eerror "Required variables in /etc/conf.d/${SVCNAME} are not set:"
 		eerror "  ${vars// /, }"
 		return 1


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/848474
Signed-off-by: Andrzej Pauli (@ChaosEngine) andrzej.pauli@gmail.com