### PR TITLE
media-video/handbrake: fix missing dep on cmake required by custom configure script

### DIFF
--- a/media-video/handbrake/handbrake-1.5.1.ebuild
+++ b/media-video/handbrake/handbrake-1.5.1.ebuild
@@ -79,6 +79,7 @@ DEPEND="
 	dev-lang/nasm
 	dev-util/intltool
 "
+BDEPEND="dev-util/cmake"
 
 PATCHES=(
 	# Remove libdvdnav duplication and call it on the original instead.


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/852701
Signed-off-by: James Beddek <telans@posteo.de>