### PR TITLE
www-apps/cgit: Fix build on musl

### DIFF
--- a/www-apps/cgit/cgit-1.2.3-r201.ebuild
+++ b/www-apps/cgit/cgit-1.2.3-r201.ebuild
@@ -70,6 +70,9 @@ src_configure() {
 	else
 		echo "NO_LUA = 1" >> cgit.conf || die "echo NO_LUA failed"
 	fi
+	if use elibc_musl; then
+		echo 'export NO_REGEX=NeedsStartEnd' >> cgit.conf || die "echo export NO_REGEX=NeedsStartEnd failed"
+	fi
 }
 
 src_compile() {


### PR DESCRIPTION
The musl libc does not support REG_STARTEND, so we need to export NO_REGEX=NeedsStartEnd to the git build.

Closes: https://bugs.gentoo.org/713836
Signed-off-by: Wolfgang Müller <wolf@oriole.systems>