### PR TITLE
net-misc/dhcp: Add missing dep

### DIFF
--- a/net-misc/dhcp/dhcp-4.4.3_p1-r2.ebuild
+++ b/net-misc/dhcp/dhcp-4.4.3_p1-r2.ebuild
@@ -26,6 +26,7 @@ BDEPEND="
 	acct-user/dhcp"
 
 DEPEND="
+	sys-libs/zlib:=
 	client? (
 		kernel_linux? (
 			ipv6? ( sys-apps/iproute2 )


### PR DESCRIPTION
    checking for zlib library... yes
    checking for library containing deflate... no
    configure: error: found zlib include but not library.
    /build/arm64-generic/tmp/portage/net-misc/dhcp-4.4.1-r1/work/dhcp-4.4.1/bind/bind-9.11.2-P1/config.log:

This shows up when cross compiling into a new sysroot when using the
ROOT= environment variable.

Signed-off-by: Raul E Rangel <rrangel@chromium.org>
