### PR TITLE
x11-plugins/wmmp3: Fix  implicit declaration of function malloc

### DIFF
--- a/x11-plugins/wmmp3/files/wmmp3-0.12-fix-implicit-function-declaration-clang16.patch
+++ b/x11-plugins/wmmp3/files/wmmp3-0.12-fix-implicit-function-declaration-clang16.patch
@@ -1,0 +1,40 @@
+Bug: https://bugs.gentoo.org/882321
+--- a/buttons.c
++++ b/buttons.c
+@@ -10,6 +10,7 @@
+  * $Id: mpg123ctl.c,v 1.12 1999/10/08 06:21:41 pcrosby Exp $
+  */
+ 
++#include "wmgeneral.h"
+ #include "buttons.h"
+ 
+ struct coord {
+--- a/main.c
++++ b/main.c
+@@ -11,6 +11,7 @@
+  * $Id: main.c,v 1.11 1999/10/08 22:21:32 pcrosby Exp $
+  */
+ 
++#include <ctype.h>
+ #include "main.h"
+ 
+ #define B_STOP 0
+--- a/mpg123ctl.c
++++ b/mpg123ctl.c
+@@ -14,6 +14,8 @@
+  * $Id: mpg123ctl.c,v 1.15 1999/10/12 04:41:20 pcrosby Exp $
+  */
+ 
++#include <time.h>
++#include <ctype.h>
+ #include "mpg123ctl.h"
+ 
+ #define MAXDIRS 100
+--- a/song_hash.c
++++ b/song_hash.c
+@@ -1,3 +1,5 @@
++#include <stdlib.h>
++#include <string.h>
+ #include "song_hash.h"
+ 
+ #define HASH_TABLE_SIZE 11

--- a/x11-plugins/wmmp3/wmmp3-0.12-r2.ebuild
+++ b/x11-plugins/wmmp3/wmmp3-0.12-r2.ebuild
@@ -1,0 +1,36 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="Mp3 player dock app for WindowMaker; frontend to mpg123"
+HOMEPAGE="https://www.dockapps.net/wmmp3"
+SRC_URI="https://www.dockapps.net/download/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~sparc ~x86"
+IUSE=""
+
+RDEPEND="x11-libs/libX11
+	x11-libs/libXext
+	x11-libs/libXpm"
+DEPEND="${RDEPEND}
+	media-sound/mpg123
+	x11-base/xorg-proto"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-x_includes_n_libraries.patch
+	"${FILESDIR}"/${P}-fno-common.patch
+	"${FILESDIR}"/${P}-fix-implicit-function-declaration-clang16.patch
+	)
+
+DOCS=( AUTHORS ChangeLog sample.wmmp3 README TODO )
+
+src_compile() {
+	emake prefix="/usr/"
+}
+
+pkg_postinst() {
+	einfo "Please copy the sample.wmmp3 to your home directory and change it to fit your needs."
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/882321