### PR TITLE
dev-libs/libsecp256k1 ebuild updates

### DIFF
--- a/dev-libs/libsecp256k1/files/0.2.0-fix-cross-compile.patch
+++ b/dev-libs/libsecp256k1/files/0.2.0-fix-cross-compile.patch
@@ -1,0 +1,85 @@
+From 772e747bd9104d80fe531bed61f23f75342d7d63 Mon Sep 17 00:00:00 2001
+From: Matt Whitlock <bitcoin@mattwhitlock.name>
+Date: Sun, 20 Nov 2022 01:46:07 -0500
+Subject: [PATCH] Makefile: build precomp generators using build-system
+ toolchain
+
+When cross-compiling libsecp256k1, if the `precomputed_ecmult*.c` source
+files need to be regenerated, then the generators need to be built for
+the *build* system, not for the *host* system. Autoconf supports this
+fairly cleanly via the `AX_PROG_CC_FOR_BUILD` macro (from Autoconf
+Archive), but Automake requires some hackery. When building the
+generators, we override the `CC`, `CFLAGS`, `CPPFLAGS`, and `LDFLAGS`
+variables to their build-system counterparts, whose names are suffixed
+with `_FOR_BUILD` and whose values are populated by the aforementioned
+Autoconf macro and may be overridden on the `make` command line. Since
+Automake lacks support for overriding `EXEEXT` on a per-program basis,
+we define a recipe that builds the generator binaries with names
+suffixed with `$(EXEEXT)` and then renames them suffixed with
+`$(BUILD_EXEEXT)`.
+---
+ Makefile.am  | 30 ++++++++++++++++++++++++------
+ configure.ac |  1 +
+ 2 files changed, 25 insertions(+), 6 deletions(-)
+
+diff --git a/Makefile.am b/Makefile.am
+index 30b6a794d0..e929300298 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -180,8 +180,26 @@ endif
+ endif
+ 
+ ### Precomputed tables
+-EXTRA_PROGRAMS = precompute_ecmult precompute_ecmult_gen
+-CLEANFILES = $(EXTRA_PROGRAMS)
++PROGRAMS_FOR_BUILD = precompute_ecmult precompute_ecmult_gen
++$(addsuffix $(BUILD_EXEEXT),$(PROGRAMS_FOR_BUILD)) : override CC = $(CC_FOR_BUILD)
++$(addsuffix $(BUILD_EXEEXT),$(PROGRAMS_FOR_BUILD)) : override CFLAGS = $(CFLAGS_FOR_BUILD)
++$(addsuffix $(BUILD_EXEEXT),$(PROGRAMS_FOR_BUILD)) : override CPPFLAGS = $(CPPFLAGS_FOR_BUILD)
++$(addsuffix $(BUILD_EXEEXT),$(PROGRAMS_FOR_BUILD)) : override LDFLAGS = $(LDFLAGS_FOR_BUILD)
++# Automake has no support for PROGRAMS suffixed with BUILD_EXEEXT
++# instead of EXEEXT, so if those extensions differ, then we define a
++# recipe that builds the latter and renames it to the former. Since
++# Cygwin toolchains always append '.exe' to the output file name given
++# by '-o', we ignore rename failures since the toolchain will have
++# already created the right output file. (Note: The leading spaces
++# before ifneq and endif here are a hack so Automake won't try to
++# interpret them as an Automake conditional.)
++ ifneq ($(BUILD_EXEEXT),$(EXEEXT))
++%$(BUILD_EXEEXT) : %$(EXEEXT)
++	mv -- '$<' '$@' || :
++ endif
++
++EXTRA_PROGRAMS = $(PROGRAMS_FOR_BUILD)
++CLEANFILES = $(addsuffix $(BUILD_EXEEXT),$(PROGRAMS_FOR_BUILD))
+ 
+ precompute_ecmult_SOURCES = src/precompute_ecmult.c
+ precompute_ecmult_CPPFLAGS = $(SECP_INCLUDES)
+@@ -198,11 +216,11 @@ precompute_ecmult_gen_LDADD = $(SECP_LIBS) $(COMMON_LIB)
+ # This means that rebuilds of the prebuilt files always need to be
+ # forced by deleting them, e.g., by invoking `make clean-precomp`.
+ src/precomputed_ecmult.c:
+-	$(MAKE) $(AM_MAKEFLAGS) precompute_ecmult$(EXEEXT)
+-	./precompute_ecmult$(EXEEXT)
++	$(MAKE) $(AM_MAKEFLAGS) precompute_ecmult$(BUILD_EXEEXT)
++	./precompute_ecmult$(BUILD_EXEEXT)
+ src/precomputed_ecmult_gen.c:
+-	$(MAKE) $(AM_MAKEFLAGS) precompute_ecmult_gen$(EXEEXT)
+-	./precompute_ecmult_gen$(EXEEXT)
++	$(MAKE) $(AM_MAKEFLAGS) precompute_ecmult_gen$(BUILD_EXEEXT)
++	./precompute_ecmult_gen$(BUILD_EXEEXT)
+ 
+ PRECOMP = src/precomputed_ecmult_gen.c src/precomputed_ecmult.c
+ precomp: $(PRECOMP)
+diff --git a/configure.ac b/configure.ac
+index a2a15d2b82..013964f5ff 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -35,6 +35,7 @@ m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
+ AC_PROG_CC
+ AM_PROG_AS
+ AM_PROG_AR
++AX_PROG_CC_FOR_BUILD
+ 
+ # Clear some cache variables as a workaround for a bug that appears due to a bad
+ # interaction between AM_PROG_AR and LT_INIT when combining MSVC's archiver lib.exe.

