### PR TITLE
x11-plugins/wmrack: Fix type specifier missing and undeclared function

### DIFF
--- a/x11-plugins/wmrack/files/1.4-Fix-type-specifier-missing-and-undeclared-function-c.patch
+++ b/x11-plugins/wmrack/files/1.4-Fix-type-specifier-missing-and-undeclared-function-c.patch
@@ -1,0 +1,41 @@
+From ff65fefaa53a199933c005129b78e0c4f5a5ab47 Mon Sep 17 00:00:00 2001
+From: Brahmajit Das <brahmajit.xyz@gmail.com>
+Date: Thu, 11 May 2023 11:34:42 +0530
+Subject: [PATCH] Fix type specifier missing and undeclared function call with
+ clang 16
+
+- wmrack.c:1243:12: error: type specifier missing, defaults to 'int'
+- wmrack.c:1300:22: error: call to undeclared function 'time'; ISO C99 and later do not support implicit function declarations
+
+Signed-off-by: Brahmajit Das <brahmajit.xyz@gmail.com>
+
+Bug: https://bugs.gentoo.org/899046
+Upstream Issue: https://sourceforge.net/p/wmrack/patches/3/
+---
+ wmrack.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/wmrack.c b/wmrack.c
+index ea49d40..4aa3d56 100644
+--- a/wmrack.c
++++ b/wmrack.c
+@@ -25,6 +25,7 @@
+ #include <unistd.h>
+ #include <errno.h>
+ #include <signal.h>
++#include <time.h>
+
+ #include <X11/Xlib.h>
+ #include <X11/Xresource.h>
+@@ -1240,7 +1241,7 @@ redrawDisplay (int force_win, int force_disp)
+     int track[2] = { 0, 0 };
+     int cdtime[4] = { 0, 0, 0, 0 };
+     static time_t last_flash_time;
+-    static flash = 0;
++    static int flash = 0;
+     int st = 0, newRack = RACK_NODISC, im_stop = 0;
+     MSF pos;
+
+--
+2.40.1
+

--- a/x11-plugins/wmrack/wmrack-1.4-r2.ebuild
+++ b/x11-plugins/wmrack/wmrack-1.4-r2.ebuild
@@ -1,0 +1,37 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="a sound mixer and CD player dockapp"
+HOMEPAGE="http://wmrack.sourceforge.net"
+SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86"
+
+RDEPEND="x11-libs/libX11
+	x11-libs/libXpm
+	x11-libs/libXext"
+DEPEND="${RDEPEND}
+	x11-base/xorg-proto"
+
+DOCS=( CHANGES README TODO )
+
+PATCHES=( "${FILESDIR}"/${PV}-Fix-type-specifier-missing-and-undeclared-function-c.patch )
+
+src_prepare() {
+	default
+	ln -s grey.style XPM/standart.style || die
+	sed -i \
+		-e 's:gcc:$(CC):' \
+		-e 's:$(OBJECTS) -o:$(OBJECTS) $(LDFLAGS) -o:' "${S}"/Makefile.in || die
+}
+
+src_install() {
+	emake LIBDIR="${D}/usr/$(get_libdir)/WMRack" \
+		MANDIR="${D}/usr/share/man" BINDIR="${D}/usr/bin" \
+		install
+	einstalldocs
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/899046