### PR TITLE
dev-libs/hiredis: Correct prefix in `hiredis_ssl.pc`

### DIFF
--- a/dev-libs/hiredis/hiredis-1.0.2-r3.ebuild
+++ b/dev-libs/hiredis/hiredis-1.0.2-r3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -48,7 +48,7 @@ src_compile() {
 	# The static lib re-uses the same objects as the shared lib, so
 	# overhead is low w/creating it all the time.  It's also needed
 	# by the tests.
-	_build dynamic static hiredis.pc
+	_build dynamic static hiredis{,_ssl}.pc
 }
 
 src_test() {

--- a/dev-libs/hiredis/hiredis-1.1.0-r1.ebuild
+++ b/dev-libs/hiredis/hiredis-1.1.0-r1.ebuild
@@ -54,7 +54,7 @@ src_compile() {
 	# The static lib re-uses the same objects as the shared lib, so
 	# overhead is low w/creating it all the time.  It's also needed
 	# by the tests.
-	_build dynamic static hiredis.pc
+	_build dynamic static hiredis{,_ssl}.pc
 }
 
 src_test() {


### PR DESCRIPTION
Ensure `hiredis_ssl.pc` is generated during the compile phase. Without this, it contains the `$ED` prefix from the install phase. It's safe to generate it, even if not installed when `USE=-ssl` is specified.