### PR TITLE
Add test-rust flag for Rust-based important test deps

### DIFF
--- a/dev-python/aiohttp/aiohttp-3.8.1-r1.ebuild
+++ b/dev-python/aiohttp/aiohttp-3.8.1-r1.ebuild
@@ -20,6 +20,7 @@ SRC_URI="mirror://pypi/${P:0:1}/${PN}/${P}.tar.gz"
 LICENSE="Apache-2.0"
 SLOT="0"
 KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~loong ppc ppc64 ~riscv ~s390 sparc x86"
+IUSE="test-rust"
 
 RDEPEND="
 	app-arch/brotli[python,${PYTHON_USEDEP}]
@@ -42,9 +43,9 @@ BDEPEND="
 		dev-python/pytest-mock[${PYTHON_USEDEP}]
 		dev-python/pytest-xdist[${PYTHON_USEDEP}]
 		dev-python/re-assert[${PYTHON_USEDEP}]
-		!hppa? ( !ia64? (
+		test-rust? (
 			dev-python/trustme[${PYTHON_USEDEP}]
-		) )
+		)
 	)
 "
 

--- a/dev-python/aiohttp/aiohttp-3.8.3.ebuild
+++ b/dev-python/aiohttp/aiohttp-3.8.3.ebuild
@@ -18,6 +18,7 @@ SRC_URI="mirror://pypi/${P:0:1}/${PN}/${P}.tar.gz"
 LICENSE="Apache-2.0"
 SLOT="0"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+IUSE="test-rust"
 
 RDEPEND="
 	app-arch/brotli[python,${PYTHON_USEDEP}]
@@ -40,9 +41,9 @@ BDEPEND="
 		dev-python/pytest-mock[${PYTHON_USEDEP}]
 		dev-python/pytest-xdist[${PYTHON_USEDEP}]
 		dev-python/re-assert[${PYTHON_USEDEP}]
-		!hppa? ( !ia64? (
+		test-rust? (
 			dev-python/trustme[${PYTHON_USEDEP}]
-		) )
+		)
 	)
 "
 

--- a/dev-python/cheroot/cheroot-8.6.0-r1.ebuild
+++ b/dev-python/cheroot/cheroot-8.6.0-r1.ebuild
@@ -19,6 +19,7 @@ SRC_URI="mirror://pypi/${PN::1}/${PN}/${P}.tar.gz"
 LICENSE="BSD"
 SLOT="0"
 KEYWORDS="amd64 arm arm64 ~hppa ~ia64 ppc ~ppc64 ~riscv ~sparc x86"
+IUSE="test-rust"
 
 RDEPEND="
 	>=dev-python/six-1.11.0[${PYTHON_USEDEP}]
@@ -36,7 +37,7 @@ BDEPEND="
 		dev-python/requests-toolbelt[${PYTHON_USEDEP}]
 		dev-python/requests-unixsocket[${PYTHON_USEDEP}]
 		dev-python/urllib3[${PYTHON_USEDEP}]
-		!ia64? (
+		test-rust? (
 			dev-python/pyopenssl[${PYTHON_USEDEP}]
 			dev-python/trustme[${PYTHON_USEDEP}]
 		)

--- a/dev-python/httpretty/httpretty-1.1.4-r1.ebuild
+++ b/dev-python/httpretty/httpretty-1.1.4-r1.ebuild
@@ -18,6 +18,7 @@ SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 SLOT="0"
 LICENSE="MIT"
 KEYWORDS="amd64 arm arm64 ppc ppc64 ~riscv sparc x86"
+IUSE="test-rust"
 
 RDEPEND="
 	dev-python/urllib3[${PYTHON_USEDEP}]
@@ -36,9 +37,9 @@ BDEPEND="
 # We're skipping redis entirely since it requires a running server.
 BDEPEND+="
 	test? (
-		!arm? ( !sparc? (
+		test-rust? (
 			dev-python/pyopenssl[${PYTHON_USEDEP}]
-		) )
+		)
 		$(python_gen_cond_dep '
 			>=dev-python/boto3-1.17.72[${PYTHON_USEDEP}]
 			dev-python/httplib2[${PYTHON_USEDEP}]

--- a/dev-python/passlib/passlib-1.7.4-r2.ebuild
+++ b/dev-python/passlib/passlib-1.7.4-r2.ebuild
@@ -18,15 +18,15 @@ SRC_URI="mirror://pypi/${PN::1}/${PN}/${P}.tar.gz"
 LICENSE="BSD-2"
 KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~x64-macos"
 SLOT="0"
-IUSE="doc"
+IUSE="doc test-rust"
 
 BDEPEND="
 	test? (
 		dev-python/scrypt[${PYTHON_USEDEP}]
-		!alpha? ( !arm? ( !hppa? ( !ia64? ( !s390? ( !sparc? (
+		test-rust? (
 			dev-python/bcrypt[${PYTHON_USEDEP}]
 			dev-python/cryptography[${PYTHON_USEDEP}]
-		) ) ) ) ) )
+		)
 	)"
 
 distutils_enable_tests pytest

--- a/dev-python/pip/pip-22.2.2.ebuild
+++ b/dev-python/pip/pip-22.2.2.ebuild
@@ -41,7 +41,7 @@ LICENSE="MIT"
 LICENSE+=" Apache-2.0 BSD BSD-2 ISC LGPL-2.1+ MPL-2.0 PSF-2"
 KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86"
 SLOT="0"
-IUSE="vanilla"
+IUSE="test-rust vanilla"
 
 RDEPEND="
 	>=dev-python/setuptools-39.2.0[${PYTHON_USEDEP}]
@@ -57,9 +57,9 @@ BDEPEND="
 			dev-python/tomli-w[${PYTHON_USEDEP}]
 			dev-python/werkzeug[${PYTHON_USEDEP}]
 			dev-python/wheel[${PYTHON_USEDEP}]
-			!alpha? ( !arm? ( !hppa? ( !ia64? ( !s390? ( !sparc? (
+			test-rust? (
 				dev-python/cryptography[${PYTHON_USEDEP}]
-			) ) ) ) ) )
+			)
 		' "${PYTHON_TESTED[@]}")
 	)
 "

--- a/dev-python/requests/requests-2.28.1.ebuild
+++ b/dev-python/requests/requests-2.28.1.ebuild
@@ -21,7 +21,7 @@ SRC_URI="mirror://pypi/${P:0:1}/${PN}/${P}.tar.gz"
 LICENSE="Apache-2.0"
 SLOT="0"
 KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86"
-IUSE="socks5"
+IUSE="socks5 test-rust"
 
 RDEPEND="
 	>=dev-python/certifi-2017.4.17[${PYTHON_USEDEP}]
@@ -36,9 +36,9 @@ BDEPEND="
 		dev-python/pytest-httpbin[${PYTHON_USEDEP}]
 		dev-python/pytest-mock[${PYTHON_USEDEP}]
 		>=dev-python/PySocks-1.5.6[${PYTHON_USEDEP}]
-		!alpha? ( !hppa? ( !ia64? (
+		test-rust? (
 			dev-python/trustme[${PYTHON_USEDEP}]
-		) ) )
+		)
 	)
 "
 

--- a/dev-python/secretstorage/secretstorage-3.3.3.ebuild
+++ b/dev-python/secretstorage/secretstorage-3.3.3.ebuild
@@ -31,8 +31,8 @@ BDEPEND="
 		!hppa? ( !sparc? ( !s390? (
 			sys-apps/dbus
 			virtual/secret-service
-		)
-	) ) )
+		) ) )
+	)
 "
 
 distutils_enable_tests unittest

