### PR TITLE
media-sound/supercollider: add USE flag to toggle ableton link support

### DIFF
--- a/media-sound/supercollider/metadata.xml
+++ b/media-sound/supercollider/metadata.xml
@@ -19,6 +19,7 @@
 		<remote-id type="github">supercollider/supercollider</remote-id>
 	</upstream>
 	<use>
+		<flag name="ableton-link">Enable support for Ableton Link</flag>
 		<flag name="vim">Enable the SCVIM user interface</flag>
 		<flag name="emacs">Enable the SCEL user interface</flag>
 		<flag name="gedit">Enable the SCED user interface</flag>

--- a/media-sound/supercollider/supercollider-3.13.0.ebuild
+++ b/media-sound/supercollider/supercollider-3.13.0.ebuild
@@ -12,7 +12,7 @@ SRC_URI="https://github.com/supercollider/supercollider/releases/download/Versio
 LICENSE="GPL-2 gpl3? ( GPL-3 )"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE="cpu_flags_x86_sse cpu_flags_x86_sse2 debug emacs +fftw gedit +gpl3 jack qt5 server +sndfile static-libs vim webengine X +zeroconf"
+IUSE="ableton-link cpu_flags_x86_sse cpu_flags_x86_sse2 debug emacs +fftw gedit +gpl3 jack qt5 server +sndfile static-libs vim webengine X +zeroconf"
 
 REQUIRED_USE="
 	qt5? ( X )
@@ -68,6 +68,7 @@ src_configure() {
 		-DINSTALL_HELP=ON
 		-DSYSTEM_BOOST=ON
 		-DSYSTEM_YAMLCPP=ON
+		-DSC_ABLETON_LINK=$(usex ableton-link)
 		-DSSE=$(usex cpu_flags_x86_sse)
 		-DSSE2=$(usex cpu_flags_x86_sse2)
 		-DSC_EL=$(usex emacs)

--- a/profiles/features/musl/package.use.mask
+++ b/profiles/features/musl/package.use.mask
@@ -1,6 +1,10 @@
 # Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Violet Purcell <vimproved@inventati.org> (2023-09-18)
+# Fails to compile on musl, bug 829544.
+media-sound/supercollider ableton-link
+
 # Matt Turner <mattst88@gentoo.org> (2023-05-30)
 # sys-apps/dbus-broker is masked on musl
 app-accessibility/at-spi2-core dbus-broker


### PR DESCRIPTION
Ableton link support does not compile on musl, so add a USE flag for it and mask it on musl.