### PR TITLE
media-gfx/graphicsmagick: enable threads by default

### DIFF
--- a/media-gfx/graphicsmagick/graphicsmagick-1.3.38-r3.ebuild
+++ b/media-gfx/graphicsmagick/graphicsmagick-1.3.38-r3.ebuild
@@ -67,6 +67,7 @@ DEPEND="${RDEPEND}"
 PATCHES=(
 	"${FILESDIR}"/${PN}-1.3.36-flags.patch
 	"${FILESDIR}"/${PN}-1.3.19-perl.patch
+	"${FILESDIR}"/${P}-configure-bashism.patch
 )
 
 pkg_pretend() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/868360
Signed-off-by: Holger Hoffstätte holger@applied-asynchrony.com

