### PR TITLE
media-gfx/metapixel: Fix call to undeclared function getpid

### DIFF
--- a/media-gfx/metapixel/files/metapixel-1.0.2-clang16-build-fix.patch
+++ b/media-gfx/metapixel/files/metapixel-1.0.2-clang16-build-fix.patch
@@ -1,0 +1,12 @@
+Bug: https://bugs.gentoo.org/896224
+--- a/getopt.c
++++ b/getopt.c
+@@ -39,6 +39,8 @@
+ #endif
+ 
+ #include <stdio.h>
++#include <string.h>
++#include <unistd.h>
+ 
+ /* Comment out all this code if we are using the GNU C Library, and are not
+    actually compiling the library itself.  This code is part of the GNU C

--- a/media-gfx/metapixel/metapixel-1.0.2-r2.ebuild
+++ b/media-gfx/metapixel/metapixel-1.0.2-r2.ebuild
@@ -1,0 +1,45 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+inherit toolchain-funcs
+
+DESCRIPTION="a program for generating photomosaics"
+HOMEPAGE="https://www.complang.tuwien.ac.at/schani/metapixel"
+SRC_URI="https://www.complang.tuwien.ac.at/schani/${PN}/files/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE=""
+
+RDEPEND="
+	dev-lang/perl
+	>=media-libs/giflib-5:0=
+	>=media-libs/libpng-1.4:0=
+	media-libs/libjpeg-turbo
+"
+DEPEND="${RDEPEND}"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-libpng15.patch
+	"${FILESDIR}"/${P}-giflib5.patch
+	"${FILESDIR}"/${P}-clang16-build-fix.patch
+)
+
+src_prepare() {
+	default
+
+	sed -i -e 's:/usr/X11R6:/usr:g' Makefile || die
+	sed -i -e 's:ar:$(AR):' rwimg/Makefile || die
+}
+
+src_compile() {
+	emake AR="$(tc-getAR)" CC="$(tc-getCC)" OPTIMIZE="${CFLAGS}" LDOPTS="${LDFLAGS}"
+}
+
+src_install() {
+	dobin ${PN}{,-prepare,-imagesize,-sizesort}
+	doman ${PN}.1
+	dodoc NEWS README
+}


### PR DESCRIPTION
and update EAPI 6 -> 8

Closes: https://bugs.gentoo.org/896224