### PR TITLE
x11-libs/wxGTK: add tests

### DIFF
--- a/x11-libs/wxGTK/wxGTK-3.0.5.1.ebuild
+++ b/x11-libs/wxGTK/wxGTK-3.0.5.1.ebuild
@@ -22,7 +22,7 @@ LICENSE="wxWinLL-3 GPL-2 doc? ( wxWinFDL-3 )"
 SLOT="${WXRELEASE}"
 KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~mips ppc ppc64 ~riscv sparc x86 ~amd64-linux ~x86-linux"
 IUSE="+X doc debug gstreamer libnotify opengl sdl test tiff webkit"
-REQUIRED_USE="test? ( tiff ) tiff? ( X )"
+REQUIRED_USE="test? ( tiff ) tiff? ( X ) gstreamer? ( X ) libnotify? ( X ) opengl? ( X ) webkit? ( X )"
 RESTRICT="!test? ( test )"
 
 RDEPEND="


### PR DESCRIPTION
Note that upstream actually replaced cppunit with catch very soon after this tagged for 3.2.0, this changes the command-line syntax so this will need to be updated when the 3.2 branch is packaged.

Note that there are also GUI tests, but they failed pretty badly for me under virtx, so leaving them off for now.