### PR TITLE
dev-util/treecc: EAPI8 bump, fix calling ar directly, bug #724244

### DIFF
--- a/dev-util/treecc/treecc-0.3.10-r2.ebuild
+++ b/dev-util/treecc/treecc-0.3.10-r2.ebuild
@@ -1,0 +1,45 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs
+
+DESCRIPTION="Compiler-compiler tool for aspect-oriented programming"
+HOMEPAGE="https://www.gnu.org/software/dotgnu/"
+SRC_URI="https://download.savannah.gnu.org/releases/dotgnu-pnet/${P}.tar.gz"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
+IUSE="doc examples"
+
+DEPEND="doc? ( app-text/texi2html )"
+
+src_compile() {
+	emake AR="$(tc-getAR)"
+
+	if use doc; then
+		[[ -f "${S}"/doc/treecc.texi ]] || die "treecc.texi was not generated"
+		cd "${S}"/doc || die
+		texi2html -split_chapter "${S}"/doc/treecc.texi \
+			|| die "texi2html failed"
+		cd "${S}" || die
+	fi
+}
+
+src_install() {
+	default
+
+	if use examples; then
+		docinto examples
+		dodoc examples/README
+		dodoc examples/{expr_c.tc,gram_c.y,scan_c.l}
+	fi
+
+	if use doc; then
+		dodoc doc/*.{txt,html}
+		docinto html
+		dodoc -r doc/treecc/*.html
+	fi
+}


### PR DESCRIPTION
Simple fix for calling `ar` directly.

```diff
--- treecc-0.3.10-r1.ebuild	2024-01-03 18:50:24.147849358 +0100
+++ treecc-0.3.10-r2.ebuild	2024-01-03 18:52:13.151017840 +0100
@@ -1,21 +1,23 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
+
+inherit toolchain-funcs
 
 DESCRIPTION="Compiler-compiler tool for aspect-oriented programming"
-HOMEPAGE="https://www.gnu.org/software/dotgnu"
+HOMEPAGE="https://www.gnu.org/software/dotgnu/"
 SRC_URI="https://download.savannah.gnu.org/releases/dotgnu-pnet/${P}.tar.gz"
 
 LICENSE="GPL-2+"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm ~hppa ~ia64 ~mips ppc ppc64 ~s390 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
 IUSE="doc examples"
 
 DEPEND="doc? ( app-text/texi2html )"
 
 src_compile() {
-	default
+	emake AR="$(tc-getAR)"
 
 	if use doc; then
 		[[ -f "${S}"/doc/treecc.texi ]] || die "treecc.texi was not generated"

```

Signed-off-by: Michael Mair-Keimberger <mmk@levelnine.at>

Closes: https://bugs.gentoo.org/724244