### PR TITLE
media-gfx/flameshot: depend on kde-frameworks/kguiaddons:5

### DIFF
--- a/media-gfx/flameshot/flameshot-12.0.0-r2.ebuild
+++ b/media-gfx/flameshot/flameshot-12.0.0-r2.ebuild
@@ -23,7 +23,7 @@ DEPEND="
 	dev-qt/qtsvg:5
 	dev-qt/qtwidgets:5
 	sys-apps/dbus
-	wayland? ( kde-frameworks/kguiaddons )
+	wayland? ( kde-frameworks/kguiaddons:5 )
 "
 BDEPEND="
 	dev-qt/linguist-tools:5

--- a/media-gfx/flameshot/flameshot-12.1.0-r2.ebuild
+++ b/media-gfx/flameshot/flameshot-12.1.0-r2.ebuild
@@ -23,7 +23,7 @@ DEPEND="
 	dev-qt/qtsvg:5
 	dev-qt/qtwidgets:5
 	sys-apps/dbus
-	wayland? ( kde-frameworks/kguiaddons )
+	wayland? ( kde-frameworks/kguiaddons:5 )
 "
 BDEPEND="
 	dev-qt/linguist-tools:5


### PR DESCRIPTION
Depend on kde-frameworks/kguiaddons:5 or otherwise this will fail right again once kguiaddons:6 comes around.

Bug: https://bugs.gentoo.org/904266