### PR TITLE
net-libs/libvncserver: turn gcrypt USE flag on by default

### DIFF
--- a/net-libs/libvncserver/libvncserver-0.9.14.ebuild
+++ b/net-libs/libvncserver/libvncserver-0.9.14.ebuild
@@ -17,7 +17,7 @@ LICENSE="GPL-2 GPL-2+ LGPL-2.1+ BSD MIT"
 # no sub slot wanted (yet), see #578958
 SLOT="0"
 KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~loong ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux"
-IUSE="+24bpp +filetransfer gcrypt gnutls ipv6 +jpeg lzo +png sasl ssl systemd +threads +zlib"
+IUSE="+24bpp +filetransfer +gcrypt gnutls ipv6 +jpeg lzo +png sasl ssl systemd +threads +zlib"
 # https://bugs.gentoo.org/690202
 # https://bugs.gentoo.org/435326
 # https://bugs.gentoo.org/550916
@@ -26,6 +26,12 @@ REQUIRED_USE="
 	jpeg? ( zlib )
 	png? ( zlib )
 	ssl? ( !gnutls? ( threads ) )
+"
+# Avoid using internal crypto backend as it doesn't support
+# all authentication methods #893608
+REQUIRED_USE+="
+	ssl? ( gnutls? ( gcrypt ) )
+	!ssl? ( gcrypt )
 "
 
 DEPEND="


### PR DESCRIPTION
Also avoid using internal crypto backend as it doesn't support all
authentication methods.

Bug: https://bugs.gentoo.org/893608