### PR TITLE
x11-libs/wxGTK: explain reason for disabling EGL

### DIFF
--- a/x11-libs/wxGTK/wxGTK-3.2.2.1-r3.ebuild
+++ b/x11-libs/wxGTK/wxGTK-3.2.2.1-r3.ebuild
@@ -146,7 +146,22 @@ multilib_src_configure() {
 		--libdir='${prefix}'/$(get_libdir)
 	)
 
-	# Switch to wxGLCanvas GLX instead of EGL, resolves many OpenGL issues.
+	# By default, we now build with the GLX GLCanvas because some software like
+	# PrusaSlicer does not yet support EGL:
+	#
+	# https://github.com/prusa3d/PrusaSlicer/issues/9774 .
+	#
+	# A solution for this is being developed upstream:
+	#
+	# https://github.com/wxWidgets/wxWidgets/issues/22325 .
+	#
+	# Any software that needs to use OpenGL under Wayland can be patched like
+	# this to run under xwayland:
+	#
+	# https://github.com/visualboyadvance-m/visualboyadvance-m/commit/aca206a721265366728222d025fec30ee500de82 .
+	#
+	# Check that the macro wxUSE_GLCANVAS_EGL is set to 1.
+	#
 	myeconfargs+=( "--disable-glcanvasegl" )
 
 	# debug in >=2.9


### PR DESCRIPTION
Explain the rationale for disabling the EGL wxGLCanvas in the ebuild
comments.

Bug: https://bugs.gentoo.org/833443
Bug: https://bugs.gentoo.org/911120