### PR TITLE
sys-devel/mold: fix wrapper error, #872773

### DIFF
--- a/sys-devel/mold/files/mold-1.4.1-cmake-libdir.patch
+++ b/sys-devel/mold/files/mold-1.4.1-cmake-libdir.patch
@@ -1,0 +1,13 @@
+Bug: https://bugs.gentoo.org/872773
+
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -16,6 +16,8 @@ endif()
+
+ add_executable(mold)
+ target_compile_features(mold PRIVATE cxx_std_20)
++target_compile_definitions(mold PRIVATE
++  "LIBDIR=\"${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}\"")
+ target_link_libraries(mold PRIVATE ${CMAKE_DL_LIBS})
+
+ if(NOT "${CMAKE_CXX_COMPILER_FRONTEND_VARIANT}" STREQUAL "MSVC")

--- a/sys-devel/mold/mold-1.4.2.ebuild
+++ b/sys-devel/mold/mold-1.4.2.ebuild
@@ -35,6 +35,8 @@ DEPEND="${RDEPEND}"
 PATCHES=(
 	# https://bugs.gentoo.org/865837
 	"${FILESDIR}"/mold-1.4.1-tbb-flags-stripping.patch
+	# https://bugs.gentoo.org/872773
+	"${FILESDIR}"/mold-1.4.1-cmake-libdir.patch
 )
 
 pkg_pretend() {
@@ -81,7 +83,8 @@ src_configure() {
 
 src_install() {
 	dobin "${BUILD_DIR}"/${PN}
-	dolib.so "${BUILD_DIR}"/${PN}-wrapper.so
+	insinto /usr/$(get_libdir)/mold
+	doins "${BUILD_DIR}"/${PN}-wrapper.so
 
 	dodoc docs/{design,execstack}.md
 	doman docs/${PN}.1

--- a/sys-devel/mold/mold-9999.ebuild
+++ b/sys-devel/mold/mold-9999.ebuild
@@ -81,7 +81,8 @@ src_configure() {
 
 src_install() {
 	dobin "${BUILD_DIR}"/${PN}
-	dolib.so "${BUILD_DIR}"/${PN}-wrapper.so
+	insinto /usr/$(get_libdir)/mold
+	doins "${BUILD_DIR}"/${PN}-wrapper.so
 
 	dodoc docs/{design,execstack}.md
 	doman docs/${PN}.1


### PR DESCRIPTION
Fixes a problem that prevented mold from working as a wrapper.

It compiles without problems on amd64.

Bug: https://bugs.gentoo.org/872773