### PR TITLE
media-sound/flac123: requires media-libs/flac compiled with Ogg support

### DIFF
--- a/media-sound/flac123/flac123-2.1.0.ebuild
+++ b/media-sound/flac123/flac123-2.1.0.ebuild
@@ -15,7 +15,7 @@ KEYWORDS="~alpha ~amd64 ~arm ~ppc ~ppc64 ~sparc ~x86"
 
 RDEPEND="
 	dev-libs/popt
-	media-libs/flac:=
+	media-libs/flac:=[ogg]
 	media-libs/libao"
 DEPEND="${RDEPEND}"
 


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/909173
Signed-off-by: Cristian Othón Martínez Vera <cfuga@cfuga.mx>
