### PR TITLE
make twisted optional

### DIFF
--- a/dev-python/prometheus_client/prometheus_client-0.16.0.ebuild
+++ b/dev-python/prometheus_client/prometheus_client-0.16.0.ebuild
@@ -22,9 +22,12 @@ S="${WORKDIR}/client_python-${PV}"
 LICENSE="Apache-2.0"
 SLOT="0"
 KEYWORDS="amd64 arm arm64 hppa ~ia64 ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86"
+IUSE="-twisted"
 
 RDEPEND="
-	dev-python/twisted[${PYTHON_USEDEP}]
+	twisted? (
+		dev-python/twisted[${PYTHON_USEDEP}]
+	)
 "
 
 distutils_enable_tests pytest

--- a/dev-python/prometheus_client/prometheus_client-0.16.0.ebuild
+++ b/dev-python/prometheus_client/prometheus_client-0.16.0.ebuild
@@ -22,7 +22,7 @@ S="${WORKDIR}/client_python-${PV}"
 LICENSE="Apache-2.0"
 SLOT="0"
 KEYWORDS="amd64 arm arm64 hppa ~ia64 ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86"
-IUSE="-twisted"
+IUSE="twisted"
 
 RDEPEND="
 	twisted? (


### PR DESCRIPTION
twisted is marked as optional in `client_python` `setup.py` 

https://github.com/prometheus/client_python/blob/8bbd16f34014d9b28fa53068eb2a1f87c45d34fc/setup.py#L29-L31