### PR TITLE
media-libs/mesa: 23.2.0_rc4 llvm slot to 17

### DIFF
--- a/media-libs/mesa/mesa-23.2.0_rc4.ebuild
+++ b/media-libs/mesa/mesa-23.2.0_rc4.ebuild
@@ -125,8 +125,8 @@ RDEPEND="${RDEPEND}
 # How to use it:
 # 1. Specify LLVM_MAX_SLOT (inclusive), e.g. 16.
 # 2. Specify LLVM_MIN_SLOT (inclusive), e.g. 15.
-LLVM_MAX_SLOT="16"
-LLVM_MIN_SLOT="15"
+LLVM_MAX_SLOT="17"
+LLVM_MIN_SLOT="17"
 LLVM_USE_DEPS="llvm_targets_AMDGPU(+),${MULTILIB_USEDEP}"
 PER_SLOT_DEPSTR="
 	(


### PR DESCRIPTION
Needs llvm-17 to build sucessfully.

Closes: https://bugs.gentoo.org/914742