### PR TITLE
profiles/arch: unmask python use flag on arm{,64}

### DIFF
--- a/profiles/arch/arm/package.use.mask
+++ b/profiles/arch/arm/package.use.mask
@@ -75,10 +75,6 @@ app-emulation/qemu rbd slirp spice virgl vde
 app-emulation/qemu qemu_softmmu_targets_i386 qemu_softmmu_targets_x86_64
 app-emulation/qemu qemu_softmmu_targets_ppc qemu_softmmu_targets_ppc64
 
-# Sam James <sam@gentoo.org> (2021-10-31)
-# dev-python/pyilmbase isn't keyworded on arm
-media-gfx/alembic python
-
 # Tomáš Mózes <hydrapolic@gmail.com> (2021-09-25)
 # Unkeyworded dependencies.
 app-admin/syslog-ng mongodb

--- a/profiles/arch/arm64/package.use.mask
+++ b/profiles/arch/arm64/package.use.mask
@@ -67,10 +67,6 @@ sys-cluster/slurm ucx
 # Supports 64-bit NEON
 dev-libs/libgcrypt -cpu_flags_arm_neon
 
-# Sam James <sam@gentoo.org> (2021-10-31)
-# dev-python/pyilmbase isn't keyworded on arm64
-media-gfx/alembic python
-
 # Jakov Smolić <jsmolic@gentoo.org> (2021-10-07)
 # dev-libs/mongo-c-driver is not keyworded here
 net-analyzer/zmap mongo


### PR DESCRIPTION
Has been missed, when last riting dev-python/pyilmbase

Closes: https://bugs.gentoo.org/905768