### PR TITLE
sys-apps/openrc: Adding -DPREFIX cflag for USE=prefix

### DIFF
--- a/sys-apps/openrc/openrc-0.45.2-r2.ebuild
+++ b/sys-apps/openrc/openrc-0.45.2-r2.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-inherit meson pam
+inherit flag-o-matic meson pam
 
 DESCRIPTION="OpenRC manages the services, startup and shutdown of a host"
 HOMEPAGE="https://github.com/openrc/openrc/"
@@ -72,6 +72,7 @@ src_configure() {
 		$(meson_use sysv-utils sysvinit)
 		-Dtermcap=$(usev ncurses)
 	)
+	use prefix && append-cflags -DPREFIX
 	# export DEBUG=$(usev debug)
 	meson_src_configure
 }

--- a/sys-apps/openrc/openrc-0.46.ebuild
+++ b/sys-apps/openrc/openrc-0.46.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit meson pam
+inherit flag-o-matic meson pam
 
 DESCRIPTION="OpenRC manages the services, startup and shutdown of a host"
 HOMEPAGE="https://github.com/openrc/openrc/"
@@ -68,6 +68,7 @@ src_configure() {
 		$(meson_use sysv-utils sysvinit)
 		-Dtermcap=$(usev ncurses)
 	)
+	use prefix && append-cflags -DPREFIX
 	# export DEBUG=$(usev debug)
 	meson_src_configure
 }

--- a/sys-apps/openrc/openrc-9999.ebuild
+++ b/sys-apps/openrc/openrc-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit meson pam
+inherit flag-o-matic meson pam
 
 DESCRIPTION="OpenRC manages the services, startup and shutdown of a host"
 HOMEPAGE="https://github.com/openrc/openrc/"
@@ -68,6 +68,7 @@ src_configure() {
 		$(meson_use sysv-utils sysvinit)
 		-Dtermcap=$(usev ncurses)
 	)
+	use prefix && append-cflags -DPREFIX
 	# export DEBUG=$(usev debug)
 	meson_src_configure
 }


### PR DESCRIPTION
@heroxbd 

Before 0.45, Makefiles recognize MKPREFIX=yes variables and adding -DPREFIX. There's no such mechanism in the meson build system, thus issues occurs on prefix systems, including "superuser access required" error message when start/stopping services.

Directly adding this flag now in ebuild to support prefix fix this.