### PR TITLE
kde-apps/konsole: fix build for musl

### DIFF
--- a/kde-apps/konsole/files/konsole-22.04.2-musl_malloc_trim.patch
+++ b/kde-apps/konsole/files/konsole-22.04.2-musl_malloc_trim.patch
@@ -1,0 +1,92 @@
+https://invent.kde.org/utilities/konsole/-/merge_requests/621
+https://invent.kde.org/utilities/konsole/-/commit/b8c90a830ceaf293e61f6cd5217bb3e584f997b8 (backport)
+
+
+From b8c90a830ceaf293e61f6cd5217bb3e584f997b8 Mon Sep 17 00:00:00 2001
+From: Heiko Becker <heiko.becker@kde.org>
+Date: Tue, 22 Mar 2022 22:08:10 +0100
+Subject: [PATCH] Detect the presence of malloc_trim to fix the build with musl
+
+malloc_trim is indeed a GNU extension, but an extension of glibc.
+Relying on __GNUC__ unfortunately doesn't help with that. Check for
+the actual presence of malloc_trim with cmake's check_function_exists
+instead.
+This fixes the build with musl libc, which doesn't come with
+malloc_trim.
+
+Co-authored-by: Ahmad Samir <a.samirh78@gmail.com>
+(cherry picked from commit f6310c2b791275f3727f2240ca7fab9f58db943d)
+---
+ CMakeLists.txt             |  2 +-
+ src/Screen.cpp             | 17 +++++++----------
+ src/config-konsole.h.cmake |  4 ++--
+ 3 files changed, 10 insertions(+), 13 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f2c9d43ac..b306597ba 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -94,7 +94,7 @@ set(HAVE_X11 ${X11_FOUND})
+ # Check for function GETPWUID
+ check_symbol_exists(getpwuid "pwd.h" HAVE_GETPWUID)
+ 
+-check_include_files(malloc.h      HAVE_MALLOC_H)
++check_function_exists(malloc_trim HAVE_MALLOC_TRIM)
+ 
+ # See above includes for defaults
+ add_definitions(
+diff --git a/src/Screen.cpp b/src/Screen.cpp
+index e57314cd5..dff9b54a4 100644
+--- a/src/Screen.cpp
++++ b/src/Screen.cpp
+@@ -28,13 +28,11 @@
+ #include "history/HistoryType.h"
+ #include "profile/Profile.h"
+ 
+-#ifdef HAVE_MALLOC_H
+-    // For malloc_trim, which is a GNU extension
+-    #ifdef __GNUC__
+-    extern "C" {
+-            #include <malloc.h>
+-    }
+-    #endif
++#ifdef HAVE_MALLOC_TRIM
++// For malloc_trim, which is a GNU extension
++extern "C" {
++#include <malloc.h>
++}
+ #endif
+ 
+ using namespace Konsole;
+@@ -1799,14 +1797,13 @@ void Screen::setScroll(const HistoryType &t, bool copyPreviousScroll)
+         t.scroll(_history);
+     }
+ 
+-#ifdef HAVE_MALLOC_H
++#ifdef HAVE_MALLOC_TRIM
++
+ #ifdef Q_OS_LINUX
+-#ifdef __GNUC__
+     // We might have been using gigabytes of memory, so make sure it is actually released
+     malloc_trim(0);
+ #endif
+ #endif
+-#endif
+ }
+ 
+ bool Screen::hasScroll() const
+diff --git a/src/config-konsole.h.cmake b/src/config-konsole.h.cmake
+index b74992b0a..4b1d9b515 100644
+--- a/src/config-konsole.h.cmake
++++ b/src/config-konsole.h.cmake
+@@ -15,5 +15,5 @@
+ 
+ #cmakedefine HAVE_GETPWUID ${HAVE_GETPWUID}
+ 
+-/* Define to 1 if you have the <malloc.h> header file. */
+-#cmakedefine HAVE_MALLOC_H 1
++/* Defined if system has the malloc_trim function, which is a GNU extension */
++#cmakedefine HAVE_MALLOC_TRIM
+-- 
+GitLab
+

--- a/kde-apps/konsole/konsole-22.04.2.ebuild
+++ b/kde-apps/konsole/konsole-22.04.2.ebuild
@@ -18,6 +18,8 @@ SLOT="5"
 KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="X"
 
+PATCHES=( "${FILESDIR}"/${PN}-22.04.2-musl_malloc_trim.patch )
+
 DEPEND="
 	>=dev-qt/qtdbus-${QTMIN}:5
 	>=dev-qt/qtgui-${QTMIN}:5


### PR DESCRIPTION
This patch fixes building Konsole with musl. Konsole uses the GNU
extension malloc_trim and this patch makes Konsole use it conditionally
depending on if it's present on the target system.

This is upstreamed for release 22.04.3 (mid July).

See-also: https://invent.kde.org/utilities/konsole/-/merge_requests/621
Signed-off-by: Alfred Persson Forsberg <cat@catcream.org>