### PR TITLE
net-fs/nfs-utils: add dev-db/sqlite and dev-libs/libevent to COMMON_DEPENDS

### DIFF
--- a/net-fs/nfs-utils/nfs-utils-2.6.3.ebuild
+++ b/net-fs/nfs-utils/nfs-utils-2.6.3.ebuild
@@ -33,6 +33,8 @@ COMMON_DEPEND="
 	net-libs/libtirpc:=
 	>=net-nds/rpcbind-0.2.4
 	sys-fs/e2fsprogs
+	dev-db/sqlite:3
+	dev-libs/libevent:=
 	caps? ( sys-libs/libcap )
 	ldap? (
 		net-nds/openldap:=
@@ -43,8 +45,6 @@ COMMON_DEPEND="
 	)
 	libmount? ( sys-apps/util-linux )
 	nfsv4? (
-		dev-db/sqlite:3
-		dev-libs/libevent:=
 		>=sys-apps/keyutils-1.5.9:=
 		kerberos? (
 			>=net-libs/libtirpc-0.2.4-r1[kerberos]
@@ -126,6 +126,7 @@ src_configure() {
 		$(use_enable nfsv41)
 		$(use_enable uuid)
 		$(use_with tcpd tcp-wrappers)
+		LIBS="-lsqlite3 -levent_core"
 	)
 	econf "${myeconfargs[@]}"
 }


### PR DESCRIPTION
Because of new nfs-utils component fsidd, when nfsv4 IUSE flag is disabled net-fs/nfs-utils-6.2.3 still needs dev-db/sqlite and dev-libs/libevent as dependencies:

USE='-nfsv4' emerge -av =nfs-utils-2.6.3::gentoo

make[2]: Entering directory '/var/tmp/portage/net-fs/nfs-utils-2.6.3/work/nfs-utils-2.6.3/support/reexport'
x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I../../support/include  -I/usr/include/tirpc  -D_GNU_SOURCE -I../../support/include -D_GNU_SOURCE -Wall  -Wextra  -Werror=strict-prototypes  -fno-strict-aliasing  -O2 -pipe -c -o fsidd-fsidd.o `test -f 'fsidd.c' || echo './'`fsidd.c
x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I../../support/include  -I/usr/include/tirpc  -D_GNU_SOURCE -I../../support/include -D_GNU_SOURCE -Wall  -Wextra  -Werror=strict-prototypes  -fno-strict-aliasing  -O2 -pipe -c -o fsidd-backend_sqlite.o `test -f 'backend_sqlite.c' || echo './'`backend_sqlite.c
x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I../../support/include  -I/usr/include/tirpc  -D_GNU_SOURCE -Wall  -Wextra  -Werror=strict-prototypes  -fno-strict-aliasing  -O2 -pipe -c -o reexport.o reexport.c
backend_sqlite.c:5:10: fatal error: sqlite3.h: No such file or directory
    5 | #include <sqlite3.h>
      |          ^~~~~~~~~~~
compilation terminated.
fsidd.c:7:10: fatal error: event2/event.h: No such file or directory
    7 | #include <event2/event.h>


Moreover another econf argument should be added to myeconfargs list to point libraries for linker:

fsidd.c:(.text+0x12): undefined reference to `event_self_cbarg'
/usr/lib/gcc/x86_64-pc-linux-gnu/11.3.1/../../../../x86_64-pc-linux-gnu/bin/ld: fsidd.c:(.text+0x2f): undefined reference to `event_new'
/usr/lib/gcc/x86_64-pc-linux-gnu/11.3.1/../../../../x86_64-pc-linux-gnu/bin/ld: fsidd-fsidd.o: in function `client_cb':
fsidd.c:(.text+0x2c4): undefined reference to `event_del'
/usr/lib/gcc/x86_64-pc-linux-gnu/11.3.1/../../../../x86_64-pc-linux-gnu/bin/ld: fsidd.c:(.text+0x2cc): undefined reference to `event_free'
/usr/lib/gcc/x86_64-pc-linux-gnu/11.3.1/../../../../x86_64-pc-linux-gnu/bin/ld: fsidd-fsidd.o: in function `srv_cb':
fsidd.c:(.text+0x3a): undefined reference to `event_add'
/usr/lib/gcc/x86_64-pc-linux-gnu/11.3.1/../../../../x86_64-pc-linux-gnu/bin/ld: fsidd-fsidd.o: in function `main':
fsidd.c:(.text.startup+0xea): undefined reference to `event_base_new'
/usr/lib/gcc/x86_64-pc-linux-gnu/11.3.1/../../../../x86_64-pc-linux-gnu/bin/ld: fsidd.c:(.text.startup+0x10d): undefined reference to `event_new'
/usr/lib/gcc/x86_64-pc-linux-gnu/11.3.1/../../../../x86_64-pc-linux-gnu/bin/ld: fsidd.c:(.text.startup+0x117): undefined reference to `event_add'
/usr/lib/gcc/x86_64-pc-linux-gnu/11.3.1/../../../../x86_64-pc-linux-gnu/bin/ld: fsidd.c:(.text.startup+0x123): undefined reference to `event_base_dispatch'
/usr/lib/gcc/x86_64-pc-linux-gnu/11.3.1/../../../../x86_64-pc-linux-gnu/bin/ld: fsidd-backend_sqlite.o: in function `sqlite_plug_init':
backend_sqlite.c:(.text+0xb7): undefined reference to `sqlite3_open_v2'
/usr/lib/gcc/x86_64-pc-linux-gnu/11.3.1/../../../../x86_64-pc-linux-gnu/bin/ld: backend_sqlite.c:(.text+0xd5): undefined reference to `sqlite3_exec'
/usr/lib/gcc/x86_64-pc-linux-gnu/11.3.1/../../../../x86_64-pc-linux-gnu/bin/ld: backend_sqlite.c:(.text+0x139): undefined reference to `sqlite3_errstr'
/usr/lib/gcc/x86_64-pc-linux-gnu/11.3.1/../../../../x86_64-pc-linux-gnu/bin/ld: backend_sqlite.c:(.text+0x158): undefined reference to `sqlite3_free'
/usr/lib/gcc/x86_64-pc-linux-gnu/11.3.1/../../../../x86_64-pc-linux-gnu/bin/ld: backend_sqlite.c:(.text+0x164): undefined reference to `sqlite3_close_v2'
/usr/lib/gcc/x86_64-pc-linux-gnu/11.3.1/../../../../x86_64-pc-linux-gnu/bin/ld: backend_sqlite.c:(.text+0x173): undefined reference to `sqlite3_errstr'


Closes: https://bugs.gentoo.org/904718