### PR TITLE
cargo.eclass: Allow CRATES to be unset

### DIFF
--- a/eclass/cargo.eclass
+++ b/eclass/cargo.eclass
@@ -35,11 +35,6 @@ case ${EAPI} in
 		# 1.52 may need setting RUSTC_BOOTSTRAP envvar for some crates
 		# 1.53 added cargo update --offline, can be used to update vulnerable crates from pre-fetched registry without editing toml
 		RUST_DEPEND=">=virtual/rust-1.53"
-
-		if [[ -z ${CRATES} && "${PV}" != *9999* ]]; then
-			eerror "undefined CRATES variable in non-live EAPI=8 ebuild"
-			die "CRATES variable not defined"
-		fi
 		;;
 esac
 


### PR DESCRIPTION
Remove the assertion requiring CRATES to be set for non-live ebuilds. There are valid use cases for ebuilds without CRATES, and the eclass works just fine -- e.g. when the package is using GIT_CRATES only, or when crates are provided via a tarball.