### PR TITLE
app-alternatives/pinentry: new package to manage pinentry symlink

### DIFF
--- a/app-alternatives/pinentry/metadata.xml
+++ b/app-alternatives/pinentry/metadata.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="project">
+		<email>base-system@gentoo.org</email>
+		<name>Gentoo Base System</name>
+	</maintainer>
+	<maintainer type="person">
+		<email>vimproved@inventati.org</email>
+		<name>Violet Purcell</name>
+	</maintainer>
+	<use>
+		<flag name="pinentry-efl">Symlink to pinentry-efl</flag>
+		<flag name="pinentry-gnome3">Symlink to pinentry-gnome3</flag>
+		<flag name="pinentry-curses">Symlink to pinentry-curses</flag>
+		<flag name="pinentry-qt5">Symlink to pinentry-qt5</flag>
+		<flag name="pinentry-tty">Symlink to pinentry-tty</flag>
+	</use>
+</pkgmetadata>

--- a/app-alternatives/pinentry/pinentry-1.ebuild
+++ b/app-alternatives/pinentry/pinentry-1.ebuild
@@ -1,0 +1,21 @@
+# Copyright 2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+ALTERNATIVES=(
+	"pinentry-curses:app-crypt/pinentry[ncurses]"
+	"pinentry-gnome3:app-crypt/pinentry[gtk]"
+	"pinentry-qt5:app-crypt/pinentry[qt5]"
+	"pinentry-efl:app-crypt/pinentry[efl]"
+	"pinentry-tty:app-crypt/pinentry"
+)
+
+inherit app-alternatives
+
+DESCRIPTION="pinentry symlinks"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~arm64-macos ~ppc-macos ~x64-macos ~x64-solaris"
+
+src_install() {
+	dosym $(get_alternative) /usr/bin/pinentry
+}

--- a/app-crypt/pinentry/pinentry-1.2.1-r4.ebuild
+++ b/app-crypt/pinentry/pinentry-1.2.1-r4.ebuild
@@ -1,0 +1,99 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/openpgp-keys/gnupg.asc
+inherit autotools qmake-utils verify-sig
+
+DESCRIPTION="Simple passphrase entry dialogs which utilize the Assuan protocol"
+HOMEPAGE="https://gnupg.org/aegypten2"
+SRC_URI="mirror://gnupg/${PN}/${P}.tar.bz2"
+SRC_URI+=" verify-sig? ( mirror://gnupg/${PN}/${P}.tar.bz2.sig )"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~arm64-macos ~ppc-macos ~x64-macos ~x64-solaris"
+IUSE="caps efl emacs gtk keyring ncurses qt5 wayland X"
+
+DEPEND="
+	>=dev-libs/libassuan-2.1
+	>=dev-libs/libgcrypt-1.6.3
+	>=dev-libs/libgpg-error-1.17
+	efl? ( dev-libs/efl[X] )
+	keyring? ( app-crypt/libsecret )
+	ncurses? ( sys-libs/ncurses:= )
+	qt5? (
+		dev-qt/qtcore:5
+		dev-qt/qtgui:5
+		dev-qt/qtwidgets:5
+		wayland? ( kde-frameworks/kwayland:5 )
+		X? (
+			dev-qt/qtx11extras:5
+			x11-libs/libX11
+		)
+	)
+"
+RDEPEND="
+	${DEPEND}
+	gtk? ( app-crypt/gcr:0[gtk] )
+"
+BDEPEND="
+	sys-devel/gettext
+	virtual/pkgconfig
+	verify-sig? ( sec-keys/openpgp-keys-gnupg )
+"
+PDEPEND="app-alternatives/pinentry"
+
+DOCS=( AUTHORS ChangeLog NEWS README THANKS TODO )
+
+PATCHES=(
+	"${FILESDIR}/${PN}-1.0.0-AR.patch"
+	"${FILESDIR}/${PN}-1.2.1-automagic-capslock.patch" # bug #819939, bug #837719
+)
+
+src_prepare() {
+	default
+
+	unset FLTK_CONFIG
+
+	eautoreconf
+}
+
+src_configure() {
+	export PATH="$(qt5_get_bindir):${PATH}"
+	export QTLIB="$(qt5_get_libdir)"
+
+	local myeconfargs=(
+		$(use_enable efl pinentry-efl)
+		$(use_enable emacs pinentry-emacs)
+		$(use_enable keyring libsecret)
+		$(use_enable gtk pinentry-gnome3)
+		$(use_enable ncurses fallback-curses)
+		$(use_enable ncurses pinentry-curses)
+		$(use_enable qt5 pinentry-qt)
+		$(use_enable wayland kf5-wayland)
+		$(use_enable X qtx11extras)
+		$(use_with X x)
+
+		--enable-pinentry-tty
+		--disable-pinentry-fltk
+		--disable-pinentry-gtk2
+
+		MOC="$(qt5_get_bindir)"/moc
+		GPG_ERROR_CONFIG="${ESYSROOT}"/usr/bin/${CHOST}-gpg-error-config
+		LIBASSUAN_CONFIG="${ESYSROOT}"/usr/bin/libassuan-config
+
+		$("${S}/configure" --help | grep -- '--without-.*-prefix' | sed -e 's/^ *\([^ ]*\) .*/\1/g')
+	)
+
+	econf "${myeconfargs[@]}"
+}
+
+src_install() {
+	default
+
+	rm "${ED}"/usr/bin/pinentry || die
+
+	use qt5 && dosym pinentry-qt /usr/bin/pinentry-qt5
+}

