### PR TITLE
dev-lang/vala: fix build crash due to abscent dependency

### DIFF
--- a/dev-lang/vala/vala-0.56.12.ebuild
+++ b/dev-lang/vala/vala-0.56.12.ebuild
@@ -28,6 +28,7 @@ DEPEND="${RDEPEND}
 "
 BDEPEND="
 	dev-libs/libxslt
+	sys-apps/help2man
 	sys-devel/flex
 	virtual/pkgconfig
 	app-alternatives/yacc


### PR DESCRIPTION
`sys-apps/help2man` is required and build crashes without it. So it should be declared in build dependencies.
Bug: https://bugs.gentoo.org/913164