### PR TITLE
kernel-build.eclass: use lockdown=integrity in generic-uki

### DIFF
--- a/eclass/kernel-build.eclass
+++ b/eclass/kernel-build.eclass
@@ -101,8 +101,8 @@ IUSE="+strip"
 # @DESCRIPTION:
 # If KERNEL_IUSE_GENERIC_UKI is set, this variable allows setting the
 # built-in kernel command line for the UKI. If unset, the default is
-# root=/dev/gpt-auto-root ro
-: "${KERNEL_GENERIC_UKI_CMDLINE:="root=/dev/gpt-auto-root ro"}"
+# root=/dev/gpt-auto-root ro lockdown=integrity
+: "${KERNEL_GENERIC_UKI_CMDLINE:="root=/dev/gpt-auto-root ro lockdown=integrity"}"
 
 if [[ ${KERNEL_IUSE_MODULES_SIGN} ]]; then
 	IUSE+=" modules-sign"


### PR DESCRIPTION
I think the first two commits make sense even if we end up opting for a different solution to Bug 921195.

- kernel-build: allow overriding the default UKI cmdline with a user variable. Though I expect there isn't any real use case for using `USE=generic-uki` on gentoo-kernel non-bin, adding this option is useful for debugging. 
- kernel-install: elog the cmdline that the UKI was built with, so the user is aware of what the cmdline will be if they do not override it. And explain that it can be overridden, but only if secureboot is disabled.
- Final commit adds `lockdown=integrity` to our default UKI cmdline as a possible solution for Bug 921195

CC @gentoo/dist-kernel 