### PR TITLE
net-misc/datapipe: EAPI8 bump, use HTTPS

### DIFF
--- a/net-misc/datapipe/datapipe-1.0-r2.ebuild
+++ b/net-misc/datapipe/datapipe-1.0-r2.ebuild
@@ -1,13 +1,14 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
 
 inherit toolchain-funcs
 
-DESCRIPTION="bind a local port and connect it to a remote socket"
-HOMEPAGE="http://http.distributed.net/pub/dcti/unsupported/"
-SRC_URI="ftp://ftp.distributed.net/pub/dcti/unsupported/${P}.tar.gz http://http.distributed.net/pub/dcti/unsupported/${P}.tar.gz"
+DESCRIPTION="Bind a local port and connect it to a remote socket"
+HOMEPAGE="https://http.distributed.net/pub/dcti/unsupported/"
+SRC_URI="ftp://ftp.distributed.net/pub/dcti/unsupported/${P}.tar.gz
+	https://http.distributed.net/pub/dcti/unsupported/${P}.tar.gz"
 
 LICENSE="public-domain"
 SLOT="0"


### PR DESCRIPTION
Another simple `EAPI8` bump.