### PR TITLE
media-libs/ctl: restrict dependency on media-libs/openexr

### DIFF
--- a/media-libs/ctl/ctl-1.5.2-r3.ebuild
+++ b/media-libs/ctl/ctl-1.5.2-r3.ebuild
@@ -1,0 +1,41 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit cmake
+
+DESCRIPTION="AMPAS' Color Transformation Language"
+HOMEPAGE="https://github.com/ampas/CTL"
+SRC_URI="https://github.com/ampas/CTL/archive/${P}.tar.gz"
+S="${WORKDIR}/CTL-ctl-${PV}"
+
+LICENSE="AMPAS"
+SLOT="0"
+KEYWORDS="~amd64 ~ia64 ~ppc64 ~x86"
+IUSE="test"
+
+RESTRICT="!test? ( test )"
+
+RDEPEND="media-libs/ilmbase:=
+	<media-libs/openexr-3:=
+	media-libs/tiff:=
+	!media-libs/openexr_ctl"
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}/${P}-Use-GNUInstallDirs-and-fix-PkgConfig-files-1.patch"
+	"${FILESDIR}/${P}-openexr-2.3.patch"
+	"${FILESDIR}/${P}-fix-to-build-with-gcc-11.patch"
+	"${FILESDIR}/${P}-install-dpx-library.patch"
+	"${FILESDIR}/${P}-fix-unit-tests.patch"
+)
+
+mycmakeargs=( -DCMAKE_INSTALL_DOCDIR="share/doc/${PF}" )
+
+src_test() {
+	pushd "${BUILD_DIR}" >/dev/null || die
+	eninja check
+	popd >/dev/null || die
+}

--- a/media-libs/ctl/files/ctl-1.5.2-Use-GNUInstallDirs-and-fix-PkgConfig-files-1.patch
+++ b/media-libs/ctl/files/ctl-1.5.2-Use-GNUInstallDirs-and-fix-PkgConfig-files-1.patch
@@ -243,7 +243,7 @@ index 1817071..eb7e14e 100644
  endif()
  
 -find_package( OpenEXR QUIET )
-+PKG_CHECK_MODULES ( OpenEXR REQUIRED OpenEXR )
++PKG_CHECK_MODULES ( OpenEXR QUIET OpenEXR )
  if (OpenEXR_FOUND)
    message( STATUS "Found OpenEXR, version ${OpenEXR_VERSION}" )
  else()


### PR DESCRIPTION
Package currently doesn't build with OpenEXR-3/Imath.
Because the package uses automagic dependencies if OpenEXR-2 is available,
we still need to depend on <media-libs/openexr-3 for now.
Upstream is in the process of migrating the package to Imath/OpenEXR-3.
Bump to EAPI 8

Bug: https://github.com/ampas/CTL/issues/100
Closes: https://bugs.gentoo.org/878247
Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>