### PR TITLE
net-analyzer/flow-tools: Remove LibreSSL patch

### DIFF
--- a/net-analyzer/flow-tools/files/flow-tools-0.68.5.1-openssl11.patch
+++ b/net-analyzer/flow-tools/files/flow-tools-0.68.5.1-openssl11.patch
@@ -1,20 +1,5 @@
 --- a/lib/ftxlate.c
 +++ b/lib/ftxlate.c
-@@ -34,6 +34,14 @@
- #include <openssl/ssl.h>
- #include <openssl/evp.h>
- #undef free_func
-+
-+/* fixup LibreSSL OpenSSL version numbering */
-+#include <openssl/opensslv.h>
-+#if (defined LIBRESSL_VERSION_NUMBER && OPENSSL_VERSION_NUMBER == 0x20000000L)
-+#undef OPENSSL_VERSION_NUMBER
-+#define OPENSSL_VERSION_NUMBER 0x1000107fL
-+#endif
-+
- #endif /* HAVE_OPENSSL */
- 
- #include <sys/time.h>
 @@ -2040,11 +2048,13 @@
  
  


### PR DESCRIPTION
This also fixes the build with libressl-3.5.x from the gentoo overlay.