### PR TITLE
Add Keywords for Dependencies of Python 3.11 for macOS and other architectures on Gentoo Prefix

### DIFF
--- a/app-misc/mime-types/mime-types-2.1.53.ebuild
+++ b/app-misc/mime-types/mime-types-2.1.53.ebuild
@@ -10,7 +10,7 @@ SRC_URI="https://pagure.io/mailcap/archive/r${MY_PV}/mailcap-r${MY_PV}.tar.gz"
 
 LICENSE="public-domain MIT"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~arm64-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 IUSE="nginx"
 
 S="${WORKDIR}/mailcap-r${MY_PV}"

--- a/dev-python/ensurepip-pip/ensurepip-pip-22.3.1.ebuild
+++ b/dev-python/ensurepip-pip/ensurepip-pip-22.3.1.ebuild
@@ -15,7 +15,7 @@ S=${DISTDIR}
 
 LICENSE="Apache-2.0 BSD BSD-2 ISC LGPL-2.1+ MIT MPL-2.0 PSF-2"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86"
+KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~x64-cygwin ~amd64-linux ~x86-linux ~arm64-macos ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 
 RDEPEND="
 	!<dev-python/ensurepip-wheels-100

--- a/dev-python/ensurepip-pip/ensurepip-pip-23.0.1.ebuild
+++ b/dev-python/ensurepip-pip/ensurepip-pip-23.0.1.ebuild
@@ -12,7 +12,7 @@ S=${DISTDIR}
 
 LICENSE="Apache-2.0 BSD BSD-2 ISC LGPL-2.1+ MIT MPL-2.0 PSF-2"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86"
+KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~x64-cygwin ~amd64-linux ~x86-linux ~arm64-macos ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 
 RDEPEND="
 	!<dev-python/ensurepip-wheels-100

--- a/dev-python/ensurepip-pip/ensurepip-pip-23.1.ebuild
+++ b/dev-python/ensurepip-pip/ensurepip-pip-23.1.ebuild
@@ -12,7 +12,7 @@ S=${DISTDIR}
 
 LICENSE="Apache-2.0 BSD BSD-2 ISC LGPL-2.1+ MIT MPL-2.0 PSF-2"
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~x64-cygwin ~amd64-linux ~x86-linux ~arm64-macos ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 
 RDEPEND="
 	!<dev-python/ensurepip-wheels-100

--- a/dev-python/ensurepip-setuptools/ensurepip-setuptools-67.6.1.ebuild
+++ b/dev-python/ensurepip-setuptools/ensurepip-setuptools-67.6.1.ebuild
@@ -12,7 +12,7 @@ S=${DISTDIR}
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86"
+KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~arm64-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 
 RDEPEND="
 	!<dev-python/ensurepip-wheels-100

--- a/dev-python/ensurepip-setuptools/ensurepip-setuptools-67.7.0.ebuild
+++ b/dev-python/ensurepip-setuptools/ensurepip-setuptools-67.7.0.ebuild
@@ -12,7 +12,7 @@ S=${DISTDIR}
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~arm64-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 
 RDEPEND="
 	!<dev-python/ensurepip-wheels-100

--- a/dev-python/ensurepip-setuptools/ensurepip-setuptools-67.7.1.ebuild
+++ b/dev-python/ensurepip-setuptools/ensurepip-setuptools-67.7.1.ebuild
@@ -12,7 +12,7 @@ S=${DISTDIR}
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~arm64-macos ~x64-macos ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~arm64-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 
 RDEPEND="
 	!<dev-python/ensurepip-wheels-100

--- a/dev-python/ensurepip-wheels/ensurepip-wheels-100.ebuild
+++ b/dev-python/ensurepip-wheels/ensurepip-wheels-100.ebuild
@@ -8,7 +8,7 @@ HOMEPAGE="https://wiki.gentoo.org/wiki/No_homepage"
 
 LICENSE="metapackage"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86"
+KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~arm64-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 
 RDEPEND="
 	dev-python/ensurepip-pip

--- a/dev-python/gentoo-common/gentoo-common-1.ebuild
+++ b/dev-python/gentoo-common/gentoo-common-1.ebuild
@@ -9,7 +9,7 @@ S=${WORKDIR}
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86"
+KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~x64-cygwin ~amd64-linux ~x86-linux ~arm64-macos ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
 
 src_install() {
 	insinto /usr/lib/python


### PR DESCRIPTION
Gentoo has bumped Python to Python 3.11. Currently there are several missing keywords for new Python dependencies that prevents bootstrap on macOS and other architectures supported by prefix. Merging this Pull Request would fix Gentoo [Bug 905619](https://bugs.gentoo.org/show_bug.cgi?id=905619).

I found that these packages are affected:

* dev-python/gentoo-common
* dev-python/ensurepip-wheels
* dev-python/ensurepip-pip
* dev-python/ensurepip-setuptools

Missing all prefix keywords. There's no prefix keywords whatsoever. Since this package is an architecture-independent script, it should be safe to keyword it for all Gentoo Prefix targets, which has been done in this PR.

* app-misc/mime-types

Missing ~arm64-macos keyword, which has been added in this PR.