### PR TITLE
dev-libs/quazip: add Core5Compat DEPEND for the Qt6 build

### DIFF
--- a/dev-libs/quazip/quazip-1.3-r2.ebuild
+++ b/dev-libs/quazip/quazip-1.3-r2.ebuild
@@ -31,6 +31,7 @@ DEPEND="${COMMON_DEPEND}
 		)
 		qt6? (
 			dev-qt/qtbase:6[gui,network]
+			dev-qt/qt5compat
 		)
 	)
 "


### PR DESCRIPTION
As per the `CMakeFiles.txt` from QuaZip, `dev-qt/qt5compat` is also required for the Qt6 version: https://github.com/stachenov/quazip/blob/master/CMakeLists.txt#L57