### PR TITLE
app-office/abiword: Fix lose precision on musl

### DIFF
--- a/app-office/abiword/abiword-3.0.5.ebuild
+++ b/app-office/abiword/abiword-3.0.5.ebuild
@@ -84,6 +84,7 @@ PATCHES=(
 	"${WORKDIR}"/patches/${PN}-3.0.4-pygobject.patch
 	"${WORKDIR}"/patches/${PN}-3.0.4-asio-standalone-placeholders.patch
 	"${WORKDIR}"/patches/${PN}-3.0.4-c++17-dynamic-exception-specifications.patch
+	"${FILESDIR}"/${PN}-3.0.5-musl-lose-precision-fix.patch
 )
 
 src_prepare() {

--- a/app-office/abiword/files/abiword-3.0.5-musl-lose-precision-fix.patch
+++ b/app-office/abiword/files/abiword-3.0.5-musl-lose-precision-fix.patch
@@ -1,0 +1,37 @@
+# Patch written by fellow Gentoo dev ernsteiswuerfel
+#
+# Please also reffer:
+# https://gitlab.gnome.org/World/AbiWord/-/commit/857cd86def49fe8557cfe123830c4d5a61eee732
+#
+# Closes: https://bugs.gentoo.org/853118
+--- a/src/af/xap/xp/xap_Dialog.cpp
++++ b/src/af/xap/xp/xap_Dialog.cpp
+@@ -36,8 +36,8 @@
+
+ XAP_Dialog::XAP_Dialog(XAP_DialogFactory * pDlgFactory, XAP_Dialog_Id id,
+ 		       const char * helpUrl )
+-  : m_pApp ( NULL ), m_pDlgFactory ( pDlgFactory ), m_id ( id ), 
+-	m_helpUrl(NULL)
++  : m_pApp ( nullptr ), m_pDlgFactory ( pDlgFactory ), m_id ( id ), 
++	m_helpUrl(nullptr)
+ {
+   m_pApp = pDlgFactory->getApp();
+
+@@ -235,7 +235,7 @@ XAP_Frame *   XAP_Dialog_Modeless::getActiveFrame(void) const
+ 	// This function returns the frame currently connected to a modeless dialog
+
+ 	XAP_Frame * pFrame = m_pApp->getLastFocussedFrame();
+-	if(pFrame == (XAP_Frame *) NULL)
++	if(pFrame == (XAP_Frame *) nullptr)
+ 	{
+ 		pFrame = m_pApp->getFrame(0);
+ 	}
+@@ -267,7 +267,7 @@ XAP_Dialog_Modeless::BuildWindowName(char * pWindowName, const char * pDialogNam
+ // This function constructs and returns the window name of a modeless dialog by
+ // concatenating the active frame with the dialog name
+
+-	*pWindowName = (char) NULL;
++	*pWindowName = (char) 0;
+ 	UT_UTF8String wn = UT_UTF8String(pDialogName);
+
+ 	XAP_Frame* pFrame = getActiveFrame();


### PR DESCRIPTION
abiword fails on musl with loses precision error for code
`*pWindowName = (char) NULL`. This patch fixes it. Patch is taken from
alpine linux [1]

[1]: https://git.alpinelinux.org/aports/tree/community/abiword/musl-1.2.3.patch

Closes: https://bugs.gentoo.org/853118

Signed-off-by: brahmajit das <listout@protonmail.com>