### PR TITLE
x11-misc/notify-osd: fix build for clang16

### DIFF
--- a/x11-misc/notify-osd/files/notify-osd-0.9.34-fix-integer-conversion.patch
+++ b/x11-misc/notify-osd/files/notify-osd-0.9.34-fix-integer-conversion.patch
@@ -1,0 +1,24 @@
+Clang16 will not allow implicit pointer to integer 
+conversions by default. (-Werror=int-conversion by default)
+This patch fixes the pointer to integer conversion.
+
+Bug: https://bugs.gentoo.org/879035
+Patch is upstreamed here: https://answers.launchpad.net/notify-osd/+question/704024
+
+Signed-off-by: Pascal Jäger <pascal.jaeger@leimstift.de>
+--- a/src/bubble-window.c
++++ b/src/bubble-window.c
+@@ -78,8 +78,8 @@ bubble_window_get_accessible (GtkWidget *widget)
+     {
+       AtkObjectFactory *factory = NULL;
+       AtkRegistry *registry = NULL;
+-      GType derived_type = NULL;
+-      GType derived_atk_type = NULL;
++      GType derived_type = 0;
++      GType derived_atk_type = 0;
+ 
+       /*
+        * Figure out whether accessibility is enabled by looking at the
+-- 
+2.38.1
+

--- a/x11-misc/notify-osd/notify-osd-0.9.34-r2.ebuild
+++ b/x11-misc/notify-osd/notify-osd-0.9.34-r2.ebuild
@@ -1,0 +1,72 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+inherit autotools gnome2-utils savedconfig
+
+DESCRIPTION="Canonical's on-screen-display notification agent"
+HOMEPAGE="https://launchpad.net/notify-osd"
+SRC_URI="https://launchpad.net/${PN}/precise/${PV}/+download/${P}.tar.gz"
+
+LICENSE="GPL-3"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="minimal"
+
+RDEPEND="
+	gnome-base/gsettings-desktop-schemas
+	!minimal? ( x11-themes/notify-osd-icons )
+"
+DEPEND="
+	dev-util/glib-utils
+	gnome-base/gnome-common
+	x11-base/xorg-proto
+	virtual/pkgconfig
+	>=dev-libs/dbus-glib-0.98
+	>=dev-libs/glib-2.16:2
+	>=x11-libs/gtk+-3.2:3
+	>=x11-libs/libnotify-0.7
+	>=x11-libs/libwnck-3:3
+	x11-libs/libX11
+	x11-libs/pixman
+	!x11-misc/notification-daemon
+	!x11-misc/qtnotifydaemon
+"
+
+RESTRICT="test" # virtualx.eclass: 1 of 1: FAIL: test-modules
+
+# Patch is upstreamed here: https://answers.launchpad.net/notify-osd/+question/704024
+PATCHES=( "${FILESDIR}/${P}-fix-integer-conversion.patch" )
+
+src_prepare() {
+	default
+	sed -i -e 's:noinst_PROG:check_PROG:' tests/Makefile.am || die
+	restore_config src/{bubble,defaults,dnd}.c #428134
+	mv configure.in configure.ac || die
+	eautoreconf
+}
+
+src_configure() {
+	econf --libexecdir="/usr/$(get_libdir)/${PN}"
+}
+
+src_install() {
+	default
+	save_config src/{bubble,defaults,dnd}.c
+	rm -f "${ED}"/usr/share/${PN}/icons/*/*/*/README
+}
+
+pkg_preinst() {
+	gnome2_icon_savelist
+	gnome2_schemas_savelist
+}
+
+pkg_postinst() {
+	gnome2_icon_cache_update
+	gnome2_schemas_update
+}
+
+pkg_postrm() {
+	gnome2_icon_cache_update
+	gnome2_schemas_update
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/879035

Signed-off-by: Pascal Jäger <pascal.jaeger@leimstift.de>