### PR TITLE
sys-boot/grub: Fix for CVE-2021-3981

### DIFF
--- a/sys-boot/grub/files/gfxpayload.patch
+++ b/sys-boot/grub/files/gfxpayload.patch
@@ -5,12 +5,6 @@ Subject: [PATCH] 10_linux: Default gfxpayload=keep only when booting using efi
 
 vesafb seems to be unreliable when using BIOS compat mode.
 
----
- util/grub.d/10_linux.in | 4 +++-
- 1 file changed, 3 insertions(+), 1 deletion(-)
-
-diff --git a/util/grub.d/10_linux.in b/util/grub.d/10_linux.in
-index d2e2a8f..a54b888 100644
 --- a/util/grub.d/10_linux.in
 +++ b/util/grub.d/10_linux.in
 @@ -104,7 +104,9 @@ linux_entry ()
@@ -24,6 +18,3 @@ index d2e2a8f..a54b888 100644
        fi
    else
        if [ "x$GRUB_GFXPAYLOAD_LINUX" != xtext ]; then
--- 
-2.7.2
-

--- a/sys-boot/grub/files/grub-2.02_beta2-KERNEL_GLOBS.patch
+++ b/sys-boot/grub/files/grub-2.02_beta2-KERNEL_GLOBS.patch
@@ -7,13 +7,6 @@ Subject: [PATCH] GRUB_LINUX_KERNEL_GLOBS: configurable kernel selection
 * docs/grub.texi: Document GRUB_LINUX_KERNEL_GLOBS
 
 Signed-off-by: Robin H. Johnson <robbat2@gentoo.org>
----
- docs/grub.texi          |  5 +++++
- util/grub.d/10_linux.in | 21 +++++++++++----------
- 2 files changed, 16 insertions(+), 10 deletions(-)
-
-diff --git a/docs/grub.texi b/docs/grub.texi
-index 9a25a0b..d1129ec 100644
 --- a/docs/grub.texi
 +++ b/docs/grub.texi
 @@ -1490,6 +1490,11 @@ This option may be set to a list of GRUB module names separated by spaces.
@@ -28,8 +21,6 @@ index 9a25a0b..d1129ec 100644
  @end table
  
  The following options are still accepted for compatibility with existing
-diff --git a/util/grub.d/10_linux.in b/util/grub.d/10_linux.in
-index 859b608..e5ac11d 100644
 --- a/util/grub.d/10_linux.in
 +++ b/util/grub.d/10_linux.in
 @@ -145,18 +145,19 @@ EOF

--- a/sys-boot/grub/files/grub-2.06-binutils-2.36.patch
+++ b/sys-boot/grub/files/grub-2.06-binutils-2.36.patch
@@ -13,12 +13,6 @@ by default. Use the assmbler option -mx86-used-note=no to disable the
 section from being generated to workaround the ensuing linker issue.
 
 Signed-off-by: Michael Chang <mchang@suse.com>
----
- configure.ac | 14 ++++++++++++++
- 1 file changed, 14 insertions(+)
-
-diff --git a/configure.ac b/configure.ac
-index fa8f74bb9..38ee5f579 100644
 --- a/configure.ac
 +++ b/configure.ac
 @@ -836,6 +836,20 @@ if ( test "x$target_cpu" = xi386 || test "x$target_cpu" = xx86_64 ) && test "x$p

