### PR TITLE
dev-libs/rocr-runtime: disable non-FHS install & NDEBUG by default

### DIFF
--- a/dev-libs/rocr-runtime/rocr-runtime-5.3.3-r1.ebuild
+++ b/dev-libs/rocr-runtime/rocr-runtime-5.3.3-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit cmake llvm
+inherit cmake flag-o-matic llvm
 
 LLVM_MAX_SLOT=15
 
@@ -25,6 +25,7 @@ PATCHES=(
 
 LICENSE="MIT"
 SLOT="0/$(ver_cut 1-2)"
+IUSE="debug"
 
 COMMON_DEPEND="dev-libs/elfutils"
 RDEPEND="${COMMON_DEPEND}"
@@ -35,8 +36,6 @@ DEPEND="${COMMON_DEPEND}
 	sys-devel/lld"
 BDEPEND="app-editors/vim-core"
 	# vim-core is needed for "xxd"
-
-CMAKE_BUILD_TYPE=Release
 
 src_prepare() {
 	# ... otherwise system llvm/clang is used ...
@@ -49,6 +48,7 @@ src_prepare() {
 }
 
 src_configure() {
+	use debug || append-cxxflags "-DNDEBUG"
 	local mycmakeargs=( -DINCLUDE_PATH_COMPATIBILITY=OFF )
 	cmake_src_configure
 }

--- a/dev-libs/rocr-runtime/rocr-runtime-5.3.3.ebuild
+++ b/dev-libs/rocr-runtime/rocr-runtime-5.3.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -46,4 +46,9 @@ src_prepare() {
 	sed -e "s:-O2:--rocm-path=${EPREFIX}/usr/lib/ -O2:" -i image/blit_src/CMakeLists.txt || die
 
 	cmake_src_prepare
+}
+
+src_configure() {
+	local mycmakeargs=( -DINCLUDE_PATH_COMPATIBILITY=OFF )
+	cmake_src_configure
 }


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/887377
Signed-off-by: Yiyang Wu <xgreenlandforwyy@gmail.com>