### PR TITLE
Allow prefixed systems to be cross-compiled

### DIFF
--- a/dev-libs/libbsd/libbsd-0.11.7-r2.ebuild
+++ b/dev-libs/libbsd/libbsd-0.11.7-r2.ebuild
@@ -1,0 +1,43 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+VERIFY_SIG_OPENPGP_KEY_PATH="${BROOT}"/usr/share/openpgp-keys/guillemjover.asc
+inherit multilib multilib-minimal verify-sig
+
+DESCRIPTION="Library to provide useful functions commonly found on BSD systems"
+HOMEPAGE="https://libbsd.freedesktop.org/wiki/ https://gitlab.freedesktop.org/libbsd/libbsd"
+SRC_URI="https://${PN}.freedesktop.org/releases/${P}.tar.xz"
+SRC_URI+=" verify-sig? ( https://${PN}.freedesktop.org/releases/${P}.tar.xz.asc )"
+
+LICENSE="BSD BSD-2 BSD-4 ISC"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux"
+IUSE="static-libs"
+
+RDEPEND="app-crypt/libmd[${MULTILIB_USEDEP}]"
+DEPEND="${RDEPEND}
+	>=sys-kernel/linux-headers-3.17
+"
+BDEPEND="verify-sig? ( sec-keys/openpgp-keys-guillemjover )"
+
+multilib_src_configure() {
+	# The build system will install libbsd-ctor.a despite USE="-static-libs"
+	# which is correct, see:
+	# https://gitlab.freedesktop.org/libbsd/libbsd/commit/c5b959028734ca2281250c85773d9b5e1d259bc8
+	ECONF_SOURCE="${S}" econf $(use_enable static-libs static)
+}
+
+multilib_src_install() {
+	emake DESTDIR="${D}" install
+
+	find "${ED}" -type f -name "*.la" -delete || die
+
+	# ld scripts on standalone prefix (RAP) systems should have the prefix
+	# stripped from any paths, as the sysroot is automatically prepended.
+	local ldscript=${ED}/usr/$(get_libdir)/${PN}$(get_libname)
+	if use prefix && ! use prefix-guest && grep -qIF "ld script" "${ldscript}" 2>/dev/null; then
+		sed -i "s|${EPREFIX}/|/|g" "${ldscript}" || die
+	fi
+}

--- a/eclass/python-utils-r1.eclass
+++ b/eclass/python-utils-r1.eclass
@@ -332,7 +332,7 @@ _python_export() {
 				debug-print "${FUNCNAME}: EPYTHON = ${EPYTHON}"
 				;;
 			PYTHON)
-				export PYTHON=${EPREFIX}/usr/bin/${impl}
+				export PYTHON=${BROOT-${EPREFIX}}/usr/bin/${impl}
 				debug-print "${FUNCNAME}: PYTHON = ${PYTHON}"
 				;;
 			PYTHON_SITEDIR)

