### PR TITLE
app-admin/chroot_safe: keyword 1.4-r1 for ~riscv

### DIFF
--- a/app-admin/chroot_safe/chroot_safe-1.4-r1.ebuild
+++ b/app-admin/chroot_safe/chroot_safe-1.4-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ SRC_URI="mirror://sourceforge/${PN//_}/${P}.tgz"
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="amd64 ppc x86"
+KEYWORDS="amd64 ppc ~riscv x86"
 
 PATCHES=( "${FILESDIR}"/${P}-ldflags.patch )
 


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/857642
Signed-off-by: Yongxiang Liang <tanekliang@gmail.com>