### PR TITLE
fix compiling mjpegtools-2.2.1 at least with c++17 standard

### DIFF
--- a/media-video/mjpegtools/files/mjpegtools-2.2.1-c++17-no-auto_ptr-fix.patch
+++ b/media-video/mjpegtools/files/mjpegtools-2.2.1-c++17-no-auto_ptr-fix.patch
@@ -1,0 +1,20 @@
+--- a/mplex/main.cpp
++++ b/mplex/main.cpp
+@@ -50,7 +50,7 @@
+ #include "multiplexor.hpp"
+ 
+ 
+-using std::auto_ptr;
++using std::unique_ptr;
+ 
+ 
+ /*************************************************************************
+@@ -138,7 +138,7 @@
+ void 
+ FileOutputStream::NextSegment( )
+ {
+-    auto_ptr<char> prev_filename_buf( new char[strlen(cur_filename)+1] );
++    unique_ptr<char[]> prev_filename_buf( new char[strlen(cur_filename)+1] );
+     char *prev_filename = prev_filename_buf.get();
+ 	fclose(strm);
+ 	++segment_num;

--- a/media-video/mjpegtools/files/mjpegtools-2.2.1-c++17-register-fix.patch
+++ b/media-video/mjpegtools/files/mjpegtools-2.2.1-c++17-register-fix.patch
@@ -1,0 +1,17 @@
+--- a/utils/fastintfns.h
++++ b/utils/fastintfns.h
+@@ -2,12 +2,12 @@
+  *
+  * WARNING: Assumes 2's complement arithmetic.
+  */
+-static inline int intmax( register int x, register int y )
++static inline int intmax( int x, int y )
+ {
+ 	return x < y ? y : x;
+ }
+ 
+-static inline int intmin( register int x, register int y )
++static inline int intmin( int x, int y )
+ {
+ 	return x < y ? x : y;
+ }

--- a/media-video/mjpegtools/mjpegtools-2.2.1.ebuild
+++ b/media-video/mjpegtools/mjpegtools-2.2.1.ebuild
@@ -40,6 +40,9 @@ DEPEND="
 src_prepare() {
 	default
 
+	eapply "${FILESDIR}/${P}-c++17-register-fix.patch"
+	eapply "${FILESDIR}/${P}-c++17-no-auto_ptr-fix.patch"
+
 	eautoreconf
 	sed -i -e '/ARCHFLAGS=/s:=.*:=:' configure
 }


### PR DESCRIPTION
add two patches those are:
- fixing usage of 'register' specifier since, since c++17 standard, it's been removed
- fixing usage pf 'auto_ptr' since, since c++17 standard, it's been removed