### PR TITLE
setup run path during config

### DIFF
--- a/sys-apps/util-linux/util-linux-2.39.ebuild
+++ b/sys-apps/util-linux/util-linux-2.39.ebuild
@@ -173,6 +173,8 @@ python_configure() {
 		--enable-libblkid
 		--enable-libmount
 		--enable-pylibmount
+		--runstatedir="${EPREFIX}/run"
+		--localstatedir="${EPREFIX}/var"
 	)
 
 	mkdir "${BUILD_DIR}" || die
@@ -209,6 +211,8 @@ multilib_src_configure() {
 		"${commonargs[@]}"
 		--with-bashcompletiondir="$(get_bashcompdir)"
 		--without-python
+		--runstatedir="${EPREFIX}/run"
+		--localstatedir="${EPREFIX}/var"
 		$(multilib_native_use_enable suid makeinstall-chown)
 		$(multilib_native_use_enable suid makeinstall-setuid)
 		$(multilib_native_use_with readline)


### PR DESCRIPTION
This is default for localstatedir from portage:
/usr/lib/portage/python3.10/phase-helpers.sh:                   --localstatedir="${EPREFIX}"/var/lib \

It makes runstatedir:
./util-linux-2.37.4/configure:  runstatedir='${localstatedir}/run'

And this path is nonexistent (/var/lib/run/) E.g. it checks for /var/lib/run/numlock-on
To me this path should be /run.

Also some selinux policy tweak comes around.
From refpolicy:
files_dontaudit_search_var_lib(getty_t)

From @perfinion patch:
files_search_var_lib(getty_t)

Looks like it's related to this numlock search.
type=PROCTITLE msg=audit(05/04/23 13:57:57.510:13265) : proctitle=/sbin/agetty 38400 tty3 linux
type=PATH msg=audit(05/04/23 13:57:57.510:13265) : item=0 name=/var/lib/run/numlock-on nametype=UNKNOWN cap_fp=none cap_fi=none cap_fe=0 cap_fver=0 cap_frootid=0
type=CWD msg=audit(05/04/23 13:57:57.510:13265) : cwd=/
type=SYSCALL msg=audit(05/04/23 13:57:57.510:13265) : arch=x86_64 syscall=access success=no exit=ENOENT(No such file or directory) a0=0x573f1b80d1a9 a1=F_OK a2=0x0 a3=0x440f76e4f669866b items=1 ppid=1 pid=24591 auid=unset uid=root gid=root
 euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=tty3 ses=unset comm=agetty exe=/sbin/agetty subj=system_u:system_r:getty_t:s0-s15:c0.c1023 key=(null)
 type=AVC msg=audit(05/04/23 13:57:57.510:13265) : avc:  granted  { search } for  pid=24591 comm=agetty name=lib dev="dm-3" ino=1075188 scontext=system_u:system_r:getty_t:s0-s15:c0.c1023 tcontext=system_u:object_r:var_lib_t:s0 tclass=dir

@perfinion Please consider removing this:
349820-diff -uNr -x '.git*' -x CVS -x '*.autogen*' -x '*.part' refpolicy/policy/modules/system/getty.te refpolicy/policy/modules/system/getty.te
349821---- refpolicy/policy/modules/system/getty.te     2022-11-01 09:54:51.000000000 -0400
349822-+++ refpolicy/policy/modules/system/getty.te     2022-06-05 10:13:41.325818313 -0400
349823-@@ -102,6 +102,8 @@
349824-         # Gentoo default /etc/issue makes agetty
349825-         # do a DNS lookup for the hostname
349826-         sysnet_dns_name_resolve(getty_t)
349827-+
349828:+        files_search_var_lib(getty_t)
349829- ')
349830- 
349831- ifdef(`distro_ubuntu',`
