### PR TITLE
app-portage/{elicense,unsymlink-lib}: Sync PYTHON_COMPAT with sys-apps/portage

### DIFF
--- a/app-portage/elicense/elicense-1.0.2.ebuild
+++ b/app-portage/elicense/elicense-1.0.2.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="7"
-PYTHON_COMPAT=( pypy3 python3_{9..10} )
+PYTHON_COMPAT=( pypy3 python3_{9..11} )
 inherit distutils-r1
 
 if [[ ${PV} == "9999" ]]; then

--- a/app-portage/unsymlink-lib/unsymlink-lib-20.ebuild
+++ b/app-portage/unsymlink-lib/unsymlink-lib-20.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{9..10} )
+PYTHON_COMPAT=( python3_{9..11} )
 inherit python-single-r1
 
 DESCRIPTION="Convert your system to SYMLINK_LIB=no"


### PR DESCRIPTION
These scripts only import portage and python default packages.