### PR TITLE
media-sound/jack: enable py3.11

### DIFF
--- a/media-sound/jack/jack-4.0.0_pre20201220-r1.ebuild
+++ b/media-sound/jack/jack-4.0.0_pre20201220-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{9..10} )
+PYTHON_COMPAT=( python3_{9..11} )
 PYTHON_REQ_USE="ncurses"
 DISTUTILS_SINGLE_IMPL=1
 


### PR DESCRIPTION
media-sound/jack: enable py3.11

Closes: https://bugs.gentoo.org/897032
Signed-off-by: Martin Dummer <martin.dummer@gmx.net>