### PR TITLE
sys-fs/zfs-9999: remove applied patches

### DIFF
--- a/sys-fs/zfs/zfs-9999.ebuild
+++ b/sys-fs/zfs/zfs-9999.ebuild
@@ -103,11 +103,6 @@ REQUIRED_USE="
 
 RESTRICT="test"
 
-PATCHES=(
-	"${FILESDIR}"/2.1.5-dracut-zfs-missing.patch
-	"${FILESDIR}"/2.2.0_rc5-bash-completion-path.patch
-)
-
 pkg_pretend() {
 	use rootfs || return 0
 


### PR DESCRIPTION
Fix zfs live ebuild by removing the two patches in PATCHES which have already been applied upstream.