### PR TITLE
dev-lang/rust: fix the build with musl-1.2.4

### DIFF
--- a/dev-lang/rust/files/1.69.0-musl-1.2.4-getrandom.patch
+++ b/dev-lang/rust/files/1.69.0-musl-1.2.4-getrandom.patch
@@ -1,0 +1,50 @@
+https://bugs.gentoo.org/903607
+https://github.com/rust-random/getrandom/pull/326
+https://github.com/rust-random/getrandom/commit/7f73e3ccc1f53bfc419e4ddcfd343766aa5837b6
+
+From 7c80ae7cae663e5b85dcd953f3e93b13ed5b1b8e Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Wed, 28 Dec 2022 21:44:17 -0800
+Subject: [PATCH] Use open instead of open64
+
+glibc is providing open64 and other lfs64 functions but musl aliases
+them to normal equivalents since off_t is always 64-bit on musl,
+therefore check for target env along when target OS is linux before
+using open64, this is more available. Latest Musl has made these
+namespace changes [1]
+
+There is no need for using LFS64 open explicitly as we are only using it
+for opening device files and not real files
+
+[1] https://git.musl-libc.org/cgit/musl/commit/?id=246f1c811448f37a44b41cd8df8d0ef9736d95f4
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ src/util_libc.rs | 10 +---------
+ 1 file changed, 1 insertion(+), 9 deletions(-)
+
+diff --git a/src/util_libc.rs b/src/util_libc.rs
+index 63b060e7..bd9c7de1 100644
+--- a/src/util_libc.rs
++++ b/src/util_libc.rs
+@@ -140,19 +140,11 @@ impl Weak {
+     }
+ }
+ 
+-cfg_if! {
+-    if #[cfg(any(target_os = "linux", target_os = "emscripten"))] {
+-        use libc::open64 as open;
+-    } else {
+-        use libc::open;
+-    }
+-}
+-
+ // SAFETY: path must be null terminated, FD must be manually closed.
+ pub unsafe fn open_readonly(path: &str) -> Result<libc::c_int, Error> {
+     debug_assert_eq!(path.as_bytes().last(), Some(&0));
+     loop {
+-        let fd = open(path.as_ptr() as *const _, libc::O_RDONLY | libc::O_CLOEXEC);
++        let fd = libc::open(path.as_ptr() as *const _, libc::O_RDONLY | libc::O_CLOEXEC);
+         if fd >= 0 {
+             return Ok(fd);
+         }

--- a/dev-lang/rust/files/1.69.0-musl-1.2.4-libc.patch
+++ b/dev-lang/rust/files/1.69.0-musl-1.2.4-libc.patch
@@ -1,0 +1,654 @@
+https://bugs.gentoo.org/903607
+https://github.com/rust-lang/libc/issues/2934
+https://github.com/rust-lang/libc/pull/2935
+https://github.com/rust-lang/libc/commit/1e8c55cbed0b6e05a6c5063baa1fea50cad49269
+
+--- a/src/unix/linux_like/linux/mod.rs
++++ b/src/unix/linux_like/linux/mod.rs
+@@ -58,11 +58,6 @@ impl ::Clone for fpos64_t {
+ }
+ 
+ s! {
+-    pub struct rlimit64 {
+-        pub rlim_cur: rlim64_t,
+-        pub rlim_max: rlim64_t,
+-    }
+-
+     pub struct glob_t {
+         pub gl_pathc: ::size_t,
+         pub gl_pathv: *mut *mut c_char,
+@@ -625,6 +620,11 @@ s! {
+         pub flag: *mut ::c_int,
+         pub val: ::c_int,
+     }
++
++    pub struct rlimit64 {
++        pub rlim_cur: rlim64_t,
++        pub rlim_max: rlim64_t,
++    }
+ }
+ 
+ s_no_extra_traits! {
+@@ -643,14 +643,6 @@ s_no_extra_traits! {
+         pub d_name: [::c_char; 256],
+     }
+ 
+-    pub struct dirent64 {
+-        pub d_ino: ::ino64_t,
+-        pub d_off: ::off64_t,
+-        pub d_reclen: ::c_ushort,
+-        pub d_type: ::c_uchar,
+-        pub d_name: [::c_char; 256],
+-    }
+-
+     pub struct sockaddr_alg {
+         pub salg_family: ::sa_family_t,
+         pub salg_type: [::c_uchar; 14],
+@@ -738,6 +730,14 @@ s_no_extra_traits! {
+         #[cfg(not(libc_union))]
+         pub ifr_ifru: ::sockaddr,
+     }
++
++    pub struct dirent64 {
++        pub d_ino: ::ino64_t,
++        pub d_off: ::off64_t,
++        pub d_reclen: ::c_ushort,
++        pub d_type: ::c_uchar,
++        pub d_name: [::c_char; 256],
++    }
+ }
+ 
+ s_no_extra_traits! {
+@@ -3872,21 +3872,8 @@ extern "C" {
+     pub fn mprotect(addr: *mut ::c_void, len: ::size_t, prot: ::c_int) -> ::c_int;
+     pub fn __errno_location() -> *mut ::c_int;
+ 
+-    pub fn fopen64(filename: *const c_char, mode: *const c_char) -> *mut ::FILE;
+-    pub fn freopen64(
+-        filename: *const c_char,
+-        mode: *const c_char,
+-        file: *mut ::FILE,
+-    ) -> *mut ::FILE;
+-    pub fn tmpfile64() -> *mut ::FILE;
+-    pub fn fgetpos64(stream: *mut ::FILE, ptr: *mut fpos64_t) -> ::c_int;
+-    pub fn fsetpos64(stream: *mut ::FILE, ptr: *const fpos64_t) -> ::c_int;
+-    pub fn fseeko64(stream: *mut ::FILE, offset: ::off64_t, whence: ::c_int) -> ::c_int;
+-    pub fn ftello64(stream: *mut ::FILE) -> ::off64_t;
+     pub fn fallocate(fd: ::c_int, mode: ::c_int, offset: ::off_t, len: ::off_t) -> ::c_int;
+-    pub fn fallocate64(fd: ::c_int, mode: ::c_int, offset: ::off64_t, len: ::off64_t) -> ::c_int;
+     pub fn posix_fallocate(fd: ::c_int, offset: ::off_t, len: ::off_t) -> ::c_int;
+-    pub fn posix_fallocate64(fd: ::c_int, offset: ::off64_t, len: ::off64_t) -> ::c_int;
+     pub fn readahead(fd: ::c_int, offset: ::off64_t, count: ::size_t) -> ::ssize_t;
+     pub fn getxattr(
+         path: *const c_char,
+@@ -4203,12 +4190,6 @@ extern "C" {
+         offset: *mut off_t,
+         count: ::size_t,
+     ) -> ::ssize_t;
+-    pub fn sendfile64(
+-        out_fd: ::c_int,
+-        in_fd: ::c_int,
+-        offset: *mut off64_t,
+-        count: ::size_t,
+-    ) -> ::ssize_t;
+     pub fn sigsuspend(mask: *const ::sigset_t) -> ::c_int;
+     pub fn getgrgid_r(
+         gid: ::gid_t,
+@@ -4460,6 +4441,40 @@ extern "C" {
+     ) -> ::c_int;
+ }
+ 
++// LFS64 extensions
++//
++// * musl has 64-bit versions only so aliases the LFS64 symbols to the standard ones
++cfg_if! {
++    if #[cfg(not(target_env = "musl"))] {
++        extern "C" {
++            pub fn fallocate64(
++                fd: ::c_int,
++                mode: ::c_int,
++                offset: ::off64_t,
++                len: ::off64_t
++            ) -> ::c_int;
++            pub fn fgetpos64(stream: *mut ::FILE, ptr: *mut fpos64_t) -> ::c_int;
++            pub fn fopen64(filename: *const c_char, mode: *const c_char) -> *mut ::FILE;
++            pub fn freopen64(
++                filename: *const c_char,
++                mode: *const c_char,
++                file: *mut ::FILE,
++            ) -> *mut ::FILE;
++            pub fn fseeko64(stream: *mut ::FILE, offset: ::off64_t, whence: ::c_int) -> ::c_int;
++            pub fn fsetpos64(stream: *mut ::FILE, ptr: *const fpos64_t) -> ::c_int;
++            pub fn ftello64(stream: *mut ::FILE) -> ::off64_t;
++            pub fn posix_fallocate64(fd: ::c_int, offset: ::off64_t, len: ::off64_t) -> ::c_int;
++            pub fn sendfile64(
++                out_fd: ::c_int,
++                in_fd: ::c_int,
++                offset: *mut off64_t,
++                count: ::size_t,
++            ) -> ::ssize_t;
++            pub fn tmpfile64() -> *mut ::FILE;
++        }
++    }
++}
++
+ cfg_if! {
+     if #[cfg(target_env = "uclibc")] {
+         mod uclibc;
+--- a/src/unix/linux_like/linux/musl/b32/riscv32/mod.rs
++++ b/src/unix/linux_like/linux/musl/b32/riscv32/mod.rs
+@@ -184,22 +184,6 @@ s! {
+         __pad1: ::c_ulong,
+         __pad2: ::c_ulong,
+     }
+-
+-    pub struct flock {
+-        pub l_type: ::c_short,
+-        pub l_whence: ::c_short,
+-        pub l_start: ::off_t,
+-        pub l_len: ::off_t,
+-        pub l_pid: ::pid_t,
+-    }
+-
+-    pub struct flock64 {
+-        pub l_type: ::c_short,
+-        pub l_whence: ::c_short,
+-        pub l_start: ::off64_t,
+-        pub l_len: ::off64_t,
+-        pub l_pid: ::pid_t,
+-    }
+ }
+ 
+ //pub const RLIM_INFINITY: ::rlim_t = !0;
+--- a/src/unix/linux_like/linux/musl/b64/riscv64/mod.rs
++++ b/src/unix/linux_like/linux/musl/b64/riscv64/mod.rs
+@@ -173,22 +173,6 @@ s! {
+         __unused5: ::c_ulong,
+         __unused6: ::c_ulong,
+     }
+-
+-    pub struct flock {
+-        pub l_type: ::c_short,
+-        pub l_whence: ::c_short,
+-        pub l_start: ::off_t,
+-        pub l_len: ::off_t,
+-        pub l_pid: ::pid_t,
+-    }
+-
+-    pub struct flock64 {
+-        pub l_type: ::c_short,
+-        pub l_whence: ::c_short,
+-        pub l_start: ::off64_t,
+-        pub l_len: ::off64_t,
+-        pub l_pid: ::pid_t,
+-    }
+ }
+ 
+ pub const SYS_read: ::c_long = 63;
+--- /dev/null
++++ b/src/unix/linux_like/linux/musl/lfs64.rs
+@@ -0,0 +1,251 @@
++#[inline]
++pub unsafe extern "C" fn creat64(path: *const ::c_char, mode: ::mode_t) -> ::c_int {
++    ::creat(path, mode)
++}
++
++#[inline]
++pub unsafe extern "C" fn fallocate64(
++    fd: ::c_int,
++    mode: ::c_int,
++    offset: ::off64_t,
++    len: ::off64_t,
++) -> ::c_int {
++    ::fallocate(fd, mode, offset, len)
++}
++
++#[inline]
++pub unsafe extern "C" fn fgetpos64(stream: *mut ::FILE, pos: *mut ::fpos64_t) -> ::c_int {
++    ::fgetpos(stream, pos as *mut _)
++}
++
++#[inline]
++pub unsafe extern "C" fn fopen64(pathname: *const ::c_char, mode: *const ::c_char) -> *mut ::FILE {
++    ::fopen(pathname, mode)
++}
++
++#[inline]
++pub unsafe extern "C" fn freopen64(
++    pathname: *const ::c_char,
++    mode: *const ::c_char,
++    stream: *mut ::FILE,
++) -> *mut ::FILE {
++    ::freopen(pathname, mode, stream)
++}
++
++#[inline]
++pub unsafe extern "C" fn fseeko64(
++    stream: *mut ::FILE,
++    offset: ::off64_t,
++    whence: ::c_int,
++) -> ::c_int {
++    ::fseeko(stream, offset, whence)
++}
++
++#[inline]
++pub unsafe extern "C" fn fsetpos64(stream: *mut ::FILE, pos: *const ::fpos64_t) -> ::c_int {
++    ::fsetpos(stream, pos as *mut _)
++}
++
++#[inline]
++pub unsafe extern "C" fn fstat64(fildes: ::c_int, buf: *mut ::stat64) -> ::c_int {
++    ::fstat(fildes, buf as *mut _)
++}
++
++#[inline]
++pub unsafe extern "C" fn fstatat64(
++    fd: ::c_int,
++    path: *const ::c_char,
++    buf: *mut ::stat64,
++    flag: ::c_int,
++) -> ::c_int {
++    ::fstatat(fd, path, buf as *mut _, flag)
++}
++
++#[inline]
++pub unsafe extern "C" fn fstatfs64(fd: ::c_int, buf: *mut ::statfs64) -> ::c_int {
++    ::fstatfs(fd, buf as *mut _)
++}
++
++#[inline]
++pub unsafe extern "C" fn fstatvfs64(fd: ::c_int, buf: *mut ::statvfs64) -> ::c_int {
++    ::fstatvfs(fd, buf as *mut _)
++}
++
++#[inline]
++pub unsafe extern "C" fn ftello64(stream: *mut ::FILE) -> ::off64_t {
++    ::ftello(stream)
++}
++
++#[inline]
++pub unsafe extern "C" fn ftruncate64(fd: ::c_int, length: ::off64_t) -> ::c_int {
++    ::ftruncate(fd, length)
++}
++
++#[inline]
++pub unsafe extern "C" fn getrlimit64(resource: ::c_int, rlim: *mut ::rlimit64) -> ::c_int {
++    ::getrlimit(resource, rlim as *mut _)
++}
++
++#[inline]
++pub unsafe extern "C" fn lseek64(fd: ::c_int, offset: ::off64_t, whence: ::c_int) -> ::off64_t {
++    ::lseek(fd, offset, whence)
++}
++
++#[inline]
++pub unsafe extern "C" fn lstat64(path: *const ::c_char, buf: *mut ::stat64) -> ::c_int {
++    ::lstat(path, buf as *mut _)
++}
++
++#[inline]
++pub unsafe extern "C" fn mmap64(
++    addr: *mut ::c_void,
++    length: ::size_t,
++    prot: ::c_int,
++    flags: ::c_int,
++    fd: ::c_int,
++    offset: ::off64_t,
++) -> *mut ::c_void {
++    ::mmap(addr, length, prot, flags, fd, offset)
++}
++
++#[inline]
++pub unsafe extern "C" fn open64(
++    pathname: *const ::c_char,
++    flags: ::c_int,
++    mode: ::mode_t,
++) -> ::c_int {
++    ::open(pathname, flags, mode)
++}
++
++#[inline]
++pub unsafe extern "C" fn openat64(
++    dirfd: ::c_int,
++    pathname: *const ::c_char,
++    flags: ::c_int,
++    mode: ::mode_t,
++) -> ::c_int {
++    ::openat(dirfd, pathname, flags, mode)
++}
++
++#[inline]
++pub unsafe extern "C" fn posix_fadvise64(
++    fd: ::c_int,
++    offset: ::off64_t,
++    len: ::off64_t,
++    advice: ::c_int,
++) -> ::c_int {
++    ::posix_fadvise(fd, offset, len, advice)
++}
++
++#[inline]
++pub unsafe extern "C" fn posix_fallocate64(
++    fd: ::c_int,
++    offset: ::off64_t,
++    len: ::off64_t,
++) -> ::c_int {
++    ::posix_fallocate(fd, offset, len)
++}
++
++#[inline]
++pub unsafe extern "C" fn pread64(
++    fd: ::c_int,
++    buf: *mut ::c_void,
++    count: ::size_t,
++    offset: ::off64_t,
++) -> ::ssize_t {
++    ::pread(fd, buf, count, offset)
++}
++
++#[inline]
++pub unsafe extern "C" fn preadv64(
++    fd: ::c_int,
++    iov: *const ::iovec,
++    iovcnt: ::c_int,
++    offset: ::off64_t,
++) -> ::ssize_t {
++    ::preadv(fd, iov, iovcnt, offset)
++}
++
++#[inline]
++pub unsafe extern "C" fn prlimit64(
++    pid: ::pid_t,
++    resource: ::c_int,
++    new_limit: *const ::rlimit64,
++    old_limit: *mut ::rlimit64,
++) -> ::c_int {
++    ::prlimit(pid, resource, new_limit as *mut _, old_limit as *mut _)
++}
++
++#[inline]
++pub unsafe extern "C" fn pwrite64(
++    fd: ::c_int,
++    buf: *const ::c_void,
++    count: ::size_t,
++    offset: ::off64_t,
++) -> ::ssize_t {
++    ::pwrite(fd, buf, count, offset)
++}
++
++#[inline]
++pub unsafe extern "C" fn pwritev64(
++    fd: ::c_int,
++    iov: *const ::iovec,
++    iovcnt: ::c_int,
++    offset: ::off64_t,
++) -> ::ssize_t {
++    ::pwritev(fd, iov, iovcnt, offset)
++}
++
++#[inline]
++pub unsafe extern "C" fn readdir64(dirp: *mut ::DIR) -> *mut ::dirent64 {
++    ::readdir(dirp) as *mut _
++}
++
++#[inline]
++pub unsafe extern "C" fn readdir64_r(
++    dirp: *mut ::DIR,
++    entry: *mut ::dirent64,
++    result: *mut *mut ::dirent64,
++) -> ::c_int {
++    ::readdir_r(dirp, entry as *mut _, result as *mut _)
++}
++
++#[inline]
++pub unsafe extern "C" fn sendfile64(
++    out_fd: ::c_int,
++    in_fd: ::c_int,
++    offset: *mut ::off64_t,
++    count: ::size_t,
++) -> ::ssize_t {
++    ::sendfile(out_fd, in_fd, offset, count)
++}
++
++#[inline]
++pub unsafe extern "C" fn setrlimit64(resource: ::c_int, rlim: *const ::rlimit64) -> ::c_int {
++    ::setrlimit(resource, rlim as *mut _)
++}
++
++#[inline]
++pub unsafe extern "C" fn stat64(pathname: *const ::c_char, statbuf: *mut ::stat64) -> ::c_int {
++    ::stat(pathname, statbuf as *mut _)
++}
++
++#[inline]
++pub unsafe extern "C" fn statfs64(pathname: *const ::c_char, buf: *mut ::statfs64) -> ::c_int {
++    ::statfs(pathname, buf as *mut _)
++}
++
++#[inline]
++pub unsafe extern "C" fn statvfs64(path: *const ::c_char, buf: *mut ::statvfs64) -> ::c_int {
++    ::statvfs(path, buf as *mut _)
++}
++
++#[inline]
++pub unsafe extern "C" fn tmpfile64() -> *mut ::FILE {
++    ::tmpfile()
++}
++
++#[inline]
++pub unsafe extern "C" fn truncate64(path: *const ::c_char, length: ::off64_t) -> ::c_int {
++    ::truncate(path, length)
++}
+--- a/src/unix/linux_like/linux/musl/mod.rs
++++ b/src/unix/linux_like/linux/musl/mod.rs
+@@ -22,8 +22,6 @@ pub type fsblkcnt_t = ::c_ulonglong;
+ pub type fsfilcnt_t = ::c_ulonglong;
+ pub type rlim_t = ::c_ulonglong;
+ 
+-pub type flock64 = flock;
+-
+ cfg_if! {
+     if #[cfg(doc)] {
+         // Used in `linux::arch` to define ioctl constants.
+@@ -189,6 +187,14 @@ s! {
+         pub l_pid: ::pid_t,
+     }
+ 
++    pub struct flock64 {
++        pub l_type: ::c_short,
++        pub l_whence: ::c_short,
++        pub l_start: ::off64_t,
++        pub l_len: ::off64_t,
++        pub l_pid: ::pid_t,
++    }
++
+     pub struct regex_t {
+         __re_nsub: ::size_t,
+         __opaque: *mut ::c_void,
+@@ -709,8 +715,6 @@ extern "C" {
+         timeout: *mut ::timespec,
+     ) -> ::c_int;
+ 
+-    pub fn getrlimit64(resource: ::c_int, rlim: *mut ::rlimit64) -> ::c_int;
+-    pub fn setrlimit64(resource: ::c_int, rlim: *const ::rlimit64) -> ::c_int;
+     pub fn getrlimit(resource: ::c_int, rlim: *mut ::rlimit) -> ::c_int;
+     pub fn setrlimit(resource: ::c_int, rlim: *const ::rlimit) -> ::c_int;
+     pub fn prlimit(
+@@ -719,13 +723,6 @@ extern "C" {
+         new_limit: *const ::rlimit,
+         old_limit: *mut ::rlimit,
+     ) -> ::c_int;
+-    pub fn prlimit64(
+-        pid: ::pid_t,
+-        resource: ::c_int,
+-        new_limit: *const ::rlimit64,
+-        old_limit: *mut ::rlimit64,
+-    ) -> ::c_int;
+-
+     pub fn ioctl(fd: ::c_int, request: ::c_int, ...) -> ::c_int;
+     pub fn gettimeofday(tp: *mut ::timeval, tz: *mut ::c_void) -> ::c_int;
+     pub fn ptrace(request: ::c_int, ...) -> ::c_long;
+@@ -774,6 +771,10 @@ extern "C" {
+     pub fn basename(path: *mut ::c_char) -> *mut ::c_char;
+ }
+ 
++// Alias <foo> to <foo>64 to mimic glibc's LFS64 support
++mod lfs64;
++pub use self::lfs64::*;
++
+ cfg_if! {
+     if #[cfg(any(target_arch = "x86_64",
+                  target_arch = "aarch64",
+--- a/src/unix/linux_like/mod.rs
++++ b/src/unix/linux_like/mod.rs
+@@ -1653,20 +1653,9 @@ extern "C" {
+     pub fn setgroups(ngroups: ::size_t, ptr: *const ::gid_t) -> ::c_int;
+     pub fn pipe2(fds: *mut ::c_int, flags: ::c_int) -> ::c_int;
+     pub fn statfs(path: *const ::c_char, buf: *mut statfs) -> ::c_int;
+-    pub fn statfs64(path: *const ::c_char, buf: *mut statfs64) -> ::c_int;
+     pub fn fstatfs(fd: ::c_int, buf: *mut statfs) -> ::c_int;
+-    pub fn fstatfs64(fd: ::c_int, buf: *mut statfs64) -> ::c_int;
+-    pub fn statvfs64(path: *const ::c_char, buf: *mut statvfs64) -> ::c_int;
+-    pub fn fstatvfs64(fd: ::c_int, buf: *mut statvfs64) -> ::c_int;
+     pub fn memrchr(cx: *const ::c_void, c: ::c_int, n: ::size_t) -> *mut ::c_void;
+-
+     pub fn posix_fadvise(fd: ::c_int, offset: ::off_t, len: ::off_t, advise: ::c_int) -> ::c_int;
+-    pub fn posix_fadvise64(
+-        fd: ::c_int,
+-        offset: ::off64_t,
+-        len: ::off64_t,
+-        advise: ::c_int,
+-    ) -> ::c_int;
+     pub fn futimens(fd: ::c_int, times: *const ::timespec) -> ::c_int;
+     pub fn utimensat(
+         dirfd: ::c_int,
+@@ -1678,43 +1667,6 @@ extern "C" {
+     pub fn freelocale(loc: ::locale_t);
+     pub fn newlocale(mask: ::c_int, locale: *const ::c_char, base: ::locale_t) -> ::locale_t;
+     pub fn uselocale(loc: ::locale_t) -> ::locale_t;
+-    pub fn creat64(path: *const c_char, mode: mode_t) -> ::c_int;
+-    pub fn fstat64(fildes: ::c_int, buf: *mut stat64) -> ::c_int;
+-    pub fn fstatat64(
+-        dirfd: ::c_int,
+-        pathname: *const c_char,
+-        buf: *mut stat64,
+-        flags: ::c_int,
+-    ) -> ::c_int;
+-    pub fn ftruncate64(fd: ::c_int, length: off64_t) -> ::c_int;
+-    pub fn lseek64(fd: ::c_int, offset: off64_t, whence: ::c_int) -> off64_t;
+-    pub fn lstat64(path: *const c_char, buf: *mut stat64) -> ::c_int;
+-    pub fn mmap64(
+-        addr: *mut ::c_void,
+-        len: ::size_t,
+-        prot: ::c_int,
+-        flags: ::c_int,
+-        fd: ::c_int,
+-        offset: off64_t,
+-    ) -> *mut ::c_void;
+-    pub fn open64(path: *const c_char, oflag: ::c_int, ...) -> ::c_int;
+-    pub fn openat64(fd: ::c_int, path: *const c_char, oflag: ::c_int, ...) -> ::c_int;
+-    pub fn pread64(fd: ::c_int, buf: *mut ::c_void, count: ::size_t, offset: off64_t) -> ::ssize_t;
+-    pub fn pwrite64(
+-        fd: ::c_int,
+-        buf: *const ::c_void,
+-        count: ::size_t,
+-        offset: off64_t,
+-    ) -> ::ssize_t;
+-    pub fn readdir64(dirp: *mut ::DIR) -> *mut ::dirent64;
+-    pub fn readdir64_r(
+-        dirp: *mut ::DIR,
+-        entry: *mut ::dirent64,
+-        result: *mut *mut ::dirent64,
+-    ) -> ::c_int;
+-    pub fn stat64(path: *const c_char, buf: *mut stat64) -> ::c_int;
+-    pub fn truncate64(path: *const c_char, length: off64_t) -> ::c_int;
+-
+     pub fn mknodat(
+         dirfd: ::c_int,
+         pathname: *const ::c_char,
+@@ -1784,8 +1736,70 @@ extern "C" {
+     pub fn uname(buf: *mut ::utsname) -> ::c_int;
+ }
+ 
++// LFS64 extensions
++//
++// * musl has 64-bit versions only so aliases the LFS64 symbols to the standard ones
++// * ulibc doesn't have preadv64/pwritev64
+ cfg_if! {
+-    if #[cfg(not(target_env = "uclibc"))] {
++    if #[cfg(not(target_env = "musl"))] {
++        extern "C" {
++            pub fn fstatfs64(fd: ::c_int, buf: *mut statfs64) -> ::c_int;
++            pub fn statvfs64(path: *const ::c_char, buf: *mut statvfs64) -> ::c_int;
++            pub fn fstatvfs64(fd: ::c_int, buf: *mut statvfs64) -> ::c_int;
++            pub fn statfs64(path: *const ::c_char, buf: *mut statfs64) -> ::c_int;
++            pub fn creat64(path: *const c_char, mode: mode_t) -> ::c_int;
++            pub fn fstat64(fildes: ::c_int, buf: *mut stat64) -> ::c_int;
++            pub fn fstatat64(
++                dirfd: ::c_int,
++                pathname: *const c_char,
++                buf: *mut stat64,
++                flags: ::c_int,
++            ) -> ::c_int;
++            pub fn ftruncate64(fd: ::c_int, length: off64_t) -> ::c_int;
++            pub fn lseek64(fd: ::c_int, offset: off64_t, whence: ::c_int) -> off64_t;
++            pub fn lstat64(path: *const c_char, buf: *mut stat64) -> ::c_int;
++            pub fn mmap64(
++                addr: *mut ::c_void,
++                len: ::size_t,
++                prot: ::c_int,
++                flags: ::c_int,
++                fd: ::c_int,
++                offset: off64_t,
++            ) -> *mut ::c_void;
++            pub fn open64(path: *const c_char, oflag: ::c_int, ...) -> ::c_int;
++            pub fn openat64(fd: ::c_int, path: *const c_char, oflag: ::c_int, ...) -> ::c_int;
++            pub fn posix_fadvise64(
++                fd: ::c_int,
++                offset: ::off64_t,
++                len: ::off64_t,
++                advise: ::c_int,
++            ) -> ::c_int;
++            pub fn pread64(
++                fd: ::c_int,
++                buf: *mut ::c_void,
++                count: ::size_t,
++                offset: off64_t
++            ) -> ::ssize_t;
++            pub fn pwrite64(
++                fd: ::c_int,
++                buf: *const ::c_void,
++                count: ::size_t,
++                offset: off64_t,
++            ) -> ::ssize_t;
++            pub fn readdir64(dirp: *mut ::DIR) -> *mut ::dirent64;
++            pub fn readdir64_r(
++                dirp: *mut ::DIR,
++                entry: *mut ::dirent64,
++                result: *mut *mut ::dirent64,
++            ) -> ::c_int;
++            pub fn stat64(path: *const c_char, buf: *mut stat64) -> ::c_int;
++            pub fn truncate64(path: *const c_char, length: off64_t) -> ::c_int;
++        }
++    }
++}
++
++cfg_if! {
++    if #[cfg(not(any(target_env = "uclibc", target_env = "musl")))] {
+         extern "C" {
+             pub fn preadv64(
+                 fd: ::c_int,
+@@ -1799,6 +1813,13 @@ cfg_if! {
+                 iovcnt: ::c_int,
+                 offset: ::off64_t,
+             ) -> ::ssize_t;
++        }
++    }
++}
++
++cfg_if! {
++    if #[cfg(not(target_env = "uclibc"))] {
++        extern "C" {
+             // uclibc has separate non-const version of this function
+             pub fn forkpty(
+                 amaster: *mut ::c_int,

--- a/dev-lang/rust/files/1.69.0-musl-1.2.4.patch
+++ b/dev-lang/rust/files/1.69.0-musl-1.2.4.patch
@@ -1,0 +1,166 @@
+https://bugs.gentoo.org/903607
+https://github.com/rust-lang/rust/pull/106246
+
+From e2355ea7f22219f1fb3919a45e4f07502652ee5c Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Fri, 19 May 2023 09:22:21 -0700
+Subject: [PATCH] Do not use LFS64 on linux with musl
+
+glibc is providing open64 and other lfs64 functions but musl aliases
+them to normal equivalents since off_t is always 64-bit on musl,
+therefore check for target env along when target OS is linux before
+using open64, this is more available. Latest Musl has made these
+namespace changes [1]
+
+[1] https://git.musl-libc.org/cgit/musl/commit/?id=246f1c811448f37a44b41cd8df8d0ef9736d95f4
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ library/std/src/os/linux/fs.rs |  9 ++++++++-
+ library/std/src/sys/unix/fd.rs | 14 ++++++++++----
+ library/std/src/sys/unix/fs.rs | 25 +++++++++++++++++++------
+ 3 files changed, 37 insertions(+), 11 deletions(-)
+
+diff --git a/library/std/src/os/linux/fs.rs b/library/std/src/os/linux/fs.rs
+index 479bbcc17a89e..ab0b2a3eda3f5 100644
+--- a/library/std/src/os/linux/fs.rs
++++ b/library/std/src/os/linux/fs.rs
+@@ -329,7 +329,14 @@ pub trait MetadataExt {
+ impl MetadataExt for Metadata {
+     #[allow(deprecated)]
+     fn as_raw_stat(&self) -> &raw::stat {
+-        unsafe { &*(self.as_inner().as_inner() as *const libc::stat64 as *const raw::stat) }
++        #[cfg(target_env = "musl")]
++        unsafe {
++            &*(self.as_inner().as_inner() as *const libc::stat as *const raw::stat)
++        }
++        #[cfg(not(target_env = "musl"))]
++        unsafe {
++            &*(self.as_inner().as_inner() as *const libc::stat64 as *const raw::stat)
++        }
+     }
+     fn st_dev(&self) -> u64 {
+         self.as_inner().as_inner().st_dev as u64
+diff --git a/library/std/src/sys/unix/fd.rs b/library/std/src/sys/unix/fd.rs
+index cb630eede6da0..c1e0c05213ac2 100644
+--- a/library/std/src/sys/unix/fd.rs
++++ b/library/std/src/sys/unix/fd.rs
+@@ -122,9 +122,12 @@ impl FileDesc {
+     }
+ 
+     pub fn read_at(&self, buf: &mut [u8], offset: u64) -> io::Result<usize> {
+-        #[cfg(not(any(target_os = "linux", target_os = "android")))]
++        #[cfg(not(any(
++            all(target_os = "linux", not(target_env = "musl")),
++            target_os = "android"
++        )))]
+         use libc::pread as pread64;
+-        #[cfg(any(target_os = "linux", target_os = "android"))]
++        #[cfg(any(all(target_os = "linux", not(target_env = "musl")), target_os = "android"))]
+         use libc::pread64;
+ 
+         unsafe {
+@@ -277,9 +280,12 @@ impl FileDesc {
+     }
+ 
+     pub fn write_at(&self, buf: &[u8], offset: u64) -> io::Result<usize> {
+-        #[cfg(not(any(target_os = "linux", target_os = "android")))]
++        #[cfg(not(any(
++            all(target_os = "linux", not(target_env = "musl")),
++            target_os = "android"
++        )))]
+         use libc::pwrite as pwrite64;
+-        #[cfg(any(target_os = "linux", target_os = "android"))]
++        #[cfg(any(all(target_os = "linux", not(target_env = "musl")), target_os = "android"))]
+         use libc::pwrite64;
+ 
+         unsafe {
+diff --git a/library/std/src/sys/unix/fs.rs b/library/std/src/sys/unix/fs.rs
+index 09db5b11dbfd3..e31f987c7dc9a 100644
+--- a/library/std/src/sys/unix/fs.rs
++++ b/library/std/src/sys/unix/fs.rs
+@@ -47,9 +47,13 @@ use libc::{c_int, mode_t};
+     all(target_os = "linux", target_env = "gnu")
+ ))]
+ use libc::c_char;
+-#[cfg(any(target_os = "linux", target_os = "emscripten", target_os = "android"))]
++#[cfg(any(
++    all(target_os = "linux", not(target_env = "musl")),
++    target_os = "emscripten",
++    target_os = "android"
++))]
+ use libc::dirfd;
+-#[cfg(any(target_os = "linux", target_os = "emscripten"))]
++#[cfg(any(not(target_env = "musl"), target_os = "emscripten"))]
+ use libc::fstatat64;
+ #[cfg(any(
+     target_os = "android",
+@@ -58,9 +62,10 @@ use libc::fstatat64;
+     target_os = "redox",
+     target_os = "illumos",
+     target_os = "nto",
++    target_env = "musl",
+ ))]
+ use libc::readdir as readdir64;
+-#[cfg(target_os = "linux")]
++#[cfg(all(target_os = "linux", not(target_env = "musl")))]
+ use libc::readdir64;
+ #[cfg(any(target_os = "emscripten", target_os = "l4re"))]
+ use libc::readdir64_r;
+@@ -81,7 +86,13 @@ use libc::{
+     dirent as dirent64, fstat as fstat64, fstatat as fstatat64, ftruncate64, lseek64,
+     lstat as lstat64, off64_t, open as open64, stat as stat64,
+ };
++#[cfg(target_env = "musl")]
++use libc::{
++    dirent as dirent64, fstat as fstat64, ftruncate as ftruncate64, lseek as lseek64,
++    lstat as lstat64, off_t as off64_t, open as open64, stat as stat64,
++};
+ #[cfg(not(any(
++    target_env = "musl",
+     target_os = "linux",
+     target_os = "emscripten",
+     target_os = "l4re",
+@@ -91,7 +102,7 @@ use libc::{
+     dirent as dirent64, fstat as fstat64, ftruncate as ftruncate64, lseek as lseek64,
+     lstat as lstat64, off_t as off64_t, open as open64, stat as stat64,
+ };
+-#[cfg(any(target_os = "linux", target_os = "emscripten", target_os = "l4re"))]
++#[cfg(any(not(target_env = "musl"), target_os = "emscripten", target_os = "l4re"))]
+ use libc::{dirent64, fstat64, ftruncate64, lseek64, lstat64, off64_t, open64, stat64};
+ 
+ pub use crate::sys_common::fs::try_exists;
+@@ -278,6 +289,7 @@ unsafe impl Sync for Dir {}
+ #[cfg(any(
+     target_os = "android",
+     target_os = "linux",
++    not(target_env = "musl"),
+     target_os = "solaris",
+     target_os = "illumos",
+     target_os = "fuchsia",
+@@ -312,6 +324,7 @@ struct dirent64_min {
+ }
+ 
+ #[cfg(not(any(
++    target_env = "musl",
+     target_os = "android",
+     target_os = "linux",
+     target_os = "solaris",
+@@ -798,7 +811,7 @@ impl DirEntry {
+     }
+ 
+     #[cfg(all(
+-        any(target_os = "linux", target_os = "emscripten", target_os = "android"),
++        any(not(target_env = "musl"), target_os = "emscripten", target_os = "android"),
+         not(miri)
+     ))]
+     pub fn metadata(&self) -> io::Result<FileAttr> {
+@@ -822,7 +835,7 @@ impl DirEntry {
+     }
+ 
+     #[cfg(any(
+-        not(any(target_os = "linux", target_os = "emscripten", target_os = "android")),
++        not(any(not(target_env = "musl"), target_os = "emscripten", target_os = "android")),
+         miri
+     ))]
+     pub fn metadata(&self) -> io::Result<FileAttr> {

--- a/dev-lang/rust/rust-1.70.0-r1.ebuild
+++ b/dev-lang/rust/rust-1.70.0-r1.ebuild
@@ -1,0 +1,792 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+PYTHON_COMPAT=( python3_{9..12} )
+
+inherit bash-completion-r1 check-reqs estack flag-o-matic llvm multiprocessing \
+	multilib multilib-build python-any-r1 rust-toolchain toolchain-funcs verify-sig
+
+if [[ ${PV} = *beta* ]]; then
+	betaver=${PV//*beta}
+	BETA_SNAPSHOT="${betaver:0:4}-${betaver:4:2}-${betaver:6:2}"
+	MY_P="rustc-beta"
+	SLOT="beta/${PV}"
+	SRC="${BETA_SNAPSHOT}/rustc-beta-src.tar.xz -> rustc-${PV}-src.tar.xz"
+else
+	ABI_VER="$(ver_cut 1-2)"
+	SLOT="stable/${ABI_VER}"
+	MY_P="rustc-${PV}"
+	SRC="${MY_P}-src.tar.xz"
+	KEYWORDS="~amd64 ~arm ~arm64 ~mips ~ppc ~ppc64 ~riscv ~sparc ~x86"
+fi
+
+RUST_STAGE0_VERSION="1.$(($(ver_cut 2) - 1)).0"
+
+DESCRIPTION="Systems programming language from Mozilla"
+HOMEPAGE="https://www.rust-lang.org/"
+
+SRC_URI="
+	https://static.rust-lang.org/dist/${SRC}
+	verify-sig? ( https://static.rust-lang.org/dist/${SRC}.asc )
+	!system-bootstrap? ( $(rust_all_arch_uris rust-${RUST_STAGE0_VERSION}) )
+"
+
+# keep in sync with llvm ebuild of the same version as bundled one.
+ALL_LLVM_TARGETS=( AArch64 AMDGPU ARM AVR BPF Hexagon Lanai LoongArch Mips MSP430
+	NVPTX PowerPC RISCV Sparc SystemZ VE WebAssembly X86 XCore )
+ALL_LLVM_TARGETS=( "${ALL_LLVM_TARGETS[@]/#/llvm_targets_}" )
+LLVM_TARGET_USEDEPS=${ALL_LLVM_TARGETS[@]/%/(-)?}
+
+LICENSE="|| ( MIT Apache-2.0 ) BSD BSD-1 BSD-2 BSD-4 UoI-NCSA"
+
+IUSE="big-endian clippy cpu_flags_x86_sse2 debug dist doc llvm-libunwind +lto miri nightly parallel-compiler profiler rustfmt rust-analyzer rust-src system-bootstrap system-llvm test wasm ${ALL_LLVM_TARGETS[*]}"
+
+# Please keep the LLVM dependency block separate. Since LLVM is slotted,
+# we need to *really* make sure we're not pulling more than one slot
+# simultaneously.
+
+# How to use it:
+# List all the working slots in LLVM_VALID_SLOTS, newest first.
+LLVM_VALID_SLOTS=( 16 )
+LLVM_MAX_SLOT="${LLVM_VALID_SLOTS[0]}"
+
+# splitting usedeps needed to avoid CI/pkgcheck's UncheckableDep limitation
+# (-) usedep needed because we may build with older llvm without that target
+LLVM_DEPEND="|| ( "
+for _s in ${LLVM_VALID_SLOTS[@]}; do
+	LLVM_DEPEND+=" ( "
+	for _x in ${ALL_LLVM_TARGETS[@]}; do
+		LLVM_DEPEND+="
+			${_x}? ( sys-devel/llvm:${_s}[${_x}(-)] )
+			wasm? ( sys-devel/lld:${_s} )"
+	done
+	LLVM_DEPEND+=" )"
+done
+unset _s _x
+LLVM_DEPEND+=" )
+	<sys-devel/llvm-$(( LLVM_MAX_SLOT + 1 )):=
+"
+
+# to bootstrap we need at least exactly previous version, or same.
+# most of the time previous versions fail to bootstrap with newer
+# for example 1.47.x, requires at least 1.46.x, 1.47.x is ok,
+# but it fails to bootstrap with 1.48.x
+# https://github.com/rust-lang/rust/blob/${PV}/src/stage0.json
+RUST_DEP_PREV="$(ver_cut 1).$(($(ver_cut 2) - 1))*"
+RUST_DEP_CURR="$(ver_cut 1).$(ver_cut 2)*"
+BOOTSTRAP_DEPEND="||
+	(
+		=dev-lang/rust-"${RUST_DEP_PREV}"
+		=dev-lang/rust-bin-"${RUST_DEP_PREV}"
+		=dev-lang/rust-"${RUST_DEP_CURR}"
+		=dev-lang/rust-bin-"${RUST_DEP_CURR}"
+	)
+"
+
+BDEPEND="${PYTHON_DEPS}
+	app-eselect/eselect-rust
+	|| (
+		>=sys-devel/gcc-4.7
+		>=sys-devel/clang-3.5
+	)
+	system-bootstrap? ( ${BOOTSTRAP_DEPEND} )
+	!system-llvm? (
+		>=dev-util/cmake-3.13.4
+		dev-util/ninja
+	)
+	test? ( sys-devel/gdb )
+	verify-sig? ( sec-keys/openpgp-keys-rust )
+"
+
+DEPEND="
+	>=app-arch/xz-utils-5.2
+	net-misc/curl:=[http2,ssl]
+	sys-libs/zlib:=
+	dev-libs/openssl:0=
+	system-llvm? (
+		${LLVM_DEPEND}
+		llvm-libunwind? ( sys-libs/llvm-libunwind:= )
+	)
+	!system-llvm? (
+		!llvm-libunwind? (
+			elibc_musl? ( sys-libs/libunwind:= )
+		)
+	)
+"
+
+RDEPEND="${DEPEND}
+	app-eselect/eselect-rust
+	sys-apps/lsb-release
+"
+
+REQUIRED_USE="|| ( ${ALL_LLVM_TARGETS[*]} )
+	miri? ( nightly )
+	parallel-compiler? ( nightly )
+	rust-analyzer? ( rust-src )
+	test? ( ${ALL_LLVM_TARGETS[*]} )
+	wasm? ( llvm_targets_WebAssembly )
+	x86? ( cpu_flags_x86_sse2 )
+"
+
+# we don't use cmake.eclass, but can get a warning
+CMAKE_WARN_UNUSED_CLI=no
+
+QA_FLAGS_IGNORED="
+	usr/lib/${PN}/${PV}/bin/.*
+	usr/lib/${PN}/${PV}/libexec/.*
+	usr/lib/${PN}/${PV}/lib/lib.*.so
+	usr/lib/${PN}/${PV}/lib/rustlib/.*/bin/.*
+	usr/lib/${PN}/${PV}/lib/rustlib/.*/lib/lib.*.so
+"
+
+QA_SONAME="
+	usr/lib/${PN}/${PV}/lib/lib.*.so.*
+	usr/lib/${PN}/${PV}/lib/rustlib/.*/lib/lib.*.so
+"
+
+QA_PRESTRIPPED="
+	usr/lib/${PN}/${PV}/lib/rustlib/.*/bin/rust-llvm-dwp
+	usr/lib/${PN}/${PV}/lib/rustlib/.*/lib/self-contained/crtn.o
+"
+
+# An rmeta file is custom binary format that contains the metadata for the crate.
+# rmeta files do not support linking, since they do not contain compiled object files.
+# so we can safely silence the warning for this QA check.
+QA_EXECSTACK="usr/lib/${PN}/${PV}/lib/rustlib/*/lib*.rlib:lib.rmeta"
+
+# causes double bootstrap
+RESTRICT="test"
+
+VERIFY_SIG_OPENPGP_KEY_PATH=${BROOT}/usr/share/openpgp-keys/rust.asc
+
+PATCHES=(
+	"${FILESDIR}"/1.70.0-ignore-broken-and-non-applicable-tests.patch
+	"${FILESDIR}"/1.62.1-musl-dynamic-linking.patch
+	"${FILESDIR}"/1.67.0-doc-wasm.patch
+	"${FILESDIR}"/1.69.0-musl-1.2.4.patch
+)
+
+S="${WORKDIR}/${MY_P}-src"
+
+eapply_crate() {
+	pushd "${1:?}" > /dev/null || die
+
+	local patch="${2:?}"
+	eapply "${patch}"
+
+	local cargo='.cargo-checksum.json'
+	local _ f
+	grep -- '^[+][+][+] ' "${patch}" | while read -r _ f; do
+		local file="${f#*/}"
+		local orig_sum="$(grep -Eo "\"${file}\":\"[0-9a-fA-F]+\"" "${cargo}" |
+			cut -d':' -f2 | tr -d '"')" || die
+		if [ -n "${orig_sum}" ]; then
+			local sum="$(sha256sum "${file}")" || die
+			sed -i "s|${orig_sum}|${sum%% *}|" "${cargo}" || die
+		fi
+	done
+
+	popd > /dev/null || die
+}
+
+toml_usex() {
+	usex "${1}" true false
+}
+
+bootstrap_rust_version_check() {
+	# never call from pkg_pretend. eselect-rust may be not installed yet.
+	[[ ${MERGE_TYPE} == binary ]] && return
+	local rustc_wanted="$(ver_cut 1).$(($(ver_cut 2) - 1))"
+	local rustc_toonew="$(ver_cut 1).$(($(ver_cut 2) + 1))"
+	local rustc_version=( $(eselect --brief rust show 2>/dev/null) )
+	rustc_version=${rustc_version[0]#rust-bin-}
+	rustc_version=${rustc_version#rust-}
+
+	[[ -z "${rustc_version}" ]] && die "Failed to determine rust version, check 'eselect rust' output"
+
+	if ver_test "${rustc_version}" -lt "${rustc_wanted}" ; then
+		eerror "Rust >=${rustc_wanted} is required"
+		eerror "please run 'eselect rust' and set correct rust version"
+		die "selected rust version is too old"
+	elif ver_test "${rustc_version}" -ge "${rustc_toonew}" ; then
+		eerror "Rust <${rustc_toonew} is required"
+		eerror "please run 'eselect rust' and set correct rust version"
+		die "selected rust version is too new"
+	else
+		einfo "Using rust ${rustc_version} to build"
+	fi
+}
+
+pre_build_checks() {
+	local M=8192
+	# multiply requirements by 1.3 if we are doing x86-multilib
+	if use amd64; then
+		M=$(( $(usex abi_x86_32 13 10) * ${M} / 10 ))
+	fi
+	M=$(( $(usex clippy 128 0) + ${M} ))
+	M=$(( $(usex miri 128 0) + ${M} ))
+	M=$(( $(usex rustfmt 256 0) + ${M} ))
+	# add 2G if we compile llvm and 256M per llvm_target
+	if ! use system-llvm; then
+		M=$(( 2048 + ${M} ))
+		local ltarget
+		for ltarget in ${ALL_LLVM_TARGETS[@]}; do
+			M=$(( $(usex ${ltarget} 256 0) + ${M} ))
+		done
+	fi
+	M=$(( $(usex wasm 256 0) + ${M} ))
+	M=$(( $(usex debug 2 1) * ${M} ))
+	eshopts_push -s extglob
+	if is-flagq '-g?(gdb)?([1-9])'; then
+		M=$(( 15 * ${M} / 10 ))
+	fi
+	eshopts_pop
+	M=$(( $(usex system-bootstrap 0 1024) + ${M} ))
+	M=$(( $(usex doc 256 0) + ${M} ))
+	CHECKREQS_DISK_BUILD=${M}M check-reqs_pkg_${EBUILD_PHASE}
+}
+
+llvm_check_deps() {
+	has_version -r "sys-devel/llvm:${LLVM_SLOT}[${LLVM_TARGET_USEDEPS// /,}]"
+}
+
+# Is LLVM being linked against libc++?
+is_libcxx_linked() {
+	local code='#include <ciso646>
+#if defined(_LIBCPP_VERSION)
+	HAVE_LIBCXX
+#endif
+'
+	local out=$($(tc-getCXX) ${CXXFLAGS} ${CPPFLAGS} -x c++ -E -P - <<<"${code}") || return 1
+	[[ ${out} == *HAVE_LIBCXX* ]]
+}
+
+pkg_pretend() {
+	pre_build_checks
+}
+
+pkg_setup() {
+	pre_build_checks
+	python-any-r1_pkg_setup
+
+	export LIBGIT2_NO_PKG_CONFIG=1 #749381
+
+	use system-bootstrap && bootstrap_rust_version_check
+
+	if use system-llvm; then
+		llvm_pkg_setup
+
+		local llvm_config="$(get_llvm_prefix "${LLVM_MAX_SLOT}")/bin/llvm-config"
+		export LLVM_LINK_SHARED=1
+		export RUSTFLAGS="${RUSTFLAGS} -Lnative=$("${llvm_config}" --libdir)"
+	fi
+}
+
+esetup_unwind_hack() {
+	# https://bugs.gentoo.org/870280
+	# this is a hack needed to bootstrap with libgcc_s linked tarball on llvm-libunwind system.
+	# it should trigger for internal bootstrap or system-bootstrap with rust-bin.
+	# the whole idea is for stage0 to bootstrap with fake libgcc_s.
+	# final stage will receive -L${T}/lib but not -lgcc_s args, producing clean compiler.
+	local fakelib="${T}/fakelib"
+	mkdir -p "${fakelib}" || die
+	# we need both symlinks, one for cargo runtime, other for linker.
+	ln -s "${ESYSROOT}/usr/lib/libunwind.so" "${fakelib}/libgcc_s.so.1" || die
+	ln -s "${ESYSROOT}/usr/lib/libunwind.so" "${fakelib}/libgcc_s.so" || die
+	export LD_LIBRARY_PATH="${fakelib}"
+	export RUSTFLAGS+=" -L${fakelib}"
+	# this is a literally magic variable that gets through cargo cache, without it some
+	# crates ignore RUSTFLAGS.
+	# this variable can not contain leading space.
+	export MAGIC_EXTRA_RUSTFLAGS+="${MAGIC_EXTRA_RUSTFLAGS:+ }-L${fakelib}"
+}
+
+src_prepare() {
+	eapply_crate vendor/getrandom "${FILESDIR}"/1.69.0-musl-1.2.4-getrandom.patch
+	eapply_crate vendor/libc-0.2.138 "${FILESDIR}"/1.69.0-musl-1.2.4-libc.patch
+	eapply_crate vendor/libc-0.2.139 "${FILESDIR}"/1.69.0-musl-1.2.4-libc.patch
+	eapply_crate vendor/libc "${FILESDIR}"/1.69.0-musl-1.2.4-libc.patch
+
+	if ! use system-bootstrap; then
+		has_version sys-devel/gcc || esetup_unwind_hack
+		local rust_stage0_root="${WORKDIR}"/rust-stage0
+		local rust_stage0="rust-${RUST_STAGE0_VERSION}-$(rust_abi)"
+
+		if use elibc_musl; then
+			local libstd
+			for libstd in "${WORKDIR}/${rust_stage0}/rust-std-$(rust_abi)/lib/rustlib/$(rust_abi)"/lib/libstd-*.rlib; do
+				"$(tc-getOBJCOPY)" \
+					--redefine-sym=stat64=stat \
+					--redefine-sym=fstat64=fstat \
+					--redefine-sym=lstat64=lstat \
+					--redefine-sym=open64=open \
+					--redefine-sym=readdir64=readdir \
+					--redefine-sym=fstatat64=fstatat \
+					--redefine-sym=lseek64=lseek \
+					--redefine-sym=ftruncate64=ftruncate \
+					"${libstd}" \
+					"${libstd}.out" || die
+
+				mv "${libstd}.out" "${libstd}" || die
+			done
+		fi
+
+		"${WORKDIR}/${rust_stage0}"/install.sh --disable-ldconfig \
+			--without=rust-docs-json-preview,rust-docs --destdir="${rust_stage0_root}" --prefix=/ || die
+	fi
+
+	default
+}
+
+src_configure() {
+	filter-lto # https://bugs.gentoo.org/862109 https://bugs.gentoo.org/866231
+
+	local rust_target="" rust_targets="" arch_cflags
+
+	# Collect rust target names to compile standard libs for all ABIs.
+	for v in $(multilib_get_enabled_abi_pairs); do
+		rust_targets+=",\"$(rust_abi $(get_abi_CHOST ${v##*.}))\""
+	done
+	if use wasm; then
+		rust_targets+=",\"wasm32-unknown-unknown\""
+		if use system-llvm; then
+			# un-hardcode rust-lld linker for this target
+			# https://bugs.gentoo.org/715348
+			sed -i '/linker:/ s/rust-lld/wasm-ld/' compiler/rustc_target/src/spec/wasm_base.rs || die
+		fi
+	fi
+	rust_targets="${rust_targets#,}"
+
+	# cargo and rustdoc are mandatory and should always be included
+	local tools='"cargo","rustdoc"'
+	use clippy && tools+=',"clippy"'
+	use miri && tools+=',"miri"'
+	use profiler && tools+=',"rust-demangler"'
+	use rustfmt && tools+=',"rustfmt"'
+	use rust-analyzer && tools+=',"rust-analyzer"'
+	use rust-src && tools+=',"src"'
+
+	local rust_stage0_root
+	if use system-bootstrap; then
+		local printsysroot
+		printsysroot="$(rustc --print sysroot || die "Can't determine rust's sysroot")"
+		rust_stage0_root="${printsysroot}"
+	else
+		rust_stage0_root="${WORKDIR}"/rust-stage0
+	fi
+	# in case of prefix it will be already prefixed, as --print sysroot returns full path
+	[[ -d ${rust_stage0_root} ]] || die "${rust_stage0_root} is not a directory"
+
+	rust_target="$(rust_abi)"
+
+	local cm_btype="$(usex debug DEBUG RELEASE)"
+	cat <<- _EOF_ > "${S}"/config.toml
+		changelog-seen = 2
+		[llvm]
+		download-ci-llvm = false
+		optimize = $(toml_usex !debug)
+		release-debuginfo = $(toml_usex debug)
+		assertions = $(toml_usex debug)
+		ninja = true
+		targets = "${LLVM_TARGETS// /;}"
+		experimental-targets = ""
+		link-shared = $(toml_usex system-llvm)
+		$(if is_libcxx_linked; then
+			# https://bugs.gentoo.org/732632
+			echo "use-libcxx = true"
+			echo "static-libstdcpp = false"
+		fi)
+		$(case "${rust_target}" in
+			i586-*-linux-*)
+				# https://github.com/rust-lang/rust/issues/93059
+				echo 'cflags = "-fcf-protection=none"'
+				echo 'cxxflags = "-fcf-protection=none"'
+				echo 'ldflags = "-fcf-protection=none"'
+				;;
+			*)
+				;;
+		esac)
+		enable-warnings = false
+		[llvm.build-config]
+		CMAKE_VERBOSE_MAKEFILE = "ON"
+		CMAKE_C_FLAGS_${cm_btype} = "${CFLAGS}"
+		CMAKE_CXX_FLAGS_${cm_btype} = "${CXXFLAGS}"
+		CMAKE_EXE_LINKER_FLAGS_${cm_btype} = "${LDFLAGS}"
+		CMAKE_MODULE_LINKER_FLAGS_${cm_btype} = "${LDFLAGS}"
+		CMAKE_SHARED_LINKER_FLAGS_${cm_btype} = "${LDFLAGS}"
+		CMAKE_STATIC_LINKER_FLAGS_${cm_btype} = "${ARFLAGS}"
+		[build]
+		build-stage = 2
+		test-stage = 2
+		build = "${rust_target}"
+		host = ["${rust_target}"]
+		target = [${rust_targets}]
+		cargo = "${rust_stage0_root}/bin/cargo"
+		rustc = "${rust_stage0_root}/bin/rustc"
+		rustfmt = "${rust_stage0_root}/bin/rustfmt"
+		docs = $(toml_usex doc)
+		compiler-docs = false
+		submodules = false
+		python = "${EPYTHON}"
+		locked-deps = true
+		vendor = true
+		extended = true
+		tools = [${tools}]
+		verbose = 2
+		sanitizers = false
+		profiler = $(toml_usex profiler)
+		cargo-native-static = false
+		[install]
+		prefix = "${EPREFIX}/usr/lib/${PN}/${PV}"
+		sysconfdir = "etc"
+		docdir = "share/doc/rust"
+		bindir = "bin"
+		libdir = "lib"
+		mandir = "share/man"
+		[rust]
+		# https://github.com/rust-lang/rust/issues/54872
+		codegen-units-std = 1
+		optimize = true
+		debug = $(toml_usex debug)
+		debug-assertions = $(toml_usex debug)
+		debug-assertions-std = $(toml_usex debug)
+		debuginfo-level = $(usex debug 2 0)
+		debuginfo-level-rustc = $(usex debug 2 0)
+		debuginfo-level-std = $(usex debug 2 0)
+		debuginfo-level-tools = $(usex debug 2 0)
+		debuginfo-level-tests = 0
+		backtrace = true
+		incremental = false
+		default-linker = "$(tc-getCC)"
+		parallel-compiler = $(toml_usex parallel-compiler)
+		channel = "$(usex nightly nightly stable)"
+		description = "gentoo"
+		rpath = false
+		verbose-tests = true
+		optimize-tests = $(toml_usex !debug)
+		codegen-tests = true
+		dist-src = false
+		remap-debuginfo = true
+		lld = $(usex system-llvm false $(toml_usex wasm))
+		# only deny warnings if doc+wasm are NOT requested, documenting stage0 wasm std fails without it
+		# https://github.com/rust-lang/rust/issues/74976
+		# https://github.com/rust-lang/rust/issues/76526
+		deny-warnings = $(usex wasm $(usex doc false true) true)
+		backtrace-on-ice = true
+		jemalloc = false
+		lto = "$(usex lto fat off)"
+		[dist]
+		src-tarball = false
+		compression-formats = ["xz"]
+		compression-profile = "balanced"
+	_EOF_
+
+	for v in $(multilib_get_enabled_abi_pairs); do
+		rust_target=$(rust_abi $(get_abi_CHOST ${v##*.}))
+		arch_cflags="$(get_abi_CFLAGS ${v##*.})"
+
+		export CFLAGS_${rust_target//-/_}="${arch_cflags}"
+
+		cat <<- _EOF_ >> "${S}"/config.toml
+			[target.${rust_target}]
+			ar = "$(tc-getAR)"
+			cc = "$(tc-getCC)"
+			cxx = "$(tc-getCXX)"
+			linker = "$(tc-getCC)"
+			ranlib = "$(tc-getRANLIB)"
+			llvm-libunwind = "$(usex llvm-libunwind $(usex system-llvm system in-tree) no)"
+		_EOF_
+		if use system-llvm; then
+			cat <<- _EOF_ >> "${S}"/config.toml
+				llvm-config = "$(get_llvm_prefix "${LLVM_MAX_SLOT}")/bin/llvm-config"
+			_EOF_
+		fi
+		# by default librustc_target/spec/linux_musl_base.rs sets base.crt_static_default = true;
+		# but we patch it and set to false here as well
+		if use elibc_musl; then
+			cat <<- _EOF_ >> "${S}"/config.toml
+				crt-static = false
+			_EOF_
+		fi
+	done
+	if use wasm; then
+		cat <<- _EOF_ >> "${S}"/config.toml
+			[target.wasm32-unknown-unknown]
+			linker = "$(usex system-llvm lld rust-lld)"
+			# wasm target does not have profiler_builtins https://bugs.gentoo.org/848483
+			profiler = false
+		_EOF_
+	fi
+
+	if [[ -n ${I_KNOW_WHAT_I_AM_DOING_CROSS} ]]; then # whitespace intentionally shifted below
+	# experimental cross support
+	# discussion: https://bugs.gentoo.org/679878
+	# TODO: c*flags, clang, system-llvm, cargo.eclass target support
+	# it would be much better if we could split out stdlib
+	# complilation to separate ebuild and abuse CATEGORY to
+	# just install to /usr/lib/rustlib/<target>
+
+	# extra targets defined as a bash array
+	# spec format:  <LLVM target>:<rust-target>:<CTARGET>
+	# best place would be /etc/portage/env/dev-lang/rust
+	# Example:
+	# RUST_CROSS_TARGETS=(
+	#	"AArch64:aarch64-unknown-linux-gnu:aarch64-unknown-linux-gnu"
+	# )
+	# no extra hand holding is done, no target transformations, all
+	# values are passed as-is with just basic checks, so it's up to user to supply correct values
+	# valid rust targets can be obtained with
+	# 	rustc --print target-list
+	# matching cross toolchain has to be installed
+	# matching LLVM_TARGET has to be enabled for both rust and llvm (if using system one)
+	# only gcc toolchains installed with crossdev are checked for now.
+
+	# BUG: we can't pass host flags to cross compiler, so just filter for now
+	# BUG: this should be more fine-grained.
+	filter-flags '-mcpu=*' '-march=*' '-mtune=*'
+
+	local cross_target_spec
+	for cross_target_spec in "${RUST_CROSS_TARGETS[@]}";do
+		# extracts first element form <LLVM target>:<rust-target>:<CTARGET>
+		local cross_llvm_target="${cross_target_spec%%:*}"
+		# extracts toolchain triples, <rust-target>:<CTARGET>
+		local cross_triples="${cross_target_spec#*:}"
+		# extracts first element after before : separator
+		local cross_rust_target="${cross_triples%%:*}"
+		# extracts last element after : separator
+		local cross_toolchain="${cross_triples##*:}"
+		use llvm_targets_${cross_llvm_target} || die "need llvm_targets_${cross_llvm_target} target enabled"
+		command -v ${cross_toolchain}-gcc > /dev/null 2>&1 || die "need ${cross_toolchain} cross toolchain"
+
+		cat <<- _EOF_ >> "${S}"/config.toml
+			[target.${cross_rust_target}]
+			ar = "${cross_toolchain}-ar"
+			cc = "${cross_toolchain}-gcc"
+			cxx = "${cross_toolchain}-g++"
+			linker = "${cross_toolchain}-gcc"
+			ranlib = "${cross_toolchain}-ranlib"
+		_EOF_
+		if use system-llvm; then
+			cat <<- _EOF_ >> "${S}"/config.toml
+				llvm-config = "$(get_llvm_prefix "${LLVM_MAX_SLOT}")/bin/llvm-config"
+			_EOF_
+		fi
+		if [[ "${cross_toolchain}" == *-musl* ]]; then
+			cat <<- _EOF_ >> "${S}"/config.toml
+				musl-root = "$(${cross_toolchain}-gcc -print-sysroot)/usr"
+			_EOF_
+		fi
+
+		# append cross target to "normal" target list
+		# example 'target = ["powerpc64le-unknown-linux-gnu"]'
+		# becomes 'target = ["powerpc64le-unknown-linux-gnu","aarch64-unknown-linux-gnu"]'
+
+		rust_targets="${rust_targets},\"${cross_rust_target}\""
+		sed -i "/^target = \[/ s#\[.*\]#\[${rust_targets}\]#" config.toml || die
+
+		ewarn
+		ewarn "Enabled ${cross_rust_target} rust target"
+		ewarn "Using ${cross_toolchain} cross toolchain"
+		ewarn
+		if ! has_version -b 'sys-devel/binutils[multitarget]' ; then
+			ewarn "'sys-devel/binutils[multitarget]' is not installed"
+			ewarn "'strip' will be unable to strip cross libraries"
+			ewarn "cross targets will be installed with full debug information"
+			ewarn "enable 'multitarget' USE flag for binutils to be able to strip object files"
+			ewarn
+			ewarn "Alternatively llvm-strip can be used, it supports stripping any target"
+			ewarn "define STRIP=\"llvm-strip\" to use it (experimental)"
+			ewarn
+		fi
+	done
+	fi # I_KNOW_WHAT_I_AM_DOING_CROSS
+
+	einfo "Rust configured with the following flags:"
+	echo
+	echo RUSTFLAGS="\"${RUSTFLAGS}\""
+	echo RUSTFLAGS_BOOTSTRAP="\"${RUSTFLAGS_BOOTSTRAP}\""
+	echo RUSTFLAGS_NOT_BOOTSTRAP="\"${RUSTFLAGS_NOT_BOOTSTRAP}\""
+	echo MAGIC_EXTRA_RUSTFLAGS="\"${MAGIC_EXTRA_RUSTFLAGS}\""
+	env | grep "CARGO_TARGET_.*_RUSTFLAGS="
+	env | grep "CFLAGS_.*"
+	echo
+	einfo "config.toml contents:"
+	cat "${S}"/config.toml || die
+	echo
+}
+
+src_compile() {
+	RUST_BACKTRACE=1 "${EPYTHON}" ./x.py build -vv --config="${S}"/config.toml -j$(makeopts_jobs) || die
+}
+
+src_test() {
+	# https://rustc-dev-guide.rust-lang.org/tests/intro.html
+
+	# those are basic and codegen tests.
+	local tests=(
+		codegen
+		codegen-units
+		compile-fail
+		incremental
+		mir-opt
+		pretty
+		run-make
+	)
+
+	# fails if llvm is not built with ALL targets.
+	# and known to fail with system llvm sometimes.
+	use system-llvm || tests+=( assembly )
+
+	# fragile/expensive/less important tests
+	# or tests that require extra builds
+	# TODO: instead of skipping, just make some nonfatal.
+	if [[ ${ERUST_RUN_EXTRA_TESTS:-no} != no ]]; then
+		tests+=(
+			rustdoc
+			rustdoc-js
+			rustdoc-js-std
+			rustdoc-ui
+			run-make-fulldeps
+			ui
+			ui-fulldeps
+		)
+	fi
+
+	local i failed=()
+	einfo "rust_src_test: enabled tests ${tests[@]/#/src/test/}"
+	for i in "${tests[@]}"; do
+		local t="src/test/${i}"
+		einfo "rust_src_test: running ${t}"
+		if ! RUST_BACKTRACE=1 "${EPYTHON}" ./x.py test -vv --config="${S}"/config.toml \
+				-j$(makeopts_jobs) --no-doc --no-fail-fast "${t}"
+		then
+				failed+=( "${t}" )
+				eerror "rust_src_test: ${t} failed"
+		fi
+	done
+
+	if [[ ${#failed[@]} -ne 0 ]]; then
+		eerror "rust_src_test: failure summary: ${failed[@]}"
+		die "aborting due to test failures"
+	fi
+}
+
+src_install() {
+	DESTDIR="${D}" "${EPYTHON}" ./x.py install -vv --config="${S}"/config.toml -j$(makeopts_jobs) || die
+
+	# bug #689562, #689160
+	rm -v "${ED}/usr/lib/${PN}/${PV}/etc/bash_completion.d/cargo" || die
+	rmdir -v "${ED}/usr/lib/${PN}/${PV}"/etc{/bash_completion.d,} || die
+	newbashcomp src/tools/cargo/src/etc/cargo.bashcomp.sh cargo
+
+	local symlinks=(
+		cargo
+		rustc
+		rustdoc
+		rust-gdb
+		rust-gdbgui
+		rust-lldb
+	)
+
+	use clippy && symlinks+=( clippy-driver cargo-clippy )
+	use miri && symlinks+=( miri cargo-miri )
+	use profiler && symlinks+=( rust-demangler )
+	use rustfmt && symlinks+=( rustfmt cargo-fmt )
+	use rust-analyzer && symlinks+=( rust-analyzer )
+
+	einfo "installing eselect-rust symlinks and paths: ${symlinks[@]}"
+	local i
+	for i in "${symlinks[@]}"; do
+		# we need realpath on /usr/bin/* symlink return version-appended binary path.
+		# so /usr/bin/rustc should point to /usr/lib/rust/<ver>/bin/rustc-<ver>
+		# need to fix eselect-rust to remove this hack.
+		local ver_i="${i}-${PV}"
+		if [[ -f "${ED}/usr/lib/${PN}/${PV}/bin/${i}" ]]; then
+			einfo "Installing ${i} symlink"
+			ln -v "${ED}/usr/lib/${PN}/${PV}/bin/${i}" "${ED}/usr/lib/${PN}/${PV}/bin/${ver_i}" || die
+		else
+			ewarn "${i} symlink requested, but source file not found"
+			ewarn "please report this"
+		fi
+		dosym "../lib/${PN}/${PV}/bin/${ver_i}" "/usr/bin/${ver_i}"
+	done
+
+	# symlinks to switch components to active rust in eselect
+	dosym "${PV}/lib" "/usr/lib/${PN}/lib-${PV}"
+	dosym "${PV}/libexec" "/usr/lib/${PN}/libexec-${PV}"
+	dosym "${PV}/share/man" "/usr/lib/${PN}/man-${PV}"
+	dosym "rust/${PV}/lib/rustlib" "/usr/lib/rustlib-${PV}"
+	dosym "../../lib/${PN}/${PV}/share/doc/rust" "/usr/share/doc/${P}"
+
+	newenvd - "50${P}" <<-_EOF_
+		LDPATH="${EPREFIX}/usr/lib/rust/lib"
+		MANPATH="${EPREFIX}/usr/lib/rust/man"
+	_EOF_
+
+	rm -rf "${ED}/usr/lib/${PN}/${PV}"/*.old || die
+	rm -rf "${ED}/usr/lib/${PN}/${PV}/doc"/*.old || die
+
+	# note: eselect-rust adds EROOT to all paths below
+	cat <<-_EOF_ > "${T}/provider-${P}"
+		/usr/bin/cargo
+		/usr/bin/rustdoc
+		/usr/bin/rust-gdb
+		/usr/bin/rust-gdbgui
+		/usr/bin/rust-lldb
+		/usr/lib/rustlib
+		/usr/lib/rust/lib
+		/usr/lib/rust/libexec
+		/usr/lib/rust/man
+		/usr/share/doc/rust
+	_EOF_
+
+	if use clippy; then
+		echo /usr/bin/clippy-driver >> "${T}/provider-${P}"
+		echo /usr/bin/cargo-clippy >> "${T}/provider-${P}"
+	fi
+	if use miri; then
+		echo /usr/bin/miri >> "${T}/provider-${P}"
+		echo /usr/bin/cargo-miri >> "${T}/provider-${P}"
+	fi
+	if use profiler; then
+		echo /usr/bin/rust-demangler >> "${T}/provider-${P}"
+	fi
+	if use rustfmt; then
+		echo /usr/bin/rustfmt >> "${T}/provider-${P}"
+		echo /usr/bin/cargo-fmt >> "${T}/provider-${P}"
+	fi
+	if use rust-analyzer; then
+		echo /usr/bin/rust-analyzer >> "${T}/provider-${P}"
+	fi
+
+	insinto /etc/env.d/rust
+	doins "${T}/provider-${P}"
+
+	if use dist; then
+		insinto "/usr/lib/${PN}/${PV}/dist"
+		doins -r "${S}/build/dist/."
+	fi
+}
+
+pkg_postinst() {
+	eselect rust update
+
+	if has_version sys-devel/gdb || has_version dev-util/lldb; then
+		elog "Rust installs a helper script for calling GDB and LLDB,"
+		elog "for your convenience it is installed under /usr/bin/rust-{gdb,lldb}-${PV}."
+	fi
+
+	if has_version app-editors/emacs; then
+		elog "install app-emacs/rust-mode to get emacs support for rust."
+	fi
+
+	if has_version app-editors/gvim || has_version app-editors/vim; then
+		elog "install app-vim/rust-vim to get vim support for rust."
+	fi
+}
+
+pkg_postrm() {
+	eselect rust cleanup
+}

--- a/dev-lang/rust/rust-1.71.0-r1.ebuild
+++ b/dev-lang/rust/rust-1.71.0-r1.ebuild
@@ -1,0 +1,796 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+PYTHON_COMPAT=( python3_{9..12} )
+
+inherit bash-completion-r1 check-reqs estack flag-o-matic llvm multiprocessing \
+	multilib multilib-build python-any-r1 rust-toolchain toolchain-funcs verify-sig
+
+if [[ ${PV} = *beta* ]]; then
+	betaver=${PV//*beta}
+	BETA_SNAPSHOT="${betaver:0:4}-${betaver:4:2}-${betaver:6:2}"
+	MY_P="rustc-beta"
+	SLOT="beta/${PV}"
+	SRC="${BETA_SNAPSHOT}/rustc-beta-src.tar.xz -> rustc-${PV}-src.tar.xz"
+else
+	ABI_VER="$(ver_cut 1-2)"
+	SLOT="stable/${ABI_VER}"
+	MY_P="rustc-${PV}"
+	SRC="${MY_P}-src.tar.xz"
+	KEYWORDS="~amd64 ~arm ~arm64 ~mips ~ppc ~ppc64 ~riscv ~sparc ~x86"
+fi
+
+RUST_STAGE0_VERSION="1.$(($(ver_cut 2) - 1)).0"
+
+DESCRIPTION="Systems programming language from Mozilla"
+HOMEPAGE="https://www.rust-lang.org/"
+
+SRC_URI="
+	https://static.rust-lang.org/dist/${SRC}
+	verify-sig? ( https://static.rust-lang.org/dist/${SRC}.asc )
+	!system-bootstrap? ( $(rust_all_arch_uris rust-${RUST_STAGE0_VERSION}) )
+"
+
+# keep in sync with llvm ebuild of the same version as bundled one.
+ALL_LLVM_TARGETS=( AArch64 AMDGPU ARM AVR BPF Hexagon Lanai LoongArch Mips MSP430
+	NVPTX PowerPC RISCV Sparc SystemZ VE WebAssembly X86 XCore )
+ALL_LLVM_TARGETS=( "${ALL_LLVM_TARGETS[@]/#/llvm_targets_}" )
+LLVM_TARGET_USEDEPS=${ALL_LLVM_TARGETS[@]/%/(-)?}
+
+LICENSE="|| ( MIT Apache-2.0 ) BSD BSD-1 BSD-2 BSD-4 UoI-NCSA"
+
+IUSE="big-endian clippy cpu_flags_x86_sse2 debug dist doc llvm-libunwind +lto miri nightly parallel-compiler profiler rustfmt rust-analyzer rust-src system-bootstrap system-llvm test wasm ${ALL_LLVM_TARGETS[*]}"
+
+# Please keep the LLVM dependency block separate. Since LLVM is slotted,
+# we need to *really* make sure we're not pulling more than one slot
+# simultaneously.
+
+# How to use it:
+# List all the working slots in LLVM_VALID_SLOTS, newest first.
+LLVM_VALID_SLOTS=( 16 )
+LLVM_MAX_SLOT="${LLVM_VALID_SLOTS[0]}"
+
+# splitting usedeps needed to avoid CI/pkgcheck's UncheckableDep limitation
+# (-) usedep needed because we may build with older llvm without that target
+LLVM_DEPEND="|| ( "
+for _s in ${LLVM_VALID_SLOTS[@]}; do
+	LLVM_DEPEND+=" ( "
+	for _x in ${ALL_LLVM_TARGETS[@]}; do
+		LLVM_DEPEND+="
+			${_x}? ( sys-devel/llvm:${_s}[${_x}(-)] )
+			wasm? ( sys-devel/lld:${_s} )"
+	done
+	LLVM_DEPEND+=" )"
+done
+unset _s _x
+LLVM_DEPEND+=" )
+	<sys-devel/llvm-$(( LLVM_MAX_SLOT + 1 )):=
+"
+
+# to bootstrap we need at least exactly previous version, or same.
+# most of the time previous versions fail to bootstrap with newer
+# for example 1.47.x, requires at least 1.46.x, 1.47.x is ok,
+# but it fails to bootstrap with 1.48.x
+# https://github.com/rust-lang/rust/blob/${PV}/src/stage0.json
+RUST_DEP_PREV="$(ver_cut 1).$(($(ver_cut 2) - 1))*"
+RUST_DEP_CURR="$(ver_cut 1).$(ver_cut 2)*"
+BOOTSTRAP_DEPEND="||
+	(
+		=dev-lang/rust-"${RUST_DEP_PREV}"
+		=dev-lang/rust-bin-"${RUST_DEP_PREV}"
+		=dev-lang/rust-"${RUST_DEP_CURR}"
+		=dev-lang/rust-bin-"${RUST_DEP_CURR}"
+	)
+"
+
+BDEPEND="${PYTHON_DEPS}
+	app-eselect/eselect-rust
+	|| (
+		>=sys-devel/gcc-4.7
+		>=sys-devel/clang-3.5
+	)
+	system-bootstrap? ( ${BOOTSTRAP_DEPEND} )
+	!system-llvm? (
+		>=dev-util/cmake-3.13.4
+		dev-util/ninja
+	)
+	test? ( sys-devel/gdb )
+	verify-sig? ( sec-keys/openpgp-keys-rust )
+"
+
+DEPEND="
+	>=app-arch/xz-utils-5.2
+	net-misc/curl:=[http2,ssl]
+	sys-libs/zlib:=
+	dev-libs/openssl:0=
+	system-llvm? (
+		${LLVM_DEPEND}
+		llvm-libunwind? ( sys-libs/llvm-libunwind:= )
+	)
+	!system-llvm? (
+		!llvm-libunwind? (
+			elibc_musl? ( sys-libs/libunwind:= )
+		)
+	)
+"
+
+RDEPEND="${DEPEND}
+	app-eselect/eselect-rust
+	sys-apps/lsb-release
+"
+
+REQUIRED_USE="|| ( ${ALL_LLVM_TARGETS[*]} )
+	miri? ( nightly )
+	parallel-compiler? ( nightly )
+	rust-analyzer? ( rust-src )
+	test? ( ${ALL_LLVM_TARGETS[*]} )
+	wasm? ( llvm_targets_WebAssembly )
+	x86? ( cpu_flags_x86_sse2 )
+"
+
+# we don't use cmake.eclass, but can get a warning
+CMAKE_WARN_UNUSED_CLI=no
+
+QA_FLAGS_IGNORED="
+	usr/lib/${PN}/${PV}/bin/.*
+	usr/lib/${PN}/${PV}/libexec/.*
+	usr/lib/${PN}/${PV}/lib/lib.*.so
+	usr/lib/${PN}/${PV}/lib/rustlib/.*/bin/.*
+	usr/lib/${PN}/${PV}/lib/rustlib/.*/lib/lib.*.so
+"
+
+QA_SONAME="
+	usr/lib/${PN}/${PV}/lib/lib.*.so.*
+	usr/lib/${PN}/${PV}/lib/rustlib/.*/lib/lib.*.so
+"
+
+QA_PRESTRIPPED="
+	usr/lib/${PN}/${PV}/lib/rustlib/.*/bin/rust-llvm-dwp
+	usr/lib/${PN}/${PV}/lib/rustlib/.*/lib/self-contained/crtn.o
+"
+
+# An rmeta file is custom binary format that contains the metadata for the crate.
+# rmeta files do not support linking, since they do not contain compiled object files.
+# so we can safely silence the warning for this QA check.
+QA_EXECSTACK="usr/lib/${PN}/${PV}/lib/rustlib/*/lib*.rlib:lib.rmeta"
+
+# causes double bootstrap
+RESTRICT="test"
+
+VERIFY_SIG_OPENPGP_KEY_PATH=${BROOT}/usr/share/openpgp-keys/rust.asc
+
+PATCHES=(
+	"${FILESDIR}"/1.71.0-fix-bashcomp-installation.patch
+	"${FILESDIR}"/1.71.0-lint-docs-libpath.patch
+	"${FILESDIR}"/1.70.0-ignore-broken-and-non-applicable-tests.patch
+	"${FILESDIR}"/1.62.1-musl-dynamic-linking.patch
+	"${FILESDIR}"/1.67.0-doc-wasm.patch
+	"${FILESDIR}"/1.69.0-musl-1.2.4.patch
+)
+
+S="${WORKDIR}/${MY_P}-src"
+
+eapply_crate() {
+	pushd "${1:?}" > /dev/null || die
+
+	local patch="${2:?}"
+	eapply "${patch}"
+
+	local cargo='.cargo-checksum.json'
+	local _ f
+	grep -- '^[+][+][+] ' "${patch}" | while read -r _ f; do
+		local file="${f#*/}"
+		local orig_sum="$(grep -Eo "\"${file}\":\"[0-9a-fA-F]+\"" "${cargo}" |
+			cut -d':' -f2 | tr -d '"')" || die
+		if [ -n "${orig_sum}" ]; then
+			local sum="$(sha256sum "${file}")" || die
+			sed -i "s|${orig_sum}|${sum%% *}|" "${cargo}" || die
+		fi
+	done
+
+	popd > /dev/null || die
+}
+
+toml_usex() {
+	usex "${1}" true false
+}
+
+bootstrap_rust_version_check() {
+	# never call from pkg_pretend. eselect-rust may be not installed yet.
+	[[ ${MERGE_TYPE} == binary ]] && return
+	local rustc_wanted="$(ver_cut 1).$(($(ver_cut 2) - 1))"
+	local rustc_toonew="$(ver_cut 1).$(($(ver_cut 2) + 1))"
+	local rustc_version=( $(eselect --brief rust show 2>/dev/null) )
+	rustc_version=${rustc_version[0]#rust-bin-}
+	rustc_version=${rustc_version#rust-}
+
+	[[ -z "${rustc_version}" ]] && die "Failed to determine rust version, check 'eselect rust' output"
+
+	if ver_test "${rustc_version}" -lt "${rustc_wanted}" ; then
+		eerror "Rust >=${rustc_wanted} is required"
+		eerror "please run 'eselect rust' and set correct rust version"
+		die "selected rust version is too old"
+	elif ver_test "${rustc_version}" -ge "${rustc_toonew}" ; then
+		eerror "Rust <${rustc_toonew} is required"
+		eerror "please run 'eselect rust' and set correct rust version"
+		die "selected rust version is too new"
+	else
+		einfo "Using rust ${rustc_version} to build"
+	fi
+}
+
+pre_build_checks() {
+	local M=8192
+	# multiply requirements by 1.3 if we are doing x86-multilib
+	if use amd64; then
+		M=$(( $(usex abi_x86_32 13 10) * ${M} / 10 ))
+	fi
+	M=$(( $(usex clippy 128 0) + ${M} ))
+	M=$(( $(usex miri 128 0) + ${M} ))
+	M=$(( $(usex rustfmt 256 0) + ${M} ))
+	# add 2G if we compile llvm and 256M per llvm_target
+	if ! use system-llvm; then
+		M=$(( 2048 + ${M} ))
+		local ltarget
+		for ltarget in ${ALL_LLVM_TARGETS[@]}; do
+			M=$(( $(usex ${ltarget} 256 0) + ${M} ))
+		done
+	fi
+	M=$(( $(usex wasm 256 0) + ${M} ))
+	M=$(( $(usex debug 2 1) * ${M} ))
+	eshopts_push -s extglob
+	if is-flagq '-g?(gdb)?([1-9])'; then
+		M=$(( 15 * ${M} / 10 ))
+	fi
+	eshopts_pop
+	M=$(( $(usex system-bootstrap 0 1024) + ${M} ))
+	M=$(( $(usex doc 256 0) + ${M} ))
+	CHECKREQS_DISK_BUILD=${M}M check-reqs_pkg_${EBUILD_PHASE}
+}
+
+llvm_check_deps() {
+	has_version -r "sys-devel/llvm:${LLVM_SLOT}[${LLVM_TARGET_USEDEPS// /,}]"
+}
+
+# Is LLVM being linked against libc++?
+is_libcxx_linked() {
+	local code='#include <ciso646>
+#if defined(_LIBCPP_VERSION)
+	HAVE_LIBCXX
+#endif
+'
+	local out=$($(tc-getCXX) ${CXXFLAGS} ${CPPFLAGS} -x c++ -E -P - <<<"${code}") || return 1
+	[[ ${out} == *HAVE_LIBCXX* ]]
+}
+
+pkg_pretend() {
+	pre_build_checks
+}
+
+pkg_setup() {
+	pre_build_checks
+	python-any-r1_pkg_setup
+
+	export LIBGIT2_NO_PKG_CONFIG=1 #749381
+
+	use system-bootstrap && bootstrap_rust_version_check
+
+	if use system-llvm; then
+		llvm_pkg_setup
+
+		local llvm_config="$(get_llvm_prefix "${LLVM_MAX_SLOT}")/bin/llvm-config"
+		export LLVM_LINK_SHARED=1
+		export RUSTFLAGS="${RUSTFLAGS} -Lnative=$("${llvm_config}" --libdir)"
+	fi
+}
+
+esetup_unwind_hack() {
+	# https://bugs.gentoo.org/870280
+	# this is a hack needed to bootstrap with libgcc_s linked tarball on llvm-libunwind system.
+	# it should trigger for internal bootstrap or system-bootstrap with rust-bin.
+	# the whole idea is for stage0 to bootstrap with fake libgcc_s.
+	# final stage will receive -L${T}/lib but not -lgcc_s args, producing clean compiler.
+	local fakelib="${T}/fakelib"
+	mkdir -p "${fakelib}" || die
+	# we need both symlinks, one for cargo runtime, other for linker.
+	ln -s "${ESYSROOT}/usr/lib/libunwind.so" "${fakelib}/libgcc_s.so.1" || die
+	ln -s "${ESYSROOT}/usr/lib/libunwind.so" "${fakelib}/libgcc_s.so" || die
+	export LD_LIBRARY_PATH="${fakelib}"
+	export RUSTFLAGS+=" -L${fakelib}"
+	# this is a literally magic variable that gets through cargo cache, without it some
+	# crates ignore RUSTFLAGS.
+	# this variable can not contain leading space.
+	export MAGIC_EXTRA_RUSTFLAGS+="${MAGIC_EXTRA_RUSTFLAGS:+ }-L${fakelib}"
+}
+
+src_prepare() {
+	eapply_crate vendor/getrandom-0.2.8 "${FILESDIR}"/1.69.0-musl-1.2.4-getrandom.patch
+	eapply_crate vendor/libc-0.2.138 "${FILESDIR}"/1.69.0-musl-1.2.4-libc.patch
+	eapply_crate vendor/libc-0.2.139 "${FILESDIR}"/1.69.0-musl-1.2.4-libc.patch
+	eapply_crate vendor/libc-0.2.140 "${FILESDIR}"/1.69.0-musl-1.2.4-libc.patch
+	eapply_crate vendor/libc-0.2.143 "${FILESDIR}"/1.69.0-musl-1.2.4-libc.patch
+	eapply_crate vendor/libc "${FILESDIR}"/1.69.0-musl-1.2.4-libc.patch
+
+	if ! use system-bootstrap; then
+		has_version sys-devel/gcc || esetup_unwind_hack
+		local rust_stage0_root="${WORKDIR}"/rust-stage0
+		local rust_stage0="rust-${RUST_STAGE0_VERSION}-$(rust_abi)"
+
+		if use elibc_musl; then
+			local libstd
+			for libstd in "${WORKDIR}/${rust_stage0}/rust-std-$(rust_abi)/lib/rustlib/$(rust_abi)"/lib/libstd-*.rlib; do
+				"$(tc-getOBJCOPY)" \
+					--redefine-sym=stat64=stat \
+					--redefine-sym=fstat64=fstat \
+					--redefine-sym=lstat64=lstat \
+					--redefine-sym=open64=open \
+					--redefine-sym=readdir64=readdir \
+					--redefine-sym=fstatat64=fstatat \
+					--redefine-sym=lseek64=lseek \
+					--redefine-sym=ftruncate64=ftruncate \
+					"${libstd}" \
+					"${libstd}.out" || die
+
+				mv "${libstd}.out" "${libstd}" || die
+			done
+		fi
+
+		"${WORKDIR}/${rust_stage0}"/install.sh --disable-ldconfig \
+			--without=rust-docs-json-preview,rust-docs --destdir="${rust_stage0_root}" --prefix=/ || die
+	fi
+
+	default
+}
+
+src_configure() {
+	filter-lto # https://bugs.gentoo.org/862109 https://bugs.gentoo.org/866231
+
+	local rust_target="" rust_targets="" arch_cflags
+
+	# Collect rust target names to compile standard libs for all ABIs.
+	for v in $(multilib_get_enabled_abi_pairs); do
+		rust_targets+=",\"$(rust_abi $(get_abi_CHOST ${v##*.}))\""
+	done
+	if use wasm; then
+		rust_targets+=",\"wasm32-unknown-unknown\""
+		if use system-llvm; then
+			# un-hardcode rust-lld linker for this target
+			# https://bugs.gentoo.org/715348
+			sed -i '/linker:/ s/rust-lld/wasm-ld/' compiler/rustc_target/src/spec/wasm_base.rs || die
+		fi
+	fi
+	rust_targets="${rust_targets#,}"
+
+	# cargo and rustdoc are mandatory and should always be included
+	local tools='"cargo","rustdoc"'
+	use clippy && tools+=',"clippy"'
+	use miri && tools+=',"miri"'
+	use profiler && tools+=',"rust-demangler"'
+	use rustfmt && tools+=',"rustfmt"'
+	use rust-analyzer && tools+=',"rust-analyzer"'
+	use rust-src && tools+=',"src"'
+
+	local rust_stage0_root
+	if use system-bootstrap; then
+		local printsysroot
+		printsysroot="$(rustc --print sysroot || die "Can't determine rust's sysroot")"
+		rust_stage0_root="${printsysroot}"
+	else
+		rust_stage0_root="${WORKDIR}"/rust-stage0
+	fi
+	# in case of prefix it will be already prefixed, as --print sysroot returns full path
+	[[ -d ${rust_stage0_root} ]] || die "${rust_stage0_root} is not a directory"
+
+	rust_target="$(rust_abi)"
+
+	local cm_btype="$(usex debug DEBUG RELEASE)"
+	cat <<- _EOF_ > "${S}"/config.toml
+		changelog-seen = 2
+		[llvm]
+		download-ci-llvm = false
+		optimize = $(toml_usex !debug)
+		release-debuginfo = $(toml_usex debug)
+		assertions = $(toml_usex debug)
+		ninja = true
+		targets = "${LLVM_TARGETS// /;}"
+		experimental-targets = ""
+		link-shared = $(toml_usex system-llvm)
+		$(if is_libcxx_linked; then
+			# https://bugs.gentoo.org/732632
+			echo "use-libcxx = true"
+			echo "static-libstdcpp = false"
+		fi)
+		$(case "${rust_target}" in
+			i586-*-linux-*)
+				# https://github.com/rust-lang/rust/issues/93059
+				echo 'cflags = "-fcf-protection=none"'
+				echo 'cxxflags = "-fcf-protection=none"'
+				echo 'ldflags = "-fcf-protection=none"'
+				;;
+			*)
+				;;
+		esac)
+		enable-warnings = false
+		[llvm.build-config]
+		CMAKE_VERBOSE_MAKEFILE = "ON"
+		CMAKE_C_FLAGS_${cm_btype} = "${CFLAGS}"
+		CMAKE_CXX_FLAGS_${cm_btype} = "${CXXFLAGS}"
+		CMAKE_EXE_LINKER_FLAGS_${cm_btype} = "${LDFLAGS}"
+		CMAKE_MODULE_LINKER_FLAGS_${cm_btype} = "${LDFLAGS}"
+		CMAKE_SHARED_LINKER_FLAGS_${cm_btype} = "${LDFLAGS}"
+		CMAKE_STATIC_LINKER_FLAGS_${cm_btype} = "${ARFLAGS}"
+		[build]
+		build-stage = 2
+		test-stage = 2
+		build = "${rust_target}"
+		host = ["${rust_target}"]
+		target = [${rust_targets}]
+		cargo = "${rust_stage0_root}/bin/cargo"
+		rustc = "${rust_stage0_root}/bin/rustc"
+		rustfmt = "${rust_stage0_root}/bin/rustfmt"
+		docs = $(toml_usex doc)
+		compiler-docs = false
+		submodules = false
+		python = "${EPYTHON}"
+		locked-deps = true
+		vendor = true
+		extended = true
+		tools = [${tools}]
+		verbose = 2
+		sanitizers = false
+		profiler = $(toml_usex profiler)
+		cargo-native-static = false
+		[install]
+		prefix = "${EPREFIX}/usr/lib/${PN}/${PV}"
+		sysconfdir = "etc"
+		docdir = "share/doc/rust"
+		bindir = "bin"
+		libdir = "lib"
+		mandir = "share/man"
+		[rust]
+		# https://github.com/rust-lang/rust/issues/54872
+		codegen-units-std = 1
+		optimize = true
+		debug = $(toml_usex debug)
+		debug-assertions = $(toml_usex debug)
+		debug-assertions-std = $(toml_usex debug)
+		debuginfo-level = $(usex debug 2 0)
+		debuginfo-level-rustc = $(usex debug 2 0)
+		debuginfo-level-std = $(usex debug 2 0)
+		debuginfo-level-tools = $(usex debug 2 0)
+		debuginfo-level-tests = 0
+		backtrace = true
+		incremental = false
+		default-linker = "$(tc-getCC)"
+		parallel-compiler = $(toml_usex parallel-compiler)
+		channel = "$(usex nightly nightly stable)"
+		description = "gentoo"
+		rpath = false
+		verbose-tests = true
+		optimize-tests = $(toml_usex !debug)
+		codegen-tests = true
+		dist-src = false
+		remap-debuginfo = true
+		lld = $(usex system-llvm false $(toml_usex wasm))
+		# only deny warnings if doc+wasm are NOT requested, documenting stage0 wasm std fails without it
+		# https://github.com/rust-lang/rust/issues/74976
+		# https://github.com/rust-lang/rust/issues/76526
+		deny-warnings = $(usex wasm $(usex doc false true) true)
+		backtrace-on-ice = true
+		jemalloc = false
+		lto = "$(usex lto fat off)"
+		[dist]
+		src-tarball = false
+		compression-formats = ["xz"]
+		compression-profile = "balanced"
+	_EOF_
+
+	for v in $(multilib_get_enabled_abi_pairs); do
+		rust_target=$(rust_abi $(get_abi_CHOST ${v##*.}))
+		arch_cflags="$(get_abi_CFLAGS ${v##*.})"
+
+		export CFLAGS_${rust_target//-/_}="${arch_cflags}"
+
+		cat <<- _EOF_ >> "${S}"/config.toml
+			[target.${rust_target}]
+			ar = "$(tc-getAR)"
+			cc = "$(tc-getCC)"
+			cxx = "$(tc-getCXX)"
+			linker = "$(tc-getCC)"
+			ranlib = "$(tc-getRANLIB)"
+			llvm-libunwind = "$(usex llvm-libunwind $(usex system-llvm system in-tree) no)"
+		_EOF_
+		if use system-llvm; then
+			cat <<- _EOF_ >> "${S}"/config.toml
+				llvm-config = "$(get_llvm_prefix "${LLVM_MAX_SLOT}")/bin/llvm-config"
+			_EOF_
+		fi
+		# by default librustc_target/spec/linux_musl_base.rs sets base.crt_static_default = true;
+		# but we patch it and set to false here as well
+		if use elibc_musl; then
+			cat <<- _EOF_ >> "${S}"/config.toml
+				crt-static = false
+			_EOF_
+		fi
+	done
+	if use wasm; then
+		cat <<- _EOF_ >> "${S}"/config.toml
+			[target.wasm32-unknown-unknown]
+			linker = "$(usex system-llvm lld rust-lld)"
+			# wasm target does not have profiler_builtins https://bugs.gentoo.org/848483
+			profiler = false
+		_EOF_
+	fi
+
+	if [[ -n ${I_KNOW_WHAT_I_AM_DOING_CROSS} ]]; then # whitespace intentionally shifted below
+	# experimental cross support
+	# discussion: https://bugs.gentoo.org/679878
+	# TODO: c*flags, clang, system-llvm, cargo.eclass target support
+	# it would be much better if we could split out stdlib
+	# complilation to separate ebuild and abuse CATEGORY to
+	# just install to /usr/lib/rustlib/<target>
+
+	# extra targets defined as a bash array
+	# spec format:  <LLVM target>:<rust-target>:<CTARGET>
+	# best place would be /etc/portage/env/dev-lang/rust
+	# Example:
+	# RUST_CROSS_TARGETS=(
+	#	"AArch64:aarch64-unknown-linux-gnu:aarch64-unknown-linux-gnu"
+	# )
+	# no extra hand holding is done, no target transformations, all
+	# values are passed as-is with just basic checks, so it's up to user to supply correct values
+	# valid rust targets can be obtained with
+	# 	rustc --print target-list
+	# matching cross toolchain has to be installed
+	# matching LLVM_TARGET has to be enabled for both rust and llvm (if using system one)
+	# only gcc toolchains installed with crossdev are checked for now.
+
+	# BUG: we can't pass host flags to cross compiler, so just filter for now
+	# BUG: this should be more fine-grained.
+	filter-flags '-mcpu=*' '-march=*' '-mtune=*'
+
+	local cross_target_spec
+	for cross_target_spec in "${RUST_CROSS_TARGETS[@]}";do
+		# extracts first element form <LLVM target>:<rust-target>:<CTARGET>
+		local cross_llvm_target="${cross_target_spec%%:*}"
+		# extracts toolchain triples, <rust-target>:<CTARGET>
+		local cross_triples="${cross_target_spec#*:}"
+		# extracts first element after before : separator
+		local cross_rust_target="${cross_triples%%:*}"
+		# extracts last element after : separator
+		local cross_toolchain="${cross_triples##*:}"
+		use llvm_targets_${cross_llvm_target} || die "need llvm_targets_${cross_llvm_target} target enabled"
+		command -v ${cross_toolchain}-gcc > /dev/null 2>&1 || die "need ${cross_toolchain} cross toolchain"
+
+		cat <<- _EOF_ >> "${S}"/config.toml
+			[target.${cross_rust_target}]
+			ar = "${cross_toolchain}-ar"
+			cc = "${cross_toolchain}-gcc"
+			cxx = "${cross_toolchain}-g++"
+			linker = "${cross_toolchain}-gcc"
+			ranlib = "${cross_toolchain}-ranlib"
+		_EOF_
+		if use system-llvm; then
+			cat <<- _EOF_ >> "${S}"/config.toml
+				llvm-config = "$(get_llvm_prefix "${LLVM_MAX_SLOT}")/bin/llvm-config"
+			_EOF_
+		fi
+		if [[ "${cross_toolchain}" == *-musl* ]]; then
+			cat <<- _EOF_ >> "${S}"/config.toml
+				musl-root = "$(${cross_toolchain}-gcc -print-sysroot)/usr"
+			_EOF_
+		fi
+
+		# append cross target to "normal" target list
+		# example 'target = ["powerpc64le-unknown-linux-gnu"]'
+		# becomes 'target = ["powerpc64le-unknown-linux-gnu","aarch64-unknown-linux-gnu"]'
+
+		rust_targets="${rust_targets},\"${cross_rust_target}\""
+		sed -i "/^target = \[/ s#\[.*\]#\[${rust_targets}\]#" config.toml || die
+
+		ewarn
+		ewarn "Enabled ${cross_rust_target} rust target"
+		ewarn "Using ${cross_toolchain} cross toolchain"
+		ewarn
+		if ! has_version -b 'sys-devel/binutils[multitarget]' ; then
+			ewarn "'sys-devel/binutils[multitarget]' is not installed"
+			ewarn "'strip' will be unable to strip cross libraries"
+			ewarn "cross targets will be installed with full debug information"
+			ewarn "enable 'multitarget' USE flag for binutils to be able to strip object files"
+			ewarn
+			ewarn "Alternatively llvm-strip can be used, it supports stripping any target"
+			ewarn "define STRIP=\"llvm-strip\" to use it (experimental)"
+			ewarn
+		fi
+	done
+	fi # I_KNOW_WHAT_I_AM_DOING_CROSS
+
+	einfo "Rust configured with the following flags:"
+	echo
+	echo RUSTFLAGS="\"${RUSTFLAGS}\""
+	echo RUSTFLAGS_BOOTSTRAP="\"${RUSTFLAGS_BOOTSTRAP}\""
+	echo RUSTFLAGS_NOT_BOOTSTRAP="\"${RUSTFLAGS_NOT_BOOTSTRAP}\""
+	echo MAGIC_EXTRA_RUSTFLAGS="\"${MAGIC_EXTRA_RUSTFLAGS}\""
+	env | grep "CARGO_TARGET_.*_RUSTFLAGS="
+	env | grep "CFLAGS_.*"
+	echo
+	einfo "config.toml contents:"
+	cat "${S}"/config.toml || die
+	echo
+}
+
+src_compile() {
+	RUST_BACKTRACE=1 "${EPYTHON}" ./x.py build -vv --config="${S}"/config.toml -j$(makeopts_jobs) || die
+}
+
+src_test() {
+	# https://rustc-dev-guide.rust-lang.org/tests/intro.html
+
+	# those are basic and codegen tests.
+	local tests=(
+		codegen
+		codegen-units
+		compile-fail
+		incremental
+		mir-opt
+		pretty
+		run-make
+	)
+
+	# fails if llvm is not built with ALL targets.
+	# and known to fail with system llvm sometimes.
+	use system-llvm || tests+=( assembly )
+
+	# fragile/expensive/less important tests
+	# or tests that require extra builds
+	# TODO: instead of skipping, just make some nonfatal.
+	if [[ ${ERUST_RUN_EXTRA_TESTS:-no} != no ]]; then
+		tests+=(
+			rustdoc
+			rustdoc-js
+			rustdoc-js-std
+			rustdoc-ui
+			run-make-fulldeps
+			ui
+			ui-fulldeps
+		)
+	fi
+
+	local i failed=()
+	einfo "rust_src_test: enabled tests ${tests[@]/#/src/test/}"
+	for i in "${tests[@]}"; do
+		local t="src/test/${i}"
+		einfo "rust_src_test: running ${t}"
+		if ! RUST_BACKTRACE=1 "${EPYTHON}" ./x.py test -vv --config="${S}"/config.toml \
+				-j$(makeopts_jobs) --no-doc --no-fail-fast "${t}"
+		then
+				failed+=( "${t}" )
+				eerror "rust_src_test: ${t} failed"
+		fi
+	done
+
+	if [[ ${#failed[@]} -ne 0 ]]; then
+		eerror "rust_src_test: failure summary: ${failed[@]}"
+		die "aborting due to test failures"
+	fi
+}
+
+src_install() {
+	DESTDIR="${D}" "${EPYTHON}" ./x.py install -vv --config="${S}"/config.toml -j$(makeopts_jobs) || die
+
+	# bug #689562, #689160
+	rm -v "${ED}/usr/lib/${PN}/${PV}/etc/bash_completion.d/cargo" || die
+	rmdir -v "${ED}/usr/lib/${PN}/${PV}"/etc{/bash_completion.d,} || die
+	newbashcomp src/tools/cargo/src/etc/cargo.bashcomp.sh cargo
+
+	local symlinks=(
+		cargo
+		rustc
+		rustdoc
+		rust-gdb
+		rust-gdbgui
+		rust-lldb
+	)
+
+	use clippy && symlinks+=( clippy-driver cargo-clippy )
+	use miri && symlinks+=( miri cargo-miri )
+	use profiler && symlinks+=( rust-demangler )
+	use rustfmt && symlinks+=( rustfmt cargo-fmt )
+	use rust-analyzer && symlinks+=( rust-analyzer )
+
+	einfo "installing eselect-rust symlinks and paths: ${symlinks[@]}"
+	local i
+	for i in "${symlinks[@]}"; do
+		# we need realpath on /usr/bin/* symlink return version-appended binary path.
+		# so /usr/bin/rustc should point to /usr/lib/rust/<ver>/bin/rustc-<ver>
+		# need to fix eselect-rust to remove this hack.
+		local ver_i="${i}-${PV}"
+		if [[ -f "${ED}/usr/lib/${PN}/${PV}/bin/${i}" ]]; then
+			einfo "Installing ${i} symlink"
+			ln -v "${ED}/usr/lib/${PN}/${PV}/bin/${i}" "${ED}/usr/lib/${PN}/${PV}/bin/${ver_i}" || die
+		else
+			ewarn "${i} symlink requested, but source file not found"
+			ewarn "please report this"
+		fi
+		dosym "../lib/${PN}/${PV}/bin/${ver_i}" "/usr/bin/${ver_i}"
+	done
+
+	# symlinks to switch components to active rust in eselect
+	dosym "${PV}/lib" "/usr/lib/${PN}/lib-${PV}"
+	dosym "${PV}/libexec" "/usr/lib/${PN}/libexec-${PV}"
+	dosym "${PV}/share/man" "/usr/lib/${PN}/man-${PV}"
+	dosym "rust/${PV}/lib/rustlib" "/usr/lib/rustlib-${PV}"
+	dosym "../../lib/${PN}/${PV}/share/doc/rust" "/usr/share/doc/${P}"
+
+	newenvd - "50${P}" <<-_EOF_
+		LDPATH="${EPREFIX}/usr/lib/rust/lib"
+		MANPATH="${EPREFIX}/usr/lib/rust/man"
+	_EOF_
+
+	rm -rf "${ED}/usr/lib/${PN}/${PV}"/*.old || die
+	rm -rf "${ED}/usr/lib/${PN}/${PV}/doc"/*.old || die
+
+	# note: eselect-rust adds EROOT to all paths below
+	cat <<-_EOF_ > "${T}/provider-${P}"
+		/usr/bin/cargo
+		/usr/bin/rustdoc
+		/usr/bin/rust-gdb
+		/usr/bin/rust-gdbgui
+		/usr/bin/rust-lldb
+		/usr/lib/rustlib
+		/usr/lib/rust/lib
+		/usr/lib/rust/libexec
+		/usr/lib/rust/man
+		/usr/share/doc/rust
+	_EOF_
+
+	if use clippy; then
+		echo /usr/bin/clippy-driver >> "${T}/provider-${P}"
+		echo /usr/bin/cargo-clippy >> "${T}/provider-${P}"
+	fi
+	if use miri; then
+		echo /usr/bin/miri >> "${T}/provider-${P}"
+		echo /usr/bin/cargo-miri >> "${T}/provider-${P}"
+	fi
+	if use profiler; then
+		echo /usr/bin/rust-demangler >> "${T}/provider-${P}"
+	fi
+	if use rustfmt; then
+		echo /usr/bin/rustfmt >> "${T}/provider-${P}"
+		echo /usr/bin/cargo-fmt >> "${T}/provider-${P}"
+	fi
+	if use rust-analyzer; then
+		echo /usr/bin/rust-analyzer >> "${T}/provider-${P}"
+	fi
+
+	insinto /etc/env.d/rust
+	doins "${T}/provider-${P}"
+
+	if use dist; then
+		insinto "/usr/lib/${PN}/${PV}/dist"
+		doins -r "${S}/build/dist/."
+	fi
+}
+
+pkg_postinst() {
+	eselect rust update
+
+	if has_version sys-devel/gdb || has_version dev-util/lldb; then
+		elog "Rust installs a helper script for calling GDB and LLDB,"
+		elog "for your convenience it is installed under /usr/bin/rust-{gdb,lldb}-${PV}."
+	fi
+
+	if has_version app-editors/emacs; then
+		elog "install app-emacs/rust-mode to get emacs support for rust."
+	fi
+
+	if has_version app-editors/gvim || has_version app-editors/vim; then
+		elog "install app-vim/rust-vim to get vim support for rust."
+	fi
+}
+
+pkg_postrm() {
+	eselect rust cleanup
+}

--- a/dev-lang/rust/rust-1.71.1-r1.ebuild
+++ b/dev-lang/rust/rust-1.71.1-r1.ebuild
@@ -1,0 +1,795 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+PYTHON_COMPAT=( python3_{9..12} )
+
+inherit bash-completion-r1 check-reqs estack flag-o-matic llvm multiprocessing \
+	multilib multilib-build python-any-r1 rust-toolchain toolchain-funcs verify-sig
+
+if [[ ${PV} = *beta* ]]; then
+	betaver=${PV//*beta}
+	BETA_SNAPSHOT="${betaver:0:4}-${betaver:4:2}-${betaver:6:2}"
+	MY_P="rustc-beta"
+	SLOT="beta/${PV}"
+	SRC="${BETA_SNAPSHOT}/rustc-beta-src.tar.xz -> rustc-${PV}-src.tar.xz"
+else
+	ABI_VER="$(ver_cut 1-2)"
+	SLOT="stable/${ABI_VER}"
+	MY_P="rustc-${PV}"
+	SRC="${MY_P}-src.tar.xz"
+	KEYWORDS="~amd64 ~arm ~arm64 ~loong ~mips ~ppc ~ppc64 ~riscv ~sparc ~x86"
+fi
+
+RUST_STAGE0_VERSION="1.$(($(ver_cut 2) - 1)).0"
+
+DESCRIPTION="Systems programming language from Mozilla"
+HOMEPAGE="https://www.rust-lang.org/"
+
+SRC_URI="
+	https://static.rust-lang.org/dist/${SRC}
+	verify-sig? ( https://static.rust-lang.org/dist/${SRC}.asc )
+	!system-bootstrap? ( $(rust_all_arch_uris rust-${RUST_STAGE0_VERSION}) )
+"
+
+# keep in sync with llvm ebuild of the same version as bundled one.
+ALL_LLVM_TARGETS=( AArch64 AMDGPU ARM AVR BPF Hexagon Lanai LoongArch Mips MSP430
+	NVPTX PowerPC RISCV Sparc SystemZ VE WebAssembly X86 XCore )
+ALL_LLVM_TARGETS=( "${ALL_LLVM_TARGETS[@]/#/llvm_targets_}" )
+LLVM_TARGET_USEDEPS=${ALL_LLVM_TARGETS[@]/%/(-)?}
+
+LICENSE="|| ( MIT Apache-2.0 ) BSD BSD-1 BSD-2 BSD-4 UoI-NCSA"
+
+IUSE="big-endian clippy cpu_flags_x86_sse2 debug dist doc llvm-libunwind +lto miri nightly parallel-compiler profiler rustfmt rust-analyzer rust-src system-bootstrap system-llvm test wasm ${ALL_LLVM_TARGETS[*]}"
+
+# Please keep the LLVM dependency block separate. Since LLVM is slotted,
+# we need to *really* make sure we're not pulling more than one slot
+# simultaneously.
+
+# How to use it:
+# List all the working slots in LLVM_VALID_SLOTS, newest first.
+LLVM_VALID_SLOTS=( 16 )
+LLVM_MAX_SLOT="${LLVM_VALID_SLOTS[0]}"
+
+# splitting usedeps needed to avoid CI/pkgcheck's UncheckableDep limitation
+# (-) usedep needed because we may build with older llvm without that target
+LLVM_DEPEND="|| ( "
+for _s in ${LLVM_VALID_SLOTS[@]}; do
+	LLVM_DEPEND+=" ( "
+	for _x in ${ALL_LLVM_TARGETS[@]}; do
+		LLVM_DEPEND+="
+			${_x}? ( sys-devel/llvm:${_s}[${_x}(-)] )
+			wasm? ( sys-devel/lld:${_s} )"
+	done
+	LLVM_DEPEND+=" )"
+done
+unset _s _x
+LLVM_DEPEND+=" )
+	<sys-devel/llvm-$(( LLVM_MAX_SLOT + 1 )):=
+"
+
+# to bootstrap we need at least exactly previous version, or same.
+# most of the time previous versions fail to bootstrap with newer
+# for example 1.47.x, requires at least 1.46.x, 1.47.x is ok,
+# but it fails to bootstrap with 1.48.x
+# https://github.com/rust-lang/rust/blob/${PV}/src/stage0.json
+RUST_DEP_PREV="$(ver_cut 1).$(($(ver_cut 2) - 1))*"
+RUST_DEP_CURR="$(ver_cut 1).$(ver_cut 2)*"
+BOOTSTRAP_DEPEND="||
+	(
+		=dev-lang/rust-"${RUST_DEP_PREV}"
+		=dev-lang/rust-bin-"${RUST_DEP_PREV}"
+		=dev-lang/rust-"${RUST_DEP_CURR}"
+		=dev-lang/rust-bin-"${RUST_DEP_CURR}"
+	)
+"
+
+BDEPEND="${PYTHON_DEPS}
+	app-eselect/eselect-rust
+	|| (
+		>=sys-devel/gcc-4.7
+		>=sys-devel/clang-3.5
+	)
+	system-bootstrap? ( ${BOOTSTRAP_DEPEND} )
+	!system-llvm? (
+		>=dev-util/cmake-3.13.4
+		dev-util/ninja
+	)
+	test? ( sys-devel/gdb )
+	verify-sig? ( sec-keys/openpgp-keys-rust )
+"
+
+DEPEND="
+	>=app-arch/xz-utils-5.2
+	net-misc/curl:=[http2,ssl]
+	sys-libs/zlib:=
+	dev-libs/openssl:0=
+	system-llvm? (
+		${LLVM_DEPEND}
+		llvm-libunwind? ( sys-libs/llvm-libunwind:= )
+	)
+	!system-llvm? (
+		!llvm-libunwind? (
+			elibc_musl? ( sys-libs/libunwind:= )
+		)
+	)
+"
+
+RDEPEND="${DEPEND}
+	app-eselect/eselect-rust
+	sys-apps/lsb-release
+"
+
+REQUIRED_USE="|| ( ${ALL_LLVM_TARGETS[*]} )
+	miri? ( nightly )
+	parallel-compiler? ( nightly )
+	rust-analyzer? ( rust-src )
+	test? ( ${ALL_LLVM_TARGETS[*]} )
+	wasm? ( llvm_targets_WebAssembly )
+	x86? ( cpu_flags_x86_sse2 )
+"
+
+# we don't use cmake.eclass, but can get a warning
+CMAKE_WARN_UNUSED_CLI=no
+
+QA_FLAGS_IGNORED="
+	usr/lib/${PN}/${PV}/bin/.*
+	usr/lib/${PN}/${PV}/libexec/.*
+	usr/lib/${PN}/${PV}/lib/lib.*.so
+	usr/lib/${PN}/${PV}/lib/rustlib/.*/bin/.*
+	usr/lib/${PN}/${PV}/lib/rustlib/.*/lib/lib.*.so
+"
+
+QA_SONAME="
+	usr/lib/${PN}/${PV}/lib/lib.*.so.*
+	usr/lib/${PN}/${PV}/lib/rustlib/.*/lib/lib.*.so
+"
+
+QA_PRESTRIPPED="
+	usr/lib/${PN}/${PV}/lib/rustlib/.*/bin/rust-llvm-dwp
+	usr/lib/${PN}/${PV}/lib/rustlib/.*/lib/self-contained/crtn.o
+"
+
+# An rmeta file is custom binary format that contains the metadata for the crate.
+# rmeta files do not support linking, since they do not contain compiled object files.
+# so we can safely silence the warning for this QA check.
+QA_EXECSTACK="usr/lib/${PN}/${PV}/lib/rustlib/*/lib*.rlib:lib.rmeta"
+
+# causes double bootstrap
+RESTRICT="test"
+
+VERIFY_SIG_OPENPGP_KEY_PATH=${BROOT}/usr/share/openpgp-keys/rust.asc
+
+PATCHES=(
+	"${FILESDIR}"/1.71.1-fix-bootstrap-version-comparison.patch
+	"${FILESDIR}"/1.70.0-ignore-broken-and-non-applicable-tests.patch
+	"${FILESDIR}"/1.62.1-musl-dynamic-linking.patch
+	"${FILESDIR}"/1.67.0-doc-wasm.patch
+	"${FILESDIR}"/1.69.0-musl-1.2.4.patch
+)
+
+S="${WORKDIR}/${MY_P}-src"
+
+eapply_crate() {
+	pushd "${1:?}" > /dev/null || die
+
+	local patch="${2:?}"
+	eapply "${patch}"
+
+	local cargo='.cargo-checksum.json'
+	local _ f
+	grep -- '^[+][+][+] ' "${patch}" | while read -r _ f; do
+		local file="${f#*/}"
+		local orig_sum="$(grep -Eo "\"${file}\":\"[0-9a-fA-F]+\"" "${cargo}" |
+			cut -d':' -f2 | tr -d '"')" || die
+		if [ -n "${orig_sum}" ]; then
+			local sum="$(sha256sum "${file}")" || die
+			sed -i "s|${orig_sum}|${sum%% *}|" "${cargo}" || die
+		fi
+	done
+
+	popd > /dev/null || die
+}
+
+toml_usex() {
+	usex "${1}" true false
+}
+
+bootstrap_rust_version_check() {
+	# never call from pkg_pretend. eselect-rust may be not installed yet.
+	[[ ${MERGE_TYPE} == binary ]] && return
+	local rustc_wanted="$(ver_cut 1).$(($(ver_cut 2) - 1))"
+	local rustc_toonew="$(ver_cut 1).$(($(ver_cut 2) + 1))"
+	local rustc_version=( $(eselect --brief rust show 2>/dev/null) )
+	rustc_version=${rustc_version[0]#rust-bin-}
+	rustc_version=${rustc_version#rust-}
+
+	[[ -z "${rustc_version}" ]] && die "Failed to determine rust version, check 'eselect rust' output"
+
+	if ver_test "${rustc_version}" -lt "${rustc_wanted}" ; then
+		eerror "Rust >=${rustc_wanted} is required"
+		eerror "please run 'eselect rust' and set correct rust version"
+		die "selected rust version is too old"
+	elif ver_test "${rustc_version}" -ge "${rustc_toonew}" ; then
+		eerror "Rust <${rustc_toonew} is required"
+		eerror "please run 'eselect rust' and set correct rust version"
+		die "selected rust version is too new"
+	else
+		einfo "Using rust ${rustc_version} to build"
+	fi
+}
+
+pre_build_checks() {
+	local M=8192
+	# multiply requirements by 1.3 if we are doing x86-multilib
+	if use amd64; then
+		M=$(( $(usex abi_x86_32 13 10) * ${M} / 10 ))
+	fi
+	M=$(( $(usex clippy 128 0) + ${M} ))
+	M=$(( $(usex miri 128 0) + ${M} ))
+	M=$(( $(usex rustfmt 256 0) + ${M} ))
+	# add 2G if we compile llvm and 256M per llvm_target
+	if ! use system-llvm; then
+		M=$(( 2048 + ${M} ))
+		local ltarget
+		for ltarget in ${ALL_LLVM_TARGETS[@]}; do
+			M=$(( $(usex ${ltarget} 256 0) + ${M} ))
+		done
+	fi
+	M=$(( $(usex wasm 256 0) + ${M} ))
+	M=$(( $(usex debug 2 1) * ${M} ))
+	eshopts_push -s extglob
+	if is-flagq '-g?(gdb)?([1-9])'; then
+		M=$(( 15 * ${M} / 10 ))
+	fi
+	eshopts_pop
+	M=$(( $(usex system-bootstrap 0 1024) + ${M} ))
+	M=$(( $(usex doc 256 0) + ${M} ))
+	CHECKREQS_DISK_BUILD=${M}M check-reqs_pkg_${EBUILD_PHASE}
+}
+
+llvm_check_deps() {
+	has_version -r "sys-devel/llvm:${LLVM_SLOT}[${LLVM_TARGET_USEDEPS// /,}]"
+}
+
+# Is LLVM being linked against libc++?
+is_libcxx_linked() {
+	local code='#include <ciso646>
+#if defined(_LIBCPP_VERSION)
+	HAVE_LIBCXX
+#endif
+'
+	local out=$($(tc-getCXX) ${CXXFLAGS} ${CPPFLAGS} -x c++ -E -P - <<<"${code}") || return 1
+	[[ ${out} == *HAVE_LIBCXX* ]]
+}
+
+pkg_pretend() {
+	pre_build_checks
+}
+
+pkg_setup() {
+	pre_build_checks
+	python-any-r1_pkg_setup
+
+	export LIBGIT2_NO_PKG_CONFIG=1 #749381
+
+	use system-bootstrap && bootstrap_rust_version_check
+
+	if use system-llvm; then
+		llvm_pkg_setup
+
+		local llvm_config="$(get_llvm_prefix "${LLVM_MAX_SLOT}")/bin/llvm-config"
+		export LLVM_LINK_SHARED=1
+		export RUSTFLAGS="${RUSTFLAGS} -Lnative=$("${llvm_config}" --libdir)"
+	fi
+}
+
+esetup_unwind_hack() {
+	# https://bugs.gentoo.org/870280
+	# this is a hack needed to bootstrap with libgcc_s linked tarball on llvm-libunwind system.
+	# it should trigger for internal bootstrap or system-bootstrap with rust-bin.
+	# the whole idea is for stage0 to bootstrap with fake libgcc_s.
+	# final stage will receive -L${T}/lib but not -lgcc_s args, producing clean compiler.
+	local fakelib="${T}/fakelib"
+	mkdir -p "${fakelib}" || die
+	# we need both symlinks, one for cargo runtime, other for linker.
+	ln -s "${ESYSROOT}/usr/lib/libunwind.so" "${fakelib}/libgcc_s.so.1" || die
+	ln -s "${ESYSROOT}/usr/lib/libunwind.so" "${fakelib}/libgcc_s.so" || die
+	export LD_LIBRARY_PATH="${fakelib}"
+	export RUSTFLAGS+=" -L${fakelib}"
+	# this is a literally magic variable that gets through cargo cache, without it some
+	# crates ignore RUSTFLAGS.
+	# this variable can not contain leading space.
+	export MAGIC_EXTRA_RUSTFLAGS+="${MAGIC_EXTRA_RUSTFLAGS:+ }-L${fakelib}"
+}
+
+src_prepare() {
+	eapply_crate vendor/getrandom-0.2.8 "${FILESDIR}"/1.69.0-musl-1.2.4-getrandom.patch
+	eapply_crate vendor/libc-0.2.138 "${FILESDIR}"/1.69.0-musl-1.2.4-libc.patch
+	eapply_crate vendor/libc-0.2.139 "${FILESDIR}"/1.69.0-musl-1.2.4-libc.patch
+	eapply_crate vendor/libc-0.2.140 "${FILESDIR}"/1.69.0-musl-1.2.4-libc.patch
+	eapply_crate vendor/libc-0.2.143 "${FILESDIR}"/1.69.0-musl-1.2.4-libc.patch
+	eapply_crate vendor/libc "${FILESDIR}"/1.69.0-musl-1.2.4-libc.patch
+
+	if ! use system-bootstrap; then
+		has_version sys-devel/gcc || esetup_unwind_hack
+		local rust_stage0_root="${WORKDIR}"/rust-stage0
+		local rust_stage0="rust-${RUST_STAGE0_VERSION}-$(rust_abi)"
+
+		if use elibc_musl; then
+			local libstd
+			for libstd in "${WORKDIR}/${rust_stage0}/rust-std-$(rust_abi)/lib/rustlib/$(rust_abi)"/lib/libstd-*.rlib; do
+				"$(tc-getOBJCOPY)" \
+					--redefine-sym=stat64=stat \
+					--redefine-sym=fstat64=fstat \
+					--redefine-sym=lstat64=lstat \
+					--redefine-sym=open64=open \
+					--redefine-sym=readdir64=readdir \
+					--redefine-sym=fstatat64=fstatat \
+					--redefine-sym=lseek64=lseek \
+					--redefine-sym=ftruncate64=ftruncate \
+					"${libstd}" \
+					"${libstd}.out" || die
+
+				mv "${libstd}.out" "${libstd}" || die
+			done
+		fi
+
+		"${WORKDIR}/${rust_stage0}"/install.sh --disable-ldconfig \
+			--without=rust-docs-json-preview,rust-docs --destdir="${rust_stage0_root}" --prefix=/ || die
+	fi
+
+	default
+}
+
+src_configure() {
+	filter-lto # https://bugs.gentoo.org/862109 https://bugs.gentoo.org/866231
+
+	local rust_target="" rust_targets="" arch_cflags
+
+	# Collect rust target names to compile standard libs for all ABIs.
+	for v in $(multilib_get_enabled_abi_pairs); do
+		rust_targets+=",\"$(rust_abi $(get_abi_CHOST ${v##*.}))\""
+	done
+	if use wasm; then
+		rust_targets+=",\"wasm32-unknown-unknown\""
+		if use system-llvm; then
+			# un-hardcode rust-lld linker for this target
+			# https://bugs.gentoo.org/715348
+			sed -i '/linker:/ s/rust-lld/wasm-ld/' compiler/rustc_target/src/spec/wasm_base.rs || die
+		fi
+	fi
+	rust_targets="${rust_targets#,}"
+
+	# cargo and rustdoc are mandatory and should always be included
+	local tools='"cargo","rustdoc"'
+	use clippy && tools+=',"clippy"'
+	use miri && tools+=',"miri"'
+	use profiler && tools+=',"rust-demangler"'
+	use rustfmt && tools+=',"rustfmt"'
+	use rust-analyzer && tools+=',"rust-analyzer"'
+	use rust-src && tools+=',"src"'
+
+	local rust_stage0_root
+	if use system-bootstrap; then
+		local printsysroot
+		printsysroot="$(rustc --print sysroot || die "Can't determine rust's sysroot")"
+		rust_stage0_root="${printsysroot}"
+	else
+		rust_stage0_root="${WORKDIR}"/rust-stage0
+	fi
+	# in case of prefix it will be already prefixed, as --print sysroot returns full path
+	[[ -d ${rust_stage0_root} ]] || die "${rust_stage0_root} is not a directory"
+
+	rust_target="$(rust_abi)"
+
+	local cm_btype="$(usex debug DEBUG RELEASE)"
+	cat <<- _EOF_ > "${S}"/config.toml
+		changelog-seen = 2
+		[llvm]
+		download-ci-llvm = false
+		optimize = $(toml_usex !debug)
+		release-debuginfo = $(toml_usex debug)
+		assertions = $(toml_usex debug)
+		ninja = true
+		targets = "${LLVM_TARGETS// /;}"
+		experimental-targets = ""
+		link-shared = $(toml_usex system-llvm)
+		$(if is_libcxx_linked; then
+			# https://bugs.gentoo.org/732632
+			echo "use-libcxx = true"
+			echo "static-libstdcpp = false"
+		fi)
+		$(case "${rust_target}" in
+			i586-*-linux-*)
+				# https://github.com/rust-lang/rust/issues/93059
+				echo 'cflags = "-fcf-protection=none"'
+				echo 'cxxflags = "-fcf-protection=none"'
+				echo 'ldflags = "-fcf-protection=none"'
+				;;
+			*)
+				;;
+		esac)
+		enable-warnings = false
+		[llvm.build-config]
+		CMAKE_VERBOSE_MAKEFILE = "ON"
+		CMAKE_C_FLAGS_${cm_btype} = "${CFLAGS}"
+		CMAKE_CXX_FLAGS_${cm_btype} = "${CXXFLAGS}"
+		CMAKE_EXE_LINKER_FLAGS_${cm_btype} = "${LDFLAGS}"
+		CMAKE_MODULE_LINKER_FLAGS_${cm_btype} = "${LDFLAGS}"
+		CMAKE_SHARED_LINKER_FLAGS_${cm_btype} = "${LDFLAGS}"
+		CMAKE_STATIC_LINKER_FLAGS_${cm_btype} = "${ARFLAGS}"
+		[build]
+		build-stage = 2
+		test-stage = 2
+		build = "${rust_target}"
+		host = ["${rust_target}"]
+		target = [${rust_targets}]
+		cargo = "${rust_stage0_root}/bin/cargo"
+		rustc = "${rust_stage0_root}/bin/rustc"
+		rustfmt = "${rust_stage0_root}/bin/rustfmt"
+		docs = $(toml_usex doc)
+		compiler-docs = false
+		submodules = false
+		python = "${EPYTHON}"
+		locked-deps = true
+		vendor = true
+		extended = true
+		tools = [${tools}]
+		verbose = 2
+		sanitizers = false
+		profiler = $(toml_usex profiler)
+		cargo-native-static = false
+		[install]
+		prefix = "${EPREFIX}/usr/lib/${PN}/${PV}"
+		sysconfdir = "etc"
+		docdir = "share/doc/rust"
+		bindir = "bin"
+		libdir = "lib"
+		mandir = "share/man"
+		[rust]
+		# https://github.com/rust-lang/rust/issues/54872
+		codegen-units-std = 1
+		optimize = true
+		debug = $(toml_usex debug)
+		debug-assertions = $(toml_usex debug)
+		debug-assertions-std = $(toml_usex debug)
+		debuginfo-level = $(usex debug 2 0)
+		debuginfo-level-rustc = $(usex debug 2 0)
+		debuginfo-level-std = $(usex debug 2 0)
+		debuginfo-level-tools = $(usex debug 2 0)
+		debuginfo-level-tests = 0
+		backtrace = true
+		incremental = false
+		default-linker = "$(tc-getCC)"
+		parallel-compiler = $(toml_usex parallel-compiler)
+		channel = "$(usex nightly nightly stable)"
+		description = "gentoo"
+		rpath = false
+		verbose-tests = true
+		optimize-tests = $(toml_usex !debug)
+		codegen-tests = true
+		dist-src = false
+		remap-debuginfo = true
+		lld = $(usex system-llvm false $(toml_usex wasm))
+		# only deny warnings if doc+wasm are NOT requested, documenting stage0 wasm std fails without it
+		# https://github.com/rust-lang/rust/issues/74976
+		# https://github.com/rust-lang/rust/issues/76526
+		deny-warnings = $(usex wasm $(usex doc false true) true)
+		backtrace-on-ice = true
+		jemalloc = false
+		lto = "$(usex lto fat off)"
+		[dist]
+		src-tarball = false
+		compression-formats = ["xz"]
+		compression-profile = "balanced"
+	_EOF_
+
+	for v in $(multilib_get_enabled_abi_pairs); do
+		rust_target=$(rust_abi $(get_abi_CHOST ${v##*.}))
+		arch_cflags="$(get_abi_CFLAGS ${v##*.})"
+
+		export CFLAGS_${rust_target//-/_}="${arch_cflags}"
+
+		cat <<- _EOF_ >> "${S}"/config.toml
+			[target.${rust_target}]
+			ar = "$(tc-getAR)"
+			cc = "$(tc-getCC)"
+			cxx = "$(tc-getCXX)"
+			linker = "$(tc-getCC)"
+			ranlib = "$(tc-getRANLIB)"
+			llvm-libunwind = "$(usex llvm-libunwind $(usex system-llvm system in-tree) no)"
+		_EOF_
+		if use system-llvm; then
+			cat <<- _EOF_ >> "${S}"/config.toml
+				llvm-config = "$(get_llvm_prefix "${LLVM_MAX_SLOT}")/bin/llvm-config"
+			_EOF_
+		fi
+		# by default librustc_target/spec/linux_musl_base.rs sets base.crt_static_default = true;
+		# but we patch it and set to false here as well
+		if use elibc_musl; then
+			cat <<- _EOF_ >> "${S}"/config.toml
+				crt-static = false
+			_EOF_
+		fi
+	done
+	if use wasm; then
+		cat <<- _EOF_ >> "${S}"/config.toml
+			[target.wasm32-unknown-unknown]
+			linker = "$(usex system-llvm lld rust-lld)"
+			# wasm target does not have profiler_builtins https://bugs.gentoo.org/848483
+			profiler = false
+		_EOF_
+	fi
+
+	if [[ -n ${I_KNOW_WHAT_I_AM_DOING_CROSS} ]]; then # whitespace intentionally shifted below
+	# experimental cross support
+	# discussion: https://bugs.gentoo.org/679878
+	# TODO: c*flags, clang, system-llvm, cargo.eclass target support
+	# it would be much better if we could split out stdlib
+	# complilation to separate ebuild and abuse CATEGORY to
+	# just install to /usr/lib/rustlib/<target>
+
+	# extra targets defined as a bash array
+	# spec format:  <LLVM target>:<rust-target>:<CTARGET>
+	# best place would be /etc/portage/env/dev-lang/rust
+	# Example:
+	# RUST_CROSS_TARGETS=(
+	#	"AArch64:aarch64-unknown-linux-gnu:aarch64-unknown-linux-gnu"
+	# )
+	# no extra hand holding is done, no target transformations, all
+	# values are passed as-is with just basic checks, so it's up to user to supply correct values
+	# valid rust targets can be obtained with
+	# 	rustc --print target-list
+	# matching cross toolchain has to be installed
+	# matching LLVM_TARGET has to be enabled for both rust and llvm (if using system one)
+	# only gcc toolchains installed with crossdev are checked for now.
+
+	# BUG: we can't pass host flags to cross compiler, so just filter for now
+	# BUG: this should be more fine-grained.
+	filter-flags '-mcpu=*' '-march=*' '-mtune=*'
+
+	local cross_target_spec
+	for cross_target_spec in "${RUST_CROSS_TARGETS[@]}";do
+		# extracts first element form <LLVM target>:<rust-target>:<CTARGET>
+		local cross_llvm_target="${cross_target_spec%%:*}"
+		# extracts toolchain triples, <rust-target>:<CTARGET>
+		local cross_triples="${cross_target_spec#*:}"
+		# extracts first element after before : separator
+		local cross_rust_target="${cross_triples%%:*}"
+		# extracts last element after : separator
+		local cross_toolchain="${cross_triples##*:}"
+		use llvm_targets_${cross_llvm_target} || die "need llvm_targets_${cross_llvm_target} target enabled"
+		command -v ${cross_toolchain}-gcc > /dev/null 2>&1 || die "need ${cross_toolchain} cross toolchain"
+
+		cat <<- _EOF_ >> "${S}"/config.toml
+			[target.${cross_rust_target}]
+			ar = "${cross_toolchain}-ar"
+			cc = "${cross_toolchain}-gcc"
+			cxx = "${cross_toolchain}-g++"
+			linker = "${cross_toolchain}-gcc"
+			ranlib = "${cross_toolchain}-ranlib"
+		_EOF_
+		if use system-llvm; then
+			cat <<- _EOF_ >> "${S}"/config.toml
+				llvm-config = "$(get_llvm_prefix "${LLVM_MAX_SLOT}")/bin/llvm-config"
+			_EOF_
+		fi
+		if [[ "${cross_toolchain}" == *-musl* ]]; then
+			cat <<- _EOF_ >> "${S}"/config.toml
+				musl-root = "$(${cross_toolchain}-gcc -print-sysroot)/usr"
+			_EOF_
+		fi
+
+		# append cross target to "normal" target list
+		# example 'target = ["powerpc64le-unknown-linux-gnu"]'
+		# becomes 'target = ["powerpc64le-unknown-linux-gnu","aarch64-unknown-linux-gnu"]'
+
+		rust_targets="${rust_targets},\"${cross_rust_target}\""
+		sed -i "/^target = \[/ s#\[.*\]#\[${rust_targets}\]#" config.toml || die
+
+		ewarn
+		ewarn "Enabled ${cross_rust_target} rust target"
+		ewarn "Using ${cross_toolchain} cross toolchain"
+		ewarn
+		if ! has_version -b 'sys-devel/binutils[multitarget]' ; then
+			ewarn "'sys-devel/binutils[multitarget]' is not installed"
+			ewarn "'strip' will be unable to strip cross libraries"
+			ewarn "cross targets will be installed with full debug information"
+			ewarn "enable 'multitarget' USE flag for binutils to be able to strip object files"
+			ewarn
+			ewarn "Alternatively llvm-strip can be used, it supports stripping any target"
+			ewarn "define STRIP=\"llvm-strip\" to use it (experimental)"
+			ewarn
+		fi
+	done
+	fi # I_KNOW_WHAT_I_AM_DOING_CROSS
+
+	einfo "Rust configured with the following flags:"
+	echo
+	echo RUSTFLAGS="\"${RUSTFLAGS}\""
+	echo RUSTFLAGS_BOOTSTRAP="\"${RUSTFLAGS_BOOTSTRAP}\""
+	echo RUSTFLAGS_NOT_BOOTSTRAP="\"${RUSTFLAGS_NOT_BOOTSTRAP}\""
+	echo MAGIC_EXTRA_RUSTFLAGS="\"${MAGIC_EXTRA_RUSTFLAGS}\""
+	env | grep "CARGO_TARGET_.*_RUSTFLAGS="
+	env | grep "CFLAGS_.*"
+	echo
+	einfo "config.toml contents:"
+	cat "${S}"/config.toml || die
+	echo
+}
+
+src_compile() {
+	RUST_BACKTRACE=1 "${EPYTHON}" ./x.py build -vv --config="${S}"/config.toml -j$(makeopts_jobs) || die
+}
+
+src_test() {
+	# https://rustc-dev-guide.rust-lang.org/tests/intro.html
+
+	# those are basic and codegen tests.
+	local tests=(
+		codegen
+		codegen-units
+		compile-fail
+		incremental
+		mir-opt
+		pretty
+		run-make
+	)
+
+	# fails if llvm is not built with ALL targets.
+	# and known to fail with system llvm sometimes.
+	use system-llvm || tests+=( assembly )
+
+	# fragile/expensive/less important tests
+	# or tests that require extra builds
+	# TODO: instead of skipping, just make some nonfatal.
+	if [[ ${ERUST_RUN_EXTRA_TESTS:-no} != no ]]; then
+		tests+=(
+			rustdoc
+			rustdoc-js
+			rustdoc-js-std
+			rustdoc-ui
+			run-make-fulldeps
+			ui
+			ui-fulldeps
+		)
+	fi
+
+	local i failed=()
+	einfo "rust_src_test: enabled tests ${tests[@]/#/src/test/}"
+	for i in "${tests[@]}"; do
+		local t="src/test/${i}"
+		einfo "rust_src_test: running ${t}"
+		if ! RUST_BACKTRACE=1 "${EPYTHON}" ./x.py test -vv --config="${S}"/config.toml \
+				-j$(makeopts_jobs) --no-doc --no-fail-fast "${t}"
+		then
+				failed+=( "${t}" )
+				eerror "rust_src_test: ${t} failed"
+		fi
+	done
+
+	if [[ ${#failed[@]} -ne 0 ]]; then
+		eerror "rust_src_test: failure summary: ${failed[@]}"
+		die "aborting due to test failures"
+	fi
+}
+
+src_install() {
+	DESTDIR="${D}" "${EPYTHON}" ./x.py install -vv --config="${S}"/config.toml -j$(makeopts_jobs) || die
+
+	# bug #689562, #689160
+	rm -v "${ED}/usr/lib/${PN}/${PV}/etc/bash_completion.d/cargo" || die
+	rmdir -v "${ED}/usr/lib/${PN}/${PV}"/etc{/bash_completion.d,} || die
+	newbashcomp src/tools/cargo/src/etc/cargo.bashcomp.sh cargo
+
+	local symlinks=(
+		cargo
+		rustc
+		rustdoc
+		rust-gdb
+		rust-gdbgui
+		rust-lldb
+	)
+
+	use clippy && symlinks+=( clippy-driver cargo-clippy )
+	use miri && symlinks+=( miri cargo-miri )
+	use profiler && symlinks+=( rust-demangler )
+	use rustfmt && symlinks+=( rustfmt cargo-fmt )
+	use rust-analyzer && symlinks+=( rust-analyzer )
+
+	einfo "installing eselect-rust symlinks and paths: ${symlinks[@]}"
+	local i
+	for i in "${symlinks[@]}"; do
+		# we need realpath on /usr/bin/* symlink return version-appended binary path.
+		# so /usr/bin/rustc should point to /usr/lib/rust/<ver>/bin/rustc-<ver>
+		# need to fix eselect-rust to remove this hack.
+		local ver_i="${i}-${PV}"
+		if [[ -f "${ED}/usr/lib/${PN}/${PV}/bin/${i}" ]]; then
+			einfo "Installing ${i} symlink"
+			ln -v "${ED}/usr/lib/${PN}/${PV}/bin/${i}" "${ED}/usr/lib/${PN}/${PV}/bin/${ver_i}" || die
+		else
+			ewarn "${i} symlink requested, but source file not found"
+			ewarn "please report this"
+		fi
+		dosym "../lib/${PN}/${PV}/bin/${ver_i}" "/usr/bin/${ver_i}"
+	done
+
+	# symlinks to switch components to active rust in eselect
+	dosym "${PV}/lib" "/usr/lib/${PN}/lib-${PV}"
+	dosym "${PV}/libexec" "/usr/lib/${PN}/libexec-${PV}"
+	dosym "${PV}/share/man" "/usr/lib/${PN}/man-${PV}"
+	dosym "rust/${PV}/lib/rustlib" "/usr/lib/rustlib-${PV}"
+	dosym "../../lib/${PN}/${PV}/share/doc/rust" "/usr/share/doc/${P}"
+
+	newenvd - "50${P}" <<-_EOF_
+		LDPATH="${EPREFIX}/usr/lib/rust/lib"
+		MANPATH="${EPREFIX}/usr/lib/rust/man"
+	_EOF_
+
+	rm -rf "${ED}/usr/lib/${PN}/${PV}"/*.old || die
+	rm -rf "${ED}/usr/lib/${PN}/${PV}/doc"/*.old || die
+
+	# note: eselect-rust adds EROOT to all paths below
+	cat <<-_EOF_ > "${T}/provider-${P}"
+		/usr/bin/cargo
+		/usr/bin/rustdoc
+		/usr/bin/rust-gdb
+		/usr/bin/rust-gdbgui
+		/usr/bin/rust-lldb
+		/usr/lib/rustlib
+		/usr/lib/rust/lib
+		/usr/lib/rust/libexec
+		/usr/lib/rust/man
+		/usr/share/doc/rust
+	_EOF_
+
+	if use clippy; then
+		echo /usr/bin/clippy-driver >> "${T}/provider-${P}"
+		echo /usr/bin/cargo-clippy >> "${T}/provider-${P}"
+	fi
+	if use miri; then
+		echo /usr/bin/miri >> "${T}/provider-${P}"
+		echo /usr/bin/cargo-miri >> "${T}/provider-${P}"
+	fi
+	if use profiler; then
+		echo /usr/bin/rust-demangler >> "${T}/provider-${P}"
+	fi
+	if use rustfmt; then
+		echo /usr/bin/rustfmt >> "${T}/provider-${P}"
+		echo /usr/bin/cargo-fmt >> "${T}/provider-${P}"
+	fi
+	if use rust-analyzer; then
+		echo /usr/bin/rust-analyzer >> "${T}/provider-${P}"
+	fi
+
+	insinto /etc/env.d/rust
+	doins "${T}/provider-${P}"
+
+	if use dist; then
+		insinto "/usr/lib/${PN}/${PV}/dist"
+		doins -r "${S}/build/dist/."
+	fi
+}
+
+pkg_postinst() {
+	eselect rust update
+
+	if has_version sys-devel/gdb || has_version dev-util/lldb; then
+		elog "Rust installs a helper script for calling GDB and LLDB,"
+		elog "for your convenience it is installed under /usr/bin/rust-{gdb,lldb}-${PV}."
+	fi
+
+	if has_version app-editors/emacs; then
+		elog "install app-emacs/rust-mode to get emacs support for rust."
+	fi
+
+	if has_version app-editors/gvim || has_version app-editors/vim; then
+		elog "install app-vim/rust-vim to get vim support for rust."
+	fi
+}
+
+pkg_postrm() {
+	eselect rust cleanup
+}


### PR DESCRIPTION
This fixes the build with musl-1.2.4, may need `-system-bootstrap` after updating musl.

Closes: https://bugs.gentoo.org/903607
Upstream-PR: https://github.com/rust-lang/rust/pull/106246
Upstream-Issue: https://github.com/rust-lang/libc/issues/2934
Upstream-PR: https://github.com/rust-lang/libc/pull/2935
Upstream-Commit: https://github.com/rust-lang/libc/commit/1e8c55cbed0b6e05a6c5063baa1fea50cad49269
Upstream-PR: https://github.com/rust-random/getrandom/pull/326
Upstream-Commit: https://github.com/rust-random/getrandom/commit/7f73e3ccc1f53bfc419e4ddcfd343766aa5837b6