### PR TITLE
net-mail/pfqueue: Fix incompatible pointer to integer conversion

### DIFF
--- a/net-mail/pfqueue/files/pfqueue-0.5.6-clang16-build-fix.patch
+++ b/net-mail/pfqueue/files/pfqueue-0.5.6-clang16-build-fix.patch
@@ -1,0 +1,26 @@
+Bug: https://bugs.gentoo.org/885839
+--- a/backends/pfq_socket.c
++++ b/backends/pfq_socket.c
+@@ -34,6 +34,11 @@ int    sock;
+ 
+ struct pfb_conf_t pfb_conf;
+ 
++int pfb_retr_to( const char* );
++int pfb_retr_from( const char* );
++int pfb_retr_path( const char* );
++int pfb_retr_subj( const char* );
++
+ void strip_nl(char* b, int l) {
+ 	int i;
+ 	for ( i=0; i<l; i++ ) {
+@@ -114,8 +119,8 @@ int pfb_setup( struct msg_t *qptr1, struct be_msg_t *qptr2 ) {
+ 	svra.sin_family = AF_INET;
+ 
+ 	memcpy ( (struct sockaddr*)&svra.sin_addr.s_addr, 
+-		(struct hostent*)svr->h_addr, 
+-		(struct hostent*)svr->h_length );
++		svr->h_addr, 
++		svr->h_length );
+ 	svra.sin_port = htons( pfb_conf.port );
+ 
+ 	if ( connect(sock, (struct sockaddr*)&svra, sizeof(svra)) <0 )

--- a/net-mail/pfqueue/pfqueue-0.5.6-r2.ebuild
+++ b/net-mail/pfqueue/pfqueue-0.5.6-r2.ebuild
@@ -1,0 +1,40 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit autotools
+
+DESCRIPTION="pfqueue is an ncurses console-based tool for managing Postfix queued messages"
+HOMEPAGE="http://pfqueue.sourceforge.net/"
+SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86"
+
+BDEPEND="sys-devel/libtool"
+RDEPEND="sys-libs/ncurses:="
+DEPEND="${RDEPEND}"
+
+DOCS=( README ChangeLog NEWS TODO AUTHORS )
+
+PATCHES=(
+	"${FILESDIR}"/${P}-tinfo.patch
+	"${FILESDIR}"/${PN}-0.5.6-clang16-build-fix.patch
+)
+
+src_prepare() {
+	default
+
+	eautoreconf
+}
+
+src_configure() {
+	econf --disable-static
+}
+
+src_install() {
+	default
+
+	find "${ED}" -name '*.la' -delete || die
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/885839