### PR TITLE
git-r3.eclass: fetch remote_ref in the mirror clone type

### DIFF
--- a/eclass/git-r3.eclass
+++ b/eclass/git-r3.eclass
@@ -682,6 +682,8 @@ git-r3_fetch() {
 					# and HEAD in case we need the default branch
 					# (we keep it in refs/git-r3 since otherwise --prune interferes)
 					"+HEAD:refs/git-r3/HEAD"
+					# fetch the specifc commit_ref to deal with orphan commits
+					"${remote_ref}"
 				)
 			else # single or shallow
 				local fetch_l fetch_r


### PR DESCRIPTION
* Handles scenarios where commits in submodules are orphaned.

Closes: https://bugs.gentoo.org/917746
Bug: https://bugs.gentoo.org/503332