### PR TITLE
sci-geosciences/gpxsee: requiere dev-qt/qtserialport 

### DIFF
--- a/sci-geosciences/gpxsee/gpxsee-12.0-r1.ebuild
+++ b/sci-geosciences/gpxsee/gpxsee-12.0-r1.ebuild
@@ -25,6 +25,7 @@ RDEPEND="dev-qt/qtcore:5
 	dev-qt/qtprintsupport:5
 	dev-qt/qtsql:5
 	dev-qt/qtpositioning:5
+	dev-qt/qtserialport:5
 	dev-qt/qtsvg:5"
 DEPEND="${RDEPEND}"
 BDEPEND="dev-qt/linguist-tools:5"


### PR DESCRIPTION
see https://github.com/tumic0/GPXSee/blob/master/gpxsee.pro in line 18
this the error

 * Running qmake ...
Info: creating stash file /var/tmp/portage/sci-geosciences/gpxsee-12.0/work/GPXSee-12.0/.qmake.stash
Project ERROR: Unknown module(s) in QT: serialport                                                                                                                                                          [ !! ]


check with pkgcheck