### PR TITLE
Fix two crashes on macOS due to undefined behavior.

### DIFF
--- a/dev-util/b2/b2-4.9.3-r1.ebuild
+++ b/dev-util/b2/b2-4.9.3-r1.ebuild
@@ -1,0 +1,67 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit edo flag-o-matic toolchain-funcs
+
+MY_PV="$(ver_rs 1- _)"
+
+DESCRIPTION="A system for large project software construction, simple to use and powerful"
+HOMEPAGE="https://www.bfgroup.xyz/b2/"
+SRC_URI="https://github.com/bfgroup/b2/archive/refs/tags/${PV}.tar.gz -> ${P}.tar.gz"
+S="${WORKDIR}/${P}/src"
+
+LICENSE="Boost-1.0"
+SLOT="0"
+KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+IUSE="examples"
+RESTRICT="test"
+
+RDEPEND="!dev-util/boost-build"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-4.9.2-disable_python_rpath.patch
+	"${FILESDIR}"/${PN}-4.9.2-darwin-gentoo-toolchain.patch
+	"${FILESDIR}"/${PN}-4.9.2-add-none-feature-options.patch
+	"${FILESDIR}"/${PN}-4.9.2-no-implicit-march-flags.patch
+	"${FILESDIR}"/${PN}-4.9.2-odr.patch
+	"${FILESDIR}"/${PN}-4.9.3-fix-apple-m1-crash-by-explicit-pointer-cast.patch
+)
+
+src_configure() {
+	# need to enable LFS explicitly for 64-bit offsets on 32-bit hosts (#761100)
+	append-lfs-flags
+}
+
+src_compile() {
+	cd engine || die
+
+	# upstream doesn't want separate flags for CPPFLAGS/LDFLAGS
+	# https://github.com/bfgroup/b2/pull/187#issuecomment-1335688424
+	edo ${CONFIG_SHELL:-${BASH}} ./build.sh cxx --cxx="$(tc-getCXX)" --cxxflags="${CXXFLAGS} ${CPPFLAGS} ${LDFLAGS}" -d+2 --without-python
+}
+
+src_test() {
+	# Forget tests, b2 is a lost cause
+	:
+}
+
+src_install() {
+	dobin engine/b2
+
+	insinto /usr/share/b2/src
+	doins -r "${FILESDIR}/site-config.jam" \
+		bootstrap.jam build-system.jam ../example/user-config.jam \
+		build kernel options tools util
+
+	find "${ED}"/usr/share/b2/src -iname '*.py' -delete || die
+
+	dodoc ../notes/{changes,release_procedure,build_dir_option,relative_source_paths}.txt
+
+	if use examples; then
+		docinto examples
+		dodoc -r ../example/.
+		docompress -x /usr/share/doc/${PF}/examples
+	fi
+}

--- a/dev-util/b2/files/b2-4.9.3-fix-apple-m1-crash-by-explicit-pointer-cast.patch
+++ b/dev-util/b2/files/b2-4.9.3-fix-apple-m1-crash-by-explicit-pointer-cast.patch
@@ -1,0 +1,55 @@
+https://github.com/bfgroup/b2/issues/152
+https://github.com/bfgroup/b2/pull/214
+https://bugs.gentoo.org/895524
+
+From 62dc6ff74a0b9717b4a8dd61ce06770e6fb7c177 Mon Sep 17 00:00:00 2001
+From: Yifeng Li <tomli@tomli.me>
+Date: Mon, 20 Feb 2023 09:52:32 +0000
+Subject: [PATCH] Fix #152 crash on Apple M1 by casting 0 to (OBJECT *)
+ explicitly.
+
+Currently, when the NULL-terminated variadic function call_rule()
+is invoked, the value "0" is passed as the last argument to act
+as a terminator. However, this is an integer value, which is
+incompatible with the pointer data type expected by call_rule().
+
+This is undefined behavior in C, correct operation is not
+guaranteed. In fact, it causes b2 to crash on Apple M1 when GCC
+is used - the loop is not terminated when it should, instead, it
+keeps running, creating the following error:
+
+> lol_add failed due to reached limit of 19 elements
+
+In some cases, it can even corrupt the internal state of the program,
+creating an infinite loop.
+
+This commit fixes the problem by explicitly casting the value 0 to
+the correct pointer type (OBJECT *).
+
+Signed-off-by: Yifeng Li <tomli@tomli.me>
+---
+ src/engine/modules/property-set.cpp | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/engine/modules/property-set.cpp b/src/engine/modules/property-set.cpp
+index 6e190a7639..b0d3c2dab8 100644
+--- src/engine/modules/property-set.cpp
++++ src/engine/modules/property-set.cpp
+@@ -162,7 +162,7 @@ LIST * property_set_create( FRAME * frame, int flags )
+         OBJECT * rulename = object_new( "new" );
+         OBJECT * varname = object_new( "self.raw" );
+         LIST * val = call_rule( rulename, frame,
+-            list_new( object_new( "property-set" ) ), 0 );
++            list_new( object_new( "property-set" ) ), (OBJECT *) 0 );
+         LISTITER iter, end;
+         object_free( rulename );
+         pos->value = object_copy( list_front( val ) );
+@@ -183,7 +183,7 @@ LIST * property_set_create( FRAME * frame, int flags )
+                 import_module( imports, frame->module );
+                 rulename = object_new( "errors.error" );
+                 call_rule( rulename, frame,
+-                    list_new( object_new( message->value ) ), 0 );
++                    list_new( object_new( message->value ) ), (OBJECT *) 0 );
+                 /* unreachable */
+                 string_free( message );
+                 list_free( imports );

