### PR TITLE
dev-python/frozendict: enable py3.11

### DIFF
--- a/dev-python/frozendict/files/frozendict-2.3.4-optional-extension.patch
+++ b/dev-python/frozendict/files/frozendict-2.3.4-optional-extension.patch
@@ -1,0 +1,20 @@
+Autodetect availability of C extension. Taken from upstream PR.
+
+Upstream-PR: https://github.com/Marco-Sulla/python-frozendict/pull/69
+
+diff --git a/setup.py b/setup.py
+index 0325383..0667b59 100755
+--- a/setup.py
++++ b/setup.py
+@@ -163,7 +163,7 @@ if len(argv) > 1 and argv[1] in custom_args:
+ impl = python_implementation()
+ 
+ if custom_arg == None:
+-    if impl == "PyPy":
++    if impl == "PyPy" or not src_path.exists():
+         custom_arg = "py"
+     else:
+         custom_arg = "c"
+-- 
+2.39.1
+

--- a/dev-python/frozendict/frozendict-2.3.4-r1.ebuild
+++ b/dev-python/frozendict/frozendict-2.3.4-r1.ebuild
@@ -1,0 +1,41 @@
+# Copyright 2022-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DISTUTILS_USE_PEP517=setuptools
+PYTHON_COMPAT=( python3_{9..11} )
+
+inherit distutils-r1
+
+DESCRIPTION="A simple immutable mapping for python"
+HOMEPAGE="
+	https://github.com/Marco-Sulla/python-frozendict/
+	https://pypi.org/project/frozendict/
+"
+SRC_URI="
+	https://github.com/Marco-Sulla/python-frozendict/archive/v${PV}.tar.gz
+		-> ${P}.gh.tar.gz
+"
+S="${WORKDIR}/python-${P}"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc64"
+
+PATCHES=(
+	"${FILESDIR}/${P}-optional-extension.patch"
+)
+
+distutils_enable_tests pytest
+
+python_test() {
+	# skip tests of native extension for python versions where it is not available
+	[[ ${EPYTHON} == python3.11 ]] && local -a EPYTEST_IGNORE=(
+		"${S}/test/test_frozendict_c.py"
+		"${S}/test/test_frozendict_c_subclass.py"
+	)
+
+	cd "${T}" || die
+	epytest "${S}/test"
+}


### PR DESCRIPTION
`frozendict` contains also pure python implementation which can be used for python versions where a native extension is not implemented yet. Pure python package is normally installed using the `py` custom argument with following command (taken from upstream [readme](https://github.com/Marco-Sulla/python-frozendict/tree/v2.3.4#building)):
```
python3 setup.py py bdist_wheel
```
but I was struggling to build the package with `python_*` functions and `esetup.py` correctly. Thus, I have created a small patch, which makes the native extension optional and disabled tests of it for py3.11 as it is not supported in this version.
