### PR TITLE
llvm.eclass: export LLVM_CONFIG if not cross-compiling

### DIFF
--- a/eclass/llvm.eclass
+++ b/eclass/llvm.eclass
@@ -250,6 +250,12 @@ llvm_pkg_setup() {
 		llvm_fix_tool_path ADDR2LINE AR AS LD NM OBJCOPY OBJDUMP RANLIB
 		llvm_fix_tool_path READELF STRINGS STRIP
 
+		# Set LLVM_CONFIG to help Meson (bug #907965) but only do it
+		# for empty ROOT (as a proxy for "are we cross-compiling?").
+		if [[ -z ${ROOT} ]] ; then
+			llvm_fix_tool_path LLVM_CONFIG
+		fi
+
 		local prefix=${ESYSROOT}
 		local llvm_path=${prefix}/usr/lib/llvm/${LLVM_SLOT}/bin
 		local IFS=:


### PR DESCRIPTION
Set LLVM_CONFIG to help Meson (bug #907965) but only do it for empty ROOT (as a proxy for "are we cross-compiling?").

Closes: https://bugs.gentoo.org/907965