### PR TITLE
sys-libs/libblockdev: make python bindings optional

### DIFF
--- a/sys-libs/libblockdev/libblockdev-3.0.3.ebuild
+++ b/sys-libs/libblockdev/libblockdev-3.0.3.ebuild
@@ -21,7 +21,7 @@ else
 fi
 LICENSE="LGPL-2+"
 SLOT="0/3"	# subslot is SOVERSION
-IUSE="+cryptsetup device-mapper escrow gtk-doc introspection lvm +nvme test +tools"
+IUSE="+cryptsetup device-mapper escrow gtk-doc introspection lvm +nvme +python test +tools"
 # Tests require root. In a future release, we may be able to run a smaller
 # subset with new run_tests.py arguments.
 RESTRICT="!test? ( test ) test"
@@ -47,10 +47,12 @@ RDEPEND="
 		virtual/udev
 	)
 	nvme? ( sys-libs/libnvme )
-	${PYTHON_DEPS}
-	$(python_gen_cond_dep '
-		dev-python/pygobject:3[${PYTHON_USEDEP}]
-	')
+	python? (
+		${PYTHON_DEPS}
+		$(python_gen_cond_dep '
+			dev-python/pygobject:3[${PYTHON_USEDEP}]
+		')
+	)
 "
 
 DEPEND="${RDEPEND}"
@@ -60,10 +62,12 @@ BDEPEND+="
 	gtk-doc? ( dev-util/gtk-doc )
 	introspection? ( >=dev-libs/gobject-introspection-1.3.0 )
 	test? (
-		$(python_gen_cond_dep '
-			dev-libs/libbytesize[python,${PYTHON_USEDEP}]
-		')
 		sys-block/targetcli-fb
+		python? (
+			$(python_gen_cond_dep '
+				dev-libs/libbytesize[python,${PYTHON_USEDEP}]
+			')
+		)
 	)
 "
 
@@ -71,6 +75,7 @@ REQUIRED_USE="${PYTHON_REQUIRED_USE}
 		escrow? ( cryptsetup )"
 
 pkg_setup() {
+	use python || return 0
 	python-single-r1_pkg_setup
 }
 
@@ -95,7 +100,6 @@ src_configure() {
 		--with-btrfs
 		--with-fs
 		--with-part
-		--with-python3
 		--without-mpath
 		--without-nvdimm
 		$(use_enable introspection)
@@ -107,6 +111,7 @@ src_configure() {
 		$(use_with lvm lvm)
 		$(use_with lvm lvm-dbus)
 		$(use_with nvme)
+		$(use_with python python3)
 		$(use_with tools)
 	)
 	econf "${myeconfargs[@]}"
@@ -127,5 +132,5 @@ src_install() {
 	if ! use lvm ; then
 		rm -f "${ED}"/usr/bin/lvm-cache-stats || die
 	fi
-	python_optimize #718576
+	use python && python_optimize #718576
 }

--- a/sys-libs/libblockdev/metadata.xml
+++ b/sys-libs/libblockdev/metadata.xml
@@ -14,6 +14,7 @@
 		<flag name="kbd">Enable kernel block device support.</flag>
 		<flag name="lvm">Enable support for Logical Volume Management via <pkg>sys-fs/lvm2</pkg>.</flag>
 		<flag name="nvme">Add nvme support via <pkg>sys-libs/libnvme</pkg></flag>
+		<flag name="python">Enable Python 3 bindings</flag>
 		<flag name="tools">Build tools</flag>
 		<flag name="vdo">Enable Virtual Data Optimizer support.</flag>
 	</use>


### PR DESCRIPTION
Python bindings are effectively useless for end users as `udisks2` does not use it. So this is may be a good idea to make it optional.