### PR TITLE
dev-embedded/u-boot-tools: Fix missing BDEPENDs

### DIFF
--- a/dev-embedded/u-boot-tools/files/disable-unused-mkeficapsule.patch
+++ b/dev-embedded/u-boot-tools/files/disable-unused-mkeficapsule.patch
@@ -1,0 +1,14 @@
+Disable unused mkeficapsule
+
+`CONFIG_TOOLS_MKEFICAPSULE` requires gnutls to build. Since we don't actually
+expose the tool, we can just disable it.
+
+diff -ur a/configs/tools-only_defconfig b/configs/tools-only_defconfig
+--- a/configs/tools-only_defconfig	2023-01-09 09:07:33.000000000 -0700
++++ b/configs/tools-only_defconfig	2023-08-11 14:01:50.151294889 -0600
+@@ -33,4 +33,4 @@
+ # CONFIG_VIRTIO_SANDBOX is not set
+ # CONFIG_GENERATE_ACPI_TABLE is not set
+ # CONFIG_EFI_LOADER is not set
+-CONFIG_TOOLS_MKEFICAPSULE=y
++# CONFIG_TOOLS_MKEFICAPSULE is not set

--- a/dev-embedded/u-boot-tools/files/disable-unused-pylibfdt.patch
+++ b/dev-embedded/u-boot-tools/files/disable-unused-pylibfdt.patch
@@ -1,0 +1,17 @@
+Disable unused pylibfdt
+
+The `imply BINMAN` causes `pylibfdt` to be built, which requires python. We
+don't currently expose `pylibfdt`, or declare python dependencies, so disable
+it.
+
+diff -ur a/arch/Kconfig b/arch/Kconfig
+--- a/arch/Kconfig	2023-01-09 09:07:33.000000000 -0700
++++ b/arch/Kconfig	2023-08-11 14:01:05.998403114 -0600
+@@ -205,7 +205,6 @@
+ 	imply KEYBOARD
+ 	imply PHYSMEM
+ 	imply GENERATE_ACPI_TABLE
+-	imply BINMAN
+ 
+ config SH
+ 	bool "SuperH architecture"

--- a/dev-embedded/u-boot-tools/u-boot-tools-2023.10-r1.ebuild
+++ b/dev-embedded/u-boot-tools/u-boot-tools-2023.10-r1.ebuild
@@ -19,11 +19,16 @@ IUSE="envtools"
 RDEPEND="dev-libs/openssl:="
 DEPEND="${RDEPEND}"
 BDEPEND="
-	dev-lang/swig
 	app-alternatives/yacc
 	app-alternatives/lex
+	sys-apps/which
 	virtual/pkgconfig
 "
+
+PATCHES=(
+	"${FILESDIR}/disable-unused-mkeficapsule.patch"
+	"${FILESDIR}/disable-unused-pylibfdt.patch"
+)
 
 src_prepare() {
 	default


### PR DESCRIPTION
This package currently shows the following errors:

```
Traceback (most recent call last):
  File "scripts/dtc/pylibfdt/setup.py", line 23, in <module>
    from setuptools import setup, Extension
ModuleNotFoundError: No module named 'setuptools'
```

```
tools/mkeficapsule.c:21:10: fatal error: 'gnutls/gnutls.h' file not found
```

```
./scripts/dtc-version.sh: line 18: which: command not found
```

This change fixes the errors by not compiling pylibfdt and mkeficapsule.
It also adds the missing `which` dependency.
