### PR TITLE
dev-libs/libfmt-9.0.0 fix dependent packages requiring an older version

### DIFF
--- a/gui-apps/waybar/waybar-0.9.12.ebuild
+++ b/gui-apps/waybar/waybar-0.9.12.ebuild
@@ -35,6 +35,7 @@ DEPEND="
 	dev-libs/libinput:=
 	dev-libs/libsigc++:2
 	>=dev-libs/libfmt-7.0.0:=
+	<dev-libs/libfmt-9.0.0:=
 	>=dev-libs/spdlog-1.8.5:=
 	dev-libs/date:=
 	dev-libs/wayland

--- a/gui-apps/waybar/waybar-0.9.13.ebuild
+++ b/gui-apps/waybar/waybar-0.9.13.ebuild
@@ -35,6 +35,7 @@ DEPEND="
 	dev-libs/libinput:=
 	dev-libs/libsigc++:2
 	>=dev-libs/libfmt-7.0.0:=
+	<dev-libs/libfmt-9.0.0:=
 	>=dev-libs/spdlog-1.8.5:=
 	dev-libs/date:=
 	dev-libs/wayland

--- a/media-video/mkvtoolnix/mkvtoolnix-60.0.0.ebuild
+++ b/media-video/mkvtoolnix/mkvtoolnix-60.0.0.ebuild
@@ -28,6 +28,7 @@ RDEPEND="
 	>=dev-libs/boost-1.66:=
 	>=dev-libs/libebml-1.4.0:=
 	>=dev-libs/libfmt-6.1.0:=
+	<dev-libs/libfmt-9.0.0:=
 	dev-libs/libpcre2:=
 	dev-libs/pugixml:=
 	media-libs/flac:=

--- a/media-video/mkvtoolnix/mkvtoolnix-61.0.0.ebuild
+++ b/media-video/mkvtoolnix/mkvtoolnix-61.0.0.ebuild
@@ -28,6 +28,7 @@ RDEPEND="
 	>=dev-libs/boost-1.66:=
 	>=dev-libs/libebml-1.4.0:=
 	>=dev-libs/libfmt-6.1.0:=
+	<dev-libs/libfmt-9.0.0:=
 	dev-libs/libpcre2:=
 	dev-libs/pugixml:=
 	media-libs/flac:=

--- a/media-video/mkvtoolnix/mkvtoolnix-64.0.0.ebuild
+++ b/media-video/mkvtoolnix/mkvtoolnix-64.0.0.ebuild
@@ -29,6 +29,7 @@ RDEPEND="
 	dev-libs/gmp:=
 	>=dev-libs/libebml-1.4.2:=
 	>=dev-libs/libfmt-8.0.1:=
+	<dev-libs/libfmt-9.0.0:=
 	>=dev-libs/pugixml-1.11:=
 	media-libs/flac:=
 	>=media-libs/libmatroska-1.6.3:=

--- a/media-video/mkvtoolnix/mkvtoolnix-67.0.0.ebuild
+++ b/media-video/mkvtoolnix/mkvtoolnix-67.0.0.ebuild
@@ -29,6 +29,7 @@ RDEPEND="
 	dev-libs/gmp:=
 	>=dev-libs/libebml-1.4.2:=
 	>=dev-libs/libfmt-8.0.1:=
+	<dev-libs/libfmt-9.0.0:=
 	>=dev-libs/pugixml-1.11:=
 	media-libs/flac:=
 	>=media-libs/libmatroska-1.6.3:=


### PR DESCRIPTION
Adding an upper bound to libfmt for waybar and mkvtoolnix since they fail to build with the new version.