### PR TITLE
gui-apps/foot: add terminfo USE flag

### DIFF
--- a/gui-apps/foot/foot-1.12.1.ebuild
+++ b/gui-apps/foot/foot-1.12.1.ebuild
@@ -13,7 +13,7 @@ S="${WORKDIR}/${PN}"
 LICENSE="MIT"
 SLOT="0"
 KEYWORDS="amd64 ~arm64"
-IUSE="+grapheme-clustering"
+IUSE="+grapheme-clustering +terminfo"
 
 COMMON_DEPEND="
 	dev-libs/wayland
@@ -54,8 +54,11 @@ src_configure() {
 		$(meson_feature grapheme-clustering)
 		-Dthemes=true
 		-Dime=true
-		-Dterminfo=disabled
+		$(meson_feature terminfo)
 	)
+	if use terminfo; then
+		emesonargs+=(-Ddefault-terminfo=foot-extra)
+	fi
 	meson_src_configure
 
 	sed 's|@bindir@|/usr/bin|g' "${S}/"/foot-server@.service.in > foot-server@.service

--- a/gui-apps/foot/foot-1.13.0.ebuild
+++ b/gui-apps/foot/foot-1.13.0.ebuild
@@ -13,7 +13,7 @@ S="${WORKDIR}/${PN}"
 LICENSE="MIT"
 SLOT="0"
 KEYWORDS="~amd64 ~arm64"
-IUSE="+grapheme-clustering"
+IUSE="+grapheme-clustering +terminfo"
 
 COMMON_DEPEND="
 	dev-libs/wayland
@@ -54,8 +54,11 @@ src_configure() {
 		$(meson_feature grapheme-clustering)
 		-Dthemes=true
 		-Dime=true
-		-Dterminfo=disabled
+		$(meson_feature terminfo)
 	)
+	if use terminfo; then
+		emesonargs+=(-Ddefault-terminfo=foot-extra)
+	fi
 	meson_src_configure
 
 	sed 's|@bindir@|/usr/bin|g' "${S}/"/foot-server@.service.in > foot-server@.service


### PR DESCRIPTION
I suggest that a USE flag be added to the gui-apps/foot package, with which it would generate its own terminfo entry.  Why does it need to do this when 'foot' is included in ncurses now? I quote:

https://codeberg.org/dnkl/foot/wiki#foot-s-terminfo-vs-ncurses-terminfo

>As of ncurses patch 2021-07-31, ncurses includes terminfo definitions for foot (`foot` and `foot-direct`). Yet we still provide our own version of the terminfo definitions (exact name depends on the distribution, but `foot-extra` and `foot-extra-direct` are common). Why?

>One reason is to support users running foot on systems where ncurses is too old.

>But another reason is that our version defines a number of non-standard capabilities, that are very unlikely to ever get upstreamed. These capabilities benefit primarily tmux, but could potentially be used by other applications as well. The non-standard capabilities we define are:

>`Sync` - terminal supports application synchronized updates
`Tc` - termminal is 24-bit (True) color capable
`setrgbb` - escape sequence to use to set a 24-bit background color
`setrgbf` - escape sequence to use to set a 25-bit foreground color

The gui-apps/foot ebuilds pass '-Dterminfo=disabled' to disable generating this slightly-enhanced terminfo file.  I expect this was in response to the name conflict with the 'foot' terminfo included in ncurses.  So there's now a foot-terminfo package, and there's ncurses which includes 'foot' as well, but those conflict. (Also see: https://bugs.gentoo.org/825434)

I want to have foot with a proper (full-featured, including Sync,Tc, etc.) terminfo installed as well as ncurses.  It makes sense to me to add a USE flag for it: with USE=terminfo, foot would build its terminfo files as `foot-extra` and `foot-extra-direct` (in line with the recommended names above).  With USE=-terminfo, it would not, and the user could just use the slightly limited terminfo files from ncurses.

Note that the attached changeset conditionally adds '-Ddefault-terminfo=foot-extra', which configures both the name of the generated terminfo file and the default $TERM for the generated executable. As far as I can tell it is not possible to separate these (generate it but then use TERM=foot and not use it by default, if one wanted to do that for some reason) without more invasively modifying the meson.build.

(This is my first pull request for Gentoo so my apologies and please let me know if I did anything wrong.)