### PR TITLE
verify-sig.eclass: Workaround GPG problems with long TMPDIR

### DIFF
--- a/eclass/verify-sig.eclass
+++ b/eclass/verify-sig.eclass
@@ -141,6 +141,9 @@ verify-sig_verify_detached() {
 	einfo "Verifying ${filename} ..."
 	case ${VERIFY_SIG_METHOD} in
 		openpgp)
+			# gpg can't handle very long TMPDIR
+			# https://bugs.gentoo.org/854492
+			local -x TMPDIR=/tmp
 			gemato gpg-wrap -K "${key}" "${extra_args[@]}" -- \
 				gpg --verify "${sig}" "${file}" ||
 				die "PGP signature verification failed"
@@ -190,6 +193,9 @@ verify-sig_verify_message() {
 	einfo "Verifying ${filename} ..."
 	case ${VERIFY_SIG_METHOD} in
 		openpgp)
+			# gpg can't handle very long TMPDIR
+			# https://bugs.gentoo.org/854492
+			local -x TMPDIR=/tmp
 			gemato gpg-wrap -K "${key}" "${extra_args[@]}" -- \
 				gpg --verify --output="${output_file}" "${file}" ||
 				die "PGP signature verification failed"


### PR DESCRIPTION
Force using TMPDIR=/tmp to workaround GPG failing when TMPDIR happens to be long enough to cause UNIX socket paths to exceed the system limit.

Closes: https://bugs.gentoo.org/854492
Signed-off-by: Michał Górny <mgorny@gentoo.org>