### PR TITLE
net-libs/nodejs: fix build with clang

### DIFF
--- a/net-libs/nodejs/files/nodejs-18.7.0-clang-fix-libatomic.patch
+++ b/net-libs/nodejs/files/nodejs-18.7.0-clang-fix-libatomic.patch
@@ -1,0 +1,28 @@
+nodejs unconditionally links to libatomic
+
+Clang implicitly links to atomic and on systems without libgcc this
+library is not installed, which breaks the build.
+
+See: https://github.com/nodejs/node/commit/4bd0d8c22ca65ba2bd02c671048a99e414f049b8
+See: https://bugs.gentoo.org/869992
+---
+ node.gyp | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/node.gyp b/node.gyp
+index e8227bb2..4bc53925 100644
+--- a/node.gyp
++++ b/node.gyp
+@@ -117,9 +117,6 @@
+           '-Wl,-bnoerrmsg',
+         ],
+       }],
+-      ['OS == "linux" and llvm_version != "0.0"', {
+-        'libraries': ['-latomic'],
+-      }],
+     ],
+   },
+ 
+-- 
+2.37.3
+

--- a/net-libs/nodejs/nodejs-18.7.0.ebuild
+++ b/net-libs/nodejs/nodejs-18.7.0.ebuild
@@ -50,6 +50,7 @@ DEPEND="${RDEPEND}"
 PATCHES=(
 	"${FILESDIR}"/${PN}-12.22.5-shared_c-ares_nameser_h.patch
 	"${FILESDIR}"/${PN}-15.2.0-global-npm-config.patch
+	"${FILESDIR}"/${PN}-18.7.0-clang-fix-libatomic.patch
 )
 
 # These are measured on a loong machine with -ggdb on, and only checked
@@ -125,6 +126,8 @@ src_configure() {
 
 	# LTO compiler flags are handled by configure.py itself
 	filter-flags '-flto*'
+	# nodejs unconditionally links to libatomic #869992
+	append-atomic-flags
 
 	local myconf=(
 		--shared-brotli


### PR DESCRIPTION
Clang implicitly links to libatomic, but nodejs unconditionally links to it in node.gyp.

This commit patches removes the stuff in node.gyp and instead uses flag-o-matic.eclass to link to libatomic.

Closes: https://bugs.gentoo.org/869992
See-also: https://github.com/nodejs/node/commit/4bd0d8c22ca65ba2bd02c671048a99e414f049b8
Signed-off-by: Alfred Persson Forsberg <cat@catcream.org>