### PR TITLE
net-wireless/bluez-5.66: fix 'MAX_INPUT' undeclared in musl

### DIFF
--- a/net-wireless/bluez/bluez-5.66-r1.ebuild
+++ b/net-wireless/bluez/bluez-5.66-r1.ebuild
@@ -77,6 +77,10 @@ PATCHES=(
 
 	# Fixed in next release
 	"${FILESDIR}"/${P}-transient-hostname-fix.patch
+
+	# https://github.com/nilfs-dev/nilfs-utils/commit/115fe4b976858c487cf83065f513d8626089579a
+	# https://bugs.gentoo.org/888467
+	"${FILESDIR}"/${PN}-5.66-musl-max-input.patch
 )
 
 pkg_setup() {

--- a/net-wireless/bluez/files/bluez-5.66-musl-max-input.patch
+++ b/net-wireless/bluez/files/bluez-5.66-musl-max-input.patch
@@ -1,0 +1,18 @@
+# musl does provide _POSIX_MAX_INPUT, but no MAX_INPUT out of the box.
+# This patch assigns _POSIX_MAX_INPUT to MAX_INPUT.
+# Please refer: https://github.com/nilfs-dev/nilfs-utils/commit/115fe4b976858c487cf83065f513d8626089579a
+# Closes: #888467
+--- a/src/shared/util.c
++++ b/src/shared/util.c
+@@ -28,6 +28,11 @@
+ #include <sys/random.h>
+ #endif
+
++/* define MAX_INPUT for musl */
++#ifndef MAX_INPUT
++#define MAX_INPUT _POSIX_MAX_INPUT
++#endif
++
+ #include "src/shared/util.h"
+
+ void *util_malloc(size_t size)


### PR DESCRIPTION
musl does provide _POSIX_MAX_INPUT, but no MAX_INPUT out of the box. This commit assigns _POSIX_MAX_INPUT to MAX_INPUT.

Closes: https://bugs.gentoo.org/888467
Signed-off-by: brahmajit das <listout@protonmail.com>