### PR TITLE
go-module.eclass: live_vendor, fallback socks5h:// schema to socks5://

### DIFF
--- a/eclass/go-module.eclass
+++ b/eclass/go-module.eclass
@@ -14,7 +14,7 @@
 # written in the go programming language that uses modules.
 # If the software you are packaging has a file named go.mod in its top level
 # directory, it uses modules.
-# 
+#
 # Modules have been the preferred method of tracking dependencies in software
 # written in Go since version 1.16,
 # so if the software isn't using modules, it should be updated.
@@ -119,13 +119,13 @@ RESTRICT+=" strip"
 #
 # You can use some combination of sed/awk/cut to extract the
 # contents of EGO_SUM or use the dev-go/get-ego-vendor tool.
-# 
+#
 # One manual way to do this is the following:
 #
 # @CODE
 #
 # cat go.sum | cut -d" " -f1,2 | awk '{print "\t\"" $0 "\""}'
-# 
+#
 # @CODE
 #
 # The format of go.sum is described upstream here:
@@ -484,6 +484,27 @@ go-module_live_vendor() {
 		die "${FUNCNAME} only allowed in src_unpack"
 	[[ -d "${S}"/vendor ]] &&
 		die "${FUNCNAME} only allowed when upstream isn't vendoring"
+
+	local hp
+	local -a hps
+	if [[ -n $HTTP_PROXY ]]; then
+		hps+=( HTTP_PROXY )
+	elif [[ -n $http_proxy ]]; then
+		hps+=( http_proxy )
+	fi
+	if [[ -n $HTTPS_PROXY ]]; then
+		hps+=( HTTPS_PROXY )
+	elif [[ -n $https_proxy ]]; then
+		hps+=( https_proxy )
+	fi
+	for hp in "${hps[@]}"; do
+		if [[ -n ${!hp} ]] && [[ ${!hp} =~ ^socks5h:// ]]; then
+			set -- export ${hp}="socks5${!hp#socks5h}"
+			ewarn "golang does not support the 'socks5h://' schema for '${hp}', fallback to the 'socks5://' schema"
+			einfo "${@}"
+			"${@}"
+		fi
+	done
 
 	pushd "${S}" >& /dev/null || die
 	ego mod vendor


### PR DESCRIPTION
Golang does not support the 'socks5h://' schema for http[s]_proxy env variable: https://github.com/golang/go/blob/9123221ccf3c80c741ead5b6f2e960573b1676b9/src/vendor/golang.org/x/net/http/httpproxy/proxy.go#L152-L159, while libcurl supports it: https://github.com/curl/curl/blob/ae98b85020094fb04eee7e7b4ec4eb1a38a98b98/docs/libcurl/opts/CURLOPT_PROXY.3#L48-L59. So, if a 'https_proxy=socks5h://127.0.0.1:1080' env has been set in the make.conf to make curl (assuming curl is the current download command) to download all packages through the proxy, go-module_live_vendor will fail.

The only difference between these two schemas is, 'socks5h' will solve the hostname via the proxy while 'socks5' will not. I think it's ok to fallback 'socks5h' to 'socks5' for `go vendor` command and warn user, until golang supports it.

related to issue: https://github.com/golang/go/issues/24135