### PR TITLE
app-editors/emacs: create verbose build logs

### DIFF
--- a/app-editors/emacs/emacs-28.2.9999.ebuild
+++ b/app-editors/emacs/emacs-28.2.9999.ebuild
@@ -184,6 +184,8 @@ src_configure() {
 	# Prevents e.g. tests interfering with running Emacs.
 	unset EMACS_SOCKET_NAME
 
+	MAKEOPTS+=" V=1"
+
 	if use alsa; then
 		use sound || ewarn \
 			"USE flag \"alsa\" overrides \"-sound\"; enabling sound support."

--- a/app-editors/emacs/emacs-28.2.ebuild
+++ b/app-editors/emacs/emacs-28.2.ebuild
@@ -182,6 +182,8 @@ src_configure() {
 	# Prevents e.g. tests interfering with running Emacs.
 	unset EMACS_SOCKET_NAME
 
+	MAKEOPTS+=" V=1"
+
 	if use alsa; then
 		use sound || ewarn \
 			"USE flag \"alsa\" overrides \"-sound\"; enabling sound support."

--- a/app-editors/emacs/emacs-29.0.9999.ebuild
+++ b/app-editors/emacs/emacs-29.0.9999.ebuild
@@ -206,6 +206,8 @@ src_configure() {
 	# Prevents e.g. tests interfering with running Emacs.
 	unset EMACS_SOCKET_NAME
 
+	MAKEOPTS+=" V=1"
+
 	if use alsa; then
 		use sound || ewarn \
 			"USE flag \"alsa\" overrides \"-sound\"; enabling sound support."


### PR DESCRIPTION
Hit a failure building 29.0.9999 earlier:
```
*** "make all" failed with exit status 2.
*** You might try to:
*** - run "make bootstrap", which might fix the problem
*** - run "make V=1", which displays the full commands invoked by make,
***   to further investigate the problem
***
make[1]: *** [Makefile:412: advice-on-failure] Error 2
make[1]: Leaving directory '/var/tmp/portage/app-editors/emacs-29.0.9999/work/emacs'
```

But without V=1, not enough information was in the log. Besides, we prefer verbose build logs in general in Gentoo anyway for this sort of reason.

Signed-off-by: Sam James <sam@gentoo.org>