### PR TITLE
app-office/planner: put -j1 back in front of gnome2_src_install

### DIFF
--- a/app-office/planner/planner-0.14.6_p20130520-r3.ebuild
+++ b/app-office/planner/planner-0.14.6_p20130520-r3.ebuild
@@ -58,7 +58,7 @@ src_configure() {
 }
 
 src_install() {
-	gnome2_src_install
+	MAKEOPTS="${MAKEOPTS} -j1" gnome2_src_install
 	mv "${ED}"/usr/share/doc/planner "${ED}"/usr/share/doc/${PF} || die
 	if ! use examples; then
 		rm -rf "${D}/usr/share/doc/${PF}/examples"


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/878815

Is it alright to keep the rev at r3?

Signed-off-by: Pascal Jäger <pascal.jaeger@leimstift.de>