### PR TITLE
dev-libs/libbpf: fix libdir

### DIFF
--- a/dev-libs/libbpf/libbpf-1.0.0-r1.ebuild
+++ b/dev-libs/libbpf/libbpf-1.0.0-r1.ebuild
@@ -34,6 +34,7 @@ src_configure() {
 	append-cflags -fPIC
 	tc-export CC AR
 	export LIBSUBDIR="$(get_libdir)"
+	export LIBDIR="${EPREFIX}/usr/$(get_libdir)"
 	export V=1
 }
 

--- a/dev-libs/libbpf/libbpf-9999.ebuild
+++ b/dev-libs/libbpf/libbpf-9999.ebuild
@@ -34,6 +34,7 @@ src_configure() {
 	append-cflags -fPIC
 	tc-export CC AR
 	export LIBSUBDIR="$(get_libdir)"
+	export LIBDIR="${EPREFIX}/usr/$(get_libdir)"
 	export V=1
 }
 


### PR DESCRIPTION
libbpf always installs to /usr/lib64

Signed-off-by: Alfred Persson Forsberg <cat@catcream.org>