### PR TITLE
media-libs/openexr: fix build for gcc-13

### DIFF
--- a/media-libs/openexr/files/openexr-3.1.5-Add-missing-include-cstdint-required-by-gcc-13-1264.patch
+++ b/media-libs/openexr/files/openexr-3.1.5-Add-missing-include-cstdint-required-by-gcc-13-1264.patch
@@ -1,0 +1,44 @@
+From https://github.com/AcademySoftwareFoundation/openexr/commit/c5763cfdf59ef4880dacdb11664782822a0976cd
+From: Cary Phillips <cary@ilm.com>
+Date: Sun, 31 Jul 2022 13:36:03 -0700
+Subject: [PATCH 1/4] Add missing #include <cstdint> required by gcc-13 (#1264)
+
+Originally submitted as #1262, thanks.
+
+Signed-off-by: Cary Phillips <cary@ilm.com>
+
+Adapted changes in exrcheck/main.cpp for 3.1.5 code base on Gentoo (different
+ordering of #included header files compared to current HEAD).
+--- a/src/bin/exrcheck/main.cpp
++++ b/src/bin/exrcheck/main.cpp
+@@ -4,6 +4,7 @@
+ #include <ImfCheckFile.h>
+ #include <ImathConfig.h>
+ 
++#include <cstdint>
+ #include <iostream>
+ #include <fstream>
+ #include <string.h>
+--- a/src/lib/OpenEXR/ImfDeepTiledInputFile.h
++++ b/src/lib/OpenEXR/ImfDeepTiledInputFile.h
+@@ -19,6 +19,7 @@
+ 
+ #include "ImfTileDescription.h"
+ 
++#include <cstdint>
+ #include <ImathBox.h>
+ 
+ OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_ENTER
+--- a/src/lib/OpenEXR/ImfDeepTiledInputPart.h
++++ b/src/lib/OpenEXR/ImfDeepTiledInputPart.h
+@@ -10,6 +10,7 @@
+ 
+ #include "ImfTileDescription.h"
+ 
++#include <cstdint>
+ #include <ImathBox.h>
+ 
+ OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_ENTER
+-- 
+2.37.3
+

--- a/media-libs/openexr/files/openexr-3.1.5-add-missed-include-cstdint-statement.patch
+++ b/media-libs/openexr/files/openexr-3.1.5-add-missed-include-cstdint-statement.patch
@@ -1,0 +1,21 @@
+https://github.com/AcademySoftwareFoundation/openexr/pull/1276
+
+From 974b14f67e89dddb6710364034116b3f7b9e0247 Mon Sep 17 00:00:00 2001
+From: Bernd Waibel <waebbl-gentoo@posteo.net>
+Date: Thu, 15 Sep 2022 18:58:01 +0200
+Subject: [PATCH] add missed #include <cstdint> statement
+
+Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>
+--- a/src/lib/OpenEXR/ImfTiledMisc.h
++++ b/src/lib/OpenEXR/ImfTiledMisc.h
+@@ -19,6 +19,7 @@
+ 
+ #include <stdio.h>
+ #include <vector>
++#include <cstdint>
+ 
+ OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_ENTER
+ 
+-- 
+2.37.3
+

--- a/media-libs/openexr/openexr-3.1.5.ebuild
+++ b/media-libs/openexr/openexr-3.1.5.ebuild
@@ -30,7 +30,11 @@ BDEPEND="
 	virtual/pkgconfig
 "
 
-PATCHES=( "${FILESDIR}"/${PN}-3.1.1-0003-disable-failing-test.patch )
+PATCHES=(
+	"${FILESDIR}"/${PN}-3.1.1-0003-disable-failing-test.patch
+	"${FILESDIR}"/${P}-Add-missing-include-cstdint-required-by-gcc-13-1264.patch
+	"${FILESDIR}"/${P}-add-missed-include-cstdint-statement.patch
+)
 
 DOCS=( CHANGES.md GOVERNANCE.md PATENTS README.md SECURITY.md docs/SymbolVisibility.md )
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/868693
Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>