### PR TITLE
gui-wm/hyprland: use updated patch for VIDEO_CARDS=nvidia

### DIFF
--- a/gui-wm/hyprland/hyprland-0.27.2.ebuild
+++ b/gui-wm/hyprland/hyprland-0.27.2.ebuild
@@ -75,7 +75,7 @@ pkg_setup() {
 src_prepare() {
 	if use video_cards_nvidia; then
 		cd "${S}/subprojects/wlroots" || die
-		eapply "${FILESDIR}/nvidia-0.25.0.patch"
+		eapply "${S}/nix/wlroots-nvidia.patch"
 		cd "${S}" || die
 	fi
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/910576