### PR TITLE
dev-libs/iksemel: EAPI8 bump

### DIFF
--- a/dev-libs/iksemel/iksemel-1.4-r2.ebuild
+++ b/dev-libs/iksemel/iksemel-1.4-r2.ebuild
@@ -1,0 +1,44 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools
+
+DESCRIPTION="eXtensible Markup Language parser library designed for Jabber applications"
+HOMEPAGE="https://github.com/meduketto/iksemel"
+SRC_URI="https://${PN}.googlecode.com/files/${P}.tar.gz"
+
+LICENSE="LGPL-2.1"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~x86"
+IUSE="ssl static-libs"
+
+RDEPEND="ssl? ( net-libs/gnutls:= )"
+DEPEND="${RDEPEND}"
+BDEPEND="ssl? ( virtual/pkgconfig )"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-1.3-gnutls-2.8.patch
+	"${FILESDIR}"/${PN}-1.4-gnutls-3.4.patch
+	"${FILESDIR}"/${PN}-1.4-ikstack.patch
+)
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_configure() {
+	econf \
+		$(use_with ssl gnutls) \
+		$(use_enable static-libs static)
+}
+
+src_install() {
+	default
+	dodoc HACKING
+
+	# package installs .pc files
+	find "${D}" -name '*.la' -delete || die
+}


### PR DESCRIPTION
Simple `EAPI8` bump

```diff
1c1
< # Copyright 1999-2020 Gentoo Authors
---
> # Copyright 1999-2023 Gentoo Authors
4c4
< EAPI=6
---
> EAPI=8
14c14
< KEYWORDS="amd64 ~arm ~arm64 ppc ~ppc64 x86"
---
> KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~x86"
18,19c18,19
< DEPEND="${RDEPEND}
< 	ssl? ( virtual/pkgconfig )"
---
> DEPEND="${RDEPEND}"
> BDEPEND="ssl? ( virtual/pkgconfig )"
```