### PR TITLE
Add asahi-nvram packages

### DIFF
--- a/sys-apps/asahi-nvram-meta/asahi-nvram-meta-0.1.ebuild
+++ b/sys-apps/asahi-nvram-meta/asahi-nvram-meta-0.1.ebuild
@@ -1,0 +1,19 @@
+# Copyright 2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DESCRIPTION="Metapackage for asahi-nvram modules"
+HOMEPAGE="https://github.com/WhatAmISupposedToPutHere/asahi-nvram"
+LICENSE="metapackage"
+SLOT="0"
+KEYWORDS="~arm64"
+IUSE="+bless gui bluetooth raw wifi"
+
+RDEPEND="
+	bless? ( sys-apps/asahi-bless )
+	gui? ( sys-apps/asahi-startup-disk )
+	bluetooth? ( net-misc/asahi-btsync )
+	raw? ( sys-apps/asahi-nvram )
+	wifi? ( net-misc/asahi-wifisync )
+"

--- a/sys-apps/asahi-nvram-meta/metadata.xml
+++ b/sys-apps/asahi-nvram-meta/metadata.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="person">
+		<email>jcalligeros99@gmail.com</email>
+		<name>James Calligeros</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>asahi@gentoo.org</email>
+		<name>Asahi</name>
+	</maintainer>
+	<longdescription>
+		Apple Silicon Macs store a large amount of platform configuration data
+		in NVRAM. This can be considered as a synthesis of a PC's BIOS settings
+		and UEFI variable store. Being able to read and write the NVRAM is
+		useful for, inter alia, handing off Bluetooth and WiFi configuration
+		data from macOS, and setting the "default" boot disk.
+	</longdescription>
+	<use>
+		<flag name="bless">Pull in <pkg>sys-apps/asahi-bless</pkg></flag>
+		<flag name="gui">
+			Pull in <pkg>sys-apps/asahi-startup-disk</pkg> for a GUI boot
+			disk selector
+		</flag>
+		<flag name="bluetooth">Pull in <pkg>net-misc/asahi-btsync</pkg></flag>
+		<flag name="raw">
+			Enable raw NVRAM reading with <pkg>sys-apps/asahi-nvram</pkg>
+		</flag>
+		<flag name="wifi">Pull in <pkg>net-misc/asahi-wifisync</pkg></flag>
+	</use>
+	<upstream>
+		<remote-id type="github">
+			WhatAmISupposedToPutHere/asahi-nvram
+		</remote-id>
+	</upstream>
+</pkgmetadata>


### PR DESCRIPTION
This PR adds the suite of software required to interact with the NVRAM on Apple Silicon Macs. The platform's NVRAM
can be thought of as a sort of mix between UEFI variable storage and what a traditional PC would call its BIOS. It
is used for setting the default boot volume, storing network and Bluetooth settings for handoff with macOS, and
many other platform-specific settings.