### PR TITLE
net-libs/neon: add upstream patches

### DIFF
--- a/net-libs/neon/files/neon-0.32.4-dash.patch
+++ b/net-libs/neon/files/neon-0.32.4-dash.patch
@@ -1,0 +1,43 @@
+https://bugs.gentoo.org/832851
+https://github.com/notroj/neon/pull/115
+https://github.com/notroj/neon/commit/e02ead4d990e49c912ef053c46b55713685119ee
+
+From e1bcf0e83012e0c1ff81c573d2650e1a4e40d955 Mon Sep 17 00:00:00 2001
+From: orbea <orbea@riseup.net>
+Date: Sat, 6 May 2023 20:50:50 -0700
+Subject: [PATCH 1/2] test/makekeys.sh: fix POSIX compliance
+
+Not all shells provide 'echo -e' and using printf is more portable.
+
+One shell that will fail is dash(1).
+
+ssl................... 10/63 FAIL - dname_readable (certificate subject dname was `-e H\0350llo World, Neon Hackers Ltd, Cambridge, Cambridgeshire, GB' not `Hèllo World, Neon Hackers Ltd, Cambridge, Cambridgeshire, GB'
+
+Gentoo-Issue: https://bugs.gentoo.org/832851
+---
+ test/makekeys.sh | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/test/makekeys.sh b/test/makekeys.sh
+index 88dc7b3..8ee90ae 100755
+--- a/test/makekeys.sh
++++ b/test/makekeys.sh
+@@ -123,15 +123,15 @@ csr_fields "Self-Signed" | \
+ ${MKCERT} -key server.key -out ssigned.pem
+ 
+ # default => T61String
+-csr_fields "`echo -e 'H\0350llo World'`" localhost |
++csr_fields "$(printf 'H%bllo World\n' '\0350')" localhost |
+ ${REQ} -new -key server.key -out t61subj.csr
+ 
+ STRMASK=pkix # => BMPString
+-csr_fields "`echo -e 'H\0350llo World'`" localhost |
++csr_fields "$(printf 'H%bllo World\n' '\0350')" localhost |
+ ${REQ} -new -key server.key -out bmpsubj.csr
+ 
+ STRMASK=utf8only # => UTF8String
+-csr_fields "`echo -e 'H\0350llo World'`" localhost |
++csr_fields "$(printf 'H%bllo World\n' '\0350')" localhost |
+ ${REQ} -new -key server.key -out utf8subj.csr
+ 
+ STRMASK=default

--- a/net-libs/neon/files/neon-0.32.4-libressl.patch
+++ b/net-libs/neon/files/neon-0.32.4-libressl.patch
@@ -1,0 +1,61 @@
+https://bugs.gentoo.org/903001
+https://github.com/notroj/neon/pull/113
+https://github.com/notroj/neon/commit/18e868e4449cd46d494944ced798f9dcd01f65c5
+https://github.com/notroj/neon/pull/116
+https://github.com/notroj/neon/commit/231a1d3f3f427b823753dc2e53adcf9cafda619b
+https://github.com/notroj/neon/pull/118
+https://github.com/notroj/neon/commit/6f98a9c9bdd76fb3d367e3b01bcc45bea574c3d1
+
+From 233f17b86ebc2cd99d9deede484f4b0be586730f Mon Sep 17 00:00:00 2001
+From: orbea <orbea@riseup.net>
+Date: Mon, 27 Mar 2023 14:58:49 -0700
+Subject: [PATCH] ne_openssl: Fix the build with libressl
+
+* Libressl 3.7 currently doesn't provide EVP_sha512_256().
+* Libressl 3.4 added SSL_CTX_set_post_handshake_auth().
+---
+ src/ne_openssl.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+From 392e1380e1fa07675934ed25e8980ae18d0bccb4 Mon Sep 17 00:00:00 2001
+From: Joe Orton <jorton@redhat.com>
+Date: Tue, 9 May 2023 16:26:55 +0100
+Subject: [PATCH] * src/ne_openssl.c: Fix GCC warning with OpenSSL build.
+
+---
+ src/ne_openssl.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+From 1e9483dbb43e82dde06bc84434c8b7124602adbc Mon Sep 17 00:00:00 2001
+From: orbea <orbea@riseup.net>
+Date: Mon, 29 May 2023 10:07:52 -0700
+Subject: [PATCH] ne_openssl: Update for LibreSSL 3.8.0
+
+EVP_sha512_256() was added in LibreSSL 3.8.0.
+---
+ src/ne_openssl.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/ne_openssl.c b/src/ne_openssl.c
+index d13c25a..bdb73e9 100644
+--- a/src/ne_openssl.c
++++ b/src/ne_openssl.c
+@@ -581,7 +581,7 @@ ne_ssl_context *ne_ssl_context_create(int mode)
+         /* enable workarounds for buggy SSL server implementations */
+         SSL_CTX_set_options(ctx->ctx, SSL_OP_ALL);
+         SSL_CTX_set_verify(ctx->ctx, SSL_VERIFY_PEER, verify_callback);
+-#if !defined(LIBRESSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER >= 0x10101000L
++#if defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER >= 0x3040000fL || (!defined(LIBRESSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER >= 0x10101000L)
+         SSL_CTX_set_post_handshake_auth(ctx->ctx, 1);
+ #endif
+     } else if (mode == NE_SSL_CTX_SERVER) {
+@@ -1122,7 +1122,9 @@ static const EVP_MD *hash_to_md(unsigned int flags)
+     case NE_HASH_SHA256: return EVP_sha256();
+ #ifdef HAVE_OPENSSL11
+     case NE_HASH_SHA512: return EVP_sha512();
++#if !defined(LIBRESSL_VERSION_NUMBER) || LIBRESSL_VERSION_NUMBER >= 0x3080000fL
+     case NE_HASH_SHA512_256: return EVP_sha512_256();
++#endif
+ #endif
+     default: break;
+     }

--- a/net-libs/neon/neon-0.32.4.ebuild
+++ b/net-libs/neon/neon-0.32.4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2001-2022 Gentoo Authors
+# Copyright 2001-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="8"
@@ -43,6 +43,11 @@ MULTILIB_CHOST_TOOLS=(
 )
 
 DOCS=( AUTHORS BUGS NEWS README.md THANKS TODO )
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-0.32.4-dash.patch #832851
+	"${FILESDIR}"/${PN}-0.32.4-libressl.patch #903001
+)
 
 src_prepare() {
 	if use gnutls; then


### PR DESCRIPTION
This fixes POSIX compliance in the tests and fixes the build with LibreSSL.

Closes: https://bugs.gentoo.org/832851
Upstream-PR: https://github.com/notroj/neon/pull/115
Upstream-Commit: https://github.com/notroj/neon/commit/e02ead4d990e49c912ef053c46b55713685119ee
Bug: https://bugs.gentoo.org/903001
Upstream-PR: https://github.com/notroj/neon/pull/113
Upstream-Commit: https://github.com/notroj/neon/commit/18e868e4449cd46d494944ced798f9dcd01f65c5
Upstream-PR: https://github.com/notroj/neon/pull/116
Upstream-Commit: https://github.com/notroj/neon/commit/231a1d3f3f427b823753dc2e53adcf9cafda619b
Upstream-PR: https://github.com/notroj/neon/pull/118
Upstream-Commit: https://github.com/notroj/neon/commit/6f98a9c9bdd76fb3d367e3b01bcc45bea574c3d1