### PR TITLE
app-backup/burp: fix strptime for musl

### DIFF
--- a/app-backup/burp/burp-2.4.0-r1.ebuild
+++ b/app-backup/burp/burp-2.4.0-r1.ebuild
@@ -1,0 +1,118 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools systemd
+
+DESCRIPTION="Network backup and restore client and server for Unix and Windows"
+HOMEPAGE="https://burp.grke.org/"
+SRC_URI="https://github.com/grke/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="AGPL-3"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~x86"
+IUSE="acl ipv6 test xattr"
+
+RESTRICT="!test? ( test )"
+
+COMMON_DEPEND="acct-group/burp
+	acct-user/burp
+	dev-libs/uthash
+	dev-libs/openssl:0=
+	net-libs/librsync:=
+	sys-libs/ncurses:0=
+	sys-libs/libcap
+	sys-libs/zlib
+	virtual/libcrypt:=
+	acl? ( sys-apps/acl )
+	xattr? ( sys-apps/attr )"
+DEPEND="${COMMON_DEPEND}
+	elibc_musl? ( sys-libs/queue-standalone )
+	test? ( dev-libs/check )"
+BDEPEND=">=sys-devel/autoconf-2.71
+	virtual/pkgconfig"
+RDEPEND="${COMMON_DEPEND}
+	virtual/logger"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-2.1.20-no_mkdir_run.patch
+	"${FILESDIR}"/${PN}-2.1.20-protocol1_by_default.patch
+	"${FILESDIR}"/${PN}-2.0.54-server_user.patch
+	"${FILESDIR}"/${PN}-2.4.0-fix-musl-strptime.patch
+)
+
+src_prepare() {
+	default
+
+	eautoreconf
+}
+
+src_configure() {
+	local myeconfargs=(
+		--localstatedir=/var
+		--sysconfdir=/etc/burp
+		--enable-largefile
+		--runstatedir=/run
+		$(use_enable acl)
+		$(use_enable ipv6)
+		$(use_enable xattr)
+	)
+	econf "${myeconfargs[@]}"
+}
+
+src_test() {
+	# See https://github.com/grke/burp/issues/869
+	local -x CK_DEFAULT_TIMEOUT=10
+	default
+}
+
+src_install() {
+	default
+	keepdir /var/spool/burp
+	fowners -R root:${PN} /var/spool/burp
+	fperms 0770 /var/spool/burp
+
+	emake DESTDIR="${D}" install-configs
+	fowners -R root:${PN} /etc/burp
+	fperms 0750 /etc/burp
+	fperms 0640 /etc/burp/burp-server.conf
+	fperms 0750 /etc/burp/clientconfdir
+
+	newinitd "${FILESDIR}"/${PN}.initd ${PN}
+	systemd_dounit "${FILESDIR}"/${PN}.service
+}
+
+pkg_postinst() {
+	elog "Burp ebuilds now support the autoupgrade mechanism in both"
+	elog "client and server mode. In both cases it is disabled by"
+	elog "default. You almost certainly do NOT want to enable it in"
+	elog "client mode because upgrades obtained this way will not be"
+	elog "managed by Portage."
+
+	if [[ ! -e ${EROOT}/etc/burp/CA/index.txt ]]; then
+		elog ""
+		elog "At first run burp server will generate DH parameters and SSL"
+		elog "certificates.  You should adjust configuration before."
+		elog "Server configuration is located at"
+		elog ""
+		elog "  ${EROOT}/etc/burp/burp-server.conf"
+		elog ""
+	fi
+
+	# According to PMS this can be a space-separated list of version
+	# numbers, even though in practice it is typically just one.
+	local oldver
+	for oldver in ${REPLACING_VERSIONS}; do
+		if [[ $(ver_cut 1 ${oldver}) -lt 2 ]]; then
+			ewarn "Starting with version 2.0.54 we no longer patch bedup to use"
+			ewarn "the server config file by default. If you use bedup, please"
+			ewarn "update your scripts to invoke it as"
+			ewarn ""
+			ewarn "  bedup -c ${EROOT}/etc/burp/burp-server.conf"
+			ewarn ""
+			ewarn "Otherwise deduplication will not work!"
+			break
+		fi
+	done
+}

