### PR TITLE
virtual/editor: remove nonexistent rdep app-editors/le

### DIFF
--- a/virtual/editor/editor-0-r6.ebuild
+++ b/virtual/editor/editor-0-r6.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 DESCRIPTION="Virtual for editor"
 
@@ -28,7 +28,6 @@ RDEPEND="|| (
 	app-editors/joe
 	app-editors/jove
 	app-editors/kakoune
-	app-editors/le
 	app-editors/levee
 	app-editors/lpe
 	app-editors/mg


### PR DESCRIPTION
https://qa-reports.gentoo.org/output/gentoo-ci/output.verbose.html;pkg=virtual:editor :
> 0-r5	NonexistentDeps	RDEPEND: nonexistent package: app-editors/le

This patch removes the `app-editors/le` rdep.

EAPI -> 8.

Closes: https://bugs.gentoo.org/914129