### PR TITLE
net-misc/lambdamoo: EAPI8 bump

### DIFF
--- a/net-misc/lambdamoo/lambdamoo-1.8.1-r3.ebuild
+++ b/net-misc/lambdamoo/lambdamoo-1.8.1-r3.ebuild
@@ -1,30 +1,28 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="6"
+EAPI=8
 
 inherit autotools toolchain-funcs
 
-DESCRIPTION="networked mud that can be used for different types of collaborative software"
+DESCRIPTION="Networked mud that can be used for different types of collaborative software"
 HOMEPAGE="https://sourceforge.net/projects/lambdamoo/"
 SRC_URI="mirror://sourceforge/lambdamoo/LambdaMOO-${PV}.tar.gz"
+S="${WORKDIR}/MOO-${PV}"
 
 LICENSE="LambdaMOO GPL-2"
 SLOT="0"
 KEYWORDS="~sparc ~x86"
-IUSE=""
 
-DEPEND="sys-devel/bison"
-RDEPEND=""
-
-S=${WORKDIR}/MOO-${PV}
+BDEPEND="sys-devel/bison"
 
 src_prepare() {
 	default
-
+	mv configure.{in,ac} || die
 	eapply "${FILESDIR}"/${PV}-enable-outbound.patch
 	sed -i Makefile.in \
 		-e '/ -o /s|$(CFLAGS)|& $(LDFLAGS)|g' \
+		-e 's|configure.in|configure.ac|' \
 		|| die "sed Makefile.in"
 	eautoreconf
 }


### PR DESCRIPTION
Simple `EAPI8` bump. 
I haven't really tested this one but it seems to work on `amd64` too. 