### PR TITLE
app-admin/syslog-ng: replace obsolete stats_freq with stats(freq())

### DIFF
--- a/app-admin/syslog-ng/files/syslog-ng.conf.gentoo.hardened.in-r1
+++ b/app-admin/syslog-ng/files/syslog-ng.conf.gentoo.hardened.in-r1
@@ -1,0 +1,115 @@
+@version: @SYSLOGNG_VERSION@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+# https://bugs.gentoo.org/426814
+@include "scl.conf"
+
+#
+# Syslog-ng configuration file, compatible with default hardened installations.
+#
+
+options {
+	threaded(yes);
+	chain_hostnames(no);
+	stats(freq(43200));
+};
+
+source src {
+    system();
+    internal();
+};
+
+source kernsrc {
+    file("/proc/kmsg");
+};
+
+#source net { udp(); };
+#log { source(net); destination(net_logs); };
+#destination net_logs { file("/var/log/HOSTS/$HOST/$YEAR$MONTH$DAY.log"); };
+
+destination authlog { file("/var/log/auth.log"); };
+destination _syslog { file("/var/log/syslog"); };
+destination cron { file("/var/log/cron.log"); };
+destination daemon { file("/var/log/daemon.log"); };
+destination kern { file("/var/log/kern.log"); };
+destination lpr { file("/var/log/lpr.log"); };
+destination user { file("/var/log/user.log"); };
+destination uucp { file("/var/log/uucp.log"); };
+#destination ppp { file("/var/log/ppp.log"); };
+destination mail { file("/var/log/mail.log"); };
+
+destination avc { file("/var/log/avc.log"); };
+destination audit { file("/var/log/audit.log"); };
+destination pax { file("/var/log/pax.log"); };
+destination grsec { file("/var/log/grsec.log"); };
+
+destination mailinfo { file("/var/log/mail.info"); };
+destination mailwarn { file("/var/log/mail.warn"); };
+destination mailerr { file("/var/log/mail.err"); };
+
+destination newscrit { file("/var/log/news/news.crit"); };
+destination newserr { file("/var/log/news/news.err"); };
+destination newsnotice { file("/var/log/news/news.notice"); };
+
+destination debug { file("/var/log/debug"); };
+destination messages { file("/var/log/messages"); };
+destination console { usertty("root"); };
+destination console_all { file("/dev/tty12"); };
+#destination loghost { udp("loghost" port(999)); };
+
+destination xconsole { pipe("/dev/xconsole"); };
+
+filter f_auth { facility(auth); };
+filter f_authpriv { facility(auth, authpriv); };
+filter f_syslog { not facility(authpriv, mail); };
+filter f_cron { facility(cron); };
+filter f_daemon { facility(daemon); };
+filter f_kern { facility(kern); };
+filter f_lpr { facility(lpr); };
+filter f_mail { facility(mail); };
+filter f_user { facility(user); };
+filter f_uucp { facility(uucp); };
+#filter f_ppp { facility(ppp); };
+filter f_news { facility(news); };
+filter f_debug { not facility(auth, authpriv, news, mail); };
+filter f_messages { level(info..warn)
+	and not facility(auth, authpriv, mail, news); };
+filter f_emergency { level(emerg); };
+
+filter f_info { level(info); };
+
+filter f_notice { level(notice); };
+filter f_warn { level(warn); };
+filter f_crit { level(crit); };
+filter f_err { level(err); };
+
+filter f_avc { message(".*avc: .*"); };
+filter f_audit { message("^(\\[.*\..*\] |)audit.*") and not message(".*avc: .*"); };
+filter f_pax { message("^(\\[.*\..*\] |)PAX:.*"); };
+filter f_grsec { message("^(\\[.*\..*\] |)grsec:.*"); };
+
+log { source(src); filter(f_authpriv); destination(authlog); };
+log { source(src); filter(f_syslog); destination(_syslog); };
+log { source(src); filter(f_cron); destination(cron); };
+log { source(src); filter(f_daemon); destination(daemon); };
+log { source(kernsrc); filter(f_kern); destination(kern); destination(console_all); };
+log { source(src); filter(f_lpr); destination(lpr); };
+log { source(src); filter(f_mail); destination(mail); };
+log { source(src); filter(f_user); destination(user); };
+log { source(src); filter(f_uucp); destination(uucp); };
+log { source(kernsrc); filter(f_pax); destination(pax); };
+log { source(kernsrc); filter(f_grsec); destination(grsec); };
+log { source(kernsrc); filter(f_audit); destination(audit); };
+log { source(kernsrc); filter(f_avc); destination(avc); };
+log { source(src); filter(f_mail); filter(f_info); destination(mailinfo); };
+log { source(src); filter(f_mail); filter(f_warn); destination(mailwarn); };
+log { source(src); filter(f_mail); filter(f_err); destination(mailerr); };
+log { source(src); filter(f_news); filter(f_crit); destination(newscrit); };
+log { source(src); filter(f_news); filter(f_err); destination(newserr); };
+log { source(src); filter(f_news); filter(f_notice); destination(newsnotice); };
+log { source(src); filter(f_debug); destination(debug); };
+log { source(src); filter(f_messages); destination(messages); };
+log { source(src); filter(f_emergency); destination(console); };
+#log { source(src); filter(f_ppp); destination(ppp); };
+log { source(src); destination(console_all); };

