### PR TITLE
lxqt-base/lxqt-config : fix building against >=kde-plasma/kscreen-5.26.90

### DIFF
--- a/dev-util/lxqt-build-tools/files/lxqt-build-tools-cpp17-standard.patch
+++ b/dev-util/lxqt-build-tools/files/lxqt-build-tools-cpp17-standard.patch
@@ -1,0 +1,27 @@
+From 4a3a7038b1927dc43942a930db103023efdcbe2c Mon Sep 17 00:00:00 2001
+From: Simon Quigley <simon@tsimonq2.net>
+Date: Wed, 25 Jan 2023 09:39:41 -0600
+Subject: [PATCH] Bump the minimum compatibility level to C++17.
+
+---
+ cmake/modules/LXQtCompilerSettings.cmake | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/cmake/modules/LXQtCompilerSettings.cmake b/cmake/modules/LXQtCompilerSettings.cmake
+index a8cb16d..acba891 100644
+--- a/cmake/modules/LXQtCompilerSettings.cmake
++++ b/cmake/modules/LXQtCompilerSettings.cmake
+@@ -181,11 +181,11 @@ endif()
+ 
+ 
+ #-----------------------------------------------------------------------------
+-# CXX14 requirements - no checks, we just set it
++# CXX17 requirements - no checks, we just set it
+ #-----------------------------------------------------------------------------
+ set(CMAKE_CXX_STANDARD_REQUIRED True)
+ set(CMAKE_CXX_EXTENSIONS OFF)
+-set(CMAKE_CXX_STANDARD 14 CACHE STRING "C++ ISO Standard")
++set(CMAKE_CXX_STANDARD 17 CACHE STRING "C++ ISO Standard")
+ 
+ 
+ #-----------------------------------------------------------------------------

--- a/dev-util/lxqt-build-tools/lxqt-build-tools-0.12.0-r1.ebuild
+++ b/dev-util/lxqt-build-tools/lxqt-build-tools-0.12.0-r1.ebuild
@@ -1,0 +1,30 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit cmake
+
+DESCRIPTION="LXQt Build Tools"
+HOMEPAGE="https://lxqt-project.org/"
+
+if [[ ${PV} = *9999* ]]; then
+	inherit git-r3
+	EGIT_REPO_URI="https://github.com/lxqt/${PN}.git"
+else
+	SRC_URI="https://github.com/lxqt/${PN}/releases/download/${PV}/${P}.tar.xz"
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ~ppc64 ~riscv ~x86"
+fi
+
+LICENSE="BSD"
+SLOT="0"
+
+DEPEND="
+	>=dev-libs/glib-2.50.0
+	>=dev-qt/qtcore-5.15:5
+"
+RDEPEND="${DEPEND}"
+
+# https://bugs.gentoo.org/894468
+# https://github.com/lxqt/lxqt-build-tools/pull/83
+PATCHES=( "${FILESDIR}"/"${PN}"-cpp17-standard.patch )

