### PR TITLE
sys-libs/ncurses: Stop embedding RCS IDs

### DIFF
--- a/sys-libs/ncurses/ncurses-6.3_p20221203-r2.ebuild
+++ b/sys-libs/ncurses/ncurses-6.3_p20221203-r2.ebuild
@@ -302,7 +302,6 @@ do_configure() {
 		$(use_enable kernel_Winnt term-driver)
 		--disable-termcap
 		--enable-symlinks
-		--with-rcs-ids
 		--with-manpage-format=normal
 		--enable-const
 		--enable-colorfgbg

--- a/sys-libs/ncurses/ncurses-6.4.ebuild
+++ b/sys-libs/ncurses/ncurses-6.4.ebuild
@@ -242,7 +242,6 @@ do_configure() {
 		$(use_enable kernel_Winnt term-driver)
 		--disable-termcap
 		--enable-symlinks
-		--with-rcs-ids
 		--with-manpage-format=normal
 		--enable-const
 		--enable-colorfgbg


### PR DESCRIPTION
It's unclear if this is still useful, and it causes a ton of warnings like:
/var/tmp/portage/sys-libs/ncurses-6.4/work/ncurses-6.4/ncurses/curses.priv.h:60:41: warning: ‘Ident’ defined but not used [-Wunused-const-variable=]
   60 | #define MODULE_ID(id) static const char Ident[] = id;
      |                                         ^~~~~
/var/tmp/portage/sys-libs/ncurses-6.4/work/ncurses-6.4/ncurses/tinfo/lib_napms.c:55:1: note: in expansion of macro ‘MODULE_ID’
   55 | MODULE_ID("$Id: lib_napms.c,v 1.27 2020/08/15 19:45:23 tom Exp $")
      | ^~~~~~~~~