### PR TITLE
xfce-extra/xfce4-cpugraph-plugin: add fix for gcc-13 (missing cstdint)

### DIFF
--- a/xfce-extra/xfce4-cpugraph-plugin/files/gcc13.patch
+++ b/xfce-extra/xfce4-cpugraph-plugin/files/gcc13.patch
@@ -1,0 +1,16 @@
+
+Bug: https://bugs.gentoo.org/910712
+Bug: https://gitlab.xfce.org/panel-plugins/xfce4-cpugraph-plugin/-/issues/37
+
+Signed-off-by: Holger Hoffstätte <holger@applied-asynchrony.com>
+
+--- a/xfce4++/util/gtk.cc~	2023-07-22 22:44:01.000000000 +0200
++++ b/xfce4++/util/gtk.cc	2023-07-23 10:01:32.508675676 +0200
+@@ -19,6 +19,7 @@
+  */
+ 
+ #include "gtk.h"
++#include <cstdint>
+ 
+ namespace xfce4 {
+ 

--- a/xfce-extra/xfce4-cpugraph-plugin/xfce4-cpugraph-plugin-1.2.7.ebuild
+++ b/xfce-extra/xfce4-cpugraph-plugin/xfce4-cpugraph-plugin-1.2.7.ebuild
@@ -31,6 +31,8 @@ BDEPEND="
 	virtual/pkgconfig
 "
 
+PATCHES=( "${FILESDIR}"/gcc13.patch )
+
 src_install() {
 	default
 	find "${ED}" -name '*.la' -delete || die

--- a/xfce-extra/xfce4-cpugraph-plugin/xfce4-cpugraph-plugin-1.2.8.ebuild
+++ b/xfce-extra/xfce4-cpugraph-plugin/xfce4-cpugraph-plugin-1.2.8.ebuild
@@ -33,6 +33,8 @@ BDEPEND="
 	virtual/pkgconfig
 "
 
+PATCHES=( "${FILESDIR}"/gcc13.patch )
+
 src_install() {
 	default
 	find "${ED}" -name '*.la' -delete || die


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/910712
