### PR TITLE
app-accessibility/brltty: correctly handle USE=python when building for non-default python

### DIFF
--- a/app-accessibility/brltty/brltty-6.6-r1.ebuild
+++ b/app-accessibility/brltty/brltty-6.6-r1.ebuild
@@ -135,7 +135,6 @@ src_configure() {
 		$(use_enable ocaml ocaml-bindings)
 		$(use_with pcm pcm-package)
 		$(use_enable policykit polkit)
-		$(use_enable python python-bindings)
 		$(use_enable speech speech-support)
 		$(use_with systemd service-package)
 		$(use_enable tcl tcl-bindings)

--- a/app-accessibility/brltty/brltty-6.6-r1.ebuild
+++ b/app-accessibility/brltty/brltty-6.6-r1.ebuild
@@ -42,7 +42,10 @@ DEPEND="
 	ncurses? ( sys-libs/ncurses:0= )
 	pcm? ( media-libs/alsa-lib )
 	policykit? ( sys-auth/polkit )
-	python? ( ${PYTHON_DEPS} )
+	python? (
+		${PYTHON_DEPS}
+		dev-python/setuptools[${PYTHON_USEDEP}]
+	)
 	speech? (
 		app-accessibility/espeak-ng
 		app-accessibility/flite

--- a/app-accessibility/brltty/brltty-6.6-r1.ebuild
+++ b/app-accessibility/brltty/brltty-6.6-r1.ebuild
@@ -68,6 +68,7 @@ RDEPEND="${DEPEND}
 	java? ( >=virtual/jre-1.8:* )
 "
 BDEPEND="
+	>=dev-lang/tcl-8.6.13-r1
 	virtual/pkgconfig
 	java? ( >=virtual/jdk-1.8:* )
 	nls? ( virtual/libintl )


### PR DESCRIPTION
It still does not install for me. Ever since commit 5b7979e4bfc53096ce7e9cf8c04081a26830d2a4, you run make install in Autostart/Udev, which only works when USE=tcl.


EDIT: fixed that too, I think.
