### PR TITLE
dev-db/mysql-connector-c: Use res_n* functions only on GLIBC

### DIFF
--- a/dev-db/mysql-connector-c/files/mysql-connector-c-8.0.27-res_n.patch
+++ b/dev-db/mysql-connector-c/files/mysql-connector-c-8.0.27-res_n.patch
@@ -1,0 +1,47 @@
+# Musl doesn't have res_n* functions so we are falling back to the not
+# thread safe ones. Patch made with help from developer Fabian Groffen
+# <grobian@gentoo.org>.
+#
+# Closes: https://bugs.gentoo.org/761352
+--- a/libmysql/CMakeLists.txt
++++ b/libmysql/CMakeLists.txt
+@@ -423,6 +423,19 @@ IF(HAS_WARN_FLAG)
+     )
+ ENDIF()
+
++check_symbol_exists(res_ninit "resolv.h" HAVE_RES_NINIT_FUNCTION)
++check_symbol_exists(res_nsearch "resolv.h" HAVE_RES_NSEARCH_FUNCTION)
++check_symbol_exists(res_nclose "resolv.h" HAVE_RES_NCLOSE_FUNCTION)
++IF (HAVE_RES_NINIT_FUNCTION)
++	add_compile_definitions(HAVE_RES_NINIT)
++ENDIF(HAVE_RES_NINIT_FUNCTION)
++IF (HAVE_RES_NSEARCH_FUNCTION)
++	add_compile_definitions(HAVE_RES_NSEARCH)
++ENDIF(HAVE_RES_NSEARCH_FUNCTION)
++IF (HAVE_RES_NCLOSE_FUNCTION)
++	add_compile_definitions(HAVE_RES_NCLOSE)
++ENDIF(HAVE_RES_NCLOSE_FUNCTION)
++
+ # Verify that libmysql_api_test runs OK
+ ADD_CUSTOM_COMMAND(TARGET libmysql_api_test POST_BUILD
+   COMMAND libmysql_api_test
+--- a/libmysql/dns_srv.cc
++++ b/libmysql/dns_srv.cc
+@@ -37,6 +37,17 @@
+ #include <netdb.h>
+ #include <resolv.h>
+
++/* we don't have anything else but the non-thread-safe variants */
++#if !defined(HAVE_RES_NINIT)
++#define res_ninit(X)              (void)X
++#endif
++#if !defined(HAVE_RES_NSEARCH)
++#define res_nsearch(X,D,I,S,B,L)  res_search(D,I,S,B,L)
++#endif
++#if !defined(HAVE_RES_NCLOSE)
++#define res_nclose(X)             (void)X
++#endif
++
+ // POSIX version
+
+ static bool get_dns_srv(Dns_srv_data &data, const char *dnsname, int &error) {

--- a/dev-db/mysql-connector-c/mysql-connector-c-8.0.27.ebuild
+++ b/dev-db/mysql-connector-c/mysql-connector-c-8.0.27.ebuild
@@ -51,6 +51,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-8.0.22-always-build-decompress-utilities.patch
 	"${FILESDIR}"/${PN}-8.0.19-do-not-install-comp_err.patch
 	"${FILESDIR}"/${PN}-8.0.27-add-OpenSSL-3.0.0-support.patch
+	"${FILESDIR}"/${PN}-8.0.27-res_n.patch
 )
 
 src_prepare() {


### PR DESCRIPTION
The issue occurs because the package tries to use the res_n* functions
(specifically res_ninit, res_nsearch and res_nclose) from resolv.h which
do not exist when using musl.

Closes: https://bugs.gentoo.org/761352

Signed-off-by: brahmajit das <brahmajit.xyz@gmail.com>