### PR TITLE
app-emulation/libvirt: Fix build with dev-libs/libxml2-2.12.0

### DIFF
--- a/app-emulation/libvirt/files/libvirt-9.10.0-virxml-include-libxml-xmlsave.h-for-xmlIndentTreeOut.patch
+++ b/app-emulation/libvirt/files/libvirt-9.10.0-virxml-include-libxml-xmlsave.h-for-xmlIndentTreeOut.patch
@@ -1,0 +1,36 @@
+From 7a5f232be2269e74943a029c0e8b1b0124674a6c Mon Sep 17 00:00:00 2001
+Message-ID: <7a5f232be2269e74943a029c0e8b1b0124674a6c.1700576185.git.mprivozn@redhat.com>
+From: Michal Privoznik <mprivozn@redhat.com>
+Date: Mon, 20 Nov 2023 03:18:12 +0100
+Subject: [PATCH] virxml: include <libxml/xmlsave.h> for xmlIndentTreeOutput
+ declaration
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+After libxml2's commit of v2.12.0~101 we no longer get
+xmlIndentTreeOutput declaration by us including just
+libxml/xpathInternals.h and libxml2's header files leakage.
+
+Resolves: https://bugs.gentoo.org/917516
+Signed-off-by: Michal Privoznik <mprivozn@redhat.com>
+Reviewed-by: Ján Tomko <jtomko@redhat.com>
+---
+ src/util/virxml.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/util/virxml.c b/src/util/virxml.c
+index 0c1eae8c3c..4f215a0e59 100644
+--- a/src/util/virxml.c
++++ b/src/util/virxml.c
+@@ -24,6 +24,7 @@
+ #include <math.h>               /* for isnan() */
+ #include <sys/stat.h>
+ 
++#include <libxml/xmlsave.h>
+ #include <libxml/xpathInternals.h>
+ 
+ #include "virerror.h"
+-- 
+2.41.0
+

--- a/app-emulation/libvirt/libvirt-9.3.0-r1.ebuild
+++ b/app-emulation/libvirt/libvirt-9.3.0-r1.ebuild
@@ -146,6 +146,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-8.2.0-do-not-use-sysconfig.patch
 	"${FILESDIR}"/${PN}-8.2.0-fix-paths-for-apparmor.patch
 	"${FILESDIR}"/${PN}-9.6.0-storage-Fix-returning-of-locked-objects-from-virStor.patch
+	"${FILESDIR}"/${PN}-9.10.0-virxml-include-libxml-xmlsave.h-for-xmlIndentTreeOut.patch
 )
 
 pkg_setup() {

--- a/app-emulation/libvirt/libvirt-9.4.0-r4.ebuild
+++ b/app-emulation/libvirt/libvirt-9.4.0-r4.ebuild
@@ -147,6 +147,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-9.4.0-do-not-use-sysconfig.patch
 	"${FILESDIR}"/${PN}-9.4.0-fix-paths-for-apparmor.patch
 	"${FILESDIR}"/${PN}-9.6.0-storage-Fix-returning-of-locked-objects-from-virStor.patch
+	"${FILESDIR}"/${PN}-9.10.0-virxml-include-libxml-xmlsave.h-for-xmlIndentTreeOut.patch
 )
 
 pkg_setup() {

--- a/app-emulation/libvirt/libvirt-9.5.0-r1.ebuild
+++ b/app-emulation/libvirt/libvirt-9.5.0-r1.ebuild
@@ -147,6 +147,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-9.4.0-do-not-use-sysconfig.patch
 	"${FILESDIR}"/${PN}-9.4.0-fix-paths-for-apparmor.patch
 	"${FILESDIR}"/${PN}-9.6.0-storage-Fix-returning-of-locked-objects-from-virStor.patch
+	"${FILESDIR}"/${PN}-9.10.0-virxml-include-libxml-xmlsave.h-for-xmlIndentTreeOut.patch
 )
 
 pkg_setup() {

--- a/app-emulation/libvirt/libvirt-9.6.0.ebuild
+++ b/app-emulation/libvirt/libvirt-9.6.0.ebuild
@@ -146,6 +146,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-9.4.0-fix_paths_in_libvirt-guests_sh.patch
 	"${FILESDIR}"/${PN}-9.4.0-do-not-use-sysconfig.patch
 	"${FILESDIR}"/${PN}-9.6.0-fix-paths-for-apparmor.patch
+	"${FILESDIR}"/${PN}-9.10.0-virxml-include-libxml-xmlsave.h-for-xmlIndentTreeOut.patch
 )
 
 pkg_setup() {

--- a/app-emulation/libvirt/libvirt-9.8.0.ebuild
+++ b/app-emulation/libvirt/libvirt-9.8.0.ebuild
@@ -146,6 +146,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-9.4.0-fix_paths_in_libvirt-guests_sh.patch
 	"${FILESDIR}"/${PN}-9.4.0-do-not-use-sysconfig.patch
 	"${FILESDIR}"/${PN}-9.6.0-fix-paths-for-apparmor.patch
+	"${FILESDIR}"/${PN}-9.10.0-virxml-include-libxml-xmlsave.h-for-xmlIndentTreeOut.patch
 )
 
 pkg_setup() {

--- a/app-emulation/libvirt/libvirt-9.9.0.ebuild
+++ b/app-emulation/libvirt/libvirt-9.9.0.ebuild
@@ -146,6 +146,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-9.4.0-fix_paths_in_libvirt-guests_sh.patch
 	"${FILESDIR}"/${PN}-9.9.0-do-not-use-sysconfig.patch
 	"${FILESDIR}"/${PN}-9.6.0-fix-paths-for-apparmor.patch
+	"${FILESDIR}"/${PN}-9.10.0-virxml-include-libxml-xmlsave.h-for-xmlIndentTreeOut.patch
 )
 
 pkg_setup() {


### PR DESCRIPTION
As of its 2.12.0 release, libxml2 cleaned up header files which rendered libvirt unable to compile. Backport the fix from upstream repo.

After this, there are still some warnings about use of a deprecated function, but those are harmless and we'll get fix with new release.

Bug: https://bugs.gentoo.org/916497