### PR TITLE
net-misc/curl: Fix typo in -without-gnutls option

### DIFF
--- a/net-misc/curl/curl-7.86.0-r1.ebuild
+++ b/net-misc/curl/curl-7.86.0-r1.ebuild
@@ -115,7 +115,7 @@ multilib_src_configure() {
 	myconf+=( --without-ca-fallback --with-ca-bundle="${EPREFIX}"/etc/ssl/certs/ca-certificates.crt  )
 	#myconf+=( --without-default-ssl-backend )
 	if use ssl ; then
-		myconf+=( -without-gnutls --without-mbedtls --without-nss )
+		myconf+=( --without-gnutls --without-mbedtls --without-nss )
 
 		if use gnutls || use curl_ssl_gnutls; then
 			einfo "SSL provided by gnutls"


### PR DESCRIPTION
It should have a double hyphen in the beginning.