### PR TITLE
x11-misc/xscreensaver: get install dirs from GTK3 instead of GTK2 in …

### DIFF
--- a/x11-misc/xscreensaver/files/xscreensaver-6.05-get-dirs-from-gtk3.0-in-configure.patch
+++ b/x11-misc/xscreensaver/files/xscreensaver-6.05-get-dirs-from-gtk3.0-in-configure.patch
@@ -6,9 +6,9 @@ Bug: https://bugs.gentoo.org/878875
 
 Signed-off-by: Pascal Jäger <pascal.jaeger@leimstift.de>
 
---- a/configure
-+++ b/configure
-@@ -16035,7 +16035,7 @@ printf "%s\n" "$ac_cv_gtk_config_libs" >&6; }
+--- a/configure.ac
++++ b/configure.ac
+@@ -2822,7 +2822,7 @@ if test "$with_gtk" = yes; then
 
    GTK_DATADIR=""
    if test "$have_gtk" = yes; then
@@ -17,7 +17,7 @@ Signed-off-by: Pascal Jäger <pascal.jaeger@leimstift.de>
      GTK_DATADIR="$GTK_DATADIR/share"
    fi
 
-@@ -21440,6 +21440,6 @@ printf %s "checking for locale directory... " >&6; }
+@@ -4282,6 +4282,6 @@ AC_MSG_CHECKING([for locale directory])
  if test -n "$GTK_DATADIR" ; then
    PO_DATADIR="$GTK_DATADIR"
  elif test "$have_gtk" = yes; then


### PR DESCRIPTION
…configure.ac

Closes: https://bugs.gentoo.org/878979
Bug: https://bugs.gentoo.org/878875
Signed-off-by: Pascal Jäger <pascal.jaeger@leimstift.de>

Last PR I only patched configure, not configure.ac. Not much sense in that if I run eautoreconf after that. 

