### PR TITLE
sys-devel/binutils: Create relative symlinks to binutils binaries 

### DIFF
--- a/sys-devel/binutils/binutils-2.37_p1-r2.ebuild
+++ b/sys-devel/binutils/binutils-2.37_p1-r2.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 inherit libtool flag-o-matic gnuconfig strip-linguas toolchain-funcs
 
@@ -333,6 +333,16 @@ src_install() {
 		mv ${d}/* . || die
 		rmdir ${d} || die
 	done
+
+	# Create relative symlinks for cross-compilation
+        if [[ ${CBUILD} != ${CTARGET} ]] ; then
+                cd ${ED}/${BINPATH}
+                for x in * ; do
+                        dosym -r /usr/${CTARGET}/binutils-bin/${PV}/${x}  /usr/${CTARGET}/bin/${x}
+                        dosym -r /usr/${CTARGET}/bin/${x} /usr/bin/${CTARGET}-${x}
+                        dosym ${CTARGET}-${x} /usr/bin/${x}
+                done
+        fi
 
 	# Now we collect everything intp the proper SLOT-ed dirs
 	# When something is built to cross-compile, it installs into


### PR DESCRIPTION
Below change fixes issue described in https://github.com/gentoo/gentoo/pull/25340.
I made another pull request because accidentally in the old one i merged master instead of rebase it.
As @thesamesam requested EAPI 8 was updated and relative symlinks were made with 'dosym -r'. 

Signed-off-by: Wiktor Jaskulski <wjaskulski@adva.com>