### PR TITLE
*: install gsed, gfind, gxargs, gpatch for better BSD compatibility

### DIFF
--- a/app-arch/cpio/cpio-2.13-r3.ebuild
+++ b/app-arch/cpio/cpio-2.13-r3.ebuild
@@ -34,6 +34,8 @@ src_configure() {
 		$(use_enable nls)
 		--bindir="${EPREFIX}"/bin
 		--with-rmt="${EPREFIX}"/usr/sbin/rmt
+		# install as gcpio for better compatibility with non-GNU userland
+		--program-prefix=g
 	)
 
 	econf "${myeconfargs[@]}"
@@ -41,10 +43,8 @@ src_configure() {
 
 src_install() {
 	default
-	# install as gcpio for better compatibility with non-GNU userland
-	# and make cpio as a symlink
-	mv "${ED}"/bin/{,g}cpio || die
+
+	# make cpio a symlink
 	dosym gcpio /bin/cpio
-	mv "${ED}"/usr/share/man/man1/{,g}cpio.1 || die
 	dosym gcpio.1 /usr/share/man/man1/cpio.1
 }

--- a/app-arch/tar/tar-1.34-r1.ebuild
+++ b/app-arch/tar/tar-1.34-r1.ebuild
@@ -43,6 +43,12 @@ src_configure() {
 		$(use_enable nls)
 		$(use_with selinux)
 		$(use_with xattr xattrs)
+
+		# autoconf looks for gtar before tar (in configure scripts), hence
+		# in Prefix it is important that it is there, otherwise, a gtar from
+		# the host system (FreeBSD, Solaris, Darwin) will be found instead
+		# of the Prefix provided (GNU) tar
+		--program-prefix=g
 	)
 
 	FORCE_UNSAFE_CONFIGURE=1 econf "${myeconfargs[@]}"
@@ -55,30 +61,24 @@ src_install() {
 	exeinto /etc
 	doexe "${FILESDIR}"/rmt
 
-	mv "${ED}"/usr/sbin/backup{,-tar} || die
-	mv "${ED}"/usr/sbin/restore{,-tar} || die
+	mv "${ED}"/usr/sbin/{gbackup,backup-tar} || die
+	mv "${ED}"/usr/sbin/{grestore,restore-tar} || die
+	mv "${ED}"/usr/sbin/{g,}backup.sh || die
+	mv "${ED}"/usr/sbin/{g,}dump-remind || die
 
 	if use minimal ; then
 		find "${ED}"/etc "${ED}"/*bin/ "${ED}"/usr/*bin/ \
-			-type f -a '!' '(' -name tar -o -name tar ')' \
+			-type f -a '!' -name gtar \
 			-delete || die
 	fi
 
-	# autoconf looks for gtar before tar (in configure scripts), hence
-	# in Prefix it is important that it is there, otherwise, a gtar from
-	# the host system (FreeBSD, Solaris, Darwin) will be found instead
-	# of the Prefix provided (GNU) tar
-	# rename tar to gtar, and make tar a symlink
-	mv "${ED}"/bin/{,g}tar || die
+	# make tar a symlink
 	dosym gtar /bin/tar
 
 	if ! use minimal; then
-		mv "${ED}"/usr/sbin/{,g}rmt || die
 		dosym grmt /usr/sbin/rmt
 	fi
 
-	mv "${ED}"/usr/share/man/man1/{,g}tar.1 || die
 	dosym gtar.1 /usr/share/man/man1/tar.1
-	mv "${ED}"/usr/share/man/man8/{,g}rmt.8 || die
 	dosym grmt.8 /usr/share/man/man8/rmt.8
 }

--- a/sys-apps/findutils/findutils-4.9.0-r2.ebuild
+++ b/sys-apps/findutils/findutils-4.9.0-r2.ebuild
@@ -1,0 +1,97 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+PYTHON_COMPAT=( python3_{8..11} )
+VERIFY_SIG_OPENPGP_KEY_PATH="${BROOT}"/usr/share/openpgp-keys/findutils.asc
+inherit flag-o-matic python-any-r1 verify-sig
+
+DESCRIPTION="GNU utilities for finding files"
+HOMEPAGE="https://www.gnu.org/software/findutils/"
+SRC_URI="mirror://gnu/${PN}/${P}.tar.xz"
+SRC_URI+=" verify-sig? ( mirror://gnu/${PN}/${P}.tar.xz.sig )"
+
+LICENSE="GPL-3+"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+IUSE="nls selinux static test"
+RESTRICT="!test? ( test )"
+
+RDEPEND="
+	selinux? ( sys-libs/libselinux )
+	nls? ( virtual/libintl )
+"
+DEPEND="${RDEPEND}"
+BDEPEND="
+	nls? ( sys-devel/gettext )
+	test? (
+		${PYTHON_DEPS}
+		dev-util/dejagnu
+	)
+	verify-sig? ( sec-keys/openpgp-keys-findutils )
+"
+
+pkg_setup() {
+	use test && python-any-r1_pkg_setup
+}
+
+src_prepare() {
+	# Don't build or install locate because it conflicts with mlocate,
+	# which is a secure version of locate.  See bug 18729
+	sed \
+		-e '/^SUBDIRS/s@locate@@' \
+		-e '/^built_programs/s@ frcode locate updatedb@@' \
+		-i Makefile.in || die
+
+	default
+}
+
+src_configure() {
+	if use static; then
+		append-flags -pthread
+		append-ldflags -static
+	fi
+
+	append-lfs-flags
+
+	if [[ ${CHOST} == *-darwin* ]] ; then
+		# https://lists.gnu.org/archive/html/bug-findutils/2021-01/msg00050.html
+		# https://lists.gnu.org/archive/html/bug-findutils/2021-01/msg00051.html
+		append-cppflags '-D__nonnull\(X\)='
+	fi
+
+	local myeconfargs=(
+		--with-packager="Gentoo"
+		--with-packager-version="${PVR}"
+		--with-packager-bug-reports="https://bugs.gentoo.org/"
+		$(use_enable nls)
+		$(use_with selinux)
+		--libexecdir='$(libdir)'/find
+		# rename to gfind, gxargs for better BSD compatibility
+		--program-prefix=g
+	)
+	econf "${myeconfargs[@]}"
+}
+
+src_test() {
+	local -x SANDBOX_PREDICT=${SANDBOX_PREDICT}
+	addpredict /
+	default
+}
+
+src_compile() {
+	# We don't build locate, but the docs want a file in there.
+	emake -C locate dblocation.texi
+	default
+}
+
+src_install() {
+	default
+
+	# symlink to the standard names
+	dosym gfind /usr/bin/find
+	dosym gxargs /usr/bin/xargs
+	dosym gfind.1 /usr/share/man/man1/find.1
+	dosym gxargs.1 /usr/share/man/man1/xargs.1
+}

--- a/sys-apps/sed/sed-4.8-r1.ebuild
+++ b/sys-apps/sed/sed-4.8-r1.ebuild
@@ -1,0 +1,60 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+VERIFY_SIG_OPENPGP_KEY_PATH="${BROOT}"/usr/share/openpgp-keys/sed.asc
+inherit flag-o-matic verify-sig
+
+DESCRIPTION="Super-useful stream editor"
+HOMEPAGE="http://sed.sourceforge.net/"
+SRC_URI="mirror://gnu/sed/${P}.tar.xz"
+SRC_URI+=" verify-sig? ( mirror://gnu/sed/${P}.tar.xz.sig )"
+
+LICENSE="GPL-3+"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+IUSE="acl nls selinux static"
+
+RDEPEND="
+	!static? (
+		acl? ( virtual/acl )
+		nls? ( virtual/libintl )
+		selinux? ( sys-libs/libselinux )
+	)
+"
+DEPEND="${RDEPEND}
+	static? (
+		acl? ( virtual/acl[static-libs(+)] )
+		nls? ( virtual/libintl[static-libs(+)] )
+		selinux? ( sys-libs/libselinux[static-libs(+)] )
+	)
+"
+BDEPEND="nls? ( sys-devel/gettext )
+	verify-sig? ( sec-keys/openpgp-keys-sed )"
+
+PATCHES=(
+	"${FILESDIR}/${P}-avoid-noreturn-diagnostic.patch"
+)
+
+src_configure() {
+	use static && append-ldflags -static
+
+	local myconf=(
+		--exec-prefix="${EPREFIX}"
+		$(use_enable acl)
+		$(use_enable nls)
+		$(use_with selinux)
+		# rename to gsed for better BSD compatibility
+		--program-prefix=g
+	)
+	econf "${myconf[@]}"
+}
+
+src_install() {
+	default
+
+	# symlink to the standard name
+	dosym gsed /bin/sed
+	dosym gsed.1 /usr/share/man/man1/sed.1
+}

--- a/sys-devel/patch/patch-2.7.6-r5.ebuild
+++ b/sys-devel/patch/patch-2.7.6-r5.ebuild
@@ -1,0 +1,59 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+VERIFY_SIG_OPENPGP_KEY_PATH="${BROOT}"/usr/share/openpgp-keys/patch.asc
+inherit flag-o-matic verify-sig
+
+DESCRIPTION="Utility to apply diffs to files"
+HOMEPAGE="https://www.gnu.org/software/patch/patch.html"
+SRC_URI="mirror://gnu/patch/${P}.tar.xz"
+SRC_URI+=" verify-sig? ( mirror://gnu/patch/${P}.tar.xz.sig )"
+
+LICENSE="GPL-3+"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+IUSE="static test xattr"
+RESTRICT="!test? ( test )"
+
+RDEPEND="xattr? ( sys-apps/attr )"
+DEPEND="${RDEPEND}"
+BDEPEND="test? ( sys-apps/ed )
+	verify-sig? ( sec-keys/openpgp-keys-patch )"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-fix-test-suite.patch
+	"${FILESDIR}"/${PN}-2.7.6-fix-error-handling-with-git-style-patches.patch
+	"${FILESDIR}"/${PN}-2.7.6-CVE-2018-6951.patch
+	"${FILESDIR}"/${PN}-2.7.6-allow-input-files-to-be-missing-for-ed-style-patches.patch
+	"${FILESDIR}"/${PN}-2.7.6-CVE-2018-1000156.patch
+	"${FILESDIR}"/${PN}-2.7.6-CVE-2018-6952.patch
+	"${FILESDIR}"/${PN}-2.7.6-Do-not-crash-when-RLIMIT_NOFILE-is-set-to-RLIM_INFINITY.patch
+	"${FILESDIR}"/${PN}-2.7.6-CVE-2018-1000156-fix1.patch
+	"${FILESDIR}"/${PN}-2.7.6-CVE-2018-1000156-fix2.patch
+	"${FILESDIR}"/${PN}-2.7.6-CVE-2019-13636.patch
+	"${FILESDIR}"/${PN}-2.7.6-CVE-2019-13638.patch
+	"${FILESDIR}"/${PN}-2.7.6-Avoid-invalid-memory-access-in-context-format-diffs.patch
+)
+
+src_configure() {
+	use static && append-ldflags -static
+
+	local myeconfargs=(
+		$(use_enable xattr)
+		# rename to gpatch for better BSD compatibility
+		--program-prefix=g
+	)
+	# Do not let $ED mess up the search for `ed` 470210.
+	ac_cv_path_ED=$(type -P ed) \
+		econf "${myeconfargs[@]}"
+}
+
+src_install() {
+	default
+
+	# symlink to the standard name
+	dosym gpatch /usr/bin/patch
+	dosym gpatch.1 /usr/share/man/man1/patch.1
+}


### PR DESCRIPTION
As a continuation of the previous effort, after covering `gcpio` and `gtar`, let's add other tools that the BSD profiles mentioned: `gsed`, `gfind`, `gxargs`, `gpatch`. As previously, the GNU versions are installed as `g*` and symlinked to their base name to make it easy to relink them to alternative implementations.