### PR TITLE
app-emulation/libvirt: Rebase libvirt-8.2.0-fix-paths-for-apparmor.patch

### DIFF
--- a/app-emulation/libvirt/files/libvirt-9.5.0-fix-paths-for-apparmor.patch
+++ b/app-emulation/libvirt/files/libvirt-9.5.0-fix-paths-for-apparmor.patch
@@ -1,0 +1,81 @@
+From 10152b243dbd7ecfe6c92dd2f831118c0c0bf85d Mon Sep 17 00:00:00 2001
+Message-Id: <10152b243dbd7ecfe6c92dd2f831118c0c0bf85d.1686298837.git.mprivozn@redhat.com>
+From: Michal Privoznik <mprivozn@redhat.com>
+Date: Tue, 15 Mar 2022 05:23:29 +0100
+Subject: [PATCH] libvirt-9.5.0-fix-paths-for-apparmor.patch
+
+Signed-off-by: Michal Privoznik <mprivozn@redhat.com>
+---
+ src/security/apparmor/libvirt-qemu                            | 1 +
+ src/security/apparmor/meson.build                             | 2 +-
+ src/security/apparmor/usr.lib.libvirt.virt-aa-helper.local    | 1 -
+ ...irt-aa-helper.in => usr.libexec.libvirt.virt-aa-helper.in} | 4 ++--
+ .../apparmor/usr.libexec.libvirt.virt-aa-helper.local         | 1 +
+ 5 files changed, 5 insertions(+), 4 deletions(-)
+ delete mode 100644 src/security/apparmor/usr.lib.libvirt.virt-aa-helper.local
+ rename src/security/apparmor/{usr.lib.libvirt.virt-aa-helper.in => usr.libexec.libvirt.virt-aa-helper.in} (94%)
+ create mode 100644 src/security/apparmor/usr.libexec.libvirt.virt-aa-helper.local
+
+diff --git a/src/security/apparmor/libvirt-qemu b/src/security/apparmor/libvirt-qemu
+index 44056b5f14..1f0db2cda2 100644
+--- a/src/security/apparmor/libvirt-qemu
++++ b/src/security/apparmor/libvirt-qemu
+@@ -96,6 +96,7 @@
+   /usr/share/sgabios/** r,
+   /usr/share/slof/** r,
+   /usr/share/vgabios/** r,
++  /usr/share/seavgabios/** r,
+ 
+   # pki for libvirt-vnc and libvirt-spice (LP: #901272, #1690140)
+   /etc/pki/CA/ r,
+diff --git a/src/security/apparmor/meson.build b/src/security/apparmor/meson.build
+index 02a6d098ad..39214a679f 100644
+--- a/src/security/apparmor/meson.build
++++ b/src/security/apparmor/meson.build
+@@ -1,5 +1,5 @@
+ apparmor_gen_profiles = [
+-  'usr.lib.libvirt.virt-aa-helper',
++  'usr.libexec.libvirt.virt-aa-helper',
+   'usr.sbin.libvirtd',
+   'usr.sbin.virtqemud',
+   'usr.sbin.virtxend',
+diff --git a/src/security/apparmor/usr.lib.libvirt.virt-aa-helper.local b/src/security/apparmor/usr.lib.libvirt.virt-aa-helper.local
+deleted file mode 100644
+index c0990e51d0..0000000000
+--- a/src/security/apparmor/usr.lib.libvirt.virt-aa-helper.local
++++ /dev/null
+@@ -1 +0,0 @@
+-# Site-specific additions and overrides for 'usr.lib.libvirt.virt-aa-helper'
+diff --git a/src/security/apparmor/usr.lib.libvirt.virt-aa-helper.in b/src/security/apparmor/usr.libexec.libvirt.virt-aa-helper.in
+similarity index 94%
+rename from src/security/apparmor/usr.lib.libvirt.virt-aa-helper.in
+rename to src/security/apparmor/usr.libexec.libvirt.virt-aa-helper.in
+index ff1d46bebe..6beedde1b1 100644
+--- a/src/security/apparmor/usr.lib.libvirt.virt-aa-helper.in
++++ b/src/security/apparmor/usr.libexec.libvirt.virt-aa-helper.in
+@@ -41,7 +41,7 @@ profile virt-aa-helper @libexecdir@/virt-aa-helper {
+   deny /dev/mapper/* r,
+ 
+   @libexecdir@/virt-aa-helper mr,
+-  /{usr/,}sbin/apparmor_parser Ux,
++  /{usr/,}{s,}bin/apparmor_parser Ux,
+ 
+   @sysconfdir@/apparmor.d/libvirt/* r,
+   @sysconfdir@/apparmor.d/libvirt/libvirt-[0-9a-f]*-[0-9a-f]*-[0-9a-f]*-[0-9a-f]*-[0-9a-f]* rw,
+@@ -71,5 +71,5 @@ profile virt-aa-helper @libexecdir@/virt-aa-helper {
+   /**.[iI][sS][oO] r,
+   /**/disk{,.*} r,
+ 
+-  #include <local/usr.lib.libvirt.virt-aa-helper>
++  #include <local/usr.libexec.libvirt.virt-aa-helper>
+ }
+diff --git a/src/security/apparmor/usr.libexec.libvirt.virt-aa-helper.local b/src/security/apparmor/usr.libexec.libvirt.virt-aa-helper.local
+new file mode 100644
+index 0000000000..974653d797
+--- /dev/null
++++ b/src/security/apparmor/usr.libexec.libvirt.virt-aa-helper.local
+@@ -0,0 +1 @@
++# Site-specific additions and overrides for 'usr.libexec.libvirt.virt-aa-helper'
+-- 
+2.39.3
+

--- a/app-emulation/libvirt/libvirt-9999.ebuild
+++ b/app-emulation/libvirt/libvirt-9999.ebuild
@@ -144,7 +144,7 @@ PDEPEND="
 PATCHES=(
 	"${FILESDIR}"/${PN}-9.4.0-fix_paths_in_libvirt-guests_sh.patch
 	"${FILESDIR}"/${PN}-9.4.0-do-not-use-sysconfig.patch
-	"${FILESDIR}"/${PN}-8.2.0-fix-paths-for-apparmor.patch
+	"${FILESDIR}"/${PN}-9.5.0-fix-paths-for-apparmor.patch
 )
 
 pkg_setup() {


### PR DESCRIPTION
Because of upstream commit v9.4.0-49-g9b743ee190 our libvirt-8.2.0-fix-paths-for-apparmor.patch does not apply cleanly anymore. Rebase it.