### PR TITLE
dev-lang/zig: use correct binary for testing 0.10.0

### DIFF
--- a/dev-lang/zig/files/zig-0.10.0-build-dir-install-stage3.patch
+++ b/dev-lang/zig/files/zig-0.10.0-build-dir-install-stage3.patch
@@ -1,0 +1,28 @@
+From: Eric Joldasov <bratishkaerik@getgoogleoff.me>
+
+Install 'zig' binary in 'build_dir/stage3' directory so that we can find it and use for testing.
+Upstream PR https://github.com/ziglang/zig/pull/14255.
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1094,7 +1094,7 @@ set(ZIG_BUILD_ARGS
+ )
+ 
+ add_custom_target(stage3 ALL
+-    COMMAND zig2 build compile ${ZIG_BUILD_ARGS}
++    COMMAND zig2 build --prefix "${CMAKE_BINARY_DIR}/stage3" ${ZIG_BUILD_ARGS}
+     DEPENDS zig2
+     COMMENT STATUS "Building stage3"
+     WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+--- a/build.zig
++++ b/build.zig
+@@ -148,10 +148,6 @@ pub fn build(b: *Builder) !void {
+     };
+ 
+     const exe = b.addExecutable("zig", main_file);
+-
+-    const compile_step = b.step("compile", "Build the self-hosted compiler");
+-    compile_step.dependOn(&exe.step);
+-
+     exe.stack_size = stack_size;
+     exe.strip = strip;
+     exe.sanitize_thread = sanitize_thread;

--- a/dev-lang/zig/zig-0.10.0.ebuild
+++ b/dev-lang/zig/zig-0.10.0.ebuild
@@ -49,6 +49,7 @@ CHECKREQS_MEMORY="10G"
 
 PATCHES=(
 	"${FILESDIR}/${P}-avoid-cmake-bug.patch"
+	"${FILESDIR}/${P}-build-dir-install-stage3.patch"
 )
 
 llvm_check_deps() {
@@ -75,7 +76,22 @@ src_configure() {
 
 src_test() {
 	cd "${BUILD_DIR}" || die
-	./zig2 build test -Dstatic-llvm=false -Denable-llvm=true -Dskip-non-native=true || die
+	local ZIG_TESTARGS=("-Dstatic-llvm=false -Denable-llvm=true -Dskip-non-native=true -Drelease -Dtarget=native")
+	./stage3/bin/zig build test-cases ${ZIG_TESTARGS[@]} || die
+	./stage3/bin/zig build test-fmt ${ZIG_TESTARGS[@]} || die
+	./stage3/bin/zig build test-behavior ${ZIG_TESTARGS[@]} || die
+	./stage3/bin/zig build test-compiler-rt ${ZIG_TESTARGS[@]} || die
+	./stage3/bin/zig build test-universal-libc ${ZIG_TESTARGS[@]} || die
+	./stage3/bin/zig build test-compare-output ${ZIG_TESTARGS[@]} || die
+	./stage3/bin/zig build test-standalone ${ZIG_TESTARGS[@]} || die
+	./stage3/bin/zig build test-c-abi ${ZIG_TESTARGS[@]} || die
+	./stage3/bin/zig build test-link ${ZIG_TESTARGS[@]} || die
+	./stage3/bin/zig build test-stack-traces ${ZIG_TESTARGS[@]} || die
+	./stage3/bin/zig build test-cli ${ZIG_TESTARGS[@]} || die
+	./stage3/bin/zig build test-asm-link ${ZIG_TESTARGS[@]} || die
+	./stage3/bin/zig build test-translate-c ${ZIG_TESTARGS[@]} || die
+	./stage3/bin/zig build test-run-translated-c ${ZIG_TESTARGS[@]} || die
+	./stage3/bin/zig build test-std ${ZIG_TESTARGS[@]} || die
 }
 
 pkg_postinst() {


### PR DESCRIPTION
According to upstream [1], 'stage3' binary should be used for testing instead of 'stage2'. Thanks to Frederik Schwan and Sam James for pointing this out! Also split tests so than we can know more accurately what test step failed.

[1] https://www.github.com/ziglang/zig/issues/14240#issuecomment-1374634325

Signed-off-by: Eric Joldasov <bratishkaerik@getgoogleoff.me>