### PR TITLE
net-misc/netkit-{bootparamd,talk,timed}: EAPI8 bumps

### DIFF
--- a/net-misc/netkit-bootparamd/netkit-bootparamd-0.17-r5.ebuild
+++ b/net-misc/netkit-bootparamd/netkit-bootparamd-0.17-r5.ebuild
@@ -1,0 +1,56 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs flag-o-matic
+
+DESCRIPTION="Netkit - bootparamd: Net-boot support daemon"
+HOMEPAGE="https://wiki.linuxfoundation.org/networking/netkit"
+SRC_URI="mirror://debian/pool/main/n/${PN}/${PN}_${PV}.orig.tar.gz"
+
+LICENSE="BSD GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~hppa ~mips ~ppc ~sparc ~x86"
+IUSE="+libtirpc"
+
+DEPEND="
+	!<=net-misc/netkit-bootpd-0.17-r2
+	libtirpc? ( net-libs/rpcsvc-proto net-libs/libtirpc )
+	!libtirpc? ( sys-libs/glibc[rpc(-)] )
+"
+RDEPEND=${DEPEND}
+
+PATCHES=(
+	"${FILESDIR}"/0.17-jumpstart.patch
+	"${FILESDIR}"/0.17-libtirpc.patch
+)
+
+src_prepare() {
+	# don't reset LDFLAGS (bug #335457), manpages into /usr/share/man
+	sed -i -e '/^LDFLAGS=/d ; /MANDIR=/s:man:share/man:' configure || die
+	sed -i -e 's:install -s:install:' rpc.bootparamd/Makefile || die
+	default
+}
+
+src_configure() {
+	if use libtirpc ; then
+		append-cflags -I/usr/include/tirpc
+		sed -i -e 's:^LIBS=$:LIBS=-ltirpc:' configure || die
+	fi
+
+	# Note this is not an autoconf configure
+	CC="$(tc-getCC)" LDFLAGS="${LDFLAGS}" CFLAGS="${CFLAGS}" ./configure || die
+}
+
+src_install() {
+	dodir usr/bin usr/sbin usr/share/man/man8
+	emake INSTALLROOT="${D}" install
+
+	newconfd "${FILESDIR}"/bootparamd.confd bootparamd
+	newinitd "${FILESDIR}"/bootparamd.initd bootparamd
+
+	doman rpc.bootparamd/bootparams.5
+	dodoc README ChangeLog
+	newdoc rpc.bootparamd/README README.bootparamd
+}

--- a/net-misc/netkit-talk/netkit-talk-0.17-r8.ebuild
+++ b/net-misc/netkit-talk/netkit-talk-0.17-r8.ebuild
@@ -1,0 +1,55 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs
+
+MY_P=netkit-ntalk-${PV}
+
+DESCRIPTION="Netkit - talkd: Daemon to help set up talk sessions"
+HOMEPAGE="https://wiki.linuxfoundation.org/networking/netkit"
+SRC_URI="http://ftp.linux.org.uk/pub/linux/Networking/netkit/${MY_P}.tar.gz"
+S="${WORKDIR}"/netkit-ntalk-${PV}
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86"
+
+DEPEND=">=sys-libs/ncurses-5.2:="
+BDEPEND="virtual/pkgconfig"
+RDEPEND="
+	${DEPEND}
+	virtual/inetd
+"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-time.patch
+	"${FILESDIR}"/${P}-ipv6.patch
+)
+
+src_prepare() {
+	default
+	sed -i configure -e '/^LDFLAGS=/d' || die
+}
+
+src_configure() {
+	# not autotools based?
+	./configure --with-c-compiler="$(tc-getCC)" || die
+}
+
+src_compile() {
+	emake LIBCURSES="$( $(tc-getPKG_CONFIG) --libs ncurses )"
+}
+
+src_install() {
+	insinto /etc/xinetd.d
+	newins "${FILESDIR}"/talk.xinetd talk
+	dobin talk/talk
+	doman talk/talk.1
+	dosbin talkd/talkd
+	dosym talkd /usr/sbin/in.talkd
+	doman talkd/talkd.8
+	dosym talkd.8 /usr/share/man/man8/in.talkd.8
+	dodoc README ChangeLog BUGS
+}

--- a/net-misc/netkit-timed/netkit-timed-0.17-r11.ebuild
+++ b/net-misc/netkit-timed/netkit-timed-0.17-r11.ebuild
@@ -1,0 +1,39 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit flag-o-matic toolchain-funcs
+
+DESCRIPTION="Netkit - timed: Time daemon"
+HOMEPAGE="https://wiki.linuxfoundation.org/networking/netkit"
+SRC_URI="http://ftp.linux.org.uk/pub/linux/Networking/netkit/${P}.tar.gz"
+
+KEYWORDS="~amd64 ~mips ~ppc ~ppc64 ~sparc ~x86"
+LICENSE="BSD GPL-2"
+SLOT="0"
+
+src_prepare() {
+	eapply "${FILESDIR}"/0.17-CFLAG-DEF-fix.patch
+	eapply "${FILESDIR}"/0.17-timed-opt-parsing.patch
+	sed -i -e '/^LDFLAGS=/d' configure || die "sed configure"
+	sed -i -e "s|ar -cruv|\${AR} -cruv|g" timed/lib/Makefile || die
+	default
+}
+
+src_configure() {
+	tc-export AR
+	# Note this is not an autoconf configure script. econf fails
+	append-flags -DCLK_TCK=CLOCKS_PER_SEC
+	./configure --prefix=/usr --with-c-compiler="$(tc-getCC)" || die "bad configure"
+}
+
+src_install() {
+	dosbin timed/timed/timed
+	doman  timed/timed/timed.8
+	dosbin timed/timedc/timedc
+	doman  timed/timedc/timedc.8
+	einstalldocs
+
+	newinitd "${FILESDIR}"/timed.rc6 timed
+}


### PR DESCRIPTION
Hi,

Another few `EAPI8` bumps.
I decided to enable `ipv6` unconditional for `net-misc/netkit-talk` and fixed the `AR` direct call in `net-misc/netkit-timed`