### PR TITLE
distutils-r1.eclass: teach setuptools to respect (some) build options

### DIFF
--- a/eclass/python-utils-r1.eclass
+++ b/eclass/python-utils-r1.eclass
@@ -1242,10 +1242,6 @@ _python_check_EPYTHON() {
 _python_check_occluded_packages() {
 	debug-print-function ${FUNCNAME} "${@}"
 
-	# DO NOT ENABLE THIS unless you're going to check for false
-	# positives before filing bugs.
-	[[ ! ${PYTHON_EXPERIMENTAL_QA} ]] && return
-
 	[[ -z ${BUILD_DIR} || ! -d ${BUILD_DIR}/install ]] && return
 
 	local sitedir="${BUILD_DIR}/install$(python_get_sitedir)"


### PR DESCRIPTION
Previously, setup.py was handled by:

- manually passing makejobs, with a heuristic to guess whether it was a time saver to do so.
- rm -rf'ing the build directory in between python versions to prevent cross-version contamination

This is because in PEP 517 mode, it doesn't accept build options specific to a setuptools phase. So a crude hack is to just build_ext twice, once explicitly and once internally as part of bdist_wheel, and pray that in the latter case it detects that there's nothing to do. Unfortunately, sometimes build_ext does NOT detect that there is nothing to do -- e.g. for codegen tools such as mypyc, that produce *.c files which are different every time you try building. As for build directories, those were given up on as hopeless.

There's a better hack which is to set a magic environment variable for a setup.cfg file which is parsed additionally to the one provided by the project. It can contain additional settings, such as the build-base and parallelism, which means that bdist_wheel intrinsically builds extensions in parallel the only time it is called. And we can set the output directory for all build artifacts to outside of the source tree, so it is no longer necessary to delete them (which among other things, makes debugging difficult).

This is similar to .pydistutils.cfg, but is processed later and can be in arbitrary locations. Since we store it in the per-impl build directory we don't need to wipe it after using it to avoid leakage.

Split out from #32598