### PR TITLE
dev-ruby/activejob: slot 7.0 add dev-ruby/zeitwerk test depend

### DIFF
--- a/dev-ruby/activejob/activejob-7.0.4.3-r1.ebuild
+++ b/dev-ruby/activejob/activejob-7.0.4.3-r1.ebuild
@@ -34,6 +34,7 @@ ruby_add_rdepend "
 ruby_add_bdepend "
 	test? (
 		dev-ruby/mocha
+		dev-ruby/zeitwerk
 	)"
 
 all_ruby_prepare() {

--- a/dev-ruby/activejob/activejob-7.0.4.3.ebuild
+++ b/dev-ruby/activejob/activejob-7.0.4.3.ebuild
@@ -34,6 +34,7 @@ ruby_add_rdepend "
 ruby_add_bdepend "
 	test? (
 		dev-ruby/mocha
+		dev-ruby/zeitwerk
 	)"
 
 all_ruby_prepare() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/904164