### PR TITLE
Next batch of global USE flags

### DIFF
--- a/app-accessibility/brltty/metadata.xml
+++ b/app-accessibility/brltty/metadata.xml
@@ -12,7 +12,6 @@
   <flag name="louis">Use braille translator <pkg>dev-libs/liblouis</pkg></flag>
   <flag name="midi">support the musical instrument digital interface</flag>
   <flag name="pcm">support for sound card digital audio</flag>
-  <flag name="speech">speech support</flag>
 </use>
 <upstream>
   <remote-id type="cpe">cpe:/a:mielke:brltty</remote-id>

--- a/app-admin/clsync/metadata.xml
+++ b/app-admin/clsync/metadata.xml
@@ -24,7 +24,6 @@
     <flag name="extra-hardened">Enable extra security checks. This will hurt performance.</flag>
     <flag name="gio">Enable GIO for FS monitoring (glib based alternative to inotify interface, not recommended; if both are compiled, may be selected at runtime).</flag>
     <flag name="highload-locks">Allows to use spinlocks for short delays instead of mutexes, but only on SMP systems.</flag>
-    <flag name="lto">Build with link time optimization (LTO).</flag>
     <flag name="namespaces">Enable namespaces isolation.</flag>
     <flag name="socket-library">Build the control and monitoring socket library: libclsync.</flag>
   </use>

--- a/app-admin/sysstat/metadata.xml
+++ b/app-admin/sysstat/metadata.xml
@@ -14,6 +14,5 @@
 	</upstream>
 	<use>
 		<flag name="dcron">Adjust cronjobs to work properly under <pkg>sys-process/dcron</pkg></flag>
-		<flag name="lto">Build using Link Time Optimizations (LTO)</flag>
 	</use>
 </pkgmetadata>

--- a/app-containers/lxc/metadata.xml
+++ b/app-containers/lxc/metadata.xml
@@ -11,7 +11,6 @@
   </maintainer>
   <use>
     <flag name="io-uring">Enable io_uring support, and use io_uring instead of epoll</flag>
-    <flag name="lto">Enable Link Time Optimization (LTO)</flag>
     <flag name="tools">Build and install additional command line tools</flag>
   </use>
   <upstream>

--- a/app-crypt/aespipe/metadata.xml
+++ b/app-crypt/aespipe/metadata.xml
@@ -10,7 +10,6 @@
 		<name>Proxy Maintainers</name>
 	</maintainer>
 	<use>
-		<flag name="asm">Enable assembly modules</flag>
 		<flag name="cpu_flags_x86_padlock">Use VIA padlock instructions,
 		detected at run time, code still works on non-padlock processors</flag>
 	</use>

--- a/app-crypt/veracrypt/metadata.xml
+++ b/app-crypt/veracrypt/metadata.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<use>
-		<flag name="asm">Enable assembly for optimization</flag>
-	</use>
 	<maintainer type="person">
 		<email>gokturk@gentoo.org</email>
 		<name>Göktürk Yüksek</name>

--- a/app-editors/neovim/metadata.xml
+++ b/app-editors/neovim/metadata.xml
@@ -14,7 +14,6 @@
 		<name>Proxy Maintainers</name>
 	</maintainer>
 	<use>
-		<flag name="lto">Build with Link Time Optimization (LTO)</flag>
 		<flag name="nvimpager">Install nvimpager symlink to less.sh macro</flag>
 	</use>
 	<upstream>

--- a/app-emulation/crossover-bin/metadata.xml
+++ b/app-emulation/crossover-bin/metadata.xml
@@ -8,7 +8,6 @@
 	<use>
 		<flag name="capi">Enable ISDN support via CAPI</flag>
 		<flag name="osmesa">Add support for OpenGL in bitmaps using libOSMesa</flag>
-		<flag name="opencl">Enable OpenCL support</flag>
 		<flag name="pcap">Support packet capture software (e.g. wireshark)</flag>
 	</use>
 </pkgmetadata>

--- a/app-emulation/wine-staging/metadata.xml
+++ b/app-emulation/wine-staging/metadata.xml
@@ -23,7 +23,6 @@ This variant of the Wine packaging includes the Wine-Staging patchset.
 		<flag name="mingw">Build PE files using a MinGW toolchain for better compatibility</flag>
 		<flag name="mono">Enable .NET support using <pkg>app-emulation/wine-mono</pkg></flag>
 		<flag name="netapi">Enable support for configuring remote shares using <pkg>net-fs/samba</pkg></flag>
-		<flag name="opencl">Enable OpenCL support</flag>
 		<flag name="osmesa">Enable off-screen rendering (OpenGL in bitmaps) support</flag>
 		<flag name="pcap">Support packet capture software (e.g. wireshark)</flag>
 		<flag name="perl">Install helpers that require perl (winedump/winemaker)</flag>

--- a/app-emulation/wine-vanilla/metadata.xml
+++ b/app-emulation/wine-vanilla/metadata.xml
@@ -23,7 +23,6 @@ This variant of the Wine packaging does not include external patchsets
 		<flag name="mingw">Build PE files using a MinGW toolchain for better compatibility</flag>
 		<flag name="mono">Enable .NET support using <pkg>app-emulation/wine-mono</pkg></flag>
 		<flag name="netapi">Enable support for configuring remote shares using <pkg>net-fs/samba</pkg></flag>
-		<flag name="opencl">Enable OpenCL support</flag>
 		<flag name="osmesa">Enable off-screen rendering (OpenGL in bitmaps) support</flag>
 		<flag name="pcap">Support packet capture software (e.g. wireshark)</flag>
 		<flag name="perl">Install helpers that require perl (winedump/winemaker)</flag>

--- a/app-misc/fastfetch/metadata.xml
+++ b/app-misc/fastfetch/metadata.xml
@@ -12,7 +12,6 @@
 	<flag name="chafa">Enables text/graphics renderer with <pkg>media-gfx/chafa</pkg></flag>
 	<flag name="ddcutil">Use <pkg>app-misc/ddcutil</pkg> to query monitor settings</flag>
 	<flag name="drm">Enables support for X.org's <pkg>x11-libs/libdrm</pkg></flag>
-	<flag name="opencl">Enables OpenCL support</flag>
 	<flag name="osmesa">Enables offscreen rendering support from <pkg>media-libs/mesa</pkg></flag>
 	<flag name="pci">Enables reading GPU via <pkg>sys-apps/pciutils</pkg></flag>
 	<flag name="vulkan">Enables reading GPU via <pkg>media-libs/vulkan-loader</pkg></flag>

--- a/app-mobilephone/scrcpy/metadata.xml
+++ b/app-mobilephone/scrcpy/metadata.xml
@@ -5,9 +5,6 @@
 		<email>voyageur@gentoo.org</email>
 		<name>Bernard Cafarelli</name>
 	</maintainer>
-	<use>
-		<flag name="lto">Build with Link Time Optimization (LTO)</flag>
-	</use>
 	<upstream>
 		<remote-id type="github">Genymobile/scrcpy</remote-id>
 	</upstream>

--- a/app-text/calibre/metadata.xml
+++ b/app-text/calibre/metadata.xml
@@ -14,7 +14,6 @@
   </upstream>
   <use>
     <flag name="font-subsetting">Enable font subsetting support</flag>
-    <flag name="speech">Enable text-to-speech support</flag>
     <flag name="system-mathjax">Use a system copy of mathjax</flag>
     <flag name="unrar">Enable support for comic books compressed with the non-free Rar format</flag>
   </use>

--- a/app-text/crengine-ng/metadata.xml
+++ b/app-text/crengine-ng/metadata.xml
@@ -20,7 +20,6 @@
     <flag name="libunibreak">Use <pkg>dev-libs/libunibreak</pkg> for hyphenation</flag>
     <flag name="fribidi">Support bidirectional text by <pkg>dev-libs/fribidi</pkg></flag>
     <flag name="libutf8proc">Use <pkg>dev-libs/libutf8proc</pkg> for manipulating unicode strings</flag>
-    <flag name="lto">Use link time optimization</flag>
   </use>
   <upstream>
     <remote-id type="gitlab">coolreader-ng/crengine-ng</remote-id>

--- a/app-text/kjots/metadata.xml
+++ b/app-text/kjots/metadata.xml
@@ -8,7 +8,4 @@
 	<upstream>
 		<bugs-to>https://bugs.kde.org/</bugs-to>
 	</upstream>
-	<use>
-		<flag name="speech">Enable text-to-speech support</flag>
-	</use>
 </pkgmetadata>

--- a/dev-cpp/benchmark/metadata.xml
+++ b/dev-cpp/benchmark/metadata.xml
@@ -10,7 +10,4 @@
 		<doc lang="en">https://github.com/google/benchmark/tree/master/docs/</doc>
 		<remote-id type="github">google/benchmark</remote-id>
 	</upstream>
-	<use>
-		<flag name="lto">Optimize the build using Link Time Optimization (LTO)</flag>
-	</use>
 </pkgmetadata>

--- a/dev-db/mongodb/metadata.xml
+++ b/dev-db/mongodb/metadata.xml
@@ -14,7 +14,6 @@
 	and powerful queries).
 	</longdescription>
 	<use>
