### PR TITLE
app-editors/neovim: Dropping cmake-release-type patch from live ebuid

### DIFF
--- a/app-editors/neovim/neovim-9999.ebuild
+++ b/app-editors/neovim/neovim-9999.ebuild
@@ -71,7 +71,6 @@ BDEPEND+="
 PATCHES=(
 	"${FILESDIR}/${PN}-0.9.0-cmake_lua_version.patch"
 	"${FILESDIR}/${PN}-0.9.0-cmake-darwin.patch"
-	"${FILESDIR}/${PN}-0.9.0-cmake-release-type.patch"
 )
 
 src_prepare() {


### PR DESCRIPTION
With upstream commit f4136c9d42f79c0f2fe3ce6fdc22b1544593692a, there is no requirement to apply this patch.