### PR TITLE
profiles/features/musl: Extending list of masked nss packages under musl

### DIFF
--- a/profiles/features/musl/package.mask
+++ b/profiles/features/musl/package.mask
@@ -326,6 +326,16 @@ app-editors/jasspa-microemacs
 sys-apps/unscd
 sys-auth/libnss-nis
 sys-auth/sssd
+net-nds/nsscache
+sys-auth/libnss-cache
+sys-auth/libnss-mysql
+sys-auth/libnss-nis
+sys-auth/libnss-pgsql
+sys-auth/nss-mdns
+sys-auth/nss-myhostname
+sys-auth/nss-pam-ldapd
+sys-auth/nss_ldap
+dev-libs/nss-pem
 
 # Sergei Trofimovich <slyfox@gentoo.org> (2020-03-21)
 # Needs a port to musl. Uses glibc-specific termio and __getppid.


### PR DESCRIPTION
As musl has no support for nss subsystem.