### PR TITLE
x11-misc/rofi: keyword 1.7.5 for ~riscv

### DIFF
--- a/x11-misc/rofi/rofi-1.7.5.ebuild
+++ b/x11-misc/rofi/rofi-1.7.5.ebuild
@@ -13,7 +13,7 @@ if [[ "${PV}" == "9999" ]]; then
 	inherit git-r3
 else
 	SRC_URI="https://github.com/davatorium/rofi/releases/download/${PV}/${P}.tar.xz"
-	KEYWORDS="amd64 arm64 x86"
+	KEYWORDS="amd64 arm64 ~riscv x86"
 fi
 
 LICENSE="MIT"

--- a/x11-misc/rofi/rofi-9999.ebuild
+++ b/x11-misc/rofi/rofi-9999.ebuild
@@ -13,7 +13,7 @@ if [[ "${PV}" == "9999" ]]; then
 	inherit git-r3
 else
 	SRC_URI="https://github.com/davatorium/rofi/releases/download/${PV}/${P}.tar.xz"
-	KEYWORDS="amd64 arm64 x86"
+	KEYWORDS="amd64 arm64 ~riscv x86"
 fi
 
 LICENSE="MIT"


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/903413