### PR TITLE
sci-libs/caffe2: add support of blas/lapack providers, including mkl

### DIFF
--- a/profiles/features/musl/package.use.mask
+++ b/profiles/features/musl/package.use.mask
@@ -138,3 +138,6 @@ app-shells/bash mem-scramble
 
 # static linking works with musl
 app-shells/mksh -static
+
+# linked against glibc
+sci-libs/caffe2 mkl

--- a/sci-libs/caffe2/caffe2-2.1.2-r2.ebuild
+++ b/sci-libs/caffe2/caffe2-2.1.2-r2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..12} )
 inherit python-single-r1 cmake cuda flag-o-matic prefix
 
 MYPN=pytorch
@@ -17,7 +17,7 @@ SRC_URI="https://github.com/pytorch/${MYPN}/archive/refs/tags/v${PV}.tar.gz
 LICENSE="BSD"
 SLOT="0"
 KEYWORDS="~amd64"
-IUSE="cuda distributed fbgemm ffmpeg gloo mpi nnpack +numpy opencl opencv openmp qnnpack tensorpipe xnnpack"
+IUSE="cuda distributed fbgemm ffmpeg gloo mpi nnpack +numpy opencl opencv openmp qnnpack tensorpipe xnnpack mkl"
 RESTRICT="test"
 REQUIRED_USE="
 	${PYTHON_REQUIRED_USE}
@@ -38,7 +38,7 @@ RDEPEND="
 	dev-libs/protobuf:=
 	dev-libs/pthreadpool
 	dev-libs/sleef
-	sci-libs/lapack
+	virtual/lapack
 	>=sci-libs/onnx-1.12.0
 	<sci-libs/onnx-1.15.0
 	sci-libs/foxi
@@ -60,10 +60,10 @@ RDEPEND="
 	qnnpack? ( sci-libs/QNNPACK )
 	tensorpipe? ( sci-libs/tensorpipe[cuda?] )
 	xnnpack? ( >=sci-libs/XNNPACK-2022.12.22 )
+	mkl? ( sci-libs/mkl )
 "
 DEPEND="
 	${RDEPEND}
-	dev-cpp/eigen
 	cuda? ( >=dev-libs/cutlass-3.1.0 )
 	dev-libs/psimd
 	dev-libs/FP16
@@ -87,6 +87,8 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-2.0.0-gcc13.patch
 	"${FILESDIR}"/${PN}-2.0.0-cudnn_include_fix.patch
 	"${FILESDIR}"/${PN}-2.1.1-cudaExtra.patch
