### PR TITLE
app-text/qpdf: Fixed DEFAULT_CRYPTO value. [please reassign]

### DIFF
--- a/app-text/qpdf/qpdf-11.1.0-r2.ebuild
+++ b/app-text/qpdf/qpdf-11.1.0-r2.ebuild
@@ -52,8 +52,9 @@ src_configure() {
 
 	if use ssl ; then
 		local crypto_provider=$(usex gnutls GNUTLS OPENSSL)
+		local crypto_provider_lowercase=${crypto_provider,,}
 		mycmakeargs+=(
-			-DDEFAULT_CRYPTO=${crypto_provider}
+			-DDEFAULT_CRYPTO=${crypto_provider_lowercase}
 			-DREQUIRE_CRYPTO_${crypto_provider}=ON
 		)
 	fi


### PR DESCRIPTION
The `DEFAULT_CRYPTO` argument expects the values to be in lowercase. Using uppercase values results in errors like:

`request to set default provider to unknown implementation \"OPENSSL\"` and bad PDFs being produced by the library.

Bug: https://bugs.gentoo.org/872716