### PR TITLE
www-client/seamonkey: add rust upper bound requirement

### DIFF
--- a/www-client/seamonkey/seamonkey-2.53.17.1.ebuild
+++ b/www-client/seamonkey/seamonkey-2.53.17.1.ebuild
@@ -75,7 +75,7 @@ BDEPEND="
 		)
 	)
 	virtual/pkgconfig
-	virtual/rust
+	<virtual/rust-1.73.0
 	amd64? ( >=dev-lang/yasm-1.1 )
 	lto? ( sys-devel/binutils[gold] )
 	x86? ( >=dev-lang/yasm-1.1 )

--- a/www-client/seamonkey/seamonkey-2.53.17.ebuild
+++ b/www-client/seamonkey/seamonkey-2.53.17.ebuild
@@ -74,7 +74,7 @@ BDEPEND="
 		)
 	)
 	virtual/pkgconfig
-	virtual/rust
+	<virtual/rust-1.73.0
 	amd64? ( >=dev-lang/yasm-1.1 )
 	lto? ( sys-devel/binutils[gold] )
 	x86? ( >=dev-lang/yasm-1.1 )


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/916304

www-client/seamonkey currently doesn't build with rust-1.73.0 or newer