### PR TITLE
dev-libs/rocm-comgr: a better workaround, tests enabling, fix for clang hardened profile, adding maintainer

### DIFF
--- a/dev-libs/rocm-comgr/files/0001-Find-CLANG_RESOURCE_DIR-using-clang-print-resource-d.patch
+++ b/dev-libs/rocm-comgr/files/0001-Find-CLANG_RESOURCE_DIR-using-clang-print-resource-d.patch
@@ -1,0 +1,48 @@
+From 4c210fdf6943c0c40b5fe0f66800c7b9c7ca84d3 Mon Sep 17 00:00:00 2001
+From: Yiyang Wu <xgreenlandforwyy@gmail.com>
+Date: Tue, 14 Jun 2022 20:21:22 +0800
+Subject: [PATCH] Find CLANG_RESOURCE_DIR using clang -print-resource-dir
+
+Suggested-By: https://reviews.llvm.org/D49486
+Signed-off-by: Yiyang Wu <xgreenlandforwyy@gmail.com>
+---
+ lib/comgr/cmake/opencl_pch.cmake | 24 +++---------------------
+ 1 file changed, 3 insertions(+), 21 deletions(-)
+
+diff --git a/lib/comgr/cmake/opencl_pch.cmake b/lib/comgr/cmake/opencl_pch.cmake
+index 95311fc..71050c8 100644
+--- a/cmake/opencl_pch.cmake
++++ b/cmake/opencl_pch.cmake
+@@ -1,26 +1,8 @@
+ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+   find_package(Clang REQUIRED CONFIG)
+-
+-  # FIXME: CLANG_CMAKE_DIR seems like the most stable way to find this, but
+-  # really there is no way to reliably discover this header.
+-  #
+-  # We effectively back up to the Clang output directory (for the case of a build
+-  # tree) or install prefix (for the case of an installed copy), and then search
+-  # for a file named opencl-c.h anywhere below that. We take the first result in
+-  # the case where there are multiple (e.g. if there is an installed copy nested
+-  # in a build directory). This is a bit imprecise, but it covers cases like MSVC
+-  # adding some additional configuration-specific subdirectories to the build
+-  # tree but not to an installed copy.
+-  file(GLOB_RECURSE OPENCL_C_H_LIST "${CLANG_CMAKE_DIR}/../../../*/opencl-c.h")
+-
+-  list(GET OPENCL_C_H_LIST 0 OPENCL_C_H)
+-
+-  if (NOT EXISTS "${OPENCL_C_H}" OR IS_DIRECTORY "${OPENCL_C_H}")
+-    message(FATAL_ERROR "Unable to locate opencl-c.h from the supplied Clang. The path '${CLANG_CMAKE_DIR}/../../../*' was searched.")
+-  endif()
+-else()
+-  get_target_property(clang_build_header_dir clang-resource-headers RUNTIME_OUTPUT_DIRECTORY)
+-  set(OPENCL_C_H "${clang_build_header_dir}/opencl-c.h")
++  execute_process(COMMAND "${CLANG_CMAKE_DIR}/../../../bin/clang" -print-resource-dir OUTPUT_VARIABLE CLANG_RESOURCE_DIR)
++  string(STRIP ${CLANG_RESOURCE_DIR} CLANG_RESOURCE_DIR)
++  set(OPENCL_C_H "${CLANG_RESOURCE_DIR}/include/opencl-c.h")
+ endif()
+ 
+ # Macro to create and install a custom target for generating PCH for given
+-- 
+2.39.0
+

