### PR TITLE
dev-lang/scala-2.12.10: Correct source URL for USE=binary

### DIFF
--- a/dev-lang/scala/scala-2.12.10-r1.ebuild
+++ b/dev-lang/scala/scala-2.12.10-r1.ebuild
@@ -44,7 +44,7 @@ SRC_URI="
 		https://dev.gentoo.org/~gienah/snapshots/${P}-sbt-deps.tar.xz
 	)
 	binary? (
-		https://dev.gentoo.org/~gienah/files/dist/${P}-gentoo-binary.tar.xz
+		https://dev.gentoo.org/~gienah/distfiles/${P}-gentoo-binary.tar.xz
 	)"
 LICENSE="BSD"
 SLOT="${SV}/${PV}"


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/733086