### PR TITLE
*/*: Remove libressl support from patches

### DIFF
--- a/app-crypt/tpm-tools/files/tpm-tools-1.3.9.1-openssl-1.1.patch
+++ b/app-crypt/tpm-tools/files/tpm-tools-1.3.9.1-openssl-1.1.patch
@@ -17,7 +17,7 @@ index f534717..33c76e7 100644
  #include <openssl/evp.h>
  #include <openssl/err.h>
  
-+#if OPENSSL_VERSION_NUMBER < 0x10100000L || (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x20700000L)
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
 +static void RSA_get0_key(const RSA *r, const BIGNUM **n, const BIGNUM **e, const BIGNUM **d) {
 +	if ( n )
 +		*n = r->n;
@@ -236,6 +236,3 @@ index f534717..33c76e7 100644
  
  	rc = 0;
  
--- 
-2.19.2
-

--- a/net-libs/libsrtp/files/libsrtp-1.6.0-openssl-1.1.patch
+++ b/net-libs/libsrtp/files/libsrtp-1.6.0-openssl-1.1.patch
@@ -217,7 +217,7 @@ Backport of https://github.com/cisco/libsrtp/commit/0b45423678ddc46d702f3a51614f
 -    if (pointer == NULL) {
 +/* OpenSSL 1.1.0 made HMAC_CTX an opaque structure, which must be allocated
 +   using HMAC_CTX_new.  But this function doesn't exist in OpenSSL 1.0.x. */
-+#if OPENSSL_VERSION_NUMBER < 0x10100000L || (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x2070000fL)
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
 +    {
 +        /* allocate memory for auth and HMAC_CTX structures */
 +        uint8_t* pointer;
@@ -263,7 +263,7 @@ Backport of https://github.com/cisco/libsrtp/commit/0b45423678ddc46d702f3a51614f
  
      hmac_ctx = (HMAC_CTX*)a->state;
  
-+#if OPENSSL_VERSION_NUMBER < 0x10100000L || (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x2070000fL)
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
      HMAC_CTX_cleanup(hmac_ctx);
  
      /* zeroize entire state*/
@@ -318,7 +318,7 @@ Backport of https://github.com/cisco/libsrtp/commit/0b45423678ddc46d702f3a51614f
  
 +/* OpenSSL 1.1.0 made EVP_MD_CTX an opaque structure, which must be allocated
 +   using EVP_MD_CTX_new. But this function doesn't exist in OpenSSL 1.0.x. */
-+#if OPENSSL_VERSION_NUMBER < 0x10100000L || (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x2070000fL)
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
 +
 +typedef EVP_MD_CTX sha1_ctx_t;
 +

--- a/net-voip/telepathy-salut/files/telepathy-salut-0.8.1-openssl-1.1.patch
+++ b/net-voip/telepathy-salut/files/telepathy-salut-0.8.1-openssl-1.1.patch
@@ -19,12 +19,12 @@ index b77fb4c..bb50523 100644
  		0x02,
  		};
  	DH *dh;
-+#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
++#if OPENSSL_VERSION_NUMBER >= 0x10100000L
 +	int r = 0;
 +#endif
  
  	if ((dh=DH_new()) == NULL) return(NULL);
-+#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
++#if OPENSSL_VERSION_NUMBER >= 0x10100000L
 +	r = DH_set0_pqg(dh, BN_bin2bn(dh1024_p,sizeof(dh1024_p),NULL),
 +					NULL, BN_bin2bn(dh1024_g,sizeof(dh1024_g),NULL));
 +	if (!r)
@@ -45,12 +45,12 @@ index c16deb7..d53ceda 100644
  		0x02,
  		};
  	DH *dh;
-+#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
++#if OPENSSL_VERSION_NUMBER >= 0x10100000L
 +	int r = 0;
 +#endif
  
  	if ((dh=DH_new()) == NULL) return(NULL);
-+#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
++#if OPENSSL_VERSION_NUMBER >= 0x10100000L
 +	r = DH_set0_pqg(dh, BN_bin2bn(dh2048_p,sizeof(dh2048_p),NULL),
 +						NULL, BN_bin2bn(dh2048_g,sizeof(dh2048_g),NULL));
 +	if (!r)
