### PR TITLE
net-libs/neon: apply patches

### DIFF
--- a/net-libs/neon/neon-0.32.4.ebuild
+++ b/net-libs/neon/neon-0.32.4.ebuild
@@ -56,7 +56,7 @@ src_prepare() {
 		sed -e "s/T(pkcs11)/T_XFAIL(pkcs11)/" -i test/ssl.c || die
 	fi
 
-	eapply_user
+	default
 
 	AT_M4DIR="macros" eautoreconf
 


### PR DESCRIPTION
This was accidentally missed in the previous PR https://github.com/gentoo/gentoo/pull/31230.

Fixes: https://github.com/gentoo/gentoo/commit/59879db8e97318941bd2da04d53878cf04c47202
Bug: https://bugs.gentoo.org/832851
Bug: https://bugs.gentoo.org/903001