### PR TITLE
sys-auth/pam_p11: Add upstream libressl patch

### DIFF
--- a/sys-auth/pam_p11/files/pam_p11-0.3.1-libressl.patch
+++ b/sys-auth/pam_p11/files/pam_p11-0.3.1-libressl.patch
@@ -1,0 +1,28 @@
+https://bugs.gentoo.org/903001
+https://github.com/OpenSC/pam_p11/pull/26
+https://github.com/OpenSC/pam_p11/commit/cb2f0c318c94e30addfce3b432ed91496a43e411
+
+From b307045a93d042ac9e3871e35f8495e8bb201574 Mon Sep 17 00:00:00 2001
+From: orbea <orbea@riseup.net>
+Date: Tue, 11 Apr 2023 07:29:12 -0700
+Subject: [PATCH] match_openssh: Fix the build for LibreSSL >= 3.0.0
+
+Newer LibreSSL versions no longer need the older OpenSSL APIs.
+---
+ src/match_openssh.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/match_openssh.c b/src/match_openssh.c
+index 89cbd73..fb59308 100644
+--- a/src/match_openssh.c
++++ b/src/match_openssh.c
+@@ -22,7 +22,8 @@
+ 
+ #define OPENSSH_LINE_MAX 16384	/* from openssh SSH_MAX_PUBKEY_BYTES */
+ 
+-#if (OPENSSL_VERSION_NUMBER < 0x10100000L) || defined (LIBRESSL_VERSION_NUMBER)
++#if (OPENSSL_VERSION_NUMBER < 0x10100000L) || \
++    (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x3000000L)
+ void RSA_get0_key(const RSA *r,
+                  const BIGNUM **n, const BIGNUM **e, const BIGNUM **d)
+ {

--- a/sys-auth/pam_p11/pam_p11-0.3.1.ebuild
+++ b/sys-auth/pam_p11/pam_p11-0.3.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -19,6 +19,10 @@ RDEPEND="sys-libs/pam
 
 DEPEND="${RDEPEND}"
 BDEPEND="virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}/${P}-libressl.patch" #903001
+)
 
 src_configure() {
 	# Ugly way to work around deprecated declarations in openssl-3


### PR DESCRIPTION
This patch was accepted upstream and fixes the build with libressl >= 3.0.0.

Bug: https://bugs.gentoo.org/903001
Upstream-PR: https://github.com/OpenSC/pam_p11/pull/26
Upstream-Commit: https://github.com/OpenSC/pam_p11/commit/cb2f0c318c94e30addfce3b432ed91496a43e411