### PR TITLE
net-libs/xdp-tools: various build improvements

### DIFF
--- a/net-libs/xdp-tools/files/1.3.1-no-Werror.patch
+++ b/net-libs/xdp-tools/files/1.3.1-no-Werror.patch
@@ -1,0 +1,97 @@
+
+Bug: https://bugs.gentoo.org/899744
+
+diff --git a/configure b/configure
+index 62c2f88..230637f 100755
+--- a/configure
++++ b/configure
+@@ -249,7 +249,7 @@ int main(int argc, char **argv) {
+     return 0;
+ }
+ EOF
+-    compile_cmd="$CC -o $TMPDIR/libbpftest $TMPDIR/libbpftest.c -Werror $LIBBPF_CFLAGS $LIBBPF_LDLIBS"
++    compile_cmd="$CC -o $TMPDIR/libbpftest $TMPDIR/libbpftest.c $LIBBPF_CFLAGS $LIBBPF_LDLIBS"
+     libbpf_err=$($compile_cmd 2>&1)
+     if [ "$?" -eq "0" ]; then
+         echo "HAVE_FEATURES+=${config_var}" >>"$CONFIG"
+@@ -323,7 +323,7 @@ int main(int argc, char **argv) {
+ }
+ EOF
+ 
+-        libbpf_err=$($CC -o $TMPDIR/libbpftest $TMPDIR/libbpftest.c -Werror $LIBBPF_CFLAGS $LIBBPF_LDLIBS 2>&1)
++        libbpf_err=$($CC -o $TMPDIR/libbpftest $TMPDIR/libbpftest.c $LIBBPF_CFLAGS $LIBBPF_LDLIBS 2>&1)
+         if [ "$?" -eq "0" ]; then
+             echo "SYSTEM_LIBBPF:=y" >>$CONFIG
+             echo "LIBBPF_VERSION=$LIBBPF_VERSION" >>$CONFIG
+diff --git a/lib/Makefile b/lib/Makefile
+index 5ee035d..5342ab3 100644
+--- a/lib/Makefile
++++ b/lib/Makefile
+@@ -1,5 +1,5 @@
+ 
+-LIBBPF_CFLAGS:=$(if $(CFLAGS),$(CFLAGS),-g -O2 -Werror -Wall) -fPIC
++LIBBPF_CFLAGS:=$(if $(CFLAGS),$(CFLAGS),-g -O2 -Wall) -fPIC
+ 
+ LIB_DIR = .
+ include defines.mk
+diff --git a/lib/common.mk b/lib/common.mk
+index b680a75..8dbcb39 100644
+--- a/lib/common.mk
++++ b/lib/common.mk
+@@ -116,7 +116,6 @@ $(XDP_OBJ): %.o: %.c $(KERN_USER_H) $(EXTRA_DEPS) $(BPF_HEADERS) $(LIBMK)
+ 	    -Wno-unused-value \
+ 	    -Wno-pointer-sign \
+ 	    -Wno-compare-distinct-pointer-types \
+-	    -Werror \
+ 	    -O2 -emit-llvm -c -g -o ${@:.o=.ll} $<
+ 	$(QUIET_LLC)$(LLC) -march=$(BPF_TARGET) -filetype=obj -o $@ ${@:.o=.ll}
+ 
+diff --git a/lib/defines.mk b/lib/defines.mk
+index 54b259f..ed246c0 100644
+--- a/lib/defines.mk
++++ b/lib/defines.mk
+@@ -40,7 +40,7 @@ endif
+ 
+ DEFINES += -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64
+ 
+-CFLAGS += -std=gnu11 -Wextra -Werror $(DEFINES)
++CFLAGS += -std=gnu11 -Wextra $(DEFINES)
+ BPF_CFLAGS += $(DEFINES) $(filter -ffile-prefix-map=%,$(CFLAGS))
+ 
+ CONFIGMK := $(LIB_DIR)/../config.mk
+diff --git a/lib/libxdp/Makefile b/lib/libxdp/Makefile
+index 431932a..a0c625d 100644
+--- a/lib/libxdp/Makefile
++++ b/lib/libxdp/Makefile
+@@ -142,7 +142,6 @@ $(XDP_OBJS): %.o: %.c $(BPF_HEADERS) $(LIBMK)
+ 	    -Wno-unused-value \
+ 	    -Wno-pointer-sign \
+ 	    -Wno-compare-distinct-pointer-types \
+-	    -Werror \
+ 	    -O2 -emit-llvm -c -g -o ${@:.o=.ll} $<
+ 	$(QUIET_LLC)$(LLC) -march=$(BPF_TARGET) -filetype=obj -o $@ ${@:.o=.ll}
+ 
+diff --git a/lib/libxdp/tests/Makefile b/lib/libxdp/tests/Makefile
+index 3c22901..a4463f3 100644
+--- a/lib/libxdp/tests/Makefile
++++ b/lib/libxdp/tests/Makefile
+@@ -72,7 +72,6 @@ $(BPF_OBJS): %.o: %.c $(BPF_HEADERS) $(LIBMK) $(EXTRA_DEPS)
+ 	    -Wno-unused-value \
+ 	    -Wno-pointer-sign \
+ 	    -Wno-compare-distinct-pointer-types \
+-	    -Werror \
+ 	    -O2 -emit-llvm -c -g -o ${@:.o=.ll} $<
+ 	$(QUIET_LLC)$(LLC) -march=$(BPF_TARGET) -filetype=obj -o $@ ${@:.o=.ll}
+ 
+diff --git a/lib/util/Makefile b/lib/util/Makefile
+index 24070f0..37485b3 100644
+--- a/lib/util/Makefile
++++ b/lib/util/Makefile
+@@ -26,7 +26,6 @@ $(UTIL_BPF_OBJS): %.o: %.c $(KERN_USER_H) $(BPF_HEADERS) $(LIBMK)
+ 	    -Wno-unused-value \
+ 	    -Wno-pointer-sign \
+ 	    -Wno-compare-distinct-pointer-types \
+-	    -Werror \
+ 	    -O2 -emit-llvm -c -g -o ${@:.o=.ll} $<
+ 	$(QUIET_LLC)$(LLC) -march=$(BPF_TARGET) -filetype=obj -o $@ ${@:.o=.ll}
+ 