--- a/app-admin/syslog-ng/files/syslog-ng.conf.gentoo.in-r1
+++ b/app-admin/syslog-ng/files/syslog-ng.conf.gentoo.in-r1
@@ -1,0 +1,36 @@
+@version: @SYSLOGNG_VERSION@
+#
+# Syslog-ng default configuration file for Gentoo Linux
+
+# https://bugs.gentoo.org/426814
+@include "scl.conf"
+
+options {
+	threaded(yes);
+	chain_hostnames(no);
+
+	# The default action of syslog-ng is to log a STATS line
+	# to the file every 10 minutes.  That's pretty ugly after a while.
+	# Change it to every 12 hours so you get a nice daily update of
+	# how many messages syslog-ng missed (0).
+	stats(freq(43200));
+	# The default action of syslog-ng is to log a MARK line
+	# to the file every 20 minutes.  That's seems high for most
+	# people so turn it down to once an hour.  Set it to zero
+	# if you don't want the functionality at all.
+	mark_freq(3600);
+};
+
+source src { system(); internal(); };
+
+destination messages { file("/var/log/messages"); };
+
+# By default messages are logged to tty12...
+destination console_all { file("/dev/tty12"); };
+# ...if you intend to use /dev/console for programs like xconsole
+# you can comment out the destination line above that references /dev/tty12
+# and uncomment the line below.
+#destination console_all { file("/dev/console"); };
+
+log { source(src); destination(messages); };
+log { source(src); destination(console_all); };

