### PR TITLE
sys-cluster/glusterfs: compile vs build deps.

### DIFF
--- a/sys-cluster/glusterfs/glusterfs-10.2-r2.ebuild
+++ b/sys-cluster/glusterfs/glusterfs-10.2-r2.ebuild
@@ -46,8 +46,6 @@ RDEPEND="
 "
 DEPEND="
 	${RDEPEND}
-	sys-devel/bison
-	sys-devel/flex
 	virtual/acl
 	test? ( >=dev-util/cmocka-1.0.1
 		app-benchmarks/dbench
@@ -59,6 +57,8 @@ DEPEND="
 		sys-apps/attr )
 "
 BDEPEND="
+	sys-devel/bison
+	sys-devel/flex
 	virtual/pkgconfig
 "
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/884761
Signed-off-by: Jaco Kroon <jaco@uls.co.za>