### PR TITLE
sys-apps/hwinfo: Fix existing preserved libs for dev-libs/libx86emu

### DIFF
--- a/sys-apps/hwinfo/hwinfo-23.2-r1.ebuild
+++ b/sys-apps/hwinfo/hwinfo-23.2-r1.ebuild
@@ -13,8 +13,8 @@ LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="amd64 ~arm ~arm64 ppc ~riscv x86 ~amd64-linux ~x86-linux"
 
-RDEPEND="amd64? ( dev-libs/libx86emu )
-	x86? ( dev-libs/libx86emu )"
+RDEPEND="amd64? ( dev-libs/libx86emu:= )
+	x86? ( dev-libs/libx86emu:= )"
 DEPEND="${RDEPEND}
 	>=sys-kernel/linux-headers-2.6.17"
 BDEPEND="sys-devel/flex"


### PR DESCRIPTION
For solve this problem:

<pre>
!!! existing preserved libs:
>>> package: dev-libs/libx86emu-3.5-r1
 *  - /usr/lib64/libx86emu.so.1
 *  - /usr/lib64/libx86emu.so.1.1
 *      used by /usr/lib64/libhd.so.23.2 (sys-apps/hwinfo-23.2)
 </pre>