### PR TITLE
app-shells/bash-completion: use the correct eselect module name

### DIFF
--- a/app-shells/bash-completion/metadata.xml
+++ b/app-shells/bash-completion/metadata.xml
@@ -11,7 +11,7 @@
 	</maintainer>
 	<use>
 		<flag name="eselect">
-			Support blacklisting of completions via 'eselect bash-completion'.
+			Support blacklisting of completions via 'eselect bashcomp'.
 			This enables custom Gentoo patching of upstream completion loader.
 		</flag>
 	</use>


### PR DESCRIPTION
Signed-off-by: Chris Mayo <aklhfex@gmail.com>