### PR TITLE
dev-python/markdown-include: dev-python/markdown-include: fix 'Invalid dash-separated options' warn

### DIFF
--- a/dev-python/markdown-include/markdown-include-0.8.1-r1.ebuild
+++ b/dev-python/markdown-include/markdown-include-0.8.1-r1.ebuild
@@ -23,3 +23,8 @@ RDEPEND=">=dev-python/markdown-3.0[${PYTHON_USEDEP}]"
 BDEPEND=">=dev-python/setuptools-scm-6.2[${PYTHON_USEDEP}]"
 
 distutils_enable_tests pytest
+
+src_prepare() {
+	sed -i "s/description-file/description_file/" setup.cfg || die
+	distutils-r1_src_prepare
+}

--- a/dev-python/markdown-include/metadata.xml
+++ b/dev-python/markdown-include/metadata.xml
@@ -5,6 +5,10 @@
 		<email>marecki@gentoo.org</email>
 		<name>Marek Szuba</name>
 	</maintainer>
+	<maintainer type="person">
+		<email>torokhov-s-a@yandex.ru</email>
+		<name>Sergey Torokhov</name>
+	</maintainer>
 	<stabilize-allarches/>
 	<upstream>
 		<remote-id type="pypi">markdown-include</remote-id>


### PR DESCRIPTION
Early I maintained `dev-python/markdown-include` package in `::guru` repository as it's required for another package I maintain. Please add me as co-maintainer.

The second commit makes a revision bump with fix of QA notice:
```
 * QA Notice: setuptools warnings detected:
 * 
 *      Invalid dash-separated options
```