### PR TITLE
sci-libs/cholmod: fix cuda build

### DIFF
--- a/sci-libs/cholmod/cholmod-3.0.13.ebuild
+++ b/sci-libs/cholmod/cholmod-3.0.13.ebuild
@@ -1,9 +1,9 @@
 # Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
-inherit toolchain-funcs
+inherit cuda toolchain-funcs
 
 DESCRIPTION="Sparse Cholesky factorization and update/downdate library"
 HOMEPAGE="https://people.engr.tamu.edu/davis/suitesparse.html"
@@ -30,6 +30,16 @@ DEPEND="
 		>=sci-libs/metis-5.1.0
 	)"
 RDEPEND="${DEPEND}"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-3.0.14-fix-CUDA.patch"
+)
+
+src_prepare() {
+	use cuda && cuda_src_prepare
+
+	default
+}
 
 src_configure() {
 	local lapack_libs=no

--- a/sci-libs/cholmod/cholmod-3.0.14.ebuild
+++ b/sci-libs/cholmod/cholmod-3.0.14.ebuild
@@ -1,9 +1,9 @@
 # Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
-inherit toolchain-funcs
+inherit cuda toolchain-funcs
 
 DESCRIPTION="Sparse Cholesky factorization and update/downdate library"
 HOMEPAGE="https://people.engr.tamu.edu/davis/suitesparse.html"
@@ -30,6 +30,16 @@ DEPEND="
 		>=sci-libs/metis-5.1.0
 	)"
 RDEPEND="${DEPEND}"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-3.0.14-fix-CUDA.patch"
+)
+
+src_prepare() {
+	use cuda && cuda_src_prepare
+
+	default
+}
 
 src_configure() {
 	local lapack_libs=no

--- a/sci-libs/cholmod/files/cholmod-3.0.14-fix-CUDA.patch
+++ b/sci-libs/cholmod/files/cholmod-3.0.14-fix-CUDA.patch
@@ -1,0 +1,109 @@
+https://bugs.gentoo.org/715610#c16
+https://bugs.gentoo.org/attachment.cgi?id=749631
+
+--- cholmod-3.0.14.old/GPU/Makefile.am	2020-09-29 22:59:54.000000000 +0300
++++ cholmod-3.0.14/GPU/Makefile.am	2021-11-09 02:20:06.579908785 +0300
+@@ -11,7 +11,7 @@
+ libcholmodl_gpu_la_CPPFLAGS = $(AM_CPPFLAGS) -DDLONG
+ 
+ libcholmod_gpu_la_SOURCES = cholmod_gpu_kernels.cu
+-libcholmod_gpu_la_LIBADD = libcholmodi_gpu.la libcholmodl_gpu.la
++libcholmod_gpu_la_LIBADD = libcholmodi_gpu.la libcholmodl_gpu.la cholmod_gpu_kernels.o
+ 
+-.cu.lo:
+-	$(LIBTOOL) --tag=CC --mode=compile $(NVCC) -c $<
++.cu.o:
++	$(NVCC) $(NVCCFLAGS) -o $@ -c $<
+--- cholmod-3.0.14.old/GPU/cholmod_gpu.h	1970-01-01 03:00:00.000000000 +0300
++++ cholmod-3.0.14/GPU/cholmod_gpu.h	2021-11-08 12:13:12.018328369 +0300
+@@ -0,0 +1,80 @@
++/* ========================================================================== */
++/* === Include/cholmod_gpu.h ================================================ */
++/* ========================================================================== */
++
++/* -----------------------------------------------------------------------------
++ * CHOLMOD/Include/cholmod_gpu.h.
++ * Copyright (C) 2014, Timothy A. Davis
++ * http://www.suitesparse.com
++ * -------------------------------------------------------------------------- */
++
++/* CHOLMOD GPU module
++ */
++
++#ifndef CHOLMOD_GPU_H
++#define CHOLMOD_GPU_H
++
++#ifdef GPU_BLAS
++#include "omp.h"
++#include <fenv.h>
++#ifndef SUITESPARSE_GPU_EXTERN_ON
++#include <cuda.h>
++#include <cuda_runtime.h>
++#endif
++#endif
++
++/* CHOLMOD_GPU_PRINTF: for printing GPU debug error messages */
++/*
++#define CHOLMOD_GPU_PRINTF(args) printf args
++*/
++#define CHOLMOD_GPU_PRINTF(args)
++
++/* define supernode requirements for processing on GPU */
++#define CHOLMOD_ND_ROW_LIMIT 256 /* required descendant rows */
++#define CHOLMOD_ND_COL_LIMIT 32  /* required descendnat cols */
++#define CHOLMOD_POTRF_LIMIT  512  /* required cols for POTRF & TRSM on GPU */
++
++/* # of host supernodes to perform before checking for free pinned buffers */
++#define CHOLMOD_GPU_SKIP     3    
++
++#define CHOLMOD_HANDLE_CUDA_ERROR(e,s) {if (e) {ERROR(CHOLMOD_GPU_PROBLEM,s);}}
++
++typedef struct cholmod_gpu_pointers
++{
++    double *h_Lx [CHOLMOD_HOST_SUPERNODE_BUFFERS] ;
++    double *d_Lx [CHOLMOD_DEVICE_STREAMS] ;
++    double *d_C ;
++    double *d_A [CHOLMOD_DEVICE_STREAMS] ;
++    void   *d_Ls ;
++    void   *d_Map ;
++    void   *d_RelativeMap ;
++
++} cholmod_gpu_pointers ;
++
++int cholmod_gpu_memorysize   /* GPU memory size available, 1 if no GPU */
++(
++    size_t         *total_mem,
++    size_t         *available_mem,
++    cholmod_common *Common
++) ;
++
++int cholmod_l_gpu_memorysize /* GPU memory size available, 1 if no GPU */
++(
++    size_t         *total_mem,
++    size_t         *available_mem,
++    cholmod_common *Common
++) ;
++ 
++int cholmod_gpu_probe   ( cholmod_common *Common ) ;
++int cholmod_l_gpu_probe ( cholmod_common *Common ) ;
++
++int cholmod_gpu_deallocate   ( cholmod_common *Common ) ;
++int cholmod_l_gpu_deallocate ( cholmod_common *Common ) ;
++
++void cholmod_gpu_end   ( cholmod_common *Common ) ;
++void cholmod_l_gpu_end ( cholmod_common *Common ) ;
++
++int cholmod_gpu_allocate   ( cholmod_common *Common ) ;
++int cholmod_l_gpu_allocate ( cholmod_common *Common ) ;
++
++#endif
+--- cholmod-3.0.14.old/configure.ac	2020-09-29 22:59:54.000000000 +0300
++++ cholmod-3.0.14/configure.ac	2021-11-08 12:17:00.865381081 +0300
+@@ -80,6 +80,7 @@
+ 		NVCC,
+ 		nvcc,,)
+     AC_SUBST([NVCC])
++    AC_SUBST([NVCCFLAGS])
+     AX_CHECK_PKG_LIB(
+ 		[cublas],
+ 		[cublas_v2.h],


### PR DESCRIPTION
- include cuda patch from https://bugs.gentoo.org/715610#c16
- make use of cuda.eclass for nvcc

Closes: https://bugs.gentoo.org/913921
Closes: https://bugs.gentoo.org/904973
Closes: https://bugs.gentoo.org/715610