### PR TITLE
Added Intel CET features to LLVM

### DIFF
--- a/sys-libs/compiler-rt/compiler-rt-14.0.6-r1.ebuild
+++ b/sys-libs/compiler-rt/compiler-rt-14.0.6-r1.ebuild
@@ -12,7 +12,7 @@ HOMEPAGE="https://llvm.org/"
 LICENSE="Apache-2.0-with-LLVM-exceptions || ( UoI-NCSA MIT )"
 SLOT="$(ver_cut 1-3)"
 KEYWORDS="amd64 arm arm64 ppc64 ~riscv x86 ~amd64-linux ~ppc-macos ~x64-macos"
-IUSE="+abi_x86_32 abi_x86_64 +clang debug test"
+IUSE="+abi_x86_32 abi_x86_64 cet +clang debug test"
 RESTRICT="!test? ( test ) !clang? ( test )"
 
 LLVM_MAX_SLOT=${SLOT%%.*}
@@ -106,6 +106,7 @@ src_configure() {
 		-DCOMPILER_RT_BUILD_PROFILE=OFF
 		-DCOMPILER_RT_BUILD_SANITIZERS=OFF
 		-DCOMPILER_RT_BUILD_XRAY=OFF
+		-DCOMPILER_RT_ENABLE_CET=$(usex cet)
 
 		-DPython3_EXECUTABLE="${PYTHON}"
 	)

--- a/sys-libs/compiler-rt/compiler-rt-15.0.7.ebuild
+++ b/sys-libs/compiler-rt/compiler-rt-15.0.7.ebuild
@@ -12,7 +12,7 @@ HOMEPAGE="https://llvm.org/"
 LICENSE="Apache-2.0-with-LLVM-exceptions || ( UoI-NCSA MIT )"
 SLOT="${LLVM_VERSION}"
 KEYWORDS="amd64 arm arm64 ppc64 ~riscv x86 ~amd64-linux ~ppc-macos ~x64-macos"
-IUSE="+abi_x86_32 abi_x86_64 +clang debug test"
+IUSE="+abi_x86_32 abi_x86_64 cet +clang debug test"
 RESTRICT="!test? ( test ) !clang? ( test )"
 
 DEPEND="
@@ -105,6 +105,7 @@ src_configure() {
 		-DCOMPILER_RT_BUILD_PROFILE=OFF
 		-DCOMPILER_RT_BUILD_SANITIZERS=OFF
 		-DCOMPILER_RT_BUILD_XRAY=OFF
+		-DCOMPILER_RT_ENABLE_CET=$(usex cet)
 
 		-DPython3_EXECUTABLE="${PYTHON}"
 	)

--- a/sys-libs/compiler-rt/compiler-rt-16.0.6.ebuild
+++ b/sys-libs/compiler-rt/compiler-rt-16.0.6.ebuild
@@ -12,7 +12,7 @@ HOMEPAGE="https://llvm.org/"
 LICENSE="Apache-2.0-with-LLVM-exceptions || ( UoI-NCSA MIT )"
 SLOT="${LLVM_MAJOR}"
 KEYWORDS="amd64 arm arm64 ~loong ppc64 ~riscv x86 ~amd64-linux ~ppc-macos ~x64-macos"
-IUSE="+abi_x86_32 abi_x86_64 +clang debug test"
+IUSE="+abi_x86_32 abi_x86_64 cet +clang debug test"
 RESTRICT="!test? ( test ) !clang? ( test )"
 
 DEPEND="
@@ -112,6 +112,7 @@ src_configure() {
 		-DCOMPILER_RT_BUILD_PROFILE=OFF
 		-DCOMPILER_RT_BUILD_SANITIZERS=OFF
 		-DCOMPILER_RT_BUILD_XRAY=OFF
+		-DCOMPILER_RT_ENABLE_CET=$(usex cet)
 
 		-DPython3_EXECUTABLE="${PYTHON}"
 	)

--- a/sys-libs/compiler-rt/compiler-rt-17.0.3.9999.ebuild
+++ b/sys-libs/compiler-rt/compiler-rt-17.0.3.9999.ebuild
@@ -11,7 +11,7 @@ HOMEPAGE="https://llvm.org/"
 
 LICENSE="Apache-2.0-with-LLVM-exceptions || ( UoI-NCSA MIT )"
 SLOT="${LLVM_MAJOR}"
