### PR TITLE
dev-python/frozendict: add missing pytest dependency

### DIFF
--- a/dev-python/frozendict/frozendict-2.3.2.ebuild
+++ b/dev-python/frozendict/frozendict-2.3.2.ebuild
@@ -21,6 +21,8 @@ LICENSE="MIT"
 SLOT="0"
 KEYWORDS="~amd64 ~ppc64"
 
+distutils_enable_tests pytest
+
 python_test() {
 	cd "${T}" || die
 	epytest "${S}/test"

--- a/dev-python/frozendict/frozendict-2.3.4.ebuild
+++ b/dev-python/frozendict/frozendict-2.3.4.ebuild
@@ -23,6 +23,8 @@ LICENSE="MIT"
 SLOT="0"
 KEYWORDS="~amd64 ~ppc64"
 
+distutils_enable_tests pytest
+
 python_test() {
 	cd "${T}" || die
 	epytest "${S}/test"


### PR DESCRIPTION
I forgot to add `dev-python/pytest` dependency in commits 89e4ee59e046 - `dev-python/frozendict: fix test phase` and 880f511ea944 - `dev-python/frozendict: add 2.3.4`. Sorry.