### PR TITLE
dev-libs/libtomcrypt: Fix cross-compiling by using libtool from SYSROOT

### DIFF
--- a/dev-libs/libtomcrypt/libtomcrypt-1.18.2-r4.ebuild
+++ b/dev-libs/libtomcrypt/libtomcrypt-1.18.2-r4.ebuild
@@ -28,12 +28,15 @@ BDEPEND="
 	sys-devel/libtool
 	virtual/pkgconfig
 "
-DEPEND="
+RDEPEND="
 	gmp? ( dev-libs/gmp:= )
 	libtommath? ( dev-libs/libtommath:= )
 	tomsfastmath? ( dev-libs/tomsfastmath:= )
 "
-RDEPEND="${DEPEND}"
+DEPEND="
+	${RDEPEND}
+	sys-devel/libtool
+"
 
 PATCHES=(
 	"${FILESDIR}"/${P}-slibtool.patch
@@ -72,6 +75,9 @@ mymake() {
 	elif use tomsfastmath ; then
 		enabled_features+=( -DUSE_TFM=1 )
 	fi
+
+	# Fix cross-compiling, but allow manual overrides for slibtool, which works.
+	[[ -z ${LIBTOOL} ]] && declare -x LIBTOOL="${BASH} ${ESYSROOT}/usr/bin/libtool"
 
 	# IGNORE_SPEED=1 is needed to respect CFLAGS
 	EXTRALIBS="${extra_libs[*]}" emake \


### PR DESCRIPTION
libtool is normally generated by configure with the right toolchain settings, but this package does not use autoconf, so it executes the build host libtool with the wrong settings. CC seems to be respected for compiling but not linking for some reason.

As much as I hate executing something from SYSROOT, hell will freeze over before libtool stops being a Bash script. This seems far easier than any alternative. ${BASH} at least ensures that it is not executed using some prefixed shebang.

slibtool is not a Bash script, but we don't currently allow users to swap libtool for slibtool, even though it is supposed to be a drop-in replacement.