### PR TITLE
sys-block/flashbench: EAPI8 bump

### DIFF
--- a/sys-block/flashbench/flashbench-20120606.ebuild
+++ b/sys-block/flashbench/flashbench-20120606.ebuild
@@ -1,16 +1,24 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
+
+inherit toolchain-funcs
 
 DESCRIPTION="Tool for benchmarking and classifying flash memory drives"
-HOMEPAGE="http://git.linaro.org/people/arnd.bergmann/flashbench.git"
+HOMEPAGE="https://git.linaro.org/people/arnd.bergmann/flashbench.git"
 SRC_URI="https://dev.gentoo.org/~bircoph/distfiles/${P}.tar.xz"
+
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~amd64 ~arm64 ~x86"
 
 PATCHES=( "${FILESDIR}"/${P}-Makefile.patch )
+
+src_compile(){
+	tc-export CC
+	default
+}
 
 src_install() {
 	dobin "${PN}"


### PR DESCRIPTION
Another simple `EAPI8` bump. This one also called `cc` directly, which is why i've added `tc-export CC`.