### PR TITLE
dev-python/symengine: add python3.11 to PYTHON_COMPAT

### DIFF
--- a/dev-python/symengine/symengine-0.9.2-r2.ebuild
+++ b/dev-python/symengine/symengine-0.9.2-r2.ebuild
@@ -1,0 +1,56 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DISTUTILS_USE_PEP517=setuptools
+PYTHON_COMPAT=( python3_{9..11} )
+
+inherit distutils-r1
+
+MY_P=${PN}.py-${PV}
+DESCRIPTION="Python wrappers to the symengine C++ library"
+HOMEPAGE="https://github.com/symengine/symengine.py/"
+SRC_URI="
+	https://github.com/symengine/symengine.py/archive/v${PV}.tar.gz
+		-> ${MY_P}.tar.gz"
+S="${WORKDIR}/${MY_P}"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~riscv ~x86"
+
+BDEPEND="
+	dev-util/cmake
+	dev-python/cython[${PYTHON_USEDEP}]
+	test? (
+		dev-python/sympy[${PYTHON_USEDEP}]
+	)
+"
+# See bug #786582 for symengine constraint
+# See also https://github.com/symengine/symengine.py/blob/master/symengine_version.txt
+RDEPEND="
+	dev-python/numpy[${PYTHON_USEDEP}]
+	>=sci-libs/symengine-$(ver_cut 1-2):=
+"
+DEPEND="${RDEPEND}"
+
+# the C library installs the same docs
+DOCS=()
+
+PATCHES=(
+	"${FILESDIR}"/${P}-setuptools-61.patch
+	"${FILESDIR}"/${PN}-0.9.2-cmake-setuptools.patch
+)
+
+distutils_enable_tests pytest
+
+python_test() {
+	cd "${BUILD_DIR}/install$(python_get_sitedir)" || die
+	epytest
+}
+
+python_install() {
+	distutils-r1_python_install
+	python_optimize
+}

--- a/dev-python/sympy/files/sympy-1.11-no-deprecated-threading-event-api.patch
+++ b/dev-python/sympy/files/sympy-1.11-no-deprecated-threading-event-api.patch
@@ -1,0 +1,54 @@
+Patch back-ported from the sympy git repo
+url: https://github.com/sympy/sympy/commit/b89ca436cf25e2a1caf82c9d33221d06698d0ff5
+
+commit b89ca436cf25e2a1caf82c9d33221d06698d0ff5
+Author: Chris Kerr <chris.kerr@mykolab.ch>
+Date:   Thu Sep 22 19:32:27 2022 +0300
+
+    Replace deprecated .isSet() method with .is_set()
+    
+    Fixes https://github.com/sympy/sympy/issues/24074
+
+diff --git a/sympy/plotting/pygletplot/plot_mode_base.py b/sympy/plotting/pygletplot/plot_mode_base.py
+index c1c2b0a6ec..2c6503650a 100644
+--- a/sympy/plotting/pygletplot/plot_mode_base.py
++++ b/sympy/plotting/pygletplot/plot_mode_base.py
+@@ -269,7 +269,7 @@ def _calculate_all(self):
+         self._calculate_cverts()
+ 
+     def _calculate_verts(self):
+-        if self._calculating_verts.isSet():
++        if self._calculating_verts.is_set():
+             return
+         self._calculating_verts.set()
+         try:
+@@ -280,9 +280,9 @@ def _calculate_verts(self):
+             self.bounds_callback()
+ 
+     def _calculate_cverts(self):
+-        if self._calculating_verts.isSet():
++        if self._calculating_verts.is_set():
+             return
+-        while self._calculating_cverts.isSet():
++        while self._calculating_cverts.is_set():
+             sleep(0)  # wait for previous calculation
+         self._calculating_cverts.set()
+         try:
+@@ -291,7 +291,7 @@ def _calculate_cverts(self):
+             self._calculating_cverts.clear()
+ 
+     def _get_calculating_verts(self):
+-        return self._calculating_verts.isSet()
++        return self._calculating_verts.is_set()
+ 
+     def _get_calculating_verts_pos(self):
+         return self._calculating_verts_pos
+@@ -300,7 +300,7 @@ def _get_calculating_verts_len(self):
+         return self._calculating_verts_len
+ 
+     def _get_calculating_cverts(self):
+-        return self._calculating_cverts.isSet()
++        return self._calculating_cverts.is_set()
+ 
+     def _get_calculating_cverts_pos(self):
+         return self._calculating_cverts_pos

--- a/dev-python/sympy/sympy-1.11.1-r1.ebuild
+++ b/dev-python/sympy/sympy-1.11.1-r1.ebuild
@@ -1,0 +1,70 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DISTUTILS_USE_PEP517=setuptools
+PYTHON_COMPAT=( python3_{9..11} )
+
+inherit distutils-r1 virtualx
+
+DESCRIPTION="Computer Algebra System in pure Python"
+HOMEPAGE="https://www.sympy.org/"
+SRC_URI="https://github.com/sympy/sympy/archive/${P}.tar.gz -> ${P}.gh.tar.gz"
+S="${WORKDIR}/${PN}-${P}"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~riscv ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos"
+IUSE="aesara examples imaging ipython latex mathml opengl pdf png pyglet symengine test texmacs"
+
+RDEPEND="
+	dev-python/mpmath[${PYTHON_USEDEP}]
+	dev-python/pexpect[${PYTHON_USEDEP}]
+	aesara? ( $(python_gen_cond_dep 'dev-python/aesara[${PYTHON_USEDEP}]' python3_{9..10}) )
+	imaging? ( dev-python/pillow[${PYTHON_USEDEP}] )
+	ipython? ( dev-python/ipython[${PYTHON_USEDEP}] )
+	latex? (
+		virtual/latex-base
+		dev-texlive/texlive-fontsextra
+		png? ( app-text/dvipng )
+		pdf? ( app-text/ghostscript-gpl )
+	)
+	mathml? ( dev-libs/libxml2:2[${PYTHON_USEDEP}] )
+	opengl? ( dev-python/pyopengl[${PYTHON_USEDEP}] )
+	pyglet? ( dev-python/pyglet[${PYTHON_USEDEP}] )
+	symengine? ( dev-python/symengine[${PYTHON_USEDEP}] )
+	texmacs? ( app-office/texmacs )
+"
+
+PATCHES=(
+ "${FILESDIR}/${PN}-1.11-no-deprecated-threading-event-api.patch"
+)
+
+distutils_enable_tests pytest
+
+src_test() {
+	virtx distutils-r1_src_test
+}
+
+python_test() {
+	esetup.py test
+}
+
+python_install_all() {
+	local DOCS=( AUTHORS README.md )
+
+	if use examples; then
+		dodoc -r examples
+		docompress -x /usr/share/doc/${PF}/examples
+	fi
+
+	distutils-r1_python_install_all
+
+	if use texmacs; then
+		exeinto /usr/libexec/TeXmacs/bin/
+		doexe data/TeXmacs/bin/tm_sympy
+		insinto /usr/share/TeXmacs/plugins/sympy/
+		doins -r data/TeXmacs/progs
+	fi
+}


### PR DESCRIPTION
Motivation for this MR is that symengine and sympy are tested upstream with python3.11:
https://github.com/symengine/symengine.py/blob/master/.github/workflows/ci.yml#L11
and almost all their dependencies are ready for it.