### PR TITLE
app-arch/zoo: revbump, fix implicit ints

### DIFF
--- a/app-arch/zoo/files/zoo-2.10-implicit-int.patch
+++ b/app-arch/zoo/files/zoo-2.10-implicit-int.patch
@@ -1,0 +1,75 @@
+Clang 16 will not allow implicit int function defitions by default.
+This patch gives all functions a proper definitons.
+
+See also: https://wiki.gentoo.org/wiki/Modern_C_porting
+
+Bug: https://bugs.gentoo.org/878611
+Upstream PR: https://github.com/jduerstock/zoo/pull/1
+
+--- a/fiz.c
++++ b/fiz.c
+@@ -24,6 +24,7 @@ file by supplying the offset of the file.
+ void prtctrl ();
+ void prtch ();
+ 
++int
+ main(argc,argv)
+ register int argc;
+ register char **argv;
+--- a/mstime.i
++++ b/mstime.i
+@@ -12,6 +12,7 @@ static char mstimeid[]="@(#) mstime.i 2.2 88/01/24 12:47:58";
+ Function mstime() converts time in seconds since January 1 of BASEYEAR
+ to MS-DOS format date and time.
+ */
++void
+ mstime(longtime, date, time)
+ long longtime;       /* input:  seconds since Jan 1, BASEYEAR   */
+ int *date, *time;    /* output: MS-DOS format date and time */
+--- a/zoo.c
++++ b/zoo.c
+@@ -44,6 +44,7 @@ int next_arg = FIRST_ARG; /* filenames start at this position */
+ int arg_count;          /* count of arguments supplied to program */
+ char **arg_vector;      /* vector of arguments supplied to program */
+ 
++int
+ main(argc,argv)
+ register int argc;
+ register char **argv;
+--- a/zoofilt.c
++++ b/zoofilt.c
+@@ -41,8 +41,10 @@ char *option;
+ 	unsigned int filetag;							/* tag stored in input */
+ 	int stat1, stat2, stat3;						/* status codes */
+ 	int use_lzh = 0;									/* use lzh instead */
+-	extern lzc(), lzh_encode();					/* possible encoders */
+-	extern lzd(), lzh_decode();					/* and decoders */
++	extern int lzc();					/* possible encoders */
++	extern int lzh_encode();
++	extern int lzd();					/* and decoders */
++	extern int lzh_decode();
+ 
+ 	while (*++option) {
+ 		switch (*option) {
+--- a/nixtime.i
++++ b/nixtime.i
+@@ -20,7 +20,7 @@
+ Function gettime() gets the date and time of the file handle supplied.
+ Date and time is in MSDOS format.
+ */
+-int gettime (file, date, time)
++void gettime (file, date, time)
+ ZOOFILE file;
+ unsigned *date, *time;
+ {
+--- a/zoofns.h
++++ b/zoofns.h
+@@ -46,7 +46,7 @@
+ int exists PARMS ((char *));
+ int getfile PARMS ((ZOOFILE, ZOOFILE, long, int));
+ int getutime PARMS ((char *, unsigned *, unsigned *));
+-int gettime PARMS ((ZOOFILE, unsigned *, unsigned *));
++void gettime PARMS ((ZOOFILE, unsigned *, unsigned *));
+ T_SIGNAL handle_break PARMS ((int));
+ 
+ #ifdef USE_ASCII

--- a/app-arch/zoo/zoo-2.10-r6.ebuild
+++ b/app-arch/zoo/zoo-2.10-r6.ebuild
@@ -1,0 +1,36 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs
+
+DESCRIPTION="Manipulate archives of files in compressed form"
+HOMEPAGE="https://github.com/jduerstock/zoo"
+SRC_URI="http://http.debian.net/debian/pool/main/z/${PN}/${PN}_${PV}.orig.tar.gz
+	http://http.debian.net/debian/pool/main/z/${PN}/${PN}_${PV}-28.debian.tar.xz"
+S="${WORKDIR}"/${P}.orig
+
+LICENSE="public-domain"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~x86-linux"
+
+PATCHES=(
+	"${WORKDIR}"/debian/patches/.
+	"${FILESDIR}"/${P}-gentoo-fbsd-r1.patch
+	"${FILESDIR}"/${P}-makefile.patch
+	"${FILESDIR}"/${P}-implicit-int.patch
+)
+
+src_configure() {
+	tc-export CC
+}
+
+src_compile() {
+	emake linux
+}
+
+src_install() {
+	dobin zoo fiz
+	doman zoo.1 fiz.1
+}


### PR DESCRIPTION
finest stuff from 1988, fit for another 25 years

Closes: https://bugs.gentoo.org/878611

This fork seems to be actively maintained, maybe switch to this upstream? https://github.com/troglobit/zoo