### PR TITLE
app-arch/brotli-1.0.9-r5: Add required IUSE debug

### DIFF
--- a/app-arch/brotli/brotli-1.0.9-r5.ebuild
+++ b/app-arch/brotli/brotli-1.0.9-r5.ebuild
@@ -29,7 +29,7 @@ HOMEPAGE="https://github.com/google/brotli/"
 
 LICENSE="MIT python? ( Apache-2.0 )"
 SLOT="0/$(ver_cut 1)"
-IUSE="python static-libs test"
+IUSE="debug python static-libs test"
 REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
 RESTRICT="!test? ( test )"
 


### PR DESCRIPTION
Without the debug use flag, this package will not build.

Bug: https://bugs.gentoo.org/905715