### PR TITLE
dev-libs/opensc: remove alpha, arm, hppa, ia64, m68k, ppc, s390, sparc

### DIFF
--- a/dev-libs/opensc/opensc-0.22.0.ebuild
+++ b/dev-libs/opensc/opensc-0.22.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -11,7 +11,7 @@ SRC_URI="https://github.com/OpenSC/OpenSC/releases/download/${PV}/${P}.tar.gz"
 
 LICENSE="LGPL-2.1"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm ~hppa ~ia64 ~m68k ppc ppc64 ~s390 ~sparc x86"
+KEYWORDS="amd64 ppc64 x86"
 IUSE="ctapi doc openct notify +pcsc-lite readline secure-messaging ssl test zlib"
 RESTRICT="!test? ( test )"
 

--- a/dev-libs/opensc/opensc-0.23.0.ebuild
+++ b/dev-libs/opensc/opensc-0.23.0.ebuild
@@ -11,7 +11,7 @@ SRC_URI="https://github.com/OpenSC/OpenSC/releases/download/${PV}/${P}.tar.gz"
 
 LICENSE="LGPL-2.1"
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~m68k ~ppc ~ppc64 ~s390 ~sparc ~x86"
+KEYWORDS="~amd64 ~ppc64 ~x86"
 IUSE="ctapi doc openct openpace notify +pcsc-lite readline secure-messaging ssl test zlib"
 RESTRICT="!test? ( test )"
 

--- a/profiles/arch/arm/package.use.mask
+++ b/profiles/arch/arm/package.use.mask
@@ -1,10 +1,6 @@
 # Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-# David Seifert <soap@gentoo.org> (2023-02-01)
-# not keyworded yet, bug #892802
-dev-libs/opensc openpace
-
 # Florian Schmaus <flow@gentoo.org> (2022-11-23)
 # avoid larger deptree, bug #882593
 dev-python/bracex doc

--- a/profiles/arch/hppa/package.use.mask
+++ b/profiles/arch/hppa/package.use.mask
@@ -4,10 +4,6 @@
 # NOTE: When masking a USE flag due to missing keywords, please file a keyword
 # request bug for the hppa arch.
 
-# David Seifert <soap@gentoo.org> (2023-02-01)
-# not keyworded yet, bug #892802
-dev-libs/opensc openpace
-
 # Sam James <sam@gentoo.org> (2022-12-26)
 # Unkeyworded dependencies
 dev-util/diffoscope opendocument pascal pdf R

--- a/profiles/arch/ia64/package.use.mask
+++ b/profiles/arch/ia64/package.use.mask
@@ -1,10 +1,6 @@
 # Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-# David Seifert <soap@gentoo.org> (2023-02-01)
-# not keyworded yet, bug #892802
-dev-libs/opensc openpace
-
 # Sam James <sam@gentoo.org> (2022-12-26)
 # Unkeyworded dependencies
 dev-util/diffoscope opendocument pascal pdf R

--- a/profiles/arch/s390/package.use.mask
+++ b/profiles/arch/s390/package.use.mask
@@ -1,10 +1,6 @@
 # Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-# David Seifert <soap@gentoo.org> (2023-02-01)
-# not keyworded yet, bug #892802
-dev-libs/opensc openpace
-
 # Florian Schmaus <flow@gentoo.org> (2022-11-23)
 # avoid larger deptree, bug #882593
 dev-python/bracex doc

--- a/profiles/arch/sparc/package.use.mask
+++ b/profiles/arch/sparc/package.use.mask
@@ -1,10 +1,6 @@
 # Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-# David Seifert <soap@gentoo.org> (2023-02-01)
-# not keyworded yet, bug #892802
-dev-libs/opensc openpace
-
 # Sam James <sam@gentoo.org> (2023-01-31)
 # jit not supported on sparc32 or sparc64
 dev-libs/libpcre2 jit


### PR DESCRIPTION
Signed-off-by: David Seifert <soap@gentoo.org>