### PR TITLE
kde-misc/kdeconnect: Fix builds using clang

### DIFF
--- a/kde-misc/kdeconnect/files/kdeconnect-23.04.1-explicit-constructor-for-QSslCertificate.patch
+++ b/kde-misc/kdeconnect/files/kdeconnect-23.04.1-explicit-constructor-for-QSslCertificate.patch
@@ -1,0 +1,35 @@
+From bbac0aa0852b14bc5cc9a1b8c3be0f55adda2428 Mon Sep 17 00:00:00 2001
+From: Ali Abdel-Qader <abdelqaderali@protonmail.com>
+Date: Sat, 6 May 2023 15:51:53 -0400
+Subject: [PATCH] Use explicit constructor for QSslCertificate with value
+ initialized argument
+
+Previously the BluetoothDeviceLink::certificate() method was returning a
+value initialized object which I believe default initializes the object.
+However, Clang throws a build error at this because QSslCertificate has
+explicit constructors. This change uses one of those constructors and
+uses value intialization to default construct/initialize the argument
+for it. It fixes the build and hopefully doesn't break anything since
+this is a TODO anyways!
+
+BUG: 469428
+
+Signed-off-by: Ali Abdel-Qader <abdelqaderali@protonmail.com>
+---
+ core/backends/bluetooth/bluetoothdevicelink.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/core/backends/bluetooth/bluetoothdevicelink.cpp b/core/backends/bluetooth/bluetoothdevicelink.cpp
+index 1ab401fc9..facf5deed 100644
+--- a/core/backends/bluetooth/bluetoothdevicelink.cpp
++++ b/core/backends/bluetooth/bluetoothdevicelink.cpp
+@@ -99,5 +99,5 @@ void BluetoothDeviceLink::dataReceived()
+ 
+ QSslCertificate BluetoothDeviceLink::certificate() const
+ {
+-    return {}; // TODO Not sure what to do here. For LanDeviceLink we use the SSL connection's certificate, but we don't have that here
++    return QSslCertificate({}); // TODO Not sure what to do here. For LanDeviceLink we use the SSL connection's certificate, but we don't have that here
+ }
+-- 
+GitLab
+

--- a/kde-misc/kdeconnect/kdeconnect-23.04.1.ebuild
+++ b/kde-misc/kdeconnect/kdeconnect-23.04.1.ebuild
@@ -76,6 +76,7 @@ BDEPEND="
 PATCHES=(
 	"${FILESDIR}/${PN}-21.07.80-revert-disable-kpeople.patch"
 	"${FILESDIR}/${PN}-23.04.0-telephony-optional.patch" # bug 904823
+	"${FILESDIR}/${PN}-23.04.1-explicit-constructor-for-QSslCertificate.patch" # bug 841416
 )
 
 src_configure() {


### PR DESCRIPTION
clang is more strict for syntax then gcc hence it was not possible to build kdeconnect with clang. This adds a patch from upstream that corrects this by explictly using the constructer as it should have in the first place.

Bug: https://bugs.gentoo.org/841416
Closes: https://bugs.gentoo.org/841416