### PR TITLE
sys-devel/gdb: fix cross build issues with configuring gmp libs

### DIFF
--- a/sys-devel/gdb/gdb-11.2.ebuild
+++ b/sys-devel/gdb/gdb-11.2.ebuild
@@ -154,6 +154,15 @@ src_configure() {
 		# Ideally we would like automagic-or-disabled here.
 		# But the check does not quite work on i686: bug #760926.
 		$(use_enable cet)
+
+		# We need to set both configure options, --with-sysroot and --libdir,
+		# to fix cross build issues that happen when configuring gmp.
+		# We explicitly need --libdir. Having only --with-sysroot without
+		# --libdir would not fix the build issues.
+		# For some reason, it is not enough to set only --with-sysroot,
+		# also not enough to pass --with-gmp-xxx options.
+		--with-sysroot="${ESYSROOT}"
+		--libdir="${ESYSROOT}/usr/$(get_libdir)"
 	)
 
 	local sysroot="${EPREFIX}/usr/${CTARGET}"

--- a/sys-devel/gdb/gdb-12.1.ebuild
+++ b/sys-devel/gdb/gdb-12.1.ebuild
@@ -153,6 +153,15 @@ src_configure() {
 		# Ideally we would like automagic-or-disabled here.
 		# But the check does not quite work on i686: bug #760926.
 		$(use_enable cet)
+
+		# We need to set both configure options, --with-sysroot and --libdir,
+		# to fix cross build issues that happen when configuring gmp.
+		# We explicitly need --libdir. Having only --with-sysroot without
+		# --libdir would not fix the build issues.
+		# For some reason, it is not enough to set only --with-sysroot,
+		# also not enough to pass --with-gmp-xxx options.
+		--with-sysroot="${ESYSROOT}"
+		--libdir="${ESYSROOT}/usr/$(get_libdir)"
 	)
 
 	local sysroot="${EPREFIX}/usr/${CTARGET}"

--- a/sys-devel/gdb/gdb-9999.ebuild
+++ b/sys-devel/gdb/gdb-9999.ebuild
@@ -154,6 +154,15 @@ src_configure() {
 		# Ideally we would like automagic-or-disabled here.
 		# But the check does not quite work on i686: bug #760926.
 		$(use_enable cet)
+
+		# We need to set both configure options, --with-sysroot and --libdir,
+		# to fix cross build issues that happen when configuring gmp.
+		# We explicitly need --libdir. Having only --with-sysroot without
+		# --libdir would not fix the build issues.
+		# For some reason, it is not enough to set only --with-sysroot,
+		# also not enough to pass --with-gmp-xxx options.
+		--with-sysroot="${ESYSROOT}"
+		--libdir="${ESYSROOT}/usr/$(get_libdir)"
 	)
 
 	local sysroot="${EPREFIX}/usr/${CTARGET}"


### PR DESCRIPTION
As gdb 11 or newer requires gmp libs as dependency, a cross build of gdb 11.2 started to fail when its configure scripts try to detect if gmp exists.
The failure occurs mainly because the build still passes `-L/usr/lib64` to LDFLAGS.

Let's say, for example, host toolchains outside of sysroot have amd64 libs, while the target inside of sysroot should have arm64 libs.
However, configure scripts of gdb 11.2 still try to find its libs outside of sysroot, `/usr/lib64`, although it should find its libs inside of sysroot, e.g. `/build/arm64/usr/lib64`.

To fix the cross build issues, pass `--with-sysroot` as well as `--libdir`, correctly with `${ESYSROOT}`.

As a side note, for some reason, upstream gdb configure scripts are not able to correctly make use of its gmp-specific options like `--with-gmp` or `--with-gmp-lib`.
Passing those options does not bring anything.

Also configure must have both `--with-sysroot` and `--libdir`, to make the build work.

Signed-off-by: Dongsu Park <dpark@linux.microsoft.com>