### PR TITLE
app-editors/neovim: mask luajit target on riscv and use lua5-1

### DIFF
--- a/profiles/arch/riscv/package.use.force
+++ b/profiles/arch/riscv/package.use.force
@@ -1,6 +1,10 @@
 # Copyright 2021-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Mike Rivnak <rivnakm1@gmail.com> (2022-11-30)
+# luajit is currently not supported on riscv
+app-editors/neovim lua_single_target_lua5-1
+
 # Georgy Yakovlev <gyakovlev@gentoo.org> (2022-11-13)
 # 1.64 segfaults, so we force 1.65 bootstrapping 1.65
 ~dev-lang/rust-1.65.0 system-bootstrap

--- a/profiles/arch/riscv/package.use.mask
+++ b/profiles/arch/riscv/package.use.mask
@@ -1,6 +1,10 @@
 # Copyright 2019-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Mike Rivnak <rivnakm1@gmail.com> (2022-11-30)
+# luajit is currently not supported on riscv
+app-editors/neovim lua_single_target_luajit
+
 # Yixun Lan <dlan@gentoo.org> (2022-11-24)
 # depend on dev-libs/libpcre2[jit] which not supported yet, bug #879511
 www-servers/varnish jit


### PR DESCRIPTION
Luajit does not support riscv at the moment