### PR TITLE
sys-process/cronbase: Changed Homepage from No_homepage to Cron + added

### DIFF
--- a/sys-process/cronbase/cronbase-0.3.7-r9.ebuild
+++ b/sys-process/cronbase/cronbase-0.3.7-r9.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 
 DESCRIPTION="Base for all cron ebuilds"
-HOMEPAGE="https://wiki.gentoo.org/wiki/No_homepage"
+HOMEPAGE="https://wiki.gentoo.org/wiki/Cron"
 S="${WORKDIR}"
 
 LICENSE="GPL-2"
@@ -26,4 +26,13 @@ src_install() {
 	keepdir /var/spool/cron/lastrun
 	diropts -m0750 -o root -g cron
 	keepdir /var/spool/cron
+}
+
+pkg_postinst() {
+	einfo "To add a user to the cron group so it can create cron jobs, run:"
+	einfo
+	einfo "    usermod -a -G cron <user>"
+	einfo
+	einfo "For more information, visit the wiki page:                      "
+	einfo "https://wiki.gentoo.org/wiki/Cron                               "
 }


### PR DESCRIPTION
einfo message informing about the cron group and how to add a user to said group.

This is in reference to commit: [#6fd345466e6afddbc2e4231dd7eb45b1685586a1](https://github.com/gentoo/gentoo/commit/6fd345466e6afddbc2e4231dd7eb45b1685586a1)