### PR TITLE
dev-libs/libdnet: switch from use_with to use_enable for tests

### DIFF
--- a/dev-libs/libdnet/libdnet-1.16.1.ebuild
+++ b/dev-libs/libdnet/libdnet-1.16.1.ebuild
@@ -55,7 +55,7 @@ src_prepare() {
 src_configure() {
 	econf \
 		$(use_with python) \
-		$(use_with test check "${ESYSROOT}/usr")
+		$(use_enable test check)
 }
 
 src_compile() {

--- a/dev-libs/libdnet/libdnet-1.16.2.ebuild
+++ b/dev-libs/libdnet/libdnet-1.16.2.ebuild
@@ -55,7 +55,7 @@ src_prepare() {
 src_configure() {
 	econf \
 		$(use_with python) \
-		$(use_with test check "${ESYSROOT}/usr")
+		$(use_enable test check)
 }
 
 src_compile() {

--- a/dev-libs/libdnet/libdnet-1.16.4.ebuild
+++ b/dev-libs/libdnet/libdnet-1.16.4.ebuild
@@ -59,7 +59,7 @@ src_prepare() {
 src_configure() {
 	econf \
 		$(use_with python) \
-		$(use_with test check "${ESYSROOT}/usr")
+		$(use_enable test check)
 }
 
 src_compile() {


### PR DESCRIPTION
This is the correct way to do it for all versions tested, otherwise the test suite is a no-op.  Tests fail though, see bug 778797.