### PR TITLE
www-servers/nginx: Add USE="ktls" (Kernel TLS offload)

### DIFF
--- a/www-servers/nginx/metadata.xml
+++ b/www-servers/nginx/metadata.xml
@@ -8,6 +8,7 @@
     <flag name="http2">Enable HTTP2 module support</flag>
     <flag name="http3">Enable HTTP3 module support</flag>
     <flag name="http-cache">Enable HTTP cache support</flag>
+    <flag name="ktls">Enable Kernel TLS offload (kTLS)</flag>
     <flag name="libatomic">Use libatomic instead of builtin atomic operations</flag>
     <flag name="pcre-jit">Enable JIT for pcre</flag>
     <flag name="pcre2">Enable support for pcre2</flag>

--- a/www-servers/nginx/nginx-1.25.1-r2.ebuild
+++ b/www-servers/nginx/nginx-1.25.1-r2.ebuild
@@ -252,7 +252,7 @@ NGINX_MODULES_3RD="
 	stream_javascript
 "
 
-IUSE="aio debug +http +http2 http3 +http-cache libatomic pcre +pcre2 pcre-jit rtmp selinux ssl threads vim-syntax"
+IUSE="aio debug +http +http2 http3 +http-cache ktls libatomic pcre +pcre2 pcre-jit rtmp selinux ssl threads vim-syntax"
 
 for mod in $NGINX_MODULES_STD; do
 	IUSE="${IUSE} +nginx_modules_http_${mod}"
@@ -298,6 +298,9 @@ CDEPEND="
 	http-cache? (
 		dev-libs/openssl:0=
 	)
+	ktls? (
+		>=dev-libs/openssl-3:0=[ktls]
+	)
 	nginx_modules_http_brotli? ( app-arch/brotli:= )
 	nginx_modules_http_geoip? ( dev-libs/geoip )
 	nginx_modules_http_geoip2? ( dev-libs/libmaxminddb:= )
@@ -328,6 +331,7 @@ BDEPEND="nginx_modules_http_brotli? ( virtual/pkgconfig )"
 PDEPEND="vim-syntax? ( app-vim/nginx-syntax )"
 
 REQUIRED_USE="pcre-jit? ( pcre )
+	ktls? ( ssl )
 	nginx_modules_http_fancyindex? ( nginx_modules_http_addition )
 	nginx_modules_http_grpc? ( http2 )
 	nginx_modules_http_lua? (
@@ -442,6 +446,7 @@ src_configure() {
 	use debug     && myconf+=( --with-debug )
 	use http2     && myconf+=( --with-http_v2_module )
 	use http3     && myconf+=( --with-http_v3_module )
+	use ktls      && myconf+=( --with-openssl-opt=enable-ktls )
 	use libatomic && myconf+=( --with-libatomic )
 	use pcre      && myconf+=( --with-pcre --without-pcre2 )
 	use pcre-jit  && myconf+=( --with-pcre-jit )


### PR DESCRIPTION
Kernel TLS offload can reduce the number of CPU and Memory ops necessary to send a file over HTTPS.

To activate kTLS you need:
- `CONFIG_TLS=y` in the kernel
- OpenSSL built with `USE="ktls"`
- `ssl_conf_command Options KTLS;` in nginx.conf

After these changes the ebuild will get everything except `nginx.conf` ready.