### PR TITLE
dev-lang/ruby: fix 901-musl-stacksize.patch for 3.2

### DIFF
--- a/dev-lang/ruby/files/3.2/901-musl-stacksize.patch
+++ b/dev-lang/ruby/files/3.2/901-musl-stacksize.patch
@@ -2,10 +2,10 @@ musl has a conservative stacksize, as compared to glibc, so treat it
 like other systems with such stacksize
 
 diff --git a/thread_pthread.c b/thread_pthread.c
-index 951885ffa0..e2d662143b 100644
+index aa5435a..074510a 100644
 --- a/thread_pthread.c
 +++ b/thread_pthread.c
-@@ -721,7 +721,7 @@ ruby_init_stack(volatile VALUE *addr
+@@ -1033,7 +1033,7 @@ ruby_init_stack(volatile VALUE *addr)
  {
      native_main_thread.id = pthread_self();
  
@@ -13,14 +13,14 @@ index 951885ffa0..e2d662143b 100644
 +#if MAINSTACKADDR_AVAILABLE && !(defined(__linux__) && !defined(__GLIBC__))
      if (native_main_thread.stack_maxsize) return;
      {
-        void* stackaddr;
-@@ -1680,7 +1680,7 @@ ruby_stack_overflowed_p(const rb_thread_t *th, const void *addr)
-
+         void* stackaddr;
+@@ -2090,7 +2090,7 @@ ruby_stack_overflowed_p(const rb_thread_t *th, const void *addr)
+ 
  #ifdef STACKADDR_AVAILABLE
      if (get_stack(&base, &size) == 0) {
 -# ifdef __APPLE__
 +# if defined(__APPLE__) || (defined(__linux__) && !defined(__GLIBC__))
- 	if (pthread_equal(th->thread_id, native_main_thread.id)) {
- 	    struct rlimit rlim;
- 	    if (getrlimit(RLIMIT_STACK, &rlim) == 0 && rlim.rlim_cur > size) {
+         if (pthread_equal(th->nt->thread_id, native_main_thread.id)) {
+             struct rlimit rlim;
+             if (getrlimit(RLIMIT_STACK, &rlim) == 0 && rlim.rlim_cur > size) {
 


### PR DESCRIPTION
901-musl-stacksize.patch fails to apply on ruby 3.2. I've rebased it against 3.2, it should work fine now.