### PR TITLE
app-emulation/wine-{staging,vanilla}: Fix rpath bug on musl

### DIFF
--- a/app-emulation/wine-staging/files/wine-staging-8.13-rpath.patch
+++ b/app-emulation/wine-staging/files/wine-staging-8.13-rpath.patch
@@ -1,0 +1,15 @@
+Patch Source: https://gitlab.alpinelinux.org/alpine/aports/-/blob/master/community/wine/rpath.patch
+Alpine Bug: https://gitlab.alpinelinux.org/alpine/aports/-/issues/13249
+
+--- a/configure.ac
++++ b/configure.ac
+@@ -784,6 +784,9 @@ case $host_os in
+                         [WINELOADER_LDFLAGS="$WINELOADER_LDFLAGS -Wl,-z,max-page-size=0x1000"])
+         ;;
+     esac
++
++    # do this at the end because it needs double dollar for makefile
++    WINE_TRY_CFLAGS([-Wl,-rpath,\\\$ORIGIN],[UNIXLDFLAGS="$UNIXLDFLAGS '-Wl,-rpath,\$\$ORIGIN'"])
+     ;;
+ esac
+ 

--- a/app-emulation/wine-staging/wine-staging-8.13.ebuild
+++ b/app-emulation/wine-staging/wine-staging-8.13.ebuild
@@ -160,6 +160,7 @@ QA_TEXTRELS="usr/lib/*/wine/i386-unix/*.so" # uses -fno-PIC -Wl,-z,notext
 PATCHES=(
 	"${FILESDIR}"/${PN}-7.17-noexecstack.patch
 	"${FILESDIR}"/${PN}-7.20-unwind.patch
+	"${FILESDIR}"/${PN}-8.13-rpath.patch
 )
 
 pkg_pretend() {

--- a/app-emulation/wine-staging/wine-staging-9999.ebuild
+++ b/app-emulation/wine-staging/wine-staging-9999.ebuild
@@ -160,6 +160,7 @@ QA_TEXTRELS="usr/lib/*/wine/i386-unix/*.so" # uses -fno-PIC -Wl,-z,notext
 PATCHES=(
 	"${FILESDIR}"/${PN}-7.17-noexecstack.patch
 	"${FILESDIR}"/${PN}-7.20-unwind.patch
+	"${FILESDIR}"/${PN}-8.13-rpath.patch
 )
 
 pkg_pretend() {

--- a/app-emulation/wine-vanilla/files/wine-vanilla-8.13-rpath.patch
+++ b/app-emulation/wine-vanilla/files/wine-vanilla-8.13-rpath.patch
@@ -1,0 +1,15 @@
+Patch Source: https://gitlab.alpinelinux.org/alpine/aports/-/blob/master/community/wine/rpath.patch
+Alpine Bug: https://gitlab.alpinelinux.org/alpine/aports/-/issues/13249
+
+--- a/configure.ac
++++ b/configure.ac
+@@ -784,6 +784,9 @@ case $host_os in
+                         [WINELOADER_LDFLAGS="$WINELOADER_LDFLAGS -Wl,-z,max-page-size=0x1000"])
+         ;;
+     esac
++
++    # do this at the end because it needs double dollar for makefile
++    WINE_TRY_CFLAGS([-Wl,-rpath,\\\$ORIGIN],[UNIXLDFLAGS="$UNIXLDFLAGS '-Wl,-rpath,\$\$ORIGIN'"])
+     ;;
+ esac
+ 

--- a/app-emulation/wine-vanilla/wine-vanilla-8.13.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-8.13.ebuild
@@ -146,6 +146,7 @@ QA_TEXTRELS="usr/lib/*/wine/i386-unix/*.so" # uses -fno-PIC -Wl,-z,notext
 PATCHES=(
 	"${FILESDIR}"/${PN}-7.0-noexecstack.patch
 	"${FILESDIR}"/${PN}-7.20-unwind.patch
+	"${FILESDIR}"/${PN}-8.13-rpath.patch
 )
 
 pkg_pretend() {

--- a/app-emulation/wine-vanilla/wine-vanilla-9999.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-9999.ebuild
@@ -146,6 +146,7 @@ QA_TEXTRELS="usr/lib/*/wine/i386-unix/*.so" # uses -fno-PIC -Wl,-z,notext
 PATCHES=(
 	"${FILESDIR}"/${PN}-7.0-noexecstack.patch
 	"${FILESDIR}"/${PN}-7.20-unwind.patch
+	"${FILESDIR}"/${PN}-8.13-rpath.patch
 )
 
 pkg_pretend() {


### PR DESCRIPTION
Patch is from https://github.com/alpinelinux/aports/blob/master/community/wine/rpath.patch, Alpine bug is https://gitlab.alpinelinux.org/alpine/aports/-/blob/master/community/wine/rpath.patch.