### PR TITLE
x11-apps/mesa-progs: Update live ebuild

### DIFF
--- a/x11-apps/mesa-progs/files/9999-Disable-things-we-don-t-want.patch
+++ b/x11-apps/mesa-progs/files/9999-Disable-things-we-don-t-want.patch
@@ -1,4 +1,4 @@
-From 04603e5b169edbbe9a6d7dc6a00906c1382b141a Mon Sep 17 00:00:00 2001
+From fa9eb6da5af8f55c49e4594b490d8af5904835f7 Mon Sep 17 00:00:00 2001
 From: Matt Turner <mattst88@gmail.com>
 Date: Fri, 27 Jan 2023 06:40:05 -0800
 Subject: [PATCH] Disable things we don't want
@@ -7,16 +7,16 @@ v2: Enable libglad to satisfy egl dependencies
 v3: Enable most of libutil to fix undefined references in es2gears
 ---
  meson.build                   | 13 +++----------
- src/egl/opengl/meson.build    | 33 --------------------------------
+ src/egl/opengl/meson.build    | 28 ---------------------------
  src/egl/opengles2/meson.build |  5 -----
  src/meson.build               |  2 --
  src/util/gl_wrap.h            |  2 --
  src/util/meson.build          |  7 +------
  src/xdemos/meson.build        | 36 -----------------------------------
- 7 files changed, 4 insertions(+), 94 deletions(-)
+ 7 files changed, 4 insertions(+), 89 deletions(-)
 
 diff --git a/meson.build b/meson.build
-index 29e5b41e..93a56b5f 100644
+index bc3278e1..66433403 100644
 --- a/meson.build
 +++ b/meson.build
 @@ -87,16 +87,7 @@ endif
@@ -36,8 +36,8 @@ index 29e5b41e..93a56b5f 100644
 +dep_glu = disabler()
  
  dep_glx = dependency('glx', required: false, disabler : true)
- if not dep_glx.found() and host_machine.system() == 'darwin'
-@@ -144,6 +135,8 @@ else
+ if not dep_glx.found()
+@@ -145,6 +136,8 @@ else
    dep_glut = dependency('', required : false)
  endif
  
@@ -47,16 +47,16 @@ index 29e5b41e..93a56b5f 100644
                                          dependencies: [dep_glut],
                                          prefix : '#include <GL/freeglut.h>')
 diff --git a/src/egl/opengl/meson.build b/src/egl/opengl/meson.build
-index a613eb43..1c91ae1b 100644
+index 9bca049c..e7122027 100644
 --- a/src/egl/opengl/meson.build
 +++ b/src/egl/opengl/meson.build
