### PR TITLE
Allow building dist kernels with savedconfig on loong

### DIFF
--- a/eclass/dist-kernel-utils.eclass
+++ b/eclass/dist-kernel-utils.eclass
@@ -87,6 +87,13 @@ dist-kernel_get_image_path() {
 				echo arch/${ARCH}/boot/Image.gz
 			fi
 			;;
+		loong)
+			if [[ ${KERNEL_EFI_ZBOOT} ]]; then
+				echo arch/loongarch/boot/vmlinuz.efi
+			else
+				echo arch/loongarch/boot/vmlinux.elf
+			fi
+			;;
 		arm)
 			echo arch/arm/boot/zImage
 			;;

--- a/eclass/kernel-build.eclass
+++ b/eclass/kernel-build.eclass
@@ -203,6 +203,12 @@ kernel-build_src_configure() {
 			.config)
 	fi
 
+	# If this is set by USE=secureboot or user config this will have an effect
+	# on the name of the output image. Set this variable to track this setting.
+	if grep -q "CONFIG_EFI_ZBOOT=y" .config; then
+		KERNEL_EFI_ZBOOT=1
+	fi
+
 	mkdir -p "${WORKDIR}"/modprep || die
 	mv .config "${WORKDIR}"/modprep/ || die
 	emake O="${WORKDIR}"/modprep "${MAKEARGS[@]}" olddefconfig
@@ -456,12 +462,6 @@ kernel-build_merge_configs() {
 
 	./scripts/kconfig/merge_config.sh -m -r \
 		.config "${merge_configs[@]}"  || die
-
-	# If this is set by USE=secureboot or user config this will have an effect
-	# on the name of the output image. Set this variable to track this setting.
-	if grep -q "CONFIG_EFI_ZBOOT=y" .config; then
-		KERNEL_EFI_ZBOOT=1
-	fi
 }
 
 fi

--- a/eclass/kernel-install.eclass
+++ b/eclass/kernel-install.eclass
@@ -167,6 +167,9 @@ kernel-install_get_qemu_arch() {
 		arm64)
 			echo aarch64
 			;;
+		loong)
+			echo loongarch64
+			;;
 		*)
 			die "${FUNCNAME}: unsupported ARCH=${ARCH}"
 			;;

--- a/sys-kernel/gentoo-kernel/gentoo-kernel-6.6.7.ebuild
+++ b/sys-kernel/gentoo-kernel/gentoo-kernel-6.6.7.ebuild
@@ -44,7 +44,7 @@ SRC_URI+="
 S=${WORKDIR}/${MY_P}
 
 LICENSE="GPL-2"
-KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~riscv ~sparc ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86"
 IUSE="debug hardened"
 REQUIRED_USE="
 	arm? ( savedconfig )

--- a/sys-kernel/gentoo-kernel/gentoo-kernel-6.6.7.ebuild
+++ b/sys-kernel/gentoo-kernel/gentoo-kernel-6.6.7.ebuild
@@ -93,6 +93,9 @@ src_prepare() {
 		hppa)
 			return
 			;;
+		loong)
+			return
+			;;
 		ppc)
 			# assume powermac/powerbook defconfig
 			# we still package.use.force savedconfig

--- a/sys-kernel/vanilla-kernel/vanilla-kernel-6.6.7.ebuild
+++ b/sys-kernel/vanilla-kernel/vanilla-kernel-6.6.7.ebuild
@@ -90,6 +90,9 @@ src_prepare() {
 		hppa)
 			return
 			;;
+		loong)
+			return
+			;;
 		ppc)
 			# assume powermac/powerbook defconfig
 			# we still package.use.force savedconfig

--- a/sys-kernel/vanilla-kernel/vanilla-kernel-6.6.7.ebuild
+++ b/sys-kernel/vanilla-kernel/vanilla-kernel-6.6.7.ebuild
@@ -44,7 +44,7 @@ SRC_URI+="
 S=${WORKDIR}/${MY_P}
 
 LICENSE="GPL-2"
-KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~x86"
 IUSE="debug hardened"
 REQUIRED_USE="arm? ( savedconfig )"
 

--- a/virtual/dist-kernel/dist-kernel-6.6.7.ebuild
+++ b/virtual/dist-kernel/dist-kernel-6.6.7.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 DESCRIPTION="Virtual to depend on any Distribution Kernel"
 SLOT="0/${PV}"
-KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~riscv ~sparc ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86"
 
 RDEPEND="
 	|| (


### PR DESCRIPTION
As a first experimental step towards proper dist kernel support.

EDIT: I've tested building and booting 6.6.7 on real hardware (Loongson 3A6000 and 2-way 3C5000L) with sd-boot and UKI-fied kernels. Everything works fine and I'll use the config as a starting point for the dist kernel config...