### PR TITLE
sys-apps/systemd-utils: Explicitly disable bpf-framework

### DIFF
--- a/sys-apps/systemd-utils/systemd-utils-251.7.ebuild
+++ b/sys-apps/systemd-utils/systemd-utils-251.7.ebuild
@@ -175,6 +175,7 @@ multilib_src_configure() {
 		-Daudit=false
 		-Dbacklight=false
 		-Dbinfmt=false
+		-Dbpf-framework=false
 		-Dbzip2=false
 		-Dcoredump=false
 		-Ddbus=false


### PR DESCRIPTION
BPF is not used by systemd-utils, only by components that are part of the full systemd installation. In Gentoo this change is a no-op. It only serves to skip some configure tests, which happen to use unprefixed 'clang', which is not allowed in ChromeOS.

Signed-off-by: Matt Turner <mattst88@gentoo.org>