### PR TITLE
net-libs/libsoup: Fix automagic test dependencies

### DIFF
--- a/net-libs/libsoup/libsoup-2.74.3.ebuild
+++ b/net-libs/libsoup/libsoup-2.74.3.ebuild
@@ -73,6 +73,9 @@ src_configure() {
 
 multilib_src_configure() {
 	local emesonargs=(
+		# Avoid automagic, built-in feature of meson
+		-Dauto_features=enabled
+
 		$(meson_feature gssapi)
 		-Dkrb5_config="${CHOST}-krb5-config"
 		$(meson_feature samba ntlm)

--- a/net-libs/libsoup/libsoup-3.4.2.ebuild
+++ b/net-libs/libsoup/libsoup-3.4.2.ebuild
@@ -75,6 +75,9 @@ src_configure() {
 
 multilib_src_configure() {
 	local emesonargs=(
+		# Avoid auto-magic, built-in feature of meson
+		-Dauto_features=enabled
+
 		$(meson_feature gssapi)
 		-Dkrb5_config="${CHOST}-krb5-config"
 		$(meson_feature samba ntlm)
@@ -87,6 +90,8 @@ multilib_src_configure() {
 		-Ddoc_tests=false
 		$(meson_use test tests)
 		-Dinstalled_tests=false
+		-Dhttp2_tests=disabled # quart is absent from gentoo repo
+		-Dautobahn=disabled # depends on py-cryptography, which depends on Rust
 		$(meson_feature sysprof)
 		$(meson_feature test pkcs11_tests)
 	)

--- a/net-libs/libsoup/libsoup-3.4.3.ebuild
+++ b/net-libs/libsoup/libsoup-3.4.3.ebuild
@@ -75,6 +75,9 @@ src_configure() {
 
 multilib_src_configure() {
 	local emesonargs=(
+		# Avoid auto-magic, built-in feature of meson
+		-Dauto_features=enabled
+
 		$(meson_feature gssapi)
 		-Dkrb5_config="${CHOST}-krb5-config"
 		$(meson_feature samba ntlm)
@@ -87,6 +90,8 @@ multilib_src_configure() {
 		-Ddoc_tests=false
 		$(meson_use test tests)
 		-Dinstalled_tests=false
+		-Dhttp2_tests=disabled # quart is absent from gentoo repo
+		-Dautobahn=disabled # depends on py-cryptography, which depends on Rust
 		$(meson_feature sysprof)
 		$(meson_feature test pkcs11_tests)
 	)


### PR DESCRIPTION
Related: https://bugs.gentoo.org/870019
Signed-off-by: Haelwenn (lanodan) Monnier <contact@hacktivis.me>
