### PR TITLE
sys-apps/s6-linux-init: fix dependencies with other packages

### DIFF
--- a/sys-apps/openrc/openrc-0.44.10-r1.ebuild
+++ b/sys-apps/openrc/openrc-0.44.10-r1.ebuild
@@ -1,9 +1,9 @@
 # Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=8
+EAPI=7
 
-inherit meson pam
+inherit flag-o-matic meson pam toolchain-funcs
 
 DESCRIPTION="OpenRC manages the services, startup and shutdown of a host"
 HOMEPAGE="https://github.com/openrc/openrc/"
@@ -13,7 +13,7 @@ if [[ ${PV} =~ ^9{4,}$ ]]; then
 	inherit git-r3
 else
 	SRC_URI="https://github.com/OpenRC/openrc/archive/${PV}.tar.gz -> ${P}.tar.gz"
-	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86"
 fi
 
 LICENSE="BSD-2"
@@ -25,10 +25,13 @@ COMMON_DEPEND="
 	pam? ( sys-libs/pam )
 	audit? ( sys-process/audit )
 	sys-process/psmisc
+	!<sys-process/procps-3.3.9-r2
 	selinux? (
 		sys-apps/policycoreutils
 		>=sys-libs/libselinux-2.6
-	)"
+	)
+	!<sys-apps/baselayout-2.1-r1
+	!<sys-fs/udev-init-scripts-27"
 DEPEND="${COMMON_DEPEND}
 	virtual/os-headers
 	ncurses? ( virtual/pkgconfig )"
@@ -39,13 +42,18 @@ RDEPEND="${COMMON_DEPEND}
 			!sys-apps/systemd[sysv-utils(-)]
 			!sys-apps/sysvinit
 		)
-		!sysv-utils? ( >=sys-apps/sysvinit-2.86-r6[selinux?] )
+		!sysv-utils? ( || (
+			>=sys-apps/sysvinit-2.86-r6[selinux?]
+			sys-apps/s6-linux-init[sysv-utils(-)]
+		) )
 		virtual/tmpfiles
 	)
 	selinux? (
 		>=sec-policy/selinux-base-policy-2.20170204-r4
 		>=sec-policy/selinux-openrc-2.20170204-r4
 	)
+	!<app-shells/gentoo-bashcomp-20180302
+	!<app-shells/gentoo-zsh-completions-20180228
 "
 
 PDEPEND="netifrc? ( net-misc/netifrc )"
@@ -107,7 +115,7 @@ src_install() {
 	fi
 
 	# install documentation
-	dodoc *.md
+	dodoc ChangeLog *.md
 }
 
 pkg_preinst() {
@@ -151,13 +159,13 @@ pkg_postinst() {
 		ewarn
 	fi
 
-	# added for 0.45 to handle seedrng/urandom switching (2022-06-07)
+	# added to handle downgrading from 0.45 (2022-06-08)
 	for v in ${REPLACING_VERSIONS}; do
 		[[ -x $(type rc-update) ]] || continue
-		if ver_test $v -lt 0.45; then
-			if rc-update show boot | grep -q urandom; then
-				rc-update del urandom boot
-				rc-update add seedrng boot
+		if ver_test $v -gt 0.44.10; then
+			if rc-update show boot | grep -q seedrng; then
+				rc-update del seedrng boot
+				rc-update add urandom boot
 		fi
 		fi
 	done

--- a/sys-apps/openrc/openrc-0.45.1-r1.ebuild
+++ b/sys-apps/openrc/openrc-0.45.1-r1.ebuild
@@ -1,9 +1,9 @@
 # Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
-inherit flag-o-matic meson pam toolchain-funcs
+inherit meson pam
 
 DESCRIPTION="OpenRC manages the services, startup and shutdown of a host"
 HOMEPAGE="https://github.com/openrc/openrc/"
@@ -13,7 +13,7 @@ if [[ ${PV} =~ ^9{4,}$ ]]; then
 	inherit git-r3
 else
 	SRC_URI="https://github.com/OpenRC/openrc/archive/${PV}.tar.gz -> ${P}.tar.gz"
-KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
 fi
 
 LICENSE="BSD-2"
@@ -25,13 +25,10 @@ COMMON_DEPEND="
 	pam? ( sys-libs/pam )
 	audit? ( sys-process/audit )
 	sys-process/psmisc
-	!<sys-process/procps-3.3.9-r2
 	selinux? (
 		sys-apps/policycoreutils
 		>=sys-libs/libselinux-2.6
-	)
-	!<sys-apps/baselayout-2.1-r1
-	!<sys-fs/udev-init-scripts-27"
+	)"
 DEPEND="${COMMON_DEPEND}
 	virtual/os-headers
 	ncurses? ( virtual/pkgconfig )"
@@ -42,15 +39,16 @@ RDEPEND="${COMMON_DEPEND}
 			!sys-apps/systemd[sysv-utils(-)]
 			!sys-apps/sysvinit
 		)
