### PR TITLE
dev-qt/qtgui: Wire up IUSE=accessibility, add missing dependency

### DIFF
--- a/dev-qt/qtgui/qtgui-5.15.11-r1.ebuild
+++ b/dev-qt/qtgui/qtgui-5.15.11-r1.ebuild
@@ -1,0 +1,180 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+if [[ ${PV} != *9999* ]]; then
+	QT5_KDEPATCHSET_REV=2
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86"
+fi
+
+QT5_MODULE="qtbase"
+inherit qt5-build
+
+DESCRIPTION="The GUI module and platform plugins for the Qt5 framework"
+
+SLOT=5/${QT5_PV} # bug 707658
+IUSE="accessibility dbus egl eglfs evdev gles2-only ibus jpeg +libinput
+	linuxfb +png tslib tuio +udev vnc vulkan wayland +X"
+REQUIRED_USE="
+	|| ( eglfs linuxfb vnc wayland X )
+	accessibility? ( dbus X )
+	eglfs? ( egl )
+	ibus? ( dbus )
+	libinput? ( udev )
+	X? ( gles2-only? ( egl ) )
+"
+
+RDEPEND="
+	dev-libs/glib:2
+	=dev-qt/qtcore-${QT5_PV}*:5=
+	dev-util/gtk-update-icon-cache
+	media-libs/fontconfig
+	media-libs/freetype:2
+	media-libs/harfbuzz:=
+	sys-libs/zlib:=
+	accessibility? ( app-accessibility/at-spi2-core:2 )
+	dbus? ( =dev-qt/qtdbus-${QT5_PV}* )
+	eglfs? (
+		media-libs/mesa[gbm(+)]
+		x11-libs/libdrm
+	)
+	evdev? ( sys-libs/mtdev )
+	jpeg? ( media-libs/libjpeg-turbo:= )
+	gles2-only? ( media-libs/libglvnd )
+	!gles2-only? ( media-libs/libglvnd[X] )
+	libinput? (
+		dev-libs/libinput:=
+		x11-libs/libxkbcommon
+	)
+	png? ( media-libs/libpng:= )
+	tslib? ( >=x11-libs/tslib-1.21 )
+	tuio? ( =dev-qt/qtnetwork-${QT5_PV}* )
+	udev? ( virtual/libudev:= )
+	vnc? ( =dev-qt/qtnetwork-${QT5_PV}* )
+	vulkan? ( dev-util/vulkan-headers )
+	X? (
+		x11-libs/libICE
+		x11-libs/libSM
+		x11-libs/libX11
+		x11-libs/libxcb:=
+		x11-libs/libxkbcommon[X]
+		x11-libs/xcb-util-image
+		x11-libs/xcb-util-keysyms
+		x11-libs/xcb-util-renderutil
+		x11-libs/xcb-util-wm
+	)
+"
+DEPEND="${RDEPEND}
+	evdev? ( sys-kernel/linux-headers )
+	linuxfb? ( sys-kernel/linux-headers )
+	udev? ( sys-kernel/linux-headers )
+	X? ( x11-base/xorg-proto )
+"
+PDEPEND="
+	ibus? ( app-i18n/ibus )
+	wayland? ( =dev-qt/qtwayland-${QT5_PV}* )
+"
+
+QT5_TARGET_SUBDIRS=(
+	src/tools/qvkgen
+	src/gui
+	src/openglextensions
+	src/platformheaders
+	src/platformsupport
+	src/plugins/generic
+	src/plugins/imageformats
+	src/plugins/platforms
+	src/plugins/platforminputcontexts
+)
+
+QT5_GENTOO_CONFIG=(
+	accessibility:accessibility-atspi-bridge
+	egl:egl:
+	eglfs:eglfs:
+	eglfs:eglfs_egldevice:
+	eglfs:eglfs_gbm:
+	evdev:evdev:
+	evdev:mtdev:
+	:fontconfig:
+	:system-freetype:FREETYPE
+	!:no-freetype:
+	gles2-only::OPENGL_ES
+	gles2-only:opengles2:OPENGL_ES_2
+	!:no-gui:
+	:system-harfbuzz:
+	!:no-harfbuzz:
+	jpeg:system-jpeg:IMAGEFORMAT_JPEG
+	!jpeg:no-jpeg:
+	libinput
+	libinput:xkbcommon:
+	:opengl
+	png:png:
+	png:system-png:IMAGEFORMAT_PNG
+	!png:no-png:
+	tslib:tslib:
+	udev:libudev:
+	vulkan:vulkan:
+	X:xcb:
+	X:xcb-glx:
+	X:xcb-plugin:
+	X:xcb-render:
+	X:xcb-sm:
+	X:xcb-xlib:
+	X:xcb-xinput:
+)
+
+QT5_GENTOO_PRIVATE_CONFIG=(
+	:gui
+)
+
+src_prepare() {
+	# don't add -O3 to CXXFLAGS, bug 549140
+	sed -i -e '/CONFIG\s*+=/s/optimize_full//' src/gui/gui.pro || die
+
+	# egl_x11 is activated when both egl and X are enabled
+	use egl && QT5_GENTOO_CONFIG+=(X:egl_x11:) || QT5_GENTOO_CONFIG+=(egl:egl_x11:)
+
+	qt_use_disable_config dbus dbus \
+		src/platformsupport/themes/genericunix/genericunix.pri
+
+	qt_use_disable_config tuio tuiotouch src/plugins/generic/generic.pro
+
+	qt_use_disable_mod ibus dbus \
+		src/plugins/platforminputcontexts/platforminputcontexts.pro
+
+	use vnc || sed -i -e '/SUBDIRS += vnc/d' \
+		src/plugins/platforms/platforms.pro || die
+
+	qt5-build_src_prepare
+}
+
+src_configure() {
+	local myconf=(
+		$(qt_use accessibility feature-accessibility-atspi-bridge)
+		$(usev dbus -dbus-linked)
+		$(qt_use egl)
+		$(qt_use eglfs)
+		$(usev eglfs '-gbm -kms')
+		$(qt_use evdev)
+		$(qt_use evdev mtdev)
+		-fontconfig
+		-system-freetype
+		-gui
+		-system-harfbuzz
+		$(qt_use jpeg libjpeg system)
+		$(qt_use libinput)
+		$(qt_use linuxfb)
+		-opengl $(usex gles2-only es2 desktop)
+		$(qt_use png libpng system)
+		$(qt_use tslib)
+		$(qt_use udev libudev)
+		$(qt_use vulkan)
+		$(qt_use X xcb)
+		$(usev X '-xcb-xlib')
+	)
+	if use libinput || use X; then
+		myconf+=( -xkbcommon )
+	fi
+	qt5-build_src_configure
+}

