### PR TITLE
Vim configure-time implicit funtion declarations

### DIFF
--- a/app-editors/gvim/gvim-9.0.1000.ebuild
+++ b/app-editors/gvim/gvim-9.0.1000.ebuild
@@ -90,6 +90,14 @@ fi
 # various failures (bugs #630042 and #682320)
 RESTRICT="test"
 
+# platform-specific checks (bug #898450):
+# - acl()     -- Solaris
+# - statacl() -- AIX
+QA_CONFIG_IMPL_DECL_SKIP=(
+	'acl'
+	'statacl'
+)
+
 pkg_setup() {
 	# people with broken alphabets run into trouble. bug 82186.
 	unset LANG LC_ALL

--- a/app-editors/gvim/gvim-9.0.1157.ebuild
+++ b/app-editors/gvim/gvim-9.0.1157.ebuild
@@ -90,6 +90,14 @@ fi
 # various failures (bugs #630042 and #682320)
 RESTRICT="test"
 
+# platform-specific checks (bug #898450):
+# - acl()     -- Solaris
+# - statacl() -- AIX
+QA_CONFIG_IMPL_DECL_SKIP=(
+	'acl'
+	'statacl'
+)
+
 pkg_setup() {
 	# people with broken alphabets run into trouble. bug 82186.
 	unset LANG LC_ALL

--- a/app-editors/gvim/gvim-9.0.1363.ebuild
+++ b/app-editors/gvim/gvim-9.0.1363.ebuild
@@ -91,6 +91,14 @@ fi
 # various failures (bugs #630042 and #682320)
 RESTRICT="test"
 
+# platform-specific checks (bug #898450):
+# - acl()     -- Solaris
+# - statacl() -- AIX
+QA_CONFIG_IMPL_DECL_SKIP=(
+	'acl'
+	'statacl'
+)
+
 pkg_setup() {
 	# people with broken alphabets run into trouble. bug 82186.
 	unset LANG LC_ALL

--- a/app-editors/gvim/gvim-9999.ebuild
+++ b/app-editors/gvim/gvim-9999.ebuild
@@ -90,6 +90,14 @@ fi
 # various failures (bugs #630042 and #682320)
 RESTRICT="test"
 
+# platform-specific checks (bug #898450):
+# - acl()     -- Solaris
+# - statacl() -- AIX
+QA_CONFIG_IMPL_DECL_SKIP=(
+	'acl'
+	'statacl'
+)
+
 pkg_setup() {
 	# people with broken alphabets run into trouble. bug 82186.
 	unset LANG LC_ALL

--- a/app-editors/vim-core/vim-core-9.0.1000.ebuild
+++ b/app-editors/vim-core/vim-core-9.0.1000.ebuild
@@ -38,6 +38,14 @@ if [[ ${PV} != 9999* ]]; then
 	)
 fi
 
+# platform-specific checks (bug #898406):
+# - acl()     -- Solaris
+# - statacl() -- AIX
+QA_CONFIG_IMPL_DECL_SKIP=(
+	'acl'
+	'statacl'
+)
+
 pkg_setup() {
 	# people with broken alphabets run into trouble. bug #82186.
 	unset LANG LC_ALL

--- a/app-editors/vim-core/vim-core-9.0.1157.ebuild
+++ b/app-editors/vim-core/vim-core-9.0.1157.ebuild
@@ -38,6 +38,14 @@ if [[ ${PV} != 9999* ]]; then
 	)
 fi
 
+# platform-specific checks (bug #898406):
+# - acl()     -- Solaris
+# - statacl() -- AIX
+QA_CONFIG_IMPL_DECL_SKIP=(
+	'acl'
+	'statacl'
+)
+
 pkg_setup() {
 	# people with broken alphabets run into trouble. bug #82186.
 	unset LANG LC_ALL

--- a/app-editors/vim-core/vim-core-9.0.1363.ebuild
+++ b/app-editors/vim-core/vim-core-9.0.1363.ebuild
@@ -38,6 +38,14 @@ if [[ ${PV} != 9999* ]]; then
 	)
 fi
 
+# platform-specific checks (bug #898406):
+# - acl()     -- Solaris
+# - statacl() -- AIX
+QA_CONFIG_IMPL_DECL_SKIP=(
+	'acl'
+	'statacl'
+)
+
 pkg_setup() {
 	# people with broken alphabets run into trouble. bug #82186.
 	unset LANG LC_ALL

--- a/app-editors/vim-core/vim-core-9999.ebuild
+++ b/app-editors/vim-core/vim-core-9999.ebuild
@@ -38,6 +38,14 @@ if [[ ${PV} != 9999* ]]; then
 	)
 fi
 
+# platform-specific checks (bug #898406):
+# - acl()     -- Solaris
+# - statacl() -- AIX
+QA_CONFIG_IMPL_DECL_SKIP=(
+	'acl'
+	'statacl'
+)
+
 pkg_setup() {
 	# people with broken alphabets run into trouble. bug #82186.
 	unset LANG LC_ALL

--- a/app-editors/vim/vim-9.0.1000.ebuild
+++ b/app-editors/vim/vim-9.0.1000.ebuild
@@ -75,6 +75,14 @@ if [[ ${PV} != 9999* ]]; then
 	)
 fi
 
+# platform-specific checks (bug #898452):
+# - acl()     -- Solaris
+# - statacl() -- AIX
+QA_CONFIG_IMPL_DECL_SKIP=(
+	'acl'
+	'statacl'
+)
+
 pkg_setup() {
 	# people with broken alphabets run into trouble. bug #82186.
 	unset LANG LC_ALL

--- a/app-editors/vim/vim-9.0.1157.ebuild
+++ b/app-editors/vim/vim-9.0.1157.ebuild
@@ -75,6 +75,14 @@ if [[ ${PV} != 9999* ]]; then
 	)
 fi
 
+# platform-specific checks (bug #898452):
+# - acl()     -- Solaris
+# - statacl() -- AIX
+QA_CONFIG_IMPL_DECL_SKIP=(
+	'acl'
+	'statacl'
+)
+
 pkg_setup() {
 	# people with broken alphabets run into trouble. bug #82186.
 	unset LANG LC_ALL

--- a/app-editors/vim/vim-9.0.1363.ebuild
+++ b/app-editors/vim/vim-9.0.1363.ebuild
@@ -75,6 +75,14 @@ if [[ ${PV} != 9999* ]]; then
 	)
 fi
 
+# platform-specific checks (bug #898452):
+# - acl()     -- Solaris
+# - statacl() -- AIX
+QA_CONFIG_IMPL_DECL_SKIP=(
+	'acl'
+	'statacl'
+)
+
 pkg_setup() {
 	# people with broken alphabets run into trouble. bug #82186.
 	unset LANG LC_ALL

--- a/app-editors/vim/vim-9999.ebuild
+++ b/app-editors/vim/vim-9999.ebuild
@@ -75,6 +75,14 @@ if [[ ${PV} != 9999* ]]; then
 	)
 fi
 
+# platform-specific checks (bug #898452):
+# - acl()     -- Solaris
+# - statacl() -- AIX
+QA_CONFIG_IMPL_DECL_SKIP=(
+	'acl'
+	'statacl'
+)
+
 pkg_setup() {
 	# people with broken alphabets run into trouble. bug #82186.
 	unset LANG LC_ALL


### PR DESCRIPTION
Ignore platform-specific implicit function declarations in configure logs.

- app-editors/gvim
- app-editors/vim
- app-editors/vim-core