### PR TITLE
x11-misc/xkeyboard-config: restrict <pycountry-23.12.7

### DIFF
--- a/x11-misc/xkeyboard-config/xkeyboard-config-2.40-r1.ebuild
+++ b/x11-misc/xkeyboard-config/xkeyboard-config-2.40-r1.ebuild
@@ -14,7 +14,7 @@ if [[ ${PV} == 9999 ]]; then
 	inherit git-r3
 else
 	SRC_URI="https://www.x.org/releases/individual/data/${PN}/${P}.tar.xz"
-	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
 fi
 
 LICENSE="MIT"
@@ -22,6 +22,7 @@ SLOT="0"
 IUSE="test"
 RESTRICT="!test? ( test )"
 
+# <dev-python/pycountry-23.12.7 bug #920278
 BDEPEND="
 	dev-lang/perl
 	dev-libs/libxslt
@@ -31,7 +32,7 @@ BDEPEND="
 		x11-apps/xkbcomp
 		x11-libs/libxkbcommon
 		$(python_gen_any_dep '
-			dev-python/pycountry[${PYTHON_USEDEP}]
+			<dev-python/pycountry-23.12.7[${PYTHON_USEDEP}]
 			dev-python/pytest-xdist[${PYTHON_USEDEP}]
 			dev-python/pytest[${PYTHON_USEDEP}]
 		')
@@ -40,9 +41,10 @@ BDEPEND="
 
 python_check_deps() {
 	use test || return 0
-	python_has_version "dev-python/pycountry[${PYTHON_USEDEP}]"
-	python_has_version "dev-python/pytest-xdist[${PYTHON_USEDEP}]"
-	python_has_version "dev-python/pytest[${PYTHON_USEDEP}]"
+	python_has_version \
+		"<dev-python/pycountry-23.12.7[${PYTHON_USEDEP}]" \
+		"dev-python/pytest-xdist[${PYTHON_USEDEP}]" \
+		"dev-python/pytest[${PYTHON_USEDEP}]"
 }
 
 pkg_setup() {


### PR DESCRIPTION
* Fix usage of python_has_version.
* Unkeyword ~s390 again.

Closes: https://bugs.gentoo.org/920278
Bug: https://bugs.gentoo.org/917501