### PR TITLE
net-misc/omniORB: enable py3.11

### DIFF
--- a/net-misc/omniORB/omniORB-4.3.0.ebuild
+++ b/net-misc/omniORB/omniORB-4.3.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{9..10} )
+PYTHON_COMPAT=( python3_{10..11} )
 
 inherit python-single-r1
 


### PR DESCRIPTION
Remove Python3.9 and add Python3.11 support.