### PR TITLE
sys-libs/compiler-rt: Override start symbol when adding -nostartfiles

### DIFF
--- a/sys-libs/compiler-rt/compiler-rt-14.0.6-r1.ebuild
+++ b/sys-libs/compiler-rt/compiler-rt-14.0.6-r1.ebuild
@@ -88,8 +88,9 @@ src_configure() {
 			local -x LDFLAGS="${LDFLAGS} ${nolib_flags[*]}"
 			ewarn "${CC} seems to lack runtime, trying with ${nolib_flags[*]}"
 		elif test_compiler "${nolib_flags[@]}" -nostartfiles; then
-			# Avoiding -nostartfiles earlier on for bug #862540
-			nolib_flags+=( -nostartfiles )
+			# Avoiding -nostartfiles earlier on for bug #862540,
+			# and set available entry symbol for bug #862798.
+			nolib_flags+=( -nostartfiles -emain )
 			local -x LDFLAGS="${LDFLAGS} ${nolib_flags[*]}"
 			ewarn "${CC} seems to lack runtime, trying with ${nolib_flags[*]}"
 		fi


### PR DESCRIPTION
* Add -emain together with -nostartfiles to LDFLAGS in sys-libs/compiler-rt-14.0.6-r1.

* flag-o-matic.eclass: test-flag-PROG, strip unused args that generate warnings
I think that the exemption wrt. -Qunused-arguments is no longer necessary, so I dropped it.
Instead, we could actually add -Qunused-arguments to the flags to get rid of the warnings,
but that would be much more complicated, so let's try the simpler solution.
If further discussion is needed I can move the commit to a separate pull request.