### PR TITLE
net-libs/libmicrohttpd: fixed rebuild of reverse depends

### DIFF
--- a/app-admin/conky/conky-1.17.0.ebuild
+++ b/app-admin/conky/conky-1.17.0.ebuild
@@ -41,7 +41,7 @@ COMMON_DEPEND="
 		x11-libs/pango
 	)
 	wifi? ( net-wireless/wireless-tools )
-	webserver? ( net-libs/libmicrohttpd )
+	webserver? ( net-libs/libmicrohttpd:= )
 	X? (
 		x11-libs/libX11
 		x11-libs/libXdamage

--- a/app-admin/conky/conky-1.19.2.ebuild
+++ b/app-admin/conky/conky-1.19.2.ebuild
@@ -41,7 +41,7 @@ COMMON_DEPEND="
 		x11-libs/pango
 	)
 	wifi? ( net-wireless/wireless-tools )
-	webserver? ( net-libs/libmicrohttpd )
+	webserver? ( net-libs/libmicrohttpd:= )
 	X? (
 		x11-libs/libX11
 		x11-libs/libXdamage

--- a/media-sound/upmpdcli/upmpdcli-1.7.2.ebuild
+++ b/media-sound/upmpdcli/upmpdcli-1.7.2.ebuild
@@ -17,7 +17,7 @@ IUSE="thirdparty"
 DEPEND="
 	dev-libs/jsoncpp
 	media-libs/libmpdclient
-	net-libs/libmicrohttpd
+	net-libs/libmicrohttpd:=
 	net-libs/libupnpp
 "
 RDEPEND="

--- a/media-sound/upmpdcli/upmpdcli-1.7.9.ebuild
+++ b/media-sound/upmpdcli/upmpdcli-1.7.9.ebuild
@@ -17,7 +17,7 @@ IUSE="thirdparty"
 DEPEND="
 	dev-libs/jsoncpp
 	media-libs/libmpdclient
-	net-libs/libmicrohttpd
+	net-libs/libmicrohttpd:=
 	net-libs/libupnpp
 "
 RDEPEND="

--- a/media-tv/kodi/kodi-19.5.ebuild
+++ b/media-tv/kodi/kodi-19.5.ebuild
@@ -152,7 +152,7 @@ COMMON_TARGET_DEPEND="${PYTHON_DEPS}
 		>=dev-libs/wayland-protocols-1.7
 		>=x11-libs/libxkbcommon-0.4.1
 	)
-	webserver? ( >=net-libs/libmicrohttpd-0.9.55[messages(+)] )
+	webserver? ( >=net-libs/libmicrohttpd-0.9.55:=[messages(+)] )
 	X? (
 		media-libs/mesa[X]
 		!gles? ( media-libs/libglvnd[X] )

--- a/media-tv/kodi/kodi-19.9999.ebuild
+++ b/media-tv/kodi/kodi-19.9999.ebuild
@@ -146,7 +146,7 @@ COMMON_TARGET_DEPEND="${PYTHON_DEPS}
 		>=dev-libs/wayland-protocols-1.7
 		>=x11-libs/libxkbcommon-0.4.1
 	)
-	webserver? ( >=net-libs/libmicrohttpd-0.9.55[messages(+)] )
+	webserver? ( >=net-libs/libmicrohttpd-0.9.55:=[messages(+)] )
 	X? (
 		media-libs/mesa[X]
 		!gles? ( media-libs/libglvnd[X] )

--- a/media-tv/kodi/kodi-9999.ebuild
+++ b/media-tv/kodi/kodi-9999.ebuild
@@ -145,7 +145,7 @@ COMMON_TARGET_DEPEND="${PYTHON_DEPS}
 		>=dev-libs/wayland-protocols-1.7
 		>=x11-libs/libxkbcommon-0.4.1
 	)
-	webserver? ( >=net-libs/libmicrohttpd-0.9.75[messages(+)] )
+	webserver? ( >=net-libs/libmicrohttpd-0.9.75:=[messages(+)] )
 	X? (
 		media-libs/mesa[X]
 		!gles? ( media-libs/libglvnd[X] )

--- a/net-libs/libnpupnp/libnpupnp-5.0.1.ebuild
+++ b/net-libs/libnpupnp/libnpupnp-5.0.1.ebuild
@@ -15,7 +15,7 @@ KEYWORDS="amd64 x86"
 
 RDEPEND="
 	dev-libs/expat
-	net-libs/libmicrohttpd
+	net-libs/libmicrohttpd:=
 	net-misc/curl
 "
 DEPEND="${RDEPEND}"

--- a/net-libs/libnpupnp/libnpupnp-5.0.2.ebuild
+++ b/net-libs/libnpupnp/libnpupnp-5.0.2.ebuild
@@ -15,7 +15,7 @@ KEYWORDS="~amd64 ~x86"
 
 RDEPEND="
 	dev-libs/expat
-	net-libs/libmicrohttpd
+	net-libs/libmicrohttpd:=
 	net-misc/curl
 "
 DEPEND="${RDEPEND}"

--- a/net-misc/bfgminer/bfgminer-5.5.0-r2.ebuild
+++ b/net-misc/bfgminer/bfgminer-5.5.0-r2.ebuild
@@ -83,7 +83,7 @@ DEPEND="
 		dev-libs/hidapi
 	)
 	proxy_getwork? (
-		net-libs/libmicrohttpd
+		net-libs/libmicrohttpd:=
 	)
 	proxy_stratum? (
 		dev-libs/libevent


### PR DESCRIPTION
Fixed all packages depending on net-libs/libmicrohttpd to be rebuilt on libmicrohttpd SO bump.
No revbump now as libmicrohttpd has stable SO currently. However, if libmicrohttpd will get SO bump all packages versions from this patch should be rev-bumped (if any such version would be actual still).