### PR TITLE
games-strategy/augustus: Fix build on musl

### DIFF
--- a/games-strategy/augustus/augustus-3.0.1.ebuild
+++ b/games-strategy/augustus/augustus-3.0.1.ebuild
@@ -26,6 +26,7 @@ RDEPEND="
 
 PATCHES=(
 	"${FILESDIR}/${PN}-3.0.1-desktop_rename.patch"
+	"${FILESDIR}/${PN}-3.0.1-musl-fix-execinfo.patch"
 )
 
 src_prepare() {

--- a/games-strategy/augustus/files/augustus-3.0.1-musl-fix-execinfo.patch
+++ b/games-strategy/augustus/files/augustus-3.0.1-musl-fix-execinfo.patch
@@ -1,0 +1,13 @@
+diff --git a/src/core/backtrace.c b/src/core/backtrace.c
+index 374fcdd..daf5c71 100644
+--- a/src/core/backtrace.c
++++ b/src/core/backtrace.c
+@@ -2,7 +2,7 @@
+ 
+ #include "core/log.h"
+ 
+-#if defined(__GNUC__) && !defined(__MINGW32__) && !defined(__OpenBSD__) && !defined(__vita__) && !defined(__SWITCH__) && !defined(__ANDROID__) && !defined(__HAIKU__)
++#if defined(__GNUC__) && defined(__GLIBC__) && !defined(__MINGW32__) && !defined(__OpenBSD__) && !defined(__vita__) && !defined(__SWITCH__) && !defined(__ANDROID__) && !defined(__HAIKU__)
+ 
+ #include <execinfo.h>
+ 


### PR DESCRIPTION
musl doesn't provide execinfo.h, so include it only on glibc systems

Closes: https://bugs.gentoo.org/829345

I'll change the patch after version bump again.

Signed-off-by: brahmajit das <brahmajit.xyz@gmail.com>