### PR TITLE
media-libs/libpulse: Fix build with lld and backport critical fixes from upstream

### DIFF
--- a/media-libs/libpulse/files/pulseaudio-16.1-add-more-standard-samplerates.patch
+++ b/media-libs/libpulse/files/pulseaudio-16.1-add-more-standard-samplerates.patch
@@ -1,0 +1,35 @@
+commit 86c5fbab5778685e19b5a4a9b8eb04ca90dff780
+Author: Igor V. Kovalenko <igor.v.kovalenko@gmail.com>
+Date:   Sun Feb 5 19:49:10 2023 +0300
+
+    alsa-util: Add more standard sample rates.
+    
+    Part-of: <https://gitlab.freedesktop.org/pulseaudio/pulseaudio/-/merge_requests/776>
+
+diff --git a/src/modules/alsa/alsa-util.c b/src/modules/alsa/alsa-util.c
+index 9f35cb20f..fd30f18bd 100644
+--- a/src/modules/alsa/alsa-util.c
++++ b/src/modules/alsa/alsa-util.c
+@@ -1430,7 +1430,8 @@ unsigned int *pa_alsa_get_supported_rates(snd_pcm_t *pcm, unsigned int fallback_
+                                         32000, 44100, 48000,
+                                         64000, 88200, 96000,
+                                         128000, 176400, 192000,
+-                                        384000 };
++                                        352800, 384000,
++                                        705600, 768000 };
+     bool supported[PA_ELEMENTSOF(all_rates)] = { false, };
+     snd_pcm_hw_params_t *hwparams;
+     unsigned int i, j, n, *rates = NULL;
+diff --git a/src/pulse/sample.h b/src/pulse/sample.h
+index 35346a865..65c0c5d6b 100644
+--- a/src/pulse/sample.h
++++ b/src/pulse/sample.h
+@@ -128,7 +128,7 @@ PA_C_DECL_BEGIN
+ #define PA_CHANNELS_MAX 32U
+ 
+ /** Maximum allowed sample rate */
+-#define PA_RATE_MAX (48000U*8U)
++#define PA_RATE_MAX (48000U*16U)
+ 
+ /** Sample format */
+ typedef enum pa_sample_format {

--- a/media-libs/libpulse/files/pulseaudio-16.1-fix-memblock-alignment.patch
+++ b/media-libs/libpulse/files/pulseaudio-16.1-fix-memblock-alignment.patch
@@ -1,0 +1,122 @@
+commit 300db779224625144d6279d230c2daa857c967d8
+Author: Igor V. Kovalenko <igor.v.kovalenko@gmail.com>
+Date:   Thu Feb 9 13:28:29 2023 +0300
+
+    pstream: Pass frame size to keep split memblock parts aligned
+    
+    `pa_pstream_send_memblock()` would split incoming memblock into parts not
+    exceeding maximum pool block size.
+    
+    To make sure split parts of memblock are still frame-aligned add new `align` arg
+    to `pa_pstream_send_memblock`, find out required alignment from stream sample
+    format and pass it there. Bump default alignment to 256 which is good up to
+    32bit 64ch frames.
+    
+    Part-of: <https://gitlab.freedesktop.org/pulseaudio/pulseaudio/-/merge_requests/780>
+
+diff --git a/src/modules/module-tunnel.c b/src/modules/module-tunnel.c
+index 61f427bd3..ab094ba4e 100644
+--- a/src/modules/module-tunnel.c
++++ b/src/modules/module-tunnel.c
+@@ -676,7 +676,7 @@ static int sink_process_msg(pa_msgobject *o, int code, void *data, int64_t offse
+              * IO thread context where the rest of the messages are
+              * dispatched. Yeah, ugly, but I am a lazy bastard. */
+ 
+-            pa_pstream_send_memblock(u->pstream, u->channel, 0, PA_SEEK_RELATIVE, chunk);
++            pa_pstream_send_memblock(u->pstream, u->channel, 0, PA_SEEK_RELATIVE, chunk, pa_frame_size(&u->sink->sample_spec));
+ 
+             u->receive_counter += chunk->length;
+ 
+diff --git a/src/pulse/stream.c b/src/pulse/stream.c
+index 0aa627396..3585b27e8 100644
+--- a/src/pulse/stream.c
++++ b/src/pulse/stream.c
+@@ -1535,7 +1535,7 @@ int pa_stream_write_ext_free(
+         s->write_memblock = NULL;
+         s->write_data = NULL;
+ 
+-        pa_pstream_send_memblock(s->context->pstream, s->channel, offset, seek, &chunk);
++        pa_pstream_send_memblock(s->context->pstream, s->channel, offset, seek, &chunk, pa_frame_size(&s->sample_spec));
+         pa_memblock_unref(chunk.memblock);
+ 
+     } else {
+@@ -1569,7 +1569,7 @@ int pa_stream_write_ext_free(
+                 pa_memblock_release(chunk.memblock);
+             }
+ 
+-            pa_pstream_send_memblock(s->context->pstream, s->channel, t_offset, t_seek, &chunk);
++            pa_pstream_send_memblock(s->context->pstream, s->channel, t_offset, t_seek, &chunk, pa_frame_size(&s->sample_spec));
+ 
+             t_offset = 0;
+             t_seek = PA_SEEK_RELATIVE;
+diff --git a/src/pulsecore/protocol-native.c b/src/pulsecore/protocol-native.c
+index 672182fbc..1342dee10 100644
+--- a/src/pulsecore/protocol-native.c
++++ b/src/pulsecore/protocol-native.c
+@@ -1260,7 +1260,7 @@ static void native_connection_send_memblock(pa_native_connection *c) {
+             if (schunk.length > r->buffer_attr.fragsize)
+                 schunk.length = r->buffer_attr.fragsize;
+ 
+-            pa_pstream_send_memblock(c->pstream, r->index, 0, PA_SEEK_RELATIVE, &schunk);
++            pa_pstream_send_memblock(c->pstream, r->index, 0, PA_SEEK_RELATIVE, &schunk, pa_memblockq_get_base(r->memblockq));
+ 
+             pa_memblockq_drop(r->memblockq, schunk.length);
+             pa_memblock_unref(schunk.memblock);
+@@ -2535,7 +2535,7 @@ static void setup_srbchannel(pa_native_connection *c, pa_mem_type_t shm_type) {
+     mc.memblock = srbt.memblock;
+     mc.index = 0;
+     mc.length = pa_memblock_get_length(srbt.memblock);
+-    pa_pstream_send_memblock(c->pstream, 0, 0, 0, &mc);
++    pa_pstream_send_memblock(c->pstream, 0, 0, 0, &mc, 0);
+ 
+     c->srbpending = srb;
+     return;
+diff --git a/src/pulsecore/pstream.c b/src/pulsecore/pstream.c
+index 7147b776a..ff62f464b 100644
+--- a/src/pulsecore/pstream.c
++++ b/src/pulsecore/pstream.c
+@@ -82,6 +82,10 @@ typedef uint32_t pa_pstream_descriptor[PA_PSTREAM_DESCRIPTOR_MAX];
+  */
+ #define FRAME_SIZE_MAX_ALLOW (1024*1024*16)
+ 
++/* Default memblock alignment used with pa_pstream_send_memblock()
++ */
++#define DEFAULT_PSTREAM_MEMBLOCK_ALIGN (256)
++
+ PA_STATIC_FLIST_DECLARE(items, 0, pa_xfree);
+ 
+ struct item_info {
+@@ -475,7 +479,7 @@ void pa_pstream_send_packet(pa_pstream*p, pa_packet *packet, pa_cmsg_ancil_data
+     p->mainloop->defer_enable(p->defer_event, 1);
+ }
+ 
+-void pa_pstream_send_memblock(pa_pstream*p, uint32_t channel, int64_t offset, pa_seek_mode_t seek_mode, const pa_memchunk *chunk) {
++void pa_pstream_send_memblock(pa_pstream*p, uint32_t channel, int64_t offset, pa_seek_mode_t seek_mode, const pa_memchunk *chunk, size_t align) {
+     size_t length, idx;
+     size_t bsm;
+ 
+@@ -492,6 +496,11 @@ void pa_pstream_send_memblock(pa_pstream*p, uint32_t channel, int64_t offset, pa
+ 
+     bsm = pa_mempool_block_size_max(p->mempool);
+ 
++    if (align == 0)
++        align = DEFAULT_PSTREAM_MEMBLOCK_ALIGN;
++
++    bsm = (bsm / align) * align;
++
+     while (length > 0) {
+         struct item_info *i;
+         size_t n;
+diff --git a/src/pulsecore/pstream.h b/src/pulsecore/pstream.h
+index 2bff270ad..88bdca4cc 100644
+--- a/src/pulsecore/pstream.h
++++ b/src/pulsecore/pstream.h
+@@ -51,7 +51,7 @@ void pa_pstream_unlink(pa_pstream *p);
+ int pa_pstream_attach_memfd_shmid(pa_pstream *p, unsigned shm_id, int memfd_fd);
+ 
+ void pa_pstream_send_packet(pa_pstream*p, pa_packet *packet, pa_cmsg_ancil_data *ancil_data);
+-void pa_pstream_send_memblock(pa_pstream*p, uint32_t channel, int64_t offset, pa_seek_mode_t seek, const pa_memchunk *chunk);
++void pa_pstream_send_memblock(pa_pstream*p, uint32_t channel, int64_t offset, pa_seek_mode_t seek, const pa_memchunk *chunk, size_t align);
+ void pa_pstream_send_release(pa_pstream *p, uint32_t block_id);
+ void pa_pstream_send_revoke(pa_pstream *p, uint32_t block_id);
+ 

--- a/media-libs/libpulse/files/pulseaudio-16.1-smoother-start-paused.patch
+++ b/media-libs/libpulse/files/pulseaudio-16.1-smoother-start-paused.patch
@@ -1,0 +1,26 @@
+commit 8fe50bbc31e11abf2f30864f1e2dbdaa16d0e1c3
+Author: Georg Chini <georg@chini.tk>
+Date:   Thu Aug 25 08:11:04 2022 +0200
+
+    time-smoother-2: Fix stream time when stream starts paused
+    
+    When a stream is started but has not yet called smoother_2_put(), pa_smoother_2_get()
+    returns the time since the start of the stream even if the stream was started paused.
+    When the stream is started paused, pa_smoother_2_get() should return 0 instead. This
+    patch fixes the problem.
+    
+    Part-of: <https://gitlab.freedesktop.org/pulseaudio/pulseaudio/-/merge_requests/745>
+
+diff --git a/src/pulsecore/time-smoother_2.c b/src/pulsecore/time-smoother_2.c
+index e14b52f72..ea7ec1b36 100644
+--- a/src/pulsecore/time-smoother_2.c
++++ b/src/pulsecore/time-smoother_2.c
+@@ -295,7 +295,7 @@ pa_usec_t pa_smoother_2_get(pa_smoother_2 *s, pa_usec_t time_stamp) {
+ 
+     /* If the smoother has not started, just return system time since resume */
+     if (!s->start_time) {
+-        if (time_stamp >= s->resume_time)
++        if (time_stamp >= s->resume_time && !s->paused)
+             current_time = time_stamp - s->resume_time;
+         else
+             current_time = 0;

--- a/media-libs/libpulse/files/pulseaudio-16.1-smoother-time-calculation.patch
+++ b/media-libs/libpulse/files/pulseaudio-16.1-smoother-time-calculation.patch
@@ -1,0 +1,27 @@
+commit c3eae5d00cb79bd897049483126e75bb48a69cd1
+Author: flyingOwl <ofenfisch@googlemail.com>
+Date:   Fri Dec 30 00:16:03 2022 +0100
+
+    time-smoother-2: Fix time calculation by comparing timestamps
+    
+    This fixes the rare case of resume_time being bigger than time_stamp. Which
+    happens sometimes when a gstreamer client is quickly seeking through a
+    media file. The resulting integer underflow then causes a huge value in
+    current_time which will break the playback.
+    
+    Part-of: <https://gitlab.freedesktop.org/pulseaudio/pulseaudio/-/merge_requests/764>
+
+diff --git a/src/pulsecore/time-smoother_2.c b/src/pulsecore/time-smoother_2.c
+index ea7ec1b36..46cc5e9cc 100644
+--- a/src/pulsecore/time-smoother_2.c
++++ b/src/pulsecore/time-smoother_2.c
+@@ -307,7 +307,8 @@ pa_usec_t pa_smoother_2_get(pa_smoother_2 *s, pa_usec_t time_stamp) {
+     /* If we are initializing, add the time since resume to the card time at pause_time */
+     else if (s->init) {
+         current_time += (s->pause_time - s->start_time - s->time_offset - s->fixup_time) * s->time_factor;
+-        current_time += (time_stamp - s->resume_time) * s->time_factor;
++        if (time_stamp > s->resume_time)
++            current_time += (time_stamp - s->resume_time) * s->time_factor;
+ 
+     /* Smoother is running, calculate current sound card time */
+     } else

--- a/media-libs/libpulse/libpulse-16.1-r3.ebuild
+++ b/media-libs/libpulse/libpulse-16.1-r3.ebuild
@@ -77,6 +77,8 @@ DOCS=( NEWS README )
 PATCHES=(
 	"${FILESDIR}"/pulseaudio-16.1-memfd-cleanup.patch
 	"${FILESDIR}"/pulseaudio-16.1-proplist-util-without-gdkx.patch
+	"${FILESDIR}"/pulseaudio-16.1-smoother-start-paused.patch
+	"${FILESDIR}"/pulseaudio-16.1-smoother-time-calculation.patch
 )
 
 src_prepare() {

--- a/media-libs/libpulse/libpulse-16.1-r3.ebuild
+++ b/media-libs/libpulse/libpulse-16.1-r3.ebuild
@@ -66,7 +66,7 @@ BDEPEND="
 PDEPEND="
 	|| (
 		media-video/pipewire[sound-server(+)]
-		media-sound/pulseaudio-daemon
+		>=media-sound/pulseaudio-daemon-16.1-r8
 		media-sound/pulseaudio[daemon(+)]
 	)
 "
@@ -79,6 +79,8 @@ PATCHES=(
 	"${FILESDIR}"/pulseaudio-16.1-proplist-util-without-gdkx.patch
 	"${FILESDIR}"/pulseaudio-16.1-smoother-start-paused.patch
 	"${FILESDIR}"/pulseaudio-16.1-smoother-time-calculation.patch
+	"${FILESDIR}"/pulseaudio-16.1-fix-memblock-alignment.patch
+	"${FILESDIR}"/pulseaudio-16.1-add-more-standard-samplerates.patch
 )
 
 src_prepare() {

--- a/media-libs/libpulse/libpulse-16.1-r3.ebuild
+++ b/media-libs/libpulse/libpulse-16.1-r3.ebuild
@@ -1,0 +1,215 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="7"
+
+MY_PV="${PV/_pre*}"
+MY_P="pulseaudio-${MY_PV}"
+inherit bash-completion-r1 flag-o-matic gnome2-utils meson-multilib optfeature systemd toolchain-funcs udev
+
+DESCRIPTION="Libraries for PulseAudio clients"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/PulseAudio/"
+
+if [[ ${PV} = 9999 ]]; then
+	inherit git-r3
+	EGIT_BRANCH="master"
+	EGIT_REPO_URI="https://gitlab.freedesktop.org/pulseaudio/pulseaudio"
+else
+	SRC_URI="https://freedesktop.org/software/pulseaudio/releases/${MY_P}.tar.xz"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86 ~amd64-linux ~x86-linux"
+fi
+
+S="${WORKDIR}/${MY_P}"
+
+LICENSE="LGPL-2.1+"
+
+SLOT="0"
+IUSE="+asyncns dbus doc +glib gtk selinux systemd test valgrind X"
+RESTRICT="!test? ( test )"
+
+# NOTE: libpcre needed in some cases, bug #472228
+# TODO: libatomic_ops is only needed on some architectures and conditions, and then at runtime too
+RDEPEND="
+	dev-libs/libatomic_ops
+	>=media-libs/libsndfile-1.0.20[${MULTILIB_USEDEP}]
+	asyncns? ( >=net-libs/libasyncns-0.1[${MULTILIB_USEDEP}] )
+	dbus? ( >=sys-apps/dbus-1.4.12[${MULTILIB_USEDEP}] )
+	elibc_mingw? ( dev-libs/libpcre:3 )
+	glib? ( >=dev-libs/glib-2.28.0:2[${MULTILIB_USEDEP}] )
+	gtk? ( x11-libs/gtk+:3 )
+	selinux? ( sec-policy/selinux-pulseaudio )
+	systemd? ( sys-apps/systemd:= )
+	valgrind? ( dev-util/valgrind )
+	X? (
+		x11-libs/libX11[${MULTILIB_USEDEP}]
+		>=x11-libs/libxcb-1.6[${MULTILIB_USEDEP}]
+	)
+	!<media-sound/pulseaudio-15.0-r100
+"
+
+DEPEND="${RDEPEND}
+	test? ( >=dev-libs/check-0.9.10 )
+	X? ( x11-base/xorg-proto )
+"
+
+# pulseaudio ships a bundled xmltoman, which uses XML::Parser
+BDEPEND="
+	dev-lang/perl
+	dev-perl/XML-Parser
+	sys-devel/gettext
+	sys-devel/m4
+	virtual/libiconv
+	virtual/libintl
+	virtual/pkgconfig
+	doc? ( app-doc/doxygen )
+"
+PDEPEND="
+	|| (
+		media-video/pipewire[sound-server(+)]
+		media-sound/pulseaudio-daemon
+		media-sound/pulseaudio[daemon(+)]
+	)
+"
+
+DOCS=( NEWS README )
+
+# patches merged upstream, to be removed with 16.2 or later bump
+PATCHES=(
+	"${FILESDIR}"/pulseaudio-16.1-memfd-cleanup.patch
+	"${FILESDIR}"/pulseaudio-16.1-proplist-util-without-gdkx.patch
+)
+
+src_prepare() {
+	default
+
+	# disable autospawn by client
+	sed -i -e 's:; autospawn = yes:autospawn = no:g' src/pulse/client.conf.in || die
+
+	gnome2_environment_reset
+}
+
+multilib_src_configure() {
+	# ideally we want !tc-ld-is-bfd for best future-proofing, but it needs
+	# https://github.com/gentoo/gentoo/pull/28355
+	# mold needs this too but right now tc-ld-is-mold is also not available
+	if tc-ld-is-lld; then
+		append-ldflags -Wl,--undefined-version
+	fi
+
+	local emesonargs=(
+		--localstatedir="${EPREFIX}"/var
+
+		-Ddaemon=false
+		-Dclient=true
+		$(meson_native_use_bool doc doxygen)
+		-Dgcov=false
+		# tests involve random modules, so just do them for the native # TODO: tests should run always
+		$(meson_native_use_bool test tests)
+		-Ddatabase=simple # Not used for non-daemon, simple database avoids external dep checks
+		-Dstream-restore-clear-old-devices=true
+		-Drunning-from-build-tree=false
+
+		# Paths
+		-Dmodlibexecdir="${EPREFIX}/usr/$(get_libdir)/pulseaudio/modules" # Was $(get_libdir)/${P}
+		-Dsystemduserunitdir=$(systemd_get_userunitdir)
+		-Dudevrulesdir="${EPREFIX}$(get_udevdir)/rules.d"
+		-Dbashcompletiondir="$(get_bashcompdir)" # Alternatively DEPEND on app-shells/bash-completion for pkg-config to provide the value
+
+		# Optional features
+		-Dalsa=disabled
+		$(meson_feature asyncns)
+		-Davahi=disabled
+		-Dbluez5=disabled
+		-Dbluez5-gstreamer=disabled
+		-Dbluez5-native-headset=false
+		-Dbluez5-ofono-headset=false
+		$(meson_feature dbus)
+		-Delogind=disabled
+		-Dfftw=disabled
+		$(meson_feature glib) # WARNING: toggling this likely changes ABI
+		-Dgsettings=disabled
+		-Dgstreamer=disabled
+		$(meson_native_use_feature gtk)
+		-Dhal-compat=false
+		-Dipv6=true
+		-Djack=disabled
+		-Dlirc=disabled
+		-Dopenssl=disabled
+		-Dorc=disabled
+		-Doss-output=disabled
+		-Dsamplerate=disabled # Matches upstream
+		-Dsoxr=disabled
+		-Dspeex=disabled
+		$(meson_native_use_feature systemd)
+		-Dtcpwrap=disabled
+		-Dudev=disabled
+		$(meson_native_use_feature valgrind)
+		$(meson_feature X x11)
+
+		# Echo cancellation
+		-Dadrian-aec=false
+		-Dwebrtc-aec=disabled
+	)
+
+	if multilib_is_native_abi; then
+		# Make padsp work for non-native ABI, supposedly only possible with glibc;
+		# this is used by /usr/bin/padsp that comes from native build, thus we need
+		# this argument for native build
+		if use elibc_glibc; then
+			emesonargs+=( -Dpulsedsp-location="${EPREFIX}"'/usr/\\$$LIB/pulseaudio' )
+		fi
+	else
+		emesonargs+=( -Dman=false )
+		if ! use elibc_glibc; then
+			# Non-glibc multilib is probably non-existent but just in case:
+			ewarn "padsp wrapper for OSS emulation will only work with native ABI applications!"
+		fi
+	fi
+
+	meson_src_configure
+}
+
+multilib_src_compile() {
+	meson_src_compile
+
+	if multilib_is_native_abi; then
+		if use doc; then
+			einfo "Generating documentation ..."
+			meson_src_compile doxygen
+		fi
+	fi
+}
+
+multilib_src_install() {
+	# The files referenced in the DOCS array do not exist in the multilib source directory,
+	# therefore clear the variable when calling the function that will access it.
+	DOCS= meson_src_install
+
+	# Upstream installs 'pactl' if client is built, with all symlinks except for
+	# 'pulseaudio', 'pacmd' and 'pasuspender' which are installed if server is built.
+	# This trips QA warning, workaround:
+	# - install missing aliases in media-libs/libpulse (client build)
+	# - remove corresponding symlinks in media-sound/pulseaudio-daemonclient (server build)
+	bashcomp_alias pactl pulseaudio
+	bashcomp_alias pactl pacmd
+	bashcomp_alias pactl pasuspender
+
+	if multilib_is_native_abi; then
+		if use doc; then
+			einfo "Installing documentation ..."
+			docinto html
+			dodoc -r doxygen/html/.
+		fi
+	fi
+}
+
+multilib_src_install_all() {
+	einstalldocs
+
+	find "${ED}" \( -name '*.a' -o -name '*.la' \) -delete || die
+}
+
+pkg_postinst() {
+	optfeature_header "PulseAudio can be enhanced by installing the following:"
+	use dbus && optfeature "restricted realtime capabilities via D-Bus" sys-auth/rtkit
+}

--- a/media-sound/pulseaudio-daemon/files/pulseaudio-16.1-add-more-standard-samplerates.patch
+++ b/media-sound/pulseaudio-daemon/files/pulseaudio-16.1-add-more-standard-samplerates.patch
@@ -1,0 +1,35 @@
+commit 86c5fbab5778685e19b5a4a9b8eb04ca90dff780
+Author: Igor V. Kovalenko <igor.v.kovalenko@gmail.com>
+Date:   Sun Feb 5 19:49:10 2023 +0300
+
+    alsa-util: Add more standard sample rates.
+    
+    Part-of: <https://gitlab.freedesktop.org/pulseaudio/pulseaudio/-/merge_requests/776>
+
+diff --git a/src/modules/alsa/alsa-util.c b/src/modules/alsa/alsa-util.c
+index 9f35cb20f..fd30f18bd 100644
+--- a/src/modules/alsa/alsa-util.c
++++ b/src/modules/alsa/alsa-util.c
+@@ -1430,7 +1430,8 @@ unsigned int *pa_alsa_get_supported_rates(snd_pcm_t *pcm, unsigned int fallback_
+                                         32000, 44100, 48000,
+                                         64000, 88200, 96000,
+                                         128000, 176400, 192000,
+-                                        384000 };
++                                        352800, 384000,
++                                        705600, 768000 };
+     bool supported[PA_ELEMENTSOF(all_rates)] = { false, };
+     snd_pcm_hw_params_t *hwparams;
+     unsigned int i, j, n, *rates = NULL;
+diff --git a/src/pulse/sample.h b/src/pulse/sample.h
+index 35346a865..65c0c5d6b 100644
+--- a/src/pulse/sample.h
++++ b/src/pulse/sample.h
+@@ -128,7 +128,7 @@ PA_C_DECL_BEGIN
+ #define PA_CHANNELS_MAX 32U
+ 
+ /** Maximum allowed sample rate */
+-#define PA_RATE_MAX (48000U*8U)
++#define PA_RATE_MAX (48000U*16U)
+ 
+ /** Sample format */
+ typedef enum pa_sample_format {

--- a/media-sound/pulseaudio-daemon/files/pulseaudio-16.1-fix-memblock-alignment.patch
+++ b/media-sound/pulseaudio-daemon/files/pulseaudio-16.1-fix-memblock-alignment.patch
@@ -1,0 +1,122 @@
+commit 300db779224625144d6279d230c2daa857c967d8
+Author: Igor V. Kovalenko <igor.v.kovalenko@gmail.com>
+Date:   Thu Feb 9 13:28:29 2023 +0300
+
+    pstream: Pass frame size to keep split memblock parts aligned
+    
+    `pa_pstream_send_memblock()` would split incoming memblock into parts not
+    exceeding maximum pool block size.
+    
+    To make sure split parts of memblock are still frame-aligned add new `align` arg
+    to `pa_pstream_send_memblock`, find out required alignment from stream sample
+    format and pass it there. Bump default alignment to 256 which is good up to
+    32bit 64ch frames.
+    
+    Part-of: <https://gitlab.freedesktop.org/pulseaudio/pulseaudio/-/merge_requests/780>
+
+diff --git a/src/modules/module-tunnel.c b/src/modules/module-tunnel.c
+index 61f427bd3..ab094ba4e 100644
+--- a/src/modules/module-tunnel.c
++++ b/src/modules/module-tunnel.c
+@@ -676,7 +676,7 @@ static int sink_process_msg(pa_msgobject *o, int code, void *data, int64_t offse
+              * IO thread context where the rest of the messages are
+              * dispatched. Yeah, ugly, but I am a lazy bastard. */
+ 
+-            pa_pstream_send_memblock(u->pstream, u->channel, 0, PA_SEEK_RELATIVE, chunk);
++            pa_pstream_send_memblock(u->pstream, u->channel, 0, PA_SEEK_RELATIVE, chunk, pa_frame_size(&u->sink->sample_spec));
+ 
+             u->receive_counter += chunk->length;
+ 
+diff --git a/src/pulse/stream.c b/src/pulse/stream.c
+index 0aa627396..3585b27e8 100644
+--- a/src/pulse/stream.c
++++ b/src/pulse/stream.c
+@@ -1535,7 +1535,7 @@ int pa_stream_write_ext_free(
+         s->write_memblock = NULL;
+         s->write_data = NULL;
+ 
+-        pa_pstream_send_memblock(s->context->pstream, s->channel, offset, seek, &chunk);
++        pa_pstream_send_memblock(s->context->pstream, s->channel, offset, seek, &chunk, pa_frame_size(&s->sample_spec));
+         pa_memblock_unref(chunk.memblock);
+ 
+     } else {
+@@ -1569,7 +1569,7 @@ int pa_stream_write_ext_free(
+                 pa_memblock_release(chunk.memblock);
+             }
+ 
+-            pa_pstream_send_memblock(s->context->pstream, s->channel, t_offset, t_seek, &chunk);
++            pa_pstream_send_memblock(s->context->pstream, s->channel, t_offset, t_seek, &chunk, pa_frame_size(&s->sample_spec));
+ 
+             t_offset = 0;
+             t_seek = PA_SEEK_RELATIVE;
+diff --git a/src/pulsecore/protocol-native.c b/src/pulsecore/protocol-native.c
+index 672182fbc..1342dee10 100644
+--- a/src/pulsecore/protocol-native.c
++++ b/src/pulsecore/protocol-native.c
+@@ -1260,7 +1260,7 @@ static void native_connection_send_memblock(pa_native_connection *c) {
+             if (schunk.length > r->buffer_attr.fragsize)
+                 schunk.length = r->buffer_attr.fragsize;
+ 
+-            pa_pstream_send_memblock(c->pstream, r->index, 0, PA_SEEK_RELATIVE, &schunk);
++            pa_pstream_send_memblock(c->pstream, r->index, 0, PA_SEEK_RELATIVE, &schunk, pa_memblockq_get_base(r->memblockq));
+ 
+             pa_memblockq_drop(r->memblockq, schunk.length);
+             pa_memblock_unref(schunk.memblock);
+@@ -2535,7 +2535,7 @@ static void setup_srbchannel(pa_native_connection *c, pa_mem_type_t shm_type) {
+     mc.memblock = srbt.memblock;
+     mc.index = 0;
+     mc.length = pa_memblock_get_length(srbt.memblock);
+-    pa_pstream_send_memblock(c->pstream, 0, 0, 0, &mc);
++    pa_pstream_send_memblock(c->pstream, 0, 0, 0, &mc, 0);
+ 
+     c->srbpending = srb;
+     return;
+diff --git a/src/pulsecore/pstream.c b/src/pulsecore/pstream.c
+index 7147b776a..ff62f464b 100644
+--- a/src/pulsecore/pstream.c
++++ b/src/pulsecore/pstream.c
+@@ -82,6 +82,10 @@ typedef uint32_t pa_pstream_descriptor[PA_PSTREAM_DESCRIPTOR_MAX];
+  */
+ #define FRAME_SIZE_MAX_ALLOW (1024*1024*16)
+ 
++/* Default memblock alignment used with pa_pstream_send_memblock()
++ */
++#define DEFAULT_PSTREAM_MEMBLOCK_ALIGN (256)
++
+ PA_STATIC_FLIST_DECLARE(items, 0, pa_xfree);
+ 
+ struct item_info {
+@@ -475,7 +479,7 @@ void pa_pstream_send_packet(pa_pstream*p, pa_packet *packet, pa_cmsg_ancil_data
+     p->mainloop->defer_enable(p->defer_event, 1);
+ }
+ 
+-void pa_pstream_send_memblock(pa_pstream*p, uint32_t channel, int64_t offset, pa_seek_mode_t seek_mode, const pa_memchunk *chunk) {
++void pa_pstream_send_memblock(pa_pstream*p, uint32_t channel, int64_t offset, pa_seek_mode_t seek_mode, const pa_memchunk *chunk, size_t align) {
+     size_t length, idx;
+     size_t bsm;
+ 
+@@ -492,6 +496,11 @@ void pa_pstream_send_memblock(pa_pstream*p, uint32_t channel, int64_t offset, pa
+ 
+     bsm = pa_mempool_block_size_max(p->mempool);
+ 
++    if (align == 0)
++        align = DEFAULT_PSTREAM_MEMBLOCK_ALIGN;
++
++    bsm = (bsm / align) * align;
++
+     while (length > 0) {
+         struct item_info *i;
+         size_t n;
+diff --git a/src/pulsecore/pstream.h b/src/pulsecore/pstream.h
+index 2bff270ad..88bdca4cc 100644
+--- a/src/pulsecore/pstream.h
++++ b/src/pulsecore/pstream.h
+@@ -51,7 +51,7 @@ void pa_pstream_unlink(pa_pstream *p);
+ int pa_pstream_attach_memfd_shmid(pa_pstream *p, unsigned shm_id, int memfd_fd);
+ 
+ void pa_pstream_send_packet(pa_pstream*p, pa_packet *packet, pa_cmsg_ancil_data *ancil_data);
+-void pa_pstream_send_memblock(pa_pstream*p, uint32_t channel, int64_t offset, pa_seek_mode_t seek, const pa_memchunk *chunk);
++void pa_pstream_send_memblock(pa_pstream*p, uint32_t channel, int64_t offset, pa_seek_mode_t seek, const pa_memchunk *chunk, size_t align);
+ void pa_pstream_send_release(pa_pstream *p, uint32_t block_id);
+ void pa_pstream_send_revoke(pa_pstream *p, uint32_t block_id);
+ 

--- a/media-sound/pulseaudio-daemon/files/pulseaudio-16.1-fix-resampler-oversized-memblock.patch
+++ b/media-sound/pulseaudio-daemon/files/pulseaudio-16.1-fix-resampler-oversized-memblock.patch
@@ -1,0 +1,55 @@
+commit 1cfa7378236b3cf9daf3be09d3227b92df69cc53
+Author: Igor V. Kovalenko <igor.v.kovalenko@gmail.com>
+Date:   Wed Feb 8 03:24:59 2023 +0300
+
+    resampler: Fix oversized memblock pushed from resampler
+    
+    The assumption that the format enum is ordered by size is not valid for quite
+    some time, since 24bit formats were appended to format enum later than 32bit
+    formats. This causes resampler to produce properly aligned memblock of size
+    larger than maximum mempool block size if input format is 24bit and output
+    format is 32bit.
+    
+    Oversized block is getting split by `pa_pstream_send_memblock()` into parts of
+    size not exceeding maximum mempool block size. This usually works well but for
+    32ch 32bit 48000Hz stream the frame alignment is 128 bytes and maximum mempool
+    block size value is multiple of 64 but not 128 bytes, therefore resulting parts
+    are misaligned.
+    
+    On receiving side this causes extra allocation of 128 byte chunk while `mcalign`
+    helper reassembles properly aligned frame out of second block of misaligned
+    size. While first and second properly aligned frames are retrieved successfully
+    from `mcalign` helper, third retrieved frame would end up with properly aligned
+    size but misaligned memblock index (in this example, that would be 64 bytes.)
+    Attempt to push a chunk with misaligned memblock index causes assertion failure
+    
+      Assertion 'uchunk->index % bq->base == 0' failed at memblockq.c:289,
+        function pa_memblockq_push(). Aborting.
+    
+    Fix oversized block issue by checking proper size of format instead of enum
+    value.
+    
+    Fixes: a67c21f09 ("merge 'lennart' branch back into trunk.")
+    Part-of: <https://gitlab.freedesktop.org/pulseaudio/pulseaudio/-/merge_requests/778>
+
+diff --git a/src/pulsecore/resampler.c b/src/pulsecore/resampler.c
+index b035f67ed..ba18c92c4 100644
+--- a/src/pulsecore/resampler.c
++++ b/src/pulsecore/resampler.c
+@@ -613,9 +613,13 @@ size_t pa_resampler_max_block_size(pa_resampler *r) {
+      * conversion */
+     max_ss.channels = (uint8_t) (PA_MAX(r->i_ss.channels, r->o_ss.channels));
+ 
+-    /* We silently assume that the format enum is ordered by size */
+-    max_ss.format = PA_MAX(r->i_ss.format, r->o_ss.format);
+-    max_ss.format = PA_MAX(max_ss.format, r->work_format);
++    max_ss.format = r->i_ss.format;
++
++    if (pa_sample_size_of_format(max_ss.format) < pa_sample_size_of_format(r->o_ss.format))
++        max_ss.format = r->o_ss.format;
++
++    if (pa_sample_size_of_format(max_ss.format) < pa_sample_size_of_format(r->work_format))
++        max_ss.format = r->work_format;
+ 
+     max_ss.rate = PA_MAX(r->i_ss.rate, r->o_ss.rate);
+ 

--- a/media-sound/pulseaudio-daemon/files/pulseaudio-16.1-fix-uac2-broken-avoid-resampling.patch
+++ b/media-sound/pulseaudio-daemon/files/pulseaudio-16.1-fix-uac2-broken-avoid-resampling.patch
@@ -1,0 +1,382 @@
+commit aed52c507f345d0b5c4cd2b1d2c58dae2d904b53
+Author: Igor V. Kovalenko <igor.v.kovalenko@gmail.com>
+Date:   Wed Feb 22 01:19:24 2023 +0300
+
+    alsa-util: Perform format and rate detection before setting HW params
+    
+    Perform detection of supported sample format and rates just after device is
+    opened, before `snd_pcm_hw_params()` is called for the first time. This fixes a
+    problem where device restricts available sample rates after HW params are set
+    preventing sample rate detection (seen with UAC2 devices and kernel 6.1.9)
+    
+    Bug: https://gitlab.freedesktop.org/pulseaudio/pulseaudio/-/issues/1414
+    Bug: https://github.com/alsa-project/alsa-lib/issues/119
+    Part-of: <https://gitlab.freedesktop.org/pulseaudio/pulseaudio/-/merge_requests/782>
+
+diff --git a/src/modules/alsa/alsa-mixer.c b/src/modules/alsa/alsa-mixer.c
+index 49c39687c..c272e392b 100644
+--- a/src/modules/alsa/alsa-mixer.c
++++ b/src/modules/alsa/alsa-mixer.c
+@@ -5074,7 +5074,7 @@ static snd_pcm_t* mapping_open_pcm(pa_alsa_mapping *m,
+     handle = pa_alsa_open_by_template(
+                               m->device_strings, dev_id, NULL, &try_ss,
+                               &try_map, mode, &try_period_size,
+-                              &try_buffer_size, 0, NULL, NULL, exact_channels);
++                              &try_buffer_size, 0, NULL, NULL, NULL, NULL, exact_channels);
+     if (handle && !exact_channels && m->channel_map.channels != try_map.channels) {
+         char buf[PA_CHANNEL_MAP_SNPRINT_MAX];
+         pa_log_debug("Channel map for mapping '%s' permanently changed to '%s'", m->name,
+diff --git a/src/modules/alsa/alsa-sink.c b/src/modules/alsa/alsa-sink.c
+index b249df680..ca22f195f 100644
+--- a/src/modules/alsa/alsa-sink.c
++++ b/src/modules/alsa/alsa-sink.c
+@@ -2527,7 +2527,9 @@ pa_sink *pa_alsa_sink_new(pa_module *m, pa_modargs *ma, const char*driver, pa_ca
+                       &ss, &map,
+                       SND_PCM_STREAM_PLAYBACK,
+                       &period_frames, &buffer_frames, tsched_frames,
+-                      &b, &d, mapping)))
++                      &b, &d,
++                      &u->supported_formats, &u->supported_rates,
++                      mapping)))
+             goto fail;
+ 
+     } else if ((dev_id = pa_modargs_get_value(ma, "device_id", NULL))) {
+@@ -2541,7 +2543,9 @@ pa_sink *pa_alsa_sink_new(pa_module *m, pa_modargs *ma, const char*driver, pa_ca
+                       &ss, &map,
+                       SND_PCM_STREAM_PLAYBACK,
+                       &period_frames, &buffer_frames, tsched_frames,
+-                      &b, &d, profile_set, &mapping)))
++                      &b, &d,
++                      &u->supported_formats, &u->supported_rates,
++                      profile_set, &mapping)))
+             goto fail;
+ 
+     } else {
+@@ -2552,7 +2556,9 @@ pa_sink *pa_alsa_sink_new(pa_module *m, pa_modargs *ma, const char*driver, pa_ca
+                       &ss, &map,
+                       SND_PCM_STREAM_PLAYBACK,
+                       &period_frames, &buffer_frames, tsched_frames,
+-                      &b, &d, false)))
++                      &b, &d,
++                      &u->supported_formats, &u->supported_rates,
++                      false)))
+             goto fail;
+     }
+ 
+@@ -2598,13 +2604,11 @@ pa_sink *pa_alsa_sink_new(pa_module *m, pa_modargs *ma, const char*driver, pa_ca
+ 
+     u->verified_sample_spec = ss;
+ 
+-    u->supported_formats = pa_alsa_get_supported_formats(u->pcm_handle, ss.format);
+     if (!u->supported_formats) {
+         pa_log_error("Failed to find any supported sample formats.");
+         goto fail;
+     }
+ 
+-    u->supported_rates = pa_alsa_get_supported_rates(u->pcm_handle, ss.rate);
+     if (!u->supported_rates) {
+         pa_log_error("Failed to find any supported sample rates.");
+         goto fail;
+diff --git a/src/modules/alsa/alsa-source.c b/src/modules/alsa/alsa-source.c
+index ef8b12c32..d88c47f1f 100644
+--- a/src/modules/alsa/alsa-source.c
++++ b/src/modules/alsa/alsa-source.c
+@@ -2218,7 +2218,7 @@ pa_source *pa_alsa_source_new(pa_module *m, pa_modargs *ma, const char*driver, p
+                       &ss, &map,
+                       SND_PCM_STREAM_CAPTURE,
+                       &period_frames, &buffer_frames, tsched_frames,
+-                      &b, &d, mapping)))
++                      &b, &d, &u->supported_formats, &u->supported_rates, mapping)))
+             goto fail;
+ 
+     } else if ((dev_id = pa_modargs_get_value(ma, "device_id", NULL))) {
+@@ -2232,7 +2232,7 @@ pa_source *pa_alsa_source_new(pa_module *m, pa_modargs *ma, const char*driver, p
+                       &ss, &map,
+                       SND_PCM_STREAM_CAPTURE,
+                       &period_frames, &buffer_frames, tsched_frames,
+-                      &b, &d, profile_set, &mapping)))
++                      &b, &d, &u->supported_formats, &u->supported_rates, profile_set, &mapping)))
+             goto fail;
+ 
+     } else {
+@@ -2243,7 +2243,7 @@ pa_source *pa_alsa_source_new(pa_module *m, pa_modargs *ma, const char*driver, p
+                       &ss, &map,
+                       SND_PCM_STREAM_CAPTURE,
+                       &period_frames, &buffer_frames, tsched_frames,
+-                      &b, &d, false)))
++                      &b, &d, &u->supported_formats, &u->supported_rates, false)))
+             goto fail;
+     }
+ 
+@@ -2279,13 +2279,11 @@ pa_source *pa_alsa_source_new(pa_module *m, pa_modargs *ma, const char*driver, p
+ 
+     u->verified_sample_spec = ss;
+ 
+-    u->supported_formats = pa_alsa_get_supported_formats(u->pcm_handle, ss.format);
+     if (!u->supported_formats) {
+         pa_log_error("Failed to find any supported sample formats.");
+         goto fail;
+     }
+ 
+-    u->supported_rates = pa_alsa_get_supported_rates(u->pcm_handle, ss.rate);
+     if (!u->supported_rates) {
+         pa_log_error("Failed to find any supported sample rates.");
+         goto fail;
+diff --git a/src/modules/alsa/alsa-ucm.c b/src/modules/alsa/alsa-ucm.c
+index e75756f53..744e7aae1 100644
+--- a/src/modules/alsa/alsa-ucm.c
++++ b/src/modules/alsa/alsa-ucm.c
+@@ -2026,7 +2026,7 @@ static snd_pcm_t* mapping_open_pcm(pa_alsa_ucm_config *ucm, pa_alsa_mapping *m,
+     try_buffer_size = ucm->core->default_n_fragments * try_period_size;
+ 
+     pcm = pa_alsa_open_by_device_string(m->device_strings[0], NULL, &try_ss,
+-            &try_map, mode, &try_period_size, &try_buffer_size, 0, NULL, NULL, exact_channels);
++            &try_map, mode, &try_period_size, &try_buffer_size, 0, NULL, NULL, NULL, NULL, exact_channels);
+ 
+     if (pcm) {
+         if (!exact_channels)
+diff --git a/src/modules/alsa/alsa-util.c b/src/modules/alsa/alsa-util.c
+index fd30f18bd..b631c870c 100644
+--- a/src/modules/alsa/alsa-util.c
++++ b/src/modules/alsa/alsa-util.c
+@@ -523,6 +523,8 @@ snd_pcm_t *pa_alsa_open_by_device_id_auto(
+         snd_pcm_uframes_t tsched_size,
+         bool *use_mmap,
+         bool *use_tsched,
++        pa_sample_format_t **query_supported_formats,
++        unsigned int **query_supported_rates,
+         pa_alsa_profile_set *ps,
+         pa_alsa_mapping **mapping) {
+ 
+@@ -561,6 +563,8 @@ snd_pcm_t *pa_alsa_open_by_device_id_auto(
+                 tsched_size,
+                 use_mmap,
+                 use_tsched,
++                query_supported_formats,
++                query_supported_rates,
+                 m);
+ 
+         if (pcm_handle) {
+@@ -588,6 +592,8 @@ snd_pcm_t *pa_alsa_open_by_device_id_auto(
+                 tsched_size,
+                 use_mmap,
+                 use_tsched,
++                query_supported_formats,
++                query_supported_rates,
+                 m);
+ 
+         if (pcm_handle) {
+@@ -612,6 +618,8 @@ snd_pcm_t *pa_alsa_open_by_device_id_auto(
+             tsched_size,
+             use_mmap,
+             use_tsched,
++            query_supported_formats,
++            query_supported_rates,
+             false);
+     pa_xfree(d);
+ 
+@@ -632,6 +640,8 @@ snd_pcm_t *pa_alsa_open_by_device_id_mapping(
+         snd_pcm_uframes_t tsched_size,
+         bool *use_mmap,
+         bool *use_tsched,
++        pa_sample_format_t **query_supported_formats,
++        unsigned int **query_supported_rates,
+         pa_alsa_mapping *m) {
+ 
+     snd_pcm_t *pcm_handle;
+@@ -661,6 +671,8 @@ snd_pcm_t *pa_alsa_open_by_device_id_mapping(
+             tsched_size,
+             use_mmap,
+             use_tsched,
++            query_supported_formats,
++            query_supported_rates,
+             pa_channel_map_valid(&m->channel_map) /* Query the channel count if we don't know what we want */);
+ 
+     if (!pcm_handle)
+@@ -684,6 +696,8 @@ snd_pcm_t *pa_alsa_open_by_device_string(
+         snd_pcm_uframes_t tsched_size,
+         bool *use_mmap,
+         bool *use_tsched,
++        pa_sample_format_t **query_supported_formats,
++        unsigned int **query_supported_rates,
+         bool require_exact_channel_number) {
+ 
+     int err;
+@@ -711,6 +725,12 @@ snd_pcm_t *pa_alsa_open_by_device_string(
+ 
+         pa_log_debug("Managed to open %s", d);
+ 
++        if (query_supported_formats)
++            *query_supported_formats = pa_alsa_get_supported_formats(pcm_handle, ss->format);
++
++        if (query_supported_rates)
++            *query_supported_rates = pa_alsa_get_supported_rates(pcm_handle, ss->rate);
++
+         if ((err = pa_alsa_set_hw_params(
+                      pcm_handle,
+                      ss,
+@@ -784,6 +804,8 @@ snd_pcm_t *pa_alsa_open_by_template(
+         snd_pcm_uframes_t tsched_size,
+         bool *use_mmap,
+         bool *use_tsched,
++        pa_sample_format_t **query_supported_formats,
++        unsigned int **query_supported_rates,
+         bool require_exact_channel_number) {
+ 
+     snd_pcm_t *pcm_handle;
+@@ -805,6 +827,8 @@ snd_pcm_t *pa_alsa_open_by_template(
+                 tsched_size,
+                 use_mmap,
+                 use_tsched,
++                query_supported_formats,
++                query_supported_rates,
+                 require_exact_channel_number);
+ 
+         pa_xfree(d);
+diff --git a/src/modules/alsa/alsa-util.h b/src/modules/alsa/alsa-util.h
+index 2eed3eac3..c65801104 100644
+--- a/src/modules/alsa/alsa-util.h
++++ b/src/modules/alsa/alsa-util.h
+@@ -67,6 +67,8 @@ snd_pcm_t *pa_alsa_open_by_device_id_auto(
+         snd_pcm_uframes_t tsched_size,
+         bool *use_mmap,                   /* modified at return */
+         bool *use_tsched,                 /* modified at return */
++        pa_sample_format_t **query_supported_formats, /* modified at return */
++        unsigned int **query_supported_rates,         /* modified at return */
+         pa_alsa_profile_set *ps,
+         pa_alsa_mapping **mapping);       /* modified at return */
+ 
+@@ -82,6 +84,8 @@ snd_pcm_t *pa_alsa_open_by_device_id_mapping(
+         snd_pcm_uframes_t tsched_size,
+         bool *use_mmap,                   /* modified at return */
+         bool *use_tsched,                 /* modified at return */
++        pa_sample_format_t **query_supported_formats, /* modified at return */
++        unsigned int **query_supported_rates,         /* modified at return */
+         pa_alsa_mapping *mapping);
+ 
+ /* Opens the explicit ALSA device */
+@@ -96,6 +100,8 @@ snd_pcm_t *pa_alsa_open_by_device_string(
+         snd_pcm_uframes_t tsched_size,
+         bool *use_mmap,                   /* modified at return */
+         bool *use_tsched,                 /* modified at return */
++        pa_sample_format_t **query_supported_formats, /* modified at return */
++        unsigned int **query_supported_rates,         /* modified at return */
+         bool require_exact_channel_number);
+ 
+ /* Opens the explicit ALSA device with a fallback list */
+@@ -111,6 +117,8 @@ snd_pcm_t *pa_alsa_open_by_template(
+         snd_pcm_uframes_t tsched_size,
+         bool *use_mmap,                   /* modified at return */
+         bool *use_tsched,                 /* modified at return */
++        pa_sample_format_t **query_supported_formats, /* modified at return */
++        unsigned int **query_supported_rates,        /* modified at return */
+         bool require_exact_channel_number);
+ 
+ void pa_alsa_dump(pa_log_level_t level, snd_pcm_t *pcm);
+commit 5ab2b9cb0e32190c3ea12b0f4cb7533d7340bbf1
+Author: Igor V. Kovalenko <igor.v.kovalenko@gmail.com>
+Date:   Wed Feb 22 01:50:22 2023 +0300
+
+    alsa-util: Fix pa_alsa_get_supported_formats fallback.
+    
+    Looks like original intention was to scan over sample formats supported by PA,
+    but code does the scan by list of alsa formats. Reverse the map and adjust
+    fallback case which now can use the same map.
+    
+    Part-of: <https://gitlab.freedesktop.org/pulseaudio/pulseaudio/-/merge_requests/782>
+
+diff --git a/src/modules/alsa/alsa-util.c b/src/modules/alsa/alsa-util.c
+index b631c870c..d3c092f52 100644
+--- a/src/modules/alsa/alsa-util.c
++++ b/src/modules/alsa/alsa-util.c
+@@ -1502,35 +1502,35 @@ unsigned int *pa_alsa_get_supported_rates(snd_pcm_t *pcm, unsigned int fallback_
+ }
+ 
+ pa_sample_format_t *pa_alsa_get_supported_formats(snd_pcm_t *pcm, pa_sample_format_t fallback_format) {
+-    static const snd_pcm_format_t format_trans_to_pa[] = {
+-        [SND_PCM_FORMAT_U8] = PA_SAMPLE_U8,
+-        [SND_PCM_FORMAT_A_LAW] = PA_SAMPLE_ALAW,
+-        [SND_PCM_FORMAT_MU_LAW] = PA_SAMPLE_ULAW,
+-        [SND_PCM_FORMAT_S16_LE] = PA_SAMPLE_S16LE,
+-        [SND_PCM_FORMAT_S16_BE] = PA_SAMPLE_S16BE,
+-        [SND_PCM_FORMAT_FLOAT_LE] = PA_SAMPLE_FLOAT32LE,
+-        [SND_PCM_FORMAT_FLOAT_BE] = PA_SAMPLE_FLOAT32BE,
+-        [SND_PCM_FORMAT_S32_LE] = PA_SAMPLE_S32LE,
+-        [SND_PCM_FORMAT_S32_BE] = PA_SAMPLE_S32BE,
+-        [SND_PCM_FORMAT_S24_3LE] = PA_SAMPLE_S24LE,
+-        [SND_PCM_FORMAT_S24_3BE] = PA_SAMPLE_S24BE,
+-        [SND_PCM_FORMAT_S24_LE] = PA_SAMPLE_S24_32LE,
+-        [SND_PCM_FORMAT_S24_BE] = PA_SAMPLE_S24_32BE,
++    static const snd_pcm_format_t format_trans_to_pcm[] = {
++        [PA_SAMPLE_U8] = SND_PCM_FORMAT_U8,
++        [PA_SAMPLE_ALAW] = SND_PCM_FORMAT_A_LAW,
++        [PA_SAMPLE_ULAW] = SND_PCM_FORMAT_MU_LAW,
++        [PA_SAMPLE_S16LE] = SND_PCM_FORMAT_S16_LE,
++        [PA_SAMPLE_S16BE] = SND_PCM_FORMAT_S16_BE,
++        [PA_SAMPLE_FLOAT32LE] = SND_PCM_FORMAT_FLOAT_LE,
++        [PA_SAMPLE_FLOAT32BE] = SND_PCM_FORMAT_FLOAT_BE,
++        [PA_SAMPLE_S32LE] = SND_PCM_FORMAT_S32_LE,
++        [PA_SAMPLE_S32BE] = SND_PCM_FORMAT_S32_BE,
++        [PA_SAMPLE_S24LE] = SND_PCM_FORMAT_S24_3LE,
++        [PA_SAMPLE_S24BE] = SND_PCM_FORMAT_S24_3BE,
++        [PA_SAMPLE_S24_32LE] = SND_PCM_FORMAT_S24_LE,
++        [PA_SAMPLE_S24_32BE] = SND_PCM_FORMAT_S24_BE,
+     };
+-    static const snd_pcm_format_t all_formats[] = {
+-        SND_PCM_FORMAT_U8,
+-        SND_PCM_FORMAT_A_LAW,
+-        SND_PCM_FORMAT_MU_LAW,
+-        SND_PCM_FORMAT_S16_LE,
+-        SND_PCM_FORMAT_S16_BE,
+-        SND_PCM_FORMAT_FLOAT_LE,
+-        SND_PCM_FORMAT_FLOAT_BE,
+-        SND_PCM_FORMAT_S32_LE,
+-        SND_PCM_FORMAT_S32_BE,
+-        SND_PCM_FORMAT_S24_3LE,
+-        SND_PCM_FORMAT_S24_3BE,
+-        SND_PCM_FORMAT_S24_LE,
+-        SND_PCM_FORMAT_S24_BE,
++    static const pa_sample_format_t all_formats[] = {
++        PA_SAMPLE_U8,
++        PA_SAMPLE_ALAW,
++        PA_SAMPLE_ULAW,
++        PA_SAMPLE_S16LE,
++        PA_SAMPLE_S16BE,
++        PA_SAMPLE_FLOAT32LE,
++        PA_SAMPLE_FLOAT32BE,
++        PA_SAMPLE_S32LE,
++        PA_SAMPLE_S32BE,
++        PA_SAMPLE_S24LE,
++        PA_SAMPLE_S24BE,
++        PA_SAMPLE_S24_32LE,
++        PA_SAMPLE_S24_32BE,
+     };
+     bool supported[PA_ELEMENTSOF(all_formats)] = {
+         false,
+@@ -1548,7 +1548,7 @@ pa_sample_format_t *pa_alsa_get_supported_formats(snd_pcm_t *pcm, pa_sample_form
+     }
+ 
+     for (i = 0, n = 0; i < PA_ELEMENTSOF(all_formats); i++) {
+-        if (snd_pcm_hw_params_test_format(pcm, hwparams, all_formats[i]) == 0) {
++        if (snd_pcm_hw_params_test_format(pcm, hwparams, format_trans_to_pcm[all_formats[i]]) == 0) {
+             supported[i] = true;
+             n++;
+         }
+@@ -1559,7 +1559,7 @@ pa_sample_format_t *pa_alsa_get_supported_formats(snd_pcm_t *pcm, pa_sample_form
+ 
+         for (i = 0, j = 0; i < PA_ELEMENTSOF(all_formats); i++) {
+             if (supported[i])
+-                formats[j++] = format_trans_to_pa[all_formats[i]];
++                formats[j++] = all_formats[i];
+         }
+ 
+         formats[j] = PA_SAMPLE_MAX;
+@@ -1567,7 +1567,7 @@ pa_sample_format_t *pa_alsa_get_supported_formats(snd_pcm_t *pcm, pa_sample_form
+         formats = pa_xnew(pa_sample_format_t, 2);
+ 
+         formats[0] = fallback_format;
+-        if ((ret = snd_pcm_hw_params_set_format(pcm, hwparams, format_trans_to_pa[formats[0]])) < 0) {
++        if ((ret = snd_pcm_hw_params_set_format(pcm, hwparams, format_trans_to_pcm[formats[0]])) < 0) {
+             pa_log_debug("snd_pcm_hw_params_set_format() failed: %s", pa_alsa_strerror(ret));
+             pa_xfree(formats);
+             return NULL;

--- a/media-sound/pulseaudio-daemon/pulseaudio-daemon-16.1-r8.ebuild
+++ b/media-sound/pulseaudio-daemon/pulseaudio-daemon-16.1-r8.ebuild
@@ -168,6 +168,7 @@ PATCHES=(
 	"${FILESDIR}"/pulseaudio-16.1-fix-memblock-alignment.patch
 	"${FILESDIR}"/pulseaudio-16.1-add-more-standard-samplerates.patch
 	"${FILESDIR}"/pulseaudio-16.1-fix-resampler-oversized-memblock.patch
+	"${FILESDIR}"/pulseaudio-16.1-fix-uac2-broken-avoid-resampling.patch
 )
 
 src_prepare() {

--- a/media-sound/pulseaudio-daemon/pulseaudio-daemon-16.1-r8.ebuild
+++ b/media-sound/pulseaudio-daemon/pulseaudio-daemon-16.1-r8.ebuild
@@ -167,6 +167,7 @@ PATCHES=(
 	# alignment fix changes internal abi, added requirement matching >=media-libs/libpulse-16.1-r3
 	"${FILESDIR}"/pulseaudio-16.1-fix-memblock-alignment.patch
 	"${FILESDIR}"/pulseaudio-16.1-add-more-standard-samplerates.patch
+	"${FILESDIR}"/pulseaudio-16.1-fix-resampler-oversized-memblock.patch
 )
 
 src_prepare() {

--- a/media-sound/pulseaudio-daemon/pulseaudio-daemon-16.1-r8.ebuild
+++ b/media-sound/pulseaudio-daemon/pulseaudio-daemon-16.1-r8.ebuild
@@ -1,0 +1,391 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="7"
+
+MY_PV="${PV/_pre*}"
+MY_P="pulseaudio-${MY_PV}"
+inherit bash-completion-r1 gnome2-utils meson optfeature systemd tmpfiles udev
+
+DESCRIPTION="Daemon component of PulseAudio (networked sound server)"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/PulseAudio/"
+
+if [[ ${PV} = 9999 ]]; then
+	inherit git-r3
+	EGIT_BRANCH="master"
+	EGIT_REPO_URI="https://gitlab.freedesktop.org/pulseaudio/pulseaudio"
+else
+	SRC_URI="https://freedesktop.org/software/pulseaudio/releases/${MY_P}.tar.xz"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86 ~amd64-linux ~x86-linux"
+fi
+
+S="${WORKDIR}/${MY_P}"
+
+# libpulse-simple and libpulse link to libpulse-core; this is daemon's
+# library and can link to gdbm and other GPL-only libraries. In this
+# cases, we have a fully GPL-2 package. Leaving the rest of the
+# GPL-forcing USE flags for those who use them.
+LICENSE="!gdbm? ( LGPL-2.1 ) gdbm? ( GPL-2 )"
+
+SLOT="0"
+
+# +alsa-plugin as discussed in bug #519530
+# TODO: Find out why webrtc-aec is + prefixed - there's already the always available speexdsp-aec
+# NOTE: The current ebuild sets +X almost certainly just for the pulseaudio.desktop file
+IUSE="+alsa +alsa-plugin aptx +asyncns bluetooth dbus elogind equalizer fftw +gdbm +glib gstreamer jack ldac lirc
+ofono-headset +orc oss selinux sox ssl systemd system-wide tcpd test +udev valgrind +webrtc-aec +X zeroconf"
+
+RESTRICT="!test? ( test )"
+
+# See "*** BLUEZ support not found (requires D-Bus)" in configure.ac
+# Basically all IUSE are either ${MULTILIB_USEDEP} for client libs or they belong under !daemon ()
+# We duplicate alsa-plugin, {native,ofono}-headset under daemon to let users deal with them at once
+REQUIRED_USE="
+	?? ( elogind systemd )
+	alsa-plugin? ( alsa )
+	aptx? ( bluetooth )
+	bluetooth? ( dbus )
+	equalizer? ( dbus )
+	ldac? ( bluetooth )
+	ofono-headset? ( bluetooth )
+	udev? ( || ( alsa oss ) )
+	zeroconf? ( dbus )
+"
+
+# NOTE:
+# - libpcre needed in some cases, bug #472228
+# - media-libs/speexdsp is providing echo canceller implementation and used in resampler
+# TODO: libatomic_ops is only needed on some architectures and conditions, and then at runtime too
+gstreamer_deps="
+	media-libs/gst-plugins-base
+	>=media-libs/gstreamer-1.14
+"
+COMMON_DEPEND="
+	~media-libs/libpulse-${PV}[dbus?,glib?,systemd?,valgrind?,X?]
+	>=media-libs/libpulse-16.1-r3
+	dev-libs/libatomic_ops
+	>=media-libs/libsndfile-1.0.20
+	>=media-libs/speexdsp-1.2
+	alsa? ( >=media-libs/alsa-lib-1.0.24 )
+	aptx? ( ${gstreamer_deps} )
+	asyncns? ( >=net-libs/libasyncns-0.1 )
+	bluetooth? (
+		>=net-wireless/bluez-5
+		media-libs/sbc
+	)
+	dev-libs/libltdl
+	sys-kernel/linux-headers
+	>=sys-libs/libcap-2.22-r2
+	dbus? ( >=sys-apps/dbus-1.4.12 )
+	elibc_mingw? ( dev-libs/libpcre:3 )
+	elogind? ( sys-auth/elogind )
+	equalizer? (
+		sci-libs/fftw:3.0=
+	)
+	fftw? (
+		sci-libs/fftw:3.0=
+	)
+	gdbm? ( sys-libs/gdbm:= )
+	glib? ( >=dev-libs/glib-2.28.0:2 )
+	gstreamer? (
+		${gstreamer_deps}
+		>=dev-libs/glib-2.26.0:2
+	)
+	jack? ( virtual/jack )
+	ldac? ( ${gstreamer_deps} )
+	lirc? ( app-misc/lirc )
+	ofono-headset? ( >=net-misc/ofono-1.13 )
+	orc? ( >=dev-lang/orc-0.4.15 )
+	selinux? ( sec-policy/selinux-pulseaudio )
+	sox? ( >=media-libs/soxr-0.1.1 )
+	ssl? ( dev-libs/openssl:= )
+	systemd? ( sys-apps/systemd:= )
+	tcpd? ( sys-apps/tcp-wrappers )
+	udev? ( >=virtual/udev-143[hwdb(+)] )
+	valgrind? ( dev-util/valgrind )
+	webrtc-aec? ( >=media-libs/webrtc-audio-processing-0.2:0 )
+	X? (
+		>=x11-libs/libxcb-1.6
+		x11-libs/libICE
+		x11-libs/libSM
+		>=x11-libs/libX11-1.4.0
+		>=x11-libs/libXtst-1.0.99.2
+	)
+	zeroconf? ( >=net-dns/avahi-0.6.12[dbus] )
+"
+
+# pulseaudio ships a bundle xmltoman, which uses XML::Parser
+DEPEND="
+	${COMMON_DEPEND}
+	test? ( >=dev-libs/check-0.9.10 )
+	X? ( x11-base/xorg-proto )
+"
+
+# alsa-utils dep is for the alsasound init.d script (see bug 155707); TODO: read it
+# NOTE: Only system-wide needs acct-group/audio unless elogind/systemd is not used
+RDEPEND="
+	${COMMON_DEPEND}
+	system-wide? (
+		alsa? ( media-sound/alsa-utils )
+		acct-user/pulse
+		acct-group/audio
+		acct-group/pulse-access
+	)
+	bluetooth? (
+		ldac? ( media-plugins/gst-plugins-ldac )
+		aptx? ( media-plugins/gst-plugins-openaptx )
+	)
+	!media-video/pipewire[sound-server(+)]
+"
+unset gstreamer_deps
+
+# This is a PDEPEND to avoid a circular dep
+PDEPEND="
+	alsa? ( alsa-plugin? ( >=media-plugins/alsa-plugins-1.0.27-r1[pulseaudio] ) )
+"
+
+BDEPEND="
+	dev-lang/perl
+	dev-perl/XML-Parser
+	sys-devel/gettext
+	sys-devel/m4
+	virtual/libiconv
+	virtual/libintl
+	virtual/pkgconfig
+	orc? ( >=dev-lang/orc-0.4.15 )
+	system-wide? ( dev-util/unifdef )
+"
+
+DOCS=( NEWS README )
+
+# patches merged upstream, to be removed with 16.2 or later bump
+PATCHES=(
+	"${FILESDIR}"/pulseaudio-16.0-optional-module-console-kit.patch
+	"${FILESDIR}"/pulseaudio-16.1-module-combine-sink-load-crash.patch
+	"${FILESDIR}"/pulseaudio-16.1-module-combine-sink-unload-crash.patch
+	"${FILESDIR}"/pulseaudio-16.1-move-qpaeq-to-daemon.patch
+	# alignment fix changes internal abi, added requirement matching >=media-libs/libpulse-16.1-r3
+	"${FILESDIR}"/pulseaudio-16.1-fix-memblock-alignment.patch
+	"${FILESDIR}"/pulseaudio-16.1-add-more-standard-samplerates.patch
+)
+
+src_prepare() {
+	default
+
+	gnome2_environment_reset
+}
+
+src_configure() {
+	local enable_bluez5_gstreamer="disabled"
+	if use aptx || use ldac ; then
+		enable_bluez5_gstreamer="enabled"
+	fi
+
+	local enable_fftw="disabled"
+	if use equalizer || use fftw ; then
+		enable_fftw="enabled"
+	fi
+
+	local emesonargs=(
+		--localstatedir="${EPREFIX}"/var
+
+		-Ddaemon=true
+		-Dclient=false
+		-Ddoxygen=false
+		-Dgcov=false
+		-Dman=true
+		# tests involve random modules, so just do them for the native # TODO: tests should run always
+		$(meson_use test tests)
+		-Ddatabase=$(usex gdbm gdbm simple) # tdb is also an option but no one cares about it
+		-Dstream-restore-clear-old-devices=true
+		-Drunning-from-build-tree=false
+
+		# Paths
+		-Dmodlibexecdir="${EPREFIX}/usr/$(get_libdir)/pulseaudio/modules" # Was $(get_libdir)/${P}
+		-Dsystemduserunitdir=$(systemd_get_userunitdir)
+		-Dudevrulesdir="${EPREFIX}$(get_udevdir)/rules.d"
+		-Dbashcompletiondir="$(get_bashcompdir)" # Alternatively DEPEND on app-shells/bash-completion for pkg-config to provide the value
+
+		# Optional features
+		$(meson_feature alsa)
+		$(meson_feature asyncns)
+		$(meson_feature zeroconf avahi)
+		$(meson_feature bluetooth bluez5)
+		-Dbluez5-gstreamer=${enable_bluez5_gstreamer}
+		$(meson_use bluetooth bluez5-native-headset)
+		$(meson_use ofono-headset bluez5-ofono-headset)
+		-Dconsolekit=disabled
+		$(meson_feature dbus)
+		$(meson_feature elogind)
+		-Dfftw=${enable_fftw}
+		$(meson_feature glib) # WARNING: toggling this likely changes ABI
+		$(meson_feature glib gsettings) # Supposedly correct?
+		$(meson_feature gstreamer)
+		-Dgtk=disabled
+		-Dhal-compat=false
+		-Dipv6=true
+		$(meson_feature jack)
+		$(meson_feature lirc)
+		$(meson_feature ssl openssl)
+		$(meson_feature orc)
+		$(meson_feature oss oss-output)
+		-Dsamplerate=disabled # Matches upstream
+		$(meson_feature sox soxr)
+		-Dspeex=enabled
+		$(meson_feature systemd)
+		$(meson_feature tcpd tcpwrap)
+		$(meson_feature udev)
+		$(meson_feature valgrind)
+		$(meson_feature X x11)
+
+		# Echo cancellation
+		-Dadrian-aec=false # Not packaged?
+		$(meson_feature webrtc-aec)
+	)
+
+	meson_src_configure
+}
+
+src_install() {
+	meson_src_install
+
+	# qpaeq moved to media-sound/qpaeq
+	if [[ -f "${ED}"/usr/bin/qpaeq ]]; then
+		rm "${ED}"/usr/bin/qpaeq || die
+	fi
+
+	# Upstream installs 'pactl' if client is built, with all symlinks except for
+	# 'pulseaudio', 'pacmd' and 'pasuspender' which are installed if server is built.
+	# This trips QA warning, workaround:
+	# - install missing aliases in media-libs/libpulse (client build)
+	# - remove corresponding symlinks in media-sound/pulseaudio-daemonclient (server build)
+	rm "${D}/$(get_bashcompdir)"/pulseaudio || die
+	rm "${D}/$(get_bashcompdir)"/pacmd || die
+	rm "${D}/$(get_bashcompdir)"/pasuspender || die
+
+	# Daemon configuration scripts will try to load snippets from corresponding '.d' dirs.
+	# Install these dirs to silence a warning if they are missing.
+	keepdir /etc/pulse/default.pa.d
+	keepdir /etc/pulse/system.pa.d
+
+	if use system-wide; then
+		newconfd "${FILESDIR}"/pulseaudio.conf.d pulseaudio
+
+		use_define() {
+			local define=${2:-$(echo ${1} | tr '[:lower:]' '[:upper:]')}
+
+			use "${1}" && echo "-D${define}" || echo "-U${define}"
+		}
+
+		unifdef -x 1 \
+			$(use_define zeroconf AVAHI) \
+			$(use_define alsa) \
+			$(use_define bluetooth) \
+			$(use_define udev) \
+			"${FILESDIR}"/pulseaudio.init.d-5 \
+			> "${T}"/pulseaudio \
+			|| die
+
+		doinitd "${T}"/pulseaudio
+
+		systemd_dounit "${FILESDIR}"/pulseaudio.service
+
+		# We need /var/run/pulse, bug 442852
+		newtmpfiles "${FILESDIR}"/pulseaudio.tmpfiles pulseaudio.conf
+	else
+		# Prevent warnings when system-wide is not used, bug 447694
+		if use dbus; then
+			rm "${ED}"/etc/dbus-1/system.d/pulseaudio-system.conf || die
+		fi
+	fi
+
+	if use zeroconf; then
+		sed -i \
+			-e '/module-zeroconf-publish/s:^#::' \
+			"${ED}/etc/pulse/default.pa" \
+			|| die
+	fi
+
+	# Only enable autospawning pulseaudio daemon on systems without systemd
+	if ! use systemd; then
+		insinto /etc/pulse/client.conf.d
+		newins "${FILESDIR}/enable-autospawn.conf" "enable-autospawn.conf"
+	fi
+
+	find "${ED}" \( -name '*.a' -o -name '*.la' \) -delete || die
+}
+
+pkg_postinst() {
+	gnome2_schemas_update
+
+	use udev && udev_reload
+
+	if use system-wide; then
+		tmpfiles_process "pulseaudio.conf"
+
+		elog "You have enabled the 'system-wide' USE flag for pulseaudio."
+		elog "This mode should only be used on headless servers, embedded systems,"
+		elog "or thin clients. It will usually require manual configuration, and is"
+		elog "incompatible with many expected pulseaudio features."
+		elog "On normal desktop systems, system-wide mode is STRONGLY DISCOURAGED."
+		elog ""
+		elog "For more information, see"
+		elog "    https://www.freedesktop.org/wiki/Software/PulseAudio/Documentation/User/WhatIsWrongWithSystemWide/"
+		elog "    https://www.freedesktop.org/wiki/Software/PulseAudio/Documentation/User/SystemWide/"
+		elog "    https://wiki.gentoo.org/wiki/PulseAudio#Headless_server"
+		elog ""
+	fi
+
+	if use bluetooth; then
+		elog "You have enabled bluetooth USE flag for pulseaudio. Daemon will now handle"
+		elog "bluetooth Headset (HSP HS and HSP AG) and Handsfree (HFP HF) profiles using"
+		elog "native headset backend by default. This can be selectively disabled"
+		elog "via runtime configuration arguments to module-bluetooth-discover"
+		elog "in /etc/pulse/default.pa"
+		elog "To disable HFP HF append enable_native_hfp_hf=false"
+		elog "To disable HSP HS append enable_native_hsp_hs=false"
+		elog "To disable HSP AG append headset=auto or headset=ofono"
+		elog "(note this does NOT require enabling USE ofono)"
+		elog ""
+	fi
+
+	if use ofono-headset; then
+		elog "You have enabled both native and ofono headset profiles. The runtime decision"
+		elog "which to use is done via the 'headset' argument of module-bluetooth-discover."
+		elog ""
+	fi
+
+	if use gstreamer; then
+		elog "GStreamer-based RTP implementation modile enabled."
+		elog "To use OPUS payload install media-plugins/gst-plugins-opus"
+		elog "and add enable_opus=1 argument to module-rtp-send"
+		elog ""
+	fi
+
+	if use systemd; then
+		elog "Pulseaudio autospawn by client library is no longer enabled when systemd is available."
+		elog "It's recommended to start pulseaudio via its systemd user units:"
+		elog ""
+		elog "  systemctl --user enable pulseaudio.service pulseaudio.socket"
+		elog ""
+		elog "Root user can change system default configuration for all users:"
+		elog ""
+		elog "  systemctl --global enable pulseaudio.service pulseaudio.socket"
+		elog ""
+		elog "If you would like to enable autospawn by client library, edit autospawn flag in /etc/pulse/client.conf like this:"
+		elog ""
+		elog "  autospawn = yes"
+		elog ""
+		elog "The change from autospawn to user units will take effect after restarting."
+		elog ""
+	fi
+
+	optfeature_header "PulseAudio can be enhanced by installing the following:"
+	use equalizer && optfeature "qpaeq script for equalizer GUI" media-sound/qpaeq
+	use dbus && optfeature "restricted realtime capabilities via D-Bus" sys-auth/rtkit
+}
+
+pkg_postrm() {
+	gnome2_schemas_update
+	use udev && udev_reload
+}


### PR DESCRIPTION
Pulseaudio uses the same linker version script for all library variants, so a few symbols remain undefined for some variants. This breaks buid with new lld which defaults to errors with undefined symbols in linker version scripts.

Fix this by adding `-Wl,--undefined-version` to linker flags.
See also https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=274111

Closes: https://bugs.gentoo.org/915207

Also backport a few critical fixes from upstream.