### PR TITLE
app-misc/ondir: EAPI8 bump

### DIFF
--- a/app-misc/ondir/ondir-0.2.4.ebuild
+++ b/app-misc/ondir/ondir-0.2.4.ebuild
@@ -1,20 +1,17 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
 
 inherit toolchain-funcs
 
 DESCRIPTION="Automatically execute scripts as you traverse directories"
-HOMEPAGE="http://swapoff.org/OnDir"
-SRC_URI="http://swapoff.org/files/${PN}/${P}.tar.gz"
+HOMEPAGE="https://swapoff.org/OnDir"
+SRC_URI="https://swapoff.org/files/${PN}/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="amd64 ppc x86 ~amd64-linux ~x86-linux ~ppc-macos"
-
-DEPEND="sys-apps/sed"
-RDEPEND="${DEPEND}"
 
 DOCS=( AUTHORS ChangeLog INSTALL scripts.tcsh scripts.sh )
 


### PR DESCRIPTION
`EAPI8` bump, and uses `https` instead of `http`.
I've also removed the `sys-apps/sed` dependency since it's a system package anyway and afacis not used by the package. Guess it was there because of the `sed` in `src_prepare`