### PR TITLE
net-dns/dnstop: EAPI8 bump, update HOMEPAGE, SRC_URI, fix #717202

### DIFF
--- a/net-dns/dnstop/dnstop-20140915-r3.ebuild
+++ b/net-dns/dnstop/dnstop-20140915-r3.ebuild
@@ -1,0 +1,39 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools flag-o-matic
+
+DESCRIPTION="Displays various tables of DNS traffic on your network"
+HOMEPAGE="https://github.com/measurement-factory/dnstop"
+SRC_URI="http://dns.measurement-factory.com/tools/dnstop/src/${P}.tar.gz"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~hppa ~ppc ~x86"
+
+RDEPEND="sys-libs/ncurses:0
+	net-libs/libpcap"
+DEPEND="${RDEPEND}"
+
+PATCHES=(
+	"${FILESDIR}/${P}"-pkg-config.patch
+	"${FILESDIR}/${P}"-musl-fix.patch
+	)
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_configure() {
+	append-cflags -D_GNU_SOURCE
+	econf --enable-ipv6
+}
+
+src_install() {
+	dobin dnstop
+	doman dnstop.8
+	dodoc CHANGES
+}

--- a/net-dns/dnstop/files/dnstop-20140915-musl-fix.patch
+++ b/net-dns/dnstop/files/dnstop-20140915-musl-fix.patch
@@ -1,0 +1,16 @@
+Fixes compilation with musl
+Patch by Natanael Copa
+https://gitlab.alpinelinux.org/alpine/aports/-/issues/2890
+https://bugs.gentoo.org/717202
+
+--- a/dnstop.c.orig
++++ a/dnstop.c
+@@ -69,7 +69,7 @@
+ #define ETHERTYPE_IPV6 0x86DD
+ #endif
+ 
+-#if defined(__linux__) || defined(__GLIBC__) || defined(__GNU__)
++#if defined(__GLIBC__) || defined(__GNU__)
+ #define uh_dport dest
+ #define uh_sport source
+ #endif

--- a/net-dns/dnstop/metadata.xml
+++ b/net-dns/dnstop/metadata.xml
@@ -5,5 +5,7 @@
   <upstream>
     <changelog>http://dns.measurement-factory.com/tools/dnstop/src/CHANGES</changelog>
     <doc>http://dns.measurement-factory.com/tools/dnstop/dnstop.8.html</doc>
+    <remote-id type="github">measurement-factory/dnstop</remote-id>
+    <bugs-to>https://github.com/measurement-factory/dnstop/issues</bugs-to>
   </upstream>
 </pkgmetadata>


### PR DESCRIPTION
Hi,

This updates `dnstop` for EAPI8.
I've also briefly looked over the open bugs. There was an patch linked in #717202 which i've included in the ebuild. There is also a note at the upstream github page regarding `musl`:
https://github.com/measurement-factory/dnstop/commit/9a16dd4814d680d0a9949ee52398461a1e0f72dc
I don't know if that fixes the second bug, but i've included the hint in the ebuild.

Unfortunately i don't have an musl system around so it would be nice if someone could confirm these changes fixes the issues.

Signed-off-by: Michael Mair-Keimberger <mmk@levelnine.at>

Closes: https://bugs.gentoo.org/717202
Bug: https://bugs.gentoo.org/907753