### PR TITLE
profiles/targets/desktop/gnome: Enable USE=screencast

### DIFF
--- a/profiles/targets/desktop/gnome/make.defaults
+++ b/profiles/targets/desktop/gnome/make.defaults
@@ -1,4 +1,4 @@
 # Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-USE="colord eds evo gnome gnome-keyring gnome-online-accounts gstreamer introspection keyring nautilus networkmanager pulseaudio sysprof tracker wayland"
+USE="colord eds evo gnome gnome-keyring gnome-online-accounts gstreamer introspection keyring nautilus networkmanager pulseaudio screencast sysprof tracker wayland"


### PR DESCRIPTION
The KDE profile has USE=screencast enabled by default, so for sake of both consistency and usability of programs such as OBS this is probably a good idea. Can't think of any issues this would create either.