### PR TITLE
sys-process/lsof: fix build issues

### DIFF
--- a/sys-process/lsof/files/lsof-4.98.0-fix-clang-version-parser.patch
+++ b/sys-process/lsof/files/lsof-4.98.0-fix-clang-version-parser.patch
@@ -1,0 +1,15 @@
+https://bugs.gentoo.org/919253
+https://github.com/lsof-org/lsof/issues/305
+
+Ignore HIP or CUDA versions in clang, when checking for compiler version
+--- a/configure.ac
++++ b/configure.ac
+@@ -410,7 +410,7 @@ AC_CONFIG_FILES([Makefile])
+ 
+ # Pass build configurations to version.h.in
+ AC_SUBST(cc, $CC)
+-AC_SUBST(ccv, $($CC -v 2>&1 | sed -n 's/.*version \(.*\)/\1/p'))
++AC_SUBST(ccv, $($CC -v 2>&1 | sed -n 's/.*version \(.*\)/\1/p;q'))
+ AC_SUBST(ccflags, $CFLAGS)
+ AC_SUBST(ldflags, "$LDFLAGS$LIBS")
+ # Reproducible build

--- a/sys-process/lsof/lsof-4.98.0-r1.ebuild
+++ b/sys-process/lsof/lsof-4.98.0-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit flag-o-matic
+inherit autotools flag-o-matic
 
 MY_P="${P/-/_}"
 DESCRIPTION="Lists open files for running Unix processes"
@@ -30,7 +30,15 @@ RESTRICT="test"
 
 PATCHES=(
 	"${FILESDIR}"/${P}-fix-common-include-strftime.patch
+	"${FILESDIR}"/${PN}-4.98.0-fix-clang-version-parser.patch
 )
+
+# TODO: drop this block, "inherit autotools" and clang-version-parser patch after 4.99.3
+# https://github.com/lsof-org/lsof/pull/306
+src_prepare() {
+	default
+	eautoreconf
+}
 
 src_configure() {
 	# TODO: drop after 4.98.0: https://github.com/lsof-org/lsof/commit/4fbe0b78f63ce115f25cf7a49756745e3bf47fea

--- a/sys-process/lsof/lsof-4.98.0.ebuild
+++ b/sys-process/lsof/lsof-4.98.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit flag-o-matic
+inherit autotools flag-o-matic
 
 MY_P="${P/-/_}"
 DESCRIPTION="Lists open files for running Unix processes"
@@ -27,6 +27,17 @@ BDEPEND="
 
 # Needs fixing first for sandbox
 RESTRICT="test"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-4.98.0-fix-clang-version-parser.patch
+)
+
+# TODO: drop this block, "inherit autotools" and clang-version-parser patch after 4.99.3
+# https://github.com/lsof-org/lsof/pull/306
+src_prepare() {
+	default
+	eautoreconf
+}
 
 src_configure() {
 	export ac_cv_header_selinux_selinux_h=$(usex selinux)

--- a/sys-process/lsof/lsof-4.99.0.ebuild
+++ b/sys-process/lsof/lsof-4.99.0.ebuild
@@ -39,6 +39,11 @@ src_compile() {
 	emake DEBUG="" all
 }
 
+src_install() {
+	default
+	find "${ED}" -name '*.la' -delete || die
+}
+
 pkg_postinst() {
 	if [[ ${CHOST} == *-solaris* ]] ; then
 		einfo "Note: to use lsof on Solaris you need read permissions on"

--- a/sys-process/lsof/lsof-4.99.0.ebuild
+++ b/sys-process/lsof/lsof-4.99.0.ebuild
@@ -3,6 +3,8 @@
 
 EAPI=8
 
+inherit autotools
+
 MY_P="${P/-/_}"
 DESCRIPTION="Lists open files for running Unix processes"
 HOMEPAGE="https://github.com/lsof-org/lsof"
@@ -25,6 +27,17 @@ BDEPEND="
 
 # Needs fixing first for sandbox
 RESTRICT="test"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-4.98.0-fix-clang-version-parser.patch
+)
+
+# TODO: drop this block, "inherit autotools" and clang-version-parser patch after 4.99.3
+# https://github.com/lsof-org/lsof/pull/306
+src_prepare() {
+	default
+	eautoreconf
+}
 
 src_configure() {
 	local myeconfargs=(

--- a/sys-process/lsof/lsof-4.99.3.ebuild
+++ b/sys-process/lsof/lsof-4.99.3.ebuild
@@ -39,6 +39,11 @@ src_compile() {
 	emake DEBUG="" all
 }
 
+src_install() {
+	default
+	find "${ED}" -name '*.la' -delete || die
+}
+
 pkg_postinst() {
 	if [[ ${CHOST} == *-solaris* ]] ; then
 		einfo "Note: to use lsof on Solaris you need read permissions on"

--- a/sys-process/lsof/lsof-4.99.3.ebuild
+++ b/sys-process/lsof/lsof-4.99.3.ebuild
@@ -3,6 +3,8 @@
 
 EAPI=8
 
+inherit autotools
+
 MY_P="${P/-/_}"
 DESCRIPTION="Lists open files for running Unix processes"
 HOMEPAGE="https://github.com/lsof-org/lsof"
@@ -25,6 +27,17 @@ BDEPEND="
 
 # Needs fixing first for sandbox
 RESTRICT="test"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-4.98.0-fix-clang-version-parser.patch
+)
+
+# TODO: drop this block, "inherit autotools" and clang-version-parser patch after 4.99.3
+# https://github.com/lsof-org/lsof/pull/306
+src_prepare() {
+	default
+	eautoreconf
+}
 
 src_configure() {
 	local myeconfargs=(


### PR DESCRIPTION
This PR fixes compilation issue fir HIP-enabled clang and [pg0303](https://projects.gentoo.org/qa/policy-guide/installed-files.html#pg0303) QA warning about redundant lo file.

Upstream bug: https://github.com/lsof-org/lsof/issues/305

Closes: https://bugs.gentoo.org/919253
Closes: https://bugs.gentoo.org/920370