### PR TITLE
media-libs/openimageio: set correct source directory

### DIFF
--- a/media-libs/openimageio/openimageio-2.4.12.0.ebuild
+++ b/media-libs/openimageio/openimageio-2.4.12.0.ebuild
@@ -17,7 +17,7 @@ SRC_URI+=" test? (
 	https://github.com/OpenImageIO/oiio-images/archive/${TEST_OIIO_IMAGE_COMMIT}.tar.gz -> ${PN}-oiio-test-image-${TEST_OIIO_IMAGE_COMMIT}.tar.gz
 	https://github.com/AcademySoftwareFoundation/openexr-images/archive/${TEST_OEXR_IMAGE_COMMIT}.tar.gz -> ${PN}-oexr-test-image-${TEST_OEXR_IMAGE_COMMIT}.tar.gz
 )"
-S="${WORKDIR}/oiio-${PV}"
+S="${WORKDIR}/OpenImageIO-${PV}"
 
 LICENSE="BSD"
 SLOT="0/$(ver_cut 1-2)"

--- a/media-libs/openimageio/openimageio-2.4.13.0.ebuild
+++ b/media-libs/openimageio/openimageio-2.4.13.0.ebuild
@@ -17,7 +17,7 @@ SRC_URI+=" test? (
 	https://github.com/OpenImageIO/oiio-images/archive/${TEST_OIIO_IMAGE_COMMIT}.tar.gz -> ${PN}-oiio-test-image-${TEST_OIIO_IMAGE_COMMIT}.tar.gz
 	https://github.com/AcademySoftwareFoundation/openexr-images/archive/${TEST_OEXR_IMAGE_COMMIT}.tar.gz -> ${PN}-oexr-test-image-${TEST_OEXR_IMAGE_COMMIT}.tar.gz
 )"
-S="${WORKDIR}/oiio-${PV}"
+S="${WORKDIR}/OpenImageIO-${PV}"
 
 LICENSE="BSD"
 SLOT="0/$(ver_cut 1-2)"

--- a/media-libs/openimageio/openimageio-2.4.14.0.ebuild
+++ b/media-libs/openimageio/openimageio-2.4.14.0.ebuild
@@ -18,6 +18,7 @@ SRC_URI="
 		https://github.com/AcademySoftwareFoundation/openexr-images/archive/${TEST_OEXR_IMAGE_COMMIT}.tar.gz -> ${PN}-oexr-test-image-${TEST_OEXR_IMAGE_COMMIT}.tar.gz
 	)
 "
+S="${WORKDIR}/OpenImageIO-${PV}"
 
 LICENSE="BSD"
 SLOT="0/$(ver_cut 1-2)"

--- a/media-libs/openimageio/openimageio-2.4.15.0.ebuild
+++ b/media-libs/openimageio/openimageio-2.4.15.0.ebuild
@@ -18,6 +18,7 @@ SRC_URI="
 		https://github.com/AcademySoftwareFoundation/openexr-images/archive/${TEST_OEXR_IMAGE_COMMIT}.tar.gz -> ${PN}-oexr-test-image-${TEST_OEXR_IMAGE_COMMIT}.tar.gz
 	)
 "
+S="${WORKDIR}/OpenImageIO-${PV}"
 
 LICENSE="BSD"
 SLOT="0/$(ver_cut 1-2)"

--- a/media-libs/openimageio/openimageio-2.4.16.0.ebuild
+++ b/media-libs/openimageio/openimageio-2.4.16.0.ebuild
@@ -18,6 +18,7 @@ SRC_URI="
 		https://github.com/AcademySoftwareFoundation/openexr-images/archive/${TEST_OEXR_IMAGE_COMMIT}.tar.gz -> ${PN}-oexr-test-image-${TEST_OEXR_IMAGE_COMMIT}.tar.gz
 	)
 "
+S="${WORKDIR}/OpenImageIO-${PV}"
 
 LICENSE="BSD"
 SLOT="0/$(ver_cut 1-2)"

--- a/media-libs/openimageio/openimageio-2.5.4.0.ebuild
+++ b/media-libs/openimageio/openimageio-2.5.4.0.ebuild
@@ -18,6 +18,7 @@ SRC_URI="
 		https://github.com/AcademySoftwareFoundation/openexr-images/archive/${TEST_OEXR_IMAGE_COMMIT}.tar.gz -> ${PN}-oexr-test-image-${TEST_OEXR_IMAGE_COMMIT}.tar.gz
 	)
 "
+S="${WORKDIR}/OpenImageIO-${PV}"
 
 LICENSE="BSD"
 SLOT="0/$(ver_cut 1-2)"


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/916320