### PR TITLE
sys-devel/llvm-common: add USE=emacs for llvm modes in utils/emacs

### DIFF
--- a/sys-devel/llvm-common/llvm-common-14.0.6.ebuild
+++ b/sys-devel/llvm-common/llvm-common-14.0.6.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-inherit llvm.org
+inherit elisp-common llvm.org
 
 DESCRIPTION="Common files shared between multiple slots of LLVM"
 HOMEPAGE="https://llvm.org/"
@@ -11,18 +11,44 @@ HOMEPAGE="https://llvm.org/"
 LICENSE="Apache-2.0-with-LLVM-exceptions UoI-NCSA"
 SLOT="0"
 KEYWORDS="amd64 arm arm64 ~ppc ppc64 ~riscv sparc x86 ~amd64-linux ~ppc-macos ~x64-macos"
+IUSE="emacs"
 
 RDEPEND="
 	!sys-devel/llvm:0
 "
+BDEPEND="
+	emacs? ( >=app-editors/emacs-23.1:* )
+"
 
-LLVM_COMPONENTS=( llvm/utils/vim )
+LLVM_COMPONENTS=( llvm/utils )
 llvm.org_set_globals
+
+SITEFILE="50llvm-gentoo.el"
+BYTECOMPFLAGS="-L emacs"
+
+src_compile() {
+	default
+
+	use emacs && elisp-compile emacs/*.el
+}
 
 src_install() {
 	insinto /usr/share/vim/vimfiles
-	doins -r */
+	doins -r vim/*/
 	# some users may find it useful
-	newdoc README README.vim
-	dodoc vimrc
+	newdoc vim/README README.vim
+	dodoc vim/vimrc
+
+	if use emacs ; then
+		elisp-install llvm emacs/*.{el,elc}
+		elisp-make-site-file "${SITEFILE}" llvm
+	fi
+}
+
+pkg_postinst() {
+	use emacs && elisp-site-regen
+}
+
+pkg_postrm() {
+	use emacs && elisp-site-regen
 }

--- a/sys-devel/llvm-common/llvm-common-15.0.7.ebuild
+++ b/sys-devel/llvm-common/llvm-common-15.0.7.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit llvm.org
+inherit elisp-common llvm.org
 
 DESCRIPTION="Common files shared between multiple slots of LLVM"
 HOMEPAGE="https://llvm.org/"
@@ -11,18 +11,44 @@ HOMEPAGE="https://llvm.org/"
 LICENSE="Apache-2.0-with-LLVM-exceptions UoI-NCSA"
 SLOT="0"
 KEYWORDS="amd64 arm arm64 ppc ppc64 ~riscv sparc x86 ~amd64-linux ~ppc-macos ~x64-macos"
+IUSE="emacs"
 
 RDEPEND="
 	!sys-devel/llvm:0
 "
+BDEPEND="
+	emacs? ( >=app-editors/emacs-23.1:* )
+"
 
-LLVM_COMPONENTS=( llvm/utils/vim )
+LLVM_COMPONENTS=( llvm/utils )
 llvm.org_set_globals
+
+SITEFILE="50llvm-gentoo.el"
+BYTECOMPFLAGS="-L emacs"
+
+src_compile() {
+	default
+
+	use emacs && elisp-compile emacs/*.el
+}
 
 src_install() {
 	insinto /usr/share/vim/vimfiles
-	doins -r */
+	doins -r vim/*/
 	# some users may find it useful
-	newdoc README README.vim
-	dodoc vimrc
+	newdoc vim/README README.vim
+	dodoc vim/vimrc
+
+	if use emacs ; then
+		elisp-install llvm emacs/*.{el,elc}
+		elisp-make-site-file "${SITEFILE}" llvm
+	fi
+}
+
+pkg_postinst() {
+	use emacs && elisp-site-regen
+}
+
+pkg_postrm() {
+	use emacs && elisp-site-regen
 }

--- a/sys-devel/llvm-common/llvm-common-16.0.6.ebuild
+++ b/sys-devel/llvm-common/llvm-common-16.0.6.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit llvm.org
+inherit elisp-common llvm.org
 
 DESCRIPTION="Common files shared between multiple slots of LLVM"
 HOMEPAGE="https://llvm.org/"
@@ -11,18 +11,44 @@ HOMEPAGE="https://llvm.org/"
 LICENSE="Apache-2.0-with-LLVM-exceptions UoI-NCSA"
 SLOT="0"
 KEYWORDS="amd64 arm arm64 ~loong ppc ppc64 ~riscv sparc x86 ~amd64-linux ~ppc-macos ~x64-macos"
+IUSE="emacs"
 
 RDEPEND="
 	!sys-devel/llvm:0
 "
+BDEPEND="
+	emacs? ( >=app-editors/emacs-23.1:* )
+"
 
-LLVM_COMPONENTS=( llvm/utils/vim )
+LLVM_COMPONENTS=( llvm/utils )
 llvm.org_set_globals
+
+SITEFILE="50llvm-gentoo.el"
+BYTECOMPFLAGS="-L emacs"
+
+src_compile() {
+	default
+
+	use emacs && elisp-compile emacs/*.el
+}
 
 src_install() {
 	insinto /usr/share/vim/vimfiles
-	doins -r */
+	doins -r vim/*/
 	# some users may find it useful
-	newdoc README README.vim
-	dodoc vimrc
+	newdoc vim/README README.vim
+	dodoc vim/vimrc
+
+	if use emacs ; then
+		elisp-install llvm emacs/*.{el,elc}
+		elisp-make-site-file "${SITEFILE}" llvm
+	fi
+}
+
+pkg_postinst() {
+	use emacs && elisp-site-regen
+}
+
+pkg_postrm() {
+	use emacs && elisp-site-regen
 }

--- a/sys-devel/llvm-common/llvm-common-17.0.1.ebuild
+++ b/sys-devel/llvm-common/llvm-common-17.0.1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit llvm.org
+inherit elisp-common llvm.org
 
 DESCRIPTION="Common files shared between multiple slots of LLVM"
 HOMEPAGE="https://llvm.org/"
@@ -11,18 +11,44 @@ HOMEPAGE="https://llvm.org/"
 LICENSE="Apache-2.0-with-LLVM-exceptions UoI-NCSA"
 SLOT="0"
 KEYWORDS="~amd64 ~arm ~arm64 ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86 ~amd64-linux ~ppc-macos ~x64-macos"
+IUSE="emacs"
 
 RDEPEND="
 	!sys-devel/llvm:0
 "
+BDEPEND="
+	emacs? ( >=app-editors/emacs-23.1:* )
+"
 
-LLVM_COMPONENTS=( llvm/utils/vim )
+LLVM_COMPONENTS=( llvm/utils )
 llvm.org_set_globals
+
+SITEFILE="50llvm-gentoo.el"
+BYTECOMPFLAGS="-L emacs"
+
+src_compile() {
+	default
+
+	use emacs && elisp-compile emacs/*.el
+}
 
 src_install() {
 	insinto /usr/share/vim/vimfiles
-	doins -r */
+	doins -r vim/*/
 	# some users may find it useful
-	newdoc README README.vim
-	dodoc vimrc
+	newdoc vim/README README.vim
+	dodoc vim/vimrc
+
+	if use emacs ; then
+		elisp-install llvm emacs/*.{el,elc}
+		elisp-make-site-file "${SITEFILE}" llvm
+	fi
+}
+
+pkg_postinst() {
+	use emacs && elisp-site-regen
+}
+
+pkg_postrm() {
+	use emacs && elisp-site-regen
 }

--- a/sys-devel/llvm-common/llvm-common-17.0.2.9999.ebuild
+++ b/sys-devel/llvm-common/llvm-common-17.0.2.9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit llvm.org
+inherit elisp-common llvm.org
 
 DESCRIPTION="Common files shared between multiple slots of LLVM"
 HOMEPAGE="https://llvm.org/"
@@ -11,18 +11,44 @@ HOMEPAGE="https://llvm.org/"
 LICENSE="Apache-2.0-with-LLVM-exceptions UoI-NCSA"
 SLOT="0"
 KEYWORDS=""
+IUSE="emacs"
 
 RDEPEND="
 	!sys-devel/llvm:0
 "
+BDEPEND="
+	emacs? ( >=app-editors/emacs-23.1:* )
+"
 
-LLVM_COMPONENTS=( llvm/utils/vim )
+LLVM_COMPONENTS=( llvm/utils )
 llvm.org_set_globals
+
+SITEFILE="50llvm-gentoo.el"
+BYTECOMPFLAGS="-L emacs"
+
+src_compile() {
+	default
+
+	use emacs && elisp-compile emacs/*.el
+}
 
 src_install() {
 	insinto /usr/share/vim/vimfiles
-	doins -r */
+	doins -r vim/*/
 	# some users may find it useful
-	newdoc README README.vim
-	dodoc vimrc
+	newdoc vim/README README.vim
+	dodoc vim/vimrc
+
+	if use emacs ; then
+		elisp-install llvm emacs/*.{el,elc}
+		elisp-make-site-file "${SITEFILE}" llvm
+	fi
+}
+
+pkg_postinst() {
+	use emacs && elisp-site-regen
+}
+
+pkg_postrm() {
+	use emacs && elisp-site-regen
 }

--- a/sys-devel/llvm-common/llvm-common-17.0.2.ebuild
+++ b/sys-devel/llvm-common/llvm-common-17.0.2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit llvm.org
+inherit elisp-common llvm.org
 
 DESCRIPTION="Common files shared between multiple slots of LLVM"
 HOMEPAGE="https://llvm.org/"
@@ -11,18 +11,44 @@ HOMEPAGE="https://llvm.org/"
 LICENSE="Apache-2.0-with-LLVM-exceptions UoI-NCSA"
 SLOT="0"
 KEYWORDS="~amd64 ~arm ~arm64 ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86 ~amd64-linux ~ppc-macos ~x64-macos"
+IUSE="emacs"
 
 RDEPEND="
 	!sys-devel/llvm:0
 "
+BDEPEND="
+	emacs? ( >=app-editors/emacs-23.1:* )
+"
 
-LLVM_COMPONENTS=( llvm/utils/vim )
+LLVM_COMPONENTS=( llvm/utils )
 llvm.org_set_globals
+
+SITEFILE="50llvm-gentoo.el"
+BYTECOMPFLAGS="-L emacs"
+
+src_compile() {
+	default
+
+	use emacs && elisp-compile emacs/*.el
+}
 
 src_install() {
 	insinto /usr/share/vim/vimfiles
-	doins -r */
+	doins -r vim/*/
 	# some users may find it useful
-	newdoc README README.vim
-	dodoc vimrc
+	newdoc vim/README README.vim
+	dodoc vim/vimrc
+
+	if use emacs ; then
+		elisp-install llvm emacs/*.{el,elc}
+		elisp-make-site-file "${SITEFILE}" llvm
+	fi
+}
+
+pkg_postinst() {
+	use emacs && elisp-site-regen
+}
+
+pkg_postrm() {
+	use emacs && elisp-site-regen
 }

--- a/sys-devel/llvm-common/llvm-common-18.0.0.9999.ebuild
+++ b/sys-devel/llvm-common/llvm-common-18.0.0.9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit llvm.org
+inherit elisp-common llvm.org
 
 DESCRIPTION="Common files shared between multiple slots of LLVM"
 HOMEPAGE="https://llvm.org/"
@@ -11,18 +11,44 @@ HOMEPAGE="https://llvm.org/"
 LICENSE="Apache-2.0-with-LLVM-exceptions UoI-NCSA"
 SLOT="0"
 KEYWORDS=""
+IUSE="emacs"
 
 RDEPEND="
 	!sys-devel/llvm:0
 "
+BDEPEND="
+	emacs? ( >=app-editors/emacs-23.1:* )
+"
 
-LLVM_COMPONENTS=( llvm/utils/vim )
+LLVM_COMPONENTS=( llvm/utils )
 llvm.org_set_globals
+
+SITEFILE="50llvm-gentoo.el"
+BYTECOMPFLAGS="-L emacs"
+
+src_compile() {
+	default
+
+	use emacs && elisp-compile emacs/*.el
+}
 
 src_install() {
 	insinto /usr/share/vim/vimfiles
-	doins -r */
+	doins -r vim/*/
 	# some users may find it useful
-	newdoc README README.vim
-	dodoc vimrc
+	newdoc vim/README README.vim
+	dodoc vim/vimrc
+
+	if use emacs ; then
+		elisp-install llvm emacs/*.{el,elc}
+		elisp-make-site-file "${SITEFILE}" llvm
+	fi
+}
+
+pkg_postinst() {
+	use emacs && elisp-site-regen
+}
+
+pkg_postrm() {
+	use emacs && elisp-site-regen
 }

--- a/sys-devel/llvm-common/llvm-common-18.0.0_pre20230925.ebuild
+++ b/sys-devel/llvm-common/llvm-common-18.0.0_pre20230925.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit llvm.org
+inherit elisp-common llvm.org
 
 DESCRIPTION="Common files shared between multiple slots of LLVM"
 HOMEPAGE="https://llvm.org/"
@@ -11,18 +11,44 @@ HOMEPAGE="https://llvm.org/"
 LICENSE="Apache-2.0-with-LLVM-exceptions UoI-NCSA"
 SLOT="0"
 KEYWORDS=""
+IUSE="emacs"
 
 RDEPEND="
 	!sys-devel/llvm:0
 "
+BDEPEND="
+	emacs? ( >=app-editors/emacs-23.1:* )
+"
 
-LLVM_COMPONENTS=( llvm/utils/vim )
+LLVM_COMPONENTS=( llvm/utils )
 llvm.org_set_globals
+
+SITEFILE="50llvm-gentoo.el"
+BYTECOMPFLAGS="-L emacs"
+
+src_compile() {
+	default
+
+	use emacs && elisp-compile emacs/*.el
+}
 
 src_install() {
 	insinto /usr/share/vim/vimfiles
-	doins -r */
+	doins -r vim/*/
 	# some users may find it useful
-	newdoc README README.vim
-	dodoc vimrc
+	newdoc vim/README README.vim
+	dodoc vim/vimrc
+
+	if use emacs ; then
+		elisp-install llvm emacs/*.{el,elc}
+		elisp-make-site-file "${SITEFILE}" llvm
+	fi
+}
+
+pkg_postinst() {
+	use emacs && elisp-site-regen
+}
+
+pkg_postrm() {
+	use emacs && elisp-site-regen
 }

--- a/sys-devel/llvm-common/llvm-common-18.0.0_pre20231002.ebuild
+++ b/sys-devel/llvm-common/llvm-common-18.0.0_pre20231002.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit llvm.org
+inherit elisp-common llvm.org
 
 DESCRIPTION="Common files shared between multiple slots of LLVM"
 HOMEPAGE="https://llvm.org/"
@@ -11,18 +11,44 @@ HOMEPAGE="https://llvm.org/"
 LICENSE="Apache-2.0-with-LLVM-exceptions UoI-NCSA"
 SLOT="0"
 KEYWORDS=""
+IUSE="emacs"
 
 RDEPEND="
 	!sys-devel/llvm:0
 "
+BDEPEND="
+	emacs? ( >=app-editors/emacs-23.1:* )
+"
 
-LLVM_COMPONENTS=( llvm/utils/vim )
+LLVM_COMPONENTS=( llvm/utils )
 llvm.org_set_globals
+
+SITEFILE="50llvm-gentoo.el"
+BYTECOMPFLAGS="-L emacs"
+
+src_compile() {
+	default
+
+	use emacs && elisp-compile emacs/*.el
+}
 
 src_install() {
 	insinto /usr/share/vim/vimfiles
-	doins -r */
+	doins -r vim/*/
 	# some users may find it useful
-	newdoc README README.vim
-	dodoc vimrc
+	newdoc vim/README README.vim
+	dodoc vim/vimrc
+
+	if use emacs ; then
+		elisp-install llvm emacs/*.{el,elc}
+		elisp-make-site-file "${SITEFILE}" llvm
+	fi
+}
+
+pkg_postinst() {
+	use emacs && elisp-site-regen
+}
+
+pkg_postrm() {
+	use emacs && elisp-site-regen
 }


### PR DESCRIPTION
llvm-mir-mode only available in master and llvm-17 snapshots. https://github.com/llvm/llvm-project/commit/8cbf041ecb1c304148cd09987f4bd73a41cb51a9

@thesamesam 