### PR TITLE
app-emulation/qemu: update live ebuild

### DIFF
--- a/app-emulation/qemu/metadata.xml
+++ b/app-emulation/qemu/metadata.xml
@@ -35,6 +35,7 @@
 		<flag name="pin-upstream-blobs">Pin the versions of BIOS firmware to the version included in the upstream release.
 		This is needed to sanely support migration/suspend/resume/snapshotting/etc... of instances.
 		When the blobs are different, random corruption/bugs/crashes/etc... may be observed.</flag>
+		<flag name="pipewire">Enable pipewire output for sound emulation</flag>
 		<flag name="plugins">Enable qemu plugin API via shared library loading.</flag>
 		<flag name="pulseaudio">Enable pulseaudio output for sound emulation</flag>
 		<flag name="rbd">Enable rados block device backend support, see https://docs.ceph.com/en/mimic/rbd/qemu-rbd/</flag>

--- a/app-emulation/qemu/qemu-9999.ebuild
+++ b/app-emulation/qemu/qemu-9999.ebuild
@@ -13,7 +13,7 @@ QEMU_DOCS_VERSION=$(ver_cut 1-3)
 # bug #830088
 QEMU_DOC_USEFLAG="+doc"
 
-PYTHON_COMPAT=( python3_{9,10,11} )
+PYTHON_COMPAT=( python3_{9,10,11,12} )
 PYTHON_REQ_USE="ncurses,readline"
 
 FIRMWARE_ABI_VERSION="7.2.0"
@@ -28,7 +28,7 @@ if [[ ${PV} == *9999* ]]; then
 	EGIT_SUBMODULES=(
 		tests/fp/berkeley-softfloat-3
 		tests/fp/berkeley-testfloat-3
-		ui/keycodemapdb
+		subprojects/keycodemapdb
 	)
 	inherit git-r3
 	SRC_URI=""
@@ -56,7 +56,7 @@ IUSE="accessibility +aio alsa bpf bzip2 capstone +curl debug ${QEMU_DOC_USEFLAG}
 	+fdt fuse glusterfs +gnutls gtk infiniband iscsi io-uring
 	jack jemalloc +jpeg
 	lzo multipath
-	ncurses nfs nls numa opengl +oss pam +pin-upstream-blobs
+	ncurses nfs nls numa opengl +oss pam +pin-upstream-blobs pipewire
 	plugins +png pulseaudio python rbd sasl +seccomp sdl sdl-image selinux
 	+slirp
 	smartcard snappy spice ssh static-user systemtap test udev usb
@@ -203,6 +203,7 @@ SOFTMMU_TOOLS_DEPEND="
 		media-libs/mesa[egl(+),gbm(+)]
 	)
 	pam? ( sys-libs/pam )
+	pipewire? ( media-video/pipewire )
 	png? ( >=media-libs/libpng-1.6.34:=[static-libs(+)] )
 	pulseaudio? ( media-libs/libpulse )
 	rbd? ( sys-cluster/ceph )
@@ -301,7 +302,6 @@ RDEPEND="${CDEPEND}
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-8.0.0-disable-keymap.patch
-	"${FILESDIR}"/${PN}-8.0.0-make.patch
 	"${FILESDIR}"/${PN}-7.1.0-capstone-include-path.patch
 	"${FILESDIR}"/${PN}-8.1.0-also-build-virtfs-proxy-helper.patch
 )
@@ -449,7 +449,7 @@ src_prepare() {
 	sed -i -e 's/-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2//' configure || die
 
 	# Remove bundled modules
-	rm -r dtc roms/*/ || die
+	rm -r subprojects/dtc roms/*/ || die
 }
 
 ##
@@ -504,6 +504,7 @@ qemu_src_configure() {
 		$(use_enable jack)
 		$(use_enable nls gettext)
 		$(use_enable oss)
+		$(use_enable pipewire)
 		$(use_enable plugins)
 		$(use_enable pulseaudio pa)
 		$(use_enable selinux)


### PR DESCRIPTION
Couple of things:

1) Upstream removed checking of $make (commit
   v8.0.0-1332-gb17bbf835c) , rendering our qemu-8.0.0-make.patch
   useless. Just stop applying it.

2) Subprojects are moved under subprojects/ gradually
   (v8.0.0-1330-g58e48b2e72 for dtc, v8.0.0-1331-gc53648abba for
   keycodemapdb). Update corresponding paths in the ebuild.