### PR TITLE
profiles/arch/powerpc/ppc64: mask openmw and unmask on le

### DIFF
--- a/profiles/arch/powerpc/ppc64/64le/package.mask
+++ b/profiles/arch/powerpc/ppc64/64le/package.mask
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # Michał Górny <mgorny@gentoo.org> (2022-08-25)
@@ -16,7 +16,9 @@
 # Broken on big endian, but should be fine on le.
 # bug #818424
 -dev-games/openscenegraph
+-dev-games/openscenegraph-openmw
 -dev-games/openscenegraph-qt
+-games-engines/openmw
 -media-libs/openexr
 -media-libs/ctl
 -media-gfx/openvdb

--- a/profiles/arch/powerpc/ppc64/package.mask
+++ b/profiles/arch/powerpc/ppc64/package.mask
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # Sam James <sam@gentoo.org> (2022-10-08)
@@ -19,7 +19,9 @@ dev-lisp/sbcl
 # Broken on big endian.
 # bug #818424
 dev-games/openscenegraph
+dev-games/openscenegraph-openmw
 dev-games/openscenegraph-qt
+games-engines/openmw
 media-libs/openexr
 media-libs/ctl
 media-gfx/openvdb


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/889996
Signed-off-by: Alexey Sokolov <alexey+gentoo@asokolov.org>