### PR TITLE
package.mask: */* mask broken/obsolete packages

### DIFF
--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -33,6 +33,13 @@
 
 #--- END OF EXAMPLES ---
 
+# Michael Mair-Keimberger <mmk@levelnine.at> (2023-01-08)
+# Dependencies of games-server/cyphesis, which got removed ~4 years ago, no
+# other reverse dependencies.
+# Removal: 2023-02-08. Bug #728230
+dev-games/mercator
+dev-games/wfmath
+
 # Sam James <sam@gentoo.org> (2023-01-05)
 # Breaks reverse dependencies: bug #889694, bug #888579.
 =sys-fs/btrfs-progs-6.1.1

--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -34,6 +34,11 @@
 #--- END OF EXAMPLES ---
 
 # Michael Mair-Keimberger <mmk@levelnine.at> (2023-01-08)
+# EAPI=6, Installs only card pictures and has no reverse dependencies.
+# Removal: 2023-02-08. Bug #805278
+dev-games/cardpics
+
+# Michael Mair-Keimberger <mmk@levelnine.at> (2023-01-08)
 # Dependencies of games-server/cyphesis, which got removed ~4 years ago, no
 # other reverse dependencies.
 # Removal: 2023-02-08. Bug #728230

--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -34,6 +34,11 @@
 #--- END OF EXAMPLES ---
 
 # Michael Mair-Keimberger <mmk@levelnine.at> (2023-01-08)
+# Broken since many years, no reverse dependencies, last release from 2000
+# Removal: 2023-02-08. Bug #678518
+net-dns/dnswalk
+
+# Michael Mair-Keimberger <mmk@levelnine.at> (2023-01-08)
 # EAPI=6, Installs only card pictures and has no reverse dependencies.
 # Removal: 2023-02-08. Bug #805278
 dev-games/cardpics


### PR DESCRIPTION
Hi,

This PR mask a few broken/obsolete packages for tree-clean which i think should have been removed for quite some time.