### PR TITLE
app-forensics/scalpel: does not build with CFLAGS=-lto

### DIFF
--- a/app-forensics/scalpel/scalpel-2.1_pre20210326.ebuild
+++ b/app-forensics/scalpel/scalpel-2.1_pre20210326.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
-inherit autotools
+inherit autotools flag-o-matic
 
 DESCRIPTION="A high performance file carver"
 HOMEPAGE="https://github.com/sleuthkit/scalpel"
@@ -34,6 +34,8 @@ src_prepare() {
 
 	default
 	eautoreconf
+
+	filter-lto # https://bugs.gentoo.org/865687
 }
 
 src_install() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/865687
Signed-off-by: Martin Dummer <martin.dummer@gmx.net>