### PR TITLE
sys-devel/autoconf: backport K&R decls fix to 2.71

### DIFF
--- a/sys-devel/autoconf/autoconf-2.13-r3.ebuild
+++ b/sys-devel/autoconf/autoconf-2.13-r3.ebuild
@@ -1,0 +1,51 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit toolchain-autoconf
+
+DESCRIPTION="Used to create autoconfiguration files"
+HOMEPAGE="https://www.gnu.org/software/autoconf/autoconf.html"
+SRC_URI="mirror://gnu/${PN}/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="${PV:0:3}"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
+
+BDEPEND="
+	sys-devel/m4
+	dev-lang/perl"
+RDEPEND="${BDEPEND}
+	sys-apps/texinfo
+	>=sys-devel/autoconf-wrapper-13"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-gentoo.patch
+	"${FILESDIR}"/${P}-destdir.patch
+	"${FILESDIR}"/${P}-test-fixes.patch #146592
+	"${FILESDIR}"/${P}-perl-5.26.patch
+	"${FILESDIR}"/${P}-K-R-decls-clang.patch
+)
+
+src_configure() {
+	# make sure configure is newer than configure.in
+	touch configure || die
+
+	# need to include --exec-prefix and --bindir or our
+	# DESTDIR patch will trigger sandbox hate :(
+	#
+	# need to force locale to C to avoid bugs in the old
+	# configure script breaking the install paths #351982
+	#
+	# force to `awk` so that we don't encode another awk that
+	# happens to currently be installed, but might later be
+	# uninstalled (like mawk).  same for m4.
+	ac_cv_path_M4="m4" \
+	ac_cv_prog_AWK="awk" \
+	LC_ALL=C \
+	econf \
+		--exec-prefix="${EPREFIX}"/usr \
+		--bindir="${EPREFIX}"/usr/bin \
+		--program-suffix="-${PV}"
+}

--- a/sys-devel/autoconf/autoconf-2.69-r7.ebuild
+++ b/sys-devel/autoconf/autoconf-2.69-r7.ebuild
@@ -1,0 +1,63 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+if [[ ${PV} == 9999 ]] ; then
+	EGIT_REPO_URI="https://git.savannah.gnu.org/git/autoconf.git"
+	inherit git-r3
+else
+	SRC_URI="mirror://gnu/${PN}/${P}.tar.xz
+		ftp://alpha.gnu.org/pub/gnu/${PN}/${P}.tar.xz
+		https://dev.gentoo.org/~polynomial-c/dist/${P}-runstatedir_patches.tar.xz"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+fi
+
+inherit toolchain-autoconf
+
+DESCRIPTION="Used to create autoconfiguration files"
+HOMEPAGE="https://www.gnu.org/software/autoconf/autoconf.html"
+
+LICENSE="GPL-3"
+SLOT="${PV}"
+IUSE="emacs"
+
+BDEPEND="
+	>=sys-devel/m4-1.4.16
+	>=dev-lang/perl-5.6
+"
+RDEPEND="
+	${BDEPEND}
+	>=sys-devel/autoconf-wrapper-13
+	!~sys-devel/${P}:2.5
+"
+
+[[ ${PV} == 9999 ]] && BDEPEND+=" >=sys-apps/texinfo-4.3"
+
+PDEPEND="emacs? ( app-emacs/autoconf-mode )"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-2.69-perl-5.26.patch
+	"${FILESDIR}"/${P}-fix-libtool-test.patch
+	"${FILESDIR}"/${PN}-2.69-perl-5.26-2.patch
+	"${FILESDIR}"/${P}-make-tests-bash5-compatible.patch
+	"${FILESDIR}"/${P}-K-R-decls-clang.patch
+
+	"${WORKDIR}"/patches/${P}-texinfo.patch
+)
+
+src_prepare() {
+	# usr/bin/libtool is provided by binutils-apple, need gnu libtool
+	if [[ ${CHOST} == *-darwin* ]] ; then
+		PATCHES+=( "${FILESDIR}"/${PN}-2.61-darwin.patch )
+	fi
+
+	# Save timestamp to avoid later makeinfo call
+	touch -r doc/{,old_}autoconf.texi || die
+
+	toolchain-autoconf_src_prepare
+
+	# Restore timestamp to avoid makeinfo call
+	# We already have an up to date autoconf.info page at this point.
+	touch -r doc/{old_,}autoconf.texi || die
+}

--- a/sys-devel/autoconf/autoconf-2.71-r3.ebuild
+++ b/sys-devel/autoconf/autoconf-2.71-r3.ebuild
@@ -1,0 +1,87 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+if [[ ${PV} == 9999 ]] ; then
+	EGIT_REPO_URI="https://git.savannah.gnu.org/git/autoconf.git"
+	inherit git-r3
+else
+	# For _beta handling replace with real version number
+	MY_PV="${PV}"
+	MY_P="${PN}-${MY_PV}"
+	#PATCH_TARBALL_NAME="${PN}-2.70-patches-01"
+	SRC_URI="mirror://gnu/${PN}/${MY_P}.tar.xz
+		https://alpha.gnu.org/pub/gnu/${PN}/${MY_P}.tar.xz"
+	#SRC_URI+=" https://dev.gentoo.org/~polynomial-c/${PATCH_TARBALL_NAME}.tar.xz"
+
+	if ! [[ ${PV} == *_beta* ]] ; then
+		KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+	fi
+	S="${WORKDIR}"/${MY_P}
+fi
+
+inherit toolchain-autoconf
+
+DESCRIPTION="Used to create autoconfiguration files"
+HOMEPAGE="https://www.gnu.org/software/autoconf/autoconf.html"
+
+LICENSE="GPL-3"
+SLOT="${PV/_*}"
+IUSE="emacs"
+
+# for 2.71, our Perl time resolution patch changes our min Perl from 5.6
+# (vanilla upstream for 2.71) to 5.8.
+BDEPEND=">=sys-devel/m4-1.4.16
+	>=dev-lang/perl-5.8"
+RDEPEND="${BDEPEND}
+	>=sys-devel/autoconf-wrapper-15
+	sys-devel/gnuconfig
+	!~sys-devel/${P}:2.5"
+[[ ${PV} == 9999 ]] && BDEPEND+=" >=sys-apps/texinfo-4.3"
+PDEPEND="emacs? ( app-emacs/autoconf-mode )"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-AC_LANG_CALL_C_cxx.patch
+	"${FILESDIR}"/${P}-time.patch
+	"${FILESDIR}"/${P}-AC_C_BIGENDIAN-lto.patch
+	"${FILESDIR}"/${P}-K-R-decls-clang.patch
+	"${FILESDIR}"/${P}-make-4.4.patch
+)
+
+src_prepare() {
+	# usr/bin/libtool is provided by binutils-apple, need gnu libtool
+	if [[ ${CHOST} == *-darwin* ]] ; then
+		PATCHES+=( "${FILESDIR}"/${PN}-2.71-darwin.patch )
+	fi
+
+	# Save timestamp to avoid later makeinfo call
+	touch -r doc/{,old_}autoconf.texi || die
+
+	local pdir
+	for pdir in "${WORKDIR}"/{upstream_,}patches ; do
+		if [[ -d "${pdir}" ]] ; then
+			eapply ${pdir}
+		fi
+	done
+
+	toolchain-autoconf_src_prepare
+
+	# Restore timestamp to avoid makeinfo call
+	# We already have an up to date autoconf.info page at this point.
+	touch -r doc/{old_,}autoconf.texi || die
+}
+
+src_test() {
+	emake check
+}
+
+src_install() {
+	toolchain-autoconf_src_install
+
+	local f
+	for f in config.{guess,sub} ; do
+		ln -fs ../../gnuconfig/${f} \
+			"${ED}"/usr/share/autoconf-*/build-aux/${f} || die
+	done
+}

