### PR TITLE
media-sound/ncmpcpp: Include upstream patch to genius lyrics

### DIFF
--- a/media-sound/ncmpcpp/files/ncmpcpp-genius-lyrics.patch
+++ b/media-sound/ncmpcpp/files/ncmpcpp-genius-lyrics.patch
@@ -1,0 +1,13 @@
+diff --git a/src/lyrics_fetcher.h b/src/lyrics_fetcher.h
+index dd08939d..672352ff 100644
+--- a/src/lyrics_fetcher.h
++++ b/src/lyrics_fetcher.h
+@@ -118,7 +118,7 @@ struct GeniusFetcher : public GoogleLyricsFetcher
+ 	virtual const char *name() const override { return "genius.com"; }
+ 
+ protected:
+-	virtual const char *regex() const override { return "<div class=\"[Ll]yrics.*?>(.*?)</div>"; }
++	virtual const char *regex() const override { return "<div.*?class=\"(?:lyrics|Lyrics__Container).*?>(.*?)</div>"; }
+ };
+ 
+ struct JahLyricsFetcher : public GoogleLyricsFetcher

--- a/media-sound/ncmpcpp/ncmpcpp-0.9.2-r4.ebuild
+++ b/media-sound/ncmpcpp/ncmpcpp-0.9.2-r4.ebuild
@@ -1,0 +1,72 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit autotools flag-o-matic
+
+DESCRIPTION="featureful ncurses based MPD client inspired by ncmpc"
+HOMEPAGE="https://ncmpcpp.rybczak.net/ https://github.com/ncmpcpp/ncmpcpp"
+SRC_URI="https://rybczak.net/ncmpcpp/stable/${P}.tar.bz2"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~sparc ~x86"
+IUSE="clock lto outputs taglib visualizer"
+
+RDEPEND="
+	>=media-libs/libmpdclient-2.1
+	dev-libs/boost:=[icu,nls]
+	dev-libs/icu:=
+	net-misc/curl
+	sys-libs/ncurses:=[unicode(+)]
+	sys-libs/readline:=
+	taglib? ( media-libs/taglib )
+	visualizer? ( sci-libs/fftw:3.0= )
+"
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-taglib-pc.patch"
+	"${FILESDIR}/${PN}-genius-lyrics.patch"
+)
+
+src_prepare() {
+	default
+	eautoreconf
+
+	sed -i -e '/^docdir/d' {,doc/}Makefile{.am,.in} || die
+	sed -i -e 's|COPYING||g' Makefile{.am,.in} || die
+}
+
+src_configure() {
+	filter-lto
+
+	econf \
+		$(use_enable clock) \
+		$(use_enable outputs) \
+		$(use_enable visualizer) \
+		$(use_with lto) \
+		$(use_with taglib) \
+		$(use_with visualizer fftw)
+}
+
+src_install() {
+	default
+
+	dodoc doc/{bindings,config}
+}
+
+pkg_postinst() {
+	echo
+	elog "Example configuration files have been installed at"
+	elog "${EROOT}/usr/share/doc/${PF}"
+	elog "${P} uses ~/.ncmpcpp/config and ~/.ncmpcpp/bindings"
+	elog "as user configuration files."
+	echo
+	if use visualizer; then
+	elog "If you want to use the visualizer, you need mpd with fifo enabled."
+	echo
+	fi
+}


### PR DESCRIPTION
The master branch has had this fix to lyric fetching from Genius for about 2 years: github.com/ncmpcpp/ncmpcpp/commit/df1c4d7

The patch works, but no new version has been pushed since that commit, so this is just a backport of that fix.