### PR TITLE
gui-apps/grim: fix fish install paths

### DIFF
--- a/gui-apps/grim/grim-1.4.0-r2.ebuild
+++ b/gui-apps/grim/grim-1.4.0-r2.ebuild
@@ -46,5 +46,5 @@ src_install() {
 
 	newbashcomp contrib/completions/bash/grim.bash grim
 	insinto /usr/share/fish/vendor_completions.d/
-	doins contrib/completions/grim.fish
+	doins contrib/completions/fish/grim.fish
 }

--- a/gui-apps/grim/grim-9999.ebuild
+++ b/gui-apps/grim/grim-9999.ebuild
@@ -46,5 +46,5 @@ src_install() {
 
 	newbashcomp contrib/completions/bash/grim.bash grim
 	insinto /usr/share/fish/vendor_completions.d/
-	doins contrib/completions/grim.fish
+	doins contrib/completions/fish/grim.fish
 }


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/849356