### PR TITLE
gui-wm/sway: update libpcre dependency

### DIFF
--- a/gui-wm/sway/sway-9999.ebuild
+++ b/gui-wm/sway/sway-9999.ebuild
@@ -26,7 +26,7 @@ DEPEND="
 	>=dev-libs/json-c-0.13:0=
 	>=dev-libs/libinput-1.6.0:0=
 	sys-auth/seatd:=
-	dev-libs/libpcre
+	dev-libs/libpcre2
 	>=dev-libs/wayland-1.20.0
 	x11-libs/cairo
 	x11-libs/libxkbcommon


### PR DESCRIPTION
`gui-wm` uses `dev-libs/libpcre2` since https://github.com/swaywm/sway/commit/f614f35e7354980bf4f0a66ca99be9b5f3a7ac90 - let's update the live ebuild.

Signed-off-by: Michael Mair-Keimberger <mmk@levelnine.at>