### PR TITLE
app-arch/cpio, app-arch/tar: install as `gcpio` and `gtar`

### DIFF
--- a/app-arch/cpio/cpio-2.13-r3.ebuild
+++ b/app-arch/cpio/cpio-2.13-r3.ebuild
@@ -1,0 +1,50 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools
+
+DESCRIPTION="A file archival tool which can also read and write tar files"
+HOMEPAGE="https://www.gnu.org/software/cpio/cpio.html"
+SRC_URI="mirror://gnu/cpio/${P}.tar.bz2"
+SRC_URI+=" https://dev.gentoo.org/~sam/distfiles/${CATEGORY}/${PN}/${P}-CVE-2021-38185.patch.xz"
+
+LICENSE="GPL-3+"
+SLOT="0"
+#KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+IUSE="nls"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-2.12-non-gnu-compilers.patch #275295
+	"${WORKDIR}"/${P}-CVE-2021-38185.patch
+	"${FILESDIR}"/${PN}-2.13-sysmacros-glibc-2.26.patch
+	"${FILESDIR}"/${PN}-2.13-fix-no-absolute-filenames-revert-CVE-2015-1197-handling.patch
+)
+
+src_prepare() {
+	default
+
+	# Drop after 2.13 (only here for CVE patch)
+	eautoreconf
+}
+
+src_configure() {
+	local myeconfargs=(
+		$(use_enable nls)
+		--bindir="${EPREFIX}"/bin
+		--with-rmt="${EPREFIX}"/usr/sbin/rmt
+	)
+
+	econf "${myeconfargs[@]}"
+}
+
+src_install() {
+	default
+	# install as gcpio for better compatibility with non-GNU userland
+	# and make cpio as a symlink
+	mv "${ED}"/bin/{,g}cpio || die
+	dosym gcpio /bin/cpio
+	mv "${ED}"/usr/share/man/man1/{,g}cpio.1 || die
+	dosym gcpio.1 /usr/share/man/man1/cpio.1
+}

--- a/app-arch/tar/tar-1.34-r1.ebuild
+++ b/app-arch/tar/tar-1.34-r1.ebuild
@@ -1,0 +1,84 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+VERIFY_SIG_OPENPGP_KEY_PATH="${BROOT}"/usr/share/openpgp-keys/tar.asc
+inherit verify-sig
+
+DESCRIPTION="Use this to make tarballs :)"
+HOMEPAGE="https://www.gnu.org/software/tar/"
+SRC_URI="mirror://gnu/tar/${P}.tar.xz
+	https://alpha.gnu.org/gnu/tar/${P}.tar.xz"
+SRC_URI+=" verify-sig? (
+		mirror://gnu/tar/${P}.tar.xz.sig
+		https://alpha.gnu.org/gnu/tar/${P}.tar.xz.sig
+	)"
+
+LICENSE="GPL-3+"
+SLOT="0"
+if [[ -z "$(ver_cut 3)" ]] || [[ "$(ver_cut 3)" -lt 90 ]] ; then
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+fi
+IUSE="acl minimal nls selinux xattr"
+
+RDEPEND="
+	acl? ( virtual/acl )
+	selinux? ( sys-libs/libselinux )
+"
+DEPEND="${RDEPEND}
+	xattr? ( elibc_glibc? ( sys-apps/attr ) )
+"
+BDEPEND="
+	nls? ( sys-devel/gettext )
+	verify-sig? ( sec-keys/openpgp-keys-tar )
+"
+
+src_configure() {
+	local myeconfargs=(
+		--bindir="${EPREFIX}"/bin
+		--enable-backup-scripts
+		--libexecdir="${EPREFIX}"/usr/sbin
+		$(use_with acl posix-acls)
+		$(use_enable nls)
+		$(use_with selinux)
+		$(use_with xattr xattrs)
+	)
+
+	FORCE_UNSAFE_CONFIGURE=1 econf "${myeconfargs[@]}"
+}
+
+src_install() {
+	default
+
+	# a nasty yet required piece of baggage
+	exeinto /etc
+	doexe "${FILESDIR}"/rmt
+
+	mv "${ED}"/usr/sbin/backup{,-tar} || die
+	mv "${ED}"/usr/sbin/restore{,-tar} || die
+
+	if use minimal ; then
+		find "${ED}"/etc "${ED}"/*bin/ "${ED}"/usr/*bin/ \
+			-type f -a '!' '(' -name tar -o -name tar ')' \
+			-delete || die
+	fi
+
+	# autoconf looks for gtar before tar (in configure scripts), hence
+	# in Prefix it is important that it is there, otherwise, a gtar from
+	# the host system (FreeBSD, Solaris, Darwin) will be found instead
+	# of the Prefix provided (GNU) tar
+	# rename tar to gtar, and make tar a symlink
+	mv "${ED}"/bin/{,g}tar || die
+	dosym gtar /bin/tar
+
+	if ! use minimal; then
+		mv "${ED}"/usr/sbin/{,g}rmt || die
+		dosym grmt /usr/sbin/rmt
+	fi
+
+	mv "${ED}"/usr/share/man/man1/{,g}tar.1 || die
+	dosym gtar.1 /usr/share/man/man1/tar.1
+	mv "${ED}"/usr/share/man/man8/{,g}rmt.8 || die
+	dosym grmt.8 /usr/share/man/man8/rmt.8
+}


### PR DESCRIPTION
Do it like FreeBSD and partially like Fedora because:

1. It's ugly to do it for Prefix only (i.e. Prefix installs have `gtar`, normal don't).
2. If we do it, then `gtar` should be the actual executable.
3. Making `cpio` and `tar` symlinks makes it easier to replace them with `bsdcpio` and `bsdtar` respectively (think of all the CVEs avoided!).