### PR TITLE
sys-kernel/linux-firmware: add option to compress with zstd

### DIFF
--- a/sys-kernel/linux-firmware/metadata.xml
+++ b/sys-kernel/linux-firmware/metadata.xml
@@ -19,6 +19,8 @@
 </maintainer>
 <use>
 	<flag name="compress">Compress firmware using xz (<pkg>app-arch/xz-utils</pkg>) before installation</flag>
+	<flag name="compress-xz">Compress firmware using xz (<pkg>app-arch/xz-utils</pkg>) before installation</flag>
+	<flag name="compress-zstd">Compress firmware using zstd (<pkg>app-arch/zstd</pkg>) before installation</flag>
 	<flag name="initramfs">Create and install initramfs for early microcode loading in /boot (only AMD for now)</flag>
 	<flag name="redistributable">Install also non-free (but redistributable) firmware files</flag>
 	<flag name="savedconfig">Allows individual selection of firmware files</flag>


### PR DESCRIPTION
With compression level 15 zstd is still much faster than xz and allows to save some space compared to default level 3:
* uncompressed: 872M
* zstd:         412M
* zstd (-15):   400M
* xz:           364M

Also some fixes:
* do not rename symlinks pointing to directories
* add missing build-time dependencies
* call linux_config_exists before doing kernel config checks

Closes: https://bugs.gentoo.org/899958