### PR TITLE
sys-libs/fortify-headers-9999: Update git sources

### DIFF
--- a/sys-libs/fortify-headers/fortify-headers-9999.ebuild
+++ b/sys-libs/fortify-headers/fortify-headers-9999.ebuild
@@ -1,19 +1,13 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-if [[ ${PV} == *9999* ]] ; then
-	EGIT_REPO_URI="git://git.2f30.org/fortify-headers"
-	inherit git-r3
-else
-	#SRC_URI="http://git.2f30.org/fortify-headers/snapshot/fortify-headers-${PV}.tar.gz"
-	SRC_URI="https://dl.2f30.org/releases/${P}.tar.gz"
-	KEYWORDS="~amd64 ~arm ~mips ~ppc ~x86"
-fi
+EGIT_REPO_URI="https://github.com/jvoisin/fortify-headers"
+inherit git-r3
 
 DESCRIPTION="A standalone implementation of fortify source"
-HOMEPAGE="http://git.2f30.org/fortify-headers/"
+HOMEPAGE="https://github.com/jvoisin/fortify-headers"
 
 LICENSE="ISC"
 SLOT="0"

--- a/sys-libs/fortify-headers/metadata.xml
+++ b/sys-libs/fortify-headers/metadata.xml
@@ -5,4 +5,7 @@
 		<email>blueness@gentoo.org</email>
 		<name>Anthony G. Basile</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">jvoisin/fortify-headers</remote-id>
+	</upstream>
 </pkgmetadata>


### PR DESCRIPTION
In prepartion to write some docs for using fortify-headers in Gentoo this change updates the git sources to jvoisin's repo.

Bug: https://bugs.gentoo.org/546692