### PR TITLE
sys-process/btop: Hard-depend on sys-devel/gcc

### DIFF
--- a/sys-process/btop/btop-1.2.8.ebuild
+++ b/sys-process/btop/btop-1.2.8.ebuild
@@ -13,6 +13,19 @@ LICENSE="Apache-2.0"
 SLOT="0"
 KEYWORDS="amd64 arm64 ppc64 ~riscv x86"
 
+BDEPEND="
+	>=sys-devel/gcc-8
+"
+
+pkg_setup() {
+	if [[ "${MERGE_TYPE}" != "binary" ]]; then
+		if ! tc-is-gcc ; then
+			# https://bugs.gentoo.org/839318
+			die "$(tc-getCXX) is not a supported compiler. Please use sys-devel/gcc instead."
+		fi
+	fi
+}
+
 src_prepare() {
 	default
 	# btop installs README.md to /usr/share/btop by default

--- a/sys-process/btop/btop-1.2.9.ebuild
+++ b/sys-process/btop/btop-1.2.9.ebuild
@@ -13,6 +13,19 @@ LICENSE="Apache-2.0"
 SLOT="0"
 KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
+BDEPEND="
+	>=sys-devel/gcc-8
+"
+
+pkg_setup() {
+	if [[ "${MERGE_TYPE}" != "binary" ]]; then
+		if ! tc-is-gcc ; then
+			# https://bugs.gentoo.org/839318
+			die "$(tc-getCXX) is not a supported compiler. Please use sys-devel/gcc instead."
+		fi
+	fi
+}
+
 src_prepare() {
 	default
 	# btop installs README.md to /usr/share/btop by default


### PR DESCRIPTION
Clang currently does not have support for the C++ 20 ranges library, causing build failures wis sys-process/btop. The only compiler supported upstream is sys-devel/gcc [0]. This commit enforces g++ to be used as a compiler until proper clang support is available.

[0] https://github.com/aristocratos/btop/issues/324

Closes: https://bugs.gentoo.org/839318