### PR TITLE
gkrellm-plugin.eclass: remove EAPI 6 support

### DIFF
--- a/eclass/gkrellm-plugin.eclass
+++ b/eclass/gkrellm-plugin.eclass
@@ -8,56 +8,40 @@
 # Original author: Jim Ramsay <lack@gentoo.org>
 # EAPI 6 author: David Seifert <soap@gentoo.org>
 # EAPI 8 author: Thomas Bracht Laumann Jespersen <t@laumann.xyz>
-# @SUPPORTED_EAPIS: 6 8
-# @PROVIDES: multilib
+# @SUPPORTED_EAPIS: 8
 # @BLURB: Provides src_install used by (almost) all gkrellm plugins
 # @DESCRIPTION:
 # - Sets up default dependencies
 # - Provides a common src_install method to avoid code duplication
-#
-# Changelog:
-#   17 March 2022: Thomas Bracht Laumann Jespersen <t@laumann.xyz>
-#     - Port to EAPI 8
-#   03 January 2018: David Seifert <soap@gentoo.org>
-#     - Port to EAPI 6, remove built_with_use, simplify a lot
-#   12 March 2007: Jim Ramsay <lack@gentoo.org>
-#     - Added server plugin support
-#   09 March 2007: Jim Ramsay <lack@gentoo.org>
-#     - Initial commit
-#
 
 # @ECLASS_VARIABLE: PLUGIN_SO
 # @DESCRIPTION:
 # The name of the plugin's .so file which will be installed in
-# the plugin dir. Defaults to "${PN}$(get_modname)". Has to be a bash array.
+# the plugin dir.  Defaults to "${PN}$(get_modname)".  Has to be a bash array.
 
 # @ECLASS_VARIABLE: PLUGIN_SERVER_SO
 # @DEFAULT_UNSET
 # @DESCRIPTION:
 # The name of the plugin's server plugin $(get_modname) portion.
-# Unset by default. Has to be a bash array.
+# Unset by default.  Has to be a bash array.
 
 # @ECLASS_VARIABLE: PLUGIN_DOCS
 # @DEFAULT_UNSET
 # @DESCRIPTION:
 # An optional list of docs to be installed, in addition to the default
-# DOCS variable which is respected too. Has to be a bash array.
+# DOCS variable which is respected too.  Has to be a bash array.
 
 case ${EAPI} in
-	6|8) ;;
+	8) ;;
 	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
 
+if [[ ! ${_GKRELLM_PLUGIN_ECLASS} ]]; then
+_GKRELLM_PLUGIN_ECLASS=1
+
 inherit multilib
 
-if [[ ! ${_GKRELLM_PLUGIN_R1} ]]; then
-_GKRELLM_PLUGIN_R1=1
-
-if [[ ${EAPI} == 6 ]]; then
-	DEPEND="virtual/pkgconfig"
-else
-	BDEPEND="virtual/pkgconfig"
-fi
+BDEPEND="virtual/pkgconfig"
 
 # @FUNCTION: gkrellm-plugin_src_install
 # @USAGE:
