### PR TITLE
app-admin/sysstat: additional fix for CVE-2022-39377

### DIFF
--- a/app-admin/sysstat/files/sysstat-12.6.2-overflow_fix.patch
+++ b/app-admin/sysstat/files/sysstat-12.6.2-overflow_fix.patch
@@ -1,0 +1,28 @@
+diff -urP sysstat-12.6.2.orig/common.c sysstat-12.6.2/common.c
+--- sysstat-12.6.2.orig/common.c	2023-01-29 01:24:19.000000000 -0700
++++ sysstat-12.6.2/common.c	2023-05-23 12:45:38.133341135 -0600
+@@ -447,15 +431,17 @@
+ void check_overflow(unsigned int val1, unsigned int val2,
+ 		    unsigned int val3)
+ {
+-	if ((unsigned long long) val1 * (unsigned long long) val2 *
+-	    (unsigned long long) val3 > UINT_MAX) {
++	if ((val1 != 0) && (val2 != 0) && (val3 != 0) &&
++	    (((unsigned long long) UINT_MAX / (unsigned long long) val1 <
++	      (unsigned long long) val2) ||
++	     ((unsigned long long) UINT_MAX / ((unsigned long long) val1 * (unsigned long long) val2) <
++	      (unsigned long long) val3))) {
+ #ifdef DEBUG
+-		fprintf(stderr, "%s: Overflow detected (%llu). Aborting...\n",
+-			__FUNCTION__, (unsigned long long) val1 * (unsigned long long) val2 *
+-			(unsigned long long) val3);
++		fprintf(stderr, "%s: Overflow detected (%u,%u,%u). Aborting...\n",
++			__FUNCTION__, val1, val2, val3);
+ #endif
+-	exit(4);
+-		}
++		exit(4);
++	}
+ }
+ 
+ #ifndef SOURCE_SADC

--- a/app-admin/sysstat/sysstat-12.6.2-r1.ebuild
+++ b/app-admin/sysstat/sysstat-12.6.2-r1.ebuild
@@ -1,0 +1,86 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit systemd toolchain-funcs
+
+DESCRIPTION="System performance tools for Linux"
+HOMEPAGE="http://sebastien.godard.pagesperso-orange.fr/"
+SRC_URI="https://github.com/${PN}/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+IUSE="dcron debug nls lm-sensors lto selinux systemd"
+
+BDEPEND="
+	virtual/pkgconfig
+	nls? ( sys-devel/gettext )
+"
+
+COMMON_DEPEND="
+	nls? ( virtual/libintl )
+	lm-sensors? ( sys-apps/lm-sensors:= )
+"
+
+DEPEND="${COMMON_DEPEND}"
+
+RDEPEND="
+	${COMMON_DEPEND}
+	!dcron? ( !sys-process/dcron )
+	selinux? ( sec-policy/selinux-sysstat )
+"
+
+REQUIRED_USE="dcron? ( !systemd )"
+
+#PATCHES=( "${FILESDIR}/${PN}-12.6.2-overflow_fix.patch" )
+
+src_prepare() {
+	if use dcron; then
+		sed -i 's/@CRON_OWNER@ //g' cron/sysstat.crond.in || die
+	fi
+	default
+}
+
+src_configure() {
+	tc-export AR
+
+	sa_lib_dir=/usr/lib/sa \
+		conf_dir=/etc \
+		econf \
+			$(use_enable !systemd use-crond) \
+			$(use_enable lm-sensors sensors) \
+			$(use_enable lto) \
+			$(use_enable nls) \
+			$(usex debug --enable-debuginfo '') \
+			--disable-compress-manpg \
+			--disable-stripping \
+			--disable-pcp \
+			--enable-copy-only \
+			--enable-documentation \
+			--enable-install-cron \
+			--with-systemdsystemunitdir=$(systemd_get_systemunitdir)
+}
+
+src_compile() {
+	LFLAGS="${LDFLAGS}" default
+}
+
+src_install() {
+	keepdir /var/log/sa
+
+	emake \
+		CHOWN=true \
+		DESTDIR="${D}" \
+		DOC_DIR=/usr/share/doc/${PF} \
+		MANGRPARG='' \
+		install
+
+	dodoc -r contrib/
+
+	newinitd "${FILESDIR}"/${PN}.init.d ${PN}
+	systemd_dounit ${PN}.service
+
+	rm "${D}"/usr/share/doc/${PF}/COPYING || die
+}


### PR DESCRIPTION
Folded in from upstream; note that
https://github.com/sysstat/sysstat/commit/6f8dc568e6ab072bb8205b732f04e685bf9237c0 shows the correct changes as-actually-merged but
https://github.com/sysstat/sysstat/commit/6f8dc568e6ab072bb8205b732f04e685bf9237c0.patch does not. Compiled and ran locally, I do not have a 32bit arch to test this on however.


Bug: https://bugs.gentoo.org/880543