--- a/app-admin/syslog-ng/syslog-ng-4.1.1-r2.ebuild
+++ b/app-admin/syslog-ng/syslog-ng-4.1.1-r2.ebuild
@@ -1,0 +1,183 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+PYTHON_COMPAT=( python3_{9..11} )
+inherit autotools python-single-r1 systemd
+
+MY_PV_MM=$(ver_cut 1-2)
+DESCRIPTION="syslog replacement with advanced filtering features"
+HOMEPAGE="https://www.syslog-ng.com/products/open-source-log-management/"
+SRC_URI="https://github.com/balabit/syslog-ng/releases/download/${P}/${P}.tar.gz"
+
+LICENSE="GPL-2+ LGPL-2.1+"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+IUSE="amqp caps dbi geoip2 http ipv6 json kafka mongodb pacct python redis smtp snmp test spoof-source systemd tcpd"
+REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )
+	test? ( python )"
+RESTRICT="!test? ( test )"
+
+RDEPEND="
+	>=dev-libs/glib-2.10.1:2
+	>=dev-libs/ivykis-0.42.4
+	>=dev-libs/libpcre-6.1:=
+	!dev-libs/eventlog
+	amqp? ( >=net-libs/rabbitmq-c-0.8.0:=[ssl] )
+	caps? ( sys-libs/libcap )
+	dbi? ( >=dev-db/libdbi-0.9.0 )
+	geoip2? ( dev-libs/libmaxminddb:= )
+	http? ( net-misc/curl )
+	json? ( >=dev-libs/json-c-0.9:= )
+	kafka? ( >=dev-libs/librdkafka-1.0.0:= )
+	mongodb? ( >=dev-libs/mongo-c-driver-1.2.0 )
+	python? (
+		${PYTHON_DEPS}
+		$(python_gen_cond_dep '
+			dev-python/setuptools[${PYTHON_USEDEP}]
+		')
+	)
+	redis? ( >=dev-libs/hiredis-0.11.0:= )
+	smtp? ( net-libs/libesmtp:= )
+	snmp? ( net-analyzer/net-snmp:0= )
+	spoof-source? ( net-libs/libnet:1.1= )
+	systemd? ( sys-apps/systemd:= )
+	tcpd? ( >=sys-apps/tcp-wrappers-7.6 )
+	dev-libs/openssl:0="
+DEPEND="${RDEPEND}
+	test? ( dev-libs/criterion )"
+BDEPEND="
+	>=sys-devel/bison-3.7.6
+	sys-devel/flex
+	virtual/pkgconfig"
+
+DOCS=( AUTHORS NEWS.md CONTRIBUTING.md contrib/syslog-ng.conf.{HP-UX,RedHat,SunOS,doc}
+	contrib/syslog2ng "${T}/syslog-ng.conf.gentoo.hardened"
+	"${T}/syslog-ng.logrotate.hardened" "${FILESDIR}/README.hardened" )
+PATCHES=(
+	"${FILESDIR}"/${PN}-3.28.1-net-snmp.patch
+)
+
+pkg_setup() {
+	use python && python-single-r1_pkg_setup
+}
+
+src_prepare() {
+	local f
+
+	# disable python-modules test as it requires additional python modules not
+	# packaged in Gentoo
+	sed -i '/MAKE/s/.*/exit 0/g' modules/python-modules/test_pymodules.sh || die
+
+	use python && python_fix_shebang .
+
+	# remove bundled libs
+	rm -r lib/ivykis || die
+
+	# drop scl modules requiring json
+	if use !json; then
+		sed -i -r '/cim|elasticsearch|ewmm|graylog2|loggly|logmatic|netskope|nodejs|osquery|slack/d' scl/Makefile.am || die
+	fi
+
+	# drop scl modules requiring http
+	if use !http; then
+		sed -i -r '/slack|telegram/d' scl/Makefile.am || die
+	fi
+
+	# use gentoo default path
+	if use systemd; then
+		sed -e 's@/etc/syslog-ng.conf@/etc/syslog-ng/syslog-ng.conf@g;s@/var/run@/run@g' \
+			-i contrib/systemd/syslog-ng@default || die
+	fi
+
+	for f in syslog-ng.logrotate.hardened.in syslog-ng.logrotate.in; do
+		sed \
+			-e "s#@GENTOO_RESTART@#$(usex systemd "systemctl kill -s HUP syslog-ng@default" \
+				"/etc/init.d/syslog-ng reload")#g" \
+			"${FILESDIR}/${f}" > "${T}/${f/.in/}" || die
+	done
+
+	for f in syslog-ng.conf.gentoo.hardened.in-r1 \
+			syslog-ng.conf.gentoo.in-r1; do
+		sed -e "s/@SYSLOGNG_VERSION@/${MY_PV_MM}/g" "${FILESDIR}/${f}" > "${T}/${f/.in-r1/}" || die
+	done
+
+	default
+	eautoreconf
+}
+
+src_configure() {
+	local myconf=(
+		--disable-docs
+		--disable-java
+		--disable-java-modules
+		--disable-riemann
+		--enable-manpages
+		--localstatedir=/var/lib/syslog-ng
+		--sysconfdir=/etc/syslog-ng
+		--with-embedded-crypto
+		--with-ivykis=system
+		--with-module-dir=/usr/$(get_libdir)/syslog-ng
+		--with-pidfile-dir=/var/run
+		--with-python-packages=none
+		--with-systemdsystemunitdir="$(systemd_get_systemunitdir)"
+		$(use_enable amqp)
+		$(usex amqp --with-librabbitmq-client=system --without-librabbitmq-client)
+		$(use_enable caps linux-caps)
+		$(use_enable dbi sql)
+		$(use_enable geoip2)
+		$(use_enable http)
+		$(use_enable ipv6)
+		$(use_enable json)
+		$(use_enable kafka)
+		$(use_enable mongodb)
+		$(usex mongodb --with-mongoc=system "--without-mongoc --disable-legacy-mongodb-options")
+		$(use_enable pacct)
+		$(use_enable python)
+		$(use_enable redis)
+		$(use_enable smtp)
+		$(use_enable snmp afsnmp)
+		$(use_enable spoof-source)
+		$(use_enable systemd)
+		$(use_enable tcpd tcp-wrapper)
+	)
+
+	econf "${myconf[@]}"
+}
+
+src_install() {
+	default
+
+	# Install default configuration
+	insinto /etc/default
+	doins contrib/systemd/syslog-ng@default
+
+	insinto /etc/syslog-ng
+	newins "${T}/syslog-ng.conf.gentoo" syslog-ng.conf
+
+	insinto /etc/logrotate.d
+	newins "${T}/syslog-ng.logrotate" syslog-ng
+
+	newinitd "${FILESDIR}/syslog-ng.rc" syslog-ng
+	newconfd "${FILESDIR}/syslog-ng.confd" syslog-ng
+	keepdir /etc/syslog-ng/patterndb.d /var/lib/syslog-ng
+	find "${D}" -name '*.la' -delete || die
+
+	use python && python_optimize
+}
+
+pkg_postinst() {
+	# bug #355257
+	if ! has_version app-admin/logrotate ; then
+		elog "It is highly recommended that app-admin/logrotate be emerged to"
+		elog "manage the log files.  ${PN} installs a file in /etc/logrotate.d"
+		elog "for logrotate to use."
+	fi
+
+	if use systemd; then
+		ewarn "The service file for systemd has changed to support multiple instances."
+		ewarn "To start the default instance issue:"
+		ewarn "# systemctl start syslog-ng@default"
+	fi
+}


### PR DESCRIPTION
```bash
--- syslog-ng-4.1.1-r1.ebuild   2023-04-19 09:32:14.827593653 +0000
+++ syslog-ng-4.1.1-r2.ebuild   2023-04-21 09:57:42.012182861 +0000
@@ -98,9 +98,9 @@
                        "${FILESDIR}/${f}" > "${T}/${f/.in/}" || die
        done
 
-       for f in syslog-ng.conf.gentoo.hardened.in \
-                       syslog-ng.conf.gentoo.in; do
-               sed -e "s/@SYSLOGNG_VERSION@/${MY_PV_MM}/g" "${FILESDIR}/${f}" > "${T}/${f/.in/}" || die
+       for f in syslog-ng.conf.gentoo.hardened.in-r1 \
+                       syslog-ng.conf.gentoo.in-r1; do
+               sed -e "s/@SYSLOGNG_VERSION@/${MY_PV_MM}/g" "${FILESDIR}/${f}" > "${T}/${f/.in-r1/}" || die
        done
 
        default
```

```
--- syslog-ng.conf.gentoo.hardened.in   2019-09-20 13:02:17.895304359 +0000
+++ syslog-ng.conf.gentoo.hardened.in-r1        2023-04-21 09:48:32.116956680 +0000
@@ -12,7 +12,7 @@
 options {
        threaded(yes);
        chain_hostnames(no);
-       stats_freq(43200);
+       stats(freq(43200));
 };
 
 source src {
```

```
--- syslog-ng.conf.gentoo.in    2019-07-02 06:32:59.898490550 +0000
+++ syslog-ng.conf.gentoo.in-r1 2023-04-21 09:48:32.117956684 +0000
@@ -13,7 +13,7 @@
        # to the file every 10 minutes.  That's pretty ugly after a while.
        # Change it to every 12 hours so you get a nice daily update of
        # how many messages syslog-ng missed (0).
-       stats_freq(43200);
+       stats(freq(43200));
        # The default action of syslog-ng is to log a MARK line
        # to the file every 20 minutes.  That's seems high for most
        # people so turn it down to once an hour.  Set it to zero
```