### PR TITLE
dev-libs/libgpg-error: Use different autogen.sh fix for cross-prefix

### DIFF
--- a/dev-libs/libgpg-error/libgpg-error-1.47-r1.ebuild
+++ b/dev-libs/libgpg-error/libgpg-error-1.47-r1.ebuild
@@ -1,0 +1,86 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+# Maintainers should:
+# 1. Join the "Gentoo" project at https://dev.gnupg.org/project/view/27/
+# 2. Subscribe to release tasks like https://dev.gnupg.org/T6159
+# (find the one for the current release then subscribe to it +
+# any subsequent ones linked within so you're covered for a while.)
+
+VERIFY_SIG_OPENPGP_KEY_PATH="${BROOT}"/usr/share/openpgp-keys/gnupg.asc
+inherit autotools multilib-minimal toolchain-funcs prefix verify-sig
+
+DESCRIPTION="Contains error handling functions used by GnuPG software"
+HOMEPAGE="https://www.gnupg.org/related_software/libgpg-error"
+SRC_URI="mirror://gnupg/${PN}/${P}.tar.bz2"
+SRC_URI+=" verify-sig? ( mirror://gnupg/${PN}/${P}.tar.bz2.sig )"
+
+LICENSE="GPL-2 LGPL-2.1"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~arm64-macos ~ppc-macos ~x64-macos ~x64-solaris"
+IUSE="common-lisp nls static-libs test"
+RESTRICT="!test? ( test )"
+
+RDEPEND="nls? ( >=virtual/libintl-0-r1[${MULTILIB_USEDEP}] )"
+DEPEND="${RDEPEND}"
+BDEPEND="
+	nls? ( sys-devel/gettext )
+	verify-sig? ( sec-keys/openpgp-keys-gnupg )
+"
+
+MULTILIB_WRAPPED_HEADERS=(
+	/usr/include/gpg-error.h
+	/usr/include/gpgrt.h
+)
+
+MULTILIB_CHOST_TOOLS=(
+	/usr/bin/gpg-error-config
+	/usr/bin/gpgrt-config
+)
+
+PATCHES=(
+	"${FILESDIR}/${PN}-1.44-remove_broken_check.patch"
+)
+
+src_prepare() {
+	default
+
+	if use prefix ; then
+		# don't hardcode /usr/xpg4/bin/sh as shell on Solaris
+		sed -i -e 's/solaris\*/disabled/' configure.ac || die
+	fi
+
+	# only necessary for as long as we run eautoreconf, configure.ac
+	# uses ./autogen.sh to generate PACKAGE_VERSION, but autogen.sh is
+	# not a pure /bin/sh script, so it fails on some hosts
+	sed -i -e "1s:.*:#\!${BASH}:" autogen.sh || die
+	eautoreconf
+}
+
+multilib_src_configure() {
+	local myeconfargs=(
+		$(multilib_is_native_abi || echo --disable-languages)
+		$(use_enable common-lisp languages)
+		$(use_enable nls)
+		# required for sys-power/suspend[crypt], bug 751568
+		$(use_enable static-libs static)
+		$(use_enable test tests)
+
+		# See bug #699206 and its duplicates wrt gpgme-config
+		# Upstream no longer install this by default and we should
+		# seek to disable it at some point.
+		--enable-install-gpg-error-config
+
+		--enable-threads
+		CC_FOR_BUILD="$(tc-getBUILD_CC)"
+		$("${S}/configure" --help | grep -o -- '--without-.*-prefix')
+	)
+	ECONF_SOURCE="${S}" econf "${myeconfargs[@]}"
+}
+
+multilib_src_install_all() {
+	einstalldocs
+	find "${ED}" -type f -name '*.la' -delete || die
+}


### PR DESCRIPTION
hprefixify uses `${EPREFIX}`, which may not be executable or may not even exist at all in a cross-prefix situation. Make autogen.sh execute using the same Bash interpreter as the package manager. Unfortunately, there doesn't seem to be a non-Bash-specific way to do this, so we cannot address this upstream.

Actual diff:
```diff
--- libgpg-error-1.47.ebuild    2023-09-23 18:30:04.473941387 +0100
+++ libgpg-error-1.47-r1.ebuild 2023-09-23 18:45:35.984689375 +0100
@@ -19,7 +19,7 @@
 
 LICENSE="GPL-2 LGPL-2.1"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux ~arm64-macos ~ppc-macos ~x64-macos ~x64-solaris"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~arm64-macos ~ppc-macos ~x64-macos ~x64-solaris"
 IUSE="common-lisp nls static-libs test"
 RESTRICT="!test? ( test )"
 
@@ -55,7 +55,7 @@
        # only necessary for as long as we run eautoreconf, configure.ac
        # uses ./autogen.sh to generate PACKAGE_VERSION, but autogen.sh is
        # not a pure /bin/sh script, so it fails on some hosts
-       hprefixify -w 1 autogen.sh
+       sed -i -e "1s:.*:#\!${BASH}:" autogen.sh || die
        eautoreconf
 }
```

I wasn't sure whether to revbump or not. Decided to play it safe.

I didn't actually see any evidence that there was a problem with the autogen.sh script, even back in 1.36. It seems to run fine under dash and bash 2.05b, but apparently grobian saw an issue.