### PR TITLE
dev-libs/dbus-c++: add tests

### DIFF
--- a/dev-libs/dbus-c++/dbus-c++-0.9.0-r5.ebuild
+++ b/dev-libs/dbus-c++/dbus-c++-0.9.0-r5.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit multilib-minimal
+inherit multilib-minimal autotools virtualx
 
 DESCRIPTION="Provides a C++ API for D-BUS"
 HOMEPAGE="https://sourceforge.net/projects/dbus-cplusplus/"
@@ -24,7 +24,8 @@ DEPEND="${RDEPEND}
 	dev-util/cppunit[${MULTILIB_USEDEP}]"
 BDEPEND="
 	virtual/pkgconfig
-	doc? ( app-doc/doxygen )"
+	doc? ( app-doc/doxygen )
+	test? ( sys-apps/dbus[X,${MULTILIB_USEDEP}] )"
 
 S="${WORKDIR}/lib${P}"
 
@@ -32,7 +33,13 @@ PATCHES=(
 	"${FILESDIR}"/${P}-gcc-4.7.patch #424707
 	"${FILESDIR}"/${PN}-gcc7.patch #622790
 	"${FILESDIR}"/${P}-gcc12.patch
+	"${FILESDIR}"/${PN}-0.9.0-enable-tests.patch #873487
 )
+
+src_prepare() {
+	default
+	eautoreconf
+}
 
 multilib_src_configure() {
 	# TODO : add ecore multilib support if/when it is multilibified
@@ -53,6 +60,10 @@ multilib_src_configure() {
 			ln -s "${S}"/doc/${d} "${BUILD_DIR}"/doc/${d} || die
 		done
 	fi
+}
+
+src_test() {
+	virtx multilib-minimal_src_test
 }
 
 multilib_src_install_all() {

--- a/dev-libs/dbus-c++/files/dbus-c++-0.9.0-enable-tests.patch
+++ b/dev-libs/dbus-c++/files/dbus-c++-0.9.0-enable-tests.patch
@@ -1,0 +1,22 @@
+https://bugs.gentoo.org/873487
+https://github.com/gentoo/gentoo/pull/27679
+
+diff --git a/test/functional/Test1/Makefile.am b/test/functional/Test1/Makefile.am
+index 3269751..50dd2a9 100644
+--- a/test/functional/Test1/Makefile.am
++++ b/test/functional/Test1/Makefile.am
+@@ -40,3 +40,4 @@ AM_CPPFLAGS =
+ 
+ ## File created by the gnome-build tools
+ 
++TESTS = $(noinst_PROGRAMS)
+diff --git a/test/generator/Makefile.am b/test/generator/Makefile.am
+index 6c2403d..c6781aa 100644
+--- a/test/generator/Makefile.am
++++ b/test/generator/Makefile.am
+@@ -38,3 +38,5 @@ dist-hook:
+ 
+ MAINTAINERCLEANFILES = \
+ 	Makefile.in
++
++TESTS = $(noinst_PROGRAMS)


### PR DESCRIPTION
Current tests are a no-op due to not including them in TESTS for whatever unknown reason.  Same on Debian.  Tests pass on alpha but need virtx.