### PR TITLE
dev-ruby/serialport: Fix incompatible pointer to integer

### DIFF
--- a/dev-ruby/serialport/files/serialport-1.3.2-clang16-build-fix.patch
+++ b/dev-ruby/serialport/files/serialport-1.3.2-clang16-build-fix.patch
@@ -1,0 +1,13 @@
+Bug: https://bugs.gentoo.org/883127
+Upstream PR: https://github.com/hparra/ruby-serialport/pull/75
+--- a/ext/native/posix_serialport_impl.c
++++ b/ext/native/posix_serialport_impl.c
+@@ -110,7 +110,7 @@ VALUE sp_create_impl(class, _port)
+    struct termios params;
+ 
+    NEWOBJ(sp, struct RFile);
+-   OBJSETUP(sp, class, T_FILE);
++   OBJSETUP((VALUE)sp, class, T_FILE);
+    MakeOpenFile((VALUE) sp, fp);
+ 
+    switch(TYPE(_port))

--- a/dev-ruby/serialport/serialport-1.3.2-r1.ebuild
+++ b/dev-ruby/serialport/serialport-1.3.2-r1.ebuild
@@ -1,0 +1,38 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+USE_RUBY="ruby26 ruby27 ruby30 ruby31"
+
+RUBY_FAKEGEM_TASK_DOC=""
+RUBY_FAKEGEM_TASK_TEST=""
+RUBY_FAKEGEM_EXTRADOC="CHANGELOG README.md"
+
+RUBY_FAKEGEM_EXTENSIONS=(ext/native/extconf.rb)
+
+inherit ruby-fakegem
+
+DESCRIPTION="a library for serial port (rs232) access in ruby"
+HOMEPAGE="https://github.com/hparra/ruby-serialport/"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86"
+IUSE=""
+
+PATCHES=(
+	"${FILESDIR}"/${P}-clang16-build-fix.patch
+)
+
+all_ruby_prepare() {
+	# Fix the miniterm script so that it might actually work, we'll
+	# install it as example.
+	sed -i -e 's:\.\./serialport.so:serialport:' test/miniterm.rb || die
+}
+
+all_ruby_install() {
+	all_fakegem_install
+
+	dodoc test/miniterm.rb
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/883127