### PR TITLE
Qscintilla qt6

### DIFF
--- a/dev-python/qscintilla-python/qscintilla-python-2.14.1-r1.ebuild
+++ b/dev-python/qscintilla-python/qscintilla-python-2.14.1-r1.ebuild
@@ -1,0 +1,98 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+PYTHON_COMPAT=( python3_{9..11} )
+inherit multibuild python-r1 qmake-utils
+
+DESCRIPTION="Python bindings for QScintilla"
+HOMEPAGE="https://www.riverbankcomputing.com/software/qscintilla/ https://pypi.org/project/QScintilla/"
+
+MY_PN=QScintilla
+MY_P=${MY_PN}_src-${PV/_pre/.dev}
+if [[ ${PV} == *_pre* ]]; then
+	SRC_URI="https://dev.gentoo.org/~pesa/distfiles/${MY_P}.tar.gz"
+else
+	SRC_URI="https://www.riverbankcomputing.com/static/Downloads/${MY_PN}/${PV}/${MY_P}.tar.gz"
+fi
+S=${WORKDIR}/${MY_P}/Python
+
+LICENSE="GPL-3"
+SLOT="0"
+KEYWORDS="~amd64 ~arm64 ~ppc64 x86"
+IUSE="debug +qt5 qt6"
+
+REQUIRED_USE="|| ( qt5 qt6 ) ${PYTHON_REQUIRED_USE}"
+
+# no tests
+RESTRICT="test"
+
+DEPEND="${PYTHON_DEPS}
+	qt5? (
+		>=dev-python/PyQt5-5.15.5[gui,printsupport,widgets,${PYTHON_USEDEP}]
+		dev-qt/qtcore:5
+		dev-qt/qtgui:5
+		dev-qt/qtprintsupport:5
+		dev-qt/qtwidgets:5
+	)
+	qt6? (
+		dev-python/PyQt6[gui,printsupport,widgets,${PYTHON_USEDEP}]
+		dev-qt/qtbase:6[cups,gui,widgets]
+	)
+	~x11-libs/qscintilla-${PV}:=[qt5=,qt6=]
+"
+RDEPEND="${DEPEND}
+	qt5? ( >=dev-python/PyQt5-sip-12.9:=[${PYTHON_USEDEP}] )
+	qt6? ( >=dev-python/PyQt6-sip-13.5:=[${PYTHON_USEDEP}] )
+"
+BDEPEND="
+	>=dev-python/PyQt-builder-1.10[${PYTHON_USEDEP}]
+	>=dev-python/sip-6.2[${PYTHON_USEDEP}]
+	qt5? ( dev-qt/qtcore:5 )
+	qt6? ( dev-qt/qtbase:6 )
+"
+
+pkg_setup() {
+	MULTIBUILD_VARIANTS=( $(usev qt5) $(usev qt6) )
+}
+
+src_configure() {
+	my_src_configure() {
+		case ${MULTIBUILD_VARIANT} in
+			qt5) local QMAKE=qmake5 ;;
+			qt6) local QMAKE=qmake6 ;;
+		esac
+		configuration() {
+			local myconf=(
+				sip-build
+				--verbose
+				--build-dir="${BUILD_DIR}"
+				--scripts-dir="$(python_get_scriptdir)"
+				--qmake="/usr/bin/${QMAKE}"
+				--no-make
+				$(usev debug '--debug --qml-debug --tracing')
+			)
+			echo "${myconf[@]}"
+			"${myconf[@]}" || die
+
+			# Run eqmake to respect toolchain and build flags
+			run_in_build_dir "${QMAKE}" -recursive ${MY_PN}.pro
+		}
+		mv pyproject{-${MULTIBUILD_VARIANT},}.toml || die
+		python_foreach_impl configuration
+	}
+	multibuild_foreach_variant my_src_configure
+}
+
+src_compile() {
+	multibuild_foreach_variant python_foreach_impl run_in_build_dir default
+}
+
+src_install() {
+	installation() {
+		emake INSTALL_ROOT="${D}" install
+		python_optimize
+	}
+	multibuild_foreach_variant python_foreach_impl run_in_build_dir installation
+}

