### PR TITLE
sci-astronomy/sirilic: enable py3.11

### DIFF
--- a/sci-astronomy/sirilic/sirilic-1.14.3-r1.ebuild
+++ b/sci-astronomy/sirilic/sirilic-1.14.3-r1.ebuild
@@ -1,0 +1,20 @@
+# Copyright 2021-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DISTUTILS_USE_PEP517=setuptools
+PYTHON_COMPAT=( python3_{9..11} )
+inherit distutils-r1
+
+DESCRIPTION="Preparing acquisition files for processing with the SiriL software"
+HOMEPAGE="https://gitlab.com/free-astro/sirilic"
+SRC_URI="https://gitlab.com/free-astro/sirilic/-/archive/V${PV//./_}/${PN}-V${PV//./_}.tar.bz2"
+S="${WORKDIR}/${PN}-V${PV//./_}"
+
+LICENSE="LGPL-3+"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+DEPEND=">=dev-python/wxpython-4.2:4.0[${PYTHON_USEDEP}]"
+RDEPEND="${DEPEND}"


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/897190