### PR TITLE
app-misc/piper: reference dev-libs/libratbag with pkg tag in longdescription

### DIFF
--- a/app-misc/piper/metadata.xml
+++ b/app-misc/piper/metadata.xml
@@ -15,7 +15,7 @@
 		mouse, adding and removing profiles, setting LED colors and changing
 		button behaviors.
 
-		Piper requires libratbag’s ratbagd, the daemon to actually communicate with the
+		Piper requires <pkg>dev-libs/libratbag</pkg>’s ratbagd, the daemon to actually communicate with the
 		mice. Piper is merely a front end to ratbagd, ratbagd must be
 		installed and running when Piper is launched.
 	</longdescription>


### PR DESCRIPTION
This improves metadata change from recent PR https://github.com/gentoo/gentoo/pull/27931 in commit 0da20a20b759 - `app-misc/piper: format metadata.xml, add upstream metadata and update description`.