### PR TITLE
media-video/pipewire: Fix missing MULTILIB_USEDEP on media-libs/alsa-lib

### DIFF
--- a/media-video/pipewire/pipewire-0.3.51-r2.ebuild
+++ b/media-video/pipewire/pipewire-0.3.51-r2.ebuild
@@ -55,7 +55,7 @@ BDEPEND="
 "
 RDEPEND="
 	acct-group/audio
-	media-libs/alsa-lib
+	media-libs/alsa-lib[${MULTILIB_USEDEP}]
 	sys-apps/dbus[${MULTILIB_USEDEP}]
 	sys-libs/readline:=
 	sys-libs/ncurses:=[unicode(+)]

--- a/media-video/pipewire/pipewire-0.3.52-r1.ebuild
+++ b/media-video/pipewire/pipewire-0.3.52-r1.ebuild
@@ -55,7 +55,7 @@ BDEPEND="
 "
 RDEPEND="
 	acct-group/audio
-	media-libs/alsa-lib
+	media-libs/alsa-lib[${MULTILIB_USEDEP}]
 	sys-apps/dbus[${MULTILIB_USEDEP}]
 	sys-libs/readline:=
 	sys-libs/ncurses:=[unicode(+)]

--- a/media-video/pipewire/pipewire-0.3.53_p20220705-r1.ebuild
+++ b/media-video/pipewire/pipewire-0.3.53_p20220705-r1.ebuild
@@ -63,7 +63,7 @@ BDEPEND="
 "
 RDEPEND="
 	acct-group/audio
-	media-libs/alsa-lib
+	media-libs/alsa-lib[${MULTILIB_USEDEP}]
 	sys-libs/readline:=
 	sys-libs/ncurses:=[unicode(+)]
 	virtual/libintl[${MULTILIB_USEDEP}]

--- a/media-video/pipewire/pipewire-0.3.55-r1.ebuild
+++ b/media-video/pipewire/pipewire-0.3.55-r1.ebuild
@@ -73,7 +73,7 @@ BDEPEND="
 "
 RDEPEND="
 	acct-group/audio
-	media-libs/alsa-lib
+	media-libs/alsa-lib[${MULTILIB_USEDEP}]
 	sys-libs/readline:=
 	sys-libs/ncurses:=[unicode(+)]
 	virtual/libintl[${MULTILIB_USEDEP}]

--- a/media-video/pipewire/pipewire-0.3.56.ebuild
+++ b/media-video/pipewire/pipewire-0.3.56.ebuild
@@ -73,7 +73,7 @@ BDEPEND="
 "
 RDEPEND="
 	acct-group/audio
-	media-libs/alsa-lib
+	media-libs/alsa-lib[${MULTILIB_USEDEP}]
 	sys-libs/readline:=
 	sys-libs/ncurses:=[unicode(+)]
 	virtual/libintl[${MULTILIB_USEDEP}]

--- a/media-video/pipewire/pipewire-9999.ebuild
+++ b/media-video/pipewire/pipewire-9999.ebuild
@@ -73,7 +73,7 @@ BDEPEND="
 "
 RDEPEND="
 	acct-group/audio
-	media-libs/alsa-lib
+	media-libs/alsa-lib[${MULTILIB_USEDEP}]
 	sys-libs/readline:=
 	sys-libs/ncurses:=[unicode(+)]
 	virtual/libintl[${MULTILIB_USEDEP}]


### PR DESCRIPTION
Signed-off-by: Branko Grubic <bitlord0xff@gmail.com>