### PR TITLE
dev-java/mockito: v1.9.5-r3 JAVADOC_ARGS="-source 8"

### DIFF
--- a/dev-java/mockito/mockito-1.9.5-r3.ebuild
+++ b/dev-java/mockito/mockito-1.9.5-r3.ebuild
@@ -27,3 +27,5 @@ DEPEND=">=virtual/jdk-1.8:*
 RDEPEND=">=virtual/jre-1.8:*
 	${CP_DEPEND}"
 BDEPEND="app-arch/unzip"
+
+JAVADOC_ARGS="-source 8"


### PR DESCRIPTION
Copied from dev-java/xml-commons-external,
commit f69ad493f113b84fdac42efb7996aa5b599187b4

Closes: https://bugs.gentoo.org/876706

Signed-off-by: Volkmar W. Pogatzki <gentoo@pogatzki.net>