### PR TITLE
sys-power/nut: Rename asciidoc-ready documentation sources to *.adoc

### DIFF
--- a/sys-power/nut/nut-9999.ebuild
+++ b/sys-power/nut/nut-9999.ebuild
@@ -187,11 +187,11 @@ src_install() {
 		mv "${i}" "${i/.sample/}" || die
 	done
 
-	local DOCS=( AUTHORS MAINTAINERS NEWS README TODO UPGRADING )
+	local DOCS=( AUTHORS MAINTAINERS NEWS.adoc README.adoc TODO.adoc UPGRADING.adoc )
 	einstalldocs
 
 	if use doc; then
-		newdoc lib/README README.lib
+		newdoc lib/README.adoc
 		dodoc docs/*.txt
 		docinto cables
 		dodoc docs/cables/*


### PR DESCRIPTION
https://github.com/networkupstools/nut/commit/83f3d8b18143baea8da0584ab11f3a4f59f56738