### PR TITLE
media-libs/alsa-lib: backport musl for for 1.2.10

### DIFF
--- a/media-libs/alsa-lib/alsa-lib-1.2.10-r1.ebuild
+++ b/media-libs/alsa-lib/alsa-lib-1.2.10-r1.ebuild
@@ -35,6 +35,7 @@ BDEPEND="doc? ( >=app-doc/doxygen-1.2.6 )"
 PATCHES=(
 	"${FILESDIR}/${PN}-1.1.6-missing_files.patch" # bug #652422
 	"${FILESDIR}/${P}-musl-string.patch" # bug #913573, backport
+	"${FILESDIR}/${P}-ump-header-detection.patch" # bug #913573, backport
 )
 
 pkg_setup() {

--- a/media-libs/alsa-lib/alsa-lib-1.2.10.ebuild
+++ b/media-libs/alsa-lib/alsa-lib-1.2.10.ebuild
@@ -34,6 +34,7 @@ BDEPEND="doc? ( >=app-doc/doxygen-1.2.6 )"
 
 PATCHES=(
 	"${FILESDIR}/${PN}-1.1.6-missing_files.patch" # bug #652422
+	"${FILESDIR}/${P}-musl-string.patch" # bug #913573, backport
 )
 
 pkg_setup() {

--- a/media-libs/alsa-lib/files/alsa-lib-1.2.10-musl-string.patch
+++ b/media-libs/alsa-lib/files/alsa-lib-1.2.10-musl-string.patch
@@ -1,0 +1,40 @@
+From https://github.com/alsa-project/alsa-lib/commit/10bd599970acc71c92f85eb08943eb8d3d702a9c Mon Sep 17 00:00:00 2001
+From: Jaroslav Kysela <perex@perex.cz>
+Date: Wed, 6 Sep 2023 15:16:44 +0200
+Subject: [PATCH] global.h: move __STRING() macro outside !PIC ifdef block
+
+It solves the musl libc compilation issue.
+
+control.c: In function 'snd_ctl_open_conf':
+../../include/global.h:98:36: warning: implicit declaration of function '__STRING' [-Wimplicit-function-declaratio]
+   98 | #define SND_DLSYM_VERSION(version) __STRING(version)
+      |                                    ^~~~~~~~
+
+Fixes: https://github.com/alsa-project/alsa-lib/issues/350
+Signed-off-by: Jaroslav Kysela <perex@perex.cz>
+--- a/include/global.h
++++ b/include/global.h
+@@ -51,6 +51,11 @@ const char *snd_asoundlib_version(void);
+ #define ATTRIBUTE_UNUSED __attribute__ ((__unused__))
+ #endif
+ 
++#ifndef __STRING
++/** \brief Return 'x' argument as string */
++#define __STRING(x)     #x
++#endif
++
+ #ifdef PIC /* dynamic build */
+ 
+ /** \hideinitializer \brief Helper macro for #SND_DLSYM_BUILD_VERSION. */
+@@ -71,11 +76,6 @@ struct snd_dlsym_link {
+ 
+ extern struct snd_dlsym_link *snd_dlsym_start;
+ 
+-#ifndef __STRING
+-/** \brief Return 'x' argument as string */
+-#define __STRING(x)     #x
+-#endif
+-
+ /** \hideinitializer \brief Helper macro for #SND_DLSYM_BUILD_VERSION. */
+ #define __SND_DLSYM_VERSION(prefix, name, version) _ ## prefix ## name ## version
+ /**

--- a/media-libs/alsa-lib/files/alsa-lib-1.2.10-ump-header-detection.patch
+++ b/media-libs/alsa-lib/files/alsa-lib-1.2.10-ump-header-detection.patch
@@ -1,0 +1,31 @@
+From https://github.com/alsa-project/alsa-lib/commit/fcce13a6726c52882bd8b7131c61c4eba308792c Mon Sep 17 00:00:00 2001
+From: Jaroslav Kysela <perex@perex.cz>
+Date: Mon, 4 Sep 2023 09:38:26 +0200
+Subject: [PATCH] control.h: Fix ump header file detection
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Apparently, the control.h is used from apps separately (outside
+asoundlib.h). Avoid errors like:
+
+/usr/include/alsa/control.h:417:47: error: ‘snd_ump_endpoint_info_t’ has not been declared
+  417 | int snd_ctl_ump_endpoint_info(snd_ctl_t *ctl, snd_ump_endpoint_info_t *info);
+      |                                               ^~~~~~~~~~~~~~~~~~~~~~~
+/usr/include/alsa/control.h:418:44: error: ‘snd_ump_block_info_t’ has not been declared
+  418 | int snd_ctl_ump_block_info(snd_ctl_t *ctl, snd_ump_block_info_t *info);
+      |                                            ^~~~~~~~~~~~~~~~~~~~
+
+Fixes: https://github.com/alsa-project/alsa-lib/issues/348
+Signed-off-by: Jaroslav Kysela <perex@perex.cz>
+--- a/include/control.h
++++ b/include/control.h
+@@ -413,6 +413,8 @@ int snd_ctl_pcm_prefer_subdevice(snd_ctl_t *ctl, int subdev);
+ int snd_ctl_rawmidi_next_device(snd_ctl_t *ctl, int * device);
+ int snd_ctl_rawmidi_info(snd_ctl_t *ctl, snd_rawmidi_info_t * info);
+ int snd_ctl_rawmidi_prefer_subdevice(snd_ctl_t *ctl, int subdev);
++#endif
++#ifdef __ALSA_UMP_H
+ int snd_ctl_ump_next_device(snd_ctl_t *ctl, int *device);
+ int snd_ctl_ump_endpoint_info(snd_ctl_t *ctl, snd_ump_endpoint_info_t *info);
+ int snd_ctl_ump_block_info(snd_ctl_t *ctl, snd_ump_block_info_t *info);


### PR DESCRIPTION
No revbump because this almost definitely shouldn't affect anything else.
Closes: https://bugs.gentoo.org/913573