### PR TITLE
app-shells/pwsh-bin: update homepage and docs link

### DIFF
--- a/app-shells/pwsh-bin/metadata.xml
+++ b/app-shells/pwsh-bin/metadata.xml
@@ -18,7 +18,7 @@
   </use>
   <upstream>
     <changelog>https://github.com/PowerShell/PowerShell/blob/master/CHANGELOG/7.1.md</changelog>
-    <doc>https://powershell.org/free-resources/</doc>
+    <doc>https://learn.microsoft.com/en-us/powershell/</doc>
     <bugs-to>https://github.com/PowerShell/PowerShell/issues</bugs-to>
     <remote-id type="github">PowerShell/PowerShell</remote-id>
   </upstream>

--- a/app-shells/pwsh-bin/pwsh-bin-7.2.4.ebuild
+++ b/app-shells/pwsh-bin/pwsh-bin-7.2.4.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DESCRIPTION="PowerShell - binary precompiled for glibc"
-HOMEPAGE="https://powershell.org/"
+HOMEPAGE="https://microsoft.com/powershell"
 BASE_URI="https://github.com/PowerShell/PowerShell/releases/download"
 SRC_URI="
 	amd64? ( ${BASE_URI}/v${PV}/powershell-${PV}-linux-x64.tar.gz )

--- a/app-shells/pwsh-bin/pwsh-bin-7.2.5.ebuild
+++ b/app-shells/pwsh-bin/pwsh-bin-7.2.5.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DESCRIPTION="PowerShell - binary precompiled for glibc"
-HOMEPAGE="https://powershell.org/"
+HOMEPAGE="https://microsoft.com/powershell"
 BASE_URI="https://github.com/PowerShell/PowerShell/releases/download"
 SRC_URI="
 	amd64? ( ${BASE_URI}/v${PV}/powershell-${PV}-linux-x64.tar.gz )

--- a/app-shells/pwsh-bin/pwsh-bin-7.2.6.ebuild
+++ b/app-shells/pwsh-bin/pwsh-bin-7.2.6.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DESCRIPTION="PowerShell - binary precompiled for glibc"
-HOMEPAGE="https://powershell.org/"
+HOMEPAGE="https://microsoft.com/powershell"
 BASE_URI="https://github.com/PowerShell/PowerShell/releases/download"
 SRC_URI="
 	amd64? ( ${BASE_URI}/v${PV}/powershell-${PV}-linux-x64.tar.gz )


### PR DESCRIPTION
The PowerShell ebuilds are linked to an older site, this changes the links to the links they use on GitHub.