### PR TITLE
sys-kernel/dracut: Fix uefi stub detection on split-usr systems

### DIFF
--- a/sys-kernel/dracut/dracut-057-r4.ebuild
+++ b/sys-kernel/dracut/dracut-057-r4.ebuild
@@ -16,7 +16,7 @@ else
 fi
 
 DESCRIPTION="Generic initramfs generation tool"
-HOMEPAGE="https://dracut.wiki.kernel.org"
+HOMEPAGE="https://github.com/dracutdevs/dracut/wiki"
 
 LICENSE="GPL-2"
 SLOT="0"
@@ -64,6 +64,8 @@ QA_MULTILIB_PATHS="usr/lib/dracut/.*"
 PATCHES=(
 	"${FILESDIR}"/gentoo-ldconfig-paths-r1.patch
 	"${FILESDIR}"/gentoo-network-r1.patch
+	"${FILESDIR}"/057-virtiofs-split-usr.patch
+	"${FILESDIR}"/057-i18n-keymaps.patch
 	"${FILESDIR}"/uefi-stub-split-usr.patch
 )
 

--- a/sys-kernel/dracut/dracut-059-r1.ebuild
+++ b/sys-kernel/dracut/dracut-059-r1.ebuild
@@ -16,7 +16,7 @@ else
 fi
 
 DESCRIPTION="Generic initramfs generation tool"
-HOMEPAGE="https://dracut.wiki.kernel.org"
+HOMEPAGE="https://github.com/dracutdevs/dracut/wiki"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/sys-kernel/dracut/files/uefi-stub-split-usr.patch
+++ b/sys-kernel/dracut/files/uefi-stub-split-usr.patch
@@ -1,0 +1,20 @@
+systemd installs the stub in ${prefix}/lib/systemd/boot/efi.
+systemdutildir is ${rootprefix}/lib/systemd.
+
+When prefix != rootprefix, the dracut code failed to find the stub.
+This failure is apparent on split-usr systems where rootprefix is empty
+and prefix=/usr.
+
+Bug: https://bugs.gentoo.org/765208
+
+--- a/dracut.sh
++++ b/dracut.sh
+@@ -1453,7 +1453,7 @@ if [[ ! $print_cmdline ]]; then
+         esac
+ 
+         if ! [[ -s $uefi_stub ]]; then
+-            uefi_stub="$dracutsysrootdir${systemdutildir}/boot/efi/linux${EFI_MACHINE_TYPE_NAME}.efi.stub"
++            uefi_stub="$dracutsysrootdir/usr/lib/systemd/boot/efi/linux${EFI_MACHINE_TYPE_NAME}.efi.stub"
+         fi
+ 
+         if ! [[ -s $uefi_stub ]]; then


### PR DESCRIPTION
Since the patch in https://bugs.gentoo.org/765208 does not apply to dracut version 057 and 059 any more, I rewrote it for these current versions.
Patch note and patch idea are by @floppym and not my work. Should I make this more clear somewhere?

I revbumped both 057 and 059, which I hope is the right thing to do here.

I tested the patched version 057 (but not 059) and can confirm that - just like the original patch by @floppym - it fixes the bug.