### PR TITLE
media-gfx/alembic: enable py3.11

### DIFF
--- a/media-gfx/alembic/alembic-1.8.4.ebuild
+++ b/media-gfx/alembic/alembic-1.8.4.ebuild
@@ -3,8 +3,7 @@
 
 EAPI=8
 
-# py311 needs imath-3.1.6+, see PR #28265
-PYTHON_COMPAT=( python3_{9..10} )
+PYTHON_COMPAT=( python3_{9..11} )
 
 inherit cmake python-single-r1
 


### PR DESCRIPTION
Enables Python 3.11 support. 
Closes: https://bugs.gentoo.org/896978
