### PR TITLE
Fix telegram and tg_owt build failed under gcc12

### DIFF
--- a/media-libs/tg_owt/tg_owt-0_pre20220507.ebuild
+++ b/media-libs/tg_owt/tg_owt-0_pre20220507.ebuild
@@ -59,6 +59,7 @@ BDEPEND="virtual/pkgconfig"
 PATCHES=(
 	"${FILESDIR}/tg_owt-0_pre20220507-allow-disabling-X11.patch"
 	"${FILESDIR}/tg_owt-0_pre20220507-unbundle-crc32c.patch"
+	"${FILESDIR}/tg_owt-0_pre20220209-gcc-12-cstdint.patch"
 )
 
 src_unpack() {

--- a/net-im/telegram-desktop/files/tdesktop-4.0.2-fix-gcc12-cstdint.patch
+++ b/net-im/telegram-desktop/files/tdesktop-4.0.2-fix-gcc12-cstdint.patch
@@ -1,0 +1,10 @@
+--- a/Telegram/ThirdParty/tgcalls/tgcalls/utils/gzip.h
++++ b/Telegram/ThirdParty/tgcalls/tgcalls/utils/gzip.h
+@@ -2,6 +2,7 @@
+ #define TGCALLS_UTILS_GZIP_H
+ 
+ #include <absl/types/optional.h>
++#include <cstdint>
+ #include <vector>
+ 
+ namespace tgcalls {

--- a/net-im/telegram-desktop/telegram-desktop-4.0.2.ebuild
+++ b/net-im/telegram-desktop/telegram-desktop-4.0.2.ebuild
@@ -75,6 +75,7 @@ PATCHES=(
 	"${FILESDIR}/tdesktop-3.6.0-jemalloc-only-telegram.patch"
 	"${FILESDIR}/tdesktop-3.3.0-fix-enchant.patch"
 	"${FILESDIR}/tdesktop-3.5.2-musl.patch"
+	"${FILESDIR}/tdesktop-4.0.2-fix-gcc12-cstdint.patch"
 )
 
 # Current desktop-file-utils-0.26 does not understand Version=1.5


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/863245, https://bugs.gentoo.org/863248