### PR TITLE
media-fgx/gimp: 2.10.32. Fix media-libs/gegl DEPEND. Add USE=jpegxl for missed new feature

### DIFF
--- a/media-gfx/gimp/gimp-2.10.32.ebuild
+++ b/media-gfx/gimp/gimp-2.10.32.ebuild
@@ -28,10 +28,10 @@ COMMON_DEPEND="
 	dev-libs/libxslt
 	>=gnome-base/librsvg-2.40.6:2
 	>=media-gfx/mypaint-brushes-2.0.2:=
-	>=media-libs/babl-0.1.88
+	>=media-libs/babl-0.1.90
 	>=media-libs/fontconfig-2.12.4
 	>=media-libs/freetype-2.1.7
-	>=media-libs/gegl-0.4.34:0.4[cairo]
+	>=media-libs/gegl-0.4.36:0.4[cairo]
 	>=media-libs/gexiv2-0.10.6
 	>=media-libs/harfbuzz-0.9.19:=
 	>=media-libs/lcms-2.8:2

--- a/media-gfx/gimp/gimp-2.10.32.ebuild
+++ b/media-gfx/gimp/gimp-2.10.32.ebuild
@@ -14,7 +14,7 @@ LICENSE="GPL-3 LGPL-3"
 SLOT="0/2"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~riscv ~x86"
 
-IUSE="aalib alsa aqua debug doc gnome heif jpeg2k mng openexr postscript udev unwind vector-icons webp wmf xpm cpu_flags_ppc_altivec cpu_flags_x86_mmx cpu_flags_x86_sse"
+IUSE="aalib alsa aqua debug doc gnome heif jpeg2k jpegxl mng openexr postscript udev unwind vector-icons webp wmf xpm cpu_flags_ppc_altivec cpu_flags_x86_mmx cpu_flags_x86_sse"
 
 RESTRICT="!test? ( test )"
 
@@ -51,6 +51,7 @@ COMMON_DEPEND="
 	aqua? ( >=x11-libs/gtk-mac-integration-2.0.0 )
 	heif? ( >=media-libs/libheif-1.9.1:= )
 	jpeg2k? ( >=media-libs/openjpeg-2.1.0:2= )
+	jpegxl? ( >=media-libs/libjxl-0.6.1:= )
 	mng? ( media-libs/libmng:= )
 	openexr? ( >=media-libs/openexr-1.6.1:= )
 	postscript? ( app-text/ghostscript-gpl )
@@ -140,6 +141,7 @@ src_configure() {
 		$(use_with !aqua x)
 		$(use_with heif libheif)
 		$(use_with jpeg2k jpeg2000)
+		$(use_with jpegxl)
 		$(use_with mng libmng)
 		$(use_with openexr)
 		$(use_with postscript gs)

--- a/profiles/arch/alpha/package.use.mask
+++ b/profiles/arch/alpha/package.use.mask
@@ -1,6 +1,11 @@
 # Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Sergey Torokhov <torokhov-s-a@yandex.ru> (2022-06-22)
+# media-libs/libjxl is not keyworded
+# bug https://bugs.gentoo.org/853628
+media-gfx/gimp jpegxl
+
 # Sam James <sam@gentoo.org> (2022-04-29)
 # Needs unkeyworded dev-util/umockdev
 sys-power/upower test

--- a/profiles/arch/hppa/package.use.mask
+++ b/profiles/arch/hppa/package.use.mask
@@ -4,6 +4,11 @@
 # NOTE: When masking a USE flag due to missing keywords, please file a keyword
 # request bug for the hppa arch.
 
+# Sergey Torokhov <torokhov-s-a@yandex.ru> (2022-06-22)
+# media-libs/libjxl is not keyworded
+# bug https://bugs.gentoo.org/853628
+media-gfx/gimp jpegxl
+
 # Sam James <sam@gentoo.org> (2022-05-17)
 # sci-libs/sundials fails to build tests on HPPA
 # bug #845222

--- a/profiles/arch/ia64/package.use.mask
+++ b/profiles/arch/ia64/package.use.mask
@@ -1,6 +1,11 @@
 # Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Sergey Torokhov <torokhov-s-a@yandex.ru> (2022-06-22)
+# media-libs/libjxl is not keyworded
+# bug https://bugs.gentoo.org/853628
+media-gfx/gimp jpegxl
+
 # Nickolas Raymond Kaczynski <nrk@disroot.org> (2022-04-24)
 # Dependencies are missing keywords
 media-libs/imlib2 svg heif jpegxl


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/853223