### PR TITLE
app-crypt/princeprocessor: EAPI8 bump, fix calling cc directly, bug #…

### DIFF
--- a/app-crypt/princeprocessor/princeprocessor-0.22-r1.ebuild
+++ b/app-crypt/princeprocessor/princeprocessor-0.22-r1.ebuild
@@ -1,0 +1,27 @@
+# Copyright 2019-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit edo toolchain-funcs
+
+DESCRIPTION="Standalone password candidate generator using the PRINCE algorithm"
+HOMEPAGE="https://github.com/hashcat/princeprocessor"
+SRC_URI="https://github.com/hashcat/princeprocessor/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+S="${WORKDIR}/${P}/src"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+src_compile() {
+	edo $(tc-getCC) -W -Wall -std=c99 ${CFLAGS} ${LDFLAGS} -DLINUX -o ${PN} pp.c mpz_int128.h
+}
+
+src_install() {
+	dobin ${PN}
+	dodoc ../{README.md,CHANGES}
+	#install rules after hashcat is fixed
+	#insinto /usr/share/hashcat
+	#doins ../rules/*.rules
+}


### PR DESCRIPTION
…722044

Fixes calling `cc` directly.
I've decided to call `tc-getCC` directly (with the corresponding flags) since it's only a *.c and *.h file.
Also installing some doc's

```diff
--- princeprocessor-0.22.ebuild	2023-12-31 18:33:02.621925811 +0100
+++ princeprocessor-0.22-r1.ebuild	2023-12-31 18:55:58.150886102 +0100
@@ -1,26 +1,26 @@
 # Copyright 2019-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
+
+inherit edo toolchain-funcs
 
 DESCRIPTION="Standalone password candidate generator using the PRINCE algorithm"
 HOMEPAGE="https://github.com/hashcat/princeprocessor"
 SRC_URI="https://github.com/hashcat/princeprocessor/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+S="${WORKDIR}/${P}/src"
 
 LICENSE="MIT"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE=""
-
-S="${WORKDIR}/${P}/src"
 
-src_prepare() {
-	sed -i "s#-O2 -s#${CFLAGS} ${LDFLAGS}#" Makefile
-	default
+src_compile() {
+	edo $(tc-getCC) -W -Wall -std=c99 ${CFLAGS} ${LDFLAGS} -m64 -DLINUX -o ${PN} pp.c mpz_int128.h
 }
 
 src_install() {
-	newbin pp64.bin princeprocessor
+	dobin ${PN}
+	dodoc ../{README.md,CHANGES}
 	#install rules after hashcat is fixed
 	#insinto /usr/share/hashcat
 	#doins ../rules/*.rule
```

Signed-off-by: Michael Mair-Keimberger <mmk@levelnine.at>

Closes: https://bugs.gentoo.org/722044