### PR TITLE
dev-python/fido2: relax cryptography dependency

### DIFF
--- a/dev-python/fido2/fido2-1.1.0.ebuild
+++ b/dev-python/fido2/fido2-1.1.0.ebuild
@@ -23,7 +23,7 @@ KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv x86"
 IUSE="examples"
 
 RDEPEND="
-	<dev-python/cryptography-40[${PYTHON_USEDEP}]
+	dev-python/cryptography[${PYTHON_USEDEP}]
 	<dev-python/pyscard-3[${PYTHON_USEDEP}]
 	examples? (
 		dev-python/flask[${PYTHON_USEDEP}]


### PR DESCRIPTION
It builds/works fine with >=cryptography-40, passes tests.

See also: https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst (40's backwards incompatible changes unlikely to affect this, but let me know if I should still version restrict it only up to 40)