### PR TITLE
net-libs/libpcap: add test

### DIFF
--- a/net-libs/libpcap/libpcap-1.10.1-r2.ebuild
+++ b/net-libs/libpcap/libpcap-1.10.1-r2.ebuild
@@ -25,7 +25,8 @@ fi
 
 LICENSE="BSD"
 SLOT="0"
-IUSE="bluetooth dbus netlink rdma remote static-libs usb yydebug"
+IUSE="bluetooth dbus netlink rdma remote static-libs test usb yydebug"
+RESTRICT="!test? ( test )"
 
 RDEPEND="
 	bluetooth? ( net-wireless/bluez:=[${MULTILIB_USEDEP}] )
@@ -83,6 +84,11 @@ multilib_src_configure() {
 
 multilib_src_compile() {
 	emake all shared
+	use test && emake testprogs
+}
+
+multilib_src_test() {
+	testprogs/findalldevstest || die
 }
 
 multilib_src_install_all() {


### PR DESCRIPTION
There's not really a test suite upstream (see mentioned link).  There's a handful of "test programs" (which we at least test building and linking with this change), but this one (findalldevstest) is the only one that is actually run (under valgrind) in upstream CI.  On the upside, it should be rather reproducible since only the loopback interface will ever be exposed inside the portage network sandbox.

See: https://github.com/the-tcpdump-group/libpcap/issues/1012