### PR TITLE
media-sound/clementine: disable spotify

### DIFF
--- a/media-sound/clementine/clementine-1.4.0_rc2-r1.ebuild
+++ b/media-sound/clementine/clementine-1.4.0_rc2-r1.ebuild
@@ -113,6 +113,7 @@ src_prepare() {
 }
 
 src_configure() {
+	# spotify is not in portage
 	local mycmakeargs=(
 		-DBUILD_WERROR=OFF
 		# force to find crypto++ see bug #548544
@@ -122,6 +123,8 @@ src_configure() {
 		-DCCACHE_EXECUTABLE=OFF
 		-DENABLE_BREAKPAD=OFF  #< disable crash reporting
 		-DENABLE_GIO=ON
+		-DENABLE_SPOTIFY=OFF
+		-DENABLE_SPOTIFY_BLOB=OFF
 		-DUSE_SYSTEM_GMOCK=ON
 		-DUSE_SYSTEM_PROJECTM=ON
 		-DBUNDLE_PROJECTM_PRESETS=OFF


### PR DESCRIPTION
This code was actually removed upstream:
https://github.com/clementine-player/Clementine/pull/7210

Signed-off-by: Alexey Sokolov <alexey+gentoo@asokolov.org>
Bug: https://bugs.gentoo.org/885529