### PR TITLE
mail-client/claws-mail-9999: handle new compile flags

### DIFF
--- a/mail-client/claws-mail/claws-mail-9999.ebuild
+++ b/mail-client/claws-mail/claws-mail-9999.ebuild
@@ -142,6 +142,8 @@ src_configure() {
 		$(use_enable clamav clamd-plugin)
 		$(use_enable dbus)
 		$(use_enable debug crash-dialog)
+		$(use_enable debug more-addressbook-debug)
+		$(use_enable debug more-ldap-debug)
 		$(use_enable dillo dillo-plugin)
 		$(use_enable doc manual)
 		$(use_enable gdata gdata-plugin)


### PR DESCRIPTION
Introduced: [`--enable-more-addressbook-debug`](https://git.claws-mail.org/?p=claws.git;a=blob;f=configure.ac;h=fdb7db51c91faa3a844e261e28fda19993a97cff;hb=HEAD#l336) and [`--enable-more-ldap-debug`](https://git.claws-mail.org/?p=claws.git;a=blob;f=configure.ac;h=fdb7db51c91faa3a844e261e28fda19993a97cff;hb=HEAD#l340). 