### PR TITLE
sys-devel/automake: Cleanup depends

### DIFF
--- a/dev-build/automake/automake-1.16.5-r2.ebuild
+++ b/dev-build/automake/automake-1.16.5-r2.ebuild
@@ -50,10 +50,11 @@ RDEPEND="
 	>=dev-build/autoconf-2.69:*
 	sys-devel/gnuconfig
 "
-DEPEND="${RDEPEND}"
 BDEPEND="
 	app-alternatives/gzip
 	sys-apps/help2man
+	dev-build/autoconf-wrapper
+	dev-build/autoconf
 	test? (
 		${PYTHON_DEPS}
 		dev-util/dejagnu

--- a/dev-build/automake/automake-9999.ebuild
+++ b/dev-build/automake/automake-9999.ebuild
@@ -47,10 +47,11 @@ RDEPEND="
 	>=dev-build/autoconf-2.69:*
 	sys-devel/gnuconfig
 "
-DEPEND="${RDEPEND}"
 BDEPEND="
 	app-alternatives/gzip
 	sys-apps/help2man
+	dev-build/autoconf-wrapper
+	dev-build/autoconf
 	test? (
 		${PYTHON_DEPS}
 		dev-util/dejagnu


### PR DESCRIPTION
The automake ./bootstrap script requires the `autom4te` tool.
```
: ${AUTOM4TE=autom4te}
export AUTOM4TE  # ditto
```

If it's not installed the package fails with the following error:
```
sh: line 1: autom4te: command not found
aclocal.tmp: error: autom4te failed with exit status: 127
 * ERROR: sys-devel/automake-1.16.5-r1::portage-stable failed (prepare phase):
 *   (no error message)
 *
 * Call stack:
 *               ebuild.sh, line  125:  Called src_prepare
 *             environment, line 2813:  Called die
 * The specific snippet of code:
 *       ./bootstrap || die;
```

We also need to add autoconf so the wrapper doesn't fail:
```
ac-wrapper: Unable to locate any usuable version of autoconf.
```

We also don't need to declare any DEPEND.

Signed-off-by: Raul E Rangel <rrangel@chromium.org>
