### PR TITLE
dev-python/django: remove optfeature for non-existent package

### DIFF
--- a/dev-python/django/django-3.2.19.ebuild
+++ b/dev-python/django/django-3.2.19.ebuild
@@ -104,5 +104,4 @@ pkg_postinst() {
 	optfeature "Memcached support" dev-python/pylibmc dev-python/python-memcached
 	optfeature "ImageField Support" dev-python/pillow
 	optfeature "Password encryption" dev-python/bcrypt
-	optfeature "High-level abstractions for Django forms" dev-python/django-formtools
 }

--- a/dev-python/django/django-4.1.9.ebuild
+++ b/dev-python/django/django-4.1.9.ebuild
@@ -97,5 +97,4 @@ pkg_postinst() {
 	optfeature "Memcached support" dev-python/pylibmc dev-python/python-memcached
 	optfeature "ImageField Support" dev-python/pillow
 	optfeature "Password encryption" dev-python/bcrypt
-	optfeature "High-level abstractions for Django forms" dev-python/django-formtools
 }

--- a/dev-python/django/django-4.2.1.ebuild
+++ b/dev-python/django/django-4.2.1.ebuild
@@ -94,5 +94,4 @@ pkg_postinst() {
 	optfeature "Memcached support" dev-python/pylibmc dev-python/python-memcached
 	optfeature "ImageField Support" dev-python/pillow
 	optfeature "Password encryption" dev-python/bcrypt
-	optfeature "High-level abstractions for Django forms" dev-python/django-formtools
 }

--- a/dev-python/django/django-4.2.2.ebuild
+++ b/dev-python/django/django-4.2.2.ebuild
@@ -94,5 +94,4 @@ pkg_postinst() {
 	optfeature "Memcached support" dev-python/pylibmc dev-python/python-memcached
 	optfeature "ImageField Support" dev-python/pillow
 	optfeature "Password encryption" dev-python/bcrypt
-	optfeature "High-level abstractions for Django forms" dev-python/django-formtools
 }


### PR DESCRIPTION
The `dev-python/django-formtools` was removed from `::gentoo` more than 4 years ago in commit ab8d9abab861 ("dev-python/django-formtools: Remove last-rited pkg").