### PR TITLE
media-plugins/gst-plugins-pulse: Switch pulseaudio dependency to media-libs/libpulse

### DIFF
--- a/media-plugins/gst-plugins-pulse/gst-plugins-pulse-1.20.4-r1.ebuild
+++ b/media-plugins/gst-plugins-pulse/gst-plugins-pulse-1.20.4-r1.ebuild
@@ -1,0 +1,16 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+GST_ORG_MODULE=gst-plugins-good
+
+inherit gstreamer-meson
+
+DESCRIPTION="PulseAudio sound server plugin for GStreamer"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~mips ~ppc ~ppc64 ~riscv ~sparc ~x86"
+
+RDEPEND="
+	>=media-libs/gst-plugins-base-${PV}:${SLOT}[${MULTILIB_USEDEP}]
+	>=media-libs/libpulse-2.1-r1[${MULTILIB_USEDEP}]
+"
+DEPEND="${RDEPEND}"


### PR DESCRIPTION
pulseaudio plugin for gstreamer works with libpulse interface, switch dependency to `media-libs/libpulse`