### PR TITLE
dev-libs/trio: Add pkgconfig file + build fixes

### DIFF
--- a/dev-libs/trio/files/trio-1.16-destdir.patch
+++ b/dev-libs/trio/files/trio-1.16-destdir.patch
@@ -1,0 +1,22 @@
+From: orbea <orbea@riseup.net>
+Date: Tue, 2 Aug 2022 11:50:22 -0700
+Subject: [PATCH] Support DESTDIR
+
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -44,11 +44,11 @@ test:	regression
+ 	./regression
+ 
+ install:	$(TARGETLIB) $(TARGETSHLIB)
+-	$(MKDIR) $(libdir)
+-	$(MKDIR) $(includedir)
+-	$(INSTALL_DATA) $(TARGETLIB) $(TARGETSHLIB) $(libdir)/
++	$(MKDIR) $(DESTDIR)$(libdir)
++	$(MKDIR) $(DESTDIR)$(includedir)
++	$(INSTALL_DATA) $(TARGETLIB) $(TARGETSHLIB) $(DESTDIR)$(libdir)/
+ 	for i in $(TARGETINCS);do \
+-	(set -x;$(INSTALL_DATA) $(srcdir)/$$i $(includedir)); \
++	(set -x;$(INSTALL_DATA) $(srcdir)/$$i $(DESTDIR)$(includedir)); \
+ 	done
+ 
+ regression: regression.o $(TARGETLIB)

--- a/dev-libs/trio/files/trio-1.16-ldflags.patch
+++ b/dev-libs/trio/files/trio-1.16-ldflags.patch
@@ -1,0 +1,36 @@
+From: orbea <orbea@riseup.net>
+Date: Tue, 2 Aug 2022 12:42:35 -0700
+Subject: [PATCH] Fix LDFLAGS
+
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -7,7 +7,7 @@ TARGETSHLIB	= $(TARGETLIB:.a=.so)
+ TARGETSHLIB_M	= $(TARGETSHLIB).2
+ TARGETSHLIB_V	= $(TARGETSHLIB_M).0.0
+ TARGETINCS	= trio.h triop.h triodef.h trionan.h triostr.h
+-LDFLAGS	= -L. -ltrio -lm
++LIBS	= -L. -ltrio -lm
+ AR	= ar
+ RANLIB	= @RANLIB@
+ ERASE	= rm -f
+@@ -58,16 +58,16 @@ install: all
+ 	done
+ 
+ regression: regression.o $(TARGETLIB)
+-	$(CC) $(CFLAGS) regression.o $(LDFLAGS) -o $@
++	$(CC) $(CFLAGS) regression.o $(LIBS) $(LDFLAGS) -o $@
+ 
+ example: example.o $(TARGETLIB)
+-	$(CC) $(CFLAGS) example.o $(LDFLAGS) -o $@
++	$(CC) $(CFLAGS) example.o $(LIBS) $(LDFLAGS) -o $@
+ 
+ compare: compare.o $(TARGETLIB)
+-	$(CC) $(CFLAGS) compare.o $(LDFLAGS) -o $@
++	$(CC) $(CFLAGS) compare.o $(LIBS) $(LDFLAGS) -o $@
+ 
+ userdef: userdef.o $(TARGETLIB)
+-	$(CC) $(CFLAGS) userdef.o $(LDFLAGS) -o $@
++	$(CC) $(CFLAGS) userdef.o $(LIBS) $(LDFLAGS) -o $@
+ 
+ $(TARGETLIB): $(OBJS)
+ 	$(AR) ruv $(TARGETLIB) $(OBJS)

