### PR TITLE
media-libs/mesa: vdpau require X

### DIFF
--- a/media-libs/mesa/mesa-22.3.7-r1.ebuild
+++ b/media-libs/mesa/mesa-22.3.7-r1.ebuild
@@ -43,6 +43,7 @@ REQUIRED_USE="
 	video_cards_radeon? ( x86? ( llvm ) amd64? ( llvm ) )
 	video_cards_r300?   ( x86? ( llvm ) amd64? ( llvm ) )
 	video_cards_radeonsi?   ( llvm )
+	vdpau? ( X )
 	xa? ( X )
 	zink? ( vulkan )
 "

--- a/media-libs/mesa/mesa-23.0.0-r1.ebuild
+++ b/media-libs/mesa/mesa-23.0.0-r1.ebuild
@@ -43,6 +43,7 @@ REQUIRED_USE="
 	video_cards_radeon? ( x86? ( llvm ) amd64? ( llvm ) )
 	video_cards_r300?   ( x86? ( llvm ) amd64? ( llvm ) )
 	video_cards_radeonsi?   ( llvm )
+	vdpau? ( X )
 	xa? ( X )
 	zink? ( vulkan )
 "

--- a/media-libs/mesa/mesa-23.0.1.ebuild
+++ b/media-libs/mesa/mesa-23.0.1.ebuild
@@ -43,6 +43,7 @@ REQUIRED_USE="
 	video_cards_radeon? ( x86? ( llvm ) amd64? ( llvm ) )
 	video_cards_r300?   ( x86? ( llvm ) amd64? ( llvm ) )
 	video_cards_radeonsi?   ( llvm )
+	vdpau? ( X )
 	xa? ( X )
 	zink? ( vulkan )
 "

--- a/media-libs/mesa/mesa-23.0.2-r1.ebuild
+++ b/media-libs/mesa/mesa-23.0.2-r1.ebuild
@@ -43,6 +43,7 @@ REQUIRED_USE="
 	video_cards_radeon? ( x86? ( llvm ) amd64? ( llvm ) )
 	video_cards_r300?   ( x86? ( llvm ) amd64? ( llvm ) )
 	video_cards_radeonsi?   ( llvm )
+	vdpau? ( X )
 	xa? ( X )
 	zink? ( vulkan )
 "

--- a/media-libs/mesa/mesa-23.0.2.ebuild
+++ b/media-libs/mesa/mesa-23.0.2.ebuild
@@ -43,6 +43,7 @@ REQUIRED_USE="
 	video_cards_radeon? ( x86? ( llvm ) amd64? ( llvm ) )
 	video_cards_r300?   ( x86? ( llvm ) amd64? ( llvm ) )
 	video_cards_radeonsi?   ( llvm )
+	vdpau? ( X )
 	xa? ( X )
 	zink? ( vulkan )
 "

--- a/media-libs/mesa/mesa-9999.ebuild
+++ b/media-libs/mesa/mesa-9999.ebuild
@@ -43,6 +43,7 @@ REQUIRED_USE="
 	video_cards_radeon? ( x86? ( llvm ) amd64? ( llvm ) )
 	video_cards_r300?   ( x86? ( llvm ) amd64? ( llvm ) )
 	video_cards_radeonsi?   ( llvm )
+	vdpau? ( X )
 	xa? ( X )
 	zink? ( vulkan )
 "


### PR DESCRIPTION
When compile media-libs/mesa without X and enable vdpau show this error.

<pre>
 * mesa-22.3.7.tar.xz BLAKE2B SHA512 size ;-) ...                        [ ok ]
 * Determining the location of the kernel source code
 * Found kernel source directory:
 *     /usr/src/linux
 * Found sources for kernel version:
 *     6.1.19-gentoo
 * Checking for suitable kernel configuration options ...
 [ ok ]
 * Checking whether python3_11 is suitable ...
 *   >=dev-lang/python-3.11.1-r1:3.11 ...
 [ !! ]
 * Checking whether python3_10 is suitable ...
 *   >=dev-lang/python-3.10.9-r1:3.10 ...
 [ ok ]
 *   python_check_deps ...
 *     >=dev-python/mako-0.8.0[python_targets_python3_10(-)] ...
 [ ok ]
 [ ok ]
 * Using python3.10 to build (via PYTHON_COMPAT iteration)
>>> Unpacking source...
>>> Unpacking mesa-22.3.7.tar.xz to /var/tmp/portage/media-libs/mesa-22.3.7-r1/work
>>> Source unpacked in /var/tmp/portage/media-libs/mesa-22.3.7-r1/work
>>> Preparing source in /var/tmp/portage/media-libs/mesa-22.3.7-r1/work/mesa-22.3.7 ...
>>> Source prepared.
>>> Configuring source in /var/tmp/portage/media-libs/mesa-22.3.7-r1/work/mesa-22.3.7 ...
 * abi_x86_64.amd64: running multilib-minimal_abi_src_configure
