### PR TITLE
sys-devel/distcc: enable py3.11

### DIFF
--- a/sys-devel/distcc/distcc-3.4-r1.ebuild
+++ b/sys-devel/distcc/distcc-3.4-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{9..10} )
+PYTHON_COMPAT=( python3_{9..11} )
 
 inherit autotools flag-o-matic prefix python-single-r1 systemd
 


### PR DESCRIPTION
Tested and working with `dev-lang/python-3.11.3:3.11::gentoo`, both client and server.  

Client:
`Linux 6.2.8-gentoo x86_64 AMD Ryzen 7 5800H with Radeon Graphics AuthenticAMD GNU/Linux`
Server:
`Linux 6.2.6-gentoo x86_64 AMD Ryzen 7 7700X 8-Core Processor AuthenticAMD GNU/Linux`

Sample journald output from `dev-libs/boost-1.81.0-r1` build:
```
Apr 06 23:23:43 Foo-Server distccd[227390]: (dcc_job_summary) client: 192.168.22.24:59846 COMPILE_OK exit:0 sig:0 core:0 ret:0 time:1658ms x86_64-pc-linux-gnu-g++ libs/math/build/../src/tr1/ellint_1.cpp
Apr 06 23:23:44 Foo-Server distccd[227391]: (dcc_job_summary) client: 192.168.22.24:59826 COMPILE_OK exit:0 sig:0 core:0 ret:0 time:3285ms x86_64-pc-linux-gnu-g++ libs/math/build/../src/tr1/cyl_bessel_jl.cpp
Apr 06 23:23:44 Foo-Server distccd[227384]: (dcc_job_summary) client: 192.168.22.24:59830 COMPILE_OK exit:0 sig:0 core:0 ret:0 time:3310ms x86_64-pc-linux-gnu-g++ libs/math/build/../src/tr1/sph_neumannf.cpp
Apr 06 23:23:45 Foo-Server distccd[227389]: (dcc_job_summary) client: 192.168.22.24:59862 COMPILE_OK exit:0 sig:0 core:0 ret:0 time:3080ms x86_64-pc-linux-gnu-g++ libs/math/build/../src/tr1/betal.cpp
Apr 06 23:23:45 Foo-Server distccd[227382]: (dcc_job_summary) client: 192.168.22.24:59918 COMPILE_OK exit:0 sig:0 core:0 ret:0 time:2198ms x86_64-pc-linux-gnu-g++ libs/math/build/../src/tr1/hermitel.cpp
Apr 06 23:23:45 Foo-Server distccd[227392]: (dcc_job_summary) client: 192.168.22.24:58764 COMPILE_OK exit:0 sig:0 core:0 ret:0 time:680ms x86_64-pc-linux-gnu-g++ libs/nowide/src/console_buffer.cpp
```
Closes: https://bugs.gentoo.org/897294
Closes: https://github.com/gentoo/gentoo/pull/30509
Signed-off-by: Peter Levine <plevine457@gmail.com>