### PR TITLE
app-text/zathura-pdf-mupdf: restrict mupdf DEPEND

### DIFF
--- a/app-text/zathura-pdf-mupdf/zathura-pdf-mupdf-0.3.8-r2.ebuild
+++ b/app-text/zathura-pdf-mupdf/zathura-pdf-mupdf-0.3.8-r2.ebuild
@@ -20,7 +20,7 @@ HOMEPAGE="https://git.pwmt.org/pwmt/zathura-pdf-mupdf"
 LICENSE="ZLIB"
 SLOT="0"
 
-DEPEND=">=app-text/mupdf-1.19:=
+DEPEND="~app-text/mupdf-1.19.1:=
 	>=app-text/zathura-0.3.9
 	dev-libs/girara
 	dev-libs/glib:2


### PR DESCRIPTION
Due to an API change in mupdf-1.20.0, zathura-pdf-mupdf is
currently incompatible with mupdf-1.20.0.
Therefore, we restrict the mupdf version to ~1.19.1.

Bug: https://bugs.gentoo.org/853217
Signed-off-by: Philipp Rösner <rndxelement@protonmail.com>