### PR TITLE
app-i18n/ibus-pinyin: Add Python 3.10 target

### DIFF
--- a/app-i18n/ibus-pinyin/ibus-pinyin-1.5.0-r5.ebuild
+++ b/app-i18n/ibus-pinyin/ibus-pinyin-1.5.0-r5.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 LUA_COMPAT=( lua5-1 )
-PYTHON_COMPAT=( python3_{8..9} )
+PYTHON_COMPAT=( python3_{8..10} )
 
 inherit autotools lua-single python-single-r1
 


### PR DESCRIPTION
With the transition to using Python 3.10 by default, ibus-pinyin is unable to build smoothly on a default world set, as noted by [the Gentoo Packages QA check](https://packages.gentoo.org/packages/app-i18n/ibus-pinyin/qa-report).
This minor revision simply adds `python_single_target_python3_10` as a compatible flag for ibus-pinyin.