--- a/net-libs/xdp-tools/files/1.3.1-xdpdump-clang.patch
+++ b/net-libs/xdp-tools/files/1.3.1-xdpdump-clang.patch
@@ -1,0 +1,36 @@
+
+From:  https://github.com/xdp-project/xdp-tools/commit/344b241da22a5358c714d6db1ea6f225f951dbdb
+
+From 344b241da22a5358c714d6db1ea6f225f951dbdb Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Holger=20Hoffst=C3=A4tte?= <holger@applied-asynchrony.com>
+Date: Wed, 8 Mar 2023 18:50:56 +0100
+Subject: [PATCH] xdpdump: fix build with clang
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+When building all of xdp-tools with clang, the xdp-dump build fails
+due to 'classic' use of variable-length arrays and -Werror.
+Disable the warning and leave a breadcrumb to the discussion.
+
+Fixes: #304
+Signed-off-by: Holger Hoffstätte <holger@applied-asynchrony.com>
+---
+ xdp-dump/Makefile | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/xdp-dump/Makefile b/xdp-dump/Makefile
+index 7ee1688e..a9ae0ae7 100644
+--- a/xdp-dump/Makefile
++++ b/xdp-dump/Makefile
+@@ -4,6 +4,10 @@ XDP_TARGETS  := xdpdump_bpf xdpdump_xdp
+ USER_TARGETS := xdpdump
+ TEST_FILE    := tests/test-xdpdump.sh
+ 
++# Disable warnings about VLAs not being at the end of a structure when building
++# with clang. The code is fine, but clang's complaint coupled with -Werror would
++# break the build. See https://github.com/xdp-project/xdp-tools/issues/304
++CFLAGS       += "-Wno-gnu-variable-sized-type-not-at-end"
+ LIB_DIR       = ../lib
+ USER_LIBS     = -lpcap
+ MAN_PAGE     := xdpdump.8


### PR DESCRIPTION
Assorted build improvements that lingered in Bugzilla:

- disable LTO
- remove -Werror from Makefiles
- fix xdpdump build error with clang

Bug: https://bugs.gentoo.org/861587
Bug: https://bugs.gentoo.org/880919
Bug: https://bugs.gentoo.org/899744
