### PR TITLE
app-shells/starship: Filter LTO

### DIFF
--- a/app-shells/starship/starship-1.10.2.ebuild
+++ b/app-shells/starship/starship-1.10.2.ebuild
@@ -379,7 +379,7 @@ CRATES="
 	zvariant_derive-3.4.1
 "
 
-inherit cargo
+inherit cargo flag-o-matic
 
 DESCRIPTION="The minimal, blazing-fast, and infinitely customizable prompt for any shell"
 HOMEPAGE="https://starship.rs/"
@@ -398,6 +398,7 @@ BDEPEND=">=virtual/rust-1.59"
 QA_FLAGS_IGNORED="usr/bin/starship"
 
 src_configure() {
+	filter-lto # Bug https://bugs.gentoo.org/869758
 	export PKG_CONFIG_ALLOW_CROSS=1
 	export OPENSSL_NO_VENDOR=true
 


### PR DESCRIPTION
As Ionen highlighted in the bug, GCC LTO causes issues with Rust packages.

As upstream already have it set to build with LTO anyway then I think filtering is the best way forward as the user is saved from the papercut while getting the same outcome they wanted originally.

I have only applied this to the	latest package as I can't see anyone using the older versions so these should have a	discussion about being removed in my opinion.

Closes: https://bugs.gentoo.org/869758
Signed-off-by: Ian Jordan <immoloism@gmail.com>

 Changes to be committed:
	modified:   app-shells/starship/starship-1.10.2.ebuild