### PR TITLE
games-action/wordwarvi: EAPI8 bump, fix bug #910281

### DIFF
--- a/games-action/wordwarvi/wordwarvi-1.00-r1.ebuild
+++ b/games-action/wordwarvi/wordwarvi-1.00-r1.ebuild
@@ -1,11 +1,11 @@
 # Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 inherit desktop toolchain-funcs
 
-DESCRIPTION="retro side-scrolling shoot'em up based on the editor war story"
+DESCRIPTION="Retro side-scrolling shoot'em up based on the editor war story"
 HOMEPAGE="https://wordwarvi.sourceforge.net"
 SRC_URI="mirror://sourceforge/wordwarvi/${P}.tar.gz"
 
@@ -40,7 +40,7 @@ src_prepare() {
 }
 
 src_compile() {
-	tc-export CC PKG_CONFIG
+	tc-export BUILD_CC CC PKG_CONFIG
 
 	emake \
 		PREFIX="/usr" \


### PR DESCRIPTION
Signed-off-by: Michael Mair-Keimberger <mmk@levelnine.at>

Closes: https://bugs.gentoo.org/910281