### PR TITLE
net-misc/r8152: Fix build issues for kernel 6.4.10+

### DIFF
--- a/net-misc/r8152/files/r8152-2.16.3-kernel-6.4.10-fix.patch
+++ b/net-misc/r8152/files/r8152-2.16.3-kernel-6.4.10-fix.patch
@@ -1,0 +1,27 @@
+From: https://github.com/wget/realtek-r8152-linux/pull/33.patch
+From ea0387211368754fb1d3fe9f72ddc766ba2dacce Mon Sep 17 00:00:00 2001
+From: Martin Pecka <peckama2@fel.cvut.cz>
+Date: Mon, 14 Aug 2023 13:44:36 +0200
+Subject: [PATCH] Fixed compatibility with Linux 6.4.10+
+
+---
+ r8152.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/r8152.c b/r8152.c
+index c3ba2ca..47aad6d 100644
+--- a/r8152.c
++++ b/r8152.c
+@@ -25,6 +25,12 @@
+ #include <linux/ip.h>
+ #include <linux/ipv6.h>
+ #include <net/ip6_checksum.h>
++// Linux 6.4.10 added net/gso.h
++#if defined __has_include
++#if __has_include (<net/gso.h>)
++#include <net/gso.h>
++#endif
++#endif
+ #include <linux/usb/cdc.h>
+ #include <linux/suspend.h>
+ #include <linux/atomic.h>

--- a/net-misc/r8152/r8152-2.16.3-r1.ebuild
+++ b/net-misc/r8152/r8152-2.16.3-r1.ebuild
@@ -23,8 +23,10 @@ IUSE="+center-tap-short"
 PATCHES=(
 	"${FILESDIR}"/${PN}-2.16.3-kernel-5.19-fix.patch
 	"${FILESDIR}"/${PN}-2.16.3-kernel-6.1-fix.patch
+	"${FILESDIR}"/${PN}-2.16.3-kernel-6.4.10-fix.patch
 	"${FILESDIR}"/${PN}-2.16.3-asus-c5000-support.patch
 )
+
 
 src_compile() {
 	local modlist=( ${PN}=kernel/net/usb:. )

--- a/net-misc/r8152/r8152-2.16.3.ebuild
+++ b/net-misc/r8152/r8152-2.16.3.ebuild
@@ -25,6 +25,7 @@ IUSE="+center-tap-short"
 PATCHES=(
 	"${FILESDIR}"/${PN}-2.16.3-kernel-5.19-fix.patch
 	"${FILESDIR}"/${PN}-2.16.3-kernel-6.1-fix.patch
+	"${FILESDIR}"/${PN}-2.16.3-kernel-6.4.10-fix.patch
 )
 
 pkg_setup() {


### PR DESCRIPTION
Build of this module was broken by a recent kernel update; this change allows the module to build on 6.4.10+ now as well as against older kernels.

Closes: https://bugs.gentoo.org/912330