### PR TITLE
LLVM: support installing "generic" symlinks for binutils/gcc-free systems

### DIFF
--- a/sys-devel/clang-toolchain-symlinks/clang-toolchain-symlinks-16.ebuild
+++ b/sys-devel/clang-toolchain-symlinks/clang-toolchain-symlinks-16.ebuild
@@ -1,0 +1,52 @@
+# Copyright 2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit multilib
+
+DESCRIPTION="Symlinks to use Clang on GCC-free system"
+HOMEPAGE="https://wiki.gentoo.org/wiki/Project:LLVM"
+SRC_URI=""
+S=${WORKDIR}
+
+LICENSE="public-domain"
+SLOT="${PV}"
+KEYWORDS=""
+PROPERTIES="live"
+IUSE="gcc-symlinks +native-symlinks"
+
+RDEPEND="
+	sys-devel/clang:${SLOT}
+"
+
+src_install() {
+	local abi t
+	local tools=()
+
+	if use native-symlinks; then
+		tools+=(
+			cc:clang
+			cpp:clang-cpp
+			c++:clang++
+		)
+	fi
+	if use gcc-symlinks; then
+		tools+=(
+			gcc:clang
+			g++:clang++
+		)
+	fi
+
+	local dest=/usr/lib/llvm/${SLOT}/bin
+	dodir "${dest}"
+	for t in "${tools[@]}"; do
+		dosym "${t#*:}" "${dest}/${t%:*}"
+	done
+	for abi in $(get_all_abis); do
+		local abi_chost=$(get_abi_CHOST "${abi}")
+		for t in "${tools[@]}"; do
+			dosym "${t#*:}" "${dest}/${abi_chost}-${t%:*}"
+		done
+	done
+}

--- a/sys-devel/clang-toolchain-symlinks/metadata.xml
+++ b/sys-devel/clang-toolchain-symlinks/metadata.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="project">
+		<email>llvm@gentoo.org</email>
+	</maintainer>
+	<use>
+		<flag name="gcc-symlinks">
+			Install symlinks for 'gcc' and 'g++' for extra
+			compatibility.
+		</flag>
+		<flag name="native-symlinks">
+			Install generic tool symlinks like 'cc' and 'c++',
+			as well as ${CTARGET}-*. These symlinks are installed
+			into slotted LLVM bindir, so they should not take precedence
+			over symlinks installed into /usr/bin
+			by <pkg>sys-devel/gcc-config</pkg> but they can be helpful
+			for GCC-free setups.
+		</flag>
+	</use>
+</pkgmetadata>

--- a/sys-devel/clang/clang-16.0.0.9999.ebuild
+++ b/sys-devel/clang/clang-16.0.0.9999.ebuild
@@ -44,6 +44,7 @@ BDEPEND="
 "
 PDEPEND="
 	sys-devel/clang-common
