### PR TITLE
sys-cluster/kubelet: fix systemd service to work with kubeadm init

### DIFF
--- a/sys-cluster/kubelet/files/kubelet.env
+++ b/sys-cluster/kubelet/files/kubelet.env
@@ -11,7 +11,7 @@ KUBELET_ADDRESS="--address=127.0.0.1"
 KUBELET_HOSTNAME="--hostname-override=127.0.0.1"
 
 # Edit the kubelet.kubeconfig to have correct cluster server address
-KUBELET_KUBECONFIG=/etc/kubernetes/kubelet.kubeconfig
+KUBELET_KUBECONFIG="--config /var/lib/kubelet/config.yaml --kubeconfig=/etc/kubernetes/kubelet.conf"
 
 # Add your own!
-KUBELET_ARGS="--cgroup-driver=systemd --fail-swap-on=false"
+KUBELET_ARGS="--fail-swap-on=false"

--- a/sys-cluster/kubelet/files/kubelet.service-r1
+++ b/sys-cluster/kubelet/files/kubelet.service-r1
@@ -1,0 +1,25 @@
+[Unit]
+Description=Kubernetes Kubelet Server
+Documentation=https://kubernetes.io/docs/concepts/overview/components/#kubelet https://kubernetes.io/docs/reference/generated/kubelet/
+After=docker.service
+Requires=docker.service
+
+[Service]
+WorkingDirectory=/var/lib/kubelet
+EnvironmentFile=-/var/lib/kubelet/kubeadm-flags.env
+EnvironmentFile=-/etc/kubernetes/kubelet.env
+ExecStart=/usr/bin/kubelet \
+	    $KUBELET_KUBEADM_ARGS \
+	    $KUBE_LOGTOSTDERR \
+	    $KUBE_LOG_LEVEL \
+	    $KUBELET_KUBECONFIG \
+	    $KUBELET_ADDRESS \
+	    $KUBELET_PORT \
+	    $KUBELET_HOSTNAME \
+	    $KUBE_ALLOW_PRIV \
+	    $KUBELET_ARGS
+Restart=on-failure
+KillMode=process
+
+[Install]
+WantedBy=multi-user.target

--- a/sys-cluster/kubelet/kubelet-1.28.3-r1.ebuild
+++ b/sys-cluster/kubelet/kubelet-1.28.3-r1.ebuild
@@ -1,0 +1,37 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+inherit go-module systemd
+
+DESCRIPTION="Kubernetes Node Agent"
+HOMEPAGE="https://kubernetes.io"
+SRC_URI="https://github.com/kubernetes/kubernetes/archive/v${PV}.tar.gz -> kubernetes-${PV}.tar.gz"
+
+LICENSE="Apache-2.0"
+SLOT="0"
+KEYWORDS="~amd64 ~arm64"
+IUSE="hardened selinux"
+
+BDEPEND=">=dev-lang/go-1.20"
+RDEPEND="selinux? ( sec-policy/selinux-kubernetes )"
+
+RESTRICT+=" test "
+S="${WORKDIR}/kubernetes-${PV}"
+
+src_compile() {
+	CGO_LDFLAGS="$(usex hardened '-fno-PIC ' '')" \
+	emake -j1 GOFLAGS="" GOLDFLAGS="" LDFLAGS="" WHAT=cmd/${PN}
+}
+
+src_install() {
+	dobin _output/bin/${PN}
+	keepdir /etc/kubernetes/manifests /var/log/kubelet /var/lib/kubelet
+	newinitd "${FILESDIR}"/${PN}.initd ${PN}
+	newconfd "${FILESDIR}"/${PN}.confd ${PN}
+	insinto /etc/logrotate.d
+	newins "${FILESDIR}"/${PN}.logrotated ${PN}
+	systemd_newunit "${FILESDIR}"/${PN}.service-r1 ${PN}.service
+	insinto /etc/kubernetes
+	newins "${FILESDIR}"/${PN}.env ${PN}.env
+}


### PR DESCRIPTION
the new kubeadm init command creates config files for kubelet and a new environment file, which should be sourced by the systemd unit
