### PR TITLE
net-fs/samba: Make smbspool_krb5_wrapper accessible to root only

### DIFF
--- a/net-fs/samba/samba-4.15.12-r1.ebuild
+++ b/net-fs/samba/samba-4.15.12-r1.ebuild
@@ -266,6 +266,8 @@ multilib_src_install() {
 
 	# Make all .so files executable
 	find "${ED}" -type f -name "*.so" -exec chmod +x {} + || die
+	# smbspool_krb5_wrapper must only be accessible to root
+	find "${ED}" -type f -name "smbspool_krb5_wrapper" -exec chmod go-rwx {} + || die
 
 	if multilib_is_native_abi ; then
 		# install ldap schema for server (bug #491002)

--- a/net-fs/samba/samba-4.16.7-r1.ebuild
+++ b/net-fs/samba/samba-4.16.7-r1.ebuild
@@ -307,6 +307,8 @@ multilib_src_install() {
 
 	# Make all .so files executable
 	find "${ED}" -type f -name "*.so" -exec chmod +x {} + || die
+	# smbspool_krb5_wrapper must only be accessible to root
+	find "${ED}" -type f -name "smbspool_krb5_wrapper" -exec chmod go-rwx {} + || die
 
 	if multilib_is_native_abi ; then
 		# Install ldap schema for server (bug #491002)


### PR DESCRIPTION
For CUPS to exec an plugin as root, group and others must not have privs.

I left out the symlink change for now. I think it should be fine to always use the wrapper, it is designed to fallback on standard smbspool if no kerberos ticket available.