### PR TITLE
package.use.mask: mask USE=binary on dev-lang/scala, dev-java/sbt

### DIFF
--- a/profiles/base/package.use.mask
+++ b/profiles/base/package.use.mask
@@ -6,6 +6,11 @@
 # This file is only for generic masks. For arch-specific masks (i.e.
 # mask everywhere, unmask on arch/*) use arch/base.
 
+# Volkmar W. Pogatzki <gentoo@pogatzki.net> (2022-06-22)
+# flag depends on non-existing file in dev.gentoo.org/~gienah
+=dev-lang/scala-2.12.10 binary
+>=dev-java/sbt-0.13.18-r1 binary
+
 # Matt Turner <mattst88@gentoo.org> (2022-06-21)
 # Depends on old spidermonkey:68. Upstream recommends using Duktape or Webkit
 # for PAC parsing. See https://github.com/libproxy/libproxy/pull/139


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/733086
Signed-off-by: Volkmar W. Pogatzki <gentoo@pogatzki.net>