### PR TITLE
sci-biology/pilercr: Fix error: ISO C++17 does not allow register sto…

### DIFF
--- a/sci-biology/pilercr/files/pilercr-1.0-drop-registers.patch
+++ b/sci-biology/pilercr/files/pilercr-1.0-drop-registers.patch
@@ -1,0 +1,14 @@
+--- a/comp.cpp
++++ b/comp.cpp
+@@ -28,7 +28,7 @@ void Complement(char *seq, int len)
+   /* Complement and reverse sequence */
+ 
+ 
+-  { register unsigned char *s, *t;
++  { unsigned char *s, *t;
+     int c;
+ 
+ 
+old mode 100644
+new mode 100755
+Binary files a/pilercr and b/pilercr differ

--- a/sci-biology/pilercr/pilercr-1.0-r3.ebuild
+++ b/sci-biology/pilercr/pilercr-1.0-r3.ebuild
@@ -1,0 +1,29 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs
+
+DESCRIPTION="Analysis of Clustered Regularly Interspaced Short Palindromic Repeats (CRISPRs)"
+HOMEPAGE="http://www.drive5.com/pilercr/"
+SRC_URI="http://www.drive5.com/pilercr/pilercr1.06.tar.gz -> ${P}.tar.gz"
+S="${WORKDIR}"
+
+LICENSE="public-domain"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-1.0-fix-build-system.patch
+	"${FILESDIR}"/${PN}-1.0-gcc43.patch
+	"${FILESDIR}"/${PN}-1.0-drop-registers.patch
+)
+
+src_configure() {
+	tc-export CXX
+}
+
+src_install() {
+	dobin pilercr
+}


### PR DESCRIPTION
…rage class specifier

Closes: https://bugs.gentoo.org/898124