### PR TITLE
mate-extra/mate-power-manager: Fix build on musl

### DIFF
--- a/mate-extra/mate-power-manager/files/mate-power-manager-1.24.3-removing-backtrace.patch
+++ b/mate-extra/mate-power-manager/files/mate-power-manager-1.24.3-removing-backtrace.patch
@@ -1,0 +1,89 @@
+# Instead of deleting the code blocks, just putting them inside a ifndef
+# condition is safer
+--- a/applets/brightness/egg-debug.c
++++ b/applets/brightness/egg-debug.c
+@@ -74,6 +74,7 @@ pk_set_console_mode (guint console_code)
+ 	printf ("%s", command);
+ }
+
++#if (defined(__UCLIBC__) || defined(__GLIBC__))
+ /**
+  * egg_debug_backtrace:
+  **/
+@@ -98,6 +99,7 @@ egg_debug_backtrace (void)
+ 		free (symbols);
+ 	}
+ }
++#endif
+
+ /**
+  * pk_log_line:
+@@ -229,8 +231,10 @@ egg_error_real (const gchar *func, const gchar *file, const int line, const gcha
+ 	pk_print_line (func, file, line, buffer, CONSOLE_RED);
+ 	g_free(buffer);
+
++#if (defined(__UCLIBC__) || defined(__GLIBC__))
+ 	/* we want to fix this! */
+ 	egg_debug_backtrace ();
++#endif
+
+ 	exit (1);
+ }
+--- a/applets/inhibit/egg-debug.c
++++ b/applets/inhibit/egg-debug.c
+@@ -74,6 +74,7 @@ pk_set_console_mode (guint console_code)
+ 	printf ("%s", command);
+ }
+
++#if (defined(__UCLIBC__) || defined(__GLIBC__))
+ /**
+  * egg_debug_backtrace:
+  **/
+@@ -98,6 +99,7 @@ egg_debug_backtrace (void)
+ 		free (symbols);
+ 	}
+ }
++#endif
+
+ /**
+  * pk_log_line:
+@@ -229,8 +231,10 @@ egg_error_real (const gchar *func, const gchar *file, const int line, const gcha
+ 	pk_print_line (func, file, line, buffer, CONSOLE_RED);
+ 	g_free(buffer);
+
++#if (defined(__UCLIBC__) || defined(__GLIBC__))
+ 	/* we want to fix this! */
+ 	egg_debug_backtrace ();
++#endif
+
+ 	exit (1);
+ }
+--- a/src/egg-debug.c
++++ b/src/egg-debug.c
+@@ -74,6 +74,7 @@ pk_set_console_mode (guint console_code)
+ 	printf ("%s", command);
+ }
+
++#if (defined(__UCLIBC__) || defined(__GLIBC__))
+ /**
+  * egg_debug_backtrace:
+  **/
+@@ -98,6 +99,7 @@ egg_debug_backtrace (void)
+ 		free (symbols);
+ 	}
+ }
++#endif
+
+ /**
+  * pk_log_line:
+@@ -229,8 +231,10 @@ egg_error_real (const gchar *func, const gchar *file, const int line, const gcha
+ 	pk_print_line (func, file, line, buffer, CONSOLE_RED);
+ 	g_free(buffer);
+
++#if (defined(__UCLIBC__) || defined(__GLIBC__))
+ 	/* we want to fix this! */
+ 	egg_debug_backtrace ();
++#endif
+
+ 	exit (1);
+ }

--- a/mate-extra/mate-power-manager/files/mate-power-manager-1.24.3-removing-execinfo.patch
+++ b/mate-extra/mate-power-manager/files/mate-power-manager-1.24.3-removing-execinfo.patch
@@ -1,0 +1,38 @@
+# Musl doesn't supply execinfo.h as a result build fails.
+# Closes: https://bugs.gentoo.org/762484
+--- a/applets/brightness/egg-debug.c
++++ b/applets/brightness/egg-debug.c
+@@ -39,7 +39,9 @@
+ #include <sys/stat.h>
+ #include <fcntl.h>
+ #include <time.h>
++#if (defined(__GLIBC__))
+ #include <execinfo.h>
++#endif
+
+ #include "egg-debug.h"
+
+--- a/applets/inhibit/egg-debug.c
++++ b/applets/inhibit/egg-debug.c
+@@ -39,7 +39,9 @@
+ #include <sys/stat.h>
+ #include <fcntl.h>
+ #include <time.h>
++#if (defined(__GLIBC__))
+ #include <execinfo.h>
++#endif
+
+ #include "egg-debug.h"
+
+--- a/src/egg-debug.c
++++ b/src/egg-debug.c
+@@ -39,7 +39,9 @@
+ #include <sys/stat.h>
+ #include <fcntl.h>
+ #include <time.h>
++#if (defined(__GLIBC__))
+ #include <execinfo.h>
++#endif
+
+ #include "egg-debug.h"
+

--- a/mate-extra/mate-power-manager/mate-power-manager-1.24.3.ebuild
+++ b/mate-extra/mate-power-manager/mate-power-manager-1.24.3.ebuild
@@ -58,7 +58,11 @@ DEPEND="${COMMON_DEPEND}
 	x11-base/xorg-proto
 "
 
-PATCHES=( "${FILESDIR}/${PN}-1.24.1-libsecret.patch" )
+PATCHES=(
+	"${FILESDIR}/${PN}-1.24.1-libsecret.patch"
+	"${FILESDIR}/${PN}-1.24.3-removing-execinfo.patch"
+	"${FILESDIR}/${PN}-1.24.3-removing-backtrace.patch"
+)
 
 src_configure() {
 	mate_src_configure \


### PR DESCRIPTION
mate-power-manager was failing to build on musl due to missing
execinfo.h, this header is not provided my musl, and egg_debug_backtrace
fucntion call. The egg_debug_backtrace function just prints some trace
to console.

Closes: https://bugs.gentoo.org/762484

Signed-off-by: brahmajit das <brahmajit.xyz@gmail.com>