### PR TITLE
app-accessibility/flite: add openmp check for tests

### DIFF
--- a/app-accessibility/flite/flite-2.2.ebuild
+++ b/app-accessibility/flite/flite-2.2.ebuild
@@ -71,6 +71,14 @@ get_audio() {
 	fi
 }
 
+pkg_pretend() {
+	[[ ${MERGE_TYPE} != binary ]] && use test && tc-check-openmp
+}
+
+pkg_setup() {
+	[[ ${MERGE_TYPE} != binary ]] && use test && tc-check-openmp
+}
+
 src_unpack() {
 	for file in ${A}; do
 		case "${file}" in


### PR DESCRIPTION
Forgot this in https://github.com/gentoo/gentoo/pull/30006