### PR TITLE
net-mail/qmhandle: add patch to fix help

### DIFF
--- a/net-mail/qmhandle/files/qmhandle-1.3.2-fix-help-parameter.patch
+++ b/net-mail/qmhandle/files/qmhandle-1.3.2-fix-help-parameter.patch
@@ -1,0 +1,15 @@
+This patch fixes typo in parameter usage when help printed
+
+diff --git a/qmHandle b/qmHandle
+index af083f4..a1f3eee 100755
+--- a/qmHandle
++++ b/qmHandle
+@@ -828,7 +828,7 @@ sub Usage {
+     print "  -mN      : display message number N\n";
+     print "  -dN      : delete message number N\n";
+     print "  -fsender : delete message from sender\n";
+-    print "  -f're'   : delete message from senders matching regular expression re\n";
++    print "  -F're'   : delete message from senders matching regular expression re\n";
+     print "  -Stext   : delete all messages that have/contain text as Subject\n";
+     print "  -h're'   : delete all messages with headers matching regular expression re (case insensitive)\n";
+     print "  -b're'   : delete all messages with body matching regular expression re (case insensitive)\n";

--- a/net-mail/qmhandle/qmhandle-1.3.2-r1.ebuild
+++ b/net-mail/qmhandle/qmhandle-1.3.2-r1.ebuild
@@ -1,0 +1,33 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="Qmail message queue tool"
+HOMEPAGE="http://qmhandle.sourceforge.net/"
+SRC_URI="mirror://sourceforge/qmhandle/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~sparc ~x86"
+IUSE=""
+
+RDEPEND="virtual/qmail
+	dev-lang/perl
+	sys-process/psmisc
+"
+DEPEND=""
+
+src_prepare() {
+	eapply "${FILESDIR}/${PN}-1.3.2-fix-help-parameter.patch"
+	sed \
+		-e 's|/usr/local/bin/svc|/usr/bin/svc|g' \
+		-e 's|/service/qmail-deliver|/var/qmail/supervise/qmail-send|g' \
+		-i qmHandle || die "Fixing qmHandle failed"
+	eapply_user
+}
+
+src_install() {
+	dodoc README HISTORY
+	dobin qmHandle
+}


### PR DESCRIPTION
The patch fixes typo in parameter usage when printed help