### PR TITLE
sys-process/prll: EAPI8 bump, fix LICENSE

### DIFF
--- a/sys-process/prll/metadata.xml
+++ b/sys-process/prll/metadata.xml
@@ -7,5 +7,6 @@
 	</maintainer>
 	<upstream>
 		<remote-id type="sourceforge">prll</remote-id>
+		<remote-id type="github">exzombie/prll</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/sys-process/prll/prll-0.6.4.ebuild
+++ b/sys-process/prll/prll-0.6.4.ebuild
@@ -1,15 +1,15 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
 
 inherit toolchain-funcs readme.gentoo-r1
 
-DESCRIPTION="A utility for parallelizing execution of shell functions"
+DESCRIPTION="Utility for parallelizing execution of shell functions"
 HOMEPAGE="https://github.com/exzombie/prll"
 SRC_URI="https://github.com/exzombie/prll/archive/${PV}.tar.gz -> ${P}.tar.gz"
 
-LICENSE="GPL-3"
+LICENSE="GPL-3+"
 SLOT="0"
 KEYWORDS="amd64 x86 ~amd64-linux ~x86-linux"
 RESTRICT="test"


### PR DESCRIPTION
Another simple `EAPI8` bump.