### PR TITLE
media-sound/cdtool: Fix call to undeclared function open

### DIFF
--- a/media-sound/cdtool/cdtool-2.1.8-r2.ebuild
+++ b/media-sound/cdtool/cdtool-2.1.8-r2.ebuild
@@ -1,0 +1,21 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DESCRIPTION="collection of command-line utilities to control cdrom devices"
+HOMEPAGE="http://hinterhof.net/cdtool/"
+SRC_URI="http://hinterhof.net/cdtool/dist/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~sparc ~x86"
+IUSE=""
+
+RDEPEND="!media-sound/cdplay"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-glibc-2.10.patch
+	"${FILESDIR}"/${P}-fix-build-system.patch
+	"${FILESDIR}"/${P}-fix-build-clang16.patch
+)

--- a/media-sound/cdtool/files/cdtool-2.1.8-fix-build-clang16.patch
+++ b/media-sound/cdtool/files/cdtool-2.1.8-fix-build-clang16.patch
@@ -1,0 +1,11 @@
+Bug: https://bugs.gentoo.org/896426
+--- a/commands.c
++++ b/commands.c
+@@ -26,6 +26,7 @@
+ #include <errno.h>
+ #include <string.h>
+ #include <signal.h>
++#include <fcntl.h>
+ 
+ #include "config.h"
+ #include "cdtool.h"


### PR DESCRIPTION
and update EAPI 7 -> 8

Closes: https://bugs.gentoo.org/896426