### PR TITLE
app-editors/vim, app-editors/vim-core: fix cros compile error during  configure check for timer_create

### DIFF
--- a/app-editors/vim-core/files/vim-9.0-fix-create-timer-for-cros-compiling.patch
+++ b/app-editors/vim-core/files/vim-9.0-fix-create-timer-for-cros-compiling.patch
@@ -1,0 +1,28 @@
+From bba26c9ed9d4ddc82afd0343f145dc9e14b91498 Mon Sep 17 00:00:00 2001
+From: Varsha Teratipally <teratipally@google.com>
+Date: Tue, 2 Aug 2022 22:18:29 +0000
+Subject: [PATCH] Configure check for timer_create may give wrong error.
+Give a warning instead of an error
+
+Partial solution from github.com/vim/vim/commit/5f6cae8b8a49c435556e32f84d067cd0b4d28e4c
+
+---
+ src/configure.ac | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/configure.ac b/src/configure.ac
+index e8522ec05..41f41dee3 100644
+--- a/src/configure.ac
++++ b/src/configure.ac
+@@ -3850,7 +3850,7 @@ static void set_flag(union sigval sv) {}
+     ])],
+     vim_cv_timer_create=yes,
+     vim_cv_timer_create=no),
+-    AC_MSG_ERROR(cross-compiling: please set 'vim_cv_timer_create')
++    AC_MSG_WARN(cross-compiling: please set 'vim_cv_timer_create')
+     )]
+ )
+ 
+-- 
+
+

--- a/app-editors/vim-core/vim-core-9.0.0049-r3.ebuild
+++ b/app-editors/vim-core/vim-core-9.0.0049-r3.ebuild
@@ -43,6 +43,7 @@ src_prepare() {
 	if [[ ${PV} != 9999* ]] ; then
 		# Gentoo patches to fix runtime issues, cross-compile errors, etc
 		eapply "${WORKDIR}/vim-patches-vim-9.0.0049-patches"
+		eapply "{FILESDIR}/vim-9.0-fix-create-timer-for-cros-compiling.patch"
 	fi
 
 	# Fixup a script to use awk instead of nawk

--- a/app-editors/vim-core/vim-core-9.0.0099-r1.ebuild
+++ b/app-editors/vim-core/vim-core-9.0.0099-r1.ebuild
@@ -43,6 +43,7 @@ src_prepare() {
 	if [[ ${PV} != 9999* ]] ; then
 		# Gentoo patches to fix runtime issues, cross-compile errors, etc
 		eapply "${WORKDIR}/vim-patches-vim-9.0.0049-patches"
+		eapply "{FILESDIR}/vim-9.0-fix-create-timer-for-cros-compiling.patch"
 	fi
 
 	# Fixup a script to use awk instead of nawk

--- a/app-editors/vim/files/vim-9.0-fix-create-timer-for-cros-compiling.patch
+++ b/app-editors/vim/files/vim-9.0-fix-create-timer-for-cros-compiling.patch
@@ -1,0 +1,28 @@
+From bba26c9ed9d4ddc82afd0343f145dc9e14b91498 Mon Sep 17 00:00:00 2001
+From: Varsha Teratipally <teratipally@google.com>
+Date: Tue, 2 Aug 2022 22:18:29 +0000
+Subject: [PATCH] Configure check for timer_create may give wrong error.
+Give a warning instead of an error
+
+Partial solution from github.com/vim/vim/commit/5f6cae8b8a49c435556e32f84d067cd0b4d28e4c
+
+---
+ src/configure.ac | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/configure.ac b/src/configure.ac
+index e8522ec05..41f41dee3 100644
+--- a/src/configure.ac
++++ b/src/configure.ac
+@@ -3850,7 +3850,7 @@ static void set_flag(union sigval sv) {}
+     ])],
+     vim_cv_timer_create=yes,
+     vim_cv_timer_create=no),
+-    AC_MSG_ERROR(cross-compiling: please set 'vim_cv_timer_create')
++    AC_MSG_WARN(cross-compiling: please set 'vim_cv_timer_create')
+     )]
+ )
+ 
+-- 
+
+

--- a/app-editors/vim/vim-9.0.0049-r1.ebuild
+++ b/app-editors/vim/vim-9.0.0049-r1.ebuild
@@ -79,6 +79,7 @@ src_prepare() {
 	if [[ ${PV} != 9999* ]] ; then
 		# Gentoo patches to fix runtime issues, cross-compile errors, etc
 		eapply "${WORKDIR}/vim-patches-vim-9.0.0049-patches"
+		eapply "{FILESDIR}/vim-9.0-fix-create-timer-for-cros-compiling.patch"
 	fi
 
 	# Fixup a script to use awk instead of nawk

--- a/app-editors/vim/vim-9.0.0099-r1.ebuild
+++ b/app-editors/vim/vim-9.0.0099-r1.ebuild
@@ -79,6 +79,7 @@ src_prepare() {
 	if [[ ${PV} != 9999* ]] ; then
 		# Gentoo patches to fix runtime issues, cross-compile errors, etc
 		eapply "${WORKDIR}/vim-patches-vim-9.0.0049-patches"
+		eapply "{FILESDIR}/vim-9.0-fix-create-timer-for-cros-compiling.patch"
 	fi
 
 	# Fixup a script to use awk instead of nawk


### PR DESCRIPTION
app-editors/vim, app-editors/vim-core: fix cros compile error during  configure check for timer_create. So instead of reporting it as an error report it as the warning and ignore the check.

partial solution from https://github.com/vim/vim/commit/5f6cae8b8a49c435556e32f84d067cd0b4d28e4c

Signed-off-by: Varsha Teratipally [teratipally@google.com](mailto:teratipally@google.com)