### PR TITLE
sci-libs/nlopt: Fortran is only needed for tests

### DIFF
--- a/sci-libs/nlopt/nlopt-2.7.1-r1.ebuild
+++ b/sci-libs/nlopt/nlopt-2.7.1-r1.ebuild
@@ -4,6 +4,7 @@
 EAPI=8
 
 PYTHON_COMPAT=( python3_{9..10} )
+FORTRAN_NEEDED="test"
 
 inherit python-r1 cmake fortran-2
 

--- a/sci-libs/nlopt/nlopt-2.7.1-r2.ebuild
+++ b/sci-libs/nlopt/nlopt-2.7.1-r2.ebuild
@@ -4,6 +4,7 @@
 EAPI=8
 
 PYTHON_COMPAT=( python3_{9..11} )
+FORTRAN_NEEDED="test"
 
 inherit python-r1 cmake fortran-2
 


### PR DESCRIPTION
Fortran is only needed for tests in nlopt, added `FORTRAN_NEEDED="test"` before the fortran-2 inherit to prevent pulling in gcc unnecessarily.