### PR TITLE
sys-devel/clang-common: Install config files for all supported ABIs

### DIFF
--- a/sys-devel/clang-common/clang-common-17.0.0.9999.ebuild
+++ b/sys-devel/clang-common/clang-common-17.0.0.9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit bash-completion-r1 llvm.org
+inherit bash-completion-r1 llvm.org multilib
 
 DESCRIPTION="Common files shared between multiple slots of clang"
 HOMEPAGE="https://llvm.org/"
@@ -169,15 +169,20 @@ src_install() {
 		EOF
 	fi
 
-	# We only install config files for ${CHOST} because unprefixed tools
+	# We only install config files for supported ABIs because unprefixed tools
 	# might be used for crosscompilation where e.g. PIE may not be supported.
 	# See bug #912237 and bug #901247.
-	local tool
-	for tool in ${CHOST}-clang{,++,-cpp}; do
-		newins - "${tool}.cfg" <<-EOF
-			# This configuration file is used by ${tool} driver.
-			@gentoo-common.cfg
-		EOF
+	# Just ${CHOST} wont do due to bug #912685.
+	for abi in $(get_all_abis); do
+		local abi_chost=$(get_abi_CHOST "${abi}")
+
+		local tool
+		for tool in ${abi_chost}-clang{,++,-cpp}; do
+			newins - "${tool}.cfg" <<-EOF
+				# This configuration file is used by ${tool} driver.
+				@gentoo-common.cfg
+			EOF
+		done
 	done
 }
 

--- a/sys-devel/clang-common/clang-common-17.0.0_rc2-r2.ebuild
+++ b/sys-devel/clang-common/clang-common-17.0.0_rc2-r2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit bash-completion-r1 llvm.org
+inherit bash-completion-r1 llvm.org multilib
 
 DESCRIPTION="Common files shared between multiple slots of clang"
 HOMEPAGE="https://llvm.org/"
@@ -169,15 +169,20 @@ src_install() {
 		EOF
 	fi
 
-	# We only install config files for ${CHOST} because unprefixed tools
+	# We only install config files for supported ABIs because unprefixed tools
 	# might be used for crosscompilation where e.g. PIE may not be supported.
 	# See bug #912237 and bug #901247.
-	local tool
-	for tool in ${CHOST}-clang{,++,-cpp}; do
-		newins - "${tool}.cfg" <<-EOF
-			# This configuration file is used by ${tool} driver.
-			@gentoo-common.cfg
-		EOF
+	# Just ${CHOST} wont do due to bug #912685.
+	for abi in $(get_all_abis); do
+		local abi_chost=$(get_abi_CHOST "${abi}")
+
+		local tool
+		for tool in ${abi_chost}-clang{,++,-cpp}; do
+			newins - "${tool}.cfg" <<-EOF
+				# This configuration file is used by ${tool} driver.
+				@gentoo-common.cfg
+			EOF
+		done
 	done
 }
 

--- a/sys-devel/clang-common/clang-common-18.0.0.9999.ebuild
+++ b/sys-devel/clang-common/clang-common-18.0.0.9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit bash-completion-r1 llvm.org
+inherit bash-completion-r1 llvm.org multilib
 
 DESCRIPTION="Common files shared between multiple slots of clang"
 HOMEPAGE="https://llvm.org/"
@@ -169,15 +169,20 @@ src_install() {
 		EOF
 	fi
 
-	# We only install config files for ${CHOST} because unprefixed tools
+	# We only install config files for supported ABIs because unprefixed tools
 	# might be used for crosscompilation where e.g. PIE may not be supported.
 	# See bug #912237 and bug #901247.
-	local tool
-	for tool in ${CHOST}-clang{,++,-cpp}; do
-		newins - "${tool}.cfg" <<-EOF
-			# This configuration file is used by ${tool} driver.
-			@gentoo-common.cfg
-		EOF
+	# Just ${CHOST} wont do due to bug #912685.
+	for abi in $(get_all_abis); do
+		local abi_chost=$(get_abi_CHOST "${abi}")
+
+		local tool
+		for tool in ${abi_chost}-clang{,++,-cpp}; do
+			newins - "${tool}.cfg" <<-EOF
+				# This configuration file is used by ${tool} driver.
+				@gentoo-common.cfg
+			EOF
+		done
 	done
 }
 

