### PR TITLE
net-analyzer/greenbone-feed-sync: fix file permissions

### DIFF
--- a/net-analyzer/greenbone-feed-sync/greenbone-feed-sync-23.8.0-r1.ebuild
+++ b/net-analyzer/greenbone-feed-sync/greenbone-feed-sync-23.8.0-r1.ebuild
@@ -38,6 +38,8 @@ python_install() {
 	newins - greenbone-feed-sync <<-EOF
 	gvm ALL = NOPASSWD: /usr/bin/greenbone-feed-sync
 EOF
+	fperms 0750 /etc/sudoers.d
+	fperms 0440 /etc/sudoers.d/greenbone-feed-sync
 
 	if use cron; then
 		exeinto /etc/cron.daily


### PR DESCRIPTION
fix /etc/sudoers.d/greenbone-feed-sync permissions