### PR TITLE
Drop proxy-maint from chiitoo's packages

### DIFF
--- a/media-video/obs-studio/metadata.xml
+++ b/media-video/obs-studio/metadata.xml
@@ -1,13 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-  <maintainer type="person" proxied="yes">
+  <maintainer type="person">
     <email>chiitoo@gentoo.org</email>
     <name>Jimi Huotari</name>
-  </maintainer>
-  <maintainer type="project" proxied="proxy">
-    <email>proxy-maint@gentoo.org</email>
-    <name>Proxy Maintainers</name>
   </maintainer>
   <longdescription>
     A rewrite of what was formerly known as "Open Broadcaster Software",

--- a/net-im/qtox/metadata.xml
+++ b/net-im/qtox/metadata.xml
@@ -1,13 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer type="person" proxied="yes">
+	<maintainer type="person">
 		<email>chiitoo@gentoo.org</email>
 		<name>Jimi Huotari</name>
-	</maintainer>
-	<maintainer type="project" proxied="proxy">
-		<email>proxy-maint@gentoo.org</email>
-		<name>Proxy Maintainers</name>
 	</maintainer>
 	<use>
 		<flag name="notification">Use snorenotify for desktop notifications</flag>

--- a/net-libs/tox_extension_messages/metadata.xml
+++ b/net-libs/tox_extension_messages/metadata.xml
@@ -1,13 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer type="person" proxied="yes">
+	<maintainer type="person">
 		<email>chiitoo@gentoo.org</email>
 		<name>Jimi Huotari</name>
-	</maintainer>
-	<maintainer type="project" proxied="proxy">
-		<email>proxy-maint@gentoo.org</email>
-		<name>Proxy Maintainers</name>
 	</maintainer>
 	<upstream>
 		<remote-id type="github">toxext/tox_extension_messages</remote-id>

--- a/net-libs/toxext/metadata.xml
+++ b/net-libs/toxext/metadata.xml
@@ -1,13 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer type="person" proxied="yes">
+	<maintainer type="person">
 		<email>chiitoo@gentoo.org</email>
 		<name>Jimi Huotari</name>
-	</maintainer>
-	<maintainer type="project" proxied="proxy">
-		<email>proxy-maint@gentoo.org</email>
-		<name>Proxy Maintainers</name>
 	</maintainer>
 	<upstream>
 		<remote-id type="github">toxext/toxext</remote-id>


### PR DESCRIPTION
I don't really know why Chiitoo still has proxied voice and proxy-maint inside their metadata.xml so let's fix it.
If you have an answer please tell me.

Signed-off-by: Marco Scardovi <mscardovi@icloud.com>