### PR TITLE
profiles: mask <sys-devel/gcc-11 (GCC 10 is EOL)

### DIFF
--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -486,10 +486,11 @@ sys-cluster/slurm
 dev-haskell/doctest-parallel
 
 # Sam James <sam@gentoo.org> (2022-05-28)
-# GCC 9 and older no longer receive upstream support or fixes for
+# GCC 10 and older no longer receive upstream support or fixes for
 # bugs. Please switch to a newer GCC version using gcc-config.
-# The lowest supported version of GCC is GCC 10.
-<sys-devel/gcc-10
+# The lowest supported version of GCC is GCC 11.
+<sys-devel/gcc-11
+<sys-devel/kgcc64-11
 
 # Joonas Niilola <juippis@gentoo.org> (2022-04-29)
 # Apparently the "b" in version means "beta". 3.24 is available, we


### PR DESCRIPTION
GCC 10 is EOL - it has been since GCC 10.5 was released in July.

It's hard to get the balance right here - if we mask immediately on the release of .5 of a series, some people aren't happy, and it's indeed kind of a nuisance for stabling the last version of a series too. (I did it the day-of for 9.5.x and had some feedback on it from users.)

In any case, by now, it's certainly overdue. Move to GCC 11 or newer, please.

Bug: https://bugs.gentoo.org/917507