### PR TITLE
dev-libs/zziplib: add python 3.11 to PYTHON_COMPAT

### DIFF
--- a/dev-libs/zziplib/zziplib-0.13.72-r3.ebuild
+++ b/dev-libs/zziplib/zziplib-0.13.72-r3.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{9..10} )
+PYTHON_COMPAT=( python3_{9..11} )
 # Needed for docs, bug #835755
 PYTHON_REQ_USE="xml(+)"
 inherit cmake flag-o-matic python-any-r1


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/896738

Signed-off-by: Kai-Chun Ning [kaichun.ning@gmail.com](mailto:kaichun.ning@gmail.com)