### PR TITLE
x11-terms/roxterm: Keyword 3.9.4 riscv, #866485

### DIFF
--- a/x11-terms/roxterm/roxterm-3.9.4.ebuild
+++ b/x11-terms/roxterm/roxterm-3.9.4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ SRC_URI="https://github.com/realh/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="GPL-2 LGPL-3"
 SLOT="1"
-KEYWORDS="amd64 x86"
+KEYWORDS="amd64 ~riscv x86"
 
 RDEPEND="dev-libs/dbus-glib
 	dev-libs/glib:2


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/866485

Signed-off-by: Yu Gu <guyu2876@gmail.com>