### PR TITLE
toolchain-funcs.eclass: Remove outdated reference to tc-has-openmp

### DIFF
--- a/eclass/toolchain-funcs.eclass
+++ b/eclass/toolchain-funcs.eclass
@@ -576,9 +576,7 @@ _tc-has-openmp() {
 # @DESCRIPTION:
 # Test for OpenMP support with the current compiler and error out with
 # a clear error message, telling the user how to rectify the missing
-# OpenMP support that has been requested by the ebuild. Using this function
-# to test for OpenMP support should be preferred over tc-has-openmp and
-# printing a custom message, as it presents a uniform interface to the user.
+# OpenMP support that has been requested by the ebuild.
 #
 # You should test for any necessary OpenMP support in pkg_pretend in order to
 # warn the user of required toolchain changes.  You must still check for OpenMP


### PR DESCRIPTION
tc-has-openmp function was deprecated in commit 9bc832c6d39b ("toolchain-funcs.eclass: deprecate tc-has-openmp") and later removed in commit eb970274d283 ("toolchain-funcs.eclass: remove tc-has-openmp"). Due to this, the reference to it in the tc-check-openmp function has become redundant and is therefore removed.