### PR TITLE
dev-libs/libvterm: fix rlibtool build (Again)

### DIFF
--- a/dev-libs/libvterm/files/libvterm-0.3.2-slibtool.patch
+++ b/dev-libs/libvterm/files/libvterm-0.3.2-slibtool.patch
@@ -1,0 +1,99 @@
+Author: orbea <orbea@riseup.net>
+Date:   Tue Aug 29 16:56:23 2023 -0700
+Subject: [PATCH] build: Add a minimal configures script
+
+When building libvterm with slibtool using the rlibtool symlink the
+build will fail when the generated libtool is not found. This file is
+required with rlibtool so that the build can determine if the build
+should be shared, static or both.
+
+This can be solved by adding a minimal configure script.
+
+The build steps are now:
+
+autoreconf -fi
+./configure
+make
+make install
+
+Gentoo Bug: https://bugs.gentoo.org/779034
+
+diff --git a/Makefile b/Makefile.in
+similarity index 88%
+rename from Makefile
+rename to Makefile.in
+--- a/Makefile
++++ b/Makefile.in
+@@ -1,13 +1,13 @@
+-ifeq ($(shell uname),Darwin)
+-  LIBTOOL ?= glibtool
+-else
+-  LIBTOOL ?= libtool
+-endif
++top_builddir = @top_builddir@
++
++LIBTOOL = @LIBTOOL@
+ 
+ ifneq ($(VERBOSE),1)
+   LIBTOOL +=--quiet
+ endif
+ 
++CC = @CC@
++
+ override CFLAGS +=-Wall -Iinclude -std=c99 -Wpedantic
+ 
+ ifeq ($(shell uname),SunOS)
+@@ -36,17 +36,21 @@ INCFILES=$(TBLFILES:.tbl=.inc)
+ 
+ HFILES_INT=$(sort $(wildcard src/*.h)) $(HFILES)
+ 
++VERSION_MAJOR=@VERSION_MAJOR@
++VERSION_MINOR=@VERSION_MINOR@
++
+ VERSION_CURRENT=0
+ VERSION_REVISION=0
+ VERSION_AGE=0
+ 
+-VERSION=0.3.2
++VERSION=@PACKAGE_VERSION@
+ 
+-PREFIX=/usr/local
+-BINDIR=$(PREFIX)/bin
+-LIBDIR=$(PREFIX)/lib
+-INCDIR=$(PREFIX)/include
+-MANDIR=$(PREFIX)/share/man
++prefix=@prefix@
++exec_prefix=@exec_prefix@
++BINDIR=@bindir@
++LIBDIR=@libdir@
++INCDIR=@includedir@
++MANDIR=@mandir@
+ MAN3DIR=$(MANDIR)/man3
+ 
+ all: $(LIBRARY) $(BINFILES)
+@@ -70,7 +74,7 @@ src/encoding.lo: $(INCFILES)
+ 
+ bin/%: bin/%.c $(LIBRARY)
+ 	@echo CC $<
+-	@$(LIBTOOL) --mode=link --tag=CC $(CC) $(CFLAGS) -o $@ $< -lvterm $(LDFLAGS)
++	@$(LIBTOOL) --mode=link --tag=CC $(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
+ 
+ t/harness.lo: t/harness.c $(HFILES)
+ 	@echo CC $<
+--- /dev/null
++++ b/configure.ac
+@@ -0,0 +1,14 @@
++m4_define([version_major], [0])
++m4_define([version_minor], [3])
++
++AC_INIT([libvterm], [version_major.version_minor])
++AC_CONFIG_FILES([Makefile])
++
++LT_INIT
++
++AC_SUBST([top_builddir], [$abs_builddir])
++
++AC_SUBST([VERSION_MAJOR], [version_major])
++AC_SUBST([VERSION_MINOR], [version_minor])
++
++AC_OUTPUT

--- a/dev-libs/libvterm/libvterm-0.3.2-r1.ebuild
+++ b/dev-libs/libvterm/libvterm-0.3.2-r1.ebuild
@@ -1,0 +1,43 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools
+
+DESCRIPTION="An abstract library implementation of a VT220/xterm/ECMA-48 terminal emulator"
+HOMEPAGE="https://www.leonerd.org.uk/code/libvterm/"
+SRC_URI="https://www.leonerd.org.uk/code/${PN}/${P}.tar.gz"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~riscv ~x86 ~x64-macos"
+
+BDEPEND="
+	dev-lang/perl
+	virtual/pkgconfig
+"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-0.3.2-slibtool.patch # 779034
+)
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_compile() {
+	emake VERBOSE=1
+}
+
+src_test() {
+	emake VERBOSE=1 test
+}
+
+src_install() {
+	emake VERBOSE=1 DESTDIR="${D}" install
+
+	find "${ED}" -name '*.la' -delete || die "Failed to prune libtool files"
+	find "${ED}" -name '*.a' -delete || die
+}


### PR DESCRIPTION
Not sure why the patch was never applied to the 0.3 versions.

Bug: https://bugs.gentoo.org/779034
Closes: https://github.com/gentoo/gentoo/pull/32515