### PR TITLE
app-benchmarks/stress-ng: Keyword 0.14.03 riscv, #863359

### DIFF
--- a/app-benchmarks/stress-ng/stress-ng-0.14.03.ebuild
+++ b/app-benchmarks/stress-ng/stress-ng-0.14.03.ebuild
@@ -11,7 +11,7 @@ SRC_URI="https://github.com/ColinIanKing/${PN}/archive/refs/tags/V${PV}.tar.gz -
 
 LICENSE="GPL-2+"
 SLOT="0"
-KEYWORDS="~amd64 ~arm ~arm64 ~loong ~ppc64 ~sparc ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~loong ~ppc64 ~riscv ~sparc ~x86"
 IUSE="apparmor sctp"
 
 DEPEND="


### PR DESCRIPTION
Signed-off-by: Yongxiang Liang <tanekliang@gmail.com>