### PR TITLE
app-crypt/nitrocli: Use cargo install for shell-complete

### DIFF
--- a/app-crypt/nitrocli/nitrocli-0.4.1.ebuild
+++ b/app-crypt/nitrocli/nitrocli-0.4.1.ebuild
@@ -93,13 +93,20 @@ RDEPEND="
 RESTRICT="test"
 QA_FLAGS_IGNORED="usr/bin/nitrocli"
 
+src_compile() {
+	cargo_src_compile --bin=nitrocli
+	# Install shell-complete binary into source directory to be able to
+	# use it later on.
+	cargo install --bin=shell-complete --path . --root "${S}" || die
+}
+
 src_install() {
 	cargo_src_install --bin=nitrocli
 
-	target/release/shell-complete bash > ${PN}.bash || die
+	"${S}"/bin/shell-complete bash > ${PN}.bash || die
 	newbashcomp ${PN}.bash ${PN}
 
-	target/release/shell-complete fish > ${PN}.fish || die
+	"${S}"/bin/shell-complete fish > ${PN}.fish || die
 	insinto /usr/share/fish/vendor_conf.d/
 	insopts -m0755
 	doins ${PN}.fish


### PR DESCRIPTION
The way we access the `shell-complete` binary during the build has always been a hack. There is no way to know for sure where it is located ahead of time and cargo does not expose this information in an easily accessible manner. That may lead to shenanigans such as https://bugs.gentoo.org/889360, where it appears as if a debug build was forced and that resulted in the executable being available in `target/debug/` as opposed to `target/release/`.
Fix this issue by using cargo install internally, to force "temporary" installation in less undefined path.

Closes: https://bugs.gentoo.org/889360
Signed-off-by: Daniel Müller <deso@posteo.net>