### PR TITLE
sci-libs/opencascade: Fix build on musl

### DIFF
--- a/profiles/features/musl/package.mask
+++ b/profiles/features/musl/package.mask
@@ -106,20 +106,6 @@ sys-libs/libstdc++-v3
 # bug #713542
 net-misc/casync
 
-# Bernd Waibel <waebbl-gentoo@posteo.net> (2022-03-14)
-# Doesn't build with musl, bug #832742
-app-doc/kicad-doc
-media-gfx/freecad
-media-gfx/prusaslicer
-media-gfx/superslicer
-sci-electronics/kicad
-sci-electronics/kicad-footprints
-sci-electronics/kicad-meta
-sci-electronics/kicad-packages3d
-sci-electronics/kicad-symbols
-sci-electronics/kicad-templates
-sci-libs/opencascade
-
 # Stephan Hartmann <sultan@gentoo.org> (2022-02-10)
 # Doesn't build on musl, bug #833028
 www-client/chromium

--- a/profiles/features/musl/use.mask
+++ b/profiles/features/musl/use.mask
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # Select the correct ELIBC
@@ -8,11 +8,6 @@ elibc_glibc
 # Andrey Grozin <grozin@gentoo.org> (2022-12-01)
 # dev-lisp/sbcl is masked
 sbcl
-
-# Sam James <sam@gentoo.org> (2022-10-04)
-# sci-libs/opencascade is masked on musl
-occ
-opencascade
 
 # Sam James <sam@gentoo.org> (2022-10-04)
 # Mask USE flags which pull in a binary package linked against glibc (rolling

