### PR TITLE
dev-libs/intel-compute-runtime: add patch to remove `-D_FORTIFY_SOURCE=2` configuration from build process

### DIFF
--- a/dev-libs/intel-compute-runtime/files/remove-fortify-sources.patch
+++ b/dev-libs/intel-compute-runtime/files/remove-fortify-sources.patch
@@ -1,0 +1,20 @@
+diff --git a/compute-runtime-22.24.23453/CMakeLists.txt b/compute-runtime-22.24.23453/CMakeLists.txt
+index f227808..83075f9 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -702,7 +702,6 @@ if("${CMAKE_BUILD_TYPE}" STREQUAL "Release")
+   else()
+     if(${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
+       set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fstack-protector-strong")
+-      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O2 -D_FORTIFY_SOURCE=2")
+       set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wformat -Wformat-security")
+     else()
+       # gcc, g++ only
+@@ -711,7 +710,6 @@ if("${CMAKE_BUILD_TYPE}" STREQUAL "Release")
+       else()
+         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fstack-protector-strong")
+       endif()
+-      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O2 -D_FORTIFY_SOURCE=2")
+       set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wformat -Wformat-security")
+       set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "${CMAKE_SHARED_LINKER_FLAGS_RELEASE} -Wl,-z,noexecstack")
+       set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "${CMAKE_SHARED_LINKER_FLAGS_RELEASE} -Wl,-z,relro")

--- a/dev-libs/intel-compute-runtime/intel-compute-runtime-22.24.23453.ebuild
+++ b/dev-libs/intel-compute-runtime/intel-compute-runtime-22.24.23453.ebuild
@@ -41,11 +41,13 @@ BDEPEND="virtual/pkgconfig"
 
 DOCS=( "README.md" "FAQ.md" )
 
-src_prepare() {
-	default
+PATCHES=(
+	"${FILESDIR}/remove-fortify-sources.patch"
+)
 
+src_prepare() {
 	# Remove '-Werror' from default
-	set -e '/Werror/d' -i CMakeLists.txt || die
+	sed -e '/Werror/d' -i CMakeLists.txt || die
 
 	cmake_src_prepare
 }

--- a/dev-libs/intel-compute-runtime/intel-compute-runtime-22.25.23529.ebuild
+++ b/dev-libs/intel-compute-runtime/intel-compute-runtime-22.25.23529.ebuild
@@ -41,11 +41,13 @@ BDEPEND="virtual/pkgconfig"
 
 DOCS=( "README.md" "FAQ.md" )
 
-src_prepare() {
-	default
+PATCHES=(
+	"${FILESDIR}/remove-fortify-sources.patch"
+)
 
+src_prepare() {
 	# Remove '-Werror' from default
-	set -e '/Werror/d' -i CMakeLists.txt || die
+	sed -e '/Werror/d' -i CMakeLists.txt || die
 
 	cmake_src_prepare
 }


### PR DESCRIPTION
Signed-off-by: Randall T. Vasquez <ran.dall@icloud.com>