### PR TITLE
sci-libs/vtk: require <sci-libs/pdal-2.6.0

### DIFF
--- a/sci-libs/vtk/vtk-9.2.5.ebuild
+++ b/sci-libs/vtk/vtk-9.2.5.ebuild
@@ -103,7 +103,7 @@ RDEPEND="
 	mysql? ( dev-db/mariadb-connector-c )
 	odbc? ( dev-db/unixODBC )
 	openvdb? ( media-gfx/openvdb:= )
-	pdal? ( sci-libs/pdal:= )
+	pdal? ( <sci-libs/pdal-2.6.0:= )
 	postgres? ( dev-db/postgresql:= )
 	python? (
 		${PYTHON_DEPS}

--- a/sci-libs/vtk/vtk-9.2.6-r1.ebuild
+++ b/sci-libs/vtk/vtk-9.2.6-r1.ebuild
@@ -103,7 +103,7 @@ RDEPEND="
 	mysql? ( dev-db/mariadb-connector-c )
 	odbc? ( dev-db/unixODBC )
 	openvdb? ( media-gfx/openvdb:= )
-	pdal? ( sci-libs/pdal:= )
+	pdal? ( <sci-libs/pdal-2.6.0:= )
 	postgres? ( dev-db/postgresql:= )
 	python? (
 		${PYTHON_DEPS}


### PR DESCRIPTION
Broken, needs further work, limit for now.

https://gitlab.kitware.com/vtk/vtk/-/issues/19158

Bug: https://bugs.gentoo.org/918898