### PR TITLE
app-crypt/{tpm2-abrmd,tpm2-tools,tpm2-tss}: Filter LTO for failing test

### DIFF
--- a/app-crypt/tpm2-abrmd/tpm2-abrmd-2.4.1-r1.ebuild
+++ b/app-crypt/tpm2-abrmd/tpm2-abrmd-2.4.1-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit autotools systemd
+inherit autotools flag-o-matic systemd
 
 DESCRIPTION="TPM2 Access Broker & Resource Manager"
 HOMEPAGE="https://github.com/tpm2-software/tpm2-abrmd"
@@ -36,6 +36,8 @@ src_prepare() {
 }
 
 src_configure() {
+	# tests fail with LTO enabbled. See bug 865275
+	filter-lto
 	econf \
 		$(use_enable static-libs static) \
 		$(use_enable test unit) \

--- a/app-crypt/tpm2-tools/tpm2-tools-5.2-r1.ebuild
+++ b/app-crypt/tpm2-tools/tpm2-tools-5.2-r1.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 PYTHON_COMPAT=( python3_{8..10} )
-inherit autotools bash-completion-r1 python-any-r1
+inherit autotools bash-completion-r1 flag-o-matic python-any-r1
 
 DESCRIPTION="Tools for the TPM 2.0 TSS"
 HOMEPAGE="https://github.com/tpm2-software/tpm2-tools"
@@ -51,6 +51,8 @@ src_prepare() {
 }
 
 src_configure() {
+	# tests fail with LTO enabbled. See bug 865275 and 865277
+	filter-lto
 	econf \
 		$(use_enable fapi) \
 		$(use_enable test unit) \

--- a/app-crypt/tpm2-tss/tpm2-tss-3.2.0-r3.ebuild
+++ b/app-crypt/tpm2-tss/tpm2-tss-3.2.0-r3.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit autotools linux-info multilib-minimal tmpfiles udev
+inherit autotools flag-o-matic linux-info multilib-minimal tmpfiles udev
 
 DESCRIPTION="TCG Trusted Platform Module 2.0 Software Stack"
 HOMEPAGE="https://github.com/tpm2-software/tpm2-tss"
@@ -59,6 +59,9 @@ src_prepare() {
 }
 
 multilib_src_configure() {
+	# tests fail with LTO enabbled. See bug 865275 and 865279
+	filter-lto
+
 	ECONF_SOURCE=${S} econf \
 		--localstatedir=/var \
 		$(multilib_native_use_enable doc doxygen-doc) \

--- a/app-crypt/tpm2-tss/tpm2-tss-3.2.0-r4.ebuild
+++ b/app-crypt/tpm2-tss/tpm2-tss-3.2.0-r4.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit autotools linux-info multilib-minimal tmpfiles udev
+inherit autotools flag-o-matic linux-info multilib-minimal tmpfiles udev
 
 DESCRIPTION="TCG Trusted Platform Module 2.0 Software Stack"
 HOMEPAGE="https://github.com/tpm2-software/tpm2-tss"
@@ -60,6 +60,9 @@ src_prepare() {
 }
 
 multilib_src_configure() {
+	# tests fail with LTO enabbled. See bug 865275 and 865279
+	filter-lto
+
 	ECONF_SOURCE=${S} econf \
 		--localstatedir=/var \
 		$(multilib_native_use_enable doc doxygen-doc) \


### PR DESCRIPTION
These patches filter LTO flags out due to failing tests. See the comments on https://bugs.gentoo.org/865275 . 