### PR TITLE
kernel-build.eclass: copy module signing key to tempdir in pkg_setup

### DIFF
--- a/eclass/kernel-build.eclass
+++ b/eclass/kernel-build.eclass
@@ -114,6 +114,13 @@ kernel-build_pkg_setup() {
 	python-any-r1_pkg_setup
 	if [[ ${KERNEL_IUSE_MODULES_SIGN} ]]; then
 		secureboot_pkg_setup
+		if [[ -e ${MODULES_SIGN_KEY} && ${MODULES_SIGN_KEY} != pkcs11:* ]]; then
+			if [[ -e ${MODULES_SIGN_CERT} && ${MODULES_SIGN_CERT} != ${MODULES_SIGN_KEY} ]]; then
+				export MODULES_SIGN_KEY_CONTENTS="$(cat "${MODULES_SIGN_CERT}" "${MODULES_SIGN_KEY}")"
+			else
+				export MODULES_SIGN_KEY_CONTENTS="$(< "${MODULES_SIGN_KEY}")"
+			fi
+		fi
 	fi
 }
 
@@ -427,12 +434,12 @@ kernel-build_merge_configs() {
 				CONFIG_MODULE_SIG_FORCE=y
 				CONFIG_MODULE_SIG_${MODULES_SIGN_HASH^^}=y
 			EOF
-			if [[ -e ${MODULES_SIGN_KEY} && -e ${MODULES_SIGN_CERT} &&
-				${MODULES_SIGN_KEY} != ${MODULES_SIGN_CERT} &&
-				${MODULES_SIGN_KEY} != pkcs11:* ]]
-			then
-				cat "${MODULES_SIGN_CERT}" "${MODULES_SIGN_KEY}" > "${T}/kernel_key.pem" || die
-				MODULES_SIGN_KEY="${T}/kernel_key.pem"
+			if [[ -n "${MODULES_SIGN_KEY_CONTENTS}" ]]; then
+				touch "${T}/kernel_key.pem" || die
+				chmod 0600 "${T}/kernel_key.pem" || die
+				echo "${MODULES_SIGN_KEY_CONTENTS}" > "${T}/kernel_key.pem" || die
+				unset MODULES_SIGN_KEY_CONTENTS
+				export MODULES_SIGN_KEY="${T}/kernel_key.pem"
 			fi
 			if [[ ${MODULES_SIGN_KEY} == pkcs11:* || -r ${MODULES_SIGN_KEY} ]]; then
 				echo "CONFIG_MODULE_SIG_KEY=\"${MODULES_SIGN_KEY}\"" \


### PR DESCRIPTION
Previously, it was being copied in src_prepare, and thus would fail if the signing key was not readable by portage:portage. This commit makes kernel-build.eclass instead copy the signing key in pkg_setup, and then correct the permissions.