### PR TITLE
dev-util/android-tools: Add patch to fix compilation on GCC 14

### DIFF
--- a/dev-util/android-tools/android-tools-34.0.1.ebuild
+++ b/dev-util/android-tools/android-tools-34.0.1.ebuild
@@ -47,6 +47,7 @@ DOCS=()
 src_prepare() {
 	eapply "${DISTDIR}/${PN}-31.0.3-no-gtest.patch"
 	eapply "${FILESDIR}/${PN}-34.0.0-protobuf.patch"
+	eapply "${FILESDIR}/${PN}-34.0.1-include-algorithm.patch"
 
 	cd "${S}/vendor/core" || die
 	eapply "${S}/patches/core/0011-Remove-the-useless-dependency-on-gtest.patch"

--- a/dev-util/android-tools/files/android-tools-34.0.1-include-algorithm.patch
+++ b/dev-util/android-tools/files/android-tools-34.0.1-include-algorithm.patch
@@ -1,0 +1,37 @@
+diff --git a/vendor/adb/client/incremental_utils.cpp b/vendor/adb/client/incremental_utils.cpp
+index 2f6958b..67f21a1 100644
+--- a/vendor/adb/client/incremental_utils.cpp
++++ b/vendor/adb/client/incremental_utils.cpp
+@@ -24,6 +24,7 @@
+ #include <ziparchive/zip_archive.h>
+ #include <ziparchive/zip_writer.h>
+ 
++#include <algorithm>
+ #include <array>
+ #include <cinttypes>
+ #include <numeric>
+diff --git a/vendor/core/fs_mgr/liblp/super_layout_builder.cpp b/vendor/core/fs_mgr/liblp/super_layout_builder.cpp
+index 37f28e1..0db82e5 100644
+--- a/vendor/core/fs_mgr/liblp/super_layout_builder.cpp
++++ b/vendor/core/fs_mgr/liblp/super_layout_builder.cpp
+@@ -17,6 +17,8 @@
+ 
+ #include <liblp/liblp.h>
+ 
++#include <algorithm>
++
+ #include "images.h"
+ #include "utility.h"
+ #include "writer.h"
+diff --git a/vendor/core/fs_mgr/liblp/utility.cpp b/vendor/core/fs_mgr/liblp/utility.cpp
+index d8e171b..70c7b79 100644
+--- a/vendor/core/fs_mgr/liblp/utility.cpp
++++ b/vendor/core/fs_mgr/liblp/utility.cpp
+@@ -25,6 +25,7 @@
+ #include <sys/ioctl.h>
+ #endif
+ 
++#include <algorithm>
+ #include <map>
+ #include <string>
+ #include <vector>


### PR DESCRIPTION
<algorithm> is no longer included by default in GCC 14 so explicitly including it is now required.

Upstream: https://github.com/nmeum/android-tools/pull/129
AOSP CR: https://android-review.googlesource.com/c/platform/packages/modules/adb/+/2838578
AOSP CR: https://android-review.googlesource.com/c/platform/system/core/+/2839495

Both CRs to AOSP have been merged and upstream has merged the PR as well, all that is needed is a version bump from AOSP.

Closes: https://bugs.gentoo.org/916788