### PR TITLE
app-emulation/libvirt: Fix a build failure with LLD 16

### DIFF
--- a/app-emulation/libvirt/files/libvirt-8.7.0-meson-Stop-detecting-Wl-version-script.patch
+++ b/app-emulation/libvirt/files/libvirt-8.7.0-meson-Stop-detecting-Wl-version-script.patch
@@ -1,0 +1,55 @@
+From ab5ce6ac561b9ef5d97ee8268df048b3432d7b8b Mon Sep 17 00:00:00 2001
+Message-Id: <ab5ce6ac561b9ef5d97ee8268df048b3432d7b8b.1679397051.git.mprivozn@redhat.com>
+From: Michal Privoznik <mprivozn@redhat.com>
+Date: Mon, 20 Mar 2023 13:38:27 +0100
+Subject: [PATCH] meson: Stop detecting -Wl,--version-script=
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+With its version 16.0, the LLVM's linker turned on
+--no-undefined-version by default [1]. This breaks how we detect
+--version-script= detection, because at the compile time there's
+no library built yet that we can use to make --version-script=
+happy. Unfortunately, meson does not provide a way to detect this
+either [2].
+
+But there's not much sense in detecting the argument either. We
+already special case some systems (windows, darwin) and do the
+check for others, which are expected to support versioned
+symbols, because of ELF. Worst case scenario - the error is
+reported during compile time rather than configure time.
+
+1: https://reviews.llvm.org/D135402
+2: https://github.com/mesonbuild/meson/issues/3047
+
+Resolves: https://bugs.gentoo.org/902211
+Signed-off-by: Michal Privoznik <mprivozn@redhat.com>
+Reviewed-by: Daniel P. Berrangé <berrange@redhat.com>
+(cherry picked from commit 743fdb97c81f38adc6e9b55f402244f7982352f4)
+Signed-off-by: Michal Privoznik <mprivozn@redhat.com>
+---
+ meson.build | 7 +------
+ 1 file changed, 1 insertion(+), 6 deletions(-)
+
+diff --git a/meson.build b/meson.build
+index 0b3187ad88..53156329a4 100644
+--- a/meson.build
++++ b/meson.build
+@@ -514,12 +514,7 @@ elif host_machine.system() == 'darwin'
+   # macOS libraries don't support symbol versioning
+   version_script_flags = ''
+ else
+-  test_file = '@0@/src/libvirt_qemu.syms'.format(meson.source_root())
+-  if cc.has_link_argument('-Wl,--version-script=@0@'.format(test_file))
+-    version_script_flags = '-Wl,--version-script='
+-  else
+-    error('No supported version script link argument found.')
+-  endif
++  version_script_flags = '-Wl,--version-script='
+ endif
+ 
+ libvirt_flat_namespace = []
+-- 
+2.39.2
+

--- a/app-emulation/libvirt/files/libvirt-9.2.0-meson-Stop-detecting-Wl-version-script.patch
+++ b/app-emulation/libvirt/files/libvirt-9.2.0-meson-Stop-detecting-Wl-version-script.patch
@@ -1,0 +1,53 @@
+From 743fdb97c81f38adc6e9b55f402244f7982352f4 Mon Sep 17 00:00:00 2001
+Message-Id: <743fdb97c81f38adc6e9b55f402244f7982352f4.1679396460.git.mprivozn@redhat.com>
+From: Michal Privoznik <mprivozn@redhat.com>
+Date: Mon, 20 Mar 2023 13:38:27 +0100
+Subject: [PATCH] meson: Stop detecting -Wl,--version-script=
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+With its version 16.0, the LLVM's linker turned on
+--no-undefined-version by default [1]. This breaks how we detect
+--version-script= detection, because at the compile time there's
+no library built yet that we can use to make --version-script=
+happy. Unfortunately, meson does not provide a way to detect this
+either [2].
+
+But there's not much sense in detecting the argument either. We
+already special case some systems (windows, darwin) and do the
+check for others, which are expected to support versioned
+symbols, because of ELF. Worst case scenario - the error is
+reported during compile time rather than configure time.
+
+1: https://reviews.llvm.org/D135402
+2: https://github.com/mesonbuild/meson/issues/3047
+
+Resolves: https://bugs.gentoo.org/902211
+Signed-off-by: Michal Privoznik <mprivozn@redhat.com>
+Reviewed-by: Daniel P. Berrangé <berrange@redhat.com>
+---
+ meson.build | 7 +------
+ 1 file changed, 1 insertion(+), 6 deletions(-)
+
+diff --git a/meson.build b/meson.build
+index c35823a79a..a0682e8d0b 100644
+--- a/meson.build
++++ b/meson.build
+@@ -534,12 +534,7 @@ elif host_machine.system() == 'darwin'
+   # macOS libraries don't support symbol versioning
+   version_script_flags = ''
+ else
+-  test_file = '@0@/src/libvirt_qemu.syms'.format(meson.project_source_root())
+-  if cc.has_link_argument('-Wl,--version-script=@0@'.format(test_file))
+-    version_script_flags = '-Wl,--version-script='
+-  else
+-    error('No supported version script link argument found.')
+-  endif
++  version_script_flags = '-Wl,--version-script='
+ endif
+ 
+ libvirt_flat_namespace = []
+-- 
+2.39.2
+

