### PR TITLE
dev-libs/boost: fix build for 1.79.0

### DIFF
--- a/dev-libs/boost/boost-1.79.0.ebuild
+++ b/dev-libs/boost/boost-1.79.0.ebuild
@@ -17,7 +17,7 @@ S="${WORKDIR}/${PN}_${MY_PV}"
 
 LICENSE="Boost-1.0"
 SLOT="0/${PV}" # ${PV} instead ${MAJOR_V} due to bug 486122
-KEYWORDS="~alpha amd64 arm arm64 ~hppa ~loong ~m68k ~mips ppc ppc64 ~riscv sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris ~x86-winnt"
+KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris ~x86-winnt"
 IUSE="bzip2 context debug doc icu lzma +nls mpi numpy python tools zlib zstd"
 REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
 # the tests will never fail because these are not intended as sanity

--- a/dev-libs/boost/boost-1.79.0.ebuild
+++ b/dev-libs/boost/boost-1.79.0.ebuild
@@ -53,6 +53,7 @@ PATCHES=(
 	# Boost.MPI's __init__.py doesn't work on Py3
 	"${FILESDIR}"/${PN}-1.73-boost-mpi-python-PEP-328.patch
 	"${FILESDIR}"/${PN}-1.74-CVE-2012-2677.patch
+	"${FILESDIR}"/${PN}-1.79.0-fix-mips1-transition.patch
 )
 
 python_bindings_needed() {

--- a/dev-libs/boost/files/boost-1.79.0-fix-mips1-transition.patch
+++ b/dev-libs/boost/files/boost-1.79.0-fix-mips1-transition.patch
@@ -1,0 +1,39 @@
+https://github.com/boostorg/boost/commit/791442bf1ed7a3b14893ed9e73ef2ab32b2a6026, and
+https://github.com/boostorg/config/commit/1a55d1d9c6d1cf7739645080bdd92fe903b4211e without the file renaming.
+
+--- a/boostcpp.jam
++++ b/boostcpp.jam
+@@ -634,7 +634,7 @@ rule address-model ( )
+     return <conditional>@boostcpp.deduce-address-model ;
+ }
+ 
+-local deducable-architectures = arm mips1 power riscv s390x sparc x86 combined ;
++local deducable-architectures = arm mips power riscv s390x sparc x86 combined ;
+ feature.feature deduced-architecture : $(deducable-architectures) : propagated optional composite hidden ;
+ for a in $(deducable-architectures)
+ {
+@@ -645,10 +645,10 @@ rule deduce-architecture ( properties * )
+ {
+     local result ;
+     local filtered = [ toolset-properties $(properties) ] ;
+-    local names = arm mips1 power riscv s390x sparc x86 combined ;
++    local names = arm mips power riscv s390x sparc x86 combined ;
+     local idx = [ configure.find-builds "default architecture" : $(filtered)
+         : /boost/architecture//arm
+-        : /boost/architecture//mips1
++        : /boost/architecture//mips
+         : /boost/architecture//power
+         : /boost/architecture//riscv
+         : /boost/architecture//s390x
+--- a/libs/config/checks/architecture/Jamfile.jam
++++ b/libs/config/checks/architecture/Jamfile.jam
+@@ -18,7 +18,8 @@ obj 64 : 64.cpp ;
+ 
+ obj arm      : arm.cpp ;
+ obj combined : combined.cpp ;
+-obj mips1    : mips1.cpp ;
++obj mips     : mips1.cpp ;
++alias mips1  : mips ; # Backwards compatibility
+ obj power    : power.cpp ;
+ obj riscv    : riscv.cpp ;
+ obj sparc    : sparc.cpp ;

--- a/profiles/arch/loong/package.mask
+++ b/profiles/arch/loong/package.mask
@@ -1,6 +1,2 @@
 # Copyright 2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-
-# WANG Xuerui <xen0n@gentoo.org> (2022-05-13)
-# Fails to build due to bug 843212
->=dev-libs/boost-1.79.0


### PR DESCRIPTION
Fix upstream issue causing configure errors on multiple arches. Changes
are hand-picked into the dist sources tree. One file rename is reverted
to make scrubbed patch work with patch(1).

Bug: https://bugs.gentoo.org/843212
Signed-off-by: WANG Xuerui <xen0n@gentoo.org>