### PR TITLE
tree-sitter-grammar.eclass: use -Wl,-install_name on Darwin

### DIFF
--- a/dev-libs/tree-sitter-bash/tree-sitter-bash-0.19.0.ebuild
+++ b/dev-libs/tree-sitter-bash/tree-sitter-bash-0.19.0.ebuild
@@ -10,4 +10,4 @@ HOMEPAGE="https://github.com/tree-sitter/tree-sitter-bash"
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~x64-macos"

--- a/dev-libs/tree-sitter/tree-sitter-0.20.6.ebuild
+++ b/dev-libs/tree-sitter/tree-sitter-0.20.6.ebuild
@@ -12,7 +12,7 @@ if [[ ${PV} == *9999* ]]; then
 	EGIT_REPO_URI="https://github.com/${PN}/${PN}"
 else
 	SRC_URI="https://github.com/${PN}/${PN}/archive/refs/tags/v${PV}.tar.gz -> ${P}.tar.gz"
-	KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~loong ppc ppc64 ~riscv ~s390 sparc x86"
+	KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~loong ppc ppc64 ~riscv ~s390 sparc x86 ~x64-macos"
 fi
 
 LICENSE="MIT"

--- a/dev-libs/tree-sitter/tree-sitter-0.20.6.ebuild
+++ b/dev-libs/tree-sitter/tree-sitter-0.20.6.ebuild
@@ -25,6 +25,12 @@ src_prepare() {
 	tc-export CC
 }
 
+src_compile() {
+	emake \
+		PREFIX="${EPREFIX}/usr" \
+		LIBDIR="${EPREFIX}/usr/$(get_libdir)"
+}
+
 src_install() {
 	emake DESTDIR="${D}" \
 		  PREFIX="${EPREFIX}/usr" \

--- a/dev-libs/tree-sitter/tree-sitter-9999.ebuild
+++ b/dev-libs/tree-sitter/tree-sitter-9999.ebuild
@@ -12,7 +12,7 @@ if [[ ${PV} == *9999* ]]; then
 	EGIT_REPO_URI="https://github.com/${PN}/${PN}"
 else
 	SRC_URI="https://github.com/${PN}/${PN}/archive/refs/tags/v${PV}.tar.gz -> ${P}.tar.gz"
-	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~x64-macos"
 fi
 
 LICENSE="MIT"

--- a/dev-libs/tree-sitter/tree-sitter-9999.ebuild
+++ b/dev-libs/tree-sitter/tree-sitter-9999.ebuild
@@ -25,6 +25,12 @@ src_prepare() {
 	tc-export CC
 }
 
+src_compile() {
+	emake \
+		PREFIX="${EPREFIX}/usr" \
+		LIBDIR="${EPREFIX}/usr/$(get_libdir)"
+}
+
 src_install() {
 	emake DESTDIR="${D}" \
 		  PREFIX="${EPREFIX}/usr" \

--- a/dev-python/tree-sitter/tree-sitter-0.20.0-r1.ebuild
+++ b/dev-python/tree-sitter/tree-sitter-0.20.0-r1.ebuild
@@ -31,7 +31,7 @@ S=${WORKDIR}/${MY_P}
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~loong ppc ppc64 ~riscv ~s390 sparc x86"
+KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~loong ppc ppc64 ~riscv ~s390 sparc x86 ~x64-macos"
 
 RDEPEND="
 	dev-libs/tree-sitter:=

--- a/eclass/tree-sitter-grammar.eclass
+++ b/eclass/tree-sitter-grammar.eclass
@@ -76,11 +76,17 @@ tree-sitter-grammar_src_compile() {
 	fi
 
 	local soname=lib${PN}$(get_libname $(_get_tsg_abi_ver))
+
+	local soname_args="-Wl,--soname=${soname}"
+	if [[ ${CHOST} == *darwin* ]] ; then
+		soname_args="-Wl,-install_name,${EPREFIX}/usr/$(get_libdir)/${soname}"
+	fi
+
 	edo ${link} ${LDFLAGS} \
 			-shared \
 			*.o \
-			-Wl,--soname=${soname} \
-			-o "${WORKDIR}"/${soname} || die
+			${soname_args} \
+			-o "${WORKDIR}"/${soname}
 }
 
 # @FUNCTION: tree-sitter-grammar_src_install


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/860828
Signed-off-by: Sam James <sam@gentoo.org>