### PR TITLE
games-emulation/pcsxr: add 1.9.95, drop 1.9.94_p20190306 + patch

### DIFF
--- a/games-emulation/pcsxr/files/pcsxr-1.9.95-harfbuzz-dep-fix.patch
+++ b/games-emulation/pcsxr/files/pcsxr-1.9.95-harfbuzz-dep-fix.patch
@@ -1,0 +1,79 @@
+new file mode 100644
+--- /dev/null
++++ b/cmake/FindHarfBuzz.cmake
+@@ -0,0 +1,65 @@
++# https://raw.githubusercontent.com/SFTtech/openage/master/buildsystem/modules/FindHarfBuzz.cmake
++# Copyright 2015-2016 the openage authors. See copying.md for legal info.
++
++# FindHarfBuzz
++# ---------
++#
++# Locate HarfBuzz, the awesome text shaping library.
++#
++# The module defines the following variables:
++#
++# ::
++#
++#    HarfBuzz_FOUND - Found HarfBuzz library
++#    HarfBuzz_INCLUDE_DIRS - HarfBuzz include directories
++#    HarfBuzz_LIBRARIES - The libraries needed to use HarfBuzz
++#    HarfBuzz_VERSION_STRING - the version of HarfBuzz found
++#
++# Example Usage:
++#
++# ::
++#
++#     find_package(HarfBuzz REQUIRED)
++#     include_directories(${HarfBuzz_INCLUDE_DIRS})
++#
++# ::
++#
++#     add_executable(foo foo.cc)
++#     target_link_libraries(foo ${HarfBuzz_LIBRARIES})
++
++find_path(HarfBuzz_INCLUDE_DIR hb.h
++  PATH_SUFFIXES
++    harfbuzz
++)
++
++find_library(HarfBuzz_LIBRARY
++  NAMES harfbuzz libharfbuzz
++  PATH_SUFFIXES lib64 lib
++)
++
++if(HarfBuzz_INCLUDE_DIR)
++  set(HarfBuzz_VERSION_FILE "${HarfBuzz_INCLUDE_DIR}/harfbuzz/hb-version.h")
++  if(EXISTS "${HarfBuzz_VERSION_FILE}")
++    file(STRINGS "${HarfBuzz_VERSION_FILE}" hb_version_str
++         REGEX "^#define[\t ]+HB_VERSION_STRING[\t ]+\".*\"")
++
++    string(REGEX REPLACE "^#define[\t ]+HB_VERSION_STRING[\t ]+\"([^\"]*)\".*" "\\1"
++           HarfBuzz_VERSION_STRING "${hb_version_str}")
++    unset(hb_version_str)
++  endif()
++  unset(HarfBuzz_VERSION_FILE)
++endif()
++
++include(FindPackageHandleStandardArgs)
++find_package_handle_standard_args(HarfBuzz
++  FOUND_VAR HarfBuzz_FOUND
++  REQUIRED_VARS HarfBuzz_LIBRARY HarfBuzz_INCLUDE_DIR
++  VERSION_VAR HarfBuzz_VERSION_STRING
++)
++
++if(HarfBuzz_FOUND)
++  set(HarfBuzz_INCLUDE_DIRS "${HarfBuzz_INCLUDE_DIR}")
++  set(HarfBuzz_LIBRARIES "${HarfBuzz_LIBRARY}")
++endif()
++
++mark_as_advanced(HarfBuzz_INCLUDE_DIR HarfBuzz_LIBRARY)
+--- a/cmake/FindPango.cmake
++++ b/cmake/FindPango.cmake
+@@ -30,6 +30,7 @@
+ find_package(PkgConfig)
+ 
+ set(Pango_DEPS
++  HarfBuzz
+   GLib)
+ 
+ if(PKG_CONFIG_FOUND)

--- a/games-emulation/pcsxr/pcsxr-1.9.95.ebuild
+++ b/games-emulation/pcsxr/pcsxr-1.9.95.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -43,6 +43,10 @@ BDEPEND="
 	app-arch/unzip
 	dev-util/intltool
 	sys-devel/gettext:0"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-1.9.95-harfbuzz-dep-fix.patch"
+)
 
 src_configure() {
 	append-cflags -fcommon


### PR DESCRIPTION
Version bump to 1.95.5 plus this also applies the patch to fix the harfbuzz dependency issue.

Closes: https://bugs.gentoo.org/791034
Thanks-to: Agostino Sarubbo
Signed-off-by: Ian Jordan <immoloism@gmail.com>