### PR TITLE
x11-libs/libXfont2: only depend on libbsd when necessary

### DIFF
--- a/x11-libs/libXfont2/libXfont2-2.0.6-r1.ebuild
+++ b/x11-libs/libXfont2/libXfont2-2.0.6-r1.ebuild
@@ -1,0 +1,35 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+XORG_DOC=doc
+XORG_PACKAGE_NAME=libxfont
+XORG_TARBALL_SUFFIX="xz"
+inherit xorg-3
+
+DESCRIPTION="X.Org Xfont library"
+
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x64-solaris"
+IUSE="bzip2 truetype"
+
+RDEPEND="sys-libs/zlib
+	elibc_glibc? ( || ( >=sys-libs/glibc-2.38 dev-libs/libbsd ) )
+	x11-libs/libfontenc
+	bzip2? ( app-arch/bzip2 )
+	truetype? ( >=media-libs/freetype-2 )"
+DEPEND="${RDEPEND}
+	x11-base/xorg-proto
+	x11-libs/xtrans"
+
+src_configure() {
+	local XORG_CONFIGURE_OPTIONS=(
+		--enable-ipv6
+		$(use_enable doc devel-docs)
+		$(use_with doc xmlto)
+		$(use_with bzip2)
+		$(use_enable truetype freetype)
+		--without-fop
+	)
+	xorg-3_src_configure
+}


### PR DESCRIPTION
With glibc >=2.38 we no longer need to unconditionally depend on libbsd. This brings libXfont2 in line with other X libs.
