### PR TITLE
app-emulation/dxvk-9999: Remove test option

### DIFF
--- a/app-emulation/dxvk/dxvk-9999.ebuild
+++ b/app-emulation/dxvk/dxvk-9999.ebuild
@@ -92,7 +92,6 @@ multilib_src_configure() {
 		$(meson_use {,enable_}d3d11)
 		$(meson_use {,enable_}dxgi)
 		$(usev !debug --strip) # portage won't strip .dll, so allow it here
-		-Denable_tests=false # needs wine/vulkan and is intended for manual use
 	)
 
 	meson_src_configure


### PR DESCRIPTION
This has been removed upstream

Signed-off-by: Mike Lothian <mike@fireburn.co.uk>