### PR TITLE
net-firewall/ufw: fix word split issue

### DIFF
--- a/net-firewall/ufw/ufw-0.36-r1.ebuild
+++ b/net-firewall/ufw/ufw-0.36-r1.ebuild
@@ -198,7 +198,7 @@ pkg_postinst() {
 		print_check_req_warn=true
 	else
 		local rv
-		for rv in "${REPLACING_VERSIONS}"; do
+		for rv in ${REPLACING_VERSIONS}; do
 			local major=${rv%%.*}
 			local minor=${rv#${major}.}
 			if [[ "${major}" -eq 0 && "${minor}" -lt 34 ]]; then

--- a/net-firewall/ufw/ufw-0.36.1.ebuild
+++ b/net-firewall/ufw/ufw-0.36.1.ebuild
@@ -196,7 +196,7 @@ pkg_postinst() {
 		print_check_req_warn=true
 	else
 		local rv
-		for rv in "${REPLACING_VERSIONS}"; do
+		for rv in ${REPLACING_VERSIONS}; do
 			local major=${rv%%.*}
 			local minor=${rv#${major}.}
 			if [[ "${major}" -eq 0 && "${minor}" -lt 34 ]]; then


### PR DESCRIPTION
Just fixing a small shellcheck bug I saw on bugs.gentoo.org. This is a pretty trivial change that doesn't affect the installed files on the user's system, so I don't think this needs a revbump, but let me know if I'm wrong.