### PR TITLE
sys-apps/darwin-miscutils: fix build with clang

### DIFF
--- a/sys-apps/darwin-miscutils/darwin-miscutils-12.ebuild
+++ b/sys-apps/darwin-miscutils/darwin-miscutils-12.ebuild
@@ -42,6 +42,7 @@ src_prepare() {
 	cp "${DISTDIR}"/adv_cmds-md-${MD_VER}.c md/md.c || die
 	cp "${DISTDIR}"/adv_cmds-md-${MD_VER}.1 md/md.1 || die
 	eapply "${DISTDIR}"/adv_cmds-md-${MD_VER}-compile.patch
+	eapply "${FILESDIR}"/${PN}-12-md-register.patch
 
 	cd "${S}"
 	eapply_user

--- a/sys-apps/darwin-miscutils/files/darwin-miscutils-12-md-register.patch
+++ b/sys-apps/darwin-miscutils/files/darwin-miscutils-12-md-register.patch
@@ -1,0 +1,14 @@
+Fix build with clang https://bugs.gentoo.org/758167
+
+--- a/md/md.c
++++ b/md/md.c
+@@ -148,8 +148,7 @@ static void parse_dep();
+ static void save_dot_o();
+ 
+ int
+-main(argc,argv)
+-register char **argv;
++main(int argc, char** argv)
+ {
+ int size;
+ 


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/758167