### PR TITLE
media-sound/cmus: Fix build errors on clang only systems

### DIFF
--- a/media-sound/cmus/cmus-2.10.0-r2.ebuild
+++ b/media-sound/cmus/cmus-2.10.0-r2.ebuild
@@ -46,7 +46,7 @@ DEPEND="
 	mp4? ( media-libs/libmp4v2:0 )
 	musepack? ( media-sound/musepack-tools )
 	opus? ( media-libs/opusfile )
-	pulseaudio? ( media-libs/libpulse )
+	pulseaudio? ( media-sound/pulseaudio )
 	sndio? ( media-sound/sndio )
 	systemd? ( sys-apps/systemd )
 	tremor? ( media-libs/tremor )


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/724702
Closes: https://bugs.gentoo.org/893162

In the first bug we have to make `./configure` honor the user's variables by assigning them to the variables actually used by the build system, like it has been previously done in `src_compile`. Since `./configure` will save these values for future invocations of `make` we just need to move the definitions.

For the second, we have to stop adding `-latomic` unconditionally and, instead, use the convenient `append-atomic-flags` and make sure that its result is used by the build.

Unfortunately, I don't have access to a system in which `append-atomic-flags` does anything so I couldn't test that case outside of modifying the `$LIBS` variables manually.

After this PR, there is still a build error with `cmus-9999` and a runtime issue with `cmus-2.10.0-r2` (https://github.com/cmus/cmus/issues/1287) but this commit should be enough to get a buildable version of cmus for the clang only folks.