### PR TITLE
net-wireless/gr-osmosdr: allow building live with gnuradio-3.10

### DIFF
--- a/net-wireless/gr-osmosdr/gr-osmosdr-9999.ebuild
+++ b/net-wireless/gr-osmosdr/gr-osmosdr-9999.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-PYTHON_COMPAT=( python3_{7,8,9} )
+PYTHON_COMPAT=( python3_{7,8,9,10} )
 
 inherit cmake python-single-r1
 
@@ -24,7 +24,7 @@ IUSE="airspy bladerf hackrf iqbalance python rtlsdr sdrplay soapy uhd"
 #xtrx? ( net-wireless/libxtrx )
 RDEPEND="${PYTHON_DEPS}
 	dev-libs/boost:=
-	=net-wireless/gnuradio-3.8*:0=[${PYTHON_SINGLE_USEDEP}]
+	net-wireless/gnuradio:0=[${PYTHON_SINGLE_USEDEP}]
 	sci-libs/volk:=
 	airspy? ( net-wireless/airspy )
 	bladerf? ( >=net-wireless/bladerf-2018.08_rc1:= )


### PR DESCRIPTION
it supports both 3.8 and 3.10 these days