### PR TITLE
acct-user.eclass: improve error message when usermod fails

### DIFF
--- a/eclass/acct-group.eclass
+++ b/eclass/acct-group.eclass
@@ -179,7 +179,7 @@ acct-group_pkg_preinst() {
 	fi
 
 	elog "Adding group ${ACCT_GROUP_NAME}"
-	groupadd "${opts[@]}" "${ACCT_GROUP_NAME}" || die
+	groupadd "${opts[@]}" "${ACCT_GROUP_NAME}" || die "groupadd failed with status ${?}"
 }
 
 fi

--- a/eclass/acct-user.eclass
+++ b/eclass/acct-user.eclass
@@ -362,7 +362,7 @@ acct-user_pkg_preinst() {
 		fi
 
 		elog "Adding user ${ACCT_USER_NAME}"
-		useradd "${opts[@]}" "${ACCT_USER_NAME}" || die
+		useradd "${opts[@]}" "${ACCT_USER_NAME}" || die "useradd failed with status ${?}"
 		_ACCT_USER_ADDED=1
 	fi
 
@@ -454,7 +454,7 @@ acct-user_pkg_postinst() {
 			eerror "  usermod ${optsq[*]} ${ACCT_USER_NAME}"
 		else
 			eerror "$(<"${T}/usermod-error.log")"
-			die "usermod failed"
+			die "usermod failed with status ${status}"
 		fi
 	fi
 }
@@ -502,7 +502,7 @@ acct-user_pkg_prerm() {
 	fi
 
 	elog "Locking user ${ACCT_USER_NAME}"
-	usermod "${opts[@]}" "${ACCT_USER_NAME}" || die
+	usermod "${opts[@]}" "${ACCT_USER_NAME}" || die "usermod failed with status ${?}"
 }
 
 fi


### PR DESCRIPTION
usermod refuses to update the home directory for a user with running processes. Output a more helpful message and avoid calling die for this.

For other usermod failures, output stderr as an eerror message and die.

Example output:

 * Failed to update user portage
 * This user currently has one or more running processes.
 * Please update this user manually with the following command:
 *   usermod '--comment' 'System user; portage' '--home' '/var/lib/portage/home' '--shell' '/bin/bash' '--gid' 'portage' '--groups' '' portage

Bug: https://bugs.gentoo.org/888189