### PR TITLE
ruby-ng.eclass: optimize

### DIFF
--- a/eclass/ruby-ng.eclass
+++ b/eclass/ruby-ng.eclass
@@ -392,7 +392,7 @@ fi
 
 _ruby_invoke_environment() {
 	old_S=${S}
-	if [ -z "${RUBY_S}" ]; then
+	if [[ -z ${RUBY_S} ]]; then
 		sub_S=${P}
 	else
 		sub_S=${RUBY_S}
@@ -728,7 +728,7 @@ ruby-ng_rspec() {
 
 	# Explicitly pass the expected spec directory since the versioned
 	# rspec wrappers don't handle this automatically.
-	if [ ${#@} -eq 0 ]; then
+	if [[ $# -eq 0 ]]; then
 		files="spec"
 	fi
 

--- a/eclass/ruby-ng.eclass
+++ b/eclass/ruby-ng.eclass
@@ -229,13 +229,13 @@ ruby_add_rdepend() {
 
 	_ruby_atoms_samelib "$1"
 
-	RDEPEND="${RDEPEND} ${_RUBY_ATOMS_SAMELIB_RESULT}"
+	RDEPEND+=" ${_RUBY_ATOMS_SAMELIB_RESULT}"
 
 	# Add the dependency as a test-dependency since we're going to
 	# execute the code during test phase.
 	case ${EAPI} in
-		6) DEPEND="${DEPEND} test? ( ${_RUBY_ATOMS_SAMELIB_RESULT} )" ;;
-		*) BDEPEND="${BDEPEND} test? ( ${_RUBY_ATOMS_SAMELIB_RESULT} )" ;;
+		6) DEPEND+=" test? ( ${_RUBY_ATOMS_SAMELIB_RESULT} )" ;;
+		*) BDEPEND+=" test? ( ${_RUBY_ATOMS_SAMELIB_RESULT} )" ;;
 	esac
 	if ! has test "$IUSE"; then
 		IUSE+=" test"
@@ -277,8 +277,8 @@ ruby_add_bdepend() {
 	_ruby_atoms_samelib "$1"
 
 	case ${EAPI} in
-		6) DEPEND="${DEPEND} ${_RUBY_ATOMS_SAMELIB_RESULT}" ;;
-		*) BDEPEND="${BDEPEND} ${_RUBY_ATOMS_SAMELIB_RESULT}" ;;
+		6) DEPEND+=" ${_RUBY_ATOMS_SAMELIB_RESULT}" ;;
+		*) BDEPEND+=" ${_RUBY_ATOMS_SAMELIB_RESULT}" ;;
 	esac
 	RDEPEND="${RDEPEND}"
 }
@@ -303,7 +303,7 @@ ruby_add_depend() {
 
 	_ruby_atoms_samelib "$1"
 
-	DEPEND="${DEPEND} ${_RUBY_ATOMS_SAMELIB_RESULT}"
+	DEPEND+=" ${_RUBY_ATOMS_SAMELIB_RESULT}"
 }
 
 # @FUNCTION: ruby_get_use_implementations
@@ -381,12 +381,12 @@ IUSE+=" ${_RUBY_GET_USE_TARGETS}"
 # If you specify RUBY_OPTIONAL you also need to take care of
 # ruby useflag and dependency.
 if [[ ${RUBY_OPTIONAL} != yes ]]; then
-	DEPEND="${DEPEND} ${_RUBY_IMPLEMENTATIONS_DEPEND}"
-	RDEPEND="${RDEPEND} ${_RUBY_IMPLEMENTATIONS_DEPEND}"
+	DEPEND+=" ${_RUBY_IMPLEMENTATIONS_DEPEND}"
+	RDEPEND+=" ${_RUBY_IMPLEMENTATIONS_DEPEND}"
 	REQUIRED_USE+=" || ( ${_RUBY_GET_USE_TARGETS} )"
 	case ${EAPI} in
 		6) ;;
-		*) BDEPEND="${BDEPEND} ${_RUBY_IMPLEMENTATIONS_DEPEND}" ;;
+		*) BDEPEND+=" ${_RUBY_IMPLEMENTATIONS_DEPEND}" ;;
 	esac
 fi
 

