### PR TITLE
media-libs/aubio: enable py3.11

### DIFF
--- a/media-libs/aubio/aubio-0.4.9-r2.ebuild
+++ b/media-libs/aubio/aubio-0.4.9-r2.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 
 DISTUTILS_OPTIONAL=1
-PYTHON_COMPAT=( python3_{9..10} )
+PYTHON_COMPAT=( python3_{9..11} )
 PYTHON_REQ_USE='threads(+)'
 inherit distutils-r1 waf-utils
 
@@ -52,6 +52,7 @@ PYTHON_SRC_DIR="${S}"
 PATCHES=(
 	"${FILESDIR}"/${PN}-0.4.9-docdir.patch
 	"${FILESDIR}"/ffmpeg5.patch
+	"${FILESDIR}"/${PN}-0.4.9-remove-universal-newlines.patch
 )
 
 src_prepare() {

--- a/media-libs/aubio/files/aubio-0.4.9-remove-universal-newlines.patch
+++ b/media-libs/aubio/files/aubio-0.4.9-remove-universal-newlines.patch
@@ -1,0 +1,31 @@
+--- aubio-0.4.9/waflib/ConfigSet.py	2023-03-07 16:02:26.109510883 -0500
++++ aubio-0.4.9/waflib/ConfigSet.py	2023-03-07 16:05:12.892415156 -0500
+@@ -146,7 +146,7 @@ class ConfigSet(object):
+ 		Utils.writef(filename,''.join(buf))
+ 	def load(self,filename):
+ 		tbl=self.table
+-		code=Utils.readf(filename,m='rU')
++		code=Utils.readf(filename,m='r')
+ 		for m in re_imp.finditer(code):
+ 			g=m.group
+ 			tbl[g(2)]=eval(g(3))
+--- aubio-0.4.9/waflib/Context.py	2023-03-07 16:02:26.109510883 -0500
++++ aubio-0.4.9/waflib/Context.py	2023-03-07 16:05:20.764245554 -0500
+@@ -106,7 +106,7 @@ class Context(ctx):
+ 				cache[node]=True
+ 				self.pre_recurse(node)
+ 				try:
+-					function_code=node.read('rU',encoding)
++					function_code=node.read('r',encoding)
+ 					exec(compile(function_code,node.abspath(),'exec'),self.exec_dict)
+ 				finally:
+ 					self.post_recurse(node)
+@@ -346,7 +346,7 @@ def load_module(path,encoding=None):
+ 		pass
+ 	module=imp.new_module(WSCRIPT_FILE)
+ 	try:
+-		code=Utils.readf(path,m='rU',encoding=encoding)
++		code=Utils.readf(path,m='r',encoding=encoding)
+ 	except EnvironmentError:
+ 		raise Errors.WafError('Could not read the file %r'%path)
+ 	module_dir=os.path.dirname(path)


### PR DESCRIPTION
The waflib part of media-libs/aubio uses the `U` mode (which was removed and made default in py3.11), which can be trivially fixed by a patch.