### PR TITLE
x11-terms/kitty: Backport fix for musl 1.2.4

### DIFF
--- a/x11-terms/kitty/files/kitty-0.29.0-musl-1.2.4.patch
+++ b/x11-terms/kitty/files/kitty-0.29.0-musl-1.2.4.patch
@@ -1,0 +1,20 @@
+From https://github.com/kovidgoyal/kitty/commit/90223b5d146828c65179da49c75ce31b304fa1b8 Mon Sep 17 00:00:00 2001
+From: Kovid Goyal <kovid@kovidgoyal.net>
+Date: Tue, 11 Jul 2023 09:22:40 +0530
+Subject: [PATCH] Fix compilation against musl
+
+As usual in C stdlib world. Ill thought out break the world changes.
+Sigh. musl no longer defines off64_t.
+
+Fixes #6441
+--- a/kitty/fast-file-copy.c
++++ b/kitty/fast-file-copy.c
+@@ -83,7 +83,7 @@ copy_with_file_range(int infd, int outfd, off_t in_pos, size_t len, FastFileCopy
+ #ifdef HAS_COPY_FILE_RANGE
+     unsigned num_of_consecutive_zero_returns = 128;
+     while (len) {
+-        off64_t r = in_pos;
++        int64_t r = in_pos;
+         ssize_t n = copy_file_range(infd, &r, outfd, NULL, len, 0);
+         if (n < 0) {
+             if (errno == EAGAIN) continue;

--- a/x11-terms/kitty/kitty-0.27.1.ebuild
+++ b/x11-terms/kitty/kitty-0.27.1.ebuild
@@ -70,6 +70,10 @@ BDEPEND="
 	wayland? ( dev-util/wayland-scanner )"
 [[ ${PV} == 9999 ]] || BDEPEND+=" verify-sig? ( sec-keys/openpgp-keys-kovidgoyal )"
 
+PATCHES=(
+	"${FILESDIR}/${PN}-0.29.0-musl-1.2.4.patch"
+)
+
 QA_FLAGS_IGNORED="usr/bin/kitten" # written in Go
 
 src_unpack() {

--- a/x11-terms/kitty/kitty-0.28.1.ebuild
+++ b/x11-terms/kitty/kitty-0.28.1.ebuild
@@ -70,6 +70,10 @@ BDEPEND="
 	wayland? ( dev-util/wayland-scanner )"
 [[ ${PV} == 9999 ]] || BDEPEND+=" verify-sig? ( sec-keys/openpgp-keys-kovidgoyal )"
 
+PATCHES=(
+	"${FILESDIR}/${PN}-0.29.0-musl-1.2.4.patch"
+)
+
 QA_FLAGS_IGNORED="usr/bin/kitten" # written in Go
 
 src_unpack() {

--- a/x11-terms/kitty/kitty-0.29.0.ebuild
+++ b/x11-terms/kitty/kitty-0.29.0.ebuild
@@ -70,6 +70,10 @@ BDEPEND="
 	wayland? ( dev-util/wayland-scanner )"
 [[ ${PV} == 9999 ]] || BDEPEND+=" verify-sig? ( sec-keys/openpgp-keys-kovidgoyal )"
 
+PATCHES=(
+	"${FILESDIR}/${PN}-0.29.0-musl-1.2.4.patch"
+)
+
 QA_FLAGS_IGNORED="usr/bin/kitten" # written in Go
 
 src_unpack() {


### PR DESCRIPTION
Upstream Commit: https://github.com/kovidgoyal/kitty/commit/90223b5d146828c65179da49c75ce31b304fa1b8
Upstream Pull Request: https://github.com/kovidgoyal/kitty/pull/6441