### PR TITLE
toolchain-funcs.eclass: runtime getters

### DIFF
--- a/eclass/tests/toolchain-funcs.sh
+++ b/eclass/tests/toolchain-funcs.sh
@@ -198,4 +198,26 @@ for compiler in gcc clang not-really-a-compiler; do
 	fi
 done
 
+if type -P gcc &>/dev/null; then
+	tbegin "tc-get-cxx-stdlib (gcc)"
+	[[ $(CXX=g++ tc-get-cxx-stdlib) == libstdc++ ]]
+	tend $?
+fi
+
+if type -P clang &>/dev/null; then
+	for stdlib in libc++ libstdc++; do
+		if clang++ -stdlib=${stdlib} -x c++ -E -P - &>/dev/null \
+			<<<'#include <ciso646>'
+		then
+			tbegin "tc-get-cxx-stdlib (clang, ${stdlib})"
+			[[ $(CXX=clang++ CXXFLAGS="-stdlib=${stdlib}" tc-get-cxx-stdlib) == ${stdlib} ]]
+			tend $?
+		fi
+	done
+
+	tbegin "tc-get-cxx-stdlib (clang, invalid)"
+	! CXX=clang++ CXXFLAGS="-stdlib=invalid" tc-get-cxx-stdlib
+	tend $?
+fi
+
 texit

--- a/eclass/tests/toolchain-funcs.sh
+++ b/eclass/tests/toolchain-funcs.sh
@@ -60,20 +60,22 @@ tbegin "tc-ld-is-gold (ld=bfd cc=bfd)"
 LD=ld.bfd LDFLAGS=-fuse-ld=bfd tc-ld-is-gold && ret=1 || ret=0
 tend ${ret}
 
-tbegin "tc-ld-is-gold (ld=gold cc=default)"
-LD=ld.gold tc-ld-is-gold
-ret=$?
-tend ${ret}
+if type -P ld.gold &>/dev/null; then
+	tbegin "tc-ld-is-gold (ld=gold cc=default)"
+	LD=ld.gold tc-ld-is-gold
+	ret=$?
+	tend ${ret}
 
-tbegin "tc-ld-is-gold (ld=gold cc=bfd)"
-LD=ld.gold LDFLAGS=-fuse-ld=bfd tc-ld-is-gold
-ret=$?
-tend ${ret}
+	tbegin "tc-ld-is-gold (ld=gold cc=bfd)"
+	LD=ld.gold LDFLAGS=-fuse-ld=bfd tc-ld-is-gold
+	ret=$?
+	tend ${ret}
 
-tbegin "tc-ld-is-gold (ld=bfd cc=gold)"
-LD=ld.bfd LDFLAGS=-fuse-ld=gold tc-ld-is-gold
-ret=$?
-tend ${ret}
+	tbegin "tc-ld-is-gold (ld=bfd cc=gold)"
+	LD=ld.bfd LDFLAGS=-fuse-ld=gold tc-ld-is-gold
+	ret=$?
+	tend ${ret}
+fi
 
 #
 # TEST: tc-ld-disable-gold
@@ -87,23 +89,25 @@ tc-ld-disable-gold
 )
 tend $?
 
-tbegin "tc-ld-disable-gold (ld=gold)"
-(
-export LD=ld.gold LDFLAGS=
-ewarn() { :; }
-tc-ld-disable-gold
-[[ ${LD} == "ld.bfd" || ${LDFLAGS} == *"-fuse-ld=bfd"* ]]
-)
-tend $?
+if type -P ld.gold &>/dev/null; then
+	tbegin "tc-ld-disable-gold (ld=gold)"
+	(
+	export LD=ld.gold LDFLAGS=
+	ewarn() { :; }
+	tc-ld-disable-gold
+	[[ ${LD} == "ld.bfd" || ${LDFLAGS} == *"-fuse-ld=bfd"* ]]
+	)
+	tend $?
 
-tbegin "tc-ld-disable-gold (cc=gold)"
-(
-export LD= LDFLAGS="-fuse-ld=gold"
-ewarn() { :; }
-tc-ld-disable-gold
-[[ ${LD} == *"/ld.bfd" || ${LDFLAGS} == "-fuse-ld=gold -fuse-ld=bfd" ]]
-)
-tend $?
+	tbegin "tc-ld-disable-gold (cc=gold)"
+	(
+	export LD= LDFLAGS="-fuse-ld=gold"
+	ewarn() { :; }
+	tc-ld-disable-gold
+	[[ ${LD} == *"/ld.bfd" || ${LDFLAGS} == "-fuse-ld=gold -fuse-ld=bfd" ]]
+	)
+	tend $?
+fi
 
 unset CPP
 

