### PR TITLE
sys-apps/gscanbus: Fix incompatible function pointer types

### DIFF
--- a/sys-apps/gscanbus/files/gscanbus-0.8-incompatible-function-pointer-types.patch
+++ b/sys-apps/gscanbus/files/gscanbus-0.8-incompatible-function-pointer-types.patch
@@ -1,0 +1,30 @@
+Bug: https://bugs.gentoo.org/887001
+--- a/menues.c
++++ b/menues.c
+@@ -280,7 +280,7 @@ static void readQuadletApp(gpointer callback_data, guint callback_action,
+ 	gtk_box_pack_start(GTK_BOX(GTK_DIALOG(dialog->dialog)->vbox),
+ 		table, TRUE, TRUE, 0);
+ 
+-	transactionDialogAddOkClose(dialog, readQuadletAppOk);
++	transactionDialogAddOkClose(dialog, (GtkSignalFunc)readQuadletAppOk);
+ 
+ 	gtk_widget_show_all(dialog->dialog);
+ }
+@@ -336,7 +336,7 @@ static void writeQuadletApp(gpointer callback_data, guint callback_action,
+ 	gtk_box_pack_start(GTK_BOX(GTK_DIALOG(dialog->dialog)->vbox),
+ 		table, TRUE, TRUE, 0);
+ 
+-	transactionDialogAddOkClose(dialog, writeQuadletAppOk);
++	transactionDialogAddOkClose(dialog, (GtkSignalFunc)writeQuadletAppOk);
+ 
+ 	gtk_widget_show_all(dialog->dialog);
+ }
+@@ -417,7 +417,7 @@ static void readBlockApp(gpointer callback_data, guint callback_action,
+ 		table, TRUE, TRUE, 0);
+ 
+ 	//dialogAddOkClose(dialog->dialog, readBlockAppOk);
+-	transactionDialogAddOkClose(dialog, readBlockAppOk);
++	transactionDialogAddOkClose(dialog, (GtkSignalFunc)readBlockAppOk);
+ 
+ 	gtk_widget_show_all(dialog->dialog);
+ }

--- a/sys-apps/gscanbus/gscanbus-0.8-r1.ebuild
+++ b/sys-apps/gscanbus/gscanbus-0.8-r1.ebuild
@@ -1,0 +1,24 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="Bus scanning, testing and topology visualizing tool for Linux IEEE1394 subsystem"
+HOMEPAGE="https://sourceforge.net/projects/gscanbus.berlios/"
+SRC_URI="mirror://sourceforge/${PN}.berlios/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86"
+
+RDEPEND="
+	sys-libs/libraw1394
+	x11-libs/gtk+:2"
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-Wimplicit-function-declaration.patch
+	"${FILESDIR}"/${P}-incompatible-function-pointer-types.patch
+
+)


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/887001