### PR TITLE
Musl 1.2.4 LFS64 build fixes

### DIFF
--- a/dev-libs/libbsd/libbsd-0.11.7-r2.ebuild
+++ b/dev-libs/libbsd/libbsd-0.11.7-r2.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 VERIFY_SIG_OPENPGP_KEY_PATH="${BROOT}"/usr/share/openpgp-keys/guillemjover.asc
-inherit autotools multilib multilib-minimal verify-sig
+inherit autotools flag-o-matic multilib multilib-minimal verify-sig
 
 DESCRIPTION="Library to provide useful functions commonly found on BSD systems"
 HOMEPAGE="https://libbsd.freedesktop.org/wiki/ https://gitlab.freedesktop.org/libbsd/libbsd"
@@ -34,6 +34,8 @@ src_prepare() {
 }
 
 multilib_src_configure() {
+	use elibc_musl && append-flags -D_LARGEFILE64_SOURCE
+
 	# The build system will install libbsd-ctor.a despite USE="-static-libs"
 	# which is correct, see:
 	# https://gitlab.freedesktop.org/libbsd/libbsd/commit/c5b959028734ca2281250c85773d9b5e1d259bc8

--- a/dev-libs/libbsd/libbsd-0.11.7.ebuild
+++ b/dev-libs/libbsd/libbsd-0.11.7.ebuild
@@ -1,10 +1,10 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
 VERIFY_SIG_OPENPGP_KEY_PATH="${BROOT}"/usr/share/openpgp-keys/guillemjover.asc
-inherit multilib-minimal verify-sig
+inherit flag-o-matic multilib-minimal verify-sig
 
 DESCRIPTION="Library to provide useful functions commonly found on BSD systems"
 HOMEPAGE="https://libbsd.freedesktop.org/wiki/ https://gitlab.freedesktop.org/libbsd/libbsd"
@@ -23,6 +23,8 @@ DEPEND="${RDEPEND}
 BDEPEND="verify-sig? ( sec-keys/openpgp-keys-guillemjover )"
 
 multilib_src_configure() {
+	use elibc_musl && append-flags -D_LARGEFILE64_SOURCE
+
 	# The build system will install libbsd-ctor.a despite USE="-static-libs"
 	# which is correct, see:
 	# https://gitlab.freedesktop.org/libbsd/libbsd/commit/c5b959028734ca2281250c85773d9b5e1d259bc8

--- a/sys-apps/acl/acl-2.3.1-r1.ebuild
+++ b/sys-apps/acl/acl-2.3.1-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -48,6 +48,8 @@ multilib_src_configure() {
 		filter-flags -D_FORTIFY_SOURCE=3
 		append-cppflags -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2
 	fi
+
+	use elibc_musl && append-flags -D_LARGEFILE64_SOURCE
 
 	local myeconfargs=(
 		--bindir="${EPREFIX}"/bin

--- a/sys-apps/acl/acl-2.3.1.ebuild
+++ b/sys-apps/acl/acl-2.3.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -31,6 +31,8 @@ multilib_src_configure() {
 	# Filter out -flto flags as they break getfacl/setfacl binaries
 	# bug #667372
 	filter-flags -flto*
+
+	use elibc_musl && append-flags -D_LARGEFILE64_SOURCE
 
 	local myeconfargs=(
 		--bindir="${EPREFIX}"/bin

--- a/sys-apps/systemd-utils/systemd-utils-252.10.ebuild
+++ b/sys-apps/systemd-utils/systemd-utils-252.10.ebuild
@@ -247,6 +247,7 @@ multilib_src_configure() {
 	if use elibc_musl; then
 		# Avoid redefinition of struct ethhdr.
 		append-cppflags -D__UAPI_DEF_ETHHDR=0
+		append-flags -D_LARGEFILE64_SOURCE
 	fi
 
 	if multilib_is_native_abi || use udev; then

--- a/sys-apps/systemd-utils/systemd-utils-252.9.ebuild
+++ b/sys-apps/systemd-utils/systemd-utils-252.9.ebuild
@@ -247,6 +247,7 @@ multilib_src_configure() {
 	if use elibc_musl; then
 		# Avoid redefinition of struct ethhdr.
 		append-cppflags -D__UAPI_DEF_ETHHDR=0
+		append-flags -D_LARGEFILE64_SOURCE
 	fi
 
 	if multilib_is_native_abi || use udev; then


### PR DESCRIPTION
Musl 1.2.4 removed support for LFS64 interfaces under `_GNU_SOURCE`, making them only available under `_LARGEFILE64_SOURCE`. For now, this appends `-D_LARGEFILE64_SOURCE` to fix builds until ideally this is fixed upstream.