### PR TITLE
sys-devel/binutils: Add conditional patch to fix ld.bfd prefix handling

### DIFF
--- a/sys-devel/binutils/binutils-2.41-r4.ebuild
+++ b/sys-devel/binutils/binutils-2.41-r4.ebuild
@@ -19,7 +19,7 @@ IUSE="cet debuginfod doc gold gprofng hardened multitarget +nls pgo +plugins sta
 # PATCH_DEV          - Use download URI https://dev.gentoo.org/~{PATCH_DEV}/distfiles/...
 #                      for the patchsets
 
-PATCH_VER=1
+PATCH_VER=4
 PATCH_DEV=dilfridge
 
 if [[ ${PV} == 9999* ]]; then
@@ -32,7 +32,7 @@ else
 	[[ -z ${PATCH_VER} ]] || SRC_URI="${SRC_URI}
 		https://dev.gentoo.org/~${PATCH_DEV}/distfiles/binutils-${PATCH_BINUTILS_VER}-patches-${PATCH_VER}.tar.xz"
 	SLOT=$(ver_cut 1-2)
-	#KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
 fi
 
 #

--- a/sys-devel/binutils/files/binutils-2.41-linker-prefix.patch
+++ b/sys-devel/binutils/files/binutils-2.41-linker-prefix.patch
@@ -1,0 +1,56 @@
+https://bugs.gentoo.org/892549
+https://github.com/gentoo/binutils-gdb/pull/5
+
+From 531bc1536dfc3070c1f7d03e98fa14bcb81fdcd0 Mon Sep 17 00:00:00 2001
+From: James Le Cuirot <chewi@gentoo.org>
+Date: Sat, 23 Dec 2023 13:48:10 +0000
+Subject: [PATCH 2/2] ld: Allow a Gentoo-specific prefix to override the prefix
+ used by ld.bfd
+
+This prefix is only used to locate $prefix/etc/ld.so.conf, with $prefix
+usually being /usr. This file is important on Gentoo Prefix systems,
+where the /usr prefix is within another directory. The problem is that
+Gentoo already passes the same directory as the sysroot, and ld.bfd
+therefore looks for /myprefix/myprefix/usr/etc/ld.so.conf.
+
+The sysroot is dynamic, while the prefix is hardcoded. A hardcoded
+prefix that isn't just /usr is unhelpful, not just because of the
+doubled prefix issue above, but also because it prevents ld.bfd from
+working effectively outside its native environment. We will therefore
+hardcode it to just /usr.
+
+This change does not simply do that though and sets up a $gentoo_prefix
+variable instead, with $prefix as a fallback. This is necessary because
+Gentoo prefix-guest systems, which use the host's libc, do not apply a
+sysroot like RAP prefix systems do. In that case, we must preserve the
+existing behaviour. The binutils ebuild will be responsible for setting
+this variable appropriately.
+---
+ ld/emultempl/elf.em | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/ld/emultempl/elf.em b/ld/emultempl/elf.em
+index 3f67f8b09d9..78c8e909b6c 100644
+--- a/ld/emultempl/elf.em
++++ b/ld/emultempl/elf.em
+@@ -138,7 +138,7 @@ gld${EMULATION_NAME}_before_plugin_all_symbols_read (void)
+   ldelf_before_plugin_all_symbols_read ($IS_LIBPATH, $IS_NATIVE,
+ 				        $IS_LINUX_TARGET,
+ 					$IS_FREEBSD_TARGET,
+-					$ELFSIZE, "$prefix");
++					$ELFSIZE, "${gentoo_prefix-${prefix}}");
+ }
+ 
+ /* This is called after all the input files have been opened.  */
+@@ -147,7 +147,7 @@ static void
+ gld${EMULATION_NAME}_after_open (void)
+ {
+   ldelf_after_open ($IS_LIBPATH, $IS_NATIVE,
+-		    $IS_LINUX_TARGET, $IS_FREEBSD_TARGET, $ELFSIZE, "$prefix");
++		    $IS_LINUX_TARGET, $IS_FREEBSD_TARGET, $ELFSIZE, "${gentoo_prefix-${prefix}}");
+ }
+ 
+ EOF
+-- 
+2.43.0
+


### PR DESCRIPTION
As before, this may make it into our patchset once it's been proven to work. Our track record here hasn't been great so far!

Closes: https://bugs.gentoo.org/892549
Bug: https://github.com/gentoo/binutils-gdb/pull/5