### PR TITLE
media-sound/ardour: Fix libc++ patch

### DIFF
--- a/media-sound/ardour/ardour-9999.ebuild
+++ b/media-sound/ardour/ardour-9999.ebuild
@@ -73,7 +73,6 @@ DEPEND="${RDEPEND}
 
 PATCHES=(
 	"${FILESDIR}/${PN}-6.8-metadata.patch"
-	"${FILESDIR}/${PN}-7.4-libc++.patch"
 )
 
 pkg_pretend() {

--- a/media-sound/ardour/files/ardour-7.4-libc++.patch
+++ b/media-sound/ardour/files/ardour-7.4-libc++.patch
@@ -13,9 +13,9 @@ Signed-off-by: Violet Purcell <vimproved@inventati.org>
  #endif
  
  #if SMTG_OS_LINUX
-+#if !defined (SMTG_USE_STDATOMIC_H)
++#if !defined (SMTG_USE_ATOMIC)
 +#if defined (_LIBCPP_VERSION)
-+#define SMTG_USE_STDATOMIC_H 1
++#define SMTG_USE_ATOMIC 1
 +#else
  #include <ext/atomicity.h>
 +#endif
@@ -26,8 +26,8 @@ Signed-off-by: Violet Purcell <vimproved@inventati.org>
  #include <boost/uuid/uuid_generators.hpp>
  #endif
  
-+#if defined (SMTG_USE_STDATOMIC_H) && SMTG_USE_STDATOMIC_H
-+#include <stdatomic.h>
++#if defined (SMTG_USE_ATOMIC) && SMTG_USE_ATOMIC
++#include <atomic>
 +#endif
 +
  namespace Steinberg {
@@ -38,8 +38,8 @@ Signed-off-by: Violet Purcell <vimproved@inventati.org>
  int32 PLUGIN_API atomicAdd (int32& var, int32 d)
  {
 -#if SMTG_OS_WINDOWS
-+#if SMTG_USE_STDATOMIC_H
-+	return atomic_fetch_add (reinterpret_cast<atomic_int_least32_t*> (&var), d) +d;
++#if SMTG_USE_ATOMIC
++	return atomic_fetch_add (reinterpret_cast<std::atomic_int_least32_t*> (&var), d) +d;
 +#elif SMTG_OS_WINDOWS
  	return InterlockedExchangeAdd ((volatile long int*)&var, d) + d;
  #elif SMTG_OS_MACOS


### PR DESCRIPTION
Fix libc++ patch and remove from 9999.

Upstream-PR: https://github.com/Ardour/ardour/pull/824