### PR TITLE
profiles/arch/riscv: Mask USE=test on www-apps/hugo

### DIFF
--- a/profiles/arch/riscv/package.use.mask
+++ b/profiles/arch/riscv/package.use.mask
@@ -1,6 +1,10 @@
 # Copyright 2019-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Yu Gu <guyu2876@gmail.com> (2023-02-26)
+# USE=test uses go test -race, which command -race is not supported on linux/riscv64
+www-apps/hugo test
+
 # Yixun Lan <dlan@gentoo.org> (2023-02-16)
 # USE=java depend on virtual/jdk:1.8 which is not support on RISC-V
 app-office/libreoffice java libreoffice_extensions_scripting-beanshell libreoffice_extensions_scripting-javascript


### PR DESCRIPTION
USE=test uses go test -race, which command -race is not supported on linux/riscv64

Signed-off-by: Yu Gu <guyu2876@gmail.com>
