### PR TITLE
net-libs/nodejs: remove gcc dependency

### DIFF
--- a/net-libs/nodejs/files/nodejs-16.20.2-clang-fix-libatomic.patch
+++ b/net-libs/nodejs/files/nodejs-16.20.2-clang-fix-libatomic.patch
@@ -1,0 +1,16 @@
+https://bugs.gentoo.org/869992
+
+diff --git a/node.gyp b/node.gyp
+index 347d82d2e1..8c4ffea256 100644
+--- a/node.gyp
++++ b/node.gyp
+@@ -117,9 +117,6 @@
+           '-Wl,-bnoerrmsg',
+         ],
+       }],
+-      ['OS == "linux" and llvm_version != "0.0"', {
+-        'libraries': ['-latomic'],
+-      }],
+     ],
+   },
+

--- a/net-libs/nodejs/nodejs-16.20.2-r1.ebuild
+++ b/net-libs/nodejs/nodejs-16.20.2-r1.ebuild
@@ -7,7 +7,7 @@ CONFIG_CHECK="~ADVISE_SYSCALLS"
 PYTHON_COMPAT=( python3_{9..11} )
 PYTHON_REQ_USE="threads(+)"
 
-inherit bash-completion-r1 check-reqs flag-o-matic linux-info pax-utils python-any-r1 toolchain-funcs xdg-utils
+inherit bash-completion-r1 flag-o-matic linux-info pax-utils python-any-r1 toolchain-funcs xdg-utils
 
 DESCRIPTION="A JavaScript runtime built on Chrome's V8 JavaScript engine"
 HOMEPAGE="https://nodejs.org/"
@@ -20,13 +20,12 @@ if [[ ${PV} == *9999 ]]; then
 else
 	SRC_URI="https://nodejs.org/dist/v${PV}/node-v${PV}.tar.xz"
 	SLOT="0/$(ver_cut 1)"
-	KEYWORDS="~amd64 ~arm ~arm64 ~loong ~ppc64 ~riscv ~x86 ~amd64-linux ~x64-macos"
+	KEYWORDS="amd64 arm arm64 ppc64 ~riscv x86 ~amd64-linux ~x64-macos"
 	S="${WORKDIR}/node-v${PV}"
 fi
 
-IUSE="corepack cpu_flags_x86_sse2 debug doc +icu inspector lto +npm pax-kernel +snapshot +ssl +system-icu +system-ssl systemtap test"
-REQUIRED_USE="corepack? ( !npm )
-	inspector? ( icu ssl )
+IUSE="cpu_flags_x86_sse2 debug doc +icu inspector lto +npm pax-kernel +snapshot +ssl +system-icu +system-ssl systemtap test"
+REQUIRED_USE="inspector? ( icu ssl )
 	npm? ( ssl )
 	system-icu? ( icu )
 	system-ssl? ( ssl )"
@@ -34,14 +33,12 @@ REQUIRED_USE="corepack? ( !npm )
 RESTRICT="!test? ( test )"
 
 RDEPEND=">=app-arch/brotli-1.0.9:=
-	>=dev-libs/libuv-1.44.0:=
+	>=dev-libs/libuv-1.40.0:=
 	>=net-dns/c-ares-1.18.1:=
 	>=net-libs/nghttp2-1.41.0:=
 	sys-libs/zlib
-	corepack? ( !sys-apps/yarn )
 	system-icu? ( >=dev-libs/icu-67:= )
-	system-ssl? ( >=dev-libs/openssl-1.1.1:0= )
-	sys-devel/gcc:*"
+	system-ssl? ( >=dev-libs/openssl-1.1.1:0= )"
 BDEPEND="${PYTHON_DEPS}
 	sys-apps/coreutils
 	virtual/pkgconfig
@@ -49,27 +46,13 @@ BDEPEND="${PYTHON_DEPS}
 	test? ( net-misc/curl )
 	pax-kernel? ( sys-apps/elfix )"
 DEPEND="${RDEPEND}"
