### PR TITLE
net-misc/curl: make openssl and nghttp3 mutually exclusive (again)

### DIFF
--- a/net-misc/curl/curl-8.3.0.ebuild
+++ b/net-misc/curl/curl-8.3.0.ebuild
@@ -30,6 +30,7 @@ RESTRICT="!test? ( test )"
 
 # Only one default ssl provider can be enabled
 # The default ssl provider needs its USE satisfied
+# nghttp3 = https://bugs.gentoo.org/912029
 REQUIRED_USE="
 	ssl? (
 		^^ (
@@ -43,6 +44,7 @@ REQUIRED_USE="
 	curl_ssl_mbedtls? ( mbedtls )
 	curl_ssl_openssl? ( openssl )
 	curl_ssl_rustls? ( rustls )
+	nghttp3? ( !openssl )
 "
 
 # cURL's docs and CI/CD are great resources for confirming supported versions

--- a/net-misc/curl/curl-9999.ebuild
+++ b/net-misc/curl/curl-9999.ebuild
@@ -30,6 +30,7 @@ RESTRICT="!test? ( test )"
 
 # Only one default ssl provider can be enabled
 # The default ssl provider needs its USE satisfied
+# nghttp3 = https://bugs.gentoo.org/912029
 REQUIRED_USE="
 	ssl? (
 		^^ (
@@ -43,6 +44,7 @@ REQUIRED_USE="
 	curl_ssl_mbedtls? ( mbedtls )
 	curl_ssl_openssl? ( openssl )
 	curl_ssl_rustls? ( rustls )
+	nghttp3? ( !openssl )
 "
 
 # cURL's docs and CI/CD are great resources for confirming supported versions


### PR DESCRIPTION
This was applied for 8.2.1 but the live ebuild template was missed so we get to play the game again for 8.3.0!

Bug: https://bugs.gentoo.org/912029
Closes: https://bugs.gentoo.org/914277