### PR TITLE
media-video/blind: EAPI8 bump

### DIFF
--- a/media-video/blind/blind-1.1-r1.ebuild
+++ b/media-video/blind/blind-1.1-r1.ebuild
@@ -1,10 +1,11 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
+
 inherit toolchain-funcs
 
-DESCRIPTION="a collection of command line video editing utilities"
+DESCRIPTION="Collection of command line video editing utilities"
 HOMEPAGE="https://tools.suckless.org/blind/"
 SRC_URI="https://dl.suckless.org/tools/${P}.tar.gz"
 
@@ -12,14 +13,7 @@ LICENSE="ISC"
 SLOT="0"
 KEYWORDS="~amd64"
 
-RDEPEND="
-"
-DEPEND="
-	${RDEPEND}
-"
-PATCHES=(
-	"${FILESDIR}"/${PN}-1.1-ldflags.patch
-)
+PATCHES=( "${FILESDIR}"/${PN}-1.1-ldflags.patch )
 
 src_prepare() {
 	default
@@ -35,8 +29,4 @@ src_prepare() {
 
 src_compile() {
 	emake CC="$(tc-getCC)"
-}
-
-src_install() {
-	emake DESTDIR="${D}" install MANPREFIX=/usr/share/man
 }


### PR DESCRIPTION
Another simple EAPI8 bump.
Since it has no stable keywords i directly updated the original. However, with removing `src_prepare` (not needed, man pages are being installed correctly) it also installs `README` and `TODO`. Not sure if for this a revbump is necessary. 