### PR TITLE
Apparmor py3.11

### DIFF
--- a/dev-python/notify2/notify2-0.3.1-r3.ebuild
+++ b/dev-python/notify2/notify2-0.3.1-r3.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{8..10} )
+PYTHON_COMPAT=( python3_{8..11} )
 
 inherit distutils-r1 virtualx
 

--- a/sys-apps/apparmor-utils/apparmor-utils-3.0.3.ebuild
+++ b/sys-apps/apparmor-utils/apparmor-utils-3.0.3.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-PYTHON_COMPAT=( python{3_7,3_8,3_9} )
+PYTHON_COMPAT=( python3_{8..11} )
 inherit perl-module python-r1 toolchain-funcs
 
 MY_PV="$(ver_cut 1-2)"

--- a/sys-libs/libapparmor/libapparmor-3.0.3-r1.ebuild
+++ b/sys-libs/libapparmor/libapparmor-3.0.3-r1.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_OPTIONAL=1
-PYTHON_COMPAT=( python3_{8..10} )
+PYTHON_COMPAT=( python3_{8..11} )
 GENTOO_DEPEND_ON_PERL="no"
 
 inherit autotools distutils-r1 perl-functions


### PR DESCRIPTION
```
 * python3_11: running distutils-r1_run_phase python_test
 * Scanning for an open DISPLAY to start Xvfb ...
 * Starting Xvfb on $DISPLAY=1 ...
python3.11 -m unittest_or_fail discover -v
/var/tmp/portage/dev-python/notify2-0.3.1-r3/work/notify2-0.3.1/test_notify2.py:11: PyGIWarning:       GdkPixbuf was imported without specifying a version first. Use gi.require_version('GdkPixbuf', '2.0')  before import to ensure that the right version gets loaded.
  from gi.repository import GdkPixbuf
test_get_server_caps (test_notify2.ModuleTests.test_get_server_caps) ... ok
test_get_server_info (test_notify2.ModuleTests.test_get_server_info) ... ok
test_init_uninit (test_notify2.ModuleTests.test_init_uninit) ... ok
test_basic (test_notify2.NotificationTests.test_basic) ... ok
test_category (test_notify2.NotificationTests.test_category) ... ok
test_data (test_notify2.NotificationTests.test_data) ... ok
test_icon (test_notify2.NotificationTests.test_icon) ... ok
test_icon_from_pixbuf (test_notify2.NotificationTests.test_icon_from_pixbuf) ... ok
test_icon_only (test_notify2.NotificationTests.test_icon_only) ... ok
test_set_location (test_notify2.NotificationTests.test_set_location) ... ok
test_timeout (test_notify2.NotificationTests.test_timeout) ... ok
test_update (test_notify2.NotificationTests.test_update) ... ok
test_urgency (test_notify2.NotificationTests.test_urgency) ... ok

----------------------------------------------------------------------
Ran 13 tests in 0.330s

OK
```

@gentoo/python I'm getting this:
```
 * Package:    sys-apps/apparmor-utils-3.0.3
 * Repository: gentoo
 * Maintainer: kensington@gentoo.org hardened@gentoo.org
 * USE:        abi_x86_64 amd64 elibc_glibc kernel_linux python_targets_python3_10 python_targets_python3_11 python_targets_python3_8 python_targets_python3_9 userland_GNU
 * FEATURES:   network-sandbox preserve-libs sandbox test userpriv usersandbox
 * No Make or Build file detected...
 * Using python3.11 in global scope
 * Skipping make test/check due to ebuild restriction.
 * QA Notice: setuptools warnings detected:
 * 
 * 	The version specified ('unknown-version') is an invalid version, this may not work as expected with newer versions of setuptools, pip, and PyPI. Please see PEP 440 for more details.
 * python3_8: running install_python
 * python3_9: running install_python
 * python3_10: running install_python
 * python3_11: running install_python
```
```
 * QA Notice: setuptools warnings detected:
 * 
 * 	The version specified ('unknown-version') is an invalid version, this may not work as expected with newer versions of setuptools, pip, and PyPI. Please see PEP 440 for more details.
```

I have no idea where this is coming from. 

But from what I can tell, python-3.11 works just fine with apparmor-utils.