### PR TITLE
dev-libs/protobuf: Add protoc USE flag

### DIFF
--- a/dev-libs/protobuf/files/protobuf-23.3-export-mergefromimpl.patch
+++ b/dev-libs/protobuf/files/protobuf-23.3-export-mergefromimpl.patch
@@ -1,0 +1,48 @@
+https://github.com/protocolbuffers/protobuf/commit/e6f8b9d1026996f6463d4f014d7760256b757227
+
+message_lite.h: Use PROTOBUF_EXPORT_TEMPLATE_DECLARE with extern template
+
+Export extern templates in message_lite.h to avoid missing symbols when
+linking protobuf-lite.so.
+
+diff --git a/src/google/protobuf/message_lite.h b/src/google/protobuf/message_lite.h
+index 519aa10..ef7cd3d 100644
+--- a/src/google/protobuf/message_lite.h
++++ b/src/google/protobuf/message_lite.h
+@@ -535,20 +535,20 @@ namespace internal {
+ template <bool alias>
+ bool MergeFromImpl(absl::string_view input, MessageLite* msg,
+                    MessageLite::ParseFlags parse_flags);
+-extern template bool MergeFromImpl<false>(absl::string_view input,
++extern template PROTOBUF_EXPORT_TEMPLATE_DECLARE bool MergeFromImpl<false>(absl::string_view input,
+                                           MessageLite* msg,
+                                           MessageLite::ParseFlags parse_flags);
+-extern template bool MergeFromImpl<true>(absl::string_view input,
++extern template PROTOBUF_EXPORT_TEMPLATE_DECLARE bool MergeFromImpl<true>(absl::string_view input,
+                                          MessageLite* msg,
+                                          MessageLite::ParseFlags parse_flags);
+ 
+ template <bool alias>
+ bool MergeFromImpl(io::ZeroCopyInputStream* input, MessageLite* msg,
+                    MessageLite::ParseFlags parse_flags);
+-extern template bool MergeFromImpl<false>(io::ZeroCopyInputStream* input,
++extern template PROTOBUF_EXPORT_TEMPLATE_DECLARE bool MergeFromImpl<false>(io::ZeroCopyInputStream* input,
+                                           MessageLite* msg,
+                                           MessageLite::ParseFlags parse_flags);
+-extern template bool MergeFromImpl<true>(io::ZeroCopyInputStream* input,
++extern template PROTOBUF_EXPORT_TEMPLATE_DECLARE bool MergeFromImpl<true>(io::ZeroCopyInputStream* input,
+                                          MessageLite* msg,
+                                          MessageLite::ParseFlags parse_flags);
+ 
+@@ -560,9 +560,9 @@ struct BoundedZCIS {
+ template <bool alias>
+ bool MergeFromImpl(BoundedZCIS input, MessageLite* msg,
+                    MessageLite::ParseFlags parse_flags);
+-extern template bool MergeFromImpl<false>(BoundedZCIS input, MessageLite* msg,
++extern template PROTOBUF_EXPORT_TEMPLATE_DECLARE bool MergeFromImpl<false>(BoundedZCIS input, MessageLite* msg,
+                                           MessageLite::ParseFlags parse_flags);
+-extern template bool MergeFromImpl<true>(BoundedZCIS input, MessageLite* msg,
++extern template PROTOBUF_EXPORT_TEMPLATE_DECLARE bool MergeFromImpl<true>(BoundedZCIS input, MessageLite* msg,
+                                          MessageLite::ParseFlags parse_flags);
+ 
+ template <typename T>

--- a/dev-libs/protobuf/metadata.xml
+++ b/dev-libs/protobuf/metadata.xml
@@ -12,6 +12,9 @@
 	<slots>
 		<subslots>Soname version number</subslots>
 	</slots>
+	<use>
+		<flag name="system-protoc">Use the system copy of protoc vs building and providing it.</flag>
+	</use>
 	<upstream>
 		<remote-id type="cpe">cpe:/a:google:protobuf</remote-id>
 		<remote-id type="github">protocolbuffers/protobuf</remote-id>

--- a/dev-libs/protobuf/protobuf-23.3-r3.ebuild
+++ b/dev-libs/protobuf/protobuf-23.3-r3.ebuild
@@ -1,0 +1,123 @@
+# Copyright 2008-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit cmake-multilib elisp-common toolchain-funcs
+
+if [[ "${PV}" == *9999 ]]; then
+	inherit git-r3
+
+	EGIT_REPO_URI="https://github.com/protocolbuffers/protobuf.git"
+	EGIT_SUBMODULES=()
+else
+	SRC_URI="https://github.com/protocolbuffers/protobuf/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~loong ~mips ~ppc64 ~riscv ~sparc ~x86 ~amd64-linux ~x86-linux ~x64-macos"
+fi
+
+DESCRIPTION="Google's Protocol Buffers - Extensible mechanism for serializing structured data"
+HOMEPAGE="https://protobuf.dev/"
+
+LICENSE="BSD"
+SLOT="0/$(ver_cut 1-2).0"
+IUSE="emacs examples system-protoc test zlib"
+RESTRICT="!test? ( test )"
+
+BDEPEND="emacs? ( app-editors/emacs:* )"
+DEPEND="
+	>=dev-cpp/abseil-cpp-20230125.3:=[${MULTILIB_USEDEP}]
+	zlib? ( sys-libs/zlib[${MULTILIB_USEDEP}] )
+	test? ( >=dev-cpp/gtest-1.9[${MULTILIB_USEDEP}] )
+"
+RDEPEND="
+	>=dev-cpp/abseil-cpp-20230125.3:=[${MULTILIB_USEDEP}]
+	emacs? ( app-editors/emacs:* )
+	zlib? ( sys-libs/zlib[${MULTILIB_USEDEP}] )
+"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-23.3-disable-32-bit-tests.patch"
+	"${FILESDIR}/${PN}-23.3-static_assert-failure.patch"
+	"${FILESDIR}/${PN}-23.3-export-mergefromimpl.patch"
+)
+
+DOCS=( CONTRIBUTORS.txt README.md )
+
+src_configure() {
+	# Enable large file support.
+	append-lfs-flags
+
+	if tc-ld-is-gold; then
+		# https://sourceware.org/bugzilla/show_bug.cgi?id=24527
+		tc-ld-disable-gold
+	fi
+
+	cmake-multilib_src_configure
+}
+
+multilib_src_configure() {
+	local mycmakeargs=(
+		-Dprotobuf_DISABLE_RTTI=ON
+		-Dprotobuf_BUILD_EXAMPLES=$(usex examples)
+		-Dprotobuf_WITH_ZLIB=$(usex zlib)
+		-Dprotobuf_BUILD_TESTS=$(usex test)
+		-Dprotobuf_BUILD_PROTOC_BINARIES=$(usex system-protoc OFF ON)
+		-Dprotobuf_BUILD_LIBPROTOC=$(usex system-protoc OFF ON)
+		-Dprotobuf_USE_EXTERNAL_GTEST=ON
+		-Dprotobuf_ABSL_PROVIDER=package
+	)
+	if tc-is-cross-compiler || use system-protoc; then
+		mycmakeargs+=(
+			-DWITH_PROTOC=protoc
+		)
+	else
+		mycmakeargs+=(
+			-DWITH_PROTOC=0
+		)
+	fi
+
+	cmake_src_configure
+}
+
+src_compile() {
+	cmake-multilib_src_compile
+
+	if use emacs; then
+		elisp-compile editors/protobuf-mode.el
+	fi
+}
+
+multilib_src_install_all() {
+	find "${ED}" -name "*.la" -delete || die
+
+	if [[ ! -f "${ED}/usr/$(get_libdir)/libprotobuf.so.${SLOT#*/}" ]]; then
+		eerror "No matching library found with SLOT variable, currently set: ${SLOT}\n" \
+			"Expected value: ${ED}/usr/$(get_libdir)/libprotobuf.so.${SLOT#*/}"
+		die "Please update SLOT variable"
+	fi
+
+	insinto /usr/share/vim/vimfiles/syntax
+	doins editors/proto.vim
+	insinto /usr/share/vim/vimfiles/ftdetect
+	doins "${FILESDIR}/proto.vim"
+
+	if use emacs; then
+		elisp-install ${PN} editors/protobuf-mode.el*
+		elisp-site-file-install "${FILESDIR}/70${PN}-gentoo.el"
+	fi
+
+	if use examples; then
+		DOCS+=(examples)
+		docompress -x /usr/share/doc/${PF}/examples
+	fi
+
+	einstalldocs
+}
+
+pkg_postinst() {
+	use emacs && elisp-site-regen
+}
+
+pkg_postrm() {
+	use emacs && elisp-site-regen
+}


### PR DESCRIPTION
* Add a protoc USE flag to control whether protoc is installed. This is primarly useful when cross compiling
* Add large-file-support flags.
* Do not conditionally set protobuf_USE_EXTERNAL_GTEST.
* Apply upstream patch to resolve missing MergeFromImpl symbols.

Closes: https://bugs.gentoo.org/917303
Closes: https://bugs.gentoo.org/896086
Closes: https://bugs.gentoo.org/917046