### PR TITLE
dev-qt/qt{base,gui}: Add wayland to platform plugin REQUIRED_USE

### DIFF
--- a/dev-qt/qtbase/qtbase-6.5.2.ebuild
+++ b/dev-qt/qtbase/qtbase-6.5.2.ebuild
@@ -33,7 +33,7 @@ REQUIRED_USE+="
 	cups? ( gui widgets )
 	eglfs? ( egl )
 	gtk? ( widgets )
-	gui? ( || ( eglfs X ) || ( libinput X ) )
+	gui? ( || ( eglfs wayland X ) || ( libinput X ) )
 	libinput? ( udev )
 	sql? ( || ( freetds mysql oci8 odbc postgres sqlite ) )
 	vnc? ( gui )

--- a/dev-qt/qtgui/qtgui-5.15.10-r1.ebuild
+++ b/dev-qt/qtgui/qtgui-5.15.10-r1.ebuild
@@ -17,7 +17,7 @@ SLOT=5/${QT5_PV} # bug 707658
 IUSE="accessibility dbus egl eglfs evdev gles2-only ibus jpeg +libinput
 	linuxfb +png tslib tuio +udev vnc vulkan wayland +X"
 REQUIRED_USE="
-	|| ( eglfs linuxfb vnc X )
+	|| ( eglfs linuxfb vnc wayland X )
 	accessibility? ( dbus X )
 	eglfs? ( egl )
 	ibus? ( dbus )


### PR DESCRIPTION
Add wayland to the REQUIRED_USE line requiring a platform plugin be built for wayland-only setups. The build system does not appear to enforce this REQUIRED_USE line, so I assume it's just there to make sure a GUI platform plugin gets built.