### PR TITLE
gui-wm/gamescope: add x11-libs/libXmu to BDEPEND

### DIFF
--- a/gui-wm/gamescope/gamescope-3.11.51.ebuild
+++ b/gui-wm/gamescope/gamescope-3.11.51.ebuild
@@ -32,6 +32,7 @@ RDEPEND="
 	x11-libs/libXext
 	x11-libs/libXfixes
 	x11-libs/libxkbcommon
+	x11-libs/libXmu
 	x11-libs/libXrender
 	x11-libs/libXres
 	x11-libs/libXtst

--- a/gui-wm/gamescope/gamescope-3.12.0.ebuild
+++ b/gui-wm/gamescope/gamescope-3.12.0.ebuild
@@ -32,6 +32,7 @@ RDEPEND="
 	x11-libs/libXext
 	x11-libs/libXfixes
 	x11-libs/libxkbcommon
+	x11-libs/libXmu
 	x11-libs/libXrender
 	x11-libs/libXres
 	x11-libs/libXtst


### PR DESCRIPTION
gamescope needs libXmu to build. I've confirmed in a gentoo/stage3 container that:

- the build fails without said package
- the build succeeds with said package

Bug: https://bugs.gentoo.org/912423