### PR TITLE
dev-libs/hyperscan: enable py3.11

### DIFF
--- a/dev-libs/hyperscan/hyperscan-5.4.0.ebuild
+++ b/dev-libs/hyperscan/hyperscan-5.4.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{8..10} )
+PYTHON_COMPAT=( python3_{8..11} )
 
 inherit cmake flag-o-matic python-any-r1
 


### PR DESCRIPTION
It works properly with `py3.11`.