### PR TITLE
dev-libs/hyphen: Fix the build with mawk

### DIFF
--- a/dev-libs/hyphen/files/hyphen-2.8.8-mawk.patch
+++ b/dev-libs/hyphen/files/hyphen-2.8.8-mawk.patch
@@ -1,0 +1,47 @@
+https://github.com/hunspell/hyphen/commit/3d05509b7ce8c350f4476830b00241025eeae329
+https://github.com/hunspell/hyphen/pull/12
+
+From 3d05509b7ce8c350f4476830b00241025eeae329 Mon Sep 17 00:00:00 2001
+From: Philip Chimento <philip.chimento@gmail.com>
+Date: Sat, 12 Nov 2016 00:36:06 -0800
+Subject: [PATCH] More portable awk script
+
+gensub() is specific to gawk, this uses gsub() instead in order to build
+on platforms that don't have gawk such as macOS.
+---
+ lig.awk | 22 ++++++++++++++--------
+ 1 file changed, 14 insertions(+), 8 deletions(-)
+
+diff --git a/lig.awk b/lig.awk
+index 6737170..4ea5e46 100644
+--- a/lig.awk
++++ b/lig.awk
+@@ -24,14 +24,20 @@ c=b
+ c!=b { print c }
+ 
+ /f[1-9]?$/ {
+-	print gensub("f[1-9]?$", "ﬀ", "g", b);
+-	if (c!=b) print gensub("f[1-9]?$", "ﬀ", "g", c);
+-
+-	print gensub("f[1-9]?$", "ﬁ", "g", b);
+-	if (c!=b) print gensub("f[1-9]?$", "ﬁ", "g", c);
+-
+-	print gensub("f[1-9]?$", "ﬂ", "g", b);
+-	if (c!=b) print gensub("f[1-9]?$", "ﬂ", "g", c);
++	out=b; gsub("f[1-9]?$", "ﬀ", out); print out
++	if (c!=b) {
++		out=c; gsub("f[1-9]?$", "ﬀ", out); print out
++	}
++
++	out=b; gsub("f[1-9]?$", "ﬁ", out); print out
++	if (c!=b) {
++		out=c; gsub("f[1-9]?$", "ﬁ", out); print out
++	}
++
++	out=b; gsub("f[1-9]?$", "ﬂ", out); print out
++	if (c!=b) {
++		out=c; gsub("f[1-9]?$", "ﬂ", out); print out
++	}
+ }
+ 
+ 

--- a/dev-libs/hyphen/hyphen-2.8.8-r1.ebuild
+++ b/dev-libs/hyphen/hyphen-2.8.8-r1.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 DESCRIPTION="ALTLinux hyphenation library"
 HOMEPAGE="http://hunspell.github.io/"
@@ -17,6 +17,10 @@ RDEPEND="${DEPEND}"
 BDEPEND="dev-lang/perl"
 
 DOCS=( AUTHORS ChangeLog NEWS README{,.nonstandard,.hyphen,.compound} THANKS TODO )
+
+PATCHES=(
+	"${FILESDIR}"/${P}-mawk.patch
+)
 
 src_configure() {
 	econf $(use_enable static-libs static)


### PR DESCRIPTION
I tested the build with both gawk and mawk.
```
mawk: ./lig.awk: line 44: function gensub never defined
```
Closes: https://bugs.gentoo.org/903656
Upstream-Commit: https://github.com/hunspell/hyphen/commit/3d05509b7ce8c350f4476830b00241025eeae329
Upstream-PR: https://github.com/hunspell/hyphen/pull/12