### PR TITLE
dev-python/pocketlint: enable py3.11

### DIFF
--- a/dev-python/pocketlint/pocketlint-0.24.ebuild
+++ b/dev-python/pocketlint/pocketlint-0.24.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..10} )
+PYTHON_COMPAT=( python3_{9..11} )
 
 inherit distutils-r1
 
@@ -26,3 +26,7 @@ RDEPEND="
 	dev-python/packaging[${PYTHON_USEDEP}]
 	dev-python/pylint[${PYTHON_USEDEP}]
 "
+
+python_test() {
+	"${EPYTHON}" tests/pylint/runpylint.py || die "test failed with ${EPYTHON}"
+}


### PR DESCRIPTION
- enable python3.11 support
- enable tests, the same way how upstream runs the CI