### PR TITLE
media-libs/mesa: add rusticl use flag

### DIFF
--- a/media-libs/mesa/files/clang_resource_dir.patch
+++ b/media-libs/mesa/files/clang_resource_dir.patch
@@ -1,0 +1,24 @@
+https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/19232#note_1776640
+https://gitlab.freedesktop.org/mesa/mesa/-/issues/7717#note_1832122
+
+diff --git a/src/compiler/clc/clc_helpers.cpp b/src/compiler/clc/clc_helpers.cpp
+index 80bc84831e4..34d156bf227 100644
+--- a/src/compiler/clc/clc_helpers.cpp
++++ b/src/compiler/clc/clc_helpers.cpp
+@@ -39,6 +39,7 @@
+ #include <llvm-c/Target.h>
+ #include <LLVMSPIRVLib/LLVMSPIRVLib.h>
+ 
++#include <clang/Config/config.h>
+ #include <clang/Driver/Driver.h>
+ #include <clang/CodeGen/CodeGenAction.h>
+ #include <clang/Lex/PreprocessorOptions.h>
+@@ -866,7 +867,7 @@ clc_compile_to_llvm_module(LLVMContext &llvm_ctx,
+    // because we might have linked clang statically.
+    auto libclang_path = fs::path(LLVM_LIB_DIR) / "libclang.so";
+    auto clang_res_path =
+-      fs::path(clang::driver::Driver::GetResourcesPath(libclang_path.string())) / "include";
++      fs::path(clang::driver::Driver::GetResourcesPath(libclang_path.string(), CLANG_RESOURCE_DIR)) / "include";
+ 
+    c->getHeaderSearchOpts().UseBuiltinIncludes = true;
+    c->getHeaderSearchOpts().UseStandardSystemIncludes = true;

--- a/media-libs/mesa/mesa-9999.ebuild
+++ b/media-libs/mesa/mesa-9999.ebuild
@@ -307,6 +307,12 @@ pkg_setup() {
 	python-any-r1_pkg_setup
 }
 
+src_prepare() {
+	# Temporary workaround: https://gitlab.freedesktop.org/mesa/mesa/-/issues/7717#note_1832122
+	use opencl && eapply "${FILESDIR}/clang_resource_dir.patch"
+	default
+}
+
 multilib_src_configure() {
 	local emesonargs=()
 

--- a/media-libs/mesa/mesa-9999.ebuild
+++ b/media-libs/mesa/mesa-9999.ebuild
@@ -222,6 +222,11 @@ llvm_check_deps() {
 	has_version "sys-devel/llvm:${LLVM_SLOT}[${flags}]"
 }
 
+PATCHES=(
+	# Temporary rusticl workaround: https://gitlab.freedesktop.org/mesa/mesa/-/issues/7717#note_1832122
+	"${FILESDIR}/clang_resource_dir.patch"
+)
+
 pkg_pretend() {
 	if use vulkan; then
 		if ! use video_cards_d3d12 &&
@@ -305,12 +310,6 @@ pkg_setup() {
 		llvm_pkg_setup
 	fi
 	python-any-r1_pkg_setup
-}
-
-src_prepare() {
-	# Temporary workaround: https://gitlab.freedesktop.org/mesa/mesa/-/issues/7717#note_1832122
-	use opencl && eapply "${FILESDIR}/clang_resource_dir.patch"
-	default
 }
 
 multilib_src_configure() {

--- a/media-libs/mesa/metadata.xml
+++ b/media-libs/mesa/metadata.xml
@@ -11,7 +11,7 @@
     <flag name="gles2">Enable GLESv2 support.</flag>
     <flag name="llvm">Enable LLVM backend for Gallium3D.</flag>
     <flag name="lm-sensors">Enable Gallium HUD lm-sensors support.</flag>
-    <flag name="opencl">Enable the Clover Gallium OpenCL state tracker.</flag>
+    <flag name="opencl">Enable the Rusticl Gallium OpenCL state tracker.</flag>
     <flag name="osmesa">Build the Mesa library for off-screen rendering.</flag>
     <flag name="proprietary-codecs">Enable codecs for patent-encumbered audio and video formats.</flag>
     <flag name="valgrind">Compile in valgrind memory hints</flag>


### PR DESCRIPTION
Rusticl is a much better alternative to clover, which will be gone soon: https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/19385

This PR tries to add a rusticl use flag to mesa, but there are several blockers:
- ~~`dev-libs/libclc` needs a `spirv` use flag (also needed for Ray Tracing)~~ _which I added_
- ~~`dev-util/rust-bindgen` requires `FEATURES="-network-sandbox"` in order to build until we will start to package crates individually~~ ~~_turned out existing cargo.eclass was more than capable enough_~~ already merged by someone else
https://bugs.gentoo.org/680984
https://wiki.gentoo.org/wiki/Project:Rust
https://github.com/kentnl-gentoo-rust/rust-dev-overlay/blob/master/dev-rust/bindgen/bindgen-0.53.1.ebuild
- ~~`-Dopencl-spirv` is unable to find LLVM unless you symlink `/usr/lib/clang` to `/usr/lib/llvm/15/lib64/clang`.
mesa developers think it's a packaging issue due to slotting, but they're currently looking for a solution anyway:
https://bugs.gentoo.org/880615~~ fixed: https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/19617
- ~~`PKG_CONFIG_LIBDIR` needs to point to `/usr/lib/llvm/15/lib64/pkgconfig` or `LLVMSPIRVLib` won't be found.~~ _I've hardcoded it for the `rusticl` use flag, so that **MIGHT** be enough._

I've also added use flags for all the possible OpenCL backends in mesa [clover, rusticl, lpcl (sw)] but we should decide which ones we want to keep.