### PR TITLE
app-alternatives/pinentry: new package to control pinentry symlink

### DIFF
--- a/app-alternatives/pinentry/metadata.xml
+++ b/app-alternatives/pinentry/metadata.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="project">
+		<email>base-system@gentoo.org</email>
+		<name>Gentoo Base System</name>
+	</maintainer>
+	<maintainer type="person">
+		<email>vimproved@inventati.org</email>
+		<name>Violet Purcell</name>
+	</maintainer>
+	<use>
+		<flag name="efl">Symlink to pinentry-efl</flag>
+		<flag name="gtk">Symlink to pinentry-gnome3</flag>
+		<flag name="ncurses">Symlink to pinentry-curses</flag>
+		<flag name="qt5">Symlink to pinentry-qt5</flag>
+		<flag name="tty">Symlink to pinentry-tty</flag>
+	</use>
+</pkgmetadata>

--- a/app-alternatives/pinentry/pinentry-0.ebuild
+++ b/app-alternatives/pinentry/pinentry-0.ebuild
@@ -1,0 +1,33 @@
+# Copyright 2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+ALTERNATIVES=(
+	"ncurses:app-crypt/pinentry[ncurses]"
+	"gtk:app-crypt/pinentry[gtk]"
+	"qt5:app-crypt/pinentry[qt5]"
+	"efl:app-crypt/pinentry[efl]"
+	"tty:app-crypt/pinentry"
+)
+
+inherit app-alternatives
+
+DESCRIPTION="pinentry symlinks"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~arm64-macos ~ppc-macos ~x64-macos ~x64-solaris"
+
+src_install() {
+	local alternative
+	case $(get_alternative) in
+		ncurses)
+			alternative=curses
+			;;
+		gtk)
+			alternative=gnome3
+			;;
+		*)
+			alternative=$(get_alternative)
+			;;
+	esac
+	dosym pinentry-${alternative} /usr/bin/pinentry
+}

--- a/app-crypt/pinentry/pinentry-1.2.1-r5.ebuild
+++ b/app-crypt/pinentry/pinentry-1.2.1-r5.ebuild
@@ -1,0 +1,102 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/openpgp-keys/gnupg.asc
+inherit autotools qmake-utils verify-sig
+
+DESCRIPTION="Simple passphrase entry dialogs which utilize the Assuan protocol"
+HOMEPAGE="https://gnupg.org/aegypten2/"
+SRC_URI="mirror://gnupg/${PN}/${P}.tar.bz2"
+SRC_URI+=" verify-sig? ( mirror://gnupg/${PN}/${P}.tar.bz2.sig )"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~arm64-macos ~ppc-macos ~x64-macos ~x64-solaris"
+IUSE="caps efl emacs gtk keyring ncurses qt5 wayland X"
+
+DEPEND="
+	>=dev-libs/libassuan-2.1
+	>=dev-libs/libgcrypt-1.6.3
+	>=dev-libs/libgpg-error-1.17
+	efl? ( dev-libs/efl[X] )
+	keyring? ( app-crypt/libsecret )
+	ncurses? ( sys-libs/ncurses:= )
+	qt5? (
+		dev-qt/qtcore:5
+		dev-qt/qtgui:5
+		dev-qt/qtwidgets:5
+		wayland? ( kde-plasma/kwayland:5 )
+		X? (
+			dev-qt/qtx11extras:5
+			x11-libs/libX11
+		)
+	)
+"
+RDEPEND="
+	${DEPEND}
+	gtk? ( app-crypt/gcr:0[gtk] )
+"
+BDEPEND="
+	sys-devel/gettext
+	virtual/pkgconfig
+	verify-sig? ( sec-keys/openpgp-keys-gnupg )
+"
+PDEPEND="
+	app-alternatives/pinentry
+	emacs? ( app-emacs/pinentry )
+"
+
+DOCS=( AUTHORS ChangeLog NEWS README THANKS TODO )
+
+PATCHES=(
+	"${FILESDIR}/${PN}-1.0.0-AR.patch"
+	"${FILESDIR}/${PN}-1.2.1-automagic-capslock.patch" # bug #819939, bug #837719
+)
+
+src_prepare() {
+	default
+
+	unset FLTK_CONFIG
+
+	eautoreconf
+}
+
+src_configure() {
+	export PATH="$(qt5_get_bindir):${PATH}"
+	export QTLIB="$(qt5_get_libdir)"
+
+	local myeconfargs=(
+		$(use_enable efl pinentry-efl)
+		$(use_enable emacs pinentry-emacs)
+		$(use_enable keyring libsecret)
+		$(use_enable gtk pinentry-gnome3)
+		$(use_enable ncurses fallback-curses)
+		$(use_enable ncurses pinentry-curses)
+		$(use_enable qt5 pinentry-qt)
+		$(use_enable wayland kf5-wayland)
+		$(use_enable X qtx11extras)
+		$(use_with X x)
+
+		--enable-pinentry-tty
+		--disable-pinentry-fltk
+		--disable-pinentry-gtk2
+
+		MOC="$(qt5_get_bindir)"/moc
+		GPG_ERROR_CONFIG="${ESYSROOT}"/usr/bin/${CHOST}-gpg-error-config
+		LIBASSUAN_CONFIG="${ESYSROOT}"/usr/bin/libassuan-config
+
+		$("${S}/configure" --help | grep -- '--without-.*-prefix' | sed -e 's/^ *\([^ ]*\) .*/\1/g')
+	)
+
+	econf "${myeconfargs[@]}"
+}
+
+src_install() {
+	default
+
+	rm "${ED}"/usr/bin/pinentry || die
+
+	use qt5 && dosym pinentry-qt /usr/bin/pinentry-qt5
+}

