### PR TITLE
media-libs/tremor: Update pkgconfig to reduce overlinking

### DIFF
--- a/media-libs/tremor/files/tremor-0_pre20130223-pkgconfig.patch
+++ b/media-libs/tremor/files/tremor-0_pre20130223-pkgconfig.patch
@@ -1,0 +1,30 @@
+Upstream-Commit: https://gitlab.xiph.org/xiph/tremor/-/commit/a733870e048fc139f696f1c57b50e0145d1ab6c2
+
+From a733870e048fc139f696f1c57b50e0145d1ab6c2 Mon Sep 17 00:00:00 2001
+From: Tim Terriberry <tterribe@xiph.org>
+Date: Fri, 5 Apr 2013 13:20:31 +0000
+Subject: [PATCH] Update pkgconfig files to reduce overlinking.
+
+Patch from Brad Smith.
+Reviewed by Ron Lee.
+Fixes #1943.
+
+git-svn-id: https://svn.xiph.org/trunk/Tremor@18906 0101bb08-14d6-0310-b084-bc0e0c8e3800
+---
+ vorbisidec.pc.in | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/vorbisidec.pc.in b/vorbisidec.pc.in
+index 9c09524..56fa656 100644
+--- a/vorbisidec.pc.in
++++ b/vorbisidec.pc.in
+@@ -8,7 +8,7 @@ includedir=@includedir@
+ Name: vorbisidec
+ Description: vorbisidec is the integer Ogg Vorbis library
+ Version: @VERSION@
+-Requires: ogg
++Requires.private: ogg
+ Conflicts:
+-Libs: -L${libdir} -lvorbisidec -lm
++Libs: -L${libdir} -lvorbisidec
+ Cflags: -I${includedir}

--- a/media-libs/tremor/tremor-0_pre20130223-r3.ebuild
+++ b/media-libs/tremor/tremor-0_pre20130223-r3.ebuild
@@ -1,0 +1,41 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools multilib-minimal
+
+DESCRIPTION="A fixed-point version of the Ogg Vorbis decoder (also known as libvorbisidec)"
+HOMEPAGE="https://wiki.xiph.org/Tremor"
+SRC_URI="https://dev.gentoo.org/~ssuominen/${P}.tar.xz"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="amd64 arm arm64 ~hppa ~ia64 ppc ppc64 ~riscv sparc x86"
+IUSE="low-accuracy"
+
+RDEPEND=">=media-libs/libogg-1.3.0:=[${MULTILIB_USEDEP}]"
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-out-of-bounds-write.patch
+	"${FILESDIR}"/${P}-autoconf.patch
+	"${FILESDIR}"/${P}-pkgconfig.patch
+)
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+multilib_src_configure() {
+	ECONF_SOURCE="${S}" econf $(use_enable low-accuracy)
+}
+
+multilib_src_install_all() {
+	HTML_DOCS=( doc/. )
+	einstalldocs
+
+	find "${ED}" -name '*.la' -type f -delete || die
+}


### PR DESCRIPTION
Backports an upstream commit to improve the output of `pkgconf --libs vorbisidec`.

Upstream-Commit: https://gitlab.xiph.org/xiph/tremor/-/commit/a733870e048fc139f696f1c57b50e0145d1ab6c2
Upstream-Issue: https://gitlab.xiph.org/xiph/tremor/-/issues/1943
