### PR TITLE
profiles/features/musl: mask app-shells/pdsh and net-analyzer/ipcad

### DIFF
--- a/profiles/features/musl/package.mask
+++ b/profiles/features/musl/package.mask
@@ -1,6 +1,11 @@
 # Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Petr Vaněk <arkamar@atlas.cz> (2022-09-23)
+# Musl does not implement rresvport function, bugs #713810 and #713376.
+app-shells/pdsh
+net-analyzer/ipcad
+
 # Sam James <sam@gentoo.org> (2022-09-17)
 # Fails to compile on musl: bug #832868
 sys-apps/uutils


### PR DESCRIPTION
Both packages require `rresvport` function, which is not implemented in musl.