### PR TITLE
media-libs/libjxl: unkeyword 0.7.0_pre20220329 for !arm

### DIFF
--- a/media-libs/libjxl/libjxl-0.7.0_pre20220329.ebuild
+++ b/media-libs/libjxl/libjxl-0.7.0_pre20220329.ebuild
@@ -9,7 +9,7 @@ DESCRIPTION="JPEG XL image format reference implementation"
 HOMEPAGE="https://github.com/libjxl/libjxl"
 
 SRC_URI="https://api.github.com/repos/libjxl/libjxl/tarball/fde214c5f4dc5ffd0360401a68df33182edf9226 -> ${P}.tar.gz"
-KEYWORDS="amd64 arm arm64 ppc ppc64 ~riscv sparc x86"
+KEYWORDS="arm"
 
 LICENSE="BSD"
 SLOT="0"


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/856037