### PR TITLE
media-libs/pcaudiolib: Fix install with slibtool

### DIFF
--- a/media-libs/pcaudiolib/pcaudiolib-1.1.ebuild
+++ b/media-libs/pcaudiolib/pcaudiolib-1.1.ebuild
@@ -34,11 +34,12 @@ src_configure() {
 		$(use_with oss)
 		$(use_with alsa)
 		$(use_with pulseaudio)
+		--disable-static
 	)
 	econf "${econf_args[@]}"
 }
 
 src_install() {
 	default
-	rm "${ED}"/usr/lib*/libpcaudio.{a,la} || die
+	find "${D}" -name '*.la' -delete || die
 }


### PR DESCRIPTION
With slibtool the '.la' files are not installed by default.

Bug: https://bugs.gentoo.org/799617