### PR TITLE
app-text/unrtf: Fix call to undeclared function strcasestr

### DIFF
--- a/app-text/unrtf/files/unrtf-0.21.10-use-strstr.patch
+++ b/app-text/unrtf/files/unrtf-0.21.10-use-strstr.patch
@@ -1,0 +1,12 @@
+Use strstr (standard) instead of strcasestr (non standard)
+Bug: https://bugs.gentoo.org/894716
+--- a/src/convert.c
++++ b/src/convert.c
+@@ -104,6 +104,7 @@
+ #ifdef HAVE_STRING_H
+ /* For strcasestr() */
+ #define __USE_GNU
++#define _GNU_SOURCE
+ #include <string.h>
+ #endif
+ 

--- a/app-text/unrtf/unrtf-0.21.10-r1.ebuild
+++ b/app-text/unrtf/unrtf-0.21.10-r1.ebuild
@@ -1,0 +1,17 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DESCRIPTION="Converts RTF files to various formats"
+HOMEPAGE="https://www.gnu.org/software/unrtf/unrtf.html"
+SRC_URI="mirror://gnu/${PN}/${P}.tar.gz"
+
+LICENSE="GPL-3"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-solaris"
+IUSE=""
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-0.21.10-use-strstr.patch
+)


### PR DESCRIPTION
and update EAPI 7 -> 8

Closes: https://bugs.gentoo.org/894716