### PR TITLE
app-containers/buildah: add to proxy-maint + myself as maintainer

### DIFF
--- a/app-containers/buildah/metadata.xml
+++ b/app-containers/buildah/metadata.xml
@@ -5,6 +5,14 @@
 		<email>zmedico@gentoo.org</email>
 		<name>Zac Medico</name>
 	</maintainer>
+	<maintainer type="project" proxied="proxy">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
+	<maintainer type="person" proxied="yes">
+		<email>rahil3108@gmail.com</email>
+		<name>Rahil Bhimjiani</name>
+	</maintainer>
 	<upstream>
 		<remote-id type="github">containers/buildah</remote-id>
 	</upstream>


### PR DESCRIPTION
I've authored buildah-1.32.0 (12fc95e0cbcc89ca0ba3dd892d1ef0b4c4a5a1c0) & buildah-9999 (https://github.com/gentoo/gentoo/pull/32934).

Being a daily user of Containers (or podman) stack, I'll be able to test these packages & motivated to keep them up-to-date & stable. So I would like to be maintainer of buildah (& podman stack). This is the start.