### PR TITLE
gui-wm/gamescope: update HOMEPAGE, SRC_URI

### DIFF
--- a/gui-wm/gamescope/gamescope-3.11.51.ebuild
+++ b/gui-wm/gamescope/gamescope-3.11.51.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -8,8 +8,8 @@ inherit fcaps meson
 MY_PV=$(ver_rs 3 -)
 MY_PV="${MY_PV//_/-}"
 DESCRIPTION="Efficient micro-compositor for running games"
-HOMEPAGE="https://github.com/Plagman/gamescope"
-SRC_URI="https://github.com/Plagman/${PN}/archive/refs/tags/${MY_PV}.tar.gz -> ${P}.tar.gz"
+HOMEPAGE="https://github.com/ValveSoftware/gamescope"
+SRC_URI="https://github.com/ValveSoftware/${PN}/archive/refs/tags/${MY_PV}.tar.gz -> ${P}.tar.gz"
 KEYWORDS="~amd64"
 LICENSE="BSD-2"
 SLOT="0"

--- a/gui-wm/gamescope/gamescope-3.11.52_beta6.ebuild
+++ b/gui-wm/gamescope/gamescope-3.11.52_beta6.ebuild
@@ -8,8 +8,8 @@ inherit fcaps meson
 MY_PV=$(ver_rs 3 -)
 MY_PV="${MY_PV//_/-}"
 DESCRIPTION="Efficient micro-compositor for running games"
-HOMEPAGE="https://github.com/Plagman/gamescope"
-SRC_URI="https://github.com/Plagman/${PN}/archive/refs/tags/${MY_PV}.tar.gz -> ${P}.tar.gz"
+HOMEPAGE="https://github.com/ValveSoftware/gamescope"
+SRC_URI="https://github.com/ValveSoftware/${PN}/archive/refs/tags/${MY_PV}.tar.gz -> ${P}.tar.gz"
 KEYWORDS="~amd64"
 LICENSE="BSD-2"
 SLOT="0"

--- a/gui-wm/gamescope/metadata.xml
+++ b/gui-wm/gamescope/metadata.xml
@@ -6,7 +6,7 @@
 		<name>James Le Cuirot</name>
 	</maintainer>
 	<upstream>
-		<remote-id type="github">Plagman/gamescope</remote-id>
+		<remote-id type="github">ValveSoftware/gamescope</remote-id>
 	</upstream>
 	<use>
 		<flag name="pipewire">Enable screen capture via PipeWire</flag>


### PR DESCRIPTION
https://github.com/Plagman/gamescope was moved to https://github.com/ValveSoftware/gamescope

There shouldn't be any issues in updating the SRC_URI. Checksums didn't change.