### PR TITLE
Clang prefix on Darwin

### DIFF
--- a/eclass/llvm.eclass
+++ b/eclass/llvm.eclass
@@ -80,6 +80,13 @@ DEPEND="!!sys-devel/llvm:0"
 # Correct values of LLVM slots, newest first.
 declare -g -r _LLVM_KNOWN_SLOTS=( {18..8} )
 
+# @ECLASS_VARIABLE: LLVM_ECLASS_SKIP_PKG_SETUP
+# @INTERNAL
+# @DESCRIPTION:
+# If set to a non-empty value, llvm_pkg_setup will not perform LLVM version
+# check, nor set PATH.  Useful for bootstrap-prefix.sh, where AppleClang has
+# unparseable version numbers, which are irrelevant anyway.
+
 # @FUNCTION: get_llvm_slot
 # @USAGE: [-b|-d] [<max_slot>]
 # @DESCRIPTION:
@@ -241,6 +248,10 @@ llvm_fix_tool_path() {
 # should be inlined into the ebuild and modified as necessary.
 llvm_pkg_setup() {
 	debug-print-function ${FUNCNAME} "${@}"
+
+	if [[ ${LLVM_ECLASS_SKIP_PKG_SETUP} ]]; then
+		return
+	fi
 
 	if [[ ${MERGE_TYPE} != binary ]]; then
 		LLVM_SLOT=$(get_llvm_slot "${LLVM_MAX_SLOT}")

--- a/sys-devel/llvm/llvm-16.0.6.ebuild
+++ b/sys-devel/llvm/llvm-16.0.6.ebuild
@@ -425,6 +425,13 @@ multilib_src_configure() {
 		)
 	fi
 
+	# On Macos prefix, Gentoo doesn't split sys-libs/ncurses to libtinfo and
+	# libncurses, but llvm tries to use libtinfo before libncurses, and ends up
+	# using libtinfo (actually, libncurses.dylib) from system instead of prefix
+	use kernel_Darwin && mycmakeargs+=(
+		-DTerminfo_LIBRARIES=-lncurses
+	)
+
 	# workaround BMI bug in gcc-7 (fixed in 7.4)
 	# https://bugs.gentoo.org/649880
 	# apply only to x86, https://bugs.gentoo.org/650506

--- a/sys-devel/llvm/llvm-17.0.0_rc4.ebuild
+++ b/sys-devel/llvm/llvm-17.0.0_rc4.ebuild
@@ -439,6 +439,13 @@ multilib_src_configure() {
 		)
 	fi
 
+	# On Macos prefix, Gentoo doesn't split sys-libs/ncurses to libtinfo and
+	# libncurses, but llvm tries to use libtinfo before libncurses, and ends up
+	# using libtinfo (actually, libncurses.dylib) from system instead of prefix
+	use kernel_Darwin && mycmakeargs+=(
+		-DTerminfo_LIBRARIES=-lncurses
+	)
+
 	# workaround BMI bug in gcc-7 (fixed in 7.4)
 	# https://bugs.gentoo.org/649880
 	# apply only to x86, https://bugs.gentoo.org/650506

--- a/sys-devel/llvm/llvm-17.0.1.9999.ebuild
+++ b/sys-devel/llvm/llvm-17.0.1.9999.ebuild
@@ -439,6 +439,13 @@ multilib_src_configure() {
 		)
 	fi
 
+	# On Macos prefix, Gentoo doesn't split sys-libs/ncurses to libtinfo and
+	# libncurses, but llvm tries to use libtinfo before libncurses, and ends up
+	# using libtinfo (actually, libncurses.dylib) from system instead of prefix
+	use kernel_Darwin && mycmakeargs+=(
+		-DTerminfo_LIBRARIES=-lncurses
+	)
+
 	# workaround BMI bug in gcc-7 (fixed in 7.4)
 	# https://bugs.gentoo.org/649880
 	# apply only to x86, https://bugs.gentoo.org/650506

--- a/sys-devel/llvm/llvm-17.0.1.ebuild
+++ b/sys-devel/llvm/llvm-17.0.1.ebuild
@@ -439,6 +439,13 @@ multilib_src_configure() {
 		)
 	fi
 
+	# On Macos prefix, Gentoo doesn't split sys-libs/ncurses to libtinfo and
+	# libncurses, but llvm tries to use libtinfo before libncurses, and ends up
+	# using libtinfo (actually, libncurses.dylib) from system instead of prefix
+	use kernel_Darwin && mycmakeargs+=(
+		-DTerminfo_LIBRARIES=-lncurses
+	)
+
 	# workaround BMI bug in gcc-7 (fixed in 7.4)
 	# https://bugs.gentoo.org/649880
 	# apply only to x86, https://bugs.gentoo.org/650506

--- a/sys-devel/llvm/llvm-18.0.0.9999.ebuild
+++ b/sys-devel/llvm/llvm-18.0.0.9999.ebuild
@@ -438,6 +438,13 @@ multilib_src_configure() {
 		)
 	fi
 
+	# On Macos prefix, Gentoo doesn't split sys-libs/ncurses to libtinfo and
+	# libncurses, but llvm tries to use libtinfo before libncurses, and ends up
+	# using libtinfo (actually, libncurses.dylib) from system instead of prefix
+	use kernel_Darwin && mycmakeargs+=(
+		-DTerminfo_LIBRARIES=-lncurses
+	)
+
 	# workaround BMI bug in gcc-7 (fixed in 7.4)
 	# https://bugs.gentoo.org/649880
 	# apply only to x86, https://bugs.gentoo.org/650506

--- a/sys-devel/llvm/llvm-18.0.0_pre20230906.ebuild
+++ b/sys-devel/llvm/llvm-18.0.0_pre20230906.ebuild
@@ -438,6 +438,13 @@ multilib_src_configure() {
 		)
 	fi
 
+	# On Macos prefix, Gentoo doesn't split sys-libs/ncurses to libtinfo and
+	# libncurses, but llvm tries to use libtinfo before libncurses, and ends up
+	# using libtinfo (actually, libncurses.dylib) from system instead of prefix
+	use kernel_Darwin && mycmakeargs+=(
+		-DTerminfo_LIBRARIES=-lncurses
+	)
+
 	# workaround BMI bug in gcc-7 (fixed in 7.4)
 	# https://bugs.gentoo.org/649880
 	# apply only to x86, https://bugs.gentoo.org/650506


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/758167

Perhaps the patch should be included into mgorny's patchset instead

I'm making this flag global because quite a few LLVM packages require this, and there will be one more (sys-devel/clang-common), which is not in this PR.