### PR TITLE
x11-terms/alacritty: Update 9999 doc install

### DIFF
--- a/x11-terms/alacritty/alacritty-9999.ebuild
+++ b/x11-terms/alacritty/alacritty-9999.ebuild
@@ -115,7 +115,7 @@ src_install() {
 
 	local DOCS=(
 		CHANGELOG.md INSTALL.md README.md
-		docs/{ansicode.txt,escape_support.md,features.md}
+		docs/{escape_support.md,features.md}
 	)
 	einstalldocs
 }


### PR DESCRIPTION
Remove obsolete entries to fix the ebuild installation.

Links: https://github.com/alacritty/alacritty/pull/7196

r @thesamesam 