### PR TITLE
python-utils-r1.eclass: Optimize PYTHON_COMPAT check

### DIFF
--- a/eclass/python-utils-r1.eclass
+++ b/eclass/python-utils-r1.eclass
@@ -114,11 +114,18 @@ _python_verify_patterns() {
 _python_set_impls() {
 	local i
 
-	if ! declare -p PYTHON_COMPAT &>/dev/null; then
-		die 'PYTHON_COMPAT not declared.'
+	# TODO: drop BASH_VERSINFO check when we require EAPI 8
+	if [[ ${BASH_VERSINFO[0]} -ge 5 ]]; then
+		[[ ${PYTHON_COMPAT@a} == *a* ]]
+	else
+		[[ $(declare -p PYTHON_COMPAT) == "declare -a"* ]]
 	fi
-	if [[ $(declare -p PYTHON_COMPAT) != "declare -a"* ]]; then
-		die 'PYTHON_COMPAT must be an array.'
+	if [[ ${?} -ne 0 ]]; then
+		if ! declare -p PYTHON_COMPAT &>/dev/null; then
+			die 'PYTHON_COMPAT not declared.'
+		else
+			die 'PYTHON_COMPAT must be an array.'
+		fi
 	fi
 
 	local obsolete=()

--- a/eclass/tests/python-utils-bench.sh
+++ b/eclass/tests/python-utils-bench.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Copyright 2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+source tests-common.sh || exit
+
+export LC_ALL=C
+
+ITERATIONS=10000
+RUNS=3
+
+doit() {
+	local i
+	for (( i = 0; i < ITERATIONS; i++ )); do
+		"${@}"
+	done
+}
+
+timeit() {
+	local real=()
+	local user=()
+	local x vr avg
+
+	einfo "Timing ${*}"
+	for (( x = 0; x < RUNS; x++ )); do
+		while read tt tv; do
+			case ${tt} in
+				real) real+=( ${tv} );;
+				user) user+=( ${tv} );;
+			esac
+		done < <( ( time -p doit "${@}" ) 2>&1 )
+	done
+
+	[[ ${#real[@]} == ${RUNS} ]] || die "Did not get ${RUNS} real times"
+	[[ ${#user[@]} == ${RUNS} ]] || die "Did not get ${RUNS} user times"
+
+	local xr avg
+	for x in real user; do
+		xr="${x}[*]"
+		avg=$(dc -S 3 -e "${ITERATIONS} ${RUNS} * ${!xr} + + / p")
+
+		printf '%s %4.0f it/s\n' "${x}" "${avg}"
+	done
+}
+
+PYTHON_COMPAT=( python3_{10..12} pypy3 )
+
+inherit python-utils-r1
+
+timeit _python_set_impls
+
+texit


### PR DESCRIPTION
It's not horrendously slow but since the eclass is very common and it's used in global scope, we can definitely do better.

The speedup on the check itself seems to be roughly 40x, though at the scale of whole `_python_set_impls` it's 3.5x.

Since we need to support old bash, I've used `${PYTHON_COMPAT@a}` in bash-5+, and the old check otherwise.