### PR TITLE
dev-python/{PyQt6,PyQt6-WebEngine}: Remove qmake g++ hack

### DIFF
--- a/dev-python/PyQt6-WebEngine/PyQt6-WebEngine-6.5.0.ebuild
+++ b/dev-python/PyQt6-WebEngine/PyQt6-WebEngine-6.5.0.ebuild
@@ -30,18 +30,7 @@ RDEPEND="
 DEPEND="${RDEPEND}"
 BDEPEND="
 	>=dev-python/PyQt-builder-1.15[${PYTHON_USEDEP}]
-	>=dev-qt/qtbase-${QT_PV}
-	sys-devel/gcc"
-
-src_prepare() {
-	default
-
-	# hack: qmake queries g++ directly for info (not building) and that doesn't
-	# work with clang, this is to make it at least respect CHOST (bug #726112)
-	mkdir "${T}"/cxx || die
-	ln -s "$(type -P ${CHOST}-g++ || type -P g++ || die)" "${T}"/cxx/g++ || die
-	PATH=${T}/cxx:${PATH}
-}
+	>=dev-qt/qtbase-${QT_PV}"
 
 python_configure_all() {
 	append-cxxflags -std=c++17 # for old gcc / clang that use <17 (bug #892331)

--- a/dev-python/PyQt6/PyQt6-6.5.0.ebuild
+++ b/dev-python/PyQt6/PyQt6-6.5.0.ebuild
@@ -66,18 +66,7 @@ RDEPEND="
 BDEPEND="
 	>=dev-python/PyQt-builder-1.15[${PYTHON_USEDEP}]
 	>=dev-qt/qtbase-${QT_PV}
-	sys-devel/gcc
 	dbus? ( virtual/pkgconfig )"
-
-src_prepare() {
-	default
-
-	# hack: qmake queries g++ directly for info (not building) and that doesn't
-	# work with clang, this is to make it at least respect CHOST (bug #726112)
-	mkdir "${T}"/cxx || die
-	ln -s "$(type -P ${CHOST}-g++ || type -P g++ || die)" "${T}"/cxx/g++ || die
-	PATH=${T}/cxx:${PATH}
-}
 
 python_configure_all() {
 	append-cxxflags -std=c++17 # for old gcc / clang that use <17 (bug #892331)

--- a/dev-python/PyQt6/PyQt6-6.5.1.ebuild
+++ b/dev-python/PyQt6/PyQt6-6.5.1.ebuild
@@ -66,18 +66,7 @@ RDEPEND="
 BDEPEND="
 	>=dev-python/PyQt-builder-1.15[${PYTHON_USEDEP}]
 	>=dev-qt/qtbase-${QT_PV}
-	sys-devel/gcc
 	dbus? ( virtual/pkgconfig )"
-
-src_prepare() {
-	default
-
-	# hack: qmake queries g++ directly for info (not building) and that doesn't
-	# work with clang, this is to make it at least respect CHOST (bug #726112)
-	mkdir "${T}"/cxx || die
-	ln -s "$(type -P ${CHOST}-g++ || type -P g++ || die)" "${T}"/cxx/g++ || die
-	PATH=${T}/cxx:${PATH}
-}
 
 python_configure_all() {
 	append-cxxflags -std=c++17 # for old gcc / clang that use <17 (bug #892331)


### PR DESCRIPTION
This appears to no longer be necessary, I've verified that it builds without the hack with both clang and gcc. This also removes the dependency on gcc.