### PR TITLE
dev-java/{felix-framework,jol-core}: switch dependency asm:4 -> asm:9

### DIFF
--- a/dev-java/felix-framework/felix-framework-7.0.5-r1.ebuild
+++ b/dev-java/felix-framework/felix-framework-7.0.5-r1.ebuild
@@ -1,8 +1,5 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-
-# Skeleton command:
-# java-ebuilder --generate-ebuild --workdir . --pom pom.xml --download-uri mirror://apache/felix/org.apache.felix.framework-7.0.5-source-release.tar.gz --slot 0 --keywords "~amd64" --ebuild felix-framework-7.0.5.ebuild
 
 EAPI=8
 
@@ -15,6 +12,7 @@ inherit java-pkg-2 java-pkg-simple
 DESCRIPTION="Implementation of the OSGi R8 core framework specification"
 HOMEPAGE="https://felix.apache.org/documentation/subprojects/apache-felix-framework.html"
 SRC_URI="mirror://apache/felix/org.apache.${PN//-/.}-${PV}-source-release.tar.gz -> ${P}.tar.gz"
+S="${WORKDIR}/org.apache.felix.framework-${PV}"
 
 LICENSE="Apache-2.0"
 SLOT="0"
@@ -42,7 +40,7 @@ DEPEND="
 	dev-java/osgi-annotation:0
 	dev-java/felix-resolver:0
 	test? (
-		dev-java/asm:4
+		dev-java/asm:9
 		dev-java/easymock:2.5
 		dev-java/mockito:0
 	)
@@ -52,8 +50,6 @@ RDEPEND="
 	>=virtual/jre-1.8:*
 	${CP_DEPEND}"
 
-S="${WORKDIR}/org.apache.felix.framework-${PV}"
-
 JAVA_CLASSPATH_EXTRA="felix-resolver,osgi-annotation"
 JAVA_SRC_DIR="src/main/java"
 JAVA_RESOURCE_DIRS="src/main/resources"
@@ -62,7 +58,7 @@ JAVA_TEST_GENTOO_CLASSPATH="asm-4,junit-4,easymock-2.5,mockito"
 JAVA_TEST_SRC_DIR="src/test/java"
 
 src_prepare() {
-	default
+	java-pkg-2_src_prepare
 	# 58,91 pom.xml
 	cat > src/main/java/module-info.java <<-EOF
 		$( sed -n '/<moduleInfoSource>/,/<\/moduleInfoSource/p' pom.xml \

--- a/dev-java/jol-core/jol-core-0.16-r1.ebuild
+++ b/dev-java/jol-core/jol-core-0.16-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2022 Gentoo Authors
+# Copyright 2022-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -13,8 +13,8 @@ MY_PN="${PN%-core}"
 MY_P="${MY_PN}-${PV}"
 
 DESCRIPTION="Java Object Layout: Core"
-HOMEPAGE="https://openjdk.java.net/projects/code-tools/jol/"
-SRC_URI="https://github.com/openjdk/jol/archive/refs/tags/${PV}.tar.gz -> jol-${PV}.tar.gz"
+HOMEPAGE="https://openjdk.org/projects/code-tools/jol/"
+SRC_URI="https://github.com/openjdk/jol/archive/${PV}.tar.gz -> jol-${PV}.tar.gz"
 
 LICENSE="GPL-2-with-classpath-exception"
 SLOT="0"
@@ -23,7 +23,7 @@ KEYWORDS="amd64 ~arm arm64 ppc64 x86"
 DEPEND="
 	>=virtual/jdk-1.8:*
 	test? (
-		dev-java/asm:4
+		dev-java/asm:9
 	)
 "
 
@@ -34,12 +34,7 @@ RDEPEND="
 S="${WORKDIR}/${MY_P}"
 
 JAVA_SRC_DIR="${PN}/src/main/java"
-JAVA_RESOURCE_DIRS=( "${PN}/src/main/resources" )
+JAVA_RESOURCE_DIRS="${PN}/src/main/resources"
 
-JAVA_TEST_GENTOO_CLASSPATH="junit-4,asm-4"
-JAVA_TEST_SRC_DIR="${PN}/src/test"
-
-src_install() {
-	java-pkg-simple_src_install
-	einstalldocs # https://bugs.gentoo.org/789582
-}
+JAVA_TEST_GENTOO_CLASSPATH="junit-4,asm-9"
+JAVA_TEST_SRC_DIR="${PN}/src/test/java"


### PR DESCRIPTION
also put java-pkg-2_src_prepare instead of "default" (preparing for bug #780585)

Signed-off-by: Volkmar W. Pogatzki <gentoo@pogatzki.net>