### PR TITLE
Enable sys-devel/llvm to be built with ROOT=

### DIFF
--- a/eclass/cmake.eclass
+++ b/eclass/cmake.eclass
@@ -484,17 +484,17 @@ cmake_src_configure() {
 		cat >> "${toolchain_file}" <<- _EOF_ || die
 			set(CMAKE_SYSTEM_NAME "${sysname}")
 		_EOF_
+	fi
 
-		if [ "${SYSROOT:-/}" != "/" ] ; then
-			# When cross-compiling with a sysroot (e.g. with crossdev's emerge wrappers)
-			# we need to tell cmake to use libs/headers from the sysroot but programs from / only.
-			cat >> "${toolchain_file}" <<- _EOF_ || die
-				set(CMAKE_SYSROOT "${ESYSROOT}")
-				set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
-				set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
-				set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
-			_EOF_
-		fi
+	if [ "${SYSROOT:-/}" != "/" ] ; then
+		# When building with a sysroot (e.g. with crossdev's emerge wrappers)
+		# we need to tell cmake to use libs/headers from the sysroot but programs from / only.
+		cat >> "${toolchain_file}" <<- _EOF_ || die
+			set(CMAKE_SYSROOT "${ESYSROOT}")
+			set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+			set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+			set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+		_EOF_
 	fi
 
 	if use prefix-guest; then


### PR DESCRIPTION
When performing a ROOT= build, the --sysroot parameter was not getting
passed to the compiler if the CBUILD and CHOST matched. This results in
the build attempting to use BROOT libraries and headers instead of the
ones from the ROOT.

This change will allow `llvm` to be built into a new ROOT.
    ROOT=/build/amd64-host emerge sys-devel/llvm

I also added a missing dependency that was unconvered when building
with ROOT=.
