### PR TITLE
*/*: http -> https and HOMEPAGE fixes

### DIFF
--- a/app-cdr/mirage2iso/metadata.xml
+++ b/app-cdr/mirage2iso/metadata.xml
@@ -14,7 +14,7 @@
 			<email>mgorny@gentoo.org</email>
 			<name>Michał Górny</name>
 		</maintainer>
-		<bugs-to>https://github.com/mgorny/mirage2iso/issues/</bugs-to>
-		<remote-id type="github">mgorny/mirage2iso</remote-id>
+		<bugs-to>https://github.com/projg2/mirage2iso/issues/</bugs-to>
+		<remote-id type="github">projg2/mirage2iso</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/app-cdr/mirage2iso/mirage2iso-0.4.2-r1.ebuild
+++ b/app-cdr/mirage2iso/mirage2iso-0.4.2-r1.ebuild
@@ -1,13 +1,13 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
 DESCRIPTION="CD/DVD image converter using libmirage"
-HOMEPAGE="https://github.com/mgorny/mirage2iso/"
+HOMEPAGE="https://github.com/projg2/mirage2iso/"
 SRC_URI="
-	https://github.com/mgorny/${PN}/releases/download/v${PV}/${P}.tar.xz
-	test? ( https://github.com/mgorny/${PN}/releases/download/v${PV}/${P}-tests.tar.xz )"
+	https://github.com/projg2/${PN}/releases/download/v${PV}/${P}.tar.xz
+	test? ( https://github.com/projg2/${PN}/releases/download/v${PV}/${P}-tests.tar.xz )"
 
 LICENSE="BSD"
 SLOT="0"

--- a/app-cdr/mirage2iso/mirage2iso-9999.ebuild
+++ b/app-cdr/mirage2iso/mirage2iso-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -6,8 +6,8 @@ EAPI=8
 inherit autotools git-r3
 
 DESCRIPTION="CD/DVD image converter using libmirage"
-HOMEPAGE="https://github.com/mgorny/mirage2iso/"
-EGIT_REPO_URI="https://github.com/mgorny/mirage2iso.git"
+HOMEPAGE="https://github.com/projg2/mirage2iso/"
+EGIT_REPO_URI="https://github.com/projg2/mirage2iso.git"
 
 LICENSE="BSD"
 SLOT="0"

--- a/app-eselect/eselect-lib-bin-symlink/eselect-lib-bin-symlink-0.1.1-r1.ebuild
+++ b/app-eselect/eselect-lib-bin-symlink/eselect-lib-bin-symlink-0.1.1-r1.ebuild
@@ -4,8 +4,8 @@
 EAPI=7
 
 DESCRIPTION="An eselect library to manage executable symlinks"
-HOMEPAGE="https://github.com/mgorny/eselect-lib-bin-symlink/"
-SRC_URI="https://github.com/mgorny/eselect-lib-bin-symlink/releases/download/${P}/${P}.tar.bz2"
+HOMEPAGE="https://github.com/projg2/eselect-lib-bin-symlink/"
+SRC_URI="https://github.com/projg2/eselect-lib-bin-symlink/releases/download/${P}/${P}.tar.bz2"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/app-eselect/eselect-lib-bin-symlink/eselect-lib-bin-symlink-9999.ebuild
+++ b/app-eselect/eselect-lib-bin-symlink/eselect-lib-bin-symlink-9999.ebuild
@@ -6,8 +6,8 @@ EAPI=7
 inherit autotools git-r3
 
 DESCRIPTION="An eselect library to manage executable symlinks"
-HOMEPAGE="https://github.com/mgorny/eselect-lib-bin-symlink/"
-EGIT_REPO_URI="https://github.com/mgorny/eselect-lib-bin-symlink.git"
+HOMEPAGE="https://github.com/projg2/eselect-lib-bin-symlink/"
+EGIT_REPO_URI="https://github.com/projg2/eselect-lib-bin-symlink.git"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/app-eselect/eselect-lib-bin-symlink/metadata.xml
+++ b/app-eselect/eselect-lib-bin-symlink/metadata.xml
@@ -10,8 +10,8 @@
       <email>mgorny@gentoo.org</email>
       <name>Michał Górny</name>
     </maintainer>
-    <bugs-to>https://github.com/mgorny/eselect-lib-bin-symlink/issues/</bugs-to>
-    <remote-id type="github">mgorny/eselect-lib-bin-symlink</remote-id>
+    <bugs-to>https://github.com/projg2/eselect-lib-bin-symlink/issues/</bugs-to>
+    <remote-id type="github">projg2/eselect-lib-bin-symlink</remote-id>
   </upstream>
   <stabilize-allarches/>
 </pkgmetadata>

--- a/app-text/openjade/openjade-1.3.2-r9.ebuild
+++ b/app-text/openjade/openjade-1.3.2-r9.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 inherit autotools flag-o-matic sgml-catalog-r1 toolchain-funcs
 
 DESCRIPTION="Jade is an implementation of DSSSL for formatting SGML and XML documents"
-HOMEPAGE="http://openjade.sourceforge.net"
+HOMEPAGE="https://openjade.sourceforge.net"
 SRC_URI="https://downloads.sourceforge.net/project/${PN}/${PN}/${PV}/${P}.tar.gz"
 
 LICENSE="MIT"

--- a/app-text/xhtml11/xhtml11-20101123.ebuild
+++ b/app-text/xhtml11/xhtml11-20101123.ebuild
@@ -1,12 +1,12 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 inherit sgml-catalog-r1
 
 DESCRIPTION="DTDs for the eXtensible HyperText Markup Language 1.0"
-HOMEPAGE="http://www.w3.org/TR/xhtml11/"
-SRC_URI="http://www.w3.org/TR/xhtml11/xhtml11.tgz -> ${P}.tar.gz"
+HOMEPAGE="https://www.w3.org/TR/xhtml11/"
+SRC_URI="https://www.w3.org/TR/xhtml11/xhtml11.tgz -> ${P}.tar.gz"
 
 LICENSE="W3C"
 SLOT="0"

--- a/dev-dotnet/pe-format/metadata.xml
+++ b/dev-dotnet/pe-format/metadata.xml
@@ -10,7 +10,7 @@
       <email>mgorny@gentoo.org</email>
       <name>Michał Górny</name>
     </maintainer>
-    <bugs-to>https://github.com/mgorny/pe-format2/issues/</bugs-to>
-    <remote-id type="bitbucket">mgorny/pe-format2</remote-id>
+    <bugs-to>https://github.com/projg2/pe-format2/issues/</bugs-to>
+    <remote-id type="bitbucket">projg2/pe-format2</remote-id>
   </upstream>
 </pkgmetadata>

--- a/dev-dotnet/pe-format/pe-format-2.1.2-r1.ebuild
+++ b/dev-dotnet/pe-format/pe-format-2.1.2-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -6,8 +6,8 @@ EAPI=7
 inherit systemd xdg-utils
 
 DESCRIPTION="Intelligent PE executable wrapper for binfmt_misc"
-HOMEPAGE="https://github.com/mgorny/pe-format2/"
-SRC_URI="https://github.com/mgorny/pe-format2/releases/download/v${PV}/${P}.tar.bz2"
+HOMEPAGE="https://github.com/projg2/pe-format2/"
+SRC_URI="https://github.com/projg2/pe-format2/releases/download/v${PV}/${P}.tar.bz2"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/dev-dotnet/pe-format/pe-format-9999.ebuild
+++ b/dev-dotnet/pe-format/pe-format-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -6,8 +6,8 @@ EAPI=7
 inherit autotools git-r3 systemd xdg-utils
 
 DESCRIPTION="Intelligent PE executable wrapper for binfmt_misc"
-HOMEPAGE="https://github.com/mgorny/pe-format2/"
-EGIT_REPO_URI="https://github.com/mgorny/pe-format2.git"
+HOMEPAGE="https://github.com/projg2/pe-format2/"
+EGIT_REPO_URI="https://github.com/projg2/pe-format2.git"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/dev-util/squashdelta/metadata.xml
+++ b/dev-util/squashdelta/metadata.xml
@@ -10,7 +10,7 @@
 			<email>mgorny@gentoo.org</email>
 			<name>Michał Górny</name>
 		</maintainer>
-		<bugs-to>https://github.com/mgorny/squashdelta/issues/</bugs-to>
-		<remote-id type="github">mgorny/squashdelta</remote-id>
+		<bugs-to>https://github.com/projg2/squashdelta/issues/</bugs-to>
+		<remote-id type="github">projg2/squashdelta</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/dev-util/squashdelta/squashdelta-0.1.1.ebuild
+++ b/dev-util/squashdelta/squashdelta-0.1.1.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
 DESCRIPTION="Efficient (partially uncompressed) SquashFS binary delta tool"
-HOMEPAGE="https://github.com/mgorny/squashdelta/"
-SRC_URI="https://github.com/mgorny/squashdelta/releases/download/v${PV}/${P}.tar.bz2"
+HOMEPAGE="https://github.com/projg2/squashdelta/"
+SRC_URI="https://github.com/projg2/squashdelta/releases/download/v${PV}/${P}.tar.bz2"
 
 # uses public-domain murmurhash3
 LICENSE="BSD public-domain"

--- a/dev-util/squashdelta/squashdelta-0.1.2.ebuild
+++ b/dev-util/squashdelta/squashdelta-0.1.2.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
 DESCRIPTION="Efficient (partially uncompressed) SquashFS binary delta tool"
-HOMEPAGE="https://github.com/mgorny/squashdelta/"
-SRC_URI="https://github.com/mgorny/squashdelta/releases/download/v${PV}/${P}.tar.bz2"
+HOMEPAGE="https://github.com/projg2/squashdelta/"
+SRC_URI="https://github.com/projg2/squashdelta/releases/download/v${PV}/${P}.tar.bz2"
 
 # uses public-domain murmurhash3
 LICENSE="BSD public-domain"

--- a/dev-util/squashdelta/squashdelta-9999.ebuild
+++ b/dev-util/squashdelta/squashdelta-9999.ebuild
@@ -1,13 +1,13 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-EGIT_REPO_URI="https://github.com/mgorny/${PN}.git"
+EGIT_REPO_URI="https://github.com/projg2/${PN}.git"
 inherit autotools git-r3
 
 DESCRIPTION="Efficient (partially uncompressed) SquashFS binary delta tool"
-HOMEPAGE="https://github.com/mgorny/squashdelta/"
+HOMEPAGE="https://github.com/projg2/squashdelta/"
 SRC_URI=""
 
 # uses public-domain murmurhash3

--- a/dev-util/squashmerge/metadata.xml
+++ b/dev-util/squashmerge/metadata.xml
@@ -10,7 +10,7 @@
 			<email>mgorny@gentoo.org</email>
 			<name>Michał Górny</name>
 		</maintainer>
-		<bugs-to>https://github.com/mgorny/squashmerge/issues/</bugs-to>
-		<remote-id type="github">mgorny/squashmerge</remote-id>
+		<bugs-to>https://github.com/projg2/squashmerge/issues/</bugs-to>
+		<remote-id type="github">projg2/squashmerge</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/dev-util/squashmerge/squashmerge-0.1.ebuild
+++ b/dev-util/squashmerge/squashmerge-0.1.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
 DESCRIPTION="dev-util/squashdelta delta merge tool"
-HOMEPAGE="https://github.com/mgorny/squashmerge/"
-SRC_URI="https://github.com/mgorny/${PN}/releases/download/v${PV}/${P}.tar.bz2"
+HOMEPAGE="https://github.com/projg2/squashmerge/"
+SRC_URI="https://github.com/projg2/${PN}/releases/download/v${PV}/${P}.tar.bz2"
 
 LICENSE="BSD"
 SLOT="0"

--- a/dev-util/squashmerge/squashmerge-9999.ebuild
+++ b/dev-util/squashmerge/squashmerge-9999.ebuild
@@ -1,13 +1,13 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-EGIT_REPO_URI="https://github.com/mgorny/${PN}.git"
+EGIT_REPO_URI="https://github.com/projg2/${PN}.git"
 inherit autotools git-r3
 
 DESCRIPTION="dev-util/squashdelta delta merge tool"
-HOMEPAGE="https://github.com/mgorny/squashmerge/"
+HOMEPAGE="https://github.com/projg2/squashmerge/"
 SRC_URI=""
 
 LICENSE="BSD"

--- a/media-gfx/pixels2pgf/metadata.xml
+++ b/media-gfx/pixels2pgf/metadata.xml
@@ -10,7 +10,7 @@
 			<email>mgorny@gentoo.org</email>
 			<name>Michał Górny</name>
 		</maintainer>
-		<bugs-to>https://github.com/mgorny/pixels2pgf/issues/</bugs-to>
-		<remote-id type="github">mgorny/pixels2pgf</remote-id>
+		<bugs-to>https://github.com/projg2/pixels2pgf/issues/</bugs-to>
+		<remote-id type="github">projg2/pixels2pgf</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/media-gfx/pixels2pgf/pixels2pgf-0.1.ebuild
+++ b/media-gfx/pixels2pgf/pixels2pgf-0.1.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
 DESCRIPTION="Convert pixel images (e.g. QRCode) to PGF/Tikz rectangles"
-HOMEPAGE="https://github.com/mgorny/pixels2pgf/"
-SRC_URI="https://github.com/mgorny/pixels2pgf/releases/download/${P}/${P}.tar.bz2"
+HOMEPAGE="https://github.com/projg2/pixels2pgf/"
+SRC_URI="https://github.com/projg2/pixels2pgf/releases/download/${P}/${P}.tar.bz2"
 
 LICENSE="BSD"
 SLOT="0"

--- a/media-gfx/pixels2pgf/pixels2pgf-9999.ebuild
+++ b/media-gfx/pixels2pgf/pixels2pgf-9999.ebuild
@@ -1,13 +1,13 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
 
-EGIT_REPO_URI="https://github.com/mgorny/${PN}.git"
+EGIT_REPO_URI="https://github.com/projg2/${PN}.git"
 inherit autotools git-r3
 
 DESCRIPTION="Convert pixel images (e.g. QRCode) to PGF/Tikz rectangles"
-HOMEPAGE="https://github.com/mgorny/pixels2pgf/"
+HOMEPAGE="https://github.com/projg2/pixels2pgf/"
 SRC_URI=""
 
 LICENSE="BSD"

--- a/sci-libs/libh2o/libh2o-0.2.1-r1.ebuild
+++ b/sci-libs/libh2o/libh2o-0.2.1-r1.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
 DESCRIPTION="Library of routines for IF97 water & steam properties"
-HOMEPAGE="https://github.com/mgorny/libh2o/"
-SRC_URI="https://github.com/mgorny/libh2o/releases/download/${P}/${P}.tar.bz2"
+HOMEPAGE="https://github.com/projg2/libh2o/"
+SRC_URI="https://github.com/projg2/libh2o/releases/download/${P}/${P}.tar.bz2"
 
 LICENSE="BSD"
 SLOT="0"

--- a/sci-libs/libh2o/metadata.xml
+++ b/sci-libs/libh2o/metadata.xml
@@ -10,7 +10,7 @@
 			<email>mgorny@gentoo.org</email>
 			<name>Michał Górny</name>
 		</maintainer>
-		<bugs-to>https://github.com/mgorny/libh2o/issues/</bugs-to>
-		<remote-id type="github">mgorny/libh2o</remote-id>
+		<bugs-to>https://github.com/projg2/libh2o/issues/</bugs-to>
+		<remote-id type="github">projg2/libh2o</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/sci-libs/libh2oxx/libh2oxx-0.2-r1.ebuild
+++ b/sci-libs/libh2oxx/libh2oxx-0.2-r1.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
 DESCRIPTION="C++ bindings for libh2o"
-HOMEPAGE="https://github.com/mgorny/libh2oxx/"
-SRC_URI="https://github.com/mgorny/libh2oxx/releases/download/${P}/${P}.tar.bz2"
+HOMEPAGE="https://github.com/projg2/libh2oxx/"
+SRC_URI="https://github.com/projg2/libh2oxx/releases/download/${P}/${P}.tar.bz2"
 
 LICENSE="BSD"
 SLOT="0"

--- a/sci-libs/libh2oxx/metadata.xml
+++ b/sci-libs/libh2oxx/metadata.xml
@@ -10,7 +10,7 @@
 			<email>mgorny@gentoo.org</email>
 			<name>Michał Górny</name>
 		</maintainer>
-		<bugs-to>https://github.com/mgorny/libh2oxx/issues/</bugs-to>
-		<remote-id type="github">mgorny/libh2oxx</remote-id>
+		<bugs-to>https://github.com/projg2/libh2oxx/issues/</bugs-to>
+		<remote-id type="github">projg2/libh2oxx</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/sys-apps/uam/metadata.xml
+++ b/sys-apps/uam/metadata.xml
@@ -15,7 +15,7 @@
 			<email>mgorny@gentoo.org</email>
 			<name>Michał Górny</name>
 		</maintainer>
-		<bugs-to>https://github.com/mgorny/uam/issues/</bugs-to>
-		<remote-id type="github">mgorny/uam</remote-id>
+		<bugs-to>https://github.com/projg2/uam/issues/</bugs-to>
+		<remote-id type="github">projg2/uam</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/sys-apps/uam/uam-0.3.2-r1.ebuild
+++ b/sys-apps/uam/uam-0.3.2-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -6,8 +6,8 @@ EAPI=6
 inherit udev
 
 DESCRIPTION="Simple udev-based automounter for removable USB media"
-HOMEPAGE="https://github.com/mgorny/uam/"
-SRC_URI="https://github.com/mgorny/uam/releases/download/${P}/${P}.tar.bz2"
+HOMEPAGE="https://github.com/projg2/uam/"
+SRC_URI="https://github.com/projg2/uam/releases/download/${P}/${P}.tar.bz2"
 
 LICENSE="BSD"
 SLOT="0"

--- a/sys-apps/uam/uam-9999.ebuild
+++ b/sys-apps/uam/uam-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -6,9 +6,9 @@ EAPI=6
 inherit autotools git-r3 udev
 
 DESCRIPTION="Simple udev-based automounter for removable USB media"
-HOMEPAGE="https://github.com/mgorny/uam/"
+HOMEPAGE="https://github.com/projg2/uam/"
 SRC_URI=""
-EGIT_REPO_URI="https://github.com/mgorny/uam.git"
+EGIT_REPO_URI="https://github.com/projg2/uam.git"
 
 LICENSE="BSD"
 SLOT="0"

--- a/sys-auth/google-authenticator-wrappers/google-authenticator-wrappers-1.ebuild
+++ b/sys-auth/google-authenticator-wrappers/google-authenticator-wrappers-1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -6,8 +6,8 @@ EAPI=7
 inherit cmake
 
 DESCRIPTION="Set of scripts to manage google-auth setup on Gentoo Infra"
-HOMEPAGE="https://github.com/mgorny/google-authenticator-wrappers"
-SRC_URI="https://github.com/mgorny/google-authenticator-wrappers/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+HOMEPAGE="https://github.com/projg2/google-authenticator-wrappers"
+SRC_URI="https://github.com/projg2/google-authenticator-wrappers/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="BSD-2"
 SLOT="0"

--- a/sys-auth/google-authenticator-wrappers/google-authenticator-wrappers-2.ebuild
+++ b/sys-auth/google-authenticator-wrappers/google-authenticator-wrappers-2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -6,8 +6,8 @@ EAPI=7
 inherit cmake
 
 DESCRIPTION="Set of scripts to manage google-auth setup on Gentoo Infra"
-HOMEPAGE="https://github.com/mgorny/google-authenticator-wrappers"
-SRC_URI="https://github.com/mgorny/google-authenticator-wrappers/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+HOMEPAGE="https://github.com/projg2/google-authenticator-wrappers"
+SRC_URI="https://github.com/projg2/google-authenticator-wrappers/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="BSD-2"
 SLOT="0"

--- a/sys-auth/google-authenticator-wrappers/google-authenticator-wrappers-3-r1.ebuild
+++ b/sys-auth/google-authenticator-wrappers/google-authenticator-wrappers-3-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -6,8 +6,8 @@ EAPI=7
 inherit cmake
 
 DESCRIPTION="Set of scripts to manage google-auth setup on Gentoo Infra"
-HOMEPAGE="https://github.com/mgorny/google-authenticator-wrappers"
-SRC_URI="https://github.com/mgorny/google-authenticator-wrappers/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+HOMEPAGE="https://github.com/projg2/google-authenticator-wrappers"
+SRC_URI="https://github.com/projg2/google-authenticator-wrappers/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="BSD-2"
 SLOT="0"

--- a/sys-auth/google-authenticator-wrappers/metadata.xml
+++ b/sys-auth/google-authenticator-wrappers/metadata.xml
@@ -5,4 +5,12 @@
 		<email>mgorny@gentoo.org</email>
 		<name>Michał Górny</name>
 	</maintainer>
+	<upstream>
+		<maintainer status="active">
+			<email>mgorny@gentoo.org</email>
+			<name>Michał Górny</name>
+		</maintainer>
+		<bugs-to>https://github.com/projg2/google-authenticator-wrappers/issues/</bugs-to>
+		<remote-id type="github">projg2/google-authenticator-wrappers</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/www-servers/pshs/pshs-0.4.1.ebuild
+++ b/www-servers/pshs/pshs-0.4.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -6,9 +6,9 @@ EAPI=7
 inherit meson
 
 DESCRIPTION="Pretty small HTTP server -- a command-line tool to share files"
-HOMEPAGE="https://github.com/mgorny/pshs/"
+HOMEPAGE="https://github.com/projg2/pshs/"
 SRC_URI="
-	https://github.com/mgorny/pshs/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+	https://github.com/projg2/pshs/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0"


### PR DESCRIPTION
@mgorny 

Just another round of `http` -> `https` and HOMEPAGE fixes.
Some notes:
* `app-text/xhtml11` replaces some Links in `pkg_postinst` which i've also update to use `https` Links. Not sure if that is fine.
* `sys-auth/google-authenticator-wrappers` here i've also updated the `metadata.xml` and added you as upstream maintainer.
* `media-gfx/pixels2pgf` and `sys-apps/uam` are still at `EAPI6`. They also have live ebuilds which i think could be removed?

Please review