### PR TITLE
dev-qt/qtwebengine: export *FLAGS in hopes of them being respected

### DIFF
--- a/dev-qt/qtwebengine/qtwebengine-5.15.11_p20230927.ebuild
+++ b/dev-qt/qtwebengine/qtwebengine-5.15.11_p20230927.ebuild
@@ -231,6 +231,9 @@ src_configure() {
 	export NINJA_PATH=/usr/bin/ninja
 	export NINJAFLAGS="${NINJAFLAGS:--j$(makeopts_jobs "${MAKEOPTS}" 999) -l$(makeopts_loadavg "${MAKEOPTS}" 0) -v}"
 
+	# Try to force thirdparty components to use user C{,XX}FLAGS as well. bug #652172
+	tc-export_build_env CC CXX
+
 	local myqmakeargs=(
 		--
 		-no-build-qtpdf


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/652172

This allowed me to use my regular package.env workaround. I didn't check if it completely addressed the bug report, but it works well enough for my purposes at least.

The warning turned error is due to enabling hardened in clang-common.

```
FAILED: host/obj/base/third_party/libevent/bundled_libevent/strlcpy.o 
/usr/lib/llvm/17/bin/clang -MMD -MF host/obj/base/third_party/libevent/bundled_libevent/strlcpy.o.d -DHAVE_CONFIG_H -DUSE_UDEV -DUSE_AURA=1 -DUSE_NSS_CERTS=1 -DUSE_OZONE=1 -DOFFICIAL_BUILD -DTOOLKIT_QT -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -DNO_UNWI
ND_TABLES -D_GNU_SOURCE -DNDEBUG -DNVALGRIND -DDYNAMIC_ANNOTATIONS_ENABLED=0 -I../../../../qtwebengine-5.15.11_p20230927/src/3rdparty/chromium/base/third_party/libevent/linux -Ihost/gen -I../../../../qtwebengine-5.15.11_p20230927/src/3rdparty/chromium -fno-strict-aliasing --p
aram=ssp-buffer-size=4 -fstack-protector -Wno-unknown-attributes -Wno-unknown-pragmas -Wno-unknown-warning-option -fno-unwind-tables -fno-asynchronous-unwind-tables -fPIC -pthread -fcolor-diagnostics -fmerge-all-constants -m64 -no-canonical-prefixes -O2 -fno-ident -fdata-sect
ions -ffunction-sections -fno-omit-frame-pointer -g0 -fvisibility=hidden -Wheader-hygiene -Wstring-conversion -Wtautological-overlap-compare -Wall -Wno-unused-variable -Wno-misleading-indentation -Wno-missing-field-initializers -Wno-unused-parameter -Wno-c++11-narrowing -Wno-
unneeded-internal-declaration -Wno-undefined-var-template -Wno-psabi -Wno-ignored-pragma-optimize -Wno-implicit-int-float-conversion -Wno-final-dtor-non-final-class -Wno-builtin-assume-aligned-alignment -Wno-deprecated-copy -Wno-non-c-typedef-for-linkage -Wno-max-tokens -std=
c11 -Wno-implicit-fallthrough -c ../../../../qtwebengine-5.15.11_p20230927/src/3rdparty/chromium/base/third_party/libevent/strlcpy.c -o host/obj/base/third_party/libevent/bundled_libevent/strlcpy.o
../../../../qtwebengine-5.15.11_p20230927/src/3rdparty/chromium/base/third_party/libevent/strlcpy.c:49:1: error: a function definition without a prototype is deprecated in all versions of C and is not supported in C2x [-Werror,-Wdeprecated-non-prototype]
   49 | _event_strlcpy(dst, src, siz)
      | ^
1 error generated.
````

[qtwebengine-5.15.11_p20230927:20231016-175726.log.gz](https://github.com/gentoo/gentoo/files/13054826/qtwebengine-5.15.11_p20230927.20231016-175726.log.gz)
