### PR TITLE
sci-geosciences/josm-bin: add link to upstream changelog to metadata

### DIFF
--- a/sci-geosciences/josm-bin/josm-bin-18570.ebuild
+++ b/sci-geosciences/josm-bin/josm-bin-18570.ebuild
@@ -7,6 +7,7 @@ inherit desktop java-utils-2 xdg
 
 DESCRIPTION="Java-based editor for the OpenStreetMap project"
 HOMEPAGE="https://josm.openstreetmap.de/"
+# PV should be stable here https://josm.openstreetmap.de/wiki/StartupPage
 SRC_URI="https://josm.openstreetmap.de/download/josm-snapshot-${PV}.jar"
 S="${WORKDIR}"
 

--- a/sci-geosciences/josm-bin/metadata.xml
+++ b/sci-geosciences/josm-bin/metadata.xml
@@ -13,4 +13,7 @@
     <email>sci-geosciences@gentoo.org</email>
     <name>Gentoo Geosciences Project</name>
   </maintainer>
+  <upstream>
+    <changelog>https://josm.openstreetmap.de/wiki/StartupPage</changelog>
+  </upstream>
 </pkgmetadata>


### PR DESCRIPTION
This might not really be the full changelog, but it tells the gentoo maintainer which versions upstream considers stable and therefore which ones we want to ship.

Signed-off-by: Henning Schild <henning@hennsch.de>