### PR TITLE
net-dns/knot-resolver: update init script with non-privileged user.

### DIFF
--- a/net-dns/knot-resolver/files/kresd.initd
+++ b/net-dns/knot-resolver/files/kresd.initd
@@ -2,11 +2,17 @@
 # Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+: ${KRESD_GROUP:=knot-resolver}
+: ${KRESD_USER:=knot-resolver}
+
 command="/usr/sbin/kresd"
 command_args="${KRESD_OPTS}"
+command_user="${KRESD_USER}:${KRESD_GROUP}"
 pidfile="${KRESD_PIDFILE:-/var/run/${RC_SVCNAME}.pid}"
 command_background=true
 start_stop_daemon_args="--start -bm --pidfile ${pidfile} --exec ${command} -- ${command_args}"
+
+capabilities="^cap_net_bind_service,^cap_setpcap"
 
 name="knot-resolver"
 description="scaleable caching DNS resolver"


### PR DESCRIPTION
Use a non-privileged user since the user and group already exists for knot-resolver. See : https://knot-resolver.readthedocs.io/en/stable/config-no-systemd-privileges.html