### PR TITLE
app-editors/neovim: fix cmake-release-type.patch

### DIFF
--- a/app-editors/neovim/files/neovim-9999-cmake-release-type.patch
+++ b/app-editors/neovim/files/neovim-9999-cmake-release-type.patch
@@ -1,16 +1,16 @@
 Ensure that :checkhealth is happy with the Gentoo build type.
 https://bugs.gentoo.org/757744
---- a/runtime/autoload/health/nvim.vim
-+++ b/runtime/autoload/health/nvim.vim
-@@ -135,7 +135,7 @@ function! s:check_performance() abort
-   let buildtype = matchstr(execute('version'), '\v\cbuild type:?\s*[^\n\r\t ]+')
-   if empty(buildtype)
-     call health#report_error('failed to get build type from :version')
--  elseif buildtype =~# '\v(MinSizeRel|Release|RelWithDebInfo)'
-+  elseif buildtype =~# '\v(MinSizeRel|Release|RelWithDebInfo|Gentoo)'
-     call health#report_ok(buildtype)
-   else
-     call health#report_info(buildtype)
+--- a/runtime/lua/nvim/health.lua
++++ b/runtime/lua/nvim/health.lua
+@@ -149,7 +149,7 @@ local function check_performance()
+     let s:buildtype = matchstr(execute('version'), '\v\cbuild type:?\s*[^\n\r\t ]+')
+     if empty(s:buildtype)
+       call health#report_error('failed to get build type from :version')
+-    elseif s:buildtype =~# '\v(MinSizeRel|Release|RelWithDebInfo)'
++    elseif s:buildtype =~# '\v(MinSizeRel|Release|RelWithDebInfo|Gentoo)'
+       call health#report_ok(s:buildtype)
+     else
+       call health#report_info(s:buildtype)
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -137,12 +137,6 @@ else()


### PR DESCRIPTION
Upstream converted the (old) `runtime/autoload/health/nvim.vim` file into the (new) `runtime/lua/nvim/health.lua` file [in this commit](https://github.com/neovim/neovim/commit/19dab2ead2dfc49c24e004fcdbbef6948b7bde94). This causes patching to fail during building, since the old file won't be found.

This commit modifies the patch file to work on the new file.

Signed-off-by: Bharath Saiguhan <bharathsaiguhan@protonmail.com>