### PR TITLE
dev-lang/haxe: Build haxe without stripping debugging symbols

### DIFF
--- a/dev-lang/haxe/haxe-4.2.5.ebuild
+++ b/dev-lang/haxe/haxe-4.2.5.ebuild
@@ -20,7 +20,7 @@ fi
 LICENSE="GPL-2+ MIT"
 SLOT="0/${PV}"
 IUSE="+ocamlopt"
-
+RESTRICT="strip"
 # NOTICE:
 # Theoretically luv <= 0.5.8 is pinned but it is because of mingw issues
 RDEPEND="


### PR DESCRIPTION
Signed-off-by: MagelessMayhem <107271276+MagelessMayhem@users.noreply.github.com>