### PR TITLE
net-misc/gns3-server: bump for newly added openrc script

### DIFF
--- a/acct-group/gns3/gns3-0.ebuild
+++ b/acct-group/gns3/gns3-0.ebuild
@@ -1,0 +1,8 @@
+# Copyright 2020-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit acct-group
+
+ACCT_GROUP_ID=522

--- a/acct-group/gns3/metadata.xml
+++ b/acct-group/gns3/metadata.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="person" proxied="yes">
+		<email>mmk@levelnine.at</email>
+		<name>Michael Mair-Keimberger</name>
+	</maintainer>
+	<maintainer type="project" proxied="proxy">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
+</pkgmetadata>

--- a/acct-user/gns3/gns3-0.ebuild
+++ b/acct-user/gns3/gns3-0.ebuild
@@ -1,0 +1,12 @@
+# Copyright 2019-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit acct-user
+
+ACCT_USER_ID=522
+ACCT_USER_HOME=/var/lib/gns3
+ACCT_USER_GROUPS=( gns3 ubridge )
+
+acct-user_add_deps

--- a/acct-user/gns3/metadata.xml
+++ b/acct-user/gns3/metadata.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="person" proxied="yes">
+		<email>mmk@levelnine.at</email>
+		<name>Michael Mair-Keimberger</name>
+	</maintainer>
+	<maintainer type="project" proxied="proxy">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
+</pkgmetadata>

--- a/net-misc/gns3-server/gns3-server-2.2.33.1-r1.ebuild
+++ b/net-misc/gns3-server/gns3-server-2.2.33.1-r1.ebuild
@@ -1,0 +1,74 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+PYTHON_COMPAT=( python3_{9..10} )
+DISTUTILS_USE_SETUPTOOLS=rdepend
+
+inherit distutils-r1 optfeature systemd
+
+DESCRIPTION="GNS3 server to asynchronously manage emulators"
+HOMEPAGE="https://www.gns3.com/ https://github.com/GNS3/gns3-server"
+SRC_URI="https://github.com/GNS3/gns3-server/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="GPL-3+"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+RDEPEND="
+	acct-group/gns3
+	acct-user/gns3
+	app-emulation/dynamips
+	>=dev-python/aiofiles-0.7.0[${PYTHON_USEDEP}]
+	>=dev-python/aiohttp-3.8.1[${PYTHON_USEDEP}]
+	>=dev-python/aiohttp-cors-0.7.0[${PYTHON_USEDEP}]
+	>=dev-python/async-timeout-4.0.2[${PYTHON_USEDEP}]
+	>=dev-python/distro-1.7.0[${PYTHON_USEDEP}]
+	>=dev-python/jinja-3.0.3[${PYTHON_USEDEP}]
+	>=dev-python/jsonschema-3.2.0[${PYTHON_USEDEP}]
+	>=dev-python/psutil-5.9.1[${PYTHON_USEDEP}]
+	>=dev-python/py-cpuinfo-8.0.0[${PYTHON_USEDEP}]
+	>=dev-python/sentry-sdk-1.5.12[${PYTHON_USEDEP}]
+	net-misc/ubridge
+	sys-apps/busybox
+"
+BDEPEND="
+	test? (
+		dev-python/pytest-aiohttp[${PYTHON_USEDEP}]
+	)
+"
+
+distutils_enable_tests pytest
+
+src_prepare() {
+	default
+
+	# newer python packages are fine
+	sed -i -e 's/[<>=].*//' requirements.txt || die
+
+	# Remove Pre-built busybox binary
+	rm gns3server/compute/docker/resources/bin/busybox || die
+}
+
+python_install() {
+	distutils-r1_python_install
+
+	systemd_dounit init/gns3.service.systemd
+	newinitd init/gns3.service.openrc gns3server
+
+	mkdir -p "${D}$(python_get_sitedir)/gns3server/compute/docker/resources/bin" || die
+	ln -s /bin/busybox "${D}$(python_get_sitedir)/gns3server/compute/docker/resources/bin/busybox" || die
+}
+
+pkg_postinst() {
+	elog "net-misc/gns3-server has several optional packages that must be merged manually for additional functionality."
+	elog ""
+	optfeature "QEMU Support" "app-emulation/qemu"
+	optfeature "Virtualbox Support" "app-emulation/virtualbox"
+	optfeature "Docker Support" "app-containers/docker"
+	optfeature "Wireshark Support" "net-analyzer/wireshark"
+	elog ""
+	elog "The following packages are currently unsupported:"
+	elog "iouyap and vpcs"
+}


### PR DESCRIPTION
Hi,

This updates the latest version of `gns3-server` to also install the newly added openrc script. (https://github.com/GNS3/gns3-server/commit/9d8ddea5776967ac33216ccdf36b8af7a9f12640)
With this script it's possible to use `gns3-server` without `gns3-gui` and use it with it's integrated web interface.

_I've checked https://wiki.gentoo.org/wiki/UID_GID_Assignment_Table and saw the next free `uid`/`gid` is `520`, which i took for the new user/group. Anything else i have todo here?_
**EDIT:** I've just changed the `uid`,`gid` to `521` since `520` is used by `firebird`..

Also, I've added `ubridge` to the groups of the `gns3` user (which is installed via `net-misc/ubrdige`). Technically it's not required, but `gns3` would be pretty useless without the group.
A home directory is required too since `gns3` needs a some place were it can save it's project files.