### PR TITLE
mate-base/mate: +theme depends on x11-themes/mate-themes

### DIFF
--- a/mate-base/mate/mate-1.26.0-r1.ebuild
+++ b/mate-base/mate/mate-1.26.0-r1.ebuild
@@ -1,0 +1,83 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+MATE_THEMES_V=3
+MATE_BRANCH="$(ver_cut 1-2)"
+MINOR=$(($(ver_cut 2) % 2))
+
+if [[ ${MINOR} -eq 0 ]]; then
+        KEYWORDS="amd64 ~arm ~arm64 ~loong ~riscv x86"
+fi
+
+DESCRIPTION="Meta ebuild for MATE, a traditional desktop environment"
+HOMEPAGE="https://mate-desktop.org"
+
+LICENSE="metapackage"
+
+SLOT="0"
+IUSE="+base bluetooth help +notification +themes +extras"
+
+S="${WORKDIR}"
+
+RDEPEND="
+	=mate-base/mate-desktop-${MATE_BRANCH}*
+	=mate-base/mate-menus-${MATE_BRANCH}*
+	=mate-base/mate-panel-${MATE_BRANCH}*
+	=mate-base/mate-session-manager-${MATE_BRANCH}*
+	=mate-base/mate-settings-daemon-${MATE_BRANCH}*
+	=x11-wm/marco-${MATE_BRANCH}*
+	base? (
+		=mate-base/caja-${MATE_BRANCH}*
+		=mate-base/mate-applets-meta-${MATE_BRANCH}*
+		=mate-base/mate-control-center-${MATE_BRANCH}*
+		=mate-extra/mate-media-${MATE_BRANCH}*
+		=x11-misc/mozo-${MATE_BRANCH}*
+		=x11-terms/mate-terminal-${MATE_BRANCH}*
+	)
+	bluetooth? ( net-wireless/blueman )
+	themes? (
+		=x11-themes/mate-backgrounds-${MATE_BRANCH}*
+		=x11-themes/mate-icon-theme-${MATE_BRANCH}*
+		=x11-themes/mate-themes-${MATE_THEMES_V}*
+	)
+	extras? (
+		=app-arch/engrampa-${MATE_BRANCH}*
+		=app-editors/pluma-${MATE_BRANCH}*
+		=app-text/atril-${MATE_BRANCH}*
+		=mate-extra/caja-extensions-${MATE_BRANCH}*
+		=mate-extra/mate-calc-${MATE_BRANCH}*
+		=mate-extra/mate-netbook-${MATE_BRANCH}*
+		=mate-extra/mate-power-manager-${MATE_BRANCH}*
+		=mate-extra/mate-screensaver-${MATE_BRANCH}*
+		=mate-extra/mate-system-monitor-${MATE_BRANCH}*
+		=mate-extra/mate-utils-${MATE_BRANCH}*
+		=media-gfx/eom-${MATE_BRANCH}*
+	)
+	help? (
+		gnome-extra/yelp
+		=mate-extra/mate-user-guide-${MATE_BRANCH}*
+	)
+"
+
+PDEPEND="
+	notification? ( =x11-misc/mate-notification-daemon-${MATE_BRANCH}* )
+	virtual/notification-daemon:0"
+
+pkg_postinst() {
+	elog "Please report all bugs to https:/bugs.gentoo.org"
+	elog ""
+	elog "For installation, usage and troubleshooting details regarding MATE;"
+	elog "read more about it at Gentoo Wiki: https://wiki.gentoo.org/wiki/MATE"
+	elog ""
+	if ! has_version x11-misc/mate-notification-daemon; then
+		elog "If you experience any issues with notifications, please try using"
+		elog "x11-misc/mate-notification-daemon instead your currently installed daemon"
+		elog ""
+	fi
+	elog "Some packages that are not included in this meta-package but may be of interest:"
+	elog "		mate-extra/caja-dropbox"
+	elog "		mate-extra/mate-user-share"
+	elog "		mate-extra/caja-admin"
+}

