### PR TITLE
dev-db/mysql-init-scripts: Create v2.4 of init scripts

### DIFF
--- a/dev-db/mysql-init-scripts/files/init.d-2.4
+++ b/dev-db/mysql-init-scripts/files/init.d-2.4
@@ -1,0 +1,207 @@
+#!/sbin/openrc-run
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+extra_commands="checkconfig"
+extra_stopped_commands="bootstrap_galera"
+
+description_checkconfig="Verify the server's configuration"
+description_boostrap_galera="Start a new Galera cluster with this server as the initial node"
+
+depend() {
+	use net.lo
+	# localmount needed for $basedir
+	need localmount
+	# This service has its own timeout and may need to wait for repairs
+	# or remote synchronization
+	keyword -timeout
+}
+
+get_config() {
+	my_print_defaults --defaults-file="$1" mysqld server mariadb |
+	sed -n -e "s/^--$2=//p"
+}
+
+mysql_svcname() {
+	local ebextra=
+	case "${SVCNAME}" in
+		mysql*) ;;
+		*) ebextra=" (mysql)" ;;
+	esac
+	echo "${SVCNAME}${ebextra}"
+}
+
+stringContain() { [ -z "${2##*$1*}" ] && [ -z "$1" -o -n "$2" ]; }
+
+bootstrap_galera() {
+	MY_ARGS="--wsrep-new-cluster ${MY_ARGS}"
+	mark_service_starting
+	if start ; then
+		mark_service_started
+		return 0
+	else
+		mark_service_stopped
+		return 1
+	fi
+}
+
+start() {
+	# Check for old conf.d variables that mean migration was not yet done.
+	set | grep -Esq '^(mysql_slot_|MYSQL_BLOG_PID_FILE|STOPTIMEOUT)'
+	rc=$?
+	# Yes, MYSQL_INIT_I_KNOW_WHAT_I_AM_DOING is a hidden variable.
+	# It does have a use in testing, as it is possible to build a config file
+	# that works with both the old and new init scripts simulateously.
+	if [ "${rc}" = 0 -a -z "${MYSQL_INIT_I_KNOW_WHAT_I_AM_DOING}" ]; then
+		eerror "You have not updated your conf.d for the new mysql-init-scripts-2 revamp."
+		eerror "Not proceeding because it may be dangerous."
+		return 1
+	fi
+
+	# Check the config or die
+	if [ ${RC_CMD} != "restart" ] ; then
+		checkconfig || return 1
+	fi
+
+	# Now we can startup
+	ebegin "Starting $(mysql_svcname)"
+
+	MY_CNF="${MY_CNF:-/etc/${SVCNAME}/my.cnf}"
+
+	if [ ! -r "${MY_CNF}" ] ; then
+		eerror "Cannot read the configuration file \`${MY_CNF}'"
+		return 1
+	fi
+
+	# tail -n1 is critical as these we only want the last instance of the option
+	local basedir=$(get_config "${MY_CNF}" basedir | tail -n1)
+	local pidfile=$(get_config "${MY_CNF}" 'pid[_-]file' | tail -n1)
+	local socket=$(get_config "${MY_CNF}" socket | tail -n1)
+	local chroot=$(get_config "${MY_CNF}" chroot | tail -n1)
+	local wsrep="$(get_config "${MY_CNF}" 'wsrep[_-]on' | tail -n1 | awk '{print tolower($0)}')"
+	local wsrep_new=$(get_config "${MY_CNF}" 'wsrep-new-cluster' | tail -n1)
+
+	if [ -n "${chroot}" ] ; then
+		socket="${chroot}/${socket}"
+		pidfile="${chroot}/${pidfile}"
+	fi
+
+	if stringContain 'wsrep-new-cluster' "${MY_ARGS}" ; then
+		local datadir=$(get_config "${MY_CNF}" datadir | tail -n1)
+		if [ -f "${datadir}/grastate.dat" ] ; then
+			local safe_to_bootstrap=$(get_grastate "${datadir}/grastate.dat" safe_to_bootstrap | tail -n1)
+			if [ "${safe_to_bootstrap}" != "1" ] ; then
+				eerror "Galera's ${datadir}/grastate.dat says we are not safe_to_bootstrap"
+				eerror "Instead you can start this node normally, as a joiner, to pull data from other healthy nodes"
+				eerror "Or you can manually set safe_to_bootstrap to 1 if this node has the most recent valid data for your cluster (this will overwrite data on your other nodes)"
+				return 1
+			fi
+		fi
+	fi
+
+	# Galera: Only check datadir if not starting a new cluster and galera is enabled
+	# wsrep_on is not on or wsrep-new-cluster exists in the config or MY_ARGS
+	[ "${wsrep}" = "1" ] && wsrep="on"
+	if [ "${wsrep}" != "on" ] || [ -n "${wsrep_new}" ] || stringContain 'wsrep-new-cluster' "${MY_ARGS}" ; then
+
+		local datadir=$(get_config "${MY_CNF}" datadir | tail -n1)
+		if [ ! -d "${datadir}" ] ; then
+			eerror "MySQL datadir \`${datadir}' is empty or invalid"
+			eerror "Please check your config file \`${MY_CNF}'"
+			return 1
+		fi
+
+		if [ ! -d "${datadir}"/mysql ] ; then
+			# find which package is installed to report an error
+			local EROOT=$(portageq envvar EROOT)
+			local DBPKG_P=$(portageq match ${EROOT} $(portageq expand_virtual ${EROOT} virtual/mysql | head -n1))
+			if [ -z ${DBPKG_P} ] ; then
+				eerror "You don't appear to have a server package installed yet."
+			else
+				eerror "You don't appear to have the mysql database installed yet."
+				eerror "Please run \`emerge --config =${DBPKG_P}\` to have this done..."
+			fi
+			return 1
+		fi
+	fi
+
+	local piddir="${pidfile%/*}"
+	checkpath -d --owner mysql:mysql --mode 0755 "$piddir"
+	rc=$?
+	if [ $rc -ne 0 ]; then
+		eerror "Directory $piddir for pidfile does not exist and cannot be created"
+		return 1
+	fi
+
+	local startup_timeout=${STARTUP_TIMEOUT:-900}
+	local startup_early_timeout=${STARTUP_EARLY_TIMEOUT:-1000}
+	local tmpnice="${NICE:+"--nicelevel "}${NICE}"
+	local tmpionice="${IONICE:+"--ionice "}${IONICE}"
+	start-stop-daemon \
+		${DEBUG:+"--verbose"} \
+		--start \
+		--exec "${basedir}"/sbin/mysqld \
+		--pidfile "${pidfile}" \
+		--background \
+		--wait ${startup_early_timeout} \
+		${tmpnice} \
+		${tmpionice} \
+		-- --defaults-file="${MY_CNF}" ${MY_ARGS}
+	local ret=$?
+	if [ ${ret} -ne 0 ] ; then
+		eend ${ret}
+		return ${ret}
+	fi
+
+	ewaitfile ${startup_timeout} "${socket}"
+	eend $? || return 1
+
+	save_options pidfile "${pidfile}"
+	save_options basedir "${basedir}"
+}
+
+stop() {
+	if [ ${RC_CMD} = "restart" ] ; then
+		checkconfig || return 1
+	fi
+
+	ebegin "Stopping $(mysql_svcname)"
+
+	local pidfile="$(get_options pidfile)"
+	local basedir="$(get_options basedir)"
+	local stop_timeout=${STOP_TIMEOUT:-120}
+
+	start-stop-daemon \
+		${DEBUG:+"--verbose"} \
+		--stop \
+		--exec "${basedir}"/sbin/mysqld \
+		--pidfile "${pidfile}" \
+		--retry ${stop_timeout}
+	eend $?
+}
+
+checkconfig() {
+	local my_cnf="${MY_CNF:-/etc/${SVCNAME}/my.cnf}"
+	local basedir=$(get_config "${my_cnf}" basedir | tail -n1)
+	local svc_name=$(mysql_svcname)
+	ebegin "Checking mysqld configuration for ${svc_name}"
+
+	if [ ${RC_CMD} = "checkconfig" ] ; then
+		# We are calling checkconfig specifically.  Print warnings regardless.
+		"${basedir}"/sbin/mysqld --defaults-file="${my_cnf}" --help --verbose > /dev/null
+	else
+		# Suppress output to check the return value
+		"${basedir}"/sbin/mysqld --defaults-file="${my_cnf}" --help --verbose > /dev/null 2>&1
+
+		# If the above command does not return 0,
+		# then there is an error to echo to the user
+		if [ $? -ne 0 ] ; then
+			"${basedir}"/sbin/mysqld --defaults-file="${my_cnf}" --help --verbose > /dev/null
+		fi
+	fi
+
+	eend $? "${svc_name} config check failed"
+}
+
+# vim: filetype=gentoo-init-d sw=2 ts=2 sts=2 noet:
+

