### PR TITLE
dev-lang/crystal: bump LLVM_MAX_SLOT to 15 for >=1.8.0

### DIFF
--- a/dev-lang/crystal/crystal-1.8.0-r1.ebuild
+++ b/dev-lang/crystal/crystal-1.8.0-r1.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 BV=${PV}-1
 BV_AMD64=${BV}-linux-x86_64
-LLVM_MAX_SLOT=14
+LLVM_MAX_SLOT=15
 
 inherit bash-completion-r1 llvm multiprocessing toolchain-funcs
 

--- a/dev-lang/crystal/crystal-1.8.1-r1.ebuild
+++ b/dev-lang/crystal/crystal-1.8.1-r1.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 BV=${PV}-1
 BV_AMD64=${BV}-linux-x86_64
-LLVM_MAX_SLOT=14
+LLVM_MAX_SLOT=15
 
 inherit bash-completion-r1 llvm multiprocessing toolchain-funcs
 


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/905160