### PR TITLE
app-arch/snappy: build using C++14 dialect

### DIFF
--- a/app-arch/snappy/snappy-1.1.9-r1.ebuild
+++ b/app-arch/snappy/snappy-1.1.9-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -28,6 +28,7 @@ PATCHES=(
 
 multilib_src_configure() {
 	local mycmakeargs=(
+		-DCMAKE_CXX_STANDARD=14 # Latest gtest needs -std=c++14 or newer
 		-DSNAPPY_BUILD_TESTS=$(usex test)
 		-DSNAPPY_BUILD_BENCHMARKS=OFF
 		# Options below are related to benchmarking, that we disable.


### PR DESCRIPTION
The latest gtest requires C++14 or later. Pass `-DCMAKE_CXX_STANDARD=14` explicitly to avoid having `-std=c++11` added to `CXXFLAGS`.

Closes: https://bugs.gentoo.org/895190
Closes: https://github.com/gentoo/gentoo/pull/29653
Signed-off-by: Peter Levine <plevine457@gmail.com>