-		!sysv-utils? ( >=sys-apps/sysvinit-2.86-r6[selinux?] )
+		!sysv-utils? ( || (
+			>=sys-apps/sysvinit-2.86-r6[selinux?]
+			sys-apps/s6-linux-init[sysv-utils(-)]
+		) )
 		virtual/tmpfiles
 	)
 	selinux? (
 		>=sec-policy/selinux-base-policy-2.20170204-r4
 		>=sec-policy/selinux-openrc-2.20170204-r4
 	)
-	!<app-shells/gentoo-bashcomp-20180302
-	!<app-shells/gentoo-zsh-completions-20180228
 "
 
 PDEPEND="netifrc? ( net-misc/netifrc )"
@@ -112,7 +110,7 @@ src_install() {
 	fi
 
 	# install documentation
-	dodoc ChangeLog *.md
+	dodoc *.md
 }
 
 pkg_preinst() {
@@ -156,13 +154,13 @@ pkg_postinst() {
 		ewarn
 	fi
 
-	# added to handle downgrading from 0.45 (2022-06-08)
+	# added for 0.45 to handle seedrng/urandom switching (2022-06-07)
 	for v in ${REPLACING_VERSIONS}; do
 		[[ -x $(type rc-update) ]] || continue
-		if ver_test $v -gt 0.44.10; then
-			if rc-update show boot | grep -q seedrng; then
-				rc-update del seedrng boot
-				rc-update add urandom boot
+		if ver_test $v -lt 0.45; then
+			if rc-update show boot | grep -q urandom; then
+				rc-update del urandom boot
+				rc-update add seedrng boot
 		fi
 		fi
 	done

--- a/sys-apps/openrc/openrc-0.45.2-r1.ebuild
+++ b/sys-apps/openrc/openrc-0.45.2-r1.ebuild
@@ -39,7 +39,10 @@ RDEPEND="${COMMON_DEPEND}
 			!sys-apps/systemd[sysv-utils(-)]
 			!sys-apps/sysvinit
 		)
-		!sysv-utils? ( >=sys-apps/sysvinit-2.86-r6[selinux?] )
+		!sysv-utils? ( || (
+			>=sys-apps/sysvinit-2.86-r6[selinux?]
+			sys-apps/s6-linux-init[sysv-utils(-)]
+		) )
 		virtual/tmpfiles
 	)
 	selinux? (

--- a/sys-apps/openrc/openrc-9999.ebuild
+++ b/sys-apps/openrc/openrc-9999.ebuild
@@ -39,7 +39,10 @@ RDEPEND="${COMMON_DEPEND}
 			!sys-apps/systemd[sysv-utils(-)]
 			!sys-apps/sysvinit
 		)