-
-# These are measured on a loong machine with -ggdb on, and only checked
-# if debugging flags are present in CFLAGS.
-#
-# The final link consumed a little more than 7GiB alone, so 8GiB is the lower
-# limit for memory usage. Disk usage was 19.1GiB for the build directory and
-# 1.2GiB for the installed image, so we leave some room for architectures with
-# fatter binaries and set the disk requirement to 22GiB.
-CHECKREQS_MEMORY="8G"
-CHECKREQS_DISK_BUILD="22G"
+PATCHES=(
+	"${FILESDIR}"/${PN}-16.20.2-clang-fix-libatomic.patch
+)
 
 pkg_pretend() {
 	(use x86 && ! use cpu_flags_x86_sse2) && \
 		die "Your CPU doesn't support the required SSE2 instruction."
-
-	if [[ ${MERGE_TYPE} != "binary" ]]; then
-		if is-flagq "-g*" && ! is-flagq "-g*0" ; then
-			einfo "Checking for sufficient disk space and memory to build ${PN} with debugging CFLAGS"
-			check-reqs_pkg_pretend
-		fi
-	fi
 }
 
 pkg_setup() {
@@ -106,7 +89,7 @@ src_prepare() {
 	fi
 
 	# We need to disable mprotect on two files when it builds Bug 694100.
-	use pax-kernel && PATCHES+=( "${FILESDIR}"/${PN}-18.16.0-paxmarking.patch )
+	use pax-kernel && PATCHES+=( "${FILESDIR}"/${PN}-16.4.2-paxmarking.patch )
 
 	default
 }
@@ -117,11 +100,7 @@ src_configure() {
 	# LTO compiler flags are handled by configure.py itself
 	filter-lto
 	# nodejs unconditionally links to libatomic #869992
-	# specifically it requires __atomic_is_lock_free which
-	# is not yet implemented by sys-libs/compiler-rt (see
-	# https://reviews.llvm.org/D85044?id=287068), therefore
-	# we depend on gcc and force using libgcc as the support lib
-	tc-is-clang && append-ldflags "--rtlib=libgcc --unwindlib=libgcc"
+	append-atomic-flags
 
 	local myconf=(
 		--shared-brotli
@@ -139,7 +118,6 @@ src_configure() {
 	else
 		myconf+=( --with-intl=none )
 	fi
-	use corepack || myconf+=( --without-corepack )
 	use inspector || myconf+=( --without-inspector )
 	use npm || myconf+=( --without-npm )
 	use snapshot || myconf+=( --without-node-snapshot )
@@ -150,15 +128,14 @@ src_configure() {
 	fi
 
 	local myarch=""
-	case "${ARCH}:${ABI}" in
-		*:amd64) myarch="x64";;
-		*:arm) myarch="arm";;
-		*:arm64) myarch="arm64";;
-		loong:lp64*) myarch="loong64";;
-		riscv:lp64*) myarch="riscv64";;
-		*:ppc64) myarch="ppc64";;
-		*:x32) myarch="x32";;
-		*:x86) myarch="ia32";;
+	case ${ABI} in
+		amd64) myarch="x64";;
+		arm) myarch="arm";;
+		arm64) myarch="arm64";;
+		lp64*) myarch="riscv64";;
+		ppc64) myarch="ppc64";;
+		x32) myarch="x32";;
+		x86) myarch="ia32";;
 		*) myarch="${ABI}";;
 	esac
 
@@ -228,9 +205,6 @@ src_install() {
 			\) \) -exec rm -rf "{}" \;
 	fi
 
-	use corepack &&
-		"${D}"/usr/bin/corepack enable --install-directory "${D}"/usr/bin
-
 	mv "${ED}"/usr/share/doc/node "${ED}"/usr/share/doc/${PF} || die
 }
 
@@ -241,10 +215,10 @@ src_test() {
 		test/parallel/test-fs-utimes-y2K38.js
 		test/parallel/test-release-npm.js
 		test/parallel/test-socket-write-after-fin-error.js
-		test/parallel/test-strace-openat-openssl.js
+		test/parallel/test-tls-streamwrap-buffersize.js
 		test/sequential/test-util-debug.js
 	)
-	rm -f "${drop_tests[@]}" || die "disabling tests failed"
+	rm -f "${drop_tests[@]}"
 
 	out/${BUILDTYPE}/cctest || die
 	"${EPYTHON}" tools/test.py --mode=${BUILDTYPE,,} --flaky-tests=dontcare -J message parallel sequential || die

