### PR TITLE
profiles/.../musl/package.mask: unmask www-client/firefox

### DIFF
--- a/profiles/default/linux/musl/package.mask
+++ b/profiles/default/linux/musl/package.mask
@@ -76,9 +76,3 @@ games-strategy/dominions2
 games-strategy/knights-demo
 games-strategy/majesty-demo
 media-video/binkplayer
-
-# Ian Stakenvicius, 2017-06-14
-# on behalf of mozilla@gentoo.org
-# Mask firefox-54 and above as it requires rust
-# now, and rust reportedly will not build yet.
->=www-client/firefox-54.0

--- a/profiles/features/musl/package.mask
+++ b/profiles/features/musl/package.mask
@@ -266,12 +266,6 @@ sys-apps/systemd
 # systemd sources fail to build without glibc
 sys-boot/systemd-boot
 
-# Ian Stakenvicius <axs@gentoo.org> (2017-06-14)
-# (on behalf of <mozilla@gentoo.org>)
-# Mask firefox-54 and above as it requires rust
-# now, and rust reportedly will not build yet.
->=www-client/firefox-54.0
-
 # rust-bin requires a glibc system
 dev-lang/rust-bin
 mail-client/thunderbird-bin

--- a/profiles/features/musl/package.use.mask
+++ b/profiles/features/musl/package.use.mask
@@ -1,6 +1,11 @@
 # Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Alfred Persson Forsberg <cat@catcream.org> (2022-07-27)
+# Firefox does not build with these flags enabled on musl libc.
+# See bug #829033
+www-client/firefox clang pgo
+
 # Ionen Wolkens <ionen@gentoo.org (2022-06-08)
 # Depends on www-plugins/chrome-binary-plugins which is masked here.
 www-client/qutebrowser widevine


### PR DESCRIPTION
This unmasks Firefox and use.mask's clang and pgo.

See: https://bugs.gentoo.org/829033
Signed-off-by: Alfred Persson Forsberg <cat@catcream.org>