### PR TITLE
app-misc/fsniper: EAPI8 bump, fix LICENSE

### DIFF
--- a/app-misc/fsniper/fsniper-1.3.1-r2.ebuild
+++ b/app-misc/fsniper/fsniper-1.3.1-r2.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
 
 inherit autotools
 
@@ -9,7 +9,7 @@ DESCRIPTION="Monitors a given set of directories for new files"
 HOMEPAGE="https://github.com/l3ib/fsniper"
 SRC_URI="http://projects.l3ib.org/${PN}/files/${P}.tar.gz"
 
-LICENSE="GPL-2"
+LICENSE="GPL-3+"
 SLOT="0"
 KEYWORDS="amd64 x86"
 
@@ -31,8 +31,4 @@ DOCS=( AUTHORS COPYING NEWS README example.conf )
 src_prepare() {
 	default
 	eautoreconf
-}
-
-src_install() {
-	default
 }


### PR DESCRIPTION
Simple `EAPI8` bump, also fixes `LICENSE`, which is `GPL-3+`