### PR TITLE
dev-libs/bglibs: Fix call to undeclared library function strcpy

### DIFF
--- a/dev-libs/bglibs/bglibs-2.04-r3.ebuild
+++ b/dev-libs/bglibs/bglibs-2.04-r3.ebuild
@@ -1,0 +1,80 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs
+
+DESCRIPTION="Bruce Guenter's Libraries Collection"
+HOMEPAGE="https://untroubled.org/bglibs/"
+SRC_URI="https://untroubled.org/bglibs/archive/${P}.tar.gz"
+
+LICENSE="LGPL-2.1+"
+SLOT="0/2"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~loong ~mips ~ppc ~ppc64 ~riscv ~sparc ~x86"
+IUSE="doc"
+
+BDEPEND="
+	sys-apps/which
+	sys-devel/libtool
+	doc? (
+		app-doc/doxygen
+		dev-texlive/texlive-latexrecommended
+		dev-texlive/texlive-latex
+		dev-texlive/texlive-latexextra
+		virtual/latex-base
+	)
+"
+
+PATCHES=(
+	"${FILESDIR}"/bglibs-2.04-stack-buffers.patch
+	"${FILESDIR}"/bglibs-2.04-clang16-build-fix.patch
+)
+
+src_prepare() {
+	default
+	# disable tests as we want them manually
+	sed -i '/^all:/s|selftests||' Makefile || die
+	sed -i '/selftests/d' TARGETS || die
+}
+
+src_configure() {
+	echo "${ED}/usr/bin" > conf-bin || die
+	echo "${ED}/usr/$(get_libdir)/bglibs" > conf-lib || die
+	echo "${ED}/usr/include" > conf-include || die
+	echo "${ED}/usr/share/man" > conf-man || die
+	echo "$(tc-getCC) ${CFLAGS}" > conf-cc || die
+	echo "$(tc-getCC) ${LDFLAGS}" > conf-ld || die
+}
+
+src_compile() {
+	# Parallel build fails, bug #343617
+	MAKEOPTS+=" -j1" default
+
+	if use doc; then
+		emake -C doc/latex pdf
+	fi
+}
+
+src_test() {
+	einfo "Running selftests"
+	emake selftests
+}
+
+src_install() {
+	default
+
+	# Install .so into LDPATH
+	mv "${ED}"/usr/$(get_libdir)/bglibs/libbg.so.2.0.0 "${ED}"/usr/$(get_libdir)/ || die
+	dosym libbg.so.2.0.0 /usr/$(get_libdir)/libbg.so.2
+	dosym libbg.so.2.0.0 /usr/$(get_libdir)/libbg.so
+	dosym ../libbg.so.2.0.0 /usr/$(get_libdir)/bglibs/libbg.so.2.0.0
+
+	rm "${ED}"/usr/$(get_libdir)/bglibs/libbg.la || die
+
+	dodoc ANNOUNCEMENT NEWS README ChangeLog TODO VERSION
+	dodoc -r doc/html/
+	if use doc; then
+		dodoc doc/latex/refman.pdf
+	fi
+}

--- a/dev-libs/bglibs/files/bglibs-2.04-clang16-build-fix.patch
+++ b/dev-libs/bglibs/files/bglibs-2.04-clang16-build-fix.patch
@@ -1,0 +1,61 @@
+Bug: https://bugs.gentoo.org/895036
+--- a/net/bindu.c
++++ b/net/bindu.c
+@@ -21,6 +21,7 @@
+ #include <sys/socket.h>
+ #include <sys/un.h>
+ #include <unistd.h>
++#include <string.h>
+ #include "socket.h"
+ 
+ /** Bind a UNIX domain address (path) to a socket. */
+--- a/net/connectu.c
++++ b/net/connectu.c
+@@ -21,6 +21,7 @@
+ #include <sys/socket.h>
+ #include <sys/un.h>
+ #include <unistd.h>
++#include <string.h>
+ #include "socket.h"
+ 
+ /** Make an UNIX domain connection. */
+--- a/unix/sig_all.c
++++ b/unix/sig_all.c
+@@ -32,7 +32,7 @@ void sig_all_default(void)
+ void sig_all_block(void)
+ {
+   int i;
+-#ifdef HASSIGPROCMASK
++#if defined(HASSIGPROCMASK) || !defined(__GLIBC__)
+   sigset_t set;
+   sigemptyset(&set);
+   for (i = 1; i < SIGMAX; i++)
+@@ -46,7 +46,7 @@ void sig_all_block(void)
+ 
+ void sig_all_unblock(void)
+ {
+-#ifdef HASSIGPROCMASK
++#if defined(HASSIGPROCMASK) || !defined(__GLIBC__)
+   sigset_t set;
+   sigemptyset(&set);
+   sigprocmask(SIG_UNBLOCK, &set, 0);
+--- a/unix/sig_block.c
++++ b/unix/sig_block.c
+@@ -21,7 +21,7 @@
+ 
+ void sig_block(int s)
+ {
+-#ifdef HASSIGPROCMASK
++#if defined(HASSIGPROCMASK) || !defined(__GLIBC__)
+   sigset_t set;
+   sigemptyset(&set);
+   sigaddset(&set, s);
+@@ -33,7 +33,7 @@ void sig_block(int s)
+ 
+ void sig_unblock(int s)
+ {
+-#ifdef HASSIGPROCMASK
++#if defined(HASSIGPROCMASK) || !defined(__GLIBC__)
+   sigset_t set;
+   sigemptyset(&set);
+   sigaddset(&set, s);


### PR DESCRIPTION
and update EAPI 7 -> 8

Closes: https://bugs.gentoo.org/895036