### PR TITLE
gui-wm/dwl: backport patch to use libxcb headers instead of libX11

### DIFF
--- a/gui-wm/dwl/dwl-0.4-r1.ebuild
+++ b/gui-wm/dwl/dwl-0.4-r1.ebuild
@@ -35,6 +35,8 @@ LICENSE="CC0-1.0 GPL-3+ MIT"
 SLOT="0"
 IUSE="X"
 
+PATCHES=( "${FILESDIR}/${P}-do-not-use-libX11.patch" )
+
 RDEPEND="
 	dev-libs/libinput:=
 	dev-libs/wayland

--- a/gui-wm/dwl/files/dwl-0.4-do-not-use-libX11.patch
+++ b/gui-wm/dwl/files/dwl-0.4-do-not-use-libX11.patch
@@ -1,0 +1,60 @@
+From 1a1ca779c7d79747dea355d03db74cd1d73787c7 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Leonardo=20Hern=C3=A1ndez=20Hern=C3=A1ndez?=
+ <leohdz172@proton.me>
+Date: Mon, 9 Oct 2023 21:35:49 -0600
+Subject: [PATCH] use <xcb/xcb.h> instead of <X11/Xlib.h>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Leonardo Hernández Hernández <leohdz172@proton.me>
+---
+ dwl.c | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/dwl.c b/dwl.c
+index 19bb6ce..92a1d3e 100644
+--- a/dwl.c
++++ b/dwl.c
+@@ -54,7 +54,7 @@
+ #include <xkbcommon/xkbcommon.h>
+ #ifdef XWAYLAND
+ #include <wlr/xwayland.h>
+-#include <X11/Xlib.h>
++#include <xcb/xcb.h>
+ #include <xcb/xcb_icccm.h>
+ #endif
+ 
+@@ -387,14 +387,14 @@ static struct wl_listener session_lock_mgr_destroy = {.notify = destroysessionmg
+ static void activatex11(struct wl_listener *listener, void *data);
+ static void configurex11(struct wl_listener *listener, void *data);
+ static void createnotifyx11(struct wl_listener *listener, void *data);
+-static Atom getatom(xcb_connection_t *xc, const char *name);
++static xcb_atom_t getatom(xcb_connection_t *xc, const char *name);
+ static void sethints(struct wl_listener *listener, void *data);
+ static void sigchld(int unused);
+ static void xwaylandready(struct wl_listener *listener, void *data);
+ static struct wl_listener new_xwayland_surface = {.notify = createnotifyx11};
+ static struct wl_listener xwayland_ready = {.notify = xwaylandready};
+ static struct wlr_xwayland *xwayland;
+-static Atom netatom[NetLast];
++static xcb_atom_t netatom[NetLast];
+ #endif
+ 
+ /* configuration, allows nested code to access above variables */
+@@ -2671,10 +2671,10 @@ createnotifyx11(struct wl_listener *listener, void *data)
+ 	LISTEN(&xsurface->events.request_fullscreen, &c->fullscreen, fullscreennotify);
+ }
+ 
+-Atom
++xcb_atom_t
+ getatom(xcb_connection_t *xc, const char *name)
+ {
+-	Atom atom = 0;
++	xcb_atom_t atom = 0;
+ 	xcb_intern_atom_reply_t *reply;
+ 	xcb_intern_atom_cookie_t cookie = xcb_intern_atom(xc, 0, strlen(name), name);
+ 	if ((reply = xcb_intern_atom_reply(xc, cookie, NULL)))
+-- 
+2.42.0
+


### PR DESCRIPTION
no revbump because there is no functional change