### PR TITLE
net-libs/libbtbb: remove sourceforge upstream metadata

### DIFF
--- a/net-libs/libbtbb/metadata.xml
+++ b/net-libs/libbtbb/metadata.xml
@@ -7,6 +7,5 @@
 	</maintainer>
 	<upstream>
 		<remote-id type="github">greatscottgadgets/libbtbb</remote-id>
-		<remote-id type="sourceforge">libbtbb</remote-id>
 	</upstream>
 </pkgmetadata>


### PR DESCRIPTION
`pkgcheck scan --net` returns:
```
net-libs/libbtbb
  RedirectedUrl: version 9999: metadata.xml: remote-id: permanently redirected: https://sourceforge.net/projects/libbtbb/ -> https://sourceforge.net/directory/
```
This upstream is obsolete.