### PR TITLE
x11-libs/fox-wrapper: EAPI8 bump

### DIFF
--- a/x11-libs/fox-wrapper/fox-wrapper-3-r1.ebuild
+++ b/x11-libs/fox-wrapper/fox-wrapper-3-r1.ebuild
@@ -1,0 +1,20 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DESCRIPTION="Wrapper for fox-config to manage multiple versions"
+HOMEPAGE="https://wiki.gentoo.org/wiki/No_homepage"
+S=${WORKDIR}
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86"
+
+src_install() {
+	exeinto /usr/lib/misc
+	newexe "${FILESDIR}"/fox-wrapper-${PV}.sh fox-wrapper.sh
+
+	dodir /usr/bin
+	dosym ../lib/misc/fox-wrapper.sh /usr/bin/fox-config
+}


### PR DESCRIPTION
Simple `EAPI8` bump:
```diff
4c4
< EAPI=6
---
> EAPI=8
6c6
< DESCRIPTION="wrapper for fox-config to manage multiple versions"
---
> DESCRIPTION="Wrapper for fox-config to manage multiple versions"
8c8
< SRC_URI=""
---
> S=${WORKDIR}
12,18c12
< KEYWORDS="~alpha amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ppc ppc64 sparc x86"
< IUSE=""
< 
< RDEPEND=""
< DEPEND=""
< 
< S=${WORKDIR}
---
> KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86"
```