### PR TITLE
dev-libs/hyperscan: update upstream metadata

### DIFF
--- a/dev-libs/hyperscan/metadata.xml
+++ b/dev-libs/hyperscan/metadata.xml
@@ -10,6 +10,6 @@
 		<name>Proxy Maintainers</name>
 	</maintainer>
 	<upstream>
-		<remote-id type="github">01org/hyperscan</remote-id>
+		<remote-id type="github">intel/hyperscan</remote-id>
 	</upstream>
 </pkgmetadata>


### PR DESCRIPTION
Found with `pkgcheck scan --net`:
```
dev-libs/hyperscan
  RedirectedUrl: version 5.4.0: metadata.xml: remote-id: permanently redirected: https://github.com/01org/hyperscan -> https://github.com/intel/hyperscan
```