### PR TITLE
media-libs/flac: remove bdepend of nasm

### DIFF
--- a/media-libs/flac/flac-1.4.2.ebuild
+++ b/media-libs/flac/flac-1.4.2.ebuild
@@ -25,8 +25,7 @@ DEPEND="${RDEPEND}"
 BDEPEND="
 	app-arch/xz-utils
 	sys-devel/gettext
-	virtual/pkgconfig
-	abi_x86_32? ( dev-lang/nasm )"
+	virtual/pkgconfig"
 
 multilib_src_configure() {
 	local myeconfargs=(


### PR DESCRIPTION
In the last version of flac remove all pure assembler, removing build dependency on nasm. See changelog in:

https://xiph.org/flac/changelog.html
Signed-off-by: INODE64 <ffelix@inode64.com>