### PR TITLE
python-utils-r1.eclass: restore support for jython2_7 in python_optimize

### DIFF
--- a/eclass/python-utils-r1.eclass
+++ b/eclass/python-utils-r1.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: python-utils-r1.eclass
@@ -633,7 +633,7 @@ python_optimize() {
 				# Python 3.9+
 				"${PYTHON}" -m compileall -j "${jobs}" -o 0 -o 1 -o 2 --hardlink-dupes -q -f -d "${instpath}" "${d}"
 				;;
-			pypy)
+			pypy|jython2.7)
 				"${PYTHON}" -m compileall -q -f -d "${instpath}" "${d}"
 				;;
 			*)


### PR DESCRIPTION
The eclass was modified to drop support for Python 2.7, however as unintended side effect, support for Jython 2.7 was also removed in python_optimize().

Fixes: 3b11f851df5e ("python-utils-r1.eclass: Clean up post disabling python2_7 compat")
Closes: https://bugs.gentoo.org/885971
Signed-off-by: Florian Schmaus <flow@gentoo.org>