### PR TITLE
Backport critical fixes to sci-libs/avogadrolibs

### DIFF
--- a/sci-libs/avogadrolibs/avogadrolibs-1.95.1.ebuild
+++ b/sci-libs/avogadrolibs/avogadrolibs-1.95.1.ebuild
@@ -47,6 +47,7 @@ BDEPEND="
 PATCHES=(
 	"${FILESDIR}/"${PN}-1.91.0_pre20180406-bundled-genxrdpattern.patch
 	"${FILESDIR}/"${PN}-1.95.1-tests.patch
+	"${FILESDIR}/"${PN}-1.95.1-usability_backport.patch
 )
 
 src_unpack() {

--- a/sci-libs/avogadrolibs/files/avogadrolibs-1.95.1-usability_backport.patch
+++ b/sci-libs/avogadrolibs/files/avogadrolibs-1.95.1-usability_backport.patch
@@ -1,0 +1,81 @@
+From 56c67fff7dd7ec84b2f2b5c2e5beaec13981e408 Mon Sep 17 00:00:00 2001
+From: Aritz Erkiaga <aerkiaga3@gmail.com>
+Date: Sat, 3 Sep 2022 16:54:55 +0200
+Subject: [PATCH 1/3] Fix erratic editing behavior
+
+Signed-off-by: Aritz Erkiaga <aerkiaga3@gmail.com>
+---
+ avogadro/qtgui/rwmolecule_undo.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/avogadro/qtgui/rwmolecule_undo.h b/avogadro/qtgui/rwmolecule_undo.h
+index de5bdd33..20768066 100644
+--- a/avogadro/qtgui/rwmolecule_undo.h
++++ b/avogadro/qtgui/rwmolecule_undo.h
+@@ -89,7 +89,7 @@ public:
+   {
+     assert(m_molecule.atomCount() == m_atomId);
+     if (m_usingPositions)
+-      m_molecule.addAtom(m_atomicNumber, Vector3::Zero(), m_atomId);
++      m_molecule.addAtom(m_atomicNumber, Vector3::Zero(), m_atomUid);
+     else
+       m_molecule.addAtom(m_atomicNumber, m_atomUid);
+     m_molecule.layer().addAtom(m_layer, m_atomId);
+-- 
+2.34.1
+
+
+From 5159ea1a9629ad82130670767cc25c5065f9627c Mon Sep 17 00:00:00 2001
+From: Aritz Erkiaga <aerkiaga3@gmail.com>
+Date: Sat, 3 Sep 2022 16:55:26 +0200
+Subject: [PATCH 2/3] Fix Manipulator Tool not working at all
+
+Signed-off-by: Aritz Erkiaga <aerkiaga3@gmail.com>
+---
+ avogadro/qtplugins/manipulator/manipulator.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/avogadro/qtplugins/manipulator/manipulator.cpp b/avogadro/qtplugins/manipulator/manipulator.cpp
+index 19dc51ac..29559dd0 100644
+--- a/avogadro/qtplugins/manipulator/manipulator.cpp
++++ b/avogadro/qtplugins/manipulator/manipulator.cpp
+@@ -129,7 +129,7 @@ QUndoCommand* Manipulator::mouseMoveEvent(QMouseEvent* e)
+   Vector2f windowPos(e->localPos().x(), e->localPos().y());
+ 
+   if (mol->isSelectionEmpty() && m_object.type == Rendering::AtomType &&
+-      m_object.molecule == mol) {
++      m_object.molecule == &m_molecule->molecule()) {
+     // translate single atom position
+     RWAtom atom = m_molecule->atom(m_object.index);
+     Vector3f oldPos(atom.position3d().cast<float>());
+-- 
+2.34.1
+
+
+From f38bfbc88f0722a66ab298ff26073874b5f73634 Mon Sep 17 00:00:00 2001
+From: Aritz Erkiaga <aerkiaga3@gmail.com>
+Date: Sat, 3 Sep 2022 16:55:59 +0200
+Subject: [PATCH 3/3] Fix Bond Centric Tool not working at all
+
+Signed-off-by: Aritz Erkiaga <aerkiaga3@gmail.com>
+---
+ avogadro/qtplugins/bondcentrictool/bondcentrictool.cpp | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/avogadro/qtplugins/bondcentrictool/bondcentrictool.cpp b/avogadro/qtplugins/bondcentrictool/bondcentrictool.cpp
+index 79112899..3a853057 100644
+--- a/avogadro/qtplugins/bondcentrictool/bondcentrictool.cpp
++++ b/avogadro/qtplugins/bondcentrictool/bondcentrictool.cpp
+@@ -342,8 +342,7 @@ QUndoCommand* BondCentricTool::mousePressEvent(QMouseEvent* e)
+   Rendering::Identifier ident = m_renderer->hit(e->pos().x(), e->pos().y());
+ 
+   // If no hits, return. Also ensure that the hit molecule is the one we expect.
+-  const Core::Molecule* mol = &m_molecule->molecule();
+-  if (!ident.isValid() || ident.molecule != mol)
++  if (!ident.isValid() || ident.molecule != &m_molecule->molecule())
+     return nullptr;
+ 
+   // If the hit is a left click on a bond, make it the selected bond and map
+-- 
+2.34.1
+


### PR DESCRIPTION
This fixes https://bugs.gentoo.org/868132, while not introducing any further changes.