### PR TITLE
media-libs/vulkan-layers: correctly fix #895348 and undo the old patch

### DIFF
--- a/media-libs/vulkan-layers/files/vulkan-layers-1.3.239-r2-Build-shared-libs.patch
+++ b/media-libs/vulkan-layers/files/vulkan-layers-1.3.239-r2-Build-shared-libs.patch
@@ -1,0 +1,13 @@
+diff --git a/layers/CMakeLists.txt b/layers/CMakeLists.txt
+index 640ac8471..19caed0ed 100644
+--- a/layers/CMakeLists.txt
++++ b/layers/CMakeLists.txt
+@@ -158,7 +158,7 @@ else()
+     message(NOTICE "VulkanVL_generated_source target requires python 3")
+ endif()
+ 
+-add_library(VkLayer_khronos_validation MODULE)
++add_library(VkLayer_khronos_validation SHARED)
+ 
+ target_sources(VkLayer_khronos_validation PRIVATE
+     generated/best_practices.cpp

--- a/media-libs/vulkan-layers/vulkan-layers-1.3.239-r2.ebuild
+++ b/media-libs/vulkan-layers/vulkan-layers-1.3.239-r2.ebuild
@@ -24,7 +24,7 @@ LICENSE="Apache-2.0"
 SLOT="0"
 IUSE="wayland X"
 
-RDEPEND="~dev-util/spirv-tools-99999999:=[${MULTILIB_USEDEP}]"
+RDEPEND="~dev-util/spirv-tools-${PV}:=[${MULTILIB_USEDEP}]"
 DEPEND="${RDEPEND}
 	${PYTHON_DEPS}
 	>=dev-cpp/robin-hood-hashing-3.11.5
@@ -37,7 +37,7 @@ DEPEND="${RDEPEND}
 	)
 "
 
-PATCHES="${FILESDIR}/${PN}-1.3.239-r2-Build-shared-libs.patch"
+PATCHES="${FILESDIR}/${PF}-Build-shared-libs.patch"
 
 multilib_src_configure() {
 	local mycmakeargs=(


### PR DESCRIPTION
Validation layers maintainer replied to a [Github issue](https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5289), saying that we patched it wrong.
He also [provided an explanation](https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5519#issuecomment-1485518954) why that happens: libVkLayer_utils is not supported being built as a .so, and hasn't been supported for a long time.

Bug: #895348