### PR TITLE
cargo.eclass: optimizations

### DIFF
--- a/eclass/cargo.eclass
+++ b/eclass/cargo.eclass
@@ -59,12 +59,16 @@ ECARGO_VENDOR="${ECARGO_HOME}/gentoo"
 # Bash string containing all crates that are to be downloaded.
 # It is used by cargo_crate_uris.
 #
+# Ideally, crate names and versions should be separated by a `@`
+# character.  A legacy syntax using hyphen is also supported but it is
+# much slower.
+#
 # Example:
 # @CODE
 # CRATES="
-# metal-1.2.3
-# bar-4.5.6
-# iron_oxide-0.0.1
+# metal@1.2.3
+# bar@4.5.6
+# iron_oxide@0.0.1
 # "
 # inherit cargo
 # ...
@@ -182,10 +186,16 @@ _cargo_set_crate_uris() {
 	CARGO_CRATE_URIS=
 	for crate in ${crates}; do
 		local name version url
-		[[ $crate =~ $regex ]] || die "Could not parse name and version from crate: $crate"
-		name="${BASH_REMATCH[1]}"
-		version="${BASH_REMATCH[2]}"
-		url="https://crates.io/api/v1/crates/${name}/${version}/download -> ${crate}.crate"
+		if [[ ${crate} == *@* ]]; then
+			name=${crate%@*}
+			version=${crate##*@}
+		else
+			[[ ${crate} =~ ${regex} ]] ||
+				die "Could not parse name and version from crate: ${crate}"
+			name="${BASH_REMATCH[1]}"
+			version="${BASH_REMATCH[2]}"
+		fi
+		url="https://crates.io/api/v1/crates/${name}/${version}/download -> ${name}-${version}.crate"
 		CARGO_CRATE_URIS+="${url} "
 	done
 

--- a/eclass/cargo.eclass
+++ b/eclass/cargo.eclass
@@ -77,6 +77,7 @@ ECARGO_VENDOR="${ECARGO_HOME}/gentoo"
 
 # @ECLASS_VARIABLE: GIT_CRATES
 # @DEFAULT_UNSET
+# @PRE_INHERIT
 # @DESCRIPTION:
 # Bash associative array containing all of the crates that are to be
 # fetched via git.  It is used by cargo_crate_uris.

--- a/eclass/cargo.eclass
+++ b/eclass/cargo.eclass
@@ -189,35 +189,35 @@ _cargo_set_crate_uris() {
 		CARGO_CRATE_URIS+="${url} "
 	done
 
-	local git_crates_type
-	git_crates_type="$(declare -p GIT_CRATES 2>&-)"
-	if [[ ${git_crates_type} == "declare -A "* ]]; then
-		local crate commit crate_uri crate_dir repo_ext feat_expr
+	if declare -p GIT_CRATES &>/dev/null; then
+		if [[ $(declare -p GIT_CRATES) == "declare -A"* ]]; then
+			local crate commit crate_uri crate_dir repo_ext feat_expr
 
-		for crate in "${!GIT_CRATES[@]}"; do
-			IFS=';' read -r crate_uri commit crate_dir <<< "${GIT_CRATES[${crate}]}"
+			for crate in "${!GIT_CRATES[@]}"; do
+				IFS=';' read -r crate_uri commit crate_dir <<< "${GIT_CRATES[${crate}]}"
 
-			case "${crate_uri}" in
-				https://github.com/*)
-					repo_ext=".gh"
-					repo_name="${crate_uri##*/}"
-					crate_uri="${crate_uri%/}/archive/%commit%.tar.gz"
-				;;
-				https://gitlab.com/*)
-					repo_ext=".gl"
-					repo_name="${crate_uri##*/}"
-					crate_uri="${crate_uri%/}/-/archive/%commit%/${repo_name}-%commit%.tar.gz"
-				;;
-				*)
-					repo_ext=
-					repo_name="${crate}"
-				;;
-			esac
+				case "${crate_uri}" in
+					https://github.com/*)
+						repo_ext=".gh"
+						repo_name="${crate_uri##*/}"
+						crate_uri="${crate_uri%/}/archive/%commit%.tar.gz"
+					;;
+					https://gitlab.com/*)
+						repo_ext=".gl"
+						repo_name="${crate_uri##*/}"
+						crate_uri="${crate_uri%/}/-/archive/%commit%/${repo_name}-%commit%.tar.gz"
+					;;
+					*)
+						repo_ext=
+						repo_name="${crate}"
+					;;
+				esac
 
-			CARGO_CRATE_URIS+="${crate_uri//%commit%/${commit}} -> ${repo_name}-${commit}${repo_ext}.tar.gz "
-		done
-	elif [[ -n ${git_crates_type} ]]; then
-		die "GIT_CRATE must be declared as an associative array"
+				CARGO_CRATE_URIS+="${crate_uri//%commit%/${commit}} -> ${repo_name}-${commit}${repo_ext}.tar.gz "
+			done
+		else
+			die "GIT_CRATE must be declared as an associative array"
+		fi
 	fi
 }
 _cargo_set_crate_uris "${CRATES}"

