### PR TITLE
dev-util/sysprof-capture: Add missing MULTILIB_USEDEP on dev-libs/glib

### DIFF
--- a/dev-util/sysprof-capture/sysprof-capture-3.36.0-r1.ebuild
+++ b/dev-util/sysprof-capture/sysprof-capture-3.36.0-r1.ebuild
@@ -14,7 +14,7 @@ SLOT="3"
 KEYWORDS="amd64 x86"
 IUSE=""
 
-RDEPEND=">=dev-libs/glib-2.61.3:2
+RDEPEND=">=dev-libs/glib-2.61.3:2[${MULTILIB_USEDEP}]
 	!=dev-util/sysprof-3.34.1-r0"
 DEPEND="${RDEPEND}"
 BDEPEND="


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/861281
Signed-off-by: Branko Grubic <bitlord0xff@gmail.com>