--- a/sci-libs/opencascade/files/opencascade-7.7.0-musl.patch
+++ b/sci-libs/opencascade/files/opencascade-7.7.0-musl.patch
@@ -1,0 +1,97 @@
+From 4351ac37b19bf43ff9a8f21e5126deb7f43f751e Mon Sep 17 00:00:00 2001
+From: Violet Purcell <vimproved@inventati.org>
+Date: Tue, 11 Jul 2023 16:13:32 -0400
+Subject: [PATCH] Fix building with musl
+
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -554,6 +554,10 @@ OCCT_IS_PRODUCT_REQUIRED (CSF_EIGEN CAN_USE_EIGEN)
+ # define CSF variable
+ OCCT_INCLUDE_CMAKE_FILE ("adm/cmake/occt_csf")
+ 
++# Check for execinfo.h
++include(CheckIncludeFile)
++CHECK_INCLUDE_FILE("execinfo.h" HAS_EXECINFO_H)
++
+ # Tcl (mandatory for Draw Harness)
+ if (USE_TCL)
+   message (STATUS "Info: TCL is used by OCCT")
+--- a/src/OSD/OSD_MemInfo.cxx
++++ b/src/OSD/OSD_MemInfo.cxx
+@@ -184,12 +184,16 @@ void OSD_MemInfo::Update()
+     #endif
+   #endif
+ 
++  #if defined(__GLIBC__)
+   #ifdef HAS_MALLINFO2
+     const struct mallinfo2 aMI = mallinfo2();
+   #else
+     const struct mallinfo aMI = mallinfo();
+   #endif
+     myCounters[MemHeapUsage] = aMI.uordblks;
++  #else
++    myCounters[MemHeapUsage] = 0;
++  #endif
+   }
+ 
+   if (!IsActive (MemVirtual)
+--- a/src/OSD/OSD_signal.cxx
++++ b/src/OSD/OSD_signal.cxx
+@@ -758,7 +758,7 @@ typedef void (* SIG_PFV) (int);
+ 
+ #include <signal.h>
+ 
+-#if !defined(__ANDROID__) && !defined(__QNX__) && !defined(__EMSCRIPTEN__)
++#if !defined(__ANDROID__) && !defined(__QNX__) && !defined(__EMSCRIPTEN__) &&  defined(__GLIBC__)
+   #include <sys/signal.h>
+ #endif
+ 
+@@ -974,7 +974,7 @@ static void SegvHandler(const int theSignal,
+ //=======================================================================
+ void OSD::SetFloatingSignal (Standard_Boolean theFloatingSignal)
+ {
+-#if defined (__linux__)
++#if defined (__linux__) && defined(__GLIBC__)
+   feclearexcept (FE_ALL_EXCEPT);
+   if (theFloatingSignal)
+   {
+@@ -1007,7 +1007,7 @@ void OSD::SetFloatingSignal (Standard_Boolean theFloatingSignal)
+ //=======================================================================
+ Standard_Boolean OSD::ToCatchFloatingSignals()
+ {
+-#if defined (__linux__)
++#if defined (__linux__) && defined(__GLIBC__)
+   return (fegetexcept() & _OSD_FPX) != 0;
+ #else
+   return Standard_False;
+--- a/src/Standard/Standard_StackTrace.cxx
++++ b/src/Standard/Standard_StackTrace.cxx
+@@ -29,7 +29,7 @@
+   //#include <unwind.h>
+ #elif defined(__QNX__)
+   //#include <backtrace.h> // requires linking to libbacktrace
+-#elif !defined(_WIN32) && !(defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE)
++#elif defined (HAS_EXECINFO_H)
+   #include <execinfo.h>
+ #elif defined(_WIN32) && !defined(OCCT_UWP)
+ 
+@@ -313,7 +313,7 @@ Standard_Boolean Standard::StackTrace (char* theBuffer,
+   Message::SendTrace ("Standard::StackTrace() is not implemented for this CPU architecture");
+   return false;
+ #endif
+-#else
++#elif defined (HAS_EXECINFO_H)
+   const int aTopSkip = theNbTopSkip + 1; // skip this function call and specified extra number
+   int aNbTraces = theNbTraces + aTopSkip;
+   void** aStackArr = (void** )alloca (sizeof(void*) * aNbTraces);
+@@ -360,5 +360,7 @@ Standard_Boolean Standard::StackTrace (char* theBuffer,
+     strcat (theBuffer, "\n=============");
+   }
+   return true;
++#else
++  return false;
+ #endif
+ }
+-- 
+2.41.0
+

--- a/sci-libs/opencascade/opencascade-7.6.3-r2.ebuild
+++ b/sci-libs/opencascade/opencascade-7.6.3-r2.ebuild
@@ -1,24 +1,23 @@
 # Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-# USE_{DRACO,FFMPEG,FREEIMAGE,FREETYPE,GLES2,OPENGL,OPENVR,RAPIDJSON,TBB,TK,VTK,XLIB}
-
 EAPI=8
 
 inherit cmake
 
 MY_SLOT="$(ver_cut 1-2)"
-MY_PV="$(ver_rs 3 '-')"
+COMMIT="b079fb9877ef64d4a8158a60fa157f59b096debb"
+COMMIT_SHORT="${COMMIT:0:7}"
 
 DESCRIPTION="Development platform for CAD/CAE, 3D surface/solid modeling and data exchange"
 HOMEPAGE="https://www.opencascade.com"
-SRC_URI="https://git.dev.opencascade.org/gitweb/?p=occt.git;a=snapshot;h=185d29b92f6764ffa9fc195b7dbe7bba3c4ac855;sf=tgz -> ${P}.tar.gz"
-S="${WORKDIR}/occt-185d29b"
+SRC_URI="https://git.dev.opencascade.org/gitweb/?p=occt.git;a=snapshot;h=${COMMIT};sf=tgz -> ${P}.tar.gz"
+S="${WORKDIR}/occt-${COMMIT_SHORT}"
 
 LICENSE="|| ( Open-CASCADE-LGPL-2.1-Exception-1.0 LGPL-2.1 )"
 SLOT="0/${MY_SLOT}"
 KEYWORDS="amd64 ~arm64 ~riscv ~x86"
-IUSE="doc examples ffmpeg freeimage gles2 json optimize tbb vtk"
+IUSE="doc eigen examples ffmpeg freeimage gles2 json optimize tbb vtk"
 
 REQUIRED_USE="?? ( optimize tbb )"
 
@@ -26,13 +25,18 @@ REQUIRED_USE="?? ( optimize tbb )"
 # properly set up.
 RESTRICT="test"
 
-# ffmpeg: https://tracker.dev.opencascade.org/view.php?id=32871
+# ffmpeg: https://dev.opencascade.org/content/build-error-when-compiling-against-ffmpeg-5
 RDEPEND="
 	!app-eselect/eselect-opencascade
 	dev-lang/tcl:=
 	dev-lang/tk:=
+	dev-tcltk/itcl
+	dev-tcltk/itk
+	dev-tcltk/tix
 	media-libs/fontconfig
 	media-libs/freetype:2
+	media-libs/ftgl
+	virtual/glu
 	virtual/opengl
 	x11-libs/libX11
 	examples? (
@@ -49,21 +53,23 @@ RDEPEND="
 "
 DEPEND="
 	${RDEPEND}
+	eigen? ( dev-cpp/eigen )
 	json? ( dev-libs/rapidjson )
 	vtk? ( dev-libs/utfcpp )
 "
 BDEPEND="
-	doc? ( app-doc/doxygen )
+	doc? ( app-doc/doxygen[dot] )
 	examples? ( dev-qt/linguist-tools:5 )
 "
 
 PATCHES=(
+	"${FILESDIR}"/${PN}-7.5.1-0004-fix-installation-of-cmake-config-files.patch
 	"${FILESDIR}"/${PN}-7.5.1-0005-fix-write-permissions-on-scripts.patch
 	"${FILESDIR}"/${PN}-7.5.1-0006-fix-creation-of-custom.sh-script.patch
-	"${FILESDIR}"/${PN}-7.7.0-add-missing-include-limits.patch
-	"${FILESDIR}"/${PN}-7.7.0-fix-installation-of-cmake-config-files.patch
-	"${FILESDIR}"/${PN}-7.7.0-avoid-pre-stripping-binaries.patch
+	"${FILESDIR}"/${PN}-7.6.2-avoid-pre-stripping-binaries.patch
+	"${FILESDIR}"/${PN}-7.5.3-tbb-2021.patch
 	"${FILESDIR}"/${PN}-7.7.0-build-against-vtk-9.2.patch
+	"${FILESDIR}"/${PN}-7.7.0-musl.patch
 )
 
 src_prepare() {
@@ -102,9 +108,7 @@ src_configure() {
 		-DUSE_D3D=NO
 		# no package yet in tree
 		-DUSE_DRACO=OFF
-		# has no function in 7.7.0_beta
-		# see https://dev.opencascade.org/content/occt-770-beta-version-available#comment-23733
-		-DUSE_EIGEN=OFF
+		-DUSE_EIGEN=$(usex eigen)
 		-DUSE_FFMPEG=$(usex ffmpeg)
 		-DUSE_FREEIMAGE=$(usex freeimage)
 		-DUSE_FREETYPE=ON
@@ -126,10 +130,6 @@ src_configure() {
 			-D3RDPARTY_QT_DIR="${ESYSROOT}"/usr
 			-DBUILD_SAMPLES_QT=ON
 		)
-	fi
-
-	if use tbb; then
-		mycmakeargs+=( -D3RDPARTY_TBB_DIR="${ESYSROOT}"/usr )
 	fi
 
 	if use vtk; then


### PR DESCRIPTION
Fixes building and unmasks opencascade on musl. Conditionalized use of GNU extensions behind the __GLIBC__ macro (and execinfo.h behind a cmake configure step for those using libexecinfo from an overlay). Patch adapted from alpine.