### PR TITLE
dev-util/rizin: remove version constraint for capstone dependency

### DIFF
--- a/dev-util/rizin/files/rizin-0.4.0-capstone.patch
+++ b/dev-util/rizin/files/rizin-0.4.0-capstone.patch
@@ -1,0 +1,22 @@
+From 2b8104bc5e763ed841d6dbffacbeaf02e86b8421 Mon Sep 17 00:00:00 2001
+From: Mario Haustein <mario.haustein@hrz.tu-chemnitz.de>
+Date: Thu, 7 Jul 2022 07:50:10 +0200
+Subject: [PATCH] Fix capstone include directory
+
+---
+ librz/analysis/arch/arm/arm_il64.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/librz/analysis/arch/arm/arm_il64.c b/librz/analysis/arch/arm/arm_il64.c
+index 2e9da10aece..6b552596c9e 100644
+--- a/librz/analysis/arch/arm/arm_il64.c
++++ b/librz/analysis/arch/arm/arm_il64.c
+@@ -2,7 +2,7 @@
+ // SPDX-License-Identifier: LGPL-3.0-only
+ 
+ #include <rz_analysis.h>
+-#include <capstone.h>
++#include <capstone/capstone.h>
+ 
+ #include "arm_cs.h"
+ 

--- a/dev-util/rizin/rizin-0.4.0-r1.ebuild
+++ b/dev-util/rizin/rizin-0.4.0-r1.ebuild
@@ -1,0 +1,95 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+PYTHON_COMPAT=( python3_{9..11} )
+
+# This is the commit that the CI for the release commit used
+BINS_COMMIT="64a6f26369bf5893ecc20cb8984a5ad506ef8566"
+
+inherit meson python-any-r1
+
+DESCRIPTION="reverse engineering framework for binary analysis"
+HOMEPAGE="https://rizin.re/"
+
+SRC_URI="mirror+https://github.com/rizinorg/rizin/releases/download/v${PV}/rizin-src-v${PV}.tar.xz
+	test? ( https://github.com/rizinorg/rizin-testbins/archive/${BINS_COMMIT}.tar.gz -> rizin-testbins-${BINS_COMMIT}.tar.gz )"
+KEYWORDS="~amd64 ~arm64 ~x86"
+
+LICENSE="Apache-2.0 BSD LGPL-3 MIT"
+SLOT="0/${PV}"
+IUSE="test"
+
+# Need to audit licenses of the binaries used for testing
+RESTRICT="fetch !test? ( test )"
+
+RDEPEND="
+	sys-apps/file
+	app-arch/lz4:0=
+	dev-libs/capstone:0=
+	dev-libs/libuv:0=
+	dev-libs/libzip:0=
+	dev-libs/openssl:0=
+	>=dev-libs/tree-sitter-0.19.0
+	dev-libs/xxhash
+	sys-libs/zlib:0=
+"
+DEPEND="${RDEPEND}"
+BDEPEND="${PYTHON_DEPS}"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-0.4.0-never-rebuild-parser.patch"
+	"${FILESDIR}/${P}-capstone.patch"
+)
+
+S="${WORKDIR}/${PN}-v${PV}"
+
+src_prepare() {
+	default
+
+	local py_to_mangle=(
+		librz/core/cmd_descs/cmd_descs_generate.py
+		subprojects/lz4-1.9.3/contrib/meson/meson/GetLz4LibraryVersion.py
+		subprojects/lz4-1.9.3/contrib/meson/meson/InstallSymlink.py
+		subprojects/lz4-1.9.3/tests/test-lz4-list.py
+		subprojects/lz4-1.9.3/tests/test-lz4-speed.py
+		subprojects/lz4-1.9.3/tests/test-lz4-versions.py
+		sys/clang-format.py
+		test/fuzz/scripts/fuzz_rz_asm.py
+		test/scripts/gdbserver.py
+	)
+
+	python_fix_shebang "${py_to_mangle[@]}"
+
+	if use test; then
+		cp -r "${WORKDIR}/rizin-testbins-${BINS_COMMIT}" "${S}/test/bins" || die
+		cp -r "${WORKDIR}/rizin-testbins-${BINS_COMMIT}" "${S}" || die
+	fi
+}
+
+src_configure() {
+	local emesonargs=(
+		-Dcli=enabled
+		-Duse_sys_capstone=enabled
+		-Duse_sys_magic=enabled
+		-Duse_sys_libzip=enabled
+		-Duse_sys_zlib=enabled
+		-Duse_sys_lz4=enabled
+		-Duse_sys_xxhash=enabled
+		-Duse_sys_openssl=enabled
+		-Duse_sys_tree_sitter=enabled
+
+		$(meson_use test enable_tests)
+		$(meson_use test enable_rz_test)
+	)
+	meson_src_configure
+}
+
+src_test() {
+	# We can select running either unit or integration tests, or all of
+	# them by not passing --suite. According to upstream, integration
+	# tests are more fragile and unit tests are sufficient for testing
+	# packaging, so only run those.
+	meson_src_test --suite unit
+}


### PR DESCRIPTION
Starting with Rizin 0.4.0 the restriction to Capstone 4 is not needed anymore. There is just a small bug which has to be patched downstream and is already reported upstream (https://github.com/rizinorg/rizin/pull/2789)

Package-Manager: Portage-3.0.30, Repoman-3.0.3
Signed-off-by: Mario Haustein <mario.haustein@hrz.tu-chemnitz.de>