### PR TITLE
dev-qt/qtwebengine: fix compiling with clang-16

### DIFF
--- a/dev-qt/qtwebengine/files/qtwebengine-5.15.10_p20230623-clang16.patch
+++ b/dev-qt/qtwebengine/files/qtwebengine-5.15.10_p20230623-clang16.patch
@@ -1,0 +1,14 @@
+--- a/src/3rdparty/chromium/v8/src/base/bit-field.h
++++ b/src/3rdparty/chromium/v8/src/base/bit-field.h
+@@ -39,8 +39,11 @@
+   static constexpr int kLastUsedBit = kShift + kSize - 1;
+   static constexpr U kNumValues = U{1} << kSize;
+ 
++  #pragma clang diagnostic push
++  #pragma clang diagnostic ignored "-Wenum-constexpr-conversion"
+   // Value for the field with all bits set.
+   static constexpr T kMax = static_cast<T>(kNumValues - 1);
++  #pragma clang diagnostic pop
+ 
+   template <class T2, int size2>
+   using Next = BitField<T2, kShift + kSize, size2, U>;

--- a/dev-qt/qtwebengine/qtwebengine-5.15.10_p20230623.ebuild
+++ b/dev-qt/qtwebengine/qtwebengine-5.15.10_p20230623.ebuild
@@ -100,7 +100,10 @@ BDEPEND="${PYTHON_DEPS}
 	ppc64? ( >=dev-util/gn-0.1807 )
 "
 
-PATCHES=( "${WORKDIR}/${PN}-5.15.8_p20230313-patchset" )
+PATCHES=(
+	"${WORKDIR}/${PN}-5.15.8_p20230313-patchset"
+	"${FILESDIR}/${PN}-5.15.10_p20230623-clang16.patch"
+)
 
 qtwebengine_check-reqs() {
 	# bug #307861


### PR DESCRIPTION
clang-16 complains about casting an integer value that exceeds an enumeration capacity in the class base::BitField
to not modify chromium code we just cancel warning about this circumstance to prevent it from being converted to an error that fails compilation