### PR TITLE
app-office/scribus:

### DIFF
--- a/app-office/scribus/scribus-1.5.8-r2.ebuild
+++ b/app-office/scribus/scribus-1.5.8-r2.ebuild
@@ -14,7 +14,7 @@ SRC_URI="mirror://sourceforge/project/${PN}/${PN}-devel/${PV}/${P}.tar.xz"
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="amd64 ppc ppc64 x86"
-IUSE="+boost debug examples graphicsmagick hunspell +minimal osg +pdf scripts +templates tk"
+IUSE="antiword +boost debug examples graphicsmagick hunspell +minimal osg +pdf scripts +templates tk"
 
 REQUIRED_USE="${PYTHON_REQUIRED_USE}
 	tk? ( scripts )"
@@ -63,6 +63,7 @@ DEPEND="${PYTHON_DEPS}
 	)
 "
 RDEPEND="${DEPEND}
+	antiword? ( app-text/antiword )
 	app-text/ghostscript-gpl
 "
 BDEPEND="


### PR DESCRIPTION
Signed-off-by: Jeffery Gazso <jeff.gazso@gmail.com>

I added the `antiword` keyword which optionally allows app-text/antiword to be used as a document import filter for legacy MS Word `.doc` files. Upstream *antiword* is bundled with MS Windows builds but not Linux builds, though *antiword* is usable as an import filter if it happens to be present on the system. Making this an optional keyword that isn't enabled by default mimics upstream behavior.

Because the keyword does not represent a change in default build-time behavior there is no need to rebuild app-office/scribus. Therefore, the revision number was NOT incremented from r2 to r3 to prevent unnecessary rebuilds.