--- a/dev-db/mysql-init-scripts/files/init.d-s6-2.4
+++ b/dev-db/mysql-init-scripts/files/init.d-s6-2.4
@@ -1,0 +1,176 @@
+#!/sbin/openrc-run
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+depend() {
+	use net.lo
+	# localmount needed for $basedir
+	need localmount s6-svscan
+}
+
+get_config() {
+	my_print_defaults --defaults-file="$1" mysqld server mariadb |
+	sed -n -e "s/^--$2=//p"
+}
+
+mysql_svcname() {
+	local ebextra=
+	case "${svc_name}" in
+		mysql*) ;;
+		*) ebextra=" (mysql)" ;;
+	esac
+	echo "${svc_name}${ebextra}"
+}
+
+stringContain() { [ -z "${2##*$1*}" ] && [ -z "$1" -o -n "$2" ]; }
+
+bootstrap_galera() {
+	MY_ARGS="--wsrep-new-cluster ${MY_ARGS}"
+	mark_service_starting
+	if start_pre && start ; then
+		mark_service_started
+		return 0
+	else
+		mark_service_stopped
+		return 1
+	fi
+}
+
+
+extra_commands="checkconfig"
+extra_stopped_commands="bootstrap_galera"
+
+description_checkconfig="Verify the server's configuration"
+description_boostrap_galera="Start a new Galera cluster with this server as the initial node"
+supervisor=s6
+name=$(mysql_svcname)
+s6_service_timeout_stop="$((1000*${STOP_TIMEOUT:-120}))"
+#s6_svwait_options_start="-U -t $((1000*${STARTUP_EARLY_TIMEOUT:-1000}))"
+svc_name=${RC_SVCNAME%-s6}
+s6_service_path=/var/svc.d/${svc_name}
+
+start_pre() {
+	# Check the config or die
+	if [ ${RC_CMD} != "restart" ] ; then
+		checkconfig || return 1
+	fi
+
+	MY_CNF="${MY_CNF:-/etc/${svc_name}/my.cnf}"
+
+	if [ ! -r "${MY_CNF}" ] ; then
+		eerror "Cannot read the configuration file \`${MY_CNF}'"
+		return 1
+	fi
+
+	# tail -n1 is critical as these we only want the last instance of the option
+	local basedir=$(get_config "${MY_CNF}" basedir | tail -n1)
+	local pidfile=$(get_config "${MY_CNF}" 'pid[_-]file' | tail -n1)
+	local socket=$(get_config "${MY_CNF}" socket | tail -n1)
+	local chroot=$(get_config "${MY_CNF}" chroot | tail -n1)
+	local wsrep="$(get_config "${MY_CNF}" 'wsrep[_-]on' | tail -n1 | awk '{print tolower($0)}')"
+	local wsrep_new=$(get_config "${MY_CNF}" 'wsrep-new-cluster' | tail -n1)
+
+	if [ -n "${chroot}" ] ; then
+		socket="${chroot}/${socket}"
+		pidfile="${chroot}/${pidfile}"
+	fi
+
+	if stringContain 'wsrep-new-cluster' "${MY_ARGS}" ; then
+		local datadir=$(get_config "${MY_CNF}" datadir | tail -n1)
+		if [ -f "${datadir}/grastate.dat" ] ; then
+			local safe_to_bootstrap=$(get_grastate "${datadir}/grastate.dat" safe_to_bootstrap | tail -n1)
+			if [ "${safe_to_bootstrap}" != "1" ] ; then
+				eerror "Galera's ${datadir}/grastate.dat says we are not safe_to_bootstrap"
+				eerror "Instead you can start this node normally, as a joiner, to pull data from other healthy nodes"
+				eerror "Or you can manually set safe_to_bootstrap to 1 if this node has the most recent valid data for your cluster (this will overwrite data on your other nodes)"
+				return 1
+			fi
+		fi
+	fi
+
+	# Galera: Only check datadir if not starting a new cluster and galera is enabled
+	# wsrep_on is not on or wsrep-new-cluster exists in the config or MY_ARGS
+	[ "${wsrep}" = "1" ] && wsrep="on"
+	if [ "${wsrep}" != "on" ] || [ -n "${wsrep_new}" ] || stringContain 'wsrep-new-cluster' "${MY_ARGS}" ; then
+
+		local datadir=$(get_config "${MY_CNF}" datadir | tail -n1)
+		if [ ! -d "${datadir}" ] ; then
+			eerror "MySQL datadir \`${datadir}' is empty or invalid"
+			eerror "Please check your config file \`${MY_CNF}'"
+			return 1
+		fi
+
+		if [ ! -d "${datadir}"/mysql ] ; then
+			# find which package is installed to report an error
+			local EROOT=$(portageq envvar EROOT)
+			local DBPKG_P=$(portageq match ${EROOT} $(portageq expand_virtual ${EROOT} virtual/mysql | head -n1))
+			if [ -z ${DBPKG_P} ] ; then
+				eerror "You don't appear to have a server package installed yet."
+			else
+				eerror "You don't appear to have the mysql database installed yet."
+				eerror "Please run \`emerge --config =${DBPKG_P}\` to have this done..."
+			fi
+			return 1
+		fi
+	fi
+
+	local piddir="${pidfile%/*}"
+	checkpath -d --owner mysql:mysql --mode 0755 "$piddir"
+	rc=$?
+	if [ $rc -ne 0 ]; then
+		eerror "Directory $piddir for pidfile does not exist and cannot be created"
+		return 1
+	fi
+
+	# Prepare env files to source
+	mkdir -p "/var/svc.d/${svc_name}"
+	echo "MY_CNF=\"${MY_CNF}\"" > "/var/svc.d/${svc_name}/env"
+	echo "MY_ARGS=\"${MY_ARGS}\"" >> "/var/svc.d/${svc_name}/env"
+	echo "basedir=\"${basedir}\"" >> "/var/svc.d/${svc_name}/env"
+	mkdir -p "/var/svc.d/${svc_name}/log"
+	echo "SVCNAME=\"${svc_name}\"" > "/var/svc.d/${svc_name}/log/env"
+	echo "S6_LOG_OPTIONS=\"${S6_LOG_OPTIONS}\"" > "/var/svc.d/${svc_name}/log/env"
+}
+
+start_post() {
+	local socket=$(get_config "${MY_CNF}" socket | tail -n1)
+	local chroot=$(get_config "${MY_CNF}" chroot | tail -n1)
+	local startup_timeout=${STARTUP_TIMEOUT:-900}
+
+	if [ -n "${chroot}" ] ; then
+		socket="${chroot}/${socket}"
+	fi
+	ewaitfile ${startup_timeout} "${socket}"
+}
+
+checkconfig() {
+	local my_cnf="${MY_CNF:-/etc/${svc_name}/my.cnf}"
+	local basedir=$(get_config "${my_cnf}" basedir | tail -n1)
+	local svc_name=$(mysql_svcname)
+	ebegin "Checking mysqld configuration for ${svc_name}"
+
+	if [ ${RC_CMD} = "checkconfig" ] ; then
+		# We are calling checkconfig specifically.  Print warnings regardless.
+		"${basedir}"/sbin/mysqld --defaults-file="${my_cnf}" --help --verbose > /dev/null
+	else
+		# Suppress output to check the return value
+		"${basedir}"/sbin/mysqld --defaults-file="${my_cnf}" --help --verbose > /dev/null 2>&1
+
+		# If the above command does not return 0,
+		# then there is an error to echo to the user
+		if [ $? -ne 0 ] ; then
+			"${basedir}"/sbin/mysqld --defaults-file="${my_cnf}" --help --verbose > /dev/null
+		fi
+	fi
+
+	eend $? "${svc_name} config check failed"
+}
+
+stop_pre() {
+	if [ ${RC_CMD} = "restart" ] ; then
+		checkconfig || return 1
+	fi
+}
+
+# vim: filetype=gentoo-init-d sw=2 ts=2 sts=2 noet:
+

