### PR TITLE
dev-util/bear: fix fails compile with libfmt-10.0.0

### DIFF
--- a/dev-util/bear/bear-3.0.21.ebuild
+++ b/dev-util/bear/bear-3.0.21.ebuild
@@ -47,6 +47,7 @@ S="${WORKDIR}/${P^}"
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-3.0.21-clang16-tests.patch
+	"${FILESDIR}"/${PN}-3.0.21-libfmt-10.0.0.patch
 )
 
 pkg_setup() {

--- a/dev-util/bear/files/bear-3.0.21-libfmt-10.0.0.patch
+++ b/dev-util/bear/files/bear-3.0.21-libfmt-10.0.0.patch
@@ -1,0 +1,26 @@
+BUG: https://bugs.gentoo.org/906082
+UPSTREAM: https://github.com/rizsotto/Bear/pull/526
+
+From 46a032fa0fc8131779ece13f26735ec84be891e8 Mon Sep 17 00:00:00 2001
+From: jinqiang zhang <peeweep@0x0.ee>
+Date: Thu, 11 May 2023 03:33:17 +0800
+Subject: [PATCH] dependency: fix fmt 10.0.0 incompatibilities (#526)
+
+Signed-off-by: jinqiang zhang <peeweep@0x0.ee>
+---
+ source/CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/source/CMakeLists.txt b/source/CMakeLists.txt
+index 6da1131f..fe6b710b 100644
+--- a/source/CMakeLists.txt
++++ b/source/CMakeLists.txt
+@@ -29,7 +29,7 @@ find_package(spdlog REQUIRED)
+ find_package(PkgConfig REQUIRED)
+ pkg_check_modules(gRPC REQUIRED IMPORTED_TARGET protobuf grpc++)
+ 
+-if (fmt_VERSION_MAJOR EQUAL 9)
++if (fmt_VERSION_MAJOR GREATER_EQUAL 9)
+     set(FMT_NEEDS_OSTREAM_FORMATTER 1)
+     set(HAVE_FMT_STD_H 1) # FIXME: this should be done with `check_include_file`
+ endif ()


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/906082