### PR TITLE
sys-apps/apparmor: LTO and clang fix

### DIFF
--- a/sys-apps/apparmor/apparmor-3.0.8-r1.ebuild
+++ b/sys-apps/apparmor/apparmor-3.0.8-r1.ebuild
@@ -1,0 +1,90 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit systemd toolchain-funcs flag-o-matic
+
+MY_PV="$(ver_cut 1-2)"
+
+DESCRIPTION="Userspace utils and init scripts for the AppArmor application security system"
+HOMEPAGE="https://gitlab.com/apparmor/apparmor/wikis/home"
+SRC_URI="https://launchpad.net/${PN}/${MY_PV}/${PV}/+download/${PN}-${PV}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~arm64 ~riscv"
+IUSE="doc"
+
+# Was restricted previously b/c needs apparmor support in kernel
+# TODO: add check to ebuild
+#RESTRICT="test" # bug 675854
+
+RDEPEND="~sys-libs/libapparmor-${PV}"
+DEPEND="${RDEPEND}"
+BDEPEND="
+	dev-lang/perl
+	sys-apps/which
+	sys-devel/bison
+	sys-devel/gettext
+	sys-devel/flex
+	doc? ( dev-tex/latex2html )
+"
+
+S=${WORKDIR}/apparmor-${PV}/parser
+
+PATCHES=(
+	"${FILESDIR}/${PN}-3.0.5-makefile.patch"
+	"${FILESDIR}/${PN}-2.11.1-dynamic-link.patch"
+	"${FILESDIR}/${PN}-3.0.8-clang.patch"
+)
+
+src_prepare() {
+	default
+
+	# remove warning about missing file that controls features
+	# we don't currently support
+	sed -e "/installation problem/ctrue" -i rc.apparmor.functions || die
+
+	# bug 634782
+	sed -e "s/cpp/$(tc-getCPP) -/" \
+		-i ../common/list_capabilities.sh \
+		-i ../common/list_af_names.sh || die
+
+	filter-lto #887475
+}
+
+src_compile() {
+	emake \
+		AR="$(tc-getAR)" \
+		CC="$(tc-getCC)" \
+		CPP="$(tc-getCPP) -" \
+		CXX="$(tc-getCXX)" \
+		USE_SYSTEM=1 \
+		arch manpages
+	use doc && emake pdf
+}
+
+src_test() {
+	emake CXX="$(tc-getCXX)" USE_SYSTEM=1 check
+}
+
+src_install() {
+	emake \
+		CPP="$(tc-getCPP) -" \
+		DESTDIR="${D}" \
+		DISTRO="unknown" \
+		USE_SYSTEM=1 \
+		install
+
+	dodir /etc/apparmor.d/disable
+
+	newinitd "${FILESDIR}/${PN}-init-1" ${PN}
+	systemd_newunit "${FILESDIR}/apparmor.service" apparmor.service
+
+	use doc && dodoc techdoc.pdf
+
+	exeinto /usr/share/apparmor
+	doexe "${FILESDIR}/apparmor_load.sh"
+	doexe "${FILESDIR}/apparmor_unload.sh"
+}

--- a/sys-apps/apparmor/files/apparmor-3.0.8-clang.patch
+++ b/sys-apps/apparmor/files/apparmor-3.0.8-clang.patch
@@ -1,0 +1,11 @@
+--- a/Makefile  2023-02-10 01:13:45.028195480 +0000
++++ b/Makefile  2023-02-10 01:19:31.242807968 +0000
+@@ -70,7 +70,7 @@
+ endif
+ endif #CFLAGS
+
+-CFLAGS += -flto-partition=none
++CFLAGS +=
+
+ EXTRA_CXXFLAGS = ${CFLAGS} ${CPPFLAGS} ${CXX_WARNINGS} -std=gnu++0x
+ EXTRA_CFLAGS = ${EXTRA_CXXFLAGS} ${CPP_WARNINGS}

--- a/sys-libs/libapparmor/files/libapparmour-3.0.8-clang.patch
+++ b/sys-libs/libapparmor/files/libapparmour-3.0.8-clang.patch
@@ -1,0 +1,11 @@
+--- a/src/Makefile.am   2022-11-22 00:54:32.000000000 +0000
++++ b/src/Makefile.am   2023-02-09 22:53:52.200000000 +0000
+@@ -39,7 +39,7 @@
+ BUILT_SOURCES = grammar.h scanner.h af_protos.h
+ AM_LFLAGS = -v
+ AM_YFLAGS = -d -p aalogparse_
+-AM_CFLAGS = -Wall $(EXTRA_WARNINGS) -fPIC -flto-partition=none
++AM_CFLAGS = -Wall $(EXTRA_WARNINGS) -fPIC
+ AM_CPPFLAGS = -D_GNU_SOURCE -I$(top_srcdir)/include/
+ scanner.h: scanner.l
+       	$(LEX) -v $<

