### PR TITLE
dev-util/pwntools: Keyword 4.10.0_beta0-r2 riscv, #892824

### DIFF
--- a/dev-python/colored-traceback/colored-traceback-0.3.0.ebuild
+++ b/dev-python/colored-traceback/colored-traceback-0.3.0.ebuild
@@ -14,6 +14,6 @@ SRC_URI="mirror://pypi/${P:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="ISC"
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~riscv ~x86"
 
 RDEPEND="dev-python/pygments[${PYTHON_USEDEP}]"

--- a/dev-python/intervaltree/intervaltree-3.1.0.ebuild
+++ b/dev-python/intervaltree/intervaltree-3.1.0.ebuild
@@ -12,7 +12,7 @@ SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="Apache-2.0"
 SLOT="0"
-KEYWORDS="amd64 x86"
+KEYWORDS="amd64 ~riscv x86"
 
 RDEPEND="dev-python/sortedcontainers[${PYTHON_USEDEP}]"
 

--- a/dev-python/plumbum/plumbum-1.8.1.ebuild
+++ b/dev-python/plumbum/plumbum-1.8.1.ebuild
@@ -18,7 +18,7 @@ SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~riscv ~x86"
 
 BDEPEND="
 	dev-python/hatch-vcs[${PYTHON_USEDEP}]

--- a/dev-python/rpyc/rpyc-5.2.3_p1.ebuild
+++ b/dev-python/rpyc/rpyc-5.2.3_p1.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://dev.gentoo.org/~grozin/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="amd64 x86"
+KEYWORDS="amd64 ~riscv x86"
 
 # USE flags gdb, numpy are used *only* to run tests depending on these packages
 IUSE="test numpy gdb"

--- a/dev-util/ROPgadget/ROPgadget-7.2.ebuild
+++ b/dev-util/ROPgadget/ROPgadget-7.2.ebuild
@@ -17,7 +17,7 @@ if [[ ${PV} == 9999 ]]; then
 	EGIT_REPO_URI="https://github.com/JonathanSalwan/ROPgadget"
 else
 	SRC_URI="https://github.com/JonathanSalwan/ROPgadget/archive/v${PV}.tar.gz -> ${P}.gh.tar.gz"
-	KEYWORDS="~amd64 ~arm64 ~ppc64 ~x86"
+	KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 fi
 
 LICENSE="GPL-2"

--- a/dev-util/pwntools/pwntools-4.10.0_beta0-r2.ebuild
+++ b/dev-util/pwntools/pwntools-4.10.0_beta0-r2.ebuild
@@ -15,7 +15,7 @@ if [[ ${PV} == "9999" ]]; then
 	EGIT_REPO_URI="https://github.com/Gallopsled/pwntools.git"
 else
 	SRC_URI="https://github.com/Gallopsled/pwntools/archive/${PV/_beta/beta}.tar.gz -> ${P}.gh.tar.gz"
-	KEYWORDS="~amd64 ~x86"
+	KEYWORDS="~amd64 ~riscv ~x86"
 	S="${WORKDIR}/${PN}-${PV/_beta/beta}"
 fi
 

--- a/dev-util/unicorn/unicorn-2.0.1.ebuild
+++ b/dev-util/unicorn/unicorn-2.0.1.ebuild
@@ -18,7 +18,7 @@ if [[ ${PV} == *9999 ]]; then
 	EGIT_REPO_URI="https://github.com/unicorn-engine/unicorn"
 else
 	SRC_URI="https://github.com/unicorn-engine/unicorn/archive/${MY_PV}.tar.gz -> ${P}.gh.tar.gz"
-	KEYWORDS="amd64 ~ppc x86"
+	KEYWORDS="amd64 ~ppc ~riscv x86"
 fi
 
 S="${WORKDIR}/${PN}-${MY_PV}"


### PR DESCRIPTION
dev-util/pwntools: Keyword 4.10.0_beta0-r2 riscv, #892824

Closes: https://bugs.gentoo.org/892824
Signed-off-by: Chris Su <chris@lesscrowds.org>