### PR TITLE
sys-apps/dracut: 059-r6 revbump for systemd 255 incompatibility

### DIFF
--- a/sys-kernel/dracut/dracut-059-r6.ebuild
+++ b/sys-kernel/dracut/dracut-059-r6.ebuild
@@ -1,0 +1,161 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit bash-completion-r1 optfeature systemd toolchain-funcs
+
+if [[ ${PV} == 9999 ]] ; then
+	inherit git-r3
+	EGIT_REPO_URI="https://github.com/dracutdevs/dracut"
+else
+	if [[ "${PV}" != *_rc* ]]; then
+		KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~mips ~ppc ~ppc64 ~riscv ~sparc ~x86"
+	fi
+	SRC_URI="https://github.com/dracutdevs/dracut/archive/refs/tags/${PV}.tar.gz -> ${P}.tar.gz"
+fi
+
+DESCRIPTION="Generic initramfs generation tool"
+HOMEPAGE="https://github.com/dracutdevs/dracut/wiki"
+
+LICENSE="GPL-2"
+SLOT="0"
+IUSE="selinux test"
+
+RESTRICT="!test? ( test )"
+
+RDEPEND="
+	app-arch/cpio
+	>=app-shells/bash-4.0:0
+	sys-apps/coreutils[xattr(-)]
+	>=sys-apps/kmod-23[tools]
+	|| (
+		>=sys-apps/sysvinit-2.87-r3
+		sys-apps/openrc[sysv-utils(-),selinux?]
+		sys-apps/systemd[sysv-utils]
+		sys-apps/s6-linux-init[sysv-utils(-)]
+	)
+	>=sys-apps/util-linux-2.21
+	virtual/pkgconfig
+	virtual/udev
+
+	elibc_musl? ( sys-libs/fts-standalone )
+	selinux? (
+		sec-policy/selinux-dracut
+		sys-libs/libselinux
+		sys-libs/libsepol
+	)
+"
+DEPEND="
+	>=sys-apps/kmod-23
+	elibc_musl? ( sys-libs/fts-standalone )
+"
+
+BDEPEND="
+	app-text/asciidoc
+	app-text/docbook-xml-dtd:4.5
+	>=app-text/docbook-xsl-stylesheets-1.75.2
+	>=dev-libs/libxslt-1.1.26
+	virtual/pkgconfig
+"
+
+QA_MULTILIB_PATHS="usr/lib/dracut/.*"
+
+PATCHES=(
+	"${FILESDIR}"/gentoo-ldconfig-paths-r1.patch
+	"${FILESDIR}"/gentoo-network-r1.patch
+	"${FILESDIR}"/059-kernel-install-uki.patch
+	"${FILESDIR}"/059-uefi-split-usr.patch
+	"${FILESDIR}"/059-uki-systemd-254.patch
+	"${FILESDIR}"/059-gawk.patch
+	"${FILESDIR}"/dracut-059-dmsquash-live.patch
+	"${FILESDIR}"/059-systemd-pcrphase.patch
+	"${FILESDIR}"/059-systemd-executor.patch
+)
+
+src_configure() {
+	local myconf=(
+		--prefix="${EPREFIX}/usr"
+		--sysconfdir="${EPREFIX}/etc"
+		--bashcompletiondir="$(get_bashcompdir)"
+		--systemdsystemunitdir="$(systemd_get_systemunitdir)"
+	)
+
+	tc-export CC PKG_CONFIG
+
+	echo ./configure "${myconf[@]}"
+	./configure "${myconf[@]}" || die
+
+	if [[ ${PV} != 9999 && ! -f dracut-version.sh ]] ; then
+		# Source tarball from github doesn't include this file
+		echo "DRACUT_VERSION=${PV}" > dracut-version.sh || die
+	fi
+}
+
+src_test() {
+	if [[ ${EUID} != 0 ]]; then
+		# Tests need root privileges, bug #298014
+		ewarn "Skipping tests: Not running as root."
+	elif [[ ! -w /dev/kvm ]]; then
+		ewarn "Skipping tests: Unable to access /dev/kvm."
+	else
+		emake -C test check
+	fi
+}
+
+src_install() {
+	local DOCS=(
+		AUTHORS
+		NEWS.md
+		README.md
+		docs/README.cross
+		docs/README.generic
+		docs/README.kernel
+		docs/SECURITY.md
+	)
+
+	default
+
+	docinto html
+	dodoc dracut.html
+}
+
+pkg_postinst() {
+	optfeature "Networking support" net-misc/networkmanager
+	optfeature "Legacy networking support" net-misc/curl "net-misc/dhcp[client]" \
+		sys-apps/iproute2 "net-misc/iputils[arping]"
+	optfeature "Scan for Btrfs on block devices"  sys-fs/btrfs-progs
+	optfeature "Load kernel modules and drop this privilege for real init" \
+		sys-libs/libcap
+	optfeature "Support CIFS" net-fs/cifs-utils
+	optfeature "Decrypt devices encrypted with cryptsetup/LUKS" \
+		"sys-fs/cryptsetup[-static-libs]"
+	optfeature "Support for GPG-encrypted keys for crypt module" \
+		app-crypt/gnupg
+	optfeature \
+		"Allows use of dash instead of default bash (on your own risk)" \
+		app-shells/dash
+	optfeature \
+		"Allows use of busybox instead of default bash (on your own risk)" \
+		sys-apps/busybox
+	optfeature "Support iSCSI" sys-block/open-iscsi
+	optfeature "Support Logical Volume Manager" sys-fs/lvm2[lvm]
+	optfeature "Support MD devices, also known as software RAID devices" \
+		sys-fs/mdadm sys-fs/dmraid
+	optfeature "Support Device Mapper multipathing" sys-fs/multipath-tools
+	optfeature "Plymouth boot splash"  '>=sys-boot/plymouth-0.8.5-r5'
+	optfeature "Support network block devices" sys-block/nbd
+	optfeature "Support NFS" net-fs/nfs-utils net-nds/rpcbind
+	optfeature \
+		"Install ssh and scp along with config files and specified keys" \
+		virtual/openssh
+	optfeature "Enable logging with rsyslog" app-admin/rsyslog
+	optfeature "Support Squashfs" sys-fs/squashfs-tools
+	optfeature "Support TPM 2.0 TSS" app-crypt/tpm2-tools
+	optfeature "Support Bluetooth (experimental)" net-wireless/bluez
+	optfeature "Support BIOS-given device names" sys-apps/biosdevname
+	optfeature "Support network NVMe" sys-apps/nvme-cli
+	optfeature \
+		"Enable rngd service to help generating entropy early during boot" \
+		sys-apps/rng-tools
+}

