### PR TITLE
sci-libs/vtk: build against CUDA 12

### DIFF
--- a/sci-libs/vtk/files/vtk-9.2.5-Fix-compilation-error-with-CUDA-12.patch
+++ b/sci-libs/vtk/files/vtk-9.2.5-Fix-compilation-error-with-CUDA-12.patch
@@ -1,0 +1,21 @@
+https://894646.bugs.gentoo.org/attachment.cgi?id=851914
+https://gitlab.kitware.com/vtk/vtk-m/-/merge_requests/2972/diffs
+
+From be96ea7d85fefcad876729377c1b73a295d1c732 Mon Sep 17 00:00:00 2001
+From: "Luke A. Guest" <laguest@archeia.com>
+Date: Thu, 16 Feb 2023 16:57:32 +0000
+Subject: [PATCH] Fix compilation error with CUDA 12.
+
+--- a/ThirdParty/vtkm/vtkvtkm/vtk-m/vtkm/exec/cuda/internal/ExecutionPolicy.h
++++ b/ThirdParty/vtkm/vtkvtkm/vtk-m/vtkm/exec/cuda/internal/ExecutionPolicy.h
+@@ -17,6 +17,7 @@
+ #include <vtkm/exec/cuda/internal/ThrustPatches.h>
+ VTKM_THIRDPARTY_PRE_INCLUDE
+ #include <thrust/execution_policy.h>
++#include <thrust/sort.h>
+ #include <thrust/system/cuda/execution_policy.h>
+ #include <thrust/system/cuda/memory.h>
+ VTKM_THIRDPARTY_POST_INCLUDE
+-- 
+2.39.1
+

--- a/sci-libs/vtk/vtk-9.2.5.ebuild
+++ b/sci-libs/vtk/vtk-9.2.5.ebuild
@@ -163,6 +163,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-9.2.2-link-with-glut-library-for-freeglut.patch
 	"${FILESDIR}"/${PN}-9.2.5-Add-include-cstdint-to-compile-with-gcc-13.patch
 	"${FILESDIR}"/${PN}-9.2.5-Add-include-cstdint-for-gcc-13.patch
+	"${FILESDIR}"/${PN}-9.2.5-Fix-compilation-error-with-CUDA-12.patch
 )
 
 DOCS=( CONTRIBUTING.md README.md )


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/894646

Patch is taken from the bug report. The patch partially implements a changeset from https://gitlab.kitware.com/vtk/vtk-m/-/merge_requests/2972/diffs. The second change in this PR seems only be relevant for consumers of vtk-m and CUDA which use the swap mechanism and can get a conflict.