### PR TITLE
app-cdr/cdrtools: Add support for big endian RISC-V

### DIFF
--- a/app-cdr/cdrtools/cdrtools-3.02_alpha09-r5.ebuild
+++ b/app-cdr/cdrtools/cdrtools-3.02_alpha09-r5.ebuild
@@ -121,6 +121,8 @@ src_prepare() {
 	# fix RISC-V build err, bug 811375
 	symlink_build_rules riscv
 	symlink_build_rules riscv64
+	# big endian support, bug 907029
+	symlink_build_rules riscv64be
 
 	# Add support for loong
 	symlink_build_rules loongarch64


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/907029