### PR TITLE
dev-python/ipyparallel: increase timeouts for new tests in 8.3.0

### DIFF
--- a/dev-python/ipyparallel/files/ipyparallel-8.3.0-additional-test-timeouts.patch
+++ b/dev-python/ipyparallel/files/ipyparallel-8.3.0-additional-test-timeouts.patch
@@ -1,0 +1,46 @@
+https://bugs.gentoo.org/834198
+
+diff --git a/ipyparallel/tests/test_view.py b/ipyparallel/tests/test_view.py
+index 5b5ca41..4c04d02 100644
+--- a/ipyparallel/tests/test_view.py
++++ b/ipyparallel/tests/test_view.py
+@@ -628,7 +628,7 @@ class TestView(ClusterTestCase):
+         """exceptions in execute requests raise appropriately"""
+         view = self.client[-1]
+         ar = view.execute("1/0")
+-        self.assertRaisesRemote(ZeroDivisionError, ar.get, 2)
++        self.assertRaisesRemote(ZeroDivisionError, ar.get, 20)
+ 
+     def test_remoteerror_render_exception(self):
+         """RemoteErrors get nice tracebacks"""
+@@ -637,7 +637,7 @@ class TestView(ClusterTestCase):
+         ip = get_ipython()
+         ip.user_ns['ar'] = ar
+         with capture_output() as io:
+-            ip.run_cell("ar.get(2)")
++            ip.run_cell("ar.get(20)")
+ 
+         self.assertTrue('ZeroDivisionError' in io.stdout, io.stdout)
+ 
+@@ -649,7 +649,7 @@ class TestView(ClusterTestCase):
+         ip.user_ns['ar'] = ar
+ 
+         with capture_output() as io:
+-            ip.run_cell("ar.get(2)")
++            ip.run_cell("ar.get(20)")
+ 
+         count = min(error.CompositeError.tb_limit, len(view))
+ 
+@@ -689,10 +689,10 @@ class TestView(ClusterTestCase):
+         view = self.client[-1]
+         ar = view.execute("%pylab inline")
+         # at least check if this raised:
+-        reply = ar.get(5)
++        reply = ar.get(50)
+         # include imports, in case user config
+         ar = view.execute("plot(rand(100))", silent=False)
+-        reply = ar.get(5)
++        reply = ar.get(50)
+         assert ar.wait_for_output(5)
+         self.assertEqual(len(reply.outputs), 1)
+         output = reply.outputs[0]

--- a/dev-python/ipyparallel/ipyparallel-8.3.0.ebuild
+++ b/dev-python/ipyparallel/ipyparallel-8.3.0.ebuild
@@ -48,6 +48,7 @@ distutils_enable_tests pytest
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-7.1.0-test-timeouts.patch
+	"${FILESDIR}"/${PN}-8.3.0-additional-test-timeouts.patch
 )
 
 src_configure() {

--- a/dev-python/ipyparallel/ipyparallel-8.4.0.ebuild
+++ b/dev-python/ipyparallel/ipyparallel-8.4.0.ebuild
@@ -52,6 +52,7 @@ distutils_enable_tests pytest
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-7.1.0-test-timeouts.patch
+	"${FILESDIR}"/${PN}-8.3.0-additional-test-timeouts.patch
 )
 
 src_configure() {

--- a/dev-python/ipyparallel/ipyparallel-8.4.1.ebuild
+++ b/dev-python/ipyparallel/ipyparallel-8.4.1.ebuild
@@ -52,6 +52,7 @@ distutils_enable_tests pytest
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-7.1.0-test-timeouts.patch
+	"${FILESDIR}"/${PN}-8.3.0-additional-test-timeouts.patch
 )
 
 src_configure() {


### PR DESCRIPTION
Tested on sparc.  I just multiplied by 10x to be safe, doesn't really seem to have a noticeable impact on test suite runtime.  Does not apply to <dev-python/ipyparallel-8.3.0.