### PR TITLE
net-news/yydecode: Fix error: call to undeclared library function strcmp

### DIFF
--- a/net-news/yydecode/files/yydecode-0.2.10-fix-strcmp-not-found.patch
+++ b/net-news/yydecode/files/yydecode-0.2.10-fix-strcmp-not-found.patch
@@ -1,0 +1,15 @@
+Bug: https://bugs.gentoo.org/898078
+Include string.h for strcmp functions
+diff --git a/src/getopt.c b/src/getopt.c
+index 10a4c32..adf91e7 100644
+--- a/src/getopt.c
++++ b/src/getopt.c
+@@ -67,6 +67,8 @@
+ #include <stdlib.h>
+ #endif	/* GNU C library.  */
+ 
++#include <string.h>
++
+ /* This version of `getopt' appears to the caller like standard Unix `getopt'
+    but it behaves differently for the user, since it allows the user
+    to intersperse the options with the other arguments.

--- a/net-news/yydecode/yydecode-0.2.10-r2.ebuild
+++ b/net-news/yydecode/yydecode-0.2.10-r2.ebuild
@@ -1,0 +1,21 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="A decoder for yENC format, popular on Usenet"
+HOMEPAGE="http://yydecode.sourceforge.net/"
+SRC_URI="mirror://sourceforge/yydecode/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~ppc ~sparc ~x86"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-0.2.10-fix-strcmp-not-found.patch
+)
+
+src_prepare() {
+	default
+	sed -e "s/t3.sh//" -e "s/t7.sh//" -i checks/Makefile.in || die
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/898078