### PR TITLE
net-libs/c-client: clang-16 fixes; virtual/imap-c-client: treeclean

### DIFF
--- a/net-libs/c-client/c-client-2007f-r8.ebuild
+++ b/net-libs/c-client/c-client-2007f-r8.ebuild
@@ -1,0 +1,161 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit flag-o-matic libtool toolchain-funcs
+
+MY_PN=imap
+MY_P="${MY_PN}-${PV}"
+S=${WORKDIR}/${MY_P}
+
+CHAPPA_PL=115
+DESCRIPTION="UW IMAP c-client library"
+HOMEPAGE="http://www.washington.edu/imap/"
+SRC_URI="ftp://ftp.cac.washington.edu/imap/${MY_P}.tar.Z
+	chappa? ( mirror://gentoo/${P}-chappa-${CHAPPA_PL}-all.patch.gz )"
+
+LICENSE="Apache-2.0"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+IUSE="doc +ipv6 kerberos pam ssl static-libs topal chappa"
+
+RDEPEND="
+	ssl? (
+		dev-libs/openssl:0=
+	)
+	kernel_linux? (
+		pam? ( >=sys-libs/pam-0.72 )
+		!pam? ( virtual/libcrypt:= )
+	)
+	kerberos? ( app-crypt/mit-krb5 )
+"
+DEPEND="${RDEPEND}"
+
+PATCHES=(
+	# Apply a patch to only build the stuff we need for c-client
+	"${FILESDIR}/${PN}-2006k_GENTOO_Makefile.patch"
+
+	# Apply patch to add the compilation of a .so for PHP
+	# This was previously conditional, but is more widely useful.
+	"${FILESDIR}/${PN}-2006k_GENTOO_amd64-so-fix.patch"
+
+	# Respect LDFLAGS
+	"${FILESDIR}/${PN}-2007f-ldflags.patch"
+
+	# openssl-1.1 build fix #647616
+	"${FILESDIR}/${PN}-2007f-openssl-1.1.patch"
+
+	# build fix for -Werror=implicit-function-declaration and
+	# incompatible function pointer types, bug #870478
+	"${FILESDIR}/${PN}-2007f-implicit-declaration-fix.patch"
+	"${FILESDIR}/${PN}-2007f-scandir-callback-types.patch"
+)
+
+src_prepare() {
+	use topal && PATCHES+=( "${FILESDIR}/${P}-topal.patch" )
+
+	default
+
+	use chappa && eapply -p2 "${WORKDIR}/${P}-chappa-${CHAPPA_PL}-all.patch"
+
+	# Tarball packed with bad file perms
+	chmod -R u+rwX,go-w . || die "failed to fix permissions"
+
+	# lots of things need -fPIC, including various platforms, and this library
+	# generally should be built with it anyway.
+	append-flags -fPIC
+
+	# Modifications so we can build it optimally and correctly
+	sed \
+		-e "s:BASECFLAGS=\".*\":BASECFLAGS=:g" \
+		-e 's:SSLDIR=/usr/local/ssl:SSLDIR=/usr:g' \
+		-e 's:SSLCERTS=$(SSLDIR)/certs:SSLCERTS=/etc/ssl/certs:g' \
+		-i src/osdep/unix/Makefile \
+		|| die "failed to fix compiler flags and SSL paths in the Makefile"
+
+	# Make the build system more multilib aware
+	sed \
+		-e "s:^SSLLIB=\$(SSLDIR)/lib:SSLLIB=\$(SSLDIR)/$(get_libdir):" \
+		-e "s:^AFSLIB=\$(AFSDIR)/lib:AFSLIB=\$(AFSDIR)/$(get_libdir):" \
+		-i src/osdep/unix/Makefile \
+		|| die "failed to fix our libdir in the Makefile"
+
+	# Targets should use the Gentoo (ie linux) fs
+	sed -e '/^bsf:/,/^$/ s:ACTIVEFILE=.*:ACTIVEFILE=/var/lib/news/active:g' \
+		-i src/osdep/unix/Makefile \
+		|| die "failed to fix the FreeBSD ACTIVEFILE path in the Makefile"
+
+	# Remove the pesky checks about SSL stuff
+	sed -e '/read.*exit/d' -i Makefile \
+		|| die "failed to disable SSL warning in the Makefile"
+
+	sed -e "s:CC=cc:CC=$(tc-getCC):" \
+		-e "s:ARRC=ar:ARRC=$(tc-getAR):" \
+		-e "s:RANLIB=ranlib:RANLIB=$(tc-getRANLIB):" \
+		-i src/osdep/unix/Makefile \
+		|| die "failed to fix build flags support in the Makefile"
+
+	elibtoolize
+}
+
+src_compile() {
+	local mymake ipver ssltype target passwdtype
+	ipver='IP=4'
+	if use ipv6 ; then
+		ipver="IP=6"
+		touch ip6 || die "failed to create ip6 file"
+	fi
+	use ssl && ssltype="unix" || ssltype="none"
+	if use kernel_linux ; then
+		# Fall back to "slx" when USE=pam is not set. This ensures that
+		# we link in libcrypt to get the crypt() routine (bug #456928).
+		use pam && target=lnp passwdtype=pam || target=slx passwdtype=std
+	fi
+	use kerberos \
+		&& mymake="EXTRAAUTHENTICATORS=gss" \
+		&& EXTRALIBS="-lgssapi_krb5 -lkrb5 -lk5crypto -lcom_err" \
+	# no parallel builds supported!
+	emake -j1 SSLTYPE=${ssltype} $target \
+		PASSWDTYPE=${passwdtype} ${ipver} ${mymake} \
+		EXTRACFLAGS="${CFLAGS}" \
+		EXTRALDFLAGS="${LDFLAGS}" \
+		EXTRALIBS="${EXTRALIBS}" \
+		GSSDIR=/usr
+}
+
+src_install() {
+	if use static-libs; then
+		# Library binary
+		dolib.a c-client/c-client.a
+		dosym c-client.a "/usr/$(get_libdir)/libc-client.a"
+	fi
+
+	# Now the shared library
+	dolib.so c-client/libc-client.so.1.0.0
+
+	dosym libc-client.so.1.0.0 "/usr/$(get_libdir)/libc-client.so"
+	dosym libc-client.so.1.0.0 "/usr/$(get_libdir)/libc-client.so.1"
+
+	# Headers
+	insinto /usr/include/imap
+	doins src/osdep/unix/*.h
+	doins src/c-client/*.h
+	doins c-client/linkage.h
+	doins c-client/linkage.c
+	doins c-client/osdep.h
+
+	if use ssl; then
+		echo "  ssl_onceonlyinit ();" >> "${D}"/usr/include/imap/linkage.c \
+			|| die "failed to add ssl init statement to linkage.c"
+	fi
+
+	# Documentation
+	dodoc README docs/*.txt docs/BUILD docs/CONFIG docs/RELNOTES docs/SSLBUILD
+	if use doc; then
+		docinto rfc
+		dodoc docs/rfc/*.txt
+		docinto draft
+		dodoc docs/draft/*
+	fi
+}

--- a/net-libs/c-client/files/c-client-2007f-implicit-declaration-fix.patch
+++ b/net-libs/c-client/files/c-client-2007f-implicit-declaration-fix.patch
@@ -1,0 +1,34 @@
+This patch solves build issues with -Werror=implicit-function-declaration
+enabled.
+
+- safe_flock is a function from flocklnx.c but header file for consumers
+  is missing, the simplest was to add function prototype to other
+  header file.
+- utime.h is needed also in multiple places but os_slx.h header file is
+  used in all of them
+
+Bug: https://bugs.gentoo.org/870478
+
+diff --git a/src/osdep/unix/os_slx.h b/src/osdep/unix/os_slx.h
+index b5f39ff..adad223 100644
+--- a/src/osdep/unix/os_slx.h
++++ b/src/osdep/unix/os_slx.h
+@@ -46,6 +46,7 @@
+ #include <sys/types.h>
+ #include <dirent.h>
+ #include <time.h>		/* for struct tm */
++#include <utime.h>
+ #include <fcntl.h>
+ #include <syslog.h>
+ #include <sys/file.h>
+@@ -57,6 +58,7 @@
+ 
+ #define direct dirent
+ 
++int safe_flock(int, int);
+ #define flock safe_flock
+ 
+ 
+-- 
+2.35.1
+

--- a/net-libs/c-client/files/c-client-2007f-scandir-callback-types.patch
+++ b/net-libs/c-client/files/c-client-2007f-scandir-callback-types.patch
@@ -1,0 +1,167 @@
+clang-16 compiler complains with following error message in multiple
+places:
+
+  error: incompatible function pointer types passing 'int (struct dirent *)' to
+        parameter of type 'int (*)(const struct dirent *)' [-Wincompatible-function-pointer-types]
+
+  error: incompatible function pointer types passing
+        'int (const void *, const void *)' to parameter of type 'int (*)(const struct dirent **, const struct dirent **)' [-Wincompatible-function-pointer-types]
+
+This patch fixes all those places by correcting function pointer types
+for scandir callbacks.
+
+Bug: https://bugs.gentoo.org/870478
+
+diff --git a/src/osdep/unix/mh.c b/src/osdep/unix/mh.c
+index 0226b7a..ace2b32 100644
+--- a/src/osdep/unix/mh.c
++++ b/src/osdep/unix/mh.c
+@@ -103,8 +103,8 @@ long mh_copy (MAILSTREAM *stream,char *sequence,char *mailbox,
+ 	      long options);
+ long mh_append (MAILSTREAM *stream,char *mailbox,append_t af,void *data);
+ 
+-int mh_select (struct direct *name);
+-int mh_numsort (const void *d1,const void *d2);
++int mh_select (const struct direct *name);
++int mh_numsort (const struct direct **d1,const struct direct **d2);
+ char *mh_file (char *dst,char *name);
+ long mh_canonicalize (char *pattern,char *ref,char *pat);
+ void mh_setdate (char *file,MESSAGECACHE *elt);
+@@ -1194,7 +1194,7 @@ long mh_append (MAILSTREAM *stream,char *mailbox,append_t af,void *data)
+  * Returns: T to use file name, NIL to skip it
+  */
+ 
+-int mh_select (struct direct *name)
++int mh_select (const struct direct *name)
+ {
+   char c;
+   char *s = name->d_name;
+@@ -1209,7 +1209,7 @@ int mh_select (struct direct *name)
+  * Returns: negative if d1 < d2, 0 if d1 == d2, postive if d1 > d2
+  */
+ 
+-int mh_numsort (const void *d1,const void *d2)
++int mh_numsort (const struct direct **d1,const struct direct **d2)
+ {
+   return atoi ((*(struct direct **) d1)->d_name) -
+     atoi ((*(struct direct **) d2)->d_name);
+diff --git a/src/osdep/unix/mix.c b/src/osdep/unix/mix.c
+index fbf4a02..0964842 100644
+--- a/src/osdep/unix/mix.c
++++ b/src/osdep/unix/mix.c
+@@ -125,7 +125,7 @@ long mix_unsubscribe (MAILSTREAM *stream,char *mailbox);
+ long mix_create (MAILSTREAM *stream,char *mailbox);
+ long mix_delete (MAILSTREAM *stream,char *mailbox);
+ long mix_rename (MAILSTREAM *stream,char *old,char *newname);
+-int mix_rselect (struct direct *name);
++int mix_rselect (const struct direct *name);
+ MAILSTREAM *mix_open (MAILSTREAM *stream);
+ void mix_close (MAILSTREAM *stream,long options);
+ void mix_abort (MAILSTREAM *stream);
+@@ -140,8 +140,8 @@ THREADNODE *mix_thread (MAILSTREAM *stream,char *type,char *charset,
+ long mix_ping (MAILSTREAM *stream);
+ void mix_check (MAILSTREAM *stream);
+ long mix_expunge (MAILSTREAM *stream,char *sequence,long options);
+-int mix_select (struct direct *name);
+-int mix_msgfsort (const void *d1,const void *d2);
++int mix_select (const struct direct *name);
++int mix_msgfsort (const struct direct **d1,const struct direct **d2);
+ long mix_addset (SEARCHSET **set,unsigned long start,unsigned long size);
+ long mix_burp (MAILSTREAM *stream,MIXBURP *burp,unsigned long *reclaimed);
+ long mix_burp_check (SEARCHSET *set,size_t size,char *file);
+@@ -587,7 +587,7 @@ long mix_rename (MAILSTREAM *stream,char *old,char *newname)
+  * Returns: T if mix file name, NIL otherwise
+  */
+ 
+-int mix_rselect (struct direct *name)
++int mix_rselect (const struct direct *name)
+ {
+   return mix_dirfmttest (name->d_name);
+ }
+@@ -1146,7 +1146,7 @@ long mix_expunge (MAILSTREAM *stream,char *sequence,long options)
+  * ".mix" with no suffix was used by experimental versions
+  */
+ 
+-int mix_select (struct direct *name)
++int mix_select (const struct direct *name)
+ {
+   char c,*s;
+ 				/* make sure name has prefix */
+@@ -1165,7 +1165,7 @@ int mix_select (struct direct *name)
+  * Returns: -1 if d1 < d2, 0 if d1 == d2, 1 d1 > d2
+  */
+ 
+-int mix_msgfsort (const void *d1,const void *d2)
++int mix_msgfsort (const struct direct **d1,const struct direct **d2)
+ {
+   char *n1 = (*(struct direct **) d1)->d_name + sizeof (MIXNAME) - 1;
+   char *n2 = (*(struct direct **) d2)->d_name + sizeof (MIXNAME) - 1;
+diff --git a/src/osdep/unix/mx.c b/src/osdep/unix/mx.c
+index 4549527..994f12c 100644
+--- a/src/osdep/unix/mx.c
++++ b/src/osdep/unix/mx.c
+@@ -98,8 +98,8 @@ long mx_append (MAILSTREAM *stream,char *mailbox,append_t af,void *data);
+ long mx_append_msg (MAILSTREAM *stream,char *flags,MESSAGECACHE *elt,
+ 		    STRING *st,SEARCHSET *set);
+ 
+-int mx_select (struct direct *name);
+-int mx_numsort (const void *d1,const void *d2);
++int mx_select (const struct direct *name);
++int mx_numsort (const struct direct **d1,const struct direct **d2);
+ char *mx_file (char *dst,char *name);
+ long mx_lockindex (MAILSTREAM *stream);
+ void mx_unlockindex (MAILSTREAM *stream);
+@@ -1110,7 +1110,7 @@ long mx_append_msg (MAILSTREAM *stream,char *flags,MESSAGECACHE *elt,
+  * Returns: T to use file name, NIL to skip it
+  */
+ 
+-int mx_select (struct direct *name)
++int mx_select (const struct direct *name)
+ {
+   char c;
+   char *s = name->d_name;
+@@ -1125,7 +1125,7 @@ int mx_select (struct direct *name)
+  * Returns: negative if d1 < d2, 0 if d1 == d2, postive if d1 > d2
+  */
+ 
+-int mx_numsort (const void *d1,const void *d2)
++int mx_numsort (const struct direct **d1,const struct direct **d2)
+ {
+   return atoi ((*(struct direct **) d1)->d_name) -
+     atoi ((*(struct direct **) d2)->d_name);
+diff --git a/src/osdep/unix/news.c b/src/osdep/unix/news.c
+index 4cf5bb7..caa6785 100644
+--- a/src/osdep/unix/news.c
++++ b/src/osdep/unix/news.c
+@@ -76,8 +76,8 @@ long news_create (MAILSTREAM *stream,char *mailbox);
+ long news_delete (MAILSTREAM *stream,char *mailbox);
+ long news_rename (MAILSTREAM *stream,char *old,char *newname);
+ MAILSTREAM *news_open (MAILSTREAM *stream);
+-int news_select (struct direct *name);
+-int news_numsort (const void *d1,const void *d2);
++int news_select (const struct direct *name);
++int news_numsort (const struct direct **d1,const struct direct **d2);
+ void news_close (MAILSTREAM *stream,long options);
+ void news_fast (MAILSTREAM *stream,char *sequence,long flags);
+ void news_flags (MAILSTREAM *stream,char *sequence,long flags);
+@@ -402,7 +402,7 @@ MAILSTREAM *news_open (MAILSTREAM *stream)
+  * Returns: T to use file name, NIL to skip it
+  */
+ 
+-int news_select (struct direct *name)
++int news_select (const struct direct *name)
+ {
+   char c;
+   char *s = name->d_name;
+@@ -417,7 +417,7 @@ int news_select (struct direct *name)
+  * Returns: negative if d1 < d2, 0 if d1 == d2, postive if d1 > d2
+  */
+ 
+-int news_numsort (const void *d1,const void *d2)
++int news_numsort (const struct direct **d1,const struct direct **d2)
+ {
+   return atoi ((*(struct direct **) d1)->d_name) -
+     atoi ((*(struct direct **) d2)->d_name);
+-- 
+2.35.1
+

--- a/profiles/package.deprecated
+++ b/profiles/package.deprecated
@@ -17,6 +17,12 @@
 
 #--- END OF EXAMPLES ---
 
+# Petr Vaněk <arkamar@atlas.cz> (2022-10-06)
+# Obsolete virtual.
+# Only one provider is left (net-libs/c-client), please change dependency to
+# that instead.
+virtual/imap-c-client
+
 # Matt Turner <mattst88@gentoo.org> (2022-10-02)
 # Dummy packages, now merged into app-accessibility/at-spi2-core.
 app-accessibility/at-spi2-atk


### PR DESCRIPTION
Those are two quite independent set of changes. First is fix of clang-16 related issues in `net-libs/c-client`, I decided to do a revbump because I also bumped `EAPI` to 8 among other changes. Then I noticed that `net-libs/c-client` was used only by `virtual/imap-c-client` as a last provider and this virtual was used only by `net-misc/asterisk` and `dev-lang/php`, which makes it good candidate for removal. I followed steps from [devmanual](https://devmanual.gentoo.org/ebuild-maintenance/removal/index.html#removing-a-virtual-package) and treeclean it.