### PR TITLE
profiles/use.desc: Make USE=cuda global

### DIFF
--- a/dev-cpp/eigen/metadata.xml
+++ b/dev-cpp/eigen/metadata.xml
@@ -16,9 +16,6 @@
 		OpenGL apps, spreadsheets and other office apps, etc. Eigen is dedicated to
 		providing optimal speed with GCC.
 	</longdescription>
-	<use>
-		<flag name="cuda">Build with cuda support</flag>
-	</use>
 	<upstream>
 		<remote-id type="gitlab">libeigen/eigen</remote-id>
 	</upstream>

--- a/dev-libs/libdynd/metadata.xml
+++ b/dev-libs/libdynd/metadata.xml
@@ -15,9 +15,6 @@
     preview development state, and can be thought of as a sandbox where
     features are being tried and tweaked to gain experience with them.
   </longdescription>
-  <use>
-    <flag name="cuda">Enable NVIDIA CUDA toolkit support</flag>
-  </use>
   <upstream>
     <remote-id type="github">libdynd/libdynd</remote-id>
   </upstream>

--- a/dev-libs/pocl/metadata.xml
+++ b/dev-libs/pocl/metadata.xml
@@ -7,7 +7,6 @@
 	<use>
 		<flag name="accel">Enable the generic hardware accelerator device driver</flag>
 		<flag name="conformance">Ensures that certain build options which would result in non-conformant pocl build stay disabled. Note that this does not quarantee a fully conformant build of pocl.</flag>
-		<flag name="cuda">Enable the CUDA backend for NVIDIA GPUs</flag>
 		<flag name="float-conversion">When enabled, OpenCL printf() call's f/e/g formatters are handled by pocl. When disabled, these are handled by system C library.</flag>
 		<flag name="hardening">Enable hardening against various attacks. May worsen performance</flag>
 		<!--<flag name="hsa">Enable the HSA base profile runtime device driver</flag>-->

--- a/dev-libs/starpu/metadata.xml
+++ b/dev-libs/starpu/metadata.xml
@@ -12,7 +12,6 @@
   efficiently as possible.
 </longdescription>
 <use>
-  <flag name="cuda">Enable NVIDIA CUDA toolkit support</flag>
   <flag name="gcc-plugin">Enable GCC extension plugin (experimental)</flag>
   <flag name="spinlock-check">Enable spinlock check</flag>
 </use>

--- a/media-libs/opensubdiv/metadata.xml
+++ b/media-libs/opensubdiv/metadata.xml
@@ -10,10 +10,6 @@
 		<name>Proxy Maintainers</name>
 	</maintainer>
 	<use>
-		<flag name="cuda">
-			Enable NVIDIA CUDA Toolkit support through
-			<pkg>dev-util/nvidia-cuda-toolkit</pkg>
-		</flag>
 		<flag name="ptex">
 			Adds support for faster per-face texture mapping through
 			<pkg>media-libs/ptex</pkg>

--- a/net-analyzer/suricata/metadata.xml
+++ b/net-analyzer/suricata/metadata.xml
@@ -11,7 +11,6 @@
     <flag name="bpf">Enable support for eBPF (as well as XDP if supported by the kernel and the NIC driver)
         for low-level, high-speed packet processing</flag>
     <flag name="control-socket">Enable unix socket</flag>
-    <flag name="cuda">Enable NVIDIA Cuda computations support</flag>
     <flag name="detection">Enable detection modules</flag>
     <flag name="hyperscan">Enable high-performance regex matching with Hyperscan</flag>
     <flag name="lz4">Enable support for compressed pcap logging using the LZ4 algorithm</flag>

--- a/profiles/use.desc
+++ b/profiles/use.desc
@@ -52,6 +52,7 @@ coreaudio - Build the CoreAudio driver on Mac OS X systems
 cracklib - Support for cracklib strong password checking
 crypt - Add support for encryption -- using mcrypt or gpg where applicable
 css - Enable reading of encrypted DVDs
