### PR TITLE
media-libs/openexr: fix x86 musl build

### DIFF
--- a/media-libs/openexr/files/openexr-3.1.5-musl-i386.patch
+++ b/media-libs/openexr/files/openexr-3.1.5-musl-i386.patch
@@ -1,0 +1,19 @@
+--- a/src/lib/Iex/IexMathFpu.cpp
++++ b/src/lib/Iex/IexMathFpu.cpp
+@@ -251,14 +251,14 @@
+ inline void
+ restoreControlRegs (const ucontext_t & ucon, bool clearExceptions)
+ {
+-#        if defined(__GLIBC__) && defined(__i386__)
++#        if defined(__linux__) && defined(__i386__)
+     setCw ((ucon.uc_mcontext.fpregs->cw & cwRestoreMask) | cwRestoreVal);
+ #else
+     setCw ((ucon.uc_mcontext.fpregs->cwd & cwRestoreMask) | cwRestoreVal);
+ #        endif
+ 
+     _fpstate* kfp = reinterpret_cast<_fpstate*> (ucon.uc_mcontext.fpregs);
+-#        if defined(__GLIBC__) && defined(__i386__)
++#        if defined(__linux__) && defined(__i386__)
+     setMxcsr (kfp->magic == 0 ? kfp->mxcsr : 0, clearExceptions);
+ #else
+     setMxcsr (kfp->mxcsr, clearExceptions);

--- a/media-libs/openexr/files/openexr-3.1.7-musl-i386.patch
+++ b/media-libs/openexr/files/openexr-3.1.7-musl-i386.patch
@@ -1,0 +1,19 @@
+--- a/src/lib/Iex/IexMathFpu.cpp
++++ b/src/lib/Iex/IexMathFpu.cpp
+@@ -251,14 +251,14 @@
+ inline void
+ restoreControlRegs (const ucontext_t & ucon, bool clearExceptions)
+ {
+-#        if (defined(__GLIBC__) && defined(__i386__)) || defined(__ANDROID_API__)
++#        if (defined(__linux__) && defined(__i386__)) || defined(__ANDROID_API__)
+     setCw ((ucon.uc_mcontext.fpregs->cw & cwRestoreMask) | cwRestoreVal);
+ #else
+     setCw ((ucon.uc_mcontext.fpregs->cwd & cwRestoreMask) | cwRestoreVal);
+ #        endif
+ 
+     _fpstate* kfp = reinterpret_cast<_fpstate*> (ucon.uc_mcontext.fpregs);
+-#        if defined(__GLIBC__) && defined(__i386__)
++#        if defined(__linux__) && defined(__i386__)
+     setMxcsr (kfp->magic == 0 ? kfp->mxcsr : 0, clearExceptions);
+ #else
+     setMxcsr (kfp->mxcsr, clearExceptions);

--- a/media-libs/openexr/openexr-3.1.5-r1.ebuild
+++ b/media-libs/openexr/openexr-3.1.5-r1.ebuild
@@ -34,6 +34,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-3.1.1-0003-disable-failing-test.patch
 	"${FILESDIR}"/${P}-Add-missing-include-cstdint-required-by-gcc-13-1264.patch
 	"${FILESDIR}"/${P}-add-missed-include-cstdint-statement.patch
+	"${FILESDIR}"/${P}-musl-i386.patch
 )
 
 DOCS=( CHANGES.md GOVERNANCE.md PATENTS README.md SECURITY.md docs/SymbolVisibility.md )

--- a/media-libs/openexr/openexr-3.1.7.ebuild
+++ b/media-libs/openexr/openexr-3.1.7.ebuild
@@ -27,7 +27,11 @@ RDEPEND="
 DEPEND="${RDEPEND}"
 BDEPEND="virtual/pkgconfig"
 
-PATCHES=( "${FILESDIR}"/${PN}-3.1.1-0003-disable-failing-test.patch )
+PATCHES=(
+	"${FILESDIR}"/${PN}-3.1.1-0003-disable-failing-test.patch
+	"${FILESDIR}"/${PN}-3.1.7-musl-i386.patch
+)
+
 DOCS=( CHANGES.md GOVERNANCE.md PATENTS README.md SECURITY.md )
 
 src_prepare() {


### PR DESCRIPTION
media-libs/openexr: fix x86 musl build

This upstream commit breaks x86 32-bit with musl, because it assumes glibc == linux.

https://github.com/AcademySoftwareFoundation/openexr/commit/7e4630f9773810297831b9a31c6fecab51623e12

These patches extend the upstream fix to all non-glibc Linux systems.

Signed-off-by: Cristian Othón Martínez Vera <cfuga@cfuga.mx>
