### PR TITLE
dev-libs/skalibs: remove doc and ipv6 use flags

### DIFF
--- a/dev-libs/skalibs/skalibs-2.13.0.0.ebuild
+++ b/dev-libs/skalibs/skalibs-2.13.0.0.ebuild
@@ -12,7 +12,6 @@ SRC_URI="https://www.skarnet.org/software/${PN}/${P}.tar.gz"
 LICENSE="ISC"
 SLOT="0/$(ver_cut 1-2)"
 KEYWORDS="~amd64 ~arm ~arm64 ~x86"
-IUSE="doc ipv6"
 
 HTML_DOCS=( doc/. )
 
@@ -33,10 +32,11 @@ src_configure() {
 		--dynlibdir=/usr/$(get_libdir)
 		--libdir=/usr/$(get_libdir)/${PN}
 		--sysdepdir=/usr/$(get_libdir)/${PN}
-		--enable-clock
-		--enable-shared
+
 		--disable-static
-		$(use_enable ipv6)
+		--enable-clock
+		--enable-ipv6
+		--enable-shared
 	)
 
 	econf "${myconf[@]}"


### PR DESCRIPTION
`doc` use flag does nothing since commit 73b2aa5cba97 - `dev-libs/skalibs: Bump to 2.7.0.0`, when local `src_install` function was removed.

Enable `ipv6` support unconditionally because some reverse dependencies install ipv6 related binaries unconditionally (there is no configuration option to control that) and fail to run with error message that contains: `Function not implemented` when ipv6 support is disabled which might be confusing for users.