### PR TITLE
sci-physics/bullet: rename altivec vector keywords

### DIFF
--- a/sci-physics/bullet/bullet-3.21.ebuild
+++ b/sci-physics/bullet/bullet-3.21.ebuild
@@ -45,6 +45,8 @@ pkg_setup() {
 }
 
 src_prepare() {
+	(use ppc || use ppc64) && PATCHES+=( "${FILESDIR}"/replace_altivec_vector_keyword.patch )
+
 	cmake_src_prepare
 
 	# allow to generate docs

--- a/sci-physics/bullet/files/replace_altivec_vector_keyword.patch
+++ b/sci-physics/bullet/files/replace_altivec_vector_keyword.patch
@@ -1,0 +1,24 @@
+--- a/src/clew/clew.h	2022-02-16 18:12:48.879740507 +0100
++++ b/src/clew/clew.h	2022-02-16 18:13:32.403061196 +0100
+@@ -319,14 +319,14 @@
+ 
+ /* Define basic vector types */
+ #if defined(__VEC__)
+ #include <altivec.h> /* may be omitted depending on compiler. AltiVec spec provides no way to detect whether the header is required. */
+-	typedef vector unsigned char __cl_uchar16;
+-	typedef vector signed char __cl_char16;
+-	typedef vector unsigned short __cl_ushort8;
+-	typedef vector signed short __cl_short8;
+-	typedef vector unsigned int __cl_uint4;
+-	typedef vector signed int __cl_int4;
+-	typedef vector float __cl_float4;
++       typedef __vector unsigned char     __cl_uchar16;
++       typedef __vector signed char       __cl_char16;
++       typedef __vector unsigned short    __cl_ushort8;
++       typedef __vector signed short      __cl_short8;
++       typedef __vector unsigned int      __cl_uint4;
++       typedef __vector signed int        __cl_int4;
++       typedef __vector float             __cl_float4;
+ #define __CL_UCHAR16__ 1
+ #define __CL_CHAR16__ 1
+ #define __CL_USHORT8__ 1


### PR DESCRIPTION
Altivec vectors can be defined with either the "vector" keyword or the "__vector" type. In general "__vector" should be prefered for include files, as otherwise it might conflicts with other type define in the source code (define a vector class in C++ is quite common). This causes bullet to fail to build on powerpc if the code is compiled with -maltivec, or by default on ppc64el which always has altivec enabled.
See also: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=760310
Closes: https://bugs.gentoo.org/852101
Signed-off-by: Niccolò Belli <niccolo.belli@linuxsystems.it>

Note: I think we could safely apply the patch to all archs, but I've put it behind a ppc/ppc64 use flag to be on the safe side.

Let me know if you want me to bump the ebuild version to `-r1` as well.