### PR TITLE
gui-apps/tuigreet: Fix var/cache folder

### DIFF
--- a/gui-apps/tuigreet/tuigreet-0.8.0.ebuild
+++ b/gui-apps/tuigreet/tuigreet-0.8.0.ebuild
@@ -158,6 +158,7 @@ DEPEND="${RDEPEND}"
 src_install() {
 	dodir /var/cache/${PN}
 	fowners greetd:greetd /var/cache/${PN}
+	keepdir /var/cache/${PN}
 
 	cargo_src_install
 }

--- a/gui-apps/tuigreet/tuigreet-9999.ebuild
+++ b/gui-apps/tuigreet/tuigreet-9999.ebuild
@@ -41,6 +41,7 @@ DEPEND="${RDEPEND}"
 src_install() {
 	dodir /var/cache/${PN}
 	fowners greetd:greetd /var/cache/${PN}
+	keepdir /var/cache/${PN}
 
 	cargo_src_install
 }


### PR DESCRIPTION
@mm1ke I missed that the cache folder was stripped from the ebuild automatically when testing https://github.com/gentoo/gentoo/pull/26797

I had already created the folder manually, so I failed to notice it being purged from the install image.

This is a follow up fix to make it work.