### PR TITLE
dev-lang/haxe: Add strip restriction to 4.2.4, revbump

### DIFF
--- a/dev-lang/haxe/haxe-4.2.4-r4.ebuild
+++ b/dev-lang/haxe/haxe-4.2.4-r4.ebuild
@@ -44,6 +44,7 @@ BDEPEND="
 	dev-ml/findlib
 "
 
+RESTRICT="strip"
 QA_FLAGS_IGNORED="usr/bin/haxelib"
 QA_PRESTRIPPED="usr/bin/haxelib"
 


### PR DESCRIPTION
This addresses the same issue that was prevalent in 4.2.5 prior to its revision bump. Apologies for not taking note of this earlier.