### PR TITLE
{kernel-build,linux-mod-r1,secureboot}.eclass: mark as interactive if key passphrase could be requested

### DIFF
--- a/eclass/kernel-build.eclass
+++ b/eclass/kernel-build.eclass
@@ -105,6 +105,8 @@ if [[ ${KERNEL_IUSE_MODULES_SIGN} ]]; then
 	BDEPEND+="
 		modules-sign? ( dev-libs/openssl )
 	"
+	# The signing key may require a passphrase
+	PROPERTIES="modules-sign? ( interactive )"
 fi
 
 # @FUNCTION: kernel-build_pkg_setup

--- a/eclass/linux-mod-r1.eclass
+++ b/eclass/linux-mod-r1.eclass
@@ -112,6 +112,8 @@ _LINUX_MOD_R1_ECLASS=1
 inherit edo linux-info multiprocessing toolchain-funcs
 
 IUSE="dist-kernel modules-sign +strip ${MODULES_OPTIONAL_IUSE}"
+# The signing key may require a passphrase
+PROPERTIES="modules-sign? ( interactive )"
 
 RDEPEND="
 	sys-apps/kmod[tools]

--- a/eclass/secureboot.eclass
+++ b/eclass/secureboot.eclass
@@ -45,6 +45,8 @@ esac
 
 IUSE="secureboot"
 BDEPEND="secureboot? ( app-crypt/sbsigntools )"
+# The signing key may require a passphrase
+PROPERTIES="secureboot? ( interactive )"
 
 # @ECLASS_VARIABLE: SECUREBOOT_SIGN_KEY
 # @USER_VARIABLE


### PR DESCRIPTION
If `--jobs>1` or `--quiet-build` is enabled we can not see the prompt for the key passphrase and emerge will hang forever. You can still enter the passphrase but you'll have to guess when it is the right time to enter the passphrase.

Specifically for `modules-sign` we have the `KBUILD_SIGN_PIN` env var, but this potentially leaks the PIN as described in the `linux-mod-r1.eclass` documentation. `sbsign` has no such mechanism.

Solution could be to enable the interactive property, but this comes with the disadvantage of forcing `--jobs=1` for the entire emerge.

A potential alternative might be to make something similar to `ebegin`/`eend` that signals to portage that whatever is in between should be sent to stdio even if `--quiet-build`. Something like `ebegin interactive`/`eend interactive`. I do not know if this is at all feasible.

WDYT?

CC @mgorny @ionenwks 
