### PR TITLE
acct-user/havp: remove unused variable

### DIFF
--- a/acct-group/havp/havp-0-r1.ebuild
+++ b/acct-group/havp/havp-0-r1.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 inherit acct-group
 

--- a/acct-user/havp/havp-0-r1.ebuild
+++ b/acct-user/havp/havp-0-r1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 inherit acct-user
 

--- a/acct-user/havp/havp-0.ebuild
+++ b/acct-user/havp/havp-0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,7 +8,6 @@ inherit acct-user
 DESCRIPTION="User for net-proxy/havp"
 
 ACCT_USER_GROUPS=( "havp" )
-ACCT_HOME_USER="/etc/havp"
 ACCT_USER_ID="254"
 
 acct-user_add_deps


### PR DESCRIPTION
The `ACCT_HOME_USER` should have been `ACCT_USER_HOME` most probably, because pre-GLEP 81 ebuild used
```
   enewuser ${PN} -1 -1 /etc/${PN} ${PN}
```
However, no one complained about the default `/dev/null` home in last few years. I don't see any signs indicating why `/etc/havp` should be used. Therefore, it seems appropriate to remove the unused variable `ACCT_HOME_USER`.