### PR TITLE
sci-libs/gdal: USE=-headless-awt for virtual/jdk

### DIFF
--- a/sci-libs/gdal/gdal-3.7.0.ebuild
+++ b/sci-libs/gdal/gdal-3.7.0.ebuild
@@ -60,7 +60,7 @@ DEPEND="
 	heif? ( media-libs/libheif:= )
 	hdf5? ( >=sci-libs/hdf5-1.6.4:=[cxx,szip] )
 	java? (
-		>=virtual/jdk-1.8:*
+		>=virtual/jdk-1.8:*[-headless-awt]
 	)
 	jpeg? ( media-libs/libjpeg-turbo:= )
 	jpeg2k? ( media-libs/openjpeg:2= )


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/909430