### PR TITLE
net-misc/dahdi-tools: rev-bump to fix two bugs

### DIFF
--- a/net-misc/dahdi-tools/dahdi-tools-3.1.0-r4.ebuild
+++ b/net-misc/dahdi-tools/dahdi-tools-3.1.0-r4.ebuild
@@ -54,7 +54,7 @@ src_install() {
 
 	# install init scripts
 	newinitd "${FILESDIR}"/dahdi.init2 dahdi
-	newinitd "${FILESDIR}"/dahdi-autoconf.init-3.1.0-r3 dahdi-autoconf
+	newinitd "${FILESDIR}"/dahdi-autoconf.init-3.1.0-r4 dahdi-autoconf
 	newconfd "${FILESDIR}"/dahdi-autoconf.conf2 dahdi-autoconf
 
 	bashcomp_alias dahdi $(sed -nre 's/^complete -F .* //p' "${ED}${bashcompdir}/dahdi" ||
@@ -66,5 +66,9 @@ src_install() {
 }
 
 pkg_postinst() {
+	udev_reload
+}
+
+pkg_postrm() {
 	udev_reload
 }

--- a/net-misc/dahdi-tools/files/dahdi-autoconf.init-3.1.0-r4
+++ b/net-misc/dahdi-tools/files/dahdi-autoconf.init-3.1.0-r4
@@ -150,20 +150,20 @@ dahdi_conf_span() {
 
 	case "${type}" in
 		digital-TE)
-			cfunc+="bri_te"
+			cfunc="${cfunc}bri_te"
 		;;
 		digital-NT)
-			cfunc+="bri_nt"
+			cfunc="${cfunc}bri_nt"
 		;;
 		digital-[TE]1)
-			cfunc+="$(echo "${type##*-}" | tr 'TE' 'te')"
+			cfunc="${cfunc}$(echo "${type##*-}" | tr 'TE' 'te')"
 			# Use CPE by default.  Unfortunately there is no easy
 			# way to detect CPE vs NET as far as I know and specifying
 			# in a config that you want NET mode seems the sanest way.
 			if yesno "${vname}"; then
-				cfunc+="_net"
+				cfunc="${cfunc}_net"
 			else
-				cfunc+="_cpe"
+				cfunc="${cfunc}_cpe"
 			fi
 		;;
 		*)


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/855467
Closes: https://bugs.gentoo.org/855464

The latter was fixed, then I didn't focus properly when updating for T1
support.

Package-Manager: Portage-3.0.30, Repoman-3.0.3
Signed-off-by: Jaco Kroon <jaco@uls.co.za>