### PR TITLE
dev-lang/zig: fix building on 9999 with "doc" USE-flag enabled

### DIFF
--- a/dev-lang/zig/zig-9999.ebuild
+++ b/dev-lang/zig/zig-9999.ebuild
@@ -116,7 +116,6 @@ src_configure() {
 		-DZIG_USE_LLVM_CONFIG=ON
 		-DCMAKE_PREFIX_PATH="$(get_llvm_prefix ${LLVM_MAX_SLOT})"
 		-DCMAKE_INSTALL_PREFIX="${EPREFIX}/usr/$(get_libdir)/zig/${PV}"
-		-DZIG_NO_LANGREF="$(usex !doc ON OFF)"
 	)
 
 	cmake_src_configure
@@ -127,7 +126,7 @@ src_compile() {
 
 	if use doc; then
 		cd "${BUILD_DIR}" || die
-		mv ./stage3/doc/langref.html "${S}" || die
+		edo ./stage3/bin/zig run ../doc/docgen.zig -- --zig ./stage3/bin/zig ../doc/langref.html.in "${S}/langref.html"
 		edo ./stage3/bin/zig test ../lib/std/std.zig --zig-lib-dir ../lib -fno-emit-bin -femit-docs="${S}/std"
 	fi
 }


### PR DESCRIPTION
ZIG_NO_LANGREF variable was disabled in https://github.com/ziglang/zig/commit/32a175740c8750a7db550011795a4c22c0d0bc93.
Signed-off-by: Eric Joldasov <bratishkaerik@getgoogleoff.me>