### PR TITLE
dev-lang/ferite: Fix incompatible function pointer types passing

### DIFF
--- a/dev-lang/ferite/ferite-1.1.17-r2.ebuild
+++ b/dev-lang/ferite/ferite-1.1.17-r2.ebuild
@@ -1,0 +1,72 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools
+
+DESCRIPTION="A clean, lightweight, object oriented scripting language"
+HOMEPAGE="http://ferite.sourceforge.net/"
+SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
+SRC_URI+=" https://dev.gentoo.org/~sam/distfiles/${CATEGORY}/${PN}/${P}-slibtool.patch.bz2"
+
+LICENSE="BSD"
+SLOT="1"
+KEYWORDS="~alpha ~amd64 ~ppc -sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
+
+RDEPEND="
+	dev-libs/boehm-gc[threads]
+	>=dev-libs/libpcre-5:3
+	dev-libs/libxml2:2
+"
+DEPEND="${RDEPEND}"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-pcre.patch
+	"${FILESDIR}"/${P}-bool.patch
+	"${WORKDIR}"/${P}-slibtool.patch
+	"${FILESDIR}"/${P}-musl-clang16-fix.patch
+)
+
+src_prepare() {
+	default
+
+	# use docsdir variable, install to DESTDIR
+	sed \
+		-e '/docsdir =/!s:$(prefix)/share/doc/ferite:$(DESTDIR)$(docsdir):' \
+		-i docs/Makefile.am || die
+
+	# Install docs to /usr/share/doc/${PF}, not .../${PN}
+	sed \
+		-e "s:doc/ferite:doc/${PF}:" \
+		-i Makefile.am \
+		docs/Makefile.am \
+		scripts/test/Makefile.am \
+		scripts/test/rmi/Makefile.am || die
+
+	# Make sure we install in $(get_libdir), not lib
+	sed -i -e "s|\$prefix/lib|\$prefix/$(get_libdir)|g" configure.ac || die
+
+	# We copy feritedoc to ${T} in src_install, then patch it in-situ
+	# note that this doesn't actually work right, currently - it still tries
+	# to pull from / instead of ${D}, and I can't figure out how to fix that
+	sed -i -e 's:$(prefix)/bin/:${T}/:' docs/Makefile.am || die
+
+	eautoreconf
+}
+
+src_configure() {
+	econf --libdir="${EPREFIX}/usr/$(get_libdir)" --disable-static
+}
+
+src_install() {
+	cp tools/doc/feritedoc "${T}" || die
+	sed -i -e '/^prefix/s:prefix:${T}:g' "${T}"/feritedoc || die
+	sed -i -e '/^$prefix/s:$prefix/bin/ferite:'"${ED}"'/usr/bin/ferite:' "${T}"/feritedoc || die
+	sed -i -e 's:$library_path $library_path:${S}/tools/doc ${S}/tools/doc:' "${T}"/feritedoc || die
+
+	export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}${LD_LIBRARY_PATH:+:}${ED}/usr/lib"
+	emake DESTDIR="${D}" LIBDIR="${EPREFIX}"/usr/$(get_libdir) install
+
+	find "${D}" -name '*.la' -delete || die
+}

