### PR TITLE
app-misc/g810-led: Fix for GCC 13

### DIFF
--- a/app-misc/g810-led/files/g810-led-0.4.2_gcc13.patch
+++ b/app-misc/g810-led/files/g810-led-0.4.2_gcc13.patch
@@ -1,0 +1,21 @@
+From 0ca17e2ba8c8f01e51a360903a2009186ff78a1c Mon Sep 17 00:00:00 2001
+From: Olav Reinert <seroton10@gmail.com>
+Date: Sun, 26 Mar 2023 13:48:10 +0200
+Subject: [PATCH] fix: compilation error with GCC 13
+
+---
+ src/helpers/help.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/helpers/help.h b/src/helpers/help.h
+index 1d176f0..b7d02fd 100644
+--- a/src/helpers/help.h
++++ b/src/helpers/help.h
+@@ -18,6 +18,7 @@
+ #define HELP_HELPER
+ 
+ #include <iostream>
++#include <cstdint>
+ 
+ namespace help {
+ 	

--- a/app-misc/g810-led/g810-led-0.4.2.ebuild
+++ b/app-misc/g810-led/g810-led-0.4.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2018-2021 Gentoo Authors
+# Copyright 2018-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -21,6 +21,10 @@ RDEPEND="
 DEPEND="${RDEPEND}"
 
 DOCS=("README.md" "sample_profiles" "sample_effects")
+
+# Fix for GCC 13; Bug #895426
+# See https://github.com/MatMoul/g810-led/pull/302
+PATCHES=( "${FILESDIR}/g810-led-0.4.2_gcc13.patch" )
 
 src_prepare() {
 	default


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/895426
Signed-off-by: Haelwenn (lanodan) Monnier <contact@hacktivis.me>
