### PR TITLE
pypi.eclass: filename normalization + version translation support

### DIFF
--- a/dev-python/Faker/Faker-16.6.1.ebuild
+++ b/dev-python/Faker/Faker-16.6.1.ebuild
@@ -4,6 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
+PYPI_NO_NORMALIZE=1
 PYTHON_COMPAT=( python3_{9..11} )
 
 inherit distutils-r1 pypi

--- a/dev-python/Faker/Faker-16.8.1.ebuild
+++ b/dev-python/Faker/Faker-16.8.1.ebuild
@@ -4,6 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
+PYPI_NO_NORMALIZE=1
 PYTHON_COMPAT=( python3_{9..11} )
 
 inherit distutils-r1 pypi

--- a/dev-python/Nuitka/Nuitka-1.4.4.ebuild
+++ b/dev-python/Nuitka/Nuitka-1.4.4.ebuild
@@ -4,6 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
+PYPI_NO_NORMALIZE=1
 PYTHON_COMPAT=( python3_10 )
 
 inherit distutils-r1 flag-o-matic optfeature pypi

--- a/dev-python/Nuitka/Nuitka-1.4.5.ebuild
+++ b/dev-python/Nuitka/Nuitka-1.4.5.ebuild
@@ -4,6 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
+PYPI_NO_NORMALIZE=1
 PYTHON_COMPAT=( python3_10 )
 
 inherit distutils-r1 flag-o-matic optfeature pypi

--- a/dev-python/click-plugins/click-plugins-1.1.1-r1.ebuild
+++ b/dev-python/click-plugins/click-plugins-1.1.1-r1.ebuild
@@ -3,6 +3,7 @@
 
 EAPI=8
 
+PYPI_NO_NORMALIZE=1
 PYTHON_COMPAT=( python3_{9..11} )
 DISTUTILS_USE_PEP517=setuptools
 

--- a/dev-python/jaraco-classes/jaraco-classes-3.2.3.ebuild
+++ b/dev-python/jaraco-classes/jaraco-classes-3.2.3.ebuild
@@ -13,7 +13,7 @@ HOMEPAGE="
 	https://github.com/jaraco/jaraco.classes/
 	https://pypi.org/project/jaraco.classes/
 "
-SRC_URI="$(pypi_sdist_url "${PN/-/.}")"
+SRC_URI="$(pypi_sdist_url --no-normalize "${PN/-/.}")"
 S=${WORKDIR}/${P/-/.}
 
 LICENSE="MIT"

--- a/dev-python/jaraco-collections/jaraco-collections-3.8.0.ebuild
+++ b/dev-python/jaraco-collections/jaraco-collections-3.8.0.ebuild
@@ -13,7 +13,7 @@ HOMEPAGE="
 	https://github.com/jaraco/jaraco.collections/
 	https://pypi.org/project/jaraco.collections/
 "
-SRC_URI="$(pypi_sdist_url "${PN/-/.}")"
+SRC_URI="$(pypi_sdist_url --no-normalize "${PN/-/.}")"
 S=${WORKDIR}/${P/-/.}
 
 LICENSE="MIT"

--- a/dev-python/jaraco-context/jaraco-context-4.3.0.ebuild
+++ b/dev-python/jaraco-context/jaraco-context-4.3.0.ebuild
@@ -14,7 +14,7 @@ HOMEPAGE="
 	https://github.com/jaraco/jaraco.context/
 	https://pypi.org/project/jaraco.context/
 "
-SRC_URI="$(pypi_sdist_url "${PN/-/.}")"
+SRC_URI="$(pypi_sdist_url --no-normalize "${PN/-/.}")"
 S=${WORKDIR}/${P/-/.}
 
 LICENSE="MIT"

--- a/dev-python/jaraco-envs/jaraco-envs-2.4.0.ebuild
+++ b/dev-python/jaraco-envs/jaraco-envs-2.4.0.ebuild
@@ -10,7 +10,7 @@ inherit distutils-r1 pypi
 
 DESCRIPTION="Classes for orchestrating Python (virtual) environments"
 HOMEPAGE="https://github.com/jaraco/jaraco.envs"
-SRC_URI="$(pypi_sdist_url "${PN/-/.}")"
+SRC_URI="$(pypi_sdist_url --no-normalize "${PN/-/.}")"
 S=${WORKDIR}/${P/-/.}
 
 LICENSE="MIT"

--- a/dev-python/jaraco-functools/jaraco-functools-3.5.2.ebuild
+++ b/dev-python/jaraco-functools/jaraco-functools-3.5.2.ebuild
@@ -14,7 +14,7 @@ HOMEPAGE="
 	https://github.com/jaraco/jaraco.functools/
 	https://pypi.org/project/jaraco.functools/
 "
-SRC_URI="$(pypi_sdist_url "${PN/-/.}")"
+SRC_URI="$(pypi_sdist_url --no-normalize "${PN/-/.}")"
 S=${WORKDIR}/${P/-/.}
 
 LICENSE="MIT"

--- a/dev-python/jaraco-itertools/jaraco-itertools-6.2.1.ebuild
+++ b/dev-python/jaraco-itertools/jaraco-itertools-6.2.1.ebuild
@@ -10,7 +10,7 @@ inherit distutils-r1 pypi
 
 DESCRIPTION="Tools for working with iterables. Complements itertools and more_itertools"
 HOMEPAGE="https://github.com/jaraco/jaraco.itertools"
