### PR TITLE
fix dev-lang/zig-9999 build

### DIFF
--- a/dev-lang/zig/zig-9999.ebuild
+++ b/dev-lang/zig/zig-9999.ebuild
@@ -52,6 +52,7 @@ src_configure() {
 		-DZIG_USE_CCACHE=OFF
 		-DZIG_PREFER_CLANG_CPP_DYLIB=ON
 		-DZIG_SINGLE_THREADED="$(usex threads OFF ON)"
+		-DZIG_SHARED_LLVM=ON
 	)
 
 	cmake_src_configure
@@ -62,7 +63,7 @@ src_compile() {
 
 	if use stage2 ; then
 		cd "${BUILD_DIR}" || die
-		./zig build -p stage2 -Dstatic-llvm=false -Denable-llvm=true -Dsingle-threaded="$(usex threads false true)" || die
+		./zig build -p stage2 -Dstatic-llvm=false -Denable-llvm=true -Dconfig_h=./config.h -Dsingle-threaded="$(usex threads false true)" || die
 	fi
 }
 


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/864247
Signed-off-by: Rahim Usubov <the.guard@mail.ru>

This is according to https://github.com/ziglang/zig/wiki/Troubleshooting-Build-Issues#arch-linux-gentoo-fedora-32