### PR TITLE
gui-libs/wlroots-9999: change wayland version

### DIFF
--- a/gui-libs/wlroots/wlroots-9999.ebuild
+++ b/gui-libs/wlroots/wlroots-9999.ebuild
@@ -23,7 +23,7 @@ IUSE="+hwdata +seatd tinywl +udev vulkan x11-backend X"
 
 DEPEND="
 	>=dev-libs/libinput-1.14.0:0=
-	>=dev-libs/wayland-1.21.0
+	>=dev-libs/wayland-1.22.0
 	>=dev-libs/wayland-protocols-1.28
 	media-libs/mesa[egl(+),gles2]
 	media-libs/libdisplay-info:=


### PR DESCRIPTION
Per upstream commit [fac7a5cc](https://gitlab.freedesktop.org/wlroots/wlroots/-/commit/fac7a5cc9d30cef8c17b8fccb31a28b02ff4f2e7), wlroots now requires the minimum version of `dev-libs/wayland` to be `1.22`.