### PR TITLE
app-editors/vscod*: Toggle desktop files with USE

### DIFF
--- a/app-editors/vscode/vscode-1.78.1.ebuild
+++ b/app-editors/vscode/vscode-1.78.1.ebuild
@@ -36,6 +36,7 @@ LICENSE="
 	W3C
 "
 SLOT="0"
+IUSE="X wayland"
 KEYWORDS="-* ~amd64 ~arm ~arm64"
 
 RDEPEND="
@@ -109,10 +110,14 @@ src_install() {
 	dosym -r "/opt/${PN}/bin/code" "usr/bin/vscode"
 	dosym -r "/opt/${PN}/bin/code" "usr/bin/code"
 	dosym -r "/opt/${PN}/bin/code-tunnel" "usr/bin/code-tunnel"
-	domenu "${FILESDIR}/vscode.desktop"
-	domenu "${FILESDIR}/vscode-url-handler.desktop"
-	domenu "${FILESDIR}/vscode-wayland.desktop"
-	domenu "${FILESDIR}/vscode-url-handler-wayland.desktop"
+	if use X; then
+		domenu "${FILESDIR}/vscode.desktop"
+		domenu "${FILESDIR}/vscode-url-handler.desktop"
+	fi
+	if use wayland; then
+		domenu "${FILESDIR}/vscode-wayland.desktop"
+		domenu "${FILESDIR}/vscode-url-handler-wayland.desktop"
+	fi
 	newicon "resources/app/resources/linux/code.png" "vscode.png"
 }
 

--- a/app-editors/vscode/vscode-1.78.2.ebuild
+++ b/app-editors/vscode/vscode-1.78.2.ebuild
@@ -36,6 +36,7 @@ LICENSE="
 	W3C
 "
 SLOT="0"
+IUSE="X wayland"
 KEYWORDS="-* ~amd64 ~arm ~arm64"
 
 RDEPEND="
@@ -109,10 +110,14 @@ src_install() {
 	dosym -r "/opt/${PN}/bin/code" "usr/bin/vscode"
 	dosym -r "/opt/${PN}/bin/code" "usr/bin/code"
 	dosym -r "/opt/${PN}/bin/code-tunnel" "usr/bin/code-tunnel"
-	domenu "${FILESDIR}/vscode.desktop"
-	domenu "${FILESDIR}/vscode-url-handler.desktop"
-	domenu "${FILESDIR}/vscode-wayland.desktop"
-	domenu "${FILESDIR}/vscode-url-handler-wayland.desktop"
+	if use X; then
+		domenu "${FILESDIR}/vscode.desktop"
+		domenu "${FILESDIR}/vscode-url-handler.desktop"
+	fi
+	if use wayland; then
+		domenu "${FILESDIR}/vscode-wayland.desktop"
+		domenu "${FILESDIR}/vscode-url-handler-wayland.desktop"
+	fi
 	newicon "resources/app/resources/linux/code.png" "vscode.png"
 }
 

--- a/app-editors/vscodium/vscodium-1.77.3.23102.ebuild
+++ b/app-editors/vscodium/vscodium-1.77.3.23102.ebuild
@@ -35,7 +35,7 @@ LICENSE="
 "
 SLOT="0"
 KEYWORDS="-* ~amd64 ~arm ~arm64"
-IUSE=""
+IUSE="X wayland"
 
 RDEPEND="
 	>=app-accessibility/at-spi2-core-2.46.0:2
@@ -104,10 +104,14 @@ src_install() {
 	fperms +x /opt/${PN}/resources/app/node_modules.asar.unpacked/node-pty/build/Release/spawn-helper
 	dosym "../../opt/${PN}/bin/codium" "usr/bin/vscodium"
 	dosym "../../opt/${PN}/bin/codium" "usr/bin/codium"
-	domenu "${FILESDIR}/vscodium.desktop"
-	domenu "${FILESDIR}/vscodium-url-handler.desktop"
-	domenu "${FILESDIR}/vscodium-wayland.desktop"
-	domenu "${FILESDIR}/vscodium-url-handler-wayland.desktop"
+	if use X; then
+		domenu "${FILESDIR}/vscodium.desktop"
+		domenu "${FILESDIR}/vscodium-url-handler.desktop"
+	fi
+	if use wayland; then
+		domenu "${FILESDIR}/vscodium-wayland.desktop"
+		domenu "${FILESDIR}/vscodium-url-handler-wayland.desktop"
+	fi
 	newicon "resources/app/resources/linux/code.png" "vscodium.png"
 }
 


### PR DESCRIPTION
I have an `USE="-X"` system (mostly) and having non-Wayland desktop files clutters up my launcher.

Similarly, I imagine there are users with `USE="X -wayland"` (AIUI the default for `desktop` profiles) where the wayland launcher variants are not helpful.