### PR TITLE
games-emulation/jgrf: remove erroneous dependency

### DIFF
--- a/games-emulation/jgrf/jgrf-1.0.2.ebuild
+++ b/games-emulation/jgrf/jgrf-1.0.2.ebuild
@@ -20,7 +20,7 @@ SLOT="1"
 
 DEPEND="
 	dev-libs/miniz
-	dev-libs/openssl:0=[-bindist(-)]
+	dev-libs/openssl:0=
 	media-libs/jg:1=
 	media-libs/libepoxy[egl]
 	media-libs/libsdl2[opengl,sound,video]

--- a/games-emulation/jgrf/jgrf-9999.ebuild
+++ b/games-emulation/jgrf/jgrf-9999.ebuild
@@ -20,7 +20,7 @@ SLOT="1"
 
 DEPEND="
 	dev-libs/miniz
-	dev-libs/openssl:0=[-bindist(-)]
+	dev-libs/openssl:0=
 	media-libs/jg:1=
 	media-libs/libepoxy[egl]
 	media-libs/libsdl2[opengl,sound,video]


### PR DESCRIPTION
The dependency on `dev-libs/openssl` is only for the MD5 Message-Digest Algorithm (RFC 1321) functions.

Closes: https://bugs.gentoo.org/912235