### PR TITLE
dev-libs/pigpio: add PYTHON_COMPAT 3_10 and 3_11

### DIFF
--- a/dev-libs/pigpio/pigpio-79.ebuild
+++ b/dev-libs/pigpio/pigpio-79.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{7,8,9} )
+PYTHON_COMPAT=( python3_{7,8,9,10,11} )
 
 inherit distutils-r1 systemd toolchain-funcs
 


### PR DESCRIPTION
adding 3_10 and 3_11 python slots

Signed-off-by: Daniel Kenzelmann <gentoo@k8n.de>
Closes: https://bugs.gentoo.org/845666