### PR TITLE
media-sound/pasystray: Fix pulseaudio requirements

### DIFF
--- a/media-sound/pasystray/pasystray-0.8.0-r1.ebuild
+++ b/media-sound/pasystray/pasystray-0.8.0-r1.ebuild
@@ -16,7 +16,9 @@ IUSE="libnotify zeroconf"
 
 RDEPEND="
 	dev-libs/glib
-	|| ( media-sound/pulseaudio-daemon[glib,zeroconf?] <media-sound/pulseaudio-15.99.1[glib,zeroconf?] )
+	|| ( media-sound/pulseaudio-daemon[glib,zeroconf?]
+		<media-sound/pulseaudio-15.99.1[glib,zeroconf?]
+		 media-libs/libpulse[glib] )
 	x11-libs/gtk+:3
 	x11-libs/libX11
 	zeroconf? ( net-dns/avahi )


### PR DESCRIPTION
In pipewire setup pasystray works like a charm and does not need
pulseaudio-daemon, libpulse is enough.

Closes: https://bugs.gentoo.org/863815
Signed-off-by: Martin Kletzander <nert.pinx@gmail.com>