### PR TITLE
www-servers/tomcat: move patches to PATCHES array

### DIFF
--- a/www-servers/tomcat/tomcat-10.1.6.ebuild
+++ b/www-servers/tomcat/tomcat-10.1.6.ebuild
@@ -51,6 +51,8 @@ DEPEND="${COMMON_DEP}
 BDEPEND="verify-sig? ( ~sec-keys/openpgp-keys-apache-tomcat-${PV}:${PV} )"
 VERIFY_SIG_OPENPGP_KEY_PATH="${BROOT}/usr/share/openpgp-keys/tomcat-${PV}.apache.org.asc"
 
+PATCHES=( "${FILESDIR}/${PN}-10.1.6-build.xml.patch" )
+
 S=${WORKDIR}/${MY_P}
 
 BND_HOME="${S}/tomcat-build-libs/bnd"
@@ -74,8 +76,6 @@ src_prepare() {
 	default
 
 	find -name '*.jar' -type f -delete -print || die
-
-	eapply "${FILESDIR}/${PN}-10.1.6-build.xml.patch"
 
 	local vm_version="$(java-config -g PROVIDES_VERSION)"
 

--- a/www-servers/tomcat/tomcat-8.5.86.ebuild
+++ b/www-servers/tomcat/tomcat-8.5.86.ebuild
@@ -47,14 +47,14 @@ DEPEND="${COMMON_DEP}
 BDEPEND="verify-sig? ( ~sec-keys/openpgp-keys-apache-tomcat-${PV}:${PV} )"
 VERIFY_SIG_OPENPGP_KEY_PATH="${BROOT}/usr/share/openpgp-keys/tomcat-${PV}.apache.org.asc"
 
+PATCHES=( "${FILESDIR}/${PN}-8.5.86-build.xml.patch" )
+
 S=${WORKDIR}/${MY_P}
 
 src_prepare() {
 	default
 
 	find -name '*.jar' -type f -delete -print || die
-
-	eapply "${FILESDIR}/${PN}-8.5.86-build.xml.patch"
 
 	# For use of catalina.sh in netbeans
 	sed -i -e "/^# ----- Execute The Requested Command/ a\

--- a/www-servers/tomcat/tomcat-9.0.72.ebuild
+++ b/www-servers/tomcat/tomcat-9.0.72.ebuild
@@ -57,6 +57,7 @@ S=${WORKDIR}/${MY_P}
 
 PATCHES=(
 	"${FILESDIR}/${PN}-9.0.50-insufficient-ecj.patch"
+	"${FILESDIR}/${PN}-9.0.72-build.xml.patch"
 )
 
 BND_HOME="${S}/tomcat-build-libs/bnd"
@@ -80,8 +81,6 @@ src_prepare() {
 	default
 
 	find -name '*.jar' -type f -delete -print || die
-
-	eapply "${FILESDIR}/${PN}-9.0.72-build.xml.patch"
 
 	# For use of catalina.sh in netbeans
 	sed -i -e "/^# ----- Execute The Requested Command/ a\


### PR DESCRIPTION
@fordfrog 
My guess, haven't tested, is that `dev-java/jax-rpc-api` might be moved from COMMON_DEP to DEPEND in `:9` and `:10`.
Then it should be possible to `:%s/COMMON_DEP/CP_DEPEND/g` and drop the `EANT_GENTOO_CLASSPATH` line.