--- a/profiles/arch/hppa/package.use.mask
+++ b/profiles/arch/hppa/package.use.mask
@@ -111,6 +111,7 @@ sci-mathematics/octave sundials
 
 # Matt Turner <mattst88@gentoo.org> (2022-05-07)
 # app-crypt/gcr is not keyworded
+app-alternatives/pinentry pinentry-gnome3
 app-crypt/pinentry gtk
 dev-libs/libgdata crypt
 

--- a/profiles/arch/ia64/package.use.mask
+++ b/profiles/arch/ia64/package.use.mask
@@ -1,6 +1,10 @@
 # Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Violet Purcell <vimproved@inventati.org> (2023-11-13)
+# qt5 is not keyworded here.
+app-alternatives/pinentry pinentry-qt5
+
 # Violet Purcell <vimproved@inventati.org> (2023-10-12)
 # dev-util/samurai is not keyworded here.
 app-alternatives/ninja samurai
@@ -169,6 +173,7 @@ dev-lang/php avif
 # dev-libs/efl not keyworded here
 # and is a desktop application mainly
 # bug #773178
+app-alternatives/pinentry pinentry-efl
 app-crypt/pinentry efl
 
 # Joonas Niilola <juippis@gentoo.org> (2021-01-15)

--- a/profiles/arch/s390/package.use.mask
+++ b/profiles/arch/s390/package.use.mask
@@ -1,6 +1,10 @@
 # Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Violet Purcell <vimproved@inventati.org> (2023-11-13)
+# GTK and QT are not keyworded here.
+app-alternatives/pinentry pinentry-gnome3 pinentry-qt5
+
 # Michał Górny <mgorny@gentoo.org> (2023-10-15)
 # Need dev-python/notebook (that indirectly requires net-libs/nodejs).
 dev-python/ipython notebook

--- a/profiles/arch/s390/package.use.mask
+++ b/profiles/arch/s390/package.use.mask
@@ -102,6 +102,7 @@ dev-libs/gobject-introspection doctool
 
 # Sam James <sam@gentoo.org> (2022-04-24)
 # dev-libs/efl not keyworded here and is a desktop application mainly
+app-alternatives/pinentry pinentry-efl
 app-crypt/pinentry efl
 
 # Sam James <sam@gentoo.org> (2022-04-24)

--- a/profiles/arch/sparc/package.use.mask
+++ b/profiles/arch/sparc/package.use.mask
@@ -1,6 +1,10 @@
 # Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Violet Purcell <vimproved@inventati.org> (2023-11-13)
+# Qt5 is not keyworded here.
+app-alternatives/pinentry pinentry-qt5
+
 # Michał Górny <mgorny@gentoo.org> (2023-10-22)
 # This is not ISDN CAPI, so unmask it.
 media-video/rav1e -capi
@@ -237,6 +241,7 @@ dev-lang/php avif
 # dev-libs/efl not keyworded here
 # and is a desktop application mainly
 # bug #773178
+app-alternatives/pinentry pinentry-efl
 app-crypt/pinentry efl
 
 # Joonas Niilola <juippis@gentoo.org> (2021-01-15)


### PR DESCRIPTION
Replaces eselect-pinentry in line with the goal of replacing eselect modules that modify files outside of /etc.