### PR TITLE
net-libs/xdp-tools: properly configure PREFIX/LIBDIR/BPF_OBJECT_DIR

### DIFF
--- a/net-libs/xdp-tools/xdp-tools-1.3.1-r1.ebuild
+++ b/net-libs/xdp-tools/xdp-tools-1.3.1-r1.ebuild
@@ -36,6 +36,9 @@ PATCHES=(
 )
 
 src_configure() {
+	export PREFIX="${EPREFIX}/usr"
+	export LIBDIR="${PREFIX}/$(get_libdir)"
+	export BPF_OBJECT_DIR="${PREFIX}/lib/bpf"
 	export PRODUCTION=1
 	export DYNAMIC_LIBXDP=1
 	export FORCE_SYSTEM_LIBBPF=1
@@ -45,9 +48,6 @@ src_configure() {
 src_test() { :; }
 
 src_install() {
-	export PREFIX="${EPREFIX}/usr"
-	export LIBDIR="${PREFIX}/$(get_libdir)"
-	export BPF_OBJECT_DIR="${PREFIX}/lib/bpf"
 	default
 
 	# To remove the scripts/testing files that are installed.


### PR DESCRIPTION
The helper objects were installed correctly, but libxdp had the wrong search path compiled in; this broke xdp-loader.

Closes: https://bugs.gentoo.org/899910
Bug: https://github.com/xdp-project/xdp-tools/issues/303
