### PR TITLE
app-text/mupdf-1.21.1: allow disabling DRM checking

### DIFF
--- a/app-text/mupdf/files/mupdf-1.21.1-no-drm.patch
+++ b/app-text/mupdf/files/mupdf-1.21.1-no-drm.patch
@@ -1,0 +1,18 @@
+diff --git a/source/html/epub-doc.c b/source/html/epub-doc.c
+index f764242..83888dc 100644
+--- a/source/html/epub-doc.c
++++ b/source/html/epub-doc.c
+@@ -692,10 +692,12 @@ epub_parse_header(fz_context *ctx, epub_document *doc)
+ 	epub_chapter **tailp;
+ 	int i;
+ 
++	#ifdef drm
+	if (fz_has_archive_entry(ctx, zip, "META-INF/rights.xml"))
+ 		fz_throw(ctx, FZ_ERROR_GENERIC, "EPUB is locked by DRM");
+ 	if (fz_has_archive_entry(ctx, zip, "META-INF/encryption.xml"))
+ 		fz_throw(ctx, FZ_ERROR_GENERIC, "EPUB is locked by DRM");
++	#endif
+ 
+ 	fz_var(buf);
+ 	fz_var(container_xml);
+

--- a/app-text/mupdf/metadata.xml
+++ b/app-text/mupdf/metadata.xml
@@ -9,4 +9,7 @@
 		<email>proxy-maint@gentoo.org</email>
 		<name>Proxy Maintainers</name>
 	</maintainer>
+	<use>
+		<flag name="drm">Enable support for Digital rights management (DRM)</flag>
+	</use>
 </pkgmetadata>

--- a/app-text/mupdf/mupdf-1.21.1.ebuild
+++ b/app-text/mupdf/mupdf-1.21.1.ebuild
@@ -16,7 +16,7 @@ S="${WORKDIR}"/${P}-source
 LICENSE="AGPL-3"
 SLOT="0/${PV}"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~ppc ~ppc64 ~riscv ~s390 ~x86"
-IUSE="+javascript opengl ssl X"
+IUSE="+drm +javascript opengl ssl X"
 REQUIRED_USE="opengl? ( javascript )"
 
 # Although we use the bundled, patched version of freeglut in mupdf (because of
@@ -52,12 +52,15 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-1.15-openssl-x11.patch
 	# General cross fixes from Debian (refreshed)
 	"${FILESDIR}"/${PN}-1.19.0-cross-fixes.patch
+	"${FILESDIR}"/$P-no-drm.patch
 )
 
 src_prepare() {
 	default
 
 	use hppa && append-cflags -ffunction-sections
+
+	use drm && append-cflags -Ddrm
 
 	append-cflags "-DFZ_ENABLE_JS=$(usex javascript 1 0)"
 


### PR DESCRIPTION
MuPDF by default blocks DRM content, see:
https://github.com/ArtifexSoftware/mupdf/commit/2b3bd1b7dbbf13f82b70587676809f189354c77a

Add patch and local use flag `drm` for allowing/disallowing DRM content in PDF files.

Suggested-by: William Rabbermann <willrabbermann@gmail.com>
Signed-off-by: Philipp Rösner <rndxelement@protonmail.com>