### PR TITLE
app-text/mupdf-1.20.0: fix version in .pc file

### DIFF
--- a/app-text/mupdf/mupdf-1.20.0.ebuild
+++ b/app-text/mupdf/mupdf-1.20.0.ebuild
@@ -69,6 +69,11 @@ src_prepare() {
 		-e "1iverbose = yes" \
 		-e "1ibuild = debug" \
 		-i Makerules || die "Failed adding build variables to Makerules in src_prepare()"
+
+	# Adjust MuPDF version in .pc file created by the
+	# mupdf-1.10a-add-desktop-pc-xpm-files.patch file
+	sed -e "s/Version: \(.*\)/Version: ${PV}/" \
+		-i platform/debian/${PN}.pc || die "Failed substituting version in ${PN}.pc"
 }
 
 _emake() {


### PR DESCRIPTION
A wrong MuPDF version (0.5.0) was specified
in the pkgconfig file mupdf.pc, which is now
fixed via a sed substitution.

Closes: https://bugs.gentoo.org/859262
Signed-off-by: Philipp Rösner <rndxelement@protonmail.com>