### PR TITLE
media-libs/libaom: backport cpu_flags_ppc_vsx to 3.6.1

### DIFF
--- a/media-libs/libaom/libaom-3.6.1.ebuild
+++ b/media-libs/libaom/libaom-3.6.1.ebuild
@@ -36,7 +36,7 @@ SLOT="0/3"
 IUSE="doc +examples test"
 IUSE="${IUSE} cpu_flags_x86_mmx cpu_flags_x86_sse cpu_flags_x86_sse2 cpu_flags_x86_sse3 cpu_flags_x86_ssse3"
 IUSE="${IUSE} cpu_flags_x86_sse4_1 cpu_flags_x86_sse4_2 cpu_flags_x86_avx cpu_flags_x86_avx2"
-IUSE="${IUSE} cpu_flags_arm_neon"
+IUSE="${IUSE} cpu_flags_arm_neon cpu_flags_ppc_vsx"
 RESTRICT="!test? ( test )"
 
 REQUIRED_USE="
@@ -84,6 +84,8 @@ multilib_src_configure() {
 		-DENABLE_SSE4_2=$(usex cpu_flags_x86_sse4_2 ON OFF)
 		-DENABLE_AVX=$(usex cpu_flags_x86_avx ON OFF)
 		-DENABLE_AVX2=$(usex cpu_flags_x86_avx2 ON OFF)
+
+		-DENABLE_VSX=$(usex cpu_flags_ppc_vsx ON OFF)
 	)
 
 	# For 32-bit multilib builds, force some intrinsics on to work around


### PR DESCRIPTION
Backport of https://github.com/gentoo/gentoo/commit/e568fd7b95d5d6402883a57505f8bf5e31458fe6