### PR TITLE
profiles/features/selinux: drop obsolete systemd-related masks

### DIFF
--- a/profiles/features/selinux/package.use.mask
+++ b/profiles/features/selinux/package.use.mask
@@ -12,12 +12,7 @@ net-analyzer/wireshark sdjournal
 # Jason Zaman <perfinion@gentoo.org> (2015-06-27)
 # systemd has no support in the SELinux policy at the moment.
 # Please see: https://wiki.gentoo.org/wiki/SELinux/FAQ#Can_I_use_SELinux_with_SystemD.3F
-app-emulation/libvirt firewalld
-gnome-base/gdm wayland
-gnome-base/gnome-extra-apps share
-net-firewall/fwknop firewalld
 www-servers/uwsgi uwsgi_plugins_systemd_logger
->=x11-wm/mutter-3.22 wayland
 
 # Brian Dolbec <dolsen@gentoo.org> (2014-09-17)
 # mask pypy for several utilities due to incompatibility with libselinux

--- a/profiles/features/selinux/package.use.mask
+++ b/profiles/features/selinux/package.use.mask
@@ -10,7 +10,7 @@ sys-apps/ipmitool openbmc
 net-analyzer/wireshark sdjournal
 
 # Jason Zaman <perfinion@gentoo.org> (2015-06-27)
-# systemd has no support in the SELinux policy at the moment.
+# systemd has only experimental support in the SELinux policy at the moment.
 # Please see: https://wiki.gentoo.org/wiki/SELinux/FAQ#Can_I_use_SELinux_with_SystemD.3F
 www-servers/uwsgi uwsgi_plugins_systemd_logger
 


### PR DESCRIPTION
These packages don't require systemd anymore anyway.

Signed-off-by: Sam James <sam@gentoo.org>