### PR TITLE
app-crypt/tpm2-tss: Build fix for multilib systems

### DIFF
--- a/app-crypt/tpm2-tss/tpm2-tss-4.0.1.ebuild
+++ b/app-crypt/tpm2-tss/tpm2-tss-4.0.1.ebuild
@@ -22,6 +22,7 @@ REQUIRED_USE="^^ ( mbedtls openssl )
 
 RDEPEND="acct-group/tss
 	acct-user/tss
+	sys-apps/util-linux:=[${MULTILIB_USEDEP}]
 	fapi? ( dev-libs/json-c:=[${MULTILIB_USEDEP}]
 		>=net-misc/curl-7.80.0[${MULTILIB_USEDEP}] )
 	mbedtls? ( net-libs/mbedtls:=[${MULTILIB_USEDEP}] )


### PR DESCRIPTION
Even though sys-apps/util-linux is part of the system set, it needs to be depended on in order to depend on the correct [${MULTILIB_USEDEP}]. Otherwise, it fails to find uuid. 