### PR TITLE
x11-libs/libICE: Bump to 1.1.0-r1, adding C++ interop fix

### DIFF
--- a/x11-libs/libICE/files/libICE-1.1.0-static-assert-fix.patch
+++ b/x11-libs/libICE/files/libICE-1.1.0-static-assert-fix.patch
@@ -1,0 +1,32 @@
+From e176b676cff17948d68299c00dddefe41638c752 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Arsen=20Arsenovi=C4=87?= <arsen@aarsen.me>
+Date: Sun, 4 Dec 2022 22:19:20 +0100
+Subject: [PATCH] ICEmsg: Fix C++ interoperability error due to static_assert
+ define
+
+Commit 0269c687e954db7aca2a4344e32cb203315a00b6 added a static_assert helper
+that gets defined to blank if left undefined by assert.h.  As this is not a
+macro in other languages that use this header, this can lead to a compile-time
+error.
+
+Bug: https://bugs.gentoo.org/884369
+---
+ include/X11/ICE/ICEmsg.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/X11/ICE/ICEmsg.h b/include/X11/ICE/ICEmsg.h
+index b6bad13..13e1509 100644
+--- a/include/X11/ICE/ICEmsg.h
++++ b/include/X11/ICE/ICEmsg.h
+@@ -34,7 +34,7 @@ Author: Ralph Mor, X Consortium
+ #include <X11/ICE/ICEconn.h>
+ 
+ #include <assert.h>
+-#ifndef static_assert
++#if !defined(__cplusplus) && !defined(static_assert)
+ #define static_assert(cond, msg) /* skip for non-C11 compilers */
+ #endif
+ 
+-- 
+GitLab
+

--- a/x11-libs/libICE/libICE-1.1.0-r1.ebuild
+++ b/x11-libs/libICE/libICE-1.1.0-r1.ebuild
@@ -1,0 +1,30 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+XORG_MULTILIB=yes
+XORG_TARBALL_SUFFIX="xz"
+inherit xorg-3
+
+DESCRIPTION="X.Org Inter-Client Exchange library"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris ~x86-winnt"
+
+DEPEND="x11-base/xorg-proto
+	x11-libs/xtrans"
+RDEPEND="${DEPEND}
+	elibc_glibc? (
+		|| ( >=sys-libs/glibc-2.36 dev-libs/libbsd[${MULTILIB_USEDEP}] )
+	)
+"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-1.1.0-static-assert-fix.patch"
+)
+
+XORG_CONFIGURE_OPTIONS=(
+	--enable-ipv6
+	--disable-docs
+	--disable-specs
+	--without-fop
+)


### PR DESCRIPTION
An upstream change lead to C++ programs (notably, Qt/KDE) being unable to build with this version of libICE.  The included patch was merged upstream already.

Closes: https://bugs.gentoo.org/884369
Signed-off-by: Arsen Arsenović <arsen@aarsen.me>