### PR TITLE
sys-libs/compiler-rt: replace "-emain" with "-e main" for LLVM 18

### DIFF
--- a/sys-libs/compiler-rt/compiler-rt-18.0.0.9999.ebuild
+++ b/sys-libs/compiler-rt/compiler-rt-18.0.0.9999.ebuild
@@ -94,7 +94,7 @@ src_configure() {
 		elif test_compiler "${nolib_flags[@]}" -nostartfiles; then
 			# Avoiding -nostartfiles earlier on for bug #862540,
 			# and set available entry symbol for bug #862798.
-			nolib_flags+=( -nostartfiles -emain )
+			nolib_flags+=( -nostartfiles -e main )
 
 			local -x LDFLAGS="${LDFLAGS} ${nolib_flags[*]}"
 			ewarn "${CC} seems to lack runtime, trying with ${nolib_flags[*]}"

--- a/sys-libs/compiler-rt/compiler-rt-18.0.0_pre20231129.ebuild
+++ b/sys-libs/compiler-rt/compiler-rt-18.0.0_pre20231129.ebuild
@@ -94,7 +94,7 @@ src_configure() {
 		elif test_compiler "${nolib_flags[@]}" -nostartfiles; then
 			# Avoiding -nostartfiles earlier on for bug #862540,
 			# and set available entry symbol for bug #862798.
-			nolib_flags+=( -nostartfiles -emain )
+			nolib_flags+=( -nostartfiles -e main )
 
 			local -x LDFLAGS="${LDFLAGS} ${nolib_flags[*]}"
 			ewarn "${CC} seems to lack runtime, trying with ${nolib_flags[*]}"


### PR DESCRIPTION
In the latest LLVM 18 snapshot, the joined form of the entrypoint argument (e.g. "-emain") was removed. Use "-e main" instead of "-emain" in nolib_flags.