### PR TITLE
dev-lang/cfortran: add -fcommon to CFLAGS for tests

### DIFF
--- a/dev-lang/cfortran/cfortran-20210827.ebuild
+++ b/dev-lang/cfortran/cfortran-20210827.ebuild
@@ -41,6 +41,7 @@ src_prepare() {
 
 src_configure() {
 	use sparc && append-fflags $(test-flags-FC -fno-store-merging -fno-tree-slp-vectorize) # bug 818400
+	append-cflags $(test-flags-CC -fcommon) # bug 899452
 	default
 }
 


### PR DESCRIPTION
In the failing test, both the Fortran code and the C code have a symbol called _fcb.  The test expects it to be in the common section in both objects, such that when it gets linked, they both refer to the same symbol, such that changes on the C side to the variable are reflected on the Fortran side and vice versa.  However with -fno-common then it's still placed in the common section in Fortran but in C it's placed in the BSS section, so now they refer to different objects.  The linker actually emits a warning for this, something like "alignment 1 is less than 16".

When there are two symbols in different sections with the same name, this is an ODR violation which is UB on all platforms.