--- a/eclass/toolchain.eclass
+++ b/eclass/toolchain.eclass
@@ -719,6 +719,19 @@ toolchain_src_prepare() {
 	einfo "Remove texinfo (bug #198182, bug #464008)"
 	eapply "${FILESDIR}"/gcc-configure-texinfo.patch
 
+	if ! use prefix-guest && [[ -n ${EPREFIX} ]] ; then
+		einfo "Prefixifying dynamic linkers..."
+		for f in gcc/config/*/*linux*.h ; do
+			ebegin "  Updating ${f}"
+			if [[ ${f} == gcc/config/rs6000/linux*.h ]]; then
+				sed -i -r "s,(DYNAMIC_LINKER_PREFIX\s+)\"\",\1\"${EPREFIX}\",g" "${f}" || die
+			else
+				sed -i -r "/_DYNAMIC_LINKER/s,([\":])(/lib),\1${EPREFIX}\2,g" "${f}" || die
+			fi
+			eend $?
+		done
+	fi
+
 	# >=gcc-4
 	if [[ -x contrib/gcc_update ]] ; then
 		einfo "Touching generated files"

--- a/eclass/toolchain.eclass
+++ b/eclass/toolchain.eclass
@@ -1200,6 +1200,21 @@ toolchain_src_configure() {
 				confgcc+=( --enable-threads=posix )
 				;;
 		esac
+
+		if ! use prefix-guest ; then
+			# GNU ld scripts, such as those in glibc, reference unprefixed paths
+			# as the sysroot given here is automatically prepended. For
+			# prefix-guest, we use the host's libc instead.
+			if [[ -n ${EPREFIX} ]] ; then
+				confgcc+=( --with-sysroot="${EPREFIX}" )
+			fi
+
+			# We need to build against the right headers and libraries. Again,
+			# for prefix-guest, this is the host's.
+			if [[ -n ${ESYSROOT} ]] ; then
+				confgcc+=( --with-build-sysroot="${ESYSROOT}" )
+			fi
+		fi
 	fi
 
 	# __cxa_atexit is "essential for fully standards-compliant handling of

--- a/eclass/usr-ldscript.eclass
+++ b/eclass/usr-ldscript.eclass
@@ -39,6 +39,13 @@ gen_usr_ldscript() {
 	tc-is-static-only && return
 	use prefix && return
 
+	# The toolchain's sysroot is automatically prepended to paths in this
+	# script. We therefore need to omit EPREFIX on standalone prefix (RAP)
+	# systems. prefix-guest (non-RAP) systems don't apply a sysroot so EPREFIX
+	# is still needed in that case. This is moot because the above line makes
+	# the function a noop on prefix, but we keep this in case that changes.
+	local prefix=$(usex prefix-guest "${EPREFIX}" "")
+
 	# We only care about stuffing / for the native ABI. #479448
 	if [[ $(type -t multilib_is_native_abi) == "function" ]] ; then
 		multilib_is_native_abi || return 0
@@ -154,7 +161,7 @@ gen_usr_ldscript() {
 			   See bug https://bugs.gentoo.org/4411 for more info.
 			 */
 			${output_format}
-			GROUP ( ${EPREFIX}/${libdir}/${tlib} )
+			GROUP ( ${prefix}/${libdir}/${tlib} )
 			END_LDSCRIPT
 			;;
 		esac

--- a/profiles/features/prefix/standalone/profile.bashrc
+++ b/profiles/features/prefix/standalone/profile.bashrc
@@ -21,9 +21,6 @@ if [[ ${CATEGORY}/${PN} == sys-devel/gcc && ${EBUILD_PHASE} == configure ]]; the
 	fi
 	eend $?
     done
-
-    # use sysroot of toolchain to get correct include and library at compile time
-    EXTRA_ECONF="${EXTRA_ECONF} --with-sysroot=${EPREFIX}"
 elif [[ ${CATEGORY}/${PN} == sys-devel/clang && ${EBUILD_PHASE} == configure ]]; then
     ebegin "Use ${EPREFIX} as default sysroot"
     sed -i -e "s@DEFAULT_SYSROOT \"\"@DEFAULT_SYSROOT \"${EPREFIX}\"@" "${S}"/CMakeLists.txt

--- a/profiles/features/prefix/standalone/profile.bashrc
+++ b/profiles/features/prefix/standalone/profile.bashrc
@@ -1,5 +1,5 @@
 # -*- mode: shell-script; -*-
-# Copyright 2018-2021 Gentoo Authors
+# Copyright 2018-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # RAP specific patches pending upstream:
@@ -24,10 +24,6 @@ if [[ ${CATEGORY}/${PN} == sys-devel/gcc && ${EBUILD_PHASE} == configure ]]; the
 
     # use sysroot of toolchain to get correct include and library at compile time
     EXTRA_ECONF="${EXTRA_ECONF} --with-sysroot=${EPREFIX}"
-
-    ebegin "remove --sysroot call on ld for native toolchain"
-    sed -i 's/--sysroot=%R//' gcc/gcc.c*
-    eend $?
 elif [[ ${CATEGORY}/${PN} == sys-devel/clang && ${EBUILD_PHASE} == configure ]]; then
     ebegin "Use ${EPREFIX} as default sysroot"
     sed -i -e "s@DEFAULT_SYSROOT \"\"@DEFAULT_SYSROOT \"${EPREFIX}\"@" "${S}"/CMakeLists.txt
@@ -35,9 +31,6 @@ elif [[ ${CATEGORY}/${PN} == sys-devel/clang && ${EBUILD_PHASE} == configure ]];
     pushd "${S}/lib/Driver/ToolChains" >/dev/null
     ebegin "Use dynamic linker from ${EPREFIX}"
     sed -i -e "/LibDir.*Loader/s@return \"\/\"@return \"${EPREFIX%/}/\"@" Linux.cpp
-    eend $?
-    ebegin "Remove --sysroot call on ld for native toolchain"
-    sed -i -e "$(grep -n -B1 sysroot= Gnu.cpp | sed -ne '{1s/-.*//;1p}'),+1 d" Gnu.cpp
     eend $?
     popd >/dev/null
 elif [[ ${CATEGORY}/${PN} == sys-devel/binutils && ${EBUILD_PHASE} == prepare ]]; then

--- a/profiles/features/prefix/standalone/profile.bashrc
+++ b/profiles/features/prefix/standalone/profile.bashrc
@@ -9,16 +9,7 @@
 # Disable RAP trick during bootstrap stage2
 [[ -z ${BOOTSTRAP_RAP_STAGE2} ]] || return 0
 
-if [[ ${CATEGORY}/${PN} == sys-devel/clang && ${EBUILD_PHASE} == configure ]]; then
-    ebegin "Use ${EPREFIX} as default sysroot"
-    sed -i -e "s@DEFAULT_SYSROOT \"\"@DEFAULT_SYSROOT \"${EPREFIX}\"@" "${S}"/CMakeLists.txt
-    eend $?
-    pushd "${S}/lib/Driver/ToolChains" >/dev/null
-    ebegin "Use dynamic linker from ${EPREFIX}"
-    sed -i -e "/LibDir.*Loader/s@return \"\/\"@return \"${EPREFIX%/}/\"@" Linux.cpp
-    eend $?
-    popd >/dev/null
-elif [[ ${CATEGORY}/${PN} == sys-devel/binutils && ${EBUILD_PHASE} == prepare ]]; then
+if [[ ${CATEGORY}/${PN} == sys-devel/binutils && ${EBUILD_PHASE} == prepare ]]; then
     ebegin "Prefixifying native library path"
     sed -i -r "/NATIVE_LIB_DIRS/s,((/usr(/local|)|)/lib),${EPREFIX}\1,g" \
 	"${S}"/ld/configure.tgt

--- a/profiles/features/prefix/standalone/profile.bashrc
+++ b/profiles/features/prefix/standalone/profile.bashrc
@@ -9,19 +9,7 @@
 # Disable RAP trick during bootstrap stage2
 [[ -z ${BOOTSTRAP_RAP_STAGE2} ]] || return 0
 
-if [[ ${CATEGORY}/${PN} == sys-devel/gcc && ${EBUILD_PHASE} == configure ]]; then
-    cd "${S}"
-    einfo "Prefixifying dynamic linkers..."
-    for h in gcc/config/*/*linux*.h; do
-	ebegin "  Updating $h"
-	if [[ "${h}" == gcc/config/rs6000/linux*.h ]]; then
-	    sed -i -r "s,(DYNAMIC_LINKER_PREFIX\s+)\"\",\1\"${EPREFIX}\",g" $h
-	else
-	    sed -i -r "/_DYNAMIC_LINKER/s,([\":])(/lib),\1${EPREFIX}\2,g" $h
-	fi
-	eend $?
-    done
-elif [[ ${CATEGORY}/${PN} == sys-devel/clang && ${EBUILD_PHASE} == configure ]]; then
+if [[ ${CATEGORY}/${PN} == sys-devel/clang && ${EBUILD_PHASE} == configure ]]; then
     ebegin "Use ${EPREFIX} as default sysroot"
     sed -i -e "s@DEFAULT_SYSROOT \"\"@DEFAULT_SYSROOT \"${EPREFIX}\"@" "${S}"/CMakeLists.txt
     eend $?

--- a/sys-devel/clang/clang-13.0.1.ebuild
+++ b/sys-devel/clang/clang-13.0.1.ebuild
@@ -82,6 +82,10 @@ src_prepare() {
 	eprefixify \
 		lib/Frontend/InitHeaderSearch.cpp \
 		lib/Driver/ToolChains/Darwin.cpp || die
+
+	if ! use prefix-guest && [[ -n ${EPREFIX} ]]; then
+		sed -i "/LibDir.*Loader/s@return \"\/\"@return \"${EPREFIX}/\"@" lib/Driver/ToolChains/Linux.cpp || die
+	fi
 }
 
 check_distribution_components() {
@@ -224,6 +228,7 @@ multilib_src_configure() {
 	local clang_version=$(ver_cut 1-3 "${llvm_version}")
 
 	local mycmakeargs=(
+		-DDEFAULT_SYSROOT=$(usex prefix-guest "" "${EPREFIX}")
 		-DLLVM_CMAKE_PATH="${EPREFIX}/usr/lib/llvm/${SLOT}/$(get_libdir)/cmake/llvm"
 		-DCMAKE_INSTALL_PREFIX="${EPREFIX}/usr/lib/llvm/${SLOT}"
 		-DCMAKE_INSTALL_MANDIR="${EPREFIX}/usr/lib/llvm/${SLOT}/share/man"

--- a/sys-devel/clang/clang-14.0.6-r1.ebuild
+++ b/sys-devel/clang/clang-14.0.6-r1.ebuild
@@ -95,6 +95,10 @@ src_prepare() {
 	eprefixify \
 		lib/Lex/InitHeaderSearch.cpp \
 		lib/Driver/ToolChains/Darwin.cpp || die
+
+	if ! use prefix-guest && [[ -n ${EPREFIX} ]]; then
+		sed -i "/LibDir.*Loader/s@return \"\/\"@return \"${EPREFIX}/\"@" lib/Driver/ToolChains/Linux.cpp || die
+	fi
 }
 
 check_distribution_components() {
@@ -234,6 +238,7 @@ multilib_src_configure() {
 	local clang_version=$(ver_cut 1-3 "${llvm_version}")
 
 	local mycmakeargs=(
+		-DDEFAULT_SYSROOT=$(usex prefix-guest "" "${EPREFIX}")
 		-DLLVM_CMAKE_PATH="${EPREFIX}/usr/lib/llvm/${SLOT}/$(get_libdir)/cmake/llvm"
 		-DCMAKE_INSTALL_PREFIX="${EPREFIX}/usr/lib/llvm/${SLOT}"
 		-DCMAKE_INSTALL_MANDIR="${EPREFIX}/usr/lib/llvm/${SLOT}/share/man"

--- a/sys-devel/clang/clang-15.0.6-r1.ebuild
+++ b/sys-devel/clang/clang-15.0.6-r1.ebuild
@@ -86,6 +86,10 @@ src_prepare() {
 	eprefixify \
 		lib/Lex/InitHeaderSearch.cpp \
 		lib/Driver/ToolChains/Darwin.cpp || die
+
+	if ! use prefix-guest && [[ -n ${EPREFIX} ]]; then
+		sed -i "/LibDir.*Loader/s@return \"\/\"@return \"${EPREFIX}/\"@" lib/Driver/ToolChains/Linux.cpp || die
+	fi
 }
 
 check_distribution_components() {
@@ -246,6 +250,7 @@ get_distribution_components() {
 
 multilib_src_configure() {
 	local mycmakeargs=(
+		-DDEFAULT_SYSROOT=$(usex prefix-guest "" "${EPREFIX}")
 		-DCMAKE_INSTALL_PREFIX="${EPREFIX}/usr/lib/llvm/${LLVM_MAJOR}"
 		-DCMAKE_INSTALL_MANDIR="${EPREFIX}/usr/lib/llvm/${LLVM_MAJOR}/share/man"
 		-DCLANG_CONFIG_FILE_SYSTEM_DIR="${EPREFIX}/etc/clang"

--- a/sys-devel/clang/clang-15.0.6.9999.ebuild
+++ b/sys-devel/clang/clang-15.0.6.9999.ebuild
@@ -86,6 +86,10 @@ src_prepare() {
 	eprefixify \
 		lib/Lex/InitHeaderSearch.cpp \
 		lib/Driver/ToolChains/Darwin.cpp || die
+
+	if ! use prefix-guest && [[ -n ${EPREFIX} ]]; then
+		sed -i "/LibDir.*Loader/s@return \"\/\"@return \"${EPREFIX}/\"@" lib/Driver/ToolChains/Linux.cpp || die
+	fi
 }
 
 check_distribution_components() {
@@ -246,6 +250,7 @@ get_distribution_components() {
 
 multilib_src_configure() {
 	local mycmakeargs=(
+		-DDEFAULT_SYSROOT=$(usex prefix-guest "" "${EPREFIX}")
 		-DCMAKE_INSTALL_PREFIX="${EPREFIX}/usr/lib/llvm/${LLVM_MAJOR}"
 		-DCMAKE_INSTALL_MANDIR="${EPREFIX}/usr/lib/llvm/${LLVM_MAJOR}/share/man"
 		-DCLANG_CONFIG_FILE_SYSTEM_DIR="${EPREFIX}/etc/clang"

--- a/sys-devel/clang/clang-16.0.0.9999.ebuild
+++ b/sys-devel/clang/clang-16.0.0.9999.ebuild
@@ -85,6 +85,10 @@ src_prepare() {
 	eprefixify \
 		lib/Lex/InitHeaderSearch.cpp \
 		lib/Driver/ToolChains/Darwin.cpp || die
+
+	if ! use prefix-guest && [[ -n ${EPREFIX} ]]; then
+		sed -i "/LibDir.*Loader/s@return \"\/\"@return \"${EPREFIX}/\"@" lib/Driver/ToolChains/Linux.cpp || die
+	fi
 }
 
 check_distribution_components() {
@@ -248,6 +252,7 @@ get_distribution_components() {
 
 multilib_src_configure() {
 	local mycmakeargs=(
+		-DDEFAULT_SYSROOT=$(usex prefix-guest "" "${EPREFIX}")
 		-DCMAKE_INSTALL_PREFIX="${EPREFIX}/usr/lib/llvm/${LLVM_MAJOR}"
 		-DCMAKE_INSTALL_MANDIR="${EPREFIX}/usr/lib/llvm/${LLVM_MAJOR}/share/man"
 		-DCLANG_CONFIG_FILE_SYSTEM_DIR="${EPREFIX}/etc/clang"

--- a/sys-devel/clang/clang-16.0.0_pre20230101.ebuild
+++ b/sys-devel/clang/clang-16.0.0_pre20230101.ebuild
@@ -85,6 +85,10 @@ src_prepare() {
 	eprefixify \
 		lib/Lex/InitHeaderSearch.cpp \
 		lib/Driver/ToolChains/Darwin.cpp || die
+
+	if ! use prefix-guest && [[ -n ${EPREFIX} ]]; then
+		sed -i "/LibDir.*Loader/s@return \"\/\"@return \"${EPREFIX}/\"@" lib/Driver/ToolChains/Linux.cpp || die
+	fi
 }
 
 check_distribution_components() {
@@ -248,6 +252,7 @@ get_distribution_components() {
 
 multilib_src_configure() {
 	local mycmakeargs=(
+		-DDEFAULT_SYSROOT=$(usex prefix-guest "" "${EPREFIX}")
 		-DCMAKE_INSTALL_PREFIX="${EPREFIX}/usr/lib/llvm/${LLVM_MAJOR}"
 		-DCMAKE_INSTALL_MANDIR="${EPREFIX}/usr/lib/llvm/${LLVM_MAJOR}/share/man"
 		-DCLANG_CONFIG_FILE_SYSTEM_DIR="${EPREFIX}/etc/clang"

--- a/sys-libs/glibc/glibc-2.36-r6.ebuild
+++ b/sys-libs/glibc/glibc-2.36-r6.ebuild
@@ -1314,6 +1314,17 @@ glibc_do_src_install() {
 		mv "${ED}"/$(alt_usrlibdir)/libm-${upstream_pv}.a "${ED}"/$(alt_usrlibdir)/${P}/libm-${upstream_pv}.a || die
 	fi
 
+	# We configure toolchains for standalone prefix systems with a sysroot,
+	# which is prepended to paths in ld scripts, so strip the prefix from these.
+	# Before: GROUP ( /foo/lib64/libc.so.6 /foo/usr/lib64/libc_nonshared.a  AS_NEEDED ( /foo/lib64/ld-linux-x86-64.so.2 ) )
+	# After: GROUP ( /lib64/libc.so.6 /usr/lib64/libc_nonshared.a  AS_NEEDED ( /lib64/ld-linux-x86-64.so.2 ) )
+	if [[ -n $(host_eprefix) ]] ; then
+		local file
+		grep -lZIF "ld script" "${ED}/$(alt_usrlibdir)"/lib*.{a,so} 2>/dev/null | while read -rd '' file ; do
+			sed -i "s|$(host_eprefix)/|/|g" "${file}" || die
+		done
+	fi
+
 	# We'll take care of the cache ourselves
 	rm -f "${ED}"/etc/ld.so.cache
 

--- a/sys-libs/glibc/glibc-9999.ebuild
+++ b/sys-libs/glibc/glibc-9999.ebuild
@@ -1314,6 +1314,17 @@ glibc_do_src_install() {
 		mv "${ED}"/$(alt_usrlibdir)/libm-${upstream_pv}.a "${ED}"/$(alt_usrlibdir)/${P}/libm-${upstream_pv}.a || die
 	fi
 
+	# We configure toolchains for standalone prefix systems with a sysroot,
+	# which is prepended to paths in ld scripts, so strip the prefix from these.
+	# Before: GROUP ( /foo/lib64/libc.so.6 /foo/usr/lib64/libc_nonshared.a  AS_NEEDED ( /foo/lib64/ld-linux-x86-64.so.2 ) )
+	# After: GROUP ( /lib64/libc.so.6 /usr/lib64/libc_nonshared.a  AS_NEEDED ( /lib64/ld-linux-x86-64.so.2 ) )
+	if [[ -n $(host_eprefix) ]] ; then
+		local file
+		grep -lZIF "ld script" "${ED}/$(alt_usrlibdir)"/lib*.{a,so} 2>/dev/null | while read -rd '' file ; do
+			sed -i "s|$(host_eprefix)/|/|g" "${file}" || die
+		done
+	fi
+
 	# We'll take care of the cache ourselves
 	rm -f "${ED}"/etc/ld.so.cache
 


### PR DESCRIPTION
The toolchain expects to find the libc's files under its own sysroot. This sysroot is automatically prepended to paths found in ld scripts, such as those installed with glibc. We configure standalone prefix systems with a sysroot, so these paths should not be prefixed. However, Gentoo Prefix has traditionally left them prefixed and stopped the compiler from passing the sysroot to the linker instead. It is better to strip the prefix and let the sysroot do its job, as this makes cross-compiling much less awkward.

prefix-guest systems do not have a sysroot applied, as they use the host's libc.

See inside for details. The remaining question is how existing prefix systems can be migrated. Creating a temporary `${EPREFIX}/${EPREFIX}` symlink and updating gcc before glibc may be sufficient.