### PR TITLE
sys-libs/libblockdev: fix dependency

### DIFF
--- a/sys-libs/libblockdev/libblockdev-3.0.3.ebuild
+++ b/sys-libs/libblockdev/libblockdev-3.0.3.ebuild
@@ -56,8 +56,10 @@ RDEPEND="
 DEPEND="${RDEPEND}"
 
 BDEPEND+="
-	dev-util/gtk-doc-am
-	gtk-doc? ( dev-util/gtk-doc )
+	gtk-doc? (
+		dev-util/gtk-doc
+		dev-util/gtk-doc-am
+	)
 	introspection? ( >=dev-libs/gobject-introspection-1.3.0 )
 	test? (
 		$(python_gen_cond_dep '


### PR DESCRIPTION
Move `gtk-doc-am` dependency under `gtk-doc` flag because it is only used for docs generation.