### PR TITLE
dev-java/jctools-core: exclude two more test classes

### DIFF
--- a/dev-java/jctools-core/jctools-core-3.3.0.ebuild
+++ b/dev-java/jctools-core/jctools-core-3.3.0.ebuild
@@ -46,6 +46,9 @@ src_test() {
 	# "org.jctools.queues.QueueSanityTest"
 	# "org.jctools.queues.ScQueueRemoveTest"
 	# "org.jctools.util.TestUtil"
+	# Test timeout on arm64, https://bugs.gentoo.org/863977
+	# "org.jctools.queues.atomic.AtomicMpqSanityTestMpscLinked"
+	# "org.jctools.queues.MpqSanityTestMpscLinked"
 	pushd src/test/java || die
 		local JAVA_TEST_RUN_ONLY=$(find * \
 			\( -name "*Test*.java" \
@@ -55,6 +58,8 @@ src_test() {
 			! -name "QueueSanityTest.java" \
 			! -name "ScQueueRemoveTest.java" \
 			! -name "TestUtil.java" \
+			! -name "AtomicMpqSanityTestMpscLinked.java" \
+			! -name "MpqSanityTestMpscLinked.java" \
 			)
 	popd
 	JAVA_TEST_RUN_ONLY="${JAVA_TEST_RUN_ONLY//.java}"


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/863977

Excluding two test classes producing TestTimedOutException on arm64:
"org.jctools.queues.atomic.AtomicMpqSanityTestMpscLinked"
"org.jctools.queues.MpqSanityTestMpscLinked"

org.junit.runners.model.TestTimedOutException: test timed out after 30000 milliseconds

Signed-off-by: Volkmar W. Pogatzki <gentoo@pogatzki.net>