### PR TITLE
dev-util/bpftool: Fix install in prefix

### DIFF
--- a/dev-util/bpftool/bpftool-5.19.12.ebuild
+++ b/dev-util/bpftool/bpftool-5.19.12.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 PYTHON_COMPAT=( python3_{9..10} )
-inherit estack linux-info optfeature python-any-r1 toolchain-funcs
+inherit estack linux-info optfeature python-any-r1 bash-completion-r1 toolchain-funcs
 
 MY_PV="${PV/_/-}"
 MY_PV="${MY_PV/-pre/-git}"
@@ -107,6 +107,7 @@ bpftool_make() {
 		HOSTCC="$(tc-getBUILD_CC)" HOSTLD="$(tc-getBUILD_LD)" \
 		EXTRA_CFLAGS="${CFLAGS}" ARCH="${arch}" BPFTOOL_VERSION="${MY_PV}" \
 		prefix="${EPREFIX}"/usr \
+		bash_compdir="$(get_bashcompdir)" \
 		feature-libcap="$(usex caps 1 0)" \
 		"$@"
 }

--- a/dev-util/bpftool/bpftool-6.0.12.ebuild
+++ b/dev-util/bpftool/bpftool-6.0.12.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 PYTHON_COMPAT=( python3_{9..10} )
-inherit estack linux-info optfeature python-any-r1 toolchain-funcs
+inherit estack linux-info optfeature python-any-r1 bash-completion-r1 toolchain-funcs
 
 MY_PV="${PV/_/-}"
 MY_PV="${MY_PV/-pre/-git}"
@@ -103,6 +103,7 @@ bpftool_make() {
 		HOSTCC="$(tc-getBUILD_CC)" HOSTLD="$(tc-getBUILD_LD)" \
 		EXTRA_CFLAGS="${CFLAGS}" ARCH="${arch}" BPFTOOL_VERSION="${MY_PV}" \
 		prefix="${EPREFIX}"/usr \
+		bash_compdir="$(get_bashcompdir)" \
 		feature-libcap="$(usex caps 1 0)" \
 		"$@"
 }


### PR DESCRIPTION
Without this patch install would cause:
```
  * QA Notice: the following files are outside of the prefix:
  * /usr
  * /usr/share
  * /usr/share/bash-completion
  * /usr/share/bash-completion/completions
  * /usr/share/bash-completion/completions/bpftool
  * ERROR: dev-util/bpftool-6.0.12::gentoo failed:
  *   Aborting due to QA concerns: there are files installed outside the prefix
```

The Makefile defines
  `bash_compdir ?= /usr/share/bash-completion/completions`
and the install command is
  `$(Q)$(INSTALL) -m 0755 -d $(DESTDIR)$(bash_compdir)`

We can just do a simple override with $(get_bashcompdir) from bash-completion-r1.eclass.

Signed-off-by: YiFei Zhu <zhuyifei@google.com>