### PR TITLE
net-dns/dnsmasq: add interface doc when USE=+dbus

### DIFF
--- a/net-dns/dnsmasq/dnsmasq-2.89-r1.ebuild
+++ b/net-dns/dnsmasq/dnsmasq-2.89-r1.ebuild
@@ -199,6 +199,9 @@ src_install() {
 	if use dbus; then
 		insinto /etc/dbus-1/system.d
 		doins dbus/dnsmasq.conf
+
+		docinto
+		dodoc dbus/DBus-interface
 	fi
 
 	if use dhcp-tools; then


### PR DESCRIPTION
The dnsmasq DBus interface is documented, and that documentation should be accessible to the user when USE=+dbus.