### PR TITLE
dev-libs/libbpf: Export PKG_CONFIG

### DIFF
--- a/dev-libs/libbpf/libbpf-1.0.1-r1.ebuild
+++ b/dev-libs/libbpf/libbpf-1.0.1-r1.ebuild
@@ -32,7 +32,7 @@ PATCHES=(
 
 src_configure() {
 	append-cflags -fPIC
-	tc-export CC AR
+	tc-export CC AR PKG_CONFIG
 	export LIBSUBDIR="$(get_libdir)"
 	export LIBDIR="${EPREFIX}/usr/$(get_libdir)"
 	export V=1


### PR DESCRIPTION
libbpf uses pkg-config as mentioned in libbpf_build.rst