### PR TITLE
dev-libs/tinyxml2: Fix build with musl 1.2.4

### DIFF
--- a/dev-libs/tinyxml2/files/tinyxml2-9.0.0-musl-1.2.4.patch
+++ b/dev-libs/tinyxml2/files/tinyxml2-9.0.0-musl-1.2.4.patch
@@ -1,0 +1,51 @@
+Bug: https://bugs.gentoo.org/905999
+Upstream: https://leethomason/tinyxml2/pull/945
+
+From dfcb914e8bbbb2dca146a3cee62f66fff7ea163b Mon Sep 17 00:00:00 2001
+From: Violet Purcell <vimproved@inventati.org>
+Date: Thu, 8 Jun 2023 15:19:41 +0000
+Subject: [PATCH] Remove LFS64 calls and set _FILE_OFFSET_BITS=64
+
+Musl 1.2.4 made the LFS64 interfaces only available when
+_LARGEFILE64_SOURCE is defined, and they will be removed altogether in
+Musl 1.2.5. This commit replaces the LFS64 calls with their non-LFS64
+versions and defines _FILE_OFFSET_BITS=64, which makes all interfaces
+64-bit.
+
+Bug: https://bugs.gentoo.org/905999
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -31,6 +31,7 @@ target_compile_definitions(
+     PUBLIC $<$<CONFIG:Debug>:TINYXML2_DEBUG>
+     INTERFACE $<$<BOOL:${BUILD_SHARED_LIBS}>:TINYXML2_IMPORT>
+     PRIVATE $<$<CXX_COMPILER_ID:MSVC>:_CRT_SECURE_NO_WARNINGS>
++    PUBLIC _FILE_OFFSET_BITS=64
+ )
+ 
+ set_target_properties(
+--- a/Makefile
++++ b/Makefile
+@@ -10,7 +10,7 @@ ARFLAGS = cr
+ RM = rm -f
+ RANLIB = ranlib
+ MKDIR = mkdir -p
+-CXXFLAGS = -fPIC
++CXXFLAGS = -D_FILE_OFFSET_BITS=64 -fPIC
+ 
+ INSTALL = install
+ INSTALL_PROGRAM = $(INSTALL)
+--- a/tinyxml2.cpp
++++ b/tinyxml2.cpp
+@@ -106,9 +106,6 @@ distribution.
+ #elif defined(__APPLE__) || defined(__FreeBSD__) || defined(__ANDROID__)
+ 	#define TIXML_FSEEK fseeko
+ 	#define TIXML_FTELL ftello
+-#elif defined(__unix__) && defined(__x86_64__)
+-	#define TIXML_FSEEK fseeko64
+-	#define TIXML_FTELL ftello64
+ #else
+ 	#define TIXML_FSEEK fseek
+ 	#define TIXML_FTELL ftell
+-- 
+2.41.0
+

--- a/dev-libs/tinyxml2/tinyxml2-9.0.0-r1.ebuild
+++ b/dev-libs/tinyxml2/tinyxml2-9.0.0-r1.ebuild
@@ -16,6 +16,10 @@ KEYWORDS="amd64 arm arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv sparc x86"
 IUSE="test"
 RESTRICT="!test? ( test )"
 
+PATCHES=(
+	"${FILESDIR}/${P}-musl-1.2.4.patch"
+)
+
 src_configure() {
 	local mycmakeargs=(
 		-DBUILD_TESTING=$(usex test)


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/905999