### PR TITLE
app-backup/backup-manager: Keyword 0.7.14-r1 riscv, #869833

### DIFF
--- a/app-backup/backup-manager/backup-manager-0.7.14-r1.ebuild
+++ b/app-backup/backup-manager/backup-manager-0.7.14-r1.ebuild
@@ -10,7 +10,7 @@ SRC_URI="https://github.com/sukria/Backup-Manager/archive/${PV}.tar.gz -> ${P}.t
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 x86"
+KEYWORDS="amd64 ~riscv x86"
 IUSE="s3"
 
 DEPEND="dev-lang/perl:=

--- a/dev-perl/AnyEvent-CacheDNS/AnyEvent-CacheDNS-0.80.0-r1.ebuild
+++ b/dev-perl/AnyEvent-CacheDNS/AnyEvent-CacheDNS-0.80.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Simple DNS resolver with caching"
 
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~riscv ~x86"
 # License note: says 'perl 5.8.8 or any later' bug #718946
 IUSE="test"
 RESTRICT="!test? ( test )"

--- a/dev-perl/AnyEvent-HTTP/AnyEvent-HTTP-2.250.0.ebuild
+++ b/dev-perl/AnyEvent-HTTP/AnyEvent-HTTP-2.250.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Simple but non-blocking HTTP/HTTPS client"
 
 SLOT="0"
-KEYWORDS="amd64 x86"
+KEYWORDS="amd64 ~riscv x86"
 
 RDEPEND="
 	>=dev-perl/AnyEvent-5.330.0

--- a/dev-perl/Data-Stream-Bulk/Data-Stream-Bulk-0.110.0-r2.ebuild
+++ b/dev-perl/Data-Stream-Bulk/Data-Stream-Bulk-0.110.0-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="N at a time iteration API"
 
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~riscv ~x86"
 IUSE="test"
 RESTRICT="!test? ( test )"
 

--- a/dev-perl/DateTime-Event-ICal/DateTime-Event-ICal-0.130.0-r1.ebuild
+++ b/dev-perl/DateTime-Event-ICal/DateTime-Event-ICal-0.130.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Perl DateTime extension for computing rfc2445 recurrences"
 
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~riscv ~x86"
 
 RDEPEND="
 	dev-perl/DateTime

--- a/dev-perl/DateTime-Event-Recurrence/DateTime-Event-Recurrence-0.190.0-r1.ebuild
+++ b/dev-perl/DateTime-Event-Recurrence/DateTime-Event-Recurrence-0.190.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="DateTime::Set extension for create basic recurrence sets"
 
 SLOT="0"
-KEYWORDS="amd64 x86"
+KEYWORDS="amd64 ~riscv x86"
 
 RDEPEND="
 	>=dev-perl/DateTime-0.270.0

--- a/dev-perl/DateTime-Format-Flexible/DateTime-Format-Flexible-0.340.0.ebuild
+++ b/dev-perl/DateTime-Format-Flexible/DateTime-Format-Flexible-0.340.0.ebuild
@@ -11,7 +11,7 @@ inherit perl-module
 DESCRIPTION="Flexibly parse strings and turn them into DateTime objects"
 
 SLOT="0"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~x86"
+KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND="
 	dev-perl/DateTime

--- a/dev-perl/DateTime-Format-HTTP/DateTime-Format-HTTP-0.420.0-r1.ebuild
+++ b/dev-perl/DateTime-Format-HTTP/DateTime-Format-HTTP-0.420.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Date conversion routines"
 
 SLOT="0"
-KEYWORDS="amd64 x86"
+KEYWORDS="amd64 ~riscv x86"
 IUSE="test"
 RESTRICT="!test? ( test )"
 

--- a/dev-perl/DateTime-Format-ICal/DateTime-Format-ICal-0.90.0-r1.ebuild
+++ b/dev-perl/DateTime-Format-ICal/DateTime-Format-ICal-0.90.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Parse and format iCal datetime and duration strings"
 
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~riscv ~x86"
 
 RDEPEND="
 	>=dev-perl/DateTime-0.170.0

