### PR TITLE
unpacker.eclass: tests, fixes, .gpkg.tar support

### DIFF
--- a/eclass/tests/tests-common.sh
+++ b/eclass/tests/tests-common.sh
@@ -60,6 +60,13 @@ die() {
 	exit 1
 }
 
+assert() {
+	local x pipestatus=${PIPESTATUS[*]}
+	for x in ${pipestatus} ; do
+		[[ ${x} -eq 0 ]] || die "$@"
+	done
+}
+
 has_version() {
 	while [[ $1 == -* ]]; do
 		shift

--- a/eclass/tests/unpacker.sh
+++ b/eclass/tests/unpacker.sh
@@ -134,6 +134,10 @@ test_deb() {
 
 	test_unpack "test-${tool}_1.2.3_noarch.deb" test.in "ar tar ${tool}" \
 		"create_deb '${suffix}' '${tool_cmd}' \${archive} \${TESTFILE}"
+	# also test with the handwoven implementation used on Prefix
+	EPREFIX=/foo \
+	test_unpack "test_pfx-${tool}_1.2.3_noarch.deb" test.in "ar tar ${tool}" \
+		"create_deb '${suffix}' '${tool_cmd}' \${archive} \${TESTFILE}"
 }
 
 create_gpkg() {

--- a/eclass/tests/unpacker.sh
+++ b/eclass/tests/unpacker.sh
@@ -165,6 +165,8 @@ test_compressed_file .lzma lzma
 test_compressed_file .xz xz
 test_compressed_file .lz lzip
 test_compressed_file .zst zstd
+test_compressed_file .lz4 lz4
+test_compressed_file .lzo lzop
 
 test_compressed_file_multistream .bz2 bzip2
 test_compressed_file_multistream .gz gzip
@@ -187,6 +189,8 @@ test_compressed_tar .tar.xz xz
 test_compressed_tar .txz xz
 test_compressed_tar .tar.lz lzip
 test_compressed_tar .tar.zst zstd
+test_compressed_tar .tar.lz4 lz4
+test_compressed_tar .tar.lzo lzop
 
 test_unpack test.cpio test.in cpio 'cpio -o --quiet <<<${TESTFILE} > ${archive}'
 test_compressed_cpio .cpio.bz2 bzip2
@@ -196,6 +200,8 @@ test_compressed_cpio .cpio.lzma lzma
 test_compressed_cpio .cpio.xz xz
 test_compressed_cpio .cpio.lz lzip
 test_compressed_cpio .cpio.zst zstd
+test_compressed_cpio .cpio.lz4 lz4
+test_compressed_cpio .cpio.lzo lzop
 
 test_deb
 test_deb .gz gzip
@@ -223,6 +229,7 @@ test_reject_junk .lz
 test_reject_junk .zst
 test_reject_junk .tar
 test_reject_junk .cpio
+test_reject_junk .gpkg.tar
 test_reject_junk .deb
 test_reject_junk .zip
 test_reject_junk .7z

--- a/eclass/tests/unpacker.sh
+++ b/eclass/tests/unpacker.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+# Copyright 2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+source tests-common.sh || exit
+
+inherit unpacker
+
+# silence the output
+unpack_banner() { :; }
+
+TESTFILE=test.in
+TESTDIR=$(mktemp -d || die)
+trap 'cd - >/dev/null && rm -r "${TESTDIR}"' EXIT
+
+# prepare some test data
+# NB: we need something "compressible", as compress(1) will return
+# an error if the file "is larger than before compression"
+cp ../unpacker.eclass "${TESTDIR}/${TESTFILE}" || die
+cd "${TESTDIR}" || die
+
+test_unpack() {
+	local archive=${1}
+	local unpacked=${2}
+	local deps=${3}
+	local packcmd=${4}
+
+	local x
+	for x in ${deps}; do
+		if ! type "${x}" &>/dev/null; then
+			ewarn "Skipping ${archive}, tool ${x} not found"
+			return
+		fi
+	done
+
+	rm -rf testdir || die
+	mkdir -p testdir || die
+
+	tbegin "unpacking ${archive}"
+	eval "${packcmd}"
+	assert "packing ${archive} failed"
+	cd testdir || die
+	local out
+	out=$(
+		_unpacker "../${archive}" 2>&1
+	)
+	ret=$?
+	if [[ ${ret} -eq 0 ]]; then
+		if [[ ! -f ${unpacked} ]]; then
+			eerror "${unpacked} not found after unpacking"
+			ret=1
+		elif ! diff -u "${unpacked}" "../${TESTFILE}"; then
+			eerror "${unpacked} different than input"
+			ret=1
+		fi
+	fi
+	[[ ${ret} -ne 0 ]] && echo "${out}" >&2
+	tend ${ret}
+
+	cd .. || die
+	rm -f "${archive}" || die
+}
+
+test_compressed_file() {
+	local suffix=${1}
+	local tool=${2}
+
+	test_unpack "test${suffix}" test "${tool}" \
+		"${tool} -c \${TESTFILE} > \${archive}"
+}
+
+test_compressed_file_multistream() {
+	local suffix=${1}
+	local tool=${2}
+
+	test_unpack "test+multistream${suffix}" "test+multistream" "${tool}" \
+		"head -n 300 \${TESTFILE} | ${tool} -c > \${archive} &&
+		tail -n +301 \${TESTFILE} | ${tool} -c >> \${archive}"
+}
+
+test_compressed_file_with_junk() {
+	local suffix=${1}
+	local tool=${2}
+	local flag=${3}
+
+	test_unpack "test+junk${suffix}" "test+junk" "${tool}" \
+		"${tool} -c \${TESTFILE} > \${archive} && cat test.in >> \${archive}"
+}
+
+test_compressed_tar() {
+	local suffix=${1}
+	local tool=${2}
+
+	test_unpack "test${suffix}" test.in "tar ${tool}" \
+		"tar -c \${TESTFILE} | ${tool} -c > \${archive}"
+}
+
+test_compressed_cpio() {
+	local suffix=${1}
+	local tool=${2}
+
+	test_unpack "test${suffix}" test.in "cpio ${tool}" \
+		"cpio -o --quiet <<<\${TESTFILE} | ${tool} -c > \${archive}"
+}
+
+create_deb() {
+	local suffix=${1}
+	local tool=${2}
+	local archive=${3}
+	local infile=${4}
+
+	echo 2.0 > debian-binary || die
+	: > control || die
+	tar -cf control.tar control || die
+	tar -c "${infile}" | ${tool} > "data.tar${suffix}"
+	assert "packing data.tar${suffix} failed"
+	ar r "${archive}" debian-binary control.tar "data.tar${suffix}" \
+		2>/dev/null || die
+	rm -f control control.tar "data.tar${suffix}" debian-binary || die
+}
+
+test_deb() {
+	local suffix=${1}
+	local tool=${2}
+	local tool_cmd
+
+	if [[ -n ${tool} ]]; then
+		tool_cmd="${tool} -c"
+	else
+		tool_cmd=cat
+	fi
+
+	test_unpack "test-${tool}_1.2.3_noarch.deb" test.in "ar tar ${tool}" \
+		"create_deb '${suffix}' '${tool_cmd}' \${archive} \${TESTFILE}"
+}
+
+test_reject_junk() {
+	local suffix=${1}
+	local archive=test${1}
+
+	rm -rf testdir || die
+	mkdir -p testdir || die
+
+	tbegin "rejecting junk named ${archive}"
+	cat test.in >> "${archive}" || die
+	cd testdir || die
+	(
+		# some decompressors (e.g. cpio) are very verbose about junk
+		_unpacker "../${archive}" &>/dev/null
+	)
+	[[ $? -ne 0 ]]
+	ret=$?
+	tend ${ret}
+
+	cd .. || die
+	rm -f "${archive}" || die
+}
+
+test_compressed_file .bz2 bzip2
+test_compressed_file .Z compress
+test_compressed_file .gz gzip
+test_compressed_file .lzma lzma
+test_compressed_file .xz xz
+test_compressed_file .lz lzip
+test_compressed_file .zst zstd
+
+test_compressed_file_multistream .bz2 bzip2
+test_compressed_file_multistream .gz gzip
+test_compressed_file_multistream .xz xz
+test_compressed_file_multistream .lz lzip
+test_compressed_file_multistream .zst zstd
+
+test_compressed_file_with_junk .bz2 bzip2
+test_compressed_file_with_junk .lz lzip
+
+test_unpack test.tar test.in tar 'tar -cf ${archive} ${TESTFILE}'
+test_compressed_tar .tar.bz2 bzip2
+test_compressed_tar .tbz bzip2
+test_compressed_tar .tbz2 bzip2
+test_compressed_tar .tar.Z compress
+test_compressed_tar .tar.gz gzip
+test_compressed_tar .tgz gzip
+test_compressed_tar .tar.lzma lzma
+test_compressed_tar .tar.xz xz
+test_compressed_tar .txz xz
+test_compressed_tar .tar.lz lzip
+test_compressed_tar .tar.zst zstd
+
+test_unpack test.cpio test.in cpio 'cpio -o --quiet <<<${TESTFILE} > ${archive}'
+test_compressed_cpio .cpio.bz2 bzip2
+test_compressed_cpio .cpio.Z compress
+test_compressed_cpio .cpio.gz gzip
+test_compressed_cpio .cpio.lzma lzma
+test_compressed_cpio .cpio.xz xz
+test_compressed_cpio .cpio.lz lzip
+test_compressed_cpio .cpio.zst zstd
+
+test_deb
+test_deb .gz gzip
+test_deb .xz xz
+test_deb .bz2 bzip2
+test_deb .lzma lzma
+
+test_unpack test.zip test.in zip 'zip -q ${archive} ${TESTFILE}'
+# test handling non-adjusted zip with junk prepended
+test_unpack test.zip test.in zip \
+	'zip -q testdir/tmp.zip ${TESTFILE} && cat test.in testdir/tmp.zip > ${archive}'
+test_unpack test.7z test.in 7z '7z -bso0 a ${archive} ${TESTFILE}'
+test_unpack test.lha test.in lha 'lha a -q ${archive} ${TESTFILE}'
+test_unpack test.lzh test.in lha 'lha a -q ${archive} ${TESTFILE}'
+test_unpack test.rar test.in rar 'rar -idq a ${archive} ${TESTFILE}'
+
+# TODO: .run/.sh/.bin
+
+test_reject_junk .bz2
+test_reject_junk .Z
+test_reject_junk .gz
+test_reject_junk .lzma
+test_reject_junk .xz
+test_reject_junk .lz
+test_reject_junk .zst
+test_reject_junk .tar
+test_reject_junk .cpio
+test_reject_junk .deb
+test_reject_junk .zip
+test_reject_junk .7z
+test_reject_junk .rar
+test_reject_junk .lha
+test_reject_junk .lzh
+
+texit

--- a/eclass/unpacker.eclass
+++ b/eclass/unpacker.eclass
@@ -389,7 +389,7 @@ _unpacker() {
 	[[ $# -eq 1 ]] || die "Usage: ${FUNCNAME} <file>"
 
 	local a=$1
-	local m=$(echo "${a}" | tr '[:upper:]' '[:lower:]')
+	local m=${a,,}
 	a=$(find_unpackable_file "${a}")
 
 	# first figure out the decompression method

--- a/eclass/unpacker.eclass
+++ b/eclass/unpacker.eclass
@@ -444,9 +444,9 @@ _unpacker() {
 		case ${m} in
 		*.7z)
 			arch="unpack_7z" ;;
-		*.rar|*.RAR)
+		*.rar)
 			arch="unpack_rar" ;;
-		*.LHA|*.LHa|*.lha|*.lzh)
+		*.lha|*.lzh)
 			arch="unpack_lha" ;;
 		esac
 	fi
@@ -513,7 +513,7 @@ unpacker_src_uri_depends() {
 		case ${m} in
 		*.cpio.*|*.cpio)
 			d="app-arch/cpio" ;;
-		*.rar|*.RAR)
+		*.rar)
 			d="app-arch/unrar" ;;
 		*.7z)
 			d="app-arch/p7zip" ;;
