### PR TITLE
verify-sig.eclass: Support accepting "1 out of n" signatures passing

### DIFF
--- a/eclass/verify-sig.eclass
+++ b/eclass/verify-sig.eclass
@@ -146,7 +146,7 @@ verify-sig_verify_detached() {
 			# https://bugs.gentoo.org/854492
 			local -x TMPDIR=/tmp
 			gemato openpgp-verify-detached -K "${key}" \
-				"${extra_args[@]}" \
+				"${extra_args[@]}" --no-require-all-good \
 				"${sig}" "${file}" ||
 				die "PGP signature verification failed"
 			;;

--- a/eclass/verify-sig.eclass
+++ b/eclass/verify-sig.eclass
@@ -65,8 +65,9 @@ case ${VERIFY_SIG_METHOD} in
 		BDEPEND="
 			verify-sig? (
 				app-crypt/gnupg
-				>=app-portage/gemato-16
-			)"
+				>=app-portage/gemato-18.0
+			)
+		"
 		;;
 	signify)
 		BDEPEND="verify-sig? ( app-crypt/signify )"
@@ -144,8 +145,9 @@ verify-sig_verify_detached() {
 			# gpg can't handle very long TMPDIR
 			# https://bugs.gentoo.org/854492
 			local -x TMPDIR=/tmp
-			gemato gpg-wrap -K "${key}" "${extra_args[@]}" -- \
-				gpg --verify "${sig}" "${file}" ||
+			gemato openpgp-verify-detached -K "${key}" \
+				"${extra_args[@]}" \
+				"${sig}" "${file}" ||
 				die "PGP signature verification failed"
 			;;
 		signify)


### PR DESCRIPTION
https://bugs.gentoo.org/873211