### PR TITLE
dev-libs/rocm-comgr: Bump fix-test.patch as well

### DIFF
--- a/dev-libs/rocm-comgr/files/rocm-comgr-5.7.1-correct-license-install-dir.patch
+++ b/dev-libs/rocm-comgr/files/rocm-comgr-5.7.1-correct-license-install-dir.patch
@@ -1,0 +1,16 @@
+Do not install same license for -asan, which avoids QA warning
+Upstream issue: https://github.com/RadeonOpenCompute/ROCm-CompilerSupport/issues/61
+===================================================================
+--- comgr.orig/CMakeLists.txt
++++ comgr/CMakeLists.txt
+@@ -281,10 +281,6 @@ install(FILES
+   "NOTICES.txt"
+   COMPONENT amd-comgr
+   DESTINATION ${CMAKE_INSTALL_DOCDIR})
+-install(FILES
+-  "LICENSE.txt"
+-  COMPONENT asan
+-  DESTINATION ${CMAKE_INSTALL_DOCDIR}-asan)
+ 
+ # Generate the install-tree package.
+ set(AMD_COMGR_PREFIX_CODE "

--- a/dev-libs/rocm-comgr/files/rocm-comgr-5.7.1-fix-tests.patch
+++ b/dev-libs/rocm-comgr/files/rocm-comgr-5.7.1-fix-tests.patch
@@ -1,0 +1,50 @@
+Vanilla LLVM does not support calling AMDGPU_KERNEL across different sources/bitcodes.
+Without this patch https://github.com/RadeonOpenCompute/ROCm-CompilerSupport/issues/45 occurs.
+Reference: https://github.com/llvm/llvm-project/issues/60313
+===================================================================
+Index: comgr/test/source/source1.cl
+===================================================================
+--- comgr.orig/test/source/source1.cl
++++ comgr/test/source/source1.cl
+@@ -35,7 +35,9 @@
+ 
+ #include "include-a.h"
+ 
++void kernel source3(__global int *j) { *j = FOO; }
++
+ void kernel source1(__global int *j) {
+   *j += 2;
+-  source2(j);
++  source3(j);
+ }
+Index: comgr/test/mangled_names_test.c
+===================================================================
+--- comgr.orig/test/mangled_names_test.c
++++ comgr/test/mangled_names_test.c
+@@ -162,7 +162,7 @@ int main(int argc, char *argv[]) {
+     exit(1);
+   }
+ 
+-  const char *bcNames[] = {"source1", "source2"};
++  const char *bcNames[] = {"source3", "source1"};
+ 
+   for (size_t I = 0; I < numNames; ++I) {
+     size_t Size;
+@@ -249,14 +249,14 @@ int main(int argc, char *argv[]) {
+ 
+   Status = amd_comgr_populate_mangled_names(DataExec, &numNames);
+ 
+-  if (numNames != 4) {
++  if (numNames != 6) {
+     printf("amd_populate_mangled_names Failed: "
+-           "produced %zu executable names (expected 4)\n",
++           "produced %zu executable names (expected 6)\n",
+            Count);
+     exit(1);
+   }
+ 
+-  const char *execNames[] = {"source1", "source1.kd", "source2", "source2.kd"};
++  const char *execNames[] = {"source3", "source3.kd", "source1", "source1.kd", "source2", "source2.kd"};
+ 
+   for (size_t I = 0; I < numNames; ++I) {
+     size_t Size;

--- a/dev-libs/rocm-comgr/rocm-comgr-5.7.1.ebuild
+++ b/dev-libs/rocm-comgr/rocm-comgr-5.7.1.ebuild
@@ -30,6 +30,7 @@ PATCHES=(
 	"${FILESDIR}/${PN}-5.7.0-metadata.patch"
 	"${FILESDIR}/${PN}-5.7.0-symbolizer.patch"
 	"${FILESDIR}/${PN}-5.7.1-fix-tests.patch"
+	"${FILESDIR}/${PN}-5.7.1-correct-license-install-dir.patch"
 )
 
 DESCRIPTION="Radeon Open Compute Code Object Manager"

--- a/dev-libs/rocm-comgr/rocm-comgr-5.7.1.ebuild
+++ b/dev-libs/rocm-comgr/rocm-comgr-5.7.1.ebuild
@@ -29,6 +29,7 @@ PATCHES=(
 	"${FILESDIR}/${PN}-5.7.0-disassembly.patch"
 	"${FILESDIR}/${PN}-5.7.0-metadata.patch"
 	"${FILESDIR}/${PN}-5.7.0-symbolizer.patch"
+	"${FILESDIR}/${PN}-5.7.1-fix-tests.patch"
 )
 
 DESCRIPTION="Radeon Open Compute Code Object Manager"


### PR DESCRIPTION
This is a small change only on test code that let all tests pass, does not affect installed package at all.

References: https://bugs.gentoo.org/836475#c5
References: https://github.com/gentoo/gentoo/pull/33400#issuecomment-1773686422
Closes: https://bugs.gentoo.org/836475