### PR TITLE
jenkins: Updated JRE to 17 and 21

### DIFF
--- a/dev-util/jenkins-bin/jenkins-bin-2.426.1.ebuild
+++ b/dev-util/jenkins-bin/jenkins-bin-2.426.1.ebuild
@@ -21,7 +21,7 @@ RDEPEND="acct-group/jenkins
 	media-fonts/dejavu
 	media-libs/freetype
 	!dev-util/jenkins-bin:0
-	|| ( virtual/jre:17 virtual/jre:11 )"
+	|| ( virtual/jre:21 virtual/jre:17 )"
 
 S="${WORKDIR}"
 

--- a/dev-util/jenkins-bin/jenkins-bin-2.428.ebuild
+++ b/dev-util/jenkins-bin/jenkins-bin-2.428.ebuild
@@ -21,7 +21,7 @@ RDEPEND="acct-group/jenkins
 	media-fonts/dejavu
 	media-libs/freetype
 	!dev-util/jenkins-bin:lts
-	|| ( virtual/jre:17 virtual/jre:11 )"
+	|| ( virtual/jre:21 virtual/jre:17 )"
 
 S="${WORKDIR}"
 


### PR DESCRIPTION
The change proposed updates the required JRE test to check for 17 and 21.
Starting with 2.426, Jenkins supports Java 21 natively and emits warnings when using Java 11.