### PR TITLE
sys-fs/fuse: Set init script dir in Meson options

### DIFF
--- a/sys-fs/fuse/fuse-3.12.0.ebuild
+++ b/sys-fs/fuse/fuse-3.12.0.ebuild
@@ -39,6 +39,7 @@ multilib_src_configure() {
 		$(meson_use test tests)
 		-Duseroot=false
 		-Dudevrulesdir="${EPREFIX}$(get_udevdir)/rules.d"
+		-Dinitscriptdir="${EPREFIX}/etc/init.d"
 	)
 	meson_src_configure
 }

--- a/sys-fs/fuse/fuse-3.13.1-r1.ebuild
+++ b/sys-fs/fuse/fuse-3.13.1-r1.ebuild
@@ -46,6 +46,7 @@ multilib_src_configure() {
 		$(meson_use test tests)
 		-Duseroot=false
 		-Dudevrulesdir="${EPREFIX}$(get_udevdir)/rules.d"
+		-Dinitscriptdir="${EPREFIX}/etc/init.d"
 	)
 	meson_src_configure
 }

--- a/sys-fs/fuse/fuse-3.14.0.ebuild
+++ b/sys-fs/fuse/fuse-3.14.0.ebuild
@@ -42,6 +42,7 @@ multilib_src_configure() {
 		$(meson_use test tests)
 		-Duseroot=false
 		-Dudevrulesdir="${EPREFIX}$(get_udevdir)/rules.d"
+		-Dinitscriptdir="${EPREFIX}/etc/init.d"
 	)
 	meson_src_configure
 }


### PR DESCRIPTION
The `initscriptdir` option was added in 3.12.0 upstream release and controls where the package's init scripts are installed.  If the option is unspecified, the default value for this option is `/etc/init.d/`, which is fine on non-Prefix systems but incorrect on Prefix.  The path shall start with `EPREFIX` to account for both types of system.

Closes: https://bugs.gentoo.org/899698