### PR TITLE
x11-wm/qtile: bump `xcffib` and `cairocffi` versions

### DIFF
--- a/x11-wm/qtile/qtile-9999.ebuild
+++ b/x11-wm/qtile/qtile-9999.ebuild
@@ -26,12 +26,12 @@ IUSE="pulseaudio wayland"
 # See bug #895722 and https://github.com/qtile/qtile/pull/3985 regarding
 # pywlroots-0.15 dep.
 RDEPEND="
-	>=dev-python/cairocffi-0.9.0[${PYTHON_USEDEP}]
+	>=dev-python/cairocffi-1.6.0[${PYTHON_USEDEP}]
 	>=dev-python/cffi-1.1.0[${PYTHON_USEDEP}]
 	dev-python/dbus-next[${PYTHON_USEDEP}]
 	dev-python/pygobject[${PYTHON_USEDEP}]
 	>=dev-python/six-1.4.1[${PYTHON_USEDEP}]
-	>=dev-python/xcffib-0.10.1[${PYTHON_USEDEP}]
+	>=dev-python/xcffib-1.4.0[${PYTHON_USEDEP}]
 	x11-libs/cairo[X,xcb(+)]
 	x11-libs/libnotify[introspection]
 	x11-libs/pango


### PR DESCRIPTION
https://github.com/qtile/qtile/commit/0dc8941896ec020c3982adf58e4e119a9863ca3b