### PR TITLE
dist-kernel-utils.eclass: fix user script overrides

### DIFF
--- a/eclass/dist-kernel-utils.eclass
+++ b/eclass/dist-kernel-utils.eclass
@@ -110,13 +110,13 @@ dist-kernel_install_kernel() {
 		# https://github.com/dracutdevs/dracut/pull/2405
 		shopt -s nullglob
 		local plugins=()
-		for file in "${EROOT}"/usr/lib/kernel/install.d/*.install; do
-			if ! has "${file##*/}" 50-dracut.install 51-dracut-rescue.install; then
-					plugins+=( "${file}" )
-			fi
-		done
 		for file in "${EROOT}"/etc/kernel/install.d/*.install; do
 			plugins+=( "${file}" )
+		done
+		for file in "${EROOT}"/usr/lib/kernel/install.d/*.install; do
+			if ! has "${file##*/}" 50-dracut.install 51-dracut-rescue.install "${plugins[@]##*/}"; then
+					plugins+=( "${file}" )
+			fi
 		done
 		shopt -u nullglob
 		export KERNEL_INSTALL_PLUGINS="${KERNEL_INSTALL_PLUGINS} ${plugins[@]}"


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/909538
Signed-off-by: Chris Pritchard <chris@christopherpritchard.co.uk>

@mgorny is this what you needed? I made a slight change to the original patch I submitted to avoid an extra "if" statement, but I've checked the function works as intended