### PR TITLE
gui-libs/wlroots-9999: add missing libdisplay-info dependency

### DIFF
--- a/gui-libs/wlroots/wlroots-9999.ebuild
+++ b/gui-libs/wlroots/wlroots-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -26,6 +26,7 @@ DEPEND="
 	>=dev-libs/wayland-1.21.0
 	>=dev-libs/wayland-protocols-1.28
 	media-libs/mesa[egl(+),gles2]
+	media-libs/libdisplay-info:=
 	hwdata? ( sys-apps/hwdata:= )
 	seatd? ( sys-auth/seatd:= )
 	udev? ( virtual/libudev )


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/899076

gui-libs/wlroots now depends on libdisplay-info for the DRM backend: https://gitlab.freedesktop.org/wlroots/wlroots/-/commit/35da9970019be6580394d5d6234b8ede0b2f0d5a