### PR TITLE
dev-libs/qcoro5: use pkg tag for dev-qt/qtdeclarative

### DIFF
--- a/dev-libs/qcoro5/metadata.xml
+++ b/dev-libs/qcoro5/metadata.xml
@@ -11,7 +11,7 @@
 	</upstream>
 	<use>
 		<flag name="network">Build <pkg>dev-qt/qtnetwork</pkg> support</flag>
-		<flag name="qml">Enable QML/QtQuick support via dev-qt/qtdeclarative</flag>
+		<flag name="qml">Enable QML/QtQuick support via <pkg>dev-qt/qtdeclarative</pkg></flag>
 		<flag name="websockets">Build <pkg>dev-qt/qtwebsockets</pkg> support</flag>
 	</use>
 </pkgmetadata>


### PR DESCRIPTION
Just small improvement of metadata file.