### PR TITLE
net-im/synapse: enable py3.11

### DIFF
--- a/net-im/synapse/synapse-1.76.0.ebuild
+++ b/net-im/synapse/synapse-1.76.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{9..10} )
+PYTHON_COMPAT=( python3_{9..11} )
 DISTUTILS_USE_PEP517=poetry
 
 CRATES="

--- a/net-im/synapse/synapse-1.77.0.ebuild
+++ b/net-im/synapse/synapse-1.77.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{9..10} )
+PYTHON_COMPAT=( python3_{9..11} )
 DISTUTILS_USE_PEP517=poetry
 
 CRATES="


### PR DESCRIPTION
Enable python3.11 for version 1.76.0 and 1.77.0. Tests pass for both versions with enabled/disabled `postgres` USE flag.