--- a/dev-libs/rocm-comgr/files/0001-Specify-clang-exe-path-in-Driver-Creation.patch
+++ b/dev-libs/rocm-comgr/files/0001-Specify-clang-exe-path-in-Driver-Creation.patch
@@ -1,0 +1,52 @@
+From e0fb8aca856eb61d2f774a0893e2243742eed341 Mon Sep 17 00:00:00 2001
+From: Yiyang Wu <xgreenlandforwyy@gmail.com>
+Date: Fri, 18 Nov 2022 15:41:53 +0800
+Subject: [PATCH] Specify clang exe path in Driver Creation
+
+By doing so, TheDriver can get the correct resource dir.
+
+Closes: #48
+Reference: #49
+---
+ lib/comgr/src/comgr-compiler.cpp | 11 +----------
+ 1 file changed, 1 insertion(+), 10 deletions(-)
+
+diff --git a/lib/comgr/src/comgr-compiler.cpp b/lib/comgr/src/comgr-compiler.cpp
+index 80849d4..67fe82b 100644
+--- a/src/comgr-compiler.cpp
++++ b/src/comgr-compiler.cpp
+@@ -660,7 +660,7 @@ AMDGPUCompiler::executeInProcessDriver(ArrayRef<const char *> Args) {
+   IntrusiveRefCntPtr<DiagnosticIDs> DiagID(new DiagnosticIDs);
+   DiagnosticsEngine Diags(DiagID, &*DiagOpts, DiagClient);
+   ProcessWarningOptions(Diags, *DiagOpts, /*ReportDiags=*/false);
+-  Driver TheDriver("", "", Diags);
++  Driver TheDriver((Twine(env::getLLVMPath()) + "/bin/clang").str(), "", Diags);
+   TheDriver.setTitle("AMDGPU Code Object Manager");
+   TheDriver.setCheckInputsExist(false);
+ 
+@@ -998,11 +998,6 @@ amd_comgr_status_t AMDGPUCompiler::addCompilationFlags() {
+   HIPIncludePath = (Twine(env::getHIPPath()) + "/include").str();
+   // HIP headers depend on hsa.h which is in ROCM_DIR/include.
+   ROCMIncludePath = (Twine(env::getROCMPath()) + "/include").str();
+-  ClangIncludePath =
+-      (Twine(env::getLLVMPath()) + "/lib/clang/" + CLANG_VERSION_STRING).str();
+-  ClangIncludePath2 = (Twine(env::getLLVMPath()) + "/lib/clang/" +
+-                       CLANG_VERSION_STRING + "/include")
+-                          .str();
+ 
+   Args.push_back("-x");
+ 
+@@ -1028,10 +1023,6 @@ amd_comgr_status_t AMDGPUCompiler::addCompilationFlags() {
+     Args.push_back(ROCMIncludePath.c_str());
+     Args.push_back("-isystem");
+     Args.push_back(HIPIncludePath.c_str());
+-    Args.push_back("-isystem");
+-    Args.push_back(ClangIncludePath.c_str());
+-    Args.push_back("-isystem");
+-    Args.push_back(ClangIncludePath2.c_str());
+     break;
+   default:
+     return AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT;
+-- 
+2.39.0
+

--- a/dev-libs/rocm-comgr/files/rocm-comgr-5.3.3-HIPIncludePath-not-needed.patch
+++ b/dev-libs/rocm-comgr/files/rocm-comgr-5.3.3-HIPIncludePath-not-needed.patch
@@ -1,0 +1,15 @@
+ROCM and HIPIncludePath is now /usr, which disturb the include order
+===================================================================
+--- comgr.orig/src/comgr-compiler.cpp
++++ comgr/src/comgr-compiler.cpp
+@@ -1010,10 +1010,6 @@ amd_comgr_status_t AMDGPUCompiler::addCo
+     Args.push_back("x86_64-unknown-linux-gnu");
+     Args.push_back("--cuda-device-only");
+     Args.push_back("-nogpulib");
+-    Args.push_back("-isystem");
+-    Args.push_back(ROCMIncludePath.c_str());
+-    Args.push_back("-isystem");
+-    Args.push_back(HIPIncludePath.c_str());
+     break;
+   default:
+     return AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT;

--- a/dev-libs/rocm-comgr/files/rocm-comgr-5.3.3-fix-tests.patch
+++ b/dev-libs/rocm-comgr/files/rocm-comgr-5.3.3-fix-tests.patch
@@ -1,0 +1,17 @@
+Vanilla LLVM does not support calling AMDGPU_KERNEL across different sources/bitcodes.
+Without this patch https://github.com/RadeonOpenCompute/ROCm-CompilerSupport/issues/45 occurs.
+Reference: https://github.com/llvm/llvm-project/issues/60313
+===================================================================
+--- comgr.orig/test/source1.cl
++++ comgr/test/source1.cl
+@@ -35,7 +35,9 @@
+ 
+ #include "include-a.h"
+ 
++void kernel source3(__global int *j) { *j = FOO; }
++
+ void kernel source1(__global int *j) {
+   *j += 2;
+-  source2(j);
++  source3(j);
+ }

--- a/dev-libs/rocm-comgr/files/rocm-comgr-5.3.3-fno-stack-protecter.patch
+++ b/dev-libs/rocm-comgr/files/rocm-comgr-5.3.3-fno-stack-protecter.patch
@@ -1,0 +1,14 @@
+This add -fno-stack-protector to all compilation, since -f-stack-protector is currently unsupported by ROCm
+Reference: https://bugs.gentoo.org/890377
+index 465187e..0baf925 100644
+--- a/src/comgr-compiler.cpp
++++ b/src/comgr-compiler.cpp
+@@ -850,6 +850,8 @@ amd_comgr_status_t AMDGPUCompiler::processFile(const char *InputFilePath,
+     Argv.push_back(Arg);
+   }
+ 
++  Argv.push_back("-fno-stack-protector");
++
+   for (auto &Option : ActionInfo->getOptions()) {
+     Argv.push_back(Option.c_str());
+     if (Option.rfind("--rocm-path", 0) == 0) {

--- a/dev-libs/rocm-comgr/metadata.xml
+++ b/dev-libs/rocm-comgr/metadata.xml
@@ -5,6 +5,10 @@
         <email>candrews@gentoo.org</email>
         <name>Craig Andrews</name>
     </maintainer>
+    <maintainer type="person" proxied="yes">
+        <email>xgreenlandforwyy@gmail.com</email>
+        <name>Yiyang Wu</name>
+    </maintainer>
     <upstream>
         <remote-id type="github">RadeonOpenCompute/ROCm-CompilerSupport</remote-id>
     </upstream>

--- a/dev-libs/rocm-comgr/rocm-comgr-5.1.3-r3.ebuild
+++ b/dev-libs/rocm-comgr/rocm-comgr-5.1.3-r3.ebuild
@@ -26,6 +26,7 @@ PATCHES=(
 	"${FILESDIR}/0001-COMGR-changes-needed-for-upstream-llvm.patch"
 	"${FILESDIR}/${PN}-5.1.3-llvm-15-remove-zlib-gnu"
 	"${FILESDIR}/${PN}-5.1.3-llvm-15-args-changed"
+	"${FILESDIR}/${PN}-5.3.3-fno-stack-protecter.patch"
 )
 
 DESCRIPTION="Radeon Open Compute Code Object Manager"

--- a/dev-libs/rocm-comgr/rocm-comgr-5.3.3-r1.ebuild
+++ b/dev-libs/rocm-comgr/rocm-comgr-5.3.3-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -18,10 +18,12 @@ else
 fi
 
 PATCHES=(
-	"${FILESDIR}/${PN}-5.1.3-Find-CLANG_RESOURCE_DIR.patch"
 	"${FILESDIR}/${PN}-5.1.3-clang-fix-include.patch"
 	"${FILESDIR}/${PN}-5.1.3-rocm-path.patch"
 	"${FILESDIR}/${PN}-5.1.3-llvm-15-remove-zlib-gnu"
+	"${FILESDIR}/0001-Specify-clang-exe-path-in-Driver-Creation.patch"
+	"${FILESDIR}/0001-Find-CLANG_RESOURCE_DIR-using-clang-print-resource-d.patch"
+	"${FILESDIR}/${PN}-5.3.3-HIPIncludePath-not-needed.patch"
 )
 
 DESCRIPTION="Radeon Open Compute Code Object Manager"
@@ -40,8 +42,6 @@ CMAKE_BUILD_TYPE=Release
 src_prepare() {
 	sed '/sys::path::append(HIPPath/s,"hip","",' -i src/comgr-env.cpp || die
 	sed "/return LLVMPath;/s,LLVMPath,llvm::SmallString<128>(\"$(get_llvm_prefix ${LLVM_MAX_SLOT})\")," -i src/comgr-env.cpp || die
-	sed '/Args.push_back(HIPIncludePath/,+1d' -i src/comgr-compiler.cpp || die
-	sed '/Args.push_back(ROCMIncludePath/,+1d' -i src/comgr-compiler.cpp || die # ROCM and HIPIncludePath is now /usr, which disturb the include order
 	eapply $(prefixify_ro "${FILESDIR}"/${PN}-5.0-rocm_path.patch)
 	cmake_src_prepare
 }
@@ -50,6 +50,7 @@ src_configure() {
 	local mycmakeargs=(
 		-DLLVM_DIR="$(get_llvm_prefix ${LLVM_MAX_SLOT})"
 		-DCMAKE_STRIP=""  # disable stripping defined at lib/comgr/CMakeLists.txt:58
+		-DBUILD_TESTING=$(usex test ON OFF)
 	)
 	cmake_src_configure
 }

--- a/dev-libs/rocm-comgr/rocm-comgr-5.3.3-r1.ebuild
+++ b/dev-libs/rocm-comgr/rocm-comgr-5.3.3-r1.ebuild
@@ -17,6 +17,9 @@ else
 	KEYWORDS="~amd64"
 fi
 
+IUSE="test"
+RESTRICT="!test? ( test )"
+
 PATCHES=(
 	"${FILESDIR}/${PN}-5.1.3-clang-fix-include.patch"
 	"${FILESDIR}/${PN}-5.1.3-rocm-path.patch"
@@ -24,6 +27,7 @@ PATCHES=(
 	"${FILESDIR}/0001-Specify-clang-exe-path-in-Driver-Creation.patch"
 	"${FILESDIR}/0001-Find-CLANG_RESOURCE_DIR-using-clang-print-resource-d.patch"
 	"${FILESDIR}/${PN}-5.3.3-HIPIncludePath-not-needed.patch"
+	"${FILESDIR}/${PN}-5.3.3-fix-tests.patch"
 )
 
 DESCRIPTION="Radeon Open Compute Code Object Manager"

--- a/dev-libs/rocm-comgr/rocm-comgr-5.3.3-r1.ebuild
+++ b/dev-libs/rocm-comgr/rocm-comgr-5.3.3-r1.ebuild
@@ -28,6 +28,7 @@ PATCHES=(
 	"${FILESDIR}/0001-Find-CLANG_RESOURCE_DIR-using-clang-print-resource-d.patch"
 	"${FILESDIR}/${PN}-5.3.3-HIPIncludePath-not-needed.patch"
 	"${FILESDIR}/${PN}-5.3.3-fix-tests.patch"
+	"${FILESDIR}/${PN}-5.3.3-fno-stack-protecter.patch"
 )
 
 DESCRIPTION="Radeon Open Compute Code Object Manager"


### PR DESCRIPTION
4 commits are: 
1. a better fix for clang include dir search
2. enable tests, and fix failed test suites
3. add myself as maintainer, because now all remained rocm-comgr ebuilds and patches are mainly contributed via my PR
4. Add `-fno-stack-protector`, Closes: https://bugs.gentoo.org/892371