### PR TITLE
media-sound/guitarix: EAPI 8 and py3.11

### DIFF
--- a/media-sound/guitarix/files/guitarix-0.41.0-py3.11.patch
+++ b/media-sound/guitarix/files/guitarix-0.41.0-py3.11.patch
@@ -1,0 +1,26 @@
+From 39d7c21c4173eb0f121b1bbff439d9cf43331a00 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Hubert=20Figui=C3=A8re?= <hub@figuiere.net>
+Date: Wed, 11 Jan 2023 18:55:36 -0500
+Subject: [PATCH] waf: python 3.11 removed the 'U' open mode
+
+Python3 deprecated it already by making this the default behaviour.
+---
+ trunk/wscript | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/trunk/wscript b/trunk/wscript
+index 947fd3d1..3f1f5cf3 100644
+--- a/wscript
++++ b/wscript
+@@ -537,7 +537,7 @@ def sub_file(task):
+     dst_fname = task.outputs[0].abspath()
+     lst = task.generator.sub_list
+ 
+-    with open(src_fname, 'rU') as f:
++    with open(src_fname, 'r') as f:
+         txt = f.read()
+     for (key, val) in lst:
+         re_pat = re.compile(key, re.M)
+-- 
+2.39.2
+

--- a/media-sound/guitarix/guitarix-0.44.1.ebuild
+++ b/media-sound/guitarix/guitarix-0.44.1.ebuild
@@ -1,18 +1,16 @@
 # Copyright 2019-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
-PYTHON_COMPAT=( python3_{9..10} )
+PYTHON_COMPAT=( python3_{9..11} )
 PYTHON_REQ_USE='threads(+)'
 
 inherit python-any-r1 waf-utils xdg
 
-MY_P="${PN}2-${PV}"
-
 DESCRIPTION="Virtual guitar amplifier for Linux"
 HOMEPAGE="https://guitarix.org/"
-SRC_URI="mirror://sourceforge/guitarix/guitarix/${MY_P}.tar.xz"
+SRC_URI="https://github.com/brummer10/${PN}/releases/download/V${PV}/guitarix2-${PV}.tar.xz"
 
 LICENSE="GPL-2"
 SLOT="0"
@@ -65,6 +63,7 @@ DOCS=( changelog README )
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-0.41.0-nostrip.patch
+	"${FILESDIR}"/${PN}-0.41.0-py3.11.patch
 )
 
 src_configure() {

--- a/media-sound/guitarix/guitarix-9999.ebuild
+++ b/media-sound/guitarix/guitarix-9999.ebuild
@@ -1,9 +1,9 @@
 # Copyright 2019-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
-PYTHON_COMPAT=( python3_{9..10} )
+PYTHON_COMPAT=( python3_{9..11} )
 PYTHON_REQ_USE='threads(+)'
 
 EGIT_OVERRIDE_REPO_ENYOJS_BOOTPLATE="https://github.com/enyojs/bootplate.git"
@@ -11,11 +11,9 @@ EGIT_OVERRIDE_BRANCH_ENYOJS_BOOTPLATE="master"
 
 inherit python-any-r1 waf-utils xdg git-r3
 
-MY_P="${PN}2-${PV}"
-
 DESCRIPTION="Virtual guitar amplifier for Linux"
 HOMEPAGE="https://guitarix.org/"
-EGIT_REPO_URI="https://git.code.sf.net/p/guitarix/git"
+EGIT_REPO_URI="https://github.com/brummer10/${PN}.git"
 S="${WORKDIR}/${P}/trunk"
 
 LICENSE="GPL-2"

--- a/media-sound/guitarix/metadata.xml
+++ b/media-sound/guitarix/metadata.xml
@@ -18,4 +18,7 @@
 		<flag name="nsm">Build NSM (Non Session Manager) support</flag>
 		<flag name="standalone">Build standalone application</flag>
 	</use>
+	<upstream>
+		<remote-id type="github">brummer10/guitarix</remote-id>
+	</upstream>
 </pkgmetadata>


### PR DESCRIPTION
Also switch to github repo. SourceForge repo is outdated.

Closes: https://bugs.gentoo.org/897030