### PR TITLE
dev-python/gentoo-common: add 1, drop 0

### DIFF
--- a/dev-python/gentoo-common/gentoo-common-1.ebuild
+++ b/dev-python/gentoo-common/gentoo-common-1.ebuild
@@ -26,5 +26,12 @@ src_install() {
 		   python -m venv /path/to/venv
 		   . /path/to/venv/bin/activate
 		   pip install mypackage
+
+		 To exit the virtual environment, run:
+
+		   deactivate
+
+		 The virtual environment is not deleted, and can be re-entered by
+		 re-sourcing the activate file.
 	EOF
 }


### PR DESCRIPTION
Add info on exiting and re-entering the venv.

Signed-off-by: Oskari Pirhonen <xxc3ncoredxx@gmail.com>