### PR TITLE
app-emulation/qemu: build pipewire audio-drv

### DIFF
--- a/app-emulation/qemu/qemu-8.1.0-r1.ebuild
+++ b/app-emulation/qemu/qemu-8.1.0-r1.ebuild
@@ -609,6 +609,7 @@ qemu_src_configure() {
 			# Note: backend order matters here: #716202
 			# We iterate from higher-level to lower level.
 			$(usex pulseaudio pa "")
+			$(usev pipewire)
 			$(usev jack)
 			$(usev sdl)
 			$(usev alsa)

--- a/app-emulation/qemu/qemu-9999.ebuild
+++ b/app-emulation/qemu/qemu-9999.ebuild
@@ -613,6 +613,7 @@ qemu_src_configure() {
 			# Note: backend order matters here: #716202
 			# We iterate from higher-level to lower level.
 			$(usex pulseaudio pa "")
+			$(usev pipewire)
 			$(usev jack)
 			$(usev sdl)
 			$(usev alsa)


### PR DESCRIPTION
This patch adds the pipewire audio-drv to the
audio-drv list if pipewire USE flag is enabled.