### PR TITLE
net-libs/libssh2: add upstream libressl patch

### DIFF
--- a/net-libs/libssh2/files/libssh2-1.10.0-libressl.patch
+++ b/net-libs/libssh2/files/libssh2-1.10.0-libressl.patch
@@ -1,0 +1,33 @@
+https://bugs.gentoo.org/903001
+https://github.com/libssh2/libssh2/pull/700
+https://github.com/libssh2/libssh2/commit/b952674f120748174ed2c0fb93e7bd78cf355cac
+
+From f0681a4573d7c7f7484d3157ddff7063a200295b Mon Sep 17 00:00:00 2001
+From: Viktor Szakats <commit@vsz.me>
+Date: Thu, 19 May 2022 13:25:06 +0000
+Subject: [PATCH] openssl: add support for LibreSSL 3.5.x
+
+LibreSSL 3.5.0 made more structures opaque, so let's enable existing
+support for that when building against these LibreSSL versions.
+
+Ref: https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-3.5.0-relnotes.txt
+---
+ src/openssl.h | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/src/openssl.h b/src/openssl.h
+index 658b040..09bfd7c 100644
+--- a/src/openssl.h
++++ b/src/openssl.h
+@@ -57,8 +57,9 @@
+ #include <openssl/pem.h>
+ #include <openssl/rand.h>
+ 
+-#if OPENSSL_VERSION_NUMBER >= 0x10100000L && \
+-    !defined(LIBRESSL_VERSION_NUMBER)
++#if (OPENSSL_VERSION_NUMBER >= 0x10100000L && \
++    !defined(LIBRESSL_VERSION_NUMBER)) || \
++    LIBRESSL_VERSION_NUMBER >= 0x3050000fL
+ # define HAVE_OPAQUE_STRUCTS 1
+ #endif
+ 

--- a/net-libs/libssh2/libssh2-1.10.0.ebuild
+++ b/net-libs/libssh2/libssh2-1.10.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -29,6 +29,10 @@ RDEPEND="
 DEPEND="
 	${RDEPEND}
 "
+
+PATCHES=(
+	"${FILESDIR}"/${P}-libressl.patch #903001
+)
 
 multilib_src_configure() {
 	local crypto_backend=OpenSSL


### PR DESCRIPTION
This patch has been accepted upstream and fixes the build libressl >= 3.5.0.

As discussed in the Gentoo issue (https://bugs.gentoo.org/903001#c16) it should be okay to backport patches which upstream has accepted to fix the build with libressl.

Bug: https://bugs.gentoo.org/903001
Upstream-PR: https://github.com/libssh2/libssh2/pull/700
Upstream-Commit: https://github.com/libssh2/libssh2/commit/b952674f120748174ed2c0fb93e7bd78cf355cac