### PR TITLE
Embree & OpenPGL fix supported arches and REQUIRED_USE

### DIFF
--- a/media-libs/embree/embree-3.13.5.ebuild
+++ b/media-libs/embree/embree-3.13.5.ebuild
@@ -11,13 +11,11 @@ SRC_URI="https://github.com/embree/embree/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="Apache-2.0"
 SLOT="3"
-KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~x86"
-X86_CPU_FLAGS=( sse2:sse2 sse4_2:sse4_2 avx:avx avx2:avx2 avx512dq:avx512dq )
+KEYWORDS="-* ~amd64 ~arm64"
+X86_CPU_FLAGS=( sse2 sse4_2 avx avx2 avx512dq )
 CPU_FLAGS=( cpu_flags_arm_neon ${X86_CPU_FLAGS[@]/#/cpu_flags_x86_} )
-IUSE="+compact-polys ispc +raymask ssp +tbb tutorial ${CPU_FLAGS[@]%:*}"
-# Let's be explicit here even though we could simplify it.
-REQUIRED_USE="amd64? ( cpu_flags_x86_sse2 )
-	x86? ( cpu_flags_x86_sse2 )"
+IUSE="+compact-polys ispc +raymask ssp +tbb tutorial ${CPU_FLAGS[@]}"
+REQUIRED_USE="|| ( ${CPU_FLAGS[@]} )"
 
 BDEPEND="
 	virtual/pkgconfig
@@ -39,6 +37,7 @@ DOCS=( CHANGELOG.md README.md readme.pdf )
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-3.13.5-fix-openimageio-test.patch
+	"${FILESDIR}"/${PN}-3.13.5-fix-arm64.patch
 )
 
 pkg_setup() {
@@ -106,6 +105,7 @@ src_configure() {
 		-DEMBREE_ISA_AVX=$(usex cpu_flags_x86_avx)
 		-DEMBREE_ISA_AVX2=$(usex cpu_flags_x86_avx2)
 		-DEMBREE_ISA_AVX512=$(usex cpu_flags_x86_avx512dq)
+		# TODO look into neon 2x support
 		-DEMBREE_ISA_NEON=$(usex cpu_flags_arm_neon)
 		-DEMBREE_ISA_SSE2=$(usex cpu_flags_x86_sse2)
 		-DEMBREE_ISA_SSE42=$(usex cpu_flags_x86_sse4_2)

--- a/media-libs/embree/files/embree-3.13.5-fix-arm64.patch
+++ b/media-libs/embree/files/embree-3.13.5-fix-arm64.patch
@@ -1,0 +1,53 @@
+Based on: https://github.com/embree/embree/commit/82ca6b5ccb7abe0403a658a0e079926478f04cb1
+Tested in: https://bugs.gentoo.org/851705
+
+Without this patch, it will only build on ARM Mac computers
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index e807351401..e8b08b1247 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -160,11 +160,13 @@ OPTION(EMBREE_MIN_WIDTH "Enables min-width feature to enlarge curve and point th
+ # Platform detection and defaults
+ ##############################################################
+ 
+-IF (APPLE)
+-  IF (CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND (CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64" OR CMAKE_OSX_ARCHITECTURES MATCHES "arm64"))
+-    MESSAGE(STATUS "Building for Apple silicon")
+-    SET(EMBREE_ARM ON)
+-  ENDIF()
++# detect ARM compilation
++IF (APPLE AND CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND (CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64" OR CMAKE_OSX_ARCHITECTURES MATCHES "arm64"))
++  MESSAGE(STATUS "Building for Apple silicon")
++  SET(EMBREE_ARM ON)
++ELSEIF(CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
++  MESSAGE(STATUS "Building for AArch64")
++  SET(EMBREE_ARM ON)
+ ENDIF()
+ 
+ SET(EMBREE_TASKING_SYSTEM "TBB" CACHE STRING "Selects tasking system")
+diff --git a/common/cmake/gnu.cmake b/common/cmake/gnu.cmake
+index f36d79ca25..365212bdda 100644
+--- a/common/cmake/gnu.cmake
++++ b/common/cmake/gnu.cmake
+@@ -26,9 +26,12 @@ IF (EMBREE_IGNORE_CMAKE_CXX_FLAGS)
+ ENDIF()
+ 
+ SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
++
+ IF (EMBREE_ARM)
+   SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsigned-char")             # treat 'char' as 'signed char'
++  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -flax-vector-conversions")  # allow lax vector type conversions
+ ENDIF (EMBREE_ARM)
++
+ SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")                       # enables most warnings
+ SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wformat -Wformat-security")  # enables string format vulnerability warnings
+ SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-class-memaccess")        # disables clearing an object of type ‘XXX’ with no trivial copy-assignment; use assignment or value-initialization instead
+@@ -89,7 +92,6 @@ SET(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -O3")
+ IF (APPLE)
+   SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mmacosx-version-min=10.7")   # makes sure code runs on older MacOSX versions
+   # SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")             # link against libc++ which supports C++11 features
+-  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -flax-vector-conversions")
+ ELSE(APPLE)
+   IF (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+     SET(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--no-undefined") # issues link error for undefined symbols in shared library

--- a/media-libs/openpgl/openpgl-0.5.0.ebuild
+++ b/media-libs/openpgl/openpgl-0.5.0.ebuild
@@ -11,11 +11,12 @@ SRC_URI="https://github.com/OpenPathGuidingLibrary/openpgl/archive/v${PV}.tar.gz
 
 LICENSE="Apache-2.0"
 SLOT="0"
-KEYWORDS="~amd64 ~arm ~arm64 ~x86"
+KEYWORDS="-* ~amd64 ~arm64"
 
 X86_CPU_FLAGS=( sse4_2 avx2 avx512dq )
-CPU_FLAGS=( ${X86_CPU_FLAGS[@]/#/cpu_flags_x86_} )
-IUSE="${CPU_FLAGS[@]%:*} debug"
+CPU_FLAGS=( cpu_flags_arm_neon ${X86_CPU_FLAGS[@]/#/cpu_flags_x86_} )
+IUSE="${CPU_FLAGS[@]} debug"
+REQUIRED_USE="|| ( ${CPU_FLAGS[@]} )"
 
 RDEPEND="
 	media-libs/embree
@@ -28,6 +29,8 @@ src_configure() {
 		-DOPENPGL_ISA_AVX2=$(usex cpu_flags_x86_avx2)
 		-DOPENPGL_ISA_AVX512=$(usex cpu_flags_x86_avx512dq)
 		-DOPENPGL_ISA_SSE4=$(usex cpu_flags_x86_sse4_2)
+		# TODO look into neon 2x support
+		-DOPENPGL_ISA_NEON=$(usex cpu_flags_arm_neon)
 	)
 
 	# Disable asserts

--- a/profiles/arch/arm/package.use.mask
+++ b/profiles/arch/arm/package.use.mask
@@ -1,6 +1,10 @@
 # Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Sebastian Parborg <darkdefende@gmail.com> (2023-05-08)
+# media-libs/openpgl and media-libs/embree only supports amd64 and arm64
+media-gfx/blender embree openpgl
+
 # Andrew Ammerlaan <andrewammerlaan@gentoo.org> (2023-03-07)
 # nbval/nbclassic docs require pandoc which is not keyworded here yet
 dev-python/nbval doc


### PR DESCRIPTION
Both Embree and OpenPGL only support and compiles on amd64 and arm64.

Embree needs a small patch to compile on arm64 on Linux