### PR TITLE
net-libs/gnutls: fix dependency

### DIFF
--- a/net-libs/gnutls/gnutls-3.8.1-r1.ebuild
+++ b/net-libs/gnutls/gnutls-3.8.1-r1.ebuild
@@ -42,9 +42,11 @@ DEPEND="
 	)
 "
 BDEPEND="
-	dev-util/gtk-doc-am
 	>=virtual/pkgconfig-0-r1
-	doc? ( dev-util/gtk-doc )
+	doc? (
+		dev-util/gtk-doc
+		dev-util/gtk-doc-am
+	)
 	nls? ( sys-devel/gettext )
 	test-full? (
 		app-crypt/dieharder


### PR DESCRIPTION
Move `gtk-doc-am` dependency under `doc` flag because it is only used for docs generation.