### PR TITLE
media-gfx/gnofract4d: resolve test failures

### DIFF
--- a/media-gfx/gnofract4d/gnofract4d-4.3_p20230717.ebuild
+++ b/media-gfx/gnofract4d/gnofract4d-4.3_p20230717.ebuild
@@ -6,9 +6,9 @@ EAPI=8
 PYTHON_COMPAT=( python3_{10..12} )
 DISTUTILS_EXT=1
 DISTUTILS_SINGLE_IMPL=1
-DISTUTILS_USE_PEP517=setuptools
+DISTUTILS_IN_SOURCE_BUILD=1
 
-inherit distutils-r1 optfeature virtualx xdg
+inherit distutils-r1 multibuild optfeature virtualx xdg
 
 COMMIT="47d2093e8f6399d1badfba0d1cb0f9867e90b326"
 
@@ -46,11 +46,16 @@ src_prepare() {
 }
 
 python_test() {
+	ln -s "${BUILD_DIR}"/lib/fract4d/*.so fract4d/ || die
 	local EPYTEST_IGNORE=(
 		# test_regress.py does not provide pytest with any tests and inspecting it requires dev-python/pillow
 		test_regress.py
 	)
-	use x86 && local EPYTEST_DESELECT=(
+	local EPYTEST_DESELECT=(
+		# terminate called after throwing an instance of 'std::exception'
+		test_fract4d.py::Test::testFDSite
+	)
+	use x86 && EPYTEST_DESELECT+=(
 		# https://bugs.gentoo.org/890796
 		test_fractal.py::Test::testDiagonal
 		test_fractal.py::Test::testRecolor


### PR DESCRIPTION
Fix test failures identified by @juippis in #32212. I also had a single testFDSite failure while creating this ebuild.

DISTUTILS_IN_SOURCE_BUILD=1 may not be the preferred solution, but I expect my time will (eventually) go into finishing off a port to Meson that I have had going for a while.

If there is an obvious better (and easy) solution then do say.
