### PR TITLE
net-misc/tigervnc: Fix for USE=-server and no pam

### DIFF
--- a/net-misc/tigervnc/files/tigervnc-1.12.0-disable-server-and-pam.patch
+++ b/net-misc/tigervnc/files/tigervnc-1.12.0-disable-server-and-pam.patch
@@ -1,0 +1,57 @@
+See https://bugs.gentoo.org/852830
+
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -234,6 +234,7 @@
+   add_subdirectory(java)
+ endif()
+ 
++option(BUILD_SERVER "Build TigerVNC server" ON)
+ option(BUILD_VIEWER "Build TigerVNC viewer" ON)
+ if(BUILD_VIEWER)
+   # Check for FLTK
+@@ -276,7 +277,7 @@
+ endif()
+ 
+ # Check for PAM library
+-if(UNIX AND NOT APPLE)
++if(BUILD_SERVER AND UNIX AND NOT APPLE)
+   check_include_files(security/pam_appl.h HAVE_PAM_H)
+   set(CMAKE_REQUIRED_LIBRARIES -lpam)
+   check_function_exists(pam_start HAVE_PAM_START)
+@@ -315,9 +316,6 @@
+   add_subdirectory(media)
+ endif()
+ 
+-add_subdirectory(tests)
+-
+-
+ if(BUILD_VIEWER)
+   add_subdirectory(release)
+ endif()
+--- a/common/rfb/CMakeLists.txt
++++ b/common/rfb/CMakeLists.txt
+@@ -75,7 +75,7 @@
+ 
+ set(RFB_LIBRARIES ${JPEG_LIBRARIES} ${PIXMAN_LIBRARY} os rdr)
+ 
+-if(UNIX AND NOT APPLE)
++if(BUILD_SERVER AND UNIX AND NOT APPLE)
+   set(RFB_SOURCES ${RFB_SOURCES} UnixPasswordValidator.cxx
+     UnixPasswordValidator.h pam.c pam.h)
+   set(RFB_LIBRARIES ${RFB_LIBRARIES} ${PAM_LIBS})
+--- a/unix/CMakeLists.txt
++++ b/unix/CMakeLists.txt
+@@ -1,6 +1,8 @@
+ add_subdirectory(tx)
+ add_subdirectory(common)
+-add_subdirectory(vncconfig)
+-add_subdirectory(vncpasswd)
+-add_subdirectory(vncserver)
+-add_subdirectory(x0vncserver)
++if(BUILD_SERVER)
++	add_subdirectory(vncconfig)
++	add_subdirectory(vncpasswd)
++	add_subdirectory(vncserver)
++	add_subdirectory(x0vncserver)
++endif()

--- a/net-misc/tigervnc/files/tigervnc-1.12.80-disable-server-and-pam.patch
+++ b/net-misc/tigervnc/files/tigervnc-1.12.80-disable-server-and-pam.patch
@@ -1,0 +1,57 @@
+See https://bugs.gentoo.org/852830
+
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -234,6 +234,7 @@
+   add_subdirectory(java)
+ endif()
+ 
++option(BUILD_SERVER "Build TigerVNC server" ON)
+ option(BUILD_VIEWER "Build TigerVNC viewer" ON)
+ if(BUILD_VIEWER)
+   # Check for FLTK
+@@ -276,7 +277,7 @@
+ endif()
+ 
+ # Check for PAM library
+-if(UNIX AND NOT APPLE)
++if(BUILD_SERVER AND UNIX AND NOT APPLE)
+   check_include_files(security/pam_appl.h HAVE_PAM_H)
+   set(CMAKE_REQUIRED_LIBRARIES -lpam)
+   check_function_exists(pam_start HAVE_PAM_START)
+@@ -315,9 +316,6 @@
+   add_subdirectory(media)
+ endif()
+ 
+-add_subdirectory(tests)
+-
+-
+ if(BUILD_VIEWER)
+   add_subdirectory(release)
+ endif()
+--- a/common/rfb/CMakeLists.txt
++++ b/common/rfb/CMakeLists.txt
+@@ -88,7 +88,7 @@
+   target_sources(rfb PRIVATE WinPasswdValidator.cxx)
+ endif(WIN32)
+ 
+-if(UNIX AND NOT APPLE)
++if(BUILD_SERVER AND UNIX AND NOT APPLE)
+   target_sources(rfb PRIVATE UnixPasswordValidator.cxx pam.c)
+   target_link_libraries(rfb ${PAM_LIBS})
+ endif()
+--- a/unix/CMakeLists.txt
++++ b/unix/CMakeLists.txt
+@@ -1,6 +1,8 @@
+ add_subdirectory(tx)
+ add_subdirectory(common)
+-add_subdirectory(vncconfig)
+-add_subdirectory(vncpasswd)
+-add_subdirectory(vncserver)
+-add_subdirectory(x0vncserver)
++if(BUILD_SERVER)
++	add_subdirectory(vncconfig)
++	add_subdirectory(vncpasswd)
++	add_subdirectory(vncserver)
++	add_subdirectory(x0vncserver)
++endif()

--- a/net-misc/tigervnc/metadata.xml
+++ b/net-misc/tigervnc/metadata.xml
@@ -12,7 +12,6 @@
 	<use>
 		<flag name="drm">Build with DRM support</flag>
 		<flag name="server">Build TigerVNC server</flag>
-		<flag name="xorgmodule">Build the Xorg module</flag>
 		<flag name="dri3">Build with DRI3 support</flag>
 	</use>
 	<upstream>


### PR DESCRIPTION
Don't build server files instead of erasing them afterwards

I remade the patch from the bug - I don't like patches applied conditionally on a USE flag, so I added a `BUILD_SERVER` option to always apply the patch.  I also removed `vncpasswd` when building with `-server`, no use to change the password if you don't have the server.

I asked for a GCO in the bug, not sure if we need it or not.