### PR TITLE
x11-misc/compose-tables: Pass keysymdefdir

### DIFF
--- a/x11-libs/libX11/libX11-1.8.4-r1.ebuild
+++ b/x11-libs/libX11/libX11-1.8.4-r1.ebuild
@@ -33,6 +33,7 @@ src_configure() {
 		$(use_enable doc specs)
 		--enable-ipv6
 		--without-fop
+		--with-keysymdefdir="${ESYSROOT}/usr/include/X11"
 		CPP="$(tc-getPROG CPP cpp)"
 	)
 	xorg-3_src_configure

--- a/x11-misc/compose-tables/compose-tables-1.8.4-r1.ebuild
+++ b/x11-misc/compose-tables/compose-tables-1.8.4-r1.ebuild
@@ -27,6 +27,7 @@ XORG_CONFIGURE_OPTIONS=(
 	--without-fop
 	--disable-specs
 	--disable-xkb
+	--with-keysymdefdir="${ESYSROOT}/usr/include/X11"
 )
 
 src_compile() {


### PR DESCRIPTION
We don't want to look at the host's keysymdef.h, but the target board's
version.

--with-keysymdefdir=DIR The location of keysymdef.h (defaults to xproto
                        include dir)

Without this change we get the following:

    checking keysym definitions...  /usr/include/X11/keysymdef.h /usr/include/X11/XF86keysym.h /usr/include/X11/Sunkeysym.h /usr/include/X11/DECkeysym.h /usr/include/X11/HPkeysym.h

With this change:

    checking keysym definitions...  /build/arm64-generic/usr/include/X11/keysymdef.h /build/arm64-generic/usr/include/X11/XF86keysym.h /build/arm64-generic/usr/include/X11/Sunkeysym.h /build/arm64-generic/usr/include/X11/DECkeysym.h /build/arm64-generic/usr/include/X11/HPkeysym.h

BUG=b:262460834
TEST=BOARD=arm64-generic bazel build --//bazel/sdk:new-sdk @portage//x11-misc/compose-tables

Change-Id: Ia011d2143d08f5087d55ad94f232744750cc01c4
