### PR TITLE
media-gfx/eog-plugins: remove picasa USE flag

### DIFF
--- a/media-gfx/eog-plugins/eog-plugins-42.3.ebuild
+++ b/media-gfx/eog-plugins/eog-plugins-42.3.ebuild
@@ -13,7 +13,7 @@ LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="amd64 x86"
 
-IUSE="+exif map picasa +python test"
+IUSE="+exif map +python test"
 RESTRICT="!test? ( test )"
 REQUIRED_USE="
 	map? ( exif )
@@ -30,7 +30,6 @@ RDEPEND="
 		>=media-libs/clutter-1.9.4:1.0
 		>=media-libs/clutter-gtk-1.1.2:1.0
 	)
-	picasa? ( >=dev-libs/libgdata-0.9.1:= )
 	python? (
 		${PYTHON_DEPS}
 		dev-libs/glib[dbus]
@@ -64,7 +63,7 @@ src_configure() {
 		-Dplugin_light-theme=true
 		$(meson_use map plugin_map)
 		$(meson_use python plugin_maximize-windows)
-		$(meson_use picasa plugin_postasa)
+		-Dplugin_postasa=false
 		-Dplugin_postr=false
 		$(meson_use python plugin_pythonconsole)
 		-Dplugin_send-by-mail=true

--- a/media-gfx/eog-plugins/eog-plugins-44.0.ebuild
+++ b/media-gfx/eog-plugins/eog-plugins-44.0.ebuild
@@ -13,7 +13,7 @@ LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
 
-IUSE="+exif map picasa +python test"
+IUSE="+exif map +python test"
 RESTRICT="!test? ( test )"
 REQUIRED_USE="
 	map? ( exif )
@@ -30,7 +30,6 @@ RDEPEND="
 		>=media-libs/clutter-1.9.4:1.0
 		>=media-libs/clutter-gtk-1.1.2:1.0
 	)
-	picasa? ( >=dev-libs/libgdata-0.9.1:= )
 	python? (
 		${PYTHON_DEPS}
 		dev-libs/glib[dbus]
@@ -64,7 +63,7 @@ src_configure() {
 		-Dplugin_light-theme=true
 		$(meson_use map plugin_map)
 		$(meson_use python plugin_maximize-windows)
-		$(meson_use picasa plugin_postasa)
+		-Dplugin_postasa=false
 		-Dplugin_postr=false
 		$(meson_use python plugin_pythonconsole)
 		-Dplugin_send-by-mail=true

--- a/media-gfx/eog-plugins/metadata.xml
+++ b/media-gfx/eog-plugins/metadata.xml
@@ -7,7 +7,6 @@
   </maintainer>
   <use>
     <flag name="map">Enable world map display using <pkg>media-libs/libchamplain</pkg></flag>
-    <flag name="picasa">Enable uploading to Google's Picasa Web Albums</flag>
   </use>
   <upstream>
     <remote-id type="gnome-gitlab">GNOME/eog-plugins</remote-id>


### PR DESCRIPTION
media-gfx/eog-plugins: remove picasa USE flag

Signed-off-by: Cristian Othón Martínez Vera <cfuga@cfuga.mx>

* The PicasaWeb API is dead since almost 4 years ago.
* The picasa USE flag depends on dev-libs/libgdata, which pulls net-libs/libsoup:2.4 in.
