### PR TITLE
sys-apps/acl: Fix build with musl 1.2.4

### DIFF
--- a/sys-apps/acl/acl-2.3.1-r1.ebuild
+++ b/sys-apps/acl/acl-2.3.1-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -19,6 +19,10 @@ RDEPEND="
 "
 DEPEND="${RDEPEND}"
 BDEPEND="nls? ( sys-devel/gettext )"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-2.3.1-musl-1.2.4-lfs64-fix.patch"
+)
 
 src_prepare() {
 	default

--- a/sys-apps/acl/acl-2.3.1.ebuild
+++ b/sys-apps/acl/acl-2.3.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -19,6 +19,10 @@ RDEPEND="
 "
 DEPEND="${RDEPEND}"
 BDEPEND="nls? ( sys-devel/gettext )"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-2.3.1-musl-1.2.4-lfs64-fix.patch"
+)
 
 src_prepare() {
 	default

--- a/sys-apps/acl/files/acl-2.3.1-musl-1.2.4-lfs64-fix.patch
+++ b/sys-apps/acl/files/acl-2.3.1-musl-1.2.4-lfs64-fix.patch
@@ -1,0 +1,37 @@
+Bug: https://bugs.gentoo.org/905910
+Upstream Bug: https://savannah.nongnu.org/bugs/index.php?64162
+
+From a9100afd77fea00b311f114a5a04108283aa681a Mon Sep 17 00:00:00 2001
+From: Violet Purcell <vimproved@inventati.org>
+Date: Mon, 8 May 2023 04:17:07 +0000
+Subject: [PATCH] musl 1.2.4 LFS64 removal fixes
+
+---
+ tools/chacl.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/tools/chacl.c b/tools/chacl.c
+index 525a7ff..8fff875 100644
+--- a/tools/chacl.c
++++ b/tools/chacl.c
+@@ -320,7 +320,7 @@ walk_dir(acl_t acl, acl_t dacl, const char *fname)
+ {
+ 	int failed = 0;
+ 	DIR *dir;
+-	struct dirent64 *d;
++	struct dirent *d;
+ 	char *name;
+ 
+ 	if ((dir = opendir(fname)) == NULL) {
+@@ -332,7 +332,7 @@ walk_dir(acl_t acl, acl_t dacl, const char *fname)
+ 		return(0);	/* got a file, not an error */
+ 	}
+ 
+-	while ((d = readdir64(dir)) != NULL) {
++	while ((d = readdir(dir)) != NULL) {
+ 		/* skip "." and ".." entries */
+ 		if (strcmp(d->d_name, ".") == 0 || strcmp(d->d_name, "..") == 0)
+ 			continue;
+-- 
+2.40.1
+


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/905910
Upstream Bug: https://savannah.nongnu.org/bugs/index.php?64162