### PR TITLE
media-libs/giflib: Add CPE string to metadata.xml

### DIFF
--- a/media-libs/giflib/metadata.xml
+++ b/media-libs/giflib/metadata.xml
@@ -7,5 +7,6 @@
   </maintainer>
   <upstream>
     <remote-id type="sourceforge">giflib</remote-id>
+    <remote-id type="cpe">cpe:/a:giflib_project:giflib</remote-id>
   </upstream>
 </pkgmetadata>


### PR DESCRIPTION
Add a CPE string for easier CVE tracking.

Bug: https://bugs.gentoo.org/915135
Closes: https://bugs.gentoo.org/915135