### PR TITLE
sys-fs/udisks: Fix install in prefix

### DIFF
--- a/sys-fs/udisks/udisks-2.9.4-r1.ebuild
+++ b/sys-fs/udisks/udisks-2.9.4-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -97,8 +97,8 @@ src_configure() {
 		--with-html-dir="${EPREFIX}"/usr/share/gtk-doc/html
 		--with-modprobedir="${EPREFIX}"/lib/modprobe.d
 		--with-systemdsystemunitdir="$(systemd_get_systemunitdir)"
-		--with-tmpfilesdir="/usr/lib/tmpfiles.d"
-		--with-udevdir="$(get_udevdir)"
+		--with-tmpfilesdir="${EPREFIX}"/usr/lib/tmpfiles.d
+		--with-udevdir="${EPREFIX}$(get_udevdir)"
 		$(use_enable acl)
 		$(use_enable daemon)
 		$(use_enable debug)


### PR DESCRIPTION
configure needs
```
--with-tmpfilesdir="${EPREFIX}"/usr/lib/tmpfiles.d
--with-udevdir="$EPREFIX$(get_udevdir)"
```
or else we get
```
 * QA Notice: the following files are outside of the prefix:
 * /lib
 * /lib/udev
 * /lib/udev/rules.d
 * /lib/udev/rules.d/80-udisks2.rules
 * /usr
 * /usr/lib
 * /usr/lib/tmpfiles.d
 * /usr/lib/tmpfiles.d/udisks2.conf
 * ERROR: sys-fs/udisks-2.9.4-r1::gentoo failed:
 *   Aborting due to QA concerns: there are files installed outside the prefix
```