### PR TITLE
dev-lang/zig: fix building with Clang 16, fix searching LLD 

### DIFF
--- a/dev-lang/zig/files/zig-0.9.1-fix-clang16.patch
+++ b/dev-lang/zig/files/zig-0.9.1-fix-clang16.patch
@@ -1,0 +1,23 @@
+From: Eric Joldasov <bratishkaerik@getgoogleoff.me>
+Fix building with Clang 16
+Upstream PR https://github.com/ziglang/zig/pull/13121
+
+--- a/src/stage1/parse_f128.c
++++ b/src/stage1/parse_f128.c
+@@ -983,14 +983,14 @@ static int isspace(int c)
+     return c == ' ' || (unsigned)c-'\t' < 5;
+ }
+ 
+-static inline float128_t makeInf128() {
++static inline float128_t makeInf128(void) {
+     union ldshape ux;
+     ux.i2.hi = 0x7fff000000000000UL;
+     ux.i2.lo = 0x0UL;
+     return ux.f;
+ }
+ 
+-static inline float128_t makeNaN128() {
++static inline float128_t makeNaN128(void) {
+     uint64_t rand = 0UL;
+     union ldshape ux;
+     ux.i2.hi = 0x7fff000000000000UL | (rand & 0xffffffffffffUL);

--- a/dev-lang/zig/zig-0.9.1-r3.ebuild
+++ b/dev-lang/zig/zig-0.9.1-r3.ebuild
@@ -23,6 +23,7 @@ IUSE="test +threads"
 RESTRICT="!test? ( test )"
 
 PATCHES=(
+	"${FILESDIR}/${P}-fix-clang16.patch"
 	"${FILESDIR}/${P}-fix-single-threaded.patch"
 	"${FILESDIR}/${P}-fix-riscv.patch"
 	"${FILESDIR}/${P}-fix-bad-hostname-segfault.patch"
@@ -59,6 +60,7 @@ src_configure() {
 		-DZIG_USE_CCACHE=OFF
 		-DZIG_PREFER_CLANG_CPP_DYLIB=ON
 		-DZIG_SINGLE_THREADED="$(usex !threads)"
+		-DCMAKE_PREFIX_PATH=$(get_llvm_prefix ${LLVM_MAX_SLOT})
 	)
 
 	cmake_src_configure


### PR DESCRIPTION
Upstream PR https://github.com/ziglang/zig/pull/13121
Signed-off-by: Eric Joldasov <bratishkaerik@getgoogleoff.me>

Patches has been accepted upstream.