### PR TITLE
sci-chemistry/tinker: update EAPI 6 -> 8

### DIFF
--- a/sci-chemistry/tinker/metadata.xml
+++ b/sci-chemistry/tinker/metadata.xml
@@ -5,4 +5,7 @@
 		<email>sci-chemistry@gentoo.org</email>
 		<name>Gentoo Chemistry Project</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">TinkerTools/tinker</remote-id>
+	</upstream>
 </pkgmetadata>


### PR DESCRIPTION
Inherits java-pkg-2 instead of java-pkg-opt-2

Closes: https://bugs.gentoo.org/905682