### PR TITLE
dev-util/hip: Fix -isystem pollution after d5835abb

### DIFF
--- a/dev-util/hip/files/hip-5.0.2-set-build-id.patch
+++ b/dev-util/hip/files/hip-5.0.2-set-build-id.patch
@@ -1,0 +1,20 @@
+If git is not found, HIP_VERSION_BUILD_ID will not be set, causing bug 853718
+===================================================================
+--- hipamd-rocm-5.0.2.orig/CMakeLists.txt
++++ hipamd-rocm-5.0.2/CMakeLists.txt
+@@ -89,6 +89,7 @@ list(GET VERSION_LIST 2 HIP_VERSION_PATC
+ string(REPLACE "-" ";" VERSION_LIST ${HIP_VERSION_PATCH_GITHASH})
+ list(GET VERSION_LIST 0 HIP_VERSION_PATCH)
+ set(HIP_VERSION_GITDATE 0)
++set(HIP_VERSION_BUILD_ID 0)
+ 
+ find_package(Git)
+ 
+@@ -126,7 +127,6 @@ if(GIT_FOUND)
+     set(HIP_VERSION_GITHASH ${git_output})
+   endif()
+ 
+-  set(HIP_VERSION_BUILD_ID 0)
+   set(HIP_VERSION_BUILD_NAME "")
+   if(NOT DEFINED ENV{HIP_OFFICIAL_BUILD} AND NOT HIP_OFFICIAL_BUILD)
+     # FIXME: Disabling it for ROCm 5.0

--- a/dev-util/hip/hip-5.0.2-r2.ebuild
+++ b/dev-util/hip/hip-5.0.2-r2.ebuild
@@ -35,6 +35,7 @@ PATCHES=(
 	"${FILESDIR}/${PN}-4.2.0-config-cmake-in.patch"
 	"${FILESDIR}/${PN}-5.0.1-hip_vector_types.patch"
 	"${FILESDIR}/${PN}-4.2.0-cancel-hcc-header-removal.patch"
+	"${FILESDIR}/${PN}-5.0.2-set-build-id.patch"
 )
 
 S="${WORKDIR}/hipamd-rocm-${PV}"


### PR DESCRIPTION
After d5835abbe66be09b9851fcc79a158d1a083ad8fc which corrects the
HIP_PATH, HIP_INCLUDE_PATH now points to /usr/include and hipcc.pl added
-isystem $HIP_INCLUDE_PATH which caused complilation failure. Fix it by
removing lines in hipcc.pl

Closes: https://bugs.gentoo.org/853184
Bugs: https://github.com/justxi/rocm/issues/8#issuecomment-1159800433
Signed-off-by: Yiyang Wu <xgreenlandforwyy@gmail.com>