@@ -71,12 +71,12 @@ index 2854385..93fa7e5 100644
  		0x02,
  		};
  	DH *dh;
-+#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
++#if OPENSSL_VERSION_NUMBER >= 0x10100000L
 +	int r = 0;
 +#endif
  
  	if ((dh=DH_new()) == NULL) return(NULL);
-+#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
++#if OPENSSL_VERSION_NUMBER >= 0x10100000L
 +	r = DH_set0_pqg(dh, BN_bin2bn(dh4096_p,sizeof(dh4096_p),NULL),
 +						NULL, BN_bin2bn(dh4096_g,sizeof(dh4096_g),NULL));
 +	if (!r)
@@ -97,12 +97,12 @@ index 8e7a278..c2891cd 100644
  		0x02,
  		};
  	DH *dh;
-+#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
++#if OPENSSL_VERSION_NUMBER >= 0x10100000L
 +	int r = 0;
 +#endif
  
  	if ((dh=DH_new()) == NULL) return(NULL);
-+#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
++#if OPENSSL_VERSION_NUMBER >= 0x10100000L
 +	r = DH_set0_pqg(dh, BN_bin2bn(dh512_p,sizeof(dh512_p),NULL),
 +					NULL, BN_bin2bn(dh512_g,sizeof(dh512_g),NULL));
 +	if (!r)
@@ -124,7 +124,7 @@ index 2201213..18f9981 100644
    gboolean rval = FALSE;
    X509_NAME *subject = X509_get_subject_name (cert);
 -  X509_CINF *ci = cert->cert_info;
-+#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
++#if OPENSSL_VERSION_NUMBER >= 0x10100000L
 +  const STACK_OF(X509_EXTENSION)* extensions = X509_get0_extensions(cert);
 +#else
 +  const STACK_OF(X509_EXTENSION)* extensions = cert->cert_info->extensions;
@@ -148,7 +148,7 @@ index 2201213..18f9981 100644
          long ni = OBJ_obj2nid (obj);
          const guchar *p;
          char *value = NULL;
-+#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
++#if OPENSSL_VERSION_NUMBER >= 0x10100000L
 +        const ASN1_OCTET_STRING* ext_value = X509_EXTENSION_get_data(ext);
 +        int len = ASN1_STRING_length(ext_value);
 +#else
@@ -161,7 +161,7 @@ index 2201213..18f9981 100644
          if ((convert = (X509V3_EXT_METHOD *) X509V3_EXT_get (ext)) == NULL)
            continue;
  
-+#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
++#if OPENSSL_VERSION_NUMBER >= 0x10100000L
 +        p = ASN1_STRING_get0_data(ext_value);
 +#else
          p = ext->value->data;
@@ -173,7 +173,7 @@ index 2201213..18f9981 100644
  
    if G_UNLIKELY (g_once_init_enter (&initialised))
      {
-+#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
++#if OPENSSL_VERSION_NUMBER >= 0x10100000L
 +      DEBUG ("initialising SSL library and error strings");
 +#else
        gint malloc_init_succeeded;

--- a/www-client/w3mmee/files/w3mmee-openssl-1.1.patch
+++ b/www-client/w3mmee/files/w3mmee-openssl-1.1.patch
@@ -15,7 +15,7 @@
  	gn = sk_GENERAL_NAME_value(alt, i);
  
  	if (gn->type == GEN_DNS) {
-+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
  	  char *sn = ASN1_STRING_data(gn->d.ia5);
 +#else
 +	  char *sn = ASN1_STRING_get0_data(gn->d.ia5);
@@ -64,7 +64,7 @@
  	X509_set_default_verify_paths(ssl_ctx->cert);
 -#else				/* SSLEAY_VERSION_NUMBER >= 0x0800 */
 +#else				/* OPENSSL_VERSION_NUMBER >= 0x0800 */
-+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
  	SSLeay_add_ssl_algorithms();
  	SSL_load_error_strings();
 +#else


### PR DESCRIPTION
This removes outdated libressl checks from various patches that are no longer required with libressl-3.5.x provided by the libressl overlay.

This also fixes the `net-voip/telepathy-salut` build with libressl.