### PR TITLE
dev-libs/libbpf: Fix install in prefix

### DIFF
--- a/dev-libs/libbpf/libbpf-0.8.1.ebuild
+++ b/dev-libs/libbpf/libbpf-0.8.1.ebuild
@@ -34,7 +34,9 @@ PATCHES=(
 src_configure() {
 	append-cflags -fPIC
 	tc-export CC AR
-	export LIBSUBDIR="$(get_libdir)" V=1
+	export LIBSUBDIR="$(get_libdir)"
+	export PREFIX="${EPREFIX}/usr"
+	export V=1
 }
 
 src_install() {

--- a/dev-libs/libbpf/libbpf-1.0.0-r1.ebuild
+++ b/dev-libs/libbpf/libbpf-1.0.0-r1.ebuild
@@ -34,7 +34,7 @@ src_configure() {
 	append-cflags -fPIC
 	tc-export CC AR
 	export LIBSUBDIR="$(get_libdir)"
-	export LIBDIR="${EPREFIX}/usr/$(get_libdir)"
+	export PREFIX="${EPREFIX}/usr"
 	export V=1
 }
 

--- a/dev-libs/libbpf/libbpf-1.0.1.ebuild
+++ b/dev-libs/libbpf/libbpf-1.0.1.ebuild
@@ -34,7 +34,7 @@ src_configure() {
 	append-cflags -fPIC
 	tc-export CC AR
 	export LIBSUBDIR="$(get_libdir)"
-	export LIBDIR="${EPREFIX}/usr/$(get_libdir)"
+	export PREFIX="${EPREFIX}/usr"
 	export V=1
 }
 

--- a/dev-libs/libbpf/libbpf-9999.ebuild
+++ b/dev-libs/libbpf/libbpf-9999.ebuild
@@ -34,7 +34,7 @@ src_configure() {
 	append-cflags -fPIC
 	tc-export CC AR
 	export LIBSUBDIR="$(get_libdir)"
-	export LIBDIR="${EPREFIX}/usr/$(get_libdir)"
+	export PREFIX="${EPREFIX}/usr"
 	export V=1
 }
 


### PR DESCRIPTION
Without this patch install would cause:

```
 * QA Notice: the following files are outside of the prefix:
 * /usr
[...]
 * /usr/include/bpf/uapi/linux/bpf.h
 * /usr/include/bpf/libbpf_legacy.h
 * ERROR: dev-libs/libbpf-1.0.1::gentoo failed:
 *   Aborting due to QA concerns: there are files installed outside the prefix
```

I replaced the declaration of LIBDIR because it is default-initialized to:
  `LIBDIR ?= $(PREFIX)/$(LIBSUBDIR)`
across all versions of libbpf versions with ebuild.

Signed-off-by: YiFei Zhu <zhuyifei@google.com>