### PR TITLE
app-editors/{vscode,vscodium}: Mark ssh-askpass script as executable

### DIFF
--- a/app-editors/vscode/vscode-1.75.0-r2.ebuild
+++ b/app-editors/vscode/vscode-1.75.0-r2.ebuild
@@ -107,7 +107,7 @@ src_install() {
 	fperms +x /opt/${PN}/{,bin/}code
 	fperms +x /opt/${PN}/chrome_crashpad_handler
 	fperms 4711 /opt/${PN}/chrome-sandbox
-	fperms 755 /opt/${PN}/resources/app/extensions/git/dist/{askpass,git-editor}{,-empty}.sh
+	fperms 755 /opt/${PN}/resources/app/extensions/git/dist/{askpass,git-editor,ssh-askpass}{,-empty}.sh
 	fperms -R +x /opt/${PN}/resources/app/out/vs/base/node
 	fperms +x /opt/${PN}/resources/app/node_modules.asar.unpacked/@vscode/ripgrep/bin/rg
 	fperms +x /opt/${PN}/resources/app/node_modules.asar.unpacked/node-pty/build/Release/spawn-helper

--- a/app-editors/vscode/vscode-1.75.1-r1.ebuild
+++ b/app-editors/vscode/vscode-1.75.1-r1.ebuild
@@ -107,7 +107,7 @@ src_install() {
 	fperms +x /opt/${PN}/{,bin/}code
 	fperms +x /opt/${PN}/chrome_crashpad_handler
 	fperms 4711 /opt/${PN}/chrome-sandbox
-	fperms 755 /opt/${PN}/resources/app/extensions/git/dist/{askpass,git-editor}{,-empty}.sh
+	fperms 755 /opt/${PN}/resources/app/extensions/git/dist/{askpass,git-editor,ssh-askpass}{,-empty}.sh
 	fperms -R +x /opt/${PN}/resources/app/out/vs/base/node
 	fperms +x /opt/${PN}/resources/app/node_modules.asar.unpacked/@vscode/ripgrep/bin/rg
 	fperms +x /opt/${PN}/resources/app/node_modules.asar.unpacked/node-pty/build/Release/spawn-helper

--- a/app-editors/vscodium/vscodium-1.75.0.23033-r2.ebuild
+++ b/app-editors/vscodium/vscodium-1.75.0.23033-r2.ebuild
@@ -98,7 +98,7 @@ src_install() {
 	fperms +x /opt/${PN}/{,bin/}codium
 	fperms +x /opt/${PN}/chrome_crashpad_handler
 	fperms 4711 /opt/${PN}/chrome-sandbox
-	fperms 755 /opt/${PN}/resources/app/extensions/git/dist/{askpass,git-editor}{,-empty}.sh
+	fperms 755 /opt/${PN}/resources/app/extensions/git/dist/{askpass,git-editor,ssh-askpass}{,-empty}.sh
 	fperms -R +x /opt/${PN}/resources/app/out/vs/base/node
 	fperms +x /opt/${PN}/resources/app/node_modules.asar.unpacked/@vscode/ripgrep/bin/rg
 	fperms +x /opt/${PN}/resources/app/node_modules.asar.unpacked/node-pty/build/Release/spawn-helper

--- a/app-editors/vscodium/vscodium-1.75.1.23040-r1.ebuild
+++ b/app-editors/vscodium/vscodium-1.75.1.23040-r1.ebuild
@@ -98,7 +98,7 @@ src_install() {
 	fperms +x /opt/${PN}/{,bin/}codium
 	fperms +x /opt/${PN}/chrome_crashpad_handler
 	fperms 4711 /opt/${PN}/chrome-sandbox
-	fperms 755 /opt/${PN}/resources/app/extensions/git/dist/{askpass,git-editor}{,-empty}.sh
+	fperms 755 /opt/${PN}/resources/app/extensions/git/dist/{askpass,git-editor,ssh-askpass}{,-empty}.sh
 	fperms -R +x /opt/${PN}/resources/app/out/vs/base/node
 	fperms +x /opt/${PN}/resources/app/node_modules.asar.unpacked/@vscode/ripgrep/bin/rg
 	fperms +x /opt/${PN}/resources/app/node_modules.asar.unpacked/node-pty/build/Release/spawn-helper


### PR DESCRIPTION
When using an SSH key that has a passcord, VS Code calls this script to authenticate. Without it being marked as executable Git SSH operations fail.