### PR TITLE
libevent threads unconditional

### DIFF
--- a/app-admin/rsyslog/rsyslog-8.2112.0-r2.ebuild
+++ b/app-admin/rsyslog/rsyslog-8.2112.0-r2.ebuild
@@ -79,7 +79,7 @@ RDEPEND="
 	rabbitmq? ( >=net-libs/rabbitmq-c-0.3.0:= )
 	redis? (
 		>=dev-libs/hiredis-0.11.0:=
-		dev-libs/libevent[threads(+)]
+		dev-libs/libevent
 	)
 	relp? ( >=dev-libs/librelp-1.2.17:= )
 	rfc3195? ( >=dev-libs/liblogging-1.0.1:=[rfc3195] )

--- a/app-admin/rsyslog/rsyslog-8.2206.0-r2.ebuild
+++ b/app-admin/rsyslog/rsyslog-8.2206.0-r2.ebuild
@@ -81,7 +81,7 @@ RDEPEND="
 	rabbitmq? ( >=net-libs/rabbitmq-c-0.3.0:= )
 	redis? (
 		>=dev-libs/hiredis-0.11.0:=
-		dev-libs/libevent[threads(+)]
+		dev-libs/libevent
 	)
 	relp? ( >=dev-libs/librelp-1.2.17:= )
 	rfc3195? ( >=dev-libs/liblogging-1.0.1:=[rfc3195] )

--- a/app-admin/rsyslog/rsyslog-8.2208.0-r2.ebuild
+++ b/app-admin/rsyslog/rsyslog-8.2208.0-r2.ebuild
@@ -81,7 +81,7 @@ RDEPEND="
 	rabbitmq? ( >=net-libs/rabbitmq-c-0.3.0:= )
 	redis? (
 		>=dev-libs/hiredis-0.11.0:=
-		dev-libs/libevent[threads(+)]
+		dev-libs/libevent
 	)
 	relp? ( >=dev-libs/librelp-1.2.17:= )
 	rfc3195? ( >=dev-libs/liblogging-1.0.1:=[rfc3195] )

--- a/app-admin/rsyslog/rsyslog-8.2210.0-r2.ebuild
+++ b/app-admin/rsyslog/rsyslog-8.2210.0-r2.ebuild
@@ -81,7 +81,7 @@ RDEPEND="
 	rabbitmq? ( >=net-libs/rabbitmq-c-0.3.0:= )
 	redis? (
 		>=dev-libs/hiredis-0.11.0:=
-		dev-libs/libevent[threads(+)]
+		dev-libs/libevent
 	)
 	relp? ( >=dev-libs/librelp-1.2.17:= )
 	rfc3195? ( >=dev-libs/liblogging-1.0.1:=[rfc3195] )

--- a/app-admin/rsyslog/rsyslog-8.2212.0-r1.ebuild
+++ b/app-admin/rsyslog/rsyslog-8.2212.0-r1.ebuild
@@ -81,7 +81,7 @@ RDEPEND="
 	rabbitmq? ( >=net-libs/rabbitmq-c-0.3.0:= )
 	redis? (
 		>=dev-libs/hiredis-0.11.0:=
-		dev-libs/libevent[threads(+)]
+		dev-libs/libevent
 	)
 	relp? ( >=dev-libs/librelp-1.2.17:= )
 	rfc3195? ( >=dev-libs/liblogging-1.0.1:=[rfc3195] )

