### PR TITLE
sci-misc/boinc: update wxGTK dependency for live

### DIFF
--- a/sci-misc/boinc/boinc-9999.ebuild
+++ b/sci-misc/boinc/boinc-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -6,7 +6,7 @@ EAPI=8
 # For live ebuilds this should be set to the latest available patch in ${FILESDIR}
 # It does not need to reflect the actual internal version reported by BOINC unless that patch is broken.
 MY_PV=7.18
-WX_GTK_VER=3.0-gtk3
+WX_GTK_VER=3.2-gtk3
 
 inherit autotools desktop flag-o-matic linux-info optfeature wxwidgets xdg-utils
 


### PR DESCRIPTION
About three months ago it began to require 3.1.3 at minimum.

I've set the requirement to `3.2-gtk3` as the lowest working version in ::gentoo - I don't see us going back to add 3.1!

See: https://github.com/BOINC/boinc/commit/ac988fd70844b25a1782a66a0e460b85f63d46e8