### PR TITLE
app-admin/qpage: EAPI 8 bump; do not install files into /var/lock; update LICENSE

### DIFF
--- a/app-admin/qpage/files/qpage.init
+++ b/app-admin/qpage/files/qpage.init
@@ -1,0 +1,32 @@
+#!/sbin/openrc-run
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+depend() {
+	need net
+}
+
+checkconfig() {
+	if [ ! -e /etc/qpage/qpage.cf ] ; then
+		eerror "You need a /etc/qpage/qpage.cf file first."
+		eerror "There is a sample file in /etc/qpage/."
+		return 1
+	fi
+}
+
+start_pre() {
+	checkpath -q -d -m 0770 -o daemon:daemon /var/lock/subsys/qpage
+}
+
+start() {
+	checkconfig || return 1
+	ebegin "Starting qpage"
+	start-stop-daemon --start --quiet --exec /usr/bin/qpage -- -q 10
+	eend $?
+}
+
+stop() {
+	ebegin "Stopping qpage"
+	start-stop-daemon --stop --quiet --exec /usr/bin/qpage
+	eend $?
+}

--- a/app-admin/qpage/qpage-3.3-r1.ebuild
+++ b/app-admin/qpage/qpage-3.3-r1.ebuild
@@ -1,0 +1,69 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs
+
+DESCRIPTION="Sends messages to an alphanumeric pager via TAP protocol"
+HOMEPAGE="http://www.qpage.org/"
+SRC_URI="http://www.qpage.org/download/${P}.tar.Z"
+
+LICENSE="qpage"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~x86"
+IUSE="tcpd"
+
+DEPEND="tcpd? ( sys-apps/tcp-wrappers )"
+RDEPEND="
+	${DEPEND}
+	virtual/mta
+"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-gentoo.patch
+	"${FILESDIR}"/${P}-fix-warning.patch
+	"${FILESDIR}"/${P}-fix-build-system.patch
+)
+
+src_configure() {
+	tc-export CC
+	default
+
+	# There doesn't seem to be a clean way to disable tcp wrappers in
+	# this package if you have it installed, but don't want to use it.
+	if ! use tcpd ; then
+		sed -i 's/-lwrap//g; s/-DTCP_WRAPPERS//g' Makefile || die
+		echo '#undef TCP_WRAPPERS' >> config.h || die
+	fi
+}
+
+src_install() {
+	default
+
+	dodir /var/spool/qpage
+	fowners daemon:daemon /var/spool/qpage
+	fperms 770 /var/spool/qpage
+
+	dodir /var/lock/subsys/qpage
+	fowners daemon:daemon /var/lock/subsys/qpage
+	fperms 770 /var/lock/subsys/qpage
+
+	insinto /etc/qpage
+	doins example.cf
+
+	doinitd "${FILESDIR}"/qpage
+}
+
+pkg_postinst() {
+	elog
+	elog "Post-installation tasks:"
+	elog
+	elog "1. Create /etc/qpage/qpage.cf (see example.cf in that dir)."
+	elog "2. Insure that the serial port selected in qpage.cf"
+	elog "   is writable by user or group daemon."
+	elog "3. Set automatic startup with rc-update add qpage default"
+	elog "4. Send mail to tomiii@qpage.org telling him how"
+	elog "   you like qpage! :-)"
+	elog
+}

--- a/app-admin/qpage/qpage-3.3-r1.ebuild
+++ b/app-admin/qpage/qpage-3.3-r1.ebuild
@@ -9,7 +9,8 @@ DESCRIPTION="Sends messages to an alphanumeric pager via TAP protocol"
 HOMEPAGE="http://www.qpage.org/"
 SRC_URI="http://www.qpage.org/download/${P}.tar.Z"
 
-LICENSE="qpage"
+# GPL-2 - init script
+LICENSE="qpage GPL-2"
 SLOT="0"
 KEYWORDS="~alpha ~amd64 ~x86"
 IUSE="tcpd"

--- a/app-admin/qpage/qpage-3.3-r1.ebuild
+++ b/app-admin/qpage/qpage-3.3-r1.ebuild
@@ -41,18 +41,14 @@ src_configure() {
 src_install() {
 	default
 
-	dodir /var/spool/qpage
+	keepdir /var/spool/qpage
 	fowners daemon:daemon /var/spool/qpage
 	fperms 770 /var/spool/qpage
-
-	dodir /var/lock/subsys/qpage
-	fowners daemon:daemon /var/lock/subsys/qpage
-	fperms 770 /var/lock/subsys/qpage
 
 	insinto /etc/qpage
 	doins example.cf
 
-	doinitd "${FILESDIR}"/qpage
+	newinitd "${FILESDIR}/qpage.init" "${PN}"
 }
 
 pkg_postinst() {


### PR DESCRIPTION
Second commit should also fix https://bugs.gentoo.org/520968, but I can't reproduce it to begin with...