### PR TITLE
games-engines/fheroes2: fix build with gettext 0.22

### DIFF
--- a/games-engines/fheroes2/fheroes2-1.0.5.ebuild
+++ b/games-engines/fheroes2/fheroes2-1.0.5.ebuild
@@ -38,6 +38,7 @@ BDEPEND="
 
 PATCHES=(
 	"${FILESDIR}/fheroes2-1.0.4-scripts.patch"
+	"${FILESDIR}/fheroes2-1.0.5-gettext.patch"
 )
 
 src_configure() {

--- a/games-engines/fheroes2/files/fheroes2-1.0.5-gettext.patch
+++ b/games-engines/fheroes2/files/fheroes2-1.0.5-gettext.patch
@@ -1,0 +1,15 @@
+https://github.com/ihhub/fheroes2/commit/e55c33c1bc7ac1b8c2ffc6e4ca61ab47921ec1b1
+https://bugs.gentoo.org/908863
+
+--- a/files/lang/Makefile
++++ b/files/lang/Makefile
+@@ -19,7 +19,8 @@
+ ###########################################################################
+ 
+ ICONV  = iconv
+-MSGFMT = sed -e '1,20 s/UTF-8/$(1)/' $< | $(ICONV) -f utf-8 -t $(1) | msgfmt - -o $@
++# TODO: consider converting game fonts and texts to UTF-8 in the engine instead
++MSGFMT = sed -e '1,20 s/UTF-8/$(1)/' $< | $(ICONV) -f utf-8 -t $(1) | if msgfmt --help | grep -q no-convert >/dev/null 2>/dev/null; then msgfmt - -o $@ --no-convert; else msgfmt - -o $@; fi
+ 
+ .PHONY: all clean merge
+ 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/908863