### PR TITLE
app-doc/doxygen: remove unused sqlite USE flag

### DIFF
--- a/app-doc/doxygen/doxygen-1.9.8.ebuild
+++ b/app-doc/doxygen/doxygen-1.9.8.ebuild
@@ -24,7 +24,7 @@ fi
 # GPL-2 also for bundled libmscgen
 LICENSE="GPL-2"
 SLOT="0"
-IUSE="clang debug doc dot doxysearch gui sqlite test"
+IUSE="clang debug doc dot doxysearch gui test"
 # - We need TeX for tests, bug #765472
 # - We keep the odd construct of noop USE=test because of
 #   the special relationship b/t RESTRICT & USE for tests.

--- a/app-doc/doxygen/doxygen-9999.ebuild
+++ b/app-doc/doxygen/doxygen-9999.ebuild
@@ -24,7 +24,7 @@ fi
 # GPL-2 also for bundled libmscgen
 LICENSE="GPL-2"
 SLOT="0"
-IUSE="clang debug doc dot doxysearch gui sqlite test"
+IUSE="clang debug doc dot doxysearch gui test"
 # - We need TeX for tests, bug #765472
 # - We keep the odd construct of noop USE=test because of
 #   the special relationship b/t RESTRICT & USE for tests.


### PR DESCRIPTION
While making a few changes to the live ebuild in commit
10c3fc41ee47042f6f3d16198e3fe178ec1d7752 the sqlite USE flag was removed
from src_configure with the rationale that upstream removed the option
to use the system sqlite. Since then, an upstream patch has been
backported for this, which is used unconditionally and comes with an
unconditional dependency on dev-db/sqlite, which still doesn't actually
check the USE flag value.

It was never removed from IUSE though (where it is disabled by default).
Clean it up.