### PR TITLE
sys-apps/kbd: depend on app-alternatives/gzip

### DIFF
--- a/sys-apps/kbd/kbd-2.5.1.ebuild
+++ b/sys-apps/kbd/kbd-2.5.1.ebuild
@@ -31,7 +31,7 @@ RESTRICT="!test? ( test )"
 QA_AM_MAINTAINER_MODE=".*--run autom4te --language=autotest.*"
 
 RDEPEND="
-	app-arch/gzip
+	app-alternatives/gzip
 	pam? (
 		!app-misc/vlock
 		sys-libs/pam

--- a/sys-apps/kbd/kbd-9999.ebuild
+++ b/sys-apps/kbd/kbd-9999.ebuild
@@ -31,7 +31,7 @@ RESTRICT="!test? ( test )"
 QA_AM_MAINTAINER_MODE=".*--run autom4te --language=autotest.*"
 
 RDEPEND="
-	app-arch/gzip
+	app-alternatives/gzip
 	pam? (
 		!app-misc/vlock
 		sys-libs/pam


### PR DESCRIPTION
...instead of directly depending on app-arch/gzip since users can select alternative implementations (such as pigz) through the app-alternatives system.