### PR TITLE
sci-electronics/kicad: Drop Python 3.9 support

### DIFF
--- a/sci-electronics/kicad/kicad-7.0.7.ebuild
+++ b/sci-electronics/kicad/kicad-7.0.7.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{10..11} )
 WX_GTK_VER="3.2-gtk3"
 
 inherit check-reqs cmake optfeature python-single-r1 toolchain-funcs wxwidgets xdg-utils

--- a/sci-electronics/kicad/kicad-7.0.8-r1.ebuild
+++ b/sci-electronics/kicad/kicad-7.0.8-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{10..11} )
 WX_GTK_VER="3.2-gtk3"
 
 inherit check-reqs cmake optfeature python-single-r1 toolchain-funcs wxwidgets xdg-utils

--- a/sci-electronics/kicad/kicad-7.0.9.ebuild
+++ b/sci-electronics/kicad/kicad-7.0.9.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{10..11} )
 WX_GTK_VER="3.2-gtk3"
 
 inherit check-reqs cmake optfeature python-single-r1 toolchain-funcs wxwidgets xdg-utils

--- a/sci-electronics/kicad/kicad-9999.ebuild
+++ b/sci-electronics/kicad/kicad-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{10..11} )
 WX_GTK_VER="3.2-gtk3"
 
 inherit check-reqs cmake optfeature python-single-r1 toolchain-funcs wxwidgets xdg-utils


### PR DESCRIPTION
Signed-off-by: Zoltan Puskas <zoltan@sinustrom.info>
