### PR TITLE
app-shells/bash: Fix the builtin man pages

### DIFF
--- a/app-shells/bash/bash-5.1_p16.ebuild
+++ b/app-shells/bash/bash-5.1_p16.ebuild
@@ -79,6 +79,9 @@ S="${WORKDIR}/${MY_P}"
 PATCHES=(
 	# Patches from Chet sent to bashbug ml
 	"${WORKDIR}"/${PN}-${GENTOO_PATCH_VER}-patches/${PN}-5.0-syslog-history-extern.patch
+
+	# Fix for the bash_builtins man pages when using mandoc
+	"${FILESDIR}"/${PN}-5.1-mandoc.patch
 )
 
 pkg_setup() {

--- a/app-shells/bash/bash-5.2_rc2.ebuild
+++ b/app-shells/bash/bash-5.2_rc2.ebuild
@@ -96,6 +96,9 @@ PATCHES=(
 
 	# Patches from Chet sent to bashbug ml
 	"${FILESDIR}"/${PN}-5.0-syslog-history-extern.patch
+
+	# Fix for the bash_builtins man pages when using mandoc
+	"${FILESDIR}"/${PN}-5.1-mandoc.patch
 )
 
 pkg_setup() {

--- a/app-shells/bash/bash-9999.ebuild
+++ b/app-shells/bash/bash-9999.ebuild
@@ -96,6 +96,9 @@ PATCHES=(
 
 	# Patches from Chet sent to bashbug ml
 	"${FILESDIR}"/${PN}-5.0-syslog-history-extern.patch
+
+	# Fix for the bash_builtins man pages when using mandoc
+	"${FILESDIR}"/${PN}-5.1-mandoc.patch
 )
 
 pkg_setup() {

--- a/app-shells/bash/files/bash-5.1-mandoc.patch
+++ b/app-shells/bash/files/bash-5.1-mandoc.patch
@@ -1,0 +1,33 @@
+Upstream-Pr: https://savannah.gnu.org/patch/?9592
+Author: orbea <orbea@riseup.net>
+Date:   Mon Mar 12 19:59:25 2018 -0700
+
+    doc: Fix referenced man page paths.
+
+    With mandoc opening these man pages will print the following error:
+
+    man: bash.1: ERROR: No such file or directory
+
+    The issue is that .so requires the prefix path such as man1 while some
+    man implementations seemingly ignore this.
+
+--- doc/builtins.1.orig
++++ doc/builtins.1
+@@ -19,6 +19,6 @@ shift, shopt, source, suspend, test, times, trap, true, type, typeset,
+ ulimit, umask, unalias, unset, wait \- bash built-in commands, see \fBbash\fR(1)
+ .SH BASH BUILTIN COMMANDS
+ .nr zZ 1
+-.so bash.1
++.so man1/bash.1
+ .SH SEE ALSO
+ bash(1), sh(1)
+--- doc/rbash.1.orig
++++ doc/rbash.1
+@@ -3,6 +3,6 @@
+ rbash \- restricted bash, see \fBbash\fR(1)
+ .SH RESTRICTED SHELL
+ .nr zY 1
+-.so bash.1
++.so man1/bash.1
+ .SH SEE ALSO
+ bash(1)


### PR DESCRIPTION
When using stricter man implementations such as `app-text/mandoc` the builtin man pages (i.e. `man export`) fail to display most of the manual unless the path for the `bash.1` man page is correct.

I submitted this patch upstream in 2018 for Slackware who now carries this patch, but upstream wasn't very understanding suggesting distros should carry it themselves.

Upstream-PR: https://savannah.gnu.org/patch/?9592