### PR TITLE
mail-filter/rspamd: respect libdir

### DIFF
--- a/mail-filter/rspamd/rspamd-3.4-r2.ebuild
+++ b/mail-filter/rspamd/rspamd-3.4-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -92,6 +92,7 @@ src_configure() {
 		-DRUNDIR=/var/run/rspamd
 		-DDBDIR=/var/lib/rspamd
 		-DLOGDIR=/var/log/rspamd
+		-DLIBDIR="/usr/$(get_libdir)/rspamd"
 
 		-DSYSTEM_DOCTEST=ON
 		-DSYSTEM_FMT=ON


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/887591