### PR TITLE
media-libs/openexr: fix build issue on x86

### DIFF
--- a/media-libs/openexr/files/openexr-3.1.5-drop-failing-testDwaLookups.patch
+++ b/media-libs/openexr/files/openexr-3.1.5-drop-failing-testDwaLookups.patch
@@ -1,0 +1,29 @@
+From 6f3c61b994e9a503fcc9649cba439d81f40901d0 Mon Sep 17 00:00:00 2001
+From: Bernd Waibel <waebbl-gentoo@posteo.net>
+Date: Tue, 27 Sep 2022 07:29:11 +0200
+Subject: [PATCH] drop failing testDwaLookups
+
+On x86_32 testDwaLookups fails
+
+Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>
+--- a/src/test/OpenEXRTest/main.cpp
++++ b/src/test/OpenEXRTest/main.cpp
+@@ -65,7 +65,6 @@
+ #include "testDwaCompressorSimd.h"
+ #include "testRle.h"
+ #include "testB44ExpLogTable.h"
+-#include "testDwaLookups.h"
+ #include "testIDManifest.h"
+ 
+ #include "tmpDir.h"
+@@ -229,7 +228,6 @@ main (int argc, char *argv[])
+     TEST (testDwaCompressorSimd, "basic");
+     TEST (testRle, "core");
+     TEST (testB44ExpLogTable, "core");
+-    TEST (testDwaLookups, "core");
+     TEST (testIDManifest, "core");
+ 
+     // NB: If you add a test here, make sure to enumerate it in the
+-- 
+2.37.3
+

--- a/media-libs/openexr/openexr-3.1.5.ebuild
+++ b/media-libs/openexr/openexr-3.1.5.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit cmake
+inherit cmake flag-o-matic
 
 MY_PN=OpenEXR
 
@@ -43,10 +43,18 @@ src_prepare() {
 	sed -e "s:/var/tmp/:${T}:" \
 		-i "${S}"/src/test/${MY_PN}{,Fuzz,Util}Test/tmpDir.h || die "failed to set temp path for tests"
 
+	if use x86; then
+		eapply "${FILESDIR}"/${P}-drop-failing-testDwaLookups.patch
+	fi
+
 	cmake_src_prepare
 }
 
 src_configure() {
+	if use x86; then
+		replace-cpu-flags native i686
+	fi
+
 	local mycmakeargs=(
 		-DBUILD_TESTING=$(usex test)
 		-DDOCS=$(usex doc)


### PR DESCRIPTION
The package can fail to build on x86_32 if -march=native is set. This sets the -mf16c intrinsic which isn't available on every x86_32 arch. The patch replaces -march=native with -march=i686 if x86 is used.

Also disable a failing test for x86.

Closes: https://bugs.gentoo.org/840580
Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>