### PR TITLE
sys-kernel/installkernel-systemd-boot: add petitboot config converter

### DIFF
--- a/profiles/arch/base/use.mask
+++ b/profiles/arch/base/use.mask
@@ -1,6 +1,11 @@
 # Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Georgy Yakovlev <gyakovlev@gentoo.org> (2022-09-17)
+# petitboot is actively used only on ppc64
+# there are some arm boards too, but it's rare occasion.
+petitboot
+
 # Michał Górny <mgorny@gentoo.org> (2021-01-07)
 # Prebuilt kernels are not supported on all architectures.
 dist-kernel

--- a/profiles/arch/powerpc/ppc64/use.mask
+++ b/profiles/arch/powerpc/ppc64/use.mask
@@ -3,6 +3,10 @@
 
 ### THIS FILE IS ONLY FOR PACKAGES MASKED ON BOTH 64-BIT AND 32-BIT USERLAND!!!
 
+# Georgy Yakovlev <gyakovlev@gentoo.org> (2022-09-17)
+# petitboot is actively used on ppc64
+-petitboot
+
 # Michał Górny <mgorny@gentoo.org> (2021-12-31)
 # PyPy3 is keyworded here.
 -python_targets_pypy3

--- a/sys-kernel/installkernel-systemd-boot/files/91-loaderentry2kboot.install
+++ b/sys-kernel/installkernel-systemd-boot/files/91-loaderentry2kboot.install
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+# (c) 2019-2022 Georgy Yakovlev
+# public-domain license
+
+find_entries() {
+	local -n arr="${1}"
+	IFS= mapfile -d '' arr < <(find /boot/loader/entries -maxdepth 1 -xtype f \
+		-iname "*.conf" -print0  2>/dev/null | sort -Vurz - -- )
+}
+
+parse_entries() {
+	local -n input="${1}"
+	local -A conf
+	local entry
+	for entry in "${input[@]}"; do
+		[[ -r ${entry} ]] || break
+		while read -r opt arg
+		do
+			conf[${opt}]="${arg}"
+		done < "${entry}"
+
+		# check that kernel is there indeed
+		[[ -f /boot/${conf[linux]} ]] || break
+		# if initrd arg is not empty, ensure file exists
+		if [[ ${conf[initrd]} ]]; then
+			[[ -f /boot/${conf[initrd]} ]] || break
+		fi
+		# label='/rel/path/vmlinux initrd=/rel/path/initrd opt1 opt2 opt3'
+		echo "${conf[version]}='${conf[linux]} ${conf[initrd]+initrd=${conf[initrd]}} ${conf[options]}'"
+	done
+}
+		
+main() {
+	if [[ -f /etc/machine-id ]]; then
+		local machine_id=$(</etc/machine-id)
+	else
+		exit 0
+	fi
+
+	if [[ ! -d /boot/${machine_id} ]]; then
+		exit 0
+	fi
+
+	if [[ ! -d /boot/loader/entries ]]; then
+		exit 0
+	fi
+	
+	local conf entries
+	find_entries entries
+	local emit
+	emit=$(
+		# we got version from kernel-install
+		# so set is as default if kernel exists
+		if [[ -f /boot/${machine_id}/${2}/linux ]]; then
+			echo default="${2}"
+		fi
+		# pass by reference and echo if found/validated
+		parse_entries entries
+	)
+	[[ ${emit} ]] && echo "${emit[@]}" > /boot/kboot.conf.new
+	[[ -f /boot/kboot.conf ]] && mv /boot/kboot.conf /boot/kboot.conf~
+	[[ -f /boot/kboot.conf.new ]] && mv /boot/kboot.conf.new /boot/kboot.conf
+}
+
+main "$@"

--- a/sys-kernel/installkernel-systemd-boot/installkernel-systemd-boot-2.ebuild
+++ b/sys-kernel/installkernel-systemd-boot/installkernel-systemd-boot-2.ebuild
@@ -9,7 +9,8 @@ S=${WORKDIR}
 
 LICENSE="public-domain"
 SLOT="0"
-KEYWORDS="amd64 arm64 ppc64 x86"
+KEYWORDS="amd64 arm64 ~ppc64 x86"
+IUSE="petitboot"
 
 RDEPEND="|| ( sys-apps/systemd sys-boot/systemd-boot )
 	!<sys-apps/debianutils-4.9-r1[installkernel(+)]
@@ -26,4 +27,9 @@ src_install() {
 
 	exeinto /usr/lib/kernel/install.d/
 	doexe "${FILESDIR}/00-00machineid-directory.install"
+
+	if use petitboot; then
+		exeinto /usr/lib/kernel/install.d/
+		doexe "${FILESDIR}/91-loaderentry2kboot.install"
+	fi
 }

--- a/sys-kernel/installkernel-systemd-boot/metadata.xml
+++ b/sys-kernel/installkernel-systemd-boot/metadata.xml
@@ -5,4 +5,7 @@
 		<email>dist-kernel@gentoo.org</email>
 		<name>Distribution Kernel Project</name>
 	</maintainer>
+	<use>
+		<flag name="petitboot">auto-convert systemd-boot entries to kboot.conf used by OpenPower systems petitboot bootloader</flag>
+	</use>
 </pkgmetadata>