--- a/dev-db/mysql/mysql-8.0.27-r1.ebuild
+++ b/dev-db/mysql/mysql-8.0.27-r1.ebuild
@@ -53,7 +53,7 @@ COMMON_DEPEND="
 	>=dev-libs/openssl-1.0.0:0=
 	server? (
 		dev-libs/icu:=
-		dev-libs/libevent:=[ssl,threads(+)]
+		dev-libs/libevent:=[ssl]
 		>=dev-libs/protobuf-3.8:=
 		net-libs/libtirpc:=
 		cjk? ( app-text/mecab:= )

--- a/dev-db/mysql/mysql-8.0.31-r2.ebuild
+++ b/dev-db/mysql/mysql-8.0.31-r2.ebuild
@@ -46,7 +46,7 @@ COMMON_DEPEND="
 	>=dev-libs/openssl-1.0.0:0=
 	server? (
 		dev-libs/icu:=
-		dev-libs/libevent:=[ssl,threads(+)]
+		dev-libs/libevent:=[ssl]
 		>=dev-libs/protobuf-3.8:=
 		net-libs/libtirpc:=
 		cjk? ( app-text/mecab:= )

--- a/dev-db/mysql/mysql-8.0.32-r2.ebuild
+++ b/dev-db/mysql/mysql-8.0.32-r2.ebuild
@@ -46,7 +46,7 @@ COMMON_DEPEND="
 	>=sys-libs/zlib-1.2.13:=
 	server? (
 		dev-libs/icu:=
-		dev-libs/libevent:=[ssl,threads(+)]
+		dev-libs/libevent:=[ssl]
 		>=dev-libs/protobuf-3.8:=
 		net-libs/libtirpc:=
 		cjk? ( app-text/mecab:= )

--- a/dev-db/percona-server/percona-server-8.0.26.16-r2.ebuild
+++ b/dev-db/percona-server/percona-server-8.0.26.16-r2.ebuild
@@ -58,7 +58,7 @@ COMMON_DEPEND="
 	>=dev-libs/openssl-1.0.0:0=
 	server? (
 		dev-libs/icu:=
-		dev-libs/libevent:=[ssl,threads(+)]
+		dev-libs/libevent:=[ssl]
 		>=dev-libs/protobuf-3.8:=
 		net-libs/libtirpc:=
 		net-misc/curl:=

--- a/dev-libs/libevent/libevent-2.1.11-r1.ebuild
+++ b/dev-libs/libevent/libevent-2.1.11-r1.ebuild
@@ -44,7 +44,8 @@ multilib_src_configure() {
 		$(use_enable debug malloc-replacement) \
 		$(use_enable ssl openssl) \
 		$(use_enable static-libs static) \
-		$(use_enable test libevent-regress)
+		$(use_enable test libevent-regress) \
+		--enable-thread-support
 }
 
 src_test() {

--- a/dev-libs/libevent/libevent-2.1.12-r1.ebuild
+++ b/dev-libs/libevent/libevent-2.1.12-r1.ebuild
@@ -56,6 +56,7 @@ multilib_src_configure() {
 		$(use_enable static-libs static) \
 		$(use_enable test libevent-regress) \
 		$(use_enable verbose-debug) \
+		--enable-thread-support \
 		--disable-samples
 }
 

--- a/dev-libs/libevent/libevent-2.1.9999.ebuild
+++ b/dev-libs/libevent/libevent-2.1.9999.ebuild
@@ -57,6 +57,7 @@ multilib_src_configure() {
 		$(use_enable static-libs static) \
 		$(use_enable test libevent-regress) \
 		$(use_enable verbose-debug) \
+		--enable-thread-support \
 		--disable-samples
 }
 

--- a/dev-libs/libevent/libevent-9999.ebuild
+++ b/dev-libs/libevent/libevent-9999.ebuild
@@ -57,6 +57,7 @@ multilib_src_configure() {
 		$(use_enable static-libs static) \
 		$(use_enable test libevent-regress) \
 		$(use_enable verbose-debug) \
+		--enable-thread-support \
 		--disable-samples
 }
 

--- a/mail-client/thunderbird/thunderbird-102.6.1.ebuild
+++ b/mail-client/thunderbird/thunderbird-102.6.1.ebuild
@@ -156,7 +156,7 @@ COMMON_DEPEND="${TB_ONLY_DEPEND}
 	)
 	system-icu? ( >=dev-libs/icu-71.1:= )
 	system-jpeg? ( >=media-libs/libjpeg-turbo-1.2.1 )
-	system-libevent? ( >=dev-libs/libevent-2.0:0=[threads(+)] )
+	system-libevent? ( >=dev-libs/libevent-2.0:0= )
 	system-libvpx? ( >=media-libs/libvpx-1.8.2:0=[postproc] )
 	system-png? ( >=media-libs/libpng-1.6.35:0=[apng] )
 	system-webp? ( >=media-libs/libwebp-1.1.0:0= )

--- a/mail-client/thunderbird/thunderbird-102.7.1.ebuild
+++ b/mail-client/thunderbird/thunderbird-102.7.1.ebuild
@@ -162,7 +162,7 @@ COMMON_DEPEND="${TB_ONLY_DEPEND}
 	)
 	system-icu? ( >=dev-libs/icu-71.1:= )
 	system-jpeg? ( >=media-libs/libjpeg-turbo-1.2.1 )
-	system-libevent? ( >=dev-libs/libevent-2.0:0=[threads(+)] )
+	system-libevent? ( >=dev-libs/libevent-2.0:0= )
 	system-libvpx? ( >=media-libs/libvpx-1.8.2:0=[postproc] )
 	system-png? ( >=media-libs/libpng-1.6.35:0=[apng] )
 	system-webp? ( >=media-libs/libwebp-1.1.0:0= )

--- a/mail-client/thunderbird/thunderbird-102.7.2.ebuild
+++ b/mail-client/thunderbird/thunderbird-102.7.2.ebuild
@@ -162,7 +162,7 @@ COMMON_DEPEND="${TB_ONLY_DEPEND}
 	)
 	system-icu? ( >=dev-libs/icu-71.1:= )
 	system-jpeg? ( >=media-libs/libjpeg-turbo-1.2.1 )
-	system-libevent? ( >=dev-libs/libevent-2.0:0=[threads(+)] )
+	system-libevent? ( >=dev-libs/libevent-2.0:0= )
 	system-libvpx? ( >=media-libs/libvpx-1.8.2:0=[postproc] )
 	system-png? ( >=media-libs/libpng-1.6.35:0=[apng] )
 	system-webp? ( >=media-libs/libwebp-1.1.0:0= )

--- a/net-analyzer/sslsplit/sslsplit-0.5.5-r1.ebuild
+++ b/net-analyzer/sslsplit/sslsplit-0.5.5-r1.ebuild
@@ -26,7 +26,7 @@ else
 fi
 
 RDEPEND="
-	dev-libs/libevent:=[ssl,threads(+)]
+	dev-libs/libevent:=[ssl]
 	dev-libs/openssl:0=
 	net-libs/libnet:1.1
 	net-libs/libpcap

--- a/net-misc/apt-cacher-ng/apt-cacher-ng-3.7.4_p1-r2.ebuild
+++ b/net-misc/apt-cacher-ng/apt-cacher-ng-3.7.4_p1-r2.ebuild
@@ -21,7 +21,7 @@ IUSE="doc fuse systemd tcpd"
 DEPEND="acct-user/apt-cacher-ng
 	acct-group/apt-cacher-ng
 	app-arch/bzip2
-	dev-libs/libevent:=[threads(+)]
+	dev-libs/libevent:=
 	dev-libs/openssl:0=
 	net-dns/c-ares:=
 	sys-libs/zlib

--- a/net-misc/apt-cacher-ng/apt-cacher-ng-9999.ebuild
+++ b/net-misc/apt-cacher-ng/apt-cacher-ng-9999.ebuild
@@ -18,7 +18,7 @@ IUSE="doc fuse systemd tcpd"
 DEPEND="acct-user/apt-cacher-ng
 	acct-group/apt-cacher-ng
 	app-arch/bzip2
-	dev-libs/libevent:=[threads(+)]
+	dev-libs/libevent:=
 	dev-libs/openssl:0=
 	sys-libs/zlib
 	fuse? ( sys-fs/fuse:0 )

--- a/net-misc/ntp/ntp-4.2.8_p15-r2.ebuild
+++ b/net-misc/ntp/ntp-4.2.8_p15-r2.ebuild
@@ -14,10 +14,10 @@ SRC_URI="http://www.eecis.udel.edu/~ntp/ntp_spool/ntp4/ntp-${PV:0:3}/${MY_P}.tar
 LICENSE="HPND BSD ISC"
 SLOT="0"
 KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux"
-IUSE="caps debug ipv6 openntpd parse-clocks readline samba selinux snmp ssl +threads vim-syntax zeroconf"
+IUSE="caps debug ipv6 openntpd parse-clocks readline samba selinux snmp ssl vim-syntax zeroconf"
 
 COMMON_DEPEND="readline? ( >=sys-libs/readline-4.1:0= )
-	>=dev-libs/libevent-2.0.9:=[threads(+)?]
+	>=dev-libs/libevent-2.0.9:=
 	kernel_linux? ( caps? ( sys-libs/libcap ) )
 	zeroconf? ( net-dns/avahi[mdnsresponder-compat] )
 	snmp? ( net-analyzer/net-snmp )

--- a/net-misc/ntp/ntp-4.2.8_p15-r2.ebuild
+++ b/net-misc/ntp/ntp-4.2.8_p15-r2.ebuild
@@ -14,7 +14,7 @@ SRC_URI="http://www.eecis.udel.edu/~ntp/ntp_spool/ntp4/ntp-${PV:0:3}/${MY_P}.tar
 LICENSE="HPND BSD ISC"
 SLOT="0"
 KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux"
-IUSE="caps debug ipv6 openntpd parse-clocks readline samba selinux snmp ssl vim-syntax zeroconf"
+IUSE="caps debug ipv6 openntpd parse-clocks readline samba selinux snmp ssl +threads vim-syntax zeroconf"
 
 COMMON_DEPEND="readline? ( >=sys-libs/readline-4.1:0= )
 	>=dev-libs/libevent-2.0.9:=

--- a/net-misc/ntp/ntp-4.2.8_p15-r6.ebuild
+++ b/net-misc/ntp/ntp-4.2.8_p15-r6.ebuild
@@ -14,10 +14,10 @@ SRC_URI="http://www.eecis.udel.edu/~ntp/ntp_spool/ntp4/ntp-${PV:0:3}/${MY_P}.tar
 LICENSE="HPND BSD ISC"
 SLOT="0"
 KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux"
-IUSE="caps debug ipv6 openntpd parse-clocks readline samba selinux snmp ssl +threads vim-syntax zeroconf"
+IUSE="caps debug ipv6 openntpd parse-clocks readline samba selinux snmp ssl vim-syntax zeroconf"
 
 COMMON_DEPEND="readline? ( >=sys-libs/readline-4.1:0= )
-	>=dev-libs/libevent-2.0.9:=[threads(+)?]
+	>=dev-libs/libevent-2.0.9:=
 	kernel_linux? ( caps? ( sys-libs/libcap ) )
 	zeroconf? ( net-dns/avahi[mdnsresponder-compat] )
 	snmp? ( net-analyzer/net-snmp )

--- a/net-misc/ntp/ntp-4.2.8_p15-r6.ebuild
+++ b/net-misc/ntp/ntp-4.2.8_p15-r6.ebuild
@@ -14,7 +14,7 @@ SRC_URI="http://www.eecis.udel.edu/~ntp/ntp_spool/ntp4/ntp-${PV:0:3}/${MY_P}.tar
 LICENSE="HPND BSD ISC"
 SLOT="0"
 KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux"
-IUSE="caps debug ipv6 openntpd parse-clocks readline samba selinux snmp ssl vim-syntax zeroconf"
+IUSE="caps debug ipv6 openntpd parse-clocks readline samba selinux snmp ssl +threads vim-syntax zeroconf"
 
 COMMON_DEPEND="readline? ( >=sys-libs/readline-4.1:0= )
 	>=dev-libs/libevent-2.0.9:=

--- a/net-p2p/transmission/transmission-4.0.0-r3.ebuild
+++ b/net-p2p/transmission/transmission-4.0.0-r3.ebuild
@@ -39,7 +39,7 @@ BDEPEND="
 	)
 "
 COMMON_DEPEND="
-	>=dev-libs/libevent-2.1.0:=[threads(+)]
+	>=dev-libs/libevent-2.1.0:=
 	!mbedtls? ( dev-libs/openssl:0= )
 	mbedtls? ( net-libs/mbedtls:0= )
 	net-libs/libnatpmp

--- a/net-p2p/transmission/transmission-9999.ebuild
+++ b/net-p2p/transmission/transmission-9999.ebuild
@@ -39,7 +39,7 @@ BDEPEND="
 	)
 "
 COMMON_DEPEND="
