### PR TITLE
net-ftp/filezilla: add dev-libs/boost as dependency for version 3.65.0

### DIFF
--- a/net-ftp/filezilla/filezilla-3.65.0.ebuild
+++ b/net-ftp/filezilla/filezilla-3.65.0.ebuild
@@ -27,6 +27,7 @@ RDEPEND="
 	>=dev-db/sqlite-3.7
 	>=dev-libs/libfilezilla-0.44.0:=
 	>=dev-libs/pugixml-1.7
+	>=dev-libs/boost-1.76.0:=
 	>=net-libs/gnutls-3.5.7
 	x11-libs/wxGTK:${WX_GTK_VER}[X]
 	x11-misc/xdg-utils


### PR DESCRIPTION
This dependency was introduced by upstream at revision 10985.
https://svn.filezilla-project.org/filezilla?revision=10985&view=revision

Signed-off-by: Cristian Othón Martínez Vera <cfuga@cfuga.mx>
Closes: https://bugs.gentoo.org/911411
