### PR TITLE
dev-db/etcd-3.5.9 version bump

### DIFF
--- a/dev-db/etcd/etcd-3.5.9.ebuild
+++ b/dev-db/etcd/etcd-3.5.9.ebuild
@@ -1,0 +1,87 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+inherit go-module systemd tmpfiles
+GIT_COMMIT=a603c0798
+
+DESCRIPTION="Highly-available key value store for shared configuration and service discovery"
+HOMEPAGE="https://github.com/etcd-io/etcd"
+SRC_URI="https://github.com/etcd-io/etcd/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+SRC_URI+=" etcd-3.5.9-deps.tar.xz"
+
+LICENSE="Apache-2.0 BSD BSD-2 MIT"
+SLOT="0"
+KEYWORDS="~amd64 ~riscv"
+IUSE="doc +server"
+
+COMMON_DEPEND="server? (
+	acct-group/etcd
+	acct-user/etcd
+	)"
+DEPEND="${COMMON_DEPEND}"
+RDEPEND="${COMMON_DEPEND}"
+
+# Tests fail with this error:
+# fatal error: checkptr: unsafe pointer conversion
+RESTRICT="test"
+
+PATCHES=(
+	"${FILESDIR}"/etcd-3.5.9-no-gobin.patch
+	"${FILESDIR}"/etcd-3.5.9-respect-go-env-vars.patch
+)
+
+src_prepare() {
+	export GO_BUILD_FLAGS="-v -x"
+	default
+	sed -e "s|GIT_SHA=.*|GIT_SHA=${GIT_COMMIT}|"\
+		-i "${S}"/build || die
+	sed -e 's:\(for p in \)shellcheck :\1 :' \
+		-e 's:^			gofmt \\$:\\:' \
+		-e 's:^			govet \\$:\\:' \
+		-e 's:^			govet_shadow \\$:\\:' \
+		-i "${S}"/test || die
+
+	sed -e "s|GO_BUILD_FLAGS=\"[^\"]*\"|GO_BUILD_FLAGS=\"${GO_BUILD_FLAGS}\"|" \
+		-e "s|go test |go test ${GO_BUILD_FLAGS} |" \
+		-i ./test || die
+}
+
+src_compile() {
+	./build.sh || die
+	#ego build
+}
+
+src_test() {
+	./test || die
+}
+
+src_install() {
+	ego install
+
+	dobin bin/etcdctl
+	use doc && dodoc -r Documentation
+	if use server; then
+		insinto /etc/${PN}
+		sed -e 's|^data-dir:|\0 /var/lib/etcd|' -i etcd.conf.yml.sample || die
+		newins etcd.conf.yml.sample etcd.conf.yml
+		dobin bin/etcd
+		dodoc README.md
+		systemd_newunit "${FILESDIR}/${PN}.service-r1" "${PN}.service"
+		newtmpfiles "${FILESDIR}/${PN}.tmpfiles.d.conf" ${PN}.conf
+		newinitd "${FILESDIR}"/${PN}.initd-r1 ${PN}
+		newconfd "${FILESDIR}"/${PN}.confd-r1 ${PN}
+		insinto /etc/logrotate.d
+		newins "${FILESDIR}/${PN}.logrotated" "${PN}"
+		keepdir /var/lib/${PN} /var/log/${PN}
+		fowners ${PN}:${PN} /var/lib/${PN} /var/log/${PN}
+		fperms 0700 /var/lib/${PN}
+		fperms 0755 /var/log/${PN}
+	fi
+}
+
+pkg_postinst() {
+	if use server; then
+		tmpfiles_process ${PN}.conf
+	fi
+}

