### PR TITLE
sys-cluster/glusterfs: sort out python deps

### DIFF
--- a/sys-cluster/glusterfs/glusterfs-10.2-r2.ebuild
+++ b/sys-cluster/glusterfs/glusterfs-10.2-r2.ebuild
@@ -34,10 +34,11 @@ RDEPEND="
 	dev-libs/userspace-rcu:=
 	sys-apps/util-linux
 	sys-libs/readline:=
+	${PYTHON_DEPS}
+
 	!elibc_glibc? ( sys-libs/argp-standalone )
 	emacs? ( >=app-editors/emacs-23.1:* )
 	fuse? ( >=sys-fs/fuse-2.7.0:0 )
-	georeplication? ( ${PYTHON_DEPS} )
 	libtirpc? ( net-libs/libtirpc:= )
 	!libtirpc? ( elibc_glibc? ( sys-libs/glibc[rpc(-)] ) )
 	selinux? ( sec-policy/selinux-glusterfs )

--- a/sys-cluster/glusterfs/glusterfs-10.4.ebuild
+++ b/sys-cluster/glusterfs/glusterfs-10.4.ebuild
@@ -34,10 +34,11 @@ RDEPEND="
 	dev-libs/userspace-rcu:=
 	sys-apps/util-linux
 	sys-libs/readline:=
+	${PYTHON_DEPS}
+
 	!elibc_glibc? ( sys-libs/argp-standalone )
 	emacs? ( >=app-editors/emacs-23.1:* )
 	fuse? ( >=sys-fs/fuse-2.7.0:0 )
-	georeplication? ( ${PYTHON_DEPS} )
 	libtirpc? ( net-libs/libtirpc:= )
 	!libtirpc? ( elibc_glibc? ( sys-libs/glibc[rpc(-)] ) )
 	selinux? ( sec-policy/selinux-glusterfs )


### PR DESCRIPTION
./configure unconditionally checks for python now, where if I recall correctly previously it only cared if georeplication was in use, since we run python for portage anyway, and glusterfs does install python based utilities even with -georeplication now, unconditionally depend on python rather than only if georeplication is enabled.