### PR TITLE
app-crypt/ccid: add missed udev_reload

### DIFF
--- a/app-crypt/ccid/ccid-1.5.0.ebuild
+++ b/app-crypt/ccid/ccid-1.5.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -58,4 +58,9 @@ src_install() {
 		fi
 
 	fi
+}
+
+pkg_postinst() {
+	default
+	udev_reload
 }


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/890841

Signed-off-by: Marco Scardovi <scardracs-gentoo@proton.me>