### PR TITLE
media-gfx/freecad: adapt for Qt6 related changes

### DIFF
--- a/media-gfx/freecad/freecad-9999.ebuild
+++ b/media-gfx/freecad/freecad-9999.ebuild
@@ -26,7 +26,7 @@ fi
 # examples are licensed CC-BY-SA (without note of specific version)
 LICENSE="LGPL-2 CC-BY-SA-4.0"
 SLOT="0"
-IUSE="debug designer headless test"
+IUSE="debug designer +gui test"
 
 FREECAD_EXPERIMENTAL_MODULES="cloud pcl"
 FREECAD_STABLE_MODULES="addonmgr fem idf image inspection material
@@ -159,7 +159,7 @@ src_configure() {
 		-DBUILD_FLAT_MESH=ON
 		-DBUILD_FORCE_DIRECTORY=ON				# force building in a dedicated directory
 		-DBUILD_FREETYPE=ON						# automagic dep
-		-DBUILD_GUI=$(usex !headless)
+		-DBUILD_GUI=$(usex gui)
 		-DBUILD_IDF=$(usex idf)
 		-DBUILD_IMAGE=$(usex image)
 		-DBUILD_IMPORT=ON						# import module for various file formats
@@ -196,6 +196,8 @@ src_configure() {
 		-DCMAKE_INSTALL_PREFIX=/usr/$(get_libdir)/${PN}
 
 		-DFREECAD_BUILD_DEBIAN=OFF
+
+		-DFREECAD_QT_VERSION="5"
 
 		-DFREECAD_USE_EXTERNAL_KDL=ON
 		-DFREECAD_USE_EXTERNAL_SMESH=OFF		# no package in Gentoo
@@ -235,7 +237,7 @@ src_configure() {
 
 # We use the FreeCADCmd binary instead of the FreeCAD binary here
 # for two reasons:
-# 1. It works out of the box with USE=headless as well, not needing a guard
+# 1. It works out of the box with USE=-gui as well, not needing a guard
 # 2. We don't need virtualx.eclass and it's dependencies
 # The exported environment variables are needed, so freecad does know
 # where to save it's temporary files, and where to look and write it's
@@ -255,7 +257,7 @@ src_install() {
 
 	dobin src/Tools/freecad-thumbnailer
 
-	if ! use headless; then
+	if use gui; then
 		dosym -r /usr/$(get_libdir)/${PN}/bin/FreeCAD /usr/bin/freecad
 		mv "${ED}"/usr/$(get_libdir)/${PN}/share/* "${ED}"/usr/share || die "failed to move shared resources"
 	fi

--- a/media-gfx/freecad/metadata.xml
+++ b/media-gfx/freecad/metadata.xml
@@ -26,6 +26,13 @@
 			Build the FEM module and workbench which provides Finite Element 
 			Analysis (FEA) workflows
 		</flag>
+		<flag name="gui">
+			Build FreeCAD with a Qt based GUI. If built without setting this
+			USE flag, FreeCAD can be used in a headless mode, for server-side
+			instances.
+			The Python modules are available, without their GUI parts though,
+			if this is unset.
+		</flag>
 		<flag name="headless">
 			Build FreeCAD without a GUI, usable for server-side instances.
 			The Python modules are still available, without their GUI parts though.


### PR DESCRIPTION
Upstream has introduced cmake changes for handling both Qt5 and Qt6. No code changes have been made so far, so we don't yet implement the qt6 USE flag.
This patch reflects the upstream changes and prepares for implementing the qt6 USE flag, by renaming the "headless" USE flag to "gui" and passing the new cmake variable FREECAD_QT_VERSION.

Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>