### PR TITLE
pypi.eclass: Do extglob reset unconditionally

### DIFF
--- a/eclass/pypi.eclass
+++ b/eclass/pypi.eclass
@@ -70,14 +70,12 @@ _PYPI_ECLASS=1
 # Internal normalization function, returns the result
 # via _PYPI_NORMALIZED_NAME variable.
 _pypi_normalize_name() {
-	local name=${1}
-	if shopt -p -q extglob; then
-		name=${name//+([._-])/_}
-	else
-		shopt -s extglob
-		name=${name//+([._-])/_}
-		shopt -u extglob
-	fi
+	# NB: it's fine to alter it unconditionally since this function is
+	# always called from a subshell or in global scope
+	# (via _pypi_set_globals)
+	shopt -s extglob
+	local name=${1//+([._-])/_}
+	shopt -u extglob
 	_PYPI_NORMALIZED_NAME="${name,,}"
 }
 


### PR DESCRIPTION
Change _pypi_normalize_name() to reset extglob unconditionally.  This function is called only in two contexts:

- inside a subshell, therefore making it unnecessary to restore the original extglob value,

- in global scope, via _pypi_set_globals, where we know that extglob is not supposed to be set.

This makes the code simpler.

CC @gentoo/python 