### PR TITLE
sys-libs/ncurses: don't populate /etc/terminfo/ when USE="-split-usr"

### DIFF
--- a/sys-libs/ncurses/ncurses-6.3_p20220423.ebuild
+++ b/sys-libs/ncurses/ncurses-6.3_p20220423.ebuild
@@ -351,8 +351,6 @@ multilib_src_install() {
 }
 
 multilib_src_install_all() {
-	# We need the basic terminfo files in /etc for embedded/recovery, bug #37026
-	einfo "Installing basic terminfo files in /etc..."
 	local terms=(
 		# Dumb/simple values that show up when using the in-kernel VT.
 		ansi console dumb linux
@@ -366,25 +364,34 @@ multilib_src_install_all() {
 		screen{,-256color}
 		screen.xterm-256color
 	)
-	local x
-	for x in "${terms[@]}"; do
-		local termfile=$(find "${ED}"/usr/share/terminfo/ -name "${x}" 2>/dev/null)
-		local basedir=$(basename "$(dirname "${termfile}")")
+	if use split-usr ; then
+		local x
+		# We need the basic terminfo files in /etc for embedded/recovery, bug #37026
+		einfo "Installing basic terminfo files in /etc..."
+		for x in "${terms[@]}"; do
+			local termfile=$(find "${ED}"/usr/share/terminfo/ -name "${x}" 2>/dev/null)
+			local basedir=$(basename "$(dirname "${termfile}")")
 
-		if [[ -n ${termfile} ]] ; then
-			dodir "/etc/terminfo/${basedir}"
-			mv "${termfile}" "${ED}/etc/terminfo/${basedir}/" || die
-			dosym "../../../../etc/terminfo/${basedir}/${x}" \
-				"/usr/share/terminfo/${basedir}/${x}"
-		fi
-	done
+			if [[ -n ${termfile} ]] ; then
+				dodir "/etc/terminfo/${basedir}"
+				mv "${termfile}" "${ED}/etc/terminfo/${basedir}/" || die
+				dosym "../../../../etc/terminfo/${basedir}/${x}" \
+					"/usr/share/terminfo/${basedir}/${x}"
+			fi
+		done
 
-	echo "CONFIG_PROTECT_MASK=\"/etc/terminfo\"" | newenvd - 50ncurses
+		echo "CONFIG_PROTECT_MASK=\"/etc/terminfo\"" | newenvd - 50ncurses
 
-	use minimal && rm -r "${ED}"/usr/share/terminfo*
-	# Because ncurses5-config --terminfo returns the directory we keep it
-	# bug #245374
-	keepdir /usr/share/terminfo
+		use minimal && rm -r "${ED}"/usr/share/terminfo*
+		# Because ncurses5-config --terminfo returns the directory we keep it
+		# bug #245374
+		keepdir /usr/share/terminfo
+	elif use minimal ; then
+		# Keep only the basic terminfo files
+		find "${ED}"/usr/share/terminfo/ \
+			-type f ${terms[*]/#/! -name } -delete , \
+			-type d -empty -delete || die
+	fi
 
 	cd "${S}" || die
 	dodoc ANNOUNCE MANIFEST NEWS README* TO-DO doc/*.doc

--- a/sys-libs/ncurses/ncurses-6.3_p20220924.ebuild
+++ b/sys-libs/ncurses/ncurses-6.3_p20220924.ebuild
@@ -413,8 +413,6 @@ multilib_src_install() {
 }
 
 multilib_src_install_all() {
-	# We need the basic terminfo files in /etc for embedded/recovery, bug #37026
-	einfo "Installing basic terminfo files in /etc..."
 	local terms=(
 		# Dumb/simple values that show up when using the in-kernel VT.
 		ansi console dumb linux
@@ -428,25 +426,34 @@ multilib_src_install_all() {
 		screen{,-256color}
 		screen.xterm-256color
 	)
-	local x
-	for x in "${terms[@]}"; do
-		local termfile=$(find "${ED}"/usr/share/terminfo/ -name "${x}" 2>/dev/null)
-		local basedir=$(basename "$(dirname "${termfile}")")
+	if use split-usr ; then
+		local x
+		# We need the basic terminfo files in /etc for embedded/recovery, bug #37026
+		einfo "Installing basic terminfo files in /etc..."
+		for x in "${terms[@]}"; do
+			local termfile=$(find "${ED}"/usr/share/terminfo/ -name "${x}" 2>/dev/null)
+			local basedir=$(basename "$(dirname "${termfile}")")
 
-		if [[ -n ${termfile} ]] ; then
-			dodir "/etc/terminfo/${basedir}"
-			mv "${termfile}" "${ED}/etc/terminfo/${basedir}/" || die
-			dosym "../../../../etc/terminfo/${basedir}/${x}" \
-				"/usr/share/terminfo/${basedir}/${x}"
-		fi
-	done
+			if [[ -n ${termfile} ]] ; then
+				dodir "/etc/terminfo/${basedir}"
+				mv "${termfile}" "${ED}/etc/terminfo/${basedir}/" || die
+				dosym "../../../../etc/terminfo/${basedir}/${x}" \
+					"/usr/share/terminfo/${basedir}/${x}"
+			fi
+		done
 
-	echo "CONFIG_PROTECT_MASK=\"/etc/terminfo\"" | newenvd - 50ncurses
+		echo "CONFIG_PROTECT_MASK=\"/etc/terminfo\"" | newenvd - 50ncurses
 
-	use minimal && rm -r "${ED}"/usr/share/terminfo*
-	# Because ncurses5-config --terminfo returns the directory we keep it
-	# bug #245374
-	keepdir /usr/share/terminfo
+		use minimal && rm -r "${ED}"/usr/share/terminfo*
+		# Because ncurses5-config --terminfo returns the directory we keep it
+		# bug #245374
+		keepdir /usr/share/terminfo
+	elif use minimal ; then
+		# Keep only the basic terminfo files
+		find "${ED}"/usr/share/terminfo/ \
+			-type f ${terms[*]/#/! -name } -delete , \
+			-type d -empty -delete || die
+	fi
 
 	cd "${S}" || die
 	dodoc ANNOUNCE MANIFEST NEWS README* TO-DO doc/*.doc


### PR DESCRIPTION
The rationale for moving the `terminfo` files for some common terminals into `/etc/terminfo/` was stated in [bug #37026](https://bugs.gentoo.org/37026#c13): "ncurses, unlike termcap, stores its terminfo database in `/usr/share`... which may not be available until all file systems are mounted." With merged-/usr this is no longer a concern, and, moreover, moving some `terminfo` files out into `/etc` undermines a core motivation of merged-/usr, which is to situate a complete system image within `/usr`.

This PR preserves the existing behavior when `USE="split-usr"` but eliminates the move of common `terminfo` files into `/etc/terminfo/` when `USE="-split-usr"`.