### PR TITLE
sys-boot/syslinux: Filter LTO

### DIFF
--- a/sys-boot/syslinux/syslinux-6.04_pre1-r2.ebuild
+++ b/sys-boot/syslinux/syslinux-6.04_pre1-r2.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-inherit toolchain-funcs
+inherit toolchain-funcs flag-o-matic
 
 DESCRIPTION="SYSLINUX, PXELINUX, ISOLINUX, EXTLINUX and MEMDISK bootloaders"
 HOMEPAGE="https://www.syslinux.org/"
@@ -104,6 +104,8 @@ _emake() {
 }
 
 src_compile() {
+	filter-lto #863722
+
 	# build system abuses the LDFLAGS variable to pass arguments to ld
 	unset LDFLAGS
 	if [[ ! -z ${loaderarch} ]]; then

--- a/sys-boot/syslinux/syslinux-6.04_pre1-r3.ebuild
+++ b/sys-boot/syslinux/syslinux-6.04_pre1-r3.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit toolchain-funcs
+inherit toolchain-funcs flag-o-matic
 
 DESCRIPTION="SYSLINUX, PXELINUX, ISOLINUX, EXTLINUX and MEMDISK bootloaders"
 HOMEPAGE="https://www.syslinux.org/"
@@ -50,6 +50,8 @@ src_prepare() {
 	default
 }
 src_compile() {
+	filter-lto #863722
+
 	local DATE=$(date -u -r NEWS +%Y%m%d)
 	local HEXDATE=$(printf '0x%08x' "${DATE}")
 

--- a/sys-boot/syslinux/syslinux-6.04_pre3.ebuild
+++ b/sys-boot/syslinux/syslinux-6.04_pre3.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit toolchain-funcs
+inherit toolchain-funcs flag-o-matic
 
 DESCRIPTION="SYSLINUX, PXELINUX, ISOLINUX, EXTLINUX and MEMDISK bootloaders"
 HOMEPAGE="https://www.syslinux.org/"
@@ -67,6 +67,8 @@ efimake() {
 }
 
 src_compile() {
+	filter-lto #863722
+
 	local DATE=$(date -u -r NEWS +%Y%m%d)
 	local HEXDATE=$(printf '0x%08x' "${DATE}")
 


### PR DESCRIPTION
Syslinux can only use LTO when using the ffat-lto-objects cflag and as this is a hack solution I recommend filtering which seems to be the only way to do it without.

Closes: https://bugs.gentoo.org/863722
Signed-off-by: Ian Jordan <immoloism@gmail.com>