### PR TITLE
x11-misc/xdock: Fix memset and memcpy undeclared

### DIFF
--- a/x11-misc/xdock/files/xdock-0.3.0-clang16-memcpy.patch
+++ b/x11-misc/xdock/files/xdock-0.3.0-clang16-memcpy.patch
@@ -1,0 +1,11 @@
+#Bug https://bugs.gentoo.org/898894
+--- a/src/lib/network.c
++++ b/src/lib/network.c
+@@ -16,6 +16,7 @@
+ #include <stdarg.h>
+ #include <stdlib.h>
+ #include <errno.h>
++#include <string.h>
+ 
+ int net_connect(char* host, int port)
+ {

--- a/x11-misc/xdock/xdock-0.3.0-r2.ebuild
+++ b/x11-misc/xdock/xdock-0.3.0-r2.ebuild
@@ -1,0 +1,40 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools
+
+DESCRIPTION="Emulates Window Maker docks (runs in any window manager)"
+HOMEPAGE="https://xdock.sourceforge.net/"
+SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+RDEPEND="x11-libs/libX11"
+DEPEND="
+	${RDEPEND}
+	x11-base/xorg-proto"
+
+DOCS=( API AUTHORS ChangeLog README TODO )
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-0.2.0-ldconfig.patch
+	"${FILESDIR}"/${P}-clang16.patch
+	"${FILESDIR}"/${P}-clang16-memcpy.patch
+)
+
+src_prepare() {
+	default
+
+	sed -i -e 's|AM_CONFIG_HEADER|AC_CONFIG_HEADERS|g' configure.ac || die
+	eautoreconf
+}
+
+src_install() {
+	default
+
+	find "${ED}" -type f -name '*.la' -delete || die
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/898894