### PR TITLE
app-arch/lbzip2: Fix call to undeclared function info

### DIFF
--- a/app-arch/lbzip2/files/lbzip2-2.5_p20181227-clang16-musl-info.patch
+++ b/app-arch/lbzip2/files/lbzip2-2.5_p20181227-clang16-musl-info.patch
@@ -1,0 +1,21 @@
+Bug: https://bugs.gentoo.org/894320
+--- a/src/common.h
++++ b/src/common.h
+@@ -35,6 +35,7 @@
+ 
+ /* Tracing, useful in debugging, but not officially supported. */
+ #ifdef ENABLE_TRACING
++#include "main.h" /* Needed for info */
+ #define Trace(x) info x
+ #else
+ #define Trace(x)
+--- a/src/main.h
++++ b/src/main.h
+@@ -20,6 +20,7 @@
+   along with lbzip2.  If not, see <http://www.gnu.org/licenses/>.
+ */
+ 
++#pragma once
+ #include <limits.h>             /* CHAR_BIT */
+ 
+ #if 8 != CHAR_BIT

--- a/app-arch/lbzip2/lbzip2-2.5_p20181227-r3.ebuild
+++ b/app-arch/lbzip2/lbzip2-2.5_p20181227-r3.ebuild
@@ -1,0 +1,36 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools flag-o-matic
+
+DESCRIPTION="Parallel bzip2 utility"
+HOMEPAGE="https://github.com/kjn/lbzip2/"
+SRC_URI="https://dev.gentoo.org/~whissi/dist/${PN}/${P}.tar.gz"
+
+LICENSE="GPL-3"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux"
+IUSE="debug static"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-2.3-s_isreg.patch
+	"${FILESDIR}"/${P}-fix-unaligned.patch
+	"${FILESDIR}"/${P}-clang16.patch
+	"${FILESDIR}"/${P}-clang16-musl-info.patch
+)
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_configure() {
+	use static && append-ldflags -static
+
+	local myeconfargs=(
+		$(use_enable debug tracing)
+	)
+	econf "${myeconfargs[@]}"
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/894320