### PR TITLE
dev-libs/cpuinfo: fix building against dev-cpp/gtest-1.13.0

### DIFF
--- a/dev-libs/cpuinfo/cpuinfo-2022.03.26-r1.ebuild
+++ b/dev-libs/cpuinfo/cpuinfo-2022.03.26-r1.ebuild
@@ -1,0 +1,44 @@
+# Copyright 2022-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+inherit cmake
+
+CommitId=b40bae27785787b6dd70788986fd96434cf90ae2
+
+DESCRIPTION="CPU INFOrmation library"
+HOMEPAGE="https://github.com/pytorch/cpuinfo/"
+SRC_URI="https://github.com/pytorch/${PN}/archive/${CommitId}.tar.gz
+	-> ${P}.tar.gz"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~amd64"
+IUSE="test"
+
+DEPEND=""
+RDEPEND="${DEPEND}"
+BDEPEND="test? ( dev-cpp/gtest )"
+RESTRICT="!test? ( test )"
+
+S="${WORKDIR}"/${PN}-${CommitId}
+
+PATCHES=(
+	"${FILESDIR}"/${P}-gentoo.patch
+)
+
+src_prepare() {
+	cmake_src_prepare
+
+	# >=dev-cpp/gtest-1.13.0 depends on building with at least C++14 standard
+	sed -i -e 's/CXX_STANDARD 11/CXX_STANDARD 14/' \
+		CMakeLists.txt || die "sed failed"
+}
+
+src_configure() {
+	local mycmakeargs=(
+		-DCPUINFO_BUILD_BENCHMARKS=OFF
+		-DCPUINFO_BUILD_UNIT_TESTS=$(usex test ON OFF)
+	)
+	cmake_src_configure
+}


### PR DESCRIPTION
`>=dev-cpp/gtest-1.13.0` requires C++14 standard of later. This commit opts for `sed` in `src_prepare`. If you'd prefer a patch instead, let me know.

Closes: https://bugs.gentoo.org/893344
Closes: https://github.com/gentoo/gentoo/pull/29474
Signed-off-by: Peter Levine <plevine457@gmail.com>