### PR TITLE
sys-cluster/lmod: add sys-devel/bc as build dependency

### DIFF
--- a/sys-cluster/lmod/lmod-8.7.23.ebuild
+++ b/sys-cluster/lmod/lmod-8.7.23.ebuild
@@ -37,6 +37,7 @@ RDEPEND="${LUA_DEPS}
 "
 DEPEND="${RDEPEND}"
 BDEPEND="${RDEPEND}
+	sys-devel/bc
 	test? (
 		$(lua_gen_cond_dep '
 			dev-util/hermes[${LUA_SINGLE_USEDEP}]


### PR DESCRIPTION
While installing Lmod (in a Prefix environment), I got the following errors for the compilation step:
```
>>> Compiling source in /tmp/gentoo/var/tmp/portage/sys-cluster/lmod-8.7.23/work/Lmod-8.7.23 ...
make -j16 
./proj_mgmt/convert_mode.sh: line 27: bc: command not found
./proj_mgmt/convert_mode.sh: line 33: bc: command not found
./proj_mgmt/convert_mode.sh: line 27: bc: command not found
./proj_mgmt/convert_mode.sh: line 33: bc: command not found
done
>>> Source compiled.
```
and a similar bunch of errors for the installation step:
```
>>> Install sys-cluster/lmod-8.7.23 into /tmp/gentoo/var/tmp/portage/sys-cluster/lmod-8.7.23/image
make -j16 DESTDIR=/tmp/gentoo/var/tmp/portage/sys-cluster/lmod-8.7.23/image install 
./proj_mgmt/convert_mode.sh: line 27: bc: command not found
./proj_mgmt/convert_mode.sh: line 33: bc: command not found
./proj_mgmt/convert_mode.sh: line 27: bc: command not found
./proj_mgmt/convert_mode.sh: line 33: bc: command not found
install -m 0 -d /tmp/gentoo/var/tmp/portage/sys-cluster/lmod-8.7.23/image/tmp/gentoo/usr/share/Lmod/libexec
install -m 0 -d /tmp/gentoo/var/tmp/portage/sys-cluster/lmod-8.7.23/image/tmp/gentoo/usr/share/Lmod/tools
install -m 0 -d /tmp/gentoo/var/tmp/portage/sys-cluster/lmod-8.7.23/image/tmp/gentoo/usr/share/Lmod/settarg
install -m 0 -d /tmp/gentoo/var/tmp/portage/sys-cluster/lmod-8.7.23/image/tmp/gentoo/usr/share/Lmod/shells
install -m 0 -d /tmp/gentoo/var/tmp/portage/sys-cluster/lmod-8.7.23/image/tmp/gentoo/usr/share/Lmod/init
install -m 0 -d /tmp/gentoo/var/tmp/portage/sys-cluster/lmod-8.7.23/image/tmp/gentoo/usr/share/Lmod/lib
install -m 0 -d /tmp/gentoo/var/tmp/portage/sys-cluster/lmod-8.7.23/image/tmp/gentoo/usr/share/Lmod/modulefiles/Core
install -m 0 -d /tmp/gentoo/var/tmp/portage/sys-cluster/lmod-8.7.23/image/tmp/gentoo/usr/share/Lmod/share/man/cat1
install -m 0 -d /tmp/gentoo/var/tmp/portage/sys-cluster/lmod-8.7.23/image/tmp/gentoo/usr/share/Lmod/messageDir
make: stat: /tmp/gentoo/var/tmp/portage/sys-cluster/lmod-8.7.23/image/tmp/gentoo/usr/share/Lmod/tools/i18n: Permission denied
install -m 0 -d /tmp/gentoo/var/tmp/portage/sys-cluster/lmod-8.7.23/image/tmp/gentoo/usr/share/Lmod/tools/i18n
make: stat: /tmp/gentoo/var/tmp/portage/sys-cluster/lmod-8.7.23/image/tmp/gentoo/usr/share/Lmod/init/fish_tab_completion: Permission denied
install -m 0 -d /tmp/gentoo/var/tmp/portage/sys-cluster/lmod-8.7.23/image/tmp/gentoo/usr/share/Lmod/init/fish_tab_completion
make: stat: /tmp/gentoo/var/tmp/portage/sys-cluster/lmod-8.7.23/image/tmp/gentoo/usr/share/Lmod/init/ksh_funcs: Permission denied
install -m 0 -d /tmp/gentoo/var/tmp/portage/sys-cluster/lmod-8.7.23/image/tmp/gentoo/usr/share/Lmod/init/ksh_funcs
install: cannot create directory ‘/tmp/gentoo/var/tmp/portage/sys-cluster/lmod-8.7.23/image/tmp/gentoo/usr/share/Lmod/tools’: Permission denied
install: cannot create directory ‘/tmp/gentoo/var/tmp/portage/sys-cluster/lmod-8.7.23/image/tmp/gentoo/usr/share/Lmod/init’: Permission denied
make: *** [makefile:248: /tmp/gentoo/var/tmp/portage/sys-cluster/lmod-8.7.23/image/tmp/gentoo/usr/share/Lmod/tools/i18n] Error 1
make: *** Waiting for unfinished jobs....
make: *** [makefile:248: /tmp/gentoo/var/tmp/portage/sys-cluster/lmod-8.7.23/image/tmp/gentoo/usr/share/Lmod/init/fish_tab_completion] Error 1
install: cannot create directory ‘/tmp/gentoo/var/tmp/portage/sys-cluster/lmod-8.7.23/image/tmp/gentoo/usr/share/Lmod/init’: Permission denied
make: *** [makefile:248: /tmp/gentoo/var/tmp/portage/sys-cluster/lmod-8.7.23/image/tmp/gentoo/usr/share/Lmod/init/ksh_funcs] Error 1
 * ERROR: sys-cluster/lmod-8.7.23::gentoo failed (install phase):
 *   emake failed
 * 
 * If you need support, post the output of `emerge --info '=sys-cluster/lmod-8.7.23::gentoo'`,
 * the complete build log and the output of `emerge -pqv '=sys-cluster/lmod-8.7.23::gentoo'`.
 * The complete build log is located at '/tmp/gentoo/var/tmp/portage/sys-cluster/lmod-8.7.23/temp/build.log'.
 * The ebuild environment file is located at '/tmp/gentoo/var/tmp/portage/sys-cluster/lmod-8.7.23/temp/environment'.
 * Working directory: '/tmp/gentoo/var/tmp/portage/sys-cluster/lmod-8.7.23/work/Lmod-8.7.23'
 * S: '/tmp/gentoo/var/tmp/portage/sys-cluster/lmod-8.7.23/work/Lmod-8.7.23'
 * QA Notice: command not found:
 * 
 * 	./proj_mgmt/convert_mode.sh: line 27: bc: command not found
 * 	./proj_mgmt/convert_mode.sh: line 33: bc: command not found
 * 	./proj_mgmt/convert_mode.sh: line 27: bc: command not found
 * 	./proj_mgmt/convert_mode.sh: line 33: bc: command not found
 * 	./proj_mgmt/convert_mode.sh: line 27: bc: command not found
 * 	./proj_mgmt/convert_mode.sh: line 33: bc: command not found
 * 	./proj_mgmt/convert_mode.sh: line 27: bc: command not found
 * 	./proj_mgmt/convert_mode.sh: line 33: bc: command not found
```

See https://github.com/TACC/Lmod/blob/8.7.23/proj_mgmt/convert_mode.sh#L27 and https://github.com/TACC/Lmod/blob/8.7.23/proj_mgmt/convert_mode.sh#L33.