--- a/app-backup/burp/burp-2.5.4-r1.ebuild
+++ b/app-backup/burp/burp-2.5.4-r1.ebuild
@@ -1,0 +1,118 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools systemd
+
+DESCRIPTION="Network backup and restore client and server for Unix and Windows"
+HOMEPAGE="https://burp.grke.org/"
+SRC_URI="https://github.com/grke/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="AGPL-3"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~x86"
+IUSE="acl ipv6 test xattr"
+
+RESTRICT="!test? ( test )"
+
+COMMON_DEPEND="acct-group/burp
+	acct-user/burp
+	dev-libs/uthash
+	dev-libs/openssl:0=
+	net-libs/librsync:=
+	sys-libs/ncurses:0=
+	sys-libs/libcap
+	sys-libs/zlib
+	virtual/libcrypt:=
+	acl? ( sys-apps/acl )
+	xattr? ( sys-apps/attr )"
+DEPEND="${COMMON_DEPEND}
+	elibc_musl? ( sys-libs/queue-standalone )
+	test? ( dev-libs/check )"
+BDEPEND=">=sys-devel/autoconf-2.71
+	virtual/pkgconfig"
+RDEPEND="${COMMON_DEPEND}
+	virtual/logger"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-2.1.20-no_mkdir_run.patch
+	"${FILESDIR}"/${PN}-2.1.20-protocol1_by_default.patch
+	"${FILESDIR}"/${PN}-2.0.54-server_user.patch
+	"${FILESDIR}"/${PN}-2.4.0-fix-musl-strptime.patch
+)
+
+src_prepare() {
+	default
+
+	eautoreconf
+}
+
+src_configure() {
+	local myeconfargs=(
+		--localstatedir=/var
+		--sysconfdir=/etc/burp
+		--enable-largefile
+		--runstatedir=/run
+		$(use_enable acl)
+		$(use_enable ipv6)
+		$(use_enable xattr)
+	)
+	econf "${myeconfargs[@]}"
+}
+
+src_test() {
+	# See https://github.com/grke/burp/issues/869
+	local -x CK_DEFAULT_TIMEOUT=10
+	default
+}
+
+src_install() {
+	default
+	keepdir /var/spool/burp
+	fowners -R root:${PN} /var/spool/burp
+	fperms 0770 /var/spool/burp
+
+	emake DESTDIR="${D}" install-configs
+	fowners -R root:${PN} /etc/burp
+	fperms 0750 /etc/burp
+	fperms 0640 /etc/burp/burp-server.conf
+	fperms 0750 /etc/burp/clientconfdir
+
+	newinitd "${FILESDIR}"/${PN}.initd ${PN}
+	systemd_dounit "${FILESDIR}"/${PN}.service
+}
+
+pkg_postinst() {
+	elog "Burp ebuilds now support the autoupgrade mechanism in both"
+	elog "client and server mode. In both cases it is disabled by"
+	elog "default. You almost certainly do NOT want to enable it in"
+	elog "client mode because upgrades obtained this way will not be"
+	elog "managed by Portage."
+
+	if [[ ! -e ${EROOT}/etc/burp/CA/index.txt ]]; then
+		elog ""
+		elog "At first run burp server will generate DH parameters and SSL"
+		elog "certificates.  You should adjust configuration before."
+		elog "Server configuration is located at"
+		elog ""
+		elog "  ${EROOT}/etc/burp/burp-server.conf"
+		elog ""
+	fi
+
+	# According to PMS this can be a space-separated list of version
+	# numbers, even though in practice it is typically just one.
+	local oldver
+	for oldver in ${REPLACING_VERSIONS}; do
+		if [[ $(ver_cut 1 ${oldver}) -lt 2 ]]; then
+			ewarn "Starting with version 2.0.54 we no longer patch bedup to use"
+			ewarn "the server config file by default. If you use bedup, please"
+			ewarn "update your scripts to invoke it as"
+			ewarn ""
+			ewarn "  bedup -c ${EROOT}/etc/burp/burp-server.conf"
+			ewarn ""
+			ewarn "Otherwise deduplication will not work!"
+			break
+		fi
+	done
+}

