### PR TITLE
=*/*-9999: add python3.11 to PYTHON_COMPAT where non-9999 version has it

### DIFF
--- a/app-backup/borgbackup/borgbackup-9999.ebuild
+++ b/app-backup/borgbackup/borgbackup-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{9..10} )
+PYTHON_COMPAT=( python3_{9..11} )
 
 inherit distutils-r1
 

--- a/app-emulation/spice/spice-9999.ebuild
+++ b/app-emulation/spice/spice-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{9,10} )
+PYTHON_COMPAT=( python3_{9..11} )
 inherit git-r3 meson python-any-r1 readme.gentoo-r1 xdg-utils
 
 DESCRIPTION="SPICE server"

--- a/media-gfx/hugin/hugin-9999.ebuild
+++ b/media-gfx/hugin/hugin-9999.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 
 WX_GTK_VER="3.0-gtk3"
-PYTHON_COMPAT=( python3_{9..10} )
+PYTHON_COMPAT=( python3_{9..11} )
 
 inherit mercurial python-single-r1 wxwidgets cmake xdg
 

--- a/media-libs/libsndfile/libsndfile-9999.ebuild
+++ b/media-libs/libsndfile/libsndfile-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{9..10} pypy3 )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 
 if [[ ${PV} == *9999 ]]; then
 	inherit autotools git-r3


### PR DESCRIPTION
Following @mgorny's call to review python3.11 compatibility I decided to handle a low-hanging one...