### PR TITLE
sys-apps/lshw: force c++14 in version 02.19.2b_p20210121

### DIFF
--- a/sys-apps/lshw/lshw-02.19.2b_p20210121-r4.ebuild
+++ b/sys-apps/lshw/lshw-02.19.2b_p20210121-r4.ebuild
@@ -65,6 +65,11 @@ src_prepare() {
 src_compile() {
 	tc-export CC CXX AR PKG_CONFIG
 	use static && append-ldflags -static
+	# Some toolchains are defaulting to C++17, which causes
+	# `<sys-apps/lshw-02.19.2b_p20220831` to break due to its use of the
+	# `register` keyword. Just pin it at 14, since future versions don't
+	# have this issue.
+	append-cxxflags '-std=c++14'
 
 	# Need two sep make statements to avoid parallel build issues. #588174
 	local sqlite=$(usex sqlite 1 0)


### PR DESCRIPTION
Clang has used C++17 as its default standard since clang-16 (released 17-Mar-2023). This version of lshw does not compile cleanly with this new standard. Keep it on C++14, since newer versions compile without issue.