### PR TITLE
net-libs/gsoap: Fix incompatible integer to pointer conversion

### DIFF
--- a/net-libs/gsoap/files/gsoap-2.8.130-musl-strerror_r.patch
+++ b/net-libs/gsoap/files/gsoap-2.8.130-musl-strerror_r.patch
@@ -1,0 +1,59 @@
+Bug: https://bugs.gentoo.org/897870
+From: Brahmajit Das <brahmajit.xyz@gmail.com>
+Date: Tue, 12 Sep 2023 17:32:42 +0000
+Subject: [PATCH] Fix incompatible integer to pointer conversion on musl
+
+musl libc only supports XSI-compliant version of strerror_r. Hence we
+need to check if __GLIBC__ is defined or not.
+
+Also it's incorrectly assumed to use a differnt version of gethostbyname_r than
+that's available with glibc or musl libc. Without the extra !defined(__GLIBC__)
+the condition goes straight to the following section of the code
+```
+#elif defined(HAVE_GETHOSTBYNAME_R)
+  hostent = gethostbyname_r(addr, hostent, tmpbuf, tmplen, &soap->errnum);
+#elif defined(VXWORKS)
+```
+Which is not the correct implementation of gethostbyname_r present.
+
+Signed-off-by: Brahmajit Das <brahmajit.xyz@gmail.com>
+--- a/gsoap/stdsoap2.c
++++ b/gsoap/stdsoap2.c
+@@ -23145,7 +23145,7 @@ soap_strerror(struct soap *soap)
+   {
+ #ifndef WIN32
+ # ifdef HAVE_STRERROR_R
+-#  if !defined(_GNU_SOURCE) || (!(~_GNU_SOURCE+1) && ((!defined(_POSIX_C_SOURCE) && !defined(_XOPEN_SOURCE)) || (_POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600)))
++#  if !defined(_GNU_SOURCE) || (!(~_GNU_SOURCE+1) && ((!defined(_POSIX_C_SOURCE) && !defined(_XOPEN_SOURCE)) || (_POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600))) || !defined(__GLIBC__)
+     err = strerror_r(err, soap->msgbuf, sizeof(soap->msgbuf)); /* XSI-compliant */
+     if (err != 0)
+       soap_strcpy(soap->msgbuf, sizeof(soap->msgbuf), "unknown error");
+--- a/gsoap/stdsoap2.cpp
++++ b/gsoap/stdsoap2.cpp
+@@ -5457,7 +5457,7 @@ tcp_gethostbyname(struct soap *soap, const char *addr, struct hostent *hostent,
+ {
+ #if (defined(_AIX43) || defined(TRU64) || defined(HP_UX)) && defined(HAVE_GETHOSTBYNAME_R)
+   struct hostent_data ht_data;
+-#elif (!defined(_GNU_SOURCE) || (!(~_GNU_SOURCE+1) && !defined(_POSIX_C_SOURCE) && !defined(_XOPEN_SOURCE)) || _POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600 || defined(__ANDROID__) || defined(FREEBSD) || defined(__FreeBSD__)) && defined(HAVE_GETHOSTBYNAME_R)
++#elif (!defined(_GNU_SOURCE) || (!(~_GNU_SOURCE+1) && !defined(_POSIX_C_SOURCE) && !defined(_XOPEN_SOURCE)) || _POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600 || defined(__ANDROID__) || defined(FREEBSD) || defined(__FreeBSD__)) && defined(HAVE_GETHOSTBYNAME_R) || !defined(__GLIBC__)
+   int r;
+   char *tmpbuf = soap->tmpbuf;
+   size_t tmplen = sizeof(soap->tmpbuf);
+@@ -5490,7 +5490,7 @@ tcp_gethostbyname(struct soap *soap, const char *addr, struct hostent *hostent,
+     hostent = NULL;
+     soap->errnum = h_errno;
+   }
+-#elif (!defined(_GNU_SOURCE) || (!(~_GNU_SOURCE+1) && !defined(_POSIX_C_SOURCE) && !defined(_XOPEN_SOURCE)) || _POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600 || defined(__ANDROID__) || defined(FREEBSD) || defined(__FreeBSD__)) && !defined(SUN_OS) && !defined(__QNX__) && !defined(QNX) && defined(HAVE_GETHOSTBYNAME_R)
++#elif (!defined(_GNU_SOURCE) || (!(~_GNU_SOURCE+1) && !defined(_POSIX_C_SOURCE) && !defined(_XOPEN_SOURCE)) || _POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600 || defined(__ANDROID__) || defined(FREEBSD) || defined(__FreeBSD__))  || !defined(__GLIBC__) && !defined(SUN_OS) && !defined(__QNX__) && !defined(QNX) && defined(HAVE_GETHOSTBYNAME_R)
+   while ((r = gethostbyname_r(addr, hostent, tmpbuf, tmplen, &hostent, &soap->errnum)) < 0)
+   {
+     if (tmpbuf != soap->tmpbuf)
+@@ -23145,7 +23145,7 @@ soap_strerror(struct soap *soap)
+   {
+ #ifndef WIN32
+ # ifdef HAVE_STRERROR_R
+-#  if !defined(_GNU_SOURCE) || (!(~_GNU_SOURCE+1) && ((!defined(_POSIX_C_SOURCE) && !defined(_XOPEN_SOURCE)) || (_POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600)))
++#  if !defined(_GNU_SOURCE) || (!(~_GNU_SOURCE+1) && ((!defined(_POSIX_C_SOURCE) && !defined(_XOPEN_SOURCE)) || (_POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600))) || !defined(__GLIBC__)
+     err = strerror_r(err, soap->msgbuf, sizeof(soap->msgbuf)); /* XSI-compliant */
+     if (err != 0)
+       soap_strcpy(soap->msgbuf, sizeof(soap->msgbuf), "unknown error");

--- a/net-libs/gsoap/gsoap-2.8.130-r1.ebuild
+++ b/net-libs/gsoap/gsoap-2.8.130-r1.ebuild
@@ -1,0 +1,83 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools
+
+MY_P="${PN}-2.8"
+DESCRIPTION="A cross-platform open source C and C++ SDK for SOAP/XML Web services"
+HOMEPAGE="http://gsoap2.sourceforge.net"
+SRC_URI="mirror://sourceforge/gsoap2/gsoap_${PV}.zip"
+S="${WORKDIR}/${MY_P}"
+
+LICENSE="|| ( gSOAP-1.3b GPL-2+-with-openssl-exception ) GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="doc debug examples ipv6 gnutls +ssl"
+
+RDEPEND="
+	sys-libs/zlib
+	gnutls? ( net-libs/gnutls )
+	ssl? (
+		dev-libs/openssl:=
+	)
+"
+DEPEND="
+	${RDEPEND}
+"
+BDEPEND="
+	app-arch/unzip
+	sys-devel/bison
+	sys-devel/flex
+"
+
+PATCHES=(
+	# Enable shared libs (bug #583398)
+	"${FILESDIR}/${PN}-2.8.130-shared_libs.patch"
+	# use XSI-compliant version of strerror_r() on musl
+	"${FILESDIR}/${PN}-2.8.130-musl-strerror_r.patch"
+)
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_configure() {
+	unset YACC LEX
+
+	local myeconfargs=(
+		# Don't include xlocale.h as it got removed in >=glibc-2.26
+		--disable-xlocale
+		$(use_enable debug)
+		$(use_enable gnutls)
+		$(usev ipv6 --enable-ipv6)
+		$(usev !ssl --disable-ssl)
+	)
+
+	econf "${myeconfargs[@]}"
+}
+
+src_install() {
+	emake DESTDIR="${D}" install
+
+	# Yes, we also install the license-file since
+	# it contains info about how to apply the licenses.
+	dodoc *.txt
+
+	docinto html
+	dodoc changelog.md
+
+	find "${ED}" \( -name "*.a" -o -name "*.la" \) -delete || die
+
+	if use examples; then
+		insinto /usr/share/${PN}/examples
+		doins -r gsoap/samples/*
+	fi
+
+	if use doc; then
+		docinto html
+		dodoc -r gsoap/doc/*
+	fi
+}


### PR DESCRIPTION
and update EAPI 7 -> 8

Closes: https://bugs.gentoo.org/897870