### PR TITLE
app-text/sigil: correct the plugin/non-plugin dependencies 

### DIFF
--- a/app-text/sigil/sigil-1.9.30-r1.ebuild
+++ b/app-text/sigil/sigil-1.9.30-r1.ebuild
@@ -4,7 +4,6 @@
 EAPI=8
 
 PYTHON_COMPAT=( python3_{9..11} )
-PYTHON_REQ_USE="tk"
 
 inherit xdg cmake python-single-r1
 
@@ -40,7 +39,8 @@ RDEPEND="
 		dev-python/cssselect[${PYTHON_USEDEP}]
 		dev-python/html5lib[${PYTHON_USEDEP}]
 		dev-python/pillow[${PYTHON_USEDEP}]
-		dev-python/regex[${PYTHON_USEDEP}]') )
+		dev-python/regex[${PYTHON_USEDEP}]')
+		$(python_gen_impl_dep 'tk') )
 "
 DEPEND="${RDEPEND}"
 BDEPEND="

--- a/app-text/sigil/sigil-1.9.30-r1.ebuild
+++ b/app-text/sigil/sigil-1.9.30-r1.ebuild
@@ -39,6 +39,8 @@ RDEPEND="
 		dev-python/cssselect[${PYTHON_USEDEP}]
 		dev-python/html5lib[${PYTHON_USEDEP}]
 		dev-python/pillow[${PYTHON_USEDEP}]
+		dev-python/PyQt5[${PYTHON_USEDEP}]
+		dev-python/PyQtWebEngine[${PYTHON_USEDEP}]
 		dev-python/regex[${PYTHON_USEDEP}]')
 		$(python_gen_impl_dep 'tk') )
 "

--- a/app-text/sigil/sigil-1.9.30-r1.ebuild
+++ b/app-text/sigil/sigil-1.9.30-r1.ebuild
@@ -25,6 +25,7 @@ RDEPEND="
 	dev-libs/libpcre2:=[pcre16]
 	$(python_gen_cond_dep '
 		dev-python/css-parser[${PYTHON_USEDEP}]
+		dev-python/dulwich[${PYTHON_USEDEP}]
 		dev-python/lxml[${PYTHON_USEDEP}]
 		dev-python/six[${PYTHON_USEDEP}]')
 	dev-qt/qtconcurrent:5
@@ -37,7 +38,6 @@ RDEPEND="
 	plugins? ( $(python_gen_cond_dep '
 		dev-python/chardet[${PYTHON_USEDEP}]
 		dev-python/cssselect[${PYTHON_USEDEP}]
-		dev-python/dulwich[${PYTHON_USEDEP}]
 		dev-python/html5lib[${PYTHON_USEDEP}]
 		dev-python/pillow[${PYTHON_USEDEP}]
 		dev-python/regex[${PYTHON_USEDEP}]') )

--- a/app-text/sigil/sigil-2.0.1-r2.ebuild
+++ b/app-text/sigil/sigil-2.0.1-r2.ebuild
@@ -4,7 +4,6 @@
 EAPI=8
 
 PYTHON_COMPAT=( python3_{10..11} )
-PYTHON_REQ_USE="tk"
 
 inherit xdg cmake python-single-r1
 
@@ -39,7 +38,8 @@ RDEPEND="
 		dev-python/html5lib[${PYTHON_USEDEP}]
 		dev-python/pillow[${PYTHON_USEDEP}]
 		dev-python/regex[${PYTHON_USEDEP}]
-	') )
+	')
+	$(python_gen_impl_dep 'tk') )
 	!qt6? (
 		dev-qt/qtconcurrent:5
 		dev-qt/qtcore:5

--- a/app-text/sigil/sigil-2.0.1-r2.ebuild
+++ b/app-text/sigil/sigil-2.0.1-r2.ebuild
@@ -30,12 +30,12 @@ RDEPEND="
 	sys-libs/zlib[minizip]
 	$(python_gen_cond_dep '
 		dev-python/css-parser[${PYTHON_USEDEP}]
+		dev-python/dulwich[${PYTHON_USEDEP}]
 		dev-python/lxml[${PYTHON_USEDEP}]
 		dev-python/six[${PYTHON_USEDEP}]')
 	plugins? ( $(python_gen_cond_dep '
 		dev-python/chardet[${PYTHON_USEDEP}]
 		dev-python/cssselect[${PYTHON_USEDEP}]
-		dev-python/dulwich[${PYTHON_USEDEP}]
 		dev-python/html5lib[${PYTHON_USEDEP}]
 		dev-python/pillow[${PYTHON_USEDEP}]
 		dev-python/regex[${PYTHON_USEDEP}]

--- a/app-text/sigil/sigil-2.0.1-r2.ebuild
+++ b/app-text/sigil/sigil-2.0.1-r2.ebuild
@@ -49,11 +49,21 @@ RDEPEND="
 		dev-qt/qtwebengine:5[widgets]
 		dev-qt/qtwidgets:5
 		dev-qt/qtxml:5
+		plugins? ( $(python_gen_cond_dep '
+			dev-python/PyQt5[${PYTHON_USEDEP}]
+			dev-python/PyQtWebEngine[${PYTHON_USEDEP}]
+
+		') )
 	)
 	qt6? (
 		dev-qt/qtbase:6[concurrent,cups,network,widgets,xml]
 		dev-qt/qt5compat:6
 		dev-qt/qtwebengine:6[widgets]
+		plugins? ( $(python_gen_cond_dep '
+			dev-python/PyQt6[${PYTHON_USEDEP}]
+			dev-python/PyQt6-WebEngine[${PYTHON_USEDEP}]
+
+		') )
 	)
 "
 DEPEND="${RDEPEND}"


### PR DESCRIPTION
This should also be implemented for the 2.0.1 ebuild, but as it is ~amd64 and only affects dependencies and dulwich is installed by default anyway, it wasn't immediately clear to me whether it should be done in -r2 or inplace.