### PR TITLE
sys-devel/slibtool: fix the build in some chroots

### DIFF
--- a/sys-devel/slibtool/slibtool-0.5.34.ebuild
+++ b/sys-devel/slibtool/slibtool-0.5.34.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 inherit toolchain-funcs
 
@@ -32,6 +32,7 @@ src_configure() {
 		--compiler="$(tc-getCC)" \
 		--host=${CHOST} \
 		--prefix="${EPREFIX}"/usr \
-		--libdir="$(get_libdir)" \
+		--libdir="${EPREFIX}/usr/$(get_libdir)" \
+		--shell="${EPREFIX}"/bin/sh \
 			|| die
 }

--- a/sys-devel/slibtool/slibtool-9999.ebuild
+++ b/sys-devel/slibtool/slibtool-9999.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 inherit toolchain-funcs
 
@@ -32,6 +32,7 @@ src_configure() {
 		--compiler="$(tc-getCC)" \
 		--host=${CHOST} \
 		--prefix="${EPREFIX}"/usr \
-		--libdir="$(get_libdir)" \
+		--libdir="${EPREFIX}/usr/$(get_libdir)" \
+		--shell="${EPREFIX}"/bin/sh \
 			|| die
 }


### PR DESCRIPTION
When building slibtool in a chroot where the SHELL is set as /sbin/nologin the sofort configure will fail. This can be worked around for now by explicitly setting the shell as /bin/sh during configure.

Also fixes the libdir path and updates to EAPI=8.

Closes: https://bugs.gentoo.org/905721