### PR TITLE
scripts/bootstrap.sh: Fix bootstrap in verbose mode

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -345,10 +345,16 @@ fi
 if [[ -n ${STRAP_RUN} ]] ; then
 	if [[ -x ${GCC_CONFIG} ]] && ${GCC_CONFIG} --get-current-profile &>/dev/null
 	then
-		# Make sure we get the old gcc unmerged ...
-		${V_ECHO} emerge ${STRAP_EMERGE_OPTS} --prune sys-devel/gcc || cleanup 1
-		# Make sure the profile and /lib/cpp and /usr/bin/cc are valid ...
-		${GCC_CONFIG} "$(${GCC_CONFIG} --get-current-profile)" &>/dev/null
+		output=$(${V_ECHO} emerge ${STRAP_EMERGE_OPTS} --prune --pretend --quiet sys-devel/gcc 2>/dev/null)
+		if [[ ${DEBUG} = "1" ]] ; then
+			echo "${output}"
+		fi
+		if [[ "${output}" = *'All selected packages:'* ]] ; then
+			# Make sure we get the old gcc unmerged ...
+			${V_ECHO} emerge ${STRAP_EMERGE_OPTS} --prune sys-devel/gcc || cleanup 1
+			# Make sure the profile and /lib/cpp and /usr/bin/cc are valid ...
+			${GCC_CONFIG} "$(${GCC_CONFIG} --get-current-profile)" &>/dev/null
+		fi
 	fi
 fi
 


### PR DESCRIPTION
Verbose mode does not unset STRAP_RUN, thus the script tries to prune sys-devel/gcc at the later stage. Currently portage exits with an exit status 1 if a specific package was requested to be pruned and there was nothing to do. This results in a bootstrap failure. So before we try to prune, let's do a dry run to see if anything would be done.

For the portage code that results in exit status 1, see the following link:

https://gitweb.gentoo.org/proj/portage.git/tree/lib/_emerge/actions.py?id=bde2a895cf520687dce7a8e92601041a37529ba0#n1700

Signed-off-by: Krzesimir Nowak <knowak@microsoft.com>