### PR TITLE
app-laptop/mbpfan: Fix call to undeclared function vsyslog

### DIFF
--- a/app-laptop/mbpfan/files/mbpfan-2.3.0-clang16-build-fix.patch
+++ b/app-laptop/mbpfan/files/mbpfan-2.3.0-clang16-build-fix.patch
@@ -1,0 +1,12 @@
+Bug: https://bugs.gentoo.org/894522
+Upstream PR: https://github.com/linux-on-mac/mbpfan/pull/261
+--- a/src/util.c
++++ b/src/util.c
+@@ -1,6 +1,7 @@
+ #include <stdarg.h>
+ #include <stdio.h>
+ #define __USE_MISC
++#define _BSD_SOURCE
+ #include <syslog.h>
+ 
+ #include "global.h"

--- a/app-laptop/mbpfan/mbpfan-2.3.0-r1.ebuild
+++ b/app-laptop/mbpfan/mbpfan-2.3.0-r1.ebuild
@@ -1,0 +1,51 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit linux-info systemd toolchain-funcs
+
+DESCRIPTION="A simple daemon to control fan speed on all Macbook/Macbook Pros"
+HOMEPAGE="https://github.com/dgraziotin/mbpfan"
+
+if [[ ${PV} == *9999 ]]; then
+	inherit git-r3
+	EGIT_REPO_URI="https://github.com/dgraziotin/${PN}.git"
+else
+	SRC_URI="https://github.com/dgraziotin/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+	KEYWORDS="~amd64"
+fi
+
+LICENSE="GPL-3+"
+SLOT="0"
+RESTRICT="test" # will fail if the hardware is unavailable, not useful
+
+CONFIG_CHECK="~SENSORS_APPLESMC ~SENSORS_CORETEMP"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-2.3.0-clang16-build-fix.patch
+)
+
+src_compile() {
+	emake CC="$(tc-getCC)"
+}
+
+src_install() {
+	emake DESTDIR="${ED}" install
+
+	# Decompress the man page to enable PM auto compression
+	gzip -d "${ED}"/usr/share/man/man8/mbpfan.8.gz || die
+
+	# Remove the empty systemd unit directory
+	# It doesn't actually install the unit file
+	rmdir --ignore-fail-on-non-empty -p "${ED}"/lib/systemd/system || die
+	# Actually install the sytstemd unit file
+	systemd_dounit ${PN}.service
+	# Install openrc init file
+	newinitd ${PN}.init.gentoo ${PN}
+
+	# make install doesn't install the docs in the right place
+	rm -r "${ED}"/usr/share/doc/${PN} || die
+
+	einstalldocs
+}


### PR DESCRIPTION
Upstream PR: https://github.com/linux-on-mac/mbpfan/pull/261

Closes: https://bugs.gentoo.org/894522