### PR TITLE
dev-ml/lablgtk: fix typo in restriction

### DIFF
--- a/dev-ml/lablgtk/metadata.xml
+++ b/dev-ml/lablgtk/metadata.xml
@@ -10,10 +10,10 @@
 		<name>Mark Wright</name>
 	</maintainer>
 	<use>
-		<flag name="glade" restrict="&lt;dev-ml/lablgtki-3">
+		<flag name="glade" restrict="&lt;dev-ml/lablgtk-3">
 			Enable <pkg>gnome-base/libglade</pkg> bindings compilation
 		</flag>
-		<flag name="gnomecanvas" restrict="&lt;dev-ml/lablgtki-3">
+		<flag name="gnomecanvas" restrict="&lt;dev-ml/lablgtk-3">
 			Enable <pkg>gnome-base/libgnomecanvas</pkg> bindings compilation
 		</flag>
 		<flag name="sourceview">


### PR DESCRIPTION
This fixes accidental typo in flag restriction from previous commit (PR https://github.com/gentoo/gentoo/pull/28564).

Fixes: 32aeb34cdae5 ("dev-ml/lablgtk: Improve use flag metadata section")