### PR TITLE
dev-util/nvidia-cuda-toolkit-11.8: Add 'cuda_profiler_api' to installed packages

### DIFF
--- a/dev-util/nvidia-cuda-toolkit/nvidia-cuda-toolkit-11.8.0.ebuild
+++ b/dev-util/nvidia-cuda-toolkit/nvidia-cuda-toolkit-11.8.0.ebuild
@@ -65,7 +65,7 @@ src_install() {
 
 	# Install standard sub packages
 	local builddirs=(
-		builds/cuda_{cccl,cudart,cuobjdump,cuxxfilt,memcheck,nvcc,nvdisasm,nvml_dev,nvprune,nvrtc,nvtx}
+		builds/cuda_{cccl,cudart,cuobjdump,cuxxfilt,memcheck,nvcc,nvdisasm,nvml_dev,nvprune,nvrtc,nvtx,profiler_api}
 		builds/lib{cublas,cufft,curand,cusolver,cusparse,npp,nvjpeg}
 		$(usex profiler "builds/cuda_nvprof builds/cuda_cupti" "")
 		$(usex vis-profiler "builds/cuda_nvvp" "")


### PR DESCRIPTION
Provides headers for profiling functions in libcuda.

Signed-off-by: Jan Vesely <jano.vesely@gmail.com>