--- a/lxqt-base/lxqt-config/files/lxqt-config-kscreen-52690.patch
+++ b/lxqt-base/lxqt-config/files/lxqt-config-kscreen-52690.patch
@@ -1,0 +1,80 @@
+From 6add4e4f0040693e7c4242fbae48c9d32007686c Mon Sep 17 00:00:00 2001
+From: Mamoru TASAKA <mtasaka@fedoraproject.org>
+Date: Fri, 3 Feb 2023 08:11:04 +0900
+Subject: [PATCH] lxqt-config-monitor: add more header file inclusion for
+ libkscreen 5.26.90 (#915)
+
+With https://github.com/KDE/libkscreen/commit/94f330959b0eda775418aef7faee80ce69144e63 ,
+`#include <KScreen/Output>` no longer includes "mode.h" implicitly.
+So in lxqt-config-monitor, files using `class KScreen::Mode` should include
+`#include <KScreen/Mode>` explicitly.
+
+Related: #903 .
+---
+ lxqt-config-monitor/kscreenutils.cpp          | 1 +
+ lxqt-config-monitor/loadsettings.cpp          | 1 +
+ lxqt-config-monitor/monitorpicture.cpp        | 1 +
+ lxqt-config-monitor/monitorsettingsdialog.cpp | 1 +
+ lxqt-config-monitor/monitorwidget.cpp         | 1 +
+ 5 files changed, 5 insertions(+)
+
+diff --git a/lxqt-config-monitor/kscreenutils.cpp b/lxqt-config-monitor/kscreenutils.cpp
+index 9515e789..be2634d7 100644
+--- a/lxqt-config-monitor/kscreenutils.cpp
++++ b/lxqt-config-monitor/kscreenutils.cpp
+@@ -2,6 +2,7 @@
+ #include "timeoutdialog.h"
+ 
+ #include <KScreen/Output>
++#include <KScreen/Mode>
+ #include <KScreen/Config>
+ #include <KScreen/GetConfigOperation>
+ #include <KScreen/SetConfigOperation>
+diff --git a/lxqt-config-monitor/loadsettings.cpp b/lxqt-config-monitor/loadsettings.cpp
+index 0c7bd73c..4e9331ba 100644
+--- a/lxqt-config-monitor/loadsettings.cpp
++++ b/lxqt-config-monitor/loadsettings.cpp
+@@ -23,6 +23,7 @@
+ #include "kscreenutils.h"
+ #include <KScreen/Output>
+ #include <KScreen/Config>
++#include <KScreen/Mode>
+ #include <KScreen/GetConfigOperation>
+ #include <KScreen/SetConfigOperation>
+ #include <LXQt/Settings>
+diff --git a/lxqt-config-monitor/monitorpicture.cpp b/lxqt-config-monitor/monitorpicture.cpp
+index 0d06ab82..4cb14894 100644
+--- a/lxqt-config-monitor/monitorpicture.cpp
++++ b/lxqt-config-monitor/monitorpicture.cpp
+@@ -24,6 +24,7 @@
+ #include <QDebug>
+ #include <QVector2D>
+ #include <QRectF>
++#include <KScreen/Mode>
+ #include <QScrollBar>
+ 
+ #include "configure.h"
+diff --git a/lxqt-config-monitor/monitorsettingsdialog.cpp b/lxqt-config-monitor/monitorsettingsdialog.cpp
+index 6172019f..bfd8c1dd 100644
+--- a/lxqt-config-monitor/monitorsettingsdialog.cpp
++++ b/lxqt-config-monitor/monitorsettingsdialog.cpp
+@@ -28,6 +28,7 @@
+ #include "kscreenutils.h"
+ 
+ #include <KScreen/Output>
++#include <KScreen/Mode>
+ #include <QJsonObject>
+ #include <QJsonArray>
+ #include <LXQt/Settings>
+diff --git a/lxqt-config-monitor/monitorwidget.cpp b/lxqt-config-monitor/monitorwidget.cpp
+index e0fcf0a8..41883c25 100644
+--- a/lxqt-config-monitor/monitorwidget.cpp
++++ b/lxqt-config-monitor/monitorwidget.cpp
+@@ -22,6 +22,7 @@
+ #include <QComboBox>
+ #include <QStringBuilder>
+ #include <QDialogButtonBox>
++#include <KScreen/Mode>
+ #include <KScreen/EDID>
+ 
+ #include <algorithm>

--- a/lxqt-base/lxqt-config/lxqt-config-1.2.0-r1.ebuild
+++ b/lxqt-base/lxqt-config/lxqt-config-1.2.0-r1.ebuild
@@ -1,0 +1,76 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+MY_PV="$(ver_cut 1-2)"
+
+inherit cmake xdg-utils
+
+DESCRIPTION="LXQt system configuration control center"
+HOMEPAGE="https://lxqt-project.org/"
+
+if [[ ${PV} = *9999* ]]; then
+	inherit git-r3
+	EGIT_REPO_URI="https://github.com/lxqt/${PN}.git"
+else
+	SRC_URI="https://github.com/lxqt/${PN}/releases/download/${PV}/${P}.tar.xz"
+	KEYWORDS="~amd64 ~arm ~arm64 ~loong ~ppc64 ~riscv ~x86"
+fi
+
+LICENSE="GPL-2 GPL-2+ GPL-3 LGPL-2 LGPL-2+ LGPL-2.1+ WTFPL-2"
+SLOT="0"
+IUSE="+monitor +touchpad"
+
+BDEPEND="
+	>=dev-qt/linguist-tools-5.15:5
+"
+DEPEND="
+	>=dev-libs/libqtxdg-3.10.0
+	>=dev-qt/qtcore-5.15:5
+	>=dev-qt/qtgui-5.15:5
+	>=dev-qt/qtwidgets-5.15:5
+	>=dev-qt/qtsvg-5.15:5
+	>=dev-qt/qtx11extras-5.15:5
+	>=dev-qt/qtxml-5.15:5
+	=lxqt-base/liblxqt-${MY_PV}*:=
+	sys-libs/zlib:=
+	x11-apps/setxkbmap
+	x11-libs/libxcb:=
+	x11-libs/libX11
+	x11-libs/libXcursor
+	x11-libs/libXfixes
+	monitor? ( kde-plasma/libkscreen:5= )
+	touchpad? (
+		virtual/libudev:=
+		x11-drivers/xf86-input-libinput
+		x11-libs/libXi
+	)
+"
+RDEPEND="${DEPEND}"
+
+# https://bugs.gentoo.org/894468
+# https://github.com/lxqt/lxqt-config/pull/915
+PATCHES=( "${FILESDIR}"/"${PN}"-kscreen-52690.patch )
+
+src_configure() {
+	local mycmakeargs=(
+		-DWITH_MONITOR=$(usex monitor)
+		-DWITH_TOUCHPAD=$(usex touchpad)
+	)
+
+	cmake_src_configure
+}
+
+src_install() {
+	cmake_src_install
+	doman man/*.1 liblxqt-config-cursor/man/*.1 lxqt-config-appearance/man/*.1
+}
+
+pkg_postinst() {
+	xdg_icon_cache_update
+}
+
+pkg_postrm() {
+	xdg_icon_cache_update
+}


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/894468
See: https://github.com/lxqt/lxqt-config/issues/903
See: https://github.com/lxqt/lxqt-build-tools/pull/83
See: https://github.com/lxqt/lxqt-config/pull/915

I tested and works fine on my system. Ideally, all LXQT stack would need a rebuild after the cpp standard change to lxqt-build-tools