### PR TITLE
mail-client/claws-mail-9999: remove outdated libsoup mention

### DIFF
--- a/mail-client/claws-mail/claws-mail-9999.ebuild
+++ b/mail-client/claws-mail/claws-mail-9999.ebuild
@@ -117,9 +117,6 @@ src_prepare() {
 }
 
 src_configure() {
-	# Don't use libsoup-gnome (bug #565924)
-	export HAVE_LIBSOUP_GNOME=no
-
 	local myeconfargs=(
 		--disable-bsfilter-plugin
 		--disable-generic-umpc


### PR DESCRIPTION
`libsoup` and `libsoup-gnome` dependencies has been removed in https://git.claws-mail.org/?p=claws.git;a=commitdiff;h=e2e7f63c6a0a762dd8d823eb29ad850e665317ff .