### PR TITLE
dev-libs/libezV24: Fix call to undeclared function fcvt

### DIFF
--- a/dev-libs/libezV24/files/libezV24-0.1.1-clang16-build-fix.patch
+++ b/dev-libs/libezV24/files/libezV24-0.1.1-clang16-build-fix.patch
@@ -1,0 +1,21 @@
+Bug: https://bugs.gentoo.org/895044
+--- a/ezV24.c
++++ b/ezV24.c
+@@ -42,6 +42,7 @@
+ #include <errno.h>
+ #include <termios.h>
+ #include <sys/ioctl.h>
++#include <sys/param.h>
+ 
+ 
+ #define __EZV24_C__
+--- a/snprintf.c
++++ b/snprintf.c
+@@ -61,6 +61,7 @@
+ 
+ /* From: Id: sprint.c,v 1.5 1995/09/10 18:35:09 chuck Exp */
+ 
++#define _GNU_SOURCE
+ #include <ctype.h>
+ #include <stdlib.h>
+ #include <stdarg.h>

--- a/dev-libs/libezV24/libezV24-0.1.1-r3.ebuild
+++ b/dev-libs/libezV24/libezV24-0.1.1-r3.ebuild
@@ -1,0 +1,38 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs
+
+DESCRIPTION="library that provides an easy API to Linux serial ports"
+HOMEPAGE="http://ezv24.sourceforge.net"
+SRC_URI="mirror://sourceforge/ezv24/${P}.tar.gz"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~ppc ~sparc ~x86"
+
+HTML_DOCS=( api-html/. )
+
+PATCHES=(
+	"${FILESDIR}"/${P}-build.patch
+	"${FILESDIR}"/${P}-test.patch
+	"${FILESDIR}"/${P}-clang16-build-fix.patch
+)
+
+src_prepare() {
+	default
+
+	tc-export AR CC RANLIB
+	sed -i -e 's:__LINUX__:__linux__:' *.c *.h || die
+}
+
+src_install() {
+	export NO_LDCONFIG="stupid"
+	emake DESTDIR="${D}" PREFIX="${EPREFIX}/usr" \
+		LIBDIR="${EPREFIX}/usr/$(get_libdir)" install
+	einstalldocs
+
+	find "${ED}" -name '*.a' -delete || die
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/895044