### PR TITLE
dev-python/cffi: Fix broken deps

### DIFF
--- a/eclass/distutils-r1.eclass
+++ b/eclass/distutils-r1.eclass
@@ -34,8 +34,8 @@
 # functions, you should consider calling the defaults (and especially
 # distutils-r1_python_prepare_all).
 #
-# Please note that distutils-r1 sets RDEPEND and BDEPEND (or DEPEND
-# in earlier EAPIs) unconditionally for you.
+# Please note that distutils-r1 sets BDEPEND, DEPEND, and RDEPEND
+# unconditionally for you.
 #
 # Also, please note that distutils-r1 will always inherit python-r1
 # as well. Thus, all the variables defined and documented there are
@@ -313,6 +313,12 @@ _distutils_set_globals() {
 	fi
 
 	if [[ ! ${DISTUTILS_OPTIONAL} ]]; then
+		# This dependency is only required for packages that build
+		# C extensions. It was deemed cleaner to unconditionally
+		# add the dependency than add it to the individual
+		# ebuilds that need it.
+		DEPEND="${PYTHON_DEPS}"
+
 		RDEPEND="${PYTHON_DEPS} ${rdep}"
 		BDEPEND="${PYTHON_DEPS} ${bdep}"
 		REQUIRED_USE=${PYTHON_REQUIRED_USE}


### PR DESCRIPTION
Fix the compile error caused by missing Python.h.

    c/_cffi_backend.c:2:10: fatal error: 'Python.h' file not found
             ^~~~~~~~~~
    	 1 error generated.

`pycparser` is also not a BDEPEND, just a normal RDEPEND.

Signed-off-by: Raul E Rangel <rrangel@chromium.org>
