### PR TITLE
dev-qt/qtdeclarative: add missing build dependency for vulkan

### DIFF
--- a/dev-qt/qtdeclarative/qtdeclarative-6.5.3.ebuild
+++ b/dev-qt/qtdeclarative/qtdeclarative-6.5.3.ebuild
@@ -18,7 +18,10 @@ IUSE="opengl +sql vulkan +widgets"
 RESTRICT="test"
 
 RDEPEND="~dev-qt/qtbase-${PV}:6[network,opengl=,sql?,vulkan=,widgets=]"
-DEPEND="${RDEPEND}"
+DEPEND="
+	${RDEPEND}
+	vulkan? ( dev-util/vulkan-headers )
+"
 BDEPEND="~dev-qt/qtshadertools-${PV}:6"
 
 src_configure() {

--- a/dev-qt/qtdeclarative/qtdeclarative-6.6.0.ebuild
+++ b/dev-qt/qtdeclarative/qtdeclarative-6.6.0.ebuild
@@ -18,7 +18,10 @@ IUSE="opengl +sql vulkan +widgets"
 RESTRICT="test"
 
 RDEPEND="~dev-qt/qtbase-${PV}:6[network,opengl=,sql?,vulkan=,widgets=]"
-DEPEND="${RDEPEND}"
+DEPEND="
+	${RDEPEND}
+	vulkan? ( dev-util/vulkan-headers )
+"
 BDEPEND="~dev-qt/qtshadertools-${PV}:6"
 
 src_configure() {

--- a/dev-qt/qtdeclarative/qtdeclarative-6.6.9999.ebuild
+++ b/dev-qt/qtdeclarative/qtdeclarative-6.6.9999.ebuild
@@ -18,7 +18,10 @@ IUSE="opengl +sql vulkan +widgets"
 RESTRICT="test"
 
 RDEPEND="~dev-qt/qtbase-${PV}:6[network,opengl=,sql?,vulkan=,widgets=]"
-DEPEND="${RDEPEND}"
+DEPEND="
+	${RDEPEND}
+	vulkan? ( dev-util/vulkan-headers )
+"
 BDEPEND="~dev-qt/qtshadertools-${PV}:6"
 
 src_configure() {

--- a/dev-qt/qtdeclarative/qtdeclarative-6.9999.ebuild
+++ b/dev-qt/qtdeclarative/qtdeclarative-6.9999.ebuild
@@ -18,7 +18,10 @@ IUSE="opengl +sql vulkan +widgets"
 RESTRICT="test"
 
 RDEPEND="~dev-qt/qtbase-${PV}:6[network,opengl=,sql?,vulkan=,widgets=]"
-DEPEND="${RDEPEND}"
+DEPEND="
+	${RDEPEND}
+	vulkan? ( dev-util/vulkan-headers )
+"
 BDEPEND="~dev-qt/qtshadertools-${PV}:6"
 
 src_configure() {

--- a/dev-qt/qtmultimedia/qtmultimedia-6.5.3.ebuild
+++ b/dev-qt/qtmultimedia/qtmultimedia-6.5.3.ebuild
@@ -49,6 +49,7 @@ DEPEND="
 	${RDEPEND}
 	X? ( x11-base/xorg-proto )
 	v4l? ( sys-kernel/linux-headers )
+	vulkan? ( dev-util/vulkan-headers )
 "
 BDEPEND="~dev-qt/qtshadertools-${PV}:6"
 

--- a/dev-qt/qtmultimedia/qtmultimedia-6.6.0.ebuild
+++ b/dev-qt/qtmultimedia/qtmultimedia-6.6.0.ebuild
@@ -49,6 +49,7 @@ DEPEND="
 	${RDEPEND}
 	X? ( x11-base/xorg-proto )
 	v4l? ( sys-kernel/linux-headers )
+	vulkan? ( dev-util/vulkan-headers )
 "
 BDEPEND="~dev-qt/qtshadertools-${PV}:6"
 

--- a/dev-qt/qtmultimedia/qtmultimedia-6.6.9999.ebuild
+++ b/dev-qt/qtmultimedia/qtmultimedia-6.6.9999.ebuild
@@ -49,6 +49,7 @@ DEPEND="
 	${RDEPEND}
 	X? ( x11-base/xorg-proto )
 	v4l? ( sys-kernel/linux-headers )
+	vulkan? ( dev-util/vulkan-headers )
 "
 BDEPEND="~dev-qt/qtshadertools-${PV}:6"
 

--- a/dev-qt/qtmultimedia/qtmultimedia-6.9999.ebuild
+++ b/dev-qt/qtmultimedia/qtmultimedia-6.9999.ebuild
@@ -49,6 +49,7 @@ DEPEND="
 	${RDEPEND}
 	X? ( x11-base/xorg-proto )
 	v4l? ( sys-kernel/linux-headers )
+	vulkan? ( dev-util/vulkan-headers )
 "
 BDEPEND="~dev-qt/qtshadertools-${PV}:6"
 

--- a/dev-qt/qtquick3d/qtquick3d-6.5.3.ebuild
+++ b/dev-qt/qtquick3d/qtquick3d-6.5.3.ebuild
@@ -25,6 +25,7 @@ RDEPEND="
 "
 DEPEND="
 	${RDEPEND}
+	vulkan? ( dev-util/vulkan-headers )
 	test? ( ~dev-qt/qtbase-${PV}:6[network] )
 "
 

--- a/dev-qt/qtquick3d/qtquick3d-6.6.0.ebuild
+++ b/dev-qt/qtquick3d/qtquick3d-6.6.0.ebuild
@@ -25,6 +25,7 @@ RDEPEND="
 "
 DEPEND="
 	${RDEPEND}
+	vulkan? ( dev-util/vulkan-headers )
 	test? ( ~dev-qt/qtbase-${PV}:6[network] )
 "
 

--- a/dev-qt/qtquick3d/qtquick3d-6.6.9999.ebuild
+++ b/dev-qt/qtquick3d/qtquick3d-6.6.9999.ebuild
@@ -25,6 +25,7 @@ RDEPEND="
 "
 DEPEND="
 	${RDEPEND}
+	vulkan? ( dev-util/vulkan-headers )
 	test? ( ~dev-qt/qtbase-${PV}:6[network] )
 "
 

--- a/dev-qt/qtquick3d/qtquick3d-6.9999.ebuild
+++ b/dev-qt/qtquick3d/qtquick3d-6.9999.ebuild
@@ -25,6 +25,7 @@ RDEPEND="
 "
 DEPEND="
 	${RDEPEND}
+	vulkan? ( dev-util/vulkan-headers )
 	test? ( ~dev-qt/qtbase-${PV}:6[network] )
 "
 


### PR DESCRIPTION
When vulkan is enabled, qtbase has to be built with vulkan support, and a bunch of private qt headers are poked at. Those headers privately make use of the bdep which qtbase itself has (USE-conditional on vulkan), but since it is only a build time dependency it is not necessarily guaranteed to be installed when building qtdeclarative.

Often it will be installed, since qtbase does after all drag it in. But e.g. when building qtdeclarative from source, but getting qtbase via a binpkg, no bdeps for qtbase are available.

Since this is private headers stuff, it makes a certain amount of sense that qtdeclarative should be independently responsible for adding the same bdep on its own, rather than forcing qtbase to runtime depend on it.