--- a/dev-python/werkzeug/werkzeug-2.2.2.ebuild
+++ b/dev-python/werkzeug/werkzeug-2.2.2.ebuild
@@ -22,6 +22,7 @@ SRC_URI="
 LICENSE="BSD"
 SLOT="0"
 KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86"
+IUSE="test-rust"
 
 RDEPEND="
 	>=dev-python/markupsafe-2.1.1[${PYTHON_USEDEP}]
@@ -34,12 +35,9 @@ BDEPEND="
 		dev-python/pytest-timeout[${PYTHON_USEDEP}]
 		dev-python/pytest-xprocess[${PYTHON_USEDEP}]
 		dev-python/watchdog[${PYTHON_USEDEP}]
-		!alpha? ( !arm? ( !hppa? ( !ia64? ( !s390? (
-			$(python_gen_cond_dep '
-				dev-python/cryptography[${PYTHON_USEDEP}]
-			' python3_{8..11} pypy3 # TODO: add py3.11 when ported
-			)
-		) ) ) ) )
+		test-rust? (
+			dev-python/cryptography[${PYTHON_USEDEP}]
+		)
 		!hppa? ( !ia64? ( !loong? (
 			$(python_gen_cond_dep '
 				dev-python/greenlet[${PYTHON_USEDEP}]

--- a/profiles/arch/base/use.force
+++ b/profiles/arch/base/use.force
@@ -1,5 +1,10 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
+
+# Michał Górny <mgorny@gentoo.org> (2022-10-09)
+# We want to run all tests by default.  This flag is disabled in wd40
+# profiles to avoid unresolved dependencies.
+test-rust
 
 # James Le Cuirot <chewi@gentoo.org> (2017-06-29)
 # Forced and masked by default. Unmask where necessary.

--- a/profiles/features/wd40/use.force
+++ b/profiles/features/wd40/use.force
@@ -1,0 +1,6 @@
+# Copyright 2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+# Michał Górny <mgorny@gentoo.org> (2022-10-09)
+# Disable tests requiring Rust.
+-test-rust

--- a/profiles/features/wd40/use.mask
+++ b/profiles/features/wd40/use.mask
@@ -3,6 +3,10 @@
 
 rust
 
+# Michał Górny <mgorny@gentoo.org> (2022-10-09)
+# Disable tests requiring Rust.
+test-rust
+
 # Sam James <sam@gentoo.org> (2022-08-26)
 # >=media-gfx/libimagequant-4 requires Rust.
 imagequant

--- a/profiles/use.desc
+++ b/profiles/use.desc
@@ -311,6 +311,7 @@ tcmalloc - Use the dev-util/google-perftools libraries to replace the malloc() i
 tcpd - Add support for TCP wrappers
 telemetry - Send anonymized usage information to upstream so they can better understand our users
 test - Enable dependencies and/or preparations necessary to run tests (usually controlled by FEATURES=test but can be toggled independently)
+test-rust - Enable important test dependencies that require Rust toolchain
 theora - Add support for the Theora Video Compression Codec
 threads - Add threads support for various packages. Usually pthreads
 tidy - Add support for HTML Tidy


### PR DESCRIPTION
Add a `test-rust` flag that's use-masked on wd40 an use-forced elsewhere. It's meant to handle these fancy cryptography deps that are required for important (e.g. TLS) tests.