### PR TITLE
sci-calculators/qalculate-qt: add missing bdep

### DIFF
--- a/sci-calculators/qalculate-qt/qalculate-qt-4.8.0.ebuild
+++ b/sci-calculators/qalculate-qt/qalculate-qt-4.8.0.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	>=sci-libs/libqalculate-${PV}
 "
 RDEPEND="${DEPEND}"
+BDEPEND="dev-qt/linguist-tools:5"
 
 src_prepare() {
 	default

--- a/sci-calculators/qalculate-qt/qalculate-qt-4.8.1.ebuild
+++ b/sci-calculators/qalculate-qt/qalculate-qt-4.8.1.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	>=sci-libs/libqalculate-${PV}
 "
 RDEPEND="${DEPEND}"
+BDEPEND="dev-qt/linguist-tools:5"
 
 src_prepare() {
 	default


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/915784