+	"${FILESDIR}"/${PN}-2.1.2-fix-rpath.patch
+	"${FILESDIR}"/${PN}-2.1.2-fix-openmp-link.patch
 )
 
 src_prepare() {
@@ -169,19 +171,24 @@ src_configure() {
 		-DPYBIND11_PYTHON_VERSION="${EPYTHON#python}"
 		-DPYTHON_EXECUTABLE="${PYTHON}"
 		-DUSE_ITT=OFF
-		-DBLAS=Eigen # avoid the use of MKL, if found on the system
-		-DUSE_SYSTEM_EIGEN_INSTALL=ON
 		-DUSE_SYSTEM_PTHREADPOOL=ON
 		-DUSE_SYSTEM_FXDIV=ON
 		-DUSE_SYSTEM_FP16=ON
 		-DUSE_SYSTEM_GLOO=ON
 		-DUSE_SYSTEM_ONNX=ON
 		-DUSE_SYSTEM_SLEEF=ON
+		-DUSE_METAL=OFF
 
 		-Wno-dev
 		-DTORCH_INSTALL_LIB_DIR="${EPREFIX}"/usr/$(get_libdir)
 		-DLIBSHM_INSTALL_LIB_SUBDIR="${EPREFIX}"/usr/$(get_libdir)
 	)
+
+	if use mkl; then
+		mycmakeargs+=(-DBLAS=MKL)
+	else
+		mycmakeargs+=(-DBLAS=Generic -DBLAS_LIBRARIES=)
+	fi
 
 	if use cuda; then
 		addpredict "/dev/nvidiactl" # bug 867706

--- a/sci-libs/caffe2/files/caffe2-2.1.2-fix-openmp-link.patch
+++ b/sci-libs/caffe2/files/caffe2-2.1.2-fix-openmp-link.patch
@@ -1,0 +1,15 @@
+Fix "undefined symbol: omp_get_max_active_levels" in mkl + <nothing else> builds
+https://github.com/pytorch/pytorch/issues/116576
+--- a/caffe2/CMakeLists.txt
++++ b/caffe2/CMakeLists.txt
+@@ -1575,6 +1575,10 @@ if(BUILD_SHARED_LIBS)
+     target_link_libraries(torch_global_deps TBB::tbb)
+   endif()
+ 
++  if(USE_OPENMP)
++    target_link_libraries(torch_global_deps OpenMP::OpenMP_CXX)
++  endif()
++
+   install(TARGETS torch_global_deps DESTINATION "${TORCH_INSTALL_LIB_DIR}")
+ endif()
+ 

--- a/sci-libs/caffe2/files/caffe2-2.1.2-fix-rpath.patch
+++ b/sci-libs/caffe2/files/caffe2-2.1.2-fix-rpath.patch
@@ -1,0 +1,12 @@
+Unset rpath to support blas-lapack-switch
+Bug: https://bugs.gentoo.org/921129
+--- a/cmake/Dependencies.cmake
++++ b/cmake/Dependencies.cmake
+@@ -10,7 +10,6 @@ endif(APPLE)
+ set(CMAKE_SKIP_BUILD_RPATH  FALSE)
+ # Don't use the install-rpath during the build phase
+ set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
+-set(CMAKE_INSTALL_RPATH "${_rpath_portable_origin}")
+ # Automatically add all linked folders that are NOT in the build directory to
+ # the rpath (per library?)
+ set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)

--- a/sci-libs/caffe2/metadata.xml
+++ b/sci-libs/caffe2/metadata.xml
@@ -21,6 +21,7 @@
 		<flag name="qnnpack">Use QNNPACK</flag>
 		<flag name="tensorpipe">Use tensorpipe</flag>
 		<flag name="xnnpack">Use XNNPACK</flag>
+		<flag name="mkl">Use <pkg>sci-libs/mkl</pkg> for blas, lapack and sparse blas routines</flag>
 	</use>
 	<upstream>
 		<remote-id type="github">pytorch/pytorch</remote-id>


### PR DESCRIPTION
This PR allows to specify custom blas/lapack provider, fixing https://bugs.gentoo.org/921129 and performance issues when comparing against version from pypi (which uses MKL). Before this PR sci-libs/caffe2 used reference blas, which is still possible, but results were unsatisfactory.

Using `prof.py`, I collected some statistics about BLAS performance for pytorch on AMD Ryzen 9 7950X3D 16-Core Processor, in clang-lto environment.

**prof.py:**
```python
import torch
import torch.utils.benchmark as benchmark

def batched_dot_mul_sum(a, b):
    '''Computes batched dot by multiplying and summing'''
    return a.mul(b).sum(-1)

def batched_dot_bmm(a, b):
    '''Computes batched dot by reducing to ``bmm``'''
    a = a.reshape(-1, 1, a.shape[-1])
    b = b.reshape(-1, b.shape[-1], 1)
    return torch.bmm(a, b).flatten(-3)

def matmul(a, b):
    return torch.matmul(a, b)


results = []
for num_threads in [1, torch.get_num_threads()]:
    x = torch.randn(10000, 10000, device='cpu')
    results.append(benchmark.Timer(
        stmt='batched_dot_mul_sum(x, x)',
        setup='from __main__ import batched_dot_mul_sum',
        num_threads=num_threads,
        label='Batched dot',
        sub_label = '[10000, 10000]',
        description='mul/sum',
        globals={'x': x}).blocked_autorange(min_run_time=1)
    )
    results.append(benchmark.Timer(
        stmt='batched_dot_bmm(x, x)',
        setup='from __main__ import batched_dot_bmm',
        num_threads=num_threads,
        label='Batched dot',
        sub_label = '[10000, 10000]',
        description='bmm',
        globals={'x': x}).blocked_autorange(min_run_time=1)
    )

    x = torch.randn(1024, 1024, device='cpu')
    results.append(benchmark.Timer(
        stmt='matmul(x, x)',
        setup='from __main__ import matmul',
        num_threads=num_threads,
        label='Matmul',
        sub_label = '[1024, 1024]',
        description='time',
        globals={'x': x}).blocked_autorange(min_run_time=1)
    )

compare = benchmark.Compare(results)
compare.trim_significant_figures()
compare.print()
```

