### PR TITLE
app-misc/hddled: Fix call to undeclared function TEMP_FAILURE_RETRY

### DIFF
--- a/app-misc/hddled/files/hddled-0.3-fix-missing-temp_failure_retry.patch
+++ b/app-misc/hddled/files/hddled-0.3-fix-missing-temp_failure_retry.patch
@@ -1,0 +1,19 @@
+Bug: https://bugs.gentoo.org/894550
+--- a/hddled.c
++++ b/hddled.c
+@@ -43,6 +43,15 @@
+ 
+ #define PACKAGE_STRING    "hddled 0.3"
+ #define PACKAGE_BUGREPORT "hddled@very.puzzling.org"
++/* taken from glibc unistd.h and fixes musl */
++#ifndef TEMP_FAILURE_RETRY
++#define TEMP_FAILURE_RETRY(expression) \
++  (__extension__                                                              \
++    ({ long int __result;                                                     \
++       do __result = (long int) (expression);                                 \
++       while (__result == -1L && errno == EINTR);                             \
++       __result; }))
++#endif
+ 
+ #define VMSTAT "/proc/vmstat"
+ 

--- a/app-misc/hddled/hddled-0.3-r1.ebuild
+++ b/app-misc/hddled/hddled-0.3-r1.ebuild
@@ -1,0 +1,49 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs flag-o-matic
+
+DESCRIPTION="Show hard disk activity using the scroll lock LED"
+HOMEPAGE="http://members.optusnet.com.au/foonly/whirlpool/code/"
+SRC_URI="mirror://gentoo/${P}.c.xz"
+S="${WORKDIR}"
+
+LICENSE="Unlicense"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="X"
+
+DEPEND="X? ( x11-libs/libX11 )"
+RDEPEND="${DEPEND}"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-0.3-fix-missing-temp_failure_retry.patch"
+)
+
+src_prepare() {
+	mv ${P}.c ${PN}.c || die
+	default
+}
+
+src_compile() {
+	if use elibc_musl ; then
+		append-libs -largp
+	fi
+
+	$(tc-getCC) ${CFLAGS} ${CPPFLAGS} -o ${PN} ${PN}.c ${LDFLAGS} ${LIBS} || die
+
+	if use X ; then
+		$(tc-getCC) ${CFLAGS} ${CPPFLAGS} -DX -lX11 -o x${PN} ${PN}.c ${LDFLAGS} ${LIBS} || die
+	fi
+}
+
+src_install() {
+	dobin ${PN}
+
+	if use X ; then
+		dobin x${PN}
+		elog "X version was renamed to x${PN}"
+	fi
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/894550