### PR TITLE
dev-libs/libtermkey: Fix QA for automagically compressing manpages

### DIFF
--- a/dev-libs/libtermkey/files/no-automagic-manpages-compress.patch
+++ b/dev-libs/libtermkey/files/no-automagic-manpages-compress.patch
@@ -1,0 +1,18 @@
+diff --git a/Makefile b/Makefile
+index 199f143..70788ee 100644
+--- a/Makefile
++++ b/Makefile
+@@ -121,13 +121,3 @@ install-lib: $(LIBRARY)
+ install-man:
+ 	install -d $(DESTDIR)$(MAN3DIR)
+ 	install -d $(DESTDIR)$(MAN7DIR)
+-	for F in man/*.3; do \
+-	  gzip <$$F >$(DESTDIR)$(MAN3DIR)/$${F#man/}.gz; \
+-	done
+-	for F in man/*.7; do \
+-	  gzip <$$F >$(DESTDIR)$(MAN7DIR)/$${F#man/}.gz; \
+-	done
+-	while read FROM EQ TO; do \
+-	  echo ln -sf $$TO.gz $(DESTDIR)$(MAN3DIR)/$$FROM.gz; \
+-	done < man/also
+-

--- a/dev-libs/libtermkey/libtermkey-0.22.ebuild
+++ b/dev-libs/libtermkey/libtermkey-0.22.ebuild
@@ -12,6 +12,9 @@ LICENSE="MIT"
 SLOT="0"
 KEYWORDS="amd64 arm arm64 ~ppc64 ~riscv x86 ~x64-macos"
 IUSE="demos static-libs"
+PATCHES=(
+	"${FILESDIR}"/no-automagic-manpages-compress.patch
+)
 
 RDEPEND="dev-libs/unibilium:="
 DEPEND="${RDEPEND}
@@ -36,4 +39,6 @@ src_install() {
 	emake PREFIX="${EPREFIX}/usr" LIBDIR="${EPREFIX}/usr/$(get_libdir)" DESTDIR="${D}" install
 	use static-libs || rm "${ED}"/usr/$(get_libdir)/${PN}.a || die
 	rm "${ED}"/usr/$(get_libdir)/${PN}.la || die
+	doman "${S}"/man/*.3
+	doman "${S}"/man/*.7
 }


### PR DESCRIPTION
Added a dead simple patch to ${FILESDIR}, so that make doesn't compress manpages by itself, thus fixing QA warning