### PR TITLE
x11-libs/libXpm: depend on app-alternatives/gzip

### DIFF
--- a/x11-libs/libXpm/libXpm-3.5.16.ebuild
+++ b/x11-libs/libXpm/libXpm-3.5.16.ebuild
@@ -18,7 +18,7 @@ RDEPEND="
 	>=x11-libs/libXext-1.3.2[${MULTILIB_USEDEP}]
 	>=x11-libs/libXt-1.1.4[${MULTILIB_USEDEP}]
 
-	app-arch/gzip
+	app-alternatives/gzip
 	app-arch/ncompress
 "
 DEPEND="${RDEPEND}


### PR DESCRIPTION
...instead of directly depending on app-arch/gzip since users can select alternative implementations (such as pigz) through the app-alternatives system.