### PR TITLE
dev-python/pytest-xdist: remove forced plugin autoload for forked

### DIFF
--- a/dev-python/pytest-xdist/pytest-xdist-3.3.1-r1.ebuild
+++ b/dev-python/pytest-xdist/pytest-xdist-3.3.1-r1.ebuild
@@ -38,7 +38,7 @@ python_test() {
 	# disable autoloading plugins in nested pytest calls
 	local -x PYTEST_DISABLE_PLUGIN_AUTOLOAD=1
 	# since we disabled autoloading, force loading necessary plugins
-	local -x PYTEST_PLUGINS=xdist.plugin,xdist.looponfail,pytest_forked
+	local -x PYTEST_PLUGINS=xdist.plugin,xdist.looponfail
 
 	epytest
 }

--- a/dev-python/pytest-xdist/pytest-xdist-3.4.0.ebuild
+++ b/dev-python/pytest-xdist/pytest-xdist-3.4.0.ebuild
@@ -38,7 +38,7 @@ python_test() {
 	# disable autoloading plugins in nested pytest calls
 	local -x PYTEST_DISABLE_PLUGIN_AUTOLOAD=1
 	# since we disabled autoloading, force loading necessary plugins
-	local -x PYTEST_PLUGINS=xdist.plugin,xdist.looponfail,pytest_forked
+	local -x PYTEST_PLUGINS=xdist.plugin,xdist.looponfail
 
 	epytest
 }

--- a/dev-python/pytest-xdist/pytest-xdist-3.5.0.ebuild
+++ b/dev-python/pytest-xdist/pytest-xdist-3.5.0.ebuild
@@ -38,7 +38,7 @@ python_test() {
 	# disable autoloading plugins in nested pytest calls
 	local -x PYTEST_DISABLE_PLUGIN_AUTOLOAD=1
 	# since we disabled autoloading, force loading necessary plugins
-	local -x PYTEST_PLUGINS=xdist.plugin,xdist.looponfail,pytest_forked
+	local -x PYTEST_PLUGINS=xdist.plugin,xdist.looponfail
 
 	epytest
 }


### PR DESCRIPTION
Followup to commit bc29e400979b556cd9c835a21fa401ec94504c0a. The dependency was removed, but it wasn't also removed from the testsuite loader, which caused pytest to fail early on when it could not find such a plugin to load.

As noted in the original commit, it's unused. We certainly shouldn't be autoloading it in the testsuite, then.