### PR TITLE
net-misc/ndppd: EAPI8 bump, minor improvements

### DIFF
--- a/net-misc/ndppd/ndppd-0.2.5-r1.ebuild
+++ b/net-misc/ndppd/ndppd-0.2.5-r1.ebuild
@@ -1,19 +1,19 @@
 # Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
 
 DESCRIPTION="Proxies NDP messages between interfaces"
 HOMEPAGE="https://github.com/DanielAdolfsson/ndppd"
 SRC_URI="https://github.com/DanielAdolfsson/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
 
-LICENSE="GPL-3"
+LICENSE="GPL-3+"
 SLOT="0"
 KEYWORDS="~amd64 ~arm ~x86"
-IUSE=""
 
 src_install() {
-	emake PREFIX=/usr DESTDIR="${D}" install
+	dosbin ${PN}
+	doman ${PN}.{1,conf.5}
 	insinto /etc
 	newins ndppd.conf-dist ndppd.conf
 	newinitd "${FILESDIR}"/ndppd.initd ndppd


### PR DESCRIPTION
Bug #466802 seems to be fixed already, at least for me it did not call g++ directly anymore (even with the `EAPI6` ebuild).
I've also fixed #731682 by directly installing the files without the Makefile.

Signed-off-by: Michael Mair-Keimberger <mmk@levelnine.at>

Closes: https://bugs.gentoo.org/466802
Closes: https://bugs.gentoo.org/731682