### PR TITLE
sci-electronics/kicad: disk space check fix

### DIFF
--- a/sci-electronics/kicad/kicad-7.0.6.ebuild
+++ b/sci-electronics/kicad/kicad-7.0.6.ebuild
@@ -72,7 +72,7 @@ if [[ ${PV} == 9999 ]] ; then
 	BDEPEND+=" >=x11-misc/util-macros-1.18"
 fi
 
-CHECKREQS_DISK_BUILD="1.2G"
+CHECKREQS_DISK_BUILD="1500M"
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-7.0.0-werror.patch

--- a/sci-electronics/kicad/kicad-9999.ebuild
+++ b/sci-electronics/kicad/kicad-9999.ebuild
@@ -72,7 +72,7 @@ if [[ ${PV} == 9999 ]] ; then
 	BDEPEND+=" >=x11-misc/util-macros-1.18"
 fi
 
-CHECKREQS_DISK_BUILD="900M"
+CHECKREQS_DISK_BUILD="1500M"
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-7.0.0-werror.patch


### PR DESCRIPTION
Use integer instead of float to prevent check_reqs from failing with an
arithmetic error

Closes: https://bugs.gentoo.org/910524
Signed-off-by: Zoltan Puskas <zoltan@sinustrom.info>
