### PR TITLE
dev-util/perf: mirror kernel restrictions for libdw support

### DIFF
--- a/dev-util/perf/perf-6.3.ebuild
+++ b/dev-util/perf/perf-6.3.ebuild
@@ -179,6 +179,19 @@ perf_make() {
 	local arch=$(tc-arch-kernel)
 	local java_dir
 	use java && java_dir="${EPREFIX}/etc/java-config-2/current-system-vm"
+
+	# sync this with the whitelist in tools/perf/Makefile.config
+	local disable_libdw
+	if ! use amd64 && ! use x86 && \
+	   ! use arm && \
+	   ! use arm64 && \
+	   ! use ppc && ! use ppc64 \
+	   ! use s390 && \
+	   ! use riscv
+	then
+		disable_libdw=1
+	fi
+
 	# FIXME: NO_CORESIGHT
 	emake V=1 VF=1 \
 		HOSTCC="$(tc-getBUILD_CC)" HOSTLD="$(tc-getBUILD_LD)" \
@@ -204,7 +217,7 @@ perf_make() {
 		NO_LIBBIONIC=1 \
 		NO_LIBBPF= \
 		NO_LIBCRYPTO=$(puse crypt) \
-		NO_LIBDW_DWARF_UNWIND= \
+		NO_LIBDW_DWARF_UNWIND="${disable_libdw}" \
 		NO_LIBELF= \
 		NO_LIBNUMA=$(puse numa) \
 		NO_LIBPERL=$(puse perl) \

--- a/dev-util/perf/perf-6.5.ebuild
+++ b/dev-util/perf/perf-6.5.ebuild
@@ -212,6 +212,20 @@ perf_make() {
 	local arch=$(tc-arch-kernel)
 	local java_dir
 	use java && java_dir="${EPREFIX}/etc/java-config-2/current-system-vm"
+
+	# sync this with the whitelist in tools/perf/Makefile.config
+	local disable_libdw
+	if ! use amd64 && ! use x86 && \
+	   ! use arm && \
+	   ! use arm64 && \
+	   ! use ppc && ! use ppc64 \
+	   ! use s390 && \
+	   ! use riscv && \
+	   ! use loong
+	then
+		disable_libdw=1
+	fi
+
 	# FIXME: NO_CORESIGHT
 	local emakeargs=(
 		V=1 VF=1
@@ -241,7 +255,7 @@ perf_make() {
 		NO_LIBBPF=$(puse bpf)
 		NO_LIBCAP=$(puse caps)
 		NO_LIBCRYPTO=$(puse crypt)
-		NO_LIBDW_DWARF_UNWIND=
+		NO_LIBDW_DWARF_UNWIND="${disable_libdw}"
 		NO_LIBELF=
 		NO_LIBNUMA=$(puse numa)
 		NO_LIBPERL=$(puse perl)

--- a/dev-util/perf/perf-6.6.ebuild
+++ b/dev-util/perf/perf-6.6.ebuild
@@ -209,6 +209,20 @@ perf_make() {
 	local arch=$(tc-arch-kernel)
 	local java_dir
 	use java && java_dir="${EPREFIX}/etc/java-config-2/current-system-vm"
+
+	# sync this with the whitelist in tools/perf/Makefile.config
+	local disable_libdw
+	if ! use amd64 && ! use x86 && \
+	   ! use arm && \
+	   ! use arm64 && \
+	   ! use ppc && ! use ppc64 \
+	   ! use s390 && \
+	   ! use riscv && \
+	   ! use loong
+	then
+		disable_libdw=1
+	fi
+
 	# FIXME: NO_CORESIGHT
 	local emakeargs=(
 		V=1 VF=1
@@ -237,7 +251,7 @@ perf_make() {
 		NO_LIBBPF=$(puse bpf)
 		NO_LIBCAP=$(puse caps)
 		NO_LIBCRYPTO=$(puse crypt)
-		NO_LIBDW_DWARF_UNWIND=
+		NO_LIBDW_DWARF_UNWIND="${disable_libdw}"
 		NO_LIBELF=
 		NO_LIBNUMA=$(puse numa)
 		NO_LIBPERL=$(puse perl)


### PR DESCRIPTION
Kernel has a whitelist of architectures for which unwind via libdw is supported.  Right now the ebuild unconditionally enables it, this fails on architectures where kernel support is not merged (e.g. alpha).

This list needs to be checked and synced on updates.  There shouldn't be anything removed from it in the future, only added.