### PR TITLE
app-misc/regex-markup: fix tests

### DIFF
--- a/app-misc/regex-markup/files/regex-markup-0.10.0-r2-configure.patch
+++ b/app-misc/regex-markup/files/regex-markup-0.10.0-r2-configure.patch
@@ -1,10 +1,17 @@
- configure.ac | 1 +
- 1 file changed, 1 insertion(+)
+Ensure tests run using serial test harness (bug #914212), and do not
+call ar directly (bug #722328)
 
-diff --git a/configure.ac b/configure.ac
-index 0b98557..3e24e2e 100644
 --- a/configure.ac
 +++ b/configure.ac
+@@ -4,7 +4,7 @@
+ # Initialization
+ AC_PREREQ(2.59)
+ AC_INIT(regex-markup, 0.10.0, oskar@osk.mine.nu)
+-AM_INIT_AUTOMAKE
++AM_INIT_AUTOMAKE([serial-tests])
+ AC_CONFIG_SRCDIR([src/remark.c])
+ AC_CONFIG_HEADER([config.h])
+ 
 @@ -19,6 +19,7 @@ AC_DEFINE_DIR(PKGDATADIR, datadir/$PACKAGE, [Directory where system-wide rule fi
  # Checks for programs.
  AC_PROG_CC


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/914212