### PR TITLE
app-editors/bluefish: revbump, fix build for clang16

### DIFF
--- a/app-editors/bluefish/bluefish-2.2.12-r2.ebuild
+++ b/app-editors/bluefish/bluefish-2.2.12-r2.ebuild
@@ -1,0 +1,98 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+PYTHON_COMPAT=( python3_{8..10} )
+
+MY_P=${P/_/-}
+inherit autotools python-single-r1 xdg
+
+DESCRIPTION="GTK HTML editor for the experienced web designer or programmer"
+HOMEPAGE="https://bluefish.openoffice.nl/"
+SRC_URI="https://www.bennewitz.com/bluefish/stable/source/${MY_P}.tar.bz2"
+
+LICENSE="GPL-3+"
+KEYWORDS="~alpha ~amd64 ~ia64 ~ppc ~ppc64 ~riscv ~sparc ~x86"
+SLOT="0"
+IUSE="gucharmap nls python spell"
+REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
+
+RDEPEND="sys-libs/zlib
+	x11-libs/gtk+:3
+	gucharmap? ( gnome-extra/gucharmap:2.90 )
+	python? ( ${PYTHON_DEPS} )
+	spell? ( app-text/enchant:2 )"
+DEPEND="${RDEPEND}
+	x11-libs/pango"
+BDEPEND=">=dev-libs/glib-2.24:2
+	dev-libs/libxml2:2
+	virtual/pkgconfig
+	nls? (
+		dev-util/intltool
+		sys-devel/gettext
+	)"
+
+S="${WORKDIR}/${MY_P}"
+
+# there actually is just some broken manpage checkup -> not bother
+RESTRICT="test"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-2.2.9-charmap_configure.patch"
+	"${FILESDIR}/${PN}-2.2.9-fix-incompatible-pointer.patch"
+)
+
+pkg_setup() {
+	use python && python-single-r1_pkg_setup
+}
+
+src_prepare() {
+	default
+
+	# eautoreconf seems to no longer kill translation files.
+	eautoreconf
+	sed -i 's:gzip -n $< -c:gzip -n -c $<:' data/bflib/Makefile.* || die "Cannot fix makefile"
+}
+
+src_configure() {
+	CONFIG_SHELL="${BROOT}/bin/bash" econf \
+		--disable-update-databases \
+		--disable-xml-catalog-update \
+		--with-freedesktop_org-appdata="${EPREFIX}"/usr/share/metainfo \
+		--without-gtk2 \
+		$(use_with gucharmap charmap) \
+		$(use_enable nls) \
+		$(use_enable spell spell-check) \
+		$(use_enable python)
+}
+
+src_install() {
+	default
+
+	find "${ED}" -name '*.la' -delete || die
+}
+
+pkg_postinst() {
+	xdg_pkg_postinst
+
+	einfo "Adding XML catalog entries..."
+	"${EPREFIX}"/usr/bin/xmlcatalog  --noout \
+		--add 'public' 'Bluefish/DTD/Bflang' 'bflang.dtd' \
+		--add 'system' 'http://bluefish.openoffice.nl/DTD/bflang.dtd' 'bflang.dtd' \
+		--add 'rewriteURI' 'http://bluefish.openoffice.nl/DTD' '/usr/share/xml/bluefish-unstable' \
+		"${EROOT}"/etc/xml/catalog \
+		|| ewarn "Failed to add XML catalog entries."
+}
+
+pkg_postrm() {
+	xdg_pkg_postrm
+
+	einfo "Removing XML catalog entries..."
+	"${EPREFIX}"/usr/bin/xmlcatalog  --noout \
+		--del 'Bluefish/DTD/Bflang' \
+		--del 'http://bluefish.openoffice.nl/DTD/bflang.dtd' \
+		--del 'http://bluefish.openoffice.nl/DTD' \
+		"${EROOT}"/etc/xml/catalog \
+		|| ewarn "Failed to remove XML catalog entries."
+}

--- a/app-editors/bluefish/files/bluefish-2.2.9-fix-incompatible-pointer.patch
+++ b/app-editors/bluefish/files/bluefish-2.2.9-fix-incompatible-pointer.patch
@@ -1,0 +1,20 @@
+Clang16 will not allow to assign incompatible pointer types by default.
+Therefore we need to and const to the third parameter of this function
+to match the pointer XmlHashScanner this function is later assigned to.
+
+Bug: https://bugs.gentoo.org/882207
+Patch has been sent to upstream here: https://sourceforge.net/p/bluefish/tickets/66/
+ 
+Pascal Jäger <pascal.jaeger@leimstift.de> (2022-12-07)
+
+--- a/src/plugin_infbrowser/infb_dtd.c
++++ b/src/plugin_infbrowser/infb_dtd.c
+@@ -80,7 +80,7 @@ static gchar *infb_dtd_str_content(xmlElementContentPtr ct,gchar *sofar) {
+ 	return ret;
+ }
+ 
+-static void infb_dtd_element_to_group(void *payload, void *data, xmlChar *name) {
++static void infb_dtd_element_to_group(void *payload, void *data,const xmlChar *name) {
+ 	xmlElementPtr el = (xmlElementPtr)payload;
+ 	switch(name[0]) {
+ 		case 'a':case 'b':case 'c':case 'd':case 'e':


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/882207

Signed-off-by: Pascal Jäger <pascal.jaeger@leimstift.de>