### PR TITLE
dev-lang/python: Only append -ffat-lto-objects with GCC

### DIFF
--- a/dev-lang/python/python-3.10.12.ebuild
+++ b/dev-lang/python/python-3.10.12.ebuild
@@ -161,7 +161,8 @@ src_configure() {
 	filter-flags -malign-double
 
 	# https://bugs.gentoo.org/700012
-	if is-flagq -flto || is-flagq '-flto=*'; then
+	# Only append -ffat-lto-objects with gcc, https://bugs.gentoo.org/912036.
+	if is-flagq -flto || is-flagq '-flto=*' && tc-is-gcc; then
 		append-cflags $(test-flags-CC -ffat-lto-objects)
 	fi
 

--- a/dev-lang/python/python-3.11.4.ebuild
+++ b/dev-lang/python/python-3.11.4.ebuild
@@ -148,7 +148,8 @@ src_configure() {
 	filter-flags -malign-double
 
 	# https://bugs.gentoo.org/700012
-	if is-flagq -flto || is-flagq '-flto=*'; then
+	# Only append -ffat-lto-objects with gcc, https://bugs.gentoo.org/912036.
+	if is-flagq -flto || is-flagq '-flto=*' && tc-is-gcc; then
 		append-cflags $(test-flags-CC -ffat-lto-objects)
 	fi
 

--- a/dev-lang/python/python-3.12.0_beta3.ebuild
+++ b/dev-lang/python/python-3.12.0_beta3.ebuild
@@ -148,7 +148,8 @@ src_configure() {
 	filter-flags -malign-double
 
 	# https://bugs.gentoo.org/700012
-	if is-flagq -flto || is-flagq '-flto=*'; then
+	# Only append -ffat-lto-objects with gcc, https://bugs.gentoo.org/912036.
+	if is-flagq -flto || is-flagq '-flto=*' && tc-is-gcc; then
 		append-cflags $(test-flags-CC -ffat-lto-objects)
 	fi
 

--- a/dev-lang/python/python-3.12.0_beta4.ebuild
+++ b/dev-lang/python/python-3.12.0_beta4.ebuild
@@ -148,7 +148,8 @@ src_configure() {
 	filter-flags -malign-double
 
 	# https://bugs.gentoo.org/700012
-	if is-flagq -flto || is-flagq '-flto=*'; then
+	# Only append -ffat-lto-objects with gcc, https://bugs.gentoo.org/912036.
+	if is-flagq -flto || is-flagq '-flto=*' && tc-is-gcc; then
 		append-cflags $(test-flags-CC -ffat-lto-objects)
 	fi
 

--- a/dev-lang/python/python-3.12.0_beta4_p1.ebuild
+++ b/dev-lang/python/python-3.12.0_beta4_p1.ebuild
@@ -148,7 +148,8 @@ src_configure() {
 	filter-flags -malign-double
 
 	# https://bugs.gentoo.org/700012
-	if is-flagq -flto || is-flagq '-flto=*'; then
+	# Only append -ffat-lto-objects with gcc, https://bugs.gentoo.org/912036.
+	if is-flagq -flto || is-flagq '-flto=*' && tc-is-gcc; then
 		append-cflags $(test-flags-CC -ffat-lto-objects)
 	fi
 

--- a/dev-lang/python/python-3.12.0_beta4_p2.ebuild
+++ b/dev-lang/python/python-3.12.0_beta4_p2.ebuild
@@ -148,7 +148,8 @@ src_configure() {
 	filter-flags -malign-double
 
 	# https://bugs.gentoo.org/700012
-	if is-flagq -flto || is-flagq '-flto=*'; then
+	# Only append -ffat-lto-objects with gcc, https://bugs.gentoo.org/912036.
+	if is-flagq -flto || is-flagq '-flto=*' && tc-is-gcc; then
 		append-cflags $(test-flags-CC -ffat-lto-objects)
 	fi
 

--- a/dev-lang/python/python-3.12.0_rc1.ebuild
+++ b/dev-lang/python/python-3.12.0_rc1.ebuild
@@ -148,7 +148,8 @@ src_configure() {
 	filter-flags -malign-double
 
 	# https://bugs.gentoo.org/700012
-	if is-flagq -flto || is-flagq '-flto=*'; then
+	# Only append -ffat-lto-objects with gcc, https://bugs.gentoo.org/912036.
+	if is-flagq -flto || is-flagq '-flto=*' && tc-is-gcc; then
 		append-cflags $(test-flags-CC -ffat-lto-objects)
 	fi
 

--- a/dev-lang/python/python-3.12.0_rc1_p1.ebuild
+++ b/dev-lang/python/python-3.12.0_rc1_p1.ebuild
@@ -148,7 +148,8 @@ src_configure() {
 	filter-flags -malign-double
 
 	# https://bugs.gentoo.org/700012
-	if is-flagq -flto || is-flagq '-flto=*'; then
+	# Only append -ffat-lto-objects with gcc, https://bugs.gentoo.org/912036.
+	if is-flagq -flto || is-flagq '-flto=*' && tc-is-gcc; then
 		append-cflags $(test-flags-CC -ffat-lto-objects)
 	fi
 

--- a/dev-lang/python/python-3.8.17.ebuild
+++ b/dev-lang/python/python-3.8.17.ebuild
@@ -150,7 +150,8 @@ src_configure() {
 	filter-flags -malign-double
 
 	# https://bugs.gentoo.org/700012
-	if is-flagq -flto || is-flagq '-flto=*'; then
+	# Only append -ffat-lto-objects with gcc, https://bugs.gentoo.org/912036.
+	if is-flagq -flto || is-flagq '-flto=*' && tc-is-gcc; then
 		append-cflags $(test-flags-CC -ffat-lto-objects)
 	fi
 

--- a/dev-lang/python/python-3.9.17.ebuild
+++ b/dev-lang/python/python-3.9.17.ebuild
@@ -157,7 +157,8 @@ src_configure() {
 	filter-flags -malign-double
 
 	# https://bugs.gentoo.org/700012
-	if is-flagq -flto || is-flagq '-flto=*'; then
+	# Only append -ffat-lto-objects with gcc, https://bugs.gentoo.org/912036.
+	if is-flagq -flto || is-flagq '-flto=*' && tc-is-gcc; then
 		append-cflags $(test-flags-CC -ffat-lto-objects)
 	fi
 


### PR DESCRIPTION
ffat-lto-objects was implemented in clang 17, but causes an ICE if combined with PGO. Since python builds with clang without ffat-lto-objects, condition the flag behind tc-is-gcc.

(Also, it seems that python appends ffat-lto-objects with gcc by itself now, at least in 3.12: https://github.com/python/cpython/blob/main/configure#L8593. Is this workaround necessary anymore?)

Closes: https://bugs.gentoo.org/912036