### PR TITLE
app-crypt/codegroup: EAPI8 bump, use HTTPS

### DIFF
--- a/app-crypt/codegroup/codegroup-20080907-r1.ebuild
+++ b/app-crypt/codegroup/codegroup-20080907-r1.ebuild
@@ -1,23 +1,21 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
 
 inherit toolchain-funcs
 
 DESCRIPTION="encode / decode binary file as five letter codegroups"
-HOMEPAGE="http://www.fourmilab.ch/codegroup/"
-SRC_URI="http://www.fourmilab.ch/${PN}/${PN}.zip -> ${P}.zip"
+HOMEPAGE="https://www.fourmilab.ch/codegroup/"
+SRC_URI="https://www.fourmilab.ch/${PN}/${PN}.zip -> ${P}.zip"
+S=${WORKDIR}
 
 LICENSE="public-domain"
 SLOT="0"
 KEYWORDS="~amd64 ~arm ~ppc ~sparc ~x86"
-IUSE=""
 
-DEPEND="app-arch/unzip"
-RDEPEND=""
+BDEPEND="app-arch/unzip"
 
-S=${WORKDIR}
 PATCHES=( "${FILESDIR}"/${P}-Makefile.patch )
 
 src_configure() {


### PR DESCRIPTION
Simple EAPI8 bump for `app-crypt/codegroup`