### PR TITLE
sys-apps/chname: EAPI8 bump

### DIFF
--- a/sys-apps/chname/chname-1.1-r1.ebuild
+++ b/sys-apps/chname/chname-1.1-r1.ebuild
@@ -1,0 +1,30 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs
+
+DESCRIPTION="Run a command with a new system hostname"
+HOMEPAGE="https://github.com/marineam/chname"
+SRC_URI="https://github.com/marineam/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+DEPEND=">=sys-kernel/linux-headers-2.6.16"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-flags.patch
+)
+
+src_configure() {
+	tc-export CC
+}
+
+src_install() {
+	dobin "${PN}"
+	doman "${PN}.1"
+	dodoc README*
+}


### PR DESCRIPTION
Simple `EAPI8` bump

```diff
--- chname-1.1.ebuild	2023-04-01 17:48:26.701943991 +0200
+++ chname-1.1-r1.ebuild	2023-04-27 18:38:58.994406729 +0200
@@ -1,7 +1,7 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="6"
+EAPI=8
 
 inherit toolchain-funcs
 
@@ -11,11 +11,9 @@
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 x86"
-IUSE=""
+KEYWORDS="~amd64 ~x86"
 
 DEPEND=">=sys-kernel/linux-headers-2.6.16"
-RDEPEND=""
 
 PATCHES=(
 	"${FILESDIR}"/${P}-flags.patch
```