### PR TITLE
media-gfx/gnome-photos: remove media-plugins/grilo-plugins dependency

### DIFF
--- a/media-gfx/gnome-photos/gnome-photos-43.0.ebuild
+++ b/media-gfx/gnome-photos/gnome-photos-43.0.ebuild
@@ -12,7 +12,7 @@ HOMEPAGE="https://wiki.gnome.org/Apps/Photos"
 LICENSE="GPL-3+ LGPL-2+ CC0-1.0"
 SLOT="0"
 KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
-IUSE="test"
+IUSE="test upnp-av"
 RESTRICT="!test? ( test )"
 
 DEPEND="
@@ -38,6 +38,7 @@ DEPEND="
 
 # tracker-miners gschema used at runtime.
 RDEPEND="${DEPEND}
+	upnp-av? ( net-libs/dleyna:1.0= )
 	app-misc/tracker-miners:3
 "
 BDEPEND="

--- a/media-gfx/gnome-photos/gnome-photos-43.0.ebuild
+++ b/media-gfx/gnome-photos/gnome-photos-43.0.ebuild
@@ -12,7 +12,7 @@ HOMEPAGE="https://wiki.gnome.org/Apps/Photos"
 LICENSE="GPL-3+ LGPL-2+ CC0-1.0"
 SLOT="0"
 KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
-IUSE="test upnp-av"
+IUSE="test"
 RESTRICT="!test? ( test )"
 
 DEPEND="
@@ -36,13 +36,8 @@ DEPEND="
 "
 # >=dev-libs/libgdata-0.17.13:0=[gnome-online-accounts] # Upstream left this commented in meson.build. Probably comes back with the next version
 
-# gnome-online-miners is also used for google, facebook, DLNA - not only upnp-av
-# but out of all the grilo-plugins, only upnp-av gets used, which has a USE flag here,
-# so don't pull it always, but only if USE flag is enabled.
 # tracker-miners gschema used at runtime.
 RDEPEND="${DEPEND}
-	net-misc/gnome-online-miners
-	upnp-av? ( media-plugins/grilo-plugins:0.3[upnp-av] )
 	app-misc/tracker-miners:3
 "
 BDEPEND="

--- a/media-gfx/gnome-photos/gnome-photos-44.0.ebuild
+++ b/media-gfx/gnome-photos/gnome-photos-44.0.ebuild
@@ -12,7 +12,7 @@ HOMEPAGE="https://wiki.gnome.org/Apps/Photos"
 LICENSE="GPL-3+ LGPL-2+ CC0-1.0"
 SLOT="0"
 KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
-IUSE="test"
+IUSE="test upnp-av"
 RESTRICT="!test? ( test )"
 
 DEPEND="
@@ -38,6 +38,7 @@ DEPEND="
 
 # tracker-miners gschema used at runtime.
 RDEPEND="${DEPEND}
+	upnp-av? ( net-libs/dleyna:1.0= )
 	app-misc/tracker-miners:3
 "
 BDEPEND="

--- a/media-gfx/gnome-photos/gnome-photos-44.0.ebuild
+++ b/media-gfx/gnome-photos/gnome-photos-44.0.ebuild
@@ -12,7 +12,7 @@ HOMEPAGE="https://wiki.gnome.org/Apps/Photos"
 LICENSE="GPL-3+ LGPL-2+ CC0-1.0"
 SLOT="0"
 KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
-IUSE="test upnp-av"
+IUSE="test"
 RESTRICT="!test? ( test )"
 
 DEPEND="
@@ -36,11 +36,8 @@ DEPEND="
 "
 # >=dev-libs/libgdata-0.17.13:0=[gnome-online-accounts] # Upstream left this commented in meson.build. Probably comes back with the next version
 
-# but out of all the grilo-plugins, only upnp-av gets used, which has a USE flag here,
-# so don't pull it always, but only if USE flag is enabled.
 # tracker-miners gschema used at runtime.
 RDEPEND="${DEPEND}
-	upnp-av? ( >=media-plugins/grilo-plugins-0.3.16:0.3[upnp-av] )
 	app-misc/tracker-miners:3
 "
 BDEPEND="

--- a/media-gfx/gnome-photos/metadata.xml
+++ b/media-gfx/gnome-photos/metadata.xml
@@ -14,7 +14,6 @@
     You can:
     - Automatically find all your pictures
     - View recent local and online photos
-    - Access your Facebook or Flickr pictures
     - View photos on TVs, laptops or other DLNA renderers on your local network
     - Set pictures as your desktop background
     - Print photos


### PR DESCRIPTION
media-gfx/gnome-photos: remove media-plugins/grilo-plugins dependency

Upstream removed dependency on media-plugins/grilo-plugins since version 43.0

https://gitlab.gnome.org/GNOME/gnome-photos/-/commit/c6f66fc47d2d434c34dd84d446f081389015785b

Signed-off-by: Cristian Othón Martínez Vera <cfuga@cfuga.mx>
