### PR TITLE
sci-libs: tensorflow. Bazel and JDK incompatibility

### DIFF
--- a/sci-libs/tensorflow/tensorflow-2.11.0.ebuild
+++ b/sci-libs/tensorflow/tensorflow-2.11.0.ebuild
@@ -188,7 +188,12 @@ src_unpack() {
 }
 
 src_prepare() {
-	export JAVA_HOME=$(java-config --jre-home) # so keepwork works
+	if java-config -P openjdk-11 &> /dev/null ; then
+		export JAVA_HOME=$(java-config -P openjdk-11 | grep -Po '^JAVA_HOME=\K[[:ascii:]]{1,}') # so keepwork works
+	else
+		export JAVA_HOME=$(java-config -P openjdk-bin-11 | grep -Po '^JAVA_HOME=\K[[:ascii:]]{1,}') # so keepwork works
+	fi
+
 
 	append-flags $(get-cpu-flags)
 	append-cxxflags -std=c++17
@@ -212,7 +217,11 @@ src_prepare() {
 }
 
 src_configure() {
-	export JAVA_HOME=$(java-config --jre-home) # so keepwork works
+	if java-config -P openjdk-11 &> /dev/null ; then
+		export JAVA_HOME=$(java-config -P openjdk-11 | grep -Po '^JAVA_HOME=\K[[:ascii:]]{1,}') # so keepwork works
+	else
+		export JAVA_HOME=$(java-config -P openjdk-bin-11 | grep -Po '^JAVA_HOME=\K[[:ascii:]]{1,}') # so keepwork works
+	fi
 	export KERAS_HOME="${T}/.keras" # otherwise sandbox violation writing ~/.keras
 
 	do_configure() {
@@ -331,7 +340,12 @@ src_configure() {
 }
 
 src_compile() {
-	export JAVA_HOME=$(java-config --jre-home) # so keepwork works
+	if java-config -P openjdk-11 &> /dev/null ; then
+		export JAVA_HOME=$(java-config -P openjdk-11 | grep -Po '^JAVA_HOME=\K[[:ascii:]]{1,}') # so keepwork works
+	else
+		export JAVA_HOME=$(java-config -P openjdk-bin-11 | grep -Po '^JAVA_HOME=\K[[:ascii:]]{1,}') # so keepwork works
+	fi
+
 	export KERAS_HOME="${T}/.keras" # otherwise sandbox violation writing ~/.keras
 
 	if use python; then
@@ -365,7 +379,12 @@ src_compile() {
 
 src_install() {
 	local i l
-	export JAVA_HOME=$(java-config --jre-home) # so keepwork works
+	if java-config -P openjdk-11 &> /dev/null ; then
+		export JAVA_HOME=$(java-config -P openjdk-11 | grep -Po '^JAVA_HOME=\K[[:ascii:]]{1,}') # so keepwork works
+	else
+		export JAVA_HOME=$(java-config -P openjdk-bin-11 | grep -Po '^JAVA_HOME=\K[[:ascii:]]{1,}') # so keepwork works
+	fi
+
 	export KERAS_HOME="${T}/.keras" # otherwise sandbox violation writing ~/.keras
 
 	do_install() {


### PR DESCRIPTION
This is a naive attempt to fix Bug: https://bugs.gentoo.org/906065. 
Mentioned here by the bazel developers:

https://github.com/bazelbuild/bazel/issues/17103

Apparently, using the openjdk 17 is not entirely functional. This patch tries to "force" the use of JDK 11, which  in [theory](https://github.com/bazelbuild/bazel/issues/17103#issuecomment-1542167314) should work (still compiling on my machine, I'll update this PR's comments when its done)

Furthermore, I could not find ebuilds for the new bazel version (ATOW [6.2.0](https://github.com/bazelbuild/bazel/releases/tag/6.2.0)). Maybe an update to the ebuild is due