### PR TITLE
app-emulation/libvirt: Fix IP_NF_TARGET_MASQUERADE check

### DIFF
--- a/app-emulation/libvirt/libvirt-8.7.0-r1.ebuild
+++ b/app-emulation/libvirt/libvirt-8.7.0-r1.ebuild
@@ -191,10 +191,21 @@ pkg_setup() {
 		~IP_NF_FILTER
 		~IP_NF_MANGLE
 		~IP_NF_NAT
-		~IP_NF_TARGET_MASQUERADE
 		~IP6_NF_FILTER
 		~IP6_NF_MANGLE
 		~IP6_NF_NAT"
+
+	# This was renamed in kernel commit v5.2-rc1~133^2~174^2~6
+	if use virt-network ; then
+		if kernel_is -lt 5 2 ; then
+			CONFIG_CHECK+="
+			~IP_NF_TARGET_MASQUERADE"
+		else
+			CONFIG_CHECK+="
+			~NETFILTER_XT_TARGET_MASQUERADE"
+		fi
+	fi
+
 	# Bandwidth Limiting Support
 	use virt-network && CONFIG_CHECK+="
 		~BRIDGE_EBT_T_NAT

--- a/app-emulation/libvirt/libvirt-8.8.0-r1.ebuild
+++ b/app-emulation/libvirt/libvirt-8.8.0-r1.ebuild
@@ -191,10 +191,21 @@ pkg_setup() {
 		~IP_NF_FILTER
 		~IP_NF_MANGLE
 		~IP_NF_NAT
-		~IP_NF_TARGET_MASQUERADE
 		~IP6_NF_FILTER
 		~IP6_NF_MANGLE
 		~IP6_NF_NAT"
+
+	# This was renamed in kernel commit v5.2-rc1~133^2~174^2~6
+	if use virt-network ; then
+		if kernel_is -lt 5 2 ; then
+			CONFIG_CHECK+="
+			~IP_NF_TARGET_MASQUERADE"
+		else
+			CONFIG_CHECK+="
+			~NETFILTER_XT_TARGET_MASQUERADE"
+		fi
+	fi
+
 	# Bandwidth Limiting Support
 	use virt-network && CONFIG_CHECK+="
 		~BRIDGE_EBT_T_NAT

--- a/app-emulation/libvirt/libvirt-8.9.0-r2.ebuild
+++ b/app-emulation/libvirt/libvirt-8.9.0-r2.ebuild
@@ -198,10 +198,21 @@ pkg_setup() {
 		~IP_NF_FILTER
 		~IP_NF_MANGLE
 		~IP_NF_NAT
-		~IP_NF_TARGET_MASQUERADE
 		~IP6_NF_FILTER
 		~IP6_NF_MANGLE
 		~IP6_NF_NAT"
+
+	# This was renamed in kernel commit v5.2-rc1~133^2~174^2~6
+	if use virt-network ; then
+		if kernel_is -lt 5 2 ; then
+			CONFIG_CHECK+="
+			~IP_NF_TARGET_MASQUERADE"
+		else
+			CONFIG_CHECK+="
+			~NETFILTER_XT_TARGET_MASQUERADE"
+		fi
+	fi
+
 	# Bandwidth Limiting Support
 	use virt-network && CONFIG_CHECK+="
 		~BRIDGE_EBT_T_NAT

--- a/app-emulation/libvirt/libvirt-8.9.0.ebuild
+++ b/app-emulation/libvirt/libvirt-8.9.0.ebuild
@@ -194,10 +194,21 @@ pkg_setup() {
 		~IP_NF_FILTER
 		~IP_NF_MANGLE
 		~IP_NF_NAT
-		~IP_NF_TARGET_MASQUERADE
 		~IP6_NF_FILTER
 		~IP6_NF_MANGLE
 		~IP6_NF_NAT"
+
+	# This was renamed in kernel commit v5.2-rc1~133^2~174^2~6
+	if use virt-network ; then
+		if kernel_is -lt 5 2 ; then
+			CONFIG_CHECK+="
+			~IP_NF_TARGET_MASQUERADE"
+		else
+			CONFIG_CHECK+="
+			~NETFILTER_XT_TARGET_MASQUERADE"
+		fi
+	fi
+
 	# Bandwidth Limiting Support
 	use virt-network && CONFIG_CHECK+="
 		~BRIDGE_EBT_T_NAT

--- a/app-emulation/libvirt/libvirt-9.2.0.ebuild
+++ b/app-emulation/libvirt/libvirt-9.2.0.ebuild
@@ -197,10 +197,21 @@ pkg_setup() {
 		~IP_NF_FILTER
 		~IP_NF_MANGLE
 		~IP_NF_NAT
-		~IP_NF_TARGET_MASQUERADE
 		~IP6_NF_FILTER
 		~IP6_NF_MANGLE
 		~IP6_NF_NAT"
+
+	# This was renamed in kernel commit v5.2-rc1~133^2~174^2~6
+	if use virt-network ; then
+		if kernel_is -lt 5 2 ; then
+			CONFIG_CHECK+="
+			~IP_NF_TARGET_MASQUERADE"
+		else
+			CONFIG_CHECK+="
+			~NETFILTER_XT_TARGET_MASQUERADE"
+		fi
+	fi
+
 	# Bandwidth Limiting Support
 	use virt-network && CONFIG_CHECK+="
 		~BRIDGE_EBT_T_NAT

--- a/app-emulation/libvirt/libvirt-9.3.0.ebuild
+++ b/app-emulation/libvirt/libvirt-9.3.0.ebuild
@@ -198,10 +198,21 @@ pkg_setup() {
 		~IP_NF_FILTER
 		~IP_NF_MANGLE
 		~IP_NF_NAT
-		~IP_NF_TARGET_MASQUERADE
 		~IP6_NF_FILTER
 		~IP6_NF_MANGLE
 		~IP6_NF_NAT"
+
+	# This was renamed in kernel commit v5.2-rc1~133^2~174^2~6
+	if use virt-network ; then
+		if kernel_is -lt 5 2 ; then
+			CONFIG_CHECK+="
+			~IP_NF_TARGET_MASQUERADE"
+		else
+			CONFIG_CHECK+="
+			~NETFILTER_XT_TARGET_MASQUERADE"
+		fi
+	fi
+
 	# Bandwidth Limiting Support
 	use virt-network && CONFIG_CHECK+="
 		~BRIDGE_EBT_T_NAT

--- a/app-emulation/libvirt/libvirt-9999.ebuild
+++ b/app-emulation/libvirt/libvirt-9999.ebuild
@@ -198,10 +198,21 @@ pkg_setup() {
 		~IP_NF_FILTER
 		~IP_NF_MANGLE
 		~IP_NF_NAT
-		~IP_NF_TARGET_MASQUERADE
 		~IP6_NF_FILTER
 		~IP6_NF_MANGLE
 		~IP6_NF_NAT"
+
+	# This was renamed in kernel commit v5.2-rc1~133^2~174^2~6
+	if use virt-network ; then
+		if kernel_is -lt 5 2 ; then
+			CONFIG_CHECK+="
+			~IP_NF_TARGET_MASQUERADE"
+		else
+			CONFIG_CHECK+="
+			~NETFILTER_XT_TARGET_MASQUERADE"
+		fi
+	fi
+
 	# Bandwidth Limiting Support
 	use virt-network && CONFIG_CHECK+="
 		~BRIDGE_EBT_T_NAT


### PR DESCRIPTION
As of kernel commit v5.2-rc1~133^2~174^2~6 the
IP_NF_TARGET_MASQUERADE is just an alias for
NETFILTER_XT_TARGET_MASQUERADE:

  config IP_NF_TARGET_MASQUERADE
    tristate "MASQUERADE target support"
    select NETFILTER_XT_TARGET_MASQUERADE
    help
    This is a backwards-compat option for the user's convenience
    (e.g. when running oldconfig). It selects NETFILTER_XT_TARGET_MASQUERADE.

Fine tune our kernel config checks, though this can be changed once kernels older than 5.2.0 leave the tree.

Closes: https://bugs.gentoo.org/907728