### PR TITLE
sys-fs/bcachefs-tools: fix live hardened build

### DIFF
--- a/sys-fs/bcachefs-tools/bcachefs-tools-9999.ebuild
+++ b/sys-fs/bcachefs-tools/bcachefs-tools-9999.ebuild
@@ -74,7 +74,6 @@ python_check_deps() {
 src_unpack() {
 	if [[ ${PV} == "9999" ]]; then
 		git-r3_src_unpack
-		S="${S}/rust-src/bch_bindgen" cargo_live_src_unpack
 		S="${S}/rust-src" cargo_live_src_unpack
 	else
 		default


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/902725