### PR TITLE
dev-util/hip: add back patch to strip -rpath in hipcc

### DIFF
--- a/dev-util/hip/files/hip-5.3.3-correct-ldflag.patch
+++ b/dev-util/hip/files/hip-5.3.3-correct-ldflag.patch
@@ -1,0 +1,20 @@
+This removes ldflag -L"/usr/lib" and -Wl,-rpath=/usr/lib:/usr/lib which
+causes `ld: skipping incompatible /usr/lib/libm.so when searching for -lm`
+Reference: https://github.com/justxi/rocm/issues/8#issuecomment-1166193820
+===================================================================
+Index: HIP-rocm-5.3.3/bin/hipcc.pl
+===================================================================
+--- HIP-rocm-5.3.3.orig/bin/hipcc.pl
++++ HIP-rocm-5.3.3/bin/hipcc.pl
+@@ -711,9 +711,9 @@ if ($HIP_PLATFORM eq "amd") {
+ 
+     if (not $isWindows  and not $compileOnly) {
+       if ($linkType eq 0) {
+-        $toolArgs = " -L$HIP_LIB_PATH -lamdhip64 -L$ROCM_PATH/lib -lhsa-runtime64 -ldl -lnuma " . ${toolArgs};
++        $toolArgs = " -lamdhip64 -lhsa-runtime64 -ldl -lnuma " . ${toolArgs};
+       } else {
+-        $toolArgs = ${toolArgs} . " -Wl,--enable-new-dtags -Wl,-rpath=$HIP_LIB_PATH:$ROCM_PATH/lib -lamdhip64 ";
++        $toolArgs = ${toolArgs} . " -Wl,--enable-new-dtags -lamdhip64 ";
+       }
+       # To support __fp16 and _Float16, explicitly link with compiler-rt
+       $HIP_CLANG_BUILTIN_LIB="$HIP_CLANG_PATH/../lib/clang/$HIP_CLANG_VERSION/lib/$HIP_CLANG_TARGET/libclang_rt.builtins.a";

--- a/dev-util/hip/hip-5.3.3-r3.ebuild
+++ b/dev-util/hip/hip-5.3.3-r3.ebuild
@@ -77,6 +77,7 @@ src_prepare() {
 	pushd ${HIP_S} || die
 	eapply "${FILESDIR}/${PN}-5.1.3-rocm-path.patch"
 	eapply "${FILESDIR}/${PN}-5.1.3-fno-stack-protector.patch"
+	eapply "${FILESDIR}/${PN}-5.3.3-correct-ldflag.patch"
 	eapply "${FILESDIR}/0001-SWDEV-344620-hipcc-fails-to-parse-version-of-clang-i.patch"
 	eapply "${FILESDIR}/0002-SWDEV-355608-Remove-clang-include-path-2996.patch"
 	eapply "${FILESDIR}/0003-SWDEV-352878-Removed-relative-path-based-CLANG-inclu.patch"


### PR DESCRIPTION
This fixes hipcc adding -rpath in compilation, which causes QA issue for building ROCm libraries, and linking the incorrect BLAS/LAPACK implementation to rocblas-test, which may cause testing performance degrade.

Signed-off-by: Yiyang Wu <xgreenlandforwyy@gmail.com>