### PR TITLE
Add blockers to avoid collisions on merged-usr and prevent abuse on split-usr

### DIFF
--- a/app-arch/bzip2/bzip2-1.0.8-r1.ebuild
+++ b/app-arch/bzip2/bzip2-1.0.8-r1.ebuild
@@ -24,6 +24,7 @@ KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~loong ~m68k ~mips ppc ppc64 ~riscv 
 IUSE="static static-libs"
 
 BDEPEND="verify-sig? ( sec-keys/openpgp-keys-bzip2 )"
+RDEPEND="!app-arch/lbzip2[symlink(-)]"
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-1.0.4-makefile-CFLAGS.patch

--- a/app-arch/bzip2/bzip2-9999.ebuild
+++ b/app-arch/bzip2/bzip2-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -18,6 +18,8 @@ LICENSE="BZIP2"
 SLOT="0/1" # subslot = SONAME
 
 IUSE="static-libs"
+
+RDEPEND="!app-arch/lbzip2[symlink(-)]"
 
 multilib_src_configure() {
 	local emesonargs=(

--- a/app-arch/gzip/gzip-1.12.ebuild
+++ b/app-arch/gzip/gzip-1.12.ebuild
@@ -21,6 +21,8 @@ KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~loong ~m68k ~mips ppc ppc64 ~riscv 
 IUSE="pic static"
 
 BDEPEND="verify-sig? ( sec-keys/openpgp-keys-gzip )"
+RDEPEND="!app-arch/pigz[symlink(-)]
+	!app-arch/ncompress"
 
 PATCHES=(
 	"${FILESDIR}/${PN}-1.3.8-install-symlinks.patch"


### PR DESCRIPTION
The affected packages (pigz, lbzip2, ncompress) are relying on the split between /bin and /usr/bin to "override" the binaries installed by gzip and bzip2.

I think this is a bad idea in general, and should probably be banned.

In the mean time, let's add a blockers to prevent issues on merged-usr.