--- a/eclass/tests/cargo-bench.sh
+++ b/eclass/tests/cargo-bench.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+# Copyright 2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+source tests-common.sh || exit
+
+export LC_ALL=C
+
+ITERATIONS=1000
+RUNS=3
+
+doit() {
+	for (( i = 0; i < ITERATIONS; i++ )); do
+		SRC_URI="
+			$(cargo_crate_uris)
+		"
+	done
+}
+
+timeit() {
+	local real=()
+	local user=()
+	local x vr avg
+
+	for (( x = 0; x < RUNS; x++ )); do
+		while read tt tv; do
+			case ${tt} in
+				real) real+=( ${tv} );;
+				user) user+=( ${tv} );;
+			esac
+		done < <( ( time -p doit ) 2>&1 )
+	done
+
+	[[ ${#real[@]} == ${RUNS} ]] || die "Did not get ${RUNS} real times"
+	[[ ${#user[@]} == ${RUNS} ]] || die "Did not get ${RUNS} user times"
+
+	local xr avg
+	for x in real user; do
+		xr="${x}[*]"
+		avg=$(dc -S 3 -e "${ITERATIONS} ${RUNS} * ${!xr} + + / p")
+
+		printf '%s %4.0f it/s\n' "${x}" "${avg}"
+	done
+}
+
+# taken from cryptograpy-41.0.1
+CRATES="
+	Inflector-0.11.4
+	aliasable-0.1.3
+	asn1-0.15.2
+	asn1_derive-0.15.2
+	autocfg-1.1.0
+	base64-0.13.1
+	bitflags-1.3.2
+	cc-1.0.79
+	cfg-if-1.0.0
+	foreign-types-0.3.2
+	foreign-types-shared-0.1.1
+	indoc-1.0.9
+	libc-0.2.144
+	lock_api-0.4.9
+	memoffset-0.8.0
+	once_cell-1.17.2
+	openssl-0.10.54
+	openssl-macros-0.1.1
+	openssl-sys-0.9.88
+	ouroboros-0.15.6
+	ouroboros_macro-0.15.6
+	parking_lot-0.12.1
+	parking_lot_core-0.9.7
+	pem-1.1.1
+	pkg-config-0.3.27
+	proc-macro-error-1.0.4
+	proc-macro-error-attr-1.0.4
+	proc-macro2-1.0.59
+	pyo3-0.18.3
+	pyo3-build-config-0.18.3
+	pyo3-ffi-0.18.3
+	pyo3-macros-0.18.3
+	pyo3-macros-backend-0.18.3
+	quote-1.0.28
+	redox_syscall-0.2.16
+	scopeguard-1.1.0
+	smallvec-1.10.0
+	syn-1.0.109
+	syn-2.0.18
+	target-lexicon-0.12.7
+	unicode-ident-1.0.9
+	unindent-0.1.11
+	vcpkg-0.2.15
+	version_check-0.9.4
+	windows-sys-0.45.0
+	windows-targets-0.42.2
+	windows_aarch64_gnullvm-0.42.2
+	windows_aarch64_msvc-0.42.2
+	windows_i686_gnu-0.42.2
+	windows_i686_msvc-0.42.2
+	windows_x86_64_gnu-0.42.2
+	windows_x86_64_gnullvm-0.42.2
+	windows_x86_64_msvc-0.42.2
+"
+
+inherit cargo
+timeit
+
+texit

--- a/eclass/tests/cargo-bench.sh
+++ b/eclass/tests/cargo-bench.sh
@@ -47,63 +47,68 @@ timeit() {
 
 # taken from cryptograpy-41.0.1
 CRATES="
-	Inflector-0.11.4
-	aliasable-0.1.3
-	asn1-0.15.2
-	asn1_derive-0.15.2
-	autocfg-1.1.0
-	base64-0.13.1
-	bitflags-1.3.2
-	cc-1.0.79
-	cfg-if-1.0.0
-	foreign-types-0.3.2
-	foreign-types-shared-0.1.1
-	indoc-1.0.9
-	libc-0.2.144
-	lock_api-0.4.9
-	memoffset-0.8.0
-	once_cell-1.17.2
-	openssl-0.10.54
-	openssl-macros-0.1.1
-	openssl-sys-0.9.88
-	ouroboros-0.15.6
-	ouroboros_macro-0.15.6
-	parking_lot-0.12.1
-	parking_lot_core-0.9.7
-	pem-1.1.1
-	pkg-config-0.3.27
-	proc-macro-error-1.0.4
-	proc-macro-error-attr-1.0.4
-	proc-macro2-1.0.59
-	pyo3-0.18.3
-	pyo3-build-config-0.18.3
-	pyo3-ffi-0.18.3
-	pyo3-macros-0.18.3
-	pyo3-macros-backend-0.18.3
-	quote-1.0.28
-	redox_syscall-0.2.16
-	scopeguard-1.1.0
-	smallvec-1.10.0
-	syn-1.0.109
-	syn-2.0.18
-	target-lexicon-0.12.7
-	unicode-ident-1.0.9
-	unindent-0.1.11
-	vcpkg-0.2.15
-	version_check-0.9.4
-	windows-sys-0.45.0
-	windows-targets-0.42.2
-	windows_aarch64_gnullvm-0.42.2
-	windows_aarch64_msvc-0.42.2
-	windows_i686_gnu-0.42.2
-	windows_i686_msvc-0.42.2
-	windows_x86_64_gnu-0.42.2
-	windows_x86_64_gnullvm-0.42.2
-	windows_x86_64_msvc-0.42.2
+	Inflector@0.11.4
+	aliasable@0.1.3
+	asn1@0.15.2
+	asn1_derive@0.15.2
+	autocfg@1.1.0
+	base64@0.13.1
+	bitflags@1.3.2
+	cc@1.0.79
+	cfg-if@1.0.0
+	foreign-types@0.3.2
+	foreign-types-shared@0.1.1
+	indoc@1.0.9
+	libc@0.2.144
+	lock_api@0.4.9
+	memoffset@0.8.0
+	once_cell@1.17.2
+	openssl@0.10.54
+	openssl-macros@0.1.1
+	openssl-sys@0.9.88
+	ouroboros@0.15.6
+	ouroboros_macro@0.15.6
+	parking_lot@0.12.1
+	parking_lot_core@0.9.7
+	pem@1.1.1
+	pkg-config@0.3.27
+	proc-macro-error@1.0.4
+	proc-macro-error-attr@1.0.4
+	proc-macro2@1.0.59
+	pyo3@0.18.3
+	pyo3-build-config@0.18.3
+	pyo3-ffi@0.18.3
+	pyo3-macros@0.18.3
+	pyo3-macros-backend@0.18.3
+	quote@1.0.28
+	redox_syscall@0.2.16
+	scopeguard@1.1.0
+	smallvec@1.10.0
+	syn@1.0.109
+	syn@2.0.18
+	target-lexicon@0.12.7
+	unicode-ident@1.0.9
+	unindent@0.1.11
+	vcpkg@0.2.15
+	version_check@0.9.4
+	windows-sys@0.45.0
+	windows-targets@0.42.2
+	windows_aarch64_gnullvm@0.42.2
+	windows_aarch64_msvc@0.42.2
+	windows_i686_gnu@0.42.2
+	windows_i686_msvc@0.42.2
+	windows_x86_64_gnu@0.42.2
+	windows_x86_64_gnullvm@0.42.2
+	windows_x86_64_msvc@0.42.2
 "
 
 inherit cargo
 
+einfo "CRATES with '@' separator"
+timeit
+
+einfo "CRATES with '-' separator"
+CRATES=${CRATES//@/-}
 timeit
 
 texit

--- a/eclass/tests/cargo-bench.sh
+++ b/eclass/tests/cargo-bench.sh
@@ -12,8 +12,9 @@ RUNS=3
 
 doit() {
 	for (( i = 0; i < ITERATIONS; i++ )); do
+		_cargo_set_crate_uris "${CRATES}"
 		SRC_URI="
-			$(cargo_crate_uris)
+			${CARGO_CRATE_URIS}
 		"
 	done
 }
@@ -102,6 +103,7 @@ CRATES="
 "
 
 inherit cargo
+
 timeit
 
 texit


### PR DESCRIPTION
Apparently cargo.eclass is the slowest thing in `dev-python/*` these days, so let's try to make things better.

This patch set makes the "best case" (i.e. an updated ebuild) 3 times as fast as the original.

The changes are limited to:

1. Providing a `${CARGO_CRATE_URIS}` variable that can be used in place of `$(cargo_crate_uris)` to avoid a subshell. Since `CRATES` are pre-inherit anyway, and the eclass dies if they're not set, there's really no point in forcing functional API here.
2. Making it possible to separate `CRATES` via a forward slash instead of hyphen which makes using regexps unnecessary. As you can guess, this makes the biggest performance gain.
3. Optimizing the logic for the common case that `GIT_CRATES` are not set. Before, a subshell would be invoked prematurely to check its type.

Technically, we could copy the new python-utils-r1 approach from #31454 but GIT_CRATES are used so rarely, I think that could be premature.

The changes are 100% backwards compatible but they are going to make using the old API slower.