### PR TITLE
net-libs/rustls-ffi: explicitly set --debug/--release

### DIFF
--- a/net-libs/rustls-ffi/rustls-ffi-0.9.1.ebuild
+++ b/net-libs/rustls-ffi/rustls-ffi-0.9.1.ebuild
@@ -101,6 +101,7 @@ multilib_src_compile() {
 		--prefix=/usr
 		--libdir="/usr/$(get_libdir)"
 		--target="$(rust_abi)"
+		$(usex debug --debug --release)
 	)
 
 	cargo cbuild "${cargoargs[@]}" || die "cargo cbuild failed"
@@ -117,6 +118,7 @@ multilib_src_install() {
 		--libdir="/usr/$(get_libdir)"
 		--target="$(rust_abi)"
 		--destdir="${ED}"
+		$(usex debug --debug --release)
 	)
 
 	cargo cinstall "${cargoargs[@]}" || die "cargo cinstall failed"


### PR DESCRIPTION
* Allows debug use flag to work
* Avoid rebuilding during src_install, otherwise it gets built as --debug during src_compile and then finally as --release in src_install

Signed-off-by: Alfred Wingate <parona@protonmail.com>