### PR TITLE
media-sound/qjackctl: fix build when qt6 is installed

### DIFF
--- a/media-sound/qjackctl/qjackctl-0.9.10.ebuild
+++ b/media-sound/qjackctl/qjackctl-0.9.10.ebuild
@@ -41,6 +41,7 @@ src_configure() {
 		-DCONFIG_DBUS=$(usex dbus 1 0)
 		-DCONFIG_DEBUG=$(usex debug 1 0)
 		-DCONFIG_PORTAUDIO=$(usex portaudio 1 0)
+		-DCONFIG_QT6=no
 	)
 	cmake_src_configure
 }

--- a/media-sound/qjackctl/qjackctl-9999.ebuild
+++ b/media-sound/qjackctl/qjackctl-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -37,6 +37,7 @@ src_configure() {
 		-DCONFIG_DBUS=$(usex dbus 1 0)
 		-DCONFIG_DEBUG=$(usex debug 1 0)
 		-DCONFIG_PORTAUDIO=$(usex portaudio 1 0)
+		-DCONFIG_QT6=no
 	)
 	cmake_src_configure
 }


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/880049