### PR TITLE
profiles/package.mask: do not remove picocli

### DIFF
--- a/dev-java/picocli/picocli-4.6.3-r1.ebuild
+++ b/dev-java/picocli/picocli-4.6.3-r1.ebuild
@@ -1,8 +1,5 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
-
-# Skeleton command:
-# java-ebuilder --generate-ebuild --workdir . --pom pom.xml --download-uri https://github.com/remkop/picocli/archive/refs/tags/v4.6.3.tar.gz --slot 0 --keywords "~amd64 ~arm64 ~ppc64 ~x86" --ebuild picocli-4.6.3.ebuild
 
 EAPI=8
 

--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -243,7 +243,6 @@ dev-java/jcip-annotations
 dev-java/jformatstring
 dev-java/jta
 dev-java/pdf-renderer
-dev-java/picocli
 
 # Florian Schmaus <flow@gentoo.org> (2023-02-10)
 # Previous dependencies of ejabberd, now no longer needed.


### PR DESCRIPTION
It will be needed for junit-5