### PR TITLE
profiles/arch: invert USE=tcmalloc to masked-by-default

### DIFF
--- a/profiles/arch/amd64/use.mask
+++ b/profiles/arch/amd64/use.mask
@@ -4,6 +4,10 @@
 # Unmask the flag which corresponds to ARCH.
 -amd64
 
+# matoro <matoro_gentoo@matoro.tk> (2022-09-29)
+# dev-util/google-perftools is supported here
+-tcmalloc
+
 # Matt Turner <mattst88@gentoo.org> (2022-04-16)
 # dev-util/sysprof-capture is keyworded on amd64
 -sysprof

--- a/profiles/arch/arm/use.mask
+++ b/profiles/arch/arm/use.mask
@@ -4,6 +4,10 @@
 # Unmask the flag which corresponds to ARCH.
 -arm
 
+# matoro <matoro_gentoo@matoro.tk> (2022-09-29)
+# dev-util/google-perftools is supported here
+-tcmalloc
+
 # Michał Górny <mgorny@gentoo.org> (2021-01-07)
 # Prebuilt kernels are supported here.
 -dist-kernel

--- a/profiles/arch/arm64/use.mask
+++ b/profiles/arch/arm64/use.mask
@@ -4,6 +4,10 @@
 # Unmask the flag which corresponds to ARCH.
 -arm64
 
+# matoro <matoro_gentoo@matoro.tk> (2022-09-29)
+# dev-util/google-perftools is supported here
+-tcmalloc
+
 # Mike Gilbert <floppym@gentoo.org> (2022-08-31)
 # Requires the following packages to be keyworded/stable:
 # sys-libs/libapparmor

--- a/profiles/arch/base/use.mask
+++ b/profiles/arch/base/use.mask
@@ -1,6 +1,11 @@
 # Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# matoro <matoro_gentoo@matoro.tk> (2022-09-29)
+# Pulls in dev-util/google-perftools, which is arch-specific
+# Unmask on supported arches.
+tcmalloc
+
 # Michał Górny <mgorny@gentoo.org> (2021-01-07)
 # Prebuilt kernels are not supported on all architectures.
 dist-kernel

--- a/profiles/arch/hppa/use.mask
+++ b/profiles/arch/hppa/use.mask
@@ -98,10 +98,6 @@ luajittex
 # Mask USE=systemtap generally until proper kernel support is in place
 systemtap
 
-# Jeroen Roovers <jer@gentoo.org> (2014-05-20)
-# USE=tcmalloc needs dev-util/google-perftools
-tcmalloc
-
 # Chí-Thanh Christopher Nguyễn <chithanh@gentoo.org> (2013-11-10)
 # sys-devel/llvm is not keyworded, bug #320221
 llvm

--- a/profiles/arch/ia64/use.mask
+++ b/profiles/arch/ia64/use.mask
@@ -4,10 +4,6 @@
 # Unmask the flag which corresponds to ARCH.
 -ia64
 
-# Sam James <sam@gentoo.org> (2022-07-30)
-# dev-util/google-perftools not keyworded here
-tcmalloc
-
 # Sam James <sam@gentoo.org> (2022-07-21)
 # Untested.
 ieee1394

--- a/profiles/arch/mips/use.mask
+++ b/profiles/arch/mips/use.mask
@@ -25,10 +25,6 @@ networkmanager
 # sci-geosciences/gpsd is not keyworded here.
 gps
 
-# Brian Evans <grknight@gentoo.org> (2018-01-15)
-# Mask tcmalloc as dev-util/google-perftools is unavailable
-tcmalloc
-
 # James Le Cuirot <chewi@gentoo.org> (2017-06-29)
 # Unmask as this profile is big endian.
 -big-endian

--- a/profiles/arch/powerpc/use.mask
+++ b/profiles/arch/powerpc/use.mask
@@ -4,6 +4,10 @@
 # PPC Specific use flags
 #
 
+# matoro <matoro_gentoo@matoro.tk> (2022-09-29)
+# dev-util/google-perftools is supported here
+-tcmalloc
+
 # Georgy Yakovlev <gyakovlev@gentoo.org> (2021-06-06)
 # XEN does not support ppc/ppc64 yet
 xen

--- a/profiles/arch/riscv/use.mask
+++ b/profiles/arch/riscv/use.mask
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 Gentoo Authors
+# Copyright 2019-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # Unmask the flag which corresponds to ARCH.
@@ -6,6 +6,10 @@
 
 # Unmask systemd
 -systemd
+
+# matoro <matoro_gentoo@matoro.tk> (2022-09-29)
+# dev-util/google-perftools is supported here
+-tcmalloc
 
 # Yixun Lan <dlan@gentoo.org> (2021-05-19)
 # Unmask for more testing

--- a/profiles/arch/s390/use.mask
+++ b/profiles/arch/s390/use.mask
@@ -13,10 +13,6 @@
 mongodb
 
 # Sam James <sam@gentoo.org> (2022-04-24)
-# Avoid unkeyworded dev-util/google-perftools
-tcmalloc
-
-# Sam James <sam@gentoo.org> (2022-04-24)
 # Desktopy stacks not currently keyworded
 alsa
 gstreamer

--- a/profiles/arch/sparc/use.mask
+++ b/profiles/arch/sparc/use.mask
@@ -153,7 +153,6 @@ gts
 metalink
 tremor
 fdk
-tcmalloc
 jemalloc
 zmq
 

--- a/profiles/arch/x86/use.mask
+++ b/profiles/arch/x86/use.mask
@@ -4,6 +4,10 @@
 # Unmask the flag which corresponds to ARCH.
 -x86
 
+# matoro <matoro_gentoo@matoro.tk> (2022-09-29)
+# dev-util/google-perftools is supported here
+-tcmalloc
+
 # Matt Turner <mattst88@gentoo.org> (2022-04-16)
 # dev-util/sysprof-capture is keyworded on x86
 -sysprof


### PR DESCRIPTION
For packages that start with KEYWORDS="-* ...", i.e., require non-trivial architecture-specific implementations, we should be masking by default and unmasking on explicitly-supported arches to avoid trashing exp profiles.