### PR TITLE
x11-plugins/gkrellshoot: fix build for clang16

### DIFF
--- a/x11-plugins/gkrellshoot/files/gkrellshoot-0.4.4-r5-fix-implicit-int.patch
+++ b/x11-plugins/gkrellshoot/files/gkrellshoot-0.4.4-r5-fix-implicit-int.patch
@@ -1,0 +1,25 @@
+By default clang16 will not allow implicit integer declarations in function parameters.
+
+Bug: https://bugs.gentoo.org/874891
+
+Signed-off-by: Pascal Jäger <pascal.jaeger@leimstift.de>
+---
+ gkrellshoot.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/gkrellshoot.c b/gkrellshoot.c
+index 114a85e..0d74d1d 100755
+--- a/gkrellshoot.c
++++ b/gkrellshoot.c
+@@ -436,7 +436,7 @@ double star_screenx[NUM_STARS];
+ double star_screeny[NUM_STARS];
+ 
+ static void
+-draw_starfield ( chart_index )
++draw_starfield ( size_t  chart_index )
+ {
+   gint i;
+   guchar b;
+-- 
+2.38.1
+

--- a/x11-plugins/gkrellshoot/gkrellshoot-0.4.4-r5.ebuild
+++ b/x11-plugins/gkrellshoot/gkrellshoot-0.4.4-r5.ebuild
@@ -1,0 +1,32 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit gkrellm-plugin toolchain-funcs
+
+DESCRIPTION="GKrellm2 plugin to take screen shots and lock screen"
+HOMEPAGE="http://gkrellshoot.sourceforge.net/"
+SRC_URI="mirror://sourceforge/gkrellshoot/${P}.tar.gz"
+S="${WORKDIR}/${P/s/S}"
+
+LICENSE="GPL-2"
+SLOT="2"
+KEYWORDS="~alpha ~amd64 ~ppc ~sparc ~x86"
+
+DEPEND="app-admin/gkrellm:2[X]"
+RDEPEND="
+	${DEPEND}
+	virtual/imagemagick-tools"
+BDEPEND="virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}"/makefile-respect-flags.patch
+	"${FILESDIR}/${P}"-r4-pkgconfig.patch
+	"${FILESDIR}/${P}"-r5-fix-implicit-int.patch
+)
+
+src_compile() {
+	tc-export PKG_CONFIG
+	default
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/874891

Signed-off-by: Pascal Jäger <pascal.jaeger@leimstift.de>