--- a/kde-plasma/kwin/files/kwin-5.27.9-xdgshellwindow-enforce-min-size.patch
+++ b/kde-plasma/kwin/files/kwin-5.27.9-xdgshellwindow-enforce-min-size.patch
@@ -1,0 +1,71 @@
+From 0900264e6f538ff915186b1bd9e528e568b28c1d Mon Sep 17 00:00:00 2001
+From: Xaver Hugl <xaver.hugl@gmail.com>
+Date: Wed, 23 Aug 2023 21:51:18 +0200
+Subject: [PATCH] xdgshellwindow: enforce a minimum size for clients
+
+It doesn't make sense for a window to become 1x1 pixels small. When we have
+server side decorations we also know that the decoration takes a lot of
+space, so this commit enforces a bigger minimum size for decorated windows
+
+BUG: 469237
+
+
+(cherry picked from commit 28c27609a4b45cf08b53dcc7dfe90f23c3338797)
+---
+ autotests/integration/xdgshellwindow_test.cpp | 8 ++++----
+ src/xdgshellwindow.cpp                        | 3 ++-
+ 2 files changed, 6 insertions(+), 5 deletions(-)
+
+diff --git a/autotests/integration/xdgshellwindow_test.cpp b/autotests/integration/xdgshellwindow_test.cpp
+index 70716e49434..53489a27f6b 100644
+--- a/autotests/integration/xdgshellwindow_test.cpp
++++ b/autotests/integration/xdgshellwindow_test.cpp
+@@ -375,12 +375,12 @@ void TestXdgShellWindow::testFullscreen()
+     QVERIFY(surfaceConfigureRequestedSpy.wait());
+ 
+     shellSurface->xdgSurface()->ack_configure(surfaceConfigureRequestedSpy.last().at(0).value<quint32>());
+-    auto window = Test::renderAndWaitForShown(surface.get(), QSize(100, 50), Qt::blue);
++    auto window = Test::renderAndWaitForShown(surface.get(), QSize(500, 250), Qt::blue);
+     QVERIFY(window);
+     QVERIFY(window->isActive());
+     QCOMPARE(window->layer(), NormalLayer);
+     QVERIFY(!window->isFullScreen());
+-    QCOMPARE(window->clientSize(), QSize(100, 50));
++    QCOMPARE(window->clientSize(), QSize(500, 250));
+     QCOMPARE(window->isDecorated(), decoMode == Test::XdgToplevelDecorationV1::mode_server_side);
+     QCOMPARE(window->clientSizeToFrameSize(window->clientSize()), window->size());
+ 
+@@ -417,14 +417,14 @@ void TestXdgShellWindow::testFullscreen()
+     QCOMPARE(surfaceConfigureRequestedSpy.count(), 4);
+     states = toplevelConfigureRequestedSpy.last().at(1).value<Test::XdgToplevel::States>();
+     QVERIFY(!(states & Test::XdgToplevel::State::Fullscreen));
+-    QCOMPARE(toplevelConfigureRequestedSpy.last().at(0).value<QSize>(), QSize(100, 50));
++    QCOMPARE(toplevelConfigureRequestedSpy.last().at(0).value<QSize>(), QSize(500, 250));
+ 
+     shellSurface->xdgSurface()->ack_configure(surfaceConfigureRequestedSpy.last().at(0).value<quint32>());
+     Test::render(surface.get(), toplevelConfigureRequestedSpy.last().at(0).value<QSize>(), Qt::blue);
+ 
+     QVERIFY(fullScreenChangedSpy.wait());
+     QCOMPARE(fullScreenChangedSpy.count(), 2);
+-    QCOMPARE(window->clientSize(), QSize(100, 50));
++    QCOMPARE(window->clientSize(), QSize(500, 250));
+     QVERIFY(!window->isFullScreen());
+     QCOMPARE(window->isDecorated(), decoMode == Test::XdgToplevelDecorationV1::mode_server_side);
+     QCOMPARE(window->layer(), NormalLayer);
+diff --git a/src/xdgshellwindow.cpp b/src/xdgshellwindow.cpp
+index 34201bdd05b..29d8623cac3 100644
+--- a/src/xdgshellwindow.cpp
++++ b/src/xdgshellwindow.cpp
+@@ -600,7 +600,8 @@ MaximizeMode XdgToplevelWindow::requestedMaximizeMode() const
+ 
+ QSizeF XdgToplevelWindow::minSize() const
+ {
+-    return rules()->checkMinSize(m_shellSurface->minimumSize());
++    const int enforcedMinimum = m_nextDecoration ? 150 : 20;
++    return rules()->checkMinSize(QSize(std::max(enforcedMinimum, m_shellSurface->minimumSize().width()), std::max(enforcedMinimum, m_shellSurface->minimumSize().height())));
+ }
+ 
+ QSizeF XdgToplevelWindow::maxSize() const
+-- 
+GitLab
+

