### PR TITLE
sys-fs/lvm2: fix building for musl

### DIFF
--- a/sys-fs/lvm2/files/lvm2-2.03.14-r1-add-fcntl.patch
+++ b/sys-fs/lvm2/files/lvm2-2.03.14-r1-add-fcntl.patch
@@ -1,0 +1,24 @@
+https://bugs.gentoo.org/712336
+https://bugs.gentoo.org/549506
+
+Adds fcntl.h into daemon-server.c to define fcntl and some constants.
+
+---
+ libdaemon/server/daemon-server.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/libdaemon/server/daemon-server.c b/libdaemon/server/daemon-server.c
+index 88905a7..771b021 100644
+--- a/libdaemon/server/daemon-server.c
++++ b/libdaemon/server/daemon-server.c
+@@ -28,6 +28,7 @@
+ #include <sys/un.h>
+ #include <unistd.h>
+ #include <signal.h>
++#include <fcntl.h>
+ 
+ #include <syslog.h> /* FIXME. For the global closelog(). */
+ 
+-- 
+2.35.1
+

--- a/sys-fs/lvm2/files/lvm2-2.03.14-r1-fopen-to-freopen.patch
+++ b/sys-fs/lvm2/files/lvm2-2.03.14-r1-fopen-to-freopen.patch
@@ -1,0 +1,43 @@
+In musl stdout, stdin and stderr are read-only unlike in glibc.
+This patch changes std* = fopen(...) to freopen(..., std*).
+
+See: https://www.gnu.org/software/libc/manual/html_node/Standard-Streams.html and https://wiki.gentoo.org/wiki/User:Sam/Musl_porting_notes
+
+---
+ tools/lvmcmdline.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/tools/lvmcmdline.c b/tools/lvmcmdline.c
+index 1e12bed..19da1e5 100644
+--- a/tools/lvmcmdline.c
++++ b/tools/lvmcmdline.c
+@@ -3384,7 +3384,7 @@ static int _check_standard_fds(void)
+ 	int err = is_valid_fd(STDERR_FILENO);
+ 
+ 	if (!is_valid_fd(STDIN_FILENO) &&
+-	    !(stdin = fopen(_PATH_DEVNULL, "r"))) {
++		!freopen(_PATH_DEVNULL, "r", stdin)) {
+ 		if (err)
+ 			perror("stdin stream open");
+ 		else
+@@ -3394,7 +3394,7 @@ static int _check_standard_fds(void)
+ 	}
+ 
+ 	if (!is_valid_fd(STDOUT_FILENO) &&
+-	    !(stdout = fopen(_PATH_DEVNULL, "w"))) {
++		!freopen(_PATH_DEVNULL, "w", stdout)) {
+ 		if (err)
+ 			perror("stdout stream open");
+ 		/* else no stdout */
+@@ -3402,7 +3402,7 @@ static int _check_standard_fds(void)
+ 	}
+ 
+ 	if (!is_valid_fd(STDERR_FILENO) &&
+-	    !(stderr = fopen(_PATH_DEVNULL, "w"))) {
++		!freopen(_PATH_DEVNULL, "w", stderr)) {
+ 		printf("stderr stream open: %s\n",
+ 		       strerror(errno));
+ 		return 0;
+-- 
+2.35.1
+

--- a/sys-fs/lvm2/files/lvm2-2.03.14-r1-mallinfo.patch
+++ b/sys-fs/lvm2/files/lvm2-2.03.14-r1-mallinfo.patch
@@ -1,0 +1,18 @@
+https://git.alpinelinux.org/aports/tree/main/lvm2/mallinfo.patch
+
+Patch from Alpine, disables _allocate_memory since mallinfo isn't defined in musl.
+19:17 <@sam_> your caution is well-advised, but it should be safe enough given it's only affecting the non-glibc path
+
+Should be looked back to!
+
+--- ./lib/mm/memlock.c.orig	2015-03-09 11:18:41.560028850 -0100
++++ ./lib/mm/memlock.c	2015-03-09 11:19:54.504373309 -0100
+@@ -137,7 +137,7 @@
+ 
+ static void _allocate_memory(void)
+ {
+-#ifndef VALGRIND_POOL
++#if !defined(VALGRIND_POOL) && defined(__GLIBC__)
+ 	void *stack_mem;
+ 	struct rlimit limit;
+ 	int i, area = 0, missing = _size_malloc_tmp, max_areas = 32, hblks;

--- a/sys-fs/lvm2/lvm2-2.03.14-r1.ebuild
+++ b/sys-fs/lvm2/lvm2-2.03.14-r1.ebuild
@@ -70,6 +70,9 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-2.03.05-dmeventd-no-idle-exit.patch
 	#"${FILESDIR}"/${PN}-2.02.184-allow-reading-metadata-with-invalid-creation_time.patch #682380 # merged upstream
 	"${FILESDIR}"/${PN}-2.02.184-mksh_build.patch #686652
+	"${FILESDIR}"/${PN}-2.03.14-r1-add-fcntl.patch
+	"${FILESDIR}"/${PN}-2.03.14-r1-fopen-to-freopen.patch
+	"${FILESDIR}"/${PN}-2.03.14-r1-mallinfo.patch
 )
 
 pkg_setup() {


### PR DESCRIPTION
A few changes to make lvm2 build on musl. Each patch file is commented in more detail, see those.