### PR TITLE
sys-libs/libselinux: use ROOT variable in pkg_postinst

### DIFF
--- a/sys-libs/libselinux/libselinux-3.5-r1.ebuild
+++ b/sys-libs/libselinux/libselinux-3.5-r1.ebuild
@@ -145,12 +145,12 @@ pkg_postinst() {
 	# Fix bug 473502
 	for POLTYPE in ${POLICY_TYPES};
 	do
-		mkdir -p /etc/selinux/${POLTYPE}/contexts/files || die
-		touch /etc/selinux/${POLTYPE}/contexts/files/file_contexts.local || die
+		mkdir -p "${ROOT}/etc/selinux/${POLTYPE}/contexts/files" || die
+		touch "${ROOT}/etc/selinux/${POLTYPE}/contexts/files/file_contexts.local" || die
 		# Fix bug 516608
 		for EXPRFILE in file_contexts file_contexts.homedirs file_contexts.local ; do
-			if [[ -f "/etc/selinux/${POLTYPE}/contexts/files/${EXPRFILE}" ]]; then
-				sefcontext_compile /etc/selinux/${POLTYPE}/contexts/files/${EXPRFILE} \
+			if [[ -f "${ROOT}/etc/selinux/${POLTYPE}/contexts/files/${EXPRFILE}" ]]; then
+				sefcontext_compile "${ROOT}/etc/selinux/${POLTYPE}/contexts/files/${EXPRFILE}" \
 				|| die "Failed to recompile contexts"
 			fi
 		done


### PR DESCRIPTION
Noticed this while upgrading SELinux on Flatcar OS. Thanks !