### PR TITLE
net-misc/icaclient: RDEPEND on sys-libs/llvm-libunwind

### DIFF
--- a/net-misc/icaclient/icaclient-22.9.0.21-r2.ebuild
+++ b/net-misc/icaclient/icaclient-22.9.0.21-r2.ebuild
@@ -35,11 +35,6 @@ REQUIRES_EXCLUDE="${REQUIRES_EXCLUDE}
 	libgstpbutils-0.10.so.0
 	libgstreamer-0.10.so.0
 "
-# we have binaries which depend on some ancient libunwind
-REQUIRES_EXCLUDE="${REQUIRES_EXCLUDE}
-	libunwind.so.1
-"
-
 RDEPEND="
 	app-crypt/libsecret
 	dev-libs/atk
@@ -65,6 +60,7 @@ RDEPEND="
 	sys-apps/util-linux
 	sys-libs/libcxx
 	sys-libs/libcxxabi
+	sys-libs/llvm-libunwind
 	sys-libs/zlib
 	virtual/krb5
 	virtual/libudev


### PR DESCRIPTION
Some binaries need libunwind.so.1 and installing sys-libs/llvm-libunwind used to be an issue because it caused a conflict with net-fs/samba. Plus it was unknown if the llvm version was the correct one, or if icaclient in fact needed an old sys-libs/libunwind.

Now it is clear that sys-libs/llvm-libunwind is correct. https://docs.citrix.com/en-us/citrix-workspace-app-for-linux/configure-xenapp.html#adding-the-libunwind-12-library-dependency-for-llvm-12

Closes: https://bugs.gentoo.org/855374
Signed-off-by: Henning Schild <henning@hennsch.de>