### PR TITLE
net-im/synapse: Fix installation phase

### DIFF
--- a/net-im/synapse/synapse-1.82.0-r1.ebuild
+++ b/net-im/synapse/synapse-1.82.0-r1.ebuild
@@ -171,7 +171,7 @@ python_test() {
 }
 
 src_install() {
-	distutils-r1_python_install_all
+	distutils-r1_src_install
 	keepdir /var/{lib,log}/synapse /etc/synapse
 	fowners synapse:synapse /var/{lib,log}/synapse /etc/synapse
 	fperms 0750 /var/{lib,log}/synapse /etc/synapse


### PR DESCRIPTION
Use correct install function for `distutils-r1`. What a shitty bug from my side. Sorry.