### PR TITLE
x11-misc/xssstate: Don't hardcode /usr/lib

### DIFF
--- a/x11-misc/xssstate/files/xssstate-1.1-libdir.patch
+++ b/x11-misc/xssstate/files/xssstate-1.1-libdir.patch
@@ -1,0 +1,23 @@
+Bug: https://bugs.gentoo.org/732450
+Upstream-Commit: https://git.suckless.org/xssstate/commit/5d8e9b49ce2970f786f1e5aa12bbaae83900453f.html
+
+From: orbea <orbea@riseup.net>
+Date: Fri, 23 Sep 2022 21:17:01 -0700
+Subject: [PATCH] config.mk: Add LIBDIR
+
+--- a/config.mk
++++ b/config.mk
+@@ -5,11 +5,12 @@ VERSION = 1.1
+ 
+ # paths
+ PREFIX = /usr/local
++LIBDIR = ${PREFIX}/lib
+ MANPREFIX = ${PREFIX}/share/man
+ 
+ # includes and libs
+ INCS = -I. -I/usr/include
+-LIBS = -L/usr/lib -lc -lX11 -lXss
++LIBS = -L${LIBDIR} -lc -lX11 -lXss
+ 
+ # flags
+ CPPFLAGS = -DVERSION=\"${VERSION}\"

--- a/x11-misc/xssstate/xssstate-1.1-r1.ebuild
+++ b/x11-misc/xssstate/xssstate-1.1-r1.ebuild
@@ -1,0 +1,42 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs
+
+DESCRIPTION="A simple tool to retrieve the X screensaver state"
+HOMEPAGE="https://tools.suckless.org/x/xssstate"
+SRC_URI="https://dl.suckless.org/tools/${P}.tar.gz"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~x86"
+
+RDEPEND="
+	x11-libs/libX11
+	x11-libs/libXScrnSaver
+"
+DEPEND="
+	${RDEPEND}
+	x11-base/xorg-proto
+"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-1.0.20130103-gentoo.patch
+	"${FILESDIR}"/${PN}-1.1-libdir.patch #732450
+)
+
+src_compile() {
+	emake CC="$(tc-getCC)" LIBDIR="${EPREFIX}/usr/$(get_libdir)"
+}
+
+src_install() {
+	emake install \
+		DESTDIR="${D}" \
+		PREFIX="${EPREFIX}"/usr \
+		LIBDIR="${EPREFIX}/usr/$(get_libdir)"
+
+	dodoc README xsidle.sh
+	doman ${PN}.1
+}


### PR DESCRIPTION
I also e-mailed the patch to the most recent upstream maintainer of xssstate, but its too soon to know if I will receive a reply.

Bug: https://bugs.gentoo.org/732450
Closes: https://bugs.gentoo.org/732450
Upstream-Commit: https://git.suckless.org/xssstate/commit/5d8e9b49ce2970f786f1e5aa12bbaae83900453f.html