### PR TITLE
sci-libs/vtk: build with LTO enabled

### DIFF
--- a/sci-libs/vtk/files/vtk-9.1.0-Change-or-scope-struct-names-to-avoid-conflicts.patch
+++ b/sci-libs/vtk/files/vtk-9.1.0-Change-or-scope-struct-names-to-avoid-conflicts.patch
@@ -1,0 +1,126 @@
+From https://gitlab.kitware.com/vtk/vtk/-/commit/0322b938968eebee585ad7efb93bbdade7106355
+From: Aron Helser <aron.helser@kitware.com>
+Date: Mon, 15 Aug 2022 10:06:13 -0400
+Subject: [PATCH 16/30] Change or scope struct names to avoid conflicts.
+
+(cherry picked from commit b79eb46bf5a4277cafc1ed2bd47fd3ffc28a5b3f)
+--- a/IO/AMR/vtkAMRFlashReader.cxx
++++ b/IO/AMR/vtkAMRFlashReader.cxx
+@@ -153,7 +153,7 @@ void vtkAMRFlashReader::ComputeStats(
+ 
+   for (int i = 0; i < internal->NumberOfBlocks; ++i)
+   {
+-    Block& theBlock = internal->Blocks[i];
++    FlashReaderBlock& theBlock = internal->Blocks[i];
+     double* gridMin = theBlock.MinBounds;
+     if (gridMin[0] < min[0])
+     {
+@@ -193,7 +193,7 @@ int vtkAMRFlashReader::FillMetaData()
+ 
+   for (int i = 0; i < this->Internal->NumberOfBlocks; ++i)
+   {
+-    Block& theBlock = this->Internal->Blocks[i];
++    FlashReaderBlock& theBlock = this->Internal->Blocks[i];
+ 
+     // Start numbering levels from 0!
+     int level = this->Internal->Blocks[i].Level - 1;
+--- a/IO/AMR/vtkAMRFlashReaderInternal.cxx
++++ b/IO/AMR/vtkAMRFlashReaderInternal.cxx
+@@ -692,7 +692,7 @@ void vtkFlashReaderInternal::GetBlockMinMaxGlobalDivisionIds()
+ 
+   for (int b = 0; b < this->NumberOfBlocks; b++)
+   {
+-    Block& B = this->Blocks[b];
++    FlashReaderBlock& B = this->Blocks[b];
+ 
+     for (int d = 0; d < 3; d++)
+     {
+--- a/IO/AMR/vtkAMRFlashReaderInternal.h
++++ b/IO/AMR/vtkAMRFlashReaderInternal.h
+@@ -74,7 +74,7 @@ typedef struct tagFlashReaderSimulationParameters
+   double RedShift;
+ } FlashReaderSimulationParameters;
+ 
+-typedef struct tagBlock
++typedef struct tagFlashReaderBlock
+ {
+   int Index;                   // Id of the block
+   int Level;                   // LOD level
+@@ -88,7 +88,7 @@ typedef struct tagBlock
+   double Center[3];            // center of the block
+   double MinBounds[3];         // lower left  of the bounding box
+   double MaxBounds[3];         // upper right of the bounding box
+-} Block;
++} FlashReaderBlock;
+ 
+ typedef struct tagFlashReaderSimulationInformation
+ {
+@@ -152,7 +152,7 @@ public:
+   FlashReaderSimulationInformation SimulationInformation; // CFD simulation
+ 
+   // blocks
+-  std::vector<Block> Blocks;
++  std::vector<FlashReaderBlock> Blocks;
+   std::vector<int> LeafBlocks;
+   std::vector<std::string> AttributeNames;
+ 
+--- a/IO/AMR/vtkAMRVelodyneReader.cxx
++++ b/IO/AMR/vtkAMRVelodyneReader.cxx
+@@ -219,7 +219,7 @@ int vtkAMRVelodyneReader::FillMetaData()
+   double spacing[3];
+   for (int i = 0; i < this->Internal->nBlocks; i++)
+   {
+-    Block& theBlock = this->Internal->Blocks[i];
++    vtkAMRVelodyneReaderInternal::Block& theBlock = this->Internal->Blocks[i];
+     int level = theBlock.Level;
+     int id = theBlock.Index;
+     CalculateBlockDims(this->Internal->blockDims.data(), theBlock.isFull, dims);
+@@ -243,7 +243,7 @@ vtkUniformGrid* vtkAMRVelodyneReader::GetAMRGrid(const int blockIdx)
+   {
+     return nullptr;
+   }
+-  Block& theBlock = this->Internal->Blocks[blockIdx];
++  vtkAMRVelodyneReaderInternal::Block& theBlock = this->Internal->Blocks[blockIdx];
+   int dims[3];
+   CalculateBlockDims(this->Internal->blockDims.data(), theBlock.isFull, dims);
+   vtkUniformGrid* ug = vtkUniformGrid::New();
+--- a/IO/AMR/vtkAMRVelodyneReaderInternal.h
++++ b/IO/AMR/vtkAMRVelodyneReaderInternal.h
+@@ -48,24 +48,20 @@
+ //================================================================================
+ //                          INTERNAL VELODYNE READER
+ //================================================================================
+-typedef struct tagVelodyneSimParameters
+-{
+-  double Time;
+-  int CycleTime;
+-} VelodneSimParameters;
+ 
+-typedef struct tagBlock
+-{
+-  int Index;
+-  int dSetLoc;
+-  int Level;
+-  double Origin[3];
+-  bool isFull;
+-  bool isLeaf;
+-} Block;
+ class vtkAMRVelodyneReaderInternal
+ {
+ public:
++  typedef struct tagVelodyneBlock
++  {
++    int Index;
++    int dSetLoc;
++    int Level;
++    double Origin[3];
++    bool isFull;
++    bool isLeaf;
++  } Block;
++
+   vtkAMRVelodyneReaderInternal();
+   ~vtkAMRVelodyneReaderInternal();
+   void SetFileName(VTK_FILEPATH VTK_FUTURE_CONST char* fileName);
+-- 
+2.37.2
+

--- a/sci-libs/vtk/vtk-9.1.0-r2.ebuild
+++ b/sci-libs/vtk/vtk-9.1.0-r2.ebuild
@@ -145,6 +145,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-9.0.3-IO-FFMPEG-support-FFmpeg-5.0-API-changes.patch
 	"${FILESDIR}"/${P}-adjust-to-find-binaries.patch
 	"${FILESDIR}"/${P}-avoid-naming-collision-with-netcdf-4.9.0.patch
+	"${FILESDIR}"/${P}-Change-or-scope-struct-names-to-avoid-conflicts.patch
 )
 
 DOCS=( CONTRIBUTING.md README.md )


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/863038
Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>

The update applies an upstream patch to address the LTO issues from b.g.o bug #863038. The patch is not applicable for 9.0.3, so only 9.1.0 is addressed.