### PR TITLE
sys-auth/libfprint: call python (fix #888683) - sys-auth/fprintd: add pam_wrapper unconditionally during test, re-fix #764500

### DIFF
--- a/sys-auth/fprintd/fprintd-1.94.2.ebuild
+++ b/sys-auth/fprintd/fprintd-1.94.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -38,7 +38,7 @@ DEPEND="
 			dev-python/python-dbusmock[${PYTHON_USEDEP}]
 			dev-python/dbus-python[${PYTHON_USEDEP}]
 			dev-python/pycairo[${PYTHON_USEDEP}]
-			pam? ( sys-libs/pam_wrapper[${PYTHON_USEDEP}] )
+			sys-libs/pam_wrapper[${PYTHON_USEDEP}]
 		')
 	)
 "

--- a/sys-auth/libfprint/libfprint-1.94.5.ebuild
+++ b/sys-auth/libfprint/libfprint-1.94.5.ebuild
@@ -2,8 +2,9 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
+PYTHON_COMPAT=( python3_{9..11} )
 
-inherit meson udev
+inherit meson python-r1 udev
 
 MY_P="${PN}-v${PV}"
 
@@ -16,7 +17,10 @@ SLOT="2"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~ia64 ~ppc ~ppc64 ~riscv ~sparc ~x86"
 IUSE="examples gtk-doc +introspection"
 
+REQUIRED_USE="${PYTHON_REQUIRED_USE}"
+
 RDEPEND="
+	${PYTHON_DEPS}
 	dev-libs/glib:2
 	dev-libs/libgudev
 	dev-libs/nss
@@ -56,4 +60,8 @@ src_configure() {
 	)
 
 	meson_src_configure
+}
+
+pkg_postinst() {
+	udev_reload
 }

--- a/sys-auth/libfprint/metadata.xml
+++ b/sys-auth/libfprint/metadata.xml
@@ -4,6 +4,7 @@
 	<!-- maintainer-needed -->
 	<upstream>
 		<remote-id type="freedesktop-gitlab">libfprint/libfprint</remote-id>
+		<remote-id type="github">freedesktop/libfprint</remote-id>
 		<bugs-to>https://bugs.freedesktop.org/enter_bug.cgi?product=libfprint</bugs-to>
 	</upstream>
 </pkgmetadata>


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/764500
Closes: https://bugs.gentoo.org/888683

Signed-off-by: Marco Scardovi <mscardovi@icloud.com>