### PR TITLE
app-dicts/eblook: Fix call to undeclared library function strcmp

### DIFF
--- a/app-dicts/eblook/eblook-1.6.1_p16-r1.ebuild
+++ b/app-dicts/eblook/eblook-1.6.1_p16-r1.ebuild
@@ -1,0 +1,34 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools
+
+DESCRIPTION="Interactive search utility for electronic dictionaries"
+HOMEPAGE="http://openlab.ring.gr.jp/edict/eblook/"
+SRC_URI="http://openlab.ring.gr.jp/edict/eblook/dist/${PN}-$(ver_cut 1-3).tar.gz"
+SRC_URI+=" mirror://debian/pool/main/e/eblook/eblook_$(ver_cut 1-3)-$(ver_cut 5).debian.tar.xz"
+S="${WORKDIR}"/${PN}-$(ver_cut 1-3)
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~riscv ~x86"
+
+DEPEND=">=dev-libs/eb-3.3.4"
+RDEPEND="${DEPEND}"
+
+PATCHES=(
+	"${WORKDIR}"/debian/patches
+	"${FILESDIR}"/${PN}-1.6.1-clang-16-buildfix.patch
+)
+
+src_prepare() {
+	default
+
+	eautoreconf
+}
+
+src_configure() {
+	econf --with-eb-conf="${EPREFIX}"/etc/eb.conf
+}

--- a/app-dicts/eblook/files/eblook-1.6.1-clang-16-buildfix.patch
+++ b/app-dicts/eblook/files/eblook-1.6.1-clang-16-buildfix.patch
@@ -1,0 +1,11 @@
+Bug: https://bugs.gentoo.org/894360
+--- a/getopt.c
++++ b/getopt.c
+@@ -40,6 +40,7 @@
+ #endif
+ 
+ #include <stdio.h>
++#include <string.h>
+ 
+ /* Comment out all this code if we are using the GNU C Library, and are not
+    actually compiling the library itself.  This code is part of the GNU C


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/894360