-SRC_URI="$(pypi_sdist_url "${PN/-/.}")"
+SRC_URI="$(pypi_sdist_url --no-normalize "${PN/-/.}")"
 S=${WORKDIR}/${P/-/.}
 
 LICENSE="MIT"

--- a/dev-python/jaraco-logging/jaraco-logging-3.1.2.ebuild
+++ b/dev-python/jaraco-logging/jaraco-logging-3.1.2.ebuild
@@ -13,7 +13,7 @@ HOMEPAGE="
 	https://github.com/jaraco/jaraco.logging/
 	https://pypi.org/project/jaraco.logging/
 "
-SRC_URI="$(pypi_sdist_url "${PN/-/.}")"
+SRC_URI="$(pypi_sdist_url --no-normalize "${PN/-/.}")"
 S=${WORKDIR}/${P/-/.}
 
 LICENSE="MIT"

--- a/dev-python/jaraco-path/jaraco-path-3.4.0.ebuild
+++ b/dev-python/jaraco-path/jaraco-path-3.4.0.ebuild
@@ -13,7 +13,7 @@ HOMEPAGE="
 	https://github.com/jaraco/jaraco.path/
 	https://pypi.org/project/jaraco.path/
 "
-SRC_URI="$(pypi_sdist_url "${PN/-/.}")"
+SRC_URI="$(pypi_sdist_url --no-normalize "${PN/-/.}")"
 S=${WORKDIR}/${P/-/.}
 
 LICENSE="MIT"

--- a/dev-python/jaraco-stream/jaraco-stream-3.0.3-r1.ebuild
+++ b/dev-python/jaraco-stream/jaraco-stream-3.0.3-r1.ebuild
@@ -13,7 +13,7 @@ HOMEPAGE="
 	https://github.com/jaraco/jaraco.stream/
 	https://pypi.org/project/jaraco.stream/
 "
-SRC_URI="$(pypi_sdist_url "${PN/-/.}")"
+SRC_URI="$(pypi_sdist_url --no-normalize "${PN/-/.}")"
 S=${WORKDIR}/${P/-/.}
 
 LICENSE="MIT"

--- a/dev-python/jaraco-test/jaraco-test-5.3.0.ebuild
+++ b/dev-python/jaraco-test/jaraco-test-5.3.0.ebuild
@@ -13,7 +13,7 @@ HOMEPAGE="
 	https://github.com/jaraco/jaraco.test/
 	https://pypi.org/project/jaraco.test/
 "
-SRC_URI="$(pypi_sdist_url "${PN/-/.}")"
+SRC_URI="$(pypi_sdist_url --no-normalize "${PN/-/.}")"
 S=${WORKDIR}/${P/-/.}
 
 LICENSE="MIT"

--- a/dev-python/jaraco-text/jaraco-text-3.11.1.ebuild
+++ b/dev-python/jaraco-text/jaraco-text-3.11.1.ebuild
@@ -14,7 +14,7 @@ HOMEPAGE="
 	https://github.com/jaraco/jaraco.text/
 	https://pypi.org/project/jaraco.text/
 "
-SRC_URI="$(pypi_sdist_url "${PN/-/.}")"
+SRC_URI="$(pypi_sdist_url --no-normalize "${PN/-/.}")"
 S=${WORKDIR}/${P/-/.}
 
 LICENSE="MIT"

--- a/dev-python/keyrings-alt/keyrings-alt-4.2.0.ebuild
+++ b/dev-python/keyrings-alt/keyrings-alt-4.2.0.ebuild
@@ -13,7 +13,7 @@ HOMEPAGE="
 	https://github.com/jaraco/keyrings.alt/
 	https://pypi.org/project/keyrings.alt/
 "
-SRC_URI="$(pypi_sdist_url "${PN/-/.}")"
+SRC_URI="$(pypi_sdist_url --no-normalize "${PN/-/.}")"
 S=${WORKDIR}/${P/-/.}
 
 LICENSE="MIT"

--- a/dev-python/markups/markups-4.0.0.ebuild
+++ b/dev-python/markups/markups-4.0.0.ebuild
@@ -14,7 +14,7 @@ HOMEPAGE="
 	https://github.com/retext-project/pymarkups
 	https://pypi.org/project/Markups/
 "
-SRC_URI="$(pypi_sdist_url "${PN^}")"
+SRC_URI="$(pypi_sdist_url --no-normalize "${PN^}")"
 S=${WORKDIR}/${P^}
 
 LICENSE="BSD"

--- a/dev-python/pip-run/pip-run-10.0.5-r1.ebuild
+++ b/dev-python/pip-run/pip-run-10.0.5-r1.ebuild
@@ -4,6 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
+PYPI_NO_NORMALIZE=1
 PYTHON_COMPAT=( python3_{9..11} pypy3 )
 
 inherit distutils-r1 pypi

--- a/dev-python/pytest-rerunfailures/pytest-rerunfailures-11.1.ebuild
+++ b/dev-python/pytest-rerunfailures/pytest-rerunfailures-11.1.ebuild
@@ -4,6 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
+PYPI_NO_NORMALIZE=1
 PYTHON_COMPAT=( python3_{9..11} pypy3 )
 
 inherit distutils-r1 pypi

--- a/dev-python/pytest-xdist/pytest-xdist-3.2.0.ebuild
+++ b/dev-python/pytest-xdist/pytest-xdist-3.2.0.ebuild
@@ -4,6 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
+PYPI_NO_NORMALIZE=1
 PYTHON_COMPAT=( python3_{9..11} pypy3 )
 
 inherit distutils-r1 pypi

