### PR TITLE
dev-python/*: enable py3.12 & one missing bdep fix

### DIFF
--- a/dev-python/arrow/arrow-1.2.3.ebuild
+++ b/dev-python/arrow/arrow-1.2.3.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} pypy3 )
+PYTHON_COMPAT=( python3_{10..12} pypy3 )
 
 inherit distutils-r1 pypi
 

--- a/dev-python/canonicaljson/canonicaljson-2.0.0.ebuild
+++ b/dev-python/canonicaljson/canonicaljson-2.0.0.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{10..12} )
 
 inherit distutils-r1 pypi
 

--- a/dev-python/frozendict/frozendict-2.3.8.ebuild
+++ b/dev-python/frozendict/frozendict-2.3.8.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 DISTUTILS_EXT=1
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{10..12} )
 
 inherit distutils-r1
 

--- a/dev-python/isodate/isodate-0.6.1-r1.ebuild
+++ b/dev-python/isodate/isodate-0.6.1-r1.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} pypy3 )
+PYTHON_COMPAT=( python3_{10..12} pypy3 )
 
 inherit distutils-r1 pypi
 

--- a/dev-python/isoduration/isoduration-20.11.0-r1.ebuild
+++ b/dev-python/isoduration/isoduration-20.11.0-r1.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} pypy3 )
+PYTHON_COMPAT=( python3_{10..12} pypy3 )
 
 inherit distutils-r1
 

--- a/dev-python/signedjson/signedjson-1.1.4.ebuild
+++ b/dev-python/signedjson/signedjson-1.1.4.ebuild
@@ -29,6 +29,9 @@ RDEPEND="
 		dev-python/importlib-metadata[${PYTHON_USEDEP}]
 	' python3_9)
 "
+BDEPEND="
+	dev-python/setuptools-scm[${PYTHON_USEDEP}]
+"
 
 distutils_enable_tests unittest
 

--- a/dev-python/simplejson/simplejson-3.19.1.ebuild
+++ b/dev-python/simplejson/simplejson-3.19.1.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 DISTUTILS_EXT=1
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} pypy3 )
+PYTHON_COMPAT=( python3_{10..12} pypy3 )
 
 inherit distutils-r1 pypi
 


### PR DESCRIPTION
couple of py3.12 enabling, few packages are mine, the rest belongs to python project, dependencies needed by poetry-core.

All tests passed for all available python versions  (`python3_{10..12}`).