### PR TITLE
app-emacs/gruvbox-theme: Added ~x86 arch keyword

### DIFF
--- a/app-emacs/gruvbox-theme/gruvbox-theme-1.30.1-r1.ebuild
+++ b/app-emacs/gruvbox-theme/gruvbox-theme-1.30.1-r1.ebuild
@@ -17,7 +17,7 @@ else
 	SRC_URI="https://github.com/greduan/emacs-theme-gruvbox/archive/${PV}.tar.gz
 		-> ${P}.tar.gz"
 	S="${WORKDIR}/emacs-theme-gruvbox-${PV}"
-	KEYWORDS="~amd64"
+	KEYWORDS="~amd64 ~x86"
 fi
 
 LICENSE="MIT"

--- a/app-emacs/gruvbox-theme/gruvbox-theme-9999.ebuild
+++ b/app-emacs/gruvbox-theme/gruvbox-theme-9999.ebuild
@@ -17,7 +17,7 @@ else
 	SRC_URI="https://github.com/greduan/emacs-theme-gruvbox/archive/${PV}.tar.gz
 		-> ${P}.tar.gz"
 	S="${WORKDIR}/emacs-theme-gruvbox-${PV}"
-	KEYWORDS="~amd64"
+	KEYWORDS="~amd64 ~x86"
 fi
 
 LICENSE="MIT"


### PR DESCRIPTION
Tested on my 32 bit machine.
Who knows, maybe now that Debian stopped supporting i686, more people will come to Gentoo to have their 32 bit machines running! 