### PR TITLE
sys-apps/portage: RDEPEND on >=sys-apps/baselayout-2.9

### DIFF
--- a/sys-apps/portage/portage-3.0.44.ebuild
+++ b/sys-apps/portage/portage-3.0.44.ebuild
@@ -44,6 +44,7 @@ RDEPEND="
 	app-arch/zstd
 	>=app-arch/tar-1.27
 	dev-lang/python-exec:2
+	>=sys-apps/baselayout-2.9
 	>=sys-apps/findutils-4.4
 	!build? (
 		>=sys-apps/sed-4.0.5

--- a/sys-apps/portage/portage-3.0.45.2.ebuild
+++ b/sys-apps/portage/portage-3.0.45.2.ebuild
@@ -44,6 +44,7 @@ RDEPEND="
 	app-arch/zstd
 	>=app-arch/tar-1.27
 	dev-lang/python-exec:2
+	>=sys-apps/baselayout-2.9
 	>=sys-apps/findutils-4.4
 	!build? (
 		>=sys-apps/sed-4.0.5

--- a/sys-apps/portage/portage-3.0.45.3.ebuild
+++ b/sys-apps/portage/portage-3.0.45.3.ebuild
@@ -44,6 +44,7 @@ RDEPEND="
 	app-arch/zstd
 	>=app-arch/tar-1.27
 	dev-lang/python-exec:2
+	>=sys-apps/baselayout-2.9
 	>=sys-apps/findutils-4.4
 	!build? (
 		>=sys-apps/sed-4.0.5

--- a/sys-apps/portage/portage-9999.ebuild
+++ b/sys-apps/portage/portage-9999.ebuild
@@ -43,6 +43,7 @@ RDEPEND="
 	app-arch/zstd
 	>=app-arch/tar-1.27
 	dev-lang/python-exec:2
+	>=sys-apps/baselayout-2.9
 	>=sys-apps/findutils-4.4
 	!build? (
 		>=sys-apps/sed-4.0.5


### PR DESCRIPTION
This ensures that baselayout defines PATH and that PATH/ROOTPATH do not differ.

Closes: https://bugs.gentoo.org/902213