### PR TITLE
sys-boot/syslinux: pass UPX=false to make

### DIFF
--- a/sys-boot/syslinux/syslinux-6.04_pre1-r5.ebuild
+++ b/sys-boot/syslinux/syslinux-6.04_pre1-r5.ebuild
@@ -60,7 +60,7 @@ src_compile() {
 	unset CFLAGS LDFLAGS
 
 	if use bios; then
-		emake bios DATE="${DATE}" HEXDATE="${HEXDATE}"
+		emake bios DATE="${DATE}" HEXDATE="${HEXDATE}" UPX=false
 	fi
 	if use efi; then
 		if use abi_x86_32; then

--- a/sys-boot/syslinux/syslinux-6.04_pre3-r1.ebuild
+++ b/sys-boot/syslinux/syslinux-6.04_pre3-r1.ebuild
@@ -77,7 +77,7 @@ src_compile() {
 	unset CFLAGS LDFLAGS
 
 	if use bios; then
-		emake bios DATE="${DATE}" HEXDATE="${HEXDATE}"
+		emake bios DATE="${DATE}" HEXDATE="${HEXDATE}" UPX=false
 	fi
 	if use efi; then
 		if use abi_x86_32; then


### PR DESCRIPTION
When building with bios support, Syslinux attempts to call upx. However, it is not a necessary build step and the build will just continue if it fails. This commit passes UPX=false to make when built with bios support to silence the command not found QA warnings.

Closes: https://bugs.gentoo.org/888211