### PR TITLE
x11-wm/icewm: Fix typo in einfo message

### DIFF
--- a/x11-wm/icewm/icewm-2.9.6.ebuild
+++ b/x11-wm/icewm/icewm-2.9.6.ebuild
@@ -82,7 +82,7 @@ BDEPEND="
 
 pkg_pretend() {
 	if use gdk-pixbuf && use imlib ; then
-		einfo 'Confilcting USE flags have been enabled:'
+		einfo 'Conflicting USE flags have been enabled:'
 		einfo '"gdk-pixbuf" and "imlib" exclude each other!'
 		einfo 'Using "gdk-pixbuf".'
 	fi

--- a/x11-wm/icewm/icewm-2.9.7.ebuild
+++ b/x11-wm/icewm/icewm-2.9.7.ebuild
@@ -82,7 +82,7 @@ BDEPEND="
 
 pkg_pretend() {
 	if use gdk-pixbuf && use imlib ; then
-		einfo 'Confilcting USE flags have been enabled:'
+		einfo 'Conflicting USE flags have been enabled:'
 		einfo '"gdk-pixbuf" and "imlib" exclude each other!'
 		einfo 'Using "gdk-pixbuf".'
 	fi

--- a/x11-wm/icewm/icewm-3.3.1.ebuild
+++ b/x11-wm/icewm/icewm-3.3.1.ebuild
@@ -82,7 +82,7 @@ BDEPEND="
 
 pkg_pretend() {
 	if use gdk-pixbuf && use imlib ; then
-		einfo 'Confilcting USE flags have been enabled:'
+		einfo 'Conflicting USE flags have been enabled:'
 		einfo '"gdk-pixbuf" and "imlib" exclude each other!'
 		einfo 'Using "gdk-pixbuf".'
 	fi


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/903700

Trivial fix for a trivial issue