### PR TITLE
sys-apps/xdg-desktop-portal: Fix python_setup for USE="-test"

### DIFF
--- a/sys-apps/xdg-desktop-portal/xdg-desktop-portal-1.18.0.ebuild
+++ b/sys-apps/xdg-desktop-portal/xdg-desktop-portal-1.18.0.ebuild
@@ -51,6 +51,10 @@ PATCHES=(
 	"${FILESDIR}/${P}-sandbox-disable-failing-tests.patch"
 )
 
+pkg_setup() {
+	use test && python_setup
+}
+
 python_check_deps() {
 	python_has_version "dev-python/pytest[${PYTHON_USEDEP}]" &&
 	python_has_version "dev-python/python-dbusmock[${PYTHON_USEDEP}]"


### PR DESCRIPTION
Currently, the ebuild always calls python_setup, and in turn, python_check_deps, however with `USE="-test"` the necessary dependencies will not be installed.

Related bug:
https://bugs.gentoo.org/914510