### PR TITLE
media-video/handbrake: enable py3.11

### DIFF
--- a/media-video/handbrake/handbrake-1.4.2-r2.ebuild
+++ b/media-video/handbrake/handbrake-1.4.2-r2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{9..10} )
+PYTHON_COMPAT=( python3_{9..11} )
 
 inherit autotools python-any-r1 toolchain-funcs xdg
 

--- a/media-video/handbrake/handbrake-1.5.1.ebuild
+++ b/media-video/handbrake/handbrake-1.5.1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{9..10} )
+PYTHON_COMPAT=( python3_{9..11} )
 
 inherit autotools python-any-r1 toolchain-funcs xdg
 


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/897050

Test Plan:
I installed both of the ebuilds changed here and did a simple test encode. Both versions worked fine afaict.