### PR TITLE
sys-apps/portage: backport message fix

### DIFF
--- a/sys-apps/portage/files/depgraph.py-fix-no-ebuilds-binpkgs-message.patch
+++ b/sys-apps/portage/files/depgraph.py-fix-no-ebuilds-binpkgs-message.patch
@@ -1,0 +1,43 @@
+From b199d0307b47f9fb06dbe533d7e24926a561c238 Mon Sep 17 00:00:00 2001
+From: Oskari Pirhonen <xxc3ncoredxx@gmail.com>
+Date: Sun, 9 Jul 2023 00:08:27 -0500
+Subject: [PATCH] depgraph.py: fix "no ebuilds/binpkgs" message
+
+The "there are no binary packages to satisfy" was being unconditionally
+output for packages that could not be found. Fix the logic for choosing
+between the "binary packages" and "ebuilds" form of the message.
+
+This is a temporary stopgap as alluded to by me in the bug, but the
+tl;dr is that some entries in the `myopts` dict have "y"/"n" values
+whereas some are True/unset, and this discrepancy should be sorted out.
+
+[sam: Add NEWS and Fixes, although the change in that commit _shouldn't_
+have been wrong, it is because of a quirk for now...]
+
+[oskari: remove NEWS for backport]
+
+Bug: https://bugs.gentoo.org/909853
+Signed-off-by: Oskari Pirhonen <xxc3ncoredxx@gmail.com>
+Closes: https://github.com/gentoo/portage/pull/1065
+Fixes: 0b21a5a392bd84c07b94373991f59108fbe98516
+Signed-off-by: Sam James <sam@gentoo.org>
+---
+ lib/_emerge/depgraph.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/_emerge/depgraph.py b/lib/_emerge/depgraph.py
+index a36ab6351..1aeae6257 100644
+--- a/lib/_emerge/depgraph.py
++++ b/lib/_emerge/depgraph.py
+@@ -6456,7 +6456,7 @@ class depgraph:
+                     cp_exists = True
+                     break
+ 
+-            if self._frozen_config.myopts.get("--usepkgonly", "y"):
++            if self._frozen_config.myopts.get("--usepkgonly", False):
+                 writemsg(
+                     f"\nemerge: there are no binary packages to satisfy {green(xinfo)}.\n",
+                     noiselevel=-1,
+-- 
+2.41.0
+

--- a/sys-apps/portage/portage-3.0.48.1-r2.ebuild
+++ b/sys-apps/portage/portage-3.0.48.1-r2.ebuild
@@ -22,7 +22,7 @@ if [[ ${PV} == 9999 ]] ; then
 	inherit git-r3
 else
 	SRC_URI="https://gitweb.gentoo.org/proj/portage.git/snapshot/${P}.tar.bz2"
-	KEYWORDS="~alpha amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc x86"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
 fi
 
 LICENSE="GPL-2"
@@ -92,6 +92,11 @@ PDEPEND="
 		>=sys-apps/file-5.44-r3
 	)
 "
+
+# message patch used in 3.0.48.1 and 3.0.49 (bug 909853)
+PATCHES=(
+	"${FILESDIR}/depgraph.py-fix-no-ebuilds-binpkgs-message.patch"
+)
 
 distutils_enable_tests pytest
 

--- a/sys-apps/portage/portage-3.0.49-r1.ebuild
+++ b/sys-apps/portage/portage-3.0.49-r1.ebuild
@@ -22,7 +22,7 @@ if [[ ${PV} == 9999 ]] ; then
 	inherit git-r3
 else
 	SRC_URI="https://gitweb.gentoo.org/proj/portage.git/snapshot/${P}.tar.bz2"
-	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+	KEYWORDS="~alpha amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc x86"
 fi
 
 LICENSE="GPL-2"
@@ -92,6 +92,11 @@ PDEPEND="
 		>=sys-apps/file-5.44-r3
 	)
 "
+
+# message patch used in 3.0.48.1 and 3.0.49 (bug 909853)
+PATCHES=(
+	"${FILESDIR}/depgraph.py-fix-no-ebuilds-binpkgs-message.patch"
+)
 
 distutils_enable_tests pytest
 


### PR DESCRIPTION
Backport the "no ebuilds/binpkgs" message fix from the unreleased 3.0.50 to the affected versions.

Bug: https://bugs.gentoo.org/909853