### PR TITLE
net-im/telegram-desktop: update metadata

### DIFF
--- a/net-im/telegram-desktop/metadata.xml
+++ b/net-im/telegram-desktop/metadata.xml
@@ -10,7 +10,7 @@
 		<name>Proxy Maintainers</name>
 	</maintainer>
 	<use>
-		<flag name="enchant">Use the <pkg>app-text/aspell</pkg> spell-checking backend instead of <pkg>app-text/hunspell</pkg></flag>
+		<flag name="enchant">Use the <pkg>app-text/enchant</pkg> spell-checking backend instead of <pkg>app-text/hunspell</pkg></flag>
 		<flag name="fonts">Use builtin patched copy of open-sans fonts (overrides fontconfig)</flag>
 		<flag name="qt6">Build with Qt6 support</flag>
 		<flag name="qt6-imageformats">Add support for HEIF, AVIF and JpegXL by bundling kde-frameworks/kimageformats</flag>


### PR DESCRIPTION
I'm aware enchant can use aspell but it also supports a bunch of other backends (hunspell included), so this updates the useflag description to describe what it actually does.