### PR TITLE
app-text/trang: remove google-code upstream metadata

### DIFF
--- a/app-text/trang/metadata.xml
+++ b/app-text/trang/metadata.xml
@@ -7,6 +7,5 @@
 	</maintainer>
 	<upstream>
 		<remote-id type="github">relaxng/jing-trang</remote-id>
-		<remote-id type="google-code">jing-trang</remote-id>
 	</upstream>
 </pkgmetadata>


### PR DESCRIPTION
before diving into https://bugs.gentoo.org/918428