### PR TITLE
sys-devel/binutils: add custom-cflags USE flag

### DIFF
--- a/sys-devel/binutils/binutils-2.32-r2.ebuild
+++ b/sys-devel/binutils/binutils-2.32-r2.ebuild
@@ -160,7 +160,7 @@ src_configure() {
 	strip-linguas -u */po
 
 	# Keep things sane
-	strip-flags
+	use custom-cflags || strip-flags
 
 	local x
 	echo

--- a/sys-devel/binutils/binutils-2.33.1-r1.ebuild
+++ b/sys-devel/binutils/binutils-2.33.1-r1.ebuild
@@ -153,7 +153,7 @@ src_configure() {
 	strip-linguas -u */po
 
 	# Keep things sane
-	strip-flags
+	use custom-cflags || strip-flags
 
 	local x
 	echo

--- a/sys-devel/binutils/binutils-2.34-r2.ebuild
+++ b/sys-devel/binutils/binutils-2.34-r2.ebuild
@@ -150,7 +150,7 @@ src_configure() {
 	strip-linguas -u */po
 
 	# Keep things sane
-	strip-flags
+	use custom-cflags || strip-flags
 
 	local x
 	echo

--- a/sys-devel/binutils/binutils-2.35.2.ebuild
+++ b/sys-devel/binutils/binutils-2.35.2.ebuild
@@ -167,7 +167,7 @@ src_configure() {
 	strip-linguas -u */po
 
 	# Keep things sane
-	strip-flags
+	use custom-cflags || strip-flags
 
 	local x
 	echo

--- a/sys-devel/binutils/binutils-2.36.1-r2.ebuild
+++ b/sys-devel/binutils/binutils-2.36.1-r2.ebuild
@@ -162,7 +162,7 @@ src_configure() {
 	strip-linguas -u */po
 
 	# Keep things sane
-	strip-flags
+	use custom-cflags || strip-flags
 
 	local x
 	echo

--- a/sys-devel/binutils/binutils-2.37_p1-r2.ebuild
+++ b/sys-devel/binutils/binutils-2.37_p1-r2.ebuild
@@ -168,7 +168,7 @@ src_configure() {
 	strip-linguas -u */po
 
 	# Keep things sane
-	strip-flags
+	use custom-cflags || strip-flags
 
 	use elibc_musl && append-ldflags -Wl,-z,stack-size=2097152
 

--- a/sys-devel/binutils/binutils-2.38-r1.ebuild
+++ b/sys-devel/binutils/binutils-2.38-r1.ebuild
@@ -168,7 +168,7 @@ src_configure() {
 	strip-linguas -u */po
 
 	# Keep things sane
-	strip-flags
+	use custom-cflags || strip-flags
 
 	use elibc_musl && append-ldflags -Wl,-z,stack-size=2097152
 

--- a/sys-devel/binutils/binutils-2.38-r2.ebuild
+++ b/sys-devel/binutils/binutils-2.38-r2.ebuild
@@ -174,7 +174,7 @@ src_configure() {
 	strip-linguas -u */po
 
 	# Keep things sane
-	strip-flags
+	use custom-cflags || strip-flags
 
 	use elibc_musl && append-ldflags -Wl,-z,stack-size=2097152
 

--- a/sys-devel/binutils/binutils-2.39.ebuild
+++ b/sys-devel/binutils/binutils-2.39.ebuild
@@ -171,7 +171,7 @@ src_configure() {
 	strip-linguas -u */po
 
 	# Keep things sane
-	strip-flags
+	use custom-cflags || strip-flags
 
 	use elibc_musl && append-ldflags -Wl,-z,stack-size=2097152
 

--- a/sys-devel/binutils/binutils-9999.ebuild
+++ b/sys-devel/binutils/binutils-9999.ebuild
@@ -170,7 +170,7 @@ src_configure() {
 	strip-linguas -u */po
 
 	# Keep things sane
-	strip-flags
+	use custom-cflags || strip-flags
 
 	use elibc_musl && append-ldflags -Wl,-z,stack-size=2097152
 

--- a/sys-devel/binutils/metadata.xml
+++ b/sys-devel/binutils/metadata.xml
@@ -7,6 +7,7 @@
 	</maintainer>
 	<use>
 		<flag name="cet">Enable Intel Control-flow Enforcement Technology.</flag>
+		<flag name="custom-cflags">Bypass strip-flags; use at your own peril</flag>
 		<flag name="default-gold">Set ld to point to ld.gold instead of ld.bfd</flag>
 		<flag name="gold">Build ld.gold linker</flag>
 		<flag name="gprofng">Enable the next-generation gprofng profiler</flag>


### PR DESCRIPTION
Gentoo Prefix bootstrap stage3 needs to add `-B${ROOT}/usr/$(get_libdir)`
to `LDFLAGS` to pick up correct `*crt*.o` files but this flag is
stripped for binutils. Allow overriding this via `custom-cflags` USE flag
as in other ebuilds (e.g. `sys-libs/glibc`).

Bug: https://bugs.gentoo.org/824482
Signed-off-by: Bart Oldeman <bart.oldeman@calculquebec.ca>