### PR TITLE
games-engines/box2d: Added testbed use flag to enable testbed in box2d.

### DIFF
--- a/games-engines/box2d/box2d-2.4.1-r1.ebuild
+++ b/games-engines/box2d/box2d-2.4.1-r1.ebuild
@@ -12,7 +12,7 @@ SRC_URI="https://github.com/erincatto/Box2D/archive/v${PV}.tar.gz -> ${P}.tar.gz
 LICENSE="ZLIB"
 SLOT="0"
 KEYWORDS="amd64 ~arm arm64 ~loong ~ppc64 ~riscv x86"
-IUSE="doc test"
+IUSE="doc test testbed"
 RESTRICT="!test? ( test )"
 
 DEPEND="test? ( dev-cpp/doctest )"
@@ -28,11 +28,19 @@ src_prepare() {
 
 src_configure() {
 	local mycmakeargs=(
-		-DBOX2D_BUILD_TESTBED=OFF # bundled libs, broken anyway right now
+		-DBOX2D_BUILD_TESTBED=$(usex testbed)
 		-DBOX2D_BUILD_UNIT_TESTS=$(usex test)
 		-DBOX2D_BUILD_DOCS=$(usex doc)
 	)
 	cmake_src_configure
+}
+
+src_install() {
+	cmake_src_install
+
+	if use testbed; then
+		dobin "${BUILD_DIR}"/bin/testbed
+	fi
 }
 
 src_test() {


### PR DESCRIPTION
The ebuild states "bundled libs, broken anyway right now"; however I managed to make testbed compile and run in amd64.
However, portage complains about insecure RUNPATHs.

Here's a picture of box2d running:
![testbed](https://github.com/gentoo/gentoo/assets/65001595/3225a10f-b73d-4583-aed2-23aaf4636a0b)
