### PR TITLE
sys-apps/lshw: fix does not allow register storage class specifier

### DIFF
--- a/sys-apps/lshw/files/lshw-02.19.2b-remove-register-keyword.patch
+++ b/sys-apps/lshw/files/lshw-02.19.2b-remove-register-keyword.patch
@@ -1,0 +1,26 @@
+https://github.com/listout/lshw/commit/9555d6cfc33a58a7cf91d137f7209ccf1bee86a8
+From: Lyonel Vincent <lyonel@ezix.org>
+Date: Tue, 12 Oct 2021 22:02:22 +0200
+Subject: [PATCH] code clean-up
+
+get rid of warning complaining about `register` storage of CRC
+Bug: https://bugs.gentoo.org/898546
+--- a/src/core/partitions.cc
++++ b/src/core/partitions.cc
+@@ -520,7 +520,6 @@ hwNode & partition)
+  * - Now pass seed as an arg
+  * - changed unsigned long to uint32_t, added #include<stdint.h>
+  * - changed len to be an unsigned long
+- * - changed crc32val to be a register
+  * - License remains unchanged!  It's still GPL-compatable!
+  */
+
+@@ -626,7 +625,7 @@ uint32_t
+ __efi_crc32(const void *buf, unsigned long len, uint32_t seed)
+ {
+   unsigned long i;
+-  register uint32_t crc32val;
++  uint32_t crc32val;
+   const unsigned char *s = (const unsigned char *)buf;
+
+   crc32val = seed;

--- a/sys-apps/lshw/lshw-02.19.2b_p20210121-r4.ebuild
+++ b/sys-apps/lshw/lshw-02.19.2b_p20210121-r4.ebuild
@@ -1,0 +1,86 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+PLOCALES='fr'
+
+inherit desktop flag-o-matic plocale toolchain-funcs xdg
+
+MY_COMMIT="fdab06ac0b190ea0aa02cd468f904ed69ce0d9f1"
+MY_PV=$(ver_cut 3 PV/b/B).$(ver_cut 1-3)_$(ver_cut 5-6)
+
+DESCRIPTION="Hardware Lister"
+HOMEPAGE="https://www.ezix.org/project/wiki/HardwareLiSter"
+SRC_URI="https://ezix.org/src/pkg/lshw/archive/${MY_COMMIT}.tar.gz -> ${P}-${MY_PV}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~riscv ~sparc ~x86 ~amd64-linux ~x86-linux"
+IUSE="gtk sqlite static"
+
+REQUIRED_USE="static? ( !gtk !sqlite )"
+
+DEPEND="${RDEPEND}"
+RDEPEND="sys-apps/hwdata
+	gtk? ( x11-libs/gtk+:3 )
+	sqlite? ( dev-db/sqlite:3 )"
+BDEPEND="gtk? ( virtual/pkgconfig )
+	sqlite? ( virtual/pkgconfig )"
+
+S=${WORKDIR}/${PN}
+
+DOCS=( COPYING README.md docs/{Changelog,TODO,IODC.txt,lshw.xsd,proc_usb_info.txt} )
+
+PATCHES=(
+	"${FILESDIR}"/lshw-02.19.2b-respect-LDFLAGS.patch
+	"${FILESDIR}"/lshw-02.19.2b-remove-register-keyword.patch
+)
+
+src_prepare() {
+	default
+
+	plocale_find_changes "src/po" "" ".po" || die
+	sed -i \
+		-e "/^LANGUAGES =/ s/=.*/= $(plocale_get_locales)/" \
+		src/po/Makefile || die
+	sed -i \
+		-e 's:\<pkg-config\>:${PKG_CONFIG}:' \
+		-e 's:+\?make -C:${MAKE} -C:' \
+		-e '/^CXXFLAGS/s:=-g: +=:' \
+		-e '/^CXXFLAGS/s:-g ::' \
+		-e '/^LDFLAGS/s: -g::' \
+		-e '/^all:/s: $(DATAFILES)::' \
+		-e '/^install:/s: all::' \
+		src/Makefile src/gui/Makefile || die
+	sed -i \
+		-e '/^CXXFLAGS/s:\?=-g: +=:' \
+		-e '/^LDFLAGS=/d' \
+		src/core/Makefile || die
+	sed -i \
+		-e '/^#define PCIID_PATH/s:DATADIR"\/pci.ids.*:"/usr/share/hwdata/pci.ids":' \
+		src/core/pci.cc || die
+	sed -i \
+		-e '/^#define USBID_PATH/s:DATADIR"\/usb.ids.*:"/usr/share/hwdata/usb.ids":' \
+		src/core/usb.cc || die
+}
+
+src_compile() {
+	tc-export CC CXX AR PKG_CONFIG
+	use static && append-ldflags -static
+
+	# Need two sep make statements to avoid parallel build issues. #588174
+	local sqlite=$(usex sqlite 1 0)
+	emake VERSION=${MY_PV} SQLITE=${sqlite} all
+	use gtk && emake SQLITE=${sqlite} gui
+}
+
+src_install() {
+	emake VERSION=${MY_PV} DESTDIR="${D}" PREFIX="${EPREFIX}/usr" install $(usex gtk 'install-gui' '')
+	if use gtk ; then
+		newicon -s scalable src/gui/artwork/logo.svg lshw.svg
+		make_desktop_entry \
+			"${EPREFIX}"/usr/sbin/gtk-lshw \
+			"${DESCRIPTION}"
+	fi
+}


### PR DESCRIPTION
Patch can be removed from a newer release as the fix has already been merged upstream.

Closes: https://bugs.gentoo.org/898546