### PR TITLE
sci-mathematics/cvc4: fix build with bash 5.2

### DIFF
--- a/sci-mathematics/cvc4/cvc4-1.8-r4.ebuild
+++ b/sci-mathematics/cvc4/cvc4-1.8-r4.ebuild
@@ -33,6 +33,7 @@ S="${WORKDIR}"/${PN^^}-archived-${PV}
 PATCHES=(
 	"${FILESDIR}"/${P}-gentoo.patch
 	"${FILESDIR}"/${P}-toml.patch
+	"${FILESDIR}"/${P}-bash-5.2-fix.patch
 )
 
 python_check_deps() {

--- a/sci-mathematics/cvc4/files/cvc4-1.8-bash-5.2-fix.patch
+++ b/sci-mathematics/cvc4/files/cvc4-1.8-bash-5.2-fix.patch
@@ -1,0 +1,44 @@
+Description: Fix FTBFS with bash 5.2
+Author: Jerry James <loganjerry@gmail.com>
+Forwarded: no
+Last-Update: 2022-10-17
+Bug: https://bugs.gentoo.org/883273
+See: https://salsa.debian.org/science-team/cvc4/-/merge_requests/2/diffs?commit_id=05ca9eee24e279ddfbaebea7393b4303200141ad
+---
+
+diff --git a/src/expr/mkexpr b/src/expr/mkexpr
+index c5f12f487..642a7ff0d 100755
+--- a/src/expr/mkexpr
++++ b/src/expr/mkexpr
+@@ -16,6 +16,7 @@
+ #
+ 
+ copyright=2010-2014
++shopt -u patsub_replacement
+ 
+ filename=`basename "$1" | sed 's,_template,,'`
+ 
+diff --git a/src/expr/mkkind b/src/expr/mkkind
+index fbf37eff4..77a8fc7e5 100755
+--- a/src/expr/mkkind
++++ b/src/expr/mkkind
+@@ -15,6 +15,7 @@
+ #
+ 
+ copyright=2010-2014
++shopt -u patsub_replacement
+ 
+ filename=`basename "$1" | sed 's,_template,,'`
+ 
+diff --git a/src/expr/mkmetakind b/src/expr/mkmetakind
+index e2a733ec8..935040bed 100755
+--- a/src/expr/mkmetakind
++++ b/src/expr/mkmetakind
+@@ -18,6 +18,7 @@
+ #
+ 
+ copyright=2010-2014
++shopt -u patsub_replacement
+ 
+ cat <<EOF
+ /*********************                                                        */


### PR DESCRIPTION
See: https://salsa.debian.org/science-team/cvc4/-/merge_requests/2/diffs?commit_id=05ca9eee24e279ddfbaebea7393b4303200141ad
Closes: https://bugs.gentoo.org/883273

Signed-off-by: Kai-Chun Ning [kaichun.ning@gmail.com](mailto:kaichun.ning@gmail.com)