### PR TITLE
dev-python/*: enable py3.12

### DIFF
--- a/dev-python/debtcollector/debtcollector-2.5.0.ebuild
+++ b/dev-python/debtcollector/debtcollector-2.5.0.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{10..12} )
 
 inherit distutils-r1 pypi
 

--- a/dev-python/oslo-context/oslo-context-5.1.1.ebuild
+++ b/dev-python/oslo-context/oslo-context-5.1.1.ebuild
@@ -6,7 +6,7 @@ EAPI=8
 DISTUTILS_USE_PEP517=setuptools
 PYPI_NO_NORMALIZE=1
 PYPI_PN=${PN/-/.}
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{10..12} )
 
 inherit distutils-r1 pypi
 

--- a/dev-python/oslo-i18n/oslo-i18n-6.0.0.ebuild
+++ b/dev-python/oslo-i18n/oslo-i18n-6.0.0.ebuild
@@ -6,7 +6,7 @@ EAPI=8
 DISTUTILS_USE_PEP517=setuptools
 PYPI_NO_NORMALIZE=1
 PYPI_PN=${PN/-/.}
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{10..12} )
 
 inherit distutils-r1 pypi
 

--- a/dev-python/oslo-serialization/oslo-serialization-5.1.1.ebuild
+++ b/dev-python/oslo-serialization/oslo-serialization-5.1.1.ebuild
@@ -6,7 +6,7 @@ EAPI=8
 DISTUTILS_USE_PEP517=setuptools
 PYPI_NO_NORMALIZE=1
 PYPI_PN=${PN/-/.}
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{10..12} )
 
 inherit distutils-r1 pypi
 

--- a/dev-python/oslo-utils/files/oslo-utils-6.1.0-py3.12-fix.patch
+++ b/dev-python/oslo-utils/files/oslo-utils-6.1.0-py3.12-fix.patch
@@ -1,0 +1,26 @@
+Subject: [PATCH] Replace deprecated assertAlmostEquals method
+
+The assertAlmostEquals method has been deprecated since Python 3.2 and
+was removed in Python 3.12 [1], assertAlmostEqual should be used as the
+replacement.
+
+[1] https://docs.python.org/3.13/whatsnew/3.12.html#removed
+
+Upstream: https://review.opendev.org/c/openstack/oslo.utils/+/886725
+
+diff --git a/oslo_utils/tests/test_timeutils.py b/oslo_utils/tests/test_timeutils.py
+index 98194f1..390d037 100644
+--- a/oslo_utils/tests/test_timeutils.py
++++ b/oslo_utils/tests/test_timeutils.py
+@@ -192,7 +192,7 @@ class TimeUtilsTest(test_base.BaseTestCase):
+         before = timeutils.utcnow()
+         after = before + datetime.timedelta(days=7, seconds=59,
+                                             microseconds=123456)
+-        self.assertAlmostEquals(604859.123456,
++        self.assertAlmostEqual(604859.123456,
+                                 timeutils.delta_seconds(before, after))
+ 
+     def test_is_soon(self):
+-- 
+2.39.3
+

--- a/dev-python/oslo-utils/oslo-utils-6.1.0-r1.ebuild
+++ b/dev-python/oslo-utils/oslo-utils-6.1.0-r1.ebuild
@@ -1,0 +1,60 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DISTUTILS_USE_PEP517=setuptools
+PYPI_NO_NORMALIZE=1
+PYPI_PN=${PN/-/.}
+PYTHON_COMPAT=( python3_{10..12} )
+
+inherit distutils-r1 pypi
+
+DESCRIPTION="Oslo Utility library"
+HOMEPAGE="
+	https://opendev.org/openstack/oslo.utils/
+	https://github.com/openstack/oslo.utils/
+	https://pypi.org/project/oslo.utils/
+"
+
+LICENSE="Apache-2.0"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~riscv ~x86"
+
+RDEPEND="
+	>=dev-python/iso8601-0.1.11[${PYTHON_USEDEP}]
+	>=dev-python/oslo-i18n-3.15.3[${PYTHON_USEDEP}]
+	>=dev-python/pytz-2013.6[${PYTHON_USEDEP}]
+	>=dev-python/netaddr-0.7.18[${PYTHON_USEDEP}]
+	>=dev-python/netifaces-0.10.4[${PYTHON_USEDEP}]
+	>=dev-python/debtcollector-1.2.0[${PYTHON_USEDEP}]
+	>=dev-python/pyparsing-2.1.0[${PYTHON_USEDEP}]
+	>=dev-python/packaging-20.4[${PYTHON_USEDEP}]
+	dev-python/pyyaml[${PYTHON_USEDEP}]
+"
+BDEPEND="
+	>=dev-python/pbr-2.2.0[${PYTHON_USEDEP}]
+	test? (
+		>=dev-python/fixtures-3.0.0[${PYTHON_USEDEP}]
+		>=dev-python/testscenarios-0.4[${PYTHON_USEDEP}]
+		>=dev-python/testtools-2.2.0[${PYTHON_USEDEP}]
+		>=dev-python/oslotest-3.2.0[${PYTHON_USEDEP}]
+		>=dev-python/ddt-1.0.1[${PYTHON_USEDEP}]
+	)
+"
+
+PATCHES=(
+	"${FILESDIR}/${P}-py3.12-fix.patch"
+)
+
+distutils_enable_tests unittest
+
+python_compile() {
+	distutils-r1_python_compile
+	find "${BUILD_DIR}"/install -name '*eventletutils*' -delete || die
+}
+
+python_test() {
+	cd "${BUILD_DIR}/install$(python_get_sitedir)" || die
+	eunittest
+}

--- a/dev-python/oslotest/files/oslotest-4.5.0-py3.12-fix.patch
+++ b/dev-python/oslotest/files/oslotest-4.5.0-py3.12-fix.patch
@@ -1,0 +1,23 @@
+Subject: [PATCH] Replace find_module function
+
+find_module function was deprecated in Python 3.4 [1] and later removed
+in Python 3.12 [2], the find_spec function should be used instead. This
+change is necessary for proper Python 3.12 support.
+
+[1] https://docs.python.org/3.4/library/importlib.html#importlib.abc.MetaPathFinder.find_module
+[2] https://github.com/python/cpython/issues/98040
+
+Upstream: https://review.opendev.org/c/openstack/oslotest/+/886646
+
+diff --git a/oslotest/modules.py b/oslotest/modules.py
+index f453b17..8fe04a2 100644
+--- a/oslotest/modules.py
++++ b/oslotest/modules.py
+@@ -45,6 +45,6 @@
+     def __init__(self, module):
+         self.module = module
+ 
+-    def find_module(self, fullname, path):
++    def find_spec(self, fullname, path, target):
+         if fullname == self.module or fullname.startswith(self.module + '.'):
+             raise ImportError

--- a/dev-python/oslotest/oslotest-4.5.0-r3.ebuild
+++ b/dev-python/oslotest/oslotest-4.5.0-r3.ebuild
@@ -1,0 +1,40 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DISTUTILS_USE_PEP517=setuptools
+PYTHON_COMPAT=( python3_{10..12} )
+
+inherit distutils-r1 pypi
+
+DESCRIPTION="Oslo test framework"
+HOMEPAGE="
+	https://opendev.org/openstack/oslotest/
+	https://github.com/openstack/oslotest/
+	https://pypi.org/project/oslotest/
+"
+
+LICENSE="Apache-2.0"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~riscv ~x86 ~amd64-linux ~x86-linux"
+
+BDEPEND="
+	>=dev-python/pbr-1.8[${PYTHON_USEDEP}]
+"
+RDEPEND="
+	>=dev-python/fixtures-3.0.0[${PYTHON_USEDEP}]
+	>=dev-python/six-1.10.0[${PYTHON_USEDEP}]
+	>=dev-python/testtools-2.2.0[${PYTHON_USEDEP}]
+"
+
+PATCHES=(
+	"${FILESDIR}/${P}-py3.12-fix.patch"
+)
+
+distutils_enable_tests unittest
+
+src_prepare() {
+	sed -i -e '/subunit/d' requirements.txt || die
+	distutils-r1_src_prepare
+}

--- a/dev-python/pyinotify/pyinotify-0.9.6-r1.ebuild
+++ b/dev-python/pyinotify/pyinotify-0.9.6-r1.ebuild
@@ -4,6 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
+# py3.12 does not work, see https://github.com/seb-m/pyinotify/issues/204
 PYTHON_COMPAT=( python3_{9..11} pypy3 )
 PYTHON_REQ_USE="threads(+)"
 

--- a/dev-python/python-memcached/python-memcached-1.59-r2.ebuild
+++ b/dev-python/python-memcached/python-memcached-1.59-r2.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( pypy3 python3_{9..11} )
+PYTHON_COMPAT=( pypy3 python3_{10..12} )
 
 inherit distutils-r1
 


### PR DESCRIPTION
Most noticeable changes:
- `dev-python/oslo-utils` and `dev-python/oslotest` need patches, I have sent them to upstream
- `dev-python/pyinotify` does not work with py3.12, I have created an issue in upstream and added comment to the ebuild.