### PR TITLE
profiles/arch/hppa: mask USE=ldap

### DIFF
--- a/net-nds/openldap/openldap-2.4.59-r2.ebuild
+++ b/net-nds/openldap/openldap-2.4.59-r2.ebuild
@@ -25,7 +25,7 @@ SRC_URI="
 
 LICENSE="OPENLDAP GPL-2"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~mips ~ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~mips ~ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux"
 
 IUSE_DAEMON="crypt samba tcpd experimental minimal"
 IUSE_BACKEND="+berkdb"

--- a/net-nds/openldap/openldap-2.5.14.ebuild
+++ b/net-nds/openldap/openldap-2.5.14.ebuild
@@ -25,7 +25,7 @@ S="${WORKDIR}"/${PN}-OPENLDAP_REL_ENG_${MY_PV}
 LICENSE="OPENLDAP GPL-2"
 # Subslot added for bug #835654
 SLOT="0/$(ver_cut 1-2)"
-KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~loong ~mips ~ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~loong ~mips ~ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux"
 
 IUSE_DAEMON="argon2 +cleartext crypt experimental minimal samba tcpd"
 IUSE_OVERLAY="overlays perl autoca"

--- a/net-nds/openldap/openldap-2.6.3-r7.ebuild
+++ b/net-nds/openldap/openldap-2.6.3-r7.ebuild
@@ -25,7 +25,7 @@ S="${WORKDIR}"/${PN}-OPENLDAP_REL_ENG_${MY_PV}
 LICENSE="OPENLDAP GPL-2"
 # Subslot added for bug #835654
 SLOT="0/$(ver_cut 1-2)"
-KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~loong ~mips ~ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~loong ~mips ~ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux"
 
 IUSE_DAEMON="argon2 +cleartext crypt experimental minimal samba tcpd"
 IUSE_OVERLAY="overlays perl autoca"

--- a/profiles/arch/hppa/package.use.stable.mask
+++ b/profiles/arch/hppa/package.use.stable.mask
@@ -17,6 +17,12 @@
 
 #--- END OF EXAMPLES ---
 
+# Sam James <sam@gentoo.org> (2023-07-02)
+# Unlikely that anybody wants to use net-nds/openldap on hppa & often has
+# platform-specific bugs.
+dev-libs/cyrus-sasl openldap
+app-crypt/mit-krb5 openldap
+
 # Arthur Zamarin <arthurzam@gentoo.org> (2022-12-18)
 # Unstable test dependencies
 dev-util/pkgdev test

--- a/profiles/arch/hppa/use.stable.mask
+++ b/profiles/arch/hppa/use.stable.mask
@@ -4,6 +4,11 @@
 # This file requires eapi 5 or later. New entries go on top.
 # Please use the same syntax as in use.mask
 
+# Sam James <sam@gentoo.org> (2023-07-02)
+# Unlikely that anybody wants to use net-nds/openldap on hppa & often has
+# platform-specific bugs.
+ldap
+
 # Rolf Eike Beer <eike@sf-mail.de> (2021-11-12)
 # dev-libs/nspr and dev-libs/nss are not stable on hppa
 nss


### PR DESCRIPTION
Unlikely that anybody wants to use net-nds/openldap on hppa & often has platform-specific bugs.