### PR TITLE
app-emulation/libvirt: Fix EnvironmentFile= in systemd units

### DIFF
--- a/app-emulation/libvirt/libvirt-9.4.0.ebuild
+++ b/app-emulation/libvirt/libvirt-9.4.0.ebuild
@@ -303,7 +303,7 @@ src_configure() {
 		-Ddriver_vmware=enabled
 
 		--localstatedir="${EPREFIX}/var"
-		-Dinitconfdir="${EPREFIX}/etc/conf.d"
+		-Dinitconfdir="${EPREFIX}/etc/systemd"
 		-Drunstatedir="${EPREFIX}/run"
 		-Ddocdir="${EPREFIX}/usr/share/doc/${PF}"
 	)

--- a/app-emulation/libvirt/libvirt-9999.ebuild
+++ b/app-emulation/libvirt/libvirt-9999.ebuild
@@ -302,7 +302,7 @@ src_configure() {
 		-Ddriver_vmware=enabled
 
 		--localstatedir="${EPREFIX}/var"
-		-Dinitconfdir="${EPREFIX}/etc/conf.d"
+		-Dinitconfdir="${EPREFIX}/etc/systemd"
 		-Drunstatedir="${EPREFIX}/run"
 		-Ddocdir="${EPREFIX}/usr/share/doc/${PF}"
 	)


### PR DESCRIPTION
Libvirt installs systemd unit files with EnvironmentFile= derived from initconfdir option passed in the configure phase, e.g.:

  src/ch/virtchd.service.in:21:EnvironmentFile=-@initconfdir@/virtchd

And since we explicitly pass:

  -Dinitconfdir="${EPREFIX}/etc/conf.d"

this results in systemd unit files using /etc/conf.d/ which is discouraged.

Closes: https://bugs.gentoo.org/908750