### PR TITLE
dev-libs/libintl: donot -fvisibility=hidden on macOS.

### DIFF
--- a/dev-libs/libintl/libintl-0.22-r1.ebuild
+++ b/dev-libs/libintl/libintl-0.22-r1.ebuild
@@ -70,6 +70,11 @@ multilib_src_configure() {
 		$(use_enable static-libs static)
 		$(use_enable threads)
 	)
+
+	# macOS linker/libtool seems to automatically hide all the symbols.
+	# libintl only works with a symbol list and without -fvisibility=hidden.
+	[[ ${CHOST} == *-darwin* ]] && export gl_cv_cc_visibility=no
+
 	ECONF_SOURCE="${S}" econf "${myconf[@]}"
 }
 


### PR DESCRIPTION
The linker/libtool on macOS hide symbol 'locale_charset' of libgnu.a, even if the function was compile with

 ` __attribute__((__visibility__("default")))`

Coincidentally, libtool specifies a set of exposed symbols to the linker in the final stage.  So not specifying -fvisibility=hidden during compilation does not expose extra symbols.  A comparison of libintl.dylib before (bad) and after (good) this revision bump:

```
 diff -u <(nm -a libintl.8.3.0.dylib.bad) <(nm -a libintl.8.3.0.dylib.good)
--- /dev/fd/63  2023-07-08 21:08:56.000000000 +0800 +++ /dev/fd/62  2023-07-08 21:08:56.000000000 +0800 @@ -105,8 +105,8 @@
 0000000000003c30 t _alias_compare
 0000000000017aa0 s _alias_table
 0000000000016dd0 s _aliasfile.0
-0000000000008290 t _bind_textdomain_codeset
-0000000000008280 t _bindtextdomain
+0000000000008290 T _bind_textdomain_codeset
+0000000000008280 T _bindtextdomain
                  U _bsearch
 000000000001b878 b _cache_initialized.1
 000000000001b870 b _cached_languages.0
@@ -117,22 +117,22 @@
                  U _close
 000000000001cd80 b _curr_prefix
 000000000001cd78 b _curr_prefix_len
-0000000000008230 t _dcgettext
-0000000000008260 t _dcngettext
-0000000000008220 t _dgettext
-0000000000008250 t _dngettext
-00000000000162e0 t _emutls_destroy
+0000000000008230 T _dcgettext
+0000000000008260 T _dcngettext
+0000000000008220 T _dgettext
+0000000000008250 T _dngettext
 00000000000162e0 - 01 0000   FUN _emutls_destroy
-0000000000016320 t _emutls_init
+00000000000162e0 t _emutls_destroy
 0000000000016320 - 01 0000   FUN _emutls_init
-00000000000165ea s _emutls_init.cold
+0000000000016320 t _emutls_init
 00000000000165ea - 01 0000   FUN _emutls_init.cold
+00000000000165ea s _emutls_init.cold
 000000000001cda0 - 0e 0000 STSYM _emutls_key
 000000000001cda0 b _emutls_key
-000000000001b7c0 - 0d 0000 STSYM _emutls_mutex
 000000000001b7c0 d _emutls_mutex
-000000000001cd98 b _emutls_size
+000000000001b7c0 - 0d 0000 STSYM _emutls_mutex
 000000000001cd98 - 0e 0000 STSYM _emutls_size
+000000000001cd98 b _emutls_size
 000000000001b860 b _enable_secure
                  U _fclose
                  U _fgets
@@ -151,7 +151,7 @@
                  U _getenv
                  U _geteuid
                  U _getgid
-0000000000008210 t _gettext
+0000000000008210 T _gettext
                  U _getuid
 0000000000008e30 T _gl_get_setlocale_null_lock
                  U _kCFPreferencesCurrentApplication
@@ -168,19 +168,19 @@
 0000000000001b40 T _libintl_bind_textdomain_codeset
 0000000000001b00 T _libintl_bindtextdomain
 0000000000001b80 T _libintl_dcgettext
-00000000000057c0 t _libintl_dcigettext
+00000000000057c0 T _libintl_dcigettext
 00000000000165b8 s _libintl_dcigettext.cold
 00000000000061c0 T _libintl_dcngettext
 0000000000001b90 T _libintl_dgettext
 00000000000061d0 T _libintl_dngettext
 0000000000001ba0 T _libintl_gettext
-0000000000001e80 t _libintl_hash_string
+0000000000001e80 T _libintl_hash_string
 0000000000007f00 T _libintl_newlocale
 00000000000061e0 T _libintl_ngettext
-000000000001b5c8 d _libintl_nl_current_default_domain
-0000000000016e00 s _libintl_nl_default_default_domain
-0000000000016de0 s _libintl_nl_default_dirname
-000000000001cdb0 s _libintl_nl_domain_bindings
+000000000001b5c8 D _libintl_nl_current_default_domain
+0000000000016e00 S _libintl_nl_default_default_domain
+0000000000016de0 S _libintl_nl_default_dirname
+000000000001cdb0 S _libintl_nl_domain_bindings
 0000000000010ac0 T _libintl_set_relocation_prefix
 00000000000077a0 T _libintl_setlocale
 00000000000165c2 s _libintl_setlocale.cold
@@ -188,7 +188,7 @@
 00000000000165a6 s _libintl_textdomain.cold
 000000000001b700 D _libintl_version
 000000000001b808 b _locale_alias_path.1
-00000000000083a0 t _locale_charset
+00000000000083a0 T _locale_charset
 00000000000170e0 s _locales_with_principal_language
 0000000000017520 s _locales_with_principal_territory
 000000000001b360 d _lock
@@ -208,7 +208,7 @@
                  U _munmap
 000000000001b760 d _mutex
                  U _newlocale
-0000000000008240 t _ngettext
+0000000000008240 T _ngettext
                  U _nl_langinfo
 000000000001b818 b _nmap
 000000000001b7a0 d _once.0
@@ -270,7 +270,7 @@
                  U _strtoul
 000000000001b8c0 b _struniq_hash_table
 000000000001b720 d _struniq_lock
-0000000000008270 t _textdomain
+0000000000008270 T _textdomain
                  U _tfind
 0000000000004d40 t _transcmp
 000000000001b5e0 d _tree_lock
```

All the important symbols are correctly exposed.

Bug: https://bugs.gentoo.org/906507