### PR TITLE
app-editor/*vim*: provide configure defaults when cross compiling

### DIFF
--- a/app-editors/gvim/gvim-9.0.0099.ebuild
+++ b/app-editors/gvim/gvim-9.0.0099.ebuild
@@ -247,6 +247,14 @@ src_configure() {
 		export ac_cv_func_sigaction=no
 	fi
 
+	if tc-is-cross-compiler ; then
+		export vim_cv_getcwd_broken=no \
+			   vim_cv_memmove_handles_overlap=yes \
+			   vim_cv_stat_ignores_slash=yes \
+			   vim_cv_terminfo=yes \
+			   vim_cv_toupper_broken=no
+	fi
+
 	econf \
 		--with-modified-by=Gentoo-${PVR} \
 		--with-vim-name=gvim \

--- a/app-editors/vim-core/vim-core-9.0.0099.ebuild
+++ b/app-editors/vim-core/vim-core-9.0.0099.ebuild
@@ -148,6 +148,14 @@ src_configure() {
 	# Keep Gentoo Prefix env contained within the EPREFIX
 	use prefix && myconf+=( --without-local-dir )
 
+	if tc-is-cross-compiler ; then
+		export vim_cv_getcwd_broken=no \
+			   vim_cv_memmove_handles_overlap=yes \
+			   vim_cv_stat_ignores_slash=yes \
+			   vim_cv_terminfo=yes \
+			   vim_cv_toupper_broken=no
+	fi
+
 	econf "${myconf[@]}"
 }
 

--- a/app-editors/vim/vim-9.0.0099.ebuild
+++ b/app-editors/vim/vim-9.0.0099.ebuild
@@ -247,6 +247,14 @@ src_configure() {
 	# keep prefix env contained within the EPREFIX
 	use prefix && myconf+=( --without-local-dir )
 
+	if tc-is-cross-compiler ; then
+		export vim_cv_getcwd_broken=no \
+			   vim_cv_memmove_handles_overlap=yes \
+			   vim_cv_stat_ignores_slash=yes \
+			   vim_cv_terminfo=yes \
+			   vim_cv_toupper_broken=no
+	fi
+
 	econf \
 		--with-modified-by=Gentoo-${PVR} \
 		"${myconf[@]}"


### PR DESCRIPTION
See: https://github.com/gentoo/gentoo/commit/fcb39bd3c5102ee6e87719d38df2625f36513611
Signed-off-by: Alfred Persson Forsberg <cat@catcream.org>