### PR TITLE
dev-python/*: enable py3.12

### DIFF
--- a/dev-python/alabaster/alabaster-0.7.13.ebuild
+++ b/dev-python/alabaster/alabaster-0.7.13.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} pypy3 )
+PYTHON_COMPAT=( python3_{10..12} pypy3 )
 
 inherit distutils-r1 pypi
 

--- a/dev-python/snowballstemmer/snowballstemmer-2.2.0-r1.ebuild
+++ b/dev-python/snowballstemmer/snowballstemmer-2.2.0-r1.ebuild
@@ -4,13 +4,15 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} pypy3 )
+PYTHON_COMPAT=( python3_{10..12} pypy3 )
 inherit distutils-r1 pypi
 
 DESCRIPTION="Stemmer algorithms generated from Snowball algorithms"
-HOMEPAGE="https://snowballstem.org/
+HOMEPAGE="
+	https://snowballstem.org/
 	https://github.com/snowballstem/snowball
-	https://pypi.org/project/snowballstemmer/"
+	https://pypi.org/project/snowballstemmer/
+"
 
 LICENSE="BSD"
 SLOT="0"

--- a/dev-python/sphinx/sphinx-7.0.1.ebuild
+++ b/dev-python/sphinx/sphinx-7.0.1.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=flit
-PYTHON_COMPAT=( python3_{9..11} pypy3 )
+PYTHON_COMPAT=( python3_{10..12} pypy3 )
 PYTHON_REQ_USE="threads(+)"
 
 inherit distutils-r1
@@ -44,7 +44,7 @@ RDEPEND="
 	>=dev-python/packaging-21.0[${PYTHON_USEDEP}]
 	$(python_gen_cond_dep '
 		>=dev-python/importlib-metadata-4.8[${PYTHON_USEDEP}]
-	' 3.8 3.9)
+	' 3.9)
 	latex? (
 		dev-texlive/texlive-latexextra
 		dev-texlive/texlive-luatex
@@ -104,6 +104,8 @@ python_test() {
 		tests/test_ext_autodoc.py::test_cython
 		tests/test_ext_autodoc_autoclass.py::test_classes
 		tests/test_ext_autodoc_autofunction.py::test_classes
+		tests/test_ext_math.py::test_imgmath_numfig_html
+		tests/test_ext_math.py::test_imgmath_png
 		tests/test_ext_inheritance_diagram.py::test_import_classes
 		# looks like a bug in lualatex
 		"tests/test_build_latex.py::test_build_latex_doc[lualatex-howto]"

--- a/dev-python/sphinxcontrib-applehelp/sphinxcontrib-applehelp-1.0.4.ebuild
+++ b/dev-python/sphinxcontrib-applehelp/sphinxcontrib-applehelp-1.0.4.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} pypy3 )
+PYTHON_COMPAT=( python3_{10..12} pypy3 )
 
 inherit distutils-r1
 

--- a/dev-python/sphinxcontrib-devhelp/sphinxcontrib-devhelp-1.0.2-r1.ebuild
+++ b/dev-python/sphinxcontrib-devhelp/sphinxcontrib-devhelp-1.0.2-r1.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
 PYPI_NO_NORMALIZE=1
-PYTHON_COMPAT=( python3_{9..11} pypy3 )
+PYTHON_COMPAT=( python3_{10..12} pypy3 )
 
 inherit distutils-r1 pypi
 

--- a/dev-python/sphinxcontrib-htmlhelp/sphinxcontrib-htmlhelp-2.0.1.ebuild
+++ b/dev-python/sphinxcontrib-htmlhelp/sphinxcontrib-htmlhelp-2.0.1.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
 PYPI_NO_NORMALIZE=1
-PYTHON_COMPAT=( python3_{9..11} pypy3 )
+PYTHON_COMPAT=( python3_{10..12} pypy3 )
 
 inherit distutils-r1 pypi
 

--- a/dev-python/sphinxcontrib-jsmath/sphinxcontrib-jsmath-1.0.1-r3.ebuild
+++ b/dev-python/sphinxcontrib-jsmath/sphinxcontrib-jsmath-1.0.1-r3.ebuild
@@ -1,0 +1,48 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DISTUTILS_USE_PEP517=setuptools
+PYPI_NO_NORMALIZE=1
+PYTHON_COMPAT=( python3_{10..12} pypy3 )
+
+inherit distutils-r1 pypi
+
+DESCRIPTION="Sphinx extension which renders display math in HTML via JavaScript"
+HOMEPAGE="
+	https://www.sphinx-doc.org/
+	https://github.com/sphinx-doc/sphinxcontrib-jsmath/
+	https://pypi.org/project/sphinxcontrib-jsmath/
+"
+
+LICENSE="BSD-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x64-solaris"
+
+PDEPEND="
+	>=dev-python/sphinx-2.0[${PYTHON_USEDEP}]
+"
+BDEPEND="
+	test? ( ${PDEPEND} )
+"
+
+distutils_enable_tests pytest
+
+src_prepare() {
+	# This is already fixed in upstream, remove it on next version bump,
+	# see https://github.com/sphinx-doc/sphinxcontrib-jsmath/pull/10
+	sed -i 's/.text()/.read_text()/' tests/test_jsmath.py || die
+	distutils-r1_src_prepare
+}
+
+python_compile() {
+	distutils-r1_python_compile
+	find "${BUILD_DIR}" -name '*.pth' -delete || die
+}
+
+python_test() {
+	distutils_write_namespace sphinxcontrib
+	cd "${T}" || die
+	epytest "${S}"/tests
+}

--- a/dev-python/sphinxcontrib-qthelp/sphinxcontrib-qthelp-1.0.3-r2.ebuild
+++ b/dev-python/sphinxcontrib-qthelp/sphinxcontrib-qthelp-1.0.3-r2.ebuild
@@ -1,0 +1,48 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DISTUTILS_USE_PEP517=setuptools
+PYPI_NO_NORMALIZE=1
+PYTHON_COMPAT=( python3_{10..12} pypy3 )
+
+inherit distutils-r1 pypi
+
+DESCRIPTION="Sphinx extension which outputs QtHelp documents"
+HOMEPAGE="
+	https://www.sphinx-doc.org/
+	https://github.com/sphinx-doc/sphinxcontrib-qthelp/
+	https://pypi.org/project/sphinxcontrib-qthelp/
+"
+
+LICENSE="BSD-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x64-solaris"
+
+PDEPEND="
+	>=dev-python/sphinx-2.0[${PYTHON_USEDEP}]
+"
+BDEPEND="
+	test? ( ${PDEPEND} )
+"
+
+distutils_enable_tests pytest
+
+src_prepare() {
+	# This is already fixed in upstream, remove it on next version bump,
+	# see https://github.com/sphinx-doc/sphinxcontrib-qthelp/pull/14
+	sed -i 's/.text()/.read_text()/' tests/test_qthelp.py || die
+	distutils-r1_src_prepare
+}
+
+python_compile() {
+	distutils-r1_python_compile
+	find "${BUILD_DIR}" -name '*.pth' -delete || die
+}
+
+python_test() {
+	distutils_write_namespace sphinxcontrib
+	cd "${T}" || die
+	epytest "${S}"/tests
+}

--- a/dev-python/sphinxcontrib-serializinghtml/sphinxcontrib-serializinghtml-1.1.5-r1.ebuild
+++ b/dev-python/sphinxcontrib-serializinghtml/sphinxcontrib-serializinghtml-1.1.5-r1.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
 PYPI_NO_NORMALIZE=1
-PYTHON_COMPAT=( python3_{9..11} pypy3 )
+PYTHON_COMPAT=( python3_{10..12} pypy3 )
 
 inherit distutils-r1 pypi
 

--- a/dev-python/sphinxcontrib-websupport/sphinxcontrib-websupport-1.2.4-r2.ebuild
+++ b/dev-python/sphinxcontrib-websupport/sphinxcontrib-websupport-1.2.4-r2.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} pypy3 )
+PYTHON_COMPAT=( python3_{10..12} pypy3 )
 
 inherit distutils-r1
 

--- a/dev-python/sqlalchemy/sqlalchemy-2.0.15.ebuild
+++ b/dev-python/sqlalchemy/sqlalchemy-2.0.15.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 DISTUTILS_EXT=1
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( pypy3 python3_{10..11} )
+PYTHON_COMPAT=( pypy3 python3_{10..12} )
 PYTHON_REQ_USE="sqlite?"
 
 inherit distutils-r1 optfeature pypi
@@ -67,6 +67,10 @@ python_test() {
 		"test/dialect/test_sqlite.py::TestTypes_sqlite+pysqlite_${sqlite_version//./_}::test_cant_parse_datetime_message"
 		"test/dialect/test_suite.py::ReturningGuardsTest_sqlite+pysqlite_${sqlite_version//./_}"::test_{delete,insert,update}_single
 		test/base/test_utils.py::ImmutableDictTest::test_pep584
+	)
+	[[ ${EPYTHON} == python3.12 ]] && EPYTEST_DESELECT+=(
+		# see https://github.com/sqlalchemy/sqlalchemy/issues/9819
+		test/base/test_result.py::ResultTupleTest::test_slices_arent_in_mappings
 	)
 	if ! has_version "dev-python/greenlet[${PYTHON_USEDEP}]"; then
 		EPYTEST_DESELECT+=(

--- a/dev-python/whoosh/metadata.xml
+++ b/dev-python/whoosh/metadata.xml
@@ -14,6 +14,7 @@
 		your needs exactly.
 	</longdescription>
 	<upstream>
+		<remote-id type="github">mchaput/whoosh</remote-id>
 		<remote-id type="pypi">Whoosh</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/dev-python/whoosh/whoosh-2.7.4-r2.ebuild
+++ b/dev-python/whoosh/whoosh-2.7.4-r2.ebuild
@@ -6,11 +6,14 @@ EAPI=8
 DISTUTILS_USE_PEP517=setuptools
 PYPI_NO_NORMALIZE=1
 PYPI_PN=${PN^}
-PYTHON_COMPAT=( python3_{9..11} pypy3 )
+PYTHON_COMPAT=( python3_{10..12} pypy3 )
 inherit distutils-r1 pypi
 
 DESCRIPTION="Fast, pure-Python full text indexing, search and spell checking library"
-HOMEPAGE="https://pypi.org/project/Whoosh/"
+HOMEPAGE="
+	https://pypi.org/project/Whoosh/
+	https://github.com/mchaput/whoosh
+"
 
 LICENSE="BSD-2"
 SLOT="0"


### PR DESCRIPTION
enable py3.12 in sphinx and its deps.

I had one problematic test in `dev-python/sqlalchemy,` the issue was already reported to upstream, which seems to be somehow addressed, but it is not merged to the master yet. I have deselected it.

Two more problematic tests were in `dev-python/sphinx`, but they were affecting all supported python version, it is probably somehow related to latex, but I am not sure. I have deselected them either.

`dev-python/sphinxcontrib-{jsmath,qthelp}` tests are fixed.

plus some minor improvements of metadata.