### PR TITLE
net-nntp/sabnzbd: add rest of possible rdeps to tdeps

### DIFF
--- a/net-nntp/sabnzbd/sabnzbd-3.6.1-r1.ebuild
+++ b/net-nntp/sabnzbd/sabnzbd-3.6.1-r1.ebuild
@@ -67,6 +67,8 @@ BDEPEND="
 			dev-python/xmltodict[${PYTHON_USEDEP}]
 		')
 		app-arch/p7zip
+		app-arch/unrar
+		app-arch/unzip
 		www-apps/chromedriver-bin
 	)
 "


### PR DESCRIPTION
zip handling on tinderbox was failing without unzip. Since rar will likely fail next adding unrar as well.

Closes: https://bugs.gentoo.org/877073
Signed-off-by: Joe Kappus <joe@wt.gd>