### PR TITLE
add USE=qt6 to x11-libs/qscintilla

### DIFF
--- a/dev-python/qscintilla-python/qscintilla-python-2.14.1-r1.ebuild
+++ b/dev-python/qscintilla-python/qscintilla-python-2.14.1-r1.ebuild
@@ -1,0 +1,112 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+PYTHON_COMPAT=( python3_{10..12} )
+inherit multibuild python-r1 qmake-utils out-of-source-utils
+
+DESCRIPTION="Python bindings for QScintilla"
+HOMEPAGE="https://www.riverbankcomputing.com/software/qscintilla/ https://pypi.org/project/QScintilla/"
+
+MY_PN=QScintilla
+MY_P=${MY_PN}_src-${PV/_pre/.dev}
+SRC_URI="https://www.riverbankcomputing.com/static/Downloads/${MY_PN}/${PV}/${MY_P}.tar.gz"
+S=${WORKDIR}/${MY_P}/Python
+
+LICENSE="GPL-3"
+SLOT="0"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~x86"
+IUSE="debug +qt5 qt6"
+
+REQUIRED_USE="|| ( qt5 qt6 ) ${PYTHON_REQUIRED_USE}"
+
+# no tests
+RESTRICT="test"
+
+DEPEND="${PYTHON_DEPS}
+	qt5? (
+		>=dev-python/PyQt5-5.15.5[gui,printsupport,widgets,${PYTHON_USEDEP}]
+		dev-qt/qtcore:5
+		dev-qt/qtgui:5
+		dev-qt/qtprintsupport:5
+		dev-qt/qtwidgets:5
+	)
+	qt6? (
+		dev-python/PyQt6[gui,printsupport,widgets,${PYTHON_USEDEP}]
+		dev-qt/qtbase:6[cups,gui,widgets]
+	)
+	~x11-libs/qscintilla-${PV}:=[qt5(+),qt6(+)]
+"
+RDEPEND="${DEPEND}
+	qt5? ( >=dev-python/PyQt5-sip-12.9:=[${PYTHON_USEDEP}] )
+	qt6? ( >=dev-python/PyQt6-sip-13.5:=[${PYTHON_USEDEP}] )
+"
+BDEPEND="
+	>=dev-python/PyQt-builder-1.10[${PYTHON_USEDEP}]
+	>=dev-python/sip-6.2[${PYTHON_USEDEP}]
+	qt5? ( dev-qt/qtcore:5 )
+	qt6? ( dev-qt/qtbase:6 )
+"
+
+pkg_setup() {
+	MULTIBUILD_VARIANTS=( $(usev qt5) $(usev qt6) )
+}
+
+src_configure() {
+	my_src_configure() {
+		case ${MULTIBUILD_VARIANT} in
+			qt5)
+				configuration() {
+					local myconf=(
+						sip-build
+						--verbose
+						--build-dir="${BUILD_DIR}"
+						--scripts-dir="$(python_get_scriptdir)"
+						--qmake="$(qt5_get_bindir)"/qmake
+						--no-make
+						$(usev debug '--debug --qml-debug --tracing')
+					)
+					echo "${myconf[@]}"
+					"${myconf[@]}" || die
+
+					run_in_build_dir qmake5 -recursive ${MY_PN}.pro
+				}
+				mv pyproject{-${MULTIBUILD_VARIANT},}.toml || die
+				python_foreach_impl configuration
+				;;
+			qt6)
+				configuration() {
+					local myconf=(
+						sip-build
+						--verbose
+						--build-dir="${BUILD_DIR}"
+						--scripts-dir="$(python_get_scriptdir)"
+						--qmake="$(qt6_get_bindir)"/qmake
+						--no-make
+						$(usev debug '--debug --qml-debug --tracing')
+					)
+					echo "${myconf[@]}"
+					"${myconf[@]}" || die
+
+					run_in_build_dir qmake6 -recursive ${MY_PN}.pro
+				}
+				mv pyproject{-${MULTIBUILD_VARIANT},}.toml || die
+				python_foreach_impl configuration
+				;;
+		esac
+	}
+	multibuild_foreach_variant my_src_configure
+}
+
+src_compile() {
+	multibuild_foreach_variant python_foreach_impl run_in_build_dir default
+}
+
+src_install() {
+	installation() {
+		emake INSTALL_ROOT="${D}" install
+		python_optimize
+	}
+	multibuild_foreach_variant python_foreach_impl run_in_build_dir installation
+}

--- a/profiles/arch/powerpc/ppc64/package.use.mask
+++ b/profiles/arch/powerpc/ppc64/package.use.mask
@@ -5,6 +5,10 @@
 # dev-qt/qtwebengine not available here
 dev-python/QtPy webengine test
 
+# José de Paula R. N. Assis <espinafre@gmail.com> (2024-03-25)
+# No PyQt6 (which is needed by USE=qt6 for qscintilla-python) on ppc64.
+>=dev-python/qscintilla-python-2.14.1-r1 qt6
+
 # Michal Privoznik <michal.privoznik@gmail.com> (2024-01-21)
 # virtiofsd is available here
 app-emulation/libvirt -virtiofsd

--- a/profiles/arch/x86/package.use.mask
+++ b/profiles/arch/x86/package.use.mask
@@ -9,6 +9,10 @@ net-p2p/ktorrent rss
 # virt-firmware is keyworded here
 sys-kernel/installkernel -efistub
 
