### PR TITLE
metadata: Add license-mapping.conf for SPDX license mapping

### DIFF
--- a/metadata/license-mapping.conf
+++ b/metadata/license-mapping.conf
@@ -1,0 +1,176 @@
+# Copyright 2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+# Mapping of SPDX-2.0 licenses to Gentoo repository licenses.
+#
+# Keys are <license-id>[+] [WITH <exception-id>].
+#
+# License and exception identifiers are case-insensitive but please follow
+# the case used in SPDX.  "WITH" exceptions are matched exactly,
+# i.e.  "Apache-2.0 WITH LLVM-exception" will not match plain "Apache-2.0".
+# The "+" operator prefers exact match but falls back to the variant without,
+# i.e. if "MPL-1.0+" is not defined, the mapping for "MPL-1.0" is used.
+#
+# Values are ebuild-style LICENSE terms, possibly including multiple
+# licenses (implicit all-of group) and all-of/any-of groups.
+
+[spdx-to-ebuild]
+0BSD = 0BSD
+AFL-2.1 = AFL-2.1
+AFL-3.0 = AFL-3.0
+AGPL-3.0 = AGPL-3
+AGPL-3.0+ = AGPL-3+
+AGPL-3.0-only = AGPL-3
+AGPL-3.0-or-later = AGPL-3+
+Aladdin = Aladdin
+AMPAS = AMPAS
+Apache-1.0 = Apache-1.0
+Apache-1.1 = Apache-1.1
+Apache-2.0 = Apache-2.0
+Apache-2.0 WITH LLVM-exception = Apache-2.0-with-LLVM-exceptions
+APL-1.0 = APL-1.0
+APSL-2.0 = APSL-2
+Artistic-1.0 = Artistic
+Artistic-2.0 = Artistic-2
+Beerware = BEER-WARE
+BSD-1-Clause = BSD-1
+BSD-2-Clause = BSD-2
+BSD-3-Clause = BSD
+BSD-4-Clause = BSD-4
+BSL-1.0 = Boost-1.0
+bzip2-1.0.5 = BZIP2
+bzip2-1.0.6 = BZIP2
+CC-BY-2.0 = CC-BY-2.0
+CC-BY-2.5 = CC-BY-2.5
+CC-BY-3.0 = CC-BY-3.0
+CC-BY-4.0 = CC-BY-4.0
+CC-BY-NC-4.0 = CC-BY-NC-4.0
+CC-BY-NC-ND-2.0 = CC-BY-NC-ND-2.0
+CC-BY-NC-ND-2.5 = CC-BY-NC-ND-2.5
+CC-BY-NC-ND-3.0 = CC-BY-NC-ND-3.0
+CC-BY-NC-ND-4.0 = CC-BY-NC-ND-4.0
+CC-BY-NC-SA-1.0 = CC-BY-NC-SA-1.0
+CC-BY-NC-SA-2.5 = CC-BY-NC-SA-2.5
+CC-BY-NC-SA-3.0 = CC-BY-NC-SA-3.0
+CC-BY-NC-SA-4.0 = CC-BY-NC-SA-4.0
+CC-BY-ND-3.0 = CC-BY-ND-3.0
+CC-BY-ND-4.0 = CC-BY-ND-4.0
+CC-BY-SA-1.0 = CC-BY-SA-1.0
+CC-BY-SA-2.0 = CC-BY-SA-2.0
+CC-BY-SA-2.5 = CC-BY-SA-2.5
+CC-BY-SA-3.0 = CC-BY-SA-3.0
+CC-BY-SA-4.0 = CC-BY-SA-4.0
+CC-PDDC = CC-PD
+CC0-1.0 = CC0-1.0
+CDDL-1.0 = CDDL
+CDDL-1.1 = CDDL-1.1
+CECILL-2.0 = CeCILL-2
+CECILL-B = CeCILL-B
+CECILL-C = CeCILL-C
+CPAL-1.0 = CPAL-1.0
+CPL-1.0 = CPL-1.0
+CPOL-1.02 = CPOL
+curl = curl
+ECL-2.0 = ECL-2.0
+EPL-1.0 = EPL-1.0
+EPL-2.0 = EPL-2.0
+ErlPL-1.1 = ErlPL-1.1
+EUPL-1.1 = EUPL-1.1
+EUPL-1.2 = EUPL-1.2
+FSFAP = FSFAP
+FTL = FTL
+GD = gd
+Glulxe = Glulxe
+gnuplot = gnuplot
+GPL-1.0 = GPL-1
+GPL-1.0+ = GPL-1+
+GPL-1.0-only = GPL-1
+GPL-1.0-or-later = GPL-1+
+GPL-2.0 = GPL-2
+GPL-2.0+ = GPL-2+
+GPL-2.0-only = GPL-2
+GPL-2.0-or-later = GPL-2+
+GPL-2.0-with-classpath-exception = GPL-2-with-classpath-exception
+GPL-2.0 WITH Classpath-exception-2.0 = GPL-2-with-classpath-exception
+GPL-2.0-only WITH Classpath-exception-2.0 = GPL-2-with-classpath-exception
+GPL-2.0-with-font-exception = GPL-2-with-font-exception
+GPL-2.0 WITH Font-exception-2.0 = GPL-2-with-font-exception
+GPL-2.0-only WITH Font-exception-2.0 = GPL-2-with-font-exception
+GPL-3.0 = GPL-3
+GPL-3.0+ = GPL-3+
+GPL-3.0-only = GPL-3
+GPL-3.0-or-later = GPL-3+
+GPL-3.0 WITH Font-exception-3.0 = GPL-3-with-font-exception
+GPL-3.0-only WITH Font-exception-3.0 = GPL-3-with-font-exception
+GPL-3.0+ WITH Font-exception-3.0 = GPL-3+-with-font-exception
+GPL-3.0-or-later WITH Font-exception-3.0 = GPL-3+-with-font-exception
+HPND = HPND
+ICU = icu
+IJG = IJG
+ImageMagick = imagemagick
+Info-ZIP = Info-ZIP
+Interbase-1.0 = Interbase-1.0
+IPA = IPAfont
+ISC = ISC
+JSON = JSON
+LGPL-2.0 = LGPL-2
+LGPL-2.0+ = LGPL-2+
+LGPL-2.0-only = LGPL-2
+LGPL-2.0-or-later = LGPL-2+
+LGPL-2.1 = LGPL-2.1
+LGPL-2.1+ = LGPL-2.1+
+LGPL-2.1-only = LGPL-2.1
+LGPL-2.1-or-later = LGPL-2.1+
+LGPL-3.0 = LGPL-3
+LGPL-3.0+ = LGPL-3+
+LGPL-3.0-only = LGPL-3
+LGPL-3.0-or-later = LGPL-3+
+Libpng = libpng
+libpng-2.0 = libpng2
+libtiff = libtiff
+LPPL-1.2 = LPPL-1.2
+LPPL-1.3c = LPPL-1.3c
+MirOS = MirOS
+MIT = MIT
+MIT-advertising = MIT-with-advertising
+mpich2 = mpich2
+MPL-1.0 = MPL-1.0
+MPL-1.1 = MPL-1.1
+MPL-2.0 = MPL-2.0
+NPL-1.1 = NPL-1.1
+OFL-1.0 = OFL
+OFL-1.0-RFN = OFL
+OFL-1.1 = OFL-1.1
+OFL-1.1-RFN = OFL-1.1
+OLDAP-2.7 = OPENLDAP
+OpenSSL = openssl
+OPUBL-1.0 = OPL
+OSL-1.1 = OSL-1.1
+OSL-2.0 = OSL-2.0
+OSL-2.1 = OSL-2.1
+PHP-3.0 = PHP-3
+PHP-3.01 = PHP-3.01
+PostgreSQL = POSTGRESQL
+PSF-2.0 = PSF-2
+psutils = psutils
+Python-2.0 = PYTHON
+QPL-1.0 = QPL-1.0
+Rdisc = rdisc
+RSA-MD = RSA
+Ruby = Ruby
+Sendmail = Sendmail
+SGI-B-2.0 = SGI-B-2.0
+Sleepycat = Sleepycat
+SSPL-1.0 = SSPL-1
+TCL = tcltk
+TCP-wrappers = tcp_wrappers_license
+Unicode-DFS-2016 = Unicode-DFS-2016
+Unlicense = Unlicense
+Vim = vim
+VOSTROM = VOSTROM
+W3C = W3C
+Watcom-1.0 = Watcom-1.0
+WTFPL = WTFPL-2
+Zend-2.0 = Zend-2.0
+Zlib = ZLIB
+ZPL-2.1 = ZPL


### PR DESCRIPTION
Add a file defining mapping of SPDX-2.0 license identifiers to Gentoo ebuild licenses.  This was originally discussed on Gentoo Bugzilla [1], the submitted to the gentoo-dev ml [2].

The proposed file uses the common key-value format used for configuration files.  Currently only `spdx-to-ebuild` section is defined but other kinds of mapping can be added in the future.  As described in the top comment, it provides the ability to map SPDX-2.0 license identifiers along with the `+` and `WITH` operators to arbitrary Gentoo LICENSE strings (including all-of and any-of groups).

The initial list is taken from cargo-ebuild's license.rs [3], courtesy of Leonardo H. Neumann and Georgy Yakovlev.  A parser for this file format is implemented in pycargoebuild [4].

[1] https://bugs.gentoo.org/706472
[2] https://archives.gentoo.org/gentoo-dev/message/01924bb71411696dce04445d85da508d [3] https://gitweb.gentoo.org/proj/cargo-ebuild.git/tree/src/license.rs?id=b4314edc5bb672f5e94dcbc996f443e98fdb4dba [4] https://github.com/projg2/pycargoebuild/

Signed-off-by: Michał Górny <mgorny@gentoo.org>