### PR TITLE
sys-auth/elogind: enable py3.12

### DIFF
--- a/sys-auth/elogind/elogind-252.9.ebuild
+++ b/sys-auth/elogind/elogind-252.9.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{10..11} )
+PYTHON_COMPAT=( python3_{10..12} )
 
 if [[ ${PV} = *9999* ]]; then
 	EGIT_BRANCH="v252-stable"


### PR DESCRIPTION
No new test failures.