### PR TITLE
sys-process/cronie: Adding acct-group/crontab to BDEPEND

### DIFF
--- a/sys-process/cronie/cronie-1.6.1-r1.ebuild
+++ b/sys-process/cronie/cronie-1.6.1-r1.ebuild
@@ -13,8 +13,10 @@ LICENSE="ISC BSD BSD-2 GPL-2"
 KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86"
 IUSE="+anacron +inotify pam selinux"
 
+BDEPEND="acct-group/crontab"
+
 DEPEND="
-	acct-group/crontab
+	${BDEPEND}
 	pam? ( sys-libs/pam )
 	anacron? (
 		!sys-process/anacron

--- a/sys-process/cronie/cronie-1.6.1-r1.ebuild
+++ b/sys-process/cronie/cronie-1.6.1-r1.ebuild
@@ -16,7 +16,6 @@ IUSE="+anacron +inotify pam selinux"
 BDEPEND="acct-group/crontab"
 
 DEPEND="
-	${BDEPEND}
 	pam? ( sys-libs/pam )
 	anacron? (
 		!sys-process/anacron
@@ -25,7 +24,9 @@ DEPEND="
 	)
 	selinux? ( sys-libs/libselinux )
 "
-RDEPEND="${DEPEND}
+RDEPEND="
+	${BDEPEND}
+	${DEPEND}
 	sys-apps/debianutils
 "
 

--- a/sys-process/cronie/cronie-1.6.1-r2.ebuild
+++ b/sys-process/cronie/cronie-1.6.1-r2.ebuild
@@ -13,8 +13,10 @@ LICENSE="ISC BSD BSD-2 GPL-2"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
 IUSE="+anacron +inotify pam selinux"
 
+BDEPEND="acct-group/crontab"
+
 DEPEND="
-	acct-group/crontab
+	${BDEPEND}
 	pam? ( sys-libs/pam )
 	anacron? (
 		!sys-process/anacron

--- a/sys-process/cronie/cronie-1.6.1-r2.ebuild
+++ b/sys-process/cronie/cronie-1.6.1-r2.ebuild
@@ -16,7 +16,6 @@ IUSE="+anacron +inotify pam selinux"
 BDEPEND="acct-group/crontab"
 
 DEPEND="
-	${BDEPEND}
 	pam? ( sys-libs/pam )
 	anacron? (
 		!sys-process/anacron
@@ -25,7 +24,9 @@ DEPEND="
 	)
 	selinux? ( sys-libs/libselinux )
 "
-RDEPEND="${DEPEND}
+RDEPEND="
+	${BDEPEND}
+	${DEPEND}
 	sys-apps/debianutils
 "
 


### PR DESCRIPTION
This error occurs when cross-compiling sys-process/cronie and the crontab group is missing from the build host:

make[2]: Leaving directory '/var/tmp/targ-portage/aarch64-linux-gnu/portage/sys-process/cronie-1.6.1-r2/work/cronie-cronie-1.6.1'
make[1]: Leaving directory '/var/tmp/targ-portage/aarch64-linux-gnu/portage/sys-process/cronie-1.6.1-r2/work/cronie-cronie-1.6.1'
install: invalid group ‘crontab’
 * ERROR: sys-process/cronie-1.6.1-r2::gentoo failed (install phase):
 *   dodir failed

Below changes fixes the issue for cronie-1.6.1-r1 and cronie-1.6.1-r2.

Signed-off-by: Wiktor Jaskulski <wjaskulski@adva.com>