### PR TITLE
app-forensics/afl: Fix type specifier missing, defaults to int

### DIFF
--- a/app-forensics/afl/afl-2.57b-r2.ebuild
+++ b/app-forensics/afl/afl-2.57b-r2.ebuild
@@ -6,7 +6,10 @@ EAPI=7
 inherit multilib toolchain-funcs flag-o-matic
 
 # See https://github.com/google/AFL/pull/117
-PATCHES=( "${FILESDIR}/${P}-install-readmemd.diff" )
+PATCHES=(
+	"${FILESDIR}/${P}-install-readmemd.diff"
+	"${FILESDIR}/${P}-implicit-int-clang16.patch"
+)
 
 DESCRIPTION="american fuzzy lop - compile-time instrumentation fuzzer"
 HOMEPAGE="https://lcamtuf.coredump.cx/afl/"

--- a/app-forensics/afl/files/afl-2.57b-implicit-int-clang16.patch
+++ b/app-forensics/afl/files/afl-2.57b-implicit-int-clang16.patch
@@ -1,0 +1,14 @@
+Bug: https://bugs.gentoo.org/894514
+diff --git a/Makefile b/Makefile
+index 3819312..536c20b 100644
+--- a/Makefile
++++ b/Makefile
+@@ -50,7 +50,7 @@ ifndef AFL_NO_X86
+ 
+ test_x86:
+ 	@echo "[*] Checking for the ability to compile x86 code..."
+-	@echo 'main() { __asm__("xorb %al, %al"); }' | $(CC) -w -x c - -o .test || ( echo; echo "Oops, looks like your compiler can't generate x86 code."; echo; echo "Don't panic! You can use the LLVM or QEMU mode, but see docs/INSTALL first."; echo "(To ignore this error, set AFL_NO_X86=1 and try again.)"; echo; exit 1 )
++	@echo 'int main() { __asm__("xorb %al, %al"); }' | $(CC) -w -x c - -o .test || ( echo; echo "Oops, looks like your compiler can't generate x86 code."; echo; echo "Don't panic! You can use the LLVM or QEMU mode, but see docs/INSTALL first."; echo "(To ignore this error, set AFL_NO_X86=1 and try again.)"; echo; exit 1 )
+ 	@rm -f .test
+ 	@echo "[+] Everything seems to be working, ready to compile."
+ 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/894514