### PR TITLE
dev-libs/opencl-icd-loader: prefixify ICD_VENDOR_PATH

### DIFF
--- a/dev-libs/opencl-icd-loader/opencl-icd-loader-2022.09.30-r1.ebuild
+++ b/dev-libs/opencl-icd-loader/opencl-icd-loader-2022.09.30-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit cmake-multilib
+inherit cmake-multilib prefix
 
 MY_PN="OpenCL-ICD-Loader"
 MY_P="${MY_PN}-${PV}"
@@ -24,6 +24,11 @@ DEPEND="${RDEPEND}
 	>=dev-util/opencl-headers-${PV}"
 
 S="${WORKDIR}/${MY_P}"
+
+src_prepare() {
+	hprefixify loader/icd_platform.h
+	cmake_src_prepare
+}
 
 multilib_src_configure() {
 	local mycmakeargs=(


### PR DESCRIPTION
This fixes opencl cannot find icds in Gentoo prefix, where it is located at ${EPREFIX}/etc/OpenCL/vendors

Signed-off-by: Yiyang Wu <xgreenlandforwyy@gmail.com>