### PR TITLE
app-emulation/virtualbox-guest-additions: fix compilation with clang

### DIFF
--- a/app-emulation/virtualbox-guest-additions/virtualbox-guest-additions-7.0.6.ebuild
+++ b/app-emulation/virtualbox-guest-additions/virtualbox-guest-additions-7.0.6.ebuild
@@ -187,7 +187,20 @@ src_compile() {
 	# we compiled the user-space tools as we need two of the
 	# automatically generated header files. (>=3.2.0)
 	# Move this here for bug 836037
-	BUILD_PARAMS="KERN_DIR=/lib/modules/${KV_FULL}/build KERNOUT=${KV_OUT_DIR} KBUILD_EXTRA_SYMBOLS=${S}/Module.symvers"
+	BUILD_PARAMS="CC=\"$(tc-getBUILD_CC)\" KERN_DIR=/lib/modules/${KV_FULL}/build \
+		KERNOUT=${KV_OUT_DIR} KBUILD_EXTRA_SYMBOLS=${S}/Module.symvers"
+	if linux_chkconfig_present CC_IS_CLANG; then
+		ewarn "Warning: building ${PN} with a clang-built kernel is experimental."
+
+		BUILD_PARAMS+=' CC=${CHOST}-clang'
+		if linux_chkconfig_present LD_IS_LLD; then
+			BUILD_PARAMS+=' LD=ld.lld'
+			if linux_chkconfig_present LTO_CLANG_THIN; then
+				# kernel enables cache by default leading to sandbox violations
+				BUILD_PARAMS+=' ldflags-y=--thinlto-cache-dir= LDFLAGS_MODULE=--thinlto-cache-dir='
+			fi
+		fi
+	fi
 	linux-mod_src_compile
 }
 


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/899082
Signed-off-by: Viorel Munteanu <ceamac@gentoo.org>
