### PR TITLE
Fix some missing names

### DIFF
--- a/net-news/sfeed/metadata.xml
+++ b/net-news/sfeed/metadata.xml
@@ -3,6 +3,7 @@
 <pkgmetadata>
 	<maintainer type="person">
 		<email>cedk@gentoo.org</email>
+		<name>Cédric Krier</name>
 	</maintainer>
 	<maintainer type="person" proxied="yes">
 		<email>nrk@disroot.org</email>
@@ -12,13 +13,13 @@
 		<email>proxy-maint@gentoo.org</email>
 		<name>Proxy Maintainers</name>
 	</maintainer>
-	<upstream>
-		<bugs-to>mailto:hiltjo@codemadness.org</bugs-to>
-	</upstream>
 	<use>
 		<flag name="theme-mono">Use mono theme</flag>
 		<flag name="theme-mono-highlight">Use mono_highlight theme</flag>
 		<flag name="theme-newsboat">Use newsboat theme</flag>
 		<flag name="theme-templeos">Use templeos theme</flag>
 	</use>
+	<upstream>
+		<bugs-to>mailto:hiltjo@codemadness.org</bugs-to>
+	</upstream>
 </pkgmetadata>

--- a/www-client/w3m/metadata.xml
+++ b/www-client/w3m/metadata.xml
@@ -3,6 +3,7 @@
 <pkgmetadata>
 	<maintainer type="person" proxied="yes">
 		<email>nrk@disroot.org</email>
+		<name>Nickolas Raymond Kaczynski</name>
 	</maintainer>
 	<maintainer type="project" proxied="proxy">
 		<email>proxy-maint@gentoo.org</email>


### PR DESCRIPTION
When a proxy-maint co-maintain a package with a dev, proxy-maintainer is not strictly required so it can be dropped. Also fixing some missing names in order to make pgo happy (atm it shows only emails and not names).