### PR TITLE
profiles/features/musl: mask net-im/slack

### DIFF
--- a/profiles/features/musl/package.mask
+++ b/profiles/features/musl/package.mask
@@ -1,6 +1,10 @@
 # Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Vladimir Pavljuchenkov <spiderx@spiderx.dp.ua> (2022-10-02)
+# Binary package linked against glibc, bug #832485.
+net-im/slack
+
 # Petr Vaněk <arkamar@atlas.cz> (2022-09-23)
 # Musl does not implement rresvport function, bugs #713810 and #713376.
 app-shells/pdsh
@@ -23,10 +27,6 @@ sys-apps/uutils
 # Andrew Ammerlaan <andrewammerlaan@gentoo.org> (2022-09-06)
 # Binary package linked against glibc
 games-action/minecraft-launcher
-
-# Vladimir Pavljuchenkov <spiderx@spiderx.dp.ua> (2022-08-21)
-# Binary package linked against glibc, bug #832607.
-net-p2p/resilio-sync
 
 # Mike Gilbert <floppym@gentoo.org> (2022-08-01)
 # Fails to build.


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/832485

Signed-off-by: Vladimir Pavljuchenkov (SpiderX) <spiderx@spiderx.dp.ua>