### PR TITLE
java-pkg-simple.eclass: invoke einstalldocs

### DIFF
--- a/eclass/java-pkg-simple.eclass
+++ b/eclass/java-pkg-simple.eclass
@@ -424,7 +424,7 @@ java-pkg-simple_src_compile() {
 # @DESCRIPTION:
 # src_install for simple single jar java packages. Simply installs
 # ${JAVA_JAR_FILENAME}. It will also install a launcher if
-# ${JAVA_MAIN_CLASS} is set.
+# ${JAVA_MAIN_CLASS} is set. Also invokes einstalldocs.
 java-pkg-simple_src_install() {
 	local sources=sources.lst classes=target/classes apidoc=target/api
 
@@ -455,6 +455,12 @@ java-pkg-simple_src_install() {
 		fi
 		java-pkg_dosrc ${srcdirs}
 	fi
+
+	if [[ ${EAPI} == 5 ]]; then
+		# einstalldocs is only available on EAPI >= 6.
+		return
+	fi
+	einstalldocs
 }
 
 # @FUNCTION: java-pkg-simple_src_test


### PR DESCRIPTION
On EAPI 8 (or newer), invoke einstalldocs in
java-pkg-simple_src_install.

Closes: https://bugs.gentoo.org/789582