### PR TITLE
app-misc/radeontop: keyword 1.4 for ~arm64

### DIFF
--- a/app-misc/radeontop/radeontop-1.4.ebuild
+++ b/app-misc/radeontop/radeontop-1.4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -11,7 +11,7 @@ SRC_URI="https://github.com/clbr/radeontop/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="GPL-3"
 SLOT="0"
-KEYWORDS="~amd64 ~loong ~ppc64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~loong ~ppc64 ~x86"
 IUSE="nls video_cards_amdgpu video_cards_radeon"
 REQUIRED_USE="
 	|| ( video_cards_amdgpu video_cards_radeon )

--- a/profiles/arch/arm64/use.mask
+++ b/profiles/arch/arm64/use.mask
@@ -133,6 +133,9 @@ snapcast
 -video_cards_tegra
 -video_cards_v3d
 -video_cards_vc4
+-video_cards_amdgpu
+-video_cards_radeon
+-video_cards_radeonsi
 
 # James Le Cuirot <chewi@gentoo.org>
 # Unmask as Vivante is available for arm.
@@ -143,13 +146,10 @@ snapcast
 video_cards_glint
 video_cards_mga
 video_cards_r128
-video_cards_radeon
 
 # Matt Turner <mattst88@gentoo.org>
 # Mask more VIDEO_CARDs added with mesa-8.0
-video_cards_amdgpu
 video_cards_r100
 video_cards_r200
 video_cards_r300
 video_cards_r600
-video_cards_radeonsi

--- a/x11-drivers/xf86-video-amdgpu/xf86-video-amdgpu-23.0.0.ebuild
+++ b/x11-drivers/xf86-video-amdgpu/xf86-video-amdgpu-23.0.0.ebuild
@@ -9,7 +9,7 @@ inherit xorg-3
 if [[ ${PV} == 9999* ]]; then
 	SRC_URI=""
 else
-	KEYWORDS="~amd64 ~loong ~ppc64 ~riscv ~x86"
+	KEYWORDS="~amd64 arm64 ~loong ~ppc64 ~riscv ~x86"
 fi
 
 DESCRIPTION="Accelerated Open Source driver for AMDGPU cards"

--- a/x11-drivers/xf86-video-ati/xf86-video-ati-19.1.0-r1.ebuild
+++ b/x11-drivers/xf86-video-ati/xf86-video-ati-19.1.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -9,7 +9,7 @@ inherit linux-info xorg-3
 if [[ ${PV} == 9999* ]]; then
 	SRC_URI=""
 else
-	KEYWORDS="~alpha amd64 ~ia64 ~loong ppc ppc64 ~riscv sparc x86"
+	KEYWORDS="~alpha amd64 arm64 ~ia64 ~loong ppc ppc64 ~riscv sparc x86"
 fi
 
 DESCRIPTION="ATI video driver"


### PR DESCRIPTION
1. profiles/arch/arm64: unmask amd video_cards
2. keyword x11-drivers: xf86-video-amdgpu xf86-video-ati
3. keyword radeontop