### PR TITLE
app-crypt/asekey: remove HOMEPAGE, mirror distfile in gentoo namespace + EAPI bump and fixes

### DIFF
--- a/app-crypt/asekey/asekey-3.7-r1.ebuild
+++ b/app-crypt/asekey/asekey-3.7-r1.ebuild
@@ -1,0 +1,44 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit udev
+
+DESCRIPTION="ASEKey USB SIM Card Reader"
+HOMEPAGE="https://wiki.gentoo.org/wiki/No_homepage"
+SRC_URI="https://dev.gentoo.org/~sam/distfiles/app-crypt/asekey/${P}.tar.bz2"
+
+LICENSE="BSD LGPL-2.1"
+SLOT="0"
+KEYWORDS="~amd64 ~riscv ~x86"
+
+RDEPEND="
+	sys-apps/pcsc-lite[udev]
+	virtual/libusb:0
+"
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}/asekey-3.7-bundle.patch"
+	"${FILESDIR}/asekey-3.7-dont-call-toolchain-cc-directly.patch"
+	"${FILESDIR}/asekey-3.7-musl-ushort.patch"
+)
+
+src_prepare() {
+	default
+	sed -i -e 's/GROUP="pcscd"/ENV{PCSCD}="1"/' "92_pcscd_${PN}.rules" || die
+}
+
+src_configure() {
+	econf --with-udev-rules-dir="$(get_udevdir)/rules.d"
+}
+
+pkg_postinst() {
+	udev_reload
+}
+
+pkg_postrm() {
+	udev_reload
+}

--- a/app-crypt/asekey/asekey-3.7.ebuild
+++ b/app-crypt/asekey/asekey-3.7.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -6,8 +6,8 @@ EAPI=7
 inherit udev
 
 DESCRIPTION="ASEKey USB SIM Card Reader"
-HOMEPAGE="https://www.athena-scs.com/"
-SRC_URI="http://www.athena-scs.com/docs/reader-drivers/${PN}-${PV/./-}-tar.bz2 -> ${P}.tar.bz2"
+HOMEPAGE="https://wiki.gentoo.org/wiki/No_homepage"
+SRC_URI="https://dev.gentoo.org/~sam/distfiles/app-crypt/asekey/${P}.tar.bz2"
 LICENSE="BSD LGPL-2.1"
 
 SLOT="0"

--- a/app-crypt/asekey/files/asekey-3.7-dont-call-toolchain-cc-directly.patch
+++ b/app-crypt/asekey/files/asekey-3.7-dont-call-toolchain-cc-directly.patch
@@ -1,0 +1,13 @@
+https://bugs.gentoo.org/745291
+
+--- a/Makefile
++++ b/Makefile
+@@ -4,7 +4,7 @@
+ DRIVER_DIR=${DESTDIR}/${USBDROPDIR}/ifd-ASEKey.bundle
+ UDEV_DIR=${DESTDIR}/${UDEVDIR}
+ 
+-CC=${BUILD}-gcc
++CC?=gcc
+ 
+ SOURCES=usb.c atr.c DriverIO.c CommandTypes.c ReaderCommands.c T1Protocol.c MemoryCards.c InitCardParams.c ifdhandler.c
+ 

--- a/app-crypt/asekey/files/asekey-3.7-musl-ushort.patch
+++ b/app-crypt/asekey/files/asekey-3.7-musl-ushort.patch
@@ -1,0 +1,14 @@
+https://bugs.gentoo.org/714222
+
+Hack instead of fix because upstream is dead and the typedef is used extensively.
+
+--- a/Ase.h
++++ b/Ase.h
+@@ -24,6 +24,7 @@
+ #include "T1Protocol.h"
+ #include "MemoryCards.h"
+ 
++typedef unsigned short ushort;
+ 
+ //#define ASE_DEBUG
+ 


### PR DESCRIPTION
* Athena Smartcard LIMITED stopped existing as an entity in 2015 when NXP Semiconducters aquired them. Now their domain has been aquired by an unrelated domain squatter.

https://find-and-update.company-information.service.gov.uk/company/05881097/filing-history https://www.nxp.com/company/about-nxp/nxp-acquires-athena-scs:NW-ACQUIRES-ATHENA-SCS

Closes: https://bugs.gentoo.org/680720