### PR TITLE
x11-libs/startup-notification: fix incompatible pointer to integer co…

### DIFF
--- a/x11-libs/startup-notification/files/startup-notification-0.12-clang-16-test-fix.patch
+++ b/x11-libs/startup-notification/files/startup-notification-0.12-clang-16-test-fix.patch
@@ -1,0 +1,27 @@
+# Fixes Gentoo bug https://bugs.gentoo.org/885563
+--- a/test/test-send-xmessage-xcb.c
++++ b/test/test-send-xmessage-xcb.c
+@@ -52,8 +52,8 @@ main (int argc, char **argv)
+   display = sn_xcb_display_new (xconnection, NULL, NULL);
+
+   sn_internal_broadcast_xmessage (display, screen,
+-                                  argv[1],
+-                                  argv[2],
++                                  (xcb_atom_t)argv[1],
++                                  (xcb_atom_t)argv[2],
+                                   argv[3]);
+
+   return 0;
+--- a/test/test-send-xmessage.c
++++ b/test/test-send-xmessage.c
+@@ -57,8 +57,8 @@ main (int argc, char **argv)
+                             error_trap_pop);
+
+   sn_internal_broadcast_xmessage (display, DefaultScreen (xdisplay),
+-                                  argv[1],
+-                                  argv[2],
++                                  (xcb_atom_t)argv[1],
++                                  (xcb_atom_t)argv[2],
+                                   argv[3]);
+
+   return 0;

--- a/x11-libs/startup-notification/startup-notification-0.12-r1.ebuild
+++ b/x11-libs/startup-notification/startup-notification-0.12-r1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 inherit xorg-3
 

--- a/x11-libs/startup-notification/startup-notification-0.12-r1.ebuild
+++ b/x11-libs/startup-notification/startup-notification-0.12-r1.ebuild
@@ -1,7 +1,8 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
+
 inherit xorg-3
 
 DESCRIPTION="Application startup notification and feedback library"
@@ -23,4 +24,5 @@ DOCS=( AUTHORS ChangeLog NEWS doc/${PN}.txt )
 PATCHES=(
 	"${FILESDIR}"/${P}-sys-select_h.patch
 	"${FILESDIR}"/${P}-time_t-crash-with-32bit.patch
+	"${FILESDIR}"/${P}-clang-16-test-fix.patch
 )


### PR DESCRIPTION
…nversion with clang 16

Closes: https://bugs.gentoo.org/885563