### PR TITLE
sys-libs/libxcrypt: fix binary cross compilation

### DIFF
--- a/sys-libs/libxcrypt/libxcrypt-4.4.28-r1.ebuild
+++ b/sys-libs/libxcrypt/libxcrypt-4.4.28-r1.ebuild
@@ -165,6 +165,7 @@ get_xcpkgconfigdir() {
 
 multilib_src_configure() {
 	local -a myconf=(
+		--host=${CTARGET}
 		--disable-werror
 		--libdir=$(get_xclibdir)
 		--with-pkgconfigdir=$(get_xcpkgconfigdir)
@@ -195,6 +196,16 @@ multilib_src_configure() {
 		;;
 		*) die "Unexpected MULTIBUILD_ID: ${MULTIBUILD_ID}";;
 	esac
+
+	tc-export PKG_CONFIG
+
+	if is_cross; then
+		if tc-is-clang; then
+			export CC="${CTARGET}-clang"
+		else
+			export CC="${CTARGET}-gcc"
+		fi
+	fi
 
 	ECONF_SOURCE="${S}" econf "${myconf[@]}"
 }

--- a/sys-libs/libxcrypt/libxcrypt-4.4.28-r2.ebuild
+++ b/sys-libs/libxcrypt/libxcrypt-4.4.28-r2.ebuild
@@ -167,12 +167,23 @@ get_xcpkgconfigdir() {
 
 multilib_src_configure() {
 	local -a myconf=(
+		--host=${CTARGET}
 		--disable-werror
 		--libdir=$(get_xclibdir)
 		--with-pkgconfigdir=$(get_xcpkgconfigdir)
 		--includedir=$(get_xcincludedir)
 		--mandir="$(get_xcmandir)"
 	)
+
+	tc-export PKG_CONFIG
+
+	if is_cross; then
+		if tc-is-clang; then
+			export CC="${CTARGET}-clang"
+		else
+			export CC="${CTARGET}-gcc"
+		fi
+	fi
 
 	if use elibc_musl; then
 		# musl declares getcontext and swapcontext in ucontext.h,


### PR DESCRIPTION
Even though all files are installed in the proper places when cross compiling, further testing revealed the libxcrypt binary itself is not correctly cross-complied for the target architecture, instead it is compiled for the host.

Set up the proper variables to ensure the binary is built for the correct architecture.

Before:
libcrypt.so.2.0.0: ELF 64-bit LSB shared object, x86-64, version 1 (SYSV), dynamically linked, BuildID[xxHash]=0d041ee2539129be, stripped

After:
libcrypt.so.2.0.0: ELF 64-bit LSB shared object, ARM aarch64, version 1 (SYSV), dynamically linked, BuildID[xxHash]=ba09206297aebce3, stripped

Closes: https://bugs.gentoo.org/877093
Signed-off-by: Adrian Ratiu <adrian.ratiu@collabora.com>