### PR TITLE
app-emulation/virtualbox: fix compilation with old GNU tar

### DIFF
--- a/app-emulation/virtualbox/virtualbox-6.1.42.ebuild
+++ b/app-emulation/virtualbox/virtualbox-6.1.42.ebuild
@@ -102,7 +102,7 @@ DEPEND="
 "
 BDEPEND="
 	${PYTHON_DEPS}
-	app-arch/tar
+	>=app-arch/tar-1.34-r2
 	>=dev-util/kbuild-0.1.9998.3127
 	>=dev-lang/yasm-0.6.2
 	dev-libs/libIDL

--- a/app-emulation/virtualbox/virtualbox-7.0.6-r2.ebuild
+++ b/app-emulation/virtualbox/virtualbox-7.0.6-r2.ebuild
@@ -126,7 +126,7 @@ RDEPEND="
 "
 BDEPEND="
 	${PYTHON_DEPS}
-	app-arch/tar
+	>=app-arch/tar-1.34-r2
 	>=dev-lang/yasm-0.6.2
 	dev-libs/libIDL
 	dev-util/glslang


### PR DESCRIPTION
Pin GNU tar to a version >=1.34-r2.

Closes: https://bugs.gentoo.org/901987
Signed-off-by: Viorel Munteanu <ceamac@gentoo.org>
