### PR TITLE
sys-apps/apmd: Fix the build with rlibtool

### DIFF
--- a/sys-apps/apmd/apmd-3.2.2_p14-r3.ebuild
+++ b/sys-apps/apmd/apmd-3.2.2_p14-r3.ebuild
@@ -1,0 +1,86 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools
+
+MY_PV="${PV%_p*}"
+MY_P="${PN}_${MY_PV}"
+PATCHV="${PV#*_p}"
+
+DESCRIPTION="Advanced Power Management Daemon"
+HOMEPAGE="https://packages.qa.debian.org/a/apmd.html"
+SRC_URI="mirror://debian/pool/main/a/apmd/${MY_P}.orig.tar.gz
+	mirror://debian/pool/main/a/apmd/${MY_P}-${PATCHV}.diff.gz"
+S="${WORKDIR}/${PN}-${MY_PV}.orig"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~ppc ~ppc64 ~x86"
+IUSE="nls X"
+
+RDEPEND="
+	>=sys-apps/debianutils-1.16
+	>=sys-power/powermgmt-base-1.31
+	X? (
+		x11-libs/libX11
+		x11-libs/libXaw
+		x11-libs/libXmu
+		x11-libs/libSM
+		x11-libs/libICE
+		x11-libs/libXt
+		x11-libs/libXext
+	)"
+DEPEND="${RDEPEND}
+	virtual/os-headers"
+
+PATCHES=(
+	"${WORKDIR}"/${MY_P}-${PATCHV}.diff
+	"${FILESDIR}"/${PN}-${MY_PV}-libtool.patch # 778383
+)
+
+src_prepare() {
+	default
+
+	if ! use X; then
+		sed -i \
+			-e 's:\(EXES=.*\)xapm:\1:' \
+			-e 's:\(.*\)\$(LT_INSTALL).*xapm.*$:\1echo:' \
+			Makefile.in || die
+	fi
+
+	# use system headers and skip on_ac_power
+	rm on_ac_power* || die
+
+	sed -i \
+		-e '/on_ac_power/d' \
+		-e 's:-I/usr/src/linux/include -I/usr/X11R6/include::' \
+		-e 's:-L/usr/X11R6/lib::' \
+		Makefile.in || die
+
+	eautoreconf
+}
+
+src_install() {
+	emake DESTDIR="${D}" install
+
+	keepdir /etc/apm/{event.d,suspend.d,resume.d,other.d,scripts.d}
+	exeinto /etc/apm
+	doexe debian/apmd_proxy
+	dodoc AUTHORS {,apmsleep.}README debian/{changelog,README.Debian}
+
+	doman *.{1,8}
+
+	# note: apmd_proxy.conf is currently disabled and not used, thus
+	# not installed - liquidx (01 Mar 2004)
+
+	newconfd "${FILESDIR}"/apmd.confd apmd
+	newinitd "${FILESDIR}"/apmd.rc6 apmd
+
+	if ! use nls; then
+		rm -r "${ED}"/usr/share/man/fr || die
+	fi
+
+	find "${ED}" -name '*.la' -delete || die
+}

