### PR TITLE
sys-cluster/ceph: fix babeltrace subslot restriction in 18.2.0-r2

### DIFF
--- a/sys-cluster/ceph/ceph-18.2.0-r2.ebuild
+++ b/sys-cluster/ceph/ceph-18.2.0-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -74,7 +74,7 @@ DEPEND="
 	sys-process/numactl:=
 	virtual/libcrypt:=
 	x11-libs/libpciaccess:=
-	babeltrace? ( dev-util/babeltrace:0/2 )
+	babeltrace? ( dev-util/babeltrace:0/1 )
 	fuse? ( sys-fs/fuse:3= )
 	jemalloc? ( dev-libs/jemalloc:= )
 	!jemalloc? ( >=dev-util/google-perftools-2.6.1:= )


### PR DESCRIPTION
Mistyped this in the initial fix.

Closes: https://bugs.gentoo.org/920371