### PR TITLE
sys-devel/clang-common: enable relro, enable bind_now (for hardened)

### DIFF
--- a/sys-devel/clang-common/clang-common-17.0.0.9999.ebuild
+++ b/sys-devel/clang-common/clang-common-17.0.0.9999.ebuild
@@ -99,6 +99,8 @@ src_install() {
 		-fstack-protector-strong
 		-fPIE
 		-include "${EPREFIX}/usr/include/gentoo/fortify.h"
+
+		-Wl,-z,relro
 	EOF
 
 	dodir /usr/include/gentoo
@@ -144,6 +146,8 @@ src_install() {
 			# https://libcxx.llvm.org/UsingLibcxx.html#assertions-mode
 			# https://libcxx.llvm.org/Hardening.html#using-hardened-mode
 			-D_LIBCPP_ENABLE_HARDENED_MODE=1
+
+			-Wl,-z,now
 		EOF
 	fi
 

--- a/sys-devel/clang-common/clang-common-17.0.0_rc3-r1.ebuild
+++ b/sys-devel/clang-common/clang-common-17.0.0_rc3-r1.ebuild
@@ -99,6 +99,8 @@ src_install() {
 		-fstack-protector-strong
 		-fPIE
 		-include "${EPREFIX}/usr/include/gentoo/fortify.h"
+
+		-Wl,-z,relro
 	EOF
 
 	dodir /usr/include/gentoo
@@ -144,6 +146,8 @@ src_install() {
 			# https://libcxx.llvm.org/UsingLibcxx.html#assertions-mode
 			# https://libcxx.llvm.org/Hardening.html#using-hardened-mode
 			-D_LIBCPP_ENABLE_HARDENED_MODE=1
+
+			-Wl,-z,now
 		EOF
 	fi
 

--- a/sys-devel/clang-common/clang-common-18.0.0.9999.ebuild
+++ b/sys-devel/clang-common/clang-common-18.0.0.9999.ebuild
@@ -99,6 +99,8 @@ src_install() {
 		-fstack-protector-strong
 		-fPIE
 		-include "${EPREFIX}/usr/include/gentoo/fortify.h"
+
+		-Wl,-z,relro
 	EOF
 
 	dodir /usr/include/gentoo
@@ -144,6 +146,8 @@ src_install() {
 			# https://libcxx.llvm.org/UsingLibcxx.html#assertions-mode
 			# https://libcxx.llvm.org/Hardening.html#using-hardened-mode
 			-D_LIBCPP_ENABLE_HARDENED_MODE=1
+
+			-Wl,-z,now
 		EOF
 	fi
 

--- a/sys-devel/clang-common/clang-common-18.0.0_pre20230825-r1.ebuild
+++ b/sys-devel/clang-common/clang-common-18.0.0_pre20230825-r1.ebuild
@@ -99,6 +99,8 @@ src_install() {
 		-fstack-protector-strong
 		-fPIE
 		-include "${EPREFIX}/usr/include/gentoo/fortify.h"
+
+		-Wl,-z,relro
 	EOF
 
 	dodir /usr/include/gentoo
@@ -144,6 +146,8 @@ src_install() {
 			# https://libcxx.llvm.org/UsingLibcxx.html#assertions-mode
 			# https://libcxx.llvm.org/Hardening.html#using-hardened-mode
 			-D_LIBCPP_ENABLE_HARDENED_MODE=1
+
+			-Wl,-z,now
 		EOF
 	fi
 


### PR DESCRIPTION
* Always enable RELRO (-Wl,-z,relro)
* Conditionally enable BIND_NOW (-Wl,-z,now) based on USE=hardened (for parity with gcc for now)