### PR TITLE
net-misc/asterisk: ./configure fixes.

### DIFF
--- a/net-misc/asterisk/asterisk-13.38.3-r3.ebuild
+++ b/net-misc/asterisk/asterisk-13.38.3-r3.ebuild
@@ -139,7 +139,8 @@ pkg_setup() {
 
 src_prepare() {
 	default
-	AT_M4DIR="autoconf third-party third-party/pjproject third-party/jansson" eautoreconf
+	AT_M4DIR="autoconf third-party third-party/pjproject third-party/jansson" \
+		AC_CONFIG_SUBDIRS=menuselect eautoreconf
 }
 
 src_configure() {

--- a/net-misc/asterisk/asterisk-16.22.0-r1.ebuild
+++ b/net-misc/asterisk/asterisk-16.22.0-r1.ebuild
@@ -140,7 +140,8 @@ pkg_setup() {
 
 src_prepare() {
 	default
-	AT_M4DIR="autoconf third-party third-party/pjproject third-party/jansson" eautoreconf
+	AT_M4DIR="autoconf third-party third-party/pjproject third-party/jansson" \
+		AC_CONFIG_SUBDIRS=menuselect eautoreconf
 }
 
 src_configure() {

--- a/net-misc/asterisk/asterisk-16.23.0-r1.ebuild
+++ b/net-misc/asterisk/asterisk-16.23.0-r1.ebuild
@@ -140,7 +140,8 @@ pkg_setup() {
 
 src_prepare() {
 	default
-	AT_M4DIR="autoconf third-party third-party/pjproject third-party/jansson" eautoreconf
+	AT_M4DIR="autoconf third-party third-party/pjproject third-party/jansson" \
+		AC_CONFIG_SUBDIRS=menuselect eautoreconf
 }
 
 src_configure() {

--- a/net-misc/asterisk/asterisk-16.24.0-r1.ebuild
+++ b/net-misc/asterisk/asterisk-16.24.0-r1.ebuild
@@ -140,7 +140,8 @@ pkg_setup() {
 
 src_prepare() {
 	default
-	AT_M4DIR="autoconf third-party third-party/pjproject third-party/jansson" eautoreconf
+	AT_M4DIR="autoconf third-party third-party/pjproject third-party/jansson" \
+		AC_CONFIG_SUBDIRS=menuselect eautoreconf
 }
 
 src_configure() {

--- a/net-misc/asterisk/asterisk-16.26.1.ebuild
+++ b/net-misc/asterisk/asterisk-16.26.1.ebuild
@@ -140,7 +140,8 @@ pkg_setup() {
 
 src_prepare() {
 	default
-	AT_M4DIR="autoconf third-party third-party/pjproject third-party/jansson" eautoreconf
+	AT_M4DIR="autoconf third-party third-party/pjproject third-party/jansson" \
+		AC_CONFIG_SUBDIRS=menuselect eautoreconf
 }
 
 src_configure() {
@@ -148,6 +149,7 @@ src_configure() {
 	local copt cstate
 
 	econf \
+		SED=sed \
 		LUA_VERSION="${ELUA#lua}" \
 		--libdir="/usr/$(get_libdir)" \
 		--localstatedir="/var" \

--- a/net-misc/asterisk/asterisk-16.27.0.ebuild
+++ b/net-misc/asterisk/asterisk-16.27.0.ebuild
@@ -140,7 +140,8 @@ pkg_setup() {
 
 src_prepare() {
 	default
-	AT_M4DIR="autoconf third-party third-party/pjproject third-party/jansson" eautoreconf
+	AT_M4DIR="autoconf third-party third-party/pjproject third-party/jansson" \
+		AC_CONFIG_SUBDIRS=menuselect eautoreconf
 }
 
 src_configure() {
@@ -148,6 +149,7 @@ src_configure() {
 	local copt cstate
 
 	econf \
+		SED=sed \
 		LUA_VERSION="${ELUA#lua}" \
 		--libdir="/usr/$(get_libdir)" \
 		--localstatedir="/var" \

--- a/net-misc/asterisk/asterisk-18.10.0-r1.ebuild
+++ b/net-misc/asterisk/asterisk-18.10.0-r1.ebuild
@@ -138,7 +138,8 @@ pkg_setup() {
 
 src_prepare() {
 	default
-	AT_M4DIR="autoconf third-party third-party/pjproject third-party/jansson" eautoreconf
+	AT_M4DIR="autoconf third-party third-party/pjproject third-party/jansson" \
+		AC_CONFIG_SUBDIRS=menuselect eautoreconf
 }
 
 src_configure() {

--- a/net-misc/asterisk/asterisk-18.13.0.ebuild
+++ b/net-misc/asterisk/asterisk-18.13.0.ebuild
@@ -138,7 +138,8 @@ pkg_setup() {
 
 src_prepare() {
 	default
-	AT_M4DIR="autoconf third-party third-party/pjproject third-party/jansson" eautoreconf
+	AT_M4DIR="autoconf third-party third-party/pjproject third-party/jansson" \
+		AC_CONFIG_SUBDIRS=menuselect eautoreconf
 }
 
 src_configure() {

--- a/net-misc/asterisk/asterisk-18.8.0-r1.ebuild
+++ b/net-misc/asterisk/asterisk-18.8.0-r1.ebuild
@@ -138,7 +138,8 @@ pkg_setup() {
 
 src_prepare() {
 	default
-	AT_M4DIR="autoconf third-party third-party/pjproject third-party/jansson" eautoreconf
+	AT_M4DIR="autoconf third-party third-party/pjproject third-party/jansson" \
+		AC_CONFIG_SUBDIRS=menuselect eautoreconf
 }
 
 src_configure() {

--- a/net-misc/asterisk/asterisk-18.9.0-r1.ebuild
+++ b/net-misc/asterisk/asterisk-18.9.0-r1.ebuild
@@ -138,7 +138,8 @@ pkg_setup() {
 
 src_prepare() {
 	default
-	AT_M4DIR="autoconf third-party third-party/pjproject third-party/jansson" eautoreconf
+	AT_M4DIR="autoconf third-party third-party/pjproject third-party/jansson" \
+		AC_CONFIG_SUBDIRS=menuselect eautoreconf
 }
 
 src_configure() {


### PR DESCRIPTION
1.  there is a ./configure in menuselect, so eautoreconf should run
    there too.
2.  SED= is set in that menuselect/configure only after using, resulting
    in "./configure: line 5027: -e: command not found", which ends up
    that libxml-2.0 is detected, but the CFLAGS for the package isn't
    correctly set, resulting in failure at a later stage to #include
    <libxml/parser.h>

Package-Manager: Portage-3.0.30, Repoman-3.0.3
Signed-off-by: Jaco Kroon <jaco@uls.co.za>