### PR TITLE
Bitcoin Core: old versions support newer dev-libs/libsecp256k1

### DIFF
--- a/dev-util/bitcoin-tx/bitcoin-tx-0.21.0-r1.ebuild
+++ b/dev-util/bitcoin-tx/bitcoin-tx-0.21.0-r1.ebuild
@@ -62,6 +62,8 @@ src_prepare() {
 		eapply "${knots_patchdir}/${KNOTS_P}.ts.patch"
 	fi
 
+	eapply "${FILESDIR}/0.21.0-compat-libsecp256k1-0.1_pre20210628.patch"
+
 	eapply_user
 
 	echo '#!/bin/true' >share/genbuild.sh || die

--- a/dev-util/bitcoin-tx/bitcoin-tx-22.0-r1.ebuild
+++ b/dev-util/bitcoin-tx/bitcoin-tx-22.0-r1.ebuild
@@ -70,7 +70,12 @@ src_prepare() {
 		eapply "${knots_patchdir}/${KNOTS_P}_p5-ts.patch"
 	fi
 
+	eapply "${FILESDIR}/22.0-compat-libsecp256k1-0.1_pre20210628.patch"
+
 	default
+
+	# fix Bashism (see cf7292597e18ffca06b0fbf8bcd545aec387e380)
+	sed -e 's/==/=/g' -i configure.ac || die
 
 	eautoreconf
 	rm -r src/leveldb src/secp256k1 || die

--- a/dev-util/bitcoin-tx/files/0.21.0-compat-libsecp256k1-0.1_pre20210628.patch
+++ b/dev-util/bitcoin-tx/files/0.21.0-compat-libsecp256k1-0.1_pre20210628.patch
@@ -1,0 +1,1 @@
+../../../net-p2p/bitcoind/files/0.21.0-compat-libsecp256k1-0.1_pre20210628.patch

--- a/dev-util/bitcoin-tx/files/22.0-compat-libsecp256k1-0.1_pre20210628.patch
+++ b/dev-util/bitcoin-tx/files/22.0-compat-libsecp256k1-0.1_pre20210628.patch
@@ -1,0 +1,1 @@
+../../../net-p2p/bitcoind/files/22.0-compat-libsecp256k1-0.1_pre20210628.patch

--- a/net-p2p/bitcoin-qt/bitcoin-qt-0.21.0.ebuild
+++ b/net-p2p/bitcoin-qt/bitcoin-qt-0.21.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -100,6 +100,7 @@ src_prepare() {
 		eapply "${knots_patchdir}/${KNOTS_P}.ts.patch"
 	fi
 
+	eapply "${FILESDIR}/0.21.0-compat-libsecp256k1-0.1_pre20210628.patch"
 	eapply "${FILESDIR}/${PN}-0.20.1-boost-1.77-compat.patch"
 
 	eapply_user

--- a/net-p2p/bitcoin-qt/bitcoin-qt-22.0.ebuild
+++ b/net-p2p/bitcoin-qt/bitcoin-qt-22.0.ebuild
@@ -132,7 +132,12 @@ src_prepare() {
 		eapply "${knots_patchdir}/${KNOTS_P}_p5-ts.patch"
 	fi
 
+	eapply "${FILESDIR}/22.0-compat-libsecp256k1-0.1_pre20210628.patch"
+
 	eapply_user
+
+	# fix Bashism (see cf7292597e18ffca06b0fbf8bcd545aec387e380)
+	sed -e 's/==/=/g' -i configure.ac || die
 
 	eautoreconf
 	rm -r src/leveldb src/secp256k1 || die

--- a/net-p2p/bitcoin-qt/files/0.21.0-compat-libsecp256k1-0.1_pre20210628.patch
+++ b/net-p2p/bitcoin-qt/files/0.21.0-compat-libsecp256k1-0.1_pre20210628.patch
@@ -1,0 +1,1 @@
+../../bitcoind/files/0.21.0-compat-libsecp256k1-0.1_pre20210628.patch

--- a/net-p2p/bitcoin-qt/files/22.0-compat-libsecp256k1-0.1_pre20210628.patch
+++ b/net-p2p/bitcoin-qt/files/22.0-compat-libsecp256k1-0.1_pre20210628.patch
@@ -1,0 +1,1 @@
+../../bitcoind/files/22.0-compat-libsecp256k1-0.1_pre20210628.patch

--- a/net-p2p/bitcoind/bitcoind-0.21.0.ebuild
+++ b/net-p2p/bitcoind/bitcoind-0.21.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -85,6 +85,7 @@ src_prepare() {
 		eapply "${knots_patchdir}/${KNOTS_P}.ts.patch"
 	fi
 
+	eapply "${FILESDIR}/0.21.0-compat-libsecp256k1-0.1_pre20210628.patch"
 	eapply "${FILESDIR}/${PN}-0.20.1-boost-1.77-compat.patch"
 
 	default

--- a/net-p2p/bitcoind/bitcoind-22.0.ebuild
+++ b/net-p2p/bitcoind/bitcoind-22.0.ebuild
@@ -117,7 +117,12 @@ src_prepare() {
 		eapply "${knots_patchdir}/${KNOTS_P}_p5-ts.patch"
 	fi
 
+	eapply "${FILESDIR}/22.0-compat-libsecp256k1-0.1_pre20210628.patch"
+
 	default
+
+	# fix Bashism (see cf7292597e18ffca06b0fbf8bcd545aec387e380)
+	sed -e 's/==/=/g' -i configure.ac || die
 
 	eautoreconf
 	rm -r src/leveldb src/secp256k1 || die

--- a/net-p2p/bitcoind/files/0.21.0-compat-libsecp256k1-0.1_pre20210628.patch
+++ b/net-p2p/bitcoind/files/0.21.0-compat-libsecp256k1-0.1_pre20210628.patch
@@ -1,0 +1,68 @@
+From 683e6d1031e72215bd36041e3ca20eb3a450d716 Mon Sep 17 00:00:00 2001
+From: Matt Whitlock <bitcoin@mattwhitlock.name>
+Date: Sat, 19 Feb 2022 17:18:45 -0500
+Subject: [PATCH] support libsecp256k1 schnorrsig ABI changes from 2021-06-27
+
+Some schnorrsig function prototypes changed in June 2021, thus breaking
+the builds of Bitcoin Knots (and Core). This commit introduces an
+Autoconf check for the introduced secp256k1_schnorrsig_sign_custom
+symbol and adds some preprocessor conditional directives to fix up the
+call sites of the affected functions to maintain compatibility.
+
+See: https://github.com/bitcoin-core/secp256k1/commit/b6c0b72fb06e3c31121f1ef4403d2a229a31ec1c
+See: https://github.com/bitcoin-core/secp256k1/commit/a0c3fc177f7f435e593962504182c3861c47d1be
+Signed-off-by: Matt Whitlock <bitcoin@mattwhitlock.name>
+---
+ configure.ac   |  7 +++++++
+ src/pubkey.cpp | 10 +++++++++-
+ 2 files changed, 16 insertions(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index 0c34fc7f52..c06d68a954 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -1298,6 +1298,13 @@ AC_ARG_WITH([system-libsecp256k1],
+ )
+ if test x$system_libsecp256k1 != xno; then
+   PKG_CHECK_MODULES([libsecp256k1],[libsecp256k1],,[true])
++  TEMP_CFLAGS="$CFLAGS"
++  TEMP_LIBS="$LIBS"
++  CFLAGS="$libsecp256k1_CFLAGS $CFLAGS"
++  LIBS="$libsecp256k1_LIBS $LIBS"
++  AC_CHECK_FUNCS([secp256k1_schnorrsig_sign_custom])
++  CFLAGS="$TEMP_CFLAGS"
++  LIBS="$TEMP_LIBS"
+ else
+   libsecp256k1_CFLAGS='-I$(srcdir)/secp256k1/include'
+   libsecp256k1_LIBS='secp256k1/libsecp256k1.la'
+diff --git a/src/pubkey.cpp b/src/pubkey.cpp
+index 4d734fc891..40c7724afa 100644
+--- a/src/pubkey.cpp
++++ b/src/pubkey.cpp
+@@ -3,6 +3,10 @@
+ // Distributed under the MIT software license, see the accompanying
+ // file COPYING or http://www.opensource.org/licenses/mit-license.php.
+ 
++#if defined(HAVE_CONFIG_H)
++#include <config/bitcoin-config.h>
++#endif
++
+ #include <pubkey.h>
+ 
+ #include <secp256k1.h>
+@@ -178,7 +182,11 @@ bool XOnlyPubKey::VerifySchnorr(const uint256& msg, Span<const unsigned char> si
+     assert(sigbytes.size() == 64);
+     secp256k1_xonly_pubkey pubkey;
+     if (!secp256k1_xonly_pubkey_parse(secp256k1_context_verify, &pubkey, m_keydata.data())) return false;
+-    return secp256k1_schnorrsig_verify(secp256k1_context_verify, sigbytes.data(), msg.begin(), &pubkey);
++    return secp256k1_schnorrsig_verify(secp256k1_context_verify, sigbytes.data(), msg.begin(),
++#if HAVE_SECP256K1_SCHNORRSIG_SIGN_CUSTOM
++            msg.size(),
++#endif
++            &pubkey);
+ }
+ 
+ bool XOnlyPubKey::CheckPayToContract(const XOnlyPubKey& base, const uint256& hash, bool parity) const
+-- 
+2.40.0
+

--- a/net-p2p/bitcoind/files/22.0-compat-libsecp256k1-0.1_pre20210628.patch
+++ b/net-p2p/bitcoind/files/22.0-compat-libsecp256k1-0.1_pre20210628.patch
@@ -1,0 +1,98 @@
+From 14d45f26b45e6362439c24f87cffb7dd70d09719 Mon Sep 17 00:00:00 2001
+From: Matt Whitlock <bitcoin@mattwhitlock.name>
+Date: Sat, 19 Feb 2022 17:18:45 -0500
+Subject: [PATCH] support libsecp256k1 schnorrsig ABI changes from 2021-06-27
+
+Some schnorrsig function prototypes changed in June 2021, thus breaking
+the builds of Bitcoin Knots (and Core). This commit introduces an
+Autoconf check for the introduced secp256k1_schnorrsig_sign_custom
+symbol and adds some preprocessor conditional directives to fix up the
+call sites of the affected functions to maintain compatibility.
+
+See: https://github.com/bitcoin-core/secp256k1/commit/b6c0b72fb06e3c31121f1ef4403d2a229a31ec1c
+See: https://github.com/bitcoin-core/secp256k1/commit/a0c3fc177f7f435e593962504182c3861c47d1be
+Signed-off-by: Matt Whitlock <bitcoin@mattwhitlock.name>
+---
+ configure.ac   |  7 +++++++
+ src/key.cpp    | 11 ++++++++++-
+ src/pubkey.cpp | 10 +++++++++-
+ 3 files changed, 26 insertions(+), 2 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index 3b2edd1b13..0d6f021cde 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -1324,6 +1324,13 @@ AC_ARG_WITH([system-libsecp256k1],
+ )
+ if test x$system_libsecp256k1 != xno; then
+   PKG_CHECK_MODULES([libsecp256k1],[libsecp256k1],,[true])
++  TEMP_CFLAGS="$CFLAGS"
++  TEMP_LIBS="$LIBS"
++  CFLAGS="$libsecp256k1_CFLAGS $CFLAGS"
++  LIBS="$libsecp256k1_LIBS $LIBS"
++  AC_CHECK_FUNCS([secp256k1_schnorrsig_sign_custom])
++  CFLAGS="$TEMP_CFLAGS"
++  LIBS="$TEMP_LIBS"
+ else
+   libsecp256k1_CFLAGS='-I$(srcdir)/secp256k1/include'
+   libsecp256k1_LIBS='secp256k1/libsecp256k1.la'
+diff --git a/src/key.cpp b/src/key.cpp
+index dcad386e77..9fffd36a05 100644
+--- a/src/key.cpp
++++ b/src/key.cpp
+@@ -3,6 +3,10 @@
+ // Distributed under the MIT software license, see the accompanying
+ // file COPYING or http://www.opensource.org/licenses/mit-license.php.
+ 
++#if defined(HAVE_CONFIG_H)
++#include <config/bitcoin-config.h>
++#endif
++
+ #include <key.h>
+ 
+ #include <crypto/common.h>
+@@ -274,7 +278,12 @@ bool CKey::SignSchnorr(const uint256& hash, Span<unsigned char> sig, const uint2
+         uint256 tweak = XOnlyPubKey(pubkey_bytes).ComputeTapTweakHash(merkle_root->IsNull() ? nullptr : merkle_root);
+         if (!secp256k1_keypair_xonly_tweak_add(GetVerifyContext(), &keypair, tweak.data())) return false;
+     }
+-    bool ret = secp256k1_schnorrsig_sign(secp256k1_context_sign, sig.data(), hash.data(), &keypair, secp256k1_nonce_function_bip340, aux ? (void*)aux->data() : nullptr);
++    bool ret = secp256k1_schnorrsig_sign(secp256k1_context_sign, sig.data(), hash.data(), &keypair,
++#if HAVE_SECP256K1_SCHNORRSIG_SIGN_CUSTOM
++            aux ? aux->data() : nullptr);
++#else
++            secp256k1_nonce_function_bip340, aux ? (void*)aux->data() : nullptr);
++#endif
+     memory_cleanse(&keypair, sizeof(keypair));
+     return ret;
+ }
+diff --git a/src/pubkey.cpp b/src/pubkey.cpp
+index 175a39b805..6bf938a1fd 100644
+--- a/src/pubkey.cpp
++++ b/src/pubkey.cpp
+@@ -3,6 +3,10 @@
+ // Distributed under the MIT software license, see the accompanying
+ // file COPYING or http://www.opensource.org/licenses/mit-license.php.
+ 
++#if defined(HAVE_CONFIG_H)
++#include <config/bitcoin-config.h>
++#endif
++
+ #include <pubkey.h>
+ 
+ #include <hash.h>
+@@ -191,7 +195,11 @@ bool XOnlyPubKey::VerifySchnorr(const uint256& msg, Span<const unsigned char> si
+     assert(sigbytes.size() == 64);
+     secp256k1_xonly_pubkey pubkey;
+     if (!secp256k1_xonly_pubkey_parse(secp256k1_context_verify, &pubkey, m_keydata.data())) return false;
+-    return secp256k1_schnorrsig_verify(secp256k1_context_verify, sigbytes.data(), msg.begin(), &pubkey);
++    return secp256k1_schnorrsig_verify(secp256k1_context_verify, sigbytes.data(), msg.begin(),
++#if HAVE_SECP256K1_SCHNORRSIG_SIGN_CUSTOM
++            msg.size(),
++#endif
++            &pubkey);
+ }
+ 
+ static const CHashWriter HASHER_TAPTWEAK = TaggedHash("TapTweak");
+-- 
+2.35.1
+


### PR DESCRIPTION
dev-util/bitcoin-tx-0.21-0-r1
dev-util/bitcoin-tx-22.0-r1
net-p2p/bitcoind-0.21.0
net-p2p/bitcoind-22.0
net-p2p/bitcoin-qt-0.21.0
net-p2p/bitcoin-qt-22.0

Closes: https://bugs.gentoo.org/901367