--- a/net-libs/nodejs/nodejs-18.17.1-r1.ebuild
+++ b/net-libs/nodejs/nodejs-18.17.1-r1.ebuild
@@ -7,7 +7,7 @@ CONFIG_CHECK="~ADVISE_SYSCALLS"
 PYTHON_COMPAT=( python3_{9..11} )
 PYTHON_REQ_USE="threads(+)"
 
-inherit bash-completion-r1 flag-o-matic linux-info pax-utils python-any-r1 toolchain-funcs xdg-utils
+inherit bash-completion-r1 check-reqs flag-o-matic linux-info pax-utils python-any-r1 toolchain-funcs xdg-utils
 
 DESCRIPTION="A JavaScript runtime built on Chrome's V8 JavaScript engine"
 HOMEPAGE="https://nodejs.org/"
@@ -20,12 +20,13 @@ if [[ ${PV} == *9999 ]]; then
 else
 	SRC_URI="https://nodejs.org/dist/v${PV}/node-v${PV}.tar.xz"
 	SLOT="0/$(ver_cut 1)"
-	KEYWORDS="amd64 arm arm64 ppc64 ~riscv x86 ~amd64-linux ~x64-macos"
+	KEYWORDS="amd64 arm arm64 ~loong ppc64 ~riscv x86 ~amd64-linux ~x64-macos"
 	S="${WORKDIR}/node-v${PV}"
 fi
 
-IUSE="cpu_flags_x86_sse2 debug doc +icu inspector lto +npm pax-kernel +snapshot +ssl +system-icu +system-ssl systemtap test"
-REQUIRED_USE="inspector? ( icu ssl )
+IUSE="corepack cpu_flags_x86_sse2 debug doc +icu inspector lto +npm pax-kernel +snapshot +ssl +system-icu +system-ssl systemtap test"
+REQUIRED_USE="corepack? ( !npm )
+	inspector? ( icu ssl )
 	npm? ( ssl )
 	system-icu? ( icu )
 	system-ssl? ( ssl )"
@@ -33,13 +34,13 @@ REQUIRED_USE="inspector? ( icu ssl )
 RESTRICT="!test? ( test )"
 
 RDEPEND=">=app-arch/brotli-1.0.9:=
-	>=dev-libs/libuv-1.40.0:=
+	>=dev-libs/libuv-1.44.0:=
 	>=net-dns/c-ares-1.18.1:=
 	>=net-libs/nghttp2-1.41.0:=
 	sys-libs/zlib
+	corepack? ( !sys-apps/yarn )
 	system-icu? ( >=dev-libs/icu-67:= )
-	system-ssl? ( >=dev-libs/openssl-1.1.1:0= )
-	sys-devel/gcc:*"
+	system-ssl? ( >=dev-libs/openssl-1.1.1:0= )"
 BDEPEND="${PYTHON_DEPS}
 	sys-apps/coreutils
 	virtual/pkgconfig
@@ -47,10 +48,30 @@ BDEPEND="${PYTHON_DEPS}
 	test? ( net-misc/curl )
 	pax-kernel? ( sys-apps/elfix )"
 DEPEND="${RDEPEND}"
