### PR TITLE
dev-ruby/prawn-table: drop ruby27/30, enable ruby32

### DIFF
--- a/dev-ruby/prawn-table/prawn-table-0.2.2-r2.ebuild
+++ b/dev-ruby/prawn-table/prawn-table-0.2.2-r2.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
-USE_RUBY="ruby27 ruby30 ruby31"
+USE_RUBY="ruby31 ruby32"
 
 RUBY_FAKEGEM_RECIPE_DOC="yard"
 RUBY_FAKEGEM_RECIPE_TEST="rspec3"


### PR DESCRIPTION
- drop ruby27 ruby30
- enable ruby32