### PR TITLE
Global IUSE=modules-compress support

### DIFF
--- a/eclass/kernel-build.eclass
+++ b/eclass/kernel-build.eclass
@@ -284,7 +284,7 @@ kernel-build_src_install() {
 	dostrip -x /lib/modules
 
 	local compress=()
-	if [[ ${KERNEL_IUSE_GENERIC_UKI} ]] && ! use module-compress; then
+	if [[ ${KERNEL_IUSE_GENERIC_UKI} ]] && ! use modules-compress; then
 		compress+=(
 			# force installing uncompressed modules even if compression
 			# is enabled via config
@@ -560,7 +560,7 @@ kernel-build_merge_configs() {
 
 	# Only semi-related but let's use that to avoid changing stable ebuilds.
 	if [[ ${KERNEL_IUSE_GENERIC_UKI} ]]; then
-		# NB: we enable this even with USE=-module-compress, in order
+		# NB: we enable this even with USE=-modules-compress, in order
 		# to support both uncompressed and compressed modules in prebuilt
 		# kernels
 		cat <<-EOF > "${WORKDIR}/module-compress.config" || die

--- a/eclass/kernel-install.eclass
+++ b/eclass/kernel-install.eclass
@@ -79,7 +79,7 @@ _IDEPEND_BASE="
 
 LICENSE="GPL-2"
 if [[ ${KERNEL_IUSE_GENERIC_UKI} ]]; then
-	IUSE+=" generic-uki module-compress"
+	IUSE+=" generic-uki modules-compress"
 	# https://github.com/AndrewAmmerlaan/dist-kernel-log-to-licenses
 	# This script can help with generating the array below, keep in mind
 	# that it is not a fully automatic solution, i.e. use flags will
@@ -762,11 +762,11 @@ kernel-install_pkg_config() {
 
 # @FUNCTION: kernel-install_compress_modules
 # @DESCRIPTION:
-# Compress modules installed in ED, if USE=module-compress is enabled.
+# Compress modules installed in ED, if USE=modules-compress is enabled.
 kernel-install_compress_modules() {
 	debug-print-function ${FUNCNAME} "${@}"
 
-	if use module-compress; then
+	if use modules-compress; then
 		einfo "Compressing kernel modules ..."
 		# taken from scripts/Makefile.modinst
 		find "${ED}/lib" -name '*.ko' -exec \

--- a/eclass/kernel-install.eclass
+++ b/eclass/kernel-install.eclass
@@ -592,6 +592,7 @@ kernel-install_pkg_preinst() {
 		die "Release file ${relfile} not installed!"
 	local release
 	release="$(<"${relfile}")" || die
+	DIST_KERNEL_RELEASE="${release}"
 
 	# perform the version check for release ebuilds only
 	if [[ ${PV} != *9999 ]]; then
@@ -706,6 +707,8 @@ kernel-install_pkg_postinst() {
 
 	local dir_ver=${PV}${KV_LOCALVERSION}
 	kernel-install_update_symlink "${EROOT}/usr/src/linux" "${dir_ver}"
+	dist-kernel_compressed_module_cleanup \
+		"${EROOT}/lib/modules/${DIST_KERNEL_RELEASE}"
 
 	if [[ -z ${ROOT} ]]; then
 		kernel-install_install_all "${dir_ver}"

--- a/eclass/linux-mod-r1.eclass
+++ b/eclass/linux-mod-r1.eclass
@@ -109,7 +109,7 @@ esac
 if [[ ! ${_LINUX_MOD_R1_ECLASS} ]]; then
 _LINUX_MOD_R1_ECLASS=1
 
-inherit edo linux-info multiprocessing toolchain-funcs
+inherit dist-kernel-utils edo linux-info multiprocessing toolchain-funcs
 
 IUSE="dist-kernel modules-compress modules-sign +strip ${MODULES_OPTIONAL_IUSE}"
 
@@ -468,6 +468,7 @@ linux-mod-r1_pkg_postinst() {
 	debug-print-function ${FUNCNAME[0]} "${@}"
 	_modules_check_function ${#} 0 0 || return 0
 
+	dist-kernel_compressed_module_cleanup "${EROOT}/lib/modules/${KV_FULL}"
 	_modules_update_depmod
 
 	# post_process ensures modules were installed and that the eclass' USE

--- a/eclass/linux-mod-r1.eclass
+++ b/eclass/linux-mod-r1.eclass
@@ -855,6 +855,9 @@ _modules_process_compress() {
 			compress=(gzip)
 		fi
 	elif linux_chkconfig_present MODULE_COMPRESS_ZSTD; then
+		if ! type -P zstd &>/dev/null; then
+			die "zstd not found, please install app-arch/zstd or disable USE=modules-compress"
+		fi
 		compress=(zstd -qT"$(makeopts_jobs)" --rm)
 	else
 		die "USE=modules-compress enabled but no MODULE_COMPRESS* configured"

--- a/eclass/linux-mod-r1.eclass
+++ b/eclass/linux-mod-r1.eclass
@@ -111,7 +111,7 @@ _LINUX_MOD_R1_ECLASS=1
 
 inherit edo linux-info multiprocessing toolchain-funcs
 
-IUSE="dist-kernel modules-sign +strip ${MODULES_OPTIONAL_IUSE}"
+IUSE="dist-kernel modules-compress modules-sign +strip ${MODULES_OPTIONAL_IUSE}"
 
 RDEPEND="
 	sys-apps/kmod[tools]
@@ -835,6 +835,8 @@ _modules_prepare_toolchain() {
 # If enabled in the kernel configuration, this compresses the given
 # modules using the same format.
 _modules_process_compress() {
+	use modules-compress || return
+
 	local -a compress
 	if linux_chkconfig_present MODULE_COMPRESS_XZ; then
 		compress=(
@@ -853,13 +855,13 @@ _modules_process_compress() {
 		fi
 	elif linux_chkconfig_present MODULE_COMPRESS_ZSTD; then
 		compress=(zstd -qT"$(makeopts_jobs)" --rm)
+	else
+		die "USE=modules-compress enabled but no MODULE_COMPRESS* configured"
 	fi
 
-	if [[ -v compress ]]; then
-		# could fail, assumes have commands that were needed for the kernel
-		einfo "Compressing modules (matching the kernel configuration) ..."
-		edob "${compress[@]}" -- "${@}"
-	fi
+	# could fail, assumes have commands that were needed for the kernel
+	einfo "Compressing modules (matching the kernel configuration) ..."
+	edob "${compress[@]}" -- "${@}"
 }
 
 # @FUNCTION: _modules_process_depmod.d

--- a/eclass/linux-mod.eclass
+++ b/eclass/linux-mod.eclass
@@ -689,7 +689,9 @@ linux-mod_src_install() {
 		# and similarly compress the module being built if != NONE.
 
 		if linux_chkconfig_present MODULE_COMPRESS_XZ; then
-			xz -T$(makeopts_jobs) --memlimit-compress=50% -q ${modulename}.${KV_OBJ} || die "Compressing ${modulename}.${KV_OBJ} with xz failed"
+			# match kernel compression options for compatibility
+			# https://bugs.gentoo.org/920837
+			xz -T$(makeopts_jobs) --memlimit-compress=50% -q --check=crc32 --lzma2=dict=1MiB ${modulename}.${KV_OBJ} || die "Compressing ${modulename}.${KV_OBJ} with xz failed"
 			doins ${modulename}.${KV_OBJ}.xz
 			KV_OBJ_COMPRESS_EXT=".xz"
 		elif linux_chkconfig_present MODULE_COMPRESS_GZIP; then

--- a/profiles/use.desc
+++ b/profiles/use.desc
@@ -201,6 +201,7 @@ mms - Support for Microsoft Media Server (MMS) streams
 mng - Add support for libmng (MNG images)
 modplug - Add libmodplug support for playing SoundTracker-style music files
 modules - Build the kernel modules
+modules-compress - Install compressed kernel modules (if kernel config enables module compression)
 modules-sign - Cryptographically sign installed kernel modules (requires CONFIG_MODULE_SIG=y in the kernel)
 mono - Build Mono bindings to support dotnet type stuff
 motif - Add support for the Motif toolkit


### PR DESCRIPTION
Add a global `modules-compress` flag to control kernel module compression, update the kernel eclasses to use it and make `linux-mod-r1` use it. While at it, fix XZ compression in the legacy eclass.

The rough idea is that `sys-kernel/gentoo-kernel` (and therefore `sys-kernel/gentoo-kernel-bin`) are going to support XZ compression of modules starting with the next release but we don't want to force compressed modules on everyone.