--- a/dev-perl/DateTime-Format-Natural/DateTime-Format-Natural-1.120.0.ebuild
+++ b/dev-perl/DateTime-Format-Natural/DateTime-Format-Natural-1.120.0.ebuild
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Parse informal natural language date/time strings"
 
 SLOT="0"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~x86"
+KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="test"
 RESTRICT="!test? ( test )"
 

--- a/dev-perl/DateTime-Set/DateTime-Set-0.390.0-r1.ebuild
+++ b/dev-perl/DateTime-Set/DateTime-Set-0.390.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Datetime sets and set math"
 
 SLOT="0"
-KEYWORDS="amd64 x86"
+KEYWORDS="amd64 ~riscv x86"
 IUSE="test"
 RESTRICT="!test? ( test )"
 

--- a/dev-perl/DateTimeX-Easy/DateTimeX-Easy-0.89.0-r1.ebuild
+++ b/dev-perl/DateTimeX-Easy/DateTimeX-Easy-0.89.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Parse a date/time string using the best method available"
 
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~riscv ~x86"
 IUSE="test"
 RESTRICT="!test? ( test )"
 

--- a/dev-perl/Digest-MD5-File/Digest-MD5-File-0.80.0-r2.ebuild
+++ b/dev-perl/Digest-MD5-File/Digest-MD5-File-0.80.0-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Perl extension for getting MD5 sums for files and urls"
 
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~riscv ~x86"
 
 RDEPEND="
 	virtual/perl-Digest-MD5

--- a/dev-perl/Module-Util/Module-Util-1.90.0-r1.ebuild
+++ b/dev-perl/Module-Util/Module-Util-1.90.0-r1.ebuild
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Module name tools and transformations"
 
 SLOT="0"
-KEYWORDS="amd64 ~arm64 ~ppc64 x86"
+KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv x86"
 
 RDEPEND=""
 BDEPEND="

--- a/dev-perl/MooseX-StrictConstructor/MooseX-StrictConstructor-0.210.0-r1.ebuild
+++ b/dev-perl/MooseX-StrictConstructor/MooseX-StrictConstructor-0.210.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -11,7 +11,7 @@ DESCRIPTION="Make your object constructors blow up on unknown attributes"
 
 LICENSE="Artistic-2"
 SLOT="0"
-KEYWORDS="amd64 ~x86"
+KEYWORDS="amd64 ~riscv ~x86"
 
 RDEPEND="
 	>=dev-perl/Moose-0.940.0

--- a/dev-perl/MooseX-Types-DateTime-MoreCoercions/MooseX-Types-DateTime-MoreCoercions-0.150.0-r1.ebuild
+++ b/dev-perl/MooseX-Types-DateTime-MoreCoercions/MooseX-Types-DateTime-MoreCoercions-0.150.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Extensions to MooseX::Types::DateTime"
 
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~riscv ~x86"
 
 RDEPEND="
 	>=dev-perl/DateTime-0.430.200

--- a/dev-perl/MooseX-Types-DateTime/MooseX-Types-DateTime-0.130.0-r1.ebuild
+++ b/dev-perl/MooseX-Types-DateTime/MooseX-Types-DateTime-0.130.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="DateTime related constraints and coercions for Moose"
 
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~riscv ~x86"
 
 RDEPEND="
 	>=dev-perl/DateTime-0.430.200

--- a/dev-perl/Net-Amazon-S3/Net-Amazon-S3-0.980.0-r1.ebuild
+++ b/dev-perl/Net-Amazon-S3/Net-Amazon-S3-0.980.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Framework for accessing the Amazon S3 Simple Storage Service"
 
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~riscv ~x86"
 
 RDEPEND="
 	virtual/perl-Carp

--- a/dev-perl/Set-Infinite/Set-Infinite-0.650.0-r2.ebuild
+++ b/dev-perl/Set-Infinite/Set-Infinite-0.650.0-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -10,4 +10,4 @@ inherit perl-module
 DESCRIPTION="Sets of intervals"
 
 SLOT="0"
-KEYWORDS="amd64 x86"
+KEYWORDS="amd64 ~riscv x86"

--- a/dev-perl/String-Approx/String-Approx-3.280.0-r1.ebuild
+++ b/dev-perl/String-Approx/String-Approx-3.280.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -11,4 +11,4 @@ DESCRIPTION="Perl extension for approximate string matching (fuzzy matching)"
 
 LICENSE="|| ( Artistic-2 LGPL-2 )"
 SLOT="0"
