### PR TITLE
virtual/tmpfiles: don't require systemd-utils

### DIFF
--- a/virtual/tmpfiles/tmpfiles-0-r5.ebuild
+++ b/virtual/tmpfiles/tmpfiles-0-r5.ebuild
@@ -11,6 +11,11 @@ IUSE="systemd"
 RDEPEND="
 	!prefix-guest? (
 		systemd? ( sys-apps/systemd )
-		!systemd? ( sys-apps/systemd-utils[tmpfiles] )
+		!systemd? (
+			|| (
+				sys-apps/systemd-utils[tmpfiles]
+				sys-fs/eudev
+			)
+		)
 	)
 "


### PR DESCRIPTION
eudev blocks systemd-utils and is not installable otherwise.