### PR TITLE
dev-libs/dbus-glib: remove unused build dependency

### DIFF
--- a/dev-libs/dbus-glib/dbus-glib-0.112.ebuild
+++ b/dev-libs/dbus-glib/dbus-glib-0.112.ebuild
@@ -26,7 +26,6 @@ BDEPEND="
 	>=dev-libs/glib-2.40:2
 	>=sys-apps/dbus-1.8
 	>=dev-util/glib-utils-2.40
-	>=dev-util/gtk-doc-am-1.14
 	virtual/pkgconfig
 " # CBUILD dependencies are needed to make a native tool while cross-compiling.
 


### PR DESCRIPTION
Reason: this ebuild extracts pre-generated docs and build time generation is explicitly disabled (`--disable-gtk-doc`).