### PR TITLE
media-libs/openh264: add missing -fPIC to flags

### DIFF
--- a/media-libs/openh264/openh264-2.3.1-r2.ebuild
+++ b/media-libs/openh264/openh264-2.3.1-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -54,6 +54,7 @@ emakecmd() {
 		INCLUDES_DIR="${EPREFIX}/usr/include/${PN}" \
 		HAVE_AVX2=$(usex cpu_flags_x86_avx2 Yes No) \
 		ARCH="$(tc-arch)" \
+		ENABLEPIC="Yes" \
 		$@
 }
 


### PR DESCRIPTION
Seems to consistently fail on systems with USE=-static-libs, but
we want PIC by default anyway.

Closes: https://bugs.gentoo.org/911141
Signed-off-by: Mazunki Hoksaas <rolferen@gmail.com>
