### PR TITLE
Drop gnome@ as a maintainer from telepathy packages

### DIFF
--- a/media-plugins/gst-plugins-libnice/metadata.xml
+++ b/media-plugins/gst-plugins-libnice/metadata.xml
@@ -2,10 +2,6 @@
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
   <maintainer type="project">
-    <email>gnome@gentoo.org</email>
-    <name>Gentoo GNOME Desktop</name>
-  </maintainer>
-  <maintainer type="project">
     <email>gstreamer@gentoo.org</email>
     <name>GStreamer package maintainers</name>
   </maintainer>

--- a/net-im/telepathy-connection-managers/metadata.xml
+++ b/net-im/telepathy-connection-managers/metadata.xml
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<maintainer type="project">
-  <email>gnome@gentoo.org</email>
-  <name>Gentoo GNOME Desktop</name>
-</maintainer>
+  <!-- maintainer-needed -->
 <use>
   <flag name="gadu">Enable Gadu Gadu protocol support.</flag>
   <flag name="icq">Enable ICQ IM protocol support.</flag>

--- a/net-libs/farstream/metadata.xml
+++ b/net-libs/farstream/metadata.xml
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-  <maintainer type="project">
-    <email>gnome@gentoo.org</email>
-    <name>Gentoo GNOME Desktop</name>
-  </maintainer>
+  <!-- maintainer-needed -->
   <use>
     <flag name="valgrind">Compile in valgrind memory hints</flag>
   </use>

--- a/net-libs/libnice/metadata.xml
+++ b/net-libs/libnice/metadata.xml
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-  <maintainer type="project">
-    <email>gnome@gentoo.org</email>
-    <name>Gentoo GNOME Desktop</name>
-  </maintainer>
+  <!-- maintainer-needed -->
   <upstream>
     <remote-id type="freedesktop-gitlab">libnice/libnice</remote-id>
   </upstream>

--- a/net-libs/sofia-sip/metadata.xml
+++ b/net-libs/sofia-sip/metadata.xml
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-  <maintainer type="project">
-    <email>gnome@gentoo.org</email>
-    <name>Gentoo GNOME Desktop</name>
-  </maintainer>
+  <!-- maintainer-needed -->
   <upstream>
     <remote-id type="github">freeswitch/sofia-sip</remote-id>
   </upstream>

--- a/net-libs/telepathy-farstream/metadata.xml
+++ b/net-libs/telepathy-farstream/metadata.xml
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-  <maintainer type="project">
-    <email>gnome@gentoo.org</email>
-    <name>Gentoo GNOME Desktop</name>
-  </maintainer>
+  <!-- maintainer-needed -->
   <upstream>
     <remote-id type="freedesktop-gitlab">telepathy/telepathy-farstream</remote-id>
   </upstream>

--- a/net-voip/telepathy-gabble/metadata.xml
+++ b/net-voip/telepathy-gabble/metadata.xml
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-  <maintainer type="project">
-    <email>gnome@gentoo.org</email>
-    <name>Gentoo GNOME Desktop</name>
-  </maintainer>
+  <!-- maintainer-needed -->
   <use>
     <flag name="jingle">Enable voice calls for jabber</flag>
     <flag name="plugins">Enable plugin loader</flag>

--- a/net-voip/telepathy-rakia/metadata.xml
+++ b/net-voip/telepathy-rakia/metadata.xml
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-  <maintainer type="project">
-    <email>gnome@gentoo.org</email>
-    <name>Gentoo GNOME Desktop</name>
-  </maintainer>
+  <!-- maintainer-needed -->
   <upstream>
     <remote-id type="freedesktop-gitlab">telepathy/telepathy-rakia</remote-id>
   </upstream>

--- a/net-voip/telepathy-salut/metadata.xml
+++ b/net-voip/telepathy-salut/metadata.xml
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-  <maintainer type="project">
-    <email>gnome@gentoo.org</email>
-    <name>Gentoo GNOME Desktop</name>
-  </maintainer>
+  <!-- maintainer-needed -->
   <upstream>
     <remote-id type="freedesktop-gitlab">telepathy/telepathy-salut</remote-id>
   </upstream>


### PR DESCRIPTION
Once GNOME 42 is gone †, GNOME packages ‡ will only have a dependence on a couple of telepathy packages:

- `net-im/telepathy-logger`
- `net-im/telepathy-mission-control`
- `net-irc/telepathy-idle`
- `net-libs/telepathy-glib`

The rest continue to have reverse dependencies outside of GNOME, so we can't remove them trivially. Telepathy seems to be wholly unmaintained, so drop the gnome@ team's maintainership.

KDE/Qt may want to take over maintainership of some of these, as they still have reverse dependencies. Cc: @gentoo/kde, @gentoo/qt.

† specifically, `gnome-base/gnome-shell`, `gnome-extra/gnome-contacts`, and `gnome-extra/gnome-shell-extensions`
‡ specifically `dev-libs/folks` and `net-irc/polari`