### PR TITLE
media-gfx/exiv2: fix test for musl

### DIFF
--- a/media-gfx/exiv2/exiv2-0.27.5-r1.ebuild
+++ b/media-gfx/exiv2/exiv2-0.27.5-r1.ebuild
@@ -50,6 +50,8 @@ DEPEND="${DEPEND}
 
 DOCS=( README.md doc/ChangeLog doc/cmd.txt )
 
+PATCHES=(  "${FILESDIR}"/${PN}-0.27.5-musl-tests.patch )
+
 pkg_setup() {
 	use doc && python-any-r1_pkg_setup
 }

--- a/media-gfx/exiv2/files/exiv2-0.27.5-musl-tests.patch
+++ b/media-gfx/exiv2/files/exiv2-0.27.5-musl-tests.patch
@@ -1,0 +1,56 @@
+https://github.com/Exiv2/exiv2/commit/82adcb1f86def0555b25713a8b84dba84944b275 (1)
+https://github.com/Exiv2/exiv2/commit/7d8cd00778c3eee9f32af04b009d8a5651eb53e7 (2)
+
+This is basically just commit (1). Though it wasn't directly applicable so I just merged it with (2).
+Easier and it makes the file same as upstream.
+
+diff -u b/unitTests/test_futils.cpp b/unitTests/test_futils.cpp
+--- b/unitTests/test_futils.cpp
++++ b/unitTests/test_futils.cpp
+@@ -42,21 +42,8 @@
+     std::string tmpFile("tmp.dat");
+     std::ofstream auxFile(tmpFile.c_str());
+     auxFile.close();
+-#if   defined(_WIN32) || defined(__CYGWIN__) || defined(__MINGW__) || defined(__MSYS__)
+-    const char * expectedString = "No error (errno = 0)";
+-#elif defined(__APPLE__)
+-    const char * expectedString = "Undefined error: 0 (errno = 0)";
+-#elif defined(__sun__)
+-    const char * expectedString = "Error 0 (errno = 0)";
+-#elif defined(__FreeBSD__)
+-    const char * expectedString = "No error: 0 (errno = 0)";
+-#elif defined(__NetBSD__)
+-    const char * expectedString = "Undefined error: 0 (errno = 0)";
+-#else
+-    const char * expectedString = "Success (errno = 0)";
+-#endif
+     std::remove(tmpFile.c_str());
+-    ASSERT_STREQ(expectedString, strError().c_str());
++    ASSERT_TRUE(strError().find("(errno = 0)") != std::string::npos);
+ }
+ 
+ TEST(strError, returnNoSuchFileOrDirectoryWhenTryingToOpenNonExistingFile)
+@@ -68,22 +55,7 @@
+ TEST(strError, doNotRecognizeUnknownError)
+ {
+     errno = 9999;
+-#if   defined(__MINGW__) || defined(__MSYS__) || defined(__CYGWIN__)
+-    const char * expectedString = "Unknown error 9999 (errno = 9999)";
+-#elif defined(_WIN32)
+-    const char * expectedString = "Unknown error (errno = 9999)";
+-#elif defined(__APPLE__)
+-    const char * expectedString = "Unknown error: 9999 (errno = 9999)";
+-#elif defined(__sun__)
+-    const char * expectedString = "Unknown error (errno = 9999)";
+-#elif defined(__FreeBSD__)
+-    const char * expectedString = "Unknown error: 9999 (errno = 9999)";
+-#elif defined(__NetBSD__)
+-    const char * expectedString = "Unknown error: 9999 (errno = 9999)";
+-#else
+-    const char * expectedString = "Unknown error 9999 (errno = 9999)";
+-#endif
+-    ASSERT_STREQ(expectedString, strError().c_str());
++    ASSERT_TRUE(strError().find("(errno = 9999)") != std::string::npos);
+ }
+ 
+ TEST(getEnv, getsDefaultValueWhenExpectedEnvVariableDoesNotExist)


### PR DESCRIPTION
This is fixed upstream. See the patch file for upstream commits. It only
patches broken tests, not tested code, so no revbump is needed.

Closes: https://bugs.gentoo.org/836230
Signed-off-by: Alfred Persson Forsberg <cat@catcream.org>