### PR TITLE
x11-misc/colord: fix usage of vala eclass in EAPI 8

### DIFF
--- a/x11-misc/colord/colord-1.4.6-r2.ebuild
+++ b/x11-misc/colord/colord-1.4.6-r2.ebuild
@@ -63,9 +63,12 @@ PATCHES=(
 	"${FILESDIR}"/${P}-FILE_OFFSET_BITS.patch
 )
 
+pkg_setup() {
+	use vala && vala_setup
+}
+
 src_prepare() {
 	default
-	use vala && vala_src_prepare
 
 	# Test requires a running session
 	# https://github.com/hughsie/colord/issues/94


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/919032