### PR TITLE
qmail.eclass: Patch make-makelib.sh only if it is present

### DIFF
--- a/eclass/qmail.eclass
+++ b/eclass/qmail.eclass
@@ -92,7 +92,12 @@ qmail_set_cc() {
 
 	echo "${cc} ${CFLAGS} ${CPPFLAGS}"  > ./conf-cc || die 'Patching conf-cc failed.'
 	echo "${ld} ${LDFLAGS}" > ./conf-ld || die 'Patching conf-ld failed.'
-	sed -e "s#'ar #'$(tc-getAR) #" -e "s#'ranlib #'$(tc-getRANLIB) #" -i make-makelib.sh || die
+
+	# This function is used also by sys-apps/ucspi-tcp and sys-process/daemontools-encore
+	# but they don't have make-makelib.sh script, see bugs #902009 and #902019
+	if [[ -f make-makelib.sh ]]; then
+		sed -e "s#'ar #'$(tc-getAR) #" -e "s#'ranlib #'$(tc-getRANLIB) #" -i make-makelib.sh || die
+	fi
 }
 
 genqmail_src_unpack() {


### PR DESCRIPTION
Some packages use qmail_set_cc function but they don't contain make-makelib.sh script. However, recent addition of || die to the sed patching this file is newly triggering build failure. This commit addresses the problem by checking if the script is available.

Closes: https://bugs.gentoo.org/902009
Closes: https://bugs.gentoo.org/902019
Fixes: fd4e88c55e34 ("qmail.eclass: remove EAPI 6")

See also this PR https://github.com/gentoo/gentoo/pull/30205