### PR TITLE
sys-fs/cryfs: enable py3.11

### DIFF
--- a/sys-fs/cryfs/cryfs-0.10.3-r1.ebuild
+++ b/sys-fs/cryfs/cryfs-0.10.3-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{9..10} )
+PYTHON_COMPAT=( python3_{9..11} )
 inherit cmake flag-o-matic linux-info python-any-r1
 
 if [[ ${PV} == 9999 ]] ; then


### PR DESCRIPTION
Builds against `dev-lang/python-3.11.3:3.11::gentoo` without issue.  The only test failures that exist are the same 27 tests that fail when built against `dev-lang/python-3.10.11::gentoo`.  That is:
```
[----------] Global test environment tear-down
[==========] 309 tests from 18 test suites ran. (1715 ms total)
[  PASSED  ] 282 tests.
[  FAILED  ] 27 tests, listed below:
[  FAILED  ] CliTest_Setup.NoSpecialOptions
[  FAILED  ] CliTest_Setup.NotexistingLogfileGiven
[  FAILED  ] CliTest_Setup.ExistingLogfileGiven
[  FAILED  ] CliTest_Setup.ConfigfileGiven
[  FAILED  ] CliTest_Setup.FuseOptionGiven
[  FAILED  ] CliTest.WorksWithCommasInBasedir
[  FAILED  ] CliTest_Unmount.givenMountedFilesystem_whenUnmounting_thenSucceeds
[  FAILED  ] RunningInForeground/CliTest_WrongEnvironment.NoErrorCondition/0, where GetParam() = 3-byte object <00-00 01>
[  FAILED  ] RunningInForeground/CliTest_WrongEnvironment.BaseDir_DoesntExist_Create/0, where GetParam() = 3-byte object <00-00 01>
[  FAILED  ] RunningInForeground/CliTest_WrongEnvironment.BaseDir_AllPermissions/0, where GetParam() = 3-byte object <00-00 01>
[  FAILED  ] RunningInForeground/CliTest_WrongEnvironment.MountDir_DoesntExist_Create/0, where GetParam() = 3-byte object <00-00 01>
[  FAILED  ] RunningInForeground/CliTest_WrongEnvironment.MountDir_AllPermissions/0, where GetParam() = 3-byte object <00-00 01>
[  FAILED  ] RunningInForeground_ExternalConfigfile/CliTest_WrongEnvironment.NoErrorCondition/0, where GetParam() = 3-byte object <01-00 01>
[  FAILED  ] RunningInForeground_ExternalConfigfile/CliTest_WrongEnvironment.BaseDir_DoesntExist_Create/0, where GetParam() = 3-byte object <01-00 01>
[  FAILED  ] RunningInForeground_ExternalConfigfile/CliTest_WrongEnvironment.BaseDir_AllPermissions/0, where GetParam() = 3-byte object <01-00 01>
[  FAILED  ] RunningInForeground_ExternalConfigfile/CliTest_WrongEnvironment.MountDir_DoesntExist_Create/0, where GetParam() = 3-byte object <01-00 01>
[  FAILED  ] RunningInForeground_ExternalConfigfile/CliTest_WrongEnvironment.MountDir_AllPermissions/0, where GetParam() = 3-byte object <01-00 01>
[  FAILED  ] RunningInForeground_LogIsNotStderr/CliTest_WrongEnvironment.NoErrorCondition/0, where GetParam() = 3-byte object <00-01 01>
[  FAILED  ] RunningInForeground_LogIsNotStderr/CliTest_WrongEnvironment.BaseDir_DoesntExist_Create/0, where GetParam() = 3-byte object <00-01 01>
[  FAILED  ] RunningInForeground_LogIsNotStderr/CliTest_WrongEnvironment.BaseDir_AllPermissions/0, where GetParam() = 3-byte object <00-01 01>
[  FAILED  ] RunningInForeground_LogIsNotStderr/CliTest_WrongEnvironment.MountDir_DoesntExist_Create/0, where GetParam() = 3-byte object <00-01 01>
[  FAILED  ] RunningInForeground_LogIsNotStderr/CliTest_WrongEnvironment.MountDir_AllPermissions/0, where GetParam() = 3-byte object <00-01 01>
[  FAILED  ] RunningInForeground_ExternalConfigfile_LogIsNotStderr/CliTest_WrongEnvironment.NoErrorCondition/0, where GetParam() = 3-byte object <01-01 01>
[  FAILED  ] RunningInForeground_ExternalConfigfile_LogIsNotStderr/CliTest_WrongEnvironment.BaseDir_DoesntExist_Create/0, where GetParam() = 3-byte object <01-01 01>
[  FAILED  ] RunningInForeground_ExternalConfigfile_LogIsNotStderr/CliTest_WrongEnvironment.BaseDir_AllPermissions/0, where GetParam() = 3-byte object <01-01 01>
[  FAILED  ] RunningInForeground_ExternalConfigfile_LogIsNotStderr/CliTest_WrongEnvironment.MountDir_DoesntExist_Create/0, where GetParam() = 3-byte object <01-01 01>
[  FAILED  ] RunningInForeground_ExternalConfigfile_LogIsNotStderr/CliTest_WrongEnvironment.MountDir_AllPermissions/0, where GetParam() = 3-byte object <01-01 01>
```
Decryption and mounting work when used in conjunction with `kde-plasma/plasma-vault` and with CLI using `cryfs` and `cryfs-unmount`. That is:
```
mkdir ~/tst
cryfs ~/.local/share/plasma-vault/Vault.enc ~/tst
cryfs-unmount ~/tst
rm -r ~/tst
```

Closes: https://bugs.gentoo.org/897304
Closes: https://github.com/gentoo/gentoo/pull/30694
Signed-off-by: Peter Levine <plevine457@gmail.com>