### PR TITLE
*/*: use gitlab.xfce.org for homepages instead of git.xfce.org

### DIFF
--- a/app-editors/mousepad/mousepad-0.5.10.ebuild
+++ b/app-editors/mousepad/mousepad-0.5.10.ebuild
@@ -6,7 +6,10 @@ EAPI=8
 inherit gnome2-utils xdg-utils
 
 DESCRIPTION="GTK+-based editor for the Xfce Desktop Environment"
-HOMEPAGE="https://git.xfce.org/apps/mousepad/about/"
+HOMEPAGE="
+	https://docs.xfce.org/apps/mousepad/start
+	https://gitlab.xfce.org/apps/mousepad/
+"
 SRC_URI="https://archive.xfce.org/src/apps/${PN}/${PV%.*}/${P}.tar.bz2"
 
 LICENSE="GPL-2+"

--- a/xfce-base/libxfce4util/libxfce4util-4.16.0.ebuild
+++ b/xfce-base/libxfce4util/libxfce4util-4.16.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -6,7 +6,10 @@ EAPI=7
 inherit vala
 
 DESCRIPTION="A basic utility library for the Xfce desktop environment"
-HOMEPAGE="https://git.xfce.org/xfce/libxfce4util/"
+HOMEPAGE="
+	https://docs.xfce.org/xfce/libxfce4util/start
+	https://gitlab.xfce.org/xfce/libxfce4util/
+"
 SRC_URI="https://archive.xfce.org/src/xfce/${PN}/${PV%.*}/${P}.tar.bz2"
 
 LICENSE="LGPL-2+ GPL-2+"

--- a/xfce-base/libxfce4util/libxfce4util-4.17.2.ebuild
+++ b/xfce-base/libxfce4util/libxfce4util-4.17.2.ebuild
@@ -6,7 +6,10 @@ EAPI=8
 inherit vala
 
 DESCRIPTION="A basic utility library for the Xfce desktop environment"
-HOMEPAGE="https://git.xfce.org/xfce/libxfce4util/"
+HOMEPAGE="
+	https://docs.xfce.org/xfce/libxfce4util/start
+	https://gitlab.xfce.org/xfce/libxfce4util/
+"
 SRC_URI="https://archive.xfce.org/src/xfce/${PN}/${PV%.*}/${P}.tar.bz2"
 
 LICENSE="LGPL-2+ GPL-2+"

--- a/xfce-base/libxfce4util/metadata.xml
+++ b/xfce-base/libxfce4util/metadata.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-  <maintainer type="project">
-    <email>xfce@gentoo.org</email>
-    <name>XFCE Team</name>
-  </maintainer>
+	<maintainer type="project">
+		<email>xfce@gentoo.org</email>
+		<name>XFCE Team</name>
+	</maintainer>
 </pkgmetadata>

--- a/xfce-extra/xfce4-panel-profiles/xfce4-panel-profiles-1.0.13.ebuild
+++ b/xfce-extra/xfce4-panel-profiles/xfce4-panel-profiles-1.0.13.ebuild
@@ -8,7 +8,10 @@ PYTHON_COMPAT=( python3_{8..10} )
 inherit python-single-r1 xdg-utils
 
 DESCRIPTION="Simple application to manage Xfce panel layouts"
-HOMEPAGE="https://git.xfce.org/apps/xfce4-panel-profiles/about/"
+HOMEPAGE="
+	https://docs.xfce.org/apps/xfce4-panel-profiles/start
+	https://gitlab.xfce.org/apps/xfce4-panel-profiles/
+"
 SRC_URI="
 	https://archive.xfce.org/src/apps/xfce4-panel-profiles/$(ver_cut 1-2)/${P}.tar.bz2
 "

--- a/xfce-extra/xfce4-pulseaudio-plugin/metadata.xml
+++ b/xfce-extra/xfce4-pulseaudio-plugin/metadata.xml
@@ -13,7 +13,4 @@
 		<flag name="wnck">Enable experimental support for raising media
 			player windows using <pkg>x11-libs/libwnck</pkg>.</flag>
 	</use>
-	<upstream>
-		<remote-id type="github">andrzej-r/xfce4-pulseaudio-plugin</remote-id>
-	</upstream>
 </pkgmetadata>

--- a/xfce-extra/xfce4-pulseaudio-plugin/xfce4-pulseaudio-plugin-0.4.5.ebuild
+++ b/xfce-extra/xfce4-pulseaudio-plugin/xfce4-pulseaudio-plugin-0.4.5.ebuild
@@ -6,7 +6,10 @@ EAPI=8
 inherit xdg-utils
 
 DESCRIPTION="A panel plug-in for PulseAudio volume control"
-HOMEPAGE="https://git.xfce.org/panel-plugins/xfce4-pulseaudio-plugin/"
+HOMEPAGE="
+	https://docs.xfce.org/panel-plugins/xfce4-pulseaudio-plugin/start
+	https://gitlab.xfce.org/panel-plugins/xfce4-pulseaudio-plugin/
+"
 SRC_URI="https://archive.xfce.org/src/panel-plugins/${PN}/${PV%.*}/${P}.tar.bz2"
 
 LICENSE="GPL-2+"

--- a/xfce-extra/xfce4-screensaver/xfce4-screensaver-4.16.0.ebuild
+++ b/xfce-extra/xfce4-screensaver/xfce4-screensaver-4.16.0.ebuild
@@ -6,7 +6,10 @@ EAPI=7
 inherit xdg-utils
 
 DESCRIPTION="Screen saver and locker (port of MATE screensaver)"
-HOMEPAGE="https://git.xfce.org/apps/xfce4-screensaver/about/"
+HOMEPAGE="
+	https://docs.xfce.org/apps/screensaver/start
+	https://gitlab.xfce.org/apps/xfce4-screensaver/
+"
 SRC_URI="https://archive.xfce.org/src/apps/${PN}/${PV%.*}/${P}.tar.bz2"
 
 LICENSE="GPL-2+ LGPL-2+"

--- a/xfce-extra/xfce4-volumed-pulse/xfce4-volumed-pulse-0.2.3.ebuild
+++ b/xfce-extra/xfce4-volumed-pulse/xfce4-volumed-pulse-0.2.3.ebuild
@@ -1,10 +1,10 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
 DESCRIPTION="Daemon to control volume up/down and mute keys for pulseaudio"
-HOMEPAGE="https://git.xfce.org/apps/xfce4-volumed-pulse/"
+HOMEPAGE="https://gitlab.xfce.org/apps/xfce4-volumed-pulse/"
 SRC_URI="https://archive.xfce.org/src/apps/${PN}/${PV%.*}/${P}.tar.bz2"
 
 LICENSE="GPL-3"


### PR DESCRIPTION
https://git.xfce.org/ is obsolete:
```
! Please note that this is our old Git server, which is read only since May 1, 2020. Please go to gitlab.xfce.org for our new server !
```

Closes: https://bugs.gentoo.org/882331