### PR TITLE
media-libs/esdl: EAPI8 bump

### DIFF
--- a/media-libs/esdl/esdl-1.3.1-r1.ebuild
+++ b/media-libs/esdl/esdl-1.3.1-r1.ebuild
@@ -1,0 +1,37 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DESCRIPTION="Erlang bindings for the SDL library"
+HOMEPAGE="https://esdl.sourceforge.net/"
+SRC_URI="mirror://sourceforge/esdl/${P}.src.tgz"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~ppc64 ~x86"
+IUSE="image truetype"
+
+RDEPEND="
+	>=dev-lang/erlang-14[wxwidgets]
+	media-libs/libsdl[opengl]
+	image? ( media-libs/sdl-image )
+	truetype? ( media-libs/sdl-ttf )
+	virtual/opengl
+"
+DEPEND="${RDEPEND}"
+BDEPEND="dev-util/rebar:0"
+
+src_compile() {
+	rebar compile || die
+}
+
+src_install() {
+	ERLANG_DIR="/usr/$(get_libdir)/erlang/lib"
+	ESDL_DIR="${ERLANG_DIR}/${P}"
+
+	find -name 'Makefile*' -exec rm -f '{}' \;
+
+	insinto ${ESDL_DIR}
+	doins -r ebin c_src include priv src
+}

--- a/media-libs/esdl/esdl-1.3.1.ebuild
+++ b/media-libs/esdl/esdl-1.3.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -6,7 +6,7 @@ EAPI=6
 inherit fixheadtails
 
 DESCRIPTION="Erlang bindings for the SDL library"
-HOMEPAGE="http://esdl.sourceforge.net/"
+HOMEPAGE="https://esdl.sourceforge.net/"
 SRC_URI="mirror://sourceforge/esdl/${P}.src.tgz"
 
 LICENSE="BSD"


### PR DESCRIPTION
Another rather easy EAPI8 bump. I've removed the `fixheadtails` eclass in the new ebuild as it wasn't used anyway.

```diff
--- esdl-1.3.1.ebuild	2023-07-05 10:34:59.026056936 +0200
+++ esdl-1.3.1-r1.ebuild	2023-07-05 10:47:48.608246476 +0200
@@ -1,9 +1,7 @@
 # Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
-
-inherit fixheadtails
+EAPI=8
 
 DESCRIPTION="Erlang bindings for the SDL library"
 HOMEPAGE="https://esdl.sourceforge.net/"
@@ -11,7 +9,7 @@
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="amd64 ppc ppc64 x86"
+KEYWORDS="~amd64 ~ppc ~ppc64 ~x86"
 IUSE="image truetype"
 
 RDEPEND="
@@ -21,10 +19,8 @@
 	truetype? ( media-libs/sdl-ttf )
 	virtual/opengl
 "
-DEPEND="
-	${RDEPEND}
-	dev-util/rebar:0
-"
+DEPEND="${RDEPEND}"
+BDEPEND="dev-util/rebar:0"
 
 src_compile() {
 	rebar compile || die
```