### PR TITLE
profiles: allow USE=cudnn only on amd64

### DIFF
--- a/profiles/arch/amd64/package.use.mask
+++ b/profiles/arch/amd64/package.use.mask
@@ -243,10 +243,6 @@ app-text/texlive-core -xindy
 # static-pie works on amd64, #719444
 sys-libs/glibc -static-pie
 
-# Guilherme Amadio <amadio@gentoo.org> (2020-03-16)
-# media-libs/cudnn is keyworded on amd64
-sci-physics/root -cudnn
-
 # Thomas Deutschmann <whissi@gentoo.org> (2020-03-11)
 # Encrypted Media Extensions (eme-free) can be disabled on amd64
 mail-client/thunderbird -eme-free

--- a/profiles/arch/amd64/use.mask
+++ b/profiles/arch/amd64/use.mask
@@ -4,6 +4,10 @@
 # Unmask the flag which corresponds to ARCH.
 -amd64
 
+# Paul Zander <negril.nx+gentoo@gmail.com> (2023-12-10)
+# cuDNN works here
+-cudnn
+
 # Paul Zander <negril.nx+gentoo@gmail.com> (2023-11-17)
 # ROCm/HIP works here
 -hip

--- a/profiles/arch/base/use.mask
+++ b/profiles/arch/base/use.mask
@@ -37,6 +37,9 @@ oci8
 cuda
 nvenc
 
+# cuDNN only works on amd64
+cudnn
+
 # ROCm/HIP only works on amd64
 hip
 

--- a/profiles/base/package.use.mask
+++ b/profiles/base/package.use.mask
@@ -660,10 +660,6 @@ dev-util/meson test
 # Ada support is not yet ready for sys-devel/gcc
 sys-devel/gcc ada
 
-# Guilherme Amadio <amadio@gentoo.org> (2020-03-16)
-# Requires dev-libs/cudnn which is only available on amd64
-sci-physics/root cudnn
-
 # Thomas Deutschmann <whissi@gentoo.org> (2020-03-11)
 # Encrypted Media Extensions (eme-free) can't be disabled everywhere
 mail-client/thunderbird eme-free


### PR DESCRIPTION
`USE=cudnn` was only masked for `sci-physics/root` on everything but `amd64`.
Make the mask global the same way cuda is so we can make use of the flag for other packages like opencv.

Bug: https://bugs.gentoo.org/830294
Bug: https://bugs.gentoo.org/905286