### PR TITLE
sys-kernel/dracut: backport uki kernel-install fixes

### DIFF
--- a/sys-kernel/dracut/dracut-059-r4.ebuild
+++ b/sys-kernel/dracut/dracut-059-r4.ebuild
@@ -1,0 +1,185 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit bash-completion-r1 linux-info optfeature systemd toolchain-funcs
+
+if [[ ${PV} == 9999 ]] ; then
+	inherit git-r3
+	EGIT_REPO_URI="https://github.com/dracutdevs/dracut"
+else
+	if [[ "${PV}" != *_rc* ]]; then
+		KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~mips ~ppc ~ppc64 ~riscv ~sparc ~x86"
+	fi
+	SRC_URI="https://github.com/dracutdevs/dracut/archive/refs/tags/${PV}.tar.gz -> ${P}.tar.gz"
+fi
+
+DESCRIPTION="Generic initramfs generation tool"
+HOMEPAGE="https://github.com/dracutdevs/dracut/wiki"
+
+LICENSE="GPL-2"
+SLOT="0"
+IUSE="selinux test"
+
+RESTRICT="!test? ( test )"
+
+RDEPEND="
+	app-arch/cpio
+	>=app-shells/bash-4.0:0
+	sys-apps/coreutils[xattr(-)]
+	>=sys-apps/kmod-23[tools]
+	|| (
+		>=sys-apps/sysvinit-2.87-r3
+		sys-apps/openrc[sysv-utils(-),selinux?]
+		sys-apps/systemd[sysv-utils]
+		sys-apps/s6-linux-init[sysv-utils(-)]
+	)
+	>=sys-apps/util-linux-2.21
+	virtual/pkgconfig
+	virtual/udev
+
+	elibc_musl? ( sys-libs/fts-standalone )
+	selinux? (
+		sec-policy/selinux-dracut
+		sys-libs/libselinux
+		sys-libs/libsepol
+	)
+"
+DEPEND="
+	>=sys-apps/kmod-23
+	elibc_musl? ( sys-libs/fts-standalone )
+"
+
+BDEPEND="
+	app-text/asciidoc
+	app-text/docbook-xml-dtd:4.5
+	>=app-text/docbook-xsl-stylesheets-1.75.2
+	>=dev-libs/libxslt-1.1.26
+	virtual/pkgconfig
+"
+
+QA_MULTILIB_PATHS="usr/lib/dracut/.*"
+
+PATCHES=(
+	"${FILESDIR}"/gentoo-ldconfig-paths-r1.patch
+	"${FILESDIR}"/gentoo-network-r1.patch
+	"${FILESDIR}"/059-kernel-install-uki.patch
+	"${FILESDIR}"/059-uefi-split-usr.patch
+	"${FILESDIR}"/059-uki-systemd-254.patch
+	"${FILESDIR}"/059-gawk.patch
+)
+
+src_configure() {
+	local myconf=(
+		--prefix="${EPREFIX}/usr"
+		--sysconfdir="${EPREFIX}/etc"
+		--bashcompletiondir="$(get_bashcompdir)"
+		--systemdsystemunitdir="$(systemd_get_systemunitdir)"
+	)
+
+	tc-export CC PKG_CONFIG
+
+	echo ./configure "${myconf[@]}"
+	./configure "${myconf[@]}" || die
+
+	if [[ ${PV} != 9999 && ! -f dracut-version.sh ]] ; then
+		# Source tarball from github doesn't include this file
+		echo "DRACUT_VERSION=${PV}" > dracut-version.sh || die
+	fi
+}
+
+src_test() {
+	if [[ ${EUID} != 0 ]]; then
+		# Tests need root privileges, bug #298014
+		ewarn "Skipping tests: Not running as root."
+	elif [[ ! -w /dev/kvm ]]; then
+		ewarn "Skipping tests: Unable to access /dev/kvm."
+	else
+		emake -C test check
+	fi
+}
+
+src_install() {
+	local DOCS=(
+		AUTHORS
+		NEWS.md
+		README.md
+		docs/README.cross
+		docs/README.generic
+		docs/README.kernel
+		docs/SECURITY.md
+	)
+
+	default
+
+	docinto html
+	dodoc dracut.html
+}
+
+pkg_postinst() {
+	if linux-info_get_any_version && linux_config_exists; then
+		ewarn ""
+		ewarn "If the following test report contains a missing kernel"
+		ewarn "configuration option, you should reconfigure and rebuild your"
+		ewarn "kernel before booting image generated with this Dracut version."
+		ewarn ""
+
+		local CONFIG_CHECK="~BLK_DEV_INITRD ~DEVTMPFS"
+
+		# Kernel configuration options descriptions:
+		local ERROR_DEVTMPFS='CONFIG_DEVTMPFS: "Maintain a devtmpfs filesystem to mount at /dev" '
+		ERROR_DEVTMPFS+='is missing and REQUIRED'
+		local ERROR_BLK_DEV_INITRD='CONFIG_BLK_DEV_INITRD: "Initial RAM filesystem and RAM disk '
+		ERROR_BLK_DEV_INITRD+='(initramfs/initrd) support" is missing and REQUIRED'
+
+		check_extra_config
+		echo
+	else
+		ewarn ""
+		ewarn "Your kernel configuration couldn't be checked."
+		ewarn "Please check manually if following options are enabled:"
+		ewarn ""
+		ewarn "  CONFIG_BLK_DEV_INITRD"
+		ewarn "  CONFIG_DEVTMPFS"
+		ewarn ""
+	fi
+
+	optfeature "Networking support" net-misc/networkmanager
+	optfeature "Legacy networking support" net-misc/curl "net-misc/dhcp[client]" \
+		sys-apps/iproute2 "net-misc/iputils[arping]"
+	optfeature "Scan for Btrfs on block devices"  sys-fs/btrfs-progs
+	optfeature "Load kernel modules and drop this privilege for real init" \
+		sys-libs/libcap
+	optfeature "Support CIFS" net-fs/cifs-utils
+	optfeature "Decrypt devices encrypted with cryptsetup/LUKS" \
+		"sys-fs/cryptsetup[-static-libs]"
+	optfeature "Support for GPG-encrypted keys for crypt module" \
+		app-crypt/gnupg
+	optfeature \
+		"Allows use of dash instead of default bash (on your own risk)" \
+		app-shells/dash
+	optfeature \
+		"Allows use of busybox instead of default bash (on your own risk)" \
+		sys-apps/busybox
+	optfeature "Support iSCSI" sys-block/open-iscsi
+	optfeature "Support Logical Volume Manager" sys-fs/lvm2[lvm]
+	optfeature "Support MD devices, also known as software RAID devices" \
+		sys-fs/mdadm sys-fs/dmraid
+	optfeature "Support Device Mapper multipathing" sys-fs/multipath-tools
+	optfeature "Plymouth boot splash"  '>=sys-boot/plymouth-0.8.5-r5'
+	optfeature "Support network block devices" sys-block/nbd
+	optfeature "Support NFS" net-fs/nfs-utils net-nds/rpcbind
+	optfeature \
+		"Install ssh and scp along with config files and specified keys" \
+		virtual/openssh
+	optfeature "Enable logging with rsyslog" app-admin/rsyslog
+	optfeature "Support Squashfs" sys-fs/squashfs-tools
+	optfeature "Support TPM 2.0 TSS" app-crypt/tpm2-tools
+	optfeature "Support Bluetooth (experimental)" net-wireless/bluez
+	optfeature "Support BIOS-given device names" sys-apps/biosdevname
+	optfeature "Support network NVMe" sys-apps/nvme-cli
+	optfeature \
+		"Enable rngd service to help generating entropy early during boot" \
+		sys-apps/rng-tools
+}

