### PR TITLE
app-office/libreoffice: Remove erroneous dependency

### DIFF
--- a/app-office/libreoffice/libreoffice-7.3.7.2.ebuild
+++ b/app-office/libreoffice/libreoffice-7.3.7.2.ebuild
@@ -90,7 +90,6 @@ $(printf 'libreoffice_extensions_%s ' ${LO_EXTS})"
 REQUIRED_USE="${PYTHON_REQUIRED_USE}
 	base? ( firebird java )
 	bluetooth? ( dbus )
-	gtk? ( dbus )
 	libreoffice_extensions_nlpsolver? ( java )
 	libreoffice_extensions_scripting-beanshell? ( java )
 	libreoffice_extensions_scripting-javascript? ( java )

--- a/app-office/libreoffice/libreoffice-7.4.4.2.ebuild
+++ b/app-office/libreoffice/libreoffice-7.4.4.2.ebuild
@@ -95,7 +95,6 @@ $(printf 'libreoffice_extensions_%s ' ${LO_EXTS})"
 REQUIRED_USE="${PYTHON_REQUIRED_USE}
 	base? ( firebird java )
 	bluetooth? ( dbus )
-	gtk? ( dbus )
 	libreoffice_extensions_nlpsolver? ( java )
 	libreoffice_extensions_scripting-beanshell? ( java )
 	libreoffice_extensions_scripting-javascript? ( java )

--- a/app-office/libreoffice/libreoffice-7.4.6.2.ebuild
+++ b/app-office/libreoffice/libreoffice-7.4.6.2.ebuild
@@ -95,7 +95,6 @@ $(printf 'libreoffice_extensions_%s ' ${LO_EXTS})"
 REQUIRED_USE="${PYTHON_REQUIRED_USE}
 	base? ( firebird java )
 	bluetooth? ( dbus )
-	gtk? ( dbus )
 	libreoffice_extensions_nlpsolver? ( java )
 	libreoffice_extensions_scripting-beanshell? ( java )
 	libreoffice_extensions_scripting-javascript? ( java )

--- a/app-office/libreoffice/libreoffice-7.4.9999.ebuild
+++ b/app-office/libreoffice/libreoffice-7.4.9999.ebuild
@@ -95,7 +95,6 @@ $(printf 'libreoffice_extensions_%s ' ${LO_EXTS})"
 REQUIRED_USE="${PYTHON_REQUIRED_USE}
 	base? ( firebird java )
 	bluetooth? ( dbus )
-	gtk? ( dbus )
 	libreoffice_extensions_nlpsolver? ( java )
 	libreoffice_extensions_scripting-beanshell? ( java )
 	libreoffice_extensions_scripting-javascript? ( java )

--- a/app-office/libreoffice/libreoffice-7.5.2.2.ebuild
+++ b/app-office/libreoffice/libreoffice-7.5.2.2.ebuild
@@ -90,7 +90,6 @@ $(printf 'libreoffice_extensions_%s ' ${LO_EXTS})"
 REQUIRED_USE="${PYTHON_REQUIRED_USE}
 	base? ( firebird java )
 	bluetooth? ( dbus )
-	gtk? ( dbus )
 	libreoffice_extensions_nlpsolver? ( java )
 	libreoffice_extensions_scripting-beanshell? ( java )
 	libreoffice_extensions_scripting-javascript? ( java )

--- a/app-office/libreoffice/libreoffice-7.5.9999.ebuild
+++ b/app-office/libreoffice/libreoffice-7.5.9999.ebuild
@@ -90,7 +90,6 @@ $(printf 'libreoffice_extensions_%s ' ${LO_EXTS})"
 REQUIRED_USE="${PYTHON_REQUIRED_USE}
 	base? ( firebird java )
 	bluetooth? ( dbus )
-	gtk? ( dbus )
 	libreoffice_extensions_nlpsolver? ( java )
 	libreoffice_extensions_scripting-beanshell? ( java )
 	libreoffice_extensions_scripting-javascript? ( java )

--- a/app-office/libreoffice/libreoffice-9999.ebuild
+++ b/app-office/libreoffice/libreoffice-9999.ebuild
@@ -89,7 +89,6 @@ $(printf 'libreoffice_extensions_%s ' ${LO_EXTS})"
 REQUIRED_USE="${PYTHON_REQUIRED_USE}
 	base? ( firebird java )
 	bluetooth? ( dbus )
-	gtk? ( dbus )
 	libreoffice_extensions_nlpsolver? ( java )
 	libreoffice_extensions_scripting-beanshell? ( java )
 	libreoffice_extensions_scripting-javascript? ( java )


### PR DESCRIPTION
It is not required to build libreoffice with dbus support when gtk support is enabled.

Closes: https://bugs.gentoo.org/726446