### PR TITLE
sci-libs/netcdf: Fix musl missing execinfo.h check

### DIFF
--- a/sci-libs/netcdf/files/netcdf-4.9.0-fix-musl-execinfo_h.patch
+++ b/sci-libs/netcdf/files/netcdf-4.9.0-fix-musl-execinfo_h.patch
@@ -1,0 +1,46 @@
+# Conditionally include execinfo as it's not available on all libc
+# systems. There is a PR upstream for a similiar issue but the actual
+# issus is not reproducable on Gentoo [math library not found] [1], so
+# for now this is a temporary fix and can be removed once the PR [1]
+# is merged upstream.
+# [1]: https://github.com/Unidata/netcdf-c/pull/1701
+#
+# Closes: https://bugs.gentoo.org/828677
+--- a/libhdf5/hdf5debug.c
++++ b/libhdf5/hdf5debug.c
+@@ -5,7 +5,7 @@
+ #include "config.h"
+ #include <stdarg.h>
+ #include <stdio.h>
+-#if !defined _WIN32 && !defined __CYGWIN__
++#ifdef HAVE_EXECINFO_H
+ #include <execinfo.h>
+ #endif
+
+@@ -15,15 +15,18 @@
+
+ #define STSIZE 1000
+
++#ifdef HAVE_EXECINFO_H
+ #ifdef H5BACKTRACE
+ #  if !defined _WIN32 && !defined __CYGWIN__
+ static void* stacktrace[STSIZE];
+ #  endif
+ #endif
++#endif
+
+ int
+ nch5breakpoint(int err)
+ {
++#ifdef HAVE_EXECINFO_H
+ #ifdef H5BACKTRACE
+ #  if !defined _WIN32 && !defined __CYGWIN__
+     int count = 0;
+@@ -39,6 +42,7 @@ nch5breakpoint(int err)
+     if(trace != NULL) free(trace);
+ #    endif
+ #  endif
++#endif
+ #endif
+     return err;
+ }

--- a/sci-libs/netcdf/netcdf-4.9.0.ebuild
+++ b/sci-libs/netcdf/netcdf-4.9.0.ebuild
@@ -36,6 +36,7 @@ REQUIRED_USE="
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-4.7.4-big-endian-test.patch
+	"${FILESDIR}"/${PN}-4.9.0-fix-musl-execinfo_h.patch
 )
 
 src_configure() {


### PR DESCRIPTION
Check if execinfo.h is present before including the header. The check is
preset in other parts of the souce code, here it was only being checked if
it's WIN32 or CYGIWIN before including execinfo.h as a result build was
failing on musl.

Closes: https://bugs.gentoo.org/828677

Signed-off-by: brahmajit das <brahmajit.xyz@gmail.com>