### PR TITLE
dev-lang/python: Add patch for libressl

### DIFF
--- a/dev-lang/python/files/python-2.7.18-libressl.patch
+++ b/dev-lang/python/files/python-2.7.18-libressl.patch
@@ -1,0 +1,16 @@
+https://bugs.gentoo.org/903001
+https://cvsweb.openbsd.org/cgi-bin/cvsweb/ports/lang/python/2.7/patches/patch-Modules__hashopenssl_c
+
+Index: Modules/_hashopenssl.c
+--- a/Modules/_hashopenssl.c.orig
++++ b/Modules/_hashopenssl.c
+@@ -56,7 +56,8 @@
+ #define _OPENSSL_SUPPORTS_SHA2
+ #endif
+ 
+-#if (OPENSSL_VERSION_NUMBER < 0x10100000L) || defined(LIBRESSL_VERSION_NUMBER)
++#if (OPENSSL_VERSION_NUMBER < 0x10100000L) || \
++    (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x2070000fL)
+ /* OpenSSL < 1.1.0 */
+ #define EVP_MD_CTX_new EVP_MD_CTX_create
+ #define EVP_MD_CTX_free EVP_MD_CTX_destroy

--- a/dev-lang/python/python-2.7.18_p16-r1.ebuild
+++ b/dev-lang/python/python-2.7.18_p16-r1.ebuild
@@ -107,6 +107,7 @@ src_prepare() {
 
 	local PATCHES=(
 		"${WORKDIR}/${PATCHSET}"
+		"${FILESDIR}"/${PN}-2.7.18-libressl.patch #903001
 	)
 
 	default


### PR DESCRIPTION
This fixes the build with libressl >= 2.7.0 where this old hack is no longer required and since python 2.7 is now EOL that leaves Gentoo as the only effective upstream to submit this patch to.

Bug: https://bugs.gentoo.org/903001