### PR TITLE
media-sound/deadbeef: fix build with clang + musl-1.2.4

### DIFF
--- a/media-sound/deadbeef/deadbeef-1.9.5-r3.ebuild
+++ b/media-sound/deadbeef/deadbeef-1.9.5-r3.ebuild
@@ -69,6 +69,7 @@ BDEPEND="
 PATCHES=(
 	"${FILESDIR}/deadbeef-1.9.2-drop-Werror.patch"
 	"${FILESDIR}/${P}-clang-strict.patch"
+	"${FILESDIR}/${P}-musl-1.2.4.patch"
 )
 
 src_prepare() {

--- a/media-sound/deadbeef/deadbeef-1.9.5-r3.ebuild
+++ b/media-sound/deadbeef/deadbeef-1.9.5-r3.ebuild
@@ -1,0 +1,195 @@
+# Copyright 2021-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools xdg flag-o-matic toolchain-funcs plocale
+
+DESCRIPTION="DeaDBeeF is a modular audio player similar to foobar2000"
+HOMEPAGE="https://deadbeef.sourceforge.io/"
+SRC_URI="mirror://sourceforge/${PN}/${P}.tar.bz2"
+
+LICENSE="
+	GPL-2
+	LGPL-2.1
+	wavpack? ( BSD )
+"
+SLOT="0"
+KEYWORDS="~amd64 ~riscv ~x86"
+IUSE="aac alsa cdda converter cover dts ffmpeg flac +hotkeys lastfm libretro libsamplerate mp3 musepack nls notify +nullout opus oss pulseaudio pipewire sc68 shellexec +supereq threads vorbis wavpack"
+
+REQUIRED_USE="
+	|| ( alsa oss pulseaudio pipewire nullout )
+"
+
+DEPEND="
+	x11-libs/gtk+:3
+	net-misc/curl:=
+	dev-libs/jansson:=
+	aac? ( media-libs/faad2 )
+	alsa? ( media-libs/alsa-lib )
+	cdda? (
+		dev-libs/libcdio:=
+		media-libs/libcddb
+		dev-libs/libcdio-paranoia:=
+	)
+	cover? (
+		media-libs/imlib2[jpeg,png]
+	)
+	dts? ( media-libs/libdca )
+	ffmpeg? ( media-video/ffmpeg )
+	flac? (
+		media-libs/flac:=
+		media-libs/libogg
+	)
+	libsamplerate? ( media-libs/libsamplerate )
+	mp3? ( media-sound/mpg123 )
+	musepack? ( media-sound/musepack-tools )
+	nls? ( virtual/libintl )
+	notify? (
+		sys-apps/dbus
+	)
+	opus? ( media-libs/opusfile )
+	pulseaudio? ( media-libs/libpulse )
+	pipewire? ( media-video/pipewire )
+	vorbis? ( media-libs/libvorbis )
+	wavpack? ( media-sound/wavpack )
+	dev-libs/libdispatch:=
+"
+
+RDEPEND="${DEPEND}"
+BDEPEND="
+	dev-util/intltool
+	sys-devel/gettext
+	sys-devel/clang
+	sys-devel/llvm
+	virtual/pkgconfig
+"
+
+PATCHES=(
+	"${FILESDIR}/deadbeef-1.9.2-drop-Werror.patch"
+	"${FILESDIR}/${P}-clang-strict.patch"
+)
+
+src_prepare() {
+	default
+
+	drop_from_linguas() {
+		sed "/${1}/d" -i "${S}/po/LINGUAS" || die
+	}
+
+	drop_and_stub() {
+		rm -rf "${1}"
+		mkdir "${1}"
+		cat > "${1}/Makefile.in" <<-EOF
+			all: nothing
+			install: nothing
+			nothing:
+		EOF
+	}
+
+	plocale_for_each_disabled_locale drop_from_linguas || die
+
+	eautopoint --force
+	eautoreconf
+
+	# Get rid of bundled gettext.
+	drop_and_stub "${S}/intl"
+
+	# Plugins that are undesired for whatever reason, candidates for unbundling and such.
+	for i in adplug alac dumb ffap mms gme mono2stereo psf shn sid soundtouch wma; do
+		drop_and_stub "${S}/plugins/${i}"
+	done
+
+	rm -rf "${S}/plugins/rg_scanner/ebur128"
+}
+
+src_configure () {
+	if ! tc-is-clang; then
+		AR=llvm-ar
+		CC=${CHOST}-clang
+		CXX=${CHOST}-clang++
+		NM=llvm-nm
+		RANLIB=llvm-ranlib
+
+		strip-unsupported-flags
+	fi
+
+	export HOST_CC="$(tc-getBUILD_CC)"
+	export HOST_CXX="$(tc-getBUILD_CXX)"
+	tc-export CC CXX LD AR NM OBJDUMP RANLIB PKG_CONFIG
+
+	local myconf=(
+		"--disable-staticlink"
+		"--disable-portable"
+		"--disable-rpath"
+
+		"--disable-libmad"
+		"--disable-gtk2"
+		"--disable-adplug"
+		"--disable-coreaudio"
+		"--disable-dumb"
+		"--disable-alac"
+		"--disable-ffap"
+		"--disable-gme"
+		"--disable-mms"
+		"--disable-mono2stereo"
+		"--disable-psf"
+		"--disable-rgscanner"
+		"--disable-shn"
+		"--disable-sid"
+		"--disable-sndfile"
+		"--disable-soundtouch"
+		"--disable-tta"
+		"--disable-vfs-zip"
+		"--disable-vtx"
+		"--disable-wildmidi"
+		"--disable-wma"
+
+		"$(use_enable alsa)"
+		"$(use_enable oss)"
+		"$(use_enable pulseaudio pulse)"
+		"$(use_enable mp3)"
+		"$(use_enable mp3 libmpg123)"
+		"$(use_enable nls)"
+		"$(use_enable vorbis)"
+		"$(use_enable threads)"
+		"$(use_enable flac)"
+		"$(use_enable supereq)"
+		"$(use_enable cdda)"
+		"$(use_enable cdda cdda-paranoia)"
+		"$(use_enable aac)"
+		"$(use_enable cover artwork)"
+		"$(use_enable cover artwork-network)"
+		"$(use_enable dts dca)"
+		"$(use_enable ffmpeg)"
+		"$(use_enable converter)"
+		"$(use_enable musepack)"
+		"$(use_enable notify)"
+		"$(use_enable nullout)"
+		"$(use_enable opus)"
+		"$(use_enable pulseaudio pulse)"
+		"$(use_enable pipewire)"
+		"$(use_enable sc68)"
+		"$(use_enable shellexec)"
+		"$(use_enable shellexec shellexecui)"
+		"$(use_enable lastfm lfm)"
+		"$(use_enable libretro)"
+		"$(use_enable libsamplerate src)"
+		"$(use_enable wavpack)"
+
+		"--enable-gtk3"
+		"--enable-vfs-curl"
+		"--enable-shared"
+		"--enable-m3u"
+		"--enable-pltbrowser"
+	)
+
+	econf "${myconf[@]}"
+}
+
+src_install() {
+	default
+
+	find "${ED}" -name '*.la' -delete || die
+}

--- a/media-sound/deadbeef/files/deadbeef-1.9.5-clang-strict.patch
+++ b/media-sound/deadbeef/files/deadbeef-1.9.5-clang-strict.patch
@@ -1,0 +1,14 @@
+https://bugs.gentoo.org/908414
+https://github.com/DeaDBeeF-Player/deadbeef/issues/2987
+
+--- a/configure.ac
++++ b/configure.ac
+@@ -16,7 +16,7 @@ AC_PROG_INSTALL
+ dnl AC_PROG_LIBTOOL
+ AC_CONFIG_MACRO_DIR([m4])
+ AC_C_BIGENDIAN
+-AM_GNU_GETTEXT
++AM_GNU_GETTEXT([external])
+ PKG_PROG_PKG_CONFIG
+ AM_PROG_CC_C_O
+ AM_ICONV

--- a/media-sound/deadbeef/files/deadbeef-1.9.5-musl-1.2.4.patch
+++ b/media-sound/deadbeef/files/deadbeef-1.9.5-musl-1.2.4.patch
@@ -1,0 +1,66 @@
+https://bugs.gentoo.org/913163
+https://github.com/DeaDBeeF-Player/deadbeef/pull/2957
+https://github.com/DeaDBeeF-Player/deadbeef/commit/8fa263e32d7aee22c3ea1bcea7e93ca285f00930
+
+From 8fa263e32d7aee22c3ea1bcea7e93ca285f00930 Mon Sep 17 00:00:00 2001
+From: orbea <orbea@riseup.net>
+Date: Mon, 12 Jun 2023 09:29:52 -0700
+Subject: [PATCH] configure: Use AC_SYS_LARGEFILE
+
+With musl-1.2.4 LFS support is being disabled and will later be entirely
+removed where it is expected to use off_t and lseek rather than off64_t
+and lseek64.
+
+With glibc these types are also obsolete where it is expected to use the
+_FILE_OFFSET_BITS define where off_t and lseek will become 64-bit
+compatible versions when needed. This is set by AC_SYS_LARGEFILE.
+---
+ configure.ac    | 1 +
+ src/vfs_stdio.c | 8 +++-----
+ 2 files changed, 4 insertions(+), 5 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index 1fd1b205c..6641265e8 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -13,6 +13,7 @@ AC_PROG_CXX
+ AC_PROG_OBJC
+ AC_STDC_HEADERS
+ AC_PROG_INSTALL
++AC_SYS_LARGEFILE
+ dnl AC_PROG_LIBTOOL
+ AC_CONFIG_MACRO_DIR([m4])
+ AC_C_BIGENDIAN
+diff --git a/vfs_stdio.c b/vfs_stdio.c
+index 9c577f7d6..26d0842bb 100644
+--- a/vfs_stdio.c
++++ b/vfs_stdio.c
+@@ -35,8 +35,6 @@
+ #include <unistd.h>
+ 
+ #ifndef __linux__
+-#define off64_t off_t
+-#define lseek64 lseek
+ #define O_LARGEFILE 0
+ #endif
+ 
+@@ -169,7 +167,7 @@ stdio_seek (DB_FILE *stream, int64_t offset, int whence) {
+         whence = SEEK_SET;
+         offset = ((STDIO_FILE*)stream)->offs + offset;
+     }
+-    off64_t res = lseek64 (((STDIO_FILE *)stream)->stream, offset, whence);
++    off_t res = lseek (((STDIO_FILE *)stream)->stream, offset, whence);
+     if (res == -1) {
+         return -1;
+     }
+@@ -214,8 +212,8 @@ stdio_getlength (DB_FILE *stream) {
+     return l;
+ #else
+     if (!f->have_size) {
+-        int64_t size = lseek64 (f->stream, 0, SEEK_END);
+-        lseek64 (f->stream, f->offs, SEEK_SET);
++        int64_t size = lseek (f->stream, 0, SEEK_END);
++        lseek (f->stream, f->offs, SEEK_SET);
+ #ifdef USE_BUFFERING
+         f->bufremaining = 0;
+ #endif


### PR DESCRIPTION
Upstream has changed enough that the patch for the clang build issue is not applicable and they will need a different fix. Additionally the musl workaround for stubbing intl subdirectory is no longer required.

Closes: https://bugs.gentoo.org/908414
Upstream-Issue: https://github.com/DeaDBeeF-Player/deadbeef/issues/2987

The musl-1.2.4 build fix is upstreamed already.

Closes: https://bugs.gentoo.org/913163
Upstream-PR: https://github.com/DeaDBeeF-Player/deadbeef/pull/2957
Upstream-Commit: https://github.com/DeaDBeeF-Player/deadbeef/commit/8fa263e32d7aee22c3ea1bcea7e93ca285f00930