### PR TITLE
app-text/libebook: EAPI8 bump, fix UnusedInherits

### DIFF
--- a/app-text/libebook/libebook-0.1.3-r3.ebuild
+++ b/app-text/libebook/libebook-0.1.3-r3.ebuild
@@ -1,0 +1,58 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+MY_P="libe-book-${PV}"
+inherit autotools
+
+DESCRIPTION="Library parsing various ebook formats"
+HOMEPAGE="https://sourceforge.net/projects/libebook/"
+SRC_URI="mirror://sourceforge/${PN}/${MY_P}.tar.bz2"
+S="${WORKDIR}/${MY_P}"
+
+LICENSE="MPL-2.0"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~loong ~ppc64 ~riscv ~x86"
+IUSE="doc test tools"
+
+RESTRICT="!test? ( test )"
+
+RDEPEND="
+	app-text/liblangtag
+	dev-libs/icu:=
+	dev-libs/librevenge
+	dev-libs/libxml2
+	sys-libs/zlib
+"
+DEPEND="${RDEPEND}
+	dev-libs/boost
+	dev-util/gperf
+"
+BDEPEND="
+	virtual/pkgconfig
+	doc? ( app-doc/doxygen )
+	test? ( dev-util/cppunit )
+"
+
+PATCHES=( "${FILESDIR}/${P}-icu-68.patch" )
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_configure() {
+	local myeconfargs=(
+		--disable-werror
+		$(use_with doc docs)
+		$(use_enable test tests)
+		$(use_with tools)
+	)
+	econf "${myeconfargs[@]}"
+}
+
+src_install() {
+	default
+	find "${D}" -name '*.la' -type f -delete || die
+}


### PR DESCRIPTION
```diff
1c1
< # Copyright 1999-2022 Gentoo Authors
---
> # Copyright 1999-2023 Gentoo Authors
4c4
< EAPI=7
---
> EAPI=8
7c7
< inherit autotools flag-o-matic
---
> inherit autotools
11a12
> S="${WORKDIR}/${MY_P}"
15c16
< KEYWORDS="amd64 ~arm arm64 ~loong ~ppc64 ~riscv x86"
---
> KEYWORDS="~amd64 ~arm ~arm64 ~loong ~ppc64 ~riscv ~x86"
37,38d37
< S="${WORKDIR}/${MY_P}"
< 
48d46
< 		--disable-static
```