### PR TITLE
sys-apps/audio-entropyd: EAPI8 bump, fix HOMEPAGE

### DIFF
--- a/sys-apps/audio-entropyd/audio-entropyd-2.0.3-r1.ebuild
+++ b/sys-apps/audio-entropyd/audio-entropyd-2.0.3-r1.ebuild
@@ -1,13 +1,13 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
 
 inherit systemd toolchain-funcs
 
 DESCRIPTION="Audio-entropyd generates entropy-data for the /dev/random device"
-HOMEPAGE="http://www.vanheusden.com/aed/"
-SRC_URI="http://www.vanheusden.com/aed/${P}.tgz"
+HOMEPAGE="https://vanheusden.com/crypto/entropy/aed/"
+SRC_URI="https://vanheusden.com/crypto/entropy/aed/${P}.tgz"
 
 LICENSE="GPL-2"
 SLOT="0"


### PR DESCRIPTION
Simple `EAPI8` bump