### PR TITLE
x11-terms/xterm: Fix  fails to start with 'open ttydev: I/O error' musl

### DIFF
--- a/x11-terms/xterm/files/xterm-372-musl.patch
+++ b/x11-terms/xterm/files/xterm-372-musl.patch
@@ -1,0 +1,28 @@
+# Patch taken from Alpine linux [1]. Without this patch xterm won't work on
+# musl giving I/O Error. This error is a runtime error, so xterm builds without
+# any error without this patch.
+#
+# [1]: https://git.alpinelinux.org/aports/tree/community/xterm/posix-ptys.patch
+#
+# Closes: https://bugs.gentoo.org/689080
+--- a/main.c
++++ b/main.c
+@@ -2654,7 +2654,7 @@ get_pty(int *pty, char *from GCC_UNUSED)
+ 	close(opened_tty);
+ 	opened_tty = -1;
+     }
+-#elif defined(HAVE_POSIX_OPENPT) && defined(HAVE_PTSNAME) && defined(HAVE_GRANTPT_PTY_ISATTY)
++#elif defined(HAVE_POSIX_OPENPT) && defined(HAVE_PTSNAME)
+     if ((*pty = posix_openpt(O_RDWR)) >= 0) {
+ 	char *name = ptsname(*pty);
+ 	if (name != 0) {
+@@ -3735,7 +3735,7 @@ spawnXTerm(XtermWidget xw)
+ 	    /*
+ 	     * now in child process
+ 	     */
+-#if defined(_POSIX_SOURCE) || defined(SVR4) || defined(__convex__) || defined(__SCO__) || defined(__QNX__)
++#if defined(_POSIX_VERSION) || defined(SVR4) || defined(__convex__) || defined(__SCO__) || defined(__QNX__)
+ 	    int pgrp = setsid();	/* variable may not be used... */
+ #else
+ 	    int pgrp = getpid();
+

--- a/x11-terms/xterm/xterm-372-r1.ebuild
+++ b/x11-terms/xterm/xterm-372-r1.ebuild
@@ -1,0 +1,102 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit desktop flag-o-matic toolchain-funcs
+
+DESCRIPTION="Terminal Emulator for X Windows"
+HOMEPAGE="https://invisible-island.net/xterm/"
+SRC_URI="ftp://ftp.invisible-island.net/${PN}/${P}.tgz"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+IUSE="+openpty sixel toolbar truetype unicode Xaw3d xinerama"
+
+BDEPEND="virtual/pkgconfig
+	x11-base/xorg-proto"
+DEPEND="
+	kernel_linux? ( sys-libs/libutempter )
+	media-libs/fontconfig:1.0
+	>=sys-libs/ncurses-5.7-r7:0=
+	x11-apps/xmessage
+	x11-libs/libICE
+	x11-libs/libX11
+	x11-libs/libXaw
+	x11-libs/libXft
+	x11-libs/libxkbfile
+	x11-libs/libXmu
+	x11-libs/libXrender
+	x11-libs/libXt
+	unicode? ( x11-apps/luit )
+	Xaw3d? ( x11-libs/libXaw3d )
+	xinerama? ( x11-libs/libXinerama )"
+RDEPEND="${DEPEND}
+	media-fonts/font-misc-misc
+	x11-apps/rgb"
+
+DOCS=( README{,.i18n} ctlseqs.txt )
+
+PATCHES=(
+	"${FILESDIR}"/xterm-372-musl.patch
+)
+
+src_configure() {
+	DEFAULTS_DIR="${EPREFIX}"/usr/share/X11/app-defaults
+
+	# bug #454736
+	# Workaround for ncurses[tinfo] until upstream fixes their buildsystem using
+	# something sane like pkg-config or ncurses5-config and stops guessing libs
+	# Everything gets linked against ncurses anyways, so don't shout
+	append-libs $($(tc-getPKG_CONFIG) --libs ncurses)
+
+	local myeconfargs=(
+		--disable-full-tgetent
+		--disable-imake
+		--disable-setgid
+		--disable-setuid
+		--enable-256-color
+		--enable-broken-osc
+		--enable-broken-st
+		--enable-dabbrev
+		--enable-exec-xterm
+		--enable-i18n
+		--enable-load-vt-fonts
+		--enable-logging
+		--enable-screen-dumps
+		--enable-warnings
+		--enable-wide-chars
+		--libdir="${EPREFIX}"/etc
+		--with-app-defaults="${DEFAULTS_DIR}"
+		--with-utempter
+		--with-x
+		$(use_enable openpty)
+		$(use_enable sixel sixel-graphics)
+		$(use_enable toolbar)
+		$(use_enable truetype freetype)
+		$(use_enable unicode luit)
+		$(use_enable unicode mini-luit)
+		$(use_with Xaw3d)
+		$(use_with xinerama)
+	)
+
+	econf "${myeconfargs[@]}"
+}
+
+src_install() {
+	default
+
+	docinto html
+	dodoc xterm.log.html
+	domenu *.desktop
+
+	# Fix permissions -- it grabs them from live system, and they can
+	# be suid or sgid like they were in pre-unix98 pty or pre-utempter days,
+	# respectively (#69510).
+	# (info from Thomas Dickey) - Donnie Berkholz <spyderous@gentoo.org>
+	fperms 0755 /usr/bin/xterm
+
+	# restore the navy blue
+	sed -i -e 's:blue2$:blue:' "${D}${DEFAULTS_DIR}"/XTerm-color || die
+}


### PR DESCRIPTION
Patch taken from Alpine linux [1]. Without this patch xterm won't work on
musl giving I/O Error. This error is a runtime error, so xterm builds without
any error without this patch.

[1]: https://git.alpinelinux.org/aports/tree/community/xterm/posix-ptys.patch

Closes: https://bugs.gentoo.org/689080

Signed-off-by: brahmajit das <listout@protonmail.com>