### PR TITLE
media-plugins/kodi-inputstream-ffmpegdirect: fixed build with GCC 13

### DIFF
--- a/media-plugins/kodi-inputstream-ffmpegdirect/files/kodi-inputstream-ffmpegdirect-19.0.0-gcc-13-fix.patch
+++ b/media-plugins/kodi-inputstream-ffmpegdirect/files/kodi-inputstream-ffmpegdirect-19.0.0-gcc-13-fix.patch
@@ -1,0 +1,28 @@
+Fix build with GCC 13
+
+Gentoo bug https://bugs.gentoo.org/915943
+
+Author: Karlson2k (Evgeny Grin)
+
+diff -ur inputstream.ffmpegdirect-19.0.0-Matrix-orig/src/utils/DiskUtils.h inputstream.ffmpegdirect-19.0.0-Matrix/src/utils/DiskUtils.h
+--- inputstream.ffmpegdirect-19.0.0-Matrix-orig/src/utils/DiskUtils.h	2021-09-14 17:23:56.000000000 +0300
++++ inputstream.ffmpegdirect-19.0.0-Matrix/src/utils/DiskUtils.h	2023-10-18 10:40:27.386513580 +0300
+@@ -7,6 +7,7 @@
+ 
+ #pragma once
+ 
++#include <cstdint>
+ #include <string>
+ 
+ namespace ffmpegdirect
+diff -ur inputstream.ffmpegdirect-19.0.0-Matrix-orig/src/utils/HttpProxy.h inputstream.ffmpegdirect-19.0.0-Matrix/src/utils/HttpProxy.h
+--- inputstream.ffmpegdirect-19.0.0-Matrix-orig/src/utils/HttpProxy.h	2021-09-14 17:23:56.000000000 +0300
++++ inputstream.ffmpegdirect-19.0.0-Matrix/src/utils/HttpProxy.h	2023-10-18 10:39:14.777829910 +0300
+@@ -7,6 +7,7 @@
+ 
+ #pragma once
+ 
++#include <cstdint>
+ #include <string>
+ 
+ namespace ffmpegdirect

--- a/media-plugins/kodi-inputstream-ffmpegdirect/kodi-inputstream-ffmpegdirect-19.0.0.ebuild
+++ b/media-plugins/kodi-inputstream-ffmpegdirect/kodi-inputstream-ffmpegdirect-19.0.0.ebuild
@@ -28,6 +28,10 @@ LICENSE="GPL-2"
 SLOT="0"
 IUSE=""
 
+PATCHES=(
+	"${FILESDIR}"/${P}-gcc-13-fix.patch # Bug 915943
+)
+
 BDEPEND="
 	virtual/pkgconfig
 	"


### PR DESCRIPTION
A trivial fix.

No revbump as it only fixes build with GCC 13. Not needed for older compilers.

Closes: https://bugs.gentoo.org/915943