### PR TITLE
mail-filter/rspamd: bug fixes

### DIFF
--- a/mail-filter/rspamd/rspamd-3.4-r3.ebuild
+++ b/mail-filter/rspamd/rspamd-3.4-r3.ebuild
@@ -30,6 +30,7 @@ RESTRICT="!test? ( test )"
 REQUIRED_USE="${LUA_REQUIRED_USE}
 	test? ( lua_single_target_luajit )"
 
+# for <dev-libs/libfmt-10 see https://github.com/rspamd/rspamd/issues/4482
 RDEPEND="${LUA_DEPS}
 	$(lua_gen_cond_dep '
 		dev-lua/LuaBitOp[${LUA_USEDEP}]
@@ -42,7 +43,7 @@ RDEPEND="${LUA_DEPS}
 	dev-libs/glib:2
 	dev-libs/icu:=
 	dev-libs/libev
-	dev-libs/libfmt:=
+	<dev-libs/libfmt-10:=
 	dev-libs/libpcre2:=[jit=]
 	dev-libs/libsodium:=
 	dev-libs/openssl:0=[-bindist(-)]

--- a/mail-filter/rspamd/rspamd-3.5-r1.ebuild
+++ b/mail-filter/rspamd/rspamd-3.5-r1.ebuild
@@ -30,6 +30,7 @@ RESTRICT="!test? ( test )"
 REQUIRED_USE="${LUA_REQUIRED_USE}
 	test? ( lua_single_target_luajit )"
 
+# for <dev-libs/libfmt-10 see https://github.com/rspamd/rspamd/issues/4482
 RDEPEND="${LUA_DEPS}
 	$(lua_gen_cond_dep '
 		dev-lua/LuaBitOp[${LUA_USEDEP}]
@@ -42,7 +43,7 @@ RDEPEND="${LUA_DEPS}
 	dev-libs/glib:2
 	dev-libs/icu:=
 	dev-libs/libev
-	dev-libs/libfmt:=
+	<dev-libs/libfmt-10:=
 	dev-libs/libpcre2:=[jit=]
 	dev-libs/libsodium:=
 	dev-libs/openssl:0=[-bindist(-)]

--- a/mail-filter/rspamd/rspamd-3.5-r1.ebuild
+++ b/mail-filter/rspamd/rspamd-3.5-r1.ebuild
@@ -3,7 +3,10 @@
 
 EAPI=8
 
-LUA_COMPAT=( lua5-{1..4} luajit )
+# lua5-{3,4} were dropped due to bug #903577. This issue has been resolved
+# upstream, see https://github.com/rspamd/rspamd/issues/4455. They will be
+# restored with the next version bump.
+LUA_COMPAT=( lua5-1 luajit )
 
 inherit cmake lua-single pax-utils systemd tmpfiles
 


### PR DESCRIPTION
- limit deps to `<dev-libs/libfmt-10`
- disable `lua5-{3,4}` for `rspamd-3.5`