meson setup --libdir lib64 --localstatedir /var/lib --prefix /usr --sysconfdir /etc --wrap-mode nodownload --build.pkg-config-path /var/tmp/portage/media-libs/mesa-22.3.7-r1/temp/python3.10/p
kgconfig:/usr/share/pkgconfig --pkg-config-path /var/tmp/portage/media-libs/mesa-22.3.7-r1/temp/python3.10/pkgconfig:/usr/share/pkgconfig --native-file /var/tmp/portage/media-libs/mesa-22.3.7
-r1/temp/meson.x86_64-pc-linux-gnu.amd64.ini -Db_pch=false -Dwerror=false --buildtype plain -Dplatforms= -Dgallium-nine=false -Dgallium-va=enabled -Dva-libs-path=/usr/lib64/va/drivers -Dgalli
um-vdpau=enabled -Dgallium-xa=disabled -Dgallium-opencl=icd -Dvulkan-layers= -Dbuild-tests=false -Dglx=disabled -Dshared-glapi=enabled -Ddri3=enabled -Degl=enabled -Dgbm=enabled -Dglvnd=true 
-Dgles1=disabled -Dgles2=enabled -Dllvm=enabled -Dlmsensors=enabled -Dosmesa=true -Dselinux=false -Dlibunwind=disabled -Dzstd=enabled -Dsse2=true -Dvalgrind=disabled -Dvideo-codecs=h264dec,h2
64enc,h265dec,h265enc,vc1dec -Dgallium-drivers=r300,r600,radeonsi,swrast -Dvulkan-drivers= --buildtype plain -Db_ndebug=true /var/tmp/portage/media-libs/mesa-22.3.7-r1/work/mesa-22.3.7 /var/t
mp/portage/media-libs/mesa-22.3.7-r1/work/mesa-22.3.7-abi_x86_64.amd64
The Meson build system
Version: 1.0.1
Source dir: /var/tmp/portage/media-libs/mesa-22.3.7-r1/work/mesa-22.3.7
Build dir: /var/tmp/portage/media-libs/mesa-22.3.7-r1/work/mesa-22.3.7-abi_x86_64.amd64
Build type: native build
Program python3 found: YES (/var/tmp/portage/media-libs/mesa-22.3.7-r1/temp/python3.10/bin/python3)
Project name: mesa
Project version: 22.3.7
C compiler for the host machine: x86_64-pc-linux-gnu-gcc (gcc 12.2.1 "x86_64-pc-linux-gnu-gcc (Gentoo 12.2.1_p20230121-r1 p10) 12.2.1 20230121")
C linker for the host machine: x86_64-pc-linux-gnu-gcc ld.bfd 2.39
C++ compiler for the host machine: x86_64-pc-linux-gnu-g++ (gcc 12.2.1 "x86_64-pc-linux-gnu-g++ (Gentoo 12.2.1_p20230121-r1 p10) 12.2.1 20230121")
C++ linker for the host machine: x86_64-pc-linux-gnu-g++ ld.bfd 2.39
Host machine cpu family: x86_64
Host machine cpu: x86_64
Checking if "-mtls-dialect=gnu2" runs: YES
Checking if "split TLSDESC" : links: YES 

../mesa-22.3.7/meson.build:666:4: ERROR: Problem encountered: VDPAU state tracker requires X11 support.
</pre>

Analyzing meson.build line 650 - 686 force to use X in vdpau
<pre>
_vdpau = get_option('gallium-vdpau')                                                                                                                                                           
if _vdpau == 'true'                                                                                                                                                                            
  _vdpau = 'enabled'                                                                                                                                                                           
  warning('gallium-vdpau option "true" deprecated, please use "enabled" instead.')                                                                                                             
elif _vdpau == 'false'                                                                                                                                                                         
  _vdpau = 'disabled'                                                                                                                                                                          
  warning('gallium-vdpau option "false" deprecated, please use "disabled" instead.')                                                                                                           
endif                                                                                                                                                                                          
if not system_has_kms_drm                                                                                                                                                                      
  if _vdpau == 'enabled'                                                                                                                                                                       
    error('VDPAU state tracker can only be build on unix-like OSes.')                                                                                                                          
  else                                                                                                                                                                                         
    _vdpau = 'disabled'                                                                                                                                                                        
  endif                                                                                                                                                                                        
elif not with_platform_x11                                                                                                                                                                     
  if _vdpau == 'enabled'                                                                                                                                                                       
    error('VDPAU state tracker requires X11 support.')                                                                                                                                         
  else                                                                                                                                                                                         
    _vdpau = 'disabled'                                                                                                                                                                        
  endif                                                                                                                                                                                        
elif not (with_gallium_r300 or with_gallium_r600 or with_gallium_radeonsi or                                                                                                                   
          with_gallium_nouveau or with_gallium_d3d12_video or with_gallium_virgl)                                                                                                              
  if _vdpau == 'enabled'                                                                                                                                                                       
    error('VDPAU state tracker requires at least one of the following gallium drivers: r300, r600, radeonsi, nouveau, d3d12 (with option gallium-d3d12-video, virgl).')                        
  else                                                                                                                                                                                         
    _vdpau = 'disabled'                                                                                                                                                                        
  endif                                                                                                                                                                                        
endif                                                                                                                                                                                          
dep_vdpau = null_dep                                                                                                                                                                           
with_gallium_vdpau = false                                                                                                                                                                     
if _vdpau != 'disabled'                                                                                                                                                                        
  dep_vdpau = dependency('vdpau', version : '>= 1.1', required : _vdpau == 'enabled')                                                                                                          
  if dep_vdpau.found()                                                                                                                                                                         
    dep_vdpau = dep_vdpau.partial_dependency(compile_args : true)                                                                                                                              
    with_gallium_vdpau = true                                                                                                                                                                  
  endif                                                                                                                                                                                        
endif                                                                                                                                                                                          
</pre>


Package-Manager: Portage-3.0.44, pkgcheck-0.10.23
Signed-off-by: Fco. Javier Félix [web@inode64.com](mailto:web@inode64.com)