### PR TITLE
sys-libs/libomp:

### DIFF
--- a/sys-libs/libomp/libomp-13.0.1.ebuild
+++ b/sys-libs/libomp/libomp-13.0.1.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 
 PYTHON_COMPAT=( python3_{8..10} )
-inherit cmake-multilib linux-info llvm llvm.org python-any-r1
+inherit flag-o-matic cmake-multilib linux-info llvm llvm.org python-any-r1
 
 DESCRIPTION="OpenMP runtime library for LLVM/clang compiler"
 HOMEPAGE="https://openmp.llvm.org"
@@ -75,6 +75,8 @@ pkg_setup() {
 }
 
 multilib_src_configure() {
+	filter-lto # LTO causes issues in other packages building https://bugs.gentoo.org/870127
+
 	# LLVM_ENABLE_ASSERTIONS=NO does not guarantee this for us, #614844
 	use debug || local -x CPPFLAGS="${CPPFLAGS} -DNDEBUG"
 

--- a/sys-libs/libomp/libomp-14.0.6-r1.ebuild
+++ b/sys-libs/libomp/libomp-14.0.6-r1.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 PYTHON_COMPAT=( python3_{8..10} )
-inherit cmake-multilib linux-info llvm llvm.org python-any-r1
+inherit flag-o-matic cmake-multilib linux-info llvm llvm.org python-any-r1
 
 DESCRIPTION="OpenMP runtime library for LLVM/clang compiler"
 HOMEPAGE="https://openmp.llvm.org"
@@ -83,6 +83,8 @@ pkg_setup() {
 }
 
 multilib_src_configure() {
+	filter-lto # LTO causes issues in other packages building https://bugs.gentoo.org/870127
+
 	# LLVM_ENABLE_ASSERTIONS=NO does not guarantee this for us, #614844
 	use debug || local -x CPPFLAGS="${CPPFLAGS} -DNDEBUG"
 

--- a/sys-libs/libomp/libomp-15.0.1.ebuild
+++ b/sys-libs/libomp/libomp-15.0.1.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 PYTHON_COMPAT=( python3_{8..11} )
-inherit cmake-multilib linux-info llvm llvm.org python-any-r1
+inherit flag-o-matic cmake-multilib linux-info llvm llvm.org python-any-r1
 
 DESCRIPTION="OpenMP runtime library for LLVM/clang compiler"
 HOMEPAGE="https://openmp.llvm.org"
@@ -76,6 +76,8 @@ pkg_setup() {
 }
 
 multilib_src_configure() {
+	filter-lto # LTO causes issues in other packages building https://bugs.gentoo.org/870127
+
 	# LLVM_ENABLE_ASSERTIONS=NO does not guarantee this for us, #614844
 	use debug || local -x CPPFLAGS="${CPPFLAGS} -DNDEBUG"
 

--- a/sys-libs/libomp/libomp-15.0.2.9999.ebuild
+++ b/sys-libs/libomp/libomp-15.0.2.9999.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 PYTHON_COMPAT=( python3_{8..11} )
-inherit cmake-multilib linux-info llvm llvm.org python-any-r1
+inherit flag-o-matic cmake-multilib linux-info llvm llvm.org python-any-r1
 
 DESCRIPTION="OpenMP runtime library for LLVM/clang compiler"
 HOMEPAGE="https://openmp.llvm.org"
@@ -76,6 +76,8 @@ pkg_setup() {
 }
 
 multilib_src_configure() {
+	filter-lto # LTO causes issues in other packages building https://bugs.gentoo.org/870127
+
 	# LLVM_ENABLE_ASSERTIONS=NO does not guarantee this for us, #614844
 	use debug || local -x CPPFLAGS="${CPPFLAGS} -DNDEBUG"
 

--- a/sys-libs/libomp/libomp-16.0.0.9999.ebuild
+++ b/sys-libs/libomp/libomp-16.0.0.9999.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 PYTHON_COMPAT=( python3_{8..11} )
-inherit cmake-multilib linux-info llvm llvm.org python-any-r1
+inherit flag-o-matic cmake-multilib linux-info llvm llvm.org python-any-r1
 
 DESCRIPTION="OpenMP runtime library for LLVM/clang compiler"
 HOMEPAGE="https://openmp.llvm.org"
@@ -76,6 +76,8 @@ pkg_setup() {
 }
 
 multilib_src_configure() {
+	filter-lto # LTO causes issues in other packages building https://bugs.gentoo.org/870127
+
 	# LLVM_ENABLE_ASSERTIONS=NO does not guarantee this for us, #614844
 	use debug || local -x CPPFLAGS="${CPPFLAGS} -DNDEBUG"
 

--- a/sys-libs/libomp/libomp-16.0.0_pre20220918.ebuild
+++ b/sys-libs/libomp/libomp-16.0.0_pre20220918.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 PYTHON_COMPAT=( python3_{8..11} )
-inherit cmake-multilib linux-info llvm llvm.org python-any-r1
+inherit flag-o-matic cmake-multilib linux-info llvm llvm.org python-any-r1
 
 DESCRIPTION="OpenMP runtime library for LLVM/clang compiler"
 HOMEPAGE="https://openmp.llvm.org"
@@ -76,6 +76,8 @@ pkg_setup() {
 }
 
 multilib_src_configure() {
+	filter-lto # LTO causes issues in other packages building https://bugs.gentoo.org/870127
+
 	# LLVM_ENABLE_ASSERTIONS=NO does not guarantee this for us, #614844
 	use debug || local -x CPPFLAGS="${CPPFLAGS} -DNDEBUG"
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/870127
Signed-off-by: Ian Jordan <immoloism@gmail.com>

 Changes to be committed:
	modified:   libomp-13.0.1.ebuild
	modified:   libomp-14.0.6-r1.ebuild
	modified:   libomp-15.0.1.ebuild
	modified:   libomp-15.0.2.9999.ebuild
	modified:   libomp-16.0.0.9999.ebuild
	modified:   libomp-16.0.0_pre20220918.ebuild

Filter LTO on sys-libs/libomp as it causes strange issues on the system like Firefox not building.