### PR TITLE
net-dialup/lrzsz: Add missing gettext BDEPEND

### DIFF
--- a/net-dialup/lrzsz/lrzsz-0.12.20-r7.ebuild
+++ b/net-dialup/lrzsz/lrzsz-0.12.20-r7.ebuild
@@ -16,6 +16,8 @@ IUSE="nls"
 
 DEPEND="nls? ( virtual/libintl )"
 
+BDEPEND="sys-devel/gettext"
+
 PATCHES=(
 	"${FILESDIR}"/${PN}-autotools.patch
 	"${FILESDIR}"/${PN}-implicit-decl.patch


### PR DESCRIPTION
`gettext` is a required BDEPEND, otherwise we get the following errors:
```
./configure: line 5497: AM_GNU_GETTEXT: command not found
...
configure: WARNING: unrecognized options: --disable-nls
...
make[2]: *** No rule to make target 'all-@USE_INCLUDED_LIBINTL@', needed by 'all'.  Stop.
```

Signed-off-by: Raul E Rangel <rrangel@chromium.org>
