### PR TITLE
dev-python/pyelftools: enable py3.12

### DIFF
--- a/dev-python/pyelftools/pyelftools-0.29.ebuild
+++ b/dev-python/pyelftools/pyelftools-0.29.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{10..12} )
 
 inherit distutils-r1
 


### PR DESCRIPTION
Drops py3.9 as well. Tests pass.