### PR TITLE
dev-util/codeblocks: use bundled squirrel to fix API issues compiling, upstream removed system wide dev-lang/squirrel support

### DIFF
--- a/dev-util/codeblocks/codeblocks-20.03-r6.ebuild
+++ b/dev-util/codeblocks/codeblocks-20.03-r6.ebuild
@@ -65,11 +65,14 @@ src_configure() {
 	# USE="-contrib fortran" setup:
 	use contrib || CONF_WITH_LST=$(use_with fortran contrib-plugins FortranProject)
 
-	econf \
-		--disable-pch \
-		$(use_with contrib boost-libdir "${ESYSROOT}/usr/$(get_libdir)") \
-		$(use_enable debug) \
+	local myeconfargs=(
+		--disable-pch
+		$(use_with contrib boost-libdir "${ESYSROOT}/usr/$(get_libdir)")
+		$(use_enable debug)
 		${CONF_WITH_LST}
+	)
+
+	econf "${myeconfargs[@]}"
 }
 
 src_install() {

--- a/dev-util/codeblocks/codeblocks-20.03-r6.ebuild
+++ b/dev-util/codeblocks/codeblocks-20.03-r6.ebuild
@@ -13,10 +13,10 @@ LICENSE="GPL-3"
 SLOT="0"
 KEYWORDS="~amd64 ~ppc ~x86"
 SRC_URI="mirror://sourceforge/${PN}/${P}.tar.xz
-https://dev.gentoo.org/~leio/distfiles/${P}-fortran.tar.xz
-https://dev.gentoo.org/~leio/distfiles/${P}-fortran-update-v1.7.tar.xz
-https://dev.gentoo.org/~leio/distfiles/${P}-fortran-update-v1.8.tar.xz
-https://dev.gentoo.org/~leio/distfiles/${P}-codecompletion-symbolbrowser-update.tar.xz
+	https://dev.gentoo.org/~leio/distfiles/${P}-fortran.tar.xz
+	https://dev.gentoo.org/~leio/distfiles/${P}-fortran-update-v1.7.tar.xz
+	https://dev.gentoo.org/~leio/distfiles/${P}-fortran-update-v1.8.tar.xz
+	https://dev.gentoo.org/~leio/distfiles/${P}-codecompletion-symbolbrowser-update.tar.xz
 "
 
 # USE="fortran" enables FortranProject plugin (updated to v1.8 2021-05-29 [r230])

--- a/dev-util/codeblocks/codeblocks-20.03-r6.ebuild
+++ b/dev-util/codeblocks/codeblocks-20.03-r6.ebuild
@@ -67,7 +67,6 @@ src_configure() {
 
 	econf \
 		--disable-pch \
-		--disable-static \
 		$(use_with contrib boost-libdir "${ESYSROOT}/usr/$(get_libdir)") \
 		$(use_enable debug) \
 		${CONF_WITH_LST}

--- a/dev-util/codeblocks/codeblocks-20.03-r6.ebuild
+++ b/dev-util/codeblocks/codeblocks-20.03-r6.ebuild
@@ -29,13 +29,18 @@ IUSE="contrib debug fortran"
 BDEPEND="virtual/pkgconfig"
 
 RDEPEND="app-arch/zip
+	dev-libs/glib:2
 	>=dev-libs/tinyxml-2.6.2-r3
 	>=dev-util/astyle-3.1-r2:0/3.1
+	x11-libs/gtk+:3
 	x11-libs/wxGTK:${WX_GTK_VER}[X]
 	contrib? (
 		app-admin/gamin
-		app-text/hunspell
-		dev-libs/boost:=
+		app-arch/bzip2
+		app-text/hunspell:=
+		dev-libs/libgamin
+		media-libs/fontconfig
+		sys-libs/zlib
 	)"
 
 DEPEND="${RDEPEND}"

--- a/dev-util/codeblocks/codeblocks-20.03-r6.ebuild
+++ b/dev-util/codeblocks/codeblocks-20.03-r6.ebuild
@@ -1,0 +1,87 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+WX_GTK_VER="3.0-gtk3"
+
+inherit autotools flag-o-matic wxwidgets xdg
+
+DESCRIPTION="The open source, cross platform, free C, C++ and Fortran IDE"
+HOMEPAGE="https://codeblocks.org/"
+LICENSE="GPL-3"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86"
+SRC_URI="mirror://sourceforge/${PN}/${P}.tar.xz
+https://dev.gentoo.org/~leio/distfiles/${P}-fortran.tar.xz
+https://dev.gentoo.org/~leio/distfiles/${P}-fortran-update-v1.7.tar.xz
+https://dev.gentoo.org/~leio/distfiles/${P}-fortran-update-v1.8.tar.xz
+https://dev.gentoo.org/~leio/distfiles/${P}-codecompletion-symbolbrowser-update.tar.xz
+"
+
+# USE="fortran" enables FortranProject plugin (updated to v1.8 2021-05-29 [r230])
+# that is delivered with Code::Blocks 20.03 source code.
+# https://sourceforge.net/projects/fortranproject
+# https://cbfortran.sourceforge.io
+
+IUSE="contrib debug fortran"
+
+BDEPEND="virtual/pkgconfig"
+
+RDEPEND="app-arch/zip
+	>=dev-libs/tinyxml-2.6.2-r3
+	>=dev-util/astyle-3.1-r2:0/3.1
+	x11-libs/wxGTK:${WX_GTK_VER}[X]
+	contrib? (
+		app-admin/gamin
+		app-text/hunspell
+		dev-libs/boost:=
+	)"
+
+DEPEND="${RDEPEND}"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-env.patch
+	"${WORKDIR}"/patches/
+	)
+
+src_prepare() {
+	default
+	# Force to use bundled Squirrel-3.1 (patched version is used by upstream) due to it's API was changed
+	sed -i '/PKG_CHECK_MODULES(\[SQUIRREL\]/c\HAVE_SQUIRREL=no' configure.ac || die # Bug 884601
+	eautoreconf
+}
+
+src_configure() {
+	# Bug 858338
+	append-flags -fno-strict-aliasing
+
+	setup-wxwidgets
+
+	# USE="contrib -fortran" setup:
+	use fortran || CONF_WITH_LST=$(use_with contrib contrib-plugins all,-FortranProject)
+	# USE="contrib fortran" setup:
+	use fortran && CONF_WITH_LST=$(use_with contrib contrib-plugins all)
+	# USE="-contrib fortran" setup:
+	use contrib || CONF_WITH_LST=$(use_with fortran contrib-plugins FortranProject)
+
+	econf \
+		--disable-pch \
+		--disable-static \
+		$(use_with contrib boost-libdir "${ESYSROOT}/usr/$(get_libdir)") \
+		$(use_enable debug) \
+		${CONF_WITH_LST}
+}
+
+src_install() {
+	default
+	find "${ED}" -type f -name '*.la' -delete || die
+}
+
+pkg_postinst() {
+	xdg_pkg_postinst
+}
+
+pkg_postrm() {
+	xdg_pkg_postrm
+}


### PR DESCRIPTION
This fixes a compiling issue when `dev-lang/squirrel` is installed.  Do not use the system's `/usr/include/squirrel.h` header, since the API may have been changed (see bottom).

```
# diff codeblocks-20.03-r5.ebuild codeblocks-20.03-r6.ebuild 
1c1
< # Copyright 1999-2022 Gentoo Authors
---
> # Copyright 1999-2023 Gentoo Authors
44a45
>       "${FILESDIR}"/${P}-squirrel.patch
```

Upstream fix: `r12418 | fuscated | 2021-05-09 14:50:21 +0200 (Sun, 09 May 2021) | 5 lines`
```
$ svn checkout svn://svn.code.sf.net/p/codeblocks/code/trunk
$ cd trunk
$ svn log --diff configure.ac@r12418
```

The bundled `src/include/scripting/include/squirrel.h` header should be used, rather than the system's `/usr/include/squirrel.h`, due to possible API changes.
```
libtool: compile:  x86_64-pc-linux-gnu-g++ -DHAVE_CONFIG_H -I. -I../../../../src/include -I/usr/include/squirrel -I../../../../src/include/scripting/sqplus -DC
B_AUTOCONF -DNDEBUG -DPIC -DTIXML_USE_STL=YES -O2 -pipe -fno-strict-aliasing -fPIC -fexceptions -c SquirrelVM.cpp  -fPIC -DPIC -o .libs/SquirrelVM.o
In file included from ../../../../src/include/scripting/sqplus/sqplus.h:58,
                 from SqPlus.cpp:1:
../../../../src/include/scripting/sqplus/SquirrelObject.h: In member function 'void* StackHandler::GetInstanceUp(SQInteger, SQUserPointer)':
../../../../src/include/scripting/sqplus/SquirrelObject.h:149:46: error: too few arguments to function 'SQRESULT sq_getinstanceup(HSQUIRRELVM, SQInteger, void*
*, SQUserPointer, SQBool)'
  149 |                 if(SQ_FAILED(sq_getinstanceup(v,idx,(SQUserPointer*)&self,tag)))
      |                              ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/squirrel.h:283:23: note: declared here
  283 | SQUIRREL_API SQRESULT sq_getinstanceup(HSQUIRRELVM v, SQInteger idx, SQUserPointer *p,SQUserPointer typetag,SQBool throwerror);
      |                       ^~~~~~~~~~~~~~~~
```

Thanks ;)