### PR TITLE
dev-util/sysdig-kmod: fix kmod build on kernels >= 5.18

### DIFF
--- a/dev-util/sysdig-kmod/files/0.27.1-fix-kmod-build-on-5.18+.patch
+++ b/dev-util/sysdig-kmod/files/0.27.1-fix-kmod-build-on-5.18+.patch
@@ -1,0 +1,63 @@
+
+Bug: https://bugs.gentoo.org/852314
+Source: https://github.com/falcosecurity/libs/pull/411/commits/36e945af4feb31c8b875f7d4624592b0c1ff929d
+
+From 36e945af4feb31c8b875f7d4624592b0c1ff929d Mon Sep 17 00:00:00 2001
+From: Federico Di Pierro <nierro92@gmail.com>
+Date: Mon, 20 Jun 2022 14:26:39 +0200
+Subject: [PATCH] fix(driver): fixed kmod build on linux kernels >= 5.18.
+
+Signed-off-by: Federico Di Pierro <nierro92@gmail.com>
+---
+ driver/main.c | 14 +++++++++-----
+ 1 file changed, 9 insertions(+), 5 deletions(-)
+
+diff --git a/driver/main.c b/driver/main.c
+index 6b5ae461a..e606cc2f8 100644
+--- a/driver/main.c
++++ b/driver/main.c
+@@ -70,8 +70,9 @@ MODULE_AUTHOR("the Falco authors");
+     #define TRACEPOINT_PROBE(probe, args...) static void probe(void *__data, args)
+ #endif
+ 
+-#ifndef pgprot_encrypted
+-#define pgprot_encrypted(x) (x)
++// Allow build even on arch where PAGE_ENC is not implemented
++#ifndef _PAGE_ENC
++#define _PAGE_ENC 0
+ #endif
+ 
+ struct ppm_device {
+@@ -1217,8 +1218,9 @@ static int ppm_mmap(struct file *filp, struct vm_area_struct *vma)
+ 
+ 			pfn = vmalloc_to_pfn(vmalloc_area_ptr);
+ 
++			pgprot_val(vma->vm_page_prot) = pgprot_val(PAGE_SHARED) | _PAGE_ENC;
+ 			ret = remap_pfn_range(vma, useraddr, pfn,
+-					      PAGE_SIZE, pgprot_encrypted(PAGE_SHARED));
++					      PAGE_SIZE, vma->vm_page_prot);
+ 			if (ret < 0) {
+ 				pr_err("remap_pfn_range failed (1)\n");
+ 				goto cleanup_mmap;
+@@ -1255,8 +1257,9 @@ static int ppm_mmap(struct file *filp, struct vm_area_struct *vma)
+ 			while (mlength > 0) {
+ 				pfn = vmalloc_to_pfn(vmalloc_area_ptr);
+ 
++				pgprot_val(vma->vm_page_prot) = pgprot_val(PAGE_SHARED) | _PAGE_ENC;
+ 				ret = remap_pfn_range(vma, useraddr, pfn,
+-						      PAGE_SIZE, pgprot_encrypted(PAGE_SHARED));
++						      PAGE_SIZE, vma->vm_page_prot);
+ 				if (ret < 0) {
+ 					pr_err("remap_pfn_range failed (1)\n");
+ 					goto cleanup_mmap;
+@@ -1277,8 +1280,9 @@ static int ppm_mmap(struct file *filp, struct vm_area_struct *vma)
+ 			while (mlength > 0) {
+ 				pfn = vmalloc_to_pfn(vmalloc_area_ptr);
+ 
++				pgprot_val(vma->vm_page_prot) = pgprot_val(PAGE_SHARED) | _PAGE_ENC;
+ 				ret = remap_pfn_range(vma, useraddr, pfn,
+-						      PAGE_SIZE, pgprot_encrypted(PAGE_SHARED));
++						      PAGE_SIZE, vma->vm_page_prot);
+ 				if (ret < 0) {
+ 					pr_err("remap_pfn_range failed (1)\n");
+ 					goto cleanup_mmap;

--- a/dev-util/sysdig-kmod/sysdig-kmod-0.27.1.ebuild
+++ b/dev-util/sysdig-kmod/sysdig-kmod-0.27.1.ebuild
@@ -19,6 +19,8 @@ RDEPEND="!<=dev-util/sysdig-0.26.4[modules]"
 
 CONFIG_CHECK="HAVE_SYSCALL_TRACEPOINTS ~TRACEPOINTS"
 
+PATCHES=( "${FILESDIR}"/${PV}-fix-kmod-build-on-5.18+.patch )
+
 pkg_pretend() {
 	linux-mod_pkg_setup
 }


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/852314
Signed-off-by: Holger Hoffstätte <holger@applied-asynchrony.com>