### PR TITLE
app-crypt/aespipe: use https:// schema

### DIFF
--- a/app-crypt/aespipe/aespipe-2.4e.ebuild
+++ b/app-crypt/aespipe/aespipe-2.4e.ebuild
@@ -6,8 +6,8 @@ EAPI=7
 inherit flag-o-matic
 
 DESCRIPTION="Encrypts data from stdin to stdout"
-HOMEPAGE="http://loop-aes.sourceforge.net"
-SRC_URI="http://loop-aes.sourceforge.net/aespipe/${PN}-v${PV}.tar.bz2"
+HOMEPAGE="https://loop-aes.sourceforge.net"
+SRC_URI="https://loop-aes.sourceforge.net/aespipe/${PN}-v${PV}.tar.bz2"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/app-crypt/aespipe/aespipe-2.4f.ebuild
+++ b/app-crypt/aespipe/aespipe-2.4f.ebuild
@@ -6,8 +6,8 @@ EAPI=7
 inherit flag-o-matic
 
 DESCRIPTION="Encrypts data from stdin to stdout"
-HOMEPAGE="http://loop-aes.sourceforge.net"
-SRC_URI="http://loop-aes.sourceforge.net/aespipe/${PN}-v${PV}.tar.bz2"
+HOMEPAGE="https://loop-aes.sourceforge.net"
+SRC_URI="https://loop-aes.sourceforge.net/aespipe/${PN}-v${PV}.tar.bz2"
 
 LICENSE="GPL-2"
 SLOT="0"


### PR DESCRIPTION
As recommended by repology  
ref: https://repology.org/repository/gentoo/problems

Both commits are signed off.  
Merge dev, please squash since github UI is problematic. TIA