### PR TITLE
dev-libs/darts: Fix no member named 'random_shuffle' in namespace 'std'

### DIFF
--- a/dev-libs/darts/darts-0.32h_pre20181117064816-r1.ebuild
+++ b/dev-libs/darts/darts-0.32h_pre20181117064816-r1.ebuild
@@ -1,0 +1,59 @@
+# Copyright 2003-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="7"
+WANT_LIBTOOL="none"
+
+inherit autotools
+
+if [[ "${PV}" == "9999" ]]; then
+	inherit git-r3
+
+	EGIT_REPO_URI="https://github.com/s-yata/darts-clone"
+else
+	DARTS_CLONE_GIT_REVISION="e40ce4627526985a7767444b6ed6893ab6ff8983"
+fi
+
+DESCRIPTION="Darts-clone (Double-ARray Trie System) C++ library"
+# Original upstream: http://chasen.org/~taku/software/darts/
+HOMEPAGE="https://github.com/s-yata/darts-clone https://code.google.com/archive/p/darts-clone/"
+if [[ "${PV}" == "9999" ]]; then
+	SRC_URI=""
+else
+	SRC_URI="https://github.com/s-yata/darts-clone/archive/${DARTS_CLONE_GIT_REVISION}.tar.gz -> ${P}.tar.gz"
+fi
+
+LICENSE="BSD-2"
+SLOT="0"
+KEYWORDS="~amd64 ~arm64 ~hppa ~ia64 ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~sparc-solaris ~x86-solaris"
+IUSE=""
+
+BDEPEND=""
+DEPEND=""
+RDEPEND=""
+
+if [[ "${PV}" != "9999" ]]; then
+	S="${WORKDIR}/darts-clone-${DARTS_CLONE_GIT_REVISION}"
+fi
+
+PATCHES=( "${FILESDIR}"/${PN}-using-custom-random-shuffle.patch )
+
+src_prepare() {
+	default
+	eaclocal
+	eautoconf
+	eautomake
+}
+
+src_install() {
+	default
+
+	local language source_file target_file
+	for source_file in doc/*/*.md; do
+		language="${source_file#*/}"
+		language="${language%%/*}"
+		target_file="${source_file##*/}"
+		target_file="${target_file%.md}.${language}.md"
+		newdoc "${source_file}" "${target_file}"
+	done
+}

--- a/dev-libs/darts/files/darts-using-custom-random-shuffle.patch
+++ b/dev-libs/darts/files/darts-using-custom-random-shuffle.patch
@@ -1,0 +1,44 @@
+From dbf839b982ecb8f3456c14195204d9d1a8a18a7d Mon Sep 17 00:00:00 2001
+From: Brahmajit Das <brahmajit.xyz@gmail.com>
+Date: Sun, 14 May 2023 11:15:13 +0530
+Subject: [PATCH] Using custom random_shuffle
+
+C++17 have removed random_shuffle (deprecated in C++14). Upstream seems
+dead too, hence using custom implementation of random_shuffle from
+https://en.cppreference.com/w/cpp/algorithm/random_shuffle.
+
+Signed-off-by: Brahmajit Das <brahmajit.xyz@gmail.com>
+Bug: https://bugs.gentoo.org/902851
+--- a/src/lexicon.h
++++ b/src/lexicon.h
+@@ -11,6 +11,18 @@
+ 
+ #include "./mersenne-twister.h"
+ 
++template<class RandomIt, class RandomFunc>
++void random_shuffle(RandomIt first, RandomIt last, RandomFunc&& r)
++{
++    typedef typename std::iterator_traits<RandomIt>::difference_type diff_t;
++ 
++    for (diff_t i = last - first - 1; i > 0; --i)
++    {
++        using std::swap;
++        swap(first[i], first[r(i + 1)]);
++    }
++}
++
+ namespace Darts {
+ 
+ class Lexicon {
+@@ -60,7 +72,7 @@ class Lexicon {
+   void randomize() {
+     Darts::MersenneTwister mt(
+         static_cast<Darts::MersenneTwister::int_type>(std::time(NULL)));
+-    std::random_shuffle(keys_.begin(), keys_.end(), mt);
++    random_shuffle(keys_.begin(), keys_.end(), mt);
+   }
+ 
+   void split();
+-- 
+2.40.1
+


### PR DESCRIPTION
random_shuffle has been removed since c++17 hence using a custom implemention.

Closes: https://bugs.gentoo.org/902851