### PR TITLE
app-office/planner: new live ebuild, fix 814152, 784086 in old ebuild 

### DIFF
--- a/app-office/planner/metadata.xml
+++ b/app-office/planner/metadata.xml
@@ -5,4 +5,7 @@
     <email>gnome@gentoo.org</email>
     <name>Gentoo GNOME Desktop</name>
   </maintainer>
+  <use>
+    <flag name="libgda">Database/GDA support</flag>
+  </use>
 </pkgmetadata>

--- a/app-office/planner/planner-0.14.6_p20130520-r3.ebuild
+++ b/app-office/planner/planner-0.14.6_p20130520-r3.ebuild
@@ -1,0 +1,67 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+GNOME2_LA_PUNT="yes"
+
+inherit gnome2
+
+DESCRIPTION="Project manager for Gnome"
+HOMEPAGE="https://wiki.gnome.org/Apps/Planner"
+if [[ "${PV}" == "9999" ]] ; then
+	EGIT_REPO_URI="https://gitlab.gnome.org/World/planner.git"
+	inherit git-r3
+	SRC_URI=""
+else
+	SRC_URI="https://dev.gentoo.org/~eva/distfiles/${PN}/${P}.tar.xz"
+	KEYWORDS="~alpha ~amd64 ~ppc ~sparc ~x86"
+fi
+
+SLOT="0"
+LICENSE="GPL-2"
+
+IUSE="examples"
+
+RDEPEND="
+	>=dev-libs/glib-2.6:2
+	>=x11-libs/gtk+-2.24:2
+	>=gnome-base/gconf-2.10:2
+	>=gnome-base/libgnomecanvas-2.10
+	>=gnome-base/libglade-2.4:2.0
+	>=dev-libs/libxml2-2.6.27:2
+	>=dev-libs/libxslt-1.1.23
+"
+DEPEND="${RDEPEND}"
+
+BDEPEND="
+	dev-util/gtk-doc-am
+	app-text/docbook-xml-dtd:4.1.2
+	>=dev-util/intltool-0.35.5
+	gnome-base/gnome-common
+	virtual/pkgconfig
+	app-text/rarian
+"
+
+S="${WORKDIR}/${PN}-0.14.6"
+src_configure() {
+	# FIXME: disable eds backend for now, it fails, upstream bug #654005
+	# FIXME: disable eds for now, bug #784086
+	# We need to set compile-warnings to a different value as it doesn't use
+	# standard macro: https://bugzilla.gnome.org/703067
+	gnome2_src_configure \
+		--disable-python \
+		--disable-python-plugin \
+		--disable-eds \
+		--disable-eds-backend \
+		--with-database=no \
+		--disable-update-mimedb \
+		--enable-compile-warnings=yes
+}
+
+src_install() {
+	gnome2_src_install
+	mv "${ED}"/usr/share/doc/planner "${ED}"/usr/share/doc/${PF} || die
+	if ! use examples; then
+		rm -rf "${D}/usr/share/doc/${PF}/examples"
+	fi
+}

--- a/app-office/planner/planner-9999.ebuild
+++ b/app-office/planner/planner-9999.ebuild
@@ -1,0 +1,71 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit gnome.org gnome2-utils meson xdg
+
+DESCRIPTION="Project manager for Gnome"
+HOMEPAGE="https://wiki.gnome.org/Apps/Planner"
+if [[ "${PV}" == "9999" ]] ; then
+	EGIT_REPO_URI="https://gitlab.gnome.org/World/planner.git"
+	inherit git-r3
+	SRC_URI=""
+else
+	KEYWORDS="~amd64"
+fi
+
+SLOT="0"
+LICENSE="GPL-2+"
+IUSE="examples gtk-doc libgda" # eds
+
+RDEPEND="
+	>=dev-libs/glib-2.50:2
+	>=x11-libs/gtk+-3.22:3
+	>=dev-libs/libxml2-2.6.27:2
+	>=dev-libs/libxslt-1.1.23
+	libgda? ( >=gnome-extra/libgda-1.0:5 )
+"
+	# eds support is broken for now
+	# eds? (
+	# 	>=gnome-extra/evolution-data-server-3.6:=
+	# )
+DEPEND="${RDEPEND}"
+
+BDEPEND="
+	gtk-doc? (
+		dev-util/gtk-doc
+		app-text/docbook-xml-dtd:4.1.2
+	)
+	virtual/pkgconfig
+	sys-devel/gettext
+"
+
+src_configure() {
+	local emesonargs=(
+		$(meson_feature libgda database-gda)
+		# $(meson_feature eds)
+		-Deds=disabled # upstream says it's broken
+		$(meson_use examples)
+		$(meson_use gtk-doc gtk_doc)
+		-Dsimple-priority-scheduling=false # upstream says it's experimental
+	)
+	meson_src_configure
+}
+
+src_install() {
+	meson_src_install
+	if use examples; then
+		mv "${ED}"/usr/share/doc/planner "${ED}"/usr/share/doc/${PF} || die
+	fi
+}
+
+pkg_postinst() {
+	xdg_pkg_postinst
+	gnome2_schemas_update
+}
+
+pkg_postrm() {
+	xdg_pkg_postrm
+	gnome2_schemas_update
+}


### PR DESCRIPTION
I prepared the 9999 ebuild to be used as a normal ebuild as well, once upstream has released a new version.