### PR TITLE
sys-apps/accountsservice: fix dependency

### DIFF
--- a/sys-apps/accountsservice/accountsservice-23.13.9.ebuild
+++ b/sys-apps/accountsservice/accountsservice-23.13.9.ebuild
@@ -29,7 +29,6 @@ DEPEND="${CDEPEND}
 	sys-apps/dbus
 "
 BDEPEND="
-	dev-libs/libxslt
 	dev-util/gdbus-codegen
 	dev-util/glib-utils
 	sys-devel/gettext
@@ -37,6 +36,7 @@ BDEPEND="
 	doc? (
 		app-text/docbook-xml-dtd:4.1.2
 		app-text/xmlto
+		dev-libs/libxslt
 	)
 	gtk-doc? (
 		dev-util/gtk-doc


### PR DESCRIPTION
Move `libxslt` dependency under `doc` flag because it is only used for docs generation.