### PR TITLE
mail-filter/rspamd: fix page-alignment of .unser files

### DIFF
--- a/mail-filter/rspamd/files/rspamd-3.4-hyperscan-page-alignment.patch
+++ b/mail-filter/rspamd/files/rspamd-3.4-hyperscan-page-alignment.patch
@@ -1,0 +1,28 @@
+Fix for hyperscan page alignment issues.
+
+Upstream-Issue: https://github.com/rspamd/rspamd/issues/4329
+
+diff --git a/src/libserver/hyperscan_tools.cxx b/src/libserver/hyperscan_tools.cxx
+index 6187208a9..96366067d 100644
+--- a/src/libserver/hyperscan_tools.cxx
++++ b/src/libserver/hyperscan_tools.cxx
+@@ -306,7 +306,15 @@ auto load_cached_hs_file(const char *fname, std::int64_t offset = 0) -> tl::expe
+ 						msg_debug_hyperscan_lambda("multipattern: create new database in %s; %Hz size",
+ 							tmpfile_pattern.data(), unserialized_size);
+ 						void *buf;
+-						posix_memalign(&buf, 16, unserialized_size);
++#ifdef HAVE_GETPAGESIZE
++						auto page_size = getpagesize();
++#else
++						auto page_size = sysconf(_SC_PAGESIZE);
++#endif
++						if (page_size == -1) {
++							page_size = 4096;
++						}
++						posix_memalign(&buf, page_size, unserialized_size);
+ 						if (buf == nullptr) {
+ 							return tl::make_unexpected(error {"Cannot allocate memory", errno, error_category::CRITICAL });
+ 						}
+-- 
+2.37.4
+

--- a/mail-filter/rspamd/rspamd-3.4-r1.ebuild
+++ b/mail-filter/rspamd/rspamd-3.4-r1.ebuild
@@ -71,6 +71,7 @@ PATCHES=(
 	"${FILESDIR}/${PN}-3.2-unbundle-lua.patch"
 	"${FILESDIR}/${PN}-2.5-unbundle-snowball.patch"
 	"${FILESDIR}/${PN}-3.3-remove-test-case.patch"
+	"${FILESDIR}/${PN}-3.4-hyperscan-page-alignment.patch"
 )
 
 src_prepare() {
@@ -133,4 +134,16 @@ src_install() {
 
 pkg_postinst() {
 	tmpfiles_process "${PN}.conf"
+
+	for ver in ${REPLACING_VERSIONS}; do
+		if ver_test "${ver}" -eq "3.4"; then
+			elog "rspamd-3.4 is known to segfault when it is updated from older version due"
+			elog "to a page-alignment of hyperscan .unser files. The issue is patched in this"
+			elog "ebuild revision rspamd-3.4-r1. All possibly broken .unser files will be"
+			elog "automaticaly removed. See https://github.com/rspamd/rspamd/issues/4329 for"
+			elog "more information."
+
+			find "${EROOT}/var/lib/rspamd" -type f -name '*.unser' -delete
+		fi
+	done
 }


### PR DESCRIPTION
This revision applies patch taken from upstream [1] which fixes page-alignment issue of .unser files causing segfaults. The issue affects only those who already started rspamd-3.4. All .unser files will be automatically removed in postinstall phase for those who are updating from 3.4 to 3.4-r1.

[1] https://github.com/rspamd/rspamd/issues/4329