### PR TITLE
java-pkg-simple.eclass: allow JAVA_MAIN_CLASS _and_ MANIFEST.MF | java-pkg-simple.eclass: improve test selection for multi-jar packages

### DIFF
--- a/eclass/java-pkg-simple.eclass
+++ b/eclass/java-pkg-simple.eclass
@@ -545,19 +545,21 @@ java-pkg-simple_src_test() {
 	if [[ -n ${JAVA_TEST_RUN_ONLY} ]]; then
 		tests_to_run="${JAVA_TEST_RUN_ONLY[@]}"
 	else
-		tests_to_run=$(find "${classes}" -type f\
-			\( -name "*Test.class"\
-			-o -name "Test*.class"\
-			-o -name "*Tests.class"\
-			-o -name "*TestCase.class" \)\
-			! -name "*Abstract*"\
-			! -name "*BaseTest*"\
-			! -name "*TestTypes*"\
-			! -name "*TestUtils*"\
-			! -name "*\$*")
-		tests_to_run=${tests_to_run//"${classes}"\/}
-		tests_to_run=${tests_to_run//.class}
-		tests_to_run=${tests_to_run//\//.}
+		pushd "${JAVA_TEST_SRC_DIR}" > /dev/null || die
+			tests_to_run=$(find * -type f\
+				\( -name "*Test.java"\
+				-o -name "Test*.java"\
+				-o -name "*Tests.java"\
+				-o -name "*TestCase.java" \)\
+				! -name "*Abstract*"\
+				! -name "*BaseTest*"\
+				! -name "*TestTypes*"\
+				! -name "*TestUtils*"\
+				! -name "*\$*")
+			tests_to_run=${tests_to_run//"${classes}"\/}
+			tests_to_run=${tests_to_run//.java}
+			tests_to_run=${tests_to_run//\//.}
+		popd > /dev/null || die
 
 		# exclude extra test classes, usually corner cases
 		# that the code above cannot handle

--- a/eclass/java-pkg-simple.eclass
+++ b/eclass/java-pkg-simple.eclass
@@ -415,21 +415,22 @@ java-pkg-simple_src_compile() {
 	fi
 
 	# package
+	[[ ! -d ${classes}/META-INF ]] && mkdir ${classes}/META-INF
+	if  [[ -v JAVA_AUTOMATIC_MODULE_NAME ]]; then
+		echo "Automatic-Module-Name: ${JAVA_AUTOMATIC_MODULE_NAME}" \
+			>> ${classes}/META-INF/MANIFEST.MF || die "adding module name failed"
+	fi
+	if  [[ -v JAVA_MAIN_CLASS ]]; then
+		echo "Main-Class: ${JAVA_MAIN_CLASS}" \
+			>> ${classes}/META-INF/MANIFEST.MF || die "adding main class failed"
+	fi
 	local jar_args
 	if [[ -e ${classes}/META-INF/MANIFEST.MF ]]; then
 		jar_args="cfm ${JAVA_JAR_FILENAME} ${classes}/META-INF/MANIFEST.MF"
-	elif [[ ${JAVA_MAIN_CLASS} ]]; then
-		jar_args="cfe ${JAVA_JAR_FILENAME} ${JAVA_MAIN_CLASS}"
 	else
 		jar_args="cf ${JAVA_JAR_FILENAME}"
 	fi
 	jar ${jar_args} -C ${classes} . || die "jar failed"
-	if  [[ -v JAVA_AUTOMATIC_MODULE_NAME ]]; then
-		cat > "${T}/add-to-MANIFEST.MF" <<< "Automatic-Module-Name: ${JAVA_AUTOMATIC_MODULE_NAME}" \
-			|| die "add-to-MANIFEST.MF failed"
-		jar ufmv ${JAVA_JAR_FILENAME} "${T}/add-to-MANIFEST.MF" \
-			|| die "updating MANIFEST.MF failed"
-	fi
 }
 
 # @FUNCTION: java-pkg-simple_src_install


### PR DESCRIPTION
[[gentoo-dev] [PATCH] java-pkg-simple.eclass: improve test selection for multi-jar packages](https://archives.gentoo.org/gentoo-dev/message/e9e6eefcbf861ffb61f5f56879a0d37b) 
[[gentoo-dev] [PATCH] java-pkg-simple.eclass: allow JAVA_MAIN_CLASS _and_ MANIFEST.MF](https://archives.gentoo.org/gentoo-dev/message/6156caac4b9f6b63777f1cdcd9062c94)