### PR TITLE
net-misc/netsed: revbump, EAPI 8, fix test

### DIFF
--- a/net-misc/netsed/netsed-1.3-r1.ebuild
+++ b/net-misc/netsed/netsed-1.3-r1.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 DESCRIPTION="Small tool for altering forwarded network data in real time"
 HOMEPAGE="http://silicone.homelinux.org/projects/netsed/"
@@ -10,6 +10,10 @@ SRC_URI="http://silicone.homelinux.org/release/netsed/${P}.tar.gz"
 LICENSE="LGPL-2"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
+IUSE="test"
+RESTRICT="!test? ( test )"
+
+BDEPEND="test? ( dev-lang/ruby )"
 
 src_compile() {
 	emake CFLAGS="${CFLAGS}"


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/740806

Signed-off-by: Marco Scardovi<mscardovi@icloud.com>