### PR TITLE
app-editors/neovim: Dropping tui USE flag

### DIFF
--- a/app-editors/neovim/neovim-0.9.0-r1.ebuild
+++ b/app-editors/neovim/neovim-0.9.0-r1.ebuild
@@ -21,7 +21,7 @@ fi
 
 LICENSE="Apache-2.0 vim"
 SLOT="0"
-IUSE="+lto +nvimpager test +tui"
+IUSE="+lto +nvimpager test"
 
 REQUIRED_USE="${LUA_REQUIRED_USE}"
 # Upstream say the test library needs LuaJIT
@@ -53,10 +53,8 @@ DEPEND="${LUA_DEPS}
 	>=dev-libs/libvterm-0.3
 	>=dev-libs/msgpack-3.0.0:=
 	>=dev-libs/tree-sitter-0.20.8:=
-	tui? (
-		>=dev-libs/libtermkey-0.22
-		>=dev-libs/unibilium-2.0.0:0=
-	)
+	>=dev-libs/libtermkey-0.22
+	>=dev-libs/unibilium-2.0.0:0=
 "
 RDEPEND="
 	${DEPEND}

--- a/app-editors/neovim/neovim-9999.ebuild
+++ b/app-editors/neovim/neovim-9999.ebuild
@@ -21,7 +21,7 @@ fi
 
 LICENSE="Apache-2.0 vim"
 SLOT="0"
-IUSE="+lto +nvimpager test +tui"
+IUSE="+lto +nvimpager test"
 
 REQUIRED_USE="${LUA_REQUIRED_USE}"
 # Upstream say the test library needs LuaJIT
@@ -53,10 +53,8 @@ DEPEND="${LUA_DEPS}
 	>=dev-libs/libvterm-0.3
 	>=dev-libs/msgpack-3.0.0:=
 	>=dev-libs/tree-sitter-0.20.8:=
-	tui? (
-		>=dev-libs/libtermkey-0.22
-		>=dev-libs/unibilium-2.0.0:0=
-	)
+	>=dev-libs/libtermkey-0.22
+	>=dev-libs/unibilium-2.0.0:0=
 "
 RDEPEND="
 	${DEPEND}


### PR DESCRIPTION
Upstream removed FEAT_TUI hence no requirement for this USE flag as it was being used to enable or disable this feature.

Closes: https://bugs.gentoo.org/904278