### PR TITLE
gui-wm/hyprland: Added check for LLVM16

### DIFF
--- a/gui-wm/hyprland/hyprland-0.25.0.ebuild
+++ b/gui-wm/hyprland/hyprland-0.25.0.ebuild
@@ -55,10 +55,14 @@ BDEPEND="
 "
 
 src_prepare() {
-	STDLIBVER=$(echo '#include <string>' | $(tc-getCXX) -x c++ -dM -E - | \
+	if [[ $(tc-is-gcc) ]]; then
+	   STDLIBVER=$(echo '#include <string>' | $(tc-getCXX) -x c++ -dM -E - | \
 					grep GLIBCXX_RELEASE | sed 's/.*\([1-9][0-9]\)/\1/')
-	if ! [[ ${STDLIBVER} -ge 12 ]]; then
-		die "Hyprland requires >=sys-devel/gcc-12.1.0 to build"
+	   if ! [[ ${STDLIBVER} -ge 12 ]]; then
+		   die "Hyprland requires >=sys-devel/gcc-12.1.0 to build"
+	   fi
+	elif [[ $(clang-major-version) -lt 16 ]]; then
+		die "Hyprland requires >=sys-devel/clang-16.0.3 to build";
 	fi
 
 	if use video_cards_nvidia; then


### PR DESCRIPTION
Hyprland compiles with CLANG/LLVM 16, the previous check did not account for this.