### PR TITLE
dev-cpp/jwt-cpp: add patch for gcc 13

### DIFF
--- a/dev-cpp/jwt-cpp/files/jwt-cpp-0.6.0-gcc13.patch
+++ b/dev-cpp/jwt-cpp/files/jwt-cpp-0.6.0-gcc13.patch
@@ -1,0 +1,14 @@
+From: Hannu Lounento <hannu.lounento@vaisala.com>
+Bug: https://github.com/Thalhammer/jwt-cpp/pull/287
+
+Fix build with GCC 13.
+
+--- a/include/jwt-cpp/base.h
++++ b/include/jwt-cpp/base.h
+@@ -3,6 +3,7 @@
+ 
+ #include <array>
++#include <cstdint>
+ #include <stdexcept>
+ #include <string>
+ 

--- a/dev-cpp/jwt-cpp/jwt-cpp-0.6.0.ebuild
+++ b/dev-cpp/jwt-cpp/jwt-cpp-0.6.0.ebuild
@@ -34,6 +34,9 @@ RESTRICT="
 	!picojson? ( test )
 	!test? ( test )
 "
+PATCHES=(
+	"${FILESDIR}"/"${PN}"-0.6.0-gcc13.patch
+)
 DOCS=( README.md docs/{faqs,ssl,traits}.md )
 
 src_prepare() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/908497