### PR TITLE
dev-ml/ocaml-ctypes: Fix installing ctypes-foreign library

### DIFF
--- a/dev-ml/ocaml-ctypes/metadata.xml
+++ b/dev-ml/ocaml-ctypes/metadata.xml
@@ -10,6 +10,6 @@
 		<name>Mark Wright</name>
 	</maintainer>
 	<upstream>
-		<remote-id type="github">ocamllabs/ocaml-ctypes</remote-id>
+		<remote-id type="github">yallop/ocaml-ctypes</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/dev-ml/ocaml-ctypes/ocaml-ctypes-0.21.1-r2.ebuild
+++ b/dev-ml/ocaml-ctypes/ocaml-ctypes-0.21.1-r2.ebuild
@@ -7,8 +7,8 @@ DUNE_PKG_NAME=ctypes
 inherit dune
 
 DESCRIPTION="Library for binding to C libraries using pure OCaml"
-HOMEPAGE="https://github.com/ocamllabs/ocaml-ctypes/"
-SRC_URI="https://github.com/ocamllabs/ocaml-ctypes/archive/${PV}.tar.gz -> ${P}.tar.gz"
+HOMEPAGE="https://github.com/yallop/ocaml-ctypes/"
+SRC_URI="https://github.com/yallop/ocaml-ctypes/archive/${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"

--- a/dev-ml/ocaml-ctypes/ocaml-ctypes-0.21.1-r2.ebuild
+++ b/dev-ml/ocaml-ctypes/ocaml-ctypes-0.21.1-r2.ebuild
@@ -26,3 +26,7 @@ RDEPEND="
 DEPEND="${RDEPEND}
 	test? ( dev-ml/ounit2 dev-ml/lwt )"
 REQUIRED_USE="ocamlopt"
+
+src_install() {
+	dune-install ctypes ctypes-foreign
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/911932
Closes: https://bugs.gentoo.org/911944