+	sys-devel/clang-toolchain-symlinks:${SLOT}
 	~sys-devel/clang-runtime-${PV}
 	default-compiler-rt? (
 		=sys-libs/compiler-rt-${PV%_*}*

--- a/sys-devel/clang/clang-16.0.0_pre20220915.ebuild
+++ b/sys-devel/clang/clang-16.0.0_pre20220915.ebuild
@@ -44,6 +44,7 @@ BDEPEND="
 "
 PDEPEND="
 	sys-devel/clang-common
+	sys-devel/clang-toolchain-symlinks:${SLOT}
 	~sys-devel/clang-runtime-${PV}
 	default-compiler-rt? (
 		=sys-libs/compiler-rt-${PV%_*}*

--- a/sys-devel/clang/clang-16.0.0_pre20220918.ebuild
+++ b/sys-devel/clang/clang-16.0.0_pre20220918.ebuild
@@ -44,6 +44,7 @@ BDEPEND="
 "
 PDEPEND="
 	sys-devel/clang-common
+	sys-devel/clang-toolchain-symlinks:${SLOT}
 	~sys-devel/clang-runtime-${PV}
 	default-compiler-rt? (
 		=sys-libs/compiler-rt-${PV%_*}*

--- a/sys-devel/lld-toolchain-symlinks/lld-toolchain-symlinks-16.ebuild
+++ b/sys-devel/lld-toolchain-symlinks/lld-toolchain-symlinks-16.ebuild
@@ -1,0 +1,33 @@
+# Copyright 2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit multilib
+
+DESCRIPTION="Symlinks to use LLD on binutils-free system"
+HOMEPAGE="https://wiki.gentoo.org/wiki/Project:LLVM"
+SRC_URI=""
+S=${WORKDIR}
+
+LICENSE="public-domain"
+SLOT="${PV}"
+KEYWORDS=""
+PROPERTIES="live"
+IUSE="+native-symlinks"
+
+RDEPEND="
+	sys-devel/lld
+"
+
+src_install() {
+	use native-symlinks || return
+
+	local dest=/usr/lib/llvm/${SLOT}/bin
+	dodir "${dest}"
+	dosym ../../../../bin/ld.lld "${dest}/ld"
+	for abi in $(get_all_abis); do
+		local abi_chost=$(get_abi_CHOST "${abi}")
+		dosym ../../../../bin/ld.lld "${dest}/${abi_chost}-ld"
+	done
+}

--- a/sys-devel/lld-toolchain-symlinks/metadata.xml
+++ b/sys-devel/lld-toolchain-symlinks/metadata.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="project">
+		<email>llvm@gentoo.org</email>
+	</maintainer>
+	<use>
+		<flag name="native-symlinks">
+			Install generic 'ld' symlink, as well as ${CTARGET}-ld.
+			These symlinks are installed into slotted LLVM bindir,
+			so they should not take precedence over symlinks installed
+			into /usr/bin by <pkg>sys-devel/binutils-config</pkg>
+			but they can be helpful for binutils-free setups.
+		</flag>
+	</use>
+</pkgmetadata>

--- a/sys-devel/lld/lld-16.0.0.9999.ebuild
+++ b/sys-devel/lld/lld-16.0.0.9999.ebuild
@@ -27,6 +27,9 @@ BDEPEND="
 		$(python_gen_any_dep "~dev-python/lit-${PV}[\${PYTHON_USEDEP}]")
 	)
 "
+PDEPEND="
+	sys-devel/lld-toolchain-symlinks:${PV%%.*}
+"
 
 LLVM_COMPONENTS=( lld cmake libunwind/include/mach-o )
 LLVM_TEST_COMPONENTS=( llvm/utils/{lit,unittest} )

--- a/sys-devel/lld/lld-16.0.0_pre20220915.ebuild
+++ b/sys-devel/lld/lld-16.0.0_pre20220915.ebuild
@@ -27,6 +27,9 @@ BDEPEND="
 		$(python_gen_any_dep "~dev-python/lit-${PV}[\${PYTHON_USEDEP}]")
 	)
 "
+PDEPEND="
+	sys-devel/lld-toolchain-symlinks:${PV%%.*}
+"
 
 LLVM_COMPONENTS=( lld cmake libunwind/include/mach-o )
 LLVM_TEST_COMPONENTS=( llvm/utils/{lit,unittest} )

--- a/sys-devel/lld/lld-16.0.0_pre20220918.ebuild
+++ b/sys-devel/lld/lld-16.0.0_pre20220918.ebuild
@@ -27,6 +27,9 @@ BDEPEND="
 		$(python_gen_any_dep "~dev-python/lit-${PV}[\${PYTHON_USEDEP}]")
 	)
 "
+PDEPEND="
+	sys-devel/lld-toolchain-symlinks:${PV%%.*}
+"
 
 LLVM_COMPONENTS=( lld cmake libunwind/include/mach-o )
 LLVM_TEST_COMPONENTS=( llvm/utils/{lit,unittest} )

--- a/sys-devel/llvm-toolchain-symlinks/llvm-toolchain-symlinks-16.ebuild
+++ b/sys-devel/llvm-toolchain-symlinks/llvm-toolchain-symlinks-16.ebuild
@@ -1,0 +1,43 @@
+# Copyright 2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit multilib
+
+DESCRIPTION="Symlinks to use LLVM on binutils-free system"
+HOMEPAGE="https://wiki.gentoo.org/wiki/Project:LLVM"
+SRC_URI=""
+S=${WORKDIR}
+
+LICENSE="public-domain"
+SLOT="${PV}"
+KEYWORDS=""
+PROPERTIES="live"
+IUSE="+native-symlinks"
+
+RDEPEND="
+	sys-devel/llvm:${SLOT}
+"
+
+src_install() {
+	use native-symlinks || return
+
+	local abi t
+	local tools=(
+		addr2line ar dlltool nm objcopy objdump ranlib readelf size
+		strings strip windres
+	)
+
+	local dest=/usr/lib/llvm/${SLOT}/bin
+	dodir "${dest}"
+	for t in "${tools[@]}"; do
+		dosym "llvm-${t}" "${dest}/${t}"
+	done
+	for abi in $(get_all_abis); do
+		local abi_chost=$(get_abi_CHOST "${abi}")
+		for t in "${tools[@]}"; do
+			dosym "llvm-${t}" "${dest}/${abi_chost}-${t}"
+		done
+	done
+}