--- a/app-emulation/libvirt/libvirt-8.7.0-r1.ebuild
+++ b/app-emulation/libvirt/libvirt-8.7.0-r1.ebuild
@@ -137,6 +137,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-6.0.0-fix_paths_in_libvirt-guests_sh.patch
 	"${FILESDIR}"/${PN}-8.2.0-do-not-use-sysconfig.patch
 	"${FILESDIR}"/${PN}-8.2.0-fix-paths-for-apparmor.patch
+	"${FILESDIR}"/${PN}-8.7.0-meson-Stop-detecting-Wl-version-script.patch
 )
 
 pkg_setup() {

--- a/app-emulation/libvirt/libvirt-8.8.0-r1.ebuild
+++ b/app-emulation/libvirt/libvirt-8.8.0-r1.ebuild
@@ -137,6 +137,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-6.0.0-fix_paths_in_libvirt-guests_sh.patch
 	"${FILESDIR}"/${PN}-8.2.0-do-not-use-sysconfig.patch
 	"${FILESDIR}"/${PN}-8.2.0-fix-paths-for-apparmor.patch
+	"${FILESDIR}"/${PN}-8.7.0-meson-Stop-detecting-Wl-version-script.patch
 )
 
 pkg_setup() {

--- a/app-emulation/libvirt/libvirt-8.9.0-r1.ebuild
+++ b/app-emulation/libvirt/libvirt-8.9.0-r1.ebuild
@@ -144,6 +144,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-6.0.0-fix_paths_in_libvirt-guests_sh.patch
 	"${FILESDIR}"/${PN}-8.2.0-do-not-use-sysconfig.patch
 	"${FILESDIR}"/${PN}-8.2.0-fix-paths-for-apparmor.patch
+	"${FILESDIR}"/${PN}-9.2.0-meson-Stop-detecting-Wl-version-script.patch
 )
 
 pkg_setup() {

--- a/app-emulation/libvirt/libvirt-8.9.0.ebuild
+++ b/app-emulation/libvirt/libvirt-8.9.0.ebuild
@@ -140,6 +140,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-6.0.0-fix_paths_in_libvirt-guests_sh.patch
 	"${FILESDIR}"/${PN}-8.2.0-do-not-use-sysconfig.patch
 	"${FILESDIR}"/${PN}-8.2.0-fix-paths-for-apparmor.patch
+	"${FILESDIR}"/${PN}-9.2.0-meson-Stop-detecting-Wl-version-script.patch
 )
 
 pkg_setup() {


### PR DESCRIPTION
With the newest LLD, the libvirt's detection of --version-script= linker argument works no more. Backport the upstream patch that fixes the issue.

Since the patch is merged and is going to be contained in the upcoming release, there's no point in adding it to the list of patched in the live ebuild. Append it only into the older versions then.

Also, I had to rebase the patch for older version of libvirt, because the patched file (meson.build) looked a bit different and the upstream patch did not apply cleanly.

Closes: https://bugs.gentoo.org/902211