### PR TITLE
profiles: Unmask gcc for cygwin

### DIFF
--- a/profiles/prefix/windows/cygwin/package.mask
+++ b/profiles/prefix/windows/cygwin/package.mask
@@ -6,10 +6,6 @@
 # see https://cygwin.com/ml/cygwin/2019-06/msg00092.html
 >=app-portage/portage-utils-0.80_pre
 
-# Michael Haubenwallner <haubi@gentoo.org> (2019-06-07)
-# Cygwin does not provide this new version yet in it's repo.
->=sys-devel/gcc-8.4
-
 # Michael Haubenwallner <haubi@gentoo.org> (2019-02-13)
 # see upstream report https://savannah.gnu.org/bugs/index.php?55708
 =sys-apps/groff-1.22.4


### PR DESCRIPTION
Modern cygwin ships gcc 11.3.0.