### PR TITLE
media-plugins/vdr-*: add some missing inherits

### DIFF
--- a/media-plugins/vdr-fritzbox/vdr-fritzbox-1.5.3-r4.ebuild
+++ b/media-plugins/vdr-fritzbox/vdr-fritzbox-1.5.3-r4.ebuild
@@ -1,18 +1,17 @@
-# Copyright 2021-2022 Gentoo Authors
+# Copyright 2021-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-inherit vdr-plugin-2
+inherit toolchain-funcs vdr-plugin-2
 
 DESCRIPTION="VDR Plugin: Inform about incoming phone-calls and use the fritz!box phonebook"
 HOMEPAGE="https://github.com/jowi24/vdr-fritz"
 SRC_URI="https://github.com/jowi24/vdr-fritz/releases/download/${PV}/${P}.tgz"
 
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="0"
 KEYWORDS="amd64 x86"
-IUSE=""
 
 DEPEND="
 	dev-libs/libgcrypt:=

--- a/media-plugins/vdr-live/metadata.xml
+++ b/media-plugins/vdr-live/metadata.xml
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<maintainer type="project">
-<email>vdr@gentoo.org</email>
-<name>Gentoo VDR Project</name>
-</maintainer>
+	<maintainer type="project">
+		<email>vdr@gentoo.org</email>
+		<name>Gentoo VDR Project</name>
+	</maintainer>
+	<upstream>
+		<remote-id type="github">MarkusEh/vdr-plugin-live</remote-id> 
+	</upstream>
 </pkgmetadata>

--- a/media-plugins/vdr-live/vdr-live-3.0.6.ebuild
+++ b/media-plugins/vdr-live/vdr-live-3.0.6.ebuild
@@ -1,9 +1,9 @@
-# Copyright 2021 Gentoo Authors
+# Copyright 2021-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-inherit ssl-cert vdr-plugin-2
+inherit ssl-cert toolchain-funcs vdr-plugin-2
 
 MY_P="v3.0.6"
 

--- a/media-plugins/vdr-mp3ng/vdr-mp3ng-0.0.1_pre5-r5.ebuild
+++ b/media-plugins/vdr-mp3ng/vdr-mp3ng-0.0.1_pre5-r5.ebuild
@@ -1,9 +1,9 @@
-# Copyright 2021 Gentoo Authors
+# Copyright 2021-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-inherit vdr-plugin-2
+inherit flag-o-matic vdr-plugin-2
 
 MY_PV=0.9.13-MKIV-pre3
 MY_P=${PN}-${MY_PV}

--- a/media-plugins/vdr-xineliboutput/vdr-xineliboutput-2.2.0-r4.ebuild
+++ b/media-plugins/vdr-xineliboutput/vdr-xineliboutput-2.2.0-r4.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit toolchain-funcs vdr-plugin-2
+inherit flag-o-matic toolchain-funcs vdr-plugin-2
 
 GENTOO_VDR_CONDITIONAL=yes
 

--- a/media-plugins/vdr-xineliboutput/vdr-xineliboutput-2.2.0-r5.ebuild
+++ b/media-plugins/vdr-xineliboutput/vdr-xineliboutput-2.2.0-r5.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit toolchain-funcs vdr-plugin-2
+inherit flag-o-matic toolchain-funcs vdr-plugin-2
 
 GENTOO_VDR_CONDITIONAL=yes
 


### PR DESCRIPTION
Hi,

This adds some missing eclass `inherit` for vdr packages, to be precise: `flag-o-matic` and `toolchain-funcs`