### PR TITLE
gui-libs/gtk: Fix target emulation unknown: -m

### DIFF
--- a/gui-libs/gtk/files/4.10.5-move-objcopy-checks-to-one-place.patch
+++ b/gui-libs/gtk/files/4.10.5-move-objcopy-checks-to-one-place.patch
@@ -1,0 +1,188 @@
+https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/6156
+From: Matthias Clasen <mclasen@redhat.com>
+Date: Wed, 28 Jun 2023 07:11:01 -0400
+Subject: [PATCH 2/3] build: Move objcopy checks to one place
+
+We were doing the same thing in three places.
+Move it to the toplevel meson.build, so we
+can change it in one place.
+--- a/demos/gtk-demo/meson.build
++++ b/demos/gtk-demo/meson.build
+@@ -158,17 +158,7 @@ demos_h = custom_target('gtk4 demo header',
+   command: [ find_program('geninclude.py'), '@OUTPUT@', '@INPUT@' ],
+ )
+ 
+-objcopy_supports_add_symbol = false
+-objcopy = find_program('objcopy', required : false)
+-if objcopy.found()
+-  objcopy_supports_add_symbol = run_command(objcopy, '--help', check: false).stdout().contains('--add-symbol')
+-endif
+-
+-ld = find_program('ld', required : false)
+-
+-if not meson.is_cross_build() and build_machine.cpu_family() != 'arm' and build_machine.system() == 'linux' and objcopy.found() and objcopy_supports_add_symbol and ld.found()
+-  glib_compile_resources = find_program('glib-compile-resources')
+-
++if can_use_objcopy_for_resources
+   # Create the resource blob
+   gtkdemo_gresource = custom_target('gtkdemo.gresource',
+       input : 'demo.gresource.xml',
+--- a/demos/widget-factory/meson.build
++++ b/demos/widget-factory/meson.build
+@@ -1,16 +1,6 @@
+ # demos/widget-factory
+ 
+-objcopy_supports_add_symbol = false
+-objcopy = find_program('objcopy', required : false)
+-if objcopy.found()
+-  objcopy_supports_add_symbol = run_command(objcopy, '--help', check: false).stdout().contains('--add-symbol')
+-endif
+-
+-ld = find_program('ld', required : false)
+-
+-if not meson.is_cross_build() and build_machine.cpu_family() != 'arm' and build_machine.system() == 'linux' and objcopy.found() and objcopy_supports_add_symbol and ld.found()
+-  glib_compile_resources = find_program('glib-compile-resources')
+-
++if can_use_objcopy_for_resources
+   # Create the resource blob
+   widgetfactory_gresource = custom_target('widgetfactory.gresource',
+       input : 'widget-factory.gresource.xml',
+--- a/gtk/meson.build
++++ b/gtk/meson.build
+@@ -758,17 +758,7 @@ if not fs.exists('theme/Default/Default-light.css')
+ endif
+ 
+ 
+-objcopy_supports_add_symbol = false
+-objcopy = find_program('objcopy', required : false)
+-if objcopy.found()
+-  objcopy_supports_add_symbol = run_command(objcopy, '--help', check: false).stdout().contains('--add-symbol')
+-endif
+-
+-ld = find_program('ld', required : false)
+-
+-if not meson.is_cross_build() and build_machine.cpu_family() == 'x86_64' and build_machine.system() == 'linux' and objcopy.found() and objcopy_supports_add_symbol and ld.found()
+-  glib_compile_resources = find_program('glib-compile-resources')
+-
++if can_use_objcopy_for_resources
+   # Create the resource blob
+   gtk_gresource = custom_target('gtk.gresource',
+       input : gtk_gresources_xml,
+--- a/meson.build
++++ b/meson.build
+@@ -737,6 +737,23 @@ endif
+ build_gir = gir.found() and (get_option('introspection').enabled() or
+                              (get_option('introspection').allowed() and get_option('gtk_doc')))
+ 
++# Resource building
++glib_compile_resources = find_program('glib-compile-resources')
++
++objcopy_supports_add_symbol = false
++objcopy = find_program('objcopy', required : false)
++if objcopy.found()
++  objcopy_supports_add_symbol = run_command(objcopy, '--help', check: false).stdout().contains('--add-symbol')
++endif
++
++ld = find_program('ld', required : false)
++
++if not meson.is_cross_build() and build_machine.cpu_family() == 'x86_64' and build_machine.system() == 'linux' and objcopy.found() and objcopy_supports_add_symbol and ld.found()
++  can_use_objcopy_for_resources = true
++else
++  can_use_objcopy_for_resources = false
++endif
++
+ project_build_root = meson.current_build_dir()
+ 
+ gen_visibility_macros = find_program('build-aux/meson/gen-visibility-macros.py')
+-- 
+GitLab
+
+
+From f341bd563b1273888f65ffdabd582ac027883b30 Mon Sep 17 00:00:00 2001
+From: Matthias Clasen <mclasen@redhat.com>
+Date: Wed, 28 Jun 2023 07:12:07 -0400
+Subject: [PATCH 3/3] build: Look for ld.bfd
+
+The objcopy+ld approach to fast resource building
+relies on behavior that is specific to the binutils
+linker, and does not work with the llvm one.
+
+Therefore, check for ld.bfd. We still fall back
+to trying with just ld, since I'm not 100% sure
+if binutils unconditionally installs ld.bfd.
+
+Fixes: #5672
+--- a/meson.build
++++ b/meson.build
+@@ -746,7 +746,7 @@ if objcopy.found()
+   objcopy_supports_add_symbol = run_command(objcopy, '--help', check: false).stdout().contains('--add-symbol')
+ endif
+ 
+-ld = find_program('ld', required : false)
++ld = find_program('ld.bfd', 'ld', required : false)
+ 
+ if not meson.is_cross_build() and build_machine.cpu_family() == 'x86_64' and build_machine.system() == 'linux' and objcopy.found() and objcopy_supports_add_symbol and ld.found()
+   can_use_objcopy_for_resources = true
+-- 
+GitLab
+
+From 1d1f35576a137dc36c63a5958a81d6135ab21f25 Mon Sep 17 00:00:00 2001
+From: Matthias Clasen <mclasen@redhat.com>
+Date: Wed, 28 Jun 2023 16:54:34 -0400
+Subject: [PATCH] build: Try harder to work with nongnu ld
+
+Only try to be fast with gnu ld.
+--- a/meson.build
++++ b/meson.build
+@@ -746,9 +746,13 @@ if objcopy.found()
+   objcopy_supports_add_symbol = run_command(objcopy, '--help', check: false).stdout().contains('--add-symbol')
+ endif
+ 
+-ld = find_program('ld.bfd', 'ld', required : false)
++ld_is_bfd = false
++ld = find_program('ld', required : false)
++if ld.found()
++  ld_is_bfd = run_command(ld, '--version', check: false).stdout().contains('GNU ld')
++endif
+ 
+-if not meson.is_cross_build() and build_machine.cpu_family() == 'x86_64' and build_machine.system() == 'linux' and objcopy.found() and objcopy_supports_add_symbol and ld.found()
++if not meson.is_cross_build() and build_machine.cpu_family() == 'x86_64' and build_machine.system() == 'linux' and objcopy.found() and objcopy_supports_add_symbol and ld.found() and ld_is_bfd
+   can_use_objcopy_for_resources = true
+ else
+   can_use_objcopy_for_resources = false
+-- 
+GitLab
+
+From c61313cbfe92d5a34f3d9ee92170a7bab95d3d76 Mon Sep 17 00:00:00 2001
+From: Matthias Clasen <mclasen@redhat.com>
+Date: Fri, 28 Jul 2023 09:05:03 +0300
+Subject: [PATCH] build: Check for objcopy options
+
+Check that objcopy understands the --set-section-alignment
+option that we are now using.
+--- a/meson.build
++++ b/meson.build
+@@ -742,9 +742,11 @@ build_gir = gir.found() and (get_option('introspection').enabled() or
+ glib_compile_resources = find_program('glib-compile-resources')
+ 
+ objcopy_supports_add_symbol = false
++objcopy_supports_section_alignment = false
+ objcopy = find_program('objcopy', required : false)
+ if objcopy.found()
+   objcopy_supports_add_symbol = run_command(objcopy, '--help', check: false).stdout().contains('--add-symbol')
++  objcopy_supports_section_alignment = run_command(objcopy, '--help', check: false).stdout().contains('--set-section-alignment')
+ endif
+ 
+ ld_is_bfd = false
+@@ -753,7 +755,7 @@ if ld.found()
+   ld_is_bfd = run_command(ld, '--version', check: false).stdout().contains('GNU ld')
+ endif
+ 
+-if not meson.is_cross_build() and build_machine.cpu_family() == 'x86_64' and build_machine.system() == 'linux' and objcopy.found() and objcopy_supports_add_symbol and ld.found() and ld_is_bfd
++if not meson.is_cross_build() and build_machine.cpu_family() == 'x86_64' and build_machine.system() == 'linux' and objcopy.found() and objcopy_supports_add_symbol and objcopy_supports_section_alignment and ld.found() and ld_is_bfd
+   can_use_objcopy_for_resources = true
+ else
+   can_use_objcopy_for_resources = false
+-- 
+GitLab
+

--- a/gui-libs/gtk/gtk-4.10.5-r1.ebuild
+++ b/gui-libs/gtk/gtk-4.10.5-r1.ebuild
@@ -1,0 +1,220 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+PYTHON_COMPAT=( python3_{10..12} )
+inherit gnome.org gnome2-utils meson optfeature python-any-r1 virtualx xdg
+
+DESCRIPTION="GTK is a multi-platform toolkit for creating graphical user interfaces"
+HOMEPAGE="https://www.gtk.org/ https://gitlab.gnome.org/GNOME/gtk/"
+
+LICENSE="LGPL-2+"
+SLOT="4"
+IUSE="aqua broadway cloudproviders colord cups examples ffmpeg gstreamer +introspection sysprof test vulkan wayland +X cpu_flags_x86_f16c"
+REQUIRED_USE="
+	|| ( aqua wayland X )
+	test? ( introspection )
+"
+
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~ia64 ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86"
+
+COMMON_DEPEND="
+	>=dev-libs/glib-2.72.0:2
+	>=x11-libs/cairo-1.17.6[aqua?,glib,svg(+),X?]
+	>=x11-libs/pango-1.50.0[introspection?]
+	>=dev-libs/fribidi-1.0.6
+	>=media-libs/harfbuzz-2.6.0:=
+	>=x11-libs/gdk-pixbuf-2.30:2[introspection?]
+	media-libs/libpng:=
+	media-libs/tiff:=
+	media-libs/libjpeg-turbo:=
+	>=media-libs/libepoxy-1.4[egl,X(+)?]
+	>=media-libs/graphene-1.10.0[introspection?]
+	app-text/iso-codes
+	x11-misc/shared-mime-info
+
+	cloudproviders? ( net-libs/libcloudproviders )
+	colord? ( >=x11-misc/colord-0.1.9:0= )
+	cups? ( >=net-print/cups-2.0 )
+	ffmpeg? ( media-video/ffmpeg:= )
+	gstreamer? (
+		>=media-libs/gst-plugins-bad-1.12.3:1.0
+		>=media-libs/gst-plugins-base-1.12.3:1.0[opengl]
+	)
+	introspection? ( >=dev-libs/gobject-introspection-1.72:= )
+	vulkan? ( media-libs/vulkan-loader:= )
+	wayland? (
+		>=dev-libs/wayland-1.21.0
+		>=dev-libs/wayland-protocols-1.25
+		media-libs/mesa[wayland]
+		>=x11-libs/libxkbcommon-0.2
+	)
+	X? (
+		>=app-accessibility/at-spi2-core-2.46.0
+		media-libs/fontconfig
+		media-libs/mesa[X(+)]
+		x11-libs/libX11
+		>=x11-libs/libXi-1.8
+		x11-libs/libXext
+		>=x11-libs/libXrandr-1.5
+		x11-libs/libXcursor
+		x11-libs/libXfixes
+		x11-libs/libXdamage
+		x11-libs/libXinerama
+	)
+"
+DEPEND="${COMMON_DEPEND}
+	sysprof? ( >=dev-util/sysprof-capture-3.40.1:4 )
+	X? ( x11-base/xorg-proto )
+"
+RDEPEND="${COMMON_DEPEND}
+	>=dev-util/gtk-update-icon-cache-3
+"
+# librsvg for svg icons (PDEPEND to avoid circular dep), bug #547710
+PDEPEND="
+	gnome-base/librsvg
+	>=x11-themes/adwaita-icon-theme-3.14
+"
+BDEPEND="
+	dev-libs/gobject-introspection-common
+	introspection? (
+		${PYTHON_DEPS}
+		$(python_gen_any_dep '
+			dev-python/pygobject:3[${PYTHON_USEDEP}]
+		')
+	)
+	dev-python/docutils
+	>=dev-util/gdbus-codegen-2.48
+	dev-util/glib-utils
+	>=sys-devel/gettext-0.19.7
+	virtual/pkgconfig
+	test? (
+		dev-libs/glib:2
+		media-fonts/cantarell
+		wayland? ( dev-libs/weston[headless] )
+	)
+"
+
+PATCHES=(
+	"${FILESDIR}"/${PV}-move-objcopy-checks-to-one-place.patch
+)
+
+python_check_deps() {
+	python_has_version "dev-python/pygobject:3[${PYTHON_USEDEP}]" || return
+}
+
+pkg_setup() {
+	use introspection && python-any-r1_pkg_setup
+}
+
+src_prepare() {
+	default
+	xdg_environment_reset
+
+	# Nothing should use gtk4-update-icon-cache and an unversioned one is shipped by dev-util/gtk-update-icon-cache
+	sed -i \
+		-e '/gtk4-update-icon-cache/d' \
+		docs/reference/gtk/meson.build \
+		tools/meson.build \
+		|| die
+}
+
+src_configure() {
+	local emesonargs=(
+		# GDK backends
+		$(meson_use X x11-backend)
+		$(meson_use wayland wayland-backend)
+		$(meson_use broadway broadway-backend)
+		-Dwin32-backend=false
+		$(meson_use aqua macos-backend)
+
+		# Media backends
+		$(meson_feature ffmpeg media-ffmpeg)
+		$(meson_feature gstreamer media-gstreamer)
+
+		# Print backends
+		-Dprint-cpdb=disabled
+		$(meson_feature cups print-cups)
+
+		# Optional dependencies
+		$(meson_feature vulkan)
+		$(meson_feature cloudproviders)
+		$(meson_feature sysprof)
+		-Dtracker=disabled  # tracker3 is not packaged in Gentoo yet
+		$(meson_feature colord)
+		# Expected to fail with GCC < 11
+		# See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=71993
+		$(meson_feature cpu_flags_x86_f16c f16c)
+
+		# Documentation and introspection
+		-Dgtk_doc=false # we ship pregenerated API docs from tarball
+		-Dupdate_screenshots=false
+		-Dman-pages=true
+		$(meson_feature introspection)
+
+		# Demos and binaries
+		$(meson_use test build-testsuite)
+		$(meson_use examples build-examples)
+		$(meson_use examples demos)
+		-Dbuild-tests=false
+	)
+	meson_src_configure
+}
+
+src_test() {
+	"${BROOT}${GLIB_COMPILE_SCHEMAS}" --allow-any-name "${S}/gtk" || die
+
+	if use X; then
+		einfo "Running tests under X"
+		GSETTINGS_SCHEMA_DIR="${S}/gtk" virtx meson_src_test --setup=x11 --timeout-multiplier=130
+	fi
+
+	if use wayland; then
+		einfo "Running tests under Weston"
+
+		export XDG_RUNTIME_DIR="$(mktemp -p $(pwd) -d xdg-runtime-XXXXXX)"
+
+		weston --backend=headless-backend.so --socket=wayland-5 --idle-time=0 &
+		compositor=$!
+		export WAYLAND_DISPLAY=wayland-5
+
+		GSETTINGS_SCHEMA_DIR="${S}/gtk" meson_src_test --setup=wayland --timeout-multiplier=130
+
+		exit_code=$?
+		kill ${compositor}
+	fi
+}
+
+src_install() {
+	meson_src_install
+
+	insinto /usr/share/gtk-doc/html
+	# This will install API docs specific to X11 and wayland regardless of USE flags, but this is intentional
+	doins -r "${S}"/docs/reference/{gtk/gtk4,gsk/gsk4,gdk/gdk4{,-wayland,-x11}}
+}
+
+pkg_preinst() {
+	xdg_pkg_preinst
+	gnome2_schemas_savelist
+}
+
+pkg_postinst() {
+	xdg_pkg_postinst
+	gnome2_schemas_update
+
+	if ! has_version "app-text/evince"; then
+		elog "Please install app-text/evince for print preview functionality."
+		elog "Alternatively, check \"gtk-print-preview-command\" documentation and"
+		elog "add it to your settings.ini file."
+	fi
+
+	if use examples ; then
+		optfeature "syntax highlighting in gtk4-demo" app-text/highlight
+	fi
+}
+
+pkg_postrm() {
+	xdg_pkg_postrm
+	gnome2_schemas_update
+}


### PR DESCRIPTION
Backport of
- https://gitlab.gnome.org/GNOME/gtk/-/commit/5ffe9a68ed9b091a0b8837cf8cbee10e40c79ba7
- https://gitlab.gnome.org/GNOME/gtk/-/commit/1d1f35576a137dc36c63a5958a81d6135ab21f25
- https://gitlab.gnome.org/GNOME/gtk/-/commit/c61313cbfe92d5a34f3d9ee92170a7bab95d3d76 This back port is required as gnome 44.3 still pulls gtk-4.10.x

Closes: https://bugs.gentoo.org/908078