### PR TITLE
lxde-base/lxappearance-obconf: Fix slibtool build

### DIFF
--- a/lxde-base/lxappearance-obconf/files/lxappearance-obconf-0.2.3-cairo-xlib.patch
+++ b/lxde-base/lxappearance-obconf/files/lxappearance-obconf-0.2.3-cairo-xlib.patch
@@ -1,0 +1,39 @@
+From: orbea <orbea@riseup.net>
+Date: Mon, 11 Jul 2022 17:38:52 -0700
+Subject: [PATCH] build: Add missing cairo-xlib dependency
+
+src/preview.c:146:15: warning: implicit declaration of function ‘cairo_xlib_surface_create’; did you mean ‘cairo_image_surface_create’? [-Wimplicit-function-declaration]
+
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -16,6 +16,7 @@ module_LTLIBRARIES = src/obconf.la
+ moduledir = $(libdir)/lxappearance/plugins
+ 
+ src_obconf_la_CPPFLAGS = \
++	$(CAIRO_CFLAGS) \
+ 	$(OPENBOX_CFLAGS) \
+ 	$(GTK_CFLAGS) \
+ 	$(LXAPPEARANCE_CFLAGS) \
+@@ -30,6 +31,7 @@ src_obconf_la_CPPFLAGS = \
+ 	-DG_LOG_DOMAIN=\"Obconf\"
+ 
+ src_obconf_la_LIBADD = \
++	$(CAIRO_LIBS) \
+ 	$(OPENBOX_LIBS) \
+ 	$(GTK_LIBS) \
+ 	$(LXAPPEARANCE_LIBS) \
+diff --git a/configure.ac b/configure.ac
+index 9042f7f..84de1c7 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -89,6 +89,10 @@ PKG_CHECK_MODULES(OPENBOX, [obrender-3.5 >= 3.5 obt-3.5 >= 3.5])
+ AC_SUBST(OPENBOX_CFLAGS)
+ AC_SUBST(OPENBOX_LIBS)
+ 
++PKG_CHECK_MODULES(CAIRO, [cairo-xlib])
++AC_SUBST(CAIRO_CFLAGS)
++AC_SUBST(CAIRO_LIBS)
++
+ if test "x$enable_gtk3" = "xyes" ; then
+   CFLAGS="$CFLAGS -DENABLE_GTK3"
+   gtk_modules="gtk+-3.0 >= 3.0.0"

--- a/lxde-base/lxappearance-obconf/files/lxappearance-obconf-0.2.3-no-undefined.patch
+++ b/lxde-base/lxappearance-obconf/files/lxappearance-obconf-0.2.3-no-undefined.patch
@@ -1,0 +1,25 @@
+Bug: https://bugs.gentoo.org/779484
+
+From: orbea <orbea@riseup.net>
+Date: Mon, 11 Jul 2022 17:23:36 -0700
+Subject: [PATCH] build: Remove -no-undefined
+
+This depends on lxappearance_changed which is only available in the
+lxappearence binary and will be undefined at build time. Additionally
+GNU libtool silently ignores -no-undefined allowing the build to work
+while slibtool will respect it as expected.
+
+The easiest way to solve this is to just remove -no-undefined since it
+is not respected anyways.
+
+--- a/configure.ac
++++ b/configure.ac
+@@ -126,7 +126,7 @@ AC_SUBST(LXAPPEARANCE_LIBDIR)
+ AC_SUBST(LXAPPEARANCE_DATADIR)
+ 
+ LXAPPEARANCE_MODULE="-avoid-version \
+-    -no-undefined "'-export-symbols-regex "^[[^_]].*"'
++    "'-export-symbols-regex "^[[^_]].*"'
+ AC_SUBST(LXAPPEARANCE_MODULE)
+ 
+ if test x"$enable_more_warnings" = x"yes"; then

--- a/lxde-base/lxappearance-obconf/lxappearance-obconf-0.2.3-r2.ebuild
+++ b/lxde-base/lxappearance-obconf/lxappearance-obconf-0.2.3-r2.ebuild
@@ -1,0 +1,61 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools
+
+DESCRIPTION="LXAppearance plugin for configuring OpenBox"
+HOMEPAGE="https://lxde.org/"
+SRC_URI="mirror://sourceforge/lxde/${P}.tar.xz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~mips ~ppc ~riscv ~x86"
+IUSE=""
+
+RDEPEND="
+	dev-libs/atk
+	dev-libs/glib:2
+	dev-libs/libxml2:2
+	gnome-base/librsvg:2
+	>=lxde-base/lxappearance-0.6.3-r2
+	media-libs/fontconfig
+	media-libs/freetype:2
+	media-libs/harfbuzz:=
+	x11-libs/cairo[X]
+	x11-libs/gdk-pixbuf:2
+	x11-libs/gtk+:3
+	x11-libs/libICE
+	x11-libs/libSM
+	x11-libs/libX11
+	x11-libs/libXft
+	x11-libs/pango
+	x11-wm/openbox
+"
+DEPEND="${RDEPEND}"
+BDEPEND="
+	dev-util/intltool
+	virtual/pkgconfig
+"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-no-undefined.patch # 779484
+	"${FILESDIR}"/${P}-cairo-xlib.patch
+)
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_configure() {
+	econf \
+		--disable-static \
+		--enable-gtk3
+}
+
+src_install() {
+	default
+	find "${ED}" -name '*.la' -delete || die
+}


### PR DESCRIPTION
Also fixes a `-Wimplicit-function-declaration` for `cairo_xlib_surface_create`.

Bug: https://bugs.gentoo.org/779484