### PR TITLE
dev-libs/jansson: Port to CMake

### DIFF
--- a/dev-libs/jansson/files/jansson-2.14-cmake-static-build.patch
+++ b/dev-libs/jansson/files/jansson-2.14-cmake-static-build.patch
@@ -1,0 +1,55 @@
+Patch the build system to install shared libraries by default, and add an option for static libraries. Upstream's CMakeLists can only install either static or shared libraries, not both.
+
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -2,7 +2,7 @@ cmake_minimum_required (VERSION 3.1)
+ project(jansson C)
+ 
+ # Options
+-option(JANSSON_BUILD_SHARED_LIBS "Build shared libraries." OFF)
++option(JANSSON_BUILD_STATIC_LIBS "Build static libraries." OFF)
+ option(USE_URANDOM "Use /dev/urandom to seed the hash function." ON)
+ option(USE_WINDOWS_CRYPTOAPI "Use CryptGenRandom to seed the hash function." ON)
+ 
+@@ -301,7 +301,6 @@ source_group("Library Sources" FILES ${J
+ source_group("Library Private Headers" FILES ${JANSSON_HDR_PRIVATE})
+ source_group("Library Public Headers" FILES ${JANSSON_HDR_PUBLIC})
+ 
+-if(JANSSON_BUILD_SHARED_LIBS)
+    add_library(jansson SHARED
+       ${JANSSON_SRC}
+       ${JANSSON_HDR_PRIVATE}
+@@ -349,13 +348,14 @@ if(JANSSON_BUILD_SHARED_LIBS)
+    set_target_properties(jansson PROPERTIES
+       VERSION ${JANSSON_VERSION}
+       SOVERSION ${JANSSON_SOVERSION})
+-else()
+-   add_library(jansson STATIC
++if(JANSSON_BUILD_STATIC_LIBS)
++   add_library(jansson-static STATIC
+       ${JANSSON_SRC}
+       ${JANSSON_HDR_PRIVATE}
+       ${JANSSON_HDR_PUBLIC})
+-   set_target_properties(jansson PROPERTIES
+-      POSITION_INDEPENDENT_CODE true)
++   set_target_properties(jansson-static PROPERTIES
++      POSITION_INDEPENDENT_CODE true
++      OUTPUT_NAME jansson)
+ endif()
+ 
+ if (JANSSON_EXAMPLES)
+@@ -637,6 +637,14 @@ if (JANSSON_INSTALL)
+           ARCHIVE DESTINATION "lib"
+           RUNTIME DESTINATION "bin"
+           INCLUDES DESTINATION "include")
++  if(JANSSON_BUILD_STATIC_LIBS)
++    install(TARGETS jansson-static
++            EXPORT janssonTargets
++            LIBRARY DESTINATION "lib"
++            ARCHIVE DESTINATION "lib"
++            RUNTIME DESTINATION "bin"
++            INCLUDES DESTINATION "include")
++  endif()
+ 
+   install(FILES ${JANSSON_HDR_PUBLIC}
+           DESTINATION "include")

--- a/dev-libs/jansson/jansson-2.14-r2.ebuild
+++ b/dev-libs/jansson/jansson-2.14-r2.ebuild
@@ -1,0 +1,38 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit cmake
+
+DESCRIPTION="C library for encoding, decoding and manipulating JSON data"
+HOMEPAGE="https://www.digip.org/jansson/"
+SRC_URI="https://github.com/akheron/jansson/releases/download/v${PV}/${P}.tar.gz"
+
+LICENSE="MIT"
+SLOT="0/4"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~x64-macos"
+IUSE="doc static-libs"
+
+BDEPEND="doc? ( dev-python/sphinx )"
+
+PATCHES=(
+	"${FILESDIR}/${P}-cmake-static-build.patch"
+	"${FILESDIR}/${P}-test-symbols.patch"
+)
+
+src_configure() {
+	local mycmakeargs=(
+		-DJANSSON_BUILD_STATIC_LIBS=$(usex static-libs)
+		-DJANSSON_BUILD_DOCS=$(usex doc)
+	)
+
+	cmake_src_configure
+}
+
+src_install() {
+	cmake_src_install
+
+	dodoc "${S}/README.rst"
+	dodoc "${S}/CHANGES"
+}


### PR DESCRIPTION
CMake adds a check for --default-symver support in the linker, fixing
build with ld.lld and ld.mold.

Bug: https://bugs.gentoo.org/814941