### PR TITLE
app-containers/buildah: add containers-common as RDEPEND

### DIFF
--- a/app-containers/buildah/buildah-1.32.2.ebuild
+++ b/app-containers/buildah/buildah-1.32.2.ebuild
@@ -36,6 +36,7 @@ RDEPEND="
 	btrfs? ( sys-fs/btrfs-progs )
 	seccomp? ( sys-libs/libseccomp:= )
 	apparmor? ( sys-libs/libapparmor:= )
+	app-containers/containers-common
 	app-crypt/gpgme:=
 	dev-libs/libgpg-error:=
 	dev-libs/libassuan:=

--- a/app-containers/buildah/buildah-9999.ebuild
+++ b/app-containers/buildah/buildah-9999.ebuild
@@ -36,6 +36,7 @@ RDEPEND="
 	btrfs? ( sys-fs/btrfs-progs )
 	seccomp? ( sys-libs/libseccomp:= )
 	apparmor? ( sys-libs/libapparmor:= )
+	app-containers/containers-common
 	app-crypt/gpgme:=
 	dev-libs/libgpg-error:=
 	dev-libs/libassuan:=


### PR DESCRIPTION
app-containers/containers-common provides essential default configurations for Containers stack.