### PR TITLE
net-misc/nx: fix musl build

### DIFF
--- a/net-misc/nx/files/nx-3.5.99.25-musl.patch
+++ b/net-misc/nx/files/nx-3.5.99.25-musl.patch
@@ -1,0 +1,54 @@
+diff -uNr a/nx-X11/extras/Mesa_6.4.2/src/mesa/main/glheader.h b/nx-X11/extras/Mesa_6.4.2/src/mesa/main/glheader.h
+--- a/nx-X11/extras/Mesa_6.4.2/src/mesa/main/glheader.h	2020-11-04 06:43:58.000000000 -0600
++++ b/nx-X11/extras/Mesa_6.4.2/src/mesa/main/glheader.h	2023-03-16 12:58:34.515215736 -0600
+@@ -62,9 +62,6 @@
+ #include <stdlib.h>
+ #include <stdio.h>
+ #include <string.h>
+-#if defined(__linux__) && defined(__i386__)
+-#include <fpu_control.h>
+-#endif
+ #endif
+ #include <float.h>
+ #include <stdarg.h>
+diff -uNr a/nx-X11/extras/Mesa_6.4.2/src/mesa/main/imports.c b/nx-X11/extras/Mesa_6.4.2/src/mesa/main/imports.c
+--- a/nx-X11/extras/Mesa_6.4.2/src/mesa/main/imports.c	2020-11-04 06:43:58.000000000 -0600
++++ b/nx-X11/extras/Mesa_6.4.2/src/mesa/main/imports.c	2023-03-16 12:59:23.828001633 -0600
+@@ -1169,20 +1169,6 @@
+    static GLboolean initialized = GL_FALSE;
+    if (!initialized) {
+       init_sqrt_table();
+-
+-#if defined(_FPU_GETCW) && defined(_FPU_SETCW)
+-      {
+-         const char *debug = _mesa_getenv("MESA_DEBUG");
+-         if (debug && _mesa_strcmp(debug, "FP")==0) {
+-            /* die on FP exceptions */
+-            fpu_control_t mask;
+-            _FPU_GETCW(mask);
+-            mask &= ~(_FPU_MASK_IM | _FPU_MASK_DM | _FPU_MASK_ZM
+-                      | _FPU_MASK_OM | _FPU_MASK_UM);
+-            _FPU_SETCW(mask);
+-         }
+-      }
+-#endif
+       initialized = GL_TRUE;
+    }
+ 
+diff -uNr a/nx-X11/programs/Xserver/Xext/xf86bigfont.c b/nx-X11/programs/Xserver/Xext/xf86bigfont.c
+--- a/nx-X11/programs/Xserver/Xext/xf86bigfont.c	2020-11-04 06:43:58.000000000 -0600
++++ b/nx-X11/programs/Xserver/Xext/xf86bigfont.c	2023-03-16 13:01:30.256598143 -0600
+@@ -40,13 +40,6 @@
+ 
+ #include <sys/types.h>
+ #ifdef HAS_SHM
+-#if defined(linux) && (!defined(__GNU_LIBRARY__) || __GNU_LIBRARY__ < 2)
+-/* libc4 does not define __GNU_LIBRARY__, libc5 defines __GNU_LIBRARY__ as 1 */
+-/* Linux libc4 and libc5 only (because glibc doesn't include kernel headers):
+-   Linux 2.0.x and 2.2.x define SHMLBA as PAGE_SIZE, but forget to define
+-   PAGE_SIZE. It is defined in <asm/page.h>. */
+-#include <asm/page.h>
+-#endif
+ #ifdef SVR4
+ #include <sys/sysmacros.h>
+ #endif

