### PR TITLE
dev-qt/qtwayland: Add dev-qt/qtbase[egl] usedep

### DIFF
--- a/dev-qt/qtwayland/qtwayland-6.5.1-r1.ebuild
+++ b/dev-qt/qtwayland/qtwayland-6.5.1-r1.ebuild
@@ -14,7 +14,7 @@ fi
 BDEPEND="dev-util/wayland-scanner"
 DEPEND="
 	dev-libs/wayland
-	=dev-qt/qtbase-${PV}*[gui,opengl]
+	=dev-qt/qtbase-${PV}*[egl,gui,opengl]
 	=dev-qt/qtdeclarative-${PV}*
 	media-libs/libglvnd
 	x11-libs/libxkbcommon


### PR DESCRIPTION
Using qtwayland with qt6 apps when dev-qt/qtbase is compiled without egl seems to cause some issues. As mentioned in the linked bug, it seems to cause runtime warnings for every qt6 app, but it also has more severe effects such as causing a segfault in qutebrowser (see https://github.com/qutebrowser/qutebrowser/issues/7603).

Closes: https://bugs.gentoo.org/900589