### PR TITLE
toolchain.eclass: build multilibs for ARM's A, R and M architecture profiles

### DIFF
--- a/eclass/toolchain.eclass
+++ b/eclass/toolchain.eclass
@@ -1213,6 +1213,17 @@ toolchain_src_configure() {
 					armv7*) confgcc+=( --with-fpu=vfpv3-d16 ) ;;
 				esac
 			fi
+
+			# If multilib is used, make the compiler build multilibs
+			# for A or R and M architecture profiles. Do this only
+			# when no specific arch/mode/float is specified, e.g.
+			# for target arm-none-eabi, since doing this is
+			# incompatible with --with-arch/cpu/float/fpu.
+			if is_multilib && [[ ${arm_arch} == arm ]] && \
+			   tc_version_is_at_least 7.1
+			then
+				confgcc+=( --with-multilib-list=aprofile,rmprofile  )
+			fi
 			;;
 		mips)
 			# Add --with-abi flags to set default ABI

--- a/eclass/toolchain.eclass
+++ b/eclass/toolchain.eclass
@@ -1187,8 +1187,6 @@ toolchain_src_configure() {
 				fi
 			done
 
-			# Convert armv6m to armv6-m
-			[[ ${arm_arch} == armv6m ]] && arm_arch=armv6-m
 			# Convert armv7{a,r,m} to armv7-{a,r,m}
 			[[ ${arm_arch} == armv7? ]] && arm_arch=${arm_arch/7/7-}
 			# See if this is a valid --with-arch flag


### PR DESCRIPTION
Make it possible to have one ARM compiler (for example `CTARGET=arm-none-eabi`) be able to link correct `libgcc` for various `-mcpu`/`-march`/`-mfloat`/`-mfpu` option.

Example of `-print-libgcc-file-name` output for various options:

| options | libgcc path |
| -- | -- |
| default | `/usr/lib/gcc/arm-none-eabi/12.1.1/libgcc.a` |
| `-mcpu=cortex-m0` | `/usr/lib/gcc/arm-none-eabi/12.1.1/thumb/v6-m/nofp/libgcc.a` |
| `-march=armv7-m` | `/usr/lib/gcc/arm-none-eabi/12.1.1/thumb/v7-m/nofp/libgcc.a` |
| `-march=armv7-a` | `/usr/lib/gcc/arm-none-eabi/12.1.1/thumb/v7-a/nofp/libgcc.a` |
| `-march=armv7-a -mhard-float -mfpu=neon` | `/usr/lib/gcc/arm-none-eabi/12.1.1/thumb/v7-a+simd/hard/libgcc.a` |
| `-march=armv7-a -mhard-float -mfpu=vfp` | `/usr/lib/gcc/arm-none-eabi/12.1.1/thumb/v7-a+fp/hard/libgcc.a` |

@thesamesam please look at this when you find some time