### PR TITLE
profiles/default/linux: drop USE="fortran openmp"

### DIFF
--- a/profiles/default/linux/make.defaults
+++ b/profiles/default/linux/make.defaults
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 #
 # System-wide defaults for the Portage system
@@ -12,9 +12,6 @@
 
 # Default starting set of USE flags for all default/linux profiles.
 USE="crypt ipv6 ncurses nls pam readline ssl zlib"
-
-# make sure toolchain has sane defaults <toolchain@gentoo.org>
-USE="${USE} fortran openmp"
 
 # Security ftw.
 USE="${USE} seccomp"

--- a/profiles/prefix/linux/make.defaults
+++ b/profiles/prefix/linux/make.defaults
@@ -1,4 +1,4 @@
-# Copyright 1999-2014 Gentoo Foundation
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # 'Sane' defaults
@@ -14,9 +14,6 @@ FEATURES="-multilib-strict"
 # on glibc system you cannot turn it off
 USE="iconv"
 
-# build gcc with parallelization support
-USE="${USE} openmp"
-
 # Turn off acl to help with bootstrapping - it isn't as helpful for prefix as it
 # can be for a non-prefix install
 USE="${USE} -acl"
@@ -31,4 +28,3 @@ USE="${USE} -acl"
 # break a random amount of packages, that don't break (or just not
 # enough) for non-Prefix installs.
 LDFLAGS="-Wl,-O1"
-


### PR DESCRIPTION
This is an obsolete profile entry from the days when IUSE defaults did not exist. We already have IUSE="+fortran +openmp" in sys-devel/gcc.

Closes: https://bugs.gentoo.org/890999