### PR TITLE
app-misc/utimer: revbump, fix build for clang 16

### DIFF
--- a/app-misc/utimer/files/utimer-0.4-fix-build-for-clang16.patch
+++ b/app-misc/utimer/files/utimer-0.4-fix-build-for-clang16.patch
@@ -1,0 +1,44 @@
+Add declarations because implicit function declarations are not allowed in clang16's defaults.
+
+Bug: https://bugs.gentoo.org/876376
+Patch sent upstream via mail. 
+
+#  Pascal Jäger <pascal.jaeger@leimstift.de> (2023-09-18)
+
+--- a/src/log.h
++++ b/src/log.h
+@@ -27,6 +27,7 @@
+ #define g_info(format...) g_log(G_LOG_DOMAIN, G_LOG_LEVEL_INFO, format)
+ #endif 
+ 
++void setup_log_handler(void);
+ 
+ 
+ #endif /* LOG_H */
+--- a/src/tests/maintests.c
++++ b/src/tests/maintests.c
+@@ -30,7 +30,8 @@
+ #endif 
+ 
+ #include <glib-object.h>
++#include "../log.h"
+ #include "../utimer.h"
+ 
+ #define TEST_DURATION_MAX_OFFSET_MSECONDS 100
+ 
+
+ /**
+  * Runs the timer for the given duration
+  * There is a timeout that prevents the function from running endlessly
+--- a/src/utimer.c
++++ b/src/utimer.c
+@@ -21,7 +21,9 @@
+  * 
+  */
+ 
++#include "glib-2.0/glib-object.h"
+ #include "utimer.h"
++#include "log.h"
+ 
+ //~ static    char            **remaining_args;
+ static ut_timer        *ttimer;

--- a/app-misc/utimer/utimer-0.4-r2.ebuild
+++ b/app-misc/utimer/utimer-0.4-r2.ebuild
@@ -1,0 +1,33 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DESCRIPTION="A command line timer and stopwatch"
+HOMEPAGE="https://sourceforge.net/projects/utimer/"
+SRC_URI="http://utimer.codealpha.net/dl.php?file=${P}.tar.gz -> ${P}.tar.gz"
+SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="debug nls"
+RESTRICT="test" #630952
+
+RDEPEND="
+	dev-libs/glib:2
+	dev-util/intltool"
+DEPEND="${RDEPEND}"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-fno-common.patch
+	"${FILESDIR}"/${P}-locale.patch
+	"${FILESDIR}"/${P}-fix-build-for-clang16.patch
+)
+DOCS=( AUTHORS ChangeLog NEWS README )
+
+src_configure() {
+	econf \
+		$(use_enable debug) \
+		$(use_enable nls)
+}


### PR DESCRIPTION
EAPI bump, changed upstream URL

Closes: https://bugs.gentoo.org/630952
Closes: https://bugs.gentoo.org/876376

Signed-off-by: Pascal Jäger <pascal.jaeger@leimstift.de>