@@ -525,7 +525,7 @@ unpacker_src_uri_depends() {
 			d="|| ( app-arch/plzip app-arch/pdlzip app-arch/lzip )" ;;
 		*.zst)
 			d="app-arch/zstd" ;;
-		*.LHA|*.LHa|*.lha|*.lzh)
+		*.lha|*.lzh)
 			d="app-arch/lha" ;;
 		esac
 		deps+=" ${d}"

--- a/eclass/unpacker.eclass
+++ b/eclass/unpacker.eclass
@@ -30,7 +30,8 @@ inherit multiprocessing toolchain-funcs
 # @DEFAULT_UNSET
 # @DESCRIPTION:
 # Utility to use to decompress bzip2 files.  Will dynamically pick between
-# `pbzip2` and `bzip2`.  Make sure your choice accepts the "-dc" options.
+# `lbzip2`, `pbzip2` and `bzip2`.  Make sure your choice accepts the "-dc"
+# options.
 # Note: this is meant for users to set, not ebuilds.
 
 # @ECLASS_VARIABLE: UNPACKER_LZIP
@@ -387,7 +388,9 @@ unpack_lha() {
 _unpacker_get_decompressor() {
 	case ${1} in
 	*.bz2|*.tbz|*.tbz2)
-		local bzcmd=${PORTAGE_BZIP2_COMMAND:-$(type -P pbzip2 || type -P bzip2)}
+		local bzcmd=${PORTAGE_BZIP2_COMMAND:-$(
+			type -P lbzip2 || type -P pbzip2 || type -P bzip2
+		)}
 		local bzuncmd=${PORTAGE_BUNZIP2_COMMAND:-${bzcmd} -d}
 		: ${UNPACKER_BZ2:=${bzuncmd}}
 		echo "${UNPACKER_BZ2} -c"

--- a/eclass/unpacker.eclass
+++ b/eclass/unpacker.eclass
@@ -23,7 +23,7 @@ esac
 if [[ -z ${_UNPACKER_ECLASS} ]]; then
 _UNPACKER_ECLASS=1
 
-inherit toolchain-funcs
+inherit multiprocessing toolchain-funcs
 
 # @ECLASS_VARIABLE: UNPACKER_BZ2
 # @USER_VARIABLE
@@ -395,7 +395,7 @@ _unpacker_get_decompressor() {
 	*.z|*.gz|*.tgz)
 		echo "gzip -dc" ;;
 	*.lzma|*.xz|*.txz)
