### PR TITLE
x11-misc/lightdm: Fix LC_IDENTIFICATION and updwtmpx on musl

### DIFF
--- a/x11-misc/lightdm/files/lightdm-1.30.0-musl-locale.patch
+++ b/x11-misc/lightdm/files/lightdm-1.30.0-musl-locale.patch
@@ -1,0 +1,40 @@
+# Fix LC_IDENTIFICATION undeclared on musl or other libc that doesn't have it defined
+# Patch is taken from Alpine linux [1]
+# [1]: https://git.alpinelinux.org/aports/tree/community/lightdm/musl-language.patch
+# Closes: https://bugs.gentoo.org/766866
+diff --git a/liblightdm-gobject/language.c b/liblightdm-gobject/language.c
+index 3d4fa96..e38f5ce 100644
+--- a/liblightdm-gobject/language.c
++++ b/liblightdm-gobject/language.c
+@@ -210,6 +210,7 @@ lightdm_language_get_name (LightDMLanguage *language)
+
+     if (!priv->name)
+     {
++#if HAVE_LC_IDENTIFICATION
+         g_autofree gchar *locale = get_locale_name (priv->code);
+         if (locale)
+         {
+@@ -223,6 +224,7 @@ lightdm_language_get_name (LightDMLanguage *language)
+
+             setlocale (LC_ALL, current);
+         }
++#endif
+         if (!priv->name)
+         {
+             g_auto(GStrv) tokens = g_strsplit_set (priv->code, "_.@", 2);
+@@ -250,6 +252,7 @@ lightdm_language_get_territory (LightDMLanguage *language)
+
+     if (!priv->territory && strchr (priv->code, '_'))
+     {
++#if HAVE_LC_IDENTIFICATION
+         g_autofree gchar *locale = get_locale_name (priv->code);
+         if (locale)
+         {
+@@ -263,6 +266,7 @@ lightdm_language_get_territory (LightDMLanguage *language)
+
+             setlocale (LC_ALL, current);
+         }
++#endif
+         if (!priv->territory)
+         {
+             g_auto(GStrv) tokens = g_strsplit_set (priv->code, "_.@", 3);

--- a/x11-misc/lightdm/files/lightdm-1.30.0-musl-updwtmpx.patch
+++ b/x11-misc/lightdm/files/lightdm-1.30.0-musl-updwtmpx.patch
@@ -1,0 +1,24 @@
+# A little bit modified version of Alpine linux patch [1]. On musl the default
+# implementation of updwtmpx will give conflicting types error and build will
+# fail. This patch should fix that. This issue is noticed together with bug
+# 766866 [2].
+# [1]: https://git.alpinelinux.org/aports/tree/community/lightdm/musl-updwtmpx.patch
+# [2]: https://bugs.gentoo.org/766866
+diff --git a/src/session-child.c b/src/session-child.c
+index eef51e4..0052904 100644
+--- a/src/session-child.c
++++ b/src/session-child.c
+@@ -193,8 +193,13 @@ read_xauth (void)
+ }
+
+ /* GNU provides this but we can't rely on that so let's make our own version */
++#if defined(__GLIBC__)
+ static void
+ updwtmpx (const gchar *wtmp_file, struct utmpx *ut)
++#else // use this version in libc's other than glibc
++void
++updwtmpx (const char *wtmp_file, const struct utmpx *ut)
++#endif
+ {
+     struct utmp u;
+     memset (&u, 0, sizeof (u));

--- a/x11-misc/lightdm/lightdm-1.30.0-r3.ebuild
+++ b/x11-misc/lightdm/lightdm-1.30.0-r3.ebuild
@@ -51,6 +51,11 @@ DOCS=( NEWS )
 RESTRICT="test"
 REQUIRED_USE="vala? ( introspection )"
 
+PATCHES=(
+	"${FILESDIR}"/${PN}-1.30.0-musl-locale.patch
+	"${FILESDIR}"/${PN}-1.30.0-musl-updwtmpx.patch
+)
+
 pkg_setup() {
 	export LIGHTDM_USER=${LIGHTDM_USER:-lightdm}
 }


### PR DESCRIPTION
This commit fixes two issues with lightdm on musl

- LC_IDENTIFICATION not being defined, and
- updwtmpx giving conflicting types

Patches are documented to the best of my abilities.
Let me know if something needs modification

Closes: https://bugs.gentoo.org/766866

Signed-off-by: brahmajit das <listout@protonmail.com>