### PR TITLE
dev-util/xfce4-dev-tools: add missing xsltproc build dependenvy

### DIFF
--- a/dev-util/xfce4-dev-tools/xfce4-dev-tools-4.18.1-r1.ebuild
+++ b/dev-util/xfce4-dev-tools/xfce4-dev-tools-4.18.1-r1.ebuild
@@ -1,0 +1,27 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DESCRIPTION="A set of scripts and m4/autoconf macros that ease build system maintenance"
+HOMEPAGE="
+	https://docs.xfce.org/xfce/xfce4-dev-tools/start
+	https://gitlab.xfce.org/xfce/xfce4-dev-tools/
+"
+SRC_URI="https://archive.xfce.org/src/xfce/${PN}/${PV%.*}/${P}.tar.bz2"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~mips ~ppc ~ppc64 ~riscv ~sparc ~x86 ~amd64-linux ~x86-linux ~x64-solaris"
+
+DEPEND="
+	>=dev-libs/glib-2.66.0
+"
+RDEPEND="
+	${DEPEND}
+"
+# libxslt for xsltproc
+BDEPEND="
+	dev-libs/libxslt
+	virtual/pkgconfig
+"


### PR DESCRIPTION
XFCE4 Development Tools 4.18.1 has xlstproc as a build dependency since https://gitlab.xfce.org/xfce/xfce4-dev-tools/-/commit/6243ebb4ec1e4b7f07374188532a4f295ff14a2f.

Closes: https://bugs.gentoo.org/916706