-IUSE="+abi_x86_32 abi_x86_64 +clang +debug test"
+IUSE="+abi_x86_32 abi_x86_64 cet +clang +debug test"
 RESTRICT="!test? ( test ) !clang? ( test )"
 
 DEPEND="
@@ -111,6 +111,7 @@ src_configure() {
 		-DCOMPILER_RT_BUILD_PROFILE=OFF
 		-DCOMPILER_RT_BUILD_SANITIZERS=OFF
 		-DCOMPILER_RT_BUILD_XRAY=OFF
+		-DCOMPILER_RT_ENABLE_CET=$(usex cet)
 
 		-DPython3_EXECUTABLE="${PYTHON}"
 	)

--- a/sys-libs/compiler-rt/compiler-rt-17.0.3.ebuild
+++ b/sys-libs/compiler-rt/compiler-rt-17.0.3.ebuild
@@ -12,7 +12,7 @@ HOMEPAGE="https://llvm.org/"
 LICENSE="Apache-2.0-with-LLVM-exceptions || ( UoI-NCSA MIT )"
 SLOT="${LLVM_MAJOR}"
 KEYWORDS="~amd64 ~arm ~arm64 ~loong ~ppc64 ~riscv ~x86 ~amd64-linux ~ppc-macos ~x64-macos"
-IUSE="+abi_x86_32 abi_x86_64 +clang debug test"
+IUSE="+abi_x86_32 abi_x86_64 cet +clang debug test"
 RESTRICT="!test? ( test ) !clang? ( test )"
 
 DEPEND="
@@ -112,6 +112,7 @@ src_configure() {
 		-DCOMPILER_RT_BUILD_PROFILE=OFF
 		-DCOMPILER_RT_BUILD_SANITIZERS=OFF
 		-DCOMPILER_RT_BUILD_XRAY=OFF
+		-DCOMPILER_RT_ENABLE_CET=$(usex cet)
 
 		-DPython3_EXECUTABLE="${PYTHON}"
 	)

--- a/sys-libs/compiler-rt/compiler-rt-18.0.0.9999.ebuild
+++ b/sys-libs/compiler-rt/compiler-rt-18.0.0.9999.ebuild
@@ -11,7 +11,7 @@ HOMEPAGE="https://llvm.org/"
 
 LICENSE="Apache-2.0-with-LLVM-exceptions || ( UoI-NCSA MIT )"
 SLOT="${LLVM_MAJOR}"
-IUSE="+abi_x86_32 abi_x86_64 +clang +debug test"
+IUSE="+abi_x86_32 abi_x86_64 cet +clang +debug test"
 RESTRICT="!test? ( test ) !clang? ( test )"
 
 DEPEND="
@@ -111,6 +111,7 @@ src_configure() {
 		-DCOMPILER_RT_BUILD_PROFILE=OFF
 		-DCOMPILER_RT_BUILD_SANITIZERS=OFF
 		-DCOMPILER_RT_BUILD_XRAY=OFF
+		-DCOMPILER_RT_ENABLE_CET=$(usex cet)
 
 		-DPython3_EXECUTABLE="${PYTHON}"
 	)

--- a/sys-libs/compiler-rt/compiler-rt-18.0.0_pre20231013.ebuild
+++ b/sys-libs/compiler-rt/compiler-rt-18.0.0_pre20231013.ebuild
@@ -11,7 +11,7 @@ HOMEPAGE="https://llvm.org/"
 
 LICENSE="Apache-2.0-with-LLVM-exceptions || ( UoI-NCSA MIT )"
 SLOT="${LLVM_MAJOR}"
-IUSE="+abi_x86_32 abi_x86_64 +clang +debug test"
+IUSE="+abi_x86_32 abi_x86_64 cet +clang +debug test"
 RESTRICT="!test? ( test ) !clang? ( test )"
 
 DEPEND="
