### PR TITLE
profiles: mask sys-libs/libucontext on non-musl

### DIFF
--- a/profiles/base/package.mask
+++ b/profiles/base/package.mask
@@ -4,6 +4,7 @@
 # Sam James <sam@gentoo.org> (2022-09-10)
 # Mask in general and unmask on specific profiles
 sys-libs/musl
+sys-libs/libucontext
 
 # Sam James <sam@gentoo.org> (2021-11-22)
 # Mask the older libcrypt virtual (which accepted glibc[crypt]) to ease

--- a/profiles/features/musl/package.mask
+++ b/profiles/features/musl/package.mask
@@ -302,6 +302,7 @@ app-emulation/dosemu
 #
 sys-libs/glibc
 -sys-libs/musl
+-sys-libs/libucontext
 
 # As of 2021-08-08, >=sys-fs/udev-249-r2 is patched in Gentoo
 # to work on musl, so no need to mask udev.


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/834450