### PR TITLE
media-libs/freeimage: correct usage of BOOL

### DIFF
--- a/media-libs/freeimage/files/freeimage-3.18.0-null-to-false.patch
+++ b/media-libs/freeimage/files/freeimage-3.18.0-null-to-false.patch
@@ -1,0 +1,22 @@
+https://bugs.gentoo.org/841973
+
+See also:
+https://sourceforge.net/p/freeimage/mailman/message/37668470/
+https://git.alpinelinux.org/aports/commit/?id=9b938a7b38ea4b8d9a73f1bf0d90ee45bbfa9139
+
+diff --git a/Source/FreeImage/PluginPSD.cpp b/Source/FreeImage/PluginPSD.cpp
+index e5b5ffa..d9de81f 100644
+--- a/Source/FreeImage/PluginPSD.cpp
++++ b/Source/FreeImage/PluginPSD.cpp
+@@ -127,7 +127,7 @@ Load(FreeImageIO *io, fi_handle handle, int page, int flags, void *data) {
+ static BOOL DLL_CALLCONV
+ Save(FreeImageIO *io, FIBITMAP *dib, fi_handle handle, int page, int flags, void *data) {
+ 	if(!handle) {
+-		return NULL;
++		return FALSE;
+ 	}
+ 	try {
+ 		psdParser parser;
+-- 
+2.35.1
+

--- a/media-libs/freeimage/freeimage-3.18.0-r8.ebuild
+++ b/media-libs/freeimage/freeimage-3.18.0-r8.ebuild
@@ -56,6 +56,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-3.18.0-openexr-3-imath.patch
 	"${FILESDIR}"/${PN}-3.18.0-libraw-0.20.0.patch
 	"${FILESDIR}"/${PN}-3.18.0-tiff-4.4.0.patch
+	"${FILESDIR}"/${PN}-3.18.0-null-to-false.patch
 )
 
 src_prepare() {


### PR DESCRIPTION
FreeImage relies on NULL being 0, while on musl for stdc++ >= 11 it is
defined as nullptr. This breaks the build for musl. Returning FALSE here
is correct.

Closes: 841973
Signed-off-by: Alfred Persson Forsberg <cat@catcream.org>