### PR TITLE
sys-libs/glibc: make crypt.h install depend on crypt use flag

### DIFF
--- a/sys-libs/glibc/glibc-2.33-r13.ebuild
+++ b/sys-libs/glibc/glibc-2.33-r13.ebuild
@@ -1131,6 +1131,7 @@ glibc_headers_configure() {
 		--host=${CTARGET_OPT:-${CTARGET}}
 		--with-headers=$(build_eprefix)$(alt_build_headers)
 		--prefix="$(host_eprefix)/usr"
+		$(use_enable crypt)
 		${EXTRA_ECONF}
 	)
 

--- a/sys-libs/glibc/glibc-2.34-r13.ebuild
+++ b/sys-libs/glibc/glibc-2.34-r13.ebuild
@@ -1149,6 +1149,7 @@ glibc_headers_configure() {
 		--host=${CTARGET_OPT:-${CTARGET}}
 		--with-headers=$(build_eprefix)$(alt_build_headers)
 		--prefix="$(host_eprefix)/usr"
+		$(use_enable crypt)
 		${EXTRA_ECONF}
 	)
 

--- a/sys-libs/glibc/glibc-2.35-r8.ebuild
+++ b/sys-libs/glibc/glibc-2.35-r8.ebuild
@@ -1136,6 +1136,7 @@ glibc_headers_configure() {
 		--host=${CTARGET_OPT:-${CTARGET}}
 		--with-headers=$(build_eprefix)$(alt_build_headers)
 		--prefix="$(host_eprefix)/usr"
+		$(use_enable crypt)
 		${EXTRA_ECONF}
 	)
 

--- a/sys-libs/glibc/glibc-2.36.ebuild
+++ b/sys-libs/glibc/glibc-2.36.ebuild
@@ -1134,6 +1134,7 @@ glibc_headers_configure() {
 		--host=${CTARGET_OPT:-${CTARGET}}
 		--with-headers=$(build_eprefix)$(alt_build_headers)
 		--prefix="$(host_eprefix)/usr"
+		$(use_enable crypt)
 		${EXTRA_ECONF}
 	)
 

--- a/sys-libs/glibc/glibc-9999.ebuild
+++ b/sys-libs/glibc/glibc-9999.ebuild
@@ -1134,6 +1134,7 @@ glibc_headers_configure() {
 		--host=${CTARGET_OPT:-${CTARGET}}
 		--with-headers=$(build_eprefix)$(alt_build_headers)
 		--prefix="$(host_eprefix)/usr"
+		$(use_enable crypt)
 		${EXTRA_ECONF}
 	)
 


### PR DESCRIPTION
The crypt use flag is supposed to control whether libcrypt
and its associated crypt.h are installed, but it's ignored
in header-only builds and crypt.h is always installed.

This generates a conflict for eg with sys-libs/libcxrypt
installed as a system lib which provides /usr/include/crypt.h
even if glibc is built with -crypt.

The solution is for glibc to properly respect the crypt
use flag when installing the headers.

Fixes: https://bugs.gentoo.org/863812
Signed-off-by: Adrian Ratiu <adrian.ratiu@collabora.com>