### PR TITLE
dev-python/*: enable py3.12

### DIFF
--- a/dev-python/alembic/alembic-1.11.1.ebuild
+++ b/dev-python/alembic/alembic-1.11.1.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( pypy3 python3_{10..11} )
+PYTHON_COMPAT=( pypy3 python3_{10..12} )
 
 inherit distutils-r1 pypi
 
@@ -28,6 +28,12 @@ RDEPEND="
 "
 
 distutils_enable_tests pytest
+
+python_test() {
+	# setup.cfg contains -p no:warnings in addopts which triggers
+	# datetime.utcfromtimestamp() deprecation warning as an error in py3.12
+	epytest -o addopts=
+}
 
 python_install_all() {
 	use doc && local HTML_DOCS=( docs/. )

--- a/dev-python/chameleon/chameleon-4.0.0.ebuild
+++ b/dev-python/chameleon/chameleon-4.0.0.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} pypy3 )
+PYTHON_COMPAT=( python3_{10..12} pypy3 )
 
 inherit distutils-r1
 

--- a/dev-python/flask-migrate/flask-migrate-4.0.4.ebuild
+++ b/dev-python/flask-migrate/flask-migrate-4.0.4.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{10..12} )
 
 inherit distutils-r1
 

--- a/dev-python/flask-sqlalchemy/flask-sqlalchemy-3.0.3.ebuild
+++ b/dev-python/flask-sqlalchemy/flask-sqlalchemy-3.0.3.ebuild
@@ -6,7 +6,7 @@ EAPI=8
 DISTUTILS_USE_PEP517=pdm
 PYPI_NO_NORMALIZE=1
 PYPI_PN="Flask-SQLAlchemy"
-PYTHON_COMPAT=( pypy3 python3_{9..11} )
+PYTHON_COMPAT=( pypy3 python3_{10..12} )
 
 inherit distutils-r1 pypi
 

--- a/dev-python/markdown2/markdown2-2.4.8.ebuild
+++ b/dev-python/markdown2/markdown2-2.4.8.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( pypy3 python3_{9..11} )
+PYTHON_COMPAT=( pypy3 python3_{10..12} )
 
 inherit distutils-r1 pypi
 

--- a/dev-python/pyotp/pyotp-2.8.0.ebuild
+++ b/dev-python/pyotp/pyotp-2.8.0.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{10..12} )
 
 inherit distutils-r1 pypi
 

--- a/dev-python/python-editor/python-editor-1.0.4-r2.ebuild
+++ b/dev-python/python-editor/python-editor-1.0.4-r2.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
 PYPI_NO_NORMALIZE=1
-PYTHON_COMPAT=( pypy3 python3_{9..11} )
+PYTHON_COMPAT=( pypy3 python3_{10..12} )
 
 inherit distutils-r1 pypi
 

--- a/dev-python/python-gnupg/python-gnupg-0.5.0.ebuild
+++ b/dev-python/python-gnupg/python-gnupg-0.5.0.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( pypy3 python3_{9..11} )
+PYTHON_COMPAT=( pypy3 python3_{10..12} )
 VERIFY_SIG_OPENPGP_KEY_PATH="${BROOT}"/usr/share/openpgp-keys/vinaysajip.asc
 inherit distutils-r1 verify-sig
 

--- a/dev-python/python-gnupg/python-gnupg-0.5.0.ebuild
+++ b/dev-python/python-gnupg/python-gnupg-0.5.0.ebuild
@@ -9,7 +9,11 @@ VERIFY_SIG_OPENPGP_KEY_PATH="${BROOT}"/usr/share/openpgp-keys/vinaysajip.asc
 inherit distutils-r1 verify-sig
 
 DESCRIPTION="A Python wrapper for GnuPG"
-HOMEPAGE="https://docs.red-dove.com/python-gnupg/"
+HOMEPAGE="
+	https://docs.red-dove.com/python-gnupg/
+	https://github.com/vsajip/python-gnupg/
+	https://pypi.org/project/python-gnupg/
+"
 SRC_URI="https://github.com/vsajip/python-gnupg/releases/download/${PV}/${P}.tar.gz"
 SRC_URI+=" verify-sig? ( https://github.com/vsajip/python-gnupg/releases/download/${PV}/${P}.tar.gz.asc )"
 

--- a/dev-python/python-xlib/python-xlib-0.33.ebuild
+++ b/dev-python/python-xlib/python-xlib-0.33.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{10..12} )
 
 inherit distutils-r1 virtualx
 

--- a/dev-python/rsa/rsa-4.9.ebuild
+++ b/dev-python/rsa/rsa-4.9.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=poetry
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{10..12} )
 
 inherit distutils-r1
 

--- a/dev-python/vobject/vobject-0.9.6.1-r3.ebuild
+++ b/dev-python/vobject/vobject-0.9.6.1-r3.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{10..12} )
 inherit distutils-r1 pypi
 
 DESCRIPTION="Python package for parsing and generating vCard and vCalendar files"

--- a/dev-python/xvfbwrapper/xvfbwrapper-0.2.9-r1.ebuild
+++ b/dev-python/xvfbwrapper/xvfbwrapper-0.2.9-r1.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{10..12} )
 
 inherit distutils-r1 pypi
 


### PR DESCRIPTION
Enable py3.12 in few dev-python packages. Tests pass for all supported python versions. Most noticeable is `dev-python/alembic`, where it was necessary to call `epytest` with `-o addopts=` otherwise py3.12 tests fail because of `datetime.utcfromtimestamp()` deprecation warning.