### PR TITLE
mate-extra/mate-screensaver-1.26.1: RDEPEND on mate-base/mate-panel

### DIFF
--- a/mate-extra/mate-screensaver/mate-screensaver-1.26.1.ebuild
+++ b/mate-extra/mate-screensaver/mate-screensaver-1.26.1.ebuild
@@ -46,6 +46,7 @@ RDEPEND="${COMMON_DEPEND}
 	>=mate-base/mate-session-manager-1.6
 	virtual/libintl
 	!!<gnome-extra/gnome-screensaver-3
+	mate-base/mate-panel
 "
 
 DEPEND="${COMMON_DEPEND}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/888589
Signed-off-by: Daniel M. Weeks <dan@danweeks.net>