### PR TITLE
games-arcade/xgalaga: Add patch to fix Wimplicit-int

### DIFF
--- a/games-arcade/xgalaga/files/xgalaga-2.1.1.0-function-and-ints.patch
+++ b/games-arcade/xgalaga/files/xgalaga-2.1.1.0-function-and-ints.patch
@@ -1,0 +1,24 @@
+Bug: https://bugs.gentoo.org/877287
+--- a/title.c
++++ b/title.c
+@@ -5,6 +5,7 @@
+ 
+ #include <stdio.h>
+ #include <stdlib.h>
++#include <unistd.h>
+ #ifdef HAVE_FCNTL_H
+ # include <fcntl.h>
+ #endif
+@@ -17,9 +18,9 @@
+ #include "proto.h"
+ 
+ /* for scrolling credits */
+-const LINESIZE= 70;
+-const VISIBLELINES=7;
+-const SPEEDFACTOR=5;
++const int LINESIZE=70;
++const int VISIBLELINES=7;
++const int SPEEDFACTOR=5;
+ char *gchLBuf;
+ int giCreditLines=0, giActCreditLine=0;
+ 

--- a/games-arcade/xgalaga/xgalaga-2.1.1.0-r1.ebuild
+++ b/games-arcade/xgalaga/xgalaga-2.1.1.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -25,6 +25,7 @@ RDEPEND+=" acct-group/gamestat"
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-2.1.1.0-respect-AR.patch
+	"${FILESDIR}"/${PN}-2.1.1.0-function-and-ints.patch
 )
 
 src_prepare() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/877287