### PR TITLE
app-misc/dvtm: fix clang-16 related issue, EAPI bump, update URIs

### DIFF
--- a/app-misc/dvtm/dvtm-0.15-r5.ebuild
+++ b/app-misc/dvtm/dvtm-0.15-r5.ebuild
@@ -41,8 +41,6 @@ src_prepare() {
 
 src_compile() {
 	tc-export PKG_CONFIG
-	local msg=""
-	use savedconfig && msg=", please check the configfile"
 	emake CC="$(tc-getCC)" ${PN}
 }
 

--- a/app-misc/dvtm/dvtm-0.15-r5.ebuild
+++ b/app-misc/dvtm/dvtm-0.15-r5.ebuild
@@ -10,7 +10,11 @@ HOMEPAGE="https://www.brain-dump.org/projects/dvtm/"
 
 if [[ ${PV} == *9999 ]]; then
 	inherit git-r3
-	EGIT_REPO_URI="https://repo.or.cz/dvtm.git"
+	EGIT_REPO_URI="
+		https://github.com/martanne/dvtm
+		https://git.sr.ht/~martanne/dvtm
+		https://repo.or.cz/dvtm.git
+	"
 else
 	SRC_URI="https://www.brain-dump.org/projects/${PN}/${P}.tar.gz"
 	KEYWORDS="amd64 arm ~arm64 ~riscv x86"

--- a/app-misc/dvtm/dvtm-0.15-r6.ebuild
+++ b/app-misc/dvtm/dvtm-0.15-r6.ebuild
@@ -1,0 +1,62 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit savedconfig toolchain-funcs
+
+DESCRIPTION="Dynamic virtual terminal manager"
+HOMEPAGE="https://www.brain-dump.org/projects/dvtm/"
+
+if [[ ${PV} == *9999 ]]; then
+	inherit git-r3
+	EGIT_REPO_URI="
+		https://github.com/martanne/dvtm
+		https://git.sr.ht/~martanne/dvtm
+		https://repo.or.cz/dvtm.git
+	"
+else
+	SRC_URI="https://www.brain-dump.org/projects/${PN}/${P}.tar.gz"
+	KEYWORDS="~amd64 ~arm ~arm64 ~riscv ~x86"
+fi
+
+LICENSE="MIT"
+SLOT="0"
+
+RDEPEND=">=sys-libs/ncurses-6.1:=[unicode(+)]"
+DEPEND="${RDEPEND}
+	virtual/pkgconfig
+"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-0.15-gentoo.patch
+	"${FILESDIR}"/${PN}-0.15-stop-installing-terminfo.patch
+)
+
+src_prepare() {
+	default
+
+	restore_config config.h
+}
+
+src_compile() {
+	tc-export PKG_CONFIG
+	emake CC="$(tc-getCC)" ${PN}
+}
+
+src_install() {
+	emake DESTDIR="${D}" PREFIX="${EPREFIX}/usr" STRIP=true install
+
+	insinto /usr/share/${PN}
+	newins config.h ${PF}.config.h
+
+	dodoc README.md
+
+	save_config config.h
+}
+
+pkg_postinst() {
+	elog "This ebuild has support for user defined configs"
+	elog "Please read this ebuild for more details and re-emerge as needed"
+	elog "if you want to add or remove functionality for ${PN}"
+}

--- a/app-misc/dvtm/dvtm-9999.ebuild
+++ b/app-misc/dvtm/dvtm-9999.ebuild
@@ -10,7 +10,11 @@ HOMEPAGE="https://www.brain-dump.org/projects/dvtm/"
 
 if [[ ${PV} == *9999 ]]; then
 	inherit git-r3
-	EGIT_REPO_URI="https://repo.or.cz/dvtm.git"
+	EGIT_REPO_URI="
+		https://github.com/martanne/dvtm
+		https://git.sr.ht/~martanne/dvtm
+		https://repo.or.cz/dvtm.git
+	"
 else
 	SRC_URI="https://www.brain-dump.org/projects/${PN}/${P}.tar.gz"
 	KEYWORDS="~amd64 ~arm ~x86"

