### PR TITLE
Last rites: app-text/stardict and friends

### DIFF
--- a/eclass/stardict.eclass
+++ b/eclass/stardict.eclass
@@ -1,6 +1,7 @@
 # Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# @DEAD
 # @ECLASS: stardict.eclass
 # @MAINTAINER:
 # No maintainer <maintainer-needed@gentoo.org>

--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -34,6 +34,12 @@
 #--- END OF EXAMPLES ---
 
 # Matt Turner <mattst88@gentoo.org> (2023-05-11)
+# Console version of stardict which is masked for removal. Only reverse
+# dependencies are app-dicts/stardict-* (via stardict.eclass).
+# Bug #905901. Removal on 2023-06-11
+app-text/sdcv
+
+# Matt Turner <mattst88@gentoo.org> (2023-05-11)
 # Dictionaries for app-text/stardict which is masked for removal.
 # Bug #905901. Removal on 2023-06-11
 app-dicts/stardict-cdict-en-zh-big5

--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -33,6 +33,16 @@
 
 #--- END OF EXAMPLES ---
 
+# Matt Turner <mattst88@gentoo.org> (2023-05-11)
+# Depends on many deprecated packages, such as
+# 	- app-text/enchant:0
+# 	- app-text/gnome-doc-utils
+# 	- gnome-extra/gucharmap:0
+# 	- x11-libs/gtk+:2
+# No reverse dependencies.
+# Bug #905901. Removal on 2023-06-11
+app-text/stardict
+
 # Sam James <sam@gentoo.org> (2023-05-10)
 # A major reverse depndency (kde-apps/libkexiv2) does not yet build against this
 # so mask for now, see bug #906087 and bug #906090.

--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -34,6 +34,38 @@
 #--- END OF EXAMPLES ---
 
 # Matt Turner <mattst88@gentoo.org> (2023-05-11)
+# Dictionaries for app-text/stardict which is masked for removal.
+# Bug #905901. Removal on 2023-06-11
+app-dicts/stardict-cdict-en-zh-big5
+app-dicts/stardict-cdict-en-zh-gb
+app-dicts/stardict-cedict-zh-en-big5
+app-dicts/stardict-cedict-zh-en-gb
+app-dicts/stardict-dictd-devils
+app-dicts/stardict-freedict-eng-deu
+app-dicts/stardict-freedict-eng-fra
+app-dicts/stardict-freedict-eng-ita
+app-dicts/stardict-freedict-eng-lat
+app-dicts/stardict-freedict-eng-rus
+app-dicts/stardict-freedict-eng-spa
+app-dicts/stardict-freedict-eng-swe
+app-dicts/stardict-freedict-eng-tur
+app-dicts/stardict-freedict-tur-deu
+app-dicts/stardict-freedict-tur-eng
+app-dicts/stardict-jmdict-en-ja
+app-dicts/stardict-jmdict-ja-en
+app-dicts/stardict-langdao-en-zh-gb
+app-dicts/stardict-langdao-zh-en-gb
+app-dicts/stardict-mova-smiley
+app-dicts/stardict-oxford-en-zh-gb
+app-dicts/stardict-quick-eng-jpn
+app-dicts/stardict-quick-jpn-eng
+app-dicts/stardict-quick-ru-en
+app-dicts/stardict-xdict-en-zh-big5
+app-dicts/stardict-xdict-en-zh-gb
+app-dicts/stardict-xdict-zh-en-big5
+app-dicts/stardict-xdict-zh-en-gb
+
+# Matt Turner <mattst88@gentoo.org> (2023-05-11)
 # Depends on many deprecated packages, such as
 # 	- app-text/enchant:0
 # 	- app-text/gnome-doc-utils


### PR DESCRIPTION
stardict seems basically unmaintained both in upstream and Gentoo. (See https://bugs.gentoo.org/776394 for example)

It's still on EAPI=6, depends on a bunch of deprecated packages, has no reverse dependencies, etc; and it's been this way for many years.

I think it's time to give it last rites. This package is maybe overlay-quality, but definitely not up to scratch for `::gentoo`.

Removing it will enable further clean ups (e.g. it is one of very few remaining consumers of `app-text/gnome-doc-utils` and `app-text/enchant` and is **the** last consumer of `gnome-extra/gucharmap:0`).

Bug: https://bugs.gentoo.org/905901