### PR TITLE
dev-python/*: enable py3.12

### DIFF
--- a/dev-python/dnspython/dnspython-2.3.0.ebuild
+++ b/dev-python/dnspython/dnspython-2.3.0.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=poetry
-PYTHON_COMPAT=( python3_{9..11} pypy3 )
+PYTHON_COMPAT=( python3_{10..12} pypy3 )
 
 inherit distutils-r1
 

--- a/dev-python/email-validator/email-validator-2.0.0_p2.ebuild
+++ b/dev-python/email-validator/email-validator-2.0.0_p2.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
 PYPI_PN=email-validator
-PYTHON_COMPAT=( python3_{9..11} pypy3 )
+PYTHON_COMPAT=( python3_{10..12} pypy3 )
 
 inherit distutils-r1 pypi
 

--- a/dev-python/immutabledict/immutabledict-2.2.4.ebuild
+++ b/dev-python/immutabledict/immutabledict-2.2.4.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=poetry
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{10..12} )
 inherit distutils-r1 pypi
 
 DESCRIPTION="An immutable wrapper around dictionaries"

--- a/dev-python/matrix-common/matrix-common-1.3.0-r1.ebuild
+++ b/dev-python/matrix-common/matrix-common-1.3.0-r1.ebuild
@@ -1,0 +1,31 @@
+# Copyright 2022-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DISTUTILS_USE_PEP517=setuptools
+PYTHON_COMPAT=( python3_{10..12} )
+
+inherit distutils-r1
+
+DESCRIPTION="Common code for Synapse, Sydent and Sygnal"
+HOMEPAGE="
+	https://github.com/matrix-org/matrix-python-common
+	https://pypi.org/project/matrix-common/
+"
+SRC_URI="
+	https://github.com/matrix-org/matrix-python-common/archive/v${PV}.tar.gz
+		-> ${P}.gh.tar.gz
+"
+
+S="${WORKDIR}/matrix-python-common-${PV}"
+
+LICENSE="Apache-2.0"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc64"
+
+RDEPEND="
+	dev-python/attrs[${PYTHON_USEDEP}]
+"
+
+distutils_enable_tests unittest

--- a/dev-python/netaddr/netaddr-0.8.0-r1.ebuild
+++ b/dev-python/netaddr/netaddr-0.8.0-r1.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{10..12} )
 
 inherit distutils-r1 optfeature
 

--- a/dev-python/pymacaroons/pymacaroons-0.13.0-r1.ebuild
+++ b/dev-python/pymacaroons/pymacaroons-0.13.0-r1.ebuild
@@ -1,10 +1,10 @@
-# Copyright 2022 Gentoo Authors
+# Copyright 2022-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{10..12} )
 
 inherit distutils-r1
 

--- a/dev-python/sh/sh-2.0.4.ebuild
+++ b/dev-python/sh/sh-2.0.4.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=poetry
-PYTHON_COMPAT=( pypy3 python3_{10..11} )
+PYTHON_COMPAT=( pypy3 python3_{10..12} )
 
 inherit distutils-r1 pypi
 

--- a/dev-python/signedjson/signedjson-1.1.4.ebuild
+++ b/dev-python/signedjson/signedjson-1.1.4.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{10..12} )
 
 inherit distutils-r1
 
@@ -25,9 +25,6 @@ RDEPEND="
 	dev-python/canonicaljson[${PYTHON_USEDEP}]
 	dev-python/pynacl[${PYTHON_USEDEP}]
 	dev-python/unpaddedbase64[${PYTHON_USEDEP}]
-	$(python_gen_cond_dep '
-		dev-python/importlib-metadata[${PYTHON_USEDEP}]
-	' python3_9)
 "
 BDEPEND="
 	dev-python/setuptools-scm[${PYTHON_USEDEP}]

--- a/dev-python/unpaddedbase64/unpaddedbase64-2.1.0.ebuild
+++ b/dev-python/unpaddedbase64/unpaddedbase64-2.1.0.ebuild
@@ -1,10 +1,10 @@
-# Copyright 2022 Gentoo Authors
+# Copyright 2022-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
 DISTUTILS_USE_PEP517=poetry
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{10..12} )
 
 inherit distutils-r1
 


### PR DESCRIPTION
Another batch of py3.12 enabled packages, all tests pass for all supported python versions.

`dev-python/matrix-common` contained unneeded rdep on `dev-python/importlib-metadata` which was needed only for older python versions but it wasn't properly `python_gen_cond_dep`ed, so I did the revbump and preserved old version. It looks cleaner to me as the `r0` is stable.