### PR TITLE
media-libs/webrtc-audio-processing: ppc64 support

### DIFF
--- a/media-libs/webrtc-audio-processing/files/webrtc-audio-processing-0.3-Add-generic-byte-order-and-pointer-size-detection.patch
+++ b/media-libs/webrtc-audio-processing/files/webrtc-audio-processing-0.3-Add-generic-byte-order-and-pointer-size-detection.patch
@@ -1,0 +1,35 @@
+From: Than <than@redhat.com>
+Date: Wed, 8 Jun 2016 19:10:08 -0400
+Subject: Add generic byte order and pointer size detection
+
+https://sources.debian.org/patches/webrtc-audio-processing/0.3-1/Add-generic-byte-order-and-pointer-size-detection.patch/
+https://bugs.freedesktop.org/show_bug.cgi?id=95738
+---
+ webrtc/typedefs.h | 14 +++++++++++++-
+ 1 file changed, 13 insertions(+), 1 deletion(-)
+
+diff --git a/webrtc/typedefs.h b/webrtc/typedefs.h
+index d875490..dc074f1 100644
+--- a/webrtc/typedefs.h
++++ b/webrtc/typedefs.h
+@@ -48,7 +48,19 @@
+ #define WEBRTC_ARCH_32_BITS
+ #define WEBRTC_ARCH_LITTLE_ENDIAN
+ #else
+-#error Please add support for your architecture in typedefs.h
++/* instead of failing, use typical unix defines... */
++#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
++#define WEBRTC_ARCH_LITTLE_ENDIAN
++#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
++#define WEBRTC_ARCH_BIG_ENDIAN
++#else
++#error __BYTE_ORDER__ is not defined
++#endif
++#if defined(__LP64__)
++#define WEBRTC_ARCH_64_BITS
++#else
++#define WEBRTC_ARCH_32_BITS
++#endif
+ #endif
+ 
+ #if !(defined(WEBRTC_ARCH_LITTLE_ENDIAN) ^ defined(WEBRTC_ARCH_BIG_ENDIAN))

