### PR TITLE
app-containers/lxd: fix io timeouts

### DIFF
--- a/app-containers/lxd/files/lxd-5.0.1-prevent-io-timeouts.patch
+++ b/app-containers/lxd/files/lxd-5.0.1-prevent-io-timeouts.patch
@@ -1,0 +1,420 @@
+https://github.com/lxc/lxd/issues/10034
+https://github.com/lxc/lxd/pull/11011
+
+From 32fa4576e330ea337e0f138e3c604e07a4e9e325 Mon Sep 17 00:00:00 2001
+From: Thomas Parrott <thomas.parrott@canonical.com>
+Date: Tue, 11 Oct 2022 10:21:04 +0100
+Subject: [PATCH 1/9] lxd/instance/exec: Use cancel.Canceller instead of context
+
+Helps to keep the cancel and wait variables together for clarity.
+
+Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>
+---
+ lxd/instance_exec.go | 23 +++++++++++------------
+ 1 file changed, 11 insertions(+), 12 deletions(-)
+
+diff --git a/lxd/instance_exec.go b/lxd/instance_exec.go
+index 1f8e7ea09878..1153443666c8 100644
+--- a/lxd/instance_exec.go
++++ b/lxd/instance_exec.go
+@@ -27,6 +27,7 @@ import (
+ 	"github.com/lxc/lxd/lxd/state"
+ 	"github.com/lxc/lxd/shared"
+ 	"github.com/lxc/lxd/shared/api"
++	"github.com/lxc/lxd/shared/cancel"
+ 	"github.com/lxc/lxd/shared/logger"
+ 	"github.com/lxc/lxd/shared/netutils"
+ 	"github.com/lxc/lxd/shared/version"
+@@ -43,10 +44,8 @@ type execWs struct {
+ 	instance              instance.Instance
+ 	conns                 map[int]*websocket.Conn
+ 	connsLock             sync.Mutex
+-	requiredConnectedCtx  context.Context
+-	requiredConnectedDone func()
+-	controlConnectedCtx   context.Context
+-	controlConnectedDone  func()
++	waitRequiredConnected *cancel.Canceller
++	waitControlConnected  *cancel.Canceller
+ 	fds                   map[int]string
+ 	s                     *state.State
+ }
+@@ -90,7 +89,7 @@ func (s *execWs) Connect(op *operations.Operation, r *http.Request, w http.Respo
+ 				s.conns[fd] = conn
+ 
+ 				if fd == execWSControl {
+-					s.controlConnectedDone() // Control connection connected.
++					s.waitControlConnected.Cancel() // Control connection connected.
+ 				}
+ 
+ 				for i, c := range s.conns {
+@@ -109,7 +108,7 @@ func (s *execWs) Connect(op *operations.Operation, r *http.Request, w http.Respo
+ 					}
+ 				}
+ 
+-				s.requiredConnectedDone() // All required connections now connected.
++				s.waitRequiredConnected.Cancel() // All required connections now connected.
+ 				return nil
+ 			} else if !found {
+ 				return fmt.Errorf("Unknown websocket number")
+@@ -140,7 +139,7 @@ func (s *execWs) Do(op *operations.Operation) error {
+ 	// connect to all of the required websockets within a short period of time and we won't proceed until then.
+ 	logger.Debug("Waiting for exec websockets to connect")
+ 	select {
+-	case <-s.requiredConnectedCtx.Done():
++	case <-s.waitRequiredConnected.Done():
+ 		break
+ 	case <-time.After(time.Second * 5):
+ 		return fmt.Errorf("Timed out waiting for websockets to connect")
+@@ -240,7 +239,7 @@ func (s *execWs) Do(op *operations.Operation) error {
+ 		s.connsLock.Unlock()
+ 
+ 		if conn == nil {
+-			s.controlConnectedDone() // Request control go routine to end if no control connection.
++			s.waitControlConnected.Cancel() // Request control go routine to end if no control connection.
+ 		} else {
+ 			err = conn.Close() // Close control connection (will cause control go routine to end).
+ 			if err != nil && cmdErr == nil {
+@@ -286,7 +285,7 @@ func (s *execWs) Do(op *operations.Operation) error {
+ 	go func() {
+ 		defer wgEOF.Done()
+ 
+-		<-s.controlConnectedCtx.Done() // Indicates control connection has started or command has ended.
++		<-s.waitControlConnected.Done() // Indicates control connection has started or command has ended.
+ 
+ 		s.connsLock.Lock()
+ 		conn := s.conns[execWSControl]
+@@ -430,7 +429,7 @@ func (s *execWs) Do(op *operations.Operation) error {
+ 						// can also be used indicate that the command has already finished.
+ 						// In either case there is no need to kill the command, but if not
+ 						// then it is our responsibility to kill the command now.
+-						if s.controlConnectedCtx.Err() == nil {
++						if s.waitControlConnected.Err() == nil {
+ 							l.Warn("Unexpected read on stdout websocket, killing command", logger.Ctx{"number": i, "err": err})
+ 							cmdKillOnce.Do(cmdKill)
+ 						}
+@@ -627,8 +626,8 @@ func instanceExecPost(d *Daemon, r *http.Request) response.Response {
+ 			ws.conns[execWSStderr] = nil
+ 		}
+ 
+-		ws.requiredConnectedCtx, ws.requiredConnectedDone = context.WithCancel(context.Background())
+-		ws.controlConnectedCtx, ws.controlConnectedDone = context.WithCancel(context.Background())
++		ws.waitRequiredConnected = cancel.New(context.Background())
++		ws.waitControlConnected = cancel.New(context.Background())
+ 
+ 		for i := range ws.conns {
+ 			ws.fds[i], err = shared.RandomCryptoString()
+
+From 2e4e513ac82a8498ee224cddce98163e3f7004a2 Mon Sep 17 00:00:00 2001
+From: Thomas Parrott <thomas.parrott@canonical.com>
+Date: Tue, 11 Oct 2022 10:21:30 +0100
+Subject: [PATCH 2/9] lxd/instance/exec: Fix comment typo
+
+Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>
+---
+ lxd/instance_exec.go | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lxd/instance_exec.go b/lxd/instance_exec.go
+index 1153443666c8..610191e81e3e 100644
+--- a/lxd/instance_exec.go
++++ b/lxd/instance_exec.go
+@@ -97,7 +97,7 @@ func (s *execWs) Connect(op *operations.Operation, r *http.Request, w http.Respo
+ 						// Due to a historical bug in the LXC CLI command, we cannot force
+ 						// the client to connect a control socket when in non-interactive
+ 						// mode. This is because the older CLI tools did not connect this
+-						// channel and so we would prevent the older CLIs connecitng to
++						// channel and so we would prevent the older CLIs connecting to
+ 						// newer servers. So skip the control connection from being
+ 						// considered as a required connection in this case.
+ 						continue
+
+From 520fdb819a8e9a4b5269caca2ab236279a96f1c1 Mon Sep 17 00:00:00 2001
+From: Thomas Parrott <thomas.parrott@canonical.com>
+Date: Tue, 11 Oct 2022 10:51:17 +0100
+Subject: [PATCH 3/9] lxd/instance/exec: Convert attachedChildIsDead channel to
+ cancel.Canceller
+
+Due to it being more flexible to use.
+
+Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>
+---
+ lxd/instance_exec.go | 14 +++++---------
+ 1 file changed, 5 insertions(+), 9 deletions(-)
+
+diff --git a/lxd/instance_exec.go b/lxd/instance_exec.go
+index 610191e81e3e..94e57cbcfc9a 100644
+--- a/lxd/instance_exec.go
++++ b/lxd/instance_exec.go
+@@ -222,13 +222,13 @@ func (s *execWs) Do(op *operations.Operation) error {
+ 		stderr = ttys[execWSStderr]
+ 	}
+ 
+-	attachedChildIsDead := make(chan struct{})
++	waitAttachedChildIsDead := cancel.New(context.Background())
+ 	var wgEOF sync.WaitGroup
+ 
+ 	// Define a function to clean up TTYs and sockets when done.
+ 	finisher := func(cmdResult int, cmdErr error) error {
+ 		// Close this before closing the control connection so control handler can detect command ending.
+-		close(attachedChildIsDead)
++		waitAttachedChildIsDead.Cancel()
+ 
+ 		for _, tty := range ttys {
+ 			_ = tty.Close()
+@@ -302,10 +302,8 @@ func (s *execWs) Do(op *operations.Operation) error {
+ 			mt, r, err := conn.NextReader()
+ 			if err != nil || mt == websocket.CloseMessage {
+ 				// Check if command process has finished normally, if so, no need to kill it.
+-				select {
+-				case <-attachedChildIsDead:
++				if waitAttachedChildIsDead.Err() != nil {
+ 					return
+-				default:
+ 				}
+ 
+ 				if mt == websocket.CloseMessage {
+@@ -322,10 +320,8 @@ func (s *execWs) Do(op *operations.Operation) error {
+ 			buf, err := io.ReadAll(r)
+ 			if err != nil {
+ 				// Check if command process has finished normally, if so, no need to kill it.
+-				select {
+-				case <-attachedChildIsDead:
++				if waitAttachedChildIsDead.Err() != nil {
+ 					return
+-				default:
+ 				}
+ 
+ 				l.Warn("Failed reading control websocket message, killing command", logger.Ctx{"err": err})
+@@ -390,7 +386,7 @@ func (s *execWs) Do(op *operations.Operation) error {
+ 			if s.instance.Type() == instancetype.Container {
+ 				// For containers, we are running the command via the local LXD managed PTY and so
+ 				// need special signal handling provided by netutils.WebsocketExecMirror.
+-				readDone, writeDone = netutils.WebsocketExecMirror(conn, ptys[0], ptys[0], attachedChildIsDead, int(ptys[0].Fd()))
++				readDone, writeDone = netutils.WebsocketExecMirror(conn, ptys[0], ptys[0], waitAttachedChildIsDead.Done(), int(ptys[0].Fd()))
+ 			} else {
+ 				// For VMs we are just relaying the websockets between client and lxd-agent, so no
+ 				// need for the special signal handling provided by netutils.WebsocketExecMirror.
+
+From 69ffd987d66d61ec9dcaf403926d03b7e62e8559 Mon Sep 17 00:00:00 2001
+From: Thomas Parrott <thomas.parrott@canonical.com>
+Date: Tue, 11 Oct 2022 10:51:49 +0100
+Subject: [PATCH 4/9] shared/netutils/network/linux: Update WebsocketExecMirror
+ to support the channel returned from context.Done()
+
+Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>
+---
+ shared/netutils/network_linux.go | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/shared/netutils/network_linux.go b/shared/netutils/network_linux.go
+index efeadb8cafa0..06998de9fae9 100644
+--- a/shared/netutils/network_linux.go
++++ b/shared/netutils/network_linux.go
+@@ -12,7 +12,7 @@ import (
+ )
+ 
+ // WebsocketExecMirror mirrors a websocket connection with a set of Writer/Reader.
+-func WebsocketExecMirror(conn *websocket.Conn, w io.WriteCloser, r io.ReadCloser, exited chan struct{}, fd int) (chan bool, chan bool) {
++func WebsocketExecMirror(conn *websocket.Conn, w io.WriteCloser, r io.ReadCloser, exited <-chan struct{}, fd int) (chan bool, chan bool) {
+ 	readDone := make(chan bool, 1)
+ 	writeDone := make(chan bool, 1)
+ 
+
+From 3c1b3cc3a5185887ade9d82ec56e8c6cae45d830 Mon Sep 17 00:00:00 2001
+From: Thomas Parrott <thomas.parrott@canonical.com>
+Date: Tue, 11 Oct 2022 10:54:59 +0100
+Subject: [PATCH 5/9] lxd/events/connections: Use time.NewTicker in Reader
+
+As is more efficient than creating repeated timers on each for loop iteration.
+
+Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>
+---
+ lxd/events/connections.go | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/lxd/events/connections.go b/lxd/events/connections.go
+index eae220e4c2d1..03640a138640 100644
+--- a/lxd/events/connections.go
++++ b/lxd/events/connections.go
+@@ -100,6 +100,9 @@ func (e *websockListenerConnection) Reader(ctx context.Context, recvFunc EventHa
+ 		}
+ 	}()
+ 
++	t := time.NewTicker(pingInterval)
++	defer t.Stop()
++
+ 	for {
+ 		if ctx.Err() != nil {
+ 			return
+@@ -121,7 +124,7 @@ func (e *websockListenerConnection) Reader(ctx context.Context, recvFunc EventHa
+ 		e.lock.Unlock()
+ 
+ 		select {
+-		case <-time.After(pingInterval):
++		case <-t.C:
+ 		case <-ctx.Done():
+ 			return
+ 		}
+
+From 5881e00af8631eecd61cb0cb0e2939f0a237d270 Mon Sep 17 00:00:00 2001
+From: Thomas Parrott <thomas.parrott@canonical.com>
+Date: Tue, 11 Oct 2022 12:02:45 +0100
+Subject: [PATCH 6/9] lxd/migrate: Don't shadow error in Connect
+
+Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>
+---
+ lxd/migrate.go | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lxd/migrate.go b/lxd/migrate.go
+index 601a5fe940f6..6544a8a1c432 100644
+--- a/lxd/migrate.go
++++ b/lxd/migrate.go
+@@ -193,7 +193,7 @@ func (s *migrationSourceWs) Connect(op *operations.Operation, r *http.Request, w
+ 	if err != nil {
+ 		logger.Error("Failed extracting TCP connection from remote connection", logger.Ctx{"err": err})
+ 	} else {
+-		err := tcp.SetTimeouts(remoteTCP)
++		err = tcp.SetTimeouts(remoteTCP)
+ 		if err != nil {
+ 			logger.Error("Failed setting TCP timeouts on remote connection", logger.Ctx{"err": err})
+ 		}
+
+From 306ad728e6c38e9fbc2037174d574d4f3c276576 Mon Sep 17 00:00:00 2001
+From: Thomas Parrott <thomas.parrott@canonical.com>
+Date: Tue, 11 Oct 2022 12:02:58 +0100
+Subject: [PATCH 7/9] client/lxd: Set TCP timeout options in rawWebsocket
+
+Affects event and exec channels.
+
+This should also be set from the LXD server side so that the TCP keepalive settings are used
+on both sides of an intermediate proxy.
+
+Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>
+---
+ client/lxd.go | 12 +++++++++++-
+ 1 file changed, 11 insertions(+), 1 deletion(-)
+
+diff --git a/client/lxd.go b/client/lxd.go
+index 48779580bcde..00949ddf14fd 100644
+--- a/client/lxd.go
++++ b/client/lxd.go
+@@ -19,6 +19,7 @@ import (
+ 	"github.com/lxc/lxd/shared"
+ 	"github.com/lxc/lxd/shared/api"
+ 	"github.com/lxc/lxd/shared/logger"
++	"github.com/lxc/lxd/shared/tcp"
+ )
+ 
+ // ProtocolLXD represents a LXD API server.
+@@ -427,10 +428,19 @@ func (r *ProtocolLXD) rawWebsocket(url string) (*websocket.Conn, error) {
+ 		return nil, err
+ 	}
+ 
++	// Set TCP timeout options.
++	remoteTCP, _ := tcp.ExtractConn(conn.UnderlyingConn())
++	if remoteTCP != nil {
++		err = tcp.SetTimeouts(remoteTCP)
++		if err != nil {
++			logger.Error("Failed setting TCP timeouts on remote connection", logger.Ctx{"err": err})
++		}
++	}
++
+ 	// Log the data
+ 	logger.Debugf("Connected to the websocket: %v", url)
+ 
+-	return conn, err
++	return conn, nil
+ }
+ 
+ func (r *ProtocolLXD) websocket(path string) (*websocket.Conn, error) {
+
+From 10c78c000b4099f98b8cd06f752d032a5264c4a3 Mon Sep 17 00:00:00 2001
+From: Thomas Parrott <thomas.parrott@canonical.com>
+Date: Tue, 11 Oct 2022 12:05:18 +0100
+Subject: [PATCH 8/9] lxd/instance/exec: Adds TCP and application level
+ keepalives and timeouts to each websocket
+
+So if there is an intermediate proxy that has read timeouts set, the application level keepalive
+request/responses will keep the connection alive.
+
+Fixes #10034
+
+Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>
+---
+ lxd/instance_exec.go | 26 ++++++++++++++++++++++++++
+ 1 file changed, 26 insertions(+)
+
+diff --git a/lxd/instance_exec.go b/lxd/instance_exec.go
+index 94e57cbcfc9a..162bb8c4927e 100644
+--- a/lxd/instance_exec.go
++++ b/lxd/instance_exec.go
+@@ -30,6 +30,7 @@ import (
+ 	"github.com/lxc/lxd/shared/cancel"
+ 	"github.com/lxc/lxd/shared/logger"
+ 	"github.com/lxc/lxd/shared/netutils"
++	"github.com/lxc/lxd/shared/tcp"
+ 	"github.com/lxc/lxd/shared/version"
+ )
+ 
+@@ -88,6 +89,31 @@ func (s *execWs) Connect(op *operations.Operation, r *http.Request, w http.Respo
+ 			if found && val == nil {
+ 				s.conns[fd] = conn
+ 
++				// Set TCP timeout options.
++				remoteTCP, _ := tcp.ExtractConn(conn.UnderlyingConn())
++				if remoteTCP != nil {
++					err = tcp.SetTimeouts(remoteTCP)
++					if err != nil {
++						logger.Error("Failed setting TCP timeouts on remote connection", logger.Ctx{"err": err})
++					}
++				}
++
++				// Start channel keep alive to run until channel is closed.
++				go func() {
++					pingInterval := time.Second * 10
++					t := time.NewTicker(pingInterval)
++					defer t.Stop()
++
++					for {
++						err := conn.WriteControl(websocket.PingMessage, []byte("keepalive"), time.Now().Add(5*time.Second))
++						if err != nil {
++							return
++						}
++
++						<-t.C
++					}
++				}()
++
+ 				if fd == execWSControl {
+ 					s.waitControlConnected.Cancel() // Control connection connected.
+ 				}
+
+From 52fe8ced024164634f7d50441da74d5d567c3d9a Mon Sep 17 00:00:00 2001
+From: Thomas Parrott <thomas.parrott@canonical.com>
+Date: Tue, 11 Oct 2022 12:20:36 +0100
+Subject: [PATCH 9/9] client/lxd/instances: Don't modify err in rawSFTPConn
+ when getting underlying TCP connection
+
+Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>
+---
+ client/lxd_instances.go | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/client/lxd_instances.go b/client/lxd_instances.go
+index 66cb821a327e..ae90f7e2b9d4 100644
+--- a/client/lxd_instances.go
++++ b/client/lxd_instances.go
+@@ -1387,9 +1387,9 @@ func (r *ProtocolLXD) rawSFTPConn(apiURL *url.URL) (net.Conn, error) {
+ 		return nil, err
+ 	}
+ 
+-	tcpConn, err := tcp.ExtractConn(conn)
+-	if err == nil {
+-		err = tcp.SetTimeouts(tcpConn)
++	remoteTCP, _ := tcp.ExtractConn(conn)
++	if remoteTCP != nil {
++		err = tcp.SetTimeouts(remoteTCP)
+ 		if err != nil {
+ 			return nil, err
+ 		}

--- a/app-containers/lxd/lxd-5.0.1-r3.ebuild
+++ b/app-containers/lxd/lxd-5.0.1-r3.ebuild
@@ -1,0 +1,193 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit bash-completion-r1 go-module linux-info optfeature systemd verify-sig
+
+DESCRIPTION="Modern, secure and powerful system container and virtual machine manager"
+HOMEPAGE="https://linuxcontainers.org/lxd/introduction/ https://github.com/lxc/lxd"
+SRC_URI="https://linuxcontainers.org/downloads/lxd/${P}.tar.gz
+	verify-sig? ( https://linuxcontainers.org/downloads/lxd/${P}.tar.gz.asc )"
+
+LICENSE="Apache-2.0"
+SLOT="0"
+KEYWORDS="~amd64 ~arm64 ~x86"
+IUSE="apparmor ipv6 nls verify-sig"
+
+DEPEND="acct-group/lxd
+	app-arch/xz-utils
+	>=app-containers/lxc-3.0.0[apparmor?,seccomp(+)]
+	dev-db/sqlite:3
+	dev-libs/dqlite:=
+	dev-libs/lzo
+	dev-libs/raft[lz4]
+	>=dev-util/xdelta-3.0[lzma(+)]
+	net-dns/dnsmasq[dhcp,ipv6(+)?]
+	sys-libs/libcap
+	virtual/udev"
+RDEPEND="${DEPEND}
+	net-firewall/ebtables
+	net-firewall/iptables[ipv6(+)?]
+	sys-apps/iproute2[ipv6(+)?]
+	sys-fs/fuse:*
+	>=sys-fs/lxcfs-5.0.0
+	sys-fs/squashfs-tools[lzma]
+	virtual/acl"
+BDEPEND="dev-lang/go
+	nls? ( sys-devel/gettext )
+	verify-sig? ( sec-keys/openpgp-keys-linuxcontainers )"
+
+CONFIG_CHECK="
+	~CGROUPS
+	~IPC_NS
+	~NET_NS
+	~PID_NS
+
+	~SECCOMP
+	~USER_NS
+	~UTS_NS
+
+	~KVM
+	~MACVTAP
+	~VHOST_VSOCK
+"
+
+ERROR_IPC_NS="CONFIG_IPC_NS is required."
+ERROR_NET_NS="CONFIG_NET_NS is required."
+ERROR_PID_NS="CONFIG_PID_NS is required."
+ERROR_SECCOMP="CONFIG_SECCOMP is required."
+ERROR_UTS_NS="CONFIG_UTS_NS is required."
+
+WARNING_KVM="CONFIG_KVM and CONFIG_KVM_AMD/-INTEL is required for virtual machines."
+WARNING_MACVTAP="CONFIG_MACVTAP is required for virtual machines."
+WARNING_VHOST_VSOCK="CONFIG_VHOST_VSOCK is required for virtual machines."
+
+# Go magic.
+QA_PREBUILT="/usr/bin/fuidshift
+	/usr/bin/lxc
+	/usr/bin/lxc-to-lxd
+	/usr/bin/lxd-agent
+	/usr/bin/lxd-benchmark
+	/usr/bin/lxd-migrate
+	/usr/sbin/lxd"
+
+VERIFY_SIG_OPENPGP_KEY_PATH=${BROOT}/usr/share/openpgp-keys/linuxcontainers.asc
+
+# The testsuite must be run as root.
+# make: *** [Makefile:156: check] Error 1
+RESTRICT="test"
+
+GOPATH="${S}/_dist"
+
+# Fixed on lxd-5.7. Waiting for downstream
+PATCHES="${FILESDIR}/${P}-prevent-io-timeouts.patch"
+
+src_prepare() {
+	export GOPATH="${S}/_dist"
+
+	default
+
+	sed -i \
+		-e "s:\./configure:./configure --prefix=/usr --libdir=${EPREFIX}/usr/lib/lxd:g" \
+		-e "s:make:make ${MAKEOPTS}:g" \
+		Makefile || die
+
+	# Fix hardcoded ovmf file path, see bug 763180
+	sed -i \
+		-e "s:/usr/share/OVMF:/usr/share/edk2-ovmf:g" \
+		-e "s:OVMF_VARS.ms.fd:OVMF_VARS.fd:g" \
+		doc/environment.md \
+		lxd/apparmor/instance.go \
+		lxd/apparmor/instance_qemu.go \
+		lxd/instance/drivers/driver_qemu.go || die "Failed to fix hardcoded ovmf paths."
+
+	# Fix hardcoded virtfs-proxy-helper file path, see bug 798924
+	sed -i \
+		-e "s:/usr/lib/qemu/virtfs-proxy-helper:/usr/libexec/virtfs-proxy-helper:g" \
+		lxd/device/device_utils_disk.go || die "Failed to fix virtfs-proxy-helper path."
+
+	cp "${FILESDIR}"/lxd-4.0.9-r1.service "${T}"/lxd.service || die
+	if use apparmor; then
+		sed -i \
+			'/^EnvironmentFile=.*/a ExecStartPre=\/usr\/libexec\/lxc\/lxc-apparmor-load' \
+			"${T}"/lxd.service || die
+	fi
+
+	# Disable -Werror's from go modules.
+	find "${S}" -name "cgo.go" -exec sed -i "s/ -Werror / /g" {} + || die
+}
+
+src_configure() { :; }
+
+src_compile() {
+	export GOPATH="${S}/_dist"
+	export CGO_LDFLAGS_ALLOW="-Wl,-z,now"
+
+	for k in fuidshift lxd-benchmark lxc lxc-to-lxd; do
+		go install -v -x "${S}/${k}" || die "failed compiling ${k}"
+	done
+
+	go install -v -x -tags libsqlite3 "${S}"/lxd || die "Failed to build the daemon"
+
+	# Needs to be built statically
+	CGO_ENABLED=0 go install -v -tags netgo "${S}"/lxd-migrate
+	CGO_ENABLED=0 go install -v -tags agent,netgo "${S}"/lxd-agent
+
+	use nls && emake build-mo
+}
+
+src_test() {
+	emake check
+}
+
+src_install() {
+	export GOPATH="${S}/_dist"
+	local bindir="_dist/bin"
+
+	dosbin ${bindir}/lxd
+
+	for l in fuidshift lxd-agent lxd-benchmark lxd-migrate lxc lxc-to-lxd; do
+		dobin ${bindir}/${l}
+	done
+
+	newbashcomp scripts/bash/lxd-client lxc
+
+	newconfd "${FILESDIR}"/lxd-4.0.0.confd lxd
+	newinitd "${FILESDIR}"/lxd-4.0.9.initd lxd
+
+	systemd_dounit "${T}"/lxd.service
+	systemd_newunit "${FILESDIR}"/lxd-containers-4.0.0.service lxd-containers.service
+	systemd_newunit "${FILESDIR}"/lxd-4.0.0.socket lxd.socket
+
+	dodoc AUTHORS
+	dodoc -r doc/*
+	use nls && domo po/*.mo
+}
+
+pkg_postinst() {
+	elog
+	elog "Consult https://wiki.gentoo.org/wiki/LXD for more information,"
+	elog "including a Quick Start."
+	elog "For virtual machine support, see:"
+	elog "https://wiki.gentoo.org/wiki/LXD#Virtual_machines"
+	elog
+	elog "Please run 'lxc-checkconfig' to see all optional kernel features."
+	elog
+	optfeature "virtual machine support" app-emulation/qemu[spice,usbredir,virtfs]
+	optfeature "btrfs storage backend" sys-fs/btrfs-progs
+	optfeature "lvm2 storage backend" sys-fs/lvm2
+	optfeature "zfs storage backend" sys-fs/zfs
+	elog
+	elog "Be sure to add your local user to the lxd group."
+
+	if [[ -n ${REPLACING_VERSIONS} ]] && has_version app-emulation/qemu[spice,usbredir,virtfs]; then
+		ewarn ""
+		ewarn "You're updating from <5.0.1. Due to incompatible API updates in the lxd-agent"
+		ewarn "product, you'll have to restart any running virtual machines before they work"
+		ewarn "properly."
+		ewarn ""
+		ewarn "Run: 'lxc restart your-vm' after the update for your vm's managed by lxd."
+		ewarn ""
+	fi
+}


### PR DESCRIPTION
Kind ping @juippis.

Following upstream [1], and reported by me too, there were a bug in LXD-5.1 that runs in io timeout after some times (between 5 and 25 mins, it depends). Upsteam was made a patch that is present only in lxd-5.7 [2].
It works on LTS branch (5.1) so here's the patch.

[1] https://github.com/lxc/lxd/issues/10034
[2] https://github.com/lxc/lxd/pull/11011

Signed-off-by: Marco Scardovi <mscardovi@icloud.com>