### PR TITLE
net-libs/pjproject: Add minimum version to libsrtp.

### DIFF
--- a/net-libs/pjproject/pjproject-2.12.1-r1.ebuild
+++ b/net-libs/pjproject/pjproject-2.12.1-r1.ebuild
@@ -22,7 +22,7 @@ IUSE="amr debug epoll examples opus resample silk ssl static-libs webrtc
 	${VIDEO_FLAGS}
 	${SOUND_FLAGS}"
 
-RDEPEND="net-libs/libsrtp:=
+RDEPEND=">=net-libs/libsrtp-2.3.0:=
 	alsa? ( media-libs/alsa-lib )
 	amr? ( media-libs/opencore-amr )
 	ffmpeg? ( media-video/ffmpeg:= )


### PR DESCRIPTION
If you already have this successfully installed you already have a new
enough libsrtp, which negates the need for a bump, fixing in-place.

Package-Manager: Portage-3.0.30, Repoman-3.0.3
Signed-off-by: Jaco Kroon <jaco@uls.co.za>