### PR TITLE
net-dns/knot-resolver: update confd/initd with non-privileged user.

### DIFF
--- a/net-dns/knot-resolver/files/kresd.confd
+++ b/net-dns/knot-resolver/files/kresd.confd
@@ -8,7 +8,7 @@
 #KRESD_GROUP=knot-resolver
 
 # Configuration file
-#KRESD_CONFIGFILE="/etc/knot-resolver/kresd.conf"
+#KRESD_CONFIG="/etc/knot-resolver/kresd.conf"
 
 # Rundir
 #KRESD_RUNDIR="/var/run/kresd"

--- a/net-dns/knot-resolver/files/kresd.confd
+++ b/net-dns/knot-resolver/files/kresd.confd
@@ -1,5 +1,19 @@
 # Copyright 1999-2023 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-KRESD_OPTS="-n /var/run/kresd"
 
+# The user to run your application as
+#KRESD_USER=knot-resolver
+
+# The group to run your application as
+#KRESD_GROUP=knot-resolver
+
+# Configuration file
+#KRESD_CONFIGFILE="/etc/knot-resolver/kresd.conf"
+
+# Rundir
+#KRESD_RUNDIR="/var/run/kresd"
+
+# PID file
 #KRESD_PIDFILE="/var/run/kresd.pid"
+
+KRESD_OPTS=""

--- a/net-dns/knot-resolver/files/kresd.initd
+++ b/net-dns/knot-resolver/files/kresd.initd
@@ -2,11 +2,20 @@
 # Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+: ${KRESD_GROUP:=knot-resolver}
+: ${KRESD_USER:=knot-resolver}
+: ${KRESD_CONFIG:=/etc/knot-resolver/kresd.conf}
+: ${KRESD_RUNDIR:=/var/run/kresd}
+: ${KRESD_PIDFILE:=/var/run/kresd.pid}
+
 command="/usr/sbin/kresd"
-command_args="${KRESD_OPTS}"
-pidfile="${KRESD_PIDFILE:-/var/run/${RC_SVCNAME}.pid}"
+command_args="${KRESD_OPTS} -n -c ${KRESD_CONFIG} ${KRESD_RUNDIR}"
+command_user="${KRESD_USER}:${KRESD_GROUP}"
+pidfile="${KRESD_PIDFILE}"
 command_background=true
-start_stop_daemon_args="--start -bm --pidfile ${pidfile} --exec ${command} -- ${command_args}"
+retry="TERM/60/KILL/5"
+
+capabilities="^cap_net_bind_service,^cap_setpcap"
 
 name="knot-resolver"
 description="scaleable caching DNS resolver"
@@ -17,7 +26,6 @@ depend() {
     provide dns
 }
 
-start() {
-	checkpath --directory /var/run/kresd
-	default_start
+start_pre() {
+        checkpath -d -m 0750 -o "${KRESD_USER}:${KRESD_GROUP}" ${KRESD_RUNDIR}
 }


### PR DESCRIPTION
Use a non-privileged user since the user and group already exists for knot-resolver. See : [https://knot-resolver.readthedocs.io/en/stable/config-no-systemd-privileges.html](https://knot-resolver.readthedocs.io/en/stable/config-no-systemd-privileges.html).
Add "retry" to kill kresd successfully with a big cache.