### PR TITLE
games-roguelike/dwarf-fortress: Added gui? USE flag and removed hard dep.

### DIFF
--- a/games-roguelike/dwarf-fortress/dwarf-fortress-0.47.05-r1.ebuild
+++ b/games-roguelike/dwarf-fortress/dwarf-fortress-0.47.05-r1.ebuild
@@ -61,11 +61,7 @@ src_compile() {
 	# -DDEBUG is recognized to give additional debug output
 	append-cppflags -D$(usev !debug N)DEBUG
 
-	if use gui; then
-		emake -f "${FILESDIR}"/Makefile.native
-	else
-		emake -f "${FILESDIR}"/Makefile.native HAVE_GTK=0
-	fi
+	emake -f "${FILESDIR}"/Makefile.native HAVE_GTK=$(usex gui 1 0)
 }
 
 src_install() {

--- a/games-roguelike/dwarf-fortress/dwarf-fortress-0.47.05-r1.ebuild
+++ b/games-roguelike/dwarf-fortress/dwarf-fortress-0.47.05-r1.ebuild
@@ -18,7 +18,7 @@ S="${WORKDIR}/df_linux"
 LICENSE="free-noncomm BSD BitstreamVera"
 SLOT="0"
 KEYWORDS="-* ~amd64 ~x86"
-IUSE="debug gtk"
+IUSE="debug gui"
 
 RDEPEND="
 	dev-libs/glib:2
@@ -29,7 +29,7 @@ RDEPEND="
 	media-libs/sdl-ttf
 	sys-libs/zlib:=
 	virtual/glu
-	gtk? ( x11-libs/gtk+:2 )"
+	gui? ( x11-libs/gtk+:2 )"
 # libsndfile, openal and ncurses are only needed at compile-time,
 # optfeature through dlopen() at runtime if requested
 DEPEND="
@@ -61,7 +61,7 @@ src_compile() {
 	# -DDEBUG is recognized to give additional debug output
 	append-cppflags -D$(usev !debug N)DEBUG
 
-	if use gtk; then
+	if use gui; then
 		emake -f "${FILESDIR}"/Makefile.native
 	else
 		emake -f "${FILESDIR}"/Makefile.native HAVE_GTK=0

--- a/games-roguelike/dwarf-fortress/dwarf-fortress-0.47.05-r1.ebuild
+++ b/games-roguelike/dwarf-fortress/dwarf-fortress-0.47.05-r1.ebuild
@@ -18,7 +18,7 @@ S="${WORKDIR}/df_linux"
 LICENSE="free-noncomm BSD BitstreamVera"
 SLOT="0"
 KEYWORDS="-* ~amd64 ~x86"
-IUSE="debug"
+IUSE="debug gtk"
 
 RDEPEND="
 	dev-libs/glib:2
@@ -29,7 +29,7 @@ RDEPEND="
 	media-libs/sdl-ttf
 	sys-libs/zlib:=
 	virtual/glu
-	x11-libs/gtk+:2"
+	gtk? ( x11-libs/gtk+:2 )"
 # libsndfile, openal and ncurses are only needed at compile-time,
 # optfeature through dlopen() at runtime if requested
 DEPEND="
@@ -44,6 +44,7 @@ QA_PREBUILT="opt/${PN}/libs/Dwarf_Fortress"
 PATCHES=(
 	"${FILESDIR}"/${P}-missing-cmath.patch
 	"${FILESDIR}"/${P}-ncurses6.patch
+	"${FILESDIR}"/${P}-nogtk.patch
 	"${FILESDIR}"/${P}-segfault-fixes.patch
 )
 
@@ -60,7 +61,11 @@ src_compile() {
 	# -DDEBUG is recognized to give additional debug output
 	append-cppflags -D$(usev !debug N)DEBUG
 
-	emake -f "${FILESDIR}"/Makefile.native
+	if use gtk; then
+		emake -f "${FILESDIR}"/Makefile.native
+	else
+		emake -f "${FILESDIR}"/Makefile.native HAVE_GTK=0
+	fi
 }
 
 src_install() {

--- a/games-roguelike/dwarf-fortress/files/Makefile.native
+++ b/games-roguelike/dwarf-fortress/files/Makefile.native
@@ -1,6 +1,8 @@
 # Copyright 2014-2016 Alex Xu (Hello71)
 # Distributed under the terms of the GNU General Public License v2
 
+HAVE_GTK ?= 1
+
 SRCS := g_src/basics.cpp g_src/command_line.cpp g_src/enabler.cpp \
 	g_src/files.cpp g_src/find_files_posix.cpp g_src/graphics.cpp \
 	g_src/init.cpp g_src/interface.cpp g_src/keybindings.cpp \
@@ -11,7 +13,12 @@ SRCS := g_src/basics.cpp g_src/command_line.cpp g_src/enabler.cpp \
 OBJS := $(SRCS:.cpp=.o)
 
 BLIBS := ncursesw openal sndfile
-LIBS := glew glu gtk+-2.0 sdl SDL_image SDL_ttf zlib
+
+LIBS := glew glu sdl SDL_image SDL_ttf zlib
+ifeq ($(HAVE_GTK),1)
+LIBS += gtk+-2.0
+endif
+
 CXXFLAGS ?= -O2 -pipe -Wall -Wextra
 CXXFLAGS += $(shell $(PKG_CONFIG) --cflags $(BLIBS) $(LIBS)) -Dunix -Dlinux -fPIC -std=c++11 -D_GLIBCXX_USE_CXX11_ABI=0
 LDLIBS := $(shell $(PKG_CONFIG) --libs $(LIBS))

--- a/games-roguelike/dwarf-fortress/files/dwarf-fortress-0.47.05-nogtk.patch
+++ b/games-roguelike/dwarf-fortress/files/dwarf-fortress-0.47.05-nogtk.patch
@@ -1,7 +1,5 @@
 Removes hard dependency on GTK in favour of stdin calls.
 
-diff --git a/g_src/KeybindingScreen.cpp b/g_src/KeybindingScreen.cpp
-index 5dd3f2f..4d1a108 100644
 --- a/g_src/KeybindingScreen.cpp
 +++ b/g_src/KeybindingScreen.cpp
 @@ -1,7 +1,9 @@
@@ -15,8 +13,6 @@ index 5dd3f2f..4d1a108 100644
  #endif
  
  #include "GL/glew.h"
-diff --git a/g_src/enabler.cpp b/g_src/enabler.cpp
-index 897d56a..4ea9458 100644
 --- a/g_src/enabler.cpp
 +++ b/g_src/enabler.cpp
 @@ -1,7 +1,9 @@
@@ -30,7 +26,7 @@ index 897d56a..4ea9458 100644
  #endif
  
  #include <cassert>
-@@ -715,7 +717,7 @@ int main (int argc, char* argv[]) {
+@@ -713,7 +715,7 @@ int main (int argc, char* argv[]) {
  #ifdef unix
    setlocale(LC_ALL, "");
  #endif
@@ -39,7 +35,7 @@ index 897d56a..4ea9458 100644
    bool gtk_ok = false;
    if (getenv("DISPLAY"))
      gtk_ok = gtk_init_check(&argc, &argv);
-@@ -736,6 +738,7 @@ int main (int argc, char* argv[]) {
+@@ -734,6 +736,7 @@ int main (int argc, char* argv[]) {
    init.begin(); // Load init.txt settings
    
  #if !defined(__APPLE__) && defined(unix)
@@ -47,7 +43,7 @@ index 897d56a..4ea9458 100644
    if (!gtk_ok && !init.display.flag.has_flag(INIT_DISPLAY_FLAG_TEXT)) {
      puts("Display not found and PRINT_MODE not set to TEXT, aborting.");
      exit(EXIT_FAILURE);
-@@ -745,6 +748,7 @@ int main (int argc, char* argv[]) {
+@@ -743,6 +746,7 @@ int main (int argc, char* argv[]) {
      puts("Graphical tiles are not compatible with text output, sorry");
      exit(EXIT_FAILURE);
    }
@@ -55,8 +51,6 @@ index 897d56a..4ea9458 100644
  #endif
  
    // Initialize video, if we /use/ video
-diff --git a/g_src/renderer_curses.cpp b/g_src/renderer_curses.cpp
-index d93061d..f873784 100644
 --- a/g_src/renderer_curses.cpp
 +++ b/g_src/renderer_curses.cpp
 @@ -1,3 +1,7 @@
@@ -67,20 +61,6 @@ index d93061d..f873784 100644
  static bool curses_initialized = false;
  
  static void endwin_void() {
-diff --git a/g_src/ttf_manager.cpp b/g_src/ttf_manager.cpp
-index aeebc14..ce48a03 100644
---- a/g_src/ttf_manager.cpp
-+++ b/g_src/ttf_manager.cpp
-@@ -2,6 +2,7 @@
- #include "init.h"
- #include <cmath>
- #include <iostream>
-+#include <cmath>
- 
- using namespace std;
- 
-diff --git a/g_src/win32_compat.cpp b/g_src/win32_compat.cpp
-index 44d6ace..02582c7 100644
 --- a/g_src/win32_compat.cpp
 +++ b/g_src/win32_compat.cpp
 @@ -13,7 +13,11 @@
@@ -104,7 +84,7 @@ index 44d6ace..02582c7 100644
      // Have X, will dialog
      GtkWidget *dialog = gtk_message_dialog_new(NULL,
                                                 GTK_DIALOG_DESTROY_WITH_PARENT,
-@@ -141,13 +146,30 @@ int MessageBox(HWND *dummy, const char *text, const char *caption, UINT type)
+@@ -141,6 +146,23 @@ int MessageBox(HWND *dummy, const char *text, const char *caption, UINT type)
          break;
        }
      }
@@ -128,14 +108,6 @@ index 44d6ace..02582c7 100644
    } else {
      // Use curses
      init_curses();
-     erase();
-     gps.force_full_display_count = 1;
-     wattrset(*stdscr_p, A_NORMAL | COLOR_PAIR(1));
--    
-+
-     mvwaddstr(*stdscr_p, 0, 5, caption);
-     mvwaddstr(*stdscr_p, 2, 2, text);
-     nodelay(*stdscr_p, false);
 @@ -173,7 +195,7 @@ int MessageBox(HWND *dummy, const char *text, const char *caption, UINT type)
      }
      nodelay(*stdscr_p, -1);

--- a/games-roguelike/dwarf-fortress/files/dwarf-fortress-0.47.05-nogtk.patch
+++ b/games-roguelike/dwarf-fortress/files/dwarf-fortress-0.47.05-nogtk.patch
@@ -1,0 +1,147 @@
+Removes hard dependency on GTK in favour of stdin calls.
+
+diff --git a/g_src/KeybindingScreen.cpp b/g_src/KeybindingScreen.cpp
+index 5dd3f2f..4d1a108 100644
+--- a/g_src/KeybindingScreen.cpp
++++ b/g_src/KeybindingScreen.cpp
+@@ -1,7 +1,9 @@
+ #ifdef __APPLE__
+ # include "osx_messagebox.h"
+ #elif defined(unix)
+-# include <gtk/gtk.h>
++# ifdef HAVE_GTK
++#  include <gtk/gtk.h>
++# endif
+ #endif
+ 
+ #include "GL/glew.h"
+diff --git a/g_src/enabler.cpp b/g_src/enabler.cpp
+index 897d56a..4ea9458 100644
+--- a/g_src/enabler.cpp
++++ b/g_src/enabler.cpp
+@@ -1,7 +1,9 @@
+ #ifdef __APPLE__
+ # include "osx_messagebox.h"
+ #elif defined(unix)
+-# include <gtk/gtk.h>
++# ifdef HAVE_GTK
++#  include <gtk/gtk.h>
++# endif
+ #endif
+ 
+ #include <cassert>
+@@ -715,7 +717,7 @@ int main (int argc, char* argv[]) {
+ #ifdef unix
+   setlocale(LC_ALL, "");
+ #endif
+-#if !defined(__APPLE__) && defined(unix)
++#if !defined(__APPLE__) && defined(unix) && defined(HAVE_GTK)
+   bool gtk_ok = false;
+   if (getenv("DISPLAY"))
+     gtk_ok = gtk_init_check(&argc, &argv);
+@@ -736,6 +738,7 @@ int main (int argc, char* argv[]) {
+   init.begin(); // Load init.txt settings
+   
+ #if !defined(__APPLE__) && defined(unix)
++ #if defined(HAVE_GTK)
+   if (!gtk_ok && !init.display.flag.has_flag(INIT_DISPLAY_FLAG_TEXT)) {
+     puts("Display not found and PRINT_MODE not set to TEXT, aborting.");
+     exit(EXIT_FAILURE);
+@@ -745,6 +748,7 @@ int main (int argc, char* argv[]) {
+     puts("Graphical tiles are not compatible with text output, sorry");
+     exit(EXIT_FAILURE);
+   }
++ #endif
+ #endif
+ 
+   // Initialize video, if we /use/ video
+diff --git a/g_src/renderer_curses.cpp b/g_src/renderer_curses.cpp
+index d93061d..f873784 100644
+--- a/g_src/renderer_curses.cpp
++++ b/g_src/renderer_curses.cpp
+@@ -1,3 +1,7 @@
++#if defined(__APPLE__) || defined(unix)
++# include <unistd.h>
++#endif
++
+ static bool curses_initialized = false;
+ 
+ static void endwin_void() {
+diff --git a/g_src/ttf_manager.cpp b/g_src/ttf_manager.cpp
+index aeebc14..ce48a03 100644
+--- a/g_src/ttf_manager.cpp
++++ b/g_src/ttf_manager.cpp
+@@ -2,6 +2,7 @@
+ #include "init.h"
+ #include <cmath>
+ #include <iostream>
++#include <cmath>
+ 
+ using namespace std;
+ 
+diff --git a/g_src/win32_compat.cpp b/g_src/win32_compat.cpp
+index 44d6ace..02582c7 100644
+--- a/g_src/win32_compat.cpp
++++ b/g_src/win32_compat.cpp
+@@ -13,7 +13,11 @@
+ # ifdef __APPLE__
+ #  include "osx_messagebox.h"
+ # elif defined(unix)
+-#  include <gtk/gtk.h>
++#  ifdef HAVE_GTK
++#    include <gtk/gtk.h>
++#  else
++#    include <unistd.h>
++#  endif
+ # endif
+ #endif
+ 
+@@ -112,6 +116,7 @@ int MessageBox(HWND *dummy, const char *text, const char *caption, UINT type)
+   }
+ # else // GTK code
+   if (getenv("DISPLAY")) {
++  #ifdef HAVE_GTK
+     // Have X, will dialog
+     GtkWidget *dialog = gtk_message_dialog_new(NULL,
+                                                GTK_DIALOG_DESTROY_WITH_PARENT,
+@@ -141,13 +146,30 @@ int MessageBox(HWND *dummy, const char *text, const char *caption, UINT type)
+         break;
+       }
+     }
++  #else
++    if (isatty(fileno(stdin))) {
++      dprintf(2, "Alert %s:\n%s\n", caption ? caption : "", text ? text : "");
++      if (type & MB_YESNO) {
++        while(ret == IDOK) {
++          dprintf(2, "please answer with 'yes' or 'no'\n");
++          char buf[16];
++          fgets(buf, sizeof buf, stdin);
++          if(!strncmp(buf, "yes", 3)) ret = IDYES;
++          else if(!strncmp(buf, "no", 2)) ret = IDNO;
++        }
++      }
++    } else {
++      /* just assume windowed if no TTY is available to ask */
++      ret = IDNO;
++    }
++  #endif /* HAVE_GTK */
+   } else {
+     // Use curses
+     init_curses();
+     erase();
+     gps.force_full_display_count = 1;
+     wattrset(*stdscr_p, A_NORMAL | COLOR_PAIR(1));
+-    
++
+     mvwaddstr(*stdscr_p, 0, 5, caption);
+     mvwaddstr(*stdscr_p, 2, 2, text);
+     nodelay(*stdscr_p, false);
+@@ -173,7 +195,7 @@ int MessageBox(HWND *dummy, const char *text, const char *caption, UINT type)
+     }
+     nodelay(*stdscr_p, -1);
+   }
+-# endif
++  #endif
+   
+   if (toggle_screen) {
+     enabler.toggle_fullscreen();

--- a/games-roguelike/dwarf-fortress/files/dwarf-fortress-0.47.05-segfault-fixes.patch
+++ b/games-roguelike/dwarf-fortress/files/dwarf-fortress-0.47.05-segfault-fixes.patch
@@ -7,32 +7,40 @@ https://bugs.gentoo.org/729002
 https://www.bay12games.com/dwarves/mantisbt/view.php?id=11564
 --- a/g_src/enabler.cpp
 +++ b/g_src/enabler.cpp
-@@ -591,4 +591,6 @@
+@@ -592,6 +592,8 @@ int enablerst::loop(string cmdline) {
+ 
    // Clean up graphical resources
    delete renderer;
 +
 +  return 0;
  }
  
+ void enablerst::override_grid_size(int x, int y) {
 --- a/g_src/music_and_sound_openal.cpp
 +++ b/g_src/music_and_sound_openal.cpp
-@@ -251,5 +251,4 @@
+@@ -250,7 +250,6 @@ void musicsoundst::deinitsound() {
+     alDeleteBuffers(1, &buffer);
    }
    // Deinit OpenAL
 -  alcMakeContextCurrent(NULL);
    alcDestroyContext(context);
    alcCloseDevice(device);
-@@ -481,5 +480,5 @@
+ 
+@@ -480,7 +479,7 @@ static bool init_openal() {
+ 
  void alEnable( ALenum capability ) { _alEnable(capability); }
  void alDisable( ALenum capability ) { _alDisable(capability); }
 -ALboolean alIsEnabled( ALenum capability ) { _alIsEnabled(capability); }
 +ALboolean alIsEnabled( ALenum capability ) { return _alIsEnabled(capability); }
  const ALchar* alGetString( ALenum param ) { return _alGetString(param); }
  void alGetBooleanv( ALenum param, ALboolean* data ) { _alGetBooleanv(param, data); }
-@@ -491,5 +490,5 @@
+ void alGetIntegerv( ALenum param, ALint* data ) { _alGetIntegerv(param, data); }
+@@ -490,7 +489,7 @@ ALboolean alGetBoolean( ALenum param ) { return _alGetBoolean(param); }
+ ALint alGetInteger( ALenum param ) { return _alGetInteger(param); }
  ALfloat alGetFloat( ALenum param ) { return _alGetFloat(param); }
  ALdouble alGetDouble( ALenum param ) { return _alGetDouble(param); }
 -ALenum alGetError( void ) { _alGetError(); }
 +ALenum alGetError( void ) { return _alGetError(); }
  ALboolean alIsExtensionPresent( const ALchar* extname ) { return _alIsExtensionPresent(extname); }
  void* alGetProcAddress( const ALchar* fname ) { return _alGetProcAddress(fname); }
+ ALenum alGetEnumValue( const ALchar* ename ) { return _alGetEnumValue(ename); }


### PR DESCRIPTION
GTK was required for runtime but was only used for a single fullscreen
dialog prompt when the config [WINDOWED:PROMPT].

Now, if libgraphics is compiled without using GTK, the game will not ask
at all if run from a window manager, but instead open in windowed mode.
However, if the game is run from a terminal, a simple scanf procedure
will ask the user for yes/no before deciding.

See https://bugs.gentoo.org/856685 for previous filing:

> For a quick explanation, the only reason GTK is pulled is for a small dialog when the game is opened which will ask if the user would like to enter fullscreen. The patch has been sitting in svenstaro/dwarf_fortress_unfuck (GitHub) for the past year and a half and I have been using it in order to play without pulling GTK.
> 
> To briefly explain the patch, a make variable HAVE_GTK is introduced and is used to #ifdef all GTK code. If the game is run in a terminal, it should ask the user via. a simple stdin request.