### PR TITLE
net-analyzer/gvm-libs: add 22.6.3-r1, drop 22.6.3

### DIFF
--- a/net-analyzer/gvm-libs/gvm-libs-22.6.3.ebuild
+++ b/net-analyzer/gvm-libs/gvm-libs-22.6.3.ebuild
@@ -53,6 +53,8 @@ BDEPEND="
 
 src_prepare() {
 	cmake_src_prepare
+	# QA-Fix | Remove -Werror compiler flag | Bug: #909558
+	sed -i -e "s/-Werror//" "${S}"/CMakeLists.txt || die
 	# QA-Fix | Remove doxygen warnings for !CLANG
 	if use doc; then
 		if ! tc-is-clang; then


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/909558