### PR TITLE
x11-base/xorg-apps: add sys-power/acpilight as alternative to xbacklight

### DIFF
--- a/x11-base/xorg-apps/xorg-apps-1.ebuild
+++ b/x11-base/xorg-apps/xorg-apps-1.ebuild
@@ -36,7 +36,7 @@ RDEPEND="
 	x11-apps/viewres
 	x11-apps/x11perf
 	x11-apps/xauth
-	x11-apps/xbacklight
+	|| ( x11-apps/xbacklight sys-power/acpilight )
 	x11-apps/xbiff
 	x11-apps/xcalc
 	x11-apps/xclipboard


### PR DESCRIPTION
Signed-off-by: Stefan Strogin <steils@gentoo.org>