### PR TITLE
dev-util/scap-driver: fix build on kernel 6.3

### DIFF
--- a/dev-util/scap-driver/files/0.29.3-fix-kmod-build-on-6.3+.patch
+++ b/dev-util/scap-driver/files/0.29.3-fix-kmod-build-on-6.3+.patch
@@ -1,0 +1,20 @@
+
+Bug: https://github.com/falcosecurity/libs/issues/1063
+Subset of patch taken from: https://github.com/falcosecurity/libs/pull/1071
+
+diff --git a/driver/ppm_fillers.c b/driver/ppm_fillers.c
+index 0441923c6d..cfa967f134 100644
+--- a/driver/ppm_fillers.c
++++ b/driver/ppm_fillers.c
+@@ -1329,7 +1329,10 @@ int f_proc_startupdate(struct event_filler_arguments *args)
+ 
+ 		if (exe_file != NULL) {
+ 			if (file_inode(exe_file) != NULL) {
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 12, 0)
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 0)
++				exe_writable |= (file_permission(exe_file, MAY_WRITE) == 0);
++				exe_writable |= inode_owner_or_capable(file_mnt_idmap(exe_file), file_inode(exe_file));
++#elif LINUX_VERSION_CODE >= KERNEL_VERSION(5, 12, 0)
+ 				exe_writable |= (inode_permission(current_user_ns(), file_inode(exe_file), MAY_WRITE) == 0);
+ 				exe_writable |= inode_owner_or_capable(current_user_ns(), file_inode(exe_file));
+ #else

--- a/dev-util/scap-driver/scap-driver-0.29.3-r2.ebuild
+++ b/dev-util/scap-driver/scap-driver-0.29.3-r2.ebuild
@@ -1,0 +1,60 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit cmake linux-mod
+
+DESCRIPTION="Kernel module for dev-util/sysdig"
+HOMEPAGE="https://sysdig.com/"
+
+# The driver is part of falcosecurity/libs, but for versioning reasons we cannot (yet)
+# use semver-released packages; instead we pull in a commit that is used and known
+# to work with sysdig, see sysdig/cmake/modules/falcosecurity-libs.cmake for details.
+# For now the commit here and the one referenced in sysdig should be in sync.
+LIBS_COMMIT="e5c53d648f3c4694385bbe488e7d47eaa36c229a"
+SRC_URI="https://github.com/falcosecurity/libs/archive/${LIBS_COMMIT}.tar.gz -> falcosecurity-libs-${LIBS_COMMIT}.tar.gz"
+S="${WORKDIR}/libs-${LIBS_COMMIT}"
+
+LICENSE="Apache-2.0"
+SLOT="0"
+KEYWORDS="~amd64 ~arm64 ~x86"
+
+RDEPEND="!<dev-util/sysdig-${PV}[modules]"
+
+CONFIG_CHECK="HAVE_SYSCALL_TRACEPOINTS ~TRACEPOINTS"
+
+PATCHES=(
+	"${FILESDIR}"/${PV}-fix-kmod-build-on-5.18+.patch
+	"${FILESDIR}"/${PV}-fix-kmod-build-on-6.2+.patch
+	"${FILESDIR}"/${PV}-fix-kmod-build-on-6.3+.patch
+)
+
+src_configure() {
+	local mycmakeargs=(
+		# we will use linux-mod, so just pretend to use bundled deps
+		# in order to make it through the cmake setup.
+		-DUSE_BUNDLED_DEPS=ON
+		-DCREATE_TEST_TARGETS=OFF
+		-DDRIVER_VERSION=${LIBS_COMMIT}
+	)
+
+	cmake_src_configure
+
+	# setup linux-mod ugliness
+	MODULE_NAMES="scap(extra:${BUILD_DIR}/driver/src:)"
+	BUILD_PARAMS='KERNELDIR="${KERNEL_DIR}"'
+	# work with clang-built kernels (#816024)
+	if linux_chkconfig_present CC_IS_CLANG; then
+		BUILD_PARAMS+=' CC=${CHOST}-clang'
+		if linux_chkconfig_present LD_IS_LLD; then
+			BUILD_PARAMS+=' LD=ld.lld'
+			if linux_chkconfig_present LTO_CLANG_THIN; then
+				# kernel enables cache by default leading to sandbox violations
+				BUILD_PARAMS+=' ldflags-y=--thinlto-cache-dir= LDFLAGS_MODULE=--thinlto-cache-dir='
+			fi
+		fi
+	fi
+
+	BUILD_TARGETS="all"
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/905328
