### PR TITLE
dev-libs/libclc: Enable USE=spirv by default

### DIFF
--- a/dev-libs/libclc/libclc-15.0.7.ebuild
+++ b/dev-libs/libclc/libclc-15.0.7.ebuild
@@ -12,7 +12,7 @@ HOMEPAGE="https://libclc.llvm.org/"
 LICENSE="Apache-2.0-with-LLVM-exceptions || ( MIT BSD )"
 SLOT="0"
 KEYWORDS="amd64 x86"
-IUSE="spirv video_cards_nvidia video_cards_r600 video_cards_radeonsi"
+IUSE="+spirv video_cards_nvidia video_cards_r600 video_cards_radeonsi"
 
 LLVM_MAX_SLOT=15
 BDEPEND="

--- a/dev-libs/libclc/libclc-16.0.3.ebuild
+++ b/dev-libs/libclc/libclc-16.0.3.ebuild
@@ -12,7 +12,7 @@ HOMEPAGE="https://libclc.llvm.org/"
 LICENSE="Apache-2.0-with-LLVM-exceptions || ( MIT BSD )"
 SLOT="0"
 KEYWORDS="~amd64 ~riscv ~x86"
-IUSE="spirv video_cards_nvidia video_cards_r600 video_cards_radeonsi"
+IUSE="+spirv video_cards_nvidia video_cards_r600 video_cards_radeonsi"
 
 LLVM_MAX_SLOT=16
 BDEPEND="

--- a/dev-libs/libclc/libclc-16.0.4.ebuild
+++ b/dev-libs/libclc/libclc-16.0.4.ebuild
@@ -12,7 +12,7 @@ HOMEPAGE="https://libclc.llvm.org/"
 LICENSE="Apache-2.0-with-LLVM-exceptions || ( MIT BSD )"
 SLOT="0"
 KEYWORDS="~amd64 ~riscv ~x86"
-IUSE="spirv video_cards_nvidia video_cards_r600 video_cards_radeonsi"
+IUSE="+spirv video_cards_nvidia video_cards_r600 video_cards_radeonsi"
 
 LLVM_MAX_SLOT=16
 BDEPEND="

--- a/dev-libs/libclc/libclc-16.0.5.9999.ebuild
+++ b/dev-libs/libclc/libclc-16.0.5.9999.ebuild
@@ -12,7 +12,7 @@ HOMEPAGE="https://libclc.llvm.org/"
 LICENSE="Apache-2.0-with-LLVM-exceptions || ( MIT BSD )"
 SLOT="0"
 KEYWORDS=""
-IUSE="spirv video_cards_nvidia video_cards_r600 video_cards_radeonsi"
+IUSE="+spirv video_cards_nvidia video_cards_r600 video_cards_radeonsi"
 
 LLVM_MAX_SLOT=16
 BDEPEND="

--- a/dev-libs/libclc/libclc-17.0.0.9999.ebuild
+++ b/dev-libs/libclc/libclc-17.0.0.9999.ebuild
@@ -12,7 +12,7 @@ HOMEPAGE="https://libclc.llvm.org/"
 LICENSE="Apache-2.0-with-LLVM-exceptions || ( MIT BSD )"
 SLOT="0"
 KEYWORDS=""
-IUSE="spirv video_cards_nvidia video_cards_r600 video_cards_radeonsi"
+IUSE="+spirv video_cards_nvidia video_cards_r600 video_cards_radeonsi"
 
 LLVM_MAX_SLOT=17
 BDEPEND="

--- a/dev-libs/libclc/libclc-17.0.0_pre20230502.ebuild
+++ b/dev-libs/libclc/libclc-17.0.0_pre20230502.ebuild
@@ -12,7 +12,7 @@ HOMEPAGE="https://libclc.llvm.org/"
 LICENSE="Apache-2.0-with-LLVM-exceptions || ( MIT BSD )"
 SLOT="0"
 KEYWORDS=""
-IUSE="spirv video_cards_nvidia video_cards_r600 video_cards_radeonsi"
+IUSE="+spirv video_cards_nvidia video_cards_r600 video_cards_radeonsi"
 
 LLVM_MAX_SLOT=17
 BDEPEND="

--- a/dev-libs/libclc/libclc-17.0.0_pre20230512.ebuild
+++ b/dev-libs/libclc/libclc-17.0.0_pre20230512.ebuild
@@ -12,7 +12,7 @@ HOMEPAGE="https://libclc.llvm.org/"
 LICENSE="Apache-2.0-with-LLVM-exceptions || ( MIT BSD )"
 SLOT="0"
 KEYWORDS=""
-IUSE="spirv video_cards_nvidia video_cards_r600 video_cards_radeonsi"
+IUSE="+spirv video_cards_nvidia video_cards_r600 video_cards_radeonsi"
 
 LLVM_MAX_SLOT=17
 BDEPEND="

--- a/dev-libs/libclc/libclc-17.0.0_pre20230520.ebuild
+++ b/dev-libs/libclc/libclc-17.0.0_pre20230520.ebuild
@@ -12,7 +12,7 @@ HOMEPAGE="https://libclc.llvm.org/"
 LICENSE="Apache-2.0-with-LLVM-exceptions || ( MIT BSD )"
 SLOT="0"
 KEYWORDS=""
-IUSE="spirv video_cards_nvidia video_cards_r600 video_cards_radeonsi"
+IUSE="+spirv video_cards_nvidia video_cards_r600 video_cards_radeonsi"
 
 LLVM_MAX_SLOT=17
 BDEPEND="


### PR DESCRIPTION
mesa-23.1.0 depends on libclc[spirv] in some common use cases (and media-libs/mesa is libclc's only consumer in ::gentoo).