### PR TITLE
gnome-extra/krb5-auth-dialog: remove myself as maintainer

### DIFF
--- a/gnome-extra/krb5-auth-dialog/metadata.xml
+++ b/gnome-extra/krb5-auth-dialog/metadata.xml
@@ -1,17 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-  <maintainer type="person" proxied="yes">
-    <email>henning@hennsch.de</email>
-    <name>Henning Schild</name>
-  </maintainer>
   <maintainer type="person">
     <email>ceamac@gentoo.org</email>
     <name>Viorel Munteanu</name>
-  </maintainer>
-  <maintainer type="project" proxied="proxy">
-    <email>proxy-maint@gentoo.org</email>
-    <name>Proxy Maintainers</name>
   </maintainer>
   <upstream>
     <remote-id type="gnome-gitlab">GNOME/krb5-auth-dialog</remote-id>


### PR DESCRIPTION
I will no longer have access to a directory using kerberos, so i can not test that any longer.