### PR TITLE
net-misc/gns3-server: fix openrc to be POSIX complaint

### DIFF
--- a/net-misc/gns3-server/files/gns3-server-2.2.33.1-openrc-posix-complaint.patch
+++ b/net-misc/gns3-server/files/gns3-server-2.2.33.1-openrc-posix-complaint.patch
@@ -1,0 +1,21 @@
+commit 3b108563a0784df332791d44cf70bbba0fc81822
+Author: Michael Mair-Keimberger <mmk@levelnine.at>
+Date:   Mon Aug 8 19:23:16 2022 +0200
+
+    gns3.service.openrc: make openrc script posix compliant
+
+diff --git a/init/gns3.service.openrc b/init/gns3.service.openrc
+index 8b0864cd..5a574fca 100755
+--- a/init/gns3.service.openrc
++++ b/init/gns3.service.openrc
+@@ -23,8 +23,8 @@ depend() {
+ 
+ checkconfig() {
+   if yesno "${GNS3_SERVER_LOG_ENABLED}" ; then
+-    command_args+=" --log ${GNS3_SERVER_LOG}";
+-    if [ "${command_user}" ] ; then 
++    command_args="${command_args} --log ${GNS3_SERVER_LOG}";
++    if [ "${command_user}" ] ; then
+       checkpath --directory --mode 0700 --owner "${command_user}" "${GNS3_SERVER_LOG_PATH}";
+     else
+       unset command_user

--- a/net-misc/gns3-server/gns3-server-2.2.33.1-r2.ebuild
+++ b/net-misc/gns3-server/gns3-server-2.2.33.1-r2.ebuild
@@ -39,6 +39,10 @@ BDEPEND="
 	)
 "
 
+PATCHES=(
+	"${FILESDIR}/${P}-openrc-posix-complaint.patch"
+	)
+
 distutils_enable_tests pytest
 
 src_prepare() {


### PR DESCRIPTION
Hi,

This fixes the openrc script to be POSIX complaint.
Upstream PR got already merged: https://github.com/GNS3/gns3-server/pull/2094

Closes: https://bugs.gentoo.org/863776
Signed-off-by: Michael Mair-Keimberger <mmk@levelnine.at>
Portage 3.0.34 / pkgdev 0.2.1 / pkgcheck 0.10.12