### PR TITLE
app-i18n/mozc: enable py3.11

### DIFF
--- a/app-i18n/mozc/mozc-2.26.4220_p20201212102434_p20201219202429.ebuild
+++ b/app-i18n/mozc/mozc-2.26.4220_p20201212102434_p20201219202429.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="8"
-PYTHON_COMPAT=( python3_{9..10} )
+PYTHON_COMPAT=( python3_{9..11} )
 
 inherit elisp-common multiprocessing python-any-r1 toolchain-funcs
 


### PR DESCRIPTION
Tested on my amd64 gentoo setup.