### PR TITLE
libxcrypt: add headers-only install

### DIFF
--- a/sys-libs/libxcrypt/metadata.xml
+++ b/sys-libs/libxcrypt/metadata.xml
@@ -13,6 +13,7 @@
 	<use>
 		<flag name="compat">Build with compatibility interfaces for other crypt implementations</flag>
 		<flag name="system">Install as system libcrypt.so rather than to an alternate directory (will collide with <pkg>sys-libs/glibc</pkg>'s version)</flag>
+		<flag name="headers-only">Build and install only the headers.</flag>
 	</use>
 	<upstream>
 		<remote-id type="github">besser82/libxcrypt</remote-id>


### PR DESCRIPTION
While bootstrapping a pure LLVM based toolchain, compiler-rt depends on crypt.h, but libxcrypt cannot be built yet because it requires a working compiler runtime, so the solution is:

1. Install libxcrypt headers-only
2. Build compiler-rt & the rest of llvm/clang
3. Build full libxcrypt

Thus we add the ability to install libxcrypt headers-only, similar to how glibc does it.

Closes: https://bugs.gentoo.org/877567
Signed-off-by: Adrian Ratiu <adrian.ratiu@collabora.com>