### PR TITLE
Add macOS keywords for dev-python/jaraco-text-3.11.1, dev-python/platformdirs-3.0.0, dev-python/autocommand, dev-python/pydantic-1.10.5

### DIFF
--- a/dev-python/autocommand/autocommand-2.2.2.ebuild
+++ b/dev-python/autocommand/autocommand-2.2.2.ebuild
@@ -20,6 +20,6 @@ SRC_URI="
 
 LICENSE="LGPL-3+"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86"
+KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~arm64-macos ~x64-macos"
 
 distutils_enable_tests pytest

--- a/dev-python/jaraco-text/jaraco-text-3.11.1.ebuild
+++ b/dev-python/jaraco-text/jaraco-text-3.11.1.ebuild
@@ -19,7 +19,7 @@ S=${WORKDIR}/${P/-/.}
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~arm64-macos ~x64-macos"
 
 RDEPEND="
 	>=dev-python/jaraco-context-4.1.1-r1[${PYTHON_USEDEP}]

--- a/dev-python/platformdirs/platformdirs-3.0.0.ebuild
+++ b/dev-python/platformdirs/platformdirs-3.0.0.ebuild
@@ -20,7 +20,7 @@ SRC_URI="
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~arm64-macos ~x64-macos"
 
 BDEPEND="
 	test? (

--- a/dev-python/pydantic/pydantic-1.10.5.ebuild
+++ b/dev-python/pydantic/pydantic-1.10.5.ebuild
@@ -22,7 +22,7 @@ S=${WORKDIR}/${MY_P}
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~arm64-macos ~x64-macos"
 IUSE="+native-extensions"
 
 RDEPEND="


### PR DESCRIPTION
When bootstrapping Gentoo Prefix on macOS 13.2 (Ventura) on an Apple M1 system, it will fail at stage3 (note that there are other bugs that prevent the bootstrapping from reach stage3, which must also be resolved) due to missing keywords in `dev-python/jaraco-text`, which is now an indirect dependency of Portage via `dev-python/setuptools`.

```
Calculating dependencies... done!

!!! All ebuilds that could satisfy ">=dev-python/jaraco-text-3.7.0-r1[python_targets_pypy3(-)?,python_targets_python3_9(-)?,python_targets_python3_10(-)?,python_targets_python3_11(-)?]" have been masked.
!!! One of the following masked packages is required to complete your request:
- dev-python/jaraco-text-3.11.1::gentoo_prefix (masked by: missing keyword)
- dev-python/jaraco-text-3.11.0::gentoo_prefix (masked by: missing keyword)

(dependency required by "dev-python/setuptools-67.3.2::gentoo_prefix" [ebuild])
(dependency required by "sys-apps/portage-3.0.34.2::gentoo_prefix" [ebuild])
(dependency required by "app-admin/perl-cleaner-2.30-r1::gentoo_prefix[-pkgcore]" [ebuild])
(dependency required by "dev-lang/perl-5.36.0-r2::gentoo_prefix[-minimal]" [ebuild])
(dependency required by "sys-apps/coreutils-9.1-r2::gentoo_prefix[-test]" [ebuild])
(dependency required by "sys-apps/coreutils" [argument])
For more information, see the MASKED PACKAGES section in the emerge
man page or refer to the Gentoo Handbook.
```

Furthermore, after adding keywords to `dev-python/jaraco-text-3.11.1`, more `KEYWORDS` problems appear. The keywords must be added to the following packages as well:

```
dev-python/platformdirs-3.0.0
dev-python/autocommand-2.2.2
dev-python/pydantic-1.10.5
```

This Pull Request fixes Gentoo bug #895336.