### PR TITLE
app-misc/gtk-sunlight: revbump, fix clang16 build, EAPI bump

### DIFF
--- a/app-misc/gtk-sunlight/files/gtk-sunlight-0.4.2-fix-function-declarations.patch
+++ b/app-misc/gtk-sunlight/files/gtk-sunlight-0.4.2-fix-function-declarations.patch
@@ -1,0 +1,32 @@
+Fix implicit function declarations as they are not supported by clang16 with standard settings.
+
+Bug: https://bugs.gentoo.org/874717
+
+Signed-off-by: Pascal Jäger <pascal.jaeger@leimstift.de>
+
+--- a/callbacks.c
++++ b/callbacks.c
+@@ -33,6 +33,12 @@ gpointer create_progressbar_window (ChData *data);
+ gboolean update_progress(gpointer data);
+ gpointer async_lengthy_func(gpointer data);
+
++extern void scale_box_sensitive (ChData *data, gboolean sensitive);
++extern gshort move_earth_true (ChData *data);
++extern void get_and_set_options (ChData *data);
++extern gshort get_map_position (ChData *data);
++extern gboolean is_peters (ChData *data);
++extern void button_sensitive (ChData *data, gboolean sensitive);
+ /***************************************
+        Window Callbacks
+ ***************************************/
+--- a/sunlight.c
++++ b/sunlight.c
+@@ -19,6 +19,8 @@
+
+ #include "support.h"
+
++extern void change_wallpaper (ChData *data);
++
+ void initialize_variables (ChData *data){
+        data->var.gi_rd1 = 1;
+        data->var.gi_rd2 = 1;

--- a/app-misc/gtk-sunlight/gtk-sunlight-0.4.2-r2.ebuild
+++ b/app-misc/gtk-sunlight/gtk-sunlight-0.4.2-r2.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 inherit toolchain-funcs xdg
 
@@ -19,6 +19,10 @@ RDEPEND="
 	x11-libs/gdk-pixbuf:2
 	x11-libs/gtk+:3"
 DEPEND="${RDEPEND}"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-fix-function-declarations.patch
+)
 
 src_compile() {
 	tc-export CC


### PR DESCRIPTION
Fix function declarations so clang16 does not complain.

Closes: https://bugs.gentoo.org/874717
Signed-off-by: Pascal Jäger <pascal.jaeger@leimstift.de>


See also stabilization request here: https://bugs.gentoo.org/878347