### PR TITLE
Patches for net-dns/avahi

### DIFF
--- a/net-dns/avahi/avahi-0.8-r6.ebuild
+++ b/net-dns/avahi/avahi-0.8-r6.ebuild
@@ -1,0 +1,217 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="7"
+
+PYTHON_COMPAT=( python3_{8..10} )
+PYTHON_REQ_USE="gdbm"
+inherit autotools flag-o-matic multilib-minimal mono-env python-single-r1 systemd
+
+DESCRIPTION="System which facilitates service discovery on a local network"
+HOMEPAGE="https://avahi.org/"
+SRC_URI="https://github.com/lathiat/avahi/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="LGPL-2.1"
+SLOT="0"
+KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~loong ~mips ppc ppc64 ~riscv ~s390 sparc x86"
+IUSE="autoipd bookmarks +dbus doc gdbm gtk howl-compat +introspection ipv6 mdnsresponder-compat mono nls python qt5 selinux systemd test"
+
+REQUIRED_USE="
+	python? ( dbus gdbm ${PYTHON_REQUIRED_USE} )
+	bookmarks? ( python )
+	mono? ( dbus )
+	howl-compat? ( dbus )
+	mdnsresponder-compat? ( dbus )
+	systemd? ( dbus )
+"
+
+RESTRICT="!test? ( test )"
+
+DEPEND="
+	dev-libs/libdaemon
+	dev-libs/libevent:=[${MULTILIB_USEDEP}]
+	dev-libs/expat
+	dev-libs/glib:2[${MULTILIB_USEDEP}]
+	gdbm? ( sys-libs/gdbm:=[${MULTILIB_USEDEP}] )
+	qt5? ( dev-qt/qtcore:5 )
+	gtk?  ( x11-libs/gtk+:3[${MULTILIB_USEDEP}] )
+	dbus? ( sys-apps/dbus[${MULTILIB_USEDEP}] )
+	kernel_linux? ( sys-libs/libcap )
+	introspection? ( dev-libs/gobject-introspection:= )
+	mono? ( dev-lang/mono )
+	python? (
+		${PYTHON_DEPS}
+		$(python_gen_cond_dep '
+			bookmarks? ( >=dev-python/twisted-16.0.0[${PYTHON_USEDEP}] )
+			dbus? ( dev-python/dbus-python[${PYTHON_USEDEP}] )
+			introspection? ( dev-python/pygobject:3[${PYTHON_USEDEP}] )
+		')
+	)
+"
+RDEPEND="
+	acct-user/avahi
+	acct-group/avahi
+	acct-group/netdev
+	autoipd? (
+		acct-user/avahi-autoipd
+		acct-group/avahi-autoipd
+	)
+	${DEPEND}
+	selinux? ( sec-policy/selinux-avahi )
+"
+BDEPEND="
+	dev-util/glib-utils
+	doc? ( app-doc/doxygen )
+	app-doc/xmltoman
+	sys-devel/gettext
+	virtual/pkgconfig
+"
+
+MULTILIB_WRAPPED_HEADERS=( /usr/include/avahi-qt5/qt-watch.h )
+
+PATCHES=(
+	"${FILESDIR}/${P}-disable-avahi-ui-sharp.patch" # bug 769062
+	"${FILESDIR}/${P}-dependency-error.patch"
+	"${FILESDIR}/${P}-null-pointer-crash.patch"
+	"${FILESDIR}/${P}-potentially-undefined-fix.patch"
+# These patches do not apply cleanly but may need to be re-instated.
+# I'll leave them commented out for now.
+#	"${FILESDIR}/${PN}-0.7-qt5.patch"
+#	"${FILESDIR}/${PN}-0.7-CVE-2017-6519.patch"
+#	"${FILESDIR}/${PN}-0.7-remove-empty-avahi_discover.patch"
+#	"${FILESDIR}/${PN}-0.7-python3.patch"
+#	"${FILESDIR}/${PN}-0.7-python3-unittest.patch"
+#	"${FILESDIR}/${PN}-0.7-python3-gdbm.patch"
+)
+
+pkg_setup() {
+	use mono && mono-env_pkg_setup
+	use python && python-single-r1_pkg_setup
+}
+
+src_prepare() {
+	default
+
+	if ! use ipv6; then
+		sed -i \
+			-e "s/use-ipv6=yes/use-ipv6=no/" \
+			avahi-daemon/avahi-daemon.conf || die
+	fi
+
+	sed -i \
+		-e "s:\\.\\./\\.\\./\\.\\./doc/avahi-docs/html/:../../../doc/${PF}/html/:" \
+		doxygen_to_devhelp.xsl || die
+
+	eautoreconf
+
+	# bundled manpages
+	multilib_copy_sources
+}
+
+multilib_src_configure() {
+	local myconf=(
+		--disable-gtk
+		--disable-monodoc
+		--disable-python-dbus
+		--disable-qt3
+		--disable-qt4
+		--disable-static
+		--enable-manpages
+		--enable-glib
+		--enable-gobject
+		--enable-xmltoman
+		--localstatedir="${EPREFIX}/var"
+		--with-distro=gentoo
+		--with-systemdsystemunitdir="$(systemd_get_systemunitdir)"
+		$(use_enable dbus)
+		$(use_enable gdbm)
+		$(use_enable gtk gtk3)
+		$(use_enable howl-compat compat-howl)
+		$(use_enable mdnsresponder-compat compat-libdns_sd)
+		$(use_enable nls)
+		$(multilib_native_use_enable autoipd)
+		$(multilib_native_use_enable doc doxygen-doc)
+		$(multilib_native_use_enable introspection)
+		$(multilib_native_use_enable mono)
+		$(multilib_native_use_enable python)
+		$(multilib_native_use_enable test tests)
+	)
+
+	if use python; then
+		myconf+=(
+			$(multilib_native_use_enable dbus python-dbus)
+			$(multilib_native_use_enable introspection pygobject)
+		)
+	fi
+
+	if use mono; then
+		myconf+=( $(multilib_native_use_enable doc monodoc) )
+	fi
+
+	if ! multilib_is_native_abi; then
+		myconf+=(
+			# used by daemons only
+			--disable-libdaemon
+			--with-xml=none
+		)
+	fi
+
+	myconf+=( $(multilib_native_use_enable qt5) )
+
+	econf "${myconf[@]}"
+}
+
+multilib_src_compile() {
+	emake
+
+	multilib_is_native_abi && use doc && emake avahi.devhelp
+}
+
+multilib_src_install() {
+	emake install DESTDIR="${D}"
+
+	if ! use bookmarks || ! use python || ! use dbus; then
+		rm -f "${ED}"/usr/bin/avahi-bookmarks || die
+	fi
+
+	# https://github.com/lathiat/avahi/issues/28
+	use howl-compat && dosym avahi-compat-howl.pc /usr/$(get_libdir)/pkgconfig/howl.pc
+	use mdnsresponder-compat && dosym avahi-compat-libdns_sd/dns_sd.h /usr/include/dns_sd.h
+
+	if multilib_is_native_abi && use doc; then
+		docinto html
+		dodoc -r doxygen/html/.
+		insinto /usr/share/devhelp/books/avahi
+		doins avahi.devhelp
+	fi
+
+	# The build system creates an empty "/run" directory, so we clean it up here
+	rmdir "${ED}"/run || die
+}
+
+multilib_src_install_all() {
+	use python && python_optimize
+
+	if use autoipd; then
+		insinto /lib/rcscripts/net
+		doins "${FILESDIR}"/autoipd.sh
+
+		insinto /lib/netifrc/net
+		newins "${FILESDIR}"/autoipd-openrc.sh autoipd.sh
+	fi
+
+	dodoc docs/{AUTHORS,NEWS,README,TODO}
+
+	find "${ED}" -name '*.la' -type f -delete || die
+}
+
+pkg_postinst() {
+	if use autoipd; then
+		elog
+		elog "To use avahi-autoipd to configure your interfaces with IPv4LL (RFC3927)"
+		elog "addresses, just set config_<interface>=( autoipd ) in /etc/conf.d/net!"
+		elog
+	fi
+
+	systemd_reenable avahi-daemon.service
+}

--- a/net-dns/avahi/files/avahi-0.8-dependency-error.patch
+++ b/net-dns/avahi/files/avahi-0.8-dependency-error.patch
@@ -1,0 +1,15 @@
+https://github.com/lathiat/avahi/commit/366e3798bdbd6b7bf24e59379f4a9a51af575ce9.patch
+From: =?UTF-8?q?Tomasz=20Pawe=C5=82=20Gajc?= <tpgxyz@gmail.com>
+Date: Thu, 20 Feb 2020 16:09:40 +0100
+Subject: [PATCH] fix requires in pc file
+
+--- a/avahi-libevent.pc.in
++++ b/avahi-libevent.pc.in
+@@ -6,6 +6,6 @@ includedir=${prefix}/include
+ Name: avahi-libevent
+ Description: Avahi Multicast DNS Responder (libevent Support)
+ Version: @PACKAGE_VERSION@
+-Requires: libevent-2.1.5
++Requires: libevent >= 2.1.5
+ Libs: -L${libdir} -lavahi-libevent
+ Cflags: -D_REENTRANT -I${includedir}

--- a/net-dns/avahi/files/avahi-0.8-disable-avahi-ui-sharp.patch
+++ b/net-dns/avahi/files/avahi-0.8-disable-avahi-ui-sharp.patch
@@ -4,13 +4,6 @@ Date: Sat, 27 Mar 2021 22:49:08 +0100
 Subject: [PATCH] Disable avahi-ui-sharp
 
 Signed-off-by: Andreas Sturmlechner <asturm@gentoo.org>
----
- Makefile.am  | 6 ++----
- configure.ac | 1 -
- 2 files changed, 2 insertions(+), 5 deletions(-)
-
-diff --git a/Makefile.am b/Makefile.am
-index 33c51f5..0e12120 100644
 --- a/Makefile.am
 +++ b/Makefile.am
 @@ -46,7 +46,6 @@ EXTRA_DIST = \
@@ -40,8 +33,6 @@ index 33c51f5..0e12120 100644
  endif
  
  endif
-diff --git a/configure.ac b/configure.ac
-index 58db8c7..844360f 100644
 --- a/configure.ac
 +++ b/configure.ac
 @@ -1166,7 +1166,6 @@ man/Makefile
@@ -52,6 +43,3 @@ index 58db8c7..844360f 100644
  avahi-compat-libdns_sd/Makefile
  avahi-compat-howl/Makefile
  avahi-compat-howl/samples/Makefile
--- 
-2.31.1
-

--- a/net-dns/avahi/files/avahi-0.8-null-pointer-crash.patch
+++ b/net-dns/avahi/files/avahi-0.8-null-pointer-crash.patch
@@ -1,0 +1,129 @@
+https://github.com/lathiat/avahi/commit/fd482a74625b8db8547b8cfca3ee3d3c6c721423.patch
+From: Tommi Rantala <tommi.t.rantala@nokia.com>
+Date: Mon, 8 Feb 2021 11:04:43 +0200
+Subject: [PATCH] Fix NULL pointer crashes from #175
+
+avahi-daemon is crashing when running "ping .local".
+The crash is due to failing assertion from NULL pointer.
+Add missing NULL pointer checks to fix it.
+
+Introduced in #175 - merge commit 8f75a045709a780c8cf92a6a21e9d35b593bdecd
+--- a/avahi-core/browse-dns-server.c
++++ b/avahi-core/browse-dns-server.c
+@@ -343,7 +343,10 @@ AvahiSDNSServerBrowser *avahi_s_dns_server_browser_new(
+         AvahiSDNSServerBrowser* b;
+ 
+         b = avahi_s_dns_server_browser_prepare(server, interface, protocol, domain, type, aprotocol, flags, callback, userdata);
++        if (!b)
++            return NULL;
++
+         avahi_s_dns_server_browser_start(b);
+ 
+         return b;
+-}
+\ No newline at end of file
++}
+
+--- a/avahi-core/browse-domain.c
++++ b/avahi-core/browse-domain.c
+@@ -253,7 +253,10 @@ AvahiSDomainBrowser *avahi_s_domain_browser_new(
+         AvahiSDomainBrowser *b;
+ 
+         b = avahi_s_domain_browser_prepare(server, interface, protocol, domain, type, flags, callback, userdata);
++        if (!b)
++            return NULL;
++
+         avahi_s_domain_browser_start(b);
+ 
+         return b;
+-}
+\ No newline at end of file
++}
+
+--- a/avahi-core/browse-service-type.c
++++ b/avahi-core/browse-service-type.c
+@@ -171,6 +171,9 @@ AvahiSServiceTypeBrowser *avahi_s_service_type_browser_new(
+         AvahiSServiceTypeBrowser *b;
+ 
+         b = avahi_s_service_type_browser_prepare(server, interface, protocol, domain, flags, callback, userdata);
++        if (!b)
++            return NULL;
++
+         avahi_s_service_type_browser_start(b);
+ 
+         return b;
+
+--- a/avahi-core/browse-service.c
++++ b/avahi-core/browse-service.c
+@@ -184,6 +184,9 @@ AvahiSServiceBrowser *avahi_s_service_browser_new(
+         AvahiSServiceBrowser *b;
+ 
+         b = avahi_s_service_browser_prepare(server, interface, protocol, service_type, domain, flags, callback, userdata);
++        if (!b)
++            return NULL;
++
+         avahi_s_service_browser_start(b);
+ 
+         return b;
+
+--- a/avahi-core/browse.c
++++ b/avahi-core/browse.c
+@@ -634,6 +634,9 @@ AvahiSRecordBrowser *avahi_s_record_browser_new(
+         AvahiSRecordBrowser *b;
+ 
+         b = avahi_s_record_browser_prepare(server, interface, protocol, key, flags, callback, userdata);
++        if (!b)
++            return NULL;
++
+         avahi_s_record_browser_start_query(b);
+ 
+         return b;
+
+--- a/avahi-core/resolve-address.c
++++ b/avahi-core/resolve-address.c
+@@ -286,7 +286,10 @@ AvahiSAddressResolver *avahi_s_address_resolver_new(
+         AvahiSAddressResolver *b;
+ 
+         b = avahi_s_address_resolver_prepare(server, interface, protocol, address, flags, callback, userdata);
++        if (!b)
++            return NULL;
++
+         avahi_s_address_resolver_start(b);
+ 
+         return b;
+-}
+\ No newline at end of file
++}
+
+--- a/avahi-core/resolve-host-name.c
++++ b/avahi-core/resolve-host-name.c
+@@ -318,7 +318,10 @@ AvahiSHostNameResolver *avahi_s_host_name_resolver_new(
+         AvahiSHostNameResolver *b;
+ 
+         b = avahi_s_host_name_resolver_prepare(server, interface, protocol, host_name, aprotocol, flags, callback, userdata);
++        if (!b)
++            return NULL;
++
+         avahi_s_host_name_resolver_start(b);
+ 
+         return b;
+-}
+\ No newline at end of file
++}
+
+--- a/avahi-core/resolve-service.c
++++ b/avahi-core/resolve-service.c
+@@ -519,7 +519,10 @@ AvahiSServiceResolver *avahi_s_service_resolver_new(
+         AvahiSServiceResolver *b;
+ 
+         b = avahi_s_service_resolver_prepare(server, interface, protocol, name, type, domain, aprotocol, flags, callback, userdata);
++        if (!b)
++            return NULL;
++
+         avahi_s_service_resolver_start(b);
+ 
+         return b;
+-}
+\ No newline at end of file
++}
+

