### PR TITLE
dev-lang/zig: add `llvm` USE-flag for 9999

### DIFF
--- a/dev-lang/zig/metadata.xml
+++ b/dev-lang/zig/metadata.xml
@@ -9,6 +9,9 @@
 		<email>proxy-maint@gentoo.org</email>
 		<name>Proxy Maintainers</name>
 	</maintainer>
+	<use>
+		<flag name="llvm">Build with LLVM backend and extensions enabled.</flag>
+	</use>
 	<upstream>
 		<remote-id type="github">ziglang/zig</remote-id>
 		<bugs-to>https://github.com/ziglang/zig/issues</bugs-to>


### PR DESCRIPTION
See upstream PRs https://www.github.com/ziglang/zig/pull/17892 and https://www.github.com/ziglang/zig/pull/17994 .

LLVM-less build cannot build `sys-fs/ncdu` yet (no @cImport support), but we are close.