### PR TITLE
net-libs/udns: Fix detection of inet_pton and inet_ntop with clang 16

### DIFF
--- a/net-libs/udns/files/udns-0.4-configure-pton-ntop-clang16.patch
+++ b/net-libs/udns/files/udns-0.4-configure-pton-ntop-clang16.patch
@@ -1,0 +1,22 @@
+Bug: https://bugs.gentoo.org/883285
+
+From e39b749619191226ccbf8730084c0d2dcadc9065 Mon Sep 17 00:00:00 2001
+From: Violet Purcell <vimproved@inventati.org>
+Date: Sat, 8 Jul 2023 18:34:11 +0000
+Subject: [PATCH] Fix detection of dns_pton and dns_ntop with clang 16
+
+--- a/configure
++++ b/configure
+@@ -94,7 +94,8 @@ int main() {
+   char buf[64];
+   long x = 0;
+   inet_pton(AF_INET, &x, buf);
+-  return inet_ntop(AF_INET, &x, buf, sizeof(buf));
++  inet_ntop(AF_INET, &x, buf, sizeof(buf));
++  return 0;
+ } 
+ EOF
+ 
+-- 
+2.41.0
+

--- a/net-libs/udns/udns-0.4-r2.ebuild
+++ b/net-libs/udns/udns-0.4-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -16,6 +16,7 @@ IUSE="ipv6 static +tools"
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-0.4-configure-clang16.patch
+	"${FILESDIR}"/${PN}-0.4-configure-pton-ntop-clang16.patch
 )
 
 src_configure() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/883285