### PR TITLE
media-plugins/calf: Fixes

### DIFF
--- a/media-plugins/calf/calf-0.90.3-r2.ebuild
+++ b/media-plugins/calf/calf-0.90.3-r2.ebuild
@@ -48,6 +48,7 @@ PATCHES=(
 	"${FILESDIR}/${PN}-0.90.1-desktop.patch"
 	"${FILESDIR}/${PN}-0.90.3-fix-build-with-lld.patch"
 	"${FILESDIR}/${PN}-0.90.3-replace-std-bind2nd.patch"
+	"${FILESDIR}/${PN}-0.90.3-clang-lerp_table_lookup_float_mask.patch"
 )
 
 src_prepare() {

--- a/media-plugins/calf/calf-0.90.3-r2.ebuild
+++ b/media-plugins/calf/calf-0.90.3-r2.ebuild
@@ -46,6 +46,7 @@ PATCHES=(
 	"${FILESDIR}/${PN}-0.90.1-no-automagic.patch"
 	"${FILESDIR}/${PN}-0.90.1-htmldir.patch"
 	"${FILESDIR}/${PN}-0.90.1-desktop.patch"
+	"${FILESDIR}/${PN}-0.90.3-fix-build-with-lld.patch"
 )
 
 src_prepare() {

--- a/media-plugins/calf/calf-0.90.3-r2.ebuild
+++ b/media-plugins/calf/calf-0.90.3-r2.ebuild
@@ -47,6 +47,7 @@ PATCHES=(
 	"${FILESDIR}/${PN}-0.90.1-htmldir.patch"
 	"${FILESDIR}/${PN}-0.90.1-desktop.patch"
 	"${FILESDIR}/${PN}-0.90.3-fix-build-with-lld.patch"
+	"${FILESDIR}/${PN}-0.90.3-replace-std-bind2nd.patch"
 )
 
 src_prepare() {

--- a/media-plugins/calf/calf-0.90.3-r2.ebuild
+++ b/media-plugins/calf/calf-0.90.3-r2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit autotools xdg
+inherit autotools flag-o-matic toolchain-funcs xdg
 
 DESCRIPTION="A set of open source instruments and effects for digital audio workstations"
 HOMEPAGE="https://calf-studio-gear.org/"
@@ -56,7 +56,13 @@ src_prepare() {
 	eautoreconf
 }
 
-src_configure() {
+src_configure()  {
+	# Upstream append -ffast-math by default, however since libtool links C++
+	# shared libs with -nostdlib, this causes symbol resolution error for
+	# __powidn2 when using compiler-rt. Disable fast math on compiler-rt until
+	# a better fix is found.
+	[[ $(tc-get-c-rtlib) = "compiler-rt" ]] && append-cxxflags "-fno-fast-math"
+
 	local myeconfargs=(
 		--prefix="${EPREFIX}"/usr
 		--without-obsolete-check

--- a/media-plugins/calf/calf-9999.ebuild
+++ b/media-plugins/calf/calf-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit autotools xdg
+inherit autotools flag-o-matic toolchain-funcs xdg
 
 DESCRIPTION="A set of open source instruments and effects for digital audio workstations"
 HOMEPAGE="https://calf-studio-gear.org/"
@@ -56,6 +56,12 @@ src_prepare() {
 }
 
 src_configure() {
+	# Upstream append -ffast-math by default, however since libtool links C++
+	# shared libs with -nostdlib, this causes symbol resolution error for
+	# __powidn2 when using compiler-rt. Disable fast math on compiler-rt until
+	# a better fix is found.
+	[[ $(tc-get-c-rtlib) = "compiler-rt" ]] && append-cxxflags "-fno-fast-math"
+
 	local myeconfargs=(
 		--prefix="${EPREFIX}"/usr
 		--without-obsolete-check

--- a/media-plugins/calf/calf-9999.ebuild
+++ b/media-plugins/calf/calf-9999.ebuild
@@ -47,6 +47,7 @@ PATCHES=(
 	"${FILESDIR}/${PN}-0.90.1-htmldir.patch"
 	"${FILESDIR}/${PN}-0.90.1-desktop.patch"
 	"${FILESDIR}/${PN}-9999-fix-build-with-lld.patch"
+	"${FILESDIR}/${PN}-0.90.3-replace-std-bind2nd.patch"
 )
 
 src_prepare() {

--- a/media-plugins/calf/calf-9999.ebuild
+++ b/media-plugins/calf/calf-9999.ebuild
@@ -46,6 +46,7 @@ PATCHES=(
 	"${FILESDIR}/${PN}-0.90.1-no-automagic.patch"
 	"${FILESDIR}/${PN}-0.90.1-htmldir.patch"
 	"${FILESDIR}/${PN}-0.90.1-desktop.patch"
+	"${FILESDIR}/${PN}-9999-fix-build-with-lld.patch"
 )
 
 src_prepare() {

--- a/media-plugins/calf/files/calf-0.90.3-clang-lerp_table_lookup_float_mask.patch
+++ b/media-plugins/calf/files/calf-0.90.3-clang-lerp_table_lookup_float_mask.patch
@@ -1,0 +1,45 @@
+From bfb857445e72230659493d3491970e3cb3c7eb9a Mon Sep 17 00:00:00 2001
+From: Krzysztof Foltman <wdev@foltman.com>
+Date: Fri, 2 Aug 2019 20:55:50 +0100
+Subject: [PATCH] Compatibility: A possible fix for the clang++-8 issue.
+
+---
+ src/calf/fixed_point.h | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/src/calf/fixed_point.h b/src/calf/fixed_point.h
+index 7dbf5c9bc..63bfce167 100644
+--- a/src/calf/fixed_point.h
++++ b/src/calf/fixed_point.h
+@@ -215,7 +215,7 @@ template<class T, int FracBits> class fixed_point {
+     }
+ 
+     template<class U, int UseBits> 
+-    inline U lerp_table_lookup_int(U data[(1U<<IntBits)+1]) const {
++    inline U lerp_table_lookup_int(U *data) const {
+         unsigned int pos = uipart();
+         return lerp_by_fract_int<U, UseBits>(data[pos], data[pos+1]);
+     }
+@@ -223,19 +223,19 @@ template<class T, int FracBits> class fixed_point {
+     /// Untested... I've started it to get a sin/cos readout for rotaryorgan, but decided to use table-less solution instead
+     /// Do not assume it works, because it most probably doesn't
+     template<class U, int UseBits> 
+-    inline U lerp_table_lookup_int_shift(U data[(1U<<IntBits)+1], unsigned int shift) {
++    inline U lerp_table_lookup_int_shift(U *data, unsigned int shift) {
+         unsigned int pos = (uipart() + shift) & ((1ULL << IntBits) - 1);
+         return lerp_by_fract_int<U, UseBits>(data[pos], data[pos+1]);
+     }
+ 
+     template<class U> 
+-    inline U lerp_table_lookup_float(U data[(1U<<IntBits)+1]) const {
++    inline U lerp_table_lookup_float(U *data) const {
+         unsigned int pos = uipart();
+         return data[pos] + (data[pos+1]-data[pos]) * fpart_as_double();
+     }
+ 
+     template<class U> 
+-    inline U lerp_table_lookup_float_mask(U data[(1U<<IntBits)+1], unsigned int mask) const {
++    inline U lerp_table_lookup_float_mask(U *data, unsigned int mask) const {
+         unsigned int pos = ui64part() & mask;
+         // printf("full = %lld pos = %d + %f\n", value, pos, fpart_as_double());
+         return data[pos] + (data[pos+1]-data[pos]) * fpart_as_double();

--- a/media-plugins/calf/files/calf-0.90.3-fix-build-with-lld.patch
+++ b/media-plugins/calf/files/calf-0.90.3-fix-build-with-lld.patch
@@ -1,0 +1,26 @@
+From https://github.com/calf-studio-gear/calf/pull/332/commits/bdaaa92dd82e2425e4683b9d496370c5880e3b3e Mon Sep 17 00:00:00 2001
+From: Violet Purcell <vimproved@inventati.org>
+Date: Thu, 21 Sep 2023 19:08:39 -0400
+Subject: [PATCH] Fix build with LLD
+
+LLVM's LLD handles the -retain-symbols-file option (used by
+-export-symbols-regex in libtool) differently from GNU ld, causing
+undefined references during link. This commit removes the
+-export-symbols-regex option from libcalf_la_LDFLAGS since by default
+libtool exports all symbols anyway, so it should not be necessary.
+
+Signed-off-by: Violet Purcell <vimproved@inventati.org>
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -42,7 +42,7 @@ libcalf_la_LIBADD = $(FLUIDSYNTH_DEPS_LIBS) $(GLIB_DEPS_LIBS)
+ if USE_DEBUG
+ calf_la_LDFLAGS = -rpath $(pkglibdir) -avoid-version -module -lexpat -disable-static
+ else
+-calf_la_LDFLAGS = -rpath $(pkglibdir) -avoid-version -module -lexpat -disable-static -export-symbols-regex "lv2_descriptor"
++calf_la_LDFLAGS = -rpath $(pkglibdir) -avoid-version -module -lexpat -disable-static
+ endif
+ 
+ if USE_LV2_GUI
+-- 
+2.42.0
+

--- a/media-plugins/calf/files/calf-0.90.3-replace-std-bind2nd.patch
+++ b/media-plugins/calf/files/calf-0.90.3-replace-std-bind2nd.patch
@@ -1,0 +1,32 @@
+From https://github.com/calf-studio-gear/calf/pull/331/commits/849a0b589fb86cb4b9869738b270fd24859bd23b Mon Sep 17 00:00:00 2001
+From: Violet Purcell <vimproved@inventati.org>
+Date: Thu, 21 Sep 2023 18:16:35 -0400
+Subject: [PATCH] Replace use of std::bind2nd with std::bind
+
+std::bind2nd was deprecated in C++11 and removed in C++17. Remove usage
+of it and replace with std::bind.
+
+Signed-off-by: Violet Purcell <vimproved@inventati.org>
+--- a/src/calf/orfanidis_eq.h
++++ b/src/calf/orfanidis_eq.h
+@@ -748,7 +748,7 @@ private:
+ 			std::vector<eq_double_t> v = landen(k, tol);
+ 
+ 			std::transform(v.begin(), v.end(), v.begin(),
+-			    bind2nd(std::plus<eq_double_t>(), 1.0));
++			    bind(std::plus<eq_double_t>(), 1.0, std::placeholders::_1));
+ 
+ 			K = std::accumulate(v.begin(), v.end(),
+ 			    1, std::multiplies<eq_double_t>()) * M_PI/2.0;
+@@ -764,7 +764,7 @@ private:
+ 			std::vector<eq_double_t> vp = landen(kp, tol);
+ 
+ 			std::transform(vp.begin(), vp.end(), vp.begin(),
+-			    bind2nd(std::plus<eq_double_t>(), 1.0));
++			    bind(std::plus<eq_double_t>(), 1.0, std::placeholders::_1));
+ 
+ 			Kprime = std::accumulate(vp.begin(), vp.end(),
+ 			    1.0, std::multiplies<eq_double_t>()) * M_PI/2.0;
+-- 
+2.42.0
+

--- a/media-plugins/calf/files/calf-9999-fix-build-with-lld.patch
+++ b/media-plugins/calf/files/calf-9999-fix-build-with-lld.patch
@@ -1,0 +1,26 @@
+From https://github.com/calf-studio-gear/calf/pull/332/commits/bdaaa92dd82e2425e4683b9d496370c5880e3b3e Mon Sep 17 00:00:00 2001
+From: Violet Purcell <vimproved@inventati.org>
+Date: Thu, 21 Sep 2023 19:08:39 -0400
+Subject: [PATCH] Fix build with LLD
+
+LLVM's LLD handles the -retain-symbols-file option (used by
+-export-symbols-regex in libtool) differently from GNU ld, causing
+undefined references during link. This commit removes the
+-export-symbols-regex option from libcalf_la_LDFLAGS since by default
+libtool exports all symbols anyway, so it should not be necessary.
+
+Signed-off-by: Violet Purcell <vimproved@inventati.org>
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -42,7 +42,7 @@ libcalf_la_LIBADD = $(FLUIDSYNTH_DEPS_LIBS) $(GLIB_DEPS_LIBS)
+ if USE_DEBUG
+ libcalf_la_LDFLAGS = -rpath $(pkglibdir) -avoid-version -module -lexpat -disable-static
+ else
+-libcalf_la_LDFLAGS = -rpath $(pkglibdir) -avoid-version -module -lexpat -disable-static -export-symbols-regex "lv2_descriptor"
++libcalf_la_LDFLAGS = -rpath $(pkglibdir) -avoid-version -module -lexpat -disable-static
+ endif
+ 
+ if USE_LV2_GUI
+-- 
+2.42.0
+


### PR DESCRIPTION
This PR contains 4 commits that fix media-plugins/calf using clang, LLD, libc++, and compiler-rt.