### PR TITLE
dev-python/*: enable py3.12

### DIFF
--- a/dev-python/aniso8601/aniso8601-9.0.1-r1.ebuild
+++ b/dev-python/aniso8601/aniso8601-9.0.1-r1.ebuild
@@ -3,13 +3,16 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{9..11} pypy3 )
+PYTHON_COMPAT=( python3_{10..12} pypy3 )
 DISTUTILS_USE_PEP517=setuptools
 
 inherit distutils-r1 pypi
 
 DESCRIPTION="A library for parsing ISO 8601 strings"
-HOMEPAGE="https://bitbucket.org/nielsenb/aniso8601/ https://pypi.org/project/aniso8601/"
+HOMEPAGE="
+	https://bitbucket.org/nielsenb/aniso8601/
+	https://pypi.org/project/aniso8601/
+"
 
 LICENSE="GPL-3+"
 SLOT="0"

--- a/dev-python/deprecation/deprecation-2.1.0-r1.ebuild
+++ b/dev-python/deprecation/deprecation-2.1.0-r1.ebuild
@@ -1,0 +1,29 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DISTUTILS_USE_PEP517=setuptools
+PYTHON_COMPAT=( pypy3 python3_{10..12} )
+inherit distutils-r1 pypi
+
+DESCRIPTION="A library to handle automated deprecations"
+HOMEPAGE="
+	https://deprecation.readthedocs.io/
+	https://github.com/briancurtin/deprecation/
+	https://pypi.org/project/deprecation/
+"
+
+LICENSE="Apache-2.0"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+
+RDEPEND="dev-python/packaging[${PYTHON_USEDEP}]"
+
+distutils_enable_sphinx docs
+distutils_enable_tests unittest
+
+src_prepare() {
+	sed -i -e 's:unittest2:unittest:' tests/test_deprecation.py || die
+	distutils-r1_src_prepare
+}

--- a/dev-python/extras/extras-1.0.0-r2.ebuild
+++ b/dev-python/extras/extras-1.0.0-r2.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} pypy3 )
+PYTHON_COMPAT=( python3_{10..12} pypy3 )
 
 inherit distutils-r1 pypi
 

--- a/dev-python/eyeD3/eyeD3-0.9.7.ebuild
+++ b/dev-python/eyeD3/eyeD3-0.9.7.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=poetry
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{10..12} )
 
 inherit distutils-r1
 

--- a/dev-python/imapclient/imapclient-2.3.1.ebuild
+++ b/dev-python/imapclient/imapclient-2.3.1.ebuild
@@ -4,13 +4,19 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{10..12} )
 
 inherit distutils-r1
 
 DESCRIPTION="easy-to-use, pythonic, and complete IMAP client library"
-HOMEPAGE="https://github.com/mjs/imapclient"
-SRC_URI="https://github.com/mjs/imapclient/archive/${PV}.tar.gz -> ${P}.gh.tar.gz"
+HOMEPAGE="
+	https://github.com/mjs/imapclient
+	https://pypi.org/project/IMAPClient
+"
+SRC_URI="
+	https://github.com/mjs/imapclient/archive/${PV}.tar.gz
+		-> ${P}.gh.tar.gz
+"
 
 LICENSE="BSD"
 SLOT="0"

--- a/dev-python/intelhex/intelhex-2.3.0-r1.ebuild
+++ b/dev-python/intelhex/intelhex-2.3.0-r1.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{10..12} )
 
 inherit distutils-r1 pypi
 

--- a/dev-python/jsmin/jsmin-3.0.1.ebuild
+++ b/dev-python/jsmin/jsmin-3.0.1.ebuild
@@ -4,11 +4,14 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{10..12} )
 inherit distutils-r1 pypi
 
 DESCRIPTION="JavaScript minifier"
-HOMEPAGE="https://pypi.org/project/jsmin/ https://github.com/tikitu/jsmin/"
+HOMEPAGE="
+	https://pypi.org/project/jsmin/
+	https://github.com/tikitu/jsmin/
+"
 
 KEYWORDS="amd64 ~arm ~arm64 ~ppc ~ppc64 ~riscv x86"
 LICENSE="MIT"

--- a/dev-python/markups/markups-4.0.0.ebuild
+++ b/dev-python/markups/markups-4.0.0.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{10..12} )
 
 inherit distutils-r1 pypi
 

--- a/dev-python/mediafile/mediafile-0.11.0.ebuild
+++ b/dev-python/mediafile/mediafile-0.11.0.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=flit
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{10..12} )
 
 inherit distutils-r1
 

--- a/dev-python/mimerender/mimerender-0.6.0-r1.ebuild
+++ b/dev-python/mimerender/mimerender-0.6.0-r1.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{10..12} )
 
 inherit distutils-r1
 

--- a/dev-python/pyaml/pyaml-23.5.9.ebuild
+++ b/dev-python/pyaml/pyaml-23.5.9.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{10..12} )
 
 inherit distutils-r1 pypi
 

--- a/dev-python/pymdown-extensions/pymdown-extensions-10.0.1.ebuild
+++ b/dev-python/pymdown-extensions/pymdown-extensions-10.0.1.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=hatchling
-PYTHON_COMPAT=( python3_{10..11} )
+PYTHON_COMPAT=( python3_{10..12} )
 
 DOCS_BUILDER="mkdocs"
 DOCS_DEPEND="

--- a/dev-python/python-markdown-math/python-markdown-math-0.8-r1.ebuild
+++ b/dev-python/python-markdown-math/python-markdown-math-0.8-r1.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
 PYPI_NO_NORMALIZE=1
-PYTHON_COMPAT=( python3_{9..11} pypy3 )
+PYTHON_COMPAT=( python3_{10..12} pypy3 )
 
 inherit distutils-r1 pypi
 

--- a/dev-python/python-mimeparse/python-mimeparse-1.6.0-r4.ebuild
+++ b/dev-python/python-mimeparse/python-mimeparse-1.6.0-r4.ebuild
@@ -1,0 +1,21 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DISTUTILS_USE_PEP517=setuptools
+PYPI_NO_NORMALIZE=1
+PYTHON_COMPAT=( python3_{10..12} pypy3 )
+
+inherit distutils-r1 pypi
+
+DESCRIPTION="Basic functions for handling mime-types in python"
+HOMEPAGE="https://github.com/dbtsai/python-mimeparse"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~x64-macos"
+
+python_test() {
+	"${EPYTHON}" mimeparse_test.py -v || die "Tests fail with ${EPYTHON}"
+}

--- a/dev-python/pytrie/pytrie-0.4.0-r1.ebuild
+++ b/dev-python/pytrie/pytrie-0.4.0-r1.ebuild
@@ -6,7 +6,7 @@ EAPI=8
 DISTUTILS_USE_PEP517=setuptools
 PYPI_NO_NORMALIZE=1
 PYPI_PN="PyTrie"
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{10..12} )
 
 inherit distutils-r1 pypi
 

--- a/dev-python/unidecode/unidecode-1.3.6.ebuild
+++ b/dev-python/unidecode/unidecode-1.3.6.ebuild
@@ -6,7 +6,7 @@ EAPI=8
 DISTUTILS_USE_PEP517=setuptools
 PYPI_NO_NORMALIZE=1
 PYPI_PN=${PN^}
-PYTHON_COMPAT=( pypy3 python3_{9..11} )
+PYTHON_COMPAT=( pypy3 python3_{10..12} )
 
 inherit distutils-r1 pypi
 

--- a/media-libs/mutagen/mutagen-1.46.0.ebuild
+++ b/media-libs/mutagen/mutagen-1.46.0.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{10..12} )
 
 inherit distutils-r1
 


### PR DESCRIPTION
Multiple py3.12 enabled packages, tests pass for all supported python versions with one exception:
- in `dev-python/eyeD3` tests pass with `dev-python/pyyaml` but one test fails with `dev-python/ruamel-yaml` in the same fashion as in bug #906717, the issue is not py3.12 related
- `dev-python/deprecation` is additionally converted to PEP517
- plus few more metadata updates and indentation changes