### PR TITLE
net-print/cups: Add USE=libpaper,filters

### DIFF
--- a/net-print/cups/cups-2.4.6-r1.ebuild
+++ b/net-print/cups/cups-2.4.6-r1.ebuild
@@ -17,7 +17,7 @@ if [[ ${PV} == *9999 ]] ; then
 else
 	SRC_URI="https://github.com/OpenPrinting/cups/releases/download/v${MY_PV}/cups-${MY_PV}-source.tar.gz"
 	if [[ ${PV} != *_beta* && ${PV} != *_rc* ]] ; then
-		KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~loong ~mips ~ppc ppc64 ~riscv ~s390 sparc x86"
+		KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~loong ~mips ppc ppc64 ~riscv ~s390 sparc x86"
 	fi
 fi
 
@@ -28,7 +28,7 @@ HOMEPAGE="https://www.cups.org/ https://github.com/OpenPrinting/cups"
 
 LICENSE="Apache-2.0"
 SLOT="0"
-IUSE="acl dbus debug kerberos openssl pam selinux static-libs systemd test usb X xinetd zeroconf"
+IUSE="acl dbus debug filters libpaper kerberos openssl pam selinux +ssl static-libs systemd test usb X xinetd zeroconf"
 
 # As of 2.4.2, they don't actually seem to be interactive (they pass some flags
 # by default to input for us), but they fail on some greyscale issue w/ poppler?
@@ -40,7 +40,7 @@ BDEPEND="
 	virtual/pkgconfig
 "
 DEPEND="