--- a/kde-plasma/kwin/kwin-5.27.9-r1.ebuild
+++ b/kde-plasma/kwin/kwin-5.27.9-r1.ebuild
@@ -24,7 +24,7 @@ COMMON_DEPEND="
 	>=dev-libs/wayland-1.21.0
 	>=dev-qt/qtdbus-${QTMIN}:5
 	>=dev-qt/qtdeclarative-${QTMIN}:5
-	>=dev-qt/qtgui-${QTMIN}:5=[egl,gles2-only=,libinput]
+	>=dev-qt/qtgui-${QTMIN}:5=[accessibility,egl,gles2-only=,libinput]
 	>=dev-qt/qtnetwork-${QTMIN}:5
 	>=dev-qt/qtwidgets-${QTMIN}:5
 	>=dev-qt/qtx11extras-${QTMIN}:5

--- a/kde-plasma/kwin/kwin-5.27.9-r1.ebuild
+++ b/kde-plasma/kwin/kwin-5.27.9-r1.ebuild
@@ -100,6 +100,8 @@ BDEPEND="
 "
 PDEPEND=">=kde-plasma/kde-cli-tools-${PVCUT}:5"
 
+PATCHES=( "${FILESDIR}/${P}-xdgshellwindow-enforce-min-size.patch" ) # KDE-bug 469237
+
 src_prepare() {
 	ecm_src_prepare
 	use multimedia || eapply "${FILESDIR}/${PN}-5.26.80-gstreamer-optional.patch"

--- a/profiles/targets/desktop/package.use
+++ b/profiles/targets/desktop/package.use
@@ -1,6 +1,11 @@
 # Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Andreas Sturmlechner <asturm@gentoo.org> (2023-11-11)
+# egl, libinput required by kde-frameworks/kwayland
+# accessibility required by kde-plasma/kwin
+dev-qt/qtgui:5 accessibility egl libinput
+
 # Sam James <sam@gentoo.org> (2023-09-22)
 # Most people aren't going to use CMake's GUI. USE=gui is enabled by default
 # on desktop profiles and CMake is unavoidable, it feels a shame to drag in
@@ -49,10 +54,6 @@ dev-libs/xmlsec nss
 # Andreas Sturmlechner <asturm@gentoo.org> (2017-11-30)
 # Not required, but makes life easier with Qt; bug #457934
 app-arch/unzip natspec
-
-# Andreas Sturmlechner <asturm@gentoo.org> (2017-11-30)
-# Required by kde-frameworks/kwayland
-dev-qt/qtgui:5 egl libinput
 
 # Andreas Sturmlechner <asturm@gentoo.org> (2017-08-04)
 # Required by flac and mp3


### PR DESCRIPTION
This exists since way before I looked at `dev-qt/*`, was there a reason to omit the build system switch or dependency that I am not aware of?

```diff
--- qtgui-5.15.11.ebuild        2023-11-08 21:05:05.104914553 +0100
+++ qtgui-5.15.11-r1.ebuild     2023-11-08 21:05:26.538147361 +0100
@@ -5,7 +5,7 @@
 
 if [[ ${PV} != *9999* ]]; then
        QT5_KDEPATCHSET_REV=2
-       KEYWORDS="amd64 arm arm64 ~hppa ~loong ppc ppc64 ~riscv ~sparc x86"
+       KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86"
 fi
 
 QT5_MODULE="qtbase"
@@ -33,6 +33,7 @@
        media-libs/freetype:2
        media-libs/harfbuzz:=
        sys-libs/zlib:=
+       accessibility? ( app-accessibility/at-spi2-core:2 )
        dbus? ( =dev-qt/qtdbus-${QT5_PV}* )
        eglfs? (
                media-libs/mesa[gbm(+)]
@@ -150,6 +151,7 @@
 
 src_configure() {
        local myconf=(
+               $(qt_use accessibility feature-accessibility-atspi-bridge)
                $(usev dbus -dbus-linked)
                $(qt_use egl)
                $(qt_use eglfs)
```