### PR TITLE
profiles/arch/ia64: mask net-misc/chrony[html]

### DIFF
--- a/profiles/arch/ia64/package.use.mask
+++ b/profiles/arch/ia64/package.use.mask
@@ -1,6 +1,10 @@
 # Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# matoro <matoro_gentoo@matoro.tk> (2022-09-30)
+# No ruby on ia64 for dev-ruby/asciidoctor
+net-misc/chrony html
+
 # Arthur Zamarin <arthurzam@gentoo.org> (2022-08-15)
 # deps not keyworded
 dev-util/pkgcheck emacs


### PR DESCRIPTION
No ruby on ia64 for dev-ruby/asciidoctor