### PR TITLE
eclass/selinux-policy-2: fix POLICY_PATCH applying

### DIFF
--- a/eclass/selinux-policy-2.eclass
+++ b/eclass/selinux-policy-2.eclass
@@ -159,7 +159,7 @@ selinux-policy-2_src_prepare() {
 	if [[ -n ${BASEPOL} ]] && [[ "${BASEPOL}" != "9999" ]]; then
 		cd "${S}"
 		einfo "Applying SELinux policy updates ... "
-		eapply -p0 "${WORKDIR}/0001-full-patch-against-stable-release.patch"
+		eapply -p0 -- "${WORKDIR}/0001-full-patch-against-stable-release.patch"
 	fi
 
 	# Call in eapply_user. We do this early on as we start moving
@@ -180,9 +180,9 @@ selinux-policy-2_src_prepare() {
 	# Apply the additional patches refered to by the module ebuild.
 	# But first some magic to differentiate between bash arrays and strings
 	if [[ "$(declare -p POLICY_PATCH 2>/dev/null 2>&1)" == "declare -a"* ]]; then
-		[[ -n ${POLICY_PATCH[*]} ]] && eapply -d "${S}/refpolicy/policy/modules" "${POLICY_PATCH[@]}"
+		[[ -n ${POLICY_PATCH[*]} ]] && eapply -d "${S}/refpolicy/policy/modules" -- "${POLICY_PATCH[@]}"
 	else
-		[[ -n ${POLICY_PATCH} ]] && eapply -d "${S}/refpolicy/policy/modules" ${POLICY_PATCH}
+		[[ -n ${POLICY_PATCH} ]] && eapply -d "${S}/refpolicy/policy/modules" -- ${POLICY_PATCH}
 	fi
 
 	# Collect only those files needed for this particular module


### PR DESCRIPTION
eapply as implemented in portage has some heuristics to find out where
the parameters that should be passed to patch utility end and actual
diff/patch files begin. It first tries to find -- which is the
explicit way of separating parameters from input files. Since there's
none, it tries to find a first non-option. And it finds the refpolicy
directory as a first non-option, while it is supposed to be a value of
the -d parameter. The said directory is then treated as an input
directory, which is expected to contain at least one patch or diff
file. Since there's none, eapply fails.

Help eapply's heuristics by explicitly delimiting the parameters from
input files with --.

Bug: https://bugs.gentoo.org/794682
Signed-off-by: Krzesimir Nowak <knowak@microsoft.com>