### PR TITLE
net-analyzer/tptest: Fix call to undeclared function open

### DIFF
--- a/net-analyzer/tptest/files/tptest-3.1.7-clang16-build-fix.patch
+++ b/net-analyzer/tptest/files/tptest-3.1.7-clang16-build-fix.patch
@@ -1,0 +1,11 @@
+Bug: https://bugs.gentoo.org/897832
+--- a/apps/unix/server/server.c
++++ b/apps/unix/server/server.c
+@@ -50,6 +50,7 @@
+ #include <sys/file.h>
+ #include <sys/stat.h>
+ #include <sys/wait.h>
++#include <fcntl.h>
+ 
+ // #include <net/if.h>
+ // #include <netinet/in.h>

--- a/net-analyzer/tptest/tptest-3.1.7-r3.ebuild
+++ b/net-analyzer/tptest/tptest-3.1.7-r3.ebuild
@@ -1,0 +1,50 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs
+
+MY_PV="${PV/./_}"
+
+DESCRIPTION="Internet bandwidth tester"
+HOMEPAGE="http://tptest.sourceforge.net/"
+SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~sparc ~x86"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-3.1.7-getstatsfromlinevuln.patch
+	"${FILESDIR}"/${PN}-3.1.7-clang16-build-fix.patch
+)
+
+src_prepare() {
+	default
+
+	sed -i apps/unix/{client,server}/Makefile \
+		-e "s:^CFLAGS[[:space:]]*=:CFLAGS+=:" \
+		|| die
+
+	cp -f os-dep/unix/* . || die
+	cp -f engine/* . || die
+}
+
+src_compile() {
+	emake -C apps/unix/client \
+		CC="$(tc-getCC)" \
+		LDFLAGS="${LDFLAGS}"
+
+	emake -C apps/unix/server \
+		CC="$(tc-getCC)" \
+		LDFLAGS="${LDFLAGS}"
+}
+
+src_install() {
+	dobin apps/unix/client/tptestclient
+	dosbin apps/unix/server/tptestserver
+
+	insinto /etc
+	doins apps/unix/server/tptest.conf
+}


### PR DESCRIPTION
And update EAPI 7 -> 8

Closes: https://bugs.gentoo.org/897832