### PR TITLE
sys-devel/mold: KEYWORDING ~x86

### DIFF
--- a/sys-devel/mold/mold-1.5.1.ebuild
+++ b/sys-devel/mold/mold-1.5.1.ebuild
@@ -12,7 +12,7 @@ if [[ ${PV} == 9999 ]] ; then
 	inherit git-r3
 else
 	SRC_URI="https://github.com/rui314/mold/archive/refs/tags/v${PV}.tar.gz -> ${P}.tar.gz"
-	KEYWORDS="~amd64 ~riscv"
+	KEYWORDS="~amd64 ~riscv ~x86"
 fi
 
 # mold (AGPL-3)

--- a/sys-devel/mold/mold-9999.ebuild
+++ b/sys-devel/mold/mold-9999.ebuild
@@ -12,7 +12,7 @@ if [[ ${PV} == 9999 ]] ; then
 	inherit git-r3
 else
 	SRC_URI="https://github.com/rui314/mold/archive/refs/tags/v${PV}.tar.gz -> ${P}.tar.gz"
-	KEYWORDS="~amd64 ~riscv"
+	KEYWORDS="~amd64 ~riscv ~x86"
 fi
 
 # mold (AGPL-3)


### PR DESCRIPTION
After discussing with upstream they have patched the issue so this can now be keyworded for ~x86.

Closes: https://bugs.gentoo.org/870760
Signed-off-by: Ian Jordan <immoloism@gmail.com>

 Changes to be committed:
	modified:   mold-1.5.1.ebuild
	modified:   mold-9999.ebuild