### PR TITLE
dev-util/itstool: Fix Handling of Untranslated Nodes

### DIFF
--- a/dev-util/itstool/files/itstool-2.0.7-missing-translation-fix.patch
+++ b/dev-util/itstool/files/itstool-2.0.7-missing-translation-fix.patch
@@ -1,0 +1,28 @@
+Bug: https://github.com/mate-desktop/mate-utils/issues/210
+Bug: https://github.com/itstool/itstool/issues/36#
+
+From: https://github.com/itstool/itstool/pull/47/commits/e9b053be5c50c2bd69442a8484a4c9c371bc3a45
+From: Harald van Dijk <harald@gigawatt.nl>
+Date: Thu, 15 Jun 2023 23:18:11 +0100
+Subject: [PATCH] Fix handling of untranslated nodes
+
+If a translation is missing, get_translated returns the node it was
+called with. But ph_node when passed to get_translated is part of
+another document and cannot just be reparented, it needs to be cloned.
+The reparenting leaves things in an inconsistent state where references
+intended to refer to nodes in the original document no longer do so, and
+they may then be accessed from those references after the new document
+has already been freed.
+
+Fixes bug #36.
+--- a/itstool.in
++++ b/itstool.in
+@@ -1096,6 +1096,8 @@ class Document (object):
+                         child.replaceNode(newnode)
+                     else:
+                         repl = self.get_translated(ph_node, translations, strict=strict, lang=lang)
++                        if repl == ph_node:
++                            repl = repl.copyNode(1)
+                         child.replaceNode(repl)
+                 scan_node(child)
+         try:

--- a/dev-util/itstool/itstool-2.0.7-r1.ebuild
+++ b/dev-util/itstool/itstool-2.0.7-r1.ebuild
@@ -1,0 +1,37 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+PYTHON_COMPAT=( python3_{10..11} )
+PYTHON_REQ_USE="xml(+)"
+
+inherit python-single-r1
+
+DESCRIPTION="Translation tool for XML documents that uses gettext files and ITS rules"
+HOMEPAGE="http://itstool.org/"
+SRC_URI="http://files.itstool.org/itstool/${P}.tar.bz2"
+
+# files in /usr/share/itstool/its are under a special exception || GPL-3+
+LICENSE="GPL-3+"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x64-solaris"
+
+REQUIRED_USE="${PYTHON_REQUIRED_USE}"
+
+RDEPEND="${PYTHON_DEPS}
+	$(python_gen_cond_dep '
+		dev-libs/libxml2[python,${PYTHON_USEDEP}]
+	')"
+DEPEND="${RDEPEND}"
+BDEPEND=""
+
+DOCS=(ChangeLog NEWS) # AUTHORS, README are empty
+
+PATCHES="
+	"${FILESDIR}"/${PN}-2.0.7-missing-translation-fix.patch"
+
+src_test() {
+	:
+	#"${PYTHON}" tests/run_tests.py || die "test suite failed" # Test suite not shipped in tarball
+}


### PR DESCRIPTION
Cherry picked patch from upstream that stops compile errors when a translation is missing.

This should be included in the next version but until then is needed to solve at least one outstanding bug in Gentoo.

Closes: https://bugs.gentoo.org/920530