### PR TITLE
sci-libs/pcl: fix several issues

### DIFF
--- a/sci-libs/pcl/files/pcl-1.12.1-allow-configuration-of-install-dirs.patch
+++ b/sci-libs/pcl/files/pcl-1.12.1-allow-configuration-of-install-dirs.patch
@@ -1,0 +1,32 @@
+From c052f26112c17068ece2f52058e3130dd328269b Mon Sep 17 00:00:00 2001
+From: Bernd Waibel <waebbl-gentoo@posteo.net>
+Date: Thu, 27 Oct 2022 09:48:15 +0200
+Subject: [PATCH] allow configuration of install dirs
+
+Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>
+--- a/cmake/pcl_utils.cmake
++++ b/cmake/pcl_utils.cmake
+@@ -101,14 +101,18 @@ macro(SET_INSTALL_DIRS)
+       set(INCLUDE_INSTALL_ROOT "include") # Android, don't put into subdir
+     endif()
+     set(INCLUDE_INSTALL_DIR "${INCLUDE_INSTALL_ROOT}/pcl")
+-    set(DOC_INSTALL_DIR "share/doc/${PROJECT_NAME_LOWER}-${PCL_VERSION_MAJOR}.${PCL_VERSION_MINOR}")
++    if(NOT DEFINED DOC_INSTALL_DIR)
++      set(DOC_INSTALL_DIR "share/doc/${PROJECT_NAME_LOWER}-${PCL_VERSION_MAJOR}.${PCL_VERSION_MINOR}")
++    endif()
+     set(BIN_INSTALL_DIR "bin")
+     set(PKGCFG_INSTALL_DIR "${LIB_INSTALL_DIR}/pkgconfig")
+-    if(WIN32 AND NOT MINGW)
++    if(NOT DEFINED PCLCONFIG_INSTALL_DIR)
++      if(WIN32 AND NOT MINGW)
+         set(PCLCONFIG_INSTALL_DIR "cmake")
+       else()
+         set(PCLCONFIG_INSTALL_DIR "share/${PROJECT_NAME_LOWER}-${PCL_VERSION_MAJOR}.${PCL_VERSION_MINOR}")
+       endif()
++    endif()
+ endmacro()
+ 
+ 
+-- 
+2.38.1
+

--- a/sci-libs/pcl/files/pcl-1.12.1-fix-hardcoded-relative-directory-of-the-installed-cmake-files.patch
+++ b/sci-libs/pcl/files/pcl-1.12.1-fix-hardcoded-relative-directory-of-the-installed-cmake-files.patch
@@ -1,0 +1,22 @@
+From efb56391957ee0f64a407fe419c25122404a53e2 Mon Sep 17 00:00:00 2001
+From: Bernd Waibel <waebbl-gentoo@posteo.net>
+Date: Thu, 27 Oct 2022 13:59:15 +0200
+Subject: [PATCH] fix hardcoded relative directory of the installed cmake files
+
+Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>
+--- a/PCLConfig.cmake.in
++++ b/PCLConfig.cmake.in
+@@ -389,8 +389,8 @@ if(WIN32 AND NOT MINGW)
+     set(PCL_ALL_IN_ONE_INSTALLER ON)
+   endif()
+ else()
+-# PCLConfig.cmake is installed to PCL_ROOT/share/pcl-x.y
+-  get_filename_component(PCL_ROOT "${CMAKE_CURRENT_LIST_DIR}/../.." ABSOLUTE)
++# PCLConfig.cmake is installed to PCL_ROOT/share/cmake/pcl-x.y
++  get_filename_component(PCL_ROOT "${CMAKE_CURRENT_LIST_DIR}/../../.." ABSOLUTE)
+ endif()
+ 
+ # check whether PCLConfig.cmake is found into a PCL installation or in a build tree
+-- 
+2.38.1
+

