### PR TITLE
app-benchmarks/ioping: fix LICENSE, fix bug #866722

### DIFF
--- a/app-benchmarks/ioping/ioping-1.3.ebuild
+++ b/app-benchmarks/ioping/ioping-1.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -9,12 +9,12 @@ DESCRIPTION="Simple disk I/0 latency measuring tool"
 HOMEPAGE="https://github.com/koct9i/ioping"
 SRC_URI="https://github.com/koct9i/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
-LICENSE="GPL-3"
+LICENSE="GPL-3+"
 SLOT="0"
 KEYWORDS="~amd64 ~x86 ~amd64-linux ~x86-linux"
 
-src_configure() {
-	tc-export CC
+src_compile() {
+	emake CC="$(tc-getCC)"
 }
 
 src_install() {


### PR DESCRIPTION
Signed-off-by: Michael Mair-Keimberger <mmk@levelnine.at>

Closes: https://bugs.gentoo.org/866722