### PR TITLE
net-p2p/amule: fix build with gcc-11 and musl

### DIFF
--- a/net-p2p/amule/amule-2.3.3.ebuild
+++ b/net-p2p/amule/amule-2.3.3.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 WX_GTK_VER="3.0-gtk3"
 
 inherit wxwidgets xdg-utils
@@ -50,6 +50,7 @@ BDEPEND="
 
 PATCHES=(
 	"${FILESDIR}/${PN}-2.3.2-disable-version-check.patch"
+	"${FILESDIR}/${PN}-2.3.3-fix-exception.patch"
 )
 
 pkg_setup() {

--- a/net-p2p/amule/amule-9999.ebuild
+++ b/net-p2p/amule/amule-9999.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 WX_GTK_VER="3.0-gtk3"
 
 inherit wxwidgets xdg-utils
@@ -49,6 +49,8 @@ BDEPEND="
 "
 
 PATCHES=(
+	"${FILESDIR}/${PN}-2.3.2-disable-version-check.patch"
+	"${FILESDIR}/${PN}-2.3.3-fix-exception.patch"
 )
 
 pkg_setup() {

--- a/net-p2p/amule/files/amule-2.3.3-fix-exception.patch
+++ b/net-p2p/amule/files/amule-2.3.3-fix-exception.patch
@@ -1,0 +1,12 @@
+diff --git a/src/libs/common/MuleDebug.cpp b/src/libs/common/MuleDebug.cpp
+index 4b023815c..19c172e61 100644
+--- a/src/libs/common/MuleDebug.cpp
++++ b/src/libs/common/MuleDebug.cpp
+@@ -55,6 +55,7 @@
+ #endif
+ 
+ #include <vector>
++#include <exception>
+ 
+ 
+ /**


### PR DESCRIPTION
Also update EAPI 7 -> 8 and apply pathes to the live version.

Closes: https://bugs.gentoo.org/836739
Closes: https://bugs.gentoo.org/872263