### PR TITLE
app-text/apvlv: Using webkit-gtk in slot 4

### DIFF
--- a/app-text/apvlv/apvlv-0.4.0.ebuild
+++ b/app-text/apvlv/apvlv-0.4.0.ebuild
@@ -19,7 +19,7 @@ RDEPEND="
 	>=app-text/poppler-0.5.0:=[cairo,xpdf-headers(+)]
 	dev-libs/glib:2
 	dev-libs/libxml2
-	net-libs/webkit-gtk:=
+	net-libs/webkit-gtk:4=
 	x11-libs/cairo
 	x11-libs/gdk-pixbuf:2
 	x11-libs/gtk+:3


### PR DESCRIPTION
This is needed for as webkit-gtk will now have slots to handle webkit2gtk-4.0 and webkit2gtk-4.1, and we want to make sure that we pull in the correct webkit-gtk.

Signed-off-by: brahmajit das <listout@protonmail.com>