### PR TITLE
dev-util/hip: Fix rocclr hsa.h include bug for 5.1.3

### DIFF
--- a/dev-util/hip/hip-5.1.3-r4.ebuild
+++ b/dev-util/hip/hip-5.1.3-r4.ebuild
@@ -128,6 +128,9 @@ src_prepare() {
 	sed -e "/HIP_CLANG_INCLUDE_SEARCH_PATHS/s,\${_IMPORT_PREFIX}.*/include,${CLANG_RESOURCE_DIR}/include," -i hip-lang-config.cmake.in || die
 	popd || die
 	sed -e "/HIP_CLANG_INCLUDE_SEARCH_PATHS/s,\${HIP_CLANG_ROOT}.*/include,${CLANG_RESOURCE_DIR}/include," -i hip-config.cmake.in || die
+
+	pushd ${CLR_S} || die
+	eapply "${FILESDIR}/rocclr-5.3.3-fix-include.patch"
 }
 
 src_configure() {


### PR DESCRIPTION
Same as f98177a3fe2ea8cf1818daec64268f9377176902, apply the patch to fix for rocclr include bug

Closes: https://bugs.gentoo.org/894040