### PR TITLE
toolchain.eclass: fix should_we_gcc_config for major-version slotting

### DIFF
--- a/eclass/toolchain.eclass
+++ b/eclass/toolchain.eclass
@@ -2244,7 +2244,9 @@ should_we_gcc_config() {
 
 	local curr_branch_ver=$(ver_cut 1-2 ${curr_config_ver})
 
-	if [[ ${curr_branch_ver} == ${GCC_BRANCH_VER} ]] ; then
+	if tc_use_major_version_only && [[ ${curr_config_ver} == ${GCCMAJOR} ]] ; then
+		return 0
+	elif ! tc_use_major_version_only && [[ ${curr_branch_ver} == ${GCC_BRANCH_VER} ]] ; then
 		return 0
 	else
 		# If we're installing a genuinely different compiler version,


### PR DESCRIPTION
Reported by the-horo on IRC.

For example, with slot as major version:
```
$ gcc-config -c x86_64-pc-linux-gnu
x86_64-pc-linux-gnu-13
$ gcc-config -S x86_64-pc-linux-gnu-13
x86_64-pc-linux-gnu 13
```
so we're indeed comparing 13 with 13.2 and hence we decide to run gcc-config unnecessarily because we think it's a major version change.

Fix that by taking into account tc_use_major_version_only and comparing based on GCCMAJOR for that case.

Bug: https://bugs.gentoo.org/865835
Bug: https://bugs.gentoo.org/873505
Reported-by: the-horo