### PR TITLE
dev-libs/weston: add x11-libs/xcb-utils-cursor as dependency for xway…

### DIFF
--- a/dev-libs/weston/weston-12.0.0.ebuild
+++ b/dev-libs/weston/weston-12.0.0.ebuild
@@ -80,6 +80,7 @@ RDEPEND="
 		x11-libs/cairo[X,xcb(+)]
 		>=x11-libs/libxcb-1.9
 		x11-libs/libXcursor
+		>=x11-libs/xcb-util-cursor-0.1.4
 	)
 "
 DEPEND="${RDEPEND}

--- a/dev-libs/weston/weston-9999.ebuild
+++ b/dev-libs/weston/weston-9999.ebuild
@@ -80,6 +80,7 @@ RDEPEND="
 		x11-libs/cairo[X,xcb(+)]
 		>=x11-libs/libxcb-1.9
 		x11-libs/libXcursor
+		>=x11-libs/xcb-util-cursor-0.1.4
 	)
 "
 DEPEND="${RDEPEND}


### PR DESCRIPTION
…land use.

Closes: https://bugs.gentoo.org/906909