### PR TITLE
net-misc/cbqinit: EAPI8 bump, fix LICENSE

### DIFF
--- a/net-misc/cbqinit/cbqinit-0.7.3-r3.ebuild
+++ b/net-misc/cbqinit/cbqinit-0.7.3-r3.ebuild
@@ -1,21 +1,18 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
 
 DESCRIPTION="Sets up class-based queue traffic control (QoS) with iproute2"
-HOMEPAGE="https://www.sourceforge.net/projects/cbqinit/"
+HOMEPAGE="https://sourceforge.net/projects/cbqinit/"
 SRC_URI="mirror://sourceforge/cbqinit/cbq.init-v${PV} -> ${P}"
+S="${WORKDIR}"
 
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="0"
 KEYWORDS="~alpha amd64 ~arm ~hppa ~mips ppc sparc x86"
-IUSE=""
 
 RDEPEND="sys-apps/iproute2"
-DEPEND=""
-
-S=${WORKDIR}
 
 src_unpack() {
 	cp "${DISTDIR}"/${P} "${S}"/cbqinit || die


### PR DESCRIPTION
Another simple `EAPI8` bump.