### PR TITLE
app-crypt/gpgme: Fix the build with slibtool

### DIFF
--- a/app-crypt/gpa/files/gpa-0.10.0-autoconf.patch
+++ b/app-crypt/gpa/files/gpa-0.10.0-autoconf.patch
@@ -1,0 +1,1111 @@
+Upstream: https://dev.gnupg.org/rGPAb40ff3b1f20dec3b14ca72d0af50137e38cd1808
+
+From b40ff3b1f20dec3b14ca72d0af50137e38cd1808 Mon Sep 17 00:00:00 2001
+From: NIIBE Yutaka <gniibe@fsij.org>
+Date: Fri, 20 Nov 2020 12:02:53 +0900
+Subject: [PATCH] build: Update to newer autoconf constructs.
+
+* configure.ac: Use AC_CONFIG_HEADERS instead of AM_CONFIG_HEADER.
+Use AC_USE_SYSTEM_EXTENSIONS instead of AC_GNU_SOURCE.
+Use AS_HELP_STRING instead of AC_HELP_STRING.
+(AC_ISC_POSIX): Replace by AC_SEARCH_LIBS.
+(AC_STDC_HEADERS): Replace by AC_HEADER_STDC.
+(byte, ushort, ulong, u16, u32): Use AC_CHECK_TYPES.
+* m4/check_zlib.m4: Use AS_HELP_STRING instead of AC_HELP_STRING.
+Use AC_MSG_ERROR instead of AC_ERROR.
+* m4/gettext.m4: Update from gnulib.
+* m4/gpg-error.m4: Update from libgpg-error.
+* m4/gpgme.m4: Update from gpgme.
+* m4/libassuan.m4: Update from libassuan.
+
+Signed-off-by: NIIBE Yutaka <gniibe@fsij.org>
+---
+ configure.ac     |  23 +++---
+ m4/check_zlib.m4 |   4 +-
+ m4/gettext.m4    | 155 ++++++++++++++++++++--------------------
+ m4/gpg-error.m4  | 157 ++++++++++++++++++++++++++++++++++++-----
+ m4/gpgme.m4      | 180 +++++++++++++++++++++++++----------------------
+ m4/libassuan.m4  | 141 ++++++++++++++++++-------------------
+ 6 files changed, 396 insertions(+), 264 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index 462d573..4c1804f 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -19,7 +19,7 @@
+ # along with this program; if not, see <http://www.gnu.org/licenses/>.
+ #
+ # (Process this file with autoconf to produce a configure script.)
+-AC_PREREQ(2.61)
++AC_PREREQ([2.61])
+ min_automake_version="1.10"
+ 
+ # The version number goes here.
+@@ -58,7 +58,7 @@ NEED_GPGME_API=1
+ NEED_GPGME_VERSION=1.9.0
+ 
+ AC_CONFIG_AUX_DIR([build-aux])
+-AM_CONFIG_HEADER(config.h)
++AC_CONFIG_HEADERS([config.h])
+ AC_CONFIG_SRCDIR(src/gpa.c)
+ AM_INIT_AUTOMAKE([dist-bzip2 no-dist-gzip])
+ 
+@@ -99,7 +99,7 @@ AC_DEFINE_UNQUOTED(BUILD_TIMESTAMP, "$BUILD_TIMESTAMP",
+ 
+ 
+ 
+-AC_GNU_SOURCE
++AC_USE_SYSTEM_EXTENSIONS
+ 
+ AH_BOTTOM([
+ /* We don't want the old assuan codes anymore. */
+@@ -159,8 +159,8 @@ AM_MISSING_PROG(AUTOMAKE, automake, $missing_dir)
+ AM_MISSING_PROG(AUTOHEADER, autoheader, $missing_dir)
+ AM_MISSING_PROG(MAKEINFO, makeinfo, $missing_dir)
+ AC_PROG_CC
+-AC_ISC_POSIX
+-AC_STDC_HEADERS
++AC_SEARCH_LIBS([strerror],[cposix])
++AC_HEADER_STDC
+ AC_PROG_RANLIB
+ AC_CHECK_TOOL(WINDRES, windres, :)
+ 
+@@ -171,7 +171,7 @@ AC_CHECK_TOOL(WINDRES, windres, :)
+ card_manager=yes
+ AC_MSG_CHECKING([whether to build the card manager])
+ AC_ARG_ENABLE(card-manager,
+-              AC_HELP_STRING([--disable-card-manager],
++              AS_HELP_STRING([--disable-card-manager],
+                              [build without the card manager]),
+               card_manager=$enableval)
+ AC_MSG_RESULT($card_manager)
+@@ -183,7 +183,7 @@ AM_CONDITIONAL(ENABLE_CARD_MANAGER, test "$card_manager" = yes)
+ keyserver_support=yes
+ AC_MSG_CHECKING([whether to include keyserver support])
+ AC_ARG_ENABLE(keyserver-support,
+-              AC_HELP_STRING([--disable-keyserver-support],
++              AS_HELP_STRING([--disable-keyserver-support],
+                              [build without keyserver support]),
+               keyserver_support=$enableval)
+ AC_MSG_RESULT($keyserver_support)
+@@ -313,12 +313,7 @@ AC_CHECK_HEADERS([locale.h])
+ #
+ # Checks for typedefs and structures
+ #
+-
+-GNUPG_CHECK_TYPEDEF(byte, HAVE_BYTE_TYPEDEF)
+-GNUPG_CHECK_TYPEDEF(ushort, HAVE_USHORT_TYPEDEF)
+-GNUPG_CHECK_TYPEDEF(ulong, HAVE_ULONG_TYPEDEF)
+-GNUPG_CHECK_TYPEDEF(u16, HAVE_U16_TYPEDEF)
+-GNUPG_CHECK_TYPEDEF(u32, HAVE_U32_TYPEDEF)
++AC_CHECK_TYPES([byte, ushort, ulong, u16, u32])
+ 
+ #
+ # Check for library functions
+@@ -476,4 +471,4 @@ echo "
+ 
+         Revision:  mym4_revision  (mym4_revision_dec)
+         Platform:  $host
+-"
+\ No newline at end of file
++"
+diff --git a/m4/check_zlib.m4 b/m4/check_zlib.m4
+index d5088d3..9836653 100644
+--- a/m4/check_zlib.m4
++++ b/m4/check_zlib.m4
+@@ -12,7 +12,7 @@
+ 
+ dnl zlib test
+ AC_DEFUN([CHECK_ZLIB], [
+-AC_ARG_WITH(zlib, AC_HELP_STRING([--with-zlib=PATH],
++AC_ARG_WITH(zlib, AS_HELP_STRING([--with-zlib=PATH],
+ [Look for zlib library installed in PATH/lib and headers in
+ PATH/include rather than default include and library paths. (Use an
+ absolute path)]),
+@@ -22,7 +22,7 @@ absolute path)]),
+ 
+ AC_CHECK_LIB(z, compress,
+ 	LIBS="$LIBS -lz", 
+-	AC_ERROR([GPA requires zlib (http://gzip.org/zlib or install Debian package zlib1g-dev)]))
++	AC_MSG_ERROR([GPA requires zlib (https://zlib.net/ or install Debian package zlib1g-dev)]))
+ 
+ AC_SUBST(LIBZ)
+ ])
+diff --git a/m4/gettext.m4 b/m4/gettext.m4
+index f84e6a5..4f25a27 100644
+--- a/m4/gettext.m4
++++ b/m4/gettext.m4
+@@ -1,16 +1,16 @@
+-# gettext.m4 serial 63 (gettext-0.18)
+-dnl Copyright (C) 1995-2010 Free Software Foundation, Inc.
++# gettext.m4 serial 71 (gettext-0.20.2)
++dnl Copyright (C) 1995-2014, 2016, 2018-2020 Free Software Foundation, Inc.
+ dnl This file is free software; the Free Software Foundation
+ dnl gives unlimited permission to copy and/or distribute it,
+ dnl with or without modifications, as long as this notice is preserved.
+ dnl
+-dnl This file can can be used in projects which are not available under
+-dnl the GNU General Public License or the GNU Library General Public
++dnl This file can be used in projects which are not available under
++dnl the GNU General Public License or the GNU Lesser General Public
+ dnl License but which still want to provide support for the GNU gettext
+ dnl functionality.
+ dnl Please note that the actual code of the GNU gettext library is covered
+-dnl by the GNU Library General Public License, and the rest of the GNU
+-dnl gettext package package is covered by the GNU General Public License.
++dnl by the GNU Lesser General Public License, and the rest of the GNU
++dnl gettext package is covered by the GNU General Public License.
+ dnl They are *not* in the public domain.
+ 
+ dnl Authors:
+@@ -20,22 +20,20 @@ dnl   Bruno Haible <haible@clisp.cons.org>, 2000-2006, 2008-2010.
+ dnl Macro to add for using GNU gettext.
+ 
+ dnl Usage: AM_GNU_GETTEXT([INTLSYMBOL], [NEEDSYMBOL], [INTLDIR]).
+-dnl INTLSYMBOL can be one of 'external', 'no-libtool', 'use-libtool'. The
+-dnl    default (if it is not specified or empty) is 'no-libtool'.
+-dnl    INTLSYMBOL should be 'external' for packages with no intl directory,
+-dnl    and 'no-libtool' or 'use-libtool' for packages with an intl directory.
++dnl INTLSYMBOL must be one of 'external', 'use-libtool'.
++dnl    INTLSYMBOL should be 'external' for packages other than GNU gettext, and
++dnl    'use-libtool' for the packages 'gettext-runtime' and 'gettext-tools'.
+ dnl    If INTLSYMBOL is 'use-libtool', then a libtool library
+ dnl    $(top_builddir)/intl/libintl.la will be created (shared and/or static,
+ dnl    depending on --{enable,disable}-{shared,static} and on the presence of
+-dnl    AM-DISABLE-SHARED). If INTLSYMBOL is 'no-libtool', a static library
+-dnl    $(top_builddir)/intl/libintl.a will be created.
++dnl    AM-DISABLE-SHARED).
+ dnl If NEEDSYMBOL is specified and is 'need-ngettext', then GNU gettext
+ dnl    implementations (in libc or libintl) without the ngettext() function
+ dnl    will be ignored.  If NEEDSYMBOL is specified and is
+ dnl    'need-formatstring-macros', then GNU gettext implementations that don't
+ dnl    support the ISO C 99 <inttypes.h> formatstring macros will be ignored.
+ dnl INTLDIR is used to find the intl libraries.  If empty,
+-dnl    the value `$(top_builddir)/intl/' is used.
++dnl    the value '$(top_builddir)/intl/' is used.
+ dnl
+ dnl The result of the configuration is one of three cases:
+ dnl 1) GNU gettext, as included in the intl subdirectory, will be compiled
+@@ -57,19 +55,17 @@ dnl
+ AC_DEFUN([AM_GNU_GETTEXT],
+ [
+   dnl Argument checking.
+-  ifelse([$1], [], , [ifelse([$1], [external], , [ifelse([$1], [no-libtool], , [ifelse([$1], [use-libtool], ,
++  ifelse([$1], [], , [ifelse([$1], [external], , [ifelse([$1], [use-libtool], ,
+     [errprint([ERROR: invalid first argument to AM_GNU_GETTEXT
+-])])])])])
++])])])])
+   ifelse(ifelse([$1], [], [old])[]ifelse([$1], [no-libtool], [old]), [old],
+-    [AC_DIAGNOSE([obsolete], [Use of AM_GNU_GETTEXT without [external] argument is deprecated.])])
++    [errprint([ERROR: Use of AM_GNU_GETTEXT without [external] argument is no longer supported.
++])])
+   ifelse([$2], [], , [ifelse([$2], [need-ngettext], , [ifelse([$2], [need-formatstring-macros], ,
+     [errprint([ERROR: invalid second argument to AM_GNU_GETTEXT
+ ])])])])
+   define([gt_included_intl],
+-    ifelse([$1], [external],
+-      ifdef([AM_GNU_GETTEXT_][INTL_SUBDIR], [yes], [no]),
+-      [yes]))
+-  define([gt_libtool_suffix_prefix], ifelse([$1], [use-libtool], [l], []))
++    ifelse([$1], [external], [no], [yes]))
+   gt_NEEDS_INIT
+   AM_GNU_GETTEXT_NEED([$2])
+ 
+@@ -91,13 +87,12 @@ AC_DEFUN([AM_GNU_GETTEXT],
+   dnl again, outside any 'if'. There are two solutions:
+   dnl - Invoke AM_ICONV_LINKFLAGS_BODY here, outside any 'if'.
+   dnl - Control the expansions in more detail using AC_PROVIDE_IFELSE.
+-  dnl Since AC_PROVIDE_IFELSE is only in autoconf >= 2.52 and not
+-  dnl documented, we avoid it.
++  dnl Since AC_PROVIDE_IFELSE is not documented, we avoid it.
+   ifelse(gt_included_intl, yes, , [
+     AC_REQUIRE([AM_ICONV_LINKFLAGS_BODY])
+   ])
+ 
+-  dnl Sometimes, on MacOS X, libintl requires linking with CoreFoundation.
++  dnl Sometimes, on Mac OS X, libintl requires linking with CoreFoundation.
+   gt_INTL_MACOSX
+ 
+   dnl Set USE_NLS.
+@@ -157,12 +152,23 @@ changequote([,])dnl
+         fi
+ 
+         AC_CACHE_CHECK([for GNU gettext in libc], [$gt_func_gnugettext_libc],
+-         [AC_TRY_LINK([#include <libintl.h>
+-$gt_revision_test_code
++         [AC_LINK_IFELSE(
++            [AC_LANG_PROGRAM(
++               [[
++#include <libintl.h>
++#ifndef __GNU_GETTEXT_SUPPORTED_REVISION
+ extern int _nl_msg_cat_cntr;
+-extern int *_nl_domain_bindings;],
+-            [bindtextdomain ("", "");
+-return * gettext ("")$gt_expression_test_code + _nl_msg_cat_cntr + *_nl_domain_bindings],
++extern int *_nl_domain_bindings;
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION (_nl_msg_cat_cntr + *_nl_domain_bindings)
++#else
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION 0
++#endif
++$gt_revision_test_code
++               ]],
++               [[
++bindtextdomain ("", "");
++return * gettext ("")$gt_expression_test_code + __GNU_GETTEXT_SYMBOL_EXPRESSION
++               ]])],
+             [eval "$gt_func_gnugettext_libc=yes"],
+             [eval "$gt_func_gnugettext_libc=no"])])
+ 
+@@ -183,35 +189,57 @@ return * gettext ("")$gt_expression_test_code + _nl_msg_cat_cntr + *_nl_domain_b
+             gt_save_LIBS="$LIBS"
+             LIBS="$LIBS $LIBINTL"
+             dnl Now see whether libintl exists and does not depend on libiconv.
+-            AC_TRY_LINK([#include <libintl.h>
+-$gt_revision_test_code
++            AC_LINK_IFELSE(
++              [AC_LANG_PROGRAM(
++                 [[
++#include <libintl.h>
++#ifndef __GNU_GETTEXT_SUPPORTED_REVISION
+ extern int _nl_msg_cat_cntr;
+ extern
+ #ifdef __cplusplus
+ "C"
+ #endif
+-const char *_nl_expand_alias (const char *);],
+-              [bindtextdomain ("", "");
+-return * gettext ("")$gt_expression_test_code + _nl_msg_cat_cntr + *_nl_expand_alias ("")],
++const char *_nl_expand_alias (const char *);
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION (_nl_msg_cat_cntr + *_nl_expand_alias (""))
++#else
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION 0
++#endif
++$gt_revision_test_code
++                 ]],
++                 [[
++bindtextdomain ("", "");
++return * gettext ("")$gt_expression_test_code + __GNU_GETTEXT_SYMBOL_EXPRESSION
++                 ]])],
+               [eval "$gt_func_gnugettext_libintl=yes"],
+               [eval "$gt_func_gnugettext_libintl=no"])
+             dnl Now see whether libintl exists and depends on libiconv.
+             if { eval "gt_val=\$$gt_func_gnugettext_libintl"; test "$gt_val" != yes; } && test -n "$LIBICONV"; then
+               LIBS="$LIBS $LIBICONV"
+-              AC_TRY_LINK([#include <libintl.h>
+-$gt_revision_test_code
++              AC_LINK_IFELSE(
++                [AC_LANG_PROGRAM(
++                   [[
++#include <libintl.h>
++#ifndef __GNU_GETTEXT_SUPPORTED_REVISION
+ extern int _nl_msg_cat_cntr;
+ extern
+ #ifdef __cplusplus
+ "C"
+ #endif
+-const char *_nl_expand_alias (const char *);],
+-                [bindtextdomain ("", "");
+-return * gettext ("")$gt_expression_test_code + _nl_msg_cat_cntr + *_nl_expand_alias ("")],
+-               [LIBINTL="$LIBINTL $LIBICONV"
+-                LTLIBINTL="$LTLIBINTL $LTLIBICONV"
+-                eval "$gt_func_gnugettext_libintl=yes"
+-               ])
++const char *_nl_expand_alias (const char *);
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION (_nl_msg_cat_cntr + *_nl_expand_alias (""))
++#else
++#define __GNU_GETTEXT_SYMBOL_EXPRESSION 0
++#endif
++$gt_revision_test_code
++                   ]],
++                   [[
++bindtextdomain ("", "");
++return * gettext ("")$gt_expression_test_code + __GNU_GETTEXT_SYMBOL_EXPRESSION
++                   ]])],
++                [LIBINTL="$LIBINTL $LIBICONV"
++                 LTLIBINTL="$LTLIBINTL $LTLIBICONV"
++                 eval "$gt_func_gnugettext_libintl=yes"
++                ])
+             fi
+             CPPFLAGS="$gt_save_CPPFLAGS"
+             LIBS="$gt_save_LIBS"])
+@@ -245,8 +273,8 @@ return * gettext ("")$gt_expression_test_code + _nl_msg_cat_cntr + *_nl_expand_a
+         dnl Mark actions used to generate GNU NLS library.
+         BUILD_INCLUDED_LIBINTL=yes
+         USE_INCLUDED_LIBINTL=yes
+-        LIBINTL="ifelse([$3],[],\${top_builddir}/intl,[$3])/libintl.[]gt_libtool_suffix_prefix[]a $LIBICONV $LIBTHREAD"
+-        LTLIBINTL="ifelse([$3],[],\${top_builddir}/intl,[$3])/libintl.[]gt_libtool_suffix_prefix[]a $LTLIBICONV $LTLIBTHREAD"
++        LIBINTL="ifelse([$3],[],\${top_builddir}/intl,[$3])/libintl.la $LIBICONV $LIBTHREAD"
++        LTLIBINTL="ifelse([$3],[],\${top_builddir}/intl,[$3])/libintl.la $LTLIBICONV $LTLIBTHREAD"
+         LIBS=`echo " $LIBS " | sed -e 's/ -lintl / /' -e 's/^ //' -e 's/ $//'`
+       fi
+ 
+@@ -314,43 +342,14 @@ return * gettext ("")$gt_expression_test_code + _nl_msg_cat_cntr + *_nl_expand_a
+   fi
+ 
+   ifelse(gt_included_intl, yes, [
+-    dnl If this is used in GNU gettext we have to set BUILD_INCLUDED_LIBINTL
+-    dnl to 'yes' because some of the testsuite requires it.
+-    if test "$PACKAGE" = gettext-runtime || test "$PACKAGE" = gettext-tools; then
+-      BUILD_INCLUDED_LIBINTL=yes
+-    fi
++    dnl In GNU gettext we have to set BUILD_INCLUDED_LIBINTL to 'yes'
++    dnl because some of the testsuite requires it.
++    BUILD_INCLUDED_LIBINTL=yes
+ 
+     dnl Make all variables we use known to autoconf.
+     AC_SUBST([BUILD_INCLUDED_LIBINTL])
+     AC_SUBST([USE_INCLUDED_LIBINTL])
+     AC_SUBST([CATOBJEXT])
+-
+-    dnl For backward compatibility. Some configure.ins may be using this.
+-    nls_cv_header_intl=
+-    nls_cv_header_libgt=
+-
+-    dnl For backward compatibility. Some Makefiles may be using this.
+-    DATADIRNAME=share
+-    AC_SUBST([DATADIRNAME])
+-
+-    dnl For backward compatibility. Some Makefiles may be using this.
+-    INSTOBJEXT=.mo
+-    AC_SUBST([INSTOBJEXT])
+-
+-    dnl For backward compatibility. Some Makefiles may be using this.
+-    GENCAT=gencat
+-    AC_SUBST([GENCAT])
+-
+-    dnl For backward compatibility. Some Makefiles may be using this.
+-    INTLOBJS=
+-    if test "$USE_INCLUDED_LIBINTL" = yes; then
+-      INTLOBJS="\$(GETTOBJS)"
+-    fi
+-    AC_SUBST([INTLOBJS])
+-
+-    dnl Enable libtool support if the surrounding package wishes it.
+-    INTL_LIBTOOL_SUFFIX_PREFIX=gt_libtool_suffix_prefix
+-    AC_SUBST([INTL_LIBTOOL_SUFFIX_PREFIX])
+   ])
+ 
+   dnl For backward compatibility. Some Makefiles may be using this.
+@@ -381,3 +380,7 @@ AC_DEFUN([AM_GNU_GETTEXT_NEED],
+ 
+ dnl Usage: AM_GNU_GETTEXT_VERSION([gettext-version])
+ AC_DEFUN([AM_GNU_GETTEXT_VERSION], [])
++
++
++dnl Usage: AM_GNU_GETTEXT_REQUIRE_VERSION([gettext-version])
++AC_DEFUN([AM_GNU_GETTEXT_REQUIRE_VERSION], [])
+diff --git a/m4/gpg-error.m4 b/m4/gpg-error.m4
+index 9d96d16..c9b235f 100644
+--- a/m4/gpg-error.m4
++++ b/m4/gpg-error.m4
+@@ -1,5 +1,5 @@
+ # gpg-error.m4 - autoconf macro to detect libgpg-error.
+-# Copyright (C) 2002, 2003, 2004 g10 Code GmbH
++# Copyright (C) 2002, 2003, 2004, 2011, 2014, 2018, 2020 g10 Code GmbH
+ #
+ # This file is free software; as a special exception the author gives
+ # unlimited permission to copy and/or distribute it, with or without
+@@ -8,58 +8,181 @@
+ # This file is distributed in the hope that it will be useful, but
+ # WITHOUT ANY WARRANTY, to the extent permitted by law; without even the
+ # implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
++#
++# Last-changed: 2020-11-17
++
+ 
+ dnl AM_PATH_GPG_ERROR([MINIMUM-VERSION,
+ dnl                   [ACTION-IF-FOUND [, ACTION-IF-NOT-FOUND ]]])
+-dnl Test for libgpg-error and define GPG_ERROR_CFLAGS and GPG_ERROR_LIBS
++dnl
++dnl Test for libgpg-error and define GPG_ERROR_CFLAGS, GPG_ERROR_LIBS,
++dnl GPG_ERROR_MT_CFLAGS, and GPG_ERROR_MT_LIBS.  The _MT_ variants are
++dnl used for programs requireing real multi thread support.
++dnl
++dnl If a prefix option is not used, the config script is first
++dnl searched in $SYSROOT/bin and then along $PATH.  If the used
++dnl config script does not match the host specification the script
++dnl is added to the gpg_config_script_warn variable.
+ dnl
+ AC_DEFUN([AM_PATH_GPG_ERROR],
+-[ AC_ARG_WITH(gpg-error-prefix,
+-            AC_HELP_STRING([--with-gpg-error-prefix=PFX],
+-                           [prefix where GPG Error is installed (optional)]),
+-     gpg_error_config_prefix="$withval", gpg_error_config_prefix="")
+-  if test x$gpg_error_config_prefix != x ; then
+-     if test x${GPG_ERROR_CONFIG+set} != xset ; then
+-        GPG_ERROR_CONFIG=$gpg_error_config_prefix/bin/gpg-error-config
++[ AC_REQUIRE([AC_CANONICAL_HOST])
++  gpg_error_config_prefix=""
++  dnl --with-libgpg-error-prefix=PFX is the preferred name for this option,
++  dnl since that is consistent with how our three siblings use the directory/
++  dnl package name in --with-$dir_name-prefix=PFX.
++  AC_ARG_WITH(libgpg-error-prefix,
++              AS_HELP_STRING([--with-libgpg-error-prefix=PFX],
++                             [prefix where GPG Error is installed (optional)]),
++              [gpg_error_config_prefix="$withval"])
++
++  dnl Accept --with-gpg-error-prefix and make it work the same as
++  dnl --with-libgpg-error-prefix above, for backwards compatibility,
++  dnl but do not document this old, inconsistently-named option.
++  AC_ARG_WITH(gpg-error-prefix,,
++              [gpg_error_config_prefix="$withval"])
++
++  if test x"${GPG_ERROR_CONFIG}" = x ; then
++     if test x"${gpg_error_config_prefix}" != x ; then
++        GPG_ERROR_CONFIG="${gpg_error_config_prefix}/bin/gpg-error-config"
++     else
++       case "${SYSROOT}" in
++         /*)
++           if test -x "${SYSROOT}/bin/gpg-error-config" ; then
++             GPG_ERROR_CONFIG="${SYSROOT}/bin/gpg-error-config"
++           fi
++           ;;
++         '')
++           ;;
++          *)
++           AC_MSG_WARN([Ignoring \$SYSROOT as it is not an absolute path.])
++           ;;
++       esac
+      fi
+   fi
+ 
+   AC_PATH_PROG(GPG_ERROR_CONFIG, gpg-error-config, no)
+-  min_gpg_error_version=ifelse([$1], ,0.0,$1)
+-  AC_MSG_CHECKING(for GPG Error - version >= $min_gpg_error_version)
++  min_gpg_error_version=ifelse([$1], ,1.33,$1)
+   ok=no
+-  if test "$GPG_ERROR_CONFIG" != "no" ; then
++
++  if test "$prefix" = NONE ; then
++    prefix_option_expanded=/usr/local
++  else
++    prefix_option_expanded="$prefix"
++  fi
++  if test "$exec_prefix" = NONE ; then
++    exec_prefix_option_expanded=$prefix_option_expanded
++  else
++    exec_prefix_option_expanded=$(prefix=$prefix_option_expanded eval echo $exec_prefix)
++  fi
++  libdir_option_expanded=$(prefix=$prefix_option_expanded exec_prefix=$exec_prefix_option_expanded eval echo $libdir)
++
++  if test -f $libdir_option_expanded/pkgconfig/gpg-error.pc; then
++    gpgrt_libdir=$libdir_option_expanded
++  else
++    if crt1_path=$(${CC:-cc} -print-file-name=crt1.o 2>/dev/null); then
++      if possible_libdir=$(cd ${crt1_path%/*} && pwd 2>/dev/null); then
++        if test -f $possible_libdir/pkgconfig/gpg-error.pc; then
++          gpgrt_libdir=$possible_libdir
++        fi
++      fi
++    fi
++  fi
++
++  if test "$GPG_ERROR_CONFIG" = "no" -a -n "$gpgrt_libdir"; then
++    AC_PATH_PROG(GPGRT_CONFIG, gpgrt-config, no)
++    if test "$GPGRT_CONFIG" = "no"; then
++      unset GPGRT_CONFIG
++    else
++      GPGRT_CONFIG="$GPGRT_CONFIG --libdir=$gpgrt_libdir"
++      if $GPGRT_CONFIG gpg-error >/dev/null 2>&1; then
++        GPG_ERROR_CONFIG="$GPGRT_CONFIG gpg-error"
++        AC_MSG_NOTICE([Use gpgrt-config with $gpgrt_libdir as gpg-error-config])
++        gpg_error_config_version=`$GPG_ERROR_CONFIG --modversion`
++      else
++        unset GPGRT_CONFIG
++      fi
++    fi
++  else
++    gpg_error_config_version=`$GPG_ERROR_CONFIG --version`
++  fi
++  if test "$GPG_ERROR_CONFIG" != "no"; then
+     req_major=`echo $min_gpg_error_version | \
+                sed 's/\([[0-9]]*\)\.\([[0-9]]*\)/\1/'`
+     req_minor=`echo $min_gpg_error_version | \
+                sed 's/\([[0-9]]*\)\.\([[0-9]]*\)/\2/'`
+-    gpg_error_config_version=`$GPG_ERROR_CONFIG $gpg_error_config_args --version`
+     major=`echo $gpg_error_config_version | \
+                sed 's/\([[0-9]]*\)\.\([[0-9]]*\).*/\1/'`
+     minor=`echo $gpg_error_config_version | \
+                sed 's/\([[0-9]]*\)\.\([[0-9]]*\).*/\2/'`
+     if test "$major" -gt "$req_major"; then
+         ok=yes
+-    else 
++    else
+         if test "$major" -eq "$req_major"; then
+             if test "$minor" -ge "$req_minor"; then
+                ok=yes
+             fi
+         fi
+     fi
++    if test -z "$GPGRT_CONFIG" -a -n "$gpgrt_libdir"; then
++      if test "$major" -gt 1 -o "$major" -eq 1 -a "$minor" -ge 33; then
++        AC_PATH_PROG(GPGRT_CONFIG, gpgrt-config, no)
++        if test "$GPGRT_CONFIG" = "no"; then
++          unset GPGRT_CONFIG
++        else
++          GPGRT_CONFIG="$GPGRT_CONFIG --libdir=$gpgrt_libdir"
++          if $GPGRT_CONFIG gpg-error >/dev/null 2>&1; then
++            GPG_ERROR_CONFIG="$GPGRT_CONFIG gpg-error"
++            AC_MSG_NOTICE([Use gpgrt-config with $gpgrt_libdir as gpg-error-config])
++          else
++            unset GPGRT_CONFIG
++          fi
++        fi
++      fi
++    fi
+   fi
++  AC_MSG_CHECKING(for GPG Error - version >= $min_gpg_error_version)
+   if test $ok = yes; then
+-    GPG_ERROR_CFLAGS=`$GPG_ERROR_CONFIG $gpg_error_config_args --cflags`
+-    GPG_ERROR_LIBS=`$GPG_ERROR_CONFIG $gpg_error_config_args --libs`
++    GPG_ERROR_CFLAGS=`$GPG_ERROR_CONFIG --cflags`
++    GPG_ERROR_LIBS=`$GPG_ERROR_CONFIG --libs`
++    if test -z "$GPGRT_CONFIG"; then
++      GPG_ERROR_MT_CFLAGS=`$GPG_ERROR_CONFIG --mt --cflags 2>/dev/null`
++      GPG_ERROR_MT_LIBS=`$GPG_ERROR_CONFIG --mt --libs 2>/dev/null`
++    else
++      GPG_ERROR_MT_CFLAGS=`$GPG_ERROR_CONFIG --variable=mtcflags 2>/dev/null`
++      GPG_ERROR_MT_CFLAGS="$GPG_ERROR_CFLAGS${GPG_ERROR_CFLAGS:+ }$GPG_ERROR_MT_CFLAGS"
++      GPG_ERROR_MT_LIBS=`$GPG_ERROR_CONFIG --variable=mtlibs 2>/dev/null`
++      GPG_ERROR_MT_LIBS="$GPG_ERROR_LIBS${GPG_ERROR_LIBS:+ }$GPG_ERROR_MT_LIBS"
++    fi
+     AC_MSG_RESULT([yes ($gpg_error_config_version)])
+     ifelse([$2], , :, [$2])
++    if test -z "$GPGRT_CONFIG"; then
++      gpg_error_config_host=`$GPG_ERROR_CONFIG --host 2>/dev/null || echo none`
++    else
++      gpg_error_config_host=`$GPG_ERROR_CONFIG --variable=host 2>/dev/null || echo none`
++    fi
++    if test x"$gpg_error_config_host" != xnone ; then
++      if test x"$gpg_error_config_host" != x"$host" ; then
++  AC_MSG_WARN([[
++***
++*** The config script "$GPG_ERROR_CONFIG" was
++*** built for $gpg_error_config_host and thus may not match the
++*** used host $host.
++*** You may want to use the configure option --with-libgpg-error-prefix
++*** to specify a matching config script or use \$SYSROOT.
++***]])
++        gpg_config_script_warn="$gpg_config_script_warn libgpg-error"
++      fi
++    fi
+   else
+     GPG_ERROR_CFLAGS=""
+     GPG_ERROR_LIBS=""
++    GPG_ERROR_MT_CFLAGS=""
++    GPG_ERROR_MT_LIBS=""
+     AC_MSG_RESULT(no)
+     ifelse([$3], , :, [$3])
+   fi
+   AC_SUBST(GPG_ERROR_CFLAGS)
+   AC_SUBST(GPG_ERROR_LIBS)
++  AC_SUBST(GPG_ERROR_MT_CFLAGS)
++  AC_SUBST(GPG_ERROR_MT_LIBS)
+ ])
+-
+diff --git a/m4/gpgme.m4 b/m4/gpgme.m4
+index 44bf43c..c749a5d 100644
+--- a/m4/gpgme.m4
++++ b/m4/gpgme.m4
+@@ -1,5 +1,5 @@
+ # gpgme.m4 - autoconf macro to detect GPGME.
+-# Copyright (C) 2002, 2003, 2004 g10 Code GmbH
++# Copyright (C) 2002, 2003, 2004, 2014, 2018 g10 Code GmbH
+ #
+ # This file is free software; as a special exception the author gives
+ # unlimited permission to copy and/or distribute it, with or without
+@@ -8,20 +8,52 @@
+ # This file is distributed in the hope that it will be useful, but
+ # WITHOUT ANY WARRANTY, to the extent permitted by law; without even the
+ # implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
++#
++# Last-changed: 2020-11-20
+ 
+ 
+ AC_DEFUN([_AM_PATH_GPGME_CONFIG],
+ [ AC_ARG_WITH(gpgme-prefix,
+-            AC_HELP_STRING([--with-gpgme-prefix=PFX],
++            AS_HELP_STRING([--with-gpgme-prefix=PFX],
+                            [prefix where GPGME is installed (optional)]),
+      gpgme_config_prefix="$withval", gpgme_config_prefix="")
+-  if test "x$gpgme_config_prefix" != x ; then
+-      GPGME_CONFIG="$gpgme_config_prefix/bin/gpgme-config"
++  if test x"${GPGME_CONFIG}" = x ; then
++     if test x"${gpgme_config_prefix}" != x ; then
++        GPGME_CONFIG="${gpgme_config_prefix}/bin/gpgme-config"
++     else
++       case "${SYSROOT}" in
++         /*)
++           if test -x "${SYSROOT}/bin/gpgme-config" ; then
++             GPGME_CONFIG="${SYSROOT}/bin/gpgme-config"
++           fi
++           ;;
++         '')
++           ;;
++          *)
++           AC_MSG_WARN([Ignoring \$SYSROOT as it is not an absolute path.])
++           ;;
++       esac
++     fi
++  fi
++
++  use_gpgrt_config=""
++  if test x"${GPGME_CONFIG}" = x -a x"$GPGRT_CONFIG" != x -a "$GPGRT_CONFIG" != "no"; then
++    if $GPGRT_CONFIG gpgme --exists; then
++      GPGME_CONFIG="$GPGRT_CONFIG gpgme"
++      AC_MSG_NOTICE([Use gpgrt-config as gpgme-config])
++      use_gpgrt_config=yes
++    fi
++  fi
++  if test -z "$use_gpgrt_config"; then
++    AC_PATH_PROG(GPGME_CONFIG, gpgme-config, no)
+   fi
+-  AC_PATH_PROG(GPGME_CONFIG, gpgme-config, no)
+ 
+   if test "$GPGME_CONFIG" != "no" ; then
+-    gpgme_version=`$GPGME_CONFIG --version`
++    if test -z "$use_gpgrt_config"; then
++      gpgme_version=`$GPGME_CONFIG --version`
++    else
++      gpgme_version=`$GPGME_CONFIG --modversion`
++    fi
+   fi
+   gpgme_version_major=`echo $gpgme_version | \
+                sed 's/\([[0-9]]*\)\.\([[0-9]]*\)\.\([[0-9]]*\).*/\1/'`
+@@ -31,10 +63,39 @@ AC_DEFUN([_AM_PATH_GPGME_CONFIG],
+                sed 's/\([[0-9]]*\)\.\([[0-9]]*\)\.\([[0-9]]*\).*/\3/'`
+ ])
+ 
++
++AC_DEFUN([_AM_PATH_GPGME_CONFIG_HOST_CHECK],
++[
++    if test -z "$use_gpgrt_config"; then
++      gpgme_config_host=`$GPGME_CONFIG --host 2>/dev/null || echo none`
++    else
++      gpgme_config_host=`$GPGME_CONFIG --variable=host 2>/dev/null || echo none`
++    fi
++    if test x"$gpgme_config_host" != xnone ; then
++      if test x"$gpgme_config_host" != x"$host" ; then
++  AC_MSG_WARN([[
++***
++*** The config script "$GPGME_CONFIG" was
++*** built for $gpgme_config_host and thus may not match the
++*** used host $host.
++*** You may want to use the configure option --with-gpgme-prefix
++*** to specify a matching config script or use \$SYSROOT.
++***]])
++        gpg_config_script_warn="$gpg_config_script_warn gpgme"
++      fi
++    fi
++])
++
++
+ dnl AM_PATH_GPGME([MINIMUM-VERSION,
+ dnl               [ACTION-IF-FOUND [, ACTION-IF-NOT-FOUND ]]])
+ dnl Test for libgpgme and define GPGME_CFLAGS and GPGME_LIBS.
+ dnl
++dnl If a prefix option is not used, the config script is first
++dnl searched in $SYSROOT/bin and then along $PATH.  If the used
++dnl config script does not match the host specification the script
++dnl is added to the gpg_config_script_warn variable.
++dnl
+ AC_DEFUN([AM_PATH_GPGME],
+ [ AC_REQUIRE([_AM_PATH_GPGME_CONFIG])dnl
+   tmp=ifelse([$1], ,1:0.4.2,$1)
+@@ -57,7 +118,7 @@ AC_DEFUN([AM_PATH_GPGME],
+                sed 's/\([[0-9]]*\)\.\([[0-9]]*\)\.\([[0-9]]*\)/\3/'`
+     if test "$gpgme_version_major" -gt "$req_major"; then
+         ok=yes
+-    else 
++    else
+         if test "$gpgme_version_major" -eq "$req_major"; then
+             if test "$gpgme_version_minor" -gt "$req_minor"; then
+                ok=yes
+@@ -75,7 +136,11 @@ AC_DEFUN([AM_PATH_GPGME],
+      # If we have a recent GPGME, we should also check that the
+      # API is compatible.
+      if test "$req_gpgme_api" -gt 0 ; then
+-        tmp=`$GPGME_CONFIG --api-version 2>/dev/null || echo 0`
++        if test -z "$use_gpgrt_config"; then
++          tmp=`$GPGME_CONFIG --api-version 2>/dev/null || echo 0`
++        else
++          tmp=`$GPGME_CONFIG --variable=api_version 2>/dev/null || echo 0`
++        fi
+         if test "$tmp" -gt 0 ; then
+            if test "$req_gpgme_api" -ne "$tmp" ; then
+              ok=no
+@@ -88,6 +153,7 @@ AC_DEFUN([AM_PATH_GPGME],
+     GPGME_LIBS=`$GPGME_CONFIG --libs`
+     AC_MSG_RESULT(yes)
+     ifelse([$2], , :, [$2])
++    _AM_PATH_GPGME_CONFIG_HOST_CHECK
+   else
+     GPGME_CFLAGS=""
+     GPGME_LIBS=""
+@@ -98,75 +164,6 @@ AC_DEFUN([AM_PATH_GPGME],
+   AC_SUBST(GPGME_LIBS)
+ ])
+ 
+-dnl AM_PATH_GPGME_PTH([MINIMUM-VERSION,
+-dnl                   [ACTION-IF-FOUND [, ACTION-IF-NOT-FOUND ]]])
+-dnl Test for libgpgme and define GPGME_PTH_CFLAGS and GPGME_PTH_LIBS.
+-dnl
+-AC_DEFUN([AM_PATH_GPGME_PTH],
+-[ AC_REQUIRE([_AM_PATH_GPGME_CONFIG])dnl
+-  tmp=ifelse([$1], ,1:0.4.2,$1)
+-  if echo "$tmp" | grep ':' >/dev/null 2>/dev/null ; then
+-     req_gpgme_api=`echo "$tmp"     | sed 's/\(.*\):\(.*\)/\1/'`
+-     min_gpgme_version=`echo "$tmp" | sed 's/\(.*\):\(.*\)/\2/'`
+-  else
+-     req_gpgme_api=0
+-     min_gpgme_version="$tmp"
+-  fi
+-
+-  AC_MSG_CHECKING(for GPGME Pth - version >= $min_gpgme_version)
+-  ok=no
+-  if test "$GPGME_CONFIG" != "no" ; then
+-    if `$GPGME_CONFIG --thread=pth 2> /dev/null` ; then
+-      req_major=`echo $min_gpgme_version | \
+-               sed 's/\([[0-9]]*\)\.\([[0-9]]*\)\.\([[0-9]]*\)/\1/'`
+-      req_minor=`echo $min_gpgme_version | \
+-               sed 's/\([[0-9]]*\)\.\([[0-9]]*\)\.\([[0-9]]*\)/\2/'`
+-      req_micro=`echo $min_gpgme_version | \
+-               sed 's/\([[0-9]]*\)\.\([[0-9]]*\)\.\([[0-9]]*\)/\3/'`
+-      if test "$gpgme_version_major" -gt "$req_major"; then
+-        ok=yes
+-      else 
+-        if test "$gpgme_version_major" -eq "$req_major"; then
+-          if test "$gpgme_version_minor" -gt "$req_minor"; then
+-            ok=yes
+-          else
+-            if test "$gpgme_version_minor" -eq "$req_minor"; then
+-              if test "$gpgme_version_micro" -ge "$req_micro"; then
+-                ok=yes
+-              fi
+-            fi
+-          fi
+-        fi
+-      fi
+-    fi
+-  fi
+-  if test $ok = yes; then
+-     # If we have a recent GPGME, we should also check that the
+-     # API is compatible.
+-     if test "$req_gpgme_api" -gt 0 ; then
+-        tmp=`$GPGME_CONFIG --api-version 2>/dev/null || echo 0`
+-        if test "$tmp" -gt 0 ; then
+-           if test "$req_gpgme_api" -ne "$tmp" ; then
+-             ok=no
+-           fi
+-        fi
+-     fi
+-  fi
+-  if test $ok = yes; then
+-    GPGME_PTH_CFLAGS=`$GPGME_CONFIG --thread=pth --cflags`
+-    GPGME_PTH_LIBS=`$GPGME_CONFIG --thread=pth --libs`
+-    AC_MSG_RESULT(yes)
+-    ifelse([$2], , :, [$2])
+-  else
+-    GPGME_PTH_CFLAGS=""
+-    GPGME_PTH_LIBS=""
+-    AC_MSG_RESULT(no)
+-    ifelse([$3], , :, [$3])
+-  fi
+-  AC_SUBST(GPGME_PTH_CFLAGS)
+-  AC_SUBST(GPGME_PTH_LIBS)
+-])
+-
+ dnl AM_PATH_GPGME_PTHREAD([MINIMUM-VERSION,
+ dnl                       [ACTION-IF-FOUND [, ACTION-IF-NOT-FOUND ]]])
+ dnl Test for libgpgme and define GPGME_PTHREAD_CFLAGS
+@@ -195,7 +192,7 @@ AC_DEFUN([AM_PATH_GPGME_PTHREAD],
+                sed 's/\([[0-9]]*\)\.\([[0-9]]*\)\.\([[0-9]]*\)/\3/'`
+       if test "$gpgme_version_major" -gt "$req_major"; then
+         ok=yes
+-      else 
++      else
+         if test "$gpgme_version_major" -eq "$req_major"; then
+           if test "$gpgme_version_minor" -gt "$req_minor"; then
+             ok=yes
+@@ -227,6 +224,7 @@ AC_DEFUN([AM_PATH_GPGME_PTHREAD],
+     GPGME_PTHREAD_LIBS=`$GPGME_CONFIG --thread=pthread --libs`
+     AC_MSG_RESULT(yes)
+     ifelse([$2], , :, [$2])
++    _AM_PATH_GPGME_CONFIG_HOST_CHECK
+   else
+     GPGME_PTHREAD_CFLAGS=""
+     GPGME_PTHREAD_LIBS=""
+@@ -264,7 +262,7 @@ AC_DEFUN([AM_PATH_GPGME_GLIB],
+                sed 's/\([[0-9]]*\)\.\([[0-9]]*\)\.\([[0-9]]*\)/\3/'`
+     if test "$gpgme_version_major" -gt "$req_major"; then
+         ok=yes
+-    else 
++    else
+         if test "$gpgme_version_major" -eq "$req_major"; then
+             if test "$gpgme_version_minor" -gt "$req_minor"; then
+                ok=yes
+@@ -282,7 +280,11 @@ AC_DEFUN([AM_PATH_GPGME_GLIB],
+      # If we have a recent GPGME, we should also check that the
+      # API is compatible.
+      if test "$req_gpgme_api" -gt 0 ; then
+-        tmp=`$GPGME_CONFIG --api-version 2>/dev/null || echo 0`
++        if test -z "$use_gpgrt_config"; then
++          tmp=`$GPGME_CONFIG --api-version 2>/dev/null || echo 0`
++        else
++          tmp=`$GPGME_CONFIG --variable=api_version 2>/dev/null || echo 0`
++        fi
+         if test "$tmp" -gt 0 ; then
+            if test "$req_gpgme_api" -ne "$tmp" ; then
+              ok=no
+@@ -291,10 +293,23 @@ AC_DEFUN([AM_PATH_GPGME_GLIB],
+      fi
+   fi
+   if test $ok = yes; then
+-    GPGME_GLIB_CFLAGS=`$GPGME_CONFIG --glib --cflags`
+-    GPGME_GLIB_LIBS=`$GPGME_CONFIG --glib --libs`
++    if test -z "$use_gpgrt_config"; then
++      GPGME_GLIB_CFLAGS=`$GPGME_CONFIG --glib --cflags`
++      GPGME_GLIB_LIBS=`$GPGME_CONFIG --glib --libs`
++    else
++      if $GPGRT_CONFIG gpgme-glib --exists; then
++        GPGME_CONFIG="$GPGRT_CONFIG gpgme-glib"
++        GPGME_GLIB_CFLAGS=`$GPGME_CONFIG --cflags`
++        GPGME_GLIB_LIBS=`$GPGME_CONFIG --libs`
++      else
++        ok = no
++      fi
++    fi
++  fi
++  if test $ok = yes; then
+     AC_MSG_RESULT(yes)
+     ifelse([$2], , :, [$2])
++    _AM_PATH_GPGME_CONFIG_HOST_CHECK
+   else
+     GPGME_GLIB_CFLAGS=""
+     GPGME_GLIB_LIBS=""
+@@ -304,4 +319,3 @@ AC_DEFUN([AM_PATH_GPGME_GLIB],
+   AC_SUBST(GPGME_GLIB_CFLAGS)
+   AC_SUBST(GPGME_GLIB_LIBS)
+ ])
+-
+diff --git a/m4/libassuan.m4 b/m4/libassuan.m4
+index 004eee3..df50484 100644
+--- a/m4/libassuan.m4
++++ b/m4/libassuan.m4
+@@ -1,5 +1,5 @@
+ dnl Autoconf macros for libassuan
+-dnl       Copyright (C) 2002, 2003 Free Software Foundation, Inc.
++dnl Copyright (C) 2002, 2003, 2011 Free Software Foundation, Inc.
+ dnl
+ dnl This file is free software; as a special exception the author gives
+ dnl unlimited permission to copy and/or distribute it, with or without
+@@ -8,23 +8,36 @@ dnl
+ dnl This file is distributed in the hope that it will be useful, but
+ dnl WITHOUT ANY WARRANTY, to the extent permitted by law; without even the
+ dnl implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
++dnl SPDX-License-Identifier: FSFULLR
++# Last-changed: 2020-11-17
+ 
+ dnl
+ dnl Common code used for libassuan detection [internal]
+ dnl Returns ok set to yes or no.
+ dnl
+ AC_DEFUN([_AM_PATH_LIBASSUAN_COMMON],
+-[ AC_ARG_WITH(libassuan-prefix,
+-              AC_HELP_STRING([--with-libassuan-prefix=PFX],
++[ AC_REQUIRE([AC_CANONICAL_HOST])
++  AC_ARG_WITH(libassuan-prefix,
++              AS_HELP_STRING([--with-libassuan-prefix=PFX],
+                              [prefix where LIBASSUAN is installed (optional)]),
+      libassuan_config_prefix="$withval", libassuan_config_prefix="")
+   if test x$libassuan_config_prefix != x ; then
+-    libassuan_config_args="$libassuan_config_args --prefix=$libassuan_config_prefix"
+     if test x${LIBASSUAN_CONFIG+set} != xset ; then
+       LIBASSUAN_CONFIG=$libassuan_config_prefix/bin/libassuan-config
+     fi
+   fi
+-  AC_PATH_PROG(LIBASSUAN_CONFIG, libassuan-config, no)
++
++  use_gpgrt_config=""
++  if test x"${LIBASSUAN_CONFIG}" = x -a x"$GPGRT_CONFIG" != x -a "$GPGRT_CONFIG" != "no"; then
++    if $GPGRT_CONFIG libassuan --exists; then
++      LIBASSUAN_CONFIG="$GPGRT_CONFIG libassuan"
++      AC_MSG_NOTICE([Use gpgrt-config as libassuan-config])
++      use_gpgrt_config=yes
++    fi
++  fi
++  if test -z "$use_gpgrt_config"; then
++    AC_PATH_PROG(LIBASSUAN_CONFIG, libassuan-config, no)
++  fi
+ 
+   tmp=ifelse([$1], ,1:0.9.2,$1)
+   if echo "$tmp" | grep ':' >/dev/null 2>/dev/null ; then
+@@ -35,55 +48,60 @@ AC_DEFUN([_AM_PATH_LIBASSUAN_COMMON],
+     min_libassuan_version="$tmp"
+   fi
+ 
+-  if test "$LIBASSUAN_CONFIG" != "no" ; then
+-    libassuan_version=`$LIBASSUAN_CONFIG --version`
+-  fi
+-  libassuan_version_major=`echo $libassuan_version | \
+-               sed 's/\([[0-9]]*\)\.\([[0-9]]*\)\.\([[0-9]]*\).*/\1/'`
+-  libassuan_version_minor=`echo $libassuan_version | \
+-               sed 's/\([[0-9]]*\)\.\([[0-9]]*\)\.\([[0-9]]*\).*/\2/'`
+-  libassuan_version_micro=`echo $libassuan_version | \
+-               sed 's/\([[0-9]]*\)\.\([[0-9]]*\)\.\([[0-9]]*\).*/\3/'`
+-
+-  AC_MSG_CHECKING(for LIBASSUAN ifelse([$2], ,,[$2 ])- version >= $min_libassuan_version)
++  AC_MSG_CHECKING(for LIBASSUAN - version >= $min_libassuan_version)
+   ok=no
+-  if test "$LIBASSUAN_CONFIG" != "no" ; then
+-    ifelse([$2], ,,[if `$LIBASSUAN_CONFIG --thread=$2 2> /dev/null` ; then])
++  if test "$LIBASSUAN_CONFIG" != "no"; then
+     req_major=`echo $min_libassuan_version | \
+                sed 's/\([[0-9]]*\)\.\([[0-9]]*\)\.\([[0-9]]*\)/\1/'`
+     req_minor=`echo $min_libassuan_version | \
+                sed 's/\([[0-9]]*\)\.\([[0-9]]*\)\.\([[0-9]]*\)/\2/'`
+     req_micro=`echo $min_libassuan_version | \
+                sed 's/\([[0-9]]*\)\.\([[0-9]]*\)\.\([[0-9]]*\)/\3/'`
+-    if test "$libassuan_version_major" -gt "$req_major"; then
++
++    if test -z "$use_gpgrt_config"; then
++      libassuan_config_version=`$LIBASSUAN_CONFIG --version`
++    else
++      libassuan_config_version=`$LIBASSUAN_CONFIG --modversion`
++    fi
++    major=`echo $libassuan_config_version | \
++               sed 's/\([[0-9]]*\)\.\([[0-9]]*\)\.\([[0-9]]*\).*/\1/'`
++    minor=`echo $libassuan_config_version | \
++               sed 's/\([[0-9]]*\)\.\([[0-9]]*\)\.\([[0-9]]*\).*/\2/'`
++    micro=`echo $libassuan_config_version | \
++               sed 's/\([[0-9]]*\)\.\([[0-9]]*\)\.\([[0-9]]*\).*/\3/'`
++
++    if test "$major" -gt "$req_major"; then
+         ok=yes
+-    else 
+-        if test "$libassuan_version_major" -eq "$req_major"; then
+-            if test "$libassuan_version_minor" -gt "$req_minor"; then
++    else
++        if test "$major" -eq "$req_major"; then
++            if test "$minor" -gt "$req_minor"; then
+                ok=yes
+             else
+-               if test "$libassuan_version_minor" -eq "$req_minor"; then
+-                   if test "$libassuan_version_micro" -ge "$req_micro"; then
++               if test "$minor" -eq "$req_minor"; then
++                   if test "$micro" -ge "$req_micro"; then
+                      ok=yes
+                    fi
+                fi
+             fi
+         fi
+     fi
+-    ifelse([$2], ,,[fi])
+   fi
+ 
+   if test $ok = yes; then
+-    AC_MSG_RESULT([yes ($libassuan_version)])
++    AC_MSG_RESULT([yes ($libassuan_config_version)])
+   else
+     AC_MSG_RESULT(no)
+   fi
+ 
+   if test $ok = yes; then
+     if test "$req_libassuan_api" -gt 0 ; then
+-      tmp=`$LIBASSUAN_CONFIG --api-version 2>/dev/null || echo 0`
++      if test -z "$use_gpgrt_config"; then
++        tmp=`$LIBASSUAN_CONFIG --api-version 2>/dev/null || echo 0`
++      else
++        tmp=`$LIBASSUAN_CONFIG --variable=api_version 2>/dev/null || echo 0`
++      fi
+       if test "$tmp" -gt 0 ; then
+-        AC_MSG_CHECKING([LIBASSUAN ifelse([$2], ,,[$2 ])API version])
++        AC_MSG_CHECKING([LIBASSUAN API version])
+         if test "$req_libassuan_api" -eq "$tmp" ; then
+           AC_MSG_RESULT(okay)
+         else
+@@ -94,6 +112,27 @@ AC_DEFUN([_AM_PATH_LIBASSUAN_COMMON],
+     fi
+   fi
+ 
++  if test $ok = yes; then
++    if test x"$host" != x ; then
++      if test -z "$use_gpgrt_config"; then
++        libassuan_config_host=`$LIBASSUAN_CONFIG --host 2>/dev/null || echo none`
++      else
++        libassuan_config_host=`$LIBASSUAN_CONFIG --variable=host 2>/dev/null || echo none`
++      fi
++      if test x"$libassuan_config_host" != xnone ; then
++        if test x"$libassuan_config_host" != x"$host" ; then
++  AC_MSG_WARN([[
++***
++*** The config script "$LIBASSUAN_CONFIG" was
++*** built for $libassuan_config_host and thus may not match the
++*** used host $host.
++*** You may want to use the configure option --with-libassuan-prefix
++*** to specify a matching config script.
++***]])
++        fi
++      fi
++    fi
++  fi
+ ])
+ 
+ dnl AM_CHECK_LIBASSUAN([MINIMUM-VERSION,
+@@ -120,8 +159,8 @@ dnl
+ AC_DEFUN([AM_PATH_LIBASSUAN],
+ [ _AM_PATH_LIBASSUAN_COMMON($1)
+   if test $ok = yes; then
+-    LIBASSUAN_CFLAGS=`$LIBASSUAN_CONFIG $libassuan_config_args --cflags`
+-    LIBASSUAN_LIBS=`$LIBASSUAN_CONFIG $libassuan_config_args --libs`
++    LIBASSUAN_CFLAGS=`$LIBASSUAN_CONFIG --cflags`
++    LIBASSUAN_LIBS=`$LIBASSUAN_CONFIG --libs`
+     ifelse([$2], , :, [$2])
+   else
+     LIBASSUAN_CFLAGS=""
+@@ -131,45 +170,3 @@ AC_DEFUN([AM_PATH_LIBASSUAN],
+   AC_SUBST(LIBASSUAN_CFLAGS)
+   AC_SUBST(LIBASSUAN_LIBS)
+ ])
+-
+-
+-dnl AM_PATH_LIBASSUAN_PTH([MINIMUM-VERSION,
+-dnl                      [ACTION-IF-FOUND [, ACTION-IF-NOT-FOUND ]]])
+-dnl Test for libassuan and define LIBASSUAN_PTH_CFLAGS and LIBASSUAN_PTH_LIBS
+-dnl
+-AC_DEFUN([AM_PATH_LIBASSUAN_PTH],
+-[ _AM_PATH_LIBASSUAN_COMMON($1,pth)
+-  if test $ok = yes; then
+-    LIBASSUAN_PTH_CFLAGS=`$LIBASSUAN_CONFIG $libassuan_config_args --thread=pth --cflags`
+-    LIBASSUAN_PTH_LIBS=`$LIBASSUAN_CONFIG $libassuan_config_args --thread=pth --libs`
+-    ifelse([$2], , :, [$2])
+-  else
+-    LIBASSUAN_PTH_CFLAGS=""
+-    LIBASSUAN_PTH_LIBS=""
+-    ifelse([$3], , :, [$3])
+-  fi
+-  AC_SUBST(LIBASSUAN_PTH_CFLAGS)
+-  AC_SUBST(LIBASSUAN_PTH_LIBS)
+-])
+-
+-
+-dnl AM_PATH_LIBASSUAN_PTHREAD([MINIMUM-VERSION,
+-dnl                           [ACTION-IF-FOUND [, ACTION-IF-NOT-FOUND ]]])
+-dnl Test for libassuan and define LIBASSUAN_PTHREAD_CFLAGS 
+-dnl                           and LIBASSUAN_PTHREAD_LIBS
+-dnl
+-AC_DEFUN([AM_PATH_LIBASSUAN_PTHREAD],
+-[ _AM_PATH_LIBASSUAN_COMMON($1,pthread)
+-  if test $ok = yes; then
+-    LIBASSUAN_PTHREAD_CFLAGS=`$LIBASSUAN_CONFIG $libassuan_config_args --thread=pthread --cflags`
+-    LIBASSUAN_PTHREAD_LIBS=`$LIBASSUAN_CONFIG $libassuan_config_args --thread=pthread --libs`
+-    ifelse([$2], , :, [$2])
+-  else
+-    LIBASSUAN_PTHREAD_CFLAGS=""
+-    LIBASSUAN_PTHREAD_LIBS=""
+-    ifelse([$3], , :, [$3])
+-  fi
+-  AC_SUBST(LIBASSUAN_PTHREAD_CFLAGS)
+-  AC_SUBST(LIBASSUAN_PTHREAD_LIBS)
+-])
+-

--- a/app-crypt/gpa/gpa-0.10.0-r1.ebuild
+++ b/app-crypt/gpa/gpa-0.10.0-r1.ebuild
@@ -1,0 +1,42 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools xdg
+
+DESCRIPTION="The GNU Privacy Assistant (GPA) is a graphical user interface for GnuPG"
+HOMEPAGE="http://gpa.wald.intevation.org"
+SRC_URI="mirror://gnupg/${PN}/${P}.tar.bz2"
+
+LICENSE="GPL-3"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~ppc ~ppc64 ~sparc ~x86"
+IUSE="nls"
+
+RDEPEND="
+	>=app-crypt/gnupg-2:=
+	>=app-crypt/gpgme-1.11.1:=
+	>=dev-libs/libassuan-1.1.0:=
+	>=dev-libs/libgpg-error-1.4:=
+	>=x11-libs/gtk+-2.10.0:2=
+"
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig
+	nls? ( sys-devel/gettext )"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-autoconf.patch
+)
+
+src_prepare() {
+	default
+	sed -i 's/Application;//' gpa.desktop
+	eautoreconf
+}
+
+src_configure() {
+	econf \
+		$(use_enable nls) \
+		GPGKEYS_LDAP="/usr/libexec/gpgkeys_ldap"
+}

--- a/app-crypt/gpgme/gpgme-1.18.0-r1.ebuild
+++ b/app-crypt/gpgme/gpgme-1.18.0-r1.ebuild
@@ -88,11 +88,9 @@ src_configure() {
 	# bug #847955
 	append-lfs-flags
 
-	# bug #811933 for libassuan prefix
 	econf \
 		$(use test || echo "--disable-gpgconf-test --disable-gpg-test --disable-gpgsm-test --disable-g13-test") \
 		--enable-languages="${languages[*]}" \
-		--with-libassuan-prefix="${ESYSROOT}"/usr \
 		$(use_enable static-libs static)
 
 	use python && emake -C lang/python prepare

--- a/app-crypt/scute/scute-1.7.0-r1.ebuild
+++ b/app-crypt/scute/scute-1.7.0-r1.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 DESCRIPTION="A PKCS #11 module for OpenPGP smartcards"
 HOMEPAGE="http://www.scute.org/"
@@ -41,9 +41,7 @@ src_unpack() {
 
 src_configure() {
 	econf \
-		--libdir="${EPREFIX}"/usr/$(get_libdir)/pkcs11 \
-		--with-libgpg-error-prefix="${ESYSROOT}"/usr \
-		--with-libassuan-prefix="${ESYSROOT}"/usr
+		--libdir="${EPREFIX}"/usr/$(get_libdir)/pkcs11
 }
 
 src_install() {

--- a/dev-libs/libgpg-error/files/libgpg-error-1.45-gpgrt_config_libdir.patch
+++ b/dev-libs/libgpg-error/files/libgpg-error-1.45-gpgrt_config_libdir.patch
@@ -1,0 +1,56 @@
+Upstream:
+https://dev.gnupg.org/rE4615816f71e91f4c3bb8b0e4122dd153ec7c1927
+https://dev.gnupg.org/T6136
+
+From 4615816f71e91f4c3bb8b0e4122dd153ec7c1927 Mon Sep 17 00:00:00 2001
+From: NIIBE Yutaka <gniibe@fsij.org>
+Date: Thu, 25 Aug 2022 15:30:07 +0900
+Subject: [PATCH] gpgrt-config: Strip system paths for --cflags and --libs.
+
+* src/gpgrt-config.in: Strip -I and -L with system paths.
+
+--
+
+This behavior is more compatible to pkg-config.
+
+GnuPG-bug-id: 6136
+Signed-off-by: NIIBE Yutaka <gniibe@fsij.org>
+
+diff --git a/src/gpgrt-config.in b/src/gpgrt-config.in
+index 3aaa243..85d21b4 100644
+--- a/src/gpgrt-config.in
++++ b/src/gpgrt-config.in
+@@ -1,6 +1,6 @@
+ #!@INSTALLSHELLPATH@
+ #                          -*- mode: shell-script; sh-shell: "/bin/sh" -*-
+-# Copyright (C) 2018, 2021 g10 Code GmbH
++# Copyright (C) 2018, 2021, 2022 g10 Code GmbH
+ #
+ # This file is free software; as a special exception the author gives
+ # unlimited permission to copy and/or distribute it, with or without
+@@ -193,9 +193,14 @@ list_only_once () {
+     __arg=""
+ 
+     for __arg; do
+-	if not_listed_yet $__arg $__result; then
+-	    __result="$__result${__result:+ }$__arg"
+-	fi
++	case "$__arg" in
++	    -I/usr/include|-I/include) ;;
++	    *)
++                if not_listed_yet $__arg $__result; then
++	            __result="$__result${__result:+ }$__arg"
++	        fi
++                ;;
++	esac
+     done
+ 
+     echo $__result
+@@ -210,6 +215,7 @@ list_only_once_for_libs () {
+     # the resulted list is in reverse order
+     for __arg; do
+ 	case "$__arg" in
++	    -L/usr/lib|-L/usr/lib64|-L/lib|-L/lib64) ;;
+ 	    -l*)
+ 		# As-is
+ 		__rev_list="$__arg${__rev_list:+ }$__rev_list"

--- a/dev-libs/libgpg-error/libgpg-error-1.45-r1.ebuild
+++ b/dev-libs/libgpg-error/libgpg-error-1.45-r1.ebuild
@@ -1,0 +1,68 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools multilib-minimal toolchain-funcs prefix
+
+DESCRIPTION="Contains error handling functions used by GnuPG software"
+HOMEPAGE="https://www.gnupg.org/related_software/libgpg-error"
+SRC_URI="mirror://gnupg/${PN}/${P}.tar.bz2"
+
+LICENSE="GPL-2 LGPL-2.1"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+IUSE="common-lisp nls static-libs test"
+RESTRICT="!test? ( test )"
+
+RDEPEND="nls? ( >=virtual/libintl-0-r1[${MULTILIB_USEDEP}] )"
+DEPEND="${RDEPEND}"
+BDEPEND="nls? ( sys-devel/gettext )"
+
+MULTILIB_CHOST_TOOLS=(
+	/usr/bin/gpg-error-config
+)
+MULTILIB_WRAPPED_HEADERS=(
+	/usr/include/gpg-error.h
+	/usr/include/gpgrt.h
+)
+
+PATCHES=(
+	"${FILESDIR}/${PN}-1.44-remove_broken_check.patch"
+	"${FILESDIR}/${PN}-1.45-gpgrt_config_libdir.patch"
+)
+
+src_prepare() {
+	default
+
+	if use prefix ; then
+		# don't hardcode /usr/xpg4/bin/sh as shell on Solaris
+		sed -i -e 's/solaris\*/disabled/' configure.ac || die
+	fi
+
+	# only necessary for as long as we run eautoreconf, configure.ac
+	# uses ./autogen.sh to generate PACKAGE_VERSION, but autogen.sh is
+	# not a pure /bin/sh script, so it fails on some hosts
+	hprefixify -w 1 autogen.sh
+	eautoreconf
+}
+
+multilib_src_configure() {
+	local myeconfargs=(
+		$(multilib_is_native_abi || echo --disable-languages)
+		$(use_enable common-lisp languages)
+		$(use_enable nls)
+		# required for sys-power/suspend[crypt], bug 751568
+		$(use_enable static-libs static)
+		$(use_enable test tests)
+		--enable-threads
+		CC_FOR_BUILD="$(tc-getBUILD_CC)"
+		$("${S}/configure" --help | grep -o -- '--without-.*-prefix')
+	)
+	ECONF_SOURCE="${S}" econf "${myeconfargs[@]}"
+}
+
+multilib_src_install_all() {
+	einstalldocs
+	find "${ED}" -type f -name '*.la' -delete || die
+}


### PR DESCRIPTION
This has two commits.

1. Adds a patch to remove the standard system `--libdir` from the `gpgrt-config` output. This is required when build `app-crypt/gpgme` with slibtool to avoid linking with the old system library instead of the newly built library.
2. The `--with-libassuan-prefix` configure argument causes `app-crypt/gpgme` to use the deprecated `libassuan-config` script instead of the maintained `gpgrt-config` script.

Edit: For the record to reproduce this bug when building with slibtool:

* Build `app-crypt/gpgme` with `USE=qt5` and `FEATURES=test`.
* Upgrade to a newer version of `app-crypt/gpgme` using the same `USE` and `FEATURES`.

Closes: https://bugs.gentoo.org/844226
Upstream-Bug: https://dev.gnupg.org/T6136
Upstream-Commit: https://dev.gnupg.org/rE4615816f71e91f4c3bb8b0e4122dd153ec7c1927