### PR TITLE
dev-haskell/data-default-class, dev-haskell/setlocale: fix profile USE flag

### DIFF
--- a/dev-haskell/data-default-class/data-default-class-0.1.2.0.ebuild
+++ b/dev-haskell/data-default-class/data-default-class-0.1.2.0.ebuild
@@ -17,7 +17,7 @@ SLOT="0/${PV}"
 KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
 IUSE=""
 
-RDEPEND=">=dev-lang/ghc-7.4.1:=
+RDEPEND=">=dev-lang/ghc-7.4.1:=[profile?]
 "
 DEPEND="${RDEPEND}
 	>=dev-haskell/cabal-1.6

--- a/dev-haskell/setlocale/setlocale-1.0.0.9.ebuild
+++ b/dev-haskell/setlocale/setlocale-1.0.0.9.ebuild
@@ -17,7 +17,7 @@ SLOT="0/${PV}"
 KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
-RDEPEND=">=dev-lang/ghc-7.6.1:=
+RDEPEND=">=dev-lang/ghc-7.6.1:=[profile?]
 "
 DEPEND="${RDEPEND}
 	>=dev-haskell/cabal-1.16.0


### PR DESCRIPTION
When building either one of those packages with the profile USE flag, the GHC also needs to be built with profile USE flag.

Closes: https://bugs.gentoo.org/905132
Closes: https://bugs.gentoo.org/905133