### PR TITLE
sys-devel/clang-common: Fix a warning when using -Weverything

### DIFF
--- a/sys-devel/clang-common/clang-common-15.0.7-r5.ebuild
+++ b/sys-devel/clang-common/clang-common-15.0.7-r5.ebuild
@@ -107,6 +107,9 @@ src_install() {
 	# without optimization and that would at the very least be very noisy
 	# during builds and at worst trigger many -Werror builds.
 	cat >> "${ED}/usr/include/gentoo/fortify.h" <<- EOF || die
+	#ifdef __clang__
+	# pragma clang system_header
+	#endif
 	#ifndef _FORTIFY_SOURCE
 	# if defined(__has_feature)
 	#  define __GENTOO_HAS_FEATURE(x) __has_feature(x)

--- a/sys-devel/clang-common/clang-common-16.0.0-r1.ebuild
+++ b/sys-devel/clang-common/clang-common-16.0.0-r1.ebuild
@@ -106,6 +106,9 @@ src_install() {
 	# without optimization and that would at the very least be very noisy
 	# during builds and at worst trigger many -Werror builds.
 	cat >> "${ED}/usr/include/gentoo/fortify.h" <<- EOF || die
+	#ifdef __clang__
+	# pragma clang system_header
+	#endif
 	#ifndef _FORTIFY_SOURCE
 	# if defined(__has_feature)
 	#  define __GENTOO_HAS_FEATURE(x) __has_feature(x)

--- a/sys-devel/clang-common/clang-common-16.0.0.9999.ebuild
+++ b/sys-devel/clang-common/clang-common-16.0.0.9999.ebuild
@@ -106,6 +106,9 @@ src_install() {
 	# without optimization and that would at the very least be very noisy
 	# during builds and at worst trigger many -Werror builds.
 	cat >> "${ED}/usr/include/gentoo/fortify.h" <<- EOF || die
+	#ifdef __clang__
+	# pragma clang system_header
+	#endif
 	#ifndef _FORTIFY_SOURCE
 	# if defined(__has_feature)
 	#  define __GENTOO_HAS_FEATURE(x) __has_feature(x)

--- a/sys-devel/clang-common/clang-common-17.0.0.9999.ebuild
+++ b/sys-devel/clang-common/clang-common-17.0.0.9999.ebuild
@@ -106,6 +106,9 @@ src_install() {
 	# without optimization and that would at the very least be very noisy
 	# during builds and at worst trigger many -Werror builds.
 	cat >> "${ED}/usr/include/gentoo/fortify.h" <<- EOF || die
+	#ifdef __clang__
+	# pragma clang system_header
+	#endif
 	#ifndef _FORTIFY_SOURCE
 	# if defined(__has_feature)
 	#  define __GENTOO_HAS_FEATURE(x) __has_feature(x)

--- a/sys-devel/clang-common/clang-common-17.0.0_pre20230314-r1.ebuild
+++ b/sys-devel/clang-common/clang-common-17.0.0_pre20230314-r1.ebuild
@@ -106,6 +106,9 @@ src_install() {
 	# without optimization and that would at the very least be very noisy
 	# during builds and at worst trigger many -Werror builds.
 	cat >> "${ED}/usr/include/gentoo/fortify.h" <<- EOF || die
+	#ifdef __clang__
+	# pragma clang system_header
+	#endif
 	#ifndef _FORTIFY_SOURCE
 	# if defined(__has_feature)
 	#  define __GENTOO_HAS_FEATURE(x) __has_feature(x)


### PR DESCRIPTION
This warning is caused by the fortify.h header that has a system-reserved macro name. This commit simply adds diagnostic pragmas to avoid it and revert back to the original diagnostic state.

I surrounded the pragmas with `#ifdef __clang__` and such in case this header is used for GCC or other compilers, but according to a Gentoo maintainer, this is not strictly necessary.

I incremented the revision number on 15.0.7-4, 16.0.0, and 17.0.0_pre20230314 but I did not increment them on 16.0.0.999 and 17.0.0.999. I may be wrong, but it doesn't seem like revisions should be incremented on ebuilds that follow the latest commits of projects.

I thought I had read about that somewhere, but the only source I could find was [1], and that one did not mention anything about 9999-type ebuilds and revision numbers.

That said, [2] did have an example where a _pre* ebuild had a revision number, so I specifically added a revision number to 17.0.0_pre20230314.

Also, [1] said to not add a revision number if the fix is trivial and would not be worth it with the compile times. However, this package is trivial to "compile" since it only installs certain files, so I thought it worth it to increment revisions.

If the Gentoo authors disagree, I don't mind at all, though.

[1]: https://devmanual.gentoo.org/general-concepts/ebuild-revisions/index.html
[2]: https://devmanual.gentoo.org/ebuild-writing/file-format/index.html#file-naming-rules