### PR TITLE
net-dns/dnsmasq: allow multiple instances

### DIFF
--- a/net-dns/dnsmasq/files/dnsmasq-init-r4
+++ b/net-dns/dnsmasq/files/dnsmasq-init-r4
@@ -4,7 +4,7 @@
 
 extra_started_commands="reload rotate"
 
-pidfile="/var/run/dnsmasq.pid"
+pidfile="/var/run/${RC_SVCNAME}.pid"
 command="/usr/sbin/dnsmasq"
 command_args="-x ${pidfile} ${DNSMASQ_OPTS}"
 retry="TERM/3/TERM/5"


### PR DESCRIPTION
A minimalist approach to allow multiple dnsmasq instances.
* Related ticket: https://bugs.gentoo.org/282397 (It has a diff attached, which also handles the config file, but this version works as well, as the config file can be set via the `conf.d` file.)
* I don't know if it should be `${RC_SVCNAME}` or `${SVCNAME}`, but used the first, as it's used in this script in other places as well.
* Maybe it should be `/run/` instead of `/var/run/`, but then the related logrotate fragment should probably be changed as well.

(Not sure if the commit should also contain renames of the ebuilds, like `dnsmasq-2.85.ebuild` -> `dnsmasq-2.85-r1.ebuild` and `dnsmasq-2.86-r1.ebuild` -> `dnsmasq-2.86-r2.ebuild`, any hints? Feel free to update my commit as required, thanks!)