### PR TITLE
dev-util/gperf: clang-16 -Wregister fix

### DIFF
--- a/dev-util/gperf/files/gperf-3.1-clang-16-wregister.patch
+++ b/dev-util/gperf/files/gperf-3.1-clang-16-wregister.patch
@@ -1,0 +1,22 @@
+https://bugs.gentoo.org/882787
+
+a63b830554920476881837eeacd4a6b507632b19
+Author:     Bruno Haible <bruno@clisp.org>
+AuthorDate: Sun Aug 30 12:36:15 2020 +0200
+Commit:     Bruno Haible <bruno@clisp.org>
+CommitDate: Sun Aug 30 12:36:15 2020 +0200
+
+Make the code C++17 compliant.
+
+* lib/getline.cc (getstr): Don't use the 'register' keyword.
+--- a/lib/getline.cc
++++ b/lib/getline.cc
+@@ -55,7 +55,7 @@ getstr (char **lineptr, size_t *n, FILE *stream, char terminator, size_t offset)
+ 
+   for (;;)
+     {
+-      register int c = getc (stream);
++      int c = getc (stream);
+ 
+       /* We always want at least one char left in the buffer, since we
+          always (unless we get an error while reading the first char)

--- a/dev-util/gperf/gperf-3.1-r1.ebuild
+++ b/dev-util/gperf/gperf-3.1-r1.ebuild
@@ -13,6 +13,7 @@ KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~
 
 PATCHES=(
 	"${FILESDIR}"/${P}-strncmp-decl-mismatch.patch
+	"${FILESDIR}"/${P}-clang-16-wregister.patch
 )
 
 src_prepare() {


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/882787
Signed-off-by: Lukas Schmelting <l3s8g@posteo.eu>