-		<flag name="lto">Adds support for link time optimization</flag>
 		<flag name="mongosh">Install the MongoDB shell from <pkg>app-admin/mongosh-bin</pkg></flag>
 		<flag name="tools">Install the MongoDB tools (mongoimport, mongodump...) from <pkg>app-admin/mongo-tools</pkg></flag>
 	</use>

--- a/dev-games/godot/metadata.xml
+++ b/dev-games/godot/metadata.xml
@@ -24,7 +24,6 @@
 		<flag name="deprecated">Enable support for deprecated features</flag>
 		<flag name="raycast">Enable the raycast Editor module using <pkg>media-libs/embree</pkg></flag>
 		<flag name="runner">Build an additional binary optimized for running games (only relevant with USE=tools)</flag>
-		<flag name="speech">Enable text-to-speech support</flag>
 		<flag name="tools">Enable the Godot Editor for game development</flag>
 		<flag name="webm">Enable the WebM module</flag>
 	</use>

--- a/dev-games/ogre/metadata.xml
+++ b/dev-games/ogre/metadata.xml
@@ -93,7 +93,6 @@ Exporters
     </flag>
     <flag name="freeimage">Support images via <pkg>media-libs/freeimage</pkg></flag>
     <flag name="gl3plus">Build OpenGL 3+ RenderSystem</flag>
-    <flag name="gles2" restrict="&lt;dev-games/ogre-13">Build OpenGL ES 2.x RenderSystem</flag>
     <flag name="gles3" restrict="&lt;dev-games/ogre-13">Enable OpenGL ES 3.x Features</flag>
     <flag name="json">Use <pkg>dev-libs/rapidjson</pkg> (needed by Hlms JSON materials)</flag>
     <flag name="legacy-animations">

--- a/dev-games/openscenegraph-openmw/metadata.xml
+++ b/dev-games/openscenegraph-openmw/metadata.xml
@@ -27,7 +27,6 @@
 	<use>
 		<flag name="collada">Enable DAE file support via <pkg>dev-libs/collada-dom</pkg></flag>
 		<flag name="dicom">Enable DICOM medical image file support via <pkg>sci-libs/dcmtk</pkg></flag>
-		<flag name="egl">Enable EGL support</flag>
 		<flag name="fox">Build examples using <pkg>x11-libs/fox</pkg> library</flag>
 		<flag name="gdal">Enable support for <pkg>sci-libs/gdal</pkg> library</flag>
 		<flag name="las">Enable support for geospatial data LAS LiDAR format using <pkg>sci-geosciences/liblas</pkg></flag>

--- a/dev-games/openscenegraph/metadata.xml
+++ b/dev-games/openscenegraph/metadata.xml
@@ -15,7 +15,6 @@
 	<use>
 		<flag name="collada">Enable DAE file support via <pkg>dev-libs/collada-dom</pkg></flag>
 		<flag name="dicom">Enable DICOM medical image file support via <pkg>sci-libs/dcmtk</pkg></flag>
-		<flag name="egl">Enable EGL support</flag>
 		<flag name="fox">Build examples using <pkg>x11-libs/fox</pkg> library</flag>
 		<flag name="gdal">Enable support for <pkg>sci-libs/gdal</pkg> library</flag>
 		<flag name="las">Enable support for geospatial data LAS LiDAR format using <pkg>sci-geosciences/liblas</pkg></flag>

--- a/dev-java/openjdk/metadata.xml
+++ b/dev-java/openjdk/metadata.xml
@@ -23,7 +23,6 @@
 		<flag name="javafx" restrict="&lt;=dev-java/openjdk-9">Provide JavaFX support via <pkg>dev-java/openjfx</pkg></flag>
 		<flag name="javafx" restrict="&gt;=dev-java/openjdk-11">Import OpenJFX modules at build time, via <pkg>dev-java/openjfx</pkg></flag>
 		<flag name="jbootstrap">Build OpenJDK twice, the second time using the result of the first</flag>
-		<flag name="lto">Enable Link Time Optimization (LTO)</flag>
 		<flag name="source">Install JVM sources</flag>
 		<flag name="system-bootstrap">Bootstrap using installed openjdk</flag>
 		<flag name="systemtap" restrict="&gt;=dev-java/openjdk-11">Enable SystemTAP/DTrace tracing</flag>

--- a/dev-lang/R/metadata.xml
+++ b/dev-lang/R/metadata.xml
@@ -5,9 +5,6 @@
 		<email>sci-mathematics@gentoo.org</email>
 		<name>Gentoo Mathematics Project</name>
 	</maintainer>
-	<use>
-		<flag name="lto">Use link-time optimization for R and its recommended packages.</flag>
-	</use>
 	<longdescription lang="en">
 		R is GNU S, a system for statistical computation and graphics. It
 		consists of a language plus a run-time environment with graphics, a

--- a/dev-lang/gnat-gpl/metadata.xml
+++ b/dev-lang/gnat-gpl/metadata.xml
@@ -20,7 +20,6 @@
 		<flag name="libssp">Build SSP support into a dedicated library rather
 			than use the code in the C library (DO NOT ENABLE THIS IF YOU DON'T
 			KNOW WHAT IT DOES)</flag>
-		<flag name="lto">Build using Link Time Optimizations (LTO)</flag>
 		<flag name="nptl">Enable support for Native POSIX Threads Library, the new threading module (requires linux-2.6 or better usually)</flag>
 		<flag name="objc">Build support for the Objective C code language
 		</flag>

--- a/dev-lang/python/metadata.xml
+++ b/dev-lang/python/metadata.xml
@@ -23,9 +23,6 @@
 			by running Python's test suite and collecting statistics
 			based on its performance. This will take longer to build.
 		</flag>
