### PR TITLE
app-crypt/scdrand: EAPI8 bump, fix calling AR directly, bug #722026

### DIFF
--- a/app-crypt/scdrand/scdrand-0.3.5.ebuild
+++ b/app-crypt/scdrand/scdrand-0.3.5.ebuild
@@ -1,17 +1,19 @@
-# Copyright 2019-2020 Gentoo Authors
+# Copyright 2019-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
-MY_P=scdtools-${PV}
+inherit toolchain-funcs
+
+MY_P="scdtools-${PV}"
 DESCRIPTION="Feed kernel entropy pool from smartcard's TRNG"
 HOMEPAGE="https://incenp.org/dvlpt/scdtools.html"
 SRC_URI="https://incenp.org/files/softs/scdtools/$(ver_cut 1-2)/${MY_P}.tar.gz"
+S="${WORKDIR}/${MY_P}"
 
 LICENSE="GPL-3+"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE=""
 
 DEPEND="dev-libs/libgcrypt:=
 	dev-libs/libassuan:=
@@ -19,10 +21,8 @@ DEPEND="dev-libs/libgcrypt:=
 RDEPEND="${DEPEND}
 	app-crypt/gnupg"
 
-S=${WORKDIR}/${MY_P}
-
 src_compile() {
-	emake -C lib
+	emake AR="$(tc-getAR)" -C lib
 	emake -C src scdrand
 }
 


### PR DESCRIPTION
Signed-off-by: Michael Mair-Keimberger <mmk@levelnine.at>

Closes: https://bugs.gentoo.org/722026