### PR TITLE
dev-lang/ghc: Revision bumps

### DIFF
--- a/dev-lang/ghc/ghc-8.10.6-r2.ebuild
+++ b/dev-lang/ghc/ghc-8.10.6-r2.ebuild
@@ -87,7 +87,7 @@ RDEPEND="
 	dev-libs/gmp:0=
 	sys-libs/ncurses:=[unicode(+)]
 	elfutils? ( dev-libs/elfutils )
-	!ghcmakebinary? ( dev-libs/libffi:= )
+	!ghcmakebinary? ( dev-libs/libffi:=[-exec-static-trampoline] )
 	numa? ( sys-process/numactl )
 "
 


### PR DESCRIPTION
The 8.10 line of ghc needs `USE=exec-static-trampoline` turned off on `libffi`. The fix exists in 9.0.2 and later versions of ghc.

See: https://gitlab.haskell.org/ghc/ghc/-/merge_requests/6155
Bug: https://bugs.gentoo.org/801109
Reported-by: Sam James <sam@gentoo.org>