--- a/sys-libs/libapparmor/libapparmor-3.0.8-r1.ebuild
+++ b/sys-libs/libapparmor/libapparmor-3.0.8-r1.ebuild
@@ -1,0 +1,119 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DISTUTILS_OPTIONAL=1
+PYTHON_COMPAT=( python3_{9..11} )
+GENTOO_DEPEND_ON_PERL="no"
+
+inherit autotools distutils-r1 perl-functions flag-o-matic
+
+MY_PV="$(ver_cut 1-2)"
+
+DESCRIPTION="Library to support AppArmor userspace utilities"
+HOMEPAGE="https://gitlab.com/apparmor/apparmor/wikis/home"
+SRC_URI="https://launchpad.net/apparmor/${MY_PV}/${PV}/+download/apparmor-${PV}.tar.gz"
+
+LICENSE="GPL-2 LGPL-2.1"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~riscv ~x86"
+IUSE="doc +perl +python static-libs"
+
+REQUIRED_USE="${PYTHON_REQUIRED_USE}"
+
+RDEPEND="perl? ( dev-lang/perl:= )
+	python? ( ${PYTHON_DEPS} )"
+DEPEND="${RDEPEND}"
+BDEPEND="
+	sys-devel/autoconf-archive
+	sys-devel/bison
+	sys-devel/flex
+	doc? ( dev-lang/perl )
+	perl? ( dev-lang/swig )
+	python? (
+		dev-lang/swig
+		dev-python/setuptools[${PYTHON_USEDEP}]
+	)"
+
+S=${WORKDIR}/apparmor-${PV}/libraries/${PN}
+
+# depends on the package already being installed
+RESTRICT="test"
+
+PATCHES=(
+        "${FILESDIR}"/${PN}-3.0.8-clang.patch
+)
+src_prepare() {
+	default
+
+	# We used to rm m4/ but led to this after eautoreconf:
+	# checking whether the libapparmor man pages should be generated... yes
+	# ./configure: 5065: PROG_PODCHECKER: not found
+	# ./configure: 5068: PROG_POD2MAN: not found
+	# checking whether python bindings are enabled... yes
+	eautoreconf
+
+	use python && distutils-r1_src_prepare
+}
+
+src_configure() {
+	filter-lto #887475
+	# Fails with reflex/byacc, heavily relies on bisonisms
+	export LEX=flex
+	export YACC=yacc.bison
+
+	econf \
+		$(use_enable static-libs static) \
+		$(use_with perl) \
+		$(use_with python)
+}
+
+src_compile() {
+	emake -C src
+	emake -C include
+	use doc && emake -C doc
+	use perl && emake -C swig/perl
+
+	if use python ; then
+		pushd swig/python > /dev/null
+		emake libapparmor_wrap.c
+		distutils-r1_src_compile
+		popd > /dev/null
+	fi
+}
+
+src_install() {
+	emake DESTDIR="${D}" -C src install
+	emake DESTDIR="${D}" -C include install
+	use doc && emake DESTDIR="${D}" -C doc install
+
+	if use perl ; then
+		emake DESTDIR="${D}" -C swig/perl install
+		perl_set_version
+		insinto "${VENDOR_ARCH}"
+		doins swig/perl/LibAppArmor.pm
+
+		# bug 620886
+		perl_delete_localpod
+		perl_fix_packlist
+	fi
+
+	if use python ; then
+		pushd swig/python > /dev/null || die
+		distutils-r1_src_install
+
+		popd > /dev/null || die
+	fi
+
+	dodoc AUTHORS ChangeLog NEWS README
+
+	find "${D}" -name '*.la' -delete || die
+}
+
+python_install() {
+	distutils-r1_python_install
+
+	python_moduleinto LibAppArmor
+	python_domodule LibAppArmor.py
+}


### PR DESCRIPTION
sys-libs/libarmor

These fixes remove -flto-partition=none from both packages then applies filter-lto so clang can now build this package and lto doesn't break apparmor.

Signed-off-by: Ian Jordan <immoloism@gmail.com>