### PR TITLE
profiles/arch: remove stable mask on base use flag for libreoffice

### DIFF
--- a/profiles/arch/amd64/package.use.stable.mask
+++ b/profiles/arch/amd64/package.use.stable.mask
@@ -83,10 +83,6 @@ dev-util/diffoscope haskell
 dev-java/openjdk:8 javafx
 dev-java/openjdk:11 javafx
 
-# Andreas Sturmlechner <asturm@gentoo.org> (2020-10-05)
-# REQUIRED_USE="base? ( firebird )", dev-db/firebird is not stable
-app-office/libreoffice base
-
 # Thomas Deutschmann <whissi@gentoo.org> (2020-09-07)
 # sys-cluster/slurm has no stable keywords
 # dev-util/nvidia-cuda-toolkit has no stable keywords

--- a/profiles/arch/x86/package.use.stable.mask
+++ b/profiles/arch/x86/package.use.stable.mask
@@ -84,10 +84,6 @@ dev-util/diffoscope haskell
 # large amount of fabric. bug #763954
 sys-block/open-iscsi infiniband
 
-# Andreas Sturmlechner <asturm@gentoo.org> (2020-10-05)
-# REQUIRED_USE="base? ( firebird )", dev-db/firebird is not stable
-app-office/libreoffice base
-
 # Thomas Deutschmann <whissi@gentoo.org> (2020-08-05)
 # sys-cluster/slurm has no stable keywords
 app-metrics/collectd collectd_plugins_slurm


### PR DESCRIPTION
"base" use flag was masked because it required firebird use flag and dev-db/firebird was and is unstable

Commit :https://gitweb.gentoo.org/repo/gentoo.git/commit/?id=bdb5c1f500f7407fee070cf6dc74653dd675d80a removed firebird as a required base dependency, so we can remove base from stable mask