### PR TITLE
media-libs/libjxl: fix tests

### DIFF
--- a/media-libs/libjxl/files/libjxl-0.8.2-backport-pr2596.patch
+++ b/media-libs/libjxl/files/libjxl-0.8.2-backport-pr2596.patch
@@ -1,0 +1,50 @@
+https://bugs.gentoo.org/908939
+https://github.com/libjxl/libjxl/issues/2433
+https://github.com/libjxl/libjxl/pull/2596
+
+From 6a5cd1ff847e7b18ba8b87fcc11ada17dccb0692 Mon Sep 17 00:00:00 2001
+From: Sami Boukortt <sboukortt@google.com>
+Date: Thu, 22 Jun 2023 12:26:25 +0200
+Subject: [PATCH] Make sure to read the rendering intent before the CICP tag
+
+The code that reads the CICP tag exits the function if it succeeds, but
+it should not skip reading the rendering intent, so make sure to have
+already done it by that point.
+---
+ lib/jxl/enc_color_management.cc | 16 ++++++++--------
+ 1 file changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/lib/jxl/enc_color_management.cc b/lib/jxl/enc_color_management.cc
+index 752e3e02c0..2b519d152e 100644
+--- a/lib/jxl/enc_color_management.cc
++++ b/lib/jxl/enc_color_management.cc
+@@ -982,6 +982,14 @@ Status ColorEncoding::SetFieldsFromICC() {
+   Profile profile;
+   JXL_RETURN_IF_ERROR(DecodeProfile(context, icc_, &profile));
+ 
++  const cmsUInt32Number rendering_intent32 =
++      cmsGetHeaderRenderingIntent(profile.get());
++  if (rendering_intent32 > 3) {
++    return JXL_FAILURE("Invalid rendering intent %u\n", rendering_intent32);
++  }
++  // ICC and RenderingIntent have the same values (0..3).
++  rendering_intent = static_cast<RenderingIntent>(rendering_intent32);
++
+   static constexpr size_t kCICPSize = 12;
+   static constexpr auto kCICPSignature =
+       static_cast<cmsTagSignature>(0x63696370);
+@@ -993,14 +1001,6 @@ Status ColorEncoding::SetFieldsFromICC() {
+     return true;
+   }
+ 
+-  const cmsUInt32Number rendering_intent32 =
+-      cmsGetHeaderRenderingIntent(profile.get());
+-  if (rendering_intent32 > 3) {
+-    return JXL_FAILURE("Invalid rendering intent %u\n", rendering_intent32);
+-  }
+-  // ICC and RenderingIntent have the same values (0..3).
+-  rendering_intent = static_cast<RenderingIntent>(rendering_intent32);
+-
+   SetColorSpace(ColorSpaceFromProfile(profile));
+   if (cmsGetColorSpace(profile.get()) == cmsSigCmykData) {
+     cmyk_ = true;

--- a/media-libs/libjxl/files/libjxl-0.8.2-backport-pr2617.patch
+++ b/media-libs/libjxl/files/libjxl-0.8.2-backport-pr2617.patch
@@ -1,0 +1,60 @@
+https://bugs.gentoo.org/908939
+https://github.com/libjxl/libjxl/issues/2433
+https://github.com/libjxl/libjxl/pull/2617
+
+From d9637bd803bf9fadc00aa01cea7becfff1e00e1f Mon Sep 17 00:00:00 2001
+From: Sami Boukortt <sboukortt@google.com>
+Date: Mon, 26 Jun 2023 15:06:17 +0200
+Subject: [PATCH] Fix decode_test with lcms2
+
+Co-authored-by: Zoltan Szabadka <szabadka@google.com>
+Co-authored-by: Luca Versari <veluca@google.com>
+---
+ lib/jxl/decode_test.cc | 17 +++++++++++------
+ 1 file changed, 11 insertions(+), 6 deletions(-)
+
+diff --git a/lib/jxl/decode_test.cc b/lib/jxl/decode_test.cc
+index 44ead99ec6..bbb7bda39c 100644
+--- a/lib/jxl/decode_test.cc
++++ b/lib/jxl/decode_test.cc
+@@ -3734,13 +3734,18 @@ void AnalyzeCodestream(const jxl::PaddedBytes& data,
+       jxl::Span<const uint8_t>(codestream.data(), codestream.size()));
+   ASSERT_EQ(br.ReadFixedBits<16>(), 0x0AFF);
+   jxl::CodecMetadata metadata;
+-  EXPECT_TRUE(ReadSizeHeader(&br, &metadata.size));
+-  EXPECT_TRUE(ReadImageMetadata(&br, &metadata.m));
++  ASSERT_TRUE(ReadSizeHeader(&br, &metadata.size));
++  ASSERT_TRUE(ReadImageMetadata(&br, &metadata.m));
+   streampos->basic_info =
+       add_offset(br.TotalBitsConsumed() / jxl::kBitsPerByte);
+   metadata.transform_data.nonserialized_xyb_encoded = metadata.m.xyb_encoded;
+-  EXPECT_TRUE(jxl::Bundle::Read(&br, &metadata.transform_data));
+-  EXPECT_TRUE(br.JumpToByteBoundary());
++  ASSERT_TRUE(jxl::Bundle::Read(&br, &metadata.transform_data));
++  if (metadata.m.color_encoding.WantICC()) {
++    jxl::PaddedBytes icc;
++    ASSERT_TRUE(jxl::ReadICC(&br, &icc));
++    ASSERT_TRUE(metadata.m.color_encoding.SetICCRaw(std::move(icc)));
++  }
++  ASSERT_TRUE(br.JumpToByteBoundary());
+   bool has_preview = metadata.m.have_preview;
+   while (br.TotalBitsConsumed() < br.TotalBytes() * jxl::kBitsPerByte) {
+     FramePositions p;
+@@ -3750,7 +3755,7 @@ void AnalyzeCodestream(const jxl::PaddedBytes& data,
+       frame_header.nonserialized_is_preview = true;
+       has_preview = false;
+     }
+-    EXPECT_TRUE(ReadFrameHeader(&br, &frame_header));
++    ASSERT_TRUE(ReadFrameHeader(&br, &frame_header));
+     p.header_end =
+         add_offset(jxl::DivCeil(br.TotalBitsConsumed(), jxl::kBitsPerByte));
+     jxl::FrameDimensions frame_dim = frame_header.ToFrameDimensions();
+@@ -3760,7 +3765,7 @@ void AnalyzeCodestream(const jxl::PaddedBytes& data,
+         frame_header.passes.num_passes, /*has_ac_global=*/true);
+     std::vector<uint64_t> section_offsets;
+     std::vector<uint32_t> section_sizes;
+-    EXPECT_TRUE(ReadGroupOffsets(toc_entries, &br, &section_offsets,
++    ASSERT_TRUE(ReadGroupOffsets(toc_entries, &br, &section_offsets,
+                                  &section_sizes, &groups_total_size));
+     EXPECT_EQ(br.TotalBitsConsumed() % jxl::kBitsPerByte, 0);
+     size_t sections_start = br.TotalBitsConsumed() / jxl::kBitsPerByte;

--- a/media-libs/libjxl/libjxl-0.8.2-r1.ebuild
+++ b/media-libs/libjxl/libjxl-0.8.2-r1.ebuild
@@ -1,0 +1,86 @@
+# Copyright 2021-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit cmake-multilib flag-o-matic
+
+# This changes frequently.  Please check the testdata submodule when bumping.
+TESTDATA_COMMIT="d6168ffb9e1cc24007e64b65dd84d822ad1fc759"
+DESCRIPTION="JPEG XL image format reference implementation"
+HOMEPAGE="https://github.com/libjxl/libjxl"
+SRC_URI="https://github.com/libjxl/libjxl/archive/refs/tags/v${PV}.tar.gz -> ${P}.tar.gz
+	test? ( https://github.com/libjxl/testdata/archive/${TESTDATA_COMMIT}.tar.gz
+		-> ${PN}-testdata-${TESTDATA_COMMIT}.tar.gz )"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86"
+IUSE="openexr test"
+RESTRICT="!test? ( test )"
+
+DEPEND="app-arch/brotli:=[${MULTILIB_USEDEP}]
+	>=dev-cpp/highway-1.0.0[${MULTILIB_USEDEP}]
+	media-libs/giflib:=[${MULTILIB_USEDEP}]
+	>=media-libs/lcms-2.13:2[${MULTILIB_USEDEP}]
+	media-libs/libjpeg-turbo:=[${MULTILIB_USEDEP}]
+	media-libs/libpng:=[${MULTILIB_USEDEP}]
+	>=x11-misc/shared-mime-info-2.2
+	openexr? ( media-libs/openexr:= )
+	test? ( dev-cpp/gtest )
+"
+RDEPEND="${DEPEND}"
+PATCHES=(
+	"${FILESDIR}/${PN}-0.8.2-backport-pr2596.patch"
+	"${FILESDIR}/${PN}-0.8.2-backport-pr2617.patch"
+)
+
+multilib_src_configure() {
+	filter-lto
+
+	local mycmakeargs=(
+		-DJPEGXL_ENABLE_BENCHMARK=OFF
+		-DJPEGXL_ENABLE_COVERAGE=OFF
+		-DJPEGXL_ENABLE_FUZZERS=OFF
+		-DJPEGXL_ENABLE_SJPEG=OFF
+		-DJPEGXL_WARNINGS_AS_ERRORS=OFF
+
+		-DJPEGXL_ENABLE_SKCMS=OFF
+		-DJPEGXL_ENABLE_VIEWERS=OFF
+		-DJPEGXL_ENABLE_PLUGINS=OFF
+		-DJPEGXL_FORCE_SYSTEM_BROTLI=ON
+		-DJPEGXL_FORCE_SYSTEM_GTEST=ON
+		-DJPEGXL_FORCE_SYSTEM_HWY=ON
+		-DJPEGXL_FORCE_SYSTEM_LCMS2=ON
+		-DJPEGXL_ENABLE_DOXYGEN=OFF
+		-DJPEGXL_ENABLE_MANPAGES=OFF
+		-DJPEGXL_ENABLE_JNI=OFF
+		-DJPEGXL_ENABLE_JPEGLI_LIBJPEG=OFF
+		-DJPEGXL_ENABLE_TCMALLOC=OFF
+		-DJPEGXL_ENABLE_EXAMPLES=OFF
+	)
+
+	if multilib_is_native_abi; then
+		mycmakeargs+=(
+			-DJPEGXL_ENABLE_TOOLS=ON
+			-DJPEGXL_ENABLE_OPENEXR=$(usex openexr)
+			-DBUILD_TESTING=$(usex test ON OFF)
+		)
+		use test &&
+			mycmakeargs+=( -DJPEGXL_TEST_DATA_PATH="${WORKDIR}/testdata-${TESTDATA_COMMIT}" )
+	else
+		mycmakeargs+=(
+			-DJPEGXL_ENABLE_TOOLS=OFF
+			-DJPEGXL_ENABLE_OPENEXR=OFF
+			-DBUILD_TESTING=OFF
+		)
+	fi
+
+	cmake_src_configure
+}
+
+multilib_src_install() {
+	cmake_src_install
+
+	find "${ED}" -name '*.a' -delete || die
+}

--- a/profiles/features/big-endian/package.mask
+++ b/profiles/features/big-endian/package.mask
@@ -1,6 +1,11 @@
 # Copyright 2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# matoro <matoro_gentoo@matoro.tk> (2023-06-30)
+# Test failures on BE
+# https://github.com/libjxl/libjxl/issues/2433
+media-libs/libjxl
+
 # James Le Cuirot <chewi@gentoo.org> (2023-06-24)
 # Test failures on BE (#901391).
 # https://github.com/any1/neatvnc/issues/85

--- a/profiles/features/big-endian/use.mask
+++ b/profiles/features/big-endian/use.mask
@@ -1,6 +1,11 @@
 # Copyright 2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# matoro <matoro_gentoo@matoro.tk> (2023-06-30)
+# media-libs/libjxl casualties
+# https://github.com/libjxl/libjxl/issues/2433
+jpegxl
+
 # matoro <matoro_gentoo@matoro.tk> (2023-05-05)
 # media-libs/zimg casualties (https://github.com/sekrit-twc/zimg/pull/156)
 zimg


### PR DESCRIPTION
Tests were broken with lcms2.  Backporting this pair of patches from https://github.com/libjxl/libjxl/issues/2433 fixes the tests on little-endian.