### PR TITLE
app-admin/pwgen: keyword 2.08-r1 for ~riscv

### DIFF
--- a/app-admin/pwgen/pwgen-2.08-r1.ebuild
+++ b/app-admin/pwgen/pwgen-2.08-r1.ebuild
@@ -9,7 +9,7 @@ SRC_URI="mirror://sourceforge/pwgen/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~mips ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~mips ~ppc ~ppc64 ~riscv ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
 IUSE="livecd"
 
 src_configure() {


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/863065

Signed-off-by: Yongxiang Liang <tanekliang@gmail.com>
