### PR TITLE
sys-kernel/linux-firmware: 99999999 add app-misc/rdfind BDEPEND

### DIFF
--- a/sys-kernel/linux-firmware/linux-firmware-99999999.ebuild
+++ b/sys-kernel/linux-firmware/linux-firmware-99999999.ebuild
@@ -38,7 +38,8 @@ RESTRICT="binchecks strip test
 
 BDEPEND="initramfs? ( app-arch/cpio )
 	compress-xz? ( app-arch/xz-utils )
-	compress-zstd? ( app-arch/zstd )"
+	compress-zstd? ( app-arch/zstd )
+	app-misc/rdfind"
 
 #add anything else that collides to this
 RDEPEND="!savedconfig? (


### PR DESCRIPTION
It needs it, else build immediately fails.