### PR TITLE
sys-apps/xdg-desktop-portal: Enabled 'screencast' USE flag by default.

### DIFF
--- a/sys-apps/xdg-desktop-portal/xdg-desktop-portal-1.16.0-r1.ebuild
+++ b/sys-apps/xdg-desktop-portal/xdg-desktop-portal-1.16.0-r1.ebuild
@@ -12,7 +12,7 @@ SRC_URI="https://github.com/flatpak/${PN}/releases/download/${PV}/${P}.tar.xz"
 LICENSE="LGPL-2.1"
 SLOT="0"
 KEYWORDS="amd64 ~arm arm64 ~loong ~ppc ~ppc64 ~riscv x86"
-IUSE="geolocation screencast systemd"
+IUSE="geolocation +screencast systemd"
 
 DEPEND="
 	>=dev-libs/glib-2.66:2


### PR DESCRIPTION
This enables the 'screencast' USE flag by default.