### PR TITLE
net-analyzer/macchanger: fix for USE="-split-usr"

### DIFF
--- a/net-analyzer/macchanger/macchanger-1.7.0_p5_p4-r1.ebuild
+++ b/net-analyzer/macchanger/macchanger-1.7.0_p5_p4-r1.ebuild
@@ -29,7 +29,7 @@ S=${WORKDIR}/${P/_p*}
 src_configure() {
 	# Shared data is installed below /lib, see Bug #57046
 	econf \
-		--bindir="${EPREFIX}/sbin" \
+		--bindir="${EPREFIX}/usr/bin" \
 		--datadir="${EPREFIX}/lib"
 }
 
@@ -38,7 +38,5 @@ src_install() {
 
 	newdoc "${WORKDIR}"/debian/changelog debian.changelog
 
-	dodir /usr/bin
-	dosym ../../sbin/macchanger /usr/bin/macchanger
 	dosym ../../lib/macchanger /usr/share/macchanger
 }


### PR DESCRIPTION
Currently, the ebuild for macchanger always creates a symlink `/usr/bin/macchanger => ../../sbin/macchanger`, however, this obviously breaks with USE="-split-usr". This PR gates the symlink creation behind USE="split-usr" being set.