### PR TITLE
dev-python/*: enable py3.12

### DIFF
--- a/dev-python/aiosignal/aiosignal-1.3.1.ebuild
+++ b/dev-python/aiosignal/aiosignal-1.3.1.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} pypy3 )
+PYTHON_COMPAT=( python3_{10..12} pypy3 )
 
 inherit distutils-r1
 

--- a/dev-python/astor/astor-0.8.1-r1.ebuild
+++ b/dev-python/astor/astor-0.8.1-r1.ebuild
@@ -4,12 +4,15 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( pypy3 python3_{9..11} )
+PYTHON_COMPAT=( pypy3 python3_{10..12} )
 
 inherit distutils-r1 pypi
 
 DESCRIPTION="Read/rewrite/write Python ASTs"
-HOMEPAGE="https://pypi.org/project/astor/"
+HOMEPAGE="
+	https://pypi.org/project/astor
+	https://github.com/berkerpeksag/astor
+"
 
 LICENSE="BSD"
 SLOT="0"

--- a/dev-python/frozenlist/frozenlist-1.3.3.ebuild
+++ b/dev-python/frozenlist/frozenlist-1.3.3.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 DISTUTILS_EXT=1
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} pypy3 )
+PYTHON_COMPAT=( python3_{10..12} pypy3 )
 
 inherit distutils-r1
 

--- a/dev-python/sniffio/sniffio-1.3.0.ebuild
+++ b/dev-python/sniffio/sniffio-1.3.0.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( pypy3 python3_{9..11} )
+PYTHON_COMPAT=( pypy3 python3_{10..12} )
 
 inherit distutils-r1
 


### PR DESCRIPTION
few more py3.12 enabled packages, tests pass. Additionally, I have appended github link to `dev-python/astor` `HOMEPAGE`.