### PR TITLE
pypi.eclass migration, part 2

### DIFF
--- a/app-admin/ansible/ansible-7.3.0.ebuild
+++ b/app-admin/ansible/ansible-7.3.0.ebuild
@@ -5,11 +5,10 @@ EAPI=8
 
 PYTHON_COMPAT=( python3_{9..11} )
 
-inherit distutils-r1
+inherit distutils-r1 pypi
 
 DESCRIPTION="Model-driven deployment, config management, and command execution framework"
 HOMEPAGE="https://www.ansible.com/"
-SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="GPL-3+"
 SLOT="0"

--- a/app-admin/salt/salt-3005.1-r1.ebuild
+++ b/app-admin/salt/salt-3005.1-r1.ebuild
@@ -15,9 +15,8 @@ if [[ ${PV} == 9999* ]]; then
 	inherit git-r3
 	EGIT_REPO_URI="https://github.com/${PN}stack/${PN}.git"
 	EGIT_BRANCH="develop"
-	SRC_URI=""
 else
-	SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
+	inherit pypi
 	KEYWORDS="~amd64 ~arm ~arm64 ~riscv x86"
 fi
 

--- a/app-admin/supervisor/supervisor-4.2.5.ebuild
+++ b/app-admin/supervisor/supervisor-4.2.5.ebuild
@@ -8,11 +8,10 @@ PYTHON_COMPAT=( pypy3 python3_{9..11} )
 # xml.etree.ElementTree module required.
 PYTHON_REQ_USE="xml(+)"
 
-inherit distutils-r1 systemd
+inherit distutils-r1 systemd pypi
 
 DESCRIPTION="A system for controlling process state under UNIX"
 HOMEPAGE="http://supervisord.org/ https://pypi.org/project/supervisor/"
-SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="repoze ZPL BSD HPND GPL-2"
 SLOT="0"

--- a/app-arch/dtrx/dtrx-8.5.0.ebuild
+++ b/app-arch/dtrx/dtrx-8.5.0.ebuild
@@ -16,7 +16,7 @@ if [[ ${PV} == *9999* ]] ; then
 	inherit git-r3
 	EGIT_REPO_URI="https://github.com/${PN}-py/${PN}.git"
 else
-	SRC_URI="mirror://pypi/${PN::1}/${PN}/${P}.tar.gz"
+	inherit pypi
 	KEYWORDS="~amd64 ~x86"
 fi
 

--- a/app-arch/dtrx/dtrx-9999.ebuild
+++ b/app-arch/dtrx/dtrx-9999.ebuild
@@ -16,7 +16,7 @@ if [[ ${PV} == *9999* ]] ; then
 	inherit git-r3
 	EGIT_REPO_URI="https://github.com/${PN}-py/${PN}.git"
 else
-	SRC_URI="mirror://pypi/${PN::1}/${PN}/${P}.tar.gz"
+	inherit pypi
 	KEYWORDS="~amd64 ~x86"
 fi
 

--- a/app-arch/patool/patool-1.12.ebuild
+++ b/app-arch/patool/patool-1.12.ebuild
@@ -5,11 +5,10 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{9..10} )
 
-inherit distutils-r1
+inherit distutils-r1 pypi
 
 DESCRIPTION="Portable archive file manager"
 HOMEPAGE="http://wummel.github.io/patool/"
-SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="GPL-3"
 SLOT="0"

--- a/app-arch/vimball/vimball-0.5.1.ebuild
+++ b/app-arch/vimball/vimball-0.5.1.ebuild
@@ -12,7 +12,7 @@ if [[ ${PV} == *9999 ]] ; then
 	inherit git-r3
 else
 	KEYWORDS="amd64 x86"
-	SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
+	inherit pypi
 fi
 
 DESCRIPTION="a command-line vimball archive extractor"

--- a/app-arch/vimball/vimball-9999.ebuild
+++ b/app-arch/vimball/vimball-9999.ebuild
@@ -12,7 +12,7 @@ if [[ ${PV} == *9999 ]] ; then
 	inherit git-r3
 else
 	KEYWORDS="~amd64 ~x86"
-	SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
+	inherit pypi
 fi
 
 DESCRIPTION="a command-line vimball archive extractor"

--- a/app-backup/borgbackup/borgbackup-1.2.3.ebuild
+++ b/app-backup/borgbackup/borgbackup-1.2.3.ebuild
@@ -12,8 +12,8 @@ if [[ ${PV} == "9999" ]] ; then
 	EGIT_REPO_URI="https://github.com/${PN}/borg.git"
 	inherit git-r3
 else
