### PR TITLE
mate-base/mate-panel: Fix msgfmt: no input file should be given if --…

### DIFF
--- a/mate-base/mate-panel/files/mate-panel-1.26.3-gettext-0.22-fix.patch
+++ b/mate-base/mate-panel/files/mate-panel-1.26.3-gettext-0.22-fix.patch
@@ -1,0 +1,14 @@
+Bug: https://bugs.gentoo.org/908877
+Reference: https://savannah.gnu.org/bugs/index.php?64335
+Upstream PR: https://github.com/mate-desktop/mate-panel/pull/1375
+--- a/libmate-panel-applet/Makefile.am
++++ b/libmate-panel-applet/Makefile.am
+@@ -95,7 +95,7 @@ appletdir       = $(datadir)/mate-panel/applets
+ applet_in_files = org.mate.panel.TestApplet.mate-panel-applet.desktop.in
+ noinst_DATA     = $(applet_in_files:.mate-panel-applet.desktop.in=.mate-panel-applet)
+ $(noinst_DATA): $(applet_in_files)
+-	$(AM_V_GEN) $(MSGFMT) --desktop --keyword Name --keyword Description --template $< -d $(top_srcdir)/po -o $@
++	$(AM_V_GEN) $(MSGFMT) --desktop --keyword=Name --keyword=Description --template $< -d $(top_srcdir)/po -o $@
+ 
+ EXTRA_DIST =						\
+ 	org.mate.panel.TestApplet.mate-panel-applet.desktop.in	\

--- a/mate-base/mate-panel/mate-panel-1.26.3.ebuild
+++ b/mate-base/mate-panel/mate-panel-1.26.3.ebuild
@@ -62,6 +62,10 @@ BDEPEND="
 	virtual/pkgconfig
 "
 
+PATCHES=(
+	"${FILESDIR}"/${PN}-1.26.3-gettext-0.22-fix.patch
+)
+
 src_configure() {
 	mate_src_configure \
 		--libexecdir="${EPREFIX}"/usr/libexec/mate-applets \


### PR DESCRIPTION
…desktop

Closes: https://bugs.gentoo.org/908877