### PR TITLE
www-apache/passenger: Fix existing preserved libs for openssl

### DIFF
--- a/www-apache/passenger/passenger-6.0.18-r1.ebuild
+++ b/www-apache/passenger/passenger-6.0.18-r1.ebuild
@@ -26,6 +26,7 @@ ruby_add_rdepend "
 # upstream, so we must use the bundled version :-(
 CDEPEND="
 	>=dev-libs/libuv-1.8.0
+	dev-libs/openssl:=
 	net-misc/curl[ssl]
 	apache2? ( www-servers/apache[apache2_modules_unixd(+)] )"
 


### PR DESCRIPTION
Solve this error:
<pre>
!!! existing preserved libs:
>>> package: dev-libs/openssl-3.0.11
 *  - /usr/lib64/libcrypto.so.1.1
 *      used by /usr/lib64/passenger/support-binaries/PassengerAgent (www-apache/passenger-6.0.18)
</pre>