### PR TITLE
dev-libs/libcbor: remove useless USE flag that is a no-op

### DIFF
--- a/dev-libs/libcbor/libcbor-0.10.2.ebuild
+++ b/dev-libs/libcbor/libcbor-0.10.2.ebuild
@@ -13,7 +13,7 @@ SRC_URI="https://github.com/PJK/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 LICENSE="MIT"
 SLOT="0/$(ver_cut 1-2)"
 KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86"
-IUSE="+custom-alloc doc test"
+IUSE="doc test"
 
 BDEPEND="
 	doc? (
@@ -42,7 +42,6 @@ pkg_setup() {
 src_configure() {
 	local mycmakeargs=(
 		-DCMAKE_BUILD_TYPE=Release
-		-DCBOR_CUSTOM_ALLOC=$(usex custom-alloc 'ON' 'OFF')
 		-DWITH_TESTS=$(usex test 'ON' 'OFF')
 	)
 

--- a/dev-libs/libcbor/metadata.xml
+++ b/dev-libs/libcbor/metadata.xml
@@ -5,9 +5,6 @@
 		<email>base-system@gentoo.org</email>
 		<name>Gentoo Base System</name>
 	</maintainer>
-	<use>
-		<flag name="custom-alloc">Custom, dynamically defined allocator support</flag>
-	</use>
 	<upstream>
 		<remote-id type="github">pjk/libcbor</remote-id>
 	</upstream>


### PR DESCRIPTION
The current ebuild logs a warning:

```
CMake Warning at CMakeLists.txt:22 (message):
  CBOR_CUSTOM_ALLOC has been deprecated.  Custom allocators are now enabled
  by default.The flag is a no-op and will be removed in the next version.
  Please remove CBOR_CUSTOM_ALLOC from your build configuation.
```

The USE flag only controls a cmake feature flag, but that feature flag is completely ignored and the resulting package is identical.

Upstream commit:
https://github.com/PJK/libcbor/commit/c03d88e02fe6f0a16389f6067b15dc3ed1b43401

Remove the USE flag. No revbump needed, the resulting package is the same either way, but people may feel free to rebuild on changed-USE anyway.