### PR TITLE
dev-libs/trio: Fix -Werror=strict-prototypes

### DIFF
--- a/dev-libs/trio/trio-1.17.ebuild
+++ b/dev-libs/trio/trio-1.17.ebuild
@@ -6,7 +6,7 @@ EAPI=8
 DOCS_BUILDER="doxygen"
 DOCS_DIR="doc"
 
-inherit docs
+inherit autotools docs
 
 DESCRIPTION="Portable string functions, focus on the *printf() and *scanf() clones"
 HOMEPAGE="https://daniel.haxx.se/projects/trio/"
@@ -15,6 +15,12 @@ SRC_URI="https://github.com/orbea/trio/releases/download/v${PV}/${P}.tar.gz"
 LICENSE="trio"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
+
+src_prepare() {
+	default
+	# Required to fix -Werror=strict-prototypes configure errors
+	eautoreconf
+}
 
 src_compile() {
 	default


### PR DESCRIPTION
Reference: https://archives.gentoo.org/gentoo-dev/message/dd9f2d3082b8b6f8dfbccb0639e6e240