### PR TITLE
Set myself as proxied maintainer for nudoku and profanity

### DIFF
--- a/games-puzzle/nudoku/metadata.xml
+++ b/games-puzzle/nudoku/metadata.xml
@@ -1,7 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<!-- maintainer-needed -->
+		<maintainer type="person" proxied="yes">
+		<email>jubalh@iodoru.org</email>
+		<name>Michael Vetter</name>
+	</maintainer>
+	<maintainer type="project" proxied="proxy">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
 	<upstream>
 		<remote-id type="github">jubalh/nudoku</remote-id>
 	</upstream>

--- a/net-im/profanity/metadata.xml
+++ b/net-im/profanity/metadata.xml
@@ -1,7 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<!-- maintainer-needed -->
+		<maintainer type="person" proxied="yes">
+		<email>jubalh@iodoru.org</email>
+		<name>Michael Vetter</name>
+	</maintainer>
+	<maintainer type="project" proxied="proxy">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
 	<longdescription>
 		Profanity is a console based XMPP client written in C using
 		ncurses and libstrophe, inspired by Irssi.


### PR DESCRIPTION
I'm upstream for both packages and would like to set myself as maintainer already to receive all the bugs even when so far I didn't do any changes to the ebuild.