### PR TITLE
dev-python/mypy: add missing build dependencies for native-extensions

### DIFF
--- a/dev-python/mypy/mypy-1.6.0.ebuild
+++ b/dev-python/mypy/mypy-1.6.0.ebuild
@@ -37,6 +37,7 @@ RDEPEND="
 "
 BDEPEND="
 	native-extensions? (
+		${RDEPEND}
 		dev-python/types-psutil[${PYTHON_USEDEP}]
 		dev-python/types-setuptools[${PYTHON_USEDEP}]
 	)

--- a/dev-python/mypy/mypy-1.6.1.ebuild
+++ b/dev-python/mypy/mypy-1.6.1.ebuild
@@ -37,6 +37,7 @@ RDEPEND="
 "
 BDEPEND="
 	native-extensions? (
+		${RDEPEND}
 		dev-python/types-psutil[${PYTHON_USEDEP}]
 		dev-python/types-setuptools[${PYTHON_USEDEP}]
 	)

--- a/dev-python/mypy/mypy-1.7.0.ebuild
+++ b/dev-python/mypy/mypy-1.7.0.ebuild
@@ -37,6 +37,7 @@ RDEPEND="
 "
 BDEPEND="
 	native-extensions? (
+		${RDEPEND}
 		dev-python/types-psutil[${PYTHON_USEDEP}]
 		dev-python/types-setuptools[${PYTHON_USEDEP}]
 	)

--- a/dev-python/mypy/mypy-1.7.1.ebuild
+++ b/dev-python/mypy/mypy-1.7.1.ebuild
@@ -37,6 +37,7 @@ RDEPEND="
 "
 BDEPEND="
 	native-extensions? (
+		${RDEPEND}
 		dev-python/types-psutil[${PYTHON_USEDEP}]
 		dev-python/types-setuptools[${PYTHON_USEDEP}]
 	)


### PR DESCRIPTION
It has to run mypy at build time, so all RDEPEND must also be BDEPEND here. I thought I had originally added this...

This prevents building with e.g. different root or --buildpkgonly, where RDEPEND isn't used at all (as an implementation detail, building and installing will merge RDEPEND first, so people might not notice the issue).