### PR TITLE
app-emulation/virtiofsd: Reflect changed path in QA_FLAGS_IGNORED

### DIFF
--- a/app-emulation/virtiofsd/virtiofsd-1.5.1-r2.ebuild
+++ b/app-emulation/virtiofsd/virtiofsd-1.5.1-r2.ebuild
@@ -114,7 +114,7 @@ RDEPEND="${DEPEND}"
 
 # rust does not use *FLAGS from make.conf, silence portage warning
 # update with proper path to binaries this crate installs, omit leading /
-QA_FLAGS_IGNORED="usr/bin/${PN}"
+QA_FLAGS_IGNORED="usr/libexec/${PN}"
 
 src_unpack() {
 	if [[ "${PV}" == *9999* ]]; then

--- a/app-emulation/virtiofsd/virtiofsd-1.6.1-r1.ebuild
+++ b/app-emulation/virtiofsd/virtiofsd-1.6.1-r1.ebuild
@@ -116,7 +116,7 @@ RDEPEND="${DEPEND}"
 
 # rust does not use *FLAGS from make.conf, silence portage warning
 # update with proper path to binaries this crate installs, omit leading /
-QA_FLAGS_IGNORED="usr/bin/${PN}"
+QA_FLAGS_IGNORED="usr/libexec/${PN}"
 
 src_unpack() {
 	if [[ "${PV}" == *9999* ]]; then

--- a/app-emulation/virtiofsd/virtiofsd-9999.ebuild
+++ b/app-emulation/virtiofsd/virtiofsd-9999.ebuild
@@ -116,7 +116,7 @@ RDEPEND="${DEPEND}"
 
 # rust does not use *FLAGS from make.conf, silence portage warning
 # update with proper path to binaries this crate installs, omit leading /
-QA_FLAGS_IGNORED="usr/bin/${PN}"
+QA_FLAGS_IGNORED="usr/libexec/${PN}"
 
 src_unpack() {
 	if [[ "${PV}" == *9999* ]]; then


### PR DESCRIPTION
The binary is no longer installed under /usr/bin rather /usr/libexec. Reflect this change in QA_FLAGS_IGNORED variable.

Closes: https://bugs.gentoo.org/911311
Closes: https://bugs.gentoo.org/911312