### PR TITLE
app-text/nfoview: enable py3.11

### DIFF
--- a/app-text/nfoview/nfoview-1.28.1-r1.ebuild
+++ b/app-text/nfoview/nfoview-1.28.1-r1.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_SETUPTOOLS=no
-PYTHON_COMPAT=( python3_{9..10} )
+PYTHON_COMPAT=( python3_{9..11} )
 
 inherit distutils-r1 virtualx xdg
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/896638

Please note, that PEP517 migration is not applied, since this will be the last version of the package using distutils. 