### PR TITLE
net-dialup/accel-ppp: revbumping and fix building on musl

### DIFF
--- a/net-dialup/accel-ppp/accel-ppp-1.12.0_p20210430-r1.ebuild
+++ b/net-dialup/accel-ppp/accel-ppp-1.12.0_p20210430-r1.ebuild
@@ -1,0 +1,119 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+LUA_COMPAT=( lua5-1 )
+
+inherit cmake flag-o-matic linux-info linux-mod lua-single
+
+DESCRIPTION="High performance PPTP, PPPoE and L2TP server"
+HOMEPAGE="https://sourceforge.net/projects/accel-ppp/"
+SRC_URI="https://dev.gentoo.org/~pinkbyte/distfiles/snapshots/${P}.tar.bz2"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64"
+IUSE="debug doc ipoe libtomcrypt lua postgres radius shaper snmp valgrind"
+
+RDEPEND="!libtomcrypt? ( dev-libs/openssl:0= )
+	libtomcrypt? ( dev-libs/libtomcrypt:0= )
+	lua? ( ${LUA_DEPS} )
+	postgres? ( dev-db/postgresql:* )
+	snmp? ( net-analyzer/net-snmp )
+	dev-libs/libpcre
+	elibc_musl? ( sys-libs/libucontext )"
+DEPEND="${RDEPEND}
+	valgrind? ( dev-util/valgrind )"
+PDEPEND="net-dialup/ppp-scripts"
+
+DOCS=( README )
+
+CONFIG_CHECK="~L2TP ~PPPOE ~PPTP"
+
+REQUIRED_USE="lua? ( ${LUA_REQUIRED_USE} )
+	valgrind? ( debug )"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-1.11.1-socklen.patch"
+	"${FILESDIR}/${PN}-1.12.0-ucontext.patch"
+	"${FILESDIR}/${PN}-1.12.0-printf.patch"
+	"${FILESDIR}/${PN}-1.12.0-tsearch.patch"
+	"${FILESDIR}/${PN}-1.12.0-if_arp.patch"
+)
+
+S="${WORKDIR}"
+
+pkg_setup() {
+	if use ipoe; then
+		linux-mod_pkg_setup
+		set_arch_to_kernel
+	else
+		linux-info_pkg_setup
+	fi
+	use lua && lua-single_pkg_setup
+}
+
+src_prepare() {
+	sed -i  -e "/mkdir/d" \
+		-e "s: RENAME accel-ppp.conf.dist::" accel-pppd/CMakeLists.txt || die 'sed on accel-pppd/CMakeLists.txt failed'
+
+	# Do not install kernel modules like that - breaks sandbox!
+	sed -i -e '/modules_install/d' \
+		drivers/ipoe/CMakeLists.txt \
+		drivers/vlan_mon/CMakeLists.txt || die
+
+	# Fix version
+	sed -i -e "s/1.11/${PV}/" drivers/ipoe/ipoe.c || die
+	sed -i -e "s/1.11/${PV}/" drivers/vlan_mon/vlan_mon.c || die
+
+	# Bug #549918
+	append-ldflags -Wl,-z,lazy
+
+	cmake_src_prepare
+}
+
+src_configure() {
+	local libdir="$(get_libdir)"
+	local mycmakeargs=(
+		-DLIB_SUFFIX="${libdir#lib}"
+		-DBUILD_IPOE_DRIVER="$(usex ipoe)"
+		-DBUILD_PPTP_DRIVER=no
+		-DBUILD_VLAN_MON_DRIVER="$(usex ipoe)"
+		-DCRYPTO="$(usex libtomcrypt TOMCRYPT OPENSSL)"
+		-DLOG_PGSQL="$(usex postgres)"
+		-DLUA="$(usex lua TRUE FALSE)"
+		-DMEMDEBUG="$(usex debug)"
+		-DNETSNMP="$(usex snmp)"
+		-DRADIUS="$(usex radius)"
+		-DSHAPER="$(usex shaper)"
+		$(use debug && echo "-DVALGRIND=$(usex valgrind)")
+		-DUSE_LIBUCONTEXT="$(usex elibc_musl)"
+	)
+	cmake_src_configure
+}
+
+src_compile() {
+	cmake_src_compile
+}
+
+src_install() {
+	if use ipoe; then
+		local MODULE_NAMES="ipoe(accel-ppp:${BUILD_DIR}/drivers/ipoe/driver) vlan_mon(accel-ppp:${BUILD_DIR}/drivers/vlan_mon/driver)"
+		linux-mod_src_install
+	fi
+
+	cmake_src_install
+
+	use doc && dodoc -r rfc
+
+	if use snmp; then
+		insinto /usr/share/snmp/mibs
+		doins accel-pppd/extra/net-snmp/ACCEL-PPP-MIB.txt
+	fi
+
+	newinitd "${FILESDIR}"/${PN}.initd ${PN}d
+	newconfd "${FILESDIR}"/${PN}.confd ${PN}d
+
+	keepdir /var/log/accel-ppp
+}

