### PR TITLE
sys-libs/glibc: refresh ld.so.cache if natively installing >=2.38 on loong

### DIFF
--- a/sys-libs/glibc/glibc-2.38-r2.ebuild
+++ b/sys-libs/glibc/glibc-2.38-r2.ebuild
@@ -6,7 +6,7 @@ EAPI=8
 # Bumping notes: https://wiki.gentoo.org/wiki/Project:Toolchain/sys-libs/glibc
 # Please read & adapt the page as necessary if obsolete.
 
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..12} )
 TMPFILES_OPTIONAL=1
 
 inherit python-any-r1 prefix preserve-libs toolchain-funcs flag-o-matic gnuconfig \
@@ -20,7 +20,7 @@ SLOT="2.2"
 EMULTILIB_PKG="true"
 
 # Gentoo patchset (ignored for live ebuilds)
-PATCH_VER=1
+PATCH_VER=2
 PATCH_DEV=dilfridge
 
 # gcc mulitilib bootstrap files version
@@ -40,6 +40,7 @@ if [[ ${PV} == 9999* ]]; then
 	inherit git-r3
 else
 	#KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+	KEYWORDS="~loong"
 	SRC_URI="mirror://gnu/glibc/${P}.tar.xz"
 	SRC_URI+=" https://dev.gentoo.org/~${PATCH_DEV}/distfiles/${P}-patches-${PATCH_VER}.tar.xz"
 fi


### PR DESCRIPTION
This is ~loong-only to avoid triggering rebuilds on other arches.