### PR TITLE
x11-wm/qtile: depend on pywlroots-0.15.x versions

### DIFF
--- a/x11-wm/qtile/qtile-0.22.1-r1.ebuild
+++ b/x11-wm/qtile/qtile-0.22.1-r1.ebuild
@@ -37,7 +37,7 @@ RDEPEND="
 		media-sound/pulseaudio
 	)
 	wayland? (
-		=dev-python/pywlroots-0.15.24[${PYTHON_USEDEP}]
+		~dev-python/pywlroots-0.15*[${PYTHON_USEDEP}]
 	)
 "
 BDEPEND="

--- a/x11-wm/qtile/qtile-0.22.1-r1.ebuild
+++ b/x11-wm/qtile/qtile-0.22.1-r1.ebuild
@@ -37,7 +37,7 @@ RDEPEND="
 		media-sound/pulseaudio
 	)
 	wayland? (
-		=dev-python/pywlroots-0.15[${PYTHON_USEDEP}]
+		=dev-python/pywlroots-0.15.24[${PYTHON_USEDEP}]
 	)
 "
 BDEPEND="

--- a/x11-wm/qtile/qtile-0.22.1-r1.ebuild
+++ b/x11-wm/qtile/qtile-0.22.1-r1.ebuild
@@ -37,7 +37,7 @@ RDEPEND="
 		media-sound/pulseaudio
 	)
 	wayland? (
-		~dev-python/pywlroots-0.15*[${PYTHON_USEDEP}]
+		=dev-python/pywlroots-0.15*[${PYTHON_USEDEP}]
 	)
 "
 BDEPEND="

--- a/x11-wm/qtile/qtile-0.22.1-r1.ebuild
+++ b/x11-wm/qtile/qtile-0.22.1-r1.ebuild
@@ -37,7 +37,7 @@ RDEPEND="
 		media-sound/pulseaudio
 	)
 	wayland? (
-		dev-python/pywlroots[${PYTHON_USEDEP}]
+		=dev-python/pywlroots-0.15[${PYTHON_USEDEP}]
 	)
 "
 BDEPEND="

--- a/x11-wm/qtile/qtile-9999.ebuild
+++ b/x11-wm/qtile/qtile-9999.ebuild
@@ -37,7 +37,7 @@ RDEPEND="
 		media-sound/pulseaudio
 	)
 	wayland? (
-		=dev-python/pywlroots-0.15.24[${PYTHON_USEDEP}]
+		~dev-python/pywlroots-0.15*[${PYTHON_USEDEP}]
 	)
 "
 BDEPEND="

--- a/x11-wm/qtile/qtile-9999.ebuild
+++ b/x11-wm/qtile/qtile-9999.ebuild
@@ -37,7 +37,7 @@ RDEPEND="
 		media-sound/pulseaudio
 	)
 	wayland? (
-		=dev-python/pywlroots-0.15[${PYTHON_USEDEP}]
+		=dev-python/pywlroots-0.15.24[${PYTHON_USEDEP}]
 	)
 "
 BDEPEND="

--- a/x11-wm/qtile/qtile-9999.ebuild
+++ b/x11-wm/qtile/qtile-9999.ebuild
@@ -37,7 +37,7 @@ RDEPEND="
 		media-sound/pulseaudio
 	)
 	wayland? (
-		~dev-python/pywlroots-0.15*[${PYTHON_USEDEP}]
+		=dev-python/pywlroots-0.15*[${PYTHON_USEDEP}]
 	)
 "
 BDEPEND="

--- a/x11-wm/qtile/qtile-9999.ebuild
+++ b/x11-wm/qtile/qtile-9999.ebuild
@@ -37,7 +37,7 @@ RDEPEND="
 		media-sound/pulseaudio
 	)
 	wayland? (
-		dev-python/pywlroots[${PYTHON_USEDEP}]
+		=dev-python/pywlroots-0.15[${PYTHON_USEDEP}]
 	)
 "
 BDEPEND="


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/895722