--- a/eclass/ruby-ng.eclass
+++ b/eclass/ruby-ng.eclass
@@ -183,11 +183,11 @@ _ruby_wrap_conditions() {
 	local conditions="$1"
 	local atoms="$2"
 
-	for condition in $conditions; do
+	for condition in ${conditions}; do
 		atoms="${condition}? ( ${atoms} )"
 	done
 
-	echo "$atoms"
+	echo "${atoms}"
 }
 
 # @FUNCTION: ruby_add_rdepend
@@ -322,11 +322,9 @@ ruby_get_use_implementations() {
 ruby_get_use_targets() {
 	debug-print-function ${FUNCNAME} "${@}"
 
-	local t implementation
-	for implementation in $(_ruby_get_all_impls); do
-		t+=" ruby_targets_${implementation}"
-	done
-	echo $t
+
+	local impls="$(_ruby_get_all_impls)"
+	echo "${impls//ruby/ruby_targets_ruby}"
 }
 
 # @FUNCTION: ruby_implementations_depend

--- a/eclass/ruby-ng.eclass
+++ b/eclass/ruby-ng.eclass
@@ -107,7 +107,7 @@ _ruby_get_all_impls() {
 	for i in ${USE_RUBY}; do
 		case ${i} in
 			# removed implementations
-			ruby19|ruby20|ruby21|ruby22|ruby23|ruby24|ruby25|ruby26|ruby27|jruby)
+			ruby19|ruby2[0-7]|jruby)
 				;;
 			*)
 				found_valid_impl=1

--- a/eclass/ruby-ng.eclass
+++ b/eclass/ruby-ng.eclass
@@ -163,7 +163,8 @@ _RUBY_ATOMS_SAMELIB_RESULT=""
 _ruby_atoms_samelib() {
 	_RUBY_ATOMS_SAMELIB_RESULT=""
 
-	eshopts_push -o noglob
+        local shopt_save=$(shopt -p -o noglob)
+	set -f
 	local token
 	local atoms=" RUBYTARGET? ("
 	for token in $*; do
@@ -177,7 +178,7 @@ _ruby_atoms_samelib() {
 		esac
 	done
 	atoms+=" ) "
-	eshopts_pop
+	${shopt_save}
 
 	_ruby_set_globals_invalidate_if_stale
 	local _ruby_implementation

--- a/eclass/ruby-ng.eclass
+++ b/eclass/ruby-ng.eclass
@@ -280,7 +280,6 @@ ruby_add_bdepend() {
 		6) DEPEND+=" ${_RUBY_ATOMS_SAMELIB_RESULT}" ;;
 		*) BDEPEND+=" ${_RUBY_ATOMS_SAMELIB_RESULT}" ;;
 	esac
-	RDEPEND="${RDEPEND}"
 }
 
 # @FUNCTION: ruby_add_depend

--- a/eclass/ruby-ng.eclass
+++ b/eclass/ruby-ng.eclass
@@ -105,6 +105,8 @@ ruby_implementation_depend() {
 _ruby_get_all_impls() {
 	_RUBY_GET_ALL_IMPLS=()
 
+	# XXX: Please update _ruby_get_use_targets if adding a non-'ruby*'
+	# target.
 	local i found_valid_impl
 	for i in ${USE_RUBY}; do
 		case ${i} in
@@ -350,6 +352,7 @@ _ruby_get_use_targets() {
 	_ruby_set_globals_invalidate_if_stale
 
 	local impls="${_RUBY_GET_ALL_IMPLS[@]}"
+	# XXX: This assumes all targets begin with 'ruby'.
 	_RUBY_GET_USE_TARGETS="${impls//ruby/ruby_targets_ruby}"
 }
 


### PR DESCRIPTION
Baseline for sourcing dev-ruby/*: 4.1s
Baseline for worst packages in tree: all 15 were ruby, range 80-85ms

Post-fixes for sourcing dev-ruby/*: 1.9s
Post-fixes for worst packages in tree: 2 are ruby, range 38-52ms