### PR TITLE
dev-libs/zziplib: fix incompatible pointer types

### DIFF
--- a/dev-libs/zziplib/files/zziplib-0.13.72-incompatible-pointer-types.patch
+++ b/dev-libs/zziplib/files/zziplib-0.13.72-incompatible-pointer-types.patch
@@ -1,0 +1,48 @@
+Remove implicit pointer types conversions.
+
+See also: https://wiki.gentoo.org/wiki/Modern_C_porting
+Bug: https://bugs.gentoo.org/919066
+Upstream PR: https://github.com/gdraheim/zziplib/pull/150
+
+--- a/SDL/SDL_rwops_zzip.c
++++ b/SDL/SDL_rwops_zzip.c
+@@ -15,17 +15,17 @@
+ #define SDL_RWOPS_ZZIP_FILE(_context)  (ZZIP_FILE*) \
+              ((_context)->hidden.unknown.data1)
+ 
+-static int _zzip_seek(SDL_RWops *context, int offset, int whence)
++static Sint64 _zzip_seek(SDL_RWops *context, Sint64 offset, int whence)
+ {
+     return zzip_seek(SDL_RWOPS_ZZIP_FILE(context), offset, whence);
+ }
+ 
+-static int _zzip_read(SDL_RWops *context, void *ptr, int size, int maxnum)
++static size_t _zzip_read(SDL_RWops *context, void *ptr, size_t size, size_t maxnum)
+ {
+     return zzip_read(SDL_RWOPS_ZZIP_FILE(context), ptr, size*maxnum) / size;
+ }
+ 
+-static int _zzip_write(SDL_RWops *context, const void *ptr, int size, int num)
++static size_t _zzip_write(SDL_RWops *context, const void *ptr, size_t size, size_t num)
+ {
+     return 0; /* ignored */
+ }
+--- a/zzip/mmapped.c
++++ b/zzip/mmapped.c
+@@ -664,14 +664,14 @@ zzip_disk_entry_fopen(ZZIP_DISK * disk, ZZIP_DISK_ENTRY * entry)
+     off_t offset = zzip_file_header_to_data(header);
+     if (csize == 0xFFFFu) {
+         struct zzip_extra_zip64* zip64 =
+-           zzip_file_header_to_extras(header);
++         (struct zzip_extra_zip64*)zzip_file_header_to_extras(header);
+         if (ZZIP_EXTRA_ZIP64_CHECK(zip64)) {
+             csize = zzip_extra_zip64_csize(zip64);
+         }
+     }
+     if (offset == 0xFFFFu) {
+         struct zzip_extra_zip64* zip64 =
+-           zzip_file_header_to_extras(header);
++           (struct zzip_extra_zip64*)zzip_file_header_to_extras(header);
+         if (ZZIP_EXTRA_ZIP64_CHECK(zip64)) {
+             offset = zzip_extra_zip64_offset(zip64);
+         }

--- a/dev-libs/zziplib/zziplib-0.13.72-r4.ebuild
+++ b/dev-libs/zziplib/zziplib-0.13.72-r4.ebuild
@@ -1,0 +1,53 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+PYTHON_COMPAT=( python3_{9..12} )
+# Needed for docs, bug #835755
+PYTHON_REQ_USE="xml(+)"
+inherit cmake flag-o-matic python-any-r1
+
+DESCRIPTION="Lightweight library for extracting data from files archived in a single zip file"
+HOMEPAGE="https://github.com/gdraheim/zziplib https://zziplib.sourceforge.net"
+SRC_URI="https://github.com/gdraheim/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="|| ( LGPL-2.1 MPL-1.1 )"
+SLOT="0/13"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x64-solaris"
+IUSE="sdl static-libs"
+
+# Tests require internet access
+# https://github.com/gdraheim/zziplib/issues/24
+
+BDEPEND="
+	${PYTHON_DEPS}
+"
+DEPEND="
+	sys-libs/zlib
+	sdl? ( >=media-libs/libsdl-1.2.6 )
+"
+RDEPEND="${DEPEND}"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-0.13.72-Wint-conversion.patch
+	"${FILESDIR}"/${PN}-0.13.72-incompatible-pointer-types.patch
+)
+
+src_configure() {
+	# https://github.com/gdraheim/zziplib/commit/f3bfc0dd6663b7df272cc0cf17f48838ad724a2f#diff-b7b1e314614cf326c6e2b6eba1540682R100
+	append-flags -fno-strict-aliasing
+	# https://github.com/gdraheim/zziplib/issues/140 (bug #869980)
+	append-flags $(test-flags-CC -Wno-error=incompatible-function-pointer-types -Wno-error=int-conversion)
+
+	local mycmakeargs=(
+		-DZZIPSDL="$(usex sdl)"
+		-DBUILD_STATIC_LIBS="$(usex static-libs)"
+		-DBUILD_TESTS=OFF
+		-DZZIPTEST=OFF
+		-DZZIPDOCS=ON
+		-DZZIPWRAP=OFF
+	)
+
+	cmake_src_configure
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/919066

Signed-off-by: Pascal Jäger <pascal.jaeger@leimstift.de>