### PR TITLE
sys-block/whdd: Fix install for Gentoo prefix

### DIFF
--- a/sys-block/whdd/whdd-3.0.1-r2.ebuild
+++ b/sys-block/whdd/whdd-3.0.1-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -28,4 +28,8 @@ RDEPEND="${DEPEND}
 src_compile() {
 	tc-export CC
 	default
+}
+
+src_install() {
+	emake DESTDIR="${ED}" install
 }


### PR DESCRIPTION
The default install location is outside prefix