### PR TITLE
dev-util/valgrind: 9999 drop merged fortify patch

### DIFF
--- a/dev-util/valgrind/valgrind-9999.ebuild
+++ b/dev-util/valgrind/valgrind-9999.ebuild
@@ -44,7 +44,6 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-3.7.0-respect-flags.patch
 	"${FILESDIR}"/${PN}-3.15.0-Build-ldst_multiple-test-with-fno-pie.patch
 	"${FILESDIR}"/${PN}-3.21.0-glibc-2.34-suppressions.patch
-	"${FILESDIR}"/${PN}-3.21.0-memcpy-fortify_source.patch
 )
 
 src_prepare() {


### PR DESCRIPTION
Patch has been merged upstream in
https://sourceware.org/git/?p=valgrind.git;a=commit;h=53e101f562fa89bbf92d658fba626e2397862a16

See https://bugs.kde.org/show_bug.cgi?id=402833#c10