### PR TITLE
dev-python/jinja: Add missing DEPEND

### DIFF
--- a/dev-python/jinja/jinja-3.1.2-r1.ebuild
+++ b/dev-python/jinja/jinja-3.1.2-r1.ebuild
@@ -28,6 +28,7 @@ IUSE="examples"
 RDEPEND="
 	>=dev-python/markupsafe-2.0.0[${PYTHON_USEDEP}]
 "
+DEPEND="${RDEPEND}"
 
 distutils_enable_sphinx docs \
 	dev-python/sphinx-issues \


### PR DESCRIPTION
Traceback (most recent call last):
  File "setup.py", line 4, in <module>
    setup(
  File "/usr/lib/python3.8/site-packages/setuptools/__init__.py", line 145, in setup
    return distutils.core.setup(**attrs)
  File "/usr/lib/python3.8/distutils/core.py", line 121, in setup
    dist.parse_config_files()
  File "/usr/lib/python3.8/site-packages/setuptools/dist.py", line 701, in parse_config_files
    parse_configuration(self, self.command_options,
  File "/usr/lib/python3.8/site-packages/setuptools/config.py", line 121, in parse_configuration
    meta.parse()
  File "/usr/lib/python3.8/site-packages/setuptools/config.py", line 426, in parse
    section_parser_method(section_options)
  File "/usr/lib/python3.8/site-packages/setuptools/config.py", line 399, in parse_section
    self[name] = value
  File "/usr/lib/python3.8/site-packages/setuptools/config.py", line 184, in __setitem__
    value = parser(value)
  File "/usr/lib/python3.8/site-packages/setuptools/config.py", line 515, in _parse_version
    version = self._parse_attr(value, self.package_dir)
  File "/usr/lib/python3.8/site-packages/setuptools/config.py", line 349, in _parse_attr
    module = import_module(module_name)
  File "/usr/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 843, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/var/tmp/portage/dev-python/jinja-3.1.2/work/jinja-3.1.2/src/jinja2/__init__.py", line 8, in <module>
    from .environment import Environment as Environment
  File "/var/tmp/portage/dev-python/jinja-3.1.2/work/jinja-3.1.2/src/jinja2/environment.py", line 14, in <module>
    from markupsafe import Markup
ModuleNotFoundError: No module named 'markupsafe'

Change-Id: I673448ec53bf326e5a20012d81bba25c351de4fc
