### PR TITLE
dev-libs/libgee: Call vala_setup in pkg_setup

### DIFF
--- a/dev-libs/libgee/libgee-0.20.6.ebuild
+++ b/dev-libs/libgee/libgee-0.20.6.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit gnome2
+inherit gnome2 vala
 
 DESCRIPTION="GObject-based interfaces and classes for commonly used data structures"
 HOMEPAGE="https://wiki.gnome.org/Projects/Libgee"
@@ -21,8 +21,11 @@ RDEPEND="
 DEPEND="${RDEPEND}"
 BDEPEND="virtual/pkgconfig"
 
+pkg_setup() {
+	vala_setup
+}
+
 src_configure() {
 	gnome2_src_configure \
-		$(use_enable introspection) \
-		VALAC="$(type -P false)"
+		$(use_enable introspection)
 }


### PR DESCRIPTION
libgee is written in vala, but the generated C sources are included in the release tarballs. However, vala_setup also includes the workaround for clang 16+, so call it here anyway.

Closes: https://bugs.gentoo.org/894376