### PR TITLE
dev-util/bftool: fix build with clang+ssp

### DIFF
--- a/dev-util/bpftool/bpftool-5.19.12.ebuild
+++ b/dev-util/bpftool/bpftool-5.19.12.ebuild
@@ -92,6 +92,7 @@ src_prepare() {
 	# Used `git format-patch 00b32625982e0c796f0abb8effcac9c05ef55bd3...600b7b26c07a070d0153daa76b3806c1e52c9e00`
 	# bug #868123
 	eapply "${WORKDIR}"/perf-5.19-binutils-2.39-patches
+	eapply "${FILESDIR}"/${PV}-no-stack-protector.patch
 	popd || die
 
 	# dev-python/docutils installs rst2man.py, not rst2man

--- a/dev-util/bpftool/bpftool-6.0.12.ebuild
+++ b/dev-util/bpftool/bpftool-6.0.12.ebuild
@@ -86,6 +86,11 @@ src_prepare() {
 		popd || die
 	fi
 
+	pushd "${S_K}" >/dev/null || die
+	# bug #890638
+	eapply "${FILESDIR}"/${PV}-no-stack-protector.patch
+	popd || die
+
 	# dev-python/docutils installs rst2man.py, not rst2man
 	sed -i -e 's/rst2man/rst2man.py/g' Documentation/Makefile || die
 }

--- a/dev-util/bpftool/files/5.19.12-no-stack-protector.patch
+++ b/dev-util/bpftool/files/5.19.12-no-stack-protector.patch
@@ -1,0 +1,14 @@
+
+https://bugs.gentoo.org/890638
+
+--- a/tools/bpf/bpftool/Makefile	2022-12-11 23:15:18.000000000 +0100
++++ b/tools/bpf/bpftool/Makefile	2023-01-13 10:32:09.615048492 +0100
+@@ -187,7 +187,7 @@ $(OUTPUT)%.bpf.o: skeleton/%.bpf.c $(OUT
+ 		-I$(or $(OUTPUT),.) \
+ 		-I$(srctree)/tools/include/uapi/ \
+ 		-I$(LIBBPF_BOOTSTRAP_INCLUDE) \
+-		-g -O2 -Wall -target bpf -c $< -o $@
++		-g -O2 -Wall -fno-stack-protector -target bpf -c $< -o $@
+ 	$(Q)$(LLVM_STRIP) -g $@
+ 
+ $(OUTPUT)%.skel.h: $(OUTPUT)%.bpf.o $(BPFTOOL_BOOTSTRAP)

--- a/dev-util/bpftool/files/6.0.12-no-stack-protector.patch
+++ b/dev-util/bpftool/files/6.0.12-no-stack-protector.patch
@@ -1,0 +1,14 @@
+
+https://bugs.gentoo.org/890638
+
+--- a/tools/bpf/bpftool/Makefile	2022-12-11 23:15:18.000000000 +0100
++++ b/tools/bpf/bpftool/Makefile	2023-01-13 10:32:09.615048492 +0100
+@@ -187,7 +187,7 @@ $(OUTPUT)%.bpf.o: skeleton/%.bpf.c $(OUT
+ 		-I$(or $(OUTPUT),.) \
+ 		-I$(srctree)/tools/include/uapi/ \
+ 		-I$(LIBBPF_BOOTSTRAP_INCLUDE) \
+-		-g -O2 -Wall -target bpf -c $< -o $@
++		-g -O2 -Wall -fno-stack-protector -target bpf -c $< -o $@
+ 	$(Q)$(LLVM_STRIP) -g $@
+ 
+ $(OUTPUT)%.skel.h: $(OUTPUT)%.bpf.o $(BPFTOOL_BOOTSTRAP)


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/890638
Signed-off-by: Holger Hoffstätte <holger@applied-asynchrony.com>
