### PR TITLE
sys-libs/musl: Reapply filter-lto

### DIFF
--- a/sys-libs/musl/musl-1.2.3-r7.ebuild
+++ b/sys-libs/musl/musl-1.2.3-r7.ebuild
@@ -102,7 +102,7 @@ src_prepare() {
 }
 
 src_configure() {
-	strip-flags # Prevent issues caused by aggressive optimizations & bug #877343
+	strip-flags && filter-lto # Prevent issues caused by aggressive optimizations & bug #877343
 	tc-getCC ${CTARGET}
 
 	just_headers && export CC=true

--- a/sys-libs/musl/musl-1.2.3-r8.ebuild
+++ b/sys-libs/musl/musl-1.2.3-r8.ebuild
@@ -102,7 +102,7 @@ src_prepare() {
 }
 
 src_configure() {
-	strip-flags # Prevent issues caused by aggressive optimizations & bug #877343
+	strip-flags && filter-lto # Prevent issues caused by aggressive optimizations & bug #877343
 	tc-getCC ${CTARGET}
 
 	just_headers && export CC=true

--- a/sys-libs/musl/musl-1.2.3.ebuild
+++ b/sys-libs/musl/musl-1.2.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -88,7 +88,7 @@ src_prepare() {
 }
 
 src_configure() {
-	strip-flags # Prevent issues caused by aggressive optimizations & bug #877343
+	strip-flags && filter-lto # Prevent issues caused by aggressive optimizations & bug #877343
 	tc-getCC ${CTARGET}
 
 	just_headers && export CC=true

--- a/sys-libs/musl/musl-1.2.4.ebuild
+++ b/sys-libs/musl/musl-1.2.4.ebuild
@@ -102,7 +102,7 @@ src_prepare() {
 }
 
 src_configure() {
-	strip-flags # Prevent issues caused by aggressive optimizations & bug #877343
+	strip-flags && filter-lto # Prevent issues caused by aggressive optimizations & bug #877343
 	tc-getCC ${CTARGET}
 
 	just_headers && export CC=true

--- a/sys-libs/musl/musl-9999.ebuild
+++ b/sys-libs/musl/musl-9999.ebuild
@@ -102,7 +102,7 @@ src_prepare() {
 }
 
 src_configure() {
-	strip-flags # Prevent issues caused by aggressive optimizations & bug #877343
+	strip-flags && filter-lto # Prevent issues caused by aggressive optimizations & bug #877343
 	tc-getCC ${CTARGET}
 
 	just_headers && export CC=true


### PR DESCRIPTION
As strip-flags no longer removes -flto then a filter-lto is now required to prevent bug 877343 from reopening, like has	already been applied to sys-libs/glibc.