### PR TITLE
app-editors/featherpad: keyword on more arches

### DIFF
--- a/app-editors/featherpad/featherpad-1.4.1.ebuild
+++ b/app-editors/featherpad/featherpad-1.4.1.ebuild
@@ -12,7 +12,7 @@ S="${WORKDIR}/FeatherPad-${PV}"
 
 LICENSE="GPL-3+"
 SLOT="0"
-KEYWORDS="~amd64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~riscv ~x86"
 IUSE="qt6 +X"
 
 RDEPEND="


### PR DESCRIPTION
~arm, ~arm64, ~ppc, ~ppc64

Closes: https://bugs.gentoo.org/918481