### PR TITLE
media-gfx/fbida: fix dependency on x11-libs/cairo

### DIFF
--- a/media-gfx/fbida/fbida-2.14-r6.ebuild
+++ b/media-gfx/fbida/fbida-2.14-r6.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -27,7 +27,7 @@ CDEPEND="
 	media-libs/libexif
 	media-libs/libjpeg-turbo:=
 	virtual/ttf-fonts
-	x11-libs/cairo[opengl]
+	x11-libs/cairo[opengl(+)]
 	curl? ( net-misc/curl )
 	fbcon? (
 		app-text/poppler[cairo]

--- a/media-gfx/fbida/fbida-9999.ebuild
+++ b/media-gfx/fbida/fbida-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -30,7 +30,7 @@ CDEPEND="
 	media-libs/tiff:=
 	net-misc/curl
 	virtual/ttf-fonts
-	x11-libs/cairo[opengl]
+	x11-libs/cairo[opengl(+)]
 	x11-libs/libX11
 	x11-libs/libXpm
 	x11-libs/libXt


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/892782
Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>