### PR TITLE
dev-qt/qtwebengine: fix build with icu74 (qt5)

### DIFF
--- a/dev-qt/qtwebengine/qtwebengine-5.15.11_p20231102.ebuild
+++ b/dev-qt/qtwebengine/qtwebengine-5.15.11_p20231102.ebuild
@@ -107,6 +107,11 @@ BDEPEND="${PYTHON_DEPS}
 
 PATCHES=( "${WORKDIR}/${PATCHSET}" )
 
+PATCHES+=(
+	# add extras as needed here, may merge in set if carries across versions
+	"${FILESDIR}"/${PN}-6.5.3-icu74.patch
+)
+
 qtwebengine_check-reqs() {
 	# bug #307861
 	eshopts_push -s extglob


### PR DESCRIPTION
Apply quick-fix from b7982facbd6d596888e100c11b07fff5599e2203 to qt5 as well.

Closes: https://bugs.gentoo.org/917635