### PR TITLE
app-editors/neovim: fix live ebuild patch file

### DIFF
--- a/app-editors/neovim/files/neovim-9999-cmake-darwin.patch
+++ b/app-editors/neovim/files/neovim-9999-cmake-darwin.patch
@@ -26,7 +26,7 @@
 -  # Work around some old, broken detection by CMake for knowing when to use the
 -  # isystem flag.  Apple's compilers have supported this for quite some time
 -  # now.
--  if(CMAKE_COMPILER_IS_GNUCC)
+-  if(CMAKE_C_COMPILER_ID_MATCHES "GNU")
 -    set(CMAKE_INCLUDE_SYSTEM_FLAG_C "-isystem ")
 -  endif()
 -endif()


### PR DESCRIPTION
Upstream has [changed its CMakeLists.txt file](https://github.com/neovim/neovim/commit/bb35422659bdc619d95cb87554632018a5a15636), replacing the deprecated variable CMAKE_COMPILER_IS_GNUCC, which causes the patch phase of the live ebuild to fail.

This commit fixes this issue and with this in place, patching succeeds.

Signed-off-by: Bharath Saiguhan <bharathsaiguhan@protonmail.com>