### PR TITLE
dev-cpp/clucene: fix removed std::binary_function in c++17

### DIFF
--- a/dev-cpp/clucene/clucene-2.3.3.4-r9.ebuild
+++ b/dev-cpp/clucene/clucene-2.3.3.4-r9.ebuild
@@ -36,6 +36,7 @@ PATCHES=(
 	"${FILESDIR}/${P}-gmtime.patch"
 	"${FILESDIR}/${P}-musl-pthread.patch"
 	"${FILESDIR}/${P}-libcxx.patch"
+	"${FILESDIR}/${P}-fix-binary-function.patch"
 )
 
 src_prepare() {

--- a/dev-cpp/clucene/files/clucene-2.3.3.4-fix-binary-function.patch
+++ b/dev-cpp/clucene/files/clucene-2.3.3.4-fix-binary-function.patch
@@ -1,0 +1,199 @@
+Replace std::binary_function with typedefs (deprecated in c++11 and removed in c++17).
+Bug: https://bugs.gentoo.org/869170
+--- a/src/core/CLucene/index/_Term.h
++++ b/src/core/CLucene/index/_Term.h
+@@ -13,9 +13,12 @@
+ CL_NS_DEF(index)
+ 
+ 
+-class Term_Equals:public CL_NS_STD(binary_function)<const Term*,const Term*,bool>
++class Term_Equals
+ {
+ public:
++	typedef const Term* first_argument_type;
++	typedef const Term* second_argument_type;
++	typedef bool result_type;
+ 	bool operator()( const Term* val1, const Term* val2 ) const{
+ 		return val1->equals(val2);
+ 	}
+--- a/src/core/CLucene/search/BooleanQuery.cpp
++++ b/src/core/CLucene/search/BooleanQuery.cpp
+@@ -25,9 +25,12 @@ CL_NS_USE(index)
+ CL_NS_USE(util)
+ CL_NS_DEF(search)
+ 
+-	class BooleanClause_Compare:public CL_NS_STD(binary_function)<const BooleanClause*,const BooleanClause*,bool>
++	class BooleanClause_Compare
+ 	{
+ 	public:
++		typedef const BooleanClause* first_argument_type;
++		typedef const BooleanClause* second_argument_type;
++		typedef bool result_type;
+ 		bool operator()( const BooleanClause* val1, const BooleanClause* val2 ) const {
+ 			return val1->equals(val2);
+ 		}
+--- a/src/core/CLucene/search/MultiPhraseQuery.cpp
++++ b/src/core/CLucene/search/MultiPhraseQuery.cpp
+@@ -377,9 +377,12 @@ TCHAR* MultiPhraseQuery::toString(const TCHAR* f) const {
+ 	return buffer.giveBuffer();
+ }
+ 
+-class TermArray_Equals:public CL_NS_STD(binary_function)<const Term**,const Term**,bool>
++class TermArray_Equals
+ {
+ public:
++	typedef const Term** first_argument_type;
++	typedef const Term** second_argument_type;
++	typedef bool result_type;
+ 	bool operator()( CL_NS(util)::ArrayBase<CL_NS(index)::Term*>* val1, CL_NS(util)::ArrayBase<CL_NS(index)::Term*>* val2 ) const{
+     if ( val1->length != val2->length )
+       return false;
+--- a/src/core/CLucene/util/Equators.h
++++ b/src/core/CLucene/util/Equators.h
+@@ -22,21 +22,30 @@ CL_NS_DEF(util)
+ /** @internal */
+ class CLUCENE_INLINE_EXPORT Equals{
+ public:
+-	class CLUCENE_INLINE_EXPORT Int32:public CL_NS_STD(binary_function)<const int32_t*,const int32_t*,bool>
++	class CLUCENE_INLINE_EXPORT Int32
+ 	{
+ 	public:
++		typedef const int32_t* first_argument_type;
++		typedef const int32_t* second_argument_type;
++		typedef bool result_type;
+ 		bool operator()( const int32_t val1, const int32_t val2 ) const;
+ 	};
+ 	
+-	class CLUCENE_INLINE_EXPORT Char:public CL_NS_STD(binary_function)<const char*,const char*,bool>
++	class CLUCENE_INLINE_EXPORT Char
+ 	{
+ 	public:
++		typedef const char* first_argument_type;
++		typedef const char* second_argument_type;
++		typedef bool result_type;
+ 		bool operator()( const char* val1, const char* val2 ) const;
+ 	};
+ #ifdef _UCS2
+-	class CLUCENE_INLINE_EXPORT WChar: public CL_NS_STD(binary_function)<const wchar_t*,const wchar_t*,bool>
++	class CLUCENE_INLINE_EXPORT WChar
+ 	{
+ 	public:
++		typedef const wchar_t* first_argument_type;
++		typedef const wchar_t* second_argument_type;
++		typedef bool result_type;
+ 		bool operator()( const wchar_t* val1, const wchar_t* val2 ) const;
+ 	};
+ 	class CLUCENE_INLINE_EXPORT TChar: public WChar{
+@@ -48,9 +57,12 @@ public:
+ 
+ 
+     template<typename _cl>
+-	class CLUCENE_INLINE_EXPORT Void:public CL_NS_STD(binary_function)<const void*,const void*,bool>
++	class CLUCENE_INLINE_EXPORT Void
+ 	{
+ 	public:
++		typedef const void* first_argument_type;
++		typedef const void* second_argument_type;
++		typedef bool result_type;
+ 		bool operator()( _cl* val1, _cl* val2 ) const{
+ 			return val1==val2;
+ 		}
+--- a/src/core/CLucene/util/_Arrays.h
++++ b/src/core/CLucene/util/_Arrays.h
+@@ -124,12 +124,14 @@ CL_NS_DEF(util)
+ 	
+ 	template <typename _kt, typename _comparator, 
+ 		typename class1, typename class2>
+-	class CLListEquals:
+-		public CL_NS_STD(binary_function)<class1*,class2*,bool>
++	class CLListEquals
+ 	{
+ 	typedef typename class1::const_iterator _itr1;
+ 	typedef typename class2::const_iterator _itr2;
+ 	public:
++		typedef class1* first_argument_type;
++		typedef class2* second_argument_type;
++		typedef bool result_type;
+ 		CLListEquals(){
+ 		}
+ 		bool equals( class1* val1, class2* val2 ) const{
+--- a/src/test/index/TestTermVectorsReader.cpp
++++ b/src/test/index/TestTermVectorsReader.cpp
+@@ -93,17 +93,21 @@ CL_NS_USE(util);
+     }
+   };
+ 
+-  struct MyTCharCompare :
+-    public std::binary_function<const TCHAR*, const TCHAR*, bool>
++  struct MyTCharCompare
+   {
++    typedef const TCHAR* first_argument_type;
++    typedef const TCHAR* second_argument_type;
++    typedef bool result_type;
+     bool operator () (const TCHAR* v1, const TCHAR* v2) const {
+       return _tcscmp(v1, v2) < 0;
+     }
+   };
+ 
+-  struct TestTokenCompare : 
+-    public std::binary_function<const TestToken*, const TestToken*, bool>
++  struct TestTokenCompare
+   {
++    typedef const TestToken* first_argument_type;
++    typedef const TestToken* second_argument_type;
++    typedef bool result_type;
+     bool operator () (const TestToken* t1, const TestToken* t2) const {
+       return t1->pos < t2->pos;
+     }
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -45,6 +45,14 @@ ELSE(NOT CMAKE_BUILD_TYPE)
+     MESSAGE( "Compiling as ${CMAKE_BUILD_TYPE}" )
+ ENDIF(NOT CMAKE_BUILD_TYPE)
+ 
++IF(CMAKE_C_COMPILER_ID MATCHES "Clang")
++  SET(CMAKE_COMPILER_IS_CLANG 1)
++ENDIF(CMAKE_C_COMPILER_ID MATCHES "Clang")
++
++IF(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
++  SET(CMAKE_COMPILER_IS_CLANGXX 1)
++ENDIF(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
++
+ OPTION(ENABLE_DEBUG
+   "enable debug support"
+   OFF)
+@@ -62,14 +70,14 @@ OPTION(ENABLE_ASCII_MODE
+   OFF)
+   
+ SET(ENABLE_ANSI_MODE OFF)
+-IF(CMAKE_COMPILER_IS_GNUCXX)
++IF(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANGXX)
+   SET(ENABLE_ANSI_MODE ON)
+   
+   #exceptions:
+   IF(MINGW OR CYGWIN)
+     SET(ENABLE_ANSI_MODE OFF)
+   ENDIF(MINGW OR CYGWIN)
+-ENDIF(CMAKE_COMPILER_IS_GNUCXX)
++ENDIF(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANGXX)
+ 
+ OPTION(ENABLE_ANSI_MODE
+   "compile with -ansi flag"
+@@ -109,7 +117,7 @@ OPTION(ENABLE_COMPILE_TESTS
+ 
+ #check flags...
+ INCLUDE (TestCXXAcceptsFlag)
+-IF ( CMAKE_COMPILER_IS_GNUCC )
++IF ( CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_CLANG )
+     CHECK_CXX_ACCEPTS_FLAG(-pg GccFlagPg)
+     IF ( GccFlagPg )
+         OPTION(ENABLE_GPROF
+@@ -131,7 +139,7 @@ IF ( CMAKE_COMPILER_IS_GNUCC )
+    IF( ENABLE_ANSI_MODE )
+     SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ansi")
+    ENDIF ( ENABLE_ANSI_MODE )
+-ENDIF(CMAKE_COMPILER_IS_GNUCC) 
++ENDIF(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_CLANG) 
+ 
+ 
+ #Single output directory for building all executables and libraries.


### PR DESCRIPTION
dev-cpp/clucene: fix removed std::binary_function in c++17

Compilation fails with Clang (should be a warning with GCC):
```bash
In file included from /var/tmp/portage/dev-cpp/clucene-2.3.3.4-r8/work/clucene-core-2.3.3.4/src/contribs-lib/CLucene/highlighter/WeightedTerm.cpp:17:
In file included from /var/tmp/portage/dev-cpp/clucene-2.3.3.4-r8/work/clucene-core-2.3.3.4/src/core/CLucene/_ApiHeader.h:19:
In file included from /var/tmp/portage/dev-cpp/clucene-2.3.3.4-r8/work/clucene-core-2.3.3.4/src/core/CLucene/util/_VoidMap.h:18:
In file included from /var/tmp/portage/dev-cpp/clucene-2.3.3.4-r8/work/clucene-core-2.3.3.4/src/core/CLucene/util/VoidMap.h:10:
/var/tmp/portage/dev-cpp/clucene-2.3.3.4-r8/work/clucene-core-2.3.3.4/src/core/CLucene/util/Equators.h:25:53: error: no template named 'binary_function' in namespace 'std'; did you mean '__binary_function'?
        class CLUCENE_INLINE_EXPORT Int32:public CL_NS_STD(binary_function)<const int32_t*,const int32_t*,bool>
                                                 ~~~~~~~~~~^~~~~~~~~~~~~~~~
                                                           __binary_function
/var/tmp/portage/dev-cpp/clucene-2.3.3.4-r8/work/clucene-core-2.3.3.4/src/shared/CLucene/SharedHeader.h:109:33: note: expanded from macro 'CL_NS_STD'
   #define CL_NS_STD(func) std::func
                           ~~~~~^
```
The patch replaces `binary_function` with typedefs.
Closes: https://bugs.gentoo.org/869170