### PR TITLE
net-misc/gerbera: fix preserved libs with media-gfx/exiv2

### DIFF
--- a/net-misc/gerbera/gerbera-1.12.1.ebuild
+++ b/net-misc/gerbera/gerbera-1.12.1.ebuild
@@ -34,7 +34,7 @@ RDEPEND="
 	virtual/libiconv
 	curl? ( net-misc/curl )
 	exif? ( media-libs/libexif )
-	exiv2? ( media-gfx/exiv2 )
+	exiv2? ( media-gfx/exiv2:= )
 	ffmpeg? ( media-video/ffmpeg:= )
 	ffmpegthumbnailer? ( media-video/ffmpegthumbnailer )
 	javascript? ( dev-lang/duktape:= )

--- a/net-misc/gerbera/gerbera-9999.ebuild
+++ b/net-misc/gerbera/gerbera-9999.ebuild
@@ -34,7 +34,7 @@ RDEPEND="
 	virtual/libiconv
 	curl? ( net-misc/curl )
 	exif? ( media-libs/libexif )
-	exiv2? ( media-gfx/exiv2 )
+	exiv2? ( media-gfx/exiv2:= )
 	ffmpeg? ( media-video/ffmpeg:= )
 	ffmpegthumbnailer? ( media-video/ffmpegthumbnailer )
 	javascript? ( dev-lang/duktape:= )


### PR DESCRIPTION
Show this warning:

>>> package: media-gfx/exiv2-0.28.0
 *  - /usr/lib64/libexiv2.so.0.27.7
 *  - /usr/lib64/libexiv2.so.27
 *      used by /usr/bin/gerbera (net-misc/gerbera-1.12.1)