### PR TITLE
media-libs/rubberband: Restrict GCC dependency to ppc

### DIFF
--- a/media-libs/rubberband/rubberband-3.1.2-r1.ebuild
+++ b/media-libs/rubberband/rubberband-3.1.2-r1.ebuild
@@ -28,7 +28,7 @@ CDEPEND="
 "
 RDEPEND="
 	${CDEPEND}
-	sys-devel/gcc:*
+	ppc? ( sys-devel/gcc:* )
 "
 DEPEND="${CDEPEND}"
 BDEPEND="test? ( dev-libs/boost[${MULTILIB_USEDEP}] )"

--- a/media-libs/rubberband/rubberband-3.1.3-r1.ebuild
+++ b/media-libs/rubberband/rubberband-3.1.3-r1.ebuild
@@ -28,7 +28,7 @@ CDEPEND="
 "
 RDEPEND="
 	${CDEPEND}
-	sys-devel/gcc:*
+	ppc? ( sys-devel/gcc:* )
 "
 DEPEND="${CDEPEND}"
 BDEPEND="test? ( dev-libs/boost[${MULTILIB_USEDEP}] )"

--- a/media-libs/rubberband/rubberband-3.2.1-r1.ebuild
+++ b/media-libs/rubberband/rubberband-3.2.1-r1.ebuild
@@ -28,7 +28,7 @@ CDEPEND="
 "
 RDEPEND="
 	${CDEPEND}
-	sys-devel/gcc:*
+	ppc? ( sys-devel/gcc:* )
 "
 DEPEND="${CDEPEND}"
 BDEPEND="test? ( dev-libs/boost[${MULTILIB_USEDEP}] )"


### PR DESCRIPTION
The gcc RDEPEND is presumably due to the ebuild linking against libatomic. However, this is conditioned behind either ppc or libstdc++, which the latter would imply that GCC is already installed. This needlessly pulls in GCC on musl/llvm systems, and making the gcc dependency ppc-only shouldn't cause any breakage.