### PR TITLE
dev-python/python-markdown-math: 0.8-r1, bump EAPI8, add Python3.11

### DIFF
--- a/dev-python/python-markdown-math/python-markdown-math-0.8-r1.ebuild
+++ b/dev-python/python-markdown-math/python-markdown-math-0.8-r1.ebuild
@@ -1,0 +1,25 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DISTUTILS_USE_PEP517=setuptools
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
+inherit distutils-r1
+
+DESCRIPTION="Math extension for Python-Markdown"
+HOMEPAGE="
+	https://github.com/mitya57/python-markdown-math/
+	https://pypi.org/project/python-markdown-math/
+"
+SRC_URI="mirror://pypi/${PN::1}/${PN}/${P}.tar.gz"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~amd64 ~riscv ~x86"
+
+RDEPEND="
+	>=dev-python/markdown-3.3.7[${PYTHON_USEDEP}]
+"
+
+distutils_enable_tests unittest


### PR DESCRIPTION
Please make revision bump with addition of Python 3.11 support and EAPI8.
The absence of py3.11 for `compat python-markdown-math` blocks the addition py3.11 compat for several packages from `::guru` overlay.

The tests are passed for `python_targets_python3_11`.