### PR TITLE
app-misc/tpconfig: revbump, fix build for clang16

### DIFF
--- a/app-misc/tpconfig/files/tpconfig-3.1.3-fix-automake-unrecognized-option.patch
+++ b/app-misc/tpconfig/files/tpconfig-3.1.3-fix-automake-unrecognized-option.patch
@@ -1,0 +1,16 @@
+Option "VERSION=1.2" is not recognized by automake anymore.
+
+Bug:https://bugs.gentoo.org/722356
+
+Signed-off-by: Pascal Jäger <pascal.jaeger@leimstift.de>
+
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -1,7 +1,6 @@
+ ## Process this file with automake to produce Makefile.in
+ # Source: $Id: Makefile.am,v 1.2 2000/11/05 21:50:25 cph Exp $
+
+-AUTOMAKE_OPTIONS = "VERSION=1.2"
+ bin_PROGRAMS = tpconfig
+ tpconfig_SOURCES = tpconfig.c synaptics.c ALPS.c utils.c
+ MAINTAINERCLEANFILES =  Makefile.in configure aclocal.m4 \

--- a/app-misc/tpconfig/files/tpconfig-3.1.3-fix-clang16-build.patch
+++ b/app-misc/tpconfig/files/tpconfig-3.1.3-fix-clang16-build.patch
@@ -1,0 +1,46 @@
+Clang16 does not implicitly include stdlib, so we have to manually include it.
+
+Bug:https://bugs.gentoo.org/871057
+
+Signed-off-by: Pascal Jäger <pascal.jaeger@leimstift.de>
+
+--- a/ALPS.c
++++ b/ALPS.c
+@@ -51,6 +51,7 @@ static char rcsid[]="$Header: /home/bruce/linux-stuff/tpconfig/tpconfig-3.1.1/RC
+
+ #include <fcntl.h>
+ #include <stdio.h>
++#include <stdlib.h>
+ #include <unistd.h>
+ #include <assert.h>
+ #include <sys/ioctl.h>
+--- a/synaptics.c
++++ b/synaptics.c
+@@ -78,6 +78,7 @@ static char rcsid[]="$Header: /home/bruce/linux-stuff/tpconfig/tpconfig-3.1.3/RC
+
+ #include <fcntl.h>
+ #include <stdio.h>
++#include <stdlib.h>
+ #include <unistd.h>
+ #include <assert.h>
+ #include <sys/ioctl.h>
+--- a/tpconfig.c
++++ b/tpconfig.c
+@@ -90,6 +90,7 @@ static char rcsid[]="$Id: tpconfig.c,v 2.13 2002/02/22 20:33:11 bruce Exp $";
+
+ #include <fcntl.h>
+ #include <stdio.h>
++#include <stdlib.h>
+ #include <unistd.h>
+ #include <assert.h>
+ #include <sys/ioctl.h>
+--- a/utils.c
++++ b/utils.c
+@@ -65,6 +65,7 @@ static char rcsid[]="$Header: /home/bruce/linux-stuff/tpconfig/tpconfig-3.1.3/RC
+
+ #include <fcntl.h>
+ #include <stdio.h>
++#include <stdlib.h>
+ #include <unistd.h>
+ #include <assert.h>
+ #include <sys/ioctl.h>

--- a/app-misc/tpconfig/tpconfig-3.1.3-r4.ebuild
+++ b/app-misc/tpconfig/tpconfig-3.1.3-r4.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
-inherit toolchain-funcs
+EAPI=8
+inherit autotools toolchain-funcs
 
 DESCRIPTION="Touchpad config for ALPS and Synaptics TPs. Controls tap/click behaviour"
 HOMEPAGE="http://www.compass.com/synaptics/"
@@ -12,8 +12,18 @@ LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="amd64 x86"
 
+PATCHES=(
+	"${FILESDIR}"/${P}-fix-automake-unrecognized-option.patch
+	"${FILESDIR}"/${P}-fix-clang16-build.patch
+)
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
 src_compile() {
-	emake CC="$(tc-getCC)"
+	emake
 }
 
 src_install() {


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/871057

Signed-off-by: Pascal Jäger <pascal.jaeger@leimstift.de>