### PR TITLE
sys-libs/compiler-rt: float16 ABI build condition.

### DIFF
--- a/sys-libs/compiler-rt/compiler-rt-17.0.5.ebuild
+++ b/sys-libs/compiler-rt/compiler-rt-17.0.5.ebuild
@@ -33,6 +33,8 @@ BDEPEND="
 LLVM_COMPONENTS=( compiler-rt cmake llvm/cmake )
 llvm.org_set_globals
 
+PATCHES=( "${FILESDIR}"/${PN}-17.0.5_float16-feature-detection.patch )
+
 python_check_deps() {
 	use test || return 0
 	python_has_version ">=dev-python/lit-15[${PYTHON_USEDEP}]"

--- a/sys-libs/compiler-rt/files/compiler-rt-17.0.5_float16-feature-detection.patch
+++ b/sys-libs/compiler-rt/files/compiler-rt-17.0.5_float16-feature-detection.patch
@@ -1,0 +1,35 @@
+Upstream: https://github.com/llvm/llvm-project/pull/69842
+
+From 9a2ca2504806de5680b5781530c8d7fed92ff2e6 Mon Sep 17 00:00:00 2001
+From: Tom Stellard <tstellar@redhat.com>
+Date: Tue, 29 Aug 2023 15:49:55 -0700
+Subject: [PATCH] compiler-rt: Fix FLOAT16 feature detection
+
+CMAKE_TRY_COMPILE_TARGET_TYPE defaults to EXECUTABLE, which causes
+any feature detection code snippet without a main function to fail,
+so we need to make sure it gets explicitly set to STATIC_LIBRARY.
+---
+ compiler-rt/lib/builtins/CMakeLists.txt | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/compiler-rt/lib/builtins/CMakeLists.txt b/compiler-rt/lib/builtins/CMakeLists.txt
+index cf2648233b0cf8f..a983e2e4ddeac33 100644
+--- a/compiler-rt/lib/builtins/CMakeLists.txt
++++ b/compiler-rt/lib/builtins/CMakeLists.txt
+@@ -5,7 +5,6 @@
+ if (CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+   cmake_minimum_required(VERSION 3.20.0)
+ 
+-  set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+   project(CompilerRTBuiltins C ASM)
+   set(COMPILER_RT_STANDALONE_BUILD TRUE)
+   set(COMPILER_RT_BUILTINS_STANDALONE_BUILD TRUE)
+@@ -50,6 +49,8 @@ if (COMPILER_RT_STANDALONE_BUILD)
+     ON)
+ endif()
+ 
++set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
++
+ include(builtin-config-ix)
+ include(CMakeDependentOption)
+ include(CMakePushCheckState)


### PR DESCRIPTION
As this becomes a blocker for HIP-5.7 bump, it makes more sense to carry the patch with Gentoo for a while.

Bug: https://github.com/llvm/llvm-project/pull/69842
Bug: https://github.com/gentoo/gentoo/pull/33400
Reference: https://github.com/llvm/llvm-project/issues/56854