### PR TITLE
sci-libs/hdf5: fix broken examplesdir support

### DIFF
--- a/sci-libs/hdf5/hdf5-1.14.3-r1.ebuild
+++ b/sci-libs/hdf5/hdf5-1.14.3-r1.ebuild
@@ -65,10 +65,6 @@ pkg_setup() {
 src_prepare() {
 	default
 
-	# Respect Gentoo examples directory
-	sed \
-		-e "s:hdf5_examples:doc/${PF}/examples:g" \
-		-i $(find . -name Makefile.am) $(find . -name "run*.sh.in") || die
 	sed \
 		-e '/docdir/d' \
 		-i config/commence.am || die
@@ -96,6 +92,7 @@ src_configure() {
 		--enable-deprecated-symbols
 		--enable-build-mode=$(usex debug debug production)
 		--with-default-plugindir="${EPREFIX}/usr/$(get_libdir)/${PN}/plugin"
+		--with-examplesdir="\${datarootdir}/doc/${PF}/examples" \
 		$(use_enable cxx)
 		$(use_enable debug codestack)
 		$(use_enable fortran)


### PR DESCRIPTION
Since at least upstream version 1.12.2, upstream added a configure option to choose the examples directory. It was no longer hardcoded in Makefile.am, which means the sed fixup did not work, but also the option wasn't passed.

Upstream commit: https://github.com/HDFGroup/hdf5/commit/b8a93a7224114739e42f32aaf62ae64fd1aad33e

iwdevtools:
```
 * SED: the following did not cause any changes
 *     sed -e "s:hdf5_examples:doc/${PF}/examples:g" -i $(find . -name Makefile.am) $(find . -name "run*.sh.in") || die;
 * no-op: -e s:hdf5_examples:doc/hdf5-1.12.2-r4/examples:g
```

Make sure the option is correctly passed.