### PR TITLE
net-misc/icaclient: fix broken BDEPEND and add error handling

### DIFF
--- a/net-misc/icaclient/icaclient-22.12.0.12-r1.ebuild
+++ b/net-misc/icaclient/icaclient-22.12.0.12-r1.ebuild
@@ -40,7 +40,7 @@ REQUIRES_EXCLUDE="${REQUIRES_EXCLUDE}
 	libgstreamer-0.10.so.0
 "
 
-BEPEND="
+BDEPEND="
 	hdx? ( >=media-plugins/hdx-realtime-media-engine-2.9.500.2802-r1 )
 "
 
@@ -121,12 +121,12 @@ src_prepare() {
 	default
 	rm lib/UIDialogLibWebKit.so || die
 
-	cp nls/en/module.ini .
+	cp nls/en/module.ini . || die
 	if use hdx; then
-		"${BROOT}${ICAROOT}"/rtme/RTMEconfig -install -ignoremm
-		mv new_module.ini module.ini
+		"${BROOT}${ICAROOT}"/rtme/RTMEconfig -install -ignoremm || die
+		mv new_module.ini module.ini || die
 	fi
-	mv module.ini config/
+	mv module.ini config/ || die
 }
 
 src_install() {


### PR DESCRIPTION
When one wants to use "hdx" that does not really work as expected due to a typo. Also include the missing "|| die"s that have been pointed out in a previous review.

Signed-off-by: Henning Schild <henning@hennsch.de>