### PR TITLE
dev-util/buildbot-worker: remove outdated dependency on "future"

### DIFF
--- a/dev-util/buildbot-worker/buildbot-worker-9999.ebuild
+++ b/dev-util/buildbot-worker/buildbot-worker-9999.ebuild
@@ -23,7 +23,6 @@ RDEPEND="
 	acct-user/buildbot
 	!<dev-util/buildbot-1.0.0
 	>=dev-python/autobahn-0.16.0[${PYTHON_USEDEP}]
-	dev-python/future[${PYTHON_USEDEP}]
 	>=dev-python/msgpack-0.6.0[${PYTHON_USEDEP}]
 	>=dev-python/twisted-18.7.0[${PYTHON_USEDEP}]
 "


### PR DESCRIPTION
Removed upstream in git via
https://github.com/buildbot/buildbot/commit/2e7d00194e4e788621fb7f8614fedd77f97ca56a

Bug: https://bugs.gentoo.org/888287