### PR TITLE
dev-java/javatoolkit: add python-3.11 support

### DIFF
--- a/dev-java/javatoolkit/javatoolkit-0.6.7.ebuild
+++ b/dev-java/javatoolkit/javatoolkit-0.6.7.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{9,10} )
+PYTHON_COMPAT=( python3_{9,11} )
 PYTHON_REQ_USE="xml(+)"
 DISTUTILS_USE_SETUPTOOLS=no
 


### PR DESCRIPTION
Tested-by: Andrés Becerra <andres.becerra@gmail.com>
Bug: https://bugs.gentoo.org/896318
Closes: https://bugs.gentoo.org/896318