### PR TITLE
dev-libs/libxslt: Enable LFS support

### DIFF
--- a/dev-libs/libxslt/libxslt-1.1.37-r1.ebuild
+++ b/dev-libs/libxslt/libxslt-1.1.37-r1.ebuild
@@ -6,7 +6,7 @@ EAPI=8
 # Note: Please bump this in sync with dev-libs/libxml2.
 
 PYTHON_COMPAT=( python3_{8..11} )
-inherit python-r1 multilib-minimal
+inherit flag-o-matic python-r1 multilib-minimal
 
 DESCRIPTION="XSLT libraries and tools"
 HOMEPAGE="https://gitlab.gnome.org/GNOME/libxslt"
@@ -53,6 +53,10 @@ src_prepare() {
 }
 
 multilib_src_configure() {
+	# Remove this after upstream merge request to add AC_SYS_LARGEFILE lands:
+	# https://gitlab.gnome.org/GNOME/libxslt/-/merge_requests/55
+	append-lfs-flags
+
 	libxslt_configure() {
 		ECONF_SOURCE="${S}" econf \
 			--without-python \


### PR DESCRIPTION
switch to using LFS-capable functions:

	fopen   -> fopen64
	gzopen  -> gzopen64
	readdir -> readdir64
	stat    -> stat64