### PR TITLE
dev-libs/argtable: fix call to undeclared library function strcmp

### DIFF
--- a/dev-libs/argtable/argtable-2.13-r4.ebuild
+++ b/dev-libs/argtable/argtable-2.13-r4.ebuild
@@ -1,0 +1,49 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+MY_PV="$(ver_rs 1 '-')"
+MY_P=${PN}${MY_PV}
+
+DESCRIPTION="An ANSI C library for parsing GNU-style command-line options with minimal fuss"
+HOMEPAGE="https://argtable.sourceforge.net"
+SRC_URI="mirror://sourceforge/${PN}/${MY_P}.tar.gz"
+S="${WORKDIR}"/${MY_P}
+
+LICENSE="LGPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm64 ~ia64 ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86"
+IUSE="doc debug examples static-libs"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-2.13-Fix-implicit-function-declaration.patch
+	"${FILESDIR}"/${PN}-2.13-Fix-undeclared-library-function.patch
+)
+
+src_configure() {
+	econf \
+		$(use_enable debug) \
+		$(use_enable static-libs static)
+}
+
+src_install() {
+	default
+
+	rm -rf "${ED}"/usr/share/doc/${PF}/
+
+	if use doc ; then
+		cd "${S}"/doc || die
+		dodoc *.pdf *.ps
+		docinto html
+		dodoc *.html *.gif
+	fi
+
+	if use examples ; then
+		cd "${S}"/example || die
+		docinto examples
+		dodoc Makefile *.[ch] README.txt
+	fi
+
+	find "${ED}" -name "*.la" -delete || die "failed to delete .la files"
+}

--- a/dev-libs/argtable/files/argtable-2.13-Fix-undeclared-library-function.patch
+++ b/dev-libs/argtable/files/argtable-2.13-Fix-undeclared-library-function.patch
@@ -1,0 +1,28 @@
+From 519609d844f1e5bbf37407de8e43fa2d2be03262 Mon Sep 17 00:00:00 2001
+From: Brahmajit Das <brahmajit.xyz@gmail.com>
+Date: Sun, 7 May 2023 00:03:40 +0530
+Subject: [PATCH] Fix undeclared library function strcmp
+
+Bug: https://bugs.gentoo.org/885609
+--- a/tests/fntests.c
++++ b/tests/fntests.c
+@@ -1,5 +1,6 @@
+ #include "../src/argtable2.h"
+ #include <assert.h>
++#include <string.h>
+
+ /* for memory leak debugging */
+ #ifdef DMALLOC
+--- a/tests/test_file.c
++++ b/tests/test_file.c
+@@ -21,6 +21,7 @@ USA.
+
+ #include "../src/argtable2.h"
+ #include <stdlib.h>
++#include <string.h>
+
+ /* for memory leak debugging */
+ #ifdef DMALLOC
+--
+2.40.1
+


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/885609