### PR TITLE
app-crypt/trousers: Add missing dev_reload

### DIFF
--- a/app-crypt/trousers/trousers-0.3.15.ebuild
+++ b/app-crypt/trousers/trousers-0.3.15.ebuild
@@ -61,5 +61,12 @@ src_install() {
 	udev_dorules "${FILESDIR}"/61-trousers.rules
 	fowners tss:tss /var/lib/tpm
 	readme.gentoo_create_doc
+}
+
+pkg_postinst() {
+	udev_reload
+}
+
+pkg_postrm() {
 	udev_reload
 }


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/854285
Signed-off-by: Christopher Byrne <salah.coronya@gmail.com>