### PR TITLE
profiles/features/wd40: mask dev-util/tree-sitter-cli

### DIFF
--- a/profiles/features/wd40/package.mask
+++ b/profiles/features/wd40/package.mask
@@ -57,6 +57,7 @@ dev-util/cargo-c
 dev-util/cbindgen
 dev-util/git-delta
 dev-util/maturin
+dev-util/tree-sitter-cli
 gnome-base/gdm
 >=gnome-base/gnome-core-apps-3.36.5
 >=gnome-base/gnome-core-libs-3.36.5


### PR DESCRIPTION
This is a rust package.

Bug: https://bugs.gentoo.org/844223