### PR TITLE
net-wireless/wireless-tools: add rdepend on wireless-regdb

### DIFF
--- a/net-wireless/wireless-tools/wireless-tools-30_pre9-r2.ebuild
+++ b/net-wireless/wireless-tools/wireless-tools-30_pre9-r2.ebuild
@@ -1,0 +1,64 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs
+
+# The following works with both pre-releases and releases
+MY_P=${PN/-/_}.${PV/_/.}
+S="${WORKDIR}/${MY_P/\.pre*/}"
+
+DESCRIPTION="A collection of tools to configure IEEE 802.11 wireless LAN cards"
+HOMEPAGE="https://www.hpl.hp.com/personal/Jean_Tourrilhes/Linux/Tools.html"
+SRC_URI="https://www.hpl.hp.com/personal/Jean_Tourrilhes/Linux/${MY_P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~ia64 ~loong ~mips ~ppc ~ppc64 ~riscv ~sparc ~x86"
+IUSE="multicall"
+
+RDEPEND="
+	net-wireless/wireless-regdb
+"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-29-asneeded.patch"
+)
+
+src_prepare() {
+	default
+
+	sed -i \
+		-e "s:^\(CC\) = gcc:\1 = $(tc-getCC):" \
+		-e "s:^\(AR\) = ar:\1 = $(tc-getAR):" \
+		-e "s:^\(RANLIB\) = ranlib:\1 = $(tc-getRANLIB):" \
+		-e "s:^\(CFLAGS=-Os\):#\1:" \
+		-e "s:\(@\$(LDCONFIG).*\):#\1:" \
+		-e "s:^\(INSTALL_MAN= \$(PREFIX)\)/man:\1/usr/share/man:" \
+		-e "s:^\(INSTALL_LIB= \$(PREFIX)\)/lib:\1/$(get_libdir)/:" \
+		-e "s:^\(INSTALL_INC= \$(PREFIX)\)/include:\1/usr/include:" \
+		-e "s:^\(BUILD_STATIC = y\):#\1:" \
+		-e '/\$(CC)/s:-Wl,-s\>::' \
+		"${S}"/Makefile || die
+}
+
+src_compile() {
+	emake
+
+	use multicall && emake iwmulticall
+}
+
+src_install() {
+	emake PREFIX="${ED}" install
+
+	# 'make install-iwmulticall' will overwrite some of the tools
+	# with symlinks - this is intentional (brix)
+	use multicall && emake PREFIX="${ED}" install-iwmulticall
+
+	has cs "${LINGUAS-cs}" || rm -rf "${ED}"/usr/share/man/cs
+	has fr "${LINGUAS-fr}" || rm -rf "${ED}"/usr/share/man/fr.{ISO8859-1,UTF-8}
+
+	dodoc CHANGELOG.h HOTPLUG-UDEV.txt IFRENAME-VS-XXX.txt PCMCIA.txt README
+	has fr "${LINGUAS-fr}" && dodoc README.fr
+}


### PR DESCRIPTION
wireless-tools can bring up a wireless device so it needs to depend on net-wireless/wireless-regdb.

Add quotes around variable expansion.
Simplify use-flag evalulation in src_install.