### PR TITLE
dev-libs/flatbuffers: Add CPE string to metadata.xml

### DIFF
--- a/dev-libs/flatbuffers/metadata.xml
+++ b/dev-libs/flatbuffers/metadata.xml
@@ -7,5 +7,6 @@
 	</maintainer>
 	<upstream>
 		<remote-id type="github">google/flatbuffers</remote-id>
+		<remote-id type="cpe">cpe:/a:google:flatbuffers</remote-id>
 	</upstream>
 </pkgmetadata>


### PR DESCRIPTION
This makes it easier to track CVEs.