### PR TITLE
dev-libs/poco: make activerecord USE flag depens on xml

### DIFF
--- a/dev-libs/poco/poco-1.12.4.ebuild
+++ b/dev-libs/poco/poco-1.12.4.ebuild
@@ -17,7 +17,7 @@ KEYWORDS="amd64 ~arm ~arm64 ppc64 x86"
 IUSE="7z activerecord cppparser +data examples +file2pagecompiler iodbc +json jwt mariadb +mongodb mysql +net odbc +pagecompiler pdf pocodoc postgres prometheus sqlite +ssl test +util +xml +zip"
 RESTRICT="!test? ( test )"
 REQUIRED_USE="
-	activerecord? ( util )
+	activerecord? ( util xml )
 	7z? ( xml )
 	file2pagecompiler? ( pagecompiler )
 	iodbc? ( odbc )


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/911234