+# José de Paula R. N. Assis <espinafre@gmail.com> (2024-03-25)
+# No PyQt6 (which is needed by USE=qt6 for qscintilla-python) on x86.
+>=dev-python/qscintilla-python-2.14.1-r1 qt6
+
 # Guilherme Amadio <amadio@gentoo.org> (2024-03-09)
 # Qt6 not keyworded on x86
 sci-physics/root qt6

--- a/x11-libs/qscintilla/qscintilla-2.14.1-r1.ebuild
+++ b/x11-libs/qscintilla/qscintilla-2.14.1-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -10,11 +10,7 @@ HOMEPAGE="https://www.riverbankcomputing.com/software/qscintilla/intro"
 
 MY_PN=QScintilla
 MY_P=${MY_PN}_src-${PV/_pre/.dev}
-if [[ ${PV} == *_pre* ]]; then
-	SRC_URI="https://dev.gentoo.org/~pesa/distfiles/${MY_P}.tar.gz"
-else
-	SRC_URI="https://www.riverbankcomputing.com/static/Downloads/${MY_PN}/${PV}/${MY_P}.tar.gz"
-fi
+SRC_URI="https://www.riverbankcomputing.com/static/Downloads/${MY_PN}/${PV}/${MY_P}.tar.gz"
 S=${WORKDIR}/${MY_P}
 
 LICENSE="GPL-3"

--- a/x11-libs/qscintilla/qscintilla-2.14.1-r1.ebuild
+++ b/x11-libs/qscintilla/qscintilla-2.14.1-r1.ebuild
@@ -1,0 +1,114 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit flag-o-matic multibuild qmake-utils
+
+DESCRIPTION="Qt port of Neil Hodgson's Scintilla C++ editor control"
+HOMEPAGE="https://www.riverbankcomputing.com/software/qscintilla/intro"
+
+MY_PN=QScintilla
+MY_P=${MY_PN}_src-${PV/_pre/.dev}
+if [[ ${PV} == *_pre* ]]; then
+	SRC_URI="https://dev.gentoo.org/~pesa/distfiles/${MY_P}.tar.gz"
+else
+	SRC_URI="https://www.riverbankcomputing.com/static/Downloads/${MY_PN}/${PV}/${MY_P}.tar.gz"
+fi
+S=${WORKDIR}/${MY_P}
+
+LICENSE="GPL-3"
+SLOT="0/15"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~riscv ~x86"
+IUSE="designer doc +qt5 qt6"
+
+REQUIRED_USE="|| ( qt5 qt6 )"
+
+# no tests
+RESTRICT="test"
+
+RDEPEND="
+	qt5? (
+		dev-qt/qtcore:5
+		dev-qt/qtgui:5
+		dev-qt/qtprintsupport:5
+		dev-qt/qtwidgets:5
+		designer? ( dev-qt/designer:5 )
+	)
+	qt6? (
+		dev-qt/qtbase:6[cups,gui,widgets]
+		designer? ( dev-qt/qttools:6[designer] )
+	)
+"
+DEPEND="${RDEPEND}"
+
+pkg_setup() {
+	MULTIBUILD_VARIANTS=( $(usev qt5) $(usev qt6) )
+}
+
+src_unpack() {
+	default
+
+	# Sub-slot sanity check
+	local subslot=${SLOT#*/}
+	local version=$(sed -nre 's:.*VERSION\s*=\s*([0-9\.]+):\1:p' "${S}"/src/qscintilla.pro || die)
+	local major=${version%%.*}
+	if [[ ${subslot} != ${major} ]]; then
+		eerror
+		eerror "Ebuild sub-slot (${subslot}) does not match QScintilla major version (${major})"
+		eerror "Please update SLOT variable as follows:"
+		eerror "    SLOT=\"${SLOT%%/*}/${major}\""
+		eerror
+		die "sub-slot sanity check failed"
+	fi
+
+	multibuild_copy_sources
+}
+
+qsci_run_in() {
+	pushd "$1" >/dev/null || die
+	shift || die
+	"$@" || die
+	popd >/dev/null || die
+}
+
+src_configure() {
+	if use designer; then
+		# prevent building against system version (bug 466120)
+		append-cxxflags -I../src
+		append-ldflags -L../src
+	fi
+	my_src_configure() {
+		case ${MULTIBUILD_VARIANT} in
+			qt5)
+				qsci_run_in "${BUILD_DIR}"/src eqmake5;
+				use designer && qsci_run_in "${BUILD_DIR}"/designer eqmake5;;
+			qt6)
+				qsci_run_in "${BUILD_DIR}"/src eqmake6;
+				use designer && qsci_run_in "${BUILD_DIR}"/designer eqmake6;;
+		esac
+	}
+
+	multibuild_foreach_variant my_src_configure
+}
+
+src_compile() {
+	my_src_compile() {
+		qsci_run_in "${BUILD_DIR}"/src emake
+		use designer && qsci_run_in "${BUILD_DIR}"/designer emake
+	}
+
+	multibuild_foreach_variant my_src_compile
+}
+
+src_install() {
+	my_src_install() {
+		qsci_run_in "${BUILD_DIR}"/src emake INSTALL_ROOT="${D}" install
+		use designer && qsci_run_in "${BUILD_DIR}"/designer emake INSTALL_ROOT="${D}" install
+	}
+
+	multibuild_foreach_variant my_src_install
+
+	use doc && local HTML_DOCS=( doc/html/. )
+	einstalldocs
+}


### PR DESCRIPTION
Adding USE=qt6 to x11-libs/qscintilla, based on previous work by @t0b3 (#31252), keeping qt5 support, via multibuild.


Closes: https://bugs.gentoo.org/916232