### PR TITLE
app-editors/neovim: Fix dependency on tree-sitter 0.20.8

### DIFF
--- a/app-editors/neovim/neovim-9999.ebuild
+++ b/app-editors/neovim/neovim-9999.ebuild
@@ -52,7 +52,7 @@ DEPEND="${LUA_DEPS}
 	>=dev-libs/libuv-1.44.2:=
 	>=dev-libs/libvterm-0.3
 	>=dev-libs/msgpack-3.0.0:=
-	>=dev-libs/tree-sitter-0.20.2:=
+	>=dev-libs/tree-sitter-0.20.8:=
 	tui? (
 		>=dev-libs/libtermkey-0.22
 		>=dev-libs/unibilium-2.0.0:0=


### PR DESCRIPTION
With upstream commit [090ade4a](https://github.com/neovim/neovim/commit/090ade4af6344a7bc4ee56a8052c0739c0428c04), function ts_tree_included_ranges is being used, which is only available from tree-sitter v0.20.8.