### PR TITLE
dev-libs/libdnet: fix lookup path for libcheck.so on 64-bit

### DIFF
--- a/dev-libs/libdnet/libdnet-1.16.4.ebuild
+++ b/dev-libs/libdnet/libdnet-1.16.4.ebuild
@@ -36,6 +36,9 @@ src_prepare() {
 		-e 's/libcheck.a/libcheck.so/g' \
 		configure.ac || die
 	sed -i \
+		-e "s/lib\/libcheck/$(get_libdir)\/libcheck/g" \
+		configure.ac || die
+	sed -i \
 		-e 's|-L$libdir ||g' \
 		dnet-config.in || die
 	sed -i \

--- a/dev-libs/libdnet/libdnet-1.17.0.ebuild
+++ b/dev-libs/libdnet/libdnet-1.17.0.ebuild
@@ -40,6 +40,9 @@ src_prepare() {
 		-e 's/libcheck.a/libcheck.so/g' \
 		configure.ac || die
 	sed -i \
+		-e "s/lib\/libcheck/$(get_libdir)\/libcheck/g" \
+		configure.ac || die
+	sed -i \
 		-e 's|-L$libdir ||g' \
 		dnet-config.in || die
 	sed -i \


### PR DESCRIPTION
We pass `--with-check=/usr`, and the configure file is hardcoded to look for `<path>/lib/libcheck.so` (we already replace `libcheck.a` with `libcheck.so`).  Adjust this path so it uses `lib64` on 64-bit.