### PR TITLE
dev-util/strace: fix live ebuild

### DIFF
--- a/dev-util/strace/strace-9999.ebuild
+++ b/dev-util/strace/strace-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit autotools flag-o-matic toolchain-funcs
+inherit autotools edo flag-o-matic toolchain-funcs
 
 if [[ ${PV} == 9999 ]] ; then
 	EGIT_REPO_URI="https://github.com/strace/strace.git"
@@ -45,15 +45,14 @@ PATCHES=(
 src_prepare() {
 	default
 
-	eautoreconf
-
 	if [[ ! -e configure ]] ; then
 		# git generation
 		sed /autoreconf/d -i bootstrap || die
-		./bootstrap || die
-		eautoreconf
+		edo ./bootstrap
 		[[ ! -e CREDITS ]] && cp CREDITS{.in,}
 	fi
+
+	eautoreconf
 
 	# Stub out the -k test since it's known to be flaky. bug #545812
 	sed -i '1iexit 77' tests*/strace-k.test || die


### PR DESCRIPTION
It is necessary to call `./bootstrap` script before `eautoreconf`, otherwise `automake` fails complaining about missing files or directories. The live ebuild is broken since commit a6b222b1be5b, where `eautoreconf` started to be used even for non-live ebuilds, but it was wrongly placed.

Additionally, edo function is used for `./bootstrap` call.

Example of failure before this fix:
```
>>> Preparing source in /var/tmp/portage/dev-util/strace-9999/work/strace-9999 ...
 * Applying strace-5.11-static.patch ...
patching file configure.ac
Hunk #1 succeeded at 54 with fuzz 2 (offset 7 lines).
patching file m4/st_libdw.m4
patching file m4/st_libunwind.m4
patching file src/Makefile.am
Hunk #1 succeeded at 414 (offset 21 lines).                                                                     [ ok ]
 * Running eautoreconf in '/var/tmp/portage/dev-util/strace-9999/work/strace-9999' ...
 * Running 'aclocal -I m4 -I src/xlat --system-acdir=/var/tmp/portage/dev-util/strace-9999/temp/aclocal' ...    [ ok ]
 * Running 'autoconf --force' ...                                                                               [ ok ]
 * Running 'autoheader' ...                                                                                     [ ok ]
 * Running 'automake --add-missing --copy --foreign --force-missing' ...                                        [ !! ]

 * Failed running 'automake'!
 *
 * Include in your bug report the contents of:
 *
 *   /var/tmp/portage/dev-util/strace-9999/temp/automake.out

 * ERROR: dev-util/strace-9999::gentoo failed (prepare phase):
 *   Failed running 'automake'!
 *
 * Call stack:
 *     ebuild.sh, line  127:  Called src_prepare
 *   environment, line 2706:  Called eautoreconf
 *   environment, line 1443:  Called eautomake
 *   environment, line 1397:  Called autotools_run_tool 'automake' '--add-missing' '--copy' '--foreign' '--force-missing'
 *   environment, line 1127:  Called die
 * The specific snippet of code:
 *           die "Failed running '${1}'!";
```

Content of `/var/tmp/portage/dev-util/strace-9999/temp/automake.out`:
```
***** automake *****
***** PWD: /var/tmp/portage/dev-util/strace-9999/work/strace-9999
***** automake --add-missing --copy --foreign --force-missing

configure.ac:353: installing 'build-aux/ar-lib'
configure.ac:39: installing 'build-aux/compile'
configure.ac:32: installing 'build-aux/config.guess'
configure.ac:32: installing 'build-aux/config.sub'
configure.ac:30: installing 'build-aux/install-sh'
configure.ac:30: installing 'build-aux/missing'
configure.ac:801: error: required file 'tests-m32/Makefile.in' not found
configure.ac:801: error: required file 'tests-mx32/Makefile.in' not found
Makefile.am:13: error: required directory ./tests-m32 does not exist
Makefile.am:16: error: required directory ./tests-mx32 does not exist
automake-1.16: error: cannot open < src/xlat/Makemodule.am: No such file or directory
```