### PR TITLE
dev-util/bpftrace: fix 0.15.0 for LLVM-15, unkeyword 0.16.0

### DIFF
--- a/dev-util/bpftrace/bpftrace-0.15.0-r2.ebuild
+++ b/dev-util/bpftrace/bpftrace-0.15.0-r2.ebuild
@@ -54,6 +54,7 @@ PATCHES=(
 	"${FILESDIR}/bpftrace-0.11.4-old-kernels.patch"
 	"${FILESDIR}/bpftrace-0.15.0-bcc-025.patch"
 	"${FILESDIR}/bpftrace-0.15.0-binutils-2.39.patch"
+	"${FILESDIR}/bpftrace-0.15.0-llvm-15-pointers.patch"
 )
 
 pkg_pretend() {

--- a/dev-util/bpftrace/bpftrace-0.16.0.ebuild
+++ b/dev-util/bpftrace/bpftrace-0.16.0.ebuild
@@ -15,7 +15,10 @@ S="${WORKDIR}/${PN}-${MY_PV:-${PV}}"
 
 LICENSE="Apache-2.0"
 SLOT="0"
-KEYWORDS="~amd64 ~arm64 ~x86"
+
+# remove keywords until build works:
+# https://github.com/iovisor/bpftrace/issues/2349
+#KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE="fuzzing test"
 
 # lots of fixing needed

--- a/dev-util/bpftrace/files/bpftrace-0.15.0-llvm-15-pointers.patch
+++ b/dev-util/bpftrace/files/bpftrace-0.15.0-llvm-15-pointers.patch
@@ -1,0 +1,30 @@
+
+From: https://github.com/iovisor/bpftrace/pull/2367
+Bug: https://bugs.gentoo.org/872842
+
+From 07fa48a94ef6d6bb1f335de345de18fe9776ca57 Mon Sep 17 00:00:00 2001
+From: kenneth topp <toppk@bllue.org>
+Date: Mon, 26 Sep 2022 00:33:29 -0400
+Subject: [PATCH] Workaround OpaquePointers for LLVM 15
+
+This workaround allows bpftrace to be compiled against
+LLVM-15.  This will have to be address properly before LLVM-16
+More details from LLVM here: https://llvm.org/docs/OpaquePointers.html
+---
+ src/ast/irbuilderbpf.cpp | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/src/ast/irbuilderbpf.cpp b/src/ast/irbuilderbpf.cpp
+index d49883f786..00f0f172ff 100644
+--- a/src/ast/irbuilderbpf.cpp
++++ b/src/ast/irbuilderbpf.cpp
+@@ -123,6 +123,9 @@ IRBuilderBPF::IRBuilderBPF(LLVMContext &context,
+     module_(module),
+     bpftrace_(bpftrace)
+ {
++#if LLVM_VERSION_MAJOR == 15
++  context.setOpaquePointers(false);
++#endif
+   // Declare external LLVM function
+   FunctionType *pseudo_func_type = FunctionType::get(
+       getInt64Ty(),


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/872842
Signed-off-by: Holger Hoffstätte <holger@applied-asynchrony.com>
