### PR TITLE
x11-terms/alacritty: Update 9999 man install

### DIFF
--- a/x11-terms/alacritty/alacritty-9999.ebuild
+++ b/x11-terms/alacritty/alacritty-9999.ebuild
@@ -57,6 +57,7 @@ RDEPEND="${COMMON_DEPEND}
 BDEPEND="
 	dev-util/cmake
 	>=virtual/rust-1.57.0
+	app-text/scdoc
 "
 
 QA_FLAGS_IGNORED="usr/bin/alacritty"
@@ -81,6 +82,11 @@ src_configure() {
 }
 
 src_compile() {
+	scdoc < ./extra/man/alacritty.1.scd > ./alacritty.1 || die
+	scdoc < ./extra/man/alacritty.5.scd > ./alacritty.5 || die
+	scdoc < ./extra/man/alacritty-msg.1.scd > ./alacritty-msg.1 || die
+	scdoc < ./extra/man/alacritty-bindings.5.scd > ./alacritty-bindings.5 || die
+
 	cd alacritty || die
 	cargo_src_compile
 }
@@ -88,8 +94,7 @@ src_compile() {
 src_install() {
 	cargo_src_install --path alacritty
 
-	newman extra/alacritty.man alacritty.1
-	newman extra/alacritty-msg.man alacritty-msg.1
+	doman alacritty.1 alacritty.5 alacritty-msg.1 alacritty-bindings.5
 
 	newbashcomp extra/completions/alacritty.bash alacritty
 
@@ -109,7 +114,6 @@ src_install() {
 	doins -r scripts/*
 
 	local DOCS=(
-		alacritty.yml
 		CHANGELOG.md INSTALL.md README.md
 		docs/{ansicode.txt,escape_support.md,features.md}
 	)


### PR DESCRIPTION
Upstream moved from man files to generated man files using scdoc. They also changed configuration to use toml, removing alacritty.yml.