### PR TITLE
app-misc/jaq: reduce minimal rust version to 1.63

### DIFF
--- a/app-misc/jaq/jaq-1.1.2.ebuild
+++ b/app-misc/jaq/jaq-1.1.2.ebuild
@@ -99,7 +99,7 @@ SLOT="0"
 KEYWORDS="~amd64"
 
 BDEPEND="
-	>=virtual/rust-1.72
+	>=virtual/rust-1.63
 "
 
 QA_FLAGS_IGNORED="usr/bin/jaq"


### PR DESCRIPTION
According to the [release notes of jaq v1.1.2](https://github.com/01mf02/jaq/releases/tag/v1.1.2), it builds at least with as low as rust version 1.63, which is what I set now.

I tested it to build with 1.71 (which is the latest stable version in gentoo) and there weren't any problems. I didn't test with 1.63, but if the maintainer of jaq says it works with that version, I trust that.

I have no idea where the old minimum version of 1.72 came from, I couldn't find any mention of that version in the jaq repo and there is no minimal version in the Cargo.toml. But I didn't want to add rust to the keywords on all my systems only to be able to install jaq, since it works with the stable rust version just as well.