### PR TITLE
media-libs/assimp: fix version mismatch in pkg-config and cmake files

### DIFF
--- a/media-libs/assimp/assimp-5.2.4-r1.ebuild
+++ b/media-libs/assimp/assimp-5.2.4-r1.ebuild
@@ -1,0 +1,67 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit cmake
+
+DESCRIPTION="Importer library to import assets from 3D files"
+HOMEPAGE="https://github.com/assimp/assimp"
+SRC_URI="https://github.com/${PN}/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="BSD"
+SLOT="0/5.2.4"
+KEYWORDS="~amd64 ~arm ~arm64 ~riscv ~x86"
+IUSE="samples test"
+
+RESTRICT="!test? ( test )"
+
+RDEPEND="
+	dev-libs/boost:=
+	sys-libs/zlib[minizip]
+	samples? (
+		media-libs/freeglut
+		virtual/opengl
+		x11-libs/libX11
+	)
+"
+DEPEND="${RDEPEND}"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-5.2.2-fix-usage-of-incompatible-minizip-data-structure.patch
+	"${FILESDIR}"/${PN}-5.2.2-disable-failing-tests.patch
+	"${FILESDIR}"/${P}-update-version.patch
+)
+
+DOCS=( CodeConventions.md Readme.md )
+
+src_prepare() {
+	if use x86 ; then
+		eapply "${FILESDIR}"/${P}-drop-failing-tests-for-abi_x86_32.patch
+	fi
+
+	cmake_src_prepare
+}
+
+src_configure() {
+	local mycmakeargs=(
+		-DASSIMP_ASAN=OFF
+		-DASSIMP_BUILD_DOCS=OFF
+		-DASSIMP_BUILD_SAMPLES=$(usex samples)
+		-DASSIMP_BUILD_TESTS=$(usex test)
+		-DASSIMP_INJECT_DEBUG_POSTFIX=OFF
+		-DASSIMP_IGNORE_GIT_HASH=ON
+		-DASSIMP_UBSAN=OFF
+		-DASSIMP_WARNINGS_AS_ERRORS=OFF
+	)
+
+	if use samples; then
+		mycmakeargs+=( -DOpenGL_GL_PREFERENCE="GLVND" )
+	fi
+
+	cmake_src_configure
+}
+
+src_test() {
+	"${BUILD_DIR}/bin/unit" || die
+}

--- a/media-libs/assimp/files/assimp-5.2.4-update-version.patch
+++ b/media-libs/assimp/files/assimp-5.2.4-update-version.patch
@@ -1,0 +1,34 @@
+https://github.com/assimp/assimp/issues/4655
+https://github.com/assimp/assimp/pull/4656
+
+From 304b0f61d7c9ef7e2e5ca2eed185b32a2951aa90 Mon Sep 17 00:00:00 2001
+From: Bernd Waibel <waebbl-gentoo@posteo.net>
+Date: Sat, 30 Jul 2022 09:39:12 +0200
+Subject: [PATCH] update version
+
+Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -56,7 +56,7 @@ IF(ASSIMP_HUNTER_ENABLED)
+   add_definitions(-DASSIMP_USE_HUNTER)
+ ENDIF()
+ 
+-PROJECT(Assimp VERSION 5.2.0)
++PROJECT(Assimp VERSION 5.2.4)
+ 
+ # All supported options ###############################################
+ 
+--- a/test/unit/utVersion.cpp
++++ b/test/unit/utVersion.cpp
+@@ -61,7 +61,7 @@ TEST_F( utVersion, aiGetVersionMajorTest ) {
+ }
+ 
+ TEST_F( utVersion, aiGetVersionPatchTest ) {
+-    EXPECT_EQ(aiGetVersionPatch(), 0U );   
++    EXPECT_EQ(aiGetVersionPatch(), 4U );
+ }
+ 
+ TEST_F( utVersion, aiGetCompileFlagsTest ) {
+-- 
+2.35.1
+


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/859862
Bug: https://github.com/assimp/assimp/issues/4655
Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>