### PR TITLE
net-im/neochat: Revbump adding qtlocation dep

### DIFF
--- a/net-im/neochat/neochat-23.08.0-r1.ebuild
+++ b/net-im/neochat/neochat-23.08.0-r1.ebuild
@@ -45,6 +45,7 @@ DEPEND="
 "
 RDEPEND="${DEPEND}
 	>=dev-qt/qtgraphicaleffects-${QTMIN}:5
+	>=dev-qt/qtlocation-${QTMIN}:5
 	>=dev-qt/qtmultimedia-${QTMIN}:5[qml]
 	>=kde-frameworks/kquickcharts-${KFMIN}:5
 	>=kde-frameworks/purpose-${KFMIN}:5


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/913017
Signed-off-by: Nils Freydank <holgersson@posteo.de>
