### PR TITLE
x11-misc/revelation: bump dependencies from python {9..10} to python ……{10..11}

### DIFF
--- a/x11-misc/revelation/revelation-0.5.5.ebuild
+++ b/x11-misc/revelation/revelation-0.5.5.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{9..10} )
+PYTHON_COMPAT=( python3_{10..11} )
 
 inherit gnome2-utils python-single-r1 meson xdg
 


### PR DESCRIPTION
as python3.11 is the new default