### PR TITLE
acct-user/*: remove ACCT_USER_HOME_OWNER if it is equal to default

### DIFF
--- a/acct-user/automatic/automatic-0.ebuild
+++ b/acct-user/automatic/automatic-0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,6 +8,5 @@ inherit acct-user
 ACCT_USER_ID=338
 ACCT_USER_GROUPS=( automatic )
 ACCT_USER_HOME="/var/lib/automatic"
-ACCT_USER_HOME_OWNER="automatic:automatic"
 
 acct-user_add_deps

--- a/acct-user/ceph/ceph-0-r1.ebuild
+++ b/acct-user/ceph/ceph-0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 Gentoo Authors
+# Copyright 2019-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -9,7 +9,6 @@ DESCRIPTION="User for ceph"
 
 ACCT_USER_ID=267
 ACCT_USER_HOME=/var/lib/ceph
-ACCT_USER_HOME_OWNER=ceph:ceph
 ACCT_USER_GROUPS=( ceph )
 
 acct-user_add_deps

--- a/acct-user/git/git-0-r2.ebuild
+++ b/acct-user/git/git-0-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2019-2022 Gentoo Authors
+# Copyright 2019-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -11,7 +11,6 @@ IUSE="git gitea gitolite"
 REQUIRED_USE="^^ ( git gitea gitolite )"
 
 ACCT_USER_ID=196
-ACCT_USER_HOME_OWNER=git:git
 ACCT_USER_HOME_PERMS=750
 ACCT_USER_SHELL=/bin/sh
 ACCT_USER_GROUPS=( git )

--- a/acct-user/goaccess/goaccess-0.ebuild
+++ b/acct-user/goaccess/goaccess-0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -8,7 +8,6 @@ inherit acct-user
 ACCT_USER_ID=523
 ACCT_USER_GROUPS=( goaccess )
 ACCT_USER_HOME="/var/lib/goaccess"
-ACCT_USER_HOME_OWNER="goaccess:goaccess"
 ACCT_USER_HOME_PERMS=0770
 
 acct-user_add_deps

--- a/acct-user/headscale/headscale-0.ebuild
+++ b/acct-user/headscale/headscale-0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -8,7 +8,6 @@ inherit acct-user
 DESCRIPTION="Headscale Server hosting user"
 
 ACCT_USER_ID=514
-ACCT_USER_HOME_OWNER=headscale:headscale
 ACCT_USER_HOME_PERMS=750
 ACCT_USER_GROUPS=( headscale )
 ACCT_USER_HOME=/var/lib/headscale

--- a/acct-user/munin-async/munin-async-0-r1.ebuild
+++ b/acct-user/munin-async/munin-async-0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 Gentoo Authors
+# Copyright 2019-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -9,7 +9,6 @@ DESCRIPTION="user for munin async proxy node"
 
 ACCT_USER_GROUPS=( munin )
 ACCT_USER_HOME="/var/spool/munin-async"
-ACCT_USER_HOME_OWNER="munin-async:munin"
 ACCT_USER_ID=178
 ACCT_USER_SHELL=/bin/sh
 

--- a/acct-user/munin/munin-0-r1.ebuild
+++ b/acct-user/munin/munin-0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 Gentoo Authors
+# Copyright 2019-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -9,7 +9,6 @@ DESCRIPTION="user for munin"
 
 ACCT_USER_GROUPS=( munin )
 ACCT_USER_HOME="/var/lib/munin"
-ACCT_USER_HOME_OWNER="munin:munin"
 ACCT_USER_ID=177
 
 acct-user_add_deps

--- a/acct-user/named/named-0-r1.ebuild
+++ b/acct-user/named/named-0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2020 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -9,7 +9,6 @@ DESCRIPTION="User for net-dns/bind"
 
 ACCT_USER_ID=40
 ACCT_USER_HOME=/etc/bind
-ACCT_USER_HOME_OWNER=named:named
 ACCT_USER_GROUPS=( named )
 
 acct-user_add_deps

--- a/acct-user/snapserver/snapserver-0.ebuild
+++ b/acct-user/snapserver/snapserver-0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2020 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,7 +8,6 @@ inherit acct-user
 DESCRIPTION="Server user for media-sound/snapcast"
 
 ACCT_USER_GROUPS=( "snapserver" )
-ACCT_USER_HOME_OWNER="snapserver"
 ACCT_USER_HOME_PERMS=0770
 ACCT_USER_ID=374
 

--- a/acct-user/unifi/unifi-0-r1.ebuild
+++ b/acct-user/unifi/unifi-0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 Gentoo Authors
+# Copyright 2019-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -9,7 +9,6 @@ DESCRIPTION="A user for the UniFi Controller"
 
 ACCT_USER_GROUPS=( "unifi" )
 ACCT_USER_HOME="/var/lib/unifi"
-ACCT_USER_HOME_OWNER="unifi:unifi"
 ACCT_USER_ID="113"
 
 acct-user_add_deps


### PR DESCRIPTION
`acct-user.eclass`'s documentation [says](https://devmanual.gentoo.org/eclass-reference/acct-user.eclass/index.html):
```
ACCT_USER_HOME_OWNER
The ownership to use for the home directory, in chown ([user][:group]) syntax.
Defaults to the newly created user, and its primary group. 
```
```
ACCT_USER_GROUPS (REQUIRED)
List of groups the user should belong to. This must be a bash array.
The first group specified is the user's primary group, while the remaining groups (if any)
become supplementary groups.
```

We have:
```
ACCT_USER_GROUPS=( git )
```

So, is `ACCT_USER_HOME_OWNER` already `"git:git"`, isn't it?

Thanks!