### PR TITLE
app-crypt/pinentry: add configure args for KF5WaylandClient, Qt5X11Ex…

### DIFF
--- a/app-crypt/pinentry/files/pinentry-1.2.1-automagic-capslock.patch
+++ b/app-crypt/pinentry/files/pinentry-1.2.1-automagic-capslock.patch
@@ -1,0 +1,99 @@
+https://dev.gnupg.org/T6161
+https://bugs.gentoo.org/819939
+https://bugs.gentoo.org/837719
+--- a/configure.ac
++++ b/configure.ac
+@@ -508,8 +508,12 @@ fi
+ dnl
+ dnl Check for libX11 library
+ dnl
++AC_ARG_WITH(x,
++        AS_HELP_STRING([--with-x],[use libX11]),
++        [want_x11=$withval], [want_x11=maybe])
++
+ have_x11=no
+-if test "$have_w32_system" != "yes"; then
++AS_IF([test "$have_w32_system" != "yes" && test "$want_x11" != "no"], [
+ 	PKG_CHECK_MODULES(
+ 		LIBX11,
+ 		[x11],
+@@ -519,18 +523,20 @@ if test "$have_w32_system" != "yes"; then
+ 			have_x11=no
+ 		]
+ 	)
++])
+ 
+-	if test "$have_x11" = "yes"; then
+-		AC_DEFINE(HAVE_X11, 1,
+-			[The pinentries can optionally use x11.])
+-	fi
+-fi
++AS_IF([test "$have_x11" = "yes"], [AC_DEFINE(HAVE_X11, 1, [The pinentries can optionally use x11.])])
+ 
+ dnl
+ dnl Check for KF5WaylandClient library
+ dnl
++
++AC_ARG_ENABLE(kf5-wayland,
++	AS_HELP_STRING([--enable-kf5-wayland],[use KF5WaylandClient for capslock indication on Wayland]),
++	[want_kf5_wayland=$enableval], [want_kf5_wayland=maybe])
++
+ have_kf5waylandclient=no
+-if test "$have_w32_system" != "yes"; then
++AS_IF([test "$have_w32_system" != "yes" && test "$want_kf5_wayland" != "no"], [
+ 	PKG_CHECK_MODULES(
+ 		KF5WAYLANDCLIENT,
+ 		[KF5WaylandClient >= 5.60],
+@@ -540,7 +546,7 @@ if test "$have_w32_system" != "yes"; then
+ 			have_kf5waylandclient=no
+ 		]
+ 	)
+-fi
++])
+ 
+ dnl
+ dnl Check for Qt5 pinentry program.
+--- a/m4/qt.m4
++++ b/m4/qt.m4
+@@ -33,6 +33,10 @@ AC_DEFUN([FIND_QT],
+                 enable_pinentry_qt5=$enableval,
+                 enable_pinentry_qt5="try")
+ 
++  AC_ARG_ENABLE(qtx11extras,
++                AS_HELP_STRING([--enable-qtx11extras],[use Qt5X11Extras for capslock indication on X11]),
++        [want_qtx11extras=$enableval], [want_qtx11extras=maybe])
++
+   have_qt5_libs="no";
+   require_qt_cpp11="no";
+ 
+@@ -63,20 +67,22 @@ AC_DEFUN([FIND_QT],
+       fi
+     fi
+ 
+-    if test "$have_x11" = "yes"; then
++    have_qt5_x11extras=no
++    AS_IF([test "$have_x11" = "yes" && test "$want_qtx11extras" != "no"], [
+       PKG_CHECK_MODULES(
+         PINENTRY_QT_X11_EXTRAS,
+         Qt5X11Extras >= 5.1.0,
+         [have_qt5_x11extras="yes"],
+-        [
+-          AC_MSG_WARN([pinentry-qt will be built without Caps Lock warning on X11])
+-          have_qt5_x11extras="no"
+-        ])
+-      if test "$have_qt5_x11extras" = "yes"; then
++        [have_qt5_x11extras="no"]
++     )
++    ])
++
++    AS_IF([test "$have_qt5_x11extras" = "yes"], [
+         PINENTRY_QT_CFLAGS="$LIBX11_CFLAGS $PINENTRY_QT_CFLAGS $PINENTRY_QT_X11_EXTRAS_CFLAGS"
+         PINENTRY_QT_LIBS="$LIBX11_LIBS $PINENTRY_QT_LIBS $PINENTRY_QT_X11_EXTRAS_LIBS"
+-      fi
+-    fi
++    ], [
++        AC_MSG_WARN([pinentry-qt will be built without Caps Lock warning on X11])
++    ])
+ 
+     AC_CHECK_TOOL(MOC, moc)
+     AC_MSG_CHECKING([moc version])

