### PR TITLE
dev-libs/capstone: don't add -Werror to compiler options

### DIFF
--- a/dev-libs/capstone/capstone-9999.ebuild
+++ b/dev-libs/capstone/capstone-9999.ebuild
@@ -35,6 +35,13 @@ DEPEND="${RDEPEND}
 BDEPEND="${DISTUTILS_DEPS}"
 REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
 
+PATCHES=(
+	# Currently "-Werror" is only added in the `next`-development branch, but
+	# not merged into 5.* releases. Eventually this patch may be needed in
+	# version 5 releas line. See bug #911481.
+	"${FILESDIR}/${P}-werror.patch"
+)
+
 distutils_enable_tests setup.py
 
 if [[ ${PV} == *_rc* ]]; then

--- a/dev-libs/capstone/files/capstone-9999-werror.patch
+++ b/dev-libs/capstone/files/capstone-9999-werror.patch
@@ -1,0 +1,13 @@
+Bug: https://bugs.gentoo.org/911481
+Upstream: https://github.com/capstone-engine/capstone/pull/2114
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -28,7 +28,7 @@ project(capstone
+ if (MSVC)
+     add_compile_options(/W1 /w14189)
+ else()
+-    add_compile_options(-Werror -Wformat -Wmissing-braces -Wunused-function -Warray-bounds -Wunused-variable -Wparentheses -Wint-in-bool-context)
++    add_compile_options(-Wformat -Wmissing-braces -Wunused-function -Warray-bounds -Wunused-variable -Wparentheses -Wint-in-bool-context)
+ endif()
+ 
+ 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/911481