### PR TITLE
sys-kernel/installkernel-systemd-boot: do not create machineid dir if using ukis

### DIFF
--- a/sys-kernel/installkernel-systemd-boot/files/installkernel-systemd-boot-2-r2-00-00machineid-directory.install
+++ b/sys-kernel/installkernel-systemd-boot/files/installkernel-systemd-boot-2-r2-00-00machineid-directory.install
@@ -1,0 +1,32 @@
+#!/usr/bin/env sh
+
+# this file is installed by sys-kernel/installkernel-systemd-boot
+
+COMMAND="${1}"
+ENTRY_DIR_ABS="${3}"
+
+# this is exported by kernel-install
+if [ -z "${KERNEL_INSTALL_MACHINE_ID}" ]; then
+	exit 0
+fi
+
+if [ "${KERNEL_INSTALL_LAYOUT}" = "uki" ]; then
+	exit 0
+fi
+
+if [ "${COMMAND}" != "add" ]; then
+	exit 0
+fi
+
+# If the machine-id dir does not exist (e.g. $ESP/<machine-id>)
+# create it. It receives values directly from kernel-install.
+# This is the only function of this plugin.
+MACHINE_ID_DIR="${ENTRY_DIR_ABS%/*}"
+if ! [ -d "${MACHINE_ID_DIR}" ]; then
+	if [ "${KERNEL_INSTALL_VERBOSE}" = "1" ]; then
+		echo "+mkdir -v -p ${MACHINE_ID_DIR}"
+		mkdir -v -p "${MACHINE_ID_DIR}"
+	else
+		mkdir -p "${MACHINE_ID_DIR}"
+	fi
+fi

--- a/sys-kernel/installkernel-systemd-boot/installkernel-systemd-boot-2-r2.ebuild
+++ b/sys-kernel/installkernel-systemd-boot/installkernel-systemd-boot-2-r2.ebuild
@@ -1,0 +1,34 @@
+# Copyright 2019-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DESCRIPTION="Wrap kernel-install from systemd-boot as installkernel"
+HOMEPAGE="https://wiki.gentoo.org/wiki/No_homepage"
+S="${WORKDIR}"
+
+LICENSE="public-domain"
+SLOT="0"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~x86"
+
+RDEPEND="
+	!sys-kernel/installkernel-gentoo
+	|| (
+		sys-apps/systemd
+		sys-apps/systemd-utils[boot]
+	)
+"
+
+src_install() {
+	# we could technically use a symlink here but it would require
+	# us to know the correct path, and that implies /usr merge problems
+	into /
+	newsbin - installkernel <<-EOF
+		#!/usr/bin/env sh
+		exec kernel-install add "\${1}" "\${2}"
+	EOF
+
+	exeinto /usr/lib/kernel/install.d/
+	newexe "${FILESDIR}/${PF}-00-00machineid-directory.install" \
+		00-00machineid-directory.install
+}


### PR DESCRIPTION
@gentoo/dist-kernel one final small fix for the uki layout.

This one cleans a directory we don't need for this layout, plus an EAPI bump while we are touching this anyway.

End result is a nice and clean ESP:
```
andrew-gentoo-pc /boot # ls /boot/*/*
/boot/loader/entries.srel  /boot/loader/loader.conf  /boot/loader/random-seed

/boot/EFI/BOOT:
BOOTX64.EFI

/boot/EFI/Linux:
gentoo-6.3.8-gentoo-dist.efi  gentoo-6.4.0-rc6-gentoo-dist+.efi

/boot/EFI/systemd:
systemd-bootx64.efi
```
