### PR TITLE
x11-misc/x11vnc: add upstream libressl patch

### DIFF
--- a/x11-misc/x11vnc/files/x11vnc-0.9.16-libressl.patch
+++ b/x11-misc/x11vnc/files/x11vnc-0.9.16-libressl.patch
@@ -1,0 +1,45 @@
+https://bugs.gentoo.org/903001
+https://github.com/LibVNC/x11vnc/pull/202
+https://github.com/LibVNC/x11vnc/commit/af63109a17f1b1ec8b1e332d215501f11c4a33a0
+https://github.com/LibVNC/x11vnc/pull/224
+https://github.com/LibVNC/x11vnc/commit/354602cffa8edcbe813da6dfd051b96d94b3efbc
+
+From af63109a17f1b1ec8b1e332d215501f11c4a33a0 Mon Sep 17 00:00:00 2001
+From: orbea <orbea@riseup.net>
+Date: Tue, 5 Jul 2022 13:12:30 -0700
+Subject: [PATCH] Fix building w/ libreSSL
+
+When building x11vnc with LibreSSL the build fails with undefined
+references for SSL_CTX_set_security_level which is currently only
+available with OpenSSL. This can be fixed by disabling the code as
+is already done for OpenSSL versions older than 1.1.0.
+
+This builds with LibreSSL 3.5.x.
+---
+ src/sslhelper.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+From 354602cffa8edcbe813da6dfd051b96d94b3efbc Mon Sep 17 00:00:00 2001
+From: orbea <orbea@riseup.net>
+Date: Tue, 2 May 2023 12:16:21 -0700
+Subject: [PATCH] sslhelper: Update for LibreSSL >= 3.6.0 (#224)
+
+Since LibreSSL 3.6.0 SSL_CTX_set_security_level() has been available.
+---
+ src/sslhelper.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/sslhelper.c b/src/sslhelper.c
+index 04c2e27..ae82cd9 100644
+--- a/src/sslhelper.c
++++ b/src/sslhelper.c
+@@ -1596,7 +1596,8 @@ static int switch_to_anon_dh(void) {
+ 	if (ssl_client_mode) {
+ 		return 1;
+ 	}
+-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
++#if (OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)) || \
++	(defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER >= 0x3060000fL)
+ 	/* Security level must be set to 0 for unauthenticated suites. */
+ 	SSL_CTX_set_security_level(ctx, 0);
+ #endif

--- a/x11-misc/x11vnc/x11vnc-0.9.16-r8.ebuild
+++ b/x11-misc/x11vnc/x11vnc-0.9.16-r8.ebuild
@@ -44,6 +44,7 @@ PATCHES=(
 	"${FILESDIR}"/${P}-fno-common.patch
 	"${FILESDIR}"/${P}-CVE-2020-29074.patch
 	"${FILESDIR}"/${P}-implicit-function-declaration.patch
+	"${FILESDIR}"/${P}-libressl.patch # 903001
 )
 
 src_prepare() {


### PR DESCRIPTION
This patch was accepted upstream and fixed the build with LibreSSL < 3.6 which doesn't have `SSL_CTX_set_security_level()` which is added in the also upstreamed x11vnc-0.9.16-anonymous-ssl.patch. The function is appropriately enabled for LibreSSL >= 3.6.

Bug: https://bugs.gentoo.org/903001
Upstream-PR: https://github.com/LibVNC/x11vnc/pull/202
Upstream-Commit: https://github.com/LibVNC/x11vnc/commit/af63109a17f1b1ec8b1e332d215501f11c4a33a0
Upstream-PR: https://github.com/LibVNC/x11vnc/pull/224
Upstream-Commit: https://github.com/LibVNC/x11vnc/commit/354602cffa8edcbe813da6dfd051b96d94b3efbc