### PR TITLE
dev-python/pyasn1*: enable py3.1

### DIFF
--- a/dev-python/pyasn1-modules/pyasn1-modules-0.3.0.ebuild
+++ b/dev-python/pyasn1-modules/pyasn1-modules-0.3.0.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} pypy3 )
+PYTHON_COMPAT=( python3_{10..12} pypy3 )
 
 inherit distutils-r1 pypi
 

--- a/dev-python/pyasn1/pyasn1-0.5.0.ebuild
+++ b/dev-python/pyasn1/pyasn1-0.5.0.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} pypy3 )
+PYTHON_COMPAT=( python3_{10..12} pypy3 )
 
 inherit distutils-r1 pypi
 


### PR DESCRIPTION
enable py3.12 for `dev-python/pyasn1*`. Tests pass for all 3 supported python versions.