### PR TITLE
sys-libs/glibc: Fix automagic Perl dependency that breaks Prefix QA checks

### DIFF
--- a/sys-libs/glibc/glibc-2.36-r6.ebuild
+++ b/sys-libs/glibc/glibc-2.36-r6.ebuild
@@ -43,7 +43,7 @@ SRC_URI+=" https://gitweb.gentoo.org/proj/locale-gen.git/snapshot/locale-gen-${L
 SRC_URI+=" multilib-bootstrap? ( https://dev.gentoo.org/~dilfridge/distfiles/gcc-multilib-bootstrap-${GCC_BOOTSTRAP_VER}.tar.xz )"
 SRC_URI+=" systemd? ( https://gitweb.gentoo.org/proj/toolchain/glibc-systemd.git/snapshot/glibc-systemd-${GLIBC_SYSTEMD_VER}.tar.gz )"
 
-IUSE="audit caps cet compile-locales +crypt custom-cflags doc gd hash-sysv-compat headers-only +multiarch multilib multilib-bootstrap nscd profile selinux +ssp stack-realign +static-libs suid systemd systemtap test vanilla"
+IUSE="audit caps cet compile-locales +crypt custom-cflags doc gd hash-sysv-compat headers-only +multiarch multilib multilib-bootstrap nscd perl profile selinux +ssp stack-realign +static-libs suid systemd systemtap test vanilla"
 
 # Minimum kernel version that glibc requires
 MIN_KERN_VER="3.2.0"
@@ -118,6 +118,7 @@ COMMON_DEPEND="
 		audit? ( sys-process/audit )
 		caps? ( sys-libs/libcap )
 	) )
+	perl? ( dev-lang/perl )
 	suid? ( caps? ( sys-libs/libcap ) )
 	selinux? ( sys-libs/libselinux )
 	systemtap? ( dev-util/systemtap )
@@ -1008,6 +1009,13 @@ glibc_do_configure() {
 		$(use_multiarch || echo --disable-multi-arch)
 		$(use_enable systemtap)
 		$(use_enable nscd)
+
+		# /usr/bin/mtrace has a Perl shebang. Gentoo Prefix QA checks fail if
+		# Perl hasn't been installed inside the prefix yet and configure picks
+		# up a Perl from outside the prefix instead. configure will fail to
+		# execute Perl during configure if we're cross-compiling a prefix, but
+		# it will just disable mtrace in that case.
+		ac_cv_path_PERL="$(usex perl "${EPREFIX}"/usr/bin/perl no)"
 
 		# locale data is arch-independent
 		# https://bugs.gentoo.org/753740

--- a/sys-libs/glibc/glibc-9999.ebuild
+++ b/sys-libs/glibc/glibc-9999.ebuild
@@ -43,7 +43,7 @@ SRC_URI+=" https://gitweb.gentoo.org/proj/locale-gen.git/snapshot/locale-gen-${L
 SRC_URI+=" multilib-bootstrap? ( https://dev.gentoo.org/~dilfridge/distfiles/gcc-multilib-bootstrap-${GCC_BOOTSTRAP_VER}.tar.xz )"
 SRC_URI+=" systemd? ( https://gitweb.gentoo.org/proj/toolchain/glibc-systemd.git/snapshot/glibc-systemd-${GLIBC_SYSTEMD_VER}.tar.gz )"
 
-IUSE="audit caps cet compile-locales +crypt custom-cflags doc gd hash-sysv-compat headers-only +multiarch multilib multilib-bootstrap nscd profile selinux +ssp stack-realign +static-libs suid systemd systemtap test vanilla"
+IUSE="audit caps cet compile-locales +crypt custom-cflags doc gd hash-sysv-compat headers-only +multiarch multilib multilib-bootstrap nscd perl profile selinux +ssp stack-realign +static-libs suid systemd systemtap test vanilla"
 
 # Minimum kernel version that glibc requires
 MIN_KERN_VER="3.2.0"
@@ -118,6 +118,7 @@ COMMON_DEPEND="
 		audit? ( sys-process/audit )
 		caps? ( sys-libs/libcap )
 	) )
+	perl? ( dev-lang/perl )
 	suid? ( caps? ( sys-libs/libcap ) )
 	selinux? ( sys-libs/libselinux )
 	systemtap? ( dev-util/systemtap )
@@ -1008,6 +1009,13 @@ glibc_do_configure() {
 		$(use_multiarch || echo --disable-multi-arch)
 		$(use_enable systemtap)
 		$(use_enable nscd)
+
+		# /usr/bin/mtrace has a Perl shebang. Gentoo Prefix QA checks fail if
+		# Perl hasn't been installed inside the prefix yet and configure picks
+		# up a Perl from outside the prefix instead. configure will fail to
+		# execute Perl during configure if we're cross-compiling a prefix, but
+		# it will just disable mtrace in that case.
+		ac_cv_path_PERL="$(usex perl "${EPREFIX}"/usr/bin/perl no)"
 
 		# locale data is arch-independent
 		# https://bugs.gentoo.org/753740

--- a/sys-libs/glibc/metadata.xml
+++ b/sys-libs/glibc/metadata.xml
@@ -17,6 +17,7 @@
 		<flag name="multiarch">enable optimizations for multiple CPU architectures (detected at runtime)</flag>
 		<flag name="multilib-bootstrap">Provide prebuilt libgcc.a and crt files if missing. Only needed for ABI switch.</flag>
 		<flag name="nscd">Build, and enable support for, the Name Service Cache Daemon</flag>
+		<flag name="perl">Install additional scripts written in Perl</flag>
 		<flag name="ssp">protect stack of glibc internals</flag>
 		<flag name="stack-realign">Realign the stack in the 32-bit build for compatibility with older binaries at some performance cost</flag>
 		<flag name="static-pie">Enable static PIE support (runtime files for -static-pie gcc option).</flag>


### PR DESCRIPTION
/usr/bin/mtrace has a Perl shebang. Gentoo Prefix QA checks fail if Perl hasn't been installed inside the prefix yet and configure picks up a Perl from outside the prefix instead. With this change, configure will fail to execute Perl during configure if we're cross-compiling a prefix, but it will just disable mtrace in that case.

Signed-off-by: James Le Cuirot <chewi@gentoo.org>