### PR TITLE
dev-python/reportlab: revbump 3.6.11-r1, add sparc SIGBUS patch

### DIFF
--- a/dev-python/reportlab/files/reportlab-3.6.11-correct-srclen-type-in-gstate__aapixbuf.patch
+++ b/dev-python/reportlab/files/reportlab-3.6.11-correct-srclen-type-in-gstate__aapixbuf.patch
@@ -1,0 +1,37 @@
+Note:  Upstream development is done in HG, not git; this patch was
+generated using the git mirror at
+https://github.com/MrBitBucket/reportlab-mirror.  Attempted to submit to
+reportlab-users mailing list but it rejected my mail server.
+
+From 9ba2380a68e891667a2659e16d0f04ebe0ecfd19 Mon Sep 17 00:00:00 2001
+From: matoro <matoro@users.noreply.github.com>
+Date: Mon, 4 Jul 2022 18:42:18 -0400
+Subject: [PATCH] correct srclen type in gstate__aapixbuf
+
+gstate__aapixbuf calls PyArg_ParseTuple with the format string
+"ddddy#ii|i".  Specifically the key "y#" will try to read a bytes-like
+object and its size into two Python variables.  The latter of these
+should be of type Py_ssize_t as specified by the C API, but here it is
+incorrectly declared as an int.  This was pointed out to me by the
+cpython developers when I mistakenly identified it as a cpython bug and
+submitted a PR there:  https://github.com/python/cpython/issues/94149
+---
+ src/rl_addons/renderPM/_renderPM.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/rl_addons/renderPM/_renderPM.c b/src/rl_addons/renderPM/_renderPM.c
+index c8415595..bc77d766 100644
+--- a/src/rl_addons/renderPM/_renderPM.c
++++ b/src/rl_addons/renderPM/_renderPM.c
+@@ -1319,7 +1319,7 @@ static	void _reverse_rows_inplace( char *buf, int nrows, int stride)
+ 
+ static PyObject* gstate__aapixbuf(gstateObject* self, PyObject* args)
+ {
+-	int			srclen;
++	Py_ssize_t	srclen;
+ 	double		ctm[6], dstX, dstY, dstW, dstH;
+ 	ArtPixBuf	src;
+ 
+-- 
+2.37.2
+

--- a/dev-python/reportlab/reportlab-3.6.11-r1.ebuild
+++ b/dev-python/reportlab/reportlab-3.6.11-r1.ebuild
@@ -1,0 +1,63 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DISTUTILS_USE_PEP517=setuptools
+PYTHON_COMPAT=( python3_{8..11} )
+
+inherit distutils-r1
+
+DESCRIPTION="Tools for generating printable PDF documents from any data source"
+HOMEPAGE="
+	https://www.reportlab.com/
+	https://pypi.org/project/reportlab/
+"
+SRC_URI="
+	mirror://pypi/${P:0:1}/${PN}/${P}.tar.gz
+	https://www.reportlab.com/ftp/fonts/pfbfer-20070710.zip
+"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux"
+
+DEPEND="
+	media-libs/freetype
+	media-libs/libart_lgpl
+	sys-libs/zlib:=
+"
+RDEPEND="
+	${DEPEND}
+	dev-python/pillow[tiff,truetype,jpeg(+),${PYTHON_USEDEP}]
+"
+BDEPEND="
+	app-arch/unzip
+"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-3.6.9-paths.patch
+	"${FILESDIR}"/${PN}-3.6.11-correct-srclen-type-in-gstate__aapixbuf.patch
+)
+
+distutils_enable_sphinx docs/source
+
+src_unpack() {
+	unpack ${P}.tar.gz
+	cd ${P}/src/reportlab/fonts || die
+	unpack pfbfer-20070710.zip
+}
+
+src_configure() {
+	cat > local-setup.cfg <<-EOF || die
+		[OPTIONS]
+		no-download-t1-files = 1
+		use-system-libart = 1
+	EOF
+}
+
+python_test() {
+	pushd tests >/dev/null || die
+	"${EPYTHON}" runAll.py -v || die "Testing failed with ${EPYTHON}"
+	popd >/dev/null || die
+}


### PR DESCRIPTION
This actually fixes a real bug that normally only would have manifested
under specific conditions (possibly crafted input file) but was revealed
due to sparc's alignment requirements.  Initially misidentified as a
cpython bug [1] but the cpython devs helpfully clarified and pointed in
the right direction [2].

[1] https://github.com/python/cpython/pull/94141
[2] https://github.com/python/cpython/issues/94149

Bug: https://bugs.gentoo.org/857408
Bug: https://bugs.gentoo.org/865051