### PR TITLE
sci-libs/rocSOLVER: restrict to dev-libs/libfmt-8

### DIFF
--- a/sci-libs/rocSOLVER/rocSOLVER-5.0.2.ebuild
+++ b/sci-libs/rocSOLVER/rocSOLVER-5.0.2.ebuild
@@ -17,7 +17,7 @@ IUSE="test benchmark"
 
 RDEPEND="dev-util/hip
 	sci-libs/rocBLAS:${SLOT}
-	>=dev-libs/libfmt-8
+	=dev-libs/libfmt-8*
 	benchmark? ( virtual/blas )"
 DEPEND="${RDEPEND}"
 BDEPEND="test? ( dev-cpp/gtest


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/866839