### PR TITLE
dev-pyhon/*: enable py3.12

### DIFF
--- a/dev-python/comm/comm-0.1.3.ebuild
+++ b/dev-python/comm/comm-0.1.3.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=hatchling
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{10..12} )
 
 inherit distutils-r1
 

--- a/dev-python/cppy/cppy-1.2.1-r1.ebuild
+++ b/dev-python/cppy/cppy-1.2.1-r1.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} pypy3 )
+PYTHON_COMPAT=( python3_{10..12} pypy3 )
 
 inherit distutils-r1 pypi
 

--- a/dev-python/cppy/cppy-1.2.1-r1.ebuild
+++ b/dev-python/cppy/cppy-1.2.1-r1.ebuild
@@ -9,7 +9,10 @@ PYTHON_COMPAT=( python3_{10..12} pypy3 )
 inherit distutils-r1 pypi
 
 DESCRIPTION="C++ header library which makes it easier to write Python extension modules"
-HOMEPAGE="https://pypi.org/project/cppy/"
+HOMEPAGE="
+	https://pypi.org/project/cppy/
+	https://github.com/nucleic/cppy/
+"
 
 LICENSE="BSD"
 SLOT="0"

--- a/dev-python/cppy/metadata.xml
+++ b/dev-python/cppy/metadata.xml
@@ -9,6 +9,7 @@
 		A small C++ header library which makes it easier to write Python extension modules. The primary feature is a PyObject smart pointer which automatically handles reference counting and provides convenience methods for performing common object operations.
 	</longdescription>
 	<upstream>
+		<remote-id type="github">nucleic/cppy</remote-id>
 		<remote-id type="pypi">cppy</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/dev-python/filetype/filetype-1.2.0.ebuild
+++ b/dev-python/filetype/filetype-1.2.0.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{10..12} )
 
 inherit distutils-r1 pypi
 

--- a/dev-python/kiwisolver/kiwisolver-1.4.4-r1.ebuild
+++ b/dev-python/kiwisolver/kiwisolver-1.4.4-r1.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 DISTUTILS_EXT=1
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} pypy3 )
+PYTHON_COMPAT=( python3_{10..12} pypy3 )
 
 inherit distutils-r1
 

--- a/dev-python/mypy_extensions/mypy_extensions-1.0.0.ebuild
+++ b/dev-python/mypy_extensions/mypy_extensions-1.0.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{9..11} pypy3 )
+PYTHON_COMPAT=( python3_{10..12} pypy3 )
 DISTUTILS_USE_PEP517=setuptools
 
 inherit distutils-r1

--- a/dev-python/serpent/serpent-1.41.ebuild
+++ b/dev-python/serpent/serpent-1.41.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} pypy3 )
+PYTHON_COMPAT=( python3_{10..12} pypy3 )
 
 inherit distutils-r1 pypi
 

--- a/dev-python/traitlets/traitlets-5.9.0.ebuild
+++ b/dev-python/traitlets/traitlets-5.9.0.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=hatchling
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{10..12} )
 
 inherit distutils-r1 pypi
 

--- a/dev-python/xxhash/xxhash-3.2.0.ebuild
+++ b/dev-python/xxhash/xxhash-3.2.0.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 DISTUTILS_EXT=1
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{10..12} )
 
 inherit distutils-r1 pypi
 

--- a/dev-python/zope-component/zope-component-6.0.ebuild
+++ b/dev-python/zope-component/zope-component-6.0.ebuild
@@ -6,7 +6,7 @@ EAPI=8
 DISTUTILS_USE_PEP517=setuptools
 PYPI_NO_NORMALIZE=1
 PYPI_PN=${PN/-/.}
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{10..12} )
 
 inherit distutils-r1 pypi
 

--- a/dev-python/zope-configuration/zope-configuration-5.0.ebuild
+++ b/dev-python/zope-configuration/zope-configuration-5.0.ebuild
@@ -6,7 +6,7 @@ EAPI=8
 DISTUTILS_USE_PEP517=setuptools
 PYPI_NO_NORMALIZE=1
 PYPI_PN=${PN/-/.}
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{10..12} )
 
 inherit distutils-r1 pypi
 

--- a/dev-python/zope-deprecation/zope-deprecation-5.0.ebuild
+++ b/dev-python/zope-deprecation/zope-deprecation-5.0.ebuild
@@ -6,7 +6,7 @@ EAPI=8
 DISTUTILS_USE_PEP517=setuptools
 PYPI_NO_NORMALIZE=1
 PYPI_PN=${PN/-/.}
-PYTHON_COMPAT=( python3_{9..11} pypy3 )
+PYTHON_COMPAT=( python3_{10..12} pypy3 )
 
 inherit distutils-r1 pypi
 

--- a/dev-python/zope-exceptions/zope-exceptions-4.6.ebuild
+++ b/dev-python/zope-exceptions/zope-exceptions-4.6.ebuild
@@ -6,7 +6,7 @@ EAPI=8
 DISTUTILS_USE_PEP517=setuptools
 PYPI_NO_NORMALIZE=1
 PYPI_PN=${PN/-/.}
-PYTHON_COMPAT=( python3_{9..11} pypy3 )
+PYTHON_COMPAT=( python3_{10..12} pypy3 )
 
 inherit distutils-r1 pypi
 

--- a/dev-python/zope-hookable/zope-hookable-5.4.ebuild
+++ b/dev-python/zope-hookable/zope-hookable-5.4.ebuild
@@ -7,7 +7,7 @@ DISTUTILS_EXT=1
 DISTUTILS_USE_PEP517=setuptools
 PYPI_NO_NORMALIZE=1
 PYPI_PN=${PN/-/.}
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{10..12} )
 
 inherit distutils-r1 pypi
 

--- a/dev-python/zope-i18nmessageid/zope-i18nmessageid-6.0.1.ebuild
+++ b/dev-python/zope-i18nmessageid/zope-i18nmessageid-6.0.1.ebuild
@@ -7,7 +7,7 @@ DISTUTILS_EXT=1
 DISTUTILS_USE_PEP517=setuptools
 PYPI_NO_NORMALIZE=1
 PYPI_PN=${PN/-/.}
-PYTHON_COMPAT=( python3_{9..11} pypy3 )
+PYTHON_COMPAT=( python3_{10..12} pypy3 )
 
 inherit distutils-r1 pypi
 

--- a/dev-python/zope-schema/zope-schema-7.0.1.ebuild
+++ b/dev-python/zope-schema/zope-schema-7.0.1.ebuild
@@ -6,7 +6,7 @@ EAPI=8
 DISTUTILS_USE_PEP517=setuptools
 PYPI_NO_NORMALIZE=1
 PYPI_PN=${PN/-/.}
-PYTHON_COMPAT=( python3_{9..11} pypy3 )
+PYTHON_COMPAT=( python3_{10..12} pypy3 )
 
 inherit distutils-r1 pypi
 


### PR DESCRIPTION
Enable py3.12 in few `dev-python/*` packages, tests pass in all supported python versions.