### PR TITLE
app-crypt/libscrypt: don't call ar directly, fix #718126

### DIFF
--- a/app-crypt/libscrypt/libscrypt-1.22-r2.ebuild
+++ b/app-crypt/libscrypt/libscrypt-1.22-r2.ebuild
@@ -1,0 +1,36 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs
+
+DESCRIPTION="Shared library to implement the scrypt algorithm"
+HOMEPAGE="https://github.com/technion/libscrypt"
+SRC_URI="https://github.com/technion/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="BSD-2"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~mips ~ppc ~ppc64 ~riscv ~sparc ~x86"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-1.22-no-clobber-fortify-source.patch
+)
+
+src_prepare() {
+	sed -i -e "s|ar rcs|$(tc-getAR) rcs|g" Makefile || die
+	default
+}
+
+src_configure() {
+	export LIBDIR=${PREFIX}/$(get_libdir)
+	export CFLAGS_EXTRA="${CFLAGS}"
+	export LDFLAGS_EXTRA="${LDFLAGS}"
+	export PREFIX=/usr
+	unset CFLAGS
+	unset LDFLAGS
+}
+
+src_compile() {
+	emake CC="$(tc-getCC)"
+}


### PR DESCRIPTION
```diff
--- libscrypt-1.22-r1.ebuild	2023-12-30 17:42:13.959655129 +0100
+++ libscrypt-1.22-r2.ebuild	2023-12-30 17:47:40.932146022 +0100
@@ -11,12 +11,17 @@
 
 LICENSE="BSD-2"
 SLOT="0"
-KEYWORDS="amd64 arm arm64 ~hppa ~mips ppc ppc64 ~riscv sparc x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~mips ~ppc ~ppc64 ~riscv ~sparc ~x86"
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-1.22-no-clobber-fortify-source.patch
 )
 
+src_prepare() {
+	sed -i -e "s|ar rcs|$(tc-getAR) rcs|g" Makefile || die
+	default
+}
+
 src_configure() {
 	export LIBDIR=${PREFIX}/$(get_libdir)
 	export CFLAGS_EXTRA="${CFLAGS}"
```

Signed-off-by: Michael Mair-Keimberger <mmk@levelnine.at>

Closes: https://bugs.gentoo.org/718126