--- a/sys-kernel/dracut/files/059-systemd-executor.patch
+++ b/sys-kernel/dracut/files/059-systemd-executor.patch
@@ -1,0 +1,31 @@
+From bee1c4824a8cd47ce6c01892a548bdc07b1fa678 Mon Sep 17 00:00:00 2001
+From: Frantisek Sumsal <frantisek@sumsal.cz>
+Date: Sat, 14 Oct 2023 23:45:57 +0200
+Subject: [PATCH] feat(systemd): install systemd-executor
+
+In [0] systemd gained a new binary - systemd-executor - that's used to
+spawn processes forked off systemd. Let's copy it into the initrd if
+it's available.
+
+[0] https://github.com/systemd/systemd/pull/27890
+
+Signed-off-by: Brian Harring <ferringb@gmail.com>
+---
+ modules.d/00systemd/module-setup.sh | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/modules.d/00systemd/module-setup.sh b/modules.d/00systemd/module-setup.sh
+index 554c25a08..9a13a1dbb 100755
+--- a/modules.d/00systemd/module-setup.sh
++++ b/modules.d/00systemd/module-setup.sh
+@@ -34,6 +34,7 @@ install() {
+         "$systemdutildir"/systemd \
+         "$systemdutildir"/systemd-coredump \
+         "$systemdutildir"/systemd-cgroups-agent \
++        "$systemdutildir"/systemd-executor \
+         "$systemdutildir"/systemd-shutdown \
+         "$systemdutildir"/systemd-reply-password \
+         "$systemdutildir"/systemd-fsck \
+-- 
+2.41.0
+

--- a/sys-kernel/dracut/files/059-systemd-pcrphase.patch
+++ b/sys-kernel/dracut/files/059-systemd-pcrphase.patch
@@ -1,0 +1,89 @@
+From cd6f683d634970112a29867137431d0d57f8c957 Mon Sep 17 00:00:00 2001
+From: Antonio Alvarez Feijoo <antonio.feijoo@suse.com>
+Date: Thu, 9 Feb 2023 13:55:47 +0100
+Subject: [PATCH] fix(systemd-pcrphase): only include
+ systemd-pcrphase-initrd.service
+
+The only systemd-pcrphase related unit configured to run in the initrd is
+systemd-pcrphase-initrd.service.
+Both systemd-pcrphase.service and systemd-pcrphase-sysinit.service contain
+`ConditionPathExists=!/etc/initrd-release`.
+
+Signed-off-by: Brian Harring <ferringb@gmail.com>
+---
+ modules.d/01systemd-pcrphase/module-setup.sh | 8 --------
+ 1 file changed, 8 deletions(-)
+
+diff --git a/modules.d/01systemd-pcrphase/module-setup.sh b/modules.d/01systemd-pcrphase/module-setup.sh
+index 3dbb4974..fa960a42 100755
+--- a/modules.d/01systemd-pcrphase/module-setup.sh
++++ b/modules.d/01systemd-pcrphase/module-setup.sh
+@@ -28,10 +28,6 @@ install() {
+ 
+     inst_multiple -o \
+         "$systemdutildir"/systemd-pcrphase \
+-        "$systemdsystemunitdir"/systemd-pcrphase.service \
+-        "$systemdsystemunitdir/systemd-pcrphase.service.d/*.conf" \
+-        "$systemdsystemunitdir"/systemd-pcrphase-sysinit.service \
+-        "$systemdsystemunitdir/systemd-pcrphase-sysinit.service/*.conf" \
+         "$systemdsystemunitdir"/systemd-pcrphase-initrd.service \
+         "$systemdsystemunitdir/systemd-pcrphase-initrd.service.d/*.conf" \
+         "$systemdsystemunitdir"/initrd.target.wants/systemd-pcrphase-initrd.service
+@@ -39,10 +35,6 @@ install() {
+     # Install the hosts local user configurations if enabled.
+     if [[ $hostonly ]]; then
+         inst_multiple -H -o \
+-            "$systemdsystemconfdir"/systemd-pcrphase.service \
+-            "$systemdsystemconfdir/systemd-pcrphase.service.d/*.conf" \
+-            "$systemdsystemconfdir"/systemd-pcrphase-sysinit.service \
+-            "$systemdsystemconfdir/systemd-pcrphase-sysinit.service.d/*.conf" \
+             "$systemdsystemconfdir"/systemd-pcrphase-initrd.service \
+             "$systemdsystemconfdir/systemd-pcrphase-initrd.service.d/*.conf" \
+             "$systemdsystemconfdir"/initrd.target.wants/systemd-pcrphase-initrd.service
+-- 
+2.41.0
+
+From cd93aaa2e096a8cbd1f1789dcce06857067b35c9 Mon Sep 17 00:00:00 2001
+From: Brian Harring <ferringb@gmail.com>
+Date: Mon, 11 Dec 2023 17:10:20 -0800
+Subject: [PATCH] fix(systemd-255): handle systemd-pcr{phase -> extend} rename
+
+The binary systemd-pcrphase was renamed to systemd-pcrextend
+in systemd 255, but the backing units were all left named
+systemd-pcrphase.
+
+Fixes: #2583
+
+Signed-off-by: Brian Harring <ferringb@gmail.com>
+---
+ modules.d/01systemd-pcrphase/module-setup.sh | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/modules.d/01systemd-pcrphase/module-setup.sh b/modules.d/01systemd-pcrphase/module-setup.sh
+index fa960a42c..87efd0c1a 100755
+--- a/modules.d/01systemd-pcrphase/module-setup.sh
++++ b/modules.d/01systemd-pcrphase/module-setup.sh
+@@ -6,7 +6,11 @@
+ check() {
+ 
+     # If the binary(s) requirements are not fulfilled the module can't be installed.
+-    require_binaries "$systemdutildir"/systemd-pcrphase || return 1
++    # systemd-255 renamed the binary, check for old and new location.
++    if ! require_binaries "$systemdutildir"/systemd-pcrphase && \
++       ! require_binaries "$systemdutildir"/systemd-pcrextend; then
++       return 1
++    fi
+ 
+     # Return 255 to only include the module, if another module requires it.
+     return 255
+@@ -28,6 +32,7 @@ install() {
+ 
+     inst_multiple -o \
+         "$systemdutildir"/systemd-pcrphase \
++        "$systemdutildir"/systemd-pcrextend \
+         "$systemdsystemunitdir"/systemd-pcrphase-initrd.service \
+         "$systemdsystemunitdir/systemd-pcrphase-initrd.service.d/*.conf" \
+         "$systemdsystemunitdir"/initrd.target.wants/systemd-pcrphase-initrd.service
+-- 
+2.41.0
+


### PR DESCRIPTION
changes:
- fix pcr{phrase -> extend} rename and reduction. Renamed patch isn't yet merged, PR is at: https://github.com/dracutdevs/dracut/pull/2586
- add systemd-executor (systemd flat out fails without it) This was already merged upstream.

At least for my setup, this is enough to get systemd-255/dracut behaving again.