-KEYWORDS="~alpha amd64 ~ppc ~ppc64 sparc x86"
+KEYWORDS="~alpha amd64 ~ppc ~ppc64 ~riscv sparc x86"

--- a/dev-perl/Term-Encoding/Term-Encoding-0.30.0.ebuild
+++ b/dev-perl/Term-Encoding/Term-Encoding-0.30.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -10,4 +10,4 @@ inherit perl-module
 DESCRIPTION="Detect encoding of the current terminal"
 
 SLOT="0"
-KEYWORDS="amd64 ~x86"
+KEYWORDS="amd64 ~riscv ~x86"

--- a/dev-perl/Term-ProgressBar-Quiet/Term-ProgressBar-Quiet-0.310.0-r2.ebuild
+++ b/dev-perl/Term-ProgressBar-Quiet/Term-ProgressBar-Quiet-0.310.0-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Provide a progress meter if run interactively"
 
 SLOT="0"
-KEYWORDS="amd64 x86"
+KEYWORDS="amd64 ~riscv x86"
 
 RDEPEND="
 	dev-perl/IO-Interactive

--- a/dev-perl/Term-ProgressBar-Simple/Term-ProgressBar-Simple-0.30.0-r1.ebuild
+++ b/dev-perl/Term-ProgressBar-Simple/Term-ProgressBar-Simple-0.30.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Simple progess bars"
 
 SLOT="0"
-KEYWORDS="amd64 x86"
+KEYWORDS="amd64 ~riscv x86"
 
 RDEPEND="
 	dev-perl/Term-ProgressBar-Quiet

--- a/dev-perl/Test-MockTime/Test-MockTime-0.170.0.ebuild
+++ b/dev-perl/Test-MockTime/Test-MockTime-0.170.0.ebuild
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Replaces actual time with simulated time"
 
 SLOT="0"
-KEYWORDS="~alpha amd64 ~arm64 ~ia64 ppc ppc64 sparc x86"
+KEYWORDS="~alpha amd64 ~arm64 ~ia64 ppc ppc64 ~riscv sparc x86"
 
 RDEPEND="
 	virtual/perl-Time-Piece

--- a/dev-perl/Time-Duration-Parse/Time-Duration-Parse-0.160.0.ebuild
+++ b/dev-perl/Time-Duration-Parse/Time-Duration-Parse-0.160.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Parse string that represents time duration"
 
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~riscv ~x86"
 
 RDEPEND="
 	virtual/perl-Carp

--- a/dev-perl/VM-EC2-Security-CredentialCache/VM-EC2-Security-CredentialCache-0.250.0-r1.ebuild
+++ b/dev-perl/VM-EC2-Security-CredentialCache/VM-EC2-Security-CredentialCache-0.250.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Cache credentials respecting expiration time for IAM roles"
 
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~riscv ~x86"
 
 RDEPEND="
 	dev-perl/DateTime-Format-ISO8601

--- a/dev-perl/VM-EC2/VM-EC2-1.280.0-r1.ebuild
+++ b/dev-perl/VM-EC2/VM-EC2-1.280.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Interface to Amazon EC2, VPC, ELB, Autoscaling, and Relational DB services"
 
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~riscv ~x86"
 
 RDEPEND="
 	>=dev-perl/AnyEvent-7.40.0

--- a/dev-perl/boolean/boolean-0.460.0-r1.ebuild
+++ b/dev-perl/boolean/boolean-0.460.0-r1.ebuild
@@ -10,7 +10,7 @@ inherit perl-module
 DESCRIPTION="Boolean support for Perl"
 
 SLOT="0"
-KEYWORDS="amd64 ~arm64 ~ppc64 x86"
+KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv x86"
 
 RDEPEND=""
 BDEPEND="${RDEPEND}


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/869833

`dev-perl/DateTimeX-Easy-0.89.0-r1` and `dev-perl/Net-Amazon-S3-0.980.0-r1` have the same errors as in amd64, so we can safely skip it.

Signed-off-by: Yu Gu <guyu2876@gmail.com>