### PR TITLE
sys-apps/hdparm: fix post-build strip

### DIFF
--- a/sys-apps/hdparm/hdparm-9.65-r1.ebuild
+++ b/sys-apps/hdparm/hdparm-9.65-r1.ebuild
@@ -1,0 +1,45 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs flag-o-matic
+
+DESCRIPTION="Utility to change hard drive performance parameters"
+HOMEPAGE="https://sourceforge.net/projects/hdparm/"
+SRC_URI="mirror://sourceforge/hdparm/${P}.tar.gz"
+
+# GPL-2 only
+LICENSE="BSD GPL-2"
+SLOT="0"
+KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux"
+IUSE="static"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-9.60-build.patch
+)
+
+src_prepare() {
+	default
+
+	use static && append-ldflags -static
+}
+
+src_compile() {
+	emake STRIP="true" CC="$(tc-getCC)" || die
+}
+
+src_install() {
+	into /
+	dosbin hdparm contrib/idectl
+
+	newinitd "${FILESDIR}"/hdparm-init-8 hdparm
+	newconfd "${FILESDIR}"/hdparm-conf.d.3 hdparm
+
+	doman hdparm.8
+	dodoc hdparm.lsm Changelog README.acoustic hdparm-sysconfig
+
+	docinto wiper
+	dodoc wiper/{README.txt,wiper.sh}
+	docompress -x /usr/share/doc/${PF}/wiper/wiper.sh
+}


### PR DESCRIPTION
Export STRIP only for emake step, to avoid confusing portage's strip step.

```
- strip: strip --strip-unneeded -N __gentoo_check_ldflags__ -R .comment -R .GCC.command.line -R .note.gnu.gold-version
+ strip: llvm-strip --strip-unneeded -N __gentoo_check_ldflags__ -R .comment -R .GCC.command.line -R .note.gnu.gold-version /sbin/hdparm
-strip: Unable to recognise the format of the input file `/build/cherry/tmp/portage/sys-apps/hdparm-9.65/image/sbin/hdparm'
```

Closes: https://bugs.gentoo.org/913959