### PR TITLE
www-apps/tt-rss: Drop php-7.3 support for live ebuild

### DIFF
--- a/www-apps/tt-rss/tt-rss-99999999.ebuild
+++ b/www-apps/tt-rss/tt-rss-99999999.ebuild
@@ -13,7 +13,7 @@ SLOT="${PV}" # Single live slot.
 IUSE="+acl daemon gd +mysqli postgres"
 REQUIRED_USE="|| ( mysqli postgres )"
 
-PHP_SLOTS="8.0 7.4 7.3"
+PHP_SLOTS="8.0 7.4"
 PHP_USE="gd?,mysqli?,postgres?,curl,fileinfo,intl,json(+),pdo,unicode,xml"
 
 php_rdepend() {


### PR DESCRIPTION
According to [upstream](https://git.tt-rss.org/fox/tt-rss.git/commit/?id=4aefbd628e9a0e1eac58523904ad887b0635cda3), drop php-7.3 support for live ebuild.
Signed-off-by: Nicolas PARLANT <ppn@parhuet.fr>