--- a/dev-python/python-utils/python-utils-3.5.1.ebuild
+++ b/dev-python/python-utils/python-utils-3.5.1.ebuild
@@ -4,6 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
+PYPI_NO_NORMALIZE=1
 PYTHON_COMPAT=( python3_{9..11} pypy3 )
 
 inherit distutils-r1 pypi

--- a/dev-python/python-utils/python-utils-3.5.2.ebuild
+++ b/dev-python/python-utils/python-utils-3.5.2.ebuild
@@ -4,6 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
+PYPI_NO_NORMALIZE=1
 PYTHON_COMPAT=( python3_{9..11} pypy3 )
 
 inherit distutils-r1 pypi

--- a/dev-python/rst-linker/rst-linker-2.4.0.ebuild
+++ b/dev-python/rst-linker/rst-linker-2.4.0.ebuild
@@ -13,7 +13,7 @@ HOMEPAGE="
 	https://github.com/jaraco/rst.linker/
 	https://pypi.org/project/rst.linker/
 "
-SRC_URI="$(pypi_sdist_url "${PN/-/.}")"
+SRC_URI="$(pypi_sdist_url --no-normalize "${PN/-/.}")"
 S=${WORKDIR}/${P/-/.}
 
 LICENSE="MIT"

--- a/dev-python/sqlalchemy/sqlalchemy-2.0.3.ebuild
+++ b/dev-python/sqlalchemy/sqlalchemy-2.0.3.ebuild
@@ -16,7 +16,7 @@ HOMEPAGE="
 	https://pypi.org/project/SQLAlchemy/
 	https://github.com/sqlalchemy/sqlalchemy/
 "
-SRC_URI="$(pypi_sdist_url "${MY_PN}")"
+SRC_URI="$(pypi_sdist_url --no-normalize "${MY_PN}")"
 S="${WORKDIR}/${MY_PN}-${PV}"
 
 LICENSE="MIT"

--- a/dev-python/types-docutils/types-docutils-0.19.1.3.ebuild
+++ b/dev-python/types-docutils/types-docutils-0.19.1.3.ebuild
@@ -4,6 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
+PYPI_NO_NORMALIZE=1
 PYTHON_COMPAT=( python3_{9..11} )
 
 inherit distutils-r1 pypi

--- a/eclass/pypi.eclass
+++ b/eclass/pypi.eclass
@@ -12,7 +12,8 @@
 # The pypi.eclass can be used to easily obtain URLs for artifacts
 # uploaded to PyPI.org.  When inherited, the eclass defaults SRC_URI
 # and S to fetch .tar.gz sdist.  The project filename is normalized
-# by default, and the version is translated using
+# by default (unless PYPI_NO_NORMALIZE is set prior to inheriting
+# the eclass), and the version is translated using
 # pypi_translate_version.
 #
 # If necessary, SRC_URI and S can be overriden by the ebuild.  Two
@@ -41,6 +42,13 @@ esac
 
 if [[ ! ${_PYPI_ECLASS} ]]; then
 _PYPI_ECLASS=1
+
+# @ECLASS_VARIABLE: PYPI_NO_NORMALIZE
+# @PRE_INHERIT
+# @DEFAULT_UNSET
+# @DESCRIPTION:
+# When set to a non-empty value, disables project name normalization
+# for the default SRC_URI and S values.
 
 # @FUNCTION: pypi_normalize_name
 # @USAGE: <name>
@@ -200,7 +208,12 @@ pypi_wheel_url() {
 	fi
 }
 
-SRC_URI="$(pypi_sdist_url)"
-S="${WORKDIR}/$(pypi_normalize_name "${PN}")-$(pypi_translate_version "${PV}")"
+if [[ ${PYPI_NO_NORMALIZE} ]]; then
+	SRC_URI="$(pypi_sdist_url --no-normalize)"
+	S="${WORKDIR}/${PN}-$(pypi_translate_version "${PV}")"
+else
+	SRC_URI="$(pypi_sdist_url)"
+	S="${WORKDIR}/$(pypi_normalize_name "${PN}")-$(pypi_translate_version "${PV}")"
+fi
 
 fi

--- a/eclass/pypi.eclass
+++ b/eclass/pypi.eclass
@@ -55,26 +55,41 @@ pypi_normalize_name() {
 }
 
 # @FUNCTION: pypi_sdist_url
-# @USAGE: [<project> [<version> [<suffix>]]]
+# @USAGE: [--no-normalize] [<project> [<version> [<suffix>]]]
 # @DESCRIPTION:
 # Output the URL to PyPI sdist for specified project/version tuple.
 #
