### PR TITLE
dev-python/pythonfinder: Add missing dev-python/click test dep

### DIFF
--- a/dev-python/pythonfinder/pythonfinder-2.0.6.ebuild
+++ b/dev-python/pythonfinder/pythonfinder-2.0.6.ebuild
@@ -21,6 +21,9 @@ KEYWORDS="~amd64 ~arm64 ~riscv"
 RDEPEND="
 	>=dev-python/pydantic-2[${PYTHON_USEDEP}]
 "
+BDEPEND="
+	test? ( dev-python/click[${PYTHON_USEDEP}] )
+"
 
 distutils_enable_tests pytest
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/919861