### PR TITLE
mail-client/alpine: enable threads by default

### DIFF
--- a/mail-client/alpine/alpine-2.26.ebuild
+++ b/mail-client/alpine/alpine-2.26.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://alpineapp.email/alpine/release/src/${P}.tar.xz
 LICENSE="Apache-2.0"
 SLOT="0"
 KEYWORDS="~alpha ~amd64 ~ia64 ~ppc ~ppc64 ~sparc ~x86"
-IUSE="+chappa ipv6 kerberos ldap nls onlyalpine passfile smime ssl threads"
+IUSE="+chappa ipv6 kerberos ldap nls onlyalpine passfile smime ssl"
 
 DEPEND="sys-libs/ncurses:=
 	virtual/libcrypt:=
@@ -37,13 +37,13 @@ src_prepare() {
 src_configure() {
 	myconf=(
 		--without-tcl
+		--with-pthread
 		--with-system-pinerc="${EPREFIX}"/etc/pine.conf
 		--with-system-fixed-pinerc="${EPREFIX}"/etc/pine.conf.fixed
 		$(use_with ldap)
 		$(use_with ssl)
 		$(use_with passfile passfile .pinepwd)
 		$(use_with kerberos krb5)
-		$(use_with threads pthread)
 		$(use_enable nls)
 		$(use_with ipv6)
 		$(use_with smime)


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/868396
Signed-off-by: Holger Hoffstätte holger@applied-asynchrony.com
