### PR TITLE
media-libs/opencolorio: Fix strtol_l on musl

### DIFF
--- a/media-libs/opencolorio/files/opencolorio-2.1.2-musl-strtol.patch
+++ b/media-libs/opencolorio/files/opencolorio-2.1.2-musl-strtol.patch
@@ -1,0 +1,27 @@
+# Fix strtol_l missing on musl. On musl libc use strtol
+# Taken from Alpine Linux, please refer:
+# https://git.alpinelinux.org/aports/tree/community/opencolorio/0002-fix-strtol.patch?id=dd7ba461824ab0618f0493cbb450b221fdc2513c
+# Please refer: https://github.com/AcademySoftwareFoundation/OpenColorIO/issues/1624
+--- a/src/utils/NumberUtils.h
++++ b/src/utils/NumberUtils.h
+@@ -68,7 +68,7 @@ really_inline from_chars_result from_chars(const char *first, const char *last,
+     tempval = ::strtod_l(first, &endptr, loc.local);
+ #endif
+
+-    if (errno != 0)
++    if (errno != 0 && errno != EINVAL)
+     {
+         return {first + (endptr - first), std::errc::result_out_of_range};
+     }
+@@ -139,8 +139,10 @@ really_inline from_chars_result from_chars(const char *first, const char *last,
+     long int
+ #ifdef _WIN32
+     tempval = _strtol_l(first, &endptr, 0, loc.local);
+-#else
++#elif defined(__GLIBC__)
+     tempval = ::strtol_l(first, &endptr, 0, loc.local);
++#else
++    tempval = ::strtol(first, &endptr, 0);
+ #endif
+
+     if (errno != 0)

--- a/media-libs/opencolorio/opencolorio-2.1.2.ebuild
+++ b/media-libs/opencolorio/opencolorio-2.1.2.ebuild
@@ -55,6 +55,7 @@ RESTRICT="test"
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-2.1.1-gcc12.patch
+	"${FILESDIR}"/${PN}-2.1.2-musl-strtol.patch
 )
 
 pkg_setup() {


### PR DESCRIPTION
Fix strtol_l missing on musl. On musl libc use strtol
Taken from Alpine Linux, please refer:
https://git.alpinelinux.org/aports/tree/community/opencolorio/0002-fix-strtol.patch

Closes: https://bugs.gentoo.org/829453

Signed-off-by: brahmajit das <listout@protonmail.com>