### PR TITLE
net-misc/r8168: fixed build with kernel 6.4.10+

### DIFF
--- a/net-misc/r8168/files/r8168-8.051.02-6.4.10-fix.patch
+++ b/net-misc/r8168/files/r8168-8.051.02-6.4.10-fix.patch
@@ -1,0 +1,17 @@
+Fixed build with kernels 6.4.10+
+Gentoo Bug: https://bugs.gentoo.org/912242
+See also:   https://github.com/mtorromeo/r8168/issues/54
+
+---
+--- a/src/r8168_n.c     2023-08-13 03:33:06.977422132 +0400
++++ b/src/r8168_n.c     2023-08-13 03:38:39.767005101 +0400
+@@ -81,6 +81,10 @@
+ #include <linux/mdio.h>
+ #endif
+
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,4,10)
++#include <net/gso.h>
++#endif
++
+ #include <asm/io.h>
+ #include <asm/irq.h>

--- a/net-misc/r8168/r8168-8.051.02.ebuild
+++ b/net-misc/r8168/r8168-8.051.02.ebuild
@@ -26,6 +26,7 @@ WARNING_R8169="CONFIG_R8169 is enabled. ${P} will not be loaded unless kernel dr
 
 PATCHES=(
 	"${FILESDIR}/${PN}-8.051.02-6.1-fix.patch"
+	"${FILESDIR}/${P}-6.4.10-fix.patch" # bug 912242
 )
 
 pkg_setup() {


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/912242