### PR TITLE
ipython and matplotlib pypy3 support

### DIFF
--- a/dev-python/PyQt-builder/PyQt-builder-1.12.2.ebuild
+++ b/dev-python/PyQt-builder/PyQt-builder-1.12.2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 inherit distutils-r1
 
 DESCRIPTION="The PEP 517 compliant PyQt build system"

--- a/dev-python/PyQt5-sip/PyQt5-sip-12.11.0.ebuild
+++ b/dev-python/PyQt5-sip/PyQt5-sip-12.11.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 DISTUTILS_USE_PEP517=setuptools
 inherit distutils-r1
 

--- a/dev-python/PyQt5/PyQt5-5.15.7.ebuild
+++ b/dev-python/PyQt5/PyQt5-5.15.7.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 inherit python-r1 qmake-utils
 
 DESCRIPTION="Python bindings for the Qt framework"

--- a/dev-python/QtPy/QtPy-2.3.0.ebuild
+++ b/dev-python/QtPy/QtPy-2.3.0.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 
 inherit distutils-r1 virtualx
 

--- a/dev-python/aiohttp-cors/aiohttp-cors-0.7.0-r2.ebuild
+++ b/dev-python/aiohttp-cors/aiohttp-cors-0.7.0-r2.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 
 inherit distutils-r1
 

--- a/dev-python/black/black-22.12.0.ebuild
+++ b/dev-python/black/black-22.12.0.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=hatchling
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 
 inherit distutils-r1 optfeature
 

--- a/dev-python/black/black-23.1.0.ebuild
+++ b/dev-python/black/black-23.1.0.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=hatchling
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 
 inherit distutils-r1 optfeature
 

--- a/dev-python/cchardet/cchardet-2.1.7-r1.ebuild
+++ b/dev-python/cchardet/cchardet-2.1.7-r1.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 inherit distutils-r1
 
 DESCRIPTION="High speed universal character encoding detector"

--- a/dev-python/cchardet/cchardet-2.1.7.ebuild
+++ b/dev-python/cchardet/cchardet-2.1.7.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{9..10} )
+PYTHON_COMPAT=( python3_{9..10} pypy3 )
 inherit distutils-r1
 
 DESCRIPTION="High speed universal character encoding detector"

--- a/dev-python/comm/comm-0.1.2.ebuild
+++ b/dev-python/comm/comm-0.1.2.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=hatchling
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 
 inherit distutils-r1
 

--- a/dev-python/dictdiffer/dictdiffer-0.9.0-r1.ebuild
+++ b/dev-python/dictdiffer/dictdiffer-0.9.0-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 DISTUTILS_USE_PEP517=setuptools
 inherit distutils-r1
 

--- a/dev-python/fuzzywuzzy/fuzzywuzzy-0.18.0.ebuild
+++ b/dev-python/fuzzywuzzy/fuzzywuzzy-0.18.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 
 inherit distutils-r1
 

--- a/dev-python/ipykernel/ipykernel-6.20.2.ebuild
+++ b/dev-python/ipykernel/ipykernel-6.20.2.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=hatchling
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 PYTHON_REQ_USE="threads(+)"
 
 inherit distutils-r1 virtualx

--- a/dev-python/ipykernel/ipykernel-6.21.2.ebuild
+++ b/dev-python/ipykernel/ipykernel-6.21.2.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=hatchling
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 PYTHON_REQ_USE="threads(+)"
 
 inherit distutils-r1 pypi virtualx

--- a/dev-python/ipython/ipython-8.10.0.ebuild
+++ b/dev-python/ipython/ipython-8.10.0.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 PYTHON_REQ_USE='readline,sqlite,threads(+)'
 
 inherit distutils-r1 optfeature virtualx

--- a/dev-python/ipython/ipython-8.8.0.ebuild
+++ b/dev-python/ipython/ipython-8.8.0.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 PYTHON_REQ_USE='readline,sqlite,threads(+)'
 
 inherit distutils-r1 optfeature virtualx

--- a/dev-python/ipython/ipython-8.9.0.ebuild
+++ b/dev-python/ipython/ipython-8.9.0.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 PYTHON_REQ_USE='readline,sqlite,threads(+)'
 
 inherit distutils-r1 optfeature virtualx

--- a/dev-python/ipywidgets/ipywidgets-8.0.4.ebuild
+++ b/dev-python/ipywidgets/ipywidgets-8.0.4.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 PYTHON_REQ_USE="threads(+)"
 
 inherit distutils-r1

