### PR TITLE
net-libs/libbtbb: Fix unknown type u_char on musl

### DIFF
--- a/net-libs/libbtbb/files/libbtbb-2020.12.1-musl-u-char.patch
+++ b/net-libs/libbtbb/files/libbtbb-2020.12.1-musl-u-char.patch
@@ -1,0 +1,14 @@
+# Fix unknown type name 'u_char' on musl
+# Closes: https://bugs.gentoo.org/829245
+# Closes: https://bugs.gentoo.org/715758
+# Upstream PR: https://github.com/greatscottgadgets/libbtbb/pull/64
+--- a/lib/src/pcap.c
++++ b/lib/src/pcap.c
+@@ -27,6 +27,7 @@
+ #include <stdlib.h>
+ #include <string.h>
+ #include <assert.h>
++#include <sys/types.h>
+
+ typedef enum {
+ 	PCAP_OK = 0,

--- a/net-libs/libbtbb/libbtbb-2020.12.1-r1.ebuild
+++ b/net-libs/libbtbb/libbtbb-2020.12.1-r1.ebuild
@@ -23,6 +23,10 @@ LICENSE="GPL-2"
 SLOT="0/${PV}"
 IUSE="static-libs"
 
+PATCHES=(
+	"${FILESDIR}"/${PN}-2020.12.1-musl-u-char.patch
+)
+
 src_configure() {
 	local mycmakeargs=(
 		-DENABLE_PYTHON=OFF


### PR DESCRIPTION
Build fails with error: unknown type name u_char

There is also bug: https://bugs.gentoo.org/829245, but I couldn't
reproduce it.

Closes: https://bugs.gentoo.org/715758

Signed-off-by: brahmajit das <listout@protonmail.com>