### PR TITLE
app-emulation/qemu: sync targets USE flags, add loongarch64

### DIFF
--- a/app-emulation/qemu/qemu-9999.ebuild
+++ b/app-emulation/qemu/qemu-9999.ebuild
@@ -52,6 +52,7 @@ COMMON_TARGETS="
 	cris
 	hppa
 	i386
+	loongarch64
 	m68k
 	microblaze
 	microblazeel

--- a/profiles/desc/qemu_softmmu_targets.desc
+++ b/profiles/desc/qemu_softmmu_targets.desc
@@ -12,6 +12,7 @@ avr - system emulation target
 cris - system emulation target
 hppa - system emulation target
 i386 - system emulation target
+loongarch64 - system emulation target
 m68k - system emulation target
 microblazeel - system emulation target
 microblaze - system emulation target

--- a/profiles/desc/qemu_user_targets.desc
+++ b/profiles/desc/qemu_user_targets.desc
@@ -14,6 +14,7 @@ cris - userspace emulation target
 hexagon - Qualcomm hexagon userspace emulation target
 hppa - userspace emulation target
 i386 - userspace emulation target
+loongarch64 - userspace emulation target
 m68k - userspace emulation target
 microblazeel - userspace emulation target
 microblaze - userspace emulation target


### PR DESCRIPTION
This is fully upstream as of https://gitlab.com/qemu-project/qemu/-/commit/1437479e5ee1a49ccd84cad9e7b010fb2ee9d805.

Signed-off-by: WANG Xuerui <xen0n@gentoo.org>