### PR TITLE
dev-util/cargo-ebuild: update github upstream metadata

### DIFF
--- a/dev-util/cargo-ebuild/metadata.xml
+++ b/dev-util/cargo-ebuild/metadata.xml
@@ -9,6 +9,6 @@
 		<email>rust@gentoo.org</email>
 	</maintainer>
 	<upstream>
-		<remote-id type="github">cardeo/cargo-ebuild</remote-id>
+		<remote-id type="github">gentoo/cargo-ebuild</remote-id>
 	</upstream>
 </pkgmetadata>


### PR DESCRIPTION
Signed-off-by: Remigiusz Micielski <remigiusz.micielski@gmail.com>
Github repo cardeo/cargo-ebuild moved to gentoo/cargo-ebuild