### PR TITLE
dev-libs/libtracefs: Fix wrong target install-doc and source-highlight dependency

### DIFF
--- a/dev-libs/libtracefs/libtracefs-1.3.1.ebuild
+++ b/dev-libs/libtracefs/libtracefs-1.3.1.ebuild
@@ -23,9 +23,10 @@ RDEPEND="
 	>=dev-libs/libtraceevent-1.3.0
 "
 DEPEND="${RDEPEND}"
+# source-highlight is needed, see bug https://bugs.gentoo.org/865469
 BDEPEND="
 	virtual/pkgconfig
-	doc? ( app-text/xmlto app-text/asciidoc )
+	doc? ( app-text/xmlto app-text/asciidoc dev-util/source-highlight )
 "
 
 PATCHES=(
@@ -51,5 +52,6 @@ src_install() {
 	emake "${EMAKE_FLAGS[@]}" DESTDIR="${ED}" install
 	# can't prevent installation of the static lib with parameters
 	rm "${ED}/usr/$(get_libdir)/libtracefs.a" || die
-	use doc && emake "${EMAKE_FLAGS[@]}" DESTDIR="${ED}" install-doc
+	# install-doc is wrong target, see https://bugs.gentoo.org/865465
+	use doc && emake "${EMAKE_FLAGS[@]}" DESTDIR="${ED}" install_doc
 }


### PR DESCRIPTION
The make target install-doc is wrong and install_doc should be used
in this package's case.

gnu source-highlight is needed for source highlighting by asciidoc

Closes: https://bugs.gentoo.org/865465
Closes: https://bugs.gentoo.org/865469

Signed-off-by: brahmajit das <listout@protonmail.com>