### PR TITLE
app-misc/linuxspa: EAPI8 bump

### DIFF
--- a/app-misc/linuxspa/linuxspa-0.7.1-r3.ebuild
+++ b/app-misc/linuxspa/linuxspa-0.7.1-r3.ebuild
@@ -1,0 +1,38 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs
+
+MY_PN="LinuxSPA"
+DESCRIPTION="Linux Serial Protocol Analyser"
+HOMEPAGE="https://sourceforge.net/projects/serialsniffer/"
+SRC_URI="mirror://sourceforge/serialsniffer/${MY_PN}-${PV}.tgz"
+S="${WORKDIR}/${MY_PN}"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+PATCHES=( "${FILESDIR}/${P}-compile-fix.patch" )
+
+src_prepare() {
+	default
+	sed -i Makefile \
+		-e 's| -o | $(LDFLAGS)&|g' \
+		|| die "sed Makefile"
+}
+
+src_compile() {
+	emake \
+		CC="$(tc-getCC)" \
+		CFLAGS="${CFLAGS} -Wall" \
+		LDFLAGS="${LDFLAGS}"
+}
+
+src_install() {
+	dobin LinuxSPA std232
+	dodoc ASCII_Filter.txt BCircuit.txt LinuxSPA.png READING_Materials.txt \
+		README TODO connector-1a.ps connector-2a.ps cooked.file raw.file
+}


### PR DESCRIPTION
Simple EAPI8 bump, changes are as followed:

```diff
--- linuxspa-0.7.1-r2.ebuild	2023-04-16 17:15:01.164902437 +0200
+++ linuxspa-0.7.1-r3.ebuild	2023-04-16 17:15:29.047622181 +0200
@@ -1,7 +1,7 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
 
 inherit toolchain-funcs
 
@@ -9,13 +9,11 @@
 DESCRIPTION="Linux Serial Protocol Analyser"
 HOMEPAGE="https://sourceforge.net/projects/serialsniffer/"
 SRC_URI="mirror://sourceforge/serialsniffer/${MY_PN}-${PV}.tgz"
-LICENSE="GPL-2"
+S="${WORKDIR}/${MY_PN}"
 
+LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~amd64 x86"
-IUSE=""
-
-S="${WORKDIR}/${MY_PN}"
+KEYWORDS="~amd64 ~x86"
 
 PATCHES=( "${FILESDIR}/${P}-compile-fix.patch" )
 
```