### PR TITLE
sci-libs/mpir: Stabilize 3.0.0-r1 arm64, #640424

### DIFF
--- a/sci-libs/mpir/mpir-3.0.0-r1.ebuild
+++ b/sci-libs/mpir/mpir-3.0.0-r1.ebuild
@@ -11,7 +11,7 @@ SRC_URI="https://www.mpir.org/${P}.tar.bz2"
 
 LICENSE="LGPL-3"
 SLOT="0/23"
-KEYWORDS="~alpha amd64 arm ~arm64 hppa ~ia64 ppc ppc64 ~riscv ~s390 ~sparc x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ppc ppc64 ~riscv ~s390 ~sparc x86 ~amd64-linux ~x86-linux"
 IUSE="+cxx cpudetection"
 
 BDEPEND="


### PR DESCRIPTION
Confirmed that this bug no longer occurs in 3.0.0, builds and passes tests fine.  Tested on arm64.