### PR TITLE
app-text/dblatex: add self as dep for tests

### DIFF
--- a/app-text/dblatex/dblatex-0.3.12.ebuild
+++ b/app-text/dblatex/dblatex-0.3.12.ebuild
@@ -14,7 +14,8 @@ SRC_URI="https://downloads.sourceforge.net/project/dblatex/dblatex/${P}/${PN}3-$
 LICENSE="GPL-2+"
 SLOT="0"
 KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
-IUSE="inkscape"
+IUSE="inkscape test"
+RESTRICT="!test? ( test )"
 
 RDEPEND="
 	app-text/docbook-xml-dtd:4.5
@@ -34,6 +35,8 @@ RDEPEND="
 	inkscape? ( media-gfx/inkscape )
 "
 DEPEND="${RDEPEND}"
+BDEPEND="${RDEPEND}
+	test? ( ~${CATEGORY}/${P} )"
 
 S="${WORKDIR}/${PN}3-${PV}"
 


### PR DESCRIPTION
Missed this in https://github.com/gentoo/gentoo/pull/27224.