### PR TITLE
app-admin/logsurfer+: Fix build for clang16

### DIFF
--- a/app-admin/logsurfer+/files/logsurfer+-1.8-fix-declaration-of-check_context_linelimit.patch
+++ b/app-admin/logsurfer+/files/logsurfer+-1.8-fix-declaration-of-check_context_linelimit.patch
@@ -1,0 +1,30 @@
+From dfd993afd0587080e73079ae7f5ea9a087784d49 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Pascal=20J=C3=A4ger?= <pascal.jaeger@leimstift.de>
+Date: Tue, 29 Nov 2022 22:01:30 +0100
+Subject: [PATCH] Fix declaration of check_context_linelimit
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Bug: https://bugs.gentoo.org/871135
+
+Signed-off-by: Pascal Jäger <pascal.jaeger@leimstift.de>
+---
+ src/context.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/context.h b/src/context.h
+index 0448cfb..addbbab 100644
+--- a/src/context.h
++++ b/src/context.h
+@@ -22,6 +22,7 @@ void		add_to_context(struct context *, struct context_line *);
+ void		do_context_action(struct context *);
+ 
+ void		check_context_timeout();
++void		check_context_linelimit();
+ 
+ void		expand_context_action_macros(struct context *);
+ 
+-- 
+2.38.1
+

--- a/app-admin/logsurfer+/logsurfer+-1.8-r5.ebuild
+++ b/app-admin/logsurfer+/logsurfer+-1.8-r5.ebuild
@@ -1,0 +1,48 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+MY_P="${P/+/}"
+
+inherit toolchain-funcs
+
+DESCRIPTION="Real Time Log Monitoring and Alerting"
+HOMEPAGE="https://www.crypt.gen.nz/logsurfer/"
+SRC_URI="mirror://sourceforge/logsurfer/${MY_P}.tar.gz"
+S="${WORKDIR}/${MY_P}"
+
+LICENSE="freedist GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+RESTRICT="bindist" #444330
+
+RDEPEND="
+	acct-group/logsurfer
+	acct-user/logsurfer
+"
+
+PATCHES=( "${FILESDIR}/${P}-fix-declaration-of-check_context_linelimit.patch" )
+
+src_configure() {
+	local myeconfargs=(
+		--with-etcdir=/etc
+	)
+
+	econf "${myeconfargs[@]}"
+}
+
+src_compile() {
+	tc-export CC
+	default
+}
+
+src_install() {
+	dobin src/logsurfer
+	doman man/logsurfer.1 man/logsurfer.conf.4
+
+	newinitd "${FILESDIR}"/logsurfer-1.8.initd-r1 logsurfer
+	newconfd "${FILESDIR}"/logsurfer.confd logsurfer
+
+	einstalldocs
+}


### PR DESCRIPTION
Not sure about this one. I think they just forgot to declare the function for __STDC__.

Closes: https://bugs.gentoo.org/871135

Signed-off-by: Pascal Jäger <pascal.jaeger@leimstift.de>