### PR TITLE
eclass/*: fixes UnquotedVariable and some extras

### DIFF
--- a/eclass/bazel.eclass
+++ b/eclass/bazel.eclass
@@ -113,7 +113,7 @@ bazel_setup_bazelrc() {
 		fetch --repository_cache="${T}/bazel-cache/" --distdir="${T}/bazel-distdir/"
 		build --repository_cache="${T}/bazel-cache/" --distdir="${T}/bazel-distdir/"
 
-		build --define=PREFIX=${EPREFIX%/}/usr
+		build --define=PREFIX=${EPREFIX}/usr
 		build --define=LIBDIR=\$(PREFIX)/$(get_libdir)
 		build --define=INCLUDEDIR=\$(PREFIX)/include
 		EOF

--- a/eclass/gnustep-base.eclass
+++ b/eclass/gnustep-base.eclass
@@ -256,7 +256,7 @@ EOF
 	if [[ -d ${EPREFIX}/usr/share/GNUstep/Makefiles ]]; then
 		exeinto /usr/bin
 	else
-		exeinto ${GNUSTEP_SYSTEM_TOOLS#${EPREFIX}}/Gentoo
+		exeinto "${GNUSTEP_SYSTEM_TOOLS#${EPREFIX}}"/Gentoo
 	fi
 	doexe "${T}"/${cfile}
 }

--- a/eclass/gstreamer-meson.eclass
+++ b/eclass/gstreamer-meson.eclass
@@ -393,7 +393,7 @@ gstreamer_multilib_src_compile() {
 
 			# https://github.com/ninja-build/ninja/issues/1251
 			# https://github.com/ninja-build/ninja/issues/1330
-			build_dir=$(readlink -f ${BUILD_DIR})
+			build_dir=$(readlink -f "${BUILD_DIR}")
 
 			plugin_path="${plugin%%:*}"
 			eninja "${plugin_path/"${build_dir}/"/}"

--- a/eclass/haskell-cabal.eclass
+++ b/eclass/haskell-cabal.eclass
@@ -390,9 +390,9 @@ cabal-configure() {
 		# it generates for ghc's base and other packages.
 		local p=${EPREFIX}/usr/bin/haddock-ghc-$(ghc-version)
 		if [[ -f $p ]]; then
-			cabalconf+=(--with-haddock="${p}")
+			cabalconf+=( --with-haddock="${p}" )
 		else
-			cabalconf+=(--with-haddock=${EPREFIX}/usr/bin/haddock)
+			cabalconf+=( --with-haddock="${EPREFIX}"/usr/bin/haddock )
 		fi
 	fi
 	if [[ -n "${CABAL_USE_PROFILE}" ]] && use profile; then
@@ -702,7 +702,7 @@ cabal_src_install() {
 	# if it does not exist (dummy libraries and binaries w/o libraries)
 	local ghc_confdir_with_prefix="$(ghc-confdir)"
 	# remove EPREFIX
-	dodir ${ghc_confdir_with_prefix#${EPREFIX}}
+	dodir "${ghc_confdir_with_prefix#${EPREFIX}}"
 	local hint_db="${D}/$(ghc-confdir)"
 	local hint_file="${hint_db}/gentoo-empty-${CATEGORY}-${PF}.conf"
 	mkdir -p "${hint_db}" || die

--- a/eclass/kodi-addon.eclass
+++ b/eclass/kodi-addon.eclass
@@ -1,24 +1,21 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: kodi-addon.eclass
 # @MAINTAINER:
 # candrews@gentoo.org
-# @SUPPORTED_EAPIS: 4 5 6 7
-# @PROVIDES: cmake cmake-utils
+# @SUPPORTED_EAPIS: 7
+# @PROVIDES: cmake
 # @BLURB: Helper for correct building and (importantly) installing Kodi addon packages.
 # @DESCRIPTION:
 # Provides a src_configure function for correct CMake configuration
 
-case "${EAPI:-0}" in
-	4|5|6)
-		inherit cmake-utils multilib
-		;;
-	7)
-		inherit cmake
-		;;
-	*) die "EAPI=${EAPI} is not supported" ;;
+case ${EAPI} in
+	7) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
+
+inherit cmake
 
 EXPORT_FUNCTIONS src_configure
 
@@ -28,11 +25,8 @@ EXPORT_FUNCTIONS src_configure
 kodi-addon_src_configure() {
 
 	mycmakeargs+=(
-		-DCMAKE_INSTALL_LIBDIR=${EPREFIX%/}/usr/$(get_libdir)/kodi
+		-DCMAKE_INSTALL_LIBDIR="${EPREFIX}/usr/$(get_libdir)/kodi"
 	)
 
-	case ${EAPI} in
-		4|5|6) cmake-utils_src_configure ;;
-		7) cmake_src_configure ;;
-	esac
+	cmake_src_configure
 }

--- a/eclass/myspell-r2.eclass
+++ b/eclass/myspell-r2.eclass
@@ -16,19 +16,25 @@
 # @DEFAULT_UNSET
 # @DESCRIPTION:
 # Array variable containing list of all dictionary files.
+# @CODE
 # MYSPELL_DICT=( "file.dic" "dir/file2.aff" )
+# @CODE
 
 # @ECLASS_VARIABLE: MYSPELL_HYPH
 # @DEFAULT_UNSET
 # @DESCRIPTION:
 # Array variable containing list of all hyphenation files.
+# @CODE
 # MYSPELL_HYPH=( "file.dic" "dir/file2.dic" )
+# @CODE
 
 # @ECLASS_VARIABLE: MYSPELL_THES
 # @DEFAULT_UNSET
 # @DESCRIPTION:
 # Array variable containing list of all thesarus files.
+# @CODE
 # MYSPELL_THES=( "file.dat" "dir/file2.idx" )
+# @CODE
 
 case ${EAPI} in
 	7|8)

--- a/eclass/myspell-r2.eclass
+++ b/eclass/myspell-r2.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: myspell-r2.eclass
@@ -6,7 +6,7 @@
 # Conrad Kostecki <conikost@gentoo.org>
 # @AUTHOR:
 # Tomáš Chvátal <scarabeus@gentoo.org>
-# @SUPPORTED_EAPIS: 5 6 7 8
+# @SUPPORTED_EAPIS: 7 8
 # @BLURB: An eclass to streamline the construction of ebuilds for new Myspell dictionaries.
 # @DESCRIPTION:
 # The myspell-r2 eclass is designed to streamline the construction of ebuilds for
@@ -30,8 +30,8 @@
 # Array variable containing list of all thesarus files.
 # MYSPELL_THES=( "file.dat" "dir/file2.idx" )
 
-case ${EAPI:-0} in
-	[5-8])
+case ${EAPI} in
+	7|8)
 		;;
 	*)
 		die "${ECLASS}: EAPI ${EAPI:-0} not supported"
@@ -43,12 +43,7 @@ EXPORT_FUNCTIONS src_unpack src_install
 # Basically no extra deps needed.
 # Unzip is required for .oxt libreoffice extensions
 # which are just fancy zip files.
-if [[ ${EAPI:-0} != [56] ]]; then
-	BDEPEND="app-arch/unzip"
-else
-	DEPEND="app-arch/unzip"
-	RDEPEND=""
-fi
+BDEPEND="app-arch/unzip"
 
 # by default this stuff does not have any folder in the pack
 S="${WORKDIR}"
@@ -65,7 +60,7 @@ myspell-r2_src_unpack() {
 		case ${f} in
 			*.oxt)
 				echo ">>> Unpacking "${DISTDIR}/${f}" to ${PWD}"
-				unzip -qoj ${DISTDIR}/${f}
+				unzip -qoj "${DISTDIR}"/${f}
 				assert "failed unpacking ${DISTDIR}/${f}"
 				;;
 			*) unpack ${f} ;;

--- a/eclass/rebar.eclass
+++ b/eclass/rebar.eclass
@@ -68,7 +68,7 @@ _rebar_find_dep() {
 	local p
 	local result
 
-	pushd "${EPREFIX%/}/$(get_erl_libs)" >/dev/null || return 1
+	pushd "${EPREFIX}/$(get_erl_libs)" >/dev/null || return 1
 	for p in ${pn} ${pn}-*; do
 		if [[ -d ${p} ]]; then
 			# Ensure there's at most one matching.
@@ -107,7 +107,7 @@ erebar() {
 
 	(( $# > 0 )) || die "erebar: at least one target is required"
 
-	local -x ERL_LIBS="${EPREFIX%/}/$(get_erl_libs)"
+	local -x ERL_LIBS="${EPREFIX}/$(get_erl_libs)"
 	[[ ${1} == eunit ]] && local -x ERL_LIBS="."
 
 	rebar -v skip_deps=true "$@" || die -n "rebar $@ failed"
@@ -128,7 +128,7 @@ rebar_fix_include_path() {
 
 	local pn="${1}"
 	local rebar_config="${2:-rebar.config}"
-	local erl_libs="${EPREFIX%/}/$(get_erl_libs)"
+	local erl_libs="${EPREFIX}/$(get_erl_libs)"
 	local p
 
 	p="$(_rebar_find_dep "${pn}")" \
@@ -217,7 +217,7 @@ rebar_src_prepare() {
 rebar_src_configure() {
 	debug-print-function ${FUNCNAME} "${@}"
 
-	local -x ERL_LIBS="${EPREFIX%/}/$(get_erl_libs)"
+	local -x ERL_LIBS="${EPREFIX}/$(get_erl_libs)"
 	default
 }
 

--- a/eclass/rebar.eclass
+++ b/eclass/rebar.eclass
@@ -6,7 +6,7 @@
 # maintainer-needed@gentoo.org
 # @AUTHOR:
 # Amadeusz Żołnowski <aidecoe@gentoo.org>
-# @SUPPORTED_EAPIS: 6 7
+# @SUPPORTED_EAPIS: 6 7 8
 # @BLURB: Build Erlang/OTP projects using dev-util/rebar.
 # @DESCRIPTION:
 # An eclass providing functions to build Erlang/OTP projects using
@@ -19,15 +19,9 @@
 # targets. The eclass workarounds some of these problems. It handles
 # installation in a generic way for Erlang/OTP structured projects.
 
-case "${EAPI:-0}" in
-	0|1|2|3|4|5)
-		die "Unsupported EAPI=${EAPI:-0} (too old) for ${ECLASS}"
-		;;
-	6|7)
-		;;
-	*)
-		die "Unsupported EAPI=${EAPI} (unknown) for ${ECLASS}"
-		;;
+case ${EAPI} in
+	6|7|8) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
 
 EXPORT_FUNCTIONS src_prepare src_compile src_test src_install

--- a/eclass/ruby-ng-gnome2.eclass
+++ b/eclass/ruby-ng-gnome2.eclass
@@ -118,7 +118,7 @@ each_ruby_install() {
 	if [[ -e Makefile ]]; then
 		# Create the directories, or the package will create them as files.
 		local archdir=$(ruby_rbconfig_value "sitearchdir")
-		dodir ${archdir#${EPREFIX}} /usr/$(get_libdir)/pkgconfig
+		dodir "${archdir#${EPREFIX}}" /usr/$(get_libdir)/pkgconfig
 
 		emake DESTDIR="${D}" install
 	fi

--- a/eclass/ruby-ng.eclass
+++ b/eclass/ruby-ng.eclass
@@ -630,7 +630,7 @@ doruby() {
 	[[ -z ${RUBY} ]] && die "\$RUBY is not set"
 	( # don't want to pollute calling env
 		sitelibdir=$(ruby_rbconfig_value 'sitelibdir')
-		insinto ${sitelibdir#${EPREFIX}}
+		insinto "${sitelibdir#${EPREFIX}}"
 		insopts -m 0644
 		doins "$@"
 	) || die "failed to install $@"

--- a/eclass/selinux-policy-2.eclass
+++ b/eclass/selinux-policy-2.eclass
@@ -187,11 +187,11 @@ selinux-policy-2_src_prepare() {
 
 	# Collect only those files needed for this particular module
 	for i in ${MODS}; do
-		modfiles="$(find ${S}/refpolicy/policy/modules -iname $i.te) $modfiles"
-		modfiles="$(find ${S}/refpolicy/policy/modules -iname $i.fc) $modfiles"
-		modfiles="$(find ${S}/refpolicy/policy/modules -iname $i.cil) $modfiles"
+		modfiles="$(find "${S}/refpolicy/policy/modules" -iname $i.te) $modfiles"
+		modfiles="$(find "${S}/refpolicy/policy/modules" -iname $i.fc) $modfiles"
+		modfiles="$(find "${S}/refpolicy/policy/modules" -iname $i.cil) $modfiles"
 		if [[ ${add_interfaces} -eq 1 ]]; then
-			modfiles="$(find ${S}/refpolicy/policy/modules -iname $i.if) $modfiles"
+			modfiles="$(find "${S}/refpolicy/policy/modules" -iname $i.if) $modfiles"
 		fi
 	done
 

--- a/eclass/udev.eclass
+++ b/eclass/udev.eclass
@@ -61,7 +61,7 @@ _udev_get_udevdir() {
 	local -x PKG_CONFIG_FDO_SYSROOT_RULES=1
 	if $($(tc-getPKG_CONFIG) --exists udev); then
 		local udevdir="$($(tc-getPKG_CONFIG) --variable=udevdir udev)"
-		echo "${udevdir#${EPREFIX%/}}"
+		echo "${udevdir#${EPREFIX}}"
 	else
 		echo /lib/udev
 	fi

--- a/eclass/vdr-plugin-2.eclass
+++ b/eclass/vdr-plugin-2.eclass
@@ -276,10 +276,9 @@ vdr_gettext_missing() {
 # DIR ${S}/po or DIR ${S]/_subdir_/po
 vdr_detect_po_dir() {
 	[[ -f po ]] && local po_dir="${S}"
-	local po_subdir=( ${S}/${PO_SUBDIR} )
-	local f
+	local po_subdir=( "${S}"/${PO_SUBDIR} )
 
-	pofile_dir=( ${po_dir} ${po_subdir[*]} )
+	pofile_dir=( ${po_dir} "${po_subdir[@]}" )
 }
 
 # @FUNCTION: vdr_linguas_support
@@ -605,7 +604,7 @@ vdr-plugin-2_src_install() {
 		local linguas
 		for linguas in ${LINGUAS[*]}; do
 		insinto "${LOCDIR}"
-		cp -r --parents ${linguas}* ${D%/}/${LOCDIR} \
+		cp -r --parents ${linguas}* "${D%/}"/${LOCDIR} \
 			|| die "could not copy linguas files"
 		done
 	fi

--- a/eclass/webapp.eclass
+++ b/eclass/webapp.eclass
@@ -201,7 +201,7 @@ webapp_configfile() {
 		my_file="$(webapp_strip_cwd "${my_file}")"
 
 		elog "(config) ${my_file}"
-		echo "${my_file}" >> ${D}/${WA_CONFIGLIST}
+		echo "${my_file}" >> "${D}/${WA_CONFIGLIST}"
 	done
 }
 


### PR DESCRIPTION
- fix `UnquotedVariable` results from live pkgcheck (note that the current CI reports some more cases, they were false positives I fixed in live pkgcheck, but still not released)
- Dropped `EAPI<7` support from `kodi-addon.eclass` and `myspell-r2.eclass`, because there were no consumers, and if we already invalidate cache, then to go with it.
- Did some refactor on `kodi-addon.eclass`, because it looked easy enough?

I will post this to ML later, and then start the timer. Currently I just want some basic first reviews, as this is my first cross eclasses changes.

- [x] clean up instances of `${EPREFIX%/}`