### PR TITLE
haskell: keyword mjo packages ~ppc64

### DIFF
--- a/dev-haskell/configurator/configurator-0.3.0.0-r1.ebuild
+++ b/dev-haskell/configurator/configurator-0.3.0.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -15,7 +15,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~ppc64 ~x86"
 IUSE=""
 
 RDEPEND=">=dev-haskell/attoparsec-0.10.0.2:=[profile?]

--- a/dev-haskell/convertible/convertible-1.1.1.0.ebuild
+++ b/dev-haskell/convertible/convertible-1.1.1.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -15,7 +15,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~ppc64 ~x86"
 IUSE=""
 
 RDEPEND="dev-haskell/mtl:=[profile?]

--- a/dev-haskell/dns/dns-4.0.1.ebuild
+++ b/dev-haskell/dns/dns-4.0.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~ppc64 ~x86"
 IUSE=""
 
 RESTRICT=test # uses internet to test resolver

--- a/dev-haskell/filemanip/filemanip-0.3.6.3.ebuild
+++ b/dev-haskell/filemanip/filemanip-0.3.6.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~ppc64 ~x86"
 IUSE=""
 
 RDEPEND="dev-haskell/mtl:=[profile?]

--- a/dev-haskell/hdbc-postgresql/hdbc-postgresql-2.5.0.0.ebuild
+++ b/dev-haskell/hdbc-postgresql/hdbc-postgresql-2.5.0.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -18,7 +18,7 @@ SRC_URI="https://hackage.haskell.org/package/${MY_P}/${MY_P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="2/${PV}"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~ppc64 ~x86"
 IUSE=""
 
 RDEPEND=">=dev-db/postgresql-7:*

--- a/dev-haskell/hdbc-sqlite3/hdbc-sqlite3-2.3.3.1-r1.ebuild
+++ b/dev-haskell/hdbc-sqlite3/hdbc-sqlite3-2.3.3.1-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -18,7 +18,7 @@ SRC_URI="https://hackage.haskell.org/package/${MY_P}/${MY_P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~ppc64 ~x86"
 IUSE="+splitbase"
 
 RDEPEND=">=dev-db/sqlite-3.0

--- a/dev-haskell/hdbc/hdbc-2.4.0.3.ebuild
+++ b/dev-haskell/hdbc/hdbc-2.4.0.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -18,7 +18,7 @@ SRC_URI="https://hackage.haskell.org/package/${MY_P}/${MY_P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="2/${PV}"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~ppc64 ~x86"
 IUSE=""
 
 RESTRICT="test" # Requires unmaintaned dev-haskell/testpack

--- a/dev-util/shelltestrunner/shelltestrunner-1.9.ebuild
+++ b/dev-util/shelltestrunner/shelltestrunner-1.9.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -12,7 +12,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~ppc64 ~x86"
 IUSE="test"
 RESTRICT="!test? ( test )"
 

--- a/net-mail/list-remote-forwards/list-remote-forwards-0.0.1-r2.ebuild
+++ b/net-mail/list-remote-forwards/list-remote-forwards-0.0.1-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="GPL-3"
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~ppc64 ~x86"
 IUSE=""
 
 RESTRICT=test # Ambiguous packages: dns-3.0.2 resolv-0.1.1.1
@@ -40,6 +40,11 @@ DEPEND="${RDEPEND}
 PATCHES=(
 	"${FILESDIR}"/${P}-ghc84.patch
 )
+
+src_prepare() {
+	sed -i -e "/-optc-O3/d" -e "/-optc-march=native/d" "${PN}.cabal" || die
+	default
+}
 
 src_install() {
 	haskell-cabal_src_install

--- a/net-mail/mailbox-count/mailbox-count-0.0.5.ebuild
+++ b/net-mail/mailbox-count/mailbox-count-0.0.5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -12,7 +12,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="AGPL-3"
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~ppc64 ~x86"
 IUSE=""
 
 RDEPEND="

--- a/net-misc/haeredes/haeredes-0.5.2.ebuild
+++ b/net-misc/haeredes/haeredes-0.5.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -12,7 +12,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="AGPL-3"
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~ppc64 ~x86"
 IUSE=""
 
 # The test suite requires network access.

--- a/net-misc/hath/hath-0.5.0.ebuild
+++ b/net-misc/hath/hath-0.5.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="AGPL-3"
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~ppc64 ~x86"
 IUSE=""
 
 RDEPEND=">=dev-haskell/cmdargs-0.10:=
@@ -28,6 +28,11 @@ DEPEND="${RDEPEND}
 	>=dev-haskell/cabal-1.24.0.0
 	test? ( dev-util/shelltestrunner )
 "
+
+src_prepare() {
+	sed -i -e '/-optc-O3/d' -e '/-optc-march=native/d' "${PN}.cabal" || die
+	default
+}
 
 src_install() {
 	cabal_src_install


### PR DESCRIPTION
`net-mail/list-remote-forwards` and `net-misc/hath` have `-optc-O3 -optc-march=native` hardcoded in their cabal files.  Strip out with sed for now.

CC @orlitzky 