### PR TITLE
dev-lang/zig: add patch from upstream for 0.10.0

### DIFF
--- a/dev-lang/zig/files/zig-0.10.0-avoid-cmake-bug.patch
+++ b/dev-lang/zig/files/zig-0.10.0-avoid-cmake-bug.patch
@@ -1,0 +1,63 @@
+https://github.com/ziglang/zig/commit/fe2bd9dda8467b775da4fe3bd535aece9e07ee1b
+Bug https://bugs.gentoo.org/886569
+
+From fe2bd9dda8467b775da4fe3bd535aece9e07ee1b Mon Sep 17 00:00:00 2001
+From: Eric Joldasov <bratishkaerik@getgoogleoff.me>
+Date: Wed, 4 Jan 2023 01:04:48 +0600
+Subject: [PATCH] cmake: move 'continue' statement to avoid cmake bug
+
+---
+ cmake/Findllvm.cmake | 32 +++++++++++---------------------
+ 1 file changed, 11 insertions(+), 21 deletions(-)
+
+diff --git a/cmake/Findllvm.cmake b/cmake/Findllvm.cmake
+index 60a52056d8d..d8662034579 100644
+--- a/cmake/Findllvm.cmake
++++ b/cmake/Findllvm.cmake
+@@ -79,7 +79,11 @@ if(ZIG_USE_LLVM_CONFIG)
+         OUTPUT_VARIABLE LLVM_TARGETS_BUILT_SPACES
+       OUTPUT_STRIP_TRAILING_WHITESPACE)
+     string(REPLACE " " ";" LLVM_TARGETS_BUILT "${LLVM_TARGETS_BUILT_SPACES}")
+-    function(NEED_TARGET TARGET_NAME)
++
++    set(ZIG_LLVM_REQUIRED_TARGETS "AArch64;AMDGPU;ARM;AVR;BPF;Hexagon;Lanai;Mips;MSP430;NVPTX;PowerPC;RISCV;Sparc;SystemZ;VE;WebAssembly;X86;XCore")
++
++    set(ZIG_LLVM_REQUIRED_TARGETS_ENABLED TRUE)
++    foreach(TARGET_NAME IN LISTS ZIG_LLVM_REQUIRED_TARGETS)
+       list (FIND LLVM_TARGETS_BUILT "${TARGET_NAME}" _index)
+       if (${_index} EQUAL -1)
+         # Save the error message, in case this is the last llvm-config we find
+@@ -87,27 +91,13 @@ if(ZIG_USE_LLVM_CONFIG)
+ 
+         # Ignore this directory and try the search again
+         list(APPEND CMAKE_IGNORE_PATH "${LLVM_CONFIG_DIR}")
+-        continue()
++        set(ZIG_LLVM_REQUIRED_TARGETS_ENABLED FALSE)
++        break()
+       endif()
+-    endfunction(NEED_TARGET)
+-    NEED_TARGET("AArch64")
+-    NEED_TARGET("AMDGPU")
+-    NEED_TARGET("ARM")
+-    NEED_TARGET("AVR")
+-    NEED_TARGET("BPF")
+-    NEED_TARGET("Hexagon")
+-    NEED_TARGET("Lanai")
+-    NEED_TARGET("Mips")
+-    NEED_TARGET("MSP430")
+-    NEED_TARGET("NVPTX")
+-    NEED_TARGET("PowerPC")
+-    NEED_TARGET("RISCV")
+-    NEED_TARGET("Sparc")
+-    NEED_TARGET("SystemZ")
+-    NEED_TARGET("VE")
+-    NEED_TARGET("WebAssembly")
+-    NEED_TARGET("X86")
+-    NEED_TARGET("XCore")
++    endforeach()
++    if (NOT ZIG_LLVM_REQUIRED_TARGETS_ENABLED)
++      continue()
++    endif()
+ 
+     # Got it!
+     break()

--- a/dev-lang/zig/zig-0.10.0.ebuild
+++ b/dev-lang/zig/zig-0.10.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2019-2022 Gentoo Authors
+# Copyright 2019-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -46,6 +46,10 @@ QA_FLAGS_IGNORED="usr/bin/zig"
 # 0.11.0 release - ~2.8 GiB, since we will (at least according to roadmap) use self-hosted compiler
 # (transpiled to C via C backend) for bootstrapping
 CHECKREQS_MEMORY="10G"
+
+PATCHES=(
+	"${FILESDIR}/${P}-avoid-cmake-bug.patch"
+)
 
 llvm_check_deps() {
 	has_version "sys-devel/clang:${LLVM_SLOT}"


### PR DESCRIPTION
IIUC it doesn't require revision bump:

>Examples of changes that can be done without a revision bump are:
> * adding a patch to fix a build-time issue that prevented users from building the package (since it does not affect users who already managed to build it) unless: it affected runtime behaviour in some way (e.g. `-Wformat` or `-Wimplicit-function-declaration` fixes); the package may have been miscompiled, or the change is substantial (if adding a huge patch to fix a problem, the chances of an unexpected issue being introduced by it are greater). 

Closes: https://bugs.gentoo.org/886569
Signed-off-by: Eric Joldasov <bratishkaerik@getgoogleoff.me>