### PR TITLE
virtual/rust: default to rust-bin

### DIFF
--- a/virtual/rust/rust-1.65.0-r1.ebuild
+++ b/virtual/rust/rust-1.65.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -18,6 +18,6 @@ IUSE="rustfmt"
 
 BDEPEND=""
 RDEPEND="|| (
-	~dev-lang/rust-${PV}[rustfmt?,${MULTILIB_USEDEP}]
 	~dev-lang/rust-bin-${PV}[rustfmt?,${MULTILIB_USEDEP}]
+	~dev-lang/rust-${PV}[rustfmt?,${MULTILIB_USEDEP}]
 )"

--- a/virtual/rust/rust-1.66.1.ebuild
+++ b/virtual/rust/rust-1.66.1.ebuild
@@ -18,6 +18,6 @@ IUSE="rustfmt"
 
 BDEPEND=""
 RDEPEND="|| (
-	~dev-lang/rust-${PV}[rustfmt?,${MULTILIB_USEDEP}]
 	~dev-lang/rust-bin-${PV}[rustfmt?,${MULTILIB_USEDEP}]
+	~dev-lang/rust-${PV}[rustfmt?,${MULTILIB_USEDEP}]
 )"

--- a/virtual/rust/rust-1.67.1.ebuild
+++ b/virtual/rust/rust-1.67.1.ebuild
@@ -18,6 +18,6 @@ IUSE="rustfmt"
 
 BDEPEND=""
 RDEPEND="|| (
-	~dev-lang/rust-${PV}[rustfmt?,${MULTILIB_USEDEP}]
 	~dev-lang/rust-bin-${PV}[rustfmt?,${MULTILIB_USEDEP}]
+	~dev-lang/rust-${PV}[rustfmt?,${MULTILIB_USEDEP}]
 )"

--- a/virtual/rust/rust-1.68.2.ebuild
+++ b/virtual/rust/rust-1.68.2.ebuild
@@ -18,6 +18,6 @@ IUSE="rustfmt"
 
 BDEPEND=""
 RDEPEND="|| (
-	~dev-lang/rust-${PV}[rustfmt?,${MULTILIB_USEDEP}]
 	~dev-lang/rust-bin-${PV}[rustfmt?,${MULTILIB_USEDEP}]
+	~dev-lang/rust-${PV}[rustfmt?,${MULTILIB_USEDEP}]
 )"

--- a/virtual/rust/rust-1.69.0.ebuild
+++ b/virtual/rust/rust-1.69.0.ebuild
@@ -18,6 +18,6 @@ IUSE="rustfmt"
 
 BDEPEND=""
 RDEPEND="|| (
-	~dev-lang/rust-${PV}[rustfmt?,${MULTILIB_USEDEP}]
 	~dev-lang/rust-bin-${PV}[rustfmt?,${MULTILIB_USEDEP}]
+	~dev-lang/rust-${PV}[rustfmt?,${MULTILIB_USEDEP}]
 )"

--- a/virtual/rust/rust-1.70.0.ebuild
+++ b/virtual/rust/rust-1.70.0.ebuild
@@ -18,6 +18,6 @@ IUSE="rustfmt"
 
 BDEPEND=""
 RDEPEND="|| (
-	~dev-lang/rust-${PV}[rustfmt?,${MULTILIB_USEDEP}]
 	~dev-lang/rust-bin-${PV}[rustfmt?,${MULTILIB_USEDEP}]
+	~dev-lang/rust-${PV}[rustfmt?,${MULTILIB_USEDEP}]
 )"

--- a/virtual/rust/rust-1.71.0.ebuild
+++ b/virtual/rust/rust-1.71.0.ebuild
@@ -18,6 +18,6 @@ IUSE="rustfmt"
 
 BDEPEND=""
 RDEPEND="|| (
-	~dev-lang/rust-${PV}[rustfmt?,${MULTILIB_USEDEP}]
 	~dev-lang/rust-bin-${PV}[rustfmt?,${MULTILIB_USEDEP}]
+	~dev-lang/rust-${PV}[rustfmt?,${MULTILIB_USEDEP}]
 )"

--- a/virtual/rust/rust-1.71.1.ebuild
+++ b/virtual/rust/rust-1.71.1.ebuild
@@ -18,6 +18,6 @@ IUSE="rustfmt"
 
 BDEPEND=""
 RDEPEND="|| (
-	~dev-lang/rust-${PV}[rustfmt?,${MULTILIB_USEDEP}]
 	~dev-lang/rust-bin-${PV}[rustfmt?,${MULTILIB_USEDEP}]
+	~dev-lang/rust-${PV}[rustfmt?,${MULTILIB_USEDEP}]
 )"

--- a/virtual/rust/rust-1.72.0.ebuild
+++ b/virtual/rust/rust-1.72.0.ebuild
@@ -18,6 +18,6 @@ IUSE="rustfmt"
 
 BDEPEND=""
 RDEPEND="|| (
-	~dev-lang/rust-${PV}[rustfmt?,${MULTILIB_USEDEP}]
 	~dev-lang/rust-bin-${PV}[rustfmt?,${MULTILIB_USEDEP}]
+	~dev-lang/rust-${PV}[rustfmt?,${MULTILIB_USEDEP}]
 )"


### PR DESCRIPTION
Prefer dev-lang/rust-bin over dev-lang/rust. Keeps it consistent with virtual/{jre,jdk}. Prevent long compile times when some dependency unknowingly pulls in rust.

Imagine new user (unaware of rust-bin) wanting simple app-crypt/certbot or app-admin/ansible-core but having to compile whole rust for that. Because dep graph goes like app-admin/ansible-core -> dev-python/cryptography -> virtual/rust -> dev-lang/rust