--- a/app-misc/dvtm/dvtm-9999.ebuild
+++ b/app-misc/dvtm/dvtm-9999.ebuild
@@ -41,8 +41,6 @@ src_prepare() {
 
 src_compile() {
 	tc-export PKG_CONFIG
-	local msg=""
-	use savedconfig && msg=", please check the configfile"
 	emake CC="$(tc-getCC)" ${PN}
 }
 

--- a/app-misc/dvtm/dvtm-9999.ebuild
+++ b/app-misc/dvtm/dvtm-9999.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
 
 inherit savedconfig toolchain-funcs
 
@@ -17,7 +17,7 @@ if [[ ${PV} == *9999 ]]; then
 	"
 else
 	SRC_URI="https://www.brain-dump.org/projects/${PN}/${P}.tar.gz"
-	KEYWORDS="~amd64 ~arm ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~riscv ~x86"
 fi
 
 LICENSE="MIT"
@@ -30,7 +30,7 @@ DEPEND="
 "
 PATCHES=(
 	"${FILESDIR}"/${PN}-9999-gentoo.patch
-	"${FILESDIR}"/${PN}-0.15-stop-installing-terminfo.patch
+	"${FILESDIR}"/${PN}-9999-stop-installing-terminfo.patch
 )
 
 src_prepare() {

--- a/app-misc/dvtm/files/dvtm-0.15-gentoo.patch
+++ b/app-misc/dvtm/files/dvtm-0.15-gentoo.patch
@@ -1,6 +1,6 @@
 --- a/config.mk
 +++ b/config.mk
-@@ -10,12 +10,12 @@
+@@ -10,12 +10,13 @@ MANPREFIX = ${PREFIX}/share/man
  TERMINFO := ${DESTDIR}${PREFIX}/share/terminfo
  
  INCS = -I.
@@ -8,6 +8,7 @@
 -CPPFLAGS = -D_POSIX_C_SOURCE=200809L -D_XOPEN_SOURCE=700 -D_XOPEN_SOURCE_EXTENDED
 +LIBS = -lc -lutil $(shell $(PKG_CONFIG) --libs ncursesw)
 +CPPFLAGS += -D_POSIX_C_SOURCE=200809L -D_XOPEN_SOURCE=700 -D_XOPEN_SOURCE_EXTENDED
++CPPFLAGS += $(shell $(PKG_CONFIG) --cflags ncursesw)
  CFLAGS += -std=c99 ${INCS} -DVERSION=\"${VERSION}\" -DNDEBUG ${CPPFLAGS}
  LDFLAGS += ${LIBS}
  
@@ -18,7 +19,7 @@
  STRIP ?= strip
 --- a/Makefile
 +++ b/Makefile
-@@ -16,13 +16,13 @@
+@@ -16,13 +16,13 @@ config.h:
  
  .c.o:
  	@echo CC $<

--- a/app-misc/dvtm/files/dvtm-9999-gentoo.patch
+++ b/app-misc/dvtm/files/dvtm-9999-gentoo.patch
@@ -1,6 +1,6 @@
 --- a/config.mk
 +++ b/config.mk
-@@ -7,8 +7,8 @@
+@@ -7,8 +7,9 @@ MANPREFIX = ${PREFIX}/share/man
  TERMINFO := ${DESTDIR}${PREFIX}/share/terminfo
  
  INCS = -I.
@@ -8,6 +8,7 @@
 -CPPFLAGS = -D_POSIX_C_SOURCE=200809L -D_XOPEN_SOURCE=700 -D_XOPEN_SOURCE_EXTENDED
 +LIBS = -lc -lutil $(shell $(PKG_CONFIG) --libs ncursesw)
 +CPPFLAGS += -D_POSIX_C_SOURCE=200809L -D_XOPEN_SOURCE=700 -D_XOPEN_SOURCE_EXTENDED
++CPPFLAGS += $(shell $(PKG_CONFIG) --cflags ncursesw)
  CFLAGS += -std=c99 ${INCS} -DNDEBUG ${CPPFLAGS}
  
  CC ?= cc

--- a/app-misc/dvtm/files/dvtm-9999-stop-installing-terminfo.patch
+++ b/app-misc/dvtm/files/dvtm-9999-stop-installing-terminfo.patch
@@ -1,0 +1,11 @@
+--- a/Makefile
++++ b/Makefile
+@@ -50,8 +50,6 @@ install: all
+ 		sed -e "s/VERSION/${VERSION}/" < "$$m" >  "${DESTDIR}${MANPREFIX}/man1/$$m" && \
+ 		chmod 644 "${DESTDIR}${MANPREFIX}/man1/$$m"; \
+ 	done
+-	@echo installing terminfo description
+-	@TERMINFO=${TERMINFO} tic -s dvtm.info
+ 
+ uninstall:
+ 	@for b in ${BIN}; do \

--- a/app-misc/dvtm/metadata.xml
+++ b/app-misc/dvtm/metadata.xml
@@ -5,4 +5,8 @@
 		<email>chithanh@gentoo.org</email>
 		<name>Chí-Thanh Christopher Nguyễn</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">martanne/dvtm</remote-id>
+		<remote-id type="sourcehut">~martanne/dvtm</remote-id>
+	</upstream>
 </pkgmetadata>


### PR DESCRIPTION
- I have updated `EGIT_REPO_URI` to use today presented repo uris in project page (github and sorucehut)
- sync live, see commit message for more info
- fix for clang-16 related issue, related to `-Werror,-Wimplicit-function-declaration`
- and finally revbump of 0.15 in order to move from deprecated EAPI 6 to 8.