### PR TITLE
x11-terms/gnome-terminal: fix missing W_EXITCODE define in gnome-terminal when building on musl

### DIFF
--- a/x11-terms/gnome-terminal/files/gnome-terminal-3.44.1-fix-missing-wexitcode.patch
+++ b/x11-terms/gnome-terminal/files/gnome-terminal-3.44.1-fix-missing-wexitcode.patch
@@ -1,0 +1,21 @@
+https://gitlab.gnome.org/GNOME/vte/-/issues/72
+Someone already tried to upstream a similar patch to gnome vte that
+would fix this but was rejected by maintainer. More info can be found
+on the link above.
+
+W_EXITCODE is missing in musl thus causing gnome-terminal build to fail.
+This patch checks if W_EXITCODE is not defined and then defines it.
+--- a/src/terminal.cc
++++ b/src/terminal.cc
+@@ -47,6 +47,11 @@
+ GS_DEFINE_CLEANUP_FUNCTION0(TerminalOptions*, gs_local_options_free, terminal_options_free)
+ #define gs_free_options __attribute__ ((cleanup(gs_local_options_free)))
+ 
++/* fix for musl */
++#ifndef W_EXITCODE
++#define W_EXITCODE(ret, sig) ((ret) << 8 | (sig))
++#endif
++
+ /* Wait-for-exit helper */
+ 
+ typedef struct {

--- a/x11-terms/gnome-terminal/gnome-terminal-3.44.1.ebuild
+++ b/x11-terms/gnome-terminal/gnome-terminal-3.44.1.ebuild
@@ -47,6 +47,7 @@ DOC_CONTENTS="To get previous working directory inherited in new opened tab, or
 	. /etc/profile.d/vte-2.91.sh"
 
 src_prepare() {
+	eapply "${FILESDIR}"/${P}-fix-missing-wexitcode.patch
 	if ! use vanilla; then
 		# https://bugzilla.gnome.org/show_bug.cgi?id=695371
 		# Fedora patches:


### PR DESCRIPTION
This should fix W_EXITCODE gnome-terminal failing to build on musl with error `'W_EXITCODE' was not declared in this scope`

Idea taken from alpine linux patch found [here](https://gitlab.alpinelinux.org/alpine/aports/-/blob/124e957f523aad1bc1c182720cc0700efe78850a/community/gnome-terminal/fix-W_EXITCODE.patch)