### PR TITLE
media-fonts/noto-emoji: add 20220912-r2

### DIFF
--- a/media-fonts/noto-emoji/files/75-noto-emoji-fallback.conf
+++ b/media-fonts/noto-emoji/files/75-noto-emoji-fallback.conf
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE fontconfig SYSTEM "fonts.dtd">
+<fontconfig>
+:
+    <!-- This adds Noto Color Emoji as a fallback font for all of the default font families;
+         When enabled any **missing** glyphs from the system font will be rendered using Noto Color Emoji in (e.g.)
+         Konsole, Firefox, etc. It _might_ impact web rendering if other fonts would usually be preferred
+         but as it's only doing replacements for missing glyphs we're really just supplementing
+         the existing fallback logic -->
+
+    <match target="pattern">
+        <test name="family"><string>sans</string></test>
+        <edit name="family" mode="append"><string>Noto Color Emoji</string></edit>
+    </match>
+
+    <match target="pattern">
+        <test name="family"><string>serif</string></test>
+        <edit name="family" mode="append"><string>Noto Color Emoji</string></edit>
+    </match>
+
+    <match target="pattern">
+        <test name="family"><string>sans-serif</string></test>
+        <edit name="family" mode="append"><string>Noto Color Emoji</string></edit>
+    </match>
+
+    <match target="pattern">
+        <test name="family"><string>monospace</string></test>
+        <edit name="family" mode="append"><string>Noto Color Emoji</string></edit>
+    </match>
+
+ </fontconfig>

--- a/media-fonts/noto-emoji/noto-emoji-20220912-r2.ebuild
+++ b/media-fonts/noto-emoji/noto-emoji-20220912-r2.ebuild
@@ -1,0 +1,53 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+inherit font
+
+DESCRIPTION="Google Noto Emoji fonts"
+HOMEPAGE="https://www.google.com/get/noto/ https://github.com/googlefonts/noto-emoji"
+
+COMMIT="e8073ab740292f8d5f19b5de144087ac58044d06"
+SRC_URI="https://github.com/googlefonts/noto-emoji/archive/${COMMIT}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="Apache-2.0 OFL-1.1"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~loong ~ppc64 ~riscv ~x86"
+IUSE="icons"
+
+RESTRICT="binchecks strip"
+
+S="${WORKDIR}/${PN}-${COMMIT}"
+
+FONT_CONF=( "${FILESDIR}"/75-noto-emoji-fallback.conf )
+
+src_prepare() {
+	default
+
+	# Drop font for Windows 10
+	rm fonts/NotoColorEmoji_WindowsCompatible.ttf || die
+}
+
+src_compile() { :; }
+
+src_install() {
+	FONT_S="${S}/fonts"
+	# Drop non used fonts
+	rm -f fonts/*COLR*.ttf || die
+
+	# Don't lose fancy emoji icons
+	if use icons; then
+		for i in 32 72 128 512; do
+			insinto "/usr/share/icons/${PN}/${i}/emotes/"
+			doins png/"${i}"/*.png
+		done
+
+		insinto /usr/share/icons/"${PN}"/scalable/emotes/
+		doins svg/*.svg
+	fi
+
+	FONT_SUFFIX="ttf"
+	font_src_install
+
+	dodoc README.md
+}


### PR DESCRIPTION
This PR adds a fontconfig fallback for noto-emoji.