### PR TITLE
www-client/firefox: force use of llvm-readelf

### DIFF
--- a/www-client/firefox/firefox-117.0.ebuild
+++ b/www-client/firefox/firefox-117.0.ebuild
@@ -744,7 +744,6 @@ src_configure() {
 		CXX=${CHOST}-clang++-${version_clang}
 		NM=llvm-nm
 		RANLIB=llvm-ranlib
-		READELF=llvm-readelf
 	elif ! use clang && ! tc-is-gcc ; then
 		# Force gcc
 		have_switched_compiler=yes
@@ -754,7 +753,6 @@ src_configure() {
 		CXX=${CHOST}-g++
 		NM=gcc-nm
 		RANLIB=gcc-ranlib
-		READELF=readelf
 	fi
 
 	if [[ -n "${have_switched_compiler}" ]] ; then
@@ -768,7 +766,11 @@ src_configure() {
 	export HOST_CC="$(tc-getBUILD_CC)"
 	export HOST_CXX="$(tc-getBUILD_CXX)"
 	export AS="$(tc-getCC) -c"
-	tc-export CC CXX LD AR AS NM OBJDUMP RANLIB PKG_CONFIG
+
+	# Configuration tests expect llvm-readelf output, bug 913130
+	READELF="llvm-readelf"
+
+	tc-export CC CXX LD AR AS NM OBJDUMP RANLIB READELF PKG_CONFIG
 
 	# Pass the correct toolchain paths through cbindgen
 	if tc-is-cross-compiler ; then


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/913130