### PR TITLE
media-libs/lib3mf: fix bug #895180

### DIFF
--- a/media-libs/lib3mf/files/lib3mf-2.2.0-0001-remove-std-and-opt-flags.patch
+++ b/media-libs/lib3mf/files/lib3mf-2.2.0-0001-remove-std-and-opt-flags.patch
@@ -1,0 +1,30 @@
+From 057ae273bf223573b7cdb6ec978e051220ffe401 Mon Sep 17 00:00:00 2001
+From: Peter Levine <plevine457@gmail.com>
+Date: Sat, 18 Feb 2023 13:21:29 -0500
+Subject: [PATCH] [Gentoo specific] remove optimization flags and C++ standard
+ flags
+
+Remove the lines in CMakeLists.txt that emit -std=c++11 (as wall as
+emitting -O2) to enable the compiler default, which builds against
+the latest GTest with both clang-16.0.0_pre20230107 and
+gcc-12.2.1_p20230121-r1.
+
+Signed-off-by: Peter Levine <plevine457@gmail.com>
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -32,12 +32,10 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+   # using GCC
+   add_definitions(-DBUILD_DLL)
+   add_compile_options(-Wall)
+-  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -O2")
+ elseif ("${CMAKE_SYSTEM_NAME}" MATCHES "Darwin")
+   # using GCC
+   add_definitions(-DBUILD_DLL)
+   add_compile_options(-Wall) 
+-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -O2")
+   set(CMAKE_MACOSX_RPATH ON)
+ endif()
+ 
+-- 
+2.39.1
+

--- a/media-libs/lib3mf/lib3mf-2.2.0.ebuild
+++ b/media-libs/lib3mf/lib3mf-2.2.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -35,6 +35,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-2.1.0-0001-Gentoo-specific-avoid-pre-stripping-library.patch
 	"${FILESDIR}"/${P}-0001-use-system-provided-act-binary.patch
 	"${FILESDIR}"/${P}-0002-Gentoo-specific-remove-add_dependencies.patch
+	"${FILESDIR}"/${P}-0001-remove-std-and-opt-flags.patch
 )
 
 src_configure() {


### PR DESCRIPTION
Remove the lines in `CMakeLists.txt` that emit `-std=c++11` (as wall as emitting `-O2`) to enable the compiler default, which builds against the latest GTest with both `clang-16.0.0_pre20230107` and `gcc-12.2.1_p20230121-r1`.  I've opted for an `sed` in `src_prepare()` but let me know if you'd prefer a patch instead.

Closes: https://bugs.gentoo.org/895180
Closes: https://github.com/gentoo/gentoo/pull/29644