### PR TITLE
dev-libs/FXdiv: fix building with dev-cpp/gtest-1.13.0

### DIFF
--- a/dev-libs/FXdiv/FXdiv-2020.12.09-r1.ebuild
+++ b/dev-libs/FXdiv/FXdiv-2020.12.09-r1.ebuild
@@ -1,0 +1,43 @@
+# Copyright 2022-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+inherit cmake
+
+CommitId=63058eff77e11aa15bf531df5dd34395ec3017c8
+DESCRIPTION="Division via fixed-point multiplication by inverse"
+HOMEPAGE="https://github.com/Maratyszcza/FXdiv/"
+SRC_URI="https://github.com/Maratyszcza/${PN}/archive/${CommitId}.tar.gz
+	-> ${P}.tar.gz"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~amd64"
+IUSE="test"
+
+DEPEND=""
+RDEPEND="${DEPEND}"
+BDEPEND="test? ( dev-cpp/gtest )"
+RESTRICT="!test? ( test )"
+
+S="${WORKDIR}"/${PN}-${CommitId}
+
+PATCHES=(
+	"${FILESDIR}"/${P}-gentoo.patch
+)
+
+src_prepare() {
+	cmake_src_prepare
+
+	# >=dev-cpp/gtest-1.13.0 requires C++14 standard or later
+	sed -i -e 's/CXX_STANDARD 11/CXX_STANDARD 14/g' \
+		CMakeLists.txt || die "sed failed"
+}
+
+src_configure() {
+	local mycmakeargs=(
+		-DFXDIV_BUILD_BENCHMARKS=OFF
+		-DFXDIV_BUILD_TESTS=$(usex test ON OFF)
+	)
+	cmake_src_configure
+}


### PR DESCRIPTION
`>=dev-cpp/gtest-1.13.0` requires C++14 standard of later.  This commit opts for  `sed`  in `src_prepare`.  If you'd prefer a patch instead, let me know.

Closes: https://bugs.gentoo.org/893340
Closes: https://github.com/gentoo/gentoo/pull/29471
Signed-off-by: Peter Levine <plevine457@gmail.com>