--- a/sci-libs/pcl/pcl-1.12.1-r2.ebuild
+++ b/sci-libs/pcl/pcl-1.12.1-r2.ebuild
@@ -9,7 +9,7 @@ if [ "${PV#9999}" != "${PV}" ] ; then
 	EGIT_REPO_URI="https://github.com/PointCloudLibrary/pcl"
 fi
 
-inherit ${SCM} cmake multilib
+inherit ${SCM} cmake cuda
 
 if [ "${PV#9999}" != "${PV}" ] ; then
 	SRC_URI=""
@@ -24,7 +24,8 @@ DESCRIPTION="2D/3D image and point cloud processing"
 LICENSE="BSD"
 SLOT="0/1.12"
 IUSE="cuda doc opengl openni openni2 pcap png +qhull qt5 usb vtk cpu_flags_x86_sse test tutorials"
-RESTRICT="!test? ( test )"
+# tests need the gtest sources to be available at build time
+RESTRICT="test"
 
 RDEPEND="
 	>=sci-libs/flann-1.7.1
@@ -48,11 +49,17 @@ RDEPEND="
 "
 DEPEND="${RDEPEND}
 	!!dev-cpp/metslib
-	test? ( >=dev-cpp/gtest-1.6.0 )
 "
 BDEPEND="
-	doc? ( app-doc/doxygen )
-	tutorials? ( dev-python/sphinx dev-python/sphinxcontrib-doxylink )
+	doc? (
+		app-doc/doxygen[dot]
+		virtual/latex-base
+	)
+	tutorials? (
+		dev-python/sphinx
+		dev-python/sphinx_rtd_theme
+		dev-python/sphinxcontrib-doxylink
+	)
 	virtual/pkgconfig"
 
 REQUIRED_USE="
@@ -61,9 +68,25 @@ REQUIRED_USE="
 	tutorials? ( doc )
 "
 
