### PR TITLE
app-crypt/tpm2-abrmd: Add openrc init dependency on dbus

### DIFF
--- a/app-crypt/tpm2-abrmd/files/tpm2-abrmd.initd
+++ b/app-crypt/tpm2-abrmd/files/tpm2-abrmd.initd
@@ -10,6 +10,7 @@ command_user="tss:tss"
 pidfile="/var/run/${RC_SVCNAME}.pid"
 
 depend() {
+	need dbus
 	use logger
 	after coldplug
 }


### PR DESCRIPTION
The project lists a dependency on DBus quite prominently in the README and won't start without it already running.

https://github.com/tpm2-software/tpm2-abrmd#tpm2-abrmd