### PR TITLE
net-libs/rpcsvc-proto: LFS64 shim fix

### DIFF
--- a/net-libs/rpcsvc-proto/files/rpcsvc-proto-1.4.3-lfs64.patch
+++ b/net-libs/rpcsvc-proto/files/rpcsvc-proto-1.4.3-lfs64.patch
@@ -1,0 +1,70 @@
+From https://github.com/thkukuk/rpcsvc-proto/commit/2527c37f956aa38408e251587556a6c8389af319.patch Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Sun, 11 Dec 2022 21:42:59 -0800
+Subject: [PATCH] Use AC_SYS_LARGEFILE macro to control largefile support
+
+The autoconf macro AC_SYS_LARGEFILE defines _FILE_OFFSET_BITS=64
+where necessary to ensure that off_t and all interfaces using off_t
+are 64bit, even on 32bit systems.
+
+replace stat64 by equivalent stat struct/func
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+--- a/configure.ac
++++ b/configure.ac
+@@ -8,6 +8,7 @@ AC_PREFIX_DEFAULT(/usr)
+ AC_SUBST(PACKAGE)
+ AC_SUBST(VERSION)
+ 
++AC_SYS_LARGEFILE
+ AC_PROG_CC
+ AC_GNU_SOURCE
+ AM_PROG_CC_C_O
+--- a/rpcgen/rpc_main.c
++++ b/rpcgen/rpc_main.c
+@@ -62,12 +62,6 @@
+ #define EXTEND	1		/* alias for TRUE */
+ #define DONT_EXTEND	0	/* alias for FALSE */
+ 
+-#ifdef __APPLE__
+-# if __DARWIN_ONLY_64_BIT_INO_T
+-#  define stat64 stat
+-# endif
+-#endif
+-
+ struct commandline
+   {
+     int cflag;			/* xdr C routines */
+@@ -337,9 +331,9 @@ clear_args (void)
+ static void
+ find_cpp (void)
+ {
+-  struct stat64 buf;
++  struct stat buf;
+ 
+-  if (stat64 (CPP, &buf) == 0)
++  if (stat (CPP, &buf) == 0)
+     return;
+ 
+   if (cppDefined) /* user specified cpp but it does not exist */
+@@ -1125,17 +1119,17 @@ putarg (int whereto, const char *cp)
+ static void
+ checkfiles (const char *infile, const char *outfile)
+ {
+-  struct stat64 buf;
++  struct stat buf;
+ 
+   if (infile)			/* infile ! = NULL */
+-    if (stat64 (infile, &buf) < 0)
++    if (stat (infile, &buf) < 0)
+       {
+ 	perror (infile);
+ 	crash ();
+       }
+   if (outfile)
+     {
+-      if (stat64 (outfile, &buf) < 0)
++      if (stat (outfile, &buf) < 0)
+ 	return;			/* file does not exist */
+       else
+ 	{

--- a/net-libs/rpcsvc-proto/rpcsvc-proto-1.4.3-r2.ebuild
+++ b/net-libs/rpcsvc-proto/rpcsvc-proto-1.4.3-r2.ebuild
@@ -1,0 +1,47 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DESCRIPTION="rpcsvc protocol definitions from glibc"
+HOMEPAGE="https://github.com/thkukuk/rpcsvc-proto"
+SRC_URI="https://github.com/thkukuk/rpcsvc-proto/releases/download/v${PV}/${P}.tar.xz"
+
+LICENSE="LGPL-2.1+ BSD"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+
+RDEPEND="!<sys-libs/glibc-2.26
+	virtual/libintl"
+# sys-devel/gettext is only for libintl detection macros.
+BDEPEND="sys-devel/gettext"
+
+inherit autotools
+
+src_prepare() {
+	default
+
+	#Apply LFS64 shim fix and run autoreconf
+	eapply "${FILESDIR}/${P}-lfs64.patch"
+	eautoreconf
+
+	# Search for a valid 'cpp' command.
+	# The CPP envvar might contain '${CC} -E', which does not work for rpcgen.
+	# Bug 718138, 870031, 870061.
+	local x cpp=
+	for x in {${CHOST}-,}{,clang-}cpp; do
+		if type -P "${x}" >/dev/null; then
+			cpp=${x}
+			break
+		fi
+	done
+	[[ -n ${cpp} ]] || die "Unable to find cpp"
+	sed -i -e "s/CPP = \"cpp\";/CPP = \"${cpp}\";/" rpcgen/rpc_main.c || die
+}
+
+src_install() {
+	default
+
+	# provided by sys-fs/quota[rpc]
+	rm "${ED}"/usr/include/rpcsvc/rquota.{x,h} || die
+}


### PR DESCRIPTION
The autoconf macro AC_SYS_LARGEFILE defines _FILE_OFFSET_BITS=64
where necessary to ensure that off_t and all interfaces using off_t
are 64bit, even on 32bit systems.

replace stat64 by equivalent stat struct/func

ebuild fixes to run autoreconf to allow successful compile

Closes: https://bugs.gentoo.org/905985