### PR TITLE
net-libs/gnome-online-accounts: add upstream patch for meson dependen…

### DIFF
--- a/net-libs/gnome-online-accounts/files/gnome-online-accounts-3.46.0-fix-meson-dependencies.patch
+++ b/net-libs/gnome-online-accounts/files/gnome-online-accounts-3.46.0-fix-meson-dependencies.patch
@@ -1,0 +1,27 @@
+https://gitlab.gnome.org/GNOME/gnome-online-accounts/-/commit/f10c48ee114f719c63a8eabccdfb401a14219f46
+https://bugs.gentoo.org/882625
+
+From: Emmanuele Bassi <ebassi@gnome.org>
+Date: Wed, 5 Oct 2022 22:15:37 +0100
+Subject: [PATCH] build: Use the appropriate dependency object
+
+Just using `link_with` will not ensure that the GOA web extension shared
+module is properly built against libgoa-backend and libgoa; the
+generated headers must be transitively available by the time we build
+the shared module.
+
+Fixes: #226
+--- a/src/goabackend/meson.build
++++ b/src/goabackend/meson.build
+@@ -157,9 +157,8 @@ libgoa_web_extension = shared_module(
+   'goawebextension',
+   libgoawebextension_sources,
+   include_directories: common_incs + [goa_inc],
+-  dependencies: deps,
++  dependencies: [deps, libgoa_backend_dep],
+   c_args: cflags,
+-  link_with: libgoa_backend,
+   install: true,
+   install_dir: join_paths(goa_pkglibdir, 'web-extensions')
+ )
+GitLab

--- a/net-libs/gnome-online-accounts/gnome-online-accounts-3.46.0.ebuild
+++ b/net-libs/gnome-online-accounts/gnome-online-accounts-3.46.0.ebuild
@@ -50,6 +50,10 @@ DEPEND="${RDEPEND}
 "
 BDEPEND="gtk-doc? ( dev-util/gtk-doc )"
 
+PATCHES=(
+	"${FILESDIR}/${P}-fix-meson-dependencies.patch" 
+)
+
 src_prepare() {
 	default
 	use vala && vala_setup


### PR DESCRIPTION
…cy fix

The patch is currently not yet in upstream's "gnome-43" branch (which produces the 3.46.x track), but I will ask ebassi to cherry-pick it so we can drop this patch in the near future.

Signed-off-by: Christophe Lermytte <gentoo@lermytte.be>
Closes: https://bugs.gentoo.org/882625