### PR TITLE
PYTHON_COMPAT pypy3 for scipy

### DIFF
--- a/dev-python/beniget/beniget-0.4.1-r1.ebuild
+++ b/dev-python/beniget/beniget-0.4.1-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 DISTUTILS_USE_PEP517=setuptools
 inherit distutils-r1
 

--- a/dev-python/cairocffi/cairocffi-1.4.0.ebuild
+++ b/dev-python/cairocffi/cairocffi-1.4.0.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 
 inherit distutils-r1 virtualx
 

--- a/dev-python/cffi/cffi-1.15.1.ebuild
+++ b/dev-python/cffi/cffi-1.15.1.ebuild
@@ -7,7 +7,7 @@ EAPI=7
 DISTUTILS_USE_PEP517=setuptools
 # DO NOT ADD pypy to PYTHON_COMPAT
 # pypy bundles a modified version of cffi. Use python_gen_cond_dep instead.
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 
 inherit distutils-r1 toolchain-funcs
 

--- a/dev-python/contourpy/contourpy-1.0.7.ebuild
+++ b/dev-python/contourpy/contourpy-1.0.7.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 
 inherit distutils-r1
 

--- a/dev-python/cppy/cppy-1.2.1-r1.ebuild
+++ b/dev-python/cppy/cppy-1.2.1-r1.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 
 inherit distutils-r1
 

--- a/dev-python/cycler/cycler-0.11.0-r1.ebuild
+++ b/dev-python/cycler/cycler-0.11.0-r1.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 inherit distutils-r1
 
 DESCRIPTION="Composable style cycles"

--- a/dev-python/debugpy/debugpy-1.6.6.ebuild
+++ b/dev-python/debugpy/debugpy-1.6.6.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 DISTUTILS_USE_PEP517=setuptools
 inherit distutils-r1
 

