### PR TITLE
eclass/cmake.eclass: add CMAKE_SKIP_TESTS

### DIFF
--- a/eclass/cmake.eclass
+++ b/eclass/cmake.eclass
@@ -124,6 +124,12 @@ fi
 # read-only. This is a user flag and should under _no circumstances_ be set in
 # the ebuild. Helps in improving QA of build systems that write to source tree.
 
+# @ECLASS_VARIABLE: CMAKE_SKIP_TESTS
+# @USER_VARIABLE
+# @DEFAULT_UNSET
+# @DESCRIPTION:
+# Array of tests that should be skipped when running CTest.
+
 [[ ${CMAKE_MIN_VERSION} ]] && die "CMAKE_MIN_VERSION is banned; if necessary, set BDEPEND=\">=dev-util/cmake-${CMAKE_MIN_VERSION}\" directly"
 [[ ${CMAKE_BUILD_DIR} ]] && die "The ebuild must be migrated to BUILD_DIR"
 [[ ${CMAKE_REMOVE_MODULES} ]] && die "CMAKE_REMOVE_MODULES is banned, set CMAKE_REMOVE_MODULES_LIST array instead"
@@ -666,6 +672,7 @@ cmake_src_test() {
 	[[ -e CTestTestfile.cmake ]] || { echo "No tests found. Skipping."; return 0 ; }
 
 	[[ -n ${TEST_VERBOSE} ]] && myctestargs+=( --extra-verbose --output-on-failure )
+	[[ -n ${CMAKE_SKIP_TESTS} ]] && myctestargs+=( -E '('$( IFS='|'; echo "${CMAKE_SKIP_TESTS[*]}")')'  )
 
 	set -- ctest -j "$(makeopts_jobs "${MAKEOPTS}" 999)" \
 		--test-load "$(makeopts_loadavg)" "${myctestargs[@]}" "$@"


### PR DESCRIPTION
Because CTest does not allow you to pass multiple -E arguments, this makes it a lot easier to specify skipped tests multiple times. An example of when this is useful is when you have a list of tests that needs to be disabled unconditionally, and then conditionally disable some.

```
src_test() {
CMAKE_SKIP_TESTS=(test1 test2 test3)
some_condition || CMAKE_SKIP_TESTS+=( test4 test5 test6 )
...
}
```

Signed-off-by: Alfred Persson Forsberg <cat@catcream.org>