### PR TITLE
sci-libs/vtk-9.1.0 - fix musl build

### DIFF
--- a/profiles/features/musl/package.use.mask
+++ b/profiles/features/musl/package.use.mask
@@ -1,6 +1,10 @@
 # Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Bernd Waibel <waebbl-gentoo@posteo.net> (2022-10-04)
+# Mask loguru until fixed upstream #873601
+sci-libs/vtk logging
+
 # Sam James <sam@gentoo.org> (2022-10-04)
 # sys-libs/libtermcap-compat is masked on musl
 dev-scheme/scm readline

--- a/sci-libs/vtk/metadata.xml
+++ b/sci-libs/vtk/metadata.xml
@@ -21,6 +21,7 @@
     <flag name="imaging">Building Imaging modules</flag>
     <flag name="json">Support for json formatted data</flag>
     <flag name="kits">Build kits in addition to modules</flag>
+    <flag name="logging">Enable the loguru logging module</flag>
     <flag name="offscreen">Offscreen rendering through OSMesa</flag>
     <flag name="pegtl">Use pegtl to build parsers</flag>
     <flag name="qt6">Use Qt6 packages instead of Qt5</flag>

--- a/sci-libs/vtk/vtk-9.1.0-r4.ebuild
+++ b/sci-libs/vtk/vtk-9.1.0-r4.ebuild
@@ -37,13 +37,12 @@ S="${WORKDIR}/VTK-${PV}"
 
 LICENSE="BSD LGPL-2"
 SLOT="0/${MY_PV}"
-# ~arm64 #864791
-KEYWORDS="~amd64 ~arm ~x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~amd64 ~arm ~arm64 ~x86 ~amd64-linux ~x86-linux"
 # TODO: Like to simplifiy these. Mostly the flags related to Groups, plus
 # maybe some flags related to Kits and a few other needed flags.
 IUSE="all-modules +boost cuda debug doc examples +ffmpeg +gdal imaging java
-	mpi mysql odbc openmp postgres python qt5 qt6 +rendering tbb test +threads
-	tk video_cards_nvidia views web"
+	logging mpi mysql odbc openmp postgres python qt5 qt6 +rendering tbb test
+	+threads tk video_cards_nvidia views web"
 
 RESTRICT="!test? ( test )"
 
@@ -294,6 +293,7 @@ src_configure() {
 		-DVTK_BUILD_EXAMPLES=$(usex examples ON OFF)
 
 		-DVTK_ENABLE_KITS=ON
+		-DVTK_ENABLE_LOGGING=$(usex logging ON OFF)
 		# defaults to ON: USE flag for this?
 		-DVTK_ENABLE_REMOTE_MODULES=OFF
 


### PR DESCRIPTION
**profiles: mask logging USE flag on sci-libs/vtk**

The loguru module doesn't build on musl. Mask it until it's fixed
upstream.

**sci-libs/vtk: fix build on musl**

- Add logging USE flag to be able to disable it for musl
- Re-keyword temporarily dropped arm64

Bug: https://bugs.gentoo.org/873601
Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>
