### PR TITLE
media-libs/libepoxy: Correctly fallback to libOpenGL

### DIFF
--- a/media-libs/libepoxy/files/libepoxy-1.5.10-libopengl-fallback.patch
+++ b/media-libs/libepoxy/files/libepoxy-1.5.10-libopengl-fallback.patch
@@ -1,0 +1,42 @@
+From 702a0e6639affa64881b9486bb8c866b9134a5cd Mon Sep 17 00:00:00 2001
+From: "Haelwenn (lanodan) Monnier" <contact@hacktivis.me>
+To: https://github.com/anholt/libepoxy/pull/259
+Date: Fri, 4 Jun 2021 06:35:23 +0200
+Subject: [PATCH] meson.build: Fallback from libGL to libOpenGL when GLX is
+ disabled
+
+---
+ meson.build     | 3 +++
+ src/meson.build | 2 +-
+ 2 files changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/meson.build b/meson.build
+index e0228d1..95b5144 100644
+--- a/meson.build
++++ b/meson.build
+@@ -164,6 +164,9 @@ endif
+ # Dependencies
+ dl_dep = cc.find_library('dl', required: false)
+ gl_dep = dependency('gl', required: false)
++if not gl_dep.found() and not build_glx
++	gl_dep = dependency('opengl', required: false)
++endif
+ egl_dep = dependency('egl', required: false)
+ 
+ # Optional dependencies for tests
+diff --git a/src/meson.build b/src/meson.build
+index 37e28f0..11c4b54 100644
+--- a/src/meson.build
++++ b/src/meson.build
+@@ -93,7 +93,7 @@ libepoxy_dep = declare_dependency(
+ # pkg-config file, for consumers of Epoxy
+ gl_reqs = []
+ if gl_dep.found() and gl_dep.type_name() == 'pkgconfig'
+-  gl_reqs += 'gl'
++  gl_reqs += gl_dep.name()
+ endif
+ if build_egl and egl_dep.found() and egl_dep.type_name() == 'pkgconfig'
+   gl_reqs += 'egl'
+-- 
+2.35.1
+

--- a/media-libs/libepoxy/libepoxy-1.5.10-r2.ebuild
+++ b/media-libs/libepoxy/libepoxy-1.5.10-r2.ebuild
@@ -1,0 +1,48 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_REQ_USE='xml(+)'
+inherit meson-multilib python-any-r1 virtualx
+
+if [[ ${PV} = 9999* ]]; then
+	EGIT_REPO_URI="https://github.com/anholt/${PN}.git"
+	inherit git-r3
+else
+	SRC_URI="https://github.com/anholt/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+fi
+
+DESCRIPTION="Library for handling OpenGL function pointer management"
+HOMEPAGE="https://github.com/anholt/libepoxy"
+
+LICENSE="MIT"
+SLOT="0"
+IUSE="+egl test +X"
+
+RESTRICT="!test? ( test )"
+
+RDEPEND="
+	egl? ( media-libs/mesa[egl(+),${MULTILIB_USEDEP}] )"
+DEPEND="${RDEPEND}
+	X? ( x11-libs/libX11[${MULTILIB_USEDEP}] )"
+BDEPEND="${PYTHON_DEPS}
+	virtual/pkgconfig"
+
+PATCHES=( "${FILESDIR}"/libepoxy-1.5.10-libopengl-fallback.patch )
+
+multilib_src_configure() {
+	local emesonargs=(
+		-Degl=$(usex egl)
+		-Dglx=$(usex X)
+		$(meson_use X x11)
+		$(meson_use test tests)
+	)
+	meson_src_configure
+}
+
+multilib_src_test() {
+	virtx meson_src_test
+}


### PR DESCRIPTION
Signed-off-by: Haelwenn (lanodan) Monnier <contact@hacktivis.me>
