### PR TITLE
app-portage/gentoolkit: fix compilation of invalid bytecode

### DIFF
--- a/app-portage/gentoolkit/gentoolkit-0.6.3-r1.ebuild
+++ b/app-portage/gentoolkit/gentoolkit-0.6.3-r1.ebuild
@@ -95,8 +95,8 @@ my_src_install() {
 	)
 
 	meson_src_install
-	python_optimize "${pydirs[@]}"
 	python_fix_shebang "${pydirs[@]}"
+	python_optimize "${pydirs[@]}"
 }
 
 pkg_postinst() {


### PR DESCRIPTION
* Fixing python prefix after compilation invalidates it.

Closes: https://bugs.gentoo.org/920490