### PR TITLE
dev-util/patchelf: Add define for DT_MIPS_XHASH

### DIFF
--- a/dev-util/patchelf/files/patchelf-glibc-dt-mips-xhash.patch
+++ b/dev-util/patchelf/files/patchelf-glibc-dt-mips-xhash.patch
@@ -1,0 +1,9 @@
+Add define for DT_MIPS_XHASH (MIPS gnu hash support) using system elf.h header.
+Bug: https://bugs.gentoo.org/860888
+--- /dev/null
++++ b/src/elf.h
+@@ -0,0 +1,4 @@
++#include_next <elf.h>
++#ifndef DT_MIPS_XHASH
++#define DT_MIPS_XHASH 0x70000036
++#endif

--- a/dev-util/patchelf/patchelf-0.18.0-r1.ebuild
+++ b/dev-util/patchelf/patchelf-0.18.0-r1.ebuild
@@ -12,9 +12,13 @@ SLOT="0"
 KEYWORDS="~amd64 ~arm ~arm64 ~ia64 ~loong ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~riscv-linux ~x86-linux"
 LICENSE="GPL-3"
 
+PATCHES=(
+	"${FILESDIR}"/${PN}-glibc-dt-mips-xhash.patch
+)
+
 src_prepare() {
-	default
 	rm src/elf.h || die
+	default
 
 	sed -i \
 		-e 's:-Werror::g' \


### PR DESCRIPTION
dev-util/patchelf: Add define for DT_MIPS_XHASH

For musl libc the bundled `elf.h` header file is replaced with `DT_MIPS_XHASH` define using regex
(alternative approach to https://bugs.gentoo.org/860888#c14 which patches the if branch directly).

Closes: https://bugs.gentoo.org/860888