### PR TITLE
app-text/dblatex: enable py3.11

### DIFF
--- a/app-text/dblatex/dblatex-0.3.12.ebuild
+++ b/app-text/dblatex/dblatex-0.3.12.ebuild
@@ -3,7 +3,7 @@
 
 EAPI="7"
 
-PYTHON_COMPAT=( python3_{9,10} )
+PYTHON_COMPAT=( python3_{9..11} )
 
 inherit distutils-r1
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/896634
Signed-off-by: Zoltan Puskas <zoltan@sinustrom.info>
