### PR TITLE
www-client/firefox: keyword 111.0 for ~riscv

### DIFF
--- a/www-client/firefox/firefox-111.0.ebuild
+++ b/www-client/firefox/firefox-111.0.ebuild
@@ -57,7 +57,7 @@ SRC_URI="${MOZ_SRC_BASE_URI}/source/${MOZ_P}.source.tar.xz -> ${MOZ_P_DISTFILES}
 DESCRIPTION="Firefox Web Browser"
 HOMEPAGE="https://www.mozilla.com/firefox"
 
-KEYWORDS="~amd64 ~arm64 ~ppc64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 SLOT="rapid"
 LICENSE="MPL-2.0 GPL-2 LGPL-2.1"

--- a/www-client/firefox/firefox-111.0.ebuild
+++ b/www-client/firefox/firefox-111.0.ebuild
@@ -790,7 +790,8 @@ src_configure() {
 	# For future keywording: This is currently (97.0) only supported on:
 	# amd64, arm, arm64 & x86.
 	# Might want to flip the logic around if Firefox is to support more arches.
-	if use ppc64; then
+	# bug 833001, bug 903411#c8
+	if use ppc64 || use riscv; then
 		mozconfig_add_options_ac '' --disable-sandbox
 	else
 		mozconfig_add_options_ac '' --enable-sandbox

--- a/www-client/firefox/firefox-111.0.ebuild
+++ b/www-client/firefox/firefox-111.0.ebuild
@@ -797,6 +797,10 @@ src_configure() {
 		mozconfig_add_options_ac '' --enable-sandbox
 	fi
 
+	# Firefox 111.0 default jit target not include riscv64,
+	# could be removed if upstream enable it by default in the future.
+	use riscv && mozconfig_add_options_ac 'Enable JIT for RISC-V 64' --enable-jit
+
 	if [[ -s "${S}/api-google.key" ]] ; then
 		local key_origin="Gentoo default"
 		if [[ $(cat "${S}/api-google.key" | md5sum | awk '{ print $1 }') != 709560c02f94b41f9ad2c49207be6c54 ]] ; then


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/903411