### PR TITLE
app-arch/tar: adapt pkg_postinst for prefix bootstrapping

### DIFF
--- a/app-arch/tar/tar-1.34-r2.ebuild
+++ b/app-arch/tar/tar-1.34-r2.ebuild
@@ -90,6 +90,13 @@ pkg_postinst() {
 	# ensure to preserve the symlink before app-alternatives/tar
 	# is installed
 	if [[ ! -h ${EROOT}/bin/tar ]]; then
+		if [[ -e ${EROOT}/usr/bin/tar ]] ; then
+			# bug #904887
+			ewarn "${EROOT}/usr/bin/tar exists but is not a symlink."
+			ewarn "This is expected during Prefix bootstrap and unsual otherwise."
+			ewarn "Moving away unexpected ${EROOT}/usr/bin/tar to .bak."
+			mv "${EROOT}/usr/bin/tar" "${EROOT}/usr/bin/tar.bak" || die
+		fi
 		ln -s gtar "${EROOT}/bin/tar" || die
 	fi
 }

--- a/app-arch/tar/tar-1.34-r3.ebuild
+++ b/app-arch/tar/tar-1.34-r3.ebuild
@@ -94,6 +94,13 @@ pkg_postinst() {
 	# ensure to preserve the symlink before app-alternatives/tar
 	# is installed
 	if [[ ! -h ${EROOT}/bin/tar ]]; then
+		if [[ -e ${EROOT}/usr/bin/tar ]] ; then
+			# bug #904887
+			ewarn "${EROOT}/usr/bin/tar exists but is not a symlink."
+			ewarn "This is expected during Prefix bootstrap and unsual otherwise."
+			ewarn "Moving away unexpected ${EROOT}/usr/bin/tar to .bak."
+			mv "${EROOT}/usr/bin/tar" "${EROOT}/usr/bin/tar.bak" || die
+		fi
 		ln -s gtar "${EROOT}/bin/tar" || die
 	fi
 }


### PR DESCRIPTION
This commit allows Portage to overwrite the binary executable "tar" with a symbolic link, this situation is encountered during Gentoo prefix bootstrap. If left unhandled, it causes the bootstrap to fail with the error message:

    ln: failed to create symbolic link '/Users/ec2-user/gentoo/tmp/bin/tar': File exists

The original binary is renamed to tar.bak.

Closes: https://bugs.gentoo.org/904887
Suggested-by: Sam James <sam@gentoo.org>