### PR TITLE
dev-libs/mdns: fix build on musl

### DIFF
--- a/dev-libs/mdns/files/mdns-1.4.2-timeval.patch
+++ b/dev-libs/mdns/files/mdns-1.4.2-timeval.patch
@@ -1,0 +1,12 @@
+https://github.com/mjansson/mdns/pull/69
+
+--- a/mdns.c
++++ b/mdns.c
+@@ -16,6 +16,7 @@
+ #include <netdb.h>
+ #include <ifaddrs.h>
+ #include <net/if.h>
++#include <sys/time.h>
+ #endif
+ 
+ // Alias some things to simulate recieving data to fuzz library

--- a/dev-libs/mdns/mdns-1.4.2.ebuild
+++ b/dev-libs/mdns/mdns-1.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2022 Gentoo Authors
+# Copyright 2022-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -12,3 +12,7 @@ SRC_URI="https://github.com/mjansson/mdns/archive/refs/tags/${PV}.tar.gz -> ${P}
 LICENSE="Unlicense"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
+
+PATCHES=(
+	"${FILESDIR}/${P}-timeval.patch"
+)


### PR DESCRIPTION
Signed-off-by: Alexey Sokolov <alexey+gentoo@asokolov.org>
Closes: https://bugs.gentoo.org/890790