### PR TITLE
verify-sig.eclass: minisig support

### DIFF
--- a/dev-libs/libsodium/libsodium-1.0.19-r1.ebuild
+++ b/dev-libs/libsodium/libsodium-1.0.19-r1.ebuild
@@ -3,7 +3,9 @@
 
 EAPI=8
 
-inherit autotools multilib-minimal
+VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/openpgp-keys/libsodium.key
+VERIFY_SIG_METHOD=minisig
+inherit autotools multilib-minimal verify-sig
 
 DESCRIPTION="Portable fork of NaCl, a higher-level cryptographic library"
 HOMEPAGE="https://libsodium.org"
@@ -40,22 +42,6 @@ BDEPEND=" verify-sig? ( app-crypt/minisign )"
 PATCHES=(
 	"${FILESDIR}"/${PN}-1.0.10-cpuflags.patch
 )
-
-src_unpack() {
-	# TODO: Could verify-sig.eclass support minisig? bug #783066
-	MINISIGN_KEY="RWQf6LRCGA9i53mlYecO4IzT51TGPpvWucNSCh1CBM0QTaLn73Y7GFO3"
-
-	if use verify-sig ; then
-		ebegin "Verifying signature using app-crypt/minisign"
-		minisign -V \
-			-P ${MINISIGN_KEY} \
-			-x "${DISTDIR}"/${P}.tar.gz.minisig \
-			-m "${DISTDIR}"/${P}.tar.gz
-		eend $? || die "Failed to verify distfile using minisign!"
-	fi
-
-	default
-}
 
 src_prepare() {
 	default

--- a/eclass/verify-sig.eclass
+++ b/eclass/verify-sig.eclass
@@ -55,17 +55,22 @@ IUSE="verify-sig"
 # @DESCRIPTION:
 # Signature verification method to use.  The allowed value are:
 #
+#  - minisig -- verify signatures with Ed25519 public key using app-crypt/minisign
 #  - openpgp -- verify PGP signatures using app-crypt/gnupg (the default)
 #  - signify -- verify signatures with Ed25519 public key using app-crypt/signify
 : "${VERIFY_SIG_METHOD:=openpgp}"
 
 case ${VERIFY_SIG_METHOD} in
+	minisig)
+		BDEPEND="verify-sig? ( app-crypt/minisign )"
+		;;
 	openpgp)
 		BDEPEND="
 			verify-sig? (
 				app-crypt/gnupg
 				>=app-portage/gemato-16
-			)"
+			)
+		"
 		;;
 	signify)
 		BDEPEND="verify-sig? ( app-crypt/signify )"
@@ -139,6 +144,10 @@ verify-sig_verify_detached() {
 	[[ ${file} == - ]] && filename='(stdin)'
 	einfo "Verifying ${filename} ..."
 	case ${VERIFY_SIG_METHOD} in
+		minisig)
+			minisign -V -P "$(<"${key}")" -x "${sig}" -m "${file}" ||
+				die "minisig signature verification failed"
+			;;
 		openpgp)
 			# gpg can't handle very long TMPDIR
 			# https://bugs.gentoo.org/854492
@@ -198,6 +207,10 @@ verify-sig_verify_message() {
 	[[ ${file} == - ]] && filename='(stdin)'
 	einfo "Verifying ${filename} ..."
 	case ${VERIFY_SIG_METHOD} in
+		minisig)
+			minisign -V -P "$(<"${key}")" -x "${sig}" -o "${output_file}" -m "${file}" ||
+				die "minisig signature verification failed"
+			;;
 		openpgp)
 			# gpg can't handle very long TMPDIR
 			# https://bugs.gentoo.org/854492
@@ -356,7 +369,7 @@ verify-sig_src_unpack() {
 		# find all distfiles and signatures, and combine them
 		for f in ${A}; do
 			found=
-			for suffix in .asc .sig; do
+			for suffix in .asc .sig .minisig; do
 				if [[ ${f} == *${suffix} ]]; then
 					signatures+=( "${f}" )
 					found=sig

--- a/sec-keys/minisig-keys-libsodium/metadata.xml
+++ b/sec-keys/minisig-keys-libsodium/metadata.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="person">
+		<email>sam@gentoo.org</email>
+		<name>Sam James</name>
+	</maintainer>
+	<stabilize-allarches/>
+</pkgmetadata>

--- a/sec-keys/minisig-keys-libsodium/minisig-keys-libsodium-20230914.ebuild
+++ b/sec-keys/minisig-keys-libsodium/minisig-keys-libsodium-20230914.ebuild
@@ -1,0 +1,19 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DESCRIPTION="OpenPGP keys used for libsodium"
+HOMEPAGE="https://doc.libsodium.org/installation#integrity-checking"
+S="${WORKDIR}"
+
+LICENSE="public-domain"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+
+src_install() {
+	insinto /usr/share/openpgp-keys
+	newins - libsodium.minisig <<-EOF
+		RWQf6LRCGA9i53mlYecO4IzT51TGPpvWucNSCh1CBM0QTaLn73Y7GFO3
+	EOF
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/783066
Signed-off-by: Sam James <sam@gentoo.org>