### PR TITLE
www-client/seamonkey-2.53.13: build fix.

### DIFF
--- a/www-client/seamonkey/seamonkey-2.53.13.ebuild
+++ b/www-client/seamonkey/seamonkey-2.53.13.ebuild
@@ -179,6 +179,9 @@ src_unpack() {
 }
 
 src_prepare() {
+	# Hotfix for bug: 869143
+	sed -e '/^#include <stddef.h>/a #include <utility>' -i mfbt/tests/TestUniquePtr.cpp || die
+
 	# Apply our patches
 	eapply "${WORKDIR}"/gentoo-${PN}-patches-${PV}/${PN}
 


### PR DESCRIPTION
Hotfix for building seamonkey-2.53.13 due to a missing include statement.

Closes: https://bugs.gentoo.org/869143

Signed-off-by: Myckel Habets <gentoo-bugs@habets-dobben.nl>