### PR TITLE
app-shells/zsh: fix docs building on live ebuild

### DIFF
--- a/app-shells/zsh/zsh-9999.ebuild
+++ b/app-shells/zsh/zsh-9999.ebuild
@@ -127,7 +127,7 @@ src_compile() {
 	default
 
 	if [[ ${PV} == *9999 ]] && use doc ; then
-		emake -C Doc everything
+		emake -C Doc everything pdf dvi
 	fi
 }
 


### PR DESCRIPTION
Original proposed patch was provided in the docs, but adjusted to
generate docs in src_compile instead of src_install.

Closes: https://bugs.gentoo.org/661802
Co-authored-by: Aidan Harris <me@aidanharr.is>
Signed-off-by: Thomas Bracht Laumann Jespersen <t@laumann.xyz>