### PR TITLE
net-libs/liblockfile: Adding acct-group/mail to BDEPEND

### DIFF
--- a/net-libs/liblockfile/liblockfile-1.17.ebuild
+++ b/net-libs/liblockfile/liblockfile-1.17.ebuild
@@ -15,7 +15,7 @@ KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~m68k ~mips ppc ppc64 ~riscv ~s390 s
 IUSE="static-libs"
 
 RDEPEND="acct-group/mail"
-DEPEND="${RDEPEND}"
+BDEPEND="${RDEPEND}"
 
 DOCS=( Changelog README )
 


### PR DESCRIPTION
This error occurs when cross-compiling net-libs/liblockfile and the mail group is missing from the build host:

install: invalid group ‘mail’
make: *** [Makefile:81: install_common] Error 1
 * ERROR: net-libs/liblockfile-1.17::gentoo failed (install phase):
 *   emake failed

This change fixes the issue.

Signed-off-by: Wiktor Jaskulski <wjaskulski@adva.com>