### PR TITLE
dev-games/irrlicht: Fix C++17 does not allow register storage class

### DIFF
--- a/dev-games/irrlicht/files/irrlicht-1.8.4-drop-register.patch
+++ b/dev-games/irrlicht/files/irrlicht-1.8.4-drop-register.patch
@@ -1,0 +1,32 @@
+Bug: https://bugs.gentoo.org/894764
+--- a/source/Irrlicht/CColorConverter.cpp
++++ b/source/Irrlicht/CColorConverter.cpp
+@@ -165,7 +165,7 @@ void CColorConverter::convert8BitTo32Bit(const u8* in, u8* out, s32 width, s32 h
+ 		out += lineWidth * height;
+ 
+ 	u32 x;
+-	register u32 c;
++	u32 c;
+ 	for (u32 y=0; y < (u32) height; ++y)
+ 	{
+ 		if (flip)
+--- a/source/Irrlicht/CMY3DHelper.h
++++ b/source/Irrlicht/CMY3DHelper.h
+@@ -269,7 +269,7 @@ unsigned long process_comp(
+     unsigned char *out_buf, int out_buf_size)
+ {
+      // we start out with 3 repeating bytes
+-     register int len = 3;
++     int len = 3;
+ 
+      unsigned char ch;
+ 
+@@ -328,7 +328,7 @@ void process_uncomp(
+ //-----------------------------------------------------------
+ void flush_outbuf(unsigned char *out_buf, int out_buf_size)
+ {
+-    register int pos=0;
++    int pos=0;
+ 
+     if(!outbuf_cnt)
+        return;        // nothing to do */

--- a/dev-games/irrlicht/irrlicht-1.8.4-r2.ebuild
+++ b/dev-games/irrlicht/irrlicht-1.8.4-r2.ebuild
@@ -1,0 +1,85 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+inherit toolchain-funcs
+
+DESCRIPTION="open source high performance realtime 3D engine written in C++"
+HOMEPAGE="https://irrlicht.sourceforge.io/"
+SRC_URI="mirror://sourceforge/irrlicht/${P}.zip
+	https://dev.gentoo.org/~mgorny/dist/${P}-patchset.tar.bz2"
+
+LICENSE="ZLIB"
+SLOT="0"
+KEYWORDS="~amd64 ~riscv ~x86"
+IUSE="debug doc static-libs"
+
+RDEPEND="app-arch/bzip2
+	~dev-games/irrlicht-headers-${PV}
+	media-libs/libpng:0=
+	sys-libs/zlib
+	media-libs/libjpeg-turbo
+	virtual/opengl
+	x11-libs/libX11
+	x11-libs/libXxf86vm"
+DEPEND="${RDEPEND}
+	x11-base/xorg-proto"
+BDEPEND="app-arch/unzip"
+
+S=${WORKDIR}/${P}/source/${PN^}
+
+PATCHES=(
+	"${WORKDIR}"/${P}-patchset/${P}-gentoo.patch
+	"${WORKDIR}"/${P}-patchset/${P}-demoMake.patch
+	"${WORKDIR}"/${P}-patchset/${P}-mesa-10.x.patch
+	"${WORKDIR}"/${P}-patchset/${P}-jpeg-9a.patch
+	"${FILESDIR}/${P}-remove-sys-sysctl.h.patch"
+	"${FILESDIR}/${P}-drop-register.patch"
+)
+
+DOCS=( changes.txt readme.txt )
+
+src_prepare() {
+	cd "${WORKDIR}"/${P} || die
+
+	# Use system-provided Irrlicht headers
+	rm -r include || die
+	ln -s "${ESYSROOT}/usr/include/irrlicht" include || die
+
+	# Fix relative path to media directory
+	sed -i \
+		-e 's:\.\./\.\./media:../media:g' \
+		$(grep -rl '\.\./\.\./media' examples) \
+		|| die 'sed failed'
+
+	# Fix line endings so ${P}-remove-sys-sysctl.h.patch applies
+	sed -i \
+		-e 's/\r$//' \
+		source/Irrlicht/COSOperator.cpp \
+		|| die 'sed failed'
+
+	default
+}
+
+src_compile() {
+	tc-export CXX CC AR
+	emake NDEBUG=$(usex debug "" "1") sharedlib $(usex static-libs "staticlib" "")
+}
+
+src_install() {
+	cd "${WORKDIR}"/${P} || die
+
+	use static-libs && dolib.a lib/Linux/libIrrlicht.a
+	dolib.so lib/Linux/libIrrlicht.so*
+
+	# create library symlinks
+	dosym libIrrlicht.so.${PV} /usr/$(get_libdir)/libIrrlicht.so.1.8
+	dosym libIrrlicht.so.${PV} /usr/$(get_libdir)/libIrrlicht.so
+
+	einstalldocs
+
+	# don't do these with einstalldocs because they shouldn't be compressed
+	if use doc ; then
+		dodoc -r examples media
+	fi
+}


### PR DESCRIPTION
And update EAPI 7 -> 8S

Closes: https://bugs.gentoo.org/894764