### PR TITLE
profiles/features/clang: update environment variables

### DIFF
--- a/profiles/features/clang/make.defaults
+++ b/profiles/features/clang/make.defaults
@@ -29,7 +29,8 @@ LDFLAGS="${LDFLAGS} ${SOME_HARDENING_LDFLAGS}"
 
 # use LLVM-provided binutils
 AR="llvm-ar"
-AS="llvm-as"
+AS="clang -c"
+CPP="clang-cpp"
 NM="llvm-nm"
 STRIP="llvm-strip"
 RANLIB="llvm-ranlib"


### PR DESCRIPTION
Add CPP="clang-cpp"
Change AS="llvm-as" to AS="clang -c"

Some x11 packages like, x11-misc/compose-tables, fail to compile when using clang if CPP isn't set to clang-cpp
This only seems to occur when gcc isn't installed to provide $CHOST-cpp as a fallback which can be seen on some musl + clang installs that don't have gcc installed

From what I understand, llvm-as only handles LLVM's assembly and doesn't work as a drop in alternative for as from binutils. This change also fixes an error when compiling firefox on a clang only install