### PR TITLE
net-analyzer/*: use https, LICENSE fixes

### DIFF
--- a/net-analyzer/arping/arping-2.22.ebuild
+++ b/net-analyzer/arping/arping-2.22.ebuild
@@ -1,16 +1,16 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
 inherit autotools fcaps
 
-DESCRIPTION="A utility to see if a specific IP is taken and what MAC owns it"
-HOMEPAGE="http://www.habets.pp.se/synscan/programs.php?prog=arping"
+DESCRIPTION="Utility to see if a specific IP is taken and what MAC owns it"
+HOMEPAGE="https://www.habets.pp.se/synscan/programs.php?prog=arping"
 SRC_URI="https://github.com/ThomasHabets/${PN}/archive/${P}.tar.gz"
 S="${WORKDIR}/${PN}-${P}"
 
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="2"
 KEYWORDS="~alpha amd64 arm ~hppa ~ia64 ~mips ppc ppc64 ~s390 sparc x86 ~amd64-linux ~x86-linux"
 IUSE="test"

--- a/net-analyzer/arping/arping-2.23.ebuild
+++ b/net-analyzer/arping/arping-2.23.ebuild
@@ -5,8 +5,8 @@ EAPI=8
 
 inherit autotools fcaps
 
-DESCRIPTION="A utility to see if a specific IP is taken and what MAC owns it"
-HOMEPAGE="http://www.habets.pp.se/synscan/programs.php?prog=arping"
+DESCRIPTION="Utility to see if a specific IP is taken and what MAC owns it"
+HOMEPAGE="https://www.habets.pp.se/synscan/programs.php?prog=arping"
 if [[ ${PV} == 9999 ]] ; then
 	EGIT_REPO_URI="https://github.com/ThomasHabets/arping"
 	inherit git-r3
@@ -17,7 +17,7 @@ else
 	S="${WORKDIR}/${PN}-${P}"
 fi
 
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="2"
 IUSE="+seccomp test"
 RESTRICT="!test? ( test )"

--- a/net-analyzer/arping/arping-9999.ebuild
+++ b/net-analyzer/arping/arping-9999.ebuild
@@ -1,12 +1,12 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
 inherit autotools fcaps
 
-DESCRIPTION="A utility to see if a specific IP is taken and what MAC owns it"
-HOMEPAGE="http://www.habets.pp.se/synscan/programs.php?prog=arping"
+DESCRIPTION="Utility to see if a specific IP is taken and what MAC owns it"
+HOMEPAGE="https://www.habets.pp.se/synscan/programs.php?prog=arping"
 if [[ ${PV} == 9999 ]] ; then
 	EGIT_REPO_URI="https://github.com/ThomasHabets/arping"
 	inherit git-r3
@@ -17,7 +17,7 @@ else
 	S="${WORKDIR}/${PN}-${P}"
 fi
 
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="2"
 IUSE="+seccomp test"
 RESTRICT="!test? ( test )"

--- a/net-analyzer/bwmon/bwmon-1.3-r2.ebuild
+++ b/net-analyzer/bwmon/bwmon-1.3-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -6,7 +6,7 @@ EAPI=7
 inherit toolchain-funcs
 
 DESCRIPTION="Simple ncurses bandwidth monitor"
-HOMEPAGE="http://bwmon.sourceforge.net/"
+HOMEPAGE="https://bwmon.sourceforge.net/"
 SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
 
 BDEPEND="virtual/pkgconfig"

--- a/net-analyzer/cryptcat/cryptcat-1.2.1-r2.ebuild
+++ b/net-analyzer/cryptcat/cryptcat-1.2.1-r2.ebuild
@@ -1,12 +1,12 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
 inherit toolchain-funcs
 
-DESCRIPTION="netcat clone extended with twofish encryption"
-HOMEPAGE="http://cryptcat.sourceforge.net/"
+DESCRIPTION="Netcat clone extended with twofish encryption"
+HOMEPAGE="https://cryptcat.sourceforge.io"
 SRC_URI="mirror://sourceforge/${PN}/${PN}-unix-${PV}.tar"
 S="${WORKDIR}"/unix
 

--- a/net-analyzer/iplog/iplog-2.2.3-r3.ebuild
+++ b/net-analyzer/iplog/iplog-2.2.3-r3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -6,7 +6,7 @@ EAPI=8
 inherit flag-o-matic toolchain-funcs
 
 DESCRIPTION="TCP/IP traffic logger"
-HOMEPAGE="http://ojnk.sourceforge.net/"
+HOMEPAGE="https://ojnk.sourceforge.net/"
 SRC_URI="mirror://sourceforge/ojnk/${P}.tar.gz"
 
 LICENSE="|| ( GPL-2 FDL-1.1 )"

--- a/net-analyzer/isic/isic-0.07-r2.ebuild
+++ b/net-analyzer/isic/isic-0.07-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -6,7 +6,7 @@ EAPI=8
 inherit toolchain-funcs
 
 DESCRIPTION="IP Stack Integrity Checker"
-HOMEPAGE="http://isic.sourceforge.net/"
+HOMEPAGE="https://isic.sourceforge.net/"
 SRC_URI="mirror://sourceforge/isic/${P}.tgz"
 
 LICENSE="BSD"

--- a/net-analyzer/labrea/labrea-2.5_p1.ebuild
+++ b/net-analyzer/labrea/labrea-2.5_p1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -6,11 +6,11 @@ EAPI=7
 inherit autotools
 
 DESCRIPTION="'Sticky' Honeypot and IDS"
-HOMEPAGE="http://labrea.sourceforge.net/"
+HOMEPAGE="https://labrea.sourceforge.io"
 SRC_URI="mirror://sourceforge/${PN}/${P/_p*}-stable-${PV/*_p}.tar.gz"
 S="${WORKDIR}/${P/_p/-stable-}"
 
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="0"
 KEYWORDS="amd64 ~ppc x86"
 

--- a/net-analyzer/nsat/nsat-1.5-r6.ebuild
+++ b/net-analyzer/nsat/nsat-1.5-r6.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -6,11 +6,11 @@ EAPI=7
 inherit autotools toolchain-funcs
 
 DESCRIPTION="Network Security Analysis Tool, an application-level network security scanner"
-HOMEPAGE="http://nsat.sourceforge.net/"
+HOMEPAGE="https://nsat.sourceforge.net/"
 SRC_URI="mirror://sourceforge/nsat/${P}.tgz"
 S="${WORKDIR}/${PN}"
 
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="0"
 KEYWORDS="~amd64 ~ppc x86"
 IUSE="X"

--- a/net-analyzer/odhcploc/odhcploc-20111021-r1.ebuild
+++ b/net-analyzer/odhcploc/odhcploc-20111021-r1.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 inherit toolchain-funcs
 
 DESCRIPTION="Open DHCP Locator"
-HOMEPAGE="http://odhcploc.sourceforge.net/"
+HOMEPAGE="https://odhcploc.sourceforge.io"
 SRC_URI="mirror://sourceforge/project/${PN}/${PV}/${P}.tar.gz"
 
 LICENSE="ISC"

--- a/net-analyzer/odhcploc/odhcploc-20111021-r2.ebuild
+++ b/net-analyzer/odhcploc/odhcploc-20111021-r2.ebuild
@@ -6,7 +6,7 @@ EAPI=8
 inherit toolchain-funcs
 
 DESCRIPTION="Open DHCP Locator"
-HOMEPAGE="http://odhcploc.sourceforge.net/"
+HOMEPAGE="https://odhcploc.sourceforge.io"
 SRC_URI="mirror://sourceforge/project/${PN}/${PV}/${P}.tar.gz"
 
 LICENSE="ISC"

--- a/net-analyzer/oinkmaster/oinkmaster-2.0.ebuild
+++ b/net-analyzer/oinkmaster/oinkmaster-2.0.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
 DESCRIPTION="Rule management for SNORT"
+HOMEPAGE="https://oinkmaster.sourceforge.net/"
 SRC_URI="mirror://sourceforge/oinkmaster/${P}.tar.gz"
-HOMEPAGE="http://oinkmaster.sf.net/"
 
 LICENSE="BSD"
 SLOT="0"

--- a/net-analyzer/pbnj/pbnj-2.04-r1.ebuild
+++ b/net-analyzer/pbnj/pbnj-2.04-r1.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 inherit perl-module
 
-DESCRIPTION="A tool for running Nmap scans and diff'ing the results"
-HOMEPAGE="http://pbnj.sourceforge.net/"
+DESCRIPTION="Tool for running Nmap scans and diff'ing the results"
+HOMEPAGE="https://pbnj.sourceforge.net/"
 SRC_URI="mirror://sourceforge/pbnj/${P}.tar.bz2"
 
 LICENSE="GPL-2"


### PR DESCRIPTION
Hi,

Just some minor `http` -> `https` and LICENSES fixes for various `net-analyzer` packages.