### PR TITLE
dev-db/etcd: fixes to package

### DIFF
--- a/dev-db/etcd/etcd-3.4.16-r1.ebuild
+++ b/dev-db/etcd/etcd-3.4.16-r1.ebuild
@@ -1,0 +1,78 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+inherit go-module systemd tmpfiles
+GIT_COMMIT=cf54fab42
+
+DESCRIPTION="Highly-available key value store for shared configuration and service discovery"
+HOMEPAGE="https://github.com/etcd-io/etcd"
+SRC_URI="https://github.com/etcd-io/etcd/archive/v${PV}.tar.gz -> ${P}.tar.gz
+	https://dev.gentoo.org/~zmedico/dist/${P}-deps.tar.xz"
+
+LICENSE="Apache-2.0 BSD BSD-2 MIT"
+SLOT="0"
+KEYWORDS="~amd64 ~riscv"
+IUSE="doc +server"
+
+COMMON_DEPEND="server? (
+	acct-group/etcd
+	acct-user/etcd
+	)"
+DEPEND="${COMMON_DEPEND}"
+RDEPEND="${COMMON_DEPEND}"
+
+# Tests fail with this error:
+# fatal error: checkptr: unsafe pointer conversion
+RESTRICT="test"
+
+src_prepare() {
+	export GO_BUILD_FLAGS="-v -x"
+	default
+	sed -e "s|GIT_SHA=.*|GIT_SHA=${GIT_COMMIT}|"\
+		-i "${S}"/build || die
+	sed -e 's:\(for p in \)shellcheck :\1 :' \
+		-e 's:^			gofmt \\$:\\:' \
+		-e 's:^			govet \\$:\\:' \
+		-e 's:^			govet_shadow \\$:\\:' \
+		-i "${S}"/test || die
+
+	sed -e "s|GO_BUILD_FLAGS=\"[^\"]*\"|GO_BUILD_FLAGS=\"${GO_BUILD_FLAGS}\"|" \
+		-e "s|go test |go test ${GO_BUILD_FLAGS} |" \
+		-i ./test || die
+}
+
+src_compile() {
+	./build || die
+}
+
+src_test() {
+	./test || die
+}
+
+src_install() {
+	dobin bin/etcdctl
+	use doc && dodoc -r Documentation
+	if use server; then
+		insinto /etc/${PN}
+		newins etcd.conf.yml.sample etcd.conf.yml
+		dobin bin/etcd
+		dodoc README.md
+		systemd_dounit "${FILESDIR}/${PN}.service"
+		newtmpfiles "${FILESDIR}/${PN}.tmpfiles.d.conf" ${PN}.conf
+		newinitd "${FILESDIR}"/${PN}.initd-r1 ${PN}
+		newconfd "${FILESDIR}"/${PN}.confd-r1 ${PN}
+		insinto /etc/logrotate.d
+		newins "${FILESDIR}/${PN}.logrotated" "${PN}"
+		keepdir /var/lib/${PN} /var/log/${PN}
+		fowners ${PN}:${PN} /var/lib/${PN} /var/log/${PN}
+		fperms 0700 /var/lib/${PN}
+		fperms 0755 /var/log/${PN}
+	fi
+}
+
+pkg_postinst() {
+	if use server; then
+		tmpfiles_process ${PN}.conf
+	fi
+}

--- a/dev-db/etcd/files/etcd.confd-r1
+++ b/dev-db/etcd/files/etcd.confd-r1
@@ -1,0 +1,10 @@
+# Name of this node in the etcd cluster.
+ETCD_NAME=etcd
+
+# Path to the data directory.
+ETCD_DATA_DIR=/var/lib/etcd
+
+# Path to config file.
+ETCD_CONFIGFILE=/etc/etcd/etcd.conf.yml
+
+ETCD_OPTS=""

--- a/dev-db/etcd/files/etcd.initd-r1
+++ b/dev-db/etcd/files/etcd.initd-r1
@@ -1,0 +1,37 @@
+#!/sbin/openrc-run
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+pidfile=/run/${RC_SVCNAME}.pid
+LOGPATH=/var/log/${RC_SVCNAME}
+DATADIR=/var/lib/${RC_SVCNAME}
+command_user=${RC_SVCNAME}
+command=/usr/bin/etcd
+command_args="
+	--name=${ETCD_NAME}
+	--data-dir=${ETCD_DATA_DIR}
+	--config-file=${ETCD_CONFIGFILE}
+	${ETCD_OPTS}"
+command_background=true
+start_stop_daemon_args="
+	--chdir ${ETCD_DATA_DIR}
+	-1 ${LOGPATH}/${RC_SVCNAME}.log
+	-2 ${LOGPATH}/${RC_SVCNAME}.err"
+
+depend() {
+	need net
+	need localmount
+	after bootmisc
+}
+
+start() {
+	if [ ! -d "${LOGPATH}" ] ; then
+		mkdir -p "${LOGPATH}"
+		chown "${command_user}:${command_user}" "${LOGPATH}"
+	fi
+	if [ ! -d "${ETCD_DATA_DIR}" ] ; then
+		mkdir -p "${ETCD_DATA_DIR}"
+		chown "${command_user}:${command_user}" "${ETCD_DATA_DIR}"
+	fi
+	default_start
+}

--- a/dev-db/etcd/files/etcd.tmpfiles.d.conf
+++ b/dev-db/etcd/files/etcd.tmpfiles.d.conf
@@ -1,2 +1,2 @@
 d    /var/lib/etcd 0700 etcd etcd - -
-d    /var/run/etcd 0755 etcd etcd - -
+d    /run/etcd 0755 etcd etcd - -

--- a/dev-db/etcd/metadata.xml
+++ b/dev-db/etcd/metadata.xml
@@ -2,10 +2,8 @@
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
 	<upstream>
-		<bugs-to>https://github.com/coreos/etcd/issues</bugs-to>
-		<changelog>https://raw.githubusercontent.com/coreos/etcd/master/CHANGELOG</changelog>
-		<doc>https://github.com/coreos/etcd/blob/master/README.md/</doc>
-		<remote-id type="github">coreos/etcd</remote-id>
+		<bugs-to>https://github.com/etcd-io/etcd/issues</bugs-to>
+		<remote-id type="github">etcd-io/etcd</remote-id>
 	</upstream>
 	<use>
 		<flag name="server">Installs etcd daemon</flag>


### PR DESCRIPTION
Update to EAPI8.
Update init.d/conf.d files to use correct options and new config file, update tmpfiles.d configuration.

Closes: https://bugs.gentoo.org/891397
Closes: https://bugs.gentoo.org/829695
Closes: https://bugs.gentoo.org/766015
Signed-off-by: Azamat H. Hackimov <azamat.hackimov@gmail.com>