### PR TITLE
dev-qt/qtcore: fix musl with libexecinfo

### DIFF
--- a/dev-qt/qtcore/files/qtcore-5.15.5-hack_never_use_execinfo.patch
+++ b/dev-qt/qtcore/files/qtcore-5.15.5-hack_never_use_execinfo.patch
@@ -1,0 +1,24 @@
+QtCore only links with -lexecinfo on *bsd and
+incorrectly assumes it's already linked on Linux
+if execinfo.h exists.
+
+---
+ src/corelib/global/qlogging.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/corelib/global/qlogging.cpp b/src/corelib/global/qlogging.cpp
+index 89f49324..1c34a1af 100644
+--- a/src/corelib/global/qlogging.cpp
++++ b/src/corelib/global/qlogging.cpp
+@@ -106,7 +106,7 @@
+ #    if __UCLIBC_HAS_BACKTRACE__
+ #      define QLOGGING_HAVE_BACKTRACE
+ #    endif
+-#  elif (defined(__GLIBC__) && defined(__GLIBCXX__)) || (__has_include(<cxxabi.h>) && __has_include(<execinfo.h>))
++#  elif (defined(__GLIBC__) && defined(__GLIBCXX__))
+ #    define QLOGGING_HAVE_BACKTRACE
+ #  endif
+ #endif
+-- 
+2.35.1
+

--- a/dev-qt/qtcore/qtcore-5.15.5.ebuild
+++ b/dev-qt/qtcore/qtcore-5.15.5.ebuild
@@ -27,6 +27,8 @@ DEPEND="
 "
 RDEPEND="${DEPEND}"
 
+PATCHES=( "${FILESDIR}/${P}-hack_never_use_execinfo.patch" )
+
 QT5_TARGET_SUBDIRS=(
 	src/tools/bootstrap
 	src/tools/moc


### PR DESCRIPTION
QtCore incorrectly assumes that execinfo is already linked on Linux if
execinfo.h is present. The edge case here is that on musl you can
install libexecinfo standalone, thereby QtCore will detect the header
but not the library, and QtCore will think that glibc has already linked it.

There is no code/config for QMake to detect and link against
-lexecinfo except on the BSD:s. Qt should properly add something
similar for non-glibc as well.

This is just a *fix* compatible with all supported Gentoo systems.

Signed-off-by: Alfred Persson Forsberg <cat@catcream.org>