### PR TITLE
dev-util/cppcheck: use subslotted dependency

### DIFF
--- a/dev-util/cppcheck/cppcheck-2.6.3.ebuild
+++ b/dev-util/cppcheck/cppcheck-2.6.3.ebuild
@@ -30,7 +30,7 @@ RDEPEND="
 		dev-qt/qthelp
 		dev-qt/qtprintsupport:5
 	)
-	z3? ( sci-mathematics/z3 )
+	z3? ( sci-mathematics/z3:= )
 "
 DEPEND="${RDEPEND}"
 BDEPEND="

--- a/dev-util/cppcheck/metadata.xml
+++ b/dev-util/cppcheck/metadata.xml
@@ -12,6 +12,7 @@
 		</flag>
 	</use>
 	<upstream>
+		<remote-id type="github">danmar/cppcheck</remote-id>
 		<remote-id type="sourceforge">cppcheck</remote-id>
 	</upstream>
 </pkgmetadata>


### PR DESCRIPTION
Changed to sci-mathematics/z3:= due ABI changes.
Added `<remote-id type="github">` to metadata.xml.