### PR TITLE
net-nntp/sabnzbd: make test deps conditional again.

### DIFF
--- a/net-nntp/sabnzbd/sabnzbd-3.7.2.ebuild
+++ b/net-nntp/sabnzbd/sabnzbd-3.7.2.ebuild
@@ -42,9 +42,13 @@ DEPEND="
 		dev-python/portend[${PYTHON_USEDEP}]
 		dev-python/puremagic[${PYTHON_USEDEP}]
 		~dev-python/sabyenc-5.4.4[${PYTHON_USEDEP}]
-		dev-python/tavalidate[${PYTHON_USEDEP}]
-		>=dev-python/tavern-2[${PYTHON_USEDEP}]
 	')
+	test? (
+		$(python_gen_cond_dep '
+			dev-python/tavalidate[${PYTHON_USEDEP}]
+			>=dev-python/tavern-2[${PYTHON_USEDEP}]
+		')
+	)
 "
 RDEPEND="
 	${DEPEND}


### PR DESCRIPTION
On the tavern-2 bringup new depends were added that are only needed for testing, this makes them conditional.