### PR TITLE
net-vpn/networkmanager-l2tp-1.8.8-r1: revbump for backports

### DIFF
--- a/net-vpn/networkmanager-l2tp/networkmanager-l2tp-1.8.8-r1.ebuild
+++ b/net-vpn/networkmanager-l2tp/networkmanager-l2tp-1.8.8-r1.ebuild
@@ -1,0 +1,69 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+MY_PN="NetworkManager-l2tp"
+MY_P="${MY_PN}-${PV}"
+
+inherit gnome.org
+
+DESCRIPTION="NetworkManager L2TP plugin"
+HOMEPAGE="https://github.com/nm-l2tp/network-manager-l2tp"
+SRC_URI="https://github.com/nm-l2tp/${MY_PN}/releases/download/${PV}/${MY_P}.tar.xz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="gtk"
+
+COMMON_DEPEND="dev-libs/glib:2
+	dev-libs/nspr
+	dev-libs/nss
+	dev-libs/openssl:=
+	net-dialup/ppp:=[eap-tls]
+	net-dialup/xl2tpd
+	>=net-misc/networkmanager-1.8[ppp]
+	|| (
+		net-vpn/strongswan
+		net-vpn/libreswan
+	)
+	gtk? (
+		app-crypt/libsecret
+		gnome-extra/nm-applet
+		media-libs/harfbuzz:=
+		net-libs/libnma
+		x11-libs/cairo
+		x11-libs/gdk-pixbuf:2
+		x11-libs/gtk+:3
+		x11-libs/pango
+	)"
+DEPEND="${COMMON_DEPEND}
+	x11-base/xorg-proto"
+RDEPEND="${COMMON_DEPEND}
+	dev-libs/dbus-glib"
+BDEPEND="dev-util/gdbus-codegen
+	dev-util/intltool
+	sys-devel/gettext
+	virtual/pkgconfig"
+
+S="${WORKDIR}/${MY_P}"
+
+src_configure() {
+	local PPPD_VER=$(best_version net-dialup/ppp)
+	PPPD_VER=${PPPD_VER#*/*-} # reduce it to ${PV}-${PR}
+	PPPD_VER=${PPPD_VER%%[_-]*} # main version without beta/pre/patch/revision
+
+	local myeconfargs=(
+		--localstatedir=/var
+		--with-pppd-plugin-dir=/usr/$(get_libdir)/pppd/${PPPD_VER}
+		$(use_with gtk gnome)
+	)
+
+	econf "${myeconfargs[@]}"
+}
+
+src_install() {
+	default
+	find "${ED}" -name '*.la' -delete || die
+}


### PR DESCRIPTION
Backported:
* fix QA 0303 (b8ce8a793839b5a2c13c785da5c6d727625db3e0),
* rename use flag gnome to gtk (922945c527bf1974135f036f6ada5ef77da854ea),
* remove redundant `src_prepare` (e8d34a8da7e755cad71678c7cf993369ae5b3562),
* fix `BDEPEND` and `RDEPEND` (8160a74439077c8f81527ba52c63637d6ca813a7).

/cc @juippis 