### PR TITLE
gnustep-*/*: EAPI8 bump, minor fixes

### DIFF
--- a/gnustep-apps/affiche/affiche-0.6.0-r5.ebuild
+++ b/gnustep-apps/affiche/affiche-0.6.0-r5.ebuild
@@ -1,0 +1,15 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit gnustep-2
+
+DESCRIPTION="Affiche allows people to 'stick' notes"
+HOMEPAGE="https://salsa.debian.org/gnustep-team/affiche.app"
+SRC_URI="mirror://gentoo/${P/a/A}.tar.gz"
+S="${WORKDIR}/${PN/a/A}"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86"

--- a/gnustep-apps/ftp/ftp-0.6.ebuild
+++ b/gnustep-apps/ftp/ftp-0.6.ebuild
@@ -1,18 +1,17 @@
 # Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
+
 inherit gnustep-2
 
 MY_P="FTP-${PV}"
 
 DESCRIPTION="FTP client for GNUstep"
-HOMEPAGE="http://gap.nongnu.org/ftp/"
+HOMEPAGE="https://gap.nongnu.org/ftp/"
 SRC_URI="https://savannah.nongnu.org/download/gap/${MY_P}.tar.gz"
+S="${WORKDIR}/${MY_P}"
 
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE=""
-
-S=${WORKDIR}/${MY_P}

--- a/gnustep-apps/gnumail/gnumail-1.4.0.ebuild
+++ b/gnustep-apps/gnumail/gnumail-1.4.0.ebuild
@@ -2,20 +2,22 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
+
 inherit gnustep-2
 
 MY_P=${P/gnum/GNUM}
 
-S=${WORKDIR}/${MY_P}
-
-DESCRIPTION="A fully featured mail application for GNUstep"
-HOMEPAGE="http://www.nongnu.org/gnustep-nonfsf/gnumail/"
+DESCRIPTION="Fully featured mail application for GNUstep"
+HOMEPAGE="https://www.nongnu.org/gnustep-nonfsf/gnumail/"
 SRC_URI="mirror://nongnu/gnustep-nonfsf/${MY_P}.tar.gz"
+S="${WORKDIR}/${MY_P}"
+
 KEYWORDS="~amd64 ~ppc ~x86"
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="0"
 
 IUSE="crypt"
+
 DEPEND=">=gnustep-base/gnustep-gui-0.11.0
 	=gnustep-libs/pantomime-1.4*
 	gnustep-apps/addresses"

--- a/gnustep-apps/gshisen/gshisen-1.3.0-r2.ebuild
+++ b/gnustep-apps/gshisen/gshisen-1.3.0-r2.ebuild
@@ -1,0 +1,16 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit gnustep-2
+
+MY_PN=GShisen
+DESCRIPTION="The first GNUstep game, similar to Mahjongg"
+HOMEPAGE="https://gap.nongnu.org/gshisen/index.html"
+SRC_URI="https://savannah.nongnu.org/download/gap/${MY_PN}-${PV}.tar.gz"
+S="${WORKDIR}/${MY_PN}-${PV}"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"

--- a/gnustep-apps/preview/preview-0.9-r1.ebuild
+++ b/gnustep-apps/preview/preview-0.9-r1.ebuild
@@ -1,0 +1,25 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit gnustep-2
+
+DESCRIPTION="Simple image viewer"
+HOMEPAGE="https://salsa.debian.org/gnustep-team/preview.app"
+SRC_URI="mirror://gentoo//${P/p/P}.tar.gz"
+S="${WORKDIR}/${PN/p/P}"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86"
+
+PATCHES=(
+	# Fix compilation, patch from debian
+	"${FILESDIR}"/${PN}-0.8.5-compilation-errors.patch
+)
+
+src_prepare() {
+	default
+	sed -e 's/sel_eq(/sel_isEqual(/' -i Document.m || die
+}

--- a/gnustep-apps/price/price-1.3.0-r1.ebuild
+++ b/gnustep-apps/price/price-1.3.0-r1.ebuild
@@ -1,0 +1,19 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit gnustep-2
+
+MY_P=PRICE-${PV}
+DESCRIPTION="Precision Raster Image Convolution Engine"
+HOMEPAGE="https://price.sourceforge.net/"
+SRC_URI="mirror://sourceforge/price/${MY_P}.tar.gz"
+S="${WORKDIR}/${MY_P}"
+
+KEYWORDS="~amd64 ~ppc ~x86"
+SLOT="0"
+LICENSE="GPL-2+"
+
+DEPEND=">=gnustep-base/gnustep-gui-0.13.0"
+RDEPEND="${DEPEND}"

--- a/gnustep-apps/talksoup/talksoup-1.1.ebuild
+++ b/gnustep-apps/talksoup/talksoup-1.1.ebuild
@@ -1,21 +1,20 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
+
 inherit gnustep-2
 
 MY_P="TalkSoup-${PV}"
 
 DESCRIPTION="IRC client for GNUstep"
-HOMEPAGE="http://gap.nongnu.org/talksoup/"
-SRC_URI="http://savannah.nongnu.org/download/gap/${MY_P}.tar.gz"
+HOMEPAGE="https://gap.nongnu.org/talksoup/"
+SRC_URI="https://savannah.nongnu.org/download/gap/${MY_P}.tar.gz"
+S="${WORKDIR}/${MY_P}"
 
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE=""
 
 DEPEND=">=gnustep-libs/netclasses-1.1.0"
 RDEPEND="${DEPEND}"
-
-S=${WORKDIR}/${MY_P}

--- a/gnustep-base/gnustep-back-art/gnustep-back-art-0.29.0.ebuild
+++ b/gnustep-base/gnustep-back-art/gnustep-back-art-0.29.0.ebuild
@@ -1,14 +1,16 @@
 # Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
+
 inherit gnustep-base
 
-DESCRIPTION="libart_lgpl back-end component for the GNUstep GUI Library"
+DESCRIPTION="Libart_lgpl back-end component for the GNUstep GUI Library"
 HOMEPAGE="https://gnustep.github.io"
 SRC_URI="ftp://ftp.gnustep.org/pub/gnustep/core/gnustep-back-${PV}.tar.gz"
+S="${WORKDIR}/gnustep-back-${PV}"
 
-LICENSE="LGPL-2.1"
+LICENSE="LGPL-2.1+"
 SLOT="0"
 KEYWORDS="~alpha ~amd64 ~ppc ~sparc ~x86 ~amd64-linux ~x86-linux"
 IUSE="opengl xim"
@@ -34,7 +36,11 @@ RDEPEND="${GNUSTEP_CORE_DEPEND}
 	!gnustep-base/gnustep-back-xlib"
 DEPEND="${RDEPEND}"
 
-S=${WORKDIR}/gnustep-back-${PV}
+src_prepare() {
+	default
+	# do not compress man pages
+	sed -i '/which gzip/,/&& gzip/d' Tools/GNUmakefile.postamble || die
+}
 
 src_configure() {
 	egnustep_env
@@ -68,8 +74,8 @@ src_compile() {
 src_install() {
 	gnustep-base_src_install
 
-	mkdir -p "${D}/${GNUSTEP_SYSTEM_LIBRARY}/Fonts"
-	cp -pPR Fonts/*.nfont "${D}/${GNUSTEP_SYSTEM_LIBRARY}/Fonts"
+	mkdir -p "${D}/${GNUSTEP_SYSTEM_LIBRARY}/Fonts" || die
+	cp -pPR Fonts/*.nfont "${D}/${GNUSTEP_SYSTEM_LIBRARY}/Fonts" || die
 }
 
 gnustep_config_script() {

--- a/gnustep-libs/dbuskit/dbuskit-0.1.1-r2.ebuild
+++ b/gnustep-libs/dbuskit/dbuskit-0.1.1-r2.ebuild
@@ -1,0 +1,36 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools gnustep-2
+
+DESCRIPTION="Framework that interfaces Objective-C applications with the D-Bus IPC service"
+HOMEPAGE="https://github.com/gnustep/libs-dbuskit"
+SRC_URI="https://github.com/gnustep/libs-dbuskit/archive/${PV}.tar.gz -> ${P}.tar.gz"
+S="${WORKDIR}/libs-${P}"
+
+LICENSE="LGPL-2.1+"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86"
+
+DEPEND=">=sys-apps/dbus-1.2.1"
+RDEPEND="${DEPEND}"
+
+PATCHES=( "${FILESDIR}"/${P}-remove_gc.patch )
+
+src_prepare() {
+	default
+
+	if ! use doc; then
+		# Remove doc target
+		sed -i -e "/SUBPROJECTS/s/Documentation//" GNUmakefile \
+			|| die "doc sed failed"
+	fi
+
+	# Bug 410697
+	sed -e "s#ObjectiveC2/runtime.h#ObjectiveC2/objc/runtime.h#" \
+		-i configure.ac || die "ObjectiveC2 runtime sed failed"
+
+	eautoreconf
+}

--- a/gnustep-libs/gsldap/gsldap-0.0.1_pre20070219-r1.ebuild
+++ b/gnustep-libs/gsldap/gsldap-0.0.1_pre20070219-r1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
 
 inherit gnustep-2
 
@@ -9,10 +9,9 @@ DESCRIPTION="GNUstep LDAP library for openldap C libraries"
 HOMEPAGE="https://gnustep.github.io/"
 SRC_URI="mirror://gentoo/${P}.tar.gz"
 
-LICENSE="LGPL-2.1"
+LICENSE="LGPL-2.1+"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE=""
 
 DEPEND="net-nds/openldap:="
 RDEPEND="${DEPEND}"

--- a/gnustep-libs/netclasses/netclasses-1.1.0-r1.ebuild
+++ b/gnustep-libs/netclasses/netclasses-1.1.0-r1.ebuild
@@ -1,0 +1,16 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit gnustep-2
+
+DESCRIPTION="Asynchronous networking library for GNUstep"
+HOMEPAGE="https://gap.nongnu.org/talksoup/"
+SRC_URI="https://savannah.nongnu.org/download/gap/${P}.tar.gz"
+
+KEYWORDS="~amd64 ~ppc ~x86"
+LICENSE="GPL-2+ LGPL-2.1+"
+SLOT="0"
+
+PATCHES=( "${FILESDIR}"/${P}-no_rfc.patch )

--- a/gnustep-libs/pantomime/pantomime-1.4.0.ebuild
+++ b/gnustep-libs/pantomime/pantomime-1.4.0.ebuild
@@ -2,20 +2,19 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
+
 inherit gnustep-2
 
 MY_P=${P/p/P}
 
-S=${WORKDIR}/${MY_P}
-
-DESCRIPTION="A set of Objective-C classes that model a mail system"
-HOMEPAGE="http://www.nongnu.org/gnustep-nonfsf/gnumail/"
+DESCRIPTION="Set of Objective-C classes that model a mail system"
+HOMEPAGE="https://www.nongnu.org/gnustep-nonfsf/gnumail/"
 SRC_URI="mirror://nongnu/gnustep-nonfsf/${MY_P}.tar.gz"
+S="${WORKDIR}/${MY_P}"
 
-LICENSE="LGPL-2.1 Elm"
+LICENSE="LGPL-2.1+ Elm"
 KEYWORDS="~amd64 ~ppc ~x86"
 SLOT="0"
-IUSE=""
 
 DEPEND="dev-libs/openssl:0=
 	>=gnustep-base/gnustep-base-1.29.0:="

--- a/gnustep-libs/performance/performance-0.5.0.ebuild
+++ b/gnustep-libs/performance/performance-0.5.0.ebuild
@@ -1,19 +1,19 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
+
 inherit gnustep-2
 
 MY_P=${P/p/P}
 DESCRIPTION="Help improve the performance of GNUstep applications"
-HOMEPAGE="http://wiki.gnustep.org/index.php/Performance"
+HOMEPAGE="https://github.com/gnustep/libs-performance"
 SRC_URI="ftp://ftp.gnustep.org/pub/gnustep/libs/${MY_P}.tar.gz"
+S="${WORKDIR}/${MY_P}"
 
 KEYWORDS="~amd64 ~ppc ~x86"
-LICENSE="LGPL-3"
+LICENSE="LGPL-3+"
 SLOT="0"
-
-S=${WORKDIR}/${MY_P}
 
 src_prepare() {
 	if ! use doc; then

--- a/gnustep-libs/renaissance/renaissance-0.9.0-r2.ebuild
+++ b/gnustep-libs/renaissance/renaissance-0.9.0-r2.ebuild
@@ -1,0 +1,17 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit gnustep-2
+
+DESCRIPTION="GNUstep Renaissance allows to describe user interfaces XML files"
+HOMEPAGE="https://github.com/gnustep/libs-renaissance"
+SRC_URI="http://www.gnustep.it/Renaissance/Download/${P/r/R}.tar.gz"
+S="${WORKDIR}/${P/r/R}"
+
+KEYWORDS="~amd64 ~ppc ~x86"
+LICENSE="LGPL-2.1+"
+SLOT="0"
+
+PATCHES=( "${FILESDIR}"/${PN}-0.8.1_pre20070522-docpath.patch )


### PR DESCRIPTION
Hi, 

This updates some `gnustep-*` apps for `EAPI8`

Some notes:
`gnustep-apps/affiche`: `HOMEPAGE` is broken, but i found `https://salsa.debian.org/gnustep-team/affiche.app`. I think it's not official, but couldn't find anything else.
`gnustep-apps/preview`: same as for preview -> only found `https://salsa.debian.org/gnustep-team/preview.app`
`gnustep-base/gnustep-back-art`: was installing compressed man pages. With a simple `sed` i could stop it from doing so.
`gnustep-libs/renaissance` & `gnustep-libs/performance` have github `HOMEPAGES` which i used as well.