### PR TITLE
app-misc/screen: fix clang16 build with USE=debug

### DIFF
--- a/app-misc/screen/files/screen-4.9.0-configure-implicit-function-decls.patch
+++ b/app-misc/screen/files/screen-4.9.0-configure-implicit-function-decls.patch
@@ -745,3 +745,16 @@ Upstream variant: https://lists.gnu.org/archive/html/screen-devel/2022-08/msg000
  AC_MSG_CHECKING(for setenv)
  if test -z "$ac_setenv_args"; then
 
+
+--- a/display.c
++++ b/display.c
+@@ -38,6 +38,9 @@
+ #include "extern.h"
+ #include "braille.h"
+ #include "canvas.h"
++#ifdef DEBUG
++#include <sys/stat.h>
++#endif
+
+ /* CSI parsing status */
+ enum

--- a/app-misc/screen/screen-4.9.0-r1.ebuild
+++ b/app-misc/screen/screen-4.9.0-r1.ebuild
@@ -142,5 +142,6 @@ pkg_postinst() {
 
 	tmpfiles_process screen.conf
 
-	ewarn "This revision changes the screen socket location to ${EROOT}/tmp/${PN}"
+	# Uncomment in case of new socket location, last change of location 2021-07-30
+	# ewarn "This revision changes the screen socket location to ${EROOT}/tmp/${PN}"
 }


### PR DESCRIPTION
This still produces one error when USE="debug", so I added a hunk to the patch. 
Draft because of https://bugs.gentoo.org/880397 (and maybe we can fix some other bugs as well)

@swegener I also fixed this bug while at it, please have a look https://bugs.gentoo.org/836410

Signed-off-by: Pascal Jäger <pascal.jaeger@leimstift.de>