### PR TITLE
app-misc/hilite: EAPI8 bump, fix LICENSE

### DIFF
--- a/app-misc/hilite/hilite-1.5-r1.ebuild
+++ b/app-misc/hilite/hilite-1.5-r1.ebuild
@@ -1,31 +1,25 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
 
-inherit toolchain-funcs
+inherit edo toolchain-funcs
 
-DESCRIPTION="A utility which highlights stderr text in red"
+DESCRIPTION="Utility which highlights stderr text in red"
 HOMEPAGE="https://sourceforge.net/projects/hilite"
 SRC_URI="mirror://gentoo/${P}.c"
+S="${WORKDIR}"
 
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="0"
 KEYWORDS="amd64 ~hppa ~ia64 ~mips ppc sparc x86 ~amd64-linux ~x86-linux ~ppc-macos"
 
-S="${WORKDIR}"
-
-src_unpack() { :; }
-
-src_prepare() {
-	default
-	cp "${DISTDIR}"/${P}.c "${WORKDIR}"/ || die
+src_unpack() {
+	cp "${DISTDIR}"/${P}.c ${P}.c || die
 }
 
 src_compile() {
-	ebegin "$(tc-getCC) ${LDFLAGS} ${CFLAGS} -o ${PN} ${P}.c"
-	$(tc-getCC) ${LDFLAGS} ${CFLAGS} -o ${PN} ${P}.c || die
-	eend $?
+	edo $(tc-getCC) ${LDFLAGS} ${CFLAGS} -o ${PN} ${P}.c || die
 }
 
 src_install() {


### PR DESCRIPTION
Another simple `EAPI8` bump, which also fixes `LICENSE` and simplifying the ebuild a bit.