### PR TITLE
app-admin/petrovich: EAPI8 bump

### DIFF
--- a/app-admin/petrovich/petrovich-1.0.0-r2.ebuild
+++ b/app-admin/petrovich/petrovich-1.0.0-r2.ebuild
@@ -1,0 +1,29 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DESCRIPTION="Filesystem Integrity Checker"
+HOMEPAGE="https://sourceforge.net/projects/petrovich"
+SRC_URI="mirror://sourceforge/petrovich/${P}.tar.gz"
+S="${WORKDIR}/${PN}"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~sparc ~x86"
+
+RDEPEND="virtual/perl-Digest-MD5"
+
+PATCHES=( "${FILESDIR}/${P}-gentoo.diff" )
+HTML_DOCS=( CHANGES.HTML LICENSE.HTML README.HTML TODO.HTML USAGE.HTML )
+
+src_install() {
+	dosbin "${PN}.pl"
+
+	insinto /etc
+	doins "${FILESDIR}/${PN}.conf"
+
+	dodir "/var/db/${PN}"
+
+	einstalldocs
+}


### PR DESCRIPTION
Hi,

another simple EAPI8 bump:

```diff
--- petrovich-1.0.0-r1.ebuild	2023-04-01 17:48:25.706959770 +0200
+++ petrovich-1.0.0-r2.ebuild	2023-04-07 18:28:45.309416075 +0200
@@ -1,20 +1,19 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
 
 DESCRIPTION="Filesystem Integrity Checker"
-SRC_URI="mirror://sourceforge/petrovich/${P}.tar.gz"
 HOMEPAGE="https://sourceforge.net/projects/petrovich"
+SRC_URI="mirror://sourceforge/petrovich/${P}.tar.gz"
+S="${WORKDIR}/${PN}"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 ppc sparc x86"
+KEYWORDS="~amd64 ~ppc ~sparc ~x86"
 
 RDEPEND="virtual/perl-Digest-MD5"
 
-S="${WORKDIR}/${PN}"
-
 PATCHES=( "${FILESDIR}/${P}-gentoo.diff" )
 HTML_DOCS=( CHANGES.HTML LICENSE.HTML README.HTML TODO.HTML USAGE.HTML )
```