### PR TITLE
gui-apps/foot: fix 1.14.0 build

### DIFF
--- a/gui-apps/foot/foot-1.14.0.ebuild
+++ b/gui-apps/foot/foot-1.14.0.ebuild
@@ -28,7 +28,7 @@ COMMON_DEPEND="
 "
 DEPEND="
 	${COMMON_DEPEND}
-	dev-libs/tllist
+	>=dev-libs/tllist-1.1.0
 	dev-libs/wayland-protocols
 "
 RDEPEND="


### PR DESCRIPTION
When compiling foot 1.14.0 with dev-libs/tllist stable version 1.0.5-r1, the compilation fails.

```
/usr/lib/gcc/x86_64-gentoo-linux-musl/12/../../../../x86_64-gentoo-linux-musl/bin/ld: foot.p/key-binding.c.o: in function `sort_binding_list':
key-binding.c:(.text+0x140): undefined reference to `tll_sort'
collect2: error: ld returned 1 exit status
```

The solution is to use dev-libs/tllist-1.1.0, which is currently unstable.

Closes [Bug 904038](https://bugs.gentoo.org/show_bug.cgi?id=904038)