### PR TITLE
sys-process/supervise-scripts: remove daemontools from DEPEND

### DIFF
--- a/sys-process/supervise-scripts/supervise-scripts-4.0-r2.ebuild
+++ b/sys-process/supervise-scripts/supervise-scripts-4.0-r2.ebuild
@@ -1,0 +1,26 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DESCRIPTION="Starting and stopping daemontools managed services"
+HOMEPAGE="http://untroubled.org/supervise-scripts/"
+SRC_URI="http://untroubled.org/supervise-scripts/archive/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~ppc ~sparc ~x86"
+IUSE="doc"
+
+RDEPEND="virtual/daemontools"
+
+src_prepare() {
+	echo "/usr/bin" > conf-bin
+	echo "/usr/share/man" > conf-man
+	default
+}
+
+src_install() {
+	emake PREFIX="${D}" install
+	use doc && dodoc *.html
+}


### PR DESCRIPTION
- daemontools are not needed for installation, only in runtime
- update EAPI 7 -> 8