### PR TITLE
profiles/arch/arm64: drop obsolete app-doc/doxygen masks

### DIFF
--- a/profiles/arch/arm64/package.use.stable.mask
+++ b/profiles/arch/arm64/package.use.stable.mask
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # Sam James <sam@gentoo.org> (2022-07-06)
@@ -126,11 +126,6 @@ media-libs/opencv contribcvv contribhdf contribsfm glog gstreamer
 # Mart Raudsepp <leio@gentoo.org> (2019-01-18)
 # Respective x11-drivers/ not tested and stable yet
 x11-base/xorg-drivers input_devices_elographics input_devices_joystick input_devices_void video_cards_dummy video_cards_fbdev video_cards_nouveau
-
-# Mart Raudsepp <leio@gentoo.org> (2018-05-29)
-# dev-libs/xapian, app-text/texlive not stable yet
-# USE=doc requires USE=latex
-app-doc/doxygen doxysearch doc
 
 # Michał Górny <mgorny@gentoo.org> (2018-04-15)
 # Non-stable dependencies.


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/894420