### PR TITLE
media-sound/pulseaudio-daemon: Add optional conf dirs to silence warning

### DIFF
--- a/media-sound/pulseaudio-daemon/pulseaudio-daemon-16.0-r4.ebuild
+++ b/media-sound/pulseaudio-daemon/pulseaudio-daemon-16.0-r4.ebuild
@@ -256,6 +256,11 @@ src_install() {
 	rm "${D}/$(get_bashcompdir)"/pacmd || die
 	rm "${D}/$(get_bashcompdir)"/pasuspender || die
 
+	# Daemon configuration scripts will try to load snippets from corresponding '.d' dirs.
+	# Install these dirs to silence a warning if they are missing.
+	keepdir /etc/pulse/default.pa.d
+	keepdir /etc/pulse/system.pa.d
+
 	if use system-wide; then
 		newconfd "${FILESDIR}"/pulseaudio.conf.d pulseaudio
 


### PR DESCRIPTION
Daemon configuration scripts will try to load snippets from corresponding `'.d'` dirs.
Install these dirs to silence a warning if they are missing.

Warning is otherwise harmless, suggest to revbump with next functional change.