### PR DESCRIPTION
converts loader entries to kboot.conf


example:

_cat /boot/loader/entries/1fff4ddbdcba4430889a2e52b405d08d-5.15.3*_
```
title      Gentoo Linux
version    5.15.32-talos64
machine-id 1fff4ddbdcba4430889a2e52b405d08d
options    root=ZFS=zroot/ROOT/default earlycon=hvc0 console=hvc0 console=tty0 iommu=nobypass pci=realloc video=offb:off audit=1 loglevel=3 rd.udev.log-priority=3 systemd.show_status=1 rd.systemd.show_status=auto crashkernel=4096M bootfs.snapshot quiet splash
linux      /1fff4ddbdcba4430889a2e52b405d08d/5.15.32-talos64/linux
initrd     /1fff4ddbdcba4430889a2e52b405d08d/5.15.32-talos64/initrd
title      Gentoo Linux
version    5.15.33-talos64
machine-id 1fff4ddbdcba4430889a2e52b405d08d
options    root=ZFS=zroot/ROOT/default earlycon=hvc0 console=hvc0 console=tty0 iommu=nobypass pci=realloc video=offb:off audit=1 loglevel=3 rd.udev.log-priority=3 systemd.show_status=1 rd.systemd.show_status=auto crashkernel=4096M bootfs.snapshot quiet splash
linux      /1fff4ddbdcba4430889a2e52b405d08d/5.15.33-talos64/linux
initrd     /1fff4ddbdcba4430889a2e52b405d08d/5.15.33-talos64/initrd
title      Gentoo Linux
version    5.15.35-talos64
machine-id 1fff4ddbdcba4430889a2e52b405d08d
options    root=ZFS=zroot/ROOT/default earlycon=hvc0 console=hvc0 console=tty0 iommu=nobypass pci=realloc video=offb:off audit=1 loglevel=3 rd.udev.log-priority=3 systemd.show_status=1 rd.systemd.show_status=auto crashkernel=4096M bootfs.snapshot quiet splash
linux      /1fff4ddbdcba4430889a2e52b405d08d/5.15.35-talos64/linux
initrd     /1fff4ddbdcba4430889a2e52b405d08d/5.15.35-talos64/initrd
title      Gentoo Linux
version    5.15.37-talos64
machine-id 1fff4ddbdcba4430889a2e52b405d08d
options    root=ZFS=zroot/ROOT/default earlycon=hvc0 console=hvc0 console=tty0 iommu=nobypass pci=realloc video=offb:off audit=1 loglevel=3 rd.udev.log-priority=3 systemd.show_status=1 rd.systemd.show_status=auto crashkernel=4096M bootfs.snapshot quiet splash
linux      /1fff4ddbdcba4430889a2e52b405d08d/5.15.37-talos64/linux
initrd     /1fff4ddbdcba4430889a2e52b405d08d/5.15.37-talos64/initrd
```

will get converted to
```
default=5.15.37-talos64
5.15.37-talos64='/1fff4ddbdcba4430889a2e52b405d08d/5.15.37-talos64/linux initrd=/1fff4ddbdcba4430889a2e52b405d08d/5.15.37-talos64/initrd root=ZFS=zroot/ROOT/default earlycon=hvc0 console=hvc0 console=tty0 iommu=nobypass pci=realloc video=offb:off audit=1 loglevel=3 rd.udev.log-priority=3 systemd.show_status=1 rd.systemd.show_status=auto crashkernel=4096M bootfs.snapshot quiet splash'
5.15.35-talos64='/1fff4ddbdcba4430889a2e52b405d08d/5.15.35-talos64/linux initrd=/1fff4ddbdcba4430889a2e52b405d08d/5.15.35-talos64/initrd root=ZFS=zroot/ROOT/default earlycon=hvc0 console=hvc0 console=tty0 iommu=nobypass pci=realloc video=offb:off audit=1 loglevel=3 rd.udev.log-priority=3 systemd.show_status=1 rd.systemd.show_status=auto crashkernel=4096M bootfs.snapshot quiet splash'
5.15.33-talos64='/1fff4ddbdcba4430889a2e52b405d08d/5.15.33-talos64/linux initrd=/1fff4ddbdcba4430889a2e52b405d08d/5.15.33-talos64/initrd root=ZFS=zroot/ROOT/default earlycon=hvc0 console=hvc0 console=tty0 iommu=nobypass pci=realloc video=offb:off audit=1 loglevel=3 rd.udev.log-priority=3 systemd.show_status=1 rd.systemd.show_status=auto crashkernel=4096M bootfs.snapshot quiet splash'
5.15.32-talos64='/1fff4ddbdcba4430889a2e52b405d08d/5.15.32-talos64/linux initrd=/1fff4ddbdcba4430889a2e52b405d08d/5.15.32-talos64/initrd root=ZFS=zroot/ROOT/default earlycon=hvc0 console=hvc0 console=tty0 iommu=nobypass pci=realloc video=offb:off audit=1 loglevel=3 rd.udev.log-priority=3 systemd.show_status=1 rd.systemd.show_status=auto crashkernel=4096M bootfs.snapshot quiet splash'
```