### PR TITLE
sci-visualization/paraview: specify qt5 qml dir

### DIFF
--- a/sci-visualization/paraview/paraview-5.10.1-r1.ebuild
+++ b/sci-visualization/paraview/paraview-5.10.1-r1.ebuild
@@ -171,6 +171,7 @@ src_configure() {
 		-DModule_pqPython="$(usex qt5 "$(usex python)" "off")"
 		-DVTK_USE_NVCONTROL="$(usex nvcontrol)"
 		-DVTK_GROUP_ENABLE_Qt="$(usex qt5 YES NO)"
+		-DCMAKE_INSTALL_QMLDIR="${EPREFIX}/usr/$(get_libdir)/qt5/qml"
 
 		# sqlite
 		-DVTK_MODULE_ENABLE_VTK_sqlite="$(usex sqlite YES NO)"


### PR DESCRIPTION
By specifying this variable, cmake will install qml plugin into the correct location.

Closes: https://bugs.gentoo.org/847376
Signed-off-by: Yiyang Wu <xgreenlandforwyy@gmail.com>