### PR TITLE
dev-util/debugedit: Fix build on musl

### DIFF
--- a/dev-util/debugedit/debugedit-5.0-r1.ebuild
+++ b/dev-util/debugedit/debugedit-5.0-r1.ebuild
@@ -34,6 +34,7 @@ PATCHES=(
 	"${FILESDIR}"/${P}-readelf.patch
 	"${FILESDIR}"/${P}-zero-dir-entry.patch
 	"${FILESDIR}"/${P}-hppa.patch
+	"${FILESDIR}"/${P}-musl-error.h-fix.patch
 )
 
 src_prepare() {

--- a/dev-util/debugedit/files/debugedit-5.0-musl-error.h-fix.patch
+++ b/dev-util/debugedit/files/debugedit-5.0-musl-error.h-fix.patch
@@ -1,0 +1,50 @@
+# musl doesn't provide error.h as a result debugedit is failing to build on
+# musl.
+#
+# With advice from developer Anthony G. Basile <blueness@gentoo.org> I went
+# with creating a define that redefines the err function. The major
+# improvements over the previous implementation is that this time the patch is
+# smaller and more readable compared to previous implementation.
+#
+# Closes: https://bugs.gentoo.org/714206
+--- a/configure.ac
++++ b/configure.ac
+@@ -57,6 +57,8 @@ PKG_CHECK_MODULES([LIBDW], [libdw])
+
+ # Checks for header files.
+ AC_CHECK_HEADERS([fcntl.h inttypes.h limits.h malloc.h stddef.h stdint.h stdlib.h string.h unistd.h])
++AC_CHECK_HEADERS([error.h],
++		 [AC_DEFINE(HAVE_ERROR_H, 1, [has error.h -- non musl system])])
+
+ # Checks for typedefs, structures, and compiler characteristics.
+ AC_CHECK_HEADER_STDBOOL
+--- a/tools/debugedit.c
++++ b/tools/debugedit.c
+@@ -25,7 +25,12 @@
+ #include <byteswap.h>
+ #include <endian.h>
+ #include <errno.h>
++#ifdef HAVE_ERROR_H
+ #include <error.h>
++#else
++#include <err.h>
++#define error(status, errno, ...) err(status, __VA_ARGS__)
++#endif
+ #include <limits.h>
+ #include <string.h>
+ #include <stdlib.h>
+--- a/tools/sepdebugcrcfix.c
++++ b/tools/sepdebugcrcfix.c
+@@ -29,7 +29,12 @@
+ #include <endian.h>
+ #include <stdio.h>
+ #include <stdlib.h>
++#ifdef HAVE_ERROR_H
+ #include <error.h>
++#else
++#include <err.h>
++#define error(status, errno, ...) err(status, __VA_ARGS__)
++#endif
+ #include <libelf.h>
+ #include <gelf.h>
+


### PR DESCRIPTION
musl doesn't provide error.h as a result debugedit is failing to build on
musl.

There are a couple of ways of handling missing error.h, one of them being using
conditionally including err.h and calling err function instead of error for
musl systems. There are other ways, for example, declaring the error function
ourselves [1] or creating a error.h[2] header that would NOP the error function
calls.

[1]: https://www.openembedded.org/pipermail/openembedded-core/2016-February/117528.html
[2]: https://www.openwall.com/lists/musl/2014/06/29/8

Closes: https://bugs.gentoo.org/714206

Signed-off-by: brahmajit das <brahmajit.xyz@gmail.com>