### PR TITLE
dev-libs/confuse: Add fix for CVE-2022-40320.

### DIFF
--- a/dev-libs/confuse/confuse-3.3-r2.ebuild
+++ b/dev-libs/confuse/confuse-3.3-r2.ebuild
@@ -1,0 +1,62 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+inherit multilib-minimal flag-o-matic
+
+DESCRIPTION="a configuration file parser library"
+HOMEPAGE="https://github.com/martinh/libconfuse"
+SRC_URI="https://github.com/martinh/libconfuse/releases/download/v${PV}/${P}.tar.xz"
+
+LICENSE="ISC"
+SLOT="0/2.1.0"
+KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~loong ~mips ppc ppc64 ~riscv sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-solaris"
+
+IUSE="nls static-libs"
+
+BDEPEND="
+	sys-devel/flex
+	sys-devel/libtool
+	virtual/pkgconfig
+	nls? ( sys-devel/gettext )
+"
+RDEPEND="
+	nls? ( virtual/libintl[${MULTILIB_USEDEP}] )
+"
+
+PATCHES=(
+	# Upstream commit to fix CVE-2022-40320:
+	# https://github.com/libconfuse/libconfuse/commit/d73777c2c3566fb2647727bb56d9a2295b81669b
+	"${FILESDIR}"/confuse-3.3-fix-CVE-2022-40320.patch
+)
+
+DOCS=( AUTHORS )
+
+src_prepare() {
+	default
+	multilib_copy_sources
+}
+
+multilib_src_configure() {
+	# https://github.com/libconfuse/libconfuse/pull/167
+	append-lfs-flags
+
+	# examples are normally compiled but not installed. They
+	# fail during a mingw crosscompile.
+	local ECONF_SOURCE=${BUILD_DIR}
+	econf \
+		--enable-shared \
+		--disable-examples \
+		$(use_enable nls) \
+		$(use_enable static-libs static)
+}
+
+multilib_src_install_all() {
+	doman doc/man/man3/*.3
+	dodoc -r doc/html
+
+	docinto examples
+	dodoc examples/*.{c,conf}
+
+	find "${D}" -name '*.la' -delete || die
+}

--- a/dev-libs/confuse/files/confuse-3.3-fix-CVE-2022-40320.patch
+++ b/dev-libs/confuse/files/confuse-3.3-fix-CVE-2022-40320.patch
@@ -1,0 +1,42 @@
+From 8095dc091decafccc672e63534ff5afef76f6f60 Mon Sep 17 00:00:00 2001
+From: Vaibhav Rustagi <vaibhavrustagi@google.com>
+Date: Mon, 13 Mar 2023 14:22:52 -0700
+Subject: [PATCH] Fix CVE-2022-40320 in confuse.
+
+Upstream commit to fix the vulnerability: https://github.com/libconfuse/libconfuse/commit/d73777c2c3566fb2647727bb56d9a2295b81669b
+---
+ src/confuse.c | 10 ++++++----
+ 1 file changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/src/confuse.c b/src/confuse.c
+index ce4fca8..060fae2 100644
+--- a/src/confuse.c
++++ b/src/confuse.c
+@@ -1863,18 +1863,20 @@ DLLIMPORT char *cfg_tilde_expand(const char *filename)
+ 			passwd = getpwuid(geteuid());
+ 			file = filename + 1;
+ 		} else {
+-			/* ~user or ~user/path */
+-			char *user;
++			char *user; /* ~user or ~user/path */
++			size_t len;
+ 
+ 			file = strchr(filename, '/');
+ 			if (file == 0)
+ 				file = filename + strlen(filename);
+ 
+-			user = malloc(file - filename);
++			len = file - filename - 1;
++			user = malloc(len + 1);
+ 			if (!user)
+ 				return NULL;
+ 
+-			strncpy(user, filename + 1, file - filename - 1);
++			strncpy(user, &filename[1], len);
++			user[len] = 0;
+ 			passwd = getpwnam(user);
+ 			free(user);
+ 		}
+-- 
+2.31.0
+


### PR DESCRIPTION
The source of libconfuse package didn't make a release since Jun 24, 2020 (https://github.com/libconfuse/libconfuse). Therefore, to fix the CVE add a patch.

Bug: https://bugs.gentoo.org/901089