### PR TITLE
app-crypt/tpm2-tss-engine: Allow tests to compile under musl

### DIFF
--- a/app-crypt/tpm2-tss-engine/files/tpm2-tss-engine-1.1.0-tests-Allow-compilation-under-musl.patch
+++ b/app-crypt/tpm2-tss-engine/files/tpm2-tss-engine-1.1.0-tests-Allow-compilation-under-musl.patch
@@ -1,0 +1,38 @@
+diff --git a/configure.ac b/configure.ac
+index 8fc7cde..a9796bb 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -174,6 +174,8 @@ AC_ARG_WITH([device],
+             [with_device_set=no])
+ AM_CONDITIONAL([TESTDEVICE],[test "x$with_device_set" = xyes])
+ 
++AC_CHECK_FUNC([backtrace_symbols_fd],[AC_DEFINE([HAVE_EXECINFO],[1], ['Define to 1 if you have the <execinfo.h> header file.'])])
++
+ # Integration test with simulator
+ AS_IF([test "x$enable_integration" = xyes && test "x$with_device_set" = xno],
+       [integration_args=""
+diff --git a/test/error_tpm2-tss-engine-common.c b/test/error_tpm2-tss-engine-common.c
+index a883e51..775f602 100644
+--- a/test/error_tpm2-tss-engine-common.c
++++ b/test/error_tpm2-tss-engine-common.c
+@@ -7,7 +7,9 @@
+ #include "tpm2-tss-engine.h"
+ #include "tpm2-tss-engine-common.h"
+ 
++#ifdef HAVE_EXECINFO
+ #include <execinfo.h>
++#endif
+ #include <stdio.h>
+ #include <unistd.h>
+ #include <setjmp.h>
+@@ -17,8 +19,10 @@ TSS2_RC
+ __wrap_Esys_Initialize()
+ {
+     printf("Esys_Initialize called\n");
++#ifdef HAVE_EXECINFO
+     void* b[128];
+     backtrace_symbols_fd(b, backtrace(b, sizeof(b)/sizeof(b[0])), STDOUT_FILENO);
++#endif
+     return -1;
+ }
+     

--- a/app-crypt/tpm2-tss-engine/tpm2-tss-engine-1.1.0-r2.ebuild
+++ b/app-crypt/tpm2-tss-engine/tpm2-tss-engine-1.1.0-r2.ebuild
@@ -1,0 +1,47 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit autotools bash-completion-r1
+
+DESCRIPTION="OpenSSL Engine for TPM2 devices"
+HOMEPAGE="https://github.com/tpm2-software/tpm2-tss-engine"
+SRC_URI="https://github.com/tpm2-software/${PN}/releases/download/v${PV}/${P}.tar.gz"
+
+LICENSE="BSD"
+SLOT="0/${PV}"
+KEYWORDS="~amd64"
+IUSE="test"
+RESTRICT="!test? ( test )"
+
+RDEPEND="app-crypt/tpm2-tss:=
+	>=dev-libs/openssl-1.1.1:=
+	<dev-libs/openssl-3.0.0:="
+DEPEND="${RDEPEND}
+	test? ( dev-util/cmocka )"
+BDEPEND="sys-devel/autoconf-archive
+	virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-1.1.0-tests-Allow-compilation-under-musl.patch"
+	)
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_configure() {
+	econf \
+		$(use_enable test unit) \
+		--disable-defaultflags \
+		--disable-static \
+		--with-completionsdir="$(get_bashcompdir)"
+}
+
+src_install () {
+	default
+	find "${ED}" -name '*.la' -delete || die
+	dobashcomp bash-completion/*
+}


### PR DESCRIPTION
This fixes the attached bug, as well as up[dated the dependencies, as this package will not be compatible with OpenSSL 3.0 (see app-crypt/tpm2-openssl in GURU for the OpenSSL 3.0 provider) and also fixes up the SLOT the same way the other engines are. Because of that, a revbump is required. 