### PR TITLE
dev-libs/dietlibc: revbump, update EAPI 7 -> 8, enable test, fix bug #722970

### DIFF
--- a/dev-libs/dietlibc/dietlibc-0.34-r1.ebuild
+++ b/dev-libs/dietlibc/dietlibc-0.34-r1.ebuild
@@ -1,0 +1,75 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit flag-o-matic toolchain-funcs
+
+DESCRIPTION="A libc optimized for small size"
+HOMEPAGE="https://www.fefe.de/dietlibc/"
+SRC_URI="https://www.fefe.de/dietlibc/${P}.tar.xz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha amd64 ~arm ~ia64 ~mips sparc x86 ~amd64-linux ~x86-linux"
+IUSE="test"
+RESTRICT="!test? ( test )"
+
+DEPEND=">=sys-devel/binutils-2.31.1-r4"
+
+DIETHOME="/usr/bin/diet/"
+
+src_prepare() {
+	default
+
+	# Replace sparc64 related C[XX]FLAGS (see bug #45716)
+	use sparc && replace-sparc64-flags
+
+	# bug 676704
+	use sparc && tc-is-gcc && append-flags -fno-tree-pre
+
+	# gcc-hppa suffers support for SSP, compilation will fail
+	use hppa && strip-unsupported-flags
+
+	# Makefile does not append CFLAGS
+	append-flags \
+		-W -Wall -Wchar-subscripts -Wmissing-prototypes \
+		-Wmissing-declarations -Wno-switch -Wno-unused \
+		-Wredundant-decls -fno-strict-aliasing
+
+	# Disable ssp for we default to it on >=gcc-4.8.3
+	append-flags $(test-flags -fno-stack-protector)
+
+	# only use -nopie on archs that support it
+	tc-enables-pie && append-flags -no-pie
+
+	sed -i -e 's:strip::' Makefile || die
+	append-flags -Wa,--noexecstack
+}
+
+src_compile() {
+	emake prefix="${EPREFIX}"${DIETHOME} \
+		CC="$(tc-getCC)" \
+		AR="$(tc-getCC)" \
+		CFLAGS="${CFLAGS}" \
+		STRIP=":"
+}
+
+src_test() {
+	emake -j1 test
+}
+
+src_install() {
+	emake -j1 \
+		prefix="${EPREFIX}"${DIETHOME} \
+		DESTDIR="${D}" \
+		install-bin \
+		install-headers \
+		install-profiling
+
+	dobin "${ED}"${DIETHOME}/bin/*
+	doman "${ED}"${DIETHOME}/man/*/*
+	rm -r "${ED}"${DIETHOME}/{man,bin} || die
+
+	dodoc AUTHOR BUGS CAVEAT CHANGES README THANKS TODO PORTING
+}


### PR DESCRIPTION
dietlibc calls ar directly, fixing it

Closes: https://bugs.gentoo.org/722970

Signed-off-by: Marco Scardovi <mscardovi@icloud.com>