### PR TITLE
app-admin/eclean-kernel: add python-3.11 support

### DIFF
--- a/app-admin/eclean-kernel/eclean-kernel-2.99.3.ebuild
+++ b/app-admin/eclean-kernel/eclean-kernel-2.99.3.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..10} )
+PYTHON_COMPAT=( python3_{9..11} )
 
 inherit distutils-r1
 


### PR DESCRIPTION
Signed-off-by: Andrés Becerra <andres.becerra@gmail.com>
Tested-by: Andrés Becerra <andres.becerra@gmail.com>
Bug: https://bugs.gentoo.org/891483
Closes: https://bugs.gentoo.org/891483