### PR TITLE
app-editors/neovim: fix live ebuild darwin patch

### DIFF
--- a/app-editors/neovim/files/neovim-9999-cmake-darwin.patch
+++ b/app-editors/neovim/files/neovim-9999-cmake-darwin.patch
@@ -4,10 +4,10 @@
  foreach(gen_include ${prop})
    list(APPEND gen_cflags "-I${gen_include}")
  endforeach()
--if(CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND CMAKE_OSX_SYSROOT)
+-if(APPLE AND CMAKE_OSX_SYSROOT)
 -  list(APPEND gen_cflags "-isysroot")
 -  list(APPEND gen_cflags "${CMAKE_OSX_SYSROOT}")
 -endif()
  set(gen_cflags ${gen_cflags} -O2)
- 
+
  set(NVIM_VERSION_GIT_H ${PROJECT_BINARY_DIR}/cmake.config/auto/versiondef_git.h)


### PR DESCRIPTION
With commit https://github.com/neovim/neovim/commit/4cf4ae93df6af09ef3a0df678bb3d154b65bf731 checking against string "Darwin" is removed and variable name APPLE is used instead.