### PR TITLE
dev-python/poetry-core: add missing BDEPENDs

### DIFF
--- a/dev-python/poetry-core/poetry-core-1.5.1.ebuild
+++ b/dev-python/poetry-core/poetry-core-1.5.1.ebuild
@@ -31,6 +31,7 @@ RDEPEND="
 	dev-python/tomlkit[${PYTHON_USEDEP}]
 "
 BDEPEND="
+	${RDEPEND}
 	test? (
 		dev-python/build[${PYTHON_USEDEP}]
 		dev-python/pep517[${PYTHON_USEDEP}]


### PR DESCRIPTION
poetry-core requires tomlkit, jsonschema, and lark to be present at build time