### PR TITLE
net-news/amphetadesk: EAPI8 bump, use https

### DIFF
--- a/net-news/amphetadesk/amphetadesk-0.93.1-r2.ebuild
+++ b/net-news/amphetadesk/amphetadesk-0.93.1-r2.ebuild
@@ -1,0 +1,42 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DESCRIPTION="Free syndicated news aggregator"
+HOMEPAGE="https://www.disobey.com/amphetadesk/"
+SRC_URI="mirror://sourceforge/sourceforge/amphetadesk/${PN}-src-v${PV}.tar.gz"
+S="${WORKDIR}/${PN}-src-v${PV}"
+
+LICENSE="Artistic"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86"
+
+DEPEND="dev-lang/perl
+	dev-perl/libwww-perl
+	dev-libs/expat
+	dev-perl/XML-Parser
+	virtual/perl-IO-Compress"
+
+src_install() {
+	dodir /usr/share/amphetadesk
+	cp "${S}"/AmphetaDesk.pl "${D}"/usr/share/amphetadesk/AmphetaDesk.pl || die
+	dodoc README.txt
+	cp -R "${S}"/data "${D}"/usr/share/amphetadesk || die
+	cp -R "${S}"/docs "${D}"/usr/share/amphetadesk || die
+	cp -R "${S}"/lib "${D}"/usr/share/amphetadesk || die
+	cp -R "${S}"/templates "${D}"/usr/share/amphetadesk || die
+	newinitd "${FILESDIR}"/amphetadesk.initd amphetadesk || die
+}
+
+pkg_postinst() {
+	# fixes bug #25066 thanks to kloeri
+	/etc/init.d/depscan.sh
+
+	einfo "AmphetaDesk should be started and stopped with the runscript located at "
+	einfo "'/etc/init.d/amphetadesk'. You can access AmphetaDesk after it has been"
+	einfo "started in your browser of choice on port 8888."
+	einfo ""
+	ewarn "If you start AmphetaDesk at boot with rc-update don't give it a browser"
+	ewarn "to start up when it loads (in the options page)"
+}


### PR DESCRIPTION
Simple `EAPI8` bump:

```diff
1c1
< # Copyright 1999-2022 Gentoo Authors
---
> # Copyright 1999-2023 Gentoo Authors
4c4
< EAPI=6
---
> EAPI=8
6,7c6,7
< DESCRIPTION="AmphetaDesk is a free syndicated news aggregator"
< HOMEPAGE="http://www.disobey.com/amphetadesk/"
---
> DESCRIPTION="Free syndicated news aggregator"
> HOMEPAGE="https://www.disobey.com/amphetadesk/"
8a9,10
> S="${WORKDIR}/${PN}-src-v${PV}"
> 
11,12c13,14
< KEYWORDS="~amd64 ~ppc x86"
< IUSE=""
---
> KEYWORDS="~amd64 ~ppc ~x86"
> 
18d19
< S=${WORKDIR}/${PN}-src-v${PV}
22c23
< 	cp "${S}"/AmphetaDesk.pl "${D}"/usr/share/amphetadesk/AmphetaDesk.pl
---
> 	cp "${S}"/AmphetaDesk.pl "${D}"/usr/share/amphetadesk/AmphetaDesk.pl || die
24,28c25,29
< 	cp -R "${S}"/data "${D}"/usr/share/amphetadesk
< 	cp -R "${S}"/docs "${D}"/usr/share/amphetadesk
< 	cp -R "${S}"/lib "${D}"/usr/share/amphetadesk
< 	cp -R "${S}"/templates "${D}"/usr/share/amphetadesk
< 	newinitd "${FILESDIR}"/amphetadesk.initd amphetadesk
---
> 	cp -R "${S}"/data "${D}"/usr/share/amphetadesk || die
> 	cp -R "${S}"/docs "${D}"/usr/share/amphetadesk || die
> 	cp -R "${S}"/lib "${D}"/usr/share/amphetadesk || die
> 	cp -R "${S}"/templates "${D}"/usr/share/amphetadesk || die
> 	newinitd "${FILESDIR}"/amphetadesk.initd amphetadesk || die
```