--- a/sys-boot/grub/files/grub-2.06-restore-umask.patch
+++ b/sys-boot/grub/files/grub-2.06-restore-umask.patch
@@ -1,0 +1,34 @@
+https://git.savannah.gnu.org/cgit/grub.git/commit/?id=0adec29674561034771c13e446069b41ef41e4d4
+From 0adec29674561034771c13e446069b41ef41e4d4 Mon Sep 17 00:00:00 2001
+From: Michael Chang <mchang@suse.com>
+Date: Fri, 3 Dec 2021 16:13:28 +0800
+Subject: grub-mkconfig: Restore umask for the grub.cfg
+
+The commit ab2e53c8a (grub-mkconfig: Honor a symlink when generating
+configuration by grub-mkconfig) has inadvertently discarded umask for
+creating grub.cfg in the process of running grub-mkconfig. The resulting
+wrong permission (0644) would allow unprivileged users to read GRUB
+configuration file content. This presents a low confidentiality risk
+as grub.cfg may contain non-secured plain-text passwords.
+
+This patch restores the missing umask and sets the creation file mode
+to 0600 preventing unprivileged access.
+
+Fixes: CVE-2021-3981
+
+Signed-off-by: Michael Chang <mchang@suse.com>
+Reviewed-by: Daniel Kiper <daniel.kiper@oracle.com>
+--- a/util/grub-mkconfig.in
++++ b/util/grub-mkconfig.in
+@@ -301,7 +301,10 @@ and /etc/grub.d/* files or please file a bug report with
+     exit 1
+   else
+     # none of the children aborted with error, install the new grub.cfg
++    oldumask=$(umask)
++    umask 077
+     cat ${grub_cfg}.new > ${grub_cfg}
++    umask $oldumask
+     rm -f ${grub_cfg}.new
+   fi
+ fi
+cgit v1.1

--- a/sys-boot/grub/files/grub-2.06-test-words.patch
+++ b/sys-boot/grub/files/grub-2.06-test-words.patch
@@ -3,12 +3,6 @@ From: Mike Gilbert <floppym@gentoo.org>
 Date: Sun, 14 Mar 2021 12:44:52 -0400
 Subject: [PATCH] Use /usr/share/dict/words as a 'compressible' file
 
----
- tests/util/grub-fs-tester.in | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
-
-diff --git a/tests/util/grub-fs-tester.in b/tests/util/grub-fs-tester.in
-index bfc425e1f..efd2977b0 100644
 --- a/tests/util/grub-fs-tester.in
 +++ b/tests/util/grub-fs-tester.in
 @@ -265,7 +265,7 @@ for LOGSECSIZE in $(range "$MINLOGSECSIZE" "$MAXLOGSECSIZE" 1); do
@@ -20,6 +14,3 @@ index bfc425e1f..efd2977b0 100644
  		if test -f "$cand" ; then
  		    CFILESRC="$cand"
  		    break
--- 
-2.31.0.rc1
-

--- a/sys-boot/grub/files/grub-2.06-xfs-v4.patch
+++ b/sys-boot/grub/files/grub-2.06-xfs-v4.patch
@@ -75,12 +75,6 @@ Fixes: 8b1e5d193 (fs/xfs: Add bigtime incompat feature support)
 Signed-off-by: Erwan Velu <e.velu@criteo.com>
 Tested-by: Carlos Maiolino <cmaiolino@redhat.com>
 Reviewed-by: Daniel Kiper <daniel.kiper@oracle.com>
----
- grub-core/fs/xfs.c | 14 ++++++++++----
- 1 file changed, 10 insertions(+), 4 deletions(-)
-
-diff --git a/grub-core/fs/xfs.c b/grub-core/fs/xfs.c
-index 0f524c3a8..e3816d1ec 100644
 --- a/grub-core/fs/xfs.c
 +++ b/grub-core/fs/xfs.c
 @@ -192,6 +192,11 @@ struct grub_xfs_time_legacy
@@ -115,6 +109,4 @@ index 0f524c3a8..e3816d1ec 100644
  
  struct grub_xfs_dirblock_tail
  {
--- 
 cgit v1.2.1
-

--- a/sys-boot/grub/grub-2.06-r3.ebuild
+++ b/sys-boot/grub/grub-2.06-r3.ebuild
@@ -1,0 +1,320 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+# This ebuild uses 3 special global variables:
+# GRUB_BOOTSTRAP: Depend on python and invoke bootstrap (gnulib).
+# GRUB_AUTOGEN: Depend on python and invoke the autogen.sh.
+# GRUB_AUTORECONF: Inherit autotools and invoke eautoreconf.
+#
+# When applying patches:
+# If gnulib is updated, set GRUB_BOOTSTRAP=1
+# If *.def is updated, set GRUB_AUTOGEN=1
+# If gnulib, *.def, or any autotools files are updated, set GRUB_AUTORECONF=1
+#
+# If any of the above applies to a user patch, the user should set the
+# corresponding variable in make.conf or the environment.
+
+if [[ ${PV} == 9999  ]]; then
+	GRUB_BOOTSTRAP=1
+fi
+
+GRUB_AUTORECONF=1
+PYTHON_COMPAT=( python3_{8..11} )
+WANT_LIBTOOL=none
+
+if [[ -n ${GRUB_AUTOGEN} || -n ${GRUB_BOOTSTRAP} ]]; then
+	inherit python-any-r1
+fi
+
+if [[ -n ${GRUB_AUTORECONF} ]]; then
+	inherit autotools
+fi
+
+inherit bash-completion-r1 flag-o-matic multibuild optfeature toolchain-funcs
+
+if [[ ${PV} != 9999 ]]; then
+	if [[ ${PV} == *_alpha* || ${PV} == *_beta* || ${PV} == *_rc* ]]; then
+		# The quote style is to work with <=bash-4.2 and >=bash-4.3 #503860
+		MY_P=${P/_/'~'}
+		SRC_URI="https://alpha.gnu.org/gnu/${PN}/${MY_P}.tar.xz"
+		S=${WORKDIR}/${MY_P}
+	else
+		SRC_URI="mirror://gnu/${PN}/${P}.tar.xz"
+		S=${WORKDIR}/${P%_*}
+	fi
+	KEYWORDS="~amd64 ~arm ~arm64 ~ia64 ~ppc ~ppc64 ~riscv ~sparc ~x86"
+else
+	inherit git-r3
+	EGIT_REPO_URI="https://git.savannah.gnu.org/git/grub.git"
+fi
+
+SRC_URI+=" https://dev.gentoo.org/~floppym/dist/grub-2.06-backports-r1.tar.xz"
+
+PATCHES=(
+	"${WORKDIR}/${P}-backports"
+	"${FILESDIR}"/gfxpayload.patch
+	"${FILESDIR}"/grub-2.02_beta2-KERNEL_GLOBS.patch
+	"${FILESDIR}"/grub-2.06-test-words.patch
+	"${FILESDIR}"/grub-2.06-restore-umask.patch
+)
+
+DEJAVU=dejavu-sans-ttf-2.37
+UNIFONT=unifont-12.1.02
+SRC_URI+=" fonts? ( mirror://gnu/unifont/${UNIFONT}/${UNIFONT}.pcf.gz )
+	themes? ( mirror://sourceforge/dejavu/${DEJAVU}.zip )"
+
+DESCRIPTION="GNU GRUB boot loader"
+HOMEPAGE="https://www.gnu.org/software/grub/"
+
+# Includes licenses for dejavu and unifont
+LICENSE="GPL-3+ BSD MIT fonts? ( GPL-2-with-font-exception ) themes? ( CC-BY-SA-3.0 BitstreamVera )"
+SLOT="2/${PVR}"
+IUSE="device-mapper doc efiemu +fonts mount nls sdl test +themes truetype libzfs"
+
+GRUB_ALL_PLATFORMS=( coreboot efi-32 efi-64 emu ieee1275 loongson multiboot qemu qemu-mips pc uboot xen xen-32 xen-pvh )
+IUSE+=" ${GRUB_ALL_PLATFORMS[@]/#/grub_platforms_}"
+
+REQUIRED_USE="
+	grub_platforms_coreboot? ( fonts )
+	grub_platforms_qemu? ( fonts )
+	grub_platforms_ieee1275? ( fonts )
+	grub_platforms_loongson? ( fonts )
+"
+
+BDEPEND="
+	${PYTHON_DEPS}
+	sys-devel/flex
+	sys-devel/bison
+	sys-apps/help2man
+	sys-apps/texinfo
+	fonts? (
+		media-libs/freetype:2
+		virtual/pkgconfig
+	)
+	test? (
+		app-admin/genromfs
+		app-arch/cpio
+		app-arch/lzop
+		app-emulation/qemu
+		dev-libs/libisoburn
+		sys-apps/miscfiles
+		sys-block/parted
+		sys-fs/squashfs-tools
+	)
+	themes? (
+		app-arch/unzip
+		media-libs/freetype:2
+		virtual/pkgconfig
+	)
+	truetype? ( virtual/pkgconfig )
+"
+DEPEND="
+	app-arch/xz-utils
+	>=sys-libs/ncurses-5.2-r5:0=
+	grub_platforms_emu? (
+		sdl? ( media-libs/libsdl )
+	)
+	device-mapper? ( >=sys-fs/lvm2-2.02.45 )
+	libzfs? ( sys-fs/zfs:= )
+	mount? ( sys-fs/fuse:0 )
+	truetype? ( media-libs/freetype:2= )
+	ppc? ( >=sys-apps/ibm-powerpc-utils-1.3.5 )
+	ppc64? ( >=sys-apps/ibm-powerpc-utils-1.3.5 )
+"
+RDEPEND="${DEPEND}
+	kernel_linux? (
+		grub_platforms_efi-32? ( sys-boot/efibootmgr )
+		grub_platforms_efi-64? ( sys-boot/efibootmgr )
+	)
+	!sys-boot/grub:0
+	nls? ( sys-devel/gettext )
+"
+
+RESTRICT="!test? ( test )"
+
+QA_EXECSTACK="usr/bin/grub-emu* usr/lib/grub/*"
+QA_PRESTRIPPED="usr/lib/grub/.*"
+QA_MULTILIB_PATHS="usr/lib/grub/.*"
+QA_WX_LOAD="usr/lib/grub/*"
+
+pkg_setup() {
+	:
+}
+
+src_unpack() {
+	if [[ ${PV} == 9999 ]]; then
+		git-r3_src_unpack
+		pushd "${P}" >/dev/null || die
+		local GNULIB_URI="https://git.savannah.gnu.org/git/gnulib.git"
+		local GNULIB_REVISION=$(source bootstrap.conf >/dev/null; echo "${GNULIB_REVISION}")
+		git-r3_fetch "${GNULIB_URI}" "${GNULIB_REVISION}"
+		git-r3_checkout "${GNULIB_URI}" gnulib
+		popd >/dev/null || die
+	fi
+	default
+}
+
+src_prepare() {
+	default
+
+	sed -i -e /autoreconf/d autogen.sh || die
+
+	if [[ -n ${GRUB_AUTOGEN} || -n ${GRUB_BOOTSTRAP} ]]; then
+		python_setup
+	else
+		export PYTHON=true
+	fi
+
+	if [[ -n ${GRUB_BOOTSTRAP} ]]; then
+		eautopoint --force
+		AUTOPOINT=: AUTORECONF=: ./bootstrap || die
+	elif [[ -n ${GRUB_AUTOGEN} ]]; then
+		./autogen.sh || die
+	fi
+
+	if [[ -n ${GRUB_AUTORECONF} ]]; then
+		eautoreconf
+	fi
+}
+
+grub_do() {
+	multibuild_foreach_variant run_in_build_dir "$@"
+}
+
+grub_do_once() {
+	multibuild_for_best_variant run_in_build_dir "$@"
+}
+
+grub_configure() {
+	local platform
+
+	case ${MULTIBUILD_VARIANT} in
+		efi*) platform=efi ;;
+		xen-pvh) platform=xen_pvh ;;
+		xen*) platform=xen ;;
+		guessed) ;;
+		*) platform=${MULTIBUILD_VARIANT} ;;
+	esac
+
+	case ${MULTIBUILD_VARIANT} in
+		*-32)
+			if [[ ${CTARGET:-${CHOST}} == x86_64* ]]; then
+				local CTARGET=i386
+			fi ;;
+		*-64)
+			if [[ ${CTARGET:-${CHOST}} == i?86* ]]; then
+				local CTARGET=x86_64
+				local -x TARGET_CFLAGS="-Os -march=x86-64 ${TARGET_CFLAGS}"
+				local -x TARGET_CPPFLAGS="-march=x86-64 ${TARGET_CPPFLAGS}"
+			fi ;;
+	esac
+
+	local myeconfargs=(
+		--disable-werror
+		--program-prefix=
+		--libdir="${EPREFIX}"/usr/lib
+		$(use_enable device-mapper)
+		$(use_enable mount grub-mount)
+		$(use_enable nls)
+		$(use_enable themes grub-themes)
+		$(use_enable truetype grub-mkfont)
+		$(use_enable libzfs)
+		$(use_enable sdl grub-emu-sdl)
+		${platform:+--with-platform=}${platform}
+
+		# Let configure detect this where supported
+		$(usex efiemu '' '--disable-efiemu')
+	)
+
+	if use fonts; then
+		ln -rs "${WORKDIR}/${UNIFONT}.pcf" unifont.pcf || die
+	fi
+
+	if use themes; then
+		ln -rs "${WORKDIR}/${DEJAVU}/ttf/DejaVuSans.ttf" DejaVuSans.ttf || die
+	fi
+
+	local ECONF_SOURCE="${S}"
+	econf "${myeconfargs[@]}"
+}
+
+src_configure() {
+	# Bug 508758.
+	replace-flags -O3 -O2
+
+	# Workaround for bug 829165.
+	filter-ldflags -pie
+
+	# We don't want to leak flags onto boot code.
+	export HOST_CCASFLAGS=${CCASFLAGS}
+	export HOST_CFLAGS=${CFLAGS}
+	export HOST_CPPFLAGS=${CPPFLAGS}
+	export HOST_LDFLAGS=${LDFLAGS}
+	unset CCASFLAGS CFLAGS CPPFLAGS LDFLAGS
+
+	tc-ld-disable-gold #439082 #466536 #526348
+	export TARGET_LDFLAGS="${TARGET_LDFLAGS} ${LDFLAGS}"
+	unset LDFLAGS
+
+	tc-export CC NM OBJCOPY RANLIB STRIP
+	tc-export BUILD_CC BUILD_PKG_CONFIG
+
+	MULTIBUILD_VARIANTS=()
+	local p
+	for p in "${GRUB_ALL_PLATFORMS[@]}"; do
+		use "grub_platforms_${p}" && MULTIBUILD_VARIANTS+=( "${p}" )
+	done
+	[[ ${#MULTIBUILD_VARIANTS[@]} -eq 0 ]] && MULTIBUILD_VARIANTS=( guessed )
+	grub_do grub_configure
+}
+
+src_compile() {
+	# Sandbox bug 404013.
+	use libzfs && addpredict /etc/dfs:/dev/zfs
+
+	grub_do emake
+	use doc && grub_do_once emake -C docs html
+}
+
+src_test() {
+	# The qemu dependency is a bit complex.
+	# You will need to adjust QEMU_SOFTMMU_TARGETS to match the cpu/platform.
+	grub_do emake check
+}
+
+src_install() {
+	grub_do emake install DESTDIR="${D}" bashcompletiondir="$(get_bashcompdir)"
+	use doc && grub_do_once emake -C docs install-html DESTDIR="${D}"
+
+	einstalldocs
+
+	insinto /etc/default
+	newins "${FILESDIR}"/grub.default-3 grub
+
+	# https://bugs.gentoo.org/231935
+	dostrip -x /usr/lib/grub
+}
+
+pkg_postinst() {
+	elog "For information on how to configure GRUB2 please refer to the guide:"
+	elog "    https://wiki.gentoo.org/wiki/GRUB2_Quick_Start"
+
+	if has_version 'sys-boot/grub:0'; then
+		elog "A migration guide for GRUB Legacy users is available:"
+		elog "    https://wiki.gentoo.org/wiki/GRUB2_Migration"
+	fi
+
+	if [[ -z ${REPLACING_VERSIONS} ]]; then
+		elog
+		optfeature "detecting other operating systems (grub-mkconfig)" sys-boot/os-prober
+		optfeature "creating rescue media (grub-mkrescue)" dev-libs/libisoburn
+		optfeature "enabling RAID device detection" sys-fs/mdadm
+	fi
+
+	if has_version sys-boot/os-prober; then
+		ewarn "Due to security concerns, os-prober is disabled by default."
+		ewarn "Set GRUB_DISABLE_OS_PROBER=false in /etc/default/grub to enable it."
+	fi
+}


### PR DESCRIPTION
This commit pulled a patch from GRUB upstream that fixes CVE-2021-3981.

Bug: https://bugs.gentoo.org/835082
Signed-off-by: Federico Denkena <federico.denkena@posteo.de>