### PR TITLE
dev-lang/perl: Fix clang check in configure

### DIFF
--- a/dev-lang/perl/files/perl-5.36.0-fix-configure-for-clang.patch
+++ b/dev-lang/perl/files/perl-5.36.0-fix-configure-for-clang.patch
@@ -1,0 +1,41 @@
+From 40db21129c0ba08ea457b6e40e7357e86ea1404b Mon Sep 17 00:00:00 2001
+From: Raul E Rangel <rrangel@chromium.org>
+Date: Fri, 28 Jul 2023 15:50:49 -0600
+Subject: [PATCH] hints/linux: Add additional expression when matching clang
+
+Newer versions of clang actually print the distro before `clang` when
+calling `$CC --version`. This changes fixes the regex so it can match
+this new pattern.
+
+i.e.,
+
+	$ clang --version
+	Debian clang version 14.0.6
+
+	$ x86_64-pc-linux-gnu-clang --version
+	Chromium OS 17.0_pre496208_p20230501-r1 clang version 17.0.0
+
+Fixes #21099
+
+BUG=b:283275881
+See: https://github.com/Perl/perl5/issues/21099
+---
+ hints/linux.sh | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/hints/linux.sh b/hints/linux.sh
+index e1508c7509..5202b28b09 100644
+--- a/hints/linux.sh
++++ b/hints/linux.sh
+@@ -166,7 +166,7 @@ esac
+ if [ -x /usr/bin/gcc ] ; then
+     gcc=/usr/bin/gcc
+ # clang also provides -print-search-dirs
+-elif ${cc:-cc} --version 2>/dev/null | grep -q '^clang ' ; then
++elif ${cc:-cc} --version 2>/dev/null | grep -q -e '^clang version' -e ' clang version'; then
+     gcc=${cc:-cc}
+ else
+     gcc=gcc
+-- 
+2.41.0.585.gd2178a4bd4-goog
+

--- a/dev-lang/perl/perl-5.36.1-r4.ebuild
+++ b/dev-lang/perl/perl-5.36.1-r4.ebuild
@@ -395,6 +395,10 @@ src_prepare() {
 	add_patch "${FILESDIR}/${PN}-5.36.1-http-tiny.patch" "0111-5.36.1-http-tiny.patch"\
 			"Enable certificate checking in HTTP::Tiny by default"\
 			"https://bugs.gentoo.org/905296" "https://bugs.debian.org/954089"
+	add_patch "${FILESDIR}/${PN}-5.36.0-fix-configure-for-clang.patch" \
+			"100-5.36.0-fix-configure-for-clang.patch" \
+			"Fix clang check in configure" \
+			"https://github.com/Perl/perl5/issues/21099"
 
 	if [[ ${CHOST} == *-solaris* ]] ; then
 		# do NOT mess with nsl, on Solaris this is always necessary,

--- a/dev-lang/perl/perl-5.38.0-r2.ebuild
+++ b/dev-lang/perl/perl-5.38.0-r2.ebuild
@@ -395,6 +395,10 @@ src_prepare() {
 	# add_patch "${FILESDIR}/${PN}-5.26.2-hppa.patch" "100-5.26.2-hppa.patch"\
 	#		"Fix broken miniperl on hppa"\
 	#		"https://bugs.debian.org/869122" "https://bugs.gentoo.org/634162"
+	add_patch "${FILESDIR}/${PN}-5.36.0-fix-configure-for-clang.patch" \
+			"100-5.36.0-fix-configure-for-clang.patch" \
+			"Fix clang check in configure" \
+			"https://github.com/Perl/perl5/issues/21099"
 
 	if [[ ${CHOST} == *-solaris* ]] ; then
 		# do NOT mess with nsl, on Solaris this is always necessary,


### PR DESCRIPTION
The check was a bit too strict. `clang` actually appears in the middle
of the version string. This change will allow perl to build correctly
when `gcc` isn't present on the system.

See: https://github.com/Perl/perl5/issues/21099
