### PR TITLE
dev-libs/capstone: fix out of bound memory access

### DIFF
--- a/dev-libs/capstone/capstone-5.0_rc2-r2.ebuild
+++ b/dev-libs/capstone/capstone-5.0_rc2-r2.ebuild
@@ -1,0 +1,83 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DISTUTILS_OPTIONAL=1
+PYTHON_COMPAT=( python3_{8..11} )
+
+inherit cmake distutils-r1 toolchain-funcs
+
+DESCRIPTION="disassembly/disassembler framework + bindings"
+HOMEPAGE="http://www.capstone-engine.org/"
+SRC_URI="https://github.com/capstone-engine/capstone/archive/${PV/_rc/-rc}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="BSD"
+SLOT="0/5" # libcapstone.so.5
+KEYWORDS="~amd64 ~arm ~arm64 ~riscv ~x86"
+
+IUSE="python test"
+RDEPEND="python? ( ${PYTHON_DEPS} )"
+DEPEND="${RDEPEND}
+	python? ( dev-python/setuptools[${PYTHON_USEDEP}] )
+"
+REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
+
+distutils_enable_tests setup.py
+
+S=${WORKDIR}/${P/_rc/-rc}
+
+PATCHES=(
+	"${FILESDIR}"/${P}-pkgconfig.patch
+	"${FILESDIR}"/${P}-oob-mem-access.patch
+)
+
+if [[ ${PV} == *_rc* ]]; then
+	# Upstream doesn't flag release candidates (bug 858350)
+	QA_PKGCONFIG_VERSION=""
+fi
+
+wrap_python() {
+	local phase=$1
+	shift
+
+	if use python; then
+		pushd bindings/python >/dev/null || die
+		distutils-r1_${phase} "$@"
+		popd >/dev/null || die
+	fi
+}
+
+src_prepare() {
+	tc-export RANLIB
+	cmake_src_prepare
+
+	wrap_python ${FUNCNAME}
+}
+
+src_configure() {
+	local mycmakeargs=(
+		-DCAPSTONE_BUILD_TESTS="$(usex test)"
+	)
+	cmake_src_configure
+
+	wrap_python ${FUNCNAME}
+}
+
+src_compile() {
+	cmake_src_compile
+
+	wrap_python ${FUNCNAME}
+}
+
+src_test() {
+	cmake_src_test
+
+	wrap_python ${FUNCNAME}
+}
+
+src_install() {
+	cmake_src_install
+
+	wrap_python ${FUNCNAME}
+}

--- a/dev-libs/capstone/files/capstone-5.0_rc2-oob-mem-access.patch
+++ b/dev-libs/capstone/files/capstone-5.0_rc2-oob-mem-access.patch
@@ -1,0 +1,40 @@
+Author: Mario Haustein <mario.haustein@hrz.tu-chemnitz.de>
+Date:   Mon Aug 22 18:52:19 2022 +0200
+
+    PPC: fix out of bound memory access
+    
+    closes #1912
+
+Bug: https://bugs.gentoo.org/865151
+Upstream: https://github.com/capstone-engine/capstone/pull/1913
+
+diff --git a/arch/PowerPC/PPCInstPrinter.c b/arch/PowerPC/PPCInstPrinter.c
+index 22eef4ee..a5a30a8b 100644
+--- a/arch/PowerPC/PPCInstPrinter.c
++++ b/arch/PowerPC/PPCInstPrinter.c
+@@ -1116,7 +1116,8 @@ static char *stripRegisterPrefix(const char *RegName)
+ 				char *name = cs_strdup(RegName + 2);
+ 
+ 				// also strip the last 2 letters
+-				name[strlen(name) - 2] = '\0';
++				if(strlen(name) > 2)
++					name[strlen(name) - 2] = '\0';
+ 
+ 				return name;
+ 			}
+diff --git a/suite/cstest/issues.cs b/suite/cstest/issues.cs
+index e4fb6cfa..3183f43f 100644
+--- a/suite/cstest/issues.cs
++++ b/suite/cstest/issues.cs
+@@ -1,3 +1,11 @@
++!# issue 1912 PPC register name
++!# CS_ARCH_PPC, CS_MODE_BIG_ENDIAN, None
++0x2d,0x03,0x00,0x80 == cmpwi cr2, r3, 0x80
++
++!# issue 1912 PPC no register name
++!# CS_ARCH_PPC, CS_MODE_BIG_ENDIAN, CS_OPT_SYNTAX_NOREGNAME
++0x2d,0x03,0x00,0x80 == cmpwi 2, 3, 0x80
++
+ !# issue 1839 AArch64 Incorrect detailed disassembly of ldr
+ !# CS_ARCH_ARM64, CS_MODE_ARM, CS_OPT_DETAIL
+ 0x41,0x00,0x40,0xf9 == ldr x1, [x2] ; operands[0].access: WRITE ; operands[1].access: READ


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/865151
Signed-off-by: Mario Haustein <mario.haustein@hrz.tu-chemnitz.de>