### PR TITLE
x11-misc/xscreensaver: revbump, get install dirs from GTK3 instead of…

### DIFF
--- a/x11-misc/xscreensaver/files/xscreensaver-6.05-get-dirs-from-gtk3.0-in-configure.patch
+++ b/x11-misc/xscreensaver/files/xscreensaver-6.05-get-dirs-from-gtk3.0-in-configure.patch
@@ -1,0 +1,27 @@
+Even though xscreensaver now uses GTK+3 instead of GTK+2 since version 6.05
+it still gets its directories from GTK+2 which results in an empty prefix
+when GTK+2 is not installed.
+
+Bug: https://bugs.gentoo.org/878875
+
+Signed-off-by: Pascal Jäger <pascal.jaeger@leimstift.de>
+
+--- a/configure
++++ b/configure
+@@ -16035,7 +16035,7 @@ printf "%s\n" "$ac_cv_gtk_config_libs" >&6; }
+
+   GTK_DATADIR=""
+   if test "$have_gtk" = yes; then
+-    GTK_DATADIR=`$pkg_config --variable=prefix gtk+-2.0`
++    GTK_DATADIR=`$pkg_config --variable=prefix gtk+-3.0`
+     GTK_DATADIR="$GTK_DATADIR/share"
+   fi
+
+@@ -21440,6 +21440,6 @@ printf %s "checking for locale directory... " >&6; }
+ if test -n "$GTK_DATADIR" ; then
+   PO_DATADIR="$GTK_DATADIR"
+ elif test "$have_gtk" = yes; then
+-  PO_DATADIR=`$pkg_config --variable=prefix gtk+-2.0`
++  PO_DATADIR=`$pkg_config --variable=prefix gtk+-3.0`
+   PO_DATADIR="$PO_DATADIR/share"
+ fi

--- a/x11-misc/xscreensaver/xscreensaver-6.05-r1.ebuild
+++ b/x11-misc/xscreensaver/xscreensaver-6.05-r1.ebuild
@@ -88,6 +88,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-6.03-without-gl-configure.patch
 	"${FILESDIR}"/${PN}-6.05-remove-update-icon-cache.patch
 	"${FILESDIR}"/${PN}-6.05-configure-exit-codes.patch
+	"${FILESDIR}"/${PN}-6.05-get-dirs-from-gtk3.0-in-configure.patch
 )
 
 DOCS=( README{,.hacking} )


### PR DESCRIPTION
… GTK2

Closes: https://bugs.gentoo.org/878875
Signed-off-by: Pascal Jäger <pascal.jaeger@leimstift.de>