### PR TITLE
profiles/prefix: Inherit features/merged-usr

### DIFF
--- a/profiles/prefix/parent
+++ b/profiles/prefix/parent
@@ -1,1 +1,2 @@
 ../features/prefix/rpath
+../features/merged-usr


### PR DESCRIPTION
The Prefix rpath profiles mask the `split-usr` USE flag to force a merged `/usr` layout, so `${EPREFIX}/{bin,lib,sbin}` are symlinks on these profiles.  Now that a `merged-usr` `feature` has been added to the profiles directory, the Prefix rpath profiles can declare this feature as one of its parents.

The `merged-usr` feature adds the `${EPREFIX}/{bin,lib,sbin}` paths to `UNINSTALL_IGNORE`, so Portage no longer emits a "symlinks to directories have been preserved" message whenever a package directly touches files under those symlinked directories.  Otherwise, the message would pop up frequently since those symlinks are not present in the base profile's `UNINSTALL_IGNORE`.