### PR TITLE
sci-libs/vtk: fix build with gcc-13

### DIFF
--- a/sci-libs/vtk/files/vtk-9.2.5-Add-include-cstdint-for-gcc-13.patch
+++ b/sci-libs/vtk/files/vtk-9.2.5-Add-include-cstdint-for-gcc-13.patch
@@ -1,0 +1,20 @@
+From 69351f357a82c0bb7f97f4f707962de3400760a8 Mon Sep 17 00:00:00 2001
+From: Bernd Waibel <waebbl-gentoo@posteo.net>
+Date: Sun, 29 Jan 2023 12:17:36 +0100
+Subject: [PATCH] Add #include <cstdint> for gcc-13
+
+Bug: https://gitlab.kitware.com/vtk/vtk/-/issues/18782
+Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>
+--- a/Rendering/Matplotlib/vtkMatplotlibMathTextUtilities.h
++++ b/Rendering/Matplotlib/vtkMatplotlibMathTextUtilities.h
+@@ -50,6 +50,7 @@
+ #include "vtkRenderingMatplotlibModule.h" // For export macro
+ 
+ #include <vector> // for std::vector
++#include <cstdint> // for std::uint64_t
+ 
+ struct _object;
+ typedef struct _object PyObject;
+-- 
+2.39.1
+

--- a/sci-libs/vtk/files/vtk-9.2.5-Add-include-cstdint-to-compile-with-gcc-13.patch
+++ b/sci-libs/vtk/files/vtk-9.2.5-Add-include-cstdint-to-compile-with-gcc-13.patch
@@ -1,0 +1,30 @@
+https://gitlab.kitware.com/vtk/vtk/-/merge-requests/9857
+
+From ef95422b62296e4c136917095eace14f48cefb82 Mon Sep 17 00:00:00 2001
+From: Laurent Rineau <laurent.rineau@cgal.org>
+Date: Tue, 17 Jan 2023 16:18:53 +0100
+Subject: [PATCH] Add #include <cstdint> to compile with gcc13
+
+The `vtkSEPReader` was introduced by MRs !4909 (from my former
+collaborator Maxime) and !4938. Then it was highly modified by
+!7516. The later MR is the one that introduced the uses of
+`std::uint8_t` and `std::uint32_t`.
+
+Those types needs the inclusion of `<cstdint>`.
+--- a/IO/Image/vtkSEPReader.h
++++ b/IO/Image/vtkSEPReader.h
+@@ -25,8 +25,9 @@
+ #include "vtkImageAlgorithm.h"
+ #include "vtkNew.h" // for ivars
+ 
+-#include <array>  // for std::array
+-#include <string> // for std::string
++#include <array>   // for std::array
++#include <cstdint> // for std::uint8_t and std::uint32_t
++#include <string>  // for std::string
+ 
+ namespace details
+ {
+-- 
+GitLab
+

--- a/sci-libs/vtk/vtk-9.2.5.ebuild
+++ b/sci-libs/vtk/vtk-9.2.5.ebuild
@@ -161,6 +161,8 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-9.2.2-vtkGeometryFilter-add-missing-mutex-header-file.patch
 	"${FILESDIR}"/${PN}-9.2.2-VTKm-respect-user-CXXFLAGS.patch
 	"${FILESDIR}"/${PN}-9.2.2-link-with-glut-library-for-freeglut.patch
+	"${FILESDIR}"/${PN}-9.2.5-Add-include-cstdint-to-compile-with-gcc-13.patch
+	"${FILESDIR}"/${PN}-9.2.5-Add-include-cstdint-for-gcc-13.patch
 )
 
 DOCS=( CONTRIBUTING.md README.md )


### PR DESCRIPTION
Add #include <cstdint> to build with gcc-13

Closes: https://bugs.gentoo.org/892435
Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>