### PR TITLE
net-misc/tinyssh: Use pkg-config instead of hardcoding libsodium flags

### DIFF
--- a/net-misc/tinyssh/tinyssh-20230101.ebuild
+++ b/net-misc/tinyssh/tinyssh-20230101.ebuild
@@ -40,13 +40,15 @@ src_prepare() {
 }
 
 src_compile() {
+	tc-export PKG_CONFIG
+
 	if use sodium
 	then
 		emake \
-			CC="$(tc-getCC)"
-			LIBS="-lsodium" \
-			CFLAGS="${CFLAGS} -I/usr/include/sodium" \
-			LDFLAGS="${LDFLAGS} -L/usr/lib"
+			CC="$(tc-getCC)" \
+			LIBS="$("${PKG_CONFIG}" --libs libsodium)" \
+			CFLAGS="${CFLAGS} $("${PKG_CONFIG}" --cflags libsodium)" \
+			LDFLAGS="${LDFLAGS}"
 	else
 		emake CC="$(tc-getCC)"
 	fi

--- a/net-misc/tinyssh/tinyssh-99999999.ebuild
+++ b/net-misc/tinyssh/tinyssh-99999999.ebuild
@@ -40,13 +40,15 @@ src_prepare() {
 }
 
 src_compile() {
+	tc-export PKG_CONFIG
+
 	if use sodium
 	then
 		emake \
-			CC="$(tc-getCC)"
-			LIBS="-lsodium" \
-			CFLAGS="${CFLAGS} -I/usr/include/sodium" \
-			LDFLAGS="${LDFLAGS} -L/usr/lib"
+			CC="$(tc-getCC)" \
+			LIBS="$("${PKG_CONFIG}" --libs libsodium)" \
+			CFLAGS="${CFLAGS} $("${PKG_CONFIG}" --cflags libsodium)" \
+			LDFLAGS="${LDFLAGS}"
 	else
 		emake CC="$(tc-getCC)"
 	fi


### PR DESCRIPTION
Followup to https://github.com/gentoo/gentoo/pull/31817#pullrequestreview-1546919593
