### PR TITLE
sys-apps/busybox: ignore cp -n error in postinstall

### DIFF
--- a/sys-apps/busybox/busybox-1.34.1-r1.ebuild
+++ b/sys-apps/busybox/busybox-1.34.1-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # See `man savedconfig.eclass` for info on how to use USE=savedconfig.
@@ -348,7 +348,9 @@ pkg_postinst() {
 		cd "${T}" || die
 		mkdir _install
 		tar xf busybox-links.tar -C _install || die
-		echo n | cp -ivpPR _install/* "${ROOT}"/ || die "copying links for ${x} failed"
+		# 907432: cp -n returns error if it skips any file, but that is expected here
+		# TODO: check if a new coreutils release has a replacement option
+		cp -nvpPR _install/* "${ROOT}"/
 	fi
 
 	if use sep-usr ; then

--- a/sys-apps/busybox/busybox-1.34.1-r2.ebuild
+++ b/sys-apps/busybox/busybox-1.34.1-r2.ebuild
@@ -355,7 +355,9 @@ pkg_postinst() {
 		cd "${T}" || die
 		mkdir _install
 		tar xf busybox-links.tar -C _install || die
-		echo n | cp -ivpPR _install/* "${ROOT}"/ || die "copying links for ${x} failed"
+		# 907432: cp -n returns error if it skips any file, but that is expected here
+		# TODO: check if a new coreutils release has a replacement option
+		cp -nvpPR _install/* "${ROOT}"/
 	fi
 
 	if use sep-usr ; then

--- a/sys-apps/busybox/busybox-1.35.0-r1.ebuild
+++ b/sys-apps/busybox/busybox-1.35.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # See `man savedconfig.eclass` for info on how to use USE=savedconfig.
@@ -349,7 +349,9 @@ pkg_postinst() {
 		cd "${T}" || die
 		mkdir _install
 		tar xf busybox-links.tar -C _install || die
-		echo n | cp -ivpPR _install/* "${ROOT}"/ || die "copying links for ${x} failed"
+		# 907432: cp -n returns error if it skips any file, but that is expected here
+		# TODO: check if a new coreutils release has a replacement option
+		cp -nvpPR _install/* "${ROOT}"/
 	fi
 
 	if use sep-usr ; then

--- a/sys-apps/busybox/busybox-1.35.0-r2.ebuild
+++ b/sys-apps/busybox/busybox-1.35.0-r2.ebuild
@@ -356,7 +356,9 @@ pkg_postinst() {
 		cd "${T}" || die
 		mkdir _install
 		tar xf busybox-links.tar -C _install || die
-		echo n | cp -ivpPR _install/* "${ROOT}"/ || die "copying links for ${x} failed"
+		# 907432: cp -n returns error if it skips any file, but that is expected here
+		# TODO: check if a new coreutils release has a replacement option
+		cp -nvpPR _install/* "${ROOT}"/
 	fi
 
 	if use sep-usr ; then

--- a/sys-apps/busybox/busybox-1.36.1.ebuild
+++ b/sys-apps/busybox/busybox-1.36.1.ebuild
@@ -346,7 +346,9 @@ pkg_postinst() {
 		cd "${T}" || die
 		mkdir _install
 		tar xf busybox-links.tar -C _install || die
-		echo n | cp -ivpPR _install/* "${ROOT}"/ || die "copying links for ${x} failed"
+		# 907432: cp -n returns error if it skips any file, but that is expected here
+		# TODO: check if a new coreutils release has a replacement option
+		cp -nvpPR _install/* "${ROOT}"/
 	fi
 
 	if use sep-usr ; then

--- a/sys-apps/busybox/busybox-9999.ebuild
+++ b/sys-apps/busybox/busybox-9999.ebuild
@@ -346,7 +346,9 @@ pkg_postinst() {
 		cd "${T}" || die
 		mkdir _install
 		tar xf busybox-links.tar -C _install || die
-		echo n | cp -ivpPR _install/* "${ROOT}"/ || die "copying links for ${x} failed"
+		# 907432: cp -n returns error if it skips any file, but that is expected here
+		# TODO: check if a new coreutils release has a replacement option
+		cp -nvpPR _install/* "${ROOT}"/
 	fi
 
 	if use sep-usr ; then


### PR DESCRIPTION
Before coreutils-9.3, cp -n (noclobber) would return success even if
skipping files.  Now it returns an error.

This is used in postinstall with the purpose of not replacing already
existing utilities with links to busybox, so failing here is expected.
Unfortunately we cannot distinguish this from other errors.