### PR TITLE
media-sound/helvum: add libadwaita dep

### DIFF
--- a/media-sound/helvum/helvum-0.5.1-r1.ebuild
+++ b/media-sound/helvum/helvum-0.5.1-r1.ebuild
@@ -138,6 +138,7 @@ BDEPEND="
 DEPEND="
 	dev-libs/glib:2
 	gui-libs/gtk:4
+	gui-libs/libadwaita
 	media-libs/graphene
 	media-video/pipewire:=
 	x11-libs/cairo


### PR DESCRIPTION
Hello @thesamesam @toralf 

Apparently our last verbump needed to have one extra dependency.

Closes: https://bugs.gentoo.org/915337