### PR TITLE
net-libs/google-cloud-cpp: disable test broken under portage

### DIFF
--- a/net-libs/google-cloud-cpp/google-cloud-cpp-2.19.0.ebuild
+++ b/net-libs/google-cloud-cpp/google-cloud-cpp-2.19.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -52,5 +52,6 @@ src_configure() {
 }
 
 src_test() {
-	cmake_src_test -LE "integration-test"
+	# ClogEnvironment fails under portage sandbox, no fail outside
+	cmake_src_test -LE "integration-test" -E common_log_test
 }


### PR DESCRIPTION
ClogEnvironment fails (segfault) under portage sandbox, doesn't fail outside, unsure why.  Most of other large test suite is fine, just disable this one for now.