### PR TITLE
net-analyzer/wireshark: Update REQUIRED_USE on v3

### DIFF
--- a/net-analyzer/wireshark/wireshark-3.6.10.ebuild
+++ b/net-analyzer/wireshark/wireshark-3.6.10.ebuild
@@ -30,7 +30,7 @@ IUSE+=" +randpktdump +reordercap sbc selinux +sharkd smi snappy spandsp sshdump 
 IUSE+=" sdjournal test +text2pcap tfshark +tshark +udpdump zlib +zstd"
 
 REQUIRED_USE="lua? ( ${LUA_REQUIRED_USE} )
-	plugin-ifdemo? ( plugins )"
+	plugin-ifdemo? ( plugins qt5 )"
 
 RESTRICT="!test? ( test )"
 

--- a/net-analyzer/wireshark/wireshark-3.6.9.ebuild
+++ b/net-analyzer/wireshark/wireshark-3.6.9.ebuild
@@ -30,7 +30,7 @@ IUSE+=" +randpktdump +reordercap sbc selinux +sharkd smi snappy spandsp sshdump 
 IUSE+=" sdjournal test +text2pcap tfshark +tshark +udpdump zlib +zstd"
 
 REQUIRED_USE="lua? ( ${LUA_REQUIRED_USE} )
-	plugin-ifdemo? ( plugins )"
+	plugin-ifdemo? ( plugins qt5 )"
 
 RESTRICT="!test? ( test )"
 


### PR DESCRIPTION
`plugin-ifdemo` requires the `qt5` USE flag or the package will fail on the configure stage (note this has not been tested on wireshark-4):

```
CMake Error at plugins/epan/pluginifdemo/CMakeLists.txt:55 (target_link_libraries):
  Target "pluginifdemo" links to:

    Qt5::Multimedia

  but the target was not found.  Possible reasons include:

    * There is a typo in the target name.
    * A find_package call is missing for an IMPORTED target. * An ALIAS target is missing.
```