### PR TITLE
app-office/libreoffice-7.5.x: fix build with gcc 14

### DIFF
--- a/app-office/libreoffice/files/libreoffice-7.5.6.2-gcc-14.patch
+++ b/app-office/libreoffice/files/libreoffice-7.5.6.2-gcc-14.patch
@@ -1,0 +1,64 @@
+From db98a3f1b1a703ea8e1284b8815eea2274abb2db Mon Sep 17 00:00:00 2001
+From: Martin Jambor <mjambor@suse.cz>
+Date: Wed, 7 Jun 2023 18:11:45 +0200
+Subject: [PATCH] Add cstdlib include necessary to build with gcc14 libstdc++
+ (tdf#155715)
+
+Without explicitely including <cstdlib>, compiling some files
+including store/source/storbase.hxx (such as store/source/storpage.cxx
+which includes it through store/source/storpage.hxx) will result in
+errors:
+
+  error: ‘malloc’ is not a member of ‘std’
+
+and
+
+  error: ‘free’ is not a member of ‘std’
+
+This patch simply adds the necessary include.
+
+Change-Id: I3d1fa2a17c5ae9d512f1de9d434dac3d82fc353f
+Reviewed-on: https://gerrit.libreoffice.org/c/core/+/152712
+Tested-by: Jenkins
+Reviewed-by: Stephan Bergmann <sbergman@redhat.com>
+---
+ store/source/storbase.hxx | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/store/source/storbase.hxx b/store/source/storbase.hxx
+index feac0db962272..207cbf40a8d3c 100644
+--- a/store/source/storbase.hxx
++++ b/store/source/storbase.hxx
+@@ -32,6 +32,7 @@
+ 
+ #include <store/types.h>
+ 
++#include <cstdlib>
+ #include <memory>
+ #include <utility>
+
+From 436c879b355f2cde763b0386df92e0d3708180a7 Mon Sep 17 00:00:00 2001
+From: Stephan Bergmann <sbergman@redhat.com>
+Date: Mon, 5 Jun 2023 13:52:01 +0200
+Subject: [PATCH] Missing include (for std::find_if)
+
+Change-Id: I91d70d72ea6cb18ed4fde2f3b3a3d037668767e5
+Reviewed-on: https://gerrit.libreoffice.org/c/core/+/152615
+Tested-by: Jenkins
+Reviewed-by: Stephan Bergmann <sbergman@redhat.com>
+---
+ libreofficekit/qa/gtktiledviewer/gtv-main-toolbar.cxx | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/libreofficekit/qa/gtktiledviewer/gtv-main-toolbar.cxx b/libreofficekit/qa/gtktiledviewer/gtv-main-toolbar.cxx
+index a89b8fc7fc72e..7127581856fce 100644
+--- a/libreofficekit/qa/gtktiledviewer/gtv-main-toolbar.cxx
++++ b/libreofficekit/qa/gtktiledviewer/gtv-main-toolbar.cxx
+@@ -16,6 +16,7 @@
+ 
+ #include <LibreOfficeKit/LibreOfficeKitGtk.h>
+ 
++#include <algorithm>
+ #include <fstream>
+ #include <map>
+ #include <memory>

--- a/app-office/libreoffice/libreoffice-7.5.6.2.ebuild
+++ b/app-office/libreoffice/libreoffice-7.5.6.2.ebuild
@@ -294,6 +294,7 @@ PATCHES=(
 
 	# git master
 	"${WORKDIR}/${PN}-7.5.2.2-loong-buildsys-fix.patch"
+	"${FILESDIR}/${PN}-7.5.6.2-gcc-14.patch"
 )
 
 S="${WORKDIR}/${PN}-${MY_PV}"

--- a/app-office/libreoffice/libreoffice-7.5.7.1.ebuild
+++ b/app-office/libreoffice/libreoffice-7.5.7.1.ebuild
@@ -294,6 +294,7 @@ PATCHES=(
 
 	# git master
 	"${WORKDIR}/${PN}-7.5.2.2-loong-buildsys-fix.patch"
+	"${FILESDIR}/${PN}-7.5.6.2-gcc-14.patch"
 )
 
 S="${WORKDIR}/${PN}-${MY_PV}"

--- a/app-office/libreoffice/libreoffice-7.5.9999.ebuild
+++ b/app-office/libreoffice/libreoffice-7.5.9999.ebuild
@@ -294,6 +294,7 @@ PATCHES=(
 
 	# git master
 	"${WORKDIR}/${PN}-7.5.2.2-loong-buildsys-fix.patch"
+	"${FILESDIR}/${PN}-7.5.6.2-gcc-14.patch"
 )
 
 S="${WORKDIR}/${PN}-${MY_PV}"


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/916621