### PR TITLE
app-admin/cronolog: fix calling ar directly, bug #721908

### DIFF
--- a/app-admin/cronolog/cronolog-1.6.2-r7.ebuild
+++ b/app-admin/cronolog/cronolog-1.6.2-r7.ebuild
@@ -1,0 +1,30 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools toolchain-funcs
+
+DESCRIPTION="Log rotation software"
+HOMEPAGE="https://github.com/fordmason/cronolog"
+SRC_URI="http://cronolog.org/download/${P}.tar.gz"
+
+LICENSE="GPL-2+ Apache-1.0"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~ppc ~x86"
+
+PATCHES=(
+	"${FILESDIR}"/${PV}-patches
+	# rename and move into ${PV}-patches after -r3 removal
+	"${FILESDIR}"/${P}-umask.patch
+)
+
+src_prepare() {
+	default
+	mv configure.{in,ac} || die
+	eautoreconf
+}
+
+src_compile() {
+	emake AR="$(tc-getAR)"
+}


### PR DESCRIPTION
A simple fix for calling `ar` directly.

```diff
--- cronolog-1.6.2-r6.ebuild	2023-12-31 11:53:29.682740446 +0100
+++ cronolog-1.6.2-r7.ebuild	2023-12-31 11:54:04.420879642 +0100
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit autotools
+inherit autotools toolchain-funcs
 
 DESCRIPTION="Log rotation software"
 HOMEPAGE="https://github.com/fordmason/cronolog"
@@ -11,7 +11,7 @@
 
 LICENSE="GPL-2+ Apache-1.0"
 SLOT="0"
-KEYWORDS="amd64 ~arm ppc x86"
+KEYWORDS="~amd64 ~arm ~ppc ~x86"
 
 PATCHES=(
 	"${FILESDIR}"/${PV}-patches
@@ -24,3 +24,7 @@
 	mv configure.{in,ac} || die
 	eautoreconf
 }
+
+src_compile() {
+	emake AR="$(tc-getAR)"
+}
```

Signed-off-by: Michael Mair-Keimberger <mmk@levelnine.at>

Closes: https://bugs.gentoo.org/721908