+cuda - Enable NVIDIA CUDA support (computation on GPU)
 cups - Add support for CUPS (Common Unix Printing System)
 curl - Add support for client-side URL transfer library
 custom-cflags - Build with user-specified CFLAGS (unsupported)

--- a/sci-chemistry/vmd/metadata.xml
+++ b/sci-chemistry/vmd/metadata.xml
@@ -10,7 +10,6 @@
     <name>Gentoo Chemistry Project</name>
   </maintainer>
   <use>
-    <flag name="cuda">Use nvidia cuda toolkit for speeding up computations</flag>
     <flag name="gromacs">Add support for TNG file format</flag>
     <flag name="msms">Add support for MSMS SES calcualtion tool</flag>
     <flag name="povray">Add support for povray raytracer for HQ images</flag>

--- a/sci-libs/caffe2/metadata.xml
+++ b/sci-libs/caffe2/metadata.xml
@@ -10,7 +10,6 @@
 		<name>James Beddek</name>
 	</maintainer>
 	<use>
-		<flag name="cuda">Add support for CUDA processing</flag>
 		<flag name="distributed">Support distributed applications</flag>
 		<flag name="fbgemm">Use FBGEMM</flag>
 		<flag name="ffmpeg">Add support for video processing operators</flag>

--- a/sci-libs/cholmod/metadata.xml
+++ b/sci-libs/cholmod/metadata.xml
@@ -6,7 +6,6 @@
     <name>Gentoo Science Project</name>
   </maintainer>
   <use>
-    <flag name="cuda">Use nvidia cuda toolkit for speeding up computations</flag>
     <flag name="cholesky">
       Enable sparse Cholesky factorisation
     </flag>

--- a/sci-libs/dealii/metadata.xml
+++ b/sci-libs/dealii/metadata.xml
@@ -32,7 +32,6 @@
 		<flag name="symengine">Add support for symengine (<pkg>sci-libs/symengine</pkg>)</flag>
 		<flag name="trilinos">Add support for trilinos (<pkg>sci-libs/trilinos</pkg>)</flag>
 		<flag name="assimp">Add support for assimp (<pkg>media-libs/assimp</pkg>)</flag>
-		<flag name="cuda">Add support for cuda (<pkg>dev-util/nvidia-cuda-toolkit</pkg>)</flag>
 		<flag name="ginkgo">Add support for ginkgo (<pkg>sci-libs/ginkgo</pkg>)</flag>
 		<flag name="sundials">Add support for sundials (<pkg>sci-libs/sundials</pkg>)</flag>
 	</use>

--- a/sci-libs/flann/metadata.xml
+++ b/sci-libs/flann/metadata.xml
@@ -17,7 +17,6 @@
   <use>
     <flag name="octave">Add bindings for
     <pkg>sci-mathematics/octave</pkg></flag>
-    <flag name="cuda">Enable support for nVidia CUDA</flag>
   </use>
   <upstream>
     <remote-id type="github">mariusmuja/flann</remote-id>

--- a/sci-libs/gloo/metadata.xml
+++ b/sci-libs/gloo/metadata.xml
@@ -9,7 +9,6 @@
 		<remote-id type="github">facebookincubator/gloo</remote-id>
 	</upstream>
 	<use>
-		<flag name="cuda">Enable CUDA support</flag>
 		<flag name="libuv">Enable libuv support</flag>
 		<flag name="redis">Enable Redis backend for storage via <pkg>dev-libs/hiredis</pkg></flag>
 	</use>

--- a/sci-libs/libgeodecomp/metadata.xml
+++ b/sci-libs/libgeodecomp/metadata.xml
@@ -20,9 +20,6 @@
     details of the parallel computer.
   </longdescription>
   <use>
-    <flag name="cuda">
-      Enables plugins for NVIDIA GPUs
-    </flag>
     <flag name="opencv">
       Enables OpenCV related code
     </flag>

--- a/sci-libs/pastix/metadata.xml
+++ b/sci-libs/pastix/metadata.xml
@@ -17,7 +17,6 @@
   block structure of the incomplete factors.
   </longdescription>
   <use>
