### PR TITLE
sys-apps/uutils-coreutils: correct musl fix

### DIFF
--- a/sys-apps/uutils-coreutils/uutils-coreutils-0.0.20.ebuild
+++ b/sys-apps/uutils-coreutils/uutils-coreutils-0.0.20.ebuild
@@ -350,7 +350,7 @@ src_compile() {
 
 		# pinky, uptime, users, and who require utmpx (not available on musl)
 		# bug #832868
-		SKIP_PROGS="$(usev elibc_musl "pinky uptime users who")"
+		SKIP_UTILS="$(usev elibc_musl "pinky uptime users who")"
 	)
 
 	emake "${makeargs[@]}"

--- a/sys-apps/uutils-coreutils/uutils-coreutils-0.0.21.ebuild
+++ b/sys-apps/uutils-coreutils/uutils-coreutils-0.0.21.ebuild
@@ -353,7 +353,7 @@ src_compile() {
 
 		# pinky, uptime, users, and who require utmpx (not available on musl)
 		# bug #832868
-		SKIP_PROGS="$(usev elibc_musl "pinky uptime users who")"
+		SKIP_UTILS="$(usev elibc_musl "pinky uptime users who")"
 	)
 
 	emake "${makeargs[@]}"

--- a/sys-apps/uutils-coreutils/uutils-coreutils-9999.ebuild
+++ b/sys-apps/uutils-coreutils/uutils-coreutils-9999.ebuild
@@ -353,7 +353,7 @@ src_compile() {
 
 		# pinky, uptime, users, and who require utmpx (not available on musl)
 		# bug #832868
-		SKIP_PROGS="$(usev elibc_musl "pinky uptime users who")"
+		SKIP_UTILS="$(usev elibc_musl "pinky uptime users who")"
 	)
 
 	emake "${makeargs[@]}"


### PR DESCRIPTION
SKIP_PROGS was supposed to be SKIP_UTILS, oops.