### PR TITLE
media-libs/libgpod: fix build for clang16, fix other bugs

### DIFF
--- a/media-libs/libgpod/files/libgpod-0.8.3-implicit-int.patch
+++ b/media-libs/libgpod/files/libgpod-0.8.3-implicit-int.patch
@@ -1,0 +1,19 @@
+Clang16 will not allow implicit integers by default.
+
+Bug: https://bugs.gentoo.org/885349
+Patch has been sent upstream here: https://sourceforge.net/p/gtkpod/patches/47/
+
+Pascal Jäger <pascal.jaeger@leimstift.de> (2022-12-11)
+
+--- a/tools/generic-callout.c
++++ b/tools/generic-callout.c
+@@ -663,8 +663,7 @@ static gboolean write_sysinfo_extended (const char *mountpoint,
+         return success;
+ }
+ 
+-
+-static char *get_info_from_usb (usb_bus_number, usb_device_number)
++static char *get_info_from_usb (guint usb_bus_number,guint usb_device_number)
+ {
+ #ifdef HAVE_LIBUSB
+         return read_sysinfo_extended_from_usb (usb_bus_number,

--- a/media-libs/libgpod/libgpod-0.8.3-r6.ebuild
+++ b/media-libs/libgpod/libgpod-0.8.3-r6.ebuild
@@ -1,0 +1,78 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools udev
+
+DESCRIPTION="Shared library to access the contents of an iPod"
+HOMEPAGE="http://www.gtkpod.org/libgpod/"
+SRC_URI="mirror://sourceforge/gtkpod/${P}.tar.bz2"
+
+LICENSE="LGPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~riscv ~x86"
+IUSE="+gtk ios +udev"
+
+RDEPEND="
+	>=app-pda/libplist-1.0:=
+	>=dev-db/sqlite-3:3
+	>=dev-libs/glib-2.16:2
+	dev-libs/libxml2:2
+	sys-apps/sg3_utils:0=
+	gtk? ( x11-libs/gdk-pixbuf:2 )
+	ios? ( app-pda/libimobiledevice:= )
+	udev? ( virtual/udev )
+"
+DEPEND="${RDEPEND}"
+BDEPEND="
+	dev-libs/libxslt
+	dev-util/intltool
+	dev-util/gtk-doc-am
+	sys-devel/gettext
+	virtual/pkgconfig
+"
+
+DOCS=( AUTHORS NEWS README{,.overview,.sqlite,.SysInfo} TROUBLESHOOTING )
+
+PATCHES=(
+	"${FILESDIR}"/${P}-comment.patch # bug 537968
+	"${FILESDIR}"/${P}-segfault.patch # bug 565052
+	"${FILESDIR}"/${P}-pkgconfig_overlinking.patch
+	"${FILESDIR}"/${P}-implicit-int.patch
+)
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_configure() {
+	local myeconfargs=(
+		--disable-pygobject
+		--disable-static
+		--without-hal
+		--without-mono
+		--without-python
+		--with-udev-dir="$(get_udevdir)"
+		$(use_enable gtk gdk-pixbuf)
+		$(use_with ios libimobiledevice)
+		$(use_enable udev)
+	)
+	econf "${myeconfargs[@]}"
+}
+
+src_install() {
+	default
+	rm "${ED}"/usr/$(get_libdir)/pkgconfig/libgpod-sharp.pc || die
+	use udev && rmdir "${ED}"/tmp || die
+	find "${ED}" -name '*.la' -type f -delete || die
+}
+
+pkg_postinst() {
+	use udev && udev_reload
+}
+
+pkg_postrm() {
+	use udev && udev_reload
+}


### PR DESCRIPTION
- rm /tmp only when USE=udev
- call udev_reload when USE=udev
- fix implicit int

Closes: https://bugs.gentoo.org/822144
Closes: https://bugs.gentoo.org/847415
Closes: https://bugs.gentoo.org/885349

Signed-off-by: Pascal Jäger <pascal.jaeger@leimstift.de>