### PR TITLE
sys-devel/gdb: Fix cross-compiling (properly) and prefix sysroot

### DIFF
--- a/sys-devel/gdb/gdb-13.1-r1.ebuild
+++ b/sys-devel/gdb/gdb-13.1-r1.ebuild
@@ -160,21 +160,13 @@ src_configure() {
 		# But the check does not quite work on i686: bug #760926.
 		$(use_enable cet)
 
-		# We need to set both configure options, --with-sysroot and --libdir,
-		# to fix cross build issues that happen when configuring gmp.
-		# We explicitly need --libdir. Having only --with-sysroot without
-		# --libdir would not fix the build issues.
-		# For some reason, it is not enough to set only --with-sysroot,
-		# also not enough to pass --with-gmp-xxx options.
-		--with-sysroot="${ESYSROOT}"
-		--libdir="${ESYSROOT}/usr/$(get_libdir)"
+		# Helps when cross-compiling. Not to be confused with --with-sysroot.
+		--with-build-sysroot="${ESYSROOT}"
 	)
 
-	local sysroot="${EPREFIX}/usr/${CTARGET}"
-
 	is_cross && myconf+=(
-		--with-sysroot="${sysroot}"
-		--includedir="${sysroot}/usr/include"
+		--with-sysroot="\${prefix}/${CTARGET}"
+		--includedir="\${prefix}/include/${CTARGET}"
 		--with-gdb-datadir="\${datadir}/gdb/${CTARGET}"
 	)
 
@@ -211,6 +203,13 @@ src_configure() {
 		$(use_with xxhash)
 		$(use_with guile)
 		$(use_with zstd)
+
+		# Find libraries using the toolchain sysroot rather than the configured
+		# prefix. Needed when cross-compiling.
+		#
+		# Check which libraries to apply this to with:
+		# "${S}"/gdb/configure --help | grep without-lib | sort
+		--without-lib{babeltrace,expat,gmp,iconv,ipt,lzma,mpfr,xxhash}-prefix
 	)
 
 	if use sparc-solaris || use x86-solaris ; then

--- a/sys-devel/gdb/gdb-9999.ebuild
+++ b/sys-devel/gdb/gdb-9999.ebuild
@@ -160,21 +160,13 @@ src_configure() {
 		# But the check does not quite work on i686: bug #760926.
 		$(use_enable cet)
 
-		# We need to set both configure options, --with-sysroot and --libdir,
-		# to fix cross build issues that happen when configuring gmp.
-		# We explicitly need --libdir. Having only --with-sysroot without
-		# --libdir would not fix the build issues.
-		# For some reason, it is not enough to set only --with-sysroot,
-		# also not enough to pass --with-gmp-xxx options.
-		--with-sysroot="${ESYSROOT}"
-		--libdir="${ESYSROOT}/usr/$(get_libdir)"
+		# Helps when cross-compiling. Not to be confused with --with-sysroot.
+		--with-build-sysroot="${ESYSROOT}"
 	)
 
-	local sysroot="${EPREFIX}/usr/${CTARGET}"
-
 	is_cross && myconf+=(
-		--with-sysroot="${sysroot}"
-		--includedir="${sysroot}/usr/include"
+		--with-sysroot="\${prefix}/${CTARGET}"
+		--includedir="\${prefix}/include/${CTARGET}"
 		--with-gdb-datadir="\${datadir}/gdb/${CTARGET}"
 	)
 
@@ -211,6 +203,13 @@ src_configure() {
 		$(use_with xxhash)
 		$(use_with guile)
 		$(use_with zstd)
+
+		# Find libraries using the toolchain sysroot rather than the configured
+		# prefix. Needed when cross-compiling.
+		#
+		# Check which libraries to apply this to with:
+		# "${S}"/gdb/configure --help | grep without-lib | sort
+		--without-lib{babeltrace,expat,gmp,iconv,ipt,lzma,mpfr,xxhash}-prefix
 	)
 
 	if use sparc-solaris || use x86-solaris ; then


### PR DESCRIPTION
#25896 tried to address cross-compiling in the wrong way by setting the runtime sysroot and the `libdir`. The build uses the latter to find dependent libraries by default, a common technique in GNU software.

This behaviour can be avoided by passing the "without-prefix" configure option for each library, allowing the runtime sysroot and the `libdir` to be set as they should be. Contrary to what you might expect, the sysroot should actually not be set at all except when building `cross-*/gdb`, otherwise the paths get double prefixed at runtime.

gdb's configure script also has a `--with-build-sysroot` option that should be set to assist with cross-compiling. This does not influence runtime behaviour.

The `includedir` for `cross-*/gdb` has been changed to prevent it from installing under `/usr/${CTARGET}`, where installed headers would collide with those from a cross-compiled `sys-devel/gdb` build. `/usr/include/${CTARGET}/gdb` is consistent with the files we install under `/usr/share`, as well as the scheme we use for multilib headers, e.g. `/usr/include/i686-pc-linux-gnu`.

Closes: https://bugs.gentoo.org/896008