### PR TITLE
dev-lang/spidermonkey: skip bad tests on sparc

### DIFF
--- a/dev-lang/spidermonkey/spidermonkey-102.10.0.ebuild
+++ b/dev-lang/spidermonkey/spidermonkey-102.10.0.ebuild
@@ -371,6 +371,13 @@ src_test() {
 		echo "test262/built-ins/TypedArray/prototype/set/typedarray-arg-set-values-same-buffer-other-type.js" >> "${T}"/known_failures.list
 	fi
 
+	if use sparc; then
+		# https://salsa.debian.org/gnome-team/mozjs/-/blob/debian/102/master/debian/patches/tests-Use-DEB_HOST_ARCH_BITS-to-skip-some-tests-on-64-bit.patch
+		echo "non262/Array/regress-157652.js" >> "${T}"/known_failures.list
+		echo "non262/Array/regress-330812.js" >> "${T}"/known_failures.list
+		echo "non262/regress/regress-422348.js" >> "${T}"/known_failures.list
+	fi
+
 	if use x86; then
 		echo "non262/Date/timeclip.js" >> "${T}"/known_failures.list
 		echo "test262/built-ins/Date/UTC/fp-evaluation-order.js" >> "${T}"/known_failures.list


### PR DESCRIPTION
Lines up with Debian patch.

See: https://salsa.debian.org/gnome-team/mozjs/-/blob/debian/102/master/debian/patches/tests-Use-DEB_HOST_ARCH_BITS-to-skip-some-tests-on-64-bit.patch