### PR TITLE
sys-cluster/slurm: remove unneeded empty line from metadata

### DIFF
--- a/sys-cluster/slurm/metadata.xml
+++ b/sys-cluster/slurm/metadata.xml
@@ -10,7 +10,6 @@
 		<name>Gentoo Cluster Project</name>
 	</maintainer>
 	<use>
-		
 		<flag name="html">Build html documentation</flag>
 		<flag name="ipmi">Build support for collecting some ipmi stats</flag>
 		<flag name="json">Add support for json-persing via json-c</flag>


### PR DESCRIPTION
I am not sure if this line was intentionaly added in commit b1947dd126df - `sys-cluster/slurm: Update to new version` but it is inconsistent with other `metadata.xml` files.