### PR TITLE
ROCm LLVM-15

### DIFF
--- a/dev-libs/rocm-comgr/files/rocm-comgr-5.1.3-llvm-15-args-changed
+++ b/dev-libs/rocm-comgr/files/rocm-comgr-5.1.3-llvm-15-args-changed
@@ -1,0 +1,20 @@
+--- a/src/comgr-compiler.cpp
++++ b/src/comgr-compiler.cpp
+@@ -453,7 +453,7 @@ static bool executeAssemblerImpl(AssemblerInvocation &Opts,
+     std::unique_ptr<MCCodeEmitter> MCE;
+     std::unique_ptr<MCAsmBackend> MAB;
+     if (Opts.ShowEncoding) {
+-      MCE.reset(TheTarget->createMCCodeEmitter(*MCII, *MRI, Ctx));
++      MCE.reset(TheTarget->createMCCodeEmitter(*MCII, Ctx));
+       MCTargetOptions Options;
+       MAB.reset(TheTarget->createMCAsmBackend(*STI, *MRI, Options));
+     }
+@@ -472,7 +472,7 @@ static bool executeAssemblerImpl(AssemblerInvocation &Opts,
+       Out = BOS.get();
+     }
+ 
+-    MCCodeEmitter *CE = TheTarget->createMCCodeEmitter(*MCII, *MRI, Ctx);
++    MCCodeEmitter *CE = TheTarget->createMCCodeEmitter(*MCII, Ctx);
+     MCTargetOptions Options;
+     MCAsmBackend *MAB = TheTarget->createMCAsmBackend(*STI, *MRI, Options);
+     Triple T(Opts.Triple);

--- a/dev-libs/rocm-comgr/files/rocm-comgr-5.1.3-llvm-15-remove-zlib-gnu
+++ b/dev-libs/rocm-comgr/files/rocm-comgr-5.1.3-llvm-15-remove-zlib-gnu
@@ -1,0 +1,17 @@
+--- a/src/comgr-compiler.cpp
++++ b/src/comgr-compiler.cpp
+@@ -244,13 +244,12 @@ bool AssemblerInvocation::createFromArgs(AssemblerInvocation &Opts,
+                                      OPT_compress_debug_sections_EQ)) {
+     if (A->getOption().getID() == OPT_compress_debug_sections) {
+       // TODO: be more clever about the compression type auto-detection
+-      Opts.CompressDebugSections = llvm::DebugCompressionType::GNU;
++      Opts.CompressDebugSections = llvm::DebugCompressionType::Z;
+     } else {
+       Opts.CompressDebugSections =
+           llvm::StringSwitch<llvm::DebugCompressionType>(A->getValue())
+               .Case("none", llvm::DebugCompressionType::None)
+               .Case("zlib", llvm::DebugCompressionType::Z)
+-              .Case("zlib-gnu", llvm::DebugCompressionType::GNU)
+               .Default(llvm::DebugCompressionType::None);
+     }
+   }

--- a/dev-libs/rocm-comgr/rocm-comgr-5.1.3-r2.ebuild
+++ b/dev-libs/rocm-comgr/rocm-comgr-5.1.3-r2.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 inherit cmake llvm prefix
 
-LLVM_MAX_SLOT=14
+LLVM_MAX_SLOT=15
 
 if [[ ${PV} == *9999 ]] ; then
 	EGIT_REPO_URI="https://github.com/RadeonOpenCompute/ROCm-CompilerSupport/"
@@ -24,6 +24,8 @@ PATCHES=(
 	"${FILESDIR}/${PN}-5.1.3-clang-fix-include.patch"
 	"${FILESDIR}/${PN}-5.1.3-rocm-path.patch"
 	"${FILESDIR}/0001-COMGR-changes-needed-for-upstream-llvm.patch"
+	"${FILESDIR}/${PN}-5.1.3-llvm-15-remove-zlib-gnu"
+	"${FILESDIR}/${PN}-5.1.3-llvm-15-args-changed"
 )
 
 DESCRIPTION="Radeon Open Compute Code Object Manager"

--- a/dev-libs/rocm-device-libs/rocm-device-libs-5.1.3-r1.ebuild
+++ b/dev-libs/rocm-device-libs/rocm-device-libs-5.1.3-r1.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 inherit cmake llvm
 
-LLVM_MAX_SLOT=14
+LLVM_MAX_SLOT=15
 
 if [[ ${PV} == *9999 ]] ; then
 	EGIT_REPO_URI="https://github.com/RadeonOpenCompute/ROCm-Device-Libs/"

--- a/dev-libs/rocr-runtime/rocr-runtime-5.1.3-r1.ebuild
+++ b/dev-libs/rocr-runtime/rocr-runtime-5.1.3-r1.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 inherit cmake llvm
 