+PATCHES=(
+	"${FILESDIR}"/${PN}-1.12.1-allow-configuration-of-install-dirs.patch
+	"${FILESDIR}"/${PN}-1.12.1-fix-hardcoded-relative-directory-of-the-installed-cmake-files.patch
+)
+
+src_prepare() {
+	if use cuda; then
+		cuda_src_prepare
+		cuda_add_sandbox -w
+	fi
+
+	cmake_src_prepare
+}
+
 src_configure() {
 	local mycmakeargs=(
+		"-DDOC_INSTALL_DIR=share/doc/${PF}"
 		"-DLIB_INSTALL_DIR=$(get_libdir)"
+		"-DPCLCONFIG_INSTALL_DIR=share/cmake/${PN}-$(ver_cut 1-2)"
 		"-DWITH_CUDA=$(usex cuda TRUE FALSE)"
 		"-DWITH_LIBUSB=$(usex usb TRUE FALSE)"
 		"-DWITH_OPENGL=$(usex opengl TRUE FALSE)"
@@ -77,7 +100,8 @@ src_configure() {
 		"-DPCL_ENABLE_SSE=$(usex cpu_flags_x86_sse TRUE FALSE)"
 		"-DWITH_DOCS=$(usex doc TRUE FALSE)"
 		"-DWITH_TUTORIALS=$(usex tutorials TRUE FALSE)"
-		"-DBUILD_TESTS=$(usex test TRUE FALSE)"
+		"-DBUILD_global_tests=FALSE"
 	)
+
 	cmake_src_configure
 }

--- a/sci-libs/pcl/pcl-9999.ebuild
+++ b/sci-libs/pcl/pcl-9999.ebuild
@@ -9,7 +9,7 @@ if [ "${PV#9999}" != "${PV}" ] ; then
 	EGIT_REPO_URI="https://github.com/PointCloudLibrary/pcl"
 fi
 
-inherit ${SCM} cmake multilib
+inherit ${SCM} cmake cuda
 
 if [ "${PV#9999}" != "${PV}" ] ; then
 	SRC_URI=""
@@ -24,7 +24,8 @@ DESCRIPTION="2D/3D image and point cloud processing"
 LICENSE="BSD"
 SLOT="0/1.12"
 IUSE="cuda doc opengl openni openni2 pcap png +qhull qt5 usb vtk cpu_flags_x86_sse test tutorials"
-RESTRICT="!test? ( test )"
+# tests need the gtest sources to be available at build time
+RESTRICT="test"
 
 RDEPEND="
 	>=sci-libs/flann-1.7.1
@@ -48,11 +49,17 @@ RDEPEND="
 "
 DEPEND="${RDEPEND}
 	!!dev-cpp/metslib
-	test? ( >=dev-cpp/gtest-1.6.0 )
 "
 BDEPEND="
-	doc? ( app-doc/doxygen )
-	tutorials? ( dev-python/sphinx dev-python/sphinxcontrib-doxylink )
+	doc? (
+		app-doc/doxygen[dot]
+		virtual/latex-base
+	)
+	tutorials? (
+		dev-python/sphinx
+		dev-python/sphinx_rtd_theme
+		dev-python/sphinxcontrib-doxylink
+	)
 	virtual/pkgconfig"
 
 REQUIRED_USE="
@@ -61,9 +68,25 @@ REQUIRED_USE="
 	tutorials? ( doc )
 "
 
+PATCHES=(
+	"${FILESDIR}"/${PN}-1.12.1-allow-configuration-of-install-dirs.patch
+	"${FILESDIR}"/${PN}-1.12.1-fix-hardcoded-relative-directory-of-the-installed-cmake-files.patch
+)
+
+src_prepare() {
+	if use cuda; then
+		cuda_src_prepare
+		cuda_add_sandbox -w
+	fi
+
+	cmake_src_prepare
+}
+
 src_configure() {
 	local mycmakeargs=(
+		"-DDOC_INSTALL_DIR=share/doc/${PF}"
 		"-DLIB_INSTALL_DIR=$(get_libdir)"
+		"-DPCLCONFIG_INSTALL_DIR=share/cmake/${PN}-$(ver_cut 1-2)"
 		"-DWITH_CUDA=$(usex cuda TRUE FALSE)"
 		"-DWITH_LIBUSB=$(usex usb TRUE FALSE)"
 		"-DWITH_OPENGL=$(usex opengl TRUE FALSE)"
@@ -77,7 +100,8 @@ src_configure() {
 		"-DPCL_ENABLE_SSE=$(usex cpu_flags_x86_sse TRUE FALSE)"
 		"-DWITH_DOCS=$(usex doc TRUE FALSE)"
 		"-DWITH_TUTORIALS=$(usex tutorials TRUE FALSE)"
-		"-DBUILD_TESTS=$(usex test TRUE FALSE)"
+		"-DBUILD_global_tests=FALSE"
 	)
+
 	cmake_src_configure
 }


### PR DESCRIPTION
- enable cuda sandbox to avoid sandbox violation, #869674
- patch the code for several installation directories to conform to FHS. This is just a hack and should be done using GNUInstallDirs and provided upstream to solve it properly, #853886
- add a dependency on virtual/latex-base to avoid an additional QA issue on latex not found, because the doxyfile uses LaTeX by default. Also depend on doxygen[dot] to avoid a cmake warning about missing doxygen component
- change test related cmake option to new value to avoid undefined cmake variables, #738996
- depend on dev-python/sphinx_rtd_theme to properly build tutorial docs with USE=tutorials, #849002
- restrict test, because it needs the gtest sources to be provided, the package alone seems not be enough.

Closes: https://bugs.gentoo.org/869674
Closes: https://bugs.gentoo.org/853886
Closes: https://bugs.gentoo.org/738996
Closes: https://bugs.gentoo.org/849002

Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>

**This PR is, strictly speaking, not restricted to a single topic. The single topic would be solving issues. If you prefer to have split this into several topic related PRs, just ping me and I split it.**