### PR TITLE
dev-qt/qtwebengine: Fix for musl

### DIFF
--- a/dev-qt/qtwebengine/files/qtwebengine-5.15.5_p20220618-backtrace-execinfo.patch
+++ b/dev-qt/qtwebengine/files/qtwebengine-5.15.5_p20220618-backtrace-execinfo.patch
@@ -1,0 +1,123 @@
+https://git.alpinelinux.org/aports/tree/community/qt5-qtwebengine/qt-musl-execinfo.patch
+
+The backtrace api is not available in musl libc. This can be added with
+libexecinfo but that needs changes in the build system. As qmake is being swapped
+for CMake in Qt6 it makes sense to just check for glibc
+
+---
+ src/3rdparty/chromium/base/debug/stack_trace.cc  |  4 ++--
+ .../chromium/base/debug/stack_trace_posix.cc     | 16 ++++++++--------
+ src/3rdparty/chromium/base/logging.cc            |  2 +-
+ 3 files changed, 11 insertions(+), 11 deletions(-)
+
+diff --git a/src/3rdparty/chromium/base/debug/stack_trace.cc b/src/3rdparty/chromium/base/debug/stack_trace.cc
+index f5e2dbba1..f0bb80ad0 100644
+--- a/src/3rdparty/chromium/base/debug/stack_trace.cc
++++ b/src/3rdparty/chromium/base/debug/stack_trace.cc
+@@ -225,14 +225,14 @@ std::string StackTrace::ToString() const {
+ }
+ std::string StackTrace::ToStringWithPrefix(const char* prefix_string) const {
+   std::stringstream stream;
+-#if !defined(__UCLIBC__) && !defined(_AIX)
++#if defined(__GLIBC__) && !defined(_AIX)
+   OutputToStreamWithPrefix(&stream, prefix_string);
+ #endif
+   return stream.str();
+ }
+ 
+ std::ostream& operator<<(std::ostream& os, const StackTrace& s) {
+-#if !defined(__UCLIBC__) & !defined(_AIX)
++#if defined(__GLIBC__) & !defined(_AIX)
+   s.OutputToStream(&os);
+ #else
+   os << "StackTrace::OutputToStream not implemented.";
+diff --git a/src/3rdparty/chromium/base/debug/stack_trace_posix.cc b/src/3rdparty/chromium/base/debug/stack_trace_posix.cc
+index 6a1531e13..0b2b2e6a6 100644
+--- a/src/3rdparty/chromium/base/debug/stack_trace_posix.cc
++++ b/src/3rdparty/chromium/base/debug/stack_trace_posix.cc
+@@ -27,7 +27,7 @@
+ #if !defined(USE_SYMBOLIZE)
+ #include <cxxabi.h>
+ #endif
+-#if !defined(__UCLIBC__) && !defined(_AIX)
++#if defined(__GLIBC__) && !defined(_AIX)
+ #include <execinfo.h>
+ #endif
+ 
+@@ -88,7 +88,7 @@ void DemangleSymbols(std::string* text) {
+   // Note: code in this function is NOT async-signal safe (std::string uses
+   // malloc internally).
+ 
+-#if !defined(__UCLIBC__) && !defined(_AIX)
++#if defined(__GLIBC__) && !defined(_AIX)
+   std::string::size_type search_from = 0;
+   while (search_from < text->size()) {
+     // Look for the start of a mangled symbol, from search_from.
+@@ -123,7 +123,7 @@ void DemangleSymbols(std::string* text) {
+       search_from = mangled_start + 2;
+     }
+   }
+-#endif  // !defined(__UCLIBC__) && !defined(_AIX)
++#endif  // defined(__GLIBC__) && !defined(_AIX)
+ }
+ #endif  // !defined(USE_SYMBOLIZE)
+ 
+@@ -135,7 +135,7 @@ class BacktraceOutputHandler {
+   virtual ~BacktraceOutputHandler() = default;
+ };
+ 
+-#if !defined(__UCLIBC__) && !defined(_AIX)
++#if defined(__GLIBC__) && !defined(_AIX)
+ void OutputPointer(void* pointer, BacktraceOutputHandler* handler) {
+   // This should be more than enough to store a 64-bit number in hex:
+   // 16 hex digits + 1 for null-terminator.
+@@ -218,7 +218,7 @@ void ProcessBacktrace(void* const* trace,
+   }
+ #endif  // defined(USE_SYMBOLIZE)
+ }
+-#endif  // !defined(__UCLIBC__) && !defined(_AIX)
++#endif  // defined(__GLIBC__) && !defined(_AIX)
+ 
+ void PrintToStderr(const char* output) {
+   // NOTE: This code MUST be async-signal safe (it's used by in-process
+@@ -834,7 +834,7 @@ size_t CollectStackTrace(void** trace, size_t count) {
+   // NOTE: This code MUST be async-signal safe (it's used by in-process
+   // stack dumping signal handler). NO malloc or stdio is allowed here.
+ 
+-#if !defined(__UCLIBC__) && !defined(_AIX)
++#if defined(__GLIBC__) && !defined(_AIX)
+   // Though the backtrace API man page does not list any possible negative
+   // return values, we take no chance.
+   return base::saturated_cast<size_t>(backtrace(trace, count));
+@@ -847,13 +847,13 @@ void StackTrace::PrintWithPrefix(const char* prefix_string) const {
+ // NOTE: This code MUST be async-signal safe (it's used by in-process
+ // stack dumping signal handler). NO malloc or stdio is allowed here.
+ 
+-#if !defined(__UCLIBC__) && !defined(_AIX)
++#if defined(__GLIBC__) && !defined(_AIX)
+   PrintBacktraceOutputHandler handler;
+   ProcessBacktrace(trace_, count_, prefix_string, &handler);
+ #endif
+ }
+ 
+-#if !defined(__UCLIBC__) && !defined(_AIX)
++#if defined(__GLIBC__) && !defined(_AIX)
+ void StackTrace::OutputToStreamWithPrefix(std::ostream* os,
+                                           const char* prefix_string) const {
+   StreamBacktraceOutputHandler handler(os);
+diff --git a/src/3rdparty/chromium/base/logging.cc b/src/3rdparty/chromium/base/logging.cc
+index b5cf2c493..4be936d32 100644
+--- a/src/3rdparty/chromium/base/logging.cc
++++ b/src/3rdparty/chromium/base/logging.cc
+@@ -548,7 +548,7 @@ LogMessage::LogMessage(const char* file, int line, const char* condition)
+ 
+ LogMessage::~LogMessage() {
+   size_t stack_start = stream_.tellp();
+-#if !defined(OFFICIAL_BUILD) && !defined(OS_NACL) && !defined(__UCLIBC__) && \
++#if !defined(OFFICIAL_BUILD) && !defined(OS_NACL) && defined(__GLIBC__) && \
+     !defined(OS_AIX)
+   if (severity_ == LOG_FATAL && !base::debug::BeingDebugged()) {
+     // Include a stack trace on a fatal, unless a debugger is attached.
+-- 
+2.35.1
+

--- a/dev-qt/qtwebengine/files/qtwebengine-5.15.5_p20220618-linux-stack_util-stackstart.patch
+++ b/dev-qt/qtwebengine/files/qtwebengine-5.15.5_p20220618-linux-stack_util-stackstart.patch
@@ -1,0 +1,31 @@
+https://git.alpinelinux.org/aports/tree/community/qt5-qtwebengine/qt-musl-stackstart.patch?id=65f58742e6e669c7d0f5b23c0764f4f73661980b
+
+---
+ .../third_party/blink/renderer/platform/wtf/stack_util.cc     | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/3rdparty/chromium/third_party/blink/renderer/platform/wtf/stack_util.cc b/src/3rdparty/chromium/third_party/blink/renderer/platform/wtf/stack_util.cc
+index 71b901f40..f33aba04b 100644
+--- a/src/3rdparty/chromium/third_party/blink/renderer/platform/wtf/stack_util.cc
++++ b/src/3rdparty/chromium/third_party/blink/renderer/platform/wtf/stack_util.cc
+@@ -29,7 +29,7 @@ size_t GetUnderestimatedStackSize() {
+ // FIXME: On Mac OSX and Linux, this method cannot estimate stack size
+ // correctly for the main thread.
+ 
+-#elif defined(__GLIBC__) || defined(OS_ANDROID) || defined(OS_FREEBSD) || \
++#elif defined(OS_LINUX) || defined(OS_ANDROID) || defined(OS_FREEBSD) || \
+     defined(OS_FUCHSIA)
+   // pthread_getattr_np() can fail if the thread is not invoked by
+   // pthread_create() (e.g., the main thread of blink_unittests).
+@@ -97,7 +97,7 @@ return Threading::ThreadStackSize();
+ }
+ 
+ void* GetStackStart() {
+-#if defined(__GLIBC__) || defined(OS_ANDROID) || defined(OS_FREEBSD) || \
++#if defined(OS_LINUX) || defined(OS_ANDROID) || defined(OS_FREEBSD) || \
+     defined(OS_FUCHSIA)
+   pthread_attr_t attr;
+   int error;
+-- 
+2.35.1
+

--- a/dev-qt/qtwebengine/files/qtwebengine-5.15.5_p20220618-msghdr-padding-initlist.patch
+++ b/dev-qt/qtwebengine/files/qtwebengine-5.15.5_p20220618-msghdr-padding-initlist.patch
@@ -1,0 +1,45 @@
+From 91fcf20ad6923db94a228faa1cf3bcdcaa5f8cbc Mon Sep 17 00:00:00 2001
+From: Alfred Persson Forsberg <cat@catcream.org>
+Date: Tue, 26 Jul 2022 20:53:11 +0200
+Subject: [PATCH] Don't use initializer list for msghdr
+
+msghdr is defined with padding in musl libc. Using an initializer list
+will set an int padding (5th element) to nullptr and break the build
+because of implicit conversion error from ptr to int.
+
+https://git.musl-libc.org/cgit/musl/tree/include/sys/socket.h#n22
+https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/bits/socket.h;h=4f1f810ea1d9bf00ff428e4e7c49a52c71620775;hb=6488f4d00653b489e7969c0a489dc665c26514a8#l262
+
+Signed-off-by: Alfred Persson Forsberg <cat@catcream.org>
+---
+ .../chromium/net/socket/udp_socket_posix.cc        | 14 ++++++++++++--
+ 1 file changed, 12 insertions(+), 2 deletions(-)
+
+diff --git a/src/3rdparty/chromium/net/socket/udp_socket_posix.cc b/src/3rdparty/chromium/net/socket/udp_socket_posix.cc
+index 71265568b..58b2b1cbf 100644
+--- a/src/3rdparty/chromium/net/socket/udp_socket_posix.cc
++++ b/src/3rdparty/chromium/net/socket/udp_socket_posix.cc
+@@ -1151,8 +1151,18 @@ SendResult UDPSocketPosixSender::InternalSendmmsgBuffers(
+   for (auto& buffer : buffers)
+     msg_iov->push_back({const_cast<char*>(buffer->data()), buffer->length()});
+   msgvec->reserve(buffers.size());
+-  for (size_t j = 0; j < buffers.size(); j++)
+-    msgvec->push_back({{nullptr, 0, &msg_iov[j], 1, nullptr, 0, 0}, 0});
++  for (size_t j = 0; j < buffers.size(); j++) {
++    struct msghdr msg;
++    msg.msg_name = nullptr;
++    msg.msg_namelen = 0;
++    msg.msg_iov = &msg_iov[j];
++    msg.msg_iovlen = 1;
++    msg.msg_control = 0;
++    msg.msg_controllen = 0;
++    msg.msg_flags = 0;
++
++    msgvec->push_back({msg, 0});
++  }
+   int result = HANDLE_EINTR(Sendmmsg(fd, &msgvec[0], buffers.size(), 0));
+   SendResult send_result(0, 0, std::move(buffers));
+   if (result < 0) {
+-- 
+2.35.1
+

--- a/dev-qt/qtwebengine/files/qtwebengine-5.15.5_p20220618-musl-canonicalize-filename.patch
+++ b/dev-qt/qtwebengine/files/qtwebengine-5.15.5_p20220618-musl-canonicalize-filename.patch
@@ -1,0 +1,15 @@
+https://git.alpinelinux.org/aports/tree/community/qt5-qtwebengine/nasm.patch
+
+diff --git a/src/3rdparty/chromium/third_party/nasm/config/config-linux.h b/src/3rdparty/chromium/third_party/nasm/config/config-linux.h
+index 7eb7c20ff..3bdc2eb39 100644
+--- a/src/3rdparty/chromium/third_party/nasm/config/config-linux.h
++++ b/src/3rdparty/chromium/third_party/nasm/config/config-linux.h
+@@ -139,7 +139,7 @@
+ #define HAVE_ACCESS 1
+ 
+ /* Define to 1 if you have the `canonicalize_file_name' function. */
+-#define HAVE_CANONICALIZE_FILE_NAME 1
++// #define HAVE_CANONICALIZE_FILE_NAME 1
+ 
+ /* Define to 1 if you have the `cpu_to_le16' intrinsic function. */
+ /* #undef HAVE_CPU_TO_LE16 */

--- a/dev-qt/qtwebengine/files/qtwebengine-5.15.5_p20220618-musl-mallinfo.patch
+++ b/dev-qt/qtwebengine/files/qtwebengine-5.15.5_p20220618-musl-mallinfo.patch
@@ -1,0 +1,58 @@
+https://git.alpinelinux.org/aports/tree/community/qt5-qtwebengine/qt-musl-mallinfo.patch
+
+musl does not support mallinfo, this patch changes OS_LINUX check to include
+checking for glibc too.
+
+Could probably be done in build system but not done because of Qt6 moving to CMake.
+
+---
+ src/3rdparty/chromium/base/process/process_metrics_posix.cc   | 4 ++--
+ .../chromium/base/trace_event/malloc_dump_provider.cc         | 4 +++-
+ 2 files changed, 5 insertions(+), 3 deletions(-)
+
+diff --git a/src/3rdparty/chromium/base/process/process_metrics_posix.cc b/src/3rdparty/chromium/base/process/process_metrics_posix.cc
+index 9d12c427b..9030de9f6 100644
+--- a/src/3rdparty/chromium/base/process/process_metrics_posix.cc
++++ b/src/3rdparty/chromium/base/process/process_metrics_posix.cc
+@@ -119,14 +119,14 @@ size_t ProcessMetrics::GetMallocUsage() {
+   malloc_statistics_t stats = {0};
+   malloc_zone_statistics(nullptr, &stats);
+   return stats.size_in_use;
+-#elif defined(OS_LINUX) || defined(OS_CHROMEOS) || defined(OS_ANDROID)
++#elif (defined(OS_LINUX) && defined(__GLIBC__)) || defined(OS_CHROMEOS) || defined(OS_ANDROID)
+   struct mallinfo minfo = mallinfo();
+ #if BUILDFLAG(USE_TCMALLOC)
+   return minfo.uordblks;
+ #else
+   return minfo.hblkhd + minfo.arena;
+ #endif
+-#elif defined(OS_FUCHSIA)
++#else //if defined(OS_FUCHSIA) // also musl doesn't do this.
+   // TODO(fuchsia): Not currently exposed. https://crbug.com/735087.
+   return 0;
+ #endif
+diff --git a/src/3rdparty/chromium/base/trace_event/malloc_dump_provider.cc b/src/3rdparty/chromium/base/trace_event/malloc_dump_provider.cc
+index c327f4865..2717eca5a 100644
+--- a/src/3rdparty/chromium/base/trace_event/malloc_dump_provider.cc
++++ b/src/3rdparty/chromium/base/trace_event/malloc_dump_provider.cc
+@@ -132,7 +132,7 @@ bool MallocDumpProvider::OnMemoryDump(const MemoryDumpArgs& args,
+   }
+ #elif defined(OS_FUCHSIA)
+ // TODO(fuchsia): Port, see https://crbug.com/706592.
+-#else
++#elif defined(__GLIBC__)
+   struct mallinfo info = mallinfo();
+   // In case of Android's jemalloc |arena| is 0 and the outer pages size is
+   // reported by |hblkhd|. In case of dlmalloc the total is given by
+@@ -142,6 +142,8 @@ bool MallocDumpProvider::OnMemoryDump(const MemoryDumpArgs& args,
+ 
+   // Total allocated space is given by |uordblks|.
+   allocated_objects_size = info.uordblks;
++#else
++  // musl libc does not support mallinfo()
+ #endif
+ 
+   MemoryAllocatorDump* outer_dump = pmd->CreateAllocatorDump("malloc");
+-- 
+2.35.1
+

--- a/dev-qt/qtwebengine/files/qtwebengine-5.15.5_p20220618-musl-mojo-strncpy.patch
+++ b/dev-qt/qtwebengine/files/qtwebengine-5.15.5_p20220618-musl-mojo-strncpy.patch
@@ -1,0 +1,21 @@
+strncpy is not defined without including string.h
+
+---
+ .../mojo/public/cpp/platform/named_platform_channel_posix.cc     | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/3rdparty/chromium/mojo/public/cpp/platform/named_platform_channel_posix.cc b/src/3rdparty/chromium/mojo/public/cpp/platform/named_platform_channel_posix.cc
+index 9082ac4da..d039ff83a 100644
+--- a/src/3rdparty/chromium/mojo/public/cpp/platform/named_platform_channel_posix.cc
++++ b/src/3rdparty/chromium/mojo/public/cpp/platform/named_platform_channel_posix.cc
+@@ -8,6 +8,7 @@
+ #include <sys/socket.h>
+ #include <sys/un.h>
+ #include <unistd.h>
++#include <string.h>
+ 
+ #include "base/files/file_util.h"
+ #include "base/files/scoped_file.h"
+-- 
+2.35.1
+

--- a/dev-qt/qtwebengine/files/qtwebengine-5.15.5_p20220618-musl-resolv-compat.patch
+++ b/dev-qt/qtwebengine/files/qtwebengine-5.15.5_p20220618-musl-resolv-compat.patch
@@ -1,0 +1,80 @@
+https://git.alpinelinux.org/aports/tree/community/qt5-qtwebengine/qt-musl-resolve.patch
+
+A better method would be to check for these functions in the build system
+but as QMake is getting replaced by CMake in Qt6 I did not bother.
+
+---
+ .../net/dns/dns_config_service_posix.cc       |  4 +++
+ src/3rdparty/chromium/net/dns/dns_reloader.cc |  4 +++
+ src/3rdparty/chromium/net/dns/resolv_compat.h | 29 +++++++++++++++++++
+ 3 files changed, 37 insertions(+)
+ create mode 100644 src/3rdparty/chromium/net/dns/resolv_compat.h
+
+diff --git a/src/3rdparty/chromium/net/dns/dns_config_service_posix.cc b/src/3rdparty/chromium/net/dns/dns_config_service_posix.cc
+index 5a4aead0a..0e4480d16 100644
+--- a/src/3rdparty/chromium/net/dns/dns_config_service_posix.cc
++++ b/src/3rdparty/chromium/net/dns/dns_config_service_posix.cc
+@@ -8,6 +8,10 @@
+ #include <string>
+ #include <type_traits>
+ 
++#if !defined(__GLIBC__)
++#include "resolv_compat.h"
++#endif
++
+ #include "base/bind.h"
+ #include "base/files/file.h"
+ #include "base/files/file_path.h"
+diff --git a/src/3rdparty/chromium/net/dns/dns_reloader.cc b/src/3rdparty/chromium/net/dns/dns_reloader.cc
+index 0672e711a..298489866 100644
+--- a/src/3rdparty/chromium/net/dns/dns_reloader.cc
++++ b/src/3rdparty/chromium/net/dns/dns_reloader.cc
+@@ -9,6 +9,10 @@
+ 
+ #include <resolv.h>
+ 
++#if !defined(__GLIBC__)
++#include "resolv_compat.h"
++#endif
++
+ #include "base/lazy_instance.h"
+ #include "base/macros.h"
+ #include "base/notreached.h"
+diff --git a/src/3rdparty/chromium/net/dns/resolv_compat.h b/src/3rdparty/chromium/net/dns/resolv_compat.h
+new file mode 100644
+index 000000000..4f0e852a1
+--- /dev/null
++++ b/src/3rdparty/chromium/net/dns/resolv_compat.h
+@@ -0,0 +1,29 @@
++#if !defined(__GLIBC__)
++/***************************************************************************
++ * resolv_compat.h
++ *
++ * Mimick GLIBC's res_ninit() and res_nclose() for musl libc
++ * Note: res_init() is actually deprecated according to
++ * http://docs.oracle.com/cd/E36784_01/html/E36875/res-nclose-3resolv.html
++ **************************************************************************/
++#include <string.h>
++
++static inline int res_ninit(res_state statp)
++{
++	int rc = res_init();
++	if (statp != &_res) {
++		memcpy(statp, &_res, sizeof(*statp));
++	}
++	return rc;
++}
++
++static inline int res_nclose(res_state statp)
++{
++	if (!statp)
++		return -1;
++	if (statp != &_res) {
++		memset(statp, 0, sizeof(*statp));
++	}
++	return 0;
++}
++#endif
+-- 
+2.35.1
+

--- a/dev-qt/qtwebengine/files/qtwebengine-5.15.5_p20220618-musl-sandbox.patch
+++ b/dev-qt/qtwebengine/files/qtwebengine-5.15.5_p20220618-musl-sandbox.patch
@@ -1,0 +1,111 @@
+https://git.alpinelinux.org/aports/tree/community/qt5-qtwebengine/musl-sandbox.patch
+
+This should be fine for all non-Android platforms.
+TODO: not okay for upstreaming.
+
+https://git.alpinelinux.org/aports/tree/community/qt5-qtwebengine/musl-sandbox.patch
+
+---
+ .../syscall_parameters_restrictions.cc        | 22 +++++--------------
+ .../linux/seccomp-bpf-helpers/syscall_sets.cc |  5 +++--
+ .../policy/linux/bpf_renderer_policy_linux.cc |  4 ++--
+ 3 files changed, 11 insertions(+), 20 deletions(-)
+
+diff --git a/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/syscall_parameters_restrictions.cc b/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/syscall_parameters_restrictions.cc
+index 6ae09fb10..57559ee6e 100644
+--- a/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/syscall_parameters_restrictions.cc
++++ b/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/syscall_parameters_restrictions.cc
+@@ -127,21 +127,11 @@ namespace sandbox {
+ // present (as in newer versions of posix_spawn).
+ ResultExpr RestrictCloneToThreadsAndEPERMFork() {
+   const Arg<unsigned long> flags(0);
+-
+-  // TODO(mdempsky): Extend DSL to support (flags & ~mask1) == mask2.
+-  const uint64_t kAndroidCloneMask = CLONE_VM | CLONE_FS | CLONE_FILES |
+-                                     CLONE_SIGHAND | CLONE_THREAD |
+-                                     CLONE_SYSVSEM;
+-  const uint64_t kObsoleteAndroidCloneMask = kAndroidCloneMask | CLONE_DETACHED;
+-
+-  const uint64_t kGlibcPthreadFlags =
+-      CLONE_VM | CLONE_FS | CLONE_FILES | CLONE_SIGHAND | CLONE_THREAD |
+-      CLONE_SYSVSEM | CLONE_SETTLS | CLONE_PARENT_SETTID | CLONE_CHILD_CLEARTID;
+-  const BoolExpr glibc_test = flags == kGlibcPthreadFlags;
+-
+-  const BoolExpr android_test =
+-      AnyOf(flags == kAndroidCloneMask, flags == kObsoleteAndroidCloneMask,
+-            flags == kGlibcPthreadFlags);
++  const int required = CLONE_VM | CLONE_FS | CLONE_FILES | CLONE_SIGHAND |
++                       CLONE_THREAD | CLONE_SYSVSEM;
++  const int safe = CLONE_SETTLS | CLONE_PARENT_SETTID | CLONE_CHILD_CLEARTID |
++	           CLONE_DETACHED;
++  const BoolExpr thread_clone_ok = (flags&~safe)==required;
+ 
+   // The following two flags are the two important flags in any vfork-emulating
+   // clone call. EPERM any clone call that contains both of them.
+@@ -151,7 +141,7 @@ ResultExpr RestrictCloneToThreadsAndEPERMFork() {
+       AnyOf((flags & (CLONE_VM | CLONE_THREAD)) == 0,
+             (flags & kImportantCloneVforkFlags) == kImportantCloneVforkFlags);
+ 
+-  return If(IsAndroid() ? android_test : glibc_test, Allow())
++  return If(thread_clone_ok, Allow())
+       .ElseIf(is_fork_or_clone_vfork, Error(EPERM))
+       .Else(CrashSIGSYSClone());
+ }
+diff --git a/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc b/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc
+index d1ea8e99a..cb1ff3042 100644
+--- a/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc
++++ b/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc
+@@ -399,6 +399,7 @@ bool SyscallSets::IsAllowedProcessStartOrDeath(int sysno) {
+ #if defined(__i386__)
+     case __NR_waitpid:
+ #endif
++    case __NR_set_tid_address:
+       return true;
+     case __NR_clone:  // Should be parameter-restricted.
+     case __NR_setns:  // Privileged.
+@@ -411,7 +412,6 @@ bool SyscallSets::IsAllowedProcessStartOrDeath(int sysno) {
+ #if defined(__i386__) || defined(__x86_64__) || defined(__mips__)
+     case __NR_set_thread_area:
+ #endif
+-    case __NR_set_tid_address:
+     case __NR_unshare:
+ #if !defined(__mips__) && !defined(__aarch64__)
+     case __NR_vfork:
+@@ -521,6 +521,8 @@ bool SyscallSets::IsAllowedAddressSpaceAccess(int sysno) {
+     case __NR_mlock:
+     case __NR_munlock:
+     case __NR_munmap:
++    case __NR_mremap:
++    case __NR_membarrier:
+       return true;
+     case __NR_madvise:
+     case __NR_mincore:
+@@ -538,7 +540,6 @@ bool SyscallSets::IsAllowedAddressSpaceAccess(int sysno) {
+     case __NR_modify_ldt:
+ #endif
+     case __NR_mprotect:
+-    case __NR_mremap:
+     case __NR_msync:
+     case __NR_munlockall:
+     case __NR_readahead:
+diff --git a/src/3rdparty/chromium/sandbox/policy/linux/bpf_renderer_policy_linux.cc b/src/3rdparty/chromium/sandbox/policy/linux/bpf_renderer_policy_linux.cc
+index 9fe9575eb..fa1a946f6 100644
+--- a/src/3rdparty/chromium/sandbox/policy/linux/bpf_renderer_policy_linux.cc
++++ b/src/3rdparty/chromium/sandbox/policy/linux/bpf_renderer_policy_linux.cc
+@@ -93,11 +93,11 @@ ResultExpr RendererProcessPolicy::EvaluateSyscall(int sysno) const {
+     case __NR_sysinfo:
+     case __NR_times:
+     case __NR_uname:
+-      return Allow();
+-    case __NR_sched_getaffinity:
+     case __NR_sched_getparam:
+     case __NR_sched_getscheduler:
+     case __NR_sched_setscheduler:
++      return Allow();
++    case __NR_sched_getaffinity:
+       return RestrictSchedTarget(GetPolicyPid(), sysno);
+     case __NR_prlimit64:
+       // See crbug.com/662450 and setrlimit comment above.
+-- 
+2.35.1
+

--- a/dev-qt/qtwebengine/files/qtwebengine-5.15.5_p20220618-pvalloc-patch.patch
+++ b/dev-qt/qtwebengine/files/qtwebengine-5.15.5_p20220618-pvalloc-patch.patch
@@ -1,0 +1,29 @@
+https://git.alpinelinux.org/aports/tree/community/qt5-qtwebengine/qt-musl-pvalloc.patch
+
+The obsolete function pvalloc() is similar to valloc(), but rounds the size of the allocation up to the next multiple of the system page size. (https://linux.die.net/man/3/pvalloc)
+
+See: https://git.alpinelinux.org/aports/tree/community/qt5-qtwebengine/qt-musl-pvalloc.patch?id=65f58742e6e669c7d0f5b23c0764f4f73661980b
+
+---
+ src/core/api/qtbug-61521.cpp | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/src/core/api/qtbug-61521.cpp b/src/core/api/qtbug-61521.cpp
+index 002a1af22..01c81ac8c 100644
+--- a/src/core/api/qtbug-61521.cpp
++++ b/src/core/api/qtbug-61521.cpp
+@@ -111,7 +111,11 @@ SHIM_HIDDEN void* ShimValloc(size_t size) {
+ }
+ 
+ SHIM_HIDDEN void* ShimPvalloc(size_t size) {
++#if defined(__GLIBC__)
+     return pvalloc(size);
++#else
++    return valloc((size+4095)&~4095);
++#endif
+ }
+ 
+ SHIM_HIDDEN int ShimPosixMemalign(void** r, size_t a, size_t s) {
+-- 
+2.35.1
+

--- a/dev-qt/qtwebengine/files/qtwebengine-5.15.5_p20220618-qmake-remove-glibc-check.patch
+++ b/dev-qt/qtwebengine/files/qtwebengine-5.15.5_p20220618-qmake-remove-glibc-check.patch
@@ -1,0 +1,81 @@
+https://git.alpinelinux.org/aports/tree/community/qt5-qtwebengine/remove-glibc-check.patch
+
+Qt checks if glibc is available and if not disables large part of Qt5WebEngine and thus cripples functionality.
+However these parts work fine with Musl so there is no need to disable them. - Alpine
+
+Just remove the check so it builds again. Since 5.15 is the last version of Qt to be released with this build system it'll be obsolete with Qt6 so there is no real point in fixing this upstream except adding to Qt5PatchCollection.
+
+https://git.alpinelinux.org/aports/tree/community/qt5-qtwebengine/remove-glibc-check.patch
+diff --git a/src/buildtools/config/support.pri b/src/buildtools/config/support.pri
+index e7f869a1..de18523d 100644
+--- a/src/buildtools/config/support.pri
++++ b/src/buildtools/config/support.pri
+@@ -189,15 +189,6 @@ defineTest(qtwebengine_checkForHostPkgCfg) {
+     return(true)
+ }
+ 
+-defineTest(qtwebengine_checkForGlibc) {
+-    module = $$1
+-    !qtConfig(webengine-system-glibc) {
+-        qtwebengine_skipBuild("A suitable version >= 2.27 of libc required to build $${module} could not be found.")
+-        return(false)
+-    }
+-    return(true)
+-}
+-
+ defineTest(qtwebengine_checkForKhronos) {
+     module = $$1
+     !qtConfig(webengine-system-khr) {
+diff --git a/src/buildtools/configure.json b/src/buildtools/configure.json
+index 88d1790c..8623f6d7 100644
+--- a/src/buildtools/configure.json
++++ b/src/buildtools/configure.json
+@@ -264,18 +264,6 @@
+             "label": "system gn",
+             "type": "detectGn"
+         },
+-        "webengine-glibc": {
+-            "label": "glibc > 2.16",
+-            "type": "compile",
+-            "test": {
+-                "include": "features.h",
+-                "tail": [
+-                    "#if __GLIBC__ < 2 || __GLIBC_MINOR__ < 17",
+-                    "#error glibc versions below 2.17 are not supported",
+-                    "#endif"
+-                ]
+-            }
+-        },
+         "webengine-gperf": {
+             "label": "gperf",
+             "type": "detectGperf"
+@@ -379,7 +367,6 @@
+                          && (!config.sanitizer || features.webengine-sanitizer)
+                          && (!config.linux || features.pkg-config)
+                          && (!config.linux || features.webengine-host-pkg-config)
+-                         && (!config.linux || features.webengine-system-glibc)
+                          && (!config.linux || features.webengine-system-khr)
+                          && (!config.linux || features.webengine-system-nss)
+                          && (!config.linux || features.webengine-system-dbus)
+@@ -517,11 +504,6 @@
+             "condition": "config.unix && !config.darwin && libs.webengine-nss",
+             "output": [ "privateFeature" ]
+         },
+-        "webengine-system-glibc": {
+-            "label": "glibc",
+-            "condition": "config.linux && tests.webengine-glibc",
+-            "output": [ "privateFeature" ]
+-        },
+         "webengine-system-x11" : {
+             "label": "x11",
+             "condition": "config.unix && libs.webengine-x11",
+@@ -782,8 +764,7 @@
+                         "webengine-system-fontconfig",
+                         "webengine-system-dbus",
+                         "webengine-system-nss",
+-                        "webengine-system-khr",
+-                        "webengine-system-glibc"
++                        "webengine-system-khr"
+                     ]
+                 },
+                 {

--- a/dev-qt/qtwebengine/files/qtwebengine-5.15.5_p20220618-remove-decls-usage.patch
+++ b/dev-qt/qtwebengine/files/qtwebengine-5.15.5_p20220618-remove-decls-usage.patch
@@ -1,0 +1,628 @@
+https://wiki.musl-libc.org/faq.html#Q:-When-compiling-something-against-musl,-I-get-error-messages-about-%3Ccode%3Esys/cdefs.h%3C/code%3E
+"The bug is in the application that uses this internal glibc header. This header is not intended to be used by any program"
+
+sys/cdefs.h does not exist in musl libc, this breaks bundled Chromium.
+The only thing QtWebEngine uses cdefs.h for is the __*_DECLS macros, so
+this patch replaces all that with the correct 'extern "C"' code.
+
+--- b/src/3rdparty/chromium/third_party/apple_apsl/dnsinfo.h
++++ b/src/3rdparty/chromium/third_party/apple_apsl/dnsinfo.h
+@@ -28,7 +28,7 @@
+  * These routines provide access to the systems DNS configuration
+  */
+ 
+-#include <sys/cdefs.h>
++
+ #include <stdint.h>
+ #include <sys/types.h>
+ #include <sys/socket.h>
+@@ -91,7 +91,9 @@
+ #pragma pack()
+ 
+ 
+-__BEGIN_DECLS
++#ifdef __cplusplus
++extern "C" {
++#endif
+ 
+ /*
+  * DNS configuration access APIs
+@@ -110,5 +112,7 @@
+ 				 const char	*bundle_id);
+ 
+-__END_DECLS
++#ifdef __cplusplus
++}
++#endif
+ 
+ #endif	/* __DNSINFO_H__ */
+--- b/src/3rdparty/chromium/third_party/libsync/src/include/sync/sync.h
++++ b/src/3rdparty/chromium/third_party/libsync/src/include/sync/sync.h
+@@ -19,12 +19,14 @@
+ #ifndef __SYS_CORE_SYNC_H
+ #define __SYS_CORE_SYNC_H
+ 
+-#include <sys/cdefs.h>
++
+ #include <stdint.h>
+ 
+ #include <linux/types.h>
+ 
+-__BEGIN_DECLS
++#ifdef __cplusplus
++extern "C" {
++#endif
+ 
+ struct sync_legacy_merge_data {
+  int32_t fd2;
+@@ -159,5 +161,7 @@
+ void sync_fence_info_free(struct sync_fence_info_data *info);
+ 
+-__END_DECLS
++#ifdef __cplusplus
++}
++#endif
+ 
+ #endif /* __SYS_CORE_SYNC_H */
+--- a/src/3rdparty/chromium/third_party/libsync/src/sw_sync.h
++++ b/src/3rdparty/chromium/third_party/libsync/src/sw_sync.h
+@@ -19,7 +19,9 @@
+ #ifndef __SYS_CORE_SW_SYNC_H
+ #define __SYS_CORE_SW_SYNC_H
+ 
+-__BEGIN_DECLS
++#ifdef __cplusplus
++extern "C" {
++#endif
+ 
+ /*
+  * sw_sync is mainly intended for testing and should not be compiled into
+@@ -30,6 +32,8 @@ int sw_sync_timeline_create(void);
+ int sw_sync_timeline_inc(int fd, unsigned count);
+ int sw_sync_fence_create(int fd, const char *name, unsigned value);
+ 
+-__END_DECLS
++#ifdef __cplusplus
++}
++#endif
+ 
+ #endif /* __SYS_CORE_SW_SYNC_H */
+--- b/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_uio.h
++++ b/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_uio.h
+@@ -33,7 +33,7 @@
+  */
+ 
+ #if defined(__FreeBSD__) && !defined(__Userspace__)
+-#include <sys/cdefs.h>
++
+ __FBSDID("$FreeBSD: head/sys/netinet/sctp_uio.h 362473 2020-06-21 23:12:56Z tuexen $");
+ #endif
+ 
+@@ -1317,7 +1317,9 @@
+  */
+ #if !(defined(_KERNEL)) && !(defined(__Userspace__))
+ 
+-__BEGIN_DECLS
++#ifdef __cplusplus
++extern "C" {
++#endif
+ int	sctp_peeloff(int, sctp_assoc_t);
+ int	sctp_bindx(int, struct sockaddr *, int, int);
+ int	sctp_connectx(int, const struct sockaddr *, int, sctp_assoc_t *);
+@@ -1355,7 +1357,9 @@
+ 
+ ssize_t	sctp_recvv(int, const struct iovec *, int, struct sockaddr *,
+ 	    socklen_t *, void *, socklen_t *, unsigned int *, int *);
+-__END_DECLS
++#ifdef __cplusplus
++}
++#endif
+ 
+ #endif				/* !_KERNEL */
+ #endif				/* !__sctp_uio_h__ */
+--- a/src/3rdparty/chromium/base/allocator/allocator_shim_internals.h
++++ b/src/3rdparty/chromium/base/allocator/allocator_shim_internals.h
+@@ -9,7 +9,7 @@
+ 
+ #if defined(__GNUC__)
+ 
+-#include <sys/cdefs.h>  // for __THROW
++  // for __THROW
+ 
+ #ifndef __THROW  // Not a glibc system
+ #ifdef _NOEXCEPT  // LLVM libc++ uses noexcept instead
+--- a/src/3rdparty/chromium/base/mac/close_nocancel.cc
++++ b/src/3rdparty/chromium/base/mac/close_nocancel.cc
+@@ -34,7 +34,7 @@
+ // is resolved from libsyscall. By linking with this version of close prior to
+ // the libsyscall version, close's implementation is overridden.
+ 
+-#include <sys/cdefs.h>
++
+ #include <unistd.h>
+ 
+ // If the non-cancelable variants of all system calls have already been
+--- a/src/3rdparty/chromium/third_party/breakpad/breakpad/src/common/android/include/stab.h
++++ b/src/3rdparty/chromium/third_party/breakpad/breakpad/src/common/android/include/stab.h
+@@ -30,7 +30,7 @@
+ #ifndef GOOGLE_BREAKPAD_COMMON_ANDROID_INCLUDE_STAB_H
+ #define GOOGLE_BREAKPAD_COMMON_ANDROID_INCLUDE_STAB_H
+ 
+-#include <sys/cdefs.h>
++
+ 
+ #ifdef __BIONIC_HAVE_STAB_H
+ #include <stab.h>
+--- a/src/3rdparty/chromium/third_party/breakpad/breakpad/src/common/android/include/sys/procfs.h
++++ b/src/3rdparty/chromium/third_party/breakpad/breakpad/src/common/android/include/sys/procfs.h
+@@ -37,7 +37,7 @@
+ #else
+ 
+ #include <asm/ptrace.h>
+-#include <sys/cdefs.h>
++
+ #if defined (__mips__)
+ #include <sys/types.h>
+ #endif
+--- a/src/3rdparty/chromium/third_party/crashpad/crashpad/compat/android/sys/mman.h
++++ b/src/3rdparty/chromium/third_party/crashpad/crashpad/compat/android/sys/mman.h
+@@ -18,7 +18,7 @@
+ #include_next <sys/mman.h>
+ 
+ #include <android/api-level.h>
+-#include <sys/cdefs.h>
++
+ 
+ // There’s no mmap() wrapper compatible with a 64-bit off_t for 32-bit code
+ // until API 21 (Android 5.0/“Lollipop”). A custom mmap() wrapper is provided
+--- a/src/3rdparty/chromium/third_party/crashpad/crashpad/compat/linux/sys/ptrace.h
++++ b/src/3rdparty/chromium/third_party/crashpad/crashpad/compat/linux/sys/ptrace.h
+@@ -17,7 +17,7 @@
+ 
+ #include_next <sys/ptrace.h>
+ 
+-#include <sys/cdefs.h>
++
+ 
+ // https://sourceware.org/bugzilla/show_bug.cgi?id=22433
+ #if !defined(PTRACE_GET_THREAD_AREA) && !defined(PT_GET_THREAD_AREA) && \
+--- a/src/3rdparty/chromium/third_party/tcmalloc/chromium/src/libc_override_gcc_and_weak.h
++++ b/src/3rdparty/chromium/third_party/tcmalloc/chromium/src/libc_override_gcc_and_weak.h
+@@ -40,7 +40,7 @@
+ #define TCMALLOC_LIBC_OVERRIDE_GCC_AND_WEAK_INL_H_
+ 
+ #ifdef HAVE_SYS_CDEFS_H
+-#include <sys/cdefs.h>    // for __THROW
++    // for __THROW
+ #endif
+ #include <gperftools/tcmalloc.h>
+ 
+--- a/src/3rdparty/chromium/third_party/tcmalloc/vendor/src/libc_override_gcc_and_weak.h
++++ b/src/3rdparty/chromium/third_party/tcmalloc/vendor/src/libc_override_gcc_and_weak.h
+@@ -40,7 +40,7 @@
+ #define TCMALLOC_LIBC_OVERRIDE_GCC_AND_WEAK_INL_H_
+ 
+ #ifdef HAVE_SYS_CDEFS_H
+-#include <sys/cdefs.h>    // for __THROW
++    // for __THROW
+ #endif
+ #include <gperftools/tcmalloc.h>
+ 
+--- a/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp.h
++++ b/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp.h
+@@ -33,7 +33,7 @@
+  */
+ 
+ #if defined(__FreeBSD__) && !defined(__Userspace__)
+-#include <sys/cdefs.h>
++
+ __FBSDID("$FreeBSD: head/sys/netinet/sctp.h 356357 2020-01-04 20:33:12Z tuexen $");
+ #endif
+ 
+--- a/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_asconf.c
++++ b/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_asconf.c
+@@ -33,7 +33,7 @@
+  */
+ 
+ #if defined(__FreeBSD__) && !defined(__Userspace__)
+-#include <sys/cdefs.h>
++
+ __FBSDID("$FreeBSD: head/sys/netinet/sctp_asconf.c 363194 2020-07-14 20:32:50Z tuexen $");
+ #endif
+ 
+--- a/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_asconf.h
++++ b/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_asconf.h
+@@ -33,7 +33,7 @@
+  */
+ 
+ #if defined(__FreeBSD__) && !defined(__Userspace__)
+-#include <sys/cdefs.h>
++
+ __FBSDID("$FreeBSD: head/sys/netinet/sctp_asconf.h 362377 2020-06-19 12:35:29Z tuexen $");
+ #endif
+ 
+--- a/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_auth.c
++++ b/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_auth.c
+@@ -33,7 +33,7 @@
+  */
+ 
+ #if defined(__FreeBSD__) && !defined(__Userspace__)
+-#include <sys/cdefs.h>
++
+ __FBSDID("$FreeBSD: head/sys/netinet/sctp_auth.c 362054 2020-06-11 13:34:09Z tuexen $");
+ #endif
+ 
+--- a/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_auth.h
++++ b/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_auth.h
+@@ -33,7 +33,7 @@
+  */
+ 
+ #if defined(__FreeBSD__) && !defined(__Userspace__)
+-#include <sys/cdefs.h>
++
+ __FBSDID("$FreeBSD: head/sys/netinet/sctp_auth.h 338749 2018-09-18 10:53:07Z tuexen $");
+ #endif
+ 
+--- a/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_bsd_addr.c
++++ b/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_bsd_addr.c
+@@ -33,7 +33,7 @@
+  */
+ 
+ #if defined(__FreeBSD__) && !defined(__Userspace__)
+-#include <sys/cdefs.h>
++
+ __FBSDID("$FreeBSD: head/sys/netinet/sctp_bsd_addr.c 358080 2020-02-18 19:41:55Z tuexen $");
+ #endif
+ 
+--- a/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_bsd_addr.h
++++ b/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_bsd_addr.h
+@@ -33,7 +33,7 @@
+  */
+ 
+ #if defined(__FreeBSD__) && !defined(__Userspace__)
+-#include <sys/cdefs.h>
++
+ __FBSDID("$FreeBSD: head/sys/netinet/sctp_bsd_addr.h 353480 2019-10-13 18:17:08Z tuexen $");
+ #endif
+ 
+--- a/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_callout.h
++++ b/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_callout.h
+@@ -31,7 +31,7 @@
+  */
+ 
+ #if defined(__FreeBSD__) && !defined(__Userspace__)
+-#include <sys/cdefs.h>
++
+ __FBSDID("$FreeBSD$");
+ #endif
+ 
+--- a/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_cc_functions.c
++++ b/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_cc_functions.c
+@@ -33,7 +33,7 @@
+  */
+ 
+ #if defined(__FreeBSD__) && !defined(__Userspace__)
+-#include <sys/cdefs.h>
++
+ __FBSDID("$FreeBSD: head/sys/netinet/sctp_cc_functions.c 359405 2020-03-28 20:25:45Z tuexen $");
+ #endif
+ 
+--- a/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_constants.h
++++ b/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_constants.h
+@@ -33,7 +33,7 @@
+  */
+ 
+ #if defined(__FreeBSD__) && !defined(__Userspace__)
+-#include <sys/cdefs.h>
++
+ __FBSDID("$FreeBSD: head/sys/netinet/sctp_constants.h 363440 2020-07-23 01:35:24Z tuexen $");
+ #endif
+ 
+--- a/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_crc32.c
++++ b/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_crc32.c
+@@ -33,7 +33,7 @@
+  */
+ 
+ #if defined(__FreeBSD__) && !defined(__Userspace__)
+-#include <sys/cdefs.h>
++
+ __FBSDID("$FreeBSD: head/sys/netinet/sctp_crc32.c 362498 2020-06-22 14:36:14Z tuexen $");
+ 
+ #include "opt_sctp.h"
+--- a/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_crc32.h
++++ b/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_crc32.h
+@@ -33,7 +33,7 @@
+  */
+ 
+ #if defined(__FreeBSD__) && !defined(__Userspace__)
+-#include <sys/cdefs.h>
++
+ __FBSDID("$FreeBSD: head/sys/netinet/sctp_crc32.h 362338 2020-06-18 19:32:34Z markj $");
+ #endif
+ 
+--- a/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_header.h
++++ b/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_header.h
+@@ -33,7 +33,7 @@
+  */
+ 
+ #if defined(__FreeBSD__) && !defined(__Userspace__)
+-#include <sys/cdefs.h>
++
+ __FBSDID("$FreeBSD: head/sys/netinet/sctp_header.h 309682 2016-12-07 19:30:59Z tuexen $");
+ #endif
+ 
+--- a/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_indata.c
++++ b/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_indata.c
+@@ -33,7 +33,7 @@
+  */
+ 
+ #if defined(__FreeBSD__) && !defined(__Userspace__)
+-#include <sys/cdefs.h>
++
+ __FBSDID("$FreeBSD: head/sys/netinet/sctp_indata.c 363440 2020-07-23 01:35:24Z tuexen $");
+ #endif
+ 
+--- a/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_indata.h
++++ b/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_indata.h
+@@ -33,7 +33,7 @@
+  */
+ 
+ #if defined(__FreeBSD__) && !defined(__Userspace__)
+-#include <sys/cdefs.h>
++
+ __FBSDID("$FreeBSD: head/sys/netinet/sctp_indata.h 361116 2020-05-16 19:26:39Z tuexen $");
+ #endif
+ 
+--- a/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_input.c
++++ b/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_input.c
+@@ -33,7 +33,7 @@
+  */
+ 
+ #if defined(__FreeBSD__) && !defined(__Userspace__)
+-#include <sys/cdefs.h>
++
+ __FBSDID("$FreeBSD: head/sys/netinet/sctp_input.c 368622 2020-12-13 23:51:51Z tuexen $");
+ #endif
+ 
+--- a/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_input.h
++++ b/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_input.h
+@@ -33,7 +33,7 @@
+  */
+ 
+ #if defined(__FreeBSD__) && !defined(__Userspace__)
+-#include <sys/cdefs.h>
++
+ __FBSDID("$FreeBSD: head/sys/netinet/sctp_input.h 326672 2017-12-07 22:19:08Z tuexen $");
+ #endif
+ 
+--- a/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_lock_userspace.h
++++ b/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_lock_userspace.h
+@@ -34,7 +34,7 @@
+  */
+ 
+ #if defined(__FreeBSD__) && !defined(__Userspace__)
+-#include <sys/cdefs.h>
++
+ __FBSDID("$FreeBSD$");
+ #endif
+ 
+--- a/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_os.h
++++ b/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_os.h
+@@ -33,7 +33,7 @@
+  */
+ 
+ #if defined(__FreeBSD__) && !defined(__Userspace__)
+-#include <sys/cdefs.h>
++
+ __FBSDID("$FreeBSD: head/sys/netinet/sctp_os.h 361872 2020-06-06 18:20:09Z tuexen $");
+ #endif
+ 
+--- a/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_output.c
++++ b/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_output.c
+@@ -33,7 +33,7 @@
+  */
+ 
+ #if defined(__FreeBSD__) && !defined(__Userspace__)
+-#include <sys/cdefs.h>
++
+ __FBSDID("$FreeBSD: head/sys/netinet/sctp_output.c 364937 2020-08-28 20:05:18Z tuexen $");
+ #endif
+ 
+--- a/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_output.h
++++ b/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_output.h
+@@ -33,7 +33,7 @@
+  */
+ 
+ #if defined(__FreeBSD__) && !defined(__Userspace__)
+-#include <sys/cdefs.h>
++
+ __FBSDID("$FreeBSD: head/sys/netinet/sctp_output.h 362054 2020-06-11 13:34:09Z tuexen $");
+ #endif
+ 
+--- a/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_pcb.c
++++ b/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_pcb.c
+@@ -33,7 +33,7 @@
+  */
+ 
+ #if defined(__FreeBSD__) && !defined(__Userspace__)
+-#include <sys/cdefs.h>
++
+ __FBSDID("$FreeBSD: head/sys/netinet/sctp_pcb.c 366248 2020-09-29 09:36:06Z tuexen $");
+ #endif
+ 
+--- a/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_pcb.h
++++ b/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_pcb.h
+@@ -33,7 +33,7 @@
+  */
+ 
+ #if defined(__FreeBSD__) && !defined(__Userspace__)
+-#include <sys/cdefs.h>
++
+ __FBSDID("$FreeBSD: head/sys/netinet/sctp_pcb.h 362106 2020-06-12 16:31:13Z tuexen $");
+ #endif
+ 
+--- a/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_peeloff.c
++++ b/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_peeloff.c
+@@ -33,7 +33,7 @@
+  */
+ 
+ #if defined(__FreeBSD__) && !defined(__Userspace__)
+-#include <sys/cdefs.h>
++
+ __FBSDID("$FreeBSD: head/sys/netinet/sctp_peeloff.c 362054 2020-06-11 13:34:09Z tuexen $");
+ #endif
+ 
+--- a/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_peeloff.h
++++ b/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_peeloff.h
+@@ -33,7 +33,7 @@
+  */
+ 
+ #if defined(__FreeBSD__) && !defined(__Userspace__)
+-#include <sys/cdefs.h>
++
+ __FBSDID("$FreeBSD: head/sys/netinet/sctp_peeloff.h 309607 2016-12-06 10:21:25Z tuexen $");
+ #endif
+ 
+--- a/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_sha1.h
++++ b/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_sha1.h
+@@ -33,7 +33,7 @@
+  */
+ 
+ #if defined(__FreeBSD__) && !defined(__Userspace__)
+-#include <sys/cdefs.h>
++
+ __FBSDID("$FreeBSD$");
+ #endif
+ 
+--- a/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_ss_functions.c
++++ b/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_ss_functions.c
+@@ -29,7 +29,7 @@
+  */
+ 
+ #if defined(__FreeBSD__) && !defined(__Userspace__)
+-#include <sys/cdefs.h>
++
+ __FBSDID("$FreeBSD: head/sys/netinet/sctp_ss_functions.c 362173 2020-06-14 09:50:00Z tuexen $");
+ #endif
+ 
+--- a/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_structs.h
++++ b/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_structs.h
+@@ -33,7 +33,7 @@
+  */
+ 
+ #if defined(__FreeBSD__) && !defined(__Userspace__)
+-#include <sys/cdefs.h>
++
+ __FBSDID("$FreeBSD: head/sys/netinet/sctp_structs.h 364268 2020-08-16 11:50:37Z tuexen $");
+ #endif
+ 
+--- a/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_sysctl.c
++++ b/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_sysctl.c
+@@ -33,7 +33,7 @@
+  */
+ 
+ #if defined(__FreeBSD__) && !defined(__Userspace__)
+-#include <sys/cdefs.h>
++
+ __FBSDID("$FreeBSD: head/sys/netinet/sctp_sysctl.c 361934 2020-06-08 20:23:20Z tuexen $");
+ #endif
+ 
+--- a/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_sysctl.h
++++ b/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_sysctl.h
+@@ -33,7 +33,7 @@
+  */
+ 
+ #if defined(__FreeBSD__) && !defined(__Userspace__)
+-#include <sys/cdefs.h>
++
+ __FBSDID("$FreeBSD: head/sys/netinet/sctp_sysctl.h 361895 2020-06-07 14:39:20Z tuexen $");
+ #endif
+ 
+--- a/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_timer.c
++++ b/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_timer.c
+@@ -33,7 +33,7 @@
+  */
+ 
+ #if defined(__FreeBSD__) && !defined(__Userspace__)
+-#include <sys/cdefs.h>
++
+ __FBSDID("$FreeBSD: head/sys/netinet/sctp_timer.c 362054 2020-06-11 13:34:09Z tuexen $");
+ #endif
+ 
+--- a/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_timer.h
++++ b/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_timer.h
+@@ -33,7 +33,7 @@
+  */
+ 
+ #if defined(__FreeBSD__) && !defined(__Userspace__)
+-#include <sys/cdefs.h>
++
+ __FBSDID("$FreeBSD: head/sys/netinet/sctp_timer.h 359195 2020-03-21 16:12:19Z tuexen $");
+ #endif
+ 
+--- a/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_usrreq.c
++++ b/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_usrreq.c
+@@ -33,7 +33,7 @@
+  */
+ 
+ #if defined(__FreeBSD__) && !defined(__Userspace__)
+-#include <sys/cdefs.h>
++
+ __FBSDID("$FreeBSD: head/sys/netinet/sctp_usrreq.c 364353 2020-08-18 19:25:03Z tuexen $");
+ #endif
+ 
+--- a/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_var.h
++++ b/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctp_var.h
+@@ -33,7 +33,7 @@
+  */
+ 
+ #if defined(__FreeBSD__) && !defined(__Userspace__)
+-#include <sys/cdefs.h>
++
+ __FBSDID("$FreeBSD: head/sys/netinet/sctp_var.h 363323 2020-07-19 12:34:19Z tuexen $");
+ #endif
+ 
+--- a/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctputil.c
++++ b/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctputil.c
+@@ -33,7 +33,7 @@
+  */
+ 
+ #if defined(__FreeBSD__) && !defined(__Userspace__)
+-#include <sys/cdefs.h>
++
+ __FBSDID("$FreeBSD: head/sys/netinet/sctputil.c 364268 2020-08-16 11:50:37Z tuexen $");
+ #endif
+ 
+--- a/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctputil.h
++++ b/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet/sctputil.h
+@@ -33,7 +33,7 @@
+  */
+ 
+ #if defined(__FreeBSD__) && !defined(__Userspace__)
+-#include <sys/cdefs.h>
++
+ __FBSDID("$FreeBSD: head/sys/netinet/sctputil.h 364268 2020-08-16 11:50:37Z tuexen $");
+ #endif
+ 
+--- a/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet6/sctp6_usrreq.c
++++ b/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet6/sctp6_usrreq.c
+@@ -33,7 +33,7 @@
+  */
+ 
+ #if defined(__FreeBSD__) && !defined(__Userspace__)
+-#include <sys/cdefs.h>
++
+ __FBSDID("$FreeBSD: head/sys/netinet6/sctp6_usrreq.c 361895 2020-06-07 14:39:20Z tuexen $");
+ #endif
+ 
+--- a/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet6/sctp6_var.h
++++ b/src/3rdparty/chromium/third_party/usrsctp/usrsctplib/usrsctplib/netinet6/sctp6_var.h
+@@ -33,7 +33,7 @@
+  */
+ 
+ #if defined(__FreeBSD__) && !defined(__Userspace__)
+-#include <sys/cdefs.h>
++
+ __FBSDID("$FreeBSD: head/sys/netinet6/sctp6_var.h 317457 2017-04-26 19:26:40Z tuexen $");
+ #endif
+ 

--- a/dev-qt/qtwebengine/metadata.xml
+++ b/dev-qt/qtwebengine/metadata.xml
@@ -14,6 +14,7 @@
 		<flag name="designer">Install the QWebEngineView plugin used to add widgets in <pkg>dev-qt/designer</pkg> forms that display web pages.</flag>
 		<flag name="geolocation">Enable physical position determination via <pkg>dev-qt/qtpositioning</pkg></flag>
 		<flag name="jumbo-build">Combine source files to speed up build process.</flag>
+		<flag name="screencast">Enable support for remote desktop and screen cast using <pkg>media-video/pipewire</pkg></flag>
 		<flag name="system-ffmpeg">Use the system-wide <pkg>media-video/ffmpeg</pkg> instead of bundled.</flag>
 		<flag name="system-icu">Use the system-wide <pkg>dev-libs/icu</pkg> instead of bundled.</flag>
 		<flag name="widgets">Enable QtWidgets support</flag>

--- a/dev-qt/qtwebengine/qtwebengine-5.15.5_p20220618.ebuild
+++ b/dev-qt/qtwebengine/qtwebengine-5.15.5_p20220618.ebuild
@@ -99,6 +99,7 @@ BDEPEND="${PYTHON_DEPS}
 	net-libs/nodejs[ssl]
 	sys-devel/bison
 	sys-devel/flex
+	elibc_musl? ( sys-libs/queue-standalone )
 	ppc64? ( >=dev-util/gn-0.1807 )
 "
 
@@ -113,6 +114,19 @@ PATCHES=(
 	"${WORKDIR}/${PN}-5.15.2_p20211019-jumbo-build.patch" # bug 813957
 	"${WORKDIR}/${PN}-5.15.3_p20220406-patchset" # bug 698988 (py2--), pipewire-3
 	"${FILESDIR}/${P}-fixup-CVE-2022-0796.patch" # bug 853097
+
+	# for musl libc
+	"${FILESDIR}"/${PN}-5.15.5_p20220618-qmake-remove-glibc-check.patch
+	"${FILESDIR}"/${PN}-5.15.5_p20220618-musl-mallinfo.patch
+	"${FILESDIR}"/${PN}-5.15.5_p20220618-musl-mojo-strncpy.patch
+	"${FILESDIR}"/${PN}-5.15.5_p20220618-musl-resolv-compat.patch
+	"${FILESDIR}"/${PN}-5.15.5_p20220618-backtrace-execinfo.patch
+	"${FILESDIR}"/${PN}-5.15.5_p20220618-pvalloc-patch.patch
+	"${FILESDIR}"/${PN}-5.15.5_p20220618-linux-stack_util-stackstart.patch
+	"${FILESDIR}"/${PN}-5.15.5_p20220618-remove-decls-usage.patch
+	"${FILESDIR}"/${PN}-5.15.5_p20220618-msghdr-padding-initlist.patch
+	## runtime
+	"${FILESDIR}"/${PN}-5.15.5_p20220618-musl-sandbox.patch
 )
 
 qtwebengine_check-reqs() {
@@ -167,6 +181,10 @@ src_unpack() {
 }
 
 src_prepare() {
+	# Using a conditional patch here since QMake is deprecated
+	# by CMake in Qt6. A build system change would be prettier but
+	# this works just as well right now.
+	use elibc_musl && PATCHES+=( "${FILESDIR}"/${PN}-5.15.5_p20220618-musl-canonicalize-filename.patch )
 	if [[ ${PV} == ${QT5_PV}_p* ]]; then
 		# This is made from git, and for some reason will fail w/o .git directories.
 		mkdir -p .git src/3rdparty/chromium/.git || die


### PR DESCRIPTION
This is a series of patches to make QtWebEngine run on musl. Many of
these patches are taken from Alpine Linux but with many added comments
and some changes.

Almost every patch is for the bundled Chromium and not QtWebEngine
"itself".

I also wonder how I should go about upstreaming this? Some patches,
like the "remove-glibc-check" are not upstreamable and could be done in
a better way. Similarly, some other patches could've been done prettier in the build
system, like the canonicalize-filename, but as QMake is deprecated for
CMake it wasn't worth it time-wise.

The remove-decls-usage patch is also a little to large (20.3 KiB).

Signed-off-by: Alfred Persson Forsberg <cat@catcream.org>