### PR TITLE
dev-db/postgresql: enable thread-safety by default, remove IUSE=threads

### DIFF
--- a/dev-db/postgresql/postgresql-15.0.ebuild
+++ b/dev-db/postgresql/postgresql-15.0.ebuild
@@ -23,7 +23,7 @@ HOMEPAGE="https://www.postgresql.org/"
 
 IUSE="debug doc icu kerberos ldap llvm lz4 nls pam
 	  perl python +readline selinux +server systemd ssl static-libs tcl
-	  threads uuid xml zlib zstd"
+	  uuid xml zlib zstd"
 
 REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
 
@@ -142,7 +142,6 @@ src_configure() {
 		--sysconfdir="${PO}/etc/postgresql-${SLOT}" \
 		--with-system-tzdata="${PO}/usr/share/zoneinfo" \
 		$(use_enable debug) \
-		$(use_enable threads thread-safety) \
 		$(use_with icu) \
 		$(use_with kerberos gssapi) \
 		$(use_with ldap) \

--- a/dev-db/postgresql/postgresql-15.1.ebuild
+++ b/dev-db/postgresql/postgresql-15.1.ebuild
@@ -23,7 +23,7 @@ HOMEPAGE="https://www.postgresql.org/"
 
 IUSE="debug doc icu kerberos ldap llvm lz4 nls pam
 	  perl python +readline selinux +server systemd ssl static-libs tcl
-	  threads uuid xml zlib zstd"
+	  uuid xml zlib zstd"
 
 REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
 
@@ -142,7 +142,6 @@ src_configure() {
 		--sysconfdir="${PO}/etc/postgresql-${SLOT}" \
 		--with-system-tzdata="${PO}/usr/share/zoneinfo" \
 		$(use_enable debug) \
-		$(use_enable threads thread-safety) \
 		$(use_with icu) \
 		$(use_with kerberos gssapi) \
 		$(use_with ldap) \

--- a/dev-db/postgresql/postgresql-15.2.ebuild
+++ b/dev-db/postgresql/postgresql-15.2.ebuild
@@ -23,7 +23,7 @@ HOMEPAGE="https://www.postgresql.org/"
 
 IUSE="debug doc icu kerberos ldap llvm lz4 nls pam
 	  perl python +readline selinux +server systemd ssl static-libs tcl
-	  threads uuid xml zlib zstd"
+	  uuid xml zlib zstd"
 
 REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
 
@@ -142,7 +142,6 @@ src_configure() {
 		--sysconfdir="${PO}/etc/postgresql-${SLOT}" \
 		--with-system-tzdata="${PO}/usr/share/zoneinfo" \
 		$(use_enable debug) \
-		$(use_enable threads thread-safety) \
 		$(use_with icu) \
 		$(use_with kerberos gssapi) \
 		$(use_with ldap) \

--- a/dev-db/postgresql/postgresql-9999.ebuild
+++ b/dev-db/postgresql/postgresql-9999.ebuild
@@ -19,7 +19,7 @@ HOMEPAGE="https://www.postgresql.org/"
 
 IUSE="debug icu kerberos ldap llvm +lz4
 	nls pam perl python +readline selinux server systemd
-	ssl static-libs tcl threads uuid xml zlib zstd"
+	ssl static-libs tcl uuid xml zlib zstd"
 
 REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
 
@@ -158,7 +158,6 @@ src_configure() {
 		--with-system-tzdata="${PO}/usr/share/zoneinfo" \
 		$(use_enable debug) \
 		$(use_enable nls) \
-		$(use_enable threads thread-safety) \
 		$(use_with icu) \
 		$(use_with kerberos gssapi) \
 		$(use_with ldap) \


### PR DESCRIPTION
This follows the expected and strongly recommended upstream default.

Closes: https://bugs.gentoo.org/868393
Signed-off-by: Holger Hoffstätte <holger@applied-asynchrony.com>