--- a/sys-devel/autoconf/files/autoconf-2.13-K-R-decls-clang.patch
+++ b/sys-devel/autoconf/files/autoconf-2.13-K-R-decls-clang.patch
@@ -1,0 +1,346 @@
+https://bugs.gentoo.org/870412
+https://git.savannah.gnu.org/cgit/autoconf.git/commit/?id=8b5e2016c7ed2d67f31b03a3d2e361858ff5299b
+
+Backport the K&R decls fix to 2.69 to avoid configure tests
+failing (often "silently", i.e. doesn't fail the build of
+the package overall, just leads to wrong results) with
+newer compilers like the upcoming Clang 16.
+
+From d8ad1096be4352c588b9bc1e16b6758f4f32b96a Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Arsen=20Arsenovi=C4=87?= <arsen@aarsen.me>
+Date: Mon, 19 Sep 2022 01:38:29 +0200
+Subject: [PATCH] ac{general,specific}: declare void param lists, where apt
+
+--- a/acgeneral.m4
++++ b/acgeneral.m4
+@@ -1542,7 +1542,7 @@ extern "C"
+ ])dnl
+ [/* We use char because int might match the return type of a gcc2
+     builtin and then its argument prototype would still apply.  */
+-char $1();
++char $1(void);
+ ]),
+ [$1()],
+ [$2],
+@@ -1597,7 +1597,7 @@ extern "C"
+ ])dnl
+ [/* We use char because int might match the return type of a gcc2
+     builtin and then its argument prototype would still apply.  */
+-char $2();
++char $2(void);
+ ])),
+ 	    [$2()],
+ 	    eval "ac_cv_lib_$ac_lib_var=yes",
+@@ -1733,7 +1733,7 @@ dnl [#]line __oline__ "[$]0"
+ [#]line __oline__ "configure"
+ #include "confdefs.h"
+ [$1]
+-int main() {
++int main(void) {
+ [$2]
+ ; return 0; }
+ ])EOF
+@@ -1777,7 +1777,7 @@ dnl [#]line __oline__ "[$]0"
+ [#]line __oline__ "configure"
+ #include "confdefs.h"
+ [$1]
+-int main() {
++int main(void) {
+ [$2]
+ ; return 0; }
+ ])EOF
+@@ -1934,7 +1934,7 @@ extern "C"
+ ])dnl
+ [/* We use char because int might match the return type of a gcc2
+     builtin and then its argument prototype would still apply.  */
+-char $1();
++char $1(void);
+ ], [
+ /* The GNU C library defines this for functions which it implements
+     to always fail with ENOSYS.  Some functions are actually named
+@@ -1988,7 +1988,7 @@ changequote([, ])dnl
+ AC_MSG_CHECKING(size of $1)
+ AC_CACHE_VAL(AC_CV_NAME,
+ [AC_TRY_RUN([#include <stdio.h>
+-main()
++main(void)
+ {
+   FILE *f=fopen("conftestval", "w");
+   if (!f) exit(1);
+--- a/acspecific.m4
++++ b/acspecific.m4
+@@ -202,7 +202,7 @@ AC_DEFUN(AC_PROG_CC_WORKS,
+ [AC_MSG_CHECKING([whether the C compiler ($CC $CFLAGS $LDFLAGS) works])
+ AC_LANG_SAVE
+ AC_LANG_C
+-AC_TRY_COMPILER([main(){return(0);}], ac_cv_prog_cc_works, ac_cv_prog_cc_cross)
++AC_TRY_COMPILER([int main(void){return(0);}], ac_cv_prog_cc_works, ac_cv_prog_cc_cross)
+ AC_LANG_RESTORE
+ AC_MSG_RESULT($ac_cv_prog_cc_works)
+ if test $ac_cv_prog_cc_works = no; then
+@@ -217,7 +217,7 @@ AC_DEFUN(AC_PROG_CXX_WORKS,
+ [AC_MSG_CHECKING([whether the C++ compiler ($CXX $CXXFLAGS $LDFLAGS) works])
+ AC_LANG_SAVE
+ AC_LANG_CPLUSPLUS
+-AC_TRY_COMPILER([int main(){return(0);}], ac_cv_prog_cxx_works, ac_cv_prog_cxx_cross)
++AC_TRY_COMPILER([int main(void){return(0);}], ac_cv_prog_cxx_works, ac_cv_prog_cxx_cross)
+ AC_LANG_RESTORE
+ AC_MSG_RESULT($ac_cv_prog_cxx_works)
+ if test $ac_cv_prog_cxx_works = no; then
+@@ -300,7 +300,7 @@ fi])])
+ 
+ AC_DEFUN(AC_PROG_CC_G,
+ [AC_CACHE_CHECK(whether ${CC-cc} accepts -g, ac_cv_prog_cc_g,
+-[echo 'void f(){}' > conftest.c
++[echo 'void f(void){}' > conftest.c
+ if test -z "`${CC-cc} -g -c conftest.c 2>&1`"; then
+   ac_cv_prog_cc_g=yes
+ else
+@@ -311,7 +311,7 @@ rm -f conftest*
+ 
+ AC_DEFUN(AC_PROG_CXX_G,
+ [AC_CACHE_CHECK(whether ${CXX-g++} accepts -g, ac_cv_prog_cxx_g,
+-[echo 'void f(){}' > conftest.cc
++[echo 'void f(void){}' > conftest.cc
+ if test -z "`${CXX-g++} -g -c conftest.cc 2>&1`"; then
+   ac_cv_prog_cxx_g=yes
+ else
+@@ -371,7 +371,7 @@ changequote(, )dnl
+ 		       sed -e 's/[^a-zA-Z0-9_]/_/g' -e 's/^[0-9]/_/'`"
+ changequote([, ])dnl
+ AC_CACHE_VAL(ac_cv_prog_cc_${ac_cc}_c_o,
+-[echo 'foo(){}' > conftest.c
++[echo 'foo(void){}' > conftest.c
+ # Make sure it works both with $CC and with simple cc.
+ # We do the test twice because some compilers refuse to overwrite an
+ # existing .o file with -o, though they will create one.
+@@ -709,7 +709,7 @@ AC_TRY_RUN([#include <ctype.h>
+ #define ISLOWER(c) ('a' <= (c) && (c) <= 'z')
+ #define TOUPPER(c) (ISLOWER(c) ? 'A' + ((c) - 'a') : (c))
+ #define XOR(e, f) (((e) && !(f)) || (!(e) && (f)))
+-int main () { int i; for (i = 0; i < 256; i++)
++int main (void) { int i; for (i = 0; i < 256; i++)
+ if (XOR (islower (i), ISLOWER (i)) || toupper (i) != TOUPPER (i)) exit(2);
+ exit (0); }
+ ], , ac_cv_header_stdc=no, :)
+@@ -820,7 +820,7 @@ esac
+ AC_CACHE_CHECK(whether closedir returns void, ac_cv_func_closedir_void,
+ [AC_TRY_RUN([#include <sys/types.h>
+ #include <$ac_header_dirent>
+-int closedir(); main() { exit(closedir(opendir(".")) != 0); }],
++int closedir(...); int main(void) { exit(closedir(opendir(".")) != 0); }],
+   ac_cv_func_closedir_void=no, ac_cv_func_closedir_void=yes, ac_cv_func_closedir_void=yes)])
+ if test $ac_cv_func_closedir_void = yes; then
+   AC_DEFINE(VOID_CLOSEDIR)
+@@ -911,7 +911,7 @@ changequote(<<, >>)dnl
+ #define NGID 256
+ #undef MAX
+ #define MAX(x, y) ((x) > (y) ? (x) : (y))
+-main()
++int main(void)
+ {
+   gid_t gidset[NGID];
+   int i, n;
+@@ -973,7 +973,7 @@ AC_DEFUN(AC_TYPE_SIGNAL,
+ #ifdef __cplusplus
+ extern "C" void (*signal (int, void (*)(int)))(int);
+ #else
+-void (*signal ()) ();
++void (*signal (void)) (void);
+ #endif
+ ],
+ [int i;], ac_cv_type_signal=void, ac_cv_type_signal=int)])
+@@ -989,7 +989,7 @@ AC_DEFUN(AC_FUNC_CLOSEDIR_VOID,
+ AC_CACHE_CHECK(whether closedir returns void, ac_cv_func_closedir_void,
+ [AC_TRY_RUN([#include <sys/types.h>
+ #include <$ac_header_dirent>
+-int closedir(); main() { exit(closedir(opendir(".")) != 0); }],
++int closedir(...); int main(void) { exit(closedir(opendir(".")) != 0); }],
+   ac_cv_func_closedir_void=no, ac_cv_func_closedir_void=yes, ac_cv_func_closedir_void=yes)])
+ if test $ac_cv_func_closedir_void = yes; then
+   AC_DEFINE(CLOSEDIR_VOID)
+@@ -1001,7 +1001,7 @@ AC_DEFUN(AC_FUNC_FNMATCH,
+ # Some versions of Solaris or SCO have a broken fnmatch function.
+ # So we run a test program.  If we are cross-compiling, take no chance.
+ # Thanks to John Oleynick and Franc,ois Pinard for this test.
+-[AC_TRY_RUN([main() { exit (fnmatch ("a*", "abc", 0) != 0); }],
++[AC_TRY_RUN([int main(void) { exit (fnmatch ("a*", "abc", 0) != 0); }],
+ ac_cv_func_fnmatch_works=yes, ac_cv_func_fnmatch_works=no,
+ ac_cv_func_fnmatch_works=no)])
+ if test $ac_cv_func_fnmatch_works = yes; then
+@@ -1083,11 +1083,11 @@ AC_CACHE_CHECK(for working mmap, ac_cv_func_mmap_fixed_mapped,
+ #ifdef __cplusplus
+ extern "C" { void *malloc(unsigned); }
+ #else
+-char *malloc();
++char *malloc(...);
+ #endif
+ 
+ int
+-main()
++main(void)
+ {
+ 	char *data, *data2, *data3;
+ 	int i, pagesize;
+@@ -1172,7 +1172,7 @@ int     pid;
+ int     pg1, pg2, pg3, pg4;
+ int     ng, np, s, child;
+ 
+-main()
++int main(void)
+ {
+         pid = getpid();
+         pg1 = getpgrp(0);
+@@ -1228,7 +1228,7 @@ AC_TRY_RUN([
+  * If this system has a BSD-style setpgrp, which takes arguments, exit
+  * successfully.
+  */
+-main()
++int main(void)
+ {
+     if (setpgrp(1,1) == -1)
+ 	exit(0);
+@@ -1291,7 +1291,7 @@ sparc_address_test (arg) int arg;
+     }
+   }
+ }
+-main() {
++int main(void) {
+   pid_t parent = getpid ();
+   pid_t child;
+ 
+@@ -1360,7 +1360,7 @@ AC_DEFUN(AC_FUNC_WAIT3,
+ #include <sys/resource.h>
+ #include <stdio.h>
+ /* HP-UX has wait3 but does not fill in rusage at all.  */
+-main() {
++int main(void) {
+   struct rusage r;
+   int i;
+   /* Use a field that we can force nonzero --
+@@ -1416,7 +1416,7 @@ AC_CACHE_CHECK([for alloca], ac_cv_func_alloca_works,
+  #pragma alloca
+ #   else
+ #    ifndef alloca /* predefined by HP cc +Olibcalls */
+-char *alloca ();
++char *alloca (...);
+ #    endif
+ #   endif
+ #  endif
+@@ -1464,7 +1464,7 @@ AC_CACHE_CHECK(stack direction for C alloca, ac_cv_c_stack_direction,
+   else
+     return (&dummy > addr) ? 1 : -1;
+ }
+-main ()
++int main (void)
+ {
+   exit (find_stack_direction() < 0);
+ }], ac_cv_c_stack_direction=1, ac_cv_c_stack_direction=-1,
+@@ -1582,7 +1582,7 @@ AC_DEFUN(AC_FUNC_UTIME_NULL,
+ # Sequent interprets utime(file, 0) to mean use start of epoch.  Wrong.
+ AC_TRY_RUN([#include <sys/types.h>
+ #include <sys/stat.h>
+-main() {
++int main(void) {
+ struct stat s, t;
+ exit(!(stat ("conftestdata", &s) == 0 && utime("conftestdata", (long *)0) == 0
+ && stat("conftestdata", &t) == 0 && t.st_mtime >= s.st_mtime
+@@ -1598,7 +1598,7 @@ fi
+ AC_DEFUN(AC_FUNC_STRCOLL,
+ [AC_CACHE_CHECK(for working strcoll, ac_cv_func_strcoll_works,
+ [AC_TRY_RUN([#include <string.h>
+-main ()
++int main (void)
+ {
+   exit (strcoll ("abc", "def") >= 0 ||
+ 	strcoll ("ABC", "DEF") >= 0 ||
+@@ -1615,7 +1615,7 @@ AC_DEFUN(AC_FUNC_SETVBUF_REVERSED,
+   ac_cv_func_setvbuf_reversed,
+ [AC_TRY_RUN([#include <stdio.h>
+ /* If setvbuf has the reversed format, exit 0. */
+-main () {
++int main (void) {
+   /* This call has the arguments reversed.
+      A reversed system may check and see that the address of main
+      is not _IOLBF, _IONBF, or _IOFBF, and return nonzero.  */
+@@ -1647,7 +1647,7 @@ LIBS="-lintl $LIBS"])])])
+ AC_DEFUN(AC_FUNC_MEMCMP,
+ [AC_CACHE_CHECK(for 8-bit clean memcmp, ac_cv_func_memcmp_clean,
+ [AC_TRY_RUN([
+-main()
++int main(void)
+ {
+   char c0 = 0x40, c1 = 0x80, c2 = 0x81;
+   exit(memcmp(&c0, &c2, 1) < 0 && memcmp(&c1, &c2, 1) < 0 ? 0 : 1);
+@@ -1805,7 +1805,7 @@ AC_TRY_RUN(
+ #if !defined(__STDC__) || __STDC__ != 1
+ #define volatile
+ #endif
+-main() {
++int main(void) {
+   volatile char c = 255; exit(c < 0);
+ }], ac_cv_c_char_unsigned=yes, ac_cv_c_char_unsigned=no)
+ fi])
+@@ -1819,7 +1819,7 @@ AC_DEFUN(AC_C_LONG_DOUBLE,
+ [if test "$GCC" = yes; then
+   ac_cv_c_long_double=yes
+ else
+-AC_TRY_RUN([int main() {
++AC_TRY_RUN([int main(void) {
+ /* The Stardent Vistra knows sizeof(long double), but does not support it.  */
+ long double foo = 0.0;
+ /* On Ultrix 4.3 cc, long double is 4 and double is 8.  */
+@@ -1834,7 +1834,7 @@ fi
+ AC_DEFUN(AC_INT_16_BITS,
+ [AC_OBSOLETE([$0], [; instead use AC_CHECK_SIZEOF(int)])dnl
+ AC_MSG_CHECKING(whether int is 16 bits)
+-AC_TRY_RUN([main() { exit(sizeof(int) != 2); }],
++AC_TRY_RUN([int main(void) { exit(sizeof(int) != 2); }],
+  [AC_MSG_RESULT(yes)
+  AC_DEFINE(INT_16_BITS)], AC_MSG_RESULT(no))
+ ])
+@@ -1842,7 +1842,7 @@ AC_TRY_RUN([main() { exit(sizeof(int) != 2); }],
+ AC_DEFUN(AC_LONG_64_BITS,
+ [AC_OBSOLETE([$0], [; instead use AC_CHECK_SIZEOF(long)])dnl
+ AC_MSG_CHECKING(whether long int is 64 bits)
+-AC_TRY_RUN([main() { exit(sizeof(long int) != 8); }],
++AC_TRY_RUN([int main(void) { exit(sizeof(long int) != 8); }],
+  [AC_MSG_RESULT(yes)
+  AC_DEFINE(LONG_64_BITS)], AC_MSG_RESULT(no))
+ ])
+@@ -1862,7 +1862,7 @@ AC_TRY_COMPILE([#include <sys/types.h>
+  not big endian
+ #endif], ac_cv_c_bigendian=yes, ac_cv_c_bigendian=no)])
+ if test $ac_cv_c_bigendian = unknown; then
+-AC_TRY_RUN([main () {
++AC_TRY_RUN([int main (void) {
+   /* Are we little or big endian?  From Harbison&Steele.  */
+   union
+   {
+@@ -1885,7 +1885,7 @@ AC_DEFUN(AC_C_INLINE,
+ [AC_CACHE_CHECK([for inline], ac_cv_c_inline,
+ [ac_cv_c_inline=no
+ for ac_kw in inline __inline__ __inline; do
+-  AC_TRY_COMPILE(, [} $ac_kw foo() {], [ac_cv_c_inline=$ac_kw; break])
++  AC_TRY_COMPILE(, [} $ac_kw foo(void) {], [ac_cv_c_inline=$ac_kw; break])
+ done
+ ])
+ case "$ac_cv_c_inline" in
+@@ -2277,7 +2277,7 @@ AC_DEFUN(AC_SYS_RESTARTABLE_SYSCALLS,
+ #include <sys/types.h>
+ #include <signal.h>
+ ucatch (isig) { }
+-main () {
++int main (void) {
+   int i = fork (), status;
+   if (i == 0) { sleep (3); kill (getppid (), SIGINT); sleep (3); exit (0); }
+   signal (SIGINT, ucatch);
+@@ -2654,7 +2654,7 @@ AC_CACHE_VAL(ac_cv_exeext,
+   ac_cv_exeext=.exe
+ else
+   rm -f conftest*
+-  echo 'int main () { return 0; }' > conftest.$ac_ext
++  echo 'int main (void) { return 0; }' > conftest.$ac_ext
+   ac_cv_exeext=
+   if AC_TRY_EVAL(ac_link); then
+     for file in conftest.*; do

--- a/sys-devel/autoconf/files/autoconf-2.69-K-R-decls-clang.patch
+++ b/sys-devel/autoconf/files/autoconf-2.69-K-R-decls-clang.patch
@@ -11,28 +11,6 @@ From: =?UTF-8?q?Arsen=20Arsenovi=C4=87?= <arsen@aarsen.me>
 Date: Mon, 19 Sep 2022 12:11:24 +0200
 Subject: [PATCH] backport K&R decl fixes
 
---- a/doc/autoconf.texi
-+++ b/doc/autoconf.texi
-@@ -5201,9 +5201,7 @@ the @samp{#undef malloc}):
- #include <config.h>
- #undef malloc
- 
--#include <sys/types.h>
--
--void *malloc ();
-+#include <stdlib.h>
- 
- /* Allocate an N-byte block of memory from the heap.
-    If N is zero, allocate a 1-byte block.  */
-@@ -8057,7 +8055,7 @@ needed:
- #  ifdef __cplusplus
-      extern "C"
- #  endif
--   int F77_DUMMY_MAIN () @{ return 1; @}
-+   int F77_DUMMY_MAIN (void) @{ return 1; @}
- #endif
- @end example
- 
 --- a/lib/autoconf/c.m4
 +++ b/lib/autoconf/c.m4
 @@ -97,7 +97,7 @@ m4_define([AC_LANG_PROGRAM(C)],

--- a/sys-devel/autoconf/files/autoconf-2.69-K-R-decls-clang.patch
+++ b/sys-devel/autoconf/files/autoconf-2.69-K-R-decls-clang.patch
@@ -1,0 +1,387 @@
+https://bugs.gentoo.org/870412
+https://git.savannah.gnu.org/cgit/autoconf.git/commit/?id=8b5e2016c7ed2d67f31b03a3d2e361858ff5299b
+
+Backport the K&R decls fix to 2.69 to avoid configure tests
+failing (often "silently", i.e. doesn't fail the build of
+the package overall, just leads to wrong results) with
+newer compilers like the upcoming Clang 16.
+
+From e6f401b94b58bb9bb58cd668a996e27663d3e6c7 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Arsen=20Arsenovi=C4=87?= <arsen@aarsen.me>
+Date: Mon, 19 Sep 2022 12:11:24 +0200
+Subject: [PATCH] backport K&R decl fixes
+
+--- a/doc/autoconf.texi
++++ b/doc/autoconf.texi
+@@ -5201,9 +5201,7 @@ the @samp{#undef malloc}):
+ #include <config.h>
+ #undef malloc
+ 
+-#include <sys/types.h>
+-
+-void *malloc ();
++#include <stdlib.h>
+ 
+ /* Allocate an N-byte block of memory from the heap.
+    If N is zero, allocate a 1-byte block.  */
+@@ -8057,7 +8055,7 @@ needed:
+ #  ifdef __cplusplus
+      extern "C"
+ #  endif
+-   int F77_DUMMY_MAIN () @{ return 1; @}
++   int F77_DUMMY_MAIN (void) @{ return 1; @}
+ #endif
+ @end example
+ 
+--- a/lib/autoconf/c.m4
++++ b/lib/autoconf/c.m4
+@@ -97,7 +97,7 @@ m4_define([AC_LANG_PROGRAM(C)],
+ m4_ifdef([_AC_LANG_PROGRAM_C_F77_HOOKS], [_AC_LANG_PROGRAM_C_F77_HOOKS])[]dnl
+ m4_ifdef([_AC_LANG_PROGRAM_C_FC_HOOKS], [_AC_LANG_PROGRAM_C_FC_HOOKS])[]dnl
+ int
+-main ()
++main (void)
+ {
+ dnl Do *not* indent the following line: there may be CPP directives.
+ dnl Don't move the `;' right after for the same reason.
+@@ -130,7 +130,7 @@ m4_if([$2], [main], ,
+ #ifdef __cplusplus
+ extern "C"
+ #endif
+-char $2 ();])], [return $2 ();])])
++char $2 (void);])], [return $2 ();])])
+ 
+ 
+ # AC_LANG_FUNC_LINK_TRY(C)(FUNCTION)
+@@ -154,7 +154,7 @@ m4_define([AC_LANG_FUNC_LINK_TRY(C)],
+ #define $1 innocuous_$1
+ 
+ /* System header to define __stub macros and hopefully few prototypes,
+-    which can conflict with char $1 (); below.
++    which can conflict with char $1 (void); below.
+     Prefer <limits.h> to <assert.h> if __STDC__ is defined, since
+     <limits.h> exists even on freestanding compilers.  */
+ 
+@@ -172,7 +172,7 @@ m4_define([AC_LANG_FUNC_LINK_TRY(C)],
+ #ifdef __cplusplus
+ extern "C"
+ #endif
+-char $1 ();
++char $1 (void);
+ /* The GNU C library defines this for functions which it implements
+     to always fail with ENOSYS.  Some functions are actually named
+     something starting with __ and the normal name is an alias.  */
+@@ -201,8 +201,8 @@ return test_array @<:@0@:>@;
+ # But we include them only after the EXPRESSION has been evaluated.
+ m4_define([AC_LANG_INT_SAVE(C)],
+ [AC_LANG_PROGRAM([$1
+-static long int longval () { return $2; }
+-static unsigned long int ulongval () { return $2; }
++static long int longval (void) { return $2; }
++static unsigned long int ulongval (void) { return $2; }
+ @%:@include <stdio.h>
+ @%:@include <stdlib.h>],
+ [
+@@ -1625,8 +1625,8 @@ for ac_kw in inline __inline__ __inline; do
+   AC_COMPILE_IFELSE([AC_LANG_SOURCE(
+ [#ifndef __cplusplus
+ typedef int foo_t;
+-static $ac_kw foo_t static_foo () {return 0; }
+-$ac_kw foo_t foo () {return 0; }
++static $ac_kw foo_t static_foo (void) {return 0; }
++$ac_kw foo_t foo (void) {return 0; }
+ #endif
+ ])],
+ 		    [ac_cv_c_inline=$ac_kw])
+@@ -1949,7 +1949,7 @@ m4_define([_AC_LANG_OPENMP(C)],
+  choke me
+ #endif
+ #include <omp.h>
+-int main () { return omp_get_num_threads (); }
++int main (void) { return omp_get_num_threads (); }
+ ])
+ 
+ # _AC_LANG_OPENMP(C++)
+--- a/lib/autoconf/functions.m4
++++ b/lib/autoconf/functions.m4
+@@ -463,9 +463,6 @@ AC_CACHE_CHECK([whether closedir returns void],
+ 	       [ac_cv_func_closedir_void],
+ [AC_RUN_IFELSE([AC_LANG_PROGRAM([AC_INCLUDES_DEFAULT
+ #include <$ac_header_dirent>
+-#ifndef __cplusplus
+-int closedir ();
+-#endif
+ ],
+ 				[[return closedir (opendir (".")) != 0;]])],
+ 	       [ac_cv_func_closedir_void=no],
+@@ -893,7 +890,7 @@ AC_CACHE_CHECK([for GNU libc compatible malloc], ac_cv_func_malloc_0_nonnull,
+ [[#if defined STDC_HEADERS || defined HAVE_STDLIB_H
+ # include <stdlib.h>
+ #else
+-char *malloc ();
++char *malloc (long);
+ #endif
+ ]],
+ 		 [return ! malloc (0);])],
+@@ -1029,7 +1026,7 @@ static const char *tz_strings[] = {
+ /* Return 0 if mktime fails to convert a date in the spring-forward gap.
+    Based on a problem report from Andreas Jaeger.  */
+ static int
+-spring_forward_gap ()
++spring_forward_gap (void)
+ {
+   /* glibc (up to about 1998-10-07) failed this test. */
+   struct tm tm;
+@@ -1066,7 +1063,7 @@ mktime_test (time_t now)
+ }
+ 
+ static int
+-irix_6_4_bug ()
++irix_6_4_bug (void)
+ {
+   /* Based on code from Ariel Faigon.  */
+   struct tm tm;
+@@ -1108,7 +1105,7 @@ bigtime_test (int j)
+ }
+ 
+ static int
+-year_2050_test ()
++year_2050_test (void)
+ {
+   /* The correct answer for 2050-02-01 00:00:00 in Pacific time,
+      ignoring leap seconds.  */
+@@ -1138,7 +1135,7 @@ year_2050_test ()
+ }
+ 
+ int
+-main ()
++main (void)
+ {
+   time_t t, delta;
+   int i, j;
+@@ -1232,7 +1229,7 @@ AC_CACHE_CHECK([for working mmap], [ac_cv_func_mmap_fixed_mapped],
+ #include <sys/mman.h>
+ 
+ #if !defined STDC_HEADERS && !defined HAVE_STDLIB_H
+-char *malloc ();
++char *malloc (void *, long);
+ #endif
+ 
+ /* This mess was copied from the GNU getpagesize.h.  */
+@@ -1268,7 +1265,7 @@ char *malloc ();
+ #endif /* no HAVE_GETPAGESIZE */
+ 
+ int
+-main ()
++main (void)
+ {
+   char *data, *data2, *data3;
+   const char *cdata2;
+@@ -1398,7 +1395,7 @@ AC_CACHE_CHECK([for GNU libc compatible realloc], ac_cv_func_realloc_0_nonnull,
+ [[#if defined STDC_HEADERS || defined HAVE_STDLIB_H
+ # include <stdlib.h>
+ #else
+-char *realloc ();
++char *realloc (void *, long);
+ #endif
+ ]],
+ 		 [return ! realloc (0, 0);])],
+@@ -1547,11 +1544,8 @@ AC_DEFUN([AC_FUNC_STRTOD],
+ AC_CACHE_CHECK(for working strtod, ac_cv_func_strtod,
+ [AC_RUN_IFELSE([AC_LANG_SOURCE([[
+ ]AC_INCLUDES_DEFAULT[
+-#ifndef strtod
+-double strtod ();
+-#endif
+ int
+-main()
++main(void)
+ {
+   {
+     /* Some versions of Linux strtod mis-parse strings with leading '+'.  */
+@@ -1645,8 +1639,7 @@ AC_CACHE_CHECK([whether strerror_r returns char *],
+       # former has a strerror_r that returns char*, while the latter
+       # has a strerror_r that returns `int'.
+       # This test should segfault on the DEC system.
+-      AC_RUN_IFELSE([AC_LANG_PROGRAM([AC_INCLUDES_DEFAULT
+-	extern char *strerror_r ();],
++      AC_RUN_IFELSE([AC_LANG_PROGRAM([AC_INCLUDES_DEFAULT],
+ 	[[char buf[100];
+ 	  char x = *strerror_r (0, buf, sizeof buf);
+ 	  return ! isalpha (x);]])],
+@@ -1879,7 +1872,7 @@ sparc_address_test (arg) int arg;
+ }
+ 
+ int
+-main ()
++main (void)
+ {
+   pid_t parent = getpid ();
+   pid_t child;
+@@ -1985,7 +1978,7 @@ AC_CACHE_CHECK([for wait3 that fills in rusage],
+ #include <sys/wait.h>
+ /* HP-UX has wait3 but does not fill in rusage at all.  */
+ int
+-main ()
++main (void)
+ {
+   struct rusage r;
+   int i;
+--- a/lib/autoconf/headers.m4
++++ b/lib/autoconf/headers.m4
+@@ -712,7 +712,7 @@ if test $ac_cv_header_stdc = yes; then
+ 
+ #define XOR(e, f) (((e) && !(f)) || (!(e) && (f)))
+ int
+-main ()
++main (void)
+ {
+   int i;
+   for (i = 0; i < 256; i++)
+--- a/lib/autoconf/specific.m4
++++ b/lib/autoconf/specific.m4
+@@ -257,7 +257,7 @@ void ucatch (dummy) int dummy; { }
+ #endif
+ 
+ int
+-main ()
++main (void)
+ {
+   int i = fork (), status;
+ 
+--- a/lib/autoconf/types.m4
++++ b/lib/autoconf/types.m4
+@@ -267,7 +267,7 @@ AC_CACHE_CHECK(type of array argument to getgroups, ac_cv_type_getgroups,
+ #define MAX(x, y) ((x) > (y) ? (x) : (y))
+ 
+ int
+-main ()
++main (void)
+ {
+   gid_t gidset[NGID];
+   int i, n;
+--- a/tests/c.at
++++ b/tests/c.at
+@@ -354,7 +354,7 @@ AT_DATA([foo.c],
+ #endif
+ #include <stdio.h>
+ 
+-int main ()
++int main (void)
+ {
+ #ifdef _OPENMP
+ #pragma omp parallel
+@@ -404,7 +404,7 @@ foo.@OBJEXT@: foo.cpp
+ ]])
+ 
+ AT_DATA([foo.cpp],
+-[[int main ()
++[[int main (void)
+ {
+   return 0;
+ }
+--- a/tests/compile.at
++++ b/tests/compile.at
+@@ -124,7 +124,7 @@ AC_PROG_CC
+ AC_COMPILE_IFELSE([AC_LANG_SOURCE([[#ifndef PACKAGE_NAME
+ choke me
+ #endif
+-int main ()
++int main (void)
+ {
+   return 0;
+ }
+@@ -150,7 +150,7 @@ AC_LANG([C++])
+ AC_COMPILE_IFELSE([AC_LANG_SOURCE([[#ifndef PACKAGE_NAME
+ choke me
+ #endif
+-int main ()
++int main (void)
+ {
+   return 0;
+ }
+@@ -249,7 +249,7 @@ AT_CHECK([sed -n 's/ *$//; /#define PACKAGE/,$p' stdout], [],
+ 
+ const char hw[] = "Hello, World\n";
+ int
+-main ()
++main (void)
+ {
+ fputs (hw, stdout);
+   ;
+@@ -269,7 +269,7 @@ AT_KEYWORDS([AC_LANG_DEFINES_PROVIDED])
+ 
+ AT_DATA([configure.ac],
+ [[AC_INIT
+-AC_COMPILE_IFELSE([int main () { return 0; }], [],
++AC_COMPILE_IFELSE([int main (void) { return 0; }], [],
+   [AC_MSG_ERROR([compiling trivial program failed])])
+ ]])
+ 
+@@ -280,7 +280,7 @@ AT_CHECK_CONFIGURE([-q])
+ 
+ AT_DATA([configure.ac],
+ [[AC_INIT
+-AC_COMPILE_IFELSE([AC_LANG_DEFINES_PROVIDED()int main () { return 0; }], [],
++AC_COMPILE_IFELSE([AC_LANG_DEFINES_PROVIDED()int main (void) { return 0; }], [],
+   [AC_MSG_ERROR([compiling trivial program failed])])
+ ]])
+ 
+@@ -324,7 +324,7 @@ test $estatus != 2 &&
+   AC_MSG_ERROR([did not get as 2 exit status: $estatus])])
+ 
+ # The old stinky one.
+-AC_TRY_RUN([int main () { return 3; }],
++AC_TRY_RUN([int main (void) { return 3; }],
+ 	   [AC_MSG_ERROR([saw `return 3' as a success])],
+ 	   [estatus=$?
+ test $estatus != 3 &&
+--- a/tests/fortran.at
++++ b/tests/fortran.at
+@@ -223,7 +223,7 @@ void FOOBAR_F77 (double *x, double *y);
+ #  ifdef __cplusplus
+      extern "C"
+ #  endif
+-   int F77_DUMMY_MAIN () { return 1; }
++   int F77_DUMMY_MAIN (void) { return 1; }
+ #endif
+ 
+ int main(int argc, char *argv[])
+@@ -301,7 +301,7 @@ void FOOBAR_FC(double *x, double *y);
+ #  ifdef __cplusplus
+      extern "C"
+ #  endif
+-   int FC_DUMMY_MAIN () { return 1; }
++   int FC_DUMMY_MAIN (void) { return 1; }
+ #endif
+ 
+ int main (int argc, char *argv[])
+@@ -533,7 +533,7 @@ void @foobar@ (int *x);
+ #  ifdef __cplusplus
+      extern "C"
+ #  endif
+-   int F77_DUMMY_MAIN () { return 1; }
++   int F77_DUMMY_MAIN (void) { return 1; }
+ #endif
+ 
+ int main(int argc, char *argv[])
+@@ -607,7 +607,7 @@ void @foobar@ (int *x);
+ #  ifdef __cplusplus
+      extern "C"
+ #  endif
+-   int FC_DUMMY_MAIN () { return 1; }
++   int FC_DUMMY_MAIN (void) { return 1; }
+ #endif
+ 
+ int main(int argc, char *argv[])
+--- a/tests/semantics.at
++++ b/tests/semantics.at
+@@ -107,7 +107,7 @@ AT_CHECK_MACRO([AC_CHECK_DECLS],
+ 		 [[int yes = 1;
+ 		   enum { myenum };
+ 		   struct { int x[20]; } mystruct;
+-		   extern int myfunc();
++		   extern int myfunc (void);
+ 		   #define mymacro1(arg) arg
+ 		   #define mymacro2]])
+   # The difference in space-before-open-paren is intentional.

--- a/sys-devel/autoconf/files/autoconf-2.71-AC_C_BIGENDIAN-lto.patch
+++ b/sys-devel/autoconf/files/autoconf-2.71-AC_C_BIGENDIAN-lto.patch
@@ -1,0 +1,50 @@
+https://git.savannah.gnu.org/cgit/autoconf.git/commit/?id=234fc6c86613ed3f366dd1d88996e4d5d85ee222
+
+From 234fc6c86613ed3f366dd1d88996e4d5d85ee222 Mon Sep 17 00:00:00 2001
+From: Paul Eggert <eggert@cs.ucla.edu>
+Date: Wed, 27 Jul 2022 08:53:35 -0700
+Subject: Port AC_C_BIGENDIAN to cross gcc -std=c11 -flto
+
+* lib/autoconf/c.m4 (AC_C_BIGENDIAN): Improve the
+inherently-unportable grep trick well enough to survive gcc
+-std=c11 -flto when cross-compiling (sr#110687).
+--- a/lib/autoconf/c.m4
++++ b/lib/autoconf/c.m4
+@@ -1838,8 +1838,8 @@ AC_DEFUN([AC_C_BIGENDIAN],
+ 	[ac_cv_c_bigendian=no],
+ 	[ac_cv_c_bigendian=yes],
+ 	[# Try to guess by grepping values from an object file.
+-	 AC_COMPILE_IFELSE(
+-	   [AC_LANG_PROGRAM(
++	 AC_LINK_IFELSE(
++	   [AC_LANG_SOURCE(
+ 	      [[unsigned short int ascii_mm[] =
+ 		  { 0x4249, 0x4765, 0x6E44, 0x6961, 0x6E53, 0x7953, 0 };
+ 		unsigned short int ascii_ii[] =
+@@ -1854,13 +1854,20 @@ AC_DEFUN([AC_C_BIGENDIAN],
+ 		int use_ebcdic (int i) {
+ 		  return ebcdic_mm[i] + ebcdic_ii[i];
+ 		}
+-		extern int foo;
+-	      ]],
+-	      [[return use_ascii (foo) == use_ebcdic (foo);]])],
+-	   [if grep BIGenDianSyS conftest.$ac_objext >/dev/null; then
++		int
++		main (int argc, char **argv)
++		{
++		  /* Intimidate the compiler so that it does not
++		     optimize the arrays away.  */
++		  char *p = argv[0];
++		  ascii_mm[1] = *p++; ebcdic_mm[1] = *p++;
++		  ascii_ii[1] = *p++; ebcdic_ii[1] = *p++;
++		  return use_ascii (argc) == use_ebcdic (*p);
++		}]])],
++	   [if grep BIGenDianSyS conftest$ac_exeext >/dev/null; then
+ 	      ac_cv_c_bigendian=yes
+ 	    fi
+-	    if grep LiTTleEnDian conftest.$ac_objext >/dev/null ; then
++	    if grep LiTTleEnDian conftest$ac_exeext >/dev/null ; then
+ 	      if test "$ac_cv_c_bigendian" = unknown; then
+ 		ac_cv_c_bigendian=no
+ 	      else
+cgit v1.1

--- a/sys-devel/autoconf/files/autoconf-2.71-AC_LANG_CALL_C_cxx.patch
+++ b/sys-devel/autoconf/files/autoconf-2.71-AC_LANG_CALL_C_cxx.patch
@@ -1,0 +1,30 @@
+https://git.savannah.gnu.org/cgit/autoconf.git/commit/?id=b27bc3e230bb12fdd9a813e38e82bc4c3e22b4cc
+
+From b27bc3e230bb12fdd9a813e38e82bc4c3e22b4cc Mon Sep 17 00:00:00 2001
+From: Paul Eggert <eggert@cs.ucla.edu>
+Date: Tue, 31 Aug 2021 16:30:46 -0700
+Subject: Port AC_LANG_CALL(C) to C++
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+* lib/autoconf/c.m4 (AC_LANG_CALL(C)): Add an extern "C" if C++.
+Problem reported by Vincent Lefèvre (sr #110532).
+--- a/lib/autoconf/c.m4
++++ b/lib/autoconf/c.m4
+@@ -126,7 +126,13 @@ m4_define([AC_LANG_CALL(C)],
+ m4_if([$2], [main], ,
+ [/* Override any GCC internal prototype to avoid an error.
+    Use char because int might match the return type of a GCC
+-   builtin and then its argument prototype would still apply.  */
++   builtin and then its argument prototype would still apply.
++   The 'extern "C"' is for builds by C++ compilers;
++   although this is not generally supported in C code, supporting it here
++   has little cost and some practical benefit (sr 110532).  */
++#ifdef __cplusplus
++extern "C"
++#endif
+ char $2 ();])], [return $2 ();])])
+ 
+ 
+cgit v1.1

--- a/sys-devel/autoconf/files/autoconf-2.71-K-R-decls-clang.patch
+++ b/sys-devel/autoconf/files/autoconf-2.71-K-R-decls-clang.patch
@@ -21,28 +21,6 @@ provokes fatal errors in some compilers nowadays.
 * tests/fortran.at (AC_F77_DUMMY_MAIN usage):
 * tests/semantics.at (AC_CHECK_DECLS):
 Don’t use () in a function decl.
---- a/doc/autoconf.texi
-+++ b/doc/autoconf.texi
-@@ -5460,9 +5460,7 @@ the @samp{#undef malloc}):
- #include <config.h>
- #undef malloc
- 
--#include <sys/types.h>
--
--void *malloc ();
-+#include <stdlib.h>
- 
- /* Allocate an N-byte block of memory from the heap.
-    If N is zero, allocate a 1-byte block.  */
-@@ -8297,7 +8295,7 @@ needed:
- #  ifdef __cplusplus
-      extern "C"
- #  endif
--   int F77_DUMMY_MAIN () @{ return 1; @}
-+   int F77_DUMMY_MAIN (void) @{ return 1; @}
- #endif
- @end example
- 
 --- a/lib/autoconf/c.m4
 +++ b/lib/autoconf/c.m4
 @@ -133,7 +133,7 @@ m4_if([$2], [main], ,

--- a/sys-devel/autoconf/files/autoconf-2.71-K-R-decls-clang.patch
+++ b/sys-devel/autoconf/files/autoconf-2.71-K-R-decls-clang.patch
@@ -1,0 +1,136 @@
+https://bugs.gentoo.org/870412
+https://git.savannah.gnu.org/cgit/autoconf.git/commit/?id=8b5e2016c7ed2d67f31b03a3d2e361858ff5299b
+
+Backport the K&R decls fix to 2.69 to avoid configure tests
+failing (often "silently", i.e. doesn't fail the build of
+the package overall, just leads to wrong results) with
+newer compilers like the upcoming Clang 16.
+
+From 8b5e2016c7ed2d67f31b03a3d2e361858ff5299b Mon Sep 17 00:00:00 2001
+From: Paul Eggert <eggert@cs.ucla.edu>
+Date: Thu, 1 Sep 2022 16:19:50 -0500
+Subject: Port to compilers that moan about K&R func decls
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+* lib/autoconf/c.m4 (AC_LANG_CALL, AC_LANG_FUNC_LINK_TRY):
+Use '(void)' rather than '()' in function prototypes, as the latter
+provokes fatal errors in some compilers nowadays.
+* lib/autoconf/functions.m4 (AC_FUNC_STRTOD):
+* tests/fortran.at (AC_F77_DUMMY_MAIN usage):
+* tests/semantics.at (AC_CHECK_DECLS):
+Don’t use () in a function decl.
+--- a/doc/autoconf.texi
++++ b/doc/autoconf.texi
+@@ -5460,9 +5460,7 @@ the @samp{#undef malloc}):
+ #include <config.h>
+ #undef malloc
+ 
+-#include <sys/types.h>
+-
+-void *malloc ();
++#include <stdlib.h>
+ 
+ /* Allocate an N-byte block of memory from the heap.
+    If N is zero, allocate a 1-byte block.  */
+@@ -8297,7 +8295,7 @@ needed:
+ #  ifdef __cplusplus
+      extern "C"
+ #  endif
+-   int F77_DUMMY_MAIN () @{ return 1; @}
++   int F77_DUMMY_MAIN (void) @{ return 1; @}
+ #endif
+ @end example
+ 
+--- a/lib/autoconf/c.m4
++++ b/lib/autoconf/c.m4
+@@ -133,7 +133,7 @@ m4_if([$2], [main], ,
+ #ifdef __cplusplus
+ extern "C"
+ #endif
+-char $2 ();])], [return $2 ();])])
++char $2 (void);])], [return $2 ();])])
+ 
+ 
+ # AC_LANG_FUNC_LINK_TRY(C)(FUNCTION)
+@@ -157,7 +157,7 @@ m4_define([AC_LANG_FUNC_LINK_TRY(C)],
+ #define $1 innocuous_$1
+ 
+ /* System header to define __stub macros and hopefully few prototypes,
+-   which can conflict with char $1 (); below.  */
++   which can conflict with char $1 (void); below.  */
+ 
+ #include <limits.h>
+ #undef $1
+@@ -168,7 +168,7 @@ m4_define([AC_LANG_FUNC_LINK_TRY(C)],
+ #ifdef __cplusplus
+ extern "C"
+ #endif
+-char $1 ();
++char $1 (void);
+ /* The GNU C library defines this for functions which it implements
+     to always fail with ENOSYS.  Some functions are actually named
+     something starting with __ and the normal name is an alias.  */
+--- a/lib/autoconf/functions.m4
++++ b/lib/autoconf/functions.m4
+@@ -1613,9 +1613,6 @@ AC_DEFUN([AC_FUNC_STRTOD],
+ AC_CACHE_CHECK(for working strtod, ac_cv_func_strtod,
+ [AC_RUN_IFELSE([AC_LANG_SOURCE([[
+ ]AC_INCLUDES_DEFAULT[
+-#ifndef strtod
+-double strtod ();
+-#endif
+ int
+ main (void)
+ {
+--- a/tests/fortran.at
++++ b/tests/fortran.at
+@@ -233,7 +233,7 @@ void FOOBAR_F77 (double *x, double *y);
+ #  ifdef __cplusplus
+      extern "C"
+ #  endif
+-   int F77_DUMMY_MAIN () { return 1; }
++   int F77_DUMMY_MAIN (void) { return 1; }
+ #endif
+ 
+ int main(int argc, char *argv[])
+@@ -315,7 +315,7 @@ void FOOBAR_FC(double *x, double *y);
+ #  ifdef __cplusplus
+      extern "C"
+ #  endif
+-   int FC_DUMMY_MAIN () { return 1; }
++   int FC_DUMMY_MAIN (void) { return 1; }
+ #endif
+ 
+ int main (int argc, char *argv[])
+@@ -561,7 +561,7 @@ void @foobar@ (int *x);
+ #  ifdef __cplusplus
+      extern "C"
+ #  endif
+-   int F77_DUMMY_MAIN () { return 1; }
++   int F77_DUMMY_MAIN (void) { return 1; }
+ #endif
+ 
+ int main(int argc, char *argv[])
+@@ -637,7 +637,7 @@ void @foobar@ (int *x);
+ #  ifdef __cplusplus
+      extern "C"
+ #  endif
+-   int FC_DUMMY_MAIN () { return 1; }
++   int FC_DUMMY_MAIN (void) { return 1; }
+ #endif
+ 
+ int main(int argc, char *argv[])
+--- a/tests/semantics.at
++++ b/tests/semantics.at
+@@ -207,7 +207,7 @@ AT_CHECK_MACRO([AC_CHECK_DECLS],
+ 		 [[extern int yes;
+ 		   enum { myenum };
+ 		   extern struct mystruct_s { int x[20]; } mystruct;
+-		   extern int myfunc();
++		   extern int myfunc (int);
+ 		   #define mymacro1(arg) arg
+ 		   #define mymacro2]])
+   # Ensure we can detect missing declarations of functions whose
+cgit v1.1


### PR DESCRIPTION
sys-devel/autoconf: backport K&R decls fix to 2.71

Backport the K&R decls fix to 2.71 to avoid configure tests
failing (often "silently", i.e. doesn't fail the build of
the package overall, just leads to wrong results) with
newer compilers like the upcoming Clang 16.

A consequence of this whole fuss is that we're going to
have to eautoreconf in a bunch of older packages, but
as Ionen pointed out on IRC, this means we get some
other stuff for free like Python 3.10 fixes, so it's
not all bad.

Undecided how to handle any packages with a generated
configure from autoconfs not in tree. We may just
patch the configure manually. Will see.

See linked bug 870412 and the Discourse thread therein for
details if unfamiliar.

Patches:
- AC_C_BIGENDIAN-lto.patch ("Port AC_C_BIGENDIAN to cross gcc -std=c11 -flto")
- AC_LANG_CALL_C_cxx.patch ("Port AC_LANG_CALL(C) to C++")
- K-R-decls-clang.patch ("Port to compilers that moan about K&R func decls")

The first two are included to make the latter apply cleanly, but they're
also both harmless and desirable.

As I remarked on IRC, it's unfortunate to have to backport anything
which will then infect generated configure, as it's somewhat
a repeat of the --runstatedir situation, and it leads to confusion/hassle
when sending patches upstream where a generated/bootstrapped configure
is required.

But this is different - it's a (serious) bug being fixed
rather than a gratuitous (although) understandable given we weren't
sure if we'd ever see another autoconf release backport of a new
feature.

Backports to 2.69 & 2.13 to follow.

Bug: https://bugs.gentoo.org/806376
Bug: https://bugs.gentoo.org/870412
Thanks-to: Arsen Arsenovic <arsen@aarsen.me>
Signed-off-by: Sam James <sam@gentoo.org>