### PR TITLE
media-video/sonic-snap: EAPI8, fix #453456,#740520

### DIFF
--- a/media-video/sonic-snap/sonic-snap-1.7-r1.ebuild
+++ b/media-video/sonic-snap/sonic-snap-1.7-r1.ebuild
@@ -1,12 +1,13 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
+
 inherit linux-info toolchain-funcs
 
 DESCRIPTION="Webcam app for sn9c10x based camera controllers (with optional MPEG4 support)"
-HOMEPAGE="http://www.stolk.org/sonic-snap/"
-SRC_URI="http://www.stolk.org/${PN}/downloads/${P}.tar.gz"
+HOMEPAGE="https://www.stolk.org/sonic-snap/"
+SRC_URI="https://www.stolk.org/${PN}/downloads/${P}.tar.gz"
 
 LICENSE="GPL-1"
 SLOT="0"
@@ -14,15 +15,15 @@ KEYWORDS="~amd64 ~mips ~ppc ~ppc64 ~sparc ~x86"
 IUSE="mpeg"
 
 DEPEND="
-	x11-libs/fltk:1
-	mpeg? ( >=media-libs/libfame-0.9.1 )
 	sys-libs/zlib
-	x11-libs/libXdmcp
-	x11-libs/libXau
-	x11-libs/libXrender
+	x11-libs/fltk:1
 	x11-libs/libX11
+	x11-libs/libXau
+	x11-libs/libXdmcp
 	x11-libs/libXext
 	x11-libs/libXft
+	x11-libs/libXrender
+	mpeg? ( >=media-libs/libfame-0.9.1 )
 "
 RDEPEND="${DEPEND}"
 
@@ -37,6 +38,7 @@ src_prepare() {
 		-e "s|\$(HOME)/lib|/usr/$(get_libdir)|" \
 		-e "s|CFLAGS=|CFLAGS= ${CXXFLAGS} |" \
 		-e "s|LFLAGS=|LFLAGS= ${LDFLAGS} |" \
+		-e "s|g++-4.0 -O3 -o|$(tc-getCXX) ${CXXFLAGS} ${LDFLAGS} -o|" \
 		-e "s/g++-4.0 -O3/$(tc-getCXX)/" \
 		Makefile || die
 
@@ -45,15 +47,9 @@ src_prepare() {
 	default
 }
 
-src_compile() {
-	make || die '"make" failed.'
-}
-
 src_install() {
 	dodir /usr/bin
-	make DESTDIR="${D}" install || die '"make install" failed.'
-
-	dodoc ChangeLog README
+	default
 	doman debian/sonic-snap.1
 }
 


### PR DESCRIPTION
Another `EAPI8`, should also fix both open bugs for `media-video/sonic-snap`

Signed-off-by: Michael Mair-Keimberger <mmk@levelnine.at>

Closes: https://bugs.gentoo.org/453456
Closes: https://bugs.gentoo.org/740520