### PR TITLE
mail-mta/opensmtpd: fix libdir path

### DIFF
--- a/mail-mta/opensmtpd/opensmtpd-6.8.0_p2-r3.ebuild
+++ b/mail-mta/opensmtpd/opensmtpd-6.8.0_p2-r3.ebuild
@@ -66,8 +66,8 @@ src_configure() {
 		--with-user-smtpd=smtpd \
 		--with-user-queue=smtpq \
 		--with-group-queue=smtpq \
-		--with-libevent="$(get_libdir)" \
-		--with-libssl="$(get_libdir)" \
+		--with-libevent="${EPREFIX}/usr/$(get_libdir)" \
+		--with-libssl="${EPREFIX}/usr/$(get_libdir)" \
 		$(use_with pam auth-pam) \
 		$(use_with berkdb table-db)
 }


### PR DESCRIPTION
This fixes the path from the previous commit that sets the libevent and libssl paths explicitly to avoid configure failures on multilib systems that use lld where the incorrect lib directory is linked.

The configure check will test the path as a sysroot and then will take it in its entirety in the 'else' case.

Fixes: https://github.com/gentoo/gentoo/commit/a05af7c36a3e4e74879cad3c03ef4ca2e3601b82
Bug: https://bugs.gentoo.org/739876