### PR TITLE
net-p2p/deluge: remove unnecessary acct-group/deluge dependency

### DIFF
--- a/net-p2p/deluge/deluge-2.1.1-r1.ebuild
+++ b/net-p2p/deluge/deluge-2.1.1-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -38,7 +38,6 @@ BDEPEND="
 "
 
 RDEPEND="
-	acct-group/deluge
 	acct-user/deluge
 	net-libs/libtorrent-rasterbar:=[python,${PYTHON_SINGLE_USEDEP}]
 	$(python_gen_cond_dep '

--- a/net-p2p/deluge/deluge-2.1.1.ebuild
+++ b/net-p2p/deluge/deluge-2.1.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -38,7 +38,6 @@ BDEPEND="
 "
 
 RDEPEND="
-	acct-group/deluge
 	acct-user/deluge
 	net-libs/libtorrent-rasterbar:=[python,${PYTHON_SINGLE_USEDEP}]
 	$(python_gen_cond_dep '

--- a/net-p2p/deluge/deluge-9999.ebuild
+++ b/net-p2p/deluge/deluge-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -38,7 +38,6 @@ BDEPEND="
 "
 
 RDEPEND="
-	acct-group/deluge
 	acct-user/deluge
 	net-libs/libtorrent-rasterbar:=[python,${PYTHON_SINGLE_USEDEP}]
 	$(python_gen_cond_dep '


### PR DESCRIPTION
`acct-user/deluge` has [already](https://packages.gentoo.org/packages/acct-user/deluge/dependencies) `RDEPEND`'ed `acct-group/deluge`.