### PR TITLE
dev-lang/python: Fix configure in Prefix for 3.12

### DIFF
--- a/dev-lang/python/python-3.12.0_beta1.ebuild
+++ b/dev-lang/python/python-3.12.0_beta1.ebuild
@@ -5,7 +5,7 @@ EAPI="7"
 WANT_LIBTOOL="none"
 
 inherit autotools check-reqs flag-o-matic multiprocessing pax-utils
-inherit prefix python-utils-r1 toolchain-funcs verify-sig
+inherit python-utils-r1 toolchain-funcs verify-sig
 
 MY_PV=${PV/_beta/b}
 MY_P="Python-${MY_PV%_p*}"
@@ -301,7 +301,6 @@ src_configure() {
 		append-cppflags -I"${ESYSROOT}"/usr/include/ncursesw
 	fi
 
-	hprefixify setup.py
 	econf "${myeconfargs[@]}"
 
 	if grep -q "#define POSIX_SEMAPHORES_NOT_ENABLED 1" pyconfig.h; then

--- a/dev-lang/python/python-3.12.0_beta1_p1.ebuild
+++ b/dev-lang/python/python-3.12.0_beta1_p1.ebuild
@@ -5,7 +5,7 @@ EAPI="7"
 WANT_LIBTOOL="none"
 
 inherit autotools check-reqs flag-o-matic multiprocessing pax-utils
-inherit prefix python-utils-r1 toolchain-funcs verify-sig
+inherit python-utils-r1 toolchain-funcs verify-sig
 
 MY_PV=${PV/_beta/b}
 MY_P="Python-${MY_PV%_p*}"
@@ -301,7 +301,6 @@ src_configure() {
 		append-cppflags -I"${ESYSROOT}"/usr/include/ncursesw
 	fi
 
-	hprefixify setup.py
 	econf "${myeconfargs[@]}"
 
 	if grep -q "#define POSIX_SEMAPHORES_NOT_ENABLED 1" pyconfig.h; then


### PR DESCRIPTION
Upstream removed setup.py in 3.12 [1]. Attempting to use hprefixify on this now non-existent file causes:

```
>>> Configuring source in /prefix/var/tmp/portage/dev-lang/python-3.12.0_beta1_p1/work/Python-3.12.0b1 ...
 * Adjusting to prefix /prefix
 * ERROR: dev-lang/python-3.12.0_beta1_p1::gentoo failed (configure phase):
 *   setup.py does not exist
```

I also removed inherit on prefix.eclass now that it is unused. Tested this patch on an aarch64 prefix and it created no QA warnings.

[1] https://github.com/python/cpython/commit/81dca70d704d0834d8c30580e648a973250b2973