### PR TITLE
dev-python/pyside6: install designer plugin to proper destination

### DIFF
--- a/dev-python/pyside6/files/pyside6-6.3.1-fix-designer-plugin-install-location.patch
+++ b/dev-python/pyside6/files/pyside6-6.3.1-fix-designer-plugin-install-location.patch
@@ -1,0 +1,16 @@
+https://bugs.gentoo.org/865363
+
+From 109d7bbec01870f8e944a9cde09d3e2f70e13e0d Mon Sep 17 00:00:00 2001
+From: Bernd Waibel <waebbl-gentoo@posteo.net>
+Date: Mon, 22 Aug 2022 07:10:35 +0200
+Subject: [PATCH] fix designer plugin install location
+
+Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>
+--- a/plugins/designer/CMakeLists.txt
++++ b/plugins/designer/CMakeLists.txt
+@@ -53,4 +53,4 @@ target_link_libraries(PySidePlugin PRIVATE
+                       Qt::Widgets
+                       ${SHIBOKEN_PYTHON_LIBRARIES})
+ 
+-install(TARGETS PySidePlugin LIBRARY DESTINATION "plugins/designer")
++install(TARGETS PySidePlugin LIBRARY DESTINATION "lib${LIB_SUFFIX}/qt6/plugins/designer")

--- a/dev-python/pyside6/pyside6-6.3.1-r1.ebuild
+++ b/dev-python/pyside6/pyside6-6.3.1-r1.ebuild
@@ -98,6 +98,7 @@ DEPEND="${RDEPEND}
 
 PATCHES=(
 	"${FILESDIR}/${P}-no-strip.patch"
+	"${FILESDIR}/${P}-fix-designer-plugin-install-location.patch"
 )
 
 src_configure() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/865363
Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>