### PR TITLE
dev-games/openscenegraph-openmw: glut is no longer used

### DIFF
--- a/dev-games/openscenegraph-openmw/openscenegraph-openmw-3.6_p20221115.ebuild
+++ b/dev-games/openscenegraph-openmw/openscenegraph-openmw-3.6_p20221115.ebuild
@@ -20,7 +20,7 @@ SLOT="0/162" # NOTE: CHECK WHEN BUMPING! Subslot is SOVERSION
 KEYWORDS="~amd64 ~arm64 ~ppc64 ~x86"
 IUSE="
 	+collada curl dicom debug doc egl examples fltk fox gdal
-	gif glut gstreamer +jpeg las lua openexr openinventor osgapps pdf +png
+	gif gstreamer +jpeg las lua openexr openinventor osgapps pdf +png
 	+sdl sdl2 +svg tiff +truetype vnc wxwidgets xrandr +zlib
 "
 
@@ -51,7 +51,6 @@ RDEPEND="
 	examples? (
 		fltk? ( x11-libs/fltk:1[opengl] )
 		fox? ( x11-libs/fox:1.6[opengl] )
-		glut? ( media-libs/freeglut )
 		sdl2? ( media-libs/libsdl2 )
 		wxwidgets? ( x11-libs/wxGTK:${WX_GTK_VER}[opengl,X] )
 	)
@@ -148,7 +147,6 @@ src_configure() {
 		mycmakeargs+=(
 			$(cmake_use_find_package fltk FLTK)
 			$(cmake_use_find_package fox FOX)
-			$(cmake_use_find_package glut GLUT)
 			$(cmake_use_find_package wxwidgets wxWidgets)
 		)
 	fi


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/907294