### PR TITLE
out-of-source-utils.eclass: new eclass for run_in_build_dir helper

### DIFF
--- a/eclass/multibuild.eclass
+++ b/eclass/multibuild.eclass
@@ -14,7 +14,10 @@
 # implementations).
 
 case ${EAPI} in
-	6|7|8) ;;
+	6|7|8)
+		# backwards compatibility for run_in_build_dir
+		inherit out-of-source-utils
+		;;
 	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
 
@@ -173,26 +176,6 @@ multibuild_copy_sources() {
 	}
 
 	multibuild_foreach_variant _multibuild_create_source_copy
-}
-
-# @FUNCTION: run_in_build_dir
-# @USAGE: <argv>...
-# @DESCRIPTION:
-# Run the given command in the directory pointed by BUILD_DIR.
-run_in_build_dir() {
-	debug-print-function ${FUNCNAME} "${@}"
-	local ret
-
-	[[ ${#} -ne 0 ]] || die "${FUNCNAME}: no command specified."
-	[[ ${BUILD_DIR} ]] || die "${FUNCNAME}: BUILD_DIR not set."
-
-	mkdir -p "${BUILD_DIR}" || die
-	pushd "${BUILD_DIR}" >/dev/null || die
-	"${@}"
-	ret=${?}
-	popd >/dev/null || die
-
-	return ${ret}
 }
 
 # @FUNCTION: multibuild_merge_root

--- a/eclass/multilib-build.eclass
+++ b/eclass/multilib-build.eclass
@@ -7,7 +7,6 @@
 # @AUTHOR:
 # Author: Michał Górny <mgorny@gentoo.org>
 # @SUPPORTED_EAPIS: 6 7 8
-# @PROVIDES: multibuild
 # @BLURB: flags and utility functions for building multilib packages
 # @DESCRIPTION:
 # The multilib-build.eclass exports USE flags and utility functions

--- a/eclass/out-of-source-utils.eclass
+++ b/eclass/out-of-source-utils.eclass
@@ -1,0 +1,43 @@
+# Copyright 2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+# @ECLASS: out-of-source-utils.eclass
+# @MAINTAINER:
+# Michał Górny <mgorny@gentoo.org>
+# @AUTHOR:
+# Michał Górny <mgorny@gentoo.org>
+# @SUPPORTED_EAPIS: 6 7 8
+# @BLURB: Utility functions for building packages out-of-source
+# @DESCRIPTION:
+# This eclass provides a run_in_build_dir() helper that can be used
+# to execute specified command inside BUILD_DIR.
+
+case ${EAPI} in
+	6|7|8) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
+
+if [[ ! ${_OUT_OF_SOURCE_UTILS_ECLASS} ]]; then
+_OUT_OF_SOURCE_UTILS_ECLASS=1
+
+# @FUNCTION: run_in_build_dir
+# @USAGE: <argv>...
+# @DESCRIPTION:
+# Run the given command in the directory pointed by BUILD_DIR.
+run_in_build_dir() {
+	debug-print-function ${FUNCNAME} "${@}"
+	local ret
+
+	[[ ${#} -eq 0 ]] && die "${FUNCNAME}: no command specified."
+	[[ -z ${BUILD_DIR} ]] && die "${FUNCNAME}: BUILD_DIR not set."
+
+	mkdir -p "${BUILD_DIR}" || die
+	pushd "${BUILD_DIR}" >/dev/null || die
+	"${@}"
+	ret=${?}
+	popd >/dev/null || die
+
+	return ${ret}
+}
+
+fi

--- a/eclass/out-of-source.eclass
+++ b/eclass/out-of-source.eclass
@@ -40,6 +40,13 @@ esac
 if [[ ! ${_OUT_OF_SOURCE_ECLASS} ]]; then
 _OUT_OF_SOURCE_ECLASS=1
 
+# @ECLASS_VARIABLE: BUILD_DIR
+# @OUTPUT_VARIABLE
+# @DEFAULT_UNSET
+# @DESCRIPTION:
+# The current build directory.  Defaults to ${WORKDIR}/${P}_build
+# if unset.
+
 # @FUNCTION: out-of-source_src_configure
 # @DESCRIPTION:
 # The default src_configure() implementation establishes a BUILD_DIR,

--- a/eclass/python-r1.eclass
+++ b/eclass/python-r1.eclass
@@ -8,7 +8,7 @@
 # Author: Michał Górny <mgorny@gentoo.org>
 # Based on work of: Krzysztof Pawlik <nelchael@gentoo.org>
 # @SUPPORTED_EAPIS: 7 8
-# @PROVIDES: multibuild python-utils-r1
+# @PROVIDES: python-utils-r1
 # @BLURB: A common, simple eclass for Python packages.
 # @DESCRIPTION:
 # A common eclass providing helper functions to build and install


### PR DESCRIPTION
This is in order to clean transitive includes a bit. Right now Python & multilib eclasses transitively include multibuild via `@PROVIDES`. However, this is only used to silence pkgcheck complaining about ebuilds using `run_in_build_dir`, and only a handful of ebuilds is actually using this helper.

At the same time, the helper itself could also be used with `out-of-source.eclass` that naturally doesn't use `multibuild.eclass`. `multibuild.eclass` itself is a low-level thingy, and it doesn't feel right for ebuilds to be inheriting it unless they really intend to do low-level stuff.

All things considered, I think it makes most sense to move `run_in_build_dir` to a new eclass. The existing eclasses will transitively include it in existing EAPIs but ebuilds should directly inherit oosu instead, and will have to do so in EAPI 9. This also means that the eclasses will no longer transitively provide multibuild.

See also: https://github.com/pkgcore/pkgcheck/issues/504