### PR TITLE
dev-games/openscenegraph*, games-action/descent*: HOMEPAGE updates, use https

### DIFF
--- a/dev-games/openscenegraph-qt/openscenegraph-qt-3.5.7-r1.ebuild
+++ b/dev-games/openscenegraph-qt/openscenegraph-qt-3.5.7-r1.ebuild
@@ -8,7 +8,7 @@ MY_P=${MY_PN}-${PV}
 inherit cmake
 
 DESCRIPTION="Qt support for OpenSceneGraph"
-HOMEPAGE="https://www.openscenegraph.org/"
+HOMEPAGE="https://www.openscenegraph.com/"
 SRC_URI="https://github.com/openscenegraph/${MY_PN}/archive/${PV}.tar.gz -> ${MY_P}.tar.gz"
 
 LICENSE="wxWinLL-3 LGPL-2.1"

--- a/dev-games/openscenegraph/openscenegraph-3.6.5-r114.ebuild
+++ b/dev-games/openscenegraph/openscenegraph-3.6.5-r114.ebuild
@@ -12,7 +12,7 @@ MY_PN="OpenSceneGraph"
 MY_P=${MY_PN}-${PV}
 
 DESCRIPTION="Open source high performance 3D graphics toolkit"
-HOMEPAGE="https://www.openscenegraph.org/"
+HOMEPAGE="https://www.openscenegraph.com/"
 SRC_URI="https://github.com/${PN}/${MY_PN}/archive/${MY_P}.tar.gz"
 S="${WORKDIR}/${MY_PN}-${MY_P}"
 

--- a/games-action/descent1-data/descent1-data-1.4a.ebuild
+++ b/games-action/descent1-data/descent1-data-1.4a.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -10,8 +10,8 @@ inherit cdrom estack
 MY_EXE="setup_descent_1.4a_(16596).exe"
 
 DESCRIPTION="Data files for Descent 1"
-HOMEPAGE="http://www.interplay.com/games/descent.php"
-SRC_URI="cdinstall? ( http://www.dxx-rebirth.com/download/dxx/misc/descent-game-content-10to14a-patch.zip )
+HOMEPAGE="https://www.interplay.com"
+SRC_URI="cdinstall? ( https://www.dxx-rebirth.com/download/dxx/misc/descent-game-content-10to14a-patch.zip )
 	!cdinstall? ( ${MY_EXE} )"
 LICENSE="descent-data"
 SLOT="0"

--- a/games-action/descent1-demodata/descent1-demodata-1.4-r1.ebuild
+++ b/games-action/descent1-demodata/descent1-demodata-1.4-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,8 +8,8 @@ inherit unpacker
 DEMO="desc${PV//.}sw.exe"
 
 DESCRIPTION="Demo data files for Descent 1"
-HOMEPAGE="http://www.interplay.com/games/descent.php"
-SRC_URI="http://icculus.org/d2x/data/${DEMO}
+HOMEPAGE="https://www.interplay.com"
+SRC_URI="https://icculus.org/d2x/data/${DEMO}
 	ftp://ftp.funet.fi/pub/msdos/games/interplay/${DEMO}"
 LICENSE="free-noncomm"
 SLOT="0"

--- a/games-action/descent2-data/descent2-data-1.2.ebuild
+++ b/games-action/descent2-data/descent2-data-1.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -8,13 +8,13 @@ inherit cdrom estack
 
 # Not possible to apply official 1.2 patch under Linux. A Gentoo user
 # created Xdelta patches and the DXX-Rebirth project kindly hosted them.
-MY_PATCH="http://www.dxx-rebirth.com/download/dxx/misc/d2xptch12.tgz"
+MY_PATCH="https://www.dxx-rebirth.com/download/dxx/misc/d2xptch12.tgz"
 
 # For GOG install
 MY_EXE="setup_descent_2_1.1_(16596).exe"
 
 DESCRIPTION="Data files for Descent 2"
-HOMEPAGE="http://www.interplay.com/games/descent.php"
+HOMEPAGE="https://www.interplay.com"
 SRC_URI="cdinstall? ( ${MY_PATCH} )
 	!cdinstall? ( ${MY_EXE} )"
 LICENSE="descent-data"

--- a/games-action/descent2-demodata/descent2-demodata-1.0-r1.ebuild
+++ b/games-action/descent2-demodata/descent2-demodata-1.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -7,7 +7,7 @@ MY_PN="d2demo"
 DEMO="${MY_PN}${PV//.}.zip"
 
 DESCRIPTION="Demo data files for Descent 2"
-HOMEPAGE="http://www.interplay.com/games/descent.php"
+HOMEPAGE="https://www.interplay.com"
 SRC_URI="ftp://ftp.funet.fi/pub/msdos/games/interplay/${DEMO}"
 LICENSE="free-noncomm"
 SLOT="0"

--- a/games-action/descent2-vertigo/descent2-vertigo-1.0.ebuild
+++ b/games-action/descent2-vertigo/descent2-vertigo-1.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -6,7 +6,7 @@ EAPI=6
 inherit cdrom estack
 
 DESCRIPTION="Data files for Descent 2: The Vertigo Series"
-HOMEPAGE="http://www.interplay.com/games/descent.php"
+HOMEPAGE="https://www.interplay.com"
 
 LICENSE="descent-data"
 SLOT="0"


### PR DESCRIPTION
@chewi 

Regarding `dev-games/openscenegraph*`: Sorry for the noise here. I overlooked that the TLD changed here too.
Regarding `games-action/descent*`: I've decided to change the HOMEPAGE to simply `https://www.interplay.com`. There are no dedicated Descent Pages anymore but they're still listed in the Catalog. It's not perfect, but i think better then the status quo.