### PR TITLE
x11-misc/rofi: add flex version requirement in live ebuild

### DIFF
--- a/x11-misc/rofi/rofi-99999.ebuild
+++ b/x11-misc/rofi/rofi-99999.ebuild
@@ -17,7 +17,7 @@ RESTRICT="!test? ( test )"
 
 BDEPEND="
 	sys-devel/bison
-	sys-devel/flex
+	>=sys-devel/flex-2.5.39
 	virtual/pkgconfig
 "
 RDEPEND="


### PR DESCRIPTION
Signed-off-by: Petrus Zhao <petrus.zy.07@gmail.com>

Sorry I fogot live ebuild at first.