### PR TITLE
mail-client/neomutt: Add use flag for Lua scripting support

### DIFF
--- a/mail-client/neomutt/neomutt-20231103.ebuild
+++ b/mail-client/neomutt/neomutt-20231103.ebuild
@@ -3,7 +3,9 @@
 
 EAPI=8
 
-inherit flag-o-matic toolchain-funcs
+LUA_COMPAT=( lua5-{2..4} )
+
+inherit flag-o-matic toolchain-funcs lua-single
 
 if [[ ${PV} =~ 99999999$ ]]; then
 	inherit git-r3
@@ -21,11 +23,12 @@ HOMEPAGE="https://neomutt.org/"
 
 LICENSE="GPL-2"
 SLOT="0"
-IUSE="autocrypt berkdb doc gdbm gnutls gpgme idn kerberos kyotocabinet lmdb lz4
-	nls notmuch pgp-classic qdbm sasl selinux smime-classic ssl tokyocabinet
+IUSE="autocrypt berkdb doc gdbm gnutls gpgme idn kerberos kyotocabinet lmdb lua
+	lz4 nls notmuch pgp-classic qdbm sasl selinux smime-classic ssl tokyocabinet
 	test zlib zstd"
 REQUIRED_USE="
-	autocrypt? ( gpgme )"
+	autocrypt? ( gpgme )
+	lua? ( ${LUA_REQUIRED_USE} )"
 
 CDEPEND="
 	app-misc/mime-types
@@ -46,6 +49,7 @@ CDEPEND="
 	autocrypt? ( >=dev-db/sqlite-3 )
 	idn? ( net-dns/libidn2:= )
 	kerberos? ( virtual/krb5 )
+	lua? ( ${LUA_DEPS} )
 	notmuch? ( net-mail/notmuch:= )
 	sasl? ( >=dev-libs/cyrus-sasl-2 )
 	ssl? ( >=dev-libs/openssl-1.0.2u:0= )
@@ -72,6 +76,10 @@ RDEPEND="${CDEPEND}
 "
 
 RESTRICT="!test? ( test )"
+
+pkg_setup() {
+	use lua && lua-single_pkg_setup
+}
 
 src_unpack() {
 	if [[ -n ${A} ]]; then
@@ -109,6 +117,7 @@ src_configure() {
 		"$(use_enable idn idn2)"
 		"$(use_enable kerberos gss)"
 		"$(use_enable lmdb)"
+		"$(use_enable lua)"
 		"$(use_enable sasl)"
 		"--sysconfdir=${EPREFIX}/etc/${PN}"
 		"$(use_enable ssl)"

--- a/mail-client/neomutt/neomutt-99999999.ebuild
+++ b/mail-client/neomutt/neomutt-99999999.ebuild
@@ -3,7 +3,9 @@
 
 EAPI=8
 
-inherit flag-o-matic toolchain-funcs
+LUA_COMPAT=( lua5-{2..4} )
+
+inherit flag-o-matic toolchain-funcs lua-single
 
 if [[ ${PV} =~ 99999999$ ]]; then
 	inherit git-r3
@@ -21,11 +23,12 @@ HOMEPAGE="https://neomutt.org/"
 
 LICENSE="GPL-2"
 SLOT="0"
-IUSE="autocrypt berkdb doc gdbm gnutls gpgme idn kerberos kyotocabinet lmdb lz4
-	nls notmuch pgp-classic qdbm sasl selinux smime-classic ssl tokyocabinet
+IUSE="autocrypt berkdb doc gdbm gnutls gpgme idn kerberos kyotocabinet lmdb lua
+	lz4 nls notmuch pgp-classic qdbm sasl selinux smime-classic ssl tokyocabinet
 	test zlib zstd"
 REQUIRED_USE="
-	autocrypt? ( gpgme )"
+	autocrypt? ( gpgme )
+	lua? ( ${LUA_REQUIRED_USE} )"
 
 CDEPEND="
 	app-misc/mime-types
@@ -48,6 +51,7 @@ CDEPEND="
 	autocrypt? ( >=dev-db/sqlite-3 )
 	idn? ( net-dns/libidn2:= )
 	kerberos? ( virtual/krb5 )
+	lua? ( ${LUA_DEPS} )
 	notmuch? ( net-mail/notmuch:= )
 	sasl? ( >=dev-libs/cyrus-sasl-2 )
 	ssl? ( >=dev-libs/openssl-1.0.2u:0= )
@@ -74,6 +78,10 @@ RDEPEND="${CDEPEND}
 "
 
 RESTRICT="!test? ( test )"
+
+pkg_setup() {
+	use lua && lua-single_pkg_setup
+}
 
 src_unpack() {
 	if [[ -n ${A} ]]; then
@@ -111,6 +119,7 @@ src_configure() {
 		"$(use_enable idn idn2)"
 		"$(use_enable kerberos gss)"
 		"$(use_enable lmdb)"
+		"$(use_enable lua)"
 		"$(use_enable sasl)"
 		"--sysconfdir=${EPREFIX}/etc/${PN}"
 		"$(use_enable ssl)"


### PR DESCRIPTION
Add the use flag `lua` to enable Lua scripting support. Official news item incl. documentation of the feature: https://neomutt.org/2017/04/29/lua
Supported Lua versions taken from [here](https://github.com/neomutt/neomutt/blob/120d957478bb957e15c97dfd50f6a5c2d6ac4f40/auto.def#L567).

I'm using the Lua integration myself since a few months and find it pretty useful, hence proposing to include it in the official ebuilds.