### PR TITLE
media-sound/pulseaudio-daemon: Depend on same version of libpulse

### DIFF
--- a/media-sound/pulseaudio-daemon/pulseaudio-daemon-16.0-r1.ebuild
+++ b/media-sound/pulseaudio-daemon/pulseaudio-daemon-16.0-r1.ebuild
@@ -61,7 +61,7 @@ gstreamer_deps="
 	>=media-libs/gstreamer-1.14
 "
 COMMON_DEPEND="
-	>=media-libs/libpulse-${PV}[dbus?,glib?,systemd?,tcpd(+)?,valgrind?,X?]
+	~media-libs/libpulse-${PV}[dbus?,glib?,systemd?,tcpd(+)?,valgrind?,X?]
 	dev-libs/libatomic_ops
 	>=media-libs/libsndfile-1.0.20
 	>=media-libs/speexdsp-1.2

--- a/media-sound/pulseaudio-daemon/pulseaudio-daemon-16.0-r4.ebuild
+++ b/media-sound/pulseaudio-daemon/pulseaudio-daemon-16.0-r4.ebuild
@@ -61,7 +61,7 @@ gstreamer_deps="
 	>=media-libs/gstreamer-1.14
 "
 COMMON_DEPEND="
-	>=media-libs/libpulse-${PV}[dbus?,glib?,systemd?,valgrind?,X?]
+	~media-libs/libpulse-${PV}[dbus?,glib?,systemd?,valgrind?,X?]
 	dev-libs/libatomic_ops
 	>=media-libs/libsndfile-1.0.20
 	>=media-libs/speexdsp-1.2

--- a/media-sound/pulseaudio-daemon/pulseaudio-daemon-16.0-r5.ebuild
+++ b/media-sound/pulseaudio-daemon/pulseaudio-daemon-16.0-r5.ebuild
@@ -61,7 +61,7 @@ gstreamer_deps="
 	>=media-libs/gstreamer-1.14
 "
 COMMON_DEPEND="
-	>=media-libs/libpulse-${PV}[dbus?,glib?,systemd?,valgrind?,X?]
+	~media-libs/libpulse-${PV}[dbus?,glib?,systemd?,valgrind?,X?]
 	dev-libs/libatomic_ops
 	>=media-libs/libsndfile-1.0.20
 	>=media-libs/speexdsp-1.2

--- a/media-sound/pulseaudio-daemon/pulseaudio-daemon-16.1.ebuild
+++ b/media-sound/pulseaudio-daemon/pulseaudio-daemon-16.1.ebuild
@@ -61,7 +61,7 @@ gstreamer_deps="
 	>=media-libs/gstreamer-1.14
 "
 COMMON_DEPEND="
-	>=media-libs/libpulse-${PV}[dbus?,glib?,systemd?,valgrind?,X?]
+	~media-libs/libpulse-${PV}[dbus?,glib?,systemd?,valgrind?,X?]
 	dev-libs/libatomic_ops
 	>=media-libs/libsndfile-1.0.20
 	>=media-libs/speexdsp-1.2


### PR DESCRIPTION
Follow-up for daemon build error against newer libpulse https://forums.gentoo.org/viewtopic-t-1152563.html

Shared library libpulsecommon is installed with version-dependend name matching pulseaudio release version. Daemon package expects that library to be the same version, and if e.g. installed libpulse is from more recent release this results in a build error.

Fix this by depending on exact same PV of media-libs/libpulse package.

Signed-off-by: Igor V. Kovalenko <igor.v.kovalenko@gmail.com>