### PR TITLE
app-office/libreoffice: Don't require X for dbus

### DIFF
--- a/app-office/libreoffice/libreoffice-7.4.9999.ebuild
+++ b/app-office/libreoffice/libreoffice-7.4.9999.ebuild
@@ -181,7 +181,7 @@ COMMON_DEPEND="${PYTHON_DEPS}
 	)
 	coinmp? ( sci-libs/coinor-mp )
 	cups? ( net-print/cups )
-	dbus? ( sys-apps/dbus[X] )
+	dbus? ( sys-apps/dbus )
 	eds? (
 		dev-libs/glib:2
 		gnome-base/dconf

--- a/app-office/libreoffice/libreoffice-7.5.9999.ebuild
+++ b/app-office/libreoffice/libreoffice-7.5.9999.ebuild
@@ -180,7 +180,7 @@ COMMON_DEPEND="${PYTHON_DEPS}
 	)
 	coinmp? ( sci-libs/coinor-mp )
 	cups? ( net-print/cups )
-	dbus? ( sys-apps/dbus[X] )
+	dbus? ( sys-apps/dbus )
 	eds? (
 		dev-libs/glib:2
 		gnome-base/dconf

--- a/app-office/libreoffice/libreoffice-9999.ebuild
+++ b/app-office/libreoffice/libreoffice-9999.ebuild
@@ -179,7 +179,7 @@ COMMON_DEPEND="${PYTHON_DEPS}
 	)
 	coinmp? ( sci-libs/coinor-mp )
 	cups? ( net-print/cups )
-	dbus? ( sys-apps/dbus[X] )
+	dbus? ( sys-apps/dbus )
 	eds? (
 		dev-libs/glib:2
 		gnome-base/dconf


### PR DESCRIPTION
I've tested three scenarios where the menu bar was always present and I didn't observe any issues.

* libreoffice: `USE='gtk -dbus'` dbus: `USE=X`
* libreoffice: `USE='gtk -dbus'` dbus: `USE=-X`
* libreoffice: `USE='gtk dbus'` dbus: `USE=-X`


Bug: https://bugs.gentoo.org/726446