### PR TITLE
dev-libs/flatbuffers: keyword 23.5.26 for ~loong

### DIFF
--- a/dev-libs/flatbuffers/flatbuffers-23.5.26.ebuild
+++ b/dev-libs/flatbuffers/flatbuffers-23.5.26.ebuild
@@ -17,7 +17,7 @@ SRC_URI="
 
 LICENSE="Apache-2.0"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm arm64 ~riscv x86"
+KEYWORDS="amd64 ~arm arm64 ~loong ~riscv x86"
 IUSE="static-libs test"
 RESTRICT="!test? ( test )"
 


### PR DESCRIPTION
dev-libs/flatbuffers: keyword 23.5.26 for ~loong