### PR TITLE
games-strategy/ja2-stracciatella: fix compile error

### DIFF
--- a/games-strategy/ja2-stracciatella/ja2-stracciatella-0.20.0.ebuild
+++ b/games-strategy/ja2-stracciatella/ja2-stracciatella-0.20.0.ebuild
@@ -149,6 +149,7 @@ REQUIRED_USE="${LUA_REQUIRED_USE}"
 
 DEPEND="
 	${LUA_DEPS}
+	>=dev-cpp/magic_enum-0.8.2
 	>=dev-cpp/sol2-3.3.0
 	>=dev-cpp/string-theory-3.1
 	>=dev-games/libsmacker-1.1.1


### PR DESCRIPTION
by adding magic-enum dependency.

Signed-off-by: Richard Fröhning <misanthropos@gmx.de>