### PR TITLE
vim: get rid of useless sed

### DIFF
--- a/app-editors/gvim/gvim-9.0.1000.ebuild
+++ b/app-editors/gvim/gvim-9.0.1000.ebuild
@@ -132,12 +132,6 @@ src_prepare() {
 		"${S}"/runtime/menu.vim \
 		"${S}"/src/configure.ac || die 'sed failed'
 
-	# Don't be fooled by /usr/include/libc.h.  When found, vim thinks
-	# this is NeXT, but it's actually just a file in dev-libs/9libs
-	# This fixes bug 43885 (20 Mar 2004 agriffis)
-	sed -i -e \
-		's/ libc\.h / /' "${S}"/src/configure.ac || die 'sed failed'
-
 	# gcc on sparc32 has this, uhm, interesting problem with detecting EOF
 	# correctly. To avoid some really entertaining error messages about stuff
 	# which isn't even in the source file being invalid, we'll do some trickery
@@ -154,11 +148,6 @@ src_prepare() {
 	fi
 
 	cp -v "${S}"/src/config.mk.dist "${S}"/src/auto/config.mk || die "cp failed"
-
-	# Bug #378107 - Build properly with >=perl-core/ExtUtils-ParseXS-3.20.0
-	sed -i -e \
-		"s:\\\$(PERLLIB)/ExtUtils/xsubpp:${EPREFIX}/usr/bin/xsubpp:" \
-		"${S}"/src/Makefile || die 'sed for ExtUtils-ParseXS failed'
 
 	# Fix bug 18245: Prevent "make" from the following chain:
 	# (1) Notice configure.ac is newer than auto/configure

--- a/app-editors/gvim/gvim-9.0.1157.ebuild
+++ b/app-editors/gvim/gvim-9.0.1157.ebuild
@@ -132,12 +132,6 @@ src_prepare() {
 		"${S}"/runtime/menu.vim \
 		"${S}"/src/configure.ac || die 'sed failed'
 
-	# Don't be fooled by /usr/include/libc.h.  When found, vim thinks
-	# this is NeXT, but it's actually just a file in dev-libs/9libs
-	# This fixes bug 43885 (20 Mar 2004 agriffis)
-	sed -i -e \
-		's/ libc\.h / /' "${S}"/src/configure.ac || die 'sed failed'
-
 	# gcc on sparc32 has this, uhm, interesting problem with detecting EOF
 	# correctly. To avoid some really entertaining error messages about stuff
 	# which isn't even in the source file being invalid, we'll do some trickery
@@ -154,11 +148,6 @@ src_prepare() {
 	fi
 
 	cp -v "${S}"/src/config.mk.dist "${S}"/src/auto/config.mk || die "cp failed"
-
-	# Bug #378107 - Build properly with >=perl-core/ExtUtils-ParseXS-3.20.0
-	sed -i -e \
-		"s:\\\$(PERLLIB)/ExtUtils/xsubpp:${EPREFIX}/usr/bin/xsubpp:" \
-		"${S}"/src/Makefile || die 'sed for ExtUtils-ParseXS failed'
 
 	# Fix bug 18245: Prevent "make" from the following chain:
 	# (1) Notice configure.ac is newer than auto/configure

--- a/app-editors/gvim/gvim-9.0.1363.ebuild
+++ b/app-editors/gvim/gvim-9.0.1363.ebuild
@@ -133,12 +133,6 @@ src_prepare() {
 		"${S}"/runtime/menu.vim \
 		"${S}"/src/configure.ac || die 'sed failed'
 
-	# Don't be fooled by /usr/include/libc.h.  When found, vim thinks
-	# this is NeXT, but it's actually just a file in dev-libs/9libs
-	# This fixes bug 43885 (20 Mar 2004 agriffis)
-	sed -i -e \
-		's/ libc\.h / /' "${S}"/src/configure.ac || die 'sed failed'
-
 	# gcc on sparc32 has this, uhm, interesting problem with detecting EOF
 	# correctly. To avoid some really entertaining error messages about stuff
 	# which isn't even in the source file being invalid, we'll do some trickery
@@ -155,11 +149,6 @@ src_prepare() {
 	fi
 
 	cp -v "${S}"/src/config.mk.dist "${S}"/src/auto/config.mk || die "cp failed"
-
-	# Bug #378107 - Build properly with >=perl-core/ExtUtils-ParseXS-3.20.0
-	sed -i -e \
-		"s:\\\$(PERLLIB)/ExtUtils/xsubpp:${EPREFIX}/usr/bin/xsubpp:" \
-		"${S}"/src/Makefile || die 'sed for ExtUtils-ParseXS failed'
 
 	# Fix bug 18245: Prevent "make" from the following chain:
 	# (1) Notice configure.ac is newer than auto/configure

--- a/app-editors/gvim/gvim-9.0.1403.ebuild
+++ b/app-editors/gvim/gvim-9.0.1403.ebuild
@@ -133,12 +133,6 @@ src_prepare() {
 		"${S}"/runtime/menu.vim \
 		"${S}"/src/configure.ac || die 'sed failed'
 
-	# Don't be fooled by /usr/include/libc.h.  When found, vim thinks
-	# this is NeXT, but it's actually just a file in dev-libs/9libs
-	# This fixes bug 43885 (20 Mar 2004 agriffis)
-	sed -i -e \
-		's/ libc\.h / /' "${S}"/src/configure.ac || die 'sed failed'
-
 	# gcc on sparc32 has this, uhm, interesting problem with detecting EOF
 	# correctly. To avoid some really entertaining error messages about stuff
 	# which isn't even in the source file being invalid, we'll do some trickery
@@ -155,11 +149,6 @@ src_prepare() {
 	fi
 
 	cp -v "${S}"/src/config.mk.dist "${S}"/src/auto/config.mk || die "cp failed"
-
-	# Bug #378107 - Build properly with >=perl-core/ExtUtils-ParseXS-3.20.0
-	sed -i -e \
-		"s:\\\$(PERLLIB)/ExtUtils/xsubpp:${EPREFIX}/usr/bin/xsubpp:" \
-		"${S}"/src/Makefile || die 'sed for ExtUtils-ParseXS failed'
 
 	# Fix bug 18245: Prevent "make" from the following chain:
 	# (1) Notice configure.ac is newer than auto/configure

--- a/app-editors/gvim/gvim-9999.ebuild
+++ b/app-editors/gvim/gvim-9999.ebuild
@@ -132,12 +132,6 @@ src_prepare() {
 		"${S}"/runtime/menu.vim \
 		"${S}"/src/configure.ac || die 'sed failed'
 
-	# Don't be fooled by /usr/include/libc.h.  When found, vim thinks
-	# this is NeXT, but it's actually just a file in dev-libs/9libs
-	# This fixes bug 43885 (20 Mar 2004 agriffis)
-	sed -i -e \
-		's/ libc\.h / /' "${S}"/src/configure.ac || die 'sed failed'
-
 	# gcc on sparc32 has this, uhm, interesting problem with detecting EOF
 	# correctly. To avoid some really entertaining error messages about stuff
 	# which isn't even in the source file being invalid, we'll do some trickery
@@ -154,11 +148,6 @@ src_prepare() {
 	fi
 
 	cp -v "${S}"/src/config.mk.dist "${S}"/src/auto/config.mk || die "cp failed"
-
-	# Bug #378107 - Build properly with >=perl-core/ExtUtils-ParseXS-3.20.0
-	sed -i -e \
-		"s:\\\$(PERLLIB)/ExtUtils/xsubpp:${EPREFIX}/usr/bin/xsubpp:" \
-		"${S}"/src/Makefile || die 'sed for ExtUtils-ParseXS failed'
 
 	# Fix bug 18245: Prevent "make" from the following chain:
 	# (1) Notice configure.ac is newer than auto/configure

--- a/app-editors/vim-core/vim-core-9.0.1000.ebuild
+++ b/app-editors/vim-core/vim-core-9.0.1000.ebuild
@@ -77,11 +77,6 @@ src_prepare() {
 		"${S}"/runtime/menu.vim \
 		"${S}"/src/configure.ac || die 'sed failed'
 
-	# Don't be fooled by /usr/include/libc.h.  When found, vim thinks
-	# this is NeXT, but it's actually just a file in dev-libs/9libs
-	# This fixes bug #43885 (20 Mar 2004 agriffis)
-	sed -i 's/ libc\.h / /' "${S}"/src/configure.ac || die 'sed failed'
-
 	# gcc on sparc32 has this, uhm, interesting problem with detecting EOF
 	# correctly. To avoid some really entertaining error messages about stuff
 	# which isn't even in the source file being invalid, we'll do some trickery
@@ -98,11 +93,6 @@ src_prepare() {
 	fi
 
 	cp -v "${S}"/src/config.mk.dist "${S}"/src/auto/config.mk || die "cp failed"
-
-	# Bug #378107 - Build properly with >=perl-core/ExtUtils-ParseXS-3.20.0
-	sed -i -e \
-		"s:\\\$(PERLLIB)/ExtUtils/xsubpp:${EPREFIX}/usr/bin/xsubpp:" \
-		"${S}"/src/Makefile || die 'sed for ExtUtils-ParseXS failed'
 
 	# Fix bug #76331: -O3 causes problems, use -O2 instead. We'll do this for
 	# everyone since previous flag filtering bugs have turned out to affect

--- a/app-editors/vim-core/vim-core-9.0.1157.ebuild
+++ b/app-editors/vim-core/vim-core-9.0.1157.ebuild
@@ -77,11 +77,6 @@ src_prepare() {
 		"${S}"/runtime/menu.vim \
 		"${S}"/src/configure.ac || die 'sed failed'
 
-	# Don't be fooled by /usr/include/libc.h.  When found, vim thinks
-	# this is NeXT, but it's actually just a file in dev-libs/9libs
-	# This fixes bug #43885 (20 Mar 2004 agriffis)
-	sed -i 's/ libc\.h / /' "${S}"/src/configure.ac || die 'sed failed'
-
 	# gcc on sparc32 has this, uhm, interesting problem with detecting EOF
 	# correctly. To avoid some really entertaining error messages about stuff
 	# which isn't even in the source file being invalid, we'll do some trickery
@@ -98,11 +93,6 @@ src_prepare() {
 	fi
 
 	cp -v "${S}"/src/config.mk.dist "${S}"/src/auto/config.mk || die "cp failed"
-
-	# Bug #378107 - Build properly with >=perl-core/ExtUtils-ParseXS-3.20.0
-	sed -i -e \
-		"s:\\\$(PERLLIB)/ExtUtils/xsubpp:${EPREFIX}/usr/bin/xsubpp:" \
-		"${S}"/src/Makefile || die 'sed for ExtUtils-ParseXS failed'
 
 	# Fix bug #76331: -O3 causes problems, use -O2 instead. We'll do this for
 	# everyone since previous flag filtering bugs have turned out to affect

--- a/app-editors/vim-core/vim-core-9.0.1363.ebuild
+++ b/app-editors/vim-core/vim-core-9.0.1363.ebuild
@@ -77,11 +77,6 @@ src_prepare() {
 		"${S}"/runtime/menu.vim \
 		"${S}"/src/configure.ac || die 'sed failed'
 
-	# Don't be fooled by /usr/include/libc.h.  When found, vim thinks
-	# this is NeXT, but it's actually just a file in dev-libs/9libs
-	# This fixes bug #43885 (20 Mar 2004 agriffis)
-	sed -i 's/ libc\.h / /' "${S}"/src/configure.ac || die 'sed failed'
-
 	# gcc on sparc32 has this, uhm, interesting problem with detecting EOF
 	# correctly. To avoid some really entertaining error messages about stuff
 	# which isn't even in the source file being invalid, we'll do some trickery
@@ -98,11 +93,6 @@ src_prepare() {
 	fi
 
 	cp -v "${S}"/src/config.mk.dist "${S}"/src/auto/config.mk || die "cp failed"
-
-	# Bug #378107 - Build properly with >=perl-core/ExtUtils-ParseXS-3.20.0
-	sed -i -e \
-		"s:\\\$(PERLLIB)/ExtUtils/xsubpp:${EPREFIX}/usr/bin/xsubpp:" \
-		"${S}"/src/Makefile || die 'sed for ExtUtils-ParseXS failed'
 
 	# Fix bug #76331: -O3 causes problems, use -O2 instead. We'll do this for
 	# everyone since previous flag filtering bugs have turned out to affect

--- a/app-editors/vim-core/vim-core-9.0.1403.ebuild
+++ b/app-editors/vim-core/vim-core-9.0.1403.ebuild
@@ -77,11 +77,6 @@ src_prepare() {
 		"${S}"/runtime/menu.vim \
 		"${S}"/src/configure.ac || die 'sed failed'
 
-	# Don't be fooled by /usr/include/libc.h.  When found, vim thinks
-	# this is NeXT, but it's actually just a file in dev-libs/9libs
-	# This fixes bug #43885 (20 Mar 2004 agriffis)
-	sed -i 's/ libc\.h / /' "${S}"/src/configure.ac || die 'sed failed'
-
 	# gcc on sparc32 has this, uhm, interesting problem with detecting EOF
 	# correctly. To avoid some really entertaining error messages about stuff
 	# which isn't even in the source file being invalid, we'll do some trickery
@@ -98,11 +93,6 @@ src_prepare() {
 	fi
 
 	cp -v "${S}"/src/config.mk.dist "${S}"/src/auto/config.mk || die "cp failed"
-
-	# Bug #378107 - Build properly with >=perl-core/ExtUtils-ParseXS-3.20.0
-	sed -i -e \
-		"s:\\\$(PERLLIB)/ExtUtils/xsubpp:${EPREFIX}/usr/bin/xsubpp:" \
-		"${S}"/src/Makefile || die 'sed for ExtUtils-ParseXS failed'
 
 	# Fix bug #76331: -O3 causes problems, use -O2 instead. We'll do this for
 	# everyone since previous flag filtering bugs have turned out to affect

--- a/app-editors/vim-core/vim-core-9999.ebuild
+++ b/app-editors/vim-core/vim-core-9999.ebuild
@@ -77,11 +77,6 @@ src_prepare() {
 		"${S}"/runtime/menu.vim \
 		"${S}"/src/configure.ac || die 'sed failed'
 
-	# Don't be fooled by /usr/include/libc.h.  When found, vim thinks
-	# this is NeXT, but it's actually just a file in dev-libs/9libs
-	# This fixes bug #43885 (20 Mar 2004 agriffis)
-	sed -i 's/ libc\.h / /' "${S}"/src/configure.ac || die 'sed failed'
-
 	# gcc on sparc32 has this, uhm, interesting problem with detecting EOF
 	# correctly. To avoid some really entertaining error messages about stuff
 	# which isn't even in the source file being invalid, we'll do some trickery
@@ -98,11 +93,6 @@ src_prepare() {
 	fi
 
 	cp -v "${S}"/src/config.mk.dist "${S}"/src/auto/config.mk || die "cp failed"
-
-	# Bug #378107 - Build properly with >=perl-core/ExtUtils-ParseXS-3.20.0
-	sed -i -e \
-		"s:\\\$(PERLLIB)/ExtUtils/xsubpp:${EPREFIX}/usr/bin/xsubpp:" \
-		"${S}"/src/Makefile || die 'sed for ExtUtils-ParseXS failed'
 
 	# Fix bug #76331: -O3 causes problems, use -O2 instead. We'll do this for
 	# everyone since previous flag filtering bugs have turned out to affect

--- a/app-editors/vim/vim-9.0.1000.ebuild
+++ b/app-editors/vim/vim-9.0.1000.ebuild
@@ -117,13 +117,6 @@ src_prepare() {
 		"${S}"/runtime/menu.vim \
 		"${S}"/src/configure.ac || die 'sed failed'
 
-	# Don't be fooled by /usr/include/libc.h.  When found, vim thinks
-	# this is NeXT, but it's actually just a file in dev-libs/9libs
-	# This fixes bug #43885 (20 Mar 2004 agriffis)
-	sed -i -e \
-		's/ libc\.h / /' \
-		"${S}"/src/configure.ac || die 'sed failed'
-
 	# gcc on sparc32 has this, uhm, interesting problem with detecting EOF
 	# correctly. To avoid some really entertaining error messages about stuff
 	# which isn't even in the source file being invalid, we'll do some trickery
@@ -153,10 +146,6 @@ src_prepare() {
 	fi
 
 	cp -v "${S}"/src/config.mk.dist "${S}"/src/auto/config.mk || die "cp failed"
-
-	sed -i -e \
-		"s:\\\$(PERLLIB)/ExtUtils/xsubpp:${EPREFIX}/usr/bin/xsubpp:" \
-		"${S}"/src/Makefile || die 'sed for ExtUtils-ParseXS failed'
 
 	# Fix bug 18245: Prevent "make" from the following chain:
 	# (1) Notice configure.ac is newer than auto/configure

--- a/app-editors/vim/vim-9.0.1157.ebuild
+++ b/app-editors/vim/vim-9.0.1157.ebuild
@@ -117,13 +117,6 @@ src_prepare() {
 		"${S}"/runtime/menu.vim \
 		"${S}"/src/configure.ac || die 'sed failed'
 
-	# Don't be fooled by /usr/include/libc.h.  When found, vim thinks
-	# this is NeXT, but it's actually just a file in dev-libs/9libs
-	# This fixes bug #43885 (20 Mar 2004 agriffis)
-	sed -i -e \
-		's/ libc\.h / /' \
-		"${S}"/src/configure.ac || die 'sed failed'
-
 	# gcc on sparc32 has this, uhm, interesting problem with detecting EOF
 	# correctly. To avoid some really entertaining error messages about stuff
 	# which isn't even in the source file being invalid, we'll do some trickery
@@ -153,10 +146,6 @@ src_prepare() {
 	fi
 
 	cp -v "${S}"/src/config.mk.dist "${S}"/src/auto/config.mk || die "cp failed"
-
-	sed -i -e \
-		"s:\\\$(PERLLIB)/ExtUtils/xsubpp:${EPREFIX}/usr/bin/xsubpp:" \
-		"${S}"/src/Makefile || die 'sed for ExtUtils-ParseXS failed'
 
 	# Fix bug 18245: Prevent "make" from the following chain:
 	# (1) Notice configure.ac is newer than auto/configure

--- a/app-editors/vim/vim-9.0.1363.ebuild
+++ b/app-editors/vim/vim-9.0.1363.ebuild
@@ -117,13 +117,6 @@ src_prepare() {
 		"${S}"/runtime/menu.vim \
 		"${S}"/src/configure.ac || die 'sed failed'
 
-	# Don't be fooled by /usr/include/libc.h.  When found, vim thinks
-	# this is NeXT, but it's actually just a file in dev-libs/9libs
-	# This fixes bug #43885 (20 Mar 2004 agriffis)
-	sed -i -e \
-		's/ libc\.h / /' \
-		"${S}"/src/configure.ac || die 'sed failed'
-
 	# gcc on sparc32 has this, uhm, interesting problem with detecting EOF
 	# correctly. To avoid some really entertaining error messages about stuff
 	# which isn't even in the source file being invalid, we'll do some trickery
@@ -153,10 +146,6 @@ src_prepare() {
 	fi
 
 	cp -v "${S}"/src/config.mk.dist "${S}"/src/auto/config.mk || die "cp failed"
-
-	sed -i -e \
-		"s:\\\$(PERLLIB)/ExtUtils/xsubpp:${EPREFIX}/usr/bin/xsubpp:" \
-		"${S}"/src/Makefile || die 'sed for ExtUtils-ParseXS failed'
 
 	# Fix bug 18245: Prevent "make" from the following chain:
 	# (1) Notice configure.ac is newer than auto/configure

--- a/app-editors/vim/vim-9.0.1403.ebuild
+++ b/app-editors/vim/vim-9.0.1403.ebuild
@@ -117,13 +117,6 @@ src_prepare() {
 		"${S}"/runtime/menu.vim \
 		"${S}"/src/configure.ac || die 'sed failed'
 
-	# Don't be fooled by /usr/include/libc.h.  When found, vim thinks
-	# this is NeXT, but it's actually just a file in dev-libs/9libs
-	# This fixes bug #43885 (20 Mar 2004 agriffis)
-	sed -i -e \
-		's/ libc\.h / /' \
-		"${S}"/src/configure.ac || die 'sed failed'
-
 	# gcc on sparc32 has this, uhm, interesting problem with detecting EOF
 	# correctly. To avoid some really entertaining error messages about stuff
 	# which isn't even in the source file being invalid, we'll do some trickery
@@ -153,10 +146,6 @@ src_prepare() {
 	fi
 
 	cp -v "${S}"/src/config.mk.dist "${S}"/src/auto/config.mk || die "cp failed"
-
-	sed -i -e \
-		"s:\\\$(PERLLIB)/ExtUtils/xsubpp:${EPREFIX}/usr/bin/xsubpp:" \
-		"${S}"/src/Makefile || die 'sed for ExtUtils-ParseXS failed'
 
 	# Fix bug 18245: Prevent "make" from the following chain:
 	# (1) Notice configure.ac is newer than auto/configure

--- a/app-editors/vim/vim-9999.ebuild
+++ b/app-editors/vim/vim-9999.ebuild
@@ -117,13 +117,6 @@ src_prepare() {
 		"${S}"/runtime/menu.vim \
 		"${S}"/src/configure.ac || die 'sed failed'
 
-	# Don't be fooled by /usr/include/libc.h.  When found, vim thinks
-	# this is NeXT, but it's actually just a file in dev-libs/9libs
-	# This fixes bug #43885 (20 Mar 2004 agriffis)
-	sed -i -e \
-		's/ libc\.h / /' \
-		"${S}"/src/configure.ac || die 'sed failed'
-
 	# gcc on sparc32 has this, uhm, interesting problem with detecting EOF
 	# correctly. To avoid some really entertaining error messages about stuff
 	# which isn't even in the source file being invalid, we'll do some trickery
@@ -153,10 +146,6 @@ src_prepare() {
 	fi
 
 	cp -v "${S}"/src/config.mk.dist "${S}"/src/auto/config.mk || die "cp failed"
-
-	sed -i -e \
-		"s:\\\$(PERLLIB)/ExtUtils/xsubpp:${EPREFIX}/usr/bin/xsubpp:" \
-		"${S}"/src/Makefile || die 'sed for ExtUtils-ParseXS failed'
 
 	# Fix bug 18245: Prevent "make" from the following chain:
 	# (1) Notice configure.ac is newer than auto/configure


### PR DESCRIPTION
Get rid of the useless/noop `sed` from the vim ebuilds mentioned by @juippis in #29736.