### PR TITLE
Firefox wayland pgo

### DIFF
--- a/gui-libs/wlroots/files/wlroots-0.15.1-tinywl-dont-crash-upon-missing-keyboard.patch
+++ b/gui-libs/wlroots/files/wlroots-0.15.1-tinywl-dont-crash-upon-missing-keyboard.patch
@@ -1,0 +1,55 @@
+From 7d950f3dac6cca62635d5e4ff2af33b35372f6db Mon Sep 17 00:00:00 2001
+From: Simon Ser <contact@emersion.fr>
+Date: Sat, 19 Mar 2022 14:00:43 +0100
+Subject: [PATCH] tinywl: don't crash when there is no keyboard
+
+Running with WLR_BACKENDS=headless, there is no keyboard device.
+Avoid crashes like so:
+
+    ../tinywl/tinywl.c:136:2: runtime error: member access within null pointer of type 'struct wlr_keyboard'
+    ../tinywl/tinywl.c:136:2: runtime error: member access within null pointer of type 'struct wlr_keyboard'
+    AddressSanitizer:DEADLYSIGNAL
+    =================================================================
+    ==331107==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000120 (pc 0x556ed03e4e99 bp 0x7ffce834bc10 sp 0x7ffce834bbb0 T0)
+    ==331107==The signal is caused by a READ memory access.
+    ==331107==Hint: address points to the zero page.
+        #0 0x556ed03e4e99 in focus_view ../tinywl/tinywl.c:136
+        #1 0x556ed03eb3be in xdg_toplevel_map ../tinywl/tinywl.c:603
+        #2 0x7f75d6f768db in wlr_signal_emit_safe ../util/signal.c:29
+        #3 0x7f75d6e9cac7 in xdg_surface_role_commit ../types/xdg_shell/wlr_xdg_surface.c:315
+        #4 0x7f75d6eb6944 in surface_commit_state ../types/wlr_compositor.c:466
+        #5 0x7f75d6eb7b02 in surface_handle_commit ../types/wlr_compositor.c:523
+        #6 0x7f75d5714d49  (/usr/lib/libffi.so.8+0x6d49)
+        #7 0x7f75d5714266  (/usr/lib/libffi.so.8+0x6266)
+        #8 0x7f75d68cb322  (/usr/lib/libwayland-server.so.0+0xd322)
+        #9 0x7f75d68c65cb  (/usr/lib/libwayland-server.so.0+0x85cb)
+        #10 0x7f75d68c91c9 in wl_event_loop_dispatch (/usr/lib/libwayland-server.so.0+0xb1c9)
+        #11 0x7f75d68c6d36 in wl_display_run (/usr/lib/libwayland-server.so.0+0x8d36)
+        #12 0x556ed03eef55 in main ../tinywl/tinywl.c:905
+        #13 0x7f75d5d2330f in __libc_start_call_main (/usr/lib/libc.so.6+0x2d30f)
+        #14 0x7f75d5d233c0 in __libc_start_main@GLIBC_2.2.5 (/usr/lib/libc.so.6+0x2d3c0)
+        #15 0x556ed03e46e4 in _start (/home/simon/src/wlroots/build/tinywl/tinywl+0x136e4)
+---
+ tinywl/tinywl.c | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/tinywl/tinywl.c b/tinywl/tinywl.c
+index dd442aac..8796e9df 100644
+--- a/tinywl/tinywl.c
++++ b/tinywl/tinywl.c
+@@ -130,8 +130,10 @@ static void focus_view(struct tinywl_view *view, struct wlr_surface *surface) {
+ 	 * track of this and automatically send key events to the appropriate
+ 	 * clients without additional work on your part.
+ 	 */
+-	wlr_seat_keyboard_notify_enter(seat, view->xdg_surface->surface,
+-		keyboard->keycodes, keyboard->num_keycodes, &keyboard->modifiers);
++	if (keyboard != NULL) {
++		wlr_seat_keyboard_notify_enter(seat, view->xdg_surface->surface,
++			keyboard->keycodes, keyboard->num_keycodes, &keyboard->modifiers);
++	}
+ }
+ 
+ static void keyboard_handle_modifiers(
+-- 
+2.36.1
+

--- a/gui-libs/wlroots/metadata.xml
+++ b/gui-libs/wlroots/metadata.xml
@@ -21,6 +21,7 @@
 		wlroots is developed under the direction of the <pkg>gui-wm/sway</pkg> project.
 	</longdescription>
 	<use>
+		<flag name="tinywl">Install the minimal wayland client, tinywl</flag>
 		<flag name="vulkan">Enable support for the vulkan backend renderer</flag>
 		<flag name="x11-backend">Enable support for handling input/output devices through <pkg>x11-libs/libxcb</pkg></flag>
 		<flag name="X">Enable support for X11 applications (XWayland)</flag>

--- a/gui-libs/wlroots/wlroots-0.15.1-r1.ebuild
+++ b/gui-libs/wlroots/wlroots-0.15.1-r1.ebuild
@@ -1,0 +1,83 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit meson
+
+DESCRIPTION="Pluggable, composable, unopinionated modules for building a Wayland compositor"
+HOMEPAGE="https://gitlab.freedesktop.org/wlroots/wlroots"
+
+if [[ ${PV} == 9999 ]]; then
+	EGIT_REPO_URI="https://gitlab.freedesktop.org/${PN}/${PN}.git"
+	inherit git-r3
+	SLOT="0/9999"
+else
+	SRC_URI="https://gitlab.freedesktop.org/${PN}/${PN}/-/archive/${PV}/${P}.tar.gz"
+	KEYWORDS="~amd64 ~arm64 ~loong ~ppc64 ~riscv ~x86"
+	SLOT="0/$(ver_cut 2)"
+fi
+
+LICENSE="MIT"
+IUSE="tinywl vulkan x11-backend X"
+
+DEPEND="
+	>=dev-libs/libinput-1.14.0:0=
+	>=dev-libs/wayland-1.20.0
+	>=dev-libs/wayland-protocols-1.24
+	media-libs/mesa[egl(+),gles2,gbm(+)]
+	sys-auth/seatd:=
+	virtual/libudev
+	vulkan? (
+		dev-util/glslang:0=
+		dev-util/vulkan-headers:0=
+		media-libs/vulkan-loader:0=
+	)
+	>=x11-libs/libdrm-2.4.109:0=
+	x11-libs/libxkbcommon
+	x11-libs/pixman
+	x11-backend? ( x11-libs/libxcb:0= )
+	X? (
+		x11-base/xwayland
+		x11-libs/libxcb:0=
+		x11-libs/xcb-util-image
+		x11-libs/xcb-util-wm
+	)
+"
+RDEPEND="
+	${DEPEND}
+"
+BDEPEND="
+	>=dev-libs/wayland-protocols-1.24
+	>=dev-util/meson-0.60.0
+	dev-util/wayland-scanner
+	virtual/pkgconfig
+"
+
+PATCHES=( "${FILESDIR}"/wlroots-0.15.1-tinywl-dont-crash-upon-missing-keyboard.patch )
+
+src_configure() {
+	# xcb-util-errors is not on Gentoo Repository (and upstream seems inactive?)
+	local emesonargs=(
+		"-Dxcb-errors=disabled"
+		$(meson_use tinywl examples)
+		-Drenderers=$(usex vulkan 'gles2,vulkan' gles2)
+		-Dxwayland=$(usex X enabled disabled)
+		-Dbackends=drm,libinput$(usex x11-backend ',x11' '')
+	)
+
+	meson_src_configure
+}
+
+src_install() {
+	meson_src_install
+
+	if use tinywl; then
+		dobin "${BUILD_DIR}"/tinywl/tinywl
+	fi
+}
+
+pkg_postinst() {
+	elog "You must be in the input group to allow your compositor"
+	elog "to access input devices via libinput."
+}

--- a/gui-libs/wlroots/wlroots-9999.ebuild
+++ b/gui-libs/wlroots/wlroots-9999.ebuild
@@ -19,7 +19,7 @@ else
 fi
 
 LICENSE="MIT"
-IUSE="vulkan x11-backend X"
+IUSE="tinywl vulkan x11-backend X"
 
 DEPEND="
 	>=dev-libs/libinput-1.14.0:0=
@@ -54,17 +54,27 @@ BDEPEND="
 	virtual/pkgconfig
 "
 
+PATCHES=( "${FILESDIR}"/wlroots-0.15.1-tinywl-dont-crash-upon-missing-keyboard.patch )
+
 src_configure() {
 	# xcb-util-errors is not on Gentoo Repository (and upstream seems inactive?)
 	local emesonargs=(
 		"-Dxcb-errors=disabled"
-		"-Dexamples=false"
+		$(meson_use tinywl examples)
 		-Drenderers=$(usex vulkan 'gles2,vulkan' gles2)
 		-Dxwayland=$(usex X enabled disabled)
 		-Dbackends=drm,libinput$(usex x11-backend ',x11' '')
 	)
 
 	meson_src_configure
+}
+
+src_install() {
+	meson_src_install
+
+	if use tinywl; then
+		dobin "${BUILD_DIR}"/tinywl/tinywl
+	fi
 }
 
 pkg_postinst() {

--- a/www-client/firefox/firefox-105.0.1.ebuild
+++ b/www-client/firefox/firefox-105.0.1.ebuild
@@ -76,7 +76,6 @@ REQUIRED_USE="debug? ( !system-av1 )
 
 # Firefox-only REQUIRED_USE flags
 REQUIRED_USE+=" || ( X wayland )"
-REQUIRED_USE+=" pgo? ( X )"
 REQUIRED_USE+=" screencast? ( wayland )"
 
 FF_ONLY_DEPEND="!www-client/firefox:0
@@ -109,7 +108,10 @@ BDEPEND="${PYTHON_DEPS}
 		)
 	)
 	amd64? ( >=dev-lang/nasm-2.14 )
