### PR TITLE
net-misc/radvd: small OpenRC service tweaks

### DIFF
--- a/net-misc/radvd/files/radvd-2.19.init
+++ b/net-misc/radvd/files/radvd-2.19.init
@@ -1,0 +1,83 @@
+#!/sbin/openrc-run
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+CONFIGFILE=/etc/radvd.conf
+PIDFILE=/run/radvd/radvd.pid
+SYSCTL_FORWARD=net.ipv6.conf.all.forwarding
+
+description="IPv6 Router Advertisement Daemon"
+
+extra_commands="configtest"
+extra_started_commands="reload"
+description_configtest="Test the configuration and run startup tests"
+description_reload="Reload the radvd configuration file"
+
+depend() {
+	need net
+}
+
+checkconfig() {
+	if [ ! -f "${CONFIGFILE}" ]; then
+		eerror "Configuration file ${CONFIGFILE} not found"
+		return 1
+	fi
+
+	if ! /usr/sbin/radvd -c -C "${CONFIGFILE}" ; then
+		eerror "Configuration file ${CONFIGFILE} failed test"
+		return 1
+	fi
+}
+
+configtest() {
+	ebegin "Checking ${RC_SVCNAME} configuration"
+	checkconfig
+	eend $?
+}
+
+start() {
+	if [ "${FORWARD}" != "no" ]; then
+		ebegin "Enabling IPv6 forwarding"
+		sysctl -w "${SYSCTL_FORWARD}=1" >/dev/null
+		eend $?
+	fi
+
+	checkconfig || return 1
+
+	checkpath -d -o radvd:radvd "${PIDFILE%/*}"
+
+	ebegin "Starting IPv6 Router Advertisement Daemon"
+	start-stop-daemon --start --exec /usr/sbin/radvd \
+		--pidfile "${PIDFILE}" \
+		-- -C "${CONFIGFILE}" -p "${PIDFILE}" -u radvd ${OPTIONS}
+	eend $?
+}
+
+stop() {
+	ebegin "Stopping IPv6 Router Advertisement Daemon"
+	start-stop-daemon --stop --exec /usr/sbin/radvd --pidfile "${PIDFILE}"
+	eend $?
+
+	if [ "${FORWARD}" != "no" ]; then
+		ebegin "Disabling IPv6 forwarding"
+		sysctl -w "${SYSCTL_FORWARD}=0" > /dev/null
+		eend $?
+	fi
+}
+
+reload() {
+	if [ "${FORWARD}" != "no" ]; then
+		ebegin "Enabling IPv6 forwarding"
+		sysctl -w "${SYSCTL_FORWARD}=1" >/dev/null
+		eend $?
+	fi
+
+	checkconfig || return 1
+
+	checkpath -d -o radvd:radvd "${PIDFILE%/*}"
+
+	ebegin "Reloading IPv6 Router Advertisement Daemon"
+	start-stop-daemon --signal HUP \
+		--exec /usr/sbin/radvd --pidfile "${PIDFILE}"
+	eend $?
+}

--- a/net-misc/radvd/radvd-2.19-r7.ebuild
+++ b/net-misc/radvd/radvd-2.19-r7.ebuild
@@ -1,0 +1,76 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools readme.gentoo-r1 systemd toolchain-funcs
+
+DESCRIPTION="Linux IPv6 Router Advertisement Daemon"
+HOMEPAGE="https://radvd.litech.org/"
+SRC_URI="https://v6web.litech.org/radvd/dist/${P}.tar.xz"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~riscv ~sparc ~x86"
+IUSE="selinux test"
+RESTRICT="!test? ( test )"
+
+BDEPEND="
+	sys-devel/bison
+	sys-devel/flex
+	virtual/pkgconfig"
+DEPEND="test? ( dev-libs/check )"
+RDEPEND="
+	acct-group/radvd
+	acct-user/radvd
+	selinux? ( sec-policy/selinux-radvd )"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-musl-include.patch
+	"${FILESDIR}"/${P}-clang16.patch
+	"${FILESDIR}"/${P}-configure-c99.patch
+)
+
+src_prepare() {
+	default
+
+	# Drop once clang16 patch is in a release
+	eautoreconf
+}
+
+src_configure() {
+	# Needs reentrant functions (yyset_in), bug #884375
+	export LEX=flex
+
+	econf --with-pidfile=/run/radvd/radvd.pid \
+		--with-systemdsystemunitdir=no \
+		$(use_with test check)
+}
+
+src_compile() {
+	emake AR="$(tc-getAR)"
+}
+
+src_install() {
+	HTML_DOCS=( INTRO.html )
+	default
+	dodoc radvd.conf.example
+
+	newinitd "${FILESDIR}"/${PN}-2.19.init ${PN}
+	newconfd "${FILESDIR}"/${PN}.conf ${PN}
+
+	systemd_dounit "${FILESDIR}"/${PN}.service
+
+	DISABLE_AUTOFORMATTING=1
+	local DOC_CONTENTS="Please create a configuration file ${EPREFIX}/etc/radvd.conf.
+See ${EPREFIX}/usr/share/doc/${PF} for an example.
+
+grsecurity users should allow a specific group to read /proc
+and add the radvd user to that group, otherwise radvd may
+segfault on startup."
+	readme.gentoo_create_doc
+}
+
+pkg_postinst() {
+	readme.gentoo_print_elog
+}


### PR DESCRIPTION
Provide a `configtest` command usable with `rc-service`. Add some descriptive strings when running `rc-service radvd describe`.