### PR TITLE
x11-themes/QGnomePlatform: make wayland optional

### DIFF
--- a/x11-themes/QGnomePlatform/QGnomePlatform-0.9.0.ebuild
+++ b/x11-themes/QGnomePlatform/QGnomePlatform-0.9.0.ebuild
@@ -11,12 +11,12 @@ SRC_URI="https://github.com/FedoraQt/QGnomePlatform/archive/${PV}.tar.gz -> ${P}
 KEYWORDS="~amd64 ~arm64 ~ppc64 ~x86"
 LICENSE="LGPL-2.1"
 SLOT="0"
-IUSE=""
+IUSE="wayland"
 
 RDEPEND="
 	dev-qt/qtdbus:5=
 	>=dev-qt/qtwidgets-5.15.2:5=
-	dev-qt/qtwayland:5=
+	wayland? ( dev-qt/qtwayland:5= )
 	dev-qt/qtx11extras:5=
 	gnome-base/gsettings-desktop-schemas
 	sys-apps/xdg-desktop-portal
@@ -29,6 +29,7 @@ BDEPEND="${RDEPEND}"
 src_configure() {
 	local mycmakeargs=(
 		-DUSE_QT6=false
+		-DDISABLE_DECORATION_SUPPORT="$(usex wayland false true)"
 	)
 	cmake_src_configure
 }


### PR DESCRIPTION
replaces https://github.com/gentoo/gentoo/pull/24691

```diff
--- a/x11-themes/QGnomePlatform/QGnomePlatform-0.9.0.ebuild
+++ b/x11-themes/QGnomePlatform/QGnomePlatform-0.9.0.ebuild
@@ -11,12 +11,12 @@ SRC_URI="https://github.com/FedoraQt/QGnomePlatform/archive/${PV}.tar.gz -> ${P}
 KEYWORDS="~amd64 ~arm64 ~ppc64 ~x86"
 LICENSE="LGPL-2.1"
 SLOT="0"
-IUSE=""
+IUSE="wayland"
 
 RDEPEND="
        dev-qt/qtdbus:5=
        >=dev-qt/qtwidgets-5.15.2:5=
-       dev-qt/qtwayland:5=
+               wayland? ( dev-qt/qtwayland:5= )
        dev-qt/qtx11extras:5=
        gnome-base/gsettings-desktop-schemas
        sys-apps/xdg-desktop-portal
@@ -29,6 +29,7 @@ BDEPEND="${RDEPEND}"
 src_configure() {
        local mycmakeargs=(
                -DUSE_QT6=false
+                       -DDISABLE_DECORATION_SUPPORT="$(usex wayland false true)"
        )
        cmake_src_configure
 }
```

