### PR TITLE
sci-biology/augustus: move remote-id inside upstream block

### DIFF
--- a/sci-biology/augustus/metadata.xml
+++ b/sci-biology/augustus/metadata.xml
@@ -5,5 +5,7 @@
     <email>sci-biology@gentoo.org</email>
     <name>Gentoo Biology Project</name>
   </maintainer>
-  <remote-id type="github">Gaius-Augustus/Augustus</remote-id>
+  <upstream>
+    <remote-id type="github">Gaius-Augustus/Augustus</remote-id>
+  </upstream>
 </pkgmetadata>


### PR DESCRIPTION
@thesamesam, fix for your recent change f203a8487a2f ("sci-biology/augustus: add github remote-id").