### PR TITLE
sci-libs/opencascade-7.{7.0,6.3} - simplify vtk logic

### DIFF
--- a/sci-libs/opencascade/opencascade-7.6.3-r1.ebuild
+++ b/sci-libs/opencascade/opencascade-7.6.3-r1.ebuild
@@ -132,17 +132,14 @@ src_configure() {
 	fi
 
 	if use vtk; then
+		local vtk_ver=$(best_version "sci-libs/vtk")
+		vtk_ver=${vtk_ver#sci-libs/vtk-}
+		vtk_ver=$(ver_cut 1-2 ${vtk_ver})
 		mycmakeargs+=(
 			-D3RDPARTY_VTK_DIR="${ESYSROOT}"/usr
+			-D3RDPARTY_VTK_INCLUDE_DIR="${ESYSROOT}"/usr/include/vtk-${vtk_ver}
 			-D3RDPARTY_VTK_LIBRARY_DIR="${ESYSROOT}"/usr/$(get_libdir)
 		)
-		if has_version ">=sci-libs/vtk-9.2.0"; then
-			mycmakeargs+=( -D3RDPARTY_VTK_INCLUDE_DIR="${ESYSROOT}"/usr/include/vtk-9.2 )
-		elif has_version ">=sci-libs/vtk-9.1.0"; then
-			mycmakeargs+=( -D3RDPARTY_VTK_INCLUDE_DIR="${ESYSROOT}"/usr/include/vtk-9.1 )
-		elif has_version ">=sci-libs/vtk-9.0.0"; then
-			mycmakeargs+=( -D3RDPARTY_VTK_INCLUDE_DIR="${ESYSROOT}"/usr/include/vtk-9.0 )
-		fi
 	fi
 
 	cmake_src_configure

--- a/sci-libs/opencascade/opencascade-7.7.0-r1.ebuild
+++ b/sci-libs/opencascade/opencascade-7.7.0-r1.ebuild
@@ -133,17 +133,14 @@ src_configure() {
 	fi
 
 	if use vtk; then
+		local vtk_ver=$(best_version "sci-libs/vtk")
+		vtk_ver=${vtk_ver#sci-libs/vtk-}
+		vtk_ver=$(ver_cut 1-2 ${vtk_ver})
 		mycmakeargs+=(
 			-D3RDPARTY_VTK_DIR="${ESYSROOT}"/usr
+			-D3RDPARTY_VTK_INCLUDE_DIR="${ESYSROOT}"/usr/include/vtk-${vtk_ver}
 			-D3RDPARTY_VTK_LIBRARY_DIR="${ESYSROOT}"/usr/$(get_libdir)
 		)
-		if has_version ">=sci-libs/vtk-9.2.0"; then
-			mycmakeargs+=( -D3RDPARTY_VTK_INCLUDE_DIR="${ESYSROOT}"/usr/include/vtk-9.2 )
-		elif has_version ">=sci-libs/vtk-9.1.0"; then
-			mycmakeargs+=( -D3RDPARTY_VTK_INCLUDE_DIR="${ESYSROOT}"/usr/include/vtk-9.1 )
-		elif has_version ">=sci-libs/vtk-9.0.0"; then
-			mycmakeargs+=( -D3RDPARTY_VTK_INCLUDE_DIR="${ESYSROOT}"/usr/include/vtk-9.0 )
-		fi
 	fi
 
 	cmake_src_configure


### PR DESCRIPTION
As suggest by @thesamesam in https://github.com/gentoo/gentoo/pull/28704#discussion_r1059657455, the logic for the cmake parameter of VTK include directory can be simplified and the conditional logic avoided.

sci-libs/opencascade: simplify vtk logic (v7.7.0)

Avoid using conditional logic to determine the include directory for VTK.

Suggested-by: Sam James <sam@gentoo.org>
Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>

sci-libs/opencascade: simplify vtk logic (v7.6.3)

Backport patch from v7.7.0

Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>
