### PR TITLE
dev-util/lockrun: EAPI8 bump

### DIFF
--- a/dev-util/lockrun/lockrun-20120508-r2.ebuild
+++ b/dev-util/lockrun/lockrun-20120508-r2.ebuild
@@ -1,0 +1,30 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs
+
+DESCRIPTION="Lockrun - runs cronjobs with overrun protection"
+HOMEPAGE="http://www.unixwiz.net/tools/lockrun.html"
+
+LICENSE="public-domain"
+SLOT="0"
+KEYWORDS="~amd64 ~hppa ~x86"
+
+S="${WORKDIR}"
+
+src_unpack() {
+	cp -v "${FILESDIR}"/${PN}.c-${PV} "${S}"/${PN}.c || die
+	cp -v "${FILESDIR}"/${PN}.c-${PV} "${S}"/README || die
+}
+
+src_compile() {
+	emake CC="$(tc-getCC)" ${PN}
+	sed -i README -e '60q;s|^ \*||g' || die
+}
+
+src_install() {
+	dobin ${PN}
+	einstalldocs
+}


### PR DESCRIPTION
Simple EAPI8 bump

```diff
1c1
< # Copyright 1999-2022 Gentoo Authors
---
> # Copyright 1999-2023 Gentoo Authors
4c4
< EAPI=6
---
> EAPI=8
13c13
< KEYWORDS="amd64 ~hppa x86"
---
> KEYWORDS="~amd64 ~hppa ~x86"
```