### PR TITLE
net-p2p/deluge: enable py3.11

### DIFF
--- a/net-p2p/deluge/deluge-2.1.1-r2.ebuild
+++ b/net-p2p/deluge/deluge-2.1.1-r2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{9..10} )
+PYTHON_COMPAT=( python3_{9..11} )
 DISTUTILS_USE_PEP517=setuptools
 DISTUTILS_SINGLE_IMPL=1
 inherit distutils-r1 systemd xdg

--- a/net-p2p/deluge/deluge-9999.ebuild
+++ b/net-p2p/deluge/deluge-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{9..10} )
+PYTHON_COMPAT=( python3_{9..11} )
 DISTUTILS_USE_PEP517=setuptools
 DISTUTILS_SINGLE_IMPL=1
 inherit distutils-r1 systemd xdg


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/897142