### PR TITLE
app-editors/neovim: Fix build failure with msgpack-6.0.0

### DIFF
--- a/app-editors/neovim/files/neovim-0.8-msgpack-6.0.0-fix.patch
+++ b/app-editors/neovim/files/neovim-0.8-msgpack-6.0.0-fix.patch
@@ -1,0 +1,25 @@
+# Closes: https://bugs.gentoo.org/903629
+# Contributed by Olivier Huber <oli.huber@gmail.com>
+--- a/cmake/FindMsgpack.cmake
++++ b/cmake/FindMsgpack.cmake
+@@ -26,18 +26,8 @@
+   set(MSGPACK_VERSION_STRING)
+ endif()
+
+-if(MSVC)
+-  # The import library for the msgpack DLL has a different name
+-  list(APPEND MSGPACK_NAMES msgpackc_import)
+-else()
+-  list(APPEND MSGPACK_NAMES msgpackc msgpack)
+-endif()
+-
+-find_library(MSGPACK_LIBRARY NAMES ${MSGPACK_NAMES}
+-  # Check each directory for all names to avoid using headers/libraries from
+-  # different places.
+-  NAMES_PER_DIR
+-  HINTS ${PC_MSGPACK_LIBDIR} ${PC_MSGPACK_LIBRARY_DIRS})
++find_library(MSGPACK_LIBRARY NAMES msgpackc msgpack msgpackc_import msgpack-c
++  NAMES_PER_DIR)
+
+ mark_as_advanced(MSGPACK_INCLUDE_DIR MSGPACK_LIBRARY)
+

--- a/app-editors/neovim/neovim-0.8.2.ebuild
+++ b/app-editors/neovim/neovim-0.8.2.ebuild
@@ -71,6 +71,7 @@ BDEPEND="
 PATCHES=(
 	"${FILESDIR}/${PN}-0.8-cmake_lua_version.patch"
 	"${FILESDIR}/${PN}-0.8-cmake-darwin.patch"
+	"${FILESDIR}/${PN}-0.8-msgpack-6.0.0-fix.patch"
 )
 
 if [[ ${PV} != 9999 ]]; then

--- a/app-editors/neovim/neovim-0.8.3.ebuild
+++ b/app-editors/neovim/neovim-0.8.3.ebuild
@@ -71,6 +71,7 @@ BDEPEND+="
 PATCHES=(
 	"${FILESDIR}/${PN}-0.8-cmake_lua_version.patch"
 	"${FILESDIR}/${PN}-0.8-cmake-darwin.patch"
+	"${FILESDIR}/${PN}-0.8-msgpack-6.0.0-fix.patch"
 )
 
 if [[ ${PV} != 9999 ]]; then


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/903629