### PR TITLE
media-gfx/openscad: fix build against >=cgal-5.4.1

### DIFF
--- a/media-gfx/openscad/files/openscad-2021.01-CGAL-build-fix-v5.4-renames-projection-traits-header.patch
+++ b/media-gfx/openscad/files/openscad-2021.01-CGAL-build-fix-v5.4-renames-projection-traits-header.patch
@@ -1,0 +1,36 @@
+https://bugs.gentoo.org/851189
+From https://github.com/openscad/openscad/commit/abfebc651343909b534ef337aacc7604c99cf0ea Mon Sep 17 00:00:00 2001
+From: Torsten Paul <Torsten.Paul@gmx.de>
+Date: Wed, 2 Feb 2022 02:30:59 +0100
+Subject: [PATCH 09/11] CGAL build fix, v5.4 renames projection traits header
+ files and classes.
+
+--- a/src/cgalutils-tess.cc
++++ b/src/cgalutils-tess.cc
+@@ -6,10 +6,12 @@
+ #pragma push_macro("NDEBUG")
+ #undef NDEBUG
+ #include <CGAL/Constrained_Delaunay_triangulation_2.h>
+-#if CGAL_VERSION_NR >= CGAL_VERSION_NUMBER(4,11,0)
+-  #include <CGAL/Triangulation_2_projection_traits_3.h>
++#if CGAL_VERSION_NR < 1050401000
++#include <CGAL/Triangulation_2_projection_traits_3.h>
++typedef CGAL::Triangulation_2_filtered_projection_traits_3<K> Projection;
+ #else
+-  #include <CGAL/Triangulation_2_filtered_projection_traits_3.h>
++#include <CGAL/Projection_traits_3.h>
++typedef CGAL::Filtered_projection_traits_3<K> Projection;
+ #endif
+ #include <CGAL/Triangulation_face_base_with_info_2.h>
+ #pragma pop_macro("NDEBUG")
+@@ -19,7 +21,6 @@ struct FaceInfo {
+   bool in_domain() { return nesting_level%2 == 1; }
+ };
+ 
+-typedef CGAL::Triangulation_2_filtered_projection_traits_3<K> Projection;
+ typedef CGAL::Triangulation_face_base_with_info_2<FaceInfo, K> Fbb;
+ typedef CGAL::Triangulation_data_structure_2<
+ 	CGAL::Triangulation_vertex_base_2<Projection>,
+-- 
+2.35.1
+

