### PR TITLE
dev-lang/fuzion: restrict to jdk:17 for #916689

### DIFF
--- a/dev-lang/fuzion/fuzion-0.085-r1.ebuild
+++ b/dev-lang/fuzion/fuzion-0.085-r1.ebuild
@@ -29,8 +29,9 @@ RDEPEND="
 	>=virtual/jre-17:*
 	dev-libs/boehm-gc
 "
+# jdk:17 for https://bugs.gentoo.org/916689
 DEPEND="
-	>=virtual/jdk-17:*
+	virtual/jdk:17
 "
 BDEPEND="
 	test? ( sys-devel/clang:* )


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/916689