### PR TITLE
M68k musl keywording

### DIFF
--- a/sys-libs/fts-standalone/fts-standalone-1.2.7.ebuild
+++ b/sys-libs/fts-standalone/fts-standalone-1.2.7.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -12,7 +12,7 @@ S="${WORKDIR}/musl-fts-${PV}"
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="amd64 arm arm64 ~mips ppc ppc64 ~riscv x86"
+KEYWORDS="amd64 arm arm64 ~m68k ~mips ppc ppc64 ~riscv x86"
 IUSE="static-libs"
 
 DEPEND="

--- a/sys-libs/obstack-standalone/obstack-standalone-1.2.3.ebuild
+++ b/sys-libs/obstack-standalone/obstack-standalone-1.2.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -12,7 +12,7 @@ S="${WORKDIR}"/musl-obstack-${PV}
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 arm arm64 ~mips ppc ppc64 ~riscv x86"
+KEYWORDS="amd64 arm arm64 ~m68k ~mips ppc ppc64 ~riscv x86"
 IUSE="static-libs"
 
 DEPEND="!sys-libs/glibc"


### PR DESCRIPTION
Blocker solving key-wording for Gentoo support for m68k with musl to allow the user to compile their own kernel.  