--- a/dev-lang/ferite/files/ferite-1.1.17-musl-clang16-fix.patch
+++ b/dev-lang/ferite/files/ferite-1.1.17-musl-clang16-fix.patch
@@ -1,0 +1,85 @@
+Bug: https://bugs.gentoo.org/913564
+https://sourceforge.net/p/ferite/bugs/7/
+--- a/include/ferite/ferror.h
++++ b/include/ferite/ferror.h
+@@ -43,6 +43,7 @@ FERITE_API void ferite_raise_script_error( FeriteScript *script, int err, char *
+ FERITE_API void ferite_vwarning(FeriteScript *script, char *errormsg, va_list *ap );
+ FERITE_API FeriteVariable *ferite_generate_backtrace( FeriteScript *script, int skip_first );
+ FERITE_API void ferite_error( FeriteScript *script, int err, char *errormsg, ... );
++FERITE_API void ferite_verror( FeriteScript *script, int err, char *errormsg, va_list *ap );
+ FERITE_API void ferite_vwarning(FeriteScript *script, char *errormsg, va_list *ap );
+ FERITE_API void ferite_warning( FeriteScript *script, char *errormsg, ... );
+ FERITE_API void ferite_set_error( FeriteScript *script, int num, char *fmt, ... );
+--- a/libs/aphex/include/aphex.h
++++ b/libs/aphex/include/aphex.h
+@@ -57,7 +57,7 @@
+ 
+ # ifdef USE_PTHREAD
+ #  include <pthread.h>
+-#  if (!defined(PTHREAD_MUTEX_RECURSIVE) && defined(PTHREAD_MUTEX_RECURSIVE_NP)) || defined(USING_LINUX)
++#  if (!defined(PTHREAD_MUTEX_RECURSIVE) && defined(PTHREAD_MUTEX_RECURSIVE_NP)) || defined(__GLIBC__)
+ #     define PTHREAD_MUTEX_RECURSIVE PTHREAD_MUTEX_RECURSIVE_NP
+ #   endif
+ # endif
+@@ -215,4 +215,18 @@ APHEX_API static __inline__ int aphex_atomic_decrement_v( AphexAtomicType *targe
+ APHEX_API int aphex_notify_can_read_with_timeout(int fd, int wait, int ce);
+ APHEX_API int aphex_notify_can_read(int fd, int ce);
+ 
++#ifdef HAVE_LIBGC
++void *aphex_malloc( size_t size );
++void *aphex_realloc( void *old, size_t new );
++void *aphex_calloc( size_t size, size_t block );
++void  aphex_free( void * ptr );
++char *aphex_strdup( char *original );
++#else
++void *aphex_malloc( size_t size );
++void *aphex_realloc( void *old, size_t new );
++void *aphex_calloc( size_t size, size_t block );
++void  aphex_free( void * ptr );
++char *aphex_strdup( char *original );
++#endif
++
+ #endif /* __APHEX_H__ */
+--- a/modules/xml/sax_handlers.c
++++ b/modules/xml/sax_handlers.c
+@@ -27,6 +27,7 @@
+ #include <libxml/parserInternals.h>
+ #include "xml_header.h"
+ #include "sax_handlers.h"
++#include "ferite/ferror.h"
+ 
+ #define DELIVER_STRING_CALLBACK( NAME, STRING, LENGTH ) \
+     do { \
+@@ -260,7 +261,7 @@ void sax_fatalError (void *ctxt, const char *msg, ...)
+     va_list ap;
+ 
+     va_start( ap, msg );
+-    ferite_verror( sr->script, (char *)msg, &ap );
++    ferite_verror( sr->script, 0, (char *)msg, &ap );
+     va_end( ap );
+ }
+ 
+--- a/src/ferite_gc_libgc.c
++++ b/src/ferite_gc_libgc.c
+@@ -57,8 +57,8 @@ void ferite_deinit_libgc_gc( FeriteScript *script )
+     FE_LEAVE_FUNCTION( NOWT );
+ }
+ 
+-void ferite_libgc_finalizer( FeriteObject *obj, FeriteScript *script ) {
+-	ferite_delete_class_object( script, obj, FE_TRUE );
++void ferite_libgc_finalizer( void *obj, void *script ) {
++	ferite_delete_class_object( (FeriteScript *)script, (FeriteObject *)obj, FE_TRUE );
+ }
+ void ferite_add_to_libgc_gc( FeriteScript *script, FeriteObject *obj )
+ {
+--- a/test/main.c
++++ b/test/main.c
+@@ -194,7 +194,7 @@ int parse_args( int argc, char **argv )
+             if((!strcmp(argv[i], "--execute")) || (!strcmp(argv[i], "-e")) &&
+                argv[i + 1])
+             {
+-                opt.scriptname = aphex_strdup( argv[++i] );
++                opt.scriptname = (char *) aphex_strdup( argv[++i] );
+                 opt.estring = FE_TRUE;
+                 gotScript = FE_TRUE;
+             }


### PR DESCRIPTION
with other build errors on musl and clang 16 and update EAPI 7 -> 8

Closes: https://bugs.gentoo.org/913564