### PR TITLE
media-tv/mesa : fix build with >=media-libs/mesa-22.3.0 

### DIFF
--- a/media-tv/kodi/files/kodi-19.4-fix-mesa-22.3.0-build.patch
+++ b/media-tv/kodi/files/kodi-19.4-fix-mesa-22.3.0-build.patch
@@ -1,0 +1,12 @@
+--- xbmc/xbmc/windowing/X11/GLContextEGL.h
++++ xbmc/xbmc/windowing/X11/GLContextEGL.h
+@@ -13,7 +13,7 @@
+ #include "threads/CriticalSection.h"
+ 
+ #include <EGL/eglext.h>
+-#include <EGL/eglextchromium.h>
++#include <EGL/eglext_angle.h>
+ #include <X11/Xutil.h>
+ 
+ class CGLContextEGL : public CGLContext
+

--- a/media-tv/kodi/kodi-19.4-r3.ebuild
+++ b/media-tv/kodi/kodi-19.4-r3.ebuild
@@ -208,6 +208,11 @@ src_unpack() {
 }
 
 src_prepare() {
+	# https://bugs.gentoo.org/885419
+	if has_version ">=media-libs/mesa-22.3.0"; then
+		PATCHES+=( "${FILESDIR}/${P}-fix-mesa-22.3.0-build.patch" )
+	fi
+
 	cmake_src_prepare
 
 	# avoid long delays when powerkit isn't running #348580

--- a/media-tv/kodi/kodi-19.4-r4.ebuild
+++ b/media-tv/kodi/kodi-19.4-r4.ebuild
@@ -209,6 +209,11 @@ src_unpack() {
 }
 
 src_prepare() {
+	# https://bugs.gentoo.org/885419
+	if has_version ">=media-libs/mesa-22.3.0"; then
+		PATCHES+=( "${FILESDIR}/${P}-fix-mesa-22.3.0-build.patch" )
+	fi
+
 	cmake_src_prepare
 
 	# avoid long delays when powerkit isn't running #348580


### PR DESCRIPTION
Fix for https://bugs.gentoo.org/885419