### PR TITLE
games-action/polymc: fix live ebuild and git fallback URL

### DIFF
--- a/games-action/polymc/polymc-1.4.2-r2.ebuild
+++ b/games-action/polymc/polymc-1.4.2-r2.ebuild
@@ -13,7 +13,6 @@ if [[ ${PV} == 9999 ]]; then
 
 	EGIT_REPO_URI="
 		https://github.com/PolyMC/PolyMC
-		https://github.com/PolyMC/libnbtplusplus
 	"
 
 	EGIT_SUBMODULES=( 'depends/libnbtplusplus' )

--- a/games-action/polymc/polymc-9999.ebuild
+++ b/games-action/polymc/polymc-9999.ebuild
@@ -13,7 +13,6 @@ if [[ ${PV} == 9999 ]]; then
 
 	EGIT_REPO_URI="
 		https://github.com/PolyMC/PolyMC
-		https://github.com/PolyMC/libnbtplusplus
 	"
 
 	EGIT_SUBMODULES=( 'depends/libnbtplusplus' )

--- a/games-action/polymc/polymc-9999.ebuild
+++ b/games-action/polymc/polymc-9999.ebuild
@@ -15,7 +15,8 @@ if [[ ${PV} == 9999 ]]; then
 		https://github.com/PolyMC/PolyMC
 	"
 
-	EGIT_SUBMODULES=( 'depends/libnbtplusplus' )
+	# TODO: Add tomlplusplus as a system library, like quazip
+	EGIT_SUBMODULES=( '*' '-libraries/quazip' )
 else
 	MY_PN="PolyMC"
 
@@ -33,6 +34,7 @@ fi
 # Apache-2.0 for MultiMC (PolyMC is forked from it)
 # GPL-3 for PolyMC
 # LGPL-3+ for libnbtplusplus
+# MIT for tomlplusplus
 # See the rest of PolyMC's libraries at https://github.com/PolyMC/PolyMC/tree/develop/libraries
 LICENSE="Apache-2.0 BSD BSD-2 GPL-2+ GPL-3 ISC LGPL-2.1+ LGPL-3+ MIT"
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/872248
Signed-off-by: Thiago Donato Ferreira <flowlnlnln@gmail.com>

I didn't change the `EGIT_SUBMODULES` in the 1.4.2 ebuild since it's already de-synced with the live one, and the comments/TODO don't hold true for it, so it's probably easier to just let 1.4.2 be like that, and base the next version on the live ebuild directly

the TODO added is due to the fact [tomlplusplus](https://github.com/marzer/tomlplusplus) is not packaged in the main repo yet AFAIK