### PR TITLE
media-video/rovclock: fix LICENSE, EAPI8 bump

### DIFF
--- a/media-video/rovclock/rovclock-0.6e-r1.ebuild
+++ b/media-video/rovclock/rovclock-0.6e-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -9,7 +9,7 @@ DESCRIPTION="Overclocking utility for ATI Radeon cards"
 HOMEPAGE="http://www.hasw.net/linux/"
 SRC_URI="http://www.hasw.net/linux/${P}.tar.bz2"
 
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="0"
 KEYWORDS="amd64 x86"
 IUSE=""

--- a/media-video/rovclock/rovclock-0.6e-r2.ebuild
+++ b/media-video/rovclock/rovclock-0.6e-r2.ebuild
@@ -1,0 +1,25 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs
+
+DESCRIPTION="Overclocking utility for ATI Radeon cards"
+HOMEPAGE="http://www.hasw.net/linux/"
+SRC_URI="http://www.hasw.net/linux/${P}.tar.bz2"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+PATCHES=( "${FILESDIR}"/${P}-ldflags.patch )
+
+src_compile() {
+	emake CC="$(tc-getCC)" CFLAGS="${CFLAGS}"
+}
+
+src_install() {
+	dosbin rovclock
+	einstalldocs
+}


### PR DESCRIPTION
Another simple EAPI8 bump:
```diff
--- rovclock-0.6e-r1.ebuild	2023-07-06 09:56:37.872221604 +0200
+++ rovclock-0.6e-r2.ebuild	2023-07-06 09:56:54.945069170 +0200
@@ -1,7 +1,7 @@
 # Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
 
 inherit toolchain-funcs
 
@@ -11,13 +11,9 @@
 
 LICENSE="GPL-2+"
 SLOT="0"
-KEYWORDS="amd64 x86"
-IUSE=""
+KEYWORDS="~amd64 ~x86"
 
-src_prepare() {
-	eapply "${FILESDIR}"/${P}-ldflags.patch
-	default
-}
+PATCHES=( "${FILESDIR}"/${P}-ldflags.patch )
 
 src_compile() {
 	emake CC="$(tc-getCC)" CFLAGS="${CFLAGS}"
@@ -25,5 +21,5 @@
 
 src_install() {
 	dosbin rovclock
-	dodoc ChangeLog README
+	einstalldocs
 }
```