### PR TITLE
 dev-libs/rapidjson: fix bug 893466

### DIFF
--- a/dev-libs/rapidjson/rapidjson-1.1.0-r3.ebuild
+++ b/dev-libs/rapidjson/rapidjson-1.1.0-r3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -44,6 +44,7 @@ src_configure() {
 	local mycmakeargs=(
 		-DDOC_INSTALL_DIR="${EPREFIX}/usr/share/doc/${PF}"
 		-DLIB_INSTALL_DIR="${EPREFIX}/usr/$(get_libdir)"
+		-DRAPIDJSON_BUILD_CXX11=OFF # latest gtest requires C++14 or later
 		-DRAPIDJSON_BUILD_DOC=$(usex doc)
 		-DRAPIDJSON_BUILD_EXAMPLES=$(usex examples)
 		-DRAPIDJSON_BUILD_TESTS=$(usex test)

--- a/dev-libs/rapidjson/rapidjson-9999.ebuild
+++ b/dev-libs/rapidjson/rapidjson-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -45,6 +45,8 @@ src_configure() {
 	local mycmakeargs=(
 		-DDOC_INSTALL_DIR="${EPREFIX}/usr/share/doc/${PF}"
 		-DLIB_INSTALL_DIR="${EPREFIX}/usr/$(get_libdir)"
+		-DRAPIDJSON_BUILD_CXX11=OFF # latest gtest requires C++14 or later
+		-DRAPIDJSON_BUILD_CXX17=ON
 		-DRAPIDJSON_BUILD_DOC=$(usex doc)
 		-DRAPIDJSON_BUILD_EXAMPLES=$(usex examples)
 		-DRAPIDJSON_BUILD_TESTS=$(usex test)


### PR DESCRIPTION
- **dev-libs/rapidjson: don't force C++11**
`dev-cpp/gtest-1.13.0` now requires building with C++14 or later. Remove
`-std=c++11` and, if not overridden in `CXXFLAGS`, use the compiler
default.  For 9999, explicitly pass `RAPIDJSON_BUILD_CXX17=ON`, which
supports that cmake option.

Closes: https://bugs.gentoo.org/893466
Closes: https://github.com/gentoo/gentoo/pull/29479