### PR TITLE
games-strategy/julius: Fix building on musl

### DIFF
--- a/games-strategy/julius/files/julius-1.6.0-musl-fix-execinfo.patch
+++ b/games-strategy/julius/files/julius-1.6.0-musl-fix-execinfo.patch
@@ -1,0 +1,14 @@
+# Fix building on musl
+#
+# Closes: https://bugs.gentoo.org/829246
+--- a/src/core/backtrace.c
++++ b/src/core/backtrace.c
+@@ -2,7 +2,7 @@
+
+ #include "core/log.h"
+
+-#if defined(__GNUC__) && !defined(__MINGW32__) && !defined(__OpenBSD__) && !defined(__vita__) && !defined(__SWITCH__) && !defined(__ANDROID__)
++#if defined(__GNUC__) && defined(__GLIBC__) && !defined(__MINGW32__) && !defined(__OpenBSD__) && !defined(__vita__) && !defined(__SWITCH__) && !defined(__ANDROID__)
+
+ #include <execinfo.h>
+

--- a/games-strategy/julius/julius-1.6.0.ebuild
+++ b/games-strategy/julius/julius-1.6.0.ebuild
@@ -24,6 +24,7 @@ RDEPEND="
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-1.4.1-rename.patch
+	"${FILESDIR}"/${PN}-1.6.0-musl-fix-execinfo.patch
 )
 
 src_install() {


### PR DESCRIPTION
execinfo is not available on musl, hence only include that header on
GLIBC systems

Closes: https://bugs.gentoo.org/829246

Signed-off-by: brahmajit das <brahmajit.xyz@gmail.com>