### PR TITLE
app-emulation/dlx: revbump, fix build for clang16, fix lto

### DIFF
--- a/app-emulation/dlx/dlx-1.5.20-r1.ebuild
+++ b/app-emulation/dlx/dlx-1.5.20-r1.ebuild
@@ -1,0 +1,34 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs
+
+DESCRIPTION="DLX Simulator"
+HOMEPAGE="https://www.davidviner.com/dlx"
+SRC_URI="https://www.davidviner.com/zip/dlx/dlx.zip -> ${P}.zip"
+S="${WORKDIR}"/dlx
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86"
+
+BDEPEND="app-arch/unzip"
+
+PATCHES=(
+	"${FILESDIR}/${P}-fix-implicit-function-declarations.patch"
+	"${FILESDIR}/${P}-fix-lto-type-mismatch.patch"
+)
+
+src_compile() {
+	# CXX not used
+	emake CC="$(tc-getCC)" LINK="$(tc-getCC)" \
+		CFLAGS="${CFLAGS} ${CPPFLAGS}" \
+		LFLAGS="${CFLAGS} ${LDFLAGS}"
+}
+
+src_install() {
+	dobin masm mon dasm
+	dodoc README.txt MANUAL.TXT
+}

--- a/app-emulation/dlx/files/dlx-1.5.20-fix-implicit-function-declarations.patch
+++ b/app-emulation/dlx/files/dlx-1.5.20-fix-implicit-function-declarations.patch
@@ -1,0 +1,102 @@
+Date: Sat, 10 Dec 2022 13:25:28 +0100
+Subject: [PATCH] fix implicit function declarations
+
+By default clang16 will not allow implicit function declarations.
+This patch overhauls the whole source code to fix that. 
+
+Bug: https://bugs.gentoo.org/874933
+This patch has been sent upstream via mail.
+
+Pascal Jaeger <pascal.jaeger@leimstift.de> (2022-12-10)
+
+--- a/cpu.h
++++ b/cpu.h
+@@ -573,4 +573,4 @@ extern struct DecodeTables DecodeT [128];
+ 
+ /////////////////////////////////////////////////////////////////////////////////////////
+ 
+-
++VOID DoMcLoad (STRPTR Cmd);
+--- a/dsym.c
++++ b/dsym.c
+@@ -19,6 +19,7 @@
+ 
+ SymTab SymBase = (SymTab) NULL;
+ 
++extern VOID Error (STRPTR Msg, BOOL PrintLine);
+ BOOL    DoTitle;
+ 
+ /////////////////////////////////////////////////////////////////////////////////////////
+--- a/dsym.h
++++ b/dsym.h
+@@ -38,6 +38,7 @@ extern SymTab   AddSymbol (STRPTR Sym, ULONG Val, BOOL SetUp);
+ extern VOID     DeleteSymbolTable ();
+ extern VOID     DisplaySymbolTable (BOOL NotFound);
+ extern SymTab   FindSymbol (STRPTR Sym);
++extern VOID     CopyMacro (SymTab S);
+ 
+ /////////////////////////////////////////////////////////////////////////////////////////
+ 
+--- a/io.c
++++ b/io.c
+@@ -14,6 +14,8 @@
+ 
+ #include "cpu.h"
+ 
++extern  ULONG   ExtractNo (STRPTR Str, WORD *Pos, BOOL *Blank);
++
+ /*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+ /* Extract a file name from Cmd at position Pos                           */
+ /*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+--- a/masm.c
++++ b/masm.c
+@@ -51,6 +51,8 @@ extern  char    LinkDate [];
+ 
+ /*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+ 
++VOID Error (STRPTR Msg);
++
+ FILE    *In;                    /* Input file */
+ 
+ BOOL    LittleEndian = FALSE, Ok = TRUE, ESym = FALSE;
+--- a/masm.h
++++ b/masm.h
+@@ -13,5 +13,3 @@
+ 
+ #define LINELEN     130
+ 
+-
+-
+--- a/mon.c
++++ b/mon.c
+@@ -88,6 +88,7 @@
+ #include "mon.h"
+ #include "io.h"
+ 
++extern void Error (STRPTR Msg, BOOL PrintLine);
+ ULONG   LastAddr = 0;
+ 
+ /*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+--- a/mon.h
++++ b/mon.h
+@@ -46,6 +46,7 @@ extern  UBYTE   PauseForKey (UBYTE Msg);
+ 
+ extern  ULONG   DebugLevel;
+ extern  FILE    *Log;
++VOID DisMicrocode ();
+ 
+ #define DB_DISASSEM     0x0001
+ #define DB_MICROCODE    0x0002
+--- a/msym.c
++++ b/msym.c
+@@ -15,6 +15,7 @@
+ 
+ SymTab SymBase = (SymTab) NULL;
+ 
++extern void     Error (STRPTR Msg, BOOL PrintLine);
+ BOOL    DoTitle;
+ 
+ /*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+-- 
+2.38.1
+

--- a/app-emulation/dlx/files/dlx-1.5.20-fix-lto-type-mismatch.patch
+++ b/app-emulation/dlx/files/dlx-1.5.20-fix-lto-type-mismatch.patch
@@ -1,0 +1,193 @@
+Date: Sat, 10 Dec 2022 14:14:35 +0100
+Subject: [PATCH] fix lto-type-mismatch
+
+This gets rid of a double definition of the function Error and renames
+one of the Error functions to Error_s
+
+Bug: https://bugs.gentoo.org/854513
+This patch has been sent upstream via mail.
+
+Signed-off-by: Pascal Jäger <pascal.jaeger@leimstift.de>
+--- a/masm.c
++++ b/masm.c
+@@ -51,7 +51,7 @@ extern  char    LinkDate [];
+ 
+ /*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+ 
+-VOID Error (STRPTR Msg);
++VOID Error_s (STRPTR Msg);
+ 
+ FILE    *In;                    /* Input file */
+ 
+@@ -274,7 +274,7 @@ STRPTR Decode2Table [] =
+ 
+ /*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+ 
+-VOID Error (STRPTR Msg)
++VOID Error_s (STRPTR Msg)
+ {
+     if (strlen (Line))
+     {
+@@ -381,7 +381,7 @@ BOOL HandleSymbol (BOOL Jump)
+     if (ST->SetUp && !Jump)
+     {
+         sprintf (Txt, "Multiple definition of label <%s>\n", Sym);
+-        Error (Txt);
++        Error_s (Txt);
+     }
+ 
+     if (!Jump)
+@@ -414,7 +414,7 @@ VOID WriteTables (STRPTR FName)
+     if (!o)
+     {
+         sprintf (Txt, "Cannot open output microcode file '%s'", FName);
+-        Error (Txt);
++        Error_s (Txt);
+     }
+ 
+     for (i = 0; i < MICROSIZE; i++)
+@@ -493,7 +493,7 @@ VOID SetJump (SymTab ST)
+     if (!ST->SetUp)
+     {
+         sprintf (Txt, "Label <%s> never defined\n", ST->Name);
+-        Error (Txt);
++        Error_s (Txt);
+     }
+ 
+     if (ST->NoRefs)
+@@ -536,7 +536,7 @@ VOID DoDecode1 ()
+     if (!Found)
+     {
+         sprintf (Txt, "Unrecognised Decode1 keyword <%s>\n", Keyword);
+-        Error (Txt);
++        Error_s (Txt);
+     }
+ 
+     ptr++;
+@@ -553,13 +553,13 @@ VOID DoDecode1 ()
+     if (!ST)    /* New label */
+     {
+         sprintf (Txt, "Unrecognised label <%s>\n", Sym);
+-        Error (Txt);
++        Error_s (Txt);
+     }
+ 
+     if (!ST->SetUp)
+     {
+         sprintf (Txt, "Label <%s> not declared\n", ST->Name);
+-        Error (Txt);
++        Error_s (Txt);
+     }
+ 
+     Decode1 [Ind] = ST->Val;
+@@ -591,7 +591,7 @@ VOID DoDecode2 ()
+     if (!Found)
+     {
+         sprintf (Txt, "Unrecognised Decode2 keyword <%s>\n", Keyword);
+-        Error (Txt);
++        Error_s (Txt);
+     }
+ 
+     ptr++;
+@@ -608,13 +608,13 @@ VOID DoDecode2 ()
+     if (!ST)    /* New label */
+     {
+         sprintf (Txt, "Unrecognised label <%s>\n", Sym);
+-        Error (Txt);
++        Error_s (Txt);
+     }
+ 
+     if (!ST->SetUp)
+     {
+         sprintf (Txt, "Label <%s> not declared\n", ST->Name);
+-        Error (Txt);
++        Error_s (Txt);
+     }
+ 
+     Decode2 [Ind] = ST->Val;
+@@ -649,7 +649,7 @@ VOID DoMicroCode ()
+         if (Ind == INVALID)
+         {
+             sprintf (Txt, "Unrecognised Dest keyword <%s>\n", Keyword);
+-            Error (Txt);
++            Error_s (Txt);
+         }
+ 
+         Microcode [Addr] |= ((Ind + 1) << 28);    /* 0 = no dest */
+@@ -671,7 +671,7 @@ VOID DoMicroCode ()
+         if (Ind == INVALID)
+         {
+             sprintf (Txt, "Unrecognised ALU keyword <%s>\n", Keyword);
+-            Error (Txt);
++            Error_s (Txt);
+         }
+ 
+         Microcode [Addr] |= (Ind << 22);
+@@ -695,7 +695,7 @@ VOID DoMicroCode ()
+         if (Ind == INVALID)
+         {
+             sprintf (Txt, "Unrecognised Source 1 keyword <%s>\n", Keyword);
+-            Error (Txt);
++            Error_s (Txt);
+         }
+ 
+         Microcode [Addr] |= (Ind << 18);
+@@ -719,7 +719,7 @@ VOID DoMicroCode ()
+         if (Ind == INVALID)
+         {
+             sprintf (Txt, "Unrecognised Source 2 keyword <%s>\n", Keyword);
+-            Error (Txt);
++            Error_s (Txt);
+         }
+ 
+         Microcode [Addr] |= (Ind << 14);
+@@ -755,7 +755,7 @@ VOID DoMicroCode ()
+         if (Ind == INVALID)
+         {
+             sprintf (Txt, "Unrecognised Misc keyword <%s>\n", Keyword);
+-            Error (Txt);
++            Error_s (Txt);
+         }
+ 
+         Microcode [Addr] |= (Ind << 5);
+@@ -779,7 +779,7 @@ VOID DoMicroCode ()
+         if (Ind == INVALID)
+         {
+             sprintf (Txt, "Unrecognised Condition keyword <%s>\n", Keyword);
+-            Error (Txt);
++            Error_s (Txt);
+         }
+ 
+         Microcode [Addr] |= (Ind + 1); /* 0 = no cond */
+@@ -933,7 +933,7 @@ int main (int argc, char **argv)
+                                 if (Addr >= MICROSIZE)
+                                 {
+                                     sprintf (Txt, "Too many microcode lines - maximum %d", MICROSIZE);
+-                                    Error (Txt);
++                                    Error_s (Txt);
+                                 }
+ 
+                                 break;
+--- a/msym.c
++++ b/msym.c
+@@ -15,7 +15,7 @@
+ 
+ SymTab SymBase = (SymTab) NULL;
+ 
+-extern void     Error (STRPTR Msg, BOOL PrintLine);
++extern VOID Error_s (STRPTR Msg);
+ BOOL    DoTitle;
+ 
+ /*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+@@ -84,7 +84,7 @@ SymTab AddSymbol (STRPTR Sym, ULONG Val, BOOL SetUp)
+     S = (SymTab) calloc (1, sizeof (struct SymTabType));
+ 
+     if (!S)
+-        Error ("Out of memory (AddSymbol)", FALSE);
++        Error_s ("Out of memory (AddSymbol)");
+ 
+     strcpy (S->Name, Sym);
+ 
+-- 
+2.38.1
+


### PR DESCRIPTION
- fix implicit function declaration
- fix lto type mismatch

Closes: https://bugs.gentoo.org/874933
Closes: https://bugs.gentoo.org/854513

Signed-off-by: Pascal Jäger <pascal.jaeger@leimstift.de>