### PR TITLE
net-vpn/openvpn: fix crushing multiple instances

### DIFF
--- a/net-vpn/openvpn/files/openvpn-2.1.init
+++ b/net-vpn/openvpn/files/openvpn-2.1.init
@@ -1,5 +1,5 @@
 #!/sbin/openrc-run
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 VPNDIR=${VPNDIR:-/etc/openvpn}
@@ -126,7 +126,8 @@ stop() {
 
 	ebegin "Stopping ${SVCNAME}"
 	start-stop-daemon --stop --quiet \
-		--exec /usr/sbin/openvpn --pidfile "${VPNPID}"
+		--exec /usr/sbin/openvpn --pidfile "${VPNPID}" \
+		-- --config "${VPNCONF}"
 	eend $?
 }
 


### PR DESCRIPTION
In environment with multiple openvpn's instances if one of them get crushed, trying to restart it will result to stoping ALL of other openvpn instances. Introduced `--config "${VPNCONF}"` option to prevent it as suggested by Zhixu Liu.

Closes: https://bugs.gentoo.org/829949
Suggested-by: Zhixu Liu <zhixu.liu@gmail.com>