### PR TITLE
dev-util/codeblocks: 9999 update; switch to wxGTK:3.2-gtk3

### DIFF
--- a/dev-util/codeblocks/codeblocks-9999.ebuild
+++ b/dev-util/codeblocks/codeblocks-9999.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-WX_GTK_VER="3.0-gtk3"
+WX_GTK_VER="3.2-gtk3"
 
 inherit autotools flag-o-matic subversion wxwidgets xdg
 
@@ -22,16 +22,25 @@ IUSE="contrib debug"
 BDEPEND="virtual/pkgconfig"
 
 RDEPEND="app-arch/zip
+	dev-libs/glib:2
 	>=dev-libs/tinyxml-2.6.2-r3
 	>=dev-util/astyle-3.1-r2:0/3.1
+	x11-libs/gtk+:3
 	x11-libs/wxGTK:${WX_GTK_VER}[X]
 	contrib? (
 		app-admin/gamin
-		app-text/hunspell
+		app-arch/bzip2
+		app-text/hunspell:=
 		dev-libs/boost:=
+		dev-libs/libgamin
+		media-libs/fontconfig
+		sys-libs/zlib
 	)"
 
-DEPEND="${RDEPEND}"
+DEPEND="
+	${RDEPEND}
+	x11-base/xorg-proto
+"
 
 PATCHES=( "${FILESDIR}/${P}-nodebug.diff" )
 
@@ -51,12 +60,15 @@ src_configure() {
 
 	setup-wxwidgets
 
-	econf \
-		--disable-pch \
-		--disable-static \
-		$(use_with contrib boost-libdir "${ESYSROOT}/usr/$(get_libdir)") \
-		$(use_enable debug) \
+	local myeconfargs=(
+		--disable-pch
+		--disable-static
+		$(use_enable debug)
+		$(use_with contrib boost-libdir "${ESYSROOT}/usr/$(get_libdir)")
 		$(use_with contrib contrib-plugins all)
+	)
+
+	econf "${myeconfargs[@]}"
 }
 
 src_install() {


### PR DESCRIPTION
The development of CodeBlocks switched to use wxwidgets 3.2 some time ago and provides nightly builds (Windows only) supported this version of library.

I guess it's a good time to switch `dev-util/codeblocks-9999.ebuild` to use of `wxGTK:3.2-gtk3`. The use of wxwidgets 3.2 should add support of HiDPI resolutions.

As example to compare I could provide compare screenshots for several resolutions from differ systems - "low"; 2.5k (global scale 150%) - tabs and font sizes slightly bigger:

1680x1050 wxGTK-3.0.5
![CodeBlocks-r13254_gcc-11 3 1_wx3 0 5](https://user-images.githubusercontent.com/18756734/229375493-a38c12f3-7e2f-423d-ae07-cc4b3a7a2de0.png)

1680x1050 wxGTK-3.2.2.1
![CodeBlocks-r13254_gcc-11 3 1_wx3 2 2 1](https://user-images.githubusercontent.com/18756734/229375503-2774995b-c41b-4467-bd2b-64bdb37aa204.png)

2560x1440 wxGTK-3.0.5
![CodeBlocks_rev13254_gcc12 2 1_wx3 0 5_3](https://user-images.githubusercontent.com/18756734/229375509-7ee242d2-6d6b-4367-a6fc-1092130ca1a8.png)

2560x1440 wxGTK-3.2.2.1
![CodeBlocks_rev13254_gcc12 2 1_wx3 2 2_3](https://user-images.githubusercontent.com/18756734/229375517-8b413f22-b72a-4cdd-8a89-9999bd765581.png)

