### PR TITLE
app-admin/entr: fix prepare and test phases issues

### DIFF
--- a/app-admin/entr/entr-5.3-r1.ebuild
+++ b/app-admin/entr/entr-5.3-r1.ebuild
@@ -27,7 +27,7 @@ BDEPEND="
 	)
 "
 
-PATCH=(
+PATCHES=(
 	"${FILESDIR}/${P}-no-which.patch"
 )
 
@@ -35,6 +35,7 @@ src_configure() {
 	tc-export CC
 	export PREFIX="${EPREFIX}/usr"
 	export SHELL="${BROOT}/bin/bash"
+	export TMUX_TMPDIR="${T}"
 
 	edo ./configure
 }


### PR DESCRIPTION
- Use correct name of `PATCHES` array in order to apply patch
- Fix issue with interfering tmux sessions in test phase by exporting `TMUX_TMPDIR="${T}"`