### PR TITLE
add net-wireless/iwd to sys-apps/openrc message

### DIFF
--- a/sys-apps/openrc/openrc-0.46.ebuild
+++ b/sys-apps/openrc/openrc-0.46.ebuild
@@ -142,7 +142,7 @@ pkg_postinst() {
 		ewarn "You have emerged OpenRc without network support. This"
 		ewarn "means you need to SET UP a network manager such as"
 		ewarn "	net-misc/netifrc, net-misc/dhcpcd, net-misc/connman,"
-		ewarn " net-misc/NetworkManager, or net-vpn/badvpn."
+		ewarn " net-misc/NetworkManager, net-wireless/iwd or net-vpn/badvpn."
 		ewarn "Or, you have the option of emerging openrc with the newnet"
 		ewarn "use flag and configuring /etc/conf.d/network and"
 		ewarn "/etc/conf.d/staticroute if you only use static interfaces."

--- a/sys-apps/openrc/openrc-0.47.1.ebuild
+++ b/sys-apps/openrc/openrc-0.47.1.ebuild
@@ -142,7 +142,7 @@ pkg_postinst() {
 		ewarn "You have emerged OpenRc without network support. This"
 		ewarn "means you need to SET UP a network manager such as"
 		ewarn "	net-misc/netifrc, net-misc/dhcpcd, net-misc/connman,"
-		ewarn " net-misc/NetworkManager, or net-vpn/badvpn."
+		ewarn " net-misc/NetworkManager, net-wireless/iwd or net-vpn/badvpn."
 		ewarn "Or, you have the option of emerging openrc with the newnet"
 		ewarn "use flag and configuring /etc/conf.d/network and"
 		ewarn "/etc/conf.d/staticroute if you only use static interfaces."

--- a/sys-apps/openrc/openrc-9999.ebuild
+++ b/sys-apps/openrc/openrc-9999.ebuild
@@ -142,7 +142,7 @@ pkg_postinst() {
 		ewarn "You have emerged OpenRc without network support. This"
 		ewarn "means you need to SET UP a network manager such as"
 		ewarn "	net-misc/netifrc, net-misc/dhcpcd, net-misc/connman,"
-		ewarn " net-misc/NetworkManager, or net-vpn/badvpn."
+		ewarn " net-misc/NetworkManager, net-wireless/iwd or net-vpn/badvpn."
 		ewarn "Or, you have the option of emerging openrc with the newnet"
 		ewarn "use flag and configuring /etc/conf.d/network and"
 		ewarn "/etc/conf.d/staticroute if you only use static interfaces."


### PR DESCRIPTION
In `sys-apps/openrc`, if the `netifrc` flag is unset, the user is prompted with a message listing alternatives to have networking support.

At least on my system, I have it setup with `net-wireless/iwd`, so I thought on adding it to the message.

Is this suggestion valid?