### PR TITLE
media-video/vdr: fix filename of ttxtsubs patch

### DIFF
--- a/media-video/vdr/vdr-2.6.4.ebuild
+++ b/media-video/vdr/vdr-2.6.4.ebuild
@@ -121,7 +121,7 @@ src_prepare() {
 	use naludump && eapply "${FILESDIR}/${PN}-2.6.1_naludump.patch"
 	use permashift && eapply "${FILESDIR}/${PN}-2.6.1-patch-for-permashift.patch"
 	use pinplugin && eapply "${FILESDIR}/${PN}-2.6.1_pinplugin.patch"
-	use ttxtsubs && eapply "${DISTDIR}/vdr-2.6.1_ttxtsubs_v2.patch"
+	use ttxtsubs && eapply "${DISTDIR}/${P}_ttxtsubs_v2.patch"
 	use menuorg && eapply "${DISTDIR}/vdr-menuorg-2.3.x.diff"
 	use mainmenuhooks && eapply "${FILESDIR}/${PN}-2.4.1_mainmenuhook-1.0.1.patch"
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/902897
Closes: https://bugs.gentoo.org/903173