### PR TITLE
sys-fs/lvm2: fix segfault on musl

### DIFF
--- a/sys-fs/lvm2/files/lvm2-2.03.14-freopen_n2.patch
+++ b/sys-fs/lvm2/files/lvm2-2.03.14-freopen_n2.patch
@@ -1,0 +1,34 @@
+In musl, the standard streams are read-only. To modify them we need to
+use freopen. This patch does the same as lvm2-2.03.14-r1-fopen-to-freopen.patch
+
+https://listman.redhat.com/archives/lvm-devel/2022-June/024203.html
+
+See also:
+https://wiki.gentoo.org/wiki/User:Sam/Musl_porting_notes#error:_assignment_of_read-only_variable_.27.5Bstdout.7Cstdin.7Cstderr.5D.27
+https://www.gnu.org/software/libc/manual/html_node/Standard-Streams.html
+
+---
+ lib/log/log.c | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/lib/log/log.c b/lib/log/log.c
+index 7b4d537..897c183 100644
+--- a/lib/log/log.c
++++ b/lib/log/log.c
+@@ -207,8 +207,12 @@ int reopen_standard_stream(FILE **stream, const char *mode)
+ 	}
+ 
+ 	_check_and_replace_standard_log_streams(old_stream, new_stream);
+-
++	
++#ifdef __GLIBC__
+ 	*stream = new_stream;
++#else
++	freopen(NULL, mode, *stream);
++#endif
+ 	return 1;
+ }
+ 
+-- 
+2.35.1
+

--- a/sys-fs/lvm2/lvm2-2.03.14-r3.ebuild
+++ b/sys-fs/lvm2/lvm2-2.03.14-r3.ebuild
@@ -73,6 +73,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-2.03.14-r1-add-fcntl.patch
 	"${FILESDIR}"/${PN}-2.03.14-r1-fopen-to-freopen.patch
 	"${FILESDIR}"/${PN}-2.03.14-r1-mallinfo.patch
+	"${FILESDIR}"/${PN}-2.03.14-freopen_n2.patch
 )
 
 pkg_setup() {


### PR DESCRIPTION
The default streams in musl are const and we can't modify them directly.
Use freopen instead.

Signed-off-by: Alfred Persson Forsberg <cat@catcream.org>