### PR TITLE
net-misc/ntp fix permissions en /var/lib/ntp

### DIFF
--- a/net-misc/ntp/files/ntp.tmpfiles
+++ b/net-misc/ntp/files/ntp.tmpfiles
@@ -1,0 +1,1 @@
+d /var/lib/ntp 755 ntp ntp

--- a/net-misc/ntp/ntp-4.2.8_p15-r1.ebuild
+++ b/net-misc/ntp/ntp-4.2.8_p15-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit autotools flag-o-matic systemd
+inherit autotools flag-o-matic systemd tmpfiles
 
 MY_P=${P/_p/p}
 DESCRIPTION="Network Time Protocol suite/programs"
@@ -108,8 +108,7 @@ src_install() {
 	fi
 	sed -i "s:/usr/bin:/usr/sbin:" "${ED}"/etc/init.d/ntpd || die
 
-	keepdir /var/lib/ntp
-	fowners ntp:ntp /var/lib/ntp
+	newtmpfiles "${FILESDIR}"/ntp.tmpfiles ntp.conf
 
 	if use openntpd ; then
 		cd "${ED}" || die
@@ -134,6 +133,8 @@ src_install() {
 }
 
 pkg_postinst() {
+	tmpfiles_process ntp.conf
+
 	if grep -qs '^[^#].*notrust' "${EROOT}"/etc/ntp.conf ; then
 		eerror "The notrust option was found in your /etc/ntp.conf!"
 		ewarn "If your ntpd starts sending out weird responses,"

--- a/net-misc/ntp/ntp-4.2.8_p15-r1.ebuild
+++ b/net-misc/ntp/ntp-4.2.8_p15-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -7,8 +7,8 @@ inherit autotools flag-o-matic systemd
 
 MY_P=${P/_p/p}
 DESCRIPTION="Network Time Protocol suite/programs"
-HOMEPAGE="http://www.ntp.org/"
-SRC_URI="http://www.eecis.udel.edu/~ntp/ntp_spool/ntp4/ntp-${PV:0:3}/${MY_P}.tar.gz
+HOMEPAGE="https://www.ntp.org/"
+SRC_URI="https://www.eecis.udel.edu/~ntp/ntp_spool/ntp4/ntp-${PV:0:3}/${MY_P}.tar.gz
 	https://dev.gentoo.org/~polynomial-c/${MY_P}-manpages.tar.xz"
 
 LICENSE="HPND BSD ISC"
@@ -109,7 +109,7 @@ src_install() {
 	sed -i "s:/usr/bin:/usr/sbin:" "${ED}"/etc/init.d/ntpd || die
 
 	keepdir /var/lib/ntp
-	use prefix || fowners ntp:ntp /var/lib/ntp
+	fowners ntp:ntp /var/lib/ntp
 
 	if use openntpd ; then
 		cd "${ED}" || die

--- a/net-misc/ntp/ntp-4.2.8_p15-r4.ebuild
+++ b/net-misc/ntp/ntp-4.2.8_p15-r4.ebuild
@@ -7,8 +7,8 @@ inherit autotools flag-o-matic systemd
 
 MY_P=${P/_p/p}
 DESCRIPTION="Network Time Protocol suite/programs"
-HOMEPAGE="http://www.ntp.org/"
-SRC_URI="http://www.eecis.udel.edu/~ntp/ntp_spool/ntp4/ntp-${PV:0:3}/${MY_P}.tar.gz
+HOMEPAGE="https://www.ntp.org/"
+SRC_URI="https://www.eecis.udel.edu/~ntp/ntp_spool/ntp4/ntp-${PV:0:3}/${MY_P}.tar.gz
 	https://dev.gentoo.org/~polynomial-c/${MY_P}-manpages.tar.xz"
 
 LICENSE="HPND BSD ISC"
@@ -110,7 +110,7 @@ src_install() {
 	sed -i "s:/usr/bin:/usr/sbin:" "${ED}"/etc/init.d/ntpd || die
 
 	keepdir /var/lib/ntp
-	use prefix || fowners ntp:ntp /var/lib/ntp
+	fowners ntp:ntp /var/lib/ntp
 
 	if use openntpd ; then
 		cd "${ED}" || die

--- a/net-misc/ntp/ntp-4.2.8_p15-r4.ebuild
+++ b/net-misc/ntp/ntp-4.2.8_p15-r4.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit autotools flag-o-matic systemd
+inherit autotools flag-o-matic systemd tmpfiles
 
 MY_P=${P/_p/p}
 DESCRIPTION="Network Time Protocol suite/programs"
@@ -109,8 +109,7 @@ src_install() {
 	fi
 	sed -i "s:/usr/bin:/usr/sbin:" "${ED}"/etc/init.d/ntpd || die
 
-	keepdir /var/lib/ntp
-	fowners ntp:ntp /var/lib/ntp
+	newtmpfiles "${FILESDIR}"/ntp.tmpfiles ntp.conf
 
 	if use openntpd ; then
 		cd "${ED}" || die
@@ -135,6 +134,8 @@ src_install() {
 }
 
 pkg_postinst() {
+	tmpfiles_process ntp.conf
+
 	if grep -qs '^[^#].*notrust' "${EROOT}"/etc/ntp.conf ; then
 		eerror "The notrust option was found in your /etc/ntp.conf!"
 		ewarn "If your ntpd starts sending out weird responses,"

--- a/net-misc/ntp/ntp-4.2.8_p15.ebuild
+++ b/net-misc/ntp/ntp-4.2.8_p15.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit autotools flag-o-matic systemd
+inherit autotools flag-o-matic systemd tmpfiles
 
 MY_P=${P/_p/p}
 DESCRIPTION="Network Time Protocol suite/programs"
@@ -108,6 +108,8 @@ src_install() {
 	fi
 	sed -i "s:/usr/bin:/usr/sbin:" "${ED}"/etc/init.d/ntpd || die
 
+	newtmpfiles "${FILESDIR}"/ntp.tmpfiles ntp.conf
+
 	keepdir /var/lib/ntp
 	fowners ntp:ntp /var/lib/ntp
 
@@ -134,6 +136,8 @@ src_install() {
 }
 
 pkg_postinst() {
+	tmpfiles_process ntp.conf
+
 	if grep -qs '^[^#].*notrust' "${EROOT}"/etc/ntp.conf ; then
 		eerror "The notrust option was found in your /etc/ntp.conf!"
 		ewarn "If your ntpd starts sending out weird responses,"

--- a/net-misc/ntp/ntp-4.2.8_p15.ebuild
+++ b/net-misc/ntp/ntp-4.2.8_p15.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -7,8 +7,8 @@ inherit autotools flag-o-matic systemd
 
 MY_P=${P/_p/p}
 DESCRIPTION="Network Time Protocol suite/programs"
-HOMEPAGE="http://www.ntp.org/"
-SRC_URI="http://www.eecis.udel.edu/~ntp/ntp_spool/ntp4/ntp-${PV:0:3}/${MY_P}.tar.gz
+HOMEPAGE="https://www.ntp.org/"
+SRC_URI="https://www.eecis.udel.edu/~ntp/ntp_spool/ntp4/ntp-${PV:0:3}/${MY_P}.tar.gz
 	https://dev.gentoo.org/~polynomial-c/${MY_P}-manpages.tar.xz"
 
 LICENSE="HPND BSD ISC"
@@ -109,7 +109,7 @@ src_install() {
 	sed -i "s:/usr/bin:/usr/sbin:" "${ED}"/etc/init.d/ntpd || die
 
 	keepdir /var/lib/ntp
-	use prefix || fowners ntp:ntp /var/lib/ntp
+	fowners ntp:ntp /var/lib/ntp
 
 	if use openntpd ; then
 		cd "${ED}" || die


### PR DESCRIPTION
Update http to https too

This fix solve problems when ntp try write in a /var/lib/ntp directory , You see the log:


feb 09 22:33:32 xxx ntpd[4734]: frequency file /var/lib/ntp/ntp.drift.TEMP: Permission denied
feb 09 22:33:32 xxx ntpd[4734]:  9 Feb 22:33:32 ntpd[4734]: frequency file /var/lib/ntp/ntp.drift.TEMP: Permission denied
feb 09 23:33:32 xxx ntpd[4734]: frequency file /var/lib/ntp/ntp.drift.TEMP: Permission denied
feb 09 23:33:32 xxx ntpd[4734]:  9 Feb 23:33:32 ntpd[4734]: frequency file /var/lib/ntp/ntp.drift.TEMP: Permission denied
feb 10 02:33:32 xxx ntpd[4734]: frequency file /var/lib/ntp/ntp.drift.TEMP: Permission denied


I think that the permissions should always be adjusted whether there is a prefix or the prefix does not exist

Signed-off-by: INODE64 <ffelix@inode64.com>