### PR TITLE
dev-util/xxdiff: Fix call to undeclared library function strcmp

### DIFF
--- a/dev-util/xxdiff/files/xxdiff-4.0.1_p20170622-clang16-build-fix.patch
+++ b/dev-util/xxdiff/files/xxdiff-4.0.1_p20170622-clang16-build-fix.patch
@@ -1,0 +1,11 @@
+Bug: https://bugs.gentoo.org/895848
+--- a/src/getopt.c
++++ b/src/getopt.c
+@@ -38,6 +38,7 @@
+ #endif
+ 
+ #include <stdio.h>
++#include <string.h>
+ 
+ /* Comment out all this code if we are using the GNU C Library, and are not
+    actually compiling the library itself.  This code is part of the GNU C

--- a/dev-util/xxdiff/xxdiff-4.0.1_p20170622-r2.ebuild
+++ b/dev-util/xxdiff/xxdiff-4.0.1_p20170622-r2.ebuild
@@ -1,0 +1,60 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit qmake-utils
+
+DESCRIPTION="A graphical file and directories comparator and merge tool"
+HOMEPAGE="https://furius.ca/xxdiff/"
+# generated as 'hg archive xxdiff-${P}.tar'
+# from https://bitbucket.org/blais/xxdiff tree
+#SRC_URI="mirror://sourceforge/${PN}/${P}.tar.bz2"
+SRC_URI="https://dev.gentoo.org/~sam/distfiles/${P}.tar.bz2"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE=""
+
+RDEPEND="
+	dev-qt/qtcore:5
+	dev-qt/qtgui:5
+	dev-qt/qtwidgets:5
+"
+DEPEND="
+	${RDEPEND}
+	app-alternatives/yacc
+"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-4.0.1-no-throw-in-dtor.patch
+	"${FILESDIR}"/${P}-cxx11.patch
+	"${FILESDIR}"/${PN}-4.0.1_p20170622-clang16-build-fix.patch
+)
+
+src_configure() {
+	pushd src >/dev/null || die
+		# mimic src/Makefile.bootstrap
+		eqmake5
+		cat Makefile.extra >> Makefile || die
+	popd
+}
+
+src_compile() {
+	emake -C src MAKEDIR=.
+
+	HTML_DOCS+=(
+		doc/*.{png,html}
+		src/doc.html
+	)
+}
+
+src_install() {
+	dobin bin/xxdiff
+
+	dodoc CHANGES README* TODO doc/*.txt src/doc.txt
+
+	# example tools, use these to build your own ones
+	dodoc -r tools
+}


### PR DESCRIPTION
And update EAPI 7 -> 8

Closes: https://bugs.gentoo.org/895848