--- a/x11-libs/qscintilla/qscintilla-2.14.1-r1.ebuild
+++ b/x11-libs/qscintilla/qscintilla-2.14.1-r1.ebuild
@@ -1,0 +1,112 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit flag-o-matic multibuild qmake-utils
+
+DESCRIPTION="Qt port of Neil Hodgson's Scintilla C++ editor control"
+HOMEPAGE="https://www.riverbankcomputing.com/software/qscintilla/intro"
+
+MY_PN=QScintilla
+MY_P=${MY_PN}_src-${PV/_pre/.dev}
+if [[ ${PV} == *_pre* ]]; then
+	SRC_URI="https://dev.gentoo.org/~pesa/distfiles/${MY_P}.tar.gz"
+else
+	SRC_URI="https://www.riverbankcomputing.com/static/Downloads/${MY_PN}/${PV}/${MY_P}.tar.gz"
+fi
+S=${WORKDIR}/${MY_P}
+
+LICENSE="GPL-3"
+SLOT="0/15"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~riscv ~x86"
+IUSE="designer doc +qt5 qt6"
+
+REQUIRED_USE="|| ( qt5 qt6 )"
+
+# no tests
+RESTRICT="test"
+
+RDEPEND="
+	qt5? (
+		dev-qt/qtcore:5
+		dev-qt/qtgui:5
+		dev-qt/qtprintsupport:5
+		dev-qt/qtwidgets:5
+		designer? ( dev-qt/designer:5 )
+	)
+	qt6? (
+		dev-qt/qtbase:6[cups,gui,widgets]
+		designer? ( dev-qt/qttools:6[designer] )
+	)
+"
+DEPEND="${RDEPEND}"
+
+pkg_setup() {
+	MULTIBUILD_VARIANTS=( $(usev qt5) $(usev qt6) )
+}
+
+src_unpack() {
+	default
+
+	# Sub-slot sanity check
+	local subslot=${SLOT#*/}
+	local version=$(sed -nre 's:.*VERSION\s*=\s*([0-9\.]+):\1:p' "${S}"/src/qscintilla.pro || die)
+	local major=${version%%.*}
+	if [[ ${subslot} != ${major} ]]; then
+		eerror
+		eerror "Ebuild sub-slot (${subslot}) does not match QScintilla major version (${major})"
+		eerror "Please update SLOT variable as follows:"
+		eerror "    SLOT=\"${SLOT%%/*}/${major}\""
+		eerror
+		die "sub-slot sanity check failed"
+	fi
+
+	multibuild_copy_sources
+}
+
+qsci_run_in() {
+	pushd "$1" >/dev/null || die
+	shift || die
+	"$@" || die
+	popd >/dev/null || die
+}
+
+src_configure() {
+	if use designer; then
+		# prevent building against system version (bug 466120)
+		append-cxxflags -I../src
+		append-ldflags -L../src
+	fi
+	my_src_configure() {
+		case ${MULTIBUILD_VARIANT} in
+			qt5) local QMAKE=eqmake5 ;;
+			qt6) local QMAKE=eqmake6 ;;
+		esac
+		qsci_run_in "${BUILD_DIR}"/src "${QMAKE}"
+		use designer && qsci_run_in "${BUILD_DIR}"/designer "${QMAKE}"
+	}
+
+	multibuild_foreach_variant my_src_configure
+}
+
+src_compile() {
+	my_src_compile() {
+		qsci_run_in "${BUILD_DIR}"/src emake
+		use designer && qsci_run_in "${BUILD_DIR}"/designer emake
+	}
+
+	multibuild_foreach_variant my_src_compile
+}
+
+src_install() {
+	my_src_install() {
+		qsci_run_in "${BUILD_DIR}"/src emake INSTALL_ROOT="${D}" install
+		use designer && qsci_run_in "${BUILD_DIR}"/designer emake INSTALL_ROOT="${D}" install
+	}
+
+	multibuild_foreach_variant my_src_install
+
+	use doc && local HTML_DOCS=( doc/html/. )
+	einstalldocs
+}


### PR DESCRIPTION
Based on the work by @t0b3 ( https://github.com/gentoo/gentoo/pull/31252 ), I've bumped the versions of x11-libs/qscintilla and dev-python/qscintilla-python, and kept his logic for multibuild with qt5 and qt6. I've also keyworded all arches. I've tested on a mostly ~amd64 system.