### PR TITLE
sys-fs/lvm2: Do no install install_device-mapper unconditionally

### DIFF
--- a/sys-fs/lvm2/lvm2-2.03.21-r1.ebuild
+++ b/sys-fs/lvm2/lvm2-2.03.21-r1.ebuild
@@ -195,14 +195,11 @@ src_test() {
 
 src_install() {
 	local INSTALL_TARGETS=(
-		# full LVM2
-		$(usev lvm "install install_tmpfiles_configuration")
+		# full LVM2  or just device mapper.
+		$(usex lvm "install install_tmpfiles_configuration" "install_device-mapper")
 		# install systemd related files only when requested, bug #522430
 		$(usev $(usex lvm systemd lvm) "SYSTEMD_GENERATOR_DIR=$(systemd_get_systemgeneratordir) \
 			install_systemd_units install_systemd_generators")
-
-		# install dm unconditionally
-		install_device-mapper
 	)
 	emake V=1 DESTDIR="${D}" "${INSTALL_TARGETS[@]}"
 


### PR DESCRIPTION
`install` rule already implies `install_device-mapper`, so no need to add it in the ebuild.

Closes: https://bugs.gentoo.org/909419
Signed-off-by: Gwendal Grignou <gwendal@chromium.org>
