### PR TITLE
sys-auth/polkit: don't keep $EPREFIX/usr/share/polkit-1/rules.d in prefix

### DIFF
--- a/sys-auth/polkit/polkit-121.ebuild
+++ b/sys-auth/polkit/polkit-121.ebuild
@@ -143,7 +143,7 @@ src_install() {
 	fi
 
 	diropts -m 0700 -o polkitd
-	keepdir /usr/share/polkit-1/rules.d
+	use prefix || keepdir /usr/share/polkit-1/rules.d
 }
 
 pkg_postinst() {

--- a/sys-auth/polkit/polkit-122.ebuild
+++ b/sys-auth/polkit/polkit-122.ebuild
@@ -145,7 +145,7 @@ src_install() {
 	fi
 
 	diropts -m 0700 -o polkitd
-	keepdir /usr/share/polkit-1/rules.d
+	use prefix || keepdir /usr/share/polkit-1/rules.d
 }
 
 pkg_postinst() {


### PR DESCRIPTION
in Gentoo Prefix, polkit's `meson_post_install.py` reports:

```
install: cannot change owner and permissions of
<eprefix>/var/tmp/portage/sys-auth/polkit-122/image/<eprefix>/usr/share/polkit-1/rules.d: Operation not permitted
```
so it cannot `keepdir` that directory.