### PR TITLE
media-gfx/openscad: workaround for parallel build failures

### DIFF
--- a/media-gfx/openscad/openscad-2021.01-r4.ebuild
+++ b/media-gfx/openscad/openscad-2021.01-r4.ebuild
@@ -78,7 +78,8 @@ src_configure() {
 }
 
 src_compile() {
-	default
+	# We have random parallel build issues, bug #856430
+	MAKEOPTS="-j1" emake
 
 	if use emacs ; then
 		elisp-compile contrib/*.el


### PR DESCRIPTION
Bug: https://github.com/openscad/openscad/issues/4344
Closes: https://bugs.gentoo.org/856430
Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>