### PR TITLE
dev-util/bcc: bump LLVM_MAX_SLOT to 16

### DIFF
--- a/dev-util/bcc/bcc-0.26.0-r2.ebuild
+++ b/dev-util/bcc/bcc-0.26.0-r2.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 LUA_COMPAT=( luajit )
 PYTHON_COMPAT=( python3_{9..11} )
-LLVM_MAX_SLOT=15
+LLVM_MAX_SLOT=16
 
 inherit cmake linux-info llvm lua-single python-r1 toolchain-funcs
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/902129
