### PR TITLE
Fix minimal dependencies for Xyce build.

### DIFF
--- a/sci-libs/trilinos/trilinos-14.4.0.ebuild
+++ b/sci-libs/trilinos/trilinos-14.4.0.ebuild
@@ -127,6 +127,11 @@ src_configure() {
 		-DTrilinos_ENABLE_Tpetra=ON
 		-DTrilinos_ENABLE_Zoltan=ON
 		-DTrilinos_ENABLE_TESTS="$(usex test)"
+		-DTrilinos_ENABLE_TrilinosCouplings=ON
+		-DEpetraExt_BUILD_BTF=ON
+		-DEpetraExt_BUILD_EXPERIMENTAL=ON
+		-DEpetraExt_BUILD_GRAPH_REORDERINGS=ON
+		-DTrilinos_ENABLE_COMPLEX_DOUBLE=ON
 		-DTPL_ENABLE_BinUtils=ON
 		-DTPL_ENABLE_BLAS=ON
 		-DTPL_ENABLE_LAPACK=ON


### PR DESCRIPTION
This is need for a build a Xyce - spice simulator.
And before merge it, need to wait fix a build bugs on Trilinos library (https://github.com/trilinos/Trilinos/issues/12200).