### PR TITLE
dev-libs/spdlog: fix fails compile with libfmt-10.0.0

### DIFF
--- a/dev-libs/spdlog/files/spdlog-libfmt-10.0.0.patch
+++ b/dev-libs/spdlog/files/spdlog-libfmt-10.0.0.patch
@@ -1,0 +1,30 @@
+Bug: https://bugs.gentoo.org/906069
+Upstream: https://github.com/gabime/spdlog/pull/2694
+
+Fixing spdlog-1.11.0 fails compile with libfmt-10.0.0
+
+diff --git a/include/spdlog/common.h b/include/spdlog/common.h
+index e69201a81..5f671c5c6 100644
+--- a/include/spdlog/common.h
++++ b/include/spdlog/common.h
+@@ -173,12 +173,19 @@ using format_string_t = fmt::format_string<Args...>;
+ template<class T>
+ using remove_cvref_t = typename std::remove_cv<typename std::remove_reference<T>::type>::type;
+ 
++template <typename Char>
++#if FMT_VERSION >= 90101
++using fmt_runtime_string = fmt::runtime_format_string<Char>;
++#else
++using fmt_runtime_string = fmt::basic_runtime<Char>;
++#endif
++
+ // clang doesn't like SFINAE disabled constructor in std::is_convertible<> so have to repeat the condition from basic_format_string here,
+ // in addition, fmt::basic_runtime<Char> is only convertible to basic_format_string<Char> but not basic_string_view<Char>
+ template<class T, class Char = char>
+ struct is_convertible_to_basic_format_string
+     : std::integral_constant<bool,
+-          std::is_convertible<T, fmt::basic_string_view<Char>>::value || std::is_same<remove_cvref_t<T>, fmt::basic_runtime<Char>>::value>
++          std::is_convertible<T, fmt::basic_string_view<Char>>::value || std::is_same<remove_cvref_t<T>, fmt_runtime_string<Char>>::value>
+ {};
+ 
+ #    if defined(SPDLOG_WCHAR_FILENAMES) || defined(SPDLOG_WCHAR_TO_UTF8_SUPPORT)

--- a/dev-libs/spdlog/spdlog-1.11.0.ebuild
+++ b/dev-libs/spdlog/spdlog-1.11.0.ebuild
@@ -31,6 +31,7 @@ RDEPEND="${DEPEND}"
 
 PATCHES=(
 	"${FILESDIR}/${PN}-force_external_fmt.patch"
+	"${FILESDIR}/${PN}-libfmt-10.0.0.patch"
 )
 
 src_prepare() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/906069