### PR TITLE
app-editors/vscode: remove additional elog messages

### DIFF
--- a/app-editors/vscode/vscode-1.76.2.ebuild
+++ b/app-editors/vscode/vscode-1.76.2.ebuild
@@ -122,7 +122,5 @@ src_install() {
 
 pkg_postinst() {
 	xdg_pkg_postinst
-	elog "You may want to install some additional utils, check in:"
-	elog "https://code.visualstudio.com/Docs/setup#_additional-tools"
 	optfeature "keyring support inside vscode" "gnome-base/gnome-keyring"
 }

--- a/app-editors/vscode/vscode-1.77.0.ebuild
+++ b/app-editors/vscode/vscode-1.77.0.ebuild
@@ -122,7 +122,5 @@ src_install() {
 
 pkg_postinst() {
 	xdg_pkg_postinst
-	elog "You may want to install some additional utils, check in:"
-	elog "https://code.visualstudio.com/Docs/setup#_additional-tools"
 	optfeature "keyring support inside vscode" "gnome-base/gnome-keyring"
 }

--- a/app-editors/vscode/vscode-1.77.1.ebuild
+++ b/app-editors/vscode/vscode-1.77.1.ebuild
@@ -122,7 +122,5 @@ src_install() {
 
 pkg_postinst() {
 	xdg_pkg_postinst
-	elog "You may want to install some additional utils, check in:"
-	elog "https://code.visualstudio.com/Docs/setup#_additional-tools"
 	optfeature "keyring support inside vscode" "gnome-base/gnome-keyring"
 }


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/904393