### PR TITLE
net-wireless/hostapd added support for wifi 6

### DIFF
--- a/net-wireless/hostapd/hostapd-2.10.ebuild
+++ b/net-wireless/hostapd/hostapd-2.10.ebuild
@@ -154,6 +154,7 @@ src_configure() {
 	echo "CONFIG_IEEE80211W=y" >> ${CONFIG} || die
 	echo "CONFIG_IEEE80211N=y" >> ${CONFIG} || die
 	echo "CONFIG_IEEE80211AC=y" >> ${CONFIG} || die
+	echo "CONFIG_IEEE80211AX=y" >> ${CONFIG} || die
 	echo "CONFIG_OCV=y" >> ${CONFIG} || die
 	echo "CONFIG_PEERKEY=y" >> ${CONFIG} || die
 	echo "CONFIG_RSN_PREAUTH=y" >> ${CONFIG} || die

--- a/net-wireless/hostapd/hostapd-9999.ebuild
+++ b/net-wireless/hostapd/hostapd-9999.ebuild
@@ -154,6 +154,7 @@ src_configure() {
 	echo "CONFIG_IEEE80211W=y" >> ${CONFIG} || die
 	echo "CONFIG_IEEE80211N=y" >> ${CONFIG} || die
 	echo "CONFIG_IEEE80211AC=y" >> ${CONFIG} || die
+	echo "CONFIG_IEEE80211AX=y" >> ${CONFIG} || die
 	echo "CONFIG_OCV=y" >> ${CONFIG} || die
 	echo "CONFIG_PEERKEY=y" >> ${CONFIG} || die
 	echo "CONFIG_RSN_PREAUTH=y" >> ${CONFIG} || die


### PR DESCRIPTION
Hostapd is compiled without 802.11ax support and this cause that hostapd doesn't start when ieee80211ax=1 is set