### PR TITLE
media-video/jubler: install missing libffdecode.so

### DIFF
--- a/media-video/jubler/jubler-7.0.3-r1.ebuild
+++ b/media-video/jubler/jubler-7.0.3-r1.ebuild
@@ -22,7 +22,7 @@ KEYWORDS="~amd64 ~x86"
 CP_DEPEND="dev-java/appenh:0"
 
 DEPEND="${CP_DEPEND}
-	media-video/ffmpeg:0=
+	<media-video/ffmpeg-5.1.3:0
 	>=virtual/jdk-1.8:*"
 
 RDEPEND="${CP_DEPEND}

--- a/media-video/jubler/jubler-7.0.3.ebuild
+++ b/media-video/jubler/jubler-7.0.3.ebuild
@@ -112,7 +112,7 @@ src_compile() {
 }
 
 src_install() {
-	java-pkg_doso dist/lib/libffdecode.so
+	java-pkg_doso resources/ffmpeg/ffdecode/libffdecode.so
 	java-pkg_dojar "coretheme.jar"
 	local module
 	for module in "${JUBLER_MODULES[@]}"; do


### PR DESCRIPTION
@fordfrog this PR installs the real .sofile, the previous was just the symlink.

but when starting from cmdline launcher still complains like this
```
$ jubler 
Using default language
Registering plugin Multi-platform application support
Registering plugin ASpell checker
Registering plugin Text subtitles
Registering plugin Basic tools
Registering plugin MPlayer media player
Registering plugin Zemberek spell checker
6 plugins found
32 plugin items found
4 listeners found
SystemDependent.mapLibraryName is libffdecode.so
libfile is null
SystemDependent.mapLibraryName is libffdecode_32.so
libfile is null
SystemDependent.mapLibraryName is libffdecode_64.so
libfile is null
Unable to locate library ffdecode
```

