### PR TITLE
games-emulation/pcsx2: Update live ebuild

### DIFF
--- a/games-emulation/pcsx2/files/pcsx2-1.7.0-crcs.patch
+++ b/games-emulation/pcsx2/files/pcsx2-1.7.0-crcs.patch
@@ -1,0 +1,43 @@
+Upstream-PR: https://github.com/PCSX2/pcsx2/pull/5082
+Upstream-Issue: https://github.com/PCSX2/pcsx2/issues/1762
+Upstream-Issue: https://github.com/PCSX2/pcsx2/issues/5062
+
+From: orbea <orbea@riseup.net>
+Date: Sun, 28 Nov 2021 16:18:48 -0800
+Subject: [PATCH] Revert "GS: Remove Unofficial CRCs (#4082)"
+
+These games hacks are still used and can be removed
+again when a better solution is available.
+
+This reverts commit 6bcdb55f22d468b2eb8b95fd35bd071f9272a89c.
+
+--- a/pcsx2/GS/GSCrc.cpp
++++ b/pcsx2/GS/GSCrc.cpp
+@@ -22,6 +22,8 @@ const CRC::Game CRC::m_games[] =
+ {
+ 	// Note: IDs 0x7ACF7E03, 0x7D4EA48F, 0x37C53760 - shouldn't be added as it's from the multiloaders when packing games.
+ 	{0x00000000, NoTitle, NoRegion, 0},
++	{0xF46142D3, ArTonelico2, NoRegion, 0},
++	{0xC38067F4, ArTonelico2, NoRegion, 0}, // project metafalica 1.0
+ 	{0xF95F37EE, ArTonelico2, US, 0},
+ 	{0x68CE6801, ArTonelico2, JP, 0},
+ 	{0xCE2C1DBF, ArTonelico2, EU, 0},
+@@ -164,6 +166,8 @@ const CRC::Game CRC::m_games[] =
+ 	{0xBF6F101F, GiTS, EU, 0}, // same CRC as another US disc
+ 	{0xA616A6C2, TalesOfAbyss, US, 0},
+ 	{0x14FE77F7, TalesOfAbyss, US, 0},
++	{0x045D77E9, TalesOfAbyss, JPUNDUB, 0},
++	{0x14FD77F7, TalesOfAbyss, JPUNDUB, 0},
+ 	{0xAA5EC3A3, TalesOfAbyss, JP, 0},
+ 	{0xFB236A46, SonicUnleashed, US, 0},
+ 	{0x8C913264, SonicUnleashed, EU, 0},
+--- a/pcsx2/GS/GSCrc.h
++++ b/pcsx2/GS/GSCrc.h
+@@ -91,6 +91,7 @@ public:
+ 		US,
+ 		EU,
+ 		JP,
++		JPUNDUB,
+ 		RU,
+ 		FR,
+ 		DE,

--- a/games-emulation/pcsx2/pcsx2-9999.ebuild
+++ b/games-emulation/pcsx2/pcsx2-9999.ebuild
@@ -61,6 +61,10 @@ FILECAPS=(
 	-m 755 "CAP_NET_RAW+eip CAP_NET_ADMIN+eip" usr/bin/pcsx2
 )
 
+PATCHES=(
+	"${FILESDIR}"/${PN}-1.7.0-crcs.patch
+)
+
 pkg_setup() {
 	if [[ ${MERGE_TYPE} != binary && $(tc-getCC) == *gcc* ]]; then
 		# -mxsave flag is needed when GCC >= 8.2 is used
@@ -93,8 +97,8 @@ src_configure() {
 	# if it something other than "Devel|Debug|Release"
 	local CMAKE_BUILD_TYPE="Release"
 	local mycmakeargs=(
-		-DARCH_FLAG=
 		-DBUILD_SHARED_LIBS=FALSE
+		-DDISABLE_ADVANCE_SIMD=TRUE
 		-DDISABLE_BUILD_DATE=TRUE
 		-DDISABLE_PCSX2_WRAPPER=TRUE
 		-DDISABLE_SETCAP=TRUE


### PR DESCRIPTION
This fixes two issues:

1.
Because `-DARCH_FLAGS=` the build fails with the following.
```
#error PCSX2 requires compiling for at least SSE 4.1
```
This can be fixed by replacing the cmake argument with `-DDISABLE_ADVANCE_SIMD=ON`.

2.
Upstream removed crcs for a few unofficial games that are required to fix major playability issues. These versions of the games can be far preferable to the official versions where one was completely broken in the North American release, but fixed in a fan patched version.

This patch should be upstreamed and it was for a long time. However at some point they decided to remove it and the process of trying to add it back and then discussing why they were so unreasonably resistant resulted in no clear answers and a ban from their github repo despite being a long term contributor to the project. Please see the linked issues and PRs for details. At the very least we can fix it in Gentoo.

Upstream-PR: https://github.com/PCSX2/pcsx2/pull/5082
Upstream-Issue: https://github.com/PCSX2/pcsx2/issues/1762
Upstream-Issue: https://github.com/PCSX2/pcsx2/issues/5062