### PR TITLE
distutils-r1.eclass: --build-option + pkg_resources namespace stripping

### DIFF
--- a/eclass/distutils-r1.eclass
+++ b/eclass/distutils-r1.eclass
@@ -1331,7 +1331,7 @@ distutils_pep517_install() {
 					"${EPYTHON}" - "${DISTUTILS_ARGS[@]}" <<-EOF || die
 						import json
 						import sys
-						print(json.dumps({"--global-option": sys.argv[1:]}))
+						print(json.dumps({"--build-option": sys.argv[1:]}))
 					EOF
 				)
 			fi


### PR DESCRIPTION
The rough idea is to deal with stuff deprecated by modern setuptools, that is:

1. Passing arbitrary args via `--global-option`: replaced by `--build-option` that has the same semantics right now (and FWIU the semantics of `--global-option` are going to change).
2. `pkg_resources` namespace packages.

We have been addressing 2. via policy before but we've only stripped `.pth` files that caused them to be loaded dynamically. We were still installing `namespace_packages.txt` that right now causes `pkg_resources` to emit deprecation warnings.

To make things easier, we now just strip both of these files automatically.

This doesn't eradicate namespaces entirely — they are still packages such as pydevd, fs, sphinx-tabs that install explicit `__init__.py` files with namespaces. I was thinking of adding an `eqawarn` for them; however — in general they are a mess by themselves, and I don't think we should be bothering Gentoo devs to figure out how to deal with them.