### PR TITLE
kernel-build.eclass: drop obsolete if use secureboot statement

### DIFF
--- a/eclass/kernel-build.eclass
+++ b/eclass/kernel-build.eclass
@@ -444,20 +444,6 @@ kernel-build_merge_configs() {
 		fi
 	fi
 
-	if [[ ${KERNEL_IUSE_SECUREBOOT} ]]; then
-		if use secureboot; then
-			# This only effects arm64 and riscv where the bootable image may
-			# contain its own decompressor (zboot). If enabled we get a
-			# sign-able efi file.
-			cat <<-EOF > "${WORKDIR}/secureboot.config" || die
-				## Enable zboot for signing
-				CONFIG_EFI_ZBOOT=y
-			EOF
-
-			merge_configs+=( "${WORKDIR}/secureboot.config" )
-		fi
-	fi
-
 	if [[ ${#user_configs[@]} -gt 0 ]]; then
 		elog "User config files are being applied:"
 		local x


### PR DESCRIPTION
- kexec allows us to replace the running kernel, without CONFIG_KEXEC_SIG this allows us to effectively bypass secureboot.

- CONFIG_SECURITY_LOCKDOWN_LSM is designed to prevent altering the running kernel image. Integrity mode is enabled automatically if this option is set and the kernel is booted with secure boot enabled. So we select this mode as our default for users who explicitly opt-in with USE=secureboot

- CONFIG_INTEGRITY_PLATFORM_KEYRING makes the kernel store the platform keys in a separate keyring, CONFIG_INTEGRITY_MACHINE_KEYRING does the same for the MOK list. This allows using these keys for CONFIG_KEXEC_SIG or to use the MOK list keys to sign additional out-of-tree modules with a different key then the in-tree modules (useful in pre-signed gentoo-kernel-bin).

Accompanying PR for https://github.com/projg2/binpkg-docker to disable the `*_FORCE_*` options for the pre-built kernels will follow soon

CC @mgorny @gentoo/dist-kernel 