### PR TITLE
gui-wm/sway: EAPI bump, minor improvements

### DIFF
--- a/gui-wm/sway/sway-1.7-r2.ebuild
+++ b/gui-wm/sway/sway-1.7-r2.ebuild
@@ -46,8 +46,8 @@ if [[ ${PV} == 9999 ]]; then
 	DEPEND+="~gui-libs/wlroots-9999:=[X?]"
 else
 	DEPEND+="
-		>=gui-libs/wlroots-0.16:=[X?]
-		<gui-libs/wlroots-0.17:=[X?]
+		>=gui-libs/wlroots-0.15:=[X?]
+		<gui-libs/wlroots-0.16:=[X?]
 	"
 fi
 RDEPEND="


### PR DESCRIPTION
@prometheanfire 

Hi,

This PR improves the `sway` ebuild, details below:

* `EAPI` bump
* removes the `swaymsg` USE flag. As far as i could see this flag does nothing anyway and `swaymsg` would be build all the time
* remove `swaybg` `swayidle` `swaylock` USE flags and suggest them via the `optfeature` eclass.
* update the dependencies:
  - wallpapers doesn't need `x11-libs/gdk-pixbuf:2[jpeg]` since the wallpapers are `png` files (besides that, the dependency should be on `swaybg[gdk-pixbuf]`
  - `swaybar` needs to be set when `tray` is set too, hence the change in the `REQUIRED_USE`
* add a pkg_postinst with the relevant information about additional tools and addons.


_There is however still a issue here: For some reason the `pkg_postinst` doesn't work and doesn't print anything. Any idea why that is the case? I couldn't find a problem..._
**Edit:** I've now tried a few things and i'm almost sure it's not a problem with the ebuild. I think somehow `ebuild` messes up here. It works when i do `ROOT=/tmp/ ebuild sway-1.7-r2.ebuild postinst`. I guess it messes up because i have sway in my local overlay too..




One more note: `x11-libs/gdk-pixbuf:2` shouldn't be required for `swaybar` as it doesn't link against gdk-pixbuf. It only links against gdk-pixbuf it the `tray` use flag is set. First i wanted to change it to something like this:
```
        media-libs/mesa[gles2,libglvnd(+)]
-       swaybar? ( x11-libs/gdk-pixbuf:2 )
-       tray? ( || (
-               sys-apps/systemd
-               sys-auth/elogind
-               sys-libs/basu
-       ) )
+       tray? (
+               x11-libs/gdk-pixbuf:2
+               || (
+                       sys-apps/systemd
+                       sys-auth/elogind
+                       sys-libs/basu
+               )
+       )
        X? ( x11-libs/libxcb:0= )

```
However, since it wouldn't fit with the meson features i decided not to change it. Any opinions here?


Package-Manager: Portage-3.0.30, Repoman-3.0.3
Signed-off-by: Michael Mair-Keimberger <mmk@levelnine.at>