### PR TITLE
x11-libs/cmrt: fix build on musl

### DIFF
--- a/x11-libs/cmrt/cmrt-1.0.6-r3.ebuild
+++ b/x11-libs/cmrt/cmrt-1.0.6-r3.ebuild
@@ -20,6 +20,10 @@ DEPEND="
 "
 RDEPEND="${DEPEND}"
 
+PATCHES=(
+	"${FILESDIR}/${P}-musl-fix.patch"
+)
+
 src_prepare() {
 	default
 	eautoreconf

--- a/x11-libs/cmrt/files/cmrt-1.0.6-musl-fix.patch
+++ b/x11-libs/cmrt/files/cmrt-1.0.6-musl-fix.patch
@@ -1,0 +1,15 @@
+diff --git a/src/os_defs.h b/src/os_defs.h
+index 82794f5..13539ee 100644
+--- a/src/os_defs.h
++++ b/src/os_defs.h
+@@ -109,6 +109,10 @@ typedef struct tagRECT {
+ 
+ #define CONST const
+ 
++#ifndef __CONCAT
++	#define __CONCAT( a1, a2 ) a1 ## a2
++#endif
++
+ #define __UNIQUENAME( a1, a2 )  __CONCAT( a1, a2 )
+ #define UNIQUENAME( __text )    __UNIQUENAME( __text, __COUNTER__ )
+ #define STATIC_ASSERT(e)  typedef char UNIQUENAME(STATIC_ASSERT_)[(e)?1:-1]


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/896238