### PR TITLE
media-gfx/imagemagick: subscribe to media-libs/libjxl subslot

### DIFF
--- a/media-gfx/imagemagick/imagemagick-7.1.1.11-r1.ebuild
+++ b/media-gfx/imagemagick/imagemagick-7.1.1.11-r1.ebuild
@@ -48,7 +48,7 @@ RDEPEND="
 	jbig? ( >=media-libs/jbigkit-2:= )
 	jpeg? ( media-libs/libjpeg-turbo:= )
 	jpeg2k? ( >=media-libs/openjpeg-2.1.0:2 )
-	jpegxl? ( >=media-libs/libjxl-0.6 )
+	jpegxl? ( >=media-libs/libjxl-0.6:= )
 	lcms? ( media-libs/lcms:2= )
 	lqr? ( media-libs/liblqr )
 	opencl? ( virtual/opencl )

--- a/media-gfx/imagemagick/imagemagick-7.1.1.11.ebuild
+++ b/media-gfx/imagemagick/imagemagick-7.1.1.11.ebuild
@@ -48,7 +48,7 @@ RDEPEND="
 	jbig? ( >=media-libs/jbigkit-2:= )
 	jpeg? ( media-libs/libjpeg-turbo:= )
 	jpeg2k? ( >=media-libs/openjpeg-2.1.0:2 )
-	jpegxl? ( >=media-libs/libjxl-0.6 )
+	jpegxl? ( >=media-libs/libjxl-0.6:= )
 	lcms? ( media-libs/lcms:2= )
 	lqr? ( media-libs/liblqr )
 	opencl? ( virtual/opencl )

--- a/media-gfx/imagemagick/imagemagick-7.1.1.6.ebuild
+++ b/media-gfx/imagemagick/imagemagick-7.1.1.6.ebuild
@@ -48,7 +48,7 @@ RDEPEND="
 	jbig? ( >=media-libs/jbigkit-2:= )
 	jpeg? ( media-libs/libjpeg-turbo:= )
 	jpeg2k? ( >=media-libs/openjpeg-2.1.0:2 )
-	jpegxl? ( >=media-libs/libjxl-0.6 )
+	jpegxl? ( >=media-libs/libjxl-0.6:= )
 	lcms? ( media-libs/lcms:2= )
 	lqr? ( media-libs/liblqr )
 	opencl? ( virtual/opencl )

--- a/media-gfx/imagemagick/imagemagick-7.1.1.8.ebuild
+++ b/media-gfx/imagemagick/imagemagick-7.1.1.8.ebuild
@@ -48,7 +48,7 @@ RDEPEND="
 	jbig? ( >=media-libs/jbigkit-2:= )
 	jpeg? ( media-libs/libjpeg-turbo:= )
 	jpeg2k? ( >=media-libs/openjpeg-2.1.0:2 )
-	jpegxl? ( >=media-libs/libjxl-0.6 )
+	jpegxl? ( >=media-libs/libjxl-0.6:= )
 	lcms? ( media-libs/lcms:2= )
 	lqr? ( media-libs/liblqr )
 	opencl? ( virtual/opencl )

--- a/media-gfx/imagemagick/imagemagick-9999.ebuild
+++ b/media-gfx/imagemagick/imagemagick-9999.ebuild
@@ -48,7 +48,7 @@ RDEPEND="
 	jbig? ( >=media-libs/jbigkit-2:= )
 	jpeg? ( media-libs/libjpeg-turbo:= )
 	jpeg2k? ( >=media-libs/openjpeg-2.1.0:2 )
-	jpegxl? ( >=media-libs/libjxl-0.6 )
+	jpegxl? ( >=media-libs/libjxl-0.6:= )
 	lcms? ( media-libs/lcms:2= )
 	lqr? ( media-libs/liblqr )
 	opencl? ( virtual/opencl )


### PR DESCRIPTION
During the last update of ```media-libs/libjxl``` I realized that ```media-gfx/imagemagick``` wasn't rebuild when it should be. Adding a subslot operator should fix it.

Signed-off-by: Cristian Othón Martínez Vera <cfuga@cfuga.mx>
