### PR TITLE
sys-cluster/hpx: Fix build failure

### DIFF
--- a/sys-cluster/hpx/files/hpx-1.8.1-fix-intmax-error.patch
+++ b/sys-cluster/hpx/files/hpx-1.8.1-fix-intmax-error.patch
@@ -1,0 +1,24 @@
+From 9ce60348a5401fe58b6fd7333d3d7e19f0d6d8ac Mon Sep 17 00:00:00 2001
+From: Jonathan Wakely <jwakely@redhat.com>
+Date: Wed, 8 Feb 2023 12:32:11 +0000
+Subject: [PATCH] Add missing header for std::intmax_t
+
+---
+ .../include/hpx/iterator_support/counting_iterator.hpp           | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/libs/core/iterator_support/include/hpx/iterator_support/counting_iterator.hpp b/libs/core/iterator_support/include/hpx/iterator_support/counting_iterator.hpp
+index e6e6c7a99cb8..1414648cc2cf 100644
+--- a/libs/core/iterator_support/include/hpx/iterator_support/counting_iterator.hpp
++++ b/libs/core/iterator_support/include/hpx/iterator_support/counting_iterator.hpp
+@@ -18,6 +18,7 @@
+ #include <hpx/type_support/lazy_conditional.hpp>
+ 
+ #include <cstddef>
++#include <cstdint>
+ #include <iterator>
+ #include <type_traits>
+ 
+-- 
+2.39.2
+

--- a/sys-cluster/hpx/hpx-1.8.1.ebuild
+++ b/sys-cluster/hpx/hpx-1.8.1.ebuild
@@ -47,6 +47,7 @@ DEPEND="${RDEPEND}"
 
 PATCHES=(
 	"${FILESDIR}/${PN}-1.8.0-python.patch"
+	"${FILESDIR}/${PN}-1.8.1-fix-intmax-error.patch"
 )
 
 hpx_memory_requirement() {


### PR DESCRIPTION
Fix build failure due to missing header file regarding std::intmax_t. Patch taken from upstream master branch. Thanks.