### PR TITLE
dev-perl/Net-IDN-Encode: Add patch for Perl 5.38

### DIFF
--- a/dev-perl/Net-IDN-Encode/Net-IDN-Encode-2.500.0-r1.ebuild
+++ b/dev-perl/Net-IDN-Encode/Net-IDN-Encode-2.500.0-r1.ebuild
@@ -24,3 +24,7 @@ BDEPEND="${RDEPEND}
 		dev-perl/Test-NoWarnings
 	)
 "
+
+PATCHES=(
+	"${FILESDIR}"/${PV}-use-uvchr_to_utf8_flags-instead-of-uvuni_to_utf8_fla.patch
+)

--- a/dev-perl/Net-IDN-Encode/files/2.500.0-use-uvchr_to_utf8_flags-instead-of-uvuni_to_utf8_fla.patch
+++ b/dev-perl/Net-IDN-Encode/files/2.500.0-use-uvchr_to_utf8_flags-instead-of-uvuni_to_utf8_fla.patch
@@ -1,0 +1,41 @@
+https://bugs.gentoo.org/912440
+https://github.com/cfaerber/Net-IDN-Encode/pull/11
+
+From: Shin Kojima <shin@kojima.org>
+Date: Sun, 23 Jul 2023 13:15:59 +0900
+Subject: [PATCH] use uvchr_to_utf8_flags instead of uvuni_to_utf8_flags (which
+ is removed in perl 5.38.0)
+
+https://perldoc.perl.org/5.36.0/perlintern#uvuni_to_utf8_flags
+Signed-off-by: Shin Kojima <shin@kojima.org>
+---
+ lib/Net/IDN/Punycode.xs | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/lib/Net/IDN/Punycode.xs b/lib/Net/IDN/Punycode.xs
+index 211ef9c..36530dd 100644
+--- a/lib/Net/IDN/Punycode.xs
++++ b/lib/Net/IDN/Punycode.xs
+@@ -24,6 +24,10 @@
+ #define utf8_to_uvchr_buf(in_p,in_e,u8) utf8_to_uvchr(in_p,u8);
+ #endif
+ 
++#ifndef uvchr_to_utf8_flags
++#define uvchr_to_utf8_flags(d, uv, flags) uvuni_to_utf8_flags(d, uv, flags);
++#endif
++
+ static char enc_digit[BASE] = {
+   'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
+   'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
+@@ -253,7 +257,7 @@ decode_punycode(input)
+ 		  if(skip_p < re_p)				/* move succeeding chars */
+ 		    Move(skip_p, skip_p + u8, re_p - skip_p, char);
+ 		  re_p += u8;
+-		  uvuni_to_utf8_flags((U8*)skip_p, n, UNICODE_ALLOW_ANY);
++		  uvchr_to_utf8_flags((U8*)skip_p, n, UNICODE_ALLOW_ANY);
+ 		}
+ 
+ 		if(!first) SvUTF8_on(RETVAL);			/* UTF-8 chars have been inserted */
+-- 
+2.41.0
+


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/912440