### PR TITLE
mail-mta/opensmtpd: Build fixes

### DIFF
--- a/mail-mta/opensmtpd/files/opensmtpd-6.8.0_p2-ar.patch
+++ b/mail-mta/opensmtpd/files/opensmtpd-6.8.0_p2-ar.patch
@@ -1,0 +1,42 @@
+https://github.com/OpenSMTPD/OpenSMTPD/pull/1199
+https://bugs.gentoo.org/720782
+
+From 92ada4471602fc737113b8dfe1b9b8e8e0aab7e0 Mon Sep 17 00:00:00 2001
+From: orbea <orbea@riseup.net>
+Date: Tue, 25 Apr 2023 09:13:51 -0700
+Subject: [PATCH] configure: Use AM_PROG_AR
+
+Automake provides AM_PROG_AR as a standard way of finding ar(1).
+
+Reference: https://www.gnu.org/software/automake/manual/html_node/Public-Macros.html
+
+Closes: https://github.com/OpenSMTPD/OpenSMTPD/pull/1177
+---
+ configure.ac | 7 +------
+ 1 file changed, 1 insertion(+), 6 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index 00450485..5b12b67e 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -67,7 +67,7 @@ AC_C_BIGENDIAN
+ AC_PROG_CPP
+ AC_PROG_INSTALL
+ AC_PROG_LIBTOOL
+-AC_PATH_PROG([AR], [ar])
++AM_PROG_AR
+ AC_PATH_PROG([CAT], [cat])
+ AC_PATH_PROG([CHMOD], [chmod])
+ AC_PATH_PROG([CHOWN], [chown])
+@@ -84,11 +84,6 @@ AC_PROG_YACC
+ 
+ AC_SUBST([ZCAT])
+ 
+-
+-if test -z "$AR"; then
+-	AC_MSG_ERROR([*** 'ar' missing, please install or fix your \$PATH ***])
+-fi
+-
+ if test -z "$LD"; then
+ 	LD=$CC
+ fi

