### PR TITLE
net-wireless/portapack-{firmware,havoc}: EAPI8 bump, fix LICENSE

### DIFF
--- a/net-wireless/portapack-firmware/portapack-firmware-20190405.ebuild
+++ b/net-wireless/portapack-firmware/portapack-firmware-20190405.ebuild
@@ -1,24 +1,22 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
 
 DESCRIPTION="Firmware and scripts for controlling the Portapack from Sharebrained"
 HOMEPAGE="https://github.com/sharebrained/portapack-hackrf/releases"
 SRC_URI="https://github.com/sharebrained/portapack-hackrf/releases/download/${PV}/portapack-h1-firmware-${PV}.tar.bz2"
+S="${WORKDIR}/portapack-h1-firmware-${PV}"
 
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE=""
 
 PDEPEND=">=net-wireless/hackrf-tools-2015.07.2-r1
 	>=app-mobilephone/dfu-util-0.7"
 
-S="${WORKDIR}/portapack-h1-firmware-${PV}"
-
 src_install() {
 	insinto /usr/share/hackrf
 	newins portapack-h1-firmware.bin portapack-h1-firmware-${PV}.bin
-	ln -s portapack-h1-firmware-${PV}.bin "${ED}/usr/share/hackrf/portapack-h1-firmware.bin"
+	ln -s portapack-h1-firmware-${PV}.bin "${ED}/usr/share/hackrf/portapack-h1-firmware.bin" || die
 }

--- a/net-wireless/portapack-havoc/portapack-havoc-0.0_p20180612.ebuild
+++ b/net-wireless/portapack-havoc/portapack-havoc-0.0_p20180612.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
 
 DESCRIPTION="Custom firmware for the HackRF SDR + PortaPack H1 addon"
 HOMEPAGE="https://github.com/furrtek/portapack-havoc/wiki"
@@ -9,9 +9,8 @@ COMMIT="609235b19f55d0bf278c0e7c4b9f9b6b15136247"
 SRC_URI="https://github.com/furrtek/portapack-havoc/archive/${COMMIT}.tar.gz -> ${P}.tar.gz"
 S="${WORKDIR}/${PN}-${COMMIT}"
 
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="0"
-IUSE=""
 
 KEYWORDS="~amd64 ~x86"
 
@@ -29,7 +28,7 @@ src_compile() {
 src_install() {
 	insinto /usr/share/hackrf
 	newins firmware/portapack-h1-havoc.bin portapack-h1-havoc-${PV}.bin
-	ln -s portapack-h1-havoc-${PV}.bin "${ED}/usr/share/hackrf/portapack-h1-havoc.bin"
+	ln -s portapack-h1-havoc-${PV}.bin "${ED}/usr/share/hackrf/portapack-h1-havoc.bin" || die
 
 	cat << EOF > switch_to_havoc
 #!/bin/sh


### PR DESCRIPTION
Hi,

This updates both `net-wireless/portapack-firmware` and `net-wireless/portapack-havoc` for `EAPI8`. Afaics these packages are also `GPL-2+`. Adds also a missing `|| die` for `ln`.