### PR TITLE
java-utils-2.eclass: fix EclassDocMissingFunc

### DIFF
--- a/eclass/java-utils-2.eclass
+++ b/eclass/java-utils-2.eclass
@@ -2390,7 +2390,7 @@ java-pkg_init-compiler_() {
 
 }
 
-# @FUNCTION: init_paths_
+# @FUNCTION: java-pkg_init_paths_
 # @INTERNAL
 # @DESCRIPTION:
 # Initializes some variables that will be used. These variables are mostly used


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/900509

@thesamesam 