### PR TITLE
games-puzzle/scramble: Fix call to undeclared function getWord

### DIFF
--- a/games-puzzle/scramble/files/scramble-0.9.5-clang16-fix.patch
+++ b/games-puzzle/scramble/files/scramble-0.9.5-clang16-fix.patch
@@ -1,0 +1,36 @@
+Bug: https://bugs.gentoo.org/885761
+--- a/src/perm.c
++++ b/src/perm.c
+@@ -25,6 +25,8 @@
+ #include <string.h>
+ #include <ctype.h>
+ #include <stdio.h>
++#include "perm.h"
++#include "ShiftyEngine.h"
+ 
+ struct node {
+ 	char * word;
+--- /dev/null
++++ b/src/perm.h
+@@ -0,0 +1,2 @@
++void initDictionary(char * name);
++void getWord(char * letters);
+--- a/src/scramble.c
++++ b/src/scramble.c
+@@ -26,6 +26,7 @@
+ #include <time.h>
+ 
+ #include "ShiftyEngine.h"
++#include "perm.h"
+ 
+ /* Forward references */
+ void timeOver();
+@@ -534,7 +535,7 @@ void updateClock()
+ 
+ /*****************************************************
+  ****************************************************/
+-int moveLetter(int i)
++void moveLetter(int i)
+ {
+ 	int minx, maxx, miny, maxy, advance;
+ 	i--;

--- a/games-puzzle/scramble/scramble-0.9.5-r2.ebuild
+++ b/games-puzzle/scramble/scramble-0.9.5-r2.ebuild
@@ -1,0 +1,45 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+inherit autotools desktop flag-o-matic
+
+DESCRIPTION="Create as many words as you can before the time runs out"
+HOMEPAGE="http://www.shiftygames.com/scramble/scramble.html"
+SRC_URI="http://www.shiftygames.com/scramble/${P}.tar.gz"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE=""
+
+RDEPEND="
+	>=media-libs/libsdl-1.2[sound,video]
+	>=media-libs/sdl-mixer-1.2[vorbis]
+	>=media-libs/sdl-image-1.2[png]
+	media-libs/sdl-ttf
+"
+DEPEND="${RDEPEND}
+	media-libs/libpng:0
+	sys-apps/miscfiles
+"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-0.9.5-clang16-fix.patch
+)
+
+src_prepare() {
+	default
+	pngfix -q --out=pics/background-fixed.png pics/background.png
+	mv -f pics/background-fixed.png pics/background.png
+	append-cflags $(sdl-config --cflags)
+	sed -i -e 's/inline //' src/scramble.c || die
+	mv configure.{in,ac} || die
+	eautoreconf
+}
+
+src_install() {
+	default
+	newicon pics/sg_icon.png ${PN}.png
+	make_desktop_entry ${PN} "Scramble"
+}


### PR DESCRIPTION
And update EAPI 6 -> 8

Closes: https://bugs.gentoo.org/885761