### PR TITLE
app-editors/yudit: improve ebuild, fix #729260

### DIFF
--- a/app-editors/yudit/yudit-3.1.0-r1.ebuild
+++ b/app-editors/yudit/yudit-3.1.0-r1.ebuild
@@ -1,0 +1,31 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs
+
+DESCRIPTION="Free (Y)unicode text editor for all unices"
+HOMEPAGE="https://www.yudit.org/"
+SRC_URI="https://yudit.org/download/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+RDEPEND="x11-libs/libX11"
+DEPEND="${RDEPEND}"
+BDEPEND="sys-devel/gettext"
+
+DOCS=( {BUGS,CHANGELOG,NEWS,TODO}.TXT )
+
+src_prepare() {
+	default
+	# Don't strip binaries, let portage do that.
+	# Don't call ar / ranlib directly
+	sed -i \
+		-e "/^INSTALL_PROGRAM/s| -s||" \
+		-e "s|ar cr|$(tc-getAR) cr|g" \
+		-e "s|ranlib|$(tc-getRANLIB)|g" \
+		Makefile.conf.in || die "sed failed"
+}


### PR DESCRIPTION
```diff
--- yudit-3.1.0.ebuild	2023-04-01 17:48:25.761958898 +0200
+++ yudit-3.1.0-r1.ebuild	2023-10-28 12:38:19.645715577 +0200
@@ -3,25 +3,29 @@
 
 EAPI=8
 
+inherit toolchain-funcs
+
 DESCRIPTION="Free (Y)unicode text editor for all unices"
 HOMEPAGE="https://www.yudit.org/"
 SRC_URI="https://yudit.org/download/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 x86"
+KEYWORDS="~amd64 ~x86"
 
 RDEPEND="x11-libs/libX11"
 DEPEND="${RDEPEND}"
 BDEPEND="sys-devel/gettext"
 
+DOCS=( {BUGS,CHANGELOG,NEWS,TODO}.TXT )
+
 src_prepare() {
 	default
 	# Don't strip binaries, let portage do that.
-	sed -i "/^INSTALL_PROGRAM/s: -s::" Makefile.conf.in || die "sed failed"
-}
-
-src_install() {
-	emake DESTDIR="${D}" install
-	dodoc {BUGS,CHANGELOG,NEWS,TODO}.TXT
+	# Don't call ar / ranlib directly
+	sed -i \
+		-e "/^INSTALL_PROGRAM/s| -s||" \
+		-e "s|ar cr|$(tc-getAR) cr|g" \
+		-e "s|ranlib|$(tc-getRANLIB)|g" \
+		Makefile.conf.in || die "sed failed"
 }
```

Signed-off-by: Michael Mair-Keimberger <mmk@levelnine.at>

Closes: https://bugs.gentoo.org/729260