### PR TITLE
media-gfx/enblend: fix docs build error

### DIFF
--- a/media-gfx/enblend/enblend-4.2.0_p20161007-r5.ebuild
+++ b/media-gfx/enblend/enblend-4.2.0_p20161007-r5.ebuild
@@ -49,6 +49,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-4.2-doc-install-dir-fix.patch
 	"${FILESDIR}"/${P}-cmake.patch
 	"${FILESDIR}"/${P}-gcc-10.patch
+	"${FILESDIR}"/${P}-doc-scaleable-fonts.patch
 )
 
 src_prepare() {

--- a/media-gfx/enblend/files/enblend-4.2.0_p20161007-doc-scaleable-fonts.patch
+++ b/media-gfx/enblend/files/enblend-4.2.0_p20161007-doc-scaleable-fonts.patch
@@ -1,0 +1,16 @@
+Use scaleable fonts.
+
+Bug: https://bugs.gentoo.org/888025
+
+diff -Naur enblend-4.2.0_p20161007.org/doc/static-preamble.tex enblend-4.2.0_p20161007/doc/static-preamble.tex
+--- enblend-4.2.0_p20161007.org/doc/static-preamble.tex 2016-09-24 11:29:40.000000000 +0200
++++ enblend-4.2.0_p20161007/doc/static-preamble.tex     2022-12-27 07:30:42.966176272 +0100
+@@ -5,6 +5,8 @@
+ \RequirePackage[l2tabu, orthodox]{nag}
+ 
+ 
++\usepackage[T1]{fontenc}
++\usepackage{lmodern}       % scaleable fonts
+ \usepackage{amsmath}       % align, align*
+ \usepackage{bold-extra}    % Bold typewriter for programming language keywords
+ \usepackage{color}         % \colorbox


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/888025
Signed-off-by: Mario Haustein <mario.haustein@hrz.tu-chemnitz.de>