### PR TITLE
media-gfx/iscan: Reload udev rules on (un)install

### DIFF
--- a/media-gfx/iscan/iscan-3.65.0.ebuild
+++ b/media-gfx/iscan/iscan-3.65.0.ebuild
@@ -94,11 +94,13 @@ src_install() {
 }
 
 pkg_postinst() {
+	udev_reload
 	use gui && xdg_icon_cache_update
 	elog "If you encounter problems with media-gfx/xsane when scanning (e.g., bad resolution),"
 	elog "please try the built-in GUI and kde-misc/skanlite first before reporting bugs."
 }
 
 pkg_postrm() {
+	udev_reload
 	use gui && xdg_icon_cache_update
 }


### PR DESCRIPTION
Signed-off-by: Marcin Deranek <marcin.deranek@slonko.net>
Closes: https://bugs.gentoo.org/859631