### PR TITLE
sys-libs/musl: use https for git clone

### DIFF
--- a/sys-libs/musl/musl-1.2.3-r7.ebuild
+++ b/sys-libs/musl/musl-1.2.3-r7.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 inherit eapi8-dosym flag-o-matic toolchain-funcs prefix
 if [[ ${PV} == "9999" ]] ; then
-	EGIT_REPO_URI="git://git.musl-libc.org/musl"
+	EGIT_REPO_URI="https://git.musl-libc.org/git/musl"
 	inherit git-r3
 else
 	VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/openpgp-keys/musl.asc

--- a/sys-libs/musl/musl-1.2.3-r8.ebuild
+++ b/sys-libs/musl/musl-1.2.3-r8.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 inherit eapi8-dosym flag-o-matic toolchain-funcs prefix
 if [[ ${PV} == "9999" ]] ; then
-	EGIT_REPO_URI="git://git.musl-libc.org/musl"
+	EGIT_REPO_URI="https://git.musl-libc.org/git/musl"
 	inherit git-r3
 else
 	VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/openpgp-keys/musl.asc

--- a/sys-libs/musl/musl-1.2.3.ebuild
+++ b/sys-libs/musl/musl-1.2.3.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 inherit eapi8-dosym flag-o-matic toolchain-funcs prefix
 if [[ ${PV} == "9999" ]] ; then
-	EGIT_REPO_URI="git://git.musl-libc.org/musl"
+	EGIT_REPO_URI="https://git.musl-libc.org/git/musl"
 	inherit git-r3
 else
 	VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/openpgp-keys/musl.asc

--- a/sys-libs/musl/musl-1.2.4-r1.ebuild
+++ b/sys-libs/musl/musl-1.2.4-r1.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 inherit crossdev flag-o-matic toolchain-funcs prefix
 if [[ ${PV} == "9999" ]] ; then
-	EGIT_REPO_URI="git://git.musl-libc.org/musl"
+	EGIT_REPO_URI="https://git.musl-libc.org/git/musl"
 	inherit git-r3
 else
 	VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/openpgp-keys/musl.asc

--- a/sys-libs/musl/musl-1.2.4.ebuild
+++ b/sys-libs/musl/musl-1.2.4.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 inherit crossdev flag-o-matic toolchain-funcs prefix
 if [[ ${PV} == "9999" ]] ; then
-	EGIT_REPO_URI="git://git.musl-libc.org/musl"
+	EGIT_REPO_URI="https://git.musl-libc.org/git/musl"
 	inherit git-r3
 else
 	VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/openpgp-keys/musl.asc

--- a/sys-libs/musl/musl-9999.ebuild
+++ b/sys-libs/musl/musl-9999.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 inherit crossdev flag-o-matic toolchain-funcs prefix
 if [[ ${PV} == "9999" ]] ; then
-	EGIT_REPO_URI="git://git.musl-libc.org/musl"
+	EGIT_REPO_URI="https://git.musl-libc.org/git/musl"
 	inherit git-r3
 else
 	VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/openpgp-keys/musl.asc


### PR DESCRIPTION
Hi,

this updates `sys-libs/musl` to use `https` instead of `git://` when building from source.
* `git://` is unencrypted and could be used by an attacker (mitm) to insert malicious code, see also [1]. I think especially for such a critical system package like musl it's better to use the more secure https variant. 
* `git://` runs on port 9418 which is also less likely open behind a firewall.

[1]https://git-scm.com/book/en/v2/Git-on-the-Server-The-Protocols