### PR TITLE
media-sound/clementine: fix deps and link

### DIFF
--- a/media-sound/clementine/clementine-1.4.0_rc2-r2.ebuild
+++ b/media-sound/clementine/clementine-1.4.0_rc2-r2.ebuild
@@ -14,8 +14,8 @@ if [[ ${PV} == *9999* ]]; then
 	EGIT_REPO_URI="https://github.com/clementine-player/Clementine.git"
 	inherit git-r3
 else
-	S="${WORKDIR}/Clementine-${PV/_}"
 	SRC_URI="https://github.com/clementine-player/Clementine/archive/refs/tags/${PV/_}.tar.gz -> ${P}.tar.gz"
+	S="${WORKDIR}/Clementine-${PV/_}"
 	KEYWORDS="~amd64 ~arm64 ~ppc64 ~x86"
 fi
 
@@ -29,19 +29,8 @@ REQUIRED_USE="
 	wiimote? ( dbus )
 "
 
-BDEPEND="
-	>=dev-cpp/gtest-1.8.0
-	dev-qt/linguist-tools:5
-	sys-devel/gettext
-	virtual/pkgconfig
-	test? (
-		dev-qt/qttest:5
-		gnome-base/gsettings-desktop-schemas
-	)
-"
 COMMON_DEPEND="
 	dev-db/sqlite:3
-	dev-libs/crypto++:=
 	dev-libs/glib:2
 	dev-libs/protobuf:=
 	dev-qt/qtconcurrent:5
@@ -64,12 +53,13 @@ COMMON_DEPEND="
 	ipod? ( >=media-libs/libgpod-0.8.0 )
 	lastfm? ( >=media-libs/liblastfm-1.1.0_pre20150206 )
 	moodbar? ( sci-libs/fftw:3.0= )
-	mtp? ( >=media-libs/libmtp-1.0.0 )
+	mtp? ( >=media-libs/libmtp-1.0.0:= )
 	projectm? (
 		media-libs/glew:=
 		>=media-libs/libprojectm-3.1.12:0=
 		virtual/opengl
 	)
+	pulseaudio? ( media-libs/libpulse )
 "
 RDEPEND="${COMMON_DEPEND}
 	media-plugins/gst-plugins-meta:1.0
@@ -88,10 +78,23 @@ DEPEND="${COMMON_DEPEND}
 	box? ( dev-cpp/sparsehash )
 	dropbox? ( dev-cpp/sparsehash )
 	googledrive? ( dev-cpp/sparsehash )
-	pulseaudio? ( media-sound/pulseaudio )
 	seafile? ( dev-cpp/sparsehash )
 	skydrive? ( dev-cpp/sparsehash )
 "
+BDEPEND="
+	>=dev-cpp/gtest-1.8.0
+	dev-qt/linguist-tools:5
+	sys-devel/gettext
+	virtual/pkgconfig
+	test? (
+		dev-qt/qttest:5
+		gnome-base/gsettings-desktop-schemas
+	)
+"
+
+PATCHES=(
+	"${FILESDIR}/clementine-1.4.0_rc2-lz.patch"
+)
 
 DOCS=( Changelog README.md )
 
