### PR TITLE
media-video/ffmpeg: fix build when USE=vulkan

### DIFF
--- a/media-video/ffmpeg/ffmpeg-5.1.2-r1.ebuild
+++ b/media-video/ffmpeg/ffmpeg-5.1.2-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -336,6 +336,7 @@ S=${WORKDIR}/${P/_/-}
 
 PATCHES=(
 	"${FILESDIR}"/chromium-r1.patch
+	"${FILESDIR}/${P}-vulkan.patch"
 )
 
 MULTILIB_WRAPPED_HEADERS=(

--- a/media-video/ffmpeg/files/ffmpeg-5.1.2-vulkan.patch
+++ b/media-video/ffmpeg/files/ffmpeg-5.1.2-vulkan.patch
@@ -1,0 +1,33 @@
+From eb0455d64690eed0068e5cb202f72ecdf899837c Mon Sep 17 00:00:00 2001
+From: Lynne <dev@lynne.ee>
+Date: Sun, 25 Dec 2022 01:03:30 +0100
+Subject: [PATCH] hwcontext_vulkan: remove optional encode/decode extensions
+ from the list
+
+They're not currently used, so they don't need to be there.
+Vulkan stabilized the decode extensions less than a week ago, and their
+name prefixes were changed from EXT to KHR. It's a bit too soon to be
+depending on it, so rather than bumping, just remove these for now.
+---
+ libavutil/hwcontext_vulkan.c | 8 --------
+ 1 file changed, 8 deletions(-)
+
+diff --git a/libavutil/hwcontext_vulkan.c b/libavutil/hwcontext_vulkan.c
+index f1db1c7291f1..2a9b5f4aac62 100644
+--- a/libavutil/hwcontext_vulkan.c
++++ b/libavutil/hwcontext_vulkan.c
+@@ -358,14 +358,6 @@ static const VulkanOptExtension optional_device_exts[] = {
+     { VK_KHR_EXTERNAL_MEMORY_WIN32_EXTENSION_NAME,            FF_VK_EXT_EXTERNAL_WIN32_MEMORY  },
+     { VK_KHR_EXTERNAL_SEMAPHORE_WIN32_EXTENSION_NAME,         FF_VK_EXT_EXTERNAL_WIN32_SEM     },
+ #endif
+-
+-    /* Video encoding/decoding */
+-    { VK_KHR_VIDEO_QUEUE_EXTENSION_NAME,                      FF_VK_EXT_NO_FLAG                },
+-    { VK_KHR_VIDEO_DECODE_QUEUE_EXTENSION_NAME,               FF_VK_EXT_NO_FLAG                },
+-    { VK_KHR_VIDEO_ENCODE_QUEUE_EXTENSION_NAME,               FF_VK_EXT_NO_FLAG                },
+-    { VK_EXT_VIDEO_ENCODE_H264_EXTENSION_NAME,                FF_VK_EXT_NO_FLAG                },
+-    { VK_EXT_VIDEO_DECODE_H264_EXTENSION_NAME,                FF_VK_EXT_NO_FLAG                },
+-    { VK_EXT_VIDEO_DECODE_H265_EXTENSION_NAME,                FF_VK_EXT_NO_FLAG                },
+ };
+ 
+ /* Converts return values to strings */


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/894122
Signed-off-by: Craig Andrews <candrews@gentoo.org>