### PR TITLE
app-admin/mktwpol: EAPI8 bump

### DIFF
--- a/app-admin/mktwpol/mktwpol-1.0.1-r1.ebuild
+++ b/app-admin/mktwpol/mktwpol-1.0.1-r1.ebuild
@@ -1,0 +1,57 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DESCRIPTION="Bash scripts to install tripwire and generate tripwire policy files"
+HOMEPAGE="https://sourceforge.net/projects/mktwpol"
+SRC_URI="mirror://sourceforge/mktwpol/${P}.tar.gz"
+S=${WORKDIR}/${P}
+
+LICENSE="CC-BY-SA-3.0"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86"
+
+RDEPEND="app-admin/tripwire"
+
+src_prepare() {
+	default
+	sed -i \
+		-e 's:/usr/local:/usr:' \
+		-e "s|^docdir.*|docdir = \"${EPREFIX}/usr/share/doc/${PF}\"|g" \
+		Makefile || die
+}
+
+pkg_preinst() {
+	# one elog message for new/first installation
+	# different elog message when updating
+	if [[ -z ${REPLACING_VERSIONS} ]] ; then
+		elog
+		elog "To facilitate a new installation and setup of tripwire:"
+		elog " - Run: \`twsetup.sh\`"
+		elog
+		elog "To update tripwire database as packages are added or deleted:"
+		elog " - Run: \`mktwpol.sh -u\`"
+		elog
+		elog "Mktwpol is packaged with multiple policy-generating rules files."
+		elog "A default \"rules file\" is installed in /etc/tripwire"
+		elog "Alternatives are available in /usr/share/doc/${PF}"
+		elog
+		elog "mktwpol.sh uses the policy-generating rules file with the"
+		elog "most recent date.  To use an alternative \"rules file\","
+		elog "copy it from /usr/share/doc/${PF} to /etc/tripwire,"
+		elog " uncompress it, and \`touch\` it."
+		elog
+		elog "Read /usr/share/doc/${PF}/README for more tips."
+		elog
+	else
+		elog
+		elog "Version bump: mktwpol policy-generating rules have changed."
+		elog "Run \`mktwpol.sh -u\` to update tripwire policy and database."
+		elog
+		elog "Alternative policy-generating rules are in /usr/share/doc/${PF}"
+		elog "To use an alternative policy-generating rules file,"
+		elog "copy it to /etc/tripwire, uncompress and \`touch\` it."
+		elog
+	fi
+}


### PR DESCRIPTION
Hi,

Another simple EAPI8 bump. Note: I think the bottom elog message could be removed. The last 0.x ebuild was deleted over 3 years ago. Any suggestions here?


``` diff
--- mktwpol-1.0.1.ebuild	2020-09-12 09:24:30.966592682 +0200
+++ mktwpol-1.0.1-r1.ebuild	2023-03-25 12:33:04.798184115 +0100
@@ -1,24 +1,25 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
 
 DESCRIPTION="Bash scripts to install tripwire and generate tripwire policy files"
 HOMEPAGE="https://sourceforge.net/projects/mktwpol"
-SRC_URI="mirror://sourceforge/mktwpol/${PF}.tar.gz"
+SRC_URI="mirror://sourceforge/mktwpol/${P}.tar.gz"
+S=${WORKDIR}/${P}
 
 LICENSE="CC-BY-SA-3.0"
 SLOT="0"
-KEYWORDS="amd64 ppc x86"
-IUSE=""
+KEYWORDS="~amd64 ~ppc ~x86"
 
 RDEPEND="app-admin/tripwire"
 
-S=${WORKDIR}/${PF}
-
 src_prepare() {
 	default
-	sed -i -e 's:/usr/local:/usr:' Makefile || die
+	sed -i \
+		-e 's:/usr/local:/usr:' \
+		-e "s|^docdir.*|docdir = \"${EPREFIX}/usr/share/doc/${PF}\"|g" \
+		Makefile || die
 }
 
 pkg_preinst() {
@@ -52,7 +53,7 @@
 		elog "To use an alternative policy-generating rules file,"
 		elog "copy it to /etc/tripwire, uncompress and \`touch\` it."
 		elog
-	 fi
+	fi
 	# ewarn message if a version change from 0.x.x
 	if [[ "${REPLACING_VERSIONS:0:1}" == "0" ]] ; then
 		ewarn
```