### PR TITLE
dev-vcs/git: allow disabling "safe.directory"

### DIFF
--- a/dev-vcs/git/files/git-2.37.1-unsafe-directory.patch
+++ b/dev-vcs/git/files/git-2.37.1-unsafe-directory.patch
@@ -1,0 +1,14 @@
+Neuter the "safe directory" feature, except for tests.
+--- a/setup.c
++++ b/setup.c
+@@ -1157,7 +1157,9 @@ static int ensure_valid_ownership(const char *gitfile,
+ 	 */
+ 	read_very_early_config(safe_directory_cb, &data);
+ 
+-	return data.is_safe;
++	if (git_env_bool("GIT_TEST_ASSUME_DIFFERENT_OWNER", 0))
++		return data.is_safe;
++	return 1;
+ }
+ 
+ enum discovery_result {

--- a/dev-vcs/git/git-2.37.1.ebuild
+++ b/dev-vcs/git/git-2.37.1.ebuild
@@ -51,7 +51,7 @@ fi
 
 LICENSE="GPL-2"
 SLOT="0"
-IUSE="+blksha1 +curl cgi doc gnome-keyring +gpg highlight +iconv mediawiki mediawiki-experimental +nls +pcre perforce +perl +ppcsha1 selinux subversion tk +threads +webdav xinetd cvs test"
+IUSE="+blksha1 +curl cgi doc gnome-keyring +gpg highlight +iconv mediawiki mediawiki-experimental +nls +pcre perforce +perl +ppcsha1 +safe-directory selinux subversion tk +threads +webdav xinetd cvs test"
 
 # Common to both DEPEND and RDEPEND
 DEPEND="
@@ -251,6 +251,13 @@ src_prepare() {
 			"${FILESDIR}"/git-2.7.0-mediawiki-namespaces.patch
 			"${FILESDIR}"/git-2.7.0-mediawiki-subpages.patch
 			"${FILESDIR}"/git-2.7.0-mediawiki-500pages.patch
+		)
+	fi
+	if ! use safe-directory ; then
+		# This patch neuters the "safe directory" detection.
+		# bugs #838271, #838223
+		PATCHES+=(
+			"${FILESDIR}"/git-2.37.1-unsafe-directory.patch
 		)
 	fi
 

--- a/dev-vcs/git/metadata.xml
+++ b/dev-vcs/git/metadata.xml
@@ -29,6 +29,7 @@
     <flag name="mediawiki-experimental">Add experimental patches for improved MediaWiki support</flag>
     <flag name="perforce">Add support for Perforce version control system (requires manual installation of Perforce client)</flag>
     <flag name="ppcsha1">Make use of a bundled routine that is optimized for the PPC arch</flag>
+    <flag name="safe-directory">Respect the safe.directory setting</flag>
     <flag name="subversion">Include git-svn for <pkg>dev-vcs/subversion</pkg> support</flag>
     <flag name="tk">Include the 'gitk' and 'git gui' tools</flag>
     <flag name="webdav">Adds support for push'ing to HTTP/HTTPS repositories via DAV</flag>


### PR DESCRIPTION
Add IUSE="+safe-directory" that when not enabled, makes the
safe.directory configuration setting not take effect. The patch is meant
to be the smallest change (in terms of lines of code) that would let the
feature work for tests still.

Signed-off-by: Thomas Bracht Laumann Jespersen <t@laumann.xyz>