### PR TITLE
app-vim/tasklist: add missing S, fix bug #914213

### DIFF
--- a/app-vim/tasklist/tasklist-1.0.1-r1.ebuild
+++ b/app-vim/tasklist/tasklist-1.0.1-r1.ebuild
@@ -8,6 +8,7 @@ inherit vim-plugin vcs-snapshot
 DESCRIPTION="Highlight FIXME/TODO/CUSTOM keywords in a separate list"
 HOMEPAGE="https://www.vim.org/scripts/script.php?script_id=2607"
 SRC_URI="https://github.com/vim-scripts/${PN}.vim/archive/${PV}.tar.gz -> ${PF}.tar.gz"
+S="${WORKDIR}/${PF}"
 
 LICENSE="MIT"
 KEYWORDS="~amd64 ~x86"


### PR DESCRIPTION
@ConiKost 
Sorry, my bad, seems like i missed that.

Signed-off-by: Michael Mair-Keimberger <mmk@levelnine.at>

Closes: https://bugs.gentoo.org/914213