-		echo "xz -dc" ;;
+		echo "xz -T$(makeopts_jobs) -dc" ;;
 	*.lz)
 		: ${UNPACKER_LZIP:=$(type -P plzip || type -P pdlzip || type -P lzip)}
 		echo "${UNPACKER_LZIP} -dc" ;;

--- a/eclass/unpacker.eclass
+++ b/eclass/unpacker.eclass
@@ -4,7 +4,7 @@
 # @ECLASS: unpacker.eclass
 # @MAINTAINER:
 # base-system@gentoo.org
-# @SUPPORTED_EAPIS: 5 6 7 8
+# @SUPPORTED_EAPIS: 6 7 8
 # @BLURB: helpers for extraneous file formats and consistent behavior across EAPIs
 # @DESCRIPTION:
 # Some extraneous file formats are not part of PMS, or are only in certain
@@ -16,7 +16,7 @@
 #  - support partial unpacks?
 
 case ${EAPI:-0} in
-	[5678]) ;;
+	[678]) ;;
 	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
 
@@ -440,7 +440,7 @@ _unpacker() {
 	esac
 
 	# 7z, rar and lha/lzh are handled by package manager in EAPI < 8
-	if [[ ${EAPI} != [567] ]]; then
+	if [[ ${EAPI} != [67] ]]; then
 		case ${m} in
 		*.7z)
 			arch="unpack_7z" ;;

