### PR TITLE
net-wireless/horst: EAPI8 bump, ebuild improvements

### DIFF
--- a/net-wireless/horst/horst-5.1.ebuild
+++ b/net-wireless/horst/horst-5.1.ebuild
@@ -1,14 +1,15 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
-inherit toolchain-funcs vcs-snapshot
+EAPI=8
+
+inherit toolchain-funcs
 
 DESCRIPTION="Small 802.11 wireless LAN analyzer"
 HOMEPAGE="https://github.com/br101/horst/"
 SRC_URI="https://github.com/br101/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
 IUSE="debug +pcap test"
@@ -18,15 +19,14 @@ RDEPEND="
 	sys-libs/ncurses:0
 	pcap? ( net-libs/libpcap )
 "
-TDEPEND="
+DEPEND="${RDEPEND}"
+BEDEPEND="
+	virtual/pkgconfig
 	test? ( sys-devel/sparse )
 "
-DEPEND="
-	${RDEPEND}
-	${TDEPEND}
-	virtual/pkgconfig
-"
-RESTRICT=test #just semantic tests, no functional tests
+
+RESTRICT="test" #just semantic tests, no functional tests
+
 PATCHES=(
 	"${FILESDIR}"/${PN}-5.1-CC.patch
 	"${FILESDIR}"/${PN}-5.1-pcap_bufsize.patch

--- a/net-wireless/horst/horst-9999.ebuild
+++ b/net-wireless/horst/horst-9999.ebuild
@@ -1,16 +1,16 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
+
 inherit git-r3 toolchain-funcs
 
 DESCRIPTION="Small 802.11 wireless LAN analyzer"
 HOMEPAGE="https://github.com/br101/horst/"
 EGIT_REPO_URI="https://github.com/br101/${PN}/"
 
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="0"
-KEYWORDS=""
 IUSE="debug +pcap test"
 
 RDEPEND="
@@ -18,15 +18,14 @@ RDEPEND="
 	sys-libs/ncurses:0
 	pcap? ( net-libs/libpcap )
 "
-TDEPEND="
+DEPEND="${RDEPEND}"
+BEDEPEND="
+	virtual/pkgconfig
 	test? ( sys-devel/sparse )
 "
-DEPEND="
-	${RDEPEND}
-	${TDEPEND}
-	virtual/pkgconfig
-"
+
 RESTRICT=test #just semantic tests, no functional tests
+
 PATCHES=(
 	"${FILESDIR}"/${PN}-9999-tinfo.patch
 )


### PR DESCRIPTION
Hi,

This update `net-wireless/horst` for `EAPI8`.
The changes are pretty simple, but i wasn't able to compile the `9999` ebuild. (fails with `EAPI6` too)