### PR TITLE
app-text/dictd: Update patch + fix QA warnings

### DIFF
--- a/app-text/dictd/dictd-1.13.0-r4.ebuild
+++ b/app-text/dictd/dictd-1.13.0-r4.ebuild
@@ -45,7 +45,9 @@ DOC_CONTENTS="
 PATCHES=(
 	"${FILESDIR}"/dictd-1.10.11-colorit-nopp-fix.patch
 	"${FILESDIR}"/dictd-1.12.0-build.patch
+	"${FILESDIR}"/dictd-1.13.0-lex.patch
 	"${FILESDIR}"/dictd-1.13.0-libtool.patch # 818535
+	"${FILESDIR}"/dictd-1.13.0-version.patch # 852884
 )
 
 src_prepare() {

--- a/app-text/dictd/files/dictd-1.13.0-lex.patch
+++ b/app-text/dictd/files/dictd-1.13.0-lex.patch
@@ -1,0 +1,28 @@
+From: orbea <orbea@riseup.net>
+Date: Sat, 18 Jun 2022 09:10:18 -0700
+Subject: [PATCH] build: Fix implicit function declarations
+
+--- a/clientparse.y
++++ b/clientparse.y
+@@ -24,6 +24,9 @@
+ #define YYERROR_VERBOSE
+ 
+ static dictServer *s;
++
++int yylex();
++void yyerror(const char *s);
+ %}
+ 
+ %union {
+--- a/servparse.y
++++ b/servparse.y
+@@ -30,6 +30,9 @@
+ 
+ static dictDatabase *db;
+ 
++int yylex();
++void yyerror(const char *s);
++
+ static int string2bool (const char *str)
+ {
+    if (

--- a/app-text/dictd/files/dictd-1.13.0-libtool.patch
+++ b/app-text/dictd/files/dictd-1.13.0-libtool.patch
@@ -1,6 +1,5 @@
 https://bugs.gentoo.org/818535
 
-From ab4c1542d8103ef2a8dcfd8cc1ad624890258090 Mon Sep 17 00:00:00 2001
 From: orbea <orbea@riseup.net>
 Date: Fri, 17 Jun 2022 16:18:40 -0700
 Subject: [PATCH] configure: Add missing LT_INIT
@@ -26,16 +25,12 @@ Subject: [PATCH] configure: Add missing LT_INIT
  echo Configuring for dict
  echo .
  
-@@ -45,7 +47,7 @@ AC_CANONICAL_HOST
- AC_PROG_CC
- AC_PROG_CPP
- AC_PROG_CXX
--
-+AC_PROG_LIBTOOL
- AC_ISC_POSIX
+@@ -70,13 +72,10 @@ echo Checking for programs
  
- REALCC="$CC"
-@@ -75,8 +77,6 @@ AC_PROG_MAKE_SET
+ AC_PROG_AWK
+ AC_PROG_INSTALL
+-AC_PROG_RANLIB
+ AC_PROG_MAKE_SET
  AC_PROG_YACC
  AC_PROG_LEX
  
@@ -44,6 +39,14 @@ Subject: [PATCH] configure: Add missing LT_INIT
  AC_CHECK_PROGS(NROFF,gnroff nroff)
  AC_CHECK_PROGS(TROFF,groff troff)
  AC_CHECK_PROGS(COL,col cat)
+@@ -188,7 +187,6 @@ AC_SUBST(DICT_VERSION)
+ AC_SUBST(USE_PLUGIN)
+ AC_SUBST(EXEEXT)
+ AC_SUBST(allsubdirs)
+-AC_SUBST(LIBTOOL)
+ 
+ AC_SUBST(PLUGINS)
+ 
 --- a/doc/Makefile.in
 +++ b/doc/Makefile.in
 @@ -28,6 +28,7 @@ endif

--- a/app-text/dictd/files/dictd-1.13.0-version.patch
+++ b/app-text/dictd/files/dictd-1.13.0-version.patch
@@ -1,0 +1,65 @@
+https://bugs.gentoo.org/852884
+
+From: orbea <orbea@riseup.net>
+Date: Sat, 18 Jun 2022 10:00:21 -0700
+Subject: [PATCH] configure: Set version directly in AC_INIT
+
+This avoids a command not found error in config.status.
+
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -20,7 +20,7 @@
+ 
+ # Add a _letter_ if you change the version number and release your own version.
+ # Numbers are for the original author(s) only.
+-DICT_VERSION=@DICT_VERSION@
++DICT_VERSION=@PACKAGE_VERSION@
+ 
+ ifneq (,)
+ This makefile requires GNU Make.
+--- a/configure.in
++++ b/configure.in
+@@ -23,14 +23,10 @@ dnl     CFLAGS and LDFLAGS should be settable on the make commandline
+ dnl             for optimization and stripping.
+ dnl     LIBOBJS is an automatically-generated list of extra objects we need
+ 
+-
+-define(VERSION, 1.13.0)
+-
+-
+ AC_PREREQ(2.53)
+ AC_REVISION($Revision: 1.144 $)
+ 
+-AC_INIT([dict],[VERSION],[dict-beta@dict.org])
++AC_INIT([dict],[1.13.0],[dict-beta@dict.org])
+ 
+ AC_CONFIG_SRCDIR([dictd.c])
+ AC_CONFIG_HEADER(config.h)
+@@ -40,8 +36,6 @@ LT_INIT
+ echo Configuring for dict
+ echo .
+ 
+-DICT_VERSION=VERSION
+-
+ AC_CANONICAL_HOST
+ 
+ AC_PROG_CC
+@@ -183,7 +177,6 @@ SBINDIR=`eval3 $sbindir`
+ LIBEXECDIR=`eval3 $libexecdir`
+ DATADIR=`eval3 $datadir`
+ 
+-AC_SUBST(DICT_VERSION)
+ AC_SUBST(USE_PLUGIN)
+ AC_SUBST(EXEEXT)
+ AC_SUBST(allsubdirs)
+--- a/dictdplugin-config.in
++++ b/dictdplugin-config.in
+@@ -24,7 +24,7 @@ while test $# -ne 0; do
+ 	    usage
+ 	    exit;;
+ 	--version)
+-	    echo @DICT_VERSION@
++	    echo @PACKAGE_VERSION@
+ 	    exit;;
+ 	--libs)
+ 	    echo -L@libdir@


### PR DESCRIPTION
Makes trivial changes to the libtool patch for correctness and silences the follow QA warnings that were exposed with autoreconf.
```
 * QA Notice: Package triggers severe warnings which indicate that it
 *            may exhibit random runtime failures.
 * y.tab.c:1054:16: warning: implicit declaration of function ‘yylex’ [-Wimplicit-function-declaration]
 * y.tab.c:1240:7: warning: implicit declaration of function ‘yyerror’; did you mean ‘YYerror’? [-Wimplicit-function-declaration]
 * y.tab.c:1430:16: warning: implicit declaration of function ‘yylex’ [-Wimplicit-function-declaration]
 * y.tab.c:2212:7: warning: implicit declaration of function ‘yyerror’; did you mean ‘YYerror’? [-Wimplicit-function-declaration]
```
```
 * QA Notice: command not found:
 *
 * 	./config.status: line 784: 1.13.0=dummy.13.0: command not found
```
Bug: https://bugs.gentoo.org/852884
Fixes: https://github.com/gentoo/gentoo/pull/25948