### PR TITLE
app-emulation/virt-manager: add virt-install optfeature in pkg_postinst

### DIFF
--- a/app-emulation/virt-manager/virt-manager-4.1.0.ebuild
+++ b/app-emulation/virt-manager/virt-manager-4.1.0.ebuild
@@ -102,4 +102,5 @@ pkg_postinst() {
 
 	optfeature "SSH_ASKPASS program implementation" lxqt-base/lxqt-openssh-askpass net-misc/ssh-askpass-fullscreen net-misc/x11-ssh-askpass
 	optfeature "QEMU host support" app-emulation/qemu[usbredir,spice]
+	optfeature "virt-install --location ISO support" dev-libs/libisoburn
 }


### PR DESCRIPTION
app-emulation/virt-manager: add virt-install optfeature in pkg_postinst

when useing virt-install, it will fail with missing dev-libs/libisoburn (xorriso) dependency

Closes: https://bugs.gentoo.org/846821
Signed-off-by: Chris Su <chris@lesscrowds.org>