### PR TITLE
media-gfx/rotoscope: revbum, fix build for clang16, fix bugs

### DIFF
--- a/media-gfx/rotoscope/files/rotoscope-0.2-fix_clang16_build.patch
+++ b/media-gfx/rotoscope/files/rotoscope-0.2-fix_clang16_build.patch
@@ -1,0 +1,19 @@
+Clang16 does not allow implicit function declarations by default.
+
+See also: https://wiki.gentoo.org/wiki/Modern_C_porting
+Bug: https://bugs.gentoo.org/875764
+
+Signed-off-by: Pascal Jäger <pascal.jaeger@leimstift.de>
+
+--- a/src/main.c
++++ b/src/main.c
+@@ -49,6 +49,9 @@ GList* edge_list = NULL;
+ MouseState mouse_state = IDLE;
+ Vertex last_click;
+ 
++/* Function prototypes */
++gboolean redraw_render_area( GtkWidget* widget, GdkEventExpose* event, gpointer user_data );
++
+ /* Functionality and callback functions */
+ void clear_edge_list()
+ {

--- a/media-gfx/rotoscope/files/rotoscope-0.2-fix_desktop_file.patch
+++ b/media-gfx/rotoscope/files/rotoscope-0.2-fix_desktop_file.patch
@@ -1,0 +1,19 @@
+This fixes the QA issue of the .desktop file
+
+Bug: https://bugs.gentoo.org/740024
+
+Signed-off-by: Pascal Jäger <pascal.jaeger@leimstift.de>
+
+--- a/rotoscope.desktop
++++ b/rotoscope.desktop
+@@ -2,7 +2,7 @@
+ Name=Rotoscope
+ Comment=Turn photos into cartoons
+ Exec=rotoscope
+-Icon=rotoscope.png
+-Terminal=0
++Icon=rotoscope
++Terminal=false
+ Type=Application
+-Categories=Application;Graphics;2DGraphics;RasterGraphics;GTK;
++Categories=Graphics;2DGraphics;RasterGraphics;GTK;

--- a/media-gfx/rotoscope/rotoscope-0.2-r1.ebuild
+++ b/media-gfx/rotoscope/rotoscope-0.2-r1.ebuild
@@ -1,10 +1,10 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
 
 DESCRIPTION="Graphics program that can be used to give photos a cartoon-like appearance"
-HOMEPAGE="http://www.toonyphotos.com"
+HOMEPAGE="http://www.toonyphotos.com https://sourceforge.net/projects/rotoscope/"
 SRC_URI="mirror://sourceforge/${PN}/${PN}_${PV}.orig.tar.gz"
 
 LICENSE="GPL-2"
@@ -14,5 +14,10 @@ IUSE=""
 
 RDEPEND="x11-libs/gtk+:2
 	>=gnome-base/libglade-2"
-DEPEND="${RDEPEND}
-	virtual/pkgconfig"
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-fix_clang16_build.patch
+	"${FILESDIR}"/${P}-fix_desktop_file.patch
+)


### PR DESCRIPTION
That is a small one. I bumped EAPI and fixed one function declaration and the .desktop file. I therefore removed the previous revision and put this revision directly to stable, without going throught ~arch.

I think upstream is dead, Jim. So no use to push this to upstream. 

* Fixes build for clang16
* Fixes QA issue with desktop file

Closes: https://bugs.gentoo.org/875764
Closes: https://bugs.gentoo.org/740024
Signed-off-by: Pascal Jäger <pascal.jaeger@leimstift.de>