### PR TITLE
kernel-install.eclass: pkg_preinst: fix symlinks for merged-usr

### DIFF
--- a/eclass/kernel-install.eclass
+++ b/eclass/kernel-install.eclass
@@ -418,6 +418,12 @@ kernel-install_pkg_preinst() {
 		eerror "Please verify that you are applying the correct patches."
 		die "Kernel release mismatch (${release} instead of ${PV}*)"
 	fi
+	if [[ -L ${EROOT}/lib && ${EROOT}/lib -ef ${EROOT}/usr/lib ]]; then
+		# Adjust symlinks for merged-usr.
+		rm "${ED}/lib/modules/${ver}"/{build,source} || die
+		dosym "../../../src/linux-${ver}" "/usr/lib/modules/${ver}/build"
+		dosym "../../../src/linux-${ver}" "/usr/lib/modules/${ver}/source"
+	fi
 }
 
 # @FUNCTION: kernel-install_install_all


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/843821