### PR TITLE
app-emulation/virtiofsd: Move virtiofsd binary into /usr/libexec

### DIFF
--- a/app-emulation/virtiofsd/virtiofsd-1.5.1-r1.ebuild
+++ b/app-emulation/virtiofsd/virtiofsd-1.5.1-r1.ebuild
@@ -128,6 +128,9 @@ src_unpack() {
 src_install() {
 	cargo_src_install
 
+	mkdir "${ED}/usr/libexec" || die
+	mv "${ED}/usr/"{bin,libexec}/${PN} || die
+
 	# Install 50-qemu-virtiofsd.json but to avoid conflicts with
 	# <app-emulation/qemu-8.0.0 install it under different name. In this case,
 	# smaller number means higher priority, but that's probably what users want

--- a/app-emulation/virtiofsd/virtiofsd-1.6.1.ebuild
+++ b/app-emulation/virtiofsd/virtiofsd-1.6.1.ebuild
@@ -130,6 +130,9 @@ src_unpack() {
 src_install() {
 	cargo_src_install
 
+	mkdir "${ED}/usr/libexec" || die
+	mv "${ED}/usr/"{bin,libexec}/${PN} || die
+
 	# Install 50-qemu-virtiofsd.json but to avoid conflicts with
 	# <app-emulation/qemu-8.0.0 install it under different name. In this case,
 	# smaller number means higher priority, but that's probably what users want

--- a/app-emulation/virtiofsd/virtiofsd-9999.ebuild
+++ b/app-emulation/virtiofsd/virtiofsd-9999.ebuild
@@ -130,6 +130,9 @@ src_unpack() {
 src_install() {
 	cargo_src_install
 
+	mkdir "${ED}/usr/libexec" || die
+	mv "${ED}/usr/"{bin,libexec}/${PN} || die
+
 	# Install 50-qemu-virtiofsd.json but to avoid conflicts with
 	# <app-emulation/qemu-8.0.0 install it under different name. In this case,
 	# smaller number means higher priority, but that's probably what users want


### PR DESCRIPTION
In one of my recent commits I've introduced JSON descriptor file that libvirt uses when learning about helper binaries (40-qemu-virtiofsd.json). What I did not realize is that the file tells libvirt to execute /usr/libexec/virtiofsd while our ebuilds install the binary under /usr/bin/.

I haven't found a way to tell cargo_src_install where to install the binary so we have to move it 'manually'.

Closes: https://bugs.gentoo.org/911274


NB: If anybody can check whether this is the correct way to install rust binaries, I'd appreciate it very much.