### PR TITLE
games-board/awale: Fix call to undeclared library function strcmp

### DIFF
--- a/games-board/awale/awale-1.6-r1.ebuild
+++ b/games-board/awale/awale-1.6-r1.ebuild
@@ -1,0 +1,39 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit desktop
+
+DESCRIPTION="Free Awale - The game of all Africa"
+HOMEPAGE="https://www.nongnu.org/awale/"
+SRC_URI="mirror://nongnu/awale/${P}.tar.gz"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="gui"
+
+RDEPEND="gui? ( dev-lang/tk )"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-1.6-clang16-build-fix.patch
+)
+
+src_install() {
+	if use gui; then
+		emake -j1 DESTDIR="${D}" install #799107
+
+		fperms +x /usr/share/${PN}/xawale.tcl
+
+		doicon src/awale.png
+		make_desktop_entry xawale "Free Awale"
+
+		rm "${ED}"/usr/share/applications/awale.desktop || die
+	else
+		dobin src/awale
+		doman man/awale.6
+	fi
+
+	einstalldocs
+}

--- a/games-board/awale/files/awale-1.6-clang16-build-fix.patch
+++ b/games-board/awale/files/awale-1.6-clang16-build-fix.patch
@@ -1,0 +1,11 @@
+Bug: https://bugs.gentoo.org/895882
+--- a/src/getopt.c
++++ b/src/getopt.c
+@@ -39,6 +39,7 @@
+ #endif
+ 
+ #include <stdio.h>
++#include <string.h>
+ 
+ /* Comment out all this code if we are using the GNU C Library, and are not
+    actually compiling the library itself.  This code is part of the GNU C


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/895882