@@ -116,9 +119,6 @@ src_configure() {
 	# spotify is not in portage
 	local mycmakeargs=(
 		-DBUILD_WERROR=OFF
-		# force to find crypto++ see bug #548544
-		-DCRYPTOPP_LIBRARIES="cryptopp"
-		-DCRYPTOPP_FOUND=ON
 		# avoid automagically enabling of ccache (bug #611010)
 		-DCCACHE_EXECUTABLE=OFF
 		-DENABLE_BREAKPAD=OFF  #< disable crash reporting
@@ -144,6 +144,7 @@ src_configure() {
 		-DENABLE_LIBPULSE="$(usex pulseaudio)"
 		-DENABLE_UDISKS2="$(usex udisks)"
 		-DENABLE_WIIMOTEDEV="$(usex wiimote)"
+		"$(cmake_use_find_package alsa ALSA)"
 	)
 
 	use !debug && append-cppflags -DQT_NO_DEBUG_OUTPUT

--- a/media-sound/clementine/clementine-9999.ebuild
+++ b/media-sound/clementine/clementine-9999.ebuild
@@ -14,8 +14,8 @@ if [[ ${PV} == *9999* ]]; then
 	EGIT_REPO_URI="https://github.com/clementine-player/Clementine.git"
 	inherit git-r3
 else
-	S="${WORKDIR}/Clementine-${PV/_}"
 	SRC_URI="https://github.com/clementine-player/Clementine/archive/refs/tags/${PV/_}.tar.gz -> ${P}.tar.gz"
+	S="${WORKDIR}/Clementine-${PV/_}"
 	KEYWORDS="~amd64 ~arm64 ~ppc64 ~x86"
 fi
 
@@ -29,19 +29,8 @@ REQUIRED_USE="
 	wiimote? ( dbus )
 "
 
-BDEPEND="
-	>=dev-cpp/gtest-1.8.0
-	dev-qt/linguist-tools:5
-	sys-devel/gettext
-	virtual/pkgconfig
-	test? (
-		dev-qt/qttest:5
-		gnome-base/gsettings-desktop-schemas
-	)
-"
 COMMON_DEPEND="
 	dev-db/sqlite:3
-	dev-libs/crypto++:=
 	dev-libs/glib:2
 	dev-libs/protobuf:=
 	dev-qt/qtconcurrent:5
@@ -64,12 +53,13 @@ COMMON_DEPEND="
 	ipod? ( >=media-libs/libgpod-0.8.0 )
 	lastfm? ( >=media-libs/liblastfm-1.1.0_pre20150206 )
 	moodbar? ( sci-libs/fftw:3.0= )
-	mtp? ( >=media-libs/libmtp-1.0.0 )
+	mtp? ( >=media-libs/libmtp-1.0.0:= )
 	projectm? (
 		media-libs/glew:=
 		>=media-libs/libprojectm-3.1.12:0=
 		virtual/opengl
 	)
+	pulseaudio? ( media-libs/libpulse )
 "
 RDEPEND="${COMMON_DEPEND}
 	media-plugins/gst-plugins-meta:1.0
@@ -88,9 +78,18 @@ DEPEND="${COMMON_DEPEND}
 	box? ( dev-cpp/sparsehash )
 	dropbox? ( dev-cpp/sparsehash )
 	googledrive? ( dev-cpp/sparsehash )
-	pulseaudio? ( media-sound/pulseaudio )
 	seafile? ( dev-cpp/sparsehash )
 	skydrive? ( dev-cpp/sparsehash )
+"
+BDEPEND="
+	>=dev-cpp/gtest-1.8.0
+	dev-qt/linguist-tools:5
+	sys-devel/gettext
+	virtual/pkgconfig
+	test? (
+		dev-qt/qttest:5
+		gnome-base/gsettings-desktop-schemas
+	)
 "
 
 DOCS=( Changelog README.md )
@@ -115,9 +114,6 @@ src_prepare() {
 src_configure() {
 	local mycmakeargs=(
 		-DBUILD_WERROR=OFF
-		# force to find crypto++ see bug #548544
-		-DCRYPTOPP_LIBRARIES="cryptopp"
-		-DCRYPTOPP_FOUND=ON
 		# avoid automagically enabling of ccache (bug #611010)
 		-DCCACHE_EXECUTABLE=OFF
 		-DENABLE_BREAKPAD=OFF  #< disable crash reporting
@@ -141,6 +137,7 @@ src_configure() {
 		-DENABLE_LIBPULSE="$(usex pulseaudio)"
 		-DENABLE_UDISKS2="$(usex udisks)"
 		-DENABLE_WIIMOTEDEV="$(usex wiimote)"
+		"$(cmake_use_find_package alsa ALSA)"
 	)
 
 	use !debug && append-cppflags -DQT_NO_DEBUG_OUTPUT

--- a/media-sound/clementine/files/clementine-1.4.0_rc2-lz.patch
+++ b/media-sound/clementine/files/clementine-1.4.0_rc2-lz.patch
@@ -1,0 +1,33 @@
+https://github.com/clementine-player/Clementine/pull/7238
+https://bugs.gentoo.org/887105
+
+--- a/3rdparty/qtiocompressor/CMakeLists.txt
++++ b/3rdparty/qtiocompressor/CMakeLists.txt
+@@ -15,4 +15,4 @@ ADD_LIBRARY(qtiocompressor STATIC
+     ${IOCOMPRESSOR-SOURCES-MOC}
+ )
+ 
+-target_link_libraries(qtiocompressor Qt5::Core)
++target_link_libraries(qtiocompressor Qt5::Core ${ZLIB_LIBRARIES})
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -78,9 +78,7 @@ pkg_check_modules(LIBXML libxml-2.0)
+ pkg_check_modules(LIBSPOTIFY libspotify>=12.1.45)
+ pkg_check_modules(TAGLIB taglib)
+ 
+-if (WIN32)
+   find_package(ZLIB REQUIRED)
+-endif (WIN32)
+ 
+ find_library(LASTFM5_LIBRARIES lastfm5)
+ find_path(LASTFM5_INCLUDE_DIRS lastfm5/ws.h)
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -1303,7 +1303,6 @@ target_link_libraries(clementine_lib
+   ${SQLITE_LIBRARIES}
+ 
+   Qocoa
+-  z
+ )
+ 
+ link_directories(


### PR DESCRIPTION
crypto++ was required only for spotify which is gone (https://bugs.gentoo.org/885529)

Bug: https://bugs.gentoo.org/887105
Bug: https://bugs.gentoo.org/887163
Signed-off-by: Alexey Sokolov <alexey+gentoo@asokolov.org>