### PR TITLE
media-gfx/freecad: fixes to metadata

### DIFF
--- a/media-gfx/freecad/freecad-0.19.4-r1.ebuild
+++ b/media-gfx/freecad/freecad-0.19.4-r1.ebuild
@@ -8,7 +8,7 @@ PYTHON_COMPAT=( python3_{8..10} )
 inherit check-reqs cmake optfeature python-single-r1 xdg
 
 DESCRIPTION="QT based Computer Aided Design application"
-HOMEPAGE="https://www.freecadweb.org/ https://github.com/FreeCAD/FreeCAD"
+HOMEPAGE="https://www.freecad.org/ https://github.com/FreeCAD/FreeCAD"
 
 MY_PN=FreeCAD
 

--- a/media-gfx/freecad/freecad-0.20-r1.ebuild
+++ b/media-gfx/freecad/freecad-0.20-r1.ebuild
@@ -8,7 +8,7 @@ PYTHON_COMPAT=( python3_{8..10} )
 inherit check-reqs cmake optfeature python-single-r1 xdg
 
 DESCRIPTION="QT based Computer Aided Design application"
-HOMEPAGE="https://www.freecadweb.org/ https://github.com/FreeCAD/FreeCAD"
+HOMEPAGE="https://www.freecad.org/ https://github.com/FreeCAD/FreeCAD"
 
 MY_PN=FreeCAD
 

--- a/media-gfx/freecad/freecad-9999.ebuild
+++ b/media-gfx/freecad/freecad-9999.ebuild
@@ -8,7 +8,7 @@ PYTHON_COMPAT=( python3_{8..10} )
 inherit check-reqs cmake optfeature python-single-r1 xdg
 
 DESCRIPTION="QT based Computer Aided Design application"
-HOMEPAGE="https://www.freecadweb.org/ https://github.com/FreeCAD/FreeCAD"
+HOMEPAGE="https://www.freecad.org/ https://github.com/FreeCAD/FreeCAD"
 
 MY_PN=FreeCAD
 

--- a/media-gfx/freecad/metadata.xml
+++ b/media-gfx/freecad/metadata.xml
@@ -101,8 +101,8 @@
 		</flag>
 	</use>
 	<upstream>
-		<bugs-to>https://www.freecadweb.org/tracker/</bugs-to>
+		<bugs-to>https://github.com/FreeCAD/FreeCAD/issues</bugs-to>
 		<remote-id type="github">FreeCAD/FreeCAD</remote-id>
-		<doc lang="en">https://www.freecadweb.org/wiki/MainPage</doc>
+		<doc lang="en">https://wiki.freecad.org/Main_Page</doc>
 	</upstream>
 </pkgmetadata>


### PR DESCRIPTION
While checking p.g.o, I noticed, that some of the metadata
has been changed recently and is no longer valid. The patch
fixes these.

Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>