### PR TITLE
kde-apps/okular: Set ECM_TESTS to true

### DIFF
--- a/kde-apps/okular/okular-23.04.3.ebuild
+++ b/kde-apps/okular/okular-23.04.3.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 ECM_HANDBOOK="optional"
-ECM_TEST="forceoptional"
+ECM_TEST="true"
 PVCUT=$(ver_cut 1-3)
 KFMIN=5.106.0
 QTMIN=5.15.9

--- a/kde-apps/okular/okular-23.08.3.ebuild
+++ b/kde-apps/okular/okular-23.08.3.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 ECM_HANDBOOK="optional"
-ECM_TEST="forceoptional"
+ECM_TEST="true"
 PVCUT=$(ver_cut 1-3)
 KFMIN=5.106.0
 QTMIN=5.15.9


### PR DESCRIPTION
Prevents CMake configuration failure because some tests are not put behind a build flag, but still want to use Qt5::Test.