### PR TITLE
media-libs/libsidplay: Fix build on llvm profile

### DIFF
--- a/media-libs/libsidplay/files/libsidplay-2.1.1-clang16.patch
+++ b/media-libs/libsidplay/files/libsidplay-2.1.1-clang16.patch
@@ -1,0 +1,48 @@
+_Ios_Openmode is an implementation detail of the GNU c++ stdlib whereas
+ios_base::openmode is the portable way to go
+--- a/libsidplay/src/sidtune/SidTune.cpp
++++ b/libsidplay/src/sidtune/SidTune.cpp
+@@ -29,6 +29,7 @@
+ #   include <new>
+ #endif
+ #include <iostream>
++#include <ios>
+ #include <iomanip>
+ #include <string.h>
+ #include <limits.h>
+@@ -283,7 +284,7 @@ bool SidTune::loadFile(const char* fileName, Buffer_sidtt<const uint_least8_t>&
+     uint_least32_t fileLen = 0;
+ 
+     // This sucks big time
+-    std::_Ios_Openmode createAtrr = std::ios::in;
++    std::ios_base::openmode createAtrr = std::ios::in;
+ #ifdef HAVE_IOS_NOCREATE
+     createAtrr |= std::ios::nocreate;
+ #endif
+@@ -952,7 +953,7 @@ bool SidTune::saveC64dataFile( const char* fileName, bool overWriteFlag )
+     if ( status )
+     {
+         // Open binary output file stream.
+-        std::_Ios_Openmode createAttr = std::ios::out;
++        std::ios_base::openmode createAttr = std::ios::out;
+ #if defined(HAVE_IOS_BIN)
+         createAttr |= std::ios::bin;
+ #else
+@@ -1002,7 +1003,7 @@ bool SidTune::saveSIDfile( const char* fileName, bool overWriteFlag )
+     if ( status )
+     {
+         // Open ASCII output file stream.
+-        std::_Ios_Openmode createAttr = std::ios::out;
++        std::ios_base::openmode createAttr = std::ios::out;
+         if ( overWriteFlag )
+             createAttr |= std::ios::trunc;
+         else
+@@ -1036,7 +1037,7 @@ bool SidTune::savePSIDfile( const char* fileName, bool overWriteFlag )
+     if ( status )
+     {
+         // Open binary output file stream.
+-        std::_Ios_Openmode createAttr = std::ios::out;
++        std::ios_base::openmode createAttr = std::ios::out;
+ #if defined(HAVE_IOS_BIN)
+         createAttr |= std::ios::bin;
+ #else

--- a/media-libs/libsidplay/libsidplay-2.1.1-r7.ebuild
+++ b/media-libs/libsidplay/libsidplay-2.1.1-r7.ebuild
@@ -1,0 +1,82 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools multilib-minimal
+
+MY_P=sidplay-libs-${PV}
+
+DESCRIPTION="C64 SID player library"
+HOMEPAGE="http://sidplay2.sourceforge.net/"
+SRC_URI="mirror://sourceforge/sidplay2/${MY_P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="2"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~loong ~mips ~ppc ~ppc64 ~riscv ~sparc ~x86"
+IUSE="static-libs"
+
+BDEPEND="sys-devel/autoconf-archive"
+
+MULTILIB_WRAPPED_HEADERS=(
+	/usr/include/sidplay/sidconfig.h
+)
+
+PATCHES=(
+	"${FILESDIR}"/${P}-gcc41.patch
+	"${FILESDIR}"/${P}-fbsd.patch
+	"${FILESDIR}"/${P}-gcc43.patch
+	"${FILESDIR}"/${P}-no_libtool_reference.patch
+	"${FILESDIR}"/${P}-gcc6.patch
+	"${FILESDIR}"/${P}-autoconf.patch
+	"${FILESDIR}"/${P}-slibtool.patch
+	"${FILESDIR}"/${P}-clang16.patch
+)
+
+S="${WORKDIR}/${MY_P}"
+
+src_prepare() {
+	default
+
+	local subdirs=(
+		builders/hardsid-builder
+		builders/resid-builder
+		libsidplay
+		libsidutils
+		resid
+		.
+	)
+
+	for i in ${subdirs[@]}; do
+		(
+			cd "$i" || die
+			eautoreconf
+		)
+	done
+
+	multilib_copy_sources
+}
+
+multilib_src_configure() {
+	local myeconfargs=(
+		--enable-shared
+		--with-pic
+		$(use_enable static-libs static)
+	)
+	econf "${myeconfargs[@]}"
+}
+
+multilib_src_install_all() {
+	docinto libsidplay
+	dodoc libsidplay/{AUTHORS,ChangeLog,README,TODO}
+
+	docinto libsidutils
+	dodoc libsidutils/{AUTHORS,ChangeLog,README,TODO}
+
+	docinto resid
+	dodoc resid/{AUTHORS,ChangeLog,NEWS,README,THANKS,TODO}
+
+	doenvd "${FILESDIR}"/65resid
+
+	find "${D}" -name '*.la' -delete || die
+}


### PR DESCRIPTION
_Ios_Openmode is an implementation detail of the GNU c++ stdlib whereas ios_base::openmode is the portable way to go