### PR TITLE
net-misc/icaclient: package all utils

### DIFF
--- a/net-misc/icaclient/icaclient-22.7.0.20-r1.ebuild
+++ b/net-misc/icaclient/icaclient-22.7.0.20-r1.ebuild
@@ -180,38 +180,11 @@ src_install() {
 	insinto "${ICAROOT}"/keyboard
 	doins keyboard/*
 
+	cp -a util "${ED}/${ICAROOT}" || die
+	test -f util/HdxRtcEngine && fperms 0755 "${ICAROOT}"/util/HdxRtcEngine
+
 	rm -r "${S}"/keystore/cacerts || die
 	dosym ../../../../etc/ssl/certs "${ICAROOT}"/keystore/cacerts
-
-	local util_files=(
-		HdxRtcEngine
-		configmgr
-		conncenter
-		ctx_app_bind
-		ctx_rehash
-		ctxlogd
-		ctxwebhelper
-		echo_cmd
-		gst_play1.0
-		gst_read1.0
-		hdxcheck.sh
-		icalicense.sh
-		libgstflatstm1.0.so
-		lurdump
-		new_store
-		nslaunch
-		setlog
-		storebrowse
-		sunraymac.sh
-		webcontainer
-		what
-		xcapture
-	)
-
-	exeinto "${ICAROOT}"/util
-	for bin in ${util_files[@]} ; do
-		doexe util/${bin}
-	done
 
 	local other_files=(
 		icasessionmgr


### PR DESCRIPTION
We used to keep a list of files to actually package and we did change
permission bits on them.
Doing that is just error prone and means more maintenance work. Plus the
list is different across x86 and x86_64.

So now we ship it all and only apply one fix for one binary which has
incorrect permission bits in that upstream package.

In addition we might see more warnings on "Unresolved soname". We will
have to see how to deal with those. But taking the upstream binary
bundle apart and only deploying bits is just work which means more work
and potential for mistakes.

Closes: https://bugs.gentoo.org/856676
Signed-off-by: Henning Schild <henning@hennsch.de>