### PR TITLE
ROCm update for python 3.11

### DIFF
--- a/dev-util/rocm-smi/rocm-smi-5.1.3-r1.ebuild
+++ b/dev-util/rocm-smi/rocm-smi-5.1.3-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{9..10} )
+PYTHON_COMPAT=( python3_{9..11} )
 
 inherit cmake python-r1
 

--- a/dev-util/roctracer/roctracer-5.1.3-r1.ebuild
+++ b/dev-util/roctracer/roctracer-5.1.3-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{9..10} )
+PYTHON_COMPAT=( python3_{9..11} )
 
 inherit cmake prefix python-any-r1
 

--- a/sci-libs/rocFFT/rocFFT-5.1.3.ebuild
+++ b/sci-libs/rocFFT/rocFFT-5.1.3.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{9..10} )
+PYTHON_COMPAT=( python3_{9..11} )
 ROCM_VERSION=${PV}
 
 inherit cmake check-reqs edo multiprocessing python-r1 rocm


### PR DESCRIPTION
sci-libs/rocFFT: update for python 3.11
dev-util/ roctracer: update for python 3.11

Closes: https://bugs.gentoo.org/906131
Closes: https://bugs.gentoo.org/897226
Closes: https://bugs.gentoo.org/906132