--- a/dev-libs/libsecp256k1/libsecp256k1-0.1_pre20201028-r1.ebuild
+++ b/dev-libs/libsecp256k1/libsecp256k1-0.1_pre20201028-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -14,13 +14,12 @@ SRC_URI="https://github.com/bitcoin-core/${MyPN}/archive/${COMMITHASH}.tar.gz ->
 LICENSE="MIT"
 SLOT="0"
 KEYWORDS="amd64 ~arm ~arm64 ~mips ~ppc ~ppc64 x86 ~amd64-linux ~x86-linux"
-IUSE="+asm ecdh +experimental +extrakeys gmp lowmem precompute-ecmult +schnorr +recovery test test-openssl valgrind"
+IUSE="+asm ecdh +experimental +extrakeys gmp lowmem +recovery +schnorr test test-openssl valgrind"
 RESTRICT="!test? ( test )"
 
 REQUIRED_USE="
 	asm? ( || ( amd64 arm ) arm? ( experimental ) )
 	extrakeys? ( experimental )
-	?? ( lowmem precompute-ecmult )
 	schnorr? ( experimental extrakeys )
 	test-openssl? ( test )
 "
@@ -63,8 +62,7 @@ src_configure() {
 		--with-bignum=$(usex gmp gmp no) \
 		$(use_enable recovery module-recovery) \
 		$(use_enable schnorr module-schnorrsig) \
-		$(usex lowmem '--with-ecmult-window=2 --with-ecmult-gen-precision=2' '') \
-		$(usex precompute-ecmult '--with-ecmult-window=24 --with-ecmult-gen-precision=8' '') \
+		$(usex lowmem '--with-ecmult-window=4 --with-ecmult-gen-precision=2' '') \
 		$(use_with valgrind) \
 		--disable-static
 }

--- a/dev-libs/libsecp256k1/libsecp256k1-0.2.0-r1.ebuild
+++ b/dev-libs/libsecp256k1/libsecp256k1-0.2.0-r1.ebuild
@@ -5,37 +5,29 @@ EAPI=8
 
 inherit autotools
 
