### PR TITLE
app-text/xapers: enable py3.11

### DIFF
--- a/app-text/xapers/xapers-0.9.0.ebuild
+++ b/app-text/xapers/xapers-0.9.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{9..10} )
+PYTHON_COMPAT=( python3_{9..11} )
 
 inherit distutils-r1
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/896648