### PR TITLE
sys-devel/clang: Remove filter-lto

### DIFF
--- a/sys-devel/clang/clang-16.0.3.ebuild
+++ b/sys-devel/clang/clang-16.0.3.ebuild
@@ -254,8 +254,6 @@ get_distribution_components() {
 }
 
 multilib_src_configure() {
-	tc-is-gcc && filter-lto # GCC miscompiles LLVM, bug #873670
-
 	local mycmakeargs=(
 		-DDEFAULT_SYSROOT=$(usex prefix-guest "" "${EPREFIX}")
 		-DCMAKE_INSTALL_PREFIX="${EPREFIX}/usr/lib/llvm/${LLVM_MAJOR}"

--- a/sys-devel/clang/clang-17.0.0_pre20230512.ebuild
+++ b/sys-devel/clang/clang-17.0.0_pre20230512.ebuild
@@ -252,8 +252,6 @@ get_distribution_components() {
 }
 
 multilib_src_configure() {
-	tc-is-gcc && filter-lto # GCC miscompiles LLVM, bug #873670
-
 	local mycmakeargs=(
 		-DDEFAULT_SYSROOT=$(usex prefix-guest "" "${EPREFIX}")
 		-DCMAKE_INSTALL_PREFIX="${EPREFIX}/usr/lib/llvm/${LLVM_MAJOR}"


### PR DESCRIPTION
Thanks to the work of fixing the gcc lto issue clang no longer needs this filter-lto flag on these two ebuilds when compiled with GCC using -flto. From testing these two don't need a revbump as clang will be compiled with the same cflags as llvm so it feels like wasting non-lto users time adding the bump.