--- a/net-misc/nx/files/nx-3.5.99.26-musl.patch
+++ b/net-misc/nx/files/nx-3.5.99.26-musl.patch
@@ -1,0 +1,55 @@
+diff -uNr a/nx-X11/extras/Mesa_6.4.2/src/mesa/main/glheader.h b/nx-X11/extras/Mesa_6.4.2/src/mesa/main/glheader.h
+--- a/nx-X11/extras/Mesa_6.4.2/src/mesa/main/glheader.h	2021-02-04 07:34:56.000000000 -0600
++++ b/nx-X11/extras/Mesa_6.4.2/src/mesa/main/glheader.h	2023-03-16 13:55:33.983114692 -0600
+@@ -62,9 +62,6 @@
+ #include <stdlib.h>
+ #include <stdio.h>
+ #include <string.h>
+-#if defined(__linux__) && defined(__i386__)
+-#include <fpu_control.h>
+-#endif
+ #endif
+ #include <float.h>
+ #include <stdarg.h>
+diff -uNr a/nx-X11/extras/Mesa_6.4.2/src/mesa/main/imports.c b/nx-X11/extras/Mesa_6.4.2/src/mesa/main/imports.c
+--- a/nx-X11/extras/Mesa_6.4.2/src/mesa/main/imports.c	2021-02-04 07:34:56.000000000 -0600
++++ b/nx-X11/extras/Mesa_6.4.2/src/mesa/main/imports.c	2023-03-16 13:56:25.569122176 -0600
+@@ -1169,20 +1169,6 @@
+    static GLboolean initialized = GL_FALSE;
+    if (!initialized) {
+       init_sqrt_table();
+-
+-#if defined(_FPU_GETCW) && defined(_FPU_SETCW)
+-      {
+-         const char *debug = _mesa_getenv("MESA_DEBUG");
+-         if (debug && _mesa_strcmp(debug, "FP")==0) {
+-            /* die on FP exceptions */
+-            fpu_control_t mask;
+-            _FPU_GETCW(mask);
+-            mask &= ~(_FPU_MASK_IM | _FPU_MASK_DM | _FPU_MASK_ZM
+-                      | _FPU_MASK_OM | _FPU_MASK_UM);
+-            _FPU_SETCW(mask);
+-         }
+-      }
+-#endif
+       initialized = GL_TRUE;
+    }
+ 
+diff -uNr a/nx-X11/programs/Xserver/Xext/xf86bigfont.c b/nx-X11/programs/Xserver/Xext/xf86bigfont.c
+--- a/nx-X11/programs/Xserver/Xext/xf86bigfont.c	2021-02-04 07:34:56.000000000 -0600
++++ b/nx-X11/programs/Xserver/Xext/xf86bigfont.c	2023-03-16 13:57:30.694956647 -0600
+@@ -40,14 +40,7 @@
+ 
+ #include <sys/types.h>
+ #ifdef HAS_SHM
+-#if defined(linux) && (!defined(__GNU_LIBRARY__) || __GNU_LIBRARY__ < 2)
+-/* libc4 does not define __GNU_LIBRARY__, libc5 defines __GNU_LIBRARY__ as 1 */
+-/* Linux libc4 and libc5 only (because glibc doesn't include kernel headers):
+-   Linux 2.0.x and 2.2.x define SHMLBA as PAGE_SIZE, but forget to define
+-   PAGE_SIZE. It is defined in <asm/page.h>. */
+-#include <asm/page.h>
+ #include <limits.h>
+-#endif
+ #ifdef SVR4
+ #include <sys/sysmacros.h>
+ #endif

--- a/net-misc/nx/nx-3.5.99.25.ebuild
+++ b/net-misc/nx/nx-3.5.99.25.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -41,6 +41,10 @@ BDEPEND="sys-apps/which
 	x11-misc/imake"
 
 S="${WORKDIR}/nx-libs-${PV}"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-3.5.99.25-musl.patch"
+)
 
 src_prepare() {
 	default

--- a/net-misc/nx/nx-3.5.99.26.ebuild
+++ b/net-misc/nx/nx-3.5.99.26.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -47,6 +47,7 @@ PATCHES=(
 	"${FILESDIR}/${PN}-3.5.99.26-binutils-2.36.patch"
 	# https://github.com/ArcticaProject/nx-libs/pull/1023
 	"${FILESDIR}/${PN}-3.5.99.26-riscv64-support.patch"
+	"${FILESDIR}/${PN}-3.5.99.26-musl.patch"
 )
 
 src_prepare() {


### PR DESCRIPTION
Signed-off-by: Cristian Othón Martínez Vera <cfuga@cfuga.mx>
Bug: https://bugs.gentoo.org/713418

This patch comes from the following upstream commits.

* mesa - Remove use of fpu_control.h (https://gitlab.freedesktop.org/mesa/mesa/-/commit/eb0ff1a1c0f1978d867c748bf2525f717a56bfce)

Remove the inclusion of fpu_control.h from compiler.h.  Since Bionic lacks fpu_control.h, this fixes the Android build.

Also remove the sole use of the fpu_control bits, which was in debug.c. Those were brianp's debug bits, and he approved of their removal.

* xorg/xserver - Drop workaround for pre-glibc linux (https://gitlab.freedesktop.org/xorg/xserver/-/commit/6634ffc4d26846dcf892f27682f9021f6d9956a9)

It seems unlikely anyone still needs to build against libc4/libc5.
