### PR TITLE
net-nds/ldapvi: revbump, fix build for clang16, fix USE dependencies

### DIFF
--- a/net-nds/ldapvi/files/ldapvi-1.7-fix-implicit-function-declarations.patch
+++ b/net-nds/ldapvi/files/ldapvi-1.7-fix-implicit-function-declarations.patch
@@ -1,0 +1,86 @@
+Date: Sun, 11 Dec 2022 19:05:47 +0100
+Subject: [PATCH] fix implicit function declarations
+
+Clang16 will not allow implicit function declarations by default.
+This patch add the declarations to make this package build with
+Clang16 defaults.
+
+Also patches some -Wreturn-type while at it. 
+
+Bug: https://bugs.gentoo.org/882229
+Bug: https://bugs.gentoo.org/740852
+Patch has been sent upstream via mail.
+
+Signed-off-by: Pascal Jäger <pascal.jaeger@leimstift.de>
+--- a/common.h
++++ b/common.h
+@@ -370,3 +370,5 @@ void finish_sasl_redirection(tsasl_defaults *);
+ tsasl_defaults *sasl_defaults_new(bind_options *bind_options);
+ void sasl_defaults_free(tsasl_defaults *sd);
+ int ldapvi_sasl_interact(LDAP *ld, unsigned flags, void *defaults, void *p);
++
++void fdcp(int fdsrc, int fddst);
+--- a/diff.c
++++ b/diff.c
+@@ -18,6 +18,7 @@
+ #include "common.h"
+ #include "config.h"
+ 
++char ldap_bv2dn_x (struct berval *bv, LDAPDN *dn, unsigned flags);
+ typedef void (*note_function)(void *, void *, void *);
+ 
+ static void
+--- a/parse.c
++++ b/parse.c
+@@ -17,6 +17,7 @@
+  */
+ #define _XOPEN_SOURCE
+ #include <unistd.h>
++#include <crypt.h>
+ #include "common.h"
+ 
+ #define fast_g_string_append_c(gstring, c)				\
+--- a/error.c
++++ b/error.c
+@@ -14,6 +14,9 @@
+  * along with this program; if not, write to the Free Software
+  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+  */
++
++#define LDAP_DEPRECATED 1
++
+ #include <dirent.h>
+ #include <errno.h>
+ #include <fcntl.h>
+--- a/port.c
++++ b/port.c
+@@ -35,6 +35,7 @@
+ #if defined(HAVE_OPENSSL)
+ #include <openssl/sha.h>
+ #include <openssl/md5.h>
++#include <openssl/rand.h>
+ #elif defined(HAVE_GNUTLS)
+ #include <gnutls/gnutls.h>
+ #include <gnutls/openssl.h>
+--- a/ldapvi.c
++++ b/ldapvi.c
+@@ -1470,7 +1470,7 @@ copy_sasl_output(FILE *out, char *sasl)
+ 	int line = 0;
+ 	int c;
+ 
+-	if (lstat(sasl, &st) == -1) return;
++	if (lstat(sasl, &st) == -1) return -1;
+ 	if ( !(in = fopen(sasl, "r"))) syserr();
+ 
+ 	if (st.st_size > 0) {
+--- a/misc.c
++++ b/misc.c
+@@ -585,7 +585,7 @@ dialog_rebuild(char *up, char *clreos,
+ 		putp(up);
+ }
+ 
+-static Keymap
++static void
+ set_meta_keymap(Keymap keymap, Keymap meta_keymap)
+ {
+ 	if (!meta_keymap)

--- a/net-nds/ldapvi/ldapvi-1.7_p20101214-r4.ebuild
+++ b/net-nds/ldapvi/ldapvi-1.7_p20101214-r4.ebuild
@@ -1,0 +1,57 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools
+
+DESCRIPTION="Manage LDAP entries with a text editor"
+HOMEPAGE="http://www.lichteblau.com/ldapvi/"
+SRC_URI="mirror://gentoo/${P}.tar.bz2"
+S="${WORKDIR}"/${P}/${PN}
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~hppa ~ppc ~sparc ~x86"
+IUSE="gnutls sasl"
+
+RDEPEND="dev-libs/popt
+	dev-libs/glib:2
+	sys-libs/readline:=
+	sys-libs/ncurses:0=
+	virtual/libcrypt:=
+	gnutls? (
+		net-libs/gnutls
+		net-nds/openldap[gnutls]
+	)
+	!gnutls? (
+		dev-libs/openssl:0
+		net-nds/openldap[ssl]
+	)
+	sasl? ( dev-libs/cyrus-sasl:2[ssl] )"
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+PATCHES=( "${FILESDIR}/${PN}-1.7-fix-implicit-function-declarations.patch" )
+
+src_prepare() {
+	default
+
+	# bug #459478
+	sed -i \
+		-e '/^AC_SEARCH_LIBS/s:curses ncurses:curses ncurses tinfo:' \
+		configure.in || die
+
+	eautoreconf
+}
+
+src_configure() {
+	econf \
+		--with-libcrypto=$(usex gnutls gnutls openssl)
+}
+
+src_install() {
+	dobin ldapvi
+	doman ldapvi.1
+	dodoc NEWS manual/{bg.png,html.xsl,manual.{css,xml}}
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/493858
Closes: https://bugs.gentoo.org/740852
Closes: https://bugs.gentoo.org/828517
Closes: https://bugs.gentoo.org/882229

Signed-off-by: Pascal Jäger <pascal.jaeger@leimstift.de>