### PR TITLE
media-libs/libass: fix implicit dep on dev-libs/libunibreak

### DIFF
--- a/media-libs/libass/libass-0.17.1-r1.ebuild
+++ b/media-libs/libass/libass-0.17.1-r1.ebuild
@@ -1,0 +1,51 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+VERIFY_SIG_OPENPGP_KEY_PATH="${BROOT}"/usr/share/openpgp-keys/libass.asc
+inherit multilib-minimal verify-sig
+
+DESCRIPTION="Library for SSA/ASS subtitles rendering"
+HOMEPAGE="https://github.com/libass/libass"
+SRC_URI="https://github.com/libass/libass/releases/download/${PV}/${P}.tar.xz"
+SRC_URI+=" verify-sig? ( https://github.com/libass/libass/releases/download/${PV}/${P}.tar.xz.asc )"
+
+LICENSE="ISC"
+SLOT="0/9" # subslot = libass soname version
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~mips ~ppc ~ppc64 ~riscv ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
+IUSE="+fontconfig libunibreak test"
+RESTRICT="!test? ( test )"
+
+RDEPEND="
+	>=dev-libs/fribidi-0.19.5-r1[${MULTILIB_USEDEP}]
+	>=media-libs/freetype-2.5.0.1:2[${MULTILIB_USEDEP}]
+	>=virtual/libiconv-0-r1[${MULTILIB_USEDEP}]
+	>=media-libs/harfbuzz-1.2.3:=[truetype,${MULTILIB_USEDEP}]
+	fontconfig? ( >=media-libs/fontconfig-2.10.92[${MULTILIB_USEDEP}] )
+	libunibreak? ( dev-libs/libunibreak:= )
+"
+DEPEND="${RDEPEND}"
+BDEPEND="
+	virtual/pkgconfig
+	amd64? ( dev-lang/nasm )
+	x86? ( dev-lang/nasm )
+	test? ( media-libs/libpng[${MULTILIB_USEDEP}] )
+	verify-sig? ( sec-keys/openpgp-keys-libass )
+"
+
+DOCS=( Changelog )
+
+multilib_src_configure() {
+	ECONF_SOURCE="${S}" econf \
+		$(use_enable fontconfig) \
+		$(use_enable libunibreak) \
+		$(use_enable test) \
+		--disable-require-system-font-provider
+}
+
+multilib_src_install_all() {
+	einstalldocs
+
+	find "${ED}" -name '*.la' -type f -delete || die
+}

--- a/media-libs/libass/metadata.xml
+++ b/media-libs/libass/metadata.xml
@@ -4,6 +4,9 @@
   <maintainer type="project">
     <email>media-video@gentoo.org</email>
   </maintainer>
+  <use>
+    <flag name="libunibreak">Use <pkg>dev-libs/libunibreak</pkg> for Unicode line breaking algorithm</flag>
+  </use>
   <upstream>
     <remote-id type="github">libass/libass</remote-id>
   </upstream>

--- a/profiles/arch/hppa/package.use.mask
+++ b/profiles/arch/hppa/package.use.mask
@@ -4,6 +4,10 @@
 # NOTE: When masking a USE flag due to missing keywords, please file a keyword
 # request bug for the hppa arch.
 
+# Cristian Othón Martínez Vera (2023-07-21)
+# dev-libs/libunibreak is not keyworded
+media-libs/libass libunibreak
+
 # Matt Turner <mattst88@gentoo.org> (2023-05-30)
 # sys-apps/dbus-broker is not keyworded
 app-accessibility/at-spi2-core dbus-broker

--- a/profiles/arch/ia64/package.use.mask
+++ b/profiles/arch/ia64/package.use.mask
@@ -1,6 +1,10 @@
 # Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Cristian Othón Martínez Vera <cfuga@cfuga.mx> (2023-07-21)
+# dev-libs/libunibreak is not keyworded
+media-libs/libass libunibreak
+
 # Sam James <sam@gentoo.org> (2023-06-18)
 # Qt 5 not keyworded here
 app-text/ansifilter gui

--- a/profiles/arch/loong/package.use.mask
+++ b/profiles/arch/loong/package.use.mask
@@ -1,6 +1,10 @@
 # Copyright 2022-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Cristian Othón Martínez Vera (2023-07-21)
+# dev-libs/libunibreak is not keyworded
+media-libs/libass libunibreak
+
 # WANG Xuerui <xen0n@gentoo.org> (2023-07-19)
 # Temporary masks; to be lifted after leaving wd40 status.
 gnome-base/nautilus previewer

--- a/profiles/arch/powerpc/ppc64/package.use.mask
+++ b/profiles/arch/powerpc/ppc64/package.use.mask
@@ -1,6 +1,10 @@
 # Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Cristian Othón Martínez Vera <cfuga@cfuga.mx> (2023-07-21)
+# dev-libs/libunibreak is not keyworded
+media-libs/libass libunibreak
+
 # Sam James <sam@gentoo.org> (2023-04-14)
 # Needs dev-python/sympy which is not yet keyworded, see bug #892183
 dev-python/nbval test

--- a/profiles/arch/riscv/package.use.mask
+++ b/profiles/arch/riscv/package.use.mask
@@ -1,6 +1,10 @@
 # Copyright 2019-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Cristian Othón Martínez Vera (2023-07-21)
+# dev-libs/libunibreak not keyworded here
+media-libs/libass libunibreak
+
 # Mike Gilbert <floppym@gentoo.org> (2023-05-27)
 # sd-boot should work here.
 sys-apps/systemd -boot -gnuefi

--- a/profiles/arch/sparc/package.use.mask
+++ b/profiles/arch/sparc/package.use.mask
@@ -1,6 +1,10 @@
 # Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Cristian Othón Martínez Vera (2023-07-21)
+# dev-libs/libunibreak not keyworded here
+media-libs/libass libunibreak
+
 # Sam James <sam@gentoo.org> (2023-06-18)
 # Qt 5 not keyworded here
 app-text/ansifilter gui


### PR DESCRIPTION
Since version 0.17.0, ```media-libs/libass``` searches for ```dev-libs/libunibreak``` to optionally use the Unicode line breaking algorithm instead of ASS' much stricter rules.

Signed-off-by: Cristian Othón Martínez Vera <cfuga@cfuga.mx>
