### PR TITLE
media-video/ffmpeg: Add v4l2-m2m USE flag

### DIFF
--- a/media-video/ffmpeg/ffmpeg-5.0.1.ebuild
+++ b/media-video/ffmpeg/ffmpeg-5.0.1.ebuild
@@ -74,7 +74,7 @@ fi
 FFMPEG_FLAG_MAP=(
 		+bzip2:bzlib cpudetection:runtime-cpudetect debug gcrypt +gnutls gmp
 		+gpl hardcoded-tables +iconv libxml2 lzma +network opencl
-		openssl +postproc samba:libsmbclient sdl:ffplay sdl:sdl2 vaapi vdpau vulkan
+		openssl +postproc samba:libsmbclient sdl:ffplay sdl:sdl2 v4l2-m2m vaapi vdpau vulkan
 		X:xlib X:libxcb X:libxcb-shm X:libxcb-xfixes +zlib
 		# libavdevice options
 		cdio:libcdio iec61883:libiec61883 ieee1394:libdc1394 libcaca openal

--- a/media-video/ffmpeg/ffmpeg-5.0.1.ebuild
+++ b/media-video/ffmpeg/ffmpeg-5.0.1.ebuild
@@ -74,7 +74,7 @@ fi
 FFMPEG_FLAG_MAP=(
 		+bzip2:bzlib cpudetection:runtime-cpudetect debug gcrypt +gnutls gmp
 		+gpl hardcoded-tables +iconv libxml2 lzma +network opencl
-		openssl +postproc samba:libsmbclient sdl:ffplay sdl:sdl2 v4l2-m2m vaapi vdpau vulkan
+		openssl +postproc samba:libsmbclient sdl:ffplay sdl:sdl2 v4l2_codec:v4l2-m2m vaapi vdpau vulkan
 		X:xlib X:libxcb X:libxcb-shm X:libxcb-xfixes +zlib
 		# libavdevice options
 		cdio:libcdio iec61883:libiec61883 ieee1394:libdc1394 libcaca openal

--- a/media-video/ffmpeg/ffmpeg-9999.ebuild
+++ b/media-video/ffmpeg/ffmpeg-9999.ebuild
@@ -74,7 +74,7 @@ fi
 FFMPEG_FLAG_MAP=(
 		+bzip2:bzlib cpudetection:runtime-cpudetect debug gcrypt +gnutls gmp
 		+gpl hardcoded-tables +iconv libxml2 lzma +network opencl
-		openssl +postproc samba:libsmbclient sdl:ffplay sdl:sdl2 vaapi vdpau vulkan
+		openssl +postproc samba:libsmbclient sdl:ffplay sdl:sdl2 v4l2-m2m vaapi vdpau vulkan
 		X:xlib X:libxcb X:libxcb-shm X:libxcb-xfixes +zlib
 		# libavdevice options
 		cdio:libcdio iec61883:libiec61883 ieee1394:libdc1394 libcaca openal

--- a/media-video/ffmpeg/ffmpeg-9999.ebuild
+++ b/media-video/ffmpeg/ffmpeg-9999.ebuild
@@ -74,7 +74,7 @@ fi
 FFMPEG_FLAG_MAP=(
 		+bzip2:bzlib cpudetection:runtime-cpudetect debug gcrypt +gnutls gmp
 		+gpl hardcoded-tables +iconv libxml2 lzma +network opencl
-		openssl +postproc samba:libsmbclient sdl:ffplay sdl:sdl2 v4l2-m2m vaapi vdpau vulkan
+		openssl +postproc samba:libsmbclient sdl:ffplay sdl:sdl2 v4l2_codec:v4l2-m2m vaapi vdpau vulkan
 		X:xlib X:libxcb X:libxcb-shm X:libxcb-xfixes +zlib
 		# libavdevice options
 		cdio:libcdio iec61883:libiec61883 ieee1394:libdc1394 libcaca openal


### PR DESCRIPTION
Hi,
This PR adds v4l2-m2m to the flag list, so that configure will autodetect whether V4L2 video acceleration (hardware) is supported or not, and compile the associated "hwaccel" if yes. 
This is needed for e.g. ChromeOS on Qualcomm platforms that support the V4L2 M2M interface for video decode acceleration.
ChromeOS bug tracker https://b.corp.google.com/issues/237389623.
Thanks!
Miguel

Signed-off-by: mcasas@chromium.org