### PR TITLE
app-arch/qpress: exclude -Werror on build

### DIFF
--- a/app-arch/qpress/files/qpress-20220819-fix-build-system.patch
+++ b/app-arch/qpress/files/qpress-20220819-fix-build-system.patch
@@ -11,13 +11,12 @@ diff --git a/makefile b/makefile
 index 4890f9d..349fbb2 100755
 --- a/makefile
 +++ b/makefile
-@@ -1,9 +1,21 @@
+@@ -1,9 +1,20 @@
 -PREFIX = /usr/local
 +DESTDIR ?=
 +PREFIX ?= /usr/local
 +CXX ?= g++
-+CXXFLAGS ?= -O3
-+CXXFLAGS += -Wall -Wextra -Werror
++CXXFLAGS ?= -O3 -Wall -Wextra -Werror
 +LDFLAGS ?=
  
 -g++:	qpress.cpp aio.cpp quicklz.c utilities.cpp


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/889336
Signed-off-by: Azamat H. Hackimov <azamat.hackimov@gmail.com>