### PR TITLE
profiles: restore KERNEL=Winnt for embedded targets

### DIFF
--- a/profiles/embedded/make.defaults
+++ b/profiles/embedded/make.defaults
@@ -24,7 +24,7 @@ USE_EXPAND_UNPREFIXED="ARCH"
 USE_EXPAND_IMPLICIT="ARCH ELIBC KERNEL"
 USE_EXPAND_VALUES_ARCH="alpha amd64 amd64-linux arm arm64 hppa ia64 loong m68k mips ppc ppc64 ppc64-linux ppc-macos riscv s390 sparc x64-macos x64-solaris x86 x86-linux"
 USE_EXPAND_VALUES_ELIBC="bionic Darwin glibc mingw musl SunOS"
-USE_EXPAND_VALUES_KERNEL="Darwin linux SunOS"
+USE_EXPAND_VALUES_KERNEL="Darwin linux SunOS Winnt"
 
 # Env vars to expand into USE vars.  Modifying this requires prior
 # discussion on gentoo-dev@lists.gentoo.org.


### PR DESCRIPTION
which is needed to cross-merge packages using CMake for MinGW.

Bug: https://bugs.gentoo.org/910605