### PR TITLE
mail-filter/imapfilter: fixes for 828110 / 854471

### DIFF
--- a/mail-filter/imapfilter/imapfilter-2.7.5.ebuild
+++ b/mail-filter/imapfilter/imapfilter-2.7.5.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-LUA_COMPAT=( lua5-{1..3} )
+LUA_COMPAT=( lua5-{1..4} luajit )
 
 inherit lua-single toolchain-funcs
 
@@ -19,7 +19,7 @@ REQUIRED_USE="${LUA_REQUIRED_USE}"
 
 RDEPEND="
 	dev-libs/openssl:0=
-	dev-libs/libpcre
+	dev-libs/libpcre2
 	${LUA_DEPS}"
 DEPEND="${RDEPEND}"
 


### PR DESCRIPTION
This PR fixes two bugs:

1) add luajit to LUA_COMPAT (https://bugs.gentoo.org/828110)
2) correctly depend on libpcre2 (https://bugs.gentoo.org/854471)

We can also allow lua-5.4 while we're at it, since upstream explicitly mentions it.

Cheers :)
