### PR TITLE
profiles/base: use.mask dev-java/{ant-apache-,}bsf}[python] | profiles/package.mask: Last rite dev-java/jython 

### DIFF
--- a/profiles/base/package.use.mask
+++ b/profiles/base/package.use.mask
@@ -6,6 +6,12 @@
 # This file is only for generic masks. For arch-specific masks (i.e.
 # mask everywhere, unmask on arch/*) use arch/base.
 
+# Volkmar W. Pogatzki <gentoo@pogatzki.net> (2023-04-09)
+# dev-java/jython is last-rited due to vulnerabilities.
+# See bug #825486.
+dev-java/bsf python
+dev-java/ant-apache-bsf python
+
 # Georgy Yakovlev <gyakovlev@gentoo.org> (2023-04-05)
 # Currently broken on 11
 # https://bugs.gentoo.org/833097

--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -33,6 +33,11 @@
 
 #--- END OF EXAMPLES ---
 
+# Volkmar W. Pogatzki <gentoo@pogatzki.net> (2023-04-09)
+# Numerous vulnerabilities, bug #825486.
+# Nothing depends on it. Removal on 2023-05-09
+dev-java/jython
+
 # Hans de Graaff <graaff@gentoo.org> (2023-04-08)
 # Last release in 2008. Upstream is gone. No reverse dependencies. No tests.
 # Removal on 2023-05-08


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/825486