### PR TITLE
net-im/telegram-desktop: Using webkit-gtk in slot 4

### DIFF
--- a/net-im/telegram-desktop/telegram-desktop-3.6.1-r1.ebuild
+++ b/net-im/telegram-desktop/telegram-desktop-3.6.1-r1.ebuild
@@ -158,5 +158,5 @@ pkg_postinst() {
 		ewarn
 	fi
 	optfeature_header
-	optfeature "shop payment support (requires USE=dbus enabled)" net-libs/webkit-gtk
+	optfeature "shop payment support (requires USE=dbus enabled)" net-libs/webkit-gtk:4
 }

--- a/net-im/telegram-desktop/telegram-desktop-4.0.2.ebuild
+++ b/net-im/telegram-desktop/telegram-desktop-4.0.2.ebuild
@@ -179,5 +179,5 @@ pkg_postinst() {
 		ewarn
 	fi
 	optfeature_header
-	optfeature "shop payment support (requires USE=dbus enabled)" net-libs/webkit-gtk
+	optfeature "shop payment support (requires USE=dbus enabled)" net-libs/webkit-gtk:4
 }

--- a/net-im/telegram-desktop/telegram-desktop-4.1.1-r1.ebuild
+++ b/net-im/telegram-desktop/telegram-desktop-4.1.1-r1.ebuild
@@ -181,5 +181,5 @@ pkg_postinst() {
 		ewarn
 	fi
 	optfeature_header
-	optfeature "shop payment support (requires USE=dbus enabled)" net-libs/webkit-gtk
+	optfeature "shop payment support (requires USE=dbus enabled)" net-libs/webkit-gtk:4
 }


### PR DESCRIPTION
While checking for optfeature, check for webkit-gtk in slot 4. This is needed for as webkit-gtk will now have slots to handle webkit2gtk-4.0 and webkit2gtk-4.1

Signed-off-by: brahmajit das <listout@protonmail.com>