### PR TITLE
net-nntp/sabnzbd: keyword 4.0.1 for ~amd64

### DIFF
--- a/net-nntp/sabnzbd/sabnzbd-4.0.1.ebuild
+++ b/net-nntp/sabnzbd/sabnzbd-4.0.1.ebuild
@@ -22,6 +22,7 @@ S="${WORKDIR}/${MY_P}"
 # Sabnzbd is GPL-2 but bundles software with the following licenses.
 LICENSE="GPL-2 BSD LGPL-2 MIT BSD-1"
 SLOT="0"
+KEYWORDS="~amd64"
 IUSE="test"
 RESTRICT="!test? ( test )"
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/907225