### PR TITLE
acct-user/cron: Sets home owner and home perms, so that users have to be

### DIFF
--- a/acct-user/cron/cron-0-r2.ebuild
+++ b/acct-user/cron/cron-0-r2.ebuild
@@ -10,5 +10,7 @@ DESCRIPTION="A user for sys-process/cronbase"
 ACCT_USER_GROUPS=( "cron" )
 ACCT_USER_HOME="/var/spool/cron"
 ACCT_USER_ID="16"
+ACCT_USER_HOME_OWNER="root:cron"
+ACCT_USER_HOME_PERMS="0750"
 
 acct-user_add_deps


### PR DESCRIPTION
in cron group to use cron

Bug: https://bugs.gentoo.org/913346
From: Brian Evans <grknight@gentoo.org>