### PR TITLE
media-libs/opencolorio: fix USE="-doc"

### DIFF
--- a/media-libs/opencolorio/opencolorio-2.2.1.ebuild
+++ b/media-libs/opencolorio/opencolorio-2.2.1.ebuild
@@ -129,9 +129,11 @@ src_configure() {
 src_install() {
 	cmake_src_install
 
-	# there are already files in ${ED}/usr/share/doc/${PF}
-	mv "${ED}/usr/share/doc/OpenColorIO/"* "${ED}/usr/share/doc/${PF}" || die
-	rmdir "${ED}/usr/share/doc/OpenColorIO" || die
+	if use doc; then
+		# there are already files in ${ED}/usr/share/doc/${PF}
+		mv "${ED}/usr/share/doc/OpenColorIO/"* "${ED}/usr/share/doc/${PF}" || die
+		rmdir "${ED}/usr/share/doc/OpenColorIO" || die
+	fi
 }
 
 src_test() {

--- a/media-libs/opencolorio/opencolorio-2.3.0.ebuild
+++ b/media-libs/opencolorio/opencolorio-2.3.0.ebuild
@@ -158,9 +158,11 @@ src_configure() {
 src_install() {
 	cmake_src_install
 
-	# there are already files in ${ED}/usr/share/doc/${PF}
-	mv "${ED}/usr/share/doc/OpenColorIO/"* "${ED}/usr/share/doc/${PF}" || die
-	rmdir "${ED}/usr/share/doc/OpenColorIO" || die
+	if use doc; then
+		# there are already files in ${ED}/usr/share/doc/${PF}
+		mv "${ED}/usr/share/doc/OpenColorIO/"* "${ED}/usr/share/doc/${PF}" || die
+		rmdir "${ED}/usr/share/doc/OpenColorIO" || die
+	fi
 }
 
 src_test() {


### PR DESCRIPTION
`/usr/share/doc/OpenColorIO/html` only exists when `USE=doc` is set. So make the move conditional.

Closes: https://bugs.gentoo.org/916474