### PR TITLE
www-apps/tt-rss: PHP 8.1 support (live ebuild)

### DIFF
--- a/www-apps/tt-rss/tt-rss-99999999.ebuild
+++ b/www-apps/tt-rss/tt-rss-99999999.ebuild
@@ -13,7 +13,7 @@ SLOT="${PV}" # Single live slot.
 IUSE="+acl daemon gd +mysqli postgres"
 REQUIRED_USE="|| ( mysqli postgres )"
 
-PHP_SLOTS="8.0 7.4"
+PHP_SLOTS="8.1 8.0 7.4"
 PHP_USE="gd?,mysqli?,postgres?,curl,fileinfo,intl,json(+),pdo,unicode,xml"
 
 php_rdepend() {


### PR DESCRIPTION
Add PHP 8.1 support , according to [master tt-rss-docker](https://dev.tt-rss.org/tt-rss/ttrss-docker-compose/commit/781666d860606b4af7234b9666b6a758296d4d2d)
Signed-off-by: Nicolas PARLANT <ppn@parhuet.fr>