### PR TITLE
dev-python/docutils: dev-python/pillow optfeature

### DIFF
--- a/dev-python/docutils/docutils-0.20.1-r1.ebuild
+++ b/dev-python/docutils/docutils-0.20.1-r1.ebuild
@@ -6,7 +6,7 @@ EAPI=8
 DISTUTILS_USE_PEP517=setuptools
 PYTHON_COMPAT=( python3_{10..12} pypy3 )
 
-inherit distutils-r1 pypi
+inherit distutils-r1 optfeature pypi
 
 DESCRIPTION="Python Documentation Utilities (reference reStructuredText impl.)"
 HOMEPAGE="
@@ -70,4 +70,8 @@ python_install_all() {
 	while IFS= read -r -d '' doc; do
 		install_txt_doc "${doc}"
 	done < <(find docs tools -name '*.txt' -print0)
+}
+
+pkg_postinst() {
+	optfeature "auto-detecting the width/height of an image when using the 'scale' option" dev-python/pillow
 }


### PR DESCRIPTION
If Pillow is installed, the `image` directive lets you give a `scale` option without the corresponding `width` and `height` options.

https://docutils.sourceforge.io/docs/ref/rst/directives.html#image-options