### PR TITLE
dev-java/jakarta-json-api: java 11 for module-info

### DIFF
--- a/dev-java/jakarta-json-api/jakarta-json-api-1.1.6-r1.ebuild
+++ b/dev-java/jakarta-json-api/jakarta-json-api-1.1.6-r1.ebuild
@@ -14,28 +14,18 @@ MY_P="${MY_PN}-${MY_PV}"
 
 DESCRIPTION="JSR 374 (JSON Processing) API"
 HOMEPAGE="https://projects.eclipse.org/projects/ee4j.jsonp"
-SRC_URI="https://github.com/eclipse-ee4j/jsonp/archive/refs/tags/${MY_PV}.tar.gz -> ${P}.tar.gz"
+SRC_URI="https://github.com/eclipse-ee4j/jsonp/archive/${MY_PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="|| ( EPL-2.0 GPL-2-with-classpath-exception )"
 # Since version 2.0.0, the namespace has changed to jakarta.json
 SLOT="1"
 KEYWORDS="amd64 ~arm arm64 ppc64 x86"
 
-DEPEND="
-	>=virtual/jdk-1.8:*
-"
-
-RDEPEND="
-	>=virtual/jre-1.8:*
-"
+DEPEND=">=virtual/jdk-11:*"
+RDEPEND=">=virtual/jre-1.8:*"
 
 S="${WORKDIR}/${MY_P}"
 
 JAVA_SRC_DIR="api/src/main"
 
 DOCS=( CONTRIBUTING.md NOTICE.md README.md )
-
-src_install() {
-	java-pkg-simple_src_install
-	einstalldocs # https://bugs.gentoo.org/789582
-}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/866923
Signed-off-by: Volkmar W. Pogatzki <gentoo@pogatzki.net>