### PR TITLE
media-gfx/gphotofs: Fix call to undeclared function setlocale

### DIFF
--- a/media-gfx/gphotofs/files/gphotofs-0.5-fix-build-clang16.patch
+++ b/media-gfx/gphotofs/files/gphotofs-0.5-fix-build-clang16.patch
@@ -1,0 +1,11 @@
+Bug: https://bugs.gentoo.org/896214
+--- a/gphotofs.c
++++ b/gphotofs.c
+@@ -26,6 +26,7 @@
+ #include <errno.h>
+ #include <fcntl.h>
+ #include <sys/time.h>
++#include <locale.h>
+ 
+ /*
+  * Static variables set by command line arguments.

--- a/media-gfx/gphotofs/gphotofs-0.5-r2.ebuild
+++ b/media-gfx/gphotofs/gphotofs-0.5-r2.ebuild
@@ -1,0 +1,25 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DESCRIPTION="FUSE file system for interfacing with digital cameras using gphoto2"
+HOMEPAGE="http://www.gphoto.org/"
+SRC_URI="mirror://sourceforge/gphoto/${P}.tar.bz2"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+RDEPEND="
+	dev-libs/glib:2
+	media-libs/libgphoto2:=
+	sys-fs/fuse:0="
+DEPEND="${RDEPEND}"
+BDEPEND="
+	sys-devel/gettext
+	virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-0.5-fix-build-clang16.patch
+)


### PR DESCRIPTION
And update EAPI 7 -> 8

Closes: https://bugs.gentoo.org/896214