### PR TITLE
sys-fs/jfsutils: MUSL Patch

### DIFF
--- a/sys-fs/jfsutils/files/jfsutils-1.1.15-musl-fix-includes.patch
+++ b/sys-fs/jfsutils/files/jfsutils-1.1.15-musl-fix-includes.patch
@@ -1,0 +1,23 @@
+Closes: https://bugs.gentoo.org/715568
+
+From https://git.alpinelinux.org/aports/commit/main/jfsutils/musl-fix-includes.patch?id=d9768c312ddc047df6c2c9b1674b2ab37ddf4e2a 2013-12-17 13:59:36 +0000
+From Timo Teräs <timo.teras@iki.fi>
+
+--- a/libfs/fssubs.c
++++ b/libfs/fssubs.c
+@@ -24,6 +24,7 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>
++#include <paths.h>
+ 
+ #if HAVE_MNTENT_H
+ #include <mntent.h>
+@@ -31,7 +32,6 @@
+ #endif
+ 
+ #if HAVE_GETMNTINFO
+-#include <paths.h>
+ #include <sys/param.h>
+ #include <sys/mount.h>
+ #endif

--- a/sys-fs/jfsutils/jfsutils-1.1.15-r2.ebuild
+++ b/sys-fs/jfsutils/jfsutils-1.1.15-r2.ebuild
@@ -1,0 +1,55 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit autotools flag-o-matic
+
+DESCRIPTION="IBM's Journaling Filesystem (JFS) Utilities"
+HOMEPAGE="http://jfs.sourceforge.net/"
+SRC_URI="http://jfs.sourceforge.net/project/pub/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+IUSE="static"
+
+LIB_DEPEND="sys-apps/util-linux:=[static-libs]"
+
+RDEPEND="!static? ( ${LIB_DEPEND//\[static-libs]} )"
+
+DEPEND="${RDEPEND}
+	static? ( ${LIB_DEPEND} )"
+
+DOCS=( AUTHORS ChangeLog NEWS README )
+
+PATCHES=(
+	"${FILESDIR}"/${P}-linux-headers.patch #448844
+	"${FILESDIR}"/${P}-sysmacros.patch #580056
+	"${FILESDIR}"/${P}-check-for-ar.patch #726032
+	"${FILESDIR}"/${P}-gcc10.patch #707314
+	"${FILESDIR}"/${P}-format-security-errors.patch #557140
+	"${FILESDIR}"/${P}-musl-fix-includes.patch # 715568
+)
+
+src_prepare() {
+	default
+
+	eautoreconf
+}
+
+src_configure() {
+	# It doesn't compile on alpha without this LDFLAGS
+	use alpha && append-ldflags "-Wl,--no-relax"
+
+	use static && append-ldflags -static
+	econf --sbindir=/sbin
+}
+
+src_install() {
+	default
+
+	rm -f "${ED}"/sbin/{mkfs,fsck}.jfs || die
+	dosym jfs_mkfs /sbin/mkfs.jfs
+	dosym jfs_fsck /sbin/fsck.jfs
+}


### PR DESCRIPTION
Patch from Alpine Linux	to fix jfsutils	not working on Musl systems. This has been tested on	both Glibc and MusL systems to work.

Original Alpine commit -  https://git.alpinelinux.org/aports/commit/main/jfsutils/musl-fix-includes.patch?id=d9768c312ddc047df6c2c9b1674b2ab37ddf4e2a

Closes: https://bugs.gentoo.org/715568
Co-authored-by:	Timo Teräs <timo.teras@iki.fi>
Signed-off-by: Ian Jordan <immoloism@gmail.com>