### PR TITLE
dev-python/dparse: add test dependency

### DIFF
--- a/dev-python/dparse/dparse-0.6.3-r1.ebuild
+++ b/dev-python/dparse/dparse-0.6.3-r1.ebuild
@@ -1,0 +1,29 @@
+# Copyright 2022-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DISTUTILS_USE_PEP517=setuptools
+PYTHON_COMPAT=( pypy3 python3_{10..12} )
+
+inherit distutils-r1 pypi
+
+DESCRIPTION="A parser for Python dependency files"
+HOMEPAGE="
+	https://github.com/pyupio/dparse
+	https://pypi.org/project/dparse/
+"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~amd64"
+IUSE="test"
+
+distutils_enable_tests pytest
+
+BDEPEND="
+	test? (
+		dev-python/pipenv[${PYTHON_USEDEP}]
+	)"
+
+PDEPEND="dev-python/pipenv[${PYTHON_USEDEP}]"


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/917900

Reopening, so the bug linked is correct.