### PR TITLE
sys-apps/sed: patch to avoid diagnostic during build

### DIFF
--- a/sys-apps/sed/files/sed-4.8-avoid-noreturn-diagnostic.patch
+++ b/sys-apps/sed/files/sed-4.8-avoid-noreturn-diagnostic.patch
@@ -1,0 +1,19 @@
+From 0cc39712803ade7b2d4b89c36b143dad72404063 Sun Oct 18 00:00:00 2020
+From: Bruno Haible  <bruno@clisp.org>
+
+obstack: Fix a clang warning.
+* lib/obstack.c (print_and_abort): Mark as __attribute_noreturn__.
+
+diff --git a/lib/obstack.c b/lib/obstack.c
+index 6e82da054c..e6475a2a09 100644
+--- a/lib/obstack.c
++++ b/lib/obstack.c
+@@ -326,7 +326,7 @@ int obstack_exit_failure = EXIT_FAILURE;
+ #   include <libio/iolibio.h>
+ #  endif
+ 
+-static _Noreturn void
++static __attribute_noreturn__ void
+ print_and_abort (void)
+ {
+   /* Don't change any of these strings.  Yes, it would be possible to add

--- a/sys-apps/sed/files/sed-4.8-avoid-noreturn-diagnostic.patch
+++ b/sys-apps/sed/files/sed-4.8-avoid-noreturn-diagnostic.patch
@@ -1,3 +1,5 @@
+https://github.com/coreutils/gnulib/commit/0cc39712803ade7b2d4b89c36b143dad72404063
+
 From 0cc39712803ade7b2d4b89c36b143dad72404063 Sun Oct 18 00:00:00 2020
 From: Bruno Haible  <bruno@clisp.org>
 

--- a/sys-apps/sed/sed-4.8.ebuild
+++ b/sys-apps/sed/sed-4.8.ebuild
@@ -33,6 +33,10 @@ DEPEND="${RDEPEND}
 BDEPEND="nls? ( sys-devel/gettext )
 	verify-sig? ( sec-keys/openpgp-keys-sed )"
 
+PATCHES=(
+	"${FILESDIR}/${P}-avoid-noreturn-diagnostic.patch"
+)
+
 src_configure() {
 	use static && append-ldflags -static
 


### PR DESCRIPTION
sed-4.8 uses an old version of gnulib, which assigns a function declared with _Noreturn to a variable declared with __attribute__((__noreturn__)). This causes the types to mismatch, which produces a Clang diagnostic.

This change fixes the issue by using __attribute__((__noreturn__)) for both the function definition and the variable. The same fix was applied to upstream gnulib, which has since been pulled into the development version of sed. Once we update sed to a version that includes the fix, we will not need this local patch anymore.