### PR TITLE
dev-python/flask-api: restrict to <dev-python/werkzeug-3

### DIFF
--- a/dev-python/flask-api/flask-api-3.1-r1.ebuild
+++ b/dev-python/flask-api/flask-api-3.1-r1.ebuild
@@ -1,0 +1,37 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DISTUTILS_USE_PEP517=setuptools
+PYTHON_COMPAT=( pypy3 python3_{10..12} )
+
+inherit distutils-r1
+
+DESCRIPTION="Browsable web APIs for Flask"
+HOMEPAGE="
+	https://github.com/flask-api/flask-api/
+	https://pypi.org/project/Flask-API/
+"
+# pypi mirror don't have docs folder
+SRC_URI="
+	https://github.com/flask-api/flask-api/archive/v${PV}.tar.gz
+		-> ${P}.gh.tar.gz
+"
+
+LICENSE="BSD-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+RDEPEND="
+	<dev-python/flask-3[${PYTHON_USEDEP}]
+	dev-python/markdown[${PYTHON_USEDEP}]
+	<dev-python/werkzeug-3[${PYTHON_USEDEP}]
+"
+
+distutils_enable_tests pytest
+
+python_install_all() {
+	local DOCS=( docs/about/release-notes.md docs/api-guide/* docs/index.md )
+	distutils-r1_python_install_all
+}


### PR DESCRIPTION
Uses werkzeug.urls.url_decode which was deprecated in werkzeug-2.3 and removed in werkzeug-3.0.  See https://stackoverflow.com/a/77215455/6214870