### PR TITLE
dev-python/pdfrw: apply test patch only if tests are included

### DIFF
--- a/dev-python/pdfrw/pdfrw-0.4_p1-r1.ebuild
+++ b/dev-python/pdfrw/pdfrw-0.4_p1-r1.ebuild
@@ -61,7 +61,7 @@ src_unpack() {
 
 src_prepare() {
 	eapply "${FILESDIR}/pdfrw-fix-import-collections-warning.patch"
-	eapply "${FILESDIR}/pdfrw-static-fix-import-collections-warning.patch"
+	use test && eapply "${FILESDIR}/pdfrw-static-fix-import-collections-warning.patch"
 
 	distutils-r1_src_prepare
 }


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/917018