### PR TITLE
sys-process/audit: fix cross compilation and add arch specific support configure options

### DIFF
--- a/sys-process/audit/audit-3.0.9-r1.ebuild
+++ b/sys-process/audit/audit-3.0.9-r1.ebuild
@@ -60,6 +60,8 @@ multilib_src_configure() {
 		$(use_enable gssapi gssapi-krb5)
 		$(use_enable ldap zos-remote)
 		$(use_enable static-libs static)
+		$(use_with arm)
+		$(use_with arm64 aarch64)
 		--enable-systemd
 		--without-golang
 		--without-python
@@ -74,6 +76,7 @@ multilib_src_configure() {
 			pushd "${BUILD_DIR}" &>/dev/null || die
 
 			ECONF_SOURCE="${S}" econf "${myeconfargs[@]}" --with-python3
+			find . -type f -name 'Makefile' -exec sed -i "s;-I/usr/include/python;-I${SYSROOT}/usr/include/python;g" {} +
 
 			popd &>/dev/null || die
 		}

--- a/sys-process/audit/audit-3.1.1.ebuild
+++ b/sys-process/audit/audit-3.1.1.ebuild
@@ -65,6 +65,8 @@ multilib_src_configure() {
 		$(use_enable ldap zos-remote)
 		$(use_enable static-libs static)
 		$(use_with io-uring io_uring)
+		$(use_with arm)
+		$(use_with arm64 aarch64)
 		--enable-systemd
 		--without-golang
 		--without-libwrap
@@ -80,6 +82,7 @@ multilib_src_configure() {
 			pushd "${BUILD_DIR}" &>/dev/null || die
 
 			ECONF_SOURCE="${S}" econf "${myeconfargs[@]}" --with-python3
+			find . -type f -name 'Makefile' -exec sed -i "s;-I/usr/include/python;-I${SYSROOT}/usr/include/python;g" {} +
 
 			popd &>/dev/null || die
 		}

--- a/sys-process/audit/audit-3.1.2.ebuild
+++ b/sys-process/audit/audit-3.1.2.ebuild
@@ -62,6 +62,8 @@ multilib_src_configure() {
 		$(use_enable ldap zos-remote)
 		$(use_enable static-libs static)
 		$(use_with io-uring io_uring)
+		$(use_with arm)
+		$(use_with arm64 aarch64)
 		--enable-systemd
 		--without-golang
 		--without-libwrap
@@ -77,6 +79,7 @@ multilib_src_configure() {
 			pushd "${BUILD_DIR}" &>/dev/null || die
 
 			ECONF_SOURCE="${S}" econf "${myeconfargs[@]}" --with-python3
+			find . -type f -name 'Makefile' -exec sed -i "s;-I/usr/include/python;-I${SYSROOT}/usr/include/python;g" {} +
 
 			popd &>/dev/null || die
 		}


### PR DESCRIPTION
First of all there are 2 arch specific options in configure for sys-process/audit which should be considered in build process:

--with-arm              enable Arm eabi processor support
--with-aarch64          enable Aarch64 processor support

For now ebuild does not set them.

What's more cross compilation fails, because of the wrong path for proper python3 includes.
In configure, audit's build system calls python3-config which does not print absolute path to headers from target sysroot:

PYTHON3_CFLAGS=`python3-config --cflags 2> /dev/null`
PYTHON3_LIBS=`python3-config --libs 2> /dev/null`
PYTHON3_INCLUDES=`python3-config --includes 2> /dev/null`

So (cross compilation for arm example) it ends up like this:

libtool: compile:  armv7a-hardfloat-linux-gnueabi-gcc -DHAVE_CONFIG_H -I. -I/var/tmp/targ-portage/armv7a-hardfloat-linux-gnueabi/portage/sys-process/audit-3.1.2/work/audit-3.1.2/bindings/swig/python3 -I/var/tmp/targ-portage/armv7a-hardfloat-linux-gnueabi/portage/sys-process/audit-3.1.2/work/audit-3.1.2-.default -I. -I/var/tmp/targ-portage/armv7a-hardfloat-linux-gnueabi/portage/sys-process/audit-3.1.2/work/audit-3.1.2-.default -I/var/tmp/targ-portage/armv7a-hardfloat-linux-gnueabi/portage/sys-process/audit-3.1.2/work/audit-3.1.2/lib -I/usr/include/python3.10 -I/usr/include/python3.10 -Os -pipe -fomit-frame-pointer -fstack-protector-all -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -c audit_wrap.c  -fPIC -DPIC -o .libs/_audit_la-audit_wrap.o
In file included from /usr/include/python3.10/Python.h:50,
                 from audit_wrap.c:168:
/usr/include/python3.10/pyport.h:746:2: error: #error "LONG_BIT definition appears wrong for platform (bad gcc/glibc config?)."
  746 | #error "LONG_BIT definition appears wrong for platform (bad gcc/glibc config?)."
      |  ^~~~~
make[1]: *** [Makefile:521: _audit_la-audit_wrap.lo] Error 1