### PR TITLE
sci-electronics/gsmc: Fix call to undeclared function recalc

### DIFF
--- a/sci-electronics/gsmc/files/gsmc-1.1-clang16-build-fix.patch
+++ b/sci-electronics/gsmc/files/gsmc-1.1-clang16-build-fix.patch
@@ -1,0 +1,41 @@
+Bug: https://bugs.gentoo.org/886137
+--- a/autotune.c
++++ b/autotune.c
+@@ -29,6 +29,8 @@
+ #include <math.h>
+ #include "main.h"
+ #include "autotune.h"
++#include "draw.h"
++#include "calc.h"
+ #include <unistd.h>
+ 
+ 
+--- a/main.h
++++ b/main.h
+@@ -112,4 +112,6 @@ gint mdw_expose_event(GtkWidget *, GdkEventExpose *, gpointer),
+ 
+ void writespice(char *);
+ void removene(void);
++void loadgw(char *);
++void savegw(char *);
+ 
+--- a/print.c
++++ b/print.c
+@@ -32,6 +32,7 @@
+ #include "main.h"
+ #include "calc.h"
+ #include "print.h"
++#include "draw.h"
+ // jvdh 2004-3-30
+ 
+ extern SMCDATA smcdata;
+--- a/widget.c
++++ b/widget.c
+@@ -36,6 +36,7 @@
+ #include "widget.h"
+ #include "draw.h"
+ #include "print.h"
++#include "autotune.h"
+ 
+ extern GtkTextBuffer *txtcircbuff;
+ extern int Zcirc, Ycirc, RHOcirc, Qcirc, tsidx, fsidx;

--- a/sci-electronics/gsmc/gsmc-1.1-r3.ebuild
+++ b/sci-electronics/gsmc/gsmc-1.1-r3.ebuild
@@ -1,0 +1,38 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools
+
+DESCRIPTION="A GTK program for doing Smith Chart calculations"
+HOMEPAGE="https://www.qsl.net/ik5nax/"
+SRC_URI="https://www.qsl.net/ik5nax/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+DEPEND="
+	dev-libs/glib:2
+	x11-libs/gtk+:2
+"
+RDEPEND="${DEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-autotools.patch
+	"${FILESDIR}"/${P}-clang16-build-fix.patch
+)
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_install() {
+	emake DESTDIR="${D}" install
+	dodoc AUTHORS NEWS README TODO
+	insinto /usr/share/${PN}
+	doins example*
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/886137