### PR TITLE
net-analyzer/tcptrace: Fix call to undeclared function fpurge

### DIFF
--- a/net-analyzer/tcptrace/files/tcptrace-6.6.7-fix-build-clang16.patch
+++ b/net-analyzer/tcptrace/files/tcptrace-6.6.7-fix-build-clang16.patch
@@ -1,0 +1,30 @@
+Bug: https://bugs.gentoo.org/897830
+--- a/compress.c
++++ b/compress.c
+@@ -61,6 +61,8 @@ static char const GCC_UNUSED rcsid[] =
+ 
+ #include "compress.h"
+ #include <sys/wait.h>
++#include <stdio.h>
++#include <stdio_ext.h>
+ 
+ /*
+  * OK, this stuff is a little complicated.  Here's why:
+@@ -240,7 +242,7 @@ CompReopenFile(
+     /* erase the file buffer and reposition to the front */
+ #ifdef HAVE_FPURGE
+     /* needed for NetBSD and FreeBSD (at least) */
+-    fpurge(stdin);		/* discard input buffer */
++    __fpurge(stdin);		/* discard input buffer */
+ #else /* HAVE_FPURGE */
+     fflush(stdin);		/* discard input buffer */
+ #endif /* HAVE_FPURGE */
+@@ -599,7 +601,7 @@ PipeHelper(void)
+     // read end of the pipe, fdpipe[0]
+     
+ #ifdef HAVE_FPURGE     
+-     fpurge(stdin); // needed for NetBSD/FreeBSD
++     __fpurge(stdin); // needed for NetBSD/FreeBSD
+ #else
+      fflush(stdin);
+ #endif

--- a/net-analyzer/tcptrace/tcptrace-6.6.7_p6-r1.ebuild
+++ b/net-analyzer/tcptrace/tcptrace-6.6.7_p6-r1.ebuild
@@ -1,0 +1,59 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+inherit autotools
+
+DESCRIPTION="A Tool for analyzing network packet dumps"
+HOMEPAGE="http://www.tcptrace.org/"
+SRC_URI="
+	http://www.tcptrace.org/download/${P/_p*}.tar.gz
+	http://www.tcptrace.org/download/old/$(ver_cut 1-2)/${P/_p*}.tar.gz
+	mirror://debian/pool/main/t/${PN}/${PN}_${PV/_p*}-${PV/*_p}.debian.tar.xz
+"
+
+SLOT="0"
+LICENSE="GPL-2"
+KEYWORDS="~amd64 ~ppc ~ppc64 ~x86"
+
+DEPEND="
+	net-libs/libpcap
+"
+RDEPEND="
+	${DEPEND}
+"
+PATCHES=(
+	"${FILESDIR}"/${P/_p*}-cross-compile.patch
+	"${FILESDIR}"/${P/_p*}-_DEFAULT_SOURCE.patch
+	"${FILESDIR}"/${P/_p*}-fix-build-clang16.patch
+)
+S=${WORKDIR}/${P/_p*}
+
+src_prepare() {
+	default
+
+	eapply \
+		$(awk '{ print "'"${WORKDIR}"'/debian/patches/" $0; }' < "${WORKDIR}"/debian/patches/series)
+
+	eautoreconf
+}
+
+src_compile() {
+	emake CCOPT="${CFLAGS}"
+}
+
+src_install() {
+	dobin tcptrace xpl2gpl
+
+	newman tcptrace.man tcptrace.1
+	dodoc CHANGES COPYRIGHT FAQ README* THANKS WWW
+}
+
+pkg_postinst() {
+	if ! has_version ${CATEGORY}/${PN}; then
+		elog "Note: tcptrace outputs its graphs in the xpl (xplot)"
+		elog "format. Since xplot is unavailable, you will have to"
+		elog "use the included xpl2gpl utility to convert it to"
+		elog "the gnuplot format."
+	fi
+}


### PR DESCRIPTION
and update EAPI 7 -> 8

Closes: https://bugs.gentoo.org/897830