### PR TITLE
dev-libs/poco: fix automagic dependency on OpenSSL

### DIFF
--- a/dev-libs/poco/metadata.xml
+++ b/dev-libs/poco/metadata.xml
@@ -33,7 +33,7 @@ done quickly and working on the features that make their application unique.
 		<flag name="7z">Add Support for the 7z archive format</flag>
 		<flag name="activerecord">Add ActiveRecord support</flag>
 		<flag name="cppparser">Build and install a minimal C++ parser</flag>
-		<flag name="crypto">Encryption and digital signing classes</flag>
+		<flag name="crypto" restrict="&lt;=dev-libs/poco-1.12.2-r1">Encryption and digital signing classes</flag>
 		<flag name="data">Database abstraction layer to easily send/retrieve data to/from various databases</flag>
 		<flag name="file2pagecompiler">Utility to convert ordinary files to Page Compiler source files</flag>
 		<flag name="json">Add JSON support</flag>

--- a/dev-libs/poco/metadata.xml
+++ b/dev-libs/poco/metadata.xml
@@ -37,6 +37,7 @@ done quickly and working on the features that make their application unique.
 		<flag name="data">Database abstraction layer to easily send/retrieve data to/from various databases</flag>
 		<flag name="file2pagecompiler">Utility to convert ordinary files to Page Compiler source files</flag>
 		<flag name="json">Add JSON support</flag>
+		<flag name="jwt" restrict="&gt;=dev-libs/poco-1.12.2-r1">Add JSON Web Token support</flag>
 		<flag name="mariadb">Prefer <pkg>dev-db/mariadb-connector-c</pkg> over <pkg>dev-db/mysql-connector-c</pkg></flag>
 		<flag name="mongodb">Add <pkg>dev-db/mongodb</pkg> support</flag>
 		<flag name="net">Classes to write network clients &amp; servers</flag>

--- a/dev-libs/poco/poco-1.12.2-r1.ebuild
+++ b/dev-libs/poco/poco-1.12.2-r1.ebuild
@@ -13,12 +13,13 @@ S="${WORKDIR}/${PN}-${P}-release"
 LICENSE="Boost-1.0"
 SLOT="0"
 KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~x86"
-IUSE="7z activerecord cppparser +crypto +data examples +file2pagecompiler iodbc +json mariadb +mongodb mysql +net odbc +pagecompiler pdf pocodoc postgres prometheus sqlite +ssl test +util +xml +zip"
+IUSE="7z activerecord cppparser +crypto +data examples +file2pagecompiler iodbc +json jwt mariadb +mongodb mysql +net odbc +pagecompiler pdf pocodoc postgres prometheus sqlite +ssl test +util +xml +zip"
 RESTRICT="!test? ( test )"
 REQUIRED_USE="
 	7z? ( xml )
 	file2pagecompiler? ( pagecompiler )
 	iodbc? ( odbc )
+	jwt? ( json ssl )
 	mongodb? ( data )
 	mysql? ( data )
 	odbc? ( data )
@@ -98,6 +99,7 @@ src_configure() {
 		-DENABLE_DATA_POSTGRESQL="$(usex postgres)"
 		-DENABLE_DATA_SQLITE="$(usex sqlite)"
 		-DENABLE_JSON="$(usex util)"
+		-DENABLE_JWT="$(usex jwt)"
 		-DENABLE_MONGODB="$(usex mongodb)"
 		-DENABLE_NET="$(usex net)"
 		-DENABLE_NETSSL="$(usex ssl)"

--- a/dev-libs/poco/poco-1.12.2-r1.ebuild
+++ b/dev-libs/poco/poco-1.12.2-r1.ebuild
@@ -47,7 +47,7 @@ RDEPEND="
 		dev-libs/openssl:0=
 	)
 	xml? ( dev-libs/expat )
-	zip? ( sys-libs/zlib )
+	zip? ( sys-libs/zlib:= )
 "
 DEPEND="${RDEPEND}"
 

--- a/dev-libs/poco/poco-1.12.2-r1.ebuild
+++ b/dev-libs/poco/poco-1.12.2-r1.ebuild
@@ -13,7 +13,7 @@ S="${WORKDIR}/${PN}-${P}-release"
 LICENSE="Boost-1.0"
 SLOT="0"
 KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~x86"
-IUSE="7z activerecord cppparser +crypto +data examples +file2pagecompiler iodbc +json jwt mariadb +mongodb mysql +net odbc +pagecompiler pdf pocodoc postgres prometheus sqlite +ssl test +util +xml +zip"
+IUSE="7z activerecord cppparser +data examples +file2pagecompiler iodbc +json jwt mariadb +mongodb mysql +net odbc +pagecompiler pdf pocodoc postgres prometheus sqlite +ssl test +util +xml +zip"
 RESTRICT="!test? ( test )"
 REQUIRED_USE="
 	7z? ( xml )


### PR DESCRIPTION
Other changes:
* Drop unused "crypto" flag
* Add slot operator for Zlib

I ran the tests, they passed.