### PR TITLE
sys-apps/nvme-cli: fixed bash completion

### DIFF
--- a/sys-apps/nvme-cli/files/nvme-cli-1.16-bash-completions.patch
+++ b/sys-apps/nvme-cli/files/nvme-cli-1.16-bash-completions.patch
@@ -1,0 +1,72 @@
+This fixes several issues:
+* the upstream rebase error (unclosed double quote)
+* typo "lugin_seagate_opts"
+* "readonly" with assignment is problematic on Bash 5.1.x
+
+Gentoo bug: https://bugs.gentoo.org/852764
+Upstream: https://github.com/linux-nvme/nvme-cli/pull/1574
+Upstream: https://github.com/linux-nvme/nvme-cli/commit/25fd8c707b106ca0763402566ad657ef710bf09e
+
+Author: Karlson2k (Evgeny Grin)
+Signed-off-by: Karlson2k (Evgeny Grin) <k2k@narod.ru>
+
+diff --git a/completions/bash-nvme-completion.sh b/completions/bash-nvme-completion.sh
+index 41938d77..31afb3b3 100644
+--- a/completions/bash-nvme-completion.sh
++++ b/completions/bash-nvme-completion.sh
+@@ -3,12 +3,13 @@
+ # Kelly Kaoudis kelly.n.kaoudis at intel.com, Aug. 2015
+ 
+ # Constant to indicate command has no options
+-readonly NO_OPTS=""
++NO_OPTS=""
++readonly NO_OPTS
+ 
+ # Associative array of plugins and associated subcommands
+ # Order here is same as PLUGIN_OBJS in Makefile
+ typeset -A _plugin_subcmds
+-readonly _plugin_subcmds=(
++_plugin_subcmds=(
+ 	[intel]="id-ctrl internal-log lat-stats \
+ 		set-bucket-thresholds lat-stats-tracking \
+ 		market-name smart-log-add temp-stats"
+@@ -55,10 +56,11 @@ readonly _plugin_subcmds=(
+ 	[nvidia]="id-ctrl"
+ 	[ymtc]="smart-log-add"
+ )
++readonly _plugin_subcmds
+ 
+ # Associative array mapping plugins to coresponding option completions
+ typeset -A _plugin_funcs
+-readonly _plugin_funcs=(
++_plugin_funcs=(
+ 	[intel]="plugin_intel_opts"
+ 	[amzn]="plugin_amzn_opts"
+ 	[lnvm]="plugin_lnvm_opts"
+@@ -77,6 +79,7 @@ readonly _plugin_funcs=(
+ 	[nvidia]="plugin_nvidia_opts"
+ 	[ymtc]="plugin_ymtc_opts"
+ )
++readonly _plugin_funcs
+ 
+ # Top level commands
+ _cmds="list list-subsys id-ctrl id-ns \
+@@ -101,8 +104,7 @@ _cmds="list list-subsys id-ctrl id-ns \
+ 	connect disconnect disconnect-all gen-hostnqn \
+ 	show-hostnqn dir-receive dir-send virt-mgmt \
+ 	rpmb boot-part-log fid-support-effects-log \
+-	supported-log-pages lockdown"
+-	supported-log-pages list-endgrp"
++	supported-log-pages lockdown list-endgrp"
+ 
+ # Add plugins:
+ for plugin in "${!_plugin_subcmds[@]}"; do
+@@ -983,7 +985,7 @@ plugin_micron_opts () {
+ 	return 0
+ }
+ 
+-lugin_seagate_opts () {
++plugin_seagate_opts () {
+     local opts=""
+ 	local compargs=""
+ 

--- a/sys-apps/nvme-cli/files/nvme-cli-2.0-bash-completions.patch
+++ b/sys-apps/nvme-cli/files/nvme-cli-2.0-bash-completions.patch
@@ -1,0 +1,61 @@
+This fixes several issues:
+* typo "lugin_seagate_opts"
+* "readonly" with assignment resulting in error on Bash 5.x
+
+Gentoo bug: https://bugs.gentoo.org/852764
+Upstream: https://github.com/linux-nvme/nvme-cli/pull/1574
+Upstream: https://github.com/linux-nvme/nvme-cli/commit/25fd8c707b106ca0763402566ad657ef710bf09e
+
+Author: Karlson2k (Evgeny Grin)
+Signed-off-by: Karlson2k (Evgeny Grin) <k2k@narod.ru>
+
+diff --git a/completions/bash-nvme-completion.sh b/completions/bash-nvme-completion.sh
+index 5e0eb23b..469ba3e2 100644
+--- a/completions/bash-nvme-completion.sh
++++ b/completions/bash-nvme-completion.sh
+@@ -3,12 +3,13 @@
+ # Kelly Kaoudis kelly.n.kaoudis at intel.com, Aug. 2015
+ 
+ # Constant to indicate command has no options
+-readonly NO_OPTS=""
++NO_OPTS=""
++readonly NO_OPTS
+ 
+ # Associative array of plugins and associated subcommands
+ # Order here is same as PLUGIN_OBJS in Makefile
+ typeset -A _plugin_subcmds
+-readonly _plugin_subcmds=(
++_plugin_subcmds=(
+ 	[intel]="id-ctrl internal-log lat-stats \
+ 		set-bucket-thresholds lat-stats-tracking \
+ 		market-name smart-log-add temp-stats"
+@@ -53,10 +54,11 @@ readonly _plugin_subcmds=(
+ 	[nvidia]="id-ctrl"
+ 	[ymtc]="smart-log-add"
+ )
++readonly _plugin_subcmds
+ 
+ # Associative array mapping plugins to coresponding option completions
+ typeset -A _plugin_funcs
+-readonly _plugin_funcs=(
++_plugin_funcs=(
+ 	[intel]="plugin_intel_opts"
+ 	[amzn]="plugin_amzn_opts"
+ 	[memblaze]="plugin_memblaze_opts"
+@@ -74,6 +76,7 @@ readonly _plugin_funcs=(
+ 	[nvidia]="plugin_nvidia_opts"
+ 	[ymtc]="plugin_ymtc_opts"
+ )
++readonly _plugin_funcs
+ 
+ # Top level commands
+ _cmds="list list-subsys id-ctrl id-ns \
+@@ -939,7 +942,7 @@ plugin_micron_opts () {
+ 	return 0
+ }
+ 
+-lugin_seagate_opts () {
++plugin_seagate_opts () {
+     local opts=""
+ 	local compargs=""
+ 

--- a/sys-apps/nvme-cli/nvme-cli-1.16-r1.ebuild
+++ b/sys-apps/nvme-cli/nvme-cli-1.16-r1.ebuild
@@ -1,0 +1,55 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit systemd toolchain-funcs udev
+
+DESCRIPTION="NVM-Express user space tooling for Linux"
+HOMEPAGE="https://github.com/linux-nvme/nvme-cli"
+SRC_URI="https://github.com/linux-nvme/nvme-cli/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+RESTRICT="test"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
+IUSE="hugepages +json systemd +uuid"
+
+RDEPEND="json? ( dev-libs/json-c:= )
+	hugepages? ( sys-libs/libhugetlbfs )
+	systemd? ( sys-apps/systemd:= )
+	uuid? ( sys-apps/util-linux:= )"
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-musl-limits.patch
+	"${FILESDIR}"/${P}-bash-completions.patch # Gentoo bug #852764
+)
+
+src_prepare() {
+	default
+
+	sed -e 's|^LIBUUID =|LIBUUID ?=|' \
+		-e 's|^LIBJSONC =|LIBJSONC ?=|' \
+		-e 's|^LIBHUGETLBFS =|LIBHUGETLBFS ?=|' \
+		-e 's|^HAVE_SYSTEMD =|HAVE_SYSTEMD ?=|' \
+		-e '/DESTDIROLD/d' \
+		-i Makefile || die
+}
+
+src_configure() {
+	tc-export CC
+
+	export PREFIX="${EPREFIX}/usr"
+
+	local unitdir="$(systemd_get_systemunitdir)"
+	export SYSTEMDDIR="${unitdir%/system}"
+	export UDEVDIR="${EPREFIX}$(get_udevdir)"
+
+	MAKEOPTS+=" LIBUUID=$(usex uuid 0 1)"
+	MAKEOPTS+=" LIBJSONC=$(usex json 0 1)"
+	MAKEOPTS+=" LIBHUGETLBFS=$(usex hugepages 0 1)"
+	MAKEOPTS+=" HAVE_SYSTEMD=$(usex systemd 0 1)"
+	MAKEOPTS+="  V=1"
+}

--- a/sys-apps/nvme-cli/nvme-cli-2.0-r1.ebuild
+++ b/sys-apps/nvme-cli/nvme-cli-2.0-r1.ebuild
@@ -1,0 +1,38 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit meson systemd udev
+
+DESCRIPTION="NVM-Express user space tooling for Linux"
+HOMEPAGE="https://github.com/linux-nvme/nvme-cli"
+SRC_URI="https://github.com/linux-nvme/nvme-cli/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+RESTRICT="test"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~arm64 ~loong ~ppc64 ~riscv ~x86"
+IUSE="hugepages +json +uuid"
+
+RDEPEND="
+	sys-libs/libnvme:=[json=,uuid=]
+	hugepages? ( sys-libs/libhugetlbfs:= )
+	json? ( dev-libs/json-c:= )
+	uuid? ( sys-apps/util-linux:= )"
+
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-bash-completions.patch # Gentoo bug #852764
+)
+
+src_configure() {
+	local unitdir="$(systemd_get_systemunitdir)"
+	local emesonargs=(
+		-Dsystemddir=${unitdir%/system}
+		-Dudevrulesdir=${EPREFIX}$(get_udevdir)
+	)
+	meson_src_configure
+}


### PR DESCRIPTION
This fixes several issues for version 1.16 and 2.0:
* the upstream rebase error (unclosed double quote) (1.16 only)
* typo "lugin_seagate_opts"
* "readonly" with assignment preventing the file to be sourced for the second time

Without this patch `emerge` reports 
```
 * Problems with installed bash completions were found:
 *
 *      nvme: does not define any completions (failed to source?).
 *
 * For more details on installing bash-completions, please see:
 * https://wiki.gentoo.org/wiki/Bash/Installing_completion_files
```
and command completion does not work.

Gentoo bug: https://bugs.gentoo.org/852764
Upstream: https://github.com/linux-nvme/nvme-cli/pull/1574
Upstream: https://github.com/linux-nvme/nvme-cli/commit/25fd8c707b106ca0763402566ad657ef710bf09e