### PR TITLE
x11-misc/xkeyboard-config: add missing test dependencies

### DIFF
--- a/x11-misc/xkeyboard-config/xkeyboard-config-2.40-r1.ebuild
+++ b/x11-misc/xkeyboard-config/xkeyboard-config-2.40-r1.ebuild
@@ -14,7 +14,7 @@ if [[ ${PV} == 9999 ]]; then
 	inherit git-r3
 else
 	SRC_URI="https://www.x.org/releases/individual/data/${PN}/${P}.tar.xz"
-	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~ia64 ~m68k ~mips ~ppc ~riscv ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
 fi
 
 LICENSE="MIT"


### PR DESCRIPTION
* New revision due to plenty dropped keywords
* pytest-xdist is used if available, make it requirement so that everybody benefits.
* Disabled timeout for pytest tests. Observed it already take 40s with xdist and a 12 thread cpu, so you can't trust it to not fail due to high load congestion.

Closes: https://bugs.gentoo.org/917479