### PR TITLE
Kde apps/kdemultimedia-meta: keyword 22.12.2 riscv #894046 

### DIFF
--- a/kde-apps/kdemultimedia-meta/kdemultimedia-meta-22.12.2.ebuild
+++ b/kde-apps/kdemultimedia-meta/kdemultimedia-meta-22.12.2.ebuild
@@ -8,7 +8,7 @@ HOMEPAGE="https://apps.kde.org/categories/multimedia/"
 
 LICENSE="metapackage"
 SLOT="5"
-KEYWORDS="~amd64 ~arm64 ~ppc64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="+cdrom +ffmpeg gstreamer"
 
 RDEPEND="

--- a/media-sound/elisa/elisa-22.12.2.ebuild
+++ b/media-sound/elisa/elisa-22.12.2.ebuild
@@ -14,7 +14,7 @@ HOMEPAGE="https://elisa.kde.org/ https://apps.kde.org/elisa/"
 
 LICENSE="LGPL-3+"
 SLOT="5"
-KEYWORDS="~amd64 ~arm64 ~ppc64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="mpris semantic-desktop +vlc"
 
 RESTRICT="test"


### PR DESCRIPTION
this package can install kde media apps easily on riscv