### PR TITLE
media-sound/mpfc: EAPI8 bump, use https

### DIFF
--- a/media-sound/mpfc/mpfc-1.3.8.1-r5.ebuild
+++ b/media-sound/mpfc/mpfc-1.3.8.1-r5.ebuild
@@ -1,0 +1,60 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools
+
+DESCRIPTION="Music Player For Console"
+HOMEPAGE="https://mpfc.sourceforge.net/"
+SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86"
+IUSE="alsa cdda flac gpm mad nls oss static-libs vorbis wav"
+
+RDEPEND="alsa? ( >=media-libs/alsa-lib-0.9.0 )
+	flac? ( media-libs/flac:= )
+	gpm? ( >=sys-libs/gpm-1.19.3 )
+	mad? ( media-libs/libmad )
+	vorbis? ( media-libs/libvorbis )
+	sys-libs/ncurses:=[unicode(+)]
+	dev-libs/icu:="
+DEPEND="${RDEPEND}"
+
+PATCHES=(
+	"${FILESDIR}/${P}-fix-underlinking.patch"
+	"${FILESDIR}/${P}-qa-implicit-declarations.patch"
+)
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_configure() {
+	local myeconfargs=(
+		$(use_enable alsa)
+		$(use_enable cdda audiocd)
+		$(use_enable flac)
+		$(use_enable gpm)
+		$(use_enable mad mp3)
+		$(use_enable nls)
+		$(use_enable oss)
+		$(use_enable static-libs static)
+		$(use_enable vorbis ogg)
+		$(use_enable wav)
+	)
+	econf "${myeconfargs[@]}"
+}
+
+src_install() {
+	default
+
+	insinto /etc
+	doins mpfcrc
+
+	# package provides .pc files
+	find "${D}" -name '*.la' -delete || die
+}


### PR DESCRIPTION
Anoterh simple `EAPI8` bump:

```diff
1c1
< # Copyright 1999-2022 Gentoo Authors
---
> # Copyright 1999-2023 Gentoo Authors
4c4
< EAPI=6
---
> EAPI=8
9c9
< HOMEPAGE="http://mpfc.sourceforge.net/"
---
> HOMEPAGE="https://mpfc.sourceforge.net/"
14c14
< KEYWORDS="amd64 ppc x86"
---
> KEYWORDS="~amd64 ~ppc ~x86"
```