### PR TITLE
dev-python/ujson: Find the DC include dir in prefix

### DIFF
--- a/dev-python/ujson/ujson-5.4.0.ebuild
+++ b/dev-python/ujson/ujson-5.4.0.ebuild
@@ -35,7 +35,7 @@ BDEPEND="
 distutils_enable_tests pytest
 
 src_configure() {
-	export UJSON_BUILD_DC_INCLUDES="/usr/include/double-conversion"
+	export UJSON_BUILD_DC_INCLUDES="${EPREFIX}/usr/include/double-conversion"
 	export UJSON_BUILD_DC_LIBS="-ldouble-conversion"
 	export UJSON_BUILD_NO_STRIP=1
 }

--- a/dev-python/ujson/ujson-5.5.0.ebuild
+++ b/dev-python/ujson/ujson-5.5.0.ebuild
@@ -35,7 +35,7 @@ BDEPEND="
 distutils_enable_tests pytest
 
 src_configure() {
-	export UJSON_BUILD_DC_INCLUDES="/usr/include/double-conversion"
+	export UJSON_BUILD_DC_INCLUDES="${EPREFIX}/usr/include/double-conversion"
 	export UJSON_BUILD_DC_LIBS="-ldouble-conversion"
 	export UJSON_BUILD_NO_STRIP=1
 }


### PR DESCRIPTION
ujson fails to build in Gentoo prefix because the specified UJSON_BUILD_DC_INCLUDES does not contain ${EPREFIX}

Signed-off-by: Yiyang Wu <xgreenlandforwyy@gmail.com>