### PR TITLE
x11-misc/peksystray: EAPI8 bump, fix LICENSE

### DIFF
--- a/x11-misc/peksystray/peksystray-0.4.0-r1.ebuild
+++ b/x11-misc/peksystray/peksystray-0.4.0-r1.ebuild
@@ -1,0 +1,29 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools
+
+DESCRIPTION="System tray dockapp for window managers supporting docking"
+HOMEPAGE="https://peksystray.sourceforge.net/"
+SRC_URI="mirror://sourceforge/${PN}/${P}.tar.bz2"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~ppc ~x86"
+
+DEPEND="x11-libs/libX11
+	x11-libs/libXt"
+
+PATCHES=( "${FILESDIR}/${P}-asneeded.patch" )
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_install() {
+	dobin src/peksystray
+	default
+}


### PR DESCRIPTION
Simple EAPI8 bump

```diff
--- peksystray-0.4.0.ebuild	2023-04-01 17:48:26.826942008 +0200
+++ peksystray-0.4.0-r1.ebuild	2023-05-03 20:31:05.813013659 +0200
@@ -1,17 +1,17 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
+
 inherit autotools
 
-DESCRIPTION="A system tray dockapp for window managers supporting docking"
-HOMEPAGE="http://peksystray.sourceforge.net/"
+DESCRIPTION="System tray dockapp for window managers supporting docking"
+HOMEPAGE="https://peksystray.sourceforge.net/"
 SRC_URI="mirror://sourceforge/${PN}/${P}.tar.bz2"
 
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="0"
-KEYWORDS="~alpha amd64 ppc x86"
-IUSE=""
+KEYWORDS="~alpha ~amd64 ~ppc ~x86"
 
 DEPEND="x11-libs/libX11
 	x11-libs/libXt"
```