### PR TITLE
net-dialup/ppp: add missing openssl and pam configure options

### DIFF
--- a/net-dialup/ppp/ppp-2.5.0-r5.ebuild
+++ b/net-dialup/ppp/ppp-2.5.0-r5.ebuild
@@ -85,10 +85,11 @@ src_configure() {
 		--runstatedir="${EPREFIX}"/run
 		$(use_enable systemd)
 		$(use_with atm)
-		$(use_with pam)
+		$(usex pam --with-pam="${SYSROOT}/usr/" --without-pam)
 		$(use_with activefilter pcap)
 		$(use_with gtk)
 		--enable-cbcp
+		--with-openssl="${SYSROOT}/usr/"
 	)
 	econf "${args[@]}"
 }


### PR DESCRIPTION
For net-dialup/ppp there are missing options in econf array. Because openssl and pam are DEPENDS, their headers should be searched in ${SYSROOT}. This can be done with proper configure options. Below important fragments of diff between config.log files (cross compilation for arm example).

--- config.log.orig     2023-09-27 16:13:35.870667419 +0200
+++ config.log         2023-09-27 16:09:38.784557342 +0200

-  $ ./configure --prefix=/usr --build=x86_64-pc-linux-gnu --host=armv7a-hardfloat-linux-gnueabi --mandir=/usr/share/man --infodir=/usr/share/info --datadir=/usr/share --sysconfdir=/etc --localstatedir=/var/lib --datarootdir=/usr/share --disable-dependency-tracking --disable-silent-rules --disable-static --docdir=/usr/share/doc/ppp-2.5.0-r5 --htmldir=/usr/share/doc/ppp-2.5.0-r5/html --with-sysroot=/usr/armv7a-hardfloat-linux-gnueabi --localstatedir=/var --runstatedir=/run --disable-systemd --without-atm --with-pam --without-pcap --without-gtk --enable-cbcp
+  $ ./configure --prefix=/usr --build=x86_64-pc-linux-gnu --host=armv7a-hardfloat-linux-gnueabi --mandir=/usr/share/man --infodir=/usr/share/info --datadir=/usr/share --sysconfdir=/etc --localstatedir=/var/lib --datarootdir=/usr/share --disable-dependency-tracking --disable-silent-rules --disable-static --docdir=/usr/share/doc/ppp-2.5.0-r5 --htmldir=/usr/share/doc/ppp-2.5.0-r5/html --with-sysroot=/usr/armv7a-hardfloat-linux-gnueabi --with-openssl=/usr/armv7a-hardfloat-linux-gnueabi/usr/ --localstatedir=/var --runstatedir=/run --disable-systemd --without-atm --with-pam=/usr/armv7a-hardfloat-linux-gnueabi/usr/ --without-pcap --without-gtk --enable-cbcp

-configure:14206: checking for openssl/ssl.h in /usr/local/ssl
-configure:14221: result: no
-configure:14206: checking for openssl/ssl.h in /usr/lib/ssl
-configure:14221: result: no
-configure:14206: checking for openssl/ssl.h in /usr/ssl
-configure:14221: result: no
-configure:14206: checking for openssl/ssl.h in /usr/pkg
-configure:14221: result: no
-configure:14206: checking for openssl/ssl.h in /usr/local
-configure:14221: result: no
-configure:14206: checking for openssl/ssl.h in /usr
+configure:14206: checking for openssl/ssl.h in /usr/armv7a-hardfloat-linux-gnueabi/usr/
 configure:14215: result: yes
 
-configure:14936: checking for pam_appl.h in /usr/local
-configure:14945: result: no
-configure:14936: checking for pam_appl.h in /usr/lib
+configure:14936: checking for pam_appl.h in /usr/armv7a-hardfloat-linux-gnueabi
 configure:14945: result: no
-configure:14936: checking for pam_appl.h in /usr
-configure:14941: result: yes