### PR TITLE
net-p2p/qbittorrent: fix RDEPEND to work with every combination of webui and gui

### DIFF
--- a/net-p2p/qbittorrent/qbittorrent-4.6.0.ebuild
+++ b/net-p2p/qbittorrent/qbittorrent-4.6.0.ebuild
@@ -29,23 +29,23 @@ RDEPEND="
 	>=dev-libs/openssl-1.1.1:=
 	>=net-libs/libtorrent-rasterbar-1.2.18:=
 	>=sys-libs/zlib-1.2.11
-	virtual/libiconv
+	qt6? ( dev-qt/qtbase:6[network,ssl,sql,sqlite,xml] )
+	!qt6? (
+		dev-qt/qtcore:5
+		dev-qt/qtnetwork:5[ssl]
+		dev-qt/qtsql:5[sqlite]
+		dev-qt/qtxml:5
+	)
 	gui? (
-		dev-libs/geoip
 		!qt6? (
 			dev-qt/qtgui:5
 			dev-qt/qtsvg:5
 			dev-qt/qtwidgets:5
-			dev-qt/qtcore:5
-			dev-qt/qtnetwork:5[ssl]
-			dev-qt/qtsql:5[sqlite]
-			dev-qt/qtxml:5
 			dbus? ( dev-qt/qtdbus:5 )
 		)
 		qt6? (
 			dev-qt/qtbase:6[dbus?,gui,widgets]
 			dev-qt/qtsvg:6
-			dev-qt/qtbase:6[network,ssl,sql,sqlite,xml(+)]
 		)
 	)"
 DEPEND="


### PR DESCRIPTION
Previously Qt libraries were only installed with `+gui` flag, but only-webui installation also requires some Qt libraries, this PR fixes this bug
Closes: https://bugs.gentoo.org/916447