### PR TITLE
dev-ruby/stringio: correct test invocation

### DIFF
--- a/dev-ruby/stringio/stringio-3.0.6.ebuild
+++ b/dev-ruby/stringio/stringio-3.0.6.ebuild
@@ -26,5 +26,5 @@ all_ruby_prepare() {
 }
 
 each_ruby_test() {
-	${RUBY} -Ilib:.:test -e 'Dir["test/test_*.rb"].each{|f| require f}' || die
+	${RUBY} -Ilib:.:test:test/lib -rhelper -e 'Dir["test/**/test_*.rb"].each{|f| require f}' || die
 }

--- a/dev-ruby/stringio/stringio-3.0.7.ebuild
+++ b/dev-ruby/stringio/stringio-3.0.7.ebuild
@@ -26,5 +26,5 @@ all_ruby_prepare() {
 }
 
 each_ruby_test() {
-	${RUBY} -Ilib:.:test -e 'Dir["test/test_*.rb"].each{|f| require f}' || die
+	${RUBY} -Ilib:.:test:test/lib -rhelper -e 'Dir["test/**/test_*.rb"].each{|f| require f}' || die
 }

--- a/dev-ruby/stringio/stringio-3.0.8.ebuild
+++ b/dev-ruby/stringio/stringio-3.0.8.ebuild
@@ -26,5 +26,5 @@ all_ruby_prepare() {
 }
 
 each_ruby_test() {
-	${RUBY} -Ilib:.:test -e 'Dir["test/test_*.rb"].each{|f| require f}' || die
+	${RUBY} -Ilib:.:test:test/lib -rhelper -e 'Dir["test/**/test_*.rb"].each{|f| require f}' || die
 }

--- a/dev-ruby/stringio/stringio-3.1.0.ebuild
+++ b/dev-ruby/stringio/stringio-3.1.0.ebuild
@@ -26,5 +26,5 @@ all_ruby_prepare() {
 }
 
 each_ruby_test() {
-	${RUBY} -Ilib:.:test -e 'Dir["test/test_*.rb"].each{|f| require f}' || die
+	${RUBY} -Ilib:.:test:test/lib -rhelper -e 'Dir["test/**/test_*.rb"].each{|f| require f}' || die
 }


### PR DESCRIPTION
This appears to have always been wrong, but it's been a no-op, i.e. 0 tests executed doesn't fail src_test.