### PR TITLE
sci-libs/vtk-9.1.0 - add support for Qt6

### DIFF
--- a/sci-libs/vtk/metadata.xml
+++ b/sci-libs/vtk/metadata.xml
@@ -23,6 +23,7 @@
     <flag name="kits">Build kits in addition to modules</flag>
     <flag name="offscreen">Offscreen rendering through OSMesa</flag>
     <flag name="pegtl">Use pegtl to build parsers</flag>
+    <flag name="qt6">Use Qt6 packages instead of Qt5</flag>
     <flag name="rendering">Building Redering modules</flag>
     <flag name="tbb">Use <pkg>dev-cpp/tbb</pkg> to handle smp support</flag>
     <flag name="views">Building Views modules</flag>


### PR DESCRIPTION
profiles: mask cgns USE flag on arm{,64} for sci-libs/vtk

Package not yet keyworded for these arches.

Bug: https://bugs.gentoo.org/864791


sci-libs/vtk: add Qt6 support

- bump to EAPI 8
- enable support for sci-libs/cgnslib and dev-libs/libfmt

Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>
