### PR TITLE
app-alternatives/bzip2!

### DIFF
--- a/app-alternatives/bzip2/bzip2-0.ebuild
+++ b/app-alternatives/bzip2/bzip2-0.ebuild
@@ -1,0 +1,51 @@
+# Copyright 2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DESCRIPTION="bzip2 symlink"
+HOMEPAGE="https://wiki.gentoo.org/wiki/Project:Base/Alternatives"
+SRC_URI=""
+S=${WORKDIR}
+
+LICENSE="CC0-1.0"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+IUSE="lbzip2 pbzip2 +reference split-usr"
+REQUIRED_USE="^^ ( lbzip2 pbzip2 reference )"
+
+RDEPEND="
+	lbzip2? ( app-arch/lbzip2[-symlink(-)] )
+	pbzip2? ( app-arch/pbzip2[-symlink(-)] )
+	reference? ( >=app-arch/bzip2-1.0.8-r4 )
+	!<app-arch/bzip2-1.0.8-r4
+	!app-arch/lbzip2[symlink(-)]
+	!app-arch/pbzip2[symlink(-)]
+"
+
+src_install() {
+	local usr_prefix=
+	use split-usr && usr_prefix=../usr/bin/
+
+	if use lbzip2; then
+		dosym "${usr_prefix}lbzip2" /bin/bzip2
+		newman - bzip2.1 <<<".so lbzip2.1"
+		newman - bunzip2.1 <<<".so lbzip2.1"
+		newman - bzcat.1 <<<".so lbzip2.1"
+	elif use pbzip2; then
+		dosym "${usr_prefix}pbzip2" /bin/bzip2
+		newman - bzip2.1 <<<".so pbzip2.1"
+		newman - bunzip2.1 <<<".so pbzip2.1"
+		newman - bzcat.1 <<<".so pbzip2.1"
+	elif use reference; then
+		dosym bzip2-reference /bin/bzip2
+		newman - bzip2.1 <<<".so bzip2-reference.1"
+		newman - bunzip2.1 <<<".so bzip2-reference.1"
+		newman - bzcat.1 <<<".so bzip2-reference.1"
+	else
+		die "Invalid USE flag combination (broken REQUIRED_USE?)"
+	fi
+
+	dosym bzip2 /bin/bunzip2
+	dosym bzip2 /bin/bzcat
+}

--- a/app-alternatives/bzip2/metadata.xml
+++ b/app-alternatives/bzip2/metadata.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="project">
+		<email>base-system@gentoo.org</email>
+		<name>Gentoo Base System</name>
+	</maintainer>
+	<maintainer type="person">
+		<email>mgorny@gentoo.org</email>
+		<name>Michał Górny</name>
+	</maintainer>
+	<use>
+		<flag name="lbzip2">
+			Symlink to <pkg>app-arch/lbzip2</pkg>.
+		</flag>
+		<flag name="pbzip2">
+			Symlink to <pkg>app-arch/pbzip2</pkg>.
+		</flag>
+		<flag name="reference">
+			Symlink to <pkg>app-arch/bzip2</pkg>.
+		</flag>
+	</use>
+</pkgmetadata>

