### PR TITLE
media-libs/mlt: fix build for musl

### DIFF
--- a/media-libs/mlt/files/mlt-7.8.0-linux_locale_h.patch
+++ b/media-libs/mlt/files/mlt-7.8.0-linux_locale_h.patch
@@ -1,0 +1,37 @@
+From 7d82553a00e74af77e69cc74645e0a3ec6bb3aa1 Mon Sep 17 00:00:00 2001
+From: alfredfo <98554039+alfredfo@users.noreply.github.com>
+Date: Sat, 25 Jun 2022 01:00:11 +0000
+Subject: [PATCH] Fix building for musl (#803)
+
+reverts: https://github.com/mltframework/mlt/pull/298.
+There is no gurantee that either HAVE_STRTOD_L or HAVE_LOCALE_H will be
+defined at compile-time. Try for example building this project :)
+
+The locale usage is now defined in POSIX and therefore we can now
+assume it will be available on Linux, except for ancient systems.
+https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/locale.h.html
+
+Another way of dealing with this would be to have a global mlt_config.h
+where HAVE_LOCALE_H and HAVE_STRTOD_L are defined to values determined
+when mlt is installed.
+
+https://git.alpinelinux.org/aports/tree/community/mlt/musl-locale.patch
+https://bugs.gentoo.org/829608
+https://github.com/mltframework/mlt/pull/803
+---
+ src/framework/mlt_property.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/framework/mlt_property.h b/src/framework/mlt_property.h
+index 85d550ac0..be61c23c2 100644
+--- a/src/framework/mlt_property.h
++++ b/src/framework/mlt_property.h
+@@ -30,7 +30,7 @@
+ #include <sys/param.h>
+ #endif
+ 
+-#if (defined(__GLIBC__) && !defined(__APPLE__)) || defined(HAVE_LOCALE_H)
++#if (defined(__linux__) && !defined(__APPLE__))
+ #  include <locale.h>
+ #elif defined(__APPLE__) || (defined(__FreeBSD_version) && __FreeBSD_version >= 900506)
+ #  include <xlocale.h>

--- a/media-libs/mlt/mlt-7.8.0.ebuild
+++ b/media-libs/mlt/mlt-7.8.0.ebuild
@@ -84,6 +84,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-6.10.0-swig-underlinking.patch
 	"${FILESDIR}"/${PN}-6.22.1-no_lua_bdepend.patch
 	"${FILESDIR}"/${PN}-7.0.1-cmake-symlink.patch
+	"${FILESDIR}"/${PN}-7.8.0-linux_locale_h.patch
 )
 
 pkg_setup() {


### PR DESCRIPTION
There is no gurantee that either HAVE_STRTOD_L or HAVE_LOCALE_H will be
defined at compile-time. Try for example building this project :)

The locale usage is now defined in POSIX and therefore we can now
assume it will be available on Linux, except for ancient systems.
https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/locale.h.html

Another way of dealing with this would be to have a global mlt_config.h
where HAVE_LOCALE_H and HAVE_STRTOD_L are defined to values determined
when mlt is installed.
See-also:
https://git.alpinelinux.org/aports/tree/community/mlt/musl-locale.patch, https://github.com/mltframework/mlt/pull/803

Closes: https://bugs.gentoo.org/829608
Signed-off-by: Alfred Persson Forsberg <cat@catcream.org>