### PR TITLE
app-*/*: various metadata fixes and improvements

### DIFF
--- a/app-accessibility/powiedz/metadata.xml
+++ b/app-accessibility/powiedz/metadata.xml
@@ -5,7 +5,7 @@
     <email>accessibility@gentoo.org</email>
     <name>Gentoo Accessibility Project</name>
   </maintainer>
-<maintainer type="project">
+  <maintainer type="project">
     <email>sound@gentoo.org</email>
     <name>Gentoo Sound project</name>
   </maintainer>

--- a/app-accessibility/speechd-el/metadata.xml
+++ b/app-accessibility/speechd-el/metadata.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
 <maintainer type="person">
-<email>williamh@gentoo.org</email>
+  <email>williamh@gentoo.org</email>
 </maintainer>
 <maintainer type="project">
   <email>accessibility@gentoo.org</email>

--- a/app-admin/multilog-watch/metadata.xml
+++ b/app-admin/multilog-watch/metadata.xml
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<!-- maintainer-needed -->
-<longdescription lang="en">This program reads logs written by multilog (part of the
-daemontools package by Dan Bernstein), discards any lines matching regular
-expressions in its configuration file, and mails the rest to a configured e-mail
-address. The e-mail is sent using qmail-remote directly, which requires qmail be
-installed on the system but which allows multilog-watch to send mail even if the
-local mail system is down.</longdescription>
+	<!-- maintainer-needed -->
+	<longdescription lang="en">
+		This program reads logs written by multilog (part of the
+		daemontools package by Dan Bernstein), discards any lines matching regular
+		expressions in its configuration file, and mails the rest to a configured e-mail
+		address. The e-mail is sent using qmail-remote directly, which requires qmail be
+		installed on the system but which allows multilog-watch to send mail even if the
+		local mail system is down.
+	</longdescription>
 </pkgmetadata>

--- a/app-admin/yadm/metadata.xml
+++ b/app-admin/yadm/metadata.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<!-- maintainer-needed -->
+	<!-- maintainer-needed -->
 	<upstream>
 		<remote-id type="github">TheLocehiliosan/yadm</remote-id>
 	</upstream>

--- a/app-arch/gzip/metadata.xml
+++ b/app-arch/gzip/metadata.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<maintainer type="project">
- <email>base-system@gentoo.org</email>
- <name>Gentoo Base System</name>
-</maintainer>
-<upstream>
- <remote-id type="cpe">cpe:/a:gnu:gzip</remote-id>
-</upstream>
-<use>
-<flag name="pic">disable optimized assembly code that is not PIC friendly</flag>
-</use>
+	<maintainer type="project">
+		<email>base-system@gentoo.org</email>
+		<name>Gentoo Base System</name>
+	</maintainer>
+	<upstream>
+		<remote-id type="cpe">cpe:/a:gnu:gzip</remote-id>
+	</upstream>
+	<use>
+		<flag name="pic">disable optimized assembly code that is not PIC friendly</flag>
+	</use>
 </pkgmetadata>

--- a/app-arch/hardlink/metadata.xml
+++ b/app-arch/hardlink/metadata.xml
@@ -5,7 +5,7 @@
 		<email>robbat2@gentoo.org</email>
 		<name>Robin H. Johnson</name>
 	</maintainer>
-<maintainer type="project">
+	<maintainer type="project">
 		<email>shell-tools@gentoo.org</email>
 		<name>Gentoo Shell Tools Project</name>
 	</maintainer>

--- a/app-arch/unp/metadata.xml
+++ b/app-arch/unp/metadata.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<maintainer type="person"><email>hanno@gentoo.org</email></maintainer>
+	<maintainer type="person">
+		<email>hanno@gentoo.org</email>
+	</maintainer>
 </pkgmetadata>

--- a/app-backup/pdumpfs/metadata.xml
+++ b/app-backup/pdumpfs/metadata.xml
@@ -9,10 +9,10 @@
 		<email>proxy-maint@gentoo.org</email>
 		<name>Proxy Maintainers</name>
 	</maintainer>
-<longdescription>
-pdumpfs is a simple daily backup system similar to Plan9's dumpfs which
-preserves every daily snapshot. pdumpfs is written in Ruby. You can access
-the past snapshots at any time for retrieving a certain day's file. Let's
-backup your home directory with pdumpfs!
-</longdescription>
+	<longdescription>
+		pdumpfs is a simple daily backup system similar to Plan9's dumpfs which
+		preserves every daily snapshot. pdumpfs is written in Ruby. You can access
+		the past snapshots at any time for retrieving a certain day's file. Let's
+		backup your home directory with pdumpfs!
+	</longdescription>
 </pkgmetadata>

--- a/app-cdr/burncdda/metadata.xml
+++ b/app-cdr/burncdda/metadata.xml
@@ -2,11 +2,11 @@
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
 	<!-- maintainer-needed -->
-<longdescription>
-	burnCDDA is a console frontend to cdrdao, cdrecord, mpg123, oggdec, mppdec,
-	flac, normalize, and mp3_check. It can be used to create audio CDs from an
-	M3U playlist (the playlist format of XMMS and amaroK). It supports MP3, OGG
-	Vorbis, Musepack, FLAC, and WAV files, and it might be the easiest way to
-	copy an audio CD.
-</longdescription>
+	<longdescription>
+		burnCDDA is a console frontend to cdrdao, cdrecord, mpg123, oggdec, mppdec,
+		flac, normalize, and mp3_check. It can be used to create audio CDs from an
+		M3U playlist (the playlist format of XMMS and amaroK). It supports MP3, OGG
+		Vorbis, Musepack, FLAC, and WAV files, and it might be the easiest way to
+		copy an audio CD.
+	</longdescription>
 </pkgmetadata>

--- a/app-cdr/xcdroast/metadata.xml
+++ b/app-cdr/xcdroast/metadata.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<!-- maintainer-needed -->
+	<!-- maintainer-needed -->
 	<upstream>
 		<remote-id type="sourceforge">xcdroast</remote-id>
 	</upstream>

--- a/app-containers/grype/metadata.xml
+++ b/app-containers/grype/metadata.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<maintainer type="person">
-<email>williamh@gentoo.org</email>
-<name>William Hubbs</name>
-</maintainer>
+	<maintainer type="person">
+		<email>williamh@gentoo.org</email>
+		<name>William Hubbs</name>
+	</maintainer>
 </pkgmetadata>

--- a/app-containers/syft/metadata.xml
+++ b/app-containers/syft/metadata.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<maintainer type="person">
-<email>williamh@gentoo.org</email>
-<name>William Hubbs</name>
-</maintainer>
-<upstream>
-<remote-id type="github">anchore/syft</remote-id>
-</upstream>
+	<maintainer type="person">
+		<email>williamh@gentoo.org</email>
+		<name>William Hubbs</name>
+	</maintainer>
+	<upstream>
+		<remote-id type="github">anchore/syft</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/app-crypt/easy-rsa/metadata.xml
+++ b/app-crypt/easy-rsa/metadata.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<!-- maintainer-needed -->
-<upstream>
-	<remote-id type="github">OpenVPN/easy-rsa</remote-id>
-</upstream>
+	<!-- maintainer-needed -->
+	<upstream>
+		<remote-id type="github">OpenVPN/easy-rsa</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/app-crypt/mhash/metadata.xml
+++ b/app-crypt/mhash/metadata.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
 	<!-- maintainer-needed -->
-<upstream>
-	<remote-id type="sourceforge">mhash</remote-id>
+	<upstream>
+		<remote-id type="sourceforge">mhash</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/app-doc/cantera-docs/metadata.xml
+++ b/app-doc/cantera-docs/metadata.xml
@@ -10,8 +10,8 @@
     <name>Proxy Maintainers</name>
   </maintainer>
   <stabilize-allarches/>
-<longdescription lang="en">
-Cantera Doxygen API Documentation for C++ library
-and Sphinx API Documentation for CTI tool, Python module and Matlab interface.
-</longdescription>
+  <longdescription lang="en">
+    Cantera Doxygen API Documentation for C++ library
+    and Sphinx API Documentation for CTI tool, Python module and Matlab interface.
+  </longdescription>
 </pkgmetadata>

--- a/app-doc/psmark/metadata.xml
+++ b/app-doc/psmark/metadata.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<!-- maintainer-needed -->
-<longdescription>Command-line Postscript watermark tool; simple, but useful 
-for things like adding a watermark to outgoing or incoming faxes (eg, use 
-with the sendfax command from net-misc/hylafax).
-</longdescription>
+	<!-- maintainer-needed -->
+	<longdescription>
+		Command-line Postscript watermark tool; simple, but useful for things
+		like adding a watermark to outgoing or incoming faxes (eg, use with the
+		sendfax command from net-misc/hylafax).
+	</longdescription>
 </pkgmetadata>

--- a/app-editors/joe/metadata.xml
+++ b/app-editors/joe/metadata.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
 <maintainer type="person">
-            <email>amynka@gentoo.org</email>
+  <email>amynka@gentoo.org</email>
 </maintainer>
 <maintainer type="project">
   <email>emacs@gentoo.org</email>

--- a/app-emulation/crossover-bin/metadata.xml
+++ b/app-emulation/crossover-bin/metadata.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<maintainer type="person">
-	<email>pacho@gentoo.org</email>
-	<name>Pacho Ramos</name>
-</maintainer>
+	<maintainer type="person">
+		<email>pacho@gentoo.org</email>
+		<name>Pacho Ramos</name>
+	</maintainer>
 	<use>
 		<flag name="capi">Enable ISDN support via CAPI</flag>
 		<flag name="osmesa">Add support for OpenGL in bitmaps using libOSMesa</flag>

--- a/app-emulation/libguestfs-appliance/metadata.xml
+++ b/app-emulation/libguestfs-appliance/metadata.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<!-- maintainer-needed -->
-<!--
-<maintainer type="person">
-	<email>rich@annexia.org</email>
-	<name>Richard Jones</name>
-	<description>Upstream - please CC on bugs that concerns upstream</description>
-</maintainer>
--->
+	<!-- maintainer-needed -->
+	<upstream>
+		<maintainer>
+			<email>rjones@redhat.com</email>
+			<name>Richard Jones</name>
+		</maintainer>
+	</upstream>
 </pkgmetadata>

--- a/app-emulation/virtualbox/metadata.xml
+++ b/app-emulation/virtualbox/metadata.xml
@@ -6,13 +6,13 @@
     <name>Viorel Munteanu</name>
   </maintainer>
   <use>
-  <flag name="dtrace">Install dtrace Extension Pack</flag>
-  <flag name="headless">Build without any graphic frontend</flag>
-  <flag name="lvm">Build VBoxVolInfo that needs devicemapper from <pkg>sys-fs/lvm2</pkg>.</flag>
-  <flag name="pax-kernel">Apply patch needed for pax enabled kernels.</flag>
-  <flag name="sdk">Enable building of SDK</flag>
-  <flag name="udev">Controls installation of special USB udev rules.</flag>
-  <flag name="vboxwebsrv">Build and install the VirtualBox webservice</flag>
-  <flag name="vde">Support for VDE networking via <pkg>net-misc/vde</pkg></flag>
-</use>
+    <flag name="dtrace">Install dtrace Extension Pack</flag>
+    <flag name="headless">Build without any graphic frontend</flag>
+    <flag name="lvm">Build VBoxVolInfo that needs devicemapper from <pkg>sys-fs/lvm2</pkg>.</flag>
+    <flag name="pax-kernel">Apply patch needed for pax enabled kernels.</flag>
+    <flag name="sdk">Enable building of SDK</flag>
+    <flag name="udev">Controls installation of special USB udev rules.</flag>
+    <flag name="vboxwebsrv">Build and install the VirtualBox webservice</flag>
+    <flag name="vde">Support for VDE networking via <pkg>net-misc/vde</pkg></flag>
+  </use>
 </pkgmetadata>

--- a/app-misc/freewvs/metadata.xml
+++ b/app-misc/freewvs/metadata.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<maintainer type="person"><email>hanno@gentoo.org</email></maintainer>
+	<maintainer type="person">
+		<email>hanno@gentoo.org</email>
+	</maintainer>
 </pkgmetadata>

--- a/app-misc/jail/metadata.xml
+++ b/app-misc/jail/metadata.xml
@@ -1,15 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<!-- maintainer-needed -->
+	<!-- maintainer-needed -->
 	<upstream>
 		<remote-id type="github">spiculator/jail</remote-id>
 		<bugs-to>https://github.com/spiculator/jail/issues</bugs-to>
 	</upstream>
 	<longdescription>
-Jail Chroot Project is an attempt of write a tool that builds a chrooted environment.
-The main goal of Jail is to be as simple as possible, and highly portable. The most
-difficult step when building a chrooted environment is to set up the right libraries and
-files. Here, Jail comes to the rescue with a tool to automagically configures and builds
-all the required files, directories and libraries.</longdescription>
+		Jail Chroot Project is an attempt of write a tool that builds a chrooted environment.
+		The main goal of Jail is to be as simple as possible, and highly portable. The most
+		difficult step when building a chrooted environment is to set up the right libraries and
+		files. Here, Jail comes to the rescue with a tool to automagically configures and builds
+		all the required files, directories and libraries.
+	</longdescription>
 </pkgmetadata>

--- a/app-misc/oneko/metadata.xml
+++ b/app-misc/oneko/metadata.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<!-- maintainer-needed -->
-<longdescription lang="en">
-"oneko-sakura" is modified version of oneko. KINOMOTO Sakura chases around your
-mouse cursor.
-To stop the program, run this command:
-	killall oneko
-If your mouse cursor changes to the default black cross after running oneko,
-you should install <pkg>x11-apps/xsetroot</pkg> and run:
-	xsetroot -cursor_name left_ptr
-</longdescription>
+	<!-- maintainer-needed -->
+	<longdescription lang="en">
+		"oneko-sakura" is modified version of oneko. KINOMOTO Sakura chases around your
+		mouse cursor.
+		To stop the program, run this command:
+			killall oneko
+		If your mouse cursor changes to the default black cross after running oneko,
+		you should install <pkg>x11-apps/xsetroot</pkg> and run:
+			xsetroot -cursor_name left_ptr
+	</longdescription>
 </pkgmetadata>

--- a/app-misc/pal/metadata.xml
+++ b/app-misc/pal/metadata.xml
@@ -2,11 +2,11 @@
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
 	<!-- maintainer-needed -->
-<longdescription>
-	pal is a command-line calendar program for Unix/Linux systems that can keep
-	track of events. It has similarities with the Unix cal command, the more
-	complex GNU gcal program and the calendar program distributed with the BSDs.
-</longdescription>
+	<longdescription>
+		pal is a command-line calendar program for Unix/Linux systems that can keep
+		track of events. It has similarities with the Unix cal command, the more
+		complex GNU gcal program and the calendar program distributed with the BSDs.
+	</longdescription>
 	<upstream>
 		<remote-id type="sourceforge">palcal</remote-id>
 	</upstream>

--- a/app-misc/vit/metadata.xml
+++ b/app-misc/vit/metadata.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<!-- maintainer-needed -->
-<longdescription lang="en">
-  A perl/Curses front end for Taskwarrior (<pkg>app-misc/task</pkg>) that
-  provides a fullscreen terminal window with modes and commands
-  modeled after the vi editor.
-</longdescription>
+  <!-- maintainer-needed -->
+  <longdescription lang="en">
+    A perl/Curses front end for Taskwarrior (<pkg>app-misc/task</pkg>) that
+    provides a fullscreen terminal window with modes and commands
+    modeled after the vi editor.
+  </longdescription>
   <upstream>
     <remote-id type="github">scottkosty/vit</remote-id>
   </upstream>

--- a/app-misc/vittk/metadata.xml
+++ b/app-misc/vittk/metadata.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<!-- maintainer-needed -->
-<longdescription lang="en">
-	A comprehensive front end for Taskwarrior (<pkg>app-misc/task</pkg>) that
-	provides a fullscreen emulated terminal window with modes and commands
-	modeled after the vi editor.
-</longdescription>
+	<!-- maintainer-needed -->
+	<longdescription lang="en">
+		A comprehensive front end for Taskwarrior (<pkg>app-misc/task</pkg>) that
+		provides a fullscreen emulated terminal window with modes and commands
+		modeled after the vi editor.
+	</longdescription>
 </pkgmetadata>

--- a/app-mobilephone/gnokii/metadata.xml
+++ b/app-mobilephone/gnokii/metadata.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<!-- maintainer-needed -->
-<longdescription>
-gnokii provides tools and a user space driver for use with mobile phones.
-With gnokii you can do such things as make data calls, update your address book, 
-change calendar entires, send and receive SMS messages and load ring tones 
-depending on the phone you have.
-</longdescription>
-<use>
-  <flag name="ical">Enable support for <pkg>dev-libs/libical</pkg></flag>
-  <flag name="irda">Enable infrared support</flag>
-  <flag name="sms">Enable SMS support (build smsd)</flag>
-  <flag name="pcsc-lite">Enable smartcard support with <pkg>sys-apps/pcsc-lite</pkg></flag>
-</use>
+  <!-- maintainer-needed -->
+  <longdescription>
+    gnokii provides tools and a user space driver for use with mobile phones.
+    With gnokii you can do such things as make data calls, update your address book,
+    change calendar entires, send and receive SMS messages and load ring tones
+    depending on the phone you have.
+  </longdescription>
+  <use>
+    <flag name="ical">Enable support for <pkg>dev-libs/libical</pkg></flag>
+    <flag name="irda">Enable infrared support</flag>
+    <flag name="sms">Enable SMS support (build smsd)</flag>
+    <flag name="pcsc-lite">Enable smartcard support with <pkg>sys-apps/pcsc-lite</pkg></flag>
+  </use>
 </pkgmetadata>

--- a/app-office/calcurse/metadata.xml
+++ b/app-office/calcurse/metadata.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<!-- maintainer-needed -->
-<longdescription>Calcurse is a text-based personal organizer which helps keeping
-track of events and everyday tasks. It contains a calendar, a 'todo' list, and
-puts your appointments in order. The user interface is configurable, and one can
-choose between different color schemes and layouts. All of the commands are
-documented within an online help system.</longdescription>
+	<!-- maintainer-needed -->
+	<longdescription>
+		Calcurse is a text-based personal organizer which helps keeping track of
+		events and everyday tasks. It contains a calendar, a 'todo' list, and
+		puts your appointments in order. The user interface is configurable, and
+		one can choose between different color schemes and layouts. All of the
+		commands are documented within an online help system.
+	</longdescription>
 </pkgmetadata>

--- a/app-office/libreoffice-bin/metadata.xml
+++ b/app-office/libreoffice-bin/metadata.xml
@@ -1,11 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer type="person"><email>dilfridge@gentoo.org</email></maintainer>
-	<maintainer type="project">
-<email>office@gentoo.org</email>
-<name>Gentoo Office project</name>
+	<maintainer type="person">
+		<email>dilfridge@gentoo.org</email>
 	</maintainer>
-	<longdescription>LibreOffice is a free office suite.
-This is the binary version of Libreoffice. Use this if you don't want to wait for the source version to build.</longdescription>
+	<maintainer type="project">
+		<email>office@gentoo.org</email>
+		<name>Gentoo Office project</name>
+	</maintainer>
+	<longdescription>
+		LibreOffice is a free office suite. This is the binary version of
+		Libreoffice. Use this if you don't want to wait for the source version
+		to build.
+	</longdescription>
 </pkgmetadata>

--- a/app-pda/jpilot/metadata.xml
+++ b/app-pda/jpilot/metadata.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<!-- maintainer-needed -->
+	<!-- maintainer-needed -->
 	<upstream>
 		<maintainer status="active">
 			<email>judd@engineer.com</email>

--- a/app-portage/genlop/metadata.xml
+++ b/app-portage/genlop/metadata.xml
@@ -5,7 +5,7 @@
 		<email>tools-portage@gentoo.org</email>
 		<name>Gentoo Portage tools team</name>
 	</maintainer>
-<maintainer type="project">
+	<maintainer type="project">
 		<email>perl@gentoo.org</email>
 		<name>Gentoo Perl Project</name>
 	</maintainer>

--- a/app-shells/shish/metadata.xml
+++ b/app-shells/shish/metadata.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<!-- maintainer-needed -->
-<use>
-  <flag name="diet">Use <pkg>dev-libs/dietlibc</pkg></flag>
-</use>
+	<!-- maintainer-needed -->
+	<use>
+		<flag name="diet">Use <pkg>dev-libs/dietlibc</pkg></flag>
+	</use>
 </pkgmetadata>

--- a/app-text/aiksaurus/metadata.xml
+++ b/app-text/aiksaurus/metadata.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<!-- maintainer-needed -->
+	<!-- maintainer-needed -->
 	<upstream>
 		<remote-id type="sourceforge">aiksaurus</remote-id>
 	</upstream>

--- a/app-text/code2html/metadata.xml
+++ b/app-text/code2html/metadata.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<!-- maintainer-needed -->
-<longdescription>
-  Code2HTML converts a program source code to syntax highlighted
-  HTML. It may be called as a CGI script. It can also handle include
-  commands in HTML files.
-</longdescription>
+	<!-- maintainer-needed -->
+	<longdescription>
+		Code2HTML converts a program source code to syntax highlighted
+		HTML. It may be called as a CGI script. It can also handle include
+		commands in HTML files.
+	</longdescription>
 </pkgmetadata>

--- a/app-text/dvipsk/metadata.xml
+++ b/app-text/dvipsk/metadata.xml
@@ -5,7 +5,7 @@
 		<email>aballier@gentoo.org</email>
 		<name>Alexis Ballier</name>
 	</maintainer>
-<maintainer type="project">
+	<maintainer type="project">
 		<email>tex@gentoo.org</email>
 		<name>Gentoo TeX Project</name>
 	</maintainer>

--- a/app-text/mandoc/metadata.xml
+++ b/app-text/mandoc/metadata.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<maintainer type="project">
-	<email>base-system@gentoo.org</email>
-</maintainer>
+	<maintainer type="project">
+		<email>base-system@gentoo.org</email>
+	</maintainer>
 	<use>
 		<flag name="cgi">build man.cgi web plugin for viewing man pages</flag>  
 		<flag name="system-man">set as the default man provider</flag>

--- a/app-text/ps2pkm/metadata.xml
+++ b/app-text/ps2pkm/metadata.xml
@@ -5,7 +5,7 @@
 		<email>aballier@gentoo.org</email>
 		<name>Alexis Ballier</name>
 	</maintainer>
-<maintainer type="project">
+	<maintainer type="project">
 		<email>tex@gentoo.org</email>
 		<name>Gentoo TeX Project</name>
 	</maintainer>

--- a/app-text/t1utils/metadata.xml
+++ b/app-text/t1utils/metadata.xml
@@ -5,7 +5,7 @@
 		<email>aballier@gentoo.org</email>
 		<name>Alexis Ballier</name>
 	</maintainer>
-<maintainer type="project">
+	<maintainer type="project">
 		<email>fonts@gentoo.org</email>
 		<name>Fonts</name>
 	</maintainer>

--- a/app-text/wscr/metadata.xml
+++ b/app-text/wscr/metadata.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<!-- maintainer-needed -->
-<longdescription lang="en">WSCR is a program to solve word jumbles, print all
-permutations of a string, and print pseudo-anagrams. It will use /usr/dict/words
-or a user-specified wordlist file</longdescription>
+	<!-- maintainer-needed -->
+	<longdescription lang="en">
+		WSCR is a program to solve word jumbles, print all permutations of a
+		string, and print pseudo-anagrams. It will use /usr/dict/words or a
+		user-specified wordlist file
+	</longdescription>
 </pkgmetadata>

--- a/app-vim/selinux-syntax/metadata.xml
+++ b/app-vim/selinux-syntax/metadata.xml
@@ -5,7 +5,7 @@
 		<email>vim@gentoo.org</email>
 		<name>Gentoo Vim Project</name>
 	</maintainer>
-<maintainer type="project">
+	<maintainer type="project">
 		<email>hardened@gentoo.org</email>
 		<name>Gentoo Hardened</name>
 	</maintainer>


### PR DESCRIPTION
Mostly indentation stuff except `app-emulation/libguestfs-appliance` where was commented maintainer who is actually upstream maintainer, I uncommented him, updated his email address and removed disallowed `</description>` block.