### PR TITLE
sys-cluster/galera: Fix build on musl

### DIFF
--- a/sys-cluster/galera/files/galera-26.4.10-gcomm-test-check-fix.patch
+++ b/sys-cluster/galera/files/galera-26.4.10-gcomm-test-check-fix.patch
@@ -1,0 +1,12 @@
+# Patches from Alpine linux:
+# https://git.alpinelinux.org/aports/tree/testing/galera/fix_gcomm-test-check_evs2.patch
+--- a/gcomm/test/check_evs2.cpp
++++ b/gcomm/test/check_evs2.cpp
+@@ -2583,6 +2583,7 @@ START_TEST(test_representative_incarnation_change)
+     gu::datetime::SimClock::inc_time(300 * gu::datetime::MSec);
+     evs_from_dummy(dn[1])->handle_timers();
+     evs_from_dummy(dn[2])->handle_timers();
++    prop.propagate_until_empty();
+     ck_assert(evs_from_dummy(dn[1])->state() == gcomm::evs::Proto::S_GATHER);
+     ck_assert(evs_from_dummy(dn[2])->state() == gcomm::evs::Proto::S_GATHER);
+

--- a/sys-cluster/galera/files/galera-26.4.10-musl-page_size-redef.patch
+++ b/sys-cluster/galera/files/galera-26.4.10-musl-page_size-redef.patch
@@ -1,0 +1,25 @@
+# Little bit modified version of Alpine linux patch to make it work for both
+# musl and other libc
+# https://git.alpinelinux.org/aports/tree/testing/galera/musl-page-size.patch
+# Closes: https://bugs.gentoo.org/829176
+--- a/galerautils/src/gu_alloc.cpp
++++ b/galerautils/src/gu_alloc.cpp
+@@ -29,10 +29,18 @@ gu::Allocator::HeapStore::my_new_page (page_size_type const size)
+     if (gu_likely(size <= left_))
+     {
+         /* to avoid too frequent allocation, make it (at least) 64K */
++#if !defined(PAGE_SIZE)
+         static page_size_type const PAGE_SIZE(gu_page_size_multiple(1 << 16));
++#else /* On musl PAGE_SIZE is already defined to PAGESIZE, check file include/limits.h*/
++        static page_size_type const PAGE_SZ(gu_page_size_multiple(1 << 16));
++#endif
+
+         page_size_type const page_size
++#if !defined(PAGE_SIZE)
+             (std::min(std::max(size, PAGE_SIZE), left_));
++#else
++            (std::min(std::max(size, PAGE_SZ), left_));
++#endif
+
+         Page* ret = new HeapPage (page_size);
+

--- a/sys-cluster/galera/files/galera-26.4.10-musl-sched-param.patch
+++ b/sys-cluster/galera/files/galera-26.4.10-musl-sched-param.patch
@@ -1,0 +1,18 @@
+# Fix building on musl
+# Patch taken from Alpine Linux
+# https://git.alpinelinux.org/aports/tree/testing/galera/musl-sched_param.patch
+--- a/galerautils/src/gu_thread.cpp
++++ b/galerautils/src/gu_thread.cpp
+@@ -86,8 +86,11 @@ void gu::thread_set_schedparam(pthread_t thd, const gu::ThreadSchedparam& sp)
+     if (schedparam_not_supported) return;
+ #if defined(__sun__)
+     struct sched_param spstr = { sp.prio(), { 0, } /* sched_pad array */};
+-#else
++#elif defined(__GLIBC__)
+     struct sched_param spstr = { sp.prio() };
++#else
++    /* musl has some reserved fields in sched_param... */
++    struct sched_param spstr = { sp.prio(), 0, 0, 0, 0, 0, 0 };
+ #endif
+     int err;
+     if ((err = pthread_setschedparam(thd, sp.policy(), &spstr)) != 0)

--- a/sys-cluster/galera/files/galera-26.4.10-musl-wordsize.patch
+++ b/sys-cluster/galera/files/galera-26.4.10-musl-wordsize.patch
@@ -1,0 +1,22 @@
+# Correct includes for WORDSIZE
+# Patch from Alpine Linux
+# https://git.alpinelinux.org/aports/tree/testing/galera/musl-wordsize.patch
+#
+# Cloese: https://bugs.gentoo.org/829176
+--- a/galerautils/src/gu_arch.h
++++ b/galerautils/src/gu_arch.h
+@@ -50,9 +50,13 @@
+ #elif defined(__APPLE__) || defined(__FreeBSD__)
+ # include <stdint.h>
+ # define GU_WORDSIZE __WORDSIZE
+-#else
++#elif defined(__GLIBC__)
+ # include <bits/wordsize.h>
+ # define GU_WORDSIZE __WORDSIZE
++#else  /* use this instead of bits/wordsize.h */
++# include <stdint.h>
++# include <bits/user.h>
++# define GU_WORDSIZE __WORDSIZE
+ #endif
+
+ #include <stdint.h>

--- a/sys-cluster/galera/galera-26.4.10-r1.ebuild
+++ b/sys-cluster/galera/galera-26.4.10-r1.ebuild
@@ -44,6 +44,10 @@ RDEPEND="${COMMON_DEPEND}"
 PATCHES=(
 	"${FILESDIR}/${PN}"-26.4.6-strip-extra-cflags.patch
 	"${FILESDIR}/${PN}"-26.4.8-respect-toolchain.patch
+	"${FILESDIR}/${PN}"-26.4.10-gcomm-test-check-fix.patch
+	"${FILESDIR}/${PN}"-26.4.10-musl-page_size-redef.patch
+	"${FILESDIR}/${PN}"-26.4.10-musl-sched-param.patch
+	"${FILESDIR}/${PN}"-26.4.10-musl-wordsize.patch
 )
 
 S="${WORKDIR}/${MY_P}"


### PR DESCRIPTION
These are patches that I've taken from Alpine linux, may be tweaked it
here and there, nothing much. These patches makes it possible to build
galera irrespective of the libc one has.

Closes: https://bugs.gentoo.org/829176

Signed-off-by: brahmajit das <brahmajit.xyz@gmail.com>