### PR TITLE
www-servers/moonbridge: Fix building on musl. Include fcntl.

### DIFF
--- a/www-servers/moonbridge/files/moonbridge-1.0.1-fcntl.patch
+++ b/www-servers/moonbridge/files/moonbridge-1.0.1-fcntl.patch
@@ -1,0 +1,14 @@
+#It is explicitely required to include fcntl.h in musl.
+#Else we get F_SETFD, FD_CLOEXEC undefined errors.
+#
+#Closes: https://bugs.gentoo.org/828671
+--- a/moonbridge.c
++++ b/moonbridge.c
+@@ -36,6 +36,7 @@
+ #include <getopt.h>
+ #include <sys/file.h>
+ #include <syslog.h>
++#include <fcntl.h>
+ #if defined(__FreeBSD__) || __has_include(<libutil.h>)
+ #include <libutil.h>
+ #endif

--- a/www-servers/moonbridge/moonbridge-1.0.1.ebuild
+++ b/www-servers/moonbridge/moonbridge-1.0.1.ebuild
@@ -27,7 +27,10 @@ BDEPEND="sys-devel/pmake
 
 S="${WORKDIR}"/${MYP}
 
-PATCHES=( "${FILESDIR}"/${P}-gentoo.patch )
+PATCHES=(
+    "${FILESDIR}"/${P}-gentoo.patch
+    "${FILESDIR}"/${P}-fcntl.patch
+)
 
 DOCS=( README reference.txt )
 


### PR DESCRIPTION
It is explicitly required to include fcntl.h in musl.
Else we get F_SETFD, FD_CLOEXEC undefined errors.

Closes: https://bugs.gentoo.org/828671

Signed-off-by: brahmajit das <brahmajit.xyz@gmail.com>