### PR TITLE
sys-apps/dmidecode: Add LFS flag from the Makefile to the ebuild

### DIFF
--- a/sys-apps/dmidecode/dmidecode-3.4.ebuild
+++ b/sys-apps/dmidecode/dmidecode-3.4.ebuild
@@ -30,7 +30,7 @@ src_prepare() {
 
 src_compile() {
 	emake \
-		CFLAGS="${CFLAGS} ${CPPFLAGS}" \
+		CFLAGS="-D_FILE_OFFSET_BITS=64 ${CFLAGS} ${CPPFLAGS}" \
 		LDFLAGS="${LDFLAGS}" \
 		CC="$(tc-getCC)"
 }


### PR DESCRIPTION
The Makefile for this application is adding "_FILE_OFFSET_BITS=64" to the CFLAGS but the ebuild seems to be overriding it.