### PR TITLE
dev-libs/spdlog: fix libfmt compatibility issue

### DIFF
--- a/dev-libs/spdlog/spdlog-1.11.0.ebuild
+++ b/dev-libs/spdlog/spdlog-1.11.0.ebuild
@@ -25,7 +25,7 @@ BDEPEND="
 	virtual/pkgconfig
 "
 DEPEND="
-	>=dev-libs/libfmt-8.0.0:=
+	dev-libs/libfmt:0/9.1.0
 "
 RDEPEND="${DEPEND}"
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/906069

New spdlog version will support dev-libs/libfmt-10.0.0 (tested with the spdlog live ebuild). For spdlog-1.11.0 just fix DEPEN to exclude incompatible versions (libfmt version 10.0.0 or higher)