### PR TITLE
app-office/gnucash: add algorithm patch to 5.3

### DIFF
--- a/app-office/gnucash/files/gnucash-5.3-include-algorithm.patch
+++ b/app-office/gnucash/files/gnucash-5.3-include-algorithm.patch
@@ -1,0 +1,12 @@
+diff --git a/libgnucash/engine/gnc-option-impl.hpp b/libgnucash/engine/gnc-option-impl.hpp
+index 4ebaa36..4d157d5 100644
+--- a/libgnucash/engine/gnc-option-impl.hpp
++++ b/libgnucash/engine/gnc-option-impl.hpp
+@@ -49,6 +49,7 @@
+ #include <variant>
+ #include <iostream>
+ #include <limits>
++#include <algorithm>
+ 
+ #include "gnc-option-uitype.hpp"
+ 

--- a/app-office/gnucash/gnucash-5.3.ebuild
+++ b/app-office/gnucash/gnucash-5.3.ebuild
@@ -108,6 +108,9 @@ PATCHES=(
 	# This is only to prevent webkit2gtk-4 from being selected.
 	# https://bugs.gentoo.org/893676
 	"${FILESDIR}/${PN}-5.0-webkit2gtk-4.1.patch"
+
+	# GCC 14 no longer includes <algorithm> by default, this is fixed in 5.5
+	"${FILESDIR}/${PN}-5.3-include-algorithm.patch"
 )
 
 # guile generates ELF files without use of C or machine code


### PR DESCRIPTION
GCC 14 no longer includes <algorithm> by default, this will add a patch that will include it.

Upstream's already accepted it and the patch should no longer be needed in 5.5.

Upstream bug: https://bugs.gnucash.org/show_bug.cgi?id=799134

Closes: https://bugs.gentoo.org/917598