### PR TITLE
distutils-r1.eclass: append scikit-build-core to documentation.

### DIFF
--- a/eclass/distutils-r1.eclass
+++ b/eclass/distutils-r1.eclass
@@ -129,6 +129,8 @@ esac
 #
 # - poetry - poetry-core backend
 #
+# - scikit-build-core - scikit-build-core backend
+#
 # - setuptools - distutils or setuptools (incl. legacy mode)
 #
 # - sip - sipbuild backend


### PR DESCRIPTION
To complete 5b29e5b1a393c21db9974de5c2d01e6dc482d4b9.