### PR TITLE
dev-cpp/folly: fix build on ppc64

### DIFF
--- a/dev-cpp/folly/folly-2023.02.06.00.ebuild
+++ b/dev-cpp/folly/folly-2023.02.06.00.ebuild
@@ -17,7 +17,7 @@ S="${WORKDIR}"
 
 LICENSE="Apache-2.0"
 SLOT="0/${PV}"
-KEYWORDS="~amd64"
+KEYWORDS="~amd64 ~ppc64"
 IUSE="llvm-libunwind test"
 RESTRICT="!test? ( test )"
 
@@ -81,6 +81,9 @@ src_configure() {
 		-DLIB_INSTALL_DIR="$(get_libdir)"
 
 		-DBUILD_TESTS=$(usex test)
+
+		# https://github.com/gentoo/gentoo/pull/29393
+		-DCMAKE_LIBRARY_ARCHITECTURE=$(usex amd64 x86_64 ${ARCH})
 	)
 
 	cmake_src_configure


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/892942

Not setting `CMAKE_LIBRARY_ARCHITECTURE` defaults it to `x86_64` and force enables `SSE4_2` breaking all platforms but amd64. Setting anything but an empty string (or `x86_64`) will do the trick. This PR conditionally sets `CMAKE_LIBRARY_ARCHITECTURE` on `ppc64`, but we should probably set it on all platforms. Unfortunately I'm not familiar with `CMAKE_LIBRARY_ARCHITECTURE` so I'm not sure if `x86_64` is arbitrary or standard naming convention (might as well use something like `powerpc64le-unknown-linux-gnu` AFAIK). It looks like amd64 needs `x86_64` specifically but other archs are not hardcoded yet. Also, shouldn't `SSE4_2` be behind a use flag even on amd64? Not sure if compiling it with `SSE4_2` actually **requires** it at runtime.

Upstream issue: https://github.com/facebook/folly/issues/1851