### PR TITLE
dev-ruby/activesupport: add msgpack dep; fix tests

### DIFF
--- a/dev-ruby/activesupport/activesupport-7.1.1-r1.ebuild
+++ b/dev-ruby/activesupport/activesupport-7.1.1-r1.ebuild
@@ -1,0 +1,82 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+USE_RUBY="ruby31 ruby32"
+
+RUBY_FAKEGEM_EXTRADOC="CHANGELOG.md README.rdoc"
+
+RUBY_FAKEGEM_GEMSPEC="activesupport.gemspec"
+
+RUBY_FAKEGEM_BINWRAP=""
+
+inherit ruby-fakegem
+
+DESCRIPTION="Utility Classes and Extension to the Standard Library"
+HOMEPAGE="https://github.com/rails/rails"
+SRC_URI="https://github.com/rails/rails/archive/v${PV}.tar.gz -> rails-${PV}.tgz"
+
+LICENSE="MIT"
+SLOT="$(ver_cut 1-2)"
+KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+IUSE="+msgpack test"
+RESTRICT="!test? ( test )"
+REQUIRED_USE="test? ( msgpack )"
+PATCHES=( "${FILESDIR}/${PN}-7.1.1-backport-pr50097.patch" )
+
+RUBY_S="rails-${PV}/${PN}"
+
+# bigdecimal and mutex_m are bundled with ruby as default gems
+ruby_add_rdepend "
+	dev-ruby/base64
+	>=dev-ruby/concurrent-ruby-1.0.2:1
+	>=dev-ruby/connection_pool-2.2.5
+	dev-ruby/drb
+	>=dev-ruby/i18n-1.6:1
+	>=dev-ruby/minitest-5.1
+	dev-ruby/tzinfo:2
+	msgpack? ( >=dev-ruby/msgpack-1.7.0 )
+"
+
+# memcache-client, nokogiri, builder, and redis are not strictly needed,
+# but there are tests using this code.
+ruby_add_bdepend "test? (
+	>=dev-ruby/dalli-3.0.1
+	>=dev-ruby/nokogiri-1.8.1
+	>=dev-ruby/builder-3.1.0
+	>=dev-ruby/listen-3.3:3
+	dev-ruby/rack:3.0
+	dev-ruby/rexml
+	dev-ruby/mocha
+	>dev-ruby/minitest-5.15.0:*
+	)"
+
+all_ruby_prepare() {
+	# Set the secure permissions that tests expect.
+	chmod 0755 "${HOME}" || die "Failed to fix permissions on home"
+
+	# Remove items from the common Gemfile that we don't need for this
+	# test run. This also requires handling some gemspecs.
+	sed -i -e "/\(system_timer\|execjs\|jquery-rails\|journey\|ruby-prof\|stackprof\|benchmark-ips\|turbolinks\|coffee-rails\|debugger\|sprockets-rails\|bcrypt\|uglifier\|minitest\|sprockets\|stackprof\|rack-cache\|sqlite\|websocket-client-simple\|\libxml-ruby\|bootsnap\|aws-sdk\|webmock\|capybara\|sass-rails\|selenium-webdriver\|webpacker\|webrick\|propshaft\|rack-test\|terser\|cgi\|net-smtp\|net-imap\|net-pop\|digest\|matrix\|web-console\|error_highlight\|jbuilder\)/ s:^:#:" \
+		-e '/stimulus-rails/,/tailwindcss-rails/ s:^:#:' \
+		-e '/^group :test/,/^end/ s:^:#:' \
+		-e '/^\s*group :\(db\|doc\|rubocop\|job\|cable\|lint\|storage\|ujs\|test\|view\|mdl\) do/,/^\s*end/ s:^:#:' \
+		-e 's/gemspec/gemspec path: "activesupport"/' \
+		-e '5igem "builder"' ../Gemfile || die
+	rm ../Gemfile.lock || die
+
+	# Avoid test that depends on timezone
+	sed -i -e '/test_implicit_coercion/,/^  end/ s:^:#:' test/core_ext/duration_test.rb || die
+
+	# Avoid tests that seem to trigger race conditions.
+	rm -f test/evented_file_update_checker_test.rb || die
+
+	# Avoid test that generates filename that is too long
+	sed -i -e '/test_filename_max_size/askip "gentoo"' test/cache/stores/file_store_test.rb || die
+
+	# Avoid tests requiring a live redis running
+	rm -f test/cache/stores/redis_cache_store_test.rb || die
+	sed -i -e '/cache_stores:redis/ s:^:#:' Rakefile || die
+	sed -i -e '/test_redis_cache_store/askip "lacking keywords"' test/cache/cache_store_setting_test.rb || die
+}