--- a/dev-python/jupyter_client/jupyter_client-7.4.9.ebuild
+++ b/dev-python/jupyter_client/jupyter_client-7.4.9.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=hatchling
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 PYTHON_REQ_USE="threads(+)"
 
 inherit distutils-r1

--- a/dev-python/jupyter_client/jupyter_client-8.0.2.ebuild
+++ b/dev-python/jupyter_client/jupyter_client-8.0.2.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=hatchling
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 PYTHON_REQ_USE="threads(+)"
 
 inherit distutils-r1

--- a/dev-python/jupyter_client/jupyter_client-8.0.3.ebuild
+++ b/dev-python/jupyter_client/jupyter_client-8.0.3.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=hatchling
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 PYTHON_REQ_USE="threads(+)"
 
 inherit distutils-r1 pypi

--- a/dev-python/jupyter_core/jupyter_core-5.1.5.ebuild
+++ b/dev-python/jupyter_core/jupyter_core-5.1.5.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=hatchling
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 
 inherit distutils-r1
 

--- a/dev-python/jupyter_core/jupyter_core-5.2.0.ebuild
+++ b/dev-python/jupyter_core/jupyter_core-5.2.0.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=hatchling
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 
 inherit distutils-r1
 

--- a/dev-python/matplotlib/matplotlib-3.6.1.ebuild
+++ b/dev-python/matplotlib/matplotlib-3.6.1.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 PYTHON_REQ_USE='tk?,threads(+)'
 
 inherit distutils-r1 flag-o-matic multiprocessing prefix toolchain-funcs \

--- a/dev-python/matplotlib/matplotlib-3.6.2.ebuild
+++ b/dev-python/matplotlib/matplotlib-3.6.2.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 PYTHON_REQ_USE='tk?,threads(+)'
 
 inherit distutils-r1 flag-o-matic multiprocessing prefix toolchain-funcs \

--- a/dev-python/matplotlib/matplotlib-3.6.3.ebuild
+++ b/dev-python/matplotlib/matplotlib-3.6.3.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 PYTHON_REQ_USE='tk?,threads(+)'
 
 inherit distutils-r1 flag-o-matic multiprocessing prefix toolchain-funcs \

--- a/dev-python/matplotlib/matplotlib-3.7.0.ebuild
+++ b/dev-python/matplotlib/matplotlib-3.7.0.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 PYTHON_REQ_USE='tk?,threads(+)'
 
 inherit distutils-r1 flag-o-matic multiprocessing prefix pypi

--- a/dev-python/mypy/mypy-0.991.ebuild
+++ b/dev-python/mypy/mypy-0.991.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 
 inherit distutils-r1 multiprocessing
 

--- a/dev-python/mypy/mypy-1.0.0.ebuild
+++ b/dev-python/mypy/mypy-1.0.0.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 
 inherit distutils-r1 multiprocessing
 

--- a/dev-python/mypy/mypy-1.0.1.ebuild
+++ b/dev-python/mypy/mypy-1.0.1.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 
 inherit distutils-r1 multiprocessing
 

--- a/dev-python/nptyping/nptyping-2.3.1.ebuild
+++ b/dev-python/nptyping/nptyping-2.3.1.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 
 inherit distutils-r1
 

--- a/dev-python/nptyping/nptyping-2.5.0.ebuild
+++ b/dev-python/nptyping/nptyping-2.5.0.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 
 inherit distutils-r1
 

--- a/dev-python/numpy/numpy-1.24.0.ebuild
+++ b/dev-python/numpy/numpy-1.24.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 PYTHON_REQ_USE="threads(+)"
 
 FORTRAN_NEEDED=lapack

--- a/dev-python/prometheus_client/prometheus_client-0.16.0.ebuild
+++ b/dev-python/prometheus_client/prometheus_client-0.16.0.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 
 inherit distutils-r1
 
@@ -21,7 +21,7 @@ S="${WORKDIR}/client_python-${PV}"
 
 LICENSE="Apache-2.0"
 SLOT="0"
-KEYWORDS="amd64 arm arm64 hppa ~ia64 ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
 
 RDEPEND="
 	dev-python/twisted[${PYTHON_USEDEP}]

--- a/dev-python/prompt-toolkit/prompt-toolkit-3.0.36.ebuild
+++ b/dev-python/prompt-toolkit/prompt-toolkit-3.0.36.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 
 inherit distutils-r1 pypi
 

--- a/dev-python/pydata-sphinx-theme/pydata-sphinx-theme-0.7.2-r1.ebuild
+++ b/dev-python/pydata-sphinx-theme/pydata-sphinx-theme-0.7.2-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 DISTUTILS_USE_PEP517=setuptools
 
 inherit distutils-r1

