### PR TITLE
net-libs/serf: add upstream libressl patch

### DIFF
--- a/net-libs/serf/files/serf-1.3.9-libressl.patch
+++ b/net-libs/serf/files/serf-1.3.9-libressl.patch
@@ -1,0 +1,51 @@
+https://bugs.gentoo.org/903001
+https://github.com/apache/serf/commit/df0d2d0dbdf88576f26da9c71df3ab6249d351dc
+
+From df0d2d0dbdf88576f26da9c71df3ab6249d351dc Mon Sep 17 00:00:00 2001
+From: Stefan Sperling <stsp@apache.org>
+Date: Tue, 20 Dec 2016 09:57:08 +0000
+Subject: [PATCH] Fix another build problem with LibreSSL.
+
+* SConstruct: Check for OpenSSL_malloc_init() and provide the
+   SERF_HAVE_OPENSSL_MALLOC_INIT feature flag.
+
+* buckets/ssl_buckets.c
+  (init_ssl_libraries): Use SERF_HAVE_OPENSSL_MALLOC_INIT instead
+   of USE_LEGACY_OPENSSL.
+
+git-svn-id: https://svn.apache.org/repos/asf/serf/trunk@1775242 13f79535-47bb-0310-9956-ffa450edef68
+---
+ SConstruct            | 6 ++++++
+ buckets/ssl_buckets.c | 2 +-
+ 2 files changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/SConstruct b/SConstruct
+index 4358a23..115f409 100644
+--- a/SConstruct
++++ b/SConstruct
+@@ -373,6 +373,12 @@ else:
+   env.Append(CPPPATH=['$OPENSSL/include'])
+   env.Append(LIBPATH=['$OPENSSL/lib'])
+ 
++  # Check for OpenSSL functions which are only available in some of
++  # the versions we support. Also handles forks like LibreSSL.
++  conf = Configure(env)
++  if conf.CheckFunc('OPENSSL_malloc_init'):
++    env.Append(CPPDEFINES=['SERF_HAVE_OPENSSL_MALLOC_INIT'])
++  env = conf.Finish()
+ 
+ # If build with gssapi, get its information and define SERF_HAVE_GSSAPI
+ if gssapi and CALLOUT_OKAY:
+diff --git a/buckets/ssl_buckets.c b/buckets/ssl_buckets.c
+index b01e535..27c84c7 100644
+--- a/buckets/ssl_buckets.c
++++ b/buckets/ssl_buckets.c
+@@ -1156,7 +1156,7 @@ static void init_ssl_libraries(void)
+         }
+ #endif
+ 
+-#ifdef USE_OPENSSL_1_1_API
++#ifdef SERF_HAVE_OPENSSL_MALLOC_INIT
+         OPENSSL_malloc_init();
+ #else
+         CRYPTO_malloc_init();

--- a/net-libs/serf/serf-1.3.9-r3.ebuild
+++ b/net-libs/serf/serf-1.3.9-r3.ebuild
@@ -34,6 +34,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-1.3.9-python3-check.patch
 	"${FILESDIR}"/${PN}-1.3.9-openssl-3-bio-ctrl.patch
 	"${FILESDIR}"/${PN}-1.3.9-openssl-3-errgetfunc.patch
+	"${FILESDIR}"/${PN}-1.3.9-libressl.patch #903001
 )
 
 src_prepare() {


### PR DESCRIPTION
This patch was accepted upstream and disables the use of `OPENSSL_malloc_init()` when it is not available as is the case with LibreSSL. Additionally serf has changed greatly since the 1.3.9 release in 2016 and no longer uses `OPENSSL_malloc_init()` altogether in their current git commit (https://github.com/apache/serf/commit/2899841712a19610ff8aad3822edde59df69cd85) which has no build failures with LibreSSL 3.7.2.

The build fix for the tests (Commit https://github.com/apache/serf/commit/6f689c72caa870aa33ab4d47a402251ab963e073) was not backported since the tests are restricted in the ebuild.

As discussed in the Gentoo issue (https://bugs.gentoo.org/903001#c16) it should be okay to backport patches which upstream has accepted to fix the build with LibreSSL.

Bug: https://bugs.gentoo.org/903001
Upstream-Commit: https://github.com/apache/serf/commit/df0d2d0dbdf88576f26da9c71df3ab6249d351dc