### PR TITLE
dev-lang/jsonnet: fix build on gcc-13

### DIFF
--- a/dev-lang/jsonnet/files/jsonnet-0.18.0-gcc-13.patch
+++ b/dev-lang/jsonnet/files/jsonnet-0.18.0-gcc-13.patch
@@ -1,0 +1,18 @@
+https://github.com/google/jsonnet/pull/1020
+From: WANG Xuerui <git@xen0n.name>
+Date: Thu, 6 Oct 2022 15:04:47 +0800
+Subject: [PATCH] Add #include <cstdint> for gcc-13 builds
+
+See https://gcc.gnu.org/gcc-13/porting_to.html#header-dep-changes.
+
+This fixes Gentoo bug https://bugs.gentoo.org/875569.
+--- a/include/libjsonnet++.h
++++ b/include/libjsonnet++.h
+@@ -17,6 +17,7 @@ limitations under the License.
+ #ifndef CPP_JSONNET_H_
+ #define CPP_JSONNET_H_
+ 
++#include <cstdint>
+ #include <cstring>
+ #include <functional>
+ #include <map>

--- a/dev-lang/jsonnet/jsonnet-0.18.0-r1.ebuild
+++ b/dev-lang/jsonnet/jsonnet-0.18.0-r1.ebuild
@@ -42,6 +42,7 @@ PATCHES=(
 	"${FILESDIR}/jsonnet-0.16.0-libdir.patch"
 	"${FILESDIR}/jsonnet-0.16.0-cp-var.patch"
 	"${FILESDIR}/jsonnet-0.18.0-unbundle.patch"
+	"${FILESDIR}/jsonnet-0.18.0-gcc-13.patch"
 )
 
 distutils_enable_tests unittest


### PR DESCRIPTION
Earlier versions couldn't be tested due to ancient versions of Python being unavailable, but the patch may apply as well.