### PR TITLE
dev-util/geany-plugins: add libgit2-1.4 support

### DIFF
--- a/dev-util/geany-plugins/files/geany-plugins-1.38-libgit2-1.4.patch
+++ b/dev-util/geany-plugins/files/geany-plugins-1.38-libgit2-1.4.patch
@@ -1,0 +1,139 @@
+# https://github.com/geany/geany-plugins/commit/668f5d07eef16e227402eab09141c738b315d94b
+# https://github.com/geany/geany-plugins/commit/5d9f1bc6d010e6b4c6a21af8a39b90922f89a82c
+--- a/git-changebar/src/gcb-plugin.c
++++ b/git-changebar/src/gcb-plugin.c
+@@ -32,11 +32,19 @@
+ #include <geany.h>
+ #include <document.h>
+ 
+-#if ! defined (LIBGIT2_VER_MINOR) || ( (LIBGIT2_VER_MAJOR == 0) && (LIBGIT2_VER_MINOR < 22) )
++#ifdef LIBGIT2_VER_MINOR
++# define CHECK_LIBGIT2_VERSION(MAJOR, MINOR) \
++  ((LIBGIT2_VER_MAJOR == (MAJOR) && LIBGIT2_VER_MINOR >= (MINOR)) || \
++   LIBGIT2_VER_MAJOR > (MAJOR))
++#else /* ! defined(LIBGIT2_VER_MINOR) */
++# define CHECK_LIBGIT2_VERSION(MAJOR, MINOR) 0
++#endif
++
++#if ! CHECK_LIBGIT2_VERSION(0, 22)
+ # define git_libgit2_init     git_threads_init
+ # define git_libgit2_shutdown git_threads_shutdown
+ #endif
+-#if ! defined (LIBGIT2_VER_MINOR) || ( (LIBGIT2_VER_MAJOR == 0) && (LIBGIT2_VER_MINOR < 23) )
++#if ! CHECK_LIBGIT2_VERSION(0, 23)
+ /* 0.23 added @p binary_cb */
+ # define git_diff_buffers(old_buffer, old_len, old_as_path, \
+                           new_buffer, new_len, new_as_path, options, \
+@@ -45,7 +53,7 @@
+                     new_buffer, new_len, new_as_path, options, \
+                     file_cb, hunk_cb, line_cb, payload)
+ #endif
+-#if ! defined (LIBGIT2_VER_MINOR) || ( (LIBGIT2_VER_MAJOR == 0) && (LIBGIT2_VER_MINOR < 28) )
++#if ! CHECK_LIBGIT2_VERSION(0, 28)
+ # define git_buf_dispose  git_buf_free
+ # define git_error_last   giterr_last
+ #endif
+@@ -211,30 +219,19 @@ static const struct {
+ };
+ 
+ 
+-/* workaround https://github.com/libgit2/libgit2/pull/3187 */
+-static int
+-gcb_git_buf_grow (git_buf  *buf,
+-                  size_t    target_size)
+-{
+-  if (buf->asize == 0) {
+-    if (target_size == 0) {
+-      target_size = buf->size;
+-    }
+-    if ((target_size & 7) == 0) {
+-      target_size++;
+-    }
+-  }
+-  return git_buf_grow (buf, target_size);
+-}
+-#define git_buf_grow gcb_git_buf_grow
+-
+ static void
+ buf_zero (git_buf *buf)
+ {
+   if (buf) {
+     buf->ptr = NULL;
+     buf->size = 0;
++#if ! CHECK_LIBGIT2_VERSION(1, 4)
+     buf->asize = 0;
++#else
++    /* we don't really need this field, but the documentation states that all
++     * fields should be set to 0, so fill it as well */
++    buf->reserved = 0;
++#endif
+   }
+ }
+ 
+@@ -248,6 +245,52 @@ clear_cached_blob_contents (void)
+   G_blob_contents_tag = 0;
+ }
+ 
++/* similar to old git_blob_filtered_content() but makes sure the caller owns
++ * the data in the output buffer -- and uses a boolean return */
++static gboolean
++get_blob_contents (git_buf     *out,
++                   git_blob    *blob,
++                   const char  *as_path,
++                   int          check_for_binary_data)
++{
++/* libgit2 1.4 changed buffer API quite a bit */
++#if ! CHECK_LIBGIT2_VERSION(1, 4)
++  gboolean success = TRUE;
++
++  if (git_blob_filtered_content (out, blob, as_path,
++                                 check_for_binary_data) != 0)
++    return FALSE;
++
++  /* Workaround for https://github.com/libgit2/libgit2/pull/3187
++   * We want to own the buffer, which git_buf_grow(buf, 0) was supposed to do,
++   * but there is a corner case where it doesn't do what it should and
++   * truncates the buffer contents, so we fix this manually. */
++  if (out->asize == 0) {
++    size_t target_size = out->size;
++    if ((target_size & 7) == 0) {
++      target_size++;
++    }
++    success = (git_buf_grow (out, target_size) == 0);
++  }
++
++  return success;
++#else /* libgit2 >= 1.4 */
++  /* Here we can assume we will always get a buffer we own (at least as of
++   * 2022-06-05 it is the case), so there's no need for a pendent to the
++   * previous git_buf_grow() shenanigans.
++   * This code path does the same as the older git_blob_filtered_content()
++   * but with non-deprecated API */
++  git_blob_filter_options opts = GIT_BLOB_FILTER_OPTIONS_INIT;
++
++  if (check_for_binary_data)
++    opts.flags |= GIT_BLOB_FILTER_CHECK_FOR_BINARY;
++  else
++    opts.flags &= ~GIT_BLOB_FILTER_CHECK_FOR_BINARY;
++
++  return git_blob_filter(out, blob, as_path, &opts) == 0;
++#endif
++}
++
+ /* get the file blob for @relpath at HEAD */
+ static gboolean
+ repo_get_file_blob_contents (git_repository  *repo,
+@@ -271,11 +314,8 @@ repo_get_file_blob_contents (git_repository  *repo,
+           git_blob *blob;
+           
+           if (git_blob_lookup (&blob, repo, git_tree_entry_id (entry)) == 0) {
+-            if (git_blob_filtered_content (contents, blob, relpath,
+-                                           check_for_binary_data) == 0 &&
+-                git_buf_grow (contents, 0) == 0) {
+-              success = TRUE;
+-            }
++            success = get_blob_contents (contents, blob, relpath,
++                                         check_for_binary_data);
+             git_blob_free (blob);
+           }
+           git_tree_entry_free (entry);

--- a/dev-util/geany-plugins/geany-plugins-1.38-r2.ebuild
+++ b/dev-util/geany-plugins/geany-plugins-1.38-r2.ebuild
@@ -1,0 +1,124 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+LUA_COMPAT=( lua5-1 )
+
+inherit lua-single
+
+DESCRIPTION="A collection of different plugins for Geany"
+HOMEPAGE="https://plugins.geany.org"
+SRC_URI="https://plugins.geany.org/${PN}/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~ppc ~ppc64 ~sparc ~x86"
+
+IUSE="ctags debugger enchant git gpg gtkspell lua markdown nls pretty-printer scope soup workbench"
+REQUIRED_USE="lua? ( ${LUA_REQUIRED_USE} )"
+
+DEPEND="
+	dev-libs/glib:2
+	>=dev-util/geany-1.37[-gtk2(-)]
+	x11-libs/gtk+:3
+	ctags? ( dev-util/ctags )
+	debugger? ( x11-libs/vte:2.91 )
+	enchant? ( app-text/enchant:= )
+	git? ( dev-libs/libgit2:= )
+	gpg? ( app-crypt/gpgme:= )
+	gtkspell? ( app-text/gtkspell:3= )
+	lua? ( ${LUA_DEPS} )
+	markdown? (
+		app-text/discount
+		net-libs/webkit-gtk:4
+		)
+	pretty-printer? ( dev-libs/libxml2:2 )
+	scope? ( x11-libs/vte:2.91 )
+	soup? ( net-libs/libsoup:2.4 )
+	workbench? ( dev-libs/libgit2:= )
+"
+RDEPEND="${DEPEND}
+	scope? ( sys-devel/gdb )
+"
+BDEPEND="virtual/pkgconfig
+	nls? ( sys-devel/gettext )
+"
+
+PATCHES=( "${FILESDIR}/${P}-libgit2-1.4.patch" )
+
+pkg_setup() {
+	use lua && lua-single_pkg_setup
+}
+
+src_configure() {
+	local myeconfargs=(
+		--disable-cppcheck
+		--disable-extra-c-warnings
+		$(use_enable nls)
+		--enable-utilslib
+		# Plugins
+		--enable-addons
+		--enable-autoclose
+		--enable-automark
+		--enable-codenav
+		--enable-commander
+		--enable-defineformat
+		--enable-geanydoc
+		--enable-geanyextrasel
+		--enable-geanyinsertnum
+		--enable-geanymacro
+		--enable-geanyminiscript
+		--enable-geanynumberedbookmarks
+		--enable-geanyprj
+		--enable-geanyvc $(use_enable gtkspell)
+		--enable-keyrecord
+		--enable-latex
+		--enable-lineoperations
+		--enable-lipsum
+		--enable-overview
+		--enable-pairtaghighlighter
+		--enable-pohelper
+		--enable-projectorganizer
+		--enable-sendmail
+		--enable-shiftcolumn
+		--enable-tableconvert
+		--enable-treebrowser
+		--enable-vimode
+		--enable-xmlsnippets
+		$(use_enable debugger)
+		$(use_enable ctags geanyctags)
+		$(use_enable lua geanylua)
+		$(use_enable gpg geanypg)
+		$(use_enable soup geniuspaste)
+		$(use_enable git gitchangebar)
+		$(use_enable markdown) --disable-peg-markdown # using app-text/discount instead
+		$(use_enable pretty-printer)
+		$(use_enable scope)
+		$(use_enable enchant spellcheck)
+		# Having updatechecker… when you’re using a package manager?
+		$(use_enable soup updatechecker)
+		$(use_enable workbench)
+		# GeanyGenDoc requires ctpl which isn’t yet in portage
+		--disable-geanygendoc
+		# Require obsolete and vulnerable webkit-gtk versions
+		--disable-devhelp
+		--disable-webhelper
+		# GTK 2 only
+		--disable-geanypy
+		--disable-multiterm
+	)
+
+	econf "${myeconfargs[@]}"
+}
+
+src_install() {
+	default
+
+	find "${D}" -name '*.la' -delete || die
+
+	# make installs all translations if LINGUAS is empty
+	if [[ -z "${LINGUAS-x}" ]]; then
+		rm -r "${ED}/usr/share/locale/" || die
+	fi
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/835407
Signed-off-by: Chris Mayo <aklhfex@gmail.com>

---

I've been using these changes for some time (currently with dev-libs/libgit2-1.5.0), now committed upstream

```diff
--- geany-plugins-1.38-r1.ebuild
+++ geany-plugins-1.38-r2.ebuild
@@ -13,7 +13,7 @@
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 arm ppc ppc64 ~sparc x86"
+KEYWORDS="~amd64 ~arm ~ppc ~ppc64 ~sparc ~x86"
 
 IUSE="ctags debugger enchant git gpg gtkspell lua markdown nls pretty-printer scope soup workbench"
 REQUIRED_USE="lua? ( ${LUA_REQUIRED_USE} )"
@@ -25,7 +25,7 @@
 	ctags? ( dev-util/ctags )
 	debugger? ( x11-libs/vte:2.91 )
 	enchant? ( app-text/enchant:= )
-	git? ( <dev-libs/libgit2-1.4.0:= )
+	git? ( dev-libs/libgit2:= )
 	gpg? ( app-crypt/gpgme:= )
 	gtkspell? ( app-text/gtkspell:3= )
 	lua? ( ${LUA_DEPS} )
@@ -44,6 +44,8 @@
 BDEPEND="virtual/pkgconfig
 	nls? ( sys-devel/gettext )
 "
+
+PATCHES=( "${FILESDIR}/${P}-libgit2-1.4.patch" )
 
 pkg_setup() {
 	use lua && lua-single_pkg_setup
```