### PR TITLE
app-text/enchant: Add missing dependency

### DIFF
--- a/app-text/enchant/enchant-2.3.4.ebuild
+++ b/app-text/enchant/enchant-2.3.4.ebuild
@@ -28,7 +28,9 @@ RDEPEND="${COMMON_DEPEND}
 DEPEND="${COMMON_DEPEND}
 	test? ( >=dev-libs/unittest++-2.0.0-r2 )
 "
-BDEPEND="virtual/pkgconfig"
+BDEPEND="sys-apps/groff
+	virtual/pkgconfig
+"
 
 src_configure() {
 	local myconf=(


### PR DESCRIPTION
The build depends on groff:
```
groff -mandoc -Thtml enchant-2.1 > enchant-2.html
/bin/sh: groff: inaccessible or not found
make[2]: *** [Makefile:1500: enchant-2.html] Error 127
```