### PR TITLE
app-containers/podman: fix quadlet generation issue

### DIFF
--- a/app-containers/podman/podman-4.4.1.ebuild
+++ b/app-containers/podman/podman-4.4.1.ebuild
@@ -100,6 +100,7 @@ src_compile() {
 	export -n GOCACHE GOPATH XDG_CACHE_HOME
 	GOBIN="${S}/bin" \
 		emake all \
+			PREFIX="${EPREFIX}/usr" \
 			GIT_BRANCH=master \
 			GIT_BRANCH_CLEAN=master \
 			COMMIT_NO="${git_commit}" \


### PR DESCRIPTION
Without prefix, the podman path generated by quadlet was targetting /usr/local/bin/podman (instead of /usr/bin/podman)

Bug: https://bugs.gentoo.org/895956