### PR TITLE
media-sound/fluidsynth: reference media-video/pipewire with pkg tag

### DIFF
--- a/media-sound/fluidsynth/metadata.xml
+++ b/media-sound/fluidsynth/metadata.xml
@@ -10,6 +10,6 @@
 	</upstream>
 	<use>
 		<flag name="network">enable network support (requires BSD sockets)</flag>
-		<flag name="pipewire">enable pipewire support</flag>
+		<flag name="pipewire">enable <pkg>media-video/pipewire</pkg> support</flag>
 	</use>
 </pkgmetadata>


### PR DESCRIPTION
This PR improves new `pipewire` flag description from commit 9c6ff2c4cb37 - `media-sound/fluidsynth: bump to 2.3.0`.