### PR TITLE
app-emulation/virt-manager: allow dev-libs/libisoburn > app-cdr/cdrtools

### DIFF
--- a/app-emulation/virt-manager/virt-manager-4.1.0-r1.ebuild
+++ b/app-emulation/virt-manager/virt-manager-4.1.0-r1.ebuild
@@ -102,4 +102,5 @@ pkg_postinst() {
 
 	optfeature "SSH_ASKPASS program implementation" lxqt-base/lxqt-openssh-askpass net-misc/ssh-askpass-fullscreen net-misc/x11-ssh-askpass
 	optfeature "QEMU host support" app-emulation/qemu[usbredir,spice]
+	optfeature "virt-install --location ISO support" dev-libs/libisoburn
 }


### PR DESCRIPTION
This commit aims to provide an alternative to the unmaintained cdrtools which has all sorts of build failures [1] and [2] and needs patching.

Upstream prefers xorrisofs provided by dev-libs/libisoburn over mkisofs which is provided by app-cdr/cdrtools.[3] I had a look at some other distros (openSUSE, Fedora and Debian) and they all use xorriso.

The other program that is from cdrtools (isoinfo) has been removed. [4]

[1] https://bugs.gentoo.org/903876
[2] https://bugs.gentoo.org/884771
[3] https://github.com/virt-manager/virt-manager/commit/3785abc6f0cb07c02ecc55760547a6f425513915
[4] https://github.com/virt-manager/virt-manager/commit/08d1a6a2ddd18f88222f9fdffa3f60f42a40bc67