### PR TITLE
Replace outdated Jenkins mirror links

### DIFF
--- a/dev-util/jenkins-bin/jenkins-bin-2.375.4.ebuild
+++ b/dev-util/jenkins-bin/jenkins-bin-2.375.4.ebuild
@@ -5,10 +5,10 @@ EAPI=8
 
 inherit systemd
 
-DESCRIPTION="Extensible continuous integration server"
+DESCRIPTION="The leading open source automation server."
 HOMEPAGE="https://jenkins.io/"
 LICENSE="MIT"
-SRC_URI="http://mirrors.jenkins-ci.org/war-stable/${PV}/${PN/-bin/}.war -> ${P}.war"
+SRC_URI="https://get.jenkins.io/war-stable/${PV}/${PN/-bin/}.war -> ${P}.war"
 SLOT="lts"
 KEYWORDS="~amd64 ~arm64 ~x86 ~amd64-linux"
 IUSE=""

--- a/dev-util/jenkins-bin/jenkins-bin-2.387.1.ebuild
+++ b/dev-util/jenkins-bin/jenkins-bin-2.387.1.ebuild
@@ -5,10 +5,10 @@ EAPI=8
 
 inherit systemd
 
-DESCRIPTION="Extensible continuous integration server"
+DESCRIPTION="The leading open source automation server."
 HOMEPAGE="https://jenkins.io/"
 LICENSE="MIT"
-SRC_URI="http://mirrors.jenkins-ci.org/war-stable/${PV}/${PN/-bin/}.war -> ${P}.war"
+SRC_URI="https://get.jenkins.io/war-stable/${PV}/${PN/-bin/}.war -> ${P}.war"
 SLOT="lts"
 KEYWORDS="~amd64 ~arm64 ~x86 ~amd64-linux"
 IUSE=""

--- a/dev-util/jenkins-bin/jenkins-bin-2.394.ebuild
+++ b/dev-util/jenkins-bin/jenkins-bin-2.394.ebuild
@@ -5,10 +5,10 @@ EAPI=8
 
 inherit systemd
 
-DESCRIPTION="Extensible continuous integration server"
+DESCRIPTION="The leading open source automation server."
 HOMEPAGE="https://jenkins.io/"
 LICENSE="MIT"
-SRC_URI="http://mirrors.jenkins-ci.org/war/${PV}/${PN/-bin/}.war -> ${P}.war"
+SRC_URI="https://get.jenkins.io/war/${PV}/${PN/-bin/}.war -> ${P}.war"
 SLOT="0"
 KEYWORDS="~amd64 ~arm64 ~x86 ~amd64-linux"
 IUSE=""


### PR DESCRIPTION
mirrors.jenkins.io is deprecated in favor of get.jenkins.io. Additionally, I went ahead and updated the description with the elevator pitch found in various documentation sources.