### PR TITLE
media-libs/audiofile: Fix Clang compilation failure

### DIFF
--- a/media-libs/audiofile/audiofile-0.3.6-r5.ebuild
+++ b/media-libs/audiofile/audiofile-0.3.6-r5.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-inherit autotools gnome.org multilib-minimal
+inherit autotools gnome.org multilib-minimal toolchain-funcs flag-o-matic
 
 DESCRIPTION="An elegant API for accessing audio files"
 HOMEPAGE="https://audiofile.68k.org/"
@@ -32,6 +32,10 @@ src_prepare() {
 }
 
 multilib_src_configure() {
+	# Bug 914349
+	if tc-is-clang; then
+		append-flags "-stdlib=libstdc++"
+	fi
 	# Tests depend on statically compiled binaries to work, so we'll have to
 	# delete them later rather than not compile them at all
 	local myconf=(


### PR DESCRIPTION
Due to upstream not having a push since 2016 (and it's not quite last rite'd yet), this fixes the Clang compilation failure from deprecated functions by adding `-stdlib=libstdc++` to CXXFLAGS.

I made sure to run the test suite and it seems to report:
```
error: non-constant-expression cannot be narrowed from type 'int32_t' (aka 'int') to 'uint32_t' (aka 'unsigned int') in initializer list [-Wc++11-narrowing]
```
but it seems to behave correctly outside of tests, not sure how to proceed if that is a blocker so I'm highlighting it to make sure I haven't missed something.

Closes: https://bugs.gentoo.org/914349