### PR TITLE
app-emulation/virtualbox-modules: fix kernel >= 5.18 build fail

### DIFF
--- a/app-emulation/virtualbox-modules/files/virtualbox-modules-6.1.34-remove-netif_rx_ni.patch
+++ b/app-emulation/virtualbox-modules/files/virtualbox-modules-6.1.34-remove-netif_rx_ni.patch
@@ -1,0 +1,16 @@
+--- a/vboxnetflt/linux/VBoxNetFlt-linux.c
++++ b/vboxnetflt/linux/VBoxNetFlt-linux.c
+@@ -2311,7 +2311,13 @@
+                 vboxNetFltDumpPacket(pSG, true, "host", (fDst & INTNETTRUNKDIR_WIRE) ? 0 : 1);
+                 Log6(("vboxNetFltPortOsXmit: pBuf->cb dump:\n%.*Rhxd\n", sizeof(pBuf->cb), pBuf->cb));
+                 Log6(("vboxNetFltPortOsXmit: netif_rx_ni(%p)\n", pBuf));
++#if RTLNX_VER_MIN(5,18,0)
++                local_bh_disable();
++                err = netif_rx(pBuf);
++                local_bh_enable();
++#else
+                 err = netif_rx_ni(pBuf);
++#endif
+                 if (err)
+                     rc = RTErrConvertFromErrno(err);
+             }

--- a/app-emulation/virtualbox-modules/virtualbox-modules-6.1.34.ebuild
+++ b/app-emulation/virtualbox-modules/virtualbox-modules-6.1.34.ebuild
@@ -29,6 +29,8 @@ MODULESD_VBOXDRV_ENABLED="yes"
 MODULESD_VBOXNETADP_ENABLED="no"
 MODULESD_VBOXNETFLT_ENABLED="no"
 
+PATCHES=( "${FILESDIR}"/${PN}-6.1.34-remove-netif_rx_ni.patch )
+
 pkg_setup() {
 	linux-mod_pkg_setup
 	BUILD_PARAMS="CC=\"$(tc-getBUILD_CC)\" KERN_DIR=${KV_DIR} KERN_VER=${KV_FULL} O=${KV_OUT_DIR} V=1 KBUILD_VERBOSE=1"


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/847094

Signed-off-by: peeweep <peeweep@0x0.ee>