### PR TITLE
Media gfx/freecad 0.20.1 Third time lucky

### DIFF
--- a/dev-libs/OpenNI2/OpenNI2-2.2_beta2-r1.ebuild
+++ b/dev-libs/OpenNI2/OpenNI2-2.2_beta2-r1.ebuild
@@ -14,7 +14,7 @@ inherit ${SCM} toolchain-funcs java-pkg-opt-2
 if [ "${PV#9999}" != "${PV}" ] ; then
 	SRC_URI=""
 else
-	KEYWORDS="amd64 ~arm"
+	KEYWORDS="amd64 ~arm ~arm64"
 	SRC_URI="https://github.com/occipital/OpenNI2/archive/${PV/_/-}.tar.gz -> ${P}.tar.gz"
 	S="${WORKDIR}/${P/_/-}"
 fi

--- a/dev-libs/OpenNI2/files/build_on_arm64_and_ppc.patch
+++ b/dev-libs/OpenNI2/files/build_on_arm64_and_ppc.patch
@@ -1,0 +1,393 @@
+diff --git a/Include/Linux-Aarch64/OniPlatformLinux-Aarch64.h b/Include/Linux-Aarch64/OniPlatformLinux-Aarch64.h
+new file mode 100644
+index 0000000..f777e5f
+--- /dev/null
++++ b/Include/Linux-Aarch64/OniPlatformLinux-Aarch64.h
+@@ -0,0 +1,45 @@
++/*****************************************************************************
++*                                                                            *
++*  OpenNI 2.x Alpha                                                          *
++*  Copyright (C) 2012 PrimeSense Ltd.                                        *
++*                                                                            *
++*  This file is part of OpenNI.                                              *
++*                                                                            *
++*  Licensed under the Apache License, Version 2.0 (the "License");           *
++*  you may not use this file except in compliance with the License.          *
++*  You may obtain a copy of the License at                                   *
++*                                                                            *
++*      http://www.apache.org/licenses/LICENSE-2.0                            *
++*                                                                            *
++*  Unless required by applicable law or agreed to in writing, software       *
++*  distributed under the License is distributed on an "AS IS" BASIS,         *
++*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  *
++*  See the License for the specific language governing permissions and       *
++*  limitations under the License.                                            *
++*                                                                            *
++*****************************************************************************/
++#ifndef _ONI_PLATFORM_LINUX_AARCH64_H_
++#define _ONI_PLATFORM_LINUX_AARCH64_H_
++
++// Start with Linux-x86, and override what's different
++#include "../Linux-x86/OniPlatformLinux-x86.h"
++
++//---------------------------------------------------------------------------
++// Platform Basic Definition
++//---------------------------------------------------------------------------
++#undef ONI_PLATFORM
++#undef ONI_PLATFORM_STRING
++#define ONI_PLATFORM ONI_PLATFORM_LINUX_AARCH64
++#define ONI_PLATFORM_STRING "Linux-Aarch64"
++
++//---------------------------------------------------------------------------
++// Platform Capabilities
++//---------------------------------------------------------------------------
++#undef ONI_PLATFORM_ENDIAN_TYPE
++#ifdef __ARM_BIG_ENDIAN
++#define ONI_PLATFORM_ENDIAN_TYPE ONI_PLATFORM_IS_BIG_ENDIAN
++#else
++#define ONI_PLATFORM_ENDIAN_TYPE ONI_PLATFORM_IS_LITTLE_ENDIAN
++#endif
++
++#endif //_ONI_PLATFORM_LINUX_AARCH64_H_
+diff --git a/Include/Linux-Ppc/OniPlatformLinux-Ppc.h b/Include/Linux-Ppc/OniPlatformLinux-Ppc.h
+new file mode 100644
+index 0000000..690740b
+--- /dev/null
++++ b/Include/Linux-Ppc/OniPlatformLinux-Ppc.h
+@@ -0,0 +1,46 @@
++/*****************************************************************************
++*                                                                            *
++*  OpenNI 2.x Alpha                                                          *
++*  Copyright (C) 2012 PrimeSense Ltd.                                        *
++*                                                                            *
++*  This file is part of OpenNI.                                              *
++*                                                                            *
++*  Licensed under the Apache License, Version 2.0 (the "License");           *
++*  you may not use this file except in compliance with the License.          *
++*  You may obtain a copy of the License at                                   *
++*                                                                            *
++*      http://www.apache.org/licenses/LICENSE-2.0                            *
++*                                                                            *
++*  Unless required by applicable law or agreed to in writing, software       *
++*  distributed under the License is distributed on an "AS IS" BASIS,         *
++*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  *
++*  See the License for the specific language governing permissions and       *
++*  limitations under the License.                                            *
++*                                                                            *
++*****************************************************************************/
++#ifndef _ONI_PLATFORM_LINUX_PPC_H_
++#define _ONI_PLATFORM_LINUX_PPC_H_
++
++// Start with Linux-x86, and override what's different
++#include "../Linux-x86/OniPlatformLinux-x86.h"
++
++//---------------------------------------------------------------------------
++// Platform Basic Definition
++//---------------------------------------------------------------------------
++#undef ONI_PLATFORM
++#undef ONI_PLATFORM_STRING
++#define ONI_PLATFORM ONI_PLATFORM_LINUX_PPC
++#define ONI_PLATFORM_STRING "Linux-Ppc"
++
++//---------------------------------------------------------------------------
++// Platform Capabilities
++//---------------------------------------------------------------------------
++#undef ONI_PLATFORM_ENDIAN_TYPE
++#ifdef __LITTLE_ENDIAN__
++#define ONI_PLATFORM_ENDIAN_TYPE ONI_PLATFORM_IS_LITTLE_ENDIAN
++#else
++#define ONI_PLATFORM_ENDIAN_TYPE ONI_PLATFORM_IS_BIG_ENDIAN
++#endif
++
++#endif //_ONI_PLATFORM_LINUX_PPC_H_
++
+diff --git a/Include/OniPlatform.h b/Include/OniPlatform.h
+index 2384188..a0cfd32 100644
+--- a/Include/OniPlatform.h
++++ b/Include/OniPlatform.h
+@@ -27,6 +27,8 @@
+ #define ONI_PLATFORM_LINUX_ARM 3
+ #define ONI_PLATFORM_MACOSX 4
+ #define ONI_PLATFORM_ANDROID_ARM 5
++#define ONI_PLATFORM_LINUX_AARCH64 6
++#define ONI_PLATFORM_LINUX_PPC 7
+ 
+ #if (defined _WIN32)
+ #	ifndef RC_INVOKED
+@@ -39,8 +41,12 @@
+ #	include "Android-Arm/OniPlatformAndroid-Arm.h"
+ #elif (__linux__ && (i386 || __x86_64__))
+ #	include "Linux-x86/OniPlatformLinux-x86.h"
++#elif (__linux__ && __aarch64__)
++#	include "Linux-Aarch64/OniPlatformLinux-Aarch64.h"
+ #elif (__linux__ && __arm__)
+ #	include "Linux-Arm/OniPlatformLinux-Arm.h"
++#elif (__linux__ && __powerpc__)
++#	include "Linux-Ppc/OniPlatformLinux-Ppc.h"
+ #elif _ARC
+ #	include "ARC/OniPlaformARC.h"
+ #elif (__APPLE__)
+diff --git a/Source/Drivers/PS1080/Sensor/XnDeviceSensorInit.h b/Source/Drivers/PS1080/Sensor/XnDeviceSensorInit.h
+index 27b5c8b..bb4e9e0 100644
+--- a/Source/Drivers/PS1080/Sensor/XnDeviceSensorInit.h
++++ b/Source/Drivers/PS1080/Sensor/XnDeviceSensorInit.h
+@@ -57,7 +57,7 @@
+ 
+ 	#define XN_SENSOR_USB_MISC_BUFFER_SIZE	0x1000
+ 	#define XN_SENSOR_USB_MISC_BUFFERS		1
+-#elif (XN_PLATFORM == XN_PLATFORM_LINUX_X86 || XN_PLATFORM == XN_PLATFORM_LINUX_ARM || XN_PLATFORM == XN_PLATFORM_MACOSX || XN_PLATFORM == XN_PLATFORM_ANDROID_ARM)
++#elif (XN_PLATFORM == XN_PLATFORM_LINUX_X86 || XN_PLATFORM == XN_PLATFORM_LINUX_ARM || XN_PLATFORM == XN_PLATFORM_LINUX_AARCH64 || XN_PLATFORM == XN_PLATFORM_LINUX_PPC || XN_PLATFORM == XN_PLATFORM_MACOSX || XN_PLATFORM == XN_PLATFORM_ANDROID_ARM)
+ 	#define XN_SENSOR_USB_IMAGE_BUFFER_SIZE_MULTIPLIER_ISO				32
+ 	#define XN_SENSOR_USB_IMAGE_BUFFER_SIZE_MULTIPLIER_BULK				40
+ 	#define XN_SENSOR_USB_IMAGE_BUFFER_SIZE_MULTIPLIER_LOWBAND_ISO		16
+diff --git a/Source/Drivers/PSLink/LinkProtoLib/XnClientUSBInDataEndpoint.cpp b/Source/Drivers/PSLink/LinkProtoLib/XnClientUSBInDataEndpoint.cpp
+index d61b559..35ae726 100644
+--- a/Source/Drivers/PSLink/LinkProtoLib/XnClientUSBInDataEndpoint.cpp
++++ b/Source/Drivers/PSLink/LinkProtoLib/XnClientUSBInDataEndpoint.cpp
+@@ -36,7 +36,7 @@ namespace xn
+ 	const XnUInt32 ClientUSBInDataEndpoint::READ_THREAD_BUFFER_NUM_PACKETS_BULK = 120;
+ 	const XnUInt32 ClientUSBInDataEndpoint::READ_THREAD_NUM_BUFFERS_BULK = 8;
+ 	const XnUInt32 ClientUSBInDataEndpoint::READ_THREAD_TIMEOUT_BULK = 1000;
+-#elif (XN_PLATFORM == XN_PLATFORM_LINUX_X86 || XN_PLATFORM == XN_PLATFORM_LINUX_ARM || XN_PLATFORM == XN_PLATFORM_MACOSX || XN_PLATFORM == XN_PLATFORM_ANDROID_ARM)
++#elif (XN_PLATFORM == XN_PLATFORM_LINUX_X86 || XN_PLATFORM == XN_PLATFORM_LINUX_ARM || XN_PLATFORM == XN_PLATFORM_LINUX_AARCH64 || XN_PLATFORM == XN_PLATFORM_LINUX_PPC || XN_PLATFORM == XN_PLATFORM_MACOSX || XN_PLATFORM == XN_PLATFORM_ANDROID_ARM)
+ 	const XnUInt32 ClientUSBInDataEndpoint::READ_THREAD_BUFFER_NUM_PACKETS_ISO = 32;
+ 	const XnUInt32 ClientUSBInDataEndpoint::READ_THREAD_NUM_BUFFERS_ISO = 16;
+ 	const XnUInt32 ClientUSBInDataEndpoint::READ_THREAD_TIMEOUT_ISO = 100;
+diff --git a/Source/Tools/NiViewer/NiViewer.cpp b/Source/Tools/NiViewer/NiViewer.cpp
+index df7dde5..cdd54cc 100644
+--- a/Source/Tools/NiViewer/NiViewer.cpp
++++ b/Source/Tools/NiViewer/NiViewer.cpp
+@@ -68,7 +68,7 @@
+ #if (ONI_PLATFORM == ONI_PLATFORM_WIN32)
+ 	#include <conio.h>
+ 	#include <direct.h>	
+-#elif (ONI_PLATFORM == ONI_PLATFORM_LINUX_X86 || ONI_PLATFORM == ONI_PLATFORM_LINUX_ARM || ONI_PLATFORM == ONI_PLATFORM_MACOSX)
++#elif (ONI_PLATFORM == ONI_PLATFORM_LINUX_X86 || ONI_PLATFORM == ONI_PLATFORM_LINUX_ARM || ONI_PLATFORM == ONI_PLATFORM_LINUX_AARCH64 || ONI_PLATFORM == ONI_PLATFORM_LINUX_PPC || ONI_PLATFORM == ONI_PLATFORM_MACOSX)
+ 	#define _getch() getchar()
+ #endif
+ 
+diff --git a/ThirdParty/PSCommon/BuildSystem/CommonDefs.mak b/ThirdParty/PSCommon/BuildSystem/CommonDefs.mak
+index dd88b04..ebd6fc4 100644
+--- a/ThirdParty/PSCommon/BuildSystem/CommonDefs.mak
++++ b/ThirdParty/PSCommon/BuildSystem/CommonDefs.mak
+@@ -18,6 +18,12 @@ else ifneq (,$(findstring i386,$(MACHINE)))
+ 	HOST_PLATFORM = x86
+ else ifneq (,$(findstring arm,$(MACHINE)))
+ 	HOST_PLATFORM = Arm
++else ifneq (,$(findstring aarch64,$(MACHINE)))
++	HOST_PLATFORM = Aarch64
++else ifneq (,$(findstring ppc64,$(MACHINE)))
++	HOST_PLATFORM = Ppc64
++else ifneq (,$(findstring ppc64,$(MACHINE)))
++	HOST_PLATFORM = Ppc
+ else
+ 	DUMMY:=$(error Can't determine host platform)
+ endif
+diff --git a/ThirdParty/PSCommon/BuildSystem/Platform.Aarch64 b/ThirdParty/PSCommon/BuildSystem/Platform.Aarch64
+new file mode 100644
+index 0000000..c471458
+--- /dev/null
++++ b/ThirdParty/PSCommon/BuildSystem/Platform.Aarch64
+@@ -0,0 +1,14 @@
++ifeq "$(CFG)" "Release"
++
++    # Hardware specifying flags
++    CFLAGS += -march=armv8-a -mtune=cortex-a72
++
++    # Optimization level, minus currently buggy optimizing methods (which break bit-exact)
++    CFLAGS += -O3 -fno-tree-pre -fno-strict-aliasing
++
++    # More optimization flags
++    CFLAGS += -ftree-vectorize -ffast-math -funsafe-math-optimizations #-fsingle-precision-constant
++
++    DEFINES += XN_NEON
++    CFLAGS += -flax-vector-conversions
++endif
+diff --git a/ThirdParty/PSCommon/BuildSystem/Platform.Ppc b/ThirdParty/PSCommon/BuildSystem/Platform.Ppc
+new file mode 100644
+index 0000000..1648cce
+--- /dev/null
++++ b/ThirdParty/PSCommon/BuildSystem/Platform.Ppc
+@@ -0,0 +1,2 @@
++# some defaults
++export GLUT_SUPPORTED=1
+diff --git a/ThirdParty/PSCommon/BuildSystem/Platform.Ppc64 b/ThirdParty/PSCommon/BuildSystem/Platform.Ppc64
+new file mode 100644
+index 0000000..32c4aeb
+--- /dev/null
++++ b/ThirdParty/PSCommon/BuildSystem/Platform.Ppc64
+@@ -0,0 +1,5 @@
++# take this file's dir
++COMMON_MAK_DIR = $(dir $(lastword $(MAKEFILE_LIST)))
++
++# everything is the same as in Ppc
++include $(COMMON_MAK_DIR)Platform.Ppc
+diff --git a/ThirdParty/PSCommon/XnLib/Include/Linux-Aarch64/XnPlatformLinux-Aarch64.h b/ThirdParty/PSCommon/XnLib/Include/Linux-Aarch64/XnPlatformLinux-Aarch64.h
+new file mode 100644
+index 0000000..87a3f66
+--- /dev/null
++++ b/ThirdParty/PSCommon/XnLib/Include/Linux-Aarch64/XnPlatformLinux-Aarch64.h
+@@ -0,0 +1,46 @@
++/*****************************************************************************
++*                                                                            *
++*  PrimeSense PSCommon Library                                               *
++*  Copyright (C) 2012 PrimeSense Ltd.                                        *
++*                                                                            *
++*  This file is part of PSCommon.                                            *
++*                                                                            *
++*  Licensed under the Apache License, Version 2.0 (the "License");           *
++*  you may not use this file except in compliance with the License.          *
++*  You may obtain a copy of the License at                                   *
++*                                                                            *
++*      http://www.apache.org/licenses/LICENSE-2.0                            *
++*                                                                            *
++*  Unless required by applicable law or agreed to in writing, software       *
++*  distributed under the License is distributed on an "AS IS" BASIS,         *
++*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  *
++*  See the License for the specific language governing permissions and       *
++*  limitations under the License.                                            *
++*                                                                            *
++*****************************************************************************/
++#ifndef _XN_PLATFORM_LINUX_AARCH64_H_
++#define _XN_PLATFORM_LINUX_AARCH64_H_
++
++// Start with Linux-x86, and override what's different
++#include "../Linux-x86/XnPlatformLinux-x86.h"
++
++//---------------------------------------------------------------------------
++// Platform Basic Definition
++//---------------------------------------------------------------------------
++#undef XN_PLATFORM
++#undef XN_PLATFORM_STRING
++#define XN_PLATFORM XN_PLATFORM_LINUX_AARCH64
++#define XN_PLATFORM_STRING "Linux-Aarch64"
++
++//---------------------------------------------------------------------------
++// Platform Capabilities
++//---------------------------------------------------------------------------
++#undef XN_PLATFORM_ENDIAN_TYPE
++#ifdef __ARM_BIG_ENDIAN
++#define XN_PLATFORM_ENDIAN_TYPE XN_PLATFORM_IS_BIG_ENDIAN
++#else
++#define XN_PLATFORM_ENDIAN_TYPE XN_PLATFORM_IS_LITTLE_ENDIAN
++#endif
++
++#endif //_XN_PLATFORM_LINUX_AARCH64_H_
++
+diff --git a/ThirdParty/PSCommon/XnLib/Include/Linux-Ppc/XnPlatformLinux-Ppc.h b/ThirdParty/PSCommon/XnLib/Include/Linux-Ppc/XnPlatformLinux-Ppc.h
+new file mode 100644
+index 0000000..91f9517
+--- /dev/null
++++ b/ThirdParty/PSCommon/XnLib/Include/Linux-Ppc/XnPlatformLinux-Ppc.h
+@@ -0,0 +1,46 @@
++/*****************************************************************************
++*                                                                            *
++*  PrimeSense PSCommon Library                                               *
++*  Copyright (C) 2012 PrimeSense Ltd.                                        *
++*                                                                            *
++*  This file is part of PSCommon.                                            *
++*                                                                            *
++*  Licensed under the Apache License, Version 2.0 (the "License");           *
++*  you may not use this file except in compliance with the License.          *
++*  You may obtain a copy of the License at                                   *
++*                                                                            *
++*      http://www.apache.org/licenses/LICENSE-2.0                            *
++*                                                                            *
++*  Unless required by applicable law or agreed to in writing, software       *
++*  distributed under the License is distributed on an "AS IS" BASIS,         *
++*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  *
++*  See the License for the specific language governing permissions and       *
++*  limitations under the License.                                            *
++*                                                                            *
++*****************************************************************************/
++#ifndef _XN_PLATFORM_LINUX_PPC_H_
++#define _XN_PLATFORM_LINUX_PPC_H_
++
++// Start with Linux-x86, and override what's different
++#include "../Linux-x86/XnPlatformLinux-x86.h"
++
++//---------------------------------------------------------------------------
++// Platform Basic Definition
++//---------------------------------------------------------------------------
++#undef XN_PLATFORM
++#undef XN_PLATFORM_STRING
++#define XN_PLATFORM XN_PLATFORM_LINUX_PPC
++#define XN_PLATFORM_STRING "Linux-Ppc"
++
++//---------------------------------------------------------------------------
++// Platform Capabilities
++//---------------------------------------------------------------------------
++#undef XN_PLATFORM_ENDIAN_TYPE
++#ifdef __LITTLE_ENDIAN__
++#define XN_PLATFORM_ENDIAN_TYPE XN_PLATFORM_IS_LITTLE_ENDIAN
++#else
++#define XN_PLATFORM_ENDIAN_TYPE XN_PLATFORM_IS_BIG_ENDIAN
++#endif
++
++#endif //_XN_PLATFORM_LINUX_PPC_H_
++
+diff --git a/ThirdParty/PSCommon/XnLib/Include/XnOS.h b/ThirdParty/PSCommon/XnLib/Include/XnOS.h
+index 3e41060..9f78851 100644
+--- a/ThirdParty/PSCommon/XnLib/Include/XnOS.h
++++ b/ThirdParty/PSCommon/XnLib/Include/XnOS.h
+@@ -43,7 +43,7 @@
+ //---------------------------------------------------------------------------
+ #if (XN_PLATFORM == XN_PLATFORM_WIN32)
+ 	#include "Win32/XnOSWin32.h"
+-#elif (XN_PLATFORM == XN_PLATFORM_LINUX_X86 || XN_PLATFORM == XN_PLATFORM_LINUX_ARM || XN_PLATFORM == XN_PLATFORM_ANDROID_ARM)
++#elif (XN_PLATFORM == XN_PLATFORM_LINUX_X86 || XN_PLATFORM == XN_PLATFORM_LINUX_ARM || XN_PLATFORM == XN_PLATFORM_LINUX_AARCH64 || XN_PLATFORM == XN_PLATFORM_LINUX_PPC || XN_PLATFORM == XN_PLATFORM_ANDROID_ARM)
+ 	#include "Linux-x86/XnOSLinux-x86.h"
+ #elif (XN_PLATFORM == XN_PLATFORM_MACOSX)
+         #include "MacOSX/XnOSMacOSX.h"
+diff --git a/ThirdParty/PSCommon/XnLib/Include/XnPlatform.h b/ThirdParty/PSCommon/XnLib/Include/XnPlatform.h
+index 07e8192..3578a28 100644
+--- a/ThirdParty/PSCommon/XnLib/Include/XnPlatform.h
++++ b/ThirdParty/PSCommon/XnLib/Include/XnPlatform.h
+@@ -31,6 +31,8 @@
+ #define XN_PLATFORM_LINUX_ARM 7
+ #define XN_PLATFORM_MACOSX 8
+ #define XN_PLATFORM_ANDROID_ARM 9
++#define XN_PLATFORM_LINUX_AARCH64 10
++#define XN_PLATFORM_LINUX_PPC 11
+ 
+ #define XN_PLATFORM_IS_LITTLE_ENDIAN 1
+ #define XN_PLATFORM_IS_BIG_ENDIAN    2
+@@ -51,8 +53,12 @@
+ #include "Android-Arm/XnPlatformAndroid-Arm.h"
+ #elif (__linux__ && (i386 || __x86_64__))
+ #include "Linux-x86/XnPlatformLinux-x86.h"
++#elif (__linux__ && __aarch64__)
++#include "Linux-Aarch64/XnPlatformLinux-Aarch64.h"
+ #elif (__linux__ && __arm__)
+ #include "Linux-Arm/XnPlatformLinux-Arm.h"
++#elif (__linux__ && __powerpc__)
++#include "Linux-Ppc/XnPlatformLinux-Ppc.h"
+ #elif _ARC
+ #include "ARC/XnPlaformARC.h"
+ #elif (__APPLE__)
+diff --git a/ThirdParty/PSCommon/XnLib/Include/XnUSBDevice.h b/ThirdParty/PSCommon/XnLib/Include/XnUSBDevice.h
+index 94c729b..bf089af 100644
+--- a/ThirdParty/PSCommon/XnLib/Include/XnUSBDevice.h
++++ b/ThirdParty/PSCommon/XnLib/Include/XnUSBDevice.h
+@@ -47,7 +47,7 @@
+ 	#define USB_DT_DEVICE_SIZE 0
+ 	#define USB_DT_DEVICE 0
+ 
+-#elif (XN_PLATFORM == XN_PLATFORM_LINUX_X86 || XN_PLATFORM == XN_PLATFORM_LINUX_ARM)
++#elif (XN_PLATFORM == XN_PLATFORM_LINUX_X86 || XN_PLATFORM == XN_PLATFORM_LINUX_ARM || XN_PLATFORM == XN_PLATFORM_LINUX_AARCH64 || XN_PLATFORM == XN_PLATFORM_LINUX_PPC)
+ 	#include <linux/usb/ch9.h>
+ 	typedef struct usb_endpoint_descriptor XnUSBEndpointDescriptor;
+ 	typedef struct usb_interface_descriptor XnUSBInterfaceDescriptor;
+diff --git a/ThirdParty/PSCommon/XnLib/Source/Linux/XnLinuxUSB.cpp b/ThirdParty/PSCommon/XnLib/Source/Linux/XnLinuxUSB.cpp
+index b886f82..1a1235a 100644
+--- a/ThirdParty/PSCommon/XnLib/Source/Linux/XnLinuxUSB.cpp
++++ b/ThirdParty/PSCommon/XnLib/Source/Linux/XnLinuxUSB.cpp
+@@ -36,7 +36,7 @@
+ #include <XnOSCpp.h>
+ #include <XnList.h>
+ 
+-#if (XN_PLATFORM == XN_PLATFORM_LINUX_X86 || XN_PLATFORM == XN_PLATFORM_LINUX_ARM)
++#if (XN_PLATFORM == XN_PLATFORM_LINUX_X86 || XN_PLATFORM == XN_PLATFORM_LINUX_ARM || XN_PLATFORM == XN_PLATFORM_LINUX_AARCH64 || XN_PLATFORM_LINUX_PPC)
+ #include <libudev.h>
+ #define XN_USE_UDEV
+ #endif

--- a/dev-libs/OpenNI2/files/build_on_arm64_and_ppc_PS1200Device.cpp.patch
+++ b/dev-libs/OpenNI2/files/build_on_arm64_and_ppc_PS1200Device.cpp.patch
@@ -1,0 +1,11 @@
+--- a/Source/Drivers/PSLink/PS1200Device.cpp_org	2022-11-19 18:40:24.772505998 -0000
++++ b/Source/Drivers/PSLink/PS1200Device.cpp	2022-11-19 18:41:46.388543221 -0000
+@@ -43,7 +43,7 @@
+ 	// On all platforms other than Windows, prefer BULK
+ 	nRetVal = SetUsbAltInterface(0);
+ 	XN_IS_STATUS_OK_LOG_ERROR("Switch to ISO", nRetVal);
+-#elif (XN_PLATFORM == XN_PLATFORM_LINUX_X86 || XN_PLATFORM == XN_PLATFORM_LINUX_ARM || XN_PLATFORM == XN_PLATFORM_MACOSX || XN_PLATFORM == XN_PLATFORM_ANDROID_ARM)
++#elif (XN_PLATFORM == XN_PLATFORM_LINUX_X86 || XN_PLATFORM == XN_PLATFORM_LINUX_ARM || XN_PLATFORM == XN_PLATFORM_LINUX_AARCH64 || XN_PLATFORM == XN_PLATFORM_LINUX_PPC || XN_PLATFORM == XN_PLATFORM_MACOSX || XN_PLATFORM == XN_PLATFORM_ANDROID_ARM)
+ 	// On all platforms other than Windows, prefer BULK
+ 	nRetVal = SetUsbAltInterface(1);
+ 	XN_IS_STATUS_OK_LOG_ERROR("Switch to BULK", nRetVal);

--- a/dev-python/pivy/pivy-0.6.8.ebuild
+++ b/dev-python/pivy/pivy-0.6.8.ebuild
@@ -16,7 +16,7 @@ if [[ ${PV} == *9999 ]]; then
 	PIVY_REPO_URI="https://github.com/coin3d/pivy.git"
 else
 	SRC_URI="https://github.com/coin3d/pivy/archive/refs/tags/${PV}.tar.gz -> ${P}.tar.gz"
-	KEYWORDS="amd64 x86"
+	KEYWORDS="amd64 ~arm64 x86"
 fi
 
 LICENSE="ISC"

--- a/media-gfx/freecad/files/freecad_toomany.patch
+++ b/media-gfx/freecad/files/freecad_toomany.patch
@@ -1,0 +1,10 @@
+--- FreeCAD-0.20.1/src/Mod/Part/App/OCCError.h.orig     2022-11-27 08:47:14.905666640 -0800
++++ FreeCAD-0.20.1/src/Mod/Part/App/OCCError.h  2022-11-27 08:47:47.769840954 -0800
+@@ -50,7 +50,6 @@
+ # include <Standard_Overflow.hxx>
+ # include <Standard_ProgramError.hxx>
+ # include <Standard_RangeError.hxx>
+-# include <Standard_TooManyUsers.hxx>
+ # include <Standard_TypeMismatch.hxx>
+ # include <Standard_Underflow.hxx>
+

--- a/media-gfx/freecad/freecad-0.20.1-r1.ebuild
+++ b/media-gfx/freecad/freecad-0.20.1-r1.ebuild
@@ -1,0 +1,303 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+PYTHON_COMPAT=( python3_{8..10} )
+
+inherit check-reqs cmake optfeature python-single-r1 xdg
+
+DESCRIPTION="QT based Computer Aided Design application"
+HOMEPAGE="https://www.freecad.org/ https://github.com/FreeCAD/FreeCAD"
+
+MY_PN=FreeCAD
+
+if [[ ${PV} = *9999 ]]; then
+	inherit git-r3
+	EGIT_REPO_URI="https://github.com/${MY_PN}/${MY_PN}.git"
+	S="${WORKDIR}/freecad-${PV}"
+else
+	SRC_URI="https://github.com/${MY_PN}/${MY_PN}/archive/refs/tags/${PV}.tar.gz -> ${P}.tar.gz"
+	KEYWORDS="~arm64"
+	S="${WORKDIR}/FreeCAD-${PV}"
+fi
+
+# code is licensed LGPL-2
+# examples are licensed CC-BY-SA (without note of specific version)
+LICENSE="LGPL-2 CC-BY-SA-4.0"
+SLOT="0"
+IUSE="debug designer headless test"
+
+FREECAD_EXPERIMENTAL_MODULES="cloud pcl"
+FREECAD_STABLE_MODULES="addonmgr fem idf image inspection material
+	openscad part-design path points raytracing robot show surface
+	techdraw tux"
+
+for module in ${FREECAD_STABLE_MODULES}; do
+	IUSE="${IUSE} +${module}"
+done
+for module in ${FREECAD_EXPERIMENTAL_MODULES}; do
+	IUSE="${IUSE} ${module}"
+done
+unset module
+
+RESTRICT="!test? ( test )"
+
+RDEPEND="
+	${PYTHON_DEPS}
+	dev-libs/OpenNI2[opengl(+)]
+	dev-libs/libspnav[X]
+	dev-libs/xerces-c[icu]
+	dev-qt/designer:5
+	dev-qt/qtconcurrent:5
+	dev-qt/qtcore:5
+	dev-qt/qtgui:5
+	dev-qt/qtnetwork:5
+	dev-qt/qtopengl:5
+	dev-qt/qtprintsupport:5
+	dev-qt/qtsvg:5
+	dev-qt/qtwebengine:5[widgets]
+	dev-qt/qtwidgets:5
+	dev-qt/qtx11extras:5
+	dev-qt/qtxml:5
+	>=media-libs/coin-4.0.0
+	media-libs/freetype
+	media-libs/qhull:=
+	sci-libs/flann[openmp]
+	sci-libs/hdf5:=[fortran,zlib]
+	>=sci-libs/med-4.0.0-r1[python,${PYTHON_SINGLE_USEDEP}]
+	sci-libs/opencascade:=[json,vtk]
+	sci-libs/orocos_kdl:=
+	sys-libs/zlib
+	virtual/glu
+	virtual/libusb:1
+	virtual/opengl
+	cloud? (
+		dev-libs/openssl:=
+		net-misc/curl
+	)
+	fem? ( sci-libs/vtk:=[boost(+),python,qt5,rendering,${PYTHON_SINGLE_USEDEP}] )
+	openscad? ( media-gfx/openscad )
+	pcl? ( >=sci-libs/pcl-1.8.1:=[opengl,openni2,qt5,vtk] )
+	$(python_gen_cond_dep '
+		dev-libs/boost:=[python,${PYTHON_USEDEP}]
+		dev-python/matplotlib[${PYTHON_USEDEP}]
+		dev-python/numpy[${PYTHON_USEDEP}]
+		>=dev-python/pivy-0.6.5[${PYTHON_USEDEP}]
+		dev-python/pybind11[${PYTHON_USEDEP}]
+		dev-python/pyside2[gui,svg,webchannel,webengine,${PYTHON_USEDEP}]
+		dev-python/shiboken2[${PYTHON_USEDEP}]
+		addonmgr? ( dev-python/GitPython[${PYTHON_USEDEP}] )
+		fem? ( dev-python/ply[${PYTHON_USEDEP}] )
+	')
+"
+DEPEND="
+	${RDEPEND}
+	>=dev-cpp/eigen-3.3.1:3
+"
+BDEPEND="
+	app-text/dos2unix
+	dev-lang/swig
+"
+
+# To get required dependencies:
+# 'grep REQUIRES_MODS cMake/FreeCAD_Helpers/CheckInterModuleDependencies.cmake'
+# We set the following requirements by default:
+# arch, draft, drawing, import, mesh, part, qt5, sketcher, spreadsheet, start, web.
+#
+# Additionally, we auto-enable mesh_part, flat_mesh and smesh
+# Fem actually needs smesh, but as long as we don't have a smesh package, we enable
+# smesh through the mesh USE flag. Note however, the fem<-smesh dependency isn't
+# reflected by the REQUIRES_MODS macro, but at
+# cMake/FreeCAD_Helpers/InitializeFreeCADBuildOptions.cmake:187.
+#
+# The increase in auto-enabled workbenches is due to their need in parts of the
+# test suite when compiled with a minimal set of USE flags.
+REQUIRED_USE="
+	${PYTHON_REQUIRED_USE}
+	inspection? ( points )
+	path? ( robot )
+"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-0.19.4-Gentoo-specific-don-t-check-vcs.patch
+	"${FILESDIR}"/${PN}-0.19.1-0001-Gentoo-specific-Remove-ccache-usage.patch
+)
+
+DOCS=( CODE_OF_CONDUCT.md ChangeLog.txt README.md )
+
+CHECKREQS_DISK_BUILD="2G"
+
+pkg_setup() {
+	check-reqs_pkg_setup
+	python-single-r1_pkg_setup
+	[[ -z ${CASROOT} ]] && die "\${CASROOT} not set, please run eselect opencascade"
+}
+
+src_prepare() {
+	# Fix desktop file
+	sed -e 's/Exec=FreeCAD/Exec=freecad/' -i src/XDGData/org.freecadweb.FreeCAD.desktop || die
+
+	find "${S}" -type f -exec dos2unix -q {} \; || die "failed to convert to unix line endings"
+
+	cmake_src_prepare
+}
+
+src_configure() {
+	local mycmakeargs=(
+		-DBUILD_ADDONMGR=$(usex addonmgr)
+		-DBUILD_ARCH=ON
+		-DBUILD_ASSEMBLY=OFF					# deprecated
+		-DBUILD_CLOUD=$(usex cloud)
+		-DBUILD_COMPLETE=OFF					# deprecated
+		-DBUILD_DRAFT=ON
+		-DBUILD_DESIGNER_PLUGIN=$(usex designer)
+		-DBUILD_DRAWING=ON
+		-DBUILD_ENABLE_CXX_STD:STRING="C++17"	# needed for >=boost-1.77.0
+		-DBUILD_FEM=$(usex fem)
+		-DBUILD_FEM_NETGEN=OFF
+		-DBUILD_FLAT_MESH=ON
+		-DBUILD_FORCE_DIRECTORY=ON				# force building in a dedicated directory
+		-DBUILD_FREETYPE=ON						# automagic dep
+		-DBUILD_GUI=$(usex !headless)
+		-DBUILD_IDF=$(usex idf)
+		-DBUILD_IMAGE=$(usex image)
+		-DBUILD_IMPORT=ON						# import module for various file formats
+		-DBUILD_INSPECTION=$(usex inspection)
+		-DBUILD_JTREADER=OFF					# code has been removed upstream, but option is still there
+		-DBUILD_MATERIAL=$(usex material)
+		-DBUILD_MESH=ON
+		-DBUILD_MESH_PART=ON
+		-DBUILD_OPENSCAD=$(usex openscad)
+		-DBUILD_PART=ON
+		-DBUILD_PART_DESIGN=$(usex part-design)
+		-DBUILD_PATH=$(usex path)
+		-DBUILD_POINTS=$(usex points)
+		-DBUILD_QT5=ON							# OFF means to use Qt4
+		-DBUILD_RAYTRACING=$(usex raytracing)
+		-DBUILD_REVERSEENGINEERING=OFF			# currently only an empty sandbox
+		-DBUILD_ROBOT=$(usex robot)
+		-DBUILD_SHOW=$(usex show)
+		-DBUILD_SKETCHER=ON						# needed by draft workspace
+		-DBUILD_SMESH=ON
+		-DBUILD_SPREADSHEET=ON
+		-DBUILD_START=ON
+		-DBUILD_SURFACE=$(usex surface)
+		-DBUILD_TECHDRAW=$(usex techdraw)
+		-DBUILD_TEST=ON							# always build test workbench for run-time testing
+		-DBUILD_TUX=$(usex tux)
+		-DBUILD_VR=OFF
+		-DBUILD_WEB=ON							# needed by start workspace
+		-DBUILD_WITH_CONDA=OFF
+
+		-DCMAKE_INSTALL_DATADIR=/usr/share/${PN}/data
+		-DCMAKE_INSTALL_DOCDIR=/usr/share/doc/${PF}
+		-DCMAKE_INSTALL_INCLUDEDIR=/usr/include/${PN}
+		-DCMAKE_INSTALL_PREFIX=/usr/$(get_libdir)/${PN}
+
+		-DFREECAD_BUILD_DEBIAN=OFF
+
+		-DFREECAD_USE_EXTERNAL_KDL=ON
+		-DFREECAD_USE_EXTERNAL_SMESH=OFF		# no package in Gentoo
+		-DFREECAD_USE_EXTERNAL_ZIPIOS=OFF		# doesn't work yet, also no package in Gentoo tree
+		-DFREECAD_USE_FREETYPE=ON
+		-DFREECAD_USE_OCC_VARIANT:STRING="Official Version"
+		-DFREECAD_USE_PCL=$(usex pcl)
+		-DFREECAD_USE_PYBIND11=ON
+		-DFREECAD_USE_QT_FILEDIALOG=ON
+		-DFREECAD_USE_QTWEBMODULE:STRING="Qt WebEngine"
+
+		# install python modules to site-packages' dir. True only for the main package,
+		# sub-packages will still be installed inside /usr/lib64/freecad
+		-DINSTALL_TO_SITEPACKAGES=ON
+
+		# Use the version of shiboken2 that matches the selected python version
+		-DPYTHON_CONFIG_SUFFIX="-${EPYTHON}"
+		-DPython3_EXECUTABLE=${PYTHON}
+	)
+
+	if use debug; then
+		# BUILD_SANDBOX currently broken, see
+		# https://forum.freecadweb.org/viewtopic.php?f=4&t=36071&start=30#p504595
+		mycmakeargs+=(
+			-DBUILD_SANDBOX=OFF
+			-DBUILD_TEMPLATE=ON
+		)
+	else
+		mycmakeargs+=(
+			-DBUILD_SANDBOX=OFF
+			-DBUILD_TEMPLATE=OFF
+		)
+	fi
+
+	cmake_src_configure
+}
+
+# We use the FreeCADCmd binary instead of the FreeCAD binary here
+# for two reasons:
+# 1. It works out of the box with USE=headless as well, not needing a guard
+# 2. We don't need virtualx.eclass and it's dependencies
+# The exported environment variables are needed, so freecad does know
+# where to save it's temporary files, and where to look and write it's
+# configuration. Without those, there are sandbox violation, when it
+# tries to create /var/lib/portage/home/.FreeCAD directory.
+src_test() {
+	pushd "${BUILD_DIR}" > /dev/null || die
+	export FREECAD_USER_HOME="${HOME}"
+	export FREECAD_USER_DATA="${T}"
+	export FREECAD_USER_TEMP="${T}"
+	nonfatal ./bin/FreeCADCmd --run-test 0
+	popd > /dev/null || die
+}
+
+src_install() {
+	cmake_src_install
+
+	dobin src/Tools/freecad-thumbnailer
+
+	if ! use headless; then
+		dosym -r /usr/$(get_libdir)/${PN}/bin/FreeCAD /usr/bin/freecad
+		mv "${ED}"/usr/$(get_libdir)/${PN}/share/* "${ED}"/usr/share || die "failed to move shared resources"
+	fi
+	dosym -r /usr/$(get_libdir)/${PN}/bin/FreeCADCmd /usr/bin/freecadcmd
+
+	python_optimize "${ED}"/usr/share/${PN}/data/Mod/Start/StartPage "${ED}"/usr/$(get_libdir)/${PN}{/Ext,/Mod}/
+	# compile main package in python site-packages as well
+	python_optimize
+}
+
+pkg_postinst() {
+	xdg_pkg_postinst
+
+	einfo "You can load a lot of additional workbenches using the integrated"
+	einfo "AddonManager."
+
+	# ToDo: check opencv, pysolar (::science), elmerfem (::science)
+	#		ifc++, ifcopenshell, netgen, z88 (no pkgs), calculix-ccx (::waebbl)
+	einfo "There are a lot of additional tools, for which FreeCAD has builtin"
+	einfo "support. Some of them are available in Gentoo. Take a look at"
+	einfo "https://wiki.freecadweb.org/Installing#External_software_supported_by_FreeCAD"
+	optfeature_header "Computational utilities"
+	optfeature "BLAS library" sci-libs/openblas
+	optfeature "Statistical computation with Python" dev-python/pandas
+	optfeature "Use scientific computation with Python" dev-python/scipy
+	optfeature "Use symbolic math with Python" dev-python/sympy
+	optfeature_header "Imaging, Plotting and Rendering utilities"
+	optfeature "Dependency graphs" media-gfx/graphviz
+	optfeature "PBR Rendering" media-gfx/povray
+	optfeature_header "Import / Export"
+	optfeature "Interact with git repositories" dev-python/GitPython
+	optfeature "Work with COLLADA documents" dev-python/pycollada
+	optfeature "YAML importer and emitter" dev-python/pyyaml
+	optfeature "Importing and exporting 2D AutoCAD DWG files" media-gfx/libredwg
+	optfeature "Importing and exporting geospatial data formats" sci-libs/gdal
+	optfeature "Working with projection data" sci-libs/proj
+	optfeature_header "Meshing and FEM"
+	optfeature "FEM mesh generator" sci-libs/gmsh
+	optfeature "Triangulating meshes" sci-libs/gts
+	optfeature "Visualization" sci-visualization/paraview
+}
+
+pkg_postrm() {
+	xdg_pkg_postrm
+}

--- a/media-libs/SoQt/SoQt-1.6.0.ebuild
+++ b/media-libs/SoQt/SoQt-1.6.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -12,7 +12,7 @@ DESCRIPTION="GUI binding for using Coin/Open Inventor with Qt"
 SRC_URI="https://github.com/coin3d/soqt/releases/download/${MY_P}/${P}-src.tar.gz"
 
 LICENSE="GPL-2"
-KEYWORDS="amd64 x86"
+KEYWORDS="amd64 ~arm64 x86"
 SLOT="0"
 IUSE="debug doc"
 

--- a/media-libs/quarter/quarter-1.1.0-r1.ebuild
+++ b/media-libs/quarter/quarter-1.1.0-r1.ebuild
@@ -14,7 +14,7 @@ S="${WORKDIR}/quarter"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 x86"
+KEYWORDS="amd64 ~arm64 x86"
 IUSE="debug designer doc man qthelp"
 
 REQUIRED_USE="

--- a/profiles/arch/arm64/use.mask
+++ b/profiles/arch/arm64/use.mask
@@ -1,6 +1,11 @@
 # Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Roy Bamford <neddyseagoon@gentoo.org> (2022-12-22)
+# dev-libs/OpenNI won't build here so its not really an option 
+# on sci-libs/pcl which is about to got an ~arm64 keyword
+openni
+
 # Unmask the flag which corresponds to ARCH.
 -arm64
 

--- a/sci-libs/med/med-4.1.1.ebuild
+++ b/sci-libs/med/med-4.1.1.ebuild
@@ -16,7 +16,7 @@ LICENSE="LGPL-3"
 S="${WORKDIR}/${P}_SRC"
 
 SLOT="0"
-KEYWORDS="amd64 ~x86"
+KEYWORDS="amd64 ~arm64 ~x86"
 IUSE="doc fortran mpi python test"
 REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
 RESTRICT="!test? ( test ) python? ( test )"

--- a/sci-libs/opencascade/files/fix_name_collision.patch
+++ b/sci-libs/opencascade/files/fix_name_collision.patch
@@ -1,0 +1,19 @@
+--- a/src/IVtkDraw/IVtkDraw_Interactor.cxx_orig	2022-12-21 22:20:13.343761869 +0000
++++ a/src/IVtkDraw/IVtkDraw_Interactor.cxx	2022-12-21 22:21:18.055780427 +0000
+@@ -27,6 +27,16 @@
+ #undef AllValues
+ #endif
+ 
++// Prevent naming collisions between X11
++// and VTK versions 9.2.0 and above.
++// X11 is included through glx
++#ifdef Status
++#undef Status
++#endif
++#ifdef Success
++#undef Success
++#endif
++
+ #include <vtkXRenderWindowInteractor.h>
+ #include <vtkXOpenGLRenderWindow.h>
+ #endif

--- a/sci-libs/orocos_kdl/orocos_kdl-1.5.1.ebuild
+++ b/sci-libs/orocos_kdl/orocos_kdl-1.5.1.ebuild
@@ -14,7 +14,7 @@ if [[ ${PV} = *9999 ]]; then
 	S="${WORKDIR}/${P}/${PN}"
 else
 	SRC_URI="https://github.com/orocos/orocos_kinematics_dynamics/archive/v${PV}.tar.gz -> orocos_kinematics_dynamics-${PV}.tar.gz"
-	KEYWORDS="amd64 ~arm ~x86"
+	KEYWORDS="amd64 ~arm ~arm64 ~x86"
 	S="${WORKDIR}/orocos_kinematics_dynamics-${PV}/${PN}"
 fi
 

--- a/sci-libs/pcl/pcl-1.12.1-r2.ebuild
+++ b/sci-libs/pcl/pcl-1.12.1-r2.ebuild
@@ -14,7 +14,7 @@ inherit ${SCM} cmake cuda
 if [ "${PV#9999}" != "${PV}" ] ; then
 	SRC_URI=""
 else
-	KEYWORDS="~amd64 ~arm"
+	KEYWORDS="~amd64 ~arm ~arm64"
 	SRC_URI="https://github.com/PointCloudLibrary/pcl/archive/${P}.tar.gz"
 	S="${WORKDIR}/${PN}-${P}"
 fi


### PR DESCRIPTION
With changes to dependencies over the last few weeks It was time to start over.

media-gfx/freecad-0.20.1 is bumped to  media-gfx/freecad-0.20.1-r1 as its no longer restricted to <sci-libs/opencascade-7.7.0

Its not all adding ~arm64.
dev-libs/OpenNI2-2.2_beta2-r1, sci-libs/opencascade-7.7.0 and media-gfx/freecad all need patches to build on ~arm64