### PR TITLE
sci-physics/lhapdf: Boost dependency can be dropped in LHAPDF-6.5.X

### DIFF
--- a/sci-physics/lhapdf/lhapdf-6.5.1-r1.ebuild
+++ b/sci-physics/lhapdf/lhapdf-6.5.1-r1.ebuild
@@ -1,0 +1,55 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+PYTHON_COMPAT=( python3_9 )
+DOCS_BUILDER="doxygen"
+DOCS_DEPEND="
+	dev-texlive/texlive-bibtexextra
+	dev-texlive/texlive-fontsextra
+	dev-texlive/texlive-fontutils
+	dev-texlive/texlive-latex
+	dev-texlive/texlive-latexextra
+"
+inherit python-single-r1 docs
+
+MY_PV=$(ver_cut 1-3)
+MY_PF=LHAPDF-${MY_PV}
+
+DESCRIPTION="Les Houches Parton Density Function unified library"
+HOMEPAGE="https://lhapdf.hepforge.org/"
+SRC_URI="https://www.hepforge.org/downloads/lhapdf/${MY_PF}.tar.gz"
+S="${WORKDIR}/${MY_PF}"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86 ~amd64-linux ~x86-linux"
+IUSE="examples"
+REQUIRED_USE="${PYTHON_REQUIRED_USE}"
+
+RDEPEND="${PYTHON_DEPS}"
+DEPEND="${RDEPEND}"
+
+src_configure() {
+	CONFIG_SHELL="${EPREFIX}/bin/bash" \
+	econf \
+		--disable-static \
+		--enable-python
+}
+
+src_compile() {
+	emake all $(use doc && echo doxy)
+}
+
+src_test() {
+	emake -C tests
+}
+
+src_install() {
+	default
+	use doc && dodoc -r doc/doxygen/.
+	use examples && dodoc examples/*.cc
+
+	find "${ED}" -name '*.la' -delete || die
+}

--- a/sci-physics/lhapdf/lhapdf-6.5.2-r2.ebuild
+++ b/sci-physics/lhapdf/lhapdf-6.5.2-r2.ebuild
@@ -1,0 +1,59 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+PYTHON_COMPAT=( python3_{9..11} )
+DOCS_BUILDER="doxygen"
+DOCS_DEPEND="
+	dev-texlive/texlive-bibtexextra
+	dev-texlive/texlive-fontsextra
+	dev-texlive/texlive-fontutils
+	dev-texlive/texlive-latex
+	dev-texlive/texlive-latexextra
+"
+inherit python-single-r1 docs
+
+MY_PV=$(ver_cut 1-3)
+MY_PF=LHAPDF-${MY_PV}
+
+DESCRIPTION="Les Houches Parton Density Function unified library"
+HOMEPAGE="https://lhapdf.hepforge.org/"
+SRC_URI="https://www.hepforge.org/downloads/lhapdf/${MY_PF}.tar.gz"
+S="${WORKDIR}/${MY_PF}"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86 ~amd64-linux ~x86-linux"
+IUSE="examples"
+REQUIRED_USE="${PYTHON_REQUIRED_USE}"
+
+RDEPEND="${PYTHON_DEPS}"
+DEPEND="${RDEPEND}"
+PATCHES=(
+	"${FILESDIR}"/${P}-py.patch
+)
+src_configure() {
+	CONFIG_SHELL="${EPREFIX}/bin/bash" \
+	econf \
+		--disable-static \
+		--enable-python
+}
+
+src_compile() {
+	emake all $(use doc && echo doxy)
+}
+
+src_test() {
+	emake -C tests
+}
+
+src_install() {
+	default
+	use doc && dodoc -r doc/doxygen/.
+	use examples && dodoc examples/*.cc
+
+	python_optimize
+
+	find "${ED}" -name '*.la' -delete || die
+}

--- a/sci-physics/lhapdf/lhapdf-6.5.3-r1.ebuild
+++ b/sci-physics/lhapdf/lhapdf-6.5.3-r1.ebuild
@@ -1,0 +1,61 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+PYTHON_COMPAT=( python3_{8..11} )
+DOCS_BUILDER="doxygen"
+DOCS_DEPEND="
+	dev-texlive/texlive-bibtexextra
+	dev-texlive/texlive-fontsextra
+	dev-texlive/texlive-fontutils
+	dev-texlive/texlive-latex
+	dev-texlive/texlive-latexextra
+"
+inherit python-single-r1 docs
+
+MY_PV=$(ver_cut 1-3)
+MY_PF=LHAPDF-${MY_PV}
+
+DESCRIPTION="Les Houches Parton Density Function unified library"
+HOMEPAGE="https://lhapdf.hepforge.org/"
+SRC_URI="https://www.hepforge.org/downloads/lhapdf/${MY_PF}.tar.gz"
+S="${WORKDIR}/${MY_PF}"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64"
+IUSE="examples"
+REQUIRED_USE="${PYTHON_REQUIRED_USE}"
+
+RDEPEND="${PYTHON_DEPS}"
+DEPEND="${RDEPEND}"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-6.5.2-py.patch
+)
+
+src_configure() {
+	CONFIG_SHELL="${EPREFIX}/bin/bash" \
+	econf \
+		--disable-static \
+		--enable-python
+}
+
+src_compile() {
+	emake all $(use doc && echo doxy)
+}
+
+src_test() {
+	emake -C tests
+}
+
+src_install() {
+	default
+	use doc && dodoc -r doc/doxygen/.
+	use examples && dodoc examples/*.cc
+
+	python_optimize
+
+	find "${ED}" -name '*.la' -delete || die
+}


### PR DESCRIPTION
Signed-off-by: Alexander Puck Neuwirth <alexander@neuwirth-informatik.de>

3 revbumps with boost removed.