### PR TITLE
dev-cpp/abseil-cpp: backport fix build with musl-1.2.4 to 20220623

### DIFF
--- a/dev-cpp/abseil-cpp/abseil-cpp-20220623.1.ebuild
+++ b/dev-cpp/abseil-cpp/abseil-cpp-20220623.1.ebuild
@@ -32,6 +32,10 @@ BDEPEND="
 
 RESTRICT="!test? ( test )"
 
+PATCHES=(
+	"${FILESDIR}"/${PN}-20230125.2-musl-1.2.4.patch #906218
+)
+
 src_prepare() {
 	cmake_src_prepare
 


### PR DESCRIPTION
20220623 is needed for bear-3.1.2 and without this patch, bear cannot be installed on musl profiles.