### PR TITLE
dev-db/redis: build fix for luajit-2.1

### DIFF
--- a/dev-db/redis/files/redis-5.0-luajit-2.1-fix.patch
+++ b/dev-db/redis/files/redis-5.0-luajit-2.1-fix.patch
@@ -1,0 +1,47 @@
+Backported from https://github.com/openresty/lua-cjson
+
+Upstream-commit: 638ac2741a7f ("optimize: improved forward-compatibility with older versions of Lua/LuaJIT.")
+Link: https://github.com/openresty/lua-cjson/commit/638ac2741a7f274979ac3fe2e1ea5fd6487702fe
+Upstream-PR: https://github.com/openresty/lua-cjson/pull/32
+See-also: https://www.freelists.org/post/luajit/ANN-LuaJIT210beta3,3
+
+diff --git a/deps/lua/src/lua_cjson.c b/deps/lua/src/lua_cjson.c
+index c26c0d7b8..af9e4ca54 100644
+--- a/deps/lua/src/lua_cjson.c
++++ b/deps/lua/src/lua_cjson.c
+@@ -1293,11 +1293,13 @@ static int json_decode(lua_State *l)
+ /* ===== INITIALISATION ===== */
+ 
+ #if !defined(LUA_VERSION_NUM) || LUA_VERSION_NUM < 502
+-/* Compatibility for Lua 5.1.
++/* Compatibility for Lua 5.1 and older LuaJIT.
+  *
+- * luaL_setfuncs() is used to create a module table where the functions have
+- * json_config_t as their first upvalue. Code borrowed from Lua 5.2 source. */
+-static void luaL_setfuncs (lua_State *l, const luaL_Reg *reg, int nup)
++ * compat_luaL_setfuncs() is used to create a module table where the functions
++ * have json_config_t as their first upvalue. Code borrowed from Lua 5.2
++ * source's luaL_setfuncs().
++ */
++static void compat_luaL_setfuncs(lua_State *l, const luaL_Reg *reg, int nup)
+ {
+     int i;
+ 
+@@ -1310,6 +1312,8 @@ static void luaL_setfuncs (lua_State *l, const luaL_Reg *reg, int nup)
+     }
+     lua_pop(l, nup);  /* remove upvalues */
+ }
++#else
++#define compat_luaL_setfuncs(L, reg, nup) luaL_setfuncs(L, reg, nup)
+ #endif
+ 
+ /* Call target function in protected mode with all supplied args.
+@@ -1365,7 +1369,7 @@ static int lua_cjson_new(lua_State *l)
+ 
+     /* Register functions with config data as upvalue */
+     json_create_config(l);
+-    luaL_setfuncs(l, reg, 1);
++    compat_luaL_setfuncs(l, reg, 1);
+ 
+     /* Set cjson.null */
+     lua_pushlightuserdata(l, NULL);

--- a/dev-db/redis/metadata.xml
+++ b/dev-db/redis/metadata.xml
@@ -1,9 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer type="person">
+	<maintainer type="person" proxied="proxy">
 		<email>sam@gentoo.org</email>
 		<name>Sam James</name>
+	</maintainer>
+	<maintainer type="person" proxied="yes">
+		<email>arkamar@atlas.cz</email>
+		<name>Petr Vaněk</name>
 	</maintainer>
 	<use>
 		<flag name="tcmalloc">

--- a/dev-db/redis/redis-5.0.14.ebuild
+++ b/dev-db/redis/redis-5.0.14.ebuild
@@ -45,6 +45,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-5.0-sharedlua.patch
 	"${FILESDIR}"/${PN}-5.0.8-ppc-atomic.patch
 	"${FILESDIR}"/${PN}-sentinel-5.0-config.patch
+	"${FILESDIR}"/${PN}-5.0-luajit-2.1-fix.patch
 )
 
 src_prepare() {

--- a/dev-db/redis/redis-6.0.16.ebuild
+++ b/dev-db/redis/redis-6.0.16.ebuild
@@ -60,6 +60,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-6.0.12-sharedlua.patch
 	"${FILESDIR}"/${PN}-5.0.8-ppc-atomic.patch
 	"${FILESDIR}"/${PN}-sentinel-5.0-config.patch
+	"${FILESDIR}"/${PN}-5.0-luajit-2.1-fix.patch
 )
 
 src_prepare() {

--- a/dev-db/redis/redis-6.2.6.ebuild
+++ b/dev-db/redis/redis-6.2.6.ebuild
@@ -60,6 +60,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-6.2.1-sharedlua.patch
 	"${FILESDIR}"/${PN}-6.2.3-ppc-atomic.patch
 	"${FILESDIR}"/${PN}-sentinel-5.0-config.patch
+	"${FILESDIR}"/${PN}-5.0-luajit-2.1-fix.patch
 )
 
 src_prepare() {


### PR DESCRIPTION
Versions with unbundled lua fail to build with `dev-lang/luajit-2.1` with an error message:
```
lua_cjson.c:1300:13: error: static declaration of 'luaL_setfuncs' follows non-static declaration
 1300 | static void luaL_setfuncs (lua_State *l, const luaL_Reg *reg, int nup)
      |             ^~~~~~~~~~~~~
```
This PR fixes this by backporting patch from `lua-cjson` upstream to bundled one (Yes, it sounds weird but we have unbundled lua, but few extensions like `lua-cjson` are still bundled). See commit message for slightly more info.

Additionally, I am joining you as a proxy co-maintainer ;)