### PR TITLE
app-benchmarks/pipebench: EAPI8, minor improvements

### DIFF
--- a/app-benchmarks/pipebench/pipebench-0.40-r2.ebuild
+++ b/app-benchmarks/pipebench/pipebench-0.40-r2.ebuild
@@ -1,18 +1,17 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
 
 inherit flag-o-matic toolchain-funcs
 
 DESCRIPTION="Measures the speed of stdin/stdout communication"
-HOMEPAGE="http://www.habets.pp.se/synscan/programs.php?prog=pipebench"
-SRC_URI="ftp://ftp.habets.pp.se/pub/synscan/${P}.tar.gz"
+HOMEPAGE="https://www.habets.pp.se/synscan/programs_pipebench.html"
+SRC_URI="https://www.habets.pp.se/synscan/files/${P}.tar.gz"
 
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="0"
 KEYWORDS="~alpha amd64 ppc ppc64 x86 ~x86-linux"
-IUSE=""
 
 PATCHES=( "${FILESDIR}"/${PN}-0.40-fix-build-system.patch )
 


### PR DESCRIPTION
Another simple `EAPI8` bump with some minor improvements.

Signed-off-by: Michael Mair-Keimberger <mmk@levelnine.at>
Portage 3.0.34 / pkgdev 0.2.1 / pkgcheck 0.10.11