### PR TITLE
toolchain.eclass: rework bootstrapping logic

### DIFF
--- a/eclass/toolchain.eclass
+++ b/eclass/toolchain.eclass
@@ -1354,20 +1354,43 @@ toolchain_src_configure() {
 	if is_jit ; then
 		einfo "Configuring JIT gcc"
 
+		local confgcc_jit=(
+			"${confgcc[@]}"
+
+			--disable-analyzer
+			--disable-bootstrap
+			--disable-cet
+			--disable-default-pie
+			--disable-default-ssp
+			--disable-gcov
+			--disable-libada
+			--disable-libatomic
+			--disable-libgomp
+			--disable-libitm
+			--disable-libquadmath
+			--disable-libsanitizer
+			--disable-libssp
+			--disable-libstdcxx-pch
+			--disable-libvtv
+			--disable-lto
+			--disable-nls
+			--disable-objc-gc
+			--disable-systemtap
+			--enable-host-shared
+			--enable-languages=jit
+			--without-isl
+			--without-zstd
+			--with-system-zlib
+		)
+
+		if tc_version_is_at_least 13.1 ; then
+			confgcc_jit+=( --disable-fixincludes )
+		fi
+
 		mkdir -p "${WORKDIR}"/build-jit || die
 		pushd "${WORKDIR}"/build-jit > /dev/null || die
-		CONFIG_SHELL="${gcc_shell}" edo "${gcc_shell}" "${S}"/configure \
-				"${confgcc[@]}" \
-				--disable-libada \
-				--disable-libsanitizer \
-				--disable-libvtv \
-				--disable-libgomp \
-				--disable-libquadmath \
-				--disable-libatomic \
-				--disable-lto \
-				--disable-bootstrap \
-				--enable-host-shared \
-				--enable-languages=jit
+
+		CONFIG_SHELL="${gcc_shell}" edo "${gcc_shell}" "${S}"/configure "${confgcc_jit[@]}"
 		popd > /dev/null || die
 	fi
 
@@ -1701,11 +1724,8 @@ gcc_do_make() {
 
 	if is_jit ; then
 		# TODO: docs for jit?
-		pushd "${WORKDIR}"/build-jit > /dev/null || die
-
 		einfo "Building JIT"
-		emake "${emakeargs[@]}"
-		popd > /dev/null || die
+		emake -C "${WORKDIR}"/build-jit "${emakeargs[@]}"
 	fi
 
 	einfo "Compiling ${PN} (${GCC_MAKE_TARGET})..."


### PR DESCRIPTION
toolchain.eclass: rework bootstrapping logic

* Build stage1 compiler with user's CFLAGS. This consistently ends up
  saving at least 15 minutes for me on a fast amd64 machine and should save
  more on slower machines and architectures.

  There's only any risk here if the host compiler is ancient/very buggy and
  even then, you get a failed bootstrap later on. The GCC developers, per the
  linked bug, end up using STAGE1_CFLAGS="-O2" anyway to speed up the process
  so it's not like this is untested at all.

  mattst88 actually brought this up.. 10 years ago (bug #477548). Let's try
  make that right now.

* Respect LDFLAGS for target libraries for native builds. Not touching this
  for cross builds, at least for now, as it's a bit more delicate.

  (Unfortunately, we have to put a hack in here for now until we can fix
  multilib.eclass - see bug #914881).

Bug: https://gcc.gnu.org/PR111619
Bug: https://bugs.gentoo.org/914881
Closes: https://bugs.gentoo.org/477548
Closes: https://bugs.gentoo.org/831423
Closes: https://bugs.gentoo.org/840392
Apologies-to: Matt Turner <mattst88@gentoo.org>
Signed-off-by: Sam James <sam@gentoo.org>