### PR TITLE
dev-ruby/zeitwerk: add dev-ruby/warning test dep to 2.6.8

### DIFF
--- a/dev-ruby/zeitwerk/zeitwerk-2.6.8.ebuild
+++ b/dev-ruby/zeitwerk/zeitwerk-2.6.8.ebuild
@@ -21,7 +21,7 @@ SLOT="2"
 KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
 IUSE=""
 
-ruby_add_bdepend "test? ( dev-ruby/bundler )"
+ruby_add_bdepend "test? ( dev-ruby/bundler dev-ruby/warning )"
 
 all_ruby_prepare() {
 	rm -f Gemfile.lock || die


### PR DESCRIPTION
This new dep was introduced in 2.6.8 per https://github.com/fxn/zeitwerk/issues/263