### PR TITLE
x11-terms/roxterm: Drop inactive proxied maintainer

### DIFF
--- a/x11-terms/roxterm/metadata.xml
+++ b/x11-terms/roxterm/metadata.xml
@@ -1,15 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer type="person" proxied="yes">
-		<email>ewoud+gentoo@kohlvanwijngaarden.nl</email>
-		<name>Ewoud Kohl van Wijngaarden</name>
-	</maintainer>
-	<maintainer type="project" proxied="proxy">
-		<email>proxy-maint@gentoo.org</email>
-		<name>Proxy Maintainers</name>
-	</maintainer>
-
+	<!-- maintainer-needed -->
 	<upstream>
 		<remote-id type="github">realh/roxterm</remote-id>
 	</upstream>


### PR DESCRIPTION
No commits in nearly 2 years. No bugzilla activity in 1.5 years.

Signed-off-by: Matt Turner <mattst88@gentoo.org>

cc: @ekohl