### PR TITLE
python: BSD Userland Fixes + pypy3.10 + strip-lto for python+cargo

### DIFF
--- a/dev-python/jaraco-text/jaraco-text-3.11.1-r1.ebuild
+++ b/dev-python/jaraco-text/jaraco-text-3.11.1-r1.ebuild
@@ -25,13 +25,6 @@ RDEPEND="
 	>=dev-python/jaraco-context-4.1.1-r1[${PYTHON_USEDEP}]
 	>=dev-python/jaraco-functools-3.5.0-r1[${PYTHON_USEDEP}]
 "
-BDEPEND="
-	test? (
-		$(python_gen_cond_dep '
-			dev-python/pathlib2[${PYTHON_USEDEP}]
-		' 3.9)
-	)
-"
 
 distutils_enable_tests pytest
 

--- a/dev-python/virtualenv/virtualenv-20.23.1.ebuild
+++ b/dev-python/virtualenv/virtualenv-20.23.1.ebuild
@@ -48,14 +48,6 @@ BDEPEND="
 		>=dev-python/packaging-20.0[${PYTHON_USEDEP}]
 	)
 "
-# https://github.com/pypa/virtualenv/issues/2554
-BDEPEND+="
-	test? (
-		$(python_gen_cond_dep '
-			!!<dev-python/virtualenv-20.22[${PYTHON_USEDEP}]
-		' 3.9)
-	)
-"
 
 distutils_enable_tests pytest
 

--- a/dev-python/virtualenv/virtualenv-20.24.0.ebuild
+++ b/dev-python/virtualenv/virtualenv-20.24.0.ebuild
@@ -48,14 +48,6 @@ BDEPEND="
 		>=dev-python/packaging-20.0[${PYTHON_USEDEP}]
 	)
 "
-# https://github.com/pypa/virtualenv/issues/2554
-BDEPEND+="
-	test? (
-		$(python_gen_cond_dep '
-			!!<dev-python/virtualenv-20.22[${PYTHON_USEDEP}]
-		' 3.9)
-	)
-"
 
 distutils_enable_tests pytest
 

--- a/eclass/distutils-r1.eclass
+++ b/eclass/distutils-r1.eclass
@@ -272,8 +272,7 @@ _distutils_set_globals() {
 				;;
 			setuptools)
 				bdep+='
-					>=dev-python/setuptools-67.7.2[${PYTHON_USEDEP}]
-					>=dev-python/wheel-0.40.0[${PYTHON_USEDEP}]
+					>=dev-python/setuptools-67.8.0-r1[${PYTHON_USEDEP}]
 				'
 				;;
 			sip)
@@ -293,7 +292,7 @@ _distutils_set_globals() {
 			eqawarn "is enabled."
 		fi
 	else
-		local setuptools_dep='>=dev-python/setuptools-67.7.2[${PYTHON_USEDEP}]'
+		local setuptools_dep='>=dev-python/setuptools-67.8.0-r1[${PYTHON_USEDEP}]'
 
 		case ${DISTUTILS_USE_SETUPTOOLS:-bdepend} in
 			no|manual)

