### PR TITLE
qt5-build.eclass: workaround undefined qt_version_tag

### DIFF
--- a/eclass/qt5-build.eclass
+++ b/eclass/qt5-build.eclass
@@ -231,6 +231,12 @@ qt5-build_src_configure() {
 		qt5_tools_configure
 	fi
 
+	# Workaround for bug #915203
+	# Upstream: https://bugreports.qt.io/browse/QTBUG-111514
+	if [[ ${PN} != qtcore ]]; then
+		append-ldflags -Wl,--undefined-version
+	fi
+
 	qt5_foreach_target_subdir qt5_qmake
 }
 


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/915203

@thesamesam 