### PR TITLE
dev-java/java-config: enable py3.11

### DIFF
--- a/dev-java/java-config/java-config-2.3.1.ebuild
+++ b/dev-java/java-config/java-config-2.3.1.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 
 # jython depends on java-config, so don't add it or things will break
-PYTHON_COMPAT=( python3_{7..10} )
+PYTHON_COMPAT=( python3_{7..11} )
 DISTUTILS_USE_SETUPTOOLS=no
 
 inherit distutils-r1

--- a/dev-java/java-config/java-config-9999.ebuild
+++ b/dev-java/java-config/java-config-9999.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 
 # jython depends on java-config, so don't add it or things will break
-PYTHON_COMPAT=( python3_{7..10} )
+PYTHON_COMPAT=( python3_{7..11} )
 DISTUTILS_USE_SETUPTOOLS=no
 
 inherit distutils-r1


### PR DESCRIPTION
Works fine, passes tests on 3.11.

Signed-off-by: Joe Kappus <joe@wt.gd>