### PR TITLE
dev-libs/rocm-opencl-runtime: dependency fixes

### DIFF
--- a/dev-libs/rocm-opencl-runtime/rocm-opencl-runtime-5.1.3.ebuild
+++ b/dev-libs/rocm-opencl-runtime/rocm-opencl-runtime-5.1.3.ebuild
@@ -21,7 +21,8 @@ RDEPEND=">=dev-libs/rocr-runtime-${PV}
 	>=dev-libs/rocm-device-libs-${PV}
 	>=virtual/opencl-3
 	media-libs/mesa"
-DEPEND="${RDEPEND}"
+DEPEND="${RDEPEND}
+	dev-util/opencl-headers"
 BDEPEND=">=dev-util/rocm-cmake-${PV}
 	media-libs/glew
 	test? ( >=x11-apps/mesa-progs-8.5.0[X] )

--- a/dev-libs/rocm-opencl-runtime/rocm-opencl-runtime-5.3.3-r1.ebuild
+++ b/dev-libs/rocm-opencl-runtime/rocm-opencl-runtime-5.3.3-r1.ebuild
@@ -21,7 +21,8 @@ RDEPEND=">=dev-libs/rocr-runtime-${PV}
 	>=dev-libs/rocm-device-libs-${PV}
 	>=virtual/opencl-3
 	media-libs/mesa"
-DEPEND="${RDEPEND}"
+DEPEND="${RDEPEND}
+	dev-util/opencl-headers"
 BDEPEND=">=dev-util/rocm-cmake-${PV}
 	media-libs/glew
 	test? ( >=x11-apps/mesa-progs-8.5.0[X] )

--- a/dev-libs/rocm-opencl-runtime/rocm-opencl-runtime-5.4.3-r1.ebuild
+++ b/dev-libs/rocm-opencl-runtime/rocm-opencl-runtime-5.4.3-r1.ebuild
@@ -33,8 +33,10 @@ RDEPEND=">=dev-libs/rocr-runtime-5.3
 DEPEND="${RDEPEND}
 	dev-util/opencl-headers"
 BDEPEND=">=dev-util/rocm-cmake-5.3
-	media-libs/glew
-	test? ( >=x11-apps/mesa-progs-8.5.0[X] )
+	test? (
+		>=x11-apps/mesa-progs-8.5.0[X]
+		media-libs/glew
+	)
 	"
 
 CLR_S="${WORKDIR}/ROCclr-rocm-${PV}"

--- a/dev-libs/rocm-opencl-runtime/rocm-opencl-runtime-5.4.3.ebuild
+++ b/dev-libs/rocm-opencl-runtime/rocm-opencl-runtime-5.4.3.ebuild
@@ -30,7 +30,8 @@ RDEPEND=">=dev-libs/rocr-runtime-5.3
 	>=dev-libs/rocm-device-libs-5.3
 	>=virtual/opencl-3
 	media-libs/mesa"
-DEPEND="${RDEPEND}"
+DEPEND="${RDEPEND}
+	dev-util/opencl-headers"
 BDEPEND=">=dev-util/rocm-cmake-5.3
 	media-libs/glew
 	test? ( >=x11-apps/mesa-progs-8.5.0[X] )

--- a/dev-libs/rocm-opencl-runtime/rocm-opencl-runtime-9999.ebuild
+++ b/dev-libs/rocm-opencl-runtime/rocm-opencl-runtime-9999.ebuild
@@ -29,7 +29,8 @@ RDEPEND=">=dev-libs/rocr-runtime-5.3
 	>=dev-libs/rocm-device-libs-5.3
 	>=virtual/opencl-3
 	media-libs/mesa"
-DEPEND="${RDEPEND}"
+DEPEND="${RDEPEND}
+	dev-util/opencl-headers"
 BDEPEND=">=dev-util/rocm-cmake-5.3
 	media-libs/glew
 	test? ( >=x11-apps/mesa-progs-8.5.0[X] )


### PR DESCRIPTION
Fix two bugs, one critical. 

Closes: https://bugs.gentoo.org/904821
Closes: https://bugs.gentoo.org/896076