### PR TITLE
app-text/crf++: Removing register keywords

### DIFF
--- a/app-text/crf++/crf++-0.58-r2.ebuild
+++ b/app-text/crf++/crf++-0.58-r2.ebuild
@@ -1,0 +1,47 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools
+
+DESCRIPTION="Yet Another CRF toolkit for segmenting/labelling sequential data"
+HOMEPAGE="https://taku910.github.io/crfpp/"
+SRC_URI="mirror://gentoo/${P^^}.tar.gz"
+S="${WORKDIR}/${P^^}"
+
+LICENSE="|| ( BSD LGPL-2.1 )"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="examples"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-autotools.patch
+	"${FILESDIR}"/${P}-registers.patch
+)
+HTML_DOCS=( doc/. )
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_test() {
+	local d
+	for d in example/*; do
+		pushd "${d}" >/dev/null || die
+		./exec.sh || die "failed test in ${d}"
+		popd >/dev/null || die
+	done
+}
+
+src_install() {
+	default
+
+	if use examples; then
+		dodoc -r example
+		docompress -x /usr/share/doc/${PF}/example
+	fi
+
+	find "${ED}" -name '*.la' -type f -delete || die
+}

--- a/app-text/crf++/files/crf++-0.58-registers.patch
+++ b/app-text/crf++/files/crf++-0.58-registers.patch
@@ -1,0 +1,57 @@
+From 12204f40fdab494328931f12f45ad7d884ef6dac Mon Sep 17 00:00:00 2001
+From: Brahmajit Das <brahmajit.xyz@gmail.com>
+Date: Tue, 16 May 2023 12:29:40 +0530
+Subject: [PATCH] Removing register keywords
+
+The register keyword has been dropped since C++17.
+
+Bug: https://bugs.gentoo.org/894642
+Signed-off-by: Brahmajit Das <brahmajit.xyz@gmail.com>
+--- a/darts.h
++++ b/darts.h
+@@ -404,10 +404,10 @@ class DoubleArrayImpl {
+     T result;
+     set_result(result, -1, 0);
+ 
+-    register array_type_  b = array_[node_pos].base;
+-    register array_u_type_ p;
++    array_type_  b = array_[node_pos].base;
++    array_u_type_ p;
+ 
+-    for (register size_t i = 0; i < len; ++i) {
++    for (size_t i = 0; i < len; ++i) {
+       p = b +(node_u_type_)(key[i]) + 1;
+       if (static_cast<array_u_type_>(b) == array_[p].check)
+         b = array_[p].base;
+@@ -431,12 +431,12 @@ class DoubleArrayImpl {
+                             size_t node_pos = 0) const {
+     if (!len) len = length_func_()(key);
+ 
+-    register array_type_  b   = array_[node_pos].base;
+-    register size_t     num = 0;
+-    register array_type_  n;
+-    register array_u_type_ p;
++    array_type_  b   = array_[node_pos].base;
++    size_t     num = 0;
++    array_type_  n;
++    array_u_type_ p;
+ 
+-    for (register size_t i = 0; i < len; ++i) {
++    for (size_t i = 0; i < len; ++i) {
+       p = b;  // + 0;
+       n = array_[p].base;
+       if ((array_u_type_) b == array_[p].check && n < 0) {
+@@ -469,8 +469,8 @@ class DoubleArrayImpl {
+                       size_t len = 0) const {
+     if (!len) len = length_func_()(key);
+ 
+-    register array_type_  b = array_[node_pos].base;
+-    register array_u_type_ p;
++    array_type_  b = array_[node_pos].base;
++    array_u_type_ p;
+ 
+     for (; key_pos < len; ++key_pos) {
+       p = b +(node_u_type_)(key[key_pos]) + 1;
+-- 
+2.40.1
+


### PR DESCRIPTION
The register keyword has been dropped since C++17.

Closes: https://bugs.gentoo.org/894642