### PR TITLE
app-misc/neofetch: update LICENSE

### DIFF
--- a/app-misc/neofetch/neofetch-7.1.0-r1.ebuild
+++ b/app-misc/neofetch/neofetch-7.1.0-r1.ebuild
@@ -15,7 +15,7 @@ fi
 
 DESCRIPTION="Simple information system script"
 HOMEPAGE="https://github.com/dylanaraps/neofetch"
-LICENSE="MIT-with-advertising"
+LICENSE="MIT"
 SLOT="0"
 
 PATCHES=(

--- a/app-misc/neofetch/neofetch-7.1.0.ebuild
+++ b/app-misc/neofetch/neofetch-7.1.0.ebuild
@@ -15,7 +15,7 @@ fi
 
 DESCRIPTION="Simple information system script"
 HOMEPAGE="https://github.com/dylanaraps/neofetch"
-LICENSE="MIT-with-advertising"
+LICENSE="MIT"
 SLOT="0"
 IUSE="X"
 

--- a/app-misc/neofetch/neofetch-9999.ebuild
+++ b/app-misc/neofetch/neofetch-9999.ebuild
@@ -15,7 +15,7 @@ fi
 
 DESCRIPTION="Simple information system script"
 HOMEPAGE="https://github.com/dylanaraps/neofetch"
-LICENSE="MIT-with-advertising"
+LICENSE="MIT"
 SLOT="0"
 
 PATCHES=(


### PR DESCRIPTION
As pointed out [in this bug report](https://bugs.gentoo.org/913398#c9), `neofetch`'s license does not have the advertising clause, so it should just be the standard MIT license.