### PR TITLE
net-fs/samba: Fix undefined innetgr on musl

### DIFF
--- a/net-fs/samba/files/samba-4.16.2-fix-musl-without-innetgr.patch
+++ b/net-fs/samba/files/samba-4.16.2-fix-musl-without-innetgr.patch
@@ -1,0 +1,23 @@
+# Gentoo bug 855047
+--- a/lib/util/access.c
++++ b/lib/util/access.c
+@@ -115,7 +115,7 @@ static bool string_match(const char *tok,const char *s)
+ 			return true;
+ 		}
+ 	} else if (tok[0] == '@') { /* netgroup: look it up */
+-#ifdef HAVE_NETGROUP
++#if defined(HAVE_NETGROUP) && defined(HAVE_INNETGR)
+ 		DATA_BLOB tmp;
+ 		char *mydomain = NULL;
+ 		char *hostname = NULL;
+--- a/source3/auth/user_util.c
++++ b/source3/auth/user_util.c
+@@ -135,7 +135,7 @@ static void store_map_in_gencache(TALLOC_CTX *ctx, const char *from, const char
+
+ bool user_in_netgroup(TALLOC_CTX *ctx, const char *user, const char *ngname)
+ {
+-#ifdef HAVE_NETGROUP
++#if defined(HAVE_NETGROUP) && defined(HAVE_INNETGR)
+ 	char nis_domain_buf[256];
+ 	const char *nis_domain = NULL;
+ 	char *lowercase_user = NULL;

--- a/net-fs/samba/samba-4.16.2.ebuild
+++ b/net-fs/samba/samba-4.16.2.ebuild
@@ -142,6 +142,7 @@ BDEPEND="${PYTHON_DEPS}
 PATCHES=(
 	"${FILESDIR}/${PN}-4.4.0-pam.patch"
 	"${FILESDIR}/${PN}-4.16.1-netdb-defines.patch"
+	"${FILESDIR}/${PN}-4.16.2-fix-musl-without-innetgr.patch"
 )
 
 #CONFDIR="${FILESDIR}/$(get_version_component_range 1-2)"


### PR DESCRIPTION
Currently samba fails to build on musl with error message saying
undefined reference to `innetgr'. This patch fixes that issue.

Closes: https://bugs.gentoo.org/855047

Signed-off-by: brahmajit das <brahmajit.xyz@gmail.com>