### PR TITLE
dev-python/weasyprint: need media-fonts/dejavu to prevent a coredump …

### DIFF
--- a/dev-python/weasyprint/weasyprint-57.1.ebuild
+++ b/dev-python/weasyprint/weasyprint-57.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -29,6 +29,7 @@ RDEPEND="
 	>=dev-python/pydyf-0.5.0[${PYTHON_USEDEP}]
 	>=dev-python/pyphen-0.9.1[${PYTHON_USEDEP}]
 	>=dev-python/tinycss2-1.0.0[${PYTHON_USEDEP}]
+	media-fonts/dejavu
 	x11-libs/pango
 "
 
@@ -39,7 +40,6 @@ BDEPEND="
 			<app-text/ghostscript-gpl-9.56.0
 		)
 		media-fonts/ahem
-		media-fonts/dejavu
 	)
 "
 

--- a/dev-python/weasyprint/weasyprint-57.2.ebuild
+++ b/dev-python/weasyprint/weasyprint-57.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -29,6 +29,7 @@ RDEPEND="
 	>=dev-python/pydyf-0.5.0[${PYTHON_USEDEP}]
 	>=dev-python/pyphen-0.9.1[${PYTHON_USEDEP}]
 	>=dev-python/tinycss2-1.0.0[${PYTHON_USEDEP}]
+	media-fonts/dejavu
 	x11-libs/pango
 "
 
@@ -39,7 +40,6 @@ BDEPEND="
 			<app-text/ghostscript-gpl-9.56.0
 		)
 		media-fonts/ahem
-		media-fonts/dejavu
 	)
 "
 


### PR DESCRIPTION
…if no fonts are installed

the error
<pre>
$ /usr/bin/weasyprint https://www.google.com google.pdf

WARNING: Ignored `overflow-y:scroll` at 1:59, unknown property. WARNING: Ignored `display:inline-box` at 1:330, invalid value.

(process:843463): Pango-CRITICAL **: 10:28:18.166: pango_font_describe: assertion 'font != NULL' failed

(process:843463): Pango-CRITICAL **: 10:28:18.166: pango_font_description_unset_fields: assertion 'desc != NULL' failed

(process:843463): Pango-CRITICAL **: 10:28:18.166: pango_font_description_hash: assertion 'desc != NULL' failed

(process:843463): Pango-CRITICAL **: 10:28:18.166: pango_font_get_hb_font: assertion 'PANGO_IS_FONT (font)' failed Segmentation fault ('core' dumped)
</pre>

Signed-off-by: INODE64 <ffelix@inode64.com>