### PR TITLE
sys-apps/accountsservice: fix building on musl

### DIFF
--- a/sys-apps/accountsservice/accountsservice-22.08.8.ebuild
+++ b/sys-apps/accountsservice/accountsservice-22.08.8.ebuild
@@ -51,6 +51,8 @@ RDEPEND="${CDEPEND}
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-22.04.62-gentoo-system-users.patch
+	"${FILESDIR}"/${PN}-22.08.8-check-for-wtmp.patch
+	"${FILESDIR}"/${PN}-22.08.8-fgetspent_r-musl.patch
 )
 
 python_check_deps() {
@@ -64,6 +66,7 @@ src_configure() {
 		--localstatedir="${EPREFIX}/var"
 		-Dsystemdsystemunitdir="$(systemd_get_systemunitdir)"
 		-Dadmin_group="wheel"
+		-Dcheck_wtmp="$(usex !elibc_musl true false)"
 		$(meson_use elogind)
 		$(meson_use introspection)
 		$(meson_use doc docbook)

--- a/sys-apps/accountsservice/files/accountsservice-22.08.8-check-for-wtmp.patch
+++ b/sys-apps/accountsservice/files/accountsservice-22.08.8-check-for-wtmp.patch
@@ -1,0 +1,41 @@
+Adds a meson build option to check if wtmp path is valid.
+wtmp is not used on musl and is implemented with stubs because it is harmful software, and because of that, checking whether the path is valid or not does not matter.
+
+See: https://wiki.musl-libc.org/faq.html#Q:_Why_is_the_utmp/wtmp_functionality_only_implemented_as_stubs?
+https://bugs.gentoo.org/762442
+
+---
+ meson.build       | 4 +++-
+ meson_options.txt | 1 +
+ 2 files changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/meson.build b/meson.build
+index 075776f..0801659 100644
+--- a/meson.build
++++ b/meson.build
+@@ -102,7 +102,9 @@ elif cc.has_header_symbol('paths.h', '_PATH_WTMPX')
+   config_h.set('PATH_WTMP', '_PATH_WTMPX')
+ else
+   path_wtmp = '/var/log/utx.log'
+-  assert(run_command('test', '-e', path_wtmp).returncode() == 0, 'Do not know which filename to watch for wtmp changes')
++  if get_option('check_wtmp')
++    assert(run_command('test', '-e', path_wtmp).returncode() == 0, 'Do not know which filename to watch for wtmp changes')
++  endif
+   config_h.set_quoted('PATH_WTMP', path_wtmp)
+ endif
+ 
+diff --git a/meson_options.txt b/meson_options.txt
+index 93f384a..4fec12e 100644
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -6,6 +6,7 @@ option('extra_admin_groups', type: 'array', value: [], description: 'Comma-separ
+ option('minimum_uid', type: 'integer', value: 1000, description: 'Set minimum uid for human users')
+ 
+ option('elogind', type: 'boolean', value: false, description: 'Use elogind')
++option('check_wtmp', type: 'boolean', value: true, description: 'Check if wtmp path is valid (musl workaround)')
+ 
+ option('introspection', type: 'boolean', value: true, description: 'Enable introspection for this build')
+ option('vapi', type: 'boolean', value: true, description : 'Enable Vala bindings for this build')
+-- 
+2.35.1
+

--- a/sys-apps/accountsservice/files/accountsservice-22.08.8-fgetspent_r-musl.patch
+++ b/sys-apps/accountsservice/files/accountsservice-22.08.8-fgetspent_r-musl.patch
@@ -1,0 +1,53 @@
+Define fgetspent_r if not already defined. (GNU extension, therefore not in musl).
+
+https://git.alpinelinux.org/aports/tree/community/accountsservice/musl-fgetspent_r.patch (copied the function from here).
+diff -u b/src/daemon.c b/src/daemon.c
+--- b/src/daemon.c
++++ b/src/daemon.c
+@@ -32,7 +32,7 @@
+ #include <pwd.h>
+ #ifdef HAVE_SHADOW_H
+ #include <shadow.h>
+-#endif
++#endif // HAVE_SHADOW_H
+ #include <unistd.h>
+ #include <errno.h>
+ #include <sys/types.h>
+@@ -51,6 +51,25 @@
+ #include "user.h"
+ #include "accounts-user-generated.h"
+ 
++#ifndef HAVE_FGETSPENT_R
++static int fgetspent_r(FILE *fp, struct spwd *spbuf, char *buf, size_t buflen, struct spwd **spbufp) {
++       struct spwd *shadow_entry = fgetspent(fp);
++       if(!shadow_entry)
++               return -1;
++       size_t namplen = strlen(shadow_entry->sp_namp);
++       size_t pwdplen = strlen(shadow_entry->sp_pwdp);
++
++       if(namplen + pwdplen + 2 > buflen)
++               return -1;
++
++       *spbufp = memcpy(spbuf, shadow_entry, sizeof(struct spwd));
++       spbuf->sp_namp = strncpy(buf, shadow_entry->sp_namp, namplen + 1);
++       spbuf->sp_pwdp = strncpy(buf + namplen + 1, shadow_entry->sp_pwdp, pwdplen + 1);
++
++       return 0;
++}
++#endif // HAVE_FGETSPENT_R
++
+ #define PATH_PASSWD "/etc/passwd"
+ #define PATH_SHADOW "/etc/shadow"
+ #define PATH_GROUP "/etc/group"
+only in patch2:
+unchanged:
+--- a/meson.build
++++ b/meson.build
+@@ -71,6 +71,7 @@ check_functions = [
+   'getusershell',
+   'setutxdb',
+   'fgetpwent',
++  'fgetspent_r'
+ ]
+ 
+ foreach func: check_functions


### PR DESCRIPTION
Accountsservice uses wtmp and fgetspent_r. See comments in patch files for more details.

Closes: https://bugs.gentoo.org/762442
Signed-off-by: Alfred Persson Forsberg cat@catcream.org