### PR TITLE
Fixes `Service 'epmd' needs non existent service 'net.lo'`

### DIFF
--- a/dev-lang/erlang/files/epmd.init
+++ b/dev-lang/erlang/files/epmd.init
@@ -7,7 +7,7 @@ pidfile="/var/run/epmd.pid"
 command_args="-daemon -relaxed_command_check -address 127.0.0.1"
 
 depend() {
-	need net.lo
+	need loopback
 	before sshd
 }
 

--- a/dev-lang/erlang/files/epmd.init-r2
+++ b/dev-lang/erlang/files/epmd.init-r2
@@ -12,7 +12,7 @@ command_background=yes
 pidfile="/var/run/epmd.pid"
 
 depend() {
-	need net.lo
+	need loopback
 	before sshd
 }
 


### PR DESCRIPTION
I personally don't have `netifrc`. I manage all my networking from `iwd`, hence I don't have `net.lo` files.
Every time the cache reloads (for example when I run `rc-service bluetooth restart`) I received the message ``Service `epmd' needs non existent service `net.lo'``. I discussed it with [this](https://forums.gentoo.org/viewtopic-t-1152539-highlight-.html) Gentoo Forum post and applied it to my machine, it worked.
So to standardize `epmd`, this PR make it search for a `loopback` interface instead of `net.lo`.

It's my first ever commit, so check it out, I really hope I did it well. :-)

It should fix [this](https://bugs.gentoo.org/857099) bug.