### PR TITLE
dev-python/autopep8: enable py3.11

### DIFF
--- a/dev-python/autopep8/autopep8-1.6.0.ebuild
+++ b/dev-python/autopep8/autopep8-1.6.0.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{8..10} pypy3 )
+PYTHON_COMPAT=( python3_{8..11} pypy3 )
 PYTHON_REQ_USE="threads(+)"
 
 inherit distutils-r1
@@ -26,3 +26,7 @@ RDEPEND="
 	dev-python/toml[${PYTHON_USEDEP}]"
 
 distutils_enable_tests unittest
+
+PATCHES=(
+	"${FILESDIR}"/autopep8-1.6.0-lib2to3-deprecation-pytest.patch
+)

--- a/dev-python/autopep8/autopep8-1.7.0.ebuild
+++ b/dev-python/autopep8/autopep8-1.7.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{8..10} pypy3 )
+PYTHON_COMPAT=( python3_{8..11} pypy3 )
 PYTHON_REQ_USE="threads(+)"
 
 inherit distutils-r1
@@ -30,4 +30,8 @@ distutils_enable_tests pytest
 EPYTEST_DESELECT=(
 	# test require in source build
 	test/test_autopep8.py::SystemTests::test_e101_skip_innocuous
+)
+
+PATCHES=(
+	"${FILESDIR}"/autopep8-1.6.0-lib2to3-deprecation-pytest.patch
 )

--- a/dev-python/autopep8/files/autopep8-1.6.0-lib2to3-deprecation-pytest.patch
+++ b/dev-python/autopep8/files/autopep8-1.6.0-lib2to3-deprecation-pytest.patch
@@ -1,0 +1,28 @@
+--- a/test/test_autopep8.py	2022-07-01 16:53:14.197393816 +0300
++++ b/test/test_autopep8.py	2022-07-01 17:26:07.740358186 +0300
+@@ -5729,7 +5729,11 @@
+                 list(AUTOPEP8_CMD_TUPLE) + [filename, '--in-place'],
+                 stderr=PIPE,
+             )
+-            _, err = p.communicate()
++            _, error = p.communicate()
++            if b'DeprecationWarning: lib2to3 package is deprecated' in error:
++                err = bytes()
++            else:
++                err = error
+             self.assertEqual(err, b'')
+             self.assertEqual(p.returncode, autopep8.EXIT_CODE_OK)
+ 
+@@ -5741,7 +5745,11 @@
+                 list(AUTOPEP8_CMD_TUPLE) + [filename, '--in-place'],
+                 stderr=PIPE,
+             )
+-            _, err = p.communicate()
++            _, error = p.communicate()
++            if b'DeprecationWarning: lib2to3 package is deprecated' in error:
++                err = bytes()
++            else:
++                err = error
+             self.assertEqual(err, b'')
+             self.assertEqual(p.returncode, autopep8.EXIT_CODE_OK)
+ 


### PR DESCRIPTION
This is part of https://github.com/gentoo/gentoo/pull/26805, add python 3.11 target to autopep8, and add patch to pass the test cases.
dev-python/python-lsp-server depend on the autopep8 >=1.6.0 and <1.7.0.
The autopep8-1.6.0 is stable, so I copy it to autopep8-1.6.0-r1 and mark all KEYWORDS to unstable.
And also, I add python 3.11 target and patch to autopep8-1.7.0.

Signed-off-by: Jinqiang Zhang <peeweep@0x0.ee>