### PR TITLE
media-sound/sidplay: Fix C++17 does not allow register storage class

### DIFF
--- a/media-sound/sidplay/files/sidplay-2.0.9-drop-register-keyword.patch
+++ b/media-sound/sidplay/files/sidplay-2.0.9-drop-register-keyword.patch
@@ -1,0 +1,16 @@
+Bug; https://bugs.gentoo.org/897796
+--- a/src/keyboard.cpp
++++ b/src/keyboard.cpp
+@@ -129,9 +129,9 @@ static char keytable[] =
+  */
+ static int keyboard_search (char *cmd)
+ {
+-    register char *p;
+-    register char *q;
+-    register int   a;
++    char *p;
++    char *q;
++    int   a;
+ 
+     for (p = keytable, q = cmd;;  p++, q++)
+     {

--- a/media-sound/sidplay/sidplay-2.0.9-r2.ebuild
+++ b/media-sound/sidplay/sidplay-2.0.9-r2.ebuild
@@ -1,0 +1,23 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="C64 SID player"
+HOMEPAGE="https://sidplay2.sourceforge.net/"
+SRC_URI="mirror://sourceforge/sidplay2/${P}.tar.gz"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~hppa ~ppc ~sparc ~x86"
+IUSE=""
+
+BDEPEND="virtual/pkgconfig"
+DEPEND="media-libs/libsidplay:2"
+RDEPEND="${DEPEND}"
+
+PATCHES=(
+	"${FILESDIR}/${P}-gcc43.patch"
+	"${FILESDIR}/${P}-gcc44.patch"
+	"${FILESDIR}/${P}-drop-register-keyword.patch"
+)


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/897796