### PR TITLE
net-misc/r8152: linux-mod-r1, new hardware support

### DIFF
--- a/net-misc/r8152/files/r8152-2.16.3-asus-c5000-support.patch
+++ b/net-misc/r8152/files/r8152-2.16.3-asus-c5000-support.patch
@@ -1,0 +1,23 @@
+From: https://github.com/wget/realtek-r8152-linux/issues/30
+From: Mark Taylor <mark.taylor.hq@gmail.com>
+Date: Thu, 8 Jun 2023 14:36:30 -0400
+Subject: [PATCH] Add support for ASUS C2500
+
+--- a/r8152.c
++++ b/r8152.c
+@@ -807,6 +807,7 @@
+ #define VENDOR_ID_LINKSYS		0x13b1
+ #define VENDOR_ID_NVIDIA		0x0955
+ #define VENDOR_ID_TPLINK		0x2357
++#define VENDOR_ID_ASUS			0x0b05
+ 
+ #define MCU_TYPE_PLA			0x0100
+ #define MCU_TYPE_USB			0x0000
+@@ -20846,6 +20847,8 @@
+ 	/* Getac */
+ 	REALTEK_USB_DEVICE(0x2baf, 0x0012),
+ 
++	/* ASUS */
++	REALTEK_USB_DEVICE(VENDOR_ID_ASUS, 0x1976),
+ 	{}
+ };

--- a/net-misc/r8152/r8152-2.16.3-r1.ebuild
+++ b/net-misc/r8152/r8152-2.16.3-r1.ebuild
@@ -1,0 +1,52 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit udev linux-info linux-mod-r1
+
+DESCRIPTION="r8152 driver for Realtek USB FE / GBE / 2.5G Gaming Ethernet Family Controller"
+HOMEPAGE="https://www.realtek.com/en/component/zoo/category/network-interface-controllers-10-100-1000m-gigabit-ethernet-usb-3-0-software"
+SRC_URI="http://rtitwww.realtek.com/rtdrivers/cn/nic1/${P}.tar.bz2"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+RDEPEND="virtual/udev"
+DEPEND="${RDEPEND}"
+
+IUSE="+center-tap-short"
+
+# https://github.com/wget/realtek-r8152-linux/ keeps reasonably up to date
+# with kernel support patches. It appears to be used by the AUR maintainer.
+PATCHES=(
+	"${FILESDIR}"/${PN}-2.16.3-kernel-5.19-fix.patch
+	"${FILESDIR}"/${PN}-2.16.3-kernel-6.1-fix.patch
+	"${FILESDIR}"/${PN}-2.16.3-asus-c5000-support.patch
+)
+
+src_compile() {
+	local modlist=( ${PN}=kernel/net/usb:. )
+	local modargs=(
+		KERNELDIR="${KV_OUT_DIR}"
+		CONFIG_CTAP_SHORT="$(usex center-tap-short on off)"
+	)
+
+	linux-mod-r1_src_compile
+}
+
+src_install() {
+	linux-mod-r1_src_install
+	udev_dorules 50-usb-realtek-net.rules
+}
+
+pkg_postinst() {
+	linux-mod-r1_pkg_postinst
+	udev_reload
+}
+
+pkg_postrm() {
+	linux-mod-r1_pkg_postrm
+	udev_reload
+}


### PR DESCRIPTION
Uses new eclass, linux-mod-r1.
Adds patch with support for ASUS USB C5000 cards.

This is the first of three changes needed to migrate fully to the new eclass:
- Add new eclass version to unstable (this)
- Stabilize new version (next)
- Remove existing with old eclass

Bug: https://bugs.gentoo.org/908703
