### PR TITLE
dev-ml/opam: fix opam dependency on bubblewrap

### DIFF
--- a/dev-ml/opam/opam-2.0.10-r1.ebuild
+++ b/dev-ml/opam/opam-2.0.10-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,14 +8,12 @@ inherit dune
 DESCRIPTION="A source-based package manager for OCaml"
 HOMEPAGE="http://opam.ocaml.org/"
 SRC_URI="https://github.com/ocaml/opam/archive/${PV/_/-}.tar.gz -> opam-${PV}.tar.gz"
-SRC_URI+=" https://dev.gentoo.org/~sam/distfiles/dev-ml/opam/opam-2.1.0-dose3-6.patch.xz"
 S="${WORKDIR}/opam-${PV/_/-}"
 
 LICENSE="LGPL-2.1-with-linking-exception"
 SLOT="0/${PV}"
-KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~x86"
 IUSE="+ocamlopt"
-RESTRICT="test" #see bugs 838658
 
 RDEPEND="
 	dev-ml/cmdliner:=
@@ -24,10 +22,12 @@ RDEPEND="
 	dev-ml/extlib:=
 	~dev-ml/opam-client-${PV}:=
 	dev-ml/opam-file-format:=
-	dev-ml/re:="
+	dev-ml/re:=
+	sys-apps/bubblewrap:="
 DEPEND="${RDEPEND}"
 
-PATCHES=( "${WORKDIR}"/opam-2.1.0-dose3-6.patch )
+# Cherry-picked from https://deb.debian.org/debian/pool/main/o/opam/opam_2.0.8-1.debian.tar.xz
+PATCHES=( "${FILESDIR}/debian-Port-to-Dose3-6.0.1.patch" )
 
 src_prepare() {
 	default

--- a/dev-ml/opam/opam-2.0.9-r1.ebuild
+++ b/dev-ml/opam/opam-2.0.9-r1.ebuild
@@ -22,7 +22,8 @@ RDEPEND="
 	dev-ml/extlib:=
 	~dev-ml/opam-client-${PV}:=
 	dev-ml/opam-file-format:=
-	dev-ml/re:="
+	dev-ml/re:=
+	sys-apps/bubblewrap:="
 DEPEND="${RDEPEND}"
 
 # Cherry-picked from https://deb.debian.org/debian/pool/main/o/opam/opam_2.0.8-1.debian.tar.xz

--- a/dev-ml/opam/opam-2.1.2-r1.ebuild
+++ b/dev-ml/opam/opam-2.1.2-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,12 +8,14 @@ inherit dune
 DESCRIPTION="A source-based package manager for OCaml"
 HOMEPAGE="http://opam.ocaml.org/"
 SRC_URI="https://github.com/ocaml/opam/archive/${PV/_/-}.tar.gz -> opam-${PV}.tar.gz"
+SRC_URI+=" https://dev.gentoo.org/~sam/distfiles/dev-ml/opam/opam-2.1.0-dose3-6.patch.xz"
 S="${WORKDIR}/opam-${PV/_/-}"
 
 LICENSE="LGPL-2.1-with-linking-exception"
 SLOT="0/${PV}"
-KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~riscv ~x86"
 IUSE="+ocamlopt"
+RESTRICT="test" #see bugs 838658
 
 RDEPEND="
 	dev-ml/cmdliner:=
@@ -22,11 +24,11 @@ RDEPEND="
 	dev-ml/extlib:=
 	~dev-ml/opam-client-${PV}:=
 	dev-ml/opam-file-format:=
-	dev-ml/re:="
+	dev-ml/re:=
+	sys-apps/bubblewrap:="
 DEPEND="${RDEPEND}"
 
-# Cherry-picked from https://deb.debian.org/debian/pool/main/o/opam/opam_2.0.8-1.debian.tar.xz
-PATCHES=( "${FILESDIR}/debian-Port-to-Dose3-6.0.1.patch" )
+PATCHES=( "${WORKDIR}"/opam-2.1.0-dose3-6.patch )
 
 src_prepare() {
 	default


### PR DESCRIPTION
Since opam 2.0.0~rc2, opam uses bwrap on Linux to run package instructions in a sandbox.
Source: https://opam.ocaml.org/doc/FAQ.html#Why-does-opam-require-bwrap

Closes: https://bugs.gentoo.org/865737
Signed-off-by: igna_martinoli <ignamartinoli@protonmail.com>