### PR TITLE
toolchain-funcs.eclass: tc-ld-force-bfd: unset LD before calling tc-getLD

### DIFF
--- a/eclass/toolchain-funcs.eclass
+++ b/eclass/toolchain-funcs.eclass
@@ -534,10 +534,9 @@ tc-ld-force-bfd() {
 	ewarn "Forcing usage of the BFD linker"
 
 	# Set up LD to point directly to bfd if it's available.
-	local ld=$(tc-getLD "$@")
-	# We need to extract the first word in case there are flags appended
-	# to its value (like multilib), bug #545218.
-	local bfd_ld="${ld%% *}.bfd"
+	# Unset LD first so we get the default value from tc-getLD.
+	local ld=$(unset LD; tc-getLD "$@")
+	local bfd_ld="${ld}.bfd"
 	local path_ld=$(type -P "${bfd_ld}" 2>/dev/null)
 	[[ -e ${path_ld} ]] && export LD=${bfd_ld}
 


### PR DESCRIPTION
The previous logic would fail with common values of LD set by the user:

LD="ld.lld" -> LD="ld.lld.bfd"
LD="ld.gold" -> LD="ld.gold.bfd"
LD="mold" -> LD="mold.bfd"

It makes more sense to ignore the user's LD setting and use the default value given by tc-getLD.

If the user doesn't have binutils installed, the "type -P" check will still fail and LD will be unaltered.