### PR TITLE
media-sound/pulseaudio: Bump metapackage to 16.1, drop default USE daemon

### DIFF
--- a/media-sound/pulseaudio/pulseaudio-16.1.ebuild
+++ b/media-sound/pulseaudio/pulseaudio-16.1.ebuild
@@ -1,0 +1,29 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="7"
+
+inherit multilib-minimal
+
+DESCRIPTION="A meta package for PulseAudio (networked sound server)"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/PulseAudio/"
+SRC_URI=""
+
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86 ~amd64-linux ~x86-linux"
+
+LICENSE="metapackage"
+
+SLOT="0"
+
+# NOTE: bluetooth and ofono-headset are passed through to
+# pulseaudio-daemon dependency to make sure users who have bluetooth enabled
+# just for pulseaudio package will also get these enabled via metapackage.
+IUSE="bluetooth daemon +glib jack ofono-headset"
+
+RDEPEND="
+	>=media-libs/libpulse-${PV}[glib?,${MULTILIB_USEDEP}]
+	daemon? ( >=media-sound/pulseaudio-daemon-${PV}[bluetooth?,glib?,jack?,ofono-headset?] )
+"
+DEPEND="${RDEPEND}"
+
+S="${WORKDIR}"


### PR DESCRIPTION
All packages which need real pulseaudio daemon (e.g. need extension modules which are only implemented for real pulseaudio daemon, or just work with real pulseaudio daemon only) already depend on `media-sound/pulseaudio-daemon` as an alternative to `media-sound/pulseaudio[daemon]`.

Drop default USE `+daemon` from metapackage to allow cleaning up `media-sound/pulseaudio-daemon` if USE `daemon` is not set by user.

Client libs package `media-libs/libpulse` will still make sure that one of available pulseaudio server implementations is installed, but will not enforce any particular choice.

To change pulseaudio server implementation to pipewire make sure neither `media-sound/pulseaudio` nor `media-sound/pulseaudio-daemon` are in the `@world` and USE `daemon` is not set for `media-sound/pulseaudio`,
then set USE `sound-server` for `media-video/pipewire` and update as usual:

    emerge -avtuDU @world

To change pulseaudio server implementation to `pulseaudio-daemon` remove USE `sound-server` from `media-video/pipewire` and update like this:

    emerge -avtuDU --oneshot @world pulseaudio-daemon

Bug: https://bugs.gentoo.org/856745