### PR TITLE
dev-python/*: enable py3.12

### DIFF
--- a/dev-python/oauthlib/oauthlib-3.2.2.ebuild
+++ b/dev-python/oauthlib/oauthlib-3.2.2.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{10..12} )
 
 inherit distutils-r1 pypi
 

--- a/dev-python/parameterized/files/parameterized-0.9.0-py312-test.patch
+++ b/dev-python/parameterized/files/parameterized-0.9.0-py312-test.patch
@@ -1,0 +1,17 @@
+Remove the usage of assertRaisesRegexp unit test alias removed in Python 3.12
+
+Upstream-PR: https://github.com/wolever/parameterized/pull/169
+
+diff --git a/parameterized/test.py b/parameterized/test.py
+index 6c71f79..498c591 100644
+--- a/parameterized/test.py
++++ b/parameterized/test.py
+@@ -35,7 +35,7 @@ def assert_raises_regexp_decorator(expected_exception, expected_regexp):
+     def func_decorator(func):
+         @wraps(func)
+         def wrapper(self, *args, **kwargs):
+-            with self.assertRaisesRegexp(expected_exception, expected_regexp):
++            with self.assertRaisesRegex(expected_exception, expected_regexp):
+                 func(self, *args, **kwargs)
+ 
+         return wrapper

--- a/dev-python/parameterized/parameterized-0.9.0.ebuild
+++ b/dev-python/parameterized/parameterized-0.9.0.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( pypy3 python3_{9..11} )
+PYTHON_COMPAT=( pypy3 python3_{10..12} )
 
 inherit distutils-r1 pypi
 
@@ -23,5 +23,9 @@ BDEPEND="
 		dev-python/mock[${PYTHON_USEDEP}]
 	)
 "
+
+PATCHES=(
+	"${FILESDIR}/${P}-py312-test.patch"
+)
 
 distutils_enable_tests unittest

--- a/dev-python/pyjwt/pyjwt-2.7.0.ebuild
+++ b/dev-python/pyjwt/pyjwt-2.7.0.ebuild
@@ -6,7 +6,7 @@ EAPI=8
 DISTUTILS_USE_PEP517=setuptools
 PYPI_NO_NORMALIZE=1
 PYPI_PN="PyJWT"
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{10..12} )
 
 inherit distutils-r1 optfeature pypi
 

--- a/dev-python/requests-futures/requests-futures-1.0.0-r1.ebuild
+++ b/dev-python/requests-futures/requests-futures-1.0.0-r1.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
 PYPI_NO_NORMALIZE=1
-PYTHON_COMPAT=( python3_{9..11} pypy3 )
+PYTHON_COMPAT=( python3_{10..12} pypy3 )
 PYTHON_REQ_USE="threads(+)"
 
 inherit distutils-r1 pypi

--- a/dev-python/requests-mock/requests-mock-1.10.0-r1.ebuild
+++ b/dev-python/requests-mock/requests-mock-1.10.0-r1.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
 PYPI_NO_NORMALIZE=1
-PYTHON_COMPAT=( pypy3 python3_{10..11} )
+PYTHON_COMPAT=( pypy3 python3_{10..12} )
 
 inherit distutils-r1 pypi
 

--- a/dev-python/requests-oauthlib/requests-oauthlib-1.3.1.ebuild
+++ b/dev-python/requests-oauthlib/requests-oauthlib-1.3.1.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{10..12} )
 
 inherit distutils-r1
 

--- a/dev-python/requests-unixsocket/requests-unixsocket-0.3.0-r4.ebuild
+++ b/dev-python/requests-unixsocket/requests-unixsocket-0.3.0-r4.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
 PYPI_NO_NORMALIZE=1
-PYTHON_COMPAT=( python3_{9..11} pypy3 )
+PYTHON_COMPAT=( python3_{10..12} pypy3 )
 
 inherit distutils-r1 pypi
 


### PR DESCRIPTION
Rather simple batch of py3.12 enabled packages. Just two packages stand out
- `dev-python/parameterized` needs to patch test due to removed `assertRaisesRegexp` alias and
-  `dev-python/requests-futures` was necessary to test with `ALLOW_TEST=network`. I tested it multiple times, some test runs passed, few did not with an error: `AssertionError: 200 != 504`, but I believe it is because of unreliable test.