### PR TITLE
dev-qt/qt-creator: call xdg_pkg_postinst

### DIFF
--- a/dev-qt/qt-creator/qt-creator-8.0.2.ebuild
+++ b/dev-qt/qt-creator/qt-creator-8.0.2.ebuild
@@ -413,6 +413,8 @@ src_install() {
 }
 
 pkg_postinst() {
+	xdg_pkg_postinst
+
 	optfeature_header \
 		"Some enabled plugins require optional dependencies for functionality:"
 	use android && optfeature "android device support" \


### PR DESCRIPTION
`xdg_pkg_postinst` needs to be explicitly called since we define our own `pkg_postinst`.

It doesn't alter any code so it shouldn't need a revbump.

Closes: https://bugs.gentoo.org/879887
Signed-off-by: Peter Levine <plevine457@gmail.com>