### PR TITLE
xfce-extra/xfce4-whiskermenu-plugin: drop maintainership

### DIFF
--- a/xfce-extra/xfce4-whiskermenu-plugin/metadata.xml
+++ b/xfce-extra/xfce4-whiskermenu-plugin/metadata.xml
@@ -1,14 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer type="person" proxied="yes">
-		<email>christian.tietz@mailbox.org</email>
-		<name>Christian Tietz</name>
-	</maintainer>
-	<maintainer type="project" proxied="proxy">
-		<email>proxy-maint@gentoo.org</email>
-		<name>Proxy Maintainers</name>
-	</maintainer>
 	<maintainer type="project">
 		<email>xfce@gentoo.org</email>
 		<name>XFCE Team</name>


### PR DESCRIPTION
Due to lack of time, I would like to drop maintainership of this package.