### PR TITLE
net-dns/dnssec-validator: Fix call to undeclared function ns_name_pton

### DIFF
--- a/net-dns/dnssec-validator/dnssec-validator-2.2.3-r4.ebuild
+++ b/net-dns/dnssec-validator/dnssec-validator-2.2.3-r4.ebuild
@@ -1,0 +1,61 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools
+
+DESCRIPTION="Tools to ease the validation of DNSSEC related technologies"
+HOMEPAGE="https://www.dnssec-tools.org/"
+SRC_URI="https://github.com/DNSSEC-Tools/DNSSEC-Tools/archive/dnssec-tools-${PV}.tar.gz"
+S="${WORKDIR}/DNSSEC-Tools-dnssec-tools-${PV}/dnssec-tools/validator"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~x86"
+IUSE="dlv +nsec3 static-libs +threads"
+
+RDEPEND=">=dev-libs/openssl-1.1.0:0="
+DEPEND="${RDEPEND}"
+
+# Tests fail due "Cannot create context: -7"
+RESTRICT="test"
+
+PATCHES=(
+	# Users LDFLAGS are not respected
+	# See https://github.com/DNSSEC-Tools/DNSSEC-Tools/pull/9
+	"${FILESDIR}/${P}-ldflags.patch"
+	"${FILESDIR}/${PN}-2.2.3-musl-fix.patch"
+)
+
+src_prepare() {
+	default
+
+	mv configure.in configure.ac || die
+	eautoreconf
+}
+
+src_configure() {
+	local myeconfargs=(
+		$(use_with dlv)
+		$(use_with nsec3)
+		$(use_enable static-libs static)
+		$(use_with threads)
+		--with-dnsval-conf="${EPREFIX}/etc/dnssec-tools/dnsval.conf"
+		--with-ipv6
+		--with-resolv-conf="${EPREFIX}/etc/dnssec-tools/resolv.conf"
+		--with-root-hints="${EPREFIX}/etc/dnssec-tools/root.hints"
+	)
+
+	econf "${myeconfargs[@]}"
+}
+
+src_install() {
+	# Install fails with MAKEOPTS > -j1
+	# See https://github.com/DNSSEC-Tools/DNSSEC-Tools/issues/8
+	emake -j1 DESTDIR="${D}" install
+
+	einstalldocs
+
+	find "${D}" -name '*.la' -delete || die
+}

--- a/net-dns/dnssec-validator/files/dnssec-validator-2.2.3-musl-fix.patch
+++ b/net-dns/dnssec-validator/files/dnssec-validator-2.2.3-musl-fix.patch
@@ -1,0 +1,29 @@
+https://github.com/DNSSEC-Tools/DNSSEC-Tools/pull/22
+From: Brahmajit Das <brahmajit.xyz@gmail.com>
+Date: Fri, 15 Sep 2023 19:20:12 +0000
+Subject: [PATCH] Fix build on musl libc
+
+Function such as ns_name_pton are glibc specific and are not available
+on other libc's like musl. This patch should make it possible to use
+those internal function. The need for this patch is due to some of the
+structs like __ns_sect are already defined on musl and glibc, thus would
+result in an redefinition error.
+
+First discovered on Gentoo linux.
+
+Bug: https://bugs.gentoo.org/897862
+Signed-off-by: Brahmajit Das <brahmajit.xyz@gmail.com>
+--- a/include/validator/validator-compat.h
++++ b/include/validator/validator-compat.h
+@@ -896,6 +896,11 @@ typedef enum __ns_flag {
+         (cp) += NS_INT32SZ; \
+ } while (0)
+ 
++#endif /* HAVE_ARPA_NAMESER_H */
++
++/* eabi = android */
++/* OpenBSD has arpa/nameser.h, but it doesn't define ns_msg */
++#if !defined(HAVE_ARPA_NAMESER_H) || defined(eabi) || defined(ANDROID) ||defined(__OpenBSD__) || !defined(__GLIBC__)
+ int	ns_name_uncompress(const u_char *, const u_char *,
+ 		const u_char *, char *, size_t);
+ int	ns_name_compress(const char *, u_char *, size_t,


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/897862