### PR TITLE
app-shells/squirrelsh: Fix C++17 does not allow register storage class

### DIFF
--- a/app-shells/squirrelsh/files/squirrelsh-drop-register.patch
+++ b/app-shells/squirrelsh/files/squirrelsh-drop-register.patch
@@ -1,0 +1,12 @@
+Bug: https://bugs.gentoo.org/894640
+--- a/shell/hash_md5.cpp
++++ b/shell/hash_md5.cpp
+@@ -52,7 +52,7 @@ void MD5Init (MD5Context *ctx)
+ // The core of the MD5 algorithm
+ void MD5Transform (unsigned buf[4], const unsigned in[16])
+ {
+-    register unsigned a, b, c, d;
++    unsigned a, b, c, d;
+ 
+     a = buf[0];
+     b = buf[1];

--- a/app-shells/squirrelsh/squirrelsh-1.2.7-r1.ebuild
+++ b/app-shells/squirrelsh/squirrelsh-1.2.7-r1.ebuild
@@ -1,0 +1,48 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit toolchain-funcs
+
+DESCRIPTION="Cross-platform object-oriented scripting shell using the squirrel language"
+HOMEPAGE="http://squirrelsh.sourceforge.net/"
+SRC_URI="mirror://sourceforge/${PN}/${P}-src.tar.bz2"
+
+LICENSE="GPL-3"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~ppc64 ~x86"
+IUSE="doc"
+
+RDEPEND="dev-libs/libpcre"
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-rename-LDFLAGS.patch
+	"${FILESDIR}"/${PN}-no-strip.patch
+	"${FILESDIR}"/${PN}-fix-in_LDFLAGS.patch
+	"${FILESDIR}"/${PN}-remove-forced-abi.patch
+	"${FILESDIR}"/${PN}-no-docs.patch
+	"${FILESDIR}"/${P}-gcc6.patch
+	"${FILESDIR}"/${PN}-drop-register.patch
+)
+
+src_configure() {
+	#This package uses a custom written configure script
+	./configure --prefix="${D}"/usr \
+		--with-cc="$(tc-getCC)" \
+		--with-cpp="$(tc-getCXX)" \
+		--with-linker="$(tc-getCXX)" \
+		--libdir=/usr/"$(get_libdir)" \
+		--with-pcre="system" \
+		--with-squirrel="local" \
+		--with-mime=no || die "configure failed"
+}
+
+src_install() {
+	emake DESTDIR="${D}" install
+	doman doc/${PN}.1
+	dodoc HISTORY INSTALL README
+	use doc && dodoc doc/*.pdf
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/894640