### PR TITLE
app-emulation/virtualbox: add vulkan dependency, add VDE

### DIFF
--- a/app-emulation/virtualbox/metadata.xml
+++ b/app-emulation/virtualbox/metadata.xml
@@ -13,5 +13,6 @@
   <flag name="sdk">Enable building of SDK</flag>
   <flag name="udev">Controls installation of special USB udev rules.</flag>
   <flag name="vboxwebsrv">Build and install the VirtualBox webservice</flag>
+  <flag name="vde">Support for VDE networking via <pkg>net-misc/vde</pkg></flag>
 </use>
 </pkgmetadata>

--- a/app-emulation/virtualbox/virtualbox-7.0.2-r1.ebuild
+++ b/app-emulation/virtualbox/virtualbox-7.0.2-r1.ebuild
@@ -51,6 +51,7 @@ COMMON_DEPEND="
 		x11-libs/libXt
 		opengl? (
 			media-libs/libglvnd[X]
+			media-libs/vulkan-loader
 		)
 		qt5? (
 			dev-qt/qtcore:5

--- a/app-emulation/virtualbox/virtualbox-7.0.4-r1.ebuild
+++ b/app-emulation/virtualbox/virtualbox-7.0.4-r1.ebuild
@@ -62,6 +62,7 @@ COMMON_DEPEND="
 	lvm? ( sys-fs/lvm2 )
 	opengl? (
 		media-libs/libglvnd[X]
+		media-libs/vulkan-loader
 		x11-libs/libX11
 		x11-libs/libXt
 	)


### PR DESCRIPTION
If compiled with USE=opengl, virtualbox tries to dlopen libvulkan.so.1 and crashes if it cannot be found when starting machines configured with display VMSVGA.

Even the headless machine crashes.  So add libvulkan as RDEPEND.

Add USE flag for vde.  I tested it, not sure how to configure it properly but the support is there, it dlopens libvdeplug.so and connects to the socket.