### PR TITLE
net-misc/modemmanager: dont build against systemd when USE="-systemd"

### DIFF
--- a/net-misc/modemmanager/modemmanager-1.20.6.ebuild
+++ b/net-misc/modemmanager/modemmanager-1.20.6.ebuild
@@ -92,6 +92,10 @@ src_configure() {
 	else
 		emesonargs+=(-Dsystemd_suspend_resume=false)
 	fi
+	# 911416
+	if ! use systemd; then
+		emesonargs+=(-Dsystemdsystemunitdir=no)
+	fi
 	meson_src_configure
 }
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/911416