### PR TITLE
dev-util/shtool: EAPI8 bump, fixes #880289, #724276

### DIFF
--- a/dev-util/shtool/shtool-2.0.8-r2.ebuild
+++ b/dev-util/shtool/shtool-2.0.8-r2.ebuild
@@ -1,0 +1,22 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs
+
+DESCRIPTION="Set of stable and portable shell scripts"
+HOMEPAGE="https://www.gnu.org/software/shtool/shtool.html"
+SRC_URI="mirror://gnu/${PN}/${P}.tar.gz"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~hppa ~ia64 ~ppc ~s390 ~sparc ~x86"
+
+DEPEND="dev-lang/perl"
+DOCS="AUTHORS ChangeLog README THANKS VERSION NEWS RATIONAL"
+
+src_prepare() {
+  default
+  sed -i "s|opt_C=\"ar\"|opt_C=\"$(tc-getAR)\"|g" sh.arx || die
+}


### PR DESCRIPTION
Another simple `EAPI8` bump, fixing #880289 and #724276.
Regarding #724276: `ar` was only called in the tests in the `sh.arx` tool. I've simply replaced `ar` with `tc-getAR`. Hope that's fine.

Signed-off-by: Michael Mair-Keimberger <mmk@levelnine.at>

Closes: https://bugs.gentoo.org/880289
Closes: https://bugs.gentoo.org/724276