### PR TITLE
dev-python/PyQt6: bugfix 42b4c9f60670 not applied to v6.5.3

### DIFF
--- a/dev-python/PyQt6/PyQt6-6.5.3.ebuild
+++ b/dev-python/PyQt6/PyQt6-6.5.3.ebuild
@@ -64,6 +64,7 @@ DEPEND="
 	positioning? ( >=dev-qt/qtpositioning-${QT_PV} )
 	qml? ( >=dev-qt/qtdeclarative-${QT_PV}[widgets?] )
 	quick3d? ( >=dev-qt/qtquick3d-${QT_PV} )
+	quick? ( >=dev-qt/qtdeclarative-${QT_PV}[opengl] )
 	sensors? ( >=dev-qt/qtsensors-${QT_PV} )
 	serialport? ( >=dev-qt/qtserialport-${QT_PV} )
 	speech? ( >=dev-qt/qtspeech-${QT_PV} )


### PR DESCRIPTION
42b4c9f60670 did not fix v6.5.3.

Skipping revbump due to long rebuilds, and technically it shouldn't matter given (as far as I can tell) it'll pass loading this bit at runtime without USE=opengl being set on PyQt6 (which would ensure it is set on qtdeclarative through qtbase/qtdeclarative[opengl=]).

Note that this does not affect PyQt5 despite also using the header given qtdeclarative:5 always installs this that I can see.

Bug: https://bugs.gentoo.org/916889