### PR TITLE
dev-python/signedjson: remove extra / from SRC_URI

### DIFF
--- a/dev-python/signedjson/signedjson-1.1.4.ebuild
+++ b/dev-python/signedjson/signedjson-1.1.4.ebuild
@@ -13,7 +13,7 @@ HOMEPAGE="
 	https://github.com/matrix-org/python-signedjson
 	https://pypi.python.org/pypi/signedjson
 "
-SRC_URI="https://github.com/matrix-org/python-signedjson//archive/v${PV}.tar.gz -> ${P}.gh.tar.gz"
+SRC_URI="https://github.com/matrix-org/python-signedjson/archive/v${PV}.tar.gz -> ${P}.gh.tar.gz"
 
 S="${WORKDIR}/python-${P}"
 


### PR DESCRIPTION
This is a fix of minor copy-paste issue from when I was constructing `SRC_URI`, just one `/` is enough before `archive`.