### PR TITLE
net-misc/tigervnc: one service per display

### DIFF
--- a/net-misc/tigervnc/files/tigervnc-1.13.1.confd
+++ b/net-misc/tigervnc/files/tigervnc-1.13.1.confd
@@ -1,0 +1,13 @@
+# Config file for /etc/init.d/tigervnc
+
+# Add the user(s) Xvnc(1) should be run for to /etc/tigervnc/vncserver.users
+# DISPLAYS is no loger used.
+
+# Optionally override the default Xsession file
+# TIGERVNC_XSESSION_FILE="/usr/share/sddm/scripts/Xsession"
+# TIGERVNC_XSESSION_FILE="/etc/gdm/Xsession"
+# TIGERVNC_XSESSION_FILE="/etc/lightdm/Xsession"
+# TIGERVNC_XSESSION_FILE="/usr/share/slim/Xsession"
+
+# vncsession no longer supports VNC_OPTS
+# Use /etc/tigervnc/vncserver-config-defaults or $HOME/.vnc/config instead

--- a/net-misc/tigervnc/files/tigervnc-1.13.1.initd
+++ b/net-misc/tigervnc/files/tigervnc-1.13.1.initd
@@ -1,0 +1,88 @@
+#!/sbin/openrc-run
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License, v2 or later
+
+# shellcheck shell=sh
+
+# Create symlinks for all displays.
+# For example for display :1, run `ln -s tigervnc /etc/init.d/tigervnc.1`
+# Then `rc-update add tigervnc.1 default`
+# For compatibility, /etc/init.d/tigervnc will start all displays.
+
+DISPLAYS=${SVCNAME#*.}
+if [ "$DISPLAYS" = "tigervnc" ]; then
+	should_warn=1
+	DISPLAYS=$(grep -v "^#" /etc/tigervnc/vncserver.users | sed -e 's/=.*//' -e 's/^://')
+fi
+
+depend() {
+	need net
+}
+
+checkconfig() {
+	if [ -n "${DISPLAYS}" ]; then
+		if [ "$1" = "start" ]; then
+			for display in $DISPLAYS; do
+				user="$(grep "^:${display}" /etc/tigervnc/vncserver.users)"
+				user=${user#*=}
+				# bug #690046
+				if [ -z "${user}" ]; then
+					eerror "User is not defined for display :${display} in /etc/tigervnc/vncserver.users"
+					return 1
+				elif ! runuser -l "${user}" -c "[ -f ~/.vnc/passwd ]"; then
+					eerror "There are no passwords defined for user ${user}."
+					return 1
+				elif [ -e "/tmp/.X11-unix/X${display}" ]; then
+					eerror "Display :${display} appears to be already in use because of /tmp/.X11-unix/X${display}"
+					eerror "Remove this file if there is no X server for :${display}"
+					return 1
+				elif [ -e "/tmp/.X${display}-lock" ]; then
+					eerror "Display :${display} appears to be already in use because of /tmp/.X${display}-lock"
+					eerror "Remove this file if there is no X server for :${display}"
+					return 1
+				fi
+				FREEDISPLAYS="${FREEDISPLAYS} ${display}"
+			done
+		fi
+		return 0
+	else
+		eerror 'There are no displays configured in /etc/tigervnc/vncserver.users'
+		return 1
+	fi
+}
+
+checkwarn() {
+	if [ "${should_warn}" = "1" ]; then
+		ewarn 'Running /etc/init.d/tigervnc in compatibility mode'
+		ewarn 'Please migrate to one service per display as detailed here:'
+		ewarn 'https://wiki.gentoo.org/wiki/TigerVNC#Migrating_from_1.13.1-r2_or_lower:'
+	fi
+}
+
+start() {
+	checkwarn
+	FREEDISPLAYS=""
+	checkconfig start || return 1
+	for display in $FREEDISPLAYS; do
+		[ -n "${TIGERVNC_XSESSION_FILE}" ] && export TIGERVNC_XSESSION_FILE
+		ebegin "Starting TigerVNC server :${display}"
+		start-stop-daemon --start --pidfile=/run/vncsession-":${display}".pid /usr/libexec/vncsession-start -- ":${display}"
+		eend $?
+	done
+}
+
+stop() {
+	checkconfig stop || return 2
+	for display in $DISPLAYS; do
+		ebegin "Stopping TigerVNC server :${display}"
+		start-stop-daemon --stop --pidfile=/run/vncsession-":${display}".pid
+		eend $?
+	done
+	# Do not fail if a server is missing
+	/bin/true
+}
+
+restart() {
+        svc_stop
+        svc_start
+}

--- a/net-misc/tigervnc/tigervnc-1.13.1-r3.ebuild
+++ b/net-misc/tigervnc/tigervnc-1.13.1-r3.ebuild
@@ -217,7 +217,10 @@ src_install() {
 pkg_postinst() {
 	xdg_pkg_postinst
 
-	use server && elog 'OpenRC users: please migrate to one service per display as documented here'	#FIXME: add link
+	use server && {
+		elog 'OpenRC users: please migrate to one service per display as documented here:'
+		elog 'https://wiki.gentoo.org/wiki/TigerVNC#Migrating_from_1.13.1-r2_or_lower:'
+	}
 
 	local OPTIONAL_DM="gnome-base/gdm x11-misc/lightdm x11-misc/sddm x11-misc/slim"
 	use server && \


### PR DESCRIPTION
Change configuration for openrc users.

Currently, it has 3 drawbacks:
- the sessions must be defined in 2 places
- if a display crashes, it cannot be restarted without stopping all of them
- openrc only keeps track of the last display started, so if any other display crashes, it will not show as crashed.

The first issue is solved by no longer using DISPLAYS from `conf.d`, and parsing `/etc/tigervnc/vncserver.users` directly.

The other two by switching to a one service per display model.