### PR TITLE
sys-devel/binutils-apple: fix build on macOS 13, including ARM64.

### DIFF
--- a/sys-devel/binutils-apple/binutils-apple-8.2.1-r101.ebuild
+++ b/sys-devel/binutils-apple/binutils-apple-8.2.1-r101.ebuild
@@ -27,6 +27,9 @@ S="${WORKDIR}/darwin-xtools-gentoo-${PVR}"
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-8.2.1-macos-12.patch
+	"${FILESDIR}"/${PN}-8.2.1-macos-13.patch
+	"${FILESDIR}"/${PN}-8.2.1-arm64.patch
+	"${FILESDIR}"/${PN}-8.2.1-fix-ar-crash.patch
 )
 
 src_configure() {

--- a/sys-devel/binutils-apple/files/binutils-apple-8.2.1-arm64.patch
+++ b/sys-devel/binutils-apple/files/binutils-apple-8.2.1-arm64.patch
@@ -1,0 +1,86 @@
+https://github.com/grobian/darwin-xtools/commit/e67225380b32c77cd6ae2e89a746739eb62d921d
+
+From e67225380b32c77cd6ae2e89a746739eb62d921d Mon Sep 17 00:00:00 2001
+From: Fabian Groffen <grobian@gentoo.org>
+Date: Wed, 8 Jun 2022 20:35:59 +0200
+Subject: [PATCH] [ld64] fix compilation on arm64
+
+Signed-off-by: Fabian Groffen <grobian@gentoo.org>
+---
+ ld64/src/ld/InputFiles.cpp                  |  2 +
+ ld64/src/ld/parsers/libunwind/Registers.hpp | 49 +++++++++++++++++++++
+ 2 files changed, 51 insertions(+)
+
+diff --git a/ld64/src/ld/InputFiles.cpp b/ld64/src/ld/InputFiles.cpp
+index 5d5a968..10ba632 100644
+--- a/ld64/src/ld/InputFiles.cpp
++++ b/ld64/src/ld/InputFiles.cpp
+@@ -908,6 +908,8 @@ void InputFiles::inferArchitecture(Options& opts, const char** archName)
+ 	opts.setArchitecture(CPU_TYPE_X86_64, CPU_SUBTYPE_X86_64_ALL, Options::kPlatformOSX);
+ #elif __arm__
+ 	opts.setArchitecture(CPU_TYPE_ARM, CPU_SUBTYPE_ARM_V6, Options::kPlatformOSX);
++#elif __arm64__
++	opts.setArchitecture(CPU_TYPE_ARM64, CPU_SUBTYPE_ARM64_ALL, Options::kPlatformOSX);
+ #else
+ 	#error unknown default architecture
+ #endif
+diff --git a/ld64/src/ld/parsers/libunwind/Registers.hpp b/ld64/src/ld/parsers/libunwind/Registers.hpp
+index ceacc28..c111947 100644
+--- a/ld64/src/ld/parsers/libunwind/Registers.hpp
++++ b/ld64/src/ld/parsers/libunwind/Registers.hpp
+@@ -43,6 +43,55 @@
+ namespace libunwind {
+ 
+ 
++#ifndef i386_thread_state_t
++struct _i386_thread_state_t
++{
++    unsigned int	__eax;
++    unsigned int	__ebx;
++    unsigned int	__ecx;
++    unsigned int	__edx;
++    unsigned int	__edi;
++    unsigned int	__esi;
++    unsigned int	__ebp;
++    unsigned int	__esp;
++    unsigned int	__ss;
++    unsigned int	__eflags;
++    unsigned int	__eip;
++    unsigned int	__cs;
++    unsigned int	__ds;
++    unsigned int	__es;
++    unsigned int	__fs;
++    unsigned int	__gs;
++};
++#define i386_thread_state_t _i386_thread_state_t
++#endif
++#ifndef x86_thread_state64_t
++struct _x86_thread_state64_t
++{
++	__uint64_t	__rax;
++	__uint64_t	__rbx;
++	__uint64_t	__rcx;
++	__uint64_t	__rdx;
++	__uint64_t	__rdi;
++	__uint64_t	__rsi;
++	__uint64_t	__rbp;
++	__uint64_t	__rsp;
++	__uint64_t	__r8;
++	__uint64_t	__r9;
++	__uint64_t	__r10;
++	__uint64_t	__r11;
++	__uint64_t	__r12;
++	__uint64_t	__r13;
++	__uint64_t	__r14;
++	__uint64_t	__r15;
++	__uint64_t	__rip;
++	__uint64_t	__rflags;
++	__uint64_t	__cs;
++	__uint64_t	__fs;
++	__uint64_t	__gs;
++};
++#define x86_thread_state64_t _x86_thread_state64_t
++#endif
+ ///
+ /// Registers_x86 holds the register state of a thread in a 32-bit intel process.  
+ ///

--- a/sys-devel/binutils-apple/files/binutils-apple-8.2.1-fix-ar-crash.patch
+++ b/sys-devel/binutils-apple/files/binutils-apple-8.2.1-fix-ar-crash.patch
@@ -1,0 +1,60 @@
+https://github.com/iains/darwin-xtools/pull/8
+
+From 86d77719693861fc8fa9c584dee36adaac5f883a Mon Sep 17 00:00:00 2001
+From: Yifeng Li <tomli@tomli.me>
+Date: Tue, 25 Apr 2023 21:41:01 +0000
+Subject: [PATCH] [cctools] fix ar(1) crash without argument, closes #7.
+
+In ar(1), strcmp() checks are used to determine the value
+of argument argv[1], even when no argument is given. In the
+past, they were possibly harmless out-of-bound reads and
+comparison with garbage, without consequences.
+
+However, running it on macOS 13 w/ Apple Silicon immediately
+crashes it with Segmentation Fault, because argv[1] is now
+NULL and generates EXC_BAD_ACCESS in strcmp().
+
+This commit checks whether argc is equal or greater than 2
+before doing strcmp().
+
+$ ./bin/ar
+Segmentation fault: 11
+
+* thread #1, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=1, address=0x0)
+    frame #0: 0x0000000193181460 libsystem_platform.dylib`_platform_strcmp + 144
+libsystem_platform.dylib`:
+->  0x193181460 <+144>: ldr    q0, [x0], #0x10
+    0x193181464 <+148>: ldr    q1, [x1], #0x10
+    0x193181468 <+152>: cmeq.16b v1, v0, v1
+    0x19318146c <+156>: and.16b v0, v0, v1
+Target 0: (ar) stopped.
+(lldb) bt
+* thread #1, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=1, address=0x0)
+  * frame #0: 0x0000000193181460 libsystem_platform.dylib`_platform_strcmp + 144
+    frame #1: 0x0000000100006440 ar`main(argc=1, argv=0x000000016fdfef58) at ar.c:126:8
+    frame #2: 0x0000000192e2be50 dyld`start + 2544
+
+Signed-off-by: Yifeng Li <tomli@tomli.me>
+---
+ cctools/ar/ar.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/cctools/ar/ar.c b/cctools/ar/ar.c
+index 90ed570..b010b02 100644
+--- a/cctools/ar/ar.c
++++ b/cctools/ar/ar.c
+@@ -123,12 +123,12 @@ main(argc, argv)
+ 	run_ranlib = 1;
+ 
+ 	if (argc < 3) {
+-	   if(strcmp(argv[1], "--version") == 0){
++	   if(argc >= 2 && strcmp(argv[1], "--version") == 0){
+ 		/* Implement a gnu-style --version to be friendly to GCC.  */
+ 		fprintf(stdout, "xtools-%s ar %s\nBased on Apple Inc. %s\n",
+ 		        xtools_version, package_version, apple_version);
+ 		exit(0);
+-	   } else if(strcmp(argv[1], "--help") == 0){
++	   } else if(argc >= 2 && strcmp(argv[1], "--help") == 0){
+ 		usage(0);
+ 		fprintf(stdout, "Please report bugs to %s\n", support_url);
+ 		exit(0);

--- a/sys-devel/binutils-apple/files/binutils-apple-8.2.1-macos-13.patch
+++ b/sys-devel/binutils-apple/files/binutils-apple-8.2.1-macos-13.patch
@@ -1,0 +1,51 @@
+https://bugs.gentoo.org/905131
+https://github.com/grobian/darwin-xtools/pull/1
+
+From 58967cfac9ab9c39d5c6988624bdd6a5c986537e Mon Sep 17 00:00:00 2001
+From: Yifeng Li <tomli@tomli.me>
+Date: Mon, 24 Apr 2023 18:58:54 +0000
+Subject: [PATCH] [cctools] don't include objc-runtime.h in print_objc.c and
+ print_bitcode.c.
+
+On macOS 13, Gentoo Prefix fails to compile cctools due to
+missing Blocks support in GCC, creating the following error:
+
+/Users/ec2-user/gentoo/MacOSX.sdk/usr/include/objc/runtime.h:373:29: error: expected ')' before '^' token
+  373 |                       void (^ _Nonnull block)(Class _Nonnull aClass, BOOL * _Nonnull stop)
+      |                             ^
+      |                             )
+
+Fortunately the header objc-runtime.h is not strictly necessary.
+As a workaround, stop including objc-runtime.h in print_objc.c
+and print_bitcode.c.
+
+Signed-off-by: Yifeng Li <tomli@tomli.me>
+---
+ cctools/otool/print_bitcode.c | 1 -
+ cctools/otool/print_objc.c    | 1 -
+ 2 files changed, 2 deletions(-)
+
+diff --git a/cctools/otool/print_bitcode.c b/cctools/otool/print_bitcode.c
+index cc54c57..617a142 100644
+--- a/cctools/otool/print_bitcode.c
++++ b/cctools/otool/print_bitcode.c
+@@ -38,7 +38,6 @@
+ #include <dlfcn.h>
+ #include <xar/xar.h>
+ #include "mach-o/loader.h"
+-#include "objc/objc-runtime.h"
+ #include "stuff/allocate.h"
+ #include "stuff/bytesex.h"
+ #include "stuff/symbol.h"
+diff --git a/cctools/otool/print_objc.c b/cctools/otool/print_objc.c
+index a1605e8..2018bd1 100644
+--- a/cctools/otool/print_objc.c
++++ b/cctools/otool/print_objc.c
+@@ -31,7 +31,6 @@
+ #include "stdio.h"
+ #include "string.h"
+ #include "mach-o/loader.h"
+-#include "objc/objc-runtime.h"
+ #include "stuff/allocate.h"
+ #include "stuff/bytesex.h"
+ #include "stuff/symbol.h"


### PR DESCRIPTION
This commits introduces three patches to fix build on macOS 13 (Intel), and also on ARM64 (Apple Silicon).

1. On macOS 13, Gentoo Prefix fails to compile cctools due to missing Blocks support in GCC, creating the following error:

```
/Users/ec2-user/gentoo/MacOSX.sdk/usr/include/objc/runtime.h:373:29: error: expected ')' before '^' token
  373 |                       void (^ _Nonnull block)(Class _Nonnull aClass, BOOL * _Nonnull stop)
      |                             ^
      |                             )
```

Fortunately the header objc-runtime.h is not strictly necessary. As a workaround, stop including objc-runtime.h in print_objc.c and print_bitcode.c.

2. In ar(1), strcmp() checks are used to determine the value of argument argv[1], even when no argument is given. In the past, they were possibly harmless out-of-bound reads and comparison with garbage, without consequences.

However, running it on macOS 13 w/ Apple Silicon immediately crashes it with Segmentation Fault, because argv[1] is now NULL and generates EXC_BAD_ACCESS in strcmp().

```
$ ./bin/ar
Segmentation fault: 11
```

This commit checks whether argc is equal or greater than 2 before doing strcmp(). No revbump is needed since the package couldn't be built on ARM64 before.

3. Fabian Groffen's downstream patch "fix compilation on arm64", which adds missing CPU register definitions.

Closes: 905131