### PR TITLE
dev-util/bpftrace: fixes for llvm-16

### DIFF
--- a/dev-util/bpftrace/bpftrace-0.17.0-r3.ebuild
+++ b/dev-util/bpftrace/bpftrace-0.17.0-r3.ebuild
@@ -55,6 +55,8 @@ PATCHES=(
 	"${FILESDIR}/bpftrace-0.17.0-install-libs.patch"
 	"${FILESDIR}/bpftrace-0.15.0-dont-compress-man.patch"
 	"${FILESDIR}/bpftrace-0.11.4-old-kernels.patch"
+	"${FILESDIR}/bpftrace-0.17.0-llvm-16.patch"
+	"${FILESDIR}/bpftrace-0.17.0-use-std-optional.patch"
 )
 
 pkg_pretend() {

--- a/dev-util/bpftrace/files/bpftrace-0.17.0-llvm-16.patch
+++ b/dev-util/bpftrace/files/bpftrace-0.17.0-llvm-16.patch
@@ -1,0 +1,26 @@
+
+From: https://github.com/iovisor/bpftrace/pull/2528
+
+From a91064d7fb26626d79719c2e2a13cc2acab9549a Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Fri, 10 Mar 2023 00:08:27 -0800
+Subject: [PATCH] cmake: Raise max llvm major version to 16
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 0a7914f580d..341ac7e9c1f 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -165,7 +165,7 @@ else()
+   endif()
+ 
+   set(MIN_LLVM_MAJOR 6)
+-  set(MAX_LLVM_MAJOR 15)
++  set(MAX_LLVM_MAJOR 16)
+ 
+   if((${LLVM_VERSION_MAJOR} VERSION_LESS ${MIN_LLVM_MAJOR}) OR (${LLVM_VERSION_MAJOR} VERSION_GREATER ${MAX_LLVM_MAJOR}))
+     message(SEND_ERROR "Unsupported LLVM version found via ${LLVM_INCLUDE_DIRS}: ${LLVM_VERSION_MAJOR}")

--- a/dev-util/bpftrace/files/bpftrace-0.17.0-use-std-optional.patch
+++ b/dev-util/bpftrace/files/bpftrace-0.17.0-use-std-optional.patch
@@ -1,0 +1,44 @@
+
+From: https://github.com/iovisor/bpftrace/pull/2525
+
+From a794397394aa836f776da17c8e08876a2f64d477 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Mon, 13 Mar 2023 21:30:27 -0700
+Subject: [PATCH] ast: Use std::optional in CodegenLLVM::CodegenLLVM call
+
+Fixes build with clang-16
+
+src/ast/passes/codegen_llvm.cpp:63:53: error: use of undeclared identifier 'Optional'; did you mean 'std::optional'?
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ src/ast/passes/codegen_llvm.cpp | 16 +++++++++++-----
+ 1 file changed, 11 insertions(+), 5 deletions(-)
+
+diff --git a/src/ast/passes/codegen_llvm.cpp b/src/ast/passes/codegen_llvm.cpp
+index 616ff89ddbc..fe440adf373 100644
+--- a/src/ast/passes/codegen_llvm.cpp
++++ b/src/ast/passes/codegen_llvm.cpp
+@@ -56,11 +56,17 @@ CodegenLLVM::CodegenLLVM(Node *root, BPFtrace &bpftrace)
+     throw std::runtime_error(
+         "Could not find bpf llvm target, does your llvm support it?");
+ 
+-  target_machine_.reset(target->createTargetMachine(LLVMTargetTriple,
+-                                                    "generic",
+-                                                    "",
+-                                                    TargetOptions(),
+-                                                    Optional<Reloc::Model>()));
++  target_machine_.reset(
++      target->createTargetMachine(LLVMTargetTriple,
++                                  "generic",
++                                  "",
++                                  TargetOptions(),
++#if LLVM_VERSION_MAJOR >= 16
++                                  std::optional<Reloc::Model>()
++#else
++                                  Optional<Reloc::Model>()
++#endif
++                                      ));
+   target_machine_->setOptLevel(llvm::CodeGenOpt::Aggressive);
+ 
+   module_->setTargetTriple(LLVMTargetTriple);


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/902135
