### PR TITLE
sys-cluster/glusterfs: 10.2-r1

### DIFF
--- a/sys-cluster/glusterfs/files/glusterd-10.2-r1.initd
+++ b/sys-cluster/glusterfs/files/glusterd-10.2-r1.initd
@@ -23,7 +23,7 @@ start_post() {
 	local c=0
 	ebegin "Waiting for glusterd to start up"
 	while ! /usr/sbin/gluster volume list >/dev/null 2>&1 && [ "${c}" -lt "${glusterd_max_wait_start-60}" ]; do
-		$(( c=c+1 ))
+		(( c=c+1 ))
 	done
 	[ "${c}" -lt "${glusterd_max_wait_start-60}" ]
 	eend $?

--- a/sys-cluster/glusterfs/glusterfs-10.2-r1.ebuild
+++ b/sys-cluster/glusterfs/glusterfs-10.2-r1.ebuild
@@ -150,7 +150,7 @@ src_install() {
 	chmod 0755 "${ED}"/usr/share/glusterfs/scripts/*.sh || die
 
 	newinitd "${FILESDIR}/glusterfsd-10.2.initd" glusterfsd
-	newinitd "${FILESDIR}/glusterd-10.2.initd" glusterd
+	newinitd "${FILESDIR}/glusterd-10.2-r1.initd" glusterd
 	newconfd "${FILESDIR}/${PN}.confd" glusterfsd
 
 	keepdir /var/log/${PN}


### PR DESCRIPTION
Fix initd $(( ... )) vs (( ... )).  The former returns the result, then
attempts to execute it, the latter merely executes the math.

Package-Manager: Portage-3.0.30, Repoman-3.0.3
Signed-off-by: Jaco Kroon <jaco@uls.co.za>