### PR TITLE
USE=lto cleanup (rolling PR)

### DIFF
--- a/app-admin/clsync/clsync-0.4.5.ebuild
+++ b/app-admin/clsync/clsync-0.4.5.ebuild
@@ -19,7 +19,7 @@ LICENSE="GPL-3+"
 SLOT="0"
 IUSE="apidoc +caps +clsync cluster control-socket cgroups doc debug
 examples extra-debug extra-hardened gio +hardened +highload-locks
-+inotify +lto mhash namespaces seccomp socket-library static-libs"
++inotify mhash namespaces seccomp socket-library static-libs"
 
 REQUIRED_USE="
 	|| ( clsync socket-library )
@@ -65,7 +65,9 @@ src_configure() {
 	use debug && debug_level=1
 	use extra-debug && debug_level=2
 
+	# --enable-lto just appends -flto
 	econf \
+		--disable-lto \
 		--enable-debug=${debug_level} \
 		--enable-paranoid=${harden_level} \
 		--without-bsm \
@@ -75,7 +77,6 @@ src_configure() {
 		$(use_enable cluster) \
 		$(use_enable control-socket socket) \
 		$(use_enable highload-locks) \
-		$(use_enable lto) \
 		$(use_enable namespaces unshare) \
 		$(use_enable seccomp) \
 		$(use_enable socket-library) \

--- a/app-admin/clsync/clsync-9999.ebuild
+++ b/app-admin/clsync/clsync-9999.ebuild
@@ -19,7 +19,7 @@ LICENSE="GPL-3+"
 SLOT="0"
 IUSE="apidoc +caps +clsync cluster control-socket cgroups doc debug
 examples extra-debug extra-hardened gio +hardened +highload-locks
-+inotify +lto mhash namespaces seccomp socket-library static-libs"
++inotify mhash namespaces seccomp socket-library static-libs"
 
 REQUIRED_USE="
 	|| ( clsync socket-library )
@@ -65,7 +65,9 @@ src_configure() {
 	use debug && debug_level=1
 	use extra-debug && debug_level=2
 
+	# --enable-lto just appends -flto
 	econf \
+		--disable-lto \
 		--enable-debug=${debug_level} \
 		--enable-paranoid=${harden_level} \
 		--without-bsm \
@@ -75,7 +77,6 @@ src_configure() {
 		$(use_enable cluster) \
 		$(use_enable control-socket socket) \
 		$(use_enable highload-locks) \
-		$(use_enable lto) \
 		$(use_enable namespaces unshare) \
 		$(use_enable seccomp) \
 		$(use_enable socket-library) \

--- a/app-admin/sysstat/sysstat-12.6.2-r1.ebuild
+++ b/app-admin/sysstat/sysstat-12.6.2-r1.ebuild
@@ -12,7 +12,7 @@ SRC_URI="https://github.com/${PN}/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~alpha amd64 arm arm64 ~hppa ~mips ppc ppc64 ~riscv ~s390 sparc x86"
-IUSE="dcron debug nls lm-sensors lto selinux systemd"
+IUSE="dcron debug nls lm-sensors selinux systemd"
 
 BDEPEND="
 	virtual/pkgconfig
@@ -48,12 +48,12 @@ src_prepare() {
 src_configure() {
 	tc-export AR
 
+	# --enable-lto only appends -flto
 	sa_lib_dir=/usr/lib/sa \
 		conf_dir=/etc \
 		econf \
 			$(use_enable !systemd use-crond) \
 			$(use_enable lm-sensors sensors) \
-			$(use_enable lto) \
 			$(use_enable nls) \
 			$(usex debug --enable-debuginfo '') \
 			--disable-compress-manpg \

--- a/app-editors/neovim/neovim-0.9.2.ebuild
+++ b/app-editors/neovim/neovim-0.9.2.ebuild
@@ -21,7 +21,7 @@ fi
 
 LICENSE="Apache-2.0 vim"
 SLOT="0"
-IUSE="+lto +nvimpager test"
+IUSE="+nvimpager test"
 
 # Upstream say the test library needs LuaJIT
 # https://github.com/neovim/neovim/blob/91109ffda23d0ce61cec245b1f4ffb99e7591b62/CMakeLists.txt#L377
@@ -82,14 +82,10 @@ src_prepare() {
 }
 
 src_configure() {
-	# Upstream default to LTO on non-debug builds
-	# Let's expose it as a USE flag because upstream
-	# have preferences for how we should use LTO
-	# if we want it on (not just -flto)
-	# ... but allow turning it off.
 	# TODO: Investigate USE_BUNDLED, doesn't seem to be needed right now
 	local mycmakeargs=(
-		-DENABLE_LTO=$(usex lto)
+		# appends -flto
+		-DENABLE_LTO=OFF
 		-DPREFER_LUA=$(usex lua_single_target_luajit no "$(lua_get_version)")
 		-DLUA_PRG="${ELUA}"
 	)

--- a/app-editors/neovim/neovim-0.9.3.ebuild
+++ b/app-editors/neovim/neovim-0.9.3.ebuild
@@ -21,7 +21,7 @@ fi
 
 LICENSE="Apache-2.0 vim"
 SLOT="0"
-IUSE="+lto +nvimpager test"
+IUSE="+nvimpager test"
 
 # Upstream say the test library needs LuaJIT
 # https://github.com/neovim/neovim/blob/91109ffda23d0ce61cec245b1f4ffb99e7591b62/CMakeLists.txt#L377
@@ -82,14 +82,10 @@ src_prepare() {
 }
 
 src_configure() {
-	# Upstream default to LTO on non-debug builds
-	# Let's expose it as a USE flag because upstream
-	# have preferences for how we should use LTO
-	# if we want it on (not just -flto)
-	# ... but allow turning it off.
 	# TODO: Investigate USE_BUNDLED, doesn't seem to be needed right now
 	local mycmakeargs=(
-		-DENABLE_LTO=$(usex lto)
+		# appends -flto
+		-DENABLE_LTO=OFF
 		-DPREFER_LUA=$(usex lua_single_target_luajit no "$(lua_get_version)")
 		-DLUA_PRG="${ELUA}"
 	)

--- a/app-editors/neovim/neovim-0.9.4.ebuild
+++ b/app-editors/neovim/neovim-0.9.4.ebuild
@@ -21,7 +21,7 @@ fi
 
 LICENSE="Apache-2.0 vim"
 SLOT="0"
-IUSE="+lto +nvimpager test"
+IUSE="+nvimpager test"
 
 # Upstream say the test library needs LuaJIT
 # https://github.com/neovim/neovim/blob/91109ffda23d0ce61cec245b1f4ffb99e7591b62/CMakeLists.txt#L377
@@ -82,14 +82,10 @@ src_prepare() {
 }
 
 src_configure() {
-	# Upstream default to LTO on non-debug builds
-	# Let's expose it as a USE flag because upstream
-	# have preferences for how we should use LTO
-	# if we want it on (not just -flto)
-	# ... but allow turning it off.
 	# TODO: Investigate USE_BUNDLED, doesn't seem to be needed right now
 	local mycmakeargs=(
-		-DENABLE_LTO=$(usex lto)
+		# appends -flto
+		-DENABLE_LTO=OFF
 		-DPREFER_LUA=$(usex lua_single_target_luajit no "$(lua_get_version)")
 		-DLUA_PRG="${ELUA}"
 	)

--- a/app-editors/neovim/neovim-9999.ebuild
+++ b/app-editors/neovim/neovim-9999.ebuild
@@ -21,7 +21,7 @@ fi
 
 LICENSE="Apache-2.0 vim"
 SLOT="0"
-IUSE="+lto +nvimpager test"
+IUSE="+nvimpager test"
 
 # Upstream say the test library needs LuaJIT
 # https://github.com/neovim/neovim/blob/91109ffda23d0ce61cec245b1f4ffb99e7591b62/CMakeLists.txt#L377
@@ -81,15 +81,10 @@ src_prepare() {
 }
 
 src_configure() {
-	ln -s "${BROOT}"/usr/bin/luajit "${BUILD_DIR}"/luajit || die
-	# Upstream default to LTO on non-debug builds
-	# Let's expose it as a USE flag because upstream
-	# have preferences for how we should use LTO
-	# if we want it on (not just -flto)
-	# ... but allow turning it off.
 	# TODO: Investigate USE_BUNDLED, doesn't seem to be needed right now
 	local mycmakeargs=(
-		-DENABLE_LTO=$(usex lto)
+		# appends -flto
+		-DENABLE_LTO=OFF
 		-DPREFER_LUA=$(usex lua_single_target_luajit no "$(lua_get_version)")
 		-DLUA_PRG="${ELUA}"
 	)

--- a/app-mobilephone/scrcpy/scrcpy-2.1.1.ebuild
+++ b/app-mobilephone/scrcpy/scrcpy-2.1.1.ebuild
@@ -14,7 +14,6 @@ SRC_URI="https://github.com/Genymobile/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.g
 LICENSE="Apache-2.0"
 SLOT="0"
 KEYWORDS="~amd64 ~ppc64 ~x86"
-IUSE="lto"
 
 DEPEND="media-libs/libsdl2[X]
 	media-video/ffmpeg
@@ -26,7 +25,6 @@ BDEPEND=""
 
 src_configure() {
 	local emesonargs=(
-		$(meson_use lto b_lto)
 		-Dprebuilt_server="${DISTDIR}/${PN}-server-v${PV}"
 	)
 	meson_src_configure

--- a/app-mobilephone/scrcpy/scrcpy-2.2.ebuild
+++ b/app-mobilephone/scrcpy/scrcpy-2.2.ebuild
@@ -14,7 +14,6 @@ SRC_URI="https://github.com/Genymobile/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.g
 LICENSE="Apache-2.0"
 SLOT="0"
 KEYWORDS="~amd64 ~ppc64 ~x86"
-IUSE="lto"
 
 DEPEND="media-libs/libsdl2[X]
 	media-video/ffmpeg
@@ -25,7 +24,6 @@ RDEPEND="${DEPEND}
 
 src_configure() {
 	local emesonargs=(
-		$(meson_use lto b_lto)
 		-Dprebuilt_server="${DISTDIR}/${PN}-server-v${PV}"
 	)
 	meson_src_configure

--- a/app-mobilephone/scrcpy/scrcpy-2.3.1.ebuild
+++ b/app-mobilephone/scrcpy/scrcpy-2.3.1.ebuild
@@ -14,7 +14,6 @@ SRC_URI="https://github.com/Genymobile/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.g
 LICENSE="Apache-2.0"
 SLOT="0"
 KEYWORDS="~amd64 ~ppc64 ~x86"
-IUSE="lto"
 
 DEPEND="media-libs/libsdl2[X]
 	media-video/ffmpeg
@@ -25,7 +24,6 @@ RDEPEND="${DEPEND}
 
 src_configure() {
 	local emesonargs=(
-		$(meson_use lto b_lto)
 		-Dprebuilt_server="${DISTDIR}/${PN}-server-v${PV}"
 	)
 	meson_src_configure

--- a/app-text/crengine-ng/crengine-ng-0.9.10.ebuild
+++ b/app-text/crengine-ng/crengine-ng-0.9.10.ebuild
@@ -12,7 +12,7 @@ SRC_URI+=" test? ( mirror://gnu/freefont/freefont-otf-20120503.tar.gz )"
 LICENSE="GPL-2+"
 SLOT="0/5"
 KEYWORDS="amd64 ~arm64 x86"
-IUSE="+png +jpeg +gif +svg +chm +harfbuzz +fontconfig +libunibreak +fribidi +zstd +libutf8proc lto static-libs test"
+IUSE="+png +jpeg +gif +svg +chm +harfbuzz +fontconfig +libunibreak +fribidi +zstd +libutf8proc static-libs test"
 
 RESTRICT="!test? ( test )"
 
@@ -68,7 +68,6 @@ src_configure() {
 		-DBUILD_TOOLS=OFF
 		-DENABLE_UNITTESTING=$(usex test)
 		-DOFFLINE_BUILD_MODE=ON
-		-DENABLE_LTO=$(usex lto)
 	)
 	cmake_src_configure
 }

--- a/dev-cpp/benchmark/benchmark-1.8.2.ebuild
+++ b/dev-cpp/benchmark/benchmark-1.8.2.ebuild
@@ -12,8 +12,7 @@ SRC_URI="https://github.com/google/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 LICENSE="Apache-2.0"
 SLOT="0"
 KEYWORDS="amd64 ~arm arm64 ~hppa ~loong ppc ppc64 ~riscv x86"
-IUSE="debug doc lto test"
-
+IUSE="debug doc test"
 RESTRICT="!test? ( test )"
 
 BDEPEND="doc? ( app-doc/doxygen )
@@ -24,7 +23,6 @@ src_configure() {
 		-DBENCHMARK_ENABLE_ASSEMBLY_TESTS=OFF
 		-DBENCHMARK_ENABLE_DOXYGEN=$(usex doc)
 		-DBENCHMARK_ENABLE_GTEST_TESTS=$(usex test)
-		-DBENCHMARK_ENABLE_LTO=$(usex lto)
 		-DBENCHMARK_ENABLE_TESTING=$(usex test)
 		-DBENCHMARK_ENABLE_WERROR=OFF
 		-DBENCHMARK_USE_BUNDLED_GTEST=OFF

--- a/dev-cpp/benchmark/benchmark-1.8.3.ebuild
+++ b/dev-cpp/benchmark/benchmark-1.8.3.ebuild
@@ -12,8 +12,7 @@ SRC_URI="https://github.com/google/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 LICENSE="Apache-2.0"
 SLOT="0"
 KEYWORDS="amd64 ~arm arm64 ~hppa ~loong ppc ppc64 ~riscv ~x86"
-IUSE="debug doc lto test"
-
+IUSE="debug doc test"
 RESTRICT="!test? ( test )"
 
 BDEPEND="doc? ( app-doc/doxygen )
@@ -24,7 +23,6 @@ src_configure() {
 		-DBENCHMARK_ENABLE_ASSEMBLY_TESTS=OFF
 		-DBENCHMARK_ENABLE_DOXYGEN=$(usex doc)
 		-DBENCHMARK_ENABLE_GTEST_TESTS=$(usex test)
-		-DBENCHMARK_ENABLE_LTO=$(usex lto)
 		-DBENCHMARK_ENABLE_TESTING=$(usex test)
 		-DBENCHMARK_ENABLE_WERROR=OFF
 		-DBENCHMARK_USE_BUNDLED_GTEST=OFF

--- a/dev-libs/pocl/pocl-4.0.ebuild
+++ b/dev-libs/pocl/pocl-4.0.ebuild
@@ -14,7 +14,7 @@ LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="amd64 ppc64"
 # TODO: hsa tce
-IUSE="accel +conformance cuda debug examples float-conversion hardening +hwloc memmanager lto test"
+IUSE="accel +conformance cuda debug examples float-conversion hardening +hwloc memmanager test"
 # Tests not yet passing, fragile in Portage environment(?)
 RESTRICT="!test? ( test ) test"
 
@@ -69,7 +69,8 @@ src_configure() {
 		-DPOCL_ICD_ABSOLUTE_PATH=ON
 		-DPOCL_INSTALL_PUBLIC_LIBDIR="${EPREFIX}/usr/$(get_libdir)/OpenCL/vendors/pocl"
 
-		-DENABLE_IPO=$(usex lto)
+		# only appends -flto
+		-DENABLE_IPO=OFF
 
 		-DENABLE_POCL_BUILDING=ON
 		-DKERNELLIB_HOST_CPU_VARIANTS="${host_cpu_variants}"

--- a/eclass/meson.eclass
+++ b/eclass/meson.eclass
@@ -334,6 +334,10 @@ meson_src_configure() {
 		# It's Gentoo policy to not have builds die on blanket -Werror, as it's
 		# an upstream development matter. bug #754279.
 		-Dwerror=false
+
+		# Prevent projects from enabling LTO by default.  In Gentoo, LTO is
+		# enabled via setting *FLAGS appropriately.
+		-Db_lto=false
 	)
 
 	if [[ -n ${EMESON_BUILDTYPE} ]]; then


### PR DESCRIPTION
This is a rolling PR to track removal of `USE=lto`. Basically:

1. If the flag doesn't do anything but appending `-flto`, remove it entirely (please make sure upstream doesn't enable it by default!).
2. If it enables some custom logic, replace it with `tc-is-lto` conditional.
3. Keep it only if it involves extra deps or alike.

CC @gentoo/qa