### PR TITLE
www-client/links: fix lzip dependency

### DIFF
--- a/www-client/links/links-2.28-r3.ebuild
+++ b/www-client/links/links-2.28-r3.ebuild
@@ -47,7 +47,7 @@ RDEPEND="
 		media-libs/libjpeg-turbo:=
 	)
 	lzip? (
-		app-arch/lzip
+		app-arch/lzlib
 	)
 	lzma? (
 		app-arch/xz-utils

--- a/www-client/links/links-2.29.ebuild
+++ b/www-client/links/links-2.29.ebuild
@@ -50,7 +50,7 @@ RDEPEND="
 		media-libs/libjpeg-turbo:=
 	)
 	lzip? (
-		app-arch/lzip
+		app-arch/lzlib
 	)
 	lzma? (
 		app-arch/xz-utils

--- a/www-client/links/metadata.xml
+++ b/www-client/links/metadata.xml
@@ -14,6 +14,6 @@
   <flag name="brotli">Enable <pkg>app-arch/brotli</pkg> support</flag>
   <flag name="freetype">Enable <pkg>media-libs/freetype</pkg> support</flag>
   <flag name="libevent">Enable <pkg>dev-libs/libevent</pkg> support</flag>
-  <flag name="lzip">Enable <pkg>app-arch/lzip</pkg> support</flag>
+  <flag name="lzip">Enable lzip support via <pkg>app-arch/lzlib</pkg></flag>
 </use>
 </pkgmetadata>


### PR DESCRIPTION
it depends on the lzlib library, not the lzip binary.