### PR TITLE
app-dicts/ydpdict: Fix call to undeclared function textdomain

### DIFF
--- a/app-dicts/ydpdict/files/ydpdict-1.0.3-clang16-build-fix.patch
+++ b/app-dicts/ydpdict/files/ydpdict-1.0.3-clang16-build-fix.patch
@@ -1,0 +1,12 @@
+Bug: https://bugs.gentoo.org/894364
+Upstream PR: https://github.com/wojtekka/ydpdict/pull/4
+--- a/src/ydpdict.c
++++ b/src/ydpdict.c
+@@ -55,6 +55,7 @@
+ 
+ #ifdef HAVE_LOCALE_H
+ #include <locale.h>
++#include <libintl.h>
+ #endif
+ 
+ #ifdef HAVE_LIBAO

--- a/app-dicts/ydpdict/ydpdict-1.0.3-r2.ebuild
+++ b/app-dicts/ydpdict/ydpdict-1.0.3-r2.ebuild
@@ -1,0 +1,59 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+inherit autotools
+
+DESCRIPTION="Interface for the Collins Dictionary"
+HOMEPAGE="https://github.com/wojtekka/ydpdict"
+SRC_URI="https://github.com/wojtekka/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~riscv ~x86"
+IUSE="ao"
+
+RDEPEND="
+	app-dicts/libydpdict
+	sys-libs/ncurses:=[unicode(+)]
+	ao? ( media-libs/libao )
+"
+DEPEND="
+	${RDEPEND}
+"
+BDEPEND="
+	virtual/pkgconfig
+"
+DOCS=(
+	README.md
+)
+PATCHES=(
+	"${FILESDIR}"/${PN}-1.0.3-tinfo.patch
+	"${FILESDIR}"/${PN}-1.0.3-clang16-build-fix.patch
+)
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_configure() {
+	econf \
+		$(use_with ao libao)
+}
+
+src_install() {
+	dodir "/etc"
+	default
+}
+
+pkg_postinst() {
+	echo
+	elog "Note that to use this program you'll need the original Collins Dictionary"
+	elog "datafiles (dict100.*, dict101.*). These can be found in the Dabasase/"
+	elog "directory of the Windows version of the Collins dictionary. Once you obtain"
+	elog "the files, put them into /usr/share/ydpdict"
+	elog
+	elog "Some configuration options can be set in /etc/ydpdict.conf"
+	echo
+}


### PR DESCRIPTION
Upstream PR: https://github.com/wojtekka/ydpdict/pull/4

Closes: https://bugs.gentoo.org/894364