### PR TITLE
net-fs/nfs4-acl-tools: Fix libtool build issues

### DIFF
--- a/net-fs/nfs4-acl-tools/files/nfs4-acl-tools-0.3.7-libtool.patch
+++ b/net-fs/nfs4-acl-tools/files/nfs4-acl-tools-0.3.7-libtool.patch
@@ -1,0 +1,86 @@
+From 2abd5015bf6bac1697ac4422d76fa121a49f2b24 Mon Sep 17 00:00:00 2001
+From: orbea <orbea@riseup.net>
+Date: Fri, 17 Jun 2022 12:36:01 -0700
+Subject: [PATCH] configure: Add missing LT_INIT
+
+Otherwise it fails to generate libtool for the build breaking the build
+when using a different toolchain than the system libtool. It also breaks
+the build with rlibtool which depends on the generated libtool to
+determine if it should build static or shared libraries.
+
+The existing make and libtool tests were removed as unnecessary and
+problematic.
+---
+ configure.ac          |  3 +++
+ include/builddefs.in  |  3 ++-
+ m4/package_utilies.m4 | 20 --------------------
+ 3 files changed, 5 insertions(+), 21 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index c624295..bc3dac8 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -9,6 +9,9 @@ AC_ARG_ENABLE(shared,
+ 			     enable_shared=no)
+ AC_SUBST(enable_shared)
+ 
++LT_INIT
++
++AC_PROG_LIBTOOL
+ AC_PROG_INSTALL
+ AC_PROG_CC
+ 
+diff --git a/include/builddefs.in b/include/builddefs.in
+index fe49b08..3cc85ec 100644
+--- a/include/builddefs.in
++++ b/include/builddefs.in
+@@ -39,6 +39,8 @@ DEBUG = @debug_build@
+ OPTIMIZER = @opt_build@
+ MALLOCLIB = @malloc_lib@
+ 
++top_builddir = $(TOPDIR)
++
+ LIBNFS4ACL = $(TOPDIR)/libnfs4acl/libnfs4acl.la
+ LIBATTR = @libattr@
+ 
+@@ -68,7 +70,6 @@ AWK		= @awk@
+ SED		= @sed@
+ TAR		= @tar@
+ ZIP		= @zip@
+-MAKE		= @make@
+ ECHO		= @echo@
+ SORT		= @sort@
+ LN_S		= @LN_S@
+diff --git a/m4/package_utilies.m4 b/m4/package_utilies.m4
+index fe54e21..431c9bc 100644
+--- a/m4/package_utilies.m4
++++ b/m4/package_utilies.m4
+@@ -22,26 +22,6 @@ AC_DEFUN([AC_PACKAGE_UTILITIES],
+     AC_SUBST(cc)
+     AC_PACKAGE_NEED_UTILITY($1, "$cc", cc, [C compiler])
+ 
+-    if test -z "$MAKE"; then
+-        AC_PATH_PROG(MAKE, gmake,, /usr/bin:/usr/freeware/bin)
+-    fi
+-    if test -z "$MAKE"; then
+-        AC_PATH_PROG(MAKE, make,, /usr/bin)
+-    fi
+-    make=$MAKE
+-    AC_SUBST(make)
+-    AC_PACKAGE_NEED_UTILITY($1, "$make", make, [GNU make])
+-
+-    if test -z "$LIBTOOL"; then
+-	AC_PATH_PROG(LIBTOOL, glibtool,, /usr/bin)
+-    fi
+-    if test -z "$LIBTOOL"; then
+-	AC_PATH_PROG(LIBTOOL, libtool,, /usr/bin:/usr/local/bin:/usr/freeware/bin)
+-    fi
+-    libtool=$LIBTOOL
+-    AC_SUBST(libtool)
+-    AC_PACKAGE_NEED_UTILITY($1, "$libtool", libtool, [GNU libtool])
+-
+     if test -z "$TAR"; then
+         AC_PATH_PROG(TAR, tar,, /usr/freeware/bin:/bin:/usr/local/bin:/usr/bin)
+     fi
+-- 
+2.35.1

--- a/net-fs/nfs4-acl-tools/nfs4-acl-tools-0.3.7.ebuild
+++ b/net-fs/nfs4-acl-tools/nfs4-acl-tools-0.3.7.ebuild
@@ -17,7 +17,10 @@ IUSE=""
 DEPEND="sys-apps/attr"
 RDEPEND="${DEPEND}"
 
-PATCHES=( "${FILESDIR}"/${PN}-0.3.5-jobserver-unavailable.patch )
+PATCHES=(
+	"${FILESDIR}"/${P}-libtool.patch # 731162
+	"${FILESDIR}"/${PN}-0.3.5-jobserver-unavailable.patch
+)
 
 src_prepare() {
 	default


### PR DESCRIPTION
When building with a different toolchain than what was used to compile
the system libtool the build will fail. To fix this autoconf needs to
generate libtool instead of using the system libtool. Additionally
rlibtool depends on libtool being generated to work correctly.

Bug: https://bugs.gentoo.org/731162