### PR TITLE
app-i18n/mecab-skkserv: Fix call to undeclared library function strcmp

### DIFF
--- a/app-i18n/mecab-skkserv/files/mecab-skkserv-missing-strcmp-clang16.patch
+++ b/app-i18n/mecab-skkserv/files/mecab-skkserv-missing-strcmp-clang16.patch
@@ -1,0 +1,11 @@
+Closes: https://bugs.gentoo.org/894518
+--- a/getopt.c
++++ b/getopt.c
+@@ -40,6 +40,7 @@
+ #endif
+ 
+ #include <stdio.h>
++#include <string.h>
+ 
+ /* Comment out all this code if we are using the GNU C Library, and are not
+    actually compiling the library itself.  This code is part of the GNU C

--- a/app-i18n/mecab-skkserv/mecab-skkserv-0.03-r1.ebuild
+++ b/app-i18n/mecab-skkserv/mecab-skkserv-0.03-r1.ebuild
@@ -1,0 +1,42 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="8"
+
+inherit autotools
+
+DESCRIPTION="mecab-skkserv is a Kana-Kanji conversion server using MeCab"
+HOMEPAGE="http://chasen.org/~taku/software/mecab-skkserv/"
+SRC_URI="http://chasen.org/~taku/software/${PN}/${P}.tar.gz"
+
+LICENSE="GPL-2 ipadic"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE=""
+
+DEPEND="app-text/mecab"
+RDEPEND="${DEPEND}
+	sys-apps/xinetd"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-cflags.patch
+	"${FILESDIR}"/${PN}-dicrc.patch
+	"${FILESDIR}"/${PN}-getopt.patch
+	"${FILESDIR}"/${PN}-missing-strcmp-clang16.patch
+)
+HTML_DOCS=( index.html ${PN}.css )
+
+src_prepare() {
+	sed -i "/^dictdir/s:lib:$(get_libdir):" Makefile.am
+
+	default
+	mv configure.{in,ac} || die
+	eautoreconf
+}
+
+src_install() {
+	default
+
+	insinto /etc/xinetd.d
+	newins "${FILESDIR}"/${PN}.xinetd ${PN}
+}


### PR DESCRIPTION
and update EAPI 6 -> 8

Closes: https://bugs.gentoo.org/894518