### PR TITLE
kde-frameworks/kdelibs4support: add upstream libressl patch

### DIFF
--- a/kde-frameworks/kdelibs4support/files/kdelibs4support-5.106.0-libressl.patch
+++ b/kde-frameworks/kdelibs4support/files/kdelibs4support-5.106.0-libressl.patch
@@ -1,0 +1,167 @@
+https://bugs.gentoo.org/903001
+https://invent.kde.org/frameworks/kdelibs4support/-/merge_requests/26
+https://invent.kde.org/frameworks/kdelibs4support/-/commit/12501f23780dc66f87532f725e277dbf90533ab0
+
+From 12501f23780dc66f87532f725e277dbf90533ab0 Mon Sep 17 00:00:00 2001
+From: Orbea variegata <orbea@riseup.net>
+Date: Mon, 10 Apr 2023 16:52:13 -0700
+Subject: [PATCH] kssl: Update for LibreSSL 3.7
+
+Current LibreSSL versions do not need these legacy OpenSSL code paths
+which will result in a build failure.
+
+LibreSSL doesn't have OPENSSL_sk_free yet and this corrects the mistaken
+define.
+
+Based on patches from OpenBSD:
+
+https://github.com/openbsd/ports/blob/29e060f1b622de29c6fe98cbd08039d12f05c1e1/devel/kf5/kdelibs4support/patches/patch-src_kssl_kopenssl_cpp
+https://github.com/openbsd/ports/blob/29e060f1b622de29c6fe98cbd08039d12f05c1e1/devel/kf5/kdelibs4support/patches/patch-src_kssl_ksslcertificate_cpp
+---
+ src/kssl/kopenssl.cpp        | 28 ++++++++++++++--------------
+ src/kssl/ksslcertificate.cpp |  2 +-
+ 2 files changed, 15 insertions(+), 15 deletions(-)
+
+diff --git a/src/kssl/kopenssl.cpp b/src/kssl/kopenssl.cpp
+index 80533ec7c..15cb8a403 100644
+--- a/src/kssl/kopenssl.cpp
++++ b/src/kssl/kopenssl.cpp
+@@ -484,7 +484,7 @@ KOpenSSLProxy::KOpenSSLProxy()
+         K_X509_STORE_CTX_get_current_cert = (X509 * (*)(X509_STORE_CTX *)) d->cryptoLib->resolve("X509_STORE_CTX_get_current_cert");
+         K_X509_STORE_CTX_set_error = (void (*)(X509_STORE_CTX *, int)) d->cryptoLib->resolve("X509_STORE_CTX_set_error");
+         K_X509_STORE_CTX_get_error = (int (*)(X509_STORE_CTX *)) d->cryptoLib->resolve("X509_STORE_CTX_get_error");
+-#if OPENSSL_VERSION_NUMBER >= 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
++#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
+         K_OPENSSL_sk_free = (void (*)(STACK *)) d->cryptoLib->resolve("OPENSSL_sk_free");
+         K_OPENSSL_sk_num = (int (*)(STACK *)) d->cryptoLib->resolve("OPENSSL_sk_num");
+         K_OPENSSL_sk_pop = (char *(*)(STACK *)) d->cryptoLib->resolve("OPENSSL_sk_pop");
+@@ -978,7 +978,7 @@ void KOpenSSLProxy::X509_STORE_free(X509_STORE *v)
+ 
+ void KOpenSSLProxy::X509_STORE_set_verify_cb(X509_STORE *store, int (*verify_cb)(int, X509_STORE_CTX *))
+ {
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+     X509_STORE_set_verify_cb_func(store, verify_cb);
+ #else
+     if (K_X509_STORE_set_verify_cb) {
+@@ -1043,7 +1043,7 @@ X509_NAME *KOpenSSLProxy::X509_get_issuer_name(X509 *a)
+ 
+ void KOpenSSLProxy::X509_get0_signature(const ASN1_BIT_STRING **psig, const X509_ALGOR **algor, const X509 *x)
+ {
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+     if (psig) {
+         *psig = x->signature;
+     }
+@@ -1121,7 +1121,7 @@ X509 *KOpenSSLProxy::X509_dup(X509 *x509)
+ 
+ ASN1_TIME *KOpenSSLProxy::X509_getm_notBefore(const X509 *x)
+ {
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+     return X509_get_notBefore(x);
+ #else
+     if (K_X509_getm_notBefore) {
+@@ -1134,7 +1134,7 @@ ASN1_TIME *KOpenSSLProxy::X509_getm_notBefore(const X509 *x)
+ 
+ ASN1_TIME *KOpenSSLProxy::X509_getm_notAfter(const X509 *x)
+ {
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+     return X509_get_notAfter(x);
+ #else
+     if (K_X509_getm_notAfter) {
+@@ -1412,7 +1412,7 @@ void KOpenSSLProxy::X509_STORE_CTX_set_purpose(X509_STORE_CTX *v, int purpose)
+ 
+ X509 *KOpenSSLProxy::X509_STORE_CTX_get_current_cert(X509_STORE_CTX *v)
+ {
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+     return v->current_cert;
+ #else
+     if (K_X509_STORE_CTX_get_current_cert) {
+@@ -1425,7 +1425,7 @@ X509 *KOpenSSLProxy::X509_STORE_CTX_get_current_cert(X509_STORE_CTX *v)
+ 
+ void KOpenSSLProxy::X509_STORE_CTX_set_error(X509_STORE_CTX *v, int error)
+ {
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+     v->error = error;
+ #else
+     if (K_X509_STORE_CTX_set_error) {
+@@ -1436,7 +1436,7 @@ void KOpenSSLProxy::X509_STORE_CTX_set_error(X509_STORE_CTX *v, int error)
+ 
+ int KOpenSSLProxy::X509_STORE_CTX_get_error(X509_STORE_CTX *v)
+ {
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+     return v->error;
+ #else
+     if (K_X509_STORE_CTX_get_error) {
+@@ -1893,7 +1893,7 @@ int KOpenSSLProxy::EVP_PKEY_assign(EVP_PKEY *pkey, int type, char *key)
+ 
+ int KOpenSSLProxy::EVP_PKEY_base_id(EVP_PKEY *pkey)
+ {
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+     return pkey->type;
+ #else
+     if (K_EVP_PKEY_base_id) {
+@@ -1906,7 +1906,7 @@ int KOpenSSLProxy::EVP_PKEY_base_id(EVP_PKEY *pkey)
+ 
+ RSA *KOpenSSLProxy::EVP_PKEY_get0_RSA(EVP_PKEY *pkey)
+ {
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+     return pkey->pkey.rsa;
+ #else
+     if (K_EVP_PKEY_get0_RSA) {
+@@ -1919,7 +1919,7 @@ RSA *KOpenSSLProxy::EVP_PKEY_get0_RSA(EVP_PKEY *pkey)
+ 
+ void KOpenSSLProxy::RSA_get0_key(RSA *rsa, const BIGNUM **n, const BIGNUM **e, const BIGNUM **d)
+ {
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+     if (n) {
+         *n = rsa->n;
+     }
+@@ -1938,7 +1938,7 @@ void KOpenSSLProxy::RSA_get0_key(RSA *rsa, const BIGNUM **n, const BIGNUM **e, c
+ 
+ DSA *KOpenSSLProxy::EVP_PKEY_get0_DSA(EVP_PKEY *pkey)
+ {
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+     return pkey->pkey.dsa;
+ #else
+     if (K_EVP_PKEY_get0_DSA) {
+@@ -1951,7 +1951,7 @@ DSA *KOpenSSLProxy::EVP_PKEY_get0_DSA(EVP_PKEY *pkey)
+ 
+ void KOpenSSLProxy::DSA_get0_pqg(DSA *dsa, const BIGNUM **p, const BIGNUM **q, const BIGNUM **g)
+ {
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+     if (p) {
+         *p = dsa->p;
+     }
+@@ -1970,7 +1970,7 @@ void KOpenSSLProxy::DSA_get0_pqg(DSA *dsa, const BIGNUM **p, const BIGNUM **q, c
+ 
+ void KOpenSSLProxy::DSA_get0_key(DSA *dsa, const BIGNUM **pub_key, const BIGNUM **priv_key)
+ {
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
++#if OPENSSL_VERSION_NUMBER < 0x10100000L
+     if (pub_key) {
+         *pub_key = dsa->pub_key;
+     }
+diff --git a/src/kssl/ksslcertificate.cpp b/src/kssl/ksslcertificate.cpp
+index 75e234fe1..129012779 100644
+--- a/src/kssl/ksslcertificate.cpp
++++ b/src/kssl/ksslcertificate.cpp
+@@ -1222,7 +1222,7 @@ QByteArray KSSLCertificate::toNetscape()
+ {
+     QByteArray qba;
+      // no equivalent in OpenSSL 1.1.0 (?), so behave as if we had no OpenSSL at all
+-#if KSSL_HAVE_SSL && (OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER))
++#if KSSL_HAVE_SSL && (OPENSSL_VERSION_NUMBER < 0x10100000L)
+     NETSCAPE_X509 nx;
+     ASN1_OCTET_STRING hdr;
+     QTemporaryFile ktf;

--- a/kde-frameworks/kdelibs4support/kdelibs4support-5.106.0.ebuild
+++ b/kde-frameworks/kdelibs4support/kdelibs4support-5.106.0.ebuild
@@ -80,6 +80,7 @@ BDEPEND="
 "
 
 PATCHES=(
+	"${FILESDIR}/${P}-libressl.patch" # bug 903001
 	# downstream patches
 	"${FILESDIR}/${PN}-5.80.0-no-kdesignerplugin.patch" # bug 755956
 	"${FILESDIR}/${PN}-5.86.0-unused-dep.patch" # bug 755956


### PR DESCRIPTION
This patch was merged upstream removing many outdated LibreSSL code paths and fixing one incorrect one.

Bug: https://bugs.gentoo.org/903001
Upstream-PR: https://invent.kde.org/frameworks/kdelibs4support/-/merge_requests/26
Upstream-Commit: https://invent.kde.org/frameworks/kdelibs4support/-/commit/12501f23780dc66f87532f725e277dbf90533ab0