### PR TITLE
profiles/targets/systemd: add sysv-utils to BOOTSTRAP_USE

### DIFF
--- a/profiles/targets/systemd/make.defaults
+++ b/profiles/targets/systemd/make.defaults
@@ -1,6 +1,6 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 USE="systemd udev"
 
-BOOTSTRAP_USE="${BOOTSTRAP_USE} systemd udev"
+BOOTSTRAP_USE="${BOOTSTRAP_USE} systemd sysv-utils udev"


### PR DESCRIPTION
catalyst, bootstrap.sh and BOOTSTRAP_USE all set USE=-* at various stages of builds.
This results in systemd build with -sysv-utils and pulls sys-apps/sysvinit as a dependency in stage1/stage2 builds.