### PR TITLE
profiles/base/package.use.mask: mask debug USE flag for sci-libs/vtk

### DIFF
--- a/profiles/base/package.use.mask
+++ b/profiles/base/package.use.mask
@@ -6,6 +6,12 @@
 # This file is only for generic masks. For arch-specific masks (i.e.
 # mask everywhere, unmask on arch/*) use arch/base.
 
+# Bernd Waibel <waebbl-gentoo@posteo.net> (2023-01-28)
+# Has some issues building and needs some love first.
+# Bug #891829
+# https://github.com/gentoo/gentoo/pull/29236#issuecomment-1407373536
+sci-libs/vtk debug
+
 # Michał Górny <mgorny@gentoo.org> (2023-01-21)
 # media-libs/libextractor is masked for removal.
 media-plugins/vdr-xineliboutput libextractor


### PR DESCRIPTION
profiles/base/package.use.mask: mask debug USE flag for sci-libs/vtk

The use flag has some issues building, adds an additional layer of
complexity and it's advantage is uncertain.
It needs some love to get the cmake options attached to it right and
see, if some of them need additional guards related to use flags in use.
We might also decide to remove this use flag completely in the future.

Closes: https://bugs.gentoo.org/891829
Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>