### PR TITLE
mail-filter/afew: enable py3.10

### DIFF
--- a/mail-filter/afew/afew-3.0.1.ebuild
+++ b/mail-filter/afew/afew-3.0.1.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
 DISTUTILS_SINGLE_IMPL=1
 DISTUTILS_USE_SETUPTOOLS=rdepend
-PYTHON_COMPAT=( python3_{7,8,9} )
+PYTHON_COMPAT=( python3_{7..10} )
 
 inherit distutils-r1
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/845996
Signed-off-by: Guillaume Seren <guillaumeseren@gmail.com>