### PR TITLE
media-libs/id3lib: Fix stack-smashing when reading VBR

### DIFF
--- a/media-libs/id3lib/files/id3lib-3.8.3-vbr-stack-smashing.patch
+++ b/media-libs/id3lib/files/id3lib-3.8.3-vbr-stack-smashing.patch
@@ -1,0 +1,19 @@
+Description: Fix crashes when reading VBR MP3 file.
+Bug-Ubuntu: https://launchpad.net/bugs/444466
+Origin: upstream, http://sourceforge.net/tracker/?func=detail&aid=937707&group_id=979&atid=300979
+Forwarded: yes
+Author: Urs Fleisch
+
+Index: id3lib3.8.3-3.8.3/src/mp3_parse.cpp
+===================================================================
+--- id3lib3.8.3-3.8.3.orig/src/mp3_parse.cpp	2009-10-06 23:12:10.381250132 +0200
++++ id3lib3.8.3-3.8.3/src/mp3_parse.cpp	2009-10-06 23:14:09.545252591 +0200
+@@ -465,7 +465,7 @@
+   // from http://www.xingtech.com/developer/mp3/
+ 
+   const size_t VBR_HEADER_MIN_SIZE = 8;     // "xing" + flags are fixed
+-  const size_t VBR_HEADER_MAX_SIZE = 116;   // frames, bytes, toc and scale are optional
++  const size_t VBR_HEADER_MAX_SIZE = 120;   // frames, bytes, toc and scale are optional
+ 
+   if (mp3size >= vbr_header_offest + VBR_HEADER_MIN_SIZE) 
+   {

--- a/media-libs/id3lib/id3lib-3.8.3-r9.ebuild
+++ b/media-libs/id3lib/id3lib-3.8.3-r9.ebuild
@@ -1,0 +1,64 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+inherit autotools
+
+DESCRIPTION="Id3 library for C/C++"
+HOMEPAGE="http://id3lib.sourceforge.net/"
+SRC_URI="mirror://sourceforge/${PN}/${P/_}.tar.gz"
+
+LICENSE="LGPL-2.1"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~riscv ~sparc ~x86 ~amd64-linux ~x86-linux ~x86-solaris"
+IUSE="doc static-libs"
+
+RDEPEND="sys-libs/zlib:="
+DEPEND="${RDEPEND}
+	doc? ( app-doc/doxygen )"
+
+RESTRICT="test"
+
+DOCS=( AUTHORS ChangeLog HISTORY README THANKS TODO )
+
+S=${WORKDIR}/${P/_}
+
+PATCHES=(
+	"${FILESDIR}"/${P}-zlib.patch
+	"${FILESDIR}"/${P}-test_io.patch
+	"${FILESDIR}"/${P}-autoconf259.patch
+	"${FILESDIR}"/${P}-doxyinput.patch
+	"${FILESDIR}"/${P}-unicode16.patch
+	"${FILESDIR}"/${P}-gcc-4.3.patch
+	"${FILESDIR}"/${P}-missing_nullpointer_check.patch
+	"${FILESDIR}"/${P}-security.patch
+	"${FILESDIR}"/${P}-vbr-stack-smashing.patch # bug 398571
+)
+
+src_prepare() {
+	default
+
+	sed -i 's:AM_CONFIG_HEADER:AC_CONFIG_HEADERS:' {.,zlib}/configure.in || die
+
+	AT_M4DIR=${S}/m4 eautoreconf
+}
+
+src_configure() {
+	econf $(use_enable static-libs static)
+}
+
+src_compile() {
+	default
+	if use doc; then
+		pushd doc >/dev/null || die
+		doxygen Doxyfile || die
+		popd >/dev/null || die
+	fi
+}
+
+src_install() {
+	use doc && local HTML_DOCS=( doc/. )
+	default
+	find "${D}" -name '*.la' -delete || die
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/398571
Signed-off-by: Kevin Martin <kevinmbecause@gmail.com>