### PR TITLE
app-forensics/volatility3: enable py3.11

### DIFF
--- a/app-forensics/volatility3/volatility3-2.4.0-r1.ebuild
+++ b/app-forensics/volatility3/volatility3-2.4.0-r1.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..10} )
+PYTHON_COMPAT=( python3_{9..11} )
 inherit distutils-r1
 
 MY_PV=${PV//_beta/-beta.}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/896544