### PR TITLE
sys-cluster/hpx: Fix building on musl

### DIFF
--- a/sys-cluster/hpx/files/hpx-1.8.0-fix-musl-exec_pagesize-not-defined.patch
+++ b/sys-cluster/hpx/files/hpx-1.8.0-fix-musl-exec_pagesize-not-defined.patch
@@ -1,0 +1,47 @@
+# EXEC_PAGESIZE is a preprocessor macro from the Linux Kernel headers. Include
+# the appropriate Linux header file <linux/param.h>
+#
+# With this PR https://github.com/STEllAR-GROUP/hpx/pull/5947 merged, from
+# 1.8.1 we can drop these patches
+--- a/components/performance_counters/memory/src/mem_counter_linux.cpp
++++ b/components/performance_counters/memory/src/mem_counter_linux.cpp
+@@ -14,6 +14,11 @@
+ #include <sys/types.h>
+ #include <unistd.h>
+
++// Fix for musl. Use linux/param.h for EXEC_PAGESIZE
++#ifdef __linux__
++#include <linux/param.h>
++#endif
++
+ #include <hpx/modules/errors.hpp>
+ #include <hpx/modules/format.hpp>
+
+--- a/libs/core/coroutines/include/hpx/coroutines/detail/context_linux_x86.hpp
++++ b/libs/core/coroutines/include/hpx/coroutines/detail/context_linux_x86.hpp
+@@ -37,6 +37,11 @@
+ #include <stdexcept>
+ #include <sys/param.h>
+
++// Fix for musl. Use linux/param.h for EXEC_PAGESIZE
++#ifdef __linux__
++#include <linux/param.h>
++#endif
++
+ #if defined(HPX_HAVE_STACKOVERFLOW_DETECTION)
+
+ #include <cstring>
+--- a/libs/core/coroutines/include/hpx/coroutines/detail/posix_utility.hpp
++++ b/libs/core/coroutines/include/hpx/coroutines/detail/posix_utility.hpp
+@@ -67,6 +67,11 @@
+ #define EXEC_PAGESIZE static_cast<std::size_t>(sysconf(_SC_PAGESIZE))
+ #endif
+
++// Fix for musl. Use linux/param.h for EXEC_PAGESIZE
++#ifdef __linux__
++#include <linux/param.h>
++#endif
++
+ /**
+  * Stack allocation routines and trampolines for setcontext
+  */

--- a/sys-cluster/hpx/files/hpx-1.8.0-fix-musl-execinfo.patch
+++ b/sys-cluster/hpx/files/hpx-1.8.0-fix-musl-execinfo.patch
@@ -1,0 +1,16 @@
+# Check for execinfo only on glibc and ulibc systems.
+#
+# With this PR https://github.com/STEllAR-GROUP/hpx/pull/5947 merged, from
+# 1.8.1 we can drop these patches
+--- a/libs/core/debugging/src/backtrace.cpp
++++ b/libs/core/debugging/src/backtrace.cpp
+@@ -19,7 +19,9 @@
+
+ #if (defined(__linux) || defined(__APPLE__) || defined(__sun)) &&              \
+     (!defined(__ANDROID__) || !defined(ANDROID))
++#if defined(__GLIBC__)
+ #define HPX_HAVE_EXECINFO
++#endif
+ #define HPX_HAVE_DLFCN
+ #if defined(__GNUC__) && !defined(__clang__)
+ #define HPX_HAVE_UNWIND

--- a/sys-cluster/hpx/files/hpx-1.8.0-fix-musl-rtdl-not-declared.patch
+++ b/sys-cluster/hpx/files/hpx-1.8.0-fix-musl-rtdl-not-declared.patch
@@ -1,0 +1,25 @@
+# RTLD_DI_ORIGIN is not defined in musl as a result hpx fails to build.
+# Closes: https://bugs.gentoo.org/829242
+#
+# With this PR https://github.com/STEllAR-GROUP/hpx/pull/5947 merged, from
+# 1.8.1 we can drop these patches
+--- a/libs/core/plugin/include/hpx/plugin/detail/dll_dlopen.hpp
++++ b/libs/core/plugin/include/hpx/plugin/detail/dll_dlopen.hpp
+@@ -319,6 +319,7 @@ namespace hpx { namespace util { namespace plugin {
+             std::string result;
+
+ #if !defined(__ANDROID__) && !defined(ANDROID) && !defined(__APPLE__)
++#if defined(RTLD_DI_ORIGIN)
+             char directory[PATH_MAX] = {'\0'};
+             const_cast<dll&>(*this).LoadLibrary(ec);
+             if (!ec && ::dlinfo(dll_handle, RTLD_DI_ORIGIN, directory) < 0)
+@@ -333,6 +334,9 @@ namespace hpx { namespace util { namespace plugin {
+             }
+             result = directory;
+             ::dlerror();    // Clear the error state.
++#else
++            result = path(dll_name).parent_path().string();
++#endif
+ #elif defined(__APPLE__)
+             // SO staticfloat's solution
+             const_cast<dll&>(*this).LoadLibrary(ec);

--- a/sys-cluster/hpx/hpx-1.8.0.ebuild
+++ b/sys-cluster/hpx/hpx-1.8.0.ebuild
@@ -47,6 +47,9 @@ DEPEND="${RDEPEND}"
 
 PATCHES=(
 	"${FILESDIR}/${P}-python.patch"
+	"${FILESDIR}/${P}-fix-musl-exec_pagesize-not-defined.patch"
+	"${FILESDIR}/${P}-fix-musl-execinfo.patch"
+	"${FILESDIR}/${P}-fix-musl-rtdl-not-declared.patch"
 )
 
 hpx_memory_requirement() {


### PR DESCRIPTION
These patches fixes building on musl. I've tried to document the patches
to the best of my abilities.

Mainly fixes the RTLD_DI_ORIGIN not being present in musl.

Closes: https://bugs.gentoo.org/829242

Signed-off-by: brahmajit das <brahmajit.xyz@gmail.com>