### PR TITLE
mate-extra/mate-sensors-applet: fix undeclared function setlocale

### DIFF
--- a/mate-extra/mate-sensors-applet/files/1.26.0-clang-16-fix-undeclared-function-setlocale.patch
+++ b/mate-extra/mate-sensors-applet/files/1.26.0-clang-16-fix-undeclared-function-setlocale.patch
@@ -1,0 +1,130 @@
+From 3ff9fb450aa2a28221fcd863bf7913e84eeeb7ba Mon Sep 17 00:00:00 2001
+From: listout <brahmajit.xyz@gmail.com>
+Date: Fri, 5 May 2023 11:07:20 +0530
+Subject: [PATCH] unconditionally include stdio.h and locale.h
+
+On musl mate-sensor-applet fails to build with error message saying
+"LC_NUMERIC undeclared". As suggested in issue mate-desktop#123, removing the include
+guards around #include <local.h> and #include <stdio.h>
+
+Upstream commit: https://patch-diff.githubusercontent.com/raw/mate-desktop/mate-sensors-applet/pull/128.patch
+Bug: https://bugs.gentoo.org/896200
+Signed-off-by: Brahmajit Das <brahmajit.xyz@gmail.com>
+--- a/configure.ac
++++ b/configure.ac
+@@ -38,7 +38,6 @@ AC_SUBST(LIBS)
+ AC_CHECK_HEADERS(
+ 	stdlib.h \
+ 	string.h \
+-	stdio.h \
+ 	sys/types.h \
+ 	sys/socket.h \
+ 	netinet/in.h \
+--- a/plugins/acpi/acpi-plugin.c
++++ b/plugins/acpi/acpi-plugin.c
+@@ -21,10 +21,7 @@
+ #include <config.h>
+ #endif /* HAVE_CONFIG_H */
+
+-#ifdef HAVE_STDIO_H
+ #include <stdio.h>
+-#endif /* HAVE_STDIO_H */
+-
+ #include <glib.h>
+ #include <glib/gi18n.h>
+ #include "acpi-plugin.h"
+--- a/plugins/i2c-proc/i2c-proc-plugin.c
++++ b/plugins/i2c-proc/i2c-proc-plugin.c
+@@ -21,14 +21,8 @@
+ #include <config.h>
+ #endif /* HAVE_CONFIG_H */
+
+-#ifdef HAVE_STDIO_H
+ #include <stdio.h>
+-#endif /* HAVE_STDIO_H */
+-
+-#ifdef HAVE_LOCALE_H
+ #include <locale.h>
+-#endif
+-
+ #include <glib.h>
+ #include <glib/gi18n.h>
+ #include "i2c-proc-plugin.h"
+--- a/plugins/i2c-sys/i2c-sys-plugin.c
++++ b/plugins/i2c-sys/i2c-sys-plugin.c
+@@ -21,10 +21,7 @@
+ #include <config.h>
+ #endif /* HAVE_CONFIG_H */
+
+-#ifdef HAVE_STDIO_H
+ #include <stdio.h>
+-#endif /* HAVE_STDIO_H */
+-
+ #include <glib.h>
+ #include <glib/gi18n.h>
+ #include "i2c-sys-plugin.h"
+--- a/plugins/i8k/i8k-plugin.c
++++ b/plugins/i8k/i8k-plugin.c
+@@ -21,10 +21,7 @@
+ #include <config.h>
+ #endif /* HAVE_CONFIG_H */
+
+-#ifdef HAVE_STDIO_H
+ #include <stdio.h>
+-#endif /* HAVE_STDIO_H */
+-
+ #include <glib.h>
+ #include <glib/gi18n.h>
+ #include "i8k-plugin.h"
+--- a/plugins/ibm-acpi/ibm-acpi-plugin.c
++++ b/plugins/ibm-acpi/ibm-acpi-plugin.c
+@@ -21,10 +21,7 @@
+ #include "config.h"
+ #endif /* HAVE_CONFIG_H */
+
+-#ifdef HAVE_STDIO_H
+ #include <stdio.h>
+-#endif /* HAVE_STDIO_H */
+-
+ #include <glib.h>
+ #include <glib/gi18n.h>
+ #include "ibm-acpi-plugin.h"
+--- a/plugins/omnibook/omnibook-plugin.c
++++ b/plugins/omnibook/omnibook-plugin.c
+@@ -21,10 +21,7 @@
+ #include "config.h"
+ #endif /* HAVE_CONFIG_H */
+
+-#ifdef HAVE_STDIO_H
+ #include <stdio.h>
+-#endif /* HAVE_STDIO_H */
+-
+ #include <glib.h>
+ #include <glib/gi18n.h>
+ #include "omnibook-plugin.h"
+--- a/plugins/pmu-sys/pmu-sys-plugin.c
++++ b/plugins/pmu-sys/pmu-sys-plugin.c
+@@ -21,10 +21,7 @@
+ #include "config.h"
+ #endif /* HAVE_CONFIG_H */
+
+-#ifdef HAVE_STDIO_H
+ #include <stdio.h>
+-#endif /* HAVE_STDIO_H */
+-
+ #include <glib.h>
+ #include <glib/gi18n.h>
+ #include "pmu-sys-plugin.h"
+--- a/plugins/smu-sys/smu-sys-plugin.c
++++ b/plugins/smu-sys/smu-sys-plugin.c
+@@ -21,10 +21,7 @@
+ #include "config.h"
+ #endif /* HAVE_CONFIG_H */
+
+-#ifdef HAVE_STDIO_H
+ #include <stdio.h>
+-#endif /* HAVE_STDIO_H */
+-
+ #include <glib.h>
+ #include <glib/gi18n.h>
+ #include "smu-sys-plugin.h"

--- a/mate-extra/mate-sensors-applet/mate-sensors-applet-1.26.0-r1.ebuild
+++ b/mate-extra/mate-sensors-applet/mate-sensors-applet-1.26.0-r1.ebuild
@@ -1,0 +1,65 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+MATE_LA_PUNT="yes"
+
+inherit mate
+
+if [[ ${PV} != 9999 ]]; then
+	KEYWORDS="~amd64 ~arm ~loong ~riscv ~x86"
+fi
+
+DESCRIPTION="MATE panel applet to display readings from hardware sensors"
+LICENSE="FDL-1.1+ GPL-2+"
+SLOT="0"
+
+IUSE="+dbus hddtemp libnotify lm-sensors video_cards_nvidia"
+
+COMMON_DEPEND="
+	>=dev-libs/glib-2.50:2
+	>=mate-base/mate-panel-1.17.0
+	>=x11-libs/cairo-1.0.4
+	x11-libs/gdk-pixbuf:2
+	>=x11-libs/gtk+-3.22:3
+	hddtemp? ( >=app-admin/hddtemp-0.3_beta13 )
+	libnotify? ( >=x11-libs/libnotify-0.7 )
+	lm-sensors? ( sys-apps/lm-sensors )
+	video_cards_nvidia? ( >=x11-drivers/nvidia-drivers-100.14.09:0[static-libs,tools] )
+"
+
+RDEPEND="${COMMON_DEPEND}
+	virtual/libintl
+"
+
+BDEPEND="${COMMON_DEPEND}
+	app-text/rarian
+	>=app-text/scrollkeeper-dtd-1:1.0
+	app-text/yelp-tools
+	>=sys-devel/gettext-0.19.8
+	virtual/pkgconfig
+"
+
+PDEPEND="hddtemp? ( dbus? ( sys-fs/udisks:2 ) )"
+
+PATCHES=(
+	"${FILESDIR}"/${PV}-clang-16-fix-undeclared-function-setlocale.patch
+)
+
+src_configure() {
+	local udisks
+
+	if use hddtemp && use dbus; then
+		udisks="--enable-udisks2"
+	else
+		udisks="--disable-udisks2"
+	fi
+
+	mate_src_configure \
+		--disable-netbsd \
+		$(use_enable libnotify) \
+		$(use_with lm-sensors libsensors) \
+		$(use_with video_cards_nvidia nvidia) \
+		${udisks}
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/896200