### PR TITLE
sys-apps/eza: fix minimum rust version

### DIFF
--- a/sys-apps/eza/eza-0.11.1-r1.ebuild
+++ b/sys-apps/eza/eza-0.11.1-r1.ebuild
@@ -118,7 +118,7 @@ IUSE="+git man"
 DEPEND="git? ( dev-libs/libgit2:= )"
 RDEPEND="${DEPEND}"
 BDEPEND="
-	>=virtual/rust-1.70.0
+	>=virtual/rust-1.65.0
 	man? ( virtual/pandoc )
 "
 


### PR DESCRIPTION
it was lowered in https://github.com/eza-community/eza/pull/236 (merged before 0.11.1)