### PR TITLE
sys-apps/sg3_utils: MUSL uint fix

### DIFF
--- a/sys-apps/sg3_utils/files/sg3_utils-1.47-musl.patch
+++ b/sys-apps/sg3_utils/files/sg3_utils-1.47-musl.patch
@@ -1,0 +1,32 @@
+Closes: https://bugs.gentoo.org/828897
+
+From https://github.com/doug-gilbert/sg3_utils/commit/c93ad13ecd8ddfbb8bb3e4d5d5ad7f3f2c633db6.patch Mon Sep 17 00:00:00 2001
+From: Fabrice Fontaine <fontaine.fabrice@gmail.com>
+Date: Sun, 14 Nov 2021 12:37:16 +0100
+Subject: [PATCH] src/sg_dd.c: fix musl build
+
+Fix the following build failure on musl raised since version 1.47 and
+https://github.com/doug-gilbert/sg3_utils/commit/f0195003bb0c66ba55084b2f7e0fe982f08c5675:
+
+sg_dd.c: In function 'main':
+sg_dd.c:2402:17: error: unknown type name 'uint'; did you mean 'int'?
+ 2402 |                 uint off;
+      |                 ^~~~
+      |                 int
+
+Fixes:
+ - http://autobuild.buildroot.org/results/9ead59ffefefe2a4e3b94a153b3d23231736d882
+
+Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>
+
+--- a/src/sg_dd.c
++++ b/src/sg_dd.c
+@@ -2399,7 +2399,7 @@ main(int argc, char * argv[])
+             res = blocks * blk_sz;
+             if (iflag.zero && iflag.ff && (blk_sz >= 4)) {
+                 uint32_t pos = (uint32_t)skip;
+-                uint off;
++                uint32_t off;
+ 
+                 for (k = 0, off = 0; k < blocks; ++k, off += blk_sz, ++pos) {
+                     for (j = 0; j < (blk_sz - 3); j += 4)

--- a/sys-apps/sg3_utils/sg3_utils-1.47-r1.ebuild
+++ b/sys-apps/sg3_utils/sg3_utils-1.47-r1.ebuild
@@ -1,0 +1,42 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="Apps for querying the sg SCSI interface"
+HOMEPAGE="https://sg.danny.cz/sg/"
+#SRC_URI="https://github.com/hreinecke/sg3_utils/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+SRC_URI="https://sg.danny.cz/sg/p/${P}.tar.xz"
+
+LICENSE="GPL-2"
+SLOT="0/${PV}"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+IUSE="static-libs"
+
+DEPEND="sys-devel/libtool"
+RDEPEND="!sys-apps/rescan-scsi-bus"
+
+PATCHES=(
+       	 # Bug #828897
+         "${FILESDIR}"/${PN}-1.47-musl.patch
+)
+
+src_configure() {
+	econf $(use_enable static-libs static)
+}
+
+src_install() {
+	default
+	dodoc COVERAGE doc/README examples/*.txt
+	newdoc scripts/README README.scripts
+
+	find "${ED}" -type f -name "*.la" -delete || die
+
+	# Better fix for bug 231089; some packages look for sgutils2
+	local path lib
+	path="/usr/$(get_libdir)"
+	for lib in "${ED}/"${path}/libsgutils2{,-${PV}}.*; do
+		lib=${lib##*/}
+		dosym "${lib}" "${path}/${lib/libsgutils2/libsgutils}"
+	done
+}


### PR DESCRIPTION
Upstream patch - https://github.com/doug-gilbert/sg3_utils/commit/c93ad13ecd8ddfbb8bb3e4d5d5ad7f3f2c633db6.patch

This patch allows sg3_utils to work under Musl by replacing uint with uint32_t and has been tested on amd64 and PPC

Upstream bug - https://github.com/doug-gilbert/sg3_utils/pull/7

Closes: https://bugs.gentoo.org/828897
Thanks-to: ayuayuayu
Signed-off-by: Ian Jordan <immoloism@gmail.com>