### PR TITLE
dev-ml/lablgtk: Improve use flag metadata section

### DIFF
--- a/dev-ml/lablgtk/metadata.xml
+++ b/dev-ml/lablgtk/metadata.xml
@@ -10,9 +10,15 @@
 		<name>Mark Wright</name>
 	</maintainer>
 	<use>
-		<flag name="glade">Enable libglade bindings compilation.</flag>
-		<flag name="gnomecanvas">Enable libgnomecanvas bindings compilation.</flag>
-		<flag name="sourceview">Enable GtkSourceView support</flag>
+		<flag name="glade" restrict="&lt;dev-ml/lablgtki-3">
+			Enable <pkg>gnome-base/libglade</pkg> bindings compilation
+		</flag>
+		<flag name="gnomecanvas" restrict="&lt;dev-ml/lablgtki-3">
+			Enable <pkg>gnome-base/libgnomecanvas</pkg> bindings compilation
+		</flag>
+		<flag name="sourceview">
+			Enable GtkSourceView (<pkg>x11-libs/gtksourceview</pkg>) support
+		</flag>
 	</use>
 	<upstream>
 		<remote-id type="github">garrigue/lablgtk</remote-id>


### PR DESCRIPTION
- Reference packages with `<pkg>` tag
- Unify flag descriptions by removing trailing dot from first two flags
- Restrict `glade` and `gnomecanvas` flag to `<dev-ml/lablgtk-3`, `dev-ml/lablgtk:3` uses `sourceview` use flag only