### PR TITLE
sys-cluster/k9scli: fix typo

### DIFF
--- a/sys-cluster/k9scli/k9scli-0.25.18.ebuild
+++ b/sys-cluster/k9scli/k9scli-0.25.18.ebuild
@@ -23,7 +23,7 @@ src_prepare() {
 }
 
 src_compile() {
-	emake GIT=${GIT_COMMIT} VERSION=v${pv} build
+	emake GIT=${GIT_COMMIT} VERSION=v${PV} build
 }
 
 src_install() {


### PR DESCRIPTION
The PV variable is not expanded correctly due to the typo.

Bug: https://bugs.gentoo.org/868258