### PR TITLE
dev-python/kafka-python: enable py3.11

### DIFF
--- a/dev-python/kafka-python/files/kafka-python-2.0.2-py311-test-fixes.patch
+++ b/dev-python/kafka-python/files/kafka-python-2.0.2-py311-test-fixes.patch
@@ -1,0 +1,26 @@
+Fix tests for Py3.11
+
+Upstream-PR: https://github.com/dpkp/kafka-python/pull/2358
+
+diff --git a/test/test_assignors.py b/test/test_assignors.py
+index 67e91e131..a1214d8fa 100644
+--- a/test/test_assignors.py
++++ b/test/test_assignors.py
+@@ -661,7 +661,7 @@ def test_reassignment_with_random_subscriptions_and_changes(mocker, execution_nu
+ 
+     subscriptions = defaultdict(set)
+     for i in range(n_consumers):
+-        topics_sample = sample(all_topics, randint(1, len(all_topics) - 1))
++        topics_sample = sample(sorted(all_topics), randint(1, len(all_topics) - 1))
+         subscriptions['C{}'.format(i)].update(topics_sample)
+ 
+     member_metadata = make_member_metadata(subscriptions)
+@@ -671,7 +671,7 @@ def test_reassignment_with_random_subscriptions_and_changes(mocker, execution_nu
+ 
+     subscriptions = defaultdict(set)
+     for i in range(n_consumers):
+-        topics_sample = sample(all_topics, randint(1, len(all_topics) - 1))
++        topics_sample = sample(sorted(all_topics), randint(1, len(all_topics) - 1))
+         subscriptions['C{}'.format(i)].update(topics_sample)
+ 
+     member_metadata = {}

--- a/dev-python/kafka-python/kafka-python-2.0.2-r1.ebuild
+++ b/dev-python/kafka-python/kafka-python-2.0.2-r1.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..10} )
+PYTHON_COMPAT=( python3_{9..11} )
 
 inherit distutils-r1 optfeature
 
@@ -34,6 +34,10 @@ BDEPEND="
 		dev-python/python-snappy[${PYTHON_USEDEP}]
 	)
 "
+
+PATCHES=(
+	"${FILESDIR}/${P}-py311-test-fixes.patch"
+)
 
 distutils_enable_tests pytest
 


### PR DESCRIPTION
It was necessary to apply patch to fix tests with py3.11. The patch was sent to upstream [1].

[1] https://github.com/dpkp/kafka-python/pull/2358

Closes: https://bugs.gentoo.org/896790