### PR TITLE
games-util/gamemode: Fix build on musl

### DIFF
--- a/games-util/gamemode/files/gamemode-1.6.1-signal_h-musl.patch
+++ b/games-util/gamemode/files/gamemode-1.6.1-signal_h-musl.patch
@@ -1,0 +1,39 @@
+https://github.com/FeralInteractive/gamemode/pull/368
+
+From 4079d246805e9ce6c1f5ee49116013eb9f5225d7 Mon Sep 17 00:00:00 2001
+From: Alfred Persson Forsberg <cat@catcream.org>
+Date: Tue, 5 Jul 2022 17:18:19 +0000
+Subject: [PATCH] Fix build on musl libc
+
+This simple patch includes signal.h in daemon/gamemode-context.c to fix building gamemode on musl
+libc.
+
+This has been tested Gentoo musl and Alpine (also Gentoo glibc to
+ensure no multiple defined symbols/other errors for glibc).
+
+> ../daemon/gamemode-context.c: In function 'game_mode_context_auto_expire':
+> ../daemon/gamemode-context.c:421:29: error: implicit declaration of function 'kill' [-Werror=implicit-function-declaration]
+>   421 |                         if (kill(client->pid, 0) != 0) {
+>       |                             ^~~~
+> ../daemon/gamemode-context.c:421:29: warning: nested extern declaration of 'kill' [-Wnested-externs]
+
+Signed-off-by: Alfred Persson Forsberg <cat@catcream.org>
+---
+ daemon/gamemode-context.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/daemon/gamemode-context.c b/daemon/gamemode-context.c
+index 3b5a61b..feba2b1 100644
+--- a/daemon/gamemode-context.c
++++ b/daemon/gamemode-context.c
+@@ -45,6 +45,7 @@ POSSIBILITY OF SUCH DAMAGE.
+ #include <assert.h>
+ #include <fcntl.h>
+ #include <pthread.h>
++#include <signal.h>
+ #include <stdatomic.h>
+ #include <stdlib.h>
+ #include <sys/time.h>
+-- 
+2.35.1
+

--- a/games-util/gamemode/gamemode-1.6.1.ebuild
+++ b/games-util/gamemode/gamemode-1.6.1.ebuild
@@ -42,6 +42,8 @@ DOCS=(
 	example/gamemode.ini
 )
 
+PATCHES=( "${FILESDIR}/${PN}-1.6.1-signal_h-musl.patch" )
+
 pkg_pretend() {
 	elog
 	elog "GameMode needs a kernel capable of SCHED_ISO to use its soft realtime"


### PR DESCRIPTION
This simple patch includes signal.h in daemon/gamemode-context.c to fix building gamemode on musl
libc.

This has been tested Gentoo musl and Alpine (also Gentoo glibc to
ensure no multiple defined symbols/other errors for glibc).

> ../daemon/gamemode-context.c: In function 'game_mode_context_auto_expire':
> ../daemon/gamemode-context.c:421:29: error: implicit declaration of function 'kill' [-Werror=implicit-function-declaration]
>   421 |                         if (kill(client->pid, 0) != 0) {
>       |                             ^~~~
> ../daemon/gamemode-context.c:421:29: warning: nested extern declaration of 'kill' [-Wnested-externs]

https://github.com/FeralInteractive/gamemode/pull/368
Signed-off-by: Alfred Persson Forsberg <cat@catcream.org>