### PR TITLE
sys-process/numactl: Fix build with clang-16 and musl

### DIFF
--- a/sys-process/numactl/files/numactl-2.0.16-configure-check-for-largefile-support.patch
+++ b/sys-process/numactl/files/numactl-2.0.16-configure-check-for-largefile-support.patch
@@ -1,0 +1,27 @@
+https://github.com/numactl/numactl/commit/246b0e695644ad614f6c324505d7cfa6e74f1fc1.patch
+From: Khem Raj <raj.khem@gmail.com>
+Date: Thu, 15 Dec 2022 12:10:37 -0800
+Subject: [PATCH] configure: Check for largefile support
+
+This helps in using 64bit versions of off_t related functions
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ configure.ac | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/configure.ac b/configure.ac
+index ebf9917..6139132 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -14,6 +14,9 @@ LT_INIT
+ 
+ AC_PROG_CC
+ 
++# Check for enabling LFS support
++AC_SYS_LARGEFILE
++
+ # Override CFLAGS so that we can specify custom CFLAGS for numademo.
+ AX_AM_OVERRIDE_VAR([CFLAGS])
+ 
+

--- a/sys-process/numactl/files/numactl-2.0.16-replace-stat64-with-normal-functions.patch
+++ b/sys-process/numactl/files/numactl-2.0.16-replace-stat64-with-normal-functions.patch
@@ -1,0 +1,65 @@
+https://github.com/numactl/numactl/commit/851bbd5b963a7a5d95b8fe3102cf05972dc72655.patch
+From: Khem Raj <raj.khem@gmail.com>
+Date: Thu, 15 Dec 2022 12:11:13 -0800
+Subject: [PATCH] shm.c: Replace stat64/fstat64/ftruncate64mmap64 with normal
+ functions
+
+These functions were needed when _FILE_OFFSET_BITS was not 64, using
+AC_SYS_LARGEFILE will detect it correctly and make the normal variants
+of these functions behave same as their *64 counterparts.
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ shm.c | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/shm.c b/shm.c
+index 20537d9..5d0d1ab 100644
+--- a/shm.c
++++ b/shm.c
+@@ -24,8 +24,8 @@
+ #include <sys/mman.h>
+ #include <sys/ipc.h>
+ #include <sys/shm.h>
+-#include <sys/fcntl.h>
+ #include <sys/stat.h>
++#include <fcntl.h>
+ #include <stdarg.h>
+ #include <errno.h>
+ #include <unistd.h>
+@@ -135,7 +135,7 @@ void attach_sysvshm(char *name, char *opt)
+ /* Attach a shared memory file. */
+ void attach_shared(char *name, char *opt)
+ {
+-	struct stat64 st;
++	struct stat st;
+ 
+ 	shmfd = open(name, O_RDWR);
+ 	if (shmfd < 0) {
+@@ -146,14 +146,14 @@ void attach_shared(char *name, char *opt)
+ 		if (shmfd < 0)
+ 			nerror("cannot create file %s", name);
+ 	}
+-	if (fstat64(shmfd, &st) < 0)
++	if (fstat(shmfd, &st) < 0)
+ 		err("shm stat");
+ 	/* the file size must be larger than mmap shmlen + shmoffset, otherwise SIGBUS
+ 	 * will be caused when we access memory, because mmaped memory is no longer in
+ 	 * the range of the file laster.
+ 	 */
+ 	if ((shmlen + shmoffset) > st.st_size) {
+-		if (ftruncate64(shmfd, shmlen + shmoffset) < 0) {
++		if (ftruncate(shmfd, shmlen + shmoffset) < 0) {
+ 			/* XXX: we could do it by hand, but it would it
+ 			   would be impossible to apply policy then.
+ 			   need to fix that in the kernel. */
+@@ -168,7 +168,7 @@ void attach_shared(char *name, char *opt)
+ 
+ 	/* RED-PEN For shmlen > address space may need to map in pieces.
+ 	   Left for some poor 32bit soul. */
+-	shmptr = mmap64(NULL, shmlen, PROT_READ | PROT_WRITE, MAP_SHARED, shmfd, shmoffset);
++	shmptr = mmap(NULL, shmlen, PROT_READ | PROT_WRITE, MAP_SHARED, shmfd, shmoffset);
+ 	if (shmptr == (char*)-1)
+ 		err("shm mmap");
+ }
+

--- a/sys-process/numactl/numactl-2.0.16-r1.ebuild
+++ b/sys-process/numactl/numactl-2.0.16-r1.ebuild
@@ -1,0 +1,69 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools multilib-minimal
+
+DESCRIPTION="Utilities and libraries for NUMA systems"
+HOMEPAGE="https://github.com/numactl/numactl"
+if [[ ${PV} == 9999 ]] ; then
+	inherit git-r3
+	EGIT_REPO_URI="https://github.com/numactl/numactl.git"
+else
+	SRC_URI="https://github.com/numactl/numactl/releases/download/v${PV}/${P}.tar.gz"
+	KEYWORDS="~alpha ~amd64 ~arm64 ~ia64 ~loong ~mips ~ppc ~ppc64 ~riscv ~sparc ~x86 ~amd64-linux"
+fi
+
+LICENSE="GPL-2"
+SLOT="0"
+IUSE="static-libs"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-2.0.14-numademo-cflags.patch # bug #540856
+	"${FILESDIR}"/${PN}-2.0.16-replace-stat64-with-normal-functions.patch # bug #540856
+	"${FILESDIR}"/${PN}-2.0.16-configure-check-for-largefile-support.patch # bug #540856
+)
+
+src_prepare() {
+	default
+
+	eautoreconf
+
+	# We need to copy the sources or else tests will fail
+	multilib_copy_sources
+}
+
+multilib_src_configure() {
+	ECONF_SOURCE="${S}" econf $(use_enable static-libs static)
+}
+
+multilib_src_compile() {
+	multilib_is_native_abi && default || emake libnuma.la
+}
+
+multilib_src_test() {
+	if multilib_is_native_abi ; then
+		if [[ -d /sys/devices/system/node ]] ; then
+			einfo "The only generically safe test is regress2."
+			einfo "The other test cases require 2 NUMA nodes."
+			emake regress2
+		else
+			ewarn "You do not have baseline NUMA support in your kernel, skipping tests."
+		fi
+	fi
+}
+
+multilib_src_install() {
+	emake DESTDIR="${D}" \
+		install$(multilib_is_native_abi || echo "-libLTLIBRARIES install-includeHEADERS")
+	find "${ED}"/usr/ -type f -name libnuma.la -delete || die
+}
+
+multilib_src_install_all() {
+	local DOCS=( README.md )
+	einstalldocs
+
+	# Delete man pages provided by the man-pages package, bug #238805
+	rm -r "${ED}"/usr/share/man/man[25] || die
+}


### PR DESCRIPTION
These are some of the patches from upstream that fixes build with clang-16 and musl, hence the backporting them till a new release.

Clsoses: https://bugs.gentoo.org/906539