### PR TITLE
dev-util/huc: EAPI8 bump, use HTTPS, fix LICENSE

### DIFF
--- a/dev-util/huc/huc-0.1-r1.ebuild
+++ b/dev-util/huc/huc-0.1-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -6,11 +6,11 @@ EAPI=6
 inherit toolchain-funcs
 
 DESCRIPTION="HTML umlaut conversion tool"
-SRC_URI="http://www.int21.de/huc/${P}.tar.bz2"
-HOMEPAGE="http://www.int21.de/huc"
+SRC_URI="https://www.int21.de/huc/${P}.tar.bz2"
+HOMEPAGE="https://www.int21.de/huc"
 
 SLOT="0"
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 KEYWORDS="amd64 ppc sparc x86 ~x86-linux ~ppc-macos"
 
 src_compile() {

--- a/dev-util/huc/huc-0.1-r2.ebuild
+++ b/dev-util/huc/huc-0.1-r2.ebuild
@@ -1,0 +1,25 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs
+
+DESCRIPTION="HTML umlaut conversion tool"
+SRC_URI="https://www.int21.de/huc/${P}.tar.bz2"
+HOMEPAGE="https://www.int21.de/huc"
+
+SLOT="0"
+LICENSE="GPL-2+"
+KEYWORDS="~amd64 ~ppc ~sparc ~x86 ~x86-linux ~ppc-macos"
+
+src_compile() {
+	$(tc-getCXX) \
+		${LDFLAGS} ${CXXFLAGS} \
+		-o ${PN} ${PN}.cpp || die "compile failed"
+}
+
+src_install() {
+	dobin "${PN}"
+	einstalldocs
+}


### PR DESCRIPTION
Hi,
another simple EAPI8 bump.