### PR TITLE
dev-lang/perl: Upgrade depedency on perl-cleaner

### DIFF
--- a/dev-lang/perl/perl-5.38.0-r1.ebuild
+++ b/dev-lang/perl/perl-5.38.0-r1.ebuild
@@ -69,8 +69,8 @@ DEPEND="${RDEPEND}"
 BDEPEND="${RDEPEND}"
 
 PDEPEND="
+	>=app-admin/perl-cleaner-2.30
 	!minimal? (
-		>=app-admin/perl-cleaner-2.5
 		>=virtual/perl-CPAN-2.290.0
 		>=virtual/perl-Encode-3.120.0
 		>=virtual/perl-File-Temp-0.230.400-r2


### PR DESCRIPTION
Update perl ebuild to install a perl-cleaner that understand perl-5.36: perl nows install files in /usr/lib*/perl5/5.36, but older perl-cleaner expects the data in /usr/lib*/perl5/5.36.0, so it considers the install unclean and force reinstall of 5.36 perl packages.

Bug: https://bugs.gentoo.org/905625
Signed-off-by: Gwendal Grignou <gwendal@chromium.org>