### PR TITLE
app-emulation/virtualbox: Fix compilation with -fcf-protection

### DIFF
--- a/app-emulation/virtualbox/files/virtualbox-6.1.36-fcf-protection.patch
+++ b/app-emulation/virtualbox/files/virtualbox-6.1.36-fcf-protection.patch
@@ -1,0 +1,16 @@
+Bug https://bugs.gentoo.org/865361
+
+gcc does not support -fcf-protection for i386 (needs i686+),
+so disable it when building iPxeBaseBin.
+
+--- a/src/VBox/Devices/PC/ipxe/Makefile.kmk
++++ b/src/VBox/Devices/PC/ipxe/Makefile.kmk
+@@ -176,6 +177,8 @@
+ 
+  iPxeBaseBin_TEMPLATE = iPxe
+ 
++ iPxeBaseBin_CFLAGS = -fcf-protection=none
++
+  iPxeBaseBin_INCS = \
+ 	src \
+ 	src/include \

--- a/app-emulation/virtualbox/virtualbox-6.1.36-r1.ebuild
+++ b/app-emulation/virtualbox/virtualbox-6.1.36-r1.ebuild
@@ -172,6 +172,9 @@ PATCHES=(
 	# Patch grabbed from Arch Linux / upstream for Python 3.10 support
 	"${FILESDIR}"/${PN}-6.1.36-python3.10.patch
 
+	# 865361
+	"${FILESDIR}"/${PN}-6.1.36-fcf-protection.patch
+
 	# Downloaded patchset
 	"${WORKDIR}"/virtualbox-patches-${MY_PV}/patches
 )


### PR DESCRIPTION
Filter out the flag only on a specific target