-	SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 	KEYWORDS="amd64 ~arm ~arm64 ~ppc64 ~riscv x86"
+	inherit pypi
 fi
 
 DESCRIPTION="Deduplicating backup program with compression and authenticated encryption"

--- a/app-backup/borgbackup/borgbackup-9999.ebuild
+++ b/app-backup/borgbackup/borgbackup-9999.ebuild
@@ -4,15 +4,16 @@
 EAPI=8
 
 PYTHON_COMPAT=( python3_{9..11} )
+DISTUTILS_USE_PEP517=setuptools
 
-inherit distutils-r1
+inherit distutils-r1 bash-completion-r1
 
 if [[ ${PV} == "9999" ]] ; then
 	EGIT_REPO_URI="https://github.com/${PN}/borg.git"
 	inherit git-r3
 else
-	SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 	KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~riscv ~x86"
+	inherit pypi
 fi
 
 DESCRIPTION="Deduplicating backup program with compression and authenticated encryption"
@@ -44,4 +45,12 @@ DEPEND="
 src_install() {
 	distutils-r1_src_install
 	doman docs/man/*
+
+	dobashcomp scripts/shell_completions/bash/borg
+
+	insinto /usr/share/zsh/site-functions
+	doins scripts/shell_completions/zsh/_borg
+
+	insinto /usr/share/fish/vendor_completions.d
+	doins scripts/shell_completions/fish/borg.fish
 }

--- a/app-backup/borgmatic/borgmatic-1.7.8.ebuild
+++ b/app-backup/borgmatic/borgmatic-1.7.8.ebuild
@@ -7,11 +7,10 @@ PYTHON_COMPAT=( python3_{9..11} )
 DISTUTILS_SINGLE_IMPL=1
 DISTUTILS_USE_PEP517=setuptools
 
-inherit distutils-r1 systemd
+inherit distutils-r1 systemd pypi
 
 DESCRIPTION="Automatically create, prune and verify backups with borgbackup"
 HOMEPAGE="https://torsion.org/borgmatic/"
-SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="GPL-3"
 SLOT="0"

--- a/app-backup/duplicity/duplicity-1.0.1-r1.ebuild
+++ b/app-backup/duplicity/duplicity-1.0.1-r1.ebuild
@@ -4,11 +4,10 @@
 EAPI=8
 PYTHON_COMPAT=( python3_10 python3_11 )
 
-inherit distutils-r1
+inherit distutils-r1 pypi
 
 DESCRIPTION="Secure backup system using gnupg to encrypt data"
 HOMEPAGE="https://duplicity.gitlab.io/"
-SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="GPL-3"
 SLOT="0"

--- a/app-emulation/glean/glean-1.23.0.ebuild
+++ b/app-emulation/glean/glean-1.23.0.ebuild
@@ -6,11 +6,10 @@ EAPI=7
 PYTHON_COMPAT=( python3_{9,10} )
 DISTUTILS_USE_SETUPTOOLS=rdepend
 
-inherit distutils-r1
+inherit distutils-r1 pypi
 
 DESCRIPTION="Simple program to write static config from config-drive"
 HOMEPAGE="https://opendev.org/opendev/glean"
-SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="Apache-2.0"
 SLOT="0"

--- a/app-misc/filebus/filebus-0.3.5.ebuild
+++ b/app-misc/filebus/filebus-0.3.5.ebuild
@@ -5,11 +5,10 @@ EAPI=7
 DISTUTILS_OPTIONAL=1
 PYTHON_COMPAT=( python3_{9,10,11} )
 
-inherit distutils-r1
+inherit distutils-r1 pypi
 
 DESCRIPTION="A user space multicast named pipe implementation backed by a regular file"
 HOMEPAGE="https://github.com/pipebus/filebus"
-SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="Apache-2.0"
 KEYWORDS="~amd64"

--- a/app-misc/freewvs/freewvs-0.1.3-r1.ebuild
+++ b/app-misc/freewvs/freewvs-0.1.3-r1.ebuild
@@ -5,11 +5,10 @@ EAPI=8
 PYTHON_COMPAT=( python3_{9,10,11} )
 DISTUTILS_SINGLE_IMPL=1
 DISTUTILS_USE_PEP517=setuptools
-inherit distutils-r1
+inherit distutils-r1 pypi
 
 DESCRIPTION="Scans filesystem for known vulnerable web applications"
 HOMEPAGE="https://freewvs.schokokeks.org/"
-SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="CC0-1.0"
 SLOT="0"

--- a/app-misc/goobook/goobook-3.5.1-r3.ebuild
+++ b/app-misc/goobook/goobook-3.5.1-r3.ebuild
@@ -4,11 +4,10 @@
 EAPI=8
 
 PYTHON_COMPAT=( python3_10 )
-inherit distutils-r1 readme.gentoo-r1
+inherit distutils-r1 readme.gentoo-r1 pypi
 
 DESCRIPTION="Access your Google contacts from the command line"
 HOMEPAGE="https://gitlab.com/goobook/goobook"
-SRC_URI="mirror://pypi/g/${PN}/${P}.tar.gz"
 
 LICENSE="GPL-3"
 SLOT="0"

--- a/app-misc/khal/khal-0.10.5.ebuild
+++ b/app-misc/khal/khal-0.10.5.ebuild
@@ -7,11 +7,10 @@ PYTHON_COMPAT=( python3_10 )
 PYTHON_REQ_USE="sqlite"
 DISTUTILS_USE_PEP517=setuptools
 
-inherit distutils-r1
+inherit distutils-r1 pypi
 
 DESCRIPTION="A CalDAV based calendar"
 HOMEPAGE="https://lostpackets.de/khal/ https://github.com/pimutils/khal"
-SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0"

--- a/app-misc/khard/khard-0.18.0.ebuild
+++ b/app-misc/khard/khard-0.18.0.ebuild
@@ -20,7 +20,7 @@ if [[ "${PV}" == *9999 ]]; then
 	inherit git-r3
 	EGIT_REPO_URI="https://github.com/lucc/khard"
 else
-	SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
+	inherit pypi
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 fi
 

--- a/app-misc/wildq/wildq-1.1.11.ebuild
+++ b/app-misc/wildq/wildq-1.1.11.ebuild
@@ -5,11 +5,10 @@ EAPI=7
 PYTHON_COMPAT=( python3_{9..10} )
 DISTUTILS_USE_SETUPTOOLS=bdepend
 
-inherit distutils-r1
+inherit distutils-r1 pypi
 
 DESCRIPTION="Command-line TOML/JSON/INI/YAML/XML processor using jq c bindings"
 HOMEPAGE="https://pypi.org/project/wildq/ https://github.com/ahmet2mir/wildq"
-SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 LICENSE="Apache-2.0"
 SLOT="0"
 KEYWORDS="~amd64"

--- a/app-portage/elsw/elsw-0.0.0-r1.ebuild
+++ b/app-portage/elsw/elsw-0.0.0-r1.ebuild
@@ -15,7 +15,7 @@ if [[ ${PV} == *9999* ]] ; then
 	inherit git-r3
 	EGIT_REPO_URI="https://gitlab.com/xgqt/python-${PN}.git"
 else
-	SRC_URI="mirror://pypi/${PN::1}/${PN}/${P}.tar.gz"
+	inherit pypi
 	KEYWORDS="~amd64 ~x86"
 fi
 

--- a/app-portage/elsw/elsw-9999.ebuild
+++ b/app-portage/elsw/elsw-9999.ebuild
@@ -15,7 +15,7 @@ if [[ ${PV} == *9999* ]] ; then
 	inherit git-r3
 	EGIT_REPO_URI="https://gitlab.com/xgqt/python-${PN}.git"
 else
-	SRC_URI="mirror://pypi/${PN::1}/${PN}/${P}.tar.gz"
+	inherit pypi
 	KEYWORDS="~amd64 ~x86"
 fi
 

--- a/app-portage/fetchcommandwrapper/fetchcommandwrapper-0.8.4-r3.ebuild
+++ b/app-portage/fetchcommandwrapper/fetchcommandwrapper-0.8.4-r3.ebuild
@@ -6,11 +6,10 @@ EAPI="8"
 DISTUTILS_USE_PEP517=setuptools
 PYTHON_COMPAT=( python3_{9..11} )
 
-inherit distutils-r1
+inherit distutils-r1 pypi
 
 DESCRIPTION="Wrapper integrating aria2 into portage's FETCHCOMMAND"
 HOMEPAGE="https://github.com/hartwork/fetchcommandwrapper"
-SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="GPL-3"
 SLOT="0"

--- a/app-portage/metagen/metagen-0.7.3-r2.ebuild
+++ b/app-portage/metagen/metagen-0.7.3-r2.ebuild
@@ -5,11 +5,10 @@ EAPI="8"
 DISTUTILS_USE_PEP517=setuptools
 PYTHON_COMPAT=( python3_{9..11} )
 
-inherit distutils-r1
+inherit distutils-r1 pypi
 
 DESCRIPTION="metadata.xml generator for ebuilds"
 HOMEPAGE="https://cgit.gentoo.org/proj/metagen.git"
-SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/app-text/asciidoc/asciidoc-10.2.0.ebuild
+++ b/app-text/asciidoc/asciidoc-10.2.0.ebuild
@@ -6,13 +6,10 @@ EAPI=8
 DISTUTILS_SINGLE_IMPL=1
 DISTUTILS_USE_PEP517=setuptools
 PYTHON_COMPAT=( python3_{9..11} pypy3 )
-inherit distutils-r1 optfeature readme.gentoo-r1
+inherit distutils-r1 optfeature readme.gentoo-r1 pypi
 
 DESCRIPTION="A plain text human readable/writable document format"
 HOMEPAGE="https://asciidoc.org/ https://github.com/asciidoc-py/asciidoc-py/"
-# Could use the github tarball but we need autotools then
-#SRC_URI="https://github.com/asciidoc-py/asciidoc-py/releases/download/${PV}/${P}.tar.gz"
-SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/app-text/paperwork/paperwork-2.1.2.ebuild
+++ b/app-text/paperwork/paperwork-2.1.2.ebuild
@@ -6,11 +6,10 @@ EAPI=8
 DISTUTILS_USE_PEP517=setuptools
 PYTHON_COMPAT=( python3_{9..11} )
 
-inherit distutils-r1 xdg
+inherit distutils-r1 xdg pypi
 
 DESCRIPTION="a personal document manager for scanned documents (and PDFs)"
 HOMEPAGE="https://gitlab.gnome.org/World/OpenPaperwork"
-SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="GPL-3"
 SLOT="0"

--- a/app-text/restview/restview-3.0.0.ebuild
+++ b/app-text/restview/restview-3.0.0.ebuild
@@ -5,11 +5,10 @@ EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
 PYTHON_COMPAT=( python3_{9..10} )
-inherit distutils-r1
+inherit distutils-r1 pypi
 
 DESCRIPTION="reStructuredText viewer"
 HOMEPAGE="https://mg.pov.lt/restview/ https://pypi.org/project/restview/"
-SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="GPL-3"
 SLOT="0"

--- a/app-text/xlsx2csv/xlsx2csv-0.8.0.ebuild
+++ b/app-text/xlsx2csv/xlsx2csv-0.8.0.ebuild
@@ -7,11 +7,10 @@ PYTHON_COMPAT=( python3_{8..11} )
 PYTHON_REQ_USE="xml(+)"
 DISTUTILS_USE_PEP517=setuptools
 
-inherit distutils-r1
+inherit distutils-r1 pypi
 
 DESCRIPTION="Convert MS Office xlsx files to CSV"
 HOMEPAGE="https://github.com/dilshod/xlsx2csv/"
-SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0"

--- a/dev-db/pgxnclient/pgxnclient-1.3.2.ebuild
+++ b/dev-db/pgxnclient/pgxnclient-1.3.2.ebuild
@@ -5,12 +5,11 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{9..10} )
 DISTUTILS_USE_SETUPTOOLS=rdepend
-inherit distutils-r1
+inherit distutils-r1 pypi
 
 DESCRIPTION="PostgreSQL Extension Network Client"
 HOMEPAGE="https://pgxn.github.io/pgxnclient/
 	https://pypi.org/project/pgxnclient/"
-SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86"
 

--- a/dev-python/pychroot/pychroot-0.10.4.ebuild
+++ b/dev-python/pychroot/pychroot-0.10.4.ebuild
@@ -4,12 +4,13 @@
 EAPI=8
 
 PYTHON_COMPAT=( python3_{9..11} )
-inherit distutils-r1 pypi
+inherit distutils-r1
 
 if [[ ${PV} == *9999 ]] ; then
 	EGIT_REPO_URI="https://github.com/pkgcore/pychroot.git"
 	inherit git-r3
 else
+	inherit pypi
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 fi
 

--- a/dev-python/pychroot/pychroot-9999.ebuild
+++ b/dev-python/pychroot/pychroot-9999.ebuild
@@ -10,8 +10,8 @@ if [[ ${PV} == *9999 ]] ; then
 	EGIT_REPO_URI="https://github.com/pkgcore/pychroot.git"
 	inherit git-r3
 else
-	KEYWORDS="~amd64 ~x86"
-	SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
+	inherit pypi
+	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 fi
 
 DESCRIPTION="a python library and cli tool that simplify chroot handling"

--- a/dev-python/pysrt/pysrt-1.1.2-r1.ebuild
+++ b/dev-python/pysrt/pysrt-1.1.2-r1.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
 PYTHON_COMPAT=( pypy3 python3_{9..11} )
-inherit distutils-r1 pypi
+inherit distutils-r1
 
 DESCRIPTION="Python library used to edit or create SubRip files"
 HOMEPAGE="https://github.com/byroot/pysrt https://pypi.org/project/pysrt/"
@@ -13,6 +13,7 @@ if [[ ${PV} == 9999 ]]; then
 	inherit git-r3
 	EGIT_REPO_URI="https://github.com/byroot/pysrt.git"
 else
+	inherit pypi
 	KEYWORDS="amd64 ~arm ~arm64 x86"
 fi
 

--- a/dev-python/pysrt/pysrt-9999.ebuild
+++ b/dev-python/pysrt/pysrt-9999.ebuild
@@ -13,7 +13,7 @@ if [[ ${PV} == 9999 ]]; then
 	inherit git-r3
 	EGIT_REPO_URI="https://github.com/byroot/pysrt.git"
 else
-	SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
+	inherit pypi
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 fi
 

--- a/dev-python/slixmpp/slixmpp-1.8.3.ebuild
+++ b/dev-python/slixmpp/slixmpp-1.8.3.ebuild
@@ -6,7 +6,7 @@ EAPI=8
 DISTUTILS_USE_PEP517=setuptools
 PYTHON_COMPAT=( python3_{9..11} )
 
-inherit distutils-r1 pypi
+inherit distutils-r1
 
 DESCRIPTION="Python 3 library for XMPP"
 HOMEPAGE="https://lab.louiz.org/poezio/slixmpp"
@@ -17,6 +17,7 @@ if [[ "${PV}" == "9999" ]]; then
 	EGIT_REPO_URI="https://lab.louiz.org/poezio/${PN}.git"
 	inherit git-r3
 else
+	inherit pypi
 	KEYWORDS="amd64 ~riscv"
 fi
 

--- a/dev-python/slixmpp/slixmpp-9999.ebuild
+++ b/dev-python/slixmpp/slixmpp-9999.ebuild
@@ -17,12 +17,12 @@ if [[ "${PV}" == "9999" ]]; then
 	EGIT_REPO_URI="https://lab.louiz.org/poezio/${PN}.git"
 	inherit git-r3
 else
-	SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
-	KEYWORDS="~amd64"
+	inherit pypi
+	KEYWORDS="~amd64 ~riscv"
 fi
 
 DEPEND="
-	net-dns/libidn
+	net-dns/libidn:=
 "
 RDEPEND="
 	dev-python/aiodns[${PYTHON_USEDEP}]

--- a/dev-util/buildbot/buildbot-3.6.1.ebuild
+++ b/dev-util/buildbot/buildbot-3.6.1.ebuild
@@ -6,17 +6,12 @@ EAPI=8
 DISTUTILS_USE_PEP517=setuptools
 PYTHON_REQ_USE="sqlite"
 PYTHON_COMPAT=( python3_10 )
-inherit readme.gentoo-r1 systemd distutils-r1
-
-MY_PV="${PV/_p/.post}"
-MY_P="${PN}-${MY_PV}"
+inherit readme.gentoo-r1 systemd distutils-r1 pypi
 
 DESCRIPTION="BuildBot build automation system"
 HOMEPAGE="https://buildbot.net/
 	https://github.com/buildbot/buildbot
 	https://pypi.org/project/buildbot/"
-SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${MY_P}.tar.gz"
-S=${WORKDIR}/${MY_P}
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/dev-util/codespell/codespell-2.2.2.ebuild
+++ b/dev-util/codespell/codespell-2.2.2.ebuild
@@ -6,11 +6,10 @@ EAPI=8
 DISTUTILS_USE_PEP517=setuptools
 PYTHON_COMPAT=( python3_{9..11} pypy3 )
 
-inherit distutils-r1
+inherit distutils-r1 pypi
 
 DESCRIPTION="Check text files for common misspellings"
 HOMEPAGE="https://pypi.org/project/codespell https://github.com/codespell-project/codespell"
-SRC_URI="mirror://pypi/${P::1}/${PN}/${P}.tar.gz"
 
 # Code licensed under GPL-2, dictionary licensed under CC-BY-SA-3.0
 LICENSE="GPL-2 CC-BY-SA-3.0"

--- a/dev-util/cram/cram-0.7-r2.ebuild
+++ b/dev-util/cram/cram-0.7-r2.ebuild
@@ -6,11 +6,10 @@ EAPI=8
 PYTHON_COMPAT=( python3_{9..11} pypy3 )
 DISTUTILS_USE_PEP517=setuptools
 
-inherit distutils-r1
+inherit distutils-r1 pypi
 
 DESCRIPTION="Functional testing framework for command line applications"
 HOMEPAGE="https://bitheap.org/cram/"
-SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/dev-util/gertty/gertty-1.6.0-r1.ebuild
+++ b/dev-util/gertty/gertty-1.6.0-r1.ebuild
@@ -13,7 +13,7 @@ if [[ ${PV} == *9999 ]];then
 	EGIT_REPO_URI="https://opendev.org/ttygroup/gertty"
 	EGIT_BRANCH="master"
 else
-	SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
+	inherit pypi
 	KEYWORDS="amd64 x86 ~amd64-linux ~x86-linux"
 fi
 

--- a/dev-util/gertty/gertty-9999.ebuild
+++ b/dev-util/gertty/gertty-9999.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
-PYTHON_COMPAT=(  python3_9 python3_10 )
+PYTHON_COMPAT=( python3_{9..10} )
 
 inherit distutils-r1
 
@@ -13,7 +13,7 @@ if [[ ${PV} == *9999 ]];then
 	EGIT_REPO_URI="https://opendev.org/ttygroup/gertty"
 	EGIT_BRANCH="master"
 else
-	SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
+	inherit pypi
 	KEYWORDS="~amd64 ~x86 ~amd64-linux ~x86-linux"
 fi
 

--- a/dev-util/howdoi/howdoi-2.0.19.ebuild
+++ b/dev-util/howdoi/howdoi-2.0.19.ebuild
@@ -5,11 +5,10 @@ EAPI=8
 
 DISTUTILS_USE_SETUPTOOLS="manual"
 PYTHON_COMPAT=( python3_10 )
-inherit distutils-r1
+inherit distutils-r1 pypi
 
 DESCRIPTION="A code search tool"
 HOMEPAGE="https://pypi.org/project/howdoi/"
-SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0"

--- a/dev-util/yamllint/yamllint-1.29.0.ebuild
+++ b/dev-util/yamllint/yamllint-1.29.0.ebuild
@@ -6,11 +6,10 @@ EAPI=8
 PYTHON_COMPAT=( python3_{9..11} )
 DISTUTILS_USE_PEP517=setuptools
 
-inherit distutils-r1
+inherit distutils-r1 pypi
 
 DESCRIPTION="A linter for YAML files"
 HOMEPAGE="https://pypi.org/project/yamllint/ https://github.com/adrienverge/yamllint/"
-SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="GPL-3"
 SLOT="0"

--- a/dev-util/ydiff/ydiff-1.2-r1.ebuild
+++ b/dev-util/ydiff/ydiff-1.2-r1.ebuild
@@ -6,11 +6,10 @@ EAPI=8
 PYTHON_COMPAT=( python3_{9..11} )
 DISTUTILS_USE_PEP517=setuptools
 
-inherit distutils-r1
+inherit distutils-r1 pypi
 
 DESCRIPTION="Colored, side-by-side diff terminal viewer (ex. cdiff)"
 HOMEPAGE="https://github.com/ymattw/ydiff"
-SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0"

--- a/dev-vcs/svneverever/svneverever-1.7.1-r3.ebuild
+++ b/dev-vcs/svneverever/svneverever-1.7.1-r3.ebuild
@@ -6,11 +6,10 @@ EAPI=8
 PYTHON_COMPAT=( python3_{9..11} )
 DISTUTILS_USE_PEP517=setuptools
 
-inherit distutils-r1
+inherit distutils-r1 pypi
 
 DESCRIPTION="Tool collecting path entries across SVN history"
 HOMEPAGE="https://github.com/hartwork/svneverever"
-SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="GPL-3+"
 SLOT="0"

--- a/mail-filter/afew/afew-3.0.1.ebuild
+++ b/mail-filter/afew/afew-3.0.1.ebuild
@@ -7,11 +7,10 @@ DISTUTILS_SINGLE_IMPL=1
 DISTUTILS_USE_SETUPTOOLS=rdepend
 PYTHON_COMPAT=( python3_{9..10} )
 
-inherit distutils-r1
+inherit distutils-r1 pypi
 
 DESCRIPTION="Initial tagging script for Notmuch"
 HOMEPAGE="https://github.com/afewmail/afew"
-SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="ISC"
 SLOT="0"

--- a/media-gfx/img2pdf/img2pdf-0.4.4.ebuild
+++ b/media-gfx/img2pdf/img2pdf-0.4.4.ebuild
@@ -5,11 +5,10 @@ EAPI=8
 
 PYTHON_COMPAT=( python3_{9..10} )
 
-inherit distutils-r1
+inherit distutils-r1 pypi
 
 DESCRIPTION="Losslessly convert raster images to PDF"
 HOMEPAGE="https://gitlab.mister-muffin.de/josch/img2pdf"
-SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="LGPL-3+"
 SLOT="0"

--- a/net-analyzer/snallygaster/snallygaster-0.0.12-r1.ebuild
+++ b/net-analyzer/snallygaster/snallygaster-0.0.12-r1.ebuild
@@ -5,11 +5,10 @@ EAPI=8
 PYTHON_COMPAT=( python3_{9,10,11} )
 DISTUTILS_SINGLE_IMPL=1
 DISTUTILS_USE_PEP517=setuptools
-inherit distutils-r1
+inherit distutils-r1 pypi
 
 DESCRIPTION="Finds file leaks and other security problems on HTTP servers"
 HOMEPAGE="https://github.com/hannob/snallygaster"
-SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="CC0-1.0"
 SLOT="0"

--- a/net-im/poezio/poezio-0.14.ebuild
+++ b/net-im/poezio/poezio-0.14.ebuild
@@ -20,7 +20,7 @@ if [[ "${PV}" == "9999" ]]; then
 	# We build the html documentation using sphinx.
 	BDEPEND="dev-python/sphinx"
 else
-	SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
+	inherit pypi
 	KEYWORDS="amd64"
 fi
 

--- a/net-im/poezio/poezio-9999.ebuild
+++ b/net-im/poezio/poezio-9999.ebuild
@@ -20,7 +20,7 @@ if [[ "${PV}" == "9999" ]]; then
 	# We build the html documentation using sphinx.
 	BDEPEND="dev-python/sphinx"
 else
-	SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
+	inherit pypi
 	KEYWORDS="~amd64"
 fi
 

--- a/net-misc/htail/htail-1.5.ebuild
+++ b/net-misc/htail/htail-1.5.ebuild
@@ -6,11 +6,10 @@ EAPI=7
 PYTHON_COMPAT=( python3_{9..11} )
 DISTUTILS_USE_SETUPTOOLS=bdepend
 
-inherit distutils-r1
+inherit distutils-r1 pypi
 
 DESCRIPTION="Tail over HTTP"
 HOMEPAGE="https://github.com/vpelletier/htail"
-SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="GPL-2+"
 SLOT="0"

--- a/net-misc/nyx/nyx-2.1.0-r5.ebuild
+++ b/net-misc/nyx/nyx-2.1.0-r5.ebuild
@@ -7,7 +7,7 @@ PYTHON_COMPAT=( python3_{9..11} pypy3 )
 PYTHON_REQ_USE='ncurses,sqlite(-)'
 DISTUTILS_USE_PEP517=setuptools
 
-inherit distutils-r1 pypi
+inherit distutils-r1
 
 DESCRIPTION="Utility to monitor real time Tor status information"
 HOMEPAGE="https://nyx.torproject.org"
@@ -16,6 +16,7 @@ if [[ ${PV} == *9999* ]]; then
 	inherit git-r3
 else
 	KEYWORDS="~amd64 ~arm ~mips ~ppc ~ppc64 ~x86"
+	inherit pypi
 fi
 
 LICENSE="GPL-3"

--- a/net-misc/ytmdl/ytmdl-2023.2.28.ebuild
+++ b/net-misc/ytmdl/ytmdl-2023.2.28.ebuild
@@ -6,11 +6,10 @@ EAPI=8
 DISTUTILS_USE_PEP517=setuptools
 PYTHON_COMPAT=( python3_{9..11} )
 
-inherit bash-completion-r1 distutils-r1
+inherit bash-completion-r1 distutils-r1 pypi
 
 DESCRIPTION="Simple app to get songs from youtube in mp3 format"
 HOMEPAGE="https://ytmdl.deepjyoti30.dev/"
-SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0"

--- a/sci-chemistry/mdtraj/mdtraj-1.9.7.ebuild
+++ b/sci-chemistry/mdtraj/mdtraj-1.9.7.ebuild
@@ -4,11 +4,10 @@
 EAPI=8
 PYTHON_COMPAT=( python3_{9..10} )
 
-inherit distutils-r1
+inherit distutils-r1 pypi
 
 DESCRIPTION="Read, write and analyze MD trajectories with only a few lines of Python code"
 HOMEPAGE="https://mdtraj.org"
-SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 SLOT="0"
 LICENSE="LGPL-2.1+"

--- a/sci-mathematics/dunshire/dunshire-0.1.1-r3.ebuild
+++ b/sci-mathematics/dunshire/dunshire-0.1.1-r3.ebuild
@@ -5,11 +5,10 @@ EAPI=8
 
 PYTHON_COMPAT=( python3_{9..11} )
 DISTUTILS_USE_PEP517=setuptools
-inherit distutils-r1
+inherit distutils-r1 pypi
 
 DESCRIPTION="Python library to solve linear games over symmetric cones"
 HOMEPAGE="http://michael.orlitzky.com/code/dunshire/"
-SRC_URI="mirror://pypi/${P:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="AGPL-3+"
 SLOT="0"

--- a/sys-apps/gcp/gcp-0.2.1.ebuild
+++ b/sys-apps/gcp/gcp-0.2.1.ebuild
@@ -5,11 +5,10 @@ EAPI=8
 
 PYTHON_COMPAT=( python3_{9..11} )
 
-inherit distutils-r1 virtualx
+inherit distutils-r1 virtualx pypi
 
 DESCRIPTION="File copying utility with progress and I/O indicator"
 HOMEPAGE="https://code.lm7.fr/mcy/gcp"
-SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="GPL-3"
 SLOT="0"

--- a/sys-auth/solo1/solo1-0.1.1-r1.ebuild
+++ b/sys-auth/solo1/solo1-0.1.1-r1.ebuild
@@ -6,11 +6,10 @@ EAPI=8
 PYTHON_COMPAT=( python3_{9..11} )
 DISTUTILS_USE_PEP517=flit
 
-inherit distutils-r1
+inherit distutils-r1 pypi
 
 DESCRIPTION="CLI and Python library for SoloKeys Solo 1"
 HOMEPAGE="https://github.com/solokeys/solo1-cli"
-SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="Apache-2.0 MIT"
 SLOT="0"

--- a/www-apps/klaus/klaus-2.0.2.ebuild
+++ b/www-apps/klaus/klaus-2.0.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -6,11 +6,10 @@ EAPI=8
 DISTUTILS_USE_PEP517=setuptools
 PYTHON_COMPAT=( python3_{9..11} )
 
-inherit distutils-r1
+inherit distutils-r1 pypi
 
 DESCRIPTION="A simple, easy-to-set-up Git web viewer"
 HOMEPAGE="https://github.com/jonashaag/klaus/"
-SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="ISC"
 SLOT="0"

--- a/www-apps/roundup/roundup-2.1.0-r1.ebuild
+++ b/www-apps/roundup/roundup-2.1.0-r1.ebuild
@@ -4,13 +4,10 @@
 EAPI=8
 PYTHON_COMPAT=( python3_{9..10} )
 
-inherit distutils-r1
-MY_P=${P/_/}
+inherit distutils-r1 pypi
 
 DESCRIPTION="Issue-tracking system with command-line, web, and e-mail interfaces"
 HOMEPAGE="http://roundup.sourceforge.net https://pypi.org/project/roundup/"
-SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${MY_P}.tar.gz"
-S="${WORKDIR}/${MY_P}"
 
 LICENSE="MIT ZPL"
 SLOT="0"

--- a/x11-misc/safeeyes/safeeyes-2.1.5-r1.ebuild
+++ b/x11-misc/safeeyes/safeeyes-2.1.5-r1.ebuild
@@ -7,11 +7,10 @@ PYTHON_COMPAT=( python3_{9..11} )
 PYTHON_REQ_USE="tk"  # for site-packages/Xlib/ext/randr.py
 DISTUTILS_USE_PEP517=setuptools
 
-inherit xdg distutils-r1
+inherit xdg distutils-r1 pypi
 
 DESCRIPTION="Linux alternative to EyeLeo"
 HOMEPAGE="https://github.com/slgobinath/SafeEyes"
-SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="GPL-3"
 SLOT="0"

--- a/x11-wm/qtile/qtile-0.22.1-r1.ebuild
+++ b/x11-wm/qtile/qtile-0.22.1-r1.ebuild
@@ -15,7 +15,7 @@ if [[ ${PV} == 9999 ]]; then
 	inherit git-r3
 	EGIT_REPO_URI="https://github.com/qtile/qtile.git"
 else
-	SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
+	inherit pypi
 	KEYWORDS="~amd64 ~riscv ~x86"
 fi
 

--- a/x11-wm/qtile/qtile-9999.ebuild
+++ b/x11-wm/qtile/qtile-9999.ebuild
@@ -15,7 +15,7 @@ if [[ ${PV} == 9999 ]]; then
 	inherit git-r3
 	EGIT_REPO_URI="https://github.com/qtile/qtile.git"
 else
-	SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
+	inherit pypi
 	KEYWORDS="~amd64 ~riscv ~x86"
 fi
 


### PR DESCRIPTION
This time all packages that could clearly use `pypi.eclass` and that are outside `dev-python/*`, plus fixes to live-ish ebuilds from part 1.