### PR TITLE
dev-util/rocminfo: enable release build

### DIFF
--- a/dev-util/rocminfo/rocminfo-5.0.2.ebuild
+++ b/dev-util/rocminfo/rocminfo-5.0.2.ebuild
@@ -28,3 +28,8 @@ src_prepare() {
 	sed -e "/CPACK_RESOURCE_FILE_LICENSE/d" -i CMakeLists.txt || die
 	cmake_src_prepare
 }
+
+src_configure() {
+	local mycmakeargs=( -DROCRTST_BLD_TYPE=Release )
+	cmake_src_configure
+}

--- a/dev-util/rocminfo/rocminfo-5.1.3.ebuild
+++ b/dev-util/rocminfo/rocminfo-5.1.3.ebuild
@@ -29,3 +29,8 @@ src_prepare() {
 	sed -e "/num_change_since_prev_pkg(/cset(NUM_COMMITS 0)" -i cmake_modules/utils.cmake || die # Fix QA issue on "git not found"
 	cmake_src_prepare
 }
+
+src_configure() {
+	local mycmakeargs=( -DROCRTST_BLD_TYPE=Release )
+	cmake_src_configure
+}

--- a/dev-util/rocminfo/rocminfo-5.3.3.ebuild
+++ b/dev-util/rocminfo/rocminfo-5.3.3.ebuild
@@ -29,3 +29,8 @@ src_prepare() {
 	sed -e "/num_change_since_prev_pkg(/cset(NUM_COMMITS 0)" -i cmake_modules/utils.cmake || die # Fix QA issue on "git not found"
 	cmake_src_prepare
 }
+
+src_configure() {
+	local mycmakeargs=( -DROCRTST_BLD_TYPE=Release )
+	cmake_src_configure
+}

--- a/dev-util/rocminfo/rocminfo-9999.ebuild
+++ b/dev-util/rocminfo/rocminfo-9999.ebuild
@@ -21,3 +21,8 @@ SLOT="0/$(ver_cut 1-2)"
 
 RDEPEND="dev-libs/rocr-runtime"
 DEPEND="${RDEPEND}"
+
+src_configure() {
+	local mycmakeargs=( -DROCRTST_BLD_TYPE=Release )
+	cmake_src_configure
+}


### PR DESCRIPTION
The rocminfo CMake file uses a custom variable named ROCRTST_BLD_TYPE to
set CMAKE_BUILD_TYPE. When not set, this defaults to Debug, which adds
-O0 to CXXFLAGS. This overrides the optimization flags in CXXFLAGS in
make.conf.

When the CXXFLAGS in make.conf contain _FORTIFY_SOURCE, this breaks
compilation with the following error:

/usr/include/features.h:412:4: error: #warning _FORTIFY_SOURCE requires compiling with optimization (-O) [-Werror=cpp]
  412 | #  warning _FORTIFY_SOURCE requires compiling with optimization (-O)
      |    ^~~~~~~

Fix this by setting the ROCRTST_BLD_TYPE variable to Release in
mycmakeargs.

Closes: https://bugs.gentoo.org/887583
Package-Manager: Portage-3.0.30, Repoman-3.0.3
Signed-off-by: Stijn Tintel <stijn@linux-ipv6.be>