### PR TITLE
eclass/texlive-module: use HTTPS

### DIFF
--- a/eclass/texlive-module.eclass
+++ b/eclass/texlive-module.eclass
@@ -81,7 +81,7 @@ _TEXLIVE_MODULE_ECLASS=1
 
 inherit texlive-common
 
-HOMEPAGE="http://www.tug.org/texlive/"
+HOMEPAGE="https://www.tug.org/texlive/"
 
 COMMON_DEPEND=">=app-text/texlive-core-${TL_PV:-${PV}}"
 


### PR DESCRIPTION
Let's use the https version for `texlive-module.eclass` too.