### PR TITLE
gui-wm/hyprland: depend on app-alternatives/ninja

### DIFF
--- a/gui-wm/hyprland/hyprland-0.34.0.ebuild
+++ b/gui-wm/hyprland/hyprland-0.34.0.ebuild
@@ -25,9 +25,9 @@ IUSE="X legacy-renderer systemd"
 # hyprpm (hyprland plugin manager) requires the dependencies at runtime
 # so that it can clone, compile and install plugins.
 HYPRPM_RDEPEND="
+	app-alternatives/ninja
 	dev-util/cmake
 	dev-util/meson
-	dev-util/ninja
 	dev-vcs/git
 	sys-auth/polkit
 	virtual/pkgconfig

--- a/gui-wm/hyprland/hyprland-9999.ebuild
+++ b/gui-wm/hyprland/hyprland-9999.ebuild
@@ -25,9 +25,9 @@ IUSE="X legacy-renderer systemd"
 # hyprpm (hyprland plugin manager) requires the dependencies at runtime
 # so that it can clone, compile and install plugins.
 HYPRPM_RDEPEND="
+	app-alternatives/ninja
 	dev-util/cmake
 	dev-util/meson
-	dev-util/ninja
 	dev-vcs/git
 	sys-auth/polkit
 	virtual/pkgconfig


### PR DESCRIPTION
Depend on app-alternatives/ninja to use samurai as a drop-in replacement for ninja and avoid installing ninja altogether