### PR TITLE
media-gfx/blender: fix build with boost-1.81

### DIFF
--- a/media-gfx/blender/blender-3.3.0-r1.ebuild
+++ b/media-gfx/blender/blender-3.3.0-r1.ebuild
@@ -130,6 +130,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-3.2.2-support-building-with-musl-libc.patch
 	"${FILESDIR}"/${PN}-3.2.2-Cycles-add-option-to-specify-OptiX-runtime-root-dire.patch
 	"${FILESDIR}"/${PN}-3.2.2-Fix-T100845-wrong-Cycles-OptiX-runtime-compilation-i.patch
+	"${FILESDIR}"/${PN}-3.3.0-fix-build-with-boost-1.81.patch
 )
 
 blender_check_requirements() {

--- a/media-gfx/blender/files/blender-3.3.0-fix-build-with-boost-1.81.patch
+++ b/media-gfx/blender/files/blender-3.3.0-fix-build-with-boost-1.81.patch
@@ -1,0 +1,17 @@
+https://bugs.gentoo.org/887059
+
+Adding include as suggested by the compiler:
+
+"intern/locale/boost_locale_wrapper.cpp:12:1: note: ‘std::cout’ is defined 
+in header ‘<iostream>’; did you forget to ‘#include <iostream>’?"
+
+--- a/intern/locale/boost_locale_wrapper.cpp
++++ b/intern/locale/boost_locale_wrapper.cpp
+@@ -9,6 +9,7 @@
+ #include <stdio.h>
+ 
+ #include "boost_locale_wrapper.h"
++#include <iostream>
+ 
+ static std::string messages_path;
+ static std::string default_domain;


### PR DESCRIPTION
Patch as suggested by the compiler:

"intern/locale/boost_locale_wrapper.cpp:12:1: note: ‘std::cout’ is defined in header ‘<iostream>’; did you forget to ‘#include <iostream>’?"