### PR TITLE
app-arch/p7zip: fix natspec patch

### DIFF
--- a/app-arch/p7zip/files/p7zip-17.05-natspec.patch
+++ b/app-arch/p7zip/files/p7zip-17.05-natspec.patch
@@ -115,16 +115,3 @@ index 353e895..44071f3 100644
    if (isUtf8)
      if (ConvertUTF8ToUnicode(s, res) || ignore_Utf8_Errors)
        return;
-diff --git a/makefile.machine b/makefile.machine
-index a89b568..3e12592 100644
---- a/makefile.machine
-+++ b/makefile.machine
-@@ -16,7 +16,7 @@ CC=gcc
- CC_SHARED=-fPIC
- LINK_SHARED=-fPIC -shared
- 
--LOCAL_LIBS=-lpthread
-+LOCAL_LIBS=-lpthread -lnatspec
- LOCAL_LIBS_DLL=$(LOCAL_LIBS) -ldl
- 
- OBJ_CRC32=$(OBJ_CRC32_C)

--- a/app-arch/p7zip/p7zip-17.05-r1.ebuild
+++ b/app-arch/p7zip/p7zip-17.05-r1.ebuild
@@ -25,7 +25,10 @@ BDEPEND="
 src_prepare() {
 	default
 
-	use natspec && eapply "${FILESDIR}"/${P}-natspec.patch
+	if use natspec; then
+		eapply "${FILESDIR}"/${P}-natspec.patch
+		sed -i '/^LOCAL_LIBS/s/$/ -lnatspec/' makefile.* || die
+	fi
 
 	if ! use pch; then
 		sed "s:PRE_COMPILED_HEADER=StdAfx.h.gch:PRE_COMPILED_HEADER=:g" -i makefile.* || die


### PR DESCRIPTION
due to how we handle makefiles need to drop that part from patch and update the makefiles directly in ebuild. fixes build with natspec.

Closes: https://bugs.gentoo.org/904332