### PR TITLE
dev-cpp/gtest: remove unittests that cause libsandbox to segfault

### DIFF
--- a/dev-cpp/gtest/gtest-1.12.1.ebuild
+++ b/dev-cpp/gtest/gtest-1.12.1.ebuild
@@ -60,7 +60,8 @@ multilib_src_configure() {
 
 multilib_src_test() {
 	# Exclude tests that fail with FEATURES="usersandbox"
-	cmake_src_test -E "googletest-(death-test|port)-test"
+	cmake_src_test -E \
+		"g(oogle)?test.(break-on-failure|death-test|filter|port|repeat).(unit)?test"
 }
 
 multilib_src_install_all() {

--- a/dev-cpp/gtest/gtest-9999.ebuild
+++ b/dev-cpp/gtest/gtest-9999.ebuild
@@ -60,7 +60,8 @@ multilib_src_configure() {
 
 multilib_src_test() {
 	# Exclude tests that fail with FEATURES="usersandbox"
-	cmake_src_test -E "googletest-death-test-test"
+	cmake_src_test -E \
+		"g(oogle)?test.(break-on-failure|death-test|filter|port|repeat).(unit)?test"
 }
 
 multilib_src_install_all() {


### PR DESCRIPTION
- **dev-cpp/gtest: remove unittests that cause libsandbox to segfault**
Exclude some unittests that cause libsandbox to spam printk with
messages about trapped segfaults when running with usersandbox.

Closes: https://bugs.gentoo.org/882589
Signed-off-by: Peter Levine <plevine457@gmail.com>