### PR TITLE
media-gfx/imagemagick: subscribe to app-text/ghostscript-gpl subslot

### DIFF
--- a/media-gfx/imagemagick/imagemagick-6.9.12.64-r1.ebuild
+++ b/media-gfx/imagemagick/imagemagick-6.9.12.64-r1.ebuild
@@ -14,7 +14,7 @@ else
 	MY_PV="$(ver_rs 3 '-')"
 	MY_P="ImageMagick-${MY_PV}"
 	SRC_URI="mirror://imagemagick/${MY_P}.tar.xz"
-	KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~mips ppc ppc64 ~s390 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
 fi
 
 S="${WORKDIR}/${MY_P}"
@@ -53,7 +53,7 @@ RDEPEND="
 	pango? ( x11-libs/pango )
 	perl? ( >=dev-lang/perl-5.8.8:= )
 	png? ( media-libs/libpng:= )
-	postscript? ( app-text/ghostscript-gpl )
+	postscript? ( app-text/ghostscript-gpl:= )
 	raw? ( media-libs/libraw:= )
 	svg? (
 		gnome-base/librsvg

--- a/media-gfx/imagemagick/imagemagick-7.1.0.44-r1.ebuild
+++ b/media-gfx/imagemagick/imagemagick-7.1.0.44-r1.ebuild
@@ -14,7 +14,7 @@ else
 	MY_PV="$(ver_rs 3 '-')"
 	MY_P="ImageMagick-${MY_PV}"
 	SRC_URI="mirror://imagemagick/${MY_P}.tar.xz"
-	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
+	KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
 fi
 
 S="${WORKDIR}/${MY_P}"
@@ -53,7 +53,7 @@ RDEPEND="
 	pango? ( x11-libs/pango )
 	perl? ( >=dev-lang/perl-5.8.8:= )
 	png? ( media-libs/libpng:= )
-	postscript? ( app-text/ghostscript-gpl )
+	postscript? ( app-text/ghostscript-gpl:= )
 	raw? ( media-libs/libraw:= )
 	svg? (
 		gnome-base/librsvg

--- a/media-gfx/imagemagick/imagemagick-7.1.0.48-r1.ebuild
+++ b/media-gfx/imagemagick/imagemagick-7.1.0.48-r1.ebuild
@@ -4,17 +4,17 @@
 EAPI=8
 
 QA_PKGCONFIG_VERSION=$(ver_cut 1-3)
-inherit flag-o-matic libtool perl-functions toolchain-funcs
+inherit autotools flag-o-matic perl-functions toolchain-funcs
 
 if [[ ${PV} == 9999 ]] ; then
-	EGIT_REPO_URI="https://github.com/ImageMagick/ImageMagick6.git"
+	EGIT_REPO_URI="https://github.com/ImageMagick/ImageMagick.git"
 	inherit git-r3
 	MY_P="imagemagick-9999"
 else
 	MY_PV="$(ver_rs 3 '-')"
 	MY_P="ImageMagick-${MY_PV}"
 	SRC_URI="mirror://imagemagick/${MY_P}.tar.xz"
-	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
 fi
 
 S="${WORKDIR}/${MY_P}"
@@ -23,8 +23,8 @@ DESCRIPTION="A collection of tools and libraries for many image formats"
 HOMEPAGE="https://www.imagemagick.org/"
 
 LICENSE="imagemagick"
-SLOT="0/6.9.12-58"
-IUSE="bzip2 corefonts +cxx djvu fftw fontconfig fpx graphviz hdri heif jbig jpeg jpeg2k lcms lqr lzma opencl openexr openmp pango perl +png postscript q32 q8 raw static-libs svg test tiff truetype webp wmf X xml zlib"
+SLOT="0/7.1.0-43"
+IUSE="bzip2 corefonts +cxx djvu fftw fontconfig fpx graphviz hdri heif jbig jpeg jpeg2k lcms lqr lzma opencl openexr openmp pango perl +png postscript q32 q8 raw static-libs svg test tiff truetype webp wmf X xml zip zlib"
 
 REQUIRED_USE="corefonts? ( truetype )
 	svg? ( xml )
@@ -53,7 +53,7 @@ RDEPEND="
 	pango? ( x11-libs/pango )
 	perl? ( >=dev-lang/perl-5.8.8:= )
 	png? ( media-libs/libpng:= )
-	postscript? ( app-text/ghostscript-gpl )
+	postscript? ( app-text/ghostscript-gpl:= )
 	raw? ( media-libs/libraw:= )
 	svg? (
 		gnome-base/librsvg
@@ -74,10 +74,15 @@ RDEPEND="
 	)
 	xml? ( dev-libs/libxml2 )
 	lzma? ( app-arch/xz-utils )
+	zip? ( dev-libs/libzip:= )
 	zlib? ( sys-libs/zlib:= )"
 DEPEND="${RDEPEND}
 	X? ( x11-base/xorg-proto )"
 BDEPEND="virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-9999-nocputuning.patch"
+)
 
 pkg_pretend() {
 	[[ ${MERGE_TYPE} != binary ]] && use openmp && tc-check-openmp
@@ -90,6 +95,9 @@ pkg_setup() {
 src_prepare() {
 	default
 
+	#elibtoolize # for Darwin modules
+	eautoreconf
+
 	# Apply hardening, bug #664236
 	cp "${FILESDIR}"/policy-hardening.snippet "${S}" || die
 	sed -i -e '/^<policymap>$/ {
@@ -100,10 +108,7 @@ src_prepare() {
 		die "Failed to apply hardening of policy.xml"
 	einfo "policy.xml hardened"
 
-	# for Darwin modules
-	elibtoolize
-
-	# For testsuite, see bug #500580#c3
+	# For testsuite, see https://bugs.gentoo.org/show_bug.cgi?id=500580#c3
 	local ati_cards mesa_cards nvidia_cards render_cards
 	shopt -s nullglob
 	ati_cards=$(echo -n /dev/ati/card* | sed 's/ /:/g')
@@ -149,6 +154,7 @@ src_configure() {
 		--with-gs-font-dir="${EPREFIX}"/usr/share/fonts/urw-fonts
 		$(use_with bzip2 bzlib)
 		$(use_with X x)
+		$(use_with zip)
 		$(use_with zlib)
 		--without-autotrace
 		$(use_with postscript dps)
@@ -164,6 +170,7 @@ src_configure() {
 		$(use_with jbig)
 		$(use_with jpeg)
 		$(use_with jpeg2k openjp2)
+		--without-jxl
 		$(use_with lcms)
 		$(use_with lqr)
 		$(use_with lzma)
@@ -177,14 +184,13 @@ src_configure() {
 		$(use_with corefonts windows-font-dir "${EPREFIX}"/usr/share/fonts/corefonts)
 		$(use_with wmf)
 		$(use_with xml)
-		--with-gcc-arch=no-automagic
 	)
 
 	CONFIG_SHELL="${BROOT}"/bin/bash econf "${myeconfargs[@]}"
 }
 
 src_test() {
-	# Install default (unrestricted) policy in ${HOME} for test suite, bug #664238
+	# Install default (unrestricted) policy in $HOME for test suite, bug #664238
 	local _im_local_config_home="${HOME}/.config/ImageMagick"
 	mkdir -p "${_im_local_config_home}" || \
 		die "Failed to create IM config dir in '${_im_local_config_home}'"
@@ -192,8 +198,12 @@ src_test() {
 		die "Failed to install default blank policy.xml in '${_im_local_config_home}'"
 
 	local im_command= IM_COMMANDS=()
-	IM_COMMANDS+=( "identify -version | grep -q -- \"${MY_PV}\"" ) # Verify that we are using version we just built
-	IM_COMMANDS+=( "identify -list policy" ) # Verify that policy.xml is used
+	if [[ ${PV} == 9999 ]] ; then
+		IM_COMMANDS+=( "magick -version" ) # Show version we are using -- cannot verify because of live ebuild
+	else
+		IM_COMMANDS+=( "magick -version | grep -q -- \"${MY_PV}\"" ) # Verify that we are using version we just built
+	fi
+	IM_COMMANDS+=( "magick -list policy" ) # Verify that policy.xml is used
 	IM_COMMANDS+=( "emake check" ) # Run tests
 
 	for im_command in "${IM_COMMANDS[@]}"; do
@@ -228,8 +238,7 @@ src_install() {
 		EOF
 
 		insinto /etc/sandbox.d
-		# bug #472766
-		doins "${T}"/99${PN}
+		doins "${T}"/99${PN} #472766
 	fi
 
 	insinto /usr/share/${PN}
@@ -245,7 +254,7 @@ pkg_postinst() {
 	else
 		local v
 		for v in ${REPLACING_VERSIONS}; do
-			if ! ver_test "${v}" -gt "6.9.10.10-r2"; then
+			if ! ver_test "${v}" -gt "7.0.8.10-r2"; then
 				# This is an upgrade
 				_show_policy_xml_notice=yes
 
@@ -256,7 +265,7 @@ pkg_postinst() {
 	fi
 
 	if [[ -n "${_show_policy_xml_notice}" ]]; then
-		elog "For security reasons, a policy.xml file was installed in /etc/ImageMagick-6"
+		elog "For security reasons, a policy.xml file was installed in /etc/ImageMagick-7"
 		elog "which will prevent the usage of the following coders by default:"
 		elog ""
 		elog "  - PS"

--- a/media-gfx/imagemagick/imagemagick-9999.ebuild
+++ b/media-gfx/imagemagick/imagemagick-9999.ebuild
@@ -53,7 +53,7 @@ RDEPEND="
 	pango? ( x11-libs/pango )
 	perl? ( >=dev-lang/perl-5.8.8:= )
 	png? ( media-libs/libpng:= )
-	postscript? ( app-text/ghostscript-gpl )
+	postscript? ( app-text/ghostscript-gpl:= )
 	raw? ( media-libs/libraw:= )
 	svg? (
 		gnome-base/librsvg


### PR DESCRIPTION
During the last update of `app-text/ghostscript-gpl` I realized that `media-gfx/imagemagick` wasn't rebuild when it should be. Adding a subslot operator should fix it. I hope this patch is fine.

Signed-off-by: Mario Haustein <mario.haustein@hrz.tu-chemnitz.de>