### PR TITLE
mail-filter/spamassassin: Fix script output when amavisd is disabled

### DIFF
--- a/mail-filter/spamassassin/files/update-spamassassin-rules-r1.cron
+++ b/mail-filter/spamassassin/files/update-spamassassin-rules-r1.cron
@@ -35,7 +35,8 @@ if (( $? == 0 || $? == 3 )); then
 	# check is to keep systemctl from outputting warnings if
 	# amavisd is not installed (bug #681872).
         systemctl try-restart spamassassin
-        systemctl is-active --quiet amavisd \
-            && systemctl try-reload-or-restart amavisd
+	if ( systemctl is-active --quiet amavisd ); then
+            systemctl try-reload-or-restart amavisd
+	fi
     fi
 fi


### PR DESCRIPTION
mail-filter/spamassassin: Fix script output when amavisd is disabled

Because bash scripts exit with the status of the last command. If systemctl is installed but amavisd is not active the script returns with the value 4.

This causes cron to send an email.

Switching from "&&" to an if fixes this.


Bug: https://bugs.gentoo.org/681872