### PR TITLE
net-ftp/lftp: add upstream libressl patch

### DIFF
--- a/net-ftp/lftp/files/lftp-4.9.2-libressl.patch
+++ b/net-ftp/lftp/files/lftp-4.9.2-libressl.patch
@@ -1,0 +1,38 @@
+https://bugs.gentoo.org/903001
+https://github.com/lavv17/lftp/pull/663
+https://github.com/lavv17/lftp/commit/3ffa0132987bdde986c82c924bc51b13b37f8b54
+
+From 3ffa0132987bdde986c82c924bc51b13b37f8b54 Mon Sep 17 00:00:00 2001
+From: Fabrice Fontaine <fontaine.fabrice@gmail.com>
+Date: Wed, 6 Apr 2022 22:56:21 +0200
+Subject: [PATCH] src/lftp_ssl.c: fix build with libressl >= 2.7.0
+
+X509_OBJECT_get0_X509_CRL is provided by libressl since version 2.7.0
+and
+https://github.com/libressl-portable/openbsd/commit/9866ae34c0af718973475296bd9ef036d3aaa94e
+resulting in the following build failure:
+
+/nvmedata/autobuild/instance-21/output-1/host/opt/ext-toolchain/bin/../lib/gcc/microblaze-buildroot-linux-musl/11.2.0/../../../../microblaze-buildroot-linux-musl/bin/ld: /nvmedata/autobuild/instance-21/output-1/host/microblaze-buildroot-linux-musl/sysroot/usr/lib/libcrypto.a(x509_lu.c.o): in function `X509_OBJECT_get0_X509_CRL':
+(.text+0xc3c): multiple definition of `X509_OBJECT_get0_X509_CRL'; /nvmedata/autobuild/instance-21/output-1/build/lftp-4.9.2/src/.libs/liblftp-network.a(liblftp_network_la-lftp_ssl.o):(.text+0x894): first defined here
+
+Fixes:
+ - http://autobuild.buildroot.org/results/7fd1dfd5bc750ae5a3278ca950c838ae90704b23
+
+Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>
+---
+ src/lftp_ssl.cc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/lftp_ssl.cc b/src/lftp_ssl.cc
+index 26e91e4b..a814543d 100644
+--- a/src/lftp_ssl.cc
++++ b/src/lftp_ssl.cc
+@@ -664,7 +664,7 @@ int gnutls_x509_crt_list_import(gnutls_x509_crt_t *certs, unsigned int* cert_max
+ #elif USE_OPENSSL
+ //static int lftp_ssl_passwd_callback(char *buf,int size,int rwflag,void *userdata);
+ 
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L || LIBRESSL_VERSION_NUMBER
++#if OPENSSL_VERSION_NUMBER < 0x10100000L || (defined (LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x2070000L)
+ // for compatibility with older versions
+ X509_OBJECT *X509_OBJECT_new()
+ {

--- a/net-ftp/lftp/lftp-4.9.2-r1.ebuild
+++ b/net-ftp/lftp/lftp-4.9.2-r1.ebuild
@@ -58,6 +58,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-4.9.1-libdir-readline.patch
 	"${FILESDIR}"/${PN}-4.9.2-ac-270.patch
 	"${FILESDIR}"/${PN}-4.9.2-configure-clang16.patch
+	"${FILESDIR}"/${PN}-4.9.2-libressl.patch #903001
 )
 
 src_prepare() {


### PR DESCRIPTION
This patch has been accepted upstream and fixes the build with LibreSSL `>= 2.7.0`.

As discussed in the [Gentoo issue ](https://bugs.gentoo.org/903001#c16) it should be okay to backport patches which upstream has accepted to fix the build with LibreSSL.

Bug: https://bugs.gentoo.org/903001
Upstream-PR: https://github.com/lavv17/lftp/pull/663
Uptream-Commit: https://github.com/lavv17/lftp/commit/3ffa0132987bdde986c82c924bc51b13b37f8b54