### PR TITLE
net-mail/checkpassword-pam: Fix call to undeclared library function s…

### DIFF
--- a/net-mail/checkpassword-pam/checkpassword-pam-0.99-r2.ebuild
+++ b/net-mail/checkpassword-pam/checkpassword-pam-0.99-r2.ebuild
@@ -1,0 +1,24 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="checkpassword-compatible authentication program w/pam support"
+HOMEPAGE="http://checkpasswd-pam.sourceforge.net/"
+SRC_URI="mirror://sourceforge/checkpasswd-pam/${P}.tar.gz"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm64 ~hppa ~ppc ~riscv ~x86"
+
+DEPEND=">=sys-libs/pam-0.75"
+
+DOCS=(
+	AUTHORS
+	NEWS
+	README
+)
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-0.99-clang16-build-fix.patch
+)

--- a/net-mail/checkpassword-pam/files/checkpassword-pam-0.99-clang16-build-fix.patch
+++ b/net-mail/checkpassword-pam/files/checkpassword-pam-0.99-clang16-build-fix.patch
@@ -1,0 +1,11 @@
+Bug: https://bugs.gentoo.org/897930
+--- a/getopt.c
++++ b/getopt.c
+@@ -38,6 +38,7 @@
+ #endif
+ 
+ #include <stdio.h>
++#include <string.h>
+ 
+ /* Comment out all this code if we are using the GNU C Library, and are not
+    actually compiling the library itself.  This code is part of the GNU C


### PR DESCRIPTION
…trcmp

Closes: https://bugs.gentoo.org/897930