### PR TITLE
media-libs/openal: add rtkit use flag

### DIFF
--- a/media-libs/openal/openal-1.22.2-r1.ebuild
+++ b/media-libs/openal/openal-1.22.2-r1.ebuild
@@ -21,7 +21,7 @@ LICENSE="LGPL-2+ BSD"
 SLOT="0"
 KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~mips ppc ppc64 ~riscv sparc x86 ~amd64-linux ~x86-linux"
 IUSE="
-	alsa coreaudio debug jack oss pipewire portaudio pulseaudio sdl sndio qt5
+	alsa coreaudio debug jack oss pipewire portaudio pulseaudio sdl sndio qt5 rtkit
 	cpu_flags_x86_sse cpu_flags_x86_sse2 cpu_flags_x86_sse4_1
 	cpu_flags_arm_neon
 "
@@ -43,6 +43,7 @@ RDEPEND="
 	)
 	sdl? ( media-libs/libsdl2[${MULTILIB_USEDEP}] )
 	sndio? ( media-sound/sndio:=[${MULTILIB_USEDEP}] )
+	rtkiy? ( sys-auth/rtkit )
 "
 DEPEND="
 	${RDEPEND}
@@ -63,6 +64,8 @@ multilib_src_configure() {
 		-DALSOFT_{BACKEND,REQUIRE}_PULSEAUDIO=$(usex pulseaudio)
 		-DALSOFT_{BACKEND,REQUIRE}_SDL2=$(usex sdl)
 		-DALSOFT_{BACKEND,REQUIRE}_SNDIO=$(usex sndio)
+		-DALSOFT_{BACKEND,REQUIRE}_RTKIT=$(usex rtkit)
+		-DALSOFT_RTKIT=$(usex rtkit)
 
 		-DALSOFT_UTILS=$(multilib_is_native_abi && echo "ON" || echo "OFF")
 		-DALSOFT_NO_CONFIG_UTIL=$(usex qt5 "$(multilib_is_native_abi && echo "OFF" || echo "ON")" ON)


### PR DESCRIPTION
OpenAL produces erroneous error messages if rtkit isn't installed: it (presumably, incorrectly) decides [rtkit support is present](https://github.com/kcat/openal-soft/blob/1b28a24f6e917380536d882384aba388e331329e/CMakeLists.txt#L683) and then [fails to set runtime priority with rtkit](https://github.com/kcat/openal-soft/blob/1b28a24f6e917380536d882384aba388e331329e/core/helpers.cpp#L483) because it is not, in fact, present. On my system, it causes an error like this:

    [ALSOFT] (EE) Could not query RTKit: No such file or directory (2)

The pull request adds an rtkit use flag that turns RTKit support on/off. Not sure if this is the right thing to do, though.