### PR TITLE
dev-libs/libxlsxwriter: fixes pkg-config file ver

### DIFF
--- a/dev-libs/libxlsxwriter/files/libxlsxwriter-1.1.4-fix-pkgconfig-version.patch
+++ b/dev-libs/libxlsxwriter/files/libxlsxwriter-1.1.4-fix-pkgconfig-version.patch
@@ -1,0 +1,18 @@
+Patch greedy dot star to fix mismatched pkg-config file version.
+Fixed upstream with: https://github.com/jmcnamara/libxlsxwriter/commit/12afb351db634ed9452eb2f38d68883a9538b8ef
+https://bugs.gentoo.org/859745
+
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -202,9 +202,9 @@
+ # Configure pkg-config
+ file(READ "include/xlsxwriter.h" ver)
+ 
+-string(REGEX MATCH "LXW_VERSION .*\"\(.*\)\".*" _ ${ver})
++string(REGEX MATCH "LXW_VERSION \"([^\"]+)\"" _ ${ver})
+ set(VERSION ${CMAKE_MATCH_1})
+-string(REGEX MATCH "LXW_SOVERSION .*\"\(.*\)\".*" _ ${ver})
++string(REGEX MATCH "LXW_SOVERSION \"([^\"]+)\"" _ ${ver})
+ set(SOVERSION ${CMAKE_MATCH_1})
+ set(PREFIX ${CMAKE_INSTALL_PREFIX})
+ 

--- a/dev-libs/libxlsxwriter/libxlsxwriter-1.1.4.ebuild
+++ b/dev-libs/libxlsxwriter/libxlsxwriter-1.1.4.ebuild
@@ -21,6 +21,10 @@ DEPEND="
 "
 RDEPEND="${DEPEND}"
 
+PATCHES=(
+	"${FILESDIR}"/${P}-fix-pkgconfig-version.patch
+)
+
 src_configure() {
 	DOUBLEFUNCTION=OFF
 	for x in $(plocale_get_locales); do


### PR DESCRIPTION
The xlsxwriter.pc had incorrect version because of
greedy dot star. The issue is fixed upstream, this
patch should do before there is a new version.

Bug: https://bugs.gentoo.org/859745
Signed-off-by: Efe İzbudak <efe.izbudak@metu.edu.tr>