### PR TITLE
x11-misc/gmrun: update metadata

### DIFF
--- a/x11-misc/gmrun/metadata.xml
+++ b/x11-misc/gmrun/metadata.xml
@@ -14,13 +14,13 @@
 		<name>Proxy Maintainers</name>
 	</maintainer>
 	<longdescription>
-		A run utility intended to replace grun or gnome-run. Most prominent
+		A run utility intended to replace <pkg>x11-misc/grun</pkg> or gnome-run. Most prominent
 		features include slim design and bash style auto-completion.
 	</longdescription>
 	<upstream>
 		<remote-id type="github">WdesktopX/gmrun</remote-id>
 	</upstream>
 	<use>
-		<flag name="xdg">Enable xdf spec for configuration and history file location</flag>
+		<flag name="xdg">Enable xdg spec for configuration and history files location</flag>
 	</use>
 </pkgmetadata>


### PR DESCRIPTION
- use `<pkg>` tag to reference `x11-misc/grun`
- fix typo: xdf -> xdg
- plural for configuration and history files