### PR TITLE
net-irc/soju: pass -D_LARGEFILE64_SOURCE for musl-1.2.4

### DIFF
--- a/net-irc/soju/soju-0.6.2.ebuild
+++ b/net-irc/soju/soju-0.6.2.ebuild
@@ -26,19 +26,22 @@ RDEPEND="
 DEPEND="${RDEPEND}"
 
 src_compile() {
-	# musl removed legacy LFS64 interfaces in version 1.2.4
-	# temporarily reenabled using _LARGEFILE64_SOURCE until
-	# this is resolved upstream
-	# https://github.com/mattn/go-sqlite3/issues/1164
-	append-cflags "-D_LARGEFILE64_SOURCE"
-
+	# musl removed legacy LFS64 interfaces in version 1.2.4 temporarily
+	# reenabled using _LARGEFILE64_SOURCE until this is resolved
+	# upstream https://github.com/mattn/go-sqlite3/issues/1164
+	CGO_CFLAGS="${CGO_CFLAGS}"
 	if use sqlite; then
 		GOFLAGS+=" -tags=libsqlite3"
+		CGO_CFLAGS="-D_LARGEFILE64_SOURCE"
 	elif use moderncsqlite; then
 		GOFLAGS+=" -tags=moderncsqlite"
+		CGO_CFLAGS="-D_LARGEFILE64_SOURCE"
 	else
 		GOFLAGS+=" -tags=nosqlite"
 	fi
+	# Only way to pass CFLAGS to CGO at the
+	# moment. https://github.com/gentoo/gentoo/pull/33539/
+	export CGO_CFLAGS
 	use pam && GOFLAGS+=" -tags=pam"
 
 	ego build ${GOFLAGS} ./cmd/soju


### PR DESCRIPTION
See-also: https://github.com/mattn/go-sqlite3/issues/1164
Closes: https://bugs.gentoo.org/912311