### PR TITLE
dev-lang/spidermonkey: allow llvm 15

### DIFF
--- a/dev-lang/spidermonkey/spidermonkey-102.3.0.ebuild
+++ b/dev-lang/spidermonkey/spidermonkey-102.3.0.ebuild
@@ -7,7 +7,7 @@ EAPI="8"
 FIREFOX_PATCHSET="firefox-102esr-patches-02j.tar.xz"
 SPIDERMONKEY_PATCHSET="spidermonkey-102-patches-04j.tar.xz"
 
-LLVM_MAX_SLOT=14
+LLVM_MAX_SLOT=15
 
 PYTHON_COMPAT=( python3_{8..11} )
 PYTHON_REQ_USE="ssl,xml(+)"
@@ -77,6 +77,13 @@ BDEPEND="${PYTHON_DEPS}
 		$(python_gen_any_dep 'dev-python/six[${PYTHON_USEDEP}]')
 	)
 	|| (
+		(
+			sys-devel/llvm:15
+			clang? (
+				sys-devel/clang:15
+				lto? ( =sys-devel/lld-15* )
+			)
+		)
 		(
 			sys-devel/llvm:14
 			clang? (


### PR DESCRIPTION
builds/works totally fine with rust built on llvm 15

also spidermonkey during build can detect if rust built with llvm 14 and by itself is switching to 14