### PR TITLE
app-arch/zip: Fix dependencies

### DIFF
--- a/app-arch/zip/zip-3.0-r8.ebuild
+++ b/app-arch/zip/zip-3.0-r8.ebuild
@@ -16,9 +16,9 @@ SLOT="0"
 KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~x64-cygwin ~amd64-linux ~x86-linux"
 IUSE="bzip2 crypt natspec unicode"
 
-DEPEND="${RDEPEND}"
 RDEPEND="bzip2? ( app-arch/bzip2 )
 	natspec? ( dev-libs/libnatspec )"
+DEPEND="${RDEPEND}"
 BDEPEND="app-arch/unzip"
 
 PATCHES=(


### PR DESCRIPTION
DEPEND should reference RDEPEND after it's set otherwise the DEPEND
variable will be incorrect.

    aarch64-cros-linux-gnu-clang -c -I. ... -o fileio_.o fileio.c
    zipup.c:37:14: fatal error: 'bzlib.h' file not found
    #    include "bzlib.h"
             ^~~~~~~~~
    zip.c:67:1 error generated.

Signed-off-by: Raul E Rangel <rrangel@chromium.org>
