### PR TITLE
sys-fs/dmg2img: EAPI8 bump

### DIFF
--- a/sys-fs/dmg2img/dmg2img-1.6.7-r1.ebuild
+++ b/sys-fs/dmg2img/dmg2img-1.6.7-r1.ebuild
@@ -1,7 +1,8 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
+
 inherit toolchain-funcs
 
 DESCRIPTION="Converts Apple DMG files to standard HFS+ images"


### PR DESCRIPTION
Simple `EAPI8` bump for `sys-fs/dmg2img`