### PR TITLE
app-text/mandoc: Add app-text/manpager to RDEPEND

### DIFF
--- a/app-text/mandoc/mandoc-1.14.6-r1.ebuild
+++ b/app-text/mandoc/mandoc-1.14.6-r1.ebuild
@@ -15,7 +15,10 @@ KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~ppc ~ppc64 ~riscv ~s390 ~sparc 
 IUSE="cgi system-man"
 
 RDEPEND="sys-libs/zlib
-	system-man? ( !sys-apps/man-db )
+	system-man? (
+		app-text/manpager
+		!sys-apps/man-db
+	)
 "
 DEPEND="${RDEPEND}
 	cgi? ( sys-libs/zlib[static-libs] )


### PR DESCRIPTION
When using `USE=system-man` man(1) fails to run if `app-text/manpager` is not installed.