### PR TITLE
dev-games/aseprite: add missing dependency

### DIFF
--- a/dev-games/aseprite/aseprite-1.2.40.ebuild
+++ b/dev-games/aseprite/aseprite-1.2.40.ebuild
@@ -48,7 +48,9 @@ RDEPEND="
 		kde-frameworks/kio:5
 	)
 	webp? ( media-libs/libwebp:= )"
-DEPEND="${RDEPEND}"
+DEPEND="
+	${RDEPEND}
+	x11-base/xorg-proto"
 BDEPEND="
 	${PYTHON_DEPS}
 	test? ( dev-cpp/gtest )


### PR DESCRIPTION
Package requires X11/X.h on build which now belongs to x11-base/xorg-proto.

Signed-off-by: Azamat H. Hackimov <azamat.hackimov@gmail.com>