### PR TITLE
media-video/pipewire: Do not pull pulseaudio alsa plugin unconditionally

### DIFF
--- a/media-video/pipewire/pipewire-0.3.53-r1.ebuild
+++ b/media-video/pipewire/pipewire-0.3.53-r1.ebuild
@@ -90,11 +90,11 @@ RDEPEND="
 		!media-sound/jack2
 	)
 	lv2? ( media-libs/lilv )
-	pipewire-alsa? (
-		>=media-libs/alsa-lib-1.1.7[${MULTILIB_USEDEP}]
-	)
-	!pipewire-alsa? ( media-plugins/alsa-plugins[${MULTILIB_USEDEP},pulseaudio] )
 	sound-server? (
+		pipewire-alsa? (
+			>=media-libs/alsa-lib-1.1.7[${MULTILIB_USEDEP}]
+		)
+		!pipewire-alsa? ( media-plugins/alsa-plugins[${MULTILIB_USEDEP},pulseaudio] )
 		!media-sound/pulseaudio[daemon(+)]
 		!media-sound/pulseaudio-daemon
 	)

--- a/media-video/pipewire/pipewire-0.3.53_p20220704.ebuild
+++ b/media-video/pipewire/pipewire-0.3.53_p20220704.ebuild
@@ -90,11 +90,11 @@ RDEPEND="
 		!media-sound/jack2
 	)
 	lv2? ( media-libs/lilv )
-	pipewire-alsa? (
-		>=media-libs/alsa-lib-1.1.7[${MULTILIB_USEDEP}]
-	)
-	!pipewire-alsa? ( media-plugins/alsa-plugins[${MULTILIB_USEDEP},pulseaudio] )
 	sound-server? (
+		pipewire-alsa? (
+			>=media-libs/alsa-lib-1.1.7[${MULTILIB_USEDEP}]
+		)
+		!pipewire-alsa? ( media-plugins/alsa-plugins[${MULTILIB_USEDEP},pulseaudio] )
 		!media-sound/pulseaudio[daemon(+)]
 		!media-sound/pulseaudio-daemon
 	)


### PR DESCRIPTION
If USE sound-server is not set, there is no reason to pull alsa plugin for
pulseaudio too.

Signed-off-by: Igor V. Kovalenko <igor.v.kovalenko@gmail.com>