### PR TITLE
sys-devel/gcc-apple: drop toolchain.eclass

### DIFF
--- a/eclass/toolchain.eclass
+++ b/eclass/toolchain.eclass
@@ -234,11 +234,8 @@ tc_has_feature() {
 
 if [[ ${PN} != kgcc64 && ${PN} != gcc-* ]] ; then
 	IUSE+=" debug +cxx +nptl" TC_FEATURES+=( nptl )
-	[[ -n ${PIE_VER} ]] && IUSE+=" nopie"
-	[[ -n ${SPECS_VER} ]] && IUSE+=" nossp"
 	IUSE+=" +fortran" TC_FEATURES+=( fortran )
 	IUSE+=" doc hardened multilib objc"
-	tc_version_is_between 3 7 && IUSE+=" awt gcj" TC_FEATURES+=( gcj )
 	IUSE+=" pgo"
 	IUSE+=" objc-gc" TC_FEATURES+=( objc-gc )
 	IUSE+=" libssp objc++"
@@ -251,32 +248,17 @@ if [[ ${PN} != kgcc64 && ${PN} != gcc-* ]] ; then
 		IUSE+=" +openmp"
 	fi
 
-	tc_version_is_at_least 4.3 && IUSE+=" fixed-point"
-	tc_version_is_at_least 4.7 && IUSE+=" go"
-
-	# sanitizer support appeared in gcc-4.8, but <gcc-5 does not
-	# support modern glibc.
-	tc_version_is_at_least 5 && IUSE+=" +sanitize"  TC_FEATURES+=( sanitize )
-
-	# Note:
-	#   <gcc-4.8 supported graphite, it required forked ppl
-	#     versions which we dropped.  Since graphite was also experimental in
-	#     the older versions, we don't want to bother supporting it.  #448024
-	#   <gcc-5 supported graphite, it required cloog
-	#   <gcc-6.5 supported graphite, it required old incompatible isl
-	tc_version_is_at_least 6.5 &&
-		IUSE+=" graphite" TC_FEATURES+=( graphite )
-
-	tc_version_is_between 4.9 8 && IUSE+=" cilk"
-	tc_version_is_at_least 4.9 && IUSE+=" ada"
-	tc_version_is_at_least 4.9 && IUSE+=" vtv"
-	tc_version_is_at_least 5.0 && IUSE+=" jit"
+	IUSE+=" fixed-point"
+	IUSE+=" go"
+	IUSE+=" +sanitize"  TC_FEATURES+=( sanitize )
+	IUSE+=" graphite" TC_FEATURES+=( graphite )
+	IUSE+=" ada"
+	IUSE+=" vtv"
+	IUSE+=" jit"
 	tc_version_is_between 5.0 9 && IUSE+=" mpx"
-	tc_version_is_at_least 6.0 && IUSE+=" +pie +ssp +pch"
+	IUSE+=" +pie +ssp +pch"
 
-	# systemtap is a gentoo-specific switch: bug #654748
-	tc_version_is_at_least 8.0 &&
-		IUSE+=" systemtap" TC_FEATURES+=( systemtap )
+	IUSE+=" systemtap" TC_FEATURES+=( systemtap )
 
 	tc_version_is_at_least 9.0 && IUSE+=" d" TC_FEATURES+=( d )
 	tc_version_is_at_least 9.1 && IUSE+=" lto"
@@ -311,18 +293,11 @@ RDEPEND="
 "
 
 GMP_MPFR_DEPS=">=dev-libs/gmp-4.3.2:0= >=dev-libs/mpfr-2.4.2:0="
-if tc_version_is_at_least 4.3 ; then
-	RDEPEND+=" ${GMP_MPFR_DEPS}"
-elif tc_has_feature fortran ; then
-	RDEPEND+=" fortran? ( ${GMP_MPFR_DEPS} )"
-fi
-
-tc_version_is_at_least 4.5 && RDEPEND+=" >=dev-libs/mpc-0.8.1:0="
+RDEPEND+=" ${GMP_MPFR_DEPS}"
+RDEPEND+=" >=dev-libs/mpc-0.8.1:0="
 
 if tc_has_feature objc-gc ; then
-	if tc_version_is_at_least 7 ; then
-		RDEPEND+=" objc-gc? ( >=dev-libs/boehm-gc-7.4.2 )"
-	fi
+	RDEPEND+=" objc-gc? ( >=dev-libs/boehm-gc-7.4.2 )"
 fi
 
 if tc_has_feature graphite ; then
@@ -345,25 +320,6 @@ if [[ ${PN} == gcc && ${PV} == *_p* ]] ; then
 	# If they start to, adjust gcc_cv_prog_makeinfo_modern logic in toolchain_src_configure.
 	# Needed unless/until https://gcc.gnu.org/bugzilla/show_bug.cgi?id=106899 is fixed
 	BDEPEND+=" sys-apps/texinfo"
-fi
-
-if tc_has_feature gcj ; then
-	DEPEND+="
-		gcj? (
-			app-arch/zip
-			app-arch/unzip
-			>=media-libs/libart_lgpl-2.1
-			awt? (
-				x11-base/xorg-proto
-				x11-libs/libXt
-				x11-libs/libX11
-				x11-libs/libXtst
-				=x11-libs/gtk+-2*
-				x11-libs/pango
-				virtual/pkgconfig
-			)
-		)
-	"
 fi
 
 if tc_has_feature sanitize ; then
@@ -475,7 +431,8 @@ gentoo_urls() {
 		HTTP~tamiko/distfiles/URI
 		HTTP~zorry/patches/gcc/URI
 		HTTP~vapier/dist/URI
-		HTTP~blueness/dist/URI"
+		HTTP~blueness/dist/URI
+	"
 	devspace=${devspace//HTTP/https:\/\/dev.gentoo.org\/}
 	echo ${devspace//URI/$1} mirror://gentoo/$1
 }
@@ -504,36 +461,9 @@ gentoo_urls() {
 #			The resulting filename of this tarball will be:
 #			gcc-${PATCH_GCC_VER:-${GCC_RELEASE_VER}}-patches-${PATCH_VER}.tar.xz
 #
-#	PIE_VER
-#	PIE_GCC_VER
-#			These variables control patching in various updates for the logic
-#			controlling Position Independent Executables. PIE_VER is expected
-#			to be the version of this patch, and PIE_GCC_VER the gcc version of
-#			the patch:
-#			An example:
-#					PIE_VER="8.7.6.5"
-#					PIE_GCC_VER="3.4.0"
-#			The resulting filename of this tarball will be:
-#			gcc-${PIE_GCC_VER:-${GCC_RELEASE_VER}}-piepatches-v${PIE_VER}.tar.xz
-#
-#	SPECS_VER
-#	SPECS_GCC_VER
-#			This is for the minispecs files included in the hardened gcc-4.x
-#			The specs files for hardenedno*, vanilla and for building the "specs" file.
-#			SPECS_VER is expected to be the version of this patch, SPECS_GCC_VER
-#			the gcc version of the patch.
-#			An example:
-#					SPECS_VER="8.7.6.5"
-#					SPECS_GCC_VER="3.4.0"
-#			The resulting filename of this tarball will be:
-#			gcc-${SPECS_GCC_VER:-${GCC_RELEASE_VER}}-specs-${SPECS_VER}.tar.xz
-#
 get_gcc_src_uri() {
 	export PATCH_GCC_VER=${PATCH_GCC_VER:-${GCC_RELEASE_VER}}
 	export MUSL_GCC_VER=${MUSL_GCC_VER:-${PATCH_GCC_VER}}
-	export PIE_GCC_VER=${PIE_GCC_VER:-${GCC_RELEASE_VER}}
-	export HTB_GCC_VER=${HTB_GCC_VER:-${GCC_RELEASE_VER}}
-	export SPECS_GCC_VER=${SPECS_GCC_VER:-${GCC_RELEASE_VER}}
 
 	# Set where to download gcc itself depending on whether we're using a
 	# live git tree, snapshot, or release tarball.
@@ -545,39 +475,16 @@ get_gcc_src_uri() {
 	elif [[ -n ${SNAPSHOT} ]] ; then
 		GCC_SRC_URI="mirror://gcc/snapshots/${SNAPSHOT}/gcc-${SNAPSHOT}.tar.xz"
 	else
-		if tc_version_is_between 5.5 6 || tc_version_is_between 6.4 7 || tc_version_is_at_least 7.2 ; then
-			GCC_SRC_URI="
-				mirror://gcc/gcc-${GCC_PV}/gcc-${GCC_RELEASE_VER}.tar.xz
-				mirror://gnu/gcc/gcc-${GCC_PV}/gcc-${GCC_RELEASE_VER}.tar.xz
-			"
-		else
-			GCC_SRC_URI="
-				mirror://gcc/gcc-${GCC_PV}/gcc-${GCC_RELEASE_VER}.tar.bz2
-				mirror://gnu/gcc/gcc-${GCC_PV}/gcc-${GCC_RELEASE_VER}.tar.bz2
-			"
-		fi
+		GCC_SRC_URI="
+			mirror://gcc/gcc-${GCC_PV}/gcc-${GCC_RELEASE_VER}.tar.xz
+			mirror://gnu/gcc/gcc-${GCC_PV}/gcc-${GCC_RELEASE_VER}.tar.xz
+		"
 	fi
 
 	[[ -n ${PATCH_VER} ]] && \
 		GCC_SRC_URI+=" $(gentoo_urls gcc-${PATCH_GCC_VER}-patches-${PATCH_VER}.tar.${TOOLCHAIN_PATCH_SUFFIX})"
 	[[ -n ${MUSL_VER} ]] && \
 		GCC_SRC_URI+=" $(gentoo_urls gcc-${MUSL_GCC_VER}-musl-patches-${MUSL_VER}.tar.${TOOLCHAIN_PATCH_SUFFIX})"
-
-	[[ -n ${PIE_VER} ]] && \
-		PIE_CORE=${PIE_CORE:-gcc-${PIE_GCC_VER}-piepatches-v${PIE_VER}.tar.${TOOLCHAIN_PATCH_SUFFIX}} && \
-		GCC_SRC_URI+=" $(gentoo_urls ${PIE_CORE})"
-
-	# gcc minispec for the hardened gcc 4 compiler
-	[[ -n ${SPECS_VER} ]] && \
-		GCC_SRC_URI+=" $(gentoo_urls gcc-${SPECS_GCC_VER}-specs-${SPECS_VER}.tar.${TOOLCHAIN_PATCH_SUFFIX})"
-
-	if tc_has_feature gcj ; then
-		if tc_version_is_at_least 4.5 ; then
-			GCC_SRC_URI+=" gcj? ( ftp://sourceware.org/pub/java/ecj-4.5.jar )"
-		elif tc_version_is_at_least 4.3 ; then
-			GCC_SRC_URI+=" gcj? ( ftp://sourceware.org/pub/java/ecj-4.3.jar )"
-		fi
-	fi
 
 	echo "${GCC_SRC_URI}"
 }
@@ -592,11 +499,7 @@ toolchain_pkg_pretend() {
 			ewarn 'Go requires a C++ compiler, disabled due to USE="-cxx"'
 		_tc_use_if_iuse objc++ && \
 			ewarn 'Obj-C++ requires a C++ compiler, disabled due to USE="-cxx"'
-		_tc_use_if_iuse gcj && \
-			ewarn 'GCJ requires a C++ compiler, disabled due to USE="-cxx"'
 	fi
-
-	want_minispecs
 }
 
 #---->> pkg_setup <<----
@@ -664,7 +567,6 @@ toolchain_src_prepare() {
 	cd "${S}" || die
 
 	do_gcc_gentoo_patches
-	do_gcc_PIE_patches
 
 	if tc_is_live ; then
 		BRANDING_GCC_PKGVERSION="${BRANDING_GCC_PKGVERSION}, commit ${EGIT_VERSION}"
@@ -684,29 +586,11 @@ toolchain_src_prepare() {
 		-exec sed -i '/^pkgconfigdir/s:=.*:=$(toolexeclibdir)/pkgconfig:' {} + || die
 
 	setup_multilib_osdirnames
-	gcc_version_patch
 
 	local actual_version=$(< "${S}"/gcc/BASE-VER)
 	if [[ "${GCC_RELEASE_VER}" != "${actual_version}" ]] ; then
 		eerror "'${S}/gcc/BASE-VER' contains '${actual_version}', expected '${GCC_RELEASE_VER}'"
 		die "Please set 'TOOLCHAIN_GCC_PV' to '${actual_version}'"
-	fi
-
-	# >= gcc-4.3 doesn't bundle ecj.jar, so copy it
-	if tc_version_is_at_least 4.3 && _tc_use_if_iuse gcj ; then
-		if tc_version_is_at_least 4.5 ; then
-			einfo "Copying ecj-4.5.jar"
-			cp -pPR "${DISTDIR}/ecj-4.5.jar" "${S}/ecj.jar" || die
-		else
-			einfo "Copying ecj-4.3.jar"
-			cp -pPR "${DISTDIR}/ecj-4.3.jar" "${S}/ecj.jar" || die
-		fi
-	fi
-
-	# Prevent libffi from being installed
-	if tc_version_is_between 3.0 4.8 ; then
-		sed -i -e 's/\(install.*:\) install-.*recursive/\1/' "${S}"/libffi/Makefile.in || die
-		sed -i -e 's/\(install-data-am:\).*/\1/' "${S}"/libffi/include/Makefile.in || die
 	fi
 
 	# Fixup libtool to correctly generate .la files with portage
@@ -723,11 +607,6 @@ toolchain_src_prepare() {
 			|| eerror "Please file a bug about this"
 		eend $?
 	done
-
-	# bug #215828
-	if ! tc_version_is_at_least 4.6.0 ; then
-		sed -i 's|A-Za-z0-9|[:alnum:]|g' "${S}"/gcc/*.awk || die
-	fi
 
 	if ! use prefix-guest && [[ -n ${EPREFIX} ]] ; then
 		einfo "Prefixifying dynamic linkers..."
@@ -780,90 +659,47 @@ do_gcc_gentoo_patches() {
 	fi
 }
 
-do_gcc_PIE_patches() {
-	want_pie || return 0
-	use vanilla && return 0
-
-	einfo "Applying PIE patches ..."
-	eapply "${WORKDIR}"/piepatch/*.patch
-
-	BRANDING_GCC_PKGVERSION="${BRANDING_GCC_PKGVERSION}, pie-${PIE_VER}"
-}
-
 # configure to build with the hardened GCC specs as the default
 make_gcc_hard() {
 	local gcc_hard_flags=""
 
-	# If we use gcc-6 or newer with PIE enabled to compile older gcc,
-	# we need to pass -no-pie to stage1; bug #618908
-	if ! tc_version_is_at_least 6.0 && [[ $(gcc-major-version) -ge 6 ]] ; then
-		einfo "Disabling PIE in stage1 (only) ..."
-		sed -i -e "/^STAGE1_LDFLAGS/ s/$/ -no-pie/" "${S}"/Makefile.in || die
+	if _tc_use_if_iuse pie ; then
+		einfo "Updating gcc to use automatic PIE building ..."
 	fi
 
-	# For gcc >= 6.x, we can use configuration options to turn PIE/SSP
-	# on as default
-	if tc_version_is_at_least 6.0 ; then
-		if _tc_use_if_iuse pie ; then
-			einfo "Updating gcc to use automatic PIE building ..."
-		fi
-		if _tc_use_if_iuse ssp ; then
-			einfo "Updating gcc to use automatic SSP building ..."
-		fi
-		if _tc_use_if_iuse default-stack-clash-protection ; then
-			# The define DEF_GENTOO_SCP is checked in 24_all_DEF_GENTOO_SCP-fstack-clash-protection.patch
-			einfo "Updating gcc to use automatic stack clash protection ..."
-			gcc_hard_flags+=" -DDEF_GENTOO_SCP"
-		fi
-		if _tc_use_if_iuse default-znow ; then
-			# The define DEF_GENTOO_ZNOW is checked in 23_all_DEF_GENTOO_ZNOW-z-now.patch
-			einfo "Updating gcc to request symbol resolution at start (-z now) ..."
-			gcc_hard_flags+=" -DDEF_GENTOO_ZNOW"
-		fi
-		if _tc_use_if_iuse hardened ; then
-			# Will add some hardened options as default, e.g. for gcc-12
-			# * -fstack-clash-protection
-			# * -z now
-			# See gcc *_all_extra-options.patch patches.
-			gcc_hard_flags+=" -DEXTRA_OPTIONS"
-			# Default to -D_FORTIFY_SOURCE=3 instead of -D_FORTIFY_SOURCE=2
-			gcc_hard_flags+=" -DGENTOO_FORTIFY_SOURCE_LEVEL=3"
-			# Add -D_GLIBCXX_ASSERTIONS
-			gcc_hard_flags+=" -DDEF_GENTOO_GLIBCXX_ASSERTIONS"
+	if _tc_use_if_iuse ssp ; then
+		einfo "Updating gcc to use automatic SSP building ..."
+	fi
 
-			if _tc_use_if_iuse cet && [[ ${CTARGET} == *x86_64*-linux* ]] ; then
-				gcc_hard_flags+=" -DEXTRA_OPTIONS_CF"
-			fi
+	if _tc_use_if_iuse default-stack-clash-protection ; then
+		# The define DEF_GENTOO_SCP is checked in 24_all_DEF_GENTOO_SCP-fstack-clash-protection.patch
+		einfo "Updating gcc to use automatic stack clash protection ..."
+		gcc_hard_flags+=" -DDEF_GENTOO_SCP"
+	fi
 
-			# Rebrand to make bug reports easier
-			BRANDING_GCC_PKGVERSION=${BRANDING_GCC_PKGVERSION/Gentoo/Gentoo Hardened}
+	if _tc_use_if_iuse default-znow ; then
+		# The define DEF_GENTOO_ZNOW is checked in 23_all_DEF_GENTOO_ZNOW-z-now.patch
+		einfo "Updating gcc to request symbol resolution at start (-z now) ..."
+		gcc_hard_flags+=" -DDEF_GENTOO_ZNOW"
+	fi
+
+	if _tc_use_if_iuse hardened ; then
+		# Will add some hardened options as default, e.g. for gcc-12
+		# * -fstack-clash-protection
+		# * -z now
+		# See gcc *_all_extra-options.patch patches.
+		gcc_hard_flags+=" -DEXTRA_OPTIONS"
+		# Default to -D_FORTIFY_SOURCE=3 instead of -D_FORTIFY_SOURCE=2
+		gcc_hard_flags+=" -DGENTOO_FORTIFY_SOURCE_LEVEL=3"
+		# Add -D_GLIBCXX_ASSERTIONS
+		gcc_hard_flags+=" -DDEF_GENTOO_GLIBCXX_ASSERTIONS"
+
+		if _tc_use_if_iuse cet && [[ ${CTARGET} == *x86_64*-linux* ]] ; then
+			gcc_hard_flags+=" -DEXTRA_OPTIONS_CF"
 		fi
-	else
-		if _tc_use_if_iuse hardened ; then
-			# Rebrand to make bug reports easier
-			BRANDING_GCC_PKGVERSION=${BRANDING_GCC_PKGVERSION/Gentoo/Gentoo Hardened}
-			if hardened_gcc_works ; then
-				einfo "Updating gcc to use automatic PIE + SSP building ..."
-				gcc_hard_flags+=" -DEFAULT_PIE_SSP"
-			elif hardened_gcc_works pie ; then
-				einfo "Updating gcc to use automatic PIE building ..."
-				ewarn "SSP has not been enabled by default"
-				gcc_hard_flags+=" -DEFAULT_PIE"
-			elif hardened_gcc_works ssp ; then
-				einfo "Updating gcc to use automatic SSP building ..."
-				ewarn "PIE has not been enabled by default"
-				gcc_hard_flags+=" -DEFAULT_SSP"
-			else
-				# Do nothing if hardened isn't supported, but don't die either
-				ewarn "hardened is not supported for this arch in this gcc version"
-				return 0
-			fi
-		else
-			if hardened_gcc_works ssp ; then
-				einfo "Updating gcc to use automatic SSP building ..."
-				gcc_hard_flags+=" -DEFAULT_SSP"
-			fi
-		fi
+
+		# Rebrand to make bug reports easier
+		BRANDING_GCC_PKGVERSION=${BRANDING_GCC_PKGVERSION/Gentoo/Gentoo Hardened}
 	fi
 
 	# We want to be able to control the PIE patch logic via something other
@@ -871,12 +707,10 @@ make_gcc_hard() {
 	sed -e '/^ALL_CFLAGS/iHARD_CFLAGS = ' \
 		-e 's|^ALL_CFLAGS = |ALL_CFLAGS = $(HARD_CFLAGS) |' \
 		-i "${S}"/gcc/Makefile.in || die
-	# Need to add HARD_CFLAGS to ALL_CXXFLAGS on >= 4.7
-	if tc_version_is_at_least 4.7 ; then
-		sed -e '/^ALL_CXXFLAGS/iHARD_CFLAGS = ' \
-			-e 's|^ALL_CXXFLAGS = |ALL_CXXFLAGS = $(HARD_CFLAGS) |' \
-			-i "${S}"/gcc/Makefile.in || die
-	fi
+
+	sed -e '/^ALL_CXXFLAGS/iHARD_CFLAGS = ' \
+		-e 's|^ALL_CXXFLAGS = |ALL_CXXFLAGS = $(HARD_CFLAGS) |' \
+		-i "${S}"/gcc/Makefile.in || die
 
 	sed -i \
 		-e "/^HARD_CFLAGS = /s|=|= ${gcc_hard_flags} |" \
@@ -932,24 +766,6 @@ setup_multilib_osdirnames() {
 	sed -i "${sed_args[@]}" "${S}"/gcc/config/${config} || die
 }
 
-gcc_version_patch() {
-	# gcc-4.3+ has configure flags (whoo!)
-	tc_version_is_at_least 4.3 && return 0
-
-	local version_string=${GCC_RELEASE_VER}
-
-	einfo "Patching gcc version: ${version_string} (${BRANDING_GCC_PKGVERSION})"
-
-	local gcc_sed=( -e 's:gcc\.gnu\.org/bugs\.html:bugs\.gentoo\.org/:' )
-	if grep -qs VERSUFFIX "${S}"/gcc/version.c ; then
-		gcc_sed+=( -e "/VERSUFFIX \"\"/s:\"\":\" (${BRANDING_GCC_PKGVERSION})\":" )
-	else
-		version_string="${version_string} (${BRANDING_GCC_PKGVERSION})"
-		gcc_sed+=( -e "/const char version_string\[\] = /s:= \".*\":= \"${version_string}\":" )
-	fi
-	sed -i "${gcc_sed[@]}" "${S}"/gcc/version.c || die
-}
-
 #---->> src_configure <<----
 
 toolchain_src_configure() {
@@ -969,12 +785,6 @@ toolchain_src_configure() {
 	# Force internal zip based jar script to avoid random
 	# issues with 3rd party jar implementations. bug #384291
 	export JAR=no
-
-	# For hardened gcc 4.3: add the pie patchset to build the hardened specs
-	# file (build.specs) to use when building gcc.
-	if ! tc_version_is_at_least 4.4 && want_minispecs ; then
-		setup_minispecs_gcc_build_specs
-	fi
 
 	local confgcc=( --host=${CHOST} )
 
@@ -1008,16 +818,13 @@ toolchain_src_configure() {
 	#  then --with-python-dir=/lib/python2.5/site-packages should be passed.
 	#
 	# This should translate into "/share/gcc-data/${CTARGET}/${GCC_CONFIG_VER}/python"
-	if tc_version_is_at_least 4.4 ; then
-		confgcc+=( --with-python-dir=${DATAPATH/$PREFIX/}/python )
-	fi
+	confgcc+=( --with-python-dir=${DATAPATH/$PREFIX/}/python )
 
 	### language options
 
 	local GCC_LANG="c"
 	is_cxx && GCC_LANG+=",c++"
 	is_d   && GCC_LANG+=",d"
-	is_gcj && GCC_LANG+=",java"
 	is_go  && GCC_LANG+=",go"
 	if is_objc || is_objcxx ; then
 		GCC_LANG+=",objc"
@@ -1075,7 +882,7 @@ toolchain_src_configure() {
 	fi
 
 	# Branding
-	tc_version_is_at_least 4.3 && confgcc+=(
+	confgcc+=(
 		--with-bugurl=https://bugs.gentoo.org/
 		--with-pkgversion="${BRANDING_GCC_PKGVERSION}"
 	)
@@ -1084,25 +891,16 @@ toolchain_src_configure() {
 		confgcc+=( --with-gcc-major-version-only )
 	fi
 
-	# If we want hardened support with the newer PIE patchset for >=gcc 4.4
-	if tc_version_is_at_least 4.4 && want_minispecs && in_iuse hardened ; then
-		confgcc+=( $(use_enable hardened esp) )
-	fi
-
 	# Allow gcc to search for clock funcs in the main C lib.
 	# if it can't find them, then tough cookies -- we aren't
 	# going to link in -lrt to all C++ apps. bug #411681
-	if tc_version_is_at_least 4.4 && is_cxx ; then
+	if is_cxx ; then
 		confgcc+=( --enable-libstdcxx-time )
 	fi
 
 	# This only controls whether the compiler *supports* LTO, not whether
 	# it's *built using* LTO. Hence we do it without a USE flag.
-	if tc_version_is_at_least 4.6 ; then
-		confgcc+=( --enable-lto )
-	elif tc_version_is_at_least 4.5 ; then
-		confgcc+=( --disable-lto )
-	fi
+	confgcc+=( --enable-lto )
 
 	# Build compiler itself using LTO
 	if tc_version_is_at_least 9.1 && _tc_use_if_iuse lto ; then
@@ -1114,7 +912,7 @@ toolchain_src_configure() {
 	fi
 
 	# Support to disable PCH when building libstdcxx
-	if tc_version_is_at_least 6.0 && ! _tc_use_if_iuse pch ; then
+	if ! _tc_use_if_iuse pch ; then
 		confgcc+=( --disable-libstdcxx-pch )
 	fi
 
@@ -1130,11 +928,6 @@ toolchain_src_configure() {
 	# 	;;
 	# esac
 
-	# Newer gcc versions like to bootstrap themselves with C++,
-	# so we need to manually disable it ourselves
-	if tc_version_is_between 4.7 4.8 && ! is_cxx ; then
-		confgcc+=( --disable-build-with-cxx --disable-build-poststage1-with-cxx )
-	fi
 
 	### Cross-compiler options
 	if is_crosscompile ; then
@@ -1184,9 +977,9 @@ toolchain_src_configure() {
 		if [[ -n ${needed_libc} ]] ; then
 			local confgcc_no_libc=( --disable-shared )
 			# requires libc: bug #734820
-			tc_version_is_at_least 4.6 && confgcc_no_libc+=( --disable-libquadmath )
+			confgcc_no_libc+=( --disable-libquadmath )
 			# requires libc
-			tc_version_is_at_least 4.8 && confgcc_no_libc+=( --disable-libatomic )
+			confgcc_no_libc+=( --disable-libatomic )
 
 			if ! has_version ${CATEGORY}/${needed_libc} ; then
 				confgcc+=(
@@ -1272,7 +1065,7 @@ toolchain_src_configure() {
 	# gcc has fixed-point arithmetic support in 4.3 for mips targets that can
 	# significantly increase compile time by several hours.  This will allow
 	# users to control this feature in the event they need the support.
-	tc_version_is_at_least 4.3 && in_iuse fixed-point && confgcc+=( $(use_enable fixed-point) )
+	in_iuse fixed-point && confgcc+=( $(use_enable fixed-point) )
 
 	case $(tc-is-softfloat) in
 		yes)
@@ -1317,10 +1110,7 @@ toolchain_src_configure() {
 			[[ ${arm_arch} == *-m ]] && confgcc+=( --with-mode=thumb )
 
 			# Enable hardvfp
-			if [[ $(tc-is-softfloat) == "no" ]] && \
-			   [[ ${CTARGET} == armv[67]* ]] && \
-			   tc_version_is_at_least 4.5
-			then
+			if [[ $(tc-is-softfloat) == "no" ]] && [[ ${CTARGET} == armv[67]* ]] ; then
 				# Follow the new arm hardfp distro standard by default
 				confgcc+=( --with-float=hard )
 				case ${CTARGET} in
@@ -1334,10 +1124,8 @@ toolchain_src_configure() {
 			# when no specific arch/mode/float is specified, e.g.
 			# for target arm-none-eabi, since doing this is
 			# incompatible with --with-arch/cpu/float/fpu.
-			if is_multilib && [[ ${arm_arch} == arm ]] && \
-			   tc_version_is_at_least 7.1
-			then
-				confgcc+=( --with-multilib-list=aprofile,rmprofile  )
+			if is_multilib && [[ ${arm_arch} == arm ]] ; then
+				confgcc+=( --with-multilib-list=aprofile,rmprofile )
 			fi
 			;;
 		mips)
@@ -1348,7 +1136,7 @@ toolchain_src_configure() {
 		amd64)
 			# drop the older/ABI checks once this gets merged into some
 			# version of gcc upstream
-			if tc_version_is_at_least 4.8 && has x32 $(get_all_abis TARGET) ; then
+			if has x32 $(get_all_abis TARGET) ; then
 				confgcc+=( --with-abi=$(gcc-abi-map ${TARGET_DEFAULT_ABI}) )
 			fi
 			;;
@@ -1356,10 +1144,6 @@ toolchain_src_configure() {
 			# Default arch for x86 is normally i386, let's give it a bump
 			# since glibc will do so based on CTARGET anyways
 			confgcc+=( --with-arch=${CTARGET%%-*} )
-			;;
-		hppa)
-			# Enable sjlj exceptions for backward compatibility on hppa
-			[[ ${GCCMAJOR} == "3" ]] && confgcc+=( --enable-sjlj-exceptions )
 			;;
 		ppc)
 			# Set up defaults based on current CFLAGS
@@ -1393,14 +1177,10 @@ toolchain_src_configure() {
 	# be small, and should simplify building of 64bit kernels in a 32bit
 	# userland by not needing sys-devel/kgcc64. bug #349405
 	case $(tc-arch) in
-		ppc|ppc64)
+		amd64|ppc|ppc64|sparc|x86)
 			confgcc+=( --enable-targets=all )
 			;;
-		sparc)
-			tc_version_is_at_least 4.4 && confgcc+=( --enable-targets=all )
-			;;
-		amd64|x86)
-			tc_version_is_at_least 4.3 && confgcc+=( --enable-targets=all )
+		*)
 			;;
 	esac
 
@@ -1412,15 +1192,6 @@ toolchain_src_configure() {
 		confgcc+=( --enable-version-specific-runtime-libs )
 
 	### library options
-
-	if tc_version_is_between 3.0 7.0 ; then
-		if is_gcj ; then
-			confgcc+=( --disable-gjdoc )
-			use awt && confgcc+=( --enable-java-awt=gtk )
-		else
-			confgcc+=( --disable-libgcj )
-		fi
-	fi
 
 	if in_iuse openmp ; then
 		# Make sure target has pthreads support: bug #326757, bug #335883
@@ -1443,10 +1214,6 @@ toolchain_src_configure() {
 	if _tc_use_if_iuse libssp ; then
 		confgcc+=( --enable-libssp )
 	else
-		if hardened_gcc_is_stable ssp; then
-			export gcc_cv_libc_provides_ssp=yes
-		fi
-
 		if _tc_use_if_iuse ssp; then
 			# On some targets USE="ssp -libssp" is an invalid
 			# configuration as the target libc does not provide
@@ -1502,31 +1269,25 @@ toolchain_src_configure() {
 
 	# graphite was added in 4.4 but we only support it in 6.5+ due to external
 	# library issues. bug #448024, bug #701270
-	if tc_version_is_at_least 6.5 && in_iuse graphite ; then
+	if in_iuse graphite ; then
 		confgcc+=( $(use_with graphite isl) )
 		use graphite && confgcc+=( --disable-isl-version-check )
-	elif tc_version_is_at_least 5.0 ; then
+	else
 		confgcc+=( --without-isl )
-	elif tc_version_is_at_least 4.8 ; then
-		confgcc+=( --without-cloog )
-	elif tc_version_is_at_least 4.4 ; then
-		confgcc+=( --without-{cloog,ppl} )
 	fi
 
-	if tc_version_is_at_least 4.8; then
-		if in_iuse sanitize ; then
-			# See Note [implicitly enabled flags]
-			confgcc+=( $(usex sanitize '' --disable-libsanitizer) )
-		else
-			confgcc+=( --disable-libsanitizer )
-		fi
+	if in_iuse sanitize ; then
+		# See Note [implicitly enabled flags]
+		confgcc+=( $(usex sanitize '' --disable-libsanitizer) )
+	else
+		confgcc+=( --disable-libsanitizer )
 	fi
 
-	if tc_version_is_at_least 6.0 && in_iuse pie ; then
+	if in_iuse pie ; then
 		confgcc+=( $(use_enable pie default-pie) )
 	fi
 
-	if tc_version_is_at_least 6.0 && in_iuse ssp ; then
+	if in_iuse ssp ; then
 		confgcc+=(
 			# This defaults to -fstack-protector-strong.
 			$(use_enable ssp default-ssp)
@@ -1743,38 +1504,13 @@ gcc_do_filter_flags() {
 
 	filter-flags '-fsanitize=*'
 
-	if tc_version_is_between 6 8 ; then
-		# -mstackrealign triggers crashes in exception throwing
-		# at least on ada: bug #688580
-		# The reason is unknown. Drop the flag for now.
-		filter-flags -mstackrealign
-	fi
-
 	case $(tc-arch) in
 		amd64|x86)
 			filter-flags '-mcpu=*'
-
-			# bug #357287
-			tc_version_is_between 4.4 4.5 && append-flags -mno-avx
-
-			if tc_version_is_between 4.6 4.7 ; then
-				# bug #411333, bug #466454
-				replace-cpu-flags c3-2 pentium2 pentium3 pentium3m pentium-m i686
-			fi
 			;;
 		alpha)
 			# bug #454426
 			append-ldflags -Wl,--no-relax
-			;;
-		sparc)
-			# Temporary workaround for random ICEs reproduced by multiple users
-			# bug #457062
-			tc_version_is_between 4.6 4.8 && MAKEOPTS+=" -j1"
-			;;
-		*-macos)
-			# https://gcc.gnu.org/PR25127
-			tc_version_is_between 4.0 4.2 && \
-				filter-flags '-mcpu=*' '-march=*' '-mtune=*'
 			;;
 	esac
 
@@ -1791,27 +1527,6 @@ gcc_do_filter_flags() {
 		local VAR="CFLAGS_"${CTARGET//[-.]/_}
 		CXXFLAGS=${!VAR-${CFLAGS}}
 	fi
-
-	export GCJFLAGS=${GCJFLAGS:-${CFLAGS}}
-}
-
-setup_minispecs_gcc_build_specs() {
-	# Setup the "build.specs" file for gcc 4.3 to use when building.
-	if hardened_gcc_works pie ; then
-		cat "${WORKDIR}"/specs/pie.specs >> "${WORKDIR}"/build.specs
-	fi
-
-	if hardened_gcc_works ssp ; then
-		for s in ssp sspall ; do
-			cat "${WORKDIR}"/specs/${s}.specs >> "${WORKDIR}"/build.specs
-		done
-	fi
-
-	for s in nostrict znow ; do
-		cat "${WORKDIR}"/specs/${s}.specs >> "${WORKDIR}"/build.specs
-	done
-
-	export GCC_SPECS="${WORKDIR}"/build.specs
 }
 
 gcc-multilib-configure() {
@@ -1835,7 +1550,7 @@ gcc-multilib-configure() {
 	if [[ -n ${list} ]] ; then
 		case ${CTARGET} in
 			x86_64*)
-				tc_version_is_at_least 4.8 && confgcc+=( --with-multilib-list=${list:1} )
+				confgcc+=( --with-multilib-list=${list:1} )
 			;;
 		esac
 	fi
@@ -1919,17 +1634,8 @@ gcc_do_make() {
 		fi
 	fi
 
-	# Older versions of GCC could not do profiledbootstrap in parallel due to
-	# collisions with profiling info.
-	if [[ ${GCC_MAKE_TARGET} == "profiledbootstrap" ]] ; then
-		! tc_version_is_at_least 4.6 && export MAKEOPTS="${MAKEOPTS} -j1"
-	fi
-
 	if [[ ${GCC_MAKE_TARGET} == "all" ]] ; then
 		STAGE1_CFLAGS=${STAGE1_CFLAGS-"${CFLAGS}"}
-	elif [[ $(gcc-version) == "3.4" && ${GCC_BRANCH_VER} == "3.4" ]] && gcc-specs-ssp ; then
-		# See bug #79852
-		STAGE1_CFLAGS=${STAGE1_CFLAGS-"-O2"}
 	fi
 
 	if is_crosscompile; then
@@ -1981,13 +1687,9 @@ gcc_do_make() {
 
 	if ! is_crosscompile && _tc_use_if_iuse cxx && _tc_use_if_iuse doc ; then
 		if type -p doxygen > /dev/null ; then
-			if tc_version_is_at_least 4.3 ; then
-				cd "${CTARGET}"/libstdc++-v3/doc
-				emake doc-man-doxygen
-			else
-				cd "${CTARGET}"/libstdc++-v3
-				emake doxygen-man
-			fi
+			cd "${CTARGET}"/libstdc++-v3/doc
+			emake -C "${CTARGET}"/libstdc++-v3/doc doc-man-doxygen
+
 			# Clean bogus manpages. bug #113902
 			find -name '*_build_*' -delete
 
@@ -2130,18 +1832,11 @@ toolchain_src_install() {
 	create_gcc_env_entry
 	create_revdep_rebuild_entry
 
-	# Setup the gcc_env_entry for hardened gcc 4 with minispecs
-	want_minispecs && copy_minispecs_gcc_specs
-
-	# Make sure we don't have stuff lying around that
-	# can nuke multiple versions of gcc
-	gcc_slot_java
-
 	dodir /usr/bin
 	cd "${D}"${BINPATH} || die
 	# Ugh: we really need to auto-detect this list.
 	#      It's constantly out of date.
-	for x in cpp gcc gccrs g++ c++ gcov g77 gcj gcjh gfortran gccgo gnat* ; do
+	for x in cpp gcc gccrs g++ c++ gcov g77 gfortran gccgo gnat* ; do
 		# For some reason, g77 gets made instead of ${CTARGET}-g77...
 		# this should take care of that
 		if [[ -f ${x} ]] ; then
@@ -2278,16 +1973,8 @@ toolchain_src_install() {
 	export QA_WX_LOAD="usr/lib*/go/*/*.gox"
 
 	# Disable RANDMMAP so PCH works, bug #301299
-	if tc_version_is_at_least 4.3 ; then
-		pax-mark -r "${ED}/libexec/gcc/${CTARGET}/${GCC_CONFIG_VER}/cc1"
-		pax-mark -r "${ED}/libexec/gcc/${CTARGET}/${GCC_CONFIG_VER}/cc1plus"
-	fi
-
-	# Disable MPROTECT so java works, bug #574808
-	if is_gcj ; then
-		pax-mark -m "${ED}/libexec/gcc/${CTARGET}/${GCC_CONFIG_VER}/ecj1"
-		pax-mark -m "${ED}/${CTARGET}/gcc-bin/${GCC_CONFIG_VER}/gij"
-	fi
+	pax-mark -r "${ED}/libexec/gcc/${CTARGET}/${GCC_CONFIG_VER}/cc1"
+	pax-mark -r "${ED}/libexec/gcc/${CTARGET}/${GCC_CONFIG_VER}/cc1plus"
 
 	if use test ; then
 		# TODO: In future, install orphaned to allow comparison across
@@ -2311,7 +1998,7 @@ gcc_movelibs() {
 	# move them to the compiler-specific CHOST internal dir.  This is stuff
 	# that you want to link against when building tools rather than building
 	# code to run on the target.
-	if tc_version_is_at_least 5 && is_crosscompile ; then
+	if is_crosscompile ; then
 		dodir "${HOSTLIBPATH#${EPREFIX}}"
 		mv "${ED}"/usr/$(get_libdir)/libcc1* "${D}${HOSTLIBPATH}" || die
 	fi
@@ -2353,14 +2040,6 @@ gcc_movelibs() {
 			fi
 		done
 		fix_libtool_libdir_paths "${LIBPATH}/${MULTIDIR}"
-
-		# SLOT up libgcj.pc if it's available (and let gcc-config worry about links)
-		FROMDIR="${PREFIX}/lib/${OS_MULTIDIR}"
-		for x in "${D}${FROMDIR}"/pkgconfig/libgcj*.pc ; do
-			[[ -f ${x} ]] || continue
-			sed -i "/^libdir=/s:=.*:=${LIBPATH}/${MULTIDIR}:" "${x}" || die
-			mv "${x}" "${D}${FROMDIR}"/pkgconfig/libgcj-${GCC_PV}.pc || die
-		done
 	done
 
 	# We remove directories separately to avoid this case:
@@ -2458,67 +2137,6 @@ create_revdep_rebuild_entry() {
 	# Ignore libraries built for ${CTARGET}, https://bugs.gentoo.org/692844.
 	SEARCH_DIRS_MASK="${LIBPATH}"
 	EOF
-}
-
-copy_minispecs_gcc_specs() {
-	# On gcc 6, we don't need minispecs
-	if tc_version_is_at_least 6.0 ; then
-		return 0
-	fi
-
-	# Setup the hardenedno* specs files and the vanilla specs file.
-	if hardened_gcc_works ; then
-		create_gcc_env_entry hardenednopiessp
-	fi
-	if hardened_gcc_works pie ; then
-		create_gcc_env_entry hardenednopie
-	fi
-	if hardened_gcc_works ssp ; then
-		create_gcc_env_entry hardenednossp
-	fi
-	create_gcc_env_entry vanilla
-	insinto ${LIBPATH#${EPREFIX}}
-	doins "${WORKDIR}"/specs/*.specs || die "failed to install specs"
-	# Build system specs file which, if it exists, must be a complete set of
-	# specs as it completely and unconditionally overrides the builtin specs.
-	if ! tc_version_is_at_least 4.4 ; then
-		$(XGCC) -dumpspecs > "${WORKDIR}"/specs/specs
-		cat "${WORKDIR}"/build.specs >> "${WORKDIR}"/specs/specs
-		doins "${WORKDIR}"/specs/specs || die "failed to install the specs file"
-	fi
-}
-
-gcc_slot_java() {
-	local x
-
-	# Move Java headers to compiler-specific dir
-	for x in "${D}${PREFIX}"/include/gc*.h "${D}${PREFIX}"/include/j*.h ; do
-		[[ -f ${x} ]] && mv -f "${x}" "${D}${LIBPATH}"/include/
-	done
-	for x in gcj gnu java javax org ; do
-		if [[ -d ${D}${PREFIX}/include/${x} ]] ; then
-			dodir /${LIBPATH#${EPREFIX}}/include/${x}
-			mv -f "${D}${PREFIX}"/include/${x}/* "${D}${LIBPATH}"/include/${x}/
-			rm -rf "${D}${PREFIX}"/include/${x}
-		fi
-	done
-
-	if [[ -d ${D}${PREFIX}/lib/security ]] || [[ -d ${D}${PREFIX}/$(get_libdir)/security ]] ; then
-		dodir /${LIBPATH#${EPREFIX}}/security
-		mv -f "${D}${PREFIX}"/lib*/security/* "${D}${LIBPATH}"/security
-		rm -rf "${D}${PREFIX}"/lib*/security
-	fi
-
-	# Move random gcj files to compiler-specific directories
-	for x in libgcj.spec logging.properties ; do
-		x="${D}${PREFIX}/lib/${x}"
-		[[ -f ${x} ]] && mv -f "${x}" "${D}${LIBPATH}"/
-	done
-
-	# Rename jar because it could clash with Kaffe's jar if this gcc is
-	# primary compiler (aka doesn't have the -<version> extension)
-	cd "${D}${BINPATH}"
-	[[ -f jar ]] && mv -f jar gcj-jar
 }
 
 #---->> pkg_post* <<----
@@ -2687,11 +2305,6 @@ is_fortran() {
 	_tc_use_if_iuse fortran
 }
 
-is_gcj() {
-	gcc-lang-supported java || return 1
-	_tc_use_if_iuse cxx && _tc_use_if_iuse gcj
-}
-
 is_go() {
 	gcc-lang-supported go || return 1
 	_tc_use_if_iuse cxx && _tc_use_if_iuse go
@@ -2740,80 +2353,6 @@ get_make_var() {
 }
 
 XGCC() { get_make_var GCC_FOR_TARGET ; }
-
-# The gentoo pie-ssp patches allow for 3 configurations:
-# 1) PIE+SSP by default
-# 2) PIE by default
-# 3) SSP by default
-hardened_gcc_works() {
-	if [[ $1 == "pie" ]] ; then
-		# $gcc_cv_ld_pie is unreliable as it simply take the output of
-		# `ld --help | grep -- -pie`, that reports the option in all cases, also if
-		# the loader doesn't actually load the resulting executables.
-
-		want_pie || return 1
-		_tc_use_if_iuse nopie && return 1
-		hardened_gcc_is_stable pie
-		return $?
-	elif [[ $1 == "ssp" ]] ; then
-		[[ -n ${SPECS_VER} ]] || return 1
-		_tc_use_if_iuse nossp && return 1
-		hardened_gcc_is_stable ssp
-		return $?
-	else
-		# laziness ;)
-		hardened_gcc_works pie || return 1
-		hardened_gcc_works ssp || return 1
-		return 0
-	fi
-}
-
-hardened_gcc_is_stable() {
-	local tocheck
-	if [[ $1 == "pie" ]] ; then
-		tocheck=${PIE_GLIBC_STABLE}
-	elif [[ $1 == "ssp" ]] ; then
-		tocheck=${SSP_STABLE}
-	else
-		die "hardened_gcc_stable needs to be called with pie or ssp"
-	fi
-
-	has $(tc-arch) ${tocheck} && return 0
-	return 1
-}
-
-want_minispecs() {
-	# On gcc 6, we don't need minispecs
-	if tc_version_is_at_least 6.0 ; then
-		return 0
-	fi
-	if tc_version_is_at_least 4.3.2 && _tc_use_if_iuse hardened ; then
-		if ! want_pie ; then
-			ewarn "PIE_VER or SPECS_VER is not defined in the GCC ebuild."
-		elif use vanilla ; then
-			ewarn "You will not get hardened features if you have the vanilla USE-flag."
-		elif _tc_use_if_iuse nopie && _tc_use_if_iuse nossp ; then
-			ewarn "You will not get hardened features if you have the nopie and nossp USE-flag."
-		elif ! hardened_gcc_works ; then
-			ewarn "Your $(tc-arch) arch is not supported."
-		else
-			return 0
-		fi
-		ewarn "Hope you know what you are doing. Hardened will not work."
-		return 0
-	fi
-	return 1
-}
-
-want_pie() {
-	! _tc_use_if_iuse hardened && [[ -n ${PIE_VER} ]] \
-		&& _tc_use_if_iuse nopie && return 1
-	[[ -n ${PIE_VER} ]] && [[ -n ${SPECS_VER} ]] && return 0
-	tc_version_is_at_least 4.3.2 && return 1
-	[[ -z ${PIE_VER} ]] && return 1
-	_tc_use_if_iuse nopie || return 0
-	return 1
-}
 
 has toolchain_death_notice ${EBUILD_DEATH_HOOKS} || EBUILD_DEATH_HOOKS+=" toolchain_death_notice"
 toolchain_death_notice() {

--- a/sys-devel/gcc-apple/gcc-apple-4.2.1_p5666-r3.ebuild
+++ b/sys-devel/gcc-apple/gcc-apple-4.2.1_p5666-r3.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="7"
 
-inherit toolchain flag-o-matic autotools prefix toolchain-funcs
+inherit flag-o-matic autotools prefix toolchain-funcs
 
 GCC_VERS=${PV/_p*/}
 APPLE_VERS="${PV/*_p/}.3"
@@ -41,6 +41,10 @@ S=${WORKDIR}/gcc-${APPLE_VERS}
 
 # TPREFIX is the prefix of the CTARGET installation
 export TPREFIX=${TPREFIX:-${EPREFIX}}
+
+is_crosscompile() {
+	[[ ${CHOST} != ${CTARGET} ]]
+}
 
 do_bootstrap() {
 	is_crosscompile && return 1


### PR DESCRIPTION
We use only a tiny function from it and this prevents modernising the eclass.

Signed-off-by: Sam James <sam@gentoo.org>