### PR TITLE
dev-java/slf4j-reload4j: exclude one more test on ppc64

### DIFF
--- a/dev-java/slf4j-reload4j/slf4j-reload4j-2.0.3.ebuild
+++ b/dev-java/slf4j-reload4j/slf4j-reload4j-2.0.3.ebuild
@@ -73,3 +73,10 @@ src_prepare() {
 	#         at org.slf4j.reload4j.EventFieldsTest.testWhetherEventsFieldsAreSet(EventFieldsTest.java:35)
 	rm src/test/java/org/slf4j/reload4j/EventFieldsTest.java || die "cannot remove test"
 }
+
+src_test() {
+	if use ppc64; then #877903
+		JAVA_TEST_EXCLUDES+=( org.slf4j.reload4j.Reload4jMultithreadedInitializationTest )
+	fi
+	java-pkg-simple_src_test
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/877903
Signed-off-by: Volkmar W. Pogatzki <gentoo@pogatzki.net>