### PR TITLE
sys-apps/usermode-utilities: Fix error: call to undeclared library fu…

### DIFF
--- a/sys-apps/usermode-utilities/files/usermode-utilities-fix-memset.patch
+++ b/sys-apps/usermode-utilities/files/usermode-utilities-fix-memset.patch
@@ -1,0 +1,44 @@
+Fix building with clang-16, as lot of functions from string.h (including
+memset) couldn't be found. Resulting in error: call to undeclared library
+function memset type error.
+Bug: https://bugs.gentoo.org/898550
+--- a/port-helper/port-helper.c
++++ b/port-helper/port-helper.c
+@@ -13,6 +13,7 @@ for read and write, and the console is functional.
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <signal.h>
++#include <string.h>
+ #include <errno.h>
+ #include <unistd.h>
+ #include <sys/ioctl.h>
+--- a/uml_switch/port.c
++++ b/uml_switch/port.c
+@@ -1,6 +1,7 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <unistd.h>
++#include <string.h>
+ #include <errno.h>
+ #include <sys/socket.h>
+ #include <sys/un.h>
+--- a/uml_switch/uml_switch.c
++++ b/uml_switch/uml_switch.c
+@@ -6,6 +6,7 @@
+ #include <errno.h>
+ #include <stdlib.h>
+ #include <signal.h>
++#include <string.h>
+ #include <fcntl.h>
+ #include <stdint.h>
+ #include <sys/socket.h>
+--- a/watchdog/uml_watchdog.c
++++ b/watchdog/uml_watchdog.c
+@@ -2,6 +2,7 @@
+ #include <stdlib.h>
+ #include <unistd.h>
+ #include <signal.h>
++#include <string.h>
+ #include <errno.h>
+ #include <sys/socket.h>
+ #include <sys/un.h>

--- a/sys-apps/usermode-utilities/usermode-utilities-20070815-r5.ebuild
+++ b/sys-apps/usermode-utilities/usermode-utilities-20070815-r5.ebuild
@@ -1,0 +1,47 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+inherit toolchain-funcs
+
+DESCRIPTION="Tools for use with Usermode Linux virtual machines"
+HOMEPAGE="http://user-mode-linux.sourceforge.net/"
+SRC_URI="http://user-mode-linux.sourceforge.net/uml_utilities_${PV}.tar.bz2"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~x86"
+IUSE="fuse"
+
+RDEPEND="
+	fuse? ( sys-fs/fuse:0= )
+	sys-libs/readline:0=
+"
+DEPEND="${RDEPEND}"
+
+S="${WORKDIR}"/tools-${PV}
+
+PATCHES=(
+	# Merge previous patches with fix for bug #331099
+	"${FILESDIR}"/${P}-rollup.patch
+	# Fix owner of humfsify; bug #364531
+	"${FILESDIR}"/${P}-humfsify-owner.patch
+	"${FILESDIR}"/${P}-headers.patch #580816
+	# Fix build /w clang-16, bug #898550
+	"${FILESDIR}"/${PN}-fix-memset.patch
+)
+
+src_prepare() {
+	default
+	sed -i -e 's:-o \$(BIN):$(LDFLAGS) -o $(BIN):' "${S}"/*/Makefile || die "LDFLAGS sed failed"
+	sed -i -e 's:-o \$@:$(LDFLAGS) -o $@:' "${S}"/moo/Makefile || die "LDFLAGS sed (moo) failed"
+	if ! use fuse; then
+		einfo "Skipping build of umlmount to avoid sys-fs/fuse dependency."
+		sed -i -e 's/\<umlfs\>//' Makefile || die "sed to remove sys-fs/fuse dependency failed"
+	fi
+}
+
+src_compile() {
+	tc-export AR CC
+	emake CFLAGS="${CFLAGS} ${CPPFLAGS} -DTUNTAP -D_FILE_OFFSET_BITS=64 -D_LARGEFILE64_SOURCE -g -Wall" all
+}


### PR DESCRIPTION
…nction memset with type void

A lot of functions from string.h (including memset) couldn't be found. Resulting in error: call to undeclared library function memset type error.

Closes: https://bugs.gentoo.org/898550