### PR TITLE
net-misc/jwhois: EAPI8, fix #446472

### DIFF
--- a/net-misc/jwhois/files/jwhois-4.0-add-timeout_init-prototype.patch
+++ b/net-misc/jwhois/files/jwhois-4.0-add-timeout_init-prototype.patch
@@ -1,0 +1,37 @@
+From 96fdd331c21421a313b6b97cb62e0c775ddc061c Mon Sep 17 00:00:00 2001
+From: Florian Weimer <fweimer@redhat.com>
+Date: Tue, 10 Jan 2023 12:36:30 +0100
+Subject: [PATCH 2/2] <utils.h>: Add timeout_init prototype
+
+So that it can be called from the main function.  This avoids a
+compilation error with future compilers.
+---
+ include/utils.h | 1 +
+ src/utils.c     | 2 +-
+ 2 files changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/include/utils.h b/include/utils.h
+index 754ddff..cd98b29 100644
+--- a/include/utils.h
++++ b/include/utils.h
+@@ -28,6 +28,7 @@ char *create_string(const char *fmt, ...);
+ int split_host_from_query(struct s_whois_query *wq);
+ int make_connect(const char *, int);
+ int add_text_to_buffer(char **, const char *);
++void timeout_init(void);
+ 
+ 
+ #endif
+diff --git a/src/utils.c b/src/utils.c
+index ab01c2c..f82bd1c 100644
+--- a/src/utils.c
++++ b/src/utils.c
+@@ -348,7 +348,7 @@ split_host_from_query(struct s_whois_query *wq)
+  *  file.
+  */
+ void
+-timeout_init()
++timeout_init(void)
+ {
+   int iret;
+   char *ret = "75", *ret2;

--- a/net-misc/jwhois/files/jwhois-4.0-avoid-implicit-declarations.patch
+++ b/net-misc/jwhois/files/jwhois-4.0-avoid-implicit-declarations.patch
@@ -1,0 +1,44 @@
+From c7c344302d81a36b20d3d26a3d13367c8ed2c80d Mon Sep 17 00:00:00 2001
+From: Florian Weimer <fweimer@redhat.com>
+Date: Tue, 10 Jan 2023 12:31:03 +0100
+Subject: [PATCH 1/2] configure.in: C99 compatibility fix
+
+Avoid implicit declarations of inet_pton, exit.  Include <arpa/inet.h>
+for the glibc declaration.  Return from main instead of calling exit.
+This avoids compilation errors with future compilers.
+---
+ configure.in | 9 ++++++---
+ 1 file changed, 6 insertions(+), 3 deletions(-)
+
+diff --git a/configure.in b/configure.in
+index f1cdd10..678fe7d 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -119,7 +119,7 @@ AC_CHECK_LIB(inet6, main,
+ AC_CHECK_FUNCS(memcpy strtol)
+ AC_CHECK_FUNCS(strcasecmp strncasecmp getopt_long)
+ AC_HEADER_STDC([])
+-AC_CHECK_HEADERS(sys/types.h sys/socket.h netinet/in.h netdb.h sys/time.h sys/stat.h sys/fcntl.h malloc.h locale.h stdint.h inttypes.h idna.h)
++AC_CHECK_HEADERS(sys/types.h sys/socket.h netinet/in.h netdb.h sys/time.h sys/stat.h sys/fcntl.h malloc.h locale.h stdint.h inttypes.h idna.h arpa/inet.h)
+ AC_HEADER_TIME
+ 
+ 
+@@ -139,13 +139,16 @@ AC_TRY_RUN(
+ #ifdef HAVE_NETINET_IN_H
+ #include <netinet/in.h>
+ #endif
++#ifdef HAVE_ARPA_INET_H
++#include <arpa/inet.h>
++#endif
+ int main()
+   {
+     struct in6_addr addr6;
+     if (inet_pton(AF_INET6, "::1", &addr6) < 1)
+-      exit(1);
++      return 1;
+     else
+-      exit(0);
++      return 0;
+   }
+   ], [
+        AC_MSG_RESULT(yes)

--- a/net-misc/jwhois/jwhois-4.0-r2.ebuild
+++ b/net-misc/jwhois/jwhois-4.0-r2.ebuild
@@ -1,0 +1,38 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools toolchain-funcs
+
+DESCRIPTION="Advanced Internet Whois client capable of recursive queries"
+HOMEPAGE="https://github.com/jonasob/jwhois/"
+SRC_URI="mirror://gnu/${PN}/${P}.tar.gz"
+
+LICENSE="GPL-3+"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+IUSE="idn nls"
+
+RDEPEND="idn? ( net-dns/libidn )"
+DEPEND="${RDEPEND}"
+
+PATCHES=(
+	# bug 208875
+	"${FILESDIR}"/${P}-connect-logic.patch
+	"${FILESDIR}"/${P}-avoid-implicit-declarations.patch
+	"${FILESDIR}"/${P}-add-timeout_init-prototype.patch
+)
+
+src_configure() {
+	econf \
+		--localstatedir="${EPREFIX}"/var/cache \
+		--without-cache \
+		$(use_enable nls) \
+		$(use_with idn libidn)
+	eautoreconf
+}
+
+src_compile(){
+	emake AR="$(tc-getAR)"
+}

--- a/net-misc/jwhois/metadata.xml
+++ b/net-misc/jwhois/metadata.xml
@@ -7,5 +7,6 @@
   </maintainer>
   <upstream>
     <remote-id type="savannah">jwhois</remote-id>
+    <remote-id type="github">jonasob/jwhois</remote-id>
   </upstream>
 </pkgmetadata>


### PR DESCRIPTION
Hi,

this updates `net-misc/jwhois` to `EAPI8`. It also fixes bug #446472
While looking at the ebuild i also got following QA Warnings. 

```
 * QA Notice: Found the following implicit function declarations in configure logs:
 *   /var/tmp/portage/net-misc/jwhois-4.0-r2/work/jwhois-4.0/config.log:626 - inet_pton
 *   /var/tmp/portage/net-misc/jwhois-4.0-r2/work/jwhois-4.0/config.log:629 - exit
```

I didn't had any idea how to correctly fix this, however there is an upstream PR which addresses this issue [1].
I've decided to add these two patches from there, `jwhois-4.0-avoid-implicit-declarations.patch` fixes the QA Warning, `jwhois-4.0-add-timeout_init-prototype.patch` should fix compilation errors with future compilers.

[1] https://github.com/jonasob/jwhois/pull/35

Signed-off-by: Michael Mair-Keimberger <mmk@levelnine.at>

Closes: https://bugs.gentoo.org/446472