### PR TITLE
sys-auth/pambase: bump python compat to python-3.11

### DIFF
--- a/sys-auth/pambase/pambase-20220214.ebuild
+++ b/sys-auth/pambase/pambase-20220214.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{9..10} )
+PYTHON_COMPAT=( python3_{9..11} )
 
 inherit pam python-any-r1 readme.gentoo-r1
 

--- a/sys-auth/pambase/pambase-999999999.ebuild
+++ b/sys-auth/pambase/pambase-999999999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{9..10} )
+PYTHON_COMPAT=( python3_{9..11} )
 
 inherit pam python-any-r1 readme.gentoo-r1
 


### PR DESCRIPTION
Hello!
This is the last dependency that keeps python-3.10 installed. After this is merged py-3.10 isn't required anymore in my install and can be dep-cleaned.

It is working for me. I hope this didn't brake anything, it seems pretty safe :)