### PR TITLE
app-arch/p7zip: install docs unconditionally

### DIFF
--- a/app-arch/p7zip/p7zip-16.02-r8.ebuild
+++ b/app-arch/p7zip/p7zip-16.02-r8.ebuild
@@ -14,7 +14,7 @@ S="${WORKDIR}/${PN}_${PV}"
 LICENSE="LGPL-2.1 rar? ( unRAR )"
 SLOT="0"
 KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos"
-IUSE="abi_x86_x32 doc kde +pch rar static wxwidgets"
+IUSE="abi_x86_x32 kde +pch rar static wxwidgets"
 REQUIRED_USE="kde? ( wxwidgets )"
 
 RDEPEND="wxwidgets? ( x11-libs/wxGTK:${WX_GTK_VER}[X] )"
@@ -143,9 +143,7 @@ src_install() {
 	doman man1/7z.1 man1/7za.1 man1/7zr.1
 
 	dodoc ChangeLog README TODO
-	if use doc; then
-		dodoc DOC/*.txt
-		docinto html
-		dodoc -r DOC/MANUAL/.
-	fi
+	dodoc DOC/*.txt
+	docinto html
+	dodoc -r DOC/MANUAL/.
 }

--- a/app-arch/p7zip/p7zip-17.05-r1.ebuild
+++ b/app-arch/p7zip/p7zip-17.05-r1.ebuild
@@ -13,7 +13,7 @@ SRC_URI="https://github.com/p7zip-project/p7zip/archive/v${PV}.tar.gz -> ${P}.ta
 LICENSE="LGPL-2.1 rar? ( unRAR )"
 SLOT="0"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos"
-IUSE="abi_x86_x32 doc natspec +pch rar static"
+IUSE="abi_x86_x32 natspec +pch rar static"
 
 RDEPEND="natspec? ( dev-libs/libnatspec )"
 DEPEND="${RDEPEND}"
@@ -106,9 +106,7 @@ src_install() {
 	doman man1/7z.1 man1/7za.1 man1/7zr.1
 
 	dodoc ChangeLog README TODO
-	if use doc; then
-		dodoc DOC/*.txt
-		docinto html
-		dodoc -r DOC/MANUAL/.
-	fi
+	dodoc DOC/*.txt
+	docinto html
+	dodoc -r DOC/MANUAL/.
 }


### PR DESCRIPTION
The QA policy is to install small files (that require no additional dependency to build) to be installed unconditionally: https://projects.gentoo.org/qa/policy-guide/installed-files.html#pg0301