### PR TITLE
sys-power/apcupsd: Call udev_reload on install

### DIFF
--- a/sys-power/apcupsd/apcupsd-3.14.14-r3.ebuild
+++ b/sys-power/apcupsd/apcupsd-3.14.14-r3.ebuild
@@ -118,6 +118,8 @@ src_install() {
 }
 
 pkg_postinst() {
+	use kernel_linux && udev_reload
+
 	tmpfiles_process ${PN}-tmpfiles.conf
 
 	if use cgi ; then


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/852284
Signed-off-by: John Einar Reitan <john.einar@gmail.com>