### PR TITLE
app-arch/upx: fix running tests (#878977)

### DIFF
--- a/app-arch/upx/upx-4.0.0.ebuild
+++ b/app-arch/upx/upx-4.0.0.ebuild
@@ -13,6 +13,15 @@ S="${WORKDIR}/${P}-src"
 LICENSE="GPL-2+ UPX-exception" # Read the exception before applying any patches
 SLOT="0"
 KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~sparc ~x86"
+IUSE="test"
+
+RESTRICT="!test? ( test )"
 
 RDEPEND="!app-arch/upx-bin"
 BDEPEND="app-arch/xz-utils[extra-filters]"
+
+src_test() {
+	# Don't run tests in parallel, #878977
+	cd "${BUILD_DIR}" || die
+	ctest || die
+}


### PR DESCRIPTION
Tests should runs sequentially since there no dependencies for each test step.

Closes: https://bugs.gentoo.org/878977
Signed-off-by: Azamat H. Hackimov <azamat.hackimov@gmail.com>