### PR TITLE
app-containers/{lxd,podman}: Fix build on musl 1.2.4

### DIFF
--- a/app-containers/lxd/files/lxd-5.0.2-fix-build-with-musl-1.2.4.patch
+++ b/app-containers/lxd/files/lxd-5.0.2-fix-build-with-musl-1.2.4.patch
@@ -1,0 +1,17 @@
+From https://github.com/mattn/go-sqlite3/pull/1177/commits/65d6085c5d87280c0d6883c884ddb25f9273942f Mon Sep 17 00:00:00 2001
+From: leso-kn <info@lesosoftware.com>
+Date: Mon, 10 Jul 2023 14:58:52 +0200
+Subject: [PATCH] Fix musl build (#1164)
+
+--- a/vendor/github.com/mattn/go-sqlite3/sqlite3.go
++++ b/vendor/github.com/mattn/go-sqlite3/sqlite3.go
+@@ -21,7 +21,7 @@ package sqlite3
+ #cgo CFLAGS: -DSQLITE_DEFAULT_WAL_SYNCHRONOUS=1
+ #cgo CFLAGS: -DSQLITE_ENABLE_UPDATE_DELETE_LIMIT
+ #cgo CFLAGS: -Wno-deprecated-declarations
+-#cgo linux,!android CFLAGS: -DHAVE_PREAD64=1 -DHAVE_PWRITE64=1
++#cgo linux,!android CFLAGS: -DHAVE_PREAD=1 -DHAVE_PWRITE=1
+ #cgo openbsd CFLAGS: -I/usr/local/include
+ #cgo openbsd LDFLAGS: -L/usr/local/lib
+ #ifndef USE_LIBSQLITE3
+

--- a/app-containers/lxd/lxd-4.0.9-r4.ebuild
+++ b/app-containers/lxd/lxd-4.0.9-r4.ebuild
@@ -1,37 +1,37 @@
 # Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=8
+EAPI=7
 
 inherit bash-completion-r1 go-module linux-info optfeature systemd verify-sig
 
-DESCRIPTION="Modern, secure and powerful system container and virtual machine manager"
-HOMEPAGE="https://ubuntu.com/lxd https://github.com/canonical/lxd"
+DESCRIPTION="Fast, dense and secure container management"
+HOMEPAGE="https://linuxcontainers.org/lxd/introduction/ https://github.com/lxc/lxd"
 SRC_URI="https://linuxcontainers.org/downloads/lxd/${P}.tar.gz
 	verify-sig? ( https://linuxcontainers.org/downloads/lxd/${P}.tar.gz.asc )"
 
-LICENSE="Apache-2.0 BSD LGPL-3 MIT"
+LICENSE="Apache-2.0"
 SLOT="0"
-KEYWORDS="amd64 ~arm64 ~x86"
-IUSE="apparmor nls"
+KEYWORDS="~amd64 ~arm64 ~x86"
+IUSE="apparmor ipv6 nls verify-sig"
 
 DEPEND="acct-group/lxd
 	app-arch/xz-utils
-	>=app-containers/lxc-5.0.0:=[apparmor?,seccomp(+)]
+	>=app-containers/lxc-3.0.0[apparmor?,seccomp(+)]
 	dev-db/sqlite:3
-	>=dev-libs/dqlite-1.13.0:=
+	dev-libs/dqlite
 	dev-libs/lzo
-	>=dev-libs/raft-0.17.1:=[lz4]
+	dev-libs/raft[lz4]
 	>=dev-util/xdelta-3.0[lzma(+)]
-	net-dns/dnsmasq[dhcp]
+	net-dns/dnsmasq[dhcp,ipv6(+)?]
 	sys-libs/libcap
 	virtual/udev"
 RDEPEND="${DEPEND}
 	net-firewall/ebtables
-	net-firewall/iptables
-	sys-apps/iproute2
+	net-firewall/iptables[ipv6(+)?]
+	sys-apps/iproute2[ipv6(+)?]
 	sys-fs/fuse:*
-	>=sys-fs/lxcfs-5.0.0
+	sys-fs/lxcfs
 	sys-fs/squashfs-tools[lzma]
 	virtual/acl"
 BDEPEND="dev-lang/go
@@ -69,7 +69,7 @@ QA_PREBUILT="/usr/bin/fuidshift
 	/usr/bin/lxc-to-lxd
 	/usr/bin/lxd-agent
 	/usr/bin/lxd-benchmark
-	/usr/bin/lxd-migrate
+	/usr/bin/lxd-p2c
 	/usr/sbin/lxd"
 
 VERIFY_SIG_OPENPGP_KEY_PATH=${BROOT}/usr/share/openpgp-keys/linuxcontainers.asc
@@ -80,8 +80,8 @@ RESTRICT="test"
 
 GOPATH="${S}/_dist"
 
-PATCHES=( "${FILESDIR}"/lxd-5.0.2-remove-shellcheck-buildsystem-checks.patch
-	"${FILESDIR}"/lxd-5.0.3-btrfs-quota-group-fix.patch )
+PATCHES=( "${FILESDIR}"/lxd-4.0.9-glibc-2.36-fix.patch
+	"${FILESDIR}"/lxd-5.0.2-fix-build-with-musl-1.2.4.patch )
 
 src_prepare() {
 	export GOPATH="${S}/_dist"
@@ -96,7 +96,7 @@ src_prepare() {
 	# Fix hardcoded ovmf file path, see bug 763180
 	sed -i \
 		-e "s:/usr/share/OVMF:/usr/share/edk2-ovmf:g" \
-		-e "s:OVMF_VARS.ms.fd:OVMF_VARS.fd:g" \
+		-e "s:OVMF_VARS.ms.fd:OVMF_VARS.secboot.fd:g" \
 		doc/environment.md \
 		lxd/apparmor/instance.go \
 		lxd/apparmor/instance_qemu.go \
@@ -131,7 +131,7 @@ src_compile() {
 	go install -v -x -tags libsqlite3 "${S}"/lxd || die "Failed to build the daemon"
 
 	# Needs to be built statically
-	CGO_ENABLED=0 go install -v -tags netgo "${S}"/lxd-migrate
+	CGO_ENABLED=0 go install -v -tags netgo "${S}"/lxd-p2c
 	CGO_ENABLED=0 go install -v -tags agent,netgo "${S}"/lxd-agent
 
 	use nls && emake build-mo
@@ -147,21 +147,20 @@ src_install() {
 
 	dosbin ${bindir}/lxd
 
-	for l in fuidshift lxd-agent lxd-benchmark lxd-migrate lxc lxc-to-lxd; do
+	for l in fuidshift lxd-agent lxd-benchmark lxd-p2c lxc lxc-to-lxd; do
 		dobin ${bindir}/${l}
 	done
 
 	newbashcomp scripts/bash/lxd-client lxc
 
 	newconfd "${FILESDIR}"/lxd-4.0.0.confd lxd
-	newinitd "${FILESDIR}"/lxd-5.0.2-r1.initd lxd
+	newinitd "${FILESDIR}"/lxd-4.0.9.initd lxd
 
 	systemd_dounit "${T}"/lxd.service
 	systemd_newunit "${FILESDIR}"/lxd-containers-4.0.0.service lxd-containers.service
 	systemd_newunit "${FILESDIR}"/lxd-4.0.0.socket lxd.socket
 
-	dodoc AUTHORS
-	dodoc -r doc/*
+	dodoc AUTHORS doc/*
 	use nls && domo po/*.mo
 }
 
@@ -176,32 +175,8 @@ pkg_postinst() {
 	elog
 	optfeature "virtual machine support" app-emulation/qemu[spice,usbredir,virtfs]
 	optfeature "btrfs storage backend" sys-fs/btrfs-progs
-	optfeature "ipv6 support" net-dns/dnsmasq[ipv6]
-	optfeature "full lxd-migrate support"
 	optfeature "lvm2 storage backend" sys-fs/lvm2
 	optfeature "zfs storage backend" sys-fs/zfs
 	elog
 	elog "Be sure to add your local user to the lxd group."
-
-	if [[ ${REPLACING_VERSIONS} ]] &&
-	ver_test ${REPLACING_VERSIONS} -lt 5.0.1 &&
-	has_version app-emulation/qemu[spice,usbredir,virtfs]; then
-		ewarn ""
-		ewarn "You're updating from <5.0.1. Due to incompatible API updates in the lxd-agent"
-		ewarn "product, you'll have to restart any running virtual machines before they work"
-		ewarn "properly."
-		ewarn ""
-		ewarn "Run: 'lxc restart your-vm' after the update for your vm's managed by lxd."
-		ewarn ""
-	fi
-
-	if [[ ${REPLACING_VERSIONS} ]] &&
-	has_version "sys-apps/openrc"; then
-		elog ""
-		elog "The new init.d script will attempt to mount "
-		elog "  /sys/fs/cgroup/systemd"
-		elog "by default, which is needed to run systemd containers with openrc host."
-		elog "See the /etc/init.d/lxd file for requirements."
-		elog ""
-	fi
 }

--- a/app-containers/podman/files/podman-4.5.0-fix-build-with-musl-1.2.4.patch
+++ b/app-containers/podman/files/podman-4.5.0-fix-build-with-musl-1.2.4.patch
@@ -1,0 +1,17 @@
+From https://github.com/mattn/go-sqlite3/pull/1177/commits/65d6085c5d87280c0d6883c884ddb25f9273942f Mon Sep 17 00:00:00 2001
+From: leso-kn <info@lesosoftware.com>
+Date: Mon, 10 Jul 2023 14:58:52 +0200
+Subject: [PATCH] Fix musl build (#1164)
+
+--- a/vendor/github.com/mattn/go-sqlite3/sqlite3.go
++++ b/vendor/github.com/mattn/go-sqlite3/sqlite3.go
+@@ -21,7 +21,7 @@ package sqlite3
+ #cgo CFLAGS: -DSQLITE_DEFAULT_WAL_SYNCHRONOUS=1
+ #cgo CFLAGS: -DSQLITE_ENABLE_UPDATE_DELETE_LIMIT
+ #cgo CFLAGS: -Wno-deprecated-declarations
+-#cgo linux,!android CFLAGS: -DHAVE_PREAD64=1 -DHAVE_PWRITE64=1
++#cgo linux,!android CFLAGS: -DHAVE_PREAD=1 -DHAVE_PWRITE=1
+ #cgo openbsd CFLAGS: -I/usr/local/include
+ #cgo openbsd LDFLAGS: -L/usr/local/lib
+ #ifndef USE_LIBSQLITE3
+

--- a/app-containers/podman/podman-4.5.0-r1.ebuild
+++ b/app-containers/podman/podman-4.5.0-r1.ebuild
@@ -48,6 +48,10 @@ RDEPEND="${COMMON_DEPEND}
 
 S=${WORKDIR}/${MY_P}
 
+PATCHES=(
+	"${FILESDIR}/${PN}-4.5.0-fix-build-with-musl-1.2.4.patch"
+)
+
 src_prepare() {
 	default
 


### PR DESCRIPTION
Combined into same PR due to both being the same bug in go-sqlite3. The joys of forced vendored dependencies.

Closes: https://bugs.gentoo.org/906073
Closes: https://bugs.gentoo.org/905996