### PR TITLE
net-proxy/torsocks: unset upstream in metadata.xml

### DIFF
--- a/net-proxy/torsocks/metadata.xml
+++ b/net-proxy/torsocks/metadata.xml
@@ -5,8 +5,4 @@
 		<email>blueness@gentoo.org</email>
 		<name>Anthony G. Basile</name>
 	</maintainer>
-	<upstream>
-		<remote-id type="google-code">torsocks</remote-id>
-		<remote-id type="github">dgoulet/torsocks</remote-id>
-	</upstream>
 </pkgmetadata>


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/757885
Signed-off-by: Craig Andrews <candrews@gentoo.org>