### PR TITLE
sys-apps/util-linux: Fix for mount_setattr use on <5.12 kernels

### DIFF
--- a/sys-apps/util-linux/files/util-linux-2.39-check-for-mount_setattr.patch
+++ b/sys-apps/util-linux/files/util-linux-2.39-check-for-mount_setattr.patch
@@ -1,0 +1,102 @@
+From 9b68f614c8d02ca41f077ba064e0a83d2ae7b1fe Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Thomas=20Wei=C3=9Fschuh?= <thomas@t-8ch.de>
+Date: Sat, 20 May 2023 06:38:20 +0200
+Subject: [PATCH] libmount: check for availability of mount_setattr
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+If mount_setattr is not available but needed fall back to the legacy
+mount API.
+
+Fixes #2247
+
+Signed-off-by: Thomas Weißschuh <thomas@t-8ch.de>
+---
+ libmount/src/hook_mount.c                   | 19 +++++++++++++++++--
+ tests/expected/mount/fallback-mount_setattr |  1 +
+ tests/ts/mount/fallback                     | 16 ++++++++++++++++
+ 3 files changed, 34 insertions(+), 2 deletions(-)
+ create mode 100644 tests/expected/mount/fallback-mount_setattr
+
+diff --git a/libmount/src/hook_mount.c b/libmount/src/hook_mount.c
+index a324637cb7..3c390a6658 100644
+--- a/libmount/src/hook_mount.c
++++ b/libmount/src/hook_mount.c
+@@ -510,6 +510,15 @@ static inline int fsopen_is_supported(void)
+ 	return rc;
+ }
+ 
++static inline int mount_setattr_is_supported(void)
++{
++	int rc;
++
++	errno = 0;
++	rc = mount_setattr(-1, NULL, 0, NULL, 0);
++	return !(rc == -1 && errno == ENOSYS);
++}
++
+ /*
+  * open_tree() and fsopen()
+  */
+@@ -675,9 +684,12 @@ static int hook_prepare(struct libmnt_context *cxt,
+ 	/* call mount_setattr() */
+ 	if (!rc
+ 	    && cxt->helper == NULL
+-	    && (set != 0 || clr != 0 || (flags & MS_REMOUNT)))
++	    && (set != 0 || clr != 0 || (flags & MS_REMOUNT))) {
++		if (!mount_setattr_is_supported())
++			return 1;
+ 		rc = mnt_context_append_hook(cxt, hs, MNT_STAGE_MOUNT, NULL,
+ 					hook_set_vfsflags);
++	}
+ 
+ 	/* call move_mount() to attach target */
+ 	if (!rc
+@@ -688,9 +700,12 @@ static int hook_prepare(struct libmnt_context *cxt,
+ 					hook_attach_target);
+ 
+ 	/* set propagation (has to be attached to VFS) */
+-	if (!rc && mnt_optlist_get_propagation(ol))
++	if (!rc && mnt_optlist_get_propagation(ol)) {
++		if (!mount_setattr_is_supported())
++			return 1;
+ 		rc = mnt_context_append_hook(cxt, hs, MNT_STAGE_MOUNT_POST, NULL,
+ 					hook_set_propagation);
++	}
+ 
+ 	DBG(HOOK, ul_debugobj(hs, "prepare mount done [rc=%d]", rc));
+ 	return rc;
+diff --git a/tests/expected/mount/fallback-mount_setattr b/tests/expected/mount/fallback-mount_setattr
+new file mode 100644
+index 0000000000..3e18ebf09e
+--- /dev/null
++++ b/tests/expected/mount/fallback-mount_setattr
+@@ -0,0 +1 @@
++private
+diff --git a/tests/ts/mount/fallback b/tests/ts/mount/fallback
+index 6033eb5757..b225be189a 100755
+--- a/tests/ts/mount/fallback
++++ b/tests/ts/mount/fallback
+@@ -68,5 +68,21 @@ $TS_CMD_UMOUNT $MOUNTPOINT
+ ts_finalize_subtest
+ 
+ 
++ts_init_subtest "mount_setattr"
++"$TS_CMD_MOUNT" "$DEVICE" "$MOUNTPOINT"  >> $TS_OUTPUT 2>> $TS_ERRLOG
++ts_is_mounted $DEVICE || ts_log "Cannot find $DEVICE in /proc/mounts"
++$TS_HELPER_ENOSYS -s mount_setattr -- \
++	"$TS_CMD_MOUNT" -o remount,ro "$MOUNTPOINT" \
++	>> $TS_OUTPUT 2>> $TS_ERRLOG
++$TS_CMD_FINDMNT --kernel --mountpoint "$MOUNTPOINT" --options "ro" &> /dev/null
++[ "$?" == "0" ] || ts_die "Cannot find read-only in $MOUNTPOINT in /proc/self/mountinfo"
++$TS_HELPER_ENOSYS -s mount_setattr -- \
++ 	"$TS_CMD_MOUNT" --make-slave "$MOUNTPOINT" \
++ 	>> $TS_OUTPUT 2>> $TS_ERRLOG
++$TS_CMD_FINDMNT -n --kernel --mountpoint "$MOUNTPOINT" -o PROPAGATION >> $TS_OUTPUT
++$TS_CMD_UMOUNT $MOUNTPOINT
++ts_finalize_subtest
++
++
+ ts_finalize
+ 

--- a/sys-apps/util-linux/files/util-linux-2.39-tests-for-mount_setattr.patch
+++ b/sys-apps/util-linux/files/util-linux-2.39-tests-for-mount_setattr.patch
@@ -1,0 +1,12 @@
+diff --git a/tests/helpers/test_enosys.c b/tests/helpers/test_enosys.c
+index 88e7af3b02fe..12eedbcb8361 100644
+--- a/tests/helpers/test_enosys.c
++++ b/tests/helpers/test_enosys.c
+@@ -68,6 +68,7 @@ const struct syscall syscalls[] = {
+ 	{ "move_mount", __NR_move_mount },
+ 	{ "open_tree", __NR_open_tree },
+ 	{ "fsopen", __NR_fsopen },
++	{ "mount_setattr", __NR_mount_setattr },
+ };
+ 
+ int main(int argc, char **argv)

--- a/sys-apps/util-linux/util-linux-2.39-r2.ebuild
+++ b/sys-apps/util-linux/util-linux-2.39-r2.ebuild
@@ -1,0 +1,398 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+PYTHON_COMPAT=( python3_{10..11} )
+
+inherit toolchain-funcs libtool flag-o-matic bash-completion-r1 usr-ldscript \
+	pam python-r1 multilib-minimal multiprocessing systemd
+
+MY_PV="${PV/_/-}"
+MY_P="${PN}-${MY_PV}"
+
+if [[ ${PV} == 9999 ]] ; then
+	EGIT_REPO_URI="https://git.kernel.org/pub/scm/utils/util-linux/util-linux.git"
+	inherit autotools git-r3
+else
+	VERIFY_SIG_OPENPGP_KEY_PATH="${BROOT}"/usr/share/openpgp-keys/karelzak.asc
+	inherit verify-sig
+
+	if [[ ${PV} != *_rc* ]] ; then
+		KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~arm64-macos"
+	fi
+
+	SRC_URI="https://www.kernel.org/pub/linux/utils/util-linux/v${PV:0:4}/${MY_P}.tar.xz"
+	SRC_URI+=" verify-sig? ( https://www.kernel.org/pub/linux/utils/util-linux/v${PV:0:4}/${MY_P}.tar.sign )"
+fi
+
+S="${WORKDIR}/${MY_P}"
+
+DESCRIPTION="Various useful Linux utilities"
+HOMEPAGE="https://www.kernel.org/pub/linux/utils/util-linux/ https://github.com/util-linux/util-linux"
+
+LICENSE="GPL-2 GPL-3 LGPL-2.1 BSD-4 MIT public-domain"
+SLOT="0"
+IUSE="audit build caps +cramfs cryptsetup fdformat +hardlink kill +logger magic ncurses nls pam python +readline rtas selinux slang static-libs +su +suid systemd test tty-helpers udev unicode"
+
+# Most lib deps here are related to programs rather than our libs,
+# so we rarely need to specify ${MULTILIB_USEDEP}.
+RDEPEND="
+	virtual/libcrypt:=
+	audit? ( >=sys-process/audit-2.6:= )
+	caps? ( sys-libs/libcap-ng )
+	cramfs? ( sys-libs/zlib:= )
+	cryptsetup? ( >=sys-fs/cryptsetup-2.1.0 )
+	hardlink? ( dev-libs/libpcre2:= )
+	ncurses? (
+		sys-libs/ncurses:=[unicode(+)?]
+		magic? ( sys-apps/file:0= )
+	)
+	nls? ( virtual/libintl[${MULTILIB_USEDEP}] )
+	pam? ( sys-libs/pam )
+	python? ( ${PYTHON_DEPS} )
+	readline? ( sys-libs/readline:0= )
+	rtas? ( sys-libs/librtas )
+	selinux? ( >=sys-libs/libselinux-2.2.2-r4[${MULTILIB_USEDEP}] )
+	slang? ( sys-libs/slang )
+	!build? ( systemd? ( sys-apps/systemd ) )
+	udev? ( virtual/libudev:= )"
+BDEPEND="
+	virtual/pkgconfig
+	nls? (
+		app-text/po4a
+		sys-devel/gettext
+	)
+	test? ( sys-devel/bc )
+"
+DEPEND="
+	${RDEPEND}
+	virtual/os-headers
+	acct-group/root
+"
+RDEPEND+="
+	hardlink? ( !app-arch/hardlink )
+	logger? ( !>=app-admin/sysklogd-2.0[logger] )
+	kill? (
+		!sys-apps/coreutils[kill]
+		!sys-process/procps[kill]
+	)
+	su? (
+		!<sys-apps/shadow-4.7-r2
+		!>=sys-apps/shadow-4.7-r2[su]
+	)
+	!net-wireless/rfkill
+"
+
+if [[ ${PV} == 9999 ]] ; then
+	# Required for man-page generation
+	BDEPEND+=" dev-ruby/asciidoctor"
+else
+	BDEPEND+=" verify-sig? ( >=sec-keys/openpgp-keys-karelzak-20230517 )"
+fi
+
+REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} ) su? ( pam )"
+RESTRICT="!test? ( test )"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-2.39-check-for-mount_setattr.patch"
+	"${FILESDIR}/${PN}-2.39-tests-for-mount_setattr.patch"
+)
+
+pkg_pretend() {
+	if use su && ! use suid ; then
+		elog "su will be installed as suid despite USE=-suid (bug #832092)"
+		elog "To use su without suid, see e.g. Portage's suidctl feature."
+	fi
+}
+
+src_unpack() {
+	if [[ ${PV} == 9999 ]] ; then
+		git-r3_src_unpack
+		return
+	fi
+
+	if use verify-sig ; then
+		mkdir "${T}"/verify-sig || die
+		pushd "${T}"/verify-sig &>/dev/null || die
+
+		# Upstream sign the decompressed .tar
+		# Let's do it separately in ${T} then cleanup to avoid external
+		# effects on normal unpack.
+		cp "${DISTDIR}"/${MY_P}.tar.xz . || die
+		xz -d ${MY_P}.tar.xz || die
+		verify-sig_verify_detached ${MY_P}.tar "${DISTDIR}"/${MY_P}.tar.sign
+
+		popd &>/dev/null || die
+		rm -r "${T}"/verify-sig || die
+	fi
+
+	default
+}
+
+src_prepare() {
+	default
+
+	if use test ; then
+		# Prevent uuidd test failure due to socket path limit, bug #593304
+		sed -i \
+			-e "s|UUIDD_SOCKET=\"\$(mktemp -u \"\${TS_OUTDIR}/uuiddXXXXXXXXXXXXX\")\"|UUIDD_SOCKET=\"\$(mktemp -u \"${T}/uuiddXXXXXXXXXXXXX.sock\")\"|g" \
+			tests/ts/uuid/uuidd || die "Failed to fix uuidd test"
+
+		# Known-failing tests
+		# TODO: investigate these
+		local known_failing_tests=(
+			# Subtest 'options-maximum-size-8192' fails
+			hardlink/options
+
+			# Fails in sandbox
+			lsns/ioctl_ns
+
+			lsfd/mkfds-symlink
+			lsfd/mkfds-rw-character-device
+		)
+
+		local known_failing_test
+		for known_failing_test in "${known_failing_tests[@]}" ; do
+			einfo "Removing known-failing test: ${known_failing_test}"
+			rm tests/ts/${known_failing_test} || die
+		done
+
+	fi
+
+	if [[ ${PV} == 9999 ]] ; then
+		po/update-potfiles
+		eautoreconf
+	else
+		elibtoolize
+	fi
+}
+
+python_configure() {
+	local myeconfargs=(
+		"${commonargs[@]}"
+		--disable-all-programs
+		--disable-bash-completion
+		--without-systemdsystemunitdir
+		--with-python
+		--enable-libblkid
+		--enable-libmount
+		--enable-pylibmount
+	)
+
+	mkdir "${BUILD_DIR}" || die
+	pushd "${BUILD_DIR}" >/dev/null || die
+	ECONF_SOURCE="${S}" econf "${myeconfargs[@]}"
+	popd >/dev/null || die
+}
+
+multilib_src_configure() {
+	# The scanf test in a run-time test which fails while cross-compiling.
+	# Blindly assume a POSIX setup since we require libmount, and libmount
+	# itself fails when the scanf test fails. bug #531856
+	tc-is-cross-compiler && export scanf_cv_alloc_modifier=ms
+
+	# bug #485486
+	export ac_cv_header_security_pam_misc_h=$(multilib_native_usex pam)
+	# bug #545042
+	export ac_cv_header_security_pam_appl_h=$(multilib_native_usex pam)
+
+	# Undo bad ncurses handling by upstream. Fall back to pkg-config.
+	# bug #601530
+	export NCURSES6_CONFIG=false NCURSES5_CONFIG=false
+	export NCURSESW6_CONFIG=false NCURSESW5_CONFIG=false
+
+	# Avoid automagic dependency on ppc*
+	export ac_cv_lib_rtas_rtas_get_sysparm=$(usex rtas)
+
+	# configure args shared by python and non-python builds
+	local commonargs=(
+		--localstatedir="${EPREFIX}/var"
+		--runstatedir="${EPREFIX}/run"
+		--enable-fs-paths-extra="${EPREFIX}/usr/sbin:${EPREFIX}/bin:${EPREFIX}/usr/bin"
+	)
+
+	local myeconfargs=(
+		"${commonargs[@]}"
+		--with-bashcompletiondir="$(get_bashcompdir)"
+		--without-python
+		$(multilib_native_use_enable suid makeinstall-chown)
+		$(multilib_native_use_enable suid makeinstall-setuid)
+		$(multilib_native_use_with readline)
+		$(multilib_native_use_with slang)
+		$(multilib_native_use_with systemd)
+		$(multilib_native_use_with udev)
+		$(multilib_native_usex ncurses "$(use_with magic libmagic)" '--without-libmagic')
+		$(multilib_native_usex ncurses "$(use_with unicode ncursesw)" '--without-ncursesw')
+		$(multilib_native_usex ncurses "$(use_with !unicode ncurses)" '--without-ncurses')
+		$(multilib_native_use_with audit)
+		$(tc-has-tls || echo --disable-tls)
+		$(use_enable nls)
+		$(use_enable nls poman)
+		$(use_enable unicode widechar)
+		$(use_enable static-libs static)
+		$(use_with ncurses tinfo)
+		$(use_with selinux)
+	)
+
+	if multilib_is_native_abi ; then
+		myeconfargs+=(
+			--disable-chfn-chsh
+			--disable-login
+			--disable-newgrp
+			--disable-nologin
+			--disable-pylibmount
+			--disable-raw
+			--disable-vipw
+			--enable-agetty
+			--enable-bash-completion
+			--enable-line
+			--enable-partx
+			--enable-rename
+			--enable-rfkill
+			--enable-schedutils
+			--with-systemdsystemunitdir="$(systemd_get_systemunitdir)"
+			$(use_enable caps setpriv)
+			$(use_enable cramfs)
+			$(use_enable fdformat)
+			$(use_enable hardlink)
+			$(use_enable kill)
+			$(use_enable logger)
+			$(use_enable ncurses pg)
+			$(use_enable su)
+			$(use_enable tty-helpers mesg)
+			$(use_enable tty-helpers wall)
+			$(use_enable tty-helpers write)
+			$(use_with cryptsetup)
+		)
+		if [[ ${PV} == *9999 ]] ; then
+			myeconfargs+=( --enable-asciidoc )
+		else
+			# Upstream is shipping pre-generated man-pages for releases
+			myeconfargs+=( --disable-asciidoc )
+		fi
+	else
+		myeconfargs+=(
+			--disable-all-programs
+			--disable-asciidoc
+			--disable-bash-completion
+			--without-systemdsystemunitdir
+			--disable-poman
+
+			# build libraries
+			--enable-libuuid
+			--enable-libblkid
+			--enable-libsmartcols
+			--enable-libfdisk
+			--enable-libmount
+		)
+	fi
+
+	ECONF_SOURCE="${S}" econf "${myeconfargs[@]}"
+
+	if multilib_is_native_abi && use python ; then
+		python_foreach_impl python_configure
+	fi
+}
+
+src_configure() {
+	append-lfs-flags
+	multilib-minimal_src_configure
+}
+
+python_compile() {
+	pushd "${BUILD_DIR}" >/dev/null || die
+	emake all
+	popd >/dev/null || die
+}
+
+multilib_src_compile() {
+	emake all
+
+	if multilib_is_native_abi && use python ; then
+		python_foreach_impl python_compile
+	fi
+}
+
+python_test() {
+	pushd "${BUILD_DIR}" >/dev/null || die
+	emake check TS_OPTS="--parallel=$(makeopts_jobs) --nonroot"
+	popd >/dev/null || die
+}
+
+multilib_src_test() {
+	emake check TS_OPTS="--parallel=$(makeopts_jobs) --nonroot"
+	if multilib_is_native_abi && use python ; then
+		python_foreach_impl python_test
+	fi
+}
+
+python_install() {
+	pushd "${BUILD_DIR}" >/dev/null || die
+	emake DESTDIR="${D}" install
+	python_optimize
+	popd >/dev/null || die
+}
+
+multilib_src_install() {
+	if multilib_is_native_abi && use python ; then
+		python_foreach_impl python_install
+	fi
+
+	# This needs to be called AFTER python_install call, bug #689190
+	emake DESTDIR="${D}" install
+
+	if multilib_is_native_abi ; then
+		# Need the libs in /
+		gen_usr_ldscript -a blkid fdisk mount smartcols uuid
+	fi
+}
+
+multilib_src_install_all() {
+	dodoc AUTHORS NEWS README* Documentation/{TODO,*.txt,releases/*}
+
+	# e2fsprogs-libs didn't install .la files, and .pc work fine
+	find "${ED}" -name "*.la" -delete || die
+
+	if use pam ; then
+		# See https://github.com/util-linux/util-linux/blob/master/Documentation/PAM-configuration.txt
+		newpamd "${FILESDIR}/runuser.pamd" runuser
+		newpamd "${FILESDIR}/runuser-l.pamd" runuser-l
+
+		newpamd "${FILESDIR}/su-l.pamd" su-l
+	fi
+
+	if use su && ! use suid ; then
+		# Always force suid su, even when USE=-suid, as su is useless
+		# for the overwhelming-majority case without suid.
+		# Users who wish to truly have a no-suid su can strip it out
+		# via e.g. Portage's suidctl or some other hook.
+		# See bug #832092
+		fperms u+s /bin/su
+	fi
+
+	# Note:
+	# Bash completion for "runuser" command is provided by same file which
+	# would also provide bash completion for "su" command. However, we don't
+	# use "su" command from this package.
+	# This triggers a known QA warning which we ignore for now to magically
+	# keep bash completion for "su" command which shadow package does not
+	# provide.
+
+	local ver=$(tools/git-version-gen .tarballversion)
+	local major=$(ver_cut 1 ${ver})
+	local minor=$(ver_cut 2 ${ver})
+	local release=$(ver_cut 3 ${ver})
+	export QA_PKGCONFIG_VERSION="${major}.${minor}.${release:-0}"
+}
+
+pkg_postinst() {
+	if ! use tty-helpers ; then
+		elog "The mesg/wall/write tools have been disabled due to USE=-tty-helpers."
+	fi
+
+	if [[ -z ${REPLACING_VERSIONS} ]] ; then
+		elog "The agetty util now clears the terminal by default. You"
+		elog "might want to add --noclear to your /etc/inittab lines."
+	fi
+}


### PR DESCRIPTION
Backported pending upstream fix from
https://github.com/util-linux/util-linux/pull/2248

Note that there's at least one other breaking bug in util-linux-2.39 so the mask probably shouldn't be removed yet.


Closes: https://bugs.gentoo.org/906797
Bug: https://bugs.gentoo.org/906859