### PR TITLE
dev-lang/lua: Fix for CVE-2022-28805

### DIFF
--- a/dev-lang/lua/files/lua-5.4.4-lparser-overread.patch
+++ b/dev-lang/lua/files/lua-5.4.4-lparser-overread.patch
@@ -1,0 +1,34 @@
+From https://github.com/lua/lua/commit/1f3c6f4534c6411313361697d98d1145a1f030fa Mon Sep 17 00:00:00 2001
+From: Roberto Ierusalimschy <roberto@inf.puc-rio.br>
+Date: Tue, 15 Feb 2022 12:28:46 -0300
+Subject: [PATCH] Bug: Lua can generate wrong code when _ENV is <const>
+
+--- a/src/lparser.c
++++ b/src/lparser.c
+@@ -468,6 +468,7 @@ static void singlevar (LexState *ls, expdesc *var) {
+     expdesc key;
+     singlevaraux(fs, ls->envn, var, 1);  /* get environment variable */
+     lua_assert(var->k != VVOID);  /* this one must exist */
++    luaK_exp2anyregup(fs, var);  /* but could be a constant */
+     codestring(&key, varname);  /* key is variable name */
+     luaK_indexed(fs, var, &key);  /* env[varname] */
+   }
+--- a/tests/attrib.lua
++++ b/tests/attrib.lua
+@@ -434,6 +434,16 @@ a.aVeryLongName012345678901234567890123456789012345678901234567890123456789 ==
+ 10)
+
+
++do
++  -- _ENV constant
++  local function foo ()
++    local _ENV <const> = 11
++    X = "hi"
++  end
++  local st, msg = pcall(foo)
++  assert(not st and string.find(msg, "number"))
++end
++
+
+ -- test of large float/integer indices
+

--- a/dev-lang/lua/lua-5.4.4-r103.ebuild
+++ b/dev-lang/lua/lua-5.4.4-r103.ebuild
@@ -22,6 +22,10 @@ DEPEND="
 RDEPEND="${DEPEND}"
 BDEPEND="virtual/pkgconfig"
 
+PATCHES=(
+	"${FILESDIR}/${P}-lparser-overread.patch"
+)
+
 src_prepare() {
 	default
 


### PR DESCRIPTION
This commit fixes CVE-2022-28805 (patch from upstream, slightly modified the location of files due to changed file paths in gentoo). Revision bumped.

This compiles without problems on amd64.