### PR TITLE
dev-tcltk/expect: allow cross compiling

### DIFF
--- a/dev-tcltk/expect/expect-5.45.4-r3.ebuild
+++ b/dev-tcltk/expect/expect-5.45.4-r3.ebuild
@@ -32,6 +32,7 @@ src_prepare() {
 	eapply "${FILESDIR}"/${PN}-5.44.1.15-ldflags.patch
 	eapply "${FILESDIR}"/${PN}-5.45-headers.patch #337943
 	eapply "${FILESDIR}"/${PN}-5.45-format-security.patch
+	eapply "${FILESDIR}"/${PN}-5.45.4-configure-in.patch
 	sed -i 's:ifdef HAVE_SYS_WAIT_H:ifndef NO_SYS_WAIT_H:' *.c
 
 	# fix install_name on darwin

--- a/dev-tcltk/expect/files/expect-5.45.4-configure-in.patch
+++ b/dev-tcltk/expect/files/expect-5.45.4-configure-in.patch
@@ -1,0 +1,113 @@
+Allow cross compiling.
+
+Signed-off-by: Anders Roxell <anders.roxell@enea.com>
+Upstream-Status: Pending
+
+Patch source:
+https://github.com/openembedded/openembedded-core/blob/bb87788832ad64079609e4f554e4d55a14f0aa94/meta/recipes-devtools/expect/expect/0001-configure.in.patch
+
+Signed-off-by: Adrian Ratiu <adrian.ratiu@collabora.com>
+---
+diff -uNr a/configure.in b/configure.in
+--- a/configure.in	2012-12-14 15:31:32.623180450 +0100
++++ b/configure.in	2012-12-14 15:53:34.518233519 +0100
+@@ -481,7 +481,7 @@
+ ,
+ 	AC_MSG_RESULT(no)
+ ,
+-	AC_MSG_ERROR([Expect can't be cross compiled])
++	AC_MSG_RESULT(no)
+ )
+ 
+ AC_MSG_CHECKING([if any value exists for WNOHANG])
+@@ -506,7 +506,9 @@
+ 	AC_MSG_RESULT(no)
+ 	AC_DEFINE(WNOHANG_BACKUP_VALUE, 1)
+ ,
+-	AC_MSG_ERROR([Expect can't be cross compiled])
++	AC_MSG_RESULT(yes)
++	AC_DEFINE_UNQUOTED(WNOHANG_BACKUP_VALUE, `cat wnohang`)
++	rm -f wnohang
+ )
+ 
+ #
+@@ -574,7 +576,8 @@
+ 	AC_DEFINE(REARM_SIG)
+ ,
+ 	AC_MSG_RESULT(no)
+-, AC_MSG_WARN([Expect can't be cross compiled])
++,
++	AC_MSG_RESULT(no)
+ )
+ 
+ # HPUX7 has trouble with the big cat so split it
+@@ -725,7 +728,9 @@
+ ,
+         AC_MSG_RESULT(no)
+ ,
+-	AC_MSG_ERROR([Expect can't be cross compiled])
++        AC_MSG_RESULT(yes)
++        AC_DEFINE(HAVE_SGTTYB)
++        PTY_TYPE=sgttyb
+ )
+ 
+ # mach systems have include files for unimplemented features
+@@ -749,7 +754,9 @@
+ ,
+         AC_MSG_RESULT(no)
+ ,
+-	AC_MSG_ERROR([Expect can't be cross compiled])
++        AC_DEFINE(HAVE_TERMIO)
++        PTY_TYPE=termios
++        AC_MSG_RESULT(yes)
+ )
+ 
+   # now check for the new style ttys (not yet posix)
+@@ -771,7 +778,9 @@
+   ,
+         AC_MSG_RESULT(no)
+   ,
+-	AC_MSG_ERROR([Expect can't be cross compiled])
++        AC_DEFINE(HAVE_TERMIOS)
++        PTY_TYPE=termios
++        AC_MSG_RESULT(yes)
+   )
+ fi
+ 
+@@ -794,7 +803,7 @@
+ ,
+ 	AC_MSG_RESULT(no)
+ ,
+-	AC_MSG_ERROR([Expect can't be cross compiled])
++	AC_MSG_RESULT(no)
+ )
+ 
+ AC_MSG_CHECKING([if TIOCGWINSZ in termios.h])
+@@ -816,7 +825,7 @@
+ ,
+ 	AC_MSG_RESULT(no)
+ ,
+-	AC_MSG_ERROR([Expect can't be cross compiled])
++	AC_MSG_RESULT(no)
+ )
+ 
+ # finally check for Cray style ttys
+@@ -837,7 +846,7 @@
+ ,
+ 	AC_MSG_RESULT(no)
+ ,
+-	AC_MSG_ERROR([Expect can't be cross compiled])
++	AC_MSG_RESULT(no)
+ )
+ 
+ #
+@@ -889,7 +898,8 @@
+ 	AC_MSG_RESULT(yes),
+ 	AC_MSG_RESULT(no)
+ ,
+-	AC_MSG_ERROR([Expect can't be cross compiled])
++	AC_DEFINE(HAVE_SV_TIMEZONE)
++	AC_MSG_RESULT(yes),
+ )
+ 
+ 


### PR DESCRIPTION
expect is a very old and mostly abandoned project seeing very
little bug-fixing and development, despite being a relatively
common dependency due to for e.g. gdb -> dejagnu -> expect
dependency chains.

One patch carried by various cross-compilation build systems
for decades adds the ability to cross compile, which we also
add to portage.

Signed-off-by: Adrian Ratiu <adrian.ratiu@collabora.com>