### PR TITLE
sys-libs/musl: Filter LTO

### DIFF
--- a/sys-libs/musl/musl-1.2.2-r8.ebuild
+++ b/sys-libs/musl/musl-1.2.2-r8.ebuild
@@ -88,6 +88,7 @@ src_prepare() {
 }
 
 src_configure() {
+	filter-lto # bug #877343
 	tc-getCC ${CTARGET}
 
 	just_headers && export CC=true

--- a/sys-libs/musl/musl-1.2.3-r4.ebuild
+++ b/sys-libs/musl/musl-1.2.3-r4.ebuild
@@ -104,6 +104,7 @@ src_prepare() {
 }
 
 src_configure() {
+	filter-lto # bug #877343
 	tc-getCC ${CTARGET}
 
 	just_headers && export CC=true

--- a/sys-libs/musl/musl-1.2.3.ebuild
+++ b/sys-libs/musl/musl-1.2.3.ebuild
@@ -88,6 +88,7 @@ src_prepare() {
 }
 
 src_configure() {
+	filter-lto # bug #877343
 	tc-getCC ${CTARGET}
 
 	just_headers && export CC=true

--- a/sys-libs/musl/musl-9999.ebuild
+++ b/sys-libs/musl/musl-9999.ebuild
@@ -104,6 +104,7 @@ src_prepare() {
 }
 
 src_configure() {
+	filter-lto # bug #877343
 	tc-getCC ${CTARGET}
 
 	just_headers && export CC=true


### PR DESCRIPTION
After discussing my bug with dalais on #musl I was informed that LTO has a negative impact on Musl so fixing the issue I highlight rather than filtering wouldn't be the desired outcome for the user.

This will also help crossdev users as a bonus as -flto applies to the crosstoolchain and can be hard to spot at first.

Chat log to comfirm:

immolo: I ran into the -flto issue while testing musl built with lto and the only thing I can find on it was a workaround in 2015.
immolo: My question though is it even worth having lto enabled on musl in the first place as every distro just seems to	filter it so
there must be a reason
dalias: not only is it not worth it. it's negative value
dalias: makes musl larger and slower
dalias: if you wanted libc.a to get LTO'd into static programs, *that* might have some value
dalias: but LTO on libc.so is worse than worthless


Closes: https://bugs.gentoo.org/877343
Thanks-to: dalias
Signed-off-by: Ian Jordan <immoloism@gmail.com>