--- a/sys-devel/flex/files/flex-2.6.4-fix-apple-m1-crash-by-explicit-pointer-cast.patch
+++ b/sys-devel/flex/files/flex-2.6.4-fix-apple-m1-crash-by-explicit-pointer-cast.patch
@@ -1,0 +1,48 @@
+https://github.com/westes/flex/issues/539
+https://github.com/westes/flex/pull/554
+https://bugs.gentoo.org/871324
+
+This is a backported version for applying to v2.6.4
+instead of git.
+
+From cce2df853386d5b5b60445b1204dcca08e9f259e Mon Sep 17 00:00:00 2001
+From: Yifeng Li <tomli@tomli.me>
+Date: Mon, 20 Feb 2023 11:23:52 +0000
+Subject: [PATCH] Fix #539 crash on Apple M1 by casting 0 to (char *)
+ explicitly
+
+Currently, when the NULL-terminated variadic function
+filter_create_ext() is invoked, the value "0" is passed as
+the last argument to act as a terminator. However, this is
+an integer value, which is incompatible with the pointer
+data type expected by filter_create_ext().
+
+This is undefined behavior in C, correct operation is not
+guaranteed. In fact, it causes flex to crash on Apple M1
+when GCC is used - the loop is not terminated when it should,
+instead, it keeps running, corrupting the argument list for
+invoking m4. As a result, it creates the following error:
+
+> flex: fatal internal error, exec of gm4 failed
+
+This commit fixes the problem by explicitly casting the value 0 to
+the correct pointer type (char *).
+
+Signed-off-by: Yifeng Li <tomli@tomli.me>
+---
+ src/main.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/main.c b/src/main.c
+index e5eac44fe..5c9086183 100644
+--- a/src/main.c
++++ b/src/main.c
+@@ -380,7 +380,7 @@ void check_options (void)
+ 			}
+ 		}
+ 	}
+-    filter_create_ext(output_chain, m4, "-P", 0);
++    filter_create_ext(output_chain, m4, "-P", (char *) 0);
+     filter_create_int(output_chain, filter_fix_linedirs, NULL);
+ 
+     /* For debugging, only run the requested number of filters. */

