### PR TITLE
media-gfx/yafaray: fix build with gcc-13

### DIFF
--- a/media-gfx/yafaray/files/yafaray-3.5.1-add-missing-include-statements-for-gcc-13.patch
+++ b/media-gfx/yafaray/files/yafaray-3.5.1-add-missing-include-statements-for-gcc-13.patch
@@ -1,0 +1,19 @@
+From ca340cbfc518cc4b0655840453198620215535df Mon Sep 17 00:00:00 2001
+From: Bernd Waibel <waebbl-gentoo@posteo.net>
+Date: Tue, 25 Apr 2023 09:27:40 +0200
+Subject: [PATCH] add missing #include statements for gcc-13
+
+Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>
+--- a/include/core_api/session.h
++++ b/include/core_api/session.h
+@@ -25,6 +25,7 @@
+ 
+ #include <yafray_constants.h>
+ #include <utilities/threadUtils.h>
++#include <string>
+ 
+ __BEGIN_YAFRAY
+ 
+-- 
+2.40.0
+

--- a/media-gfx/yafaray/metadata.xml
+++ b/media-gfx/yafaray/metadata.xml
@@ -28,4 +28,7 @@
 			Add support for <pkg>media-libs/opencv</pkg> image processing.
 		</flag>
 	</use>
+	<upstream>
+		<remote-id type="github">YafaRay/libYafaRay</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/media-gfx/yafaray/yafaray-3.5.1-r4.ebuild
+++ b/media-gfx/yafaray/yafaray-3.5.1-r4.ebuild
@@ -47,6 +47,7 @@ BDEPEND="
 PATCHES=(
 	"${FILESDIR}"/${P}-0001-respect-distribution-CFLAGS.patch
 	"${FILESDIR}"/${P}-add-missing-limits-header.patch
+	"${FILESDIR}"/${PN}-3.5.1-add-missing-include-statements-for-gcc-13.patch
 )
 
 DOCS=( AUTHORS.md CHANGELOG.md CODING.md INSTALL.md README.md )


### PR DESCRIPTION
add missing #include statement

Bug: https://github.com/YafaRay/libYafaRay/issues/14
Closes: https://bugs.gentoo.org/895208