### PR TITLE
media-video/vdr-2.2.0-r7: fix compile with USE=vanilla

### DIFF
--- a/media-video/vdr/vdr-2.2.0-r7.ebuild
+++ b/media-video/vdr/vdr-2.2.0-r7.ebuild
@@ -32,7 +32,7 @@ KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~x86"
 IUSE="bidi debug keyboard html systemd vanilla ${EXT_PATCH_FLAGS} ${EXT_PATCH_FLAGS_RENAMED}"
 
 COMMON_DEPEND="
-	virtual/jpeg:*
+	media-libs/libjpeg-turbo
 	sys-libs/libcap
 	>=media-libs/fontconfig-2.4.2
 	>=media-libs/freetype-2"
@@ -212,9 +212,9 @@ src_prepare() {
 		eend $? "make depend failed"
 
 		eapply "${FILESDIR}/${P}_gcc7extpng.patch"
-		eapply "${FILESDIR}/${P}_gcc11.patch"
 	fi
 
+	eapply "${FILESDIR}/${P}_gcc11.patch"
 	eapply "${FILESDIR}/${P}_gentoo.patch"
 	eapply "${FILESDIR}/${P}_unsignedtosigned.patch"
 	eapply "${FILESDIR}/${P}_glibc-2.24.patch"


### PR DESCRIPTION
fix error in patch logic with gcc-11
replace deprecated virtual/jpeg

Closes: https://bugs.gentoo.org/855269
Signed-off-by: Martin Dummer <martin.dummer@gmx.net>