### PR TITLE
app-arch/upx: add 4.0.1-r1, security fixes

### DIFF
--- a/app-arch/upx/files/upx-4.0.1-CVE-2023-23456.patch
+++ b/app-arch/upx/files/upx-4.0.1-CVE-2023-23456.patch
@@ -1,0 +1,61 @@
+From 1d291ff0db8a056600ebdebb9c3c62d700eaa842 Mon Sep 17 00:00:00 2001
+From: John Reiser <jreiser@BitWagon.com>
+Date: Thu, 24 Nov 2022 10:28:03 -0800
+Subject: [PATCH] p_tmt: more sanity of input, cleanup MemBuffer usage
+
+https://github.com/upx/upx/issues/632
+	modified:   src/p_tmt.cpp
+---
+ src/p_tmt.cpp | 23 +++++++++++------------
+ 1 file changed, 11 insertions(+), 12 deletions(-)
+
+diff --git a/src/p_tmt.cpp b/src/p_tmt.cpp
+index 7dc72888..592809a9 100644
+--- a/src/p_tmt.cpp
++++ b/src/p_tmt.cpp
+@@ -173,15 +173,13 @@ int PackTmt::readFileHeader()
+     fi->seek(adam_offset,SEEK_SET);
+     fi->readx(&ih,sizeof(ih));
+     // FIXME: should add more checks for the values in 'ih'
+-    unsigned const imagesize = get_le32(&ih.imagesize);
+-    unsigned const entry     = get_le32(&ih.entry);
+-    unsigned const relocsize = get_le32(&ih.relocsize);
+-    if (!imagesize
+-    ||  file_size <= imagesize
+-    ||  file_size <= entry
+-    ||  file_size <= relocsize) {
+-        printWarn(getName(), "bad header; imagesize=%#x  entry=%#x  relocsize=%#x",
+-            imagesize, entry, relocsize);
++    unsigned const imagesize = ih.imagesize;
++    unsigned const entry = ih.entry;
++    unsigned const relocsize = ih.relocsize;
++    if (imagesize < sizeof(ih) || entry < sizeof(ih) || file_size <= imagesize ||
++        file_size <= entry || file_size <= relocsize) {
++        printWarn(getName(), "bad header; imagesize=%#x  entry=%#x  relocsize=%#x", imagesize,
++                  entry, relocsize);
+         return 0;
+     }
+ 
+@@ -215,15 +213,16 @@ void PackTmt::pack(OutputFile *fo)
+     ibuf.alloc(usize+rsize+128);
+     obuf.allocForCompression(usize+rsize+128);
+ 
+-    MemBuffer wrkmem;
+-    wrkmem.alloc(rsize+EXTRA_INFO); // relocations
++    MemBuffer mb_wrkmem;
++    mb_wrkmem.alloc(rsize + EXTRA_INFO + 4); // relocations + original entry point + relocsize
++    SPAN_S_VAR(upx_byte, wrkmem, mb_wrkmem);
+ 
+     fi->seek(adam_offset+sizeof(ih),SEEK_SET);
+     fi->readx(ibuf,usize);
+     fi->readx(wrkmem+4,rsize);
+     const unsigned overlay = file_size - fi->tell();
+ 
+-    if (find_le32(ibuf,128,get_le32("UPX ")) >= 0)
++    if (find_le32(ibuf, UPX_MIN(128u, usize), get_le32("UPX ")) >= 0)
+         throwAlreadyPacked();
+     if (rsize == 0)
+         throwCantPack("file is already compressed with another packer");
+-- 
+2.38.2
+

--- a/app-arch/upx/files/upx-4.0.1-CVE-2023-23457.patch
+++ b/app-arch/upx/files/upx-4.0.1-CVE-2023-23457.patch
@@ -1,0 +1,45 @@
+From 779b648c5f6aa9b33f4728f79dd4d0efec0bf860 Mon Sep 17 00:00:00 2001
+From: John Reiser <jreiser@BitWagon.com>
+Date: Wed, 23 Nov 2022 19:49:28 -0800
+Subject: [PATCH] invert_pt_dynamic: fix thinko; PackLinuxElf64help1 insist on
+ ELF
+
+https://github.com/upx/upx/issues/631
+	modified:   src/p_lx_elf.cpp
+---
+ src/p_lx_elf.cpp | 8 +++++---
+ 1 file changed, 5 insertions(+), 3 deletions(-)
+
+diff --git a/src/p_lx_elf.cpp b/src/p_lx_elf.cpp
+index fa55470f7..b698ee0a2 100644
+--- a/src/p_lx_elf.cpp
++++ b/src/p_lx_elf.cpp
+@@ -256,7 +256,8 @@ PackLinuxElf32::PackLinuxElf32help1(InputFile *f)
+     e_phnum = get_te16(&ehdri.e_phnum);
+     e_shnum = get_te16(&ehdri.e_shnum);
+     unsigned const e_phentsize = get_te16(&ehdri.e_phentsize);
+-    if (ehdri.e_ident[Elf32_Ehdr::EI_CLASS]!=Elf32_Ehdr::ELFCLASS32
++    if (memcmp((char const *)&ehdri, "\x7f\x45\x4c\x46", 4)  // "\177ELF"
++    || ehdri.e_ident[Elf32_Ehdr::EI_CLASS]!=Elf32_Ehdr::ELFCLASS32
+     || sizeof(Elf32_Phdr) != e_phentsize
+     || (Elf32_Ehdr::ELFDATA2MSB == ehdri.e_ident[Elf32_Ehdr::EI_DATA]
+             && &N_BELE_RTP::be_policy != bele)
+@@ -761,7 +762,8 @@ PackLinuxElf64::PackLinuxElf64help1(InputFile *f)
+     e_phnum = get_te16(&ehdri.e_phnum);
+     e_shnum = get_te16(&ehdri.e_shnum);
+     unsigned const e_phentsize = get_te16(&ehdri.e_phentsize);
+-    if (ehdri.e_ident[Elf64_Ehdr::EI_CLASS]!=Elf64_Ehdr::ELFCLASS64
++    if (memcmp((char const *)&ehdri, "\x7f\x45\x4c\x46", 4)  // "\177ELF"
++    || ehdri.e_ident[Elf64_Ehdr::EI_CLASS]!=Elf64_Ehdr::ELFCLASS64
+     || sizeof(Elf64_Phdr) != e_phentsize
+     || (Elf64_Ehdr::ELFDATA2MSB == ehdri.e_ident[Elf64_Ehdr::EI_DATA]
+             && &N_BELE_RTP::be_policy != bele)
+@@ -5780,7 +5782,7 @@ PackLinuxElf64::invert_pt_dynamic(Elf64_Dyn const *dynp, upx_uint64_t headway)
+         }
+         if (file_size <= dt_offsets[n_off]) {
+             char msg[60]; snprintf(msg, sizeof(msg), "bad DT_{%#x} = %#x (beyond EOF)",
+-                dt_names[k], dt_offsets[n_off]);
++                k, dt_offsets[n_off]);
+                 throwCantPack(msg);
+         }
+         n_off += !!dt_offsets[n_off];

--- a/app-arch/upx/upx-4.0.1-r1.ebuild
+++ b/app-arch/upx/upx-4.0.1-r1.ebuild
@@ -1,0 +1,35 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit cmake
+
+DESCRIPTION="Ultimate Packer for eXecutables (free version using UCL compression and not NRV)"
+HOMEPAGE="https://upx.github.io/"
+SRC_URI="https://github.com/upx/upx/releases/download/v${PV}/${P}-src.tar.xz"
+S="${WORKDIR}/${P}-src"
+
+LICENSE="GPL-2+ UPX-exception" # Read the exception before applying any patches
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~sparc ~x86"
+
+RDEPEND="!app-arch/upx-bin"
+BDEPEND="app-arch/xz-utils[extra-filters]"
+
+PATCHES=(
+	"${FILESDIR}/${P}-CVE-2023-23456.patch"
+	"${FILESDIR}/${P}-CVE-2023-23457.patch"
+)
+
+src_configure() {
+	local mycmakeargs=(
+		-DUPX_CONFIG_DISABLE_WERROR=ON
+	)
+	cmake_src_configure
+}
+
+src_test() {
+	# Don't run tests in parallel, #878977
+	cmake_src_test -j1
+}


### PR DESCRIPTION
Fixes issues CVE-2023-23456 and CVE-2023-23457.

Bug: https://bugs.gentoo.org/890616
Signed-off-by: Azamat H. Hackimov <azamat.hackimov@gmail.com>