### PR TITLE
games-engines/theforceengine: add 9999

### DIFF
--- a/games-engines/theforceengine/metadata.xml
+++ b/games-engines/theforceengine/metadata.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+  <maintainer type="project">
+    <email>games@gentoo.org</email>
+    <name>Gentoo Games Project</name>
+  </maintainer>
+  <longdescription>
+    Modern replacement Engine for the 1990's era LucasArts shooters
+    "Dark Forces" and in the future "Outlaws"; with full support for
+    Digital Audio, MIDI music and Mods.
+  </longdescription>
+  <use>
+    <flag name="softmidi">Adds runtime dependency on a known-working software midi synthesizer.</flag>
+  </use>
+  <upstream>
+    <bugs-to>https://github.com/luciusDXL/TheForceEngine/issues</bugs-to>
+    <changelog>https://github.com/luciusDXL/TheForceEngine/releases/</changelog>
+    <doc>https://theforceengine.github.io</doc>
+  </upstream>
+</pkgmetadata>

--- a/games-engines/theforceengine/theforceengine-9999.ebuild
+++ b/games-engines/theforceengine/theforceengine-9999.ebuild
@@ -1,0 +1,50 @@
+# Copyright 2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit cmake
+
+DESCRIPTION="Games Engine for LucasArts' 'DarkForces' and 'Outlaws'"
+HOMEPAGE="https://theforceengine.github.io"
+
+if [[ ${PV} == *9999* ]] ; then
+	EGIT_REPO_URI="https://github.com/luciusDXL/TheForceEngine.git"
+	EGIT_BRANCH="master"
+	inherit git-r3
+else
+	# no official release tarball with linux support yet
+	SRC_URI="https://github.com/luciusDXL/TheForceEngine/archive/refs/tags/v${P/_/}.tar.xz"
+fi
+
+IUSE="+softmidi"
+
+LICENSE="GPL-2"
+SLOT="0"
+
+BDEPEND="
+	virtual/pkgconfig
+"
+
+DEPEND="
+	>=media-libs/rtaudio-5.2.0
+	>=media-libs/rtmidi-5.0.0
+	>=media-libs/libsdl2-2.24.0
+	>=media-libs/devil-1.7.0
+	>=media-libs/glew-2.0.0
+	virtual/opengl
+"
+
+RDEPEND="
+	${DEPEND}
+	softmidi? (
+		|| (
+			media-sound/fluidsynth
+			media-sound/timidity++
+		)
+	)
+	|| (
+		gnome-extra/zenity
+		kde-apps/kdialog
+	)
+"


### PR DESCRIPTION
Ebuild for the development branch of "The Force Engine" -- a project to provide a modern game engine for the 1990s era LucasArts shooters "Dark Forces" and "Outlaws".
Only the github master branch supports Linux for now, there's no release tarball with Linux support yet.
I will submit an update when it is ready.

Signed-off-by: Manuel Lauss <manuel.lauss@gmail.com>