### PR TITLE
distutils-r1.eclass: DISTUTILS_EXT support

### DIFF
--- a/eclass/distutils-r1.eclass
+++ b/eclass/distutils-r1.eclass
@@ -49,6 +49,13 @@ case ${EAPI} in
 	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
 
+# @ECLASS_VARIABLE: DISTUTILS_EXT
+# @DEFAULT_UNSET
+# @DESCRIPTION:
+# Set this variable to a non-null value if the package (possibly
+# optionally) builds Python extensions (loadable modules written in C,
+# Cython, Rust, etc.).
+
 # @ECLASS_VARIABLE: DISTUTILS_OPTIONAL
 # @DEFAULT_UNSET
 # @DESCRIPTION:

--- a/eclass/distutils-r1.eclass
+++ b/eclass/distutils-r1.eclass
@@ -2069,6 +2069,16 @@ _distutils-r1_post_python_install() {
 			eerror "https://projects.gentoo.org/python/guide/qawarn.html#stray-top-level-files-in-site-packages"
 			die "Failing install because of stray top-level files in site-packages"
 		fi
+
+		if [[ ! ${DISTUTILS_EXT} && ! ${_DISTUTILS_EXT_WARNED} ]]; then
+			if [[ $(find "${sitedir}" -name "*$(get_modname)" | head -n 1) ]]
+			then
+				eqawarn "Python extension modules (*$(get_modname)) found installed. Please set:"
+				eqawarn "  DISTUTILS_EXT=1"
+				eqawarn "in the ebuild."
+				_DISTUTILS_EXT_WARNED=1
+			fi
+		fi
 	fi
 }
 

--- a/eclass/distutils-r1.eclass
+++ b/eclass/distutils-r1.eclass
@@ -62,6 +62,9 @@ esac
 #   DISTUTILS_OPTIONAL is used
 #
 # - adds debug flag to IUSE that controls assertions (i.e. -DNDEBUG)
+#
+# - calls `build_ext` command if setuptools build backend is used
+#   and there is potential benefit from parallel builds
 
 # @ECLASS_VARIABLE: DISTUTILS_OPTIONAL
 # @DEFAULT_UNSET
@@ -1452,12 +1455,14 @@ distutils-r1_python_compile() {
 				# .pyx is added for Cython
 				#
 				# esetup.py does not respect SYSROOT, so skip it there
-				if [[ -z ${SYSROOT} && 1 -ne ${jobs} && 2 -eq $(
-					find '(' -name '*.c' -o -name '*.cc' -o -name '*.cpp' \
-						-o -name '*.cxx' -o -name '*.c++' -o -name '*.m' \
-						-o -name '*.mm' -o -name '*.pyx' ')' -printf '\n' |
-						head -n 2 | wc -l
-				) ]]; then
+				if [[ -z ${SYSROOT} && ${DISTUTILS_EXT} && 1 -ne ${jobs}
+					&& 2 -eq $(
+						find '(' -name '*.c' -o -name '*.cc' -o -name '*.cpp' \
+							-o -name '*.cxx' -o -name '*.c++' -o -name '*.m' \
+							-o -name '*.mm' -o -name '*.pyx' ')' -printf '\n' |
+							head -n 2 | wc -l
+					)
+				]]; then
 					esetup.py build_ext -j "${jobs}" "${@}"
 				fi
 			else

--- a/eclass/distutils-r1.eclass
+++ b/eclass/distutils-r1.eclass
@@ -60,6 +60,8 @@ esac
 #
 # - adds PYTHON_DEPS to DEPEND (for cross-compilation support), unless
 #   DISTUTILS_OPTIONAL is used
+#
+# - adds debug flag to IUSE that controls assertions (i.e. -DNDEBUG)
 
 # @ECLASS_VARIABLE: DISTUTILS_OPTIONAL
 # @DEFAULT_UNSET
@@ -325,6 +327,7 @@ _distutils_set_globals() {
 
 		if [[ ${DISTUTILS_EXT} ]]; then
 			DEPEND="${PYTHON_DEPS}"
+			IUSE="debug"
 		fi
 	fi
 }
@@ -1765,6 +1768,10 @@ distutils-r1_run_phase() {
 	# Set up build environment, bug #513664.
 	local -x AR=${AR} CC=${CC} CPP=${CPP} CXX=${CXX}
 	tc-export AR CC CPP CXX
+
+	if [[ ${DISTUTILS_EXT} ]]; then
+		local -x CPPFLAGS="${CPPFLAGS} $(usex debug '-UNDEBUG' '-DNDEBUG')"
+	fi
 
 	# How to build Python modules in different worlds...
 	local ldopts

--- a/eclass/distutils-r1.eclass
+++ b/eclass/distutils-r1.eclass
@@ -55,6 +55,11 @@ esac
 # Set this variable to a non-null value if the package (possibly
 # optionally) builds Python extensions (loadable modules written in C,
 # Cython, Rust, etc.).
+#
+# When enabled, the eclass:
+#
+# - adds PYTHON_DEPS to DEPEND (for cross-compilation support), unless
+#   DISTUTILS_OPTIONAL is used
 
 # @ECLASS_VARIABLE: DISTUTILS_OPTIONAL
 # @DEFAULT_UNSET
@@ -317,6 +322,10 @@ _distutils_set_globals() {
 		RDEPEND="${PYTHON_DEPS} ${rdep}"
 		BDEPEND="${PYTHON_DEPS} ${bdep}"
 		REQUIRED_USE=${PYTHON_REQUIRED_USE}
+
+		if [[ ${DISTUTILS_EXT} ]]; then
+			DEPEND="${PYTHON_DEPS}"
+		fi
 	fi
 }
 _distutils_set_globals


### PR DESCRIPTION
Long story short, we add `DISTUTILS_EXT=1` to all packages that (at least optionally) install Python extensions (written in C, Cython, Rust…). When set, the eclass:

- adds `PYTHON_DEPS` to `DEPEND`
- adds `IUSE=debug` to control `-DNDEBUG` / `-UNDEBUG`
- controls calling `build_ext`

We can also use it later to detect wrong `<stabilize-allarches/>`.

The eclass detects if any Python extensions are installed and reports missing `DISTUTILS_EXT=1`.

Technically, none of the above strictly applies to Rust extensions but they're non-trivial to distinguish from C extensions and adding it doesn't hurt (cargo.eclass adds `IUSE=debug` anyway), so…