### PR TITLE
java-utils-2.eclass: default to java-pkg_clean for future EAPI | java-*-2.eclass: drop support for EAPI 5

### DIFF
--- a/eclass/java-ant-2.eclass
+++ b/eclass/java-ant-2.eclass
@@ -1,4 +1,4 @@
-# Copyright 2004-2021 Gentoo Authors
+# Copyright 2004-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: java-ant-2.eclass
@@ -7,7 +7,7 @@
 # @AUTHOR:
 # kiorky <kiorky@cryptelium.net>
 # Petteri Räty <betelgeuse@gentoo.org>
-# @SUPPORTED_EAPIS: 5 6 7 8
+# @SUPPORTED_EAPIS: 6 7 8
 # @PROVIDES: java-utils-2
 # @BLURB: eclass for ant based Java packages
 # @DESCRIPTION:
@@ -18,7 +18,7 @@
 inherit java-utils-2 multilib
 
 case ${EAPI:-0} in
-	[5678]) ;;
+	[678]) ;;
 	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
 
@@ -72,8 +72,8 @@ fi
 # We need some tools from javatoolkit. We also need ant dependencies
 # constructed above.
 JAVA_ANT_E_DEPEND="${JAVA_ANT_E_DEPEND}
-	   ${ANT_TASKS_DEPEND}
-	   dev-java/javatoolkit"
+	${ANT_TASKS_DEPEND}
+	dev-java/javatoolkit"
 
 # this eclass must be inherited after java-pkg-2 or java-pkg-opt-2
 # if it's java-pkg-opt-2, ant dependencies are pulled based on USE flag

--- a/eclass/java-pkg-2.eclass
+++ b/eclass/java-pkg-2.eclass
@@ -1,4 +1,4 @@
-# Copyright 2004-2021 Gentoo Authors
+# Copyright 2004-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: java-pkg-2.eclass
@@ -6,7 +6,7 @@
 # java@gentoo.org
 # @AUTHOR:
 # Thomas Matthijs <axxo@gentoo.org>
-# @SUPPORTED_EAPIS: 5 6 7 8
+# @SUPPORTED_EAPIS: 6 7 8
 # @PROVIDES: java-utils-2
 # @BLURB: Eclass for Java Packages
 # @DESCRIPTION:
@@ -14,7 +14,7 @@
 # need to use Java.
 
 case ${EAPI:-0} in
-	[5678]) ;;
+	[678]) ;;
 	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
 

--- a/eclass/java-pkg-opt-2.eclass
+++ b/eclass/java-pkg-opt-2.eclass
@@ -1,4 +1,4 @@
-# Copyright 2004-2021 Gentoo Authors
+# Copyright 2004-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: java-pkg-opt-2.eclass
@@ -6,7 +6,7 @@
 # java@gentoo.org
 # @AUTHOR:
 # Thomas Matthijs <axxo@gentoo.org>
-# @SUPPORTED_EAPIS: 5 6 7 8
+# @SUPPORTED_EAPIS: 6 7 8
 # @PROVIDES: java-utils-2
 # @BLURB: Eclass for package with optional Java support
 # @DESCRIPTION:
@@ -14,7 +14,7 @@
 # support.
 
 case ${EAPI:-0} in
-	[5678]) ;;
+	[678]) ;;
 	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
 
@@ -49,10 +49,6 @@ java-pkg-opt-2_pkg_setup() {
 
 java-pkg-opt-2_src_prepare() {
 	use ${JAVA_PKG_OPT_USE} && java-utils-2_src_prepare
-	case "${EAPI:-0}" in
-		[0-5]) ;;
-		*) use ${JAVA_PKG_OPT_USE} || eapply_user ;;
-	esac
 }
 
 

--- a/eclass/java-utils-2.eclass
+++ b/eclass/java-utils-2.eclass
@@ -1955,6 +1955,12 @@ java-utils-2_src_prepare() {
 		find "${WORKDIR}" -name "*.class"
 		echo "Search done."
 	fi
+
+	# Delete bundled .class and .jar files.
+	case ${EAPI:-0} in
+		[678]) ;;
+		*) java-pkg_clean ;;
+	esac
 }
 
 # @FUNCTION: java-utils-2_pkg_preinst

--- a/eclass/java-utils-2.eclass
+++ b/eclass/java-utils-2.eclass
@@ -6,7 +6,7 @@
 # java@gentoo.org
 # @AUTHOR:
 # Thomas Matthijs <axxo@gentoo.org>, Karl Trygve Kalleberg <karltk@gentoo.org>
-# @SUPPORTED_EAPIS: 5 6 7 8
+# @SUPPORTED_EAPIS: 6 7 8
 # @BLURB: Base eclass for Java packages
 # @DESCRIPTION:
 # This eclass provides functionality which is used by java-pkg-2.eclass,
@@ -18,7 +18,7 @@
 # Ant-based packages.
 
 case ${EAPI:-0} in
-	[5678]) ;;
+	[678]) ;;
 	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
 
@@ -27,7 +27,7 @@ _JAVA_UTILS_2_ECLASS=1
 
 # EAPI 7 has version functions built-in. Use eapi7-ver for all earlier eclasses.
 # Keep versionator inheritance in case consumers are using it implicitly.
-[[ ${EAPI} == [56] ]] && inherit eapi7-ver eutils multilib versionator
+[[ ${EAPI} == 6 ]] && inherit eapi7-ver eutils multilib versionator
 
 # Make sure we use java-config-2
 export WANT_JAVA_CONFIG="2"
@@ -1933,14 +1933,7 @@ etestng() {
 # src_prepare Searches for bundled jars
 # Don't call directly, but via java-pkg-2_src_prepare!
 java-utils-2_src_prepare() {
-	case ${EAPI:-0} in
-		5)
-			java-pkg_func-exists java_prepare && java_prepare ;;
-		*)
-			java-pkg_func-exists java_prepare &&
-				eqawarn "java_prepare is no longer called, define src_prepare instead."
-			eapply_user ;;
-	esac
+	eapply_user
 
 	# Check for files in JAVA_RM_FILES array.
 	if [[ ${JAVA_RM_FILES[@]} ]]; then


### PR DESCRIPTION
Adding these lines to java-pkg_clean() will allow putting not only expressions but also file names in JAVA_PKG_NO_CLEAN.

Signed-off-by: Volkmar W. Pogatzki <gentoo@pogatzki.net>