--- a/dev-libs/trio/files/trio-1.16-pkgconfig.patch
+++ b/dev-libs/trio/files/trio-1.16-pkgconfig.patch
@@ -1,0 +1,51 @@
+From: orbea <orbea@riseup.net>
+Date: Tue, 2 Aug 2022 11:41:19 -0700
+Subject: [PATCH] Add a pkgconfig file
+
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -44,9 +44,10 @@ test:	regression
+ 	./regression
+ 
+ install:	$(TARGETLIB) $(TARGETSHLIB)
+-	$(MKDIR) $(DESTDIR)$(libdir)
++	$(MKDIR) $(DESTDIR)$(libdir)/pkgconfig
+ 	$(MKDIR) $(DESTDIR)$(includedir)
+ 	$(INSTALL_DATA) $(TARGETLIB) $(TARGETSHLIB) $(DESTDIR)$(libdir)/
++	$(INSTALL_DATA) libtrio.pc $(DESTDIR)$(libdir)/pkgconfig/
+ 	for i in $(TARGETINCS);do \
+ 	(set -x;$(INSTALL_DATA) $(srcdir)/$$i $(DESTDIR)$(includedir)); \
+ 	done
+--- a/configure.in
++++ b/configure.in
+@@ -2,7 +2,7 @@ dnl
+ dnl Configuration for trio
+ dnl
+ 
+-AC_INIT
++AC_INIT([trio], [1.16])
+ AC_CONFIG_SRCDIR([triodef.h])
+ AC_PREREQ(2.55) dnl autoconf 2.55 was released in 2002
+ 
+@@ -73,5 +73,5 @@ if test $ac_cv_sigaction != false; then
+   CFLAGS="${CFLAGS} -DHAVE_STRUCT_SIGACTION"
+ fi
+ 
+-AC_CONFIG_FILES([Makefile])
++AC_CONFIG_FILES([Makefile libtrio.pc])
+ AC_OUTPUT
+new file mode 100644
+--- /dev/null
++++ b/libtrio.pc.in
+@@ -0,0 +1,11 @@
++prefix=@prefix@
++exec_prefix=${prefix}
++includedir=@includedir@
++libdir=@libdir@
++
++Name: libtrio
++Description: Portable printf and string functions
++URL: https://daniel.haxx.se/projects/trio/
++Version: @PACKAGE_VERSION@
++CFlags: -I${includedir}
++Libs: -L${libdir} -ltrio

