### PR TITLE
sys-apps/keyutils: drop unused seds

### DIFF
--- a/sys-apps/keyutils/keyutils-1.6.3.ebuild
+++ b/sys-apps/keyutils/keyutils-1.6.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -61,11 +61,6 @@ src_prepare() {
 
 	# The lsb check is useless, so avoid spurious command not found messages.
 	sed -i -e 's,lsb_release,:,' tests/prepare.inc.sh || die
-	# All the test files are bash, but try to execute via `sh`.
-	sed -i -r \
-		-e 's:([[:space:]])sh([[:space:]]):\1bash\2:' \
-		tests/{Makefile*,*.sh} || die
-	find tests/ -name '*.sh' -exec sed -i '1s:/sh$:/bash:' {} + || die
 	# Some tests call the kernel which calls userspace, but that will
 	# run the install keyutils rather than the locally compiled one,
 	# so disable round trip tests.


### PR DESCRIPTION
QA checks warned that the first sed was not used. Turns out neither is the second sed.

This was fixed in upstream version v1.5.9-2-g80d4848 (commit 80d484853742639b9a83c17ee99188e56206eaa4 dated 2014 (so before gentoo.git conversion) and has survived all this time.