### PR TITLE
net-wireless/urh: fix python import during build

### DIFF
--- a/net-wireless/urh/urh-2.9.4.ebuild
+++ b/net-wireless/urh/urh-2.9.4.ebuild
@@ -42,6 +42,11 @@ RDEPEND="${DEPEND}
 
 distutils_enable_tests pytest
 
+src_prepare() {
+	default
+	touch "${S}/src/__init__.py" || die
+}
+
 python_configure_all() {
 	DISTUTILS_ARGS=(
 			$(use_with airspy)

--- a/net-wireless/urh/urh-9999.ebuild
+++ b/net-wireless/urh/urh-9999.ebuild
@@ -42,6 +42,11 @@ RDEPEND="${DEPEND}
 
 distutils_enable_tests pytest
 
+src_prepare() {
+	default
+	touch "${WORKDIR}/src/__init__.py" || die
+}
+
 python_configure_all() {
 	DISTUTILS_ARGS=(
 			$(use_with airspy)


### PR DESCRIPTION
This PR fixes Gentoo bug 888627, but I'm not sure whether the fix does it in the right way. Someone familiar with the python build infrastructure should review it.

Closes: https://bugs.gentoo.org/888627
Signed-off-by: Mario Haustein <mario.haustein@hrz.tu-chemnitz.de>