### PR TITLE
mail-filter/maildrop-3.1.0: fix library deps

### DIFF
--- a/mail-filter/maildrop/maildrop-3.1.0.ebuild
+++ b/mail-filter/maildrop/maildrop-3.1.0.ebuild
@@ -17,8 +17,8 @@ IUSE="berkdb debug dovecot gdbm ldap mysql postgres static-libs authlib +tools t
 
 CDEPEND="!mail-mta/courier
 	net-mail/mailbase
-	dev-libs/libpcre
-	net-dns/libidn:0=
+	dev-libs/libpcre2
+	net-dns/libidn2:=
 	>=net-libs/courier-unicode-2.0:=
 	gdbm?     ( >=sys-libs/gdbm-1.8.0:= )
 	mysql?    ( net-libs/courier-authlib )


### PR DESCRIPTION
Maildrop depends on PCRE2 since version 3.0.4. Since last version (3.1.0), it also depends on libidn2

Signed-off-by: Cristian Othón Martínez Vera <cfuga@cfuga.mx>
