### PR TITLE
dev-perl/Crypt-OpenSSL-*, dev-perl/Net-SSLeay: Fix OpenSSL detection when cross-compiling

### DIFF
--- a/dev-perl/Crypt-OpenSSL-RSA/Crypt-OpenSSL-RSA-0.330.0.ebuild
+++ b/dev-perl/Crypt-OpenSSL-RSA/Crypt-OpenSSL-RSA-0.330.0.ebuild
@@ -37,3 +37,5 @@ PERL_RM_FILES=(
 )
 
 mydoc="rfc*.txt"
+
+export OPENSSL_PREFIX="${ESYSROOT}/usr"

--- a/dev-perl/Crypt-OpenSSL-Random/Crypt-OpenSSL-Random-0.150.0-r1.ebuild
+++ b/dev-perl/Crypt-OpenSSL-Random/Crypt-OpenSSL-Random-0.150.0-r1.ebuild
@@ -1,0 +1,43 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DIST_AUTHOR=RURBAN
+DIST_VERSION=0.15
+inherit perl-module
+
+DESCRIPTION="OpenSSL pseudo-random number generator access"
+
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~x64-macos"
+
+RDEPEND="
+	dev-libs/openssl:0=
+"
+DEPEND="
+	dev-libs/openssl:0=
+"
+BDEPEND="${RDEPEND}
+	>=dev-perl/Crypt-OpenSSL-Guess-0.110.0
+	virtual/perl-ExtUtils-MakeMaker
+"
+PERL_RM_FILES=(
+	t/z_kwalitee.t
+	t/z_manifest.t
+	t/z_meta.t
+	t/z_perl_minimum_version.t
+	t/z_pod-coverage.t
+	t/z_pod.t
+)
+
+mydoc="ToDo"
+
+export OPENSSL_PREFIX="${ESYSROOT}/usr"
+
+src_compile() {
+	mymake=(
+		"OPTIMIZE=${CFLAGS}"
+	)
+	perl-module_src_compile
+}

--- a/dev-perl/Net-SSLeay/Net-SSLeay-1.920.0.ebuild
+++ b/dev-perl/Net-SSLeay/Net-SSLeay-1.920.0.ebuild
@@ -52,14 +52,14 @@ src_configure() {
 		export NETWORK_TESTS=no
 	fi
 	export LIBDIR=$(get_libdir)
-	use prefix && export OPENSSL_PREFIX="${EPREFIX}/usr"
+	export OPENSSL_PREFIX="${ESYSROOT}/usr"
 	perl-module_src_configure
 }
 
 src_compile() {
 	mymake=(
 		OPTIMIZE="${CFLAGS}"
-		OPENSSL_PREFIX="${EPREFIX}"/usr
+		OPENSSL_PREFIX="${ESYSROOT}"/usr
 	)
 	perl-module_src_compile
 }


### PR DESCRIPTION
Crypt-OpenSSL-Guess looks for OpenSSL in a bunch of random places, which we want to avoid. Specifying it this way also fixes cross-compiling, at least when combined with other fixes.

With Net-SSLeay, search for OpenSSL using ESYSROOT as EPREFIX is not sufficient when you're cross-compiling.