### PR TITLE
sys-devel/clang-common: mark fortify.h as system header

### DIFF
--- a/sys-devel/clang-common/clang-common-15.0.7-r5.ebuild
+++ b/sys-devel/clang-common/clang-common-15.0.7-r5.ebuild
@@ -10,7 +10,7 @@ HOMEPAGE="https://llvm.org/"
 
 LICENSE="Apache-2.0-with-LLVM-exceptions UoI-NCSA"
 SLOT="0"
-KEYWORDS=""
+KEYWORDS="amd64 arm arm64 ppc ppc64 ~riscv sparc x86 ~amd64-linux ~ppc-macos ~x64-macos"
 IUSE="
 	default-compiler-rt default-libcxx default-lld llvm-libunwind
 	hardened stricter
@@ -90,10 +90,11 @@ src_install() {
 	EOF
 
 	# Baseline hardening (bug #851111)
+	# (-fstack-clash-protection is omitted because of a possible Clang bug,
+	# see bug #892537 and bug #865339.)
 	newins - gentoo-hardened.cfg <<-EOF
 		# Some of these options are added unconditionally, regardless of
 		# USE=hardened, for parity with sys-devel/gcc.
-		-fstack-clash-protection
 		-fstack-protector-strong
 		-fPIE
 		-include "${EPREFIX}/usr/include/gentoo/fortify.h"
@@ -106,6 +107,7 @@ src_install() {
 	# without optimization and that would at the very least be very noisy
 	# during builds and at worst trigger many -Werror builds.
 	cat >> "${ED}/usr/include/gentoo/fortify.h" <<- EOF || die
+	#pragma clang system_header
 	#ifndef _FORTIFY_SOURCE
 	# if defined(__has_feature)
 	#  define __GENTOO_HAS_FEATURE(x) __has_feature(x)
@@ -142,12 +144,6 @@ src_install() {
 			-Werror=implicit-function-declaration
 			-Werror=implicit-int
 			-Werror=incompatible-function-pointer-types
-
-			# constructs banned by C2x
-			-Werror=deprecated-non-prototype
-
-			# deprecated but large blast radius
-			#-Werror=strict-prototypes
 		EOF
 
 		cat >> "${ED}/etc/clang/gentoo-common.cfg" <<-EOF || die

--- a/sys-devel/clang-common/clang-common-16.0.0-r1.ebuild
+++ b/sys-devel/clang-common/clang-common-16.0.0-r1.ebuild
@@ -106,6 +106,7 @@ src_install() {
 	# without optimization and that would at the very least be very noisy
 	# during builds and at worst trigger many -Werror builds.
 	cat >> "${ED}/usr/include/gentoo/fortify.h" <<- EOF || die
+	#pragma clang system_header
 	#ifndef _FORTIFY_SOURCE
 	# if defined(__has_feature)
 	#  define __GENTOO_HAS_FEATURE(x) __has_feature(x)

--- a/sys-devel/clang-common/clang-common-16.0.0.9999.ebuild
+++ b/sys-devel/clang-common/clang-common-16.0.0.9999.ebuild
@@ -106,6 +106,7 @@ src_install() {
 	# without optimization and that would at the very least be very noisy
 	# during builds and at worst trigger many -Werror builds.
 	cat >> "${ED}/usr/include/gentoo/fortify.h" <<- EOF || die
+	#pragma clang system_header
 	#ifndef _FORTIFY_SOURCE
 	# if defined(__has_feature)
 	#  define __GENTOO_HAS_FEATURE(x) __has_feature(x)

--- a/sys-devel/clang-common/clang-common-17.0.0.9999.ebuild
+++ b/sys-devel/clang-common/clang-common-17.0.0.9999.ebuild
@@ -106,6 +106,7 @@ src_install() {
 	# without optimization and that would at the very least be very noisy
 	# during builds and at worst trigger many -Werror builds.
 	cat >> "${ED}/usr/include/gentoo/fortify.h" <<- EOF || die
+	#pragma clang system_header
 	#ifndef _FORTIFY_SOURCE
 	# if defined(__has_feature)
 	#  define __GENTOO_HAS_FEATURE(x) __has_feature(x)

--- a/sys-devel/clang-common/clang-common-17.0.0_pre20230314-r1.ebuild
+++ b/sys-devel/clang-common/clang-common-17.0.0_pre20230314-r1.ebuild
@@ -10,7 +10,7 @@ HOMEPAGE="https://llvm.org/"
 
 LICENSE="Apache-2.0-with-LLVM-exceptions UoI-NCSA"
 SLOT="0"
-KEYWORDS="amd64 arm arm64 ppc ppc64 ~riscv sparc x86 ~amd64-linux ~ppc-macos ~x64-macos"
+KEYWORDS=""
 IUSE="
 	default-compiler-rt default-libcxx default-lld llvm-libunwind
 	hardened stricter
@@ -90,11 +90,10 @@ src_install() {
 	EOF
 
 	# Baseline hardening (bug #851111)
-	# (-fstack-clash-protection is omitted because of a possible Clang bug,
-	# see bug #892537 and bug #865339.)
 	newins - gentoo-hardened.cfg <<-EOF
 		# Some of these options are added unconditionally, regardless of
 		# USE=hardened, for parity with sys-devel/gcc.
+		-fstack-clash-protection
 		-fstack-protector-strong
 		-fPIE
 		-include "${EPREFIX}/usr/include/gentoo/fortify.h"
@@ -107,6 +106,7 @@ src_install() {
 	# without optimization and that would at the very least be very noisy
 	# during builds and at worst trigger many -Werror builds.
 	cat >> "${ED}/usr/include/gentoo/fortify.h" <<- EOF || die
+	#pragma clang system_header
 	#ifndef _FORTIFY_SOURCE
 	# if defined(__has_feature)
 	#  define __GENTOO_HAS_FEATURE(x) __has_feature(x)
@@ -143,6 +143,12 @@ src_install() {
 			-Werror=implicit-function-declaration
 			-Werror=implicit-int
 			-Werror=incompatible-function-pointer-types
+
+			# constructs banned by C2x
+			-Werror=deprecated-non-prototype
+
+			# deprecated but large blast radius
+			#-Werror=strict-prototypes
 		EOF
 
 		cat >> "${ED}/etc/clang/gentoo-common.cfg" <<-EOF || die


### PR DESCRIPTION
Suppresses a warning complaining that `__GENTOO_HAS_FEATURE` is a reserved macro identifier (`-Wreserved-macro-identifier`).

```
$ cat a.c
#include <gentoo/fortify.h>

int main(void) { return 0; }
$ clang -Weverything a.c
In file included from <built-in>:1:
/usr/include/gentoo/fortify.h:3:11: warning: macro name is a reserved identifier [-Wreserved-macro-identifier]
#  define __GENTOO_HAS_FEATURE(x) __has_feature(x)
          ^
/usr/include/gentoo/fortify.h:13:9: warning: macro name is a reserved identifier [-Wreserved-macro-identifier]
# undef __GENTOO_HAS_FEATURE
        ^
2 warnings generated.
```