### PR TITLE
app-benchmarks/pipebench: Fix call to undeclared function atoi

### DIFF
--- a/app-benchmarks/pipebench/files/pipebench-0.40-fix-build-clang16.patch
+++ b/app-benchmarks/pipebench/files/pipebench-0.40-fix-build-clang16.patch
@@ -1,0 +1,12 @@
+Bug: https://bugs.gentoo.org/894336
+--- a/pipebench.c
++++ b/pipebench.c
+@@ -28,6 +28,8 @@
+  */
+ #include <stdio.h>
+ #include <unistd.h>
++#include <stdlib.h>
++#include <string.h>
+ #include <time.h>
+ #include <signal.h>
+ #include <sys/time.h>

--- a/app-benchmarks/pipebench/pipebench-0.40-r3.ebuild
+++ b/app-benchmarks/pipebench/pipebench-0.40-r3.ebuild
@@ -1,0 +1,24 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit flag-o-matic toolchain-funcs
+
+DESCRIPTION="Measures the speed of stdin/stdout communication"
+HOMEPAGE="https://www.habets.pp.se/synscan/programs_pipebench.html"
+SRC_URI="https://www.habets.pp.se/synscan/files/${P}.tar.gz"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~ppc ~ppc64 ~x86 ~x86-linux"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-0.40-fix-build-system.patch
+	"${FILESDIR}"/${PN}-0.40-fix-build-clang16.patch
+)
+
+src_configure() {
+	append-cflags -Wall -w -pedantic
+	tc-export CC
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/894336