### PR TITLE
dev-java/junit: Update HOMEPAGE for 4.13.2

### DIFF
--- a/dev-java/junit/junit-4.13.2.ebuild
+++ b/dev-java/junit/junit-4.13.2.ebuild
@@ -12,7 +12,7 @@ MAVEN_ID="junit:junit:4.13.2"
 inherit java-pkg-2 java-pkg-simple
 
 DESCRIPTION="Simple framework to write repeatable tests"
-HOMEPAGE="https://junit.org/junit5/"
+HOMEPAGE="https://junit.org/junit4/"
 SRC_URI="https://github.com/${PN}-team/${PN}4/archive/refs/tags/r${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="EPL-1.0"


### PR DESCRIPTION
JUnit 4 has a dedicated homepage, so it is better to use that homepage instead of the JUnit 5 homepage.