--- a/media-libs/webrtc-audio-processing/files/webrtc-audio-processing-0.3-big-endian-support.patch
+++ b/media-libs/webrtc-audio-processing/files/webrtc-audio-processing-0.3-big-endian-support.patch
@@ -1,0 +1,103 @@
+From: Than <than@redhat.com>
+Date: Mon, 6 Jun 2016 12:08:58 -0400
+Subject: big endian support
+
+https://sources.debian.org/patches/webrtc-audio-processing/0.3-1/big-endian-support.patch/
+https://bugs.freedesktop.org/show_bug.cgi?id=95738
+---
+ webrtc/common_audio/wav_file.cc   | 20 +++++++++++++++-----
+ webrtc/common_audio/wav_header.cc | 34 +++++++++++++++++++++++++++++++++-
+ 2 files changed, 48 insertions(+), 6 deletions(-)
+
+diff --git a/webrtc/common_audio/wav_file.cc b/webrtc/common_audio/wav_file.cc
+index b14b620..05fa052 100644
+--- a/webrtc/common_audio/wav_file.cc
++++ b/webrtc/common_audio/wav_file.cc
+@@ -64,9 +64,6 @@ WavReader::~WavReader() {
+ }
+ 
+ size_t WavReader::ReadSamples(size_t num_samples, int16_t* samples) {
+-#ifndef WEBRTC_ARCH_LITTLE_ENDIAN
+-#error "Need to convert samples to big-endian when reading from WAV file"
+-#endif
+   // There could be metadata after the audio; ensure we don't read it.
+   num_samples = std::min(rtc::checked_cast<uint32_t>(num_samples),
+                          num_samples_remaining_);
+@@ -76,6 +73,12 @@ size_t WavReader::ReadSamples(size_t num_samples, int16_t* samples) {
+   RTC_CHECK(read == num_samples || feof(file_handle_));
+   RTC_CHECK_LE(read, num_samples_remaining_);
+   num_samples_remaining_ -= rtc::checked_cast<uint32_t>(read);
++#ifndef WEBRTC_ARCH_LITTLE_ENDIAN
++  //convert to big-endian
++  for(size_t idx = 0; idx < num_samples; idx++) {
++    samples[idx] = (samples[idx]<<8) | (samples[idx]>>8);
++  }
++#endif
+   return read;
+ }
+ 
+@@ -120,10 +123,17 @@ WavWriter::~WavWriter() {
+ 
+ void WavWriter::WriteSamples(const int16_t* samples, size_t num_samples) {
+ #ifndef WEBRTC_ARCH_LITTLE_ENDIAN
+-#error "Need to convert samples to little-endian when writing to WAV file"
+-#endif
++  int16_t * le_samples = new int16_t[num_samples];
++  for(size_t idx = 0; idx < num_samples; idx++) {
++    le_samples[idx] = (samples[idx]<<8) | (samples[idx]>>8);
++  }
++  const size_t written =
++      fwrite(le_samples, sizeof(*le_samples), num_samples, file_handle_);
++  delete []le_samples;
++#else
+   const size_t written =
+       fwrite(samples, sizeof(*samples), num_samples, file_handle_);
++#endif
+   RTC_CHECK_EQ(num_samples, written);
+   num_samples_ += static_cast<uint32_t>(written);
+   RTC_CHECK(written <= std::numeric_limits<uint32_t>::max() ||
+diff --git a/webrtc/common_audio/wav_header.cc b/webrtc/common_audio/wav_header.cc
+index 61cfffe..53882ff 100644
+--- a/webrtc/common_audio/wav_header.cc
++++ b/webrtc/common_audio/wav_header.cc
+@@ -129,7 +129,39 @@ static inline std::string ReadFourCC(uint32_t x) {
+   return std::string(reinterpret_cast<char*>(&x), 4);
+ }
+ #else
+-#error "Write be-to-le conversion functions"
++static inline void WriteLE16(uint16_t* f, uint16_t x) {
++  *f = ((x << 8) & 0xff00)  | ( ( x >> 8) & 0x00ff);
++}
++
++static inline void WriteLE32(uint32_t* f, uint32_t x) {
++    *f = ( (x & 0x000000ff) << 24 )
++      | ((x & 0x0000ff00) << 8)
++      | ((x & 0x00ff0000) >> 8)
++      | ((x & 0xff000000) >> 24 );
++}
++
++static inline void WriteFourCC(uint32_t* f, char a, char b, char c, char d) {
++    *f = (static_cast<uint32_t>(a) << 24 )
++      |  (static_cast<uint32_t>(b) << 16)
++      |  (static_cast<uint32_t>(c) << 8)
++      |  (static_cast<uint32_t>(d) );
++}
++
++static inline uint16_t ReadLE16(uint16_t x) {
++  return  (( x & 0x00ff) << 8 )| ((x & 0xff00)>>8);
++}
++
++static inline uint32_t ReadLE32(uint32_t x) {
++  return   ( (x & 0x000000ff) << 24 )
++         | ( (x & 0x0000ff00) << 8 )
++         | ( (x & 0x00ff0000) >> 8)
++         | ( (x & 0xff000000) >> 24 );
++}
++
++static inline std::string ReadFourCC(uint32_t x) {
++  x = ReadLE32(x);
++  return std::string(reinterpret_cast<char*>(&x), 4);
++}
+ #endif
+ 
+ static inline uint32_t RiffChunkSize(uint32_t bytes_in_payload) {

--- a/media-libs/webrtc-audio-processing/webrtc-audio-processing-0.3.1.ebuild
+++ b/media-libs/webrtc-audio-processing/webrtc-audio-processing-0.3.1.ebuild
@@ -11,13 +11,15 @@ SRC_URI="https://freedesktop.org/software/pulseaudio/${PN}/${P}.tar.xz"
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="amd64 ~arm64 x86 ~amd64-linux"
+KEYWORDS="amd64 ~arm64 ~ppc64 x86 ~amd64-linux"
 IUSE="static-libs"
 
 DOCS=( AUTHORS NEWS README.md )
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-0.3-proper_detection_cxxabi_execinfo.patch
+	"${FILESDIR}"/${PN}-0.3-Add-generic-byte-order-and-pointer-size-detection.patch
+	"${FILESDIR}"/${PN}-0.3-big-endian-support.patch
 )
 
 src_prepare() {

--- a/profiles/arch/powerpc/ppc64/package.use.mask
+++ b/profiles/arch/powerpc/ppc64/package.use.mask
@@ -30,6 +30,10 @@ dev-python/nbval test
 # libomptarget is only supported on 64-bit architectures.
 >=sys-libs/libomp-16.0.0_pre20230124 -offload
 
+# Niccolò Belli <niccolo.belli@linuxsystems.it> (2022-11-29)
+# media-libs/webrtc-audio-processing only has amd64, x86 and ppc64 keywords
+media-video/pipewire -echo-cancel
+
 # Sam James <sam@gentoo.org> (2022-10-13)
 # Causes segfaults, bug #871921
 sci-libs/symengine tcmalloc

--- a/profiles/arch/powerpc/ppc64/package.use.stable.mask
+++ b/profiles/arch/powerpc/ppc64/package.use.stable.mask
@@ -17,6 +17,10 @@
 
 #--- END OF EXAMPLES ---
 
+# Niccolò Belli <niccolo.belli@linuxsystems.it> (2023-03-12)
+# media-libs/webrtc-audio-processing not stable on ppc64
+media-video/pipewire echo-cancel
+
 # Hans de Graaff <graaff@gentoo.org> (2023-03-28)
 # dev-ruby/stringex is not marked stable here yet
 dev-ruby/kramdown unicode


### PR DESCRIPTION
Currently echo-cancel use flag is masked on archs other than x86/amd64 and for good reason: in fact the library it depends on (webrtc-audio-processing) won't build on archs other than x86/amd64. Fortunately there are patches available (https://bugs.freedesktop.org/show_bug.cgi?id=95738) and major distros like Debian already ship them (https://packages.debian.org/sid/libwebrtc-audio-processing1).
Looking at Debian supported architectures I would say it should build on most archs now, but I've only been able to test it on ppc64le so that's what I've unmasked (that and big endian because that was the main focus of the patchset).
The patches I've ended up using are the Debian ones.