### PR TITLE
app-misc/qlcplus: Add calls to udev_reload and update copyright dates

### DIFF
--- a/app-misc/qlcplus/qlcplus-4.12.2.ebuild
+++ b/app-misc/qlcplus/qlcplus-4.12.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -60,6 +60,14 @@ src_install() {
 	emake INSTALL_ROOT="${D}" install
 }
 
+pkg_postinst() {
+	udev_reload
+}
+
 src_test() {
 	virtx emake check
+}
+
+pkg_postrm() {
+	udev_reload
 }

--- a/app-misc/qlcplus/qlcplus-4.12.3.ebuild
+++ b/app-misc/qlcplus/qlcplus-4.12.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -60,6 +60,14 @@ src_install() {
 	emake INSTALL_ROOT="${D}" install
 }
 
+pkg_postinst() {
+	udev_reload
+}
+
 src_test() {
 	virtx emake check
+}
+
+pkg_postrm() {
+	udev_reload
 }

--- a/app-misc/qlcplus/qlcplus-4.12.4.ebuild
+++ b/app-misc/qlcplus/qlcplus-4.12.4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -60,6 +60,14 @@ src_install() {
 	emake INSTALL_ROOT="${D}" install
 }
 
+pkg_postinst() {
+	udev_reload
+}
+
 src_test() {
 	virtx emake check
+}
+
+pkg_postrm() {
+	udev_reload
 }

--- a/app-misc/qlcplus/qlcplus-5.0.0_alpha3.ebuild
+++ b/app-misc/qlcplus/qlcplus-5.0.0_alpha3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -68,10 +68,16 @@ src_test() {
 }
 
 pkg_postinst() {
+	udev_reload
+
 	elog "Some configurations of KDE Plasma break the layout of"
 	elog "QLC+ 5's QML UI."
 	elog "As a workaround, try those environment variables:"
 	elog "	export XDG_CURRENT_DESKTOP=GNOME"
 	elog "OR"
 	elog "	export QT_QPA_PLATFORMTHEME=gtk3"
+}
+
+pkg_postrm() {
+	udev_reload
 }


### PR DESCRIPTION
No revbumps since calling `udev_reload` doesn't give any advantage to people already having the package emerged.

Repoman complained about missing KEYWORDS for v5.0.0-alpha3. Acknowledged but on purpose since it's an alpha version.

Closes: https://bugs.gentoo.org/854765