### PR TITLE
dev-libs/cutlass: use ${ED} as install destination for prefix

### DIFF
--- a/dev-libs/cutlass/cutlass-2.10.0-r1.ebuild
+++ b/dev-libs/cutlass/cutlass-2.10.0-r1.ebuild
@@ -34,5 +34,5 @@ src_configure() {
 
 src_install() {
 	cmake_src_install
-	rm -r "${D}"/usr/test || die
+	rm -r "${ED}"/usr/test || die
 }


### PR DESCRIPTION
Otherwise the rm command fails due to non-existing ${D}/usr/test