### PR TITLE
app-text/pdfminer: remove python_compile_all()

### DIFF
--- a/app-text/pdfminer/pdfminer-20221105.ebuild
+++ b/app-text/pdfminer/pdfminer-20221105.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..12} )
+PYTHON_COMPAT=( python3_{10..12} )
 inherit distutils-r1
 
 MY_P="${PN}.six-${PV}"
@@ -22,20 +22,12 @@ IUSE="doc examples"
 RDEPEND=">=dev-python/charset-normalizer-2.0.0[${PYTHON_USEDEP}]
 	>=dev-python/cryptography-36.0.0[${PYTHON_USEDEP}]"
 
-distutils_enable_sphinx docs "dev-python/sphinx-argparse"
+distutils_enable_sphinx docs/source "dev-python/sphinx-argparse"
 distutils_enable_tests pytest
 
 python_prepare_all() {
 	sed -i -e "s:__VERSION__:${PV}:g" pdfminer/__init__.py || die
 	distutils-r1_python_prepare_all
-}
-
-python_compile_all() {
-	# Non-standard doc generation
-	if use doc; then
-		PYTHONPATH="${PYTHONPATH}:${BUILD_DIR}/install" sphinx-build docs/source "${WORKDIR}"/_docs
-		HTML_DOCS=( "${WORKDIR}"/_docs/. )
-	fi
 }
 
 python_install_all() {


### PR DESCRIPTION
The path to the documentation subdirectory is passed to `distutils_enable_sphinx`, use that.
