### PR TITLE
sys-power/nut: Fix missing cgi flag in configure

### DIFF
--- a/sys-power/nut/nut-2.8.0-r1.ebuild
+++ b/sys-power/nut/nut-2.8.0-r1.ebuild
@@ -108,6 +108,7 @@ src_configure() {
 		--with-altpidpath=/run/nut
 		--with-pidpath=/run/nut
 		$(use_enable test cppunit)
+		$(use_with cgi)
 		$(use_with i2c linux_i2c)
 		$(use_with ipmi freeipmi)
 		$(use_with ipmi)

--- a/sys-power/nut/nut-9999.ebuild
+++ b/sys-power/nut/nut-9999.ebuild
@@ -132,6 +132,7 @@ src_configure() {
 		--without-python2
 		--with-altpidpath=/run/nut
 		--with-pidpath=/run/nut
+		$(use_with cgi)
 		$(use_with gpio)
 		$(use_with i2c linux_i2c)
 		$(use_with ipmi freeipmi)


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/908689