### PR TITLE
sys-fs/genfstab: add sys-devel/m4 to BDEPEND

### DIFF
--- a/sys-fs/genfstab/genfstab-28-r1.ebuild
+++ b/sys-fs/genfstab/genfstab-28-r1.ebuild
@@ -20,6 +20,7 @@ RESTRICT="!test? ( test )"
 BDEPEND="
 	app-alternatives/awk
 	app-text/asciidoc
+	sys-devel/m4
 "
 
 src_test() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/920260