### PR TITLE
dev-db/mariadb: unleash 10.11 to testing, mask <10.6

### DIFF
--- a/dev-db/mariadb/mariadb-10.11.4.ebuild
+++ b/dev-db/mariadb/mariadb-10.11.4.ebuild
@@ -28,8 +28,7 @@ REQUIRED_USE="jdbc? ( extraengine server !static )
 	?? ( tcmalloc jemalloc )
 	static? ( yassl !pam )"
 
-#KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~mips ~ppc ~ppc64 ~riscv ~s390 ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x64-solaris"
-KEYWORDS=""
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~mips ~ppc ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x64-solaris"
 
 # Shorten the path because the socket path length must be shorter than 107 chars
 # and we will run a mysql server during test phase

--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -33,6 +33,10 @@
 
 #--- END OF EXAMPLES ---
 
+# Tomáš Mózes <hydrapolic@gmail.com> (2023-07-12)
+# Incompatible with OpenSSL-3, update to MariaDB 10.6.
+<dev-db/mariadb-10.6
+
 # Michał Górny <mgorny@gentoo.org> (2023-07-12)
 # Having scikit-build-core installed still breaks building setuptools
 # extensions in some scenarios.


### PR DESCRIPTION
Updated some testing machines to 10.11, seems to be working fine.

Note: s390 needs to be re-keyworded due to dev-libs/libfmt