### PR TITLE
tree-sitter-grammar.eclass: Add src_test implementation

### DIFF
--- a/dev-libs/tree-sitter-cpp/tree-sitter-cpp-0.20.0.ebuild
+++ b/dev-libs/tree-sitter-cpp/tree-sitter-cpp-0.20.0.ebuild
@@ -11,3 +11,6 @@ HOMEPAGE="https://github.com/tree-sitter/tree-sitter-cpp"
 LICENSE="MIT"
 SLOT="0"
 KEYWORDS="amd64"
+
+# requires test data from tree-sitter-c
+RESTRICT="test"

--- a/eclass/tree-sitter-grammar.eclass
+++ b/eclass/tree-sitter-grammar.eclass
@@ -29,7 +29,11 @@ S="${WORKDIR}"/${PN}-${TS_PV:-${PV}}/src
 # Needed for tree_sitter/parser.h
 DEPEND="dev-libs/tree-sitter"
 
-EXPORT_FUNCTIONS src_compile src_install
+BDEPEND+=" test? ( dev-util/tree-sitter-cli )"
+IUSE+=" test"
+RESTRICT+=" !test? ( test )"
+
+EXPORT_FUNCTIONS src_compile src_test src_install
 
 # @ECLASS_VARIABLE: TS_PV
 # @PRE_INHERIT
@@ -87,6 +91,16 @@ tree-sitter-grammar_src_compile() {
 			*.o \
 			${soname_args} \
 			-o "${WORKDIR}"/${soname}
+}
+
+# @FUNCTION: tree-sitter-grammar_src_test
+# @DESCRIPTION:
+# Runs the Tree Sitter parser's test suite.
+# See: https://tree-sitter.github.io/tree-sitter/creating-parsers#command-test
+tree-sitter-grammar_src_test() {
+	debug-print-function ${FUNCNAME} "${@}"
+
+	(cd .. && tree-sitter test) || die "Test suite failed"
 }
 
 # @FUNCTION: tree-sitter-grammar_src_install

--- a/profiles/features/wd40/package.use.mask
+++ b/profiles/features/wd40/package.use.mask
@@ -1,6 +1,32 @@
 # Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# matoro <matoro_gentoo@matoro.tk> (2022-12-01)
+# tree-sitter-grammar.eclass adds dev-util/tree-sitter-cli as test dep
+dev-libs/tree-sitter-bash test
+dev-libs/tree-sitter-c test
+dev-libs/tree-sitter-c-sharp test
+dev-libs/tree-sitter-cpp test
+dev-libs/tree-sitter-css test
+dev-libs/tree-sitter-embedded-template test
+dev-libs/tree-sitter-go test
+dev-libs/tree-sitter-haskell test
+dev-libs/tree-sitter-html test
+dev-libs/tree-sitter-java test
+dev-libs/tree-sitter-javascript test
+dev-libs/tree-sitter-jsdoc test
+dev-libs/tree-sitter-json test
+dev-libs/tree-sitter-julia test
+dev-libs/tree-sitter-ocaml test
+dev-libs/tree-sitter-php test
+dev-libs/tree-sitter-python test
+dev-libs/tree-sitter-ql test
+dev-libs/tree-sitter-ruby test
+dev-libs/tree-sitter-rust test
+dev-libs/tree-sitter-scala test
+dev-libs/tree-sitter-tsq test
+dev-libs/tree-sitter-typescript test
+
 # Sam James <sam@gentoo.org> (2022-11-19)
 # GNOME packages pulling in e.g. gjs which then needs Rust.
 dev-util/glade gjs


### PR DESCRIPTION
See https://tree-sitter.github.io/tree-sitter/creating-parsers#command-test.  Tested with all existing eclass consumers currently in tree, all of them have a functioning test suite except for dev-libs/tree-sitter-cpp.  To be posted to mailing list shortly.