### PR TITLE
dev-lang/nim: enable tests

### DIFF
--- a/dev-lang/nim/files/nim-1.6.10-testament-skipfile.txt
+++ b/dev-lang/nim/files/nim-1.6.10-testament-skipfile.txt
@@ -1,0 +1,40 @@
+# broken
+tests/assert/tassert_c.nim
+tests/async/tasync_traceback.nim
+tests/errmsgs/tcall_with_default_arg.nim
+tests/errmsgs/tproper_stacktrace.nim
+tests/errmsgs/tproper_stacktrace2.nim
+tests/errmsgs/tproper_stacktrace3.nim
+tests/js/tmangle.nim
+tests/js/twritestacktrace.nim
+tests/lent/tbasic_lent_check.nim
+tests/misc/trunner.nim
+tests/misc/tstrace.nim
+tests/pragmas/thintprocessing.nim
+tests/pragmas/tused.nim
+tests/pragmas/twarning_off.nim
+tests/stdlib/tos.nim
+tests/stdlib/tstackframes.nim
+tests/stdlib/tstats.nim
+tests/system/talloc.nim
+tests/testament/tshould_not_work.nim
+# require network
+tests/stdlib/thttpclient.nim
+tests/stdlib/tnetconnect.nim
+tests/stdlib/tssl.nim
+# don't work without megatest
+tests/misc/tjoinable.nim
+tests/testament/tjoinable.nim
+# don't work with "--hint:all:off" hack
+tests/concepts/t3330.nim
+tests/stylecheck/t20397_2.nim
+tests/stylecheck/treject.nim
+tests/stylecheck/tusages.nim
+# need external dependencies
+tests/manyloc/keineschweine/keineschweine.nim
+tests/manyloc/nake/nakefile.nim
+tests/niminaction/Chapter7/Tweeter/src/tweeter.nim
+# need functional valgrind
+tests/destructor/tnewruntime_strutils.nim
+tests/destructor/tv2_raise.nim
+tests/views/tsplit_into_openarray.nim

--- a/dev-lang/nim/metadata.xml
+++ b/dev-lang/nim/metadata.xml
@@ -38,5 +38,6 @@
   </upstream>
   <use>
     <flag name="experimental">Apply experimental patches</flag>
+    <flag name="test-js">Enable tests that require Node.js</flag>
   </use>
 </pkgmetadata>

--- a/profiles/arch/amd64/x32/package.use.mask
+++ b/profiles/arch/amd64/x32/package.use.mask
@@ -41,6 +41,7 @@ www-servers/uwsgi uwsgi_plugins_rados
 
 # Michał Górny <mgorny@gentoo.org> (2018-01-12)
 # Those packages require net-libs/nodejs.
+dev-lang/nim test-js
 dev-python/nbdime webtools
 dev-ruby/ammeter test
 dev-ruby/jsobfu test


### PR DESCRIPTION
Some categories are skipped:
* `arc`, `valgrind`: need function valgrind
* `ic`: random failures