### PR TITLE
gnome-base/gnome-control-center: Version bump to 45_rc-r1

### DIFF
--- a/gnome-base/gnome-control-center/gnome-control-center-45_rc-r1.ebuild
+++ b/gnome-base/gnome-control-center/gnome-control-center-45_rc-r1.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..11} )
 
 inherit gnome.org gnome2-utils meson python-any-r1 virtualx xdg
 


### PR DESCRIPTION
Upstream using distutils, not present in python 12

```
meson.build:31:12: ERROR: <PythonExternalProgram 'python3' -> ['/var/tmp/portage/gnome-base/gnome-control-center-45_rc/temp/python3.12/bin/python3']> is not a valid python or it is missing distutils

``