### PR TITLE
media-radio/gpredict: add 9999, EAPI 8, update remote-id

### DIFF
--- a/media-radio/gpredict/gpredict-9999.ebuild
+++ b/media-radio/gpredict/gpredict-9999.ebuild
@@ -1,0 +1,43 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools
+
+DESCRIPTION="Real-time satellite tracking and orbit prediction application"
+HOMEPAGE="http://gpredict.oz9aec.net"
+
+if [[ ${PV} = "9999" ]]; then
+	inherit git-r3
+	EGIT_REPO_URI="https://github.com/csete/gpredict.git"
+else
+	SRC_URI="https://github.com/csete/gpredict/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+	KEYWORDS="~amd64 ~ppc ~x86"
+fi
+
+LICENSE="GPL-2"
+SLOT="0"
+
+RDEPEND="dev-libs/glib:2
+	x11-libs/gdk-pixbuf[jpeg]
+	x11-libs/gtk+:3
+	x11-libs/goocanvas:2.0
+	net-misc/curl"
+DEPEND="${RDEPEND}"
+BDEPEND="dev-util/intltool
+	sys-devel/gettext
+	virtual/pkgconfig"
+
+DOCS=( AUTHORS NEWS README )
+
+PATCHES=(
+	# remove wrong doc location
+	"${FILESDIR}/${PN}-2.3-doc.patch"
+	"${FILESDIR}/${PN}-2.3-gethostbyname.patch"
+)
+
+src_prepare() {
+	default
+	eautoreconf
+}


### PR DESCRIPTION
It's a long time since the last release of gpredict. Adding the live ebuild would allow to install a more recent version for all Gentoo users.