### PR TITLE
net-analyzer/arpoisen: use HTTPS, EAPI8, ebuild improvements

### DIFF
--- a/net-analyzer/arpoison/arpoison-0.7-r1.ebuild
+++ b/net-analyzer/arpoison/arpoison-0.7-r1.ebuild
@@ -1,0 +1,28 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs edo
+
+DESCRIPTION="Utility to poison ARP caches"
+HOMEPAGE="https://arpoison.sourceforge.net/ http://www.arpoison.net/"
+SRC_URI="https://dev.gentoo.org/~jsmolic/distfiles/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~ppc ~riscv ~x86"
+
+RDEPEND="net-libs/libnet:1.1"
+DEPEND="${RDEPEND}"
+BDEPEND="${RDEPEND}"
+
+src_compile() {
+	edo "$(tc-getCC)" "${PN}.c" -o "${PN}" ${CFLAGS} ${LDFLAGS} $("${BROOT}/usr/bin/libnet-config" --cflags --libs)
+}
+
+src_install() {
+	dosbin arpoison
+	doman arpoison.8
+	dodoc README
+}

--- a/net-analyzer/arpoison/arpoison-0.7.ebuild
+++ b/net-analyzer/arpoison/arpoison-0.7.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 inherit toolchain-funcs
 
-DESCRIPTION="A utility to poison ARP caches"
-HOMEPAGE="http://arpoison.sourceforge.net/ http://www.arpoison.net/"
+DESCRIPTION="Utility to poison ARP caches"
+HOMEPAGE="https://arpoison.sourceforge.net/ http://www.arpoison.net/"
 SRC_URI="https://dev.gentoo.org/~jsmolic/distfiles/${P}.tar.gz"
 
 LICENSE="GPL-2"


### PR DESCRIPTION
Minor improvements for `net-analyzer/arpoisen`