--- a/net-dialup/accel-ppp/files/accel-ppp-1.12.0-if_arp.patch
+++ b/net-dialup/accel-ppp/files/accel-ppp-1.12.0-if_arp.patch
@@ -1,0 +1,30 @@
+# Dont use if_arp on musl libc. Causes redefinition error
+#
+# Taken from Alpine linux patch:
+# https://git.alpinelinux.org/aports/tree/community/accel-ppp/0004-if_arp.patch
+#
+# Closes: https://bugs.gentoo.org/828906
+--- a/accel-pppd/ctrl/ipoe/arp.c
++++ b/accel-pppd/ctrl/ipoe/arp.c
+@@ -13,7 +13,9 @@
+ #include <netinet/ip.h>
+ #include <sys/socket.h>
+ #include <sys/ioctl.h>
++#if defined(__GLIBC__)
+ #include <linux/if_arp.h>
++#endif
+ #include <linux/if_packet.h>
+
+ #include "list.h"
+--- a/accel-pppd/ctrl/ipoe/ipoe.c
++++ b/accel-pppd/ctrl/ipoe/ipoe.c
+@@ -15,7 +15,9 @@
+ #include <sys/socket.h>
+ #include <sys/ioctl.h>
+ #include <linux/if.h>
++#if defined(__GLIBC__)
+ #include <linux/if_arp.h>
++#endif
+ #include <linux/route.h>
+
+ #include <pcre.h>

--- a/net-dialup/accel-ppp/files/accel-ppp-1.12.0-printf.patch
+++ b/net-dialup/accel-ppp/files/accel-ppp-1.12.0-printf.patch
@@ -1,0 +1,16 @@
+# No need to include printf.h
+#
+# Taken Alpine linux patch:
+# https://git.alpinelinux.org/aports/tree/community/accel-ppp/0002-printf.patch
+#
+# Closes: https://bugs.gentoo.org/828906
+--- a/accel-pppd/ctrl/pppoe/pppoe.c
++++ b/accel-pppd/ctrl/pppoe/pppoe.c
+@@ -11,7 +11,6 @@
+ #include <net/ethernet.h>
+ #include <netpacket/packet.h>
+ #include <arpa/inet.h>
+-#include <printf.h>
+
+ #include "crypto.h"
+

--- a/net-dialup/accel-ppp/files/accel-ppp-1.12.0-tsearch.patch
+++ b/net-dialup/accel-ppp/files/accel-ppp-1.12.0-tsearch.patch
@@ -1,0 +1,17 @@
+# Don't type cast l2tp_tunnel_free_sessions on musl libc
+#
+# Taken from Alpine linux patch:
+# https://git.alpinelinux.org/aports/tree/community/accel-ppp/0003-tsearch.patch
+#
+# Closes: https://bugs.gentoo.org/828906
+--- a/accel-pppd/ctrl/l2tp/l2tp.c
++++ b/accel-pppd/ctrl/l2tp/l2tp.c
+@@ -852,7 +852,7 @@ static void l2tp_tunnel_free_sessions(struct l2tp_conn_t *conn)
+ 	void *sessions = conn->sessions;
+
+ 	conn->sessions = NULL;
+-	tdestroy(sessions, (__free_fn_t)l2tp_session_free);
++	tdestroy(sessions, l2tp_session_free);
+ 	/* Let l2tp_session_free() handle the session counter and
+ 	 * the reference held by the tunnel.
+ 	 */

--- a/net-dialup/accel-ppp/files/accel-ppp-1.12.0-ucontext.patch
+++ b/net-dialup/accel-ppp/files/accel-ppp-1.12.0-ucontext.patch
@@ -1,0 +1,30 @@
+# Use ucontext, this is specific to musl libc
+#
+# Modified from Alpine linux patch:
+# https://git.alpinelinux.org/aports/tree/community/accel-ppp/0001-ucontext.patch
+#
+# Closes: https://bugs.gentoo.org/828906
+--- a/accel-pppd/CMakeLists.txt
++++ b/accel-pppd/CMakeLists.txt
+@@ -113,7 +113,21 @@ ADD_EXECUTABLE(accel-pppd
+ 	main.c
+ )
+
++option(USE_LIBUCONTEXT "Use libucontext on non glibc systems" OFF)
++IF(USE_LIBUCONTEXT)
++	find_library(LIBUCONTEXT_LIBRARY ucontext)
++
++	IF(NOT LIBUCONTEXT_LIBRARY)
++		message(FATAL_ERROR "Required libucontext not found.\n Install ucontext and run cmake again")
++	ENDIF(NOT LIBUCONTEXT_LIBRARY)
++ENDIF(USE_LIBUCONTEXT)
++
+ TARGET_LINK_LIBRARIES(accel-pppd triton rt pthread ${crypto_lib} pcre)
++
++IF(USE_LIBUCONTEXT)
++	TARGET_LINK_LIBRARIES(accel-pppd ucontext)
++ENDIF(USE_LIBUCONTEXT)
++
+ set_property(TARGET accel-pppd PROPERTY CMAKE_SKIP_BUILD_RPATH FALSE)
+ set_property(TARGET accel-pppd PROPERTY CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
+ set_property(TARGET accel-pppd PROPERTY INSTALL_RPATH_USE_LINK_PATH FALSE)


### PR DESCRIPTION
Patches taken from alpine linux to fix build on musl. Only major change
is making accel-ppp on libucontext.

Closes: https://bugs.gentoo.org/828906

Signed-off-by: brahmajit das <brahmajit.xyz@gmail.com>