### PR TITLE
media-video/pipewire: drop dep on media-plugins/alsa-plugins[pulseaudio]

### DIFF
--- a/media-video/pipewire/pipewire-0.3.53_p20220704-r1.ebuild
+++ b/media-video/pipewire/pipewire-0.3.53_p20220704-r1.ebuild
@@ -93,7 +93,6 @@ RDEPEND="
 	pipewire-alsa? (
 		>=media-libs/alsa-lib-1.1.7[${MULTILIB_USEDEP}]
 	)
-	!pipewire-alsa? ( media-plugins/alsa-plugins[${MULTILIB_USEDEP},pulseaudio] )
 	sound-server? (
 		!media-sound/pulseaudio[daemon(+)]
 		!media-sound/pulseaudio-daemon
@@ -380,6 +379,10 @@ pkg_postinst() {
 
 	optfeature_header "The following can be installed for optional runtime features:"
 	optfeature "restricted realtime capabilities via D-Bus" sys-auth/rtkit
+
+	if use sound-server && ! use pipewire-alsa; then
+		optfeature "ALSA plugin to use PulseAudio interface for output" "media-plugins/alsa-plugins[pulseaudio]"
+	fi
 
 	if has_version 'net-misc/ofono' ; then
 		ewarn "Native backend has become default. Please disable oFono via:"

--- a/media-video/pipewire/pipewire-9999.ebuild
+++ b/media-video/pipewire/pipewire-9999.ebuild
@@ -93,7 +93,6 @@ RDEPEND="
 	pipewire-alsa? (
 		>=media-libs/alsa-lib-1.1.7[${MULTILIB_USEDEP}]
 	)
-	!pipewire-alsa? ( media-plugins/alsa-plugins[${MULTILIB_USEDEP},pulseaudio] )
 	sound-server? (
 		!media-sound/pulseaudio[daemon(+)]
 		!media-sound/pulseaudio-daemon
@@ -380,6 +379,10 @@ pkg_postinst() {
 
 	optfeature_header "The following can be installed for optional runtime features:"
 	optfeature "restricted realtime capabilities via D-Bus" sys-auth/rtkit
+
+	if use sound-server && ! use pipewire-alsa; then
+		optfeature "ALSA plugin to use PulseAudio interface for output" "media-plugins/alsa-plugins[pulseaudio]"
+	fi
 
 	if has_version 'net-misc/ofono' ; then
 		ewarn "Native backend has become default. Please disable oFono via:"


### PR DESCRIPTION
Instead, emit an optfeature message if sound-server is enabled and pipewire-alsa is disabled.

This allows users to use pipewire without installing any ALSA plugins.