-	app-text/libpaper:=
+	libpaper? ( app-text/libpaper:= )
 	sys-libs/zlib
 	acl? (
 		kernel_linux? (
@@ -52,8 +52,10 @@ DEPEND="
 	kerberos? ( >=virtual/krb5-0-r1[${MULTILIB_USEDEP}] )
 	pam? ( sys-libs/pam )
 	!pam? ( virtual/libcrypt:= )
-	!openssl? ( >=net-libs/gnutls-2.12.23-r6:=[${MULTILIB_USEDEP}] )
-	openssl? ( dev-libs/openssl:=[${MULTILIB_USEDEP}] )
+	ssl? (
+		!openssl? ( >=net-libs/gnutls-2.12.23-r6:0=[${MULTILIB_USEDEP}] )
+		openssl? ( dev-libs/openssl:=[${MULTILIB_USEDEP}] )
+	)
 	systemd? ( sys-apps/systemd )
 	usb? ( virtual/libusb:1 )
 	X? ( x11-misc/xdg-utils )
@@ -66,7 +68,9 @@ RDEPEND="
 	acct-group/lpadmin
 	selinux? ( sec-policy/selinux-cups )
 "
-PDEPEND=">=net-print/cups-filters-1.0.43"
+PDEPEND="
+	filters? ( >=net-print/cups-filters-1.0.43 )
+"
 
 PATCHES=(
 	"${FILESDIR}/${PN}-2.4.1-nostrip.patch"
@@ -164,11 +168,13 @@ multilib_src_configure() {
 		$(multilib_native_use_enable pam)
 		$(use_enable static-libs static)
 		$(use_enable test unit-tests)
-		--with-tls=$(usex openssl openssl gnutls)
+		# USE="ssl" => gnutls
+		# USE="ssl openssl" => openssl
+		$(use_with ssl tls $(usex openssl openssl gnutls))
 		$(use_with systemd ondemand systemd)
 		$(multilib_native_use_enable usb libusb)
 		$(use_with zeroconf dnssd avahi)
-		$(multilib_is_native_abi && echo --enable-libpaper || echo --disable-libpaper)
+		$(multilib_is_native_abi && use_enable libpaper || echo --disable-libpaper)
 	)
 
 	# Handle empty LINGUAS properly, bug #771162

--- a/net-print/cups/cups-2.4.7-r2.ebuild
+++ b/net-print/cups/cups-2.4.7-r2.ebuild
@@ -17,7 +17,7 @@ if [[ ${PV} == *9999 ]] ; then
 else
 	SRC_URI="https://github.com/OpenPrinting/cups/releases/download/v${MY_PV}/cups-${MY_PV}-source.tar.gz"
 	if [[ ${PV} != *_beta* && ${PV} != *_rc* ]] ; then
-		KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~loong ~mips ppc ppc64 ~riscv ~s390 sparc x86"
+		KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~loong ~mips ~ppc ppc64 ~riscv ~s390 sparc x86"
 	fi
 fi
 
@@ -28,7 +28,7 @@ HOMEPAGE="https://www.cups.org/ https://github.com/OpenPrinting/cups"
 
 LICENSE="Apache-2.0"
 SLOT="0"
-IUSE="acl dbus debug kerberos openssl pam selinux +ssl static-libs systemd test usb X xinetd zeroconf"
+IUSE="acl dbus debug filters libpaper kerberos openssl pam selinux static-libs systemd test usb X xinetd zeroconf"
 
 # As of 2.4.2, they don't actually seem to be interactive (they pass some flags
 # by default to input for us), but they fail on some greyscale issue w/ poppler?
@@ -40,7 +40,7 @@ BDEPEND="
 	virtual/pkgconfig
 "
 DEPEND="
-	app-text/libpaper:=
+	libpaper? ( app-text/libpaper:= )
 	sys-libs/zlib
 	acl? (
 		kernel_linux? (
@@ -52,10 +52,8 @@ DEPEND="
 	kerberos? ( >=virtual/krb5-0-r1[${MULTILIB_USEDEP}] )
 	pam? ( sys-libs/pam )
 	!pam? ( virtual/libcrypt:= )
-	ssl? (
-		!openssl? ( >=net-libs/gnutls-2.12.23-r6:0=[${MULTILIB_USEDEP}] )
-		openssl? ( dev-libs/openssl:=[${MULTILIB_USEDEP}] )
-	)
+	!openssl? ( >=net-libs/gnutls-2.12.23-r6:=[${MULTILIB_USEDEP}] )
+	openssl? ( dev-libs/openssl:=[${MULTILIB_USEDEP}] )
 	systemd? ( sys-apps/systemd )
 	usb? ( virtual/libusb:1 )
 	X? ( x11-misc/xdg-utils )
@@ -68,7 +66,9 @@ RDEPEND="
 	acct-group/lpadmin
 	selinux? ( sec-policy/selinux-cups )
 "
-PDEPEND=">=net-print/cups-filters-1.0.43"
+PDEPEND="
+	filters? ( >=net-print/cups-filters-1.0.43 )
+"
 
 PATCHES=(
 	"${FILESDIR}/${PN}-2.4.1-nostrip.patch"
@@ -166,13 +166,11 @@ multilib_src_configure() {
 		$(multilib_native_use_enable pam)
 		$(use_enable static-libs static)
 		$(use_enable test unit-tests)
-		# USE="ssl" => gnutls
-		# USE="ssl openssl" => openssl
-		$(use_with ssl tls $(usex openssl openssl gnutls))
+		--with-tls=$(usex openssl openssl gnutls)
 		$(use_with systemd ondemand systemd)
 		$(multilib_native_use_enable usb libusb)
 		$(use_with zeroconf dnssd avahi)
-		$(multilib_is_native_abi && echo --enable-libpaper || echo --disable-libpaper)
+		$(multilib_is_native_abi && use_enable libpaper || echo --disable-libpaper)
 	)
 
 	# Handle empty LINGUAS properly, bug #771162

--- a/net-print/cups/cups-9999.ebuild
+++ b/net-print/cups/cups-9999.ebuild
@@ -28,7 +28,7 @@ HOMEPAGE="https://www.cups.org/ https://github.com/OpenPrinting/cups"
 
 LICENSE="Apache-2.0"
 SLOT="0"
-IUSE="acl dbus debug kerberos openssl pam selinux static-libs systemd test usb X xinetd zeroconf"
+IUSE="acl dbus debug filters libpaper kerberos openssl pam selinux static-libs systemd test usb X xinetd zeroconf"
 
 # As of 2.4.2, they don't actually seem to be interactive (they pass some flags
 # by default to input for us), but they fail on some greyscale issue w/ poppler?
@@ -40,7 +40,7 @@ BDEPEND="
 	virtual/pkgconfig
 "
 DEPEND="
-	app-text/libpaper:=
+	libpaper? ( app-text/libpaper:= )
 	sys-libs/zlib
 	acl? (
 		kernel_linux? (
@@ -66,7 +66,9 @@ RDEPEND="
 	acct-group/lpadmin
 	selinux? ( sec-policy/selinux-cups )
 "
-PDEPEND=">=net-print/cups-filters-1.0.43"
+PDEPEND="
+	filters? ( >=net-print/cups-filters-1.0.43 )
+"
 
 PATCHES=(
 	"${FILESDIR}/${PN}-2.4.1-nostrip.patch"
@@ -168,7 +170,7 @@ multilib_src_configure() {
 		$(use_with systemd ondemand systemd)
 		$(multilib_native_use_enable usb libusb)
 		$(use_with zeroconf dnssd avahi)
-		$(multilib_is_native_abi && echo --enable-libpaper || echo --disable-libpaper)
+		$(multilib_is_native_abi && use_enable libpaper || echo --disable-libpaper)
 	)
 
 	# Handle empty LINGUAS properly, bug #771162

--- a/net-print/cups/metadata.xml
+++ b/net-print/cups/metadata.xml
@@ -7,6 +7,8 @@
 	</maintainer>
 	<use>
 		<flag name="openssl">Use <pkg>dev-libs/openssl</pkg> instead of <pkg>net-libs/gnutls</pkg> for TLS support</flag>
+		<flag name="libpaper">Enable <pkg>app-text/libpaper</pkg> support</flag>
+		<flag name="filters">Enable <pkg>net-print/cups-filters</pkg> support</flag>
 	</use>
 	<upstream>
 		<remote-id type="cpe">cpe:/a:apple:cups</remote-id>


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/813507

Test plan:

I installed cups-2.4.5-r1.ebuild and it seems to work locally (even after dep-cleaning away all the old dependencies, `emerge @preserved-rebuild`, rebooting, and opening a print dialog in Chrome (I don't own a printer so I'm not sure what else I can do))