--- a/dev-libs/trio/files/trio-1.16-symlinks.patch
+++ b/dev-libs/trio/files/trio-1.16-symlinks.patch
@@ -1,0 +1,64 @@
+From: orbea <orbea@riseup.net>
+Date: Tue, 2 Aug 2022 12:09:16 -0700
+Subject: [PATCH] Create shared library symlinks
+
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -3,12 +3,15 @@ CC	= @CC@
+ CFLAGS	= @CFLAGS@ -I. -DDEBUG -fPIC -fvisibility=hidden
+ OBJS	= triostr.o trio.o trionan.o
+ TARGETLIB	= libtrio.a
+-TARGETSHLIB	= $(TARGETLIB:.a=.so.2.0.0)
++TARGETSHLIB	= $(TARGETLIB:.a=.so)
++TARGETSHLIB_M	= $(TARGETSHLIB).2
++TARGETSHLIB_V	= $(TARGETSHLIB_M).0.0
+ TARGETINCS	= trio.h triop.h triodef.h trionan.h triostr.h
+ LDFLAGS	= -L. -ltrio -lm
+ AR	= ar
+ RANLIB	= @RANLIB@
+ ERASE	= rm -f
++LN	= ln -s
+ MKDIR	= mkdir -p
+ GENDOC	= doxygen
+ srcdir	= @srcdir@
+@@ -25,7 +28,7 @@ exec_prefix	= @exec_prefix@
+ includedir	= @includedir@
+ libdir		= @libdir@
+ 
+-all: $(TARGETLIB) $(TARGETSHLIB) $(TARGET)
++all: $(TARGETSHLIB) $(TARGETSHLIB_M) $(TARGET)
+ 
+ .PHONY: all check test install doc clean
+ 
+@@ -43,10 +46,12 @@ check:	test
+ test:	regression
+ 	./regression
+ 
+-install:	$(TARGETLIB) $(TARGETSHLIB)
++install: all
+ 	$(MKDIR) $(DESTDIR)$(libdir)/pkgconfig
+ 	$(MKDIR) $(DESTDIR)$(includedir)
+-	$(INSTALL_DATA) $(TARGETLIB) $(TARGETSHLIB) $(DESTDIR)$(libdir)/
++	$(INSTALL_DATA) $(TARGETLIB) $(TARGETSHLIB_V) $(DESTDIR)$(libdir)/
++	$(LN) $(TARGETSHLIB_V) $(DESTDIR)$(libdir)/$(TARGETSHLIB)
++	$(LN) $(TARGETSHLIB_V) $(DESTDIR)$(libdir)/$(TARGETSHLIB_M)
+ 	$(INSTALL_DATA) libtrio.pc $(DESTDIR)$(libdir)/pkgconfig/
+ 	for i in $(TARGETINCS);do \
+ 	(set -x;$(INSTALL_DATA) $(srcdir)/$$i $(DESTDIR)$(includedir)); \
+@@ -68,11 +73,14 @@ $(TARGETLIB): $(OBJS)
+ 	$(AR) ruv $(TARGETLIB) $(OBJS)
+ 	$(RANLIB) $(TARGETLIB)
+ 
+-$(TARGETSHLIB): $(TARGETLIB)
++$(TARGETSHLIB_V): $(TARGETLIB)
+ 	$(CC) -lm -shared -Wl,-soname,$(patsubst %.so.2.0.0,%.so.2,$@) -Wl,--whole-archive,$< -Wl,--no-whole-archive -o $@
+ 
++$(TARGETSHLIB) $(TARGETSHLIB_M): $(TARGETSHLIB_V)
++	$(LN) $< $@
++
+ doc::
+ 	(cd $(srcdir) && $(GENDOC) doc/trio.cfg)
+ 
+ clean:
+-	$(ERASE) *~ core core.* regression example $(TOBJS) $(OBJS) $(TARGET) $(TARGETLIB) $(TARGETSHLIB) example.o regression.o
++	$(ERASE) *~ core core.* regression example $(TOBJS) $(OBJS) $(TARGET) $(TARGETLIB) $(TARGETSHLIB) $(TARGETSHLIB_M) $(TARGETSHLIB_V) example.o regression.o

--- a/dev-libs/trio/trio-1.16-r1.ebuild
+++ b/dev-libs/trio/trio-1.16-r1.ebuild
@@ -1,0 +1,43 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools toolchain-funcs
+
+DESCRIPTION="Portable string functions, focus on the *printf() and *scanf() clones"
+HOMEPAGE="https://daniel.haxx.se/projects/trio/"
+SRC_URI="mirror://sourceforge/ctrio/${P}.tar.gz"
+
+LICENSE="trio"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-no-inline.patch
+	"${FILESDIR}"/${P}-destdir.patch
+	"${FILESDIR}"/${P}-pkgconfig.patch
+	"${FILESDIR}"/${P}-symlinks.patch
+	"${FILESDIR}"/${P}-ldflags.patch
+)
+HTML_DOCS=( html/. )
+
+src_prepare() {
+	default
+
+	# Don't install the static library
+	sed -e 's/$(INSTALL_DATA) $(TARGETLIB)/$(INSTALL_DATA)/' \
+		-e 's/configure.in/configure.ac/' \
+		-i Makefile.in || die
+
+	eautoreconf
+}
+
+src_compile() {
+	emake AR="$(tc-getAR)"
+}
+
+src_test() {
+	emake regression
+	LD_LIBRARY_PATH=".:${LD_LIBRARY_PATH}" ./regression || die
+}


### PR DESCRIPTION
This adds a pkgconfig file that can be useful for removing vendored instances of `dev-libs/trio` in other projects.

Additionally, there are several build fixes:

1. Support DESTDIR.
2. Fixes the project's LDFLAGS to not conflict with the user's LDFLAGS.
3. Installs the shared library symlinks.

The trio upstream hasn't been updated since 2014, but unfortunately I still need it for removing the vendored trio from the jgemu mednafen port. This is currently available for Gentoo in the following overlay until the jgemu project reaches stable.

https://0xacab.org/orbea/jgemu