### PR TITLE
media-video/qmplay2: drop no longer needed patch

### DIFF
--- a/media-video/qmplay2/qmplay2-23.02.05.ebuild
+++ b/media-video/qmplay2/qmplay2-23.02.05.ebuild
@@ -66,10 +66,6 @@ RDEPEND="
 DEPEND="${RDEPEND}"
 BDEPEND="dev-qt/linguist-tools:5"
 
-PATCHES=(
-	"${FILESDIR}/${P}-fix-includes.patch"
-)
-
 src_prepare() {
 	# disable compress man pages
 	sed -r \


### PR DESCRIPTION
media-video/qmplay2-23.02.05 is trying to apply a patch that doesn't exist. A patch file exists in FILESDIR for the previous version, which is no longer needed in the new version. So drop the patch altogether.