### PR TITLE
net-misc/streamlink: remove unneeded build env var

### DIFF
--- a/net-misc/streamlink/streamlink-4.1.0-r2.ebuild
+++ b/net-misc/streamlink/streamlink-4.1.0-r2.ebuild
@@ -51,8 +51,3 @@ BDEPEND="
 	')"
 
 distutils_enable_tests pytest
-
-python_configure_all() {
-	# Avoid iso-639, iso3166 dependencies since we use pycountry.
-	export STREAMLINK_USE_PYCOUNTRY=1
-}

--- a/net-misc/streamlink/streamlink-4.2.0.ebuild
+++ b/net-misc/streamlink/streamlink-4.2.0.ebuild
@@ -51,8 +51,3 @@ BDEPEND="
 	')"
 
 distutils_enable_tests pytest
-
-python_configure_all() {
-	# Avoid iso-639, iso3166 dependencies since we use pycountry.
-	export STREAMLINK_USE_PYCOUNTRY=1
-}

--- a/net-misc/streamlink/streamlink-9999.ebuild
+++ b/net-misc/streamlink/streamlink-9999.ebuild
@@ -51,8 +51,3 @@ BDEPEND="
 	')"
 
 distutils_enable_tests pytest
-
-python_configure_all() {
-	# Avoid iso-639, iso3166 dependencies since we use pycountry.
-	export STREAMLINK_USE_PYCOUNTRY=1
-}


### PR DESCRIPTION
I'm the Streamlink project maintainer and I noticed that Gentoo's `net-misc/streamlink` package build config was incorrectly setting old build env vars which were removed in the 3.0.0 release.

See:
https://streamlink.github.io/changelog.html#streamlink-3-0-0-2021-11-17

Since I'm not a Gentoo user, these changes are completely untested.