--- a/dev-db/etcd/files/etcd-3.5.9-no-gobin.patch
+++ b/dev-db/etcd/files/etcd-3.5.9-no-gobin.patch
@@ -1,0 +1,32 @@
+--- a/scripts/test_lib.sh
++++ b/scripts/test_lib.sh
+@@ -305,11 +305,6 @@ function tool_exists {
+   fi
+ }
+ 
+-# Ensure gobin is available, as it runs majority of the tools
+-if ! command -v "gobin" >/dev/null; then
+-    run env GO111MODULE=off go get github.com/myitcv/gobin || exit 1
+-fi
+-
+ # tool_get_bin [tool] - returns absolute path to a tool binary (or returns error)
+ function tool_get_bin {
+   local tool="$1"
+--- a/tests/Dockerfile
++++ b/tests/Dockerfile
+@@ -44,7 +44,6 @@ WORKDIR ${GOPATH}/src/go.etcd.io/etcd
+ 
+ ADD ./scripts/install-marker.sh /tmp/install-marker.sh
+ 
+-RUN GO111MODULE=off go get github.com/myitcv/gobin
+ RUN /tmp/install-marker.sh amd64 \
+   && rm -f /tmp/install-marker.sh \
+   && curl -s https://codecov.io/bash >/codecov \
+--- a/tools/mod/install_all.sh
++++ b/tools/mod/install_all.sh
+@@ -1,4 +1,4 @@
+ #!/usr/bin/env bash
+ 
+ cd ./tools/mod || exit 2
+-go list --tags tools -f '{{ join .Imports "\n" }}' | xargs gobin -p
++go list --tags tools -f '{{ join .Imports "\n" }}' | xargs go install

--- a/dev-db/etcd/files/etcd-3.5.9-respect-go-env-vars.patch
+++ b/dev-db/etcd/files/etcd-3.5.9-respect-go-env-vars.patch
@@ -1,0 +1,33 @@
+--- a/build.sh
++++ b/build.sh
+@@ -18,7 +18,7 @@ GOARCH=${GOARCH:-$(go env GOARCH)}
+ # Set GO_LDFLAGS="-s" for building without symbols for debugging.
+ # shellcheck disable=SC2206
+ GO_LDFLAGS=(${GO_LDFLAGS:-} "-X=${VERSION_SYMBOL}=${GIT_SHA}")
+-GO_BUILD_ENV=("CGO_ENABLED=0" "GO_BUILD_FLAGS=${GO_BUILD_FLAGS:-}" "GOOS=${GOOS}" "GOARCH=${GOARCH}")
++GO_BUILD_ENV=("CGO_ENABLED=0" "GO_BUILD_FLAGS=${GO_BUILD_FLAGS:-}" "GOOS=${GOOS}" "GOARCH=${GOARCH}" "GO111MODULE=${GO111MODULE}" "GOCACHE=${GOCACHE}" "GOMODCACHE=${GOMODCACHE}")
+ 
+ # enable/disable failpoints
+ toggle_failpoints() {
+diff --git a/build.sh b/build.sh
+index 19f715f..f04dc3a 100755
+--- a/build.sh
++++ b/build.sh
+@@ -100,7 +100,7 @@ tools_build() {
+     echo "Building" "'${tool}'"...
+     run rm -f "${out}/${tool}"
+     # shellcheck disable=SC2086
+-    run env GO_BUILD_FLAGS="${GO_BUILD_FLAGS:-}" CGO_ENABLED=0 go build ${GO_BUILD_FLAGS:-} \
++    run env GO_BUILD_FLAGS="${GO_BUILD_FLAGS:-}" CGO_ENABLED=0 "${GO_BUILD_ENV[@]}" go build ${GO_BUILD_FLAGS:-} \
+       -trimpath \
+       -installsuffix=cgo \
+       "-ldflags=${GO_LDFLAGS[*]}" \
+@@ -124,7 +124,7 @@ tests_build() {
+       run rm -f "../${out}/${tool}"
+ 
+       # shellcheck disable=SC2086
+-      run env CGO_ENABLED=0 GO_BUILD_FLAGS="${GO_BUILD_FLAGS:-}" go build ${GO_BUILD_FLAGS:-} \
++      run env CGO_ENABLED=0 GO_BUILD_FLAGS="${GO_BUILD_FLAGS:-}" "${GO_BUILD_ENV[@]}" go build ${GO_BUILD_FLAGS:-} \
+         -installsuffix=cgo \
+         "-ldflags=${GO_LDFLAGS[*]}" \
+         -o="../${out}/${tool}" "./${tool}" || return 2


### PR DESCRIPTION
first i want to say thanks to sam_ for all his help to get  this done.

i created a repo for the dependencies .tar.xz at https://github.com/kfirufk/etcd_3_5_9-deps

there are still 2 issues that should be resolved/understood:

1. the all build phase shows the output as stderr, the installation phase also compile stuff but shows the output properly.
2. etcd complains about .keep files at /var/lib/etcd, i personally verified that these errors don't block etcd from starting but we need understand how we want to address this. not having a /var/lib/etcd directory at all will block etcd from starting.

thank you.