### PR TITLE
dev-python/pathlib2: add missing runtime dependency

### DIFF
--- a/dev-python/pathlib2/pathlib2-2.3.7_p1-r1.ebuild
+++ b/dev-python/pathlib2/pathlib2-2.3.7_p1-r1.ebuild
@@ -25,4 +25,8 @@ LICENSE="MIT"
 SLOT="0"
 KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86"
 
+RDEPEND="
+	dev-python/six[${PYTHON_USEDEP}]
+"
+
 distutils_enable_tests pytest


### PR DESCRIPTION
Tests in `dev-python/pathlib2` and `dev-python/jaraco-text` fail without it. See
https://github.com/jazzband/pathlib2/blob/e9b1985b141a527061137d28a9f3c7f54e849343/pathlib2/__init__.py#L17