### PR TITLE
www-client/chromium: stabilize 115.0.5790.170 for amd64

### DIFF
--- a/www-client/chromium/chromium-115.0.5790.170.ebuild
+++ b/www-client/chromium/chromium-115.0.5790.170.ebuild
@@ -32,7 +32,7 @@ SRC_URI="https://commondatastorage.googleapis.com/chromium-browser-official/${P}
 
 LICENSE="BSD"
 SLOT="0/stable"
-KEYWORDS="~amd64 ~arm64"
+KEYWORDS="amd64 ~arm64"
 IUSE="+X component-build cups cpu_flags_arm_neon debug gtk4 +hangouts headless kerberos libcxx lto +official pax-kernel pgo pic +proprietary-codecs pulseaudio qt5 qt6 screencast selinux +suid +system-av1 +system-ffmpeg +system-harfbuzz +system-icu +system-png vaapi wayland widevine"
 REQUIRED_USE="
 	component-build? ( !suid !libcxx )


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/911675
Closes: https://bugs.gentoo.org/911676