### PR TITLE
sys-libs/glibc: avoid gcc-major-version failure

### DIFF
--- a/sys-libs/glibc/glibc-2.36-r3.ebuild
+++ b/sys-libs/glibc/glibc-2.36-r3.ebuild
@@ -336,10 +336,14 @@ setup_target_flags() {
 				use stack-realign && export CFLAGS_x86+=" -mstackrealign"
 
 				# Workaround for bug #823780.
+				# Need to save/restore CC because earlier on, we stuff it full of CFLAGS, and tc-getCPP doesn't like that.
+				CC_mangled=${CC}
+				CC=${glibc__GLIBC_CC}
 				if tc-is-gcc && (($(gcc-major-version) == 11)) && (($(gcc-minor-version) <= 2)) && (($(gcc-micro-version) == 0)) ; then
 					export CFLAGS_x86="${CFLAGS_x86} -mno-avx512f"
 					einfo "Auto adding -mno-avx512f to CFLAGS_x86 for buggy GCC version (bug #823780) (ABI=${ABI})"
 				fi
+				CC=${CC_mangled}
 			fi
 		;;
 		mips)

--- a/sys-libs/glibc/glibc-9999.ebuild
+++ b/sys-libs/glibc/glibc-9999.ebuild
@@ -26,8 +26,7 @@ PATCH_DEV=dilfridge
 if [[ ${PV} == 9999* ]]; then
 	inherit git-r3
 else
-	#KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
-	KEYWORDS=""
+	#KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
 	SRC_URI="mirror://gnu/glibc/${P}.tar.xz"
 	SRC_URI+=" https://dev.gentoo.org/~${PATCH_DEV}/distfiles/${P}-patches-${PATCH_VER}.tar.xz"
 fi
@@ -337,10 +336,14 @@ setup_target_flags() {
 				use stack-realign && export CFLAGS_x86+=" -mstackrealign"
 
 				# Workaround for bug #823780.
+				# Need to save/restore CC because earlier on, we stuff it full of CFLAGS, and tc-getCPP doesn't like that.
+				CC_mangled=${CC}
+				CC=${glibc__GLIBC_CC}
 				if tc-is-gcc && (($(gcc-major-version) == 11)) && (($(gcc-minor-version) <= 2)) && (($(gcc-micro-version) == 0)) ; then
 					export CFLAGS_x86="${CFLAGS_x86} -mno-avx512f"
 					einfo "Auto adding -mno-avx512f to CFLAGS_x86 for buggy GCC version (bug #823780) (ABI=${ABI})"
 				fi
+				CC=${CC_mangled}
 			fi
 		;;
 		mips)


### PR DESCRIPTION
I ended up getting a weird failure (which I can't reproduce any longer, but it maeks sense still I think):
```
x86_64-pc-linux-gnu-gcc -m64 -pipe -march=native -fdiagnostics-color=always -ggdb3 -O2 -Wl,-O1 -Wl,--as-needed -Wl,--defsym=__gentoo_check_ldflags__=0 -Wl,-z,pack-relative-relocs -fuse-ld=bfd -Wl,-O1 -Wl,--as-needed -pipe -march=native -fdiagnostics-color=always -ggdb3 -O2 -m32  -Wl,-O1 -Wl,--as-needed -Wl,--defsym=__gentoo_check_ldflags__=0 -Wl,-z,pack-relative-relocs -fuse-ld=bfd -Wl,-O1 -Wl,--as-needed  glibc-test.c   -o glibc-test
/var/tmp/portage/sys-libs/glibc-2.36-r1/temp/environment: line 3892: ((: #define == 11: syntax error: operand expected (error token is "#define == 11")
 * Running do_src_configure for ABI x86
 *             ABI:   x86
 *          CBUILD:   x86_64-pc-linux-gnu
```

It's because tc-getCPP can't handle at least a large amount of CFLAGS (seems to handle some okay though). Strip them all out and just use barebones CC when calling gcc-major-version and friends, then restor after.

Signed-off-by: Sam James <sam@gentoo.org>