### PR TITLE
app-editors/emacs: Fix unknown string-join function.

### DIFF
--- a/app-editors/emacs/emacs-28.3_rc1-r1.ebuild
+++ b/app-editors/emacs/emacs-28.3_rc1-r1.ebuild
@@ -456,6 +456,7 @@ src_install() {
 	X
 	;;; ${EMACS_SUFFIX} site-lisp configuration
 	X
+	(require 'subr-x)
 	(when (string-match "\\\\\`${FULL_VERSION//./\\\\.}\\\\>" emacs-version)
 	Y  (setq find-function-C-source-directory
 	Y	"${EPREFIX}${cdir}")


### PR DESCRIPTION
In fresh version emacs-28.3_rc1-r1 inside site load used `string-join` function from `subr-x` package without loading it.