-@@ -25,38 +25,12 @@ executable(
-   dependencies: [_deps, dep_glu, idep_eglut_x11],
+@@ -25,27 +25,6 @@ executable(
+   dependencies: [_deps, dep_glu, idep_eglut],
    install: true
  )
 -executable(
--  'egltri_x11', files('egltri.c'),
--  dependencies: [_deps, dep_glu, idep_eglut_x11],
+-  'egltri', files('egltri.c'),
+-  dependencies: [_deps, dep_glu, idep_eglut],
 -  install: true
 -)
 -executable(
@@ -69,17 +69,6 @@ index a613eb43..1c91ae1b 100644
 -  dependencies: [_deps, dep_x11],
 -  install: true
 -)
- 
- executable(
-   'eglgears_wayland', files('eglgears.c'),
-   dependencies: [_deps, dep_glu, idep_eglut_wayland],
-   install: true
- )
--executable(
--  'egltri_wayland', files('egltri.c'),
--  dependencies: [_deps, dep_glu, idep_eglut_wayland],
--  install: true
--)
 -
 -executable(
 -  'eglkms', 'eglkms.c',
@@ -89,7 +78,7 @@ index a613eb43..1c91ae1b 100644
  
  executable(
    'eglinfo', 'eglinfo.c',
-@@ -64,10 +38,3 @@ executable(
+@@ -53,10 +32,3 @@ executable(
    include_directories: [inc_glad],
    install: true
  )
@@ -101,11 +90,11 @@ index a613eb43..1c91ae1b 100644
 -)
 -
 diff --git a/src/egl/opengles2/meson.build b/src/egl/opengles2/meson.build
-index da083cf2..59b35d66 100644
+index 86062cbd..729c0df6 100644
 --- a/src/egl/opengles2/meson.build
 +++ b/src/egl/opengles2/meson.build
 @@ -29,11 +29,6 @@ executable(
-   dependencies: [dep_gles2, idep_eglut_x11, idep_util],
+   dependencies: [dep_gles2, idep_eglut, idep_util],
    install: true
  )
 -executable(
@@ -114,8 +103,8 @@ index da083cf2..59b35d66 100644
 -  install: true
 -)
  executable(
-   'es2gears_wayland', files('es2gears.c'),
-   dependencies: [dep_gles2, idep_eglut_wayland, idep_util],
+   'texture_from_pixmap_glesv2', files('texture_from_pixmap_glesv2.c'),
+   dependencies: [_deps_x11, idep_util],
 diff --git a/src/meson.build b/src/meson.build
 index fd4a1673..cea622a6 100644
 --- a/src/meson.build

--- a/x11-apps/mesa-progs/mesa-progs-9999.ebuild
+++ b/x11-apps/mesa-progs/mesa-progs-9999.ebuild
@@ -21,10 +21,10 @@ else
 fi
 LICENSE="LGPL-2"
 SLOT="0"
-IUSE="gles2 wayland X"
+IUSE="gles2 vulkan wayland X"
 
 RDEPEND="
-	media-libs/mesa[${MULTILIB_USEDEP},egl(+),gles2?,wayland?,X?]
+	media-libs/mesa[${MULTILIB_USEDEP},egl(+),gles2?,vulkan?,wayland?,X?]
 	wayland? ( dev-libs/wayland[${MULTILIB_USEDEP}] )
 	X? (
 		x11-libs/libX11[${MULTILIB_USEDEP}]
@@ -32,11 +32,13 @@ RDEPEND="
 	)
 "
 DEPEND="${RDEPEND}
+	vulkan? ( media-libs/vulkan-loader[${MULTILIB_USEDEP}] )
 	wayland? ( >=dev-libs/wayland-protocols-1.12 )
 	X? ( x11-base/xorg-proto )
 "
 BDEPEND="
 	virtual/pkgconfig
+	vulkan? ( dev-util/glslang )
 	wayland? ( dev-util/wayland-scanner )
 "
 
@@ -56,11 +58,11 @@ pkg_setup() {
 
 	use gles2 && use X && MULTILIB_CHOST_TOOLS+=(
 		/usr/bin/es2_info
-		/usr/bin/es2gears_x11
+		/usr/bin/es2gears
 	)
 
-	use gles2 && use wayland && MULTILIB_CHOST_TOOLS+=(
-		/usr/bin/es2gears_wayland
+	use vulkan && MULTILIB_CHOST_TOOLS+=(
+		/usr/bin/vkgears
 	)
 }
 
@@ -71,6 +73,7 @@ multilib_src_configure() {
 		-Dgles1=disabled
 		$(meson_feature gles2)
 		-Dosmesa=disabled
+		$(meson_feature vulkan)
 		$(meson_feature wayland)
 		$(meson_feature X x11)
 	)

--- a/x11-apps/mesa-progs/metadata.xml
+++ b/x11-apps/mesa-progs/metadata.xml
@@ -7,6 +7,7 @@
   </maintainer>
   <use>
     <flag name="gles2">Build OpenGL ES 2 utilities</flag>
+    <flag name="vulkan">Build Vulkan utilities</flag>
   </use>
   <upstream>
     <remote-id type="freedesktop-gitlab">mesa/demos</remote-id>


### PR DESCRIPTION
Note `USE=wayland` fails because Gentoo doesn't carry libdecor (https://gitlab.freedesktop.org/libdecor/libdecor). I will leave this for someone that actually uses wayland. There is also a build time dependency for `glslangValidator` which is why I added the glslang dependency.

* Rebases the live patch
* Add USE=vulkan for vkgears
* es2gears_wayland was removed upstream
* es2gears_x11 was renamed to es2gears upstream