-LLVM_MAX_SLOT=14
+LLVM_MAX_SLOT=15
 
 if [[ ${PV} == *9999 ]] ; then
 	EGIT_REPO_URI="https://github.com/RadeonOpenCompute/ROCR-Runtime/"

--- a/dev-util/Tensile/Tensile-5.1.3-r1.ebuild
+++ b/dev-util/Tensile/Tensile-5.1.3-r1.ebuild
@@ -7,7 +7,7 @@ PYTHON_COMPAT=( python3_{8..11} )
 DISTUTILS_USE_PEP517=setuptools
 inherit distutils-r1 llvm prefix
 
-LLVM_MAX_SLOT=14
+LLVM_MAX_SLOT=15
 
 DESCRIPTION="Stretching GPU performance for GEMMs and tensor contractions"
 HOMEPAGE="https://github.com/ROCmSoftwarePlatform/Tensile"
@@ -23,10 +23,10 @@ SLOT="0/$(ver_cut 1-2)"
 RESTRICT="test"
 
 RDEPEND="${PYTHON_DEPS}
+	sys-devel/clang:${LLVM_MAX_SLOT}
 	dev-python/pyyaml[${PYTHON_USEDEP}]
 	dev-python/msgpack[${PYTHON_USEDEP}]
 	>=dev-util/rocm-smi-4.3.0
-	>=sys-devel/clang-14.0.6-r1:${LLVM_MAX_SLOT}=
 "
 DEPEND="${RDEPEND}
 	dev-util/hip

--- a/dev-util/hip/files/hip-5.1.3-llvm-15-noinline-keyword.patch
+++ b/dev-util/hip/files/hip-5.1.3-llvm-15-noinline-keyword.patch
@@ -1,0 +1,21 @@
+LLVM 15 adds __noinline__ as a keyword to match behaviour of GCC 12.
+
+When this macro is left in, it can cause the expression __attribute__((__noinline__)) to be expanded incorrectly.
+
+When the __noinline__ keyword is available disable the macro.
+
+Ref: https://reviews.llvm.org/D124866
+     https://bugs.gentoo.org/85712
+===================================================================
+--- a/include/hip/amd_detail/host_defines.h
++++ b/include/hip/amd_detail/host_defines.h
+@@ -47,7 +47,9 @@ THE SOFTWARE.
+ #define __constant__ __attribute__((constant))
+ #endif // !__CLANG_HIP_RUNTIME_WRAPPER_INCLUDED__
+ 
++#if !defined(__has_feature) || !__has_feature(cuda_noinline_keyword)
+ #define __noinline__ __attribute__((noinline))
++#endif
+ #define __forceinline__ inline __attribute__((always_inline))
+ 
+ #if __HIP_NO_IMAGE_SUPPORT

--- a/dev-util/hip/hip-5.1.3-r2.ebuild
+++ b/dev-util/hip/hip-5.1.3-r2.ebuild
@@ -9,7 +9,7 @@ DOCS_DEPEND="media-gfx/graphviz"
 
 inherit cmake docs llvm prefix python-any-r1
 
-LLVM_MAX_SLOT=14
+LLVM_MAX_SLOT=15
 
 DESCRIPTION="C++ Heterogeneous-Compute Interface for Portability"
 HOMEPAGE="https://github.com/ROCm-Developer-Tools/hipamd"
@@ -52,6 +52,7 @@ PATCHES=(
 	"${FILESDIR}/${PN}-5.1.3-correct-sample-install-location.patch"
 	"${FILESDIR}/${PN}-5.1.3-remove-cmake-doxygen-commands.patch"
 	"${FILESDIR}/0001-SWDEV-316128-HIP-surface-API-support.patch"
+	"${FILESDIR}/${PN}-5.1.3-llvm-15-noinline-keyword.patch"
 )
 
 python_check_deps() {

--- a/sci-libs/miopen/miopen-5.1.3-r1.ebuild
+++ b/sci-libs/miopen/miopen-5.1.3-r1.ebuild
@@ -7,7 +7,7 @@ ROCM_VERSION=${PV}
 
 inherit cmake flag-o-matic llvm rocm
 
-LLVM_MAX_SLOT=14
+LLVM_MAX_SLOT=15
 
 DESCRIPTION="AMD's Machine Intelligence Library"
 HOMEPAGE="https://github.com/ROCmSoftwarePlatform/MIOpen"


### PR DESCRIPTION
Backports ROCm-Developer-Tools/hipamd@28009bc68faf2b4dd8fda91c99b0725e1b063a18 to enable compiling with LLVM 15, which introduced the `__noinline__` keyword to allow CUDA/HIP code to be compiled against GCC 12, see https://github.com/llvm/llvm-project/issues/57544 and https://reviews.llvm.org/D124866

This bug was preventing rocBLAS from being able to build for some users, see https://forums.gentoo.org/viewtopic-p-8756823.html

Other ROCm packages are updated to LLVM 15 to maintain compatibility with LLVM bytecode.