### PR TITLE
app-misc/nnn: Set executable bit on plugins

### DIFF
--- a/app-misc/nnn/nnn-4.7.ebuild
+++ b/app-misc/nnn/nnn-4.7.ebuild
@@ -65,7 +65,9 @@ src_install() {
 	einstalldocs
 
 	insinto /usr/share/nnn
+	insopts -m0755
 	doins -r plugins
+	fperms 0644 /usr/share/nnn/plugins/README.md
 }
 
 pkg_postinst() {


### PR DESCRIPTION
`app-misc/nnn-4.7` installs the plugins but does not make them executable. Therefore, nnn does not run them.
This PR fixes the issue by making the plugins executable during installation.