--- a/sys-kernel/dracut/files/059-kernel-install-uki.patch
+++ b/sys-kernel/dracut/files/059-kernel-install-uki.patch
@@ -1,0 +1,150 @@
+Combination of:
+- https://github.com/dracutdevs/dracut/pull/2405
+- https://github.com/dracutdevs/dracut/pull/2495
+- https://github.com/dracutdevs/dracut/pull/2521
+
+Fixes installing manually configured kernel in uki layout and
+allows dropping workaround from dist-kernel-utils.eclass
+
+Provides compatibility with systemd-254's ukify plugin
+
+--- a/dracut.sh
++++ b/dracut.sh
+@@ -2594,6 +2594,9 @@ freeze_ok_for_fstype() {
+         zfs)
+             return 1
+             ;;
++        tmpfs)
++            return 1
++            ;;
+         btrfs)
+             freeze_ok_for_btrfs "$outfile"
+             ;;
+--- a/install.d/50-dracut.install	2023-09-21 10:19:00.843827541 +0200
++++ b/install.d/50-dracut.install	2023-07-20 16:53:51.000000000 +0200
+@@ -11,27 +11,69 @@
+     exit 0
+ fi
+
+-if [[ -d "$BOOT_DIR_ABS" ]]; then
+-    INITRD="initrd"
++# Do not attempt to create initramfs if the supplied image is already a UKI
++if [[ "$KERNEL_INSTALL_IMAGE_TYPE" = "uki" ]]; then
++    exit 0
++fi
++
++# Mismatching the install layout and the --uefi/--no-uefi opts just creates a mess.
++if [[ $KERNEL_INSTALL_LAYOUT == "uki" && -n $KERNEL_INSTALL_STAGING_AREA ]]; then
++    BOOT_DIR_ABS="$KERNEL_INSTALL_STAGING_AREA"
++    if [[ -z $KERNEL_INSTALL_UKI_GENERATOR || $KERNEL_INSTALL_UKI_GENERATOR == "dracut" ]]; then
++        # No uki generator preference set or we have been chosen
++        IMAGE="uki.efi"
++        UEFI_OPTS="--uefi"
++    elif [[ -z $KERNEL_INSTALL_INITRD_GENERATOR || $KERNEL_INSTALL_INITRD_GENERATOR == "dracut" ]]; then
++        # We aren't the uki generator, but we have been requested to make the initrd
++        IMAGE="initrd"
++        UEFI_OPTS="--no-uefi"
++    else
++        exit 0
++    fi
++elif [[ $KERNEL_INSTALL_LAYOUT == "bls" && -n $KERNEL_INSTALL_STAGING_AREA ]]; then
++    BOOT_DIR_ABS="$KERNEL_INSTALL_STAGING_AREA"
++    if [[ -z $KERNEL_INSTALL_INITRD_GENERATOR || $KERNEL_INSTALL_INITRD_GENERATOR == "dracut" ]]; then
++        IMAGE="initrd"
++        UEFI_OPTS="--no-uefi"
++    else
++        exit 0
++    fi
+ else
+-    BOOT_DIR_ABS="/boot"
+-    INITRD="initramfs-${KERNEL_VERSION}.img"
++    # No layout information, use users --uefi/--no-uefi preference
++    UEFI_OPTS=""
++    if [[ -d $BOOT_DIR_ABS ]]; then
++        IMAGE="initrd"
++    else
++        BOOT_DIR_ABS="/boot"
++        IMAGE="initramfs-${KERNEL_VERSION}.img"
++    fi
+ fi
+
+ ret=0
++
+ case "$COMMAND" in
+     add)
+-        INITRD_IMAGE_PREGENERATED=${KERNEL_IMAGE%/*}/initrd
+-        if [[ -f ${INITRD_IMAGE_PREGENERATED} ]]; then
+-            # we found an initrd at the same place as the kernel
++        if [[ $IMAGE == "uki.efi" ]]; then
++            IMAGE_PREGENERATED=${KERNEL_IMAGE%/*}/uki.efi
++        else
++            IMAGE_PREGENERATED=${KERNEL_IMAGE%/*}/initrd
++        fi
++        if [[ -f ${IMAGE_PREGENERATED} ]]; then
++            # we found an initrd or uki.efi at the same place as the kernel
+             # use this and don't generate a new one
+-            cp --reflink=auto "$INITRD_IMAGE_PREGENERATED" "$BOOT_DIR_ABS/$INITRD" \
+-                && chown root:root "$BOOT_DIR_ABS/$INITRD" \
+-                && chmod 0600 "$BOOT_DIR_ABS/$INITRD" \
++            [[ $KERNEL_INSTALL_VERBOSE == 1 ]] && echo \
++                "There is an ${IMAGE} image at the same place as the kernel, skipping generating a new one"
++            cp --reflink=auto "$IMAGE_PREGENERATED" "$BOOT_DIR_ABS/$IMAGE" \
++                && chown root:root "$BOOT_DIR_ABS/$IMAGE" \
++                && chmod 0600 "$BOOT_DIR_ABS/$IMAGE" \
+                 && exit 0
+         fi
+
+-        if [[ -f /etc/kernel/cmdline ]]; then
++        if [ -n "$KERNEL_INSTALL_CONF_ROOT" ]; then
++            if [ -f "$KERNEL_INSTALL_CONF_ROOT/cmdline" ]; then
++                read -r -d '' -a BOOT_OPTIONS < "$KERNEL_INSTALL_CONF_ROOT/cmdline"
++            fi
++        elif [[ -f /etc/kernel/cmdline ]]; then
+             read -r -d '' -a BOOT_OPTIONS < /etc/kernel/cmdline
+         elif [[ -f /usr/lib/kernel/cmdline ]]; then
+             read -r -d '' -a BOOT_OPTIONS < /usr/lib/kernel/cmdline
+@@ -40,14 +82,14 @@
+
+             read -r -d '' -a line < /proc/cmdline
+             for i in "${line[@]}"; do
+-                [[ "${i#initrd=*}" != "$i" ]] && continue
++                [[ ${i#initrd=*} != "$i" ]] && continue
+                 BOOT_OPTIONS+=("$i")
+             done
+         fi
+
+         unset noimageifnotneeded
+
+-        for ((i=0; i < "${#BOOT_OPTIONS[@]}"; i++)); do
++        for ((i = 0; i < "${#BOOT_OPTIONS[@]}"; i++)); do
+             # shellcheck disable=SC1001
+             if [[ ${BOOT_OPTIONS[$i]} == root\=PARTUUID\=* ]]; then
+                 noimageifnotneeded="yes"
+@@ -55,16 +97,21 @@
+             fi
+         done
+
++        # shellcheck disable=SC2046
+         dracut -f \
+             ${noimageifnotneeded:+--noimageifnotneeded} \
+-            $([[ "$KERNEL_INSTALL_VERBOSE" == 1 ]] && echo --verbose) \
+-            "$BOOT_DIR_ABS/$INITRD" \
+-            "$KERNEL_VERSION"
++            $([[ $KERNEL_INSTALL_VERBOSE == 1 ]] && echo --verbose) \
++            $([[ -n $KERNEL_IMAGE ]] && echo --kernel-image "$KERNEL_IMAGE") \
++            "$UEFI_OPTS" \
++            --kver "$KERNEL_VERSION" \
++            "$BOOT_DIR_ABS/$IMAGE"
+         ret=$?
+-	;;
++        ;;
++
+     remove)
+-        rm -f -- "$BOOT_DIR_ABS/$INITRD"
++        rm -f -- "$BOOT_DIR_ABS/$IMAGE"
+         ret=$?
+-	;;
++        ;;
+ esac
++
+ exit $ret


### PR DESCRIPTION
- Fixes installing manually configured kernel in uki layout 
- allows dropping workaround from dist-kernel-utils.eclass
- Provides compatibility with systemd-254's ukify plugin