### PR TITLE
gui-wm/wayfire: require missing use flags

### DIFF
--- a/gui-wm/wayfire/wayfire-0.7.5-r1.ebuild
+++ b/gui-wm/wayfire/wayfire-0.7.5-r1.ebuild
@@ -73,6 +73,10 @@ BDEPEND="
 	virtual/pkgconfig
 "
 
+PATCHES=(
+	"${FILESDIR}"/${PN}-0.7.5-gcc13.patch
+)
+
 src_configure() {
 	sed -e "s:@EPREFIX@:${EPREFIX}:" \
 	    "${FILESDIR}"/wayfire-session > "${T}"/wayfire-session || die


### PR DESCRIPTION
* drm and libinput were made optional in wlroots-0.15, they are required by wayfire unconditionally though.
* Require x11-backend in wlroots to avoid automagic in wayfire.

https://gitlab.freedesktop.org/wlroots/wlroots/-/commit/b37731cdbbef4dc52033c2d26b04d2329720fa07 https://github.com/WayfireWM/wayfire/blob/v0.7.5/meson.build#L133

Closes: https://bugs.gentoo.org/907638