### PR TITLE
dev-libs/keystone: build system requires python during build time

### DIFF
--- a/dev-libs/keystone/keystone-0.9.2-r1.ebuild
+++ b/dev-libs/keystone/keystone-0.9.2-r1.ebuild
@@ -36,6 +36,7 @@ RDEPEND="
 	python? ( ${PYTHON_DEPS} )
 "
 DEPEND="${RDEPEND}"
+BDEPEND="${PYTHON_DEPS}"
 
 RESTRICT=test # only regression tests
 

--- a/dev-libs/keystone/keystone-9999.ebuild
+++ b/dev-libs/keystone/keystone-9999.ebuild
@@ -36,6 +36,7 @@ RDEPEND="
 	python? ( ${PYTHON_DEPS} )
 "
 DEPEND="${RDEPEND}"
+BDEPEND="${PYTHON_DEPS}"
 
 RESTRICT=test # only regression tests
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/765691
Signed-off-by: Mario Haustein <mario.haustein@hrz.tu-chemnitz.de>