### PR TITLE
sys-cluster/ceph: limit to dev-util/babeltrace:0/1 for USE=babeltrace

### DIFF
--- a/dev-util/babeltrace/babeltrace-1.5.8.ebuild
+++ b/dev-util/babeltrace/babeltrace-1.5.8.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -10,7 +10,7 @@ HOMEPAGE="https://babeltrace.org/"
 SRC_URI="https://www.efficios.com/files/${PN}/${P}.tar.bz2"
 
 LICENSE="GPL-2"
-SLOT="0"
+SLOT="0/$(ver_cut 1)"
 KEYWORDS="amd64 arm arm64 ppc ppc64 ~riscv x86"
 IUSE="test"
 RESTRICT="!test? ( test )"

--- a/sys-cluster/ceph/ceph-16.2.14-r1.ebuild
+++ b/sys-cluster/ceph/ceph-16.2.14-r1.ebuild
@@ -70,7 +70,7 @@ DEPEND="
 	sys-process/numactl:=
 	virtual/libcrypt:=
 	x11-libs/libpciaccess:=
-	babeltrace? ( dev-util/babeltrace )
+	babeltrace? ( dev-util/babeltrace:0/1 )
 	fuse? ( sys-fs/fuse:3= )
 	jemalloc? ( dev-libs/jemalloc:= )
 	!jemalloc? ( >=dev-util/google-perftools-2.6.1:= )

--- a/sys-cluster/ceph/ceph-17.2.6-r8.ebuild
+++ b/sys-cluster/ceph/ceph-17.2.6-r8.ebuild
@@ -74,7 +74,7 @@ DEPEND="
 	sys-process/numactl:=
 	virtual/libcrypt:=
 	x11-libs/libpciaccess:=
-	babeltrace? ( dev-util/babeltrace )
+	babeltrace? ( dev-util/babeltrace:0/1 )
 	fuse? ( sys-fs/fuse:3= )
 	jemalloc? ( dev-libs/jemalloc:= )
 	!jemalloc? ( >=dev-util/google-perftools-2.6.1:= )

--- a/sys-cluster/ceph/ceph-17.2.7.ebuild
+++ b/sys-cluster/ceph/ceph-17.2.7.ebuild
@@ -74,7 +74,7 @@ DEPEND="
 	sys-process/numactl:=
 	virtual/libcrypt:=
 	x11-libs/libpciaccess:=
-	babeltrace? ( dev-util/babeltrace )
+	babeltrace? ( dev-util/babeltrace:0/1 )
 	fuse? ( sys-fs/fuse:3= )
 	jemalloc? ( dev-libs/jemalloc:= )
 	!jemalloc? ( >=dev-util/google-perftools-2.6.1:= )

--- a/sys-cluster/ceph/ceph-18.2.0-r2.ebuild
+++ b/sys-cluster/ceph/ceph-18.2.0-r2.ebuild
@@ -74,7 +74,7 @@ DEPEND="
 	sys-process/numactl:=
 	virtual/libcrypt:=
 	x11-libs/libpciaccess:=
-	babeltrace? ( dev-util/babeltrace )
+	babeltrace? ( dev-util/babeltrace:0/2 )
 	fuse? ( sys-fs/fuse:3= )
 	jemalloc? ( dev-libs/jemalloc:= )
 	!jemalloc? ( >=dev-util/google-perftools-2.6.1:= )


### PR DESCRIPTION
dev-util/babeltrace:0/2 installs itself as "babeltrace2" for pkg-config.  This is on purpose since the interface is significantly different enough to require complete rewrites against it.