-	>=dev-libs/libevent-2.1.0:=[threads(+)]
+	>=dev-libs/libevent-2.1.0:=
 	!mbedtls? ( dev-libs/openssl:0= )
 	mbedtls? ( net-libs/mbedtls:0= )
 	net-libs/libnatpmp

--- a/sys-cluster/openmpi/openmpi-4.1.4-r1.ebuild
+++ b/sys-cluster/openmpi/openmpi-4.1.4-r1.ebuild
@@ -46,7 +46,7 @@ CDEPEND="
 	!sys-cluster/mpich
 	!sys-cluster/mpich2
 	!sys-cluster/nullmpi
-	>=dev-libs/libevent-2.0.22:=[${MULTILIB_USEDEP},threads(+)]
+	>=dev-libs/libevent-2.0.22:=[${MULTILIB_USEDEP}]
 	dev-libs/libltdl:0[${MULTILIB_USEDEP}]
 	>=sys-apps/hwloc-2.0.2:=[${MULTILIB_USEDEP}]
 	>=sys-libs/zlib-1.2.8-r1[${MULTILIB_USEDEP}]

--- a/www-client/firefox/firefox-102.7.0.ebuild
+++ b/www-client/firefox/firefox-102.7.0.ebuild
@@ -164,7 +164,7 @@ COMMON_DEPEND="${FF_ONLY_DEPEND}
 	)
 	system-icu? ( >=dev-libs/icu-71.1:= )
 	system-jpeg? ( >=media-libs/libjpeg-turbo-1.2.1 )
