### PR TITLE
sys-libs/libseccomp: Rebase libseccomp-python-shared.patch

### DIFF
--- a/sys-libs/libseccomp/files/libseccomp-2.6.0-python-shared.patch
+++ b/sys-libs/libseccomp/files/libseccomp-2.6.0-python-shared.patch
@@ -1,0 +1,25 @@
+From 594fecb16833c693ac0cff8f857aec0edd097077 Mon Sep 17 00:00:00 2001
+Message-Id: <594fecb16833c693ac0cff8f857aec0edd097077.1666701554.git.mprivozn@redhat.com>
+From: Michal Privoznik <mprivozn@redhat.com>
+Date: Tue, 25 Oct 2022 14:39:07 +0200
+Subject: [PATCH] Link python module against shared library
+
+---
+ src/python/setup.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/python/setup.py b/src/python/setup.py
+index 46f9a73..85deb03 100755
+--- a/src/python/setup.py
++++ b/src/python/setup.py
+@@ -40,6 +40,6 @@ setup(
+ 	ext_modules = cythonize([
+ 		Extension("seccomp", ["seccomp.pyx"],
+ 			# unable to handle libtool libraries directly
+-			extra_objects=["../.libs/libseccomp.a"]),
++			extra_objects=["../.libs/libseccomp.so"]),
+ 	])
+ )
+-- 
+2.37.4
+

--- a/sys-libs/libseccomp/libseccomp-9999.ebuild
+++ b/sys-libs/libseccomp/libseccomp-9999.ebuild
@@ -37,7 +37,7 @@ BDEPEND="${DEPEND}
 	python? ( dev-python/cython[${PYTHON_USEDEP}] )"
 
 PATCHES=(
-	"${FILESDIR}"/libseccomp-python-shared.patch
+	"${FILESDIR}"/libseccomp-2.6.0-python-shared.patch
 	"${FILESDIR}"/libseccomp-2.5.3-skip-valgrind.patch
 )
 


### PR DESCRIPTION
The libseccomp-python-shared.patch that makes python module depend on libseccomp.so instead of linking it statically in does no longer apply cleanly. Rebase it.

Signed-off-by: Michal Privoznik <michal.privoznik@gmail.com>