### PR TITLE
sys-libs/musl: Replace -Ofast with -O3

### DIFF
--- a/sys-libs/musl/musl-1.2.2-r8.ebuild
+++ b/sys-libs/musl/musl-1.2.2-r8.ebuild
@@ -88,7 +88,7 @@ src_prepare() {
 }
 
 src_configure() {
-	filter-lto # bug #877343
+	strip-flags # Prevent issues caused by aggressive optimizations & bug #877343
 	tc-getCC ${CTARGET}
 
 	just_headers && export CC=true

--- a/sys-libs/musl/musl-1.2.3-r5.ebuild
+++ b/sys-libs/musl/musl-1.2.3-r5.ebuild
@@ -102,7 +102,7 @@ src_prepare() {
 }
 
 src_configure() {
-	filter-lto # bug #877343
+	strip-flags # Prevent issues caused by aggressive optimizations & bug #877343
 	tc-getCC ${CTARGET}
 
 	just_headers && export CC=true

--- a/sys-libs/musl/musl-1.2.3.ebuild
+++ b/sys-libs/musl/musl-1.2.3.ebuild
@@ -88,7 +88,7 @@ src_prepare() {
 }
 
 src_configure() {
-	filter-lto # bug #877343
+	strip-flags # Prevent issues caused by aggressive optimizations & bug #877343
 	tc-getCC ${CTARGET}
 
 	just_headers && export CC=true

--- a/sys-libs/musl/musl-9999.ebuild
+++ b/sys-libs/musl/musl-9999.ebuild
@@ -102,7 +102,7 @@ src_prepare() {
 }
 
 src_configure() {
-	filter-lto # bug #877343
+	strip-flags # Prevent issues caused by aggressive optimizations & bug #877343
 	tc-getCC ${CTARGET}
 
 	just_headers && export CC=true


### PR DESCRIPTION
Found reports of systemwide issues when Musl is compiled with -Ofast so this is intended to at least save some users from one issue using Ofast systemwide.

Thanks-to: Krusin
Signed-off-by: Ian Jordan <immoloism@gmail.com>