### PR TITLE
dev-java/ant-core: remove useless java-pkg-2_src_prepare

### DIFF
--- a/dev-java/ant-core/ant-core-1.10.9-r5.ebuild
+++ b/dev-java/ant-core/ant-core-1.10.9-r5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -67,7 +67,6 @@ src_prepare() {
 
 	# See bug #196080 for more details.
 	java-ant_bsfix_one build.xml
-	java-pkg-2_src_prepare
 
 	# Remove JDK9+ stuff
 	einfo "Removing JDK9+ classes (Jmod and Link)"

--- a/dev-java/commons-daemon/commons-daemon-1.3.3.ebuild
+++ b/dev-java/commons-daemon/commons-daemon-1.3.3.ebuild
@@ -38,7 +38,6 @@ JAVA_SRC_DIR="src/main/java"
 
 src_prepare() {
 	default #780585
-	java-pkg-2_src_prepare
 }
 
 src_compile() {


### PR DESCRIPTION
Calling java-pkg-2_src_prepare after "default" makes no sense.
Signed-off-by: Volkmar W. Pogatzki <gentoo@pogatzki.net>