### PR TITLE
acct-user/deluge:

### DIFF
--- a/acct-user/deluge/deluge-0-r1.ebuild
+++ b/acct-user/deluge/deluge-0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 Gentoo Authors
+# Copyright 2019-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,5 +8,6 @@ inherit acct-user
 DESCRIPTION="user for deluge"
 ACCT_USER_ID=454
 ACCT_USER_GROUPS=( deluge )
+ACCT_USER_HOME=/var/lib/deluge
 
 acct-user_add_deps


### PR DESCRIPTION
Sets homedir for the 'deluge' user to '/var/lib/deluge' which is the default working directory for both deluged and deluge-web when started with openrc. This change makes the openrc scripts work out-of-the-box after emerging deluge.

Previously users were required to manually create and set permissions for this directory and/or edit configs for deluged and deluge-web for them to be startable via openrc. Since the deluge user also writes logs to this directory by default, this solution is not always apparent to users.

Closes: https://bugs.gentoo.org/828507