### PR TITLE
profiles/arch: remove "nv" from default VIDEO_CARDS

### DIFF
--- a/profiles/arch/alpha/make.defaults
+++ b/profiles/arch/alpha/make.defaults
@@ -21,7 +21,7 @@ LIBDIR_alpha="lib"
 
 # Donnie Berkholz <dberkholz@gentoo.org> (2006-08-18)
 # Defaults for video drivers
-VIDEO_CARDS="fbdev mga nv r128 radeon"
+VIDEO_CARDS="fbdev mga r128 radeon"
 
 # Tobias Klausmann <klausman@gentoo.org> (2018-06-25)
 # Enable USE=libtirpc by default, to ease dependency resolution during

--- a/profiles/arch/powerpc/ppc32/make.defaults
+++ b/profiles/arch/powerpc/ppc32/make.defaults
@@ -15,7 +15,7 @@ FCFLAGS="${CFLAGS}"
 
 # Donnie Berkholz <dberkholz@gentoo.org> (2006-08-18)
 # Defaults for video drivers
-VIDEO_CARDS="fbdev mga nv r128 radeon"
+VIDEO_CARDS="fbdev mga r128 radeon"
 
 # Michał Górny <mgorny@gentoo.org> (2014-06-27)
 # Multilib-related setup for compatibility with future multilib.

--- a/profiles/arch/powerpc/ppc64/make.defaults
+++ b/profiles/arch/powerpc/ppc64/make.defaults
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # All extra USE/etc should be specified in sub-profiles.
@@ -35,7 +35,7 @@ IUSE_IMPLICIT="abi_ppc_64"
 
 # Donnie Berkholz <dberkholz@gentoo.org> (2006-08-18)
 # Defaults for video drivers
-VIDEO_CARDS="fbdev mga nv r128 radeon"
+VIDEO_CARDS="fbdev mga r128 radeon"
 
 # Enable abi_ppc_64 for packages that don't have it forced.
 ABI_PPC="64"


### PR DESCRIPTION
This driver no longer compiles with recent xorg versions.