### PR TITLE
flag-o-matic.eclass: add filter-lto, fix is-flagq to respect -fno-flag

### DIFF
--- a/eclass/flag-o-matic.eclass
+++ b/eclass/flag-o-matic.eclass
@@ -218,6 +218,14 @@ filter-lfs-flags() {
 	filter-flags -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_TIME_BITS=64
 }
 
+# @FUNCTION: filter-lto
+# @DESCRIPTION:
+# Remove flags that enable LTO and those that depend on it
+filter-lto() {
+	[[ $# -ne 0 ]] && die "filter-lto takes no arguments"
+	filter-flags '-flto*' -fwhole-program-vtables '-fsanitize=cfi*'
+}
+
 # @FUNCTION: filter-ldflags
 # @USAGE: <flags>
 # @DESCRIPTION:

--- a/eclass/flag-o-matic.eclass
+++ b/eclass/flag-o-matic.eclass
@@ -372,19 +372,30 @@ replace-cpu-flags() {
 # @USAGE: <variable> <flag>
 # @INTERNAL
 # @DESCRIPTION:
-# Returns shell true if <flag> is in a given <variable>, else returns shell false.
+# Returns shell true if <flag> is in a given <variable> and not surpassed by e.g. -fno-<flag>,
+# else returns shell false.
 _is_flagq() {
-	local x var="$1[*]"
+	local x var="$1[*]" equal_str equal_pos flag_no active=1
+	equal_str=${2%%=*}
+	equal_pos=${#equal_str}
+	# This results in -fno-flag for -fflag=*
+	flag_no="${2:0:2}no-${2:2:(equal_pos - 2)}"
+
 	for x in ${!var} ; do
-		[[ ${x} == $2 ]] && return 0
+		case ${x} in
+			$2) active=0 ;;
+			$flag_no) active=1 ;;
+			*) ;;
+		esac
 	done
-	return 1
+	return $active
 }
 
 # @FUNCTION: is-flagq
 # @USAGE: <flag>
 # @DESCRIPTION:
-# Returns shell true if <flag> is in {C,CXX,F,FC}FLAGS, else returns shell false.  Accepts shell globs.
+# Returns shell true if <flag> is in {C,CXX,F,FC}FLAGS and not surpassed by e.g. -fno-<flag>,
+# else returns shell false. Accepts shell globs.
 is-flagq() {
 	[[ -n $2 ]] && die "Usage: is-flag <flag>"
 


### PR DESCRIPTION
Inspired by https://wiki.gentoo.org/wiki/Project:Toolchain/LTO and recent discussion in -toolchain