### PR TITLE
sys-apps/systemd: BDEPEND on >=dev-python/pyelftools-0.30 on loong

### DIFF
--- a/dev-python/pefile/pefile-2023.2.7.ebuild
+++ b/dev-python/pefile/pefile-2023.2.7.ebuild
@@ -15,7 +15,7 @@ if [[ ${PV} == 9999 ]] ; then
 	inherit git-r3
 else
 	SRC_URI="https://github.com/erocarrera/pefile/releases/download/v${PV}/${P}.tar.gz -> ${P}.gh.tar.gz"
-	KEYWORDS="amd64 ~arm ~arm64 ~riscv x86"
+	KEYWORDS="amd64 ~arm ~arm64 ~loong ~riscv x86"
 fi
 
 LICENSE="MIT"

--- a/dev-python/pefile/pefile-9999.ebuild
+++ b/dev-python/pefile/pefile-9999.ebuild
@@ -15,7 +15,7 @@ if [[ ${PV} == 9999 ]] ; then
 	inherit git-r3
 else
 	SRC_URI="https://github.com/erocarrera/pefile/releases/download/v${PV}/${P}.tar.gz -> ${P}.gh.tar.gz"
-	KEYWORDS="amd64 ~arm ~arm64 x86"
+	KEYWORDS="amd64 ~arm ~arm64 ~loong x86"
 fi
 
 LICENSE="MIT"

--- a/dev-python/pefile/pefile-9999.ebuild
+++ b/dev-python/pefile/pefile-9999.ebuild
@@ -15,7 +15,7 @@ if [[ ${PV} == 9999 ]] ; then
 	inherit git-r3
 else
 	SRC_URI="https://github.com/erocarrera/pefile/releases/download/v${PV}/${P}.tar.gz -> ${P}.gh.tar.gz"
-	KEYWORDS="amd64 ~arm ~arm64 ~loong x86"
+	KEYWORDS="amd64 ~arm ~arm64 ~loong ~riscv x86"
 fi
 
 LICENSE="MIT"

--- a/profiles/arch/loong/package.use.mask
+++ b/profiles/arch/loong/package.use.mask
@@ -59,12 +59,8 @@ app-accessibility/at-spi2-core dbus-broker
 
 # Mike Gilbert <floppym@gentoo.org> (2023-05-27)
 # Newer sd-boot does not use gnuefi.
-#
-# (xen0n: keep USE=boot masked before fixed dev-python/pyelftools is tagged
-# and packaged, so we can have systemd-254 keyworded on loong a bit earlier.
-# The systemd-boot feature was never available before anyway.)
-#>=sys-apps/systemd-254 -boot
-#>=sys-apps/systemd-utils-254 -boot
+>=sys-apps/systemd-254 -boot
+>=sys-apps/systemd-utils-254 -boot
 
 # WANG Xuerui <xen0n@gentoo.org> (2023-04-16)
 # dev-python/pyopengl fails tests

--- a/sys-apps/systemd/systemd-254.1-r2.ebuild
+++ b/sys-apps/systemd/systemd-254.1-r2.ebuild
@@ -171,7 +171,7 @@ BDEPEND="
 		dev-python/jinja[\${PYTHON_USEDEP}]
 		dev-python/lxml[\${PYTHON_USEDEP}]
 		boot? (
-			dev-python/pyelftools[\${PYTHON_USEDEP}]
+			>=dev-python/pyelftools-0.30[\${PYTHON_USEDEP}]
 			test? ( ${PEFILE_DEPEND} )
 		)
 	")

--- a/sys-apps/systemd/systemd-9999.ebuild
+++ b/sys-apps/systemd/systemd-9999.ebuild
@@ -171,7 +171,7 @@ BDEPEND="
 		dev-python/jinja[\${PYTHON_USEDEP}]
 		dev-python/lxml[\${PYTHON_USEDEP}]
 		boot? (
-			dev-python/pyelftools[\${PYTHON_USEDEP}]
+			>=dev-python/pyelftools-0.30[\${PYTHON_USEDEP}]
 			test? ( ${PEFILE_DEPEND} )
 		)
 	")


### PR DESCRIPTION
The loong support has been fixed since this version of pyelftools. Also, restore the USE=boot unmask while at it.