### PR TITLE
profiles/base: mask USE=webkit on dev-java/swt:4.10

### DIFF
--- a/profiles/base/package.use.mask
+++ b/profiles/base/package.use.mask
@@ -6,6 +6,10 @@
 # This file is only for generic masks. For arch-specific masks (i.e.
 # mask everywhere, unmask on arch/*) use arch/base.
 
+# Volkmar W. Pogatzki <gentoo@pogatzki.net> (2023-02-09)
+# Bug #893686. Presently nothing depends on dev-java/swt built with this flag.
+dev-java/swt:4.10 webkit
+
 # Bernd Waibel <waebbl-gentoo@posteo.net> (2023-01-28)
 # Has some issues building and needs some love first.
 # Bug #891829


### PR DESCRIPTION
Older slots don't have that flag.

Closes: https://bugs.gentoo.org/893686
Signed-off-by: Volkmar W. Pogatzki <gentoo@pogatzki.net>