### PR TITLE
www-apps/jellyfin: Add confd to facilitate greater configurability

### DIFF
--- a/www-apps/jellyfin/files/jellyfin.confd
+++ b/www-apps/jellyfin/files/jellyfin.confd
@@ -1,0 +1,15 @@
+# This is the directory that will hold all Jellyfin data, and is also used as a default base directory for some other paths below.
+#JELLYFIN_DATA_DIR=/var/lib/jellyfin
+
+# This is the directory where the Jellyfin logs will be stored.
+#JELLYFIN_LOG_DIR=/var/log/jellyfin
+
+# This is the directory containing the server cache.
+#JELLYFIN_CACHE_DIR=/var/cache/jellyfin
+
+# This is the directory containing the server configuration files.
+#JELLYFIN_CONFIG_DIR=/etc/jellyfin
+
+# To configure Jellyfin to use a proxy, set http_proxy and/or https_proxy
+# export http_proxy=192.168.33.10:3128
+# export https_proxy=192.168.33.10:3129

--- a/www-apps/jellyfin/files/jellyfin.init-r1
+++ b/www-apps/jellyfin/files/jellyfin.init-r1
@@ -1,0 +1,24 @@
+#!/sbin/openrc-run
+
+: ${JELLYFIN_CACHE_DIR:=/var/cache/jellyfin}
+: ${JELLYFIN_LOG_DIR:=/var/log/jellyfin}
+: ${JELLYFIN_DATA_DIR:=/var/lib/jellyfin}
+: ${JELLYFIN_CONFIG_DIR:=/etc/jellyfin}
+
+pidfile="/run/${RC_SVCNAME}.pid"
+command="/opt/jellyfin/jellyfin"
+command_args="--logdir ${JELLYFIN_LOG_DIR} --cachedir ${JELLYFIN_CACHE_DIR} --configdir ${JELLYFIN_CONFIG_DIR} --datadir ${JELLYFIN_DATA_DIR}"
+command_user="${RC_SVCNAME}:${RC_SVCNAME}"
+command_background=true
+
+start_pre() {
+	# Ensure that our dirs are correct
+	checkpath --directory --owner jellyfin:jellyfin --mode 0775 \
+		${JELLYFIN_LOG_DIR}
+	checkpath --directory --owner jellyfin:jellyfin --mode 0775 \
+		${JELLYFIN_CACHE_DIR}
+	checkpath --directory --owner jellyfin:jellyfin --mode 0775 \
+		${JELLYFIN_CONFIG_DIR}
+	checkpath --directory --owner jellyfin:jellyfin --mode 0775 \
+		${JELLYFIN_DATA_DIR}
+}

--- a/www-apps/jellyfin/jellyfin-10.8.1-r2.ebuild
+++ b/www-apps/jellyfin/jellyfin-10.8.1-r2.ebuild
@@ -1,0 +1,57 @@
+# Copyright 2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit systemd
+
+DESCRIPTION="Jellyfin puts you in control of managing and streaming your media"
+HOMEPAGE="https://jellyfin.readthedocs.io/en/latest/"
+
+SRC_URI="
+	arm64? (
+		https://repo.jellyfin.org/releases/server/linux/stable/combined/${PN}_${PV}_arm64.tar.gz
+		https://repo.jellyfin.org/archive/linux/stable/${PV}/combined/${PN}_${PV}_arm64.tar.gz
+	)
+	amd64? (
+		https://repo.jellyfin.org/releases/server/linux/stable/combined/${PN}_${PV}_amd64.tar.gz
+		https://repo.jellyfin.org/archive/linux/stable/${PV}/combined/${PN}_${PV}_amd64.tar.gz
+	)"
+
+RESTRICT="mirror test"
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64"
+DEPEND="acct-user/jellyfin"
+RDEPEND="${DEPEND}
+	media-video/ffmpeg[vpx,x264]"
+BDEPEND="acct-user/jellyfin"
+INST_DIR="/opt/${PN}"
+QA_PREBUILT="${INST_DIR#/}/*.so ${INST_DIR#/}/jellyfin ${INST_DIR#/}/createdump"
+
+src_unpack() {
+	unpack ${A}
+	mv ${PN}_${PV} ${P} || die
+}
+
+src_prepare() {
+	default
+
+	# https://github.com/jellyfin/jellyfin/issues/7471
+	# https://github.com/dotnet/runtime/issues/57784
+	rm libcoreclrtraceptprovider.so || die
+}
+
+src_install() {
+	keepdir /var/log/jellyfin
+	fowners jellyfin:jellyfin /var/log/jellyfin
+	keepdir /etc/jellyfin
+	fowners jellyfin:jellyfin /etc/jellyfin
+	insinto ${INST_DIR}
+	dodir ${INST_DIR}
+	doins -r "${S}"/*
+	chmod 755 "${D}${INST_DIR}/jellyfin"
+	newinitd "${FILESDIR}/${PN}.init-r1" "${PN}"
+	newconfd "${FILESDIR}"/${PN}.confd "${PN}"
+	systemd_dounit "${FILESDIR}/${PN}.service"
+}


### PR DESCRIPTION
Allows easier modification of Jelly's log, cache, data, and
configuration directories, and allows configuration of a proxy.