### PR TITLE
sci-libs/caffe2: sci-libs/caffe2-1.13.1-r4 fails during install - rm:…

### DIFF
--- a/sci-libs/caffe2/caffe2-1.13.1-r4.ebuild
+++ b/sci-libs/caffe2/caffe2-1.13.1-r4.ebuild
@@ -178,7 +178,7 @@ src_install() {
 	mv "${ED}"/usr/lib/python*/site-packages/caffe2 python/ || die
 	mv "${ED}"/usr/include/torch python/torch/include || die
 	cp torch/version.py python/torch/ || die
-	rm -r "${ED}"/var/tmp || die
+	rm -rf "${ED}"/var/tmp || die
 	python_domodule python/caffe2
 	python_domodule python/torch
 }


### PR DESCRIPTION
… cannot remove '/dev/shm/portage/sci-libs/caffe2-1.13.1-r4/image/var/tmp': No such file or directory

Closes: https://bugs.gentoo.org/901967