### PR TITLE
dev-util/promu: Disable pie for x86

### DIFF
--- a/dev-util/promu/promu-0.15.0.ebuild
+++ b/dev-util/promu/promu-0.15.0.ebuild
@@ -34,6 +34,10 @@ src_unpack() {
 }
 
 src_compile() {
+	if use x86; then
+		#917577 pie breaks build on x86
+		GOFLAGS=${GOFLAGS//-buildmode=pie}
+	fi
 	emake build
 }
 

--- a/dev-util/promu/promu-9999.ebuild
+++ b/dev-util/promu/promu-9999.ebuild
@@ -34,6 +34,10 @@ src_unpack() {
 }
 
 src_compile() {
+	if use x86; then
+		#917577 pie breaks build on x86
+		GOFLAGS=${GOFLAGS//-buildmode=pie}
+	fi
 	emake build
 }
 


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/917577

@rahilarious @robbat2 