### PR TITLE
pypi.eclass: pypi_wheel_url --unpack support

### DIFF
--- a/dev-python/installer/installer-0.6.0.ebuild
+++ b/dev-python/installer/installer-0.6.0.ebuild
@@ -7,7 +7,7 @@ EAPI=7
 DISTUTILS_USE_PEP517=no
 PYTHON_COMPAT=( python3_{9..11} pypy3 )
 
-inherit distutils-r1
+inherit distutils-r1 pypi
 
 DESCRIPTION="A library for installing Python wheels"
 HOMEPAGE="
@@ -18,8 +18,7 @@ HOMEPAGE="
 SRC_URI="
 	https://github.com/pypa/installer/archive/${PV}.tar.gz
 		-> ${P}.gh.tar.gz
-	https://files.pythonhosted.org/packages/py3/${PN::1}/${PN}/${P%_p*}-py3-none-any.whl
-		-> ${P%_p*}-py3-none-any.whl.zip
+	$(pypi_wheel_url --unpack)
 "
 
 LICENSE="MIT"

--- a/dev-python/tomli/tomli-2.0.1-r1.ebuild
+++ b/dev-python/tomli/tomli-2.0.1-r1.ebuild
@@ -7,7 +7,7 @@ EAPI=7
 DISTUTILS_USE_PEP517=no
 PYTHON_COMPAT=( python3_{9..11} pypy3 )
 
-inherit distutils-r1
+inherit distutils-r1 pypi
 
 DESCRIPTION="A lil' TOML parser"
 HOMEPAGE="
@@ -17,8 +17,7 @@ HOMEPAGE="
 SRC_URI="
 	https://github.com/hukkin/tomli/archive/${PV}.tar.gz
 		-> ${P}.gh.tar.gz
-	https://files.pythonhosted.org/packages/py3/${PN::1}/${PN}/${P}-py3-none-any.whl
-		-> ${P}-py3-none-any.whl.zip
+	$(pypi_wheel_url --unpack)
 "
 
 LICENSE="MIT"

--- a/eclass/pypi.eclass
+++ b/eclass/pypi.eclass
@@ -6,7 +6,7 @@
 # Michał Górny <mgorny@gentoo.org>
 # @AUTHOR:
 # Michał Górny <mgorny@gentoo.org>
-# @SUPPORTED_EAPIS: 8
+# @SUPPORTED_EAPIS: 7 8
 # @BLURB: A helper eclass to generate PyPI source URIs
 # @DESCRIPTION:
 # The pypi.eclass can be used to easily obtain URLs for artifacts
@@ -27,7 +27,7 @@
 # @CODE@
 
 case ${EAPI} in
-	8) ;;
+	7|8) ;;
 	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
 


### PR DESCRIPTION
A handy short way to get `dev-python/installer` and `dev-python/tomli` working with the new eclass.