### PR TITLE
dev-python/requests: allow charset normalizer >=2 and <4

### DIFF
--- a/dev-python/requests/files/requests-2.28.1-fix-charsetnormalizer-assert.patch
+++ b/dev-python/requests/files/requests-2.28.1-fix-charsetnormalizer-assert.patch
@@ -1,0 +1,71 @@
+From 52b292ba7875dbc4c6f4825ae03def649ffae15d Mon Sep 17 00:00:00 2001
+From: deedy5 <65482418+deedy5@users.noreply.github.com>
+Date: Thu, 20 Oct 2022 10:04:34 +0000
+Subject: [PATCH 1/3] charset_normalizer>=2,<4
+
+---
+ setup.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/setup.py b/setup.py
+index 23977ed77a..b679181bda 100755
+--- a/setup.py
++++ b/setup.py
+@@ -59,7 +59,7 @@ def run_tests(self):
+     sys.exit()
+ 
+ requires = [
+-    "charset_normalizer>=2,<3",
++    "charset_normalizer>=2,<4",
+     "idna>=2.5,<4",
+     "urllib3>=1.21.1,<1.27",
+     "certifi>=2017.4.17",
+
+From f0616c31cb1181960ac474070ac6f0a65078e199 Mon Sep 17 00:00:00 2001
+From: deedy5 <65482418+deedy5@users.noreply.github.com>
+Date: Thu, 20 Oct 2022 10:05:19 +0000
+Subject: [PATCH 2/3] charset_normalizer>=2,<4
+
+---
+ setup.cfg | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/setup.cfg b/setup.cfg
+index 33af66eb15..0c167eb8c9 100644
+--- a/setup.cfg
++++ b/setup.cfg
+@@ -5,7 +5,7 @@ provides-extra =
+ 	use_chardet_on_py3
+ requires-dist = 
+ 	certifi>=2017.4.17
+-	charset_normalizer>=2,<3
++	charset_normalizer>=2,<4
+ 	idna>=2.5,<4
+ 	urllib3>=1.21.1,<1.27
+
+From 1bbeb3ce1b6b284734d7a27b6dec2db7b3299a89 Mon Sep 17 00:00:00 2001
+From: deedy5 <65482418+deedy5@users.noreply.github.com>
+Date: Thu, 20 Oct 2022 14:28:23 +0000
+Subject: [PATCH 3/3] Update Dependency with charset_normalizer >= 2.0.0 <
+ 4.0.0
+
+---
+ requests/__init__.py | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/requests/__init__.py b/requests/__init__.py
+index 7ac8e297b8..5812c85d8a 100644
+--- a/requests/__init__.py
++++ b/requests/__init__.py
+@@ -80,8 +80,8 @@ def check_compatibility(urllib3_version, chardet_version, charset_normalizer_ver
+     elif charset_normalizer_version:
+         major, minor, patch = charset_normalizer_version.split(".")[:3]
+         major, minor, patch = int(major), int(minor), int(patch)
+-        # charset_normalizer >= 2.0.0 < 3.0.0
+-        assert (2, 0, 0) <= (major, minor, patch) < (3, 0, 0)
++        # charset_normalizer >= 2.0.0 < 4.0.0
++        assert (2, 0, 0) <= (major, minor, patch) < (4, 0, 0)
+     else:
+         raise Exception("You need either charset_normalizer or chardet installed")
+ 
+

--- a/dev-python/requests/requests-2.28.1-r1.ebuild
+++ b/dev-python/requests/requests-2.28.1-r1.ebuild
@@ -1,0 +1,73 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+# please keep this ebuild at EAPI 7 -- sys-apps/portage dep
+EAPI=7
+
+DISTUTILS_USE_PEP517=setuptools
+PYTHON_COMPAT=( python3_{8..11} pypy3 )
+PYTHON_REQ_USE="threads(+)"
+
+inherit distutils-r1
+
+DESCRIPTION="HTTP library for human beings"
+HOMEPAGE="
+	https://requests.readthedocs.io/
+	https://github.com/psf/requests/
+	https://pypi.org/project/requests/
+"
+SRC_URI="mirror://pypi/${P:0:1}/${PN}/${P}.tar.gz"
+
+LICENSE="Apache-2.0"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+IUSE="socks5 test-rust"
+
+RDEPEND="
+	>=dev-python/certifi-2017.4.17[${PYTHON_USEDEP}]
+	dev-python/charset_normalizer[${PYTHON_USEDEP}]
+	<dev-python/idna-4[${PYTHON_USEDEP}]
+	<dev-python/urllib3-1.27[${PYTHON_USEDEP}]
+	socks5? ( >=dev-python/PySocks-1.5.6[${PYTHON_USEDEP}] )
+"
+
+BDEPEND="
+	test? (
+		dev-python/pytest-httpbin[${PYTHON_USEDEP}]
+		dev-python/pytest-mock[${PYTHON_USEDEP}]
+		>=dev-python/PySocks-1.5.6[${PYTHON_USEDEP}]
+		test-rust? (
+			dev-python/trustme[${PYTHON_USEDEP}]
+		)
+	)
+"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-2.28.0-drop-dependency-warnings.patch
+	"${FILESDIR}"/${PN}-2.28.1-fix-charsetnormalizer-assert.patch
+)
+
+distutils_enable_tests pytest
+
+python_test() {
+	local EPYTEST_DESELECT=(
+		# Internet (doctests)
+		requests/__init__.py::requests
+		requests/api.py::requests.api.request
+		requests/models.py::requests.models.PreparedRequest
+		requests/sessions.py::requests.sessions.Session
+		# require IPv4 interface in 10.* range
+		tests/test_requests.py::TestTimeout::test_connect_timeout
+		tests/test_requests.py::TestTimeout::test_total_timeout_connect
+		# TODO: openssl?
+		tests/test_requests.py::TestRequests::test_pyopenssl_redirect
+	)
+
+	if ! has_version "dev-python/trustme[${PYTHON_USEDEP}]"; then
+		EPYTEST_DESELECT+=(
+			tests/test_requests.py::TestRequests::test_https_warnings
+		)
+	fi
+
+	epytest
+}


### PR DESCRIPTION
charset-normalizer 3.0.0 has been released in ::gentoo
Fix crashed problem when installed charset_normalizer-3.0.0

Closes: https://bugs.gentoo.org/878035
Patch from https://github.com/psf/requests/pull/6261 and backport to dev-python/requests-2.28.1