### PR TITLE
sys-cluster/glusterfs: 10.2-r2 bump to enable USE=uring.

### DIFF
--- a/sys-cluster/glusterfs/files/glusterd-10.2-r2.initd
+++ b/sys-cluster/glusterfs/files/glusterd-10.2-r2.initd
@@ -1,0 +1,32 @@
+#!/sbin/openrc-run
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+description="Gluster elastic volume management daemon"
+command="/usr/sbin/glusterd"
+pidfile="/run/${SVCNAME}.pid"
+command_args="-N"
+
+command_background="yes"
+
+depend() {
+	need net
+	before netmount
+}
+
+start_pre() {
+	# Ensure that the GlusterFS auxiliary mount parent directory exists
+	checkpath --directory --owner gluster:gluster --mode 0775 /run/gluster
+}
+
+start_post() {
+	local c=0
+	ebegin "Waiting for glusterd to start up"
+	while ! /usr/sbin/gluster volume list >/dev/null 2>&1 && [ "${c}" -lt "${glusterd_max_wait_start-60}" ]; do
+		c=$(( c+1 ))
+	done
+	[ "${c}" -lt "${glusterd_max_wait_start-60}" ]
+	eend $?
+
+	return 0
+}

--- a/sys-cluster/glusterfs/glusterfs-10.2-r2.ebuild
+++ b/sys-cluster/glusterfs/glusterfs-10.2-r2.ebuild
@@ -1,0 +1,203 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+PYTHON_COMPAT=( python3_{8..11} )
+
+inherit autotools elisp-common python-single-r1 tmpfiles systemd
+
+DESCRIPTION="GlusterFS is a powerful network/cluster filesystem"
+HOMEPAGE="https://www.gluster.org/ https://github.com/gluster/glusterfs/"
+SRC_URI="https://download.gluster.org/pub/gluster/${PN}/$(ver_cut 1)/${PV}/${P}.tar.gz"
+
+LICENSE="|| ( GPL-2 LGPL-3+ )"
+SLOT="0/${PV%%.*}"
+KEYWORDS="~amd64 ~arm ~arm64 ~loong ~ppc ~ppc64 ~riscv ~x86"
+
+IUSE="debug emacs +fuse georeplication ipv6 +libtirpc rsyslog static-libs tcmalloc test +uring xml"
+
+REQUIRED_USE="${PYTHON_REQUIRED_USE}
+	georeplication? ( xml )
+	ipv6? ( libtirpc )"
+
+# the tests must be run as root
+RESTRICT="test"
+
+# sys-apps/util-linux is required for libuuid
+RDEPEND="
+	acct-group/gluster
+	acct-user/gluster
+	dev-libs/libaio
+	dev-libs/openssl:=[-bindist(-)]
+	net-libs/rpcsvc-proto
+	dev-libs/userspace-rcu:=
+	sys-apps/util-linux
+	sys-libs/readline:=
+	!elibc_glibc? ( sys-libs/argp-standalone )
+	emacs? ( >=app-editors/emacs-23.1:* )
+	fuse? ( >=sys-fs/fuse-2.7.0:0 )
+	georeplication? ( ${PYTHON_DEPS} )
+	libtirpc? ( net-libs/libtirpc:= )
+	!libtirpc? ( elibc_glibc? ( sys-libs/glibc[rpc(-)] ) )
+	tcmalloc? ( dev-util/google-perftools )
+	uring? ( sys-libs/liburing:= )
+	xml? ( dev-libs/libxml2 )
+"
+DEPEND="
+	${RDEPEND}
+	sys-devel/bison
+	sys-devel/flex
+	virtual/acl
+	test? ( >=dev-util/cmocka-1.0.1
+		app-benchmarks/dbench
+		dev-vcs/git
+		net-fs/nfs-utils
+		virtual/perl-Test-Harness
+		dev-libs/yajl
+		sys-fs/xfsprogs
+		sys-apps/attr )
+"
+BDEPEND="
+	virtual/pkgconfig
+"
+
+SITEFILE="50${PN}-mode-gentoo.el"
+
+DOCS=( AUTHORS ChangeLog NEWS README.md THANKS )
+
+QA_PKGCONFIG_VERSION=7.10.2
+
+# Maintainer notes:
+# * The build system will always configure & build argp-standalone but it'll never use it
+#   if the argp.h header is found in the system. Which should be the case with
+#   glibc or if argp-standalone is installed.
+
+pkg_setup() {
+	python_setup "python3*"
+	python-single-r1_pkg_setup
+}
+
+src_prepare() {
+	default
+
+	# build rpc-transport and xlators only once as shared libs
+	find rpc/rpc-transport xlators -name Makefile.am -exec \
+		sed -i 's|.*$(top_srcdir).*\.sym|\0 -shared|' {} + || die
+
+	# fix execution permissions
+	chmod +x libglusterfs/src/gen-defaults.py || die
+
+	eautoreconf
+}
+
+src_configure() {
+	econf \
+		--disable-fusermount \
+		--disable-lto \
+		$(use_enable debug) \
+		$(use_enable fuse fuse-client) \
+		$(use_enable georeplication) \
+		$(use_enable static-libs static) \
+		$(use_enable test cmocka) \
+		$(use_enable uring linux-io-uring) \
+		$(use_enable xml xml-output) \
+		$(usex ipv6 --with-ipv6-default "") \
+		$(usex libtirpc "" --without-libtirpc) \
+		$(usex tcmalloc "" --without-tcmalloc) \
+		--with-tmpfilesdir="${EPREFIX}"/usr/lib/tmpfiles.d \
+		--localstatedir="${EPREFIX}"/var
+}
+
+src_compile() {
+	default
+	use emacs && elisp-compile extras/glusterfs-mode.el
+}
+
+src_test() {
+	./run-tests.sh || die
+}
+
+src_install() {
+	default
+
+	rm \
+		"${ED}"/etc/glusterfs/glusterfs-{georep-,}logrotate \
+		"${ED}"/etc/glusterfs/gluster-rsyslog-*.conf \
+		"${ED}"/usr/share/doc/${PF}/glusterfs{-mode.el,.vim} || die "removing false files failed"
+
+	insinto /etc/logrotate.d
+	newins "${FILESDIR}"/glusterfs.logrotate glusterfs
+
+	if use rsyslog ; then
+		insinto /etc/rsyslog.d
+		newins extras/gluster-rsyslog-7.2.conf 60-gluster.conf
+	fi
+
+	if use emacs ; then
+		elisp-install ${PN} extras/glusterfs-mode.el*
+		elisp-site-file-install "${FILESDIR}/${SITEFILE}"
+	fi
+
+	insinto /usr/share/vim/vimfiles/ftdetect; doins "${FILESDIR}"/${PN}.vim
+	insinto /usr/share/vim/vimfiles/syntax; doins extras/${PN}.vim
+
+	# insert some other tools which might be useful
+	insinto /usr/share/glusterfs/scripts
+	doins \
+		extras/backend-{cleanup,xattr-sanitize}.sh \
+		extras/clear_xattrs.sh \
+		extras/migrate-unify-to-distribute.sh
+
+	# correct permissions on installed scripts
+	# fperms 0755 /usr/share/glusterfs/scripts/*.sh
+	chmod 0755 "${ED}"/usr/share/glusterfs/scripts/*.sh || die
+
+	newinitd "${FILESDIR}/glusterfsd-10.2.initd" glusterfsd
+	newinitd "${FILESDIR}/glusterd-10.2-r2.initd" glusterd
+	newconfd "${FILESDIR}/${PN}.confd" glusterfsd
+
+	keepdir /var/log/${PN}
+	keepdir /var/lib/glusterd/{events,glusterfind/.keys}
+
+	systemd_dounit extras/systemd/{glusterd,glustereventsd,glusterfssharedstorage,gluster-ta-volume}.service
+
+	# QA
+	rm -r "${ED}/var/run/" || die
+	if ! use static-libs; then
+		find "${D}" -type f -name '*.la' -delete || die
+	fi
+
+	python_optimize "${ED}"
+}
+
+pkg_postinst() {
+	tmpfiles_process gluster.conf
+
+	elog "Starting with ${PN}-3.1.0, you can use the glusterd daemon to configure your"
+	elog "volumes dynamically. To do so, simply use the gluster CLI after running:"
+	elog "  /etc/init.d/glusterd start"
+	echo
+	elog "For static configurations, the glusterfsd startup script can be multiplexed."
+	elog "The default startup script uses /etc/conf.d/glusterfsd to configure the"
+	elog "separate service.  To create additional instances of the glusterfsd service"
+	elog "simply create a symlink to the glusterfsd startup script."
+	echo
+	elog "Example:"
+	elog "    # ln -s glusterfsd /etc/init.d/glusterfsd2"
+	elog "    # ${EDITOR} /etc/glusterfs/glusterfsd2.vol"
+	elog "You can now treat glusterfsd2 like any other service"
+	echo
+	ewarn "You need to use a ntp client to keep the clocks synchronized across all"
+	ewarn "of your servers. Setup a NTP synchronizing service before attempting to"
+	ewarn "run GlusterFS."
+	echo
+	elog "If you are upgrading from a previous version of ${PN}, please read:"
+	elog "  http://docs.gluster.org/en/latest/Upgrade-Guide/upgrade_to_$(ver_cut '1-2')/"
+
+	use emacs && elisp-site-regen
+}
+
+pkg_postrm() {
+	use emacs && elisp-site-regen
+}

--- a/sys-cluster/glusterfs/metadata.xml
+++ b/sys-cluster/glusterfs/metadata.xml
@@ -26,5 +26,6 @@
 		<flag name="ipv6">Use IPv6 by default, requires libtirpc</flag>
 		<flag name="libtirpc">Build against <pkg>net-libs/libtirpc</pkg> for RPC support</flag>
 		<flag name="rsyslog">Install configuration snippet for <pkg>app-admin/rsyslog</pkg></flag>
+		<flag name="uring">Control whether or not glusterfs is compiled with uring support or not.</flag>
 	</use>
 </pkgmetadata>


### PR DESCRIPTION
Other minor fixes:

Closes: https://bugs.gentoo.org/860312
Closes: https://bugs.gentoo.org/860309
Package-Manager: Portage-3.0.30, Repoman-3.0.3
Signed-off-by: Jaco Kroon <jaco@uls.co.za>

```
--- glusterfs-10.2-r1.ebuild	2022-07-25 12:43:17.756688223 +0200
+++ glusterfs-10.2-r2.ebuild	2022-08-18 17:55:32.653054869 +0200
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{8..10} )
+PYTHON_COMPAT=( python3_{8..11} )
 
 inherit autotools elisp-common python-single-r1 tmpfiles systemd
 
@@ -15,9 +15,10 @@
 SLOT="0/${PV%%.*}"
 KEYWORDS="~amd64 ~arm ~arm64 ~loong ~ppc ~ppc64 ~riscv ~x86"
 
-IUSE="debug emacs +fuse +georeplication ipv6 +libtirpc rsyslog static-libs tcmalloc test +xml"
+IUSE="debug emacs +fuse georeplication ipv6 +libtirpc rsyslog static-libs tcmalloc test +uring xml"
 
-REQUIRED_USE="georeplication? ( ${PYTHON_REQUIRED_USE} xml )
+REQUIRED_USE="${PYTHON_REQUIRED_USE}
+	georeplication? ( xml )
 	ipv6? ( libtirpc )"
 
 # the tests must be run as root
@@ -32,7 +33,6 @@
 	net-libs/rpcsvc-proto
 	dev-libs/userspace-rcu:=
 	sys-apps/util-linux
-	sys-libs/liburing:=
 	sys-libs/readline:=
 	!elibc_glibc? ( sys-libs/argp-standalone )
 	emacs? ( >=app-editors/emacs-23.1:* )
@@ -41,6 +41,7 @@
 	libtirpc? ( net-libs/libtirpc:= )
 	!libtirpc? ( elibc_glibc? ( sys-libs/glibc[rpc(-)] ) )
 	tcmalloc? ( dev-util/google-perftools )
+	uring? ( sys-libs/liburing:= )
 	xml? ( dev-libs/libxml2 )
 "
 DEPEND="
@@ -65,6 +66,8 @@
 
 DOCS=( AUTHORS ChangeLog NEWS README.md THANKS )
 
+QA_PKGCONFIG_VERSION=7.10.2
+
 # Maintainer notes:
 # * The build system will always configure & build argp-standalone but it'll never use it
 #   if the argp.h header is found in the system. Which should be the case with
@@ -97,6 +100,7 @@
 		$(use_enable georeplication) \
 		$(use_enable static-libs static) \
 		$(use_enable test cmocka) \
+		$(use_enable uring linux-io-uring) \
 		$(use_enable xml xml-output) \
 		$(usex ipv6 --with-ipv6-default "") \
 		$(usex libtirpc "" --without-libtirpc) \
@@ -150,7 +154,7 @@
 	chmod 0755 "${ED}"/usr/share/glusterfs/scripts/*.sh || die
 
 	newinitd "${FILESDIR}/glusterfsd-10.2.initd" glusterfsd
-	newinitd "${FILESDIR}/glusterd-10.2-r1.initd" glusterd
+	newinitd "${FILESDIR}/glusterd-10.2-r2.initd" glusterd
 	newconfd "${FILESDIR}/${PN}.confd" glusterfsd
 
 	keepdir /var/log/${PN}
```