### PR TITLE
net-mail/vpopmail: add missing headers in configure tests

### DIFF
--- a/net-mail/vpopmail/files/vpopmail-5.4.33-add-missing-headers-in-configure-tests.patch
+++ b/net-mail/vpopmail/files/vpopmail-5.4.33-add-missing-headers-in-configure-tests.patch
@@ -1,0 +1,40 @@
+From 6a2bc617c8ca8368697e971b6456b5b07a1c8b18 Mon Sep 17 00:00:00 2001
+From: Rolf Eike Beer <eike@sf-mail.de>
+Date: Thu, 15 Dec 2022 21:34:18 +0100
+Subject: [PATCH 1/5] add missing headers in configure tests
+
+See: https://bugs.gentoo.org/885873
+---
+ configure    | 2 ++
+ configure.in | 2 ++
+ 2 files changed, 4 insertions(+)
+
+diff --git a/configure b/configure
+index 43030d8..a4b0d54 100755
+--- a/configure
++++ b/configure
+@@ -5686,6 +5686,8 @@ else
+   #include <stdio.h>
+   #include <pwd.h>
+   #include <stdlib.h>
++  #include <string.h>
++  #include <unistd.h>
+ 
+   int main() {
+     struct passwd *pw;
+diff --git a/configure.in b/configure.in
+index c4e32d4..f557f26 100644
+--- a/configure.in
++++ b/configure.in
+@@ -423,6 +423,8 @@ AC_TRY_RUN( [
+   #include <stdio.h>
+   #include <pwd.h>
+   #include <stdlib.h>
++  #include <string.h>
++  #include <unistd.h>
+ 
+   int main() {
+     struct passwd *pw;
+-- 
+2.35.3
+

--- a/net-mail/vpopmail/vpopmail-5.4.33-r9.ebuild
+++ b/net-mail/vpopmail/vpopmail-5.4.33-r9.ebuild
@@ -42,6 +42,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-5.4.33-use-proper-printf-format-strings.patch
 	"${FILESDIR}"/${PN}-5.4.33-vpgsql-onchange.patch
 	"${FILESDIR}"/${PN}-5.4.33-avoid-duplicate-definitions-of-MYSQL_READ_-and-MYSQL.patch
+	"${FILESDIR}"/${PN}-5.4.33-add-missing-headers-in-configure-tests.patch
 )
 DOCS=(
 	ChangeLog


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/885873
Closes: https://bugs.gentoo.org/900192

Looks like this never made it to the main tree for whatever reason.