### PR TITLE
sys-fs/genfstab-24: fix the download link

### DIFF
--- a/sys-fs/genfstab/genfstab-24.ebuild
+++ b/sys-fs/genfstab/genfstab-24.ebuild
@@ -4,8 +4,8 @@
 EAPI=7
 
 DESCRIPTION="Genfstab - generate output suitable for addition to an fstab file"
-HOMEPAGE="https://github.com/mscardovi/genfstab https://man.archlinux.org/man/genfstab.8"
-SRC_URI="https://github.com/mscardovi/genfstab/releases/download/${PV}/${P}.tar.gz"
+HOMEPAGE="https://github.com/scardracs/genfstab https://man.archlinux.org/man/genfstab.8"
+SRC_URI="https://github.com/scardracs/genfstab/releases/download/${PV}/${P}.tar.gz"
 S="${WORKDIR}"
 
 LICENSE="GPL-2"


### PR DESCRIPTION
As I've changed the nickname, again, of my GH profile, we need to change the download link of it.
As I used to suggest some times ago please find a better place for it, as I'm not a proxy maintainer anymore.

EDIT:

TBH It's not a problem for me to maintain the download link but I can't assure to maintain my GH profile forever.
If you want you can also remove it entirely (if you find genfstab not useful). Everything is up to you.
As I side note I'd want to say I've found some users using it on gentoo reddit.