### PR TITLE
dev-lang/mono: Filter LTO with LLD

### DIFF
--- a/dev-lang/mono/mono-6.12.0.122.ebuild
+++ b/dev-lang/mono/mono-6.12.0.122.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 
 CHECKREQS_DISK_BUILD="4500M"
-inherit autotools check-reqs linux-info mono-env pax-utils multilib-minimal
+inherit autotools check-reqs flag-o-matic linux-info mono-env pax-utils multilib-minimal toolchain-funcs
 
 DESCRIPTION="Mono runtime and class libraries, a C# compiler/interpreter"
 HOMEPAGE="https://mono-project.com"
@@ -85,6 +85,8 @@ src_prepare() {
 }
 
 multilib_src_configure() {
+	tc-ld-is-lld && filter-lto
+
 	local myeconfargs=(
 		$(use_with xen xen_opt)
 		--without-ikvm-native

--- a/dev-lang/mono/mono-6.12.0.182.ebuild
+++ b/dev-lang/mono/mono-6.12.0.182.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 
 CHECKREQS_DISK_BUILD="4500M"
-inherit autotools check-reqs linux-info mono-env pax-utils multilib-minimal
+inherit autotools check-reqs flag-o-matic linux-info mono-env pax-utils multilib-minimal toolchain-funcs
 
 DESCRIPTION="Mono runtime and class libraries, a C# compiler/interpreter"
 HOMEPAGE="https://mono-project.com"
@@ -85,6 +85,8 @@ src_prepare() {
 }
 
 multilib_src_configure() {
+	tc-ld-is-lld && filter-lto
+
 	local myeconfargs=(
 		$(use_with xen xen_opt)
 		--without-ikvm-native


### PR DESCRIPTION
Compilation fails with LLD and LTO with the following error:

```
ld.lld: error: boringssl/crypto/bn/CMakeFiles/bn.dir/convert.c.o <inline asm>:1:7: invalid operand for instruction
        divq $-8446744073709551616
             ^~~~~~~~~~~~~~~~~~~~~


ld.lld: error: boringssl/crypto/asn1/CMakeFiles/asn1.dir/a_object.c.o <inline asm>:1:7: invalid operand for instruction
        divq $-9223372036854775808
             ^~~~~~~~~~~~~~~~~~~~~
```