### PR TITLE
sys-process/btop: Backport clang fix

### DIFF
--- a/sys-process/btop/btop-1.2.13-r2.ebuild
+++ b/sys-process/btop/btop-1.2.13-r2.ebuild
@@ -22,6 +22,10 @@ PATCHES=(
 	# Backported fix for https://bugs.gentoo.org/908670
 	# can be removed in 1.2.14 or later
 	"${FILESDIR}/${P}-musl-1.2.4-lfs64.patch"
+
+	# Backported patch to allow compilation with clang 16 or above
+	# can be removed in 1.2.14 or later
+	"${FILESDIR}/${P}-allow-clang.patch"
 )
 
 pkg_setup() {

--- a/sys-process/btop/btop-1.2.13-r2.ebuild
+++ b/sys-process/btop/btop-1.2.13-r2.ebuild
@@ -1,0 +1,67 @@
+# Copyright 2021-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs xdg-utils
+
+DESCRIPTION="A monitor of resources"
+HOMEPAGE="https://github.com/aristocratos/btop"
+SRC_URI="https://github.com/aristocratos/btop/archive/refs/tags/v${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="Apache-2.0"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~mips ~ppc ~ppc64 ~riscv ~x86"
+
+PATCHES=(
+	# Backported fixes for https://bugs.gentoo.org/884005,
+	# can be removed in 1.2.14 or later
+	"${FILESDIR}/${P}-fix-makefile-deps.patch"
+	"${FILESDIR}/${P}-verbose-mkdir.patch"
+
+	# Backported fix for https://bugs.gentoo.org/908670
+	# can be removed in 1.2.14 or later
+	"${FILESDIR}/${P}-musl-1.2.4-lfs64.patch"
+)
+
+pkg_setup() {
+	if [[ "${MERGE_TYPE}" != "binary" ]]; then
+		if tc-is-clang ; then
+			if [[ "$(clang-major-version)" -lt 16 ]]; then
+				die "sys-process/btop requires >=sys-devel/clang-16.0.0 to build."
+			fi
+		elif ! tc-is-gcc ; then
+			die "$(tc-getCXX) is not a supported compiler. Please use sys-devel/gcc or >=sys-devel/clang-16.0.0 instead."
+		fi
+	fi
+}
+
+src_prepare() {
+	default
+	# btop installs README.md to /usr/share/btop by default
+	sed -i '/^.*cp -p README.md.*$/d' Makefile || die
+}
+
+src_compile() {
+	# Disable btop optimization flags, since we have our flags in CXXFLAGS
+	emake VERBOSE=true OPTFLAGS="" CXX="$(tc-getCXX)"
+}
+
+src_install() {
+	emake \
+		PREFIX="${EPREFIX}/usr" \
+		DESTDIR="${D}" \
+		install
+
+	dodoc README.md CHANGELOG.md
+}
+
+pkg_postinst() {
+	xdg_desktop_database_update
+	xdg_icon_cache_update
+}
+
+pkg_postrm() {
+	xdg_desktop_database_update
+	xdg_icon_cache_update
+}

--- a/sys-process/btop/files/btop-1.2.13-allow-clang.patch
+++ b/sys-process/btop/files/btop-1.2.13-allow-clang.patch
@@ -1,0 +1,191 @@
+Support compiling with clang 16 or above.
+
+Bug: https://bugs.gentoo.org/839318
+Upstream Commit: https://github.com/aristocratos/btop/commit/7e50b03e391a346b2b6ce92be332c58d91f75a000w
+
+With hunks from:
+From af7d5086fce8d995f3f8b10677d107a1124a12bf Mon Sep 17 00:00:00 2001
+From: "Jakob P. Liljenberg" <admin@qvantnet.com>
+Date: Thu, 15 Jun 2023 17:45:05 +0200
+Subject: [PATCH] Merge pull request #510 from nobounce/LLVM
+--- a/Makefile
++++ b/Makefile
+@@ -1,4 +1,4 @@
+-#* Btop++ makefile v1.5
++#* Btop++ makefile v1.6
+ 
+ BANNER  = \n \033[38;5;196m██████\033[38;5;240m╗ \033[38;5;196m████████\033[38;5;240m╗ \033[38;5;196m██████\033[38;5;240m╗ \033[38;5;196m██████\033[38;5;240m╗\n \033[38;5;160m██\033[38;5;239m╔══\033[38;5;160m██\033[38;5;239m╗╚══\033[38;5;160m██\033[38;5;239m╔══╝\033[38;5;160m██\033[38;5;239m╔═══\033[38;5;160m██\033[38;5;239m╗\033[38;5;160m██\033[38;5;239m╔══\033[38;5;160m██\033[38;5;239m╗   \033[38;5;160m██\033[38;5;239m╗    \033[38;5;160m██\033[38;5;239m╗\n \033[38;5;124m██████\033[38;5;238m╔╝   \033[38;5;124m██\033[38;5;238m║   \033[38;5;124m██\033[38;5;238m║   \033[38;5;124m██\033[38;5;238m║\033[38;5;124m██████\033[38;5;238m╔╝ \033[38;5;124m██████\033[38;5;238m╗\033[38;5;124m██████\033[38;5;238m╗\n \033[38;5;88m██\033[38;5;237m╔══\033[38;5;88m██\033[38;5;237m╗   \033[38;5;88m██\033[38;5;237m║   \033[38;5;88m██\033[38;5;237m║   \033[38;5;88m██\033[38;5;237m║\033[38;5;88m██\033[38;5;237m╔═══╝  ╚═\033[38;5;88m██\033[38;5;237m╔═╝╚═\033[38;5;88m██\033[38;5;237m╔═╝\n \033[38;5;52m██████\033[38;5;236m╔╝   \033[38;5;52m██\033[38;5;236m║   ╚\033[38;5;52m██████\033[38;5;236m╔╝\033[38;5;52m██\033[38;5;236m║        ╚═╝    ╚═╝\n \033[38;5;235m╚═════╝    ╚═╝    ╚═════╝ ╚═╝      \033[1;3;38;5;240mMakefile v1.5\033[0m
+ 
+@@ -39,6 +39,46 @@ endif
+ 
+ override PLATFORM_LC := $(shell echo $(PLATFORM) | tr '[:upper:]' '[:lower:]')
+ 
++#? Compiler and Linker
++ifeq ($(shell $(CXX) --version | grep clang >/dev/null 2>&1; echo $$?),0)
++	override CXX_IS_CLANG := true
++endif
++override CXX_VERSION := $(shell $(CXX) -dumpfullversion -dumpversion || echo 0)
++override CXX_VERSION_MAJOR := $(shell echo $(CXX_VERSION) | cut -d '.' -f 1)
++
++CLANG_WORKS = false
++GCC_WORKS = false
++
++#? Supported is Clang 16.0.0 and later
++ifeq ($(CXX_IS_CLANG),true)
++	ifneq ($(shell test $(CXX_VERSION_MAJOR) -lt 16; echo $$?),0)
++		CLANG_WORKS := true
++	endif
++endif
++ifeq ($(CLANG_WORKS),false)
++	#? Try to find a newer GCC version
++	ifeq ($(shell command -v g++-12 >/dev/null; echo $$?),0)
++		CXX := g++-12
++	else ifeq ($(shell command -v g++-11 >/dev/null; echo $$?),0)
++		CXX := g++-11
++	else ifeq ($(shell command -v g++11 >/dev/null; echo $$?),0)
++		CXX := g++11
++	else ifeq ($(shell command -v g++ >/dev/null; echo $$?),0)
++		CXX := g++
++	endif
++	override CXX_VERSION := $(shell $(CXX) -dumpfullversion -dumpversion || echo 0)
++	override CXX_VERSION_MAJOR := $(shell echo $(CXX_VERSION) | cut -d '.' -f 1)
++	ifneq ($(shell test $(CXX_VERSION_MAJOR) -lt 10; echo $$?),0)
++		GCC_WORKS := true
++	endif
++endif
++
++ifeq ($(CLANG_WORKS),false)
++	ifeq ($(GCC_WORKS),false)
++$(error $(shell printf "\033[1;91mERROR: \033[97mCompiler too old. (Requires Clang 16.0.0, GCC 10.1.0)\033[0m"))
++	endif
++endif
++
+ #? Any flags added to TESTFLAGS must not contain whitespace for the testing to work
+ override TESTFLAGS := -fexceptions -fstack-clash-protection -fcf-protection
+ ifneq ($(PLATFORM) $(ARCH),macos arm64)
+@@ -46,7 +86,13 @@ ifneq ($(PLATFORM) $(ARCH),macos arm64)
+ endif
+ 
+ ifeq ($(STATIC),true)
+-	override ADDFLAGS += -static-libgcc -static-libstdc++
++	ifeq ($(CXX_IS_CLANG),true)
++		ifeq ($(shell $(CXX) -print-target-triple | grep gnu >/dev/null; echo $$?),0)
++$(error $(shell printf "\033[1;91mERROR: \033[97m$(CXX) can't statically link glibc\033[0m"))
++		endif
++	else
++		override ADDFLAGS += -static-libgcc -static-libstdc++
++	endif
+ 	ifneq ($(PLATFORM),macos)
+ 		override ADDFLAGS += -DSTATIC_BUILD -static -Wl,--fatal-warnings
+ 	endif
+@@ -62,33 +108,6 @@ else
+ 	override VERBOSE := true
+ endif
+ 
+-#? Compiler and Linker
+-ifeq ($(shell command -v g++-12 >/dev/null; echo $$?),0)
+-	CXX := g++-12
+-else ifeq ($(shell command -v g++-11 >/dev/null; echo $$?),0)
+-	CXX := g++-11
+-else ifeq ($(shell command -v g++11 >/dev/null; echo $$?),0)
+-	CXX := g++11
+-else ifeq ($(shell command -v g++ >/dev/null; echo $$?),0)
+-	CXX := g++
+-endif
+-override CXX_VERSION := $(shell $(CXX) -dumpfullversion -dumpversion || echo 0)
+-
+-#? Try to make sure we are using GCC/G++ version 11 or later if not instructed to use g++-10
+-ifeq ($(CXX),g++)
+-	ifeq ($(shell g++ --version | grep clang >/dev/null 2>&1; echo $$?),0)
+-		V_MAJOR := 0
+-	else
+-		V_MAJOR := $(shell echo $(CXX_VERSION) | cut -f1 -d".")
+-	endif
+-	ifneq ($(shell test $(V_MAJOR) -ge 11; echo $$?),0)
+-		ifeq ($(shell command -v g++-11 >/dev/null; echo $$?),0)
+-			override CXX := g++-11
+-			override CXX_VERSION := $(shell $(CXX) -dumpfullversion -dumpversion || echo 0)
+-		endif
+-	endif
+-endif
+-
+ #? Pull in platform specific source files and get thread count
+ ifeq ($(PLATFORM_LC),linux)
+ 	PLATFORM_DIR := linux
+@@ -115,6 +134,13 @@ ifeq ($(THREADS),1)
+ 	override THREADS := auto
+ endif
+ 
++#? LTO command line
++ifeq ($(CLANG_WORKS),true)
++	LTO := thin
++else
++	LTO := $(THREADS)
++endif
++
+ #? The Directories, Source, Includes, Objects and Binary
+ SRCDIR		:= src
+ INCDIR		:= include
+@@ -130,8 +156,8 @@ override GOODFLAGS := $(foreach flag,$(TESTFLAGS),$(strip $(shell echo "int main
+ #? Flags, Libraries and Includes
+ override REQFLAGS   := -std=c++20
+ WARNFLAGS			:= -Wall -Wextra -pedantic
+-OPTFLAGS			:= -O2 -ftree-loop-vectorize -flto=$(THREADS)
++OPTFLAGS			:= -O2 -ftree-vectorize -flto=$(LTO)
+ LDCXXFLAGS			:= -pthread -D_FORTIFY_SOURCE=2 -D_GLIBCXX_ASSERTIONS -D_FILE_OFFSET_BITS=64 $(GOODFLAGS) $(ADDFLAGS)
+ override CXXFLAGS	+= $(REQFLAGS) $(LDCXXFLAGS) $(OPTFLAGS) $(WARNFLAGS)
+ override LDFLAGS	+= $(LDCXXFLAGS) $(OPTFLAGS) $(WARNFLAGS)
+ INC					:= -I$(INCDIR) -I$(SRCDIR)
+--- a/src/btop.cpp
++++ b/src/btop.cpp
+@@ -37,6 +37,11 @@ tab-size = 4
+ 	#include <mach-o/dyld.h>
+ 	#include <limits.h>
+ #endif
++#if !defined(__clang__) && __GNUC__ < 11
++	#include <semaphore.h>
++#else
++	#include <semaphore>
++#endif
+ 
+ #include <btop_shared.hpp>
+ #include <btop_tools.hpp>
+@@ -321,14 +326,12 @@ namespace Runner {
+ 	atomic<bool> coreNum_reset (false);
+ 
+ 	//* Setup semaphore for triggering thread to do work
+-#if __GNUC__ < 11
+-	#include <semaphore.h>
++#if !defined(__clang__) && __GNUC__ < 11
+ 	sem_t do_work;
+ 	inline void thread_sem_init() { sem_init(&do_work, 0, 0); }
+ 	inline void thread_wait() { sem_wait(&do_work); }
+ 	inline void thread_trigger() { sem_post(&do_work); }
+ #else
+-	#include <semaphore>
+ 	std::binary_semaphore do_work(0);
+ 	inline void thread_sem_init() { ; }
+ 	inline void thread_wait() { do_work.acquire(); }
+--- a/src/btop_tools.cpp
++++ b/src/btop_tools.cpp
+@@ -17,6 +17,7 @@ tab-size = 4
+ */
+ 
+ #include <cmath>
++#include <codecvt>
+ #include <iostream>
+ #include <fstream>
+ #include <ctime>
+--- a/src/btop.cpp
++++ b/src/btop.cpp
+@@ -657,7 +657,7 @@ namespace Runner {
+ 				<< Term::sync_end << flush;
+ 		}
+ 		//* ----------------------------------------------- THREAD LOOP -----------------------------------------------
+-		pthread_exit(NULL);
++		return {};
+ 	}
+ 	//? ------------------------------------------ Secondary thread end -----------------------------------------------
+
+-- 
+2.41.0

--- a/sys-process/btop/files/btop-1.2.13-musl-1.2.4-lfs64.patch
+++ b/sys-process/btop/files/btop-1.2.13-musl-1.2.4-lfs64.patch
@@ -1,0 +1,39 @@
+Fix for building on musl 1.2.4 and above due to deprecation of LFS64 interfaces.
+
+Bug: https://bugs.gentoo.org/908670
+Upstream Commit: https://github.com/aristocratos/btop/commit/7e50b03e391a346b2b6ce92be332c58d91f75a000w
+
+With hunks from:
+From af7d5086fce8d995f3f8b10677d107a1124a12bf Mon Sep 17 00:00:00 2001
+From: "Jakob P. Liljenberg" <admin@qvantnet.com>
+Date: Thu, 15 Jun 2023 17:45:05 +0200
+Subject: [PATCH] Merge pull request #510 from nobounce/LLVM
+--- a/src/linux/btop_collect.cpp
++++ b/src/linux/btop_collect.cpp
+@@ -1079,9 +1079,9 @@ namespace Mem {
+ 				bool new_ignored = false;
+ 				for (auto& [mountpoint, disk] : disks) {
+ 					if (std::error_code ec; not fs::exists(mountpoint, ec) or v_contains(ignore_list, mountpoint)) continue;
+-					struct statvfs64 vfs;
+-					if (statvfs64(mountpoint.c_str(), &vfs) < 0) {
+-						Logger::warning("Failed to get disk/partition stats for mount \""+ mountpoint + "\" with statvfs64 error code: " + to_string(errno) + ". Ignoring...");
++					struct statvfs vfs;
++					if (statvfs(mountpoint.c_str(), &vfs) < 0) {
++						Logger::warning("Failed to get disk/partition stats for mount \""+ mountpoint + "\" with statvfs error code: " + to_string(errno) + ". Ignoring...");
+ 						ignore_list.push_back(mountpoint);
+ 						new_ignored = true;
+ 						continue;
+--- a/Makefile
++++ b/Makefile
+@@ -130,8 +156,8 @@ override GOODFLAGS := $(foreach flag,$(TESTFLAGS),$(strip $(shell echo "int main
+ #? Flags, Libraries and Includes
+ override REQFLAGS   := -std=c++20
+ WARNFLAGS			:= -Wall -Wextra -pedantic
+ OPTFLAGS			:= -O2 -ftree-loop-vectorize -flto=$(THREADS)
+-LDCXXFLAGS			:= -pthread -D_FORTIFY_SOURCE=2 -D_GLIBCXX_ASSERTIONS $(GOODFLAGS) $(ADDFLAGS)
++LDCXXFLAGS			:= -pthread -D_FORTIFY_SOURCE=2 -D_GLIBCXX_ASSERTIONS -D_FILE_OFFSET_BITS=64 $(GOODFLAGS) $(ADDFLAGS)
+ override CXXFLAGS	+= $(REQFLAGS) $(LDCXXFLAGS) $(OPTFLAGS) $(WARNFLAGS)
+ override LDFLAGS	+= $(LDCXXFLAGS) $(OPTFLAGS) $(WARNFLAGS)
+ INC					:= -I$(INCDIR) -I$(SRCDIR)
+-- 
+2.41.0


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/839318
Closes: https://bugs.gentoo.org/908670

The same commit that allowed building with clang also fixes https://bugs.gentoo.org/908670 (musl LFS64 issue).