### PR TITLE
games-emulation/melonds: drop old dependency and add wayland USE flag

### DIFF
--- a/games-emulation/melonds/melonds-0.9.5-r3.ebuild
+++ b/games-emulation/melonds/melonds-0.9.5-r3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2019-2022 Gentoo Authors
+# Copyright 2019-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -37,7 +37,6 @@ RDEPEND="
 	media-libs/libsdl2[sound,video]
 	net-libs/libpcap
 	net-libs/libslirp
-	opengl? ( media-libs/libepoxy )
 "
 DEPEND="${RDEPEND}"
 BDEPEND="kde-frameworks/extra-cmake-modules:5"

--- a/games-emulation/melonds/melonds-9999.ebuild
+++ b/games-emulation/melonds/melonds-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2019-2022 Gentoo Authors
+# Copyright 2019-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -37,7 +37,6 @@ RDEPEND="
 	media-libs/libsdl2[sound,video]
 	net-libs/libpcap
 	net-libs/libslirp
-	opengl? ( media-libs/libepoxy )
 "
 DEPEND="${RDEPEND}"
 BDEPEND="kde-frameworks/extra-cmake-modules:5"

--- a/games-emulation/melonds/melonds-9999.ebuild
+++ b/games-emulation/melonds/melonds-9999.ebuild
@@ -22,13 +22,12 @@ else
 	KEYWORDS="~amd64"
 fi
 
-IUSE="+jit +opengl"
+IUSE="+jit +opengl wayland"
 LICENSE="BSD-2 GPL-2 GPL-3 Unlicense"
 SLOT="0"
 
 RDEPEND="
 	app-arch/libarchive
-	dev-libs/wayland
 	dev-qt/qtcore:5
 	dev-qt/qtgui:5
 	dev-qt/qtmultimedia:5
@@ -37,9 +36,10 @@ RDEPEND="
 	media-libs/libsdl2[sound,video]
 	net-libs/libpcap
 	net-libs/libslirp
+	wayland? ( dev-libs/wayland )
 "
 DEPEND="${RDEPEND}"
-BDEPEND="kde-frameworks/extra-cmake-modules:5"
+BDEPEND="wayland? ( kde-frameworks/extra-cmake-modules:5 )"
 
 # used for JIT recompiler
 QA_EXECSTACK="usr/bin/melonDS"
@@ -65,6 +65,7 @@ src_configure() {
 		-DBUILD_SHARED_LIBS=OFF
 		-DENABLE_JIT=$(usex jit)
 		-DENABLE_OGLRENDERER=$(usex opengl)
+		-DENABLE_WAYLAND=$(usex wayland)
 	)
 	cmake_src_configure
 }


### PR DESCRIPTION
melonDS-emu/melonDS@ac3118cbc54715da55856958b42817fbd1eed666 changed the OpenGL context code to use that from DuckStation, dropping libepoxy as a dependency and now having Wayland as a dependency.

melonDS-emu/melonDS@350292fb3c4037f90ba53f72e3d7cf08a7b3e196 allows toggling Wayland support at build, now making it optional.