### PR TITLE
media-libs/noise-suppression-for-voice: require at least one enabled plugin

### DIFF
--- a/media-libs/noise-suppression-for-voice/noise-suppression-for-voice-1.03.ebuild
+++ b/media-libs/noise-suppression-for-voice/noise-suppression-for-voice-1.03.ebuild
@@ -18,7 +18,9 @@ fi
 
 LICENSE="GPL-3+"
 SLOT="0"
+
 IUSE="+ladspa lv2 vst vst3"
+REQUIRED_USE="|| ( ladspa lv2 vst vst3 )"
 
 COMMON_DEPEND="
 	media-libs/freetype

--- a/media-libs/noise-suppression-for-voice/noise-suppression-for-voice-9999.ebuild
+++ b/media-libs/noise-suppression-for-voice/noise-suppression-for-voice-9999.ebuild
@@ -18,7 +18,9 @@ fi
 
 LICENSE="GPL-3+"
 SLOT="0"
+
 IUSE="+ladspa lv2 vst vst3"
+REQUIRED_USE="|| ( ladspa lv2 vst vst3 )"
 
 COMMON_DEPEND="
 	media-libs/freetype


### PR DESCRIPTION
If no plugins are enabled, the package offers no files to install, in which case CMake doesn't generate an `install` target.