### PR TITLE
net-analyzer/ipband: EAPI8 bump, use https, fix LICENSE

### DIFF
--- a/net-analyzer/ipband/ipband-0.8.1-r2.ebuild
+++ b/net-analyzer/ipband/ipband-0.8.1-r2.ebuild
@@ -1,14 +1,15 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
+
 inherit toolchain-funcs
 
-DESCRIPTION="A pcap based IP traffic and bandwidth monitor"
-HOMEPAGE="http://ipband.sourceforge.net/"
+DESCRIPTION="Pcap based IP traffic and bandwidth monitor"
+HOMEPAGE="https://ipband.sourceforge.net/"
 SRC_URI="mirror://sourceforge/${PN}/${P}.tgz"
 
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="0"
 KEYWORDS="~amd64 x86"
 


### PR DESCRIPTION
Simple `EAPI8` bump for `net-analyzer/ipband`