### PR TITLE
app-editors/kakoune: fix gcc13 build bug #895264

### DIFF
--- a/app-editors/kakoune/files/kakoune-2022.10.31-gcc13.patch
+++ b/app-editors/kakoune/files/kakoune-2022.10.31-gcc13.patch
@@ -1,0 +1,29 @@
+https://bugs.gentoo.org/895264
+https://github.com/mawww/kakoune/issues/4854
+
+diff --git a/src/keys.hh b/src/keys.hh
+index 0af1a5a8..ccafe336 100644
+--- a/src/keys.hh
++++ b/src/keys.hh
+@@ -9,6 +9,8 @@
+ #include "unicode.hh"
+ #include "vector.hh"
+
++#include <cstdint>
++
+ namespace Kakoune
+ {
+     
+diff --git a/src/ranked_match.hh b/src/ranked_match.hh
+index ec7fe626..62d6b8f0 100644
+--- a/src/ranked_match.hh
++++ b/src/ranked_match.hh
+@@ -4,6 +4,8 @@
+ #include "string.hh"
+ #include "meta.hh"
+
++#include <cstdint>
++
+ namespace Kakoune
+ {
+ 

--- a/app-editors/kakoune/kakoune-2022.10.31.ebuild
+++ b/app-editors/kakoune/kakoune-2022.10.31.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 Gentoo Authors
+# Copyright 2020-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -14,6 +14,10 @@ SLOT="0"
 KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~x86"
 
 BDEPEND="virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-gcc13.patch
+)
 
 src_prepare() {
 	sed -i '/CXXFLAGS += -O3/d' src/Makefile || die


### PR DESCRIPTION
Fix build with gcc-13.0.0 bug #895264

Closes: https://bugs.gentoo.org/895264