### PR TITLE
dev-java/openjdk: Fix build for musl

### DIFF
--- a/dev-java/openjdk/files/openjdk-17.0.3-fix-nullptr-cast.patch
+++ b/dev-java/openjdk/files/openjdk-17.0.3-fix-nullptr-cast.patch
@@ -1,0 +1,111 @@
+https://git.alpinelinux.org/aports/tree/community/openjdk17/FixNullPtrCast.patch
+https://github.com/openjdk/jdk17u/pull/347
+
+See also:
+https://www.openwall.com/lists/musl/2013/01/09/1
+https://git.musl-libc.org/cgit/musl/tree/include/unistd.h#n20
+
+Subject: Fix cast errors with latest GCC (11.2)
+Upstream: No
+Author: Simon Frankenberger <simon-alpine@fraho.eu>
+
+This patch fixes multiple casting errors reported by GCC 11.2
+
+--- old/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.inline.hpp
++++ new/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.inline.hpp
+@@ -205,7 +205,7 @@
+ 
+   // Note: We don't need a keep-alive-barrier here. We already enqueue any loaded reference for SATB anyway,
+   // because it must be the previous value.
+-  res = load_reference_barrier(decorators, res, reinterpret_cast<T*>(NULL));
++  res = load_reference_barrier(decorators, res, static_cast<T*>(NULL));
+   satb_enqueue(res);
+   return res;
+ }
+@@ -216,7 +216,7 @@
+   oop previous = RawAccess<>::oop_atomic_xchg(addr, new_value);
+   // Note: We don't need a keep-alive-barrier here. We already enqueue any loaded reference for SATB anyway,
+   // because it must be the previous value.
+-  previous = load_reference_barrier<T>(decorators, previous, reinterpret_cast<T*>(NULL));
++  previous = load_reference_barrier<T>(decorators, previous, static_cast<T*>(NULL));
+   satb_enqueue(previous);
+   return previous;
+ }
+--- old/src/hotspot/share/oops/access.hpp
++++ new/src/hotspot/share/oops/access.hpp
+@@ -294,8 +294,8 @@
+   static inline void arraycopy(arrayOop src_obj, size_t src_offset_in_bytes,
+                                arrayOop dst_obj, size_t dst_offset_in_bytes,
+                                size_t length) {
+-    AccessT::arraycopy(src_obj, src_offset_in_bytes, reinterpret_cast<const T*>(NULL),
+-                       dst_obj, dst_offset_in_bytes, reinterpret_cast<T*>(NULL),
++    AccessT::arraycopy(src_obj, src_offset_in_bytes, static_cast<const T*>(NULL),
++                       dst_obj, dst_offset_in_bytes, static_cast<T*>(NULL),
+                        length);
+   }
+ 
+@@ -303,7 +303,7 @@
+   static inline void arraycopy_to_native(arrayOop src_obj, size_t src_offset_in_bytes,
+                                          T* dst,
+                                          size_t length) {
+-    AccessT::arraycopy(src_obj, src_offset_in_bytes, reinterpret_cast<const T*>(NULL),
++    AccessT::arraycopy(src_obj, src_offset_in_bytes, static_cast<const T*>(NULL),
+                        NULL, 0, dst,
+                        length);
+   }
+@@ -313,15 +313,15 @@
+                                            arrayOop dst_obj, size_t dst_offset_in_bytes,
+                                            size_t length) {
+     AccessT::arraycopy(NULL, 0, src,
+-                       dst_obj, dst_offset_in_bytes, reinterpret_cast<T*>(NULL),
++                       dst_obj, dst_offset_in_bytes, static_cast<T*>(NULL),
+                        length);
+   }
+ 
+   static inline bool oop_arraycopy(arrayOop src_obj, size_t src_offset_in_bytes,
+                                    arrayOop dst_obj, size_t dst_offset_in_bytes,
+                                    size_t length) {
+-    return AccessT::oop_arraycopy(src_obj, src_offset_in_bytes, reinterpret_cast<const HeapWord*>(NULL),
+-                                  dst_obj, dst_offset_in_bytes, reinterpret_cast<HeapWord*>(NULL),
++    return AccessT::oop_arraycopy(src_obj, src_offset_in_bytes, static_cast<const HeapWord*>(NULL),
++                                  dst_obj, dst_offset_in_bytes, static_cast<HeapWord*>(NULL),
+                                   length);
+   }
+ 
+--- old/src/hotspot/cpu/x86/interp_masm_x86.cpp
++++ new/src/hotspot/cpu/x86/interp_masm_x86.cpp
+@@ -1122,7 +1122,7 @@
+ 
+     bind(loop);
+     // check if current entry is used
+-    cmpptr(Address(rmon, BasicObjectLock::obj_offset_in_bytes()), (int32_t) NULL);
++    cmpptr(Address(rmon, BasicObjectLock::obj_offset_in_bytes()), 0);
+     jcc(Assembler::notEqual, exception);
+ 
+     addptr(rmon, entry_size); // otherwise advance to next entry
+--- old/src/hotspot/cpu/x86/interpreterRT_x86_64.cpp
++++ new/src/hotspot/cpu/x86/interpreterRT_x86_64.cpp
+@@ -443,10 +443,10 @@
+     _from -= Interpreter::stackElementSize;
+ 
+     if (_num_int_args < Argument::n_int_register_parameters_c-1) {
+-      *_int_args++ = (*from_addr == 0) ? NULL : (intptr_t)from_addr;
++      *_int_args++ = (*from_addr == 0) ? (intptr_t) 0 : (intptr_t) from_addr;
+       _num_int_args++;
+     } else {
+-      *_to++ = (*from_addr == 0) ? NULL : (intptr_t) from_addr;
++      *_to++ = (*from_addr == 0) ? (intptr_t) 0 : (intptr_t) from_addr;
+     }
+   }
+ 
+--- old/src/hotspot/cpu/aarch64/interpreterRT_aarch64.cpp
++++ new/src/hotspot/cpu/aarch64/interpreterRT_aarch64.cpp
+@@ -267,7 +267,7 @@
+ 
+   virtual void pass_object() {
+     intptr_t* addr = single_slot_addr();
+-    intptr_t value = *addr == 0 ? NULL : (intptr_t)addr;
++    intptr_t value = *addr == 0 ? (intptr_t) 0 : (intptr_t)addr;
+     if (pass_gpr(value) < 0) {
+       pass_stack<>(value);
+     }

--- a/dev-java/openjdk/openjdk-17.0.3_p7-r1.ebuild
+++ b/dev-java/openjdk/openjdk-17.0.3_p7-r1.ebuild
@@ -107,6 +107,8 @@ DEPEND="
 
 S="${WORKDIR}/jdk${SLOT}u-jdk-${MY_PV//+/-}"
 
+PATCHES=( "${FILESDIR}"/${PN}-17.0.3-fix-nullptr-cast.patch )
+
 # The space required to build varies wildly depending on USE flags,
 # ranging from 2GB to 16GB. This function is certainly not exact but
 # should be close enough to be useful.


### PR DESCRIPTION
On musl libc NULL is defined as nullptr for stdc++>=11, which breaks some implicit
conversions and reinterpret_cast's.

See: https://www.openwall.com/lists/musl/2013/01/09/1,
https://git.musl-libc.org/cgit/musl/tree/include/unistd.h#n20

This patch is taken from
https://git.alpinelinux.org/aports/tree/community/openjdk17/FixNullPtrCast.patch

Upstream PR: https://github.com/openjdk/jdk17u/pull/347
The master branch needed some additional fixing though which is not
included in this patch (for 17.0.3).

Signed-off-by: Alfred Persson Forsberg <cat@catcream.org>