### PR TITLE
dev-python/pypax: enable py3.11

### DIFF
--- a/dev-python/pypax/pypax-0.9.5-r1.ebuild
+++ b/dev-python/pypax/pypax-0.9.5-r1.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..10} )
+PYTHON_COMPAT=( python3_{9..11} )
 
 inherit distutils-r1
 

--- a/dev-python/pypax/pypax-9999.ebuild
+++ b/dev-python/pypax/pypax-9999.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..10} )
+PYTHON_COMPAT=( python3_{9..11} )
 
 inherit distutils-r1
 


### PR DESCRIPTION
Tested and working with `dev-lang/python-3.11.3:3.11::gentoo`.

Part of output of `revdep-pax -rv`:
```
libperfetto.so  /opt/android-studio/plugins/android/resources/perfetto/armeabi-v7a/libperfetto.so :ARM ( **** )
        /opt/android-studio/plugins/android/resources/perfetto/armeabi-v7a/traced ( **** )
        /opt/android-studio/plugins/android/resources/perfetto/armeabi-v7a/traced_probes ( **** )

        No mismatches


libandroid.so   unknown_library :ARM ( **** )
        /opt/android-studio/plugins/android/resources/screen-sharing-agent/armeabi-v7a/libscreen-sharing-agent.so ( **** )

        No mismatches
```
Part of output of `revdep-pax -fv`:
```
/usr/bin/syncthing :X86_64 ( -em-- )

        No mismatches


/usr/bin/tailscale :X86_64 ( -em-- )
        libresolv.so.2  /lib64/libresolv.so.2 ( **** )
        libc.so.6       /lib64/libc.so.6 ( **** )

        Mismatches


/usr/sbin/tailscaled :X86_64 ( -em-- )
        libresolv.so.2  /lib64/libresolv.so.2 ( **** )
        libc.so.6       /lib64/libc.so.6 ( **** )

        Mismatches
```
Closes: https://bugs.gentoo.org/896836
Signed-off-by: Peter Levine <plevine457@gmail.com>