### PR TITLE
app-admin/testdisk: fix clang build

### DIFF
--- a/app-admin/testdisk/files/testdisk-7.1-backport-ntfs-3g-ioctl-prototype.patch
+++ b/app-admin/testdisk/files/testdisk-7.1-backport-ntfs-3g-ioctl-prototype.patch
@@ -1,0 +1,46 @@
+From 2b0a0fcde875a89e2beffbe5c43c7518f682b482 Mon Sep 17 00:00:00 2001
+From: Christophe Grenier <grenier@cgsecurity.org>
+Date: Wed, 6 Apr 2022 07:43:45 +0200
+Subject: [PATCH] src/ntfs_io.c: fix ntfs_device_testdisk_io_ioctl() prototype
+ for ntfs-3g
+
+---
+Gentoo note: link to upstream commit:
+https://git.cgsecurity.org/cgit/testdisk/commit/?id=2b0a0fcde875a89e2beffbe5c43c7518f682b482
+
+ src/ntfs_io.c | 12 ++++++++++++
+ 1 file changed, 12 insertions(+)
+
+diff --git a/src/ntfs_io.c b/src/ntfs_io.c
+index 5ca494a5..fa056724 100644
+--- a/src/ntfs_io.c
++++ b/src/ntfs_io.c
+@@ -159,6 +159,7 @@ static int ntfs_device_testdisk_io_stat(struct ntfs_device *dev, struct stat *bu
+ 	return -1;
+ }
+ 
++#ifdef HAVE_LIBNTFS
+ static int ntfs_device_testdisk_io_ioctl(struct ntfs_device *dev, int request,
+ 		void *argp)
+ {
+@@ -168,6 +169,17 @@ static int ntfs_device_testdisk_io_ioctl(struct ntfs_device *dev, int request,
+ #endif
+ 	return -1;
+ }
++#else
++static int ntfs_device_testdisk_io_ioctl(struct ntfs_device *dev, unsigned long request,
++		void *argp)
++{
++	log_warning( "ntfs_device_testdisk_io_ioctl() unimplemented\n");
++#ifdef ENOTSUP
++	errno = ENOTSUP;
++#endif
++	return -1;
++}
++#endif
+ 
+ /**
+  * Device operations for working with unix style devices and files.
+-- 
+2.37.4
+

--- a/app-admin/testdisk/testdisk-7.1-r2.ebuild
+++ b/app-admin/testdisk/testdisk-7.1-r2.ebuild
@@ -1,0 +1,95 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit flag-o-matic qmake-utils xdg-utils
+
+DESCRIPTION="Checks and undeletes partitions + PhotoRec, signature based recovery tool"
+HOMEPAGE="https://www.cgsecurity.org/wiki/TestDisk"
+SRC_URI="https://www.cgsecurity.org/${P}.tar.bz2"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~hppa ~ppc ~ppc64 ~riscv ~x86"
+IUSE="ewf jpeg ntfs qt5 reiserfs static zlib"
+
+REQUIRED_USE="static? ( !qt5 )"
+
+# WARNING: reiserfs support does NOT work with reiserfsprogs
+# you MUST use progsreiserfs-0.3.1_rc8 (the last version ever released).
+DEPEND="
+	static? (
+		sys-apps/util-linux[static-libs]
+		sys-fs/e2fsprogs[static-libs]
+		sys-libs/ncurses:0[static-libs]
+		jpeg? ( media-libs/libjpeg-turbo:=[static-libs] )
+		ntfs? ( sys-fs/ntfs3g[static-libs] )
+		reiserfs? ( >=sys-fs/progsreiserfs-0.3.1_rc8[static-libs] )
+		zlib? ( sys-libs/zlib[static-libs] )
+		!arm? ( ewf? ( app-forensics/libewf[static-libs] ) )
+	)
+	!static? (
+		sys-apps/util-linux
+		sys-fs/e2fsprogs
+		sys-libs/ncurses:0=
+		jpeg? ( media-libs/libjpeg-turbo:= )
+		ntfs? ( sys-fs/ntfs3g:= )
+		qt5? (
+			dev-qt/qtcore:5
+			dev-qt/qtgui:5
+			dev-qt/qtwidgets:5
+		)
+		reiserfs? ( >=sys-fs/progsreiserfs-0.3.1_rc8 )
+		zlib? ( sys-libs/zlib )
+		!arm? ( ewf? ( app-forensics/libewf:= ) )
+	)
+"
+RDEPEND="!static? ( ${DEPEND} )"
+BDEPEND="qt5? ( dev-qt/linguist-tools:5 )"
+
+DOCS=()
+
+PATCHES=(
+	"${FILESDIR}"/${P}-backport-ntfs-3g-ioctl-prototype.patch
+)
+
+src_configure() {
+	export PATH="$(qt5_get_bindir):${PATH}"
+
+	local myconf=(
+		--enable-sudo
+		--without-ntfs
+		$(use_with ewf)
+		$(use_with jpeg)
+		$(use_with ntfs ntfs3g)
+		$(use_enable qt5 qt)
+		$(use_with reiserfs)
+		$(use_with zlib)
+	)
+
+	# this static method is the same used by upstream for their 'static' make
+	# target, but better, as it doesn't break.
+	use static && append-ldflags -static
+
+	econf "${myconf[@]}"
+
+	# perform safety checks for NTFS, REISERFS and JPEG
+	if use ntfs && ! grep -E -q '^#define HAVE_LIBNTFS(3G)? 1$' "${S}"/config.h ; then
+		die "Failed to find either NTFS or NTFS-3G library."
+	fi
+	if use reiserfs && grep -E -q 'undef HAVE_LIBREISERFS\>' "${S}"/config.h ; then
+		die "Failed to find reiserfs library."
+	fi
+	if use jpeg && grep -E -q 'undef HAVE_LIBJPEG\>' "${S}"/config.h ; then
+		die "Failed to find jpeg library."
+	fi
+}
+
+pkg_postinst() {
+	xdg_icon_cache_update
+}
+
+pkg_postrm() {
+	xdg_icon_cache_update
+}


### PR DESCRIPTION
Backport the ntfs-3g ioctl prototype fixes from upstream master.

Closes: https://bugs.gentoo.org/875509
Signed-off-by: Oskari Pirhonen <xxc3ncoredxx@gmail.com>