### PR TITLE
app-accessibility/speech-dispatcher: Fix build for musl

### DIFF
--- a/app-accessibility/speech-dispatcher/files/speech-dispatcher-0.11.1-include-pthread_h.patch
+++ b/app-accessibility/speech-dispatcher/files/speech-dispatcher-0.11.1-include-pthread_h.patch
@@ -1,0 +1,22 @@
+This fixes pthread_mutex_t being undefined on musl libc.
+
+https://bugs.gentoo.org/833347
+---
+ src/modules/module_main.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/modules/module_main.h b/src/modules/module_main.h
+index 7d9ed6d..f1d4c65 100644
+--- a/src/modules/module_main.h
++++ b/src/modules/module_main.h
+@@ -31,6 +31,7 @@
+ 
+ #include <speechd_types.h>
+ #include <spd_audio.h>
++#include <pthread.h>
+ 
+ #ifdef __cplusplus
+ extern "C" {
+-- 
+2.35.1
+

--- a/app-accessibility/speech-dispatcher/files/speech-dispatcher-0.11.1-remove-unused-variable-musl.patch
+++ b/app-accessibility/speech-dispatcher/files/speech-dispatcher-0.11.1-remove-unused-variable-musl.patch
@@ -1,0 +1,35 @@
+https://github.com/brailcom/speechd/commit/57e2c131f03ae8244b0478e449d86dea7d5724d8
+
+musl additionally requires explicitly including sys/stat.h header for stat.
+Including that would've been the proper patch if 'st' was actually used.
+
+From 57e2c131f03ae8244b0478e449d86dea7d5724d8 Mon Sep 17 00:00:00 2001
+From: Samuel Thibault <samuel.thibault@ens-lyon.org>
+Date: Sun, 13 Mar 2022 18:35:59 +0100
+Subject: [PATCH] Drop unused variable
+
+---
+ src/modules/espeak.c | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/src/modules/espeak.c b/src/modules/espeak.c
+index 94a01197..1a47bb09 100644
+--- a/src/modules/espeak.c
++++ b/src/modules/espeak.c
+@@ -3,7 +3,7 @@
+  * espeak.c - Speech Dispatcher backend for espeak
+  *
+  * Copyright (C) 2007 Brailcom, o.p.s.
+- * Copyright (C) 2019-2021 Samuel Thibault <samuel.thibault@ens-lyon.org>
++ * Copyright (C) 2019-2022 Samuel Thibault <samuel.thibault@ens-lyon.org>
+  *
+  * This is free software; you can redistribute it and/or modify it
+  * under the terms of the GNU General Public License as published by
+@@ -880,7 +880,6 @@ static SPDVoice **espeak_list_synthesis_voices()
+ 		{
+ 			const char *identifier = espeak_mbrola[j]->identifier;
+ 			char *voicename, *dash, *path;
+-			struct stat st;
+ 
+ 			totnummbrola++;
+ 

--- a/app-accessibility/speech-dispatcher/speech-dispatcher-0.11.1.ebuild
+++ b/app-accessibility/speech-dispatcher/speech-dispatcher-0.11.1.ebuild
@@ -35,6 +35,11 @@ BDEPEND="
 	>=sys-devel/gettext-0.19.8
 	virtual/pkgconfig"
 
+PATCHES=(
+	"${FILESDIR}"/${PN}-0.11.1-include-pthread_h.patch
+	"${FILESDIR}"/${PN}-0.11.1-remove-unused-variable-musl.patch
+)
+
 src_configure() {
 	# bug 573732
 	export GIT_CEILING_DIRECTORIES="${WORKDIR}"


### PR DESCRIPTION
pthread_mutex_t and stat are undefined, including pthread.h and
sys/stat.h fixes these errors.

Closes: https://bugs.gentoo.org/833347
Signed-off-by: Alfred Persson Forsberg <cat@catcream.org>