### PR TITLE
app-text/talkfilters: Fix call to undeclared library function strcmp

### DIFF
--- a/app-text/talkfilters/files/talkfilters-2.3.8-clang16-build-fix.patch
+++ b/app-text/talkfilters/files/talkfilters-2.3.8-clang16-build-fix.patch
@@ -1,0 +1,11 @@
+Bug: https://bugs.gentoo.org/894712
+--- a/getopt.c
++++ b/getopt.c
+@@ -26,6 +26,7 @@
+ #define _NO_PROTO
+ #endif
+ 
++#include <string.h>
+ #ifdef HAVE_CONFIG_H
+ #include <config.h>
+ #endif

--- a/app-text/talkfilters/talkfilters-2.3.8-r2.ebuild
+++ b/app-text/talkfilters/talkfilters-2.3.8-r2.ebuild
@@ -1,0 +1,26 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DESCRIPTION="Convert ordinary English text into text that mimics a stereotyped dialect"
+HOMEPAGE="http://www.hyperrealm.com/talkfilters/talkfilters.html"
+SRC_URI="http://www.hyperrealm.com/${PN}/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~hppa ~mips ~ppc ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-format-security.patch
+	"${FILESDIR}"/${P}-clang16-build-fix.patch
+)
+
+src_configure() {
+	econf --disable-static
+}
+
+src_install() {
+	default
+	find "${ED}" -name '*.la' -delete || die
+}


### PR DESCRIPTION
and update EAPI 7 -> 8

Closes: https://bugs.gentoo.org/894712