### PR TITLE
sci-libs/spr: fix https:// schema in HOMEPAGE url

### DIFF
--- a/sci-libs/spr/spr-3.3.2.ebuild
+++ b/sci-libs/spr/spr-3.3.2.ebuild
@@ -6,7 +6,7 @@ EAPI=6
 inherit autotools
 
 DESCRIPTION="Statistical analysis and machine learning library"
-HOMEPAGE="http://statpatrec.sourceforge.net/"
+HOMEPAGE="https://statpatrec.sourceforge.net/"
 SRC_URI="mirror://sourceforge/statpatrec/${P^^}.tar.gz"
 
 LICENSE="GPL-2"


### PR DESCRIPTION
As reported in https://repology.org/repository/gentoo/problems