### PR TITLE
dev-java/zxing-javase: fix tests on openjdk:8

### DIFF
--- a/dev-java/zxing-javase/files/3.5.1-test-available-formats.patch
+++ b/dev-java/zxing-javase/files/3.5.1-test-available-formats.patch
@@ -1,0 +1,29 @@
+--- a/src/test/java/com/google/zxing/client/j2se/MatrixToImageWriterTestCase.java
++++ b/src/test/java/com/google/zxing/client/j2se/MatrixToImageWriterTestCase.java
+@@ -17,7 +17,9 @@
+ package com.google.zxing.client.j2se;
+ 
+ import com.google.zxing.common.BitMatrix;
++import static org.hamcrest.CoreMatchers.hasItem;
+ import org.junit.Assert;
++import static org.junit.Assume.assumeThat;
+ import org.junit.Test;
+ 
+ import javax.imageio.ImageIO;
+@@ -25,6 +27,7 @@
+ import java.io.IOException;
+ import java.nio.file.Files;
+ import java.nio.file.Path;
++import java.util.Arrays;
+ 
+ /**
+  * Tests {@link MatrixToImageWriter}.
+@@ -52,6 +55,8 @@ private static void doTest(MatrixToImageConfig config) throws IOException {
+   }
+ 
+   private static void doTestFormat(String format, MatrixToImageConfig config) throws IOException {
++    assumeThat(Arrays.asList(ImageIO.getWriterFormatNames()), hasItem(format));
++
+     int width = 2;
+     int height = 3;
+     BitMatrix matrix = new BitMatrix(width, height);

--- a/dev-java/zxing-javase/zxing-javase-3.5.1.ebuild
+++ b/dev-java/zxing-javase/zxing-javase-3.5.1.ebuild
@@ -10,7 +10,7 @@ JAVA_TESTING_FRAMEWORKS="junit-4"
 inherit java-pkg-2 java-pkg-simple
 
 DESCRIPTION="Core barcode encoding/decoding library"
-HOMEPAGE="https://github.com/zxing/zxing/core"
+HOMEPAGE="https://github.com/zxing/zxing"
 SRC_URI="https://github.com/zxing/zxing/archive/zxing-${PV}.tar.gz"
 LICENSE="Apache-2.0"
 SLOT="3"
@@ -31,7 +31,16 @@ RDEPEND="
 
 S="${WORKDIR}/zxing-zxing-${PV}/javase"
 
+PATCHES=(
+	"${FILESDIR}/${PV}-test-available-formats.patch"
+)
+
 JAVA_AUTOMATIC_MODULE_NAME="com.google.zxing.javase"
 JAVA_SRC_DIR="src/main/java"
 JAVA_TEST_GENTOO_CLASSPATH="junit-4"
 JAVA_TEST_SRC_DIR="src/test/java"
+
+src_prepare() {
+	default # apply PATCHES
+	java-pkg-2_src_prepare
+}


### PR DESCRIPTION
fix tests with openjdk:8, upstreamed patch @ https://github.com/zxing/zxing/pull/1668, no revbump as only touching test impl.