### PR TITLE
app-alternatives/*: ebuild for "alternatives"-style tool symlinks

### DIFF
--- a/app-alternatives/cpio/cpio-0.ebuild
+++ b/app-alternatives/cpio/cpio-0.ebuild
@@ -1,0 +1,36 @@
+# Copyright 2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DESCRIPTION="CPIO symlink"
+HOMEPAGE="https://wiki.gentoo.org/wiki/Project:Base/Alternatives"
+SRC_URI=""
+S=${WORKDIR}
+
+LICENSE="CC0-1.0"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+IUSE="+gnu libarchive split-usr"
+REQUIRED_USE="^^ ( gnu libarchive )"
+
+RDEPEND="
+	gnu? ( >=app-arch/cpio-2.13-r4 )
+	libarchive? ( app-arch/libarchive )
+	!<app-arch/cpio-2.13-r4
+"
+
+src_install() {
+	local usr_prefix=
+	use split-usr && usr_prefix=../usr/bin/
+
+	if use gnu; then
+		dosym gcpio /bin/cpio
+		newman - cpio.1 <<<".so gcpio.1"
+	elif use libarchive; then
+		dosym "${usr_prefix}bsdcpio" /bin/cpio
+		newman - cpio.1 <<<".so bsdcpio.1"
+	else
+		die "Invalid USE flag combination (broken REQUIRED_USE?)"
+	fi
+}

--- a/app-alternatives/cpio/metadata.xml
+++ b/app-alternatives/cpio/metadata.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="project">
+		<email>base-system@gentoo.org</email>
+		<name>Gentoo Base System</name>
+	</maintainer>
+	<maintainer type="person">
+		<email>mgorny@gentoo.org</email>
+		<name>Michał Górny</name>
+	</maintainer>
+	<use>
+		<flag name="gnu">
+			Symlink to GNU cpio (<pkg>app-arch/cpio</pkg>)
+		</flag>
+		<flag name="libarchive">
+			Symlink to bsdcpio from <pkg>app-arch/libarchive</pkg>
+		</flag>
+	</use>
+</pkgmetadata>

--- a/app-alternatives/metadata.xml
+++ b/app-alternatives/metadata.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE catmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
+<catmetadata>
+	<longdescription lang="en">
+		The app-alternatives category contains packages providing
+		symlinks linking different available implementations for various
+		executables.
+	</longdescription>
+</catmetadata>

--- a/app-alternatives/sh/metadata.xml
+++ b/app-alternatives/sh/metadata.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="project">
+		<email>base-system@gentoo.org</email>
+		<name>Gentoo Base System</name>
+	</maintainer>
+	<maintainer type="person">
+		<email>mgorny@gentoo.org</email>
+		<name>Michał Górny</name>
+	</maintainer>
+	<use>
+		<flag name="bash">
+			Symlink to <pkg>app-shells/bash</pkg>
+		</flag>
+		<flag name="dash">
+			Symlink to <pkg>app-shells/dash</pkg>
+		</flag>
+		<flag name="ksh">
+			Symlink to <pkg>app-shells/ksh</pkg>
+		</flag>
+		<flag name="lksh">
+			Symlink to lksh from <pkg>app-shells/mksh</pkg>
+		</flag>
+		<flag name="mksh">
+			Symlink to mksh from <pkg>app-shells/mksh</pkg>
+		</flag>
+	</use>
+</pkgmetadata>

--- a/app-alternatives/sh/sh-0.ebuild
+++ b/app-alternatives/sh/sh-0.ebuild
@@ -1,0 +1,48 @@
+# Copyright 2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DESCRIPTION="/bin/sh (POSIX shell) symlink"
+HOMEPAGE="https://wiki.gentoo.org/wiki/Project:Base/Alternatives"
+SRC_URI=""
+S=${WORKDIR}
+
+LICENSE="CC0-1.0"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+IUSE="+bash dash ksh lksh mksh"
+REQUIRED_USE="^^ ( bash dash ksh lksh mksh )"
+
+RDEPEND="
+	bash? ( app-shells/bash )
+	dash? ( app-shells/dash )
+	ksh? ( app-shells/ksh )
+	lksh? ( app-shells/mksh[lksh] )
+	mksh? ( app-shells/mksh )
+	!!app-eselect/eselect-sh
+"
+
+src_install() {
+	if use bash; then
+		dosym bash /bin/sh
+	elif use dash; then
+		dosym dash /bin/sh
+	elif use ksh; then
+		dosym ksh /bin/sh
+	elif use lksh; then
+		dosym lksh /bin/sh
+	elif use mksh; then
+		dosym mksh /bin/sh
+	else
+		die "Invalid USE flag combination (broken REQUIRED_USE?)"
+	fi
+}
+
+pkg_postrm() {
+	# make sure we don't leave the user without /bin/sh, since it's not
+	# been owned by any other package
+	if [[ ! -h ${EROOT}/bin/sh ]]; then
+		ln -s bash "${EROOT}/bin/sh" || die
+	fi
+}

--- a/app-alternatives/tar/metadata.xml
+++ b/app-alternatives/tar/metadata.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="project">
+		<email>base-system@gentoo.org</email>
+		<name>Gentoo Base System</name>
+	</maintainer>
+	<maintainer type="person">
+		<email>mgorny@gentoo.org</email>
+		<name>Michał Górny</name>
+	</maintainer>
+	<use>
+		<flag name="gnu">
+			Symlink to GNU tar (<pkg>app-arch/tar</pkg>)
+		</flag>
+		<flag name="libarchive">
+			Symlink to bsdtar from <pkg>app-arch/libarchive</pkg>
+		</flag>
+	</use>
+</pkgmetadata>

--- a/app-alternatives/tar/tar-0.ebuild
+++ b/app-alternatives/tar/tar-0.ebuild
@@ -1,0 +1,36 @@
+# Copyright 2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DESCRIPTION="Tar symlink"
+HOMEPAGE="https://wiki.gentoo.org/wiki/Project:Base/Alternatives"
+SRC_URI=""
+S=${WORKDIR}
+
+LICENSE="CC0-1.0"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+IUSE="+gnu libarchive split-usr"
+REQUIRED_USE="^^ ( gnu libarchive )"
+
+RDEPEND="
+	gnu? ( >=app-arch/tar-1.34-r2 )
+	libarchive? ( app-arch/libarchive )
+	!<app-arch/tar-1.34-r2
+"
+
+src_install() {
+	local usr_prefix=
+	use split-usr && usr_prefix=../usr/bin/
+
+	if use gnu; then
+		dosym gtar /bin/tar
+		newman - tar.1 <<<".so gtar.1"
+	elif use libarchive; then
+		dosym "${usr_prefix}bsdtar" /bin/tar
+		newman - tar.1 <<<".so bsdtar.1"
+	else
+		die "Invalid USE flag combination (broken REQUIRED_USE?)"
+	fi
+}

--- a/app-arch/cpio/cpio-2.13-r4.ebuild
+++ b/app-arch/cpio/cpio-2.13-r4.ebuild
@@ -1,0 +1,54 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools
+
+DESCRIPTION="A file archival tool which can also read and write tar files"
+HOMEPAGE="https://www.gnu.org/software/cpio/cpio.html"
+SRC_URI="mirror://gnu/cpio/${P}.tar.bz2"
+SRC_URI+=" https://dev.gentoo.org/~sam/distfiles/${CATEGORY}/${PN}/${P}-CVE-2021-38185.patch.xz"
+
+LICENSE="GPL-3+"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+IUSE="nls"
+
+PDEPEND="
+	app-alternatives/cpio
+"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-2.12-non-gnu-compilers.patch #275295
+	"${WORKDIR}"/${P}-CVE-2021-38185.patch
+	"${FILESDIR}"/${PN}-2.13-sysmacros-glibc-2.26.patch
+	"${FILESDIR}"/${PN}-2.13-fix-no-absolute-filenames-revert-CVE-2015-1197-handling.patch
+)
+
+src_prepare() {
+	default
+
+	# Drop after 2.13 (only here for CVE patch)
+	eautoreconf
+}
+
+src_configure() {
+	local myeconfargs=(
+		$(use_enable nls)
+		--bindir="${EPREFIX}"/bin
+		--with-rmt="${EPREFIX}"/usr/sbin/rmt
+		# install as gcpio for better compatibility with non-GNU userland
+		--program-prefix=g
+	)
+
+	econf "${myeconfargs[@]}"
+}
+
+pkg_postinst() {
+	# ensure to preserve the symlink before app-alternatives/cpio
+	# is installed
+	if [[ ! -h ${EROOT}/bin/cpio ]]; then
+		ln -s gcpio "${EROOT}/bin/cpio" || die
+	fi
+}

--- a/app-arch/tar/tar-1.34-r2.ebuild
+++ b/app-arch/tar/tar-1.34-r2.ebuild
@@ -1,0 +1,90 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+VERIFY_SIG_OPENPGP_KEY_PATH="${BROOT}"/usr/share/openpgp-keys/tar.asc
+inherit verify-sig
+
+DESCRIPTION="Use this to make tarballs :)"
+HOMEPAGE="https://www.gnu.org/software/tar/"
+SRC_URI="mirror://gnu/tar/${P}.tar.xz
+	https://alpha.gnu.org/gnu/tar/${P}.tar.xz"
+SRC_URI+=" verify-sig? (
+		mirror://gnu/tar/${P}.tar.xz.sig
+		https://alpha.gnu.org/gnu/tar/${P}.tar.xz.sig
+	)"
+
+LICENSE="GPL-3+"
+SLOT="0"
+if [[ -z "$(ver_cut 3)" ]] || [[ "$(ver_cut 3)" -lt 90 ]] ; then
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+fi
+IUSE="acl minimal nls selinux xattr"
+
+RDEPEND="
+	acl? ( virtual/acl )
+	selinux? ( sys-libs/libselinux )
+"
+DEPEND="${RDEPEND}
+	xattr? ( elibc_glibc? ( sys-apps/attr ) )
+"
+BDEPEND="
+	nls? ( sys-devel/gettext )
+	verify-sig? ( sec-keys/openpgp-keys-tar )
+"
+PDEPEND="
+	app-alternatives/tar
+"
+
+src_configure() {
+	local myeconfargs=(
+		--bindir="${EPREFIX}"/bin
+		--enable-backup-scripts
+		--libexecdir="${EPREFIX}"/usr/sbin
+		$(use_with acl posix-acls)
+		$(use_enable nls)
+		$(use_with selinux)
+		$(use_with xattr xattrs)
+
+		# autoconf looks for gtar before tar (in configure scripts), hence
+		# in Prefix it is important that it is there, otherwise, a gtar from
+		# the host system (FreeBSD, Solaris, Darwin) will be found instead
+		# of the Prefix provided (GNU) tar
+		--program-prefix=g
+	)
+
+	FORCE_UNSAFE_CONFIGURE=1 econf "${myeconfargs[@]}"
+}
+
+src_install() {
+	default
+
+	# a nasty yet required piece of baggage
+	exeinto /etc
+	doexe "${FILESDIR}"/rmt
+
+	mv "${ED}"/usr/sbin/{gbackup,backup-tar} || die
+	mv "${ED}"/usr/sbin/{grestore,restore-tar} || die
+	mv "${ED}"/usr/sbin/{g,}backup.sh || die
+	mv "${ED}"/usr/sbin/{g,}dump-remind || die
+
+	if use minimal ; then
+		find "${ED}"/etc "${ED}"/*bin/ "${ED}"/usr/*bin/ \
+			-type f -a '!' -name gtar \
+			-delete || die
+	fi
+
+	if ! use minimal; then
+		dosym grmt /usr/sbin/rmt
+	fi
+	dosym grmt.8 /usr/share/man/man8/rmt.8
+}
+
+pkg_postinst() {
+	# ensure to preserve the symlink before app-alternatives/tar
+	# is installed
+	if [[ ! -h ${EROOT}/bin/tar ]]; then
+		ln -s gtar "${EROOT}/bin/tar" || die
+	fi
+}

--- a/profiles/arch/s390/package.use.mask
+++ b/profiles/arch/s390/package.use.mask
@@ -1,6 +1,10 @@
 # Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Michał Górny <mgorny@gentoo.org> (2022-11-25)
+# Unkeyworded shells.
+app-alternatives/sh lksh mksh
+
 # Florian Schmaus <flow@gentoo.org> (2022-11-23)
 # avoid larger deptree, bug #882593
 dev-python/bracex doc

--- a/profiles/categories
+++ b/profiles/categories
@@ -2,6 +2,7 @@ acct-group
 acct-user
 app-accessibility
 app-admin
+app-alternatives
 app-antivirus
 app-arch
 app-backup


### PR DESCRIPTION
The idea is to have ebuilds that install and control symlinks such as:

- /bin/sh
- cpio
- tar

This serves three goals:
1. It ensures that we maintain working symlinks for these tools (eselect can't guarantee that e.g. removing the implementation won't break them).
2. Unlike eselect, it doesn't write to /bin or /usr/bin outside PM.
3. It makes it possible to cleanly depend on "any" implementation vs. specific implementation. For example, if you need GNU tar, then you'd depend on `app-arch/tar` explicitly, and if you need "any tar", you're fine with the future `sys-meta/tar` dependency provided by `@system`.