--- a/dev-python/fonttools/files/fonttools-4.38.0-pypy3.patch
+++ b/dev-python/fonttools/files/fonttools-4.38.0-pypy3.patch
@@ -1,0 +1,34 @@
+url: https://github.com/fonttools/fonttools/issues/2996
+
+commit ca9d98d94c3ba98db934f0d1e3a77134171f2262
+Author: Jérôme Carretero <cJ-gentoo@zougloub.eu>
+Date:   Fri Feb 17 19:24:46 2023 -0500
+
+    Fixup pypy3 compatibility
+
+diff --git a/Lib/fontTools/misc/macCreatorType.py b/Lib/fontTools/misc/macCreatorType.py
+index 6b191054b..f680f238d 100644
+--- a/Lib/fontTools/misc/macCreatorType.py
++++ b/Lib/fontTools/misc/macCreatorType.py
+@@ -24,7 +24,7 @@ def getMacCreatorAndType(path):
+ 	"""
+ 	if xattr is not None:
+ 		try:
+-			finderInfo = xattr.getxattr(path, 'com.apple.FinderInfo')
++			finderInfo = xattr.getxattr(str(path), 'com.apple.FinderInfo')
+ 		except (KeyError, IOError):
+ 			pass
+ 		else:
+diff --git a/Lib/fontTools/subset/svg.py b/Lib/fontTools/subset/svg.py
+index 4ed2cbd20..4a8823928 100644
+--- a/Lib/fontTools/subset/svg.py
++++ b/Lib/fontTools/subset/svg.py
+@@ -77,7 +77,7 @@ def iter_referenced_ids(tree: etree.Element) -> Iterator[str]:
+ 
+         attrs = el.attrib
+         if "style" in attrs:
+-            attrs = {**attrs, **parse_css_declarations(el.attrib["style"])}
++            attrs = {**dict(attrs), **dict(parse_css_declarations(el.attrib["style"]))}
+         for attr in ("fill", "clip-path"):
+             if attr in attrs:
+                 value = attrs[attr]

--- a/dev-python/fonttools/fonttools-4.38.0-r1.ebuild
+++ b/dev-python/fonttools/fonttools-4.38.0-r1.ebuild
@@ -1,0 +1,70 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DISTUTILS_USE_PEP517=setuptools
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
+PYTHON_REQ_USE="xml(+)"
+
+inherit distutils-r1 virtualx
+
+DESCRIPTION="Library for manipulating TrueType, OpenType, AFM and Type1 fonts"
+HOMEPAGE="
+	https://github.com/fonttools/fonttools/
+	https://pypi.org/project/fonttools/
+"
+SRC_URI="
+	https://github.com/fonttools/fonttools/archive/${PV}.tar.gz
+		-> ${P}.gh.tar.gz
+"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~x64-macos"
+
+RDEPEND="
+	>=dev-python/fs-2.4.9[${PYTHON_USEDEP}]
+"
+BDEPEND="
+	dev-python/cython[${PYTHON_USEDEP}]
+	test? (
+		app-arch/brotli[python,${PYTHON_USEDEP}]
+		app-arch/zopfli
+	)
+"
+
+PATCHES=(
+ "${FILESDIR}/fonttools-4.38.0-pypy3.patch"
+)
+
+distutils_enable_tests pytest
+
+python_prepare_all() {
+	# When dev-python/pytest-shutil is installed, we get weird import errors.
+	# This is due to incomplete nesting in the Tests/ tree:
+	#
+	#   Tests/feaLib/__init__.py
+	#   Tests/ufoLib/__init__.py
+	#   Tests/svgLib/path/__init__.py
+	#   Tests/otlLib/__init__.py
+	#   Tests/varLib/__init__.py
+	#
+	# This tree requires an __init__.py in Tests/svgLib/ too, bug #701148.
+	touch Tests/svgLib/__init__.py || die
+
+	distutils-r1_python_prepare_all
+}
+
+src_configure() {
+	export FONTTOOLS_WITH_CYTHON=1
+}
+
+src_test() {
+	# virtualx used when matplotlib is installed causing plot module tests to run
+	virtx distutils-r1_src_test
+}
+
+python_test() {
+	epytest Tests fontTools || die "Tests failed with ${EPYTHON}"
+}

--- a/dev-python/gast/gast-0.5.3-r1.ebuild
+++ b/dev-python/gast/gast-0.5.3-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 DISTUTILS_USE_PEP517=setuptools
 inherit distutils-r1
 

--- a/dev-python/gmpy/gmpy-2.1.5.ebuild
+++ b/dev-python/gmpy/gmpy-2.1.5.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 
 inherit distutils-r1
 

--- a/dev-python/kiwisolver/files/kiwisolver-1.4.4-pypy3-tests.patch
+++ b/dev-python/kiwisolver/files/kiwisolver-1.4.4-pypy3-tests.patch
@@ -1,0 +1,30 @@
+Patch provided upstream as https://github.com/nucleic/kiwi/pull/158
+from issue created at https://github.com/nucleic/kiwi/issues/157
+
+commit ad1c62f046dc14c1e85e4e1c1b8e175eda08838e
+Author: Jérôme Carretero <cJ-kiwisolver@zougloub.eu>
+Date:   Fri Feb 17 18:40:45 2023 -0500
+
+    py: tests: make tests run under PyPy
+
+diff --git a/py/tests/test_expression.py b/py/tests/test_expression.py
+index 671dd7f..6b5d8e5 100644
+--- a/py/tests/test_expression.py
++++ b/py/tests/test_expression.py
+@@ -8,6 +8,7 @@
+ import gc
+ import math
+ import operator
++import sys
+ from typing import Tuple
+ 
+ import pytest
+@@ -264,4 +265,7 @@ def test_expression_rich_compare_operations(op, symbol) -> None:
+     else:
+         with pytest.raises(TypeError) as excinfo:
+             op(e1, e2)
+-        assert "kiwisolver.Expression" in excinfo.exconly()
++        if "PyPy" in sys.version:
++            assert "Expression" in excinfo.exconly()
++        else:
++            assert "kiwisolver.Expression" in excinfo.exconly()

--- a/dev-python/kiwisolver/kiwisolver-1.4.4-r1.ebuild
+++ b/dev-python/kiwisolver/kiwisolver-1.4.4-r1.ebuild
@@ -1,0 +1,44 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DISTUTILS_USE_PEP517=setuptools
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
+
+inherit distutils-r1
+
+MY_P=kiwi-${PV}
+DESCRIPTION="An efficient C++ implementation of the Cassowary constraint solving algorithm"
+HOMEPAGE="
+	https://github.com/nucleic/kiwi/
+	https://pypi.org/project/kiwisolver/
+"
+SRC_URI="
+	https://github.com/nucleic/kiwi/archive/${PV}.tar.gz -> ${MY_P}.gh.tar.gz
+"
+S=${WORKDIR}/${MY_P}
+
+LICENSE="Clear-BSD"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+
+COMMON_DEPEND="
+	>=dev-python/cppy-1.2.0[${PYTHON_USEDEP}]
+"
+
+RDEPEND="
+	${COMMON_DEPEND}
+"
+BDEPEND="
+	${COMMON_DEPEND}
+	>=dev-python/setuptools_scm-3.4.3[${PYTHON_USEDEP}]
+"
+
+PATCHES=(
+ "${FILESDIR}/${PN}-1.4.4-pypy3-tests.patch"
+)
+
+distutils_enable_tests pytest
+
+export SETUPTOOLS_SCM_PRETEND_VERSION=${PV}

--- a/dev-python/lxml/lxml-4.9.2-r1.ebuild
+++ b/dev-python/lxml/lxml-4.9.2-r1.ebuild
@@ -1,0 +1,112 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DISTUTILS_USE_PEP517=setuptools
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
+
+inherit distutils-r1 optfeature toolchain-funcs
+
+DESCRIPTION="A Pythonic binding for the libxml2 and libxslt libraries"
+HOMEPAGE="
+	https://lxml.de/
+	https://pypi.org/project/lxml/
+	https://github.com/lxml/lxml/
+"
+SRC_URI="
+	https://github.com/lxml/lxml/archive/${P}.tar.gz
+		-> ${P}.gh.tar.gz
+"
+S=${WORKDIR}/lxml-${P}
+
+LICENSE="BSD ElementTree GPL-2 PSF-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~x64-solaris ~x86-solaris"
+IUSE="doc examples +threads test"
+RESTRICT="!test? ( test )"
+
+# Note: lib{xml2,xslt} are used as C libraries, not Python modules.
+DEPEND="
+	>=dev-libs/libxml2-2.9.12-r2
+	>=dev-libs/libxslt-1.1.28
+"
+RDEPEND="
+	${DEPEND}
+"
+BDEPEND="
+	virtual/pkgconfig
+	>=dev-python/cython-0.29.29[${PYTHON_USEDEP}]
+	doc? (
+		$(python_gen_any_dep '
+			dev-python/docutils[${PYTHON_USEDEP}]
+			dev-python/pygments[${PYTHON_USEDEP}]
+			dev-python/sphinx[${PYTHON_USEDEP}]
+			dev-python/sphinx-rtd-theme[${PYTHON_USEDEP}]
+		')
+	)
+	test? (
+		dev-python/cssselect[${PYTHON_USEDEP}]
+	)
+"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-4.6.0-tests-pypy.patch
+)
+
+python_check_deps() {
+	use doc || return 0
+	python_has_version -b "dev-python/docutils[${PYTHON_USEDEP}]" &&
+	python_has_version -b "dev-python/pygments[${PYTHON_USEDEP}]" &&
+	python_has_version -b "dev-python/sphinx[${PYTHON_USEDEP}]" &&
+	python_has_version -b "dev-python/sphinx-rtd-theme[${PYTHON_USEDEP}]"
+}
+
+python_prepare_all() {
+	# avoid replacing PYTHONPATH in tests.
+	sed -i -e '/sys\.path/d' test.py || die
+
+	# don't use some random SDK on Darwin
+	sed -i -e '/_ldflags =/s/=.*isysroot.*darwin.*None/= None/' \
+		setupinfo.py || die
+
+	distutils-r1_python_prepare_all
+}
+
+python_compile() {
+	tc-export PKG_CONFIG
+	distutils-r1_python_compile
+}
+
+python_compile_all() {
+	use doc && emake html
+}
+
+python_test() {
+	local dir=${BUILD_DIR}/test$(python_get_sitedir)/lxml
+	local -x PATH=${BUILD_DIR}/test/usr/bin:${PATH}
+
+	cp -al "${BUILD_DIR}"/{install,test} || die
+	cp -al src/lxml/tests "${dir}/" || die
+	cp -al src/lxml/html/tests "${dir}/html/" || die
+	ln -rs "${S}"/doc "${dir}"/../../ || die
+
+	"${EPYTHON}" test.py -vv --all-levels -p || die "Test ${test} fails with ${EPYTHON}"
+}
+
+python_install_all() {
+	if use doc; then
+		local DOCS=( README.rst *.txt doc/*.txt )
+		local HTML_DOCS=( doc/html/. )
+	fi
+	if use examples; then
+		dodoc -r samples
+	fi
+
+	distutils-r1_python_install_all
+}
+
+pkg_postinst() {
+	optfeature "Support for BeautifulSoup as a parser backend" dev-python/beautifulsoup4
+	optfeature "Translates CSS selectors to XPath 1.0 expressions" dev-python/cssselect
+}

--- a/dev-python/matplotlib/matplotlib-3.7.0.ebuild
+++ b/dev-python/matplotlib/matplotlib-3.7.0.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 PYTHON_REQ_USE='tk?,threads(+)'
 
 inherit distutils-r1 flag-o-matic multiprocessing prefix pypi
@@ -76,10 +76,14 @@ RDEPEND="
 		dev-texlive/texlive-xetex
 	)
 	qt5? (
-		dev-python/PyQt5[gui,widgets,${PYTHON_USEDEP}]
+		$(python_gen_cond_dep '
+			dev-python/PyQt5[gui,widgets,${PYTHON_USEDEP}]
+		' python3_{8..11})
 	)
 	webagg? (
-		>=dev-python/tornado-6.0.4[${PYTHON_USEDEP}]
+		$(python_gen_cond_dep '
+			>=dev-python/tornado-6.0.4[${PYTHON_USEDEP}]
+		' python3_{8..11})
 	)
 	wxwidgets? (
 		$(python_gen_cond_dep '
@@ -114,7 +118,9 @@ BDEPEND="
 		dev-python/psutil[${PYTHON_USEDEP}]
 		dev-python/pytest-xdist[${PYTHON_USEDEP}]
 		>=dev-python/pygobject-3.40.1-r1:3[cairo?,${PYTHON_USEDEP}]
-		>=dev-python/tornado-6.0.4[${PYTHON_USEDEP}]
+		$(python_gen_cond_dep '
+			>=dev-python/tornado-6.0.4[${PYTHON_USEDEP}]
+		' python3_{8..11})
 		x11-libs/gtk+:3[introspection]
 	)
 "

--- a/dev-python/meson-python/meson-python-0.12.1.ebuild
+++ b/dev-python/meson-python/meson-python-0.12.1.ebuild
@@ -4,7 +4,10 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=standalone
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
+
+# GitPython doesn't support pypy3
+PYTHON_TESTED=( python3_{9..11} )
 
 inherit distutils-r1
 
@@ -36,7 +39,9 @@ RDEPEND="
 BDEPEND="
 	dev-python/cython[${PYTHON_USEDEP}]
 	test? (
-		dev-python/GitPython[${PYTHON_USEDEP}]
+		$(python_gen_cond_dep '
+			dev-python/GitPython[${PYTHON_USEDEP}]
+		' "${PYTHON_TESTED[@]}")
 		dev-python/pytest-mock[${PYTHON_USEDEP}]
 	)
 "

--- a/dev-python/mpmath/mpmath-1.2.1.ebuild
+++ b/dev-python/mpmath/mpmath-1.2.1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 
 inherit distutils-r1 virtualx
 

--- a/dev-python/numpy/numpy-1.24.2.ebuild
+++ b/dev-python/numpy/numpy-1.24.2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 PYTHON_REQ_USE="threads(+)"
 
 FORTRAN_NEEDED=lapack

--- a/dev-python/paramiko/paramiko-3.0.0.ebuild
+++ b/dev-python/paramiko/paramiko-3.0.0.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 PYTHON_REQ_USE="threads(+)"
 
 inherit distutils-r1

--- a/dev-python/pikepdf/pikepdf-7.1.1.ebuild
+++ b/dev-python/pikepdf/pikepdf-7.1.1.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 
 inherit distutils-r1
 

--- a/dev-python/pooch/pooch-1.6.0.ebuild
+++ b/dev-python/pooch/pooch-1.6.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 DISTUTILS_USE_PEP517=setuptools
 inherit distutils-r1
 

--- a/dev-python/pybind11/pybind11-2.10.3.ebuild
+++ b/dev-python/pybind11/pybind11-2.10.3.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 
 inherit cmake distutils-r1
 

--- a/dev-python/pydevd/pydevd-2.9.5.ebuild
+++ b/dev-python/pydevd/pydevd-2.9.5.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 inherit distutils-r1 toolchain-funcs
 
 MY_P="pydev_debugger_${PV//./_}"

--- a/dev-python/pyftpdlib/pyftpdlib-1.5.7.ebuild
+++ b/dev-python/pyftpdlib/pyftpdlib-1.5.7.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 PYTHON_REQ_USE="ssl(+)"
 
 inherit distutils-r1

--- a/dev-python/pygame/pygame-2.1.3.ebuild
+++ b/dev-python/pygame/pygame-2.1.3.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 
 inherit distutils-r1
 

--- a/dev-python/pyglet/pyglet-2.0.4.ebuild
+++ b/dev-python/pyglet/pyglet-2.0.4.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 
 inherit distutils-r1 virtualx xdg-utils
 

--- a/dev-python/pygobject/pygobject-3.42.2.ebuild
+++ b/dev-python/pygobject/pygobject-3.42.2.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=no
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 
 inherit gnome.org meson virtualx xdg distutils-r1
 
@@ -29,7 +29,7 @@ RDEPEND="
 DEPEND="
 	${RDEPEND}
 	test? (
-		dev-libs/atk[introspection]
+		>=app-accessibility/at-spi2-core-2.46.0[introspection]
 		dev-python/pytest[${PYTHON_USEDEP}]
 		x11-libs/gdk-pixbuf:2[introspection,jpeg]
 		x11-libs/gtk+:3[introspection]

--- a/dev-python/pynacl/pynacl-1.5.0-r2.ebuild
+++ b/dev-python/pynacl/pynacl-1.5.0-r2.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 
 inherit distutils-r1
 

--- a/dev-python/pyopengl/pyopengl-3.1.6-r2.ebuild
+++ b/dev-python/pyopengl/pyopengl-3.1.6-r2.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
 PYTHON_REQ_USE="tk?"
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 
 inherit distutils-r1 virtualx
 

--- a/dev-python/pytest-localftpserver/pytest-localftpserver-1.1.4.ebuild
+++ b/dev-python/pytest-localftpserver/pytest-localftpserver-1.1.4.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 inherit distutils-r1
 
 MY_PN="${PN/-/_}"

--- a/dev-python/python-xmp-toolkit/python-xmp-toolkit-2.0.1-r2.ebuild
+++ b/dev-python/python-xmp-toolkit/python-xmp-toolkit-2.0.1-r2.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 
 inherit distutils-r1
 

--- a/dev-python/pythran/pythran-0.12.1.ebuild
+++ b/dev-python/pythran/pythran-0.12.1.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
 PYTHON_TESTED=( python3_{9..11} )
-PYTHON_COMPAT=( "${PYTHON_TESTED[@]}" )
+PYTHON_COMPAT=( "${PYTHON_TESTED[@]}" pypy3 )
 
 inherit distutils-r1 multiprocessing
 
@@ -41,7 +41,6 @@ BDEPEND="
 		dev-python/scipy[${PYTHON_USEDEP}]
 		dev-python/wheel[${PYTHON_USEDEP}]
 		virtual/cblas
-		!!dev-python/setuptools-declarative-requirements
 	)
 "
 

--- a/dev-python/scipy/scipy-1.10.0.ebuild
+++ b/dev-python/scipy/scipy-1.10.0.ebuild
@@ -5,7 +5,8 @@ EAPI=8
 
 FORTRAN_NEEDED=fortran
 DISTUTILS_USE_PEP517=meson-python
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
+PYTHON_TESTED=( python3_{9..11} )
 PYTHON_REQ_USE="threads(+)"
 
 inherit fortran-2 distutils-r1 multiprocessing

--- a/dev-python/symengine/symengine-0.9.2-r2.ebuild
+++ b/dev-python/symengine/symengine-0.9.2-r2.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 
 inherit distutils-r1
 

--- a/dev-python/sympy/sympy-1.11.1-r2.ebuild
+++ b/dev-python/sympy/sympy-1.11.1-r2.ebuild
@@ -30,7 +30,7 @@ RDEPEND="
 		png? ( app-text/dvipng )
 		pdf? ( app-text/ghostscript-gpl )
 	)
-	mathml? ( dev-libs/libxml2:2[${PYTHON_USEDEP}] )
+	mathml? ( dev-python/lxml[${PYTHON_USEDEP}] )
 	opengl? ( dev-python/pyopengl[${PYTHON_USEDEP}] )
 	pyglet? ( dev-python/pyglet[${PYTHON_USEDEP}] )
 	symengine? ( dev-python/symengine[${PYTHON_USEDEP}] )

--- a/dev-python/sympy/sympy-1.11.1-r2.ebuild
+++ b/dev-python/sympy/sympy-1.11.1-r2.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 
 inherit distutils-r1 virtualx
 
@@ -21,9 +21,17 @@ IUSE="aesara examples imaging ipython latex mathml opengl pdf png pyglet symengi
 RDEPEND="
 	dev-python/mpmath[${PYTHON_USEDEP}]
 	dev-python/pexpect[${PYTHON_USEDEP}]
-	aesara? ( $(python_gen_cond_dep 'dev-python/aesara[${PYTHON_USEDEP}]' python3_{9..10}) )
+	aesara? (
+		$(python_gen_cond_dep '
+			dev-python/aesara[${PYTHON_USEDEP}]
+		' python3_{9..10})
+	)
 	imaging? ( dev-python/pillow[${PYTHON_USEDEP}] )
-	ipython? ( dev-python/ipython[${PYTHON_USEDEP}] )
+	ipython? (
+		$(python_gen_cond_dep '
+			dev-python/ipython[${PYTHON_USEDEP}]
+		' python3_{9..11})
+	)
 	latex? (
 		virtual/latex-base
 		dev-texlive/texlive-fontsextra

--- a/dev-python/untangle/untangle-1.2.1-r1.ebuild
+++ b/dev-python/untangle/untangle-1.2.1-r1.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=poetry
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 
 inherit distutils-r1
 

--- a/dev-python/xcffib/xcffib-1.2.0.ebuild
+++ b/dev-python/xcffib/xcffib-1.2.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 DISTUTILS_USE_PEP517=setuptools
 
 inherit distutils-r1

--- a/dev-python/xlwt/xlwt-1.3.0-r2.ebuild
+++ b/dev-python/xlwt/xlwt-1.3.0-r2.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 
 inherit distutils-r1
 

--- a/dev-util/meson/meson-1.0.0.ebuild
+++ b/dev-util/meson/meson-1.0.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 DISTUTILS_USE_PEP517=setuptools
 
 if [[ ${PV} = *9999* ]]; then


### PR DESCRIPTION
After #29636.

Scipy is also known to work under PyPy since v1.1.0.
It has a bunch of dependencies to bump.

This MR aims to have everything tested under pypy3, but maybe it won't be possible.

TODO: decide what to do with scipy tests which are failing due to too many open files - probably due to `del` behavior on PyPy