### PR TITLE
net-vpn/vtun: Fix implicit setproctitle, also libbsd is a runtime dependency

### DIFF
--- a/net-vpn/vtun/files/vtun-3.0.3-includes.patch
+++ b/net-vpn/vtun/files/vtun-3.0.3-includes.patch
@@ -20,14 +20,24 @@
  #include "linkfd.h"
 --- a/lib.h
 +++ b/lib.h
-@@ -26,6 +26,7 @@
+@@ -26,6 +26,8 @@
  #include <sys/types.h>
  #include <signal.h>
  #include <errno.h>
 +#include <unistd.h> /* read(), write() */
++#include <bsd/unistd.h> /* setproctitle(), see man libbsd(7) */
  
  #ifdef HAVE_LIBUTIL_H
  #include <libutil.h>
+@@ -35,7 +37,7 @@
+   void init_title(int argc,char *argv[],char *env[], char *name);
+   void set_title(const char *ftm, ...);
+ #else
+-  #define init_title( a... ) 
++  #define init_title(argc, argv, env, name) setproctitle_init(argc, argv, env)
+   #define set_title setproctitle
+ #endif /* HAVE_SETPROC_TITLE */
+ 
 --- a/vtun.h
 +++ b/vtun.h
 @@ -232,5 +232,9 @@

--- a/net-vpn/vtun/files/vtun-3.0.4-includes.patch
+++ b/net-vpn/vtun/files/vtun-3.0.4-includes.patch
@@ -20,14 +20,24 @@
  #include "linkfd.h"
 --- a/lib.h
 +++ b/lib.h
-@@ -26,6 +26,7 @@
+@@ -26,6 +26,8 @@
  #include <sys/types.h>
  #include <signal.h>
  #include <errno.h>
 +#include <unistd.h> /* read(), write() */
++#include <bsd/unistd.h> /* setproctitle(), see man libbsd(7) */
  
  #ifdef HAVE_LIBUTIL_H
  #include <libutil.h>
+@@ -35,7 +37,7 @@
+   void init_title(int argc,char *argv[],char *env[], char *name);
+   void set_title(const char *ftm, ...);
+ #else
+-  #define init_title( a... ) 
++  #define init_title(argc, argv, env, name) setproctitle_init(argc, argv, env)
+   #define set_title setproctitle
+ #endif /* HAVE_SETPROC_TITLE */
+ 
 --- a/lock.c
 +++ b/lock.c
 @@ -32,6 +32,7 @@
@@ -48,3 +58,15 @@
  
  #include "vtun.h"
  #include "linkfd.h"
+--- a/generic/pty_dev.c
++++ b/generic/pty_dev.c
+@@ -22,6 +22,8 @@
+ 
+ #include "config.h"
+ 
++#define _GNU_SOURCE // getpt, grantpt 
++#define _XOPEN_SOURCE // unlockpt
+ #include <unistd.h>
+ #include <fcntl.h>
+ #include <stdlib.h>
+

--- a/net-vpn/vtun/vtun-3.0.3-r2.ebuild
+++ b/net-vpn/vtun/vtun-3.0.3-r2.ebuild
@@ -18,7 +18,8 @@ RDEPEND="
 	lzo? ( dev-libs/lzo:2 )
 	socks5? ( net-proxy/dante )
 	ssl? ( dev-libs/openssl:0= )
-	zlib? ( sys-libs/zlib )"
+	zlib? ( sys-libs/zlib )
+	dev-libs/libbsd"
 DEPEND="${RDEPEND}"
 BDEPEND="sys-devel/bison"
 

--- a/net-vpn/vtun/vtun-3.0.4.ebuild
+++ b/net-vpn/vtun/vtun-3.0.4.ebuild
@@ -18,7 +18,8 @@ RDEPEND="
 	lzo? ( dev-libs/lzo:2 )
 	socks5? ( net-proxy/dante )
 	ssl? ( dev-libs/openssl:0= )
-	zlib? ( sys-libs/zlib )"
+	zlib? ( sys-libs/zlib )
+	dev-libs/libbsd"
 DEPEND="${RDEPEND}"
 BDEPEND="sys-devel/bison"
 


### PR DESCRIPTION
Fix implicit setproctitle, also libbsd is a runtime dependencydepencency. Also fix implicit getpt, grantpt, ptsname, by enabling nonstandard (_GNU_SOURCE) gnu extensions and extra open/posix (_XOPEN_SOURCE).
Bug: https://bugs.gentoo.org/875443
