### PR TITLE
x11-misc/trayer-srg: avoid prestripping files, add myself as maintainer

### DIFF
--- a/x11-misc/trayer-srg/files/trayer-srg-1.1.8-avoid-prestripping-of-files.patch
+++ b/x11-misc/trayer-srg/files/trayer-srg-1.1.8-avoid-prestripping-of-files.patch
@@ -1,20 +1,9 @@
-From 5414b1b6f89238d60e160f580ee36505b0988447 Mon Sep 17 00:00:00 2001
-From: =?UTF-8?q?Pascal=20J=C3=A4ger?= <pascal.jaeger@leimstift.de>
 Date: Sat, 3 Dec 2022 17:24:58 +0100
 Subject: [PATCH] avoid prestripping of files
-MIME-Version: 1.0
-Content-Type: text/plain; charset=UTF-8
-Content-Transfer-Encoding: 8bit
 
 Bug: https://bugs.gentoo.org/837260
 
 Signed-off-by: Pascal Jäger <pascal.jaeger@leimstift.de>
----
- Makefile | 6 +++---
- 1 file changed, 3 insertions(+), 3 deletions(-)
-
-diff --git a/Makefile b/Makefile
-index d530e25..380b46f 100644
 --- a/Makefile
 +++ b/Makefile
 @@ -20,9 +20,9 @@ endif

--- a/x11-misc/trayer-srg/files/trayer-srg-1.1.8-avoid-prestripping-of-files.patch
+++ b/x11-misc/trayer-srg/files/trayer-srg-1.1.8-avoid-prestripping-of-files.patch
@@ -1,0 +1,35 @@
+From 5414b1b6f89238d60e160f580ee36505b0988447 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Pascal=20J=C3=A4ger?= <pascal.jaeger@leimstift.de>
+Date: Sat, 3 Dec 2022 17:24:58 +0100
+Subject: [PATCH] avoid prestripping of files
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Bug: https://bugs.gentoo.org/837260
+
+Signed-off-by: Pascal Jäger <pascal.jaeger@leimstift.de>
+---
+ Makefile | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index d530e25..380b46f 100644
+--- a/Makefile
++++ b/Makefile
+@@ -20,9 +20,9 @@ endif
+ TARGET = trayer
+ $(TARGET): $(OBJ)
+ 	$(CC) $(LDFLAGS) $(OBJ) -o $@ $(LIBS)
+-ifeq (,$(DEVEL))
+-	strip $@
+-endif
++# ifeq (,$(DEVEL))
++# 	strip $@
++# endif
+ 
+ all: $(TARGET)
+ 
+-- 
+2.38.1
+

--- a/x11-misc/trayer-srg/metadata.xml
+++ b/x11-misc/trayer-srg/metadata.xml
@@ -1,8 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<!-- maintainer-needed -->
-	<upstream>
-		<remote-id type="github">sargon/trayer-srg</remote-id>
-	</upstream>
+  <maintainer type="person" proxied="yes">
+    <email>pascal.jaeger@leimstift.de</email>
+    <name>Pascal Jäger</name>
+  </maintainer>
+  <maintainer type="project" proxied="proxy">
+    <email>proxy-maint@gentoo.org</email>
+    <name>Proxy Maintainers</name>
+  </maintainer>
+  <upstream>
+    <remote-id type="github">sargon/trayer-srg</remote-id>
+  </upstream>
 </pkgmetadata>

--- a/x11-misc/trayer-srg/trayer-srg-1.1.8-r2.ebuild
+++ b/x11-misc/trayer-srg/trayer-srg-1.1.8-r2.ebuild
@@ -1,0 +1,39 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs
+
+DESCRIPTION="trayer fork with multi monitor support and cleaned up codebase"
+HOMEPAGE="https://github.com/sargon/trayer-srg"
+SRC_URI="https://github.com/sargon/${PN}/archive/${P/-srg/}.tar.gz -> ${P}.tar.gz"
+S="${WORKDIR}"/${PN}-trayer-${PV}
+
+LICENSE="MIT GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+RDEPEND="
+	x11-libs/gdk-pixbuf:2
+	dev-libs/glib:2
+	x11-libs/gtk+:2
+	x11-libs/libX11
+"
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+PATCHES=( "${FILESDIR}/${P}-avoid-prestripping-of-files.patch" )
+
+src_configure() {
+	./configure --prefix="${EPREFIX}" || die
+}
+
+src_compile() {
+	emake TARGET=${PN} CC="$(tc-getCC)"
+}
+
+src_install() {
+	dobin ${PN}
+	einstalldocs
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/837260

I'm using this on a daily basis, so I would like to adopt it. 