### PR TITLE
sys-libs/queue-standalone: keyword 0.1-r1 for ~m68k

### DIFF
--- a/sys-libs/queue-standalone/queue-standalone-0.1-r1.ebuild
+++ b/sys-libs/queue-standalone/queue-standalone-0.1-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,7 +8,7 @@ HOMEPAGE="https://www.gnu.org/software/libc/libc.html"
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="amd64 arm arm64 ~hppa ~mips ppc ppc64 ~riscv x86"
+KEYWORDS="amd64 arm arm64 ~hppa ~m68k ~mips ppc ppc64 ~riscv x86"
 
 DEPEND="
 	!sys-libs/glibc"


### PR DESCRIPTION
Pre-requirement to allow musl stage3s to be built for m68k.

Closes: https://bugs.gentoo.org/910517