### PR TITLE
Add `GHC_BOOTSTRAP_PACKAGES` to ebuilds that need it

### DIFF
--- a/app-portage/hackport/hackport-0.7.2.2.ebuild
+++ b/app-portage/hackport/hackport-0.7.2.2.ebuild
@@ -16,6 +16,10 @@ LICENSE="GPL-3+"
 SLOT="0"
 KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
+GHC_BOOTSTRAP_PACKAGES=(
+	cabal-doctest
+)
+
 RDEPEND=">=dev-haskell/async-2.0:=
 	>=dev-haskell/base16-bytestring-0.1.1:=
 	>=dev-haskell/base64-bytestring-1.0:=

--- a/dev-haskell/wai-logger/wai-logger-2.3.6.ebuild
+++ b/dev-haskell/wai-logger/wai-logger-2.3.6.ebuild
@@ -17,6 +17,10 @@ SLOT="0/${PV}"
 KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
+GHC_BOOTSTRAP_PACKAGES=(
+	cabal-doctest
+)
+
 RESTRICT=test # does not specify full dependencies
 
 RDEPEND="dev-haskell/byteorder:=[profile?]

--- a/dev-vcs/git-annex/git-annex-10.20220624.ebuild
+++ b/dev-vcs/git-annex/git-annex-10.20220624.ebuild
@@ -19,6 +19,13 @@ IUSE="+assistant +benchmark +dbus debug doc +gitlfs +magicmime +pairing +torrent
 
 REQUIRED_USE="webapp? ( assistant )"
 
+GHC_BOOTSTRAP_PACKAGES=(
+	async
+	filepath-bytestring
+	split
+	unix-compat
+)
+
 RDEPEND="dev-haskell/aeson:=
 	>=dev-haskell/ansi-terminal-0.9:=
 	dev-haskell/async:=


### PR DESCRIPTION
These got left out in https://github.com/gentoo/gentoo/pull/29961, but are needed to get through the configuration phase.