### PR TITLE
net-dns/knot-resolver: added OpenRC init script

### DIFF
--- a/net-dns/knot-resolver/files/kresd.openrc
+++ b/net-dns/knot-resolver/files/kresd.openrc
@@ -1,0 +1,31 @@
+#!/sbin/openrc-run
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+command=/usr/sbin/kresd
+command_args="-n /var/run/kresd/"
+description="knot-resolver, scaleable caching DNS resolver"
+required_files=/etc/knot-resolver/kresd.conf
+
+pidfile="/var/run/${RC_SVCNAME}.pid"
+command_background=true
+
+depend() {
+    need net
+    use logger
+    provide dns
+}
+
+start() {
+    ebegin "Starting kresd"
+    checkpath --directory "/var/run/kresd"
+    start-stop-daemon --start -bm \
+                      --pidfile $pidfile --exec $command -- $command_args
+    eend $?
+}
+
+stop() {
+    ebegin "Stopping kresd"
+    [ -f $pidfile ] && start-stop-daemon --stop --pidfile $pidfile
+    ewend $?
+}

--- a/net-dns/knot-resolver/knot-resolver-5.6.0-r1.ebuild
+++ b/net-dns/knot-resolver/knot-resolver-5.6.0-r1.ebuild
@@ -1,0 +1,95 @@
+# Copyright 2022-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+LUA_COMPAT=( luajit )
+
+inherit lua-single meson tmpfiles verify-sig
+
+DESCRIPTION="A scaleable caching DNS resolver"
+HOMEPAGE="https://www.knot-resolver.cz https://gitlab.nic.cz/knot/knot-resolver"
+SRC_URI="
+	https://secure.nic.cz/files/${PN}/${P}.tar.xz
+	verify-sig? ( https://secure.nic.cz/files/${PN}/${P}.tar.xz.asc )
+"
+
+LICENSE="Apache-2.0 BSD CC0-1.0 GPL-3+ LGPL-2.1+ MIT"
+SLOT="0"
+KEYWORDS="~amd64"
+IUSE="caps dnstap kresc nghttp2 systemd test"
+RESTRICT="!test? ( test )"
+REQUIRED_USE="${LUA_REQUIRED_USE}"
+
+RDEPEND="
+	${LUA_DEPS}
+	acct-group/knot-resolver
+	acct-user/knot-resolver
+	dev-db/lmdb:=
+	dev-libs/libuv:=
+	net-dns/knot:=
+	net-libs/gnutls:=
+	caps? ( sys-libs/libcap-ng )
+	dnstap? (
+		dev-libs/fstrm
+		dev-libs/protobuf-c:=
+	)
+	kresc? ( dev-libs/libedit )
+	nghttp2? ( net-libs/nghttp2:= )
+	systemd? ( sys-apps/systemd:= )
+"
+DEPEND="
+	${RDEPEND}
+	test? (
+		  dev-util/cmocka
+	)
+"
+BDEPEND="
+	virtual/pkgconfig
+	verify-sig? ( sec-keys/openpgp-keys-knot-resolver )
+"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-5.5.3-docdir.patch
+	"${FILESDIR}"/${PN}-5.5.3-nghttp-openssl.patch
+)
+
+VERIFY_SIG_OPENPGP_KEY_PATH="${BROOT}"/usr/share/openpgp-keys/${PN}.gpg
+
+src_unpack() {
+	if use verify-sig; then
+		verify-sig_verify_detached "${DISTDIR}"/${P}.tar.xz{,.asc}
+	fi
+
+	unpack ${P}.tar.xz
+}
+
+src_configure() {
+	local emesonargs=(
+		--localstatedir "${EPREFIX}"/var # double lib
+		# https://bugs.gentoo.org/870019
+		-Dauto_features=disabled
+		-Ddoc=disabled
+		-Ddocdir="${EPREFIX}"/usr/share/doc/${PF}
+		-Dopenssl=disabled
+		$(meson_feature caps capng)
+		$(meson_feature dnstap)
+		$(meson_feature kresc client)
+		$(meson_feature nghttp2)
+		$(meson_feature test unit_tests)
+		$(meson_feature systemd systemd_files)
+	)
+
+	meson_src_configure
+}
+
+src_install() {
+	meson_src_install
+	fowners -R ${PN}: /etc/${PN}
+
+	newinitd "${FILESDIR}/kresd.openrc" kresd
+}
+
+pkg_postinst() {
+	use systemd && tmpfiles_process knot-resolver.conf
+}


### PR DESCRIPTION
I've been trying out knot-resolver and I found it had no good init for openrc. 

The daemon itself is a bit weird, like not forking to the background or creating a PID file, so I did it via start-stop-daemon.
It also relies on systemd for threading, spawning multiple instances of kresd rather than controlling its own threads. The init script I wrote doesn't fork itself, but one thread is more than fine for small-scale like single desktop or home networks. 

I also don't have much experience writing init scripts so if there's something that needs to be changed, I'd be more than happy to. 