### PR TITLE
profiles/arch: only unmask media-video/ffmpeg[amf] on amd64

### DIFF
--- a/profiles/arch/alpha/package.use.mask
+++ b/profiles/arch/alpha/package.use.mask
@@ -42,11 +42,6 @@ media-gfx/graphicsmagick jpegxl
 # Untested useflag on other arches, needs keywording
 media-video/ffmpeg vmaf
 
-# Adel Kara Slimane <adel.ks@zegrapher.com> (2022-02-17)
-# Mask AMF keyword on non-amd64 arches
-# It is unusable, for now, in other arches
-media-video/ffmpeg amf
-
 # Sam James <sam@gentoo.org> (2022-01-29)
 # app-text/ronn-ng not keyworded here, bug #801103
 app-accessibility/espeak-ng man

--- a/profiles/arch/amd64/package.use.mask
+++ b/profiles/arch/amd64/package.use.mask
@@ -50,6 +50,10 @@ media-sound/qmmp -xmp
 # Need intel-hybrid-codec-driver, which only works on amd64
 media-libs/libva-intel-driver -hybrid
 
+# Adel Kara Slimane <adel.ks@zegrapher.com> (2022-02-17)
+# Unmask AMF keyword on amd64 only
+media-video/ffmpeg -amf
+
 # James Le Cuirot <chewi@gentoo.org> (2021-10-22)
 # The JIT feature only works on amd64 and x86.
 app-emulation/fs-uae -jit

--- a/profiles/arch/arm/package.use.mask
+++ b/profiles/arch/arm/package.use.mask
@@ -39,11 +39,6 @@ kde-frameworks/kfilemetadata mobi
 # https://www.boost.org/doc/libs/1_78_0/libs/context/doc/html/context/architectures.html
 dev-libs/boost -context
 
-# Adel Kara Slimane <adel.ks@zegrapher.com> (2022-01-17)
-# Mask AMF keyword on non-amd64 arches
-# It is unusable, for now, in other arches
-media-video/ffmpeg amf
-
 # Sam James <sam@gentoo.org> (2022-01-15)
 # Deps not yet stable:
 # app-emulation/spice

--- a/profiles/arch/arm64/package.use.mask
+++ b/profiles/arch/arm64/package.use.mask
@@ -42,11 +42,6 @@ media-video/ffmpeg vmaf
 # Supports 64-bit NEON
 >=media-libs/libjpeg-turbo-2.1.3 -cpu_flags_arm_neon
 
-# Adel Kara Slimane <adel.ks@zegrapher.com> (2022-01-11)
-# Mask AMF keyword on non-amd64 arches
-# It is unusable, for now, in other arches
-media-video/ffmpeg amf
-
 # Sam James <sam@gentoo.org> (2022-02-02)
 # sys-cluster/knem is not keyworded on arm64
 sys-cluster/openmpi openmpi_fabrics_knem

--- a/profiles/arch/base/package.use.mask
+++ b/profiles/arch/base/package.use.mask
@@ -43,6 +43,11 @@ sys-libs/libseccomp experimental-loong
 # These GRUB platforms are only for MIPS.
 sys-boot/grub grub_platforms_loongson grub_platforms_qemu-mips
 
+# Adel Kara Slimane <adel.ks@zegrapher.com> (2022-02-17)
+# Mask AMF keyword on non-amd64 arches
+# It is unusable, for now, in other arches
+media-video/ffmpeg amf
+
 # Sam James <sam@gentoo.org> (2021-11-15)
 # Only available on PPC*.
 sys-apps/util-linux rtas

--- a/profiles/arch/hppa/package.use.mask
+++ b/profiles/arch/hppa/package.use.mask
@@ -65,11 +65,6 @@ media-video/ffmpeg vmaf
 # Unkeyworded dependencies
 net-mail/cyrus-imapd http
 
-# Adel Kara Slimane <adel.ks@zegrapher.com> (2022-02-17)
-# Mask AMF keyword on non-amd64 arches
-# It is unusable, for now, in other arches
-media-video/ffmpeg amf
-
 # Arthur Zamarin <arthurzam@gentoo.org> (2022-02-08)
 # bash becomes corrupted and system breaks, bug #832946
 app-shells/bash mem-scramble

--- a/profiles/arch/ia64/package.use.mask
+++ b/profiles/arch/ia64/package.use.mask
@@ -47,11 +47,6 @@ media-video/ffmpeg vmaf
 # Unkeyworded dependencies
 net-mail/cyrus-imapd http
 
-# Adel Kara Slimane <adel.ks@zegrapher.com> (2022-01-11)
-# Mask AMF keyword on non-amd64 arches
-# It is unusable, for now, in other arches
-media-video/ffmpeg amf
-
 # Sam James <sam@gentoo.org> (2022-01-29)
 # app-text/ronn-ng not keyworded here, bug #801103
 app-accessibility/espeak-ng man

