### PR TITLE
mail-filter/rspamd: enable Backward for glibc only

### DIFF
--- a/mail-filter/rspamd/rspamd-3.7.4.ebuild
+++ b/mail-filter/rspamd/rspamd-3.7.4.ebuild
@@ -99,6 +99,9 @@ src_configure() {
 		-DSYSTEM_ZSTD=ON
 
 		# For bundled https://github.com/bombela/backward-cpp
+		# Bundled backward library uses execinfo.h in current setting, which is
+		# available in glibc, but not in musl. Let's enable it for glibc only.
+		-DENABLE_BACKWARD=$(usex elibc_glibc ON OFF) # bug 917643
 		-DSTACK_DETAILS_AUTO_DETECT=OFF
 
 		-DENABLE_BLAS=$(usex blas ON OFF)


### PR DESCRIPTION
Enabling Backward for glibc only solves the problem for other libcs like musl, which does not provide execinfo.h.

Closes: https://bugs.gentoo.org/917643