### PR TITLE
git-r3.eclass: Add checkout dirs as "safe" directories

### DIFF
--- a/eclass/git-r3.eclass
+++ b/eclass/git-r3.eclass
@@ -887,6 +887,11 @@ git-r3_checkout() {
 			cp "${orig_repo}"/packed-refs "${GIT_DIR}"/packed-refs || die
 		fi
 
+		# mark this directory as "safe" so that src_install() can access it
+		# https://bugs.gentoo.org/879353
+		git config --global --add safe.directory \
+			"$(cd "${out_dir}" && echo "${PWD}")" || die
+
 		# (no need to copy HEAD, we will set it via checkout)
 
 		if [[ -f ${orig_repo}/shallow ]]; then


### PR DESCRIPTION
Mark all checkout directories as "safe" to avoid dubious ownership errors with newer git versions when the checkout directory is accessed from src_install().

Bug: https://bugs.gentoo.org/879353
Signed-off-by: Michał Górny <mgorny@gentoo.org>