### PR TITLE
sys-apps/hd-idle: systemd units must not use conf.d

### DIFF
--- a/sys-apps/hd-idle/files/hd-idle-dropin.conf
+++ b/sys-apps/hd-idle/files/hd-idle-dropin.conf
@@ -1,0 +1,30 @@
+# Copyright 1999-2023 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+# override settings for hd-idle
+
+# hd-idle command line options
+# Options are:
+#  -a                      Set (partial) device name of disks for subsequent
+#                          idle-time parameters (-i). This parameter is optional
+#                          in the sense that there's a default entry for all
+#                          disks which are not named otherwise by using this
+#                          parameter.
+#  -i <idle_time>          Idle time in seconds.
+#  -l <logfile>            Name of logfile (written only after a disk has spun
+#                          up). Please note that this option might cause the
+#                          disk which holds the logfile to spin up just because
+#                          another disk had some activity. This option should
+#                          not be used on systems with more than one disk
+#                          except for tuning purposes. On single-disk systems,
+#                          this option should not cause any additional spinups.
+#
+# Options not exactly useful here:
+#  -t <disk>               Spin-down the specfified disk immediately and exit.
+#  -d                      Debug mode. This will prevent hd-idle from
+#                          becoming a daemon and print debugging info to
+#                          stdout/stderr
+#  -h                      Print usage information.
+
+# To override, uncomment the following line to override ExecStart:
+#ExecStart=/usr/sbin/hd-idle -i 180 -l /var/log/hd-idle.log

--- a/sys-apps/hd-idle/files/hd-idle.service
+++ b/sys-apps/hd-idle/files/hd-idle.service
@@ -1,0 +1,12 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+[Unit]
+Description=hd-idle - spinning down HDDs after a period of idle time
+Documentation=man:hd-idle(1)
+
+[Service]
+Type=forking
+ExecStart=/usr/sbin/hd-idle -i 180 -l /var/log/hd-idle.log
+
+[Install]
+WantedBy=multi-user.target

--- a/sys-apps/hd-idle/hd-idle-1.05-r2.ebuild
+++ b/sys-apps/hd-idle/hd-idle-1.05-r2.ebuild
@@ -1,0 +1,34 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit linux-info systemd
+
+DESCRIPTION="Utility for spinning down hard disks after a period of idle time"
+HOMEPAGE="https://hd-idle.sourceforge.net/"
+SRC_URI="mirror://sourceforge/${PN}/${P}.tgz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS=""
+
+S="${WORKDIR}/${PN}"
+
+CONFIG_CHECK="~PROC_FS"
+
+DOCS=( debian/changelog README )
+
+src_install() {
+	default
+	systemd_newunit "${FILESDIR}"/hd-idle.service ${PN}.service
+	systemd_install_serviced "${FILESDIR}"/hd-idle-dropin.conf
+	newinitd "${FILESDIR}"/hd-idle-init hd-idle
+	newconfd "${FILESDIR}"/hd-idle-conf hd-idle
+
+	elog "The systemd unit file for hd-idle no longer sources ${EPREFIX}/etc/conf.d/hd-idle ."
+	elog "Configuration is still done via ${EPREFIX}/etc/conf.d/hd-idle for OpenRC systems"
+	elog "while for systemd systems, a systemd drop-in file located at"
+	elog "${EPREFIX}/etc/systemd/system/hd-idle.service.d/00gentoo.conf"
+	elog "is used for configuration."
+}


### PR DESCRIPTION
Add a drop-in file to allow configuration for systemd users and inform about the change via elog.
Also, bump to EAPI 8 and use https for HOMEPAGE.

Closes: https://bugs.gentoo.org/892005
Signed-off-by: Oliver Freyermuth <o.freyermuth@googlemail.com>