### PR TITLE
kernel-build.eclass: unzip kernel image on arm64/riscv before signing

### DIFF
--- a/eclass/dist-kernel-utils.eclass
+++ b/eclass/dist-kernel-utils.eclass
@@ -71,8 +71,12 @@ dist-kernel_get_image_path() {
 		amd64|x86)
 			echo arch/x86/boot/bzImage
 			;;
-		arm64)
-			echo arch/arm64/boot/Image.gz
+		arm64|riscv)
+			if [[ ${KERNEL_IUSE_SECUREBOOT} ]] && use secureboot; then
+				echo arch/${ARCH}/boot/vmlinuz.efi
+			else
+				echo arch/${ARCH}/boot/Image.gz
+			fi
 			;;
 		arm)
 			echo arch/arm/boot/zImage
@@ -82,9 +86,6 @@ dist-kernel_get_image_path() {
 			# ./ is required because of ${image_path%/*}
 			# substitutions in the code
 			echo ./vmlinux
-			;;
-		riscv)
-			echo arch/riscv/boot/Image.gz
 			;;
 		*)
 			die "${FUNCNAME}: unsupported ARCH=${ARCH}"

--- a/eclass/kernel-build.eclass
+++ b/eclass/kernel-build.eclass
@@ -436,6 +436,20 @@ kernel-build_merge_configs() {
 		fi
 	fi
 
+	if [[ ${KERNEL_IUSE_SECUREBOOT} ]]; then
+		if use secureboot; then
+			# This only effects arm64 and riscv where the bootable image may
+			# contain its own decompressor (zboot). If enabled we get a
+			# sign-able efi file.
+			cat <<-EOF > "${WORKDIR}/secureboot.config" || die
+				## Enable zboot for signing
+				CONFIG_EFI_ZBOOT=y
+			EOF
+
+			merge_configs+=( "${WORKDIR}/secureboot.config" )
+		fi
+	fi
+
 	if [[ ${#user_configs[@]} -gt 0 ]]; then
 		elog "User config files are being applied:"
 		local x


### PR DESCRIPTION
Arm64 has no compressed kernel support, therefore the DOS header is in the image itself instead of the compressed image (bzimage on e.g. amd64). To successfully sign we have to unzip the image, then sign and zip it up again.