### PR TITLE
dev-python/markups: enable py3.11

### DIFF
--- a/dev-python/markups/markups-4.0.0.ebuild
+++ b/dev-python/markups/markups-4.0.0.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..10} )
+PYTHON_COMPAT=( python3_{9..11} )
 
 inherit distutils-r1 pypi
 


### PR DESCRIPTION
Tests pass for all 3 python versions.