### PR TITLE
dev-libs/libxlsxwriter: fix cmake zlib find_package() syntax

### DIFF
--- a/dev-libs/libxlsxwriter/files/libxlsxwriter-1.1.5-findzlib.patch
+++ b/dev-libs/libxlsxwriter/files/libxlsxwriter-1.1.5-findzlib.patch
@@ -1,0 +1,22 @@
+ZLIB syntax
+Fixed upstream with: https://github.com/jmcnamara/libxlsxwriter/commit/e5014443ffca8614ea0cc6d70e6e6e3d15f82155
+https://bugs.gentoo.org/902017
+
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -219,13 +219,13 @@ enable_language(CXX)
+ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+ 
+ # ZLIB
+-find_package(ZLIB REQUIRED "1.0")
++find_package(ZLIB "1.0" REQUIRED)
+ list(APPEND LXW_PRIVATE_INCLUDE_DIRS ${ZLIB_INCLUDE_DIRS})
+ message("zlib version: " ${ZLIB_VERSION})
+ 
+ # MINIZIP
+ if (USE_SYSTEM_MINIZIP)
+-    find_package(MINIZIP REQUIRED "1.0")
++    find_package(MINIZIP REQUIRED)
+     list(APPEND LXW_PRIVATE_INCLUDE_DIRS ${MINIZIP_INCLUDE_DIRS})
+ endif()
+ 

--- a/dev-libs/libxlsxwriter/libxlsxwriter-1.1.5-r1.ebuild
+++ b/dev-libs/libxlsxwriter/libxlsxwriter-1.1.5-r1.ebuild
@@ -1,0 +1,50 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit cmake plocale
+
+DESCRIPTION="C library for creating Excel XLSX files"
+HOMEPAGE="https://libxlsxwriter.github.io/ https://github.com/jmcnamara/libxlsxwriter"
+SRC_URI="https://github.com/jmcnamara/libxlsxwriter/archive/RELEASE_${PV}.tar.gz -> ${P}.tar.gz"
+S="${WORKDIR}/${PN}-RELEASE_${PV}"
+
+LICENSE="BSD-2"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~x86"
+IUSE="openssl"
+
+DEPEND="
+	sys-libs/zlib[minizip]
+	openssl? ( dev-libs/openssl:= )
+"
+RDEPEND="${DEPEND}"
+
+PATCHES=(
+	"${FILESDIR}/${P}-findzlib.patch"
+	)
+
+src_configure() {
+	DOUBLEFUNCTION=OFF
+	for x in $(plocale_get_locales); do
+		if ! [[ "${x}" =~ ^en* ]]; then
+			#non-english locale detected; apply double function fix
+			DOUBLEFUNCTION=ON
+			break
+		fi
+	done
+	local mycmakeargs=(
+		-DCMAKE_BUILD_TYPE=Release
+		-DUSE_OPENSSL_MD5="$(usex openssl)"
+		-DUSE_SYSTEM_MINIZIP=ON
+		-DUSE_DTOA_LIBRARY=${DOUBLEFUNCTION}
+	)
+	cmake_src_configure
+}
+
+src_install() {
+	cmake_src_install
+	dodoc CONTRIBUTING.md License.txt Readme.md Changes.txt
+	dodoc -r docs examples
+}


### PR DESCRIPTION
A syntax error in the CMakeLists.txt have been fixed about zlib find_package().

Closes: https://bugs.gentoo.org/902017
Signed-off-by: Efe İzbudak <efe.izbudak@metu.edu.tr>