### PR TITLE
dev-cpp/scitokens-cpp: depend on dev-cpp/jwt-cpp[picojson]

### DIFF
--- a/dev-cpp/scitokens-cpp/scitokens-cpp-1.0.1-r1.ebuild
+++ b/dev-cpp/scitokens-cpp/scitokens-cpp-1.0.1-r1.ebuild
@@ -21,11 +21,11 @@ SLOT="0"
 IUSE="test"
 
 DEPEND="
-	dev-cpp/jwt-cpp
+	dev-cpp/jwt-cpp[picojson]
 	dev-db/sqlite
 	dev-libs/openssl:0=
 	net-misc/curl:0=
-	sys-apps/util-linux
+	kernel_linux? ( sys-apps/util-linux )
 "
 RDEPEND="${DEPEND}"
 BDEPEND="

--- a/dev-cpp/scitokens-cpp/scitokens-cpp-1.0.2.ebuild
+++ b/dev-cpp/scitokens-cpp/scitokens-cpp-1.0.2.ebuild
@@ -21,11 +21,11 @@ SLOT="0"
 IUSE="test"
 
 DEPEND="
-	dev-cpp/jwt-cpp
+	dev-cpp/jwt-cpp[picojson]
 	dev-db/sqlite
 	dev-libs/openssl:0=
 	net-misc/curl:0=
-	sys-apps/util-linux
+	kernel_linux? ( sys-apps/util-linux )
 "
 RDEPEND="${DEPEND}"
 BDEPEND="


### PR DESCRIPTION
This adds the missing explicit dependency on `USE=picojson` being enabled for `dev-cpp/jwt-cpp`, and also conditionalizes `sys-apps/util-linux` with `kernel_linux`.

Closes: https://bugs.gentoo.org/908610