--- a/eclass/tests/toolchain-funcs.sh
+++ b/eclass/tests/toolchain-funcs.sh
@@ -202,6 +202,10 @@ if type -P gcc &>/dev/null; then
 	tbegin "tc-get-cxx-stdlib (gcc)"
 	[[ $(CXX=g++ tc-get-cxx-stdlib) == libstdc++ ]]
 	tend $?
+
+	tbegin "tc-get-c-rtlib (gcc)"
+	[[ $(CC=gcc tc-get-c-rtlib) == libgcc ]]
+	tend $?
 fi
 
 if type -P clang &>/dev/null; then
@@ -218,6 +222,12 @@ if type -P clang &>/dev/null; then
 	tbegin "tc-get-cxx-stdlib (clang, invalid)"
 	! CXX=clang++ CXXFLAGS="-stdlib=invalid" tc-get-cxx-stdlib
 	tend $?
+
+	for rtlib in compiler-rt libgcc; do
+		tbegin "tc-get-c-rtlib (clang, ${rtlib})"
+		[[ $(CC=clang CFLAGS="--rtlib=${rtlib}" tc-get-c-rtlib) == ${rtlib} ]]
+		tend $?
+	done
 fi
 
 texit

--- a/eclass/toolchain-funcs.eclass
+++ b/eclass/toolchain-funcs.eclass
@@ -1173,4 +1173,40 @@ gen_usr_ldscript() {
 	done
 }
 
+# @FUNCTION: tc-get-cxx-stdlib
+# @DESCRIPTION:
+# Attempt to identify the C++ standard library used by the compiler.
+# If the library is identified, the function returns 0 and prints one
+# of the following:
+#
+# - ``libc++`` for ``sys-libs/libcxx``
+# - ``libstdc++`` for ``sys-devel/gcc``'s libstdc++
+#
+# If the library is not recognized, the function returns 1.
+tc-get-cxx-stdlib() {
+	local code='#include <ciso646>
+
+#if defined(_LIBCPP_VERSION)
+	HAVE_LIBCXX
+#elif defined(__GLIBCXX__)
+	HAVE_LIBSTDCPP
+#endif
+'
+	local res=$(
+		$(tc-getCXX) ${CXXFLAGS} ${CPPFLAGS} -x c++ -E -P - \
+			<<<"${code}" 2>/dev/null
+	)
+
+	case ${res} in
+		*HAVE_LIBCXX*)
+			echo libc++;;
+		*HAVE_LIBSTDCPP*)
+			echo libstdc++;;
+		*)
+			return 1;;
+	esac
+
+	return 0
+}
+
 fi

--- a/eclass/toolchain-funcs.eclass
+++ b/eclass/toolchain-funcs.eclass
@@ -1209,4 +1209,32 @@ tc-get-cxx-stdlib() {
 	return 0
 }
 
+# @FUNCTION: tc-get-c-rtlib
+# @DESCRIPTION:
+# Attempt to identify the runtime used by the C/C++ compiler.
+# If the runtime is identifed, the function returns 0 and prints one
+# of the following:
+#
+# - ``compiler-rt`` for ``sys-libs/compiler-rt``
+# - ``libgcc`` for ``sys-devel/gcc``'s libgcc
+#
+# If the runtime is not recognized, the function returns 1.
+tc-get-c-rtlib() {
+	local res=$(
+		$(tc-getCC) ${CFLAGS} ${CPPFLAGS} ${LDFLAGS} \
+			-print-libgcc-file-name 2>/dev/null
+	)
+
+	case ${res} in
+		*libclang_rt*)
+			echo compiler-rt;;
+		*libgcc*)
+			echo libgcc;;
+		*)
+			return 1;;
+	esac
+
+	return 0
+}
+
 fi


### PR DESCRIPTION
- [x] `tc-get-cxx-stdlib` to get C++ standard library (libc++, libstdc++)
- [x] `tc-get-c-rtlib` to get C/C++ compiler runtime library (compiler-rt, libgcc)