### PR TITLE
dev-libs/libcgroup: fix patching

### DIFF
--- a/dev-libs/libcgroup/libcgroup-0.41-r6.ebuild
+++ b/dev-libs/libcgroup/libcgroup-0.41-r6.ebuild
@@ -28,8 +28,8 @@ DEPEND="pam? ( sys-libs/pam )"
 RDEPEND="${DEPEND}"
 
 PATCHES=(
-	"${FILESDIR}"/${P}-replace-DECLS.patch
-	"${FILESDIR}"/${P}-replace-INLCUDES.patch
+	"${FILESDIR}"/${P}-replace_DECLS.patch
+	"${FILESDIR}"/${P}-replace_INLCUDES.patch
 	"${FILESDIR}"/${P}-reorder-headers.patch
 	"${FILESDIR}"/${P}-remove-umask.patch
 	"${FILESDIR}"/${P}-slibtool.patch


### PR DESCRIPTION
This seemed to be an oversight. With the correct name, patching works as expected.