### PR TITLE
x11-libs/gtk+: add media-libs/libepoxy[egl], media-libs/libepoxy[egl]: remove hppa stable mask

### DIFF
--- a/profiles/arch/hppa/package.use.stable.mask
+++ b/profiles/arch/hppa/package.use.stable.mask
@@ -42,10 +42,6 @@ net-misc/chrony pps
 # Unstable dependencies (dev-libs/libnl, sys-cluster/rdma-core)
 net-libs/libpcap netlink rdma
 
-# Sam James <sam@gentoo.org> (2021-11-17)
-# media-libs/mesa is not marked stable on HPPA
-media-libs/libepoxy egl
-
 # Rolf Eike Beer <eike@sf-mail.de> (2021-11-10)
 # The following packages have no stable keywords on hppa:
 # net-mail/courier-imap mail-mta/courier

--- a/x11-libs/gtk+/gtk+-3.24.38.ebuild
+++ b/x11-libs/gtk+/gtk+-3.24.38.ebuild
@@ -26,7 +26,7 @@ COMMON_DEPEND="
 	>=dev-libs/glib-2.57.2:2[${MULTILIB_USEDEP}]
 	media-libs/fontconfig[${MULTILIB_USEDEP}]
 	>=media-libs/harfbuzz-2.2.0:=
-	>=media-libs/libepoxy-1.4[X(+)?,${MULTILIB_USEDEP}]
+	>=media-libs/libepoxy-1.4[X(+)?,egl,${MULTILIB_USEDEP}]
 	virtual/libintl[${MULTILIB_USEDEP}]
 	>=x11-libs/cairo-1.14[aqua?,glib,svg(+),X?,${MULTILIB_USEDEP}]
 	>=x11-libs/gdk-pixbuf-2.30:2[introspection?,${MULTILIB_USEDEP}]


### PR DESCRIPTION
`gdk/wayland/gdkdisplay-wayland.h` includes `epoxy/egl.h`.