### PR TITLE
sci-electronics/kicad: Fix up 9999

### DIFF
--- a/sci-electronics/kicad/kicad-9999.ebuild
+++ b/sci-electronics/kicad/kicad-9999.ebuild
@@ -35,6 +35,7 @@ REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 # Contains bundled pybind but it's patched for wx
 # See https://gitlab.com/kicad/code/kicad/-/commit/74e4370a9b146b21883d6a2d1df46c7a10bd0424
 # Depend on opencascade:0 to get unslotted variant (so we know path to it), bug #833301
+# Depend wxGTK version needs to be limited due to switch from EGL to GLX, bug #911120
 COMMON_DEPEND="
 	dev-db/unixODBC
 	dev-libs/boost:=[context,nls]
@@ -47,9 +48,9 @@ COMMON_DEPEND="
 	>=sci-libs/opencascade-7.3.0:0=
 	>=x11-libs/cairo-1.8.8:=
 	>=x11-libs/pixman-0.30
-	x11-libs/wxGTK:${WX_GTK_VER}[X,opengl]
 	>sci-electronics/ngspice-27[shared]
 	sys-libs/zlib
+	>=x11-libs/wxGTK-3.2.2.1-r3:${WX_GTK_VER}[X,opengl]
 	$(python_gen_cond_dep '
 		dev-libs/boost:=[context,nls,python,${PYTHON_USEDEP}]
 		~dev-python/wxpython-4.2.0:*[${PYTHON_USEDEP}]
@@ -100,9 +101,6 @@ src_configure() {
 		-DKICAD_DOCS="${EPREFIX}/usr/share/doc/${PN}-doc-${PV}"
 
 		-DKICAD_SCRIPTING_WXPYTHON=ON
-		# wxWidgets does not support runtime selection of backends (GLX vs EGL),
-		# if enabled it can break KiCad depending on what wxGTK was compiled
-		# with, see bug #911120
 		-DKICAD_USE_EGL=OFF
 
 		-DKICAD_BUILD_I18N="$(usex nls)"


### PR DESCRIPTION
Bug #911120 haunts us so this change forces the latest wxGTK for
kicad-9999 ebuilds too. This brings the ebuild almost in sync with the
latest release, except for the new libgit2 dependency.

Signed-off-by: Zoltan Puskas <zoltan@sinustrom.info>
