### PR TITLE
net-analyzer/netdata: Keyword 1.36.1-r1 riscv, #866139

### DIFF
--- a/net-analyzer/netdata/netdata-1.36.1-r1.ebuild
+++ b/net-analyzer/netdata/netdata-1.36.1-r1.ebuild
@@ -12,7 +12,7 @@ if [[ ${PV} == *9999 ]] ; then
 else
 	SRC_URI="https://github.com/netdata/${PN}/releases/download/v${PV}/${PN}-v${PV}.tar.gz -> ${P}.tar.gz"
 	S="${WORKDIR}/${PN}-v${PV}"
-	KEYWORDS="~amd64 ~ppc64 ~x86"
+	KEYWORDS="~amd64 ~ppc64 ~riscv ~x86"
 fi
 
 DESCRIPTION="Linux real time system monitoring, done right!"

--- a/net-firewall/nfacct/nfacct-1.0.2-r2.ebuild
+++ b/net-firewall/nfacct/nfacct-1.0.2-r2.ebuild
@@ -11,7 +11,7 @@ SRC_URI="https://www.netfilter.org/projects/${PN}/files/${P}.tar.bz2"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 ~arm ~ppc64 x86"
+KEYWORDS="amd64 ~arm ~ppc64 ~riscv x86"
 
 RDEPEND="
 	net-libs/libmnl:=

--- a/net-libs/libnetfilter_acct/libnetfilter_acct-1.0.3.ebuild
+++ b/net-libs/libnetfilter_acct/libnetfilter_acct-1.0.3.ebuild
@@ -12,7 +12,7 @@ SRC_URI="https://www.netfilter.org/projects/${PN}/files/${P}.tar.bz2
 
 LICENSE="LGPL-2.1"
 SLOT="0"
-KEYWORDS="~alpha amd64 ~arm ~ia64 ppc ~ppc64 x86 ~amd64-linux"
+KEYWORDS="~alpha amd64 ~arm ~ia64 ppc ~ppc64 ~riscv x86 ~amd64-linux"
 IUSE="examples"
 VERIFY_SIG_OPENPGP_KEY_PATH="${BROOT}"/usr/share/openpgp-keys/netfilter.org.asc
 

--- a/net-libs/libwebsockets/libwebsockets-4.3.2-r1.ebuild
+++ b/net-libs/libwebsockets/libwebsockets-4.3.2-r1.ebuild
@@ -11,7 +11,7 @@ SRC_URI="https://github.com/warmcat/libwebsockets/archive/v${PV}.tar.gz -> ${P}.
 
 LICENSE="MIT"
 SLOT="0/19" # libwebsockets.so.19
-KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~riscv ~x86"
 IUSE="access-log caps cgi client dbus extensions generic-sessions http-proxy http2 ipv6
 	+lejp libev libevent libuv mbedtls peer-limits server-status smtp socks5
 	sqlite3 ssl threads zip"

--- a/net-libs/stem/stem-1.8.0_p20211118.ebuild
+++ b/net-libs/stem/stem-1.8.0_p20211118.ebuild
@@ -15,7 +15,7 @@ S="${WORKDIR}/${PN}-${COMMIT}"
 
 LICENSE="LGPL-3"
 SLOT="0"
-KEYWORDS="~amd64 ~arm ~mips ~ppc ~ppc64 ~x86"
+KEYWORDS="~amd64 ~arm ~mips ~ppc ~ppc64 ~riscv ~x86"
 IUSE="test"
 RESTRICT="!test? ( test )"
 


### PR DESCRIPTION
net-analyzer/netdata: Keyword 1.36.1-r1 riscv, #866139
Closes: https://bugs.gentoo.org/866139