### PR TITLE
gui-wm/hyrpland: Add wlroots-headers use flag and right wlroots version 

### DIFF
--- a/gui-libs/wlroots/wlroots-20230828.ebuild
+++ b/gui-libs/wlroots/wlroots-20230828.ebuild
@@ -1,0 +1,91 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit meson
+
+DESCRIPTION="Pluggable, composable, unopinionated modules for building a Wayland compositor"
+HOMEPAGE="https://gitlab.freedesktop.org/wlroots/wlroots"
+
+#Hyprland wlroots commit
+EGIT_COMMIT=98a745d926d8048bc30aef11b421df207a01c279
+EGIT_REPO_URI="https://gitlab.freedesktop.org/${PN}/${PN}.git"
+inherit git-r3
+SLOT="0/20231001"
+
+LICENSE="MIT"
+IUSE="+drm +libinput tinywl vulkan x11-backend xcb-errors X"
+REQUIRED_USE="
+	xcb-errors? ( || ( x11-backend X ) )
+"
+
+DEPEND="
+	>=dev-libs/wayland-1.21.0
+	media-libs/mesa[egl(+),gles2]
+	sys-auth/seatd:=
+	virtual/libudev
+	>=x11-libs/libdrm-2.4.114
+	x11-libs/libxkbcommon
+	>=x11-libs/pixman-0.42.0
+	drm? ( sys-apps/hwdata )
+	libinput? ( >=dev-libs/libinput-1.14.0:= )
+	vulkan? (
+		dev-util/glslang:=
+		dev-util/vulkan-headers
+		media-libs/vulkan-loader
+	)
+	xcb-errors? ( x11-libs/xcb-util-errors )
+	x11-backend? (
+		x11-libs/libxcb:=
+		x11-libs/xcb-util-renderutil
+	)
+	X? (
+		x11-base/xwayland
+		x11-libs/libxcb:=
+		x11-libs/xcb-util-wm
+	)
+"
+RDEPEND="
+	${DEPEND}
+"
+BDEPEND="
+	>=dev-libs/wayland-protocols-1.28
+	dev-util/wayland-scanner
+	virtual/pkgconfig
+"
+
+src_configure() {
+	local backends=(
+		$(usev drm)
+		$(usev libinput)
+		$(usev x11-backend 'x11')
+	)
+	local meson_backends=$(
+		IFS=','
+		echo "${backends[*]}"
+	)
+	local emesonargs=(
+		$(meson_feature xcb-errors)
+		$(meson_use tinywl examples)
+		-Drenderers=$(usex vulkan 'gles2,vulkan' gles2)
+		$(meson_feature X xwayland)
+		-Dbackends=${meson_backends}
+	)
+
+	meson_src_configure
+}
+
+src_install() {
+	meson_src_install
+	dodoc docs/*
+
+	if use tinywl; then
+		dobin "${BUILD_DIR}"/tinywl/tinywl
+	fi
+}
+
+pkg_postinst() {
+	elog "You must be in the input group to allow your compositor"
+	elog "to access input devices via libinput."
+}

--- a/gui-libs/wlroots/wlroots-20231001.ebuild
+++ b/gui-libs/wlroots/wlroots-20231001.ebuild
@@ -1,0 +1,91 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit meson
+
+DESCRIPTION="Pluggable, composable, unopinionated modules for building a Wayland compositor"
+HOMEPAGE="https://gitlab.freedesktop.org/wlroots/wlroots"
+
+#Hyprland wlroots commit
+EGIT_COMMIT=3406c1b17a4a7e6d4e2a7d9c1176affa72bce1bc
+EGIT_REPO_URI="https://gitlab.freedesktop.org/${PN}/${PN}.git"
+inherit git-r3
+SLOT="0/20231001"
+
+LICENSE="MIT"
+IUSE="+drm +libinput tinywl vulkan x11-backend xcb-errors X"
+REQUIRED_USE="
+	xcb-errors? ( || ( x11-backend X ) )
+"
+
+DEPEND="
+	>=dev-libs/wayland-1.21.0
+	media-libs/mesa[egl(+),gles2]
+	sys-auth/seatd:=
+	virtual/libudev
+	>=x11-libs/libdrm-2.4.114
+	x11-libs/libxkbcommon
+	>=x11-libs/pixman-0.42.0
+	drm? ( sys-apps/hwdata )
+	libinput? ( >=dev-libs/libinput-1.14.0:= )
+	vulkan? (
+		dev-util/glslang:=
+		dev-util/vulkan-headers
+		media-libs/vulkan-loader
+	)
+	xcb-errors? ( x11-libs/xcb-util-errors )
+	x11-backend? (
+		x11-libs/libxcb:=
+		x11-libs/xcb-util-renderutil
+	)
+	X? (
+		x11-base/xwayland
+		x11-libs/libxcb:=
+		x11-libs/xcb-util-wm
+	)
+"
+RDEPEND="
+	${DEPEND}
+"
+BDEPEND="
+	>=dev-libs/wayland-protocols-1.28
+	dev-util/wayland-scanner
+	virtual/pkgconfig
+"
+
+src_configure() {
+	local backends=(
+		$(usev drm)
+		$(usev libinput)
+		$(usev x11-backend 'x11')
+	)
+	local meson_backends=$(
+		IFS=','
+		echo "${backends[*]}"
+	)
+	local emesonargs=(
+		$(meson_feature xcb-errors)
+		$(meson_use tinywl examples)
+		-Drenderers=$(usex vulkan 'gles2,vulkan' gles2)
+		$(meson_feature X xwayland)
+		-Dbackends=${meson_backends}
+	)
+
+	meson_src_configure
+}
+
+src_install() {
+	meson_src_install
+	dodoc docs/*
+
+	if use tinywl; then
+		dobin "${BUILD_DIR}"/tinywl/tinywl
+	fi
+}
+
+pkg_postinst() {
+	elog "You must be in the input group to allow your compositor"
+	elog "to access input devices via libinput."
+}

--- a/gui-wm/hyprland/hyprland-0.30.0.ebuild
+++ b/gui-wm/hyprland/hyprland-0.30.0.ebuild
@@ -14,7 +14,7 @@ S="${WORKDIR}/${PN}-source"
 KEYWORDS="~amd64"
 LICENSE="BSD"
 SLOT="0"
-IUSE="X legacy-renderer systemd video_cards_nvidia"
+IUSE="X legacy-renderer systemd video_cards_nvidia wlroots-headers"
 
 # bundled wlroots has the following dependency string according to included headers.
 # wlroots[drm,gles2-renderer,libinput,x11-backend?,X?]
@@ -37,6 +37,9 @@ WLROOTS_RDEPEND="
 		x11-libs/libxcb:0=
 		x11-libs/xcb-util-renderutil
 		x11-libs/xcb-util-wm
+	)
+	wlroots-headers? (
+		=gui-libs/wlroots-20230828
 	)
 "
 WLROOTS_DEPEND="
@@ -86,11 +89,11 @@ PATCHES=(
 pkg_setup() {
 	[[ ${MERGE_TYPE} == binary ]] && return
 
-	if tc-is-gcc && ver_test $(gcc-version) -lt 13 ; then
+	if tc-is-gcc && ver_test $(gcc-version) -lt 13; then
 		eerror "Hyprland requires >=sys-devel/gcc-13 to build"
 		eerror "Please upgrade GCC: emerge -v1 sys-devel/gcc"
 		die "GCC version is too old to compile Hyprland!"
-	elif tc-is-clang && ver_test $(clang-version) -lt 16 ; then
+	elif tc-is-clang && ver_test $(clang-version) -lt 16; then
 		eerror "Hyprland requires >=sys-devel/clang-16 to build"
 		eerror "Please upgrade Clang: emerge -v1 sys-devel/clang"
 		die "Clang version is too old to compile Hyprland!"

--- a/gui-wm/hyprland/hyprland-0.31.0.ebuild
+++ b/gui-wm/hyprland/hyprland-0.31.0.ebuild
@@ -14,7 +14,7 @@ S="${WORKDIR}/${PN}-source"
 KEYWORDS="~amd64"
 LICENSE="BSD"
 SLOT="0"
-IUSE="X legacy-renderer systemd video_cards_nvidia"
+IUSE="X legacy-renderer systemd video_cards_nvidia wlroots-headers"
 
 # bundled wlroots has the following dependency string according to included headers.
 # wlroots[drm,gles2-renderer,libinput,x11-backend?,X?]
@@ -37,6 +37,9 @@ WLROOTS_RDEPEND="
 		x11-libs/libxcb:0=
 		x11-libs/xcb-util-renderutil
 		x11-libs/xcb-util-wm
+	)
+	wlroots-headers? (
+		=gui-libs/wlroots-20231001
 	)
 "
 WLROOTS_DEPEND="
@@ -86,11 +89,11 @@ PATCHES=(
 pkg_setup() {
 	[[ ${MERGE_TYPE} == binary ]] && return
 
-	if tc-is-gcc && ver_test $(gcc-version) -lt 13 ; then
+	if tc-is-gcc && ver_test $(gcc-version) -lt 13; then
 		eerror "Hyprland requires >=sys-devel/gcc-13 to build"
 		eerror "Please upgrade GCC: emerge -v1 sys-devel/gcc"
 		die "GCC version is too old to compile Hyprland!"
-	elif tc-is-clang && ver_test $(clang-version) -lt 16 ; then
+	elif tc-is-clang && ver_test $(clang-version) -lt 16; then
 		eerror "Hyprland requires >=sys-devel/clang-16 to build"
 		eerror "Please upgrade Clang: emerge -v1 sys-devel/clang"
 		die "Clang version is too old to compile Hyprland!"

--- a/gui-wm/hyprland/metadata.xml
+++ b/gui-wm/hyprland/metadata.xml
@@ -17,5 +17,6 @@
 	</upstream>
 	<use>
 		<flag name="legacy-renderer">Enable legacy renderer</flag>
+		<flag name="wlroots-headers">Install the wlroots commit use by Hyprland (Allow the use of hyprland plugins)</flag>
 	</use>
 </pkgmetadata>


### PR DESCRIPTION
The wlroots ebuild added here is to be used with the new wlroots-header use flag added to the Hyprland package.

I made this PR since if you what to use hyprland-plugin ebuild in guru or other hyprland plugin, the plugin will fail to compile since the wlroots version on gentoo is behind the version use to compile hyprland. See this [Issue](https://github.com/hyprwm/hyprland-plugins/issues/46)

Since hyprland use specific commit and not the latest stable version, the version name on the ebuild is the date that specif commit was added to the master brach (ebuild dont allow the commit hash to be use as the version name [wlroots-3406c1b1.ebuild is not valid as atom])