### PR TITLE
*/*: fix VariableShadowed

### DIFF
--- a/app-editors/neovim/neovim-0.9.0-r1.ebuild
+++ b/app-editors/neovim/neovim-0.9.0-r1.ebuild
@@ -23,10 +23,9 @@ LICENSE="Apache-2.0 vim"
 SLOT="0"
 IUSE="+lto +nvimpager test"
 
-REQUIRED_USE="${LUA_REQUIRED_USE}"
 # Upstream say the test library needs LuaJIT
 # https://github.com/neovim/neovim/blob/91109ffda23d0ce61cec245b1f4ffb99e7591b62/CMakeLists.txt#L377
-REQUIRED_USE="test? ( lua_single_target_luajit )"
+REQUIRED_USE="${LUA_REQUIRED_USE} test? ( lua_single_target_luajit )"
 # TODO: Get tests running
 RESTRICT="!test? ( test ) test"
 

--- a/app-editors/neovim/neovim-0.9.1.ebuild
+++ b/app-editors/neovim/neovim-0.9.1.ebuild
@@ -23,10 +23,9 @@ LICENSE="Apache-2.0 vim"
 SLOT="0"
 IUSE="+lto +nvimpager test"
 
-REQUIRED_USE="${LUA_REQUIRED_USE}"
 # Upstream say the test library needs LuaJIT
 # https://github.com/neovim/neovim/blob/91109ffda23d0ce61cec245b1f4ffb99e7591b62/CMakeLists.txt#L377
-REQUIRED_USE="test? ( lua_single_target_luajit )"
+REQUIRED_USE="${LUA_REQUIRED_USE} test? ( lua_single_target_luajit )"
 # TODO: Get tests running
 RESTRICT="!test? ( test ) test"
 

--- a/app-editors/neovim/neovim-0.9.2.ebuild
+++ b/app-editors/neovim/neovim-0.9.2.ebuild
@@ -23,10 +23,9 @@ LICENSE="Apache-2.0 vim"
 SLOT="0"
 IUSE="+lto +nvimpager test"
 
-REQUIRED_USE="${LUA_REQUIRED_USE}"
 # Upstream say the test library needs LuaJIT
 # https://github.com/neovim/neovim/blob/91109ffda23d0ce61cec245b1f4ffb99e7591b62/CMakeLists.txt#L377
-REQUIRED_USE="test? ( lua_single_target_luajit )"
+REQUIRED_USE="${LUA_REQUIRED_USE} test? ( lua_single_target_luajit )"
 # TODO: Get tests running
 RESTRICT="!test? ( test ) test"
 

--- a/app-editors/neovim/neovim-9999.ebuild
+++ b/app-editors/neovim/neovim-9999.ebuild
@@ -23,10 +23,9 @@ LICENSE="Apache-2.0 vim"
 SLOT="0"
 IUSE="+lto +nvimpager test"
 
-REQUIRED_USE="${LUA_REQUIRED_USE}"
 # Upstream say the test library needs LuaJIT
 # https://github.com/neovim/neovim/blob/91109ffda23d0ce61cec245b1f4ffb99e7591b62/CMakeLists.txt#L377
-REQUIRED_USE="test? ( lua_single_target_luajit )"
+REQUIRED_USE="${LUA_REQUIRED_USE} test? ( lua_single_target_luajit )"
 # TODO: Get tests running
 RESTRICT="!test? ( test ) test"
 

--- a/app-emulation/libguestfs/libguestfs-1.48.4.ebuild
+++ b/app-emulation/libguestfs/libguestfs-1.48.4.ebuild
@@ -107,14 +107,16 @@ DEPEND="${COMMON_DEPEND}
 	ruby? ( dev-lang/ruby virtual/rubygems dev-ruby/rake )
 	test? ( introspection? ( dev-libs/gjs ) )
 "
-BDEPEND="virtual/pkgconfig"
 RDEPEND="${COMMON_DEPEND}
 	app-emulation/libguestfs-appliance
 	acct-group/kvm
 "
 # Upstream build scripts compile and install Lua bindings for the ABI version
 # obtained by running 'lua' on the build host
-BDEPEND="lua? ( ${LUA_DEPS} )"
+BDEPEND="
+	virtual/pkgconfig
+	lua? ( ${LUA_DEPS} )
+"
 
 DOCS=( AUTHORS BUGS ChangeLog HACKING README TODO )
 

--- a/app-emulation/libguestfs/libguestfs-1.48.6.ebuild
+++ b/app-emulation/libguestfs/libguestfs-1.48.6.ebuild
@@ -107,14 +107,16 @@ DEPEND="${COMMON_DEPEND}
 	ruby? ( dev-lang/ruby virtual/rubygems dev-ruby/rake )
 	test? ( introspection? ( dev-libs/gjs ) )
 "
-BDEPEND="virtual/pkgconfig"
 RDEPEND="${COMMON_DEPEND}
 	app-emulation/libguestfs-appliance
 	acct-group/kvm
 "
 # Upstream build scripts compile and install Lua bindings for the ABI version
 # obtained by running 'lua' on the build host
-BDEPEND="lua? ( ${LUA_DEPS} )"
+BDEPEND="
+	virtual/pkgconfig
+	lua? ( ${LUA_DEPS} )
+"
 
 DOCS=( AUTHORS BUGS ChangeLog HACKING README TODO )
 

--- a/dev-db/sqldeveloper/sqldeveloper-23.1.0.097.1607.ebuild
+++ b/dev-db/sqldeveloper/sqldeveloper-23.1.0.097.1607.ebuild
@@ -28,8 +28,6 @@ RDEPEND="
 "
 BDEPEND="app-arch/unzip"
 
-S="${WORKDIR}/${PN}"
-
 QA_PREBUILT="
 	opt/${PN}/netbeans/platform/modules/lib/amd64/linux/libjnidispatch-422.so
 "

--- a/dev-java/fop/fop-2.8-r1.ebuild
+++ b/dev-java/fop/fop-2.8-r1.ebuild
@@ -59,8 +59,9 @@ JAVA_CLASSPATH_EXTRA="
 	sun-jai-bin
 "
 
-BDEPEND="verify-sig? ( sec-keys/openpgp-keys-apache-xmlgraphics-fop )"
+BDEPEND+=" verify-sig? ( sec-keys/openpgp-keys-apache-xmlgraphics-fop )"
 VERIFY_SIG_OPENPGP_KEY_PATH="${BROOT}/usr/share/openpgp-keys/xmlgraphics-fop.apache.org.asc"
+
 src_unpack() {
 	if use verify-sig; then
 		verify-sig_verify_detached "${DISTDIR}"/${P}-src.tar.gz{,.asc}

--- a/dev-lang/luajit/luajit-2.1.0_beta3_p20220127-r2.ebuild
+++ b/dev-lang/luajit/luajit-2.1.0_beta3_p20220127-r2.ebuild
@@ -20,7 +20,7 @@ MY_P="LuaJIT-${MY_PV}"
 
 DESCRIPTION="Just-In-Time Compiler for the Lua programming language"
 HOMEPAGE="https://luajit.org/"
-SRC_URI="https://luajit.org/download/${MY_P}.tar.gz"
+# SRC_URI="https://luajit.org/download/${MY_P}.tar.gz"
 SRC_URI="https://github.com/LuaJIT/LuaJIT/archive/${GIT_COMMIT}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="MIT"

--- a/dev-lang/luajit/luajit-2.1.0_beta3_p20220613.ebuild
+++ b/dev-lang/luajit/luajit-2.1.0_beta3_p20220613.ebuild
@@ -20,7 +20,7 @@ MY_P="LuaJIT-${MY_PV}"
 
 DESCRIPTION="Just-In-Time Compiler for the Lua programming language"
 HOMEPAGE="https://luajit.org/"
-SRC_URI="https://luajit.org/download/${MY_P}.tar.gz"
+# SRC_URI="https://luajit.org/download/${MY_P}.tar.gz"
 SRC_URI="https://github.com/LuaJIT/LuaJIT/archive/${GIT_COMMIT}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="MIT"

--- a/dev-libs/gmp/gmp-6.2.1-r5.ebuild
+++ b/dev-libs/gmp/gmp-6.2.1-r5.ebuild
@@ -8,7 +8,6 @@ inherit gnuconfig libtool flag-o-matic multilib-minimal toolchain-funcs
 MY_PV=${PV/_p*}
 MY_PV=${MY_PV/_/-}
 
-MANUAL_PV=${MY_PV}
 MANUAL_PV=6.2.1
 
 MY_P=${PN}-${MY_PV}

--- a/dev-libs/gmp/gmp-6.3.0.ebuild
+++ b/dev-libs/gmp/gmp-6.3.0.ebuild
@@ -8,7 +8,6 @@ inherit gnuconfig libtool flag-o-matic multilib-minimal toolchain-funcs
 MY_PV=${PV/_p*}
 MY_PV=${MY_PV/_/-}
 
-MANUAL_PV=${MY_PV}
 MANUAL_PV=6.2.1
 
 MY_P=${PN}-${MY_PV}

--- a/dev-libs/libcgroup/libcgroup-0.41-r6.ebuild
+++ b/dev-libs/libcgroup/libcgroup-0.41-r6.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -32,6 +32,7 @@ PATCHES=(
 	"${FILESDIR}"/${P}-replace-INLCUDES.patch
 	"${FILESDIR}"/${P}-reorder-headers.patch
 	"${FILESDIR}"/${P}-remove-umask.patch
+	"${FILESDIR}"/${P}-slibtool.patch
 )
 
 pkg_setup() {
@@ -41,14 +42,6 @@ pkg_setup() {
 	fi
 	linux-info_pkg_setup
 }
-
-PATCHES=(
-	"${FILESDIR}"/${P}-replace_DECLS.patch
-	"${FILESDIR}"/${P}-replace_INLCUDES.patch
-	"${FILESDIR}"/${P}-reorder-headers.patch
-	"${FILESDIR}"/${P}-remove-umask.patch
-	"${FILESDIR}"/${P}-slibtool.patch
-)
 
 src_prepare() {
 	default

--- a/dev-ml/ppx_deriving/ppx_deriving-5.2-r1.ebuild
+++ b/dev-ml/ppx_deriving/ppx_deriving-5.2-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -15,14 +15,13 @@ KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~x86"
 IUSE="+ocamlopt test"
 RESTRICT="!test? ( test )"
 
-DEPEND="
+RDEPEND="
 	dev-ml/ppx_tools:=
 	dev-ml/ocaml-migrate-parsetree:=
 	dev-ml/ppx_derivers:=
 	>=dev-ml/ppxlib-0.20.0:=
 	dev-ml/result:=
 "
-RDEPEND="${DEPEND}"
 DEPEND="${RDEPEND}
 	dev-ml/cppo
 	test? ( dev-ml/ounit2 )"

--- a/dev-ml/ppx_deriving/ppx_deriving-5.2.1-r1.ebuild
+++ b/dev-ml/ppx_deriving/ppx_deriving-5.2.1-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -15,7 +15,7 @@ KEYWORDS="amd64 ~arm ~arm64 ~ppc ~ppc64 x86"
 IUSE="+ocamlopt test"
 RESTRICT="!test? ( test )"
 
-DEPEND="
+RDEPEND="
 	dev-ml/ppx_tools:=
 	dev-ml/ocaml-migrate-parsetree:=
 	dev-ml/ppx_derivers:=
@@ -24,7 +24,6 @@ DEPEND="
 	dev-ml/result:=
 	dev-ml/sexplib0:=
 "
-RDEPEND="${DEPEND}"
 DEPEND="${RDEPEND}
 	dev-ml/cppo
 	test? ( dev-ml/ounit2 )"

--- a/dev-ml/stdcompat/stdcompat-19.ebuild
+++ b/dev-ml/stdcompat/stdcompat-19.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2022 Gentoo Authors
+# Copyright 2022-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -8,9 +8,8 @@ HOMEPAGE="https://github.com/thierry-martinez/stdcompat"
 SRC_URI="https://github.com/thierry-martinez/stdcompat/releases/download/v${PV}/${P}.tar.gz"
 
 LICENSE="BSD-2"
-SLOT="0"
-KEYWORDS="~amd64 ~x86"
 SLOT="0/${PV}"
+KEYWORDS="~amd64 ~x86"
 
 DEPEND="dev-lang/ocaml:=[ocamlopt]
 	dev-ml/result:=[ocamlopt]

--- a/dev-perl/DBD-MariaDB/DBD-MariaDB-1.210.0-r1.ebuild
+++ b/dev-perl/DBD-MariaDB/DBD-MariaDB-1.210.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -17,10 +17,6 @@ REQUIRED_USE="^^ ( mysql mariadb )"
 RDEPEND="
 	>=dev-perl/DBI-1.608.0
 	virtual/perl-XSLoader
-	mysql? ( dev-db/mysql-connector-c:0= )
-	mariadb? ( dev-db/mariadb-connector-c:0= )
-"
-DEPEND="
 	mysql? ( dev-db/mysql-connector-c:0= )
 	mariadb? ( dev-db/mariadb-connector-c:0= )
 "

--- a/dev-perl/DBD-MariaDB/DBD-MariaDB-1.220.0.ebuild
+++ b/dev-perl/DBD-MariaDB/DBD-MariaDB-1.220.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -17,10 +17,6 @@ REQUIRED_USE="^^ ( mysql mariadb )"
 RDEPEND="
 	>=dev-perl/DBI-1.608.0
 	virtual/perl-XSLoader
-	mysql? ( dev-db/mysql-connector-c:= )
-	mariadb? ( dev-db/mariadb-connector-c:= )
-"
-DEPEND="
 	mysql? ( dev-db/mysql-connector-c:= )
 	mariadb? ( dev-db/mariadb-connector-c:= )
 "

--- a/dev-php/pecl-eio/pecl-eio-3.0.0_rc2.ebuild
+++ b/dev-php/pecl-eio/pecl-eio-3.0.0_rc2.ebuild
@@ -2,6 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
+
 MY_PN="${PN/pecl-}"
 MY_PV="${PV/_rc/RC}"
 MY_P="${MY_PN}-${MY_PV}"
@@ -15,15 +16,13 @@ DOCS=( README.md )
 USE_PHP="php8-0"
 inherit php-ext-pecl-r3
 
-KEYWORDS="~amd64 ~x86"
-LICENSE="PHP-3.01"
-
 DESCRIPTION="PHP wrapper for libeio library"
-LICENSE="PHP-3"
-SLOT="0"
-IUSE="debug"
-
 S="${PHP_EXT_S}"
+
+LICENSE="PHP-3.01"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="debug"
 
 src_configure() {
 	local PHP_EXT_ECONF_ARGS=("--with-eio" "$(use_enable debug eio-debug)" )

--- a/dev-php/pecl-eio/pecl-eio-3.0.0_rc4.ebuild
+++ b/dev-php/pecl-eio/pecl-eio-3.0.0_rc4.ebuild
@@ -2,6 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
+
 MY_PN="${PN/pecl-}"
 MY_PV="${PV/_rc/RC}"
 MY_P="${MY_PN}-${MY_PV}"
@@ -15,15 +16,13 @@ DOCS=( README.md )
 USE_PHP="php8-0 php8-1"
 inherit php-ext-pecl-r3
 
-KEYWORDS="~amd64 ~x86"
-LICENSE="PHP-3.01"
-
 DESCRIPTION="PHP wrapper for libeio library"
-LICENSE="PHP-3"
-SLOT="0"
-IUSE="debug"
-
 S="${PHP_EXT_S}"
+
+LICENSE="PHP-3.01"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="debug"
 
 src_configure() {
 	local PHP_EXT_ECONF_ARGS=("--with-eio" "$(use_enable debug eio-debug)" )

--- a/dev-php/pecl-eio/pecl-eio-3.1.0_rc1.ebuild
+++ b/dev-php/pecl-eio/pecl-eio-3.1.0_rc1.ebuild
@@ -2,6 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
+
 MY_PN="${PN/pecl-}"
 MY_PV="${PV/_rc/RC}"
 MY_P="${MY_PN}-${MY_PV}"
@@ -15,15 +16,13 @@ DOCS=( README.md )
 USE_PHP="php8-0 php8-1"
 inherit php-ext-pecl-r3
 
-KEYWORDS="~amd64 ~x86"
-LICENSE="PHP-3.01"
-
 DESCRIPTION="PHP wrapper for libeio library"
-LICENSE="PHP-3"
-SLOT="0"
-IUSE="debug"
-
 S="${PHP_EXT_S}"
+
+LICENSE="PHP-3.01"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="debug"
 
 src_configure() {
 	local PHP_EXT_ECONF_ARGS=("--with-eio" "$(use_enable debug eio-debug)" )

--- a/dev-php/pecl-translit/pecl-translit-0.7.1.ebuild
+++ b/dev-php/pecl-translit/pecl-translit-0.7.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="8"
@@ -8,7 +8,6 @@ PHP_EXT_INI="yes"
 PHP_EXT_ZENDEXT="no"
 
 USE_PHP="php8-0 php8-1"
-PHP_EXT_NAME="translit"
 
 inherit php-ext-source-r3
 

--- a/dev-python/keystoneauth1/keystoneauth1-5.2.1.ebuild
+++ b/dev-python/keystoneauth1/keystoneauth1-5.2.1.ebuild
@@ -9,7 +9,6 @@ PYTHON_COMPAT=( python3_{10..11} )
 inherit distutils-r1 pypi
 
 DESCRIPTION="This package contains tools for authenticating to an OpenStack-based cloud"
-HOMEPAGE="https://github.com/openstack/keystoneauth"
 HOMEPAGE="
 	https://opendev.org/openstack/keystoneauth/
 	https://github.com/openstack/keystoneauth/

--- a/dev-python/keystoneauth1/keystoneauth1-5.3.0.ebuild
+++ b/dev-python/keystoneauth1/keystoneauth1-5.3.0.ebuild
@@ -9,7 +9,6 @@ PYTHON_COMPAT=( python3_{10..11} )
 inherit distutils-r1 pypi
 
 DESCRIPTION="This package contains tools for authenticating to an OpenStack-based cloud"
-HOMEPAGE="https://github.com/openstack/keystoneauth"
 HOMEPAGE="
 	https://opendev.org/openstack/keystoneauth/
 	https://github.com/openstack/keystoneauth/

--- a/games-puzzle/pauker/pauker-1.8-r3.ebuild
+++ b/games-puzzle/pauker/pauker-1.8-r3.ebuild
@@ -16,7 +16,6 @@ LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
 
-BDEPEND="app-arch/unzip"
 COMMON_DEP="
 	dev-java/browserlauncher2:1.0
 	dev-java/javahelp

--- a/gnome-base/gnome-control-center/gnome-control-center-44.3.ebuild
+++ b/gnome-base/gnome-control-center/gnome-control-center-44.3.ebuild
@@ -21,9 +21,6 @@ REQUIRED_USE="
 " # Theoretically "?? ( elogind systemd )" is fine too, lacking some functionality at runtime, but needs testing if handled gracefully enough
 KEYWORDS="amd64 ~arm arm64 ~loong ~ppc ~ppc64 ~riscv x86"
 
-# meson.build depends on python unconditionally
-BDEPEND="${PYTHON_DEPS}"
-
 # kerberos unfortunately means mit-krb5; build fails with heimdal
 # display panel requires colord and gnome-settings-daemon[colord]
 # wacom panel requires gsd-enums.h from gsd at build time, probably also runtime support
@@ -117,7 +114,8 @@ RDEPEND="${DEPEND}
 PDEPEND=">=gnome-base/gnome-session-2.91.6-r1
 	networkmanager? ( gnome-extra/nm-applet )" # networking panel can call into nm-connection-editor
 
-BDEPEND="
+# meson.build depends on python unconditionally
+BDEPEND="${PYTHON_DEPS}
 	dev-libs/libxslt
 	app-text/docbook-xsl-stylesheets
 	app-text/docbook-xml-dtd:4.2

--- a/gnome-base/gnome-control-center/gnome-control-center-45_rc.ebuild
+++ b/gnome-base/gnome-control-center/gnome-control-center-45_rc.ebuild
@@ -21,9 +21,6 @@ REQUIRED_USE="
 " # Theoretically "?? ( elogind systemd )" is fine too, lacking some functionality at runtime, but needs testing if handled gracefully enough
 KEYWORDS="~amd64 ~arm ~arm64 ~loong ~ppc ~ppc64 ~riscv ~x86"
 
-# meson.build depends on python unconditionally
-BDEPEND="${PYTHON_DEPS}"
-
 # kerberos unfortunately means mit-krb5; build fails with heimdal
 # display panel requires colord and gnome-settings-daemon[colord]
 # wacom panel requires gsd-enums.h from gsd at build time, probably also runtime support
@@ -116,7 +113,8 @@ RDEPEND="${DEPEND}
 PDEPEND=">=gnome-base/gnome-session-2.91.6-r1
 	networkmanager? ( gnome-extra/nm-applet )" # networking panel can call into nm-connection-editor
 
-BDEPEND="
+# meson.build depends on python unconditionally
+BDEPEND="${PYTHON_DEPS}
 	dev-libs/libxslt
 	app-text/docbook-xsl-stylesheets
 	app-text/docbook-xml-dtd:4.2

--- a/media-gfx/viewer/viewer-0.8.0-r1.ebuild
+++ b/media-gfx/viewer/viewer-0.8.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -7,14 +7,13 @@ inherit autotools
 
 DESCRIPTION="A stereo pair image viewer (supports ppm's only)"
 HOMEPAGE="http://www-users.cs.umn.edu/~wburdick/geowall/viewer.html"
-SRC_URI="ftp://ftp.cs.umn.edu/dept/users/wburdick/geowall/${P}.tar.gz"
+# SRC_URI="ftp://ftp.cs.umn.edu/dept/users/wburdick/geowall/${P}.tar.gz"
 SRC_URI="http://www-users.cs.umn.edu/~wburdick/ftp/geowall/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"
 
 KEYWORDS="~amd64 ~ppc ~x86"
-IUSE=""
 DEPEND="virtual/opengl
 	media-libs/freeglut
 	x11-libs/libXmu
@@ -27,7 +26,7 @@ src_prepare() {
 	default
 	sed -i configure.in \
 		-e "s|/usr/X11R6/lib|/usr/$(get_libdir)/X11|g" \
-		-e 's|/usr/X11R6/include|/usr/include/X11|g'
+		-e 's|/usr/X11R6/include|/usr/include/X11|g' || die
 	eautoreconf
 }
 

--- a/media-libs/gstreamer-editing-services/gstreamer-editing-services-1.20.3.ebuild
+++ b/media-libs/gstreamer-editing-services/gstreamer-editing-services-1.20.3.ebuild
@@ -9,6 +9,7 @@ inherit meson python-r1
 DESCRIPTION="SDK for making video editors and more"
 HOMEPAGE="http://wiki.pitivi.org/wiki/GES"
 SRC_URI="https://gstreamer.freedesktop.org/src/${PN}/${P/gstreamer/gst}.tar.xz"
+S="${WORKDIR}"/${P/gstreamer/gst}
 
 LICENSE="LGPL-2+"
 SLOT="1.0"
@@ -16,7 +17,8 @@ KEYWORDS="amd64 x86"
 
 IUSE="+introspection test"
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"
-RESTRICT="!test? ( test )"
+# Some tests are failing
+RESTRICT="test"
 
 RDEPEND="
 	${PYTHON_DEPS}
@@ -29,11 +31,6 @@ RDEPEND="
 "
 DEPEND="${RDEPEND}"
 BDEPEND="virtual/pkgconfig"
-
-# Some tests are failing
-RESTRICT="test"
-
-S="${WORKDIR}"/${P/gstreamer/gst}
 
 src_configure() {
 	local emesonargs=(

--- a/media-libs/gstreamer-editing-services/gstreamer-editing-services-1.20.4.ebuild
+++ b/media-libs/gstreamer-editing-services/gstreamer-editing-services-1.20.4.ebuild
@@ -9,6 +9,7 @@ inherit meson python-r1
 DESCRIPTION="SDK for making video editors and more"
 HOMEPAGE="http://wiki.pitivi.org/wiki/GES"
 SRC_URI="https://gstreamer.freedesktop.org/src/${PN}/${P/gstreamer/gst}.tar.xz"
+S="${WORKDIR}"/${P/gstreamer/gst}
 
 LICENSE="LGPL-2+"
 SLOT="1.0"
@@ -16,7 +17,8 @@ KEYWORDS="amd64 x86"
 
 IUSE="+introspection test"
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"
-RESTRICT="!test? ( test )"
+# Some tests are failing
+RESTRICT="test"
 
 RDEPEND="
 	${PYTHON_DEPS}
@@ -29,11 +31,6 @@ RDEPEND="
 "
 DEPEND="${RDEPEND}"
 BDEPEND="virtual/pkgconfig"
-
-# Some tests are failing
-RESTRICT="test"
-
-S="${WORKDIR}"/${P/gstreamer/gst}
 
 src_configure() {
 	local emesonargs=(

--- a/media-libs/gstreamer-editing-services/gstreamer-editing-services-1.20.5.ebuild
+++ b/media-libs/gstreamer-editing-services/gstreamer-editing-services-1.20.5.ebuild
@@ -9,6 +9,7 @@ inherit meson python-r1
 DESCRIPTION="SDK for making video editors and more"
 HOMEPAGE="http://wiki.pitivi.org/wiki/GES"
 SRC_URI="https://gstreamer.freedesktop.org/src/${PN}/${P/gstreamer/gst}.tar.xz"
+S="${WORKDIR}"/${P/gstreamer/gst}
 
 LICENSE="LGPL-2+"
 SLOT="1.0"
@@ -16,7 +17,8 @@ KEYWORDS="amd64 x86"
 
 IUSE="+introspection test"
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"
-RESTRICT="!test? ( test )"
+# Some tests are failing
+RESTRICT="test"
 
 RDEPEND="
 	${PYTHON_DEPS}
@@ -29,11 +31,6 @@ RDEPEND="
 "
 DEPEND="${RDEPEND}"
 BDEPEND="virtual/pkgconfig"
-
-# Some tests are failing
-RESTRICT="test"
-
-S="${WORKDIR}"/${P/gstreamer/gst}
 
 src_configure() {
 	local emesonargs=(

--- a/media-libs/gstreamer-editing-services/gstreamer-editing-services-1.20.6.ebuild
+++ b/media-libs/gstreamer-editing-services/gstreamer-editing-services-1.20.6.ebuild
@@ -9,6 +9,7 @@ inherit meson python-r1
 DESCRIPTION="SDK for making video editors and more"
 HOMEPAGE="http://wiki.pitivi.org/wiki/GES"
 SRC_URI="https://gstreamer.freedesktop.org/src/${PN}/${P/gstreamer/gst}.tar.xz"
+S="${WORKDIR}"/${P/gstreamer/gst}
 
 LICENSE="LGPL-2+"
 SLOT="1.0"
@@ -16,7 +17,8 @@ KEYWORDS="amd64 x86"
 
 IUSE="+introspection test"
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"
-RESTRICT="!test? ( test )"
+# Some tests are failing
+RESTRICT="test"
 
 RDEPEND="
 	${PYTHON_DEPS}
@@ -29,11 +31,6 @@ RDEPEND="
 "
 DEPEND="${RDEPEND}"
 BDEPEND="virtual/pkgconfig"
-
-# Some tests are failing
-RESTRICT="test"
-
-S="${WORKDIR}"/${P/gstreamer/gst}
 
 src_configure() {
 	local emesonargs=(

--- a/media-libs/gstreamer-editing-services/gstreamer-editing-services-1.22.3.ebuild
+++ b/media-libs/gstreamer-editing-services/gstreamer-editing-services-1.22.3.ebuild
@@ -9,6 +9,7 @@ inherit meson python-r1
 DESCRIPTION="SDK for making video editors and more"
 HOMEPAGE="http://wiki.pitivi.org/wiki/GES"
 SRC_URI="https://gstreamer.freedesktop.org/src/${PN}/${P/gstreamer/gst}.tar.xz"
+S="${WORKDIR}"/${P/gstreamer/gst}
 
 LICENSE="LGPL-2+"
 SLOT="1.0"
@@ -16,7 +17,8 @@ KEYWORDS="~amd64 ~x86"
 
 IUSE="+introspection test"
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"
-RESTRICT="!test? ( test )"
+# Some tests are failing
+RESTRICT="test"
 
 RDEPEND="
 	${PYTHON_DEPS}
@@ -29,11 +31,6 @@ RDEPEND="
 "
 DEPEND="${RDEPEND}"
 BDEPEND="virtual/pkgconfig"
-
-# Some tests are failing
-RESTRICT="test"
-
-S="${WORKDIR}"/${P/gstreamer/gst}
 
 src_configure() {
 	local emesonargs=(

--- a/media-libs/rubberband/rubberband-3.3.0-r1.ebuild
+++ b/media-libs/rubberband/rubberband-3.3.0-r1.ebuild
@@ -13,11 +13,9 @@ LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~loong ~mips ppc ppc64 ~riscv ~sparc x86"
 IUSE="ladspa lv2 jni static-libs +programs test vamp"
+RESTRICT="!test? ( test )"
 
-BDEPEND="
-	virtual/pkgconfig
-"
-CDEPEND="
+DEPEND="
 	media-libs/libsamplerate[${MULTILIB_USEDEP}]
 	sci-libs/fftw:3.0[${MULTILIB_USEDEP}]
 	jni? ( >=virtual/jdk-1.8:* )
@@ -27,12 +25,13 @@ CDEPEND="
 	vamp? ( media-libs/vamp-plugin-sdk[${MULTILIB_USEDEP}] )
 "
 RDEPEND="
-	${CDEPEND}
+	${DEPEND}
 	ppc? ( sys-devel/gcc:* )
 "
-DEPEND="${CDEPEND}"
-BDEPEND="test? ( dev-libs/boost[${MULTILIB_USEDEP}] )"
-RESTRICT="!test? ( test )"
+BDEPEND="
+	virtual/pkgconfig
+	test? ( dev-libs/boost[${MULTILIB_USEDEP}] )
+"
 
 src_prepare() {
 	sed -i \

--- a/media-libs/suil/suil-0.10.18-r1.ebuild
+++ b/media-libs/suil/suil-0.10.18-r1.ebuild
@@ -15,14 +15,6 @@ KEYWORDS="amd64 ~arm64 ~loong ppc ppc64 ~riscv x86"
 IUSE="doc gtk gtk2 qt5 test X"
 RESTRICT="!test? ( test )"
 
-BDEPEND="
-	virtual/pkgconfig
-	doc? (
-		app-doc/doxygen
-		dev-python/sphinx
-		dev-python/sphinx_lv2_theme
-	)
-"
 # This could be way refined, but it's quickly a rabbit hole
 # Take care on bumps to check lv2 minimum version!
 RDEPEND="
@@ -44,7 +36,15 @@ RDEPEND="
 	X? ( x11-libs/libX11 )
 "
 DEPEND="${RDEPEND}"
-BDEPEND="test? ( dev-libs/check )"
+BDEPEND="
+	virtual/pkgconfig
+	doc? (
+		app-doc/doxygen
+		dev-python/sphinx
+		dev-python/sphinx_lv2_theme
+	)
+	test? ( dev-libs/check )
+"
 
 DOCS=( AUTHORS NEWS README.md )
 

--- a/media-sound/cmus/cmus-2.10.0-r1.ebuild
+++ b/media-sound/cmus/cmus-2.10.0-r1.ebuild
@@ -21,8 +21,11 @@ SLOT="0"
 IUSE="aac alsa ao cddb cdio debug discid elogind examples ffmpeg +flac jack libsamplerate
 	+mad mikmod modplug mp4 musepack opus oss pidgin pulseaudio sndio systemd tremor +unicode
 	+vorbis wavpack"
-
-REQUIRED_USE="?? ( elogind systemd )"
+# Both CONFIG_TREMOR=y and CONFIG_VORBIS=y are required to link to tremor libs instead of vorbis libs
+REQUIRED_USE="
+	?? ( elogind systemd )
+	tremor? ( vorbis )
+	mp4? ( aac )" # enabling mp4 adds -lfaad
 
 BDEPEND="
 	virtual/pkgconfig
@@ -59,10 +62,6 @@ RDEPEND="${DEPEND}
 		net-im/pidgin
 	)
 "
-
-# Both CONFIG_TREMOR=y and CONFIG_VORBIS=y are required to link to tremor libs instead of vorbis libs
-REQUIRED_USE="tremor? ( vorbis )
-	mp4? ( aac )" # enabling mp4 adds -lfaad
 
 DOCS=( AUTHORS README.md )
 

--- a/media-sound/cmus/cmus-9999.ebuild
+++ b/media-sound/cmus/cmus-9999.ebuild
@@ -22,7 +22,11 @@ IUSE="aac alsa ao cddb cdio debug discid elogind examples ffmpeg +flac jack libs
 	+mad mikmod modplug mp4 musepack opus oss pidgin pulseaudio sndio systemd tremor +unicode
 	+vorbis wavpack"
 
-REQUIRED_USE="?? ( elogind systemd )"
+# Both CONFIG_TREMOR=y and CONFIG_VORBIS=y are required to link to tremor libs instead of vorbis libs
+REQUIRED_USE="
+	?? ( elogind systemd )
+	tremor? ( vorbis )
+	mp4? ( aac )" # enabling mp4 adds -lfaad
 
 BDEPEND="
 	virtual/pkgconfig
@@ -59,10 +63,6 @@ RDEPEND="${DEPEND}
 		net-im/pidgin
 	)
 "
-
-# Both CONFIG_TREMOR=y and CONFIG_VORBIS=y are required to link to tremor libs instead of vorbis libs
-REQUIRED_USE="tremor? ( vorbis )
-	mp4? ( aac )" # enabling mp4 adds -lfaad
 
 DOCS=( AUTHORS README.md )
 

--- a/media-sound/pulseaudio-daemon/pulseaudio-daemon-16.1-r3.ebuild
+++ b/media-sound/pulseaudio-daemon/pulseaudio-daemon-16.1-r3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="7"
@@ -157,8 +157,6 @@ BDEPEND="
 "
 
 DOCS=( NEWS README )
-
-S="${WORKDIR}/${MY_P}"
 
 # patches merged upstream, to be removed with 16.2 or later bump
 PATCHES=(

--- a/media-sound/pulseaudio-daemon/pulseaudio-daemon-16.1-r6.ebuild
+++ b/media-sound/pulseaudio-daemon/pulseaudio-daemon-16.1-r6.ebuild
@@ -158,8 +158,6 @@ BDEPEND="
 
 DOCS=( NEWS README )
 
-S="${WORKDIR}/${MY_P}"
-
 # patches merged upstream, to be removed with 16.2 or later bump
 PATCHES=(
 	"${FILESDIR}"/pulseaudio-16.0-optional-module-console-kit.patch

--- a/media-sound/pulseaudio-daemon/pulseaudio-daemon-16.1-r7.ebuild
+++ b/media-sound/pulseaudio-daemon/pulseaudio-daemon-16.1-r7.ebuild
@@ -157,8 +157,6 @@ BDEPEND="
 
 DOCS=( NEWS README )
 
-S="${WORKDIR}/${MY_P}"
-
 # patches merged upstream, to be removed with 16.2 or later bump
 PATCHES=(
 	"${FILESDIR}"/pulseaudio-16.0-optional-module-console-kit.patch

--- a/media-sound/qpaeq/qpaeq-16.1.ebuild
+++ b/media-sound/qpaeq/qpaeq-16.1.ebuild
@@ -1,31 +1,22 @@
 # Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="8"
+EAPI=8
 
 MY_PV="${PV/_pre*}"
 MY_P="pulseaudio-${MY_PV}"
 
-PYTHON_COMPAT=( python3_{8..11} )
+PYTHON_COMPAT=( python3_{10..11} )
 inherit python-single-r1
 
 DESCRIPTION="Equalizer interface for equalizer sinks of PulseAudio (networked sound server)"
 HOMEPAGE="https://www.freedesktop.org/wiki/Software/PulseAudio/"
-
-if [[ ${PV} = 9999 ]]; then
-	inherit git-r3
-	EGIT_BRANCH="master"
-	EGIT_REPO_URI="https://gitlab.freedesktop.org/pulseaudio/pulseaudio"
-else
-	SRC_URI="https://freedesktop.org/software/pulseaudio/releases/${MY_P}.tar.xz"
-	KEYWORDS="~amd64 ~arm ~arm64 ~loong ~ppc ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux"
-fi
-
+SRC_URI="https://freedesktop.org/software/pulseaudio/releases/${MY_P}.tar.xz"
 S="${WORKDIR}/${MY_P}"
 
 LICENSE="LGPL-2.1"
 SLOT="0"
-IUSE=""
+KEYWORDS="~amd64 ~arm ~arm64 ~loong ~ppc ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux"
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 
 RDEPEND="
@@ -37,11 +28,6 @@ RDEPEND="
 	>=media-sound/pulseaudio-daemon-16.1-r7[dbus,fftw]
 	!<media-sound/pulseaudio-daemon-16.1-r7
 "
-DEPEND=""
-
-BDEPEND=""
-
-S="${WORKDIR}/${MY_P}"
 
 src_configure() {
 	:; # do nothing

--- a/media-sound/zynaddsubfx/zynaddsubfx-3.0.6-r1.ebuild
+++ b/media-sound/zynaddsubfx/zynaddsubfx-3.0.6-r1.ebuild
@@ -13,13 +13,8 @@ LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="amd64 ~ppc x86"
 IUSE="+alsa doc dssi +fltk jack lash portaudio"
-
 REQUIRED_USE="|| ( alsa jack portaudio )"
 
-BDEPEND="
-	virtual/pkgconfig
-	doc? ( app-doc/doxygen )
-"
 DEPEND="
 	dev-libs/mxml
 	media-libs/liblo
@@ -40,6 +35,7 @@ DEPEND="
 RDEPEND="${DEPEND}"
 BDEPEND="
 	dev-lang/ruby:*
+	virtual/pkgconfig
 	doc? ( app-doc/doxygen )
 "
 

--- a/net-analyzer/nagstamon/nagstamon-3.10.1.ebuild
+++ b/net-analyzer/nagstamon/nagstamon-3.10.1.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 PYTHON_COMPAT=( python3_{10..11} )
 
-inherit python-r1 distutils-r1
+inherit distutils-r1
 
 distutils_enable_tests pytest
 

--- a/net-analyzer/nagstamon/nagstamon-3.10.1.ebuild
+++ b/net-analyzer/nagstamon/nagstamon-3.10.1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{9,10,11} )
+PYTHON_COMPAT=( python3_{10..11} )
 
 inherit python-r1 distutils-r1
 
@@ -12,10 +12,10 @@ distutils_enable_tests pytest
 MY_PN="Nagstamon"
 MY_P="${MY_PN}-${PV/_p/-}"
 
-DESCRIPTION="status monitor for the desktop"
 DESCRIPTION="systray monitor for displaying realtime status of several monitoring systems"
 HOMEPAGE="https://nagstamon.de"
 SRC_URI="https://github.com/HenriWahl/Nagstamon/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+S="${WORKDIR}/${MY_P}"
 
 LICENSE="GPL-2"
 SLOT="0"
@@ -40,8 +40,6 @@ RDEPEND="${PYTHON_DEPS}
 DEPEND="${RDEPEND}
 	dev-python/setuptools[${PYTHON_USEDEP}]
 	test? ( dev-python/pylint[${PYTHON_USEDEP}] )"
-
-S="${WORKDIR}/${MY_P}"
 
 PATCHES=( "${FILESDIR}/${PN}-3.10.1-setup.patch" )
 

--- a/net-analyzer/nagstamon/nagstamon-3.12.0.ebuild
+++ b/net-analyzer/nagstamon/nagstamon-3.12.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10,11} )
+PYTHON_COMPAT=( python3_{10..11} )
 DISTUTILS_USE_PEP517=setuptools
 
 inherit distutils-r1
@@ -13,10 +13,10 @@ distutils_enable_tests pytest
 MY_PN="Nagstamon"
 MY_P="${MY_PN}-${PV/_p/-}"
 
-DESCRIPTION="status monitor for the desktop"
 DESCRIPTION="systray monitor for displaying realtime status of several monitoring systems"
 HOMEPAGE="https://nagstamon.de"
 SRC_URI="https://github.com/HenriWahl/Nagstamon/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+S="${WORKDIR}/${MY_P}"
 
 LICENSE="GPL-2"
 SLOT="0"
@@ -44,8 +44,6 @@ RDEPEND="${PYTHON_DEPS}
 DEPEND="${RDEPEND}
 	dev-python/setuptools[${PYTHON_USEDEP}]
 	test? ( dev-python/pylint[${PYTHON_USEDEP}] )"
-
-S="${WORKDIR}/${MY_P}"
 
 PATCHES=( "${FILESDIR}/${PN}-3.12.0-setup.patch" )
 

--- a/net-nds/openldap/openldap-2.4.59-r2.ebuild
+++ b/net-nds/openldap/openldap-2.4.59-r2.ebuild
@@ -34,13 +34,12 @@ IUSE_OPTIONAL="gnutls iodbc sasl ssl odbc debug ipv6 +syslog selinux static-libs
 IUSE_CONTRIB="smbkrb5passwd kerberos kinit pbkdf2 sha2"
 IUSE_CONTRIB="${IUSE_CONTRIB} cxx"
 IUSE="${IUSE_DAEMON} ${IUSE_BACKEND} ${IUSE_OVERLAY} ${IUSE_OPTIONAL} ${IUSE_CONTRIB}"
-
-RESTRICT="!test? ( test )"
 REQUIRED_USE="cxx? ( sasl )
 	pbkdf2? ( ssl )
 	test? ( berkdb )
 	?? ( test minimal )
 	kerberos? ( ?? ( kinit smbkrb5passwd ) )"
+RESTRICT="!test? ( test )"
 
 # always list newer first
 # Do not add any AGPL-3 BDB here!

--- a/net-nds/openldap/openldap-2.5.14.ebuild
+++ b/net-nds/openldap/openldap-2.5.14.ebuild
@@ -33,15 +33,13 @@ IUSE_OPTIONAL="debug gnutls iodbc ipv6 odbc sasl ssl selinux static-libs +syslog
 IUSE_CONTRIB="kerberos kinit pbkdf2 sha2 smbkrb5passwd"
 IUSE_CONTRIB="${IUSE_CONTRIB} cxx"
 IUSE="systemd ${IUSE_DAEMON} ${IUSE_BACKEND} ${IUSE_OVERLAY} ${IUSE_OPTIONAL} ${IUSE_CONTRIB}"
-RESTRICT="!test? ( test )"
-
-RESTRICT="!test? ( test )"
 REQUIRED_USE="cxx? ( sasl )
 	pbkdf2? ( ssl )
 	test? ( cleartext debug sasl )
 	autoca? ( !gnutls )
 	?? ( test minimal )
 	kerberos? ( ?? ( kinit smbkrb5passwd ) )"
+RESTRICT="!test? ( test )"
 
 SYSTEM_LMDB_VER=0.9.30
 # openssl is needed to generate lanman-passwords required by samba

--- a/net-nds/openldap/openldap-2.5.16.ebuild
+++ b/net-nds/openldap/openldap-2.5.16.ebuild
@@ -33,15 +33,13 @@ IUSE_OPTIONAL="debug gnutls iodbc ipv6 odbc sasl ssl selinux static-libs +syslog
 IUSE_CONTRIB="kerberos kinit pbkdf2 sha2 smbkrb5passwd"
 IUSE_CONTRIB="${IUSE_CONTRIB} cxx"
 IUSE="systemd ${IUSE_DAEMON} ${IUSE_BACKEND} ${IUSE_OVERLAY} ${IUSE_OPTIONAL} ${IUSE_CONTRIB}"
-RESTRICT="!test? ( test )"
-
-RESTRICT="!test? ( test )"
 REQUIRED_USE="cxx? ( sasl )
 	pbkdf2? ( ssl )
 	test? ( cleartext debug sasl )
 	autoca? ( !gnutls )
 	?? ( test minimal )
 	kerberos? ( ?? ( kinit smbkrb5passwd ) )"
+RESTRICT="!test? ( test )"
 
 SYSTEM_LMDB_VER=0.9.31
 # openssl is needed to generate lanman-passwords required by samba

--- a/net-nds/openldap/openldap-2.6.3-r7.ebuild
+++ b/net-nds/openldap/openldap-2.6.3-r7.ebuild
@@ -33,15 +33,13 @@ IUSE_OPTIONAL="debug gnutls iodbc ipv6 odbc sasl ssl selinux static-libs +syslog
 IUSE_CONTRIB="kerberos kinit pbkdf2 sha2 smbkrb5passwd"
 IUSE_CONTRIB="${IUSE_CONTRIB} cxx"
 IUSE="systemd ${IUSE_DAEMON} ${IUSE_BACKEND} ${IUSE_OVERLAY} ${IUSE_OPTIONAL} ${IUSE_CONTRIB}"
-RESTRICT="!test? ( test )"
-
-RESTRICT="!test? ( test )"
 REQUIRED_USE="cxx? ( sasl )
 	pbkdf2? ( ssl )
 	test? ( cleartext sasl )
 	autoca? ( !gnutls )
 	?? ( test minimal )
 	kerberos? ( ?? ( kinit smbkrb5passwd ) )"
+RESTRICT="!test? ( test )"
 
 # openssl is needed to generate lanman-passwords required by samba
 COMMON_DEPEND="

--- a/net-nds/openldap/openldap-2.6.4-r1.ebuild
+++ b/net-nds/openldap/openldap-2.6.4-r1.ebuild
@@ -33,15 +33,13 @@ IUSE_OPTIONAL="debug gnutls iodbc ipv6 odbc sasl ssl selinux static-libs +syslog
 IUSE_CONTRIB="kerberos kinit pbkdf2 sha2 smbkrb5passwd"
 IUSE_CONTRIB="${IUSE_CONTRIB} cxx"
 IUSE="systemd ${IUSE_DAEMON} ${IUSE_BACKEND} ${IUSE_OVERLAY} ${IUSE_OPTIONAL} ${IUSE_CONTRIB}"
-RESTRICT="!test? ( test )"
-
-RESTRICT="!test? ( test )"
 REQUIRED_USE="cxx? ( sasl )
 	pbkdf2? ( ssl )
 	test? ( cleartext sasl )
 	autoca? ( !gnutls )
 	?? ( test minimal )
 	kerberos? ( ?? ( kinit smbkrb5passwd ) )"
+RESTRICT="!test? ( test )"
 
 SYSTEM_LMDB_VER=0.9.30
 # openssl is needed to generate lanman-passwords required by samba

--- a/net-nds/openldap/openldap-2.6.4-r2.ebuild
+++ b/net-nds/openldap/openldap-2.6.4-r2.ebuild
@@ -34,15 +34,13 @@ IUSE_OPTIONAL="debug gnutls iodbc odbc sasl ssl selinux static-libs +syslog test
 IUSE_CONTRIB="kerberos kinit pbkdf2 sha2 smbkrb5passwd"
 IUSE_CONTRIB="${IUSE_CONTRIB} cxx"
 IUSE="systemd ${IUSE_DAEMON} ${IUSE_BACKEND} ${IUSE_OVERLAY} ${IUSE_OPTIONAL} ${IUSE_CONTRIB}"
-RESTRICT="!test? ( test )"
-
-RESTRICT="!test? ( test )"
 REQUIRED_USE="cxx? ( sasl )
 	pbkdf2? ( ssl )
 	test? ( cleartext sasl )
 	autoca? ( !gnutls )
 	?? ( test minimal )
 	kerberos? ( ?? ( kinit smbkrb5passwd ) )"
+RESTRICT="!test? ( test )"
 
 SYSTEM_LMDB_VER=0.9.30
 # openssl is needed to generate lanman-passwords required by samba

--- a/net-nds/openldap/openldap-2.6.5.ebuild
+++ b/net-nds/openldap/openldap-2.6.5.ebuild
@@ -34,7 +34,6 @@ IUSE_OPTIONAL="debug gnutls iodbc odbc sasl ssl selinux static-libs +syslog test
 IUSE_CONTRIB="kerberos kinit pbkdf2 sha2 smbkrb5passwd"
 IUSE_CONTRIB="${IUSE_CONTRIB} cxx"
 IUSE="systemd ${IUSE_DAEMON} ${IUSE_BACKEND} ${IUSE_OVERLAY} ${IUSE_OPTIONAL} ${IUSE_CONTRIB}"
-RESTRICT="!test? ( test )"
 REQUIRED_USE="
 	cxx? ( sasl )
 	pbkdf2? ( ssl )
@@ -43,6 +42,7 @@ REQUIRED_USE="
 	?? ( test minimal )
 	kerberos? ( ?? ( kinit smbkrb5passwd ) )
 "
+RESTRICT="!test? ( test )"
 
 SYSTEM_LMDB_VER=0.9.31
 # openssl is needed to generate lanman-passwords required by samba

--- a/net-nds/openldap/openldap-2.6.6.ebuild
+++ b/net-nds/openldap/openldap-2.6.6.ebuild
@@ -34,7 +34,6 @@ IUSE_OPTIONAL="debug gnutls iodbc odbc sasl ssl selinux static-libs +syslog test
 IUSE_CONTRIB="kerberos kinit pbkdf2 sha2 smbkrb5passwd"
 IUSE_CONTRIB="${IUSE_CONTRIB} cxx"
 IUSE="systemd ${IUSE_DAEMON} ${IUSE_BACKEND} ${IUSE_OVERLAY} ${IUSE_OPTIONAL} ${IUSE_CONTRIB}"
-RESTRICT="!test? ( test )"
 REQUIRED_USE="
 	cxx? ( sasl )
 	pbkdf2? ( ssl )
@@ -43,6 +42,7 @@ REQUIRED_USE="
 	?? ( test minimal )
 	kerberos? ( ?? ( kinit smbkrb5passwd ) )
 "
+RESTRICT="!test? ( test )"
 
 SYSTEM_LMDB_VER=0.9.31
 # openssl is needed to generate lanman-passwords required by samba

--- a/net-p2p/nicotine+/nicotine+-3.2.8.ebuild
+++ b/net-p2p/nicotine+/nicotine+-3.2.8.ebuild
@@ -3,41 +3,28 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{10..11} )
 DISTUTILS_USE_PEP517=setuptools
 
-inherit distutils-r1 xdg-utils
+inherit distutils-r1 xdg
 
 DESCRIPTION="A fork of nicotine, a Soulseek client in Python"
 HOMEPAGE="https://github.com/Nicotine-Plus/nicotine-plus"
 SRC_URI="https://github.com/Nicotine-Plus/nicotine-plus/archive/${PV}.tar.gz -> ${P}.tar.gz"
+S="${WORKDIR}/nicotine-plus-${PV}"
 
 LICENSE="GPL-3 LGPL-3"
 SLOT="0"
 KEYWORDS="amd64 ppc x86"
-IUSE=""
 
-DEPEND="${PYTHON_DEPS}"
-RDEPEND="
+RDEPEND="${PYTHON_DEPS}
 	dev-python/pygobject:3[${PYTHON_USEDEP}]
 	x11-libs/gtk+:3[introspection]
-	${DEPEND}
 "
-
 DEPEND="${RDEPEND}"
-
-S="${WORKDIR}/nicotine-plus-${PV}"
 
 EPYTEST_IGNORE=(
 	"test/integration/test_startup.py"
 )
 
 distutils_enable_tests pytest
-
-pkg_postinst() {
-	xdg_icon_cache_update
-}
-
-pkg_postrm() {
-	xdg_icon_cache_update
-}

--- a/net-p2p/nicotine+/nicotine+-3.2.9-r1.ebuild
+++ b/net-p2p/nicotine+/nicotine+-3.2.9-r1.ebuild
@@ -3,42 +3,29 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{10..11} )
 PYTHON_REQ_USE="gdbm"
 DISTUTILS_USE_PEP517=setuptools
 
-inherit distutils-r1 xdg-utils
+inherit distutils-r1 xdg
 
 DESCRIPTION="A fork of nicotine, a Soulseek client in Python"
 HOMEPAGE="https://github.com/Nicotine-Plus/nicotine-plus"
 SRC_URI="https://github.com/Nicotine-Plus/nicotine-plus/archive/${PV}.tar.gz -> ${P}.tar.gz"
+S="${WORKDIR}/nicotine-plus-${PV}"
 
 LICENSE="GPL-3 LGPL-3"
 SLOT="0"
 KEYWORDS="~amd64 ~ppc ~x86"
-IUSE=""
 
-DEPEND="${PYTHON_DEPS}"
-RDEPEND="
+RDEPEND="${PYTHON_DEPS}
 	dev-python/pygobject:3[${PYTHON_USEDEP}]
 	x11-libs/gtk+:3[introspection]
-	${DEPEND}
 "
-
 DEPEND="${RDEPEND}"
-
-S="${WORKDIR}/nicotine-plus-${PV}"
 
 EPYTEST_IGNORE=(
 	"test/integration/test_startup.py"
 )
 
 distutils_enable_tests pytest
-
-pkg_postinst() {
-	xdg_icon_cache_update
-}
-
-pkg_postrm() {
-	xdg_icon_cache_update
-}

--- a/net-p2p/nicotine+/nicotine+-3.2.9.ebuild
+++ b/net-p2p/nicotine+/nicotine+-3.2.9.ebuild
@@ -3,41 +3,28 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{10..11} )
 DISTUTILS_USE_PEP517=setuptools
 
-inherit distutils-r1 xdg-utils
+inherit distutils-r1 xdg
 
 DESCRIPTION="A fork of nicotine, a Soulseek client in Python"
 HOMEPAGE="https://github.com/Nicotine-Plus/nicotine-plus"
 SRC_URI="https://github.com/Nicotine-Plus/nicotine-plus/archive/${PV}.tar.gz -> ${P}.tar.gz"
+S="${WORKDIR}/nicotine-plus-${PV}"
 
 LICENSE="GPL-3 LGPL-3"
 SLOT="0"
 KEYWORDS="amd64 ppc x86"
-IUSE=""
 
-DEPEND="${PYTHON_DEPS}"
-RDEPEND="
+RDEPEND="${PYTHON_DEPS}
 	dev-python/pygobject:3[${PYTHON_USEDEP}]
 	x11-libs/gtk+:3[introspection]
-	${DEPEND}
 "
-
 DEPEND="${RDEPEND}"
-
-S="${WORKDIR}/nicotine-plus-${PV}"
 
 EPYTEST_IGNORE=(
 	"test/integration/test_startup.py"
 )
 
 distutils_enable_tests pytest
-
-pkg_postinst() {
-	xdg_icon_cache_update
-}
-
-pkg_postrm() {
-	xdg_icon_cache_update
-}

--- a/sci-chemistry/molequeue/molequeue-0.9.0-r1.ebuild
+++ b/sci-chemistry/molequeue/molequeue-0.9.0-r1.ebuild
@@ -2,7 +2,8 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-PYTHON_COMPAT=( python3_{9..11} )
+
+PYTHON_COMPAT=( python3_{10..11} )
 
 inherit cmake python-r1 virtualx
 
@@ -15,13 +16,13 @@ LICENSE="BSD"
 KEYWORDS="~amd64 ~x86 ~amd64-linux ~x86-linux"
 
 IUSE="+client doc server test +zeromq"
-RESTRICT="!test? ( test )"
-
 REQUIRED_USE="
 	server? ( client )
 	test? ( server )
 	zeromq? ( ${PYTHON_REQUIRED_USE} )
 "
+# Some tests still fail
+RESTRICT="test !test? ( test )"
 
 BDEPEND="
 	doc? ( app-doc/doxygen )
@@ -38,9 +39,6 @@ RDEPEND="
 "
 DEPEND="${RDEPEND}"
 
-# Some tests still fail
-RESTRICT="test"
-
 src_configure() {
 	configuration() {
 		local mycmakeargs=(
@@ -51,7 +49,7 @@ src_configure() {
 			-DENABLE_TESTING=$(usex test)
 			-DUSE_ZERO_MQ=$(usex zeromq)
 			-DINSTALL_LIBRARY_DIR=$(get_libdir)
-			)
+		)
 		use zeromq && \
 			mycmakeargs+=( "-DZeroMQ_ROOT_DIR=\"${EPREFIX}/usr\"" )
 

--- a/sys-block/nbd/nbd-3.24.ebuild
+++ b/sys-block/nbd/nbd-3.24.ebuild
@@ -20,8 +20,6 @@ LICENSE="GPL-2"
 SLOT="0"
 IUSE="debug gnutls netlink zlib"
 
-BDEPEND="virtual/pkgconfig"
-
 RDEPEND="
 	>=dev-libs/glib-2.26.0
 	gnutls? ( >=net-libs/gnutls-2.12.0 )
@@ -29,9 +27,12 @@ RDEPEND="
 	zlib? ( sys-libs/zlib )
 "
 DEPEND="${RDEPEND}"
-BDEPEND="sys-devel/bison"
+BDEPEND="
+	sys-devel/bison
+	virtual/pkgconfig
+"
 
-if [[ ${PV} = 9999 ]] ; then
+if [[ ${PV} == 9999 ]] ; then
 	BDEPEND+="
 		app-text/docbook-sgml-dtd:4.5
 		app-text/docbook-sgml-utils

--- a/sys-fs/btrfs-progs/btrfs-progs-6.3.1.ebuild
+++ b/sys-fs/btrfs-progs/btrfs-progs-6.3.1.ebuild
@@ -33,7 +33,7 @@ SLOT="0/${libbtrfs_soname}"
 IUSE="+convert python +man reiserfs static static-libs udev +zstd"
 # Could support it with just !systemd => eudev, see mdadm, but let's
 # see if someone asks for it first.
-REQUIRED_USE="static? ( !udev )"
+REQUIRED_USE="static? ( !udev ) python? ( ${PYTHON_REQUIRED_USE} )"
 
 # Tries to mount repaired filesystems
 RESTRICT="test"
@@ -82,8 +82,6 @@ BDEPEND="
 if [[ ${PV} == 9999 ]]; then
 	BDEPEND+=" sys-devel/gnuconfig"
 fi
-
-REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
 
 pkg_setup() {
 	use python && python-single-r1_pkg_setup

--- a/sys-fs/btrfs-progs/btrfs-progs-6.3.2.ebuild
+++ b/sys-fs/btrfs-progs/btrfs-progs-6.3.2.ebuild
@@ -32,7 +32,7 @@ SLOT="0/${libbtrfs_soname}"
 IUSE="+convert python +man reiserfs static static-libs udev +zstd"
 # Could support it with just !systemd => eudev, see mdadm, but let's
 # see if someone asks for it first.
-REQUIRED_USE="static? ( !udev )"
+REQUIRED_USE="static? ( !udev ) python? ( ${PYTHON_REQUIRED_USE} )"
 
 # Tries to mount repaired filesystems
 RESTRICT="test"
@@ -81,8 +81,6 @@ BDEPEND="
 if [[ ${PV} == 9999 ]]; then
 	BDEPEND+=" sys-devel/gnuconfig"
 fi
-
-REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
 
 pkg_setup() {
 	use python && python-single-r1_pkg_setup

--- a/sys-fs/btrfs-progs/btrfs-progs-6.3.3.ebuild
+++ b/sys-fs/btrfs-progs/btrfs-progs-6.3.3.ebuild
@@ -32,7 +32,7 @@ SLOT="0/${libbtrfs_soname}"
 IUSE="+convert python +man reiserfs static static-libs udev +zstd"
 # Could support it with just !systemd => eudev, see mdadm, but let's
 # see if someone asks for it first.
-REQUIRED_USE="static? ( !udev )"
+REQUIRED_USE="static? ( !udev ) python? ( ${PYTHON_REQUIRED_USE} )"
 
 # Tries to mount repaired filesystems
 RESTRICT="test"
@@ -81,8 +81,6 @@ BDEPEND="
 if [[ ${PV} == 9999 ]]; then
 	BDEPEND+=" sys-devel/gnuconfig"
 fi
-
-REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
 
 pkg_setup() {
 	use python && python-single-r1_pkg_setup

--- a/sys-fs/btrfs-progs/btrfs-progs-6.5.1.ebuild
+++ b/sys-fs/btrfs-progs/btrfs-progs-6.5.1.ebuild
@@ -32,7 +32,7 @@ SLOT="0/${libbtrfs_soname}"
 IUSE="+convert python +man reiserfs static static-libs udev +zstd"
 # Could support it with just !systemd => eudev, see mdadm, but let's
 # see if someone asks for it first.
-REQUIRED_USE="static? ( !udev )"
+REQUIRED_USE="static? ( !udev ) python? ( ${PYTHON_REQUIRED_USE} )"
 
 # Tries to mount repaired filesystems
 RESTRICT="test"
@@ -81,8 +81,6 @@ BDEPEND="
 if [[ ${PV} == 9999 ]]; then
 	BDEPEND+=" sys-devel/gnuconfig"
 fi
-
-REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
 
 pkg_setup() {
 	use python && python-single-r1_pkg_setup

--- a/sys-fs/btrfs-progs/btrfs-progs-6.5.ebuild
+++ b/sys-fs/btrfs-progs/btrfs-progs-6.5.ebuild
@@ -32,7 +32,7 @@ SLOT="0/${libbtrfs_soname}"
 IUSE="+convert python +man reiserfs static static-libs udev +zstd"
 # Could support it with just !systemd => eudev, see mdadm, but let's
 # see if someone asks for it first.
-REQUIRED_USE="static? ( !udev )"
+REQUIRED_USE="static? ( !udev ) python? ( ${PYTHON_REQUIRED_USE} )"
 
 # Tries to mount repaired filesystems
 RESTRICT="test"
@@ -81,8 +81,6 @@ BDEPEND="
 if [[ ${PV} == 9999 ]]; then
 	BDEPEND+=" sys-devel/gnuconfig"
 fi
-
-REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-6.5-avoid-textrel-crc32c-pcl-intel-asm_64.patch

--- a/sys-fs/btrfs-progs/btrfs-progs-9999.ebuild
+++ b/sys-fs/btrfs-progs/btrfs-progs-9999.ebuild
@@ -32,7 +32,7 @@ SLOT="0/${libbtrfs_soname}"
 IUSE="+convert python +man reiserfs static static-libs udev +zstd"
 # Could support it with just !systemd => eudev, see mdadm, but let's
 # see if someone asks for it first.
-REQUIRED_USE="static? ( !udev )"
+REQUIRED_USE="static? ( !udev ) python? ( ${PYTHON_REQUIRED_USE} )"
 
 # Tries to mount repaired filesystems
 RESTRICT="test"
@@ -81,8 +81,6 @@ BDEPEND="
 if [[ ${PV} == 9999 ]]; then
 	BDEPEND+=" sys-devel/gnuconfig"
 fi
-
-REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
 
 pkg_setup() {
 	use python && python-single-r1_pkg_setup

--- a/sys-libs/ncurses-compat/ncurses-compat-6.4_p20230401.ebuild
+++ b/sys-libs/ncurses-compat/ncurses-compat-6.4_p20230401.ebuild
@@ -16,7 +16,6 @@ MY_PN="${PN/-compat}"
 
 DESCRIPTION="Console display library (ABI version 5)"
 HOMEPAGE="https://www.gnu.org/software/ncurses/ https://invisible-island.net/ncurses/"
-SRC_URI="mirror://gnu/ncurses/${MY_P}.tar.gz"
 
 # Keep invisible-mirror.net here as some users reported 403 forbidden with invisible-island.net
 SRC_URI="

--- a/www-client/vivaldi-snapshot/vivaldi-snapshot-6.3.3119.4.ebuild
+++ b/www-client/vivaldi-snapshot/vivaldi-snapshot-6.3.3119.4.ebuild
@@ -101,10 +101,11 @@ fi
 KEYWORDS="-* ~amd64 ~arm ~arm64"
 VIVALDI_BASE_URI="https://downloads.vivaldi.com/${VIVALDI_PN#vivaldi-}/${VIVALDI_PN}_${PV%_p*}-${DEB_REV}_"
 
-RE="\bamd64\b"; [[ ${KEYWORDS} =~ ${RE} ]] && SRC_URI+=" amd64? ( ${VIVALDI_BASE_URI}amd64.deb )"
-RE="\barm\b"; [[ ${KEYWORDS} =~ ${RE} ]] && SRC_URI+=" arm? ( ${VIVALDI_BASE_URI}armhf.deb )"
-RE="\barm64\b"; [[ ${KEYWORDS} =~ ${RE} ]] && SRC_URI+=" arm64? ( ${VIVALDI_BASE_URI}arm64.deb )"
-RE="\bx86\b"; [[ ${KEYWORDS} =~ ${RE} ]] && SRC_URI+=" x86? ( ${VIVALDI_BASE_URI}i386.deb )"
+SRC_URI="
+	amd64? ( ${VIVALDI_BASE_URI}amd64.deb )
+	arm? ( ${VIVALDI_BASE_URI}armhf.deb )
+	arm64? ( ${VIVALDI_BASE_URI}arm64.deb )
+"
 
 LICENSE="Vivaldi"
 SLOT="0"

--- a/www-client/vivaldi-snapshot/vivaldi-snapshot-6.3.3120.3.ebuild
+++ b/www-client/vivaldi-snapshot/vivaldi-snapshot-6.3.3120.3.ebuild
@@ -101,10 +101,11 @@ fi
 KEYWORDS="-* ~amd64 ~arm ~arm64"
 VIVALDI_BASE_URI="https://downloads.vivaldi.com/${VIVALDI_PN#vivaldi-}/${VIVALDI_PN}_${PV%_p*}-${DEB_REV}_"
 
-RE="\bamd64\b"; [[ ${KEYWORDS} =~ ${RE} ]] && SRC_URI+=" amd64? ( ${VIVALDI_BASE_URI}amd64.deb )"
-RE="\barm\b"; [[ ${KEYWORDS} =~ ${RE} ]] && SRC_URI+=" arm? ( ${VIVALDI_BASE_URI}armhf.deb )"
-RE="\barm64\b"; [[ ${KEYWORDS} =~ ${RE} ]] && SRC_URI+=" arm64? ( ${VIVALDI_BASE_URI}arm64.deb )"
-RE="\bx86\b"; [[ ${KEYWORDS} =~ ${RE} ]] && SRC_URI+=" x86? ( ${VIVALDI_BASE_URI}i386.deb )"
+SRC_URI="
+	amd64? ( ${VIVALDI_BASE_URI}amd64.deb )
+	arm? ( ${VIVALDI_BASE_URI}armhf.deb )
+	arm64? ( ${VIVALDI_BASE_URI}arm64.deb )
+"
 
 LICENSE="Vivaldi"
 SLOT="0"

--- a/www-client/vivaldi/vivaldi-6.2.3105.47.ebuild
+++ b/www-client/vivaldi/vivaldi-6.2.3105.47.ebuild
@@ -101,10 +101,11 @@ fi
 KEYWORDS="-* amd64 ~arm ~arm64"
 VIVALDI_BASE_URI="https://downloads.vivaldi.com/${VIVALDI_PN#vivaldi-}/${VIVALDI_PN}_${PV%_p*}-${DEB_REV}_"
 
-RE="\bamd64\b"; [[ ${KEYWORDS} =~ ${RE} ]] && SRC_URI+=" amd64? ( ${VIVALDI_BASE_URI}amd64.deb )"
-RE="\barm\b"; [[ ${KEYWORDS} =~ ${RE} ]] && SRC_URI+=" arm? ( ${VIVALDI_BASE_URI}armhf.deb )"
-RE="\barm64\b"; [[ ${KEYWORDS} =~ ${RE} ]] && SRC_URI+=" arm64? ( ${VIVALDI_BASE_URI}arm64.deb )"
-RE="\bx86\b"; [[ ${KEYWORDS} =~ ${RE} ]] && SRC_URI+=" x86? ( ${VIVALDI_BASE_URI}i386.deb )"
+SRC_URI="
+	amd64? ( ${VIVALDI_BASE_URI}amd64.deb )
+	arm? ( ${VIVALDI_BASE_URI}armhf.deb )
+	arm64? ( ${VIVALDI_BASE_URI}arm64.deb )
+"
 
 LICENSE="Vivaldi"
 SLOT="0"

--- a/www-client/vivaldi/vivaldi-6.2.3105.48.ebuild
+++ b/www-client/vivaldi/vivaldi-6.2.3105.48.ebuild
@@ -101,10 +101,11 @@ fi
 KEYWORDS="-* ~amd64 ~arm ~arm64"
 VIVALDI_BASE_URI="https://downloads.vivaldi.com/${VIVALDI_PN#vivaldi-}/${VIVALDI_PN}_${PV%_p*}-${DEB_REV}_"
 
-RE="\bamd64\b"; [[ ${KEYWORDS} =~ ${RE} ]] && SRC_URI+=" amd64? ( ${VIVALDI_BASE_URI}amd64.deb )"
-RE="\barm\b"; [[ ${KEYWORDS} =~ ${RE} ]] && SRC_URI+=" arm? ( ${VIVALDI_BASE_URI}armhf.deb )"
-RE="\barm64\b"; [[ ${KEYWORDS} =~ ${RE} ]] && SRC_URI+=" arm64? ( ${VIVALDI_BASE_URI}arm64.deb )"
-RE="\bx86\b"; [[ ${KEYWORDS} =~ ${RE} ]] && SRC_URI+=" x86? ( ${VIVALDI_BASE_URI}i386.deb )"
+SRC_URI="
+	amd64? ( ${VIVALDI_BASE_URI}amd64.deb )
+	arm? ( ${VIVALDI_BASE_URI}armhf.deb )
+	arm64? ( ${VIVALDI_BASE_URI}arm64.deb )
+"
 
 LICENSE="Vivaldi"
 SLOT="0"


### PR DESCRIPTION
As a result of new pkgcheck check https://github.com/pkgcore/pkgcheck/pull/623, it captures global assign shadows, and reports them. So let's fix all of them 😄 . The only once I gave up were:

```
sci-mathematics/fricas
  VariableShadowed: version 1.3.8-r1: possible variable 'n' is shadowed, on lines: 29, 45
  VariableShadowed: version 1.3.9: possible variable 'n' is shadowed, on lines: 30, 46
```

<details>
  <summary>Original Results for ::gentoo</summary>
  
  ```
  app-editors/neovim
    VariableShadowed: version 0.9.0-r1: possible variable 'REQUIRED_USE' is shadowed, on lines: 26, 29
    VariableShadowed: version 0.9.1: possible variable 'REQUIRED_USE' is shadowed, on lines: 26, 29
    VariableShadowed: version 0.9.2: possible variable 'REQUIRED_USE' is shadowed, on lines: 26, 29
    VariableShadowed: version 9999: possible variable 'REQUIRED_USE' is shadowed, on lines: 26, 29
  
  app-emulation/libguestfs
    VariableShadowed: version 1.48.4: possible variable 'BDEPEND' is shadowed, on lines: 110, 117
    VariableShadowed: version 1.48.6: possible variable 'BDEPEND' is shadowed, on lines: 110, 117
  
  dev-db/sqldeveloper
    VariableShadowed: version 23.1.0.097.1607: possible variable 'S' is shadowed, on lines: 11, 31
  
  dev-java/fop
    VariableShadowed: version 2.8-r1: possible variable 'BDEPEND' is shadowed, on lines: 50, 62
  
  dev-lang/luajit
    VariableShadowed: version 2.1.0_beta3_p20220127-r2: possible variable 'SRC_URI' is shadowed, on lines: 23, 24
    VariableShadowed: version 2.1.0_beta3_p20220613: possible variable 'SRC_URI' is shadowed, on lines: 23, 24
  
  dev-libs/gmp
    VariableShadowed: version 6.2.1-r5: possible variable 'MANUAL_PV' is shadowed, on lines: 11, 12
    VariableShadowed: version 6.3.0: possible variable 'MANUAL_PV' is shadowed, on lines: 11, 12
  
  dev-libs/libcgroup
    VariableShadowed: version 0.41-r6: possible variable 'PATCHES' is shadowed, on lines: 30, 45
  
  dev-ml/ppx_deriving
    VariableShadowed: version 5.2: possible variable 'DEPEND' is shadowed, on lines: 18, 26
    VariableShadowed: version 5.2.1: possible variable 'DEPEND' is shadowed, on lines: 18, 28
  
  dev-ml/stdcompat
    VariableShadowed: version 19: possible variable 'SLOT' is shadowed, on lines: 11, 13
  
  dev-perl/DBD-MariaDB
    VariableShadowed: version 1.210.0-r1: possible variable 'DEPEND' is shadowed, on lines: 23, 28
    VariableShadowed: version 1.220.0: possible variable 'DEPEND' is shadowed, on lines: 23, 28
  
  dev-php/pecl-translit
    VariableShadowed: version 0.7.1: possible variable 'PHP_EXT_NAME' is shadowed, on lines: 6, 11
  
  dev-php/pecl-eio
    VariableShadowed: version 3.0.0_rc2: possible variable 'LICENSE' is shadowed, on lines: 19, 22
    VariableShadowed: version 3.0.0_rc4: possible variable 'LICENSE' is shadowed, on lines: 19, 22
    VariableShadowed: version 3.1.0_rc1: possible variable 'LICENSE' is shadowed, on lines: 19, 22
  
  dev-python/keystoneauth1
    VariableShadowed: version 5.2.1: possible variable 'HOMEPAGE' is shadowed, on lines: 12, 13
    VariableShadowed: version 5.3.0: possible variable 'HOMEPAGE' is shadowed, on lines: 12, 13
  
  games-puzzle/pauker
    VariableShadowed: version 1.8-r3: possible variable 'BDEPEND' is shadowed, on lines: 19, 30
  
  gnome-base/gnome-control-center
    VariableShadowed: version 44.3: possible variable 'BDEPEND' is shadowed, on lines: 25, 120
    VariableShadowed: version 45_rc: possible variable 'BDEPEND' is shadowed, on lines: 25, 119
  
  media-gfx/viewer
    VariableShadowed: version 0.8.0-r1: possible variable 'SRC_URI' is shadowed, on lines: 10, 11
  
  media-libs/suil
    VariableShadowed: version 0.10.18-r1: possible variable 'BDEPEND' is shadowed, on lines: 18, 47
  
  media-libs/rubberband
    VariableShadowed: version 3.3.0-r1: possible variable 'BDEPEND' is shadowed, on lines: 17, 34
  
  media-libs/gstreamer-editing-services
    VariableShadowed: version 1.20.3: possible variable 'RESTRICT' is shadowed, on lines: 19, 34
    VariableShadowed: version 1.20.4: possible variable 'RESTRICT' is shadowed, on lines: 19, 34
    VariableShadowed: version 1.20.5: possible variable 'RESTRICT' is shadowed, on lines: 19, 34
    VariableShadowed: version 1.20.6: possible variable 'RESTRICT' is shadowed, on lines: 19, 34
    VariableShadowed: version 1.22.3: possible variable 'RESTRICT' is shadowed, on lines: 19, 34
  
  media-sound/cmus
    VariableShadowed: version 2.10.0-r1: possible variable 'REQUIRED_USE' is shadowed, on lines: 25, 64
    VariableShadowed: version 9999: possible variable 'REQUIRED_USE' is shadowed, on lines: 25, 64
  
  media-sound/qpaeq
    VariableShadowed: version 16.1: possible variable 'S' is shadowed, on lines: 24, 44
  
  media-sound/zynaddsubfx
    VariableShadowed: version 3.0.6-r1: possible variable 'BDEPEND' is shadowed, on lines: 19, 41
  
  media-sound/pulseaudio-daemon
    VariableShadowed: version 16.1-r3: possible variable 'S' is shadowed, on lines: 22, 161
    VariableShadowed: version 16.1-r6: possible variable 'S' is shadowed, on lines: 22, 161
    VariableShadowed: version 16.1-r7: possible variable 'S' is shadowed, on lines: 22, 160
  
  net-analyzer/nagstamon
    VariableShadowed: version 3.10.1: possible variable 'DESCRIPTION' is shadowed, on lines: 15, 16
    VariableShadowed: version 3.12.0: possible variable 'DESCRIPTION' is shadowed, on lines: 16, 17
  
  net-p2p/nicotine+
    VariableShadowed: version 3.2.8: possible variable 'DEPEND' is shadowed, on lines: 20, 27
    VariableShadowed: version 3.2.9: possible variable 'DEPEND' is shadowed, on lines: 20, 27
    VariableShadowed: version 3.2.9-r1: possible variable 'DEPEND' is shadowed, on lines: 21, 28
  
  sci-chemistry/molequeue
    VariableShadowed: version 0.9.0-r1: possible variable 'RESTRICT' is shadowed, on lines: 18, 42
  
  net-nds/openldap
    VariableShadowed: version 2.5.14: possible variable 'RESTRICT' is shadowed, on lines: 36, 38
    VariableShadowed: version 2.5.16: possible variable 'RESTRICT' is shadowed, on lines: 36, 38
    VariableShadowed: version 2.6.3-r7: possible variable 'RESTRICT' is shadowed, on lines: 36, 38
    VariableShadowed: version 2.6.4-r1: possible variable 'RESTRICT' is shadowed, on lines: 36, 38
    VariableShadowed: version 2.6.4-r2: possible variable 'RESTRICT' is shadowed, on lines: 37, 39
  
  sci-mathematics/fricas
    VariableShadowed: version 1.3.8-r1: possible variable 'n' is shadowed, on lines: 29, 45
    VariableShadowed: version 1.3.9: possible variable 'n' is shadowed, on lines: 30, 46
  
  sys-block/nbd
    VariableShadowed: version 3.24: possible variable 'BDEPEND' is shadowed, on lines: 23, 32
  
  sys-libs/ncurses-compat
    VariableShadowed: version 6.4_p20230401: possible variable 'SRC_URI' is shadowed, on lines: 19, 22
  
  sys-fs/btrfs-progs
    VariableShadowed: version 6.3.1: possible variable 'REQUIRED_USE' is shadowed, on lines: 36, 86
    VariableShadowed: version 6.3.2: possible variable 'REQUIRED_USE' is shadowed, on lines: 35, 85
    VariableShadowed: version 6.3.3: possible variable 'REQUIRED_USE' is shadowed, on lines: 35, 85
    VariableShadowed: version 6.5: possible variable 'REQUIRED_USE' is shadowed, on lines: 35, 85
    VariableShadowed: version 6.5.1: possible variable 'REQUIRED_USE' is shadowed, on lines: 35, 85
    VariableShadowed: version 9999: possible variable 'REQUIRED_USE' is shadowed, on lines: 35, 85
  
  www-client/vivaldi-snapshot
    VariableShadowed: version 6.3.3119.4: possible variable 'RE' is shadowed, on lines: 104, 105, 106, 107
    VariableShadowed: version 6.3.3120.3: possible variable 'RE' is shadowed, on lines: 104, 105, 106, 107
  
  www-client/vivaldi
    VariableShadowed: version 6.2.3105.47: possible variable 'RE' is shadowed, on lines: 104, 105, 106, 107
    VariableShadowed: version 6.2.3105.48: possible variable 'RE' is shadowed, on lines: 104, 105, 106, 107
  ```
</details>