### PR TITLE
net-irc/irker: update systemd service file

### DIFF
--- a/net-irc/irker/files/irkerd.service
+++ b/net-irc/irker/files/irkerd.service
@@ -1,0 +1,21 @@
+# Copyright 2012 Wulf C. Krueger <philantrop@exherbo.org>
+# Copyright 2022 Arthur Zamarin <arthurzam@gentoo.org>
+# Distributed under the terms of the BSD LICENSE
+
+[Unit]
+Description=Internet Relay Chat (IRC) notification daemon
+Requires=network.target
+Documentation=man:irkerd(8) man:irkerhook(1) man:irk(1)
+
+[Service]
+ExecStart=@EPREFIX@/usr/bin/irkerd
+User=irker
+DynamicUser=yes
+NoNewPrivileges=yes
+CapabilityBoundingSet=
+PrivateDevices=yes
+ProtectHome=yes
+
+[Install]
+WantedBy=multi-user.target
+Alias=irker.service

--- a/net-irc/irker/irker-2.22-r2.ebuild
+++ b/net-irc/irker/irker-2.22-r2.ebuild
@@ -39,12 +39,10 @@ src_prepare() {
 	default
 
 	# Rely on systemd eclass for systemd service install
-	sed -i -e "/^SYSTEMDSYSTEMUNITDIR/d" Makefile \
-		|| die "sed failed"
+	sed -e "/^SYSTEMDSYSTEMUNITDIR/d" -i Makefile || die "sed failed"
 
 	# Prefix support
-	sed -i -e "/^ExecStart=/ s:=/:=${EPREFIX}/:" irkerd.service \
-		|| die "sed failed"
+	sed -e "s|@EPREFIX@|${EPREFIX}|" "${FILESDIR}"/irkerd.service > "${WORKDIR}"/irkerd.service || die "sed failed"
 }
 
 src_install() {
@@ -57,7 +55,7 @@ src_install() {
 	newinitd "${FILESDIR}"/irkerd.initd irkerd
 	newconfd "${FILESDIR}"/irkerd.confd irkerd
 
-	systemd_dounit irkerd.service
+	systemd_dounit "${WORKDIR}"/irkerd.service
 
 	docinto examples
 	dodoc filter-example.py filter-test.py


### PR DESCRIPTION
- fix the `User=irker` by also setting `DynamicUser` (no need for new system user, and also much better security)
- Better EPREFIX placeholder
- Some more security options for less capabilities