### PR TITLE
dev-games/aseprite: fix wrong file ends for patch

### DIFF
--- a/dev-games/aseprite/aseprite-1.2.40.ebuild
+++ b/dev-games/aseprite/aseprite-1.2.40.ebuild
@@ -77,6 +77,9 @@ PATCHES=(
 )
 
 src_prepare() {
+	# Remove extra \r on ends, #895504
+	sed -i -e 's/\r$//' \
+		third_party/IXWebSocket/ixwebsocket/IXWebSocketSendData.h || die
 	cmake_src_prepare
 	# Skia: remove custom optimizations
 	sed -i -e 's:"\/\/gn\/skia\:optimize",::g' \


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/895504