### PR TITLE
sci-libs/pastix: destabilize 5.2.3 for ~ppc64

### DIFF
--- a/sci-libs/pastix/pastix-5.2.3.ebuild
+++ b/sci-libs/pastix/pastix-5.2.3.ebuild
@@ -22,7 +22,7 @@ S="${WORKDIR}/${PN}_${PV}/src"
 
 LICENSE="CeCILL-C"
 SLOT="0"
-KEYWORDS="amd64 arm arm64 ~ppc ppc64 ~riscv ~sparc ~x86 ~amd64-linux ~x86-linux"
+KEYWORDS="amd64 arm arm64 ~ppc ~ppc64 ~riscv ~sparc ~x86 ~amd64-linux ~x86-linux"
 IUSE="doc int64 mpi +smp starpu static-libs"
 
 RDEPEND="


### PR DESCRIPTION
As was already done for ppc and x86