### PR TITLE
net-wireless/gnuradio: re-introduce GCC-13 fix

### DIFF
--- a/net-wireless/gnuradio/gnuradio-3.10.6.0-r1.ebuild
+++ b/net-wireless/gnuradio/gnuradio-3.10.6.0-r1.ebuild
@@ -133,6 +133,7 @@ DEPEND="${RDEPEND}
 
 PATCHES=(
 	"${FILESDIR}/${PN}-3.10.3.0-fix-fmt-v9.patch" #858659
+	"${FILESDIR}/${PN}-3.10.6.0-fix-stdint.patch"
 )
 
 src_prepare() {


### PR DESCRIPTION
This was fixed in #31472, but then not added for -r1.