### PR TITLE
app-pda/usbmuxd: adopt the package, revbump and update EAPI 7 -> 8

### DIFF
--- a/app-pda/usbmuxd/metadata.xml
+++ b/app-pda/usbmuxd/metadata.xml
@@ -1,8 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<!-- maintainer-needed -->
-<upstream>
-	<remote-id type="github">libimobiledevice/usbmuxd</remote-id>
-</upstream>
+	<maintainer type="person" proxied="yes">
+		<email>zurabid2016@gmail.com</email>
+		<name>Zurab Kvachadze</name>
+	</maintainer>
+	<maintainer type="project" proxied="proxy">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
+	<upstream>
+		<remote-id type="github">libimobiledevice/usbmuxd</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/app-pda/usbmuxd/usbmuxd-1.1.1-r1.ebuild
+++ b/app-pda/usbmuxd/usbmuxd-1.1.1-r1.ebuild
@@ -1,0 +1,49 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit systemd udev
+
+DESCRIPTION="USB multiplex daemon for use with Apple iPhone/iPod Touch devices"
+HOMEPAGE="https://libimobiledevice.org/"
+SRC_URI="https://github.com/libimobiledevice/usbmuxd/releases/download/${PV}/${P}.tar.bz2"
+
+# src/utils.h is LGPL-2.1+, rest is found in COPYING*
+LICENSE="|| ( GPL-2 GPL-3 ) LGPL-2.1+"
+SLOT="0"
+KEYWORDS="amd64 ~arm ~ppc ~ppc64 x86"
+IUSE="selinux systemd"
+
+DEPEND="
+	acct-user/usbmux
+	>=app-pda/libimobiledevice-1.3.0:=
+	>=app-pda/libplist-2.2:=
+	virtual/libusb:1=
+"
+
+RDEPEND="
+	${DEPEND}
+	virtual/udev
+	selinux? ( sec-policy/selinux-usbmuxd )
+	systemd? ( sys-apps/systemd )
+"
+
+BDEPEND="
+	virtual/pkgconfig
+"
+
+pkg_postrm() {
+	udev_reload
+}
+
+pkg_postinst() {
+	udev_reload
+}
+
+src_configure() {
+	econf \
+		"$(use_with systemd)" \
+		--with-systemdsystemunitdir="$(systemd_get_systemunitdir)" \
+		--with-udevrulesdir="$(get_udevdir)"/rules.d
+}


### PR DESCRIPTION
I want to maintain usbmuxd as proxied maintainer. I know the maintainer of the package and've made a few commits 
to a codebase.
Haven't dropped keywords, because commit doesn't really add anything, the old revision is planned to be removed in the nearest future

Closes: https://bugs.gentoo.org/854843
Closes: https://bugs.gentoo.org/732984
Closes: https://bugs.gentoo.org/732912