### PR TITLE
pypi.eclass migration, part 3

### DIFF
--- a/app-misc/jpipe/jpipe-0.2.0-r1.ebuild
+++ b/app-misc/jpipe/jpipe-0.2.0-r1.ebuild
@@ -6,12 +6,13 @@ GO_OPTIONAL=1
 DISTUTILS_OPTIONAL=1
 PYTHON_COMPAT=( python3_{9,10,11} )
 
-inherit go-module distutils-r1
+inherit go-module distutils-r1 pypi
 
 DESCRIPTION="Command line interface to JMESPath"
 HOMEPAGE="https://github.com/pipebus/jpipe https://github.com/jmespath/jp/pull/30 http://jmespath.org"
-SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz
-	!python? ( https://dev.gentoo.org/~zmedico/dist/${P}-deps.tar.xz )"
+SRC_URI+="
+	!python? ( https://dev.gentoo.org/~zmedico/dist/${P}-deps.tar.xz )
+"
 
 LICENSE="Apache-2.0 BSD BSD-2 MIT"
 SLOT="0"

--- a/dev-python/bcrypt/bcrypt-4.0.1.ebuild
+++ b/dev-python/bcrypt/bcrypt-4.0.1.ebuild
@@ -58,15 +58,14 @@ CRATES="
 	zeroize-1.5.7
 "
 
-inherit cargo distutils-r1
+inherit cargo distutils-r1 pypi
 
 DESCRIPTION="Modern password hashing for software and servers"
 HOMEPAGE="
 	https://github.com/pyca/bcrypt/
 	https://pypi.org/project/bcrypt/
 "
-SRC_URI="
-	mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz
+SRC_URI+="
 	$(cargo_crate_uris)
 "
 

--- a/dev-python/citeproc-py/citeproc-py-0.6.0.ebuild
+++ b/dev-python/citeproc-py/citeproc-py-0.6.0.ebuild
@@ -3,6 +3,7 @@
 
 EAPI=8
 
+PYPI_NO_NORMALIZE=1
 PYTHON_COMPAT=( python3_{9..10} )
 
 # Keep synced with tests/citeproc-test.py
@@ -12,11 +13,12 @@ inherit distutils-r1
 
 DESCRIPTION="Yet another Python CSL Processor"
 HOMEPAGE="https://pypi.org/project/citeproc-py/"
-SRC_URI="
-	mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz
+SRC_URI+="
 	test? (
-		https://github.com/citation-style-language/test-suite/archive/${TEST_SUITE_COMMIT}.tar.gz -> ${PN}-test-suite-${TEST_SUITE_COMMIT}.tar.gz
-	)"
+		https://github.com/citation-style-language/test-suite/archive/${TEST_SUITE_COMMIT}.tar.gz
+			-> ${PN}-test-suite-${TEST_SUITE_COMMIT}.tar.gz
+	)
+"
 
 LICENSE="BSD-2"
 SLOT="0"

--- a/dev-python/dbfread/dbfread-2.0.7-r1.ebuild
+++ b/dev-python/dbfread/dbfread-2.0.7-r1.ebuild
@@ -6,12 +6,16 @@ EAPI=8
 DISTUTILS_USE_PEP517=setuptools
 PYTHON_COMPAT=( python3_{9..11} )
 
-inherit distutils-r1
+inherit distutils-r1 pypi
 
 DESCRIPTION="Read DBF Files with Python"
 HOMEPAGE="https://github.com/olemb/dbfread https://pypi.org/project/dbfread/"
-SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz
-	test? ( https://github.com/olemb/dbfread/archive/refs/tags/${PV}.tar.gz -> ${P}-src.tar.gz )"
+SRC_URI+="
+	test? (
+		https://github.com/olemb/dbfread/archive/refs/tags/${PV}.tar.gz
+			-> ${P}-src.tar.gz
+	)
+"
 
 LICENSE="MIT"
 SLOT="0"

--- a/dev-python/enzyme/enzyme-0.4.1-r3.ebuild
+++ b/dev-python/enzyme/enzyme-0.4.1-r3.ebuild
@@ -7,12 +7,11 @@ DISTUTILS_USE_PEP517=setuptools
 PYTHON_COMPAT=( python3_{9..11} )
 PYTHON_REQ_USE='xml(+)'
 
-inherit distutils-r1
+inherit distutils-r1 pypi
 
 DESCRIPTION="Python video metadata parser"
 HOMEPAGE="https://github.com/Diaoul/enzyme https://pypi.org/project/enzyme/"
-SRC_URI="
-	mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz
+SRC_URI+="
 	test? ( mirror://sourceforge/matroska/test_files/matroska_test_w1_1.zip )
 "
 

--- a/dev-python/jupyter/jupyter-1.0.0-r4.ebuild
+++ b/dev-python/jupyter/jupyter-1.0.0-r4.ebuild
@@ -6,14 +6,14 @@ EAPI=8
 DISTUTILS_USE_PEP517=setuptools
 PYTHON_COMPAT=( python3_{9..11} )
 
-inherit distutils-r1
+inherit distutils-r1 pypi
 
 DESCRIPTION="Jupyter metapackage. Install all the Jupyter components in one go"
 HOMEPAGE="https://jupyter.org"
-SRC_URI="
-	mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz
-	https://patch-diff.githubusercontent.com/raw/jupyter/jupyter/pull/198.patch -> ${P}-file-colision.patch
-	"
+SRC_URI+="
+	https://patch-diff.githubusercontent.com/raw/jupyter/jupyter/pull/198.patch
+		-> ${P}-file-colision.patch
+"
 
 LICENSE="BSD"
 SLOT="0"

--- a/dev-python/psutil/psutil-5.9.4.ebuild
+++ b/dev-python/psutil/psutil-5.9.4.ebuild
@@ -6,7 +6,7 @@ EAPI=8
 DISTUTILS_USE_PEP517=setuptools
 PYTHON_COMPAT=( python3_{9..11} pypy3 )
 
-inherit distutils-r1
+inherit distutils-r1 pypi
 
 TEST_PATCH=psutil-5.9.3-tests-r1.patch
 DESCRIPTION="Retrieve information on running processes and system utilization"
@@ -14,8 +14,7 @@ HOMEPAGE="
 	https://github.com/giampaolo/psutil/
 	https://pypi.org/project/psutil/
 "
-SRC_URI="
-	mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz
+SRC_URI+="
 	https://dev.gentoo.org/~mgorny/dist/${TEST_PATCH}.xz
 "
 

--- a/dev-python/pyacoustid/pyacoustid-1.2.2-r1.ebuild
+++ b/dev-python/pyacoustid/pyacoustid-1.2.2-r1.ebuild
@@ -5,12 +5,11 @@ EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
 PYTHON_COMPAT=( python3_{9..11} )
-inherit distutils-r1
+inherit distutils-r1 pypi
 
 DESCRIPTION="Python bindings for Chromaprint and the AcoustID web service"
 HOMEPAGE="https://pypi.org/project/pyacoustid/"
-SRC_URI="
-	mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz
+SRC_URI+="
 	test? (
 		https://s3.wasabisys.com/blocsonic/releases/maxblocs/bsmx0198/01-Follow_192kb.mp3
 			-> ${PN}-test.mp3

--- a/dev-python/reportlab/reportlab-3.6.12.ebuild
+++ b/dev-python/reportlab/reportlab-3.6.12.ebuild
@@ -6,15 +6,14 @@ EAPI=8
 DISTUTILS_USE_PEP517=setuptools
 PYTHON_COMPAT=( python3_{9..11} )
 
-inherit distutils-r1
+inherit distutils-r1 pypi
 
 DESCRIPTION="Tools for generating printable PDF documents from any data source"
 HOMEPAGE="
 	https://www.reportlab.com/
 	https://pypi.org/project/reportlab/
 "
-SRC_URI="
-	mirror://pypi/${P:0:1}/${PN}/${P}.tar.gz
+SRC_URI+="
 	https://www.reportlab.com/ftp/fonts/pfbfer-20070710.zip
 "
 

--- a/dev-python/sgmllib3k/sgmllib3k-1.0.0-r1.ebuild
+++ b/dev-python/sgmllib3k/sgmllib3k-1.0.0-r1.ebuild
@@ -6,14 +6,13 @@ EAPI=8
 DISTUTILS_USE_PEP517=setuptools
 PYTHON_COMPAT=( python3_{9..11} pypy3 )
 
-inherit distutils-r1
+inherit distutils-r1 pypi
 
 DESCRIPTION="Py3k port of sgmllib"
 HOMEPAGE="
 	https://pypi.org/project/sgmllib3k/
 "
-SRC_URI="
-	mirror://pypi/${PN::1}/${PN}/${P}.tar.gz
+SRC_URI+="
 	test? (
 		https://dev.gentoo.org/~arthurzam/distfiles/dev-python/${PN}/test_sgmllib.py.gz
 	)

--- a/net-proxy/sshuttle/sshuttle-1.1.1.ebuild
+++ b/net-proxy/sshuttle/sshuttle-1.1.1.ebuild
@@ -15,11 +15,10 @@ SSHUTTLE_DOCS_USEFLAG="+doc"
 
 DISTUTILS_USE_PEP517=setuptools
 PYTHON_COMPAT=( python3_{9..11} )
-inherit distutils-r1 linux-info
+inherit distutils-r1 linux-info pypi
 
 DESCRIPTION="Transparent proxy server that works as a poor man's VPN using ssh"
 HOMEPAGE="https://github.com/sshuttle/sshuttle https://pypi.org/project/sshuttle/"
-SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 if [[ ${SSHUTTLE_DOCS_PREBUILT} == 1 ]] ; then
 	SRC_URI+=" !doc? ( https://dev.gentoo.org/~${SSHUTTLE_DOCS_PREBUILT_DEV}/distfiles/${CATEGORY}/${PN}/${PN}-${SSHUTTLE_DOCS_VERSION}-docs.tar.xz )"
 

--- a/x11-wm/xpra/xpra-4.3.4.ebuild
+++ b/x11-wm/xpra/xpra-4.3.4.ebuild
@@ -7,8 +7,10 @@ if [[ ${PV} = 9999* ]]; then
 	EGIT_REPO_URI="https://github.com/Xpra-org/xpra.git"
 	inherit git-r3
 else
-	SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz
-		https://dev.gentoo.org/~chewi/distfiles/${PN}-4.3.1-tests.patch"
+	inherit pypi
+	SRC_URI+="
+		https://dev.gentoo.org/~chewi/distfiles/${PN}-4.3.1-tests.patch
+	"
 	KEYWORDS="~amd64 ~x86"
 fi
 

--- a/x11-wm/xpra/xpra-9999.ebuild
+++ b/x11-wm/xpra/xpra-9999.ebuild
@@ -7,7 +7,7 @@ if [[ ${PV} = 9999* ]]; then
 	EGIT_REPO_URI="https://github.com/Xpra-org/xpra.git"
 	inherit git-r3
 else
-	SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
+	inherit pypi
 	KEYWORDS="~amd64 ~x86"
 fi
 


### PR DESCRIPTION
Third part, moderately easy, i.e. all ebuilds requiring `SRC_URI+=`. This includes one package that needed no-normalize switch.