### PR TITLE
profiles/targets/desktop: move 'keyring' from desktop/gnome to desktop

### DIFF
--- a/profiles/targets/desktop/gnome/make.defaults
+++ b/profiles/targets/desktop/gnome/make.defaults
@@ -1,4 +1,4 @@
 # Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-USE="colord eds evo gnome gnome-keyring gnome-online-accounts gstreamer introspection keyring nautilus networkmanager pulseaudio sysprof tracker wayland"
+USE="colord eds evo gnome gnome-keyring gnome-online-accounts gstreamer introspection nautilus networkmanager pulseaudio sysprof tracker wayland"

--- a/profiles/targets/desktop/make.defaults
+++ b/profiles/targets/desktop/make.defaults
@@ -1,4 +1,4 @@
 # Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-USE="a52 aac acpi alsa bluetooth branding cairo cdda cdr cups dbus dri dts dvd dvdr elogind encode exif flac gif gpm gtk gui icu jpeg lcms libnotify mad mng mp3 mp4 mpeg ogg opengl pango pdf png policykit ppds qt5 sdl sound spell startup-notification svg tiff truetype vorbis udev udisks unicode upower usb vulkan wxwidgets X xcb xft x264 xml xv xvid"
+USE="a52 aac acpi alsa bluetooth branding cairo cdda cdr cups dbus dri dts dvd dvdr elogind encode exif flac gif gpm gtk gui icu jpeg keyring lcms libnotify mad mng mp3 mp4 mpeg ogg opengl pango pdf png policykit ppds qt5 sdl sound spell startup-notification svg tiff truetype vorbis udev udisks unicode upower usb vulkan wxwidgets X xcb xft x264 xml xv xvid"


### PR DESCRIPTION
Using the freedesktop.org Secret Service API for secure password/credential storage enhances the security for our users. Having the USE flag disabled leads to bad UX, see bug #912844 for example.

Bug: https://bugs.gentoo.org/912844