### PR TITLE
dev-libs/libtsm: Fix call to undeclared function static_assert

### DIFF
--- a/dev-libs/libtsm/files/libtsm-clang16-static_assert-fix.patch
+++ b/dev-libs/libtsm/files/libtsm-clang16-static_assert-fix.patch
@@ -1,0 +1,10 @@
+Bug: https://bugs.gentoo.org/895052
+--- a/cmake/CompileOptions.cmake
++++ b/cmake/CompileOptions.cmake
+@@ -1,5 +1,5 @@
+ # Set compiler flags
+-set(CMAKE_C_STANDARD 99)
++set(CMAKE_C_STANDARD 11)
+ set(CMAKE_C_STANDARD_REQUIRED ON)
+ 
+ # analogous to AC_USE_SYSTEM_EXTENSIONS in configure.ac

--- a/dev-libs/libtsm/libtsm-4.0.2-r1.ebuild
+++ b/dev-libs/libtsm/libtsm-4.0.2-r1.ebuild
@@ -1,0 +1,20 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit cmake
+
+DESCRIPTION="Terminal Emulator State Machine"
+HOMEPAGE="https://github.com/Aetf/libtsm"
+SRC_URI="https://github.com/Aetf/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="LGPL-2.1 MIT"
+SLOT="0/4"
+KEYWORDS="~amd64 ~x86"
+IUSE=""
+
+PATCHES=(
+	"${FILESDIR}/${PN}-cmake.patch"
+	"${FILESDIR}/${PN}-clang16-static_assert-fix.patch"
+)


### PR DESCRIPTION
and update EAPI 7 -> 8

Closes: https://bugs.gentoo.org/895052