### PR TITLE
eclass/sgml-catalog-r1: Strip ROOT when generating catalog

### DIFF
--- a/eclass/sgml-catalog-r1.eclass
+++ b/eclass/sgml-catalog-r1.eclass
@@ -35,7 +35,7 @@ sgml-catalog-r1_update_catalog() {
 
 	if [[ ${#cats[@]} -gt 0 ]]; then
 		ebegin "Updating ${EROOT}/etc/sgml/catalog"
-		printf 'CATALOG "%s"\n' "${cats[@]}" > "${T}"/catalog &&
+		printf 'CATALOG "%s"\n' "${cats[@]#${ROOT}}" > "${T}"/catalog &&
 		mv "${T}"/catalog "${EROOT}"/etc/sgml/catalog
 		eend "${?}"
 	else


### PR DESCRIPTION
When cross compiling by setting the ROOT variable, the eclass was
writing the full EROOT path into the catalog file. This results in an
invalid path at runtime.

i.e.,
    $ cat /build/amd64-host/etc/sgml/catalog
    CATALOG "/build/amd64-host/etc/sgml/sgml-docbook.cat"
    CATALOG "/build/amd64-host/etc/sgml/sgml-ent.cat"
    CATALOG "/build/amd64-host/etc/sgml/xml-docbook-4.1.2.cat"

Instead we should be stripping off the ROOT so we get a valid path:

    $ cat /build/amd64-host/etc/sgml/catalog
    CATALOG "/etc/sgml/sgml-docbook.cat"
    CATALOG "/etc/sgml/sgml-ent.cat"
    CATALOG "/etc/sgml/xml-docbook-4.1.2.cat"

We don't strip EROOT because we want to keep the prefix if it's
present.

Closes: https://bugs.gentoo.org/903747
Change-Id: I976f9ba1647629017aeb5ef1b4c6a167c41beba1
Signed-off-by: Raul E Rangel <rrangel@chromium.org>
