### PR TITLE
www-client/firefox: fix dbus indirect dependency

### DIFF
--- a/www-client/firefox/firefox-102.6.0.ebuild
+++ b/www-client/firefox/firefox-102.6.0.ebuild
@@ -113,7 +113,6 @@ BDEPEND="${PYTHON_DEPS}
 	x86? ( >=dev-lang/nasm-2.14 )"
 
 COMMON_DEPEND="${FF_ONLY_DEPEND}
-	>=app-accessibility/at-spi2-core-2.46.0:2
 	dev-libs/expat
 	dev-libs/glib:2
 	dev-libs/libffi:=
@@ -144,6 +143,7 @@ COMMON_DEPEND="${FF_ONLY_DEPEND}
 	dbus? (
 		dev-libs/dbus-glib
 		sys-apps/dbus
+		>=app-accessibility/at-spi2-core-2.46.0:2
 	)
 	jack? ( virtual/jack )
 	libproxy? ( net-libs/libproxy )


### PR DESCRIPTION
at-spi2-core depends on dbus. It makes it impossible to build firefox on systems without dbus.

Signed-off-by: Marius Dinu <m95d+git@psihoexpert.ro>