### PR TITLE
sys-boot/colo: remove direct calls to toolchain components

### DIFF
--- a/sys-boot/colo/colo-1.22.ebuild
+++ b/sys-boot/colo/colo-1.22.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -17,6 +17,7 @@ RESTRICT="strip"
 
 src_prepare() {
 	epatch "${FILESDIR}"/colo-stage2_src_heap-fix.patch
+	sed -E -i -e "s/CFLAGS_COLO=/CFLAGS_COLO:=/g" -e "/[A-Z]+= /d" Rules.mak || die # bug 725846
 	default
 }
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/725846

No revbump, this is build fix only.