### PR TITLE
app-editors/helix: Fix grammar build with 'debug' USE flag

### DIFF
--- a/app-editors/helix/helix-22.12.ebuild
+++ b/app-editors/helix/helix-22.12.ebuild
@@ -434,7 +434,7 @@ src_compile() {
 	cargo_src_compile
 
 	if use grammar; then
-		target/release/hx --grammar build || die
+		target/$(usex debug debug release)/hx --grammar build || die
 	fi
 }
 


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/901007