### PR TITLE
www-apps/hugo: Keyword 0.110.0 riscv, #895650

### DIFF
--- a/virtual/pandoc/pandoc-0.ebuild
+++ b/virtual/pandoc/pandoc-0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -7,7 +7,7 @@ DESCRIPTION="Virtual for pandoc"
 
 LICENSE=""
 SLOT="0"
-KEYWORDS="~amd64 ~arm64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~riscv ~x86"
 
 BDEPEND=""
 RDEPEND="|| ( app-text/pandoc-bin[pandoc-symlink] app-text/pandoc )"

--- a/www-apps/hugo/hugo-0.110.0.ebuild
+++ b/www-apps/hugo/hugo-0.110.0.ebuild
@@ -17,7 +17,7 @@ SRC_URI="
 
 LICENSE="Apache-2.0 BSD BSD-2 MIT Unlicense"
 SLOT="0"
-KEYWORDS="~amd64 ~arm64 ~loong ~x86"
+KEYWORDS="~amd64 ~arm64 ~loong ~riscv ~x86"
 IUSE="doc +sass test"
 
 BDEPEND="


### PR DESCRIPTION
Although the package's test dependencies failed to install, the package works fine. And the test dependencies of this package have also been keyworded.
Signed-off-by: Yu Gu guyu2876@gmail.com