### PR TITLE
x11-libs/cairo: add missing gtk-doc to BDEPEND

### DIFF
--- a/x11-libs/cairo/cairo-1.17.8-r1.ebuild
+++ b/x11-libs/cairo/cairo-1.17.8-r1.ebuild
@@ -11,7 +11,7 @@ if [[ ${PV} == *9999* ]]; then
 	SRC_URI=""
 else
 	SRC_URI="https://gitlab.freedesktop.org/cairo/cairo/-/archive/${PV}/cairo-${PV}.tar.bz2"
-	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x64-solaris"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~arm64-macos ~ppc-macos ~x64-macos ~x64-solaris"
 fi
 
 DESCRIPTION="A vector graphics library with cross-device output support"
@@ -51,10 +51,14 @@ BDEPEND="
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-respect-fontconfig.patch
+
+	# Upstream
+	"${FILESDIR}"/${PV}-tee-Fix-cairo-wrapper-functions.patch
 )
 
 multilib_src_configure() {
 	local emesonargs=(
+		-Ddwrite=disabled
 		-Dfontconfig=enabled
 		-Dfreetype=enabled
 		-Dpng=enabled
@@ -63,6 +67,7 @@ multilib_src_configure() {
 		$(meson_feature X xcb)
 		$(meson_feature X xlib)
 		-Dxlib-xcb=disabled
+		-Dxml=disabled
 		-Dzlib=enabled
 
 		# Requires poppler-glib (poppler[cairo]) which isn't available in multilib


### PR DESCRIPTION
https://gitlab.freedesktop.org/cairo/cairo/-/blob/1.17.8/doc/public/meson.build#L133

Closes: https://bugs.gentoo.org/887335