### PR TITLE
media-sound/ardour: add media-libs/suil[X] usedep

### DIFF
--- a/media-sound/ardour/ardour-6.9-r2.ebuild
+++ b/media-sound/ardour/ardour-6.9-r2.ebuild
@@ -58,7 +58,7 @@ RDEPEND="
 	media-libs/lilv
 	media-libs/sratom
 	dev-libs/sord
-	media-libs/suil[gtk2]
+	media-libs/suil[X,gtk2]
 	media-libs/lv2"
 #	!bundled-libs? ( media-sound/fluidsynth ) at least libltc is missing to be able to unbundle...
 
@@ -136,7 +136,8 @@ src_configure() {
 		--noconfirm
 		--optimize
 		--with-backends=${backends}
-		$({ use cpu_flags_ppc_altivec || use cpu_flags_x86_sse; } && echo "--fpu-optimization" || echo "--no-fpu-optimization")
+		$({ use cpu_flags_ppc_altivec || use cpu_flags_x86_sse; } && \
+			echo "--fpu-optimization" || echo "--no-fpu-optimization")
 		$(usex doc "--docs" '')
 		$(usex nls "--nls" "--no-nls")
 		$(usex phonehome "--phone-home" "--no-phone-home")

--- a/media-sound/ardour/ardour-7.3-r1.ebuild
+++ b/media-sound/ardour/ardour-7.3-r1.ebuild
@@ -58,7 +58,7 @@ RDEPEND="
 	media-libs/lilv
 	media-libs/sratom
 	dev-libs/sord
-	media-libs/suil[gtk2]
+	media-libs/suil[X,gtk2]
 	media-libs/lv2"
 #	!bundled-libs? ( media-sound/fluidsynth ) at least libltc is missing to be able to unbundle...
 
@@ -136,7 +136,8 @@ src_configure() {
 		--noconfirm
 		--optimize
 		--with-backends=${backends}
-		$({ use cpu_flags_ppc_altivec || use cpu_flags_x86_sse; } && echo "--fpu-optimization" || echo "--no-fpu-optimization")
+		$({ use cpu_flags_ppc_altivec || use cpu_flags_x86_sse; } && \
+			echo "--fpu-optimization" || echo "--no-fpu-optimization")
 		$(usex doc "--docs" '')
 		$(usex nls "--nls" "--no-nls")
 		$(usex phonehome "--phone-home" "--no-phone-home")

--- a/media-sound/ardour/ardour-7.4-r1.ebuild
+++ b/media-sound/ardour/ardour-7.4-r1.ebuild
@@ -58,7 +58,7 @@ RDEPEND="
 	media-libs/lilv
 	media-libs/sratom
 	dev-libs/sord
-	media-libs/suil[gtk2]
+	media-libs/suil[X,gtk2]
 	media-libs/lv2"
 #	!bundled-libs? ( media-sound/fluidsynth ) at least libltc is missing to be able to unbundle...
 
@@ -136,7 +136,8 @@ src_configure() {
 		--noconfirm
 		--optimize
 		--with-backends=${backends}
-		$({ use cpu_flags_ppc_altivec || use cpu_flags_x86_sse; } && echo "--fpu-optimization" || echo "--no-fpu-optimization")
+		$({ use cpu_flags_ppc_altivec || use cpu_flags_x86_sse; } && \
+			echo "--fpu-optimization" || echo "--no-fpu-optimization")
 		$(usex doc "--docs" '')
 		$(usex nls "--nls" "--no-nls")
 		$(usex phonehome "--phone-home" "--no-phone-home")

--- a/media-sound/ardour/ardour-9999.ebuild
+++ b/media-sound/ardour/ardour-9999.ebuild
@@ -58,7 +58,7 @@ RDEPEND="
 	media-libs/lilv
 	media-libs/sratom
 	dev-libs/sord
-	media-libs/suil[gtk2]
+	media-libs/suil[X,gtk2]
 	media-libs/lv2"
 #	!bundled-libs? ( media-sound/fluidsynth ) at least libltc is missing to be able to unbundle...
 
@@ -136,7 +136,8 @@ src_configure() {
 		--noconfirm
 		--optimize
 		--with-backends=${backends}
-		$({ use cpu_flags_ppc_altivec || use cpu_flags_x86_sse; } && echo "--fpu-optimization" || echo "--no-fpu-optimization")
+		$({ use cpu_flags_ppc_altivec || use cpu_flags_x86_sse; } && \
+			echo "--fpu-optimization" || echo "--no-fpu-optimization")
 		$(usex doc "--docs" '')
 		$(usex nls "--nls" "--no-nls")
 		$(usex phonehome "--phone-home" "--no-phone-home")


### PR DESCRIPTION
Almost no plugin GUIs will work without media-libs/suil being built with the X use flag. Add it to the suil dependency to avoid any confusion. Also, split line 139 to avoid excessive length.