### PR TITLE
*/*: fixes for wayland-scanner and wayland-protocols in DEPEND/BDEPEND

### DIFF
--- a/app-admin/conky/conky-1.17.0.ebuild
+++ b/app-admin/conky/conky-1.17.0.ebuild
@@ -38,7 +38,6 @@ COMMON_DEPEND="
 	truetype? ( x11-libs/libXft >=media-libs/freetype-2 )
 	wayland? (
 		dev-libs/wayland
-		dev-libs/wayland-protocols
 		x11-libs/pango
 	)
 	wifi? ( net-wireless/wireless-tools )
@@ -66,6 +65,9 @@ RDEPEND="
 "
 DEPEND="
 	${COMMON_DEPEND}
+	wayland? (
+		dev-libs/wayland-protocols
+	)
 "
 BDEPEND="
 	doc? (

--- a/dev-libs/bemenu/bemenu-0.6.10.ebuild
+++ b/dev-libs/bemenu/bemenu-0.6.10.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2019-2022 Gentoo Authors
+# Copyright 2019-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -26,7 +26,6 @@ DEPEND="
 	ncurses? ( sys-libs/ncurses:= )
 	wayland? (
 		dev-libs/wayland
-		dev-libs/wayland-protocols
 		x11-libs/cairo
 		x11-libs/pango
 		x11-libs/libxcb
@@ -40,7 +39,11 @@ DEPEND="
 		x11-libs/libXinerama
 	)
 "
-RDEPEND="${DEPEND}"
+DEPEND="${RDEPEND}
+	wayland? (
+		dev-libs/wayland-protocols
+	)
+"
 BDEPEND="doc? ( app-doc/doxygen )"
 
 src_compile() {

--- a/dev-libs/bemenu/bemenu-9999.ebuild
+++ b/dev-libs/bemenu/bemenu-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2019-2022 Gentoo Authors
+# Copyright 2019-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -26,7 +26,6 @@ DEPEND="
 	ncurses? ( sys-libs/ncurses:= )
 	wayland? (
 		dev-libs/wayland
-		dev-libs/wayland-protocols
 		x11-libs/cairo
 		x11-libs/pango
 		x11-libs/libxcb
@@ -40,7 +39,11 @@ DEPEND="
 		x11-libs/libXinerama
 	)
 "
-RDEPEND="${DEPEND}"
+DEPEND="${RDEPEND}
+	wayland? (
+		dev-libs/wayland-protocols
+	)
+"
 BDEPEND="doc? ( app-doc/doxygen )"
 
 src_compile() {

--- a/dev-libs/weston/weston-11.0.1.ebuild
+++ b/dev-libs/weston/weston-11.0.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -42,7 +42,6 @@ REQUIRED_USE="
 RDEPEND="
 	>=dev-libs/libinput-0.8.0
 	>=dev-libs/wayland-1.20.0
-	>=dev-libs/wayland-protocols-1.24
 	lcms? ( >=media-libs/lcms-2.9:2 )
 	media-libs/libpng:0=
 	webp? ( media-libs/libwebp:0= )
@@ -85,7 +84,9 @@ RDEPEND="
 		x11-libs/libXcursor
 	)
 "
-DEPEND="${RDEPEND}"
+DEPEND="${RDEPEND}
+	>=dev-libs/wayland-protocols-1.24
+"
 BDEPEND="
 	${PYTHON_DEPS}
 	virtual/pkgconfig

--- a/dev-libs/weston/weston-9999.ebuild
+++ b/dev-libs/weston/weston-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -41,7 +41,6 @@ REQUIRED_USE="
 RDEPEND="
 	>=dev-libs/libinput-0.8.0
 	>=dev-libs/wayland-1.20.0
-	>=dev-libs/wayland-protocols-1.24
 	media-libs/libpng:0=
 	sys-auth/seatd:=
 	>=x11-libs/cairo-1.11.3
@@ -83,9 +82,12 @@ RDEPEND="
 		x11-libs/libXcursor
 	)
 "
-DEPEND="${RDEPEND}"
+DEPEND="${RDEPEND}
+	>=dev-libs/wayland-protocols-1.24
+"
 BDEPEND="
 	${PYTHON_DEPS}
+	dev-util/wayland-scanner
 	virtual/pkgconfig
 "
 

--- a/gui-apps/grim/grim-1.4.0-r1.ebuild
+++ b/gui-apps/grim/grim-1.4.0-r1.ebuild
@@ -20,14 +20,15 @@ LICENSE="MIT"
 SLOT="0"
 IUSE="+man jpeg"
 
-DEPEND="
+RDEPEND="
 	dev-libs/wayland
-	>=dev-libs/wayland-protocols-1.14
 	media-libs/libpng
 	x11-libs/pixman
 	jpeg? ( media-libs/libjpeg-turbo )
 "
-RDEPEND="${DEPEND}"
+DEPEND="${RDEPEND}
+	>=dev-libs/wayland-protocols-1.14
+"
 BDEPEND="man? ( app-text/scdoc )"
 
 src_configure() {
@@ -45,5 +46,5 @@ src_install() {
 
 	newbashcomp contrib/completions/bash/grim.bash grim
 	insinto /usr/share/fish/vendor_completions.d/
-	doins contrib/completions/fish/grim.fish
+	doins contrib/completions/grim.fish
 }

--- a/gui-apps/mako/mako-1.7.1-r1.ebuild
+++ b/gui-apps/mako/mako-1.7.1-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -20,9 +20,8 @@ LICENSE="MIT"
 SLOT="0"
 IUSE="elogind +icons systemd"
 
-DEPEND="
+RDEPEND="
 	dev-libs/wayland
-	dev-util/wayland-scanner
 	x11-libs/pango
 	x11-libs/cairo
 	|| (
@@ -36,13 +35,14 @@ DEPEND="
 		x11-libs/gdk-pixbuf
 	)
 "
-RDEPEND="
-	${DEPEND}
+DEPEND="
+	${RDEPEND}
 	>=dev-libs/wayland-protocols-1.21
 "
 BDEPEND="
-	virtual/pkgconfig
 	app-text/scdoc
+	dev-util/wayland-scanner
+	virtual/pkgconfig
 "
 
 src_configure() {

--- a/gui-apps/mako/mako-9999.ebuild
+++ b/gui-apps/mako/mako-9999.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
-inherit meson
+inherit meson systemd
 
 DESCRIPTION="A lightweight notification daemon for Wayland. Works on Sway"
 HOMEPAGE="https://github.com/emersion/mako"
@@ -20,9 +20,8 @@ LICENSE="MIT"
 SLOT="0"
 IUSE="elogind +icons systemd"
 
-DEPEND="
+RDEPEND="
 	dev-libs/wayland
-	dev-util/wayland-scanner
 	x11-libs/pango
 	x11-libs/cairo
 	|| (
@@ -36,18 +35,22 @@ DEPEND="
 		x11-libs/gdk-pixbuf
 	)
 "
-RDEPEND="
-	${DEPEND}
+DEPEND="
+	${RDEPEND}
 	>=dev-libs/wayland-protocols-1.21
 "
 BDEPEND="
-	virtual/pkgconfig
 	app-text/scdoc
+	dev-util/wayland-scanner
+	virtual/pkgconfig
 "
 
 src_configure() {
 	local emesonargs=(
 		-Dicons=$(usex icons enabled disabled)
+		-Dzsh-completions=true
+		-Dfish-completions=true
+		-Dbash-completions=true
 	)
 
 	if use systemd ; then
@@ -59,4 +62,10 @@ src_configure() {
 	fi
 
 	meson_src_configure
+}
+
+src_install() {
+	meson_src_install
+
+	systemd_douserunit contrib/systemd/mako.service
 }

--- a/media-libs/intel-mediasdk/intel-mediasdk-22.6.5.ebuild
+++ b/media-libs/intel-mediasdk/intel-mediasdk-22.6.5.ebuild
@@ -30,7 +30,7 @@ IUSE="dri test +tools wayland X"
 # Test not working at the moment
 #RESTRICT="!test? ( test )"
 RESTRICT="test"
-# Most of these flags only have an effect on the tools
+# # Most of these flags only have an effect on the tools
 REQUIRED_USE="
 	dri? ( X )
 	wayland? ( tools )
@@ -39,22 +39,29 @@ REQUIRED_USE="
 
 # x11-libs/libdrm[video_cards_intel] for intel_bufmgr.h in samples
 # bug #805224
-DEPEND="
+RDEPEND="
 	x11-libs/libpciaccess
 	>=media-libs/libva-intel-media-driver-${PV}
 	media-libs/libva[X?,wayland?]
 	x11-libs/libdrm[video_cards_intel]
 	wayland? (
 		dev-libs/wayland
-		dev-util/wayland-scanner
-		dev-libs/wayland-protocols
 	)
 	X? (
 		x11-libs/libX11
 		x11-libs/libxcb
 	)
 "
-RDEPEND="${DEPEND}"
+DEPEND="${RDEPEND}
+	wayland? (
+		dev-libs/wayland-protocols
+	)
+"
+BDEPEND="
+	wayland? (
+		dev-util/wayland-scanner
+	)
+"
 
 src_configure() {
 	local mycmakeargs=(

--- a/media-libs/intel-mediasdk/intel-mediasdk-9999.ebuild
+++ b/media-libs/intel-mediasdk/intel-mediasdk-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -39,22 +39,29 @@ REQUIRED_USE="
 
 # x11-libs/libdrm[video_cards_intel] for intel_bufmgr.h in samples
 # bug #805224
-DEPEND="
+RDEPEND="
 	x11-libs/libpciaccess
 	>=media-libs/libva-intel-media-driver-${PV}
 	media-libs/libva[X?,wayland?]
 	x11-libs/libdrm[video_cards_intel]
 	wayland? (
 		dev-libs/wayland
-		dev-util/wayland-scanner
-		dev-libs/wayland-protocols
 	)
 	X? (
 		x11-libs/libX11
 		x11-libs/libxcb
 	)
 "
-RDEPEND="${DEPEND}"
+DEPEND="${RDEPEND}
+	wayland? (
+		dev-libs/wayland-protocols
+	)
+"
+BDEPEND="
+	wayland? (
+		dev-util/wayland-scanner
+	)
+"
 
 src_configure() {
 	local mycmakeargs=(


### PR DESCRIPTION
dev-utils/wayland-scanner should be a BDEPEND only for packages and dev-libs/wayland-protocols is a DEPEND only (no RDEPEND) for packages.

The current set of patches fixes all the wayland-scanner and a couple of wayland-protocols, more to come for wayland-protocol.