### PR TITLE
app-office/calcurse-4.8.0: add missing dep for musl systems

### DIFF
--- a/app-office/calcurse/calcurse-4.8.0-r1.ebuild
+++ b/app-office/calcurse/calcurse-4.8.0-r1.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 PYTHON_COMPAT=( python3_{10..11} )
 
-inherit python-single-r1
+inherit autotools python-single-r1
 
 DESCRIPTION="A text-based calendar and scheduling application"
 HOMEPAGE="https://calcurse.org/"
@@ -19,6 +19,7 @@ IUSE="caldav doc"
 
 RDEPEND="
 	sys-libs/ncurses:0=
+	sys-libs/timezone-data
 	${PYTHON_DEPS}
 	caldav? (
 		$(python_gen_cond_dep '
@@ -42,7 +43,9 @@ src_configure() {
 
 src_compile() {
 	default
-	python_fix_shebang contrib/caldav/calcurse-caldav
+	if use caldav; then
+		python_fix_shebang contrib/caldav/calcurse-caldav
+	fi
 }
 
 src_install() {


### PR DESCRIPTION
Musl does not pull in sys-libs/timezone-data, which calcurse requires.

Closes: https://bugs.gentoo.org/906212