### PR TITLE
media-libs/babl: 0.1.92-r1. Fix universal_nonlinear_rgb_u8_converter_sse2

### DIFF
--- a/media-libs/babl/babl-0.1.92-r1.ebuild
+++ b/media-libs/babl/babl-0.1.92-r1.ebuild
@@ -1,0 +1,68 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+VALA_USE_DEPEND=vapigen
+
+inherit meson gnome2-utils vala
+
+if [[ ${PV} == *9999* ]]; then
+	inherit git-r3
+	EGIT_REPO_URI="https://gitlab.gnome.org/GNOME/babl.git"
+	SRC_URI=""
+else
+	SRC_URI="https://ftp.gimp.org/pub/${PN}/${PV:0:3}/${P}.tar.xz"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~riscv -sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x64-solaris ~x86-solaris"
+fi
+
+DESCRIPTION="A dynamic, any to any, pixel format conversion library"
+HOMEPAGE="https://gegl.org/babl/"
+
+LICENSE="LGPL-3"
+SLOT="0"
+IUSE="introspection lcms vala cpu_flags_x86_avx2 cpu_flags_x86_f16c cpu_flags_x86_mmx cpu_flags_x86_sse cpu_flags_x86_sse2 cpu_flags_x86_sse4_1"
+REQUIRED_USE="vala? ( introspection )"
+
+BDEPEND="
+	virtual/pkgconfig
+	vala? ( $(vala_depend) )
+"
+RDEPEND="
+	introspection? ( >=dev-libs/gobject-introspection-1.32:= )
+	lcms? ( >=media-libs/lcms-2.8:2 )
+"
+DEPEND="${RDEPEND}"
+
+PATCHES=(
+	"${FILESDIR}/${P}_universal_nonlinear_rgb_u8_converter_sse2.patch" # Bug 857708
+)
+
+src_prepare() {
+	default
+	gnome2_environment_reset
+
+	sed -i -e 's/Description/description/' meson.build || die # bug 843266
+}
+
+src_configure() {
+	use vala && vala_setup
+
+	# Automagic rsvg support is just for website generation we do not call,
+	#     so we don't need to fix it
+	# w3m is used for dist target thus no issue for us that it is automagically
+	#     detected
+	local emesonargs=(
+		-Dwith-docs=false
+		$(meson_use introspection enable-gir)
+		$(meson_use lcms with-lcms)
+		$(meson_use vala enable-vapi)
+		$(meson_use cpu_flags_x86_avx2 enable-avx2)
+		$(meson_use cpu_flags_x86_f16c enable-f16c)
+		$(meson_use cpu_flags_x86_mmx enable-mmx)
+		$(meson_use cpu_flags_x86_sse enable-sse)
+		$(meson_use cpu_flags_x86_sse2 enable-sse2)
+		$(meson_use cpu_flags_x86_sse4_1 enable-sse4_1)
+	)
+	meson_src_configure
+}

--- a/media-libs/babl/files/babl-0.1.92_universal_nonlinear_rgb_u8_converter_sse2.patch
+++ b/media-libs/babl/files/babl-0.1.92_universal_nonlinear_rgb_u8_converter_sse2.patch
@@ -1,0 +1,17 @@
+Fix alignment of vector of floats in babl-rgb-converter.c
+Bug: https://bugs.gentoo.org/857708
+Signed-off-by: Alexander Bezrukov <phmagic@mail.ru>
+
+diff -ur a/babl/base/babl-rgb-converter.c b/babl/base/babl-rgb-converter.c
+--- a/babl/base/babl-rgb-converter.c
++++ b/babl/base/babl-rgb-converter.c
+@@ -306,7 +306,8 @@
+   uint8_t *rgb_in_u8 = (void*)src_char;
+   uint8_t *rgb_out_u8 = (void*)dst_char;
+ 
+-  float rgba_out[4*samples];
++  // The alignment is necessary for SIMD intrinsics in babl_matrix_mul_vectorff_buf4_sse2()
++  float __attribute__ ((aligned (16))) rgba_out[4*samples];
+ 
+   for (i = 0; i < samples; i++)
+   {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/857708

