### PR TITLE
sys-kernel/dracut: dracut-version.sh is included in the source

### DIFF
--- a/sys-kernel/dracut/dracut-059_p20231027.ebuild
+++ b/sys-kernel/dracut/dracut-059_p20231027.ebuild
@@ -81,11 +81,6 @@ src_configure() {
 	tc-export CC PKG_CONFIG
 
 	edo ./configure "${myconf[@]}"
-
-	if [[ ${PV} != 9999 && ! -f dracut-version.sh ]] ; then
-		# Source tarball from github doesn't include this file
-		echo "DRACUT_VERSION=${PV}" > dracut-version.sh || die
-	fi
 }
 
 src_test() {

--- a/sys-kernel/dracut/dracut-060_pre20231030.ebuild
+++ b/sys-kernel/dracut/dracut-060_pre20231030.ebuild
@@ -82,11 +82,6 @@ src_configure() {
 	tc-export CC PKG_CONFIG
 
 	edo ./configure "${myconf[@]}"
-
-	if [[ ${PV} != 9999 && ! -f dracut-version.sh ]] ; then
-		# Source tarball from github doesn't include this file
-		echo "DRACUT_VERSION=${PV}" > dracut-version.sh || die
-	fi
 }
 
 src_test() {

--- a/sys-kernel/dracut/dracut-9999.ebuild
+++ b/sys-kernel/dracut/dracut-9999.ebuild
@@ -81,11 +81,6 @@ src_configure() {
 	tc-export CC PKG_CONFIG
 
 	edo ./configure "${myconf[@]}"
-
-	if [[ ${PV} != 9999 && ! -f dracut-version.sh ]] ; then
-		# Source tarball from github doesn't include this file
-		echo "DRACUT_VERSION=${PV}" > dracut-version.sh || die
-	fi
 }
 
 src_test() {


### PR DESCRIPTION
See https://github.com/dracutdevs/dracut/commit/b4e23ce4238821b0c2dd3c846da45f9cfeb57954.

Technically this is a no-op. The main benefit is to remove the confusing code block and less code to maintain.