### PR TITLE
games-action/polymc: add patch for explicitly include QDebug in PollServer.cpp

### DIFF
--- a/games-action/polymc/files/polymc-1.4.1-include_QDebug.patch
+++ b/games-action/polymc/files/polymc-1.4.1-include_QDebug.patch
@@ -1,0 +1,16 @@
+add explicit QDebug include in PollServer
+https://bugs.gentoo.org/869395
+--- a/libraries/katabasis/src/PollServer.cpp
++++ b/libraries/katabasis/src/PollServer.cpp
+@@ -1,6 +1,8 @@
+ #include <QNetworkAccessManager>
+ #include <QNetworkReply>
+ 
++#include <QDebug>
++
+ #include "katabasis/PollServer.h"
+ #include "JsonResponse.h"
+ 
+-- 
+2.37.3
+

--- a/games-action/polymc/polymc-1.4.1-r2.ebuild
+++ b/games-action/polymc/polymc-1.4.1-r2.ebuild
@@ -33,9 +33,9 @@ fi
 
 # Apache-2.0 for MultiMC (PolyMC is forked from it)
 # GPL-3 for PolyMC
-# LGPL-3+ for libnbtplusplus
+# LGPL-3 for libnbtplusplus
 # See the rest of PolyMC's libraries at https://github.com/PolyMC/PolyMC/tree/develop/libraries
-LICENSE="Apache-2.0 BSD BSD-2 GPL-2+ GPL-3 ISC LGPL-2.1+ LGPL-3+ MIT"
+LICENSE="Apache-2.0 Boost-1.0 BSD BSD-2 GPL-2+ GPL-3 LGPL-3 OFL-1.1 MIT"
 
 SLOT="0"
 
@@ -84,6 +84,10 @@ RDEPEND="
 	>=virtual/jre-1.8.0:*
 	virtual/opengl
 "
+
+PATCHES=(
+	"${FILESDIR}"/${P}-include_QDebug.patch
+)
 
 src_prepare() {
 	cmake_src_prepare

--- a/games-action/polymc/polymc-1.4.2-r1.ebuild
+++ b/games-action/polymc/polymc-1.4.2-r1.ebuild
@@ -33,9 +33,9 @@ fi
 
 # Apache-2.0 for MultiMC (PolyMC is forked from it)
 # GPL-3 for PolyMC
-# LGPL-3 for libnbtplusplus
+# LGPL-3+ for libnbtplusplus
 # See the rest of PolyMC's libraries at https://github.com/PolyMC/PolyMC/tree/develop/libraries
-LICENSE="Apache-2.0 Boost-1.0 BSD BSD-2 GPL-2+ GPL-3 LGPL-3 OFL-1.1 MIT"
+LICENSE="Apache-2.0 BSD BSD-2 GPL-2+ GPL-3 ISC LGPL-2.1+ LGPL-3+ MIT"
 
 SLOT="0"
 
@@ -84,6 +84,10 @@ RDEPEND="
 	>=virtual/jre-1.8.0:*
 	virtual/opengl
 "
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-1.4.1-include_QDebug.patch
+)
 
 src_prepare() {
 	cmake_src_prepare

--- a/games-action/polymc/polymc-9999.ebuild
+++ b/games-action/polymc/polymc-9999.ebuild
@@ -85,6 +85,10 @@ RDEPEND="
 	virtual/opengl
 "
 
+PATCHES=(
+	"${FILESDIR}"/${PN}-1.4.1-include_QDebug.patch
+)
+
 src_prepare() {
 	cmake_src_prepare
 


### PR DESCRIPTION
I hope I changed the ebuild names correctly :grimacing: 

Bug: https://bugs.gentoo.org/869395