### PR TITLE
media-sound/musepack-tools: fix build on musl

### DIFF
--- a/media-sound/musepack-tools/files/musepack-tools-465-musl.patch
+++ b/media-sound/musepack-tools/files/musepack-tools-465-musl.patch
@@ -1,6 +1,7 @@
-diff -uNr a/mpcenc/keyboard.c b/mpcenc/keyboard.c
---- a/mpcenc/keyboard.c	2006-12-19 13:39:02.000000000 -0600
-+++ b/mpcenc/keyboard.c	2021-06-03 13:54:01.000000000 -0500
+Bug: https://bugs.gentoo.org/712978
+
+--- a/mpcenc/keyboard.c
++++ b/mpcenc/keyboard.c
 @@ -84,6 +84,8 @@
  #  define echo_on()   (void)0
  # endif
@@ -10,9 +11,8 @@ diff -uNr a/mpcenc/keyboard.c b/mpcenc/keyboard.c
  int
  WaitKey ( void )
  {
-diff -uNr a/mpcenc/mpcenc.h b/mpcenc/mpcenc.h
---- a/mpcenc/mpcenc.h	2009-02-23 12:15:46.000000000 -0600
-+++ b/mpcenc/mpcenc.h	2021-06-03 14:00:30.000000000 -0500
+--- a/mpcenc/mpcenc.h
++++ b/mpcenc/mpcenc.h
 @@ -50,7 +50,7 @@
  # include <unistd.h>
  #endif

--- a/media-sound/musepack-tools/files/musepack-tools-465-musl.patch
+++ b/media-sound/musepack-tools/files/musepack-tools-465-musl.patch
@@ -1,0 +1,24 @@
+diff -uNr a/mpcenc/keyboard.c b/mpcenc/keyboard.c
+--- a/mpcenc/keyboard.c	2006-12-19 13:39:02.000000000 -0600
++++ b/mpcenc/keyboard.c	2021-06-03 13:54:01.000000000 -0500
+@@ -84,6 +84,8 @@
+ #  define echo_on()   (void)0
+ # endif
+ 
++# include <sys/select.h>
++
+ int
+ WaitKey ( void )
+ {
+diff -uNr a/mpcenc/mpcenc.h b/mpcenc/mpcenc.h
+--- a/mpcenc/mpcenc.h	2009-02-23 12:15:46.000000000 -0600
++++ b/mpcenc/mpcenc.h	2021-06-03 14:00:30.000000000 -0500
+@@ -50,7 +50,7 @@
+ # include <unistd.h>
+ #endif
+ 
+-#if   defined __linux__
++#if   defined __GLIBC__
+ #  include <fpu_control.h>
+ #elif defined __FreeBSD__
+ # include <machine/floatingpoint.h>

--- a/media-sound/musepack-tools/musepack-tools-465-r2.ebuild
+++ b/media-sound/musepack-tools/musepack-tools-465-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -29,4 +29,5 @@ RDEPEND="
 PATCHES=(
 	"${FILESDIR}"/${P}-gentoo.patch
 	"${FILESDIR}"/${P}-fno-common.patch
+	"${FILESDIR}"/${P}-musl.patch
 )


### PR DESCRIPTION
Signed-off-by: Cristian Othón Martínez Vera <cfuga@cfuga.mx>
Bug: https://bugs.gentoo.org/712978

This patch makes the following changes.
* __linux__ isn't the same as __GLIBC__

Thus, it avoids calling <fpu_control.h> macros in musl, doesn't require
conditional patching and still works nicely with glibc-based systems.

* Includes <sys/select.h> for select(3). That header includes <sys/time.h>
and also fixes the struct timeval error.
