### PR TITLE
gui-libs/wlroots: bump minimum version of libdrm

### DIFF
--- a/gui-libs/wlroots/wlroots-9999.ebuild
+++ b/gui-libs/wlroots/wlroots-9999.ebuild
@@ -29,7 +29,7 @@ REQUIRED_USE="
 DEPEND="
 	>=dev-libs/wayland-1.22.0
 	media-libs/mesa[egl(+),gles2]
-	>=x11-libs/libdrm-2.4.114
+	>=x11-libs/libdrm-2.4.118
 	x11-libs/libxkbcommon
 	>=x11-libs/pixman-0.42.0
 	drm? (


### PR DESCRIPTION
References: https://gitlab.freedesktop.org/wlroots/wlroots/-/commit/ae3d7a697c3e8b137f6cf5f9208cc9dd132f541c