### PR TITLE
x11-libs/libXaw3dXft: fix pkg-config Version

### DIFF
--- a/x11-libs/libXaw3dXft/libXaw3dXft-1.6.2h.ebuild
+++ b/x11-libs/libXaw3dXft/libXaw3dXft-1.6.2h.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -6,7 +6,7 @@ EAPI=7
 inherit xorg-3
 
 DESCRIPTION="Xaw3dXft library"
-HOMEPAGE="https://sourceforge.net/projects/sf-xpaint"
+HOMEPAGE="https://sourceforge.net/projects/sf-xpaint/"
 SRC_URI="mirror://sourceforge/sf-xpaint/${P}.tar.bz2"
 
 KEYWORDS="amd64 x86"
@@ -23,7 +23,10 @@ DEPEND="${RDEPEND}
 	x11-base/xorg-proto"
 BDEPEND="
 	sys-devel/flex
-	virtual/yacc"
+	virtual/yacc
+	x11-misc/util-macros"
+
+QA_PKGCONFIG_VERSION="${PV//[!0-9.]}"
 
 src_configure() {
 	local XORG_CONFIGURE_OPTIONS=(


### PR DESCRIPTION
Upstream set **1.6.2** in `configure.ac`.  This is an attempt to add the final letter (if it exists) to `configure.ac` to make the `pkg-config` file contain the right `Version` field.

According to pkg-config (and rpm) documentation, **1.6.2h** > **1.6.2**, so any dependency that requires **>= 1.6.2** should still work.

The only reverse dependency in the tree is `media-gfx/xpaint` and I checked, it still compiles and runs.

So no harm done fixing this bug.