### PR TITLE
dev-java/jdepend: switch to java-pkg-simple

### DIFF
--- a/dev-java/jdepend/jdepend-2.10-r1.ebuild
+++ b/dev-java/jdepend/jdepend-2.10-r1.ebuild
@@ -1,0 +1,25 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+JAVA_PKG_IUSE="doc source test"
+JAVA_TESTING_FRAMEWORKS="junit-4"
+
+inherit java-pkg-2 java-pkg-simple
+
+DESCRIPTION="Traverses Java class file directories and generates design quality metrics"
+HOMEPAGE="https://github.com/clarkware/jdepend"
+SRC_URI="https://github.com/clarkware/jdepend/archive/${PV}.tar.gz -> ${P}.tar.gz"
+S="${WORKDIR}/${P}"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x64-solaris"
+RESTRICT="test" # TODO: solve test failures.
+
+DEPEND=">=virtual/jdk-1.8:*"
+RDEPEND=">=virtual/jre-1.8:*"
+JAVA_SRC_DIR="src"
+JAVA_TEST_GENTOO_CLASSPATH="junit-4"
+JAVA_TEST_SRC_DIR="test"


### PR DESCRIPTION
Needed to avoid a cyclic dependency with upcoming >=dev-java/ant-1.10.14