### PR TITLE
media-sound/klick: EAPI 8 and py3.11

### DIFF
--- a/media-sound/klick/klick-0.12.2-r4.ebuild
+++ b/media-sound/klick/klick-0.12.2-r4.ebuild
@@ -1,9 +1,9 @@
 # Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
-PYTHON_COMPAT=( python3_{9..10} )
+PYTHON_COMPAT=( python3_{9..11} )
 
 inherit python-any-r1 scons-utils toolchain-funcs
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/897034