### PR TITLE
Sign kernel image in src_install instead of pkg_postinst

### DIFF
--- a/eclass/dist-kernel-utils.eclass
+++ b/eclass/dist-kernel-utils.eclass
@@ -131,11 +131,11 @@ dist-kernel_install_kernel() {
 		done
 		shopt -u nullglob
 		export KERNEL_INSTALL_PLUGINS="${KERNEL_INSTALL_PLUGINS} ${plugins[@]}"
-	fi
 
-	if [[ ${KERNEL_IUSE_SECUREBOOT} ]]; then
-		# Kernel-install requires uki's are named uki.efi, sign in-place
-		secureboot_sign_efi_file "${image}" "${image}"
+		if [[ ${KERNEL_IUSE_SECUREBOOT} ]]; then
+			# Ensure the uki is signed if dracut hasn't already done so.
+			secureboot_sign_efi_file "${image}"
+		fi
 	fi
 
 	ebegin "Installing the kernel via installkernel"

--- a/eclass/kernel-build.eclass
+++ b/eclass/kernel-build.eclass
@@ -33,6 +33,7 @@ if [[ ${KERNEL_IUSE_MODULES_SIGN} ]]; then
 	# If we have enabled module signing IUSE
 	# then we can also enable secureboot IUSE
 	KERNEL_IUSE_SECUREBOOT=1
+	inherit secureboot
 fi
 
 inherit multiprocessing python-any-r1 savedconfig toolchain-funcs kernel-install
@@ -347,6 +348,10 @@ kernel-build_src_install() {
 	# fix source tree and build dir symlinks
 	dosym "../../../${kernel_dir}" "/lib/modules/${module_ver}/build"
 	dosym "../../../${kernel_dir}" "/lib/modules/${module_ver}/source"
+
+	if [[ ${KERNEL_IUSE_SECUREBOOT} ]]; then
+		secureboot_sign_efi_file "${ED}${kernel_dir}/${image_path}"
+	fi
 
 	# unset to at least be out of the environment file in, e.g. shared binpkgs
 	unset KBUILD_SIGN_PIN

--- a/eclass/secureboot.eclass
+++ b/eclass/secureboot.eclass
@@ -98,16 +98,18 @@ secureboot_pkg_setup() {
 }
 
 # @FUNCTION: secureboot_sign_efi_file
-# @USAGE: <input file> <output file>
+# @USAGE: <input file> [<output file>]
 # @DESCRIPTION:
 # Sign a file using sbsign and the requested key/certificate.
-# If the file is already signed with our key then skip.
+# If the file is already signed with our key then the file is skipped.
+# If no output file is specified the output file will be the same
+# as the input file, i.e. the file will be overwritten.
 secureboot_sign_efi_file() {
 	debug-print-function ${FUNCNAME[0]} "${@}"
 	use secureboot || return
 
 	local input_file=${1}
-	local output_file=${2}
+	local output_file=${2:-${1}}
 
 	_secureboot_die_if_unset
 


### PR DESCRIPTION
@mgorny This allows distributing a signed kernel image in `sys-kernel/gentoo-kernel-bin`.

Note that if we want to use UKIs we still have to sign the generated UKI in postinst. This does however allow using `gentoo-kernel-bin` with Secure Boot enabled in the non-uki layout (that is if our certificated is added to the UEFI database or the MOK list).