### PR TITLE
dev-libs/json-parser: fix tests

### DIFF
--- a/dev-libs/json-parser/json-parser-1.1.0_p20211208.ebuild
+++ b/dev-libs/json-parser/json-parser-1.1.0_p20211208.ebuild
@@ -68,7 +68,7 @@ python_test() {
 }
 
 src_test() {
-	edo $(tc-getCC) ${CFLAGS} -I. ${CPPFLAGS} ${LDFLAGS} -o tests/test tests/test.c json.o
+	edo $(tc-getCC) ${CFLAGS} -I. ${CPPFLAGS} ${LDFLAGS} -o tests/test tests/test.c json.o -lm
 	pushd tests > /dev/null || die
 	edo ./test
 	use python && distutils-r1_src_test


### PR DESCRIPTION
It is necessary to link the `test` with `libm`. I missed it as I was developing the ebuild in system with `musl` libc, where `-lm` is not strictly necessary.