### PR TITLE
package.mask: mask sys-devel/clang-crossdev-wrappers

### DIFF
--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -763,3 +763,4 @@ dev-util/mingw64-runtime
 sys-libs/newlib
 dev-embedded/avr-libc
 sys-devel/nvptx-tools
+sys-devel/clang-crossdev-wrappers


### PR DESCRIPTION
This package is supposed to be installed from Crossdev.

Closes: 912850
Closes: 912885