### PR TITLE
dev-libs/libbpf: Fix install in cross-compilation

### DIFF
--- a/dev-libs/libbpf/libbpf-0.8.1.ebuild
+++ b/dev-libs/libbpf/libbpf-0.8.1.ebuild
@@ -42,6 +42,7 @@ src_configure() {
 src_install() {
 	emake \
 		DESTDIR="${D}" \
+		LIBSUBDIR="${LIBSUBDIR}" \
 		install install_uapi_headers
 
 	if ! use static-libs; then

--- a/dev-libs/libbpf/libbpf-1.0.0-r1.ebuild
+++ b/dev-libs/libbpf/libbpf-1.0.0-r1.ebuild
@@ -41,6 +41,7 @@ src_configure() {
 src_install() {
 	emake \
 		DESTDIR="${D}" \
+		LIBSUBDIR="${LIBSUBDIR}" \
 		install install_uapi_headers
 
 	if ! use static-libs; then

--- a/dev-libs/libbpf/libbpf-1.0.1.ebuild
+++ b/dev-libs/libbpf/libbpf-1.0.1.ebuild
@@ -42,6 +42,7 @@ src_configure() {
 src_install() {
 	emake \
 		DESTDIR="${D}" \
+		LIBSUBDIR="${LIBSUBDIR}" \
 		install install_uapi_headers
 
 	if ! use static-libs; then

--- a/dev-libs/libbpf/libbpf-9999.ebuild
+++ b/dev-libs/libbpf/libbpf-9999.ebuild
@@ -42,6 +42,7 @@ src_configure() {
 src_install() {
 	emake \
 		DESTDIR="${D}" \
+		LIBSUBDIR="${LIBSUBDIR}" \
 		install install_uapi_headers
 
 	if ! use static-libs; then


### PR DESCRIPTION
Without this patch install would cause:

```
* Bad lib64 usage detected:
drwxr-xr-x 3 root root 4.0K Jan  4 06:31 /build/target/tmp/portage/dev-libs/libbpf-1.0.1/image/usr/lib64
lrwxrwxrwx 1 root root   11 Jan  4 06:31 /build/target/tmp/portage/dev-libs/libbpf-1.0.1/image/usr/lib64/libbpf.so -> libbpf.so.1
lrwxrwxrwx 1 root root   15 Jan  4 06:31 /build/target/tmp/portage/dev-libs/libbpf-1.0.1/image/usr/lib64/libbpf.so.1 -> libbpf.so.1.0.1
-rwxr-xr-x 1 root root 889K Jan  4 06:31 /build/target/tmp/portage/dev-libs/libbpf-1.0.1/image/usr/lib64/libbpf.so.1.0.1
drwxr-xr-x 2 root root 4.0K Jan  4 06:31 /build/target/tmp/portage/dev-libs/libbpf-1.0.1/image/usr/lib64/pkgconfig
-rw-r--r-- 1 root root  294 Jan  4 06:31 /build/target/tmp/portage/dev-libs/libbpf-1.0.1/image/usr/lib64/pkgconfig/libbpf.pc
* This arch (arm) should never use 'lib64'.
```

PR #28323 commit bd8d3b7a7f3d (dev-libs/libbpf: Fix install in prefix") removed declaration of LIBDIR because it is default-initialized to:
  `LIBDIR ?= $(PREFIX)/$(LIBSUBDIR)`

However this causes regression because while we do set:
  `export LIBSUBDIR="$(get_libdir)"`

This does not take effect in the Makefile, because it does either one of:
```
LIBSUBDIR := lib64
LIBSUBDIR := lib
```

Environment variables don't take precedence over variables from makefiles unless -e is given. To minimize other possible regressions I'm explicitly whitelisting LIBSUBDIR for precedence over that from makefile.

Reported-by: Aashay Shringarpure <aashay@google.com>
Signed-off-by: YiFei Zhu <zhuyifei@google.com>