### PR TITLE
java-utils-2.eclass: default to default_src_prepare for future EAPI

### DIFF
--- a/eclass/java-utils-2.eclass
+++ b/eclass/java-utils-2.eclass
@@ -1933,7 +1933,10 @@ etestng() {
 # src_prepare Searches for bundled jars
 # Don't call directly, but via java-pkg-2_src_prepare!
 java-utils-2_src_prepare() {
-	eapply_user
+	case ${EAPI:-0} in
+		[678]) eapply_user ;;
+		*) default_src_prepare ;;
+	esac
 
 	# Check for files in JAVA_RM_FILES array.
 	if [[ ${JAVA_RM_FILES[@]} ]]; then

--- a/eclass/java-utils-2.eclass
+++ b/eclass/java-utils-2.eclass
@@ -2947,7 +2947,7 @@ is-java-strict() {
 java-pkg_clean() {
 	NO_DELETE=()
 	for keep in ${JAVA_PKG_NO_CLEAN[@]}; do
-		NO_DELETE+=( '!' '-wholename' ${keep} )
+		NO_DELETE+=( '!' '-path' ${keep} )
 	done
 	find "${@}" '(' -name '*.class' -o -name '*.jar' ${NO_DELETE[@]} ')' -type f -delete -print || die
 }


### PR DESCRIPTION
@fordfrog 
There are more cleanup and documentation works on `java-utils-2.eclass` in the first commit of ezzieyguywuf's https://github.com/gentoo/gentoo/pull/20608.  These could now be adopted.  There are 2 or 3 merge conflicts which could easily be solved. 
PR https://github.com/gentoo/gentoo/pull/20608 could then be closed since all `ebuild` reworks can be done later with the EAPI bumps.
