### PR TITLE
app-admin/logrotate: fix initial warning message "... is world-readable and thus can be lo…

### DIFF
--- a/app-admin/logrotate/logrotate-3.20.1-r1.ebuild
+++ b/app-admin/logrotate/logrotate-3.20.1-r1.ebuild
@@ -93,4 +93,7 @@ pkg_postinst() {
 		elog "Additionally, /etc/logrotate.conf may need to be modified"
 		elog "for your particular needs. See man logrotate for details."
 	fi
+
+	# fix initial warning message "... is world-readable and thus can be locked from other unprivileged users"
+	chmod 0640 /var/lib/misc/logrotate.status &>/dev/null
 }


### PR DESCRIPTION
The first time logrotate is run it displays the following warning message:

---
warning: state file /var/lib/misc/logrotate.status is world-readable and thus can be locked from other unprivileged users. Skipping lock acquisition...
---

See pull https://github.com/logrotate/logrotate/commit/1f76a381e2caa0603ae3dbc51ed0f1aa0d6658b9

Package-Manager: Portage-3.0.30-r3, Repoman-3.0.3-r2
Signed-off-by: Fco Javier Felix <ffelix@inode64.com>