-MY_PN=${PN##lib}
-
+MyPN=secp256k1
 DESCRIPTION="Optimized C library for EC operations on curve secp256k1"
 HOMEPAGE="https://github.com/bitcoin-core/secp256k1"
-if [[ ${PV} == *_p* ]] ; then
-	MY_COMMIT="3967d96bf184519eb98b766af665b4d4b072563e"
-	SRC_URI="https://github.com/bitcoin-core/${MyPN}/archive/${COMMITHASH}.tar.gz -> ${P}.tar.gz"
-	S="${WORKDIR}"/${MY_PN}-${MY_COMMIT}
-else
-	SRC_URI="https://github.com/bitcoin-core/secp256k1/archive/refs/tags/v${PV}.tar.gz -> ${P}.tar.gz"
-	S="${WORKDIR}"/${MY_PN}-${PV}
-fi
+SRC_URI="https://github.com/bitcoin-core/secp256k1/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="MIT"
-SLOT="0/1"
+SLOT="0/1"  # subslot is "$((_LIB_VERSION_CURRENT-_LIB_VERSION_AGE))" from configure.ac
 KEYWORDS="~amd64 ~arm ~arm64 ~mips ~ppc ~ppc64 ~x86 ~amd64-linux ~x86-linux"
 IUSE="+asm ecdh experimental +extrakeys lowmem precompute-ecmult +schnorr +recovery test valgrind"
 RESTRICT="!test? ( test )"
+
 REQUIRED_USE="
 	?? ( lowmem precompute-ecmult )
-	asm? (
-		|| ( amd64 arm )
-	)
+	asm? ( || ( amd64 arm ) arm? ( experimental ) )
 	schnorr? ( extrakeys )
 "
-
 BDEPEND="
 	virtual/pkgconfig
 	test? ( dev-libs/openssl )
 	valgrind? ( dev-util/valgrind )
 "
+
+S="${WORKDIR}/${MyPN}-${PV}"
 
 src_prepare() {
 	default
@@ -46,37 +38,33 @@ src_prepare() {
 }
 
 src_configure() {
-	local asm_opt
-	if use asm; then
-		if use arm; then
-			asm_opt=arm
-		else
-			asm_opt=auto
-		fi
-	else
-		asm_opt=no
-	fi
-
 	local myeconfargs=(
 		--disable-benchmark
 		$(use_enable experimental)
 		$(use_enable test tests)
 		$(use_enable test exhaustive-tests)
-		$(use_enable ecdh module-ecdh)
-		$(use_enable extrakeys module-extrakeys)
-		--with-asm=${asm_opt}
-		$(use_enable recovery module-recovery)
+		$(use_enable {,module-}ecdh)
+		$(use_enable {,module-}extrakeys)
+		$(use_enable {,module-}recovery)
 		$(use_enable schnorr module-schnorrsig)
 		$(usev lowmem '--with-ecmult-window=2 --with-ecmult-gen-precision=2')
 		$(usev precompute-ecmult '--with-ecmult-window=24 --with-ecmult-gen-precision=8')
 		$(use_with valgrind)
 	)
+	if use asm; then
+		if use arm; then
+			myeconfargs+=( --with-asm=arm )
+		else
+			myeconfargs+=( --with-asm=auto )
+		fi
+	else
+		myeconfargs+=( --with-asm=no )
+	fi
 
 	econf "${myeconfargs[@]}"
 }
 
 src_install() {
 	default
-
 	find "${ED}" -name '*.la' -delete || die
 }

--- a/dev-libs/libsecp256k1/libsecp256k1-0.2.0-r1.ebuild
+++ b/dev-libs/libsecp256k1/libsecp256k1-0.2.0-r1.ebuild
@@ -13,7 +13,7 @@ SRC_URI="https://github.com/bitcoin-core/secp256k1/archive/v${PV}.tar.gz -> ${P}
 LICENSE="MIT"
 SLOT="0/1"  # subslot is "$((_LIB_VERSION_CURRENT-_LIB_VERSION_AGE))" from configure.ac
 KEYWORDS="~amd64 ~arm ~arm64 ~mips ~ppc ~ppc64 ~x86 ~amd64-linux ~x86-linux"
-IUSE="+asm ecdh experimental +extrakeys lowmem precompute-ecmult +schnorr +recovery test valgrind"
+IUSE="+asm +ecdh experimental +extrakeys lowmem precompute-ecmult +schnorr +recovery test valgrind"
 RESTRICT="!test? ( test )"
 
 REQUIRED_USE="

--- a/dev-libs/libsecp256k1/libsecp256k1-0.2.0-r1.ebuild
+++ b/dev-libs/libsecp256k1/libsecp256k1-0.2.0-r1.ebuild
@@ -23,7 +23,6 @@ REQUIRED_USE="
 "
 BDEPEND="
 	virtual/pkgconfig
-	test? ( dev-libs/openssl )
 	valgrind? ( dev-util/valgrind )
 "
 

--- a/dev-libs/libsecp256k1/libsecp256k1-0.2.0-r2.ebuild
+++ b/dev-libs/libsecp256k1/libsecp256k1-0.2.0-r2.ebuild
@@ -13,11 +13,10 @@ SRC_URI="https://github.com/bitcoin-core/secp256k1/archive/v${PV}.tar.gz -> ${P}
 LICENSE="MIT"
 SLOT="0/1"  # subslot is "$((_LIB_VERSION_CURRENT-_LIB_VERSION_AGE))" from configure.ac
 KEYWORDS="~amd64 ~arm ~arm64 ~mips ~ppc ~ppc64 ~x86 ~amd64-linux ~x86-linux"
-IUSE="+asm +ecdh experimental +extrakeys lowmem precompute-ecmult +schnorr +recovery test valgrind"
+IUSE="+asm +ecdh experimental +extrakeys lowmem +recovery +schnorr test valgrind"
 RESTRICT="!test? ( test )"
 
 REQUIRED_USE="
-	?? ( lowmem precompute-ecmult )
 	asm? ( || ( amd64 arm ) arm? ( experimental ) )
 	schnorr? ( extrakeys )
 "
@@ -46,8 +45,7 @@ src_configure() {
 		$(use_enable {,module-}extrakeys)
 		$(use_enable {,module-}recovery)
 		$(use_enable schnorr module-schnorrsig)
-		$(usev lowmem '--with-ecmult-window=2 --with-ecmult-gen-precision=2')
-		$(usev precompute-ecmult '--with-ecmult-window=24 --with-ecmult-gen-precision=8')
+		$(usev lowmem '--with-ecmult-window=4 --with-ecmult-gen-precision=2')
 		$(use_with valgrind)
 	)
 	if use asm; then

--- a/dev-libs/libsecp256k1/libsecp256k1-0.2.0-r2.ebuild
+++ b/dev-libs/libsecp256k1/libsecp256k1-0.2.0-r2.ebuild
@@ -21,9 +21,14 @@ REQUIRED_USE="
 	schnorr? ( extrakeys )
 "
 BDEPEND="
+	sys-devel/autoconf-archive
 	virtual/pkgconfig
 	valgrind? ( dev-util/valgrind )
 "
+
+PATCHES=(
+	"${FILESDIR}/0.2.0-fix-cross-compile.patch"
+)
 
 S="${WORKDIR}/${MyPN}-${PV}"
 

--- a/dev-libs/libsecp256k1/metadata.xml
+++ b/dev-libs/libsecp256k1/metadata.xml
@@ -15,8 +15,7 @@
     <flag name="endomorphism">Enable endomorphism</flag>
     <flag name="experimental">Allow experimental USE flags</flag>
     <flag name="extrakeys">Enable extrakeys module</flag>
-    <flag name="lowmem">Reduce runtime memory usage at the expense of performance (ecmult window size 2, gen precision 2)</flag>
-    <flag name="precompute-ecmult">Use over 512 MB memory at runtime for better performance (ecmult window size 24, gen precision 8)</flag>
+    <flag name="lowmem">Reduce runtime memory usage at the expense of performance (ecmult window size 4, gen precision 2)</flag>
     <flag name="recovery">Enable ECDSA pubkey recovery module</flag>
     <flag name="schnorr">Enable Schnorr signature module</flag>
     <flag name="test-openssl">Enable OpenSSL comparison tests</flag>


### PR DESCRIPTION
This is a request to incorporate various fixes and enhancements from the `dev-libs/libsecp256k1-0.2.0` ebuild in the [`bitcoin-gentoo`](https://gitlab.com/bitcoin/gentoo) repo into the main repo.

* ~~Implements `USE="static-libs"`.~~
* Drops build-time dependency on `dev-libs/openssl`, as it [has not](https://github.com/bitcoin-core/secp256k1/commit/bc08599e776aff33c834ef829843ec5f629d1f39) been used in a long time.
* Enables `USE="ecdh"` by default since upstream now [enables](https://github.com/bitcoin-core/secp256k1/commit/2286f8090242098a33f0d85b27c48e58d4235df1) it by default.
* Drops `USE="precompute-ecmult"` as [recommended](https://github.com/bitcoin-core/secp256k1/pull/1159#issuecomment-1323523530) by upstream.
* [Fixes](https://github.com/bitcoin-core/secp256k1/pull/1159) cross-compilation due to build-time source-code generator not being built with the build-system toolchain.
* ~~Implements multilib build.~~

If/when this PR is merged, then `bitcoin-gentoo` can drop its local copy of the ebuild and defer to the main tree. Please and thank you.

@thesamesam