### PR TITLE
net-misc/dhcp: small OpenRC service tweaks

### DIFF
--- a/net-misc/dhcp/files/dhcpd.conf2
+++ b/net-misc/dhcp/files/dhcpd.conf2
@@ -16,7 +16,9 @@
 # All file paths below are relative to the chroot.
 # You can specify a different chroot directory but MAKE SURE it's empty.
 
-# Specify a configuration file - the default is /etc/dhcp/dhcpd.conf
+# Specify a configuration file - the default is based on the service name,
+# so dhcpd would use /etc/dhcp/dhcpd.conf and dhcpd.foo would use
+# /etc/dhcp/dhcpd.foo.conf
 # DHCPD_CONF="/etc/dhcp/dhcpd.conf"
 
 # Configure which interface or interfaces to for dhcpd to listen on.

--- a/net-misc/dhcp/files/dhcpd.init5
+++ b/net-misc/dhcp/files/dhcpd.init5
@@ -1,8 +1,11 @@
 #!/sbin/openrc-run
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+description="ISC DHCP server"
+
 extra_commands="configtest"
+description_configtest="Test the syntax of the configuration file"
 
 : ${DHCPD_CONF:=/etc/dhcp/${SVCNAME}.conf}
 


### PR DESCRIPTION
Make the comment describing the `DHCPD_CONF` variable match the behavior of the service script.

Add some descriptions when running `rc-service dhcpd describe`.