### PR TITLE
sys-apps/hwinfo: Move libx86emu to DEPEND

### DIFF
--- a/sys-apps/hwinfo/hwinfo-23.1-r1.ebuild
+++ b/sys-apps/hwinfo/hwinfo-23.1-r1.ebuild
@@ -16,9 +16,8 @@ SLOT="0"
 KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~riscv ~x86 ~amd64-linux ~x86-linux"
 IUSE=""
 
-RDEPEND="amd64? ( dev-libs/libx86emu:= )
-	x86? ( dev-libs/libx86emu:= )"
-DEPEND="${RDEPEND}
+DEPEND="amd64? ( dev-libs/libx86emu:= )
+	x86? ( dev-libs/libx86emu:= )
 	>=sys-kernel/linux-headers-2.6.17"
 BDEPEND="sys-devel/flex"
 


### PR DESCRIPTION
It's needed during both compilation and runtime, otherwise portage may cause linker errors with --jobs > 1

`ld: cannot find -lx86emu: No such file or directory`