### PR TITLE
net-misc/socat: fix 1.7.4.4 build on musl

### DIFF
--- a/net-misc/socat/socat-1.7.4.4.ebuild
+++ b/net-misc/socat/socat-1.7.4.4.ebuild
@@ -43,12 +43,6 @@ src_configure() {
 
 	tc-export AR
 
-	# getprotobynumber_r doesn't exist on musl, so avoid probing for it
-	# and possibly getting it wrong. TODO: fix configure?
-	# (Grabbed from Alpine Linux: https://git.alpinelinux.org/aports/commit/main/socat/APKBUILD?id=5edc9195355ced3db991c1a7cda5648d52019b11)
-	# bug #831016
-	use elibc_musl && export sc_cv_getprotobynumber_r=2
-
 	econf \
 		$(use_enable ssl openssl) \
 		$(use_enable readline) \


### PR DESCRIPTION
The issue with undefined reference to `getprotobynumber_r` for musl was fixed in 1.7.4.4 in commit [1]. It is no longer wanted to treat musl configuration specially.

[1] https://repo.or.cz/socat.git/commitdiff/75cb44bc90577c3487458564ca803163681319f1