### PR TITLE
dev-util/hip: add missing BDEPEND for USE=profile

### DIFF
--- a/dev-util/hip/files/hip-5.0.2-correct-ldflag.patch
+++ b/dev-util/hip/files/hip-5.0.2-correct-ldflag.patch
@@ -1,0 +1,18 @@
+This removes ldflag -L"/usr/lib" and -Wl,-rpath=/usr/lib:/usr/lib which
+causes `ld: skipping incompatible /usr/lib/libm.so when searching for -lm`
+Reference: https://github.com/justxi/rocm/issues/8#issuecomment-1166193820
+===================================================================
+--- HIP-rocm-5.1.3.orig/bin/hipcc.pl
++++ HIP-rocm-5.1.3/bin/hipcc.pl
+@@ -703,9 +703,9 @@ if ($HIP_PLATFORM eq "amd") {
+ 
+     if (not $isWindows  and not $compileOnly) {
+       if ($linkType eq 0) {
+-        $toolArgs = " -L$HIP_LIB_PATH -lamdhip64 -L$ROCM_PATH/lib -lhsa-runtime64 -ldl -lnuma " . ${toolArgs};
++        $toolArgs = " -lamdhip64 -lhsa-runtime64 -ldl -lnuma " . ${toolArgs};
+       } else {
+-        $toolArgs = " -Wl,--enable-new-dtags -Wl,-rpath=$HIP_LIB_PATH:$ROCM_PATH/lib -lamdhip64 " . ${toolArgs};
++        $toolArgs = " -Wl,--enable-new-dtags -lamdhip64 " . ${toolArgs};
+       }
+       # To support __fp16 and _Float16, explicitly link with compiler-rt
+       $HIP_CLANG_BUILTIN_LIB="/opt/gentoo/opt/gentoo/usr/lib/llvm/14/bin/../../../../lib/clang/14.0.6/lib/$HIP_CLANG_TARGET/libclang_rt.builtins.a";


### PR DESCRIPTION
Also fix ld warnings by patch out unecessary ldflag added by hipcc.pl

Reference: https://github.com/justxi/rocm/issues/8#issuecomment-1166193820
Signed-off-by: Yiyang Wu <xgreenlandforwyy@gmail.com>