### PR TITLE
net-mail/qmailadmin-1.2.16-r1: fix wrong dir for chown

### DIFF
--- a/net-mail/qmailadmin/qmailadmin-1.2.16-r1.ebuild
+++ b/net-mail/qmailadmin/qmailadmin-1.2.16-r1.ebuild
@@ -82,7 +82,7 @@ src_install() {
 
 	# CGI needs to be able to read /etc/vpopmail.conf
 	# Which is 0640 root:vpopmail, as it contains passwords
-	cgi=/usr/share/webapps/${PN}/${PV}/hostroot/cgi-bin/qmailadmin
+	cgi="${MY_CGIBINDIR}"/qmailadmin
 	fowners root:vpopmail ${cgi}
 	fperms g+s ${cgi}
 }


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/898166