### PR TITLE
eclass/go-env.eclass: add compile env helper to enable cross compiling Go programs

### DIFF
--- a/eclass/go-env.eclass
+++ b/eclass/go-env.eclass
@@ -1,0 +1,48 @@
+# Copyright 2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+# @ECLASS: go-env.eclass
+# @MAINTAINER:
+# Flatcar Linux Maintainers <infra@flatcar-linux.org>
+# @AUTHOR:
+# Flatcar Linux Maintainers <infra@flatcar-linux.org>
+# @BLURB: Helper eclass for setting the Go compile environment. Required for cross-compiling.
+# @DESCRIPTION:
+# This eclass includes a helper function for setting the compile environment for Go ebuilds.
+# Intended to be called by other Go eclasses in an early build stage, e.g. src_unpack.
+
+if [[ -z ${_GO_ENV_ECLASS} ]]; then
+_GO_ENV_ECLASS=1
+
+inherit toolchain-funcs
+
+# @FUNCTION: go-env_set_compile_environment
+# @DESCRIPTION:
+# Set up basic compile environment: CC, CXX, and GOARCH.
+# Also carry over CFLAGS, LDFLAGS and friends.
+# Required for cross-compiling with crossdev.
+# If not set, host defaults will be used and the resulting binaries are host arch.
+# (e.g. "emerge-aarch64-cross-linux-gnu foo" run on x86_64 will emerge "foo" for x86_64
+#  instead of aarch64)
+go-env_set_compile_environment() {
+	local arch="$(tc-arch)"
+	case "${arch}" in
+		x86)	GOARCH="386" ;;
+		x64-*)	GOARCH="amd64" ;;
+		ppc64)	if [[ "$(tc-endian)" == "big" ]] ; then
+					GOARCH="ppc64"
+				else
+					GOARCH="ppc64le"
+				fi ;;
+			*)	GOARCH="${arch}" ;;
+	esac
+
+	tc-export CC CXX
+	export GOARCH
+	export CGO_CFLAGS="${CGO_CFLAGS:-$CFLAGS}"
+	export CGO_CPPFLAGS="${CGO_CPPFLAGS:-$CPPFLAGS}"
+	export CGO_CXXFLAGS="${CGO_CXXFLAGS:-$CXXFLAGS}"
+	export CGO_LDFLAGS="${CGO_LDFLAGS:-$LDFLAGS}"
+}
+
+fi

--- a/eclass/go-module.eclass
+++ b/eclass/go-module.eclass
@@ -68,7 +68,7 @@ esac
 if [[ -z ${_GO_MODULE_ECLASS} ]]; then
 _GO_MODULE_ECLASS=1
 
-inherit multiprocessing toolchain-funcs
+inherit multiprocessing toolchain-funcs go-env
 
 if [[ ! ${GO_OPTIONAL} ]]; then
 	BDEPEND=">=dev-lang/go-1.18"
