### PR TITLE
sys-boot/plymouth: Fix call to undeclared function rpmatch on musl

### DIFF
--- a/sys-boot/plymouth/files/plymouth-22.02.122-rpmatch-musl.patch
+++ b/sys-boot/plymouth/files/plymouth-22.02.122-rpmatch-musl.patch
@@ -1,0 +1,35 @@
+From bd9d2d7e4a6df4608962bfbe0a85b716fffe9e03 Mon Sep 17 00:00:00 2001
+From: Brahmajit Das <brahmajit.xyz@gmail.com>
+Date: Tue, 16 May 2023 12:53:29 +0530
+Subject: [PATCH] Dont use rpmatch on non glibc systems
+
+The funciton rpmatch is available only on glibc, so other build systems
+like musl will give undeclared funtion error.
+
+Patch taken from alpine linux distribution
+https://git.alpinelinux.org/aports/tree/community/plymouth/plymouth-rpmatch.patch
+
+Signed-off-by: Brahmajit Das <brahmajit.xyz@gmail.com>
+--- a/src/libply/ply-command-parser.c
++++ b/src/libply/ply-command-parser.c
+@@ -76,6 +76,17 @@ struct _ply_command_parser
+         uint32_t          dispatch_is_queued : 1;
+ };
+ 
++// From https://git.alpinelinux.org/aports/tree/community/plymouth/plymouth-rpmatch.patch
++#ifndef __GLIBC__
++static inline int
++rpmatch (const char *response)
++{
++  /* Test against "^[yY]" and "^[nN]", hardcoded to avoid requiring regex */
++  return (*response == 'y' || *response == 'Y' ? 1
++	  : *response == 'n' || *response == 'N' ? 0 : -1);
++}
++#endif /* ifndef __GLIBC__ */
++
+ static ply_command_option_t *
+ ply_command_option_new (const char               *name,
+                         const char               *description,
+-- 
+2.40.1
+

--- a/sys-boot/plymouth/plymouth-22.02.122-r2.ebuild
+++ b/sys-boot/plymouth/plymouth-22.02.122-r2.ebuild
@@ -1,0 +1,114 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit flag-o-matic
+SRC_URI="https://dev.gentoo.org/~aidecoe/distfiles/${CATEGORY}/${PN}/gentoo-logo.png"
+
+if [[ ${PV} == 9999 ]]; then
+	inherit git-r3
+	EGIT_REPO_URI="https://gitlab.freedesktop.org/plymouth/plymouth"
+else
+	SRC_URI="${SRC_URI} https://www.freedesktop.org/software/plymouth/releases/${P}.tar.xz"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~ia64 ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86"
+fi
+
+inherit autotools readme.gentoo-r1 systemd
+
+DESCRIPTION="Graphical boot animation (splash) and logger"
+HOMEPAGE="https://cgit.freedesktop.org/plymouth/"
+
+LICENSE="GPL-2"
+SLOT="0"
+IUSE="debug +drm +gtk +pango +split-usr static-libs +udev"
+
+CDEPEND="
+	>=media-libs/libpng-1.2.16:=
+	drm? ( x11-libs/libdrm )
+	gtk? (
+		dev-libs/glib:2
+		>=x11-libs/gtk+-3.14:3
+		x11-libs/cairo
+	)
+	pango? ( >=x11-libs/pango-1.21 )
+"
+DEPEND="${CDEPEND}
+	elibc_musl? ( sys-libs/rpmatch-standalone )
+	app-text/docbook-xsl-stylesheets
+	dev-libs/libxslt
+	virtual/pkgconfig
+"
+# Block due bug #383067
+RDEPEND="${CDEPEND}
+	udev? ( virtual/udev )
+	!<sys-kernel/dracut-0.37-r3
+"
+
+DOC_CONTENTS="
+	Follow the following instructions to set up Plymouth:\n
+	https://wiki.gentoo.org/wiki/Plymouth#Configuration
+"
+
+PATCHES=(
+	"${FILESDIR}"/0.9.3-glibc-sysmacros.patch
+	"${FILESDIR}"/${P}-glibc-2.36.patch
+	"${FILESDIR}"/${P}-rpmatch-musl.patch
+)
+
+src_prepare() {
+	use elibc_musl && append-ldflags -lrpmatch
+	default
+	eautoreconf
+}
+
+src_configure() {
+	local myconf=(
+		--with-system-root-install=no
+		--localstatedir=/var
+		--without-rhgb-compat-link
+		--enable-documentation
+		--enable-systemd-integration
+		--with-systemdunitdir="$(systemd_get_systemunitdir)"
+		$(use_enable !static-libs shared)
+		$(use_enable static-libs static)
+		$(use_enable debug tracing)
+		$(use_enable drm)
+		$(use_enable gtk)
+		$(use_enable pango)
+		$(use_with udev)
+	)
+	econf "${myconf[@]}"
+}
+
+src_install() {
+	default
+
+	insinto /usr/share/plymouth
+	newins "${DISTDIR}"/gentoo-logo.png bizcom.png
+
+	if use split-usr ; then
+		# Install compatibility symlinks as some rdeps hardcode the paths
+		dosym ../usr/bin/plymouth /bin/plymouth
+		dosym ../usr/sbin/plymouth-set-default-theme /sbin/plymouth-set-default-theme
+		dosym ../usr/sbin/plymouthd /sbin/plymouthd
+	fi
+
+	readme.gentoo_create_doc
+
+	# looks like make install create /var/run/plymouth
+	# this is not needed for systemd, same should hold for openrc
+	# so remove
+	rm -rf "${D}"/var/run
+
+	# fix broken symlink
+	dosym ../../bizcom.png /usr/share/plymouth/themes/spinfinity/header-image.png
+}
+
+pkg_postinst() {
+	readme.gentoo_print_elog
+	if ! has_version "sys-kernel/dracut"; then
+		ewarn "If you want initramfs builder with plymouth support, please emerge"
+		ewarn "sys-kernel/dracut."
+	fi
+}


### PR DESCRIPTION
rpmatch is not available on musl, hence had to define it ourselves.

Closes: https://bugs.gentoo.org/898564