### PR TITLE
app-arch/lzlib: fix calling AR directly, bug #721916

### DIFF
--- a/app-arch/lzlib/lzlib-1.13-r2.ebuild
+++ b/app-arch/lzlib/lzlib-1.13-r2.ebuild
@@ -1,0 +1,41 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/openpgp-keys/antoniodiazdiaz.asc
+inherit toolchain-funcs verify-sig
+
+DESCRIPTION="Library for lzip compression"
+HOMEPAGE="https://www.nongnu.org/lzip/lzlib.html"
+SRC_URI="https://download.savannah.gnu.org/releases/lzip/${PN}/${P}.tar.gz"
+SRC_URI+=" verify-sig? ( https://download.savannah.gnu.org/releases/lzip/${PN}/${P/_/-}.tar.gz.sig )"
+
+LICENSE="libstdc++" # fancy form of GPL-2+ with library exception
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+
+BDEPEND="verify-sig? ( sec-keys/openpgp-keys-antoniodiazdiaz )"
+
+src_configure() {
+	local myconf=(
+		--enable-shared
+		--disable-static
+		--disable-ldconfig
+		--prefix="${EPREFIX}"/usr
+		--libdir='$(prefix)'/$(get_libdir)
+		AR="$(tc-getAR)"
+		CC="$(tc-getCC)"
+		CFLAGS="${CFLAGS}"
+		CPPFLAGS="${CPPFLAGS}"
+		LDFLAGS="${LDFLAGS}"
+	)
+
+	# not autotools-based
+	./configure "${myconf[@]}" || die
+}
+
+src_install() {
+	emake DESTDIR="${D}" install install-man
+	einstalldocs
+}


### PR DESCRIPTION
Simple fix to not call `AR` directly.
The change is really minimal - if it's fine i can do the change without a rev-bump.

```diff 
--- lzlib-1.13-r1.ebuild	2023-12-31 18:04:04.531631275 +0100
+++ lzlib-1.13-r2.ebuild	2023-12-31 18:04:38.845346912 +0100
@@ -13,7 +13,7 @@
 
 LICENSE="libstdc++" # fancy form of GPL-2+ with library exception
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~loong ~mips ppc ppc64 ~riscv ~s390 sparc x86"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
 
 BDEPEND="verify-sig? ( sec-keys/openpgp-keys-antoniodiazdiaz )"
 
@@ -24,6 +24,7 @@
 		--disable-ldconfig
 		--prefix="${EPREFIX}"/usr
 		--libdir='$(prefix)'/$(get_libdir)
+		AR="$(tc-getAR)"
 		CC="$(tc-getCC)"
 		CFLAGS="${CFLAGS}"
 		CPPFLAGS="${CPPFLAGS}"
```

Signed-off-by: Michael Mair-Keimberger <mmk@levelnine.at>

Closes: https://bugs.gentoo.org/721916