### PR TITLE
dev-lang/tcl: consider using threads by default

### DIFF
--- a/dev-lang/tcl/tcl-8.6.12-r1.ebuild
+++ b/dev-lang/tcl/tcl-8.6.12-r1.ebuild
@@ -1,0 +1,123 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+# Please bump with dev-lang/tk!
+
+inherit autotools flag-o-matic multilib-minimal multilib toolchain-funcs
+
+MY_P="${PN}${PV}"
+
+DESCRIPTION="Tool Command Language"
+HOMEPAGE="http://www.tcl.tk/"
+SRC_URI="mirror://sourceforge/tcl/${PN}-core${PV}-src.tar.gz"
+
+LICENSE="tcltk"
+SLOT="0/8.6"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+IUSE="debug"
+
+RDEPEND=">=sys-libs/zlib-1.2.8-r1[${MULTILIB_USEDEP}]"
+DEPEND="${RDEPEND}"
+
+SPARENT="${WORKDIR}/${MY_P}"
+S="${SPARENT}"/unix
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-8.6.10-multilib.patch
+	"${FILESDIR}"/${PN}-8.6.8-conf.patch # Bug 125971
+	"${FILESDIR}"/${PN}-8.6.9-include-spec.patch # Bug 731120
+)
+
+src_prepare() {
+	find \
+		"${SPARENT}"/compat/* \
+		"${SPARENT}"/doc/try.n \
+		-delete || die
+
+	pushd "${SPARENT}" &>/dev/null || die
+	default
+	popd &>/dev/null || die
+
+	# httpold tests require netowk
+	rm ../tests/httpold.test \
+		../tests/env.test \
+		../tests/http.test \
+		|| die
+
+	# workaround stack check issues, bug #280934
+	use hppa && append-cflags "-DTCL_NO_STACK_CHECK=1"
+
+	tc-export CC
+
+	sed \
+		-e '/chmod/s:555:755:g' \
+		-i Makefile.in || die
+
+	sed \
+		-e 's:-O[2s]\?::g' \
+		-i tcl.m4 || die
+
+	mv configure.{in,ac} || die
+
+	eautoconf
+
+	multilib_copy_sources
+}
+
+multilib_src_configure() {
+	# We went ahead and deleted the whole compat/ subdir which means
+	# the configure tests to detect broken versions need to pass (else
+	# we'll fail to build).  This comes up when cross-compiling, but
+	# might as well get a minor configure speed up normally.
+	export ac_cv_func_memcmp_working="yes"
+	export tcl_cv_str{str,toul,tod}_unbroken="ok"
+	export tcl_cv_strtod_buggy="no"
+
+	econf \
+		--enable-threads \
+		$(use_enable debug symbols)
+}
+
+multilib_src_install() {
+	#short version number
+	local v1=$(ver_cut 1-2)
+	local mylibdir=$(get_libdir)
+
+	S= default
+	# fix the tclConfig.sh to eliminate refs to the build directory
+	# and drop unnecessary -L inclusion to default system libdir
+
+	sed \
+		-e "/^TCL_BUILD_LIB_SPEC=/s:-L$(pwd) *::g" \
+		-e "/^TCL_LIB_SPEC=/s:-L${EPREFIX}/usr/${mylibdir} *::g" \
+		-e "/^TCL_SRC_DIR=/s:${SPARENT}:${EPREFIX}/usr/${mylibdir}/tcl${v1}/include:g" \
+		-e "/^TCL_BUILD_STUB_LIB_SPEC=/s:-L$(pwd) *::g" \
+		-e "/^TCL_STUB_LIB_SPEC=/s:-L${EPREFIX}/usr/${mylibdir} *::g" \
+		-e "/^TCL_BUILD_STUB_LIB_PATH=/s:$(pwd):${EPREFIX}/usr/${mylibdir}:g" \
+		-e "/^TCL_LIBW_FILE=/s:'libtcl${v1}..TCL_DBGX..so':\"libtcl${v1}\$\{TCL_DBGX\}.so\":g" \
+		-i "${ED}"/usr/${mylibdir}/tclConfig.sh || die
+	if use prefix && [[ ${CHOST} != *-darwin* ]] ; then
+		sed \
+			-e "/^TCL_CC_SEARCH_FLAGS=/s|'$|:${EPREFIX}/usr/${mylibdir}'|g" \
+			-e "/^TCL_LD_SEARCH_FLAGS=/s|'$|:${EPREFIX}/usr/${mylibdir}'|" \
+			-i "${ED}"/usr/${mylibdir}/tclConfig.sh || die
+	fi
+
+	# install private headers
+	insinto /usr/${mylibdir}/tcl${v1}/include/unix
+	doins *.h
+	insinto /usr/${mylibdir}/tcl${v1}/include/generic
+	doins "${SPARENT}"/generic/*.h
+	rm -f "${ED}"/usr/${mylibdir}/tcl${v1}/include/generic/{tcl,tclDecls,tclPlatDecls}.h || die
+
+	# install symlink for libraries
+	dosym libtcl${v1}$(get_libname) /usr/${mylibdir}/libtcl$(get_libname)
+	dosym libtclstub${v1}.a /usr/${mylibdir}/libtclstub.a
+
+	if multilib_is_native_abi; then
+		dosym tclsh${v1} /usr/bin/tclsh
+		dodoc "${SPARENT}"/{ChangeLog*,README.md,changes}
+	fi
+}

--- a/dev-tcltk/expect/expect-5.45.4-r3.ebuild
+++ b/dev-tcltk/expect/expect-5.45.4-r3.ebuild
@@ -13,11 +13,11 @@ SRC_URI="mirror://sourceforge/${PN}/${MY_P}.tar.gz"
 LICENSE="BSD"
 SLOT="0"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~x64-macos ~x64-solaris ~x86-solaris"
-IUSE="debug doc threads"
+IUSE="debug doc"
 
 # We need dejagnu for src_test, but dejagnu needs expect
 # to compile/run, so we cant add dejagnu to DEPEND :/
-DEPEND=">=dev-lang/tcl-8.2:=[threads?]"
+DEPEND=">=dev-lang/tcl-8.2:="
 RDEPEND="${DEPEND}"
 
 S=${WORKDIR}/${MY_P}
@@ -51,7 +51,7 @@ src_configure() {
 		--with-tcl="${EPREFIX}/usr/$(get_libdir)" \
 		--disable-64bit \
 		--enable-shared \
-		$(use_enable threads) \
+		--enable-threads \
 		$(use_enable debug symbols mem)
 }
 

--- a/dev-tcltk/thread/thread-2.8.5.ebuild
+++ b/dev-tcltk/thread/thread-2.8.5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -16,7 +16,7 @@ SLOT="0"
 KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86"
 IUSE=""
 
-DEPEND="dev-lang/tcl:0=[threads]"
+DEPEND="dev-lang/tcl:0="
 RDEPEND="${DEPEND}"
 
 S="${WORKDIR}"/${MY_P}


### PR DESCRIPTION
Upstream enables pthreads by default, so enable it unconditionally.

Closes: https://bugs.gentoo.org/868468
Signed-off-by: Holger Hoffstätte <holger@applied-asynchrony.com>
