### PR TITLE
games-emulation/pcsx2: remove myself from maintainers

### DIFF
--- a/games-emulation/pcsx2/metadata.xml
+++ b/games-emulation/pcsx2/metadata.xml
@@ -1,14 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer type="person" proxied="yes">
-		<email>ykonotopov@gnome.org</email>
-		<name>Yuri Konotopov</name>
-	</maintainer>
-	<maintainer type="project" proxied="proxy">
-		<email>proxy-maint@gentoo.org</email>
-		<name>Proxy Maintainers</name>
-	</maintainer>
 	<maintainer type="project">
 		<email>games@gentoo.org</email>
 		<name>Gentoo Games Project</name>


### PR DESCRIPTION
It's now maintained by Gentoo Games Project, so there is no work left for me there.