### PR TITLE
media-sound/pulseaudio-daemon: Add dev-libs/glib dep for gio library

### DIFF
--- a/media-sound/pulseaudio-daemon/pulseaudio-daemon-16.0-r3.ebuild
+++ b/media-sound/pulseaudio-daemon/pulseaudio-daemon-16.0-r3.ebuild
@@ -89,7 +89,10 @@ COMMON_DEPEND="
 	)
 	gdbm? ( sys-libs/gdbm:= )
 	glib? ( >=dev-libs/glib-2.28.0:2 )
-	gstreamer? ( ${gstreamer_deps} )
+	gstreamer? (
+		${gstreamer_deps}
+		>=dev-libs/glib-2.26.0:2
+	)
 	jack? ( virtual/jack )
 	ldac? ( ${gstreamer_deps} )
 	lirc? ( app-misc/lirc )


### PR DESCRIPTION
GStreamer-based RTP protocol module requires gio library from dev-libs/glib, add explicit dependency.

Closes: https://bugs.gentoo.org/818229