### PR TITLE
net-im/telegram-desktop-bin: add missing USE for gtk+:3 dep

### DIFF
--- a/net-im/telegram-desktop-bin/telegram-desktop-bin-4.11.1.ebuild
+++ b/net-im/telegram-desktop-bin/telegram-desktop-bin-4.11.1.ebuild
@@ -25,7 +25,7 @@ RDEPEND="
 	>=media-libs/fontconfig-2.13
 	media-libs/freetype:2
 	virtual/opengl
-	x11-libs/gtk+:3
+	x11-libs/gtk+:3[X,wayland]
 	x11-libs/libX11
 	>=x11-libs/libxcb-1.10
 "


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/915598
Fixes: 50ef5d226cf0 ("net-im/telegram-desktop-bin: add missing gtk+:3 dep")
Related-to: https://github.com/telegramdesktop/tdesktop/issues/26919