### PR TITLE
sys-power/apcupsd: Call udev_reload in pkg_postrm

### DIFF
--- a/sys-power/apcupsd/apcupsd-3.14.14-r3.ebuild
+++ b/sys-power/apcupsd/apcupsd-3.14.14-r3.ebuild
@@ -149,3 +149,7 @@ pkg_postinst() {
 		elog "in /dev/apcups/by-id directory."
 	fi
 }
+
+pkg_postrm() {
+	use kernel_linux && udev_reload
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/852641
Signed-off-by: John Einar Reitan <john.einar@gmail.com>