### PR TITLE
media-libs/libsfml: Fix no member named 'auto_ptr'

### DIFF
--- a/media-libs/libsfml/files/libsfml-2.5.1-clang-16-auto_ptr.patch
+++ b/media-libs/libsfml/files/libsfml-2.5.1-clang-16-auto_ptr.patch
@@ -1,0 +1,50 @@
+https://github.com/SFML/SFML/commit/bf92efe9a4035fee0258386173d53556aa196e49
+Bug: https://bugs.gentoo.org/910519
+From: Tobias Widlund <widlundtobias@gmail.com>
+Date: Fri, 18 Jan 2019 14:12:14 +0100
+Subject: [PATCH] Remove usages of std::auto_ptr to get rid of warnings when
+ building with gcc 8.2+
+
+--- a/src/SFML/Audio/AudioDevice.cpp
++++ b/src/SFML/Audio/AudioDevice.cpp
+@@ -29,7 +29,7 @@
+ #include <SFML/Audio/ALCheck.hpp>
+ #include <SFML/Audio/Listener.hpp>
+ #include <SFML/System/Err.hpp>
+-#include <memory>
++#include <vector>
+ 
+ 
+ namespace
+@@ -107,9 +107,13 @@ bool AudioDevice::isExtensionSupported(const std::string& extension)
+     // This device will not be used in this function and merely
+     // makes sure there is a valid OpenAL device for extension
+     // queries if none has been created yet.
+-    std::auto_ptr<AudioDevice> device;
++    //
++    // Using an std::vector for this since auto_ptr is deprecated
++    // and we have no better STL facility for dynamically allocating
++    // a temporary instance with strong exception guarantee.
++    std::vector<AudioDevice> device;
+     if (!audioDevice)
+-        device.reset(new AudioDevice);
++        device.resize(1);
+ 
+     if ((extension.length() > 2) && (extension.substr(0, 3) == "ALC"))
+         return alcIsExtensionPresent(audioDevice, extension.c_str()) != AL_FALSE;
+@@ -125,9 +129,13 @@ int AudioDevice::getFormatFromChannelCount(unsigned int channelCount)
+     // This device will not be used in this function and merely
+     // makes sure there is a valid OpenAL device for format
+     // queries if none has been created yet.
+-    std::auto_ptr<AudioDevice> device;
++    //
++    // Using an std::vector for this since auto_ptr is deprecated
++    // and we have no better STL facility for dynamically allocating
++    // a temporary instance with strong exception guarantee.
++    std::vector<AudioDevice> device;
+     if (!audioDevice)
+-        device.reset(new AudioDevice);
++        device.resize(1);
+ 
+     // Find the good format according to the number of channels
+     int format = 0;

--- a/media-libs/libsfml/libsfml-2.5.1-r2.ebuild
+++ b/media-libs/libsfml/libsfml-2.5.1-r2.ebuild
@@ -1,0 +1,75 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit cmake
+
+DESCRIPTION="Simple and Fast Multimedia Library (SFML)"
+HOMEPAGE="https://www.sfml-dev.org/ https://github.com/SFML/SFML"
+SRC_URI="https://github.com/SFML/SFML/archive/${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="ZLIB"
+SLOT="0/$(ver_cut 1-2)"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~riscv ~x86"
+IUSE="debug doc examples"
+
+RDEPEND="
+	media-libs/flac:=
+	media-libs/freetype:2
+	media-libs/libjpeg-turbo:=
+	media-libs/libpng:=
+	media-libs/libogg
+	media-libs/libvorbis
+	media-libs/openal
+	sys-libs/zlib
+	virtual/opengl
+	x11-libs/libX11
+	x11-libs/libXrandr
+	x11-libs/libxcb
+	x11-libs/xcb-util-image
+	kernel_linux? ( virtual/libudev:= )
+"
+DEPEND="${RDEPEND}"
+BDEPEND="
+	doc? ( app-doc/doxygen )
+"
+
+DOCS=( changelog.md readme.md )
+
+S="${WORKDIR}/SFML-${PV}"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-musl-1.2.3-nullptr.patch
+	"${FILESDIR}"/${P}-clang-16-auto_ptr.patch
+)
+
+src_prepare() {
+	sed -i "s:DESTINATION .*:DESTINATION /usr/share/doc/${PF}:" \
+		doc/CMakeLists.txt || die
+
+	find examples -name CMakeLists.txt -delete || die
+	cmake_src_prepare
+}
+
+src_configure() {
+	local mycmakeargs=(
+		-DSFML_BUILD_DOC=$(usex doc)
+		-DSFML_INSTALL_PKGCONFIG_FILES=TRUE
+	)
+
+	cmake_src_configure
+}
+
+src_install() {
+	cmake_src_install
+
+	insinto /usr/share/cmake/Modules
+	doins cmake/SFMLConfig.cmake.in
+	doins cmake/SFMLConfigDependencies.cmake.in
+
+	if use examples ; then
+		docompress -x /usr/share/doc/${PF}/examples
+		dodoc -r examples
+	fi
+}


### PR DESCRIPTION
The backport is needed as some packges are still dependent on 2.5.1

Closes: https://bugs.gentoo.org/910519