### PR TITLE
distutils-r1/python-utils-r1.eclass: Support EPYTEST_XDIST

### DIFF
--- a/dev-python/numpy/numpy-1.26.1.ebuild
+++ b/dev-python/numpy/numpy-1.26.1.ebuild
@@ -46,11 +46,11 @@ BDEPEND="
 		' 'python*')
 		dev-python/charset-normalizer[${PYTHON_USEDEP}]
 		>=dev-python/hypothesis-5.8.0[${PYTHON_USEDEP}]
-		dev-python/pytest-xdist[${PYTHON_USEDEP}]
 		>=dev-python/pytz-2019.3[${PYTHON_USEDEP}]
 	)
 "
 
+EPYTEST_XDIST=1
 distutils_enable_tests pytest
 
 python_prepare_all() {
@@ -143,7 +143,7 @@ python_test() {
 	esac
 
 	rm -rf numpy || die
-	epytest -n "$(makeopts_jobs)" --pyargs numpy
+	epytest --pyargs numpy
 }
 
 python_install_all() {

--- a/dev-python/pyrate-limiter/pyrate-limiter-3.1.0.ebuild
+++ b/dev-python/pyrate-limiter/pyrate-limiter-3.1.0.ebuild
@@ -26,7 +26,6 @@ RDEPEND="
 BDEPEND="
 	test? (
 		dev-python/pytest-asyncio[${PYTHON_USEDEP}]
-		dev-python/pytest-xdist[${PYTHON_USEDEP}]
 		dev-python/pyyaml[${PYTHON_USEDEP}]
 	)
 "
@@ -37,6 +36,7 @@ EPYTEST_DESELECT=(
 	# Python 3.11 is slightly faster, leading to a non-critical failure here
 	"tests/test_concurrency.py::test_concurrency[ProcessPoolExecutor-SQLiteBucket]"
 )
+EPYTEST_XDIST=1
 
 # TODO: package sphinx-copybutton
 # distutils_enable_sphinx docs \
@@ -66,8 +66,4 @@ src_test() {
 
 	# Clean up afterwards
 	kill "$(<"${redis_pid}")" || die
-}
-
-python_test() {
-	epytest -n "$(makeopts_jobs)" --dist=worksteal
 }

--- a/eclass/distutils-r1.eclass
+++ b/eclass/distutils-r1.eclass
@@ -617,6 +617,9 @@ distutils_enable_tests() {
 			;;
 		pytest)
 			test_pkgs='>=dev-python/pytest-7.3.1[${PYTHON_USEDEP}]'
+			if [[ ${EPYTEST_XDIST} ]]; then
+				test_pkgs+=' dev-python/pytest-xdist[${PYTHON_USEDEP}]'
+			fi
 			;;
 		setup.py)
 			;;

--- a/eclass/distutils-r1.eclass
+++ b/eclass/distutils-r1.eclass
@@ -610,13 +610,13 @@ distutils_enable_tests() {
 	[[ ${#} -eq 1 ]] || die "${FUNCNAME} takes exactly one argument: test-runner"
 
 	local test_deps=${RDEPEND}
-	local test_pkg
+	local test_pkgs
 	case ${1} in
 		nose)
-			test_pkg=">=dev-python/nose-1.3.7_p20221026"
+			test_pkgs='>=dev-python/nose-1.3.7_p20221026[${PYTHON_USEDEP}]'
 			;;
 		pytest)
-			test_pkg=">=dev-python/pytest-7.3.1"
+			test_pkgs='>=dev-python/pytest-7.3.1[${PYTHON_USEDEP}]'
 			;;
 		setup.py)
 			;;
@@ -635,12 +635,12 @@ distutils_enable_tests() {
 	_DISTUTILS_TEST_RUNNER=${1}
 	python_test() { distutils-r1_python_test; }
 
-	if [[ -n ${test_pkg} ]]; then
+	if [[ -n ${test_pkgs} ]]; then
 		if [[ ! ${DISTUTILS_SINGLE_IMPL} ]]; then
-			test_deps+=" ${test_pkg}[${PYTHON_USEDEP}]"
+			test_deps+=" ${test_pkgs//'${PYTHON_USEDEP}'/${PYTHON_USEDEP}}"
 		else
 			test_deps+=" $(python_gen_cond_dep "
-				${test_pkg}[\${PYTHON_USEDEP}]
+				${test_pkgs}
 			")"
 		fi
 	fi

--- a/eclass/python-utils-r1.eclass
+++ b/eclass/python-utils-r1.eclass
@@ -1311,7 +1311,9 @@ _python_check_occluded_packages() {
 # @DEFAULT_UNSET
 # @DESCRIPTION:
 # If set to a non-empty value, enables running tests in parallel
-# via pytest-xdist plugin.
+# via pytest-xdist plugin.  If this variable is set prior to calling
+# distutils_enable_tests in distutils-r1, a test dependency
+# on dev-python/pytest-xdist is added automatically.
 
 # @VARIABLE: EPYTEST_JOBS
 # @USER_VARIABLE

--- a/eclass/python-utils-r1.eclass
+++ b/eclass/python-utils-r1.eclass
@@ -1307,6 +1307,19 @@ _python_check_occluded_packages() {
 # parameter, when calling epytest.  The listed files will be entirely
 # skipped from test collection.
 
+# @VARIABLE: EPYTEST_XDIST
+# @DEFAULT_UNSET
+# @DESCRIPTION:
+# If set to a non-empty value, enables running tests in parallel
+# via pytest-xdist plugin.
+
+# @VARIABLE: EPYTEST_JOBS
+# @USER_VARIABLE
+# @DEFAULT_UNSET
+# @DESCRIPTION:
+# Specifies the number of jobs for parallel (pytest-xdist) test runs.
+# When unset, defaults to -j from MAKEOPTS, or the current nproc.
+
 # @FUNCTION: epytest
 # @USAGE: [<args>...]
 # @DESCRIPTION:
@@ -1371,6 +1384,22 @@ epytest() {
 		-p no:plus
 		-p no:tavern
 	)
+
+	if [[ ${EPYTEST_XDIST} ]]; then
+		local jobs=${EPYTEST_JOBS:-$(makeopts_jobs)}
+		if [[ ${jobs} -gt 1 ]]; then
+			args+=(
+				# explicitly enable the plugin, in case the ebuild was using
+				# PYTEST_DISABLE_PLUGIN_AUTOLOAD=1
+				-p xdist
+				-n "${jobs}"
+				# worksteal ensures that workers don't end up idle when heavy
+				# jobs are unevenly distributed
+				--dist=worksteal
+			)
+		fi
+	fi
+
 	local x
 	for x in "${EPYTEST_DESELECT[@]}"; do
 		args+=( --deselect "${x}" )


### PR DESCRIPTION
Add an `EPYTEST_XDIST` control variable that:

1. Makes `epytest` enable xdist with the usual set of parameters (provided that we're actually doing >1 job).
2. Makes `distutils_enable_tests pytest` add `dev-python/pytext-xdist` dep.

Also add `EPYTEST_JOBS` to control jobs independently of `MAKEOPTS`.

I suppose when this lands, we'd use a pkgcheck check for `EPYTEST_XDIST` being declared after `d_e_t` call.