### PR TITLE
net-misc/r8152: Support kernel 6.1

### DIFF
--- a/net-misc/r8152/files/r8152-2.16.3-kernel-6.1-fix.patch
+++ b/net-misc/r8152/files/r8152-2.16.3-kernel-6.1-fix.patch
@@ -1,0 +1,46 @@
+https://github.com/ervinpopescu/realtek-r8152-linux/commit/0029747c3cf68dbccbebfcb560277040673dfe36.patch
+From: ervinpopescu <ervin.popescu10@gmail.com>
+Date: Tue, 15 Nov 2022 19:30:16 +0200
+Subject: [PATCH] Fix for linux 6.1 without breaking older kernel compatibility
+
+--- a/r8152.c
++++ b/r8152.c
+@@ -17558,7 +17558,6 @@ static void r8156_init(struct r8152 *tp)
+ //		break;
+ //	}
+ 
+-
+ 	r8153b_mcu_spdown_en(tp, false);
+ 
+ 	ocp_data = ocp_read_word(tp, MCU_TYPE_PLA, PLA_EXTRA_STATUS);
+@@ -18339,7 +18338,6 @@ int rtl8152_get_settings(struct net_device *netdev, struct ethtool_cmd *cmd)
+ 		cmd->autoneg = AUTONEG_DISABLE;
+ 	}
+ 
+-
+ 	if (netif_running(netdev) && netif_carrier_ok(netdev)) {
+ 		u16 speed = rtl8152_get_speed(tp);
+ 
+@@ -19202,7 +19200,6 @@ static int rtltool_ioctl(struct r8152 *tp, struct ifreq *ifr)
+ 		}
+ 		break;
+ 
+-
+ 	case RTLTOOL_USB_OCP_WRITE_DWORD:
+ 		if (!tp->rtk_enable_diag && net_ratelimit())
+ 			netif_warn(tp, drv, netdev,
+@@ -20708,10 +20705,14 @@ static int rtl8152_probe(struct usb_interface *intf,
+ 
+ 	usb_set_intfdata(intf, tp);
+ 
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6,1,0)
+ 	if (tp->support_2500full)
+ 		netif_napi_add(netdev, &tp->napi, r8152_poll, 256);
+ 	else
+ 		netif_napi_add(netdev, &tp->napi, r8152_poll, 64);
++#else /* LINUX_VERSION_CODE >= KERNEL_VERSION(6,1,0) */
++  netif_napi_add(netdev, &tp->napi, r8152_poll);
++#endif /* LINUX_VERSION_CODE < KERNEL_VERSION(6,1,0) */
+ 
+ 	ret = register_netdev(netdev);
+ 	if (ret != 0) {

--- a/net-misc/r8152/r8152-2.16.3.ebuild
+++ b/net-misc/r8152/r8152-2.16.3.ebuild
@@ -24,6 +24,7 @@ IUSE="+center-tap-short"
 # with kernel support patches. It appears to be used by the AUR maintainer.
 PATCHES=(
 	"${FILESDIR}"/${PN}-2.16.3-kernel-5.19-fix.patch
+	"${FILESDIR}"/${PN}-2.16.3-kernel-6.1-fix.patch
 )
 
 pkg_setup() {


### PR DESCRIPTION
Kernel 6.1 is changing the interface for network drivers. This is a backwards-compatable fix to the kernel module to make it work on 6.1.

Thanks to @ervinpopescu for the patch.

Signed-off-by: Jay Faulkner <jay@jvf.cc>