### PR TITLE
net-voip/murmur: Fix default config and OpenRC files

### DIFF
--- a/net-voip/mumble/mumble-9999.ebuild
+++ b/net-voip/mumble/mumble-9999.ebuild
@@ -16,6 +16,7 @@ if [[ "${PV}" == 9999 ]] ; then
 	# even if these components may not be compiled in
 	EGIT_SUBMODULES=(
 		'-*'
+		3rdparty/cmake-compiler-flags
 		3rdparty/FindPythonInterpreter
 		3rdparty/gsl
 		3rdparty/minhook

--- a/net-voip/murmur/files/murmur.confd-r2
+++ b/net-voip/murmur/files/murmur.confd-r2
@@ -1,0 +1,9 @@
+# where to look for the config file
+MURMUR_CONF=/etc/murmur/mumble-server.ini
+
+# run as this user
+MURMUR_USER=murmur
+
+# HOME directory of MURMUR_USER
+MURMUR_HOME=/var/lib/murmur
+

--- a/net-voip/murmur/murmur-1.4.287-r2.ebuild
+++ b/net-voip/murmur/murmur-1.4.287-r2.ebuild
@@ -1,0 +1,200 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit cmake flag-o-matic systemd readme.gentoo-r1 tmpfiles
+
+DESCRIPTION="Mumble is an open source, low-latency, high quality voice chat software"
+HOMEPAGE="https://wiki.mumble.info"
+if [[ "${PV}" == 9999 ]] ; then
+	inherit git-r3
+	EGIT_REPO_URI="https://github.com/mumble-voip/mumble.git"
+	EGIT_SUBMODULES=( '-*' )
+else
+	MY_PN="mumble"
+	if [[ "${PV}" == *_pre* ]] ; then
+		MY_P="${MY_PN}-${PV}"
+		SRC_URI="https://dev.gentoo.org/~concord/distfiles/${MY_P}.tar.xz"
+		S="${WORKDIR}/${MY_P}"
+	else
+		MY_PV="${PV/_/-}"
+		MY_P="${MY_PN}-${MY_PV}"
+		SRC_URI="https://github.com/mumble-voip/mumble/releases/download/v${MY_PV}/${MY_P}.tar.gz
+			https://dl.mumble.info/${MY_P}.tar.gz"
+		S="${WORKDIR}/${MY_P}.src"
+	fi
+	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
+fi
+
+SRC_URI+=" https://dev.gentoo.org/~concord/distfiles/mumble-1.4-openssl3.patch.xz"
+SRC_URI+=" https://dev.gentoo.org/~concord/distfiles/mumble-1.4-crypto-threads.patch.xz"
+SRC_URI+=" https://dev.gentoo.org/~concord/distfiles/mumble-1.4-odr.patch.xz"
+
+LICENSE="BSD"
+SLOT="0"
+IUSE="+dbus grpc +ice test zeroconf"
+RESTRICT="!test? ( test )"
+
+RDEPEND="
+	acct-group/murmur
+	acct-user/murmur
+	>=dev-libs/openssl-1.0.0b:0=
+	>=dev-libs/protobuf-2.2.0:=
+	dev-qt/qtcore:5
+	dev-qt/qtnetwork:5[ssl]
+	|| (
+		dev-qt/qtsql:5[sqlite]
+		dev-qt/qtsql:5[mysql]
+	)
+	dev-qt/qtxml:5
+	sys-apps/lsb-release
+	>=sys-libs/libcap-2.15
+	dbus? ( dev-qt/qtdbus:5 )
+	grpc? ( net-libs/grpc )
+	ice? ( dev-libs/Ice:= )
+	zeroconf? ( net-dns/avahi[mdnsresponder-compat] )
+"
+
+DEPEND="${RDEPEND}
+	dev-libs/boost
+	dev-qt/qttest:5
+"
+BDEPEND="
+	acct-group/murmur
+	acct-user/murmur
+	virtual/pkgconfig
+"
+
+if [[ "${PV}" == *9999 ]] ; then
+	# Required for the mkini.sh script which calls perl multiple times
+	BDEPEND+="
+		dev-lang/perl
+	"
+fi
+
+DOC_CONTENTS="
+	Useful scripts are located in /usr/share/doc/${PF}/scripts.
+	The defualt 'SuperUser' password will be written into the log file
+	when starting murmur for the first time.
+	If you want to set it yourself, please execute:
+	su murmur -s /bin/bash -c 'mumble-server -ini /etc/murmur/murmur.ini -supw <pw>'
+	to set the build-in 'SuperUser' password before starting murmur.
+	Please restart dbus before starting murmur, or else dbus
+	registration will fail.
+"
+
+PATCHES=(
+	"${WORKDIR}/mumble-1.4-openssl3.patch"
+	"${WORKDIR}/mumble-1.4-crypto-threads.patch"
+	"${WORKDIR}/mumble-1.4-odr.patch"
+)
+
+src_prepare() {
+	if [[ "${PV}" == *9999 ]] ; then
+		pushd scripts &>/dev/null || die
+		./mkini.sh || die
+		popd &>/dev/null || die
+	fi
+
+	# Change dbus user from mumble-server to murmur
+	sed \
+		-e 's:mumble-server:murmur:g' \
+		-i "${S}"/scripts/murmur.conf || die
+
+	# Adjust default server settings to be correct for our default setup
+	sed \
+		-e 's:database=:database=/var/lib/murmur/database.sqlite:' \
+		-e 's:;logfile=murmur.log:logfile=/var/log/murmur/murmur.log:' \
+		-e 's:;pidfile=:pidfile=/run/murmur/murmur.pid:' \
+		-i "${S}"/scripts/murmur.ini || die
+
+	# Adjust systemd service file to our config location #689208
+	sed \
+		-e "s@/etc/${PN}\.ini@/etc/${PN}/${PN}.ini@" \
+		-e "s@murmurd@mumble-server@" \
+		-i scripts/${PN}.service || die
+
+	cmake_src_prepare
+}
+
+src_configure() {
+	myuse() {
+		[[ -n "${1}" ]] || die "myconf: No use flag given."
+		use ${1} || echo "no-${1}"
+	}
+	local mycmakeargs=(
+		-DBUILD_TESTING="$(usex test)"
+		-Dclient="OFF"
+		-Ddbus="$(usex dbus)"
+		-Dg15="OFF"
+		-Dgrpc="$(usex grpc)"
+		-Dice="$(usex ice)"
+		-Doverlay="OFF"
+		-Dserver="ON"
+		-Dzeroconf="$(usex zeroconf)"
+	)
+	if [[ "${PV}" != 9999 ]] ; then
+		mycmakeargs+=( -DBUILD_NUMBER="$(ver_cut 3)" )
+	fi
+
+	# https://bugs.gentoo.org/832978
+	# fix tests (and possibly runtime issues) on arches with unsigned chars
+	append-cxxflags -fsigned-char
+
+	cmake_src_configure
+}
+
+src_install() {
+	cmake_src_install
+
+	dodoc README.md CHANGES
+
+	docinto scripts
+	dodoc -r scripts/server
+	docompress -x /usr/share/doc/${PF}/scripts
+
+	local etcdir="/etc/murmur"
+	insinto ${etcdir}
+	doins scripts/${PN}.ini
+
+	insinto /etc/logrotate.d/
+	newins "${FILESDIR}"/murmur.logrotate murmur
+
+	insinto /etc/dbus-1/system.d/
+	doins scripts/murmur.conf
+
+	insinto /usr/share/murmur/
+	doins src/murmur/Murmur.ice
+
+	# Copy over the initd file so we can modify it incase zeroconf support is on.
+	cp "${FILESDIR}"/murmur.initd-r2 "${T}"/murmur.initd
+
+	if use zeroconf; then
+		sed -e 's:need:need avahi-daemon:' -i "${T}"/murmur.initd || die
+	fi
+
+	newinitd "${T}"/murmur.initd murmur
+	newconfd "${FILESDIR}"/murmur.confd murmur
+
+	systemd_dounit scripts/${PN}.service
+	newtmpfiles "${FILESDIR}"/murmurd-dbus.tmpfiles "${PN}".conf
+
+	keepdir /var/lib/murmur /var/log/murmur
+	fowners -R murmur /var/lib/murmur /var/log/murmur
+	fperms 750 /var/lib/murmur /var/log/murmur
+
+	# Fix permissions on config file as it might contain passwords.
+	# (bug #559362)
+	fowners root:murmur ${etcdir}/murmur.ini
+	fperms 640 ${etcdir}/murmur.ini
+
+	doman man/mumble-server.1
+
+	readme.gentoo_create_doc
+}
+
+pkg_postinst() {
+	tmpfiles_process ${PN}.conf
+	readme.gentoo_print_elog
+}

--- a/net-voip/murmur/murmur-9999.ebuild
+++ b/net-voip/murmur/murmur-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -10,7 +10,20 @@ HOMEPAGE="https://wiki.mumble.info"
 if [[ "${PV}" == 9999 ]] ; then
 	inherit git-r3
 	EGIT_REPO_URI="https://github.com/mumble-voip/mumble.git"
-	EGIT_SUBMODULES=( '-*' 3rdparty/FindPythonInterpreter 3rdparty/gsl 3rdparty/tracy )
+
+	# needed for the included 3rdparty license script,
+	# even if these components may not be compiled in
+	EGIT_SUBMODULES=(
+		'-*'
+		3rdparty/cmake-compiler-flags
+		3rdparty/FindPythonInterpreter
+		3rdparty/gsl
+		3rdparty/minhook
+		3rdparty/opus
+		3rdparty/rnnoise-src
+		3rdparty/speexdsp
+		3rdparty/tracy
+	)
 else
 	MY_PN="mumble"
 	if [[ "${PV}" == *_pre* ]] ; then
@@ -29,7 +42,7 @@ fi
 
 LICENSE="BSD"
 SLOT="0"
-IUSE="+dbus grpc +ice test zeroconf"
+IUSE="+ice test zeroconf"
 RESTRICT="!test? ( test )"
 
 RDEPEND="
@@ -38,6 +51,7 @@ RDEPEND="
 	>=dev-libs/openssl-1.0.0b:0=
 	>=dev-libs/protobuf-2.2.0:=
 	dev-qt/qtcore:5
+	dev-qt/qtdbus:5
 	dev-qt/qtnetwork:5[ssl]
 	|| (
 		dev-qt/qtsql:5[sqlite]
@@ -46,8 +60,6 @@ RDEPEND="
 	dev-qt/qtxml:5
 	sys-apps/lsb-release
 	>=sys-libs/libcap-2.15
-	dbus? ( dev-qt/qtdbus:5 )
-	grpc? ( net-libs/grpc )
 	ice? ( dev-libs/Ice:= )
 	zeroconf? ( net-dns/avahi[mdnsresponder-compat] )
 "
@@ -62,58 +74,43 @@ BDEPEND="
 	virtual/pkgconfig
 "
 
-if [[ "${PV}" == *9999 ]] ; then
-	# Required for the mkini.sh script which calls perl multiple times
-	BDEPEND+="
-		dev-lang/perl
-	"
-fi
-
+DISABLE_AUTOFORMATTING="yes"
 DOC_CONTENTS="
-	Useful scripts are located in /usr/share/doc/${PF}/scripts.\n
-	Please execute:\n
-	murmurd -ini /etc/murmur/murmur.ini -supw <pw>\n
-	chown murmur:murmur /var/lib/murmur/murmur.sqlite\n
-	to set the build-in 'SuperUser' password before starting murmur.
-	Please restart dbus before starting murmur, or else dbus
-	registration will fail.
+The default 'SuperUser' password will be written into the log file
+when starting murmur for the first time.
+
+If you want to manually set a password yourself, please execute:
+su murmur -s /bin/bash -c 'mumble-server -ini /etc/murmur/mumble-server.ini -supw <pw>'
+
+This will set the built-in 'SuperUser' password to '<pw>' when starting murmur.
 "
 
 src_prepare() {
-	if [[ "${PV}" == *9999 ]] ; then
-		pushd scripts &>/dev/null || die
-		./mkini.sh || die
-		popd &>/dev/null || die
-	fi
-
+	# Adjust default server settings to be correct for our default setup
 	sed \
-		-e 's:mumble-server:murmur:g' \
-		-e 's:/var/run:/run:g' \
-		-i "${S}"/scripts/murmur.{conf,ini} || die
+		-e 's:database=:database=/var/lib/murmur/database.sqlite:' \
+		-e 's:;logfile=mumble-server.log:logfile=/var/log/murmur/murmur.log:' \
+		-e 's:;pidfile=:pidfile=/run/murmur/murmur.pid:' \
+		-i auxiliary_files/mumble-server.ini || die
 
-	# Adjust systemd service file to our config location #689208
-	sed \
-		-e "s@/etc/${PN}\.ini@/etc/${PN}/${PN}.ini@" \
-		-e "s@murmurd@mumble-server@" \
-		-i scripts/${PN}.service || die
+	# Replace the default group and user _mumble-server with murmur
+	grep -r -l _mumble-server auxiliary_files/ | xargs sed -i 's/_mumble-server/murmur/g' || die
 
 	cmake_src_prepare
 }
 
 src_configure() {
-	myuse() {
-		[[ -n "${1}" ]] || die "myconf: No use flag given."
-		use ${1} || echo "no-${1}"
-	}
 	local mycmakeargs=(
 		-DBUILD_TESTING="$(usex test)"
 		-Dclient="OFF"
-		-Ddbus="$(usex dbus)"
 		-Dg15="OFF"
-		-Dgrpc="$(usex grpc)"
 		-Dice="$(usex ice)"
+		-DMUMBLE_INSTALL_SYSCONFDIR="/etc/murmur"
 		-Doverlay="OFF"
 		-Dserver="ON"
+		-DMUMBLE_INSTALL_SERVICEFILEDIR=$(systemd_get_systemunitdir)
+		-DMUMBLE_INSTALL_SYSUSERSDIR=$(systemd_get_userunitdir)
+		-DMUMBLE_INSTALL_TMPFILESDIR="/usr/lib/tmpfiles.d"
 		-Dzeroconf="$(usex zeroconf)"
 	)
 	if [[ "${PV}" != 9999 ]] ; then
@@ -132,44 +129,32 @@ src_install() {
 
 	dodoc README.md
 
-	docinto scripts
-	dodoc -r scripts/server
-	docompress -x /usr/share/doc/${PF}/scripts
-
-	local etcdir="/etc/murmur"
-	insinto ${etcdir}
-	doins scripts/${PN}.ini
-
 	insinto /etc/logrotate.d/
 	newins "${FILESDIR}"/murmur.logrotate murmur
 
-	insinto /etc/dbus-1/system.d/
-	doins scripts/murmur.conf
+	# Copy over the initd file so we can modify it incase zeroconf support is on.
+	cp "${FILESDIR}"/murmur.initd-r2 "${T}"/murmur.initd || die
 
-	insinto /usr/share/murmur/
-	doins src/murmur/Murmur.ice
+	if use zeroconf; then
+		sed -e 's:need:need avahi-daemon:' -i "${T}"/murmur.initd || die
+	fi
 
-	newinitd "${FILESDIR}"/murmur.initd-r2 murmur
-	newconfd "${FILESDIR}"/murmur.confd murmur
-
-	systemd_dounit scripts/${PN}.service
-	newtmpfiles "${FILESDIR}"/murmurd-dbus.tmpfiles "${PN}".conf
+	newinitd "${T}"/murmur.initd murmur
+	newconfd "${FILESDIR}"/murmur.confd-r2 murmur
 
 	keepdir /var/lib/murmur /var/log/murmur
 	fowners -R murmur /var/lib/murmur /var/log/murmur
 	fperms 750 /var/lib/murmur /var/log/murmur
 
-	# Fix permissions on config file as it might contain passwords.
-	# (bug #559362)
-	fowners root:murmur ${etcdir}/murmur.ini
-	fperms 640 ${etcdir}/murmur.ini
-
-	newman man/mumble-server.1 murmurd.1
-
 	readme.gentoo_create_doc
 }
 
 pkg_postinst() {
-	tmpfiles_process ${PN}.conf
+	tmpfiles_process mumble-server.conf
 	readme.gentoo_print_elog
+
+	if use zeroconf; then
+		elog "To turn on the zeroconf functionality, you need to uncomment and"
+		elog "change the 'bonjour=false' setting in mumble-server.ini to 'true'"
+	fi
 }


### PR DESCRIPTION
@0xC0ncord I've done the fixes that I pointed out in https://github.com/gentoo/gentoo/pull/29194

I was going to also update the live ebuild, but I noticed that they have revamped how they do the config files.
There is no `mkini.sh` script anymore and they moved most config things to the `auxiliary_files/` directory.
In addition to this, it seems like the systemd files are not handled by cmake.

So I didn't want to do a update for that without consulting you first.
What are your plans for murmur/mumble >=1.5.0?
On the server side, seems like they have done a lot of cleanup so now there is no trace left of "murmur" anymore and everything seem to be "mumble-server" now. (At least in the config files and server service names)