### PR TITLE
net-misc/snarf: Revbump, EAPI bump, fix build for clang16

### DIFF
--- a/net-misc/snarf/files/snarf-fix-build-for-clang16.patch
+++ b/net-misc/snarf/files/snarf-fix-build-for-clang16.patch
@@ -1,0 +1,33 @@
+Clang16 will not allow implicit function declarations by default.
+This patch overhauls the source to make it build with clang16 defaults.
+
+This patch was sent upstream via mail.
+Bug: https://bugs.gentoo.org/874012
+
+# Pascal Jäger <pascal.jaeger@leimstift.de> (2022-11-23)
+
+--- a/http.c
++++ b/http.c
+@@ -2,6 +2,7 @@
+ 
+ #include <config.h>
+ 
++#include <ctype.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>
+--- a/util.c
++++ b/util.c
+@@ -33,8 +33,11 @@
+ #include <errno.h>
+ #include <time.h>
+ #include <libgen.h>
+-#include "url.h"
++#include "ftp.h"
++#include "gopher.h"
++#include "http.h"
+ #include "options.h"
++#include "url.h"
+ 
+ 
+ char output_buf[BUFSIZ];

--- a/net-misc/snarf/snarf-7.0-r5.ebuild
+++ b/net-misc/snarf/snarf-7.0-r5.ebuild
@@ -1,0 +1,44 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+WANT_AUTOCONF="2.1"
+inherit autotools toolchain-funcs
+
+DESCRIPTION="Small and fast CLI resource grabber for http, gopher, finger, ftp"
+HOMEPAGE="https://www.xach.com/snarf/"
+SRC_URI="https://www.xach.com/snarf/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~ppc ~sparc ~x86"
+
+PATCHES=(
+	"${FILESDIR}"/snarf-basename-patch.diff
+	"${FILESDIR}"/snarf-unlink-empty.diff
+	"${FILESDIR}"/snarf-fix-off-by-ones.diff
+	"${FILESDIR}"/snarf-fix-build-for-clang16.patch
+)
+
+src_prepare() {
+	default
+	eautoconf
+}
+
+src_compile() {
+	emake CC="$(tc-getCC)"
+}
+
+src_install() {
+	dobin snarf
+	doman snarf.1
+	dodoc ChangeLog README TODO
+}
+
+pkg_postinst() {
+	elog 'To use snarf with portage, try these settings in your make.conf'
+	elog
+	elog '	FETCHCOMMAND="/usr/bin/snarf -b \${URI} \${DISTDIR}/\${FILE}"'
+	elog '	RESUMECOMMAND="/usr/bin/snarf -rb \${URI} \${DISTDIR}/\${FILE}"'
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/874012
Signed-off-by: Pascal Jäger <pascal.jaeger@leimstift.de>