--- a/sys-apps/apmd/files/apmd-3.2.2-libtool.patch
+++ b/sys-apps/apmd/files/apmd-3.2.2-libtool.patch
@@ -1,0 +1,124 @@
+https://bugs.gentoo.org/778383
+
+From: orbea <orbea@riseup.net>
+Date: Sun, 19 Jun 2022 10:56:10 -0700
+Subject: [PATCH] build: Add minimal configure.ac
+
+This is required to generate libtool for the build which allows the
+build with rlibtool to work correctly.
+
+diff --git a/Makefile b/Makefile.in
+similarity index 86%
+rename from Makefile
+rename to Makefile.in
+index 92fc0fd..75e0a3a 100644
+--- a/Makefile
++++ b/Makefile.in
+@@ -19,7 +19,7 @@
+ # $Id: Makefile,v 1.30 2001/11/25 22:46:16 apenwarr Exp $
+ #
+ 
+-VERSION=3.2.1
++VERSION=@PACKAGE_VERSION@
+ LIB_VERSION=1:0
+ 
+ ifneq (,)
+@@ -28,37 +28,39 @@ endif
+ 
+ .SUFFIXES:
+ 
+-OBJS=apmlib.o
++OBJS=apmlib.lo
+ EXES=apm apmd xapm apmsleep
+ HEADERS=apm.h
+ 
+-PREFIX=/usr
+-MANDIR=$(PREFIX)/man
+-BINDIR=$(PREFIX)/bin
+-SBINDIR=$(PREFIX)/sbin
+-LIBDIR=$(PREFIX)/lib
+-INCDIR=$(PREFIX)/include
+-PROXY_DIR=/etc
+-DESTDIR=
+-
+-CC=gcc
+-CFLAGS=-O -g
++prefix := @prefix@
++exec_prefix := @exec_prefix@
++MANDIR := @mandir@
++BINDIR := @bindir@
++SBINDIR := @sbindir@
++LIBDIR := @libdir@
++INCDIR := @includedir@
++PROXY_DIR := @sysconfdir@
++
++CC := @CC@
++CFLAGS := @CFLAGS@
++LDFLAGS := @LDFLAGS@
++
+ XTRACFLAGS=-Wall -pipe -I. -I/usr/src/linux/include -I/usr/X11R6/include \
+ 		-I/usr/src/linux-2.2/include -I /usr/src/linux-2.0/include \
+ 		-DVERSION=\"$(VERSION)\" \
+ 		-DDEFAULT_PROXY_NAME=\"$(PROXY_DIR)/apmd_proxy\"
+-LDFLAGS=
+ LIBAPM=libapm.la
+ LIBAPM_FLAGS=-rpath $(LIBDIR) -version-info $(LIB_VERSION)
+ XLDFLAGS=-L/usr/X11R6/lib
+ XLIBS=-lXaw -lXmu -lXt -lXext -lSM -lICE -lX11
+-RANLIB=ranlib
+ 
+ # Uncomment these lines for a production compile
+ #CFLAGS=-O3 -m486 -fomit-frame-pointer
+ #LDFLAGS=-s
+ 
+-LIBTOOL=libtool --quiet
++top_builddir := @top_builddir@
++
++LIBTOOL = @LIBTOOL@
+ LT_COMPILE = $(LIBTOOL) --mode=compile $(CC)
+ LT_LINK = $(LIBTOOL) --mode=link $(CC)
+ LT_INSTALL = $(LIBTOOL) --mode=install install
+@@ -68,22 +70,22 @@ all: $(EXES)
+ 
+ $(OBJS): $(HEADERS)
+ 
+-%.o: %.c
++%.lo: %.c
+ 	$(LT_COMPILE) -c $(CPPFLAGS) $(CFLAGS) $(XTRACFLAGS) $<
+ 
+-%: %.o $(LIBAPM)
++%: %.lo $(LIBAPM)
+ 	$(LT_LINK) -o $@ $< $(LDFLAGS) $(LIBAPM)
+ 
+-xapm.o: xapm.c
++xapm.lo: xapm.c
+ 	$(LT_COMPILE) -c $(CPPFLAGS) $(CFLAGS) $(XTRACFLAGS) -DNARROWPROTO $<
+ 
+-apmd: apmd.o
++apmd: apmd.lo
+ 
+-apmsleep: apmsleep.o
++apmsleep: apmsleep.lo
+ 
+-apmexists: apmexists.o
++apmexists: apmexists.lo
+ 
+-xapm: xapm.o $(LIBAPM)
++xapm: xapm.lo $(LIBAPM)
+ 	$(LT_LINK) -o $@ $< $(LDFLAGS) $(LIBAPM) $(XLDFLAGS) $(XLIBS)
+ 
+ $(LIBAPM): apmlib.lo
+diff --git a/configure.ac b/configure.ac
+new file mode 100644
+index 0000000..1c8b7b7
+--- /dev/null
++++ b/configure.ac
+@@ -0,0 +1,8 @@
++AC_INIT([apmd], [3.2.2])
++AC_CONFIG_FILES([Makefile])
++
++LT_INIT
++
++AC_SUBST([top_builddir], [$abs_builddir])
++
++AC_OUTPUT


### PR DESCRIPTION
When building with rlibtool the build will fail because there is no generated libtool to determine if building shared or static. This adds a minimal autoreconf to fix the build.

Bug: https://bugs.gentoo.org/778383