### PR TITLE
net-misc/pssh: bump PYTHON_COMPAT to 3.11

### DIFF
--- a/net-misc/pssh/pssh-2.3.4-r2.ebuild
+++ b/net-misc/pssh/pssh-2.3.4-r2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{8,9,10} )
+PYTHON_COMPAT=( python3_{8..11} )
 DISTUTILS_SINGLE_IMPL=1
 
 inherit distutils-r1


### PR DESCRIPTION
Signed-off-by: Kai-Chun Ning <kaichun.ning@gmail.com>