### PR TITLE
games-fps/gzdoom: Filter LTO and disable strict aliasing

### DIFF
--- a/games-fps/gzdoom/gzdoom-4.8.2.ebuild
+++ b/games-fps/gzdoom/gzdoom-4.8.2.ebuild
@@ -44,6 +44,10 @@ src_prepare() {
 }
 
 src_configure() {
+	# https://bugs.gentoo.org/858749
+	filter-lto
+	append-flags -fno-strict-aliasing
+
 	local mycmakeargs=(
 		-DBUILD_SHARED_LIBS=OFF
 		-DINSTALL_DOCS_PATH="${EPREFIX}/usr/share/doc/${PF}"


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/858749
Signed-off-by: William Breathitt Gray <vilhelm.gray@gmail.com>