### PR TITLE
dev-util/roctracer: strip -Werror and fix a configure issue

### DIFF
--- a/dev-util/roctracer/files/roctracer-5.3.3-Werror.patch
+++ b/dev-util/roctracer/files/roctracer-5.3.3-Werror.patch
@@ -1,0 +1,15 @@
+Should not use the aggressive -Werror flag.
+
+Index: roctracer-rocm-5.3.3/CMakeLists.txt
+===================================================================
+--- roctracer-rocm-5.3.3.orig/CMakeLists.txt
++++ roctracer-rocm-5.3.3/CMakeLists.txt
+@@ -37,7 +37,7 @@ endif()
+ 
+ set(CMAKE_CXX_STANDARD 17)
+ set(CMAKE_CXX_STANDARD_REQUIRED ON)
+-add_compile_options(-Wall -Werror)
++add_compile_options(-Wall)
+ 
+ set(THREADS_PREFER_PTHREAD_FLAG ON)
+ 

--- a/dev-util/roctracer/roctracer-5.3.3.ebuild
+++ b/dev-util/roctracer/roctracer-5.3.3.ebuild
@@ -31,7 +31,8 @@ BDEPEND="
 "
 
 PATCHES=( "${FILESDIR}"/roctracer-5.3.3-flat-lib-layout.patch
-	"${FILESDIR}"/roctracer-5.3.3-do-not-install-test-files.patch )
+	"${FILESDIR}"/roctracer-5.3.3-do-not-install-test-files.patch
+	"${FILESDIR}"/roctracer-5.3.3-Werror.patch )
 
 python_check_deps() {
 	python_has_version "dev-python/CppHeaderParser[${PYTHON_USEDEP}]" \
@@ -51,6 +52,7 @@ src_configure() {
 		-DCMAKE_MODULE_PATH="${EPREFIX}/usr/lib64/cmake/hip"
 		-DAMDGPU_TARGETS="$(get_amdgpu_flags)"
 		-DFILE_REORG_BACKWARD_COMPATIBILITY=OFF
+		-DHIP_CXX_COMPILER=hipcc
 	)
 
 	cmake_src_configure


### PR DESCRIPTION
hip-config.cmake run ${HIP_CXX_COMPILER} -print-resource-dir to determine some paths. By default,
HIP_CXX_COMPILER=${CMAKE_CXX_COMPILER}=gcc, causing configuration issues, so set HIP_CXX_COMPILER=hipcc.

Closes: https://bugs.gentoo.org/891945
Bug: https://bugs.gentoo.org/892730
Signed-off-by: Yiyang Wu <xgreenlandforwyy@gmail.com>