### PR TITLE
sys-kernel/genkernel: add missing rdepends

### DIFF
--- a/sys-kernel/genkernel/genkernel-4.2.6-r5.ebuild
+++ b/sys-kernel/genkernel/genkernel-4.2.6-r5.ebuild
@@ -117,6 +117,9 @@ RDEPEND="${PYTHON_DEPS}
 	sys-devel/autoconf
 	sys-devel/autoconf-archive
 	sys-devel/automake
+	sys-devel/bc
+	sys-devel/bison
+	sys-devel/flex
 	sys-devel/libtool
 	virtual/pkgconfig
 	elibc_glibc? ( sys-libs/glibc[static-libs(+)] )

--- a/sys-kernel/genkernel/genkernel-9999.ebuild
+++ b/sys-kernel/genkernel/genkernel-9999.ebuild
@@ -119,6 +119,9 @@ RDEPEND="${PYTHON_DEPS}
 	sys-devel/autoconf
 	sys-devel/autoconf-archive
 	sys-devel/automake
+	sys-devel/bc
+	sys-devel/bison
+	sys-devel/flex
 	sys-devel/libtool
 	virtual/pkgconfig
 	elibc_glibc? ( sys-libs/glibc[static-libs(+)] )


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/846536