### PR TITLE
sys-libs/ncurses[minimal,-split-usr]: don't install dangling symlinks

### DIFF
--- a/sys-libs/ncurses/ncurses-6.3_p20220924-r10.ebuild
+++ b/sys-libs/ncurses/ncurses-6.3_p20220924-r10.ebuild
@@ -453,7 +453,7 @@ multilib_src_install_all() {
 	elif use minimal ; then
 		# Keep only the basic terminfo files
 		find "${ED}"/usr/share/terminfo/ \
-			-type f ${terms[*]/#/! -name } -delete , \
+			\( -type f -o -type l \) ${terms[*]/#/! -name } -delete , \
 			-type d -empty -delete || die
 	fi
 

--- a/sys-libs/ncurses/ncurses-6.3_p20220924-r2.ebuild
+++ b/sys-libs/ncurses/ncurses-6.3_p20220924-r2.ebuild
@@ -451,7 +451,7 @@ multilib_src_install_all() {
 	elif use minimal ; then
 		# Keep only the basic terminfo files
 		find "${ED}"/usr/share/terminfo/ \
-			-type f ${terms[*]/#/! -name } -delete , \
+			\( -type f -o -type l \) ${terms[*]/#/! -name } -delete , \
 			-type d -empty -delete || die
 	fi
 

--- a/sys-libs/ncurses/ncurses-6.3_p20221203-r1.ebuild
+++ b/sys-libs/ncurses/ncurses-6.3_p20221203-r1.ebuild
@@ -465,7 +465,7 @@ multilib_src_install_all() {
 	elif use minimal ; then
 		# Keep only the basic terminfo files
 		find "${ED}"/usr/share/terminfo/ \
-			-type f ${terms[*]/#/! -name } -delete , \
+			\( -type f -o -type l \) ${terms[*]/#/! -name } -delete , \
 			-type d -empty -delete || die
 	fi
 

--- a/sys-libs/ncurses/ncurses-6.3_p20221203.ebuild
+++ b/sys-libs/ncurses/ncurses-6.3_p20221203.ebuild
@@ -463,7 +463,7 @@ multilib_src_install_all() {
 	elif use minimal ; then
 		# Keep only the basic terminfo files
 		find "${ED}"/usr/share/terminfo/ \
-			-type f ${terms[*]/#/! -name } -delete , \
+			\( -type f -o -type l \) ${terms[*]/#/! -name } -delete , \
 			-type d -empty -delete || die
 	fi
 


### PR DESCRIPTION
I inadventently introduced a bug in #27988: when `USE="minimal -split-usr"`, a large number of dangling symlinks were being installed to `${ED}/usr/share/terminfo`. This PR corrects my oversight; I have tested and do confirm that the dangling symlinks are no longer installed. @floppym

**Note:** I don't see a need to revbump and force reinstallation, as there is no *problem* with installing the dangling symlinks other than wasting inodes in the file system.