### PR TITLE
app-alternatives/unzip: new package to control unzip symlink

### DIFF
--- a/app-alternatives/unzip/metadata.xml
+++ b/app-alternatives/unzip/metadata.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="project">
+		<email>base-system@gentoo.org</email>
+		<name>Gentoo Base System</name>
+	</maintainer>
+	<use>
+		<flag name="info-zip">
+			Symlink to Info-ZIP unzip (<pkg>app-arch/unzip</pkg>)
+		</flag>
+		<flag name="libarchive">
+			Symlink to bsdunzip from <pkg>app-arch/libarchive</pkg>
+		</flag>
+	</use>
+</pkgmetadata>

--- a/app-alternatives/unzip/unzip-0.ebuild
+++ b/app-alternatives/unzip/unzip-0.ebuild
@@ -1,0 +1,32 @@
+# Copyright 2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+ALTERNATIVES=(
+	"info-zip:>=app-arch/unzip-6.0_p27-r2"
+	libarchive:app-arch/libarchive
+)
+
+inherit app-alternatives
+
+DESCRIPTION="Unzip symlink"
+
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~arm64-macos ~ppc-macos ~x64-macos ~x64-solaris"
+
+RDEPEND="
+	!<app-arch/unzip-6.0_p27-r2
+"
+
+src_install() {
+	case $(get_alternative) in
+		info-zip)
+			dosym info-unzip /usr/bin/unzip
+			newman - unzip.1 <<<".so info-unzip.1"
+			;;
+		libarchive)
+			dosym bsdunzip /usr/bin/unzip
+			newman - unzip.1 <<<".so bsdunzip.1"
+			;;
+	esac
+}

--- a/app-arch/unzip/unzip-6.0_p27-r2.ebuild
+++ b/app-arch/unzip/unzip-6.0_p27-r2.ebuild
@@ -1,0 +1,95 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit flag-o-matic multilib toolchain-funcs
+
+MY_PV="${PV//.}"
+MY_PV="${MY_PV%_p*}"
+MY_P="${PN}${MY_PV}"
+
+DESCRIPTION="unzipper for pkzip-compressed files"
+HOMEPAGE="https://infozip.sourceforge.net/UnZip.html"
+SRC_URI="mirror://sourceforge/infozip/${MY_P}.tar.gz
+	mirror://debian/pool/main/u/${PN}/${PN}_${PV/_p/-}.debian.tar.xz"
+
+LICENSE="Info-ZIP"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~arm64-macos ~ppc-macos ~x64-macos ~x64-solaris"
+IUSE="bzip2 natspec unicode"
+
+DEPEND="bzip2? ( app-arch/bzip2 )
+	natspec? ( dev-libs/libnatspec )"
+RDEPEND="${DEPEND}"
+PDEPEND="app-alternatives/unzip"
+
+S="${WORKDIR}/${MY_P}"
+
+PATCHES=(
+	"${WORKDIR}"/debian/patches
+	"${FILESDIR}"/${PN}-6.0-no-exec-stack.patch
+	"${FILESDIR}"/${PN}-6.0-format-security.patch
+	"${FILESDIR}"/${PN}-6.0-fix-false-overlap-detection-on-32bit-systems.patch
+)
+
+src_prepare() {
+	# bug #275244
+	use natspec && PATCHES+=( "${FILESDIR}"/${PN}-6.0-natspec.patch )
+
+	rm "${WORKDIR}"/debian/patches/02-this-is-debian-unzip.patch || die
+
+	default
+
+	sed -i -r \
+		-e '/^CFLAGS/d' \
+		-e '/CFLAGS/s:-O[0-9]?:$(CFLAGS) $(CPPFLAGS):' \
+		-e '/^STRIP/s:=.*:=true:' \
+		-e "s:\<CC *= *\"?g?cc2?\"?\>:CC=\"$(tc-getCC)\":" \
+		-e "s:\<LD *= *\"?(g?cc2?|ld)\"?\>:LD=\"$(tc-getCC)\":" \
+		-e "s:\<AS *= *\"?(g?cc2?|as)\"?\>:AS=\"$(tc-getCC)\":" \
+		-e 's:LF2 = -s:LF2 = :' \
+		-e 's:LF = :LF = $(LDFLAGS) :' \
+		-e 's:SL = :SL = $(LDFLAGS) :' \
+		-e 's:FL = :FL = $(LDFLAGS) :' \
+		-e "/^#L_BZ2/s:^$(use bzip2 && echo .)::" \
+		-e 's:$(AS) :$(AS) $(ASFLAGS) :g' \
+		unix/Makefile \
+		|| die "sed unix/Makefile failed"
+
+	# Delete bundled code to make sure we don't use it.
+	rm -r bzip2 || die
+}
+
+src_configure() {
+	case ${CHOST} in
+		i?86*-*linux*)       TARGET="linux_asm" ;;
+		*linux*)             TARGET="linux_noasm" ;;
+		*-darwin*)           TARGET="macosx" ;;
+		*-solaris*)          TARGET="generic" ;;
+		*) die "Unknown target; please update the ebuild to handle ${CHOST}" ;;
+	esac
+
+	# Needed for Clang 16
+	append-flags -std=gnu89
+
+	[[ ${CHOST} == *linux* ]] && append-cppflags -DNO_LCHMOD
+	use bzip2 && append-cppflags -DUSE_BZIP2
+	use unicode && append-cppflags -DUNICODE_SUPPORT -DUNICODE_WCHAR -DUTF8_MAYBE_NATIVE -DUSE_ICONV_MAPPING
+
+	# bug #281473
+	append-cppflags -DLARGE_FILE_SUPPORT
+}
+
+src_compile() {
+	ASFLAGS="${ASFLAGS} $(get_abi_CFLAGS)" emake -f unix/Makefile ${TARGET}
+}
+
+src_install() {
+	dobin funzip unzipsfx unix/zipgrep
+	newbin unzip info-unzip
+	dosym info-unzip /usr/bin/zipinfo
+	doman man/{funzip,unzipsfx,zipgrep,zipinfo}.1
+	newman man/unzip.1 info-unzip.1
+	dodoc BUGS History* README ToDo WHERE
+}


### PR DESCRIPTION
Allow use of libarchive implementation instead which has added compatibility for the Info-ZIP implementation.

Draft as want comments on binary name, use flag name and because I'm waiting on a bug to be fixed in how "--" is handled. The latter was the only issue I noticed while testing this.

https://github.com/libarchive/libarchive/pull/2022