### PR TITLE
net-misc/wol: additional build fixes

### DIFF
--- a/net-misc/wol/files/wol-0.7.1-linux-headers.patch
+++ b/net-misc/wol/files/wol-0.7.1-linux-headers.patch
@@ -1,0 +1,11 @@
+--- a/src/magic.c
++++ b/src/magic.c
+@@ -142,7 +142,7 @@ magic_assemble (struct magic *magic_buf, const char *mac_str,
+ 				}
+ 
+ 			for (j = 0; j < MAC_LEN; ++j)
+-				m[j] = ea.ETHER_ADDR_OCTET[j];
++				m[j] = ea.ether_addr_octet[j];
+ 		}
+ 
+ 	/* accommodate the packet chunk's size to the packet type */

--- a/net-misc/wol/wol-0.7.1-r4.ebuild
+++ b/net-misc/wol/wol-0.7.1-r4.ebuild
@@ -18,6 +18,7 @@ PATCHES=(
 	"${FILESDIR}/${P}-musl.patch"
 	"${FILESDIR}/${P}-Fix-config.h-test-consumption.patch"
 	"${FILESDIR}/${P}-Fix-malloc-detection.patch"
+	"${FILESDIR}/${P}-linux-headers.patch"
 )
 
 src_prepare() {
@@ -28,6 +29,8 @@ src_prepare() {
 }
 
 src_configure() {
+	export jm_cv_func_working_{re,m}alloc=yes
+
 	local myeconfargs=(
 		--disable-rpath
 		$(use_enable nls)

--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -55,11 +55,6 @@ app-i18n/scim-sunpinyin
 # Removal after 2022-12-24.  Bug #878337.
 app-misc/tpconfig
 
-# Sam James <sam@gentoo.org> (2022-10-25)
-# Fails to build with Clang 16 but also modern linux-headers. No activity upstream.
-# Removal on 2022-10-25. bug #874420.
-net-misc/wol
-
 # Sam James <sam@gentoo.org> (2022-10-24)
 # Non-free licence which prohibits any patching. Fails to build with Clang 16.
 # Removal on 2022-10-24.


### PR DESCRIPTION
- Try harder to convince it we've got a decent malloc & realloc (if upstream were alive, it'd be worth fixing up the autoconf here, but...)

- Fix build with newer linux-headers(?)

Closes: https://bugs.gentoo.org/874420
Signed-off-by: Sam James <sam@gentoo.org>