### PR TITLE
net-im/telegram-desktop-bin: disable internal updater again

### DIFF
--- a/net-im/telegram-desktop-bin/telegram-desktop-bin-4.11.3-r1.ebuild
+++ b/net-im/telegram-desktop-bin/telegram-desktop-bin-4.11.3-r1.ebuild
@@ -41,7 +41,7 @@ src_prepare() {
 src_install() {
 	newbin Telegram telegram-desktop
 
-	insinto /etc/tdesktop
+	insinto /usr/share/TelegramDesktop/externalupdater.d/
 	newins - externalupdater <<<"${EPREFIX}/usr/bin/telegram-desktop"
 
 	local icon_size


### PR DESCRIPTION
Upstream changed the interface to disable the "internal updater" of the application, or to tell it that there is an "external updater", in our case portage.

Closes: https://bugs.gentoo.org/916687