### PR TITLE
kernel-{build,install}.eclass: Support XZ module compression

### DIFF
--- a/eclass/kernel-build.eclass
+++ b/eclass/kernel-build.eclass
@@ -283,9 +283,18 @@ kernel-build_src_install() {
 	# Modules were already stripped by the kernel build system
 	dostrip -x /lib/modules
 
+	local compress=()
+	if [[ ${KERNEL_IUSE_GENERIC_UKI} ]] && ! use module-compress; then
+		compress+=(
+			# force installing uncompressed modules even if compression
+			# is enabled via config
+			suffix-y=
+		)
+	fi
+
 	emake O="${WORKDIR}"/build "${MAKEARGS[@]}" \
 		INSTALL_MOD_PATH="${ED}" INSTALL_MOD_STRIP="${strip_args}" \
-		INSTALL_PATH="${ED}/boot" "${targets[@]}"
+		INSTALL_PATH="${ED}/boot" "${compress[@]}" "${targets[@]}"
 
 	# note: we're using mv rather than doins to save space and time
 	# install main and arch-specific headers first, and scripts
@@ -545,6 +554,17 @@ kernel-build_merge_configs() {
 			fi
 			merge_configs+=( "${WORKDIR}/modules-sign.config" )
 		fi
+	fi
+
+	# Only semi-related but let's use that to avoid changing stable ebuilds.
+	if [[ ${KERNEL_IUSE_GENERIC_UKI} ]]; then
+		# NB: we enable this even with USE=-module-compress, in order
+		# to support both uncompressed and compressed modules in prebuilt
+		# kernels
+		cat <<-EOF > "${WORKDIR}/module-compress.config" || die
+			CONFIG_MODULE_COMPRESS_XZ=y
+		EOF
+		merge_configs+=( "${WORKDIR}/module-compress.config" )
 	fi
 
 	if [[ ${#user_configs[@]} -gt 0 ]]; then

--- a/eclass/kernel-install.eclass
+++ b/eclass/kernel-install.eclass
@@ -79,7 +79,7 @@ _IDEPEND_BASE="
 
 LICENSE="GPL-2"
 if [[ ${KERNEL_IUSE_GENERIC_UKI} ]]; then
-	IUSE+=" generic-uki"
+	IUSE+=" generic-uki module-compress"
 	# https://github.com/AndrewAmmerlaan/dist-kernel-log-to-licenses
 	# This script can help with generating the array below, keep in mind
 	# that it is not a fully automatic solution, i.e. use flags will


### PR DESCRIPTION
When KERNEL_IUSE_GENERIC_UKI is set (to gatekeep for new ebuilds), enable XZ module compression in kernel and add IUSE=module-compress. When the flag is enabled, the modules are installed .xz compressed per the config.  When it is disabled, they are installed uncompressed but the kernel retains module compression support.