### PR TITLE
media-gfx/freecad: cleanup workbenches in 0.20 and live ebuild

### DIFF
--- a/media-gfx/freecad/freecad-0.20-r1.ebuild
+++ b/media-gfx/freecad/freecad-0.20-r1.ebuild
@@ -17,8 +17,6 @@ if [[ ${PV} = *9999 ]]; then
 	EGIT_REPO_URI="https://github.com/${MY_PN}/${MY_PN}.git"
 	S="${WORKDIR}/freecad-${PV}"
 else
-	MY_PV=$(ver_cut 1-2)
-	MY_PV=$(ver_rs 1 '_' ${MY_PV})
 	SRC_URI="https://github.com/${MY_PN}/${MY_PN}/archive/refs/tags/${PV}.tar.gz -> ${P}.tar.gz"
 	KEYWORDS="~amd64"
 	S="${WORKDIR}/FreeCAD-${PV}"
@@ -32,7 +30,7 @@ SLOT="0"
 # see https://forum.freecadweb.org/viewtopic.php?f=4&t=69450
 IUSE="debug headless test"
 
-FREECAD_EXPERIMENTAL_MODULES="cloud pcl plot ship"
+FREECAD_EXPERIMENTAL_MODULES="cloud pcl"
 FREECAD_STABLE_MODULES="addonmgr fem idf image inspection material
 	openscad part-design path points raytracing robot show surface
 	techdraw tux"
@@ -121,7 +119,6 @@ REQUIRED_USE="
 	${PYTHON_REQUIRED_USE}
 	inspection? ( points )
 	path? ( robot )
