### PR TITLE
x11-wm/qtile: Fix Python syntax on replaced code

### DIFF
--- a/x11-wm/qtile/qtile-9999.ebuild
+++ b/x11-wm/qtile/qtile-9999.ebuild
@@ -62,7 +62,7 @@ distutils_enable_tests pytest
 python_prepare_all() {
 	# Avoid automagic dependency on libpulse
 	if ! use pulseaudio ; then
-		sed -i -e 's/call("libpulse", "--libs")/throw PkgConfigError/' setup.py || die
+		sed -i -e 's/call("libpulse", "--libs")/raise PkgConfigError/' setup.py || die
 	fi
 
 	# Avoid automagic dependency on pywlroots


### PR DESCRIPTION
When not building with `pulseaudio` use flag, the `sed` replacement will insert code that `throw`'s an exception, rather than the correct syntax to `raise` the exception. Fix this typo.