### PR TITLE
dev-util/watchman: Fix __fsword_t type not defined on musl

### DIFF
--- a/dev-util/watchman/files/watchman-2022.08.08.00-musl-fsword-fix.patch
+++ b/dev-util/watchman/files/watchman-2022.08.08.00-musl-fsword-fix.patch
@@ -1,0 +1,20 @@
+# dev-util/watchman: Fix __fsword_t type not defined on musl
+#
+# __fsword_t is a glibc specific internal type, hence cannot be used on musl.
+# According to the fstatfs man page [1], we can use unsigned integer instead of
+# __fsword_t. But we are using unsigned long due the definition of
+# __FSWORD_T_TYPE seemes to be long [2].
+#
+# [1]: https://man7.org/linux/man-pages/man2/fstatfs.2.html [2]:
+# [2]: https://code.woboq.org/qt5/include/bits/typesizes.h.html#46
+--- a/watchman/fs/FSDetect.cpp
++++ b/watchman/fs/FSDetect.cpp
+@@ -143,7 +143,7 @@ w_string w_fstype(const char* path) {
+
+   // Unfortunately the FUSE magic number is not defined in linux/magic.h,
+   // and is only available in the Linux source code in fs/fuse/inode.c
+-  constexpr __fsword_t FUSE_MAGIC_NUMBER = 0x65735546;
++  constexpr unsigned long FUSE_MAGIC_NUMBER = 0x65735546;
+
+   if (statfs(path, &sfs) == 0) {
+     switch (sfs.f_type) {

--- a/dev-util/watchman/watchman-2022.08.08.00.ebuild
+++ b/dev-util/watchman/watchman-2022.08.08.00.ebuild
@@ -139,6 +139,7 @@ DEPEND="${RDEPEND}
 PATCHES=(
 	"${FILESDIR}"/${PN}-2022.07.04.00-python-working-dir.patch
 	"${FILESDIR}"/${PN}-2022.02.28.00-libatomic.patch
+	"${FILESDIR}"/${PN}-2022.08.08.00-musl-fsword-fix.patch
 )
 
 # Rust utility


### PR DESCRIPTION
__fsword_t is a glibc specific internal type, hence cannot be used on musl.
According to the fstatfs man page [1], we can use unsigned integer instead of
__fsword_t. But we are using unsigned long due the definition of
__FSWORD_T_TYPE seemes to be long [2].

[1]: https://man7.org/linux/man-pages/man2/fstatfs.2.html [2]:
[2]: https://code.woboq.org/qt5/include/bits/typesizes.h.html#46

Signed-off-by: brahmajit das <listout@protonmail.com>