### PR TITLE
Vulkan stuff EAPI-8 bumps and micro cleanups

### DIFF
--- a/dev-util/glslang/glslang-1.3.239.ebuild
+++ b/dev-util/glslang/glslang-1.3.239.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 PYTHON_COMPAT=( python3_{9..11} )
 inherit cmake-multilib python-any-r1
@@ -19,15 +19,15 @@ fi
 DESCRIPTION="Khronos reference front-end for GLSL and ESSL, and sample SPIR-V generator"
 HOMEPAGE="https://www.khronos.org/opengles/sdk/tools/Reference-Compiler/ https://github.com/KhronosGroup/glslang"
 
-PATCHES=( "${FILESDIR}/${PN}-1.3.236-Install-static-libs.patch" )
-
 LICENSE="BSD"
 SLOT="0/12"
 
-BDEPEND="${PYTHON_DEPS}"
-
 # Bug 698850
 RESTRICT="test"
+
+BDEPEND="${PYTHON_DEPS}"
+
+PATCHES=( "${FILESDIR}/${PN}-1.3.236-Install-static-libs.patch" )
 
 multilib_src_configure() {
 	local mycmakeargs=(

--- a/dev-util/glslang/glslang-9999.ebuild
+++ b/dev-util/glslang/glslang-9999.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 PYTHON_COMPAT=( python3_{9..11} )
 inherit cmake-multilib python-any-r1
@@ -19,15 +19,15 @@ fi
 DESCRIPTION="Khronos reference front-end for GLSL and ESSL, and sample SPIR-V generator"
 HOMEPAGE="https://www.khronos.org/opengles/sdk/tools/Reference-Compiler/ https://github.com/KhronosGroup/glslang"
 
-PATCHES=( "${FILESDIR}/${PN}-1.3.236-Install-static-libs.patch" )
-
 LICENSE="BSD"
 SLOT="0/12"
 
-BDEPEND="${PYTHON_DEPS}"
-
 # Bug 698850
 RESTRICT="test"
+
+BDEPEND="${PYTHON_DEPS}"
+
+PATCHES=( "${FILESDIR}/${PN}-1.3.236-Install-static-libs.patch" )
 
 multilib_src_configure() {
 	local mycmakeargs=(

--- a/dev-util/spirv-headers/spirv-headers-1.3.239.ebuild
+++ b/dev-util/spirv-headers/spirv-headers-1.3.239.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 inherit cmake
 
@@ -9,9 +9,8 @@ DESCRIPTION="Machine-readable files for the SPIR-V Registry"
 HOMEPAGE="https://www.khronos.org/registry/spir-v/"
 EGIT_COMMIT="sdk-${PV}"
 SRC_URI="https://github.com/KhronosGroup/SPIRV-Headers/archive/${EGIT_COMMIT}.tar.gz -> ${P}.tar.gz"
+S="${WORKDIR}/SPIRV-Headers-${EGIT_COMMIT}"
 
 LICENSE="MIT"
 SLOT="0"
 KEYWORDS="~amd64 ~arm ~arm64 ~loong ~ppc ~ppc64 ~riscv ~x86"
-
-S="${WORKDIR}/SPIRV-Headers-${EGIT_COMMIT}"

--- a/dev-util/spirv-headers/spirv-headers-99999999.ebuild
+++ b/dev-util/spirv-headers/spirv-headers-99999999.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 MY_PN=SPIRV-Headers
 inherit cmake
@@ -11,7 +11,7 @@ if [[ ${PV} == *9999* ]]; then
 	inherit git-r3
 else
 	SRC_URI="https://github.com/KhronosGroup/${MY_PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
-	KEYWORDS="~amd64 ~loong ~ppc64 ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~loong ~ppc ~ppc64 ~riscv ~x86"
 	S="${WORKDIR}"/${MY_PN}-${PV}
 fi
 

--- a/dev-util/spirv-tools/spirv-tools-1.3.239.ebuild
+++ b/dev-util/spirv-tools/spirv-tools-1.3.239.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 MY_PN=SPIRV-Tools
 PYTHON_COMPAT=( python3_{9..11} )
@@ -26,6 +26,7 @@ SLOT="0"
 # Tests fail upon finding symbols that do not match a regular expression
 # in the generated library. Easily hit with non-standard compiler flags
 RESTRICT="test"
+
 COMMON_DEPEND="~dev-util/spirv-headers-${PV}"
 DEPEND="${COMMON_DEPEND}"
 RDEPEND=""
@@ -34,10 +35,9 @@ BDEPEND="${PYTHON_DEPS}
 
 multilib_src_configure() {
 	local mycmakeargs=(
-		"-DSPIRV-Headers_SOURCE_DIR=${ESYSROOT}/usr/"
-		"-DSPIRV_WERROR=OFF"
-		"-DSPIRV_TOOLS_BUILD_STATIC=OFF"
-		"-DBUILD_SHARED_LIBS=ON"
+		-DSPIRV-Headers_SOURCE_DIR="${ESYSROOT}"/usr/
+		-DSPIRV_WERROR=OFF
+		-DSPIRV_TOOLS_BUILD_STATIC=OFF
 	)
 
 	cmake_src_configure

--- a/dev-util/spirv-tools/spirv-tools-1.3.239.ebuild
+++ b/dev-util/spirv-tools/spirv-tools-1.3.239.ebuild
@@ -27,11 +27,9 @@ SLOT="0"
 # in the generated library. Easily hit with non-standard compiler flags
 RESTRICT="test"
 
-COMMON_DEPEND="~dev-util/spirv-headers-${PV}"
-DEPEND="${COMMON_DEPEND}"
+DEPEND="~dev-util/spirv-headers-${PV}"
 RDEPEND=""
-BDEPEND="${PYTHON_DEPS}
-	${COMMON_DEPEND}"
+BDEPEND="${PYTHON_DEPS}"
 
 multilib_src_configure() {
 	local mycmakeargs=(

--- a/dev-util/spirv-tools/spirv-tools-99999999.ebuild
+++ b/dev-util/spirv-tools/spirv-tools-99999999.ebuild
@@ -27,11 +27,9 @@ SLOT="0"
 # in the generated library. Easily hit with non-standard compiler flags
 RESTRICT="test"
 
-COMMON_DEPEND="~dev-util/spirv-headers-1.3.239"
-DEPEND="${COMMON_DEPEND}"
+DEPEND="~dev-util/spirv-headers-1.3.239"
 RDEPEND=""
-BDEPEND="${PYTHON_DEPS}
-	${COMMON_DEPEND}"
+BDEPEND="${PYTHON_DEPS}"
 
 multilib_src_configure() {
 	local mycmakeargs=(

--- a/dev-util/spirv-tools/spirv-tools-99999999.ebuild
+++ b/dev-util/spirv-tools/spirv-tools-99999999.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 MY_PN=SPIRV-Tools
 PYTHON_COMPAT=( python3_{9..11} )
@@ -26,6 +26,7 @@ SLOT="0"
 # Tests fail upon finding symbols that do not match a regular expression
 # in the generated library. Easily hit with non-standard compiler flags
 RESTRICT="test"
+
 COMMON_DEPEND="~dev-util/spirv-headers-1.3.239"
 DEPEND="${COMMON_DEPEND}"
 RDEPEND=""
@@ -34,10 +35,9 @@ BDEPEND="${PYTHON_DEPS}
 
 multilib_src_configure() {
 	local mycmakeargs=(
-		"-DSPIRV-Headers_SOURCE_DIR=${ESYSROOT}/usr/"
-		"-DSPIRV_WERROR=OFF"
-		"-DSPIRV_TOOLS_BUILD_STATIC=OFF"
-		"-DBUILD_SHARED_LIBS=ON"
+		-DSPIRV-Headers_SOURCE_DIR="${ESYSROOT}"/usr/
+		-DSPIRV_WERROR=OFF
+		-DSPIRV_TOOLS_BUILD_STATIC=OFF
 	)
 
 	cmake_src_configure

--- a/dev-util/vulkan-headers/vulkan-headers-1.3.239.ebuild
+++ b/dev-util/vulkan-headers/vulkan-headers-1.3.239.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 MY_PN=Vulkan-Headers
 inherit cmake
@@ -20,5 +20,3 @@ HOMEPAGE="https://github.com/KhronosGroup/Vulkan-Headers"
 
 LICENSE="Apache-2.0"
 SLOT="0"
-
-BDEPEND=">=dev-util/cmake-3.10.2"

--- a/dev-util/vulkan-headers/vulkan-headers-9999.ebuild
+++ b/dev-util/vulkan-headers/vulkan-headers-9999.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 MY_PN=Vulkan-Headers
 inherit cmake
@@ -20,5 +20,3 @@ HOMEPAGE="https://github.com/KhronosGroup/Vulkan-Headers"
 
 LICENSE="Apache-2.0"
 SLOT="0"
-
-BDEPEND=">=dev-util/cmake-3.10.2"

--- a/dev-util/vulkan-tools/vulkan-tools-1.3.239.ebuild
+++ b/dev-util/vulkan-tools/vulkan-tools-1.3.239.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 MY_PN=Vulkan-Tools
 PYTHON_COMPAT=( python3_{9..11} )
@@ -28,7 +28,6 @@ IUSE="cube wayland +X"
 REQUIRED_USE="cube? ( ^^ ( X wayland ) )"
 
 BDEPEND="${PYTHON_DEPS}
-	>=dev-util/cmake-3.10.2
 	cube? ( ~dev-util/glslang-${PV}:=[${MULTILIB_USEDEP}] )
 "
 RDEPEND="
@@ -75,8 +74,4 @@ multilib_src_configure() {
 	)
 
 	cmake_src_configure
-}
-
-multilib_src_install() {
-	cmake_src_install
 }

--- a/dev-util/vulkan-tools/vulkan-tools-9999.ebuild
+++ b/dev-util/vulkan-tools/vulkan-tools-9999.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 MY_PN=Vulkan-Tools
 PYTHON_COMPAT=( python3_{9..11} )
@@ -28,7 +28,6 @@ IUSE="cube wayland +X"
 REQUIRED_USE="cube? ( ^^ ( X wayland ) )"
 
 BDEPEND="${PYTHON_DEPS}
-	>=dev-util/cmake-3.10.2
 	cube? ( ~dev-util/glslang-${PV}:=[${MULTILIB_USEDEP}] )
 "
 RDEPEND="
@@ -75,8 +74,4 @@ multilib_src_configure() {
 	)
 
 	cmake_src_configure
-}
-
-multilib_src_install() {
-	cmake_src_install
 }

--- a/media-libs/vulkan-layers/vulkan-layers-1.3.239.ebuild
+++ b/media-libs/vulkan-layers/vulkan-layers-1.3.239.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 MY_PN=Vulkan-ValidationLayers
 PYTHON_COMPAT=( python3_{9..11} )
@@ -24,7 +24,6 @@ LICENSE="Apache-2.0"
 SLOT="0"
 IUSE="wayland X"
 
-BDEPEND=">=dev-util/cmake-3.10.2"
 RDEPEND="~dev-util/spirv-tools-${PV}:=[${MULTILIB_USEDEP}]"
 DEPEND="${RDEPEND}
 	${PYTHON_DEPS}

--- a/media-libs/vulkan-layers/vulkan-layers-9999.ebuild
+++ b/media-libs/vulkan-layers/vulkan-layers-9999.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 MY_PN=Vulkan-ValidationLayers
 PYTHON_COMPAT=( python3_{9..11} )
@@ -24,7 +24,6 @@ LICENSE="Apache-2.0"
 SLOT="0"
 IUSE="wayland X"
 
-BDEPEND=">=dev-util/cmake-3.10.2"
 RDEPEND="~dev-util/spirv-tools-99999999:=[${MULTILIB_USEDEP}]"
 DEPEND="${RDEPEND}
 	${PYTHON_DEPS}

--- a/media-libs/vulkan-loader/vulkan-loader-1.3.239.ebuild
+++ b/media-libs/vulkan-loader/vulkan-loader-1.3.239.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 MY_PN=Vulkan-Loader
 inherit flag-o-matic cmake-multilib toolchain-funcs
@@ -23,7 +23,6 @@ LICENSE="Apache-2.0"
 SLOT="0"
 IUSE="layers wayland X"
 
-BDEPEND=">=dev-util/cmake-3.10.2"
 DEPEND="
 	~dev-util/vulkan-headers-${PV}
 	wayland? ( dev-libs/wayland:=[${MULTILIB_USEDEP}] )
@@ -58,9 +57,4 @@ multilib_src_install() {
 	keepdir /etc/vulkan/icd.d
 
 	cmake_src_install
-}
-
-pkg_postinst() {
-	einfo "USE=demos has been dropped as per upstream packaging"
-	einfo "vulkaninfo is now available in the dev-util/vulkan-tools package"
 }

--- a/media-libs/vulkan-loader/vulkan-loader-9999.ebuild
+++ b/media-libs/vulkan-loader/vulkan-loader-9999.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 MY_PN=Vulkan-Loader
 inherit flag-o-matic cmake-multilib toolchain-funcs
@@ -23,7 +23,6 @@ LICENSE="Apache-2.0"
 SLOT="0"
 IUSE="layers wayland X"
 
-BDEPEND=">=dev-util/cmake-3.10.2"
 DEPEND="
 	~dev-util/vulkan-headers-${PV}
 	wayland? ( dev-libs/wayland:=[${MULTILIB_USEDEP}] )
@@ -59,9 +58,4 @@ multilib_src_install() {
 	keepdir /etc/vulkan/icd.d
 
 	cmake_src_install
-}
-
-pkg_postinst() {
-	einfo "USE=demos has been dropped as per upstream packaging"
-	einfo "vulkaninfo is now available in the dev-util/vulkan-tools package"
 }


### PR DESCRIPTION
*9999* ebuilds first, current ~arch commits in second wave.

There's one thing I don't understand in dev-util/spirv-tools:

```
COMMON_DEPEND="~dev-util/spirv-headers-1.3.239"
DEPEND="${COMMON_DEPEND}"
RDEPEND=""
BDEPEND="${PYTHON_DEPS}
	${COMMON_DEPEND}"
```

If this is really a thing, that the build system requires headers in BDEPEND in addition to DEPEND, maybe the reasoning should be put into a comment for others to understand.