### PR TITLE
sys-apps/firejail: remove note about sys-apps/firejail-lts

### DIFF
--- a/sys-apps/firejail/metadata.xml
+++ b/sys-apps/firejail/metadata.xml
@@ -14,8 +14,6 @@
 		untrusted applications using Linux namespaces and seccomp-bpf. It allows a process and all its descendants to 
 		have their own private view of the globally shared kernel resources, such as the network stack, process table,
 		mount table.
-
-		This is the regular version. For a long term support version see sys-apps/firejail-lts.
 	</longdescription>
 	<upstream>
 		<remote-id type="cpe">cpe:/a:firejail_project:firejail</remote-id>


### PR DESCRIPTION
This note is obsolete since `sys-apps/firejail-lts` removal from the tree in commit d33a6359c10f - `sys-apps/firejail-lts: treeclean`.