--- a/app-arch/bzip2/bzip2-1.0.8-r4.ebuild
+++ b/app-arch/bzip2/bzip2-1.0.8-r4.ebuild
@@ -1,0 +1,135 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+# XXX: atm, libbz2.a is always PIC :(, so it is always built quickly
+#      (since we're building shared libs) ...
+
+EAPI=7
+
+VERIFY_SIG_OPENPGP_KEY_PATH="${BROOT}"/usr/share/openpgp-keys/bzip2.gpg
+inherit toolchain-funcs multilib-minimal usr-ldscript verify-sig
+
+DESCRIPTION="A high-quality data compressor used extensively by Gentoo Linux"
+HOMEPAGE="https://sourceware.org/bzip2/"
+SRC_URI="https://sourceware.org/pub/${PN}/${P}.tar.gz"
+SRC_URI+=" verify-sig? ( https://sourceware.org/pub/${PN}/${P}.tar.gz.sig )"
+
+LICENSE="BZIP2"
+SLOT="0/1" # subslot = SONAME
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+IUSE="static static-libs"
+
+BDEPEND="
+	verify-sig? ( sec-keys/openpgp-keys-bzip2 )
+"
+PDEPEND="
+	app-alternatives/bzip2
+"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-1.0.4-makefile-CFLAGS.patch
+	"${FILESDIR}"/${PN}-1.0.8-saneso.patch
+	"${FILESDIR}"/${PN}-1.0.4-man-links.patch #172986
+	"${FILESDIR}"/${PN}-1.0.6-progress.patch
+	"${FILESDIR}"/${PN}-1.0.3-no-test.patch
+	"${FILESDIR}"/${PN}-1.0.8-mingw.patch #393573
+	"${FILESDIR}"/${PN}-1.0.8-out-of-tree-build.patch
+)
+
+DOCS=( CHANGES README{,.COMPILATION.PROBLEMS,.XML.STUFF} manual.pdf )
+HTML_DOCS=( manual.html )
+
+src_prepare() {
+	default
+
+	# - Use right man path
+	# - Generate symlinks instead of hardlinks
+	# - pass custom variables to control libdir
+	sed -i \
+		-e 's:\$(PREFIX)/man:\$(PREFIX)/share/man:g' \
+		-e 's:ln -s -f $(PREFIX)/bin/:ln -s -f :' \
+		-e 's:$(PREFIX)/lib:$(PREFIX)/$(LIBDIR):g' \
+		Makefile || die
+}
+
+bemake() {
+	emake \
+		VPATH="${S}" \
+		CC="$(tc-getCC)" \
+		AR="$(tc-getAR)" \
+		RANLIB="$(tc-getRANLIB)" \
+		"$@"
+}
+
+multilib_src_compile() {
+	bemake -f "${S}"/Makefile-libbz2_so all
+	# Make sure we link against the shared lib #504648
+	ln -s libbz2.so.${PV} libbz2.so || die
+	bemake -f "${S}"/Makefile all LDFLAGS="${LDFLAGS} $(usex static -static '')"
+}
+
+multilib_src_test() {
+	cp "${S}"/sample* "${BUILD_DIR}" || die
+	bemake -f "${S}"/Makefile check
+}
+
+multilib_src_install() {
+	into /usr
+
+	# Install the shared lib manually.  We install:
+	#  .x.x.x - standard shared lib behavior
+	#  .x.x   - SONAME some distros use #338321
+	#  .x     - SONAME Gentoo uses
+	dolib.so libbz2.so.${PV}
+	local v
+	for v in libbz2.so{,.{${PV%%.*},${PV%.*}}} ; do
+		dosym libbz2.so.${PV} /usr/$(get_libdir)/${v}
+	done
+
+	use static-libs && dolib.a libbz2.a
+
+	if multilib_is_native_abi ; then
+		gen_usr_ldscript -a bz2
+
+		dobin bzip2recover
+		into /
+		newbin bzip2 bzip2-reference
+	fi
+}
+
+multilib_src_install_all() {
+	# `make install` doesn't cope with out-of-tree builds, nor with
+	# installing just non-binaries, so handle things ourselves.
+	insinto /usr/include
+	doins bzlib.h
+	into /usr
+	dobin bz{diff,grep,more}
+	doman bz{diff,grep,more}.1
+	newman bzip2.1 bzip2-reference.1
+
+	dosym bzdiff /usr/bin/bzcmp
+	dosym bzdiff.1 /usr/share/man/man1/bzcmp.1
+
+	dosym bzmore /usr/bin/bzless
+	dosym bzmore.1 /usr/share/man/man1/bzless.1
+
+	dosym bzip2-reference.1 /usr/share/man/man1/bzip2recover.1
+	local x
+	for x in bz{e,f}grep ; do
+		dosym bzgrep /usr/bin/${x}
+		dosym bzgrep.1 /usr/share/man/man1/${x}.1
+	done
+
+	einstalldocs
+}
+
+pkg_postinst() {
+	# ensure to preserve the symlinks before app-alternatives/bzip2
+	# is installed
+	local x
+	for x in bzip2 bunzip2 bzcat; do
+		if [[ ! -h ${EROOT}/bin/${x} ]]; then
+			ln -s bzip2-reference "${EROOT}/bin/${x}" || die
+		fi
+	done
+}

--- a/app-arch/bzip2/bzip2-9999.ebuild
+++ b/app-arch/bzip2/bzip2-9999.ebuild
@@ -19,9 +19,8 @@ SLOT="0/1" # subslot = SONAME
 
 IUSE="static-libs"
 
-RDEPEND="
-	!app-arch/lbzip2[symlink(-)]
-	!app-arch/pbzip2[symlink(-)]
+PDEPEND="
+	app-alternatives/bzip2
 "
 
 multilib_src_configure() {
@@ -39,16 +38,17 @@ multilib_src_install() {
 
 	if multilib_is_native_abi ; then
 		gen_usr_ldscript -a bz2
-
-		dodir /bin
-		mv "${ED}"/usr/bin/bzip2 "${ED}"/bin || die
 	fi
 }
 
 multilib_src_install_all() {
-	# Move "important" bzip2 binaries to /bin and use the shared libbz2.so
-	dosym bzip2 /bin/bzcat
-	dosym bzip2 /bin/bunzip2
+	dodir /bin
+	mv "${ED}"/usr/bin/bzip2 "${ED}"/bin/bzip2-reference || die
+	mv "${ED}"/usr/share/man/man1/bzip2{,-reference}.1 || die
+
+	# moved to app-alternatives/bzip2
+	rm "${ED}"/usr/bin/{bzcat,bunzip2} || die
+	rm "${ED}"/usr/share/man/man1/{bzcat,bunzip2.1} || die
 
 	dosym bzdiff /usr/bin/bzcmp
 	dosym bzmore /usr/bin/bzless
@@ -57,8 +57,7 @@ multilib_src_install_all() {
 		dosym bzgrep /usr/bin/${x}
 	done
 
-	dosym bzip2.1 /usr/share/man/man1/bzip2recover.1
+	dosym bzip2-reference.1 /usr/share/man/man1/bzip2recover.1
 
-	local DOCS=( AUTHORS NEWS{,-pre-1.0.7} README.md )
 	einstalldocs
 }

--- a/profiles/arch/riscv/package.use.mask
+++ b/profiles/arch/riscv/package.use.mask
@@ -1,6 +1,10 @@
 # Copyright 2019-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Michał Górny <mgorny@gentoo.org> (2022-11-30)
+# Mask unkeyworded providers.
+app-alternatives/bzip2 pbzip2
+
 # Yixun Lan <dlan@gentoo.org> (2022-11-24)
 # depend on dev-libs/libpcre2[jit] which not supported yet, bug #879511
 www-servers/varnish jit


### PR DESCRIPTION
The idea is to install `app-arch/bzip2` as `bzip2-reference` and control `bzip2`, `bunzip2` and `bzcat` symlinks between `bzip2-reference`, `lbzip2` and `pbzip2`. Now usr-merge friendly!

I haven't touched other fancy symlinks like `bzless` since they seem reference implementation-specific (also do we really want them?)