### PR TITLE
app-emulation/virtualbox-extpack-oracle: allow old to be installed with newer vbox

### DIFF
--- a/app-emulation/virtualbox-extpack-oracle/virtualbox-extpack-oracle-6.1.42.ebuild
+++ b/app-emulation/virtualbox-extpack-oracle/virtualbox-extpack-oracle-6.1.42.ebuild
@@ -17,7 +17,7 @@ SLOT="0/$(ver_cut 1-2)"
 KEYWORDS="amd64"
 RESTRICT="bindist mirror strip"
 
-RDEPEND="=app-emulation/virtualbox-${MY_PV}*"
+RDEPEND=">=app-emulation/virtualbox-${MY_PV}"
 
 QA_PREBUILT="usr/lib*/virtualbox/ExtensionPacks/${MY_PN}/*"
 


### PR DESCRIPTION
Windows 10 and 11 guests hang on >=7.0.6 additions when 3D acceleration is disabled. The only workaround found besides enabling 3D acceleration is to downgrade additions to 6.1.42 in the guest. This change allows the older extpack (additions) to be installed with newer VirtualBox (from Portage).

With this change, the Extension Manager will show a conflict in the but otherwise causes no issues.

Enabling 3D acceleration is not an acceptable workaround for many due to multiple long-standing graphical bugs.

See tickets and the forum thread below:

Freezes:
https://www.virtualbox.org/ticket/21291
https://www.virtualbox.org/ticket/21431
https://www.virtualbox.org/ticket/21448
https://www.virtualbox.org/ticket/21492

Artifacts / 3D Accel:
https://www.virtualbox.org/ticket/21136
https://www.virtualbox.org/ticket/21233
https://www.virtualbox.org/ticket/21433
https://www.virtualbox.org/ticket/21515

https://forums.virtualbox.org/viewtopic.php?f=7&t=108440

Signed-off-by: Andrew Udvare <audvare@gmail.com>