### PR TITLE
net-irc/unrealircd: keyword 6.0.4 for ~riscv

### DIFF
--- a/net-irc/unrealircd/unrealircd-6.0.4.ebuild
+++ b/net-irc/unrealircd/unrealircd-6.0.4.ebuild
@@ -14,7 +14,7 @@ SRC_URI+=" verify-sig? ( https://www.unrealircd.org/downloads/${P}.tar.gz.asc )"
 
 LICENSE="GPL-2+"
 SLOT="0"
-KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~x86 ~amd64-linux"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~riscv ~x86 ~amd64-linux"
 IUSE="class-nofakelag curl geoip +operoverride operoverride-verify"
 
 RDEPEND="acct-group/unrealircd


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/865395
Signed-off-by: Yongxiang Liang <tanekliang@gmail.com>


Works fine. And can reproduce then same problem as https://bugs.gentoo.org/837197