**Reference** (sci-libs/lapack-3.11) is the slowest one:
```
$ sudo eselect blas set reference && python prof.py
[------------- Batched dot -------------]
                      |  mul/sum  |  bmm 
1 threads: ------------------------------
      [10000, 10000]  |    130    |  86.0
16 threads: -----------------------------
      [10000, 10000]  |     45    |  87.9

Times are in milliseconds (ms).

[--------- Matmul --------]
                    |  time
1 threads: ----------------
      [1024, 1024]  |  249 
16 threads: ---------------
      [1024, 1024]  |  289 

Times are in milliseconds (ms).
```

With 16 threads reference implementation was even slower than with 1 thread, with 289ms for matmul.

**sci-libs/openblas-0.3.23:**
```
$ sudo eselect blas set openblas && python prof.py
[------------ Batched dot -------------]
                      |  mul/sum  |  bmm
1 threads: -----------------------------
      [10000, 10000]  |    128    |  118
16 threads: ----------------------------
      [10000, 10000]  |     50    |  124

Times are in milliseconds (ms).

[--------- Matmul ---------]
                    |   time
1 threads: -----------------
      [1024, 1024]  |  13.90
16 threads: ----------------
      [1024, 1024]  |   1.41
```

OpenBLAS is almost on-par with MKL for matrix multiplication, however it fails to see an opportunity for parallelization for pytorch.bmm.

**sci-libs/blis-0.9.0:**
```
$ sudo eselect blas set blis && python prof.py
[------------- Batched dot -------------]
                      |  mul/sum  |  bmm 
1 threads: ------------------------------
      [10000, 10000]  |    130    |  19.3
16 threads: -----------------------------
      [10000, 10000]  |     46    |  18.9

Times are in milliseconds (ms).

[--------- Matmul --------]
                    |  time
1 threads: ----------------
      [1024, 1024]  |  13.9
16 threads: ---------------
      [1024, 1024]  |  13.8

Times are in milliseconds (ms).
```

BLIS is faster than OpenBLAS. However it completely ignores num-cpu specified in pytorch. I'm not sure if this is a bug; but for BLIS users number of threads can be customized with standard OpenMP environment variables:
```
$ sudo eselect blas set blis && OMP_NUM_THREADS=16 OMP_PLACES=cores python prof.py
...
[--------- Matmul --------]
                    |  time
1 threads: ----------------
      [1024, 1024]  |  1.14
16 threads: ---------------
      [1024, 1024]  |  1.14
```

**amd/blis** (aocl-blas, out of gentoo tree)
```
$ sudo eselect blas set aocl-blas && OMP_NUM_THREADS=16 OMP_PLACES=cores python prof.py
...
[--------- Matmul ---------]
                    |   time
16 threads: ----------------
      [1024, 1024]  |    981

Times are in microseconds (us).
```

aocl-blas has the fastest matmul implementation for zen4, 321 times faster than reference implementation.

**sci-libs/mkl-2023.0.0.25398** (with `USE=mkl emerge -av1 caffe2`)
```
$ python prof.py 
[------------- Batched dot -------------]
                      |  mul/sum  |  bmm 
1 threads: ------------------------------
      [10000, 10000]  |    120    |  80.0
16 threads: -----------------------------
      [10000, 10000]  |     44    |   5.3

Times are in milliseconds (ms).

[--------- Matmul ---------]
                    |   time
1 threads: -----------------
      [1024, 1024]  |  14.40
16 threads: ----------------
      [1024, 1024]  |   1.35

Times are in milliseconds (ms).
```

Build with MKL is the only one that succeds to parallelize pytorch.bmm, but it is still slower than blis/aocl-blas for zen4. 

Closes: https://bugs.gentoo.org/921129