### PR TITLE
 sci-misc/apertium: use https:// schema for HOMEPAGE url

### DIFF
--- a/sci-misc/apertium/apertium-3.2.0.ebuild
+++ b/sci-misc/apertium/apertium-3.2.0.ebuild
@@ -6,7 +6,7 @@ EAPI=7
 inherit autotools
 
 DESCRIPTION="Shallow-transfer machine Translation engine and toolbox"
-HOMEPAGE="http://apertium.sourceforge.net/"
+HOMEPAGE="https://apertium.sourceforge.net/"
 SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
 
 LICENSE="GPL-2"

--- a/sci-misc/apertium/apertium-3.8.3.ebuild
+++ b/sci-misc/apertium/apertium-3.8.3.ebuild
@@ -7,7 +7,7 @@ PYTHON_COMPAT=( python3_{9..11} )
 inherit autotools python-any-r1
 
 DESCRIPTION="Shallow-transfer machine Translation engine and toolbox"
-HOMEPAGE="http://apertium.sourceforge.net/"
+HOMEPAGE="https://apertium.sourceforge.net/"
 SRC_URI="https://github.com/apertium/apertium/releases/download/v${PV}/${P}.tar.bz2"
 
 LICENSE="GPL-2"


### PR DESCRIPTION
> Homepage link http://apertium.sourceforge.net/ is a permanent redirect to its HTTPS counterpart https://apertium.sourceforge.net/ and should be updated.

ref: https://repology.org/repository/gentoo/problems

Please squash on merge (Github interface doesn't allow that git versatility)