### PR TITLE
net-wireless/iwd: add USE=selinux

### DIFF
--- a/net-wireless/iwd/iwd-2.3.ebuild
+++ b/net-wireless/iwd/iwd-2.3.ebuild
@@ -22,7 +22,7 @@ HOMEPAGE="https://git.kernel.org/pub/scm/network/wireless/iwd.git/"
 
 LICENSE="GPL-2"
 SLOT="0"
-IUSE="+client cpu_flags_x86_aes cpu_flags_x86_ssse3 crda +monitor ofono standalone systemd wired"
+IUSE="+client cpu_flags_x86_aes cpu_flags_x86_ssse3 crda +monitor ofono selinux standalone systemd wired"
 
 DEPEND="
 	sys-apps/dbus
@@ -36,6 +36,7 @@ RDEPEND="
 	acct-group/netdev
 	net-wireless/wireless-regdb
 	crda? ( net-wireless/crda )
+	selinux? ( sec-policy/selinux-networkmanager )
 	standalone? (
 		systemd? ( sys-apps/systemd )
 		!systemd? ( virtual/resolvconf )

--- a/net-wireless/iwd/iwd-2.4.ebuild
+++ b/net-wireless/iwd/iwd-2.4.ebuild
@@ -22,7 +22,7 @@ HOMEPAGE="https://git.kernel.org/pub/scm/network/wireless/iwd.git/"
 
 LICENSE="GPL-2"
 SLOT="0"
-IUSE="+client cpu_flags_x86_aes cpu_flags_x86_ssse3 crda +monitor ofono standalone systemd wired"
+IUSE="+client cpu_flags_x86_aes cpu_flags_x86_ssse3 crda +monitor ofono selinux standalone systemd wired"
 
 DEPEND="
 	sys-apps/dbus
@@ -36,6 +36,7 @@ RDEPEND="
 	acct-group/netdev
 	net-wireless/wireless-regdb
 	crda? ( net-wireless/crda )
+	selinux? ( sec-policy/selinux-networkmanager )
 	standalone? (
 		systemd? ( sys-apps/systemd )
 		!systemd? ( virtual/resolvconf )

--- a/net-wireless/iwd/iwd-2.8-r2.ebuild
+++ b/net-wireless/iwd/iwd-2.8-r2.ebuild
@@ -22,7 +22,7 @@ HOMEPAGE="https://git.kernel.org/pub/scm/network/wireless/iwd.git/"
 
 LICENSE="GPL-2"
 SLOT="0"
-IUSE="+client cpu_flags_x86_aes cpu_flags_x86_ssse3 +monitor ofono standalone systemd wired"
+IUSE="+client cpu_flags_x86_aes cpu_flags_x86_ssse3 +monitor ofono selinux standalone systemd wired"
 
 DEPEND="
 	sys-apps/dbus
@@ -35,6 +35,7 @@ RDEPEND="
 	${DEPEND}
 	acct-group/netdev
 	net-wireless/wireless-regdb
+	selinux? ( sec-policy/selinux-networkmanager )
 	standalone? (
 		systemd? ( sys-apps/systemd )
 		!systemd? ( virtual/resolvconf )

--- a/net-wireless/iwd/iwd-9999.ebuild
+++ b/net-wireless/iwd/iwd-9999.ebuild
@@ -22,7 +22,7 @@ HOMEPAGE="https://git.kernel.org/pub/scm/network/wireless/iwd.git/"
 
 LICENSE="GPL-2"
 SLOT="0"
-IUSE="+client cpu_flags_x86_aes cpu_flags_x86_ssse3 +monitor ofono standalone systemd wired"
+IUSE="+client cpu_flags_x86_aes cpu_flags_x86_ssse3 +monitor ofono selinux standalone systemd wired"
 
 DEPEND="
 	sys-apps/dbus
@@ -35,6 +35,7 @@ RDEPEND="
 	${DEPEND}
 	acct-group/netdev
 	net-wireless/wireless-regdb
+	selinux? ( sec-policy/selinux-networkmanager )
 	standalone? (
 		systemd? ( sys-apps/systemd )
 		!systemd? ( virtual/resolvconf )


### PR DESCRIPTION
```
SELinux:  Context system_u:object_r:NetworkManager_etc_t is not valid (left unmapped).
SELinux:  Context system_u:object_r:NetworkManager_etc_rw_t is not valid (left unmapped).
```

no revbump based on previous commits adding this useflag (like 1bf83bcb2351c75602b07f4b339d8e64d30ecbd8 )