### PR TITLE
profiles/arch/arm64: unmask 'apparmor' USE flag

### DIFF
--- a/profiles/arch/amd64/use.mask
+++ b/profiles/arch/amd64/use.mask
@@ -40,7 +40,10 @@
 -firebird
 
 # Mike Gilbert <floppym@gentoo.org> (2014-10-19)
+# Requires the following packages to be keyworded/stable:
 # sys-libs/libapparmor
+# sys-apps/apparmor
+# sys-apps/apparmor-utils
 -apparmor
 
 # Michał Górny <mgorny@gentoo.org> (2014-03-30)

--- a/profiles/arch/arm64/use.mask
+++ b/profiles/arch/arm64/use.mask
@@ -4,6 +4,10 @@
 # Unmask the flag which corresponds to ARCH.
 -arm64
 
+# Mike Gilbert <floppym@gentoo.org> (2022-08-31)
+# sys-libs/libapparmor
+-apparmor
+
 # David Seifert <soap@gentoo.org> (2022-03-13)
 # NVENC works here
 -nvenc

--- a/profiles/arch/arm64/use.mask
+++ b/profiles/arch/arm64/use.mask
@@ -5,7 +5,10 @@
 -arm64
 
 # Mike Gilbert <floppym@gentoo.org> (2022-08-31)
+# Requires the following packages to be keyworded/stable:
 # sys-libs/libapparmor
+# sys-apps/apparmor
+# sys-apps/apparmor-utils
 -apparmor
 
 # David Seifert <soap@gentoo.org> (2022-03-13)

--- a/profiles/arch/base/use.mask
+++ b/profiles/arch/base/use.mask
@@ -208,7 +208,10 @@ sbcl
 systemd
 
 # Mike Gilbert <floppym@gentoo.org> (2014-10-19)
+# Requires the following packages to be keyworded/stable:
 # sys-libs/libapparmor
+# sys-apps/apparmor
+# sys-apps/apparmor-utils
 apparmor
 
 # Mask flags that correspond to all possible ARCH values.

--- a/profiles/arch/x86/package.use.mask
+++ b/profiles/arch/x86/package.use.mask
@@ -43,10 +43,6 @@ media-video/ffmpeg amf
 # Only supports cpu_flags_x86_aes in 64-bit mode
 net-fs/samba cpu_flags_x86_aes
 
-# Conrad Kostecki <conikost@gentoo.org> (2021-11-16)
-# AppArmor is not available on x86
-app-benchmarks/stress-ng apparmor
-
 # James Le Cuirot <chewi@gentoo.org> (2021-10-22)
 # The JIT feature only works on amd64 and x86.
 app-emulation/fs-uae -jit
@@ -149,11 +145,6 @@ dev-python/influxdb test
 # Mikle Kolyada <zlogene@gentoo.org> (2020-06-08)
 # clisp is keyworded on x86
 app-text/texlive-core -xindy
-
-# Joonas Niilola <juippis@gentoo.org> (2020-05-14)
-# sys-apps/apparmor not keyworded on x86.
-app-containers/lxc apparmor
-app-containers/lxd apparmor
 
 # Georgy Yakovlev <gyakovlev@gentoo.org (2020-04-26)
 # static-pie works on x86, #719444

--- a/profiles/arch/x86/use.mask
+++ b/profiles/arch/x86/use.mask
@@ -34,10 +34,6 @@
 # dev-db/firebird is keyworded ~x86
 -firebird
 
-# Mike Gilbert <floppym@gentoo.org (2014-10-19)
-# sys-libs/libapparmor
--apparmor
-
 # Michał Górny <mgorny@gentoo.org> (2014-03-30)
 # PyPy is keyworded on this arch.
 -python_targets_pypy3

--- a/profiles/arch/x86/use.stable.mask
+++ b/profiles/arch/x86/use.stable.mask
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # This file requires eapi 5 or later. New entries go on top.
@@ -17,10 +17,6 @@ mkl
 # Andreas K. Hüttel <dilfridge@gentoo.org> (2017-05-26)
 # dev-db/firebird is keyworded ~x86
 firebird
-
-# Mike Gilbert <floppym@gentoo.org> (2014-10-19)
-# sys-libs/libapparmor
-apparmor
 
 # Michał Górny <mgorny@gentoo.org> (2014-03-30)
 # PyPy is unstable on this arch.


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/867739