--- a/profiles/arch/m68k/package.use.mask
+++ b/profiles/arch/m68k/package.use.mask
@@ -9,11 +9,6 @@ sys-apps/systemd tpm xkb
 # Untested useflag on other arches, needs keywording
 media-video/ffmpeg vmaf
 
-# Adel Kara Slimane <adel.ks@zegrapher.com> (2022-01-11)
-# Mask AMF keyword on non-amd64 arches
-# It is unusable, for now, in other arches
-media-video/ffmpeg amf
-
 # James Le Cuirot <chewi@gentoo.org> (2022-01-09)
 # Most usage of KMS requires GBM, which is provided by Mesa, which currently
 # doesn't work on m68k.

--- a/profiles/arch/mips/package.use.mask
+++ b/profiles/arch/mips/package.use.mask
@@ -27,11 +27,6 @@ media-video/ffmpeg vmaf
 # These GRUB platforms are only for MIPS.
 sys-boot/grub -grub_platforms_loongson -grub_platforms_qemu-mips
 
-# Adel Kara Slimane <adel.ks@zegrapher.com> (2022-01-17)
-# Mask AMF keyword on non-amd64 arches
-# It is unusable, for now, in other arches
-media-video/ffmpeg amf
-
 # Fabian Groffen <grobian@gentoo.org> (2022-02-13)
 # needs unkeyworded virtual/gsasl
 mail-client/mutt gsasl

--- a/profiles/arch/powerpc/package.use.mask
+++ b/profiles/arch/powerpc/package.use.mask
@@ -30,11 +30,6 @@ app-text/enchant nuspell
 # Untested useflag on other arches, needs keywording
 media-video/ffmpeg vmaf
 
-# Adel Kara Slimane <adel.ks@zegrapher.com> (2021-12-11)
-# Mask AMF keyword on non-amd64 arches
-# It is unusable, for now, in other arches
-media-video/ffmpeg amf
-
 # Sam James <sam@gentoo.org> (2021-11-15)
 # librtas is available on (only) ppc*
 sys-apps/util-linux -rtas

--- a/profiles/arch/riscv/package.use.mask
+++ b/profiles/arch/riscv/package.use.mask
@@ -84,11 +84,6 @@ sys-block/fio rbd
 # Upstream bug for criu: https://github.com/checkpoint-restore/criu/issues/1702
 app-containers/crun criu
 
-# Adel Kara Slimane <adel.ks@zegrapher.com> (2022-02-17)
-# Mask AMF keyword on non-amd64 arches
-# It is unusable, for now, in other arches
-media-video/ffmpeg amf
-
 # Yongxinag Liang <tanekliang@gmail.com> (2022-01-09)
 # app-emulation/xen-tools doesn't support riscv yet
 app-emulation/qemu xen

--- a/profiles/arch/s390/package.use.mask
+++ b/profiles/arch/s390/package.use.mask
@@ -109,11 +109,6 @@ app-portage/nattka depgraph-order
 # Untested useflag on other arches, needs keywording
 media-video/ffmpeg vmaf
 
-# Adel Kara Slimane <adel.ks@zegrapher.com> (2021-12-11)
-# Mask AMF keyword on non-amd64 arches
-# It is unusable, for now, in other arches
-media-video/ffmpeg amf
-
 # Sam James <sam@gentoo.org> (2021-11-05)
 # Avoid keywording unnecessary depenencies for now, bug #804115
 dev-python/scipy pythran

--- a/profiles/arch/sparc/package.use.mask
+++ b/profiles/arch/sparc/package.use.mask
@@ -65,11 +65,6 @@ media-video/ffmpeg vmaf
 # Unkeyworded dependencies
 net-mail/cyrus-imapd http
 
-# Adel Kara Slimane <adel.ks@zegrapher.com> (2022-02-17)
-# Mask AMF keyword on non-amd64 arches
-# It is unusable, for now, in other arches
-media-video/ffmpeg amf
-
 # Daniel Pielmeier <billie@gentoo.org> (2021-11-07)
 # gnome-base/librsvg is not keyworded here, bug #807130
 app-admin/conky lua-rsvg

--- a/profiles/arch/x86/package.use.mask
+++ b/profiles/arch/x86/package.use.mask
@@ -63,11 +63,6 @@ media-video/ffmpeg vmaf
 # dev-util/hip and its rocm dependencies not keyworded here
 sci-physics/lammps hip
 
-# Adel Kara Slimane <adel.ks@zegrapher.com> (2021-02-17)
-# Mask AMF keyword on non-amd64 arches
-# It is unusable, for now, in other arches
-media-video/ffmpeg amf
-
 # Sam James <sam@gentoo.org> (2022-01-20)
 # Only supports cpu_flags_x86_aes in 64-bit mode
 net-fs/samba cpu_flags_x86_aes


### PR DESCRIPTION
As media-video/amdgpu-pro-amf is amd64-only, an arch/base mask plus an arch/amd64 unmask is enough, no need for all the masks on individual arches.

Fixes: 8012d5042f1bc8501a33aa371bd63a495f6d8a25
Signed-off-by: WANG Xuerui <xen0n@gentoo.org>