### PR TITLE
media-sound/guitarix: fix LTO build

### DIFF
--- a/media-sound/guitarix/guitarix-0.44.1.ebuild
+++ b/media-sound/guitarix/guitarix-0.44.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2019-2023 Gentoo Authors
+# Copyright 2019-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -69,7 +69,10 @@ PATCHES=(
 )
 
 src_configure() {
+	export -n {CXX,LD}FLAGS
+
 	local myconf=(
+		--cxxflags="${CXXFLAGS}"
 		--cxxflags-debug=""
 		--cxxflags-release="-DNDEBUG"
 		--ldflags="${LDFLAGS}"

--- a/media-sound/guitarix/guitarix-9999.ebuild
+++ b/media-sound/guitarix/guitarix-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2019-2023 Gentoo Authors
+# Copyright 2019-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -66,7 +66,10 @@ BDEPEND="
 DOCS=( changelog README )
 
 src_configure() {
+	export -n {CXX,LD}FLAGS
+
 	local myconf=(
+		--cxxflags="${CXXFLAGS}"
 		--cxxflags-debug=""
 		--cxxflags-release="-DNDEBUG"
 		--ldflags="${LDFLAGS}"


### PR DESCRIPTION
Pass `--cxxflags` to waf configure. This allows waf to do some magic and append `-ffat-lto-objects` to `CXXFLAGS`.

Also unexport `CXXFLAGS` and `LDFLAGS` before waf configure to prevent duplicating flags.

Closes: https://bugs.gentoo.org/860861