### PR TITLE
dev-cpp/highway: fix tests with neon optimization on armv7

### DIFF
--- a/dev-cpp/highway/files/0002-fix-armv7-neon-detect-via-asm-hwcap.patch
+++ b/dev-cpp/highway/files/0002-fix-armv7-neon-detect-via-asm-hwcap.patch
@@ -1,0 +1,29 @@
+https://github.com/google/highway/commit/f3a33e8204b69f9e21b5fbd8036c11128cec0d2e.patch
+https://github.com/google/highway/issues/1199
+
+https://bugs.gentoo.org/900352
+
+From f3a33e8204b69f9e21b5fbd8036c11128cec0d2e Mon Sep 17 00:00:00 2001
+From: Jan Wassenberg <janwas@google.com>
+Date: Tue, 7 Mar 2023 22:59:17 -0800
+Subject: [PATCH] fix arm7 NEON detect, thanks @stefson. Fixes #1199
+
+PiperOrigin-RevId: 514940076
+---
+ hwy/targets.cc | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/hwy/targets.cc b/hwy/targets.cc
+index dc4217c..24fcaf7 100644
+--- a/hwy/targets.cc
++++ b/hwy/targets.cc
+@@ -43,6 +43,9 @@
+ #endif  // HWY_COMPILER_MSVC
+ 
+ #elif HWY_ARCH_ARM && HWY_OS_LINUX && !defined(TOOLCHAIN_MISS_SYS_AUXV_H)
++// sys/auxv.h does not always include asm/hwcap.h, or define HWCAP*, hence we
++// still include this directly. See #1199.
++#include <asm/hwcap.h>
+ #include <sys/auxv.h>
+ #endif  // HWY_ARCH_*
+ 

--- a/dev-cpp/highway/highway-1.0.3-r1.ebuild
+++ b/dev-cpp/highway/highway-1.0.3-r1.ebuild
@@ -1,0 +1,42 @@
+# Copyright 2021-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit cmake-multilib
+
+DESCRIPTION="Performance-portable, length-agnostic SIMD with runtime dispatch"
+HOMEPAGE="https://github.com/google/highway"
+
+if [[ "${PV}" == *9999* ]]; then
+	inherit git-r3
+	EGIT_REPO_URI="https://github.com/google/highway.git"
+else
+	SRC_URI="https://github.com/google/highway/archive/refs/tags/${PV}.tar.gz -> ${P}.tar.gz"
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86"
+fi
+
+LICENSE="Apache-2.0"
+SLOT="0"
+IUSE="cpu_flags_arm_neon test"
+
+DEPEND="test? ( dev-cpp/gtest[${MULTILIB_USEDEP}] )"
+
+RESTRICT="!test? ( test )"
+
+PATCHES=(
+	"${FILESDIR}"/0001-fix-compile-for-armv7-targets-with-vfp4-and-lower.patch
+	"${FILESDIR}"/0002-fix-armv7-neon-detect-via-asm-hwcap.patch
+)
+
+multilib_src_configure() {
+	local mycmakeargs=(
+		-DHWY_CMAKE_ARM7=$(usex cpu_flags_arm_neon)
+		-DBUILD_TESTING=$(usex test)
+		-DHWY_WARNINGS_ARE_ERRORS=OFF
+	)
+
+	use test && mycmakeargs+=( "-DHWY_SYSTEM_GTEST=ON" )
+
+	cmake_src_configure
+}


### PR DESCRIPTION
This is an important fixup, because it now allows using NEON on Armv7 in runtime dispatch mode. I decided to add revision -r1, as it doesn't fix a compile failure. 

Closes: https://bugs.gentoo.org/900352