### PR TITLE
media-libs/babl: add upstream bug link to patch

### DIFF
--- a/media-libs/babl/files/babl-0.1.92_universal_nonlinear_rgb_u8_converter_sse2.patch
+++ b/media-libs/babl/files/babl-0.1.92_universal_nonlinear_rgb_u8_converter_sse2.patch
@@ -1,5 +1,6 @@
 Fix alignment of vector of floats in babl-rgb-converter.c
 Bug: https://bugs.gentoo.org/857708
+Upstream-Bug: https://gitlab.gnome.org/GNOME/babl/-/issues/76
 Signed-off-by: Alexander Bezrukov <phmagic@mail.ru>
 
 diff -ur a/babl/base/babl-rgb-converter.c b/babl/base/babl-rgb-converter.c


### PR DESCRIPTION
Add upstream bug link to `universal_nonlinear_rgb_u8_converter_sse2.patch`

Bug: https://bugs.gentoo.org/857708
Upstream-Bug: https://gitlab.gnome.org/GNOME/babl/-/issues/76

Proposed upstream merge request to fix related issue: https://gitlab.gnome.org/GNOME/babl/-/merge_requests/50
