### PR TITLE
app-office/gnucash: fix python finding

### DIFF
--- a/app-office/gnucash/files/gnucash-5.4-fix-python-finding.patch
+++ b/app-office/gnucash/files/gnucash-5.4-fix-python-finding.patch
@@ -1,0 +1,49 @@
+https://bugs.gentoo.org/919859
+https://github.com/Gnucash/gnucash/commit/3782eed56785adaca02cf2bd4766d3825a6f6ca7
+
+From 3782eed56785adaca02cf2bd4766d3825a6f6ca7 Mon Sep 17 00:00:00 2001
+From: Simon Arlott <sa.me.uk>
+Date: Wed, 4 Oct 2023 21:15:11 +0100
+Subject: [PATCH] Use the default version of Python 3
+
+Python scripts that run with the default version of Python 3 by executing
+with /usr/bin/python3 that try to import gnucash can't find it if it has
+been built for a different version.
+
+Instead of using other installed versions of Python 3 that happen to be
+present, default to using the default "unversioned" version.
+
+It doesn't look like CMake are going to fix the default behaviour, so every
+project has to do this:
+https://gitlab.kitware.com/cmake/cmake/-/issues/24878
+https://gitlab.kitware.com/cmake/cmake/-/issues/24126
+https://gitlab.kitware.com/cmake/cmake/-/merge_requests/8287
+
+This is only supported on CMake 3.20 or newer, so users of older versions
+will still get the broken behaviour.
+
+Use the newer default Python3_FIND_STRATEGY=LOCATION (CMP0094).
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -2,6 +2,11 @@
+ 
+ cmake_minimum_required (VERSION 3.14.5)
+ 
++# CMake 3.15+ Python3_FIND_STRATEGY=LOCATION
++if (POLICY CMP0094)
++  cmake_policy(SET CMP0094 NEW)
++endif()
++
+ project (gnucash
+     VERSION 5.4
+ )
+@@ -492,6 +497,9 @@ endif()
+ 
+ if (WITH_PYTHON)
+   set (PYTHON_MIN_VERSION 3.6.0)
++  if (NOT DEFINED Python3_FIND_UNVERSIONED_NAMES)
++    set (Python3_FIND_UNVERSIONED_NAMES FIRST)
++  endif()
+   find_package (Python3 ${PYTHON_MIN_VERSION} COMPONENTS Interpreter Development)
+   if (NOT Python3_FOUND)
+     message(SEND_ERROR "Python support enabled, but Python3 interpreter and/or libaries not found.")

--- a/app-office/gnucash/gnucash-5.4-r1.ebuild
+++ b/app-office/gnucash/gnucash-5.4-r1.ebuild
@@ -90,10 +90,16 @@ DEPEND="
 	sys-devel/libtool
 	>=dev-cpp/gtest-1.8.0
 "
+# distutils is not available in python3.12, but it is still in setuptools
 BDEPEND="
 	dev-lang/swig
 	>=dev-util/cmake-3.10
 	virtual/pkgconfig
+	python? (
+		$(python_gen_cond_dep '
+			dev-python/setuptools[${PYTHON_USEDEP}]
+		')
+	)
 "
 
 PDEPEND="
@@ -111,6 +117,9 @@ PATCHES=(
 	# This is only to prevent webkit2gtk-4 from being selected.
 	# https://bugs.gentoo.org/893676
 	"${FILESDIR}/${PN}-5.0-webkit2gtk-4.1.patch"
+
+	# bug #919859
+	"${FILESDIR}/${PN}-5.4-fix-python-finding.patch"
 )
 
 # guile generates ELF files without use of C or machine code


### PR DESCRIPTION
* Also require dev-python/setuptools with python3.12 due distutils getting removed.

Closes: https://bugs.gentoo.org/919859

The backported patch https://github.com/Gnucash/gnucash/commit/3782eed56785adaca02cf2bd4766d3825a6f6ca7

Older version are still affected of course.