### PR TITLE
app-misc/goobook: revbump for python3_10

### DIFF
--- a/app-misc/goobook/goobook-3.5.1-r3.ebuild
+++ b/app-misc/goobook/goobook-3.5.1-r3.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
-PYTHON_COMPAT=( python3_{8..9} )
+PYTHON_COMPAT=( python3_{8..10} )
 inherit distutils-r1 readme.gentoo-r1
 
 DESCRIPTION="Access your Google contacts from the command line"


### PR DESCRIPTION
Cherry-picked form https://github.com/thinrope/pkalin/commit/8d6c39ce4dd16efb9079bcaf12cb5ca260f4a43a

Tested with python-3.10.5 - works as expected.

NOTE: goobook-3.5.2 is a whole new beast, not easy to support yet.

Bug: https://bugs.gentoo.org/845501
Reported-by: Kalin KOZHUHAROV <kalin@thinrope.net>
Signed-off-by: Kalin KOZHUHAROV <kalin@thinrope.net>
Related: https://bugs.gentoo.org/678398