-    <flag name="cuda">Enable GPU support using CUDA kernels</flag>
     <flag name="fortran">Install the Fortran interface</flag>
     <flag name="int64">Use 64- rather than 32-bit integer representation</flag>
     <flag name="metis">Enable matrix ordering with <pkg>sci-libs/metis</pkg></flag>

--- a/sci-libs/pcl/metadata.xml
+++ b/sci-libs/pcl/metadata.xml
@@ -6,7 +6,6 @@
 		<name>Alexis Ballier</name>
 	</maintainer>
 	<use>
-		<flag name="cuda">Adds support for NVIDIA CUDA.</flag>
 		<flag name="openni">Adds support for Kinect-like 3D sensors devices with <pkg>dev-libs/OpenNI</pkg>.</flag>
 		<flag name="openni2">Adds support for Kinect-like 3D sensors devices with <pkg>dev-libs/OpenNI2</pkg> (should be preferred over openni).</flag>
 		<flag name="pcap">Adds pcap file capabilities in some drivers.</flag>

--- a/sci-libs/suitesparse/metadata.xml
+++ b/sci-libs/suitesparse/metadata.xml
@@ -29,9 +29,6 @@
     * SSMULT: sparse matrix times sparse matrix
 </longdescription>
 <use>
-  <flag name="cuda">
-    Enable nvidia cuda toolkit for speeding up computations
-  </flag>
   <flag name="partition">
     Enable graph partitioning and graph-partition-based orderings
     through <pkg>sci-libs/metis</pkg> or <pkg>sci-libs/parmetis</pkg>

--- a/sci-libs/tensorflow/metadata.xml
+++ b/sci-libs/tensorflow/metadata.xml
@@ -6,7 +6,6 @@
 		<name>Jason Zaman</name>
 	</maintainer>
 	<use>
-		<flag name="cuda">Enable support for nVidia CUDA</flag>
 		<flag name="xla">XLA (Accelerated Linear Algebra) Optimizing Compiler for TensorFlow</flag>
 	</use>
 	<upstream>

--- a/sci-libs/tensorpipe/metadata.xml
+++ b/sci-libs/tensorpipe/metadata.xml
@@ -5,9 +5,6 @@
 		<email>tupone@gentoo.org</email>
 		<name>Tupone Alfredo</name>
 	</maintainer>
-	<use>
-		<flag name="cuda">Add support for CUDA processing</flag>
-	</use>
 	<upstream>
 		<remote-id type="github">pytorch/tensorpipe</remote-id>
 	</upstream>

--- a/sci-libs/trilinos/metadata.xml
+++ b/sci-libs/trilinos/metadata.xml
@@ -19,7 +19,6 @@
 		<flag name="all-packages">Enable all supported Trilinos packages (per default only a subset is built)</flag>
 		<flag name="arprec">Add support for arprec (<pkg>sci-libs/arprec</pkg>)</flag>
 		<flag name="clp">Add support for clp (<pkg>sci-libs/coinor-clp</pkg>)</flag>
-		<flag name="cuda">Add support for cuda (<pkg>dev-util/nvidia-cuda-toolkit</pkg>)</flag>
 		<flag name="eigen">Add support for eigen (<pkg>dev-cpp/eigen</pkg>)</flag>
 		<flag name="glpk">Add support for glpk (<pkg>sci-mathematics/glpk</pkg>)</flag>
 		<flag name="gtest">Add support for gtest (<pkg>dev-cpp/gtest</pkg>)</flag>

--- a/sci-libs/vtk/metadata.xml
+++ b/sci-libs/vtk/metadata.xml
@@ -20,7 +20,6 @@
   <use>
     <flag name="all-modules">Build all modules</flag>
     <flag name="boost">Add support for boost</flag>
-    <flag name="cuda">Add support for CUDA</flag>
     <flag name="freetype">Build support for font rendering</flag>
     <flag name="gdal">Support for gdal formated data</flag>
     <flag name="imaging">Building Imaging modules</flag>

