### PR TITLE
app-editors/neovim: remove unnecessary underscore

### DIFF
--- a/app-editors/neovim/files/neovim-9999-cmake-darwin.patch
+++ b/app-editors/neovim/files/neovim-9999-cmake-darwin.patch
@@ -26,7 +26,7 @@
 -  # Work around some old, broken detection by CMake for knowing when to use the
 -  # isystem flag.  Apple's compilers have supported this for quite some time
 -  # now.
--  if(CMAKE_C_COMPILER_ID_MATCHES "GNU")
+-  if(CMAKE_C_COMPILER_ID MATCHES "GNU")
 -    set(CMAKE_INCLUDE_SYSTEM_FLAG_C "-isystem ")
 -  endif()
 -endif()


### PR DESCRIPTION
This fixes an extra underscore introduced by mistake in the previous commit (#27198).

Signed-off-by: Bharath Saiguhan <bharathsaiguhan@protonmail.com>