### PR TITLE
net-misc/suite3270: Fix unknown type name wint_t on musl

### DIFF
--- a/net-misc/suite3270/files/suite3270-4.1-musl-wint-t-fix.patch
+++ b/net-misc/suite3270/files/suite3270-4.1-musl-wint-t-fix.patch
@@ -1,0 +1,12 @@
+# Fix unknown type name wint_t when building against musl
+# Closes: https://bugs.gentoo.org/713618
+--- a/c3270/screen.c
++++ b/c3270/screen.c
+@@ -63,6 +63,7 @@
+ #include "utils.h"
+ #include "xio.h"
+ #include "xscroll.h"
++#include "wctype.h"
+
+ #include "cscreen.h"
+

--- a/net-misc/suite3270/suite3270-4.1_p11.ebuild
+++ b/net-misc/suite3270/suite3270-4.1_p11.ebuild
@@ -64,6 +64,10 @@ src_prepare() {
 	export ac_cv_path_install="${S}/_install"
 }
 
+PATCHES=(
+	"${FILESDIR}"/${PN}-4.1-musl-wint-t-fix.patch
+)
+
 src_configure() {
 	econf \
 		--cache-file="${S}"/config.cache \


### PR DESCRIPTION
While building on musl we get build error 'error: unknown type name
wint_t; did you mean ino_t?'. This patch fixes it.

Closes: https://bugs.gentoo.org/713618

Signed-off-by: brahmajit das <listout@protonmail.com>