### PR TITLE
net-mail/email: EAPI bump, fix clang16 configure

### DIFF
--- a/net-mail/email/email-3.1.3-r2.ebuild
+++ b/net-mail/email/email-3.1.3-r2.ebuild
@@ -1,17 +1,18 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 DESCRIPTION="Advanced CLI tool for sending email"
 HOMEPAGE="https://github.com/deanproxy/eMail"
 SRC_URI="http://www.cleancode.org/downloads/${PN}/${P}.tar.bz2"
 LICENSE="GPL-2"
-SLOT="0"
 
+SLOT="0"
 KEYWORDS="~alpha amd64 x86"
 PATCHES=(
 	"${FILESDIR}"/${PN}-3.1.3-fno-common.patch
+	"${FILESDIR}"/${PN}-3.1.3-fix-clang16-configure.patch
 )
 
 src_install() {

--- a/net-mail/email/files/email-3.1.3-fix-clang16-configure.patch
+++ b/net-mail/email/files/email-3.1.3-fix-clang16-configure.patch
@@ -1,0 +1,19 @@
+Clang16 will not allow using undeclared library functions by default.
+This imports ctype.h into that check so isdigit() can be used without errors.
+
+Bug: https://bugs.gentoo.org/879737
+
+PR upstream: https://github.com/deanproxy/eMail/pull/63
+
+Signed-off-by: Pascal Jäger <pascal.jaeger@leimstift.de>
+
+--- a/check_strftime.sh
++++ b/check_strftime.sh
+@@ -14,6 +14,7 @@ cat << EOF > /tmp/strftime_try.c
+ #include <stdlib.h>
+ #include <time.h>
+ #include <sys/time.h>
++#include <ctype.h>
+ 
+ int
+ main (void)


### PR DESCRIPTION
This just complains because it calls a isdigit() function without importing the library:
```
checking if strftime is GNU or Non-GNU... /tmp/strftime_try.c:16:8: error: call to undeclared library function 'isdigit' with type
      'int (int)'; ISO C99 and later do not support implicit function declarations
      [-Werror,-Wimplicit-function-declaration]
  if (!isdigit(buf[1]))
       ^
```
They do this in some shell script, so no use in running autotools.
I wrote a patch to import ctype.h and the error is gone. 


Closes: https://bugs.gentoo.org/879737

Signed-off-by: Pascal Jäger <pascal.jaeger@leimstift.de>