### PR TITLE
dev-libs/libffi: revbump 3.4.2-r2, fix ppc64 header defs

### DIFF
--- a/dev-libs/libffi/files/libffi-3.4.2-backport-pr-722.patch
+++ b/dev-libs/libffi/files/libffi-3.4.2-backport-pr-722.patch
@@ -1,0 +1,88 @@
+From f4d413725030b35ec2f01733b154489d0b4c6e1d Mon Sep 17 00:00:00 2001
+From: matoro <matoro@users.noreply.github.com>
+Date: Sun, 26 Jun 2022 23:19:00 -0400
+Subject: [PATCH] Move FFI_TYPE definitions above <ffitarget.h> include
+
+For powerpc at least, these definitions are referenced in the
+target-specific ffitarget.h.  Discovered in the jffi project.  Should
+close https://github.com/libffi/libffi/issues/637.  Downstream jffi bug
+https://github.com/jnr/jffi/issues/107.  Downstream distro bug
+https://bugs.gentoo.org/827215.
+
+Testing - both libffi and jffi test suites pass with this patch applied,
+at least on ppc64le linux.  I did not see any warnings about
+redefinitions.
+
+Tested versions - libffi 3.4.2, jffi 1.3.6 and 1.3.9.
+---
+ include/ffi.h.in | 50 ++++++++++++++++++++++++------------------------
+ 1 file changed, 25 insertions(+), 25 deletions(-)
+
+diff --git a/include/ffi.h.in b/include/ffi.h.in
+index d16f307e..6cd19baa 100644
+--- a/include/ffi.h.in
++++ b/include/ffi.h.in
+@@ -56,6 +56,31 @@ extern "C" {
+ 
+ /* ---- System configuration information --------------------------------- */
+ 
++/* If these change, update src/mips/ffitarget.h. */
++#define FFI_TYPE_VOID       0
++#define FFI_TYPE_INT        1
++#define FFI_TYPE_FLOAT      2
++#define FFI_TYPE_DOUBLE     3
++#if @HAVE_LONG_DOUBLE@
++#define FFI_TYPE_LONGDOUBLE 4
++#else
++#define FFI_TYPE_LONGDOUBLE FFI_TYPE_DOUBLE
++#endif
++#define FFI_TYPE_UINT8      5
++#define FFI_TYPE_SINT8      6
++#define FFI_TYPE_UINT16     7
++#define FFI_TYPE_SINT16     8
++#define FFI_TYPE_UINT32     9
++#define FFI_TYPE_SINT32     10
++#define FFI_TYPE_UINT64     11
++#define FFI_TYPE_SINT64     12
++#define FFI_TYPE_STRUCT     13
++#define FFI_TYPE_POINTER    14
++#define FFI_TYPE_COMPLEX    15
++
++/* This should always refer to the last type code (for sanity checks).  */
++#define FFI_TYPE_LAST       FFI_TYPE_COMPLEX
++
+ #include <ffitarget.h>
+ 
+ #ifndef LIBFFI_ASM
+@@ -496,31 +521,6 @@ ffi_status ffi_get_struct_offsets (ffi_abi abi, ffi_type *struct_type,
+ 
+ #endif
+ 
+-/* If these change, update src/mips/ffitarget.h. */
+-#define FFI_TYPE_VOID       0
+-#define FFI_TYPE_INT        1
+-#define FFI_TYPE_FLOAT      2
+-#define FFI_TYPE_DOUBLE     3
+-#if @HAVE_LONG_DOUBLE@
+-#define FFI_TYPE_LONGDOUBLE 4
+-#else
+-#define FFI_TYPE_LONGDOUBLE FFI_TYPE_DOUBLE
+-#endif
+-#define FFI_TYPE_UINT8      5
+-#define FFI_TYPE_SINT8      6
+-#define FFI_TYPE_UINT16     7
+-#define FFI_TYPE_SINT16     8
+-#define FFI_TYPE_UINT32     9
+-#define FFI_TYPE_SINT32     10
+-#define FFI_TYPE_UINT64     11
+-#define FFI_TYPE_SINT64     12
+-#define FFI_TYPE_STRUCT     13
+-#define FFI_TYPE_POINTER    14
+-#define FFI_TYPE_COMPLEX    15
+-
+-/* This should always refer to the last type code (for sanity checks).  */
+-#define FFI_TYPE_LAST       FFI_TYPE_COMPLEX
+-
+ #ifdef __cplusplus
+ }
+ #endif

--- a/dev-libs/libffi/libffi-3.4.2-r2.ebuild
+++ b/dev-libs/libffi/libffi-3.4.2-r2.ebuild
@@ -1,0 +1,80 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit multilib-minimal preserve-libs
+
+MY_PV=${PV/_rc/-rc}
+MY_P=${PN}-${MY_PV}
+
+DESCRIPTION="a portable, high level programming interface to various calling conventions"
+HOMEPAGE="https://sourceware.org/libffi/"
+SRC_URI="https://github.com/libffi/libffi/releases/download/v${MY_PV}/${MY_P}.tar.gz
+	experimental-loong? ( https://dev.gentoo.org/~xen0n/distfiles/${MY_P}-loongarch64-20220428.patch.xz )"
+S="${WORKDIR}"/${MY_P}
+
+LICENSE="MIT"
+# This is a core package which is depended on by e.g. Python
+# Please use preserve-libs.eclass in pkg_{pre,post}inst to cover users
+# with FEATURES="-preserved-libs" or another package manager if SONAME
+# changes.
+SLOT="0/8" # SONAME=libffi.so.8
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+IUSE="debug exec-static-trampoline experimental-loong pax-kernel static-libs test"
+
+RESTRICT="!test? ( test )"
+BDEPEND="test? ( dev-util/dejagnu )"
+
+DOCS="ChangeLog* README.md"
+
+ECONF_SOURCE=${S}
+
+PATCHES=( "${FILESDIR}/libffi-3.4.2-backport-pr-722.patch" ) # bug 827215
+
+src_prepare() {
+	if use experimental-loong; then
+		PATCHES+=( "${WORKDIR}/${MY_P}-loongarch64-20220428.patch" )
+	fi
+
+	default
+	if [[ ${CHOST} == arm64-*-darwin* ]] ; then
+		# ensure we use aarch64 asm, not x86 on arm64
+		sed -i -e 's/aarch64\*-\*-\*/arm64*-*-*|&/' \
+			configure configure.host || die
+	fi
+}
+
+multilib_src_configure() {
+	# --includedir= path maintains a few properties:
+	# 1. have stable name across libffi versions: some packages like
+	#    dev-lang/ghc or kde-frameworks/networkmanager-qt embed
+	#    ${includedir} at build-time. Don't require those to be
+	#    rebuilt unless SONAME changes. bug #695788
+	#
+	#    We use /usr/.../${PN} (instead of former /usr/.../${P}).
+	#
+	# 2. have ${ABI}-specific location as ffi.h is target-dependent.
+	#
+	#    We use /usr/$(get_libdir)/... to have ABI identifier.
+	econf \
+		--includedir="${EPREFIX}"/usr/$(get_libdir)/${PN}/include \
+		--disable-multi-os-directory \
+		$(use_enable static-libs static) \
+		$(use_enable exec-static-trampoline exec-static-tramp) \
+		$(use_enable pax-kernel pax_emutramp) \
+		$(use_enable debug)
+}
+
+multilib_src_install_all() {
+	find "${ED}" -name "*.la" -delete || die
+	einstalldocs
+}
+
+pkg_preinst() {
+	preserve_old_lib /usr/$(get_libdir)/libffi.so.7
+}
+
+pkg_postinst() {
+	preserve_old_lib_notify /usr/$(get_libdir)/libffi.so.7
+}


### PR DESCRIPTION
Backports https://github.com/libffi/libffi/pull/722