### PR TITLE
net-wireless/bladerf-fpga: update to https:// schema

### DIFF
--- a/net-wireless/bladerf-fpga/bladerf-fpga-0.12.0.ebuild
+++ b/net-wireless/bladerf-fpga/bladerf-fpga-0.12.0.ebuild
@@ -4,15 +4,15 @@
 EAPI=7
 
 DESCRIPTION="bladeRF FPGA bitstreams"
-HOMEPAGE="http://nuand.com/fpga.php"
+HOMEPAGE="https://nuand.com/fpga.php"
 
 #fpga code is open source, but uses a proprietary toolchain to build
 #automated builds from git are available, but likely unneeded
 #http://hoopycat.com/bladerf_builds/
-SRC_URI="xA4? ( http://nuand.com/fpga/v${PV}/hostedxA4.rbf -> hostedxA4-${PV}.rbf )
-		xA9? ( http://nuand.com/fpga/v${PV}/hostedxA9.rbf -> hostedxA9-${PV}.rbf )
-		x40? ( http://nuand.com/fpga/v${PV}/hostedx40.rbf -> hostedx40-${PV}.rbf )
-		x115? ( http://nuand.com/fpga/v${PV}/hostedx115.rbf -> hostedx115-${PV}.rbf )"
+SRC_URI="xA4? ( https://nuand.com/fpga/v${PV}/hostedxA4.rbf -> hostedxA4-${PV}.rbf )
+		xA9? ( https://nuand.com/fpga/v${PV}/hostedxA9.rbf -> hostedxA9-${PV}.rbf )
+		x40? ( https://nuand.com/fpga/v${PV}/hostedx40.rbf -> hostedx40-${PV}.rbf )
+		x115? ( https://nuand.com/fpga/v${PV}/hostedx115.rbf -> hostedx115-${PV}.rbf )"
 
 LICENSE="MIT"
 SLOT="0"

--- a/net-wireless/bladerf-fpga/bladerf-fpga-0.15.0.ebuild
+++ b/net-wireless/bladerf-fpga/bladerf-fpga-0.15.0.ebuild
@@ -4,15 +4,15 @@
 EAPI=8
 
 DESCRIPTION="bladeRF FPGA bitstreams"
-HOMEPAGE="http://nuand.com/fpga.php"
+HOMEPAGE="https://nuand.com/fpga.php"
 
 #fpga code is open source, but uses a proprietary toolchain to build
 #automated builds from git are available, but likely unneeded
 #http://hoopycat.com/bladerf_builds/
-SRC_URI="xA4? ( http://nuand.com/fpga/v${PV}/hostedxA4.rbf -> hostedxA4-${PV}.rbf )
-		xA9? ( http://nuand.com/fpga/v${PV}/hostedxA9.rbf -> hostedxA9-${PV}.rbf )
-		x40? ( http://nuand.com/fpga/v${PV}/hostedx40.rbf -> hostedx40-${PV}.rbf )
-		x115? ( http://nuand.com/fpga/v${PV}/hostedx115.rbf -> hostedx115-${PV}.rbf )"
+SRC_URI="xA4? ( https://nuand.com/fpga/v${PV}/hostedxA4.rbf -> hostedxA4-${PV}.rbf )
+		xA9? ( https://nuand.com/fpga/v${PV}/hostedxA9.rbf -> hostedxA9-${PV}.rbf )
+		x40? ( https://nuand.com/fpga/v${PV}/hostedx40.rbf -> hostedx40-${PV}.rbf )
+		x115? ( https://nuand.com/fpga/v${PV}/hostedx115.rbf -> hostedx115-${PV}.rbf )"
 
 LICENSE="MIT"
 SLOT="0"


### PR DESCRIPTION
Includes changes to:  
bladerf-fpga-0.12.0.ebuild  
bladerf-fpga-0.15.0.ebuild  
as reported in https://repology.org/repository/gentoo/problems