### PR TITLE
media-libs/assimp: don't build COLLADA module

### DIFF
--- a/media-libs/assimp/assimp-5.2.5-r1.ebuild
+++ b/media-libs/assimp/assimp-5.2.5-r1.ebuild
@@ -30,6 +30,7 @@ DEPEND="${RDEPEND}"
 PATCHES=(
 	"${FILESDIR}"/${PN}-5.2.5-fix-version.patch
 	"${FILESDIR}"/${PN}-5.2.5-disable-failing-tests.patch
+	"${FILESDIR}"/${PN}-5.2.5-disable-collada-tests.patch
 )
 
 DOCS=( CodeConventions.md Readme.md )
@@ -55,6 +56,9 @@ src_configure() {
 		-DASSIMP_IGNORE_GIT_HASH=ON
 		-DASSIMP_UBSAN=OFF
 		-DASSIMP_WARNINGS_AS_ERRORS=OFF
+		# bug #891787, intentionally not in alphabetic ordering
+		-DASSIMP_BUILD_COLLADA_IMPORTER=OFF
+		-DASSIMP_BUILD_COLLADA_EXPORTER=OFF
 	)
 
 	if use samples; then

--- a/media-libs/assimp/files/assimp-5.2.5-disable-collada-tests.patch
+++ b/media-libs/assimp/files/assimp-5.2.5-disable-collada-tests.patch
@@ -1,0 +1,28 @@
+From 3bd65679f7db2ec95abb22fef7a30a15dcc1c297 Mon Sep 17 00:00:00 2001
+From: Bernd Waibel <waebbl-gentoo@posteo.net>
+Date: Mon, 23 Jan 2023 19:54:23 +0100
+Subject: [PATCH] disable collada tests
+
+Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>
+--- a/test/CMakeLists.txt
++++ b/test/CMakeLists.txt
+@@ -63,7 +63,6 @@ SET( COMMON
+   unit/utSimd.cpp
+   unit/utIOSystem.cpp
+   unit/utIOStreamBuffer.cpp
+-  unit/utIssues.cpp
+   unit/utAnim.cpp
+   unit/AssimpAPITest.cpp
+   unit/AssimpAPITest_aiMatrix3x3.cpp
+@@ -137,8 +136,6 @@ SET( IMPORTERS
+   unit/utBlendImportMaterials.cpp
+   unit/utBlenderWork.cpp
+   unit/utBVHImportExport.cpp
+-  unit/utColladaExport.cpp
+-  unit/utColladaImportExport.cpp
+   unit/utCSMImportExport.cpp
+   unit/utB3DImportExport.cpp
+   #unit/utM3DImportExport.cpp
+-- 
+2.39.1
+


### PR DESCRIPTION
Avoid a security issue when processing COLLADA files. Don't build the module until fixed upstream.
Need to drop additional collada related tests as well.

Bug: https://github.com/assimp/assimp/issues/4286
Bug: https://bugs.gentoo.org/891787
Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>