--- a/profiles/arch/hppa/package.use.mask
+++ b/profiles/arch/hppa/package.use.mask
@@ -115,6 +115,7 @@ sci-mathematics/octave sundials
 
 # Matt Turner <mattst88@gentoo.org> (2022-05-07)
 # app-crypt/gcr is not keyworded
+app-alternatives/pinentry gtk
 app-crypt/pinentry gtk
 dev-libs/libgdata crypt
 

--- a/profiles/arch/ia64/package.use.mask
+++ b/profiles/arch/ia64/package.use.mask
@@ -173,6 +173,7 @@ dev-lang/php avif
 # dev-libs/efl not keyworded here
 # and is a desktop application mainly
 # bug #773178
+app-alternatives/pinentry efl
 app-crypt/pinentry efl
 
 # Joonas Niilola <juippis@gentoo.org> (2021-01-15)

--- a/profiles/arch/s390/package.use.mask
+++ b/profiles/arch/s390/package.use.mask
@@ -102,6 +102,7 @@ dev-libs/gobject-introspection doctool
 
 # Sam James <sam@gentoo.org> (2022-04-24)
 # dev-libs/efl not keyworded here and is a desktop application mainly
+app-alternatives/pinentry efl
 app-crypt/pinentry efl
 
 # Sam James <sam@gentoo.org> (2022-04-24)

--- a/profiles/arch/sparc/package.use.mask
+++ b/profiles/arch/sparc/package.use.mask
@@ -241,6 +241,7 @@ dev-lang/php avif
 # dev-libs/efl not keyworded here
 # and is a desktop application mainly
 # bug #773178
+app-alternatives/pinentry efl
 app-crypt/pinentry efl
 
 # Joonas Niilola <juippis@gentoo.org> (2021-01-15)

--- a/profiles/targets/desktop/package.use
+++ b/profiles/targets/desktop/package.use
@@ -1,6 +1,12 @@
 # Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Violet Purcell <vimproved@inventati.org> (2023-11-29)
+# app-alternatives/pinentry defaults to ncurses, and the desktop profile causes
+# issues due to gtk and qt5 being enabled. Disable them by default, let the
+# user set them.
+app-alternatives/pinentry -gtk -qt5
+
 # Andreas Sturmlechner <asturm@gentoo.org> (2023-11-12)
 # NSS: Required by kde-apps/okular[pdf]
 # Boost: app-text/poppler[qt5] recommended w/ Boost (bug #795888)


### PR DESCRIPTION
In line with replacing the eselect modules that modify files outside of /etc with packages in app-alternatives, this is a package meant to replace `app-eselect/eselect-pinentry` that controls which implementation of pinentry is symlinked to `/usr/bin/pinentry`. I don't think that anything should be necessary in the `pkg_postinst` of `app-crypt/pinentry` since removing `app-eselect/eselect-pinentry` does not remove the symlink, but please correct me if this assumption is wrong.