### PR TITLE
net-im/telegram-desktop: Remove redundant dependency

### DIFF
--- a/net-im/telegram-desktop/telegram-desktop-4.10.3-r1.ebuild
+++ b/net-im/telegram-desktop/telegram-desktop-4.10.3-r1.ebuild
@@ -66,7 +66,6 @@ CDEPEND="
 		>=dev-qt/qtbase-6.5:6=[dbus?,gui,network,opengl,wayland?,widgets,X?]
 		>=dev-qt/qtimageformats-6.5:6
 		>=dev-qt/qtsvg-6.5:6
-		wayland? ( >=dev-qt/qtwayland-6.5:6[compositor] )
 		webkit? (
 			>=dev-qt/qtdeclarative-6.5:6
 			>=dev-qt/qtwayland-6.5:6[compositor]


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/915109
Thanks-to: Ionen Wolkens <ionen@gentoo.org>
Signed-off-by: Esteve Varela Colominas <esteve.varela@gmail.com>
