### PR TITLE
app-text/pelican: fix tests on musl

### DIFF
--- a/app-text/pelican/files/pelican-4.9.1-no-locales-for-tests.patch
+++ b/app-text/pelican/files/pelican-4.9.1-no-locales-for-tests.patch
@@ -1,0 +1,22 @@
+https://bugs.gentoo.org/863962
+https://git.alpinelinux.org/aports/tree/testing/py3-pelican/no-locales-for-tests.patch
+
+--- a/pelican/tests/support.py
++++ b/pelican/tests/support.py
+@@ -150,15 +150,7 @@
+ 
+ 
+ def locale_available(locale_):
+-    old_locale = locale.setlocale(locale.LC_TIME)
+-
+-    try:
+-        locale.setlocale(locale.LC_TIME, str(locale_))
+-    except locale.Error:
+-        return False
+-    else:
+-        locale.setlocale(locale.LC_TIME, old_locale)
+-        return True
++    return False
+ 
+ 
+ def can_symlink():

--- a/app-text/pelican/pelican-4.9.1.ebuild
+++ b/app-text/pelican/pelican-4.9.1.ebuild
@@ -47,11 +47,18 @@ BDEPEND="
 
 DOCS=( README.rst )
 
+# For musl, bug 863962
+PATCHES=( "${FILESDIR}/${PN}-4.9.1-no-locales-for-tests.patch" )
+
 EPYTEST_DESELECT=(
 	# Needs investigation, we weren't running tests at all before
 	pelican/tests/test_testsuite.py::TestSuiteTest::test_error_on_warning
 	pelican/tests/test_pelican.py::TestPelican::test_basic_generation_works
 	pelican/tests/test_pelican.py::TestPelican::test_custom_generation_works
+
+	# For musl, bug 863962
+	# Per Alpine https://git.alpinelinux.org/aports/tree/testing/py3-pelican/APKBUILD
+	pelican/tests/test_contents.py::TestPage::test_datetime
 )
 
 distutils_enable_tests pytest


### PR DESCRIPTION
These fixes come from [Alpine repo](https://git.alpinelinux.org/aports/tree/testing/py3-pelican).