### PR TITLE
www-apps/nextcloud: Depend on php8.0

### DIFF
--- a/www-apps/nextcloud/nextcloud-24.0.3.ebuild
+++ b/www-apps/nextcloud/nextcloud-24.0.3.ebuild
@@ -15,7 +15,7 @@ IUSE="+curl +imagemagick mysql postgres +sqlite"
 REQUIRED_USE="|| ( mysql postgres sqlite )"
 
 DEPEND=""
-RDEPEND="dev-lang/php[curl?,filter,gd,hash(+),intl,json(+),mysql?,pdo,posix,postgres?,session,simplexml,sqlite?,truetype,xmlreader,xmlwriter,zip]
+RDEPEND="dev-lang/php:8.0[curl?,filter,gd,hash(+),intl,json(+),mysql?,pdo,posix,postgres?,session,simplexml,sqlite?,truetype,xmlreader,xmlwriter,zip]
 	imagemagick? ( dev-php/pecl-imagick )
 	virtual/httpd-php"
 


### PR DESCRIPTION
Nextcloud depends on php8.0, using the latest php8.1 renders the package
unusable. Thus it is necessary to depend on php8.0 specifically.

Closes: https://bugs.gentoo.org/840221
Signed-off-by: Federico Denkena <federico.denkena@posteo.de>