### PR TITLE
distutils-r1.eclass: Report stray top-level files in site-packages

### DIFF
--- a/eclass/distutils-r1.eclass
+++ b/eclass/distutils-r1.eclass
@@ -1220,7 +1220,7 @@ _distutils-r1_get_backend() {
 		if [[ -n ${new_backend} ]]; then
 			if [[ ! -f ${T}/.distutils_deprecated_backend_warned ]]; then
 				eqawarn "${build_backend} backend is deprecated.  Please see:"
-				eqawarn "https://projects.gentoo.org/python/guide/distutils.html#deprecated-pep-517-backends"
+				eqawarn "https://projects.gentoo.org/python/guide/qawarn.html#deprecated-pep-517-backends"
 				eqawarn "The eclass will be using ${new_backend} instead."
 				> "${T}"/.distutils_deprecated_backend_warned || die
 			fi

--- a/eclass/distutils-r1.eclass
+++ b/eclass/distutils-r1.eclass
@@ -1267,6 +1267,8 @@ distutils_wheel_install() {
 		-o -path '*.dist-info/LICENSE*' \
 		-o -path '*.dist-info/license_files/*' \
 		-o -path '*.dist-info/license_files' \
+		-o -path '*.dist-info/licenses/*' \
+		-o -path '*.dist-info/licenses' \
 		\) -delete || die
 }
 


### PR DESCRIPTION
In addition to checking for known-bad package names, detect stray files installed into top-level site-packages directory.  This is primarily meant to cover the common mistake in using `include` in Poetry-built packages.

Signed-off-by: Michał Górny <mgorny@gentoo.org>