### PR TITLE
media-gfx/blender: 3.6.5 drop ocio-2.3.0 patch

### DIFF
--- a/media-gfx/blender/blender-3.6.5.ebuild
+++ b/media-gfx/blender/blender-3.6.5.ebuild
@@ -138,10 +138,6 @@ BDEPEND="
 	)
 "
 
-PATCHES=(
-	"${FILESDIR}/${PN}-4.0.0-ocio-2.3.0.patch"
-)
-
 blender_check_requirements() {
 	[[ ${MERGE_TYPE} != binary ]] && use openmp && tc-check-openmp
 


### PR DESCRIPTION
Patch no longer needed since
https://github.com/blender/blender/commit/f6558e3a233e19a06f8bbff6c26421db4b40d93e

Closes: https://bugs.gentoo.org/916324