### PR TITLE
app-arch/bzip2: 9999 pytest BDEPEND

### DIFF
--- a/app-arch/bzip2/bzip2-9999.ebuild
+++ b/app-arch/bzip2/bzip2-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -21,6 +21,10 @@ IUSE="static-libs"
 
 PDEPEND="
 	app-alternatives/bzip2
+"
+
+BDEPEND="
+	dev-python/pytest
 "
 
 multilib_src_configure() {


### PR DESCRIPTION
app-arch/bzip2-9999 requires dev-python/pytest as a BDEPEND as of testing 2023-01-30

Signed-off-by: Ian Jordan <immoloism@gmail.com>