### PR TITLE
net-nntp/sabnzbd: fix test dependency

### DIFF
--- a/net-nntp/sabnzbd/sabnzbd-3.6.1-r1.ebuild
+++ b/net-nntp/sabnzbd/sabnzbd-3.6.1-r1.ebuild
@@ -66,6 +66,7 @@ BDEPEND="
 			dev-python/werkzeug[${PYTHON_USEDEP}]
 			dev-python/xmltodict[${PYTHON_USEDEP}]
 		')
+		app-arch/p7zip
 		www-apps/chromedriver-bin
 	)
 "


### PR DESCRIPTION
Add app-arch/p7zip so unit tests don't fail.

Closes: https://bugs.gentoo.org/876929
Signed-off-by: Joe Kappus <joe@wt.gd>