### PR TITLE
mate-extra/mate-sensors-applet: Removing config checks

### DIFF
--- a/mate-extra/mate-sensors-applet/files/mate-sensors-applet-1.24.1-dont-check-for-headers.patch
+++ b/mate-extra/mate-sensors-applet/files/mate-sensors-applet-1.24.1-dont-check-for-headers.patch
@@ -1,0 +1,20 @@
+# Removing unnecessary HAVE_STDIO_H and HAVE_LOCALE_H config checks. The
+# HAVE_LOCALE_H also makes fails to build on musl system.
+# Upstream issue: https://github.com/mate-desktop/mate-sensors-applet/issues/123
+# Closes: https://bugs.gentoo.org/777375
+--- a/plugins/i2c-proc/i2c-proc-plugin.c
++++ b/plugins/i2c-proc/i2c-proc-plugin.c
+@@ -20,13 +20,8 @@
+ #include <config.h>
+ #endif /* HAVE_CONFIG_H */
+
+-#ifdef HAVE_STDIO_H
+ #include <stdio.h>
+-#endif /* HAVE_STDIO_H */
+-
+-#ifdef HAVE_LOCALE_H
+ #include <locale.h>
+-#endif
+
+ #include <glib.h>
+ #include <glib/gi18n.h>

--- a/mate-extra/mate-sensors-applet/mate-sensors-applet-1.24.1.ebuild
+++ b/mate-extra/mate-sensors-applet/mate-sensors-applet-1.24.1.ebuild
@@ -43,6 +43,10 @@ DEPEND="${COMMON_DEPEND}
 
 PDEPEND="hddtemp? ( dbus? ( sys-fs/udisks:2 ) )"
 
+PATCHES=(
+    "${FILESDIR}/${PN}-1.24.1-dont-check-for-headers.patch"
+)
+
 src_configure() {
 	local udisks
 


### PR DESCRIPTION
Removing unnecessary HAVE_STDIO_H and HAVE_LOCALE_H config checks. The
HAVE_LOCALE_H also makes fails to build on musl system.

Upstream issue: https://github.com/mate-desktop/mate-sensors-applet/issues/123

Closes: https://bugs.gentoo.org/777375

Signed-off-by: brahmajit das <brahmajit.xyz@gmail.com>