### PR TITLE
cargo.eclass: explicitly disable stripping

### DIFF
--- a/eclass/cargo.eclass
+++ b/eclass/cargo.eclass
@@ -283,6 +283,13 @@ cargo_gen_config() {
 	[term]
 	verbose = true
 	$([[ "${NOCOLOR}" = true || "${NOCOLOR}" = yes ]] && echo "color = 'never'")
+
+	[profile.release]
+	strip = false
+
+	[profile.dev]
+	strip = false
+
 	$(_cargo_gen_git_config)
 	_EOF_
 


### PR DESCRIPTION
Some upstreams may be helpful and strip it for you, which is not what is desired on gentoo.

@freijon 

https://doc.rust-lang.org/cargo/reference/profiles.html