### PR TITLE
app-crypt/mit-krb5: enable threads by default

### DIFF
--- a/app-crypt/mit-krb5/mit-krb5-1.20.ebuild
+++ b/app-crypt/mit-krb5/mit-krb5-1.20.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://web.mit.edu/kerberos/dist/krb5/${P_DIR}/${MY_P}.tar.gz"
 LICENSE="openafs-krb5-a BSD MIT OPENLDAP BSD-2 HPND BSD-4 ISC RSA CC-BY-SA-3.0 || ( BSD-2 GPL-2+ )"
 SLOT="0"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
-IUSE="cpu_flags_x86_aes doc +keyutils lmdb nls openldap +pkinit selinux +threads test xinetd"
+IUSE="cpu_flags_x86_aes doc +keyutils lmdb nls openldap +pkinit selinux test xinetd"
 
 RESTRICT="!test? ( test )"
 
@@ -77,11 +77,11 @@ multilib_src_configure() {
 		$(use_with openldap ldap) \
 		$(use_enable nls) \
 		$(use_enable pkinit) \
-		$(use_enable threads thread-support) \
 		$(use_with lmdb) \
 		$(use_with keyutils) \
 		--without-hesiod \
 		--enable-shared \
+		--enable-thread-support \
 		--with-system-et \
 		--with-system-ss \
 		--enable-dns-for-realm \


### PR DESCRIPTION
Upstream enables pthreads by default, so enable it unconditionally.

Closes: https://bugs.gentoo.org/868462
Signed-off-by: Holger Hoffstätte <holger@applied-asynchrony.com>
