### PR TITLE
sys-apps/gentoo-systemd-integration: need floppy and usb groups in /lib/udev/rules.d/40-gentoo.rules

### DIFF
--- a/acct-group/floppy/floppy-0.ebuild
+++ b/acct-group/floppy/floppy-0.ebuild
@@ -1,0 +1,8 @@
+# Copyright 2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit acct-group
+
+ACCT_GROUP_ID=11

--- a/sys-apps/gentoo-systemd-integration/gentoo-systemd-integration-9.ebuild
+++ b/sys-apps/gentoo-systemd-integration/gentoo-systemd-integration-9.ebuild
@@ -20,7 +20,9 @@ LICENSE="BSD"
 SLOT="0"
 IUSE=""
 
-RDEPEND=">=sys-apps/systemd-207
+RDEPEND="acct-group/floppy
+	acct-group/usb
+	>=sys-apps/systemd-207
 	!sys-fs/eudev
 	!sys-fs/udev"
 DEPEND=">=sys-apps/systemd-207"

--- a/sys-apps/gentoo-systemd-integration/gentoo-systemd-integration-9999.ebuild
+++ b/sys-apps/gentoo-systemd-integration/gentoo-systemd-integration-9999.ebuild
@@ -20,7 +20,9 @@ LICENSE="BSD"
 SLOT="0"
 IUSE=""
 
-RDEPEND=">=sys-apps/systemd-207
+RDEPEND="acct-group/floppy
+	acct-group/usb
+	>=sys-apps/systemd-207
 	!sys-fs/eudev
 	!sys-fs/udev"
 DEPEND=">=sys-apps/systemd-207"


### PR DESCRIPTION


See the error log

feb 10 13:02:30 xxx systemd-udevd[3186]: /lib/udev/rules.d/40-gentoo.rules:2 Unknown group 'floppy', ignoring

Signed-off-by: INODE64 <ffelix@inode64.com>