--- a/sys-devel/clang-common/clang-common-18.0.0_pre20230803-r1.ebuild
+++ b/sys-devel/clang-common/clang-common-18.0.0_pre20230803-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit bash-completion-r1 llvm.org
+inherit bash-completion-r1 llvm.org multilib
 
 DESCRIPTION="Common files shared between multiple slots of clang"
 HOMEPAGE="https://llvm.org/"
@@ -169,15 +169,20 @@ src_install() {
 		EOF
 	fi
 
-	# We only install config files for ${CHOST} because unprefixed tools
+	# We only install config files for supported ABIs because unprefixed tools
 	# might be used for crosscompilation where e.g. PIE may not be supported.
 	# See bug #912237 and bug #901247.
-	local tool
-	for tool in ${CHOST}-clang{,++,-cpp}; do
-		newins - "${tool}.cfg" <<-EOF
-			# This configuration file is used by ${tool} driver.
-			@gentoo-common.cfg
-		EOF
+	# Just ${CHOST} wont do due to bug #912685.
+	for abi in $(get_all_abis); do
+		local abi_chost=$(get_abi_CHOST "${abi}")
+
+		local tool
+		for tool in ${abi_chost}-clang{,++,-cpp}; do
+			newins - "${tool}.cfg" <<-EOF
+				# This configuration file is used by ${tool} driver.
+				@gentoo-common.cfg
+			EOF
+		done
 	done
 }
 

--- a/sys-devel/clang-common/clang-common-18.0.0_pre20230810-r2.ebuild
+++ b/sys-devel/clang-common/clang-common-18.0.0_pre20230810-r2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit bash-completion-r1 llvm.org
+inherit bash-completion-r1 llvm.org multilib
 
 DESCRIPTION="Common files shared between multiple slots of clang"
 HOMEPAGE="https://llvm.org/"
@@ -169,15 +169,20 @@ src_install() {
 		EOF
 	fi
 
-	# We only install config files for ${CHOST} because unprefixed tools
+	# We only install config files for supported ABIs because unprefixed tools
 	# might be used for crosscompilation where e.g. PIE may not be supported.
 	# See bug #912237 and bug #901247.
-	local tool
-	for tool in ${CHOST}-clang{,++,-cpp}; do
-		newins - "${tool}.cfg" <<-EOF
-			# This configuration file is used by ${tool} driver.
-			@gentoo-common.cfg
-		EOF
+	# Just ${CHOST} wont do due to bug #912685.
+	for abi in $(get_all_abis); do
+		local abi_chost=$(get_abi_CHOST "${abi}")
+
+		local tool
+		for tool in ${abi_chost}-clang{,++,-cpp}; do
+			newins - "${tool}.cfg" <<-EOF
+				# This configuration file is used by ${tool} driver.
+				@gentoo-common.cfg
+			EOF
+		done
 	done
 }
 

--- a/sys-devel/clang-common/clang-common-18.0.0_pre20230820-r1.ebuild
+++ b/sys-devel/clang-common/clang-common-18.0.0_pre20230820-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit bash-completion-r1 llvm.org
+inherit bash-completion-r1 llvm.org multilib
 
 DESCRIPTION="Common files shared between multiple slots of clang"
 HOMEPAGE="https://llvm.org/"
@@ -169,15 +169,20 @@ src_install() {
 		EOF
 	fi
 
-	# We only install config files for ${CHOST} because unprefixed tools
+	# We only install config files for supported ABIs because unprefixed tools
 	# might be used for crosscompilation where e.g. PIE may not be supported.
 	# See bug #912237 and bug #901247.
-	local tool
-	for tool in ${CHOST}-clang{,++,-cpp}; do
-		newins - "${tool}.cfg" <<-EOF
-			# This configuration file is used by ${tool} driver.
-			@gentoo-common.cfg
-		EOF
+	# Just ${CHOST} wont do due to bug #912685.
+	for abi in $(get_all_abis); do
+		local abi_chost=$(get_abi_CHOST "${abi}")
+
+		local tool
+		for tool in ${abi_chost}-clang{,++,-cpp}; do
+			newins - "${tool}.cfg" <<-EOF
+				# This configuration file is used by ${tool} driver.
+				@gentoo-common.cfg
+			EOF
+		done
 	done
 }
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/912685