### PR TITLE
net-analyzer/ibmonitor: EAPI8 bump, use https, fix LICENSE

### DIFF
--- a/net-analyzer/ibmonitor/ibmonitor-1.4-r1.ebuild
+++ b/net-analyzer/ibmonitor/ibmonitor-1.4-r1.ebuild
@@ -1,18 +1,18 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 DESCRIPTION="Interactive bandwidth monitor"
-HOMEPAGE="http://ibmonitor.sourceforge.net"
+HOMEPAGE="https://ibmonitor.sourceforge.net"
 SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
+S="${WORKDIR}/${PN}"
 
 KEYWORDS="~amd64 ~hppa ~ppc ~riscv x86"
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="0"
 
 RDEPEND="dev-perl/TermReadKey"
-S=${WORKDIR}/${PN}
 
 src_install() {
 	dobin ibmonitor


### PR DESCRIPTION
Simple `EAPI8` bump. 
Since basically nothing changes i kept `KEYWORDS`.