--- a/mate-base/mate/mate-1.27.0-r1.ebuild
+++ b/mate-base/mate/mate-1.27.0-r1.ebuild
@@ -1,0 +1,85 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+MATE_THEMES_V=3
+MATE_BRANCH="$(ver_cut 1-2)"
+MINOR=$(($(ver_cut 2) % 2))
+
+if [[ ${MINOR} -eq 0 ]]; then
+        KEYWORDS="~amd64 ~arm ~arm64 ~loong ~riscv ~x86"
+fi
+
+SRC_URI=""
+DESCRIPTION="Meta ebuild for MATE, a traditional desktop environment"
+HOMEPAGE="https://mate-desktop.org"
+
+LICENSE="metapackage"
+
+SLOT="0"
+IUSE="+base bluetooth help +notification +themes +extras"
+
+S="${WORKDIR}"
+
+RDEPEND="
+	=mate-base/mate-desktop-${MATE_BRANCH}*
+	=mate-base/mate-menus-${MATE_BRANCH}*
+	=mate-base/mate-panel-${MATE_BRANCH}*
+	=mate-base/mate-session-manager-${MATE_BRANCH}*
+	=mate-base/mate-settings-daemon-${MATE_BRANCH}*
+	=x11-wm/marco-${MATE_BRANCH}*
+	base? (
+		=mate-base/caja-${MATE_BRANCH}*
+		=mate-base/mate-applets-meta-${MATE_BRANCH}*
+		=mate-base/mate-control-center-${MATE_BRANCH}*
+		=mate-extra/mate-media-${MATE_BRANCH}*
+		=x11-misc/mozo-${MATE_BRANCH}*
+		=x11-terms/mate-terminal-${MATE_BRANCH}*
+	)
+	bluetooth? ( net-wireless/blueman )
+	themes? (
+		=x11-themes/mate-backgrounds-${MATE_BRANCH}*
+		=x11-themes/mate-icon-theme-${MATE_BRANCH}*
+		=x11-themes/mate-themes-${MATE_THEMES_V}*
+	)
+	extras? (
+		=app-arch/engrampa-${MATE_BRANCH}*
+		=app-editors/pluma-${MATE_BRANCH}*
+		=app-text/atril-${MATE_BRANCH}*
+		=mate-extra/caja-extensions-${MATE_BRANCH}*
+		=mate-extra/mate-calc-${MATE_BRANCH}*
+		=mate-extra/mate-netbook-${MATE_BRANCH}*
+		=mate-extra/mate-power-manager-${MATE_BRANCH}*
+		=mate-extra/mate-screensaver-${MATE_BRANCH}*
+		=mate-extra/mate-system-monitor-${MATE_BRANCH}*
+		=mate-extra/mate-utils-${MATE_BRANCH}*
+		=media-gfx/eom-${MATE_BRANCH}*
+	)
+	help? (
+		gnome-extra/yelp
+		=mate-extra/mate-user-guide-${MATE_BRANCH}*
+	)
+"
+
+PDEPEND="
+	notification? ( =x11-misc/mate-notification-daemon-${MATE_BRANCH}* )
+	virtual/notification-daemon:0"
+
+pkg_postinst() {
+	elog "1.27.x is a development release, if a stable desktop experince is required then use 1.26."
+	elog "Please report all issues to https:/bugs.gentoo.org"
+	elog ""
+	elog "For installation, usage and troubleshooting details regarding MATE;"
+	elog "read more about it at Gentoo Wiki: https://wiki.gentoo.org/wiki/MATE"
+	elog ""
+	if ! has_version x11-misc/mate-notification-daemon; then
+		elog "If you experience any issues with notifications, please try using"
+		elog "x11-misc/mate-notification-daemon instead your currently installed daemon"
+		elog ""
+	fi
+	elog "Some packages that are not included in this meta-package but may be of interest:"
+	elog "		mate-extra/caja-dropbox"
+	elog "		mate-extra/mate-user-share"
+	elog "		mate-extra/caja-admin"
+}


### PR DESCRIPTION
As per bug, it is reasonable to assume that +themes would pull x11-themes/mate-themes in the meta package.

1.26 should be a stable push in this case as it's just adding functionality that was incorrectly missing and the dependency is already well tested looking at feedback.  

Closes: https://bugs.gentoo.org/890959
