### PR TITLE
dev-vcs/git: Add missing BDEPEND

### DIFF
--- a/dev-vcs/git/git-2.39.2-r1.ebuild
+++ b/dev-vcs/git/git-2.39.2-r1.ebuild
@@ -120,6 +120,7 @@ BDEPEND="
 		app-text/xmlto
 		sys-apps/texinfo
 	)
+	curl? ( net-misc/curl )
 	keyring? ( virtual/pkgconfig )
 	nls? ( sys-devel/gettext )
 	test? (	app-crypt/gnupg	)


### PR DESCRIPTION
We also need to declare curl as a BDEPEND because we require the
`curl-config` command. i.e.,
```
make: curl-config: Command not found

ld.lld: error: undefined symbol: curl_easy_setopt
>>> referenced by http-walker.c:381 (/build/arm64-generic/tmp/portage/dev-vcs/git-2.39.2/work/git-2.39.2/http-walker.c:381)
>>>               http-walker.o:(fetch_alternates)
>>> referenced by http-walker.c:382 (/build/arm64-generic/tmp/portage/dev-vcs/git-2.39.2/work/git-2.39.2/http-walker.c:382)
>>>               http-walker.o:(fetch_alternates)
>>> referenced by http-walker.c:383 (/build/arm64-generic/tmp/portage/dev-vcs/git-2.39.2/work/git-2.39.2/http-walker.c:383)
>>>               http-walker.o:(fetch_alternates)
>>> referenced 109 more times
```

BUG=b:278728702
TEST=BOARD=arm64-generic bazel build @portage//internal/packages/stage2/target/board/portage-stable/dev-vcs/git:2.39.2-r1

Change-Id: I16e303367cb9092780d1e4ad20bd3c3d789669d2
Signed-off-by: Raul E Rangel <rrangel@chromium.org>
