### PR TITLE
x11-themes/sound-theme-freedesktop: add dev-perl/XML-Parser BDEP

### DIFF
--- a/x11-themes/sound-theme-freedesktop/sound-theme-freedesktop-0.8.ebuild
+++ b/x11-themes/sound-theme-freedesktop/sound-theme-freedesktop-0.8.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -14,4 +14,5 @@ KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~loong ~mips ppc ppc64 ~riscv sparc
 BDEPEND="
 	>=dev-util/intltool-0.40
 	sys-devel/gettext
+	dev-perl/XML-Parser
 "


### PR DESCRIPTION
Fixing a missing BDEPEND that a user highlighted on Reddit.

Closes: https://bugs.gentoo.org/912950