### PR TITLE
dev-libs/keystone: explicitly specify python interpreter for cmake

### DIFF
--- a/dev-libs/keystone/keystone-0.9.2-r1.ebuild
+++ b/dev-libs/keystone/keystone-0.9.2-r1.ebuild
@@ -56,6 +56,10 @@ wrap_python() {
 	fi
 }
 
+pkg_setup() {
+	python_setup
+}
+
 src_prepare() {
 	default
 
@@ -73,6 +77,7 @@ src_configure() {
 		-DBUILD_SHARED_LIBS=ON
 		-DLLVM_TARGETS_TO_BUILD="${LLVM_TARGETS// /;}"
 		-DLLVM_HOST_TRIPLE="${CHOST}"
+		-DPYTHON_EXECUTABLE="${PYTHON}"
 	)
 
 	cmake_src_configure

--- a/dev-libs/keystone/keystone-9999.ebuild
+++ b/dev-libs/keystone/keystone-9999.ebuild
@@ -56,6 +56,10 @@ wrap_python() {
 	fi
 }
 
+pkg_setup() {
+	python_setup
+}
+
 src_prepare() {
 	default
 
@@ -73,6 +77,7 @@ src_configure() {
 		-DBUILD_SHARED_LIBS=ON
 		-DLLVM_TARGETS_TO_BUILD="${LLVM_TARGETS// /;}"
 		-DLLVM_HOST_TRIPLE="${CHOST}"
+		-DPYTHON_EXECUTABLE="${PYTHON}"
 	)
 
 	cmake_src_configure


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/867631
Signed-off-by: Mario Haustein <mario.haustein@hrz.tu-chemnitz.de>