@@ -68,20 +52,13 @@ gkrellm-plugin_src_install() {
 
 	if ! declare -p PLUGIN_SO >/dev/null 2>&1 ; then
 		doexe ${PN}$(get_modname)
-	elif declare -p PLUGIN_SO | grep -q "^declare -a " ; then
-		doexe "${PLUGIN_SO[@]}"
 	else
-		die "PLUGIN_SO has to be a bash array!"
+		doexe "${PLUGIN_SO[@]}"
 	fi
 
 	if [[ -n ${PLUGIN_SERVER_SO} ]]; then
 		exeinto /usr/$(get_libdir)/gkrellm2/plugins-gkrellmd
-
-		if declare -p PLUGIN_SERVER_SO | grep -q "^declare -a " ; then
-			doexe "${PLUGIN_SERVER_SO[@]}"
-		else
-			die "PLUGIN_SERVER_SO has to be a bash array!"
-		fi
+		doexe "${PLUGIN_SERVER_SO[@]}"
 	fi
 
 	einstalldocs
@@ -90,13 +67,7 @@ gkrellm-plugin_src_install() {
 		[[ -s "${d}" ]] && dodoc "${d}"
 	done
 
-	if [[ -n ${PLUGIN_DOCS} ]]; then
-		if declare -p PLUGIN_DOCS | grep -q "^declare -a " ; then
-			dodoc "${PLUGIN_DOCS[@]}"
-		else
-			die "PLUGIN_DOCS has to be a bash array!"
-		fi
-	fi
+	[[ -n ${PLUGIN_DOCS} ]] && dodoc "${PLUGIN_DOCS[@]}"
 }
 
 fi

--- a/x11-plugins/gkrellkam/gkrellkam-2.0.0-r1.ebuild
+++ b/x11-plugins/gkrellkam/gkrellkam-2.0.0-r1.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-inherit gkrellm-plugin toolchain-funcs
+inherit gkrellm-plugin multilib toolchain-funcs
 
 MY_P=${P/-/_}
 

--- a/x11-plugins/gkrellm-bgchanger/gkrellm-bgchanger-0.1.11-r3.ebuild
+++ b/x11-plugins/gkrellm-bgchanger/gkrellm-bgchanger-0.1.11-r3.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-inherit gkrellm-plugin toolchain-funcs
+inherit gkrellm-plugin multilib toolchain-funcs
 
 MY_PN="gkrellmbgchg2"
 MY_P="${MY_PN}-${PV}"

--- a/x11-plugins/gkrellm-bluez/gkrellm-bluez-0.2-r3.ebuild
+++ b/x11-plugins/gkrellm-bluez/gkrellm-bluez-0.2-r3.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit gkrellm-plugin
+inherit gkrellm-plugin multilib
 
 DESCRIPTION="GKrellm plugin for monitoring bluetooth (Linux BlueZ) adapters"
 HOMEPAGE="http://gkrellm-bluez.sourceforge.net"

--- a/x11-plugins/gkrellm-cpupower/gkrellm-cpupower-0.2-r2.ebuild
+++ b/x11-plugins/gkrellm-cpupower/gkrellm-cpupower-0.2-r2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit gkrellm-plugin toolchain-funcs
+inherit gkrellm-plugin multilib toolchain-funcs
 
 MY_P="${P/gkrellm/gkrellm2}"
 

--- a/x11-plugins/gkrellm-leds/gkrellm-leds-0.8.2-r2.ebuild
+++ b/x11-plugins/gkrellm-leds/gkrellm-leds-0.8.2-r2.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-inherit gkrellm-plugin autotools
+inherit autotools gkrellm-plugin multilib
 
 MY_P="${P/rellm-/}"
 

--- a/x11-plugins/gkrellm-mailwatch/gkrellm-mailwatch-2.4.3-r3.ebuild
+++ b/x11-plugins/gkrellm-mailwatch/gkrellm-mailwatch-2.4.3-r3.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-inherit gkrellm-plugin toolchain-funcs
+inherit gkrellm-plugin multilib toolchain-funcs
 
 DESCRIPTION="A GKrellM2 plugin that shows the status of additional mail boxes"
 HOMEPAGE="http://gkrellm.luon.net/mailwatch.php"

--- a/x11-plugins/gkrellm-radio/gkrellm-radio-2.0.4-r1.ebuild
+++ b/x11-plugins/gkrellm-radio/gkrellm-radio-2.0.4-r1.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-inherit gkrellm-plugin toolchain-funcs
+inherit gkrellm-plugin multilib toolchain-funcs
 
 DESCRIPTION="A minimalistic GKrellM2 plugin to control radio tuners"
 HOMEPAGE="http://gkrellm.luon.net/gkrellm-radio.php"

--- a/x11-plugins/gkrellm-radio/gkrellm-radio-2.0.4-r2.ebuild
+++ b/x11-plugins/gkrellm-radio/gkrellm-radio-2.0.4-r2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit gkrellm-plugin toolchain-funcs
+inherit gkrellm-plugin multilib toolchain-funcs
 
 DESCRIPTION="A minimalistic GKrellM2 plugin to control radio tuners"
 HOMEPAGE="http://gkrellm.luon.net/gkrellm-radio.php"

--- a/x11-plugins/gkrellm-trayicons/gkrellm-trayicons-1.03-r2.ebuild
+++ b/x11-plugins/gkrellm-trayicons/gkrellm-trayicons-1.03-r2.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-inherit gkrellm-plugin toolchain-funcs
+inherit gkrellm-plugin multilib toolchain-funcs
 
 DESCRIPTION="Configurable Tray Icons for GKrellM"
 HOMEPAGE="http://gkrellm.srcbox.net/Plugins.html"

--- a/x11-plugins/gkrellm-vaiobright/gkrellm-vaiobright-2.5-r3.ebuild
+++ b/x11-plugins/gkrellm-vaiobright/gkrellm-vaiobright-2.5-r3.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-inherit gkrellm-plugin toolchain-funcs
+inherit gkrellm-plugin multilib toolchain-funcs
 
 MY_P=${P/gkrellm-/}
 

--- a/x11-plugins/gkrellm-vaiobright/gkrellm-vaiobright-2.5-r4.ebuild
+++ b/x11-plugins/gkrellm-vaiobright/gkrellm-vaiobright-2.5-r4.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit gkrellm-plugin toolchain-funcs
+inherit gkrellm-plugin multilib toolchain-funcs
 
 MY_P=${P/gkrellm-/}
 

--- a/x11-plugins/gkrellm-volume/gkrellm-volume-2.1.13-r3.ebuild
+++ b/x11-plugins/gkrellm-volume/gkrellm-volume-2.1.13-r3.ebuild
@@ -1,8 +1,9 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
-inherit gkrellm-plugin toolchain-funcs
+
+inherit gkrellm-plugin multilib toolchain-funcs
 
 DESCRIPTION="A mixer control plugin for gkrellm"
 HOMEPAGE="http://gkrellm.luon.net/volume.php"

--- a/x11-plugins/gkrellm-xkb/gkrellm-xkb-1.05-r2.ebuild
+++ b/x11-plugins/gkrellm-xkb/gkrellm-xkb-1.05-r2.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-inherit gkrellm-plugin toolchain-funcs
+inherit gkrellm-plugin multilib toolchain-funcs
 
 DESCRIPTION="XKB keyboard switcher for gkrellm2"
 HOMEPAGE="http://tripie.sweb.cz/gkrellm/xkb/"

--- a/x11-plugins/gkrellmss/gkrellmss-2.6-r5.ebuild
+++ b/x11-plugins/gkrellmss/gkrellmss-2.6-r5.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit gkrellm-plugin toolchain-funcs
+inherit gkrellm-plugin multilib toolchain-funcs
 
 DESCRIPTION="A plugin for GKrellM2 that has a VU meter and a sound chart"
 HOMEPAGE="http://members.dslextreme.com/users/billw/gkrellmss/gkrellmss.html"

--- a/x11-plugins/gkrellmwireless/gkrellmwireless-2.0.3-r3.ebuild
+++ b/x11-plugins/gkrellmwireless/gkrellmwireless-2.0.3-r3.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-inherit gkrellm-plugin toolchain-funcs
+inherit gkrellm-plugin multilib toolchain-funcs
 
 DESCRIPTION="A plugin for GKrellM that monitors your wireless network card"
 HOMEPAGE="http://gkrellm.luon.net/gkrellmwireless.php"

--- a/x11-plugins/gkrellsun/gkrellsun-1.0.0-r5.ebuild
+++ b/x11-plugins/gkrellsun/gkrellsun-1.0.0-r5.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-inherit gkrellm-plugin toolchain-funcs
+inherit gkrellm-plugin multilib toolchain-funcs
 
 DESCRIPTION="A GKrellM plugin that shows sunrise and sunset times"
 HOMEPAGE="http://gkrellsun.sourceforge.net/"

--- a/x11-plugins/gkrelltop/gkrelltop-2.2.13-r3.ebuild
+++ b/x11-plugins/gkrelltop/gkrelltop-2.2.13-r3.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
-inherit gkrellm-plugin toolchain-funcs
+inherit gkrellm-plugin multilib toolchain-funcs
 
 DESCRIPTION="a GKrellM2 plugin which displays the top three processes"
 HOMEPAGE="https://sourceforge.net/projects/gkrelltop"


### PR DESCRIPTION
Signed-off-by: David Seifert <soap@gentoo.org>