### PR TITLE
dev-python/logbook: add python 3.10 support

### DIFF
--- a/dev-python/logbook/logbook-1.5.3.ebuild
+++ b/dev-python/logbook/logbook-1.5.3.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
-PYTHON_COMPAT=( python3_{7,8,9} )
+PYTHON_COMPAT=( python3_{8..10} )
 
 inherit distutils-r1
 


### PR DESCRIPTION
Package-Manager: Portage-3.0.30, Repoman-3.0.3
Signed-off-by: Andreas Zuber <a.zuber@gmx.ch>
Closes: https://bugs.gentoo.org/845747