### PR TITLE
dev-util/pkgcheck: emacs support for live version

### DIFF
--- a/dev-util/pkgcheck/files/50pkgcheck-gentoo.el
+++ b/dev-util/pkgcheck/files/50pkgcheck-gentoo.el
@@ -1,0 +1,4 @@
+(add-to-list 'load-path "@SITELISP@")
+(autoload 'flycheck-pkgcheck-setup "flycheck-pkgcheck"
+  "Flycheck pkgcheck setup." t)
+(add-hook 'ebuild-mode-hook 'flycheck-pkgcheck-setup)

--- a/dev-util/pkgcheck/pkgcheck-9999.ebuild
+++ b/dev-util/pkgcheck/pkgcheck-9999.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 PYTHON_COMPAT=( python3_{8..10} )
 DISTUTILS_IN_SOURCE_BUILD=1
-inherit distutils-r1 optfeature
+inherit elisp-common distutils-r1 optfeature
 
 if [[ ${PV} == *9999 ]] ; then
 	EGIT_REPO_URI="https://github.com/pkgcore/pkgcheck.git"
@@ -20,6 +20,7 @@ HOMEPAGE="https://github.com/pkgcore/pkgcheck"
 
 LICENSE="BSD MIT"
 SLOT="0"
+IUSE="emacs"
 
 if [[ ${PV} == *9999 ]]; then
 	RDEPEND="
@@ -38,8 +39,14 @@ RDEPEND+="
 	dev-python/lxml[${PYTHON_USEDEP}]
 	dev-python/pathspec[${PYTHON_USEDEP}]
 	>=dev-python/tree-sitter-0.19.0[${PYTHON_USEDEP}]
+	emacs? (
+		>=app-editors/emacs-24.1:*
+		app-emacs/ebuild-mode
+		app-emacs/flycheck
+	)
 "
 BDEPEND="
+	${RDEPEND}
 	test? (
 		dev-python/pytest[${PYTHON_USEDEP}]
 		dev-python/requests[${PYTHON_USEDEP}]
@@ -47,9 +54,21 @@ BDEPEND="
 	)
 "
 
+SITEFILE="50${PN}-gentoo.el"
+
 distutils_enable_tests setup.py
 
 export USE_SYSTEM_TREE_SITTER_BASH=1
+
+src_compile() {
+	distutils-r1_src_compile
+
+	if use emacs ; then
+	   pushd "${S}"/contrib/emacs >/dev/null || die
+	   elisp-compile *.el
+	   popd >/dev/null || die
+	fi
+}
 
 src_test() {
 	local -x PYTHONDONTWRITEBYTECODE=
@@ -60,9 +79,20 @@ python_install_all() {
 	local DOCS=( NEWS.rst )
 	[[ ${PV} == *9999 ]] || doman man/*
 	distutils-r1_python_install_all
+
+	if use emacs ; then
+		elisp-install ${PN} "${S}"/contrib/emacs/*.el{,c}
+		elisp-site-file-install "${FILESDIR}/${SITEFILE}"
+	fi
 }
 
 pkg_postinst() {
+	use emacs && elisp-site-regen
+
 	optfeature "Network check support" dev-python/requests
 	optfeature "Perl module version check support" dev-perl/Gentoo-PerlMod-Version
+}
+
+pkg_postrm() {
+	use emacs && elisp-site-regen
 }


### PR DESCRIPTION
Bug: https://github.com/pkgcore/pkgcheck/pull/420
Signed-off-by: Maciej Barć <xgqt@gentoo.org>