--- a/eclass/unpacker.eclass
+++ b/eclass/unpacker.eclass
@@ -509,7 +509,8 @@ unpacker_src_uri_depends() {
 	fi
 
 	for uri in "$@" ; do
-		case ${uri} in
+		local m=${uri,,}
+		case ${m} in
 		*.cpio.*|*.cpio)
 			d="app-arch/cpio" ;;
 		*.rar|*.RAR)

--- a/eclass/unpacker.eclass
+++ b/eclass/unpacker.eclass
@@ -344,8 +344,11 @@ unpack_7z() {
 
 	local p7z=$(find_unpackable_file "$1")
 	unpack_banner "${p7z}"
-	local output="$(7z x -y "${p7z}")"
 
+	# warning: putting local and command substitution in a single call
+	# discards the exit status!
+	local output
+	output="$(7z x -y "${p7z}")"
 	if [ $? -ne 0 ]; then
 		echo "${output}" >&2
 		die "unpacking ${p7z} failed (arch=unpack_7z)"

--- a/eclass/unpacker.eclass
+++ b/eclass/unpacker.eclass
@@ -282,6 +282,8 @@ unpack_deb() {
 			local f timestamp uid gid mode size magic
 			while read f timestamp uid gid mode size magic ; do
 				[[ -n ${f} && -n ${size} ]] || continue # ignore empty lines
+				# GNU ar uses / as filename terminator (and .deb permits that)
+				f=${f%/}
 				if [[ ${f} = "data.tar"* ]] ; then
 					head -c "${size}" > "${f}"
 				else

--- a/eclass/unpacker.eclass
+++ b/eclass/unpacker.eclass
@@ -401,6 +401,10 @@ _unpacker_get_decompressor() {
 		echo "${UNPACKER_LZIP} -dc" ;;
 	*.zst)
 		echo "zstd -dc" ;;
+	*.lz4)
+		echo "lz4 -dc" ;;
+	*.lzo)
+		echo "lzop -dc" ;;
 	esac
 }
 
