### PR TITLE
sci-astronomy/xephem: enable parallel build

### DIFF
--- a/sci-astronomy/xephem/files/xephem-4.1.0-allow-parallel-builds.patch
+++ b/sci-astronomy/xephem/files/xephem-4.1.0-allow-parallel-builds.patch
@@ -1,0 +1,26 @@
+From 89cc80f47cdf71d3a5eae0ea6a2bade329a3e1fb Mon Sep 17 00:00:00 2001
+From: Bernd Waibel <waebbl-gentoo@posteo.net>
+Date: Fri, 9 Dec 2022 12:30:24 +0100
+Subject: [PATCH] allow parallel builds
+
+Ensure all libraries are ready before the final binary is
+going to get linked.
+
+Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>
+--- a/GUI/xephem/Makefile
++++ b/GUI/xephem/Makefile
+@@ -182,9 +182,9 @@ OBJS =			\
+ 	xephem.o	\
+ 	xmisc.o
+ 
+-all: libs xephem xephem.1
++all: xephem xephem.1
+ 
+-xephem: $(INCS) $(OBJS)
++xephem: libs $(INCS) $(OBJS)
+ 	$(CC) $(LDFLAGS) -o $@ $(OBJS) $(LIBS)
+ 
+ xephem.1: xephem.man
+-- 
+2.38.1
+

--- a/sci-astronomy/xephem/metadata.xml
+++ b/sci-astronomy/xephem/metadata.xml
@@ -13,4 +13,7 @@
 		the moons of Jupiter, Saturn and Earth; Mars' and Jupiter's central
 		meridian longitude; Saturn's rings; and Jupiter's Great Red Spot.
 	</longdescription>
+	<upstream>
+		<remote-id type="github">XEphem/XEphem</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/sci-astronomy/xephem/xephem-4.1.0.ebuild
+++ b/sci-astronomy/xephem/xephem-4.1.0.ebuild
@@ -16,9 +16,9 @@ KEYWORDS="amd64 ppc ppc64 x86 ~amd64-linux ~x86-linux"
 
 RDEPEND="
 	dev-libs/openssl:=
-	>=x11-libs/motif-2.3:0
-	virtual/jpeg:0
+	media-libs/libjpeg-turbo:=
 	media-libs/libpng:0=
+	>=x11-libs/motif-2.3:0
 	x11-libs/libXext
 	x11-libs/libXmu
 	x11-libs/libXt
@@ -28,9 +28,12 @@ BDEPEND="sys-apps/groff"
 
 HTML_DOCS=( GUI/xephem/help/. )
 
+# NOTE: order is relevant - parallel build patch requires respect env vars
+# patch to be already applied
 PATCHES=(
 	"${FILESDIR}/${PN}-3.7.7-implicits.patch"
 	"${FILESDIR}/${P}-respect_env_vars.patch"
+	"${FILESDIR}/${P}-allow-parallel-builds.patch"
 )
 
 src_compile() {


### PR DESCRIPTION
- add a patch to allow parallel builds
- add remote-id to make pkgcheck happy
- update obsolete virtual/jpeg dependency and sort deps

Closes: https://bugs.gentoo.org/881813
Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>