+PATCHES=(
+	"${FILESDIR}"/${PN}-16.20.2-clang-fix-libatomic.patch
+)
+
+# These are measured on a loong machine with -ggdb on, and only checked
+# if debugging flags are present in CFLAGS.
+#
+# The final link consumed a little more than 7GiB alone, so 8GiB is the lower
+# limit for memory usage. Disk usage was 19.1GiB for the build directory and
+# 1.2GiB for the installed image, so we leave some room for architectures with
+# fatter binaries and set the disk requirement to 22GiB.
+CHECKREQS_MEMORY="8G"
+CHECKREQS_DISK_BUILD="22G"
 
 pkg_pretend() {
 	(use x86 && ! use cpu_flags_x86_sse2) && \
 		die "Your CPU doesn't support the required SSE2 instruction."
+
+	if [[ ${MERGE_TYPE} != "binary" ]]; then
+		if is-flagq "-g*" && ! is-flagq "-g*0" ; then
+			einfo "Checking for sufficient disk space and memory to build ${PN} with debugging CFLAGS"
+			check-reqs_pkg_pretend
+		fi
+	fi
 }
 
 pkg_setup() {
@@ -87,7 +108,7 @@ src_prepare() {
 	fi
 
 	# We need to disable mprotect on two files when it builds Bug 694100.
-	use pax-kernel && PATCHES+=( "${FILESDIR}"/${PN}-16.4.2-paxmarking.patch )
+	use pax-kernel && PATCHES+=( "${FILESDIR}"/${PN}-18.16.0-paxmarking.patch )
 
 	default
 }
@@ -98,11 +119,7 @@ src_configure() {
 	# LTO compiler flags are handled by configure.py itself
 	filter-lto
 	# nodejs unconditionally links to libatomic #869992
-	# specifically it requires __atomic_is_lock_free which
-	# is not yet implemented by sys-libs/compiler-rt (see
-	# https://reviews.llvm.org/D85044?id=287068), therefore
-	# we depend on gcc and force using libgcc as the support lib
-	tc-is-clang && append-ldflags "--rtlib=libgcc --unwindlib=libgcc"
+	append-atomic-flags
 
 	local myconf=(
 		--shared-brotli
@@ -120,6 +137,7 @@ src_configure() {
 	else
 		myconf+=( --with-intl=none )
 	fi
+	use corepack || myconf+=( --without-corepack )
 	use inspector || myconf+=( --without-inspector )
 	use npm || myconf+=( --without-npm )
 	use snapshot || myconf+=( --without-node-snapshot )
@@ -130,14 +148,15 @@ src_configure() {
 	fi
 
 	local myarch=""
-	case ${ABI} in
-		amd64) myarch="x64";;
-		arm) myarch="arm";;
-		arm64) myarch="arm64";;
-		lp64*) myarch="riscv64";;
-		ppc64) myarch="ppc64";;
-		x32) myarch="x32";;
-		x86) myarch="ia32";;
+	case "${ARCH}:${ABI}" in
+		*:amd64) myarch="x64";;
+		*:arm) myarch="arm";;
+		*:arm64) myarch="arm64";;
+		loong:lp64*) myarch="loong64";;
+		riscv:lp64*) myarch="riscv64";;
+		*:ppc64) myarch="ppc64";;
+		*:x32) myarch="x32";;
+		*:x86) myarch="ia32";;
 		*) myarch="${ABI}";;
 	esac
 
@@ -207,6 +226,9 @@ src_install() {
 			\) \) -exec rm -rf "{}" \;
 	fi
 
+	use corepack &&
+		"${D}"/usr/bin/corepack enable --install-directory "${D}"/usr/bin
+
 	mv "${ED}"/usr/share/doc/node "${ED}"/usr/share/doc/${PF} || die
 }
 
@@ -217,10 +239,10 @@ src_test() {
 		test/parallel/test-fs-utimes-y2K38.js
 		test/parallel/test-release-npm.js
 		test/parallel/test-socket-write-after-fin-error.js
-		test/parallel/test-tls-streamwrap-buffersize.js
+		test/parallel/test-strace-openat-openssl.js
 		test/sequential/test-util-debug.js
 	)
-	rm -f "${drop_tests[@]}"
+	rm -f "${drop_tests[@]}" || die "disabling tests failed"
 
 	out/${BUILDTYPE}/cctest || die
 	"${EPYTHON}" tools/test.py --mode=${BUILDTYPE,,} --flaky-tests=dontcare -J message parallel sequential || die

--- a/net-libs/nodejs/nodejs-18.18.0-r1.ebuild
+++ b/net-libs/nodejs/nodejs-18.18.0-r1.ebuild
@@ -24,13 +24,12 @@ else
 	S="${WORKDIR}/node-v${PV}"
 fi
 
-IUSE="corepack cpu_flags_x86_sse2 debug doc +icu inspector lto +npm pax-kernel +snapshot +ssl +system-icu +system-ssl test"
+IUSE="corepack cpu_flags_x86_sse2 debug doc +icu inspector lto +npm pax-kernel +snapshot +ssl +system-icu +system-ssl systemtap test"
 REQUIRED_USE="corepack? ( !npm )
 	inspector? ( icu ssl )
 	npm? ( ssl )
 	system-icu? ( icu )
-	system-ssl? ( ssl )
-	x86? ( cpu_flags_x86_sse2 )"
+	system-ssl? ( ssl )"
 
 RESTRICT="!test? ( test )"
 
