### PR TITLE
sci-libs/proj: add patch to install geotiff files

### DIFF
--- a/sci-libs/proj/files/proj-geotiff.patch
+++ b/sci-libs/proj/files/proj-geotiff.patch
@@ -1,0 +1,33 @@
+https://bugs.gentoo.org/917393
+https://github.com/OSGeo/PROJ/pull/3970
+
+From afccfb609db16524b602216d9dc2b55c154403bb Mon Sep 17 00:00:00 2001
+From: Marco Genasci <fedeliallalinea@gmail.com>
+Date: Sun, 26 Nov 2023 08:40:45 +0100
+Subject: [PATCH] Database: added ability to install *.tif if present in data
+
+---
+ data/CMakeLists.txt | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/data/CMakeLists.txt b/data/CMakeLists.txt
+index 4cb89e7849..85ed6ba8d4 100644
+--- a/data/CMakeLists.txt
++++ b/data/CMakeLists.txt
+@@ -38,6 +38,8 @@ set(GRIDSHIFT_FILES ${GSB_FILES} ${GTX_FILES})
+ 
+ file(GLOB SCHEMA_FILES *.json)
+ 
++file(GLOB GEOTIFF_FILES *.tif)
++
+ set(ALL_SQL_IN "${CMAKE_CURRENT_BINARY_DIR}/all.sql.in")
+ set(PROJ_DB "${CMAKE_CURRENT_BINARY_DIR}/proj.db")
+ include(sql_filelist.cmake)
+@@ -107,6 +109,7 @@ set(ALL_DATA_FILE
+   ${GRIDSHIFT_FILES}
+   ${PROJ_DB}
+   ${SCHEMA_FILES}
++  ${GEOTIFF_FILES}
+ )
+ install(
+   FILES ${ALL_DATA_FILE}

--- a/sci-libs/proj/proj-9.2.1-r1.ebuild
+++ b/sci-libs/proj/proj-9.2.1-r1.ebuild
@@ -6,7 +6,7 @@ EAPI=8
 inherit cmake
 
 # Check https://proj.org/download.html for latest data tarball
-PROJ_DATA="proj-data-1.15.tar.gz"
+PROJ_DATA="proj-data-1.13.tar.gz"
 DESCRIPTION="PROJ coordinate transformation software"
 HOMEPAGE="https://proj.org/"
 SRC_URI="
@@ -17,7 +17,7 @@ SRC_URI="
 LICENSE="MIT"
 # Changes on every major release
 SLOT="0/$(ver_cut 1)"
-KEYWORDS="~amd64 ~arm ~arm64 ~ia64 ~loong ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
+KEYWORDS="amd64 ~arm arm64 ~ia64 ~loong ~ppc ppc64 ~riscv ~s390 ~sparc x86 ~amd64-linux ~x86-linux ~ppc-macos"
 IUSE="curl test +tiff"
 RESTRICT="!test? ( test )"
 
@@ -30,6 +30,10 @@ DEPEND="
 	${RDEPEND}
 	test? ( dev-cpp/gtest )
 "
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-geotiff.patch
+)
 
 src_unpack() {
 	unpack ${P}.tar.gz

--- a/sci-libs/proj/proj-9.3.0-r1.ebuild
+++ b/sci-libs/proj/proj-9.3.0-r1.ebuild
@@ -6,7 +6,7 @@ EAPI=8
 inherit cmake
 
 # Check https://proj.org/download.html for latest data tarball
-PROJ_DATA="proj-data-1.13.tar.gz"
+PROJ_DATA="proj-data-1.15.tar.gz"
 DESCRIPTION="PROJ coordinate transformation software"
 HOMEPAGE="https://proj.org/"
 SRC_URI="
@@ -17,7 +17,7 @@ SRC_URI="
 LICENSE="MIT"
 # Changes on every major release
 SLOT="0/$(ver_cut 1)"
-KEYWORDS="amd64 ~arm arm64 ~ia64 ~loong ~ppc ppc64 ~riscv ~s390 ~sparc x86 ~amd64-linux ~x86-linux ~ppc-macos"
+KEYWORDS="~amd64 ~arm ~arm64 ~ia64 ~loong ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
 IUSE="curl test +tiff"
 RESTRICT="!test? ( test )"
 
@@ -30,6 +30,10 @@ DEPEND="
 	${RDEPEND}
 	test? ( dev-cpp/gtest )
 "
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-geotiff.patch
+)
 
 src_unpack() {
 	unpack ${P}.tar.gz


### PR DESCRIPTION
This patch is a backport of an upstream patch that will be applied in version 9.4.0 scheduled for March 01, 2024.

Upstream: https://github.com/OSGeo/PROJ/pull/3970

Closes: https://bugs.gentoo.org/917393