### PR TITLE
dev-qt/qtbase: add missing dep xcb-util-cursor

### DIFF
--- a/dev-qt/qtbase/qtbase-6.5.0.ebuild
+++ b/dev-qt/qtbase/qtbase-6.5.0.ebuild
@@ -97,6 +97,7 @@ DEPEND="
 		x11-libs/xcb-util-keysyms
 		x11-libs/xcb-util-renderutil
 		x11-libs/xcb-util-wm
+		x11-libs/xcb-util-cursor
 	)
 	zstd? ( app-arch/zstd:= )
 "


### PR DESCRIPTION
fix for error 
```bash
CMake Error at cmake/QtTargetHelpers.cmake:146 (target_link_libraries):
  Target "XcbQpaPrivate" links to:

    XCB::CURSOR

  but the target was not found.
```