### PR TITLE
profiles/features/musl: Remove sbcl from use.mask

### DIFF
--- a/profiles/features/musl/use.mask
+++ b/profiles/features/musl/use.mask
@@ -1,13 +1,9 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # Select the correct ELIBC
 -elibc_musl
 elibc_glibc
-
-# Andrey Grozin <grozin@gentoo.org> (2022-12-01)
-# dev-lisp/sbcl is masked
-sbcl
 
 # Sam James <sam@gentoo.org> (2022-10-04)
 # sci-libs/opencascade is masked on musl


### PR DESCRIPTION
As of https://github.com/gentoo/gentoo/pull/30752, dev-lisp/sbcl is no longer masked on musl.