### PR TITLE
x11-plugins/wm*: EAPI8 bumps

### DIFF
--- a/x11-plugins/wmSpaceWeather/wmSpaceWeather-1.04_p19-r2.ebuild
+++ b/x11-plugins/wmSpaceWeather/wmSpaceWeather-1.04_p19-r2.ebuild
@@ -1,0 +1,61 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs
+
+MY_PN="wmspaceweather"
+MY_PV_ORIG="${PV/_p*}"
+MY_PV_PATCH="${PV/_p/-}"
+MY_P_ORIG="${MY_PN}_${MY_PV_ORIG}.orig"
+MY_P_PATCH="${MY_PN}_${MY_PV_PATCH}.diff"
+
+DESCRIPTION="Dockapp showing weather at geosynchronous orbit"
+HOMEPAGE="https://www.dockapps.net/wmspaceweather"
+SRC_URI="mirror://debian/pool/main/w/${MY_PN}/${MY_P_ORIG}.tar.gz
+	    mirror://debian/pool/main/w/${MY_PN}/${MY_P_PATCH}.gz"
+S="${WORKDIR}/${MY_P_ORIG/_/-}/${PN}"
+
+SLOT="0"
+LICENSE="GPL-2+"
+KEYWORDS="~amd64 ~hppa ~mips ~ppc ~sparc ~x86"
+
+DOCS=( ../{BUGS,CHANGES,HINTS,README} )
+
+CDEPEND="x11-libs/libX11
+	x11-libs/libXext
+	x11-libs/libXpm"
+DEPEND="${CDEPEND}
+	x11-base/xorg-proto"
+RDEPEND="${CDEPEND}
+	net-misc/curl
+	dev-lang/perl"
+
+src_prepare() {
+	default
+
+	cd .. || die
+
+	eapply "${WORKDIR}"/${MY_P_PATCH}
+	eapply "${FILESDIR}"/${P}-gcc-10.patch
+
+	# need to apply patches from Debian first, do NOT change the order
+	cd "${S}" || die
+	eapply -p2 ../debian/patches/*.dpatch
+	eapply "${FILESDIR}"/${P}-gentoo.patch
+	eapply "${FILESDIR}"/${P}-getkp.patch
+}
+
+src_compile() {
+	emake clean
+	emake CC="$(tc-getCC)" LIBDIR="/usr/$(get_libdir)"
+}
+
+pkg_postinst() {
+	elog "You need to emerge www-client/firefox or www-client/firefox-bin"
+	elog "to use the -url functionality - see man ${PN} for more info."
+	elog
+	elog "This version uses curl instead of wget. You may edit /usr/share/wmspaceweather/GetKp"
+	elog "if you don't like it."
+}

--- a/x11-plugins/wmacpimon/wmacpimon-0.2.1-r1.ebuild
+++ b/x11-plugins/wmacpimon/wmacpimon-0.2.1-r1.ebuild
@@ -1,0 +1,47 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs
+
+DESCRIPTION="DockApp monitors the temperature and Speedstep features in ACPI-based systems"
+HOMEPAGE="https://wiki.gentoo.org/wiki/No_homepage"
+SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~x86"
+
+RDEPEND="x11-libs/libX11
+	x11-libs/libXext
+	x11-libs/libXpm"
+DEPEND="${RDEPEND}
+	x11-base/xorg-proto"
+
+PATCHES=(
+	# patch wmacpimon.c file to set default path for
+	# wmacpimon.prc to /var/tmp/
+	"${FILESDIR}/wmacpimon.c.patch"
+
+	# fix LDFLAGS ordering. See bug #248618.
+	# fix LDFLAGS ordering again and other stuff. See bug #336091.
+	"${FILESDIR}/Makefile.patch"
+)
+
+src_compile() {
+	tc-export CC
+	default
+}
+
+src_install() {
+	dobin wmacpimond wmacpimon
+	dodoc AUTHORS ChangeLog README
+	newinitd "${FILESDIR}"/wmacpimon.initscript wmacpimon
+}
+
+pkg_postinst() {
+	elog "Remember to start the wmacpimond daemon"
+	elog "(by issuing the \"/etc/init.d/wmacpimon start\" command)"
+	elog "before you attempt to run wmacpimon..."
+}

--- a/x11-plugins/wmbio/wmbio-1.02-r1.ebuild
+++ b/x11-plugins/wmbio/wmbio-1.02-r1.ebuild
@@ -1,0 +1,40 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs
+
+DESCRIPTION="Window Maker applet that shows your biorhythm"
+HOMEPAGE="https://wmbio.sourceforge.net/"
+SRC_URI="mirror://sourceforge/wmbio/${P}.tar.gz"
+S="${WORKDIR}/${P}/src"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~ppc64 ~sparc ~x86"
+
+RDEPEND="x11-libs/libX11
+	x11-libs/libXext
+	x11-libs/libXpm"
+DEPEND="${RDEPEND}
+	x11-base/xorg-proto"
+
+PATCHES=( "${FILESDIR}"/${P}-fno-common.patch )
+
+src_prepare() {
+	default
+	# Honour Gentoo CFLAGS, LDFLAGS, CC
+	sed -i -e "s/-g -O2/\$(CFLAGS)/" \
+		-e "s/-o wmbio/\$(LDFLAGS) -o wmbio/" \
+		-e "s/cc /\$(CC) /" Makefile || die
+}
+
+src_compile() {
+	emake CC="$(tc-getCC)"
+}
+
+src_install() {
+	dobin wmbio
+	dodoc ../{AUTHORS,Changelog,NEWS,README}
+}

--- a/x11-plugins/wmblob/wmblob-1.0.4-r1.ebuild
+++ b/x11-plugins/wmblob/wmblob-1.0.4-r1.ebuild
@@ -1,0 +1,35 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools
+
+DESCRIPTION="Fancy but useless dockapp with moving blobs"
+HOMEPAGE="https://github.com/bbidulock/wmblob"
+SRC_URI="https://github.com/bbidulock/wmblob/releases/download/${PV}/${P}.tar.bz2"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~sparc ~x86"
+
+RDEPEND="x11-libs/gtk+:2
+	x11-libs/libX11
+	x11-libs/libXpm
+	x11-libs/libXext"
+DEPEND="${RDEPEND}
+	x11-libs/libXt"
+BDEPEND="virtual/pkgconfig"
+
+DOCS="AUTHORS ChangeLog NEWS README doc/how_it_works"
+
+src_prepare() {
+	default
+
+	sed -i \
+		-e "s|-O2|${CFLAGS}|g" \
+		-e "s|\$x_libraries|/usr/$(get_libdir)|" \
+		configure.ac || die
+
+	eautoreconf
+}

--- a/x11-plugins/wmbutton/wmbutton-0.7.1-r1.ebuild
+++ b/x11-plugins/wmbutton/wmbutton-0.7.1-r1.ebuild
@@ -1,0 +1,19 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DESCRIPTION="Dockapp application that displays nine configurable buttons"
+HOMEPAGE="https://www.dockapps.net/wmbutton"
+SRC_URI="https://www.dockapps.net/download/${P}.tar.gz"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~sparc ~x86"
+IUSE="branding"
+
+RDEPEND="x11-libs/libX11
+	x11-libs/libXpm
+	x11-libs/libXext"
+DEPEND="${RDEPEND}
+	x11-base/xorg-proto"

--- a/x11-plugins/wmcliphist/wmcliphist-2.1-r3.ebuild
+++ b/x11-plugins/wmcliphist/wmcliphist-2.1-r3.ebuild
@@ -1,0 +1,33 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs
+
+DESCRIPTION="Dockable clipboard history application for Window Maker"
+HOMEPAGE="https://www.dockapps.net/wmcliphist"
+SRC_URI="https://dev.gentoo.org/~voyageur/distfiles/${P}.tar.gz"
+S="${WORKDIR}/dockapps"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~sparc ~x86"
+
+RDEPEND="x11-libs/gtk+:3[X]"
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+src_prepare() {
+	default
+
+	sed -e '/^PREFIX/s:=.*:=/usr:' \
+		-i Makefile || die
+	tc-export CC
+}
+
+src_install() {
+	default
+
+	newdoc ${PN}rc ${PN}rc.sample
+}

--- a/x11-plugins/wmcoincoin/wmcoincoin-2.6.3-r1.ebuild
+++ b/x11-plugins/wmcoincoin/wmcoincoin-2.6.3-r1.ebuild
@@ -1,0 +1,33 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DESCRIPTION="Dockapp for browsing dacode news and board sites"
+HOMEPAGE="http://hules.free.fr/wmcoincoin/"
+SRC_URI="http://hules.free.fr/${PN}/download/${P}.tar.gz"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86"
+IUSE="nls xinerama"
+
+RDEPEND="media-libs/imlib2[X]
+	x11-libs/gtk+:2
+	x11-libs/libX11
+	x11-libs/libXext
+	x11-libs/libXft
+	x11-libs/libXmu
+	x11-libs/libXpm
+	xinerama? ( x11-libs/libXinerama )"
+DEPEND="${RDEPEND}
+	x11-base/xorg-proto
+	x11-libs/libXt"
+BDEPEND="virtual/pkgconfig
+	nls? ( sys-devel/gettext )"
+
+src_configure() {
+	econf \
+		$(use_enable nls) \
+		$(use_enable xinerama)
+}

--- a/x11-plugins/wmcpuload/wmcpuload-1.1.1-r1.ebuild
+++ b/x11-plugins/wmcpuload/wmcpuload-1.1.1-r1.ebuild
@@ -1,0 +1,18 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DESCRIPTION="Dockapp for monitoring CPU usage with a LCD display"
+HOMEPAGE="https://www.dockapps.net/wmcpuload"
+SRC_URI="https://www.dockapps.net/download/${P}.tar.gz"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~mips ~ppc ~ppc64 ~sparc ~x86"
+
+RDEPEND="x11-libs/libX11
+	x11-libs/libXext
+	x11-libs/libXpm"
+DEPEND="${RDEPEND}
+	x11-libs/libICE"

--- a/x11-plugins/wmdrawer/wmdrawer-0.10.5-r4.ebuild
+++ b/x11-plugins/wmdrawer/wmdrawer-0.10.5-r4.ebuild
@@ -1,0 +1,48 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs
+
+DESCRIPTION="Dockapp which provides a drawer (retractable button bar) to launch applications"
+HOMEPAGE="http://people.easter-eggs.org/~valos/wmdrawer/"
+SRC_URI="http://people.easter-eggs.org/~valos/wmdrawer/${P}.tar.gz"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~sparc ~x86"
+
+RDEPEND="x11-libs/gdk-pixbuf-xlib
+	>=x11-libs/gdk-pixbuf-2.42.0:2
+	x11-libs/gtk+:2"
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+DOCS=( README TODO AUTHORS ChangeLog wmdrawerrc.example )
+PATCHES=( "${FILESDIR}"/${P}-gtk+-2.patch )
+
+src_prepare() {
+	default
+
+	gunzip doc/wmdrawer.1x.gz || die
+
+	# Honour Gentoo CFLAGS
+	sed -i -e "s|-O3|${CFLAGS}|" Makefile || die
+	# Fix LDFLAGS ordering per bug #248640
+	sed -i -e 's/$(CC) $(LDFLAGS) -o $@ $(OBJS)/$(CC) -o $@ $(OBJS) $(LDFLAGS)/' Makefile || die
+	# Do not auto-strip binaries
+	sed -i -e 's/	strip $@//' Makefile || die
+	# Honour Gentoo LDFLAGS
+	sed -i -e 's/$(CC) -o/$(CC) $(GENTOO_LDFLAGS) -o/' Makefile || die
+}
+
+src_compile() {
+	emake CC="$(tc-getCC)" GENTOO_LDFLAGS="${LDFLAGS}"
+}
+
+src_install() {
+	dobin wmdrawer
+	doman doc/wmdrawer.1x
+	einstalldocs
+}

--- a/x11-plugins/wmget/wmget-0.6.1-r1.ebuild
+++ b/x11-plugins/wmget/wmget-0.6.1-r1.ebuild
@@ -1,0 +1,28 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools
+
+DESCRIPTION="Libcurl based dockapp for automated downloads"
+HOMEPAGE="https://www.dockapps.net/wmget"
+SRC_URI="https://www.dockapps.net/download/${P}.tar.gz"
+# Specific to this tarball
+S="${WORKDIR}/dockapps-5aaf842"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~sparc ~x86"
+
+RDEPEND="x11-libs/libX11
+	x11-libs/libXext
+	x11-libs/libXpm
+	>=net-misc/curl-7.9.7"
+DEPEND="${RDEPEND}
+	x11-base/xorg-proto"
+
+src_prepare() {
+	default
+	eautoreconf
+}

--- a/x11-plugins/wmgtemp/wmgtemp-1.2.ebuild
+++ b/x11-plugins/wmgtemp/wmgtemp-1.2.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
 
 DESCRIPTION="CPU and SYS temperature dockapp"
 HOMEPAGE="https://www.dockapps.net/wmgtemp"
@@ -10,7 +10,6 @@ SRC_URI="https://www.dockapps.net/download/${P}.tar.gz"
 LICENSE="Artistic"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE=""
 
 DEPEND="sys-apps/lm-sensors:=
 	>=x11-libs/libdockapp-0.7:=

--- a/x11-plugins/wmifs/wmifs-1.8-r1.ebuild
+++ b/x11-plugins/wmifs/wmifs-1.8-r1.ebuild
@@ -1,0 +1,19 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DESCRIPTION="Network monitoring dockapp"
+HOMEPAGE="https://www.dockapps.net/wmifs"
+SRC_URI="https://dev.gentoo.org/~voyageur/distfiles/${P}.tar.gz"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~mips ~ppc ~sparc ~x86"
+
+RDEPEND=">=x11-libs/libdockapp-0.7:=
+	x11-libs/libX11
+	x11-libs/libXpm"
+DEPEND="${RDEPEND}"
+
+DOCS=( BUGS CHANGES HINTS README TODO )

--- a/x11-plugins/wmlongrun/wmlongrun-0.3.1.ebuild
+++ b/x11-plugins/wmlongrun/wmlongrun-0.3.1.ebuild
@@ -1,16 +1,15 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
 
-DESCRIPTION="A dockapp to monitor LongRun on a Transmeta Crusoe processor"
+DESCRIPTION="Dockapp to monitor LongRun on a Transmeta Crusoe processor"
 HOMEPAGE="https://www.dockapps.net/wmlongrun"
 SRC_URI="https://www.dockapps.net/download/${P}.tar.gz"
 
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="0"
 KEYWORDS="-* ~x86"
-IUSE=""
 
 RDEPEND="x11-libs/libX11
 	x11-libs/libXext

--- a/x11-plugins/wmmand/wmmand-1.3.2-r1.ebuild
+++ b/x11-plugins/wmmand/wmmand-1.3.2-r1.ebuild
@@ -1,27 +1,26 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
+
 inherit desktop toolchain-funcs
 
-MY_P=wmMand-${PV}
+MY_P="wmMand-${PV}"
 
 DESCRIPTION="a dockable mandelbrot browser"
 HOMEPAGE="https://sourceforge.net/projects/wmmand/"
 SRC_URI="mirror://sourceforge/${PN}/${MY_P}.tar.bz2"
+S="${WORKDIR}/${MY_P}/wmMand"
 
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE=""
 
 RDEPEND="x11-libs/libX11
 	x11-libs/libXext
 	x11-libs/libXpm"
 DEPEND="${RDEPEND}
 	x11-base/xorg-proto"
-
-S=${WORKDIR}/${MY_P}/wmMand
 
 DOCS=( ../{BUGS,changelog,TODO} )
 

--- a/x11-plugins/wmmon/wmmon-1.4-r1.ebuild
+++ b/x11-plugins/wmmon/wmmon-1.4-r1.ebuild
@@ -1,0 +1,18 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DESCRIPTION="Dockable system resources monitor applet for WindowMaker"
+HOMEPAGE="https://www.dockapps.net/wmmon"
+SRC_URI="https://www.dockapps.net/download/${P}.tar.gz"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~sparc ~x86"
+
+RDEPEND=">=x11-libs/libdockapp-0.7:=
+	x11-libs/libX11
+	x11-libs/libXpm"
+DEPEND="${RDEPEND}
+	x11-base/xorg-proto"

--- a/x11-plugins/wmpop3/wmpop3-0.5.6a-r2.ebuild
+++ b/x11-plugins/wmpop3/wmpop3-0.5.6a-r2.ebuild
@@ -1,0 +1,41 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs
+
+DESCRIPTION="Dockapp for checking pop3 accounts"
+HOMEPAGE="https://www.dockapps.net/wmpop3"
+SRC_URI="https://www.dockapps.net/download/${P/wmpop3/WMPop3}.tar.gz"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~sparc ~x86"
+
+DEPEND="x11-wm/windowmaker
+	x11-libs/libXpm"
+RDEPEND="${DEPEND}"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-list.patch
+	"${FILESDIR}"/${P}-fno-common.patch
+	)
+
+src_prepare() {
+	sed -e "s|cc |$(tc-getCC) |" \
+		-e "s|-O2|${CFLAGS}|" \
+		-e "s|-o wmpop3|${LDFLAGS} -o wmpop3|" \
+		-i ${PN}/Makefile || die
+
+	default
+}
+
+src_compile() {
+	emake -C wmpop3
+}
+
+src_install() {
+	dobin wmpop3/wmpop3
+	dodoc CHANGE_LOG README
+}

--- a/x11-plugins/wmtimer/wmtimer-2.92-r3.ebuild
+++ b/x11-plugins/wmtimer/wmtimer-2.92-r3.ebuild
@@ -1,0 +1,45 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs
+
+DESCRIPTION="Dockable clock which can run in alarm, countdown timer or chronograph mode"
+HOMEPAGE="https://github.com/bbidulock/wmtimer"
+SRC_URI="https://github.com/bbidulock/wmtimer/releases/download/v${PV}/${P}.tar.gz"
+S="${WORKDIR}/${P}/${PN}"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~ppc64 ~sparc ~x86"
+
+RDEPEND=">=dev-libs/glib-2
+	x11-libs/gtk+:2
+	x11-libs/libXpm
+	x11-libs/libXext
+	x11-libs/libX11"
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+src_prepare() {
+	sed -i -e "s|\$(CFLAGS)||" Makefile || die
+	sed -i -e "s|-g||g" Makefile || die
+	sed -i -e "s|-O2|\$(CFLAGS) ${CFLAGS}|"  Makefile || die
+	sed -i -e "s|-o wmtimer|\$(LDFLAGS) -o wmtimer|" Makefile || die
+
+	cd "${WORKDIR}"/${P} || die
+	eapply "${FILESDIR}"/${P}-counter-fix.patch
+	eapply "${FILESDIR}"/${P}-list.patch
+	eapply "${FILESDIR}"/${P}-gcc-10.patch
+	eapply_user
+}
+
+src_compile() {
+	emake CC="$(tc-getCC)" LIBDIR="-L/usr/$(get_libdir)"
+}
+
+src_install() {
+	dobin wmtimer
+	dodoc ../{Changelog,CREDITS,README}
+}

--- a/x11-plugins/wmtop/wmtop-0.85-r1.ebuild
+++ b/x11-plugins/wmtop/wmtop-0.85-r1.ebuild
@@ -1,0 +1,28 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools
+
+DESCRIPTION="Dockapp for monitoring the top three processes using cpu or memory"
+HOMEPAGE="https://www.dockapps.net/wmtop"
+SRC_URI="https://www.dockapps.net/download/${P}.tar.gz"
+# Incorrect path in this tarball version
+S="${WORKDIR}/dockapps-be3f170"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86"
+
+RDEPEND=">=x11-libs/libdockapp-0.7:=
+	x11-libs/libX11
+	x11-libs/libXpm
+	x11-libs/libXext"
+DEPEND="${RDEPEND}
+	x11-base/xorg-proto"
+
+src_prepare() {
+	eapply_user
+	eautoreconf
+}

--- a/x11-plugins/wmtz/wmtz-0.7_p20150816-r1.ebuild
+++ b/x11-plugins/wmtz/wmtz-0.7_p20150816-r1.ebuild
@@ -1,0 +1,41 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs
+
+DESCRIPTION="Dockapp that shows the time in multiple timezones"
+HOMEPAGE="https://www.dockapps.net/wmtz"
+# https://www.dockapps.net/download/${P}.tar.gz
+SRC_URI="https://dev.gentoo.org/~voyageur/distfiles/${P}.tar.gz"
+S="${WORKDIR}/${P}/${PN}"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~sparc ~x86"
+
+RDEPEND=">=x11-libs/libdockapp-0.7:=
+	x11-libs/libX11
+	x11-libs/libXext
+	x11-libs/libXpm"
+DEPEND="${RDEPEND}"
+
+src_prepare() {
+	default
+	#Honour Gentoo LDFLAGS, see bug #337890.
+	sed -e "s/\$(FLAGS) -o wmtz/\$(LDFLAGS) -o wmtz/" -i Makefile || die
+}
+
+src_compile() {
+	emake CC="$(tc-getCC)" FLAGS="${CFLAGS}" \
+		LIBDIR="-L/usr/$(get_libdir)"
+}
+
+src_install() {
+	dobin ${PN}
+	doman ${PN}.1
+	insinto /etc
+	doins wmtzrc
+	dodoc ../{BUGS,CHANGES,README}
+}

--- a/x11-plugins/wmweather/wmweather-2.4.7-r1.ebuild
+++ b/x11-plugins/wmweather/wmweather-2.4.7-r1.ebuild
@@ -1,0 +1,34 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DESCRIPTION="Dockable weather monitor for standard METAR stations using ICAO location"
+HOMEPAGE="https://people.debian.org/~godisch/wmweather/"
+SRC_URI="mirror://debian/pool/main/w/${PN}/${PN}_${PV}.orig.tar.gz"
+S="${WORKDIR}/${P}/src"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~mips ~ppc ~ppc64 ~sparc ~x86"
+
+RDEPEND="x11-libs/libX11
+	x11-libs/libXext
+	x11-libs/libXpm
+	x11-libs/libICE
+	x11-apps/xmessage
+	net-misc/curl"
+DEPEND="${RDEPEND}
+	x11-base/xorg-proto"
+
+DOCS=(
+	"${WORKDIR}"/${P}/CHANGES
+	"${WORKDIR}"/${P}/README
+	)
+
+src_prepare() {
+	default
+
+	pushd "${WORKDIR}"/${P} || die
+	eapply "${FILESDIR}"/${P}-fno-common.patch
+}


### PR DESCRIPTION
Hi,

just a few `EAPI8` bumps for wm* packages.
Ebuilds which didn't had any stable keywords were directly updated, others got a revision bump.

Note: `x11-plugins/wmacpimon` doens't have ~amd64 keywords. However compiling and running `wmacpimon -h` worked for me.