### PR TITLE
net-im/bitlbee: enable py3.11

### DIFF
--- a/net-im/bitlbee/bitlbee-3.6-r1.ebuild
+++ b/net-im/bitlbee/bitlbee-3.6-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{8..10} )
+PYTHON_COMPAT=( python3_{8..11} )
 
 inherit python-any-r1 systemd toolchain-funcs
 

--- a/net-im/bitlbee/bitlbee-9999.ebuild
+++ b/net-im/bitlbee/bitlbee-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{8..10} )
+PYTHON_COMPAT=( python3_{8..11} )
 
 inherit python-any-r1 systemd toolchain-funcs
 


### PR DESCRIPTION
Both work with `py3.11`.