--- a/sci-mathematics/mathematica/metadata.xml
+++ b/sci-mathematics/mathematica/metadata.xml
@@ -23,7 +23,6 @@
 	</longdescription>
 	<use>
 		<flag name="bundle">Install from Wolfram's bundle file or from Mathematica only</flag>
-		<flag name="cuda">Install with cuda support</flag>
 		<flag name="R">Enable <pkg>dev-lang/R</pkg> backend support</flag>
 		<flag name="ffmpeg">Enable <pkg>media-video/ffmpeg</pkg> backend support</flag>
 	</use>

--- a/sci-misc/boinc/metadata.xml
+++ b/sci-misc/boinc/metadata.xml
@@ -17,13 +17,6 @@
 		BOINC (Berkeley Open Infrastructure for Network Computing) is a software
 		platform for distributed computing using volunteered computer resources.
 	</longdescription>
-	<use>
-		<flag name="cuda">
-			Use nvidia cuda toolkit for speeding up computations.
-			NOTE: works only for subset of nvidia graphic cards so make sure your card
-			is supported before opening a bug about it.
-		</flag>
-	</use>
 	<upstream>
 		<remote-id type="github">BOINC/boinc</remote-id>
 	</upstream>

--- a/sci-physics/espresso/metadata.xml
+++ b/sci-physics/espresso/metadata.xml
@@ -6,7 +6,6 @@
     <name>Gentoo Physics Project</name>
   </maintainer>
   <use>
-    <flag name="cuda">Enable cuda support</flag>
     <flag name="examples">Installs the examples</flag>
   </use>
   <upstream>

--- a/sci-physics/lammps/metadata.xml
+++ b/sci-physics/lammps/metadata.xml
@@ -19,7 +19,6 @@
 		<flag name="lammps-memalign">Enables the use of the posix_memalign()
 			call instead of malloc() when large chunks or memory are allocated
 			by LAMMPS. Aliengnment is on 16 byte boundaries.</flag>
-		<flag name="cuda">Enable cuda gpu computing support</flag>
 		<flag name="hip">Enable hip gpu computing support</flag>
 		<!--<flag name="kokkos">Enable kokkos non-bonded kernels</flag>-->
 	</use>

--- a/sci-physics/root/metadata.xml
+++ b/sci-physics/root/metadata.xml
@@ -24,7 +24,6 @@
   </upstream>
   <use>
     <flag name="asimage">Enable support for <pkg>media-libs/libafterimage</pkg></flag>
-    <flag name="cuda">Enable support for nVidia CUDA</flag>
     <flag name="cudnn">Enable support for nVidia cuDNN library</flag>
     <flag name="davix">Enable support for DAVIX Data Management Client (https://cern.ch/davix)</flag>
     <flag name="fits">Enable support for images and data from FITS files with <pkg>sci-libs/cfitsio</pkg></flag>

--- a/sys-block/libfabric/metadata.xml
+++ b/sys-block/libfabric/metadata.xml
@@ -6,7 +6,6 @@
 		<name>Patrick McLean</name>
 	</maintainer>
 	<use>
-		<flag name="cuda">Enable for CUDA provider</flag>
 		<flag name="efa">Enable Amazon EC2 Elastic Fabric Adapter provider</flag>
 		<flag name="usnic">Enable Cisco VIC (virtualized NIC) hardware on Cisco UCS server provider</flag>
 		<flag name="rocr">Enable Radeon Open Compute provider</flag>

--- a/sys-cluster/openmpi/metadata.xml
+++ b/sys-cluster/openmpi/metadata.xml
@@ -7,7 +7,6 @@
 	</maintainer>
 	<use>
 		<flag name="cma">Enable the CMA (Cross Memory Attach) MCA</flag>
-		<flag name="cuda">Add GPU direct support</flag>
 		<flag name="libompitrace">Enable support for contributed package libompitrace</flag>
 		<flag name="peruse">Enable PERUSE interface</flag>
 		<flag name="romio">Build the ROMIO MPI-IO component</flag>


### PR DESCRIPTION
Add a global USE=cuda.  It is used semi-consistently in 39 packages.

CC @gentoo/qa