### PR TITLE
media-sound/pulseaudio-daemon: Add BDEPEND sys-devel/m4

### DIFF
--- a/media-sound/pulseaudio-daemon/pulseaudio-daemon-16.1-r3.ebuild
+++ b/media-sound/pulseaudio-daemon/pulseaudio-daemon-16.1-r3.ebuild
@@ -148,6 +148,7 @@ BDEPEND="
 	dev-lang/perl
 	dev-perl/XML-Parser
 	sys-devel/gettext
+	sys-devel/m4
 	virtual/libiconv
 	virtual/libintl
 	virtual/pkgconfig

--- a/media-sound/pulseaudio-daemon/pulseaudio-daemon-16.1-r4.ebuild
+++ b/media-sound/pulseaudio-daemon/pulseaudio-daemon-16.1-r4.ebuild
@@ -148,6 +148,7 @@ BDEPEND="
 	dev-lang/perl
 	dev-perl/XML-Parser
 	sys-devel/gettext
+	sys-devel/m4
 	virtual/libiconv
 	virtual/libintl
 	virtual/pkgconfig


### PR DESCRIPTION
Build system requires m4, add it to BDEPEND.
Closes: https://bugs.gentoo.org/885717