### PR TITLE
profiles/features/musl: mask sys-apps/fakechroot

### DIFF
--- a/profiles/features/musl/package.mask
+++ b/profiles/features/musl/package.mask
@@ -1,6 +1,14 @@
 # Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+#Marco Scardovi <mscardovi@icloud.com> (2022-12-27)
+# sys/cdefs.h is not present in musl, so we are gonna
+# mask it and their revdeps. Bug #716706
+app-arch/rpm
+app-emulation/guestfs-tools
+app-emulation/libguestfs
+sys-apps/fakechroot
+
 # Sam James <sam@gentoo.org> (2022-12-17)
 # Segfaults when building on musl, bug #885501
 >=sys-devel/gcc-12.2.1_p20221203:12


### PR DESCRIPTION
It requires sys/cdefs.h which is not available in musl. We are gonna mask it.

Closes: https://bugs.gentoo.org/716706

Signed-off-by: Marco Scardovi <mscardovi@icloud.com>