### PR TITLE
sys-libs/glibc: Always keepdir /lib and /usr/lib

### DIFF
--- a/sys-libs/glibc/glibc-9999.ebuild
+++ b/sys-libs/glibc/glibc-9999.ebuild
@@ -1433,19 +1433,19 @@ glibc_do_src_install() {
 		find "${ED}" -name pt_chown -exec chmod -s {} +
 	fi
 
+	# We need to make sure that /lib and /usr/lib always exists.
+	# gcc likes to use relative paths to get to its multilibs like
+	# /usr/lib/../lib64/.  So while we don't install any files into
+	# /usr/lib/, we do need it to exist.
+	keepdir $(alt_prefix)/lib
+	keepdir $(alt_prefix)/usr/lib
+
 	#################################################################
 	# EVERYTHING AFTER THIS POINT IS FOR NATIVE GLIBC INSTALLS ONLY #
 	# Make sure we install some symlink hacks so that when we build
 	# a 2nd stage cross-compiler, gcc finds the target system
 	# headers correctly.  See gcc/doc/gccinstall.info
 	if is_crosscompile ; then
-		# We need to make sure that /lib and /usr/lib always exists.
-		# gcc likes to use relative paths to get to its multilibs like
-		# /usr/lib/../lib64/.  So while we don't install any files into
-		# /usr/lib/, we do need it to exist.
-		keepdir $(alt_prefix)/lib
-		keepdir $(alt_prefix)/usr/lib
-
 		dosym usr/include $(alt_prefix)/sys-include
 		return 0
 	fi


### PR DESCRIPTION
When cross compiling a new ROOT, i.e.,
    ROOT=/build/amd64-generic emerge glibc

The $ROOT/lib and $ROOT/usr/lib directories are not getting created.
This results in linker errors when compiling certain packages in the
new ROOT.

A good invocation looks like this:
    x86_64-cros-linux-gnu-clang -Wl,--verbose -o mains/mosys ...
    ld.lld: /build/amd64-generic/lib/../lib64/libminijail.so

An invocation lacking the $ROOT/lib directory:
    ld.lld: error: unable to find library -lminijail
