### PR TITLE
sci-astronomy/pal: Fix call to undeclared library function strlcpy

### DIFF
--- a/sci-astronomy/pal/files/pal-0.9.8-fix-strlcpy-musl.patch
+++ b/sci-astronomy/pal/files/pal-0.9.8-fix-strlcpy-musl.patch
@@ -1,0 +1,13 @@
+Bug: https://bugs.gentoo.org/898106
+bsd/string.h is available on most libc's
+--- a/palDfltin.c
++++ b/palDfltin.c
+@@ -121,6 +121,8 @@ static int ISBLANK( int c ) {
+ 
+ #ifdef HAVE_BSD_STRING_H
+ #include <bsd/string.h>
++#else
++#define _GNU_SOURCE
+ #endif
+ 
+ /* System include files */

--- a/sci-astronomy/pal/pal-0.9.8-r1.ebuild
+++ b/sci-astronomy/pal/pal-0.9.8-r1.ebuild
@@ -1,0 +1,38 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DESCRIPTION="Positional Astronomy Library"
+HOMEPAGE="https://github.com/Starlink/pal"
+SRC_URI="https://github.com/Starlink/${PN}/releases/download/v${PV}/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86 ~amd64-linux ~x86-linux"
+IUSE="static-libs"
+RDEPEND="sci-astronomy/erfa:="
+DEPEND="${RDEPEND}"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-0.9.8-fix-strlcpy-musl.patch
+)
+
+src_configure() {
+	econf --without-starlink \
+		  --without-stardocs \
+		  --with-erfa \
+		  $(use_enable static-libs static)
+}
+
+src_install() {
+	default
+
+	# remove cruft from non-fhs compliant
+	dodoc -r "${ED}"/usr/{docs,manifests,news}
+	rm -r "${ED}"/usr/{docs,manifests,news} || die
+
+	if ! use static-libs; then
+		find "${ED}" -name '*.la' -delete || die
+	fi
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/898106