### PR TITLE
RFC: secureboot.eclass: easier and more releable signing of bootloaders and kernels

### DIFF
--- a/app-emulation/xen/xen-4.17.1.ebuild
+++ b/app-emulation/xen/xen-4.17.1.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 PYTHON_COMPAT=( python3_{9..11} )
 
-inherit flag-o-matic mount-boot python-any-r1 toolchain-funcs
+inherit flag-o-matic mount-boot python-any-r1 secureboot toolchain-funcs
 
 if [[ ${PV} == *9999 ]]; then
 	inherit git-r3
@@ -78,6 +78,7 @@ pkg_setup() {
 			die "Unsupported architecture!"
 		fi
 	fi
+	use efi && secureboot_pkg_setup
 }
 
 src_prepare() {
@@ -169,6 +170,11 @@ src_install() {
 
 	xen_make DESTDIR="${D}" -C xen install
 
-	# make install likes to throw in some extra EFI bits if it built
-	use efi || rm -rf "${D}/usr/$(get_libdir)/efi"
+	if use efi; then
+		secureboot_auto_sign --in-place
+	else
+		# make install likes to throw in some extra EFI bits if it built
+		rm -rf "${D}/usr/$(get_libdir)/efi"
+	fi
+
 }

--- a/sys-apps/ipmicfg/ipmicfg-1.34.2.230224.ebuild
+++ b/sys-apps/ipmicfg/ipmicfg-1.34.2.230224.ebuild
@@ -7,6 +7,8 @@ MY_DATE="$(ver_cut 4)"
 MY_PN="${PN^^}"
 MY_PV="$(ver_cut 1-3)"
 
+inherit secureboot
+
 DESCRIPTION="An in-band utility for configuring Supermicro IPMI devices"
 HOMEPAGE="https://www.supermicro.com"
 SRC_URI="https://www.supermicro.com/Bios/sw_download/551/${MY_PN}_${MY_PV}_build.${MY_DATE}.zip"
@@ -23,12 +25,17 @@ RESTRICT="bindist mirror"
 
 QA_PREBUILT="usr/bin/ipmicfg"
 
+pkg_setup() {
+	use uefi && secureboot_pkg_setup
+}
+
 src_install() {
 	newbin Linux/$(usex amd64 '64bit' '32bit')/IPMICFG-Linux.x86$(usex amd64 '_64' '') ipmicfg
 
 	if use uefi; then
 		insinto /usr/share/ipmicfg
 		newins UEFI/IPMICFG.efi ipmicfg.efi
+		secureboot_auto_sign --in-place
 	fi
 
 	# Install docs

--- a/sys-apps/memtest86+/memtest86+-6.20-r1.ebuild
+++ b/sys-apps/memtest86+/memtest86+-6.20-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit mount-boot toolchain-funcs
+inherit mount-boot secureboot toolchain-funcs
 
 MY_PV=${PV/_/-}
 
@@ -27,6 +27,12 @@ BDEPEND="
 "
 
 S=${WORKDIR}/memtest86plus-${MY_PV}
+
+pkg_setup() {
+	if use efi32 || use efi64; then
+		secureboot_pkg_setup
+	fi
+}
 
 src_prepare() {
 	sed -i \
@@ -75,6 +81,10 @@ src_install() {
 	install_memtest_images
 	use iso32 && newins build32/memtest.iso memtest32.iso
 	use iso64 && newins build64/memtest.iso memtest64.iso
+
+	if use efi32 || use efi64; then
+		secureboot_auto_sign --in-place
+	fi
 }
 
 pkg_pretend() {

--- a/sys-apps/memtest86-bin/memtest86-bin-10.5.ebuild
+++ b/sys-apps/memtest86-bin/memtest86-bin-10.5.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit mount-boot
+inherit mount-boot secureboot
 
 DESCRIPTION="Stand alone memory testing software for x86 EFI hardware"
 HOMEPAGE="http://www.memtest86.com/"
@@ -33,6 +33,8 @@ src_install() {
 	newexe "${FILESDIR}"/${PN}-grub.d 39_memtest86-bin
 
 	dodoc MemTest86_User_Guide_UEFI.pdf
+
+	secureboot_auto_sign --in-place
 }
 
 pkg_postinst() {

--- a/sys-block/perccli/perccli-7.5.007.0529-r2.ebuild
+++ b/sys-block/perccli/perccli-7.5.007.0529-r2.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-inherit mount-boot rpm
+inherit mount-boot rpm secureboot
 
 DESCRIPTION="LINUX PERCCLI Utility For All Dell HBA/PERC Controllers"
 HOMEPAGE="https://www.dell.com/support/home/us/en/19/drivers/driversdetails?driverId=NF8G9"
@@ -21,6 +21,10 @@ SRC_URI="https://downloads.dell.com/FOLDER05235308M/1/perccli_linux_NF8G9_A07_7.
 	doc? ( https://topics-cdn.dell.com/pdf/${DISTFILE_DOC} )"
 
 S="${WORKDIR}"/perccli_7.5-007.0529_linux
+
+pkg_setup() {
+	use efi && secureboot_pkg_setup
+}
 
 src_unpack() {
 	default
@@ -41,4 +45,5 @@ src_install() {
 		doexe EFI/perccli.efi
 	fi
 	use doc && dodoc "${DISTDIR}"/${DISTFILE_DOC}
+	use efi && secureboot_auto_sign --in-place
 }

--- a/sys-block/sas3flash/sas3flash-16.ebuild
+++ b/sys-block/sas3flash/sas3flash-16.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-inherit mount-boot
+inherit mount-boot secureboot
 
 DESCRIPTION="Flash utility for LSI MPT-SAS3 controller"
 HOMEPAGE="https://www.broadcom.com/products/storage/host-bus-adapters/sas-9300-8e#downloads"
@@ -47,6 +47,10 @@ pkg_nofetch() {
 	einfo "${SRC_URI}"
 }
 
+pkg_setup() {
+	use efi && secureboot_pkg_setup
+}
+
 supportedcards() {
 	elog "This binary supports should support ALL cards, including, but not"
 	elog "limited to the following series:"
@@ -88,6 +92,7 @@ src_install() {
 		if use amd64; then
 			doexe Installer_P"${PV}"_for_UEFI/sas3flash_udk_uefi_x64_rel/sas3flash.efi
 		fi
+		secureboot_auto_sign --in-place
 	fi
 
 	default

--- a/sys-block/sas3ircu/sas3ircu-16.ebuild
+++ b/sys-block/sas3ircu/sas3ircu-16.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-inherit mount-boot
+inherit mount-boot secureboot
 
 DESCRIPTION="LSI MPT-SAS3 controller management tool"
 HOMEPAGE="https://www.broadcom.com/products/storage/host-bus-adapters/sas-9300-8e#downloads"
@@ -40,6 +40,10 @@ pkg_nofetch() {
 		elog "and also place it into your DISTDIR directory"
 	fi
 	einfo "${SRC_URI}"
+}
+
+pkg_setup() {
+	use efi && secureboot_pkg_setup
 }
 
 supportedcards() {
@@ -84,5 +88,6 @@ src_install() {
 		elif use arm64; then
 			doexe sas3ircu_rel/sas3ircu/sas3ircu_udk_uefi_arm_rel/sas3ircu.efi
 		fi
+		secureboot_auto_sign --in-place
 	fi
 }

--- a/sys-boot/syslinux/syslinux-6.04_pre3-r1.ebuild
+++ b/sys-boot/syslinux/syslinux-6.04_pre3-r1.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-inherit toolchain-funcs flag-o-matic
+inherit toolchain-funcs flag-o-matic secureboot
 
 DESCRIPTION="SYSLINUX, PXELINUX, ISOLINUX, EXTLINUX and MEMDISK bootloaders"
 HOMEPAGE="https://www.syslinux.org/"
@@ -40,6 +40,10 @@ QA_EXECSTACK="usr/share/syslinux/*"
 QA_WX_LOAD="usr/share/syslinux/*"
 QA_PRESTRIPPED="usr/share/syslinux/.*"
 QA_FLAGS_IGNORED=".*"
+
+pkg_setup() {
+	use efi && secureboot_pkg_setup
+}
 
 src_prepare() {
 	local PATCHES=(
@@ -102,4 +106,6 @@ src_install() {
 	fi
 	einstalldocs
 	dostrip -x /usr/share/syslinux
+
+	use efi && secureboot_auto_sign --in-place
 }

--- a/sys-firmware/edk2-ovmf-bin/edk2-ovmf-bin-202202.ebuild
+++ b/sys-firmware/edk2-ovmf-bin/edk2-ovmf-bin-202202.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-inherit readme.gentoo-r1
+inherit readme.gentoo-r1 secureboot
 
 BINPKG="${P/-bin/}-1"
 
@@ -60,6 +60,8 @@ src_install() {
 	# Don't want to try to install the readme from the source package
 	rm "usr/share/doc/${PF}/README.gentoo.bz2"
 	mv usr "${ED}" || die
+
+	secureboot_auto_sign --in-place
 
 	readme.gentoo_create_doc
 }

--- a/sys-firmware/edk2-ovmf/edk2-ovmf-202105-r2.ebuild
+++ b/sys-firmware/edk2-ovmf/edk2-ovmf-202105-r2.ebuild
@@ -6,7 +6,7 @@ EAPI=7
 PYTHON_REQ_USE="sqlite"
 PYTHON_COMPAT=( python3_{9,10,11} )
 
-inherit python-any-r1 readme.gentoo-r1
+inherit python-any-r1 readme.gentoo-r1 secureboot
 
 DESCRIPTION="UEFI firmware for 64-bit x86 virtual machines"
 HOMEPAGE="https://github.com/tianocore/edk2"
@@ -90,6 +90,7 @@ In order to use the firmware you can run qemu the following way
 
 pkg_setup() {
 	[[ ${PV} != "999999" ]] && use binary || python-any-r1_pkg_setup
+	secureboot_pkg_setup
 }
 
 src_prepare() {
@@ -168,6 +169,8 @@ src_install() {
 	insinto /usr/share/qemu/firmware
 	doins qemu/*
 	rm "${ED}"/usr/share/qemu/firmware/40-edk2-ovmf-x64-sb-enrolled.json || die "rm failed"
+
+	secureboot_auto_sign --in-place
 
 	readme.gentoo_create_doc
 }

--- a/sys-firmware/edk2-ovmf/edk2-ovmf-202202.ebuild
+++ b/sys-firmware/edk2-ovmf/edk2-ovmf-202202.ebuild
@@ -6,7 +6,7 @@ EAPI=8
 PYTHON_REQ_USE="sqlite"
 PYTHON_COMPAT=( python3_{9,10,11} )
 
-inherit python-any-r1 readme.gentoo-r1
+inherit python-any-r1 readme.gentoo-r1 secureboot
 
 DESCRIPTION="UEFI firmware for 64-bit x86 virtual machines"
 HOMEPAGE="https://github.com/tianocore/edk2"
@@ -68,6 +68,11 @@ In order to use the firmware you can run qemu the following way
 	$ qemu-system-x86_64 \
 		-drive file=/usr/share/edk2-ovmf/OVMF.fd,if=pflash,format=raw,unit=0,readonly=on \
 		..."
+
+pkg_setup() {
+	python-any-r1_pkg_setup
+	secureboot_pkg_setup
+}
 
 src_prepare() {
 	# Bundled submodules
@@ -139,6 +144,8 @@ src_install() {
 	insinto /usr/share/qemu/firmware
 	doins qemu/*
 	rm "${ED}"/usr/share/qemu/firmware/40-edk2-ovmf-x64-sb-enrolled.json || die "rm failed"
+
+	secureboot_auto_sign --in-place
 
 	readme.gentoo_create_doc
 }

--- a/sys-firmware/ipxe/ipxe-1.21.1_p20230601.ebuild
+++ b/sys-firmware/ipxe/ipxe-1.21.1_p20230601.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit savedconfig toolchain-funcs
+inherit savedconfig secureboot toolchain-funcs
 
 # for 1.21.1_p20230601
 COMMIT_SHA1="4fa4052c7ebb59e4d4aa396f1563c89118623ec7"
@@ -33,6 +33,12 @@ BDEPEND="
 		amd64? ( ${SOURCE_DEPEND} )
 		x86? ( ${SOURCE_DEPEND} )
 	)"
+
+pkg_setup() {
+	if use efi || use efi64; then
+		secureboot_pkg_setup
+	fi
+}
 
 src_configure() {
 	use binary && return
@@ -122,6 +128,10 @@ src_install() {
 	use undi && doins bin/*.kpxe
 	use usb && doins bin/*.usb
 	use lkrn && doins bin/*.lkrn
+
+	if use efi || use efi64; then
+		secureboot_auto_sign --in-place
+	fi
 
 	save_config config/local/general.h
 }


### PR DESCRIPTION
This adds a small `secureboot.eclass` that calls `sbsign` to sign efi executables (and can be used for other files as well).

## The problem:

Sure you can manually sign e.g. `systemd-boot`, but when `bootctl update` updates the bootloader files on the ESP the signature is gone and secure boot breaks. If you have enabled the systemd-boot automatic updating service this can come as an unpleasant surprise.

## The solution:

Use the environment variables `SECUREBOOT_SIGN_KEY` and `SECUREBOOT_SIGN_CERT` (similar to `linux-mod-r1.eclass`) to sign any efi executables (or regular kernel files) provided by a package *before* they get installed to the file system. It is now guaranteed that any tooling will install signed files, and as such bootloader and kernel upgrades become more reliable with secure boot enabled.

- `bootctl update` and `bootctl install` are smart enough to install `systemd-bootx64.efi.signed` instead of `systemd-bootx64.efi` if it is present.
- AFAIK `refind-install` doesn't do this so we sign the files in place instead.
- `sys-kernel/gentoo-kernel` (via `dist-kernel-utils.eclass`) is also signed in place because the `90-uki-copy` `kernel-install` plugin enforces the file has the `.efi` extension (not `.efi.signed`). 
- The next release of dracut will expect uki files to be named `uki.efi`, we can already make this change now so we are prepared. 
- Signing uki's was already possible using the dracut configuration flags `uefi_secureboot_cert` and `uefi_secureboot_key`. Now we can also sign regular kernel files, this is required to use secure boot in combination with grub since uki support for grub hasn't landed in a released version yet.
- Tried to make the same changes to the grub ebuild, but apparently there is no grub efi executable generated during compilation. Presumably this is done by `grub-install`? So there are still some extra steps required here to make secure boot work with grub.

## Still todo:

- Somehow make `systemd-boot` work with `shim`. With these changes we can enable secure boot provided we ensure the key we use is registered with the uefi firmware. However,  It is not always possible or desirable to enrol custom keys. Shim makes it possible to use secure boot without enrolling custom keys but is currently hardcoded to load grub. `refind-install` is smart enough to deal with this if you call it with the `--shim` option but getting this to work with `systemd-boot` requires manual copying which is undesirable because then the bootloader doesn't get updated automatically any more. Possibly the best solution here is an upstream solution (https://github.com/systemd/systemd/issues/27234).
- Somehow also provide a way to semi-automatically sign the grub efi executable.

Lets discuss this with the relevant package/eclass maintainers first before I send it to the mailing list. @floppym @gentoo/base-system @sveyret @gentoo/proxy-maint @gentoo/systemd @gentoo/dist-kernel @mgorny 