### PR TITLE
x11-wm/qtile: downgrade cairocffi dependency for 0.22.1

### DIFF
--- a/x11-wm/qtile/qtile-0.22.1-r2.ebuild
+++ b/x11-wm/qtile/qtile-0.22.1-r2.ebuild
@@ -27,7 +27,7 @@ IUSE="pulseaudio wayland"
 # pywlroots-0.15 dep.
 # xcffib v1.4.0 breaks its ffi export (https://github.com/qtile/qtile/pull/4289)
 RDEPEND="
-	>=dev-python/cairocffi-0.9.0[${PYTHON_USEDEP}]
+	<dev-python/cairocffi-1.6.0[${PYTHON_USEDEP}]
 	>=dev-python/cffi-1.1.0[${PYTHON_USEDEP}]
 	dev-python/dbus-next[${PYTHON_USEDEP}]
 	dev-python/pygobject[${PYTHON_USEDEP}]


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/908595