### PR TITLE
dev-libs/libspt: Fix call to undeclared function gettimeofday

### DIFF
--- a/dev-libs/libspt/files/libspt-clang16-gettimeofday-fix.patch
+++ b/dev-libs/libspt/files/libspt-clang16-gettimeofday-fix.patch
@@ -1,0 +1,11 @@
+Bug: https://bugs.gentoo.org/895050
+--- a/sptagent.c
++++ b/sptagent.c
+@@ -7,6 +7,7 @@
+ #include <sys/stat.h>
+ #include <grp.h>
+ #include <pwd.h>
++#include <sys/time.h>
+ #include <time.h>
+ #include <signal.h>
+ #ifdef HAVE_LASTLOG_H

--- a/dev-libs/libspt/libspt-1.1-r5.ebuild
+++ b/dev-libs/libspt/libspt-1.1-r5.ebuild
@@ -1,0 +1,51 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools
+
+DESCRIPTION="Library for handling root privilege"
+HOMEPAGE="http://www.j10n.org/libspt/"
+SRC_URI="http://www.j10n.org/${PN}/${P}.tar.bz2"
+
+LICENSE="BSD-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+IUSE="suid"
+RESTRICT="test"
+
+RDEPEND="net-libs/libtirpc"
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-gentoo.patch"
+	"${FILESDIR}/${PN}-glibc-2.30.patch"
+	"${FILESDIR}/${PN}-rpc.patch"
+	"${FILESDIR}/${PN}-clang16-gettimeofday-fix.patch"
+)
+
+src_prepare() {
+	rm aclocal.m4
+
+	default
+	eautoreconf
+}
+
+src_configure() {
+	econf \
+		--disable-static \
+		--with-libtirpc
+}
+
+src_install() {
+	default
+
+	# no static archives
+	find "${ED}" -name '*.la' -delete || die
+
+	if use suid; then
+		fperms 4755 /usr/libexec/sptagent
+	fi
+}


### PR DESCRIPTION
and update EAPI 7 -> 8

Closes: https://bugs.gentoo.org/895050