### PR TITLE
www-client/epiphany: Using webkit-gtk in slot 4

### DIFF
--- a/www-client/epiphany/epiphany-42.3.ebuild
+++ b/www-client/epiphany/epiphany-42.3.ebuild
@@ -74,7 +74,7 @@ pkg_postinst() {
 	xdg_pkg_postinst
 	gnome2_schemas_update
 
-	if ! has_version net-libs/webkit-gtk[jpeg2k]; then
+	if ! has_version net-libs/webkit-gtk:4[jpeg2k]; then
 		ewarn "Your net-libs/webkit-gtk is built without USE=jpeg2k."
 		ewarn "Various image galleries/managers may be broken."
 	fi

--- a/www-client/epiphany/epiphany-42.4.ebuild
+++ b/www-client/epiphany/epiphany-42.4.ebuild
@@ -74,7 +74,7 @@ pkg_postinst() {
 	xdg_pkg_postinst
 	gnome2_schemas_update
 
-	if ! has_version net-libs/webkit-gtk[jpeg2k]; then
+	if ! has_version net-libs/webkit-gtk:4[jpeg2k]; then
 		ewarn "Your net-libs/webkit-gtk is built without USE=jpeg2k."
 		ewarn "Various image galleries/managers may be broken."
 	fi


### PR DESCRIPTION
In the checks for webkit-gtk[jpeg2k] slot was not explicitely mentioned. This is needed for as webkit-gtk will now have slots to handle webkit2gtk-4.0 and webkit2gtk-4.1

Signed-off-by: brahmajit das <listout@protonmail.com>