### PR TITLE
app-admin/syslog-summary: add python 3.11 to compat

### DIFF
--- a/app-admin/syslog-summary/syslog-summary-1.14-r5.ebuild
+++ b/app-admin/syslog-summary/syslog-summary-1.14-r5.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{9,10} )
+PYTHON_COMPAT=( python3_{10,11} )
 
 inherit python-single-r1
 


### PR DESCRIPTION
    add python 3.11
    drop python 3.9

    Bug:https://bugs.gentoo.org/896486
    Signed-off-by: Paul Healy <lmiphay@gmail.com>