### PR TITLE
sci-libs/{caffe2,gloo}: support compile caffe2 with cuda and gloo useflag

### DIFF
--- a/sci-libs/caffe2/caffe2-1.13.1-r6.ebuild
+++ b/sci-libs/caffe2/caffe2-1.13.1-r6.ebuild
@@ -1,0 +1,193 @@
+# Copyright 2022-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+PYTHON_COMPAT=( python3_{9..11} )
+inherit python-single-r1 cmake cuda flag-o-matic
+
+MYPN=pytorch
+MYP=${MYPN}-${PV}
+
+DESCRIPTION="A deep learning framework"
+HOMEPAGE="https://pytorch.org/"
+SRC_URI="https://github.com/pytorch/${MYPN}/archive/refs/tags/v${PV}.tar.gz
+	-> ${MYP}.tar.gz"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~amd64"
+IUSE="cuda distributed fbgemm ffmpeg gloo mpi nnpack +numpy opencl opencv openmp qnnpack tensorpipe xnnpack"
+RESTRICT="test"
+REQUIRED_USE="
+	${PYTHON_REQUIRED_USE}
+	ffmpeg? ( opencv )
+	mpi? ( distributed )
+	tensorpipe? ( distributed )
+	gloo? ( distributed )
+" # ?? ( cuda rocm )
+
+# CUDA 12 not supported yet: https://github.com/pytorch/pytorch/issues/91122
+RDEPEND="
+	${PYTHON_DEPS}
+	dev-cpp/gflags:=
+	>=dev-cpp/glog-0.5.0
+	dev-libs/cpuinfo
+	dev-libs/libfmt
+	dev-libs/protobuf:=
+	dev-libs/pthreadpool
+	dev-libs/sleef
+	sci-libs/lapack
+	>=sci-libs/onnx-1.12.0
+	sci-libs/foxi
+	cuda? (
+		=dev-libs/cudnn-8*
+		dev-libs/cudnn-frontend:0/8
+		<dev-util/nvidia-cuda-toolkit-12:=[profiler]
+	)
+	fbgemm? ( dev-libs/FBGEMM )
+	ffmpeg? ( media-video/ffmpeg:= )
+	gloo? ( sci-libs/gloo[cuda?] )
+	mpi? ( sys-cluster/openmpi )
+	nnpack? ( sci-libs/NNPACK )
+	numpy? ( $(python_gen_cond_dep '
+		dev-python/numpy[${PYTHON_USEDEP}]
+		') )
+	opencl? ( virtual/opencl )
+	opencv? ( media-libs/opencv:= )
+	qnnpack? ( sci-libs/QNNPACK )
+	tensorpipe? ( sci-libs/tensorpipe )
+	xnnpack? ( sci-libs/XNNPACK )
+"
+DEPEND="
+	${RDEPEND}
+	dev-cpp/eigen
+	cuda? ( dev-libs/cutlass )
+	dev-libs/psimd
+	dev-libs/FP16
+	dev-libs/FXdiv
+	dev-libs/pocketfft
+	dev-libs/flatbuffers
+	sci-libs/kineto
+	$(python_gen_cond_dep '
+		dev-python/pyyaml[${PYTHON_USEDEP}]
+		dev-python/pybind11[${PYTHON_USEDEP}]
+	')
+"
+
+S="${WORKDIR}"/${MYP}
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-1.13.0-gentoo.patch
+	"${FILESDIR}"/${PN}-1.13.0-install-dirs.patch
+	"${FILESDIR}"/${PN}-1.12.0-glog-0.6.0.patch
+	"${FILESDIR}"/${PN}-1.12.0-clang.patch
+	"${FILESDIR}"/${P}-tensorpipe.patch
+)
+
+src_prepare() {
+	filter-lto #bug 862672
+	sed -i \
+		-e "/third_party\/gloo/d" \
+		cmake/Dependencies.cmake \
+		|| die
+	cmake_src_prepare
+	pushd torch/csrc/jit/serialization || die
+	flatc --cpp --gen-mutable --scoped-enums mobile_bytecode.fbs || die
+	popd
+}
+
+src_configure() {
+	if use cuda && [[ -z ${TORCH_CUDA_ARCH_LIST} ]]; then
+		ewarn "WARNING: caffe2 is being built with its default CUDA compute capabilities: 3.5 and 7.0."
+		ewarn "These may not be optimal for your GPU."
+		ewarn ""
+		ewarn "To configure caffe2 with the CUDA compute capability that is optimal for your GPU,"
+		ewarn "set TORCH_CUDA_ARCH_LIST in your make.conf, and re-emerge caffe2."
+		ewarn "For example, to use CUDA capability 7.5 & 3.5, add: TORCH_CUDA_ARCH_LIST=7.5,3.5"
+		ewarn "For a Maxwell model GPU, an example value would be: TORCH_CUDA_ARCH_LIST=Maxwell"
+		ewarn ""
+		ewarn "You can look up your GPU's CUDA compute capability at https://developer.nvidia.com/cuda-gpus"
+		ewarn "or by running /opt/cuda/extras/demo_suite/deviceQuery | grep 'CUDA Capability'"
+	fi
+
+	local mycmakeargs=(
+		-DBUILD_CUSTOM_PROTOBUF=OFF
+		-DBUILD_SHARED_LIBS=ON
+
+		-DUSE_CCACHE=OFF
+		-DUSE_CUDA=$(usex cuda)
+		-DUSE_CUDNN=$(usex cuda)
+		-DUSE_FAST_NVCC=$(usex cuda)
+		-DTORCH_CUDA_ARCH_LIST="${TORCH_CUDA_ARCH_LIST:-3.5 7.0}"
+		-DUSE_DISTRIBUTED=$(usex distributed)
+		-DUSE_MPI=$(usex mpi)
+		-DUSE_FAKELOWP=OFF
+		-DUSE_FBGEMM=$(usex fbgemm)
+		-DUSE_FFMPEG=$(usex ffmpeg)
+		-DUSE_GFLAGS=ON
+		-DUSE_GLOG=ON
+		-DUSE_GLOO=$(usex gloo)
+		-DUSE_KINETO=OFF # TODO
+		-DUSE_LEVELDB=OFF
+		-DUSE_MAGMA=OFF # TODO: In GURU as sci-libs/magma
+		-DUSE_MKLDNN=OFF
+		-DUSE_NCCL=OFF # TODO: NVIDIA Collective Communication Library
+		-DUSE_NNPACK=$(usex nnpack)
+		-DUSE_QNNPACK=$(usex qnnpack)
+		-DUSE_XNNPACK=$(usex xnnpack)
+		-DUSE_SYSTEM_XNNPACK=$(usex xnnpack)
+		-DUSE_TENSORPIPE=$(usex tensorpipe)
+		-DUSE_PYTORCH_QNNPACK=OFF
+		-DUSE_NUMPY=$(usex numpy)
+		-DUSE_OPENCL=$(usex opencl)
+		-DUSE_OPENCV=$(usex opencv)
+		-DUSE_OPENMP=$(usex openmp)
+		-DUSE_ROCM=OFF # TODO
+		-DUSE_SYSTEM_CPUINFO=ON
+		-DUSE_SYSTEM_PYBIND11=ON
+		-DUSE_UCC=OFF
+		-DUSE_VALGRIND=OFF
+		-DPYBIND11_PYTHON_VERSION="${EPYTHON#python}"
+		-DPYTHON_EXECUTABLE="${PYTHON}"
+		-DUSE_ITT=OFF
+		-DBLAS=Eigen # avoid the use of MKL, if found on the system
+		-DUSE_SYSTEM_EIGEN_INSTALL=ON
+		-DUSE_SYSTEM_PTHREADPOOL=ON
+		-DUSE_SYSTEM_FXDIV=ON
+		-DUSE_SYSTEM_FP16=ON
+		-DUSE_SYSTEM_GLOO=ON
+		-DUSE_SYSTEM_ONNX=ON
+		-DUSE_SYSTEM_SLEEF=ON
+
+		-Wno-dev
+		-DTORCH_INSTALL_LIB_DIR="${EPREFIX}"/usr/$(get_libdir)
+		-DLIBSHM_INSTALL_LIB_SUBDIR="${EPREFIX}"/usr/$(get_libdir)
+	)
+
+	if use cuda; then
+		addpredict "/dev/nvidiactl" # bug 867706
+		addpredict "/dev/char"
+
+		mycmakeargs+=(
+			-DCMAKE_CUDA_FLAGS="$(cuda_gccdir -f | tr -d \")"
+		)
+	fi
+	cmake_src_configure
+}
+
+src_install() {
+	cmake_src_install
+
+	insinto "/var/lib/${PN}"
+	doins "${BUILD_DIR}"/CMakeCache.txt
+
+	rm -rf python
+	mkdir -p python/torch/include || die
+	mv "${ED}"/usr/lib/python*/site-packages/caffe2 python/ || die
+	mv "${ED}"/usr/include/torch python/torch/include || die
+	cp torch/version.py python/torch/ || die
+	rm -rf "${ED}"/var/tmp || die
+	python_domodule python/caffe2
+	python_domodule python/torch
+}

--- a/sci-libs/caffe2/caffe2-2.0.0-r4.ebuild
+++ b/sci-libs/caffe2/caffe2-2.0.0-r4.ebuild
@@ -1,0 +1,195 @@
+# Copyright 2022-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+PYTHON_COMPAT=( python3_{9..11} )
+inherit python-single-r1 cmake cuda flag-o-matic
+
+MYPN=pytorch
+MYP=${MYPN}-${PV}
+
+DESCRIPTION="A deep learning framework"
+HOMEPAGE="https://pytorch.org/"
+SRC_URI="https://github.com/pytorch/${MYPN}/archive/refs/tags/v${PV}.tar.gz
+	-> ${MYP}.tar.gz"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~amd64"
+IUSE="cuda distributed fbgemm ffmpeg gloo mpi nnpack +numpy opencl opencv openmp qnnpack tensorpipe xnnpack"
+RESTRICT="test"
+REQUIRED_USE="
+	${PYTHON_REQUIRED_USE}
+	ffmpeg? ( opencv )
+	mpi? ( distributed )
+	tensorpipe? ( distributed )
+	gloo? ( distributed )
+" # ?? ( cuda rocm )
+
+# CUDA 12 not supported yet: https://github.com/pytorch/pytorch/issues/91122
+RDEPEND="
+	${PYTHON_DEPS}
+	dev-cpp/gflags:=
+	>=dev-cpp/glog-0.5.0
+	dev-libs/cpuinfo
+	dev-libs/libfmt
+	dev-libs/protobuf:=
+	dev-libs/pthreadpool
+	dev-libs/sleef
+	sci-libs/lapack
+	>=sci-libs/onnx-1.12.0
+	sci-libs/foxi
+	cuda? (
+		=dev-libs/cudnn-8*
+		dev-libs/cudnn-frontend:0/8
+		<dev-util/nvidia-cuda-toolkit-12:=[profiler]
+	)
+	fbgemm? ( dev-libs/FBGEMM )
+	ffmpeg? ( media-video/ffmpeg:= )
+	gloo? ( sci-libs/gloo[cuda?] )
+	mpi? ( sys-cluster/openmpi )
+	nnpack? ( sci-libs/NNPACK )
+	numpy? ( $(python_gen_cond_dep '
+		dev-python/numpy[${PYTHON_USEDEP}]
+		') )
+	opencl? ( virtual/opencl )
+	opencv? ( media-libs/opencv:= )
+	qnnpack? ( sci-libs/QNNPACK )
+	tensorpipe? ( sci-libs/tensorpipe )
+	xnnpack? ( >=sci-libs/XNNPACK-2022.12.22 )
+"
+DEPEND="
+	${RDEPEND}
+	dev-cpp/eigen
+	cuda? ( dev-libs/cutlass )
+	dev-libs/psimd
+	dev-libs/FP16
+	dev-libs/FXdiv
+	dev-libs/pocketfft
+	dev-libs/flatbuffers
+	sci-libs/kineto
+	$(python_gen_cond_dep '
+		dev-python/pyyaml[${PYTHON_USEDEP}]
+		dev-python/pybind11[${PYTHON_USEDEP}]
+	')
+"
+
+S="${WORKDIR}"/${MYP}
+
+PATCHES=(
+	"${FILESDIR}"/${P}-gentoo.patch
+	"${FILESDIR}"/${PN}-1.13.0-install-dirs.patch
+	"${FILESDIR}"/${PN}-1.12.0-glog-0.6.0.patch
+	"${FILESDIR}"/${PN}-1.13.1-tensorpipe.patch
+	"${FILESDIR}"/${P}-gcc13.patch
+	"${FILESDIR}"/${P}-cudnn_include_fix.patch
+)
+
+src_prepare() {
+	filter-lto #bug 862672
+	sed -i \
+		-e "/third_party\/gloo/d" \
+		cmake/Dependencies.cmake \
+		|| die
+	cmake_src_prepare
+	pushd torch/csrc/jit/serialization || die
+	flatc --cpp --gen-mutable --scoped-enums mobile_bytecode.fbs || die
+	popd
+}
+
+src_configure() {
+	if use cuda && [[ -z ${TORCH_CUDA_ARCH_LIST} ]]; then
+		ewarn "WARNING: caffe2 is being built with its default CUDA compute capabilities: 3.5 and 7.0."
+		ewarn "These may not be optimal for your GPU."
+		ewarn ""
+		ewarn "To configure caffe2 with the CUDA compute capability that is optimal for your GPU,"
+		ewarn "set TORCH_CUDA_ARCH_LIST in your make.conf, and re-emerge caffe2."
+		ewarn "For example, to use CUDA capability 7.5 & 3.5, add: TORCH_CUDA_ARCH_LIST=7.5,3.5"
+		ewarn "For a Maxwell model GPU, an example value would be: TORCH_CUDA_ARCH_LIST=Maxwell"
+		ewarn ""
+		ewarn "You can look up your GPU's CUDA compute capability at https://developer.nvidia.com/cuda-gpus"
+		ewarn "or by running /opt/cuda/extras/demo_suite/deviceQuery | grep 'CUDA Capability'"
+	fi
+
+	local mycmakeargs=(
+		-DBUILD_CUSTOM_PROTOBUF=OFF
+		-DBUILD_SHARED_LIBS=ON
+
+		-DUSE_CCACHE=OFF
+		-DUSE_CUDA=$(usex cuda)
+		-DUSE_CUDNN=$(usex cuda)
+		-DUSE_FAST_NVCC=$(usex cuda)
+		-DTORCH_CUDA_ARCH_LIST="${TORCH_CUDA_ARCH_LIST:-3.5 7.0}"
+		-DBUILD_NVFUSER=OFF
+		-DUSE_DISTRIBUTED=$(usex distributed)
+		-DUSE_MPI=$(usex mpi)
+		-DUSE_FAKELOWP=OFF
+		-DUSE_FBGEMM=$(usex fbgemm)
+		-DUSE_FFMPEG=$(usex ffmpeg)
+		-DUSE_GFLAGS=ON
+		-DUSE_GLOG=ON
+		-DUSE_GLOO=$(usex gloo)
+		-DUSE_KINETO=OFF # TODO
+		-DUSE_LEVELDB=OFF
+		-DUSE_MAGMA=OFF # TODO: In GURU as sci-libs/magma
+		-DUSE_MKLDNN=OFF
+		-DUSE_NCCL=OFF # TODO: NVIDIA Collective Communication Library
+		-DUSE_NNPACK=$(usex nnpack)
+		-DUSE_QNNPACK=$(usex qnnpack)
+		-DUSE_XNNPACK=$(usex xnnpack)
+		-DUSE_SYSTEM_XNNPACK=$(usex xnnpack)
+		-DUSE_TENSORPIPE=$(usex tensorpipe)
+		-DUSE_PYTORCH_QNNPACK=OFF
+		-DUSE_NUMPY=$(usex numpy)
+		-DUSE_OPENCL=$(usex opencl)
+		-DUSE_OPENCV=$(usex opencv)
+		-DUSE_OPENMP=$(usex openmp)
+		-DUSE_ROCM=OFF # TODO
+		-DUSE_SYSTEM_CPUINFO=ON
+		-DUSE_SYSTEM_PYBIND11=ON
+		-DUSE_UCC=OFF
+		-DUSE_VALGRIND=OFF
+		-DPYBIND11_PYTHON_VERSION="${EPYTHON#python}"
+		-DPYTHON_EXECUTABLE="${PYTHON}"
+		-DUSE_ITT=OFF
+		-DBLAS=Eigen # avoid the use of MKL, if found on the system
+		-DUSE_SYSTEM_EIGEN_INSTALL=ON
+		-DUSE_SYSTEM_PTHREADPOOL=ON
+		-DUSE_SYSTEM_FXDIV=ON
+		-DUSE_SYSTEM_FP16=ON
+		-DUSE_SYSTEM_GLOO=ON
+		-DUSE_SYSTEM_ONNX=ON
+		-DUSE_SYSTEM_SLEEF=ON
+
+		-Wno-dev
+		-DTORCH_INSTALL_LIB_DIR="${EPREFIX}"/usr/$(get_libdir)
+		-DLIBSHM_INSTALL_LIB_SUBDIR="${EPREFIX}"/usr/$(get_libdir)
+	)
+
+	if use cuda; then
+		addpredict "/dev/nvidiactl" # bug 867706
+		addpredict "/dev/char"
+
+		mycmakeargs+=(
+			-DCMAKE_CUDA_FLAGS="$(cuda_gccdir -f | tr -d \")"
+		)
+	fi
+	cmake_src_configure
+}
+
+src_install() {
+	cmake_src_install
+
+	insinto "/var/lib/${PN}"
+	doins "${BUILD_DIR}"/CMakeCache.txt
+
+	rm -rf python
+	mkdir -p python/torch/include || die
+	mv "${ED}"/usr/lib/python*/site-packages/caffe2 python/ || die
+	mv "${ED}"/usr/include/torch python/torch/include || die
+	cp torch/version.py python/torch/ || die
+	rm -rf "${ED}"/var/tmp || die
+	python_domodule python/caffe2
+	python_domodule python/torch
+}

--- a/sci-libs/gloo/files/gloo-2022.05.18-cuda.patch
+++ b/sci-libs/gloo/files/gloo-2022.05.18-cuda.patch
@@ -1,0 +1,13 @@
+diff --git a/gloo/CMakeLists.txt b/gloo/CMakeLists.txt
+index 9ee82df..3b3affb 100644
+--- a/gloo/CMakeLists.txt
++++ b/gloo/CMakeLists.txt
+@@ -184,7 +184,7 @@ if(GLOO_INSTALL)
+           DESTINATION ${CMAKE_INSTALL_LIBDIR})
+   if(USE_CUDA)
+     install(TARGETS gloo_cuda EXPORT GlooTargets
+-        DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
++        DESTINATION ${CMAKE_INSTALL_LIBDIR})
+   endif()
+   if(USE_ROCM)
+     install(TARGETS gloo_hip EXPORT GlooTargets

--- a/sci-libs/gloo/gloo-2022.05.18-r2.ebuild
+++ b/sci-libs/gloo/gloo-2022.05.18-r2.ebuild
@@ -1,0 +1,64 @@
+# Copyright 2022-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+inherit cmake cuda
+
+CommitId=5b143513263133af2b95547e97c07cebeb72bf72
+
+DESCRIPTION="library of floating-point neural network inference operators"
+HOMEPAGE="https://github.com/facebookincubator/gloo/"
+SRC_URI="https://github.com/facebookincubator/${PN}/archive/${CommitId}.tar.gz
+	-> ${P}.tar.gz"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~amd64"
+IUSE="cuda libuv mpi redis ssl test"
+
+RDEPEND="
+	cuda? ( <dev-util/nvidia-cuda-toolkit-12:= )
+	libuv? ( dev-libs/libuv )
+	mpi? ( virtual/mpi )
+	redis? (
+		dev-db/redis
+		dev-libs/hiredis
+	)
+	ssl? ( dev-libs/openssl:0/1.1 )
+"
+DEPEND="${RDEPEND}
+"
+
+BDEPEND="test? ( dev-cpp/gtest )"
+RESTRICT="test" # For some test the network is needed
+
+S="${WORKDIR}"/${PN}-${CommitId}
+
+PATCHES=(
+	"${FILESDIR}"/${P}-gentoo.patch
+	"${FILESDIR}"/${P}-cuda.patch
+)
+
+src_prepare() {
+	eapply_user
+	cmake_src_prepare
+	use cuda && cuda_add_sandbox
+}
+
+src_configure() {
+	local mycmakeargs=(
+		-DBUILD_TEST=$(usex test ON OFF)
+		-DUSE_LIBUV=$(usex libuv ON OFF)
+		-DUSE_MPI=$(usex mpi ON OFF)
+		-DUSE_REDIS=$(usex redis ON OFF)
+		-DUSE_TCP_OPENSSL_LINK=$(usex ssl ON OFF)
+		-DUSE_CUDA=$(usex cuda ON OFF)
+		-DGLOO_USE_CUDA_TOOLKIT=ON=$(usex cuda ON OFF)
+	)
+	if use cuda; then
+		mycmakeargs+=(
+			-DCMAKE_CUDA_FLAGS="$(cuda_gccdir -f | tr -d \")"
+		)
+	fi
+	cmake_src_configure
+}

--- a/sci-libs/gloo/gloo-2023.01.17-r1.ebuild
+++ b/sci-libs/gloo/gloo-2023.01.17-r1.ebuild
@@ -1,0 +1,64 @@
+# Copyright 2022-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+inherit cmake cuda
+
+CommitId=10909297fedab0a680799211a299203e53515032
+
+DESCRIPTION="library of floating-point neural network inference operators"
+HOMEPAGE="https://github.com/facebookincubator/gloo/"
+SRC_URI="https://github.com/facebookincubator/${PN}/archive/${CommitId}.tar.gz
+	-> ${P}.tar.gz"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~amd64"
+IUSE="cuda libuv mpi redis ssl test"
+
+RDEPEND="
+	cuda? ( <dev-util/nvidia-cuda-toolkit-12:= )
+	libuv? ( dev-libs/libuv )
+	mpi? ( virtual/mpi )
+	redis? (
+		dev-db/redis
+		dev-libs/hiredis
+	)
+	ssl? ( dev-libs/openssl:0/1.1 )
+"
+DEPEND="${RDEPEND}
+"
+
+BDEPEND="test? ( dev-cpp/gtest )"
+RESTRICT="test" # For some test the network is needed
+
+S="${WORKDIR}"/${PN}-${CommitId}
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-2022.05.18-gentoo.patch
+	"${FILESDIR}"/${PN}-2022.05.18-cuda.patch
+)
+
+src_prepare() {
+	eapply_user
+	cmake_src_prepare
+	use cuda && cuda_add_sandbox
+}
+
+src_configure() {
+	local mycmakeargs=(
+		-DBUILD_TEST=$(usex test ON OFF)
+		-DUSE_LIBUV=$(usex libuv ON OFF)
+		-DUSE_MPI=$(usex mpi ON OFF)
+		-DUSE_REDIS=$(usex redis ON OFF)
+		-DUSE_TCP_OPENSSL_LINK=$(usex ssl ON OFF)
+		-DUSE_CUDA=$(usex cuda ON OFF)
+		-DGLOO_USE_CUDA_TOOLKIT=ON=$(usex cuda ON OFF)
+	)
+	if use cuda; then
+		mycmakeargs+=(
+			-DCMAKE_CUDA_FLAGS="$(cuda_gccdir -f | tr -d \")"
+		)
+	fi
+	cmake_src_configure
+}

--- a/sci-libs/gloo/metadata.xml
+++ b/sci-libs/gloo/metadata.xml
@@ -9,6 +9,7 @@
 		<remote-id type="github">facebookincubator/gloo</remote-id>
 	</upstream>
 	<use>
+		<flag name="cuda">Enable CUDA support</flag>
 		<flag name="libuv">Enable libuv support</flag>
 		<flag name="redis">Enable Redis backend for storage via <pkg>dev-libs/hiredis</pkg></flag>
 	</use>


### PR DESCRIPTION
When I emerge sci-libs/caffe2 with `USE="cuda gloo"`, it fails since `libgloo_cuda.so` cannot be found. So I have to build sci-libs/gloo with CUDA support.

I add `cuda` use flag for gloo, and change the dependency in caffe2 to insure that if both `cuda` and `gloo` use flags are enabled for caffe2, it requires sci-libs/gloo with `cuda` use flag enabled.

I've tested with `caffe2-1.13.1 + gloo-2023.01.17` and `caffe2-2.0.0 + gloo-2023.01.17`, and all these combinations compiles successfully.

`gloo-2022.05.18` is not tested on my computer due to [#878145](https://bugs.gentoo.org/878145).