### PR TITLE
net-analyzer/xprobe: Fix C++17 does not allow register storage class

### DIFF
--- a/net-analyzer/xprobe/files/xprobe-0.3-clang16-build-fix.patch
+++ b/net-analyzer/xprobe/files/xprobe-0.3-clang16-build-fix.patch
@@ -1,0 +1,48 @@
+Bug: https://bugs.gentoo.org/897838
+--- a/libs-external/USI++/src/misc.cc
++++ b/libs-external/USI++/src/misc.cc
+@@ -18,9 +18,9 @@ unsigned short
+ in_cksum (unsigned short *ptr, int nbytes, bool may_pad)
+ {
+ 
+-  register long sum;		/* assumes long == 32 bits */
++  long sum;		/* assumes long == 32 bits */
+   u_short oddbyte;
+-  register u_short answer;	/* assumes u_short == 16 bits */
++  u_short answer;	/* assumes u_short == 16 bits */
+ 
+ 
+   /* For psuedo-headers: odd len's require
+--- a/src/target.cc
++++ b/src/target.cc
+@@ -28,6 +28,7 @@
+ #include "os_matrix.h"
+ #include "xplib/xplib.h"
+ #include "log.h"
++#include <random>
+ 
+ extern Interface *ui;
+ extern Xprobe_Module_Hdlr   *xmh;
+@@ -370,7 +371,10 @@ int Port_Range::get_next(u_short *port) {
+ 		// initialize
+ 		for (k=0; k < sz; k++) 
+ 			ports.push_back(low + k);
+-		random_shuffle(ports.begin(), ports.end());
++		// https://en.cppreference.com/w/cpp/algorithm/random_shuffle
++		random_device rd;
++		mt19937 g(rd());
++		shuffle(ports.begin(), ports.end(), g);
+ 		*port = ports[curr++];
+ 	} else 
+ 		*port = ports[curr++];
+--- a/src/xplib/xp_lib.cc
++++ b/src/xplib/xp_lib.cc
+@@ -82,7 +82,7 @@ int xp_lib::OpenUDPSocket(struct sockaddr_in *to, struct sockaddr_in *bind_sin)
+ 		return FAIL;
+ 	}
+ 	if (bind_sin != NULL)
+-		if (bind(sock, (struct sockaddr *)bind_sin, sizeof(struct sockaddr_in)) == -1) {
++		if (::bind(sock, (struct sockaddr *)bind_sin, sizeof(struct sockaddr_in)) == -1) {
+ 			return FAIL;
+ 		}
+ 

--- a/net-analyzer/xprobe/xprobe-0.3-r2.ebuild
+++ b/net-analyzer/xprobe/xprobe-0.3-r2.ebuild
@@ -1,0 +1,42 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs
+
+MY_P=${PN}2-${PV}
+
+DESCRIPTION="Active OS fingerprinting tool - this is Xprobe2"
+HOMEPAGE="http://sys-security.com/blog/xprobe2"
+SRC_URI="mirror://sourceforge/${PN}/${MY_P}.tar.gz"
+S="${WORKDIR}"/${MY_P}
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~sparc ~x86"
+
+DEPEND="net-libs/libpcap"
+RDEPEND="${DEPEND}"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-gcc43.patch
+	"${FILESDIR}"/${P}-cxx11.patch
+	"${FILESDIR}"/${P}-gcc-12.patch
+	"${FILESDIR}"/${P}-clang16-build-fix.patch
+)
+
+src_prepare() {
+	default
+
+	sed -i -e 's:strip:true:' src/Makefile.in || die
+	sed -i -e 's:ar cr:$(AR) cr:g' $(find -name '*Makefile*') || die
+
+	tc-export AR
+}
+
+src_install() {
+	default
+
+	dodoc AUTHORS CHANGELOG CREDITS README TODO docs/*.{txt,pdf}
+}


### PR DESCRIPTION
Plus some other build errors related to clang 16 and update EAPI 7 -> 8

Closes: https://bugs.gentoo.org/897838