### PR TITLE
dev-libs/libgee: use vala

### DIFF
--- a/dev-libs/libgee/libgee-0.20.6.ebuild
+++ b/dev-libs/libgee/libgee-0.20.6.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit gnome2
+inherit gnome2 vala
 
 DESCRIPTION="GObject-based interfaces and classes for commonly used data structures"
 HOMEPAGE="https://wiki.gnome.org/Projects/Libgee"
@@ -19,10 +19,19 @@ RDEPEND="
 	introspection? ( >=dev-libs/gobject-introspection-0.9.6:= )
 "
 DEPEND="${RDEPEND}"
-BDEPEND="virtual/pkgconfig"
+BDEPEND="
+	$(vala_depend)
+	virtual/pkgconfig
+"
 
 src_configure() {
+	vala_setup
 	gnome2_src_configure \
-		$(use_enable introspection) \
-		VALAC="$(type -P false)"
+		$(use_enable introspection)
+}
+
+src_compile() {
+	# Run make clean to remove pre-generated C sources
+	emake clean
+	gnome2_src_compile
 }


### PR DESCRIPTION
libgee includes C source pre-generated from the vala sources in their release tarballs. However, to keep in line with other vala packages, it's better to re-generate the C sources in the ebuild. This commit makes src_compile run make clean before building to remove the generated C sources, and adds the appropriate BDEPEND on vala.