-# If <package> is unspecified, it defaults to ${PN}.
+# The `--no-normalize` option disables project name normalization
+# for sdist filename.  This may be necessary when dealing with distfiles
+# generated using build systems that did not follow PEP 625
+# (i.e. the sdist name contains uppercase letters, hyphens or dots).
+#
+# If <package> is unspecified, it defaults to ${PN}.  The package name
+# is normalized according to the specification unless `--no-normalize`
+# is passed.
 #
 # If <version> is unspecified, it defaults to ${PV}.
 #
 # If <format> is unspecified, it defaults to ".tar.gz".  Another valid
 # value is ".zip" (please remember to add a BDEPEND on app-arch/unzip).
 pypi_sdist_url() {
+	local normalize=1
+	if [[ ${1} == --no-normalize ]]; then
+		normalize=
+		shift
+	fi
+
 	if [[ ${#} -gt 3 ]]; then
-		die "Usage: ${FUNCNAME} <project> [<version> [<suffix>]]"
+		die "Usage: ${FUNCNAME} [--no-normalize] <project> [<version> [<suffix>]]"
 	fi
 
 	local project=${1-"${PN}"}
 	local version=${2-"${PV}"}
 	local suffix=${3-.tar.gz}
+	local fn_project=${project}
+	[[ ${normalize} ]] && fn_project=$(pypi_normalize_name "${project}")
 	printf "https://files.pythonhosted.org/packages/source/%s" \
-		"${project::1}/${project}/${project}-${version}${suffix}"
+		"${project::1}/${project}/${fn_project}-${version}${suffix}"
 }
 
 # @FUNCTION: pypi_wheel_name

--- a/eclass/pypi.eclass
+++ b/eclass/pypi.eclass
@@ -34,10 +34,6 @@ esac
 if [[ ! ${_PYPI_ECLASS} ]]; then
 _PYPI_ECLASS=1
 
-SRC_URI="
-	https://files.pythonhosted.org/packages/source/${PN::1}/${PN}/${P}.tar.gz
-"
-
 # @FUNCTION: pypi_sdist_url
 # @USAGE: [<project> [<version> [<suffix>]]]
 # @DESCRIPTION:
@@ -131,5 +127,7 @@ pypi_wheel_url() {
 		echo " -> ${filename}.zip"
 	fi
 }
+
+SRC_URI="$(pypi_sdist_url)"
 
 fi

--- a/eclass/pypi.eclass
+++ b/eclass/pypi.eclass
@@ -87,7 +87,10 @@ pypi_translate_version() {
 # is normalized according to the specification unless `--no-normalize`
 # is passed.
 #
-# If <version> is unspecified, it defaults to ${PV}.
+# If <version> is unspecified, it defaults to ${PV} translated
+# via pypi_translate_version.  If it is specified, then it is used
+# verbatim (the function can be called explicitly to translate custom
+# version number).
 #
 # If <format> is unspecified, it defaults to ".tar.gz".  Another valid
 # value is ".zip" (please remember to add a BDEPEND on app-arch/unzip).
@@ -103,7 +106,7 @@ pypi_sdist_url() {
 	fi
 
 	local project=${1-"${PN}"}
-	local version=${2-"${PV}"}
+	local version=${2-"$(pypi_translate_version "${PV}")"}
 	local suffix=${3-.tar.gz}
 	local fn_project=${project}
 	[[ ${normalize} ]] && fn_project=$(pypi_normalize_name "${project}")
@@ -119,7 +122,10 @@ pypi_sdist_url() {
 # If <package> is unspecified, it defaults to ${PN}.  The package name
 # is normalized according to the wheel specification.
 #
-# If <version> is unspecified, it defaults to ${PV}.
+# If <version> is unspecified, it defaults to ${PV} translated
+# via pypi_translate_version.  If it is specified, then it is used
+# verbatim (the function can be called explicitly to translate custom
+# version number).
 #
 # If <python-tag> is unspecified, it defaults to "py3".  It can also be
 # "py2.py3", or a specific version in case of non-pure wheels.
@@ -133,7 +139,7 @@ pypi_wheel_name() {
 	fi
 
 	local project=$(pypi_normalize_name "${1-"${PN}"}")
-	local version=${2-"${PV}"}
+	local version=${2-"$(pypi_translate_version "${PV}")"}
 	local pytag=${3-py3}
 	local abitag=${4-none-any}
 	echo "${project}-${version}-${pytag}-${abitag}.whl"
@@ -152,7 +158,10 @@ pypi_wheel_name() {
 #
 # If <package> is unspecified, it defaults to ${PN}.
 #
-# If <version> is unspecified, it defaults to ${PV}.
+# If <version> is unspecified, it defaults to ${PV} translated
+# via pypi_translate_version.  If it is specified, then it is used
+# verbatim (the function can be called explicitly to translate custom
+# version number).
 #
 # If <python-tag> is unspecified, it defaults to "py3".  It can also be
 # "py2.py3", or a specific version in case of non-pure wheels.
@@ -173,7 +182,7 @@ pypi_wheel_url() {
 
 	local filename=$(pypi_wheel_name "${@}")
 	local project=${1-"${PN}"}
-	local version=${2-"${PV}"}
+	local version=${2-"$(pypi_translate_version "${PV}")"}
 	local pytag=${3-py3}
 	printf "https://files.pythonhosted.org/packages/%s" \
 		"${pytag}/${project::1}/${project}/${filename}"

--- a/eclass/pypi.eclass
+++ b/eclass/pypi.eclass
@@ -54,6 +54,25 @@ pypi_normalize_name() {
 	echo "${name,,}"
 }
 
+# @FUNCTION: pypi_translate_version
+# @USAGE: <version>
+# @DESCRIPTION:
+# Translate the specified Gentoo version into the usual Python
+# counterpart.  Assumes PEP 440 versions.
+#
+# Note that we do not have clear counterparts for the epoch segment,
+# nor for development release segment.
+pypi_translate_version() {
+	[[ ${#} -ne 1 ]] && die "Usage: ${FUNCNAME} <version>"
+
+	local version=${1}
+	version=${version/_alpha/a}
+	version=${version/_beta/b}
+	version=${version/_rc/rc}
+	version=${version/_p/.post}
+	echo "${version}"
+}
+
 # @FUNCTION: pypi_sdist_url
 # @USAGE: [--no-normalize] [<project> [<version> [<suffix>]]]
 # @DESCRIPTION:

--- a/eclass/pypi.eclass
+++ b/eclass/pypi.eclass
@@ -134,7 +134,7 @@ pypi_wheel_url() {
 	fi
 
 	if [[ ${#} -gt 4 ]]; then
-		die "Usage: ${FUNCNAME} <project> [<version> [<python-tag> [<abi-platform-tag>]]]"
+		die "Usage: ${FUNCNAME} [--unpack] <project> [<version> [<python-tag> [<abi-platform-tag>]]]"
 	fi
 
 	local filename=$(pypi_wheel_name "${@}")

--- a/eclass/pypi.eclass
+++ b/eclass/pypi.eclass
@@ -11,12 +11,20 @@
 # @DESCRIPTION:
 # The pypi.eclass can be used to easily obtain URLs for artifacts
 # uploaded to PyPI.org.  When inherited, the eclass defaults SRC_URI
-# to fetch ${P}.tar.gz sdist.
+# and S to fetch .tar.gz sdist.  The project filename is normalized
+# by default, and the version is translated using
+# pypi_translate_version.
 #
-# If necessary, SRC_URI can be overriden by the ebuild.  Two helper
-# functions, pypi_sdist_url and pypi_wheel_url are provided to generate
-# URLs to artifacts of specified type, with customizable project name.
-# Additionally, pypi_wheel_name can be used to generate wheel filename.
+# If necessary, SRC_URI and S can be overriden by the ebuild.  Two
+# helper functions, pypi_sdist_url and pypi_wheel_url are provided
+# to generate URLs to artifacts of specified type, with customizable
+# URL components.  Additionally, pypi_wheel_name can be used to generate
+# wheel filename.
+#
+# pypi_normalize_name can be used to normalize an arbitrary project name
+# according to sdist/wheel normalization rules.  pypi_translate_version
+# can be used to translate a Gentoo version string into its PEP 440
+# equivalent.
 #
 # @EXAMPLE:
 # @CODE@
@@ -193,5 +201,6 @@ pypi_wheel_url() {
 }
 
 SRC_URI="$(pypi_sdist_url)"
+S="${WORKDIR}/$(pypi_normalize_name "${PN}")-$(pypi_translate_version "${PV}")"
 
 fi

--- a/eclass/pypi.eclass
+++ b/eclass/pypi.eclass
@@ -82,7 +82,8 @@ pypi_sdist_url() {
 # @DESCRIPTION:
 # Output the wheel filename for the specified project/version tuple.
 #
-# If <package> is unspecified, it defaults to ${PN}.
+# If <package> is unspecified, it defaults to ${PN}.  The package name
+# is normalized according to the wheel specification.
 #
 # If <version> is unspecified, it defaults to ${PV}.
 #
@@ -97,7 +98,7 @@ pypi_wheel_name() {
 		die "Usage: ${FUNCNAME} <project> [<version> [<python-tag> [<abi-platform-tag>]]]"
 	fi
 
-	local project=${1-"${PN}"}
+	local project=$(pypi_normalize_name "${1-"${PN}"}")
 	local version=${2-"${PV}"}
 	local pytag=${3-py3}
 	local abitag=${4-none-any}

--- a/eclass/pypi.eclass
+++ b/eclass/pypi.eclass
@@ -34,6 +34,26 @@ esac
 if [[ ! ${_PYPI_ECLASS} ]]; then
 _PYPI_ECLASS=1
 
+# @FUNCTION: pypi_normalize_name
+# @USAGE: <name>
+# @DESCRIPTION:
+# Normalize the project name according to sdist/wheel normalization
+# rules.  That is, convert to lowercase and replace runs of [._-]
+# with a single underscore.
+#
+# Based on the spec, as of 2023-02-10:
+# https://packaging.python.org/en/latest/specifications/#package-distribution-file-formats
+pypi_normalize_name() {
+	[[ ${#} -ne 1 ]] && die "Usage: ${FUNCNAME} <name>"
+
+	local name=${1}
+	local shopt_save=$(shopt -p extglob)
+	shopt -s extglob
+	name=${name//+([._-])/_}
+	${shopt_save}
+	echo "${name,,}"
+}
+
 # @FUNCTION: pypi_sdist_url
 # @USAGE: [<project> [<version> [<suffix>]]]
 # @DESCRIPTION:

--- a/eclass/tests/pypi.sh
+++ b/eclass/tests/pypi.sh
@@ -6,7 +6,7 @@ EAPI=8
 source tests-common.sh || exit
 
 PN=Foo.Bar
-PV=1.2.3
+PV=1.2.3_beta2
 
 inherit pypi
 
@@ -39,8 +39,8 @@ test-eq "pypi_translate_version 1.2.3_beta1" 1.2.3b1
 test-eq "pypi_translate_version 1.2.3_rc2" 1.2.3rc2
 test-eq "pypi_translate_version 1.2.3_rc2_p1" 1.2.3rc2.post1
 
-test-eq "pypi_wheel_name" foo_bar-1.2.3-py3-none-any.whl
-test-eq "pypi_wheel_name Flask-BabelEx" flask_babelex-1.2.3-py3-none-any.whl
+test-eq "pypi_wheel_name" foo_bar-1.2.3b2-py3-none-any.whl
+test-eq "pypi_wheel_name Flask-BabelEx" flask_babelex-1.2.3b2-py3-none-any.whl
 test-eq "pypi_wheel_name Flask-BabelEx 4" flask_babelex-4-py3-none-any.whl
 test-eq "pypi_wheel_name Flask-BabelEx 4 py2.py3" \
 	flask_babelex-4-py2.py3-none-any.whl
@@ -48,9 +48,9 @@ test-eq "pypi_wheel_name cryptography 39.0.1 cp36 abi3-manylinux_2_28_x86_64" \
 	cryptography-39.0.1-cp36-abi3-manylinux_2_28_x86_64.whl
 
 test-eq "pypi_wheel_url" \
-	https://files.pythonhosted.org/packages/py3/F/Foo.Bar/foo_bar-1.2.3-py3-none-any.whl
+	https://files.pythonhosted.org/packages/py3/F/Foo.Bar/foo_bar-1.2.3b2-py3-none-any.whl
 test-eq "pypi_wheel_url Flask-BabelEx" \
-	https://files.pythonhosted.org/packages/py3/F/Flask-BabelEx/flask_babelex-1.2.3-py3-none-any.whl
+	https://files.pythonhosted.org/packages/py3/F/Flask-BabelEx/flask_babelex-1.2.3b2-py3-none-any.whl
 test-eq "pypi_wheel_url Flask-BabelEx 4" \
 	https://files.pythonhosted.org/packages/py3/F/Flask-BabelEx/flask_babelex-4-py3-none-any.whl
 test-eq "pypi_wheel_url Flask-BabelEx 4 py2.py3" \
@@ -59,9 +59,9 @@ test-eq "pypi_wheel_url cryptography 39.0.1 cp36 abi3-manylinux_2_28_x86_64" \
 	https://files.pythonhosted.org/packages/cp36/c/cryptography/cryptography-39.0.1-cp36-abi3-manylinux_2_28_x86_64.whl
 
 test-eq "pypi_wheel_url --unpack" \
-	"https://files.pythonhosted.org/packages/py3/F/Foo.Bar/foo_bar-1.2.3-py3-none-any.whl -> foo_bar-1.2.3-py3-none-any.whl.zip"
+	"https://files.pythonhosted.org/packages/py3/F/Foo.Bar/foo_bar-1.2.3b2-py3-none-any.whl -> foo_bar-1.2.3b2-py3-none-any.whl.zip"
 test-eq "pypi_wheel_url --unpack Flask-BabelEx" \
-	"https://files.pythonhosted.org/packages/py3/F/Flask-BabelEx/flask_babelex-1.2.3-py3-none-any.whl -> flask_babelex-1.2.3-py3-none-any.whl.zip"
+	"https://files.pythonhosted.org/packages/py3/F/Flask-BabelEx/flask_babelex-1.2.3b2-py3-none-any.whl -> flask_babelex-1.2.3b2-py3-none-any.whl.zip"
 test-eq "pypi_wheel_url --unpack Flask-BabelEx 4" \
 	"https://files.pythonhosted.org/packages/py3/F/Flask-BabelEx/flask_babelex-4-py3-none-any.whl -> flask_babelex-4-py3-none-any.whl.zip"
 test-eq "pypi_wheel_url --unpack Flask-BabelEx 4 py2.py3" \
@@ -70,24 +70,24 @@ test-eq "pypi_wheel_url --unpack cryptography 39.0.1 cp36 abi3-manylinux_2_28_x8
 	"https://files.pythonhosted.org/packages/cp36/c/cryptography/cryptography-39.0.1-cp36-abi3-manylinux_2_28_x86_64.whl -> cryptography-39.0.1-cp36-abi3-manylinux_2_28_x86_64.whl.zip"
 
 test-eq "pypi_sdist_url" \
-	https://files.pythonhosted.org/packages/source/F/Foo.Bar/foo_bar-1.2.3.tar.gz
+	https://files.pythonhosted.org/packages/source/F/Foo.Bar/foo_bar-1.2.3b2.tar.gz
 test-eq "pypi_sdist_url Flask-BabelEx" \
-	https://files.pythonhosted.org/packages/source/F/Flask-BabelEx/flask_babelex-1.2.3.tar.gz
+	https://files.pythonhosted.org/packages/source/F/Flask-BabelEx/flask_babelex-1.2.3b2.tar.gz
 test-eq "pypi_sdist_url Flask-BabelEx 4" \
 	https://files.pythonhosted.org/packages/source/F/Flask-BabelEx/flask_babelex-4.tar.gz
 test-eq "pypi_sdist_url Flask-BabelEx 4 .zip" \
 	https://files.pythonhosted.org/packages/source/F/Flask-BabelEx/flask_babelex-4.zip
 
 test-eq "pypi_sdist_url --no-normalize" \
-	https://files.pythonhosted.org/packages/source/F/Foo.Bar/Foo.Bar-1.2.3.tar.gz
+	https://files.pythonhosted.org/packages/source/F/Foo.Bar/Foo.Bar-1.2.3b2.tar.gz
 test-eq "pypi_sdist_url --no-normalize Flask-BabelEx" \
-	https://files.pythonhosted.org/packages/source/F/Flask-BabelEx/Flask-BabelEx-1.2.3.tar.gz
+	https://files.pythonhosted.org/packages/source/F/Flask-BabelEx/Flask-BabelEx-1.2.3b2.tar.gz
 test-eq "pypi_sdist_url --no-normalize Flask-BabelEx 4" \
 	https://files.pythonhosted.org/packages/source/F/Flask-BabelEx/Flask-BabelEx-4.tar.gz
 test-eq "pypi_sdist_url --no-normalize Flask-BabelEx 4 .zip" \
 	https://files.pythonhosted.org/packages/source/F/Flask-BabelEx/Flask-BabelEx-4.zip
 
 test-eq 'declare -p SRC_URI' \
-	'declare -- SRC_URI="https://files.pythonhosted.org/packages/source/F/Foo.Bar/foo_bar-1.2.3.tar.gz"'
+	'declare -- SRC_URI="https://files.pythonhosted.org/packages/source/F/Foo.Bar/foo_bar-1.2.3b2.tar.gz"'
 
 texit

--- a/eclass/tests/pypi.sh
+++ b/eclass/tests/pypi.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Copyright 2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+source tests-common.sh || exit
+
+inherit pypi
+
+test-eq() {
+	local call=${1}
+	local exp=${2}
+
+	tbegin "${call} -> ${exp}"
+	local ret=0
+	local have=$(${call})
+	if [[ ${have} != ${exp} ]]; then
+		eindent
+		eerror "incorrect result: ${have}"
+		eoutdent
+		ret=1
+	fi
+	tend "${ret}"
+}
+
+test-eq "pypi_normalize_name foo" foo
+test-eq "pypi_normalize_name foo_bar" foo_bar
+test-eq "pypi_normalize_name foo___bar" foo_bar
+test-eq "pypi_normalize_name Flask-BabelEx" flask_babelex
+test-eq "pypi_normalize_name jaraco.context" jaraco_context
+
+texit

--- a/eclass/tests/pypi.sh
+++ b/eclass/tests/pypi.sh
@@ -5,6 +5,9 @@
 EAPI=8
 source tests-common.sh || exit
 
+PN=Foo.Bar
+PV=1.2.3
+
 inherit pypi
 
 test-eq() {
@@ -28,9 +31,6 @@ test-eq "pypi_normalize_name foo_bar" foo_bar
 test-eq "pypi_normalize_name foo___bar" foo_bar
 test-eq "pypi_normalize_name Flask-BabelEx" flask_babelex
 test-eq "pypi_normalize_name jaraco.context" jaraco_context
-
-PN=Foo.Bar
-PV=1.2.3
 
 test-eq "pypi_wheel_name" foo_bar-1.2.3-py3-none-any.whl
 test-eq "pypi_wheel_name Flask-BabelEx" flask_babelex-1.2.3-py3-none-any.whl
@@ -61,5 +61,26 @@ test-eq "pypi_wheel_url --unpack Flask-BabelEx 4 py2.py3" \
 	"https://files.pythonhosted.org/packages/py2.py3/F/Flask-BabelEx/flask_babelex-4-py2.py3-none-any.whl -> flask_babelex-4-py2.py3-none-any.whl.zip"
 test-eq "pypi_wheel_url --unpack cryptography 39.0.1 cp36 abi3-manylinux_2_28_x86_64" \
 	"https://files.pythonhosted.org/packages/cp36/c/cryptography/cryptography-39.0.1-cp36-abi3-manylinux_2_28_x86_64.whl -> cryptography-39.0.1-cp36-abi3-manylinux_2_28_x86_64.whl.zip"
+
+test-eq "pypi_sdist_url" \
+	https://files.pythonhosted.org/packages/source/F/Foo.Bar/foo_bar-1.2.3.tar.gz
+test-eq "pypi_sdist_url Flask-BabelEx" \
+	https://files.pythonhosted.org/packages/source/F/Flask-BabelEx/flask_babelex-1.2.3.tar.gz
+test-eq "pypi_sdist_url Flask-BabelEx 4" \
+	https://files.pythonhosted.org/packages/source/F/Flask-BabelEx/flask_babelex-4.tar.gz
+test-eq "pypi_sdist_url Flask-BabelEx 4 .zip" \
+	https://files.pythonhosted.org/packages/source/F/Flask-BabelEx/flask_babelex-4.zip
+
+test-eq "pypi_sdist_url --no-normalize" \
+	https://files.pythonhosted.org/packages/source/F/Foo.Bar/Foo.Bar-1.2.3.tar.gz
+test-eq "pypi_sdist_url --no-normalize Flask-BabelEx" \
+	https://files.pythonhosted.org/packages/source/F/Flask-BabelEx/Flask-BabelEx-1.2.3.tar.gz
+test-eq "pypi_sdist_url --no-normalize Flask-BabelEx 4" \
+	https://files.pythonhosted.org/packages/source/F/Flask-BabelEx/Flask-BabelEx-4.tar.gz
+test-eq "pypi_sdist_url --no-normalize Flask-BabelEx 4 .zip" \
+	https://files.pythonhosted.org/packages/source/F/Flask-BabelEx/Flask-BabelEx-4.zip
+
+test-eq 'declare -p SRC_URI' \
+	'declare -- SRC_URI="https://files.pythonhosted.org/packages/source/F/Foo.Bar/foo_bar-1.2.3.tar.gz"'
 
 texit

--- a/eclass/tests/pypi.sh
+++ b/eclass/tests/pypi.sh
@@ -7,6 +7,7 @@ source tests-common.sh || exit
 
 PN=Foo.Bar
 PV=1.2.3_beta2
+WORKDIR='<WORKDIR>'
 
 inherit pypi
 
@@ -89,5 +90,7 @@ test-eq "pypi_sdist_url --no-normalize Flask-BabelEx 4 .zip" \
 
 test-eq 'declare -p SRC_URI' \
 	'declare -- SRC_URI="https://files.pythonhosted.org/packages/source/F/Foo.Bar/foo_bar-1.2.3b2.tar.gz"'
+test-eq 'declare -p S' \
+	'declare -- S="<WORKDIR>/foo_bar-1.2.3b2"'
 
 texit

--- a/eclass/tests/pypi.sh
+++ b/eclass/tests/pypi.sh
@@ -32,6 +32,13 @@ test-eq "pypi_normalize_name foo___bar" foo_bar
 test-eq "pypi_normalize_name Flask-BabelEx" flask_babelex
 test-eq "pypi_normalize_name jaraco.context" jaraco_context
 
+test-eq "pypi_translate_version 1.2.3" 1.2.3
+test-eq "pypi_translate_version 1.2.3_p101" 1.2.3.post101
+test-eq "pypi_translate_version 1.2.3_alpha4" 1.2.3a4
+test-eq "pypi_translate_version 1.2.3_beta1" 1.2.3b1
+test-eq "pypi_translate_version 1.2.3_rc2" 1.2.3rc2
+test-eq "pypi_translate_version 1.2.3_rc2_p1" 1.2.3rc2.post1
+
 test-eq "pypi_wheel_name" foo_bar-1.2.3-py3-none-any.whl
 test-eq "pypi_wheel_name Flask-BabelEx" flask_babelex-1.2.3-py3-none-any.whl
 test-eq "pypi_wheel_name Flask-BabelEx 4" flask_babelex-4-py3-none-any.whl

--- a/eclass/tests/pypi.sh
+++ b/eclass/tests/pypi.sh
@@ -29,4 +29,37 @@ test-eq "pypi_normalize_name foo___bar" foo_bar
 test-eq "pypi_normalize_name Flask-BabelEx" flask_babelex
 test-eq "pypi_normalize_name jaraco.context" jaraco_context
 
+PN=Foo.Bar
+PV=1.2.3
+
+test-eq "pypi_wheel_name" foo_bar-1.2.3-py3-none-any.whl
+test-eq "pypi_wheel_name Flask-BabelEx" flask_babelex-1.2.3-py3-none-any.whl
+test-eq "pypi_wheel_name Flask-BabelEx 4" flask_babelex-4-py3-none-any.whl
+test-eq "pypi_wheel_name Flask-BabelEx 4 py2.py3" \
+	flask_babelex-4-py2.py3-none-any.whl
+test-eq "pypi_wheel_name cryptography 39.0.1 cp36 abi3-manylinux_2_28_x86_64" \
+	cryptography-39.0.1-cp36-abi3-manylinux_2_28_x86_64.whl
+
+test-eq "pypi_wheel_url" \
+	https://files.pythonhosted.org/packages/py3/F/Foo.Bar/foo_bar-1.2.3-py3-none-any.whl
+test-eq "pypi_wheel_url Flask-BabelEx" \
+	https://files.pythonhosted.org/packages/py3/F/Flask-BabelEx/flask_babelex-1.2.3-py3-none-any.whl
+test-eq "pypi_wheel_url Flask-BabelEx 4" \
+	https://files.pythonhosted.org/packages/py3/F/Flask-BabelEx/flask_babelex-4-py3-none-any.whl
+test-eq "pypi_wheel_url Flask-BabelEx 4 py2.py3" \
+	https://files.pythonhosted.org/packages/py2.py3/F/Flask-BabelEx/flask_babelex-4-py2.py3-none-any.whl
+test-eq "pypi_wheel_url cryptography 39.0.1 cp36 abi3-manylinux_2_28_x86_64" \
+	https://files.pythonhosted.org/packages/cp36/c/cryptography/cryptography-39.0.1-cp36-abi3-manylinux_2_28_x86_64.whl
+
+test-eq "pypi_wheel_url --unpack" \
+	"https://files.pythonhosted.org/packages/py3/F/Foo.Bar/foo_bar-1.2.3-py3-none-any.whl -> foo_bar-1.2.3-py3-none-any.whl.zip"
+test-eq "pypi_wheel_url --unpack Flask-BabelEx" \
+	"https://files.pythonhosted.org/packages/py3/F/Flask-BabelEx/flask_babelex-1.2.3-py3-none-any.whl -> flask_babelex-1.2.3-py3-none-any.whl.zip"
+test-eq "pypi_wheel_url --unpack Flask-BabelEx 4" \
+	"https://files.pythonhosted.org/packages/py3/F/Flask-BabelEx/flask_babelex-4-py3-none-any.whl -> flask_babelex-4-py3-none-any.whl.zip"
+test-eq "pypi_wheel_url --unpack Flask-BabelEx 4 py2.py3" \
+	"https://files.pythonhosted.org/packages/py2.py3/F/Flask-BabelEx/flask_babelex-4-py2.py3-none-any.whl -> flask_babelex-4-py2.py3-none-any.whl.zip"
+test-eq "pypi_wheel_url --unpack cryptography 39.0.1 cp36 abi3-manylinux_2_28_x86_64" \
+	"https://files.pythonhosted.org/packages/cp36/c/cryptography/cryptography-39.0.1-cp36-abi3-manylinux_2_28_x86_64.whl -> cryptography-39.0.1-cp36-abi3-manylinux_2_28_x86_64.whl.zip"
+
 texit


### PR DESCRIPTION
1. Normalize sdist & wheel filenames according to the standards by default.
2. Support `pypi_sdist_url --no-normalize` for packages using setuptools that don't follow the standards (yet).
3. Translate Gentoo versions by default (e.g. `_beta` to `b` and so on).
4. Add tests.
5. Update existing packages.