--- a/media-gfx/openscad/files/openscad-2021.01-CVE-2022-0496-Out-of-bounds-memory-access-in-DXF-loa.patch
+++ b/media-gfx/openscad/files/openscad-2021.01-CVE-2022-0496-Out-of-bounds-memory-access-in-DXF-loa.patch
@@ -1,0 +1,74 @@
+From https://github.com/openscad/openscad/commit/00a4692989c4e2f191525f73f24ad8727bacdf41 Mon Sep 17 00:00:00 2001
+From: Torsten Paul <Torsten.Paul@gmx.de>
+Date: Sat, 5 Feb 2022 18:38:31 +0100
+Subject: [PATCH 01/11] CVE-2022-0496 Out-of-bounds memory access in DXF
+ loader.
+
+Public issue:
+https://github.com/openscad/openscad/issues/4037
+
+Fix in master branch:
+https://github.com/openscad/openscad/pull/4090
+--- a/src/dxfdata.cc
++++ b/src/dxfdata.cc
+@@ -441,6 +441,11 @@ DxfData::DxfData(double fn, double fs, double fa,
+ 				auto lv = grid.data(this->points[lines[idx].idx[j]][0], this->points[lines[idx].idx[j]][1]);
+ 				for (size_t ki = 0; ki < lv.size(); ++ki) {
+ 					int k = lv.at(ki);
++                    if (k < 0 || k >= lines.size()) {
++                        LOG(message_group::Warning,Location::NONE,"",
++                            "Bad DXF line index in %1$s.",QuotedString(boostfs_uncomplete(filename, fs::current_path()).generic_string()));
++                        continue;
++                    }
+ 					if (k == idx || lines[k].disabled) continue;
+ 					goto next_open_path_j;
+ 				}
+@@ -466,13 +471,20 @@ DxfData::DxfData(double fn, double fs, double fa,
+ 			auto lv = grid.data(ref_point[0], ref_point[1]);
+ 			for (size_t ki = 0; ki < lv.size(); ++ki) {
+ 				int k = lv.at(ki);
++                if (k < 0 || k >= lines.size()) {
++                    LOG(message_group::Warning,Location::NONE,"",
++                        "Bad DXF line index in %1$s.",QuotedString(boostfs_uncomplete(filename, fs::current_path()).generic_string()));
++                    continue;
++                }
+ 				if (lines[k].disabled) continue;
+-				if (grid.eq(ref_point[0], ref_point[1], this->points[lines[k].idx[0]][0], this->points[lines[k].idx[0]][1])) {
++                auto idk0 = lines[k].idx[0];    // make it easier to read and debug
++                auto idk1 = lines[k].idx[1];
++				if (grid.eq(ref_point[0], ref_point[1], this->points[idk0][0], this->points[idk0][1])) {
+ 					current_line = k;
+ 					current_point = 0;
+ 					goto found_next_line_in_open_path;
+ 				}
+-				if (grid.eq(ref_point[0], ref_point[1], this->points[lines[k].idx[1]][0], this->points[lines[k].idx[1]][1])) {
++				if (grid.eq(ref_point[0], ref_point[1], this->points[idk1][0], this->points[idk1][1])) {
+ 					current_line = k;
+ 					current_point = 1;
+ 					goto found_next_line_in_open_path;
+@@ -501,13 +513,20 @@ DxfData::DxfData(double fn, double fs, double fa,
+ 			auto lv = grid.data(ref_point[0], ref_point[1]);
+ 			for (size_t ki = 0; ki < lv.size(); ++ki) {
+ 				int k = lv.at(ki);
++                if (k < 0 || k >= lines.size()) {
++                    LOG(message_group::Warning,Location::NONE,"",
++                        "Bad DXF line index in %1$s.",QuotedString(boostfs_uncomplete(filename, fs::current_path()).generic_string()));
++                    continue;
++                }
+ 				if (lines[k].disabled) continue;
+-				if (grid.eq(ref_point[0], ref_point[1], this->points[lines[k].idx[0]][0], this->points[lines[k].idx[0]][1])) {
++                auto idk0 = lines[k].idx[0];    // make it easier to read and debug
++                auto idk1 = lines[k].idx[1];
++				if (grid.eq(ref_point[0], ref_point[1], this->points[idk0][0], this->points[idk0][1])) {
+ 					current_line = k;
+ 					current_point = 0;
+ 					goto found_next_line_in_closed_path;
+ 				}
+-					if (grid.eq(ref_point[0], ref_point[1], this->points[lines[k].idx[1]][0], this->points[lines[k].idx[1]][1])) {
++                if (grid.eq(ref_point[0], ref_point[1], this->points[idk1][0], this->points[idk1][1])) {
+ 					current_line = k;
+ 					current_point = 1;
+ 					goto found_next_line_in_closed_path;
+-- 
+2.35.1
+

--- a/media-gfx/openscad/files/openscad-2021.01-CVE-2022-0497-Out-of-bounds-memory-access-in-comment.patch
+++ b/media-gfx/openscad/files/openscad-2021.01-CVE-2022-0497-Out-of-bounds-memory-access-in-comment.patch
@@ -1,0 +1,25 @@
+From https://github.com/openscad/openscad/commit/84addf3c1efbd51d8ff424b7da276400bbfa1a4b Mon Sep 17 00:00:00 2001
+From: Torsten Paul <Torsten.Paul@gmx.de>
+Date: Sat, 5 Feb 2022 18:45:29 +0100
+Subject: [PATCH 02/11] CVE-2022-0497 Out-of-bounds memory access in comment
+ parser.
+
+Public issue:
+https://github.com/openscad/openscad/issues/4043
+
+Fix in master branch:
+https://github.com/openscad/openscad/pull/4044
+--- a/src/comment.cpp
++++ b/src/comment.cpp
+@@ -92,7 +92,7 @@ static std::string getComment(const std::string &fulltext, int line)
+ 	}
+ 
+ 	int end = start + 1;
+-	while (fulltext[end] != '\n') end++;
++	while (end < fulltext.size() && fulltext[end] != '\n') end++;
+ 
+ 	std::string comment = fulltext.substr(start, end - start);
+ 
+-- 
+2.35.1
+

--- a/media-gfx/openscad/files/openscad-2021.01-Fix-build-failure-with-generic_print_polyhedron-on-C.patch
+++ b/media-gfx/openscad/files/openscad-2021.01-Fix-build-failure-with-generic_print_polyhedron-on-C.patch
@@ -1,0 +1,42 @@
+https://bugs.gentoo.org/851189
+From https://github.com/openscad/openscad/commit/9aa0d7e9f2914fe5f547bdde69202161d1c6064d Mon Sep 17 00:00:00 2001
+From: Jordan Brown <github@jordan.maileater.net>
+Date: Sun, 18 Jul 2021 21:01:46 -0700
+Subject: [PATCH 05/11] Fix build failure with "generic_print_polyhedron" on
+ CGAL-5.3.
+
+--- a/src/cgalutils-polyhedron.cc
++++ b/src/cgalutils-polyhedron.cc
+@@ -337,19 +337,6 @@ namespace CGALUtils {
+     }
+ 	};
+ 
+-	template <typename Polyhedron>
+-	std::string printPolyhedron(const Polyhedron &p) {
+-		std::ostringstream sstream;
+-		sstream.precision(20);
+-
+-    Polyhedron_writer writer;
+-    generic_print_polyhedron(sstream, p, writer);
+-		
+-		return sstream.str();
+-	}
+-
+-	template std::string printPolyhedron(const CGAL_Polyhedron &p);
+-
+ }; // namespace CGALUtils
+ 
+ #endif /* ENABLE_CGAL */
+--- a/src/cgalutils.h
++++ b/src/cgalutils.h
+@@ -45,7 +45,6 @@ namespace CGALUtils {
+ 	bool is_approximately_convex(const PolySet &ps);
+ 	Geometry const* applyMinkowski(const Geometry::Geometries &children);
+ 
+-	template <typename Polyhedron> std::string printPolyhedron(const Polyhedron &p);
+ 	template <typename Polyhedron> bool createPolySetFromPolyhedron(const Polyhedron &p, PolySet &ps);
+ 	template <typename Polyhedron> bool createPolyhedronFromPolySet(const PolySet &ps, Polyhedron &p);
+ 	template <class Polyhedron_A, class Polyhedron_B> 
+-- 
+2.35.1
+

--- a/media-gfx/openscad/files/openscad-2021.01-Fix-build-issue-with-overloaded-join.patch
+++ b/media-gfx/openscad/files/openscad-2021.01-Fix-build-issue-with-overloaded-join.patch
@@ -1,0 +1,60 @@
+https://bugs.gentoo.org/851189
+From https://github.com/openscad/openscad/commit/08bf69b4115c989fc5671254e0d05735d01bcca5 Mon Sep 17 00:00:00 2001
+From: Torsten Paul <Torsten.Paul@gmx.de>
+Date: Wed, 2 Feb 2022 00:50:43 +0100
+Subject: [PATCH 10/11] Fix build issue with overloaded join().
+
+--- a/src/openscad.cc
++++ b/src/openscad.cc
+@@ -65,7 +65,6 @@
+ #include <chrono>
+ #include <boost/algorithm/string.hpp>
+ #include <boost/algorithm/string/split.hpp>
+-#include <boost/algorithm/string/join.hpp>
+ #include <boost/range/adaptor/transformed.hpp>
+ #include <boost/program_options.hpp>
+ #include <boost/filesystem.hpp>
+@@ -307,7 +306,7 @@ void set_render_color_scheme(const std::string color_scheme, const bool exit_if_
+ 	}
+ 
+ 	if (exit_if_not_found) {
+-		LOG(message_group::None,Location::NONE,"",(boost::join(ColorMap::inst()->colorSchemeNames(), "\n")));
++		LOG(message_group::None,Location::NONE,"",(boost::algorithm::join(ColorMap::inst()->colorSchemeNames(), "\n")));
+ 
+ 		exit(1);
+ 	} else {
+@@ -885,7 +884,7 @@ struct CommaSeparatedVector
+ };
+ 
+ template <class Seq, typename ToString>
+-std::string join(const Seq &seq, const std::string &sep, const ToString &toString)
++std::string str_join(const Seq &seq, const std::string &sep, const ToString &toString)
+ {
+     return boost::algorithm::join(boost::adaptors::transform(seq, toString), sep);
+ }
+@@ -947,7 +946,7 @@ int main(int argc, char **argv)
+ 		("P,P", po::value<string>(), "customizer parameter set")
+ #ifdef ENABLE_EXPERIMENTAL
+ 		("enable", po::value<vector<string>>(), ("enable experimental features: " +
+-		                                          join(boost::make_iterator_range(Feature::begin(), Feature::end()), " | ",
++		                                          str_join(boost::make_iterator_range(Feature::begin(), Feature::end()), " | ",
+ 		                                               [](const Feature *feature) {
+ 		                                                   return feature->get_name();
+ 		                                               }) +
+@@ -964,11 +963,11 @@ int main(int argc, char **argv)
+ 		("render", po::value<string>()->implicit_value(""), "for full geometry evaluation when exporting png")
+ 		("preview", po::value<string>()->implicit_value(""), "[=throwntogether] -for ThrownTogether preview png")
+ 		("animate", po::value<unsigned>(), "export N animated frames")
+-		("view", po::value<CommaSeparatedVector>(), ("=view options: " + boost::join(viewOptions.names(), " | ")).c_str())
++		("view", po::value<CommaSeparatedVector>(), ("=view options: " + boost::algorithm::join(viewOptions.names(), " | ")).c_str())
+ 		("projection", po::value<string>(), "=(o)rtho or (p)erspective when exporting png")
+ 		("csglimit", po::value<unsigned int>(), "=n -stop rendering at n CSG elements when exporting png")
+ 		("colorscheme", po::value<string>(), ("=colorscheme: " +
+-		                                      join(ColorMap::inst()->colorSchemeNames(), " | ",
++		                                      str_join(ColorMap::inst()->colorSchemeNames(), " | ",
+ 		                                           [](const std::string& colorScheme) {
+ 		                                               return (colorScheme == ColorMap::inst()->defaultColorSchemeName() ? "*" : "") + colorScheme;
+ 		                                           }) +
+-- 
+2.35.1
+

--- a/media-gfx/openscad/files/openscad-2021.01-Remove-double-quoting-of-the-output-file-parameter-f.patch
+++ b/media-gfx/openscad/files/openscad-2021.01-Remove-double-quoting-of-the-output-file-parameter-f.patch
@@ -1,0 +1,20 @@
+From https://github.com/openscad/openscad/commit/45a5e3bdd6c8071cb50b9c3f2b14a62554aafc4a Mon Sep 17 00:00:00 2001
+From: Torsten Paul <Torsten.Paul@gmx.de>
+Date: Thu, 14 Apr 2022 16:07:04 +0200
+Subject: [PATCH 11/11] Remove double quoting of the output file parameter for
+ ghostscript.
+
+--- a/tests/export_pngtest.py
++++ b/tests/export_pngtest.py
+@@ -82,7 +82,7 @@ result = subprocess.call(export_cmd, env = fontenv)
+ if result != 0:
+     failquit('OpenSCAD failed with return code ' + str(result))
+ 
+-convert_cmd = gs_cmd + ["-sOutputFile=\"" + pngfile + "\"", exportfile]
++convert_cmd = gs_cmd + ["-sOutputFile=" + pngfile, exportfile]
+ print('Running Converter:', ' '.join(convert_cmd), file=sys.stderr)
+ result = subprocess.call(convert_cmd)
+ if result != 0:
+-- 
+2.35.1
+

--- a/media-gfx/openscad/openscad-2021.01-r4.ebuild
+++ b/media-gfx/openscad/openscad-2021.01-r4.ebuild
@@ -1,0 +1,112 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit elisp-common qmake-utils xdg
+
+SITEFILE="50${PN}-gentoo.el"
+
+DESCRIPTION="The Programmers Solid 3D CAD Modeller"
+HOMEPAGE="https://www.openscad.org/"
+SRC_URI="https://github.com/${PN}/${PN}/releases/download/${P}/${P}.src.tar.gz -> ${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~arm64 ~x86"
+IUSE="emacs"
+# tests are not fully working and need cmake which isn't yet
+# officially supported.
+RESTRICT="test"
+
+RDEPEND="
+	dev-cpp/eigen:3
+	dev-libs/boost:=
+	dev-libs/double-conversion:=
+	dev-libs/glib:2
+	dev-libs/gmp:0=
+	dev-libs/hidapi
+	dev-libs/libspnav
+	dev-libs/libxml2
+	dev-libs/libzip:=
+	dev-libs/mpfr:0=
+	dev-qt/qtconcurrent:5
+	dev-qt/qtcore:5
+	dev-qt/qtdbus:5
+	dev-qt/qtgui:5[-gles2-only]
+	dev-qt/qtmultimedia:5
+	dev-qt/qtnetwork:5
+	dev-qt/qtopengl:5
+	dev-qt/qtwidgets:5
+	media-gfx/opencsg:=
+	media-libs/fontconfig
+	media-libs/freetype
+	>=media-libs/glew-2.0.0:0=
+	media-libs/harfbuzz:=
+	media-libs/lib3mf
+	sci-mathematics/cgal:=
+	x11-libs/cairo
+	>=x11-libs/qscintilla-2.10.3:=
+	emacs? ( >=app-editors/emacs-23.1:* )
+"
+DEPEND="${RDEPEND}"
+BDEPEND="
+	dev-util/itstool
+	sys-devel/bison
+	sys-devel/flex
+	sys-devel/gettext
+	virtual/pkgconfig
+"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-0001-Gentoo-specific-Disable-ccache-building.patch
+	"${FILESDIR}"/${P}-0002-fix-to-find-lib3mf-2.patch
+	"${FILESDIR}"/${P}-CVE-2022-0496-Out-of-bounds-memory-access-in-DXF-loa.patch
+	"${FILESDIR}"/${P}-CVE-2022-0497-Out-of-bounds-memory-access-in-comment.patch
+	"${FILESDIR}"/${P}-Fix-build-failure-with-generic_print_polyhedron-on-C.patch
+	"${FILESDIR}"/${P}-CGAL-build-fix-v5.4-renames-projection-traits-header.patch
+	"${FILESDIR}"/${P}-Fix-build-issue-with-overloaded-join.patch
+	"${FILESDIR}"/${P}-Remove-double-quoting-of-the-output-file-parameter-f.patch
+)
+
+src_configure() {
+	if has ccache ${FEATURES}; then
+		eqmake5 "PREFIX = ${ESYSROOT}/usr" "CONFIG += ccache" "${PN}.pro"
+	else
+		eqmake5 "PREFIX = ${ESYSROOT}/usr" "${PN}.pro"
+	fi
+}
+
+src_compile() {
+	default
+
+	if use emacs ; then
+		elisp-compile contrib/*.el
+	fi
+}
+
+src_install() {
+	emake install INSTALL_ROOT="${D}"
+
+	if use emacs; then
+		elisp-site-file-install "${FILESDIR}/${SITEFILE}"
+		elisp-install ${PN} contrib/*.el contrib/*.elc
+	fi
+
+	mv -i "${ED}"/usr/share/openscad/locale "${ED}"/usr/share || die "failed to move locales"
+	ln -sf ../locale "${ED}"/usr/share/openscad/locale || die
+
+	einstalldocs
+}
+
+pkg_postinst() {
+	use emacs && elisp-site-regen
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
+}
+
+pkg_postrm() {
+	use emacs && elisp-site-regen
+	xdg_desktop_database_update
+	xdg_mimeinfo_database_update
+}


### PR DESCRIPTION
**media-gfx/openscad: fix build against >=cgal-5.4.1**

Also address two CVE issues, CVE-2022-0496 and CVE-2022-0497
Fix double quoting of output file parameter for ghostscript

Closes: https://bugs.gentoo.org/851189
Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>

**media-gfx/openscad: drop 2021.01-r2**

Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>
