### PR TITLE
kernel-install.eclass: enforce signed modules in test with USE=modules-sign

### DIFF
--- a/eclass/kernel-install.eclass
+++ b/eclass/kernel-install.eclass
@@ -301,6 +301,10 @@ kernel-install_test() {
 			;;
 	esac
 
+	if [[ ${KERNEL_IUSE_MODULES_SIGN} ]]; then
+		use modules-sign && qemu_extra_append+=" module.sig_enforce=1"
+	fi
+
 	cat > run.sh <<-EOF || die
 		#!/bin/sh
 		exec qemu-system-${qemu_arch} \


### PR DESCRIPTION
This only has effect when building the gpkg for gentoo-kernel-bin which overrides CONFIG_MODULE_SIG_FORCE. To ensure that the module signing was successful we instruct the kernel to reject modules with an invalid signature.

This has no effect on other kernel packages which already have CONFIG_MODULE_SIG_FORCE=y.

CC @mgorny 