### PR TITLE
java-pkg-simple.eclass: MANIFEST.MF show Gentoo in "Created-By: "

### DIFF
--- a/eclass/java-pkg-simple.eclass
+++ b/eclass/java-pkg-simple.eclass
@@ -1,4 +1,4 @@
-# Copyright 2004-2022 Gentoo Authors
+# Copyright 2004-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: java-pkg-simple.eclass
@@ -417,6 +417,7 @@ java-pkg-simple_src_compile() {
 	# package
 	local jar_args
 	if [[ -e ${classes}/META-INF/MANIFEST.MF ]]; then
+		sed '/Created-By: /Id' -i ${classes}/META-INF/MANIFEST.MF
 		jar_args="cfm ${JAVA_JAR_FILENAME} ${classes}/META-INF/MANIFEST.MF"
 	else
 		jar_args="cf ${JAVA_JAR_FILENAME}"


### PR DESCRIPTION
Presently, MANIFEST.MF can receive upstream's "Created-By:" if such line is found in a predefined META-INF/MANIFEST.MF in ${JAVA_RESOURCE_DIRS}. This change removes such line before the jar command creates the final MANIFEST.MF putting "Created-By: (GEntoo)"

Closes: https://bugs.gentoo.org/897786

@fordfrog 