### PR TITLE
dev-libs/libtracefs: Fix pthread_mutex_t unknown type on musl

### DIFF
--- a/dev-libs/libtracefs/files/libtracefs-1.3.1-musl-pthread.patch
+++ b/dev-libs/libtracefs/files/libtracefs-1.3.1-musl-pthread.patch
@@ -1,0 +1,16 @@
+# On musl it is necessary to include pthread header else the compiler cannot
+# identify pthread_mutex_t as a known type
+# Closes: https://bugs.gentoo.org/855893
+diff --git a/include/tracefs-local.h b/include/tracefs-local.h
+index 926fd02..779e853 100644
+--- a/include/tracefs-local.h
++++ b/include/tracefs-local.h
+@@ -6,6 +6,8 @@
+ #ifndef _TRACE_FS_LOCAL_H
+ #define _TRACE_FS_LOCAL_H
+
++#include <pthread.h>
++
+ #define __hidden __attribute__((visibility ("hidden")))
+ #define __weak __attribute__((weak))
+

--- a/dev-libs/libtracefs/libtracefs-1.3.1.ebuild
+++ b/dev-libs/libtracefs/libtracefs-1.3.1.ebuild
@@ -28,6 +28,10 @@ BDEPEND="
 	doc? ( app-text/xmlto app-text/asciidoc )
 "
 
+PATCHES=(
+	"${FILESDIR}"/${PN}-1.3.1-musl-pthread.patch
+)
+
 src_configure() {
 	EMAKE_FLAGS=(
 		"prefix=${EPREFIX}/usr"


### PR DESCRIPTION
On musl it is necessary to include pthread header else the compiler cannot
identify pthread_mutex_t as a known type

Closes: https://bugs.gentoo.org/855893

Signed-off-by: brahmajit das <listout@protonmail.com>