### PR TITLE
app-arch/ncompress: Fix installation of the uncompress symlink

### DIFF
--- a/app-arch/ncompress/ncompress-5.0-r1.ebuild
+++ b/app-arch/ncompress/ncompress-5.0-r1.ebuild
@@ -1,0 +1,37 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="7"
+
+inherit toolchain-funcs
+
+DESCRIPTION="Classic compress & uncompress programs for .Z (LZW) files"
+HOMEPAGE="https://vapier.github.io/ncompress/"
+SRC_URI="https://github.com/vapier/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="public-domain"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~sparc-solaris ~x86-solaris"
+IUSE=""
+
+src_prepare() {
+	default
+	# First sed expression replaces hardlinking with
+	# symlinking. Second sed expression fixes the symlink target
+	# to use relative path to a file in the same directory as the
+	# symlink (so point to compress instead of
+	# $(DESTDIR)$(BINDIR)/compress).
+	sed -i \
+		-e 's:\bln :ln -s :' \
+		-e 's:\(\bln [^$]*\)\$(DESTDIR)\$(BINDIR)/:\1:' \
+		Makefile.def || die
+}
+
+src_configure() {
+	tc-export CC
+}
+
+src_install() {
+	emake install_core DESTDIR="${ED}" PREFIX="/usr"
+	dodoc Acknowleds Changes LZW.INFO README.md
+}


### PR DESCRIPTION
We were patching Makefile.def to create symbolic links instead of hardlinks and this resulted in symlinks pointing to `$(DESTDIR)$(BINDIR)/compress`. This meant that the symlink was broken in the merged filesystem. Add some more sed hacking to achieve `ln -s compress $(DESTDIR)$(BINDIR)/uncompress` instead.

Signed-off-by: Krzesimir Nowak <knowak@microsoft.com>