@@ -111,6 +111,7 @@ src_configure() {
 		-DCOMPILER_RT_BUILD_PROFILE=OFF
 		-DCOMPILER_RT_BUILD_SANITIZERS=OFF
 		-DCOMPILER_RT_BUILD_XRAY=OFF
+		-DCOMPILER_RT_ENABLE_CET=$(usex cet)
 
 		-DPython3_EXECUTABLE="${PYTHON}"
 	)

--- a/sys-libs/compiler-rt/compiler-rt-18.0.0_pre20231019.ebuild
+++ b/sys-libs/compiler-rt/compiler-rt-18.0.0_pre20231019.ebuild
@@ -11,7 +11,7 @@ HOMEPAGE="https://llvm.org/"
 
 LICENSE="Apache-2.0-with-LLVM-exceptions || ( UoI-NCSA MIT )"
 SLOT="${LLVM_MAJOR}"
-IUSE="+abi_x86_32 abi_x86_64 +clang +debug test"
+IUSE="+abi_x86_32 abi_x86_64 cet +clang +debug test"
 RESTRICT="!test? ( test ) !clang? ( test )"
 
 DEPEND="
@@ -111,6 +111,7 @@ src_configure() {
 		-DCOMPILER_RT_BUILD_PROFILE=OFF
 		-DCOMPILER_RT_BUILD_SANITIZERS=OFF
 		-DCOMPILER_RT_BUILD_XRAY=OFF
+		-DCOMPILER_RT_ENABLE_CET=$(usex cet)
 
 		-DPython3_EXECUTABLE="${PYTHON}"
 	)

--- a/sys-libs/compiler-rt/metadata.xml
+++ b/sys-libs/compiler-rt/metadata.xml
@@ -7,6 +7,7 @@
 	<use>
 		<flag name="clang">Force building using installed clang (rather
 			than the default CC/CXX).</flag>
+		<flag name="cet">Enable Intel CET features</flag>
 	</use>
 	<upstream>
 		<remote-id type="github">llvm/llvm-project</remote-id>

--- a/sys-libs/llvm-libunwind/llvm-libunwind-14.0.6-r1.ebuild
+++ b/sys-libs/llvm-libunwind/llvm-libunwind-14.0.6-r1.ebuild
@@ -12,7 +12,7 @@ HOMEPAGE="https://llvm.org/docs/ExceptionHandling.html"
 LICENSE="Apache-2.0-with-LLVM-exceptions || ( UoI-NCSA MIT )"
 SLOT="0"
 KEYWORDS="amd64 arm arm64 ~ppc ppc64 ~riscv sparc x86 ~x64-macos"
-IUSE="debug static-libs test"
+IUSE="cet debug static-libs test"
 RESTRICT="!test? ( test )"
 
 RDEPEND="
