### PR TITLE
Update musescore-9999.ebuild

### DIFF
--- a/media-sound/musescore/musescore-9999.ebuild
+++ b/media-sound/musescore/musescore-9999.ebuild
@@ -43,6 +43,7 @@ DEPEND="
 	dev-qt/qtnetworkauth:5
 	dev-qt/qtopengl:5
 	dev-qt/qtprintsupport:5
+	dev-qt/qtquickcontrols:5
 	dev-qt/qtquickcontrols2:5
 	>=dev-qt/qtsingleapplication-2.6.1_p20171024[X]
 	dev-qt/qtsvg:5


### PR DESCRIPTION
Add dependency on 'dev-qt/qtquickcontrols:5' as needs 'QtQuick.Dialogs'.


Signed-off-by: tepidjuice <tamemeese@gmail.com>