### PR TITLE
profiles/arch/sparc: unmask dev-libs/openssl[asm] 

### DIFF
--- a/dev-libs/openssl-compat/openssl-compat-1.1.1s.ebuild
+++ b/dev-libs/openssl-compat/openssl-compat-1.1.1s.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 VERIFY_SIG_OPENPGP_KEY_PATH="${BROOT}"/usr/share/openpgp-keys/openssl.org.asc
-inherit edo flag-o-matic toolchain-funcs multilib-minimal verify-sig
+inherit edo flag-o-matic toolchain-funcs multilib-minimal verify-sig linux-info
 
 MY_P=openssl-${PV/_/-}
 DESCRIPTION="Full-strength general purpose cryptography library (including SSL and TLS)"
@@ -54,6 +54,9 @@ pkg_setup() {
 			die "FEATURES=test with USE=sctp requires net.sctp.auth_enable=1!"
 		fi
 	fi
+
+	use test && CONFIG_CHECK="~CRYPTO_USER_API_SKCIPHER"
+	linux-info_pkg_setup
 }
 
 src_unpack() {

--- a/dev-libs/openssl/openssl-1.1.1s.ebuild
+++ b/dev-libs/openssl/openssl-1.1.1s.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 VERIFY_SIG_OPENPGP_KEY_PATH="${BROOT}"/usr/share/openpgp-keys/openssl.org.asc
-inherit edo flag-o-matic toolchain-funcs multilib-minimal verify-sig
+inherit edo flag-o-matic toolchain-funcs multilib-minimal verify-sig linux-info
 
 MY_P=${P/_/-}
 DESCRIPTION="Full-strength general purpose cryptography library (including SSL and TLS)"
@@ -61,6 +61,9 @@ pkg_setup() {
 			die "FEATURES=test with USE=sctp requires net.sctp.auth_enable=1!"
 		fi
 	fi
+
+	use test && CONFIG_CHECK="~CRYPTO_USER_API_SKCIPHER"
+	linux-info_pkg_setup
 }
 
 src_unpack() {

--- a/dev-libs/openssl/openssl-3.0.7-r2.ebuild
+++ b/dev-libs/openssl/openssl-3.0.7-r2.ebuild
@@ -63,6 +63,7 @@ pkg_setup() {
 			CONFIG_CHECK="~TLS ~TLS_DEVICE"
 			ERROR_TLS="You will be unable to offload TLS to kernel because CONFIG_TLS is not set!"
 			ERROR_TLS_DEVICE="You will be unable to offload TLS to kernel because CONFIG_TLS_DEVICE is not set!"
+			use test && CONFIG_CHECK+=" ~CRYPTO_USER_API_SKCIPHER"
 
 			linux-info_pkg_setup
 		fi

--- a/profiles/arch/sparc/package.use.mask
+++ b/profiles/arch/sparc/package.use.mask
@@ -310,10 +310,6 @@ dev-libs/dbus-c++ ecore
 # PPS should work on all arches, but only keyworded on some arches
 >=net-misc/ntp-4.2.6_p3-r1 -parse-clocks
 
-# Matt Turner <mattst88@gentoo.org> (2019-12-01)
-# Fails to build, bug #676060
-dev-libs/openssl asm
-
 # Eugene Bright <eugene@bright.gdn> (2019-09-09)
 # Missing keyword on dev-embedded/libjaylink
 sys-apps/flashrom jlink-spi


### PR DESCRIPTION
test/recipes/30-test_afalg.t requires this kernel option to be enabled. Builtin or module is fine.

Bug: https://bugs.gentoo.org/864793