### PR TITLE
gnome-extra/krb5-auth-dialog: add missing USE to dep

### DIFF
--- a/gnome-extra/krb5-auth-dialog/krb5-auth-dialog-43.0-r1.ebuild
+++ b/gnome-extra/krb5-auth-dialog/krb5-auth-dialog-43.0-r1.ebuild
@@ -14,7 +14,7 @@ SLOT="0"
 KEYWORDS="~amd64"
 
 RDEPEND="
-	app-crypt/gcr:=
+	app-crypt/gcr:0=[gtk]
 	dev-libs/glib:2
 	sys-libs/pam
 	x11-libs/gtk+:3


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/890290
Signed-off-by: Henning Schild <henning@hennsch.de>