### PR TITLE
kernel-build.eclass: Properly install vmlinux(.debug)

### DIFF
--- a/eclass/kernel-build.eclass
+++ b/eclass/kernel-build.eclass
@@ -196,15 +196,16 @@ kernel-build_src_install() {
 	local image_path=$(dist-kernel_get_image_path)
 	cp -p "build/${image_path}" "${ED}/usr/src/linux-${ver}/${image_path}" || die
 
-	# Install the unstripped uncompressed vmlinux for use with systemtap
-	# etc.  Use mv rather than doins for the same reason as above --
-	# space and time.
-	if use debug; then
-		mv build/vmlinux "${ED}/usr/src/linux-${ver}/" || die
-	fi
-
 	# building modules fails with 'vmlinux has no symtab?' if stripped
 	use ppc64 && dostrip -x "/usr/src/linux-${ver}/${image_path}"
+
+	# Install vmlinux with debuginfo when requested
+	if use debug; then
+		if [[ "${image_path}" != "vmlinux" ]]; then
+			mv "build/vmlinux" "${ED}/usr/src/linux-${ver}/vmlinux" || die
+		fi
+		dostrip -x "/usr/src/linux-${ver}/vmlinux"
+	fi
 
 	# strip empty directories
 	find "${D}" -type d -empty -exec rmdir {} + || die


### PR DESCRIPTION
Previously, in commit ad3b55e32736 we installed vmlinux with debug
symbols, but two issues remained.  Firstly, the debug symbols were
stripped (and optionally extracted), and secondly the build-id was
changed due to how estrip works.

In order to make systemtap work without complaining about missing
debuginfo and mismatch of build-id from the running kernel this commit
does the optional debug symbol extraction itself and then makes sure the
vmlinux(.debug) is not stripped in order for systemtap to be able to
find any required symbols.

On top of that move the vmlinux installation part more to the bottom of
the function because it now uses insinto so it does not cause issues.

Signed-off-by: Martin Kletzander <nert.pinx@gmail.com>