### PR TITLE
app-arch/libarchive: Add patch to fix CVE-2022-36227.

### DIFF
--- a/app-arch/libarchive/files/libarchive-3.6.1-CVE-2022-36227.patch
+++ b/app-arch/libarchive/files/libarchive-3.6.1-CVE-2022-36227.patch
@@ -1,0 +1,35 @@
+From bff38efe8c110469c5080d387bec62a6ca15b1a5 Mon Sep 17 00:00:00 2001
+From: obiwac <obiwac@gmail.com>
+Date: Fri, 22 Jul 2022 22:41:10 +0200
+Subject: [PATCH] libarchive: Handle a `calloc` returning NULL (fixes #1754)
+
+---
+ libarchive/archive_write.c | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/libarchive/archive_write.c b/libarchive/archive_write.c
+index 66592e826..27626b541 100644
+--- a/libarchive/archive_write.c
++++ b/libarchive/archive_write.c
+@@ -201,6 +201,10 @@ __archive_write_allocate_filter(struct archive *_a)
+ 	struct archive_write_filter *f;
+ 
+ 	f = calloc(1, sizeof(*f));
++
++	if (f == NULL)
++		return (NULL);
++
+ 	f->archive = _a;
+ 	f->state = ARCHIVE_WRITE_FILTER_STATE_NEW;
+ 	if (a->filter_first == NULL)
+@@ -548,6 +552,10 @@ archive_write_open2(struct archive *_a, void *client_data,
+ 	a->client_data = client_data;
+ 
+ 	client_filter = __archive_write_allocate_filter(_a);
++
++	if (client_filter == NULL)
++		return (ARCHIVE_FATAL);
++
+ 	client_filter->open = archive_write_client_open;
+ 	client_filter->write = archive_write_client_write;
+ 	client_filter->close = archive_write_client_close;

--- a/app-arch/libarchive/libarchive-3.6.1.ebuild
+++ b/app-arch/libarchive/libarchive-3.6.1.ebuild
@@ -47,6 +47,7 @@ BDEPEND="
 
 PATCHES=(
 	"${FILESDIR}"/${P}-glibc-2.36.patch
+	"${FILESDIR}"/${P}-CVE-2022-36227.patch
 )
 
 multilib_src_configure() {


### PR DESCRIPTION
New version is not released in libarchive with the CVE-2022-36227 fix.

Closes: https://bugs.gentoo.org/882521
Signed-off-by: Meena Shanmugam <meenashanmugam@google.com>