### PR TITLE
www-client/elinks: fix compilation with USE="-nls"

### DIFF
--- a/www-client/elinks/elinks-0.16.1.1-r1.ebuild
+++ b/www-client/elinks/elinks-0.16.1.1-r1.ebuild
@@ -88,7 +88,7 @@ src_configure() {
 		$(meson_use ftp)
 		-Dfsp=false
 		-Dgemini=false
-		-Dgettext=true
+		$(meson_use nls gettext)
 		$(meson_use gopher)
 		$(meson_use gpm)
 		$(meson_use guile)

--- a/www-client/elinks/elinks-9999.ebuild
+++ b/www-client/elinks/elinks-9999.ebuild
@@ -88,7 +88,7 @@ src_configure() {
 		$(meson_use ftp)
 		-Dfsp=false
 		-Dgemini=false
-		-Dgettext=true
+		$(meson_use nls gettext)
 		$(meson_use gopher)
 		$(meson_use gpm)
 		$(meson_use guile)


### PR DESCRIPTION
USE="-nls" indicates no nls/gettext, so we should pass -Dgettext=false in that case.

Bug: https://bugs.gentoo.org/888952