### PR TITLE
media-libs/libplacebo: new submodule, fast_float

### DIFF
--- a/media-libs/libplacebo/libplacebo-9999.ebuild
+++ b/media-libs/libplacebo/libplacebo-9999.ebuild
@@ -64,7 +64,7 @@ python_check_deps() {
 
 src_unpack() {
 	if [[ ${PV} == 9999 ]]; then
-		local EGIT_SUBMODULES=( $(usev opengl 3rdparty/glad) )
+		local EGIT_SUBMODULES=( $(usev opengl 3rdparty/glad) 3rdparty/fast_float )
 		git-r3_src_unpack
 	else
 		default


### PR DESCRIPTION
Required by `src/meson.build`.