### PR TITLE
dev-util/pwndbg: remove unnecessary dependencies

### DIFF
--- a/dev-util/pwndbg/pwndbg-20221219-r1.ebuild
+++ b/dev-util/pwndbg/pwndbg-20221219-r1.ebuild
@@ -33,8 +33,6 @@ RDEPEND="
 	sys-devel/gdb[python,${PYTHON_SINGLE_USEDEP}]
 	$(python_gen_cond_dep '
 		dev-libs/capstone[python,${PYTHON_USEDEP}]
-		dev-python/future[${PYTHON_USEDEP}]
-		dev-python/isort[${PYTHON_USEDEP}]
 		dev-python/psutil[${PYTHON_USEDEP}]
 		dev-python/pycparser[${PYTHON_USEDEP}]
 		dev-python/pyelftools[${PYTHON_USEDEP}]

--- a/dev-util/pwndbg/pwndbg-99999999.ebuild
+++ b/dev-util/pwndbg/pwndbg-99999999.ebuild
@@ -33,8 +33,6 @@ RDEPEND="
 	sys-devel/gdb[python,${PYTHON_SINGLE_USEDEP}]
 	$(python_gen_cond_dep '
 		dev-libs/capstone[python,${PYTHON_USEDEP}]
-		dev-python/future[${PYTHON_USEDEP}]
-		dev-python/isort[${PYTHON_USEDEP}]
 		dev-python/psutil[${PYTHON_USEDEP}]
 		dev-python/pycparser[${PYTHON_USEDEP}]
 		dev-python/pyelftools[${PYTHON_USEDEP}]


### PR DESCRIPTION
dev-python/future was never needed (see
https://github.com/pwndbg/pwndbg/issues/1250).

dev-python/isort is a development dependency only.

Closes: https://bugs.gentoo.org/888289
Signed-off-by: Mario Haustein <mario.haustein@hrz.tu-chemnitz.de>