### PR TITLE
app-arch/lz4: enable tests (switch to custom Makefiles)

### DIFF
--- a/app-arch/lz4/lz4-1.9.4-r1.ebuild
+++ b/app-arch/lz4/lz4-1.9.4-r1.ebuild
@@ -1,0 +1,48 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+# CMake build doesn't support tests, bug #866097
+inherit multilib-minimal toolchain-funcs
+
+DESCRIPTION="Extremely Fast Compression algorithm"
+HOMEPAGE="https://github.com/lz4/lz4"
+SRC_URI="https://github.com/lz4/lz4/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="BSD-2 GPL-2"
+# https://abi-laboratory.pro/tracker/timeline/lz4/
+SLOT="0/r132"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+IUSE="static-libs"
+
+src_prepare() {
+	default
+
+	multilib_copy_sources
+}
+
+mymake() {
+	emake \
+		CC="$(tc-getCC)" \
+		CXX="$(tc-getCXX)" \
+		AR="$(tc-getAR)" \
+		PREFIX="${EPREFIX}/usr" \
+		LIBDIR="${EPREFIX}/usr/$(get_libdir)" \
+		BUILD_SHARED=yes \
+		BUILD_STATIC=$(usex static-libs) \
+		V=1 \
+		"${@}"
+}
+
+multilib_src_compile() {
+	mymake
+}
+
+multilib_src_test() {
+	mymake check
+}
+
+multilib_src_install() {
+	mymake DESTDIR="${D}" install
+}


### PR DESCRIPTION
Bit sad given it has a CMake build system (but it's kind of
unofficial, and then the Meson build system is even more
unofficial, as it's in "contrib", and there's a PR pending
to bump it to 1.9.4).

But in any case, this is really the same as app-arch/zstd
(same upstream) and anything but Makefiles aren't properly
supported and don't have all the needed functionality.

So, we switch to the Makefiles for tests.

Also has a benefit of not having weird symbol
leakage.

Closes: https://bugs.gentoo.org/866097
Signed-off-by: Sam James <sam@gentoo.org>