### PR TITLE
dev-libs/xalan-c: Fix threads test

### DIFF
--- a/dev-libs/xalan-c/files/xalan-c-1.12-fix-threads.patch
+++ b/dev-libs/xalan-c/files/xalan-c-1.12-fix-threads.patch
@@ -1,0 +1,51 @@
+xercesc::XMLMutex doesn't work, replace it by std::mutex
+Bug: https://bugs.gentoo.org/887197
+
+--- a/Tests/Threads/ThreadTest.cpp
++++ b/Tests/Threads/ThreadTest.cpp
+@@ -49,6 +49,7 @@
+ 
+ #if defined(XALAN_USE_THREAD_STD)
+ #include <thread>
++#include <mutex>
+ #elif defined(XALAN_USE_THREAD_WINDOWS)
+ 
+ #include <process.h>
+@@ -95,8 +96,8 @@
+ 
+ 
+ 
+-typedef xercesc::XMLMutex         XMLMutexType;
+-typedef xercesc::XMLMutexLock     XMLMutexLockType;
++typedef std::mutex                  XMLMutexType;
++typedef std::lock_guard<std::mutex> XMLMutexLockType;
+ 
+ 
+ 
+@@ -121,7 +122,7 @@
+ 
+     XMLMutexType    m_mutex;
+ 
+-    long            m_counter;
++    volatile long   m_counter;
+ };
+ 
+ 
+@@ -143,7 +144,7 @@
+ void
+ SynchronizedCounter::increment()
+ {
+-    const XMLMutexLockType  theLock(&m_mutex);
++    const XMLMutexLockType  theLock(m_mutex);
+ 
+     if (m_counter < LONG_MAX)
+     {
+@@ -156,7 +157,7 @@
+ void
+ SynchronizedCounter::decrement()
+ {
+-    const XMLMutexLockType  theLock(&m_mutex);
++    const XMLMutexLockType  theLock(m_mutex);
+ 
+     if (m_counter > 0)
+     {

--- a/dev-libs/xalan-c/xalan-c-1.12-r2.ebuild
+++ b/dev-libs/xalan-c/xalan-c-1.12-r2.ebuild
@@ -43,6 +43,7 @@ BDEPEND+="
 
 PATCHES=(
 	"${FILESDIR}"/${P}-fix-lto.patch
+	"${FILESDIR}"/${P}-fix-threads.patch
 )
 
 src_configure() {


### PR DESCRIPTION
The threads run and finish ok, but the counter used in the testing application is not synchronized correctly; it seems the mutex they used doesn't really work.  So replace it by a std::mutex.

No need for a revbump, I only fixed the test.