--- a/app-crypt/pinentry/pinentry-1.2.1-r3.ebuild
+++ b/app-crypt/pinentry/pinentry-1.2.1-r3.ebuild
@@ -1,0 +1,107 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+VERIFY_SIG_OPENPGP_KEY_PATH="${BROOT}"/usr/share/openpgp-keys/gnupg.asc
+inherit autotools qmake-utils verify-sig
+
+DESCRIPTION="Simple passphrase entry dialogs which utilize the Assuan protocol"
+HOMEPAGE="https://gnupg.org/aegypten2"
+SRC_URI="mirror://gnupg/${PN}/${P}.tar.bz2"
+SRC_URI+=" verify-sig? ( mirror://gnupg/${PN}/${P}.tar.bz2.sig )"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~x64-cygwin ~amd64-linux ~x86-linux ~arm64-macos ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+IUSE="caps efl emacs gtk keyring ncurses qt5 wayland X"
+
+DEPEND="
+	>=dev-libs/libassuan-2.1
+	>=dev-libs/libgcrypt-1.6.3
+	>=dev-libs/libgpg-error-1.17
+	efl? ( dev-libs/efl[X] )
+	keyring? ( app-crypt/libsecret )
+	ncurses? ( sys-libs/ncurses:= )
+	qt5? (
+		dev-qt/qtcore:5
+		dev-qt/qtgui:5
+		dev-qt/qtwidgets:5
+		wayland? ( kde-frameworks/kwayland:5 )
+		X? (
+			dev-qt/qtx11extras:5
+			x11-libs/libX11
+		)
+	)
+"
+RDEPEND="
+	${DEPEND}
+	gtk? ( app-crypt/gcr:0[gtk] )
+"
+BDEPEND="
+	sys-devel/gettext
+	virtual/pkgconfig
+	verify-sig? ( sec-keys/openpgp-keys-gnupg )
+"
+IDEPEND=">=app-eselect/eselect-pinentry-0.7.2"
+
+DOCS=( AUTHORS ChangeLog NEWS README THANKS TODO )
+
+PATCHES=(
+	"${FILESDIR}/${PN}-1.0.0-AR.patch"
+	"${FILESDIR}/${PN}-1.2.1-automagic-capslock.patch"
+)
+
+src_prepare() {
+	default
+
+	unset FLTK_CONFIG
+
+	eautoreconf
+}
+
+src_configure() {
+	export PATH="$(qt5_get_bindir):${PATH}"
+	export QTLIB="$(qt5_get_libdir)"
+
+	local myeconfargs=(
+		$(use_enable efl pinentry-efl)
+		$(use_enable emacs pinentry-emacs)
+		$(use_enable keyring libsecret)
+		$(use_enable gtk pinentry-gnome3)
+		$(use_enable ncurses fallback-curses)
+		$(use_enable ncurses pinentry-curses)
+		$(use_enable qt5 pinentry-qt)
+		$(use_enable wayland kf5-wayland)
+		$(use_enable X qtx11extras)
+		$(use_with X x)
+
+		--enable-pinentry-tty
+		--disable-pinentry-fltk
+		--disable-pinentry-gtk2
+
+		MOC="$(qt5_get_bindir)"/moc
+		GPG_ERROR_CONFIG="${ESYSROOT}"/usr/bin/${CHOST}-gpg-error-config
+		LIBASSUAN_CONFIG="${ESYSROOT}"/usr/bin/libassuan-config
+
+		$("${S}/configure" --help | grep -- '--without-.*-prefix' | sed -e 's/^ *\([^ ]*\) .*/\1/g')
+	)
+
+	econf "${myeconfargs[@]}"
+}
+
+src_install() {
+	default
+
+	rm "${ED}"/usr/bin/pinentry || die
+
+	use qt5 && dosym pinentry-qt /usr/bin/pinentry-qt5
+}
+
+pkg_postinst() {
+	eselect pinentry update ifunset
+}
+
+pkg_postrm() {
+	eselect pinentry update ifunset
+}

--- a/profiles/arch/hppa/package.use.mask
+++ b/profiles/arch/hppa/package.use.mask
@@ -4,6 +4,10 @@
 # NOTE: When masking a USE flag due to missing keywords, please file a keyword
 # request bug for the hppa arch.
 
+# Sam James <sam@gentoo.org> (2023-05-19)
+# kde-frameworks/kwayland:5 is not keyworded here.
+app-crypt/pinentry wayland
+
 # Sam James <sam@gentoo.org> (2023-05-10)
 # sys-cluster/ceph not keyworded here
 sys-block/tgt rbd

--- a/profiles/arch/powerpc/ppc32/package.use.mask
+++ b/profiles/arch/powerpc/ppc32/package.use.mask
@@ -1,6 +1,10 @@
 # Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Sam James <sam@gentoo.org> (2023-05-19)
+# kde-frameworks/kwayland:5 is not keyworded here.
+app-crypt/pinentry wayland
+
 # Sam James <sam@gentoo.org> (2023-05-06)
 # sci-libs/vtk not keyworded here (+ lots of unkw'd deps), bug #778293
 sci-mathematics/maxima vtk


### PR DESCRIPTION
…tras, libX11

I was really hoping this would get looked at upstream but it's not happening, so add in a patch given pinentry is pretty hard for people to avoid.

Bug: https://bugs.gentoo.org/906677
Closes: https://bugs.gentoo.org/819939
Closes: https://bugs.gentoo.org/837719