-		<flag name="lto">
-			Optimize the build using Link Time Optimization (LTO)
-		</flag>
 		<flag name="valgrind">
 			Disable pymalloc when running under
 			<pkg>dev-util/valgrind</pkg> is detected (may incur minor

--- a/dev-lang/rust/metadata.xml
+++ b/dev-lang/rust/metadata.xml
@@ -12,7 +12,6 @@
 	<use>
 		<flag name="clippy">Install clippy, Rust code linter</flag>
 		<flag name="dist">Install dist tarballs (used for bootstrapping)</flag>
-		<flag name="lto">Optimize the build using Link Time Optimization (LTO)</flag>
 		<flag name="miri">Install miri, an interpreter for Rust's mid-level intermediate representation (requires USE=nightly, sometimes is broken)</flag>
 		<flag name="nightly">Enable nightly (UNSTABLE) features (NOTE: it does not install nightly version, just enables features marked as nightly at time of release)</flag>
 		<flag name="parallel-compiler">Build a multi-threaded rustc (experimental, not tested by upstream)</flag>

--- a/dev-lang/spidermonkey/metadata.xml
+++ b/dev-lang/spidermonkey/metadata.xml
@@ -8,6 +8,5 @@
 	<use>
 		<flag name="clang">Use Clang compiler instead of GCC</flag>
 		<flag name="debug">Enable assertions to allow for easier debugging of programs that link to spidermonkey -- note this will often crash software on regular end-user systems</flag>
-		<flag name="lto">Enable Link Time Optimization (LTO)</flag>
 	</use>
 </pkgmetadata>

--- a/dev-libs/crypto++/metadata.xml
+++ b/dev-libs/crypto++/metadata.xml
@@ -5,9 +5,6 @@
     <email>sam@gentoo.org</email>
     <name>Sam James</name>
   </maintainer>
-  <use>
-    <flag name="asm">Support assembly hand optimized crypto functions (i.e. faster run time)</flag>
-  </use>
   <upstream>
     <remote-id type="github">weidai11/cryptopp</remote-id>
   </upstream>

--- a/dev-libs/gmp/metadata.xml
+++ b/dev-libs/gmp/metadata.xml
@@ -6,7 +6,6 @@
 		<name>Gentoo Toolchain Project</name>
 	</maintainer>
 	<use>
-		<flag name="asm">Enable use of hand optimized assembly routines (faster execution)</flag>
 		<flag name="cpudetection">
 			Enables runtime CPU detection (useful for binpkgs, compatibility on other CPUs).
 

--- a/dev-libs/ktextaddons/metadata.xml
+++ b/dev-libs/ktextaddons/metadata.xml
@@ -11,6 +11,5 @@
 	</upstream>
 	<use>
 		<flag name="designer">Build plugins for <pkg>dev-qt/designer</pkg></flag>
-		<flag name="speech">Enable text-to-speech support</flag>
 	</use>
 </pkgmetadata>

--- a/dev-libs/libgcrypt/metadata.xml
+++ b/dev-libs/libgcrypt/metadata.xml
@@ -9,7 +9,6 @@
 		<remote-id type="cpe">cpe:/a:gnupg:libgcrypt</remote-id>
 	</upstream>
 	<use>
-		<flag name="asm">Enable assembly for optimization</flag>
 		<flag name="getentropy">Use getentropy function to obtain randomness from the kernel</flag>
 	</use>
 </pkgmetadata>

--- a/dev-libs/libsodium/metadata.xml
+++ b/dev-libs/libsodium/metadata.xml
@@ -14,7 +14,6 @@
 		packageable fork of NaCl, with a compatible API.
 	</longdescription>
 	<use>
-		<flag name="asm">Enables assembly implementations</flag>
 		<flag name="urandom">Use /dev/urandom instead of /dev/random</flag>
 	</use>
 	<upstream>

--- a/dev-libs/nettle/metadata.xml
+++ b/dev-libs/nettle/metadata.xml
@@ -9,7 +9,4 @@
 		<remote-id type="cpe">cpe:/a:nettle_project:nettle</remote-id>
 		<remote-id type="github">gnutls/nettle</remote-id>
 	</upstream>
-	<use>
-		<flag name="asm">Support assembly hand optimized crypto functions (i.e. faster run time)</flag>
-	</use>
 </pkgmetadata>

--- a/dev-libs/openssl-compat/metadata.xml
+++ b/dev-libs/openssl-compat/metadata.xml
@@ -6,7 +6,6 @@
 		<name>Gentoo Base System</name>
 	</maintainer>
 	<use>
-		<flag name="asm">Support assembly hand optimized crypto functions (i.e. faster run time)</flag>
 		<flag name="bindist">Disable/Restrict EC algorithms (as they seem to be patented) -- note: changes the ABI</flag>
 		<flag name="rfc3779">Enable support for RFC 3779 (X.509 Extensions for IP Addresses and AS Identifiers)</flag>
 		<flag name="sslv2">Support for the old/insecure SSLv2 protocol -- note: not required for TLS/https</flag>

--- a/dev-libs/openssl/metadata.xml
+++ b/dev-libs/openssl/metadata.xml
@@ -6,7 +6,6 @@
 		<name>Gentoo Base System</name>
 	</maintainer>
 	<use>
-		<flag name="asm">Support assembly hand optimized crypto functions (i.e. faster run time)</flag>
 		<flag name="bindist">Disable/Restrict EC algorithms (as they seem to be patented) -- note: changes the ABI</flag>
 		<flag name="fips">Enable FIPS provider</flag>
 		<flag name="ktls">Enable support for Kernel implementation of TLS (kTLS)</flag>

--- a/dev-libs/pocl/metadata.xml
+++ b/dev-libs/pocl/metadata.xml
@@ -13,7 +13,6 @@
 		<!--<flag name="hsa">Enable the HSA base profile runtime device driver</flag>-->
 		<flag name="hwloc">Enable hwloc support</flag>
 		<flag name="memmanager">Enables custom memory manager. Except for special circumstances, this should be disabled</flag>
-		<flag name="lto">Adds support for link time optimization</flag>
 	</use>
 	<upstream>
 		<remote-id type="github">pocl/pocl</remote-id>

--- a/dev-libs/starpu/metadata.xml
+++ b/dev-libs/starpu/metadata.xml
@@ -14,7 +14,6 @@
 <use>
   <flag name="cuda">Enable NVIDIA CUDA toolkit support</flag>
   <flag name="gcc-plugin">Enable GCC extension plugin (experimental)</flag>
-  <flag name="opencl">Enable OpenCL support</flag>
   <flag name="spinlock-check">Enable spinlock check</flag>
 </use>
 </pkgmetadata>

--- a/dev-qt/qtgui/metadata.xml
+++ b/dev-qt/qtgui/metadata.xml
@@ -6,7 +6,6 @@
 		<name>Gentoo Qt Project</name>
 	</maintainer>
 	<use>
-		<flag name="egl">Enable EGL integration</flag>
 		<flag name="eglfs">Build the EGL Full Screen/Single Surface platform plugin</flag>
 		<flag name="evdev">Enable support for input devices via evdev</flag>
 		<flag name="ibus">Build the IBus input method plugin</flag>

--- a/games-action/prismlauncher/metadata.xml
+++ b/games-action/prismlauncher/metadata.xml
@@ -20,7 +20,6 @@
   </upstream>
   <longdescription>Prism Launcher is a multi-instance Minecraft launcher focused on user freedom, redistributability, and simplicity.</longdescription>
   <use>
-    <flag name="lto">Enable link-time optimization</flag>
     <flag name="qt6">Build with Qt6 support instead of the default Qt5</flag>
   </use>
 </pkgmetadata>

--- a/games-emulation/mgba/metadata.xml
+++ b/games-emulation/mgba/metadata.xml
@@ -8,7 +8,6 @@
   <use>
     <flag name="discord">Enable Discord RPC support</flag>
     <flag name="elf">Enable the use of elf utils via <pkg>dev-libs/elfutils</pkg></flag>
-    <flag name="gles2">Build OpenGL ES 2.x RenderSystem</flag>
     <flag name="gles3">Build OpenGL ES 3.x RenderSystem</flag>
     <flag name="libretro">Build libretro port</flag>
   </use>

--- a/games-engines/scummvm/metadata.xml
+++ b/games-engines/scummvm/metadata.xml
@@ -16,7 +16,6 @@
     <flag name="mpeg2">enable mpeg2 codec for cutscenes</flag>
     <flag name="net">enable cloud support via <pkg>media-libs/sdl2-net</pkg></flag>
     <flag name="sndio">Enable support for MIDI music using <pkg>media-sound/sndio</pkg></flag>
-    <flag name="speech">enable text-to-speech support through <pkg>app-accessibility/speech-dispatcher</pkg></flag>
     <flag name="unsupported">enable unsupported and/or broken game engines (you're on your own)</flag>
   </use>
   <upstream>

--- a/games-fps/gzdoom/metadata.xml
+++ b/games-fps/gzdoom/metadata.xml
@@ -14,7 +14,6 @@
 		<name>Gentoo Games Project</name>
 	</maintainer>
 	<use>
-		<flag name="gles2">Enable GLES2 backend</flag>
 		<flag name="non-free">Enable non-free components</flag>
 		<flag name="swr">Enable software renderer</flag>
 	</use>

--- a/games-util/basis_universal/metadata.xml
+++ b/games-util/basis_universal/metadata.xml
@@ -5,9 +5,6 @@
 		<email>games@gentoo.org</email>
 		<name>Gentoo Games Project</name>
 	</maintainer>
-	<use>
-		<flag name="opencl">Enable OpenCL support</flag>
-	</use>
 	<upstream>
 		<remote-id type="github">BinomialLLC/basis_universal</remote-id>
 	</upstream>

--- a/gnustep-base/gnustep-gui/metadata.xml
+++ b/gnustep-base/gnustep-gui/metadata.xml
@@ -5,9 +5,6 @@
 	<email>gnustep@gentoo.org</email>
 	<name>Gentoo GNUstep Project</name>
 </maintainer>
-<use>
-	<flag name="speech">Audio support using <pkg>app-accessibility/flite</pkg></flag>
-</use>
 <longdescription>
 It is a library of graphical user interface classes written completely
 in the Objective-C language; the classes are based upon the OpenStep

--- a/kde-apps/akregator/metadata.xml
+++ b/kde-apps/akregator/metadata.xml
@@ -8,7 +8,4 @@
 	<upstream>
 		<bugs-to>https://bugs.kde.org/</bugs-to>
 	</upstream>
-	<use>
-		<flag name="speech">Enable text-to-speech support</flag>
-	</use>
 </pkgmetadata>

--- a/kde-apps/kalarm/metadata.xml
+++ b/kde-apps/kalarm/metadata.xml
@@ -10,6 +10,5 @@
 	</upstream>
 	<use>
 		<flag name="pim">Enable birthday import, email functions etc. using <pkg>kde-apps/akonadi</pkg></flag>
-		<flag name="speech">Enable text-to-speech support</flag>
 	</use>
 </pkgmetadata>

--- a/kde-apps/kanagram/metadata.xml
+++ b/kde-apps/kanagram/metadata.xml
@@ -8,7 +8,4 @@
 	<upstream>
 		<bugs-to>https://bugs.kde.org/</bugs-to>
 	</upstream>
-	<use>
-		<flag name="speech">Enable text-to-speech support</flag>
-	</use>
 </pkgmetadata>

--- a/kde-apps/kdepim-runtime/metadata.xml
+++ b/kde-apps/kdepim-runtime/metadata.xml
@@ -8,7 +8,4 @@
 	<upstream>
 		<bugs-to>https://bugs.kde.org/</bugs-to>
 	</upstream>
-	<use>
-		<flag name="speech">Enable text-to-speech support</flag>
-	</use>
 </pkgmetadata>

--- a/kde-apps/kmail/metadata.xml
+++ b/kde-apps/kmail/metadata.xml
@@ -9,7 +9,4 @@
 		<bugs-to>https://bugs.kde.org/</bugs-to>
 		<remote-id type="cpe">cpe:/a:kde:kmail</remote-id>
 	</upstream>
-	<use>
-		<flag name="speech">Enable text-to-speech support</flag>
-	</use>
 </pkgmetadata>

--- a/kde-apps/knights/metadata.xml
+++ b/kde-apps/knights/metadata.xml
@@ -12,7 +12,4 @@
 	<upstream>
 		<bugs-to>https://bugs.kde.org/</bugs-to>
 	</upstream>
-	<use>
-		<flag name="speech">Enable text-to-speech support</flag>
-	</use>
 </pkgmetadata>

--- a/kde-apps/konqueror/metadata.xml
+++ b/kde-apps/konqueror/metadata.xml
@@ -11,6 +11,5 @@
 	</upstream>
 	<use>
 		<flag name="activities">Enable kactivities support</flag>
-		<flag name="speech">Build text-to-speech plugin</flag>
 	</use>
 </pkgmetadata>

--- a/kde-apps/kpimtextedit/metadata.xml
+++ b/kde-apps/kpimtextedit/metadata.xml
@@ -10,6 +10,5 @@
 	</upstream>
 	<use>
 		<flag name="designer">Build plugins for <pkg>dev-qt/designer</pkg></flag>
-		<flag name="speech">Enable text-to-speech support</flag>
 	</use>
 </pkgmetadata>

--- a/kde-apps/libksieve/metadata.xml
+++ b/kde-apps/libksieve/metadata.xml
@@ -8,7 +8,4 @@
 	<upstream>
 		<bugs-to>https://bugs.kde.org/</bugs-to>
 	</upstream>
-	<use>
-		<flag name="speech">Enable text-to-speech support</flag>
-	</use>
 </pkgmetadata>

--- a/kde-apps/messagelib/metadata.xml
+++ b/kde-apps/messagelib/metadata.xml
@@ -9,7 +9,4 @@
 		<bugs-to>https://bugs.kde.org/</bugs-to>
 		<remote-id type="cpe">cpe:/a:kde:messagelib</remote-id>
 	</upstream>
-	<use>
-		<flag name="speech">Enable text-to-speech support</flag>
-	</use>
 </pkgmetadata>

--- a/kde-apps/okular/metadata.xml
+++ b/kde-apps/okular/metadata.xml
@@ -19,6 +19,5 @@
 		<flag name="plucker">Enable Plucker E-Book for Palm OS devices support</flag>
 		<flag name="qml">Install Okular Qml components</flag>
 		<flag name="share">Enable support for a share menu using <pkg>kde-frameworks/purpose</pkg></flag>
-		<flag name="speech">Enable text-to-speech support</flag>
 	</use>
 </pkgmetadata>

--- a/kde-frameworks/ktextwidgets/metadata.xml
+++ b/kde-frameworks/ktextwidgets/metadata.xml
@@ -10,7 +10,6 @@
 	</upstream>
 	<use>
 		<flag name="designer">Build plugins for <pkg>dev-qt/designer</pkg></flag>
-		<flag name="speech">Enable text-to-speech support</flag>
 	</use>
 	<slots>
 		<subslots>

--- a/mail-client/thunderbird/metadata.xml
+++ b/mail-client/thunderbird/metadata.xml
@@ -10,7 +10,6 @@
 	<flag name="eme-free">Disable EME (DRM plugin) capability at build time</flag>
 	<flag name="hwaccel">Force-enable hardware-accelerated rendering (Mozilla bug 594876)</flag>
 	<flag name="libproxy">Enable libproxy support</flag>
-	<flag name="lto">Enable Link Time Optimization (LTO)</flag>
 	<flag name="openh264">Use <pkg>media-libs/openh264</pkg> for H.264 support
 		instead of downloading binary blob from Mozilla at runtime</flag>
 	<flag name="pgo">Add support for profile-guided optimization using gcc-4.5,

--- a/media-fonts/essays1743/metadata.xml
+++ b/media-fonts/essays1743/metadata.xml
@@ -5,8 +5,4 @@
 		<email>fonts@gentoo.org</email>
 		<name>Fonts</name>
 	</maintainer>
-	<use>
-			<flag name="otf">Install the OpenType version of the font</flag>
-			<flag name="ttf">Install the TrueType version of the font</flag>
-	</use>
 </pkgmetadata>

--- a/media-fonts/fira-mono/metadata.xml
+++ b/media-fonts/fira-mono/metadata.xml
@@ -5,8 +5,4 @@
     <email>fonts@gentoo.org</email>
     <name>Fonts</name>
   </maintainer>
-  <use>
-    <flag name="otf">Install the OpenType version of the font</flag>
-    <flag name="ttf">Install the TrueType version of the font</flag>
-  </use>
 </pkgmetadata>

--- a/media-fonts/fira-sans/metadata.xml
+++ b/media-fonts/fira-sans/metadata.xml
@@ -6,8 +6,4 @@
 		<name>Fonts</name>
 	</maintainer>
 	<stabilize-allarches/>
-	<use>
-		<flag name="otf">Install the OpenType version of the font</flag>
-		<flag name="ttf">Install the TrueType version of the font</flag>
-	</use>
 </pkgmetadata>

--- a/media-fonts/fontawesome/metadata.xml
+++ b/media-fonts/fontawesome/metadata.xml
@@ -9,9 +9,5 @@
 		<email>proxy-maint@gentoo.org</email>
 		<name>Proxy Maintainers</name>
 	</maintainer>
-	<use>
-		<flag name="otf">Install the OpenType version of the font</flag>
-		<flag name="ttf">Install the TrueType version of the font</flag>
-	</use>
 	<stabilize-allarches/>
 </pkgmetadata>

--- a/media-fonts/ibm-plex/metadata.xml
+++ b/media-fonts/ibm-plex/metadata.xml
@@ -2,10 +2,6 @@
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
 	<!-- maintainer-needed -->
-	<use>
-		<flag name="otf">Install OTF fonts</flag>
-		<flag name="ttf">Install TTF fonts</flag>
-	</use>
 	<upstream>
 		<remote-id type="github">IBM/plex</remote-id>
 	</upstream>

--- a/media-fonts/vollkorn/metadata.xml
+++ b/media-fonts/vollkorn/metadata.xml
@@ -5,10 +5,6 @@
 		<email>fonts@gentoo.org</email>
 		<name>Fonts</name>
 	</maintainer>
-	<use>
-		<flag name="otf">Install the OpenType version of the font</flag>
-		<flag name="ttf">Install the TrueType version of the font</flag>
-	</use>
 	<stabilize-allarches/>
 	<upstream>
 		<remote-id type="github">FAlthausen/Vollkorn-Typeface</remote-id>

--- a/media-gfx/darktable/metadata.xml
+++ b/media-gfx/darktable/metadata.xml
@@ -16,7 +16,6 @@
 		<flag name="kwallet">Enable encrypted storage of passwords with <pkg>kde-frameworks/kwallet</pkg></flag>
 		<flag name="lto">Enable link-time optimisations in the RawSpeed library</flag>
 		<flag name="midi">Support using MIDI input devices such as Behringer X-Touch Mini, Arturia Beatstep or Korg nanoKONTROL2, as input devices</flag>
-		<flag name="opencl">Enable opencl support</flag>
 		<flag name="tools">Install tools for generating base curves and noise profiles</flag>
 	</use>
 	<upstream>

--- a/media-gfx/imagemagick/metadata.xml
+++ b/media-gfx/imagemagick/metadata.xml
@@ -14,7 +14,6 @@
 		<flag name="fpx">Enable <pkg>media-libs/libfpx</pkg> support</flag>
 		<flag name="hdri">Enable High Dynamic Range Images formats</flag>
 		<flag name="lqr">Enable experimental liquid rescale support using <pkg>media-libs/liblqr</pkg></flag>
-		<flag name="opencl">Enable OpenCL support</flag>
 		<flag name="pango">Enable Pango support using <pkg>x11-libs/pango</pkg></flag>
 		<flag name="q32">Set quantum depth value to 32</flag>
 		<flag name="q8">Set quantum depth value to 8</flag>

--- a/media-libs/clutter/metadata.xml
+++ b/media-libs/clutter/metadata.xml
@@ -6,7 +6,6 @@
     <name>Gentoo GNOME Desktop</name>
   </maintainer>
   <use>
-    <flag name="egl">Enable EGL backend.</flag>
     <flag name="gtk">Use gdk-pixbuf from <pkg>x11-libs/gtk+</pkg> as image rendering backend</flag>
   </use>
   <upstream>

--- a/media-libs/cogl/metadata.xml
+++ b/media-libs/cogl/metadata.xml
@@ -6,7 +6,6 @@
     <name>Gentoo GNOME Desktop</name>
   </maintainer>
   <use>
-    <flag name="gles2">Enable OpenGL ES 2.0 support</flag>
     <flag name="kms">Enable KMS support.</flag>
     <flag name="pango">Build cogl-pango library for <pkg>x11-libs/pango</pkg> integration</flag>
   </use>

--- a/media-libs/dav1d/metadata.xml
+++ b/media-libs/dav1d/metadata.xml
@@ -7,7 +7,6 @@
 	<use>
 		<flag name="8bit">Add support for decoding 8-bit AV1.</flag>
 		<flag name="10bit">Add support for building 10-bit and 12-bit AV1.</flag>
-		<flag name="asm">Enable custom assembly for faster decoding.</flag>
 		<flag name="xxhash">Enable <pkg>dev-libs/xxhash</pkg> support for hashing muxer</flag>
 	</use>
 	<upstream>

--- a/media-libs/gst-plugins-bad/metadata.xml
+++ b/media-libs/gst-plugins-bad/metadata.xml
@@ -8,7 +8,6 @@
 	<use>
 		<flag name="bzip2">Enable bzip2 encoder/decoder plugin</flag>
 		<flag name="egl">Enable EGL support</flag>
-		<flag name="gles2">Enable GLES2 support</flag>
 		<flag name="qsv">Enable Intel Quick Sync Video using the <pkg>media-libs/oneVPL</pkg> dispatcher</flag>
 	</use>
 </pkgmetadata>

--- a/media-libs/gst-plugins-bad/metadata.xml
+++ b/media-libs/gst-plugins-bad/metadata.xml
@@ -7,7 +7,6 @@
 	</maintainer>
 	<use>
 		<flag name="bzip2">Enable bzip2 encoder/decoder plugin</flag>
-		<flag name="egl">Enable EGL support</flag>
 		<flag name="qsv">Enable Intel Quick Sync Video using the <pkg>media-libs/oneVPL</pkg> dispatcher</flag>
 	</use>
 </pkgmetadata>

--- a/media-libs/gst-plugins-base/metadata.xml
+++ b/media-libs/gst-plugins-base/metadata.xml
@@ -7,7 +7,6 @@
 </maintainer>
 <use>
 	<flag name="gbm">Enable Graphics Buffer Manager based EGL windowing system support (requires egl and at least one of gles or opengl)</flag>
-	<flag name="egl">Enable EGL platform support</flag>
 	<flag name="gles2">Enable OpenGL library and plugin via GLESv2 API (requires egl)</flag>
 	<flag name="ivorbis">Enable integer based vorbis decoder</flag>
 	<flag name="opengl">Enable OpenGL library and plugin via desktop OpenGL API</flag>

--- a/media-libs/libepoxy/metadata.xml
+++ b/media-libs/libepoxy/metadata.xml
@@ -5,9 +5,6 @@
 		<email>x11@gentoo.org</email>
 		<name>X11</name>
 	</maintainer>
-	<use>
-		<flag name="egl">Enable EGL support.</flag>
-	</use>
 	<upstream>
 		<remote-id type="github">anholt/libepoxy</remote-id>
 	</upstream>

--- a/media-libs/libsdl2/metadata.xml
+++ b/media-libs/libsdl2/metadata.xml
@@ -26,7 +26,6 @@
 	<use>
 		<flag name="fcitx4">Enable support for <pkg>app-i18n/fcitx</pkg> 4</flag>
 		<flag name="gles1">include OpenGL ES 1.0 support</flag>
-		<flag name="gles2">include OpenGL ES 2.0 support</flag>
 		<flag name="haptic">Enable the haptic (force feedback) subsystem</flag>
 		<flag name="ibus">Enable support for <pkg>app-i18n/ibus</pkg></flag>
 		<flag name="joystick">Control joystick support (disable at your own risk)</flag>

--- a/media-libs/libva-compat/metadata.xml
+++ b/media-libs/libva-compat/metadata.xml
@@ -6,7 +6,6 @@
 		<name>James Le Cuirot</name>
 	</maintainer>
 	<use>
-		<flag name="egl">Enables EGL support.</flag>
 		<flag name="drm">Enables VA/DRM API support.</flag>
 	</use>
 	<upstream>

--- a/media-libs/mesa-amber/metadata.xml
+++ b/media-libs/mesa-amber/metadata.xml
@@ -7,7 +7,6 @@
   </maintainer>
   <use>
     <flag name="gles1">Enable GLESv1 support.</flag>
-    <flag name="gles2">Enable GLESv2 support.</flag>
     <flag name="wayland">Enable support for <pkg>dev-libs/wayland</pkg></flag>
   </use>
   <upstream>

--- a/media-libs/mesa/metadata.xml
+++ b/media-libs/mesa/metadata.xml
@@ -8,7 +8,6 @@
   <use>
     <flag name="d3d9">Enable Direct 3D9 API through Nine state tracker. Can be used together with patched wine.</flag>
     <flag name="gles1">Enable GLESv1 support.</flag>
-    <flag name="gles2">Enable GLESv2 support.</flag>
     <flag name="llvm">Enable LLVM backend for Gallium3D.</flag>
     <flag name="lm-sensors">Enable Gallium HUD lm-sensors support.</flag>
     <flag name="opencl">Enable the Rusticl Gallium OpenCL state tracker.</flag>

--- a/media-libs/opencv/metadata.xml
+++ b/media-libs/opencv/metadata.xml
@@ -34,7 +34,6 @@
 		<flag restrict="&gt;=media-libs/opencv-4.4.0" name="contribfreetype">Enable Drawing UTF-8 strings with freetype/harfbuzz</flag>
 		<flag restrict="&gt;=media-libs/opencv-4.4.0" name="contribovis">Enable Ogre vision module support</flag>
 		<flag restrict="&gt;=media-libs/opencv-3.4.0" name="dnnsamples">Download dnn caffeemodel samples</flag>
-		<flag name="opencl">Add support for OpenCL</flag>
 		<flag restrict="&gt;=media-libs/opencv-3.1.0" name="tesseract">Use Google's OCR Engine</flag>
 		<flag name="testprograms">Build and install programs for testing OpenCV (performance)</flag>
 		<flag name="vtk">Build new 3D visualization module viz based on <pkg>sci-libs/vtk</pkg></flag>

--- a/media-libs/opensubdiv/metadata.xml
+++ b/media-libs/opensubdiv/metadata.xml
@@ -14,10 +14,6 @@
 			Enable NVIDIA CUDA Toolkit support through
 			<pkg>dev-util/nvidia-cuda-toolkit</pkg>
 		</flag>
-		<flag name="opencl">
-			Enable OpenCL support through
-			<pkg>virtual/opencl</pkg>
-		</flag>
 		<flag name="ptex">
 			Adds support for faster per-face texture mapping through
 			<pkg>media-libs/ptex</pkg>

--- a/media-libs/x264/metadata.xml
+++ b/media-libs/x264/metadata.xml
@@ -6,7 +6,6 @@
 	</maintainer>
 	<use>
 		<flag name="interlaced">enable interlaced encoding support, this can decrease encoding speed by up to 2%</flag>
-		<flag name="opencl">Add support for OpenCL.</flag>
 		<flag name="pic">disable optimized assembly code that is not PIC friendly</flag>
 	</use>
 </pkgmetadata>

--- a/media-plugins/audacious-plugins/metadata.xml
+++ b/media-plugins/audacious-plugins/metadata.xml
@@ -15,7 +15,6 @@
 		<flag name="openmpt">Add support for OpenMPT</flag>
 		<flag name="pipewire">Build the PipeWire output plugin</flag>
 		<flag name="scrobbler">Build with scrobbler/LastFM submission support</flag>
-		<flag name="sid">Build with SID (Commodore 64 Audio) support</flag>
 		<flag name="soxr">Build with SoX Resampler support</flag>
 		<flag name="speedpitch">Enable speed/pitch effects</flag>
 		<flag name="streamtuner">Build the streamtuner plugin</flag>

--- a/media-plugins/gst-plugins-gtk/metadata.xml
+++ b/media-plugins/gst-plugins-gtk/metadata.xml
@@ -6,7 +6,6 @@
 	<name>GStreamer package maintainers</name>
 </maintainer>
 <use>
-	<flag name="egl">Enable EGL platform usage</flag>
 	<flag name="gles2">Enable gtkglsink OpenGL sink based on GLESv2 API</flag>
 	<flag name="opengl">Enable gtkglsink OpenGL sink based on desktop OpenGL API</flag>
 </use>

--- a/media-plugins/gst-plugins-vaapi/metadata.xml
+++ b/media-plugins/gst-plugins-vaapi/metadata.xml
@@ -7,7 +7,6 @@
 	</maintainer>
 	<use>
 		<flag name="drm">Enable DRM renderer</flag>
-		<flag name="egl">Enable EGL support</flag>
 		<flag name="gles2">Enable GLESv2 and GLESv3 support</flag>
 	</use>
 </pkgmetadata>

--- a/media-sound/mangler/metadata.xml
+++ b/media-sound/mangler/metadata.xml
@@ -2,7 +2,6 @@
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
   <use>
-    <flag name="espeak">Text to speech engine</flag>
     <flag name="g15">Logitech g15 lcd support</flag>
   </use>
   <maintainer type="person">

--- a/media-sound/moc/metadata.xml
+++ b/media-sound/moc/metadata.xml
@@ -7,7 +7,6 @@
 	</maintainer>
 	<use>
 		<flag name="cache">Enable tags caching support</flag>
-		<flag name="sid">Build with SID (Commodore 64 Audio) support</flag>
 		<flag name="sndio">Enable support for the <pkg>media-sound/sndio</pkg> backend</flag>
 		<flag name="tremor">Build vorbis support using an integer implementation
 			of the vorbis library (<pkg>media-libs/tremor</pkg>)</flag>

--- a/media-sound/mp3blaster/metadata.xml
+++ b/media-sound/mp3blaster/metadata.xml
@@ -5,9 +5,6 @@
     <email>sound@gentoo.org</email>
     <name>Gentoo Sound project</name>
   </maintainer>
-  <use>
-    <flag name="sid">Build with SID (Commodore 64 Audio) support</flag>
-  </use>
   <upstream>
     <remote-id type="sourceforge">mp3blaster</remote-id>
   </upstream>

--- a/media-sound/mpd/metadata.xml
+++ b/media-sound/mpd/metadata.xml
@@ -32,7 +32,6 @@
     <flag name="pipewire">PipeWire support</flag>
     <flag name="qobuz">Build plugin to access qobuz</flag>
     <flag name="recorder">Enables output plugin for recording radio streams</flag>
-    <flag name="sid">Build with SID (Commodore 64 Audio) support</flag>
     <flag name="signalfd">Use the signalfd function in MPD's event loop</flag>
     <flag name="snapcast">Snapcast audio plugin</flag>
     <flag name="sndio">Enable support for the <pkg>media-sound/sndio</pkg> backend</flag>

--- a/media-sound/ncmpcpp/metadata.xml
+++ b/media-sound/ncmpcpp/metadata.xml
@@ -11,7 +11,6 @@
 	</maintainer>
 	<use>
 		<flag name="clock">Enable clock screen</flag>
-		<flag name="lto">Build with link-time optimisation</flag>
 		<flag name="outputs">Enable outputs screen</flag>
 		<flag name="visualizer">Enable visualizer screen with sound wave/frequency spectrum modes</flag>
 	</use>

--- a/media-sound/qmmp/metadata.xml
+++ b/media-sound/qmmp/metadata.xml
@@ -25,7 +25,6 @@
 		<flag name="qtmedia">Enable playback via <pkg>dev-qt/qtmultimedia</pkg></flag>
 		<flag name="scrobbler">Enable audioscrobbler/last.fm support</flag>
 		<flag name="shout">Enable shoutcast plug-in via <pkg>media-libs/libshout</pkg>.</flag>
-		<flag name="sid">Build with SID (Commodore 64 Audio) support</flag>
 		<flag name="soxr">Use the SoX resampling library</flag>
 		<flag name="sndfile">Enable wav playback support via <pkg>media-libs/libsndfile</pkg></flag>
 		<flag name="stereo">Enable stereo effect</flag>

--- a/media-sound/xmms2/metadata.xml
+++ b/media-sound/xmms2/metadata.xml
@@ -14,7 +14,6 @@
 		<flag name="mac">Support for Monkey's Audio (APE) format using <pkg>media-sound/mac</pkg></flag>
 		<flag name="mlib-update">Enable building of xmms2-mlib-updater client</flag>
 		<flag name="server">Build xmms2 player daemon (otherwise only clients are built)</flag>
-		<flag name="sid">Support for C64 SID using <pkg>media-libs/libsidplay</pkg></flag>
 		<flag name="tremor">Support Vorbis using an alternate fixed-point decoder with <pkg>media-libs/tremor</pkg></flag>
 		<flag name="vocoder">Phase vocoder effect plugin</flag>
 		<flag name="xml">Enable support for various XML based playlists and sources: RSS, XSPF</flag>

--- a/media-video/ffmpeg/metadata.xml
+++ b/media-video/ffmpeg/metadata.xml
@@ -56,7 +56,6 @@
 		<flag name="qsv">Enable Intel Quick Sync Video via <pkg>media-libs/intel-mediasdk</pkg> (ffmpeg versions older than, and including, 5.1) or <pkg>media-libs/oneVPL</pkg> (ffmpeg version newer than 5.1).</flag>
 		<flag name="mmal">Enables Multi-Media Abstraction Layer (MMAL) decoding support: Available e.g. on the Raspberry Pi.</flag>
 		<flag name="network">Enables network streaming support</flag>
-		<flag name="opencl">Enable OpenCL support</flag>
 		<flag name="openh264">Enables H.264 encoding suppoprt via <pkg>media-libs/openh264</pkg>.</flag>
 		<flag name="openssl">Enables <pkg>dev-libs/openssl</pkg> support. Adds support for encrypted network protocols (TLS/HTTPS).</flag>
 		<flag name="pic">Force shared libraries to be built as PIC (this is slower)</flag>

--- a/media-video/qmplay2/metadata.xml
+++ b/media-video/qmplay2/metadata.xml
@@ -19,7 +19,6 @@
 		<flag name="libass">Build with SSA/ASS subtitles rendering support</flag>
 		<flag name="notifications">Build additional notifications module</flag>
 		<flag name="pipewire">Build with PipeWire support</flag>
-		<flag name="sid">Build Chiptune with SIDPLAY support</flag>
 		<flag name="shaders">Compile Vulkan shaders using <pkg>media-libs/shaderc</pkg></flag>
 		<flag name="videofilters">Build with VideoFilters module</flag>
 		<flag name="visualizations">Build with Visualizations module</flag>

--- a/media-video/vlc/metadata.xml
+++ b/media-video/vlc/metadata.xml
@@ -43,7 +43,6 @@
 		<flag name="sdl-image">Enable sdl image video decoder (depends on sdl)</flag>
 		<flag name="sftp">Enable libssh2 to support SFTP file transfer</flag>
 		<flag name="shout">Enable libshout output</flag>
-		<flag name="sid">Adds support for playing C64 SID files through <pkg>media-libs/libsidplay</pkg>:2</flag>
 		<flag name="skins">Enable support for the skins2 interface</flag>
 		<flag name="soxr">Enable SoX Resampler support via <pkg>media-libs/soxr</pkg></flag>
 		<flag name="srt">Enable support for Secure Reliable Transport (SRT) via <pkg>net-libs/srt</pkg></flag>

--- a/net-analyzer/icinga2/metadata.xml
+++ b/net-analyzer/icinga2/metadata.xml
@@ -7,7 +7,6 @@
 	</maintainer>
 	<use>
 		<flag name="console">Adds support for line-editing in the console</flag>
-		<flag name="lto">Adds support for link time optimization</flag>
 		<flag name="jumbo-build">Combine source files to speed up build process, requires more memory</flag>
 		<flag name="mail">Allows for mailing of alerts</flag>
 		<flag name="mariadb">Enable support for the mariadb database backend</flag>

--- a/net-analyzer/netdata/metadata.xml
+++ b/net-analyzer/netdata/metadata.xml
@@ -11,7 +11,6 @@
     <flag name="dbengine">Enable the Netdata database engine</flag>
     <flag name="ipmi">Install <pkg>sys-apps/ipmitool</pkg> required for monitoring IPMI sensors.</flag>
     <flag name="jsonc">Enable optimization of JSON using <pkg>dev-libs/json-c</pkg></flag>
-    <flag name="lto">Build with Link Time Optimization (LTO)</flag>
     <flag name="mongodb">Enable support for the mongodb backend</flag>
     <flag name="nfacct">Enable the nfacct plugin</flag>
     <flag name="nodejs">Enable use of nodejs (which some plugins use)</flag>

--- a/net-analyzer/wireshark/metadata.xml
+++ b/net-analyzer/wireshark/metadata.xml
@@ -39,7 +39,6 @@
 		<flag name="http2">Use <pkg>net-libs/nghttp2</pkg> for HTTP/2 support</flag>
 		<flag name="ilbc">Build with iLBC support in RTP Player using <pkg>media-libs/libilbc</pkg></flag>
 		<flag name="libxml2">Use <pkg>dev-libs/libxml2</pkg> for handling XML configuration in dissectors</flag>
-		<flag name="lto">Enable link time optimization</flag>
 		<flag name="maxminddb">Use <pkg>dev-libs/libmaxminddb</pkg> for IP address geolocation</flag>
 		<flag name="mergecap">Install mergecap, to merge two or more capture files into one</flag>
 		<flag name="minizip">Build with zip file compression support</flag>

--- a/net-irc/ircii/metadata.xml
+++ b/net-irc/ircii/metadata.xml
@@ -5,7 +5,4 @@
 		<email>bkohler@gentoo.org</email>
 		<name>Ben Kohler</name>
 	</maintainer>
-	<use>
-		<flag name="lto">Build using Link Time Optimizations (LTO)</flag>
-	</use>
 </pkgmetadata>

--- a/net-libs/libbitcoinconsensus/metadata.xml
+++ b/net-libs/libbitcoinconsensus/metadata.xml
@@ -9,9 +9,6 @@
 		<email>proxy-maint@gentoo.org</email>
 		<name>Proxy Maintainers</name>
 	</maintainer>
-	<use>
-		<flag name="asm">Enable assembly for optimization</flag>
-	</use>
 	<upstream>
 		<remote-id type="github">bitcoin/bitcoin</remote-id>
 		<remote-id type="github">bitcoinknots/bitcoin</remote-id>

--- a/net-libs/nodejs/metadata.xml
+++ b/net-libs/nodejs/metadata.xml
@@ -8,7 +8,6 @@
 	<use>
 		<flag name="corepack">Enable the experimental corepack package management tool</flag>
 		<flag name="inspector">Enable V8 inspector</flag>
-		<flag name="lto">Build with link-time optimisation</flag>
 		<flag name="npm">Enable NPM package manager</flag>
 		<flag name="pax-kernel">Enable building under a PaX enabled kernel</flag>
 		<flag name="snapshot">Enable snapshot creation for faster startup</flag>

--- a/net-misc/eventd/metadata.xml
+++ b/net-misc/eventd/metadata.xml
@@ -8,7 +8,6 @@
 			(Note: not required for local notifications via <pkg>net-misc/eventd</pkg>)</flag>
 		<flag name="notification">Enable plugin to display on-screen notifications</flag>
 		<flag name="purple">Enable plugin for IM notifications via libpurple</flag>
-		<flag name="speech">Enable plugin for Text-To-Speech support</flag>
 		<flag name="webhook">Enable plugin to send payloads to webhook handlers</flag>
 		<flag name="websocket">Enable support for WebSocket protocol</flag>
 	</use>

--- a/net-misc/networkmanager/metadata.xml
+++ b/net-misc/networkmanager/metadata.xml
@@ -14,7 +14,6 @@
     <flag name="iptables">Use <pkg>net-firewall/iptables</pkg> for connection sharing</flag>
     <flag name="iwd">Use <pkg>net-wireless/iwd</pkg> instead of <pkg>net-wireless/wpa_supplicant</pkg> for wifi support by default</flag>
     <flag name="psl">Use public suffix list via <pkg>net-libs/libpsl</pkg></flag>
-    <flag name="lto">Build using Link Time Optimizations (LTO)</flag>
     <flag name="modemmanager">Enable support for mobile broadband devices using <pkg>net-misc/modemmanager</pkg></flag>
     <flag name="nftables">Use <pkg>net-firewall/nftables</pkg> for connection sharing</flag>
     <flag name="nss">Use <pkg>dev-libs/nss</pkg> for cryptography</flag>

--- a/net-misc/xmrig/metadata.xml
+++ b/net-misc/xmrig/metadata.xml
@@ -24,9 +24,6 @@
     <flag name="hwloc">
       Use <pkg>sys-apps/hwloc</pkg> for CPU affinity support
     </flag>
-    <flag name="opencl">
-      Enable OpenCL support
-    </flag>
   </use>
   <upstream>
     <remote-id type="github">xmrig/xmrig</remote-id>

--- a/net-p2p/bitcoin-core/metadata.xml
+++ b/net-p2p/bitcoin-core/metadata.xml
@@ -10,7 +10,6 @@
 		<name>Proxy Maintainers</name>
 	</maintainer>
 	<use>
-		<flag name="asm">Enable assembly for optimization</flag>
 		<flag name="berkdb">Support legacy wallets in Berkeley DB format</flag>
 		<flag name="bitcoin-cli">Build and install bitcoin-cli command line interface</flag>
 		<flag name="daemon">Build and install bitcoind daemon</flag>

--- a/net-p2p/bitcoin-qt/metadata.xml
+++ b/net-p2p/bitcoin-qt/metadata.xml
@@ -10,7 +10,6 @@
 		<name>Proxy Maintainers</name>
 	</maintainer>
 	<use>
-		<flag name="asm">Enable assembly for optimization</flag>
 		<flag name="external-signer">Include support for external wallet signer programs</flag>
 		<flag name="nat-pmp">Enable NAT-PMP port forwarding</flag>
 		<flag name="qrcode">Enable generation of QR Codes for receiving payments</flag>

--- a/net-p2p/bitcoind/metadata.xml
+++ b/net-p2p/bitcoind/metadata.xml
@@ -10,7 +10,6 @@
 		<name>Proxy Maintainers</name>
 	</maintainer>
 	<use>
-		<flag name="asm">Enable assembly for optimization</flag>
 		<flag name="external-signer">Include support for external wallet signer programs</flag>
 		<flag name="nat-pmp">Enable NAT-PMP port forwarding</flag>
 		<flag name="systemtap">Enable SystemTAP/DTrace tracing</flag>

--- a/net-voip/mumble/metadata.xml
+++ b/net-voip/mumble/metadata.xml
@@ -9,7 +9,6 @@
 		<flag name="g15">Enable support for the Logitech G15 LCD (and compatible devices).</flag>
 		<flag name="pipewire">Enable pipewire support for audio output.</flag>
 		<flag name="rnnoise">Enable alternative noise suppression option based on RNNoise.</flag>
-		<flag name="speech">Enable text-to-speech support in Mumble.</flag>
 	</use>
 	<upstream>
 		<remote-id type="github">mumble-voip/mumble</remote-id>

--- a/profiles/use.desc
+++ b/profiles/use.desc
@@ -300,6 +300,7 @@ socks5 - Add support for the socks5 proxy
 sound - Enable sound support
 source - Zip the sources and install them
 sox - Add support for Sound eXchange (SoX)
+speech - Enable text-to-speech support
 speex - Add support for the speex audio codec (used for speech)
 spell - Add dictionary support
 split-usr - Enable behavior to support maintaining /bin, /lib*, /sbin and /usr/sbin  separately from /usr/bin and /usr/lib*

--- a/profiles/use.desc
+++ b/profiles/use.desc
@@ -287,6 +287,7 @@ secureboot - Automatically sign efi executables using user specified key
 selinux - !!internal use only!! Security Enhanced Linux support, this must be set by the selinux profile or breakage will occur
 semantic-desktop - Cross-KDE support for semantic search and information retrieval
 session - Add persistent session support
+sid - Enable SID (Commodore 64 audio) file support
 skey - Enable S/Key (Single use password) authentication support
 slang - Add support for the slang text display library (it's like ncurses, but different)
 smartcard - Enable smartcard support

--- a/profiles/use.desc
+++ b/profiles/use.desc
@@ -101,7 +101,8 @@ ggi - Add support for media-libs/libggi (non-X video api/drivers)
 gif - Add GIF image support
 gimp - Build a plugin for the GIMP
 git - Enable git (version control system) support
-gles2-only - Use GLES 2.0 or later instead of full OpenGL
+gles2 - Enable GLES 2.0 (OpenGL for Embedded Systems) support (independently of full OpenGL, see also: gles2-only)
+gles2-only - Use GLES 2.0 (OpenGL for Embedded Systems) or later instead of full OpenGL (see also: gles2)
 glut - Build an OpenGL plugin using the GLUT library
 gmp - Add support for dev-libs/gmp (GNU MP library)
 gnome - Add GNOME support

--- a/profiles/use.desc
+++ b/profiles/use.desc
@@ -174,6 +174,7 @@ lirc - Add support for lirc (Linux's Infra-Red Remote Control)
 livecd - !!internal use only!! DO NOT SET THIS FLAG YOURSELF!, used during livecd building
 llvm-libunwind - Use sys-libs/llvm-libunwind instead of sys-libs/libunwind
 lm-sensors - Add linux lm-sensors (hardware sensors) support
+lto - Enable Link-Time Optimization (LTO) to optimize the build
 lua - Enable Lua scripting support
 lz4 - Enable support for lz4 compression (as implemented in app-arch/lz4)
 lzip - Enable support for lzip compression

--- a/profiles/use.desc
+++ b/profiles/use.desc
@@ -17,6 +17,7 @@ alsa - Add support for media-libs/alsa-lib (Advanced Linux Sound Architecture)
 ao - Use libao audio output library for sound playback
 apache2 - Add Apache2 support
 aqua - Include support for the Mac OS X Aqua (Carbon/Cocoa) GUI
+asm - Enable using assembly for optimization
 atm - Enable Asynchronous Transfer Mode protocol support
 apparmor - Enable support for the AppArmor application security system
 appindicator - Build in support for notifications using the libindicate or libappindicator plugin

--- a/profiles/use.desc
+++ b/profiles/use.desc
@@ -232,6 +232,7 @@ offensive - Enable potentially offensive items in packages
 ofx - Enable support for importing (and exporting) OFX (Open Financial eXchange) data files
 ogg - Add support for the Ogg container format (commonly used by Vorbis, Theora and flac)
 openal - Add support for the Open Audio Library
+opencl - Enable OpenCL support (computation on GPU)
 openexr - Support for the OpenEXR graphics file format
 opengl - Add support for OpenGL (3D graphics)
 openmp - Build support for the OpenMP (support parallel computing), requires >=sys-devel/gcc-4.2 built with USE="openmp"

--- a/profiles/use.desc
+++ b/profiles/use.desc
@@ -241,6 +241,7 @@ oracle - Enable Oracle Database support
 orc - Use dev-lang/orc for just-in-time optimization of array operations
 osc - Enable support for Open Sound Control
 oss - Add support for OSS (Open Sound System)
+otf - Install OpenType font versions
 pam - Add support for PAM (Pluggable Authentication Modules) - DANGEROUS to arbitrarily flip
 pch - Enable precompiled header support for faster compilation at the expense of disk space and memory (>=sys-devel/gcc-3.4 only)
 pcmcia - Add support for PCMCIA slots/devices found on laptop computers
@@ -333,6 +334,7 @@ tiff - Add support for the TIFF image format
 timidity - Build with Timidity++ (MIDI sequencer) support
 tk - Add support for Tk GUI toolkit
 truetype - Add support for FreeType and/or FreeType2 fonts
+ttf - Install TrueType font versions
 udev - Enable virtual/udev integration (device discovery, power and storage device support, etc)
 udisks - Enable storage management support (automounting, volume monitoring, etc)
 uefi - Enable support for the Unified Extensible Firmware Interface

--- a/profiles/use.desc
+++ b/profiles/use.desc
@@ -72,6 +72,7 @@ dvb - Add support for DVB (Digital Video Broadcasting)
 dvd - Add support for DVDs
 dvdr - Add support for DVD writer hardware (e.g. in xcdroast)
 eds - Enable support for Evolution-Data-Server (EDS)
+egl - Enable EGL (Embedded-System Graphics Library, interfacing between windowing system and OpenGL/GLES) support
 elogind - Enable session tracking via sys-auth/elogind
 emacs - Add support for GNU Emacs
 emboss - Add support for the European Molecular Biology Open Software Suite

--- a/sci-geosciences/grass/metadata.xml
+++ b/sci-geosciences/grass/metadata.xml
@@ -21,7 +21,6 @@
 	<use>
 		<flag name="geos">Use <pkg>sci-libs/geos</pkg> for v.buffer and adds extended options to the v.select module</flag>
 		<flag name="las">Include support for LAS and LAZ encoded LiDAR files through <pkg>sci-geosciences/liblas</pkg></flag>
-		<flag name="opencl">Enable OpenCL support</flag>
 		<flag name="pdal">Enable support for PDAL for point clouds via <pkg>sci-libs/pdal</pkg></flag>
 	</use>
 	<upstream>

--- a/sci-geosciences/qgis/metadata.xml
+++ b/sci-geosciences/qgis/metadata.xml
@@ -20,7 +20,6 @@
 		<flag name="hdf5">Enable MDAL support for <pkg>sci-libs/hdf5</pkg></flag>
 		<flag name="mapserver">Determines whether mapserver should be built</flag>
 		<flag name="netcdf">Enable MDAL support for GRIB and XMDF formats</flag>
-		<flag name="opencl">Enable OpenCL support</flag>
 		<flag name="pdal">Enable support for PDAL for point clouds via <pkg>sci-libs/pdal</pkg></flag>
 		<flag name="polar">Enable support for the polar coordinate system via <pkg>x11-libs/qwtpolar</pkg></flag>
 		<flag name="qml">Enable support Qml-based plugins using <pkg>dev-qt/qtdeclarative</pkg></flag>

--- a/sci-libs/caffe2/metadata.xml
+++ b/sci-libs/caffe2/metadata.xml
@@ -17,7 +17,6 @@
 		<flag name="gloo">Use sci-libs/gloo</flag>
 		<flag name="nnpack">Use NNPACK</flag>
 		<flag name="numpy">Add support for math operations through numpy</flag>
-		<flag name="opencl">Use OpenCL</flag>
 		<flag name="opencv">Add support for image processing operators</flag>
 		<flag name="openmp">Use OpenMP for parallel code</flag>
 		<flag name="qnnpack">Use QNNPACK</flag>

--- a/sci-libs/clblast/metadata.xml
+++ b/sci-libs/clblast/metadata.xml
@@ -21,9 +21,6 @@
     <flag name="cuda">
       Build with support for cuda instead of opencl (beta!)
     </flag>
-    <flag name="opencl">
-      Build with support for opencl
-    </flag>
   </use>
   <upstream>
     <remote-id type="github">CNugteren/CLBlast</remote-id>

--- a/sci-libs/gdal/metadata.xml
+++ b/sci-libs/gdal/metadata.xml
@@ -19,7 +19,6 @@
 		<flag name="geos">Add support for geometry engine (<pkg>sci-libs/geos</pkg>)</flag>
 		<flag name="gml">Enable support for <pkg>dev-libs/xerces-c</pkg> C++ API</flag>
 		<flag name="ogdi">Enable support for the open geographic datastore interface (<pkg>sci-libs/ogdi</pkg>)</flag>
-		<flag name="opencl">Enable OpenCL support</flag>
 		<flag name="spatialite">Enable Spatial DBMS over sqlite <pkg>dev-db/spatialite</pkg></flag>
 		<flag name="xls">Add the <pkg>dev-libs/freexl</pkg> library for xls import support</flag>
 	</use>

--- a/sci-libs/libgeodecomp/metadata.xml
+++ b/sci-libs/libgeodecomp/metadata.xml
@@ -23,9 +23,6 @@
     <flag name="cuda">
       Enables plugins for NVIDIA GPUs
     </flag>
-    <flag name="opencl">
-      Enables OpenCL backend
-    </flag>
     <flag name="opencv">
       Enables OpenCV related code
     </flag>

--- a/sci-libs/linbox/metadata.xml
+++ b/sci-libs/linbox/metadata.xml
@@ -18,12 +18,6 @@
     <name>Proxy Maintainers</name>
   </maintainer>
 
-  <use>
-    <flag name="opencl">
-      Enable the use of OpenCL in LinBox
-    </flag>
-  </use>
-
   <longdescription lang="en">
     LinBox is a C++ template library for exact, high-performance
     linear algebra computation with dense, sparse, and structured

--- a/sci-libs/opencascade/metadata.xml
+++ b/sci-libs/opencascade/metadata.xml
@@ -17,9 +17,6 @@
 	<flag name="freeimage">
 		Enable support for image i/o via <pkg>media-libs/freeimage</pkg>
 	</flag>
-	<flag name="gles2">
-		Use OpenGL ES 2.0
-	</flag>
 	<flag name="json">
 		Enable JSON support through <pkg>dev-libs/rapidjson</pkg>
 	</flag>

--- a/sci-misc/boinc/metadata.xml
+++ b/sci-misc/boinc/metadata.xml
@@ -23,7 +23,6 @@
 			NOTE: works only for subset of nvidia graphic cards so make sure your card
 			is supported before opening a bug about it.
 		</flag>
-		<flag name="opencl">Use OpenCL to enable computations using your GPU.</flag>
 	</use>
 	<upstream>
 		<remote-id type="github">BOINC/boinc</remote-id>

--- a/sci-physics/lammps/metadata.xml
+++ b/sci-physics/lammps/metadata.xml
@@ -20,7 +20,6 @@
 			call instead of malloc() when large chunks or memory are allocated
 			by LAMMPS. Aliengnment is on 16 byte boundaries.</flag>
 		<flag name="cuda">Enable cuda gpu computing support</flag>
-		<flag name="opencl">Enable opencl gpu computing support</flag>
 		<flag name="hip">Enable hip gpu computing support</flag>
 		<!--<flag name="kokkos">Enable kokkos non-bonded kernels</flag>-->
 	</use>

--- a/sys-apps/cpu-x/metadata.xml
+++ b/sys-apps/cpu-x/metadata.xml
@@ -23,14 +23,12 @@
 		<flag name="cpu">Use the <pkg>dev-libs/libcpuid</pkg> library for CPU info</flag>
 		<flag name="force-libstatgrab">Use <pkg>sys-libs/libstatgrab</pkg> to instead of <pkg>sys-process/procps</pkg></flag>
 		<flag name="gpu">Use the <pkg>media-libs/glfw</pkg> library for GPU info</flag>
-		<flag name="opencl">Use the <pkg>virtual/opencl</pkg> library</flag>
 		<flag name="pci">Use the <pkg>sys-apps/pciutils</pkg> library for PCI info</flag>
 	</use>
 	<use lang="fr">
 		<flag name="cpu">Utiliser la bibliothèque <pkg>dev-libs/libcpuid</pkg> pour les informations liées au C.P.U.</flag>
 		<flag name="force-libstatgrab">Utiliser <pkg>sys-libs/libstatgrab</pkg> à la place de <pkg>sys-process/procps</pkg></flag>
 		<flag name="gpu">Utiliser la bibliothèque <pkg>media-libs/glfw</pkg> pour les informations liées au G.P.U.</flag>
-		<flag name="opencl">Utiliser la bibliothèque <pkg>virtual/opencl</pkg></flag>
 		<flag name="pci">Utiliser la bibliothèque <pkg>sys-apps/pciutils</pkg> pour les informations liées aux bus P.C.I.</flag>
 	</use>
 	<upstream>

--- a/sys-apps/kmscon/metadata.xml
+++ b/sys-apps/kmscon/metadata.xml
@@ -8,7 +8,6 @@
 	<use>
 		<flag name="drm">Enable Linux DRM for backend</flag>
 		<flag name="fbdev">Enable Linux FBDev for backend</flag>
-		<flag name="gles2">Enable GLES2 for backend</flag>
 		<flag name="pango">Enable pango font rendering</flag>
 		<flag name="pixman">Enable pixman font rendering</flag>
 		<flag name="systemd">Enable multiseat support via systemd</flag>

--- a/www-client/firefox/metadata.xml
+++ b/www-client/firefox/metadata.xml
@@ -14,7 +14,6 @@
 	<flag name="hwaccel">Force-enable hardware-accelerated rendering (Mozilla bug 594876)</flag>
 	<flag name="jumbo-build">Enable unified build - combines source files to speed up build process, but requires more memory</flag>
 	<flag name="libproxy">Enable libproxy support</flag>
-	<flag name="lto">Enable Link Time Optimization (LTO)</flag>
 	<flag name="openh264">Use <pkg>media-libs/openh264</pkg> for H264 support
 		instead of downloading binary blob from Mozilla at runtime</flag>
 	<flag name="pgo">Add support for profile-guided optimization for faster binaries - this

--- a/x11-apps/mesa-progs/metadata.xml
+++ b/x11-apps/mesa-progs/metadata.xml
@@ -5,9 +5,6 @@
     <email>x11@gentoo.org</email>
     <name>X11</name>
   </maintainer>
-  <use>
-    <flag name="gles2">Build OpenGL ES 2 utilities</flag>
-  </use>
   <upstream>
     <remote-id type="freedesktop-gitlab">mesa/demos</remote-id>
   </upstream>


### PR DESCRIPTION
```
+asm - Enable using assembly for optimization
+egl - Enable EGL support
+gles2 - Enable GLES 2.0 support (independently of full OpenGL, see also: gles2-only)
+lto - Enable Link-Time Optimization (LTO) to optimize the build
+opencl - Enable OpenCL support (computation on GPU)
+otf - Install OpenType font versions
+sid - Enable SID (Commodore 64 Audio) support
+speech - Enable text-to-speech support
+ttf - Install TrueType font versions
```

CC @gentoo/qa 