### PR TITLE
net-ftp/atftp: does not run with CFLAGS=-lto

### DIFF
--- a/net-ftp/atftp/atftp-0.8.0.ebuild
+++ b/net-ftp/atftp/atftp-0.8.0.ebuild
@@ -38,6 +38,8 @@ src_prepare() {
 }
 
 src_configure() {
+	filter-lto # https://bugs.gentoo.org/876939
+
 	econf \
 		$(use_enable tcpd libwrap) \
 		$(use_enable readline libreadline) \


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/876939
Signed-off-by: Martin Dummer <martin.dummer@gmx.net>