### PR TITLE
app-emulation/vkd3d-proton: fix 9999 src_install fail

### DIFF
--- a/app-emulation/vkd3d-proton/vkd3d-proton-9999.ebuild
+++ b/app-emulation/vkd3d-proton/vkd3d-proton-9999.ebuild
@@ -152,7 +152,6 @@ multilib_src_install_all() {
 	einstalldocs
 
 	# unnecesasry files, see package-release.sh
-	rm "${ED}"/usr/lib/${PN}/x*/libvkd3d-proton-utils-3.dll || die
 	find "${ED}" -type f -name '*.a' -delete || die
 }
 


### PR DESCRIPTION
With recent refactor in vkd3d-proton [commit](https://github.com/HansKristian-Work/vkd3d-proton/commit/1474978505da9d178624dc571b760f98220ef744) which removed vkd3d-utils creation and build does not create _libvkd3d-proton-utils-3.dll_ file
removed obsolete 'libvkd3d-proton-utils-3.dll' rm command for 9999 causing install fail.

Signed-off-by: Akash Paul <paul007-dev@outlook.com>