### PR TITLE
dev-embedded/openocd: add libgpiod subslot dep

### DIFF
--- a/dev-embedded/openocd/openocd-0.12.0.ebuild
+++ b/dev-embedded/openocd/openocd-0.12.0.ebuild
@@ -27,6 +27,7 @@ RESTRICT="strip" # includes non-native binaries
 RDEPEND="
 	acct-group/plugdev
 	>=dev-lang/jimtcl-0.81:=
+	dev-libs/libgpiod:0/2
 	capstone? ( dev-libs/capstone )
 	cmsis-dap? ( dev-libs/hidapi )
 	jlink? ( >=dev-embedded/libjaylink-0.2.0 )


### PR DESCRIPTION
Upstream won't spend time on new libpgiod APIs on right now
ref: https://sourceforge.net/p/openocd/mailman/message/37389960/

Bug: https://bugs.gentoo.org/915709