@@ -363,6 +363,7 @@ go-module_setup_proxy() {
 #    local go proxy.  This mode is deprecated.
 # 2. Otherwise, if EGO_VENDOR is set, bail out, as this functionality was removed.
 # 3. Otherwise, call 'ego mod verify' and then do a normal unpack.
+# Set compile env via go-env.
 go-module_src_unpack() {
 	if use amd64 || use arm || use arm64 ||
 		( use ppc64 && [[ $(tc-endian) == "little" ]] ) || use s390 || use x86; then
@@ -386,6 +387,8 @@ go-module_src_unpack() {
 			${nf} ego mod verify
 		fi
 	fi
+
+	go-env_set_compile_environment
 }
 
 # @FUNCTION: _go-module_src_unpack_gosum

--- a/eclass/golang-vcs-snapshot.eclass
+++ b/eclass/golang-vcs-snapshot.eclass
@@ -52,7 +52,7 @@ esac
 if [[ -z ${_GOLANG_VCS_SNAPSHOT_ECLASS} ]]; then
 _GOLANG_VCS_SNAPSHOT_ECLASS=1
 
-inherit golang-base
+inherit golang-base go-env
 
 # @ECLASS_VARIABLE: EGO_VENDOR
 # @DESCRIPTION:
@@ -92,6 +92,7 @@ _golang-vcs-snapshot_dovendor() {
 # @FUNCTION: golang-vcs-snapshot_src_unpack
 # @DESCRIPTION:
 # Extract the first archive from ${A} to the appropriate location for GOPATH.
+# Set compile env via go-env.
 golang-vcs-snapshot_src_unpack() {
 	local lib vendor_path x
 	ego_pn_check
@@ -117,6 +118,8 @@ golang-vcs-snapshot_src_unpack() {
 			fi
 		done
 	fi
+
+	go-env_set_compile_environment
 }
 
 fi

--- a/eclass/golang-vcs.eclass
+++ b/eclass/golang-vcs.eclass
@@ -20,7 +20,7 @@ esac
 if [[ -z ${_GOLANG_VCS_ECLASS} ]]; then
 _GOLANG_VCS_ECLASS=1
 
-inherit estack golang-base
+inherit estack golang-base go-env
 
 PROPERTIES+=" live"
 
@@ -63,6 +63,7 @@ PROPERTIES+=" live"
 # @INTERNAL
 # @DESCRIPTION:
 # Create EGO_STORE_DIR if necessary.
+# Set compile env via go-env.
 _golang-vcs_env_setup() {
 	debug-print-function ${FUNCNAME} "$@"
 
@@ -84,6 +85,8 @@ _golang-vcs_env_setup() {
 	mkdir -p "${WORKDIR}/${P}/src" ||
 		die "${ECLASS}: unable to create ${WORKDIR}/${P}"
 	return 0
+
+	go-env_set_compile_environment
 }
 
 # @FUNCTION: _golang-vcs_fetch


### PR DESCRIPTION
This PR addresses an issue with Go programs which, to the best of our knowledge (and testing) currently cannot be cross-compiled with crossdev on Gentoo.

The change adds a helper function to explicitly set `CC`, `CXX`, and `GOARCH` to the values returned by toolchain-funcs and carry over CFLAGS, LDFLAGS and friends to CGO equivalents, to provide a minimal sane compile environment for Go. It enables Go builds to play nice with crossdev's wrappers for emerge/ebuild etc.

Previously, Go ebuilds emitted binaries for the _host_ architecture since Go defaults `CC`, `CXX`, and `GOARCH` to the host. This can be easily validated by putting the command `go env` into the `src_compile()` stage of a Go program's ebuild and then cross-emerge that program - the environment will reflect the host environment instead of the target env.

For example, when running on an x86_64 host:
```
   emerge-aarch64-cross-linux-gnu foo
```
would previously either emit binaries for x86_64 or break entirely during `src_compile()` from linker errors. With this PR the command will now correctly emerge Go package "foo" for aarch64 instead of x86_64.

The eclass added provides a single helper function
```
    go-env_set_compile_environment()
```
intended to be called by other Go eclasses in an early build stage. Ebuilds may also explicitly call this function.

The helper function is supposed to be called in an early build stage. Calls to this function from _src_prepare in go-module.eclass, golang-vcs-snapshot.eclass, and golang-vcs.eclass have been added to immediately un-break cross-compilation of existing Go packages.

# Testing done

The PR has been tested using the Gentoo stage3 / portage containers:
1. A full Gentoo container image was built in accordance with https://github.com/gentoo/gentoo-docker-images
2. An `aarch64-cross-linux-gnu` crossdev environment was installed in the container, following https://wiki.gentoo.org/wiki/Crossdev
3. For testing purposes `runc`, a simple Go program, was emerged:
    ```
    emerge-aarch64-cross-linux-gnu runc
    ```
    This failed in stage `src_compile` with a linker error:
    ```
    ...
    GOROOT_FINAL='$GOROOT' /usr/lib/go/pkg/tool/linux_amd64/link -o $WORK/b001/exe/a.out -importcfg $WORK/b001/importcfg.link -installsuffix shared -X=runtime.godebugDefault=panicnil=1 -buildmode=pie -buildid=6MUnT5PQr_SBpvPFIWW-/eZ8c261V2-y_pzaOtVhP/YxEOWcTUB9Lsz-2nDChM/6MUnT5PQr_SBpvPFIWW- -X main.gitCommit=ccaecfcbc907d70a7aa870a6650887b901b25b82 -X main.version=1.1.9 -extld=x86_64-pc-linux-gnu-gcc $WORK/b001/_pkg_.a
    ...
    /usr/libexec/gcc/x86_64-pc-linux-gnu/ld: skipping incompatible /usr/lib/libc.a when searching for -lc
    /usr/libexec/gcc/x86_64-pc-linux-gnu/ld: /usr/aarch64-cross-linux-gnu/tmp/portage/app-containers/runc-1.1.9/temp/go-link-738209211/000010.o: in function `getenv_int':
    nsexec.c:(.text+0xd37): undefined reference to `__isoc23_strtol'
    /usr/libexec/gcc/x86_64-pc-linux-gnu/ld: /usr/aarch64-cross-linux-gnu/tmp/portage/app-containers/runc-1.1.9/temp/go-link-738209211/000010.o: in function `receive_mountsources':
    nsexec.c:(.text+0x1fdc): undefined reference to `__isoc23_strtol'
    collect2: error: ld returned 1 exit status

    make: *** [Makefile:61: runc] Error 1
    ```
    From the output it's clear that Go tried to build x86_64 binaries.
4. The patch shipped with this PR was applied to `/var/db/repos/gentoo/`
5. `runc` was now cross-emerged successfully:
    ```
    emerge-aarch64-cross-linux-gnu runc
    ```
    And the resulting binary has the correct arch:
    ```
    file /usr/aarch64-cross-linux-gnu/usr/bin/runc
    /usr/aarch64-cross-linux-gnu/usr/bin/runc: ELF 64-bit LSB pie executable, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, for GNU/Linux 3.7.0, Go BuildID=OFslkehqBcinH9G-YTjt/eYtglPhJGrLwlpqQXkK1/mDQ_zWTC3hiGroV_8tzq/ushdIjZQV322dHy6oPli, with debug_info, not stripped
    ```
 
# Continued Maintenance of the new EClass

The Flatcar Maintainers team commit to maintaining this eclass. We are planning to actively use it in our downstream Flatcar Container Linux distro (which is based on Gentoo) to cross-compile Go binaries. Initially it will be used for runc, containerd, docker, docker-cli, and cri-tools. These will be cross-built regularly in our Nightlies and will undergo full scenario testing in our release tests, so regressions will be identified swiftly and be fixed in a timely manner.