### PR TITLE
net-proxy/haproxy: fix musl support in all available versions

### DIFF
--- a/net-proxy/haproxy/haproxy-2.2.25.ebuild
+++ b/net-proxy/haproxy/haproxy-2.2.25.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="7"
@@ -75,11 +75,16 @@ pkg_setup() {
 src_compile() {
 	local -a args=(
 		V=1
-		TARGET=linux-glibc
 		# Switching to PCRE2 by default, bug 838013
 		PCRE=
 		PCRE_JIT=
 	)
+
+	if use elibc_musl; then
+		args+=( TARGET=linux-musl )
+	else
+		args+=( TARGET=linux-glibc )
+	fi
 
 	# TODO: PCRE2_WIDTH?
 	args+=( $(haproxy_use threads THREAD) )

--- a/net-proxy/haproxy/haproxy-2.2.29.ebuild
+++ b/net-proxy/haproxy/haproxy-2.2.29.ebuild
@@ -75,11 +75,16 @@ pkg_setup() {
 src_compile() {
 	local -a args=(
 		V=1
-		TARGET=linux-glibc
 		# Switching to PCRE2 by default, bug 838013
 		PCRE=
 		PCRE_JIT=
 	)
+
+	if use elibc_musl; then
+		args+=( TARGET=linux-musl )
+	else
+		args+=( TARGET=linux-glibc )
+	fi
 
 	# TODO: PCRE2_WIDTH?
 	args+=( $(haproxy_use threads THREAD) )

--- a/net-proxy/haproxy/haproxy-2.2.9999.ebuild
+++ b/net-proxy/haproxy/haproxy-2.2.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="7"
@@ -75,11 +75,16 @@ pkg_setup() {
 src_compile() {
 	local -a args=(
 		V=1
-		TARGET=linux-glibc
 		# Switching to PCRE2 by default, bug 838013
 		PCRE=
 		PCRE_JIT=
 	)
+
+	if use elibc_musl; then
+		args+=( TARGET=linux-musl )
+	else
+		args+=( TARGET=linux-glibc )
+	fi
 
 	# TODO: PCRE2_WIDTH?
 	args+=( $(haproxy_use threads THREAD) )

--- a/net-proxy/haproxy/haproxy-2.4.18.ebuild
+++ b/net-proxy/haproxy/haproxy-2.4.18.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="7"
@@ -70,11 +70,16 @@ pkg_setup() {
 src_compile() {
 	local -a args=(
 		V=1
-		TARGET=linux-glibc
 		# Switching to PCRE2 by default, bug 838013
 		PCRE=
 		PCRE_JIT=
 	)
+
+	if use elibc_musl; then
+		args+=( TARGET=linux-musl )
+	else
+		args+=( TARGET=linux-glibc )
+	fi
 
 	# TODO: PCRE2_WIDTH?
 	args+=( $(haproxy_use threads THREAD) )

--- a/net-proxy/haproxy/haproxy-2.4.22.ebuild
+++ b/net-proxy/haproxy/haproxy-2.4.22.ebuild
@@ -71,11 +71,16 @@ pkg_setup() {
 src_compile() {
 	local -a args=(
 		V=1
-		TARGET=linux-glibc
 		# Switching to PCRE2 by default, bug 838013
 		PCRE=
 		PCRE_JIT=
 	)
+
+	if use elibc_musl; then
+		args+=( TARGET=linux-musl )
+	else
+		args+=( TARGET=linux-glibc )
+	fi
 
 	# TODO: PCRE2_WIDTH?
 	args+=( $(haproxy_use threads THREAD) )

--- a/net-proxy/haproxy/haproxy-2.4.9999.ebuild
+++ b/net-proxy/haproxy/haproxy-2.4.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="7"
@@ -70,11 +70,16 @@ pkg_setup() {
 src_compile() {
 	local -a args=(
 		V=1
-		TARGET=linux-glibc
 		# Switching to PCRE2 by default, bug 838013
 		PCRE=
 		PCRE_JIT=
 	)
+
+	if use elibc_musl; then
+		args+=( TARGET=linux-musl )
+	else
+		args+=( TARGET=linux-glibc )
+	fi
 
 	# TODO: PCRE2_WIDTH?
 	args+=( $(haproxy_use threads THREAD) )

--- a/net-proxy/haproxy/haproxy-2.6.9.ebuild
+++ b/net-proxy/haproxy/haproxy-2.6.9.ebuild
@@ -70,11 +70,16 @@ pkg_setup() {
 src_compile() {
 	local -a args=(
 		V=1
-		TARGET=linux-glibc
 		# Switching to PCRE2 by default, bug 838013
 		PCRE=
 		PCRE_JIT=
 	)
+
+	if use elibc_musl; then
+		args+=( TARGET=linux-musl )
+	else
+		args+=( TARGET=linux-glibc )
+	fi
 
 	# TODO: PCRE2_WIDTH?
 	args+=( $(haproxy_use threads THREAD) )

--- a/net-proxy/haproxy/haproxy-2.6.9999.ebuild
+++ b/net-proxy/haproxy/haproxy-2.6.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="7"
@@ -70,11 +70,16 @@ pkg_setup() {
 src_compile() {
 	local -a args=(
 		V=1
-		TARGET=linux-glibc
 		# Switching to PCRE2 by default, bug 838013
 		PCRE=
 		PCRE_JIT=
 	)
+
+	if use elibc_musl; then
+		args+=( TARGET=linux-musl )
+	else
+		args+=( TARGET=linux-glibc )
+	fi
 
 	# TODO: PCRE2_WIDTH?
 	args+=( $(haproxy_use threads THREAD) )

--- a/net-proxy/haproxy/haproxy-2.7.3.ebuild
+++ b/net-proxy/haproxy/haproxy-2.7.3.ebuild
@@ -70,11 +70,16 @@ pkg_setup() {
 src_compile() {
 	local -a args=(
 		V=1
-		TARGET=linux-glibc
 		# Switching to PCRE2 by default, bug 838013
 		PCRE=
 		PCRE_JIT=
 	)
+
+	if use elibc_musl; then
+		args+=( TARGET=linux-musl )
+	else
+		args+=( TARGET=linux-glibc )
+	fi
 
 	# TODO: PCRE2_WIDTH?
 	args+=( $(haproxy_use threads THREAD) )

--- a/net-proxy/haproxy/haproxy-2.7.9999.ebuild
+++ b/net-proxy/haproxy/haproxy-2.7.9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="7"
@@ -70,11 +70,16 @@ pkg_setup() {
 src_compile() {
 	local -a args=(
 		V=1
-		TARGET=linux-glibc
 		# Switching to PCRE2 by default, bug 838013
 		PCRE=
 		PCRE_JIT=
 	)
+
+	if use elibc_musl; then
+		args+=( TARGET=linux-musl )
+	else
+		args+=( TARGET=linux-glibc )
+	fi
 
 	# TODO: PCRE2_WIDTH?
 	args+=( $(haproxy_use threads THREAD) )

--- a/net-proxy/haproxy/haproxy-9999.ebuild
+++ b/net-proxy/haproxy/haproxy-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="7"
@@ -70,11 +70,16 @@ pkg_setup() {
 src_compile() {
 	local -a args=(
 		V=1
-		TARGET=linux-glibc
 		# Switching to PCRE2 by default, bug 838013
 		PCRE=
 		PCRE_JIT=
 	)
+
+	if use elibc_musl; then
+		args+=( TARGET=linux-musl )
+	else
+		args+=( TARGET=linux-glibc )
+	fi
 
 	# TODO: PCRE2_WIDTH?
 	args+=( $(haproxy_use threads THREAD) )


### PR DESCRIPTION
`TARGET` needs to be set to `linux-musl` for proper musl support. It is available since version 2.2, therefore all currently present ebuilds are updated appropriately.

Closes: https://bugs.gentoo.org/866053