### PR TITLE
sys-devel/binutils: remove unused file

### DIFF
--- a/sys-devel/binutils/files/50binutils-gentoo.el
+++ b/sys-devel/binutils/files/50binutils-gentoo.el
@@ -1,3 +1,0 @@
-(add-to-list 'load-path "@SITELISP@")
-(autoload 'dwarf-browse "dwarf-mode"
-  "Invoke `objdump' and put output into a `dwarf-mode' buffer." t)


### PR DESCRIPTION
Signed-off-by: Michael Mair-Keimberger <mmk@levelnine.at>
Portage 3.0.35 / pkgdev 0.2.1 / pkgcheck 0.10.14