### PR TITLE
profiles: test masking ruby30 (to find <ruby31-only pkgs)

### DIFF
--- a/profiles/base/make.defaults
+++ b/profiles/base/make.defaults
@@ -100,7 +100,7 @@ LCD_DEVICES="bayrad cfontz cfontz633 glk hd44780 lb216 lcdm001 mtxorb ncurses te
 # Manuel Rüger <mrueg@gentoo.org> (2015-09-09)
 # Default Ruby build target(s)
 # Updated to add ruby31 on 2023-05-29
-RUBY_TARGETS="ruby30 ruby31"
+RUBY_TARGETS="ruby31"
 
 # Andreas K. Hüttel <dilfridge@gentoo.org> (2022-10-22)
 # These USE flags are what is common between the various sub-profiles. Stages 2

--- a/profiles/base/use.mask
+++ b/profiles/base/use.mask
@@ -4,6 +4,9 @@
 # This file is only for generic masks. For arch-specific masks (i.e.
 # mask everywhere, unmask on arch/*) use arch/base.
 
+# test to find <ruby31-only pkgs
+ruby_targets_ruby30
+
 # Hans de Graaff <graaff@gentoo.org> (2023-04-10)
 # Ruby 2.7 is masked for removal.
 ruby_targets_ruby27

--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -33,6 +33,9 @@
 
 #--- END OF EXAMPLES ---
 
+# test to find <ruby31-only pkgs
+dev-lang/ruby:3.0
+
 # Sam James <sam@gentoo.org> (2023-06-12)
 # Installs no files with newer versions because GTK 2 support was dropped upstream.
 # Removal on 2023-07-12.  Bug #908378.


### PR DESCRIPTION
This is just a convenient way to find stuff we should fix before making ruby31 the only default, rather than actually planning on masking ruby30