### PR TITLE
flag-o-matic.eclass: Don't inherit eutils in EAPI 7

### DIFF
--- a/eclass/flag-o-matic.eclass
+++ b/eclass/flag-o-matic.eclass
@@ -20,7 +20,7 @@ _FLAG_O_MATIC_ECLASS=1
 
 inherit toolchain-funcs
 
-[[ ${EAPI} == [67] ]] && inherit eutils
+[[ ${EAPI} == 6 ]] && inherit eutils
 
 # @FUNCTION: all-flag-vars
 # @DESCRIPTION:


### PR DESCRIPTION
None of the ebuilds inheriting flag-o-matic in EAPI 7 needs any of the remaining eutils features.