### PR TITLE
dev-libs/marisa: fix build on 64-bit sparc

### DIFF
--- a/dev-libs/marisa/files/marisa-0.2.6-sparc64_word_size.patch
+++ b/dev-libs/marisa/files/marisa-0.2.6-sparc64_word_size.patch
@@ -1,0 +1,16 @@
+Originally reported in https://bugs.gentoo.org/show_bug.cgi?id=843422
+Upstream PR https://github.com/s-yata/marisa-trie/pull/46
+
+diff --git a/include/marisa/base.h b/include/marisa/base.h
+index bf4794e..95861b4 100644
+--- a/include/marisa/base.h
++++ b/include/marisa/base.h
+@@ -30,7 +30,7 @@ typedef uint64_t marisa_uint64;
+ 
+ #if defined(_WIN64) || defined(__amd64__) || defined(__x86_64__) || \
+     defined(__ia64__) || defined(__ppc64__) || defined(__powerpc64__) || \
+-    defined(__sparc64__) || defined(__mips64__) || defined(__aarch64__) || \
++    (defined(__sparc__) && defined(__LP64__)) || defined(__mips64__) || defined(__aarch64__) || \
+     defined(__s390x__) || (defined(__riscv) && (__riscv_xlen == 64)) || \
+     defined(__loongarch64)
+  #define MARISA_WORD_SIZE 64

--- a/dev-libs/marisa/marisa-0.2.6.ebuild
+++ b/dev-libs/marisa/marisa-0.2.6.ebuild
@@ -41,6 +41,7 @@ fi
 PATCHES=(
 	"${FILESDIR}/${PN}-0.2.6-riscv_word_size.patch"
 	"${FILESDIR}/${PN}-0.2.6-loong_word_size.patch"
+	"${FILESDIR}/${PN}-0.2.6-sparc64_word_size.patch"
 )
 
 src_prepare() {


### PR DESCRIPTION
Upstream PR:  https://github.com/s-yata/marisa-trie/pull/46

I'm submitting this early, because upstream is dead, and we have already had to pull in identical patches for riscv and loong in https://github.com/gentoo/gentoo/commit/ddedb2650b0beb769a2e165681be5a99a46cfac8 and https://github.com/gentoo/gentoo/commit/78057fe9e8fb2c1a89ff10dba205f2b40b009090 respectively.