### PR TITLE
sys-libs/musl: Add IUSE custom-cflags

### DIFF
--- a/sys-libs/musl/musl-1.2.3-r6.ebuild
+++ b/sys-libs/musl/musl-1.2.3-r6.ebuild
@@ -105,10 +105,10 @@ src_configure() {
 	# Allow users to explicitly avoid flag sanitization via
 	# USE=custom-cflags.
 	if ! use custom-cflags; then
-	# Over-zealous CFLAGS can often cause problems.  What may work for one
-	# person may not work for another.  To avoid a large influx of bugs
-	# relating to failed builds, we strip most CFLAGS out to ensure as few
-	# problems as possible.
+		# Over-zealous CFLAGS can often cause problems.  What may work for one
+		# person may not work for another.  To avoid a large influx of bugs
+		# relating to failed builds, we strip most CFLAGS out to ensure as few
+		# problems as possible.
 		strip-flags
 	else
 		# While allowing the user to set their own CFLAGS with this option


### PR DESCRIPTION
From a request this is an added USEFLAG to allow users to add optimizations to Musl while still removing known CFLAGS to causes breakages. Comment wording was taken from the Glibc ebuild.

Currently only applied to a new revision and the 9999 ebuild so tracking of issues with this change can be easily spotted but can be changed to all if requested.

Signed-off-by: Ian Jordan <immoloism@gmail.com>