### PR TITLE
sys-block/nbd: Fix emake command in src_prepare for live ebuild

### DIFF
--- a/sys-block/nbd/nbd-3.24.ebuild
+++ b/sys-block/nbd/nbd-3.24.ebuild
@@ -43,11 +43,12 @@ src_prepare() {
 	default
 
 	if [[ ${PV} = 9999 ]] ; then
-		emake -C man -f Makefile.am \
+		emake -C man -f mans.mk \
 			nbd-server.1.sh.in \
 			nbd-server.5.sh.in \
 			nbd-client.8.sh.in \
 			nbd-trdump.1.sh.in \
+			nbd-trplay.1.sh.in \
 			nbdtab.5.sh.in
 
 		emake -C systemd -f Makefile.am nbd@.service.sh.in

--- a/sys-block/nbd/nbd-9999.ebuild
+++ b/sys-block/nbd/nbd-9999.ebuild
@@ -43,11 +43,12 @@ src_prepare() {
 	default
 
 	if [[ ${PV} = 9999 ]] ; then
-		emake -C man -f Makefile.am \
+		emake -C man -f mans.mk \
 			nbd-server.1.sh.in \
 			nbd-server.5.sh.in \
 			nbd-client.8.sh.in \
 			nbd-trdump.1.sh.in \
+			nbd-trplay.1.sh.in \
 			nbdtab.5.sh.in
 
 		emake -C systemd -f Makefile.am nbd@.service.sh.in


### PR DESCRIPTION
Trying to emerge nbd-9999 currently fails as per linked bug report. I've found that this is caused by upstream changes that have not yet been reflected in the ebuild:

https://github.com/NetworkBlockDevice/nbd/commit/9b03c8c0b0ce44d554ef502ad863577a632e57c6
https://github.com/NetworkBlockDevice/nbd/commit/c9970dbd2366a98a26048645cbabf010d1da0559

This pull request takes the upstream changes into account and allows to successfully emerge nbd-9999.

Closes: https://bugs.gentoo.org/882293
Signed-off-by: Jan Krieg <git@jankrieg.anonaddy.com>