### PR TITLE
dev-python/caldav: Add dev-python/icalendar runtime dep

### DIFF
--- a/dev-python/caldav/caldav-1.2.1.ebuild
+++ b/dev-python/caldav/caldav-1.2.1.ebuild
@@ -23,6 +23,7 @@ SLOT="0"
 KEYWORDS="~amd64 ~x86"
 
 RDEPEND="
+	dev-python/icalendar[${PYTHON_USEDEP}]
 	dev-python/lxml[${PYTHON_USEDEP}]
 	dev-python/requests[${PYTHON_USEDEP}]
 	dev-python/vobject[${PYTHON_USEDEP}]


### PR DESCRIPTION
The `dev-python/caldav` `1.2.1` ebuild most certainly requires `dev-python/icalendar` at runtime, or various import failures are the result.
Add the dependency accordingly.