### PR TITLE
net-vpn/iodine: Add support for arbitrary args in conf.d/iodined

### DIFF
--- a/net-vpn/iodine/files/iodined-1.init-r1
+++ b/net-vpn/iodine/files/iodined-1.init-r1
@@ -1,0 +1,64 @@
+#!/sbin/openrc-run
+# Copyright 1999-2014 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+PID_FILE="/run/iodined.pid"
+
+depend() {
+	need net
+}
+
+start() {
+	ebegin "Starting iodined"
+	ARGS=""
+	if [ "$IODINED_ARGS" ]; then
+		ARGS="$ARGS $IODINED_ARGS"
+	fi
+	if [ "$IODINED_USER" ]; then
+		ARGS="$ARGS -u $IODINED_USER"
+	fi
+	if [ "$IODINED_CHROOT" ]; then
+		ARGS="$ARGS -t $IODINED_CHROOT"
+	fi
+	if [ "$IODINED_MTU" ]; then
+		ARGS="$ARGS -m $IODINED_MTU"
+	fi
+	if [ "$IODINED_LISTENPORT" ]; then
+		ARGS="$ARGS -p $IODINED_LISTENPORT"
+	fi
+	if [ "$IODINED_EXTERN_IP" ]; then
+		ARGS="$ARGS -n $IODINED_EXTERN_IP"
+	fi
+	if [ "$IODINED_LOCAL_DNS_PORT" ]; then
+		ARGS="$ARGS -b $IODINED_LOCAL_DNS_PORT"
+	fi
+	if [ "$IODINED_LISTENIP" ]; then
+		ARGS="$ARGS -l $IODINED_LISTENIP"
+	fi
+	if [ "$IODINED_PASSWD" ]; then
+		ARGS="$ARGS -P $IODINED_PASSWD"
+	else
+		eerror "Please set a password (IODINED_PASSWD) in /etc/conf.d/iodined!"
+		return 1
+	fi
+	if [ "$IODINED_IP" ]; then
+		ARGS="$ARGS $IODINED_IP"
+	else
+		eerror "Please set an IP (IODINED_IP) in /etc/conf.d/iodined!"
+		return 1
+	fi
+	if [ "$IODINED_DOMAIN" ]; then
+		ARGS="$ARGS $IODINED_DOMAIN"
+	else
+		eerror "Please set a domain (IODINED_DOMAIN) in /etc/conf.d/iodined!"
+		return 1
+	fi
+	start-stop-daemon --start --exec /usr/sbin/iodined --pidfile $PID_FILE -- -F $PID_FILE $ARGS
+	eend $?
+}
+
+stop() {
+	ebegin "Stopping iodined"
+	start-stop-daemon --stop --exec /usr/sbin/iodined --pidfile $PID_FILE
+	eend $?
+}

--- a/net-vpn/iodine/files/iodined.conf-r1
+++ b/net-vpn/iodine/files/iodined.conf-r1
@@ -1,0 +1,46 @@
+# /etc/conf.d/iodined: config file for /etc/init.d/iodined
+
+# Drop privileges to this user after startup
+# This is used by the -u argument. Comment out to keep running as root.
+IODINED_USER="nobody"
+
+# Chroot to this directory after startup
+# This is used by the -t argument. Comment out to avoid chroot.
+IODINED_CHROOT="/var/empty"
+
+# This password needs to be used in all clients when they connect
+# This is used by the -P argument
+IODINED_PASSWD=""
+
+# This is the MTU (Max Transmit Unit) used in the tunnel.
+# You probably dont need this field at all, downstream data will
+# now be fragmented. This is used by the -m argument
+#IODINED_MTU=1020
+
+# The server port to listen on. You should normally not change this.
+# See man page. This is used by the -p argument
+#IODINED_LISTENPORT=53
+
+# The IP address to return as reply to NS queries. If not set, it will
+# be the destination address of the query. Used by the -n argument
+#IODINED_EXTERN_IP=1.1.1.1
+
+# The port used by a "real" DNS server on localhost. Queries for
+# domains not handled by iodined will be forwarded to this port,
+# and answers will be routed back. Used by the -b argument
+#IODINED_LOCAL_DNS_PORT=5353
+
+# The IP number to listen on.
+# This is used by the -l argument
+#IODINED_LISTENIP=127.0.0.1
+
+# This IP number will be used by the local tun device.
+IODINED_IP="172.28.0.1"
+
+# Use subdomains to this domain for network tunneling
+# If a real domain is used, it should be delegated to this server with 
+# a NS entry in the domain zone (see man page)
+IODINED_DOMAIN="blah.abc"
+
+# Any extra args not covered above.
+#IODINED_ARGS=""

--- a/net-vpn/iodine/iodine-0.7.0-r4.ebuild
+++ b/net-vpn/iodine/iodine-0.7.0-r4.ebuild
@@ -1,0 +1,50 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit linux-info toolchain-funcs
+
+DESCRIPTION="IP over DNS tunnel"
+HOMEPAGE="https://code.kryo.se/iodine/"
+SRC_URI="https://code.kryo.se/${PN}/${P}.tar.gz"
+
+CONFIG_CHECK="~TUN"
+
+LICENSE="ISC GPL-2" #GPL-2 for init script bug #426060
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="test"
+RESTRICT="!test? ( test )"
+
+RDEPEND="sys-libs/zlib"
+DEPEND="${RDEPEND}
+	test? ( dev-libs/check )"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-TestMessage.patch
+	"${FILESDIR}"/${P}-new-systemd.patch
+)
+
+src_prepare() {
+	default
+
+	sed -e '/^\s@echo \(CC\|LD\)/d' \
+		-e 's:^\(\s\)@:\1:' \
+		-i {,src/}Makefile || die
+
+	tc-export CC
+}
+
+src_install() {
+	# Don't re-run submake
+	sed -e '/^install:/s: all: :' \
+		-i Makefile || die
+	emake prefix="${EPREFIX}"/usr DESTDIR="${D}" install
+	einstalldocs
+
+	newinitd "${FILESDIR}"/iodined-1.init-r1 iodined
+	newconfd "${FILESDIR}"/iodined.conf-r1 iodined
+	keepdir /var/empty
+	fperms 600 /etc/conf.d/iodined
+}


### PR DESCRIPTION
Signed-off-by: Hank Leininger <hlein@korelogic.com>
Closes: https://bugs.gentoo.org/881355