### PR TITLE
www-servers/tomcat: DEPEND on jax-rpc-api

### DIFF
--- a/www-servers/tomcat/tomcat-10.1.7.ebuild
+++ b/www-servers/tomcat/tomcat-10.1.7.ebuild
@@ -32,7 +32,6 @@ RESTRICT="test" # can we run them on a production system?
 ECJ_SLOT="4.26"
 
 COMMON_DEP="dev-java/eclipse-ecj:${ECJ_SLOT}
-	dev-java/jax-rpc-api:0
 	>=dev-java/jakartaee-migration-1.0.5:0
 	dev-java/wsdl4j:0"
 RDEPEND="${COMMON_DEP}
@@ -42,6 +41,7 @@ RDEPEND="${COMMON_DEP}
 DEPEND="${COMMON_DEP}
 	app-admin/pwgen
 	dev-java/ant-core
+	dev-java/jax-rpc-api:0
 	>=virtual/jdk-11:*
 	test? (
 		dev-java/ant-junit:0

--- a/www-servers/tomcat/tomcat-9.0.73.ebuild
+++ b/www-servers/tomcat/tomcat-9.0.73.ebuild
@@ -35,7 +35,6 @@ RESTRICT="test" # can we run them on a production system?
 ECJ_SLOT="4.15"
 
 COMMON_DEP="dev-java/eclipse-ecj:${ECJ_SLOT}
-	dev-java/jax-rpc-api:0
 	dev-java/wsdl4j:0"
 RDEPEND="${COMMON_DEP}
 	acct-group/tomcat
@@ -44,6 +43,7 @@ RDEPEND="${COMMON_DEP}
 DEPEND="${COMMON_DEP}
 	app-admin/pwgen
 	>=dev-java/ant-core-1.9.13
+	dev-java/jax-rpc-api:0
 	>=virtual/jdk-1.8:*
 	test? (
 		>=dev-java/ant-junit-1.9:0


### PR DESCRIPTION
Moving jax-rpc-api from COMMON_DEP to DEPEND because looking at its classpath assignment it seems misplaced.