### PR TITLE
media-gfx/freecad: restrict to <sci-libs/opencascade-7.7.0

### DIFF
--- a/media-gfx/freecad/freecad-0.20.1.ebuild
+++ b/media-gfx/freecad/freecad-0.20.1.ebuild
@@ -66,7 +66,7 @@ RDEPEND="
 	sci-libs/flann[openmp]
 	sci-libs/hdf5:=[fortran,zlib]
 	>=sci-libs/med-4.0.0-r1[python,${PYTHON_SINGLE_USEDEP}]
-	sci-libs/opencascade:=[json,vtk]
+	<sci-libs/opencascade-7.7.0:=[json,vtk]
 	sci-libs/orocos_kdl:=
 	sys-libs/zlib
 	virtual/glu


### PR DESCRIPTION
Several issues when trying to build against OCC 7.7.0.

They have been updated upstream already and there's an v0.20.2 version planed for release, so just restrict the dependency for now. If you rely on FreeCAD build against OCC 7.7.0, you can use the live ebuild.

Closes: https://bugs.gentoo.org/883073
Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>