### PR TITLE
vscode/vscodium:  update dependencies

### DIFF
--- a/app-editors/vscode/vscode-1.83.0-r1.ebuild
+++ b/app-editors/vscode/vscode-1.83.0-r1.ebuild
@@ -42,18 +42,23 @@ IUSE="kerberos"
 RDEPEND="
 	>=app-accessibility/at-spi2-core-2.46.0:2
 	app-crypt/libsecret[crypt]
+	app-i18n/ibus
+	app-misc/ca-certificates
 	dev-libs/expat
 	dev-libs/glib:2
 	dev-libs/nspr
 	dev-libs/nss
 	media-libs/alsa-lib
+	media-libs/libcanberra[gtk3]
+	media-libs/libglvnd
 	media-libs/mesa
-	sys-apps/util-linux
-	sys-apps/dbus
+	net-misc/curl
+	sys-libs/zlib
+	sys-process/lsof
 	x11-libs/cairo
-	x11-libs/gdk-pixbuf:2
 	x11-libs/gtk+:3
 	x11-libs/libdrm
+	x11-libs/libnotify
 	x11-libs/libX11
 	x11-libs/libxcb
 	x11-libs/libXcomposite
@@ -63,8 +68,9 @@ RDEPEND="
 	x11-libs/libxkbcommon
 	x11-libs/libxkbfile
 	x11-libs/libXrandr
-	x11-libs/libxshmfence
+	x11-libs/libXScrnSaver
 	x11-libs/pango
+	x11-misc/xdg-utils
 	kerberos? ( app-crypt/mit-krb5 )
 "
 

--- a/app-editors/vscodium/vscodium-1.83.0.23277-r1.ebuild
+++ b/app-editors/vscodium/vscodium-1.83.0.23277-r1.ebuild
@@ -49,19 +49,23 @@ IUSE="kerberos"
 RDEPEND="
 	>=app-accessibility/at-spi2-core-2.46.0:2
 	app-crypt/libsecret[crypt]
+	app-i18n/ibus
+	app-misc/ca-certificates
 	dev-libs/expat
 	dev-libs/glib:2
 	dev-libs/nspr
 	dev-libs/nss
 	media-libs/alsa-lib
+	media-libs/libcanberra[gtk3]
+	media-libs/libglvnd
 	media-libs/mesa
-	net-print/cups
-	sys-apps/util-linux
-	sys-apps/dbus
+	net-misc/curl
+	sys-libs/zlib
+	sys-process/lsof
 	x11-libs/cairo
-	x11-libs/gdk-pixbuf:2
 	x11-libs/gtk+:3
 	x11-libs/libdrm
+	x11-libs/libnotify
 	x11-libs/libX11
 	x11-libs/libxcb
 	x11-libs/libXcomposite
@@ -71,8 +75,9 @@ RDEPEND="
 	x11-libs/libxkbcommon
 	x11-libs/libxkbfile
 	x11-libs/libXrandr
-	x11-libs/libxshmfence
+	x11-libs/libXScrnSaver
 	x11-libs/pango
+	x11-misc/xdg-utils
 	kerberos? ( app-crypt/mit-krb5 )
 "
 


### PR DESCRIPTION
Hello @arthurzam ,

I kinda had the feeling that our dependencies weren't exactly accurate so I went down the rabbit hole by checking the deps of the ubuntu package (downloaded the `.deb` then did `dpkg -I code_1.83.0-1696350811_amd64.deb`), which gives this:

```
ca-certificates, 
libasound2 (>= 1.0.17), 
libatk-bridge2.0-0 (>= 2.5.3), 
libatk1.0-0 (>= 2.2.0), 
libatspi2.0-0 (>= 2.9.90), 
libc6 (>= 2.14), 
libc6 (>= 2.16), 
libc6 (>= 2.17), 
libc6 (>= 2.2.5), 
libcairo2 (>= 1.6.0), 
libcurl3-gnutls | libcurl3-nss | libcurl4 | libcurl3, libdbus-1-3 (>= 1.5.12), 
libdrm2 (>= 2.4.75), 
libexpat1 (>= 2.0.1), 
libgbm1 (>= 17.1.0~rc2), 
libglib2.0-0 (>= 2.37.3), 
libgssapi-krb5-2, 
libgtk-3-0 (>= 3.9.10), 
libgtk-3-0 (>= 3.9.10) | libgtk-4-1, 
libkrb5-3, 
libnspr4 (>= 2:4.9-2~), 
libnss3 (>= 2:3.30), 
libnss3 (>= 3.26), 
libpango-1.0-0 (>= 1.14.0), 
libx11-6, 
libx11-6 (>= 2:1.4.99.1), 
libxcb1 (>= 1.9.2), 
libxcomposite1 (>= 1:0.4.4-1), 
libxdamage1 (>= 1:1.1), 
libxext6, 
libxfixes3, 
libxkbcommon0 (>= 0.4.1), 
libxkbfile1, 
libxrandr2, 
xdg-utils (>= 1.0.2)
```
Then listed the files provided by each package (mainly the shared libs) and searched for our equivalent. A tool could definitely automate this actually, if it doesn't exist already.

Then I went to check this: https://github.com/microsoft/vscode/blob/main/resources/linux/snap/snapcraft.yaml

Then ran `qa-vdb` which gave me `zlib` as addition. 

`sys-apps/util-linux`, `sys-apps/dbus`, `x11-libs/gdk-pixbuf:2` and `x11-libs/libxshmfence` don't seem to be necessary actually, the Archlinux AUR package [does not have them](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=visual-studio-code-bin) either. But gave the interesting addition of `lsof` due to this https://github.com/Microsoft/vscode/issues/62991