### PR TITLE
net-p2p/rtorrent: Resolve overflow issue on hardened build

### DIFF
--- a/net-p2p/rtorrent/files/rtorrent-0.9.8-bgo891995.patch
+++ b/net-p2p/rtorrent/files/rtorrent-0.9.8-bgo891995.patch
@@ -1,0 +1,29 @@
+From 812bba81bc049a5f786282b3654cab294b0ef236 Mon Sep 17 00:00:00 2001
+From: Aleksa Sarai <cyphar@cyphar.com>
+Date: Mon, 20 Jun 2022 19:09:57 +1000
+Subject: [PATCH] utils: lockfile: avoid stack overflow for lockfile buffer
+
+There appears to have been some change on openSUSE (likely some new
+hardening flags for builds, or some glibc hardening) such that incorrect
+buffer handling results in a segfault even if the buffer is never
+overflowed.
+
+Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>
+---
+ src/utils/lockfile.cc | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/utils/lockfile.cc b/src/utils/lockfile.cc
+index 7d11d8c99..fac5cb23e 100644
+--- a/src/utils/lockfile.cc
++++ b/src/utils/lockfile.cc
+@@ -98,7 +98,8 @@ Lockfile::try_lock() {
+   int pos = ::gethostname(buf, 255);
+ 
+   if (pos == 0) {
+-    ::snprintf(buf + std::strlen(buf), 255, ":+%i\n", ::getpid());
++    ssize_t len = std::strlen(buf);
++    ::snprintf(buf + len, 255 - len, ":+%i\n", ::getpid());
+     int __UNUSED result = ::write(fd, buf, std::strlen(buf));
+   }
+ 

--- a/net-p2p/rtorrent/rtorrent-0.9.8-r2.ebuild
+++ b/net-p2p/rtorrent/rtorrent-0.9.8-r2.ebuild
@@ -1,0 +1,74 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools linux-info systemd
+
+DESCRIPTION="BitTorrent Client using libtorrent"
+HOMEPAGE="https://rakshasa.github.io/rtorrent/"
+SRC_URI="http://rtorrent.net/downloads/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~riscv ~sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~x64-solaris"
+IUSE="debug selinux test xmlrpc"
+RESTRICT="!test? ( test )"
+
+COMMON_DEPEND="~net-libs/libtorrent-0.13.${PV##*.}
+	>=net-misc/curl-7.19.1
+	sys-libs/ncurses:0=
+	xmlrpc? ( dev-libs/xmlrpc-c:= )"
+RDEPEND="${COMMON_DEPEND}
+	selinux? ( sec-policy/selinux-rtorrent )
+"
+DEPEND="${COMMON_DEPEND}
+	dev-util/cppunit
+	virtual/pkgconfig"
+
+DOCS=( doc/rtorrent.rc )
+
+PATCHES=(
+	"${FILESDIR}/${P}-bgo891995.patch"
+)
+
+pkg_setup() {
+	if ! linux_config_exists || ! linux_chkconfig_present IPV6; then
+		ewarn "rtorrent will not start without IPv6 support in your kernel"
+		ewarn "without further configuration. Please set bind=0.0.0.0 or"
+		ewarn "similar in your rtorrent.rc"
+		ewarn "Upstream bug: https://github.com/rakshasa/rtorrent/issues/732"
+	fi
+}
+
+src_prepare() {
+	default
+
+	# https://github.com/rakshasa/rtorrent/issues/332
+	cp "${FILESDIR}"/rtorrent.1 "${S}"/doc/ || die
+
+	if [[ ${CHOST} != *-darwin* ]]; then
+		# syslibroot is only for macos, change to sysroot for others
+		sed -i 's/Wl,-syslibroot,/Wl,--sysroot,/' "${S}/scripts/common.m4" || die
+	fi
+
+	eautoreconf
+}
+
+src_configure() {
+	default
+
+	# configure needs bash or script bombs out on some null shift, bug #291229
+	CONFIG_SHELL=${BASH} econf \
+		$(use_enable debug) \
+		$(use_with xmlrpc xmlrpc-c)
+}
+
+src_install() {
+	default
+	doman doc/rtorrent.1
+
+	newinitd "${FILESDIR}/rtorrent-r1.init" rtorrent
+	newconfd "${FILESDIR}/rtorrentd.conf" rtorrent
+	systemd_newunit "${FILESDIR}/rtorrentd_at-r1.service" "rtorrentd@.service"
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/891995

If someone built rtorrent on Hardened and hit this bug, they'd have a version of rtorrent that segfaults, so a revbump seems justified in this case I think?