### PR TITLE
dev-ruby/llhttp-ffi: add explicit rspec test dep

### DIFF
--- a/dev-ruby/llhttp-ffi/llhttp-ffi-0.4.0.ebuild
+++ b/dev-ruby/llhttp-ffi/llhttp-ffi-0.4.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -22,7 +22,10 @@ RUBY_S="llhttp-${MY_PV}/ffi"
 
 ruby_add_rdepend "=dev-ruby/ffi-compiler-1*"
 
-ruby_add_bdepend "test? ( dev-ruby/async-io )"
+ruby_add_bdepend "test? (
+	dev-ruby/async-io
+	dev-ruby/rspec:3
+)"
 
 all_ruby_prepare() {
 	sed -i -e 's/gem "rake-compiler"//g' "Gemfile" || die


### PR DESCRIPTION
Needs to be a test dep, but should NOT have RUBY_FAKEGEM_RECIPE_TEST set as it needs to be called via rake.