### PR TITLE
introduce KERNEL_EFI_ZBOOT  to fix dist-kernel-bin on arm64

### DIFF
--- a/eclass/dist-kernel-utils.eclass
+++ b/eclass/dist-kernel-utils.eclass
@@ -19,6 +19,13 @@
 # If set to a non-null value, inherits secureboot.eclass
 # and allows signing of generated kernel images.
 
+# @ECLASS_VARIABLE: KERNEL_EFI_ZBOOT
+# @DEFAULT_UNSET
+# @DESCRIPTION:
+# If set to a non-null value, it is assumed the kernel was built with
+# CONFIG_EFI_ZBOOT enabled. This effects the name of the kernel image on
+# arm64 and riscv. Mainly useful for sys-kernel/gentoo-kernel-bin.
+
 if [[ ! ${_DIST_KERNEL_UTILS} ]]; then
 
 case ${EAPI} in
@@ -72,7 +79,7 @@ dist-kernel_get_image_path() {
 			echo arch/x86/boot/bzImage
 			;;
 		arm64|riscv)
-			if [[ ${KERNEL_IUSE_SECUREBOOT} ]] && use secureboot; then
+			if [[ ${KERNEL_EFI_ZBOOT} ]]; then
 				echo arch/${ARCH}/boot/vmlinuz.efi
 			else
 				echo arch/${ARCH}/boot/Image.gz

--- a/eclass/kernel-build.eclass
+++ b/eclass/kernel-build.eclass
@@ -461,6 +461,12 @@ kernel-build_merge_configs() {
 
 	./scripts/kconfig/merge_config.sh -m -r \
 		.config "${merge_configs[@]}"  || die
+
+	# If this is set by USE=secureboot or user config this will have an effect
+	# on the name of the output image. Set this variable to track this setting.
+	if grep -q "CONFIG_EFI_ZBOOT=y" .config; then
+		KERNEL_EFI_ZBOOT=1
+	fi
 }
 
 fi

--- a/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-6.4.14.ebuild
+++ b/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-6.4.14.ebuild
@@ -3,6 +3,7 @@
 
 EAPI=8
 
+KERNEL_EFI_ZBOOT=1
 KERNEL_IUSE_SECUREBOOT=1
 inherit kernel-install toolchain-funcs unpacker
 


### PR DESCRIPTION
I think the best way to address both Bug 897684 and Bug 913542 is to simply introduce a new variable that an ebuild or eclass can set if `CONFIG_EFI_ZBOOT` was enabled.

I first tried detecting this in `dist-kernel_get_image_path` but things just become too messy because `dist-kernel_get_image_path` doesn't know where the kernel directory with our `.config` is. And changing this function to take a `kernel_dir` argument requires quiet a lot of changes elsewhere.

After this change `arm64` and `riscv` users can now also enable `CONFIG_EFI_ZBOOT` as user override.

Again this is only tested on `amd64`.

CC @mgorny @thesamesam 