### PR TITLE
media-libs/mesa: Fix undefined symbols in version script

### DIFF
--- a/media-libs/mesa/files/mesa-23.2.1-Fix-undefined-version-script-symbols.patch
+++ b/media-libs/mesa/files/mesa-23.2.1-Fix-undefined-version-script-symbols.patch
@@ -1,0 +1,60 @@
+
+From https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/25551/diffs?commit_id=4b5851f98fcdb4fc8e3fab44f11210366e51366b Mon Sep 17 00:00:00 2001
+From: Violet Purcell <vimproved@inventati.org>
+Date: Sun, 1 Oct 2023 17:35:00 -0400
+Subject: [PATCH] gallium: Fix undefined symbols in dri.sym
+
+Currently, dri.sym unconditionally uses symbols from gallium drivers
+that may not be enabled, which causes linking to fail with
+--no-undefined-version (as is default in LLD 17), and can cause issues
+with LTO. This commit adds logic to generate dri.sym based on the enabled
+gallium drivers, ensuring only defined symbols are used.
+
+Closes: https://gitlab.freedesktop.org/mesa/mesa/-/issues/8003
+Signed-off-by: Violet Purcell <vimproved@inventati.org>
+--- /dev/null
++++ b/src/gallium/targets/dri/dri.sym.in
+@@ -0,0 +1,11 @@
++{
++	global:
++		__driDriverGetExtensions*;
++		@nouveau_drm_screen_create@
++		@radeon_drm_winsys_create@
++		@amdgpu_winsys_create@
++		@fd_drm_screen_create_renderonly@
++		@ac_init_shared_llvm_once@
++	local:
++		*;
++};
+--- a/src/gallium/targets/dri/meson.build
++++ b/src/gallium/targets/dri/meson.build
+@@ -28,9 +28,25 @@ gallium_dri_ld_args = []
+ gallium_dri_link_depends = []
+ gallium_dri_drivers = []
+ 
++dri_sym_config = configuration_data()
++
++foreach d : [[with_gallium_r300 or with_gallium_radeonsi or with_gallium_r600, 'radeon_drm_winsys_create'],
++             [with_gallium_radeonsi, 'amdgpu_winsys_create'],
++             [with_gallium_nouveau, 'nouveau_drm_screen_create'],
++             [with_gallium_freedreno, 'fd_drm_screen_create_renderonly'],
++             [with_llvm and with_gallium_radeonsi, 'ac_init_shared_llvm_once']]
++  if d[0]
++    dri_sym_config.set(d[1], d[1] + ';')
++  else
++    dri_sym_config.set(d[1], '')
++  endif
++endforeach
++
++dri_sym = configure_file(input : 'dri.sym.in', output : 'dri.sym', configuration : dri_sym_config)
++
+ if with_ld_version_script
+-  gallium_dri_ld_args += ['-Wl,--version-script', join_paths(meson.current_source_dir(), 'dri.sym')]
+-  gallium_dri_link_depends += files('dri.sym')
++  gallium_dri_ld_args += ['-Wl,--version-script', join_paths(meson.current_build_dir(), 'dri.sym')]
++  gallium_dri_link_depends += dri_sym
+ endif
+ if with_ld_dynamic_list
+   gallium_dri_ld_args += ['-Wl,--dynamic-list', join_paths(meson.current_source_dir(), '../dri.dyn')]
+-- 
+GitLab

--- a/media-libs/mesa/mesa-23.2.1.ebuild
+++ b/media-libs/mesa/mesa-23.2.1.ebuild
@@ -203,6 +203,8 @@ x86? (
 PATCHES=(
 	# Workaround the CMake dependency lookup returning a different LLVM to llvm-config, bug #907965
 	"${FILESDIR}/clang_config_tool.patch"
+
+	"${FILESDIR}/mesa-23.2.1-Fix-undefined-version-script-symbols.patch"
 )
 
 llvm_check_deps() {


### PR DESCRIPTION
This should fix linking with LLD 17, as well as fixing some potential LTO issues caused by undefined symbols in a version script.

Upstream-PR: https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/25551