### PR TITLE
app-admin/syslog-ng: depend on dev-libs/libpcre2 instead of dev-libs/libpcre

### DIFF
--- a/app-admin/syslog-ng/syslog-ng-4.3.1-r1.ebuild
+++ b/app-admin/syslog-ng/syslog-ng-4.3.1-r1.ebuild
@@ -21,7 +21,7 @@ RESTRICT="!test? ( test )"
 RDEPEND="
 	>=dev-libs/glib-2.10.1:2
 	>=dev-libs/ivykis-0.42.4
-	>=dev-libs/libpcre-6.1
+	>=dev-libs/libpcre2-10.0
 	dev-libs/openssl:0=
 	!dev-libs/eventlog
 	amqp? ( >=net-libs/rabbitmq-c-0.8.0:=[ssl] )

--- a/app-admin/syslog-ng/syslog-ng-4.4.0-r1.ebuild
+++ b/app-admin/syslog-ng/syslog-ng-4.4.0-r1.ebuild
@@ -21,7 +21,7 @@ RESTRICT="!test? ( test )"
 RDEPEND="
 	>=dev-libs/glib-2.10.1:2
 	>=dev-libs/ivykis-0.42.4
-	>=dev-libs/libpcre-6.1
+	>=dev-libs/libpcre2-10.0
 	dev-libs/openssl:0=
 	!dev-libs/eventlog
 	amqp? ( >=net-libs/rabbitmq-c-0.8.0:=[ssl] )


### PR DESCRIPTION
app-admin/syslog-ng changed this dependency since version 4.3.0

https://github.com/syslog-ng/syslog-ng/commit/cb6de08dc9078644d48ca536b5660e406b1a50d6

Signed-off-by: Cristian Othón Martínez Vera <cfuga@cfuga.mx>
