### PR TITLE
profiles/arch/hppa: unmask net-libs/nghttp2[cxx]

### DIFF
--- a/profiles/arch/hppa/package.use.mask
+++ b/profiles/arch/hppa/package.use.mask
@@ -305,10 +305,6 @@ kde-frameworks/extra-cmake-modules doc
 # pulls in many dev-ruby/asciidoctor dependencies (bug #583390)
 net-misc/chrony html
 
-# Jeroen Roovers <jer@gentoo.org> (2015-07-03)
-# net-libs/nghttp2 fails to compile (bug #552898)
-net-libs/nghttp2 cxx
-
 # Jeroen Roovers <jer@gentoo.org> (2015-05-17)
 # Mask USE=rados for net-analyzer/rrdtool since sys-cluster/ceph is not
 # keyworded (bug #549516)


### PR DESCRIPTION
See: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=64735
See: https://gcc.gnu.org/git/?p=gcc.git&a=commit;h=ed3cb4970392edfbae74c82d7e25b7cd961ce70f
See: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=727621