### PR TITLE
net-analyzer/netdata: add dev-libs/libyaml dependency

### DIFF
--- a/net-analyzer/netdata/netdata-1.40.0.ebuild
+++ b/net-analyzer/netdata/netdata-1.40.0.ebuild
@@ -49,6 +49,7 @@ RDEPEND="
 		dev-libs/openssl:=
 	)
 	dev-libs/libuv:=
+	dev-libs/libyaml
 	cloud? ( dev-libs/protobuf:= )
 	sys-libs/zlib
 	ipmi? ( sys-libs/freeipmi )


### PR DESCRIPTION
Today I found the next error while compiling netdata: `configure: error: LIBYAML required but not found. Try installing 'libyaml-dev'`

Given that the issue was simple to fix and I had time I fixed it directly instead of opening filling a new issue on bugzilla which would have slow things down. I'm not sure if it would be better to fill a new ticket anyway to keep track of regressions or whatever in which case please let me know :)