### PR TITLE
sys-fs/mp3fs: fix LICENSE, fix bug #869656

### DIFF
--- a/sys-fs/mp3fs/mp3fs-1.1.1-r5.ebuild
+++ b/sys-fs/mp3fs/mp3fs-1.1.1-r5.ebuild
@@ -1,0 +1,37 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs
+
+DESCRIPTION="Read-only FUSE filesystem which transcodes FLAC audio files to MP3 when read"
+HOMEPAGE="https://khenriks.github.io/mp3fs/"
+SRC_URI="https://github.com/khenriks/mp3fs/releases/download/v${PV}/${P}.tar.gz"
+
+LICENSE="GPL-3+"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="+flac vorbis"
+
+REQUIRED_USE="|| ( flac vorbis )"
+RESTRICT="test"
+
+DEPEND="
+	media-libs/libid3tag:=
+	media-sound/lame
+	sys-fs/fuse:0=
+	flac? ( >=media-libs/flac-1.1.4:=[cxx] )
+	vorbis? ( >=media-libs/libvorbis-1.3.0 )
+"
+RDEPEND="${DEPEND}"
+
+src_configure() {
+	econf \
+		$(use_with flac) \
+		$(use_with vorbis)
+}
+
+src_compile() {
+	emake AR="$(tc-getAR)"
+}


### PR DESCRIPTION
```diff
--- mp3fs-1.1.1-r4.ebuild	2023-11-15 17:01:28.942046830 +0100
+++ mp3fs-1.1.1-r5.ebuild	2023-12-29 23:00:01.456043315 +0100
@@ -3,13 +3,15 @@
 
 EAPI=8
 
+inherit toolchain-funcs
+
 DESCRIPTION="Read-only FUSE filesystem which transcodes FLAC audio files to MP3 when read"
 HOMEPAGE="https://khenriks.github.io/mp3fs/"
 SRC_URI="https://github.com/khenriks/mp3fs/releases/download/v${PV}/${P}.tar.gz"
 
-LICENSE="GPL-3"
+LICENSE="GPL-3+"
 SLOT="0"
-KEYWORDS="amd64 x86"
+KEYWORDS="~amd64 ~x86"
 IUSE="+flac vorbis"
 
 REQUIRED_USE="|| ( flac vorbis )"
@@ -29,3 +31,7 @@
 		$(use_with flac) \
 		$(use_with vorbis)
 }
+
+src_compile() {
+	emake AR="$(tc-getAR)"
+}
```

Signed-off-by: Michael Mair-Keimberger <mmk@levelnine.at>

Closes: https://bugs.gentoo.org/869656