### PR TITLE
app-misc/gentoo: EAPI8 bump

### DIFF
--- a/app-misc/gentoo/gentoo-0.20.7-r1.ebuild
+++ b/app-misc/gentoo/gentoo-0.20.7-r1.ebuild
@@ -1,0 +1,65 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools desktop
+
+DESCRIPTION="Graphical file manager for Unix-like systems, using GTK+"
+HOMEPAGE="https://sourceforge.net/projects/gentoo/"
+SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+IUSE="nls"
+
+RDEPEND="
+	>x11-libs/gtk+-3.12:3
+	dev-libs/glib:2
+	x11-libs/cairo
+	x11-libs/gdk-pixbuf
+	x11-libs/pango
+"
+DEPEND="${RDEPEND}"
+BDEPEND="nls? ( sys-devel/gettext )"
+
+DOCS=(
+	AUTHORS BUGS CONFIG-CHANGES CREDITS NEWS README TODO docs/{FAQ,menus.txt}
+)
+
+src_prepare() {
+	sed -i \
+		-e 's^icons/gnome/16x16/mimetypes^gentoo/icons^' \
+		gentoorc.in || die
+	sed -i \
+		-e '/GTK_DISABLE_DEPRECATED/d' \
+		-e '/^GENTOO_CFLAGS=/s|".*"|"${CFLAGS}"|g' \
+		-e 's|AM_CONFIG_HEADER|AC_CONFIG_HEADERS|g' \
+		configure.ac || die #357343
+
+	eapply_user
+	eautoreconf
+}
+
+src_configure() {
+	econf \
+		--sysconfdir=/etc/gentoo \
+		$(use_enable nls)
+}
+
+src_install() {
+	default
+
+	docinto html
+	dodoc -r docs/{images,config,*.{html,css}}
+
+	newman docs/gentoo.1x gentoo.1
+
+	docinto scratch
+	dodoc docs/scratch/*
+
+	make_desktop_entry ${PN} Gentoo \
+		/usr/share/${PN}/icons/${PN}.png \
+		"System;FileTools;FileManager"
+}


### PR DESCRIPTION
Simple EAPI8 bump:

```diff
--- gentoo-0.20.7.ebuild	2023-04-01 17:48:25.817958010 +0200
+++ gentoo-0.20.7-r1.ebuild	2023-07-06 09:45:42.301861623 +0200
@@ -1,7 +1,7 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
 
 inherit autotools desktop
 
@@ -11,7 +11,7 @@
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~alpha amd64 ~hppa ~ia64 ppc ppc64 sparc x86"
+KEYWORDS="~alpha ~amd64 ~hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86"
 IUSE="nls"
 
 RDEPEND="
@@ -21,10 +21,8 @@
 	x11-libs/gdk-pixbuf
 	x11-libs/pango
 "
-DEPEND="
-	${RDEPEND}
-	nls? ( sys-devel/gettext )
-"
+DEPEND="${RDEPEND}"
+BDEPEND="nls? ( sys-devel/gettext )"
 
 DOCS=(
 	AUTHORS BUGS CONFIG-CHANGES CREDITS NEWS README TODO docs/{FAQ,menus.txt}
@@ -41,7 +39,6 @@
 		configure.ac || die #357343
 
 	eapply_user
-
 	eautoreconf
 }
```