### PR TITLE
virtual/service-manager: add sys-apps/s6-rc to the list

### DIFF
--- a/virtual/service-manager/service-manager-1-r1.ebuild
+++ b/virtual/service-manager/service-manager-1-r1.ebuild
@@ -15,6 +15,7 @@ RDEPEND="
 			sys-apps/openrc
 			kernel_linux? (
 				|| (
+					sys-apps/s6-rc
 					sys-apps/systemd
 					sys-process/runit
 					virtual/daemontools


### PR DESCRIPTION
`sys-apps/s6-rc`[1] is an alternative service manager that should be in the list as well.

This PR is related to https://github.com/gentoo/gentoo/pull/27325 but it is independent change.

[1] https://skarnet.org/software/s6-rc/