### PR TITLE
net-im/mattermost-desktop-bin: fix python path

### DIFF
--- a/net-im/mattermost-desktop-bin/mattermost-desktop-bin-5.2.0-r1.ebuild
+++ b/net-im/mattermost-desktop-bin/mattermost-desktop-bin-5.2.0-r1.ebuild
@@ -79,7 +79,9 @@ src_install() {
 	doexe *.so *.so.* "${MY_PN}"
 
 	dosym -r "/opt/${MY_PN}/${MY_PN}" "/usr/bin/${MY_PN}"
-	find "/opt/${MY_PN}/resources" -type l -name python3 -exec dosym -r "${PYTHON}" "{}" \; || die
+	pushd "${ED}" || die
+	find "opt/${MY_PN}/resources" -type l -name python3 -exec dosym -r "${PYTHON}" "{}" \; || die
+	popd || die
 
 	make_desktop_entry "${MY_PN}" Mattermost "${MY_PN}"
 


### PR DESCRIPTION
The previous fix was wrong.  It worked for me because I had mattermost 5.2.0 already installed, so find wouldn't fail.