### PR TITLE
media-plugins/hdx-realtime-media-engine: add -* to KEYWORDS

### DIFF
--- a/media-plugins/hdx-realtime-media-engine/hdx-realtime-media-engine-2.9.400.2702.ebuild
+++ b/media-plugins/hdx-realtime-media-engine/hdx-realtime-media-engine-2.9.400.2702.ebuild
@@ -14,7 +14,7 @@ SRC_URI="amd64? ( HDX_RealTime_Media_Engine_${MY_PV}_for_Linux_x64.zip )
 LICENSE="icaclient"
 SLOT="0"
 
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="-* ~amd64 ~x86"
 RESTRICT="fetch mirror strip"
 
 BDEPEND="app-arch/unzip"

--- a/media-plugins/hdx-realtime-media-engine/hdx-realtime-media-engine-2.9.500.2802-r1.ebuild
+++ b/media-plugins/hdx-realtime-media-engine/hdx-realtime-media-engine-2.9.500.2802-r1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="amd64? ( HDX_RealTime_Media_Engine_${MY_PV}_for_Linux_x64.zip )
 LICENSE="icaclient"
 SLOT="0"
 
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="-* ~amd64 ~x86"
 RESTRICT="fetch mirror strip"
 
 BDEPEND="app-arch/unzip"

--- a/media-plugins/hdx-realtime-media-engine/hdx-realtime-media-engine-2.9.500.2802.ebuild
+++ b/media-plugins/hdx-realtime-media-engine/hdx-realtime-media-engine-2.9.500.2802.ebuild
@@ -14,7 +14,7 @@ SRC_URI="amd64? ( HDX_RealTime_Media_Engine_${MY_PV}_for_Linux_x64.zip )
 LICENSE="icaclient"
 SLOT="0"
 
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="-* ~amd64 ~x86"
 RESTRICT="fetch mirror strip"
 
 BDEPEND="app-arch/unzip"


### PR DESCRIPTION
This package ships binaries only available for x86 and amd64, make sure nobody else even tries.

Signed-off-by: Henning Schild <henning@hennsch.de>