-		!sysv-utils? ( >=sys-apps/sysvinit-2.86-r6[selinux?] )
+		!sysv-utils? ( || (
+			>=sys-apps/sysvinit-2.86-r6[selinux?]
+			sys-apps/s6-linux-init[sysv-utils(-)]
+		) )
 		virtual/tmpfiles
 	)
 	selinux? (

--- a/sys-apps/s6-linux-init/s6-linux-init-1.0.8.0.ebuild
+++ b/sys-apps/s6-linux-init/s6-linux-init-1.0.8.0.ebuild
@@ -18,6 +18,7 @@ RDEPEND="dev-lang/execline:=
 	dev-libs/skalibs:=
 	sys-apps/s6:=[execline]
 	sysv-utils? (
+		!sys-apps/openrc[sysv-utils(-)]
 		!sys-apps/systemd[sysv-utils]
 		!sys-apps/sysvinit
 	)

--- a/sys-kernel/dracut/dracut-056-r2.ebuild
+++ b/sys-kernel/dracut/dracut-056-r2.ebuild
@@ -9,10 +9,9 @@ if [[ ${PV} == 9999 ]] ; then
 	inherit git-r3
 	EGIT_REPO_URI="https://github.com/dracutdevs/dracut"
 else
-	if [[ "${PV}" != *_rc* ]]; then
-		KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~mips ~ppc ~ppc64 ~riscv ~sparc ~x86"
-	fi
-	SRC_URI="https://github.com/dracutdevs/dracut/archive/refs/tags/${PV}.tar.gz -> ${P}.tar.gz"
+	[[ "${PV}" = *_rc* ]] || \
+	KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~loong ~mips ppc ppc64 ~riscv sparc x86"
+	SRC_URI="https://www.kernel.org/pub/linux/utils/boot/${PN}/${P}.tar.xz"
 fi
 
 DESCRIPTION="Generic initramfs generation tool"
@@ -33,6 +32,7 @@ RDEPEND="
 		>=sys-apps/sysvinit-2.87-r3
 		sys-apps/openrc[sysv-utils(-),selinux?]
 		sys-apps/systemd[sysv-utils]
+		sys-apps/s6-linux-init[sysv-utils(-)]
 	)
 	>=sys-apps/util-linux-2.21
 	virtual/pkgconfig
@@ -62,8 +62,8 @@ QA_MULTILIB_PATHS="usr/lib/dracut/.*"
 
 PATCHES=(
 	"${FILESDIR}"/gentoo-ldconfig-paths-r1.patch
-	"${FILESDIR}"/057-virtiofs-split-usr.patch
-	"${FILESDIR}"/057-i18n-keymaps.patch
+	"${FILESDIR}"/056-musl.patch
+	"${FILESDIR}"/056-fix-lvm-add-missing-grep-requirement.patch
 )
 
 src_configure() {

--- a/sys-kernel/dracut/dracut-057-r2.ebuild
+++ b/sys-kernel/dracut/dracut-057-r2.ebuild
@@ -9,9 +9,10 @@ if [[ ${PV} == 9999 ]] ; then
 	inherit git-r3
 	EGIT_REPO_URI="https://github.com/dracutdevs/dracut"
 else
-	[[ "${PV}" = *_rc* ]] || \
-	KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~loong ~mips ppc ppc64 ~riscv sparc x86"
-	SRC_URI="https://www.kernel.org/pub/linux/utils/boot/${PN}/${P}.tar.xz"
+	if [[ "${PV}" != *_rc* ]]; then
+		KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~mips ~ppc ~ppc64 ~riscv ~sparc ~x86"
+	fi
+	SRC_URI="https://github.com/dracutdevs/dracut/archive/refs/tags/${PV}.tar.gz -> ${P}.tar.gz"
 fi
 
 DESCRIPTION="Generic initramfs generation tool"
@@ -32,6 +33,7 @@ RDEPEND="
 		>=sys-apps/sysvinit-2.87-r3
 		sys-apps/openrc[sysv-utils(-),selinux?]
 		sys-apps/systemd[sysv-utils]
+		sys-apps/s6-linux-init[sysv-utils(-)]
 	)
 	>=sys-apps/util-linux-2.21
 	virtual/pkgconfig
@@ -61,8 +63,8 @@ QA_MULTILIB_PATHS="usr/lib/dracut/.*"
 
 PATCHES=(
 	"${FILESDIR}"/gentoo-ldconfig-paths-r1.patch
-	"${FILESDIR}"/056-musl.patch
-	"${FILESDIR}"/056-fix-lvm-add-missing-grep-requirement.patch
+	"${FILESDIR}"/057-virtiofs-split-usr.patch
+	"${FILESDIR}"/057-i18n-keymaps.patch
 )
 
 src_configure() {

--- a/sys-kernel/dracut/dracut-9999.ebuild
+++ b/sys-kernel/dracut/dracut-9999.ebuild
@@ -33,6 +33,7 @@ RDEPEND="
 		>=sys-apps/sysvinit-2.87-r3
 		sys-apps/openrc[sysv-utils(-),selinux?]
 		sys-apps/systemd[sysv-utils]
+		sys-apps/s6-linux-init[sysv-utils(-)]
 	)
 	>=sys-apps/util-linux-2.21
 	virtual/pkgconfig


### PR DESCRIPTION
This PR corrects dependencies in `sys-apps/openrc` and `sys-kernel/dracut` which makes it properly alternative init system.