### PR TITLE
media-libs/vulkan-layers: fix 9999 build

### DIFF
--- a/media-libs/vulkan-layers/vulkan-layers-9999.ebuild
+++ b/media-libs/vulkan-layers/vulkan-layers-9999.ebuild
@@ -29,7 +29,7 @@ DEPEND="${RDEPEND}
 	${PYTHON_DEPS}
 	>=dev-cpp/robin-hood-hashing-3.11.5
 	~dev-util/glslang-${PV}:=[${MULTILIB_USEDEP}]
-	~dev-util/spirv-headers-${PV}
+	~dev-util/spirv-headers-99999999
 	~dev-util/vulkan-headers-${PV}
 	wayland? ( dev-libs/wayland:=[${MULTILIB_USEDEP}] )
 	X? (


### PR DESCRIPTION
it depends on vulkan-headers 99999999 not 9999. 