### PR TITLE
mate-base/mate: remove reference to mate-extra/caja-hide

### DIFF
--- a/mate-base/mate/mate-1.26.0.ebuild
+++ b/mate-base/mate/mate-1.26.0.ebuild
@@ -79,5 +79,4 @@ pkg_postinst() {
 	elog "		mate-extra/caja-dropbox"
 	elog "		mate-extra/mate-user-share"
 	elog "		mate-extra/caja-admin"
-	elog "		mate-extra/caja-hide"
 }


### PR DESCRIPTION
mate-extra/caja-hide was removed from the repository in commit 898126b9f1ab3878346364fa051f3df163a5320e