### PR TITLE
app-eselect/eselect-sh: Add 0.5.0

### DIFF
--- a/app-eselect/eselect-sh/eselect-sh-0.5.0.ebuild
+++ b/app-eselect/eselect-sh/eselect-sh-0.5.0.ebuild
@@ -1,0 +1,21 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DESCRIPTION="Manages the /bin/sh (POSIX shell) symlink"
+HOMEPAGE="https://wiki.gentoo.org/wiki/No_homepage"
+SRC_URI=""
+S=${WORKDIR}
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+IUSE=""
+
+RDEPEND="app-eselect/eselect-lib-bin-symlink"
+
+src_install() {
+	insinto /usr/share/eselect/modules
+	newins "${FILESDIR}"/sh.eselect-${PV} sh.eselect
+}

--- a/app-eselect/eselect-sh/files/sh.eselect-0.5.0
+++ b/app-eselect/eselect-sh/files/sh.eselect-0.5.0
@@ -1,0 +1,13 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+DESCRIPTION="Manage /bin/sh (POSIX shell) implementations"
+MAINTAINER="mgorny@gentoo.org"
+VERSION="0.5.0"
+
+SYMLINK_PATH=/bin/sh
+SYMLINK_TARGETS=( bash dash lksh mksh )
+SYMLINK_DESCRIPTION='POSIX shell'
+SYMLINK_CRUCIAL=1
+
+inherit bin-symlink


### PR DESCRIPTION
Adds support to set lksh as /bin/sh which preferred /bin/sh for mksh according to upstream.

 Using mksh as /bin/sh is only POSIX on 32-bit systems, but some may still prefer it as POSIX requires some undefined behavior which is respected with lksh.


I believe a new feature requires bumping the MINOR version?

https://semver.org/

Closes: https://github.com/gentoo/gentoo/pull/20787