### PR TITLE
net-analyzer/bmon: EAPI8, update ebuild

### DIFF
--- a/net-analyzer/bmon/bmon-4.0-r1.ebuild
+++ b/net-analyzer/bmon/bmon-4.0-r1.ebuild
@@ -1,0 +1,43 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools linux-info toolchain-funcs
+
+DESCRIPTION="Interface bandwidth monitor"
+HOMEPAGE="https://github.com/tgraf/bmon/"
+SRC_URI="https://codeload.github.com/tgraf/${PN}/tar.gz/v${PV} -> ${P}.tar.gz"
+
+LICENSE="BSD-2 MIT"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~hppa ~ppc ~ppc64 ~riscv ~sparc ~x86"
+
+RDEPEND="
+	>=sys-libs/ncurses-5.3-r2:0=
+	dev-libs/confuse:=
+	dev-libs/libnl:3
+"
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+DOCS=( ChangeLog NEWS README )
+
+CONFIG_CHECK="~NET_SCHED"
+ERROR_NET_SCHED="
+	CONFIG_NET_SCHED is not set when it should be.
+	Run ${PN} -i proc to use the deprecated proc interface instead.
+"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-3.6-docdir-examples.patch
+)
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_configure() {
+	econf CURSES_LIB="$("$(tc-getPKG_CONFIG)" --libs ncurses)"
+}

--- a/net-analyzer/bmon/bmon-4.0.ebuild
+++ b/net-analyzer/bmon/bmon-4.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -6,7 +6,7 @@ EAPI=7
 inherit autotools linux-info toolchain-funcs
 
 DESCRIPTION="Interface bandwidth monitor"
-HOMEPAGE="http://www.infradead.org/~tgr/bmon/ https://github.com/tgraf/bmon/"
+HOMEPAGE="https://github.com/tgraf/bmon/"
 SRC_URI="https://codeload.github.com/tgraf/${PN}/tar.gz/v${PV} -> ${P}.tar.gz"
 
 LICENSE="BSD-2 MIT"

--- a/net-analyzer/bmon/bmon-999.ebuild
+++ b/net-analyzer/bmon/bmon-999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -6,7 +6,7 @@ EAPI=7
 inherit autotools git-r3 linux-info toolchain-funcs
 
 DESCRIPTION="Interface bandwidth monitor"
-HOMEPAGE="http://www.infradead.org/~tgr/bmon/ https://github.com/tgraf/bmon/"
+HOMEPAGE="https://github.com/tgraf/bmon/"
 EGIT_REPO_URI="https://github.com/tgraf/bmon/"
 
 LICENSE="BSD-2 MIT"

--- a/net-analyzer/bmon/bmon-9999.ebuild
+++ b/net-analyzer/bmon/bmon-9999.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 inherit autotools git-r3 linux-info toolchain-funcs
 
@@ -20,7 +20,7 @@ RDEPEND="
 DEPEND="${RDEPEND}"
 BDEPEND="virtual/pkgconfig"
 
-DOCS=( ChangeLog )
+DOCS=( ChangeLog NEWS README )
 
 CONFIG_CHECK="~NET_SCHED"
 ERROR_NET_SCHED="


### PR DESCRIPTION
Hi,

This updates the `net-analyzer/bmon` ebuild for EAPI8.
Not much changes but since i've added some more DOCS Files i've decided todo a revision bump.
I've also changed the the name of the live ebuild. No idea why it used only -999 instead -9999.