### PR TITLE
app-text/mupdf: add high resolution icon

### DIFF
--- a/app-text/mupdf/files/mupdf-1.21.0-add-desktop-pc-files.patch
+++ b/app-text/mupdf/files/mupdf-1.21.0-add-desktop-pc-files.patch
@@ -1,0 +1,33 @@
+--- /dev/null
++++ ./platform/debian/mupdf.desktop
+@@ -0,0 +1,15 @@
++[Desktop Entry]
++Name=MuPDF
++GenericName=PDF file viewer
++Exec=mupdf %f
++TryExec=mupdf
++Icon=new-mupdf-icon
++Terminal=false
++Type=Application
++MimeType=application/pdf;application/x-pdf;application/x-cbz;application/oxps;application/vnd.ms-xpsdocument;image/jpeg;image/pjpeg;image/png;image/tiff;image/x-tiff;
++Categories=Viewer;Graphics;
++Actions=View;
++
++[Desktop Action View]
++Name=View with mupdf
++Exec=mupdf %f
+--- /dev/null
++++ ./platform/debian/mupdf.pc
+@@ -0,0 +1,12 @@
++prefix=/usr
++exec_prefix=${prefix}
++libdir=${exec_prefix}/lib
++includedir=${prefix}/include
++
++Name: mupdf
++Description: Library for rendering PDF documents
++Requires: freetype2 libopenjp2 libcrypto
++Version: 0.5.0
++Libs: -L${libdir} -lmupdf
++Libs.private: -lmupdf-js-none
++Cflags: -I${includedir}

--- a/app-text/mupdf/mupdf-1.21.0.ebuild
+++ b/app-text/mupdf/mupdf-1.21.0.ebuild
@@ -46,7 +46,7 @@ BDEPEND="X? ( x11-base/xorg-proto )
 PATCHES=(
 	"${FILESDIR}"/${PN}-1.15-CFLAGS.patch
 	"${FILESDIR}"/${PN}-1.19.0-Makefile.patch
-	"${FILESDIR}"/${PN}-1.10a-add-desktop-pc-xpm-files.patch
+	"${FILESDIR}"/${P}-add-desktop-pc-files.patch
 	"${FILESDIR}"/${PN}-1.19.0-darwin.patch
 	# See bugs #662352
 	"${FILESDIR}"/${PN}-1.15-openssl-x11.patch
@@ -126,7 +126,7 @@ src_compile() {
 src_install() {
 	if use opengl || use X ; then
 		domenu platform/debian/${PN}.desktop
-		doicon platform/debian/${PN}.xpm
+		doicon -s scalable docs/logo/new-${PN}-icon.svg
 	else
 		rm docs/man/${PN}.1 || die "Failed to remove man page in src_install()"
 	fi


### PR DESCRIPTION
As pointed out by <pacho@gentoo.org> a high resolution icon for MuPDF is available at docs/logo.

I created a new `mupdf-1.21.0-add-desktop-pc-files.patch` based on the previous 
`mupdf-1.10a-add-desktop-pc-xpm-files.patch`, removing the .xpm logo and replacing the icon name `mupdf`
by `new-mupdf-icon`, as now the icon at `docs/logo/new-mupdf-icon.svg` is used by the ebuild. 

Closes: https://bugs.gentoo.org/882701
Signed-off-by: Philipp Rösner <rndxelement@protonmail.com>