### PR TITLE
sys-libs/liburing: backport fix for building without libgcc

### DIFF
--- a/sys-libs/liburing/files/liburing-2.5-print-libgcc-file-name.patch
+++ b/sys-libs/liburing/files/liburing-2.5-print-libgcc-file-name.patch
@@ -1,0 +1,43 @@
+From https://github.com/axboe/liburing/commit/09b8ded9686f33f1044ad8c612f2281b865cd314 Mon Sep 17 00:00:00 2001
+From: Violet Purcell <vimproved@inventati.org>
+Date: Sat, 16 Dec 2023 16:17:09 -0500
+Subject: [PATCH] Link against libgcc based on output of
+ -print-libgcc-file-name
+
+GCC and clang have the -print-libgcc-file-name option to automatically
+print out the correct compiler runtime library to link to. This can be
+helpful in case the runtime library is named something other than libgcc
+(i.e. on a system where only LLVM's compiler-rt is used), or if libgcc
+is in a non-standard directory. If the option fails for whatever reason,
+fall back to using "-lgcc".
+
+Signed-off-by: Violet Purcell <vimproved@inventati.org>
+--- a/configure
++++ b/configure
+@@ -202,6 +202,15 @@ print_and_output_mak "relativelibdir" "$relativelibdir"
+ print_and_output_mak "mandir" "$mandir"
+ print_and_output_mak "datadir" "$datadir"
+ 
++####################################################
++# Check for correct compiler runtime library to link with
++libgcc_link_flag="-lgcc"
++if $cc -print-libgcc-file-name >/dev/null 2>&1; then
++  libgcc_link_flag="$($cc $CFLAGS $LDFLAGS -print-libgcc-file-name)"
++fi
++print_and_output_mak "libgcc_link_flag" "$libgcc_link_flag"
++####################################################
++
+ ##########################################
+ # check for compiler -Wstringop-overflow
+ stringop_overflow="no"
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -47,7 +47,7 @@ ifeq ($(CONFIG_NOLIBC),y)
+ 	liburing_srcs += nolibc.c
+ 	override CFLAGS += -nostdlib -nodefaultlibs -ffreestanding -fno-builtin -fno-stack-protector
+ 	override CPPFLAGS += -nostdlib -nodefaultlibs -ffreestanding -fno-builtin -fno-stack-protector
+-	override LINK_FLAGS += -nostdlib -nodefaultlibs -lgcc
++	override LINK_FLAGS += -nostdlib -nodefaultlibs $(libgcc_link_flag)
+ endif
+ 
+ override CPPFLAGS += -MT "$@" -MMD -MP -MF "$@.d"

--- a/sys-libs/liburing/liburing-2.5-r2.ebuild
+++ b/sys-libs/liburing/liburing-2.5-r2.ebuild
@@ -1,0 +1,88 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit multilib-minimal toolchain-funcs
+
+DESCRIPTION="Efficient I/O with io_uring"
+HOMEPAGE="https://github.com/axboe/liburing"
+if [[ "${PV}" == *9999 ]] ; then
+	inherit git-r3
+	EGIT_REPO_URI="https://github.com/axboe/liburing.git"
+else
+	SRC_URI="https://git.kernel.dk/cgit/${PN}/snapshot/${P}.tar.bz2"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+	QA_PKGCONFIG_VERSION=${PV}
+fi
+LICENSE="MIT"
+SLOT="0/2" # liburing.so major version
+
+IUSE="examples static-libs test"
+# fsync test hangs forever
+RESTRICT="!test? ( test )"
+
+# At least installed headers need <linux/*>, bug #802516
+DEPEND=">=sys-kernel/linux-headers-5.1"
+RDEPEND="${DEPEND}"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-lld-17.patch
+	"${FILESDIR}"/${P}-print-libgcc-file-name.patch
+)
+
+src_prepare() {
+	default
+
+	if ! use examples; then
+		sed -e '/examples/d' Makefile -i || die
+	fi
+	if ! use test; then
+		sed -e '/test/d' Makefile -i || die
+	fi
+
+	multilib_copy_sources
+}
+
+multilib_src_configure() {
+	local myconf=(
+		--prefix="${EPREFIX}/usr"
+		--libdir="${EPREFIX}/usr/$(get_libdir)"
+		--libdevdir="${EPREFIX}/usr/$(get_libdir)"
+		--mandir="${EPREFIX}/usr/share/man"
+		--cc="$(tc-getCC)"
+		--cxx="$(tc-getCXX)"
+	)
+	# No autotools configure! "econf" will fail.
+	TMPDIR="${T}" ./configure "${myconf[@]}" || die
+}
+
+multilib_src_compile() {
+	emake V=1 AR="$(tc-getAR)" RANLIB="$(tc-getRANLIB)"
+}
+
+multilib_src_install_all() {
+	einstalldocs
+
+	if ! use static-libs ; then
+		find "${ED}" -type f -name "*.a" -delete || die
+	fi
+}
+
+multilib_src_test() {
+	local disabled_tests=(
+		accept.c
+		fpos.c
+		io_uring_register.c
+		link-timeout.c
+		read-before-exit.c
+		recv-msgall-stream.c
+	)
+	local disabled_test
+	for disabled_test in "${disabled_tests[@]}"; do
+		sed -i "/\s*${disabled_test}/d" test/Makefile \
+			|| die "Failed to remove ${disabled_test}"
+	done
+
+	emake -C test V=1 runtests
+}


### PR DESCRIPTION
Since 2.4, liburing has been building in its nolibc configuration for arm64, x86, and amd64. Since 2.5, in this configuration, it explicitly links to -lgcc. This commit backports a patch that removes the explicit -lgcc link and replaces it with the output of cc
-print-libgcc-file-name, which fixes building on LLVM-only systems.

Upstream-Commit: https://github.com/axboe/liburing/commit/09b8ded9686f33f1044ad8c612f2281b865cd314