### PR TITLE
dev-go/act: no longer use go-module

### DIFF
--- a/dev-go/act/act-1.6.0.ebuild
+++ b/dev-go/act/act-1.6.0.ebuild
@@ -3,8 +3,6 @@
 
 EAPI=8
 
-inherit go-module toolchain-funcs
-
 DESCRIPTION="Automated Component Toolkit code generator"
 HOMEPAGE="https://github.com/Autodesk/AutomaticComponentToolkit"
 SRC_URI="https://github.com/Autodesk/AutomaticComponentToolkit/archive/v${PV}.tar.gz -> ${P}.tar.gz"
@@ -14,44 +12,19 @@ LICENSE="BSD-2"
 SLOT="0"
 KEYWORDS="amd64 ~arm64 x86"
 
-RESTRICT="test"
+RESTRICT="strip test"
 
-# Package does not follow the usual go directory structure
-# Functions borrowed from dev-lang/go ebuild.
-go_arch() {
-	# By chance most portage arch names match Go
-	local portage_arch=$(tc-arch $@)
-	case "${portage_arch}" in
-		x86)	echo 386;;
-		x64-*)	echo amd64;;
-		*)		echo "${portage_arch}";;
-	esac
-}
+BDEPEND="dev-lang/go"
 
-go_arm() {
-	case "${1:-${CHOST}}" in
-		armv5*) echo 5;;
-		armv6*) echo 6;;
-		armv7*) echo 7;;
-		*)
-			die "unknown GOARM for ${1:-${CHOST}}"
-			;;
-	esac
-}
+QA_FLAGS_IGNORED="/usr/bin/act"
 
 src_compile() {
-	export GOARCH=$(go_arch)
-	export GOOS=linux
-	if [[ ${ARCH} == arm ]]; then
-		export GOARM=$(go_arm)
-	fi
-
-	cd "${S}"/Source || die
+	cd Source || die
 	go build -x -o ../${PN} *.go || die
 }
 
 src_install() {
-	newbin "${S}"/${PN} ${PN}
+	dobin ${PN}
 	einstalldocs
 	dodoc -r Documentation/.
 }


### PR DESCRIPTION
The package doesn't use the usual Go structure and fails to build with changes to go-module.
Thanks to William Hubbs for the suggestion to go related changes.

Suggested-by: William Hubbs <williamh@gentoo.org>
Closes: https://bugs.gentoo.org/877881
Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>