### PR TITLE
net-misc/r8168: use upstream URL

### DIFF
--- a/net-misc/r8168/r8168-8.049.02-r1.ebuild
+++ b/net-misc/r8168/r8168-8.049.02-r1.ebuild
@@ -8,10 +8,7 @@ inherit linux-info linux-mod
 DESCRIPTION="r8168 driver for Realtek 8111/8168 PCI-E NICs"
 HOMEPAGE="https://www.realtek.com/en/component/zoo/category/network-interface-controllers-10-100-1000m-gigabit-ethernet-pci-express-software"
 
-# "GBE Ethernet LINUX driver r8168 for kernel up to 5.6" from above link,
-# we need to mirror it to avoid users from needing to fill a captcha to
-# download
-SRC_URI="https://dev.gentoo.org/~pacho/${PN}/${P}.tar.bz2"
+SRC_URI="https://rtitwww.realtek.com/rtdrivers/cn/nic1/${P}.tar.bz2"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/net-misc/r8168/r8168-8.050.00.ebuild
+++ b/net-misc/r8168/r8168-8.050.00.ebuild
@@ -8,10 +8,7 @@ inherit linux-info linux-mod
 DESCRIPTION="r8168 driver for Realtek 8111/8168 PCI-E NICs"
 HOMEPAGE="https://www.realtek.com/en/component/zoo/category/network-interface-controllers-10-100-1000m-gigabit-ethernet-pci-express-software"
 
-# "GBE Ethernet LINUX driver r8168 for kernel up to 5.17" from above link,
-# we need to mirror it to avoid users from needing to fill a captcha to
-# download
-SRC_URI="https://dev.gentoo.org/~pacho/${PN}/${P}.tar.bz2"
+SRC_URI="https://rtitwww.realtek.com/rtdrivers/cn/nic1/${P}.tar.bz2"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/net-misc/r8168/r8168-8.050.02.ebuild
+++ b/net-misc/r8168/r8168-8.050.02.ebuild
@@ -8,10 +8,7 @@ inherit linux-info linux-mod
 DESCRIPTION="r8168 driver for Realtek 8111/8168 PCI-E NICs"
 HOMEPAGE="https://www.realtek.com/en/component/zoo/category/network-interface-controllers-10-100-1000m-gigabit-ethernet-pci-express-software"
 
-# "GBE Ethernet LINUX driver r8168 for kernel up to 5.17" from above link,
-# we need to mirror it to avoid users from needing to fill a captcha to
-# download
-SRC_URI="https://dev.gentoo.org/~pacho/${PN}/${P}.tar.bz2"
+SRC_URI="https://rtitwww.realtek.com/rtdrivers/cn/nic1/${P}.tar.bz2"
 
 LICENSE="GPL-2"
 SLOT="0"


### PR DESCRIPTION
Use upstream URL to avoid manually host the source code copy
