### PR TITLE
media-libs/imlib2: backport BE build fix to 1.7.5

### DIFF
--- a/media-libs/imlib2/files/7d60151ba9.patch
+++ b/media-libs/imlib2/files/7d60151ba9.patch
@@ -1,0 +1,37 @@
+https://bugs.gentoo.org/877777
+https://git.enlightenment.org/old/legacy-imlib2/commit/7d60151ba9696ef07be79af68d5c631a97c63906
+
+From 7d60151ba9696ef07be79af68d5c631a97c63906 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?S=C3=B6ren=20Tempel?= <soeren+git@soeren-tempel.net>
+Date: Mon, 3 Jan 2022 10:56:03 +0100
+Subject: [PATCH] ICO loader: Fix compilation on big endian architectures
+
+Commit ff79901a071a76ec73cc98c7ff15102c514afb7b refactors the
+ico_read_idir function and removed the local nr variable. Unfortunately,
+this variable is still used within an `#ifdef WORDS_BIGENDIAN` block on
+big endian architectures as a for loop index variable. As such, the code
+does presently not compile since the aforementioned commit. This patch
+fixes this issue by re-introducing the variable conditionally on big
+endian architectures.
+
+Note: It would likely be cleaner to declare the nr variable as part of
+the loop declaration, however, this C99 feature does not seem to be used
+anywhere in the code base, hence I refrained from using it here.
+---
+ src/modules/loaders/loader_ico.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/src/modules/loaders/loader_ico.c b/src/modules/loaders/loader_ico.c
+index e8cef41..66c3643 100644
+--- a/src/modules/loaders/loader_ico.c
++++ b/src/modules/loaders/loader_ico.c
+@@ -139,6 +139,9 @@ ico_read_icon(ico_t * ico, int ino)
+ {
+    ie_t               *ie;
+    unsigned int        size;
++#ifdef WORDS_BIGENDIAN
++   unsigned int        nr;
++#endif
+ 
+    ie = &ico->ie[ino];
+ 

--- a/media-libs/imlib2/imlib2-1.7.5.ebuild
+++ b/media-libs/imlib2/imlib2-1.7.5.ebuild
@@ -37,6 +37,7 @@ RDEPEND="
 DEPEND="${RDEPEND}
 	X? ( x11-base/xorg-proto )"
 BDEPEND="virtual/pkgconfig"
+PATCHES="${FILESDIR}/7d60151ba9.patch"
 
 multilib_src_configure() {
 	local myeconfargs=(


### PR DESCRIPTION
No revbump since this is build-only.