### PR TITLE
dev-perl/Search-Xapian: inmemory use flag required in xapian

### DIFF
--- a/dev-perl/Search-Xapian/Search-Xapian-1.2.25.5-r2.ebuild
+++ b/dev-perl/Search-Xapian/Search-Xapian-1.2.25.5-r2.ebuild
@@ -1,0 +1,38 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DIST_AUTHOR=OLLY
+inherit perl-module toolchain-funcs
+
+DESCRIPTION="Perl XS frontend to the Xapian C++ search library"
+
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~ia64 ~mips ~ppc ~ppc64 ~sparc ~x86"
+IUSE="examples test"
+RESTRICT="!test? ( test )"
+
+RDEPEND=">=dev-libs/xapian-1.4:0=[inmemory]
+	!dev-libs/xapian-bindings[perl]"
+DEPEND="${RDEPEND}
+	virtual/perl-ExtUtils-MakeMaker
+	test? ( dev-perl/Devel-Leak )
+"
+
+DIST_TEST=do
+# parallel fails sometimes...
+
+src_configure() {
+	myconf="CXX=$(tc-getCXX) CXXFLAGS=${CXXFLAGS}"
+	perl-module_src_configure
+}
+
+src_install() {
+	perl-module_src_install
+
+	use examples && {
+		docinto examples
+		dodoc "${S}"/examples/*
+	}
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/625658