### PR TITLE
media-gfx/gimp: 9999.ebuild. Pass LD_LIBRARY_PATH for src_test() phase.

### DIFF
--- a/media-gfx/gimp/gimp-9999.ebuild
+++ b/media-gfx/gimp/gimp-9999.ebuild
@@ -215,6 +215,11 @@ _rename_plugins() {
 	)
 }
 
+src_test() {
+	local -x LD_LIBRARY_PATH="${BUILD_DIR}/libgimp:${LD_LIBRARY_PATH}"
+	meson_src_test
+}
+
 src_install() {
 	meson_src_install
 


### PR DESCRIPTION
While running the tests the `gimp:2.99` tries to link system `libgimp-3.0.so` if `gimp:2.99` is already installed.
If system `libgimp-3.0` has old GIMP API then it causes some tests fail. The proposed changes should fix this problem.

Closes: https://bugs.gentoo.org/867856

For some reason the `gimp:app / core` test sometimes fails due to timeout (60 s) on my system, 
while on re-running the tests it passes in 3 s