### PR TITLE
www-client/surf: migrate to net-libs/webkit-gtk:4.1

### DIFF
--- a/www-client/surf/files/surf-2.1-gentoo-webkit-4.1.patch
+++ b/www-client/surf/files/surf-2.1-gentoo-webkit-4.1.patch
@@ -1,0 +1,28 @@
+--- a/config.mk
++++ b/config.mk
+@@ -4,18 +4,18 @@ VERSION = 2.1
+ # Customize below to fit your system
+ 
+ # paths
+-PREFIX = /usr/local
++PREFIX = /usr
+ MANPREFIX = $(PREFIX)/share/man
+ LIBPREFIX = $(PREFIX)/lib
+ LIBDIR = $(LIBPREFIX)/surf
+ 
+-X11INC = `pkg-config --cflags x11`
+-X11LIB = `pkg-config --libs x11`
++X11INC = $(shell $(PKG_CONFIG) --cflags x11)
++X11LIB = $(shell $(PKG_CONFIG) --libs x11)
+ 
+-GTKINC = `pkg-config --cflags gtk+-3.0 gcr-3 webkit2gtk-4.0`
+-GTKLIB = `pkg-config --libs gtk+-3.0 gcr-3 webkit2gtk-4.0`
+-WEBEXTINC = `pkg-config --cflags webkit2gtk-4.0 webkit2gtk-web-extension-4.0 gio-2.0`
+-WEBEXTLIBS = `pkg-config --libs webkit2gtk-4.0 webkit2gtk-web-extension-4.0 gio-2.0`
++GTKINC = $(shell $(PKG_CONFIG) --cflags gtk+-3.0 gcr-3 webkit2gtk-4.1)
++GTKLIB = $(shell $(PKG_CONFIG) --libs gtk+-3.0 gcr-3 webkit2gtk-4.1)
++WEBEXTINC = $(shell $(PKG_CONFIG) --cflags webkit2gtk-4.1 webkit2gtk-web-extension-4.1 gio-2.0)
++WEBEXTLIBS = $(shell $(PKG_CONFIG) --libs webkit2gtk-4.1 webkit2gtk-web-extension-4.1 gio-2.0)
+ 
+ # includes and libs
+ INCS = $(X11INC) $(GTKINC)

--- a/www-client/surf/surf-2.1-r3.ebuild
+++ b/www-client/surf/surf-2.1-r3.ebuild
@@ -1,0 +1,99 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit desktop savedconfig toolchain-funcs xdg
+
+DESCRIPTION="A simple web browser based on WebKit/GTK+"
+HOMEPAGE="https://surf.suckless.org/"
+
+if [[ ${PV} == "9999" ]] ; then
+	inherit git-r3
+	EGIT_REPO_URI="https://git.suckless.org/surf"
+	EGIT_BRANCH="surf-webkit2"
+else
+	SRC_URI="https://dl.suckless.org/${PN}/${P}.tar.gz"
+	KEYWORDS="~amd64 ~riscv ~x86"
+fi
+
+LICENSE="MIT"
+SLOT="0"
+IUSE="tabbed"
+
+DEPEND="
+	app-crypt/gcr:0=[gtk]
+	dev-libs/glib:2
+	net-libs/webkit-gtk:4.1=
+	x11-libs/gtk+:3
+	x11-libs/libX11
+"
+RDEPEND="${DEPEND}
+	!sci-chemistry/surf
+	!savedconfig? (
+		net-misc/curl
+		x11-apps/xprop
+		x11-misc/dmenu
+		x11-terms/st
+	)
+	tabbed? ( x11-misc/tabbed )
+"
+BDEPEND="
+	virtual/pkgconfig
+"
+
+PATCHES=(
+	"${FILESDIR}/${P}-gentoo-webkit-4.1.patch"
+)
+
+pkg_setup() {
+	if ! use savedconfig; then
+		elog "The default config.h assumes you have"
+		elog " net-misc/curl"
+		elog " x11-terms/st"
+		elog "installed to support the download function."
+		elog "Without those, downloads will fail (gracefully)."
+		elog "You can fix this by:"
+		elog "1) Installing these packages, or"
+		elog "2) Setting USE=savedconfig and changing config.h accordingly."
+	fi
+}
+
+src_prepare() {
+	default
+
+	restore_config config.h
+
+	tc-export CC PKG_CONFIG
+}
+
+src_install() {
+	default
+
+	if use tabbed; then
+		dobin surf-open.sh
+	fi
+
+	save_config config.h
+
+	newicon "${S}/${PN}.png" "${PN}.png"
+
+	local mime_types="text/html;text/xml;application/xhtml+xml;"
+	mime_types+="x-scheme-handler/http;x-scheme-handler/https;"
+	make_desktop_entry \
+		"surf %u" \
+		"Surf" \
+		"surf" \
+		"Network;WebBrowser" \
+		"MimeType=${mime_types}\nStartupWMClass=surf"
+}
+
+pkg_postinst() {
+	xdg_desktop_database_update
+	xdg_icon_cache_update
+}
+
+pkg_postrm() {
+	xdg_desktop_database_update
+	xdg_icon_cache_update
+}

--- a/www-client/surf/surf-9999.ebuild
+++ b/www-client/surf/surf-9999.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 inherit desktop savedconfig toolchain-funcs xdg
 
@@ -24,7 +24,7 @@ IUSE="tabbed"
 DEPEND="
 	app-crypt/gcr:0=[gtk]
 	dev-libs/glib:2
-	net-libs/webkit-gtk:4
+	net-libs/webkit-gtk:4.1=
 	x11-libs/gtk+:3
 	x11-libs/libX11
 "
@@ -41,8 +41,9 @@ RDEPEND="${DEPEND}
 BDEPEND="
 	virtual/pkgconfig
 "
+
 PATCHES=(
-	"${FILESDIR}"/${PN}-2.1-gentoo.patch
+	"${FILESDIR}/${PN}-2.1-gentoo-webkit-4.1.patch"
 )
 
 pkg_setup() {


### PR DESCRIPTION
- new revision with cahnged dependency `net-libs/webkit-gtk:{4 -> 4.1}`
- synced live ebuild with the same change.