### PR TITLE
app-crypt/adcli: switch DEPEND from net-nds/openldap:= to net-nds/openldap

### DIFF
--- a/app-crypt/adcli/adcli-0.9.2-r1.ebuild
+++ b/app-crypt/adcli/adcli-0.9.2-r1.ebuild
@@ -16,7 +16,7 @@ IUSE="doc"
 
 DEPEND="
 	app-crypt/mit-krb5
-	net-nds/openldap:=[sasl]"
+	net-nds/openldap[sasl]"
 RDEPEND="${DEPEND}"
 BDEPEND="
 	doc? (


### PR DESCRIPTION
$ qa-vdb app-crypt/adcli
VDB: detected possibly incorrect RDEPEND (app-crypt/adcli-0.9.2)
net-nds/openldap:= | net-nds/openldap

Signed-off-by: Henning Schild <henning@hennsch.de>