### PR TITLE
sys-firmware/raspberrypi-wifi-ucode: fix

### DIFF
--- a/sys-firmware/raspberrypi-wifi-ucode/raspberrypi-wifi-ucode-20210315.3_p7-r2.ebuild
+++ b/sys-firmware/raspberrypi-wifi-ucode/raspberrypi-wifi-ucode-20210315.3_p7-r2.ebuild
@@ -58,6 +58,13 @@ pkg_pretend() {
 	fi
 }
 
+src_configure() {
+	unlink "${S}"/debian/config/brcm80211/brcm/brcmfmac43455-sdio.bin || die
+	ln -rs \
+		"${S}"/debian/config/brcm80211/cypress/cyfmac43455-sdio-standard.bin \
+		"${S}"/debian/config/brcm80211/brcm/brcmfmac43455-sdio.bin || die
+}
+
 src_install() {
 	insinto /lib/firmware/brcm
 	doins debian/config/brcm80211/brcm/*


### PR DESCRIPTION
fix broken symlink for brcmfmac43455-sdio.bin

Bug: https://bugs.gentoo.org/878509
Signed-off-by: Dennis Lamm <expeditioneer@gentoo.org>