### PR TITLE
media-libs/libpulse: Fix pulseaudio daemon version req

### DIFF
--- a/media-libs/libpulse/libpulse-16.1-r3.ebuild
+++ b/media-libs/libpulse/libpulse-16.1-r3.ebuild
@@ -45,6 +45,7 @@ RDEPEND="
 		>=x11-libs/libxcb-1.6[${MULTILIB_USEDEP}]
 	)
 	!<media-sound/pulseaudio-15.0-r100
+	!<media-sound/pulseaudio-daemon-16.1-r8
 "
 
 DEPEND="${RDEPEND}
@@ -66,7 +67,7 @@ BDEPEND="
 PDEPEND="
 	|| (
 		media-video/pipewire[sound-server(+)]
-		>=media-sound/pulseaudio-daemon-16.1-r8
+		media-sound/pulseaudio-daemon
 		media-sound/pulseaudio[daemon(+)]
 	)
 "


### PR DESCRIPTION
Move pulseaudio daemon version requirement to the right place.

Bug: https://bugs.gentoo.org/915850