### PR TITLE
pypi.eclass: optimizations

### DIFF
--- a/eclass/pypi.eclass
+++ b/eclass/pypi.eclass
@@ -71,10 +71,13 @@ _PYPI_ECLASS=1
 # via _PYPI_NORMALIZED_NAME variable.
 _pypi_normalize_name() {
 	local name=${1}
-	local shopt_save=$(shopt -p extglob)
-	shopt -s extglob
-	name=${name//+([._-])/_}
-	${shopt_save}
+	if shopt -p -q extglob; then
+		name=${name//+([._-])/_}
+	else
+		shopt -s extglob
+		name=${name//+([._-])/_}
+		shopt -u extglob
+	fi
 	_PYPI_NORMALIZED_NAME="${name,,}"
 }
 

--- a/eclass/pypi.eclass
+++ b/eclass/pypi.eclass
@@ -95,6 +95,19 @@ pypi_normalize_name() {
 	echo "${_PYPI_NORMALIZED_NAME}"
 }
 
+# @FUNCTION: _pypi_translate_version
+# @USAGE: <version>
+# @DESCRIPTION:
+# Internal version translation function, returns the result
+# via _PYPI_TRANSLATED_VERSION variable.
+_pypi_translate_version() {
+	local version=${1}
+	version=${version/_alpha/a}
+	version=${version/_beta/b}
+	version=${version/_rc/rc}
+	_PYPI_TRANSLATED_VERSION=${version/_p/.post}
+}
+
 # @FUNCTION: pypi_translate_version
 # @USAGE: <version>
 # @DESCRIPTION:
@@ -106,12 +119,9 @@ pypi_normalize_name() {
 pypi_translate_version() {
 	[[ ${#} -ne 1 ]] && die "Usage: ${FUNCNAME} <version>"
 
-	local version=${1}
-	version=${version/_alpha/a}
-	version=${version/_beta/b}
-	version=${version/_rc/rc}
-	version=${version/_p/.post}
-	echo "${version}"
+	local _PYPI_TRANSLATED_VERSION
+	_pypi_translate_version "${@}"
+	echo "${_PYPI_TRANSLATED_VERSION}"
 }
 
 # @FUNCTION: pypi_sdist_url
@@ -239,16 +249,17 @@ pypi_wheel_url() {
 # @DESCRIPTION:
 # Set global variables, SRC_URI and S.
 _pypi_set_globals() {
-	local version=$(pypi_translate_version "${PV}")
+	local _PYPI_TRANSLATED_VERSION
+	_pypi_translate_version "${PV}"
 
 	if [[ ${PYPI_NO_NORMALIZE} ]]; then
-		SRC_URI="$(pypi_sdist_url --no-normalize "${PYPI_PN}" "${version}")"
-		S="${WORKDIR}/${PYPI_PN}-${version}"
+		SRC_URI="$(pypi_sdist_url --no-normalize "${PYPI_PN}" "${_PYPI_TRANSLATED_VERSION}")"
+		S="${WORKDIR}/${PYPI_PN}-${_PYPI_TRANSLATED_VERSION}"
 	else
 		local _PYPI_NORMALIZED_NAME
 		_pypi_normalize_name "${PYPI_PN}"
-		SRC_URI="$(pypi_sdist_url "${PYPI_PN}" "${version}")"
-		S="${WORKDIR}/${_PYPI_NORMALIZED_NAME}-${version}"
+		SRC_URI="$(pypi_sdist_url "${PYPI_PN}" "${_PYPI_TRANSLATED_VERSION}")"
+		S="${WORKDIR}/${_PYPI_NORMALIZED_NAME}-${_PYPI_TRANSLATED_VERSION}"
 	fi
 }
 

--- a/eclass/pypi.eclass
+++ b/eclass/pypi.eclass
@@ -226,12 +226,14 @@ pypi_wheel_url() {
 # @DESCRIPTION:
 # Set global variables, SRC_URI and S.
 _pypi_set_globals() {
+	local version=$(pypi_translate_version "${PV}")
+
 	if [[ ${PYPI_NO_NORMALIZE} ]]; then
-		SRC_URI="$(pypi_sdist_url --no-normalize)"
-		S="${WORKDIR}/${PYPI_PN}-$(pypi_translate_version "${PV}")"
+		SRC_URI="$(pypi_sdist_url --no-normalize "${PYPI_PN}" "${version}")"
+		S="${WORKDIR}/${PYPI_PN}-${version}"
 	else
-		SRC_URI="$(pypi_sdist_url)"
-		S="${WORKDIR}/$(pypi_normalize_name "${PYPI_PN}")-$(pypi_translate_version "${PV}")"
+		SRC_URI="$(pypi_sdist_url "${PYPI_PN}" "${version}")"
+		S="${WORKDIR}/$(pypi_normalize_name "${PYPI_PN}")-${version}"
 	fi
 }
 

--- a/eclass/pypi.eclass
+++ b/eclass/pypi.eclass
@@ -221,12 +221,20 @@ pypi_wheel_url() {
 	fi
 }
 
-if [[ ${PYPI_NO_NORMALIZE} ]]; then
-	SRC_URI="$(pypi_sdist_url --no-normalize)"
-	S="${WORKDIR}/${PYPI_PN}-$(pypi_translate_version "${PV}")"
-else
-	SRC_URI="$(pypi_sdist_url)"
-	S="${WORKDIR}/$(pypi_normalize_name "${PYPI_PN}")-$(pypi_translate_version "${PV}")"
-fi
+# @FUNCTION: _pypi_set_globals
+# @INTERNAL
+# @DESCRIPTION:
+# Set global variables, SRC_URI and S.
+_pypi_set_globals() {
+	if [[ ${PYPI_NO_NORMALIZE} ]]; then
+		SRC_URI="$(pypi_sdist_url --no-normalize)"
+		S="${WORKDIR}/${PYPI_PN}-$(pypi_translate_version "${PV}")"
+	else
+		SRC_URI="$(pypi_sdist_url)"
+		S="${WORKDIR}/$(pypi_normalize_name "${PYPI_PN}")-$(pypi_translate_version "${PV}")"
+	fi
+}
+
+_pypi_set_globals
 
 fi

--- a/eclass/tests/pypi-bench.sh
+++ b/eclass/tests/pypi-bench.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# Copyright 2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+source tests-common.sh || exit
+
+export LC_ALL=C
+
+doit() {
+	for (( i = 0; i < 1000; i++ )); do
+		_pypi_set_globals
+	done
+}
+
+timeit() {
+	einfo "Timing PYPI_PN=\"${PYPI_PN}\" PV=\"${PV}\" PYPI_NO_NORMALIZE=${PYPI_NO_NORMALIZE}"
+
+	local real=()
+	local user=()
+	local x vr avg
+
+	for x in {1..3}; do
+		while read tt tv; do
+			case ${tt} in
+				real) real+=( ${tv} );;
+				user) user+=( ${tv} );;
+			esac
+		done < <( ( time -p doit ) 2>&1 )
+	done
+
+	[[ ${#real[@]} == 3 ]] || die "Did not get 3 real times"
+	[[ ${#user[@]} == 3 ]] || die "Did not get 3 user times"
+
+	local xr avg
+	for x in real user; do
+		xr="${x}[*]"
+		avg=$(dc -S 3 -e "3000 ${!xr} + + / p")
+
+		printf '%s %4.0f it/s\n' "${x}" "${avg}"
+	done
+}
+
+PN=foo-bar
+PYPI_PN=Foo.Bar
+PV=1.2.3_beta2
+WORKDIR='<WORKDIR>'
+
+inherit pypi
+timeit
+
+PV=1.2.3
+timeit
+PYPI_NO_NORMALIZE=1 timeit
+
+PN=foobar
+PYPI_PN=FooBar
+timeit
+PYPI_NO_NORMALIZE=1 timeit
+
+PYPI_PN=foobar
+timeit
+PYPI_NO_NORMALIZE=1 timeit
+
+texit


### PR DESCRIPTION
These changes make the eclass run twice as fast for the "common" use case.

Technically, there are still some possible optimizations:
- using `_pypi_translate_version` in wheel functions
- "caching" normalized project name (right now we do it twice, for `S` and as part of `pypi_sdist_url`)
- "caching" betwen `pypi_wheel_name` and `pypi_wheel_url`

That said, I'm not sure if there's a point in adding more complexity, given these functions aren't used all that often.