--- a/app-backup/burp/files/burp-2.4.0-fix-musl-strptime.patch
+++ b/app-backup/burp/files/burp-2.4.0-fix-musl-strptime.patch
@@ -1,0 +1,82 @@
+From 76b7f1ba9f4445108059b13f3d79a7fde8a292a3 Mon Sep 17 00:00:00 2001
+From: Graham Keeling <grke@grke.net>
+Date: Mon, 8 Aug 2022 07:53:38 +1000
+Subject: [PATCH] 908: Only glibc supports %z in strptime()
+
+Change-Id: I220e4529073c92df856b892559725b323dc84334
+---
+ src/times.h                            |  8 ++++----
+ utest/client/monitor/test_json_input.c | 15 +++++++++++----
+ utest/test_times.c                     |  7 ++++---
+ 3 files changed, 19 insertions(+), 11 deletions(-)
+
+diff --git a/src/times.h b/src/times.h
+index 325419c2b..b0fd3876f 100644
+--- a/src/times.h
++++ b/src/times.h
+@@ -3,11 +3,11 @@
+ 
+ #define DEFAULT_TIMESTAMP_FORMAT_OLD	"%Y-%m-%d %H:%M:%S"
+ 
+-// Windows does not seem to support %z.
+-#ifdef HAVE_WIN32
+-#define DEFAULT_TIMESTAMP_FORMAT DEFAULT_TIMESTAMP_FORMAT_OLD
+-#else
++#ifdef __GLIBC__
+ #define DEFAULT_TIMESTAMP_FORMAT	"%Y-%m-%d %H:%M:%S %z"
++#else
++// Only glibc supports %z in strptime.
++#define DEFAULT_TIMESTAMP_FORMAT DEFAULT_TIMESTAMP_FORMAT_OLD
+ #endif
+ 
+ extern const char *getdatestr(const time_t t);
+diff --git a/utest/client/monitor/test_json_input.c b/utest/client/monitor/test_json_input.c
+index 516fc779b..aea2a4154 100644
+--- a/utest/client/monitor/test_json_input.c
++++ b/utest/client/monitor/test_json_input.c
+@@ -162,13 +162,20 @@ static struct sd sd1[] = {
+ 
+ static void assert_bu_minimal(struct bu *bu, struct sd *s)
+ {
+-	const char *sd_timestamp;
++	const char *cp;
++	const char *cp_end;
+ 	fail_unless(bu!=NULL);
+ 	fail_unless(s->bno==bu->bno);
+ 	fail_unless(s->flags==bu->flags);
+-	fail_unless((sd_timestamp=strchr(s->timestamp, ' '))!=NULL);
+-	sd_timestamp++;
+-	ck_assert_str_eq(sd_timestamp, bu->timestamp);
++	fail_unless((cp=strchr(s->timestamp, ' '))!=NULL);
++	cp++;
++#ifdef __GLIBC__
++	cp_end=s->timestamp+strlen(s->timestamp)-1;
++#else
++	// Only glibc supports %z in strptime.
++	fail_unless((cp_end=strrchr(s->timestamp, ' '))!=NULL);
++#endif
++	fail_unless(strncmp(cp, bu->timestamp, cp_end-cp)==0);
+ }
+ 
+ static void do_test_json_clients_with_backup(const char *path,
+diff --git a/utest/test_times.c b/utest/test_times.c
+index 98be11fd1..5a68203a6 100644
+--- a/utest/test_times.c
++++ b/utest/test_times.c
+@@ -35,12 +35,13 @@ struct ds
+ 
+ static struct ds ds[] = {
+ 	{ 0, "", "never" },
+-#ifdef HAVE_WIN32
+-	{ 1000, "", "1970-01-01 00:16:40" },
+-#else
++#ifdef __GLIBC__
+ 	{ 1000, "", "1970-01-01 00:16:40 +0000" },
+ 	{ 1000, "UTC+10", "1969-12-31 14:16:40 -1000" },
+ 	{ 1000, "UTC+10", "1969-12-31 14:16:40 -1000" },
++#else
++	// Only glibc supports %z in strptime.
++	{ 1000, "", "1970-01-01 00:16:40" },
+ #endif
+ };
+ 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/862019

Signed-off-by: Anton Fischl <github@fischl-online.de>