### PR TITLE
media-video/vlc: add libplacebo USE flag for 3.0.18, 3.0.9999

### DIFF
--- a/media-video/vlc/files/vlc-3.0.18-libplacebo-5.patch
+++ b/media-video/vlc/files/vlc-3.0.18-libplacebo-5.patch
@@ -1,0 +1,133 @@
+https://code.videolan.org/videolan/vlc/-/issues/27624
+
+From efbb1fdbc4420365b3ffd22e55dd27ad520037c7 Mon Sep 17 00:00:00 2001
+From: Niklas Haas <git@haasn.dev>
+Date: Sat, 16 Jul 2022 14:41:13 +0200
+Subject: [PATCH] opengl: port to libplacebo v4 API
+
+These v3.x APIs will be removed in v5.x. Fortunately, the new APIs are a
+near drop-in replacement, so the change was minimal. Only the error
+handling was cleaned up slightly.
+---
+ modules/video_output/opengl/converter.h        | 18 ++++++++++--------
+ modules/video_output/opengl/fragment_shaders.c |  4 ++--
+ modules/video_output/opengl/vout_helper.c      | 14 +++++++-------
+ 3 files changed, 19 insertions(+), 17 deletions(-)
+
+diff --git a/modules/video_output/opengl/converter.h b/modules/video_output/opengl/converter.h
+index 7000e1f38e..cb8e593a9a 100644
+--- a/modules/video_output/opengl/converter.h
++++ b/modules/video_output/opengl/converter.h
+@@ -52,6 +52,11 @@
+ # endif
+ #endif
+ 
++#ifdef HAVE_LIBPLACEBO
++# include <libplacebo/log.h>
++# include <libplacebo/shaders.h>
++#endif
++
+ #define VLCGL_PICTURE_MAX 128
+ 
+ #ifndef GL_TEXTURE_RECTANGLE
+@@ -253,10 +258,6 @@ static inline bool HasExtension(const char *apis, const char *api)
+     return false;
+ }
+ 
+-struct pl_context;
+-struct pl_shader;
+-struct pl_shader_res;
+-
+ /*
+  * Structure that is filled by "glhw converter" module probe function
+  * The implementation should initialize every members of the struct that are
+@@ -272,8 +273,12 @@ struct opengl_tex_converter_t
+     /* Pointer to object gl, set by the caller */
+     vlc_gl_t *gl;
+ 
++#ifdef HAVE_LIBPLACEBO
+     /* libplacebo context, created by the caller (optional) */
+-    struct pl_context *pl_ctx;
++    pl_log pl_log;
++    pl_shader pl_sh;
++    const struct pl_shader_res *pl_sh_res;
++#endif
+ 
+     /* Function pointers to OpenGL functions, set by the caller */
+     const opengl_vtable_t *vt;
+@@ -337,9 +342,6 @@ struct opengl_tex_converter_t
+     bool yuv_color;
+     GLfloat yuv_coefficients[16];
+ 
+-    struct pl_shader *pl_sh;
+-    const struct pl_shader_res *pl_sh_res;
+-
+     /* Private context */
+     void *priv;
+ 
+diff --git a/modules/video_output/opengl/fragment_shaders.c b/modules/video_output/opengl/fragment_shaders.c
+index 2246e33afd..16380335cc 100644
+--- a/modules/video_output/opengl/fragment_shaders.c
++++ b/modules/video_output/opengl/fragment_shaders.c
+@@ -611,7 +611,7 @@ opengl_fragment_shader_init_impl(opengl_tex_converter_t *tc, GLenum tex_target,
+ 
+ #ifdef HAVE_LIBPLACEBO
+     if (tc->pl_sh) {
+-        struct pl_shader *sh = tc->pl_sh;
++        pl_shader sh = tc->pl_sh;
+         struct pl_color_map_params color_params = pl_color_map_default_params;
+         color_params.intent = var_InheritInteger(tc->gl, "rendering-intent");
+         color_params.tone_mapping_algo = var_InheritInteger(tc->gl, "tone-mapping");
+@@ -634,7 +634,7 @@ opengl_fragment_shader_init_impl(opengl_tex_converter_t *tc, GLenum tex_target,
+                 pl_color_space_from_video_format(&tc->fmt),
+                 dst_space, NULL, false);
+ 
+-        struct pl_shader_obj *dither_state = NULL;
++        pl_shader_obj dither_state = NULL;
+         int method = var_InheritInteger(tc->gl, "dither-algo");
+         if (method >= 0) {
+ 
+diff --git a/modules/video_output/opengl/vout_helper.c b/modules/video_output/opengl/vout_helper.c
+index 13d65e04c8..e971f5170b 100644
+--- a/modules/video_output/opengl/vout_helper.c
++++ b/modules/video_output/opengl/vout_helper.c
+@@ -570,8 +570,8 @@ opengl_deinit_program(vout_display_opengl_t *vgl, struct prgm *prgm)
+ 
+ #ifdef HAVE_LIBPLACEBO
+     FREENULL(tc->uloc.pl_vars);
+-    if (tc->pl_ctx)
+-        pl_context_destroy(&tc->pl_ctx);
++    pl_shader_free(&tc->pl_sh);
++    pl_log_destroy(&tc->pl_log);
+ #endif
+ 
+     vlc_object_release(tc);
+@@ -622,21 +622,21 @@ opengl_init_program(vout_display_opengl_t *vgl, struct prgm *prgm,
+     // create the main libplacebo context
+     if (!subpics)
+     {
+-        tc->pl_ctx = pl_context_create(PL_API_VER, &(struct pl_context_params) {
++        tc->pl_log = pl_log_create(PL_API_VER, &(struct pl_log_params) {
+             .log_cb    = log_cb,
+             .log_priv  = tc,
+             .log_level = PL_LOG_INFO,
+         });
+-        if (tc->pl_ctx) {
++        if (tc->pl_log) {
+ #   if PL_API_VER >= 20
+-            tc->pl_sh = pl_shader_alloc(tc->pl_ctx, &(struct pl_shader_params) {
++            tc->pl_sh = pl_shader_alloc(tc->pl_log, &(struct pl_shader_params) {
+                 .glsl.version = tc->glsl_version,
+                 .glsl.gles = tc->is_gles,
+             });
+ #   elif PL_API_VER >= 6
+-            tc->pl_sh = pl_shader_alloc(tc->pl_ctx, NULL, 0);
++            tc->pl_sh = pl_shader_alloc(tc->pl_log, NULL, 0);
+ #   else
+-            tc->pl_sh = pl_shader_alloc(tc->pl_ctx, NULL, 0, 0);
++            tc->pl_sh = pl_shader_alloc(tc->pl_log, NULL, 0, 0);
+ #   endif
+         }
+     }
+-- 
+2.38.1

--- a/media-video/vlc/vlc-3.0.18-r1.ebuild
+++ b/media-video/vlc/vlc-3.0.18-r1.ebuild
@@ -33,8 +33,8 @@ SLOT="0/5-9" # vlc - vlccore
 IUSE="a52 alsa aom archive aribsub bidi bluray cddb chromaprint chromecast dav1d dbus
 	dc1394 debug directx dts +dvbpsi dvd +encode faad fdk +ffmpeg flac fluidsynth
 	fontconfig +gcrypt gme gnome-keyring gstreamer +gui ieee1394 jack jpeg kate
-	libass libcaca libnotify +libsamplerate libtar libtiger linsys lirc live lua
-	macosx-notifications mad matroska modplug mp3 mpeg mtp musepack ncurses nfs ogg
+	libass libcaca libnotify libplacebo +libsamplerate libtar libtiger linsys lirc live
+	lua macosx-notifications mad matroska modplug mp3 mpeg mtp musepack ncurses nfs ogg
 	omxil optimisememory opus png projectm pulseaudio rdp run-as-root samba sdl-image
 	sftp shout sid skins soxr speex srt ssl svg taglib theora tremor truetype twolame
 	udev upnp vaapi v4l vdpau vnc vpx wayland +X x264 x265 xml zeroconf zvbi
@@ -141,6 +141,7 @@ RDEPEND="
 		x11-libs/gtk+:3
 		x11-libs/libnotify
 	)
+	libplacebo? ( media-libs/libplacebo )
 	libsamplerate? ( media-libs/libsamplerate )
 	libtar? ( dev-libs/libtar )
 	libtiger? ( media-libs/libtiger )
@@ -234,6 +235,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-2.2.8-freerdp-2.patch # bug 590164
 	"${FILESDIR}"/${PN}-3.0.6-fdk-aac-2.0.0.patch # bug 672290
 	"${FILESDIR}"/${PN}-3.0.11.1-configure_lua_version.patch
+	"${FILESDIR}"/${PN}-3.0.18-libplacebo-5.patch
 )
 
 DOCS=( AUTHORS THANKS NEWS README doc/fortunes.txt )
@@ -348,6 +350,7 @@ src_configure() {
 		$(use_enable libass)
 		$(use_enable libcaca caca)
 		$(use_enable libnotify notify)
+		$(use_enable libplacebo)
 		$(use_enable libsamplerate samplerate)
 		$(use_enable libtar)
 		$(use_enable libtiger tiger)
@@ -419,7 +422,6 @@ src_configure() {
 		--disable-goom
 		--disable-kai
 		--disable-kva
-		--disable-libplacebo
 		--disable-maintainer-mode
 		--disable-merge-ffmpeg
 		--disable-mfx

--- a/media-video/vlc/vlc-3.0.9999.ebuild
+++ b/media-video/vlc/vlc-3.0.9999.ebuild
@@ -33,8 +33,8 @@ SLOT="0/5-9" # vlc - vlccore
 IUSE="a52 alsa aom archive aribsub bidi bluray cddb chromaprint chromecast dav1d dbus
 	dc1394 debug directx dts +dvbpsi dvd +encode faad fdk +ffmpeg flac fluidsynth
 	fontconfig +gcrypt gme gnome-keyring gstreamer +gui ieee1394 jack jpeg kate
-	libass libcaca libnotify +libsamplerate libtar libtiger linsys lirc live lua
-	macosx-notifications mad matroska modplug mp3 mpeg mtp musepack ncurses nfs ogg
+	libass libcaca libnotify libplacebo +libsamplerate libtar libtiger linsys lirc live
+	lua macosx-notifications mad matroska modplug mp3 mpeg mtp musepack ncurses nfs ogg
 	omxil optimisememory opus png projectm pulseaudio rdp run-as-root samba sdl-image
 	sftp shout sid skins soxr speex srt ssl svg taglib theora tremor truetype twolame
 	udev upnp vaapi v4l vdpau vnc vpx wayland +X x264 x265 xml zeroconf zvbi
@@ -141,6 +141,7 @@ RDEPEND="
 		x11-libs/gtk+:3
 		x11-libs/libnotify
 	)
+	libplacebo? ( media-libs/libplacebo )
 	libsamplerate? ( media-libs/libsamplerate )
 	libtar? ( dev-libs/libtar )
 	libtiger? ( media-libs/libtiger )
@@ -234,6 +235,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-2.2.8-freerdp-2.patch # bug 590164
 	"${FILESDIR}"/${PN}-3.0.6-fdk-aac-2.0.0.patch # bug 672290
 	"${FILESDIR}"/${PN}-3.0.11.1-configure_lua_version.patch
+	"${FILESDIR}"/${PN}-3.0.18-libplacebo-5.patch
 )
 
 DOCS=( AUTHORS THANKS NEWS README doc/fortunes.txt )
@@ -348,6 +350,7 @@ src_configure() {
 		$(use_enable libass)
 		$(use_enable libcaca caca)
 		$(use_enable libnotify notify)
+		$(use_enable libplacebo)
 		$(use_enable libsamplerate samplerate)
 		$(use_enable libtar)
 		$(use_enable libtiger tiger)
@@ -419,7 +422,6 @@ src_configure() {
 		--disable-goom
 		--disable-kai
 		--disable-kva
-		--disable-libplacebo
 		--disable-maintainer-mode
 		--disable-merge-ffmpeg
 		--disable-mfx


### PR DESCRIPTION
This requires a patch to build as VLC 3.0.x uses APIs deprecated in libplacebo 4.x and removed in 5.x.
This functionality is used for colorspace conversion and tone mapping configuration with the OpenGL renderer (usually set to be used automatically).