### PR TITLE
app-arch/dump: fix incompatible pointer to integer conversion

### DIFF
--- a/app-arch/dump/dump-0.4.47-r3.ebuild
+++ b/app-arch/dump/dump-0.4.47-r3.ebuild
@@ -1,0 +1,100 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit readme.gentoo-r1
+
+MY_P="${PN}-$(ver_rs 2 b)"
+
+DESCRIPTION="Dump/restore ext2fs backup utilities"
+HOMEPAGE="https://dump.sourceforge.io/"
+SRC_URI="mirror://sourceforge/dump/${MY_P}.tar.gz"
+S="${WORKDIR}/${MY_P}"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+# We keep uuid USE flag default dsiabled for this version. Don't forget
+# to default enable it for later versions as this is the upstream default.
+IUSE="bzip2 debug ermt lzo readline selinux sqlite ssl static test uuid zlib"
+RESTRICT="!test? ( test )"
+REQUIRED_USE="
+	ermt? ( ssl )
+	ssl? ( zlib )
+	test? ( sqlite? ( uuid ) )"
+
+RDEPEND="
+	>=sys-fs/e2fsprogs-1.27:=
+	sys-apps/util-linux
+	bzip2? (
+		app-arch/bzip2:=
+		static? ( app-arch/bzip2[static-libs] )
+	)
+	zlib? ( >=sys-libs/zlib-1.1.4:= )
+	lzo? (
+		dev-libs/lzo:2=
+		static? ( dev-libs/lzo:2[static-libs] )
+	)
+	sqlite? ( dev-db/sqlite:3= )
+	ermt? ( dev-libs/openssl:0= )
+	ssl? ( dev-libs/openssl:0= )
+	readline? (
+		sys-libs/readline:0=
+		sys-libs/ncurses:=
+		static? ( sys-libs/ncurses:=[static-libs] )
+	)"
+DEPEND="${RDEPEND}
+	virtual/os-headers"
+BDEPEND="virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-fix-incompatible-pointer-to-integer-conversion.patch
+)
+
+src_configure() {
+	local myeconfargs=(
+		--with-dumpdatespath=/etc/dumpdates
+		--with-rmtpath='$(sbindir)/rmt'
+		--enable-blkid
+		$(use_enable bzip2)
+		$(use_enable debug)
+		$(use_enable ermt)
+		$(use_enable lzo)
+		$(use_enable readline)
+		$(use_enable selinux)
+		$(use_enable sqlite)
+		$(use_enable ssl)
+		$(use_enable static static-progs)
+		$(use_enable uuid)
+		$(use_enable zlib)
+	)
+	econf "${myeconfargs[@]}"
+}
+
+src_install() {
+	default
+
+	mv "${ED}"/usr/sbin/{,dump-}rmt || die
+	mv "${ED}"/usr/share/man/man8/{,dump-}rmt.8 || die
+	use ermt && newsbin rmt/ermt dump-ermt
+
+	dodoc KNOWNBUGS MAINTAINERS REPORTING-BUGS
+	dodoc -r examples
+
+	# Don't install pre-compressed files
+	gunzip "${ED}"/usr/share/doc/${PF}/examples/cron_dump_to_disk/backupskel.tar.gz \
+		|| die
+
+	local DOC_CONTENTS="dump has serious bugs
+	(see https://sourceforge.net/p/dump/bugs/162/ and
+	https://sourceforge.net/p/dump/bugs/174/). This tool should only
+	be used for restoring old backups, not for creating new ones.
+	\n\n${CATEGORY}/${PN} installs 'rmt' as 'dump-rmt'.
+	This is to avoid conflicts with app-arch/tar 'rmt'."
+	readme.gentoo_create_doc
+}
+
+pkg_postinst() {
+	readme.gentoo_print_elog
+}

--- a/app-arch/dump/files/dump-fix-incompatible-pointer-to-integer-conversion.patch
+++ b/app-arch/dump/files/dump-fix-incompatible-pointer-to-integer-conversion.patch
@@ -1,0 +1,25 @@
+From: listout <listout@protonmail.com>
+Date: Mon, 17 Apr 2023 12:36:40 +0530
+Subject: [PATCH] Fix incompatible pointer to integer conversion
+
+transformation_null was initializing one of it's elements with NULL
+which is zero type casted to void. Hence, instead of initializing with
+NULL, now we are initializing that element with zero.
+
+Refer: https://bugs.gentoo.org/874675
+
+Signed-off-by: listout <listout@protonmail.com>
+--- a/common/transformation_null.c
++++ b/common/transformation_null.c
+@@ -81,7 +81,7 @@ null_decompress(Transformation *xform, struct tapebuf *tpbin, unsigned long *des
+ Transformation transformation_null =
+ {
+ 	0,
+-	NULL,
++	0,
+ 	"null",
+ 	0,
+ 	&null_initialize,
+--
+2.39.2
+


### PR DESCRIPTION
transformation_null was initializing one of it's elements with NULL which is zero type casted to void. Hence, instead of initializing with NULL, now we are initializing that element with zero.

Closes: https://bugs.gentoo.org/874675