### PR TITLE
media-gfx/gimp: 9999, fix -Denable-default-bin type (true->enabled)

### DIFF
--- a/media-gfx/gimp/gimp-9999.ebuild
+++ b/media-gfx/gimp/gimp-9999.ebuild
@@ -157,7 +157,7 @@ src_configure() {
 	use vala && vala_setup
 
 	local emesonargs=(
-		-Denable-default-bin=true
+		-Denable-default-bin=enabled
 
 		-Dcheck-update=no
 		-Denable-multiproc=true


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/907302