### PR TITLE
media-video/mpv: Add libXpresent as a dependency

### DIFF
--- a/media-video/mpv/mpv-9999.ebuild
+++ b/media-video/mpv/mpv-9999.ebuild
@@ -106,6 +106,7 @@ COMMON_DEPEND="
 		x11-libs/libXScrnSaver
 		x11-libs/libXext
 		x11-libs/libXinerama
+		x11-libs/libXpresent
 		x11-libs/libXrandr
 		opengl? (
 			x11-libs/libXdamage


### PR DESCRIPTION
Fixes a waf configure error where it fails to find xpresent.pc.