### PR TITLE
Syft ebuild fixes

### DIFF
--- a/app-containers/syft/syft-0.51.0.ebuild
+++ b/app-containers/syft/syft-0.51.0.ebuild
@@ -18,5 +18,5 @@ src_compile() {
 }
 
 src_install() {
-dobin bin/*
+	dobin bin/*
 }

--- a/app-containers/syft/syft-0.51.0.ebuild
+++ b/app-containers/syft/syft-0.51.0.ebuild
@@ -11,7 +11,7 @@ SRC_URI+=" https://dev.gentoo.org/~williamh/dist/${P}-deps.tar.xz"
 
 LICENSE="Apache-2.0"
 SLOT="0"
-KEYWORDS="~amd64"
+KEYWORDS="~amd64 ~arm64"
 
 src_compile() {
 	ego build -o bin/syft -ldflags "-X github.com/anchore/syft/internal/version.version=${PV}" ./cmd/syft

--- a/app-containers/syft/syft-0.51.0.ebuild
+++ b/app-containers/syft/syft-0.51.0.ebuild
@@ -14,7 +14,7 @@ SLOT="0"
 KEYWORDS="~amd64"
 
 src_compile() {
-	ego build -o bin/syft ./cmd/syft
+	ego build -o bin/syft -ldflags "-X github.com/anchore/syft/internal/version.version=${PV}" ./cmd/syft
 }
 
 src_install() {


### PR DESCRIPTION
* keyword for ~arm64
* fix indentation
* compile the correct version string into the binary so that `syft version` reports correct output