### PR TITLE
sys-firmware/vgabios: EAPI8, fix LICENSE, fix calling gcc directly

### DIFF
--- a/sys-firmware/vgabios/vgabios-0.8a-r1.ebuild
+++ b/sys-firmware/vgabios/vgabios-0.8a-r1.ebuild
@@ -1,0 +1,41 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs
+
+DESCRIPTION="VGA BIOS implementation"
+HOMEPAGE="https://www.nongnu.org/vgabios/"
+SRC_URI="https://savannah.gnu.org/download/${PN}/${P}.tgz"
+
+LICENSE="LGPL-2.1+"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~x86"
+IUSE="binary debug"
+BDEPEND="!binary? ( sys-devel/dev86 )"
+
+src_compile() {
+	if ! use binary ; then
+		emake clean # Necessary to clean up the pre-built pieces
+		emake biossums CC="$(tc-getCC)"
+		emake GCC="$(tc-getCC)" CC="$(tc-getCC)"
+	fi
+}
+
+src_install() {
+	insinto /usr/share/vgabios
+
+	# Stock VGABIOS
+	newins VGABIOS-lgpl-latest.bin vgabios.bin
+	use debug && newins VGABIOS-lgpl-latest.debug.bin vgabios.debug.bin
+
+	# Cirrus
+	newins VGABIOS-lgpl-latest.cirrus.bin vgabios-cirrus.bin
+	use debug && newins VGABIOS-lgpl-latest.cirrus.debug.bin \
+		vgabios-cirrus.debug.bin
+
+	# Banshee
+	newins VGABIOS-lgpl-latest.banshee.bin vgabios-banshee.bin
+
+}


### PR DESCRIPTION
`EAPI8` bump, `LICENSE` fix and also fixing calling `gcc` directly

```diff
--- vgabios-0.8a.ebuild	2023-11-15 17:01:28.937046876 +0100
+++ vgabios-0.8a-r1.ebuild	2023-12-31 11:46:20.781549645 +0100
@@ -1,23 +1,25 @@
 # Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
+
+inherit toolchain-funcs
 
 DESCRIPTION="VGA BIOS implementation"
-HOMEPAGE="http://www.nongnu.org/vgabios/"
+HOMEPAGE="https://www.nongnu.org/vgabios/"
 SRC_URI="https://savannah.gnu.org/download/${PN}/${P}.tgz"
 
-LICENSE="LGPL-2.1"
+LICENSE="LGPL-2.1+"
 SLOT="0"
-KEYWORDS="amd64 ~arm ~arm64 ~ppc ~ppc64 x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~x86"
 IUSE="binary debug"
 BDEPEND="!binary? ( sys-devel/dev86 )"
 
 src_compile() {
 	if ! use binary ; then
 		emake clean # Necessary to clean up the pre-built pieces
-		emake biossums
-		emake
+		emake biossums CC="$(tc-getCC)"
+		emake GCC="$(tc-getCC)" CC="$(tc-getCC)"
 	fi
 }
```

Signed-off-by: Michael Mair-Keimberger <mmk@levelnine.at>

Closes: https://bugs.gentoo.org/721592