### PR TITLE
app-emulation/virtualbox: revert QA fix for CFLAGS

### DIFF
--- a/app-emulation/virtualbox/virtualbox-6.1.34-r5.ebuild
+++ b/app-emulation/virtualbox/virtualbox-6.1.34-r5.ebuild
@@ -299,13 +299,6 @@ src_configure() {
 	if use amd64 && ! has_multilib_profile ; then
 		myconf+=( --disable-vmmraw )
 	fi
-
-	# bug #843437
-	cat >> LocalConfig.kmk <<-EOF || die
-		CFLAGS=${CFLAGS}
-		CXXFLAGS=${CXXFLAGS}
-	EOF
-
 	# not an autoconf script
 	edo ./configure "${myconf[@]}"
 

--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -53,10 +53,6 @@ games-engines/nazghul
 # Removal on 2022-08-09.  Bug #857252.
 dev-python/pydispatcher
 
-# David Seifert <soap@gentoo.org> (2022-07-07)
-# Broken by recent fix attempts, bug #856811.
->app-emulation/virtualbox-6.1.34-r1
-
 # David Seifert <soap@gentoo.org> (2022-07-02)
 # Unmaintained, no response on bugs, stuck on python 3.9. If you
 # want to unmask these, you have to at least port them to python 3.10.


### PR DESCRIPTION
Surprisingly, this change broke it, not the python stuff.
This is an emergency fix, so we can unmask the package.
There still are QA issues, I'll fix them later.