### PR TITLE
sys-firmware/raspberrypi-wifi-ucode: fixed dodoc

### DIFF
--- a/sys-firmware/raspberrypi-wifi-ucode/raspberrypi-wifi-ucode-20210315.3_p7-r1.ebuild
+++ b/sys-firmware/raspberrypi-wifi-ucode/raspberrypi-wifi-ucode-20210315.3_p7-r1.ebuild
@@ -65,5 +65,5 @@ src_install() {
 	insinto /lib/firmware/cypress
 	doins debian/config/brcm80211/cypress/*
 
-	dodoc debian/config/brcm80211/LICENSE debian/changelog
+	dodoc debian/changelog
 }


### PR DESCRIPTION
removed installation of no longer provided LICENSE file

Signed-off-by: Dennis Lamm <expeditioneer@gentoo.org>