### PR TITLE
sci-mathematics/sha1-polyml: Update package metadata

### DIFF
--- a/sci-mathematics/sha1-polyml/metadata.xml
+++ b/sci-mathematics/sha1-polyml/metadata.xml
@@ -10,8 +10,8 @@
     <name>Gentoo Mathematics Project</name>
   </maintainer>
   <longdescription lang="en">
-sci-mathematics/sha1-polyml is the implementation of SHA1 taken from
-the GNU coreutils package as described in the sci-mathematics/sha1-polyml
-README.  It is required by sci-mathematics/isabelle.
-</longdescription>
+    <pkg>sci-mathematics/sha1-polyml</pkg> is the implementation of SHA1 taken from
+    the GNU coreutils package as described in the <pkg>sci-mathematics/sha1-polyml</pkg>
+    README.
+  </longdescription>
 </pkgmetadata>


### PR DESCRIPTION
- Fix indentation
- Use `<pkg>` tags in `<longdescription>`
- Remove note about sci-mathematics/isabelle package which is not in the tree since commit 7d2aafd09b8f - `sci-mathematics/isabelle: Remove last-rited pkg`