### PR TITLE
sys-devel/slibtool: remove shell workaround

### DIFF
--- a/sys-devel/slibtool/slibtool-9999.ebuild
+++ b/sys-devel/slibtool/slibtool-9999.ebuild
@@ -33,6 +33,5 @@ src_configure() {
 		--host=${CHOST} \
 		--prefix="${EPREFIX}"/usr \
 		--libdir="${EPREFIX}/usr/$(get_libdir)" \
-		--shell="${EPREFIX}"/bin/sh \
 			|| die
 }


### PR DESCRIPTION
slibtool now uses `CONFIG_SHELL` like autoconf instead of accepting the `SHELL` variable which may not be a bourne compatible shell.

Bug: https://bugs.gentoo.org/905721
Upstream-Commit: https://git.foss21.org/slibtool/commit/?id=667d348ca9d54b31857fd20c08b97c642ae9f815