### PR TITLE
kde-plasma/plasma-nm: Add support for optionally building components for mobile devices

### DIFF
--- a/kde-plasma/plasma-nm/metadata.xml
+++ b/kde-plasma/plasma-nm/metadata.xml
@@ -9,6 +9,7 @@
 		<bugs-to>https://bugs.kde.org/</bugs-to>
 	</upstream>
 	<use>
+		<flag name="mobile">Build components for mobile devices (Plasma Mobile)</flag>
 		<flag name="modemmanager">Enable support for mobile broadband devices</flag>
 		<flag name="openconnect">Build support for the OpenConnect VPN client</flag>
 		<flag name="teamd">Enable Teamd control support</flag>

--- a/kde-plasma/plasma-nm/plasma-nm-5.27.1-r1.ebuild
+++ b/kde-plasma/plasma-nm/plasma-nm-5.27.1-r1.ebuild
@@ -14,7 +14,7 @@ DESCRIPTION="KDE Plasma applet for NetworkManager"
 LICENSE="GPL-2 LGPL-2.1"
 SLOT="5"
 KEYWORDS="~amd64 ~arm ~arm64 ~loong ~ppc64 ~riscv ~x86"
-IUSE="openconnect teamd"
+IUSE="mobile openconnect teamd"
 
 DEPEND="
 	>=app-crypt/qca-2.3.0:2[qt5(+)]
@@ -70,6 +70,14 @@ src_prepare() {
 	if ! use openconnect; then
 		sed -e "s/^pkg_check_modules.*openconnect/#&/" -i CMakeLists.txt || die
 	fi
+}
+
+src_configure() {
+	local mycmakeargs=(
+		-DBUILD_MOBILE=$(usex mobile "True" "False")
+	)
+
+	ecm_src_configure
 }
 
 pkg_postinst() {


### PR DESCRIPTION
As explained in [bug 898010](https://bugs.gentoo.org/898010), `kde-plasma/plasma-nm` is already shipped upstream with KCMs for mobile devices (as those using Plasma Mobile) but those components are just not enabled in the ebuild:

![image](https://user-images.githubusercontent.com/3270352/221438342-9c122f02-4a3d-44eb-b0dd-d994371fe6f5.png)

This PR adds support for optionally enabling those mobile components.