### PR TITLE
app-shells/nushell Removed 'extra' USE flag, added 'dataframe' USE flag

### DIFF
--- a/app-shells/nushell/metadata.xml
+++ b/app-shells/nushell/metadata.xml
@@ -13,6 +13,5 @@
 	</upstream>
 	<use>
 		<flag name="dataframe">Dataframe feature for nushell</flag>
-		<flag name="sqlite">SQLite commands for nushell</flag>
 	</use>
 </pkgmetadata>

--- a/app-shells/nushell/metadata.xml
+++ b/app-shells/nushell/metadata.xml
@@ -12,6 +12,7 @@
 		<remote-id type="github">nushell/nushell</remote-id>
 	</upstream>
 	<use>
-		<flag name="extra">Install extra plugins: binaryview, tree, clipboard-cli, trash-support and others</flag>
+		<flag name="dataframe">Dataframe feature for nushell</flag>
+		<flag name="sqlite">SQLite commands for nushell</flag>
 	</use>
 </pkgmetadata>

--- a/app-shells/nushell/nushell-0.74.0-r1.ebuild
+++ b/app-shells/nushell/nushell-0.74.0-r1.ebuild
@@ -577,7 +577,7 @@ SRC_URI="https://github.com/nushell/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz
 LICENSE="Apache-2.0 Apache-2.0-with-LLVM-exceptions BSD-2 BSD Boost-1.0 CC0-1.0 ISC MIT MPL-2.0 Unlicense ZLIB"
 SLOT="0"
 KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv"
-IUSE="dataframe sqlite"
+IUSE="dataframe"
 
 DEPEND="
 	>=dev-libs/libgit2-0.99:=
@@ -586,9 +586,7 @@ DEPEND="
 	net-libs/libssh2:=
 	net-libs/nghttp2:=
 	net-misc/curl
-	sqlite? (
-		dev-db/sqlite:3=
-	)
+	dev-db/sqlite:3=
 	x11-libs/libX11
 	x11-libs/libxcb
 "
@@ -619,7 +617,6 @@ src_configure() {
 	local myfeatures=(
 		stable
 		$(usev dataframe)
-		$(usev sqlite)
 	)
 
 	cargo_src_configure

--- a/app-shells/nushell/nushell-0.74.0-r1.ebuild
+++ b/app-shells/nushell/nushell-0.74.0-r1.ebuild
@@ -577,7 +577,7 @@ SRC_URI="https://github.com/nushell/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz
 LICENSE="Apache-2.0 Apache-2.0-with-LLVM-exceptions BSD-2 BSD Boost-1.0 CC0-1.0 ISC MIT MPL-2.0 Unlicense ZLIB"
 SLOT="0"
 KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv"
-IUSE="+extra"
+IUSE="dataframe sqlite"
 
 DEPEND="
 	>=dev-libs/libgit2-0.99:=
@@ -586,11 +586,11 @@ DEPEND="
 	net-libs/libssh2:=
 	net-libs/nghttp2:=
 	net-misc/curl
-	extra? (
+	sqlite? (
 		dev-db/sqlite:3=
-		x11-libs/libX11
-		x11-libs/libxcb
 	)
+	x11-libs/libX11
+	x11-libs/libxcb
 "
 
 RDEPEND="${DEPEND}"
@@ -618,7 +618,8 @@ src_configure() {
 
 	local myfeatures=(
 		stable
-		$(usev extra)
+		$(usev dataframe)
+		$(usev sqlite)
 	)
 
 	cargo_src_configure


### PR DESCRIPTION
As described in the [Changelog 0.72](https://www.nushell.sh/blog/2022-11-29-nushell-0.72.html) the feature `extra` no longer contains extra features. In fact, if you look at [Cargo.toml](https://github.com/nushell/nushell/blob/main/Cargo.toml), you'll find that `extra` is the same as `stable` or `default`:

```toml
# extra used to be more useful but now it's the same as default. Leaving it in for backcompat with existing build scripts
extra = ["default"]
default = ["plugin", "which-support", "trash-support", "sqlite"]
stable = ["default"]
wasi = []
```

Also, the feature `dataframe` is now optional, see [reasoning](https://www.nushell.sh/blog/2022-11-29-nushell-0.72.html#dataframes-no-longer-included-by-default-smaller-binaries). 

I therefore propose to remove the `extra` USE flag and introduce the new USE flag `dataframe` (disabled by default, as per upstream)