### PR TITLE
net-im/swift: fix soname

### DIFF
--- a/net-im/swift/swift-4.0.3-r1.ebuild
+++ b/net-im/swift/swift-4.0.3-r1.ebuild
@@ -112,6 +112,11 @@ src_prepare() {
 	else
 		rm -fr 3rdParty || die
 	fi
+
+	if [[ ! -f VERSION.swift ]] ; then
+		# Source tarball from git doesn't include this file
+		echo "${PV}" > VERSION.swift || die
+	fi
 }
 
 src_configure() {


### PR DESCRIPTION
build system derives soname from the version in this file; since this is not a release tarball this file is not present, add it.
soname goes back to libSwiften.so.4.0, as it was in 4.0.2, from libSwiften.so.0.0 by doing this.