### PR TITLE
sys-block/partimage: fix musl build failure

### DIFF
--- a/sys-block/partimage/files/partimage-0.6.9-musl-null-type.patch
+++ b/sys-block/partimage/files/partimage-0.6.9-musl-null-type.patch
@@ -1,0 +1,34 @@
+In newer musl, the type of NULL in C++ is nullptr rather than an
+integer.
+
+Upstream: https://git.musl-libc.org/cgit/musl/commit/?id=98e688a9da5e7b2925dda17a2d6820dddf1fb287
+Bug: https://bugs.gentoo.org/853883
+
+diff --git a/src/server/partimaged-client.cpp b/src/server/partimaged-client.cpp
+index 7c5f856..35b3514 100644
+--- a/src/server/partimaged-client.cpp
++++ b/src/server/partimaged-client.cpp
+@@ -89,9 +89,9 @@ void CPartimagedClients::Release(unsigned int client)
+   pthread_mutex_lock(&mClients);
+   showDebug(1, "%d released\n", client);
+   shutdown(Clients[client].Sock, SHUT_RDWR);
+-  Clients[client].Sock = NULL;
++  Clients[client].Sock = 0x0;
+   Clients[client].Present = false;
+-  Clients[client].MyPid = NULL;
++  Clients[client].MyPid = 0x0;
+   pthread_mutex_unlock(&mClients);
+ }
+ 
+@@ -109,9 +109,9 @@ void CPartimagedClients::ReleaseClientByPid(unsigned int client_pid)
+           found = true;
+           showDebug(1, "client %d pid = %d released by pid\n", next, client_pid);
+           shutdown(Clients[next].Sock, SHUT_RDWR);
+-          Clients[next].Sock = NULL;
++          Clients[next].Sock = 0x0;
+           Clients[next].Present = false;
+-          Clients[next].MyPid = NULL;
++          Clients[next].MyPid = 0x0;
+ 	    }
+       else
+         next++;

--- a/sys-block/partimage/partimage-0.6.9-r4.ebuild
+++ b/sys-block/partimage/partimage-0.6.9-r4.ebuild
@@ -1,0 +1,142 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools flag-o-matic pam
+
+DESCRIPTION="Console-based application to efficiently save raw partition data to image file"
+HOMEPAGE="https://www.partimage.org/"
+SRC_URI="mirror://sourceforge/${PN}/${P}.tar.bz2"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~loong ~ppc ~riscv ~sparc ~x86"
+IUSE="nls nologin pam ssl static"
+REQUIRED_USE="static? ( !pam )"
+
+COMMON_DEPEND="
+	acct-group/partimag
+	acct-user/partimag
+"
+LIBS_DEPEND="
+	app-arch/bzip2
+	>=dev-libs/newt-0.52
+	>=sys-libs/slang-2
+	sys-libs/zlib:=
+	!nologin? ( virtual/libcrypt:= )
+	ssl? ( dev-libs/openssl:0= )
+"
+PAM_DEPEND="pam? ( sys-libs/pam )"
+RDEPEND="
+	${COMMON_DEPEND}
+	${PAM_DEPEND}
+	!static? ( ${LIBS_DEPEND} )
+"
+DEPEND="
+	${PAM_DEPEND}
+	${LIBS_DEPEND}
+"
+BDEPEND="
+	${COMMON_DEPEND}
+	nls? ( sys-devel/gettext )
+"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-0.6.9-zlib-1.2.5.2-r1.patch #405323
+	"${FILESDIR}"/${PN}-0.6.9-minor-typo.patch #580290
+	"${FILESDIR}"/${PN}-0.6.9-openssl-1.1-compatibility.patch
+	"${FILESDIR}"/${PN}-0.6.9-missing-includes.patch
+	"${FILESDIR}"/${PN}-0.6.9-clang.patch
+	"${FILESDIR}"/${PN}-0.6.9-musl-null-type.patch #853883
+)
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_configure() {
+	# XXX: Do we still need these?
+	filter-flags -fno-exceptions
+	use ppc && append-flags -fsigned-char
+
+	local myeconfargs=(
+		$(use_enable nls)
+		$(usex nologin '--disable-login' '')
+		$(use_enable pam)
+		$(use_enable ssl)
+		$(use_enable static all-static)
+		--with-log-dir="${EPREFIX}"/var/log/partimage
+	)
+
+	econf "${myeconfargs[@]}"
+}
+
+src_install() {
+	default
+
+	keepdir /var/lib/partimage
+	keepdir /var/log/partimage
+
+	newinitd "${FILESDIR}"/partimaged.init.2 partimaged
+	newconfd "${FILESDIR}"/partimaged.conf partimaged
+
+	if use pam; then
+		newpamd "${FILESDIR}"/partimaged.pam.2 partimaged
+	fi
+
+	if use ssl; then
+		insinto /etc/partimaged
+		doins "${FILESDIR}"/servercert.cnf
+	fi
+
+	fowners partimag:root /etc/partimaged/partimagedusers
+}
+
+pkg_config() {
+	if use ssl; then
+		local confdir="${EROOT}"/etc/partimaged
+		local privkey="${confdir}"/partimaged.key
+		local cnf="${confdir}"/servercert.cnf
+		local csr="${confdir}"/partimaged.csr
+		local cert="${confdir}"/partimaged.cert
+
+		ewarn "Please customize /etc/partimaged/servercert.cnf before you continue!"
+		ewarn "Press Ctrl-C to break now for it, or press enter to continue."
+		read
+		if [ ! -f "${privkey}" ]; then
+			einfo "Generating unencrypted private key: ${privkey}"
+			openssl genrsa -out "${privkey}" 2048 || die
+		else
+			einfo "Private key already exists: ${privkey}"
+		fi
+		if [ ! -f "${csr}" ]; then
+			einfo "Generating certificate request: ${csr}"
+			openssl req -new -x509 -outform PEM -out "${csr}" -key "${privkey}" -config "${cnf}" || die
+		else
+			einfo "Certificate request already exists: ${csr}"
+		fi
+		if [ ! -f "${cert}" ]; then
+			einfo "Generating self-signed certificate: ${cert}"
+			openssl x509 -in "${csr}" -out "${cert}" -signkey "${privkey}" || die
+		else
+			einfo "Self-signed certifcate already exists: ${cert}"
+		fi
+		einfo "Setting permissions"
+		chmod 600 "${privkey}" || die
+		chown partimag:root "${privkey}" || die
+		chmod 644 "${cert}" "${csr}" || die
+		chown root:root "${cert}" "${csr}" || die
+		einfo "Done"
+	else
+		einfo "SSL is disabled, not building certificates"
+	fi
+}
+
+pkg_postinst() {
+	if use ssl; then
+		einfo "To create the required SSL certificates, please do:"
+		einfo "emerge --config =${PF}"
+	fi
+}


### PR DESCRIPTION
Additionally, this should let us treeclean partimage from ::musl, fixing the CI failure due to partimage::musl's use of user.eclass.

Bug: https://bugs.gentoo.org/853883
Bug: https://bugs.gentoo.org/884993
Signed-off-by: John Helmert III <ajak@gentoo.org>