### PR TITLE
dist-kernel eclasses: better KV deduction and override support

### DIFF
--- a/eclass/dist-kernel-utils.eclass
+++ b/eclass/dist-kernel-utils.eclass
@@ -155,5 +155,21 @@ dist-kernel_reinstall_initramfs() {
 		"${kernel_dir}/System.map"
 }
 
+# @FUNCTION: dist-kernel_PV_to_KV
+# @USAGE: <pv>
+# @DESCRIPTION:
+# Convert a Gentoo-style ebuild version to kernel "x.y.z[-rcN]" version.
+dist-kernel_PV_to_KV() {
+	debug-print-function ${FUNCNAME} "${@}"
+
+	[[ ${#} -ne 1 ]] && die "${FUNCNAME}: invalid arguments"
+	local pv=${1}
+
+	local kv=${pv%%_*}
+	[[ -z $(ver_cut 3- "${kv}") ]] && kv+=".0"
+	[[ ${pv} == *_* ]] && kv+=-${pv#*_}
+	echo "${kv}"
+}
+
 _DIST_KERNEL_UTILS=1
 fi

--- a/eclass/kernel-build.eclass
+++ b/eclass/kernel-build.eclass
@@ -150,7 +150,7 @@ kernel-build_src_test() {
 	emake O="${WORKDIR}"/build "${MAKEARGS[@]}" \
 		INSTALL_MOD_PATH="${T}" "${targets[@]}"
 
-	local ver="${PV}${KV_LOCALVERSION}"
+	local ver="${KV_FULL}${KV_LOCALVERSION}"
 	kernel-install_test "${ver}" \
 		"${WORKDIR}/build/$(dist-kernel_get_image_path)" \
 		"${T}/lib/modules/${ver}"
@@ -159,7 +159,7 @@ kernel-build_src_test() {
 # @FUNCTION: kernel-build_src_install
 # @DESCRIPTION:
 # Install the built kernel along with subset of sources
-# into /usr/src/linux-${PV}.  Install the modules.  Save the config.
+# into /usr/src/linux-${KV_FULL}.  Install the modules.  Save the config.
 kernel-build_src_install() {
 	debug-print-function ${FUNCNAME} "${@}"
 
@@ -177,7 +177,7 @@ kernel-build_src_install() {
 	# note: we're using mv rather than doins to save space and time
 	# install main and arch-specific headers first, and scripts
 	local kern_arch=$(tc-arch-kernel)
-	local ver="${PV}${KV_LOCALVERSION}"
+	local ver="${KV_FULL}${KV_LOCALVERSION}"
 	dodir "/usr/src/linux-${ver}/arch/${kern_arch}"
 	mv include scripts "${ED}/usr/src/linux-${ver}/" || die
 	mv "arch/${kern_arch}/include" \

--- a/eclass/tests/dist-kernel-utils.sh
+++ b/eclass/tests/dist-kernel-utils.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Copyright 2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+source tests-common.sh || exit
+
+inherit dist-kernel-utils
+# TODO: hack because tests-common don't implement ver_cut
+EAPI=6 inherit eapi7-ver
+
+test_PV_to_KV() {
+	local kv=${1}
+	local exp_PV=${2}
+
+	tbegin "dist-kernel_PV_to_KV ${kv} -> ${exp_PV}"
+	local val=$(dist-kernel_PV_to_KV "${kv}")
+	[[ ${val} == ${exp_PV} ]]
+	tend $?
+}
+
+test_PV_to_KV 6.0_rc1 6.0.0-rc1
+test_PV_to_KV 6.0 6.0.0
+test_PV_to_KV 6.0.1_rc1 6.0.1-rc1
+test_PV_to_KV 6.0.1 6.0.1
+
+texit


### PR DESCRIPTION
As requested by @thesamesam, this enables us to package x.y and x.y-rcN kernels.

CC @gentoo/dist-kernel 