@@ -77,6 +77,7 @@ multilib_src_configure() {
 			-DLLVM_EXTERNAL_LIT="${EPREFIX}/usr/bin/lit"
 			-DLLVM_LIT_ARGS="$(get_lit_flags)"
 			-DLIBUNWIND_LIBCXX_PATH="${WORKDIR}/libcxx"
+			-DLIBUNWIND_ENABLE_CET=$(usex cet)
 
 			-DLIBCXXABI_LIBDIR_SUFFIX=
 			-DLIBCXXABI_ENABLE_SHARED=OFF

--- a/sys-libs/llvm-libunwind/llvm-libunwind-15.0.7.ebuild
+++ b/sys-libs/llvm-libunwind/llvm-libunwind-15.0.7.ebuild
@@ -13,7 +13,7 @@ HOMEPAGE="https://llvm.org/docs/ExceptionHandling.html"
 LICENSE="Apache-2.0-with-LLVM-exceptions || ( UoI-NCSA MIT )"
 SLOT="0"
 KEYWORDS="amd64 arm arm64 ~ppc ppc64 ~riscv sparc x86 ~x64-macos"
-IUSE="+clang debug static-libs test"
+IUSE="cet +clang debug static-libs test"
 REQUIRED_USE="test? ( clang )"
 RESTRICT="!test? ( test )"
 
@@ -75,6 +75,7 @@ multilib_src_configure() {
 		-DLLVM_INCLUDE_TESTS=OFF
 		-DLIBUNWIND_ENABLE_ASSERTIONS=$(usex debug)
 		-DLIBUNWIND_ENABLE_STATIC=$(usex static-libs)
+		-DLIBUNWIND_ENABLE_CET=$(usex cet)
 		-DLIBUNWIND_INCLUDE_TESTS=$(usex test)
 		-DLIBUNWIND_INSTALL_HEADERS=ON
 

--- a/sys-libs/llvm-libunwind/llvm-libunwind-16.0.6-r1.ebuild
+++ b/sys-libs/llvm-libunwind/llvm-libunwind-16.0.6-r1.ebuild
@@ -13,7 +13,7 @@ HOMEPAGE="https://llvm.org/docs/ExceptionHandling.html"
 LICENSE="Apache-2.0-with-LLVM-exceptions || ( UoI-NCSA MIT )"
 SLOT="0"
 KEYWORDS="amd64 arm arm64 ~loong ~ppc ppc64 ~riscv sparc x86 ~x64-macos"
-IUSE="+clang debug static-libs test"
+IUSE="cet +clang debug static-libs test"
 REQUIRED_USE="test? ( clang )"
 RESTRICT="!test? ( test )"
 
@@ -84,6 +84,7 @@ multilib_src_configure() {
 		-DLLVM_INCLUDE_TESTS=OFF
 		-DLIBUNWIND_ENABLE_ASSERTIONS=$(usex debug)
 		-DLIBUNWIND_ENABLE_STATIC=$(usex static-libs)
+		-DLIBUNWIND_ENABLE_CET=$(usex cet)
 		-DLIBUNWIND_INCLUDE_TESTS=$(usex test)
 		-DLIBUNWIND_INSTALL_HEADERS=ON
 

--- a/sys-libs/llvm-libunwind/llvm-libunwind-17.0.3.9999.ebuild
+++ b/sys-libs/llvm-libunwind/llvm-libunwind-17.0.3.9999.ebuild
@@ -12,7 +12,7 @@ HOMEPAGE="https://llvm.org/docs/ExceptionHandling.html"
 
 LICENSE="Apache-2.0-with-LLVM-exceptions || ( UoI-NCSA MIT )"
 SLOT="0"
-IUSE="+clang +debug static-libs test"
+IUSE="cet +clang +debug static-libs test"
 REQUIRED_USE="test? ( clang )"
 RESTRICT="!test? ( test )"
 
@@ -83,6 +83,7 @@ multilib_src_configure() {
 		-DLLVM_INCLUDE_TESTS=OFF
 		-DLIBUNWIND_ENABLE_ASSERTIONS=$(usex debug)
 		-DLIBUNWIND_ENABLE_STATIC=$(usex static-libs)
+		-DLIBUNWIND_ENABLE_CET=$(usex cet)
 		-DLIBUNWIND_INCLUDE_TESTS=$(usex test)
 		-DLIBUNWIND_INSTALL_HEADERS=ON
 

--- a/sys-libs/llvm-libunwind/llvm-libunwind-17.0.3.ebuild
+++ b/sys-libs/llvm-libunwind/llvm-libunwind-17.0.3.ebuild
@@ -13,7 +13,7 @@ HOMEPAGE="https://llvm.org/docs/ExceptionHandling.html"
 LICENSE="Apache-2.0-with-LLVM-exceptions || ( UoI-NCSA MIT )"
 SLOT="0"
 KEYWORDS="~amd64 ~arm ~arm64 ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86 ~x64-macos"
-IUSE="+clang debug static-libs test"
+IUSE="cet +clang debug static-libs test"
 REQUIRED_USE="test? ( clang )"
 RESTRICT="!test? ( test )"
 
@@ -84,6 +84,7 @@ multilib_src_configure() {
 		-DLLVM_INCLUDE_TESTS=OFF
 		-DLIBUNWIND_ENABLE_ASSERTIONS=$(usex debug)
 		-DLIBUNWIND_ENABLE_STATIC=$(usex static-libs)
+		-DLIBUNWIND_ENABLE_CET=$(usex cet)
 		-DLIBUNWIND_INCLUDE_TESTS=$(usex test)
 		-DLIBUNWIND_INSTALL_HEADERS=ON
 

--- a/sys-libs/llvm-libunwind/llvm-libunwind-18.0.0.9999.ebuild
+++ b/sys-libs/llvm-libunwind/llvm-libunwind-18.0.0.9999.ebuild
@@ -12,7 +12,7 @@ HOMEPAGE="https://llvm.org/docs/ExceptionHandling.html"
 
 LICENSE="Apache-2.0-with-LLVM-exceptions || ( UoI-NCSA MIT )"
 SLOT="0"
-IUSE="+clang +debug static-libs test"
+IUSE="cet +clang +debug static-libs test"
 REQUIRED_USE="test? ( clang )"
 RESTRICT="!test? ( test )"
 
@@ -83,6 +83,7 @@ multilib_src_configure() {
 		-DLLVM_INCLUDE_TESTS=OFF
 		-DLIBUNWIND_ENABLE_ASSERTIONS=$(usex debug)
 		-DLIBUNWIND_ENABLE_STATIC=$(usex static-libs)
+		-DLIBUNWIND_ENABLE_CET=$(usex cet)
 		-DLIBUNWIND_INCLUDE_TESTS=$(usex test)
 		-DLIBUNWIND_INSTALL_HEADERS=ON
 

--- a/sys-libs/llvm-libunwind/llvm-libunwind-18.0.0_pre20231013.ebuild
+++ b/sys-libs/llvm-libunwind/llvm-libunwind-18.0.0_pre20231013.ebuild
@@ -12,7 +12,7 @@ HOMEPAGE="https://llvm.org/docs/ExceptionHandling.html"
 
 LICENSE="Apache-2.0-with-LLVM-exceptions || ( UoI-NCSA MIT )"
 SLOT="0"
-IUSE="+clang +debug static-libs test"
+IUSE="cet +clang +debug static-libs test"
 REQUIRED_USE="test? ( clang )"
 RESTRICT="!test? ( test )"
 
@@ -83,6 +83,7 @@ multilib_src_configure() {
 		-DLLVM_INCLUDE_TESTS=OFF
 		-DLIBUNWIND_ENABLE_ASSERTIONS=$(usex debug)
 		-DLIBUNWIND_ENABLE_STATIC=$(usex static-libs)
+		-DLIBUNWIND_ENABLE_CET=$(usex cet)
 		-DLIBUNWIND_INCLUDE_TESTS=$(usex test)
 		-DLIBUNWIND_INSTALL_HEADERS=ON
 

--- a/sys-libs/llvm-libunwind/llvm-libunwind-18.0.0_pre20231019.ebuild
+++ b/sys-libs/llvm-libunwind/llvm-libunwind-18.0.0_pre20231019.ebuild
@@ -12,7 +12,7 @@ HOMEPAGE="https://llvm.org/docs/ExceptionHandling.html"
 
 LICENSE="Apache-2.0-with-LLVM-exceptions || ( UoI-NCSA MIT )"
 SLOT="0"
-IUSE="+clang +debug static-libs test"
+IUSE="cet +clang +debug static-libs test"
 REQUIRED_USE="test? ( clang )"
 RESTRICT="!test? ( test )"
 
@@ -83,6 +83,7 @@ multilib_src_configure() {
 		-DLLVM_INCLUDE_TESTS=OFF
 		-DLIBUNWIND_ENABLE_ASSERTIONS=$(usex debug)
 		-DLIBUNWIND_ENABLE_STATIC=$(usex static-libs)
+		-DLIBUNWIND_ENABLE_CET=$(usex cet)
 		-DLIBUNWIND_INCLUDE_TESTS=$(usex test)
 		-DLIBUNWIND_INSTALL_HEADERS=ON
 

--- a/sys-libs/llvm-libunwind/metadata.xml
+++ b/sys-libs/llvm-libunwind/metadata.xml
@@ -10,5 +10,6 @@
 	<use>
 		<flag name="clang">Force building using installed clang (rather
 			than the default CC/CXX; required for testing).</flag>
+		<flag name="cet">Enable Intel CET features</flag>
 	</use>
 </pkgmetadata>


### PR DESCRIPTION
This PR adds the neccesary changes to llvm-libunwind and compiler-rt so LLVM can support (and enable if it is activated via C{XX}FLAGS) Intel CET features