### PR TITLE
gui-wm/hyprland: fix updated patch for VIDEO_CARDS=nvidia

### DIFF
--- a/gui-wm/hyprland/hyprland-0.27.2-r1.ebuild
+++ b/gui-wm/hyprland/hyprland-0.27.2-r1.ebuild
@@ -76,6 +76,10 @@ src_prepare() {
 	if use video_cards_nvidia; then
 		cd "${S}/subprojects/wlroots" || die
 		eapply "${S}/nix/wlroots-nvidia.patch"
+		# https://bugs.gentoo.org/911597
+		# https://github.com/hyprwm/Hyprland/pull/2874
+		# https://github.com/hyprwm/Hyprland/blob/main/nix/wlroots.nix#L54
+		sed -i -e 's/glFlush();/glFinish();/' render/gles2/renderer.c || die
 		cd "${S}" || die
 	fi
 


### PR DESCRIPTION
Fix problem reported in bug 911597 (https://bugs.gentoo.org/911597)