### PR TITLE
app-misc/regex-markup: update EAPI 6 -> 8

### DIFF
--- a/app-misc/regex-markup/files/regex-markup-0.10.0-r2-configure.patch
+++ b/app-misc/regex-markup/files/regex-markup-0.10.0-r2-configure.patch
@@ -1,0 +1,15 @@
+ configure.ac | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/configure.ac b/configure.ac
+index 0b98557..3e24e2e 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -19,6 +19,7 @@ AC_DEFINE_DIR(PKGDATADIR, datadir/$PACKAGE, [Directory where system-wide rule fi
+ # Checks for programs.
+ AC_PROG_CC
+ AC_PROG_INSTALL
++AM_PROG_AR
+ #AC_PROG_MAKE_SET
+ AC_PROG_RANLIB
+ AM_PROG_LEX

--- a/app-misc/regex-markup/regex-markup-0.10.0-r2.ebuild
+++ b/app-misc/regex-markup/regex-markup-0.10.0-r2.ebuild
@@ -1,0 +1,44 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit flag-o-matic autotools
+
+DESCRIPTION="A tool to color syslog files as well"
+HOMEPAGE="http://www.nongnu.org/regex-markup/"
+SRC_URI="https://savannah.nongnu.org/download/regex-markup/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86"
+IUSE="examples nls"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-locale.patch
+	"${FILESDIR}"/${PN}-0.10.0-r2-configure.patch
+)
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_configure() {
+	# fix #570960 by restoring pre-GCC5 inline semantics
+	append-cflags -std=gnu89
+
+	local myconf=(
+		--enable-largefile
+		$(use_enable nls)
+	)
+	econf "${myconf[@]}"
+}
+
+src_install() {
+	default
+	if use examples; then
+		cd examples || die
+		emake -f Makefile
+	fi
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/722328