### PR TITLE
# x11-plugins/astime: revbump, fix build for clang16

### DIFF
--- a/x11-plugins/astime/astime-2.8-r3.ebuild
+++ b/x11-plugins/astime/astime-2.8-r3.ebuild
@@ -1,0 +1,48 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools toolchain-funcs
+
+DESCRIPTION="Analogue clock utility for X Windows"
+HOMEPAGE="https://tigr.net/afterstep/applets/ http://www.afterstep.org/"
+SRC_URI="http://www.tigr.net/afterstep/download/${PN}/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="amd64 ppc ppc64 x86"
+IUSE="jpeg"
+
+RDEPEND="x11-libs/libXpm
+	x11-libs/libSM
+	jpeg? ( media-libs/libjpeg-turbo:0 )"
+
+DEPEND="${RDEPEND}
+	x11-base/xorg-proto"
+
+PATCHES=(
+	"${FILESDIR}/${P}-remove-double-config.h-autotools.patch"
+	"${FILESDIR}/${P}-fix-implicit-function-decl.patch"
+)
+
+src_prepare() {
+	default
+	cd "${S}/autoconf" || die
+	eautoreconf
+	cp "${S}/autoconf/configure" "${S}/" || die
+}
+
+src_configure() {
+	econf $(use_enable jpeg) --with-xpm-library=/usr/$(get_libdir)
+}
+
+src_compile() {
+	emake CC="$(tc-getCC)"
+}
+
+src_install() {
+	dobin "${PN}"
+	newman "${PN}.man" "${PN}.1"
+	einstalldocs
+}

--- a/x11-plugins/astime/files/astime-2.8-fix-implicit-function-decl.patch
+++ b/x11-plugins/astime/files/astime-2.8-fix-implicit-function-decl.patch
@@ -1,0 +1,17 @@
+File uses implicit declaration of a library function. This is not allow with clang16s default settings.
+
+Bug: https://bugs.gentoo.org/882175
+Patch has been sent to upstream via mail
+
+#  Pascal Jäger <pascal.jaeger@leimstift.de> (2023-09-18)
+
+--- a/astime_x.c
++++ b/astime_x.c
+@@ -11,6 +11,7 @@
+ 
+ #include <stdio.h>
+ #include <stdlib.h>
++#include <string.h>
+ #include <math.h>
+ #include <time.h>
+ 

--- a/x11-plugins/astime/files/astime-2.8-remove-double-config.h-autotools.patch
+++ b/x11-plugins/astime/files/astime-2.8-remove-double-config.h-autotools.patch
@@ -1,0 +1,27 @@
+In order to do a full eautoreconf we need to remove the double declarations of config.h in configure.in
+
+Bug: https://bugs.gentoo.org/874714
+Bug: https://bugs.gentoo.org/898458
+Patch has been sent to upstream via mail
+
+#  Pascal Jäger <pascal.jaeger@leimstift.de> (2023-09-18)
+
+--- a/autoconf/configure.in
++++ b/autoconf/configure.in
+@@ -60,7 +60,6 @@ AC_PATH_XTRA
+ AC_CHECK_HEADERS(sys/wait.h sys/time.h)
+ AC_CHECK_HEADERS(sys/statvfs.h sys/vfs.h sys/mount.h ustat.h)
+ AC_CHECK_HEADERS(machine/soundcard.h linux/soundcard.h linux/radio.h)
+-AC_CONFIG_HEADER(config.h)
+ 
+ dnl# Check for X
+ 
+@@ -120,8 +119,6 @@ AC_SUBST(with_afterdir)
+ 
+ dnl# Write results
+ 
+-AC_CONFIG_HEADER(config.h)
+-
+ dnl# Common parts of the Makefile
+ MAKEFILEDEFINES=./autoconf/Makefile.defines
+ MAKEFILECOMMON=./autoconf/Makefile.common


### PR DESCRIPTION
EAPI bump
Fix homepage

Closes: https://bugs.gentoo.org/874714
Closes: https://bugs.gentoo.org/882175
Closes: https://bugs.gentoo.org/898458
Signed-off-by: Pascal Jäger <pascal.jaeger@leimstift.de>

Maybe its better to last-rite this. Most of the other plugins in https://tigr.net/afterstep/applets/ are not in ::gentoo anymore and what this plugin is actually part of also isn't (http://www.afterstep.org/)

