### PR TITLE
www-client/firefox: fix the build with musl-1.2.4

### DIFF
--- a/www-client/firefox/files/firefox-113.0.2-musl-1.2.4-getrandom.patch
+++ b/www-client/firefox/files/firefox-113.0.2-musl-1.2.4-getrandom.patch
@@ -1,0 +1,49 @@
+https://github.com/rust-random/getrandom/pull/326
+https://github.com/rust-random/getrandom/commit/7f73e3ccc1f53bfc419e4ddcfd343766aa5837b6
+
+From 7c80ae7cae663e5b85dcd953f3e93b13ed5b1b8e Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Wed, 28 Dec 2022 21:44:17 -0800
+Subject: [PATCH] Use open instead of open64
+
+glibc is providing open64 and other lfs64 functions but musl aliases
+them to normal equivalents since off_t is always 64-bit on musl,
+therefore check for target env along when target OS is linux before
+using open64, this is more available. Latest Musl has made these
+namespace changes [1]
+
+There is no need for using LFS64 open explicitly as we are only using it
+for opening device files and not real files
+
+[1] https://git.musl-libc.org/cgit/musl/commit/?id=246f1c811448f37a44b41cd8df8d0ef9736d95f4
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ src/util_libc.rs | 10 +---------
+ 1 file changed, 1 insertion(+), 9 deletions(-)
+
+diff --git a/src/util_libc.rs b/src/util_libc.rs
+index 63b060e7..bd9c7de1 100644
+--- a/third_party/rust/getrandom/src/util_libc.rs
++++ b/third_party/rust/getrandom/src/util_libc.rs
+@@ -140,19 +140,11 @@ impl Weak {
+     }
+ }
+ 
+-cfg_if! {
+-    if #[cfg(any(target_os = "linux", target_os = "emscripten"))] {
+-        use libc::open64 as open;
+-    } else {
+-        use libc::open;
+-    }
+-}
+-
+ // SAFETY: path must be null terminated, FD must be manually closed.
+ pub unsafe fn open_readonly(path: &str) -> Result<libc::c_int, Error> {
+     debug_assert_eq!(path.as_bytes().last(), Some(&0));
+     loop {
+-        let fd = open(path.as_ptr() as *const _, libc::O_RDONLY | libc::O_CLOEXEC);
++        let fd = libc::open(path.as_ptr() as *const _, libc::O_RDONLY | libc::O_CLOEXEC);
+         if fd >= 0 {
+             return Ok(fd);
+         }

--- a/www-client/firefox/firefox-113.0.2.ebuild
+++ b/www-client/firefox/firefox-113.0.2.ebuild
@@ -649,6 +649,9 @@ src_prepare() {
 	! use ppc64 && rm -v "${WORKDIR}"/firefox-patches/*bmo-1775202-ppc64*.patch
 
 	eapply "${WORKDIR}/firefox-patches"
+	eapply "${FILESDIR}"/${PN}-113.0.2-musl-1.2.4-getrandom.patch
+	sed -e 's/2a63ac0e6dab16b85c4728b79a16e0640301e8b876f151b0a1db0b4394fa219f/a47b20e73637fed248405650f56358f3339e511b217b7ba80e32011d8ee2ca22/' \
+		-i third_party/rust/getrandom/.cargo-checksum.json
 
 	# Allow user to apply any additional patches without modifing ebuild
 	eapply_user


### PR DESCRIPTION
Upstream-PR: https://github.com/rust-random/getrandom/pull/326
Upstream-Commit: https://github.com/rust-random/getrandom/commit/7f73e3ccc1f53bfc419e4ddcfd343766aa5837b6

Same getrandom patch from PR https://github.com/gentoo/gentoo/pull/31205.