### PR TITLE
net-misc/openntpd: keyword 6.8_p1-r1 for ~alpha

### DIFF
--- a/net-misc/openntpd/openntpd-6.8_p1-r1.ebuild
+++ b/net-misc/openntpd/openntpd-6.8_p1-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -13,7 +13,7 @@ SRC_URI="mirror://openbsd/OpenNTPD/${MY_P}.tar.gz"
 
 LICENSE="BSD GPL-2"
 SLOT="0"
-KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
 IUSE="constraints selinux"
 
 DEPEND="

--- a/profiles/arch/alpha/package.use.mask
+++ b/profiles/arch/alpha/package.use.mask
@@ -1,6 +1,10 @@
 # Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# matoro <matoro_gentoo@matoro.tk> (2022-09-22)
+# Unable to test due to mask, bug #763963
+~net-misc/openntpd-6.8_p1 constraints
+
 # Matthew Smith <matthew@gentoo.org> (2022-07-10)
 # Needs unkeyworded app-doc/halibut
 >=net-misc/putty-0.77 doc


### PR DESCRIPTION
This is a blind keyword (besides compile test) per @thesamesam 