### PR TITLE
app-arch/arc: multiple fixes

### DIFF
--- a/app-arch/arc/arc-5.21p-r1.ebuild
+++ b/app-arch/arc/arc-5.21p-r1.ebuild
@@ -1,0 +1,40 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs
+
+DESCRIPTION="Create & extract files from DOS .ARC files"
+HOMEPAGE="https://arc.sourceforge.net"
+SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm64 ~hppa ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-solaris"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-5.21m-darwin.patch
+	"${FILESDIR}"/${PN}-5.21m-gentoo-fbsd.patch
+	"${FILESDIR}"/${PN}-5.21o-interix.patch
+	"${FILESDIR}"/${PN}-5.21p-fno-common.patch
+	"${FILESDIR}"/${PN}-5.21p-variadic-arcdie.patch
+)
+
+src_prepare() {
+	default
+
+	sed -i Makefile \
+		-e 's/CFLAGS = $(OPT) $(SYSTEM)/CFLAGS += $(SYSTEM)/' \
+		|| die "sed Makefile"
+}
+
+src_compile() {
+	emake CC="$(tc-getCC)" OPT="${LDFLAGS}"
+}
+
+src_install() {
+	dobin arc marc
+	doman arc.1
+	dodoc Arc521.doc Arcinfo Changelog Readme
+}

--- a/app-arch/arc/arc-5.21p.ebuild
+++ b/app-arch/arc/arc-5.21p.ebuild
@@ -6,7 +6,7 @@ EAPI=7
 inherit toolchain-funcs
 
 DESCRIPTION="Create & extract files from DOS .ARC files"
-HOMEPAGE="http://arc.sourceforge.net"
+HOMEPAGE="https://arc.sourceforge.net"
 SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
 
 LICENSE="GPL-2"

--- a/app-arch/arc/files/arc-5.21p-variadic-arcdie.patch
+++ b/app-arch/arc/files/arc-5.21p-variadic-arcdie.patch
@@ -1,0 +1,38 @@
+Convert arcdie to variadic function, which solves the issue with
+-Werror=implicit-int enabled.
+
+Bug: https://bugs.gentoo.org/870517
+
+diff --git a/arcmisc.c b/arcmisc.c
+index ea12b41..3d6272e 100644
+--- a/arcmisc.c
++++ b/arcmisc.c
+@@ -3,6 +3,7 @@
+  * $Header: /cvsroot/arc/arc/arcmisc.c,v 1.4 2005/10/09 01:38:22 highlandsun Exp $ 
+  */
+ 
++#include <stdarg.h>
+ #include <stdio.h>
+ #include <ctype.h>
+ #include "arc.h"
+@@ -223,11 +224,14 @@ upper(string)
+ }
+ /* VARARGS1 */
+ VOID
+-arcdie(s, arg1, arg2, arg3)
+-	char           *s;
++arcdie(char * s, ...)
+ {
++	va_list ap;
++
+ 	fprintf(stderr, "ARC: ");
+-	fprintf(stderr, s, arg1, arg2, arg3);
++	va_start(ap, s);
++	vfprintf(stderr, s, ap);
++	va_end(ap);
+ 	fprintf(stderr, "\n");
+ #if	UNIX
+ 	perror("UNIX");
+-- 
+2.35.1
+


### PR DESCRIPTION
- fix build issue with `-Werror=implicit-int` enabled, this is related to `clang-16-porting`.
- change `HOMEPAGE` to use `https`
- EAPI bump