### PR TITLE
dev-lua/*: Drop myself as a maintainer

### DIFF
--- a/dev-lua/lua-bit32/metadata.xml
+++ b/dev-lua/lua-bit32/metadata.xml
@@ -1,14 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer type="person" proxied="yes">
-		<email>azamat.hackimov@gmail.com</email>
-		<name>Azamat H. Hackimov</name>
-	</maintainer>
-	<maintainer type="project" proxied="proxy">
-		<email>proxy-maint@gentoo.org</email>
-		<name>Proxy Maintainers</name>
-	</maintainer>
 	<maintainer type="person">
 		<email>conikost@gentoo.org</email>
 		<name>Conrad Kostecki</name>

--- a/dev-lua/luaexpat/metadata.xml
+++ b/dev-lua/luaexpat/metadata.xml
@@ -1,14 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer type="person" proxied="yes">
-		<email>azamat.hackimov@gmail.com</email>
-		<name>Azamat H. Hackimov</name>
-	</maintainer>
-	<maintainer type="project" proxied="proxy">
-		<email>proxy-maint@gentoo.org</email>
-		<name>Proxy Maintainers</name>
-	</maintainer>
 	<maintainer type="person">
 		<email>conikost@gentoo.org</email>
 		<name>Conrad Kostecki</name>

--- a/dev-lua/luaposix/metadata.xml
+++ b/dev-lua/luaposix/metadata.xml
@@ -1,14 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer type="person" proxied="yes">
-		<email>azamat.hackimov@gmail.com</email>
-		<name>Azamat H. Hackimov</name>
-	</maintainer>
-	<maintainer type="project" proxied="proxy">
-		<email>proxy-maint@gentoo.org</email>
-		<name>Proxy Maintainers</name>
-	</maintainer>
 	<maintainer type="person">
 		<email>conikost@gentoo.org</email>
 		<name>Conrad Kostecki</name>


### PR DESCRIPTION
Drop myself as a maintainer for some Lua packages. They are now in good shape and have an active Gentoo maintainer.