-	x86? ( >=dev-lang/nasm-2.14 )"
+	x86? ( >=dev-lang/nasm-2.14 )
+	pgo? (
+		wayland? ( >=gui-libs/wlroots-0.15.1-r1[tinywl] )
+	)"
 COMMON_DEPEND="${FF_ONLY_DEPEND}
 	dev-libs/atk
 	dev-libs/expat
@@ -406,6 +408,27 @@ mozconfig_use_with() {
 
 	local flag=$(use_with "${@}")
 	mozconfig_add_options_ac "$(use ${1} && echo +${1} || echo -${1})" "${flag}"
+}
+
+virtwl() {
+	debug-print-function ${FUNCNAME} "$@"
+
+	[[ $# -lt 1 ]] && die "${FUNCNAME} needs at least one argument"
+	[[ -n $XDG_RUNTIME_DIR ]] || die "${FUNCNAME} needs XDG_RUNTIME_DIR to be set; try xdg_environment_reset"
+	tinywl -h >/dev/null || die 'tinywl -h failed'
+
+	# TODO: don't run addpredict in utility function. WLR_RENDERER=pixman doesn't work
+	addpredict /dev/dri
+	local VIRTWL VIRTWL_PID
+	coproc VIRTWL { WLR_BACKENDS=headless exec tinywl -s 'echo $WAYLAND_DISPLAY; read _; kill $PPID'; }
+	local -x WAYLAND_DISPLAY
+	read WAYLAND_DISPLAY <&${VIRTWL[0]}
+
+	debug-print "${FUNCNAME}: $@"
+	"$@"
+
+	[[ -n $VIRTWL_PID ]] || die "tinywl exited unexpectedly"
+	exec {VIRTWL[0]}<&- {VIRTWL[1]}>&-
 }
 
 pkg_pretend() {
@@ -1011,16 +1034,20 @@ src_configure() {
 src_compile() {
 	local virtx_cmd=
 
-	if use pgo ; then
-		virtx_cmd=virtx
-
+	if use pgo; then
 		# Reset and cleanup environment variables used by GNOME/XDG
 		gnome2_environment_reset
 
 		addpredict /root
+
+		if ! use X; then
+			virtx_cmd=virtwl
+		else
+			virtx_cmd=virtx
+		fi
 	fi
 
-	if ! use X && use wayland; then
+	if ! use X; then
 		local -x GDK_BACKEND=wayland
 	else
 		local -x GDK_BACKEND=x11


### PR DESCRIPTION
```diff
--- wlroots-0.15.1.ebuild	2022-09-28 18:38:29.916445934 +0300
+++ wlroots-0.15.1-r1.ebuild	2022-09-28 18:39:31.741510599 +0300
@@ -14,12 +14,12 @@
 	SLOT="0/9999"
 else
 	SRC_URI="https://gitlab.freedesktop.org/${PN}/${PN}/-/archive/${PV}/${P}.tar.gz"
-	KEYWORDS="amd64 arm64 ~loong ~ppc64 ~riscv x86"
+	KEYWORDS="~amd64 ~arm64 ~loong ~ppc64 ~riscv ~x86"
 	SLOT="0/$(ver_cut 2)"
 fi
 
 LICENSE="MIT"
-IUSE="vulkan x11-backend X"
+IUSE="tinywl vulkan x11-backend X"
 
 DEPEND="
 	>=dev-libs/libinput-1.14.0:0=
@@ -54,11 +54,13 @@
 	virtual/pkgconfig
 "
 
+PATCHES=( "${FILESDIR}"/wlroots-0.15.1-tinywl-dont-crash-upon-missing-keyboard.patch )
+
 src_configure() {
 	# xcb-util-errors is not on Gentoo Repository (and upstream seems inactive?)
 	local emesonargs=(
 		"-Dxcb-errors=disabled"
-		"-Dexamples=false"
+		$(meson_use tinywl examples)
 		-Drenderers=$(usex vulkan 'gles2,vulkan' gles2)
 		-Dxwayland=$(usex X enabled disabled)
 		-Dbackends=drm,libinput$(usex x11-backend ',x11' '')
@@ -67,6 +69,14 @@
 	meson_src_configure
 }
 
+src_install() {
+	meson_src_install
+
+	if use tinywl; then
+		dobin "${BUILD_DIR}"/tinywl/tinywl
+	fi
+}
+
 pkg_postinst() {
 	elog "You must be in the input group to allow your compositor"
 	elog "to access input devices via libinput."
```