### PR TITLE
app-arch/tar-1.34: Adding a patch to fix CVE-2022-48303

### DIFF
--- a/app-arch/tar/files/tar-1.34-fix-cve-2022-48303.patch
+++ b/app-arch/tar/files/tar-1.34-fix-cve-2022-48303.patch
@@ -1,0 +1,32 @@
+Gentoo Bug: https://bugs.gentoo.org/898176
+Upstream Commit Link: https://git.savannah.gnu.org/cgit/tar.git/commit/?id=3da78400eafcccb97e2f2fd4b227ea40d794ede8
+
+From 3da78400eafcccb97e2f2fd4b227ea40d794ede8 Mon Sep 17 00:00:00 2001
+From: Sergey Poznyakoff <gray@gnu.org>
+Date: Sat, 11 Feb 2023 11:57:39 +0200
+Subject: [PATCH] Fix boundary checking in base-256 decoder
+
+* src/list.c (from_header): Base-256 encoding is at least 2 bytes
+long.
+---
+ src/list.c | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/src/list.c b/src/list.c
+index 9fafc425..86bcfdd1 100644
+--- a/src/list.c
++++ b/src/list.c
+@@ -881,8 +881,9 @@ from_header (char const *where0, size_t digs, char const *type,
+ 	  where++;
+ 	}
+     }
+-  else if (*where == '\200' /* positive base-256 */
+-	   || *where == '\377' /* negative base-256 */)
++  else if (where <= lim - 2
++	   && (*where == '\200' /* positive base-256 */
++	       || *where == '\377' /* negative base-256 */))
+     {
+       /* Parse base-256 output.  A nonnegative number N is
+ 	 represented as (256**DIGS)/2 + N; a negative number -N is
+--
+2.39.2.637.g21b0678d19-goog

--- a/app-arch/tar/tar-1.34-r3.ebuild
+++ b/app-arch/tar/tar-1.34-r3.ebuild
@@ -18,7 +18,7 @@ SRC_URI+=" verify-sig? (
 LICENSE="GPL-3+"
 SLOT="0"
 if [[ -z "$(ver_cut 3)" ]] || [[ "$(ver_cut 3)" -lt 90 ]] ; then
-	KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~x64-cygwin ~amd64-linux ~x86-linux ~arm64-macos ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~x64-cygwin ~amd64-linux ~x86-linux ~arm64-macos ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 fi
 IUSE="acl minimal nls selinux xattr"
 
@@ -36,6 +36,10 @@ BDEPEND="
 PDEPEND="
 	app-alternatives/tar
 "
+
+PATCHES=(
+	"${FILESDIR}"/${P}-fix-cve-2022-48303.patch
+)
 
 src_configure() {
 	local myeconfargs=(


### PR DESCRIPTION
This patch is cherry-picked from the upstream gnu/tar repository which fixes a heap buffer overflow issue in the utility. Since the tar project only made this commit in master and has not made a release with this fix yet, I'm back-porting it to 1.34 to resolve CVE-2022-48303.

No bug has been created yet since I couldn't create a bug within 24 hours of creating my gentoo bugzilla account.

tar commit in master is: 3da78400eafcccb97e2f2fd4b227ea40d794ede8