### PR TITLE
sys-kernel/raspberrypi-sources: Fix patch application

### DIFF
--- a/sys-kernel/raspberrypi-sources/files/raspberrypi-sources-6.1.21-gentoo-kconfig.patch
+++ b/sys-kernel/raspberrypi-sources/files/raspberrypi-sources-6.1.21-gentoo-kconfig.patch
@@ -1,0 +1,13 @@
+--- a/drivers/base/firmware_loader/Kconfig
++++ b/drivers/base/firmware_loader/Kconfig
+@@ -75,6 +75,7 @@ config EXTRA_FIRMWARE_DIR
+ 
+ config FW_LOADER_USER_HELPER
+ 	bool "Enable the firmware sysfs fallback mechanism"
++	depends on !GENTOO_LINUX_INIT_SYSTEMD
+ 	select FW_LOADER_SYSFS
+ 	select FW_LOADER_PAGED_BUF
+ 	help
+-- 
+2.41.0
+

--- a/sys-kernel/raspberrypi-sources/raspberrypi-sources-6.1.21_p20230405.ebuild
+++ b/sys-kernel/raspberrypi-sources/raspberrypi-sources-6.1.21_p20230405.ebuild
@@ -29,11 +29,12 @@ SRC_URI="
 
 KEYWORDS="~arm ~arm64"
 
-PATCHES=("${FILESDIR}"/${PN}-5.15.32-gentoo-kconfig.patch)
+PATCHES=("${FILESDIR}"/${PN}-6.1.21-gentoo-kconfig.patch)
 
 UNIPATCH_EXCLUDE="
 	10*
 	15*
+	1700
 	2000
 	29*
 	3000


### PR DESCRIPTION
Rebased user patch and excluded 1700.