### PR TITLE
app-misc/cfiles: EAPI8 bump, fix bug #722342, #726636, add remote id

### DIFF
--- a/app-misc/cfiles/cfiles-1.8-r1.ebuild
+++ b/app-misc/cfiles/cfiles-1.8-r1.ebuild
@@ -1,0 +1,37 @@
+# Copyright 2019-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs
+
+DESCRIPTION="Ncurses file manager written in C with vim like keybindings"
+HOMEPAGE="https://github.com/mananapr/cfiles"
+SRC_URI="https://github.com/mananapr/cfiles/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+DEPEND="
+	sys-libs/ncurses:=
+	app-text/poppler[utils]
+"
+RDEPEND="${DEPEND}"
+
+src_prepare() {
+	sed -i -e 's/$(CC) $(CFLAGS)/& $(LDFLAGS)/g' Makefile || die
+	default
+}
+
+src_compile() {
+	emake CC="$(tc-getCC)"
+}
+
+src_install() {
+	dobin cfiles
+	dobin scripts/displayimg_uberzug
+	dobin scripts/clearimg_uberzug
+	dobin scripts/displayimg
+	doman cfiles.1
+}

--- a/app-misc/cfiles/metadata.xml
+++ b/app-misc/cfiles/metadata.xml
@@ -9,6 +9,9 @@
 	<email>alicef@gentoo.org</email>
 	<name>Alice Ferrazzi</name>
 </maintainer>
+<upstream>
+	<remote-id type="github">mananapr/cfiles</remote-id>
+</upstream>
 <longdescription lang="en">
 cfiles is a terminal file manager with vim like keybindings, written in C using the ncurses library. It aims to provide an interface like ranger while being lightweight, fast and minimal.
 </longdescription>


### PR DESCRIPTION
`EAPI8` bump with some minor fixes.

```diff
--- cfiles-1.8.ebuild	2023-12-29 23:43:30.765490304 +0100
+++ cfiles-1.8-r1.ebuild	2023-12-29 23:45:16.414281048 +0100
@@ -1,16 +1,17 @@
-# Copyright 2019-2020 Gentoo Authors
+# Copyright 2019-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
-DESCRIPTION="A ncurses file manager written in C with vim like keybindings"
+inherit toolchain-funcs
+
+DESCRIPTION="Ncurses file manager written in C with vim like keybindings"
 HOMEPAGE="https://github.com/mananapr/cfiles"
 SRC_URI="https://github.com/mananapr/cfiles/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE=""
 
 DEPEND="
 	sys-libs/ncurses:=
@@ -18,6 +19,15 @@
 "
 RDEPEND="${DEPEND}"
 
+src_prepare() {
+	sed -i -e 's/$(CC) $(CFLAGS)/& $(LDFLAGS)/g' Makefile || die
+	default
+}
+
+src_compile() {
+	emake CC="$(tc-getCC)"
+}
+
 src_install() {
 	dobin cfiles
 	dobin scripts/displayimg_uberzug
```