### PR TITLE
sys-process/at: Fix several installation issues

### DIFF
--- a/sys-process/at/at-3.2.5-r2.ebuild
+++ b/sys-process/at/at-3.2.5-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -42,6 +42,8 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-3.1.13-configure.in-fix-PAM-automagick-dep.patch
 	# Fix parallel make issue (bug #408375)
 	"${FILESDIR}"/${PN}-3.1.13-parallel-make-fix.patch
+	# Fix permissions (bug #711598)
+	"${FILESDIR}"/${P}-Makefile.binary-permission-fix.patch
 )
 
 src_prepare() {
@@ -75,6 +77,8 @@ src_install() {
 
 	systemd_dounit "${FILESDIR}/atd.service"
 	keepdir /var/spool/at/atspool
+	# Fix permission since keepdir changes it (bug #658460)
+	fperms 1770 /var/spool/at/atspool
 }
 
 pkg_preinst() {
@@ -84,15 +88,4 @@ pkg_preinst() {
 		einfo "Preserving existing .SEQ file (bug #386625)."
 		cp -p "${seq_file}" "${ED}"/var/spool/at/atjobs/ || die
 	fi
-}
-
-pkg_postinst() {
-	einfo "Forcing correct permissions on /var/spool/at"
-	local atspooldir="${EROOT}/var/spool/at"
-	chown at:at "${atspooldir}/atjobs"
-	chmod 1770  "${atspooldir}/atjobs"
-	chown at:at "${atspooldir}/atjobs/.SEQ"
-	chmod 0600  "${atspooldir}/atjobs/.SEQ"
-	chown at:at "${atspooldir}/atspool"
-	chmod 1770  "${atspooldir}/atspool"
 }

--- a/sys-process/at/files/at-3.2.5-Makefile.binary-permission-fix.patch
+++ b/sys-process/at/files/at-3.2.5-Makefile.binary-permission-fix.patch
@@ -1,0 +1,12 @@
+diff -Naur at-3.2.5-orig/Makefile.in at-3.2.5/Makefile.in
+--- at-3.2.5-orig/Makefile.in	2022-02-05 02:00:57.000000000 -0800
++++ at-3.2.5/Makefile.in	2023-07-27 20:49:58.505824137 -0700
+@@ -114,7 +114,7 @@
+ 	chmod 600 $(DESTDIR)$(LFILE)
+ 	chown $(DAEMON_USERNAME):$(DAEMON_GROUPNAME) $(DESTDIR)$(LFILE)
+ 	test -f $(DESTDIR)$(etcdir)/at.allow || test -f $(DESTDIR)$(etcdir)/at.deny || $(INSTALL) -o root -g $(DAEMON_GROUPNAME) -m 640 at.deny $(DESTDIR)$(etcdir)/
+-	$(INSTALL) -g $(DAEMON_GROUPNAME) -o $(DAEMON_USERNAME) -m 6755 at $(DESTDIR)$(bindir)
++	$(INSTALL) -g $(DAEMON_GROUPNAME) -o root -m 6755 at $(DESTDIR)$(bindir)
+ 	$(LN_S) -f at $(DESTDIR)$(bindir)/atq
+ 	$(LN_S) -f at $(DESTDIR)$(bindir)/atrm
+ 	$(INSTALL) -g root -o root -m 755 batch $(DESTDIR)$(bindir)


### PR DESCRIPTION
- Fix `at` binary ownership
- Remove `pkg_postinst()` since Makefile actually sets the ownership and
  permissions as needed. Fix broken permission by keepdir in scr_install
  instead.

Closes: https://bugs.gentoo.org/658460
Closes: https://bugs.gentoo.org/711598
Signed-off-by: Zoltan Puskas <zoltan@sinustrom.info>
