### PR TITLE
dev-python/virtualenvwrapper: get absolute path for python executable

### DIFF
--- a/dev-python/virtualenvwrapper/virtualenvwrapper-4.8.4_p20230121-r1.ebuild
+++ b/dev-python/virtualenvwrapper/virtualenvwrapper-4.8.4_p20230121-r1.ebuild
@@ -51,7 +51,7 @@ src_prepare() {
 
 	# specify default python interpeter to align with PYTHON_SINGLE_TARGET
 	sed -i -e \
-		"s|\(_virtualenvwrapper_python_executable=\"\)\$(.*)\(\"\)|\1${EPYTHON}\2|" \
+		"s|\(_virtualenvwrapper_python_executable=\"\$(\).\w\((\"\)|\1command -v ${EPYTHON}\2|" \
 		virtualenvwrapper.sh || die
 
 	# remove tests which require an internet connection


### PR DESCRIPTION
* Using the absolute path avoid issues when going inside the venv