### PR TITLE
media-libs/x264: add check for MSA instructions on mips 

### DIFF
--- a/media-libs/x264/x264-0.0.20220222.ebuild
+++ b/media-libs/x264/x264-0.0.20220222.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-inherit multilib-minimal toolchain-funcs
+inherit multilib-minimal toolchain-funcs flag-o-matic
 
 DESCRIPTION="A free library for encoding X264/AVC streams"
 HOMEPAGE="https://www.videolan.org/developers/x264.html"
@@ -41,7 +41,13 @@ multilib_src_configure() {
 
 	local asm_conf=""
 
-	if [[ ${ABI} == x86* ]] && { use pic || use !cpu_flags_x86_sse ; } || [[ ${ABI} == "x32" ]] || [[ ${CHOST} == armv5* ]] || [[ ${ABI} == ppc* ]] && { use !cpu_flags_ppc_altivec ; }; then
+	if \
+		[[ ${ABI} == x86* ]] && { use pic || use !cpu_flags_x86_sse ; } \
+		|| [[ ${ABI} == "x32" ]] \
+		|| [[ ${CHOST} == armv5* ]] \
+		|| [[ ${ABI} == ppc* ]] && { use !cpu_flags_ppc_altivec ; } \
+		|| use mips && { ! test-compile 'c' 'int main(void){__asm__("addvi.b $w0, $w1, 1");return 0;}' ; }
+	then
 		asm_conf=" --disable-asm"
 	fi
 

--- a/media-libs/x264/x264-9999.ebuild
+++ b/media-libs/x264/x264-9999.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-inherit multilib-minimal toolchain-funcs
+inherit multilib-minimal toolchain-funcs flag-o-matic
 
 DESCRIPTION="A free library for encoding X264/AVC streams"
 HOMEPAGE="https://www.videolan.org/developers/x264.html"
@@ -41,7 +41,13 @@ multilib_src_configure() {
 
 	local asm_conf=""
 
-	if [[ ${ABI} == x86* ]] && { use pic || use !cpu_flags_x86_sse ; } || [[ ${ABI} == "x32" ]] || [[ ${CHOST} == armv5* ]] || [[ ${ABI} == ppc* ]] && { use !cpu_flags_ppc_altivec ; }; then
+	if \
+		[[ ${ABI} == x86* ]] && { use pic || use !cpu_flags_x86_sse ; } \
+		|| [[ ${ABI} == "x32" ]] \
+		|| [[ ${CHOST} == armv5* ]] \
+		|| [[ ${ABI} == ppc* ]] && { use !cpu_flags_ppc_altivec ; } \
+		|| use mips && { ! test-compile 'c' 'int main(void){__asm__("addvi.b $w0, $w1, 1");return 0;}' ; }
+	then
 		asm_conf=" --disable-asm"
 	fi
 


### PR DESCRIPTION
Implements the configure check from https://github.com/mirror/x264/commit/ce0757d9d2778e349a7c2f6445b6aa75d8765c30, which bails out if MSA instructions are not available per CFLAGS.

eclass change in ML:  https://archives.gentoo.org/gentoo-dev/message/0f3f09eb21e8b38b0000c240e62b949a