### PR TITLE
Vim: remove manual patch application

### DIFF
--- a/app-editors/gvim/gvim-9.0.1000.ebuild
+++ b/app-editors/gvim/gvim-9.0.1000.ebuild
@@ -80,6 +80,13 @@ BDEPEND="
 "
 PDEPEND="!minimal? ( app-vim/gentoo-syntax )"
 
+if [[ ${PV} != 9999* ]]; then
+	# Gentoo patches to fix runtime issues, cross-compile errors, etc
+	PATCHES=(
+		"${WORKDIR}/vim-patches-vim-${VIM_PATCHES_VERSION}-patches"
+	)
+fi
+
 # various failures (bugs #630042 and #682320)
 RESTRICT="test"
 
@@ -93,10 +100,7 @@ pkg_setup() {
 }
 
 src_prepare() {
-	if [[ ${PV} != 9999* ]]; then
-		# Gentoo patches to fix runtime issues, cross-compile errors, etc
-		eapply "${WORKDIR}/vim-patches-vim-${VIM_PATCHES_VERSION}-patches"
-	fi
+	default
 
 	# Fixup a script to use awk instead of nawk
 	sed -i -e \
@@ -163,8 +167,6 @@ src_prepare() {
 		sed -i -e \
 			'/# define FEAT_CSCOPE/d' src/feature.h || die "couldn't disable cscope"
 	fi
-
-	eapply_user
 }
 
 src_configure() {

--- a/app-editors/gvim/gvim-9.0.1157.ebuild
+++ b/app-editors/gvim/gvim-9.0.1157.ebuild
@@ -80,6 +80,13 @@ BDEPEND="
 "
 PDEPEND="!minimal? ( app-vim/gentoo-syntax )"
 
+if [[ ${PV} != 9999* ]]; then
+	# Gentoo patches to fix runtime issues, cross-compile errors, etc
+	PATCHES=(
+		"${WORKDIR}/vim-patches-vim-${VIM_PATCHES_VERSION}-patches"
+	)
+fi
+
 # various failures (bugs #630042 and #682320)
 RESTRICT="test"
 
@@ -93,10 +100,7 @@ pkg_setup() {
 }
 
 src_prepare() {
-	if [[ ${PV} != 9999* ]]; then
-		# Gentoo patches to fix runtime issues, cross-compile errors, etc
-		eapply "${WORKDIR}/vim-patches-vim-${VIM_PATCHES_VERSION}-patches"
-	fi
+	default
 
 	# Fixup a script to use awk instead of nawk
 	sed -i -e \
@@ -163,8 +167,6 @@ src_prepare() {
 		sed -i -e \
 			'/# define FEAT_CSCOPE/d' src/feature.h || die "couldn't disable cscope"
 	fi
-
-	eapply_user
 }
 
 src_configure() {

--- a/app-editors/gvim/gvim-9999.ebuild
+++ b/app-editors/gvim/gvim-9999.ebuild
@@ -80,6 +80,13 @@ BDEPEND="
 "
 PDEPEND="!minimal? ( app-vim/gentoo-syntax )"
 
+if [[ ${PV} != 9999* ]]; then
+	# Gentoo patches to fix runtime issues, cross-compile errors, etc
+	PATCHES=(
+		"${WORKDIR}/vim-patches-vim-${VIM_PATCHES_VERSION}-patches"
+	)
+fi
+
 # various failures (bugs #630042 and #682320)
 RESTRICT="test"
 
@@ -93,10 +100,7 @@ pkg_setup() {
 }
 
 src_prepare() {
-	if [[ ${PV} != 9999* ]]; then
-		# Gentoo patches to fix runtime issues, cross-compile errors, etc
-		eapply "${WORKDIR}/vim-patches-vim-${VIM_PATCHES_VERSION}-patches"
-	fi
+	default
 
 	# Fixup a script to use awk instead of nawk
 	sed -i -e \
@@ -163,8 +167,6 @@ src_prepare() {
 		sed -i -e \
 			'/# define FEAT_CSCOPE/d' src/feature.h || die "couldn't disable cscope"
 	fi
-
-	eapply_user
 }
 
 src_configure() {

--- a/app-editors/vim-core/vim-core-9.0.1000.ebuild
+++ b/app-editors/vim-core/vim-core-9.0.1000.ebuild
@@ -31,6 +31,13 @@ IUSE="nls acl minimal"
 DEPEND=">=sys-libs/ncurses-5.2-r2:0"
 BDEPEND="sys-devel/autoconf"
 
+if [[ ${PV} != 9999* ]]; then
+	# Gentoo patches to fix runtime issues, cross-compile errors, etc
+	PATCHES=(
+		"${WORKDIR}/vim-patches-vim-${VIM_PATCHES_VERSION}-patches"
+	)
+fi
+
 pkg_setup() {
 	# people with broken alphabets run into trouble. bug #82186.
 	unset LANG LC_ALL
@@ -38,10 +45,7 @@ pkg_setup() {
 }
 
 src_prepare() {
-	if [[ ${PV} != 9999* ]] ; then
-		# Gentoo patches to fix runtime issues, cross-compile errors, etc
-		eapply "${WORKDIR}"/vim-patches-vim-${VIM_PATCHES_VERSION}-patches
-	fi
+	default
 
 	# Fixup a script to use awk instead of nawk
 	sed -i \
@@ -106,8 +110,6 @@ src_prepare() {
 
 	# Remove src/auto/configure file.
 	rm -v src/auto/configure || die "rm configure failed"
-
-	eapply_user
 }
 
 src_configure() {

--- a/app-editors/vim-core/vim-core-9.0.1157.ebuild
+++ b/app-editors/vim-core/vim-core-9.0.1157.ebuild
@@ -31,6 +31,13 @@ IUSE="nls acl minimal"
 DEPEND=">=sys-libs/ncurses-5.2-r2:0"
 BDEPEND="sys-devel/autoconf"
 
+if [[ ${PV} != 9999* ]]; then
+	# Gentoo patches to fix runtime issues, cross-compile errors, etc
+	PATCHES=(
+		"${WORKDIR}/vim-patches-vim-${VIM_PATCHES_VERSION}-patches"
+	)
+fi
+
 pkg_setup() {
 	# people with broken alphabets run into trouble. bug #82186.
 	unset LANG LC_ALL
@@ -38,10 +45,7 @@ pkg_setup() {
 }
 
 src_prepare() {
-	if [[ ${PV} != 9999* ]] ; then
-		# Gentoo patches to fix runtime issues, cross-compile errors, etc
-		eapply "${WORKDIR}"/vim-patches-vim-${VIM_PATCHES_VERSION}-patches
-	fi
+	default
 
 	# Fixup a script to use awk instead of nawk
 	sed -i \
@@ -106,8 +110,6 @@ src_prepare() {
 
 	# Remove src/auto/configure file.
 	rm -v src/auto/configure || die "rm configure failed"
-
-	eapply_user
 }
 
 src_configure() {

--- a/app-editors/vim-core/vim-core-9999.ebuild
+++ b/app-editors/vim-core/vim-core-9999.ebuild
@@ -31,6 +31,13 @@ IUSE="nls acl minimal"
 DEPEND=">=sys-libs/ncurses-5.2-r2:0"
 BDEPEND="sys-devel/autoconf"
 
+if [[ ${PV} != 9999* ]]; then
+	# Gentoo patches to fix runtime issues, cross-compile errors, etc
+	PATCHES=(
+		"${WORKDIR}/vim-patches-vim-${VIM_PATCHES_VERSION}-patches"
+	)
+fi
+
 pkg_setup() {
 	# people with broken alphabets run into trouble. bug #82186.
 	unset LANG LC_ALL
@@ -38,10 +45,7 @@ pkg_setup() {
 }
 
 src_prepare() {
-	if [[ ${PV} != 9999* ]] ; then
-		# Gentoo patches to fix runtime issues, cross-compile errors, etc
-		eapply "${WORKDIR}"/vim-patches-vim-9.0.0049-patches
-	fi
+	default
 
 	# Fixup a script to use awk instead of nawk
 	sed -i \
@@ -106,8 +110,6 @@ src_prepare() {
 
 	# Remove src/auto/configure file.
 	rm -v src/auto/configure || die "rm configure failed"
-
-	eapply_user
 }
 
 src_configure() {

--- a/app-editors/vim/vim-9.0.1000.ebuild
+++ b/app-editors/vim/vim-9.0.1000.ebuild
@@ -68,6 +68,13 @@ BDEPEND="
 "
 PDEPEND="!minimal? ( app-vim/gentoo-syntax )"
 
+if [[ ${PV} != 9999* ]]; then
+	# Gentoo patches to fix runtime issues, cross-compile errors, etc
+	PATCHES=(
+		"${WORKDIR}/vim-patches-vim-${VIM_PATCHES_VERSION}-patches"
+	)
+fi
+
 pkg_setup() {
 	# people with broken alphabets run into trouble. bug #82186.
 	unset LANG LC_ALL
@@ -78,10 +85,7 @@ pkg_setup() {
 }
 
 src_prepare() {
-	if [[ ${PV} != 9999* ]] ; then
-		# Gentoo patches to fix runtime issues, cross-compile errors, etc
-		eapply "${WORKDIR}"/vim-patches-vim-${VIM_PATCHES_VERSION}-patches
-	fi
+	default
 
 	# Fixup a script to use awk instead of nawk
 	sed -i -e \
@@ -153,8 +157,6 @@ src_prepare() {
 	# (4) Run ./configure (with wrong args) to remake auto/config.mk
 	sed -i 's# auto/config\.mk:#:#' src/Makefile || die "Makefile sed failed"
 	rm src/auto/configure || die "rm failed"
-
-	eapply_user
 }
 
 src_configure() {

--- a/app-editors/vim/vim-9.0.1157.ebuild
+++ b/app-editors/vim/vim-9.0.1157.ebuild
@@ -68,6 +68,13 @@ BDEPEND="
 "
 PDEPEND="!minimal? ( app-vim/gentoo-syntax )"
 
+if [[ ${PV} != 9999* ]]; then
+	# Gentoo patches to fix runtime issues, cross-compile errors, etc
+	PATCHES=(
+		"${WORKDIR}/vim-patches-vim-${VIM_PATCHES_VERSION}-patches"
+	)
+fi
+
 pkg_setup() {
 	# people with broken alphabets run into trouble. bug #82186.
 	unset LANG LC_ALL
@@ -78,10 +85,7 @@ pkg_setup() {
 }
 
 src_prepare() {
-	if [[ ${PV} != 9999* ]] ; then
-		# Gentoo patches to fix runtime issues, cross-compile errors, etc
-		eapply "${WORKDIR}"/vim-patches-vim-${VIM_PATCHES_VERSION}-patches
-	fi
+	default
 
 	# Fixup a script to use awk instead of nawk
 	sed -i -e \
@@ -153,8 +157,6 @@ src_prepare() {
 	# (4) Run ./configure (with wrong args) to remake auto/config.mk
 	sed -i 's# auto/config\.mk:#:#' src/Makefile || die "Makefile sed failed"
 	rm src/auto/configure || die "rm failed"
-
-	eapply_user
 }
 
 src_configure() {

--- a/app-editors/vim/vim-9999.ebuild
+++ b/app-editors/vim/vim-9999.ebuild
@@ -68,6 +68,13 @@ BDEPEND="
 "
 PDEPEND="!minimal? ( app-vim/gentoo-syntax )"
 
+if [[ ${PV} != 9999* ]]; then
+	# Gentoo patches to fix runtime issues, cross-compile errors, etc
+	PATCHES=(
+		"${WORKDIR}/vim-patches-vim-${VIM_PATCHES_VERSION}-patches"
+	)
+fi
+
 pkg_setup() {
 	# people with broken alphabets run into trouble. bug #82186.
 	unset LANG LC_ALL
@@ -78,10 +85,7 @@ pkg_setup() {
 }
 
 src_prepare() {
-	if [[ ${PV} != 9999* ]] ; then
-		# Gentoo patches to fix runtime issues, cross-compile errors, etc
-		eapply "${WORKDIR}"/vim-patches-vim-${VIM_PATCHES_VERSION}-patches
-	fi
+	default
 
 	# Fixup a script to use awk instead of nawk
 	sed -i -e \
@@ -153,8 +157,6 @@ src_prepare() {
 	# (4) Run ./configure (with wrong args) to remake auto/config.mk
 	sed -i 's# auto/config\.mk:#:#' src/Makefile || die "Makefile sed failed"
 	rm src/auto/configure || die "rm failed"
-
-	eapply_user
 }
 
 src_configure() {


### PR DESCRIPTION
Replace the manual `eapply` with `PATCHES` array and a call to `default` in `src_prepare()`.