### PR TITLE
app-crypt/signify: Fix call to undeclared function b64_pton

### DIFF
--- a/app-crypt/signify/files/signify-31-fix-build-clang-16.patch
+++ b/app-crypt/signify/files/signify-31-fix-build-clang-16.patch
@@ -1,0 +1,35 @@
+Upstream PR: https://github.com/aperezdc/signify/pull/43
+From: Brahmajit Das <brahmajit.xyz@gmail.com>
+Date: Sat, 29 Jul 2023 20:07:48 +0000
+Subject: [PATCH] Fix build with clang 16
+
+Bug: https://bugs.gentoo.org/894354
+Signed-off-by: Brahmajit Das <brahmajit.xyz@gmail.com>
+--- a/base64.c
++++ b/base64.c
+@@ -52,6 +52,7 @@
+ 
+ #include <stdlib.h>
+ #include <string.h>
++#include "base64.h"
+ 
+ static const char Base64[] =
+ 	"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+--- /dev/null
++++ b/base64.h
+@@ -0,0 +1,2 @@
++int b64_pton(char const *, unsigned char *, size_t);
++int b64_ntop(unsigned char const *, size_t , char *, size_t);
+--- a/signify.c
++++ b/signify.c
+@@ -34,6 +34,7 @@
+ #include "sha2.h"
+ 
+ #include "crypto_api.h"
++#include "base64.h"
+ #include "signify.h"
+ 
+ #define SIGBYTES crypto_sign_ed25519_BYTES
+-- 
+2.41.0
+

--- a/app-crypt/signify/signify-31-r1.ebuild
+++ b/app-crypt/signify/signify-31-r1.ebuild
@@ -1,0 +1,54 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+VERIFY_SIG_METHOD="signify"
+inherit toolchain-funcs verify-sig
+
+DESCRIPTION="Cryptographically sign and verify files"
+HOMEPAGE="
+	https://www.openbsd.org/
+	https://github.com/aperezdc/signify/
+"
+SRC_URI="
+	https://github.com/aperezdc/${PN}/releases/download/v${PV}/${P}.tar.xz
+	verify-sig? (
+		https://github.com/aperezdc/${PN}/releases/download/v${PV}/SHA256.sig
+			-> ${P}.sha.sig
+	)"
+
+LICENSE="BSD-1"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~riscv ~sparc ~x86"
+
+RDEPEND="!net-mail/signify
+	>=dev-libs/libbsd-0.7"
+DEPEND="${RDEPEND}"
+BDEPEND="verify-sig? ( sec-keys/signify-keys-signify )"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-30-man_compress.patch
+	"${FILESDIR}"/${PN}-31-fix-build-clang-16.patch
+)
+
+VERIFY_SIG_OPENPGP_KEY_PATH="${BROOT}/usr/share/signify-keys/${PN}-30.pub"
+
+src_unpack() {
+	if use verify-sig; then
+		# Too many levels of symbolic links
+		cp "${DISTDIR}"/${P}.{sha.sig,tar.xz} "${WORKDIR}" || die
+		verify-sig_verify_signed_checksums \
+			${P}.sha.sig sha256 ${P}.tar.xz
+	fi
+	default
+}
+
+src_configure() {
+	tc-export CC
+}
+
+src_install() {
+	emake DESTDIR="${ED}" PREFIX="/usr" install
+	einstalldocs
+}


### PR DESCRIPTION
Upstream PR: https://github.com/aperezdc/signify/pull/43

Closes: https://bugs.gentoo.org/894354