### PR TITLE
dev-haskell/vector-algorithms: Require gmp source

### DIFF
--- a/dev-haskell/vector-algorithms/vector-algorithms-0.9.0.1-r1.ebuild
+++ b/dev-haskell/vector-algorithms/vector-algorithms-0.9.0.1-r1.ebuild
@@ -24,6 +24,15 @@ RDEPEND=">=dev-haskell/bitvec-1.0:=[profile?] <dev-haskell/bitvec-1.2:=[profile?
 	>=dev-haskell/vector-0.6:=[profile?] <dev-haskell/vector-0.14:=[profile?]
 	>=dev-lang/ghc-8.4.3:=
 "
+
+# bug 916191
+RDEPEND+="
+	|| (
+		dev-haskell/bitvec[gmp]
+		dev-lang/ghc[gmp]
+	)
+"
+
 DEPEND="${RDEPEND}
 	>=dev-haskell/cabal-2.2.0.1
 	test? ( properties? ( >dev-haskell/quickcheck-2.9 <dev-haskell/quickcheck-2.15 ) )


### PR DESCRIPTION
It appears that `vector-algorithms` implicitly depends on gmp either via `ghc` or the `bitvec` package. If neither source for gmp is available, packages in `vector-algorithm`'s reverse dependency tree may run into linker errors during compile time:

    libHSbitvec-1.1.3.0-*.so: undefined symbol: __gmpn_popcount

Closes: https://bugs.gentoo.org/917291
Closes: https://bugs.gentoo.org/917267
Closes: https://bugs.gentoo.org/916208
Closes: https://bugs.gentoo.org/916191
Closes: https://bugs.gentoo.org/916186
Closes: https://bugs.gentoo.org/916183
Closes: https://bugs.gentoo.org/920461