### PR TITLE
dev-python/{canonicaljson,unpaddedbase64,signedjson}: correct pypi HOMEPAGE link

### DIFF
--- a/dev-python/canonicaljson/canonicaljson-1.6.2.ebuild
+++ b/dev-python/canonicaljson/canonicaljson-1.6.2.ebuild
@@ -10,8 +10,8 @@ inherit distutils-r1
 
 DESCRIPTION="Canonical JSON"
 HOMEPAGE="
-	https://github.com/matrix-org/python-canonicaljson
-	https://pypi.python.org/pypi/canonicaljson
+	https://github.com/matrix-org/python-canonicaljson/
+	https://pypi.org/project/canonicaljson/
 "
 SRC_URI="https://github.com/matrix-org/python-canonicaljson/archive/v${PV}.tar.gz -> ${P}.gh.tar.gz"
 

--- a/dev-python/signedjson/signedjson-1.1.4.ebuild
+++ b/dev-python/signedjson/signedjson-1.1.4.ebuild
@@ -10,8 +10,8 @@ inherit distutils-r1
 
 DESCRIPTION="Signs JSON objects with ED25519 signatures."
 HOMEPAGE="
-	https://github.com/matrix-org/python-signedjson
-	https://pypi.python.org/pypi/signedjson
+	https://github.com/matrix-org/python-signedjson/
+	https://pypi.org/project/signedjson/
 "
 SRC_URI="https://github.com/matrix-org/python-signedjson/archive/v${PV}.tar.gz -> ${P}.gh.tar.gz"
 

--- a/dev-python/unpaddedbase64/unpaddedbase64-2.1.0.ebuild
+++ b/dev-python/unpaddedbase64/unpaddedbase64-2.1.0.ebuild
@@ -10,8 +10,8 @@ inherit distutils-r1
 
 DESCRIPTION="Unpadded Base64"
 HOMEPAGE="
-	https://github.com/matrix-org/python-unpaddedbase64
-	https://pypi.python.org/pypi/unpaddedbase64
+	https://github.com/matrix-org/python-unpaddedbase64/
+	https://pypi.org/project/unpaddedbase64/
 "
 SRC_URI="https://github.com/matrix-org/python-unpaddedbase64/archive/v${PV}.tar.gz -> ${P}.gh.tar.gz"
 


### PR DESCRIPTION
I found those with `pkgcheck scan --net`:
```
dev-python/unpaddedbase64
  RedirectedUrl: version 2.1.0: HOMEPAGE: permanently redirected: https://pypi.python.org/pypi/unpaddedbase64 -> https://pypi.org/project/unpaddedbase64/

dev-python/canonicaljson
  RedirectedUrl: version 1.6.2: HOMEPAGE: permanently redirected: https://pypi.python.org/pypi/canonicaljson -> https://pypi.org/project/canonicaljson/

dev-python/signedjson
  RedirectedUrl: version 1.1.4: HOMEPAGE: permanently redirected: https://pypi.python.org/pypi/signedjson -> https://pypi.org/project/signedjson/
```