--- a/dev-db/mysql-init-scripts/files/init.d-supervise-2.4
+++ b/dev-db/mysql-init-scripts/files/init.d-supervise-2.4
@@ -1,0 +1,193 @@
+#!/sbin/openrc-run
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+extra_commands="checkconfig"
+extra_stopped_commands="boostrap_galera"
+
+description_checkconfig="Verify the server's configuration"
+description_boostrap_galera="Start a new Galera cluster with this server as the initial node"
+
+depend() {
+	use net.lo
+	# localmount needed for $basedir
+	need localmount
+}
+
+get_config() {
+	my_print_defaults --defaults-file="$1" mysqld server mariadb |
+	sed -n -e "s/^--$2=//p"
+}
+
+mysql_svcname() {
+	local ebextra=
+	case "${SVCNAME}" in
+		mysql*) ;;
+		*) ebextra=" (mysql)" ;;
+	esac
+	echo "${SVCNAME}${ebextra}"
+}
+
+stringContain() { [ -z "${2##*$1*}" ] && [ -z "$1" -o -n "$2" ]; }
+
+bootstrap_galera() {
+	MY_ARGS="--wsrep-new-cluster ${MY_ARGS}"
+	mark_service_starting
+	if start ; then
+		mark_service_started
+		return 0
+	else
+		mark_service_stopped
+		return 1
+	fi
+}
+
+start() {
+	# Check for old conf.d variables that mean migration was not yet done.
+	set | grep -Esq '^(mysql_slot_|MYSQL_BLOG_PID_FILE|STOPTIMEOUT)'
+	rc=$?
+	# Yes, MYSQL_INIT_I_KNOW_WHAT_I_AM_DOING is a hidden variable.
+	# It does have a use in testing, as it is possible to build a config file
+	# that works with both the old and new init scripts simulateously.
+	if [ "${rc}" = 0 -a -z "${MYSQL_INIT_I_KNOW_WHAT_I_AM_DOING}" ]; then
+		eerror "You have not updated your conf.d for the new mysql-init-scripts-2 revamp."
+		eerror "Not proceeding because it may be dangerous."
+		return 1
+	fi
+
+	# Check the config or die
+	if [ ${RC_CMD} != "restart" ] ; then
+		checkconfig || return 1
+	fi
+
+	# Now we can startup
+	ebegin "Starting $(mysql_svcname)"
+
+	MY_CNF="${MY_CNF:-/etc/${SVCNAME}/my.cnf}"
+
+	if [ ! -r "${MY_CNF}" ] ; then
+		eerror "Cannot read the configuration file \`${MY_CNF}'"
+		return 1
+	fi
+
+	# tail -n1 is critical as these we only want the last instance of the option
+	local basedir=$(get_config "${MY_CNF}" basedir | tail -n1)
+	local pidfile=$(get_config "${MY_CNF}" 'pid[_-]file' | tail -n1)
+	local socket=$(get_config "${MY_CNF}" socket | tail -n1)
+	local chroot=$(get_config "${MY_CNF}" chroot | tail -n1)
+	local wsrep="$(get_config "${MY_CNF}" 'wsrep[_-]on' | tail -n1 | awk '{print tolower($0)}')"
+	local wsrep_new=$(get_config "${MY_CNF}" 'wsrep-new-cluster' | tail -n1)
+
+	if [ -n "${chroot}" ] ; then
+		socket="${chroot}/${socket}"
+		pidfile="${chroot}/${pidfile}"
+	fi
+
+	if stringContain 'wsrep-new-cluster' "${MY_ARGS}" ; then
+		local datadir=$(get_config "${MY_CNF}" datadir | tail -n1)
+		if [ -f "${datadir}/grastate.dat" ] ; then
+			local safe_to_bootstrap=$(get_grastate "${datadir}/grastate.dat" safe_to_bootstrap | tail -n1)
+			if [ "${safe_to_bootstrap}" != "1" ] ; then
+				eerror "Galera's ${datadir}/grastate.dat says we are not safe_to_bootstrap"
+				eerror "Instead you can start this node normally, as a joiner, to pull data from other healthy nodes"
+				eerror "Or you can manually set safe_to_bootstrap to 1 if this node has the most recent valid data for your cluster (this will overwrite data on your other nodes)"
+				return 1
+			fi
+		fi
+	fi
+
+	# Galera: Only check datadir if not starting a new cluster and galera is enabled
+	# wsrep_on is not on or wsrep-new-cluster exists in the config or MY_ARGS
+	[ "${wsrep}" = "1" ] && wsrep="on"
+	if [ "${wsrep}" != "on" ] || [ -n "${wsrep_new}" ] || stringContain 'wsrep-new-cluster' "${MY_ARGS}" ; then
+
+		local datadir=$(get_config "${MY_CNF}" datadir | tail -n1)
+		if [ ! -d "${datadir}" ] ; then
+			eerror "MySQL datadir \`${datadir}' is empty or invalid"
+			eerror "Please check your config file \`${MY_CNF}'"
+			return 1
+		fi
+
+		if [ ! -d "${datadir}"/mysql ] ; then
+			# find which package is installed to report an error
+			local EROOT=$(portageq envvar EROOT)
+			local DBPKG_P=$(portageq match ${EROOT} $(portageq expand_virtual ${EROOT} virtual/mysql | head -n1))
+			if [ -z ${DBPKG_P} ] ; then
+				eerror "You don't appear to have a server package installed yet."
+			else
+				eerror "You don't appear to have the mysql database installed yet."
+				eerror "Please run \`emerge --config =${DBPKG_P}\` to have this done..."
+			fi
+			return 1
+		fi
+	fi
+
+	local piddir="${pidfile%/*}"
+	checkpath -d --owner mysql:mysql --mode 0755 "$piddir"
+	rc=$?
+	if [ $rc -ne 0 ]; then
+		eerror "Directory $piddir for pidfile does not exist and cannot be created"
+		return 1
+	fi
+
+	local startup_timeout=${STARTUP_TIMEOUT:-900}
+#	local startup_early_timeout=${STARTUP_EARLY_TIMEOUT:-1000}
+	local tmpnice="${NICE:+"--nicelevel "}${NICE}"
+	local tmpionice="${IONICE:+"--ionice "}${IONICE}"
+	supervise-daemon "${SVCNAME}" \
+		${DEBUG:+"--verbose"} \
+		--pidfile "/run/${SVCNAME}.pid" \
+		${tmpnice} \
+		${tmpionice} \
+		--start \
+		"${basedir}"/sbin/mysqld \
+		-- --defaults-file="${MY_CNF}" ${MY_ARGS}
+	local ret=$?
+	if [ ${ret} -ne 0 ] ; then
+		eend ${ret}
+		return ${ret}
+	fi
+
+	ewaitfile ${startup_timeout} "${socket}"
+	eend $? || return 1
+}
+
+stop() {
+	if [ ${RC_CMD} = "restart" ] ; then
+		checkconfig || return 1
+	fi
+
+	ebegin "Stopping $(mysql_svcname)"
+
+	supervise-daemon "${SVCNAME}" \
+		${DEBUG:+"--verbose"} \
+		--stop \
+		--pidfile "/run/${SVCNAME}.pid"
+	eend $?
+}
+
+checkconfig() {
+	local my_cnf="${MY_CNF:-/etc/${SVCNAME}/my.cnf}"
+	local basedir=$(get_config "${my_cnf}" basedir | tail -n1)
+	local svc_name=$(mysql_svcname)
+	ebegin "Checking mysqld configuration for ${svc_name}"
+
+	if [ ${RC_CMD} = "checkconfig" ] ; then
+		# We are calling checkconfig specifically.  Print warnings regardless.
+		"${basedir}"/sbin/mysqld --defaults-file="${my_cnf}" --help --verbose > /dev/null
+	else
+		# Suppress output to check the return value
+		"${basedir}"/sbin/mysqld --defaults-file="${my_cnf}" --help --verbose > /dev/null 2>&1
+
+		# If the above command does not return 0,
+		# then there is an error to echo to the user
+		if [ $? -ne 0 ] ; then
+			"${basedir}"/sbin/mysqld --defaults-file="${my_cnf}" --help --verbose > /dev/null
+		fi
+	fi
+
+	eend $? "${svc_name} config check failed"
+}
+
+# vim: filetype=gentoo-init-d sw=2 ts=2 sts=2 noet:
+

