### PR TITLE
app-editors/neovim: Syncing live ebuild to 0.8.2 ebuild

### DIFF
--- a/app-editors/neovim/neovim-9999.ebuild
+++ b/app-editors/neovim/neovim-9999.ebuild
@@ -68,17 +68,14 @@ BDEPEND="
 	)
 "
 
-PATCHES=()
+PATCHES=(
+	"${FILESDIR}/${PN}-9999-cmake_lua_version.patch"
+	"${FILESDIR}/${PN}-9999-cmake-darwin.patch"
+)
 
-if [[ ${PV} == 9999 ]]; then
+if [[ ${PV} != 9999 ]]; then
 	PATCHES+=(
-		"${FILESDIR}/${PN}-9999-cmake_lua_version.patch"
-		"${FILESDIR}/${PN}-9999-cmake-darwin.patch"
-	)
-else
-	PATCHES+=(
-		"${FILESDIR}/${PN}-9999-cmake_lua_version.patch"
-		"${FILESDIR}/${PN}-9999-cmake-darwin.patch"
+		"${FILESDIR}/${PN}-0.8.0-cmake-release-type.patch"
 	)
 fi
 


### PR DESCRIPTION
With PR #28893, the syntax of adding patches is modified, this PR is reflecting those changes in the live ebuild.

Referrence: https://github.com/gentoo/gentoo/pull/28893#issuecomment-1370510768
Signed-off-by: listout <listout@protonmail.com>