### PR TITLE
app-crypt/gcr: remove systemd workaround

### DIFF
--- a/app-crypt/gcr/gcr-3.41.1-r1.ebuild
+++ b/app-crypt/gcr/gcr-3.41.1-r1.ebuild
@@ -79,13 +79,6 @@ src_test() {
 src_install() {
 	meson_src_install
 
-	# These files are installed by gcr:4
-	rm \
-		"${ED}"/usr/libexec/gcr-ssh-agent \
-		"${ED}"/usr/lib/systemd/user/gcr-ssh-agent.service \
-		"${ED}"/usr/lib/systemd/user/gcr-ssh-agent.socket \
-		|| die
-
 	if use gtk-doc; then
 		mkdir -p "${ED}"/usr/share/gtk-doc/html/ || die
 		mv "${ED}"/usr/share/doc/{gck-1,gcr-3,gcr-ui-3} "${ED}"/usr/share/gtk-doc/html/ || die


### PR DESCRIPTION
A workaround was added to remove systemd
init files that are not actually added on
non-systemd causing install to fall.

If this creates an issue for systemd systems
file a bug and fix this properly with a useflag.

Closes: https://bugs.gentoo.org/873895
Signed-off-by: Joe Kappus <joe@wt.gd>