### PR TITLE
profiles/features/musl: mask app-shells/pwsh-bin

### DIFF
--- a/profiles/features/musl/package.mask
+++ b/profiles/features/musl/package.mask
@@ -147,6 +147,7 @@ app-emulation/crossover-bin
 app-misc/kryoflux-dtc
 app-office/libreoffice-bin
 app-office/libreoffice-bin-debug
+app-shells/pwsh-bin
 app-text/master-pdf-editor
 app-text/zotero-bin
 dev-db/ocp


### PR DESCRIPTION
Binary package linked to glibc.

Signed-off-by: Cristian Othón Martínez Vera <cfuga@cfuga.mx>
