### PR TITLE
gui-wm/dwl: fix RDEPEND

### DIFF
--- a/gui-wm/dwl/dwl-0.4-r1.ebuild
+++ b/gui-wm/dwl/dwl-0.4-r1.ebuild
@@ -38,7 +38,7 @@ IUSE="X"
 RDEPEND="
 	dev-libs/libinput:=
 	dev-libs/wayland
-	gui-libs/wlroots:${WLROOTS_SLOT}[X(-)?]
+	gui-libs/wlroots:${WLROOTS_SLOT}[libinput(+),X?]
 	x11-libs/libxkbcommon
 	X? (
 		x11-libs/libxcb:=

--- a/gui-wm/dwl/dwl-9999-r1.ebuild
+++ b/gui-wm/dwl/dwl-9999-r1.ebuild
@@ -38,7 +38,7 @@ IUSE="X"
 RDEPEND="
 	dev-libs/libinput:=
 	dev-libs/wayland
-	gui-libs/wlroots:${WLROOTS_SLOT}[X(-)?]
+	gui-libs/wlroots:${WLROOTS_SLOT}[libinput,session,X?]
 	x11-libs/libxkbcommon
 	X? (
 		x11-libs/libxcb:=

--- a/gui-wm/dwl/dwl-9999.ebuild
+++ b/gui-wm/dwl/dwl-9999.ebuild
@@ -38,7 +38,7 @@ IUSE="X"
 RDEPEND="
 	dev-libs/libinput:=
 	dev-libs/wayland
-	gui-libs/wlroots:${WLROOTS_SLOT}[X(-)?]
+	gui-libs/wlroots:${WLROOTS_SLOT}[libinput(+),X?]
 	x11-libs/libxkbcommon
 	X? (
 		x11-libs/libxcb:=


### PR DESCRIPTION
dwl requires libinput support in wlroots
gui-libs/wlroots[drm] is recommended but not required

also drop the default value for IUSE=X in wlroots, it's useless since *all* versions of wlroots have that USE

Closes: https://bugs.gentoo.org/914641