### PR TITLE
net-wireless/mfoc: EAPI8 bump

### DIFF
--- a/net-wireless/mfoc/mfoc-0.10.7-r1.ebuild
+++ b/net-wireless/mfoc/mfoc-0.10.7-r1.ebuild
@@ -1,13 +1,14 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
 
 inherit autotools
 
 DESCRIPTION="Mifare Classic Offline Cracker"
 HOMEPAGE="https://github.com/nfc-tools/mfoc"
 SRC_URI="https://github.com/nfc-tools/${PN}/archive/${P}.tar.gz"
+S="${WORKDIR}/${PN}-${P}"
 
 LICENSE="GPL-2 GPL-2+ BSD-2"
 SLOT="0"
@@ -15,8 +16,6 @@ KEYWORDS="~amd64"
 
 DEPEND=">=dev-libs/libnfc-1.7.0:="
 RDEPEND="${DEPEND}"
-
-S="${WORKDIR}/${PN}-${P}"
 
 src_prepare() {
 	default


### PR DESCRIPTION
Another very simple `EAPI8` bump.