### PR TITLE
dev-lang/rust-1.64.0-r1: Re-add abi 32 support

### DIFF
--- a/dev-lang/rust/rust-1.64.0-r1.ebuild
+++ b/dev-lang/rust/rust-1.64.0-r1.ebuild
@@ -297,14 +297,13 @@ src_configure() {
 	use system-llvm && filter-flags '-flto*' # https://bugs.gentoo.org/862109
 
 	local rust_target="" rust_targets="" arch_cflags use_libcxx="false"
-	local chost_target="$(get_abi_CHOST ${v##*.})"
 
 	# Collect rust target names to compile standard libs for all ABIs.
 	for v in $(multilib_get_enabled_abi_pairs); do
-		rust_targets+=",\"$(rust_abi ${chost_target})\""
+		rust_targets="${rust_targets},\"$(rust_abi $(get_abi_CHOST ${v##*.}))\""
 	done
 	if use wasm; then
-		rust_targets+=",\"wasm32-unknown-unknown\""
+		rust_targets="${rust_targets},\"wasm32-unknown-unknown\""
 		if use system-llvm; then
 			# un-hardcode rust-lld linker for this target
 			# https://bugs.gentoo.org/715348


### PR DESCRIPTION
Switching back to the rust 1.63.0 way of doing things gets 32bit working for me again

Bug: https://bugs.gentoo.org/872815
Signed-off-by: Mike Lothian <mike@fireburn.co.uk>