### PR TITLE
net-analyzer/arpon: EAPI8 bump, use https

### DIFF
--- a/net-analyzer/arpon/arpon-3.0.ebuild
+++ b/net-analyzer/arpon/arpon-3.0.ebuild
@@ -1,17 +1,17 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 inherit cmake
 
-DESCRIPTION="ArpON (Arp handler inspectiON) is a portable Arp handler"
-
 MY_PN="ArpON"
 MY_P="${MY_PN}-${PV}"
-HOMEPAGE="http://arpon.sourceforge.net/"
+
+DESCRIPTION="ArpON (Arp handler inspectiON) is a portable Arp handler"
+HOMEPAGE="https://arpon.sourceforge.io/"
 SRC_URI="mirror://sourceforge/${PN}/${MY_P}-ng.tar.gz"
-S="${WORKDIR}"/${MY_P}-ng
+S="${WORKDIR}/${MY_P}-ng"
 
 LICENSE="BSD-2"
 SLOT="0"


### PR DESCRIPTION
Simple EAPI8 bump + http -> https.
I've decided to keep `KEYWORDS` since basically nothing changed.