### PR TITLE
sys-block/cec: Fix type specifier missing, defaults to int

### DIFF
--- a/sys-block/cec/cec-14-r1.ebuild
+++ b/sys-block/cec/cec-14-r1.ebuild
@@ -1,0 +1,30 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit toolchain-funcs
+
+DESCRIPTION="Coraid Ethernet Console client"
+HOMEPAGE="http://aoetools.sourceforge.net/"
+SRC_URI="mirror://sourceforge/aoetools/${P}.tgz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-fno-common.patch
+	"${FILESDIR}"/${PN}-14-including-select.h-and-time.h.patch
+	"${FILESDIR}"/${PN}-14-using-unsigned-int-instead-of-uint.patch
+)
+
+src_compile() {
+	emake CC="$(tc-getCC)" CFLAGS="${CFLAGS}"
+}
+
+src_install() {
+	dosbin ${PN}
+	doman ${PN}.8
+	dodoc ${PN}.txt NEWS README
+}

--- a/sys-block/cec/files/cec-14-including-select.h-and-time.h.patch
+++ b/sys-block/cec/files/cec-14-including-select.h-and-time.h.patch
@@ -1,0 +1,107 @@
+From b8e4f29db4b46614e7f21515ba439eab3c0698b1 Mon Sep 17 00:00:00 2001
+From: Brahmajit Das <brahmajit.xyz@gmail.com>
+Date: Tue, 13 Jun 2023 10:43:46 +0000
+Subject: [PATCH 2/2] cec.c: Including select.h and time.h
+
+According to POSIX.1-2001 sys/select.h should be included for usage of
+identifier fd_set
+
+For using structure timeval sys/time.h is needed.
+
+Without the aforementioned includes, I'm getting the following error:
+cec.c:311:3: warning: switch condition has boolean value [-Wswitch-bool]
+                switch (sh == tab) {
+                ^       ~~~~~~~~~
+cec.c:515:2: error: use of undeclared identifier 'fd_set'
+        fd_set rfds;
+        ^
+cec.c:521:23: error: variable has incomplete type 'struct timeval'
+        struct timeval *tvp, timout;
+                             ^
+cec.c:521:9: note: forward declaration of 'struct timeval'
+        struct timeval *tvp, timout;
+               ^
+cec.c:527:3: error: call to undeclared function 'FD_ZERO'; ISO C99 and later do not
+      support implicit function declarations [-Wimplicit-function-declaration]
+                FD_ZERO(&rfds);
+                ^
+cec.c:527:12: error: use of undeclared identifier 'rfds'; did you mean 'ffs'?
+                FD_ZERO(&rfds);
+                         ^~~~
+                         ffs
+/usr/include/strings.h:25:5: note: 'ffs' declared here
+int ffs (int);
+    ^
+cec.c:528:3: error: call to undeclared function 'FD_SET'; ISO C99 and later do not
+      support implicit function declarations [-Wimplicit-function-declaration]
+                FD_SET(fd, &rfds);
+                ^
+cec.c:528:15: error: use of undeclared identifier 'rfds'; did you mean 'ffs'?
+                FD_SET(fd, &rfds);
+                            ^~~~
+                            ffs
+/usr/include/strings.h:25:5: note: 'ffs' declared here
+int ffs (int);
+    ^
+cec.c:530:15: error: use of undeclared identifier 'rfds'; did you mean 'ffs'?
+                        FD_SET(0, &rfds);
+                                   ^~~~
+                                   ffs
+/usr/include/strings.h:25:5: note: 'ffs' declared here
+int ffs (int);
+    ^
+cec.c:533:7: error: incomplete definition of type 'struct timeval'
+                        tvp->tv_sec = 1;
+                        ~~~^
+cec.c:521:9: note: forward declaration of 'struct timeval'
+        struct timeval *tvp, timout;
+               ^
+cec.c:534:7: error: incomplete definition of type 'struct timeval'
+                        tvp->tv_usec = 0;
+                        ~~~^
+cec.c:521:9: note: forward declaration of 'struct timeval'
+        struct timeval *tvp, timout;
+               ^
+cec.c:537:7: error: call to undeclared function 'select'; ISO C99 and later do not
+      support implicit function declarations [-Wimplicit-function-declaration]
+                n = select(fd+1, &rfds, nil, nil, tvp);
+                    ^
+cec.c:537:21: error: use of undeclared identifier 'rfds'; did you mean 'ffs'?
+                n = select(fd+1, &rfds, nil, nil, tvp);
+                                  ^~~~
+                                  ffs
+/usr/include/strings.h:25:5: note: 'ffs' declared here
+int ffs (int);
+    ^
+cec.c:550:7: error: call to undeclared function 'FD_ISSET'; ISO C99 and later do not
+      support implicit function declarations [-Wimplicit-function-declaration]
+                if (FD_ISSET(0, &rfds)) {
+                    ^
+cec.c:550:20: error: use of undeclared identifier 'rfds'; did you mean 'ffs'?
+                if (FD_ISSET(0, &rfds)) {
+                                 ^~~~
+                                 ffs
+/usr/include/strings.h:25:5: note: 'ffs' declared here
+int ffs (int);
+    ^
+cec.c:576:28: error: use of undeclared identifier 'rfds'; did you mean 'ffs'?
+                } else if (FD_ISSET(fd, &rfds)) {
+                                         ^~~~
+                                         ffs
+/usr/include/strings.h:25:5: note: 'ffs' declared here
+
+Signed-off-by: Brahmajit Das <brahmajit.xyz@gmail.com>
+--- a/cec.c
++++ b/cec.c
+@@ -9,6 +9,8 @@
+ #include <string.h>
+ #include <signal.h>
+ #include <sys/errno.h>
++#include <sys/select.h>
++#include <sys/time.h>
+ #include <arpa/inet.h>
+ #include <ctype.h>
+ #include "cec.h"
+-- 
+2.41.0
+

--- a/sys-block/cec/files/cec-14-using-unsigned-int-instead-of-uint.patch
+++ b/sys-block/cec/files/cec-14-using-unsigned-int-instead-of-uint.patch
@@ -1,0 +1,33 @@
+From 53cba8765ece2fddaea58405649d00df8041823b Mon Sep 17 00:00:00 2001
+From: Brahmajit Das <brahmajit.xyz@gmail.com>
+Date: Tue, 13 Jun 2023 10:39:04 +0000
+Subject: [PATCH 1/2] cec.h utils.c: using unsigned int instead of uint
+
+Since uint ins't a standard type, using unsigned int in its place.
+
+Signed-off-by: Brahmajit Das <brahmajit.xyz@gmail.com>
+--- a/cec.h
++++ b/cec.h
+@@ -22,7 +22,7 @@ void exits(char *);
+ 
+ enum { FQUOTE = (1<<0), FEMPTY = (1<<1) };
+ int getfields(char *, char **, int, char *, int);
+-char *htoa(char *, char *, uint);
++char *htoa(char *, char *, unsigned int);
+ int parseether(char *, char *);
+ 
+ #define tokenize(A, B, C) getfields((A), (B), (C), " \t\r\n", FQUOTE)
+--- a/utils.c
++++ b/utils.c
+@@ -57,7 +57,7 @@ dump(char *ap, int len)
+ }
+ 
+ char *
+-htoa(char *to, char *frm, uint len)
++htoa(char *to, char *frm, unsigned int len)
+ {
+ 	char *cp = to;
+ 	uchar ch;
+-- 
+2.41.0
+


### PR DESCRIPTION
And some other misc. fixes

Closes: https://bugs.gentoo.org/898560