### PR TITLE
app-emacs/org-roam: install gentoo sitefile

### DIFF
--- a/app-emacs/org-roam/org-roam-2.2.2-r1.ebuild
+++ b/app-emacs/org-roam/org-roam-2.2.2-r1.ebuild
@@ -31,6 +31,8 @@ RDEPEND="
 "
 BDEPEND="${RDEPEND}"
 
+SITEFILE="50${PN}-gentoo.el"
+
 src_install() {
 	elisp-make-autoload-file
 	elisp_src_install

--- a/app-emacs/org-roam/org-roam-9999.ebuild
+++ b/app-emacs/org-roam/org-roam-9999.ebuild
@@ -31,6 +31,8 @@ RDEPEND="
 "
 BDEPEND="${RDEPEND}"
 
+SITEFILE="50${PN}-gentoo.el"
+
 src_install() {
 	elisp-make-autoload-file
 	elisp_src_install


### PR DESCRIPTION
@ArsenArsen 

I was about to create another PR removing the sitefile from this package. However, since this is a new package i guess this was just forgotten to be installed?
Please review, if it's a leftover, this file could be removed too.