### PR TITLE
gui-apps/grim: update HOMEPAGE/EGIT_REPO_URI and metadata.xml

### DIFF
--- a/gui-apps/grim/grim-1.4.0-r1.ebuild
+++ b/gui-apps/grim/grim-1.4.0-r1.ebuild
@@ -6,14 +6,15 @@ EAPI=8
 inherit bash-completion-r1 meson
 
 DESCRIPTION="Grab images from a Wayland compositor"
-HOMEPAGE="https://github.com/emersion/grim"
+HOMEPAGE="https://sr.ht/~emersion/grim"
 
 if [[ ${PV} == 9999 ]]; then
 	inherit git-r3
-	EGIT_REPO_URI="https://github.com/emersion/${PN}.git"
+	EGIT_REPO_URI="https://git.sr.ht/~emersion/${PN}"
 else
 	SRC_URI="https://github.com/emersion/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 	KEYWORDS="amd64 arm64 ~loong ~ppc64 ~riscv x86"
+	#S="${WORKDIR}/${PN}-v${PV}"
 fi
 
 LICENSE="MIT"

--- a/gui-apps/grim/grim-1.4.0-r3.ebuild
+++ b/gui-apps/grim/grim-1.4.0-r3.ebuild
@@ -6,14 +6,15 @@ EAPI=8
 inherit bash-completion-r1 meson
 
 DESCRIPTION="Grab images from a Wayland compositor"
-HOMEPAGE="https://github.com/emersion/grim"
+HOMEPAGE="https://sr.ht/~emersion/grim"
 
 if [[ ${PV} == 9999 ]]; then
 	inherit git-r3
-	EGIT_REPO_URI="https://github.com/emersion/${PN}.git"
+	EGIT_REPO_URI="https://git.sr.ht/~emersion/${PN}"
 else
 	SRC_URI="https://github.com/emersion/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 	KEYWORDS="~amd64 ~arm64 ~loong ~ppc64 ~riscv ~x86"
+	#S="${WORKDIR}/${PN}-v${PV}"
 fi
 
 LICENSE="MIT"

--- a/gui-apps/grim/grim-9999.ebuild
+++ b/gui-apps/grim/grim-9999.ebuild
@@ -6,14 +6,15 @@ EAPI=8
 inherit bash-completion-r1 meson
 
 DESCRIPTION="Grab images from a Wayland compositor"
-HOMEPAGE="https://github.com/emersion/grim"
+HOMEPAGE="https://sr.ht/~emersion/grim"
 
 if [[ ${PV} == 9999 ]]; then
 	inherit git-r3
-	EGIT_REPO_URI="https://github.com/emersion/${PN}.git"
+	EGIT_REPO_URI="https://git.sr.ht/~emersion/${PN}"
 else
 	SRC_URI="https://github.com/emersion/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 	KEYWORDS="~amd64 ~arm64 ~loong ~ppc64 ~riscv ~x86"
+	#S="${WORKDIR}/${PN}-v${PV}"
 fi
 
 LICENSE="MIT"

--- a/gui-apps/grim/metadata.xml
+++ b/gui-apps/grim/metadata.xml
@@ -10,7 +10,7 @@
 	</use>
 	<upstream>
 		<remote-id type="sourcehut">~emersion/grim</remote-id>
-		<bugs-to>https://github.com/emersion/grim/issues</bugs-to>
-		<changelog>https://github.com/emersion/grim/releases</changelog>
+		<bugs-to>https://todo.sr.ht/~emersion/grim</bugs-to>
+		<changelog>https://git.sr.ht/~emersion/grim/refs</changelog>
 	</upstream>
 </pkgmetadata>


### PR DESCRIPTION
Upstream was moved to https://git.sr.ht/~emersion/grim some time ago already.