--- a/dev-python/pytest-check/pytest-check-2.1.2.ebuild
+++ b/dev-python/pytest-check/pytest-check-2.1.2.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=flit
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 
 inherit distutils-r1
 

--- a/dev-python/pytest-check/pytest-check-2.1.3.ebuild
+++ b/dev-python/pytest-check/pytest-check-2.1.3.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=flit
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 
 inherit distutils-r1
 

--- a/dev-python/pytest-check/pytest-check-2.1.4.ebuild
+++ b/dev-python/pytest-check/pytest-check-2.1.4.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 DISTUTILS_USE_PEP517=flit
 PYPI_NO_NORMALIZE=1
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 
 inherit distutils-r1 pypi
 

--- a/dev-python/pytest_jupyter/pytest_jupyter-0.6.2.ebuild
+++ b/dev-python/pytest_jupyter/pytest_jupyter-0.6.2.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=hatchling
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 
 inherit distutils-r1
 

--- a/dev-python/qtconsole/qtconsole-5.4.0.ebuild
+++ b/dev-python/qtconsole/qtconsole-5.4.0.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 PYTHON_REQ_USE="threads(+)"
 
 inherit distutils-r1

--- a/dev-python/selenium/selenium-4.5.0.ebuild
+++ b/dev-python/selenium/selenium-4.5.0.ebuild
@@ -7,7 +7,7 @@ EAPI=8
 # but only in a wheel format.
 
 DISTUTILS_USE_PEP517=standalone
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 inherit distutils-r1
 
 DESCRIPTION="Python language binding for Selenium Remote Control"

--- a/dev-python/sip/sip-4.19.25-r1.ebuild
+++ b/dev-python/sip/sip-4.19.25-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{9..10} )
+PYTHON_COMPAT=( python3_{9..10} pypy3 )
 inherit python-r1 toolchain-funcs
 
 DESCRIPTION="Python bindings generator for C/C++ libraries"

--- a/dev-python/sip/sip-6.7.5-r1.ebuild
+++ b/dev-python/sip/sip-6.7.5-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 DISTUTILS_USE_PEP517=setuptools
 
 inherit distutils-r1

--- a/dev-python/sphinx-autodoc-typehints/sphinx-autodoc-typehints-1.22.ebuild
+++ b/dev-python/sphinx-autodoc-typehints/sphinx-autodoc-typehints-1.22.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=hatchling
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 
 inherit distutils-r1
 

--- a/dev-python/sphinxcontrib-github-alt/sphinxcontrib-github-alt-1.2-r2.ebuild
+++ b/dev-python/sphinxcontrib-github-alt/sphinxcontrib-github-alt-1.2-r2.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 
 DISTUTILS_USE_PEP517=flit
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 
 inherit distutils-r1
 

--- a/dev-python/sphinxcontrib-spelling/sphinxcontrib-spelling-7.7.0.ebuild
+++ b/dev-python/sphinxcontrib-spelling/sphinxcontrib-spelling-7.7.0.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 
 inherit distutils-r1
 

--- a/dev-python/sphinxcontrib-spelling/sphinxcontrib-spelling-8.0.0.ebuild
+++ b/dev-python/sphinxcontrib-spelling/sphinxcontrib-spelling-8.0.0.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
 PYPI_NO_NORMALIZE=1
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 
 inherit distutils-r1 pypi
 

--- a/dev-python/sphobjinv/sphobjinv-2.3.1.ebuild
+++ b/dev-python/sphobjinv/sphobjinv-2.3.1.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 
 inherit distutils-r1
 

--- a/dev-python/stdio-mgr/stdio-mgr-1.0.1.ebuild
+++ b/dev-python/stdio-mgr/stdio-mgr-1.0.1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 
 inherit distutils-r1
 

--- a/dev-python/typeguard/typeguard-2.13.3-r1.ebuild
+++ b/dev-python/typeguard/typeguard-2.13.3-r1.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 
 inherit distutils-r1
 

--- a/dev-python/widgetsnbextension/widgetsnbextension-4.0.5.ebuild
+++ b/dev-python/widgetsnbextension/widgetsnbextension-4.0.5.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..11} pypy3 )
 PYTHON_REQ_USE="threads(+)"
 
 inherit distutils-r1


### PR DESCRIPTION
This PR includes all dependencies needed to run ipython on pypy3.

There are multiple build failures at the moment. This PR is being created so that there is a place to discuss specific issues related to the dependency tree.

The commits are not atomic at the moment but can be made so if needs be.

Closes: https://bugs.gentoo.org/729958

Supersedes:
https://github.com/gentoo/gentoo/pull/16466