### PR TITLE
profiles/default/linux/mips/17.0/musl: DROP package.mask

### DIFF
--- a/profiles/default/linux/mips/17.0/musl/package.mask
+++ b/profiles/default/linux/mips/17.0/musl/package.mask
@@ -1,4 +1,0 @@
-# Copyright 2022 Gentoo Authors
-# Distributed under the terms of the GNU General Public License v2
-
->sys-apps/kbd-1.15.5-r99


### PR DESCRIPTION
Seems to be a legacy mask for sys-apps/kbd and is a blocker for being able to supply MIPS Musl stage3 files.

I have tested building kbd on mipsel, mips64 and mips32el crossdev environments.

Signed-off-by: Ian Jordan <immoloism@gmail.com>