### PR TITLE
app-text/sablotron: Fix C++17 does not allow register storage class

### DIFF
--- a/app-text/sablotron/files/1.0.3-drop-register-keyword.patch
+++ b/app-text/sablotron/files/1.0.3-drop-register-keyword.patch
@@ -1,0 +1,14 @@
+Bug: https://bugs.gentoo.org/894710
+--- a/src/engine/hash.cpp
++++ b/src/engine/hash.cpp
+@@ -305,8 +305,8 @@ void HashTable::report(Sit S, MsgType type, MsgCode code, const Str& arg1, const
+ 
+ oolong hash(const Str& key)
+ {
+-   register oolong a, b, c, len;
+-   register const char *k = (const char*) key;
++   oolong a, b, c, len;
++   const char *k = (const char*) key;
+ 
+    /* Set up the internal state */
+    len = key.length();

--- a/app-text/sablotron/sablotron-1.0.3-r3.ebuild
+++ b/app-text/sablotron/sablotron-1.0.3-r3.ebuild
@@ -1,0 +1,57 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools
+
+MY_PN="Sablot"
+MY_P="${MY_PN}-${PV}"
+S=${WORKDIR}/${MY_P}
+
+DESCRIPTION="An XSLT Parser in C++"
+HOMEPAGE="https://sourceforge.net/projects/sablotron/"
+SRC_URI="mirror://sourceforge/sablotron/${MY_P}.tar.gz"
+
+# Sablotron can optionally be built under GPL, using MPL for now
+LICENSE="MPL-1.1"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
+IUSE="perl"
+
+RDEPEND="
+	>=dev-libs/expat-1.95.6-r1
+"
+DEPEND="
+	${RDEPEND}
+"
+BDEPEND="
+	>=dev-perl/XML-Parser-2.3
+"
+DOCS=(
+	README README_JS RELEASE src/TODO
+)
+PATCHES=(
+	"${FILESDIR}"/1.0.3-libsablot-expat.patch
+	"${FILESDIR}"/1.0.3-cxx11.patch
+	"${FILESDIR}"/1.0.3-drop-register-keyword.patch
+)
+
+src_prepare() {
+	default
+	sed -i configure.in -e 's|AM_CONFIG_HEADER|AC_CONFIG_HEADERS|g' || die
+	mv configure.{in,ac} || die
+	eautoreconf
+}
+
+src_configure() {
+	econf \
+		--disable-static \
+		$(use_enable perl perlconnect) \
+		--with-html-dir="${EPREFIX}"/usr/share/doc/${PF}/html
+}
+
+src_install() {
+	default
+	find "${ED}" -name '*.la' -delete || die
+}


### PR DESCRIPTION
And update EAPI 7 -> 8

Closes: https://bugs.gentoo.org/894710