### PR TITLE
systemd.eclass: misc improvements

### DIFF
--- a/eclass/systemd.eclass
+++ b/eclass/systemd.eclass
@@ -1,4 +1,4 @@
-# Copyright 2011-2022 Gentoo Authors
+# Copyright 2011-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: systemd.eclass
@@ -98,7 +98,7 @@ systemd_get_unitdir() {
 systemd_get_userunitdir() {
 	debug-print-function ${FUNCNAME} "${@}"
 
-	_systemd_get_dir systemduserunitdir /usr/lib/systemd/user
+	_systemd_get_dir systemduserunitdir /lib/systemd/user
 }
 
 # @FUNCTION: systemd_get_utildir
@@ -222,7 +222,7 @@ systemd_install_serviced() {
 
 	(
 		insopts -m 0644
-		insinto /etc/systemd/system/"${service}".d
+		insinto "$(_systemd_unprefix systemd_get_systemunitdir)"/"${service}".d
 		newins "${src}" 00gentoo.conf
 	)
 }


### PR DESCRIPTION
1. Set systemd_get_userunitdir's fallback path in-line with other similar fallback paths
2. For dropins (systemd_install_serviced), use /usr/lib/... instead of /etc/...

Snippet from systemd.unit(5)
"In addition to /etc/systemd/system, the drop-in ".d/" directories for system services can be placed in /usr/lib/systemd/system or /run/systemd/system directories."