### PR TITLE
net-proxy/adzapper: use https:// schema

### DIFF
--- a/net-proxy/adzapper/adzapper-20110915-r2.ebuild
+++ b/net-proxy/adzapper/adzapper-20110915-r2.ebuild
@@ -6,8 +6,8 @@ EAPI=7
 MY_P=${P/zapper/zap}
 
 DESCRIPTION="Redirector for squid to intercept advertising, page counters and web bugs"
-HOMEPAGE="http://adzapper.sourceforge.net/"
-SRC_URI="http://adzapper.sourceforge.net/${MY_P}.tar.gz"
+HOMEPAGE="https://adzapper.sourceforge.net/"
+SRC_URI="https://adzapper.sourceforge.net/${MY_P}.tar.gz"
 S="${WORKDIR}"/${P/per/}
 
 LICENSE="BSD"


### PR DESCRIPTION
> Homepage link http://adzapper.sourceforge.net/ is a permanent redirect to its HTTPS counterpart https://adzapper.sourceforge.net/ and should be updated. 

> Download link http://adzapper.sourceforge.net/adzap-20110915.tar.gz is a permanent redirect to its HTTPS counterpart https://adzapper.sourceforge.net/adzap-20110915.tar.gz and should be updated. 

ref: https://repology.org/repository/gentoo/problems