### PR TITLE
net-fs/samba: Make libunwind optional, it's only for debug and backtraces

### DIFF
--- a/net-fs/samba/metadata.xml
+++ b/net-fs/samba/metadata.xml
@@ -29,6 +29,7 @@
 			bundled heimdal.</flag>
 		<flag name="system-mitkrb5">Use <pkg>app-crypt/mit-krb5</pkg> instead of
 			<pkg>app-crypt/heimdal</pkg>.</flag>
+		<flag name="unwind">Enable libunwind usage for backtraces</flag>
 		<flag name="winbind">Enables support for the winbind auth daemon</flag>
 	</use>
 	<upstream>

--- a/net-fs/samba/samba-4.15.9.ebuild
+++ b/net-fs/samba/samba-4.15.9.ebuild
@@ -24,7 +24,7 @@ LICENSE="GPL-3"
 SLOT="0"
 IUSE="acl addc ads ceph client cluster cpu_flags_x86_aes cups debug fam
 glusterfs gpg iprint json ldap pam profiling-data python quota +regedit selinux
-snapper spotlight syslog system-heimdal +system-mitkrb5 systemd test winbind
+snapper spotlight syslog system-heimdal +system-mitkrb5 systemd test unwind winbind
 zeroconf"
 
 REQUIRED_USE="${PYTHON_REQUIRED_USE}
@@ -87,7 +87,7 @@ COMMON_DEPEND="
 			net-dns/bind-tools[gssapi]
 		)
 	")
-	!alpha? ( !sparc? ( sys-libs/libunwind:= ) )
+	!alpha? ( !sparc? ( unwind? ( sys-libs/libunwind:= ) ) )
 	acl? ( virtual/acl )
 	ceph? ( sys-cluster/ceph )
 	cluster? ( net-libs/rpcsvc-proto )
@@ -141,6 +141,7 @@ BDEPEND="${PYTHON_DEPS}
 PATCHES=(
 	"${FILESDIR}/${PN}-4.4.0-pam.patch"
 	"${FILESDIR}/ldb-2.5.2-skip-wav-tevent-check.patch"
+	"${FILESDIR}/optional-unwind.patch"
 )
 
 #CONFDIR="${FILESDIR}/$(get_version_component_range 1-2)"
@@ -229,6 +230,7 @@ multilib_src_configure() {
 		$(multilib_native_use_with systemd)
 		--systemd-install-services
 		--with-systemddir="$(systemd_get_systemunitdir)"
+		$(multilib_native_use_with unwind)
 		$(multilib_native_use_with winbind)
 		$(multilib_native_usex python '' '--disable-python')
 		$(multilib_native_use_enable zeroconf avahi)

--- a/net-fs/samba/samba-4.16.0-r1.ebuild
+++ b/net-fs/samba/samba-4.16.0-r1.ebuild
@@ -24,7 +24,7 @@ LICENSE="GPL-3"
 SLOT="0"
 IUSE="acl addc ads ceph client cluster cpu_flags_x86_aes cups debug fam
 glusterfs gpg iprint json ldap pam profiling-data python quota +regedit selinux
-snapper spotlight syslog system-heimdal +system-mitkrb5 systemd test winbind
+snapper spotlight syslog system-heimdal +system-mitkrb5 systemd test unwind winbind
 zeroconf"
 
 REQUIRED_USE="${PYTHON_REQUIRED_USE}
@@ -87,7 +87,7 @@ COMMON_DEPEND="
 			net-dns/bind-tools[gssapi]
 		)
 	")
-	!alpha? ( !sparc? ( sys-libs/libunwind:= ) )
+	!alpha? ( !sparc? ( unwind? ( sys-libs/libunwind:= ) ) )
 	acl? ( virtual/acl )
 	ceph? ( sys-cluster/ceph )
 	cluster? ( net-libs/rpcsvc-proto )
@@ -141,6 +141,7 @@ BDEPEND="${PYTHON_DEPS}
 
 PATCHES=(
 	"${FILESDIR}/${PN}-4.4.0-pam.patch"
+	"${FILESDIR}/optional-unwind.patch"
 )
 
 #CONFDIR="${FILESDIR}/$(get_version_component_range 1-2)"
@@ -229,6 +230,7 @@ multilib_src_configure() {
 		$(multilib_native_use_with systemd)
 		--systemd-install-services
 		--with-systemddir="$(systemd_get_systemunitdir)"
+		$(multilib_native_use_with unwind)
 		$(multilib_native_use_with winbind)
 		$(multilib_native_usex python '' '--disable-python')
 		$(multilib_native_use_enable zeroconf avahi)

--- a/net-fs/samba/samba-4.16.1.ebuild
+++ b/net-fs/samba/samba-4.16.1.ebuild
@@ -24,7 +24,7 @@ LICENSE="GPL-3"
 SLOT="0"
 IUSE="acl addc ads ceph client cluster cpu_flags_x86_aes cups debug fam
 glusterfs gpg iprint json ldap pam profiling-data python quota +regedit selinux
-snapper spotlight syslog system-heimdal +system-mitkrb5 systemd test winbind
+snapper spotlight syslog system-heimdal +system-mitkrb5 systemd test unwind winbind
 zeroconf"
 
 REQUIRED_USE="${PYTHON_REQUIRED_USE}
@@ -87,7 +87,7 @@ COMMON_DEPEND="
 			net-dns/bind-tools[gssapi]
 		)
 	")
-	!alpha? ( !sparc? ( sys-libs/libunwind:= ) )
+	!alpha? ( !sparc? ( unwind? ( sys-libs/libunwind:= ) ) )
 	acl? ( virtual/acl )
 	ceph? ( sys-cluster/ceph )
 	cluster? ( net-libs/rpcsvc-proto )
