### PR TITLE
net-misc/moonlight: Moonlight will not compile with vdpau if libsdl2 …

### DIFF
--- a/net-misc/moonlight/moonlight-5.0.1.ebuild
+++ b/net-misc/moonlight/moonlight-5.0.1.ebuild
@@ -38,7 +38,10 @@ RDEPEND="
 	libdrm? ( x11-libs/libdrm )
 	soundio? ( media-libs/libsoundio:= )
 	vaapi? ( media-libs/libva:=[wayland?,X?] )
-	vdpau? ( x11-libs/libvdpau )
+	vdpau? (
+		x11-libs/libvdpau
+		media-libs/libsdl2[X]
+	)
 	wayland? ( dev-libs/wayland )
 	X? ( x11-libs/libX11 )
 "


### PR DESCRIPTION
Moonlight fails to compile with vdpau if libsdl2 has been compiled without X support.

I am still investigating other solutions ( eg: patch to moonlight or further changes to this ebuild )

This may be a temporary workaround until a solution is found enabling a wayland only version of libsdl2 to work.