### PR TITLE
virtual/openssh: keyword 0 for ~m68k, ~mips

### DIFF
--- a/virtual/openssh/openssh-0.ebuild
+++ b/virtual/openssh/openssh-0.ebuild
@@ -6,7 +6,7 @@ EAPI=8
 DESCRIPTION="Virtual for net-misc/openssh and variants"
 
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~loong ppc ppc64 ~riscv ~s390 sparc x86"
+KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86"
 IUSE="ssl"
 
 RDEPEND="


### PR DESCRIPTION
Fixes the issue with catalayst and crossdev pulling in dropbear by default when mergeing virtual/ssh on m68k and mips arches.