### PR TITLE
x11-misc/rofi: add flex version requirement

### DIFF
--- a/x11-misc/rofi/rofi-1.7.3-r1.ebuild
+++ b/x11-misc/rofi/rofi-1.7.3-r1.ebuild
@@ -17,7 +17,7 @@ RESTRICT="!test? ( test )"
 
 BDEPEND="
 	sys-devel/bison
-	sys-devel/flex
+	>=sys-devel/flex-2.5.39
 	virtual/pkgconfig
 "
 RDEPEND="

--- a/x11-misc/rofi/rofi-1.7.5.ebuild
+++ b/x11-misc/rofi/rofi-1.7.5.ebuild
@@ -17,7 +17,7 @@ RESTRICT="!test? ( test )"
 
 BDEPEND="
 	sys-devel/bison
-	sys-devel/flex
+	>=sys-devel/flex-2.5.39
 	virtual/pkgconfig
 "
 RDEPEND="


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/887049

Signed-off-by: Petrus Zhao <petrus.zy.07@gmail.com>