### PR TITLE
net-dialup/minicom: Fix incorrect BDEPEND

### DIFF
--- a/net-dialup/minicom/minicom-2.8-r3.ebuild
+++ b/net-dialup/minicom/minicom-2.8-r3.ebuild
@@ -23,7 +23,7 @@ RDEPEND="
 
 BDEPEND="
 	virtual/pkgconfig
-	nls? ( sys-devel/gettext )
+	sys-devel/gettext
 "
 
 PATCHES=(


### PR DESCRIPTION
gettext is required regardless if the nls USE flag is set. If gettext
isn't installed we get the following errors:
```
aclocal-1.16: warning: couldn't open directory 'm4': No such file or directory
configure.ac:27: warning: macro 'AM_ICONV_LINK' not found in library
configure.ac:125: warning: macro 'AM_GNU_GETTEXT' not found in library
configure.ac:126: warning: macro 'AM_GNU_GETTEXT_VERSION' not found in library
```

Signed-off-by: Raul E Rangel <rrangel@chromium.org>
