### PR TITLE
dev-ml/ppx_import: require ppxlib>=24.0

### DIFF
--- a/dev-ml/ppx_import/ppx_import-1.9.1.ebuild
+++ b/dev-ml/ppx_import/ppx_import-1.9.1.ebuild
@@ -16,7 +16,7 @@ KEYWORDS="~amd64 ~x86"
 IUSE="+ocamlopt test"
 RESTRICT="!test? ( test )"
 
-RDEPEND="dev-ml/ppxlib:="
+RDEPEND=">=dev-ml/ppxlib-0.24:="
 DEPEND="${RDEPEND}"
 BDEPEND="
 	test? (


### PR DESCRIPTION
Fails to build with previous versions (such as the stable version, as I noticed on my mostly stable system).