### PR TITLE
app-arch/gzip: remove gzip-reference exec fixups

### DIFF
--- a/app-arch/gzip/gzip-1.12-r3.ebuild
+++ b/app-arch/gzip/gzip-1.12-r3.ebuild
@@ -56,8 +56,6 @@ src_install() {
 	for x in gunzip gzip zcat; do
 		mv "${ED}/usr/bin/${x}" "${ED}/bin/${x}-reference" || die
 	done
-	sed -i -e 's:exec gzip:&-reference:' \
-		"${ED}"/bin/{gunzip,zcat}-reference || die
 	mv "${ED}"/usr/share/man/man1/gzip{,-reference}.1 || die
 	rm "${ED}"/usr/share/man/man1/{gunzip,zcat}.1 || die
 }

--- a/app-arch/gzip/gzip-1.12_p20221228.ebuild
+++ b/app-arch/gzip/gzip-1.12_p20221228.ebuild
@@ -71,8 +71,6 @@ src_install() {
 	for x in gunzip gzip zcat; do
 		mv "${ED}/usr/bin/${x}" "${ED}/bin/${x}-reference" || die
 	done
-	sed -i -e 's:exec gzip:&-reference:' \
-		"${ED}"/bin/{gunzip,zcat}-reference || die
 	mv "${ED}"/usr/share/man/man1/gzip{,-reference}.1 || die
 	rm "${ED}"/usr/share/man/man1/{gunzip,zcat}.1 || die
 }


### PR DESCRIPTION
`gunzip` and `zcat` are shellscripts provided by gzip that redirect to
the `gzip` executable (with flags added for the desired behavior).
Some development tools, such as bitbake from Yocto Linux, sanitize the
PATH to remove `/usr/bin` and `/bin`, but create symlinks for specific
tools into a directory that is in the path ('hosttools' for
Yocto/bitbake).  This means that the original executables (gzip, gunzip
zcat) are in the PATH but the new `*-reference` files are not.

Remove the fixups from `gunzip` and `zcat` that exec to `gzip-reference`
directly and instead let them use the `gzip` (which is likely symlinked
to the real `gzip-reference`) directly.

Signed-off-by: Patrick Williams <patrick@stwcx.xyz>
