### PR TITLE
media-sound/helvum: bump LLVM_MAX_SLOT to 17

### DIFF
--- a/media-sound/helvum/helvum-0.5.1-r2.ebuild
+++ b/media-sound/helvum/helvum-0.5.1-r2.ebuild
@@ -109,7 +109,7 @@ CRATES="
 	winnow@0.5.15
 "
 
-LLVM_MAX_SLOT=16
+LLVM_MAX_SLOT=17
 
 inherit cargo desktop xdg llvm
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/918521