@@ -41,15 +40,17 @@ RDEPEND=">=app-arch/brotli-1.0.9:=
 	sys-libs/zlib
 	corepack? ( !sys-apps/yarn )
 	system-icu? ( >=dev-libs/icu-67:= )
-	system-ssl? ( >=dev-libs/openssl-1.1.1:0= )
-	sys-devel/gcc:*"
+	system-ssl? ( >=dev-libs/openssl-1.1.1:0= )"
 BDEPEND="${PYTHON_DEPS}
-	dev-util/ninja
 	sys-apps/coreutils
 	virtual/pkgconfig
+	systemtap? ( dev-util/systemtap )
 	test? ( net-misc/curl )
 	pax-kernel? ( sys-apps/elfix )"
 DEPEND="${RDEPEND}"
+PATCHES=(
+	"${FILESDIR}"/${PN}-16.20.2-clang-fix-libatomic.patch
+)
 
 # These are measured on a loong machine with -ggdb on, and only checked
 # if debugging flags are present in CFLAGS.
@@ -61,11 +62,10 @@ DEPEND="${RDEPEND}"
 CHECKREQS_MEMORY="8G"
 CHECKREQS_DISK_BUILD="22G"
 
-PATCHES=(
-	"${FILESDIR}"/"${PN}"-20.3.0-gcc14.patch
-	)
-
 pkg_pretend() {
+	(use x86 && ! use cpu_flags_x86_sse2) && \
+		die "Your CPU doesn't support the required SSE2 instruction."
+
 	if [[ ${MERGE_TYPE} != "binary" ]]; then
 		if is-flagq "-g*" && ! is-flagq "-g*0" ; then
 			einfo "Checking for sufficient disk space and memory to build ${PN} with debugging CFLAGS"
@@ -108,7 +108,7 @@ src_prepare() {
 	fi
 
 	# We need to disable mprotect on two files when it builds Bug 694100.
-	use pax-kernel && PATCHES+=( "${FILESDIR}"/${PN}-20.6.0-paxmarking.patch )
+	use pax-kernel && PATCHES+=( "${FILESDIR}"/${PN}-18.16.0-paxmarking.patch )
 
 	default
 }
@@ -119,14 +119,9 @@ src_configure() {
 	# LTO compiler flags are handled by configure.py itself
 	filter-lto
 	# nodejs unconditionally links to libatomic #869992
-	# specifically it requires __atomic_is_lock_free which
-	# is not yet implemented by sys-libs/compiler-rt (see
-	# https://reviews.llvm.org/D85044?id=287068), therefore
-	# we depend on gcc and force using libgcc as the support lib
-	tc-is-clang && append-ldflags "--rtlib=libgcc --unwindlib=libgcc"
+	append-atomic-flags
 
 	local myconf=(
-		--ninja
 		--shared-brotli
 		--shared-cares
 		--shared-libuv
@@ -171,11 +166,12 @@ src_configure() {
 	"${EPYTHON}" configure.py \
 		--prefix="${EPREFIX}"/usr \
 		--dest-cpu=${myarch} \
+		$(use_with systemtap dtrace) \
 		"${myconf[@]}" || die
 }
 
 src_compile() {
-	emake
+	emake -C out
 }
 
 src_install() {
@@ -238,11 +234,9 @@ src_install() {
 
 src_test() {
 	local drop_tests=(
-		test/parallel/test-fs-read-stream.js
 		test/parallel/test-dns-setserver-when-querying.js
 		test/parallel/test-fs-mkdir.js
 		test/parallel/test-fs-utimes-y2K38.js
-		test/parallel/test-fs-watch-recursive-add-file.js
 		test/parallel/test-release-npm.js
 		test/parallel/test-socket-write-after-fin-error.js
 		test/parallel/test-strace-openat-openssl.js

--- a/net-libs/nodejs/nodejs-20.7.0-r1.ebuild
+++ b/net-libs/nodejs/nodejs-20.7.0-r1.ebuild
@@ -20,7 +20,7 @@ if [[ ${PV} == *9999 ]]; then
 else
 	SRC_URI="https://nodejs.org/dist/v${PV}/node-v${PV}.tar.xz"
 	SLOT="0/$(ver_cut 1)"
-	KEYWORDS="amd64 arm arm64 ~loong ppc64 ~riscv x86 ~amd64-linux ~x64-macos"
+	KEYWORDS="~amd64 ~arm ~arm64 ~loong ~ppc64 ~riscv ~x86 ~amd64-linux ~x64-macos"
 	S="${WORKDIR}/node-v${PV}"
 fi
 
@@ -41,8 +41,7 @@ RDEPEND=">=app-arch/brotli-1.0.9:=
 	sys-libs/zlib
 	corepack? ( !sys-apps/yarn )
 	system-icu? ( >=dev-libs/icu-67:= )
-	system-ssl? ( >=dev-libs/openssl-1.1.1:0= )
-	sys-devel/gcc:*"
+	system-ssl? ( >=dev-libs/openssl-1.1.1:0= )"
 BDEPEND="${PYTHON_DEPS}
 	dev-util/ninja
 	sys-apps/coreutils
@@ -63,6 +62,7 @@ CHECKREQS_DISK_BUILD="22G"
 
 PATCHES=(
 	"${FILESDIR}"/"${PN}"-20.3.0-gcc14.patch
+	"${FILESDIR}"/${PN}-16.20.2-clang-fix-libatomic.patch
 	)
 
 pkg_pretend() {
@@ -119,11 +119,7 @@ src_configure() {
 	# LTO compiler flags are handled by configure.py itself
 	filter-lto
 	# nodejs unconditionally links to libatomic #869992
-	# specifically it requires __atomic_is_lock_free which
-	# is not yet implemented by sys-libs/compiler-rt (see
-	# https://reviews.llvm.org/D85044?id=287068), therefore
-	# we depend on gcc and force using libgcc as the support lib
-	tc-is-clang && append-ldflags "--rtlib=libgcc --unwindlib=libgcc"
+	append-atomic-flags
 
 	local myconf=(
 		--ninja

--- a/net-libs/nodejs/nodejs-99999999.ebuild
+++ b/net-libs/nodejs/nodejs-99999999.ebuild
@@ -41,8 +41,7 @@ RDEPEND=">=app-arch/brotli-1.0.9:=
 	sys-libs/zlib
 	corepack? ( !sys-apps/yarn )
 	system-icu? ( >=dev-libs/icu-67:= )
-	system-ssl? ( >=dev-libs/openssl-1.1.1:0= )
-	sys-devel/gcc:*"
+	system-ssl? ( >=dev-libs/openssl-1.1.1:0= )"
 BDEPEND="${PYTHON_DEPS}
 	dev-util/ninja
 	sys-apps/coreutils
@@ -50,6 +49,9 @@ BDEPEND="${PYTHON_DEPS}
 	test? ( net-misc/curl )
 	pax-kernel? ( sys-apps/elfix )"
 DEPEND="${RDEPEND}"
+PATCHES=(
+	"${FILESDIR}"/${PN}-16.20.2-clang-fix-libatomic.patch
+)
 
 # These are measured on a loong machine with -ggdb on, and only checked
 # if debugging flags are present in CFLAGS.
@@ -115,11 +117,7 @@ src_configure() {
 	# LTO compiler flags are handled by configure.py itself
 	filter-lto
 	# nodejs unconditionally links to libatomic #869992
-	# specifically it requires __atomic_is_lock_free which
-	# is not yet implemented by sys-libs/compiler-rt (see
-	# https://reviews.llvm.org/D85044?id=287068), therefore
-	# we depend on gcc and force using libgcc as the support lib
-	tc-is-clang && append-ldflags "--rtlib=libgcc --unwindlib=libgcc"
+	append-atomic-flags
 
 	local myconf=(
 		--ninja


### PR DESCRIPTION
Previously, libgcc was needed for `__atomic_is_lock_free`, which was originally not implemented in LLVM's compiler-rt. With this LLVM upstream commit[0] being merged, gcc is now unnecessary. This commit reverts 7dc748f875d8f1a7bda9d0b8c00d45ad4be2d58d for all nodejs ebuilds.

[0] https://github.com/llvm/llvm-project/commit/00530dee5d1295dc20ebafdd9a8a79662f41513e

Bug: https://bugs.gentoo.org/869992
Closes: https://bugs.gentoo.org/911340