### PR TITLE
dev-ruby/sassc: Fix quoting of ESYSROOT in sed expression

### DIFF
--- a/dev-ruby/sassc/sassc-2.4.0-r1.ebuild
+++ b/dev-ruby/sassc/sassc-2.4.0-r1.ebuild
@@ -34,7 +34,7 @@ all_ruby_prepare() {
 	# Use unbundled libsass
 	rm -rf ext || die
 
-	sed -i -e "/ffi_lib/ s:__dir__:${ESYSROOT}/usr/$(get_libdir):" \
+	sed -i -e "/ffi_lib/ s:__dir__:\"${ESYSROOT}/usr/$(get_libdir)\":" \
 		lib/sassc/native.rb || die
 
 	# Avoid version-specific test so newer libsass versions can be used.


### PR DESCRIPTION
In a fix for an unquoted ESYSROOT variable, I inadvertently removed the
quotes that were intended to be inserted by the sed expression.

Closes: https://bugs.gentoo.org/852674
Fixes: 0b69db1f3e1 ("dev-ruby/sassc: fix unquoted variable ESYSROOT")
Signed-off-by: Thomas Bracht Laumann Jespersen <t@laumann.xyz>