### PR TITLE
profiles/arch/powerpc/ppc64: remove obsolete package.use.mask

### DIFF
--- a/profiles/arch/powerpc/ppc64/package.use.mask
+++ b/profiles/arch/powerpc/ppc64/package.use.mask
@@ -86,7 +86,6 @@ media-video/obs-studio browser
 
 # Joonas Niilola <juippis@gentoo.org> (2021-06-23)
 # Pandoc is a required dep, and not keyworded.
-sys-apps/exa man
 sys-apps/eza man
 
 # Matt Turner <mattst88@gentoo.org> (2021-06-10)


### PR DESCRIPTION
The sys-apps/exa package was treecleaned in commit: 64cad5f333e2 ("sys-apps/exa: treeclean")

Bug: https://bugs.gentoo.org/913737