### PR TITLE
net-misc/bsdwhois: fix build for clang16

### DIFF
--- a/net-misc/bsdwhois/bsdwhois-1.43.2.1-r1.ebuild
+++ b/net-misc/bsdwhois/bsdwhois-1.43.2.1-r1.ebuild
@@ -1,0 +1,35 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+inherit autotools flag-o-matic
+
+DESCRIPTION="FreeBSD Whois Client"
+HOMEPAGE="https://www.freebsd.org/"
+SRC_URI="http://utenti.gufi.org/~drizzt/codes/${P}.tar.gz"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86 ~amd64-linux ~x86-linux"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-1.43.2.1-musl-cdefs.patch"
+	"${FILESDIR}/${PN}-1.43.2.1-clang16-build.patch"
+)
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_configure() {
+	append-cppflags -D_GNU_SOURCE
+	default
+}
+
+src_install() {
+	default
+
+	mv "${ED}"/usr/share/man/man1/{whois,bsdwhois}.1 || die
+	mv "${ED}"/usr/bin/{whois,bsdwhois} || die
+}

--- a/net-misc/bsdwhois/files/bsdwhois-1.43.2.1-clang16-build.patch
+++ b/net-misc/bsdwhois/files/bsdwhois-1.43.2.1-clang16-build.patch
@@ -1,0 +1,21 @@
+Clang16 will not allow implicit function declarations and implicit integers etc.
+This patch overhauls the source code for modern C.
+
+Bug: https://bugs.gentoo.org/875029
+
+Signed-off-by: Pascal Jäger <pascal.jaeger@leimstift.de>
+
+--- a/strnstr.c
++++ b/strnstr.c
+@@ -46,10 +46,7 @@ static char sccsid[] = "@(#)strstr.c	8.1 (Berkeley) 6/4/93";
+  * first slen characters of s.
+  */
+ char *
+-strnstr(s, find, slen)
+-	const char *s;
+-	const char *find;
+-	size_t slen;
++strnstr(const char *s, const char *find, size_t slen)
+ {
+ 	char c, sc;
+ 	size_t len;


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/875029

Signed-off-by: Pascal Jäger <pascal.jaeger@leimstift.de>