### PR TITLE
sys-libs/ldb: Remove samba CPE from metadata.xml

### DIFF
--- a/sys-libs/ldb/metadata.xml
+++ b/sys-libs/ldb/metadata.xml
@@ -5,9 +5,6 @@
 		<email>samba@gentoo.org</email>
 		<name>Samba</name>
 	</maintainer>
-	<upstream>
-		<remote-id type="cpe">cpe:/a:samba:samba</remote-id>
-	</upstream>
 	<use>
 		<flag name="doc">Builds documentation</flag>
 		<flag name="ldap">Enable LDAP support</flag>


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/902905