### PR TITLE
app-office/onlyoffice-bin: Fix launch the Onlyoffice on ALSA systems

### DIFF
--- a/app-office/onlyoffice-bin/metadata.xml
+++ b/app-office/onlyoffice-bin/metadata.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
 	<maintainer type="person">
 		<email>parona@protonmail.com</email>

--- a/app-office/onlyoffice-bin/onlyoffice-bin-7.4.1-r1.ebuild
+++ b/app-office/onlyoffice-bin/onlyoffice-bin-7.4.1-r1.ebuild
@@ -38,7 +38,6 @@ RDEPEND="
 	media-libs/gstreamer:1.0
 	media-libs/harfbuzz
 	media-libs/libglvnd
-	media-libs/libpulse
 	net-print/cups
 	sys-apps/dbus
 	x11-libs/cairo
@@ -60,11 +59,23 @@ RDEPEND="
 	x11-libs/libXScrnSaver
 	x11-libs/libXtst
 	x11-libs/pango
+	|| (
+		media-libs/libpulse
+		media-sound/apulse
+	)
 "
 
 S="${WORKDIR}"
 
 QA_PREBUILT="*"
+
+src_prepare() {
+	default
+
+	# Patch to allow launching the ONLYOFFICE on ALSA systems via media-sound/apulse
+	sed -i -e 's|\(export LD_LIBRARY_PATH=$DIR$LDLPATH\)|\1:'"${EPREFIX}"'/usr/'$(get_libdir)'/apulse|' \
+		"${S}"/usr/bin/onlyoffice-desktopeditors || die
+}
 
 src_install() {
 	domenu usr/share/applications/onlyoffice-desktopeditors.desktop


### PR DESCRIPTION
The proposed changes allows to install and launch the `app-office/onlyoffice-bin` on ALSA systems the way similar
it's was done for `www-client/firefoix-bin` using `USE="-pulseaudio"` and shouldn't affects the Pulseaudio systems.

I could confirm that with this changes the Onlyoffice is successfully installed, launched and that the video and audio files being inserted into Presentation are played at slideshow mode.