### PR TITLE
dev-libs/pocl-3.1: Fix possible build failure

### DIFF
--- a/dev-libs/pocl/files/pocl-3.1-nodebug.patch
+++ b/dev-libs/pocl/files/pocl-3.1-nodebug.patch
@@ -1,0 +1,29 @@
+commit a13cb332d6678d4556d7319b284b77c371c4b91e
+Author: Martin Kletzander <nert.pinx@gmail.com>
+Date:   Tue Jan 17 09:04:41 2023 +0100
+
+    Add stub macro POCL_MSG_PRINT_ALMAIF_MMAP without POCL_DEBUG_MESSAGES
+    
+    Without this the build fails with the following error when built without
+    POCL_DEBUG_MESSAGES:
+    
+    ../lib/CL/devices/almaif/MMAPRegion.cc: In constructor ‘MMAPRegion::MMAPRegion(size_t, size_t, int)’:
+    ../lib/CL/devices/almaif/MMAPRegion.cc:43:3: error: ‘POCL_MSG_PRINT_ALMAIF_MMAP’ was not declared in this scope; did you mean ‘POCL_MSG_PRINT_ALMAIF2’?
+       43 |   POCL_MSG_PRINT_ALMAIF_MMAP(
+          |   ^~~~~~~~~~~~~~~~~~~~~~~~~~
+          |   POCL_MSG_PRINT_ALMAIF2
+    
+    and about 10 more.
+
+diff --git a/lib/CL/pocl_debug.h b/lib/CL/pocl_debug.h
+index 5a81744bff47..f9e128f9822c 100644
+--- a/lib/CL/pocl_debug.h
++++ b/lib/CL/pocl_debug.h
+@@ -284,6 +284,7 @@ POCL_EXPORT
+ 
+     #define POCL_MSG_PRINT_ALMAIF2(...)  do {} while (0)
+     #define POCL_MSG_PRINT_ALMAIF(...)  do {} while (0)
++    #define POCL_MSG_PRINT_ALMAIF_MMAP(...)  do {} while (0)
+     #define POCL_MSG_PRINT_PROXY2(...)  do {} while (0)
+     #define POCL_MSG_PRINT_PROXY(...)  do {} while (0)
+     #define POCL_MSG_PRINT_VULKAN2(...)  do {} while (0)

--- a/dev-libs/pocl/pocl-3.1.ebuild
+++ b/dev-libs/pocl/pocl-3.1.ebuild
@@ -57,6 +57,10 @@ llvm_check_deps() {
 		has_version -b "sys-devel/clang:${LLVM_SLOT}${usedep}"
 }
 
+PATCHES=(
+	"${FILESDIR}"/${P}-nodebug.patch
+)
+
 pkg_setup() {
 	use doc && python-any-r1_pkg_setup
 


### PR DESCRIPTION
There is a possible missing macro which was now fixed upstream, but not in 3.1, so this is a backport.  Not raising the release number since there is no need for rebuild of installed pocl-3.1.

Signed-off-by: Martin Kletzander <nert.pinx@gmail.com>