### PR TITLE
net-analyzer/netperf: Fix dependencies

### DIFF
--- a/net-analyzer/netperf/netperf-2.7.0-r5.ebuild
+++ b/net-analyzer/netperf/netperf-2.7.0-r5.ebuild
@@ -14,11 +14,14 @@ LICENSE="netperf"
 SLOT="0"
 IUSE="demo sctp"
 
-DEPEND="
+RDEPEND="
 	acct-group/netperf
 	acct-user/netperf
 "
-RDEPEND="${DEPEND}"
+BDEPEND="
+	sys-devel/gnuconfig
+	${RDEPEND}
+"
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-fix-scripts.patch


### PR DESCRIPTION
The acct- dependencies should be BDEPEND instead of DEPEND.
We also need gnuconfig so that the config.sub will get patched
with `econf`. Otherwise we get the following error:

```
configure: loading site script /usr/share/config.site
configure: loading site script /usr/share/crossdev/include/site/linux
configure: loading site script /usr/share/crossdev/include/site/linux-gnu
checking build system type... x86_64-pc-linux-gnu
checking host system type... Invalid configuration `aarch64-cros-linux-gnu': machine `aarch64-cros' not recognized
configure: error: /bin/sh ./config.sub aarch64-cros-linux-gnu failed
```

vs a good run that has gnuconfig installed prints the following:
```
>>> Configuring source in /build/arm64-generic/tmp/portage/net-analyzer/netperf-2.7.0-r4/work/netperf-2.7.0 ...
 * econf: updating netperf-2.7.0/config.guess with /usr/share/gnuconfig/config.guess
 * econf: updating netperf-2.7.0/config.sub with /usr/share/gnuconfig/config.sub
```

Signed-off-by: Raul E Rangel <rrangel@chromium.org>
