### PR TITLE
gui-wm/gamescope: require libinput to be enabled in wlroots

### DIFF
--- a/gui-wm/gamescope/gamescope-3.12.7-r1.ebuild
+++ b/gui-wm/gamescope/gamescope-3.12.7-r1.ebuild
@@ -22,7 +22,7 @@ RDEPEND="
 	=dev-libs/libliftoff-0.4*
 	>=dev-libs/wayland-1.21
 	>=dev-libs/wayland-protocols-1.17
-	=gui-libs/wlroots-0.16*[X]
+	=gui-libs/wlroots-0.16*[X,libinput(+)]
 	>=media-libs/libdisplay-info-0.1.1
 	media-libs/libsdl2[video,vulkan]
 	media-libs/vulkan-loader


### PR DESCRIPTION
* libinput has been exposed as use flag instead of being enabled by default since wlroots-0.16.2-r1.

Closes: https://bugs.gentoo.org/909044