### PR TITLE
sci-libs/libecpint: Fix bug 894044

### DIFF
--- a/sci-libs/libecpint/libecpint-1.0.6-r1.ebuild
+++ b/sci-libs/libecpint/libecpint-1.0.6-r1.ebuild
@@ -1,0 +1,34 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit cmake
+
+DESCRIPTION="Efficient evaluation of integrals over ab initio effective core potentials"
+HOMEPAGE="https://github.com/robashaw/libecpint"
+SRC_URI="https://github.com/robashaw/libecpint/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~amd64 ~x86 ~amd64-linux ~x86-linux"
+IUSE="test"
+RESTRICT="!test? ( test )"
+
+RDEPEND="dev-libs/pugixml"
+DEPEND="${RDEPEND}
+	test? ( dev-cpp/gtest )"
+
+src_prepare() {
+	cmake_src_prepare
+
+	find . -name CMakeLists.txt -exec \
+		sed -i -e 's/CXX_STANDARD 11/CXX_STANDARD 14/g' {} \; || die
+}
+
+src_configure() {
+	local mycmakeargs=(
+		-DLIBECPINT_BUILD_TESTS=$(usex test)
+	)
+	cmake_src_configure
+}


### PR DESCRIPTION
- **sci-libs/libecpint: change C++ standard to C++14 and bump EAPI**
The latest gtest now requires being built with the C++14 dialect or later.
 Change all references of C++11 to C++14 in several affected CMakeLists.txt files.

If opted for `sed` but if you'd prefer a patch instead, let me know.

Closes: https://bugs.gentoo.org/894044
Closes: https://github.com/gentoo/gentoo/pull/29561
Signed-off-by: Peter Levine <plevine457@gmail.com>