### PR TITLE
profiles/arch/sparc/32ul: mask app-antivirus/clamav

### DIFF
--- a/profiles/arch/sparc/32ul/package.mask
+++ b/profiles/arch/sparc/32ul/package.mask
@@ -1,0 +1,7 @@
+# Copyright 2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+# matoro <matoro_gentoo@matoro.tk> (2022-08-05)
+# Test failures on 32-bit, passes on 64-bit.  Bug #638888
+app-antivirus/clamav
+dev-perl/File-Scan-ClamAV

--- a/profiles/arch/sparc/32ul/package.use.mask
+++ b/profiles/arch/sparc/32ul/package.use.mask
@@ -1,0 +1,9 @@
+# Copyright 2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+# matoro <matoro_gentoo@matoro.tk> (2022-08-05)
+# Depends on app-antivirus/clamav.  Bug #638888
+mail-client/claws-mail clamav
+mail-filter/amavisd-new clamav
+net-ftp/proftpd clamav
+net-mail/cyrus-imapd clamav


### PR DESCRIPTION
Test failures on 32-bit, passes on 64-bit.

Closes: https://bugs.gentoo.org/638888