### PR TITLE
sys-kernel/dracut: homepage moved

### DIFF
--- a/sys-kernel/dracut/dracut-057-r1.ebuild
+++ b/sys-kernel/dracut/dracut-057-r1.ebuild
@@ -16,7 +16,7 @@ else
 fi
 
 DESCRIPTION="Generic initramfs generation tool"
-HOMEPAGE="https://dracut.wiki.kernel.org"
+HOMEPAGE="https://github.com/dracutdevs/dracut/wiki"
 
 LICENSE="GPL-2"
 SLOT="0"


### PR DESCRIPTION
new wiki is at https://github.com/dracutdevs/dracut/wiki .