### PR TITLE
media-sound/musescore: add missing dependencies

### DIFF
--- a/media-sound/musescore/musescore-4.0.2-r1.ebuild
+++ b/media-sound/musescore/musescore-4.0.2-r1.ebuild
@@ -34,7 +34,7 @@ BDEPEND="
 	dev-qt/linguist-tools:5
 	virtual/pkgconfig
 "
-DEPEND="
+RDEPEND="
 	dev-libs/tinyxml2:=
 	dev-qt/designer:5
 	dev-qt/qtconcurrent:5
@@ -50,6 +50,7 @@ DEPEND="
 	dev-qt/qtquickcontrols2:5
 	>=dev-qt/qtsingleapplication-2.6.1_p20171024[X]
 	dev-qt/qtsvg:5
+	dev-qt/qtx11extras:5
 	dev-qt/qtxml:5
 	dev-qt/qtxmlpatterns:5
 	>=media-libs/alsa-lib-1.0.0
@@ -60,12 +61,13 @@ DEPEND="
 	media-libs/opus
 	media-sound/lame
 	sys-libs/zlib:=
-
-	test? (
-		dev-cpp/gtest
-	)
 "
-RDEPEND="${DEPEND}"
+# dev-cpp/gtest is required even when tests are disabled!
+DEPEND="
+	${RDEPEND}
+
+	dev-cpp/gtest
+"
 
 PATCHES=(
 	"${FILESDIR}/${P}-uncompressed-man-pages.patch"


### PR DESCRIPTION
The dependency on GTest seems to be only at build time, probably due to a few macros to make the code easier to test. The software is not linked against GTest, so it can be safely removed after installation.

Closes: https://bugs.gentoo.org/907955
Closes: https://bugs.gentoo.org/907945