### PR TITLE
sys-apps/hdparm: enable LFS flags

### DIFF
--- a/sys-apps/hdparm/files/hdparm-9.65-graceful-lfs.patch
+++ b/sys-apps/hdparm/files/hdparm-9.65-graceful-lfs.patch
@@ -1,0 +1,16 @@
+# Guard _LARGEFILE64_SOURCE define to avoid warning with append-lfs-flags
+# https://bugs.gentoo.org/914505
+diff --git a/hdparm.c b/hdparm.c
+index eb9796b..a3204f9 100644
+--- a/hdparm.c
++++ b/hdparm.c
+@@ -4,7 +4,9 @@
+  */
+ #define HDPARM_VERSION "v9.65"
+ 
++#ifndef _LARGEFILE64_SOURCE
+ #define _LARGEFILE64_SOURCE /*for lseek64*/
++#endif
+ #define _BSD_SOURCE	/* for strtoll() */
+ #include <unistd.h>
+ #include <stdlib.h>

--- a/sys-apps/hdparm/hdparm-9.65-r2.ebuild
+++ b/sys-apps/hdparm/hdparm-9.65-r2.ebuild
@@ -1,0 +1,50 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs flag-o-matic
+
+DESCRIPTION="Utility to change hard drive performance parameters"
+HOMEPAGE="https://sourceforge.net/projects/hdparm/"
+SRC_URI="mirror://sourceforge/hdparm/${P}.tar.gz"
+
+# GPL-2 only
+LICENSE="BSD GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux"
+IUSE="static"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-9.60-build.patch
+	"${FILESDIR}"/${P}-graceful-lfs.patch
+)
+
+src_prepare() {
+	default
+
+	use static && append-ldflags -static
+}
+
+src_configure() {
+	append-lfs-flags
+}
+
+src_compile() {
+	emake STRIP="true" CC="$(tc-getCC)"
+}
+
+src_install() {
+	into /
+	dosbin hdparm contrib/idectl
+
+	newinitd "${FILESDIR}"/hdparm-init-8 hdparm
+	newconfd "${FILESDIR}"/hdparm-conf.d.3 hdparm
+
+	doman hdparm.8
+	dodoc hdparm.lsm Changelog README.acoustic hdparm-sysconfig
+
+	docinto wiper
+	dodoc wiper/{README.txt,wiper.sh}
+	docompress -x /usr/share/doc/${PF}/wiper/wiper.sh
+}


### PR DESCRIPTION
```
    $ diff -u hdparm-9.65-r1.ebuild hdparm-9.65-r2.ebuild
    --- hdparm-9.65-r1.ebuild       2023-09-22 07:41:40.287176532 +1000
    +++ hdparm-9.65-r2.ebuild       2023-09-22 07:58:18.888053647 +1000
    @@ -17,6 +17,7 @@
    
     PATCHES=(
            "${FILESDIR}"/${PN}-9.60-build.patch
    +       "${FILESDIR}"/${P}-graceful-lfs.patch
     )
    
     src_prepare() {
    @@ -25,6 +26,10 @@
            use static && append-ldflags -static
     }
    
    +src_configure() {
    +       append-lfs-flags
    +}
    +
     src_compile() {
            emake STRIP="true" CC="$(tc-getCC)"
     }

```

Closes: https://bugs.gentoo.org/914505