### PR TITLE
sys-libs/libhugetlbfs: Fix _SC_LEVEL2_CACHE_LINESIZE undeclared and misc

### DIFF
--- a/sys-libs/libhugetlbfs/files/libhugetlbfs-2.23-musl-ino_t-fix.patch
+++ b/sys-libs/libhugetlbfs/files/libhugetlbfs-2.23-musl-ino_t-fix.patch
@@ -1,0 +1,13 @@
+# Include dirent.h for ino_t
+# Fixes error: unknown typename 'ino_t'
+# Closes: https://bugs.gentoo.org/828830
+--- a/tests/hugetests.h
++++ b/tests/hugetests.h
+@@ -22,6 +22,7 @@
+
+ #include <errno.h>
+ #include <string.h>
++#include <dirent.h>
+ #include <unistd.h>
+
+ #include "libhugetlbfs_privutils.h"

--- a/sys-libs/libhugetlbfs/files/libhugetlbfs-2.23-musl-nonnull-fix.patch
+++ b/sys-libs/libhugetlbfs/files/libhugetlbfs-2.23-musl-nonnull-fix.patch
@@ -1,0 +1,31 @@
+# Use __nonnull only on glibc system
+# Closes: https://bugs.gentoo.org/832980
+--- a/shm.c
++++ b/shm.c
+@@ -35,6 +35,12 @@
+ #endif
+
+ #ifdef HAVE_SHMGET_SYSCALL
++
++/* define __THROW to avoid build issue when it's not available from the libc */
++#ifndef __THROW
++#define __THROW
++#endif
++
+ /*
+  * The calls to dlsym() and dlerror() in the shmget() wrapper below force
+  * a dependency on libdl.so.  This does not work for static executables
+@@ -48,8 +54,13 @@
+  * system shmget() may be performed without worry as there is no dynamic
+  * call chain.
+  */
++#ifdef __GLIBC__
+ extern void *dlsym (void *__restrict __handle, __const char *__restrict __name)
+ 		__attribute__((weak)) __THROW __nonnull ((2));
++#else
++extern void *dlsym (void *__restrict __handle, __const char *__restrict __name)
++		__attribute__((weak)) __THROW __attribute__((nonnull((2))));
++#endif // __GLIBC__
+ extern char *dlerror (void) __attribute__((weak)) __THROW;
+
+

--- a/sys-libs/libhugetlbfs/files/libhugetlbfs-2.23-musl-path-max-fix.patch
+++ b/sys-libs/libhugetlbfs/files/libhugetlbfs-2.23-musl-path-max-fix.patch
@@ -1,0 +1,22 @@
+# Include limits.h for PATH_MAX
+# Closes: https://bugs.gentoo.org/828830
+--- a/hugeadm.c
++++ b/hugeadm.c
+@@ -33,6 +33,7 @@
+ #include <grp.h>
+ #include <pwd.h>
+ #include <fcntl.h>
++#include <limits.h>
+
+ #include <sys/stat.h>
+ #include <sys/types.h>
+--- a/tests/gethugepagesizes.c
++++ b/tests/gethugepagesizes.c
+@@ -27,6 +27,7 @@
+ #include <sys/types.h>
+ #include <sys/stat.h>
+ #include <fcntl.h>
++#include <limits.h>
+ #include <stdarg.h>
+ #include <hugetlbfs.h>
+

--- a/sys-libs/libhugetlbfs/files/libhugetlbfs-2.23-musl-sc-level2-fix.patch
+++ b/sys-libs/libhugetlbfs/files/libhugetlbfs-2.23-musl-sc-level2-fix.patch
@@ -1,0 +1,45 @@
+# _SC_LEVEL2_CACHE_LINESIZE is most probably Glibc specific define. Hence we
+# cannot use it with other libc's. Check if _SC_LEVEL2_CACHE_LINESIZE is
+# available or use custom function to get CPU cache size
+# Original patch was found here [1]
+# [1]: https://cgit.openembedded.org/meta-openembedded/plain/meta-oe/recipes-benchmark/libhugetlbfs/files/0003-alloc.c-Avoid-sysconf-_SC_LEVEL2_CACHE_LINESIZE-on-l.patch
+# Closes: https://bugs.gentoo.org/828830
+--- a/alloc.c
++++ b/alloc.c
+@@ -245,6 +245,24 @@ void free_huge_pages(void *ptr)
+ 	__free_huge_pages(ptr, 1);
+ }
+
++/*
++ * Avoid sysconf(_SC_LEVEL2_CACHE_LINESIZE) on linux
++ * Taken from the folling patch [1]
++ *
++ * [1]: https://cgit.openembedded.org/meta-openembedded/plain/meta-oe/recipes-benchmark/libhugetlbfs/files/0003-alloc.c-Avoid-sysconf-_SC_LEVEL2_CACHE_LINESIZE-on-l.patch
++ */
++#if !defined(_SC_LEVEL2_CACHE_LINESIZE)
++static size_t get_cacheline_size() {
++	FILE * fp = fopen("/sys/devices/system/cpu/cpu0/cache/index0/coherency_line_size", "r");
++	unsigned int line_size = 0;
++	if (fp) {
++		fscanf(fp, "%d", &line_size);
++		fclose(fp);
++	}
++	return line_size;
++}
++#endif
++
+ /*
+  * Offset the buffer using bytes wasted due to alignment to avoid using the
+  * same cache lines for the start of every buffer returned by
+@@ -261,7 +279,11 @@ void *cachecolor(void *buf, size_t len, size_t color_bytes)
+
+ 	/* Lookup our cacheline size once */
+ 	if (cacheline_size == 0) {
++#if defined(_SC_LEVEL2_CACHE_LINESIZE)
+ 		cacheline_size = sysconf(_SC_LEVEL2_CACHE_LINESIZE);
++#else
++		cacheline_size = get_cacheline_size();
++#endif
+ 		linemod = time(NULL);
+ 	}
+

--- a/sys-libs/libhugetlbfs/libhugetlbfs-2.23.ebuild
+++ b/sys-libs/libhugetlbfs/libhugetlbfs-2.23.ebuild
@@ -23,6 +23,10 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-2.6-fixup-testsuite.patch
 	"${FILESDIR}"/${PN}-2.23-uncompressed-man-pages.patch
 	"${FILESDIR}"/${PN}-2.23-allow-building-against-glibc-2.34.patch
+	"${FILESDIR}"/${PN}-2.23-musl-sc-level2-fix.patch
+	"${FILESDIR}"/${PN}-2.23-musl-path-max-fix.patch
+	"${FILESDIR}"/${PN}-2.23-musl-nonnull-fix.patch
+	"${FILESDIR}"/${PN}-2.23-musl-ino_t-fix.patch
 )
 
 src_prepare() {


### PR DESCRIPTION
Patches for musl that mainly closes bug 828830, pluse some other patches
for errors that come along 828830.

Closes: https://bugs.gentoo.org/828830
Closes: https://bugs.gentoo.org/832980

Signed-off-by: brahmajit das <listout@protonmail.com>