### PR TITLE
profiles/base: add app-alternatives/{awk,bzip2,gzip,sh,tar} to @system

### DIFF
--- a/profiles/base/packages
+++ b/profiles/base/packages
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License, v2
 
 # Gentoo Base Profile
@@ -24,9 +24,12 @@
 # of the minimum set of packages needed for any Gentoo based system.
 
 *>=sys-apps/baselayout-2
+*app-alternatives/awk
+*app-alternatives/bzip2
+*app-alternatives/gzip
+*app-alternatives/sh
+*app-alternatives/tar
 *app-admin/eselect
-*app-arch/bzip2
-*app-arch/gzip
 *app-arch/tar
 *app-arch/xz-utils
 *app-shells/bash:0


### PR DESCRIPTION
profiles/base: add app-alternatives/{awk,bzip2,gzip,sh,tar} to @system

- Before this commit, nothing pulls in app-alternatives/sh, so we're relying on
  app-shells/bash handling /bin/sh as an orphaned symlink (which is one of the big
  things we're trying to move away from).

- Add in the others (app-alternatives/{awk,bzip2,gzip,tar}) to allow setup
  via /etc/portage/package.use without adding these to @world manually,
  this also lays the ground work for at some point removing specific implementations
  in the future (after making sure ebuilds which need specific impls. depend on them).

- Note that there's two exceptions:
  1. app-alternatives/yacc

     No need to explicitly add into @system, because we previously had virtual/yacc
     so it'll get pulled in by ebuild dependencies anyway.

  2. app-alternatives/lex

     We never had virtual/lex before and packages very often explicitly
     depend on sys-devel/flex. But this isn't a big deal given it's very unlikely
     that a user wants to try modify lex yet and reflex is still very new as an
     option in Gentoo.

     That is, as time goes on and we test more to ensure it works with any lex,
     it'll get pulled in as various ebuilds get updated anyway.

Bug: https://bugs.gentoo.org/886017
Bug: https://bugs.gentoo.org/886247
Signed-off-by: Sam James <sam@gentoo.org>