### PR TITLE
net-irc/irssistats: Fix call to undeclared library function isdigit

### DIFF
--- a/net-irc/irssistats/files/irssistats-0.75-clang16-build-fix.patch
+++ b/net-irc/irssistats/files/irssistats-0.75-clang16-build-fix.patch
@@ -1,0 +1,40 @@
+Bug: https://bugs.gentoo.org/897866
+--- a/irssistats.c
++++ b/irssistats.c
+@@ -29,6 +29,7 @@
+ #include <time.h>
+ #include <string.h>
+ #include <locale.h>
++#include <ctype.h>
+ #ifdef __WIN32__
+ #define GLOBALCONF "irssistats.conf"
+ #else
+@@ -1561,19 +1562,19 @@ void gen_xhtml(char *xhtmlfile)
+   fclose(fic);
+ }
+ 
+-void parse_config(char *configfile)
++void expand(char *path)
+ {
+-  void expand(char *path)
++  char temp[MAXLINELENGTH];
++  if (*path=='~')
+   {
+-    char temp[MAXLINELENGTH];
+-    if (*path=='~')
+-    {
+-      snprintf(temp,MAXLINELENGTH-1,"%s%s",getenv("HOME"),path+1);
+-      temp[MAXLINELENGTH-1]='\0';
+-      strcpy(path,temp);
+-    }
++    snprintf(temp,MAXLINELENGTH-1,"%s%s",getenv("HOME"),path+1);
++    temp[MAXLINELENGTH-1]='\0';
++    strcpy(path,temp);
+   }
++}
+   
++void parse_config(char *configfile)
++{
+   FILE *fic;
+   char line[MAXLINELENGTH];
+   char keyword[MAXLINELENGTH];

--- a/net-irc/irssistats/irssistats-0.75-r2.ebuild
+++ b/net-irc/irssistats/irssistats-0.75-r2.ebuild
@@ -1,0 +1,37 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs
+
+DESCRIPTION="Generates HTML IRC stats based on irssi logs"
+HOMEPAGE="http://royale.zerezo.com/irssistats/"
+SRC_URI="http://royale.zerezo.com/irssistats/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+
+KEYWORDS="~amd64 ~ppc ~sparc ~x86"
+
+DEPEND="net-irc/irssi"
+
+PATCHES=(
+	"${FILESDIR}/${P}-Makefile.patch"
+	"${FILESDIR}/${P}-clang16-build-fix.patch"
+)
+
+src_prepare() {
+	default
+}
+
+src_compile() {
+	emake CC="$(tc-getCC)" CFLAGS="${CFLAGS}" LDFLAGS="${LDFLAGS}"
+}
+
+src_install() {
+	emake \
+		PRE="${D}"/usr \
+		DOC="${D}"/usr/share/doc/${PF} \
+		install
+}


### PR DESCRIPTION
and update EAPI 6 -> 8

Closes: https://bugs.gentoo.org/897866