--- a/net-dns/avahi/files/avahi-0.8-potentially-undefined-fix.patch
+++ b/net-dns/avahi/files/avahi-0.8-potentially-undefined-fix.patch
@@ -1,0 +1,25 @@
+https://github.com/lathiat/avahi/commit/b897ca43ac100d326d118e5877da710eb7f836f9.patch
+From: traffic-millions <60914101+traffic-millions@users.noreply.github.com>
+Date: Tue, 3 Mar 2020 11:15:48 +0800
+Subject: [PATCH] avahi_dns_packet_consume_uint32: fix potential undefined
+ behavior
+
+avahi_dns_packet_consume_uint32 left shifts uint8_t values by 8, 16 and 24 bits to combine them into a 32-bit value. This produces an undefined behavior warning with gcc -fsanitize when fed input values of 128 or 255 however in testing no actual unexpected behavior occurs in practice and the 32-bit uint32_t is always correctly produced as the final value is immediately stored into a uint32_t and the compiler appears to handle this "correctly".
+
+Cast the intermediate values to uint32_t to prevent this warning and ensure the intended result is explicit.
+
+Closes: #267
+Closes: #268
+Reference: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=19304
+--- a/avahi-core/dns.c
++++ b/avahi-core/dns.c
+@@ -455,7 +455,7 @@ int avahi_dns_packet_consume_uint32(AvahiDnsPacket *p, uint32_t *ret_v) {
+         return -1;
+ 
+     d = (uint8_t*) (AVAHI_DNS_PACKET_DATA(p) + p->rindex);
+-    *ret_v = (d[0] << 24) | (d[1] << 16) | (d[2] << 8) | d[3];
++    *ret_v = ((uint32_t)d[0] << 24) | ((uint32_t)d[1] << 16) | ((uint32_t)d[2] << 8) | (uint32_t)d[3];
+     p->rindex += sizeof(uint32_t);
+ 
+     return 0;
+


### PR DESCRIPTION
These patches were pulled from the avahi upstream to fix a vulnerability
and other bugs.
Bug: https://bugs.gentoo.org/793953
Signed-off-by: Federico Denkena <federico.denkena@posteo.de>