@@ -142,6 +142,7 @@ BDEPEND="${PYTHON_DEPS}
 PATCHES=(
 	"${FILESDIR}/${PN}-4.4.0-pam.patch"
 	"${FILESDIR}/${PN}-4.16.1-netdb-defines.patch"
+	"${FILESDIR}/optional-unwind.patch"
 )
 
 #CONFDIR="${FILESDIR}/$(get_version_component_range 1-2)"
@@ -230,6 +231,7 @@ multilib_src_configure() {
 		$(multilib_native_use_with systemd)
 		--systemd-install-services
 		--with-systemddir="$(systemd_get_systemunitdir)"
+		$(multilib_native_use_with unwind)
 		$(multilib_native_use_with winbind)
 		$(multilib_native_usex python '' '--disable-python')
 		$(multilib_native_use_enable zeroconf avahi)

--- a/net-fs/samba/samba-4.16.2.ebuild
+++ b/net-fs/samba/samba-4.16.2.ebuild
@@ -24,7 +24,7 @@ LICENSE="GPL-3"
 SLOT="0"
 IUSE="acl addc ads ceph client cluster cpu_flags_x86_aes cups debug fam
 glusterfs gpg iprint json ldap pam profiling-data python quota +regedit selinux
-snapper spotlight syslog system-heimdal +system-mitkrb5 systemd test winbind
+snapper spotlight syslog system-heimdal +system-mitkrb5 systemd test unwind winbind
 zeroconf"
 
 REQUIRED_USE="${PYTHON_REQUIRED_USE}
@@ -87,7 +87,7 @@ COMMON_DEPEND="
 			net-dns/bind-tools[gssapi]
 		)
 	")
-	!alpha? ( !sparc? ( sys-libs/libunwind:= ) )
+	!alpha? ( !sparc? ( unwind? ( sys-libs/libunwind:= ) ) )
 	acl? ( virtual/acl )
 	ceph? ( sys-cluster/ceph )
 	cluster? ( net-libs/rpcsvc-proto )
@@ -143,6 +143,7 @@ PATCHES=(
 	"${FILESDIR}/${PN}-4.4.0-pam.patch"
 	"${FILESDIR}/${PN}-4.16.1-netdb-defines.patch"
 	"${FILESDIR}/${PN}-4.16.2-fix-musl-without-innetgr.patch"
+	"${FILESDIR}/optional-unwind.patch"
 )
 
 #CONFDIR="${FILESDIR}/$(get_version_component_range 1-2)"
@@ -232,6 +233,7 @@ multilib_src_configure() {
 		$(multilib_native_use_with systemd)
 		--systemd-install-services
 		--with-systemddir="$(systemd_get_systemunitdir)"
+		$(multilib_native_use_with unwind)
 		$(multilib_native_use_with winbind)
 		$(multilib_native_usex python '' '--disable-python')
 		$(multilib_native_use_enable zeroconf avahi)

--- a/net-fs/samba/samba-4.16.4.ebuild
+++ b/net-fs/samba/samba-4.16.4.ebuild
@@ -24,7 +24,7 @@ LICENSE="GPL-3"
 SLOT="0"
 IUSE="acl addc ads ceph client cluster cpu_flags_x86_aes cups debug fam
 glusterfs gpg iprint json ldap pam profiling-data python quota +regedit selinux
-snapper spotlight syslog system-heimdal +system-mitkrb5 systemd test winbind
+snapper spotlight syslog system-heimdal +system-mitkrb5 systemd test unwind winbind
 zeroconf"
 
 REQUIRED_USE="${PYTHON_REQUIRED_USE}
@@ -87,7 +87,7 @@ COMMON_DEPEND="
 			net-dns/bind-tools[gssapi]
 		)
 	")
-	!alpha? ( !sparc? ( sys-libs/libunwind:= ) )
+	!alpha? ( !sparc? ( unwind? ( sys-libs/libunwind:= ) ) )
 	acl? ( virtual/acl )
 	ceph? ( sys-cluster/ceph )
 	cluster? ( net-libs/rpcsvc-proto )
@@ -145,6 +145,7 @@ PATCHES=(
 	"${FILESDIR}/${PN}-4.16.2-fix-musl-without-innetgr.patch"
 	"${FILESDIR}/ldb-2.5.2-skip-wav-tevent-check.patch"
 	"${FILESDIR}/${P}-glibc-2.36.patch"
+	"${FILESDIR}/optional-unwind.patch"
 )
 
 #CONFDIR="${FILESDIR}/$(get_version_component_range 1-2)"
@@ -234,6 +235,7 @@ multilib_src_configure() {
 		$(multilib_native_use_with systemd)
 		--systemd-install-services
 		--with-systemddir="$(systemd_get_systemunitdir)"
+		$(multilib_native_use_with unwind)
 		$(multilib_native_use_with winbind)
 		$(multilib_native_usex python '' '--disable-python')
 		$(multilib_native_use_enable zeroconf avahi)


### PR DESCRIPTION
Backport from samba-4.17, Look at the commits in:
https://gitlab.com/samba-team/samba/-/merge_requests/2401?commit_id=ac8064cb0d79db377df75a22a240632dbc37f99f https://gitlab.com/samba-team/samba/-/commit/14feb93d481011765f62614ab49b304e17e4f6fd 

And my old pull 
https://github.com/gentoo/gentoo/pull/24280

Package-Manager: Portage-3.0.36, pkgcheck-0.10.14
Signed-off-by: Fco Javier Felix <ffelix@inode64.com>