### PR TITLE
gui-libs/wlroots: fix building with seatd, revbump to wlroots-0.16.2-r1

### DIFF
--- a/gui-libs/wlroots/metadata.xml
+++ b/gui-libs/wlroots/metadata.xml
@@ -21,9 +21,10 @@
 		wlroots is developed under the direction of the <pkg>gui-wm/sway</pkg> project.
 	</longdescription>
 	<use>
-		<flag name="hwdata">Use system hwdata</flag>
-		<flag name="liftoff">Enable support for libliftoff kms plane backend</flag>
-		<flag name="seatd">Enable libseatd session support</flag>
+		<flag name="drm">Enable Direct Rendering Management</flag>
+		<flag name="liftoff">Enable support for libliftoff KMS plane backend</flag>
+		<flag name="libinput">Enable support for input devices via <pkg>dev-libs/libinput</pkg></flag>
+		<flag name="session">Enable session support (is required for DRM and libinput)</flag>
 		<flag name="tinywl">Install the minimal wayland client, tinywl</flag>
 		<flag name="vulkan">Enable support for the vulkan backend renderer</flag>
 		<flag name="x11-backend">Enable support for handling input/output devices through <pkg>x11-libs/libxcb</pkg></flag>

--- a/gui-libs/wlroots/wlroots-9999.ebuild
+++ b/gui-libs/wlroots/wlroots-9999.ebuild
@@ -19,18 +19,23 @@ else
 fi
 
 LICENSE="MIT"
-IUSE="+hwdata liftoff +seatd tinywl +udev vulkan x11-backend xcb-errors X"
+IUSE="liftoff +libinput +drm +session tinywl vulkan x11-backend xcb-errors X"
+REQUIRED_USE="drm? ( session ) libinput? ( session )"
 
 DEPEND="
-	>=dev-libs/libinput-1.14.0:0=
 	>=dev-libs/wayland-1.22.0
 	>=dev-libs/wayland-protocols-1.28
+	drm? (
+		liftoff? ( dev-libs/libliftoff )
+		media-libs/libdisplay-info
+		sys-apps/hwdata:=
+	)
+	libinput? ( >=dev-libs/libinput-1.14.0:0= )
 	media-libs/mesa[egl(+),gles2]
-	media-libs/libdisplay-info
-	hwdata? ( sys-apps/hwdata:= )
-	liftoff? ( dev-libs/libliftoff )
-	seatd? ( sys-auth/seatd:= )
-	udev? ( virtual/libudev )
+	session? (
+		sys-auth/seatd:=
+		virtual/libudev
+	)
 	vulkan? (
 		dev-util/glslang:0=
 		dev-util/vulkan-headers:0=
@@ -60,20 +65,22 @@ BDEPEND="
 "
 
 src_configure() {
+	local backends=(
+		$(usev drm)
+		$(usev libinput)
+		$(usev x11-backend 'x11')
+	)
+	# Separate values with a comma with this evil floating point bit hack
+	local meson_backends=$(IFS=','; echo "${backends[*]}")
 	# xcb-util-errors is not on Gentoo Repository (and upstream seems inactive?)
 	local emesonargs=(
-		"-Dxcb-errors=disabled"
-		-Dxcb-errors=$(usex xcb-errors enabled disabled)
+		$(meson_feature xcb-errors)
 		$(meson_use tinywl examples)
 		-Drenderers=$(usex vulkan 'gles2,vulkan' gles2)
-		-Dxwayland=$(usex X enabled disabled)
-		-Dbackends=drm,libinput$(usex x11-backend ',x11' '')
+		$(meson_feature X xwayland)
+		-Dbackends=${meson_backends}
+		$(meson_feature session)
 	)
-	if use udev; then
-		emesonargs+=(-Dsession=$(usex seatd enabled disabled))
-	else
-		emesonargs+=(-Dsession=disabled)
-	fi
 
 	meson_src_configure
 }


### PR DESCRIPTION
So, the initial issue was in compilation failure if seatd USE flag was disabled - it didn't do anything (in wlroots <=0.16.2 seatd is mandatory).
In 9999 version it is optional, though, but is required for DRM and libinput, so I reworked backends system a bit.

I have done a bit of a testing - all the ebuilds for wlroots (even the ones I haven't touched) were successfuly recompiled (except for unsatisfying required USE) with any combination of the following USE flags I added: drm, libinput, session.

Bug: https://bugs.gentoo.org/883781
Closes: https://bugs.gentoo.org/883781