### PR TITLE
profiles/features/wd40: Remove media-libs/libavif from package.mask

### DIFF
--- a/profiles/features/wd40/package.mask
+++ b/profiles/features/wd40/package.mask
@@ -84,7 +84,6 @@ gnome-extra/gnome-browser-connector
 gnome-extra/gnome-tweaks
 gnome-extra/sushi
 >=media-gfx/libimagequant-4
-media-libs/libavif
 >=media-libs/libopenraw-0.3.2
 media-video/rav1e
 net-im/gajim


### PR DESCRIPTION
`media-libs/libavif rav1e` already being in package.use.mask
