### PR TITLE
media-libs/kvazaar: add patch to fix tests on big-endian

### DIFF
--- a/media-libs/kvazaar/files/kvazaar-2.2.0-backport-pr377.patch
+++ b/media-libs/kvazaar/files/kvazaar-2.2.0-backport-pr377.patch
@@ -1,0 +1,32 @@
+https://bugs.gentoo.org/902217
+https://github.com/ultravideo/kvazaar/pull/377
+
+From e19b7925d910e4b77fc5a46d92de0f2563a7e506 Mon Sep 17 00:00:00 2001
+From: matoro <matoro@users.noreply.github.com>
+Date: Wed, 29 Nov 2023 10:58:08 -0500
+Subject: [PATCH] Don't export MD5 byteReverse symbol on big-endian
+
+Otherwise this fails the test which checks that all exported symbols
+begin with kvz_ prefix.
+---
+ src/extras/libmd5.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/extras/libmd5.c b/src/extras/libmd5.c
+index b06b291eb..8a437da68 100644
+--- a/src/extras/libmd5.c
++++ b/src/extras/libmd5.c
+@@ -27,11 +27,11 @@ static void MD5Transform(uint32_t buf[4], uint32_t const in[16]);
+ #ifndef __BIG_ENDIAN__
+ # define byteReverse(buf, len)    /* Nothing */
+ #else
+-void byteReverse(uint32_t *buf, unsigned len);
++static void byteReverse(uint32_t *buf, unsigned len);
+ /*
+  * Note: this code is harmless on little-endian machines.
+  */
+-void byteReverse(uint32_t *buf, unsigned len)
++static void byteReverse(uint32_t *buf, unsigned len)
+ {
+   uint32_t t;
+   do {

--- a/media-libs/kvazaar/kvazaar-2.2.0.ebuild
+++ b/media-libs/kvazaar/kvazaar-2.2.0.ebuild
@@ -36,6 +36,8 @@ DEPEND="${RDEPEND}
 	abi_x86_64? ( ${ASM_DEP} )
 "
 
+PATCHES=( "${FILESDIR}/${PN}-2.2.0-backport-pr377.patch" )
+
 src_prepare() {
 	default
 	sed -e "/^dist_doc_DATA/s/COPYING //" -i Makefile.am || die


### PR DESCRIPTION
Trivial fix and only affects BE so no revbump.

See: https://github.com/ultravideo/kvazaar/pull/377