--- a/dev-db/mysql-init-scripts/mysql-init-scripts-2.4.ebuild
+++ b/dev-db/mysql-init-scripts/mysql-init-scripts-2.4.ebuild
@@ -1,0 +1,63 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit systemd s6 tmpfiles
+
+DESCRIPTION="Gentoo MySQL init scripts"
+HOMEPAGE="https://wiki.gentoo.org/wiki/No_homepage"
+# Need to set S due to PMS saying we need it existing, but no SRC_URI
+S=${WORKDIR}
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+
+# This NEEDS openrc for the save_options/get_options builtins.
+# mysql-connector-c needed for my_print_defaults
+RDEPEND="
+	sys-apps/openrc
+	dev-db/mysql-connector-c
+	!prefix? (
+		acct-group/mysql acct-user/mysql
+	)
+"
+
+src_install() {
+	newconfd "${FILESDIR}"/conf.d-2.0 mysql
+
+	# s6 init scripts
+	if use amd64 || use x86 ; then
+		newconfd "${FILESDIR}"/conf.d-2.0 mysql-s6
+		newinitd "${FILESDIR}"/init.d-s6-2.4 mysql-s6
+		s6_install_service mysql "${FILESDIR}"/run-s6
+		s6_install_service mysql/log "${FILESDIR}"/log-s6
+	fi
+
+	newinitd "${FILESDIR}"/init.d-2.4 mysql
+	newinitd "${FILESDIR}"/init.d-supervise-2.4 mysql-supervise
+
+	# systemd unit installation
+	exeinto /usr/libexec
+	doexe "${FILESDIR}"/mysqld-wait-ready
+	systemd_newunit "${FILESDIR}"/mysqld-v2.service mysqld.service
+	systemd_newunit "${FILESDIR}"/mysqld_at-v2.service mysqld@.service
+	newtmpfiles "${FILESDIR}"/mysql.conf-r1 mysql.conf
+
+	insinto /etc/logrotate.d
+	newins "${FILESDIR}"/logrotate.mysql-2.3 mysql
+}
+
+pkg_postinst() {
+	tmpfiles_process mysql.conf
+
+	if use amd64 || use x86 ; then
+		elog "To use the mysql-s6 script, you need to install the optional sys-apps/s6 package."
+		elog "If you wish to use s6 logging support, comment out the log-error setting in your my.cnf"
+		elog
+	fi
+
+	elog "Starting with version 10.1.8, MariaDB includes an improved systemd unit named mariadb.service"
+	elog "You should prefer that unit over this package's mysqld.service."
+}


### PR DESCRIPTION
The primary focus of this release is additional sanity checks saving database admins time when using the bootstrap_galera command.

One of the biggest points of confusion I've seen among junior DBAs with Galera on Gentoo is that the bootstrap_galera command doesn't work when grastate.dat safe_to_bootstrap is not set to 1.

It's expected that this value is 0, if this server was not the last server cleanly shut down, or if there was a split-brain condition.

Highlighting this value makes it harder to misuse bootstrap_galera and figure out which node is the correct one to restart from.