### PR TITLE
app-emulation/libvirt: Explicitly disable openwsman in configure

### DIFF
--- a/app-emulation/libvirt/libvirt-8.7.0-r1.ebuild
+++ b/app-emulation/libvirt/libvirt-8.7.0-r1.ebuild
@@ -272,6 +272,7 @@ src_configure() {
 
 		-Dnetcf=disabled
 		-Dsanlock=disabled
+		-Dopenwsman=disabled
 
 		-Ddriver_esx=enabled
 		-Dinit_script=systemd

--- a/app-emulation/libvirt/libvirt-8.8.0-r1.ebuild
+++ b/app-emulation/libvirt/libvirt-8.8.0-r1.ebuild
@@ -272,6 +272,7 @@ src_configure() {
 
 		-Dnetcf=disabled
 		-Dsanlock=disabled
+		-Dopenwsman=disabled
 
 		-Ddriver_esx=enabled
 		-Dinit_script=systemd

--- a/app-emulation/libvirt/libvirt-8.9.0-r2.ebuild
+++ b/app-emulation/libvirt/libvirt-8.9.0-r2.ebuild
@@ -279,6 +279,7 @@ src_configure() {
 
 		-Dnetcf=disabled
 		-Dsanlock=disabled
+		-Dopenwsman=disabled
 
 		-Ddriver_esx=enabled
 		-Dinit_script=systemd

--- a/app-emulation/libvirt/libvirt-8.9.0.ebuild
+++ b/app-emulation/libvirt/libvirt-8.9.0.ebuild
@@ -275,6 +275,7 @@ src_configure() {
 
 		-Dnetcf=disabled
 		-Dsanlock=disabled
+		-Dopenwsman=disabled
 
 		-Ddriver_esx=enabled
 		-Dinit_script=systemd

--- a/app-emulation/libvirt/libvirt-9999.ebuild
+++ b/app-emulation/libvirt/libvirt-9999.ebuild
@@ -278,6 +278,7 @@ src_configure() {
 
 		-Dnetcf=disabled
 		-Dsanlock=disabled
+		-Dopenwsman=disabled
 
 		-Ddriver_esx=enabled
 		-Dinit_script=systemd


### PR DESCRIPTION
Libvirt's configure script (well, meson.build file) is written so that it automatically enables features found on the build host, unless explicitly disabled on the cmd line. And one of such features is 'openwsman' [1], which isn't packaged in the portage, but if installed from an overlay, then `quickpkg` won't work.

Explicitly disable openwsman, until there's an official package (possibly not soon [2]).

1: https://openwsman.github.io/
2: https://bugs.gentoo.org/430312
Closes: https://bugs.gentoo.org/904082
Signed-off-by: Michal Privoznik <michal.privoznik@gmail.com>