### PR TITLE
dev-java/saslprep: adjust dependency type

### DIFF
--- a/dev-java/saslprep/saslprep-1.1-r1.ebuild
+++ b/dev-java/saslprep/saslprep-1.1-r1.ebuild
@@ -16,8 +16,8 @@ LICENSE="BSD-2"
 SLOT="0"
 KEYWORDS="amd64 ppc64 x86"
 
+CP_DEPEND="dev-java/stringprep:0"
 DEPEND=">=virtual/jdk-1.8:*
-	dev-java/stringprep:0"
-RDEPEND=">=virtual/jre-1.8:*"
-
-JAVA_CLASSPATH_EXTRA="stringprep"
+	${CP_DEPEND}"
+RDEPEND=">=virtual/jre-1.8:*
+	${CP_DEPEND}"


### PR DESCRIPTION
have saslprep in CP_DEPEDND, not only in DEPEND
Bug: https://bugs.gentoo.org/864931
Signed-off-by: Volkmar W. Pogatzki <gentoo@pogatzki.net>