### PR TITLE
dev-libs/jansson: Fix build with non-bfd linkers

### DIFF
--- a/dev-libs/jansson/files/jansson-2.14-default-symver-test.patch
+++ b/dev-libs/jansson/files/jansson-2.14-default-symver-test.patch
@@ -1,0 +1,55 @@
+From https://github.com/akheron/jansson/pull/666/commits/1e2ac681e5f39fc7a7e8b8deb2162a93976d4622 Mon Sep 17 00:00:00 2001
+From: Violet Purcell <vimproved@inventati.org>
+Date: Wed, 11 Oct 2023 20:51:57 -0400
+Subject: [PATCH] Port check for --default-symver to autoconf
+
+This commit ports the configure check for -Wl,--default-symver that is
+present in CMake to autoconf. This fixes building Jansson via autoconf
+with non-bfd linkers on glibc systems.
+
+Signed-off-by: Violet Purcell <vimproved@inventati.org>
+--- a/configure.ac
++++ b/configure.ac
+@@ -25,6 +25,9 @@ AC_TYPE_UINT16_T
+ AC_TYPE_UINT8_T
+ AC_TYPE_LONG_LONG_INT
+ 
++jansson_soversion="4"
++AC_SUBST([jansson_soversion])
++
+ AC_C_INLINE
+ case $ac_cv_c_inline in
+     yes) json_inline=inline;;
+@@ -138,8 +141,12 @@ AS_IF([test "x$with_Bsymbolic" = "xyes"], [JSON_BSYMBOLIC_LDFLAGS=-Wl[,]-Bsymbol
+ AC_SUBST(JSON_BSYMBOLIC_LDFLAGS)
+ 
+ # Enable symbol versioning on GNU libc
++m4_pattern_forbid([^AX_CHECK_LINK_FLAG$])
+ JSON_SYMVER_LDFLAGS=
+-AC_CHECK_DECL([__GLIBC__], [JSON_SYMVER_LDFLAGS=-Wl,--default-symver])
++AC_CHECK_DECL([__GLIBC__],
++  [AX_CHECK_LINK_FLAG([-Wl,--default-symver],
++    [JSON_SYMVER_LDFLAGS=-Wl,--default-symver],
++    [JSON_SYMVER_LDFLAGS=-Wl,--version-script,$ac_abs_confdir/jansson.sym])])
+ AC_SUBST([JSON_SYMVER_LDFLAGS])
+ 
+ AC_ARG_ENABLE([ossfuzzers],
+@@ -168,6 +175,7 @@ AC_SUBST([AM_CFLAGS])
+ 
+ AC_CONFIG_FILES([
+         jansson.pc
++	jansson.sym
+         Makefile
+         doc/Makefile
+         src/Makefile
+--- /dev/null
++++ b/jansson.sym.in
+@@ -0,0 +1,5 @@
++JANSSON_@jansson_soversion@ {
++	global:
++	*;
++};
++
+-- 
+2.42.0
+

--- a/dev-libs/jansson/jansson-2.14-r2.ebuild
+++ b/dev-libs/jansson/jansson-2.14-r2.ebuild
@@ -1,0 +1,49 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools
+
+DESCRIPTION="C library for encoding, decoding and manipulating JSON data"
+HOMEPAGE="https://www.digip.org/jansson/"
+SRC_URI="https://github.com/akheron/jansson/releases/download/v${PV}/${P}.tar.gz"
+
+LICENSE="MIT"
+SLOT="0/4"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~x64-macos"
+IUSE="doc static-libs"
+
+BDEPEND="
+	sys-devel/autoconf-archive
+	doc? ( dev-python/sphinx )
+"
+
+PATCHES=(
+	"${FILESDIR}/${P}-default-symver-test.patch"
+	"${FILESDIR}/${P}-test-symbols.patch"
+)
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_configure() {
+	econf $(use_enable static-libs static)
+}
+
+src_compile() {
+	default
+
+	if use doc ; then
+		emake html
+		HTML_DOCS=( doc/_build/html/. )
+	fi
+}
+
+src_install() {
+	default
+
+	find "${ED}" -name '*.la' -delete || die
+}


### PR DESCRIPTION
This patch ports the test for `-Wl,--default-symver` that exists in CMake to autoconf, which should fix building with non-bfd linkers on glibc.