### PR TITLE
net-libs/nativebiginteger: remove useless PATCHES array

### DIFF
--- a/net-libs/nativebiginteger/nativebiginteger-1.6.1.ebuild
+++ b/net-libs/nativebiginteger/nativebiginteger-1.6.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2018-2022 Gentoo Authors
+# Copyright 2018-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -22,10 +22,6 @@ DEPEND="
 RDEPEND="${DEPEND}"
 
 S="${WORKDIR}/i2p-${PV}/core"
-
-PATCHES=(
-	"${FILESDIR}/${P}-asmfix.patch"
-)
 
 src_compile() {
 	local compile_lib

--- a/net-libs/nativebiginteger/nativebiginteger-1.7.0.ebuild
+++ b/net-libs/nativebiginteger/nativebiginteger-1.7.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2018-2022 Gentoo Authors
+# Copyright 2018-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -22,10 +22,6 @@ DEPEND="
 RDEPEND="${DEPEND}"
 
 S="${WORKDIR}/i2p-${PV}/core"
-
-PATCHES=(
-	"${FILESDIR}/${P}-asmfix.patch"
-)
 
 src_compile() {
 	local compile_lib


### PR DESCRIPTION
That array pointing to no existing files would cause src_prepare() fail once java-utils-2.eclass adds default src_prepare.

Closes: https://bugs.gentoo.org/891671

Signed-off-by: Volkmar W. Pogatzki <gentoo@pogatzki.net>