### PR TITLE
sci-libs/caffe2: use addpredict /dev/nvidiactl for CUDA version check

### DIFF
--- a/sci-libs/caffe2/caffe2-1.12.0.ebuild
+++ b/sci-libs/caffe2/caffe2-1.12.0.ebuild
@@ -139,6 +139,8 @@ src_configure() {
 		-DTORCH_INSTALL_LIB_DIR=/usr/$(get_libdir)
 		-DLIBSHM_INSTALL_LIB_SUBDIR=/usr/$(get_libdir)
 	)
+
+	use cuda && addpredict "/dev/nvidiactl" # bug 867706
 	cmake_src_configure
 }
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/867706
Signed-off-by: James Beddek <telans@posteo.de>