### PR TITLE
rocm.eclass: support RDNA3 GPU for >=5.4, remove <5

### DIFF
--- a/eclass/rocm.eclass
+++ b/eclass/rocm.eclass
@@ -1,4 +1,4 @@
-# Copyright 2022 Gentoo Authors
+# Copyright 2022-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: rocm.eclass
@@ -138,17 +138,18 @@ _rocm_set_globals() {
 	# may help. Gentoo have patches to enable gfx1031 as well.
 	local unofficial_amdgpu_targets official_amdgpu_targets
 	case ${ROCM_VERSION} in
-		4.*)
-			unofficial_amdgpu_targets=(
-				gfx803 gfx900 gfx1010 gfx1011 gfx1012 gfx1030
-			)
-			official_amdgpu_targets=(
-				gfx906 gfx908
-			)
-			;;
-		5.*)
+		5.[0-3].*)
 			unofficial_amdgpu_targets=(
 				gfx803 gfx900 gfx1010 gfx1011 gfx1012 gfx1031
+			)
+			official_amdgpu_targets=(
+				gfx906 gfx908 gfx90a gfx1030
+			)
+			;;
+		5.*|9999)
+			unofficial_amdgpu_targets=(
+				gfx803 gfx900 gfx1010 gfx1011 gfx1012
+				gfx1031 gfx1100 gfx1101 gfx1102
 			)
 			official_amdgpu_targets=(
 				gfx906 gfx908 gfx90a gfx1030

--- a/profiles/desc/amdgpu_targets.desc
+++ b/profiles/desc/amdgpu_targets.desc
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors.
+# Copyright 1999-2023 Gentoo Authors.
 # Distributed under the terms of the GNU General Public License v2
 
 # Reference:
@@ -15,3 +15,6 @@ gfx1011 - RDNA GPU, codename navi12, including Radeon Pro 5600M/V520
 gfx1012 - RDNA GPU, codename navi14, including Radeon RX 5500XT/5500/5500M/5500XTB/5300/5300M, Radeon Pro 5500XT/5500M/5300/5300M, Radeon Pro W5500X/W5500/W5500M/W5300M
 gfx1030 - RDNA2 GPU, codename navi21/sienna cichlid, including Radeon RX 6950XT/6900XT/6800XT/6800, Radeon Pro W6800
 gfx1031 - RDNA2 GPU, codename navi22/navy flounder, including Radeon RX 6750XT/6700XT/6800M/6700M
+gfx1100 - RDNA3 GPU, codename navi31/plum bonito, including Radeon RX 7900XTX/7900XT
+gfx1101 - RDNA3 GPU, codename navi32
+gfx1102 - RDNA3 GPU, codename navi33


### PR DESCRIPTION
ROCm libraries with version <5 are cleaned up, remove version 4 support for rocm.eclass.

RDNA3 has initial support in ROCm libraries starting from 5.4 releases. Enable gfx110* amdgpu_targets in rocm.eclass and add corresponding description.

Tried =sci-libs/rocBLAS-5.4.2, can compile successfully with amdgpu_targets_gfx1100 (but not tested on real GPU). rocBLAS-5.4.2.ebuild is in https://github.com/gentoo/gentoo/pull/29319

Closes: https://bugs.gentoo.org/891499
Signed-off-by: Yiyang Wu <xgreenlandforwyy@gmail.com>