### PR TITLE
media-video/dvdauthor: EAPI8 bump, fix #914235

### DIFF
--- a/media-video/dvdauthor/dvdauthor-0.7.2-r3.ebuild
+++ b/media-video/dvdauthor/dvdauthor-0.7.2-r3.ebuild
@@ -1,0 +1,54 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools flag-o-matic toolchain-funcs
+
+DESCRIPTION="Tools for generating DVD files to be played on standalone DVD players"
+HOMEPAGE="https://dvdauthor.sourceforge.net/"
+SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
+S="${WORKDIR}/${PN}"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~ppc64 ~sparc ~x86"
+IUSE="graphicsmagick +imagemagick"
+
+RDEPEND=">=dev-libs/fribidi-0.19.2
+	dev-libs/libxml2
+	>=media-libs/freetype-2
+	media-libs/libdvdread
+	media-libs/libpng:0=
+	imagemagick? (
+		graphicsmagick? ( media-gfx/graphicsmagick:= )
+		imagemagick? ( media-gfx/imagemagick:= )
+	)"
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-freetype-pkgconfig.patch
+)
+
+src_prepare() {
+	default
+
+	eautoreconf
+
+	if use imagemagick && has_version '>=media-gfx/imagemagick-7.0.1.0' ; then
+		eapply "${FILESDIR}/${PN}-0.7.2-imagemagick7.patch"
+	fi
+
+	if use graphicsmagick ; then
+		sed -i -e 's:ExportImagePixels:dIsAbLeAuToMaGiC&:' configure \
+			|| die
+	fi
+}
+
+src_configure() {
+	use graphicsmagick && \
+		append-cppflags "$($(tc-getPKG_CONFIG) --cflags GraphicsMagick)" #459976
+	append-cppflags "$($(tc-getPKG_CONFIG) --cflags fribidi)" #417041
+	econf
+}


### PR DESCRIPTION
`EAPI8` bump and bug fix for https://bugs.gentoo.org/914235

```diff
--- dvdauthor-0.7.2-r2.ebuild	2023-11-15 17:01:28.694049110 +0100
+++ dvdauthor-0.7.2-r3.ebuild	2023-12-23 13:00:37.270801687 +0100
@@ -1,32 +1,31 @@
 # Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
+
 inherit autotools flag-o-matic toolchain-funcs
 
 DESCRIPTION="Tools for generating DVD files to be played on standalone DVD players"
-HOMEPAGE="http://dvdauthor.sourceforge.net/"
+HOMEPAGE="https://dvdauthor.sourceforge.net/"
 SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
+S="${WORKDIR}/${PN}"
 
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="0"
-KEYWORDS="amd64 ppc ppc64 sparc x86"
+KEYWORDS="~amd64 ~ppc ~ppc64 ~sparc ~x86"
 IUSE="graphicsmagick +imagemagick"
-REQUIRED_USE="^^ ( graphicsmagick imagemagick )"
 
 RDEPEND=">=dev-libs/fribidi-0.19.2
 	dev-libs/libxml2
 	>=media-libs/freetype-2
 	media-libs/libdvdread
 	media-libs/libpng:0=
-	graphicsmagick? ( media-gfx/graphicsmagick:= )
-	imagemagick? ( media-gfx/imagemagick:= )"
-DEPEND="${RDEPEND}
-	virtual/pkgconfig"
-
-S="${WORKDIR}/${PN}"
-
-DOCS=( AUTHORS ChangeLog README TODO )
+	imagemagick? (
+		graphicsmagick? ( media-gfx/graphicsmagick:= )
+		imagemagick? ( media-gfx/imagemagick:= )
+	)"
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
 
 PATCHES=(
 	"${FILESDIR}"/${P}-freetype-pkgconfig.patch
```

Signed-off-by: Michael Mair-Keimberger <mmk@levelnine.at>

Closes: https://bugs.gentoo.org/914235