--- a/dev-ruby/activesupport/files/activesupport-7.1.1-backport-pr50097.patch
+++ b/dev-ruby/activesupport/files/activesupport-7.1.1-backport-pr50097.patch
@@ -1,0 +1,65 @@
+https://bugs.gentoo.org/show_bug.cgi?id=917059
+https://github.com/rails/rails/pull/50097
+
+From 2ddb90f63e0fffea493cb1987850797608c4d895 Mon Sep 17 00:00:00 2001
+From: matoro <matoro@users.noreply.github.com>
+Date: Sat, 18 Nov 2023 12:46:23 -0500
+Subject: [PATCH] Skip activesupport event processing tests on platforms w/o
+ highres clock
+
+On platforms without a high-resolution (nanosecond) clock, it is likely
+that the processing of an event will take less time than one complete
+clock resolution cycle, which means that the start and end times will be
+equal and the duration zero, failing these tests.  Usually these issues
+are fixed by adding a sleep of equal to one clock resolution cycle, but
+that is not applicable here since the duration measurement occurs in the
+actual library code rather than the test code, so just skip these tests
+on such platforms.  Also tested and confirmed that the tests are not
+skipped under normal platforms with a highres clock.
+---
+ test/log_subscriber_test.rb | 9 +++++++--
+ test/notifications_test.rb  | 9 ++++++---
+ 2 files changed, 13 insertions(+), 5 deletions(-)
+
+diff --git a/test/log_subscriber_test.rb b/test/log_subscriber_test.rb
+index 455f6952e31b..0fd3ff69eb19 100644
+--- a/test/log_subscriber_test.rb
++++ b/test/log_subscriber_test.rb
+@@ -108,10 +108,15 @@ def test_event_attributes
+       assert_equal 0, event.cpu_time
+       assert_equal 0, event.allocations
+     else
+-      assert_operator event.cpu_time, :>, 0
++      # These assertions may fail on platforms without nanosecond-resolution clocks
++      if Process.clock_getres(Process::CLOCK_MONOTONIC) <= 1.0e-09
++        assert_operator event.cpu_time, :>, 0
++      end
+       assert_operator event.allocations, :>, 0
+     end
+-    assert_operator event.duration, :>, 0
++    if Process.clock_getres(Process::CLOCK_MONOTONIC) <= 1.0e-09
++      assert_operator event.duration, :>, 0
++    end
+     assert_operator event.idle_time, :>=, 0
+   end
+ 
+diff --git a/test/notifications_test.rb b/test/notifications_test.rb
+index 87416602bb2f..9bc7e393e3a9 100644
+--- a/test/notifications_test.rb
++++ b/test/notifications_test.rb
+@@ -36,9 +36,12 @@ def test_subscribe_events
+       event = events.first
+       assert event, "should have an event"
+       assert_operator event.allocations, :>, 0
+-      assert_operator event.cpu_time, :>, 0
+-      assert_operator event.idle_time, :>=, 0
+-      assert_operator event.duration, :>, 0
++      # These assertions may fail on platforms without nanosecond-resolution clocks
++      if Process.clock_getres(Process::CLOCK_MONOTONIC) <= 1.0e-09
++        assert_operator event.cpu_time, :>, 0
++        assert_operator event.idle_time, :>=, 0
++        assert_operator event.duration, :>, 0
++      end
+     end
+ 
+     def test_subscribe_to_events_where_payload_is_changed_during_instrumentation

--- a/dev-ruby/activesupport/metadata.xml
+++ b/dev-ruby/activesupport/metadata.xml
@@ -5,6 +5,9 @@
     <email>ruby@gentoo.org</email>
     <name>Gentoo Ruby Project</name>
   </maintainer>
+  <use>
+    <flag name="msgpack">Support ActiveSupport::MessagePack module</flag>
+  </use>
   <upstream>
     <remote-id type="github">rails/rails</remote-id>
   </upstream>

--- a/profiles/arch/powerpc/package.use.mask
+++ b/profiles/arch/powerpc/package.use.mask
@@ -1,6 +1,11 @@
 # Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# matoro <matoro_gentoo@matoro.tk> (2023-11-25)
+# Casualty of dev-ruby/msgpack restriction to ruby32
+# Remove this once ruby32 is unmasked in base
+dev-ruby/activesupport msgpack test
+
 # matoro <matoro_gentoo@matoro.tk> (2023-11-22)
 # Broken on <dev-lang/ruby-3.2
 # https://github.com/msgpack/msgpack-ruby/pull/355


### PR DESCRIPTION
Rails 7.1 added a new `ActiveSupport::MessagePack` module that pulls in `msgpack` gem (packaged as `dev-ruby/msgpack`) when imported, see https://blog.saeloun.com/2023/11/15/rails-7-1-message-pack-as-message-serializer/ .  There are non-optional unit tests covering this module.  Unfortunately `dev-ruby/msgpack` is broken on PowerPC arches (big and little endian) with Ruby <3.2, see https://github.com/gentoo/gentoo/commit/e23086d068c221fd7e72780c1715938fca5efcde and https://github.com/msgpack/msgpack-ruby/pull/355.  Therefore the only way to resolve this without dekeywording `dev-ruby/activesupport` on PowerPC (with its dep family) is to add `USE=msgpack`, which I have default-enabled, and have `USE=test` depend on it.  This whole setup can be removed once `dev-lang/ruby:3.2` is unmasked.