### PR TITLE
app-shells/ccsh: EAPI8 bump

### DIFF
--- a/app-shells/ccsh/ccsh-0.0.4-r5.ebuild
+++ b/app-shells/ccsh/ccsh-0.0.4-r5.ebuild
@@ -1,0 +1,25 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs
+
+DESCRIPTION="UNIX Shell for people already familiar with the C language"
+HOMEPAGE="https://ccsh.sourceforge.net/"
+SRC_URI="mirror://sourceforge/ccsh/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~ppc64 ~sparc ~x86"
+
+src_compile() {
+	emake CFLAGS="${CFLAGS}" CC="$(tc-getCC)"
+}
+
+src_install() {
+	exeinto /bin
+	doexe "${PN}"
+	newman "${PN}.man" "${PN}.1"
+	dodoc ChangeLog README TODO
+}


### PR DESCRIPTION
Another simple `EAPI8` bump
```diff
--- ccsh-0.0.4-r4.ebuild	2023-07-07 14:50:26.951703303 +0200
+++ ccsh-0.0.4-r5.ebuild	2023-07-07 14:56:59.397359878 +0200
@@ -1,18 +1,17 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
 
 inherit toolchain-funcs
 
 DESCRIPTION="UNIX Shell for people already familiar with the C language"
-HOMEPAGE="http://ccsh.sourceforge.net/"
+HOMEPAGE="https://ccsh.sourceforge.net/"
 SRC_URI="mirror://sourceforge/ccsh/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 ppc ~ppc64 sparc x86"
-IUSE=""
+KEYWORDS="~amd64 ~ppc ~ppc64 ~sparc ~x86"
 
 src_compile() {
 	emake CFLAGS="${CFLAGS}" CC="$(tc-getCC)"
```