### PR TITLE
dev-cpp/folly: Fix ELFCLASSFOLLY_ELF_NATIVE_CLASS was not declared in…

### DIFF
--- a/dev-cpp/folly/files/folly-2022.07.04.00-musl-fix.patch
+++ b/dev-cpp/folly/files/folly-2022.07.04.00-musl-fix.patch
@@ -1,0 +1,36 @@
+# Elf.cpp expects __ELF_NATIVE_CLASS to be defined at least for platforms
+# besides FreeBSD-based ones, and so it defines FOLLY_ELF_NATIVE_CLASS with it.
+# Without __ELF_NATIVE_CLASS (and apparently musl does not define it),
+# FOLLY_ELF_NATIVE_CLASS is also not defined so what was supposed to be
+# expanded to ELFCLASS32 or ELFCLASS64 ends up being
+# ELFCLASSFOLLY_ELF_NATIVE_CLASS.
+#
+# Please refer: https://github.com/facebook/folly/issues/1478
+#
+# Closes: https://bugs.gentoo.org/835744
+--- a/folly/experimental/symbolizer/Elf.cpp
++++ b/folly/experimental/symbolizer/Elf.cpp
+@@ -39,12 +39,10 @@
+
+ #if defined(__ELF_NATIVE_CLASS)
+ #define FOLLY_ELF_NATIVE_CLASS __ELF_NATIVE_CLASS
+-#elif defined(__FreeBSD__)
+-#if defined(__LP64__)
++#elif defined(__LP64__)
+ #define FOLLY_ELF_NATIVE_CLASS 64
+ #else
+ #define FOLLY_ELF_NATIVE_CLASS 32
+-#endif
+ #endif // __ELF_NATIVE_CLASS
+
+ namespace folly {
+--- a/folly/experimental/symbolizer/Elf.h
++++ b/folly/experimental/symbolizer/Elf.h
+@@ -24,6 +24,7 @@
+ #include <initializer_list>
+ #include <stdexcept>
+ #include <system_error>
++#include <sys/types.h>
+
+ #include <folly/Conv.h>
+ #include <folly/Likely.h>

--- a/dev-cpp/folly/folly-2022.07.04.00.ebuild
+++ b/dev-cpp/folly/folly-2022.07.04.00.ebuild
@@ -39,6 +39,10 @@ DEPEND="${RDEPEND}
 	sys-libs/binutils-libs"
 BDEPEND="test? ( sys-devel/clang )"
 
+PATCHES=(
+	"${FILESDIR}/${PN}"-2022.07.04.00-musl-fix.patch
+)
+
 pkg_setup() {
 	[[ ${BUILD_TYPE} == "binary" ]] && return
 


### PR DESCRIPTION
… this scope

Elf.cpp expects __ELF_NATIVE_CLASS to be defined at least for platforms
besides FreeBSD-based ones, and so it defines FOLLY_ELF_NATIVE_CLASS
with it. Without __ELF_NATIVE_CLASS (and apparently musl does not define
it), FOLLY_ELF_NATIVE_CLASS is also not defined so what was supposed to
be expanded to ELFCLASS32 or ELFCLASS64 ends up being
ELFCLASSFOLLY_ELF_NATIVE_CLASS.

Please refer: https://github.com/facebook/folly/issues/1478#issuecomment-719883898

Closes: https://bugs.gentoo.org/835744

Signed-off-by: brahmajit das <listout@protonmail.com>