### PR TITLE
Spamassassin fix 4.0.0 tests

### DIFF
--- a/mail-filter/spamassassin/files/4.0.0-tests-dnsbl_subtests.t.patch
+++ b/mail-filter/spamassassin/files/4.0.0-tests-dnsbl_subtests.t.patch
@@ -1,0 +1,14 @@
+https://bz.apache.org/SpamAssassin/show_bug.cgi?id=8095
+--- a/t/dnsbl_subtests.t
++++ b/t/dnsbl_subtests.t
+@@ -20,6 +20,10 @@
+ 
+ use Mail::SpamAssassin;
+ 
++tstpre ("
++  loadplugin Mail::SpamAssassin::Plugin::URIDNSBL
++");
++
+ # Bug 5761 (no 127.0.0.1 in jail, use SPAMD_LOCALHOST if specified)
+ my $dns_server_localaddr = $ENV{'SPAMD_LOCALHOST'};
+ if (!$dns_server_localaddr) {

--- a/mail-filter/spamassassin/files/4.0.0-tests-strip2.t.patch
+++ b/mail-filter/spamassassin/files/4.0.0-tests-strip2.t.patch
@@ -1,0 +1,20 @@
+https://bz.apache.org/SpamAssassin/show_bug.cgi?id=8096
+--- a/t/strip2.t
++++ b/t/strip2.t
+@@ -4,14 +4,15 @@
+ use SATest; sa_t_init("strip2");
+ 
+ use Test::More;
++use constant HAS_TEXTDIFF => eval { require Text::Diff; };
+ plan skip_all => 'Long running tests disabled' unless conf_bool('run_long_tests');
++plan skip_all => 'Need Text::Diff' unless HAS_TEXTDIFF;
+ plan tests => 98;
+ 
+ # ---------------------------------------------------------------------------
+ 
+ use File::Copy;
+ use File::Compare qw(compare_text);
+-use Text::Diff;
+ 
+ my @files = qw(
+ 	data/nice/crlf-endings

--- a/mail-filter/spamassassin/spamassassin-4.0.0.ebuild
+++ b/mail-filter/spamassassin/spamassassin-4.0.0.ebuild
@@ -90,6 +90,7 @@ VERIFY_SIG_OPENPGP_KEY_PATH=${BROOT}/usr/share/openpgp-keys/spamassassin.apache.
 
 PATCHES=(
 	"${FILESDIR}/mention-geoip.cf-in-init.pre.patch"
+	"${FILESDIR}/4.0.0-tests-dnsbl_subtests.t.patch"
 )
 
 # There are a few renames and use-dependent ones in src_install as well.

--- a/mail-filter/spamassassin/spamassassin-4.0.0.ebuild
+++ b/mail-filter/spamassassin/spamassassin-4.0.0.ebuild
@@ -91,6 +91,7 @@ VERIFY_SIG_OPENPGP_KEY_PATH=${BROOT}/usr/share/openpgp-keys/spamassassin.apache.
 PATCHES=(
 	"${FILESDIR}/mention-geoip.cf-in-init.pre.patch"
 	"${FILESDIR}/4.0.0-tests-dnsbl_subtests.t.patch"
+	"${FILESDIR}/4.0.0-tests-strip2.t.patch"
 )
 
 # There are a few renames and use-dependent ones in src_install as well.


### PR DESCRIPTION
Patch `dnsbl_subtests.t` & `strip2.t` test failures in 4.0.0.

Posted fixes to upstream:
 - https://bz.apache.org/SpamAssassin/show_bug.cgi?id=8095
 - https://bz.apache.org/SpamAssassin/show_bug.cgi?id=8096