--- a/sys-devel/flex/flex-2.6.4-r6.ebuild
+++ b/sys-devel/flex/flex-2.6.4-r6.ebuild
@@ -1,0 +1,101 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit flag-o-matic libtool multilib-minimal toolchain-funcs
+
+DESCRIPTION="The Fast Lexical Analyzer"
+HOMEPAGE="https://github.com/westes/flex"
+SRC_URI="https://github.com/westes/${PN}/releases/download/v${PV}/${P}.tar.gz"
+SRC_URI+=" https://dev.gentoo.org/~sam/distfiles/${CATEGORY}/${PN}/${P}-autotools-regenerate.patch.xz"
+
+LICENSE="FLEX"
+SLOT="0"
+KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+IUSE="nls static test"
+RESTRICT="!test? ( test )"
+
+RDEPEND="sys-devel/m4"
+# We want bison explicitly and not yacc in general, bug #381273
+BDEPEND="
+	${RDEPEND}
+	nls? ( sys-devel/gettext )
+	test? ( sys-devel/bison )
+"
+PDEPEND="app-alternatives/lex"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-libobjdir.patch
+	"${FILESDIR}"/${P}-fix-build-with-glibc2.26.patch
+	"${FILESDIR}"/${P}-fix-apple-m1-crash-by-explicit-pointer-cast.patch
+
+	"${WORKDIR}"/${P}-autotools-regenerate.patch
+)
+
+src_prepare() {
+	default
+
+	# Drop on next release when we can remove ${P}-autotools-regenerate.patch
+	touch configure.ac aclocal.m4 Makefile.in configure src/config.h.in || die
+
+	# Disable running in the tests/ subdir as it has a bunch of built sources
+	# that cannot be made conditional (automake limitation). bug #568842
+	if ! use test ; then
+		sed -i \
+			-e '/^SUBDIRS =/,/^$/{/tests/d}' \
+			Makefile.in || die
+	fi
+
+	# Prefix always needs this
+	elibtoolize
+}
+
+src_configure() {
+	use static && append-ldflags -static
+
+	multilib-minimal_src_configure
+}
+
+multilib_src_configure() {
+	# Do not install shared libs, #503522
+	ECONF_SOURCE="${S}" econf \
+		CC_FOR_BUILD="$(tc-getBUILD_CC)" \
+		--disable-shared \
+		$(use_enable nls)
+}
+
+multilib_src_compile() {
+	if multilib_is_native_abi; then
+		default
+	else
+		emake -C src -f Makefile -f - lib <<< 'lib: $(lib_LTLIBRARIES)'
+	fi
+}
+
+multilib_src_test() {
+	multilib_is_native_abi && emake check
+}
+
+multilib_src_install() {
+	if multilib_is_native_abi; then
+		default
+	else
+		emake -C src DESTDIR="${D}" install-libLTLIBRARIES install-includeHEADERS
+	fi
+}
+
+multilib_src_install_all() {
+	einstalldocs
+	dodoc ONEWS
+	find "${ED}" -name '*.la' -type f -delete || die
+	rm "${ED}"/usr/share/doc/${PF}/COPYING || die
+}
+
+pkg_postinst() {
+	# ensure to preserve the symlink before app-alternatives/lex
+	# is installed
+	if [[ ! -h ${EROOT}/usr/bin/lex ]]; then
+		ln -s flex "${EROOT}/usr/bin/lex" || die
+	fi
+}


### PR DESCRIPTION
This Pull Request fixes crashes in two packages due to undefined behavior.

### 1. sys-devel/flex: fix crash on Apple M1 due to undefined behavior.

Currently, when the `NULL`-terminated variadic function `filter_create_ext()` is invoked, the value "0" is passed as the last argument to act as a terminator. However, this is an integer value, which is incompatible with the pointer data type expected by `filter_create_ext()`.

This is undefined behavior in C, correct operation is not guaranteed. In fact, it causes flex to crash on Apple M1 when GCC is used - the loop is not terminated when it should, instead, it keeps running, corrupting the argument list for invoking m4. As a result, it creates the following error:

> flex: fatal internal error, exec of gm4 failed
    
This commit fixes the problem by explicitly casting the value `0` to the correct pointer type `(char *)`.
    
Since the existence of the bug doesn't always prevent a Gentoo Prefix bootstrapping, it can lurk inside the system and remain undetected, furthermore, it's technically a C programming bug, other platforms could've been affected as well in theory. Thus, we also bump the package version.

This fix closes Gentoo Bug 871324. The patch has also been submitted to the upstream as https://github.com/westes/flex/pull/554

### 2. dev-util/b2: fix crash on Apple M1 due to undefined behavior.

Currently, the build system `dev-util/b2-4.9.3`, notably used by Boost, crashes on Apple M1 w/ macOS with a Segmentation Fault. This prevents one from using the tool, and also making building Boost impossible. It's also notable since it contains the keyword `~x64-macos`, so it should receive first-class macOS support.
    
It has been determined that when the `NULL`-terminated variadic function `call_rule()` is invoked, the value 0 is passed as the last argument to act as a terminator. However, this is an integer value, which is incompatible with the pointer data type expected by `call_rule()`.
    
This is undefined behavior in C, correct operation is not guaranteed. In fact, it causes b2 to crash on Apple M1 when GCC is used - the loop is not terminated when it should, instead, it keeps running, creating the following error:
    
> lol_add failed due to reached limit of 19 elements
    
In some cases, it can even corrupt the internal state of the program, creating an infinite loop.
    
This commit fixes the problem by explicitly casting the value `0` to the correct pointer type `(OBJECT *)`.
    
Since the existence of the bug doesn't prevent one from installing the package, it can lurk inside the system and remain undetected, furthermore, it's technically a C programming bug, other platforms could've been affected as well in theory. Thus, we also bump the package version.

This commit closes Gentoo Bug 895524. The patch has also been submitted to the upstream as https://github.com/bfgroup/b2/pull/214.