### PR TITLE
dev-perl/Net-SSLeay: update libressl patch

### DIFF
--- a/dev-perl/Net-SSLeay/files/Net-SSLeay-1.92-libressl.patch
+++ b/dev-perl/Net-SSLeay/files/Net-SSLeay-1.92-libressl.patch
@@ -5,6 +5,9 @@ https://github.com/radiator-software/p5-net-ssleay/pull/362
 https://github.com/radiator-software/p5-net-ssleay/commit/88c3bbc45399c8ef2c8879aada8bfa91d8bc6c10
 https://github.com/radiator-software/p5-net-ssleay/pull/363
 https://github.com/radiator-software/p5-net-ssleay/commit/3dd2f101b8e15a59f66e22525b8d001d5ad6ce7d
+https://github.com/radiator-software/p5-net-ssleay/pull/434
+https://github.com/radiator-software/p5-net-ssleay/pull/435
+https://github.com/radiator-software/p5-net-ssleay/commit/fe9e49d220fa424c55fc436303b24f5bddae0b8d
 
 From 4a886e06c1cac80e7fb3f8d52146a27ce557ba8c Mon Sep 17 00:00:00 2001
 From: Alexander Bluhm <alexander.bluhm@gmx.net>
@@ -46,14 +49,24 @@ Use RSA_get0... functions to provide RSA_get_key_parameters().
  SSLeay.xs | 25 +++++++++++++++++++++++--
  1 file changed, 23 insertions(+), 2 deletions(-)
 
-diff --git a/SSLeay.xs b/SSLeay.xs
-index b0667e2..58f1716 100644
+From fe9e49d220fa424c55fc436303b24f5bddae0b8d Mon Sep 17 00:00:00 2001
+From: orbea <orbea@riseup.net>
+Date: Mon, 29 May 2023 10:16:33 -0700
+Subject: [PATCH] SSLeay.xs: Disable Policy Tree API for LibreSSL 3.8 and later
+
+This is taken from the OpenBSD ports tree.
+
+https://github.com/openbsd/ports/commit/f6567f938c9bd51bfd99f8426eba6a1590cc6384
+---
+ SSLeay.xs | 2 ++
+ 1 file changed, 2 insertions(+)
+
 --- a/SSLeay.xs
 +++ b/SSLeay.xs
 @@ -1914,7 +1914,7 @@ X509 * find_issuer(X509 *cert,X509_STORE *store, STACK_OF(X509) *chain) {
      return issuer;
  }
- 
+
 -SV* bn2sv(BIGNUM* p_bn)
 +SV* bn2sv(const BIGNUM* p_bn)
  {
@@ -94,13 +107,29 @@ index b0667e2..58f1716 100644
      XPUSHs(bn2sv(rsa->iqmp));
 +#endif
  }
- 
+
 -#endif
 +#endif /* OpenSSL < 1.1 or LibreSSL */
- 
+
  void
  RSA_free(r)
-@@ -7197,7 +7218,7 @@ ASN1_OBJECT *
+@@ -7010,6 +7031,7 @@ X509_VERIFY_PARAM_get0_peername(param)
+
+ #endif /* OpenSSL 1.0.2-beta2, LibreSSL 2.7.0 */
+
++#if !defined(LIBRESSL_VERSION_NUMBER) || (LIBRESSL_VERSION_NUMBER < 0x3080000fL) /* LibreSSL < 3.8.0 */
+ void
+ X509_policy_tree_free(tree)
+     X509_POLICY_TREE *tree
+@@ -7052,6 +7074,7 @@ const X509_POLICY_NODE *
+ X509_policy_node_get0_parent(node)
+     const X509_POLICY_NODE *node
+
++#endif /* !(LibreSSL >= 3.7.0) */
+ #endif
+
+ ASN1_OBJECT *
+@@ -7197,7 +7220,7 @@ ASN1_OBJECT *
  P_X509_get_signature_alg(x)
          X509 * x
      CODE:
@@ -109,7 +138,7 @@ index b0667e2..58f1716 100644
          RETVAL = (X509_get0_tbs_sigalg(x)->algorithm);
  #else
          RETVAL = (x->cert_info->signature->algorithm);
-@@ -7690,7 +7711,7 @@ OCSP_response_results(rsp,...)
+@@ -7690,7 +7713,7 @@ OCSP_response_results(rsp,...)
  		if (!idsv) {
  		    /* getall: create new SV with OCSP_CERTID */
  		    unsigned char *pi,*pc;
@@ -118,7 +147,7 @@ index b0667e2..58f1716 100644
  		    int len = i2d_OCSP_CERTID((OCSP_CERTID *)OCSP_SINGLERESP_get0_id(sir),NULL);
  #else
  		    int len = i2d_OCSP_CERTID(sir->certId,NULL);
-@@ -7699,7 +7720,7 @@ OCSP_response_results(rsp,...)
+@@ -7699,7 +7722,7 @@ OCSP_response_results(rsp,...)
  		    Newx(pc,len,unsigned char);
  		    if (!pc) croak("out of memory");
  		    pi = pc;


### PR DESCRIPTION
The patch is updated with a fix for >= libressl 3.8.0 that was accepted upstream.

Bug: https://bugs.gentoo.org/903001
Upstream-PR: https://github.com/radiator-software/p5-net-ssleay/pull/434
Upstream-PR: https://github.com/radiator-software/p5-net-ssleay/pull/435
Upstream-Commit: https://github.com/radiator-software/p5-net-ssleay/commit/fe9e49d220fa424c55fc436303b24f5bddae0b8d