### PR TITLE
games-puzzle/toppler: Fix C++17 does not allow register storage class

### DIFF
--- a/games-puzzle/toppler/files/toppler-1.1.6-drop-register-keyword.patch
+++ b/games-puzzle/toppler/files/toppler-1.1.6-drop-register-keyword.patch
@@ -1,0 +1,21 @@
+Bug: https://bugs.gentoo.org/896006
+--- a/keyb.cc
++++ b/keyb.cc
+@@ -215,7 +215,7 @@ void key_keydatas(SDLKey &sdlkey, ttkey &tkey, char &ch) {
+ 
+ 
+ SDLKey key_conv2sdlkey(ttkey k, bool game) {
+-  register int i;
++  int i;
+ 
+   if (game) {
+     for (i = SIZE(ttkeyconv) - 1; i >= 0; i--)
+@@ -231,7 +231,7 @@ SDLKey key_conv2sdlkey(ttkey k, bool game) {
+ }
+ 
+ ttkey key_sdlkey2conv(SDLKey k, bool game) {
+-  register int i;
++  int i;
+ 
+   if (k != SDLK_UNKNOWN) {
+     if (game) {

--- a/games-puzzle/toppler/toppler-1.1.6-r3.ebuild
+++ b/games-puzzle/toppler/toppler-1.1.6-r3.ebuild
@@ -1,0 +1,40 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools
+
+DESCRIPTION="Reimplementation of Nebulous using SDL"
+HOMEPAGE="https://gitlab.com/roever/toppler/"
+SRC_URI="mirror://sourceforge/toppler/${P}.tar.gz"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="nls"
+
+RDEPEND="acct-group/gamestat
+	media-libs/libsdl[joystick,video]
+	media-libs/sdl-mixer[vorbis]
+	sys-libs/zlib
+	nls? ( virtual/libintl )"
+DEPEND="${RDEPEND}"
+BDEPEND="nls? ( sys-devel/gettext )"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-gentoo.patch
+	"${FILESDIR}"/${P}-fix-docdir.patch
+	"${FILESDIR}"/${P}-use-gamestat-group.patch
+	"${FILESDIR}"/${P}-drop-register-keyword.patch
+)
+
+src_prepare() {
+	default
+
+	eautoreconf
+}
+
+src_configure() {
+	econf $(use_enable nls)
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/896006