### PR TITLE
pulseaudio post 16.0 fixes

### DIFF
--- a/media-libs/libpulse/files/pulseaudio-16.0-fix-pactl-volume-command.patch
+++ b/media-libs/libpulse/files/pulseaudio-16.0-fix-pactl-volume-command.patch
@@ -1,0 +1,55 @@
+https://gitlab.freedesktop.org/pulseaudio/pulseaudio/-/commit/05c06afa58e30b7958e96766d1e917099c8a4041
+
+From 05c06afa58e30b7958e96766d1e917099c8a4041 Mon Sep 17 00:00:00 2001
+From: Sean Greenslade <sean@seangreenslade.com>
+Date: Sat, 4 Jun 2022 00:24:49 -0700
+Subject: [PATCH] pactl: fix parsing of percentages with decimal points
+
+The logic for detecting which type of volume was given incorrectly interpreted
+any value with a decimal as a VOL_LINEAR. It also could set multiple flags,
+which would put the flags variable into an indeterminate state. Additionally,
+the flags stack variable was uninitialized which could also lead to an
+indeterminate flag state.
+
+Percentages are now prioritized over all other types, and only one type flag
+can be set.
+---
+ src/utils/pactl.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/src/utils/pactl.c b/src/utils/pactl.c
+index 35163f277..2761ebaaf 100644
+--- a/src/utils/pactl.c
++++ b/src/utils/pactl.c
+@@ -2527,16 +2527,16 @@ static int parse_volume(const char *vol_spec, pa_volume_t *vol, enum volume_flag
+     vs = pa_xstrdup(vol_spec);
+ 
+     *vol_flags = (pa_startswith(vs, "+") || pa_startswith(vs, "-")) ? VOL_RELATIVE : VOL_ABSOLUTE;
+-    if (strchr(vs, '.'))
+-        *vol_flags |= VOL_LINEAR;
+     if (pa_endswith(vs, "%")) {
+         *vol_flags |= VOL_PERCENT;
+         vs[strlen(vs)-1] = 0;
+     }
+-    if (pa_endswith(vs, "db") || pa_endswith(vs, "dB")) {
++    else if (pa_endswith(vs, "db") || pa_endswith(vs, "dB")) {
+         *vol_flags |= VOL_DECIBEL;
+         vs[strlen(vs)-2] = 0;
+     }
++    else if (strchr(vs, '.'))
++        *vol_flags |= VOL_LINEAR;
+ 
+     atod_input = vs;
+ 
+@@ -2597,7 +2597,7 @@ static int parse_volumes(char *args[], unsigned n) {
+ 
+     volume.channels = n;
+     for (i = 0; i < volume.channels; i++) {
+-        enum volume_flags flags;
++        enum volume_flags flags = 0;
+ 
+         if (parse_volume(args[i], &volume.values[i], &flags) < 0)
+             return -1;
+-- 
+GitLab
+

--- a/media-libs/libpulse/libpulse-16.0-r1.ebuild
+++ b/media-libs/libpulse/libpulse-16.0-r1.ebuild
@@ -1,0 +1,204 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="7"
+
+MY_PV="${PV/_pre*}"
+MY_P="pulseaudio-${MY_PV}"
+inherit bash-completion-r1 gnome2-utils meson-multilib optfeature systemd udev
+
+DESCRIPTION="Libraries for PulseAudio clients"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/PulseAudio/"
+
+if [[ ${PV} = 9999 ]]; then
+	inherit git-r3
+	EGIT_BRANCH="master"
+	EGIT_REPO_URI="https://gitlab.freedesktop.org/pulseaudio/pulseaudio"
+else
+	SRC_URI="https://freedesktop.org/software/pulseaudio/releases/${MY_P}.tar.xz"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86 ~amd64-linux ~x86-linux"
+fi
+
+S="${WORKDIR}/${MY_P}"
+
+LICENSE="LGPL-2.1+"
+
+SLOT="0"
+IUSE="+asyncns dbus doc +glib gtk selinux systemd test valgrind X"
+RESTRICT="!test? ( test )"
+
+# NOTE: libpcre needed in some cases, bug #472228
+# TODO: libatomic_ops is only needed on some architectures and conditions, and then at runtime too
+RDEPEND="
+	dev-libs/libatomic_ops
+	>=media-libs/libsndfile-1.0.20[${MULTILIB_USEDEP}]
+	virtual/libc
+	asyncns? ( >=net-libs/libasyncns-0.1[${MULTILIB_USEDEP}] )
+	dbus? ( >=sys-apps/dbus-1.4.12[${MULTILIB_USEDEP}] )
+	glib? ( >=dev-libs/glib-2.28.0:2[${MULTILIB_USEDEP}] )
+	gtk? ( x11-libs/gtk+:3 )
+	selinux? ( sec-policy/selinux-pulseaudio )
+	systemd? ( sys-apps/systemd:= )
+	valgrind? ( dev-util/valgrind )
+	X? (
+		x11-libs/libX11[${MULTILIB_USEDEP}]
+		>=x11-libs/libxcb-1.6[${MULTILIB_USEDEP}]
+	)
+	|| (
+		elibc_glibc? ( virtual/libc )
+		dev-libs/libpcre:3
+	)
+	!<media-sound/pulseaudio-15.0-r100
+"
+
+DEPEND="${RDEPEND}
+	test? ( >=dev-libs/check-0.9.10 )
+	X? ( x11-base/xorg-proto )
+"
+
+# pulseaudio ships a bundled xmltoman, which uses XML::Parser
+BDEPEND="
+	dev-lang/perl
+	dev-perl/XML-Parser
+	sys-devel/gettext
+	sys-devel/m4
+	virtual/libiconv
+	virtual/libintl
+	virtual/pkgconfig
+	doc? ( app-doc/doxygen )
+"
+
+DOCS=( NEWS README )
+
+# patches merged upstream, to be removed with 16.0 bump
+PATCHES=(
+	"${FILESDIR}"/pulseaudio-16.0-fix-pactl-volume-command.patch
+)
+
+src_prepare() {
+	default
+
+	# disable autospawn by client
+	sed -i -e 's:; autospawn = yes:autospawn = no:g' src/pulse/client.conf.in || die
+
+	gnome2_environment_reset
+}
+
+multilib_src_configure() {
+	local emesonargs=(
+		--localstatedir="${EPREFIX}"/var
+
+		-Ddaemon=false
+		-Dclient=true
+		$(meson_native_use_bool doc doxygen)
+		-Dgcov=false
+		# tests involve random modules, so just do them for the native # TODO: tests should run always
+		$(meson_native_use_bool test tests)
+		-Ddatabase=simple # Not used for non-daemon, simple database avoids external dep checks
+		-Dstream-restore-clear-old-devices=true
+		-Drunning-from-build-tree=false
+
+		# Paths
+		-Dmodlibexecdir="${EPREFIX}/usr/$(get_libdir)/pulseaudio/modules" # Was $(get_libdir)/${P}
+		-Dsystemduserunitdir=$(systemd_get_userunitdir)
+		-Dudevrulesdir="${EPREFIX}$(get_udevdir)/rules.d"
+		-Dbashcompletiondir="$(get_bashcompdir)" # Alternatively DEPEND on app-shells/bash-completion for pkg-config to provide the value
+
+		# Optional features
+		-Dalsa=disabled
+		$(meson_feature asyncns)
+		-Davahi=disabled
+		-Dbluez5=disabled
+		-Dbluez5-gstreamer=disabled
+		-Dbluez5-native-headset=false
+		-Dbluez5-ofono-headset=false
+		$(meson_feature dbus)
+		-Delogind=disabled
+		-Dfftw=disabled
+		$(meson_feature glib) # WARNING: toggling this likely changes ABI
+		-Dgsettings=disabled
+		-Dgstreamer=disabled
+		$(meson_native_use_feature gtk)
+		-Dhal-compat=false
+		-Dipv6=true
+		-Djack=disabled
+		-Dlirc=disabled
+		-Dopenssl=disabled
+		-Dorc=disabled
+		-Doss-output=disabled
+		-Dsamplerate=disabled # Matches upstream
+		-Dsoxr=disabled
+		-Dspeex=disabled
+		$(meson_native_use_feature systemd)
+		-Dtcpwrap=disabled
+		-Dudev=disabled
+		$(meson_native_use_feature valgrind)
+		$(meson_feature X x11)
+
+		# Echo cancellation
+		-Dadrian-aec=false
+		-Dwebrtc-aec=disabled
+	)
+
+	if multilib_is_native_abi; then
+		# Make padsp work for non-native ABI, supposedly only possible with glibc;
+		# this is used by /usr/bin/padsp that comes from native build, thus we need
+		# this argument for native build
+		if use elibc_glibc; then
+			emesonargs+=( -Dpulsedsp-location="${EPREFIX}"'/usr/\\$$LIB/pulseaudio' )
+		fi
+	else
+		emesonargs+=( -Dman=false )
+		if ! use elibc_glibc; then
+			# Non-glibc multilib is probably non-existent but just in case:
+			ewarn "padsp wrapper for OSS emulation will only work with native ABI applications!"
+		fi
+	fi
+
+	meson_src_configure
+}
+
+multilib_src_compile() {
+	meson_src_compile
+
+	if multilib_is_native_abi; then
+		if use doc; then
+			einfo "Generating documentation ..."
+			meson_src_compile doxygen
+		fi
+	fi
+}
+
+multilib_src_install() {
+	# The files referenced in the DOCS array do not exist in the multilib source directory,
+	# therefore clear the variable when calling the function that will access it.
+	DOCS= meson_src_install
+
+	# Upstream installs 'pactl' if client is built, with all symlinks except for
+	# 'pulseaudio', 'pacmd' and 'pasuspender' which are installed if server is built.
+	# This trips QA warning, workaround:
+	# - install missing aliases in media-libs/libpulse (client build)
+	# - remove corresponding symlinks in media-sound/pulseaudio-daemonclient (server build)
+	bashcomp_alias pactl pulseaudio
+	bashcomp_alias pactl pacmd
+	bashcomp_alias pactl pasuspender
+
+	if multilib_is_native_abi; then
+		if use doc; then
+			einfo "Installing documentation ..."
+			docinto html
+			dodoc -r doxygen/html/.
+		fi
+	fi
+}
+
+multilib_src_install_all() {
+	einstalldocs
+
+	find "${ED}" \( -name '*.a' -o -name '*.la' \) -delete || die
+}
+
+pkg_postinst() {
+	optfeature_header "PulseAudio can be enhanced by installing the following:"
+	use dbus && optfeature "restricted realtime capabilities via D-Bus" sys-auth/rtkit
+}

--- a/media-sound/pulseaudio-daemon/files/pulseaudio-16.0-fix-combine-sink-underrun-crash.patch
+++ b/media-sound/pulseaudio-daemon/files/pulseaudio-16.0-fix-combine-sink-underrun-crash.patch
@@ -1,0 +1,72 @@
+https://gitlab.freedesktop.org/pulseaudio/pulseaudio/-/commit/ee8bfb49adddd271d8a8cafa796c6f9fa84de48a
+
+From ee8bfb49adddd271d8a8cafa796c6f9fa84de48a Mon Sep 17 00:00:00 2001
+From: Georg Chini <georg@chini.tk>
+Date: Fri, 17 Jun 2022 13:11:11 +0200
+Subject: [PATCH] combine-sink: Fix threading issue during underrun
+
+A recent commit added i->origin sink for the sink inputs of the combine sinks.
+Therefore pa_sink_process_input_underruns() treated the combine sink like
+filter sinks. pa_sink_process_input_underruns() calls itself with the
+origin sink, which is only correct for filter sinks because they run in the
+thread context of the origin sink. The combine sink however has its own
+thread context, so pa_sink_process_input_underruns() was executed in the
+wrong context.
+This patch fixes the issue by skipping the section for module-combine-sink.
+
+Part-of: <https://gitlab.freedesktop.org/pulseaudio/pulseaudio/-/merge_requests/722>
+---
+ src/pulsecore/sink.c | 37 +++++++++++++++++++++++--------------
+ 1 file changed, 23 insertions(+), 14 deletions(-)
+
+diff --git a/src/pulsecore/sink.c b/src/pulsecore/sink.c
+index 3108ae765..0f0dc56fc 100644
+--- a/src/pulsecore/sink.c
++++ b/src/pulsecore/sink.c
+@@ -1016,20 +1016,29 @@ size_t pa_sink_process_input_underruns(pa_sink *s, size_t left_to_play) {
+         if (i->origin_sink) {
+             size_t filter_result, left_to_play_origin;
+ 
+-            /* The recursive call works in the origin sink domain ... */
+-            left_to_play_origin = pa_convert_size(left_to_play, &i->sink->sample_spec, &i->origin_sink->sample_spec);
+-
+-            /* .. and returns the time to sleep before waking up. We need the
+-             * underrun duration for comparisons, so we undo the subtraction on
+-             * the return value... */
+-            filter_result = left_to_play_origin - pa_sink_process_input_underruns(i->origin_sink, left_to_play_origin);
+-
+-            /* ... and convert it back to the master sink domain */
+-            filter_result = pa_convert_size(filter_result, &i->origin_sink->sample_spec, &i->sink->sample_spec);
+-
+-            /* Remember the longest underrun so far */
+-            if (filter_result > result)
+-                result = filter_result;
++            /* The combine sink sets i->origin sink but has a different threading model
++             * than the filter sinks. Therefore the recursion below may not be executed
++             * because pa_sink_process_input_underruns() was not called in the thread
++             * context of the origin sink.
++             * FIXME: It is unclear if some other kind of recursion would be necessary
++             * for the combine sink. */
++            if (!i->module || !pa_safe_streq(i->module->name, "module-combine-sink")) {
++
++                /* The recursive call works in the origin sink domain ... */
++                left_to_play_origin = pa_convert_size(left_to_play, &i->sink->sample_spec, &i->origin_sink->sample_spec);
++
++                /* .. and returns the time to sleep before waking up. We need the
++                 * underrun duration for comparisons, so we undo the subtraction on
++                 * the return value... */
++                filter_result = left_to_play_origin - pa_sink_process_input_underruns(i->origin_sink, left_to_play_origin);
++
++                /* ... and convert it back to the master sink domain */
++                filter_result = pa_convert_size(filter_result, &i->origin_sink->sample_spec, &i->sink->sample_spec);
++
++                /* Remember the longest underrun so far */
++                if (filter_result > result)
++                    result = filter_result;
++            }
+         }
+ 
+         if (uf == 0) {
+-- 
+GitLab
+

--- a/media-sound/pulseaudio-daemon/files/pulseaudio-16.0-fix-gstreamer-bluetooth-arm-crash.patch
+++ b/media-sound/pulseaudio-daemon/files/pulseaudio-16.0-fix-gstreamer-bluetooth-arm-crash.patch
@@ -1,0 +1,43 @@
+https://gitlab.freedesktop.org/pulseaudio/pulseaudio/-/commit/dd4dc5e8bce2c03631c3613dbddee1a691bdd17d
+
+From dd4dc5e8bce2c03631c3613dbddee1a691bdd17d Mon Sep 17 00:00:00 2001
+From: Jan Palus <jpalus@fastmail.com>
+Date: Fri, 17 Jun 2022 14:36:36 +0200
+Subject: [PATCH] bluetooth/gst: Correct var type for GST_TYPE_BITMASK
+
+GST_TYPE_BITMASK is 64-bit bit mask while corresponding channel_mask in
+pulseaudio is int therefore usually 32-bit. Switch to uint64_t instead
+to match internal representation in gstreamer.
+
+Fixes pulseaudio crash on ARM 32-bit when pulseaudio is compiled with
+gstreamer and either LDAC or aptX support is available.
+
+Part-of: <https://gitlab.freedesktop.org/pulseaudio/pulseaudio/-/merge_requests/723>
+---
+ src/modules/bluetooth/a2dp-codec-gst.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/modules/bluetooth/a2dp-codec-gst.c b/src/modules/bluetooth/a2dp-codec-gst.c
+index 8ef74be9c..11839c580 100644
+--- a/src/modules/bluetooth/a2dp-codec-gst.c
++++ b/src/modules/bluetooth/a2dp-codec-gst.c
+@@ -22,6 +22,7 @@
+ #endif
+ 
+ #include <arpa/inet.h>
++#include <stdint.h>
+ 
+ #include <pulsecore/log.h>
+ #include <pulsecore/macro.h>
+@@ -82,7 +83,7 @@ fail:
+ static GstCaps *gst_create_caps_from_sample_spec(const pa_sample_spec *ss) {
+     gchar *sample_format;
+     GstCaps *caps;
+-    int channel_mask;
++    uint64_t channel_mask;
+ 
+     switch (ss->format) {
+         case PA_SAMPLE_S16LE:
+-- 
+GitLab
+

--- a/media-sound/pulseaudio-daemon/files/pulseaudio-16.0-fix-pacmd-play-file-crash.patch
+++ b/media-sound/pulseaudio-daemon/files/pulseaudio-16.0-fix-pacmd-play-file-crash.patch
@@ -1,0 +1,42 @@
+https://gitlab.freedesktop.org/pulseaudio/pulseaudio/-/commit/a8a2a31408c4acf54530d65922d235d3e590ce05
+
+From a8a2a31408c4acf54530d65922d235d3e590ce05 Mon Sep 17 00:00:00 2001
+From: Jaechul Lee <jcsing.lee@samsung.com>
+Date: Thu, 2 Jun 2022 15:07:09 +0900
+Subject: [PATCH] sound-file-stream: Fix crash when playing a file which is not
+ aligned
+
+pulseaudio crash occurred when I play a file using pacmd play-file command.
+The file is not aligned with its frame size and the last rendering size
+is also not aligned. Thus, an assertion was generated at the end of the
+file as the following.
+
+memblockq.c: Assertion 'uchunk->length % bq->base == 0' failed at
+../src/pulsecore/memblockq.c:288, function pa_memblockq_push(). Aborting.
+
+When I play the file using paplay, it works good. So, I changed to
+pa_memblockq_push_align instead of pa_memblockq_push to prevent the
+assertion.
+
+Signed-off-by: Jaechul Lee <jcsing.lee@samsung.com>
+Part-of: <https://gitlab.freedesktop.org/pulseaudio/pulseaudio/-/merge_requests/717>
+---
+ src/pulsecore/sound-file-stream.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/pulsecore/sound-file-stream.c b/src/pulsecore/sound-file-stream.c
+index 147aa2288..255f4b61a 100644
+--- a/src/pulsecore/sound-file-stream.c
++++ b/src/pulsecore/sound-file-stream.c
+@@ -185,7 +185,7 @@ static int sink_input_pop_cb(pa_sink_input *i, size_t length, pa_memchunk *chunk
+ 
+         tchunk.length = (size_t) n * fs;
+ 
+-        pa_memblockq_push(u->memblockq, &tchunk);
++        pa_memblockq_push_align(u->memblockq, &tchunk);
+         pa_memblock_unref(tchunk.memblock);
+     }
+ 
+-- 
+GitLab
+

--- a/media-sound/pulseaudio-daemon/pulseaudio-daemon-16.0-r5.ebuild
+++ b/media-sound/pulseaudio-daemon/pulseaudio-daemon-16.0-r5.ebuild
@@ -165,6 +165,7 @@ S="${WORKDIR}/${MY_P}"
 PATCHES=(
 	"${FILESDIR}"/pulseaudio-16.0-fix-rtp-receiver-sdp-record.patch
 	"${FILESDIR}"/pulseaudio-16.0-optional-module-console-kit.patch
+	"${FILESDIR}"/pulseaudio-16.0-fix-combine-sink-underrun-crash.patch
 )
 
 src_prepare() {

--- a/media-sound/pulseaudio-daemon/pulseaudio-daemon-16.0-r5.ebuild
+++ b/media-sound/pulseaudio-daemon/pulseaudio-daemon-16.0-r5.ebuild
@@ -1,0 +1,388 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="7"
+
+MY_PV="${PV/_pre*}"
+MY_P="pulseaudio-${MY_PV}"
+inherit bash-completion-r1 gnome2-utils meson optfeature systemd tmpfiles udev
+
+DESCRIPTION="A networked sound server with an advanced plugin system"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/PulseAudio/"
+
+if [[ ${PV} = 9999 ]]; then
+	inherit git-r3
+	EGIT_BRANCH="master"
+	EGIT_REPO_URI="https://gitlab.freedesktop.org/pulseaudio/pulseaudio"
+else
+	SRC_URI="https://freedesktop.org/software/pulseaudio/releases/${MY_P}.tar.xz"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86 ~amd64-linux ~x86-linux"
+fi
+
+S="${WORKDIR}/${MY_P}"
+
+# libpulse-simple and libpulse link to libpulse-core; this is daemon's
+# library and can link to gdbm and other GPL-only libraries. In this
+# cases, we have a fully GPL-2 package. Leaving the rest of the
+# GPL-forcing USE flags for those who use them.
+LICENSE="!gdbm? ( LGPL-2.1 ) gdbm? ( GPL-2 )"
+
+SLOT="0"
+
+# +alsa-plugin as discussed in bug #519530
+# TODO: Find out why webrtc-aec is + prefixed - there's already the always available speexdsp-aec
+# NOTE: The current ebuild sets +X almost certainly just for the pulseaudio.desktop file
+IUSE="+alsa +alsa-plugin aptx +asyncns bluetooth dbus elogind equalizer fftw +gdbm +glib gstreamer jack ldac lirc
+ofono-headset +orc oss selinux sox ssl systemd system-wide tcpd test +udev valgrind +webrtc-aec +X zeroconf"
+
+RESTRICT="!test? ( test )"
+
+# See "*** BLUEZ support not found (requires D-Bus)" in configure.ac
+# Basically all IUSE are either ${MULTILIB_USEDEP} for client libs or they belong under !daemon ()
+# We duplicate alsa-plugin, {native,ofono}-headset under daemon to let users deal with them at once
+REQUIRED_USE="
+	?? ( elogind systemd )
+	alsa-plugin? ( alsa )
+	aptx? ( bluetooth )
+	bluetooth? ( dbus )
+	equalizer? ( dbus )
+	ldac? ( bluetooth )
+	ofono-headset? ( bluetooth )
+	udev? ( || ( alsa oss ) )
+	zeroconf? ( dbus )
+"
+
+# NOTE:
+# - libpcre needed in some cases, bug #472228
+# - media-libs/speexdsp is providing echo canceller implementation and used in resampler
+# TODO: libatomic_ops is only needed on some architectures and conditions, and then at runtime too
+gstreamer_deps="
+	media-libs/gst-plugins-base
+	>=media-libs/gstreamer-1.14
+"
+COMMON_DEPEND="
+	>=media-libs/libpulse-${PV}[dbus?,glib?,systemd?,valgrind?,X?]
+	dev-libs/libatomic_ops
+	>=media-libs/libsndfile-1.0.20
+	>=media-libs/speexdsp-1.2
+	|| (
+		elibc_glibc? ( virtual/libc )
+		dev-libs/libpcre:3
+	)
+	alsa? ( >=media-libs/alsa-lib-1.0.24 )
+	aptx? ( ${gstreamer_deps} )
+	asyncns? ( >=net-libs/libasyncns-0.1 )
+	bluetooth? (
+		>=net-wireless/bluez-5
+		media-libs/sbc
+	)
+	dev-libs/libltdl
+	sys-kernel/linux-headers
+	>=sys-libs/libcap-2.22-r2
+	dbus? ( >=sys-apps/dbus-1.4.12 )
+	elogind? ( sys-auth/elogind )
+	equalizer? (
+		sci-libs/fftw:3.0=
+	)
+	fftw? (
+		sci-libs/fftw:3.0=
+	)
+	gdbm? ( sys-libs/gdbm:= )
+	glib? ( >=dev-libs/glib-2.28.0:2 )
+	gstreamer? (
+		${gstreamer_deps}
+		>=dev-libs/glib-2.26.0:2
+	)
+	jack? ( virtual/jack )
+	ldac? ( ${gstreamer_deps} )
+	lirc? ( app-misc/lirc )
+	ofono-headset? ( >=net-misc/ofono-1.13 )
+	orc? ( >=dev-lang/orc-0.4.15 )
+	selinux? ( sec-policy/selinux-pulseaudio )
+	sox? ( >=media-libs/soxr-0.1.1 )
+	ssl? ( dev-libs/openssl:= )
+	systemd? ( sys-apps/systemd:= )
+	tcpd? ( sys-apps/tcp-wrappers )
+	udev? ( >=virtual/udev-143[hwdb(+)] )
+	valgrind? ( dev-util/valgrind )
+	webrtc-aec? ( >=media-libs/webrtc-audio-processing-0.2:0 )
+	X? (
+		>=x11-libs/libxcb-1.6
+		x11-libs/libICE
+		x11-libs/libSM
+		>=x11-libs/libX11-1.4.0
+		>=x11-libs/libXtst-1.0.99.2
+	)
+	zeroconf? ( >=net-dns/avahi-0.6.12[dbus] )
+	!<media-sound/pulseaudio-15.0-r100
+"
+
+# pulseaudio ships a bundle xmltoman, which uses XML::Parser
+DEPEND="
+	${COMMON_DEPEND}
+	test? ( >=dev-libs/check-0.9.10 )
+	X? ( x11-base/xorg-proto )
+"
+
+# alsa-utils dep is for the alsasound init.d script (see bug 155707); TODO: read it
+# NOTE: Only system-wide needs acct-group/audio unless elogind/systemd is not used
+RDEPEND="
+	${COMMON_DEPEND}
+	system-wide? (
+		alsa? ( media-sound/alsa-utils )
+		acct-user/pulse
+		acct-group/audio
+		acct-group/pulse-access
+	)
+	bluetooth? (
+		ldac? ( media-plugins/gst-plugins-ldac )
+		aptx? ( media-plugins/gst-plugins-openaptx )
+	)
+"
+unset gstreamer_deps
+
+# This is a PDEPEND to avoid a circular dep
+PDEPEND="
+	alsa? ( alsa-plugin? ( >=media-plugins/alsa-plugins-1.0.27-r1[pulseaudio] ) )
+"
+
+BDEPEND="
+	dev-lang/perl
+	dev-perl/XML-Parser
+	sys-devel/gettext
+	virtual/libiconv
+	virtual/libintl
+	virtual/pkgconfig
+	orc? ( >=dev-lang/orc-0.4.15 )
+	system-wide? ( dev-util/unifdef )
+"
+
+DOCS=( NEWS README )
+
+S="${WORKDIR}/${MY_P}"
+
+# patches merged upstream, to be removed with 16.1 or later bump
+PATCHES=(
+	"${FILESDIR}"/pulseaudio-16.0-fix-rtp-receiver-sdp-record.patch
+	"${FILESDIR}"/pulseaudio-16.0-optional-module-console-kit.patch
+)
+
+src_prepare() {
+	default
+
+	gnome2_environment_reset
+}
+
+src_configure() {
+	local enable_bluez5_gstreamer="disabled"
+	if use aptx || use ldac ; then
+		enable_bluez5_gstreamer="enabled"
+	fi
+
+	local enable_fftw="disabled"
+	if use equalizer || use fftw ; then
+		enable_fftw="enabled"
+	fi
+
+	local emesonargs=(
+		--localstatedir="${EPREFIX}"/var
+
+		-Ddaemon=true
+		-Dclient=false
+		-Ddoxygen=false
+		-Dgcov=false
+		-Dman=true
+		# tests involve random modules, so just do them for the native # TODO: tests should run always
+		$(meson_use test tests)
+		-Ddatabase=$(usex gdbm gdbm simple) # tdb is also an option but no one cares about it
+		-Dstream-restore-clear-old-devices=true
+		-Drunning-from-build-tree=false
+
+		# Paths
+		-Dmodlibexecdir="${EPREFIX}/usr/$(get_libdir)/pulseaudio/modules" # Was $(get_libdir)/${P}
+		-Dsystemduserunitdir=$(systemd_get_userunitdir)
+		-Dudevrulesdir="${EPREFIX}$(get_udevdir)/rules.d"
+		-Dbashcompletiondir="$(get_bashcompdir)" # Alternatively DEPEND on app-shells/bash-completion for pkg-config to provide the value
+
+		# Optional features
+		$(meson_feature alsa)
+		$(meson_feature asyncns)
+		$(meson_feature zeroconf avahi)
+		$(meson_feature bluetooth bluez5)
+		-Dbluez5-gstreamer=${enable_bluez5_gstreamer}
+		$(meson_use bluetooth bluez5-native-headset)
+		$(meson_use ofono-headset bluez5-ofono-headset)
+		-Dconsolekit=disabled
+		$(meson_feature dbus)
+		$(meson_feature elogind)
+		-Dfftw=${enable_fftw}
+		$(meson_feature glib) # WARNING: toggling this likely changes ABI
+		$(meson_feature glib gsettings) # Supposedly correct?
+		$(meson_feature gstreamer)
+		-Dgtk=disabled
+		-Dhal-compat=false
+		-Dipv6=true
+		$(meson_feature jack)
+		$(meson_feature lirc)
+		$(meson_feature ssl openssl)
+		$(meson_feature orc)
+		$(meson_feature oss oss-output)
+		-Dsamplerate=disabled # Matches upstream
+		$(meson_feature sox soxr)
+		-Dspeex=enabled
+		$(meson_feature systemd)
+		$(meson_feature tcpd tcpwrap)
+		$(meson_feature udev)
+		$(meson_feature valgrind)
+		$(meson_feature X x11)
+
+		# Echo cancellation
+		-Dadrian-aec=false # Not packaged?
+		$(meson_feature webrtc-aec)
+	)
+
+	meson_src_configure
+}
+
+src_install() {
+	meson_src_install
+
+	# Upstream installs 'pactl' if client is built, with all symlinks except for
+	# 'pulseaudio', 'pacmd' and 'pasuspender' which are installed if server is built.
+	# This trips QA warning, workaround:
+	# - install missing aliases in media-libs/libpulse (client build)
+	# - remove corresponding symlinks in media-sound/pulseaudio-daemonclient (server build)
+	rm "${D}/$(get_bashcompdir)"/pulseaudio || die
+	rm "${D}/$(get_bashcompdir)"/pacmd || die
+	rm "${D}/$(get_bashcompdir)"/pasuspender || die
+
+	if use system-wide; then
+		newconfd "${FILESDIR}"/pulseaudio.conf.d pulseaudio
+
+		use_define() {
+			local define=${2:-$(echo ${1} | tr '[:lower:]' '[:upper:]')}
+
+			use "${1}" && echo "-D${define}" || echo "-U${define}"
+		}
+
+		unifdef -x 1 \
+			$(use_define zeroconf AVAHI) \
+			$(use_define alsa) \
+			$(use_define bluetooth) \
+			$(use_define udev) \
+			"${FILESDIR}"/pulseaudio.init.d-5 \
+			> "${T}"/pulseaudio \
+			|| die
+
+		doinitd "${T}"/pulseaudio
+
+		systemd_dounit "${FILESDIR}"/pulseaudio.service
+
+		# We need /var/run/pulse, bug 442852
+		newtmpfiles "${FILESDIR}"/pulseaudio.tmpfiles pulseaudio.conf
+	else
+		# Prevent warnings when system-wide is not used, bug 447694
+		if use dbus; then
+			rm "${ED}"/etc/dbus-1/system.d/pulseaudio-system.conf || die
+		fi
+	fi
+
+	if use zeroconf; then
+		sed -i \
+			-e '/module-zeroconf-publish/s:^#::' \
+			"${ED}/etc/pulse/default.pa" \
+			|| die
+	fi
+
+	# Only enable autospawning pulseaudio daemon on systems without systemd
+	if ! use systemd; then
+		insinto /etc/pulse/client.conf.d
+		newins "${FILESDIR}/enable-autospawn.conf" "enable-autospawn.conf"
+	fi
+
+	find "${ED}" \( -name '*.a' -o -name '*.la' \) -delete || die
+}
+
+pkg_postinst() {
+	gnome2_schemas_update
+
+	use udev && udev_reload
+
+	if use system-wide; then
+		tmpfiles_process "pulseaudio.conf"
+
+		elog "You have enabled the 'system-wide' USE flag for pulseaudio."
+		elog "This mode should only be used on headless servers, embedded systems,"
+		elog "or thin clients. It will usually require manual configuration, and is"
+		elog "incompatible with many expected pulseaudio features."
+		elog "On normal desktop systems, system-wide mode is STRONGLY DISCOURAGED."
+		elog ""
+		elog "For more information, see"
+		elog "    https://www.freedesktop.org/wiki/Software/PulseAudio/Documentation/User/WhatIsWrongWithSystemWide/"
+		elog "    https://www.freedesktop.org/wiki/Software/PulseAudio/Documentation/User/SystemWide/"
+		elog "    https://wiki.gentoo.org/wiki/PulseAudio#Headless_server"
+		elog ""
+	fi
+
+	if use equalizer; then
+		elog "You will need to load some extra modules to make qpaeq work."
+		elog "You can do that by adding the following two lines in"
+		elog "/etc/pulse/default.pa and restarting pulseaudio:"
+		elog "load-module module-equalizer-sink"
+		elog "load-module module-dbus-protocol"
+		elog ""
+	fi
+
+	if use bluetooth; then
+		elog "You have enabled bluetooth USE flag for pulseaudio. Daemon will now handle"
+		elog "bluetooth Headset (HSP HS and HSP AG) and Handsfree (HFP HF) profiles using"
+		elog "native headset backend by default. This can be selectively disabled"
+		elog "via runtime configuration arguments to module-bluetooth-discover"
+		elog "in /etc/pulse/default.pa"
+		elog "To disable HFP HF append enable_native_hfp_hf=false"
+		elog "To disable HSP HS append enable_native_hsp_hs=false"
+		elog "To disable HSP AG append headset=auto or headset=ofono"
+		elog "(note this does NOT require enabling USE ofono)"
+		elog ""
+	fi
+
+	if use ofono-headset; then
+		elog "You have enabled both native and ofono headset profiles. The runtime decision"
+		elog "which to use is done via the 'headset' argument of module-bluetooth-discover."
+		elog ""
+	fi
+
+	if use gstreamer; then
+		elog "GStreamer-based RTP implementation modile enabled."
+		elog "To use OPUS payload install media-plugins/gst-plugins-opus"
+		elog "and add enable_opus=1 argument to module-rtp-send"
+		elog ""
+	fi
+
+	if use systemd; then
+		elog "Pulseaudio autospawn by client library is no longer enabled when systemd is available."
+		elog "It's recommended to start pulseaudio via its systemd user units:"
+		elog ""
+		elog "  systemctl --user enable pulseaudio.service pulseaudio.socket"
+		elog ""
+		elog "Root user can change system default configuration for all users:"
+		elog ""
+		elog "  systemctl --global enable pulseaudio.service pulseaudio.socket"
+		elog ""
+		elog "If you would like to enable autospawn by client library, edit autospawn flag in /etc/pulse/client.conf like this:"
+		elog ""
+		elog "  autospawn = yes"
+		elog ""
+		elog "The change from autospawn to user units will take effect after restarting."
+		elog ""
+	fi
+
+	optfeature_header "PulseAudio can be enhanced by installing the following:"
+	use equalizer && optfeature "using the qpaeq script" dev-python/PyQt5[dbus,widgets]
+	use dbus && optfeature "restricted realtime capabilities via D-Bus" sys-auth/rtkit
+}
+
+pkg_postrm() {
+	gnome2_schemas_update
+	use udev && udev_reload
+}

--- a/media-sound/pulseaudio-daemon/pulseaudio-daemon-16.0-r5.ebuild
+++ b/media-sound/pulseaudio-daemon/pulseaudio-daemon-16.0-r5.ebuild
@@ -256,6 +256,11 @@ src_install() {
 	rm "${D}/$(get_bashcompdir)"/pacmd || die
 	rm "${D}/$(get_bashcompdir)"/pasuspender || die
 
+	# Daemon configuration scripts will try to load snippets from corresponding '.d' dirs.
+	# Install these dirs to silence a warning if they are missing.
+	keepdir /etc/pulse/default.pa.d
+	keepdir /etc/pulse/system.pa.d
+
 	if use system-wide; then
 		newconfd "${FILESDIR}"/pulseaudio.conf.d pulseaudio
 

--- a/media-sound/pulseaudio-daemon/pulseaudio-daemon-16.0-r5.ebuild
+++ b/media-sound/pulseaudio-daemon/pulseaudio-daemon-16.0-r5.ebuild
@@ -166,6 +166,7 @@ PATCHES=(
 	"${FILESDIR}"/pulseaudio-16.0-fix-rtp-receiver-sdp-record.patch
 	"${FILESDIR}"/pulseaudio-16.0-optional-module-console-kit.patch
 	"${FILESDIR}"/pulseaudio-16.0-fix-combine-sink-underrun-crash.patch
+	"${FILESDIR}"/pulseaudio-16.0-fix-gstreamer-bluetooth-arm-crash.patch
 )
 
 src_prepare() {

--- a/media-sound/pulseaudio-daemon/pulseaudio-daemon-16.0-r5.ebuild
+++ b/media-sound/pulseaudio-daemon/pulseaudio-daemon-16.0-r5.ebuild
@@ -167,6 +167,7 @@ PATCHES=(
 	"${FILESDIR}"/pulseaudio-16.0-optional-module-console-kit.patch
 	"${FILESDIR}"/pulseaudio-16.0-fix-combine-sink-underrun-crash.patch
 	"${FILESDIR}"/pulseaudio-16.0-fix-gstreamer-bluetooth-arm-crash.patch
+	"${FILESDIR}"/pulseaudio-16.0-fix-pacmd-play-file-crash.patch
 )
 
 src_prepare() {


### PR DESCRIPTION
media-libs/libpulse: Fix parsing of percentages with decimal points
media-sound/pulseaudio-daemon: Add optional conf dirs to silence warning https://bugs.gentoo.org/852587
media-sound/pulseaudio-daemon: Fix crash after combine-sink underrun https://bugs.gentoo.org/852848
media-sound/pulseaudio-daemon: Fix gstreamer bluetooth crash on 32-bit ARM
media-sound/pulseaudio-daemon: Fix crash using pacmd play-file command
