### PR TITLE
sci-astronomy/siril: fix build without OpenMP

### DIFF
--- a/sci-astronomy/siril/files/siril-1.2-openmp.patch
+++ b/sci-astronomy/siril/files/siril-1.2-openmp.patch
@@ -1,0 +1,19 @@
+From: Mario Haustein <mario.haustein@hrz.tu-chemnitz.de>
+Date: Fri, 24 Mar 2023 18:24:26 +0100
+Subject: [PATCH] Add ifdef around openmp function
+Bug: https://bugs.gentoo.org/902833
+Upstream: https://gitlab.com/free-astro/siril/-/merge_requests/482
+
+--- a/src/algos/quantize.c
++++ b/src/algos/quantize.c
+@@ -1396,8 +1396,10 @@ row of the image.
+ #pragma omp parallel num_threads(threads) if (threads>1)
+ #endif
+ 	{
++#ifdef _OPENMP
+ 		if (threads > 1 && omp_get_num_threads() != threads)
+ 			siril_debug_print("actual number of threads: %d of %d requested (level %d)\n", omp_get_num_threads(), threads, omp_get_level());
++#endif
+ 		float *rowpix, v1;
+ 		double mean, stdev;
+ 		float *differences;

--- a/sci-astronomy/siril/siril-1.2.0_beta1.ebuild
+++ b/sci-astronomy/siril/siril-1.2.0_beta1.ebuild
@@ -54,6 +54,7 @@ PATCHES=(
 	"${FILESDIR}/${PN}-$(ver_cut 1-2)-htmesh.patch"
 	"${FILESDIR}/${PN}-$(ver_cut 1-2)-execinfo.patch"
 	"${FILESDIR}/${PN}-$(ver_cut 1-2)-prototypes.patch"
+	"${FILESDIR}/${PN}-$(ver_cut 1-2)-openmp.patch"
 )
 
 DOCS=( README.md NEWS ChangeLog AUTHORS )


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/902833