### PR TITLE
net-vpn/tailscale: fix build version reporting

### DIFF
--- a/net-vpn/tailscale/tailscale-1.46.1.ebuild
+++ b/net-vpn/tailscale/tailscale-1.46.1.ebuild
@@ -28,9 +28,9 @@ RESTRICT="test"
 # ebuild equivalent.
 build_dist() {
 	ego build -tags xversion -ldflags "
-		-X tailscale.com/version.Long=${VERSION_LONG}
-		-X tailscale.com/version.Short=${VERSION_SHORT}
-		-X tailscale.com/version.GitCommit=${VERSION_GIT_HASH}" "$@"
+		-X tailscale.com/version.longStamp=${VERSION_LONG}
+		-X tailscale.com/version.shortStamp=${VERSION_SHORT}
+		-X tailscale.com/version.gitCommitStamp=${VERSION_GIT_HASH}" "$@"
 }
 
 src_compile() {


### PR DESCRIPTION
Variables used to tag the reported version have changed https://github.com/tailscale/tailscale/commit/70a2929a12f246aa783684eca7f48cb4c8eb9d65