### PR TITLE
mask sys-auth/polkit-pkla-compat on musl profile

### DIFF
--- a/profiles/features/musl/package.mask
+++ b/profiles/features/musl/package.mask
@@ -1,6 +1,11 @@
 # Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Brahmajit Das <brahmajit.xyz@gmail.com> (2023-06-13)
+# masking polkit-pkla-compat on musl
+# the package uses innetgr which is not available in musl, bug 898556
+sys-auth/polkit-pkla-compat
+
 # Maciej Barć <xgqt@gentoo.org> (2023-04-03)
 # Mask until execinfo.h use can be properly patched, bug #877721 and #903689.
 dev-scheme/guile-ssh


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/898556