### PR TITLE
sys-apps/dog: EAPI8 bump, fix LICENSE

### DIFF
--- a/sys-apps/dog/dog-1.7-r6.ebuild
+++ b/sys-apps/dog/dog-1.7-r6.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
 
 inherit toolchain-funcs
 
@@ -9,7 +9,7 @@ DESCRIPTION="Dog is better than cat"
 HOMEPAGE="https://wiki.gentoo.org/wiki/No_homepage"
 SRC_URI="mirror://gentoo/${P}.tar.gz"
 
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="0"
 KEYWORDS="~alpha amd64 ~arm64 ~mips ppc ppc64 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos"
 


### PR DESCRIPTION
Very simple `EAPI8` bump.