### PR TITLE
dist-kernel version fixes: take two

### DIFF
--- a/eclass/kernel-build.eclass
+++ b/eclass/kernel-build.eclass
@@ -150,7 +150,7 @@ kernel-build_src_test() {
 	emake O="${WORKDIR}"/build "${MAKEARGS[@]}" \
 		INSTALL_MOD_PATH="${T}" "${targets[@]}"
 
-	local ver="${KV_FULL}${KV_LOCALVERSION}"
+	local ver="${PV}${KV_LOCALVERSION}"
 	kernel-install_test "${ver}" \
 		"${WORKDIR}/build/$(dist-kernel_get_image_path)" \
 		"${T}/lib/modules/${ver}"
@@ -159,7 +159,7 @@ kernel-build_src_test() {
 # @FUNCTION: kernel-build_src_install
 # @DESCRIPTION:
 # Install the built kernel along with subset of sources
-# into /usr/src/linux-${KV_FULL}.  Install the modules.  Save the config.
+# into /usr/src/linux-${PV}.  Install the modules.  Save the config.
 kernel-build_src_install() {
 	debug-print-function ${FUNCNAME} "${@}"
 
@@ -177,7 +177,7 @@ kernel-build_src_install() {
 	# note: we're using mv rather than doins to save space and time
 	# install main and arch-specific headers first, and scripts
 	local kern_arch=$(tc-arch-kernel)
-	local ver="${KV_FULL}${KV_LOCALVERSION}"
+	local ver="${PV}${KV_LOCALVERSION}"
 	dodir "/usr/src/linux-${ver}/arch/${kern_arch}"
 	mv include scripts "${ED}/usr/src/linux-${ver}/" || die
 	mv "arch/${kern_arch}/include" \

--- a/eclass/kernel-build.eclass
+++ b/eclass/kernel-build.eclass
@@ -150,10 +150,14 @@ kernel-build_src_test() {
 	emake O="${WORKDIR}"/build "${MAKEARGS[@]}" \
 		INSTALL_MOD_PATH="${T}" "${targets[@]}"
 
-	local ver="${PV}${KV_LOCALVERSION}"
-	kernel-install_test "${ver}" \
+	local dir_ver=${PV}${KV_LOCALVERSION}
+	local relfile=${WORKDIR}/build/include/config/kernel.release
+	local module_ver
+	module_ver=$(<"${relfile}") || die
+
+	kernel-install_test "${module_ver}" \
 		"${WORKDIR}/build/$(dist-kernel_get_image_path)" \
-		"${T}/lib/modules/${ver}"
+		"${T}/lib/modules/${module_ver}"
 }
 
 # @FUNCTION: kernel-build_src_install
@@ -177,14 +181,15 @@ kernel-build_src_install() {
 	# note: we're using mv rather than doins to save space and time
 	# install main and arch-specific headers first, and scripts
 	local kern_arch=$(tc-arch-kernel)
-	local ver="${PV}${KV_LOCALVERSION}"
-	dodir "/usr/src/linux-${ver}/arch/${kern_arch}"
-	mv include scripts "${ED}/usr/src/linux-${ver}/" || die
+	local dir_ver=${PV}${KV_LOCALVERSION}
+	local kernel_dir=/usr/src/linux-${dir_ver}
+	dodir "${kernel_dir}/arch/${kern_arch}"
+	mv include scripts "${ED}${kernel_dir}/" || die
 	mv "arch/${kern_arch}/include" \
-		"${ED}/usr/src/linux-${ver}/arch/${kern_arch}/" || die
+		"${ED}${kernel_dir}/arch/${kern_arch}/" || die
 	# some arches need module.lds linker script to build external modules
 	if [[ -f arch/${kern_arch}/kernel/module.lds ]]; then
-		insinto "/usr/src/linux-${ver}/arch/${kern_arch}/kernel"
+		insinto "${kernel_dir}/arch/${kern_arch}/kernel"
 		doins "arch/${kern_arch}/kernel/module.lds"
 	fi
 
@@ -192,7 +197,7 @@ kernel-build_src_install() {
 	find -type f '!' '(' -name 'Makefile*' -o -name 'Kconfig*' ')' \
 		-delete || die
 	find -type l -delete || die
-	cp -p -R * "${ED}/usr/src/linux-${ver}/" || die
+	cp -p -R * "${ED}${kernel_dir}/" || die
 
 	cd "${WORKDIR}" || die
 	# strip out-of-source build stuffs from modprep
@@ -203,31 +208,35 @@ kernel-build_src_install() {
 			'(' -name '.*' -a -not -name '.config' ')' \
 		')' -delete || die
 	rm modprep/source || die
-	cp -p -R modprep/. "${ED}/usr/src/linux-${ver}"/ || die
+	cp -p -R modprep/. "${ED}${kernel_dir}"/ || die
 
 	# install the kernel and files needed for module builds
-	insinto "/usr/src/linux-${ver}"
+	insinto "${kernel_dir}"
 	doins build/{System.map,Module.symvers}
 	local image_path=$(dist-kernel_get_image_path)
-	cp -p "build/${image_path}" "${ED}/usr/src/linux-${ver}/${image_path}" || die
+	cp -p "build/${image_path}" "${ED}${kernel_dir}/${image_path}" || die
 
 	# building modules fails with 'vmlinux has no symtab?' if stripped
-	use ppc64 && dostrip -x "/usr/src/linux-${ver}/${image_path}"
+	use ppc64 && dostrip -x "${kernel_dir}/${image_path}"
 
 	# Install vmlinux with debuginfo when requested
 	if use debug; then
 		if [[ "${image_path}" != "vmlinux" ]]; then
-			mv "build/vmlinux" "${ED}/usr/src/linux-${ver}/vmlinux" || die
+			mv "build/vmlinux" "${ED}${kernel_dir}/vmlinux" || die
 		fi
-		dostrip -x "/usr/src/linux-${ver}/vmlinux"
+		dostrip -x "${kernel_dir}/vmlinux"
 	fi
 
 	# strip empty directories
 	find "${D}" -type d -empty -exec rmdir {} + || die
 
+	local relfile=${ED}${kernel_dir}/include/config/kernel.release
+	local module_ver
+	module_ver=$(<"${relfile}") || die
+
 	# fix source tree and build dir symlinks
-	dosym ../../../usr/src/linux-${ver} /lib/modules/${ver}/build
-	dosym ../../../usr/src/linux-${ver} /lib/modules/${ver}/source
+	dosym "../../../${kernel_dir}" "/lib/modules/${module_ver}/build"
+	dosym "../../../${kernel_dir}" "/lib/modules/${module_ver}/source"
 
 	save_config build/.config
 }

--- a/eclass/kernel-install.eclass
+++ b/eclass/kernel-install.eclass
@@ -14,12 +14,19 @@
 # kinds of Distribution Kernel packages, including both kernels built
 # from source and distributed as binaries.  The eclass relies on the
 # ebuild installing a subset of built kernel tree into
-# /usr/src/linux-${KV_FULL}${KV_LOCALVERSION} containing the kernel
-# image in its standard location and System.map.
+# /usr/src/linux-${PV} containing the kernel image in its standard
+# location and System.map.
 #
 # The eclass exports src_test, pkg_postinst and pkg_postrm.
 # Additionally, the inherited mount-boot eclass exports pkg_pretend.
 # It also stubs out pkg_preinst and pkg_prerm defined by mount-boot.
+
+# @ECLASS_VARIABLE: KV_LOCALVERSION
+# @DEFAULT_UNSET
+# @DESCRIPTION:
+# A string containing the kernel LOCALVERSION, e.g. '-gentoo'.
+# Needs to be set only when installing binary kernels,
+# kernel-build.eclass obtains it from kernel config.
 
 if [[ ! ${_KERNEL_INSTALL_ECLASS} ]]; then
 
@@ -29,19 +36,6 @@ case ${EAPI} in
 esac
 
 inherit dist-kernel-utils mount-boot toolchain-funcs
-
-# @ECLASS_VARIABLE: KV_FULL
-# @DESCRIPTION:
-# The "x.y.z[-rcN]" kernel version.  The default is derived from PV
-# following upstream kernel versioning rules.
-: "${KV_FULL:=$(dist-kernel_PV_to_KV "${PV}")}"
-
-# @ECLASS_VARIABLE: KV_LOCALVERSION
-# @DEFAULT_UNSET
-# @DESCRIPTION:
-# A string containing the kernel LOCALVERSION, e.g. '-gentoo'.
-# Needs to be set only when installing binary kernels,
-# kernel-build.eclass obtains it from kernel config.
 
 SLOT="${PV}"
 IUSE="+initramfs test"
@@ -409,18 +403,18 @@ kernel-install_src_test() {
 kernel-install_pkg_preinst() {
 	debug-print-function ${FUNCNAME} "${@}"
 
-	local ver="${KV_FULL}${KV_LOCALVERSION}"
+	local ver="${PV}${KV_LOCALVERSION}"
 	local kdir="${ED}/usr/src/linux-${ver}"
 	local relfile="${kdir}/include/config/kernel.release"
 	[[ ! -d ${kdir} ]] && die "Kernel directory ${kdir} not installed!"
 	[[ ! -f ${relfile} ]] && die "Release file ${relfile} not installed!"
 	local release="$(<"${relfile}")"
-	if [[ ${release} != ${KV_FULL}* ]]; then
+	if [[ ${release} != ${PV}* ]]; then
 		eerror "Kernel release mismatch!"
-		eerror "  expected (KV_FULL): ${KV_FULL}*"
-		eerror "               found: ${release}"
+		eerror "  expected (PV): ${PV}*"
+		eerror "          found: ${release}"
 		eerror "Please verify that you are applying the correct patches."
-		die "Kernel release mismatch (${release} instead of ${KV_FULL}*)"
+		die "Kernel release mismatch (${release} instead of ${PV}*)"
 	fi
 	if [[ -L ${EROOT}/lib && ${EROOT}/lib -ef ${EROOT}/usr/lib ]]; then
 		# Adjust symlinks for merged-usr.
@@ -482,7 +476,7 @@ kernel-install_install_all() {
 kernel-install_pkg_postinst() {
 	debug-print-function ${FUNCNAME} "${@}"
 
-	local ver="${KV_FULL}${KV_LOCALVERSION}"
+	local ver="${PV}${KV_LOCALVERSION}"
 	kernel-install_update_symlink "${EROOT}/usr/src/linux" "${ver}"
 
 	if [[ -z ${ROOT} ]]; then
@@ -506,7 +500,7 @@ kernel-install_pkg_postrm() {
 	debug-print-function ${FUNCNAME} "${@}"
 
 	if [[ -z ${ROOT} ]] && use initramfs; then
-		local ver="${KV_FULL}${KV_LOCALVERSION}"
+		local ver="${PV}${KV_LOCALVERSION}"
 		local image_path=$(dist-kernel_get_image_path)
 		ebegin "Removing initramfs"
 		rm -f "${EROOT}/usr/src/linux-${ver}/${image_path%/*}"/initrd{,.uefi} &&
@@ -521,7 +515,7 @@ kernel-install_pkg_postrm() {
 kernel-install_pkg_config() {
 	[[ -z ${ROOT} ]] || die "ROOT!=/ not supported currently"
 
-	kernel-install_install_all "${KV_FULL}${KV_LOCALVERSION}"
+	kernel-install_install_all "${PV}${KV_LOCALVERSION}"
 }
 
 _KERNEL_INSTALL_ECLASS=1


### PR DESCRIPTION
So the plan to use transformed PV doesn't work for live ebuilds. Let's use PV for `/usr/src/linux*` directory, transformed PV for version check and get KV straight of the release file for module directory.