### PR TITLE
app-text/xournal: clang16 fix

### DIFF
--- a/app-text/xournal/files/xournal-0.4.8-c99-fix.patch
+++ b/app-text/xournal/files/xournal-0.4.8-c99-fix.patch
@@ -1,0 +1,89 @@
+Bug: https://bugs.gentoo.org/875158
+
+Patch: https://src.fedoraproject.org/rpms/xournal/raw/dacd5bf30ec95debca62946868d9450f68ea54de/f/xournal-c99-1.patch
+Patch: https://src.fedoraproject.org/rpms/xournal/raw/dacd5bf30ec95debca62946868d9450f68ea54de/f/xournal-c99-2.patch
+Author: Denis Auroux <auroux@users.sourceforge.net>
+Date:   Sun Jan 24 15:48:16 2021 -0500
+
+    Fix implicit function declarations by including config.h in ttsubset/*.c
+
+--- a/src/ttsubset/list.c
++++ b/src/ttsubset/list.c
+@@ -33,7 +33,7 @@
+  *
+  */
+ 
+-/* $Id$ */
++/* $Id: list.c,v 1.4 2004/09/10 18:59:06 jody Exp $ */
+ /* @(#)list.c 1.7 03/02/06 SMI */
+ 
+ /*
+@@ -44,6 +44,10 @@
+  *
+  */
+ 
++#ifdef HAVE_CONFIG_H
++#  include <config.h>
++#endif
++
+ #include <stdlib.h>
+ #include <assert.h>
+ #ifdef MALLOC_TRACE
+--- a/src/ttsubset/sft.c
++++ b/src/ttsubset/sft.c
+@@ -33,7 +33,7 @@
+  *
+  */
+ 
+-/* $Id$ */
++/* $Id: sft.c,v 1.9 2005/01/04 20:10:46 jody Exp $ */
+ /* @(#)sft.c 1.17 03/01/08 SMI */
+ 
+ /*
+@@ -43,6 +43,10 @@
+  * @version 1.0
+  */
+ 
++#ifdef HAVE_CONFIG_H
++#  include <config.h>
++#endif
++
+ #include <assert.h>
+ #include <stdlib.h>
+ #include <string.h>
+--- a/src/ttsubset/ttcr.c
++++ b/src/ttsubset/ttcr.c
+@@ -33,7 +33,7 @@
+  *
+  */
+ 
+-/* $Id$ */
++/* $Id: ttcr.c,v 1.7 2005/01/04 20:10:46 jody Exp $ */
+ /* @(#)ttcr.c 1.7 03/01/08 SMI */
+ 
+ /*
+@@ -44,6 +44,10 @@
+  *
+  */
+ 
++#ifdef HAVE_CONFIG_H
++#  include <config.h>
++#endif
++
+ #include <sys/types.h>
+ #ifdef HAVE_UNISTD_H
+ #include <unistd.h>
+
+Add missing include directives for make_dashed, set_cursor_busy.
+
+--- a/src/xo-image.c
++++ b/src/xo-image.c
+@@ -25,6 +25,8 @@
+ #include "xo-support.h"
+ #include "xo-image.h"
+ #include "xo-misc.h"
++#include "xo-selection.h"
++#include "xo-paint.h"
+ 
+ // create pixbuf from buffer, or return NULL on failure
+ GdkPixbuf *pixbuf_from_buffer(const gchar *buf, gsize buflen)

--- a/app-text/xournal/xournal-0.4.8.2016-r1.ebuild
+++ b/app-text/xournal/xournal-0.4.8.2016-r1.ebuild
@@ -1,0 +1,63 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+[[ ${PV} == *9999 ]] && GNOME2_EAUTORECONF=yes
+
+inherit gnome2
+
+if [[ ${PV} == *9999 ]]; then
+	inherit git-r3
+	EGIT_REPO_URI="https://git.code.sf.net/p/xournal/code"
+	unset SRC_URI
+else
+	KEYWORDS="amd64 ~ppc64 ~x86"
+	SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
+fi
+
+DESCRIPTION="An application for notetaking, sketching, and keeping a journal using a stylus"
+HOMEPAGE="http://xournal.sourceforge.net/"
+
+LICENSE="GPL-2"
+SLOT="0"
+IUSE="+pdf vanilla"
+
+COMMONDEPEND="
+	app-text/poppler[cairo]
+	dev-libs/atk
+	dev-libs/glib
+	gnome-base/libgnomecanvas
+	media-libs/freetype
+	media-libs/fontconfig
+	sys-libs/zlib
+	x11-libs/cairo
+	x11-libs/gdk-pixbuf
+	x11-libs/gtk+:2
+	x11-libs/pango
+"
+RDEPEND="${COMMONDEPEND}
+	pdf? ( app-text/poppler[utils] app-text/ghostscript-gpl )
+"
+DEPEND="${COMMONDEPEND}
+	virtual/pkgconfig
+"
+
+PATCHES=(
+	"${FILESDIR}/${PN}"-0.4.8-c99-fix.patch
+)
+
+src_prepare() {
+	default_src_prepare
+	if ! use vanilla; then
+		eapply "${FILESDIR}"/xournal-0.4.8-aspectratio.patch
+	fi
+}
+
+src_install() {
+	emake DESTDIR="${D}" install
+	emake DESTDIR="${D}" desktop-install
+
+	dodoc ChangeLog AUTHORS README
+	dodoc -r html-doc/*
+}


### PR DESCRIPTION
Upstream patch to fix compiling under clang16. Not required for the 9999 build.

Closes: https://bugs.gentoo.org/875158
Co-authoured-by: Denis Auroux <auroux@users.sourceforge.net>
Signed-off-by: Ian Jordan <immoloism@gmail.com>