### PR TITLE
dev-python/python-mpd: enable py3.11

### DIFF
--- a/dev-python/python-mpd/python-mpd-3.0.5.ebuild
+++ b/dev-python/python-mpd/python-mpd-3.0.5.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..10} )
+PYTHON_COMPAT=( python3_{9..11} )
 inherit distutils-r1
 
 MY_P=python-mpd2-${PV}


### PR DESCRIPTION
Signed-off-by: Egor Martynov <martynovegorOF@yandex.ru>

This package is a dependency on the x11-wm/qtile package (which already has py3.11 support). I did not find any issues that would mention the lack of py3.11 support.

![](http://0x0.st/ohJm.png)