### PR TITLE
sci-astronomy/siril: fix build without OpenMP

### DIFF
--- a/sci-astronomy/siril/files/siril-1.2-openmp.patch
+++ b/sci-astronomy/siril/files/siril-1.2-openmp.patch
@@ -17,3 +17,33 @@ Upstream: https://gitlab.com/free-astro/siril/-/merge_requests/482
  		float *rowpix, v1;
  		double mean, stdev;
  		float *differences;
+From 59272d18d67dc342b1a040b7574b6b71b28310e6 Mon Sep 17 00:00:00 2001
+From: Mario Haustein <mario.haustein@hrz.tu-chemnitz.de>
+Date: Mon, 10 Apr 2023 22:17:54 +0200
+Subject: [PATCH] Remove uneeded openmp headers
+Bug: https://bugs.gentoo.org/903021
+Upstream: https://gitlab.com/free-astro/siril/-/merge_requests/494
+
+--- a/src/filters/nlbayes/LibImages.cpp
++++ b/src/filters/nlbayes/LibImages.cpp
+@@ -26,7 +26,6 @@
+ #include <unistd.h>
+ #include <stdlib.h>
+ #include <math.h>
+-#include <omp.h>
+ 
+  using namespace std;
+ 
+--- a/src/filters/nlbayes/Utilities.cpp
++++ b/src/filters/nlbayes/Utilities.cpp
+@@ -20,7 +20,6 @@
+ #include "Utilities.h"
+ 
+ #include <math.h>
+-#include <omp.h>
+ #include <iostream>
+ #include <stdlib.h>
+ #include <fstream>
+-- 
+2.39.2
+


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/903021