### PR TITLE
app-crypt/qca: fix use flag doc for multibuild

### DIFF
--- a/app-crypt/qca/qca-2.3.6-r2.ebuild
+++ b/app-crypt/qca/qca-2.3.6-r2.ebuild
@@ -100,14 +100,14 @@ src_test() {
 }
 
 src_install() {
-	multibuild_foreach_variant cmake_src_install
-
-	if use doc; then
-		pushd "${BUILD_DIR}" >/dev/null || die
-		doxygen Doxyfile || die
-		dodoc -r apidocs/html
-		popd >/dev/null || die
-	fi
+	myinstall() {
+		cmake_src_install
+		if use doc; then
+			cmake_build doc
+			dodoc -r "${BUILD_DIR}"/apidocs/html
+		fi
+	}
+	multibuild_foreach_variant myinstall
 
 	if use examples; then
 		dodoc -r "${S}"/examples


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/908454