### PR TITLE
dev-python/sphinx-tabs: update python support, fix test failure

### DIFF
--- a/dev-python/sphinx-tabs/sphinx-tabs-3.4.1-r1.ebuild
+++ b/dev-python/sphinx-tabs/sphinx-tabs-3.4.1-r1.ebuild
@@ -1,0 +1,52 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DISTUTILS_USE_PEP517=setuptools
+PYTHON_COMPAT=( python3_{10..12} )
+
+inherit distutils-r1
+
+DESCRIPTION="Tabbed views for Sphinx"
+HOMEPAGE="
+	https://github.com/executablebooks/sphinx-tabs/
+	https://pypi.org/project/sphinx-tabs/
+"
+SRC_URI="
+	https://github.com/executablebooks/sphinx-tabs/archive/v${PV}.tar.gz
+		-> ${P}.gh.tar.gz
+"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~ppc ~ppc64 ~riscv ~s390 sparc ~x86"
+
+RDEPEND="
+	dev-python/docutils[${PYTHON_USEDEP}]
+	dev-python/pygments[${PYTHON_USEDEP}]
+	dev-python/sphinx[${PYTHON_USEDEP}]
+"
+
+BDEPEND="
+	test? (
+		dev-python/beautifulsoup4[${PYTHON_USEDEP}]
+		dev-python/pytest-regressions[${PYTHON_USEDEP}]
+		dev-python/pygments[${PYTHON_USEDEP}]
+	)
+"
+
+distutils_enable_tests pytest
+distutils_enable_sphinx docs dev-python/sphinx-rtd-theme
+
+EPYTEST_DESELECT=(
+	# Unpackaged rinohtype
+	tests/test_build.py::test_rinohtype_pdf
+)
+
+src_prepare() {
+	# annoying, incorrect version limitations
+	sed -i -e '/install_requires/d' setup.py || die
+
+	distutils-r1_src_prepare
+}


### PR DESCRIPTION
PYTHON_COMPAT:
    - add python-3.11
    - add python-3.12
    - drop python-3.9

remove old test fix that now leds to breakage

drop dependency on depracated sphinx-testing in favour of spinx.testing

Bug: https://bugs.gentoo.org/896884
Bug: https://bugs.gentoo.org/855866
Closes: https://bugs.gentoo.org/896884
Closes: https://bugs.gentoo.org/855866