### PR TITLE
media-libs/libnsgif: close https://bugs.gentoo.org/718594

### DIFF
--- a/eclass/netsurf.eclass
+++ b/eclass/netsurf.eclass
@@ -1,16 +1,16 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: netsurf.eclass
 # @MAINTAINER:
 # maintainer-needed@gentoo.org
-# @SUPPORTED_EAPIS: 7
+# @SUPPORTED_EAPIS: 7 8
 # @BLURB: Handle buildsystem of www.netsurf-browser.org components
 # @DESCRIPTION:
 # Handle settings build environment for netsurf build system
 
 case "${EAPI:-0}" in
-    7) ;;
+    7|8) ;;
     *) die "EAPI=${EAPI} is not supported" ;;
 esac
 
@@ -26,6 +26,7 @@ netsurf_define_makeconf() {
 		NSSHARED="${EPREFIX}/usr/share/netsurf-buildsystem"
 		LIBDIR="$(get_libdir)"
 		Q=
+		AR="$(tc-getAR)"
 		CC="$(tc-getCC)"
 		LD="$(tc-getLD)"
 		HOST_CC="\$(CC)"
@@ -36,7 +37,6 @@ netsurf_define_makeconf() {
 		CCNOOPT=
 		CCDBG=
 		LDDBG=
-		AR="$(tc-getAR)"
 		WARNFLAGS=
 	)
 }

--- a/media-libs/libnsgif/libnsgif-0.2.1-r4.ebuild
+++ b/media-libs/libnsgif/libnsgif-0.2.1-r4.ebuild
@@ -1,0 +1,39 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit netsurf
+
+DESCRIPTION="decoding library for the GIF image file format, written in C"
+HOMEPAGE="https://www.netsurf-browser.org/projects/libnsgif/"
+SRC_URI="https://download.netsurf-browser.org/libs/releases/${P}-src.tar.gz"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~ppc ~ppc64 ~riscv ~x86"
+IUSE=""
+
+BDEPEND="
+	>=dev-util/netsurf-buildsystem-1.7-r1
+	virtual/pkgconfig
+"
+
+src_prepare() {
+	default
+	sed -e '1i#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"' \
+		-i src/lzw.c || die
+}
+
+_emake() {
+	netsurf_define_makeconf
+	emake "${NETSURF_MAKECONF[@]}" COMPONENT_TYPE=lib-shared $@
+}
+
+src_compile() {
+	_emake
+}
+
+src_install() {
+	_emake DESTDIR="${D}" install
+}


### PR DESCRIPTION
media-libs/libnsgif call cc directly, let fix it.
Closes: https://bugs.gentoo.org/718594

Signed-off-by: Marco Scardovi <mscardovi@icloud.com>