### PR TITLE
sys-fs/udisks: remove 'gtk-doc-am' dependency

### DIFF
--- a/sys-fs/udisks/udisks-2.10.1.ebuild
+++ b/sys-fs/udisks/udisks-2.10.1.ebuild
@@ -49,7 +49,6 @@ DEPEND="${COMMON_DEPEND}
 BDEPEND="
 	app-text/docbook-xsl-stylesheets
 	>=dev-util/gdbus-codegen-2.32
-	>=dev-util/gtk-doc-am-1.3
 	virtual/pkgconfig
 	nls? ( >=sys-devel/gettext-0.19.8 )
 	dev-libs/gobject-introspection-common


### PR DESCRIPTION
Current source ships with pregenerated docs and its generation is explicitly disabled by `--disable-gtk-doc`.
So `gtk-doc-am` dependency is unused.