### PR TITLE
app-misc/hyfetch: keyword ~arm64

### DIFF
--- a/app-misc/hyfetch/hyfetch-1.4.10.ebuild
+++ b/app-misc/hyfetch/hyfetch-1.4.10.ebuild
@@ -14,7 +14,7 @@ if [[ ${PV} == *9999 ]]; then
 	inherit git-r3
 else
 	SRC_URI="https://github.com/hykilpikonna/${PN}/archive/${PV}/${P}.tar.gz"
-	KEYWORDS="~amd64"
+	KEYWORDS="~amd64 ~arm64"
 fi
 
 LICENSE="MIT"

--- a/app-misc/hyfetch/hyfetch-9999.ebuild
+++ b/app-misc/hyfetch/hyfetch-9999.ebuild
@@ -14,7 +14,7 @@ if [[ ${PV} == *9999* ]]; then
 	inherit git-r3
 else
 	SRC_URI="https://github.com/hykilpikonna/${PN}/archive/${PV}/${P}.tar.gz"
-	KEYWORDS="~amd64"
+	KEYWORDS="~amd64 ~arm64"
 fi
 
 LICENSE="MIT"


### PR DESCRIPTION
Adds the `~arm64` keyword so that hyfetch can be enjoyed on an M1 Mac 🚀 