--- a/sys-devel/llvm-toolchain-symlinks/metadata.xml
+++ b/sys-devel/llvm-toolchain-symlinks/metadata.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="project">
+		<email>llvm@gentoo.org</email>
+	</maintainer>
+	<use>
+		<flag name="native-symlinks">
+			Install generic tool symlinks like 'objdump' and 'ranlib',
+			as well as ${CTARGET}-*. These symlinks are installed
+			into slotted LLVM bindir, so they should not take precedence
+			over symlinks installed into /usr/bin
+			by <pkg>sys-devel/binutils-config</pkg> but they can be
+			helpful for binutils-free setups.
+		</flag>
+	</use>
+</pkgmetadata>

--- a/sys-devel/llvm/llvm-16.0.0.9999.ebuild
+++ b/sys-devel/llvm/llvm-16.0.0.9999.ebuild
@@ -60,6 +60,7 @@ RDEPEND="
 "
 PDEPEND="
 	sys-devel/llvm-common
+	sys-devel/llvm-toolchain-symlinks:${SLOT}
 	binutils-plugin? ( >=sys-devel/llvmgold-${SLOT} )
 "
 

--- a/sys-devel/llvm/llvm-16.0.0_pre20220915.ebuild
+++ b/sys-devel/llvm/llvm-16.0.0_pre20220915.ebuild
@@ -60,6 +60,7 @@ RDEPEND="
 "
 PDEPEND="
 	sys-devel/llvm-common
+	sys-devel/llvm-toolchain-symlinks:${SLOT}
 	binutils-plugin? ( >=sys-devel/llvmgold-${SLOT} )
 "
 

--- a/sys-devel/llvm/llvm-16.0.0_pre20220918.ebuild
+++ b/sys-devel/llvm/llvm-16.0.0_pre20220918.ebuild
@@ -60,6 +60,7 @@ RDEPEND="
 "
 PDEPEND="
 	sys-devel/llvm-common
+	sys-devel/llvm-toolchain-symlinks:${SLOT}
 	binutils-plugin? ( >=sys-devel/llvmgold-${SLOT} )
 "
 


### PR DESCRIPTION
On regular Gentoo systems, symlinks such as `cc`, `ld` and `objdump` are maintained either using binutils-config or gcc-config. However, on binutils/GCC-free systems (e.g. our musl clang stages), these symlinks are missing entirely. This is causing issues e.g. with Python that expects to be able to find a working `cc` (or `gcc`) and `objdump` for shared library lookup but also inconvenience for end users that always have to pass e.g. `clang`, `ld.lld`, `llvm-objdump`, etc. when building something.

To avoid this inconvenience, this PR proposes adding 3 PDEP-ebuilds to LLVM, LLD and Clang respectively. Their purpose is to (optionally, based on USE flags) install "generic" (and "gcc"-compatible) symlinks for LLVM/LLD/Clang-specific tools. To avoid collisions, these symlinks are installed into `/usr/lib/llvm/*/bin` rather than `/usr/bin`, which means that the packages can be installed harmlessly onto regular binutils/GCC systems as well. Since `/usr/bin` comes earlier in PATH, the symlinks installed by binutils-config/gcc-config will take precedence and nothing will change. However, if binutils/GCC are not installed, PATH lookup will find LLVM toolchain symlinks and use them instead.

This PR starts by providing the new packages for LLVM 16 (live or snapshot ebuilds). We can backport them to earlier versions later if this works out.

The installed symlinks are:

```
>>> /usr/lib/llvm/16/bin/addr2line -> llvm-addr2line
>>> /usr/lib/llvm/16/bin/ar -> llvm-ar
>>> /usr/lib/llvm/16/bin/dlltool -> llvm-dlltool
>>> /usr/lib/llvm/16/bin/nm -> llvm-nm
>>> /usr/lib/llvm/16/bin/objcopy -> llvm-objcopy
>>> /usr/lib/llvm/16/bin/objdump -> llvm-objdump
>>> /usr/lib/llvm/16/bin/ranlib -> llvm-ranlib
>>> /usr/lib/llvm/16/bin/readelf -> llvm-readelf
>>> /usr/lib/llvm/16/bin/size -> llvm-size
>>> /usr/lib/llvm/16/bin/strings -> llvm-strings
>>> /usr/lib/llvm/16/bin/strip -> llvm-strip
>>> /usr/lib/llvm/16/bin/windres -> llvm-windres

>>> /usr/lib/llvm/16/bin/ld -> ../../../../bin/ld.lld

>>> /usr/lib/llvm/16/bin/cc -> clang
>>> /usr/lib/llvm/16/bin/cpp -> clang-cpp
>>> /usr/lib/llvm/16/bin/c++ -> clang++
```

Plus their CHOST variants for all enables ABIs.

All packages include `IUSE=+native-symlinks` to let people disable them if they want rougher experience. There's also `IUSE=gcc-symlinks` to install `gcc` and `g++` to reduce annoyance with really broken software.

CC @gentoo/llvm, @gentoo/musl, @gentoo/toolchain