--- a/eclass/distutils-r1.eclass
+++ b/eclass/distutils-r1.eclass
@@ -1974,7 +1974,7 @@ _distutils-r1_post_python_compile() {
 			die "${rscriptdir} should not exist!"
 		if [[ -d ${bindir} ]]; then
 			mkdir -p "${rscriptdir}" || die
-			cp -a --reflink=auto "${bindir}"/. "${rscriptdir}"/ || die
+			cp -a "${bindir}"/. "${rscriptdir}"/ || die
 		fi
 
 		# enable venv magic inside the install tree

--- a/eclass/distutils-r1.eclass
+++ b/eclass/distutils-r1.eclass
@@ -1718,7 +1718,7 @@ distutils-r1_python_install() {
 		# python likes to compile any module it sees, which triggers sandbox
 		# failures if some packages haven't compiled their modules yet.
 		addpredict "${EPREFIX}/usr/lib/${EPYTHON}"
-		addpredict "${EPREFIX}/usr/lib/pypy3.9"
+		addpredict "${EPREFIX}/usr/lib/pypy3.10"
 		addpredict "${EPREFIX}/usr/local" # bug 498232
 
 		if [[ ! ${DISTUTILS_SINGLE_IMPL} ]]; then

--- a/eclass/distutils-r1.eclass
+++ b/eclass/distutils-r1.eclass
@@ -191,6 +191,7 @@ esac
 if [[ -z ${_DISTUTILS_R1_ECLASS} ]]; then
 _DISTUTILS_R1_ECLASS=1
 
+inherit flag-o-matic
 inherit multibuild multilib multiprocessing ninja-utils toolchain-funcs
 
 if [[ ! ${DISTUTILS_SINGLE_IMPL} ]]; then
@@ -1834,6 +1835,12 @@ distutils-r1_run_phase() {
 		# bug fixes from Cython (this works only when setup.py is using
 		# cythonize() but it's better than nothing)
 		local -x CYTHON_FORCE_REGEN=1
+	fi
+
+	# Rust extensions are incompatible with C/C++ LTO compiler
+	# see e.g. https://bugs.gentoo.org/910220
+	if has cargo ${INHERITED}; then
+		filter-lto
 	fi
 
 	# How to build Python modules in different worlds...

--- a/eclass/multibuild.eclass
+++ b/eclass/multibuild.eclass
@@ -170,8 +170,7 @@ multibuild_copy_sources() {
 
 	_multibuild_create_source_copy() {
 		einfo "${MULTIBUILD_VARIANT}: copying to ${BUILD_DIR}"
-		# enable reflinking if possible to make this faster
-		cp -p -R --reflink=auto \
+		cp -p -R \
 			"${_MULTIBUILD_INITIAL_BUILD_DIR}" "${BUILD_DIR}" || die
 	}
 
@@ -190,8 +189,7 @@ multibuild_merge_root() {
 	local src=${1}
 	local dest=${2}
 
-	# enable reflinking if possible to make this faster
-	cp -a --reflink=auto "${src}"/. "${dest}"/ || die "${MULTIBUILD_VARIANT:-(unknown)}: merging image failed"
+	cp -a "${src}"/. "${dest}"/ || die "${MULTIBUILD_VARIANT:-(unknown)}: merging image failed"
 	rm -rf "${src}" || die
 }
 

--- a/eclass/pypi.eclass
+++ b/eclass/pypi.eclass
@@ -105,6 +105,7 @@ _pypi_translate_version() {
 	local version=${1}
 	version=${version/_alpha/a}
 	version=${version/_beta/b}
+	version=${version/_pre/.dev}
 	version=${version/_rc/rc}
 	_PYPI_TRANSLATED_VERSION=${version/_p/.post}
 }

--- a/eclass/python-any-r1.eclass
+++ b/eclass/python-any-r1.eclass
@@ -176,7 +176,7 @@ _python_any_set_globals() {
 		_python_export "${i}" PYTHON_PKG_DEP
 
 		# note: need to strip '=' slot operator for || deps
-		deps="${PYTHON_PKG_DEP/:0=/:0} ${deps}"
+		deps="${PYTHON_PKG_DEP/:=} ${deps}"
 	done
 	deps="|| ( ${deps})"
 
@@ -259,7 +259,7 @@ python_gen_any_dep() {
 		local i_depstr=${depstr//\$\{PYTHON_USEDEP\}/${PYTHON_USEDEP}}
 		i_depstr=${i_depstr//\$\{PYTHON_SINGLE_USEDEP\}/${PYTHON_SINGLE_USEDEP}}
 		# note: need to strip '=' slot operator for || deps
-		out="( ${PYTHON_PKG_DEP%=} ${i_depstr} ) ${out}"
+		out="( ${PYTHON_PKG_DEP%:=} ${i_depstr} ) ${out}"
 	done
 	echo "|| ( ${out})"
 }

--- a/eclass/python-r1.eclass
+++ b/eclass/python-r1.eclass
@@ -522,7 +522,7 @@ python_gen_any_dep() {
 			local i_depstr=${depstr//\$\{PYTHON_USEDEP\}/${PYTHON_USEDEP}}
 			i_depstr=${i_depstr//\$\{PYTHON_SINGLE_USEDEP\}/${PYTHON_SINGLE_USEDEP}}
 			# note: need to strip '=' slot operator for || deps
-			out="( ${PYTHON_PKG_DEP/:0=/:0} ${i_depstr} ) ${out}"
+			out="( ${PYTHON_PKG_DEP/:=} ${i_depstr} ) ${out}"
 		fi
 	done
 	echo "|| ( ${out})"

--- a/eclass/python-utils-r1.eclass
+++ b/eclass/python-utils-r1.eclass
@@ -446,14 +446,12 @@ _python_export() {
 			PYTHON_PKG_DEP)
 				local d
 				case ${impl} in
-					python3.10)
-						PYTHON_PKG_DEP=">=dev-lang/python-3.10.12:3.10";;
-					python3.11)
-						PYTHON_PKG_DEP=">=dev-lang/python-3.11.4:3.11";;
-					python3.12)
-						PYTHON_PKG_DEP=">=dev-lang/python-3.12.0_beta3:3.12";;
+					python*)
+						PYTHON_PKG_DEP="dev-lang/python:${impl#python}"
+						;;
 					pypy3)
-						PYTHON_PKG_DEP='>=dev-python/pypy3-7.3.12:0=';;
+						PYTHON_PKG_DEP="dev-python/${impl}:="
+						;;
 					*)
 						die "Invalid implementation: ${impl}"
 				esac

--- a/eclass/python-utils-r1.eclass
+++ b/eclass/python-utils-r1.eclass
@@ -238,12 +238,11 @@ _python_impl_matches() {
 				fi
 				return 0
 				;;
-			3.9|3.10)
-				# <pypy3-7.3.12 is 3.9, >=7.3.12 is 3.10
+			3.10)
 				[[ ${impl} == python${pattern/./_} || ${impl} == pypy3 ]] &&
 					return 0
 				;;
-			3.8|3.1[1-2])
+			3.8|3.9|3.1[1-2])
 				[[ ${impl} == python${pattern/./_} ]] && return 0
 				;;
 			*)

--- a/eclass/python-utils-r1.eclass
+++ b/eclass/python-utils-r1.eclass
@@ -454,7 +454,7 @@ _python_export() {
 					python3.12)
 						PYTHON_PKG_DEP=">=dev-lang/python-3.12.0_beta3:3.12";;
 					pypy3)
-						PYTHON_PKG_DEP='>=dev-python/pypy3-7.3.11_p1:0=';;
+						PYTHON_PKG_DEP='>=dev-python/pypy3-7.3.12:0=';;
 					*)
 						die "Invalid implementation: ${impl}"
 				esac


### PR DESCRIPTION
--reflink=auto has become the default behaviour in coreutils 9, and is not compatible with BSD userland.