### PR TITLE
dev-libs/glib: Fix build on musl

### DIFF
--- a/dev-libs/glib/files/glib-2.72.3-remove-unneccesary-ngettext-usage.patch
+++ b/dev-libs/glib/files/glib-2.72.3-remove-unneccesary-ngettext-usage.patch
@@ -1,0 +1,50 @@
+ngettext really does not make sense here.
+breaks build on musl.
+https://www.gnu.org/software/gettext/manual/html_node/Plural-forms.html
+
+---
+ gio/gunixconnection.c | 14 +++-----------
+ 1 file changed, 3 insertions(+), 11 deletions(-)
+
+diff --git a/gio/gunixconnection.c b/gio/gunixconnection.c
+index e89aba6..a671f6c 100644
+--- a/gio/gunixconnection.c
++++ b/gio/gunixconnection.c
+@@ -175,10 +175,7 @@ g_unix_connection_receive_fd (GUnixConnection  *connection,
+       gint i;
+ 
+       g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+-        ngettext("Expecting 1 control message, got %d",
+-                 "Expecting 1 control message, got %d",
+-                 nscm),
+-        nscm);
++        "Expecting 1 control message, got %d", nscm);
+ 
+       for (i = 0; i < nscm; i++)
+         g_object_unref (scms[i]);
+@@ -209,10 +206,7 @@ g_unix_connection_receive_fd (GUnixConnection  *connection,
+       gint i;
+ 
+       g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+-                   ngettext("Expecting one fd, but got %d\n",
+-                            "Expecting one fd, but got %d\n",
+-                            nfd),
+-                   nfd);
++                   "Expecting one fd, but got %d\n", nfd);
+ 
+       for (i = 0; i < nfd; i++)
+         close (fds[i]);
+@@ -593,9 +587,7 @@ g_unix_connection_receive_credentials (GUnixConnection      *connection,
+           g_set_error (error,
+                        G_IO_ERROR,
+                        G_IO_ERROR_FAILED,
+-                       ngettext("Expecting 1 control message, got %d",
+-                                "Expecting 1 control message, got %d",
+-                                nscm),
++                       "Expecting 1 control message, got %d",
+                        nscm);
+           goto out;
+         }
+-- 
+2.35.1
+

--- a/dev-libs/glib/glib-2.72.3.ebuild
+++ b/dev-libs/glib/glib-2.72.3.ebuild
@@ -70,6 +70,7 @@ MULTILIB_CHOST_TOOLS=(
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-2.64.1-mark-gdbus-server-auth-test-flaky.patch
+	"${FILESDIR}"/${PN}-2.72.3-remove-unneccesary-ngettext-usage.patch
 )
 
 pkg_setup() {


### PR DESCRIPTION
Glib uses ngettext unneccesarily and this patch removes it.
ngettext doesn't exist on musl.

Signed-off-by: Alfred Persson Forsberg <cat@catcream.org>