### PR TITLE
games-arcade/pengupop: Fix call to undeclared function swprintf

### DIFF
--- a/games-arcade/pengupop/files/pengupop-2.2.5-clang16-fix.patch
+++ b/games-arcade/pengupop/files/pengupop-2.2.5-clang16-fix.patch
@@ -1,0 +1,40 @@
+Bug: https://bugs.gentoo.org/883463
+--- a/main.c
++++ b/main.c
+@@ -48,6 +48,7 @@
+ #include "common.h"
+ #include "packet.h"
+ #include "sound.h"
++#include "main.h"
+ 
+ extern unsigned char saved_level;
+ extern unsigned char level;
+@@ -74,9 +75,6 @@ static struct option long_options[] =
+ 
+ extern void play_single_player();
+ 
+-#ifndef swprintf
+-int swprintf(wchar_t *wcs, size_t maxlen, const wchar_t *format, ...);
+-#endif
+ #endif
+ 
+ int hwalpha;
+--- /dev/null
++++ b/main.h
+@@ -0,0 +1,6 @@
++#include <stdio.h>
++#include <wchar.h>
++#ifndef swprintf
++int swprintf(wchar_t *wcs, size_t maxlen, const wchar_t *format, ...);
++#endif
++void remove_bubble(struct player_state* p, int x, int y, int evil);
+--- a/singleplayer.c
++++ b/singleplayer.c
+@@ -24,6 +24,7 @@
+ 
+ #include "common.h"
+ #include "sound.h"
++#include "main.h"
+ 
+ #ifndef WIN32
+ #include <unistd.h>

--- a/games-arcade/pengupop/pengupop-2.2.5-r2.ebuild
+++ b/games-arcade/pengupop/pengupop-2.2.5-r2.ebuild
@@ -1,0 +1,34 @@
+# Copyright 1999-2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=9
+
+inherit desktop
+
+DESCRIPTION="Networked Puzzle Bubble clone"
+HOMEPAGE="http://freshmeat.net/projects/pengupop"
+SRC_URI="mirror://gentoo/${P}.tar.gz"
+
+LICENSE="GPL-3+"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+RDEPEND="
+	media-libs/libsdl[sound,video]
+	virtual/zlib:="
+DEPEND="${RDEPEND}"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-2.2.5-clang16-fix.patch
+)
+
+src_compile() {
+	emake LIBS=-lm #497196
+}
+
+src_install() {
+	default
+
+	doicon pengupop.png
+	make_desktop_entry ${PN} Pengupop
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/883463