### PR TITLE
sys-devel/bin86: fix implicit int declarations

### DIFF
--- a/sys-devel/bin86/bin86-0.16.21-r2.ebuild
+++ b/sys-devel/bin86/bin86-0.16.21-r2.ebuild
@@ -1,0 +1,36 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="8"
+
+inherit toolchain-funcs
+
+DESCRIPTION="Assembler and loader used to create kernel bootsector"
+HOMEPAGE="http://v3.sk/~lkundrak/dev86/"
+SRC_URI="http://v3.sk/~lkundrak/dev86/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~x86"
+
+PATCHES=( "${FILESDIR}"/${PN}-0.16.21-amd64-build.patch
+		  "${FILESDIR}"/${PN}-0.16.21-fix-build-for-clang16.patch
+)
+
+src_prepare() {
+	use elibc_musl && CPPFLAGS="${CPPFLAGS} -U__linux__"
+	sed -i \
+		-e '/^PREFIX/s|=.*|=$(DESTDIR)/usr|' \
+		-e '/^MANDIR/s|)/man/man1|)/share/man/man1|' \
+		-e '/^INSTALL_OPTS/s|-s||' \
+		-e "/^CFLAGS/s|=.*|=${CFLAGS} -D_POSIX_SOURCE ${CPPFLAGS}|" \
+		-e "/^LDFLAGS/s|=.*|=${LDFLAGS}|" \
+		Makefile || die
+	tc-export CC
+	default
+}
+
+src_install() {
+	dodir /usr/bin /usr/share/man/man1
+	default
+}

--- a/sys-devel/bin86/files/bin86-0.16.21-fix-build-for-clang16.patch
+++ b/sys-devel/bin86/files/bin86-0.16.21-fix-build-for-clang16.patch
@@ -1,0 +1,145 @@
+Subject: [PATCH] fix build for clang 16
+
+clang 16 does not allow implicit int in function declarations
+
+Bug: https://bugs.gentoo.org/880797
+Upstream PR: https://github.com/lkundrak/dev86/pull/26
+
+Signed-off-by: Pascal Jäger <pascal.jaeger@leimstift.de>
+---
+ ld/catimage.c | 32 +++++++++++++++++++-------------
+ ld/objchop.c  | 16 ++++++++--------
+ 2 files changed, 27 insertions(+), 21 deletions(-)
+
+diff --git a/ld/catimage.c b/ld/catimage.c
+index 1f5e160..47161b9 100644
+--- a/ld/catimage.c
++++ b/ld/catimage.c
+@@ -24,6 +24,7 @@
+ #ifdef __STDC__
+ #include <unistd.h>
+ #include <stdlib.h>
++#include <string.h>
+ #endif
+ #include "x86_aout.h"
+ 
+@@ -39,9 +40,14 @@ FILE * ofd;
+ FILE * ifd = 0;
+ struct exec header;
+ 
+-main(argc, argv)
+-int argc;
+-char ** argv;
++void open_obj(char * fname);
++void copy_segment(long out_offset,long in_offset,long length);
++void patch_bin(long file_off, int value);
++void read_symtable(void);
++void fatal(char * str);
++
++int
++main(int argc, char ** argv)
+ {
+    long image_offset, text_off;
+    int  image_id;
+@@ -100,8 +106,8 @@ char ** argv;
+    exit(0);
+ }
+ 
+-open_obj(fname)
+-char * fname;
++void
++open_obj(char * fname)
+ {
+    input_file = fname;
+ 
+@@ -117,8 +123,8 @@ char * fname;
+       fatal("Input file has bad magic number");
+ }
+ 
+-copy_segment(out_offset, in_offset, length)
+-long out_offset, in_offset, length;
++void
++copy_segment(long out_offset,long in_offset,long length)
+ {
+    char buffer[1024];
+    int ssize;
+@@ -143,9 +149,8 @@ long out_offset, in_offset, length;
+    }
+ }
+ 
+-patch_bin(file_off, value)
+-long file_off;
+-int value;
++void
++patch_bin(long file_off, int value)
+ {
+    char wbuf[4];
+    if( file_off > 0 )
+@@ -163,7 +168,8 @@ int value;
+    }
+ }
+ 
+-read_symtable()
++void
++read_symtable(void)
+ {
+    struct nlist item;
+    int nitems;
+@@ -234,8 +240,8 @@ read_symtable()
+    }
+ }
+ 
+-fatal(str)
+-char * str;
++void
++fatal(char * str)
+ {
+    fprintf(stderr, "catimage:%s: %s\n", input_file, str);
+    exit(2);
+diff --git a/ld/objchop.c b/ld/objchop.c
+index c7631c1..495df75 100644
+--- a/ld/objchop.c
++++ b/ld/objchop.c
+@@ -16,12 +16,13 @@ main()
+ 
+ #else
+ 
++void fatal(char* str);
++void write_file(char *fname, long bsize);
++
+ FILE * ifd;
+ struct exec header;
+ 
+-main(argc, argv)
+-int argc;
+-char ** argv;
++int main(int argc, char** argv)
+ {
+    FILE * ofd;
+    if( argc != 5 ) fatal("Usage: objchop a.out text.bin data.bin sizes.asm");
+@@ -56,9 +57,8 @@ char ** argv;
+    exit(0);
+ }
+ 
+-write_file(fname, bsize)
+-char * fname;
+-long bsize;
++void
++write_file(char *fname, long bsize)
+ {
+    char buffer[1024];
+    int ssize;
+@@ -81,8 +81,8 @@ long bsize;
+    fclose(ofd);
+ }
+ 
+-fatal(str)
+-char * str;
++void
++fatal(char* str)
+ {
+    fprintf(stderr, "objchop: %s\n", str);
+    exit(2);
+-- 
+2.41.0
+


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/880797

Signed-off-by: Pascal Jäger <pascal.jaeger@leimstift.de>