### PR TITLE
x11-misc/ydotool: Update the OpenRC unit name

### DIFF
--- a/x11-misc/ydotool/ydotool-1.0.4-r1.ebuild
+++ b/x11-misc/ydotool/ydotool-1.0.4-r1.ebuild
@@ -20,5 +20,5 @@ BDEPEND="
 
 src_install() {
 	cmake_src_install
-	newinitd Daemon/ydotool.service-openrc.in ydotoold
+	newinitd Daemon/ydotool.service-openrc.in ${PN}
 }


### PR DESCRIPTION
Name the OpenRC unit the same as upstream's systemd unit for
consistency, even though we are launching ydotoold.

Signed-off-by: Zoltan Puskas <zoltan@sinustrom.info>
