### PR TITLE
sys-apps/dbus: minor shellcheck fixes

### DIFF
--- a/sys-apps/dbus/files/80-dbus
+++ b/sys-apps/dbus/files/80-dbus
@@ -2,12 +2,12 @@
 
 # launches a session dbus instance
 
-dbuslaunch="`which dbus-launch 2>/dev/null`"
+dbuslaunch=$(which dbus-launch 2>/dev/null)
 if [ -n "$dbuslaunch" ] && [ -x "$dbuslaunch" ] && [ -z "$DBUS_SESSION_BUS_ADDRESS" ]; then
   if [ -n "$command" ]; then
     command="$dbuslaunch --exit-with-session $command"
   else
-    eval `$dbuslaunch --sh-syntax --exit-with-session`
+    eval "$($dbuslaunch --sh-syntax --exit-with-session)"
   fi
 fi
 

--- a/sys-apps/dbus/files/80-dbus-r1
+++ b/sys-apps/dbus/files/80-dbus-r1
@@ -2,12 +2,12 @@
 
 # launches a session dbus instance
 
-dbuslaunch="`command -v dbus-launch 2>/dev/null`"
+dbuslaunch=$(command -v dbus-launch 2>/dev/null)
 if [ -n "$dbuslaunch" ] && [ -x "$dbuslaunch" ] && [ -z "$DBUS_SESSION_BUS_ADDRESS" ]; then
   if [ -n "$command" ]; then
     command="$dbuslaunch --exit-with-session $command"
   else
-    eval `$dbuslaunch --sh-syntax --exit-with-session`
+    eval "$($dbuslaunch --sh-syntax --exit-with-session)"
   fi
 fi
 


### PR DESCRIPTION
- [x] Run shellcheck
- [x] Use `$(...)` syntax instead of backticks
- [x] Quote eval arguments
Package-Manager: Portage-3.0.30, Repoman-3.0.3
Signed-off-by: Andrew Udvare <audvare@gmail.com>
