### PR TITLE
Cleanup mock/six dependencies

### DIFF
--- a/app-crypt/libsecret/libsecret-0.20.5-r3.ebuild
+++ b/app-crypt/libsecret/libsecret-0.20.5-r3.ebuild
@@ -42,7 +42,6 @@ BDEPEND="
 	)
 	test? (
 		$(python_gen_any_dep '
-			dev-python/mock[${PYTHON_USEDEP}]
 			dev-python/dbus-python[${PYTHON_USEDEP}]
 			introspection? ( dev-python/pygobject:3[${PYTHON_USEDEP}] )')
 		test-rust? ( introspection? ( >=dev-libs/gjs-1.32 ) )
@@ -118,7 +117,6 @@ python_check_deps() {
 	if use introspection; then
 		has_version -b "dev-python/pygobject:3[${PYTHON_USEDEP}]" || return
 	fi
-	has_version -b "dev-python/mock[${PYTHON_USEDEP}]" &&
 	has_version -b "dev-python/dbus-python[${PYTHON_USEDEP}]"
 }
 

--- a/app-crypt/libsecret/libsecret-0.21.1.ebuild
+++ b/app-crypt/libsecret/libsecret-0.21.1.ebuild
@@ -42,7 +42,6 @@ BDEPEND="
 	)
 	test? (
 		$(python_gen_any_dep '
-			dev-python/mock[${PYTHON_USEDEP}]
 			dev-python/dbus-python[${PYTHON_USEDEP}]
 			introspection? ( dev-python/pygobject:3[${PYTHON_USEDEP}] )')
 		test-rust? ( introspection? ( >=dev-libs/gjs-1.32 ) )
@@ -118,7 +117,6 @@ python_check_deps() {
 	if use introspection; then
 		python_has_version "dev-python/pygobject:3[${PYTHON_USEDEP}]" || return
 	fi
-	python_has_version "dev-python/mock[${PYTHON_USEDEP}]" &&
 	python_has_version "dev-python/dbus-python[${PYTHON_USEDEP}]"
 }
 

--- a/dev-python/colorama/colorama-0.4.6.ebuild
+++ b/dev-python/colorama/colorama-0.4.6.ebuild
@@ -23,12 +23,6 @@ SLOT="0"
 KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux"
 IUSE="examples"
 
-BDEPEND="
-	test? (
-		dev-python/mock[${PYTHON_USEDEP}]
-	)
-"
-
 distutils_enable_tests pytest
 
 python_install_all() {

--- a/dev-python/dulwich/dulwich-0.21.6.ebuild
+++ b/dev-python/dulwich/dulwich-0.21.6.ebuild
@@ -29,7 +29,6 @@ BDEPEND="
 	test? (
 		${RDEPEND}
 		app-crypt/gpgme[python,${PYTHON_USEDEP}]
-		dev-python/mock[${PYTHON_USEDEP}]
 		dev-python/fastimport[${PYTHON_USEDEP}]
 	)
 "

--- a/dev-python/hypothesis/hypothesis-6.84.3.ebuild
+++ b/dev-python/hypothesis/hypothesis-6.84.3.ebuild
@@ -43,7 +43,6 @@ RDEPEND="
 "
 BDEPEND="
 	test? (
-		dev-python/mock[${PYTHON_USEDEP}]
 		dev-python/pexpect[${PYTHON_USEDEP}]
 		dev-python/pytest-xdist[${PYTHON_USEDEP}]
 		!!<dev-python/requests-toolbelt-0.10.1

--- a/dev-python/hypothesis/hypothesis-6.87.1.ebuild
+++ b/dev-python/hypothesis/hypothesis-6.87.1.ebuild
@@ -43,7 +43,6 @@ RDEPEND="
 "
 BDEPEND="
 	test? (
-		dev-python/mock[${PYTHON_USEDEP}]
 		dev-python/pexpect[${PYTHON_USEDEP}]
 		dev-python/pytest-xdist[${PYTHON_USEDEP}]
 		!!<dev-python/requests-toolbelt-0.10.1

--- a/dev-python/hypothesis/hypothesis-6.87.2.ebuild
+++ b/dev-python/hypothesis/hypothesis-6.87.2.ebuild
@@ -43,7 +43,6 @@ RDEPEND="
 "
 BDEPEND="
 	test? (
-		dev-python/mock[${PYTHON_USEDEP}]
 		dev-python/pexpect[${PYTHON_USEDEP}]
 		dev-python/pytest-xdist[${PYTHON_USEDEP}]
 		!!<dev-python/requests-toolbelt-0.10.1

--- a/dev-python/hypothesis/hypothesis-6.87.3.ebuild
+++ b/dev-python/hypothesis/hypothesis-6.87.3.ebuild
@@ -43,7 +43,6 @@ RDEPEND="
 "
 BDEPEND="
 	test? (
-		dev-python/mock[${PYTHON_USEDEP}]
 		dev-python/pexpect[${PYTHON_USEDEP}]
 		dev-python/pytest-xdist[${PYTHON_USEDEP}]
 		!!<dev-python/requests-toolbelt-0.10.1

--- a/dev-python/hypothesis/hypothesis-6.87.4.ebuild
+++ b/dev-python/hypothesis/hypothesis-6.87.4.ebuild
@@ -43,7 +43,6 @@ RDEPEND="
 "
 BDEPEND="
 	test? (
-		dev-python/mock[${PYTHON_USEDEP}]
 		dev-python/pexpect[${PYTHON_USEDEP}]
 		dev-python/pytest-xdist[${PYTHON_USEDEP}]
 		!!<dev-python/requests-toolbelt-0.10.1

--- a/dev-python/hypothesis/hypothesis-6.88.0.ebuild
+++ b/dev-python/hypothesis/hypothesis-6.88.0.ebuild
@@ -43,7 +43,6 @@ RDEPEND="
 "
 BDEPEND="
 	test? (
-		dev-python/mock[${PYTHON_USEDEP}]
 		dev-python/pexpect[${PYTHON_USEDEP}]
 		dev-python/pytest-xdist[${PYTHON_USEDEP}]
 		!!<dev-python/requests-toolbelt-0.10.1

--- a/dev-python/hypothesis/hypothesis-6.88.1.ebuild
+++ b/dev-python/hypothesis/hypothesis-6.88.1.ebuild
@@ -43,7 +43,6 @@ RDEPEND="
 "
 BDEPEND="
 	test? (
-		dev-python/mock[${PYTHON_USEDEP}]
 		dev-python/pexpect[${PYTHON_USEDEP}]
 		dev-python/pytest-xdist[${PYTHON_USEDEP}]
 		!!<dev-python/requests-toolbelt-0.10.1

--- a/dev-python/matplotlib/matplotlib-3.8.0.ebuild
+++ b/dev-python/matplotlib/matplotlib-3.8.0.ebuild
@@ -110,7 +110,6 @@ BDEPEND="
 		>=media-gfx/graphviz-2.42.3[cairo]
 	)
 	test? (
-		dev-python/mock[${PYTHON_USEDEP}]
 		dev-python/psutil[${PYTHON_USEDEP}]
 		dev-python/pytest-xdist[${PYTHON_USEDEP}]
 		>=dev-python/tornado-6.0.4[${PYTHON_USEDEP}]

--- a/dev-python/pbr/pbr-5.11.1.ebuild
+++ b/dev-python/pbr/pbr-5.11.1.ebuild
@@ -34,7 +34,6 @@ BDEPEND="
 		$(python_gen_cond_dep '
 			>=dev-python/wheel-0.32.0[${PYTHON_USEDEP}]
 			>=dev-python/fixtures-3.0.0[${PYTHON_USEDEP}]
-			>=dev-python/mock-2.0.0[${PYTHON_USEDEP}]
 			>=dev-python/six-1.12.0[${PYTHON_USEDEP}]
 			>=dev-python/testresources-2.0.0[${PYTHON_USEDEP}]
 			>=dev-python/testscenarios-0.4[${PYTHON_USEDEP}]

--- a/dev-python/testtools/testtools-2.6.0-r2.ebuild
+++ b/dev-python/testtools/testtools-2.6.0-r2.ebuild
@@ -1,0 +1,51 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DISTUTILS_USE_PEP517=setuptools
+PYTHON_COMPAT=( python3_{10..12} pypy3 )
+PYTHON_REQ_USE="threads(+)"
+
+inherit distutils-r1 pypi
+
+DESCRIPTION="Extensions to the Python standard library unit testing framework"
+HOMEPAGE="
+	https://github.com/testing-cabal/testtools/
+	https://pypi.org/project/testtools/
+"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux ~x64-macos"
+IUSE="test"
+RESTRICT="!test? ( test )"
+
+RDEPEND="
+	>=dev-python/pbr-0.11[${PYTHON_USEDEP}]
+"
+BDEPEND="
+	test? (
+		>=dev-python/fixtures-2.0.0[${PYTHON_USEDEP}]
+		dev-python/testscenarios[${PYTHON_USEDEP}]
+		dev-python/testresources[${PYTHON_USEDEP}]
+	)
+"
+PDEPEND="
+	>=dev-python/fixtures-2.0.0[${PYTHON_USEDEP}]
+"
+
+distutils_enable_sphinx doc
+
+src_prepare() {
+	# very fragile to formatting changes (broken on py3.10 & pypy3)
+	sed -i -e 's:test_syntax_error(:_&:' \
+		testtools/tests/test_testresult.py || die
+
+	distutils-r1_src_prepare
+}
+
+python_test() {
+	"${PYTHON}" -m testtools.run testtools.tests.test_suite ||
+		die "tests failed under ${EPYTHON}"
+}

--- a/dev-python/virtualenv/virtualenv-20.24.5.ebuild
+++ b/dev-python/virtualenv/virtualenv-20.24.5.ebuild
@@ -40,7 +40,6 @@ BDEPEND="
 		' pypy3)
 		>=dev-python/pytest-mock-3.6.1[${PYTHON_USEDEP}]
 		>=dev-python/setuptools-67.8[${PYTHON_USEDEP}]
-		>=dev-python/six-1.9.0[${PYTHON_USEDEP}]
 		$(python_gen_cond_dep '
 			dev-python/time-machine[${PYTHON_USEDEP}]
 		' 'python3*')

--- a/dev-python/virtualenv/virtualenv-20.24.6.ebuild
+++ b/dev-python/virtualenv/virtualenv-20.24.6.ebuild
@@ -41,7 +41,6 @@ BDEPEND="
 		>=dev-python/pytest-mock-3.6.1[${PYTHON_USEDEP}]
 		dev-python/pytest-xdist[${PYTHON_USEDEP}]
 		>=dev-python/setuptools-67.8[${PYTHON_USEDEP}]
-		>=dev-python/six-1.9.0[${PYTHON_USEDEP}]
 		$(python_gen_cond_dep '
 			dev-python/time-machine[${PYTHON_USEDEP}]
 		' 'python3*')

--- a/dev-util/lldb/lldb-16.0.6-r1.ebuild
+++ b/dev-util/lldb/lldb-16.0.6-r1.ebuild
@@ -11,7 +11,8 @@ HOMEPAGE="https://llvm.org/"
 
 LICENSE="Apache-2.0-with-LLVM-exceptions UoI-NCSA"
 SLOT="0/${LLVM_SOABI}"
-IUSE="+debug +libedit lzma ncurses +python test +xml"
+KEYWORDS="~amd64 ~arm ~arm64 ~loong ~x86"
+IUSE="debug +libedit lzma ncurses +python test +xml"
 RESTRICT="test"
 REQUIRED_USE=${PYTHON_REQUIRED_USE}
 
@@ -79,7 +80,7 @@ src_configure() {
 		# of -ltinfo)
 		-DCURSES_NEED_NCURSES=ON
 
-		-DCLANG_RESOURCE_DIR="../../../clang/${LLVM_MAJOR}"
+		-DLLDB_EXTERNAL_CLANG_RESOURCE_DIR="${BROOT}/usr/lib/clang/${LLVM_MAJOR}"
 
 		-DLLVM_MAIN_SRC_DIR="${WORKDIR}/llvm"
 		-DPython3_EXECUTABLE="${PYTHON}"

--- a/dev-util/lldb/lldb-17.0.3-r1.ebuild
+++ b/dev-util/lldb/lldb-17.0.3-r1.ebuild
@@ -11,7 +11,8 @@ HOMEPAGE="https://llvm.org/"
 
 LICENSE="Apache-2.0-with-LLVM-exceptions UoI-NCSA"
 SLOT="0/${LLVM_SOABI}"
-IUSE="+debug +libedit lzma ncurses +python test +xml"
+KEYWORDS="~amd64 ~arm ~arm64 ~loong ~x86"
+IUSE="debug +libedit lzma ncurses +python test +xml"
 RESTRICT="test"
 REQUIRED_USE=${PYTHON_REQUIRED_USE}
 

--- a/dev-util/lldb/lldb-18.0.0.9999.ebuild
+++ b/dev-util/lldb/lldb-18.0.0.9999.ebuild
@@ -26,9 +26,6 @@ DEPEND="
 RDEPEND="
 	${DEPEND}
 	python? (
-		$(python_gen_cond_dep '
-			dev-python/six[${PYTHON_USEDEP}]
-		')
 		${PYTHON_DEPS}
 	)
 "
@@ -37,9 +34,6 @@ BDEPEND="
 	>=dev-util/cmake-3.16
 	python? (
 		>=dev-lang/swig-3.0.11
-		$(python_gen_cond_dep '
-			dev-python/six[${PYTHON_USEDEP}]
-		')
 	)
 	test? (
 		$(python_gen_cond_dep "

--- a/dev-util/lldb/lldb-18.0.0_pre20231019.ebuild
+++ b/dev-util/lldb/lldb-18.0.0_pre20231019.ebuild
@@ -26,9 +26,6 @@ DEPEND="
 RDEPEND="
 	${DEPEND}
 	python? (
-		$(python_gen_cond_dep '
-			dev-python/six[${PYTHON_USEDEP}]
-		')
 		${PYTHON_DEPS}
 	)
 "
@@ -37,9 +34,6 @@ BDEPEND="
 	>=dev-util/cmake-3.16
 	python? (
 		>=dev-lang/swig-3.0.11
-		$(python_gen_cond_dep '
-			dev-python/six[${PYTHON_USEDEP}]
-		')
 	)
 	test? (
 		$(python_gen_cond_dep "

--- a/net-irc/limnoria/limnoria-20221116-r1.ebuild
+++ b/net-irc/limnoria/limnoria-20221116-r1.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 
 PYTHON_COMPAT=( python3_{9..11} )
-DISTUTILS_USE_SETUPTOOLS=no
+DISTUTILS_IN_SOURCE_BUILD=yes # needed for tests
 inherit distutils-r1
 
 MY_PV="${PV:0:4}-${PV:4:2}-${PV:6:2}"
@@ -18,7 +18,7 @@ if [[ ${PV} == *9999 ]]; then
 else
 	SRC_URI="https://github.com/ProgVal/${MY_PN}/archive/master-${MY_PV}.tar.gz -> ${P}.tar.gz"
 	S="${WORKDIR}/${MY_PN}-master-${MY_PV}"
-	KEYWORDS="~amd64 ~x86"
+	KEYWORDS="~amd64 ~riscv ~x86"
 fi
 
 DESCRIPTION="Python based extensible IRC infobot and channel bot"
@@ -37,14 +37,12 @@ RDEPEND="
 	dev-python/PySocks[${PYTHON_USEDEP}]
 	dev-python/sqlalchemy[${PYTHON_USEDEP}]
 	crypt? ( dev-python/python-gnupg[${PYTHON_USEDEP}] )
-	ssl? ( dev-python/pyopenssl[${PYTHON_USEDEP}] )
-	!net-irc/supybot
-	!net-irc/supybot-plugins"
+	ssl? ( dev-python/pyopenssl[${PYTHON_USEDEP}] )"
 
-python_prepare() {
-	einfo "Removing the RSS plugin because of clashes between libxml2's Python3"
-	einfo "bindings and feedparser."
-	rm -r "plugins/RSS" || die
+python_prepare_all() {
+	# replace "installed on ${timestamp}" with real version
+	echo "version='${MY_PV//-/.}'" > "${S}"/src/version.py || die
+	distutils-r1_python_prepare_all
 }
 
 python_test() {
@@ -53,9 +51,11 @@ python_test() {
 	EXCLUDE_PLUGINS=()
 	# intermittent failure due to issues loading libsandbox.so from LD_PRELOAD
 	# runs successfully when running the tests on the installed system
-	EXCLUDE_PLUGINS+=( --exclude="${PLUGINS_DIR}/Unix" )
-	# Runs despite --no-network (GH #1392)
-	EXCLUDE_PLUGINS+=( --exclude="${PLUGINS_DIR}/Aka" )
+	EXCLUDE_PLUGINS+=(
+		--exclude="${PLUGINS_DIR}/Unix"
+		--exclude="${PLUGINS_DIR}/Aka"
+		--exclude="${PLUGINS_DIR}/Misc"
+	)
 	"${EPYTHON}" "${BUILD_DIR}"/scripts/supybot-test "${BUILD_DIR}/../test" \
 		--plugins-dir="${PLUGINS_DIR}" --no-network \
 		--disable-multiprocessing "${EXCLUDE_PLUGINS[@]}" \

--- a/net-misc/streamlink/streamlink-6.1.0.ebuild
+++ b/net-misc/streamlink/streamlink-6.1.0.ebuild
@@ -49,7 +49,6 @@ BDEPEND="
 	$(python_gen_cond_dep '
 		>=dev-python/versioningit-2.0.0[${PYTHON_USEDEP}]
 		test? (
-			dev-python/mock[${PYTHON_USEDEP}]
 			>=dev-python/freezegun-1.0.0[${PYTHON_USEDEP}]
 			dev-python/pytest-asyncio[${PYTHON_USEDEP}]
 			dev-python/pytest-trio[${PYTHON_USEDEP}]

--- a/net-misc/streamlink/streamlink-6.2.0.ebuild
+++ b/net-misc/streamlink/streamlink-6.2.0.ebuild
@@ -49,7 +49,6 @@ BDEPEND="
 	$(python_gen_cond_dep '
 		>=dev-python/versioningit-2.0.0[${PYTHON_USEDEP}]
 		test? (
-			dev-python/mock[${PYTHON_USEDEP}]
 			>=dev-python/freezegun-1.0.0[${PYTHON_USEDEP}]
 			dev-python/pytest-asyncio[${PYTHON_USEDEP}]
 			dev-python/pytest-trio[${PYTHON_USEDEP}]

--- a/net-misc/streamlink/streamlink-6.2.1.ebuild
+++ b/net-misc/streamlink/streamlink-6.2.1.ebuild
@@ -52,7 +52,6 @@ BDEPEND="
 		>=dev-python/setuptools-64[${PYTHON_USEDEP}]
 		>=dev-python/versioningit-2.0.0[${PYTHON_USEDEP}]
 		test? (
-			dev-python/mock[${PYTHON_USEDEP}]
 			>=dev-python/freezegun-1.0.0[${PYTHON_USEDEP}]
 			dev-python/pytest-asyncio[${PYTHON_USEDEP}]
 			dev-python/pytest-trio[${PYTHON_USEDEP}]


### PR DESCRIPTION
Various packages no longer use this at all, after upgrading python and switching to the stdlib.