### PR TITLE
dev-libs/protobuf: add minimum abseil-cpp version requirement

### DIFF
--- a/dev-libs/protobuf/protobuf-23.3-r2.ebuild
+++ b/dev-libs/protobuf/protobuf-23.3-r2.ebuild
@@ -25,12 +25,12 @@ RESTRICT="!test? ( test )"
 
 BDEPEND="emacs? ( app-editors/emacs:* )"
 DEPEND="
-	dev-cpp/abseil-cpp:=[${MULTILIB_USEDEP}]
+	>=dev-cpp/abseil-cpp-20230125.3:=[${MULTILIB_USEDEP}]
 	zlib? ( sys-libs/zlib[${MULTILIB_USEDEP}] )
 	test? ( >=dev-cpp/gtest-1.9[${MULTILIB_USEDEP}] )
 "
 RDEPEND="
-	dev-cpp/abseil-cpp:=[${MULTILIB_USEDEP}]
+	>=dev-cpp/abseil-cpp-20230125.3:=[${MULTILIB_USEDEP}]
 	emacs? ( app-editors/emacs:* )
 	zlib? ( sys-libs/zlib[${MULTILIB_USEDEP}] )
 "


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/912796