### PR TITLE
media-sound/orpheus: Fix build \w clang-16

### DIFF
--- a/media-sound/orpheus/files/orpheus-1.6-fix-build-w-clang-16.patch
+++ b/media-sound/orpheus/files/orpheus-1.6-fix-build-w-clang-16.patch
@@ -1,0 +1,87 @@
+Bug: https://bugs.gentoo.org/897794
+Some replacements for making it possible to be built with clang-16
+Some of the functions (for eample binary_function and bind1st) are removed in C++17
+--- a/kkconsui-0.1/src/texteditor.cc
++++ b/kkconsui-0.1/src/texteditor.cc
+@@ -791,7 +791,8 @@ void texteditor::showline(int ln, int startx, int distance, int extrax) {
+     const char *p;
+ 
+     if(!(cs = (char *) curfile->lines->at(ln))) return;
+-    char cp[i = (strlen(cs)+1)*4];
++	i = (strlen(cs)+1)*4;
++    char cp[i];
+     char buf[i];
+ 
+     eolstart = i;
+--- a/kkstrtext-0.1/kkstrtext.cc
++++ b/kkstrtext-0.1/kkstrtext.cc
+@@ -167,7 +167,7 @@ string toutf8(const string &text) {
+ }
+ 
+ char *unmime(char *text) {
+-    register int s, d;
++    int s, d;
+     int htm;
+ 
+     for(s = 0, d = 0; text[s] != 0; s++) {
+@@ -185,7 +185,7 @@ char *unmime(char *text) {
+ }
+ 
+ char *mime(char *dst, const char *src) {
+-    register int s, d;
++    int s, d;
+     char c;
+ 
+     for(s = 0, d = 0; src[s]; s++) {
+--- a/src/cdtrack.cc
++++ b/src/cdtrack.cc
+@@ -45,8 +45,12 @@ int cdfd = -1, numtracks;
+ string cddbquery, cdid, cdtitle;
+ bool ejected = false;
+ 
+-struct istracknumber: public binary_function<int, const track*, bool> {
+-    public: bool operator()(int n, const track *c) const {
++struct istracknumber {
++    public:
++		using first_argument_type = int;
++		using second_argument_type = const track*;
++		using result_type = bool;
++		bool operator()(int n, const track *c) const {
+ 	const cdtrack *cdt = static_cast<const cdtrack *>(c);
+ 
+ 	if(cdt) {
+@@ -104,7 +108,7 @@ vector<string> cdtrack::getstatus() const {
+ 
+ 	r.push_back("CD: " + cdtitle + "; " + buf);
+ 
+-	it = find_if(plist.begin(), plist.end(), bind1st(istracknumber(), subc.cdsc_trk));
++	it = find_if(plist.begin(), plist.end(), bind(istracknumber(), subc.cdsc_trk, std::placeholders::_1));
+ 
+ 	if(it != plist.end()) {
+ 	    cdtrack *ct = static_cast<cdtrack *>(*it);
+@@ -332,7 +336,7 @@ bool cdtrack::loadtracks(const string &fname) {
+ 
+ 		} else if(param.substr(0, 6) == "TTITLE") {
+ 		    ntrack = strtoul(param.substr(6).c_str(), 0, 0);
+-		    it = find_if(plist.begin(), plist.end(), bind1st(istracknumber(), ntrack+1));
++		    it = find_if(plist.begin(), plist.end(), bind(istracknumber(), ntrack+1, std::placeholders::_1));
+ 
+ 		    if(it != plist.end()) {
+ 			cdtrack *ct = static_cast<cdtrack *>(*it);
+--- a/src/streamtrack.cc
++++ b/src/streamtrack.cc
+@@ -283,8 +283,12 @@ string streamtrack::makerequest(const string &url) {
+     return reply;
+ }
+ 
+-struct equals_url: public binary_function<const char *, const track*, bool> {
+-    public: bool operator()(const char *aurl, const track *c) const {
++struct equals_url {
++    public: 
++		using first_argument_type = const char*;
++		using second_argument_type = const track*;
++		using result_type = bool;
++		bool operator()(const char *aurl, const track *c) const {
+ 	const streamtrack *st = static_cast<const streamtrack *>(c);
+ 
+ 	if(st) {

--- a/media-sound/orpheus/orpheus-1.6-r4.ebuild
+++ b/media-sound/orpheus/orpheus-1.6-r4.ebuild
@@ -1,0 +1,44 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit autotools
+
+DESCRIPTION="Command line MP3 player"
+HOMEPAGE="http://konst.org.ua/en/orpheus"
+SRC_URI="http://konst.org.ua/download/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86"
+
+RDEPEND="sys-libs/ncurses:0=
+	media-libs/libvorbis
+	media-sound/mpg123
+	media-sound/vorbis-tools[ogg123]"
+DEPEND="${RDEPEND}"
+
+PATCHES=(
+	"${FILESDIR}"/1.5-amd64.patch
+	"${FILESDIR}"/101_fix-buffer-overflow.diff
+	"${FILESDIR}"/${P}-fix-buildsystem.patch
+	"${FILESDIR}"/${P}-cppflags.patch
+	"${FILESDIR}"/${P}-bufsize.patch
+	"${FILESDIR}"/${P}-gcc47.patch
+	"${FILESDIR}"/${P}-constify.patch
+	"${FILESDIR}"/${P}-musl-stdint.patch
+	"${FILESDIR}"/${P}-fix-build-w-clang-16.patch
+)
+
+src_prepare() {
+	default
+
+	cp config.rpath kkstrtext-0.1/ || die
+
+	mv configure.{in,ac} || die
+	mv kkstrtext-0.1/configure.{in,ac} || die
+	mv kkconsui-0.1/configure.{in,ac} || die
+
+	eautoreconf
+}


### PR DESCRIPTION
Mainly dropping register storage class and replacing some functions which are removed in C++17.