### PR TITLE
games-emulation/bsnes-jg: fix arm endianness detection

### DIFF
--- a/games-emulation/bsnes-jg/bsnes-jg-1.1.2-r1.ebuild
+++ b/games-emulation/bsnes-jg/bsnes-jg-1.1.2-r1.ebuild
@@ -1,0 +1,50 @@
+# Copyright 2022-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs
+
+MY_PN=${PN%-*}
+MY_P=${MY_PN}-${PV}
+DESCRIPTION="Jolly Good Fork of bsnes"
+HOMEPAGE="https://gitlab.com/jgemu/bsnes"
+if [[ "${PV}" == *9999 ]] ; then
+	inherit git-r3
+	EGIT_REPO_URI="https://gitlab.com/jgemu/${MY_PN}.git"
+else
+	SRC_URI="https://gitlab.com/jgemu/${MY_PN}/-/archive/${PV}/${MY_P}.tar.bz2"
+	S="${WORKDIR}/${MY_P}"
+	KEYWORDS="~amd64 ~arm64 ~ppc ~ppc64 ~x86"
+fi
+
+LICENSE="ISC GPL-3+ LGPL-2.1+ MIT ZLIB"
+SLOT="1"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-endianness.patch # 891201#c9
+)
+
+DEPEND="
+	media-libs/jg:1=
+	media-libs/libsamplerate
+"
+RDEPEND="
+	${DEPEND}
+	games-emulation/jgrf
+"
+BDEPEND="
+	virtual/pkgconfig
+"
+
+src_compile() {
+	emake CC="$(tc-getCC)" CXX="$(tc-getCXX)" PKG_CONFIG="$(tc-getPKG_CONFIG)"
+}
+
+src_install() {
+	emake install \
+		DESTDIR="${D}" \
+		PREFIX="${EPREFIX}"/usr \
+		DOCDIR="${EPREFIX}"/usr/share/doc/${PF} \
+		LIBDIR="${EPREFIX}/usr/$(get_libdir)"
+}

--- a/games-emulation/bsnes-jg/files/bsnes-jg-1.1.2-endianness.patch
+++ b/games-emulation/bsnes-jg/files/bsnes-jg-1.1.2-endianness.patch
@@ -1,0 +1,58 @@
+https://bugs.gentoo.org/891201#c9
+https://gitlab.com/jgemu/bsnes/-/merge_requests/371
+https://gitlab.com/jgemu/bsnes/-/commit/647e868f3d97bd937c46ecf312bbfbc25b816dc1
+
+From 647e868f3d97bd937c46ecf312bbfbc25b816dc1 Mon Sep 17 00:00:00 2001
+From: orbea <orbea@riseup.net>
+Date: Sat, 9 Dec 2023 07:12:12 -0800
+Subject: [PATCH] processor: update endian.hpp
+
+Reference: https://sourceforge.net/p/predef/wiki/Endianness/
+---
+ src/processor/endian.hpp | 25 ++++++++++++++-----------
+ 1 file changed, 14 insertions(+), 11 deletions(-)
+
+diff --git a/src/processor/endian.hpp b/src/processor/endian.hpp
+index 3b6d93e..7d6ad04 100644
+--- a/src/processor/endian.hpp
++++ b/src/processor/endian.hpp
+@@ -1,25 +1,28 @@
+ #pragma once
+ 
++// Reference: https://sourceforge.net/p/predef/wiki/Endianness/
++
+ #if defined(__APPLE__)
+   #include <machine/endian.h>
+ #elif defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined (__DragonFly__)
+   #include <sys/endian.h>
+ #endif
+ 
+-#if  (defined(__BYTE_ORDER) && defined(__LITTLE_ENDIAN) && __BYTE_ORDER == __LITTLE_ENDIAN) \
+-  || (defined( _BYTE_ORDER) && defined( _LITTLE_ENDIAN) &&  _BYTE_ORDER ==  _LITTLE_ENDIAN) \
+-  || (defined(  BYTE_ORDER) && defined(  LITTLE_ENDIAN) &&   BYTE_ORDER ==   LITTLE_ENDIAN) \
+-  || defined(__LITTLE_ENDIAN__) \
+-  || defined(__i386__) || defined(__amd64__) || defined(__aarch64__) \
+-  || defined(_M_IX86) || defined(_M_AMD64)
++#if (defined(__BYTE_ORDER) && __BYTE_ORDER == __LITTLE_ENDIAN) \
++    || (defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__) \
++    || (defined(__FLOAT_WORD_ORDER__) && __FLOAT_WORD_ORDER__ == __ORDER_LITTLE_ENDIAN__) \
++    || defined(__LITTLE_ENDIAN__) || defined(__ARMEL__) || defined(__THUMBEL__) \
++    || defined(__AARCH64EL__) || defined(_MIPSEL) || defined(__MIPSEL) \
++    || defined(__MIPSEL__) || defined(_WIN32) || defined(_WIN64)
+   //little-endian: uint8_t[] { 0x01, 0x02, 0x03, 0x04 } == 0x04030201
+   #define order_lsb2(a,b)             a,b
+   #define order_lsb4(a,b,c,d)         a,b,c,d
+-#elif(defined(__BYTE_ORDER) && defined(__BIG_ENDIAN) && __BYTE_ORDER == __BIG_ENDIAN) \
+-  || (defined( _BYTE_ORDER) && defined( _BIG_ENDIAN) &&  _BYTE_ORDER ==  _BIG_ENDIAN) \
+-  || (defined(  BYTE_ORDER) && defined(  BIG_ENDIAN) &&   BYTE_ORDER ==   BIG_ENDIAN) \
+-  || defined(__BIG_ENDIAN__) \
+-  || defined(__powerpc__) || defined(_M_PPC)
++#elif (defined(__BYTE_ORDER) && __BYTE_ORDER == __BIG_ENDIAN) \
++    || (defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__) \
++    || (defined(__FLOAT_WORD_ORDER__) && __FLOAT_WORD_ORDER__ == __ORDER_BIG_ENDIAN__) \
++    || defined(__BIG_ENDIAN__) || defined(__ARMEB__) || defined(__THUMBEB__) \
++    || defined(__AARCH64EB__) || defined(_MIPSEB) || defined(__MIPSEB) \
++    || defined(__MIPSEB__) || defined(__powerpc__) || defined(_M_PPC)
+   //big-endian:    uint8_t[] { 0x01, 0x02, 0x03, 0x04 } == 0x01020304
+   #define order_lsb2(a,b)             b,a
+   #define order_lsb4(a,b,c,d)         d,c,b,a


### PR DESCRIPTION
Reported in comment #9 in issue #891201.

Bug: https://bugs.gentoo.org/891201
Upstream-PR: https://gitlab.com/jgemu/bsnes/-/merge_requests/371
Upstream-Commit: https://gitlab.com/jgemu/bsnes/-/commit/647e868f3d97bd937c46ecf312bbfbc25b816dc1