--- a/mail-mta/opensmtpd/files/opensmtpd-6.8.0_p2-implicit-function-declaration.patch
+++ b/mail-mta/opensmtpd/files/opensmtpd-6.8.0_p2-implicit-function-declaration.patch
@@ -1,0 +1,303 @@
+https://github.com/OpenSMTPD/OpenSMTPD/pull/1195
+https://bugs.gentoo.org/727260
+https://bugs.gentoo.org/896050
+https://bugs.gentoo.org/899876
+
+From 7abe6305f864113aec4c6fc55cccabdc55959252 Mon Sep 17 00:00:00 2001
+From: orbea <orbea@riseup.net>
+Date: Thu, 13 Apr 2023 11:04:14 -0700
+Subject: [PATCH] build: Fix -Werror=implicit-function-declaration
+
+On a system with musl these functions are not available, but they are
+found by the build system inside of libbsd instead. However many of the
+relevant headers are never incuded resulting in many implicit function
+declarations. Additionally clang-16 is more strict about these turning
+them into errors.
+
+* While libbsd contains symbols for inet_net_pton() they do not have any
+  headers with the function prototype. Upstream has marked this function
+  for removal since it is now provided in glibc even when musl doesn't
+  have it. This can be fixed by not looking for inet_net_pton() in libbsd.
+---
+ configure.ac                    | 6 +++++-
+ openbsd-compat/openbsd-compat.h | 4 +++-
+ usr.sbin/smtpd/aliases.c        | 3 +++
+ usr.sbin/smtpd/config.c         | 6 ++++++
+ usr.sbin/smtpd/control.c        | 3 +++
+ usr.sbin/smtpd/envelope.c       | 3 +++
+ usr.sbin/smtpd/forward.c        | 3 +++
+ usr.sbin/smtpd/mail.maildir.c   | 1 +
+ usr.sbin/smtpd/mda.c            | 2 ++
+ usr.sbin/smtpd/mda_variables.c  | 3 +++
+ usr.sbin/smtpd/mta_session.c    | 3 +++
+ usr.sbin/smtpd/parse.y          | 3 +++
+ usr.sbin/smtpd/smtp_session.c   | 2 ++
+ usr.sbin/smtpd/ssl.c            | 6 ++++++
+ usr.sbin/smtpd/table.c          | 3 +++
+ usr.sbin/smtpd/to.c             | 3 +++
+ usr.sbin/smtpd/util.c           | 3 +++
+ 17 files changed, 55 insertions(+), 2 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index c215f3bf..cf6fa675 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -119,6 +119,10 @@ AC_SUBST([MANFMT])
+ #
+ AC_CHECK_HEADERS([ \
+ 	arpa/nameser_compat.h \
++	bsd/stdlib.h \
++	bsd/string.h \
++	bsd/unistd.h \
++	bsd/vis.h \
+ 	crypt.h \
+ 	dirent.h \
+ 	err.h \
+@@ -442,7 +446,7 @@ AC_SEARCH_LIBS([dirname],
+ 	])
+ 
+ AC_SEARCH_LIBS([inet_net_pton],
+-	[resolv bsd],
++	[resolv],
+ 	[
+ 		AC_DEFINE([HAVE_INET_NET_PTON], [1],
+ 			[Define if you have the inet_net_pton() function.])
+diff --git a/openbsd-compat/openbsd-compat.h b/openbsd-compat/openbsd-compat.h
+index dcb643f1..5bebd78b 100644
+--- a/openbsd-compat/openbsd-compat.h
++++ b/openbsd-compat/openbsd-compat.h
+@@ -41,7 +41,9 @@
+ 
+ #include <sys/queue.h>
+ #include <sys/tree.h>
++#ifndef HAVE_BSD_VIS_H
+ #include "bsd-vis.h"
++#endif
+ 
+ #ifdef HAVE_SYS_TIME_H
+ #include <sys/time.h>
+@@ -67,7 +69,7 @@ size_t strlcpy(char *dst, const char *src, size_t size);
+ size_t strlcat(char *dst, const char *src, size_t size);
+ #endif
+ 
+-#ifndef HAVE_STRMODE
++#if !defined(HAVE_STROMODE) && !defined(HAVE_BSD_STRING_H)
+ void strmode(int mode, char *p);
+ #endif
+ 
+diff --git a/usr.sbin/smtpd/aliases.c b/usr.sbin/smtpd/aliases.c
+index 0f8a5c1e..f66d13e4 100644
+--- a/usr.sbin/smtpd/aliases.c
++++ b/usr.sbin/smtpd/aliases.c
+@@ -37,6 +37,9 @@
+ #ifdef HAVE_LIBUTIL_H
+ #include <libutil.h>
+ #endif
++#ifdef HAVE_BSD_LIBUTIL_H
++#include <bsd/libutil.h> /* needed for fparseln */
++#endif
+ 
+ #include "smtpd.h"
+ #include "log.h"
+diff --git a/usr.sbin/smtpd/config.c b/usr.sbin/smtpd/config.c
+index 8fe983d6..e1056b1d 100644
+--- a/usr.sbin/smtpd/config.c
++++ b/usr.sbin/smtpd/config.c
+@@ -30,9 +30,15 @@
+ #include <netdb.h>
+ #include <stdio.h>
+ #include <stdlib.h>
++#ifdef HAVE_BSD_STDLIB_H
++#include <bsd/stdlib.h> /* needed for freezero */
++#endif
+ #include <limits.h>
+ #include <string.h>
+ #include <unistd.h>
++#ifdef HAVE_BSD_UNISTD_H
++#include <bsd/unistd.h> /* needed for setproctitle */
++#endif
+ 
+ #include <openssl/ssl.h>
+ 
+diff --git a/usr.sbin/smtpd/control.c b/usr.sbin/smtpd/control.c
+index dbb2840d..b9f0df88 100644
+--- a/usr.sbin/smtpd/control.c
++++ b/usr.sbin/smtpd/control.c
+@@ -40,6 +40,9 @@
+ #include <string.h>
+ #include <time.h>
+ #include <unistd.h>
++#ifdef HAVE_BSD_UNISTD_H
++#include <bsd/unistd.h> /* needed for getpeereid */
++#endif
+ #include <limits.h>
+ 
+ #include "smtpd.h"
+diff --git a/usr.sbin/smtpd/envelope.c b/usr.sbin/smtpd/envelope.c
+index 35d98b79..0bb45aae 100644
+--- a/usr.sbin/smtpd/envelope.c
++++ b/usr.sbin/smtpd/envelope.c
+@@ -39,6 +39,9 @@
+ #include <limits.h>
+ #include <stdio.h>
+ #include <stdlib.h>
++#ifdef HAVE_BSD_STDLIB_H
++#include <bsd/stdlib.h> /* needed for strtonum */
++#endif
+ #include <string.h>
+ #include <time.h>
+ #include <unistd.h>
+diff --git a/usr.sbin/smtpd/forward.c b/usr.sbin/smtpd/forward.c
+index 7494c6ce..cf8dc6ef 100644
+--- a/usr.sbin/smtpd/forward.c
++++ b/usr.sbin/smtpd/forward.c
+@@ -36,6 +36,9 @@
+ #ifdef HAVE_LIBUTIL_H
+ #include <libutil.h>
+ #endif
++#ifdef HAVE_BSD_LIBUTIL_H
++#include <bsd/libutil.h> /* needed for fparseln */
++#endif
+ #include <unistd.h>
+ #include <limits.h>
+ 
+diff --git a/usr.sbin/smtpd/mail.maildir.c b/usr.sbin/smtpd/mail.maildir.c
+index fe6adba6..1f613b36 100644
+--- a/usr.sbin/smtpd/mail.maildir.c
++++ b/usr.sbin/smtpd/mail.maildir.c
+@@ -34,6 +34,7 @@
+ #include <string.h>
+ #include <time.h>
+ #include <sysexits.h>
++#include <time.h>
+ #include <unistd.h>
+ 
+ #define	MAILADDR_ESCAPE		"!#$%&'*/?^`{|}~"
+diff --git a/usr.sbin/smtpd/mda.c b/usr.sbin/smtpd/mda.c
+index 5e8fec19..9bc31be6 100644
+--- a/usr.sbin/smtpd/mda.c
++++ b/usr.sbin/smtpd/mda.c
+@@ -44,6 +44,8 @@
+ #include <limits.h>
+ #if defined(HAVE_VIS_H) && !defined(BROKEN_STRNVIS)
+ #include <vis.h>
++#elif defined(HAVE_BSD_VIS_H)
++#include <bsd/vis.h> /* needed for strnvis */
+ #else
+ #include "bsd-vis.h"
+ #endif
+diff --git a/usr.sbin/smtpd/mda_variables.c b/usr.sbin/smtpd/mda_variables.c
+index b672e492..10cb1cd0 100644
+--- a/usr.sbin/smtpd/mda_variables.c
++++ b/usr.sbin/smtpd/mda_variables.c
+@@ -29,6 +29,9 @@
+ #include <imsg.h>
+ #include <stdio.h>
+ #include <stdlib.h>
++#ifdef HAVE_BSD_STDLIB_H
++#include <bsd/stdlib.h> /* needed for strtonum */
++#endif
+ #include <string.h>
+ #include <unistd.h>
+ #include <limits.h>
+diff --git a/usr.sbin/smtpd/mta_session.c b/usr.sbin/smtpd/mta_session.c
+index 327502b7..72f8d29b 100644
+--- a/usr.sbin/smtpd/mta_session.c
++++ b/usr.sbin/smtpd/mta_session.c
+@@ -42,6 +42,9 @@
+ #include <signal.h>
+ #include <stdio.h>
+ #include <stdlib.h>
++#ifdef HAVE_BSD_STDLIB_H
++#include <bsd/stdlib.h> /* needed for strtonum */
++#endif
+ #include <string.h>
+ #include <time.h>
+ #include <unistd.h>
+diff --git a/usr.sbin/smtpd/parse.y b/usr.sbin/smtpd/parse.y
+index a82f8206..6510936d 100644
+--- a/usr.sbin/smtpd/parse.y
++++ b/usr.sbin/smtpd/parse.y
+@@ -50,6 +50,9 @@
+ #include <resolv.h>
+ #include <stdio.h>
+ #include <stdlib.h>
++#ifdef HAVE_BSD_STDLIB_H
++#include <bsd/stdlib.h> /* needed for strtonum */
++#endif
+ #include <string.h>
+ #include <syslog.h>
+ #include <unistd.h>
+diff --git a/usr.sbin/smtpd/smtp_session.c b/usr.sbin/smtpd/smtp_session.c
+index e8167fca..8bc877ea 100644
+--- a/usr.sbin/smtpd/smtp_session.c
++++ b/usr.sbin/smtpd/smtp_session.c
+@@ -43,6 +43,8 @@
+ #include <unistd.h>
+ #if defined(HAVE_VIS_H) && !defined(BROKEN_STRNVIS)
+ #include <vis.h>
++#elif defined(HAVE_BSD_VIS_H)
++#include <bsd/vis.h> /* needed for strnvis */
+ #else
+ #include "bsd-vis.h"
+ #endif
+diff --git a/usr.sbin/smtpd/ssl.c b/usr.sbin/smtpd/ssl.c
+index 97f7b1df..1ef692e5 100644
+--- a/usr.sbin/smtpd/ssl.c
++++ b/usr.sbin/smtpd/ssl.c
+@@ -34,7 +34,13 @@
+ #include <pwd.h>
+ #include <stdio.h>
+ #include <stdlib.h>
++#ifdef HAVE_BSD_STDLIB_H
++#include <bsd/stdlib.h> /* needed for freezero */
++#endif
+ #include <string.h>
++#ifdef HAVE_BSD_STRING_H
++#include <bsd/string.h> /* needed for strmode */
++#endif
+ #include <unistd.h>
+ 
+ #include <openssl/ssl.h>
+diff --git a/usr.sbin/smtpd/table.c b/usr.sbin/smtpd/table.c
+index 6d3292ce..ed3ba6d3 100644
+--- a/usr.sbin/smtpd/table.c
++++ b/usr.sbin/smtpd/table.c
+@@ -34,6 +34,9 @@
+ #include <imsg.h>
+ #include <stdio.h>
+ #include <stdlib.h>
++#ifdef HAVE_BSD_STDLIB_H
++#include <bsd/stdlib.h> /* needed for strtonum */
++#endif
+ #include <regex.h>
+ #include <limits.h>
+ #include <string.h>
+diff --git a/usr.sbin/smtpd/to.c b/usr.sbin/smtpd/to.c
+index 81a1bb54..1068b1a9 100644
+--- a/usr.sbin/smtpd/to.c
++++ b/usr.sbin/smtpd/to.c
+@@ -43,6 +43,9 @@
+ #include <stdarg.h>
+ #include <stdio.h>
+ #include <stdlib.h>
++#ifdef HAVE_BSD_STDLIB_H
++#include <bsd/stdlib.h> /* needed for strtonum */
++#endif
+ #include <string.h>
+ #include <time.h>
+ #include <unistd.h>
+diff --git a/usr.sbin/smtpd/util.c b/usr.sbin/smtpd/util.c
+index b2b1458c..7b1b5876 100644
+--- a/usr.sbin/smtpd/util.c
++++ b/usr.sbin/smtpd/util.c
+@@ -47,6 +47,9 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>
++#ifdef HAVE_BSD_STRING_H
++#include <bsd/string.h> /* needed for strmode */
++#endif
+ #include <syslog.h>
+ #include <time.h>
+ #include <unistd.h>

--- a/mail-mta/opensmtpd/files/opensmtpd-6.8.0_p2-strict-prototypes.patch
+++ b/mail-mta/opensmtpd/files/opensmtpd-6.8.0_p2-strict-prototypes.patch
@@ -1,0 +1,74 @@
+https://github.com/OpenSMTPD/OpenSMTPD/pull/1198
+
+From 84331a266b7d8d8e469aea8b85d1e493725807ae Mon Sep 17 00:00:00 2001
+From: orbea <orbea@riseup.net>
+Date: Thu, 13 Apr 2023 11:19:53 -0700
+Subject: [PATCH 1/2] build: Fix -Werror=strict-prototypes
+
+Clang-16 is more strict about these so make the compiler happy.
+---
+ usr.sbin/smtpd/bounce.c | 2 +-
+ usr.sbin/smtpd/ioev.c   | 2 +-
+ usr.sbin/smtpd/mda.c    | 4 ++--
+ usr.sbin/smtpd/smtpd.c  | 2 +-
+ 4 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/usr.sbin/smtpd/bounce.c b/usr.sbin/smtpd/bounce.c
+index bb08f90e..7fb1cf32 100644
+--- a/usr.sbin/smtpd/bounce.c
++++ b/usr.sbin/smtpd/bounce.c
+@@ -243,7 +243,7 @@ bounce_timeout(int fd, short ev, void *arg)
+ }
+ 
+ static void
+-bounce_drain()
++bounce_drain(void)
+ {
+ 	struct bounce_message	*msg;
+ 	struct timeval		 tv;
+diff --git a/usr.sbin/smtpd/ioev.c b/usr.sbin/smtpd/ioev.c
+index 747b3a51..3e3e68f4 100644
+--- a/usr.sbin/smtpd/ioev.c
++++ b/usr.sbin/smtpd/ioev.c
+@@ -228,7 +228,7 @@ io_frame_leave(struct io *io)
+ }
+ 
+ void
+-_io_init()
++_io_init(void)
+ {
+ 	static int init = 0;
+ 
+diff --git a/usr.sbin/smtpd/mda.c b/usr.sbin/smtpd/mda.c
+index 6a28b923..bd963e54 100644
+--- a/usr.sbin/smtpd/mda.c
++++ b/usr.sbin/smtpd/mda.c
+@@ -386,12 +386,12 @@ mda_imsg(struct mproc *p, struct imsg *imsg)
+ }
+ 
+ void
+-mda_postfork()
++mda_postfork(void)
+ {
+ }
+ 
+ void
+-mda_postprivdrop()
++mda_postprivdrop(void)
+ {
+ 	tree_init(&sessions);
+ 	tree_init(&users);
+diff --git a/usr.sbin/smtpd/smtpd.c b/usr.sbin/smtpd/smtpd.c
+index 26078c49..830417e6 100644
+--- a/usr.sbin/smtpd/smtpd.c
++++ b/usr.sbin/smtpd/smtpd.c
+@@ -353,7 +353,7 @@ parent_send_config_dispatcher(void)
+ }
+ 
+ void
+-parent_send_config_lka()
++parent_send_config_lka(void)
+ {
+ 	log_debug("debug: parent_send_config_ruleset: reloading");
+ 	m_compose(p_lka, IMSG_CONF_START, 0, 0, -1, NULL, 0);
+

--- a/mail-mta/opensmtpd/opensmtpd-6.8.0_p2-r3.ebuild
+++ b/mail-mta/opensmtpd/opensmtpd-6.8.0_p2-r3.ebuild
@@ -1,0 +1,91 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools pam systemd toolchain-funcs
+
+DESCRIPTION="Lightweight but featured SMTP daemon from OpenBSD"
+HOMEPAGE="https://www.opensmtpd.org"
+SRC_URI="https://www.opensmtpd.org/archives/${P/_}.tar.gz"
+
+LICENSE="ISC BSD BSD-1 BSD-2 BSD-4"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~riscv ~x86"
+IUSE="berkdb +mta pam split-usr"
+
+# < openssl 3 for bug #881701
+DEPEND="
+	acct-user/smtpd
+	acct-user/smtpq
+	<dev-libs/openssl-3:=
+	elibc_musl? ( sys-libs/fts-standalone )
+	sys-libs/zlib
+	pam? ( sys-libs/pam )
+	berkdb? ( sys-libs/db:= )
+	dev-libs/libevent:=
+	app-misc/ca-certificates
+	net-mail/mailbase
+	net-libs/libasr
+	virtual/libcrypt:=
+	!mail-mta/courier
+	!mail-mta/esmtp
+	!mail-mta/exim
+	!mail-mta/mini-qmail
+	!mail-mta/msmtp[mta]
+	!mail-mta/netqmail
+	!mail-mta/nullmailer
+	!mail-mta/postfix
+	!mail-mta/qmail-ldap
+	!mail-mta/sendmail
+	!mail-mta/ssmtp[mta]
+"
+RDEPEND="${DEPEND}"
+BDEPEND="app-alternatives/yacc"
+
+S=${WORKDIR}/${P/_}
+
+PATCHES=(
+	"${FILESDIR}"/${P}-ar.patch #720782
+	"${FILESDIR}"/${P}-implicit-function-declaration.patch #727260, 896050, 899876
+	"${FILESDIR}"/${P}-strict-prototypes.patch
+)
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_configure() {
+	econf \
+		--sysconfdir=/etc/smtpd \
+		--with-path-mbox=/var/spool/mail \
+		--with-path-empty=/var/empty \
+		--with-path-socket=/run \
+		--with-path-CAfile=/etc/ssl/certs/ca-certificates.crt \
+		--with-user-smtpd=smtpd \
+		--with-user-queue=smtpq \
+		--with-group-queue=smtpq \
+		--with-libevent="$(get_libdir)" \
+		--with-libssl="$(get_libdir)" \
+		$(use_with pam auth-pam) \
+		$(use_with berkdb table-db)
+}
+
+src_install() {
+	default
+	newinitd "${FILESDIR}"/smtpd.initd smtpd
+	systemd_dounit "${FILESDIR}"/smtpd.{service,socket}
+	use pam && newpamd "${FILESDIR}"/smtpd.pam smtpd
+	dosym smtpctl /usr/sbin/makemap
+	dosym smtpctl /usr/sbin/newaliases
+	if use mta ; then
+		dodir /usr/sbin
+		dosym smtpctl /usr/sbin/sendmail
+		# on USE="-split-usr" system sbin and bin are merged
+		# so symlink made above will collide with one below
+		use split-usr && dosym ../sbin/smtpctl /usr/bin/sendmail
+		mkdir -p "${ED}"/usr/$(get_libdir) || die
+		ln -s --relative "${ED}"/usr/sbin/smtpctl "${ED}"/usr/$(get_libdir)/sendmail || die
+	fi
+}


### PR DESCRIPTION
Fixes some build issues:
    
* Build failure on musl systems
* Build failure with clang-16
* Uses `AM_PROG_AR` to find `ar(1)` during configure
* Uses configure arguments to find libevent and libssl on multilib systems.

Closes: https://bugs.gentoo.org/720782
Closes: https://bugs.gentoo.org/727260
Closes: https://bugs.gentoo.org/739876
Closes: https://bugs.gentoo.org/896050
Closes: https://bugs.gentoo.org/899876
Upstream-Issue: https://github.com/OpenSMTPD/OpenSMTPD/issues/1065
Upstream-PR: https://github.com/OpenSMTPD/OpenSMTPD/pull/1195
Upstream-PR: https://github.com/OpenSMTPD/OpenSMTPD/pull/1198
Upstream-PR: https://github.com/OpenSMTPD/OpenSMTPD/pull/1199