### PR TITLE
media-gfx/freecad: add netgen support

### DIFF
--- a/media-gfx/freecad/files/freecad-0.20.2-Fixes-8206-FreeCAD-segfaults-being-run-with-paramete.patch
+++ b/media-gfx/freecad/files/freecad-0.20.2-Fixes-8206-FreeCAD-segfaults-being-run-with-paramete.patch
@@ -1,0 +1,22 @@
+https://github.com/FreeCAD/FreeCAD/commit/c7a21ecbeecefe7c2dfc9e950b3d6bb42351d476
+
+From c7a21ecbeecefe7c2dfc9e950b3d6bb42351d476 Mon Sep 17 00:00:00 2001
+From: wmayer <wmayer@users.sourceforge.net>
+Date: Sat, 11 Feb 2023 17:47:49 +0100
+Subject: [PATCH 02/51] Fixes #8206: FreeCAD segfaults being run with
+ parameters (e.g .desktop file has /usr/bin/freecad --single-instance)
+
+--- a/src/Base/Interpreter.cpp
++++ b/src/Base/Interpreter.cpp
+@@ -563,7 +563,7 @@ void initInterpreter(int argc,char *argv[])
+ {
+     PyStatus status;
+     PyConfig config;
+-    PyConfig_InitPythonConfig(&config);
++    PyConfig_InitIsolatedConfig(&config);
+ 
+     status = PyConfig_SetBytesArgv(&config, argc, argv);
+     if (PyStatus_Exception(status)) {
+-- 
+2.39.1
+

--- a/media-gfx/freecad/files/freecad-0.20.2-Netgen-add-headers-to-support-recent-Netgen.patch
+++ b/media-gfx/freecad/files/freecad-0.20.2-Netgen-add-headers-to-support-recent-Netgen.patch
@@ -1,0 +1,93 @@
+https://github.com/FreeCAD/FreeCAD/commit/8b056f156fd087b3df36a5223fc5ca6900649a83
+
+From 8b056f156fd087b3df36a5223fc5ca6900649a83 Mon Sep 17 00:00:00 2001
+From: Uwe <donovaly@users.noreply.github.com>
+Date: Wed, 17 Aug 2022 12:32:02 +0200
+Subject: [PATCH 0008/1678] [Netgen] add headers to support recent Netgen
+
+- as reported here: https://forum.freecadweb.org/viewtopic.php?p=618174#p618174
+- also fix compiler warnings about unsafe bool handling
+--- a/src/3rdParty/salomesmesh/src/NETGENPlugin/NETGENPlugin_Mesher.cpp
++++ b/src/3rdParty/salomesmesh/src/NETGENPlugin/NETGENPlugin_Mesher.cpp
+@@ -50,7 +50,9 @@
+ 
+ #include <utilities.h>
+ 
++#include <BRepBndLib.hxx>
+ #include <BRepBuilderAPI_Copy.hxx>
++#include <BRepMesh_IncrementalMesh.hxx>
+ #include <BRep_Tool.hxx>
+ #include <Bnd_B3d.hxx>
+ #include <NCollection_Map.hxx>
+@@ -66,6 +68,7 @@
+ #include <TopTools_DataMapOfShapeShape.hxx>
+ #include <TopTools_MapOfShape.hxx>
+ #include <TopoDS.hxx>
++#include <TopoDS_Solid.hxx>
+ 
+ #ifdef _MSC_VER
+ #pragma warning(disable : 4067)
+@@ -3027,7 +3030,7 @@ bool NETGENPlugin_Mesher::Compute()
+         }
+       }
+     }
+-    if (!err && mparams.secondorder > 0)
++    if (!err && mparams.secondorder)
+     {
+       try
+       {
+@@ -3302,7 +3305,7 @@ bool NETGENPlugin_Mesher::Evaluate(MapShapeNbElems& aResMap)
+   // calculate total nb of segments and length of edges
+   double fullLen = 0.0;
+   int fullNbSeg = 0;
+-  int entity = mparams.secondorder > 0 ? SMDSEntity_Quad_Edge : SMDSEntity_Edge;
++  int entity = mparams.secondorder ? SMDSEntity_Quad_Edge : SMDSEntity_Edge;
+   TopTools_DataMapOfShapeInteger Edge2NbSeg;
+   for (TopExp_Explorer exp(_shape, TopAbs_EDGE); exp.More(); exp.Next())
+   {
+@@ -3340,7 +3343,7 @@ bool NETGENPlugin_Mesher::Evaluate(MapShapeNbElems& aResMap)
+   {
+     vector<int>& aVec = aResMap[_mesh->GetSubMesh(Edge2NbSegIt.Key())];
+     if ( aVec[ entity ] > 1 && aVec[ SMDSEntity_Node ] == 0 )
+-      aVec[SMDSEntity_Node] = mparams.secondorder > 0  ? 2*aVec[ entity ]-1 : aVec[ entity ]-1;
++      aVec[SMDSEntity_Node] = mparams.secondorder ? 2*aVec[ entity ]-1 : aVec[ entity ]-1;
+ 
+     fullNbSeg += aVec[ entity ];
+     Edge2NbSeg( Edge2NbSegIt.Key() ) = aVec[ entity ];
+@@ -3386,7 +3389,7 @@ bool NETGENPlugin_Mesher::Evaluate(MapShapeNbElems& aResMap)
+     int nbNodes = tooManyElems ? hugeNb : (( nbFaces*3 - (nb1d-1)*2 ) / 6 + 1 );
+ 
+     vector<int> aVec(SMDSEntity_Last, 0);
+-    if( mparams.secondorder > 0 ) {
++    if (mparams.secondorder) {
+       int nb1d_in = (nbFaces*3 - nb1d) / 2;
+       aVec[SMDSEntity_Node] = nbNodes + nb1d_in;
+       aVec[SMDSEntity_Quad_Triangle] = nbFaces;
+@@ -3428,11 +3431,11 @@ bool NETGENPlugin_Mesher::Evaluate(MapShapeNbElems& aResMap)
+     if ( tooManyElems ) // avoid FPE
+     {
+       aVec[SMDSEntity_Node] = hugeNb;
+-      aVec[ mparams.secondorder > 0 ? SMDSEntity_Quad_Tetra : SMDSEntity_Tetra] = hugeNb;
++      aVec[ mparams.secondorder ? SMDSEntity_Quad_Tetra : SMDSEntity_Tetra] = hugeNb;
+     }
+     else
+     {
+-      if( mparams.secondorder > 0 ) {
++      if (mparams.secondorder) {
+         aVec[SMDSEntity_Node] = nb1d_in/3 + 1 + nb1d_in;
+         aVec[SMDSEntity_Quad_Tetra] = nbVols;
+       }
+--- a/src/3rdParty/salomesmesh/src/NETGENPlugin/NETGENPlugin_NETGEN_2D_ONLY.cpp
++++ b/src/3rdParty/salomesmesh/src/NETGENPlugin/NETGENPlugin_NETGEN_2D_ONLY.cpp
+@@ -39,6 +39,8 @@
+ #include <StdMeshers_MaxElementArea.hxx>
+ #include <StdMeshers_QuadranglePreference.hxx>
+ #include <StdMeshers_ViscousLayers2D.hxx>
++#include <TopExp.hxx>
++#include <TopExp_Explorer.hxx>
+ 
+ #include <Precision.hxx>
+ #include <Standard_ErrorHandler.hxx>
+-- 
+2.39.1
+

--- a/media-gfx/freecad/files/freecad-9999-tests-src-Qt-only-build-test-for-BUILD_GUI-ON.patch
+++ b/media-gfx/freecad/files/freecad-9999-tests-src-Qt-only-build-test-for-BUILD_GUI-ON.patch
@@ -1,0 +1,24 @@
+From cb77c7d937c259224699273fee1ba5907588fa4c Mon Sep 17 00:00:00 2001
+From: Bernd Waibel <waebbl-gentoo@posteo.net>
+Date: Sun, 12 Feb 2023 19:54:13 +0100
+Subject: [PATCH] tests/src/Qt: only build test for BUILD_GUI=ON
+
+Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>
+--- a/tests/src/Qt/CMakeLists.txt
++++ b/tests/src/Qt/CMakeLists.txt
+@@ -30,6 +30,7 @@ endfunction()
+ set(CMAKE_AUTOMOC ON)
+ 
+ # Qt Test
++if(BUILD_GUI)
+ include_directories(
+     ${QtGui_INCLUDE_DIRS}
+     ${QtTest_INCLUDE_DIRS}
+@@ -46,3 +47,4 @@ set (InventorBuilder_LIBS
+ SETUP_TESTS(
+     InventorBuilder
+ )
++endif()
+-- 
+2.39.1
+

--- a/media-gfx/freecad/freecad-9999.ebuild
+++ b/media-gfx/freecad/freecad-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{9..10} )
+PYTHON_COMPAT=( python3_{9..11} )
 
 inherit check-reqs cmake optfeature python-single-r1 xdg
 
@@ -28,7 +28,7 @@ LICENSE="LGPL-2 CC-BY-SA-4.0"
 SLOT="0"
 IUSE="debug designer +gui test"
 
-FREECAD_EXPERIMENTAL_MODULES="cloud pcl"
+FREECAD_EXPERIMENTAL_MODULES="cloud netgen pcl"
 FREECAD_STABLE_MODULES="addonmgr fem idf image inspection material
 	openscad part-design path points raytracing robot show surface
 	techdraw tux"
@@ -46,47 +46,54 @@ RESTRICT="!test? ( test )"
 RDEPEND="
 	${PYTHON_DEPS}
 	dev-libs/OpenNI2[opengl(+)]
+	dev-libs/boost:=
+	dev-libs/libfmt:=
 	dev-libs/libspnav[X]
 	dev-libs/xerces-c[icu]
-	dev-qt/designer:5
 	dev-qt/qtconcurrent:5
 	dev-qt/qtcore:5
-	dev-qt/qtgui:5
 	dev-qt/qtnetwork:5
-	dev-qt/qtopengl:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtsvg:5
-	dev-qt/qtwebengine:5[widgets]
-	dev-qt/qtwidgets:5
-	dev-qt/qtx11extras:5
 	dev-qt/qtxml:5
-	>=media-libs/coin-4.0.0
+	dev-qt/qtxmlpatterns:5
 	media-libs/freetype
 	media-libs/qhull:=
 	sci-libs/flann[openmp]
 	sci-libs/hdf5:=[fortran,zlib]
-	>=sci-libs/med-4.0.0-r1[python,${PYTHON_SINGLE_USEDEP}]
-	sci-libs/opencascade:=[json,vtk(+)]
+	>=sci-libs/med-4.0.0-r1
+	sci-libs/opencascade:=[json,vtk]
 	sci-libs/orocos_kdl:=
 	sys-libs/zlib
-	virtual/glu
 	virtual/libusb:1
-	virtual/opengl
 	cloud? (
 		dev-libs/openssl:=
 		net-misc/curl
 	)
-	fem? ( sci-libs/vtk:=[boost(+),python,qt5,rendering,${PYTHON_SINGLE_USEDEP}] )
+	fem? ( sci-libs/vtk:=[qt5,rendering] )
+	gui? (
+		dev-qt/designer:5
+		dev-qt/qtgui:5
+		dev-qt/qtopengl:5
+		dev-qt/qtprintsupport:5
+		dev-qt/qtsvg:5
+		dev-qt/qtwebengine:5[widgets]
+		dev-qt/qtwidgets:5
+		dev-qt/qtx11extras:5
+		>=media-libs/coin-4.0.0
+		virtual/glu
+		virtual/opengl
+		$(python_gen_cond_dep '
+			dev-python/matplotlib[${PYTHON_USEDEP}]
+			>=dev-python/pivy-0.6.5[${PYTHON_USEDEP}]
+			dev-python/pyside2[gui,svg,webchannel,webengine,${PYTHON_USEDEP}]
+			dev-python/shiboken2[${PYTHON_USEDEP}]
+		')
+	)
+	netgen? ( media-gfx/netgen[opencascade] )
 	openscad? ( media-gfx/openscad )
-	pcl? ( sci-libs/pcl:=[opengl,openni2(+),qt5(+),vtk(+)] )
+	pcl? ( sci-libs/pcl:=[opengl,openni2,qt5,vtk] )
 	$(python_gen_cond_dep '
-		dev-libs/boost:=[python,${PYTHON_USEDEP}]
-		dev-python/matplotlib[${PYTHON_USEDEP}]
 		dev-python/numpy[${PYTHON_USEDEP}]
-		>=dev-python/pivy-0.6.5[${PYTHON_USEDEP}]
 		dev-python/pybind11[${PYTHON_USEDEP}]
-		dev-python/pyside2[gui,svg,webchannel,webengine,${PYTHON_USEDEP}]
-		dev-python/shiboken2[${PYTHON_USEDEP}]
 		addonmgr? ( dev-python/GitPython[${PYTHON_USEDEP}] )
 		fem? ( dev-python/ply[${PYTHON_USEDEP}] )
 	')
@@ -94,10 +101,18 @@ RDEPEND="
 DEPEND="
 	${RDEPEND}
 	>=dev-cpp/eigen-3.3.1:3
+	test? (
+		$(python_gen_cond_dep 'dev-python/pyyaml[${PYTHON_USEDEP}]')
+		dev-qt/qttest:5
+	)
 "
 BDEPEND="
 	app-text/dos2unix
 	dev-lang/swig
+	test? (
+		$(python_gen_cond_dep 'dev-python/pyyaml[${PYTHON_USEDEP}]')
+		dev-qt/qttest:5
+	)
 "
 
 # To get required dependencies:
@@ -115,6 +130,7 @@ BDEPEND="
 # test suite when compiled with a minimal set of USE flags.
 REQUIRED_USE="
 	${PYTHON_REQUIRED_USE}
+	designer? ( gui )
 	inspection? ( points )
 	path? ( robot )
 "
@@ -122,9 +138,10 @@ REQUIRED_USE="
 PATCHES=(
 	"${FILESDIR}"/${PN}-0.19.4-Gentoo-specific-don-t-check-vcs.patch
 	"${FILESDIR}"/${PN}-0.19.1-0001-Gentoo-specific-Remove-ccache-usage.patch
+	"${FILESDIR}"/${PN}-9999-tests-src-Qt-only-build-test-for-BUILD_GUI-ON.patch
 )
 
-DOCS=( CODE_OF_CONDUCT.md ChangeLog.txt README.md )
+DOCS=( CODE_OF_CONDUCT.md README.md )
 
 CHECKREQS_DISK_BUILD="2G"
 
@@ -155,7 +172,7 @@ src_configure() {
 		-DBUILD_DRAWING=ON
 		-DBUILD_ENABLE_CXX_STD:STRING="C++17"	# needed for current git master
 		-DBUILD_FEM=$(usex fem)
-		-DBUILD_FEM_NETGEN=OFF
+		-DBUILD_FEM_NETGEN=$(usex netgen)
 		-DBUILD_FLAT_MESH=ON
 		-DBUILD_FORCE_DIRECTORY=ON				# force building in a dedicated directory
 		-DBUILD_FREETYPE=ON						# automagic dep
@@ -263,6 +280,9 @@ src_install() {
 	fi
 	dosym -r /usr/$(get_libdir)/${PN}/bin/FreeCADCmd /usr/bin/freecadcmd
 
+	rm -r "${ED}"/usr/$(get_libdir)/${PN}/include/E57Format || die "failed to drop unneeded include directory E57Format"
+	use test && rm -r "${ED}"/usr/include/${PN}/{gmock,gtest} || die
+
 	python_optimize "${ED}"/usr/share/${PN}/data/Mod/Start/StartPage "${ED}"/usr/$(get_libdir)/${PN}{/Ext,/Mod}/
 	# compile main package in python site-packages as well
 	python_optimize
@@ -275,7 +295,7 @@ pkg_postinst() {
 	einfo "AddonManager."
 
 	# ToDo: check opencv, pysolar (::science), elmerfem (::science)
-	#		ifc++, ifcopenshell, netgen, z88 (no pkgs), calculix-ccx (::waebbl)
+	#		ifc++, ifcopenshell, z88 (no pkgs), calculix-ccx (::waebbl)
 	einfo "There are a lot of additional tools, for which FreeCAD has builtin"
 	einfo "support. Some of them are available in Gentoo. Take a look at"
 	einfo "https://wiki.freecadweb.org/Installing#External_software_supported_by_FreeCAD"

--- a/media-gfx/freecad/metadata.xml
+++ b/media-gfx/freecad/metadata.xml
@@ -52,6 +52,9 @@
 		<flag name="material">
 			Build the material module and workbench to work with materials
 		</flag>
+		<flag name="netgen">
+			Build support for the netgen mesher through <pkg>media-gfx/netgen</pkg>.
+		</flag>
 		<flag name="openscad">
 			Build the OpenSCAD module for interoperability with OpenSCAD 
 			and repairing Constructive Solid Geometry (CSG) history


### PR DESCRIPTION
**media-gfx/freecad: enable netgen support in live ebuild and 0.20.2**

- add py3.11 support
- better organize dependencies
- fix REQUIRED_USE for the designer plugin
- add libfmt dependency for live ebuild

Closes: https://bugs.gentoo.org/895660
Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>
