### PR TITLE
sci-calculators/bc-gh: Fix QA issues with pre-stripping

### DIFF
--- a/sci-calculators/bc-gh/bc-gh-6.1.1.ebuild
+++ b/sci-calculators/bc-gh/bc-gh-6.1.1.ebuild
@@ -14,5 +14,5 @@ KEYWORDS="~amd64 ~arm64 ~x86"
 S="${WORKDIR}/bc-${PV}"
 
 src_configure() {
-	EXECSUFFIX="-gh" PREFIX="${EPREFIX}/usr" ./configure.sh -GTl -pGNU || die
+	EXECSUFFIX="-gh" PREFIX="${EPREFIX}/usr" ./configure.sh -pGNU -GTl || die
 }


### PR DESCRIPTION
The problem was that the argument for disabling pre-stripping came *before* the predefined build, which then overrode it. I just reversed the arguments; this is what I should have done at the beginning anyway since that's how the predefined build arguments were designed.

Signed-off-by: Gavin D. Howard <gavin@yzena.com>