### PR TITLE
sci-libs/vtk: fix build against netcdf-4.9.0

### DIFF
--- a/sci-libs/vtk/files/vtk-9.1.0-avoid-naming-collision-with-netcdf-4.9.0.patch
+++ b/sci-libs/vtk/files/vtk-9.1.0-avoid-naming-collision-with-netcdf-4.9.0.patch
@@ -1,0 +1,26 @@
+https://bugs.gentoo.org/851594
+
+From b155e9716a1cf4a03948c01f49c4097e466da4f0 Mon Sep 17 00:00:00 2001
+From: Bernd Waibel <waebbl-gentoo@posteo.net>
+Date: Mon, 20 Jun 2022 07:07:19 +0200
+Subject: [PATCH] avoid naming collision with netcdf-4.9.0
+
+The identifier has already been #defined with netcdf-4.9.0. To avoid
+conflicts guard the declaration.
+
+Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>
+--- a/ThirdParty/exodusII/vtkexodusII/src/ex_utils.c
++++ b/ThirdParty/exodusII/vtkexodusII/src/ex_utils.c
+@@ -1770,7 +1770,9 @@ void ex__compress_variable(int exoid, int varid, int type)
+         */
+ 
+         /* const int NC_SZIP_EC = 4; */ /* Selects entropy coding method for szip. */
++#ifndef NC_SZIP_NN
+         const int NC_SZIP_NN = 32;      /* Selects nearest neighbor coding method for szip. */
++#endif
+         /* Even and between 4 and 32; typical values are 8, 10, 16, 32 */
+         const int SZIP_PIXELS_PER_BLOCK =
+             file->compression_level == 0 ? 32 : file->compression_level;
+-- 
+2.35.1
+

--- a/sci-libs/vtk/vtk-9.1.0-r2.ebuild
+++ b/sci-libs/vtk/vtk-9.1.0-r2.ebuild
@@ -144,6 +144,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-8.2.0-freetype-2.10.3-provide-FT_CALLBACK_DEF.patch
 	"${FILESDIR}"/${PN}-9.0.3-IO-FFMPEG-support-FFmpeg-5.0-API-changes.patch
 	"${FILESDIR}"/${P}-adjust-to-find-binaries.patch
+	"${FILESDIR}"/${P}-avoid-naming-collision-with-netcdf-4.9.0.patch
 )
 
 DOCS=( CONTRIBUTING.md README.md )


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/851594
Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>

Please test if this patch works on affected machines.