### PR TITLE
net-libs/libmicrohttpd: fixed license

### DIFF
--- a/licenses/GPL-2+-with-eCos-exception-2
+++ b/licenses/GPL-2+-with-eCos-exception-2
@@ -1,0 +1,12 @@
+GNU General Public License, version 2 or any later version.
+See GPL-2 or GPL-3 for the full text of these licenses.
+
+As a special exception, if other files instantiate templates or use macros or
+inline functions from this file, or you compile this file and link it with
+other works to produce a work based on this file, this file does not by itself
+cause the resulting work to be covered by the GNU General Public License.
+However the source code for this file must still be made available in
+accordance with section (3) of the GNU General Public License v2.
+
+This exception does not invalidate any other reasons why a work based on this
+file might be covered by the GNU General Public License.

--- a/net-libs/libmicrohttpd/libmicrohttpd-0.9.75.ebuild
+++ b/net-libs/libmicrohttpd/libmicrohttpd-0.9.75.ebuild
@@ -12,7 +12,7 @@ HOMEPAGE="https://www.gnu.org/software/libmicrohttpd/"
 SRC_URI="mirror://gnu/${PN}/${MY_P}.tar.gz"
 S="${WORKDIR}"/${MY_P}
 
-LICENSE="LGPL-2.1+"
+LICENSE="|| ( LGPL-2.1+ !ssl? ( GPL-2+-with-eCos-exception-2 ) )"
 SLOT="0/12"
 KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86"
 IUSE="+epoll ssl static-libs test +thread-names"

--- a/net-libs/libmicrohttpd/libmicrohttpd-0.9.76.ebuild
+++ b/net-libs/libmicrohttpd/libmicrohttpd-0.9.76.ebuild
@@ -12,7 +12,7 @@ HOMEPAGE="https://www.gnu.org/software/libmicrohttpd/"
 SRC_URI="mirror://gnu/${PN}/${MY_P}.tar.gz"
 S="${WORKDIR}"/${MY_P}
 
-LICENSE="LGPL-2.1+"
+LICENSE="|| ( LGPL-2.1+ !ssl? ( GPL-2+-with-eCos-exception-2 ) )"
 SLOT="0/12"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
 IUSE="+epoll ssl static-libs test +thread-names"


### PR DESCRIPTION
See https://git.gnunet.org/libmicrohttpd.git/tree/COPYING for libmicrohttpd license details.
eCos license could be found at http://ecos.sourceware.org/license-overview.html.
SPDX identifier: https://spdx.org/licenses/eCos-exception-2.0.html 