### PR TITLE
dev-python/boto: Make dev-python/six a build dependency too

### DIFF
--- a/dev-python/boto/boto-2.49.0-r6.ebuild
+++ b/dev-python/boto/boto-2.49.0-r6.ebuild
@@ -33,6 +33,7 @@ RDEPEND="
 "
 
 BDEPEND="
+	${RDEPEND}
 	test? (
 		dev-python/httpretty[${PYTHON_USEDEP}]
 		dev-python/keyring[${PYTHON_USEDEP}]


### PR DESCRIPTION
The setup.py scripts acquires the version information by importing the boto module, which in turn imports the six module. Since running setup.py happens at a build time and the six module was unbundled (so the code comes now from the dev-python/six package), this means that the six module is also a build-time dependency.

~Avoid it by removing the import and hardcoding the version - we already have this information in the PV variable.~