### PR TITLE
dev-util/qdevicemonitor: disable pedantic errors

### DIFF
--- a/dev-util/qdevicemonitor/files/qdevicemonitor-1.0.1-disable-pedantic-errors.patch
+++ b/dev-util/qdevicemonitor/files/qdevicemonitor-1.0.1-disable-pedantic-errors.patch
@@ -1,0 +1,31 @@
+From 5b2a6cbc4d64d5ee48d6fae1cf2a8f17335be634 Mon Sep 17 00:00:00 2001
+From: Alexander Lopatin <alopatindev@gmail.com>
+Date: Wed, 13 Dec 2023 19:16:54 +0800
+Subject: [PATCH] Disable pedantic errors
+
+https://bugs.gentoo.org/919714
+---
+ qdevicemonitor/qdevicemonitor.pro | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/qdevicemonitor/qdevicemonitor.pro b/qdevicemonitor/qdevicemonitor.pro
+index 6aa2ecf..5327af0 100644
+--- a/qdevicemonitor/qdevicemonitor.pro
++++ b/qdevicemonitor/qdevicemonitor.pro
+@@ -61,11 +61,11 @@ FORMS += \
+ 
+ CONFIG += c++11 link_pkgconfig
+ 
+-QMAKE_CXXFLAGS += -pedantic-errors -pedantic -Wextra -Wall
++QMAKE_CXXFLAGS += -Wextra -Wall
+ QMAKE_CXXFLAGS_RELEASE -= -O2
+ QMAKE_CXXFLAGS_RELEASE += -O3
+ 
+-QMAKE_CFLAGS += -pedantic-errors -pedantic -Wextra -Wall -std=c11
++QMAKE_CFLAGS += -Wextra -Wall -std=c11
+ QMAKE_CFLAGS_RELEASE -= -O2
+ QMAKE_CFLAGS_RELEASE += -O3
+ 
+-- 
+2.41.0
+

--- a/dev-util/qdevicemonitor/qdevicemonitor-1.0.1-r2.ebuild
+++ b/dev-util/qdevicemonitor/qdevicemonitor-1.0.1-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -34,6 +34,7 @@ PATCHES=(
 	"${FILESDIR}"/${P}-screen-geometry-is-deprecated.patch
 	"${FILESDIR}"/${P}-endl-is-deprecated.patch
 	"${FILESDIR}"/${P}-disable-warnings-as-errors.patch
+	"${FILESDIR}"/${P}-disable-pedantic-errors.patch
 )
 
 src_configure() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/919714