### PR TITLE
app-editors/neovim: Fix cmake unused variable warning

### DIFF
--- a/app-editors/neovim/neovim-0.9.0.ebuild
+++ b/app-editors/neovim/neovim-0.9.0.ebuild
@@ -93,10 +93,8 @@ src_configure() {
 	# TODO: Investigate USE_BUNDLED, doesn't seem to be needed right now
 	local mycmakeargs=(
 		-DENABLE_LTO=$(usex lto)
-		-DFEAT_TUI=$(usex tui)
 		-DPREFER_LUA=$(usex lua_single_target_luajit no "$(lua_get_version)")
 		-DLUA_PRG="${ELUA}"
-		-DMIN_LOG_LEVEL=3
 	)
 	cmake_src_configure
 }

--- a/app-editors/neovim/neovim-9999.ebuild
+++ b/app-editors/neovim/neovim-9999.ebuild
@@ -92,10 +92,8 @@ src_configure() {
 	# TODO: Investigate USE_BUNDLED, doesn't seem to be needed right now
 	local mycmakeargs=(
 		-DENABLE_LTO=$(usex lto)
-		-DFEAT_TUI=$(usex tui)
 		-DPREFER_LUA=$(usex lua_single_target_luajit no "$(lua_get_version)")
 		-DLUA_PRG="${ELUA}"
-		-DMIN_LOG_LEVEL=3
 	)
 	cmake_src_configure
 }


### PR DESCRIPTION
MIN_LOG_LEVEL and FEAT_TUI have been removed from v0.9.0, hence the warning.

Closes: https://bugs.gentoo.org/904095