### PR TITLE
dev-lang/zig: update to LLVM 17 for 9999

### DIFF
--- a/dev-lang/zig/zig-9999.ebuild
+++ b/dev-lang/zig/zig-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-LLVM_MAX_SLOT=16
+LLVM_MAX_SLOT=17
 inherit edo cmake llvm check-reqs toolchain-funcs
 
 DESCRIPTION="A robust, optimal, and maintainable programming language"


### PR DESCRIPTION
See also https://www.github.com/ziglang/zig/pull/17202 .