### PR TITLE
net-p2p/bitcoin-core: fix build failure when USE="-daemon"

### DIFF
--- a/net-p2p/bitcoin-core/bitcoin-core-26.0.ebuild
+++ b/net-p2p/bitcoin-core/bitcoin-core-26.0.ebuild
@@ -194,7 +194,9 @@ src_configure() {
 src_compile() {
 	default
 
-	tc-is-cross-compiler || TOPDIR="${S}" bash contrib/devtools/gen-bitcoin-conf.sh || die
+	if use daemon && ! tc-is-cross-compiler ; then
+		TOPDIR="${S}" bash contrib/devtools/gen-bitcoin-conf.sh || die
+	fi
 	sed -e 's/ To use, copy this file$//p;Tp;:0;n;/save the file\.$/!b0;d;:p;p' \
 		-ni share/examples/bitcoin.conf || die
 }


### PR DESCRIPTION
Regenerating the example bitcoin.conf doesn't work when we didn't build bitcoind.

No revbump required since it was not possible to complete a build in the affected configurations.

Fixes: https://bugs.gentoo.org/919772

@Flowdalic