### PR TITLE
net-misc/dhcp: Adding acct-user/dhcp and acct-group/dhcp to BDPEND

### DIFF
--- a/net-misc/dhcp/dhcp-4.4.3_p1.ebuild
+++ b/net-misc/dhcp/dhcp-4.4.3_p1.ebuild
@@ -21,9 +21,12 @@ SLOT="0"
 KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86"
 IUSE="+client ipv6 ldap selinux +server ssl vim-syntax"
 
-DEPEND="
+BDEPEND="
 	acct-group/dhcp
-	acct-user/dhcp
+        acct-user/dhcp"
+
+DEPEND="
+	${BDEPEND}
 	client? (
 		kernel_linux? (
 			ipv6? ( sys-apps/iproute2 )

--- a/net-misc/dhcp/dhcp-4.4.3_p1.ebuild
+++ b/net-misc/dhcp/dhcp-4.4.3_p1.ebuild
@@ -26,7 +26,6 @@ BDEPEND="
         acct-user/dhcp"
 
 DEPEND="
-	${BDEPEND}
 	client? (
 		kernel_linux? (
 			ipv6? ( sys-apps/iproute2 )
@@ -37,7 +36,9 @@ DEPEND="
 		net-nds/openldap:=
 		ssl? ( dev-libs/openssl:= )
 	)"
-RDEPEND="${DEPEND}
+RDEPEND="
+	${BDEPEND}
+	${DEPEND}
 	selinux? ( sec-policy/selinux-dhcp )
 	vim-syntax? ( app-vim/dhcpd-syntax )"
 


### PR DESCRIPTION
This error occurs when cross-compiling net-misc / dhcp and the dhcp user is missing from the build host:

make[2]: Leaving directory '/var/tmp/targ-portage/aarch64-linux-gnu/portage/net-misc/dhcp-4.4.3_p1/work/dhcp-4.4.3-P1'
make[1]: Leaving directory '/var/tmp/targ-portage/aarch64-linux-gnu/portage/net-misc/dhcp-4.4.3_p1/work/dhcp-4.4.3-P1'
install: invalid user ‘dhcp’
 * ERROR: net-misc/dhcp-4.4.3_p1::gentoo failed (install phase):
 *   dodir failed

Below change fixes this issue.


Signed-off-by: Wiktor Jaskulski <root@GDN-N-WIKTORJ.advaoptical.com>