### PR TITLE
net-misc/socat: Build system fixes

### DIFF
--- a/net-misc/socat/files/socat-1.7.4.4-configure-gcc.patch
+++ b/net-misc/socat/files/socat-1.7.4.4-configure-gcc.patch
@@ -1,0 +1,13 @@
+diff --git a/configure.ac b/configure.ac
+index 9d60473..e89f231 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -16,7 +16,7 @@ fi
+ # find out which defines gcc passes to cpp, so makedepend does not run into
+ # (harmless) "error architecture not supported"
+ AC_MSG_CHECKING(which defines needed for makedepend)
+-__cpp_defs=`gcc -v -E - </dev/null 2>&1 |$FGREP -e '/cpp ' -e '/cc1 '`
++__cpp_defs=`$CC -v -E - </dev/null 2>&1 |$FGREP -e '/cpp ' -e '/cc1 '`
+ SYSDEFS=`aa=; for a in $__cpp_defs
+ 	do case "$a" in -D*) aa="$aa $a";; esac; done; echo "$aa"`
+ AC_SUBST(SYSDEFS)

--- a/net-misc/socat/files/socat-1.7.4.4-large-file-support.patch
+++ b/net-misc/socat/files/socat-1.7.4.4-large-file-support.patch
@@ -1,0 +1,30 @@
+diff --git a/config.h.in b/config.h.in
+index be3cee9..7b939b6 100644
+--- a/config.h.in
++++ b/config.h.in
+@@ -704,6 +704,12 @@
+ 
+ #undef WITH_MSGLEVEL
+ 
++/* Number of bits in a file offset, on hosts where this is settable. */
++#undef _FILE_OFFSET_BITS
++
++/* Define for large files, on AIX-style hosts. */
++#undef _LARGE_FILES
++
+ #define BUILD_DATE __DATE__ " " __TIME__
+ 
+ #endif /* !defined(__config_h_included) */
+diff --git a/configure.ac b/configure.ac
+index e89f231..2abd820 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -30,6 +30,8 @@ if test -z "$CFLAGS"; then
+    export CFLAGS=-O
+ fi
+ 
++AC_SYS_LARGEFILE
++
+ dnl Checks for programs.
+ AC_PROG_INSTALL(install)
+ AC_PROG_CC

--- a/net-misc/socat/socat-1.7.4.4-r2.ebuild
+++ b/net-misc/socat/socat-1.7.4.4-r2.ebuild
@@ -1,0 +1,60 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools flag-o-matic toolchain-funcs
+
+MY_P=${P/_beta/-b}
+DESCRIPTION="Multipurpose relay (SOcket CAT)"
+HOMEPAGE="http://www.dest-unreach.org/socat/ https://repo.or.cz/socat.git"
+SRC_URI="http://www.dest-unreach.org/socat/download/${MY_P}.tar.bz2"
+S="${WORKDIR}/${MY_P}"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos"
+IUSE="ipv6 readline ssl tcpd"
+
+DEPEND="ssl? ( >=dev-libs/openssl-3:0= )
+	readline? ( sys-libs/readline:= )
+	tcpd? ( sys-apps/tcp-wrappers )"
+RDEPEND="${DEPEND}"
+
+# Tests are a large bash script
+# Hard to disable individual tests needing network or privileges
+# in 1.7.4.2: FAILED:  59 329
+RESTRICT="test"
+
+DOCS=( BUGREPORTS CHANGES DEVELOPMENT EXAMPLES FAQ FILES PORTING README SECURITY )
+
+PATCHES=(
+	"${FILESDIR}/${PN}-1.7.4.4-configure-gcc.patch"
+	"${FILESDIR}/${PN}-1.7.4.4-large-file-support.patch"
+)
+
+src_prepare() {
+	default
+
+	eautoreconf
+}
+
+src_configure() {
+	# bug #293324
+	filter-flags '-Wno-error*'
+
+	tc-export AR
+
+	econf \
+		$(use_enable ssl openssl) \
+		$(use_enable readline) \
+		$(use_enable ipv6 ip6) \
+		$(use_enable tcpd libwrap)
+}
+
+src_install() {
+	default
+
+	docinto html
+	dodoc doc/*.html doc/*.css
+}


### PR DESCRIPTION
This adds two patches, one to fix a cross-compilation issue, the other to enable large files support. These patches are also being submitted upstream.