-	system-libevent? ( >=dev-libs/libevent-2.1.12:0=[threads(+)] )
+	system-libevent? ( >=dev-libs/libevent-2.1.12:0= )
 	system-libvpx? ( >=media-libs/libvpx-1.8.2:0=[postproc] )
 	system-png? ( >=media-libs/libpng-1.6.35:0=[apng] )
 	system-webp? ( >=media-libs/libwebp-1.1.0:0= )

--- a/www-client/firefox/firefox-109.0.1.ebuild
+++ b/www-client/firefox/firefox-109.0.1.ebuild
@@ -172,7 +172,7 @@ COMMON_DEPEND="${FF_ONLY_DEPEND}
 	)
 	system-icu? ( >=dev-libs/icu-71.1:= )
 	system-jpeg? ( >=media-libs/libjpeg-turbo-1.2.1 )
-	system-libevent? ( >=dev-libs/libevent-2.1.12:0=[threads(+)] )
+	system-libevent? ( >=dev-libs/libevent-2.1.12:0= )
 	system-libvpx? ( >=media-libs/libvpx-1.8.2:0=[postproc] )
 	system-png? ( >=media-libs/libpng-1.6.35:0=[apng] )
 	system-webp? ( >=media-libs/libwebp-1.1.0:0= )


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/869722
Bug : https://bugs.gentoo.org/894270
https://github.com/gentoo/gentoo/pull/29573

The above pull request removed the "threads" IUSE from libevent, however without adding "--enable-thread-support" to econf to actually enable threads support unconditionally. It also introduced blockers such as in bug 894270, where some packages request libevent[threads] even though that no longer exists. This should fix everything. 