### PR TITLE
sci-libs/gklib: fix no x86 arches compile

### DIFF
--- a/sci-libs/gklib/gklib-5.1.1_p20230327-r1.ebuild
+++ b/sci-libs/gklib/gklib-5.1.1_p20230327-r1.ebuild
@@ -20,3 +20,13 @@ PATCHES=(
 	"${FILESDIR}/${P}-multilib.patch"
 	"${FILESDIR}/${P}-respect-user-flags.patch"
 )
+
+src_configure() {
+	local mycmakeargs=()
+	if ! use amd64 && ! use x86; then # bug 905642
+		mycmakeargs+=(
+			-DNO_X86=ON
+		)
+	fi
+	cmake_src_configure
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/905642