### PR TITLE
sys-apps/nvme-cli: Install udev rules and systemd units in correct pl…

### DIFF
--- a/sys-apps/nvme-cli/nvme-cli-2.4-r2.ebuild
+++ b/sys-apps/nvme-cli/nvme-cli-2.4-r2.ebuild
@@ -1,0 +1,51 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit meson systemd udev
+
+DESCRIPTION="NVM-Express user space tooling for Linux"
+HOMEPAGE="https://github.com/linux-nvme/nvme-cli"
+SRC_URI="https://github.com/linux-nvme/nvme-cli/archive/v${PV}.tar.gz -> ${P}.gh.tar.gz"
+
+LICENSE="GPL-2 GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~arm64 ~loong ~ppc64 ~riscv ~x86"
+IUSE="hugepages +json"
+
+RDEPEND="
+	=sys-libs/libnvme-1.4*:=[json?]
+	hugepages? ( sys-libs/libhugetlbfs:= )
+	json? ( dev-libs/json-c:= )
+	sys-libs/zlib:=
+"
+
+DEPEND="
+	${RDEPEND}
+"
+BDEPEND="
+	virtual/pkgconfig
+"
+
+PATCHES=(
+	"${FILESDIR}/nvme-cli-2.2-docdir.patch"
+	"${FILESDIR}/nvme-cli-2.4-no-hugetlbfs-automatic-dep.patch"
+)
+
+src_configure() {
+	local emesonargs=(
+		-Dversion-tag="${PV}"
+		-Ddocs=all
+		-Dhtmldir="${EPREFIX}/usr/share/doc/${PF}/html"
+		-Dsystemddir="$(systemd_get_systemunitdir)"
+		-Dudevrulesdir="${EPREFIX}$(get_udevdir)/rules.d"
+		$(meson_use hugepages)
+		$(meson_feature json json-c)
+	)
+	meson_src_configure
+}
+
+src_install() {
+	meson_src_install
+}


### PR DESCRIPTION
…aces

This popped up when we updated the package in Flatcar - we used to have 1.16 and, after updating to 2.3, some files changed their locations. This PR tries to fix it. The diff between the nvme-cli-2.4-r{1,2} ebuilds is:

```diff
14c14
< KEYWORDS="amd64 ~arm64 ~loong ~ppc64 ~riscv x86"
---
> KEYWORDS="~amd64 ~arm64 ~loong ~ppc64 ~riscv ~x86"
37d36
< 	local unitdir="$(systemd_get_systemunitdir)"
42,43c41,42
< 		-Dsystemddir="${unitdir%/system}"
< 		-Dudevrulesdir="${EPREFIX}$(get_udevdir)"
---
> 		-Dsystemddir="$(systemd_get_systemunitdir)"
> 		-Dudevrulesdir="${EPREFIX}$(get_udevdir)/rules.d"
```

Udev rules should be installed in rules.d directory (so in `/usr/lib/udev/rules.d`), currently they are installed in `/usr/lib/udev`. This mistake probably comes from a build system change, where for old build system (in version 1.16), UDEVDIR was supposed to be specified, and the build system defined UDEVRULESDIR based on the former (see
https://github.com/linux-nvme/nvme-cli/blob/v1.16/Makefile#L17-L18). The new build system expects the udev rules directory to be passed as a parameter.

Similar mistake happened for the systemd unit directory - the systemd unit files are installed in `/usr/lib/systemd/system`, not in `/usr/lib/systemd`. This one stems from a change in meaning of the `systemddir` option in the build system - in the old build system it meant to be `/usr/lib/systemd` and the `system` subdirectory was appended by the old build system when installing the units (see https://github.com/linux-nvme/nvme-cli/blob/v1.16/Makefile#L142-L144). The new build system does not do it any more - it just installs the units to `systemddir` (see
https://github.com/linux-nvme/nvme-cli/blob/v1.16/Makefile#L142-L144), thus making the `systemddir` option name rather misleading - probably should be named `systemdunitdir`, as `systemddir` is not used for anything else (see
https://github.com/linux-nvme/nvme-cli/blob/v2.4/Makefile#L49).