### PR TITLE
www-apache/mod_musicindex: Fix slibtool install

### DIFF
--- a/www-apache/mod_musicindex/files/mod_musicindex-1.4.1-slibtool.patch
+++ b/www-apache/mod_musicindex/files/mod_musicindex-1.4.1-slibtool.patch
@@ -1,0 +1,28 @@
+https://bugs.gentoo.org/778566
+
+commit 7455f156499c1980193f0c7a4e25b1040ba99104
+Author: orbea <orbea@riseup.net>
+Date:   Sat Apr 8 12:31:47 2023 -0700
+
+    build: Don't overwrite the default install target
+    
+    Autotools is capable of creating a working install target without any
+    help from apache's apxs which results in calling apache's libtool
+    implementation instead of GNU libtool or slibtool.
+
+diff --git a/src/Makefile.am b/src/Makefile.am
+index 4815507..7a63571 100644
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -69,11 +69,3 @@ noinst_HEADERS = \
+ 	playlist-mp4.h \
+ 	playlist-vorbis.h \
+ 	sort.h
+-
+-install: $(lib_LTLIBRARIES)
+-	$(mkinstalldirs) "$(DESTDIR)$(libdir)"
+-if BUILD_FOR_APACHE2
+-	$(APXS) -S LIBEXECDIR="$(DESTDIR)$(libdir)" -i -n musicindex mod_musicindex.la
+-else
+-	$(APXS) -S LIBEXECDIR="$(DESTDIR)$(libdir)" -i -n musicindex .libs/mod_musicindex.so
+-endif

--- a/www-apache/mod_musicindex/mod_musicindex-1.4.1-r3.ebuild
+++ b/www-apache/mod_musicindex/mod_musicindex-1.4.1-r3.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
-inherit apache-module
+inherit apache-module autotools
 
 DESCRIPTION="mod_musicindex allows nice displaying of directories containing music files"
 HOMEPAGE="http://hacks.slashdirt.org/sw/musicindex/"
@@ -30,10 +30,19 @@ APACHE2_MOD_CONF="50_${PN}"
 APACHE2_MOD_DEFINE="MUSICINDEX"
 DOCS=( AUTHORS BUGS ChangeLog README UPGRADING )
 
+PATCHES=(
+	"${FILESDIR}"/${P}-slibtool.patch #778566
+)
+
 need_apache2
 
 pkg_setup() {
 	_init_apache2_late
+}
+
+src_prepare() {
+	default
+	eautoreconf
 }
 
 src_configure() {
@@ -62,4 +71,6 @@ src_install() {
 	newins "${DISTDIR}/${P}_valid-rss.png" valid-rss.png
 	newins "${DISTDIR}/${P}_valid-xhtml11" valid-xhtml11
 	newins "${DISTDIR}/${P}_vcss" vcss
+
+	find "${ED}" -type f -name "*.la" -delete || die
 }


### PR DESCRIPTION
I submitted a patch upstream by e-mail, I don't know if this an active project? The md5sum of the installed `/usr/lib/apache2/modules/mod_musicindex.so` is the same with the GNU libtool generated by autotools or `/usr/share/apr/build/libtool` so there should be no functional differences. The build process already is using the former and its only the install target that is broken with slibtool.

Closes: https://bugs.gentoo.org/778566