### PR TITLE
app-editors/retext: add python 3.11 to PYTHON_COMPAT, drop Python 3.8

### DIFF
--- a/app-editors/retext/retext-8.0.0.ebuild
+++ b/app-editors/retext/retext-8.0.0.ebuild
@@ -6,7 +6,7 @@ EAPI=8
 # Please don't add pypy support before testing if it's actually supported. The
 # old compat matrix is no longer accessible as of 2021-02-13 but stated back
 # in 2020-07-05 that PyQt5 was explicitly not supported.
-PYTHON_COMPAT=( python3_{8,9,10} )
+PYTHON_COMPAT=( python3_{9..11} )
 
 inherit distutils-r1 optfeature qmake-utils virtualx xdg
 

--- a/app-editors/retext/retext-9999.ebuild
+++ b/app-editors/retext/retext-9999.ebuild
@@ -6,7 +6,7 @@ EAPI=8
 # Please don't add pypy support before testing if it's actually supported. The
 # old compat matrix is no longer accessible as of 2021-02-13 but stated back
 # in 2020-07-05 that PyQt5 was explicitly not supported.
-PYTHON_COMPAT=( python3_{9,10} )
+PYTHON_COMPAT=( python3_{9..11} )
 
 inherit distutils-r1 optfeature qmake-utils virtualx xdg
 


### PR DESCRIPTION
- Added Python 3.11 to PYTHON_COMPAT
- Removed Python 3.8 from PYTHON_COMPAT
- Tested basic functionalities of ReText built with Python 3.11 -> Seems to work fine
- Updated the 9999 ebuild to support Python 3.11