### PR TITLE
dev-vcs/git: introduce USE=make-symlinks

### DIFF
--- a/dev-vcs/git/git-2.41.0-r1.ebuild
+++ b/dev-vcs/git/git-2.41.0-r1.ebuild
@@ -50,7 +50,7 @@ if [[ ${PV} != *9999 ]]; then
 	SRC_URI+=" doc? ( ${SRC_URI_KORG}/${PN}-htmldocs-${DOC_VER}.tar.${SRC_URI_SUFFIX} )"
 
 	if [[ ${PV} != *_rc* ]] ; then
-		KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x64-solaris"
+		KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~arm64-macos ~ppc-macos ~x64-macos ~x64-solaris"
 	fi
 fi
 

--- a/dev-vcs/git/git-9999-r2.ebuild
+++ b/dev-vcs/git/git-9999-r2.ebuild
@@ -58,7 +58,7 @@ S="${WORKDIR}"/${MY_P}
 
 LICENSE="GPL-2"
 SLOT="0"
-IUSE="+blksha1 +curl cgi doc keyring +gpg highlight +iconv mediawiki +nls +pcre perforce +perl +safe-directory selinux subversion tk +webdav xinetd cvs test"
+IUSE="+blksha1 +curl cgi doc keyring +gpg highlight +iconv make-symlinks mediawiki +nls +pcre perforce +perl +safe-directory selinux subversion tk +webdav xinetd cvs test"
 
 # Common to both DEPEND and RDEPEND
 DEPEND="
@@ -174,6 +174,7 @@ exportmakeopts() {
 		$(usex perl 'INSTALLDIRS=vendor NO_PERL_CPAN_FALLBACKS=YesPlease' NO_PERL=YesPlease)
 
 		$(usev elibc_musl NO_REGEX=NeedsStartEnd)
+		$(usev make-symlinks INSTALL_SYMLINKS=YesPlease)
 		$(usev !cvs NO_CVS=YesPlease)
 		$(usev !iconv NO_ICONV=YesPlease)
 		$(usev !nls NO_GETTEXT=YesPlease)

--- a/dev-vcs/git/git-9999-r3.ebuild
+++ b/dev-vcs/git/git-9999-r3.ebuild
@@ -58,7 +58,7 @@ S="${WORKDIR}"/${MY_P}
 
 LICENSE="GPL-2"
 SLOT="0"
-IUSE="+blksha1 +curl cgi doc keyring +gpg highlight +iconv mediawiki +nls +pcre perforce +perl +safe-directory selinux subversion tk +webdav xinetd cvs test"
+IUSE="+blksha1 +curl cgi doc keyring +gpg highlight +iconv make-symlinks mediawiki +nls +pcre perforce +perl +safe-directory selinux subversion tk +webdav xinetd cvs test"
 
 # Common to both DEPEND and RDEPEND
 DEPEND="
@@ -174,6 +174,7 @@ exportmakeopts() {
 		$(usex perl 'INSTALLDIRS=vendor NO_PERL_CPAN_FALLBACKS=YesPlease' NO_PERL=YesPlease)
 
 		$(usev elibc_musl NO_REGEX=NeedsStartEnd)
+		$(usev make-symlinks INSTALL_SYMLINKS=YesPlease)
 		$(usev !cvs NO_CVS=YesPlease)
 		$(usev !iconv NO_ICONV=YesPlease)
 		$(usev !nls NO_GETTEXT=YesPlease)

--- a/dev-vcs/git/git-9999.ebuild
+++ b/dev-vcs/git/git-9999.ebuild
@@ -58,7 +58,7 @@ S="${WORKDIR}"/${MY_P}
 
 LICENSE="GPL-2"
 SLOT="0"
-IUSE="+blksha1 +curl cgi doc keyring +gpg highlight +iconv mediawiki +nls +pcre perforce +perl +safe-directory selinux subversion tk +webdav xinetd cvs test"
+IUSE="+blksha1 +curl cgi doc keyring +gpg highlight +iconv make-symlinks mediawiki +nls +pcre perforce +perl +safe-directory selinux subversion tk +webdav xinetd cvs test"
 
 # Common to both DEPEND and RDEPEND
 DEPEND="
@@ -174,6 +174,7 @@ exportmakeopts() {
 		$(usex perl 'INSTALLDIRS=vendor NO_PERL_CPAN_FALLBACKS=YesPlease' NO_PERL=YesPlease)
 
 		$(usev elibc_musl NO_REGEX=NeedsStartEnd)
+		$(usev make-symlinks INSTALL_SYMLINKS=YesPlease)
 		$(usev !cvs NO_CVS=YesPlease)
 		$(usev !iconv NO_ICONV=YesPlease)
 		$(usev !nls NO_GETTEXT=YesPlease)

--- a/dev-vcs/git/metadata.xml
+++ b/dev-vcs/git/metadata.xml
@@ -25,6 +25,7 @@
     <flag name="curl">Support fetching and pushing (requires webdav too) over http:// and https:// protocols</flag>
     <flag name="gpg">Pull in gnupg for signing -- without gnupg, attempts at signing will fail at runtime!</flag>
     <flag name="highlight">GitWeb support for <pkg>app-text/highlight</pkg></flag>
+    <flag name="make-symlinks">Install symbolic links to git binary instead hard links</flag>
     <flag name="mediawiki">Support pulling and pushing from MediaWiki</flag>
     <flag name="perforce">Add support for Perforce version control system (requires manual installation of Perforce client)</flag>
     <flag name="safe-directory">Respect the safe.directory setting</flag>


### PR DESCRIPTION
This USE forces symbolic link creation instead hard links, which in some cases may reduce size of installed package.

Closes: https://bugs.gentoo.org/911325