### PR TITLE
media-gfx/rotoscope: fix -Wreturn-type warnings

### DIFF
--- a/media-gfx/rotoscope/files/rotoscope-0.2-fix_clang16_build.patch
+++ b/media-gfx/rotoscope/files/rotoscope-0.2-fix_clang16_build.patch
@@ -12,8 +12,27 @@ Signed-off-by: Pascal Jäger <pascal.jaeger@leimstift.de>
  Vertex last_click;
  
 +/* Function prototypes */
-+gboolean redraw_render_area( GtkWidget* widget, GdkEventExpose* event, gpointer user_data );
++void redraw_render_area( GtkWidget* widget, GdkEventExpose* event, gpointer user_data );
 +
  /* Functionality and callback functions */
  void clear_edge_list()
  {
+@@ -165,7 +168,7 @@ void draw_pixbuf_to_drawing_area( GdkPixbuf* src, GtkWidget* dest )
+ 			 GDK_RGB_DITHER_NONE, 0, 0 );
+ }
+ 
+-gboolean redraw_render_area( GtkWidget* widget, GdkEventExpose* event, gpointer user_data )
++void redraw_render_area( GtkWidget* widget, GdkEventExpose* event, gpointer user_data )
+ {
+ 	GtkWidget* render_drawing_area = glade_xml_get_widget( xml, "render_drawing_area" );
+ 	draw_pixbuf_to_drawing_area( render_result, render_drawing_area );
+--- a/src/graph.c
++++ b/src/graph.c
+@@ -64,6 +64,7 @@ gboolean save_graph_to_file( GList* edges, char* filename )
+ 	}
+ 
+ 	fclose( f );
++	return FALSE;
+ }
+ 
+ GList* load_graph_from_file( char* filename )


### PR DESCRIPTION
Signed-off-by: Pascal Jäger <pascal.jaeger@leimstift.de>