### PR TITLE
profiles/arch: Force multilib flags on sys-devel/gcc deps

### DIFF
--- a/profiles/arch/amd64/no-multilib/package.use.force
+++ b/profiles/arch/amd64/no-multilib/package.use.force
@@ -1,5 +1,10 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
+
+# Michał Górny <mgorny@gentoo.org> (2023-10-06)
+# Undo multilib forcing.
+dev-libs/libatomic_ops -abi_x86_32
+dev-libs/boehm-gc -abi_x86_32
 
 # Michał Górny <mgorny@gentoo.org> (2017-04-08)
 # Undo multilib forcing.

--- a/profiles/arch/amd64/package.use.force
+++ b/profiles/arch/amd64/package.use.force
@@ -1,6 +1,12 @@
 # Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Michał Górny <mgorny@gentoo.org> (2023-10-06)
+# Require ABIs matching MULTILIB_ABIS in gcc dependencies -- otherwise
+# sys-devel/gcc[multilib] (which is forced) will fail late in build.
+dev-libs/libatomic_ops abi_x86_32
+dev-libs/boehm-gc abi_x86_32
+
 # Michał Górny <mgorny@gentoo.org> (2017-12-30)
 # We have ready-to-use configs here.
 sys-kernel/gentoo-kernel -savedconfig

--- a/profiles/arch/amd64/x32/package.use.force
+++ b/profiles/arch/amd64/x32/package.use.force
@@ -1,6 +1,12 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
+# Michał Górny <mgorny@gentoo.org> (2023-10-06)
+# Require ABIs matching MULTILIB_ABIS in gcc dependencies -- otherwise
+# sys-devel/gcc[multilib] (which is forced) will fail late in build.
+dev-libs/libatomic_ops abi_x86_64
+dev-libs/boehm-gc abi_x86_64
+
 # Michał Górny <mgorny@gentoo.org> (2017-04-08)
 # Require sandbox to be multilib-capable to avoid failures when building
 # multilib packages, #611292.

--- a/profiles/arch/mips/mips64/multilib/package.use.force
+++ b/profiles/arch/mips/mips64/multilib/package.use.force
@@ -1,0 +1,8 @@
+# Copyright 2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+# Michał Górny <mgorny@gentoo.org> (2023-10-06)
+# Require ABIs matching MULTILIB_ABIS in gcc dependencies -- otherwise
+# sys-devel/gcc[multilib] (which is forced) will fail late in build.
+dev-libs/libatomic_ops abi_mips_n32 abi_mips_n64 abi_mips_o32
+dev-libs/boehm-gc abi_mips_n32 abi_mips_n64 abi_mips_o32

--- a/profiles/arch/mips/mipsel/mips64el/multilib/package.use.force
+++ b/profiles/arch/mips/mipsel/mips64el/multilib/package.use.force
@@ -1,0 +1,8 @@
+# Copyright 2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+# Michał Górny <mgorny@gentoo.org> (2023-10-06)
+# Require ABIs matching MULTILIB_ABIS in gcc dependencies -- otherwise
+# sys-devel/gcc[multilib] (which is forced) will fail late in build.
+dev-libs/libatomic_ops abi_mips_n32 abi_mips_n64 abi_mips_o32
+dev-libs/boehm-gc abi_mips_n32 abi_mips_n64 abi_mips_o32


### PR DESCRIPTION
Force enabling respective abi_* flags on sys-devel/gcc dependencies in profiles where multiple MULTILIB_ABIS are used by default.  This prevents sys-devel/gcc build from failing late in the build with cryptic error messages when USE=multilib (that is forced on) is used along with USE=objc.

Bug: https://bugs.gentoo.org/617788