### PR TITLE
sys-devel/gettext: fix macOS bootstrap build.

### DIFF
--- a/sys-devel/gettext/gettext-0.21.1.ebuild
+++ b/sys-devel/gettext/gettext-0.21.1.ebuild
@@ -90,6 +90,7 @@ src_prepare() {
 	elibtoolize
 
 	use elibc_musl && eapply "${FILESDIR}"/${PN}-0.21-musl-omit_setlocale_lock.patch
+	use elibc_Darwin && eapply "${FILESDIR}"/${PN}-0.21-musl-omit_setlocale_lock.patch
 }
 
 multilib_src_configure() {


### PR DESCRIPTION
When bootstrapping Gentoo Prefix on macOS 13.2 (Ventura) on an Apple M1 system, it will fail at stage3 (note that there are other bugs that prevent the bootstrapping from reach stage3, which must also be resolved) due to the following build failure in `sys-devel/gettext-0.21.1`:

```
Undefined symbols for architecture arm64:
  "_gl_get_setlocale_null_lock", referenced from:
      _libgettextpo_setlocale_null_r in libgnu.a(setlocale_null.o)
      _libgettextpo_setlocale_null in libgnu.a(setlocale_null.o)
ld: symbol(s) not found for architecture arm64
```

A quick search of the symbol `_gl_get_setlocale_null_lock` revealed that the bug is actually already known - GNU gettext bug 62659 [1]. It failed to find the symbol because GNU's libintl was not present during the bootstrap stage (though it would be installed later), and due to the hardcoded `OMIT_SETLOCALE_LOCK` value, GNU gettext still attempts to use `SETLOCALE_LOCK`.

Currently the Portage tree already contains a patch for musl. The simplest fix is just applying the same patch to Darwin as well.

This Pull Request fixes Gentoo bug #895330.

[1] https://savannah.gnu.org/bugs/?62659