### PR TITLE
x11-apps/sessreg: Fix wtmp path for musl

### DIFF
--- a/x11-apps/sessreg/files/sessreg-1.1.0-missing_path_wtmpx.patch
+++ b/x11-apps/sessreg/files/sessreg-1.1.0-missing_path_wtmpx.patch
@@ -1,0 +1,19 @@
+https://gitweb.gentoo.org/proj/musl.git/tree/x11-apps/sessreg/files/sessreg-1.1.0-missing_path_wtmpx.patch
+
+diff -Naur sessreg-1.1.0.orig/sessreg.h sessreg-1.1.0/sessreg.h
+--- sessreg-1.1.0.orig/sessreg.h	2015-01-20 05:00:27.000000000 +0000
++++ sessreg-1.1.0/sessreg.h	2016-02-23 11:54:42.057000000 +0000
+@@ -103,6 +103,13 @@
+ # define TTYS_FILE	"/etc/ttys"
+ #endif
+ 
++#ifndef _PATH_WTMPX
++# define _PATH_WTMPX	_PATH_WTMP
++#endif
++#ifndef _PATH_UTMPX
++# define _PATH_UTMPX	_PATH_UTMP
++#endif
++
+ #ifndef WTMPX_FILE
+ # define WTMPX_FILE	_PATH_WTMPX
+ #endif

--- a/x11-apps/sessreg/sessreg-1.1.2.ebuild
+++ b/x11-apps/sessreg/sessreg-1.1.2.ebuild
@@ -13,3 +13,7 @@ IUSE=""
 RDEPEND=""
 DEPEND="${RDEPEND}
 	x11-base/xorg-proto"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-1.1.0-missing_path_wtmpx.patch
+)


### PR DESCRIPTION
This patch is taken from ::musl.

As the patch checks if paths are defined before defining
them this should work just fine for glibc too.

See: https://gitweb.gentoo.org/proj/musl.git/tree/x11-apps/sessreg/files/sessreg-1.1.0-missing_path_wtmpx.patch
Signed-off-by: Alfred Persson Forsberg <cat@catcream.org>