### PR TITLE
dev-libs/gmp: add -fno-sanitize-address-globals-dead-stripping

### DIFF
--- a/dev-libs/gmp/gmp-6.3.0-r1.ebuild
+++ b/dev-libs/gmp/gmp-6.3.0-r1.ebuild
@@ -163,6 +163,14 @@ multilib_src_configure() {
 		export ac_cv_host="${gmp_host}"
 	fi
 
+	# Clang with -fsanitize=address may emit weird section names in its asm,
+	# which causes gmp's configure checks to select a broken way of
+	# specifying `.rodata`. Disable this feature, which was introduced in
+	# Clang 15 (and defaulted to on in Clang 18).
+	if tc-is-clang && [[ "$(clang-major-version)" -ge 15 ]]; then
+		append-cppflags "-fno-sanitize-address-globals-dead-stripping"
+	fi
+
 	ECONF_SOURCE="${S}" econf "${myeconfargs[@]}"
 }
 


### PR DESCRIPTION
Clang recently defaulted `-fsanitize-address-globals-dead-stripping` to 'on' for ELF: https://reviews.llvm.org/D152604. This breaks gmp's configure checks, as it detects that rodata sections should be declared with:
```
.rodata.foo,"aG",@progbits,foo,comdat
```

instead of:
```
.rodata,"a",@progbits
```

Since Clang uses LLVM-specific assembler extensions to make this ASAN symbol GCing work, disable the feature for this package.

---

In my local setup, I was only able to test this on dev-libs/gmp-6.3.0, so I only have a patch for that ebuild. More than happy to backport it to other versions of gmp available in-tree if you all would like.

cc @vapier, @arthurzam 