### PR TITLE
sci-libs/onnx, dev-libs/FP16, sci-libs/caffe2: Fix installation in Gentoo Prefix

### DIFF
--- a/dev-libs/FP16/FP16-2021.03.20-r2.ebuild
+++ b/dev-libs/FP16/FP16-2021.03.20-r2.ebuild
@@ -53,6 +53,6 @@ python_install() {
 
 src_install() {
 	cmake_src_install
-	rm "${D}"/usr/include/fp16/*.py || die
+	rm "${ED}"/usr/include/fp16/*.py || die
 	python_foreach_impl python_install
 }

--- a/sci-libs/caffe2/caffe2-1.11.0-r2.ebuild
+++ b/sci-libs/caffe2/caffe2-1.11.0-r2.ebuild
@@ -135,8 +135,8 @@ src_configure() {
 		-DUSE_TENSORPIPE=OFF
 
 		-Wno-dev
-		-DTORCH_INSTALL_LIB_DIR=/usr/$(get_libdir)
-		-DLIBSHM_INSTALL_LIB_SUBDIR=/usr/$(get_libdir)
+		-DTORCH_INSTALL_LIB_DIR="${EPREFIX}"/usr/$(get_libdir)
+		-DLIBSHM_INSTALL_LIB_SUBDIR="${EPREFIX}"/usr/$(get_libdir)
 	)
 	cmake_src_configure
 }
@@ -154,7 +154,7 @@ src_install() {
 
 	rm -rf python
 	mkdir -p python/torch || die
-	mv "${D}"/usr/lib/python*/site-packages/caffe2 python/ || die
+	mv "${ED}"/usr/lib/python*/site-packages/caffe2 python/ || die
 	cp torch/version.py python/torch/ || die
 	python_foreach_impl python_install
 }

--- a/sci-libs/caffe2/caffe2-1.12.0.ebuild
+++ b/sci-libs/caffe2/caffe2-1.12.0.ebuild
@@ -136,8 +136,8 @@ src_configure() {
 		-DUSE_TENSORPIPE=OFF
 
 		-Wno-dev
-		-DTORCH_INSTALL_LIB_DIR=/usr/$(get_libdir)
-		-DLIBSHM_INSTALL_LIB_SUBDIR=/usr/$(get_libdir)
+		-DTORCH_INSTALL_LIB_DIR="${EPREFIX}"/usr/$(get_libdir)
+		-DLIBSHM_INSTALL_LIB_SUBDIR="${EPREFIX}"/usr/$(get_libdir)
 	)
 
 	use cuda && addpredict "/dev/nvidiactl" # bug 867706
@@ -157,7 +157,7 @@ src_install() {
 
 	rm -rf python
 	mkdir -p python/torch || die
-	mv "${D}"/usr/lib/python*/site-packages/caffe2 python/ || die
+	mv "${ED}"/usr/lib/python*/site-packages/caffe2 python/ || die
 	cp torch/version.py python/torch/ || die
 	python_foreach_impl python_install
 }

--- a/sci-libs/onnx/onnx-1.11.0-r2.ebuild
+++ b/sci-libs/onnx/onnx-1.11.0-r2.ebuild
@@ -33,8 +33,8 @@ src_configure() {
 src_install() {
 	cmake_src_install
 
-	patchelf --set-soname libonnxifi.so "${D}"/usr/lib/libonnxifi.so \
+	patchelf --set-soname libonnxifi.so "${ED}"/usr/lib/libonnxifi.so \
 		|| die
-	mv "${D}"/usr/lib/libonnxifi.so "${D}"/usr/$(get_libdir)/libonnxifi.so \
+	mv "${ED}"/usr/lib/libonnxifi.so "${ED}"/usr/$(get_libdir)/libonnxifi.so \
 		|| die
 }


### PR DESCRIPTION
Use `${ED}` instead of `${D}` in these two packages to fix `src_install()` phase in Gentoo Prefix.