@@ -535,6 +539,10 @@ unpacker_src_uri_depends() {
 			d="app-arch/zstd" ;;
 		*.lha|*.lzh)
 			d="app-arch/lha" ;;
+		*.lz4)
+			d="app-arch/lz4" ;;
+		*.lzo)
+			d="app-arch/lzop" ;;
 		esac
 		deps+=" ${d}"
 	done

--- a/eclass/unpacker.eclass
+++ b/eclass/unpacker.eclass
@@ -406,7 +406,7 @@ _unpacker() {
 		: ${UNPACKER_LZIP:=$(type -P plzip || type -P pdlzip || type -P lzip)}
 		comp="${UNPACKER_LZIP} -dc" ;;
 	*.zst)
-		comp="zstd -dfc" ;;
+		comp="zstd -dc" ;;
 	esac
 
 	# then figure out if there are any archiving aspects

--- a/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-5.19.11.ebuild
+++ b/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-5.19.11.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit kernel-install toolchain-funcs
+inherit kernel-install toolchain-funcs unpacker
 
 MY_P=linux-${PV%.*}
 GENPATCHES_P=genpatches-${PV%.*}-$(( ${PV##*.} + 2 ))
@@ -55,11 +55,6 @@ QA_PREBUILT='*'
 KV_LOCALVERSION='-gentoo-dist'
 KPV=${PV}${KV_LOCALVERSION}
 
-src_unpack() {
-	default
-	unpack "${BINPKG}"/image.tar.xz
-}
-
 src_prepare() {
 	local PATCHES=(
 		# meh, genpatches have no directory
@@ -102,22 +97,22 @@ src_configure() {
 	)
 
 	mkdir modprep || die
-	cp "image/usr/src/linux-${KPV}/.config" modprep/ || die
+	cp "${BINPKG}/image/usr/src/linux-${KPV}/.config" modprep/ || die
 	emake -C "${MY_P}" "${makeargs[@]}" modules_prepare
 }
 
 src_test() {
 	kernel-install_test "${KPV}" \
-		"${WORKDIR}/image/usr/src/linux-${KPV}/$(dist-kernel_get_image_path)" \
-		"image/lib/modules/${KPV}"
+		"${WORKDIR}/${BINPKG}/image/usr/src/linux-${KPV}/$(dist-kernel_get_image_path)" \
+		"${BINPKG}/image/lib/modules/${KPV}"
 }
 
 src_install() {
-	mv image/{lib,usr} "${ED}"/ || die
+	mv "${BINPKG}"/image/{lib,usr} "${ED}"/ || die
 
 	# FIXME: requires proper mount-boot
 	if [[ -d boot/dtbs ]]; then
-		mv image/boot "${ED}"/ || die
+		mv "${BINPKG}"/image/boot "${ED}"/ || die
 	fi
 
 	# strip out-of-source build stuffs from modprep


### PR DESCRIPTION
- add tests for unpacking various file formats
- fix handling broken/invalid `.zst` and `.7z` files
- use lowercase suffixes everywhere consistently
- add support for `.lz4` and `.lzo`
- add support for on-the-fly unpacking of the image archive from `.gpkg.tar`
- use parallel xz decompression (by @thesamesam)
- support lbzip2 if available
- fix handling `.deb` that use GNU ar format
- unpack `.deb` on-the-fly (i.e. without temporary files)

Includes an example `.gpkg.tar` unpacking for gentoo-kernel-bin.

CC @gentoo/base-system, @gentoo/dist-kernel