### PR TITLE
net-analyzer/ettercap: add upstream libressl patch

### DIFF
--- a/net-analyzer/ettercap/ettercap-0.8.3.1-r3.ebuild
+++ b/net-analyzer/ettercap/ettercap-0.8.3.1-r3.ebuild
@@ -56,6 +56,7 @@ BDEPEND="
 
 PATCHES=(
 	"${FILESDIR}"/${P}-curl-8.patch
+	"${FILESDIR}"/${P}-libressl.patch #903001, 736990
 	"${FILESDIR}"/${P}-musl.patch #897820
 )
 

--- a/net-analyzer/ettercap/files/ettercap-0.8.3.1-libressl.patch
+++ b/net-analyzer/ettercap/files/ettercap-0.8.3.1-libressl.patch
@@ -1,0 +1,36 @@
+https://bugs.gentoo.org/903001
+https://bugs.gentoo.org/736990
+https://github.com/Ettercap/ettercap/pull/1069
+https://github.com/Ettercap/ettercap/commit/b2fc8e959dc71fdbaba08aecb1f157c914490a07
+
+From b2f7634c9dbc0ef68640f0571787d92300e9f9f9 Mon Sep 17 00:00:00 2001
+From: Stefan Strogin <stefan@steils.org>
+Date: Sat, 15 Aug 2020 07:18:31 +0300
+Subject: [PATCH] ec_sslwrap: fix compilation with LibreSSL
+
+Disable taking over SNI extension from ClientHello and SSL configuration
+operations until LibreSSL supports the required API.
+
+Fixes: https://github.com/Ettercap/ettercap/issues/1068
+---
+ src/ec_sslwrap.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/ec_sslwrap.c b/src/ec_sslwrap.c
+index b9f26a142..1e4c24fc1 100644
+--- a/src/ec_sslwrap.c
++++ b/src/ec_sslwrap.c
+@@ -71,11 +71,11 @@
+ #define TLS_server_method SSLv23_server_method
+ #endif
+ 
+-#if (OPENSSL_VERSION_NUMBER >= 0x10100000L)
++#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && !defined(LIBRESSL_VERSION_NUMBER)
+ #define HAVE_OPENSSL_1_1_0
+ #endif
+ 
+-#if (OPENSSL_VERSION_NUMBER >= 0x10101000L)
++#if (OPENSSL_VERSION_NUMBER >= 0x10101000L) && !defined(LIBRESSL_VERSION_NUMBER)
+ #define HAVE_OPENSSL_1_1_1
+ #endif
+ 


### PR DESCRIPTION
This patch was accepted upstream and disables APIs not supported by LibreSSL <= 3.7.2.

As discussed in the Gentoo issue (https://bugs.gentoo.org/903001#c16) it should be okay to backport patches which upstream has accepted to fix the build with LibreSSL.

Bug: https://bugs.gentoo.org/903001
Bug: https://bugs.gentoo.org/736990
Upstream-Issue: https://github.com/Ettercap/ettercap/issues/1068
Upstream-PR: https://github.com/Ettercap/ettercap/pull/1069
Upstream-Commit: https://github.com/Ettercap/ettercap/commit/b2fc8e959dc71fdbaba08aecb1f157c914490a07