### PR TITLE
app-emulation/libvirt: Backport fix for CVE-2023-3750

### DIFF
--- a/app-emulation/libvirt/files/libvirt-9.6.0-storage-Fix-returning-of-locked-objects-from-virStor.patch
+++ b/app-emulation/libvirt/files/libvirt-9.6.0-storage-Fix-returning-of-locked-objects-from-virStor.patch
@@ -1,0 +1,57 @@
+From 9a47442366fcf8a7b6d7422016d7bbb6764a1098 Mon Sep 17 00:00:00 2001
+Message-ID: <9a47442366fcf8a7b6d7422016d7bbb6764a1098.1698742017.git.mprivozn@redhat.com>
+From: Peter Krempa <pkrempa@redhat.com>
+Date: Thu, 13 Jul 2023 16:16:37 +0200
+Subject: [PATCH] storage: Fix returning of locked objects from
+ 'virStoragePoolObjListSearch'
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+CVE-2023-3750
+
+'virStoragePoolObjListSearch' explicitly documents that it's returning
+a pointer to a locked and ref'd pool that maches the lookup function.
+
+This was not the case as in commit 0c4b391e2a9 (released in
+libvirt-8.3.0) the code was accidentally converted to use 'VIR_LOCK_GUARD'
+which auto-unlocked it when leaving the scope, even when the code was
+originally "leaking" the lock.
+
+Revert the corresponding conversion and add a comment that this function
+is intentionally leaking a locked object.
+
+Fixes: 0c4b391e2a9
+Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2221851
+Signed-off-by: Peter Krempa <pkrempa@redhat.com>
+Reviewed-by: Ján Tomko <jtomko@redhat.com>
+Signed-off-by: Michal Privoznik <mprivozn@redhat.com>
+---
+ src/conf/virstorageobj.c | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/src/conf/virstorageobj.c b/src/conf/virstorageobj.c
+index 7010e97d61..59fa5da372 100644
+--- a/src/conf/virstorageobj.c
++++ b/src/conf/virstorageobj.c
+@@ -454,11 +454,16 @@ virStoragePoolObjListSearchCb(const void *payload,
+     virStoragePoolObj *obj = (virStoragePoolObj *) payload;
+     struct _virStoragePoolObjListSearchData *data =
+         (struct _virStoragePoolObjListSearchData *)opaque;
+-    VIR_LOCK_GUARD lock = virObjectLockGuard(obj);
+ 
++    virObjectLock(obj);
++
++    /* If we find the matching pool object we must return while the object is
++     * locked as the caller wants to return a locked object. */
+     if (data->searcher(obj, data->opaque))
+         return 1;
+ 
++    virObjectUnlock(obj);
++
+     return 0;
+ }
+ 
+-- 
+2.41.0
+

--- a/app-emulation/libvirt/libvirt-9.3.0-r1.ebuild
+++ b/app-emulation/libvirt/libvirt-9.3.0-r1.ebuild
@@ -145,6 +145,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-6.0.0-fix_paths_in_libvirt-guests_sh.patch
 	"${FILESDIR}"/${PN}-8.2.0-do-not-use-sysconfig.patch
 	"${FILESDIR}"/${PN}-8.2.0-fix-paths-for-apparmor.patch
+	"${FILESDIR}"/${PN}-9.6.0-storage-Fix-returning-of-locked-objects-from-virStor.patch
 )
 
 pkg_setup() {

--- a/app-emulation/libvirt/libvirt-9.4.0-r4.ebuild
+++ b/app-emulation/libvirt/libvirt-9.4.0-r4.ebuild
@@ -21,7 +21,7 @@ if [[ ${PV} = *9999* ]]; then
 else
 	SRC_URI="https://libvirt.org/sources/${P}.tar.xz
 		verify-sig? ( https://libvirt.org/sources/${P}.tar.xz.asc )"
-	KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~x86"
+	KEYWORDS="amd64 ~arm arm64 ~ppc64 x86"
 fi
 
 DESCRIPTION="C toolkit to manipulate virtual machines"
@@ -146,6 +146,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-9.4.0-fix_paths_in_libvirt-guests_sh.patch
 	"${FILESDIR}"/${PN}-9.4.0-do-not-use-sysconfig.patch
 	"${FILESDIR}"/${PN}-9.4.0-fix-paths-for-apparmor.patch
+	"${FILESDIR}"/${PN}-9.6.0-storage-Fix-returning-of-locked-objects-from-virStor.patch
 )
 
 pkg_setup() {

--- a/app-emulation/libvirt/libvirt-9.5.0-r1.ebuild
+++ b/app-emulation/libvirt/libvirt-9.5.0-r1.ebuild
@@ -21,7 +21,7 @@ if [[ ${PV} = *9999* ]]; then
 else
 	SRC_URI="https://libvirt.org/sources/${P}.tar.xz
 		verify-sig? ( https://libvirt.org/sources/${P}.tar.xz.asc )"
-	KEYWORDS="amd64 ~arm arm64 ~ppc64 x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~x86"
 fi
 
 DESCRIPTION="C toolkit to manipulate virtual machines"
@@ -146,6 +146,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-9.4.0-fix_paths_in_libvirt-guests_sh.patch
 	"${FILESDIR}"/${PN}-9.4.0-do-not-use-sysconfig.patch
 	"${FILESDIR}"/${PN}-9.4.0-fix-paths-for-apparmor.patch
+	"${FILESDIR}"/${PN}-9.6.0-storage-Fix-returning-of-locked-objects-from-virStor.patch
 )
 
 pkg_setup() {


### PR DESCRIPTION
A security flaw was identified in <app-emulation/libvirt-9.6.0 which can result int DoS. The upstream is fixed from 9.6.0. Backport the fix to older versions found in portage.

I figured this is so important change that it warrants revnumber bump in affected ebuilds.

Bug: https://bugs.gentoo.org/916497