### PR TITLE
app-portage/pfl: enable py3.12

### DIFF
--- a/app-portage/pfl/pfl-3.2.1.ebuild
+++ b/app-portage/pfl/pfl-3.2.1.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9,10,11} )
+PYTHON_COMPAT=( python3_{9..12} )
 PYTHON_REQ_USE="xml(+)"
 
 inherit distutils-r1 systemd


### PR DESCRIPTION
Tested on amd64. Not sure, if this change warrants dropping the keywords to unstable.