### PR TITLE
media-sound/liblc3: wire up tests

### DIFF
--- a/media-sound/liblc3/liblc3-1.0.4-r1.ebuild
+++ b/media-sound/liblc3/liblc3-1.0.4-r1.ebuild
@@ -1,0 +1,52 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+PYTHON_COMPAT=( python3_{10,11,12} pypy3 )
+inherit meson python-any-r1
+
+DESCRIPTION="LC3 is an efficient low latency audio codec"
+HOMEPAGE="https://github.com/google/liblc3"
+SRC_URI="https://github.com/google/${PN}/archive/refs/tags/v${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="Apache-2.0"
+SLOT="0"
+IUSE="test tools"
+KEYWORDS="~amd64 ~arm ~arm64 ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86"
+RESTRICT="!test? ( test )"
+
+DEPEND="test? (
+	$(python_gen_any_dep '
+		dev-python/numpy[${PYTHON_USEDEP}]
+		dev-python/scipy[${PYTHON_USEDEP}]
+	')
+)"
+
+python_check_deps() {
+	python_has_version -d "dev-python/numpy[${PYTHON_USEDEP}]" &&
+	python_has_version -d "dev-python/scipy[${PYTHON_USEDEP}]"
+}
+
+pkg_setup() {
+	use test && python-any-r1_pkg_setup
+}
+
+src_prepare() {
+	use arm || rm -rf "test/arm" || die
+	use arm64 || rm -rf "test/neon" || die
+	default
+}
+
+src_configure() {
+	local emesonargs=(
+		# We let users choose to enable LTO
+		-Db_lto=false
+		$(meson_use tools)
+	)
+	meson_src_configure
+}
+
+src_test() {
+	V= emake test CFLAGS:="${CPPFLAGS} ${CFLAGS} -I"$("${EPYTHON}" -c "import numpy;print(numpy.get_include())")""
+}


### PR DESCRIPTION
The `test/arm` and `test/neon` suites actually run on non-ARM platforms, but the generic implementations are not endian-safe, and since they're supposed to test ARM assembly, there's not much point in running them on other platforms.

Most of the tricks stolen from Debian:  [deps](https://salsa.debian.org/multimedia-team/liblc3/-/blob/master/debian/control) and [rules](https://salsa.debian.org/multimedia-team/liblc3/-/blob/master/debian/rules).

Tested on arm and arm64, as well as other 64-bit BE and LE platforms.