### PR TITLE
sys-apps/gptfdisk: Backport musl 1.2.4 fix

### DIFF
--- a/sys-apps/gptfdisk/files/gptfdisk-1.0.9-musl-1.2.4.patch
+++ b/sys-apps/gptfdisk/files/gptfdisk-1.0.9-musl-1.2.4.patch
@@ -1,0 +1,30 @@
+Upstream: https://sourceforge.net/p/gptfdisk/code/ci/7dfa8984f5a30f313d8675ff6097c8592d636d10/
+
+From 7dfa8984f5a30f313d8675ff6097c8592d636d10 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Mon, 12 Dec 2022 12:50:07 -0800
+Subject: [PATCH] Use 64bit time_t on linux as well
+
+Alias 64bit version of stat functions to original functions
+we are already passing -D_FILE_OFFSET_BITS=64 in linux Makefile
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+--- a/diskio-unix.cc
++++ b/diskio-unix.cc
+@@ -37,8 +37,12 @@
+ 
+ using namespace std;
+ 
+-#ifdef __APPLE__
++#if defined(__APPLE__) || defined(__linux__)
+ #define off64_t off_t
++#define stat64 stat
++#define fstat64 fstat
++#define lstat64 lstat
++#define lseek64 lseek
+ #endif
+ 
+ // Returns the official "real" name for a shortened version of same.
+-- 
+2.41.0
+

--- a/sys-apps/gptfdisk/gptfdisk-1.0.9-r3.ebuild
+++ b/sys-apps/gptfdisk/gptfdisk-1.0.9-r3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -33,6 +33,7 @@ DEPEND="
 PATCHES=(
 	"${FILESDIR}/${PN}-1.0.9-libuuid.patch" #844073
 	"${FILESDIR}/${PN}-1.0.9-popt_segv.patch" #872131
+	"${FILESDIR}/${PN}-1.0.9-musl-1.2.4.patch" #906151
 )
 
 src_prepare() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/906151
Upstream: https://sourceforge.net/p/gptfdisk/code/ci/7dfa8984f5a30f313d8675ff6097c8592d636d10/