### PR TITLE
sys-libs/ncurses: Fix cygwin build

### DIFF
--- a/sys-libs/ncurses/ncurses-6.3_p20221203-r2.ebuild
+++ b/sys-libs/ncurses/ncurses-6.3_p20221203-r2.ebuild
@@ -1,10 +1,10 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
 VERIFY_SIG_OPENPGP_KEY_PATH="${BROOT}"/usr/share/openpgp-keys/thomasdickey.asc
-inherit flag-o-matic toolchain-funcs multilib-minimal preserve-libs usr-ldscript verify-sig
+inherit flag-o-matic toolchain-funcs multilib multilib-minimal preserve-libs usr-ldscript verify-sig
 
 MY_PV="${PV:0:3}"
 MY_P="${PN}-${MY_PV}"
@@ -198,6 +198,11 @@ src_configure() {
 	# bug #214642
 	BUILD_CPPFLAGS+=" -D_GNU_SOURCE"
 
+	# bug #852665
+	if [[ ${CHOST} == *-cygwin* ]]; then
+	  BUILD_CPPFLAGS+=" -DBUILDING_NCURSES"
+	fi
+
 	# Build the various variants of ncurses -- narrow, wide, and threaded. #510440
 	# Order matters here -- we want unicode/thread versions to come last so that the
 	# binaries in /usr/bin support both wide and narrow.
@@ -348,17 +353,7 @@ do_configure() {
 src_compile() {
 	# See comments in src_configure.
 	if ! has_version -b "~sys-libs/${P}:0" ; then
-		# We could possibly merge these two branches but opting to be
-		# conservative when merging some of the Prefix changes.
-
-		if [[ ${CHOST} == *-cygwin* ]] && ! multilib_is_native_abi ; then
-			# We make 'tic$(x)' here, for Cygwin having x=".exe".
-			BUILD_DIR="${WORKDIR}" \
-				 do_compile cross -C progs all PROGS='tic$(x)'
-		else
-			BUILD_DIR="${WORKDIR}" \
-				 do_compile cross -C progs tic
-		fi
+		BUILD_DIR="${WORKDIR}" do_compile cross -C progs tic$(get_exeext)
 	fi
 
 	multilib-minimal_src_compile


### PR DESCRIPTION
Force -DBUILDING_NCURCES for build tools to avoid dllimport errors. Update tic build to use get_exeext, which fixes native builds.

Bug: https://bugs.gentoo.org/852665