-	ship? ( image plot )
 "
 
 PATCHES=(
@@ -181,13 +178,11 @@ src_configure() {
 		-DBUILD_PART=ON
 		-DBUILD_PART_DESIGN=$(usex part-design)
 		-DBUILD_PATH=$(usex path)
-		-DBUILD_PLOT=$(usex plot)				# conflicts with possible external workbench
 		-DBUILD_POINTS=$(usex points)
 		-DBUILD_QT5=ON							# OFF means to use Qt4
 		-DBUILD_RAYTRACING=$(usex raytracing)
 		-DBUILD_REVERSEENGINEERING=OFF			# currently only an empty sandbox
 		-DBUILD_ROBOT=$(usex robot)
-		-DBUILD_SHIP=$(usex ship)				# conflicts with possible external workbench
 		-DBUILD_SHOW=$(usex show)
 		-DBUILD_SKETCHER=ON						# needed by draft workspace
 		-DBUILD_SMESH=ON
@@ -279,18 +274,6 @@ src_install() {
 
 pkg_postinst() {
 	xdg_pkg_postinst
-
-	if use plot; then
-		einfo "Note: You are enabling the 'plot' USE flag."
-		einfo "This conflicts with the plot workbench that can be loaded"
-		einfo "via the addon manager! You can only install one of those."
-	fi
-
-	if use ship; then
-		einfo "Note: You are enabling the 'ship' USE flag."
-		einfo "This conflicts with the ship workbench that can be loaded"
-		einfo "via the addon manager! You can only install one of those."
-	fi
 
 	einfo "You can load a lot of additional workbenches using the integrated"
 	einfo "AddonManager."

--- a/media-gfx/freecad/freecad-9999.ebuild
+++ b/media-gfx/freecad/freecad-9999.ebuild
@@ -17,10 +17,7 @@ if [[ ${PV} = *9999 ]]; then
 	EGIT_REPO_URI="https://github.com/${MY_PN}/${MY_PN}.git"
 	S="${WORKDIR}/freecad-${PV}"
 else
-	MY_PV=$(ver_cut 1-2)
-	MY_PV=$(ver_rs 1 '_' ${MY_PV})
-	SRC_URI="https://github.com/${MY_PN}/${MY_PN}/archive/refs/tags/${PV}.tar.gz -> ${P}.tar.gz
-		https://raw.githubusercontent.com/waebbl/waebbl-gentoo/master/patches/${P}-0005-Make-smesh-compile-with-vtk9.patch.xz"
+	SRC_URI="https://github.com/${MY_PN}/${MY_PN}/archive/refs/tags/${PV}.tar.gz -> ${P}.tar.gz"
 	KEYWORDS="~amd64"
 	S="${WORKDIR}/FreeCAD-${PV}"
 fi
@@ -31,7 +28,7 @@ LICENSE="LGPL-2 CC-BY-SA-4.0"
 SLOT="0"
 IUSE="debug designer headless test"
 
-FREECAD_EXPERIMENTAL_MODULES="cloud pcl plot ship"
+FREECAD_EXPERIMENTAL_MODULES="cloud pcl"
 FREECAD_STABLE_MODULES="addonmgr fem idf image inspection material
 	openscad part-design path points raytracing robot show surface
 	techdraw tux"
@@ -69,7 +66,7 @@ RDEPEND="
 	sci-libs/flann[openmp]
 	sci-libs/hdf5:=[fortran,zlib]
 	>=sci-libs/med-4.0.0-r1[python,${PYTHON_SINGLE_USEDEP}]
-	sci-libs/opencascade:=[vtk(+)]
+	sci-libs/opencascade:=[json,vtk(+)]
 	sci-libs/orocos_kdl:=
 	sys-libs/zlib
 	virtual/glu
@@ -120,7 +117,6 @@ REQUIRED_USE="
 	${PYTHON_REQUIRED_USE}
 	inspection? ( points )
 	path? ( robot )
-	ship? ( image plot )
 "
 
 PATCHES=(
@@ -139,10 +135,6 @@ pkg_setup() {
 }
 
 src_prepare() {
-	# the upstream provided file doesn't find the coin doc tag file,
-	# but cmake ships a working one, so we use this.
-	rm "${S}/cMake/FindCoin3D.cmake" || die
-
 	# Fix desktop file
 	sed -e 's/Exec=FreeCAD/Exec=freecad/' -i src/XDGData/org.freecadweb.FreeCAD.desktop || die
 
@@ -178,13 +170,11 @@ src_configure() {
 		-DBUILD_PART=ON
 		-DBUILD_PART_DESIGN=$(usex part-design)
 		-DBUILD_PATH=$(usex path)
-		-DBUILD_PLOT=$(usex plot)				# conflicts with possible external workbench
 		-DBUILD_POINTS=$(usex points)
 		-DBUILD_QT5=ON							# OFF means to use Qt4
 		-DBUILD_RAYTRACING=$(usex raytracing)
 		-DBUILD_REVERSEENGINEERING=OFF			# currently only an empty sandbox
 		-DBUILD_ROBOT=$(usex robot)
-		-DBUILD_SHIP=$(usex ship)				# conflicts with possible external workbench
 		-DBUILD_SHOW=$(usex show)
 		-DBUILD_SKETCHER=ON						# needed by draft workspace
 		-DBUILD_SMESH=ON
@@ -277,18 +267,6 @@ src_install() {
 pkg_postinst() {
 	xdg_pkg_postinst
 
-	if use plot; then
-		einfo "Note: You are enabling the 'plot' USE flag."
-		einfo "This conflicts with the plot workbench that can be loaded"
-		einfo "via the addon manager! You can only install one of those."
-	fi
-
-	if use ship; then
-		einfo "Note: You are enabling the 'ship' USE flag."
-		einfo "This conflicts with the ship workbench that can be loaded"
-		einfo "via the addon manager! You can only install one of those."
-	fi
-
 	einfo "You can load a lot of additional workbenches using the integrated"
 	einfo "AddonManager."
 
@@ -299,23 +277,23 @@ pkg_postinst() {
 	einfo "https://wiki.freecadweb.org/Installing#External_software_supported_by_FreeCAD"
 	optfeature_header "Computational utilities"
 	optfeature "BLAS library" sci-libs/openblas
-	optfeature "statistical computation with Python" dev-python/pandas
-	optfeature "scientific computation with Python" dev-python/scipy
-	optfeature "symbolic math with Python" dev-python/sympy
+	optfeature "Statistical computation with Python" dev-python/pandas
+	optfeature "Use scientific computation with Python" dev-python/scipy
+	optfeature "Use symbolic math with Python" dev-python/sympy
 	optfeature_header "Imaging, Plotting and Rendering utilities"
-	optfeature "dependency graphs" media-gfx/graphviz
+	optfeature "Dependency graphs" media-gfx/graphviz
 	optfeature "PBR Rendering" media-gfx/povray
 	optfeature_header "Import / Export"
-	optfeature "interacting with git repositories" dev-python/GitPython
-	optfeature "working with COLLADA documents" dev-python/pycollada
+	optfeature "Interact with git repositories" dev-python/GitPython
+	optfeature "Work with COLLADA documents" dev-python/pycollada
 	optfeature "YAML importer and emitter" dev-python/pyyaml
-	optfeature "importing and exporting 2D AutoCAD DWG files" media-gfx/libredwg
-	optfeature "importing and exporting geospatial data formats" sci-libs/gdal
-	optfeature "working with projection data" sci-libs/proj
+	optfeature "Importing and exporting 2D AutoCAD DWG files" media-gfx/libredwg
+	optfeature "Importing and exporting geospatial data formats" sci-libs/gdal
+	optfeature "Working with projection data" sci-libs/proj
 	optfeature_header "Meshing and FEM"
 	optfeature "FEM mesh generator" sci-libs/gmsh
-	optfeature "triangulating meshes" sci-libs/gts
-	optfeature "visualization" sci-visualization/paraview
+	optfeature "Triangulating meshes" sci-libs/gts
+	optfeature "Visualization" sci-visualization/paraview
 }
 
 pkg_postrm() {


### PR DESCRIPTION
Upstream has dropped the ship and plot workbenches recently. The
patch reflects these changes and drops the USE flags for it.
Note, that the plot module is still available, only the workbench
for separate working with plots has been removed.

See also https://github.com/FreeCAD/FreeCAD/pull/4971 and
https://github.com/FreeCAD/FreeCAD/pull/4900

Bug: https://bugs.gentoo.org/858308#c2
Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>

Some additional typo fixes and minor code cleanup for live ebuild.
