### PR TITLE
app-crypt/dehydrated: don't run cron job exactly on the hour

### DIFF
--- a/app-crypt/dehydrated/files/cron
+++ b/app-crypt/dehydrated/files/cron
@@ -1,2 +1,2 @@
 # dehydrated cron job
-#0 2 * * * dehydrated /usr/bin/dehydrated --cron
+#27 2 * * * dehydrated /usr/bin/dehydrated --cron


### PR DESCRIPTION
The Let's Encrypt API is often overwhelmed at 2:00 because a lot of
people call it exactly on the hour. I chose a number over 23 to make
minutes and hours instantly distinguishable.

Signed-off-by: Ronny (tastytea) Gutbrod <gentoo@tastytea.de>

----

The argument could be made that it would be better to use random numbers, but i don't think the number of users of dehydrated on Gentoo is big enough for that to matter much.