### PR TITLE
dev-lang/zig: remove ".max_rss" fields initializers from build.zig in 9999

### DIFF
--- a/dev-lang/zig/zig-9999.ebuild
+++ b/dev-lang/zig/zig-9999.ebuild
@@ -148,6 +148,11 @@ src_configure() {
 }
 
 src_compile() {
+	# Remove "limit memory usage" flags, it's already verified by
+	# CHECKREQS_MEMORY and causes unneccessary errors. Upstream set them
+	# according to CI OOM failures, which are higher than during Gentoo build.
+	sed -i -e '/\.max_rss = .*,/d' build.zig || die
+
 	if ! use llvm; then
 		$(tc-getCC) -o bootstrap bootstrap.c || die "Zig's bootstrap.c compilation failed"
 		edob ./bootstrap


### PR DESCRIPTION
They are too high and cause errors like below:
 * https://www.github.com/ziglang/zig/issues/18263