### PR TITLE
app-crypt/tpm2-tss: Remove tss user and group creation machinery

### DIFF
--- a/app-crypt/tpm2-tss/files/tpm2-tss-3.2.0-Dont-run-systemd-sysusers-in-Makefile.patch
+++ b/app-crypt/tpm2-tss/files/tpm2-tss-3.2.0-Dont-run-systemd-sysusers-in-Makefile.patch
@@ -1,0 +1,57 @@
+diff --git a/Makefile.am b/Makefile.am
+index ce19aac3..22a8c075 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -498,10 +498,9 @@ fapi-config.json: dist/fapi-config.json.in
+ 		-e 's|[@]userstatedir@|$(userstatedir)|g' \
+ 		< "$<" > "$@"
+ 
+-sysusers_DATA = dist/sysusers.d/tpm2-tss.conf
+ tmpfiles_DATA = tpm2-tss-fapi.conf
+ 
+-EXTRA_DIST += dist/sysusers.d/tpm2-tss.conf dist/tmpfiles.d/tpm2-tss-fapi.conf.in
++EXTRA_DIST += dist/tmpfiles.d/tpm2-tss-fapi.conf.in
+ CLEANFILES += tpm2-tss-fapi.conf
+ 
+ # We have to do this ourselves, in order to get absolute paths
+@@ -726,13 +725,6 @@ EXTRA_DIST += dist/tpm-udev.rules
+ 
+ install-dirs:
+ if HOSTOS_LINUX
+-if SYSD_SYSUSERS
+-	@echo "systemd-sysusers $(DESTDIR)$(sysconfdir)/sysusers.d/tpm2-tss.conf"
+-	@systemd-sysusers $(DESTDIR)$(sysconfdir)/sysusers.d/tpm2-tss.conf || echo "WARNING Failed to create the tss user and group"
+-else
+-	@echo "call make_tss_user_and_group"
+-	@$(call make_tss_user_and_group) || echo "WARNING Failed to create the tss user and group"
+-endif
+ if SYSD_TMPFILES
+ 	@echo "systemd-tmpfiles --create $(DESTDIR)$(sysconfdir)/tmpfiles.d/tpm2-tss-fapi.conf"
+ 	@systemd-tmpfiles --create $(DESTDIR)$(sysconfdir)/tmpfiles.d/tpm2-tss-fapi.conf|| echo "WARNING Failed to create the FAPI directories with the correct permissions"
+diff --git a/configure.ac b/configure.ac
+index 6482944f..44c0e383 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -483,22 +483,9 @@ AS_IF([test "x$enable_integration" = "xyes" && test "x$enable_self_generated_cer
+       [AC_MSG_WARN([Running integration tests without EK certificate verification, use --enable-self-generated-certificate for full test coverage])])
+ 
+ # Check for systemd helper tools used by make install
+-AC_CHECK_PROG(systemd_sysusers, systemd-sysusers, yes)
+-AM_CONDITIONAL(SYSD_SYSUSERS, test "x$systemd_sysusers" = "xyes")
+ AC_CHECK_PROG(systemd_tmpfiles, systemd-tmpfiles, yes)
+ AM_CONDITIONAL(SYSD_TMPFILES, test "x$systemd_tmpfiles" = "xyes")
+ 
+-# Check all tools used by make install
+-AS_IF([test "$HOSTOS" = "Linux"],
+-    [ AC_CHECK_PROG(useradd, useradd, yes)
+-      AC_CHECK_PROG(groupadd, groupadd, yes)
+-      AC_CHECK_PROG(adduser, adduser, yes)
+-      AC_CHECK_PROG(addgroup, addgroup, yes)
+-      AS_IF([test "x$addgroup" != "xyes" && test "x$groupadd" != "xyes" ],
+-         [AC_MSG_ERROR([addgroup or groupadd are needed.])])
+-      AS_IF([test "x$adduser" != "xyes" && test "x$useradd" != "xyes" ],
+-         [AC_MSG_ERROR([adduser or useradd are needed.])])])
+-
+ AC_SUBST([PATH])
+ 
+ dnl --------- Doxy Gen -----------------------

--- a/app-crypt/tpm2-tss/tpm2-tss-3.2.0-r4.ebuild
+++ b/app-crypt/tpm2-tss/tpm2-tss-3.2.0-r4.ebuild
@@ -1,0 +1,99 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit autotools linux-info multilib-minimal tmpfiles udev
+
+DESCRIPTION="TCG Trusted Platform Module 2.0 Software Stack"
+HOMEPAGE="https://github.com/tpm2-software/tpm2-tss"
+SRC_URI="https://github.com/tpm2-software/${PN}/releases/download/${PV}/${P}.tar.gz"
+
+LICENSE="BSD-2"
+SLOT="0/3"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~riscv ~x86"
+IUSE="doc +fapi +openssl mbedtls static-libs test"
+
+RESTRICT="!test? ( test )"
+
+REQUIRED_USE="^^ ( mbedtls openssl )
+		fapi? ( openssl !mbedtls )"
+
+RDEPEND="acct-group/tss
+	acct-user/tss
+	fapi? ( dev-libs/json-c:=[${MULTILIB_USEDEP}]
+		>=net-misc/curl-7.80.0[${MULTILIB_USEDEP}] )
+	mbedtls? ( net-libs/mbedtls:=[${MULTILIB_USEDEP}] )
+	openssl? ( dev-libs/openssl:=[${MULTILIB_USEDEP}] )"
+
+DEPEND="${RDEPEND}
+	test? ( app-crypt/swtpm
+		dev-libs/uthash
+		dev-util/cmocka
+		fapi? ( >=net-misc/curl-7.80.0 ) )"
+BDEPEND="sys-apps/acl
+	virtual/pkgconfig
+	doc? ( app-doc/doxygen )"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-3.2.0-Dont-run-systemd-sysusers-in-Makefile.patch"
+)
+
+pkg_setup() {
+	local CONFIG_CHECK=" \
+		~TCG_TPM
+	"
+	linux-info_pkg_setup
+	kernel_is ge 4 12 0 || ewarn "At least kernel 4.12.0 is required"
+}
+
+src_prepare() {
+	default
+
+	# See bug #833887 (and similar); eautoreconf means .pc file gets wrong version.
+	sed -i \
+	"s/m4_esyscmd_s(\[git describe --tags --always --dirty\])/${PV}/" \
+		"configure.ac" || die
+
+	eautoreconf
+}
+
+multilib_src_configure() {
+	ECONF_SOURCE=${S} econf \
+		--localstatedir=/var \
+		$(use_enable doc doxygen-doc) \
+		$(use_enable fapi) \
+		$(use_enable static-libs static) \
+		$(multilib_native_use_enable test unit) \
+		$(multilib_native_use_enable test integration) \
+		$(multilib_native_use_enable test self-generated-certificate) \
+		--disable-tcti-libtpms \
+		--disable-defaultflags \
+		--disable-weakcrypto \
+		--with-crypto="$(usex mbedtls mbed ossl)" \
+		--with-runstatedir=/run \
+		--with-udevrulesdir="$(get_udevdir)/rules.d" \
+		--with-udevrulesprefix=60- \
+		--with-sysusersdir="/usr/lib/sysusers.d" \
+		--with-tmpfilesdir="/usr/lib/tmpfiles.d"
+}
+
+multilib_src_install() {
+	default
+
+	if [[ ${PV} != $(sed -n -e 's/^Version: //p' "${ED}/usr/$(get_libdir)/pkgconfig/tss2-sys.pc" || die) ]] ; then
+		# Safeguard for bug #833887
+		die "pkg-config file version doesn't match ${PV}! Please report a bug!"
+	fi
+
+	find "${D}" -name '*.la' -delete || die
+}
+
+pkg_postinst() {
+	tmpfiles_process tpm2-tss-fapi.conf
+	udev_reload
+}
+
+pkg_postrm() {
+	udev_reload
+}


### PR DESCRIPTION
This avoid a conflict with systemd-sysusers