### PR TITLE
net-fs/samba: netdb defines patch

### DIFF
--- a/net-fs/samba/files/samba-4.16.1-netdb-defines.patch
+++ b/net-fs/samba/files/samba-4.16.1-netdb-defines.patch
@@ -1,0 +1,21 @@
+# Define NETDB_INTERNAL and NETDB_SUCCESS if they are not defined
+#
+# Gentoo bug 832629 and 835017
+
+--- a/nsswitch/wins.c
++++ b/nsswitch/wins.c
+@@ -40,6 +40,14 @@ static pthread_mutex_t wins_nss_mutex = PTHREAD_MUTEX_INITIALIZER;
+ #define INADDRSZ 4
+ #endif
+
++#ifndef NETDB_INTERNAL
++#define NETDB_INTERNAL -1
++#endif
++
++#ifndef NETDB_SUCCESS
++#define NETDB_SUCCESS 0
++#endif
++
+ _PUBLIC_ON_LINUX_
+ NSS_STATUS _nss_wins_gethostbyname_r(const char *hostname,
+ 				     struct hostent *he,

--- a/net-fs/samba/samba-4.16.1.ebuild
+++ b/net-fs/samba/samba-4.16.1.ebuild
@@ -141,6 +141,7 @@ BDEPEND="${PYTHON_DEPS}
 
 PATCHES=(
 	"${FILESDIR}/${PN}-4.4.0-pam.patch"
+	"${FILESDIR}/${PN}-4.16.1-netdb-defines.patch"
 )
 
 #CONFDIR="${FILESDIR}/$(get_version_component_range 1-2)"


### PR DESCRIPTION
This PR is related to PR #25882. I, unfortunately, forced pushed something that closed the PR, I'll be more careful next time.

@thesamesam I've made changes as you asked on #25882, see if they are good enough or I'll change them as needed.

To summarize, the following things have been done

- Ran scrub-patch on the .patch file
- Respected the previous naming convention in the PATCHES array
- Squashed the commits as much as possible.
- Linked relevant Gentoo bugs both in the patch and commit message

Bug: https://bugs.gentoo.org/835017
Bug: https://bugs.gentoo.org/832629

Signed-off-by: brahmajit das <brahmajit.xyz@gmail.com>