### PR TITLE
dev-lang/rust-bin: add check for clang-runtime[libcxx]

### DIFF
--- a/profiles/features/llvm/package.mask
+++ b/profiles/features/llvm/package.mask
@@ -1,0 +1,11 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+# Joonas Niilola <juippis@gentoo.org> (2023-08-17) 
+# sys-devel/clang-common[default-libcxx] &&
+# sys-devel/clang-runtime[libcxx] aren't compatible with most
+# pre-compiled binary packages provided by upstreams, like rust-bin,
+# firefox-bin, etc. Append this list as needed. Bug #912154
+dev-lang/rust-bin
+mail-client/thunderbird-bin
+www-client/firefox-bin


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/912154