### PR TITLE
sci-electronics/kicad: Revert EGL flag for stable

### DIFF
--- a/sci-electronics/kicad/kicad-7.0.1.ebuild
+++ b/sci-electronics/kicad/kicad-7.0.1.ebuild
@@ -35,6 +35,7 @@ REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 # Contains bundled pybind but it's patched for wx
 # See https://gitlab.com/kicad/code/kicad/-/commit/74e4370a9b146b21883d6a2d1df46c7a10bd0424
 # Depend on opencascade:0 to get unslotted variant (so we know path to it), bug #833301
+# Depend wxGTK version needs to be limited due to switch from EGL to GLX, bug #911120
 COMMON_DEPEND="
 	dev-db/unixODBC
 	dev-libs/boost:=[context,nls]
@@ -46,7 +47,7 @@ COMMON_DEPEND="
 	>=sci-libs/opencascade-7.3.0:0=
 	>=x11-libs/cairo-1.8.8:=
 	>=x11-libs/pixman-0.30
-	x11-libs/wxGTK:${WX_GTK_VER}[X,opengl]
+	<=x11-libs/wxGTK-3.2.2.1-r2:${WX_GTK_VER}[X,opengl]
 	sys-libs/zlib
 	$(python_gen_cond_dep '
 		dev-libs/boost:=[context,nls,python,${PYTHON_USEDEP}]
@@ -101,10 +102,7 @@ src_configure() {
 		-DKICAD_DOCS="${EPREFIX}/usr/share/doc/${PN}-doc-${PV}"
 
 		-DKICAD_SCRIPTING_WXPYTHON=ON
-		# wxWidgets does not support runtime selection of backends (GLX vs EGL),
-		# if enabled it can break KiCad depending on what wxGTK was compiled
-		# with, see bug #911120
-		-DKICAD_USE_EGL=OFF
+		-DKICAD_USE_EGL=ON
 
 		-DKICAD_BUILD_I18N="$(usex nls)"
 		-DKICAD_I18N_UNIX_STRICT_PATH="$(usex nls)"


### PR DESCRIPTION
In stable wxGTK is still built with EGL instead of GLX, so build KiCAD
with EGL enabled, but also limit the wxGTK version to prevent build
failures, in case GLX enabled wxGTK goes stable or the user unmasks it.

Since users cannot upgrade to -r1 due to build failures, it's better to
revert to no revision version. This should prevent unnecessary rebuilds
for anyone who has KiCad already installed.

Bug: https://bugs.gentoo.org/911120

Signed-off-by: Zoltan Puskas <zoltan@sinustrom.info>
