### PR TITLE
dev-python/sphinxcontrib-*: enable py3.12

### DIFF
--- a/dev-python/sphinxcontrib-httpdomain/sphinxcontrib-httpdomain-1.8.1.ebuild
+++ b/dev-python/sphinxcontrib-httpdomain/sphinxcontrib-httpdomain-1.8.1.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{10..12} )
 
 inherit distutils-r1
 

--- a/dev-python/sphinxcontrib-jquery/sphinxcontrib-jquery-4.1.ebuild
+++ b/dev-python/sphinxcontrib-jquery/sphinxcontrib-jquery-4.1.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 DISTUTILS_USE_PEP517=flit
 PYPI_NO_NORMALIZE=1
-PYTHON_COMPAT=( pypy3 python3_{9..11} )
+PYTHON_COMPAT=( pypy3 python3_{10..12} )
 
 inherit distutils-r1 pypi
 

--- a/dev-python/sphinxcontrib-programoutput/sphinxcontrib-programoutput-0.17-r1.ebuild
+++ b/dev-python/sphinxcontrib-programoutput/sphinxcontrib-programoutput-0.17-r1.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
 PYPI_NO_NORMALIZE=1
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{10..12} )
 
 inherit distutils-r1 pypi
 


### PR DESCRIPTION
few py3.12 enabled `dev-python/sphinxcontrib-*` packages. All tests pass for all supported python versions.