### PR TITLE
cargo.eclass: Support PKGBUMPING to avoid fetching/unpacking crates

### DIFF
--- a/eclass/cargo.eclass
+++ b/eclass/cargo.eclass
@@ -175,6 +175,9 @@ ECARGO_VENDOR="${ECARGO_HOME}/gentoo"
 # If no arguments are provided, it uses the CRATES variable.
 # The value is set as CARGO_CRATE_URIS.
 _cargo_set_crate_uris() {
+	# when called by pkgbump, do not fetch crates
+	[[ ${PKGBUMPING} == ${PVR} ]] && return
+
 	local -r regex='^([a-zA-Z0-9_\-]+)-([0-9]+\.[0-9]+\.[0-9]+.*)$'
 	local crates=${1}
 	local crate
@@ -331,6 +334,9 @@ cargo_src_unpack() {
 	for archive in ${A}; do
 		case "${archive}" in
 			*.crate)
+				# when called by pkgdiff-mg, do not unpack crates
+				[[ ${PKGBUMPING} == ${PVR} ]] && continue
+
 				ebegin "Loading ${archive} into Cargo registry"
 				tar -xf "${DISTDIR}"/${archive} -C "${ECARGO_VENDOR}/" || die
 				# generate sha256sum of the crate itself as cargo needs this


### PR DESCRIPTION
Support using the PKGBUMPING variable set by pkgbump/pkgdiff-mg to avoid respectively fetching and unpacking crates, to speed up using these tools.

CC @gentoo/rust 