### PR TITLE
dev-perl/Moo: Add missing Class-XSAccessor dep

### DIFF
--- a/dev-perl/Class-XSAccessor/Class-XSAccessor-1.190.0-r2.ebuild
+++ b/dev-perl/Class-XSAccessor/Class-XSAccessor-1.190.0-r2.ebuild
@@ -1,0 +1,32 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DIST_AUTHOR=SMUELLER
+DIST_VERSION=1.19
+inherit perl-module
+
+DESCRIPTION="Generate fast XS accessors without runtime compilation"
+# License note: perl 5-or-newer
+# https://bugs.gentoo.org/718946#c6
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~m68k ~mips ~ppc ~ppc64 ~riscv ~sparc ~x86 ~ppc-macos ~x86-solaris"
+IUSE="test"
+RESTRICT="!test? ( test )"
+
+RDEPEND="
+	virtual/perl-Time-HiRes
+	virtual/perl-XSLoader
+"
+BDEPEND="${RDEPEND}
+	virtual/perl-ExtUtils-MakeMaker
+	!dev-perl/Class-XSAccessor-Array
+	test? (
+		virtual/perl-Test-Simple
+	)
+"
+src_compile() {
+	mymake=( "OPTIMIZE=${CFLAGS}" )
+	perl-module_src_compile
+}

--- a/dev-perl/Moo/Moo-2.5.4-r1.ebuild
+++ b/dev-perl/Moo/Moo-2.5.4-r1.ebuild
@@ -1,0 +1,30 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DIST_AUTHOR=HAARG
+DIST_VERSION=2.005004
+inherit perl-module
+
+DESCRIPTION="Minimalist Object Orientation (with Moose compatiblity)"
+
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~m68k ~mips ~ppc ~ppc64 ~riscv ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-solaris"
+
+RDEPEND="
+	virtual/perl-Carp
+	>=dev-perl/Class-Method-Modifiers-1.100.0
+	>=virtual/perl-Exporter-5.570.0
+	>=dev-perl/Role-Tiny-2.2.3
+	>=virtual/perl-Scalar-List-Utils-1.0.0
+	>=dev-perl/Sub-Quote-2.6.6
+	>=dev-perl/Class-XSAccessor-1.190.0-r2
+"
+BDEPEND="${RDEPEND}
+	virtual/perl-ExtUtils-MakeMaker
+	test? (
+		>=dev-perl/Test-Fatal-0.3.0
+		>=virtual/perl-Test-Simple-0.940.0
+	)
+"


### PR DESCRIPTION
dev-perl/Moo: Add missing Class-XSAccessor dep

Two commits:
---
    dev-perl/Class-XSAccessor: rev-bump in prep for adding "~ia64 ~s390"

    Those keywords are needed by dev-perl/Moo.

    Bug: https://bugs.gentoo.org/898358
---
    dev-perl/Moo: Add missing Class-XSAccessor dep

    Dropped ~ia64 ~s390 keywords, but will re-request them soon.

    Bug: https://bugs.gentoo.org/898358
    Closes: https://github.com/gentoo/gentoo/pull/29853
---
Diff against previous rev for easier review: 
```diff
--- Moo/Moo-2.5.4.ebuild        2022-05-16 13:23:07.031213309 -0400
+++ Moo/Moo-2.5.4-r1.ebuild     2023-03-12 14:08:35.013824082 -0400
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2

 EAPI=8
@@ -10,7 +10,7 @@
 DESCRIPTION="Minimalist Object Orientation (with Moose compatiblity)"

 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-solaris"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~m68k ~mips ~ppc ~ppc64 ~riscv ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-solaris"

 RDEPEND="
        virtual/perl-Carp
@@ -19,6 +19,7 @@
        >=dev-perl/Role-Tiny-2.2.3
        >=virtual/perl-Scalar-List-Utils-1.0.0
        >=dev-perl/Sub-Quote-2.6.6
+       >=dev-perl/Class-XSAccessor-1.190.0-r2
 "
 BDEPEND="${RDEPEND}
        virtual/perl-ExtUtils-MakeMaker```
```

```diff
--- Class-XSAccessor/Class-XSAccessor-1.190.0-r1.ebuild 2023-03-12 13:48:27.567142032 -0400
+++ Class-XSAccessor/Class-XSAccessor-1.190.0-r2.ebuild 2023-03-12 14:05:07.330836366 -0400
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2

 EAPI=7
@@ -11,7 +11,7 @@
 # License note: perl 5-or-newer
 # https://bugs.gentoo.org/718946#c6
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 hppa ~m68k ~mips ppc ppc64 ~riscv ~sparc x86 ~ppc-macos ~x86-solaris"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~m68k ~mips ~ppc ~ppc64 ~riscv ~sparc ~x86 ~ppc-macos ~x86-solaris"
 IUSE="test"
 RESTRICT="!test? ( test )"
```