### PR TITLE
install-qa-check.d: New QA checks for Python packages

### DIFF
--- a/metadata/install-qa-check.d/60python-site
+++ b/metadata/install-qa-check.d/60python-site
@@ -88,7 +88,8 @@ python_site_check() {
 					-name '*.pth' -o \
 					-name '*.py' -o \
 					-name '*.pyi' -o \
-					-name "*$(get_modname)" \
+					-name "*$(get_modname)" -o \
+					-name 'README.txt' \
 				')' -print0
 		)
 		# check for forbidden packages

--- a/metadata/install-qa-check.d/60python-site
+++ b/metadata/install-qa-check.d/60python-site
@@ -1,10 +1,11 @@
-# Copyright 2019-2022 Gentoo Authors
+# Copyright 2019-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-# QA check: ensure that Python modules are compiled after installing
+# QA checks related to site-packages directory:
+# - missing, mismatched or stray .pyc files
 # Maintainer: Python project <python@gentoo.org>
 
-python_pyc_check() {
+python_site_check() {
 	local save=$(shopt -p nullglob)
 	shopt -s nullglob
 	local progs=( "${EPREFIX}"/usr/lib/python-exec/*/gpep517 )
@@ -69,7 +70,7 @@ python_pyc_check() {
 		eqawarn "not byte-compiled."
 		eqawarn "The following files are missing:"
 		eqawarn
-		eqatag -v python-pyc.missing "${missing[@]}"
+		eqatag -v python-site.pyc.missing "${missing[@]}"
 		found=1
 	fi
 
@@ -79,7 +80,7 @@ python_pyc_check() {
 		eqawarn "that seem to be invalid (do not have the correct header)."
 		eqawarn "The following files are invalid:"
 		eqawarn
-		eqatag -v python-pyc.invalid "${invalid[@]}"
+		eqatag -v python-site.pyc.invalid "${invalid[@]}"
 		found=1
 	fi
 
@@ -88,7 +89,7 @@ python_pyc_check() {
 		eqawarn "QA Notice: This package installs one or more compiled Python modules whose"
 		eqawarn ".py files have different content (size or hash) than recorded:"
 		eqawarn
-		eqatag -v python-pyc.mismatched.data "${mismatched_data[@]}"
+		eqatag -v python-site.pyc.mismatched.data "${mismatched_data[@]}"
 		found=1
 	fi
 
@@ -97,7 +98,7 @@ python_pyc_check() {
 		eqawarn "QA Notice: This package installs one or more compiled Python modules whose"
 		eqawarn ".py files have different timestamps than recorded:"
 		eqawarn
-		eqatag -v python-pyc.mismatched.timestamp "${mismatched_timestamp[@]}"
+		eqatag -v python-site.pyc.mismatched.timestamp "${mismatched_timestamp[@]}"
 		found=1
 	fi
 
@@ -107,7 +108,7 @@ python_pyc_check() {
 		eqawarn "that do not match installed modules (or their implementation)."
 		eqawarn "The following files are stray:"
 		eqawarn
-		eqatag -v python-pyc.stray "${stray[@]}"
+		eqatag -v python-site.pyc.stray "${stray[@]}"
 		found=1
 	fi
 
@@ -118,7 +119,7 @@ python_pyc_check() {
 	fi
 }
 
-python_pyc_check
+python_site_check
 
 : # guarantee successful exit
 

--- a/metadata/install-qa-check.d/60python-site
+++ b/metadata/install-qa-check.d/60python-site
@@ -9,6 +9,10 @@ python_site_check() {
 	local save=$(shopt -p nullglob)
 	shopt -s nullglob
 	local progs=( "${EPREFIX}"/usr/lib/python-exec/*/gpep517 )
+	local bad_libdirs=()
+	[[ $(get_libdir) != lib ]] && bad_libdirs=(
+		"${ED}/usr/$(get_libdir)"/{python3,pypy}*
+	)
 	${save}
 
 	local forbidden_package_names=(
@@ -184,6 +188,14 @@ python_site_check() {
 		# TODO: make this fatal once we fix the existing issues, and remove
 		# the previous version from distutils-r1
 		#die "Failing install because of stray top-level files in site-packages"
+	fi
+
+	if [[ ${bad_libdirs[@]} ]]; then
+		eqawarn
+		eqawarn "QA Notice: Package installs Python files to /usr/$(get_libdir)"
+		eqawarn "instead of /usr/lib (use \$(python_get_sitedir)):"
+		eqawarn
+		eqatag -v python-site.libdir "${bad_libdirs[@]#${ED}}"
 	fi
 }
 

--- a/metadata/install-qa-check.d/60python-site
+++ b/metadata/install-qa-check.d/60python-site
@@ -31,6 +31,7 @@ python_site_check() {
 	local stray=()
 
 	local bad_versions=()
+	local eggs=()
 	local outside_site=()
 	local stray_packages=()
 
@@ -79,11 +80,22 @@ python_site_check() {
 				')' -print0
 		)
 
+		# check for deprecated egg format
+		while IFS= read -d $'\0' -r f; do
+			eggs+=( "${f#${ED}}" )
+		done < <(
+			find "${sitedir}" -maxdepth 1 '(' \
+				-name '*.egg-info' -o \
+				-name '*.egg' \
+				')' -print0
+		)
+
 		# check for stray files in site-packages
 		while IFS= read -d $'\0' -r f; do
 			stray_packages+=( "${f#${ED}}" )
 		done < <(
 			find "${sitedir}" -maxdepth 1 -type f '!' '(' \
+					-name '*.egg' -o \
 					-name '*.egg-info' -o \
 					-name '*.pth' -o \
 					-name '*.py' -o \
@@ -192,6 +204,14 @@ python_site_check() {
 		eqawarn "invalid/suspicious names or versions in the site-packages directory:"
 		eqawarn
 		eqatag -v python-site.bad_version "${bad_versions[@]}"
+	fi
+
+	if [[ ${eggs[@]} ]]; then
+		eqawarn
+		eqawarn "QA Notice: The following deprecated .egg or .egg-info files were found."
+		eqawarn "Please migrate the ebuild to use the PEP517 build."
+		eqawarn
+		eqatag -v python-site.egg "${eggs[@]}"
 	fi
 
 	if [[ ${stray_packages[@]} ]]; then

--- a/metadata/install-qa-check.d/60python-site
+++ b/metadata/install-qa-check.d/60python-site
@@ -55,9 +55,9 @@ python_site_check() {
 		done < <(
 			find "${sitedir}" -maxdepth 1 '(' \
 				-name '*-0.0.0.dist-info' -o \
-				-name '*-UNKNOWN.dist-info' -o \
+				-name '*UNKNOWN*.dist-info' -o \
 				-name '*-0.0.0.egg-info' -o \
-				-name '*-UNKNOWN.egg-info' \
+				-name '*UNKNOWN*.egg-info' \
 				')' -print0
 		)
 
@@ -170,7 +170,7 @@ python_site_check() {
 	if [[ ${bad_versions[@]} ]]; then
 		eqawarn
 		eqawarn "QA Notice: The following Python packages were installed with"
-		eqawarn "invalid/suspicious versions in the site-packages directory:"
+		eqawarn "invalid/suspicious names or versions in the site-packages directory:"
 		eqawarn
 		eqatag -v python-site.bad_version "${bad_versions[@]}"
 	fi

--- a/metadata/install-qa-check.d/60python-site
+++ b/metadata/install-qa-check.d/60python-site
@@ -11,11 +11,20 @@ python_site_check() {
 	local progs=( "${EPREFIX}"/usr/lib/python-exec/*/gpep517 )
 	${save}
 
+	local forbidden_package_names=(
+		# NB: setuptools/discovery.py is a good source of ideas
+		benchmark benchmarks dist doc docs examples scripts tasks
+		test tests tools util utils
+		.pytest_cache .hypothesis _trial_temp
+	)
+
 	local invalid=()
 	local mismatched_timestamp=()
 	local mismatched_data=()
 	local missing=()
 	local stray=()
+
+	local stray_packages=()
 
 	# Avoid running the check if sufficiently new gpep517 is not installed
 	# yet. It's valid to schedule (for merge order) >=gpep517-8 after
@@ -24,12 +33,33 @@ python_site_check() {
 		return
 	fi
 
+	local f prog
 	for prog in "${progs[@]}"; do
 		local impl=${prog%/*}
 		impl=${impl##*/}
 
 		# NB: using ${impl}* to catch pypy3.* for pypy3
-		[[ -d "${ED}"/usr/lib/${impl}*/site-packages ]] || continue
+		local sitedir=( "${ED}"/usr/lib/${impl}*/site-packages )
+		[[ -d ${sitedir} ]] || continue
+
+		# check for stray files in site-packages
+		while IFS= read -d $'\0' -r f; do
+			stray_packages+=( "${f#${ED}}" )
+		done < <(
+			find "${sitedir}" -maxdepth 1 -type f '!' '(' \
+					-name '*.egg-info' -o \
+					-name '*.pth' -o \
+					-name '*.py' -o \
+					-name '*.pyi' -o \
+					-name "*$(get_modname)" \
+				')' -print0
+		)
+		# check for forbidden packages
+		for f in "${forbidden_package_names[@]}"; do
+			[[ -d ${sitedir}/${f} ]] && stray_packages+=(
+				"${sitedir#${ED}}/${f}"
+			)
+		done
 
 		einfo "Verifying compiled files for ${impl}"
 		local kind pyc py
@@ -116,6 +146,21 @@ python_site_check() {
 		eqawarn
 		eqawarn "For more information on bytecode files and related issues, please see:"
 		eqawarn "  https://projects.gentoo.org/python/guide/qawarn.html#compiled-bytecode-related-warnings"
+	fi
+
+	if [[ ${stray_packages[@]} ]]; then
+		eqawarn
+		eqawarn "QA Notice: The following unexpected files/directories were found"
+		eqawarn "top-level in the site-packages directory:"
+		eqawarn
+		eqatag -v python-site.stray "${stray_packages[@]}"
+		eqawarn
+		eqawarn "This is most likely a bug in the build system.  More information"
+		eqawarn "can be found in the Python Guide:"
+		eqawarn "https://projects.gentoo.org/python/guide/qawarn.html#stray-top-level-files-in-site-packages"
+		# TODO: make this fatal once we fix the existing issues, and remove
+		# the previous version from distutils-r1
+		#die "Failing install because of stray top-level files in site-packages"
 	fi
 }
 

--- a/metadata/install-qa-check.d/60python-site
+++ b/metadata/install-qa-check.d/60python-site
@@ -31,6 +31,7 @@ python_site_check() {
 	local stray=()
 
 	local bad_versions=()
+	local outside_site=()
 	local stray_packages=()
 
 	# Avoid running the check if sufficiently new gpep517 is not installed
@@ -46,7 +47,24 @@ python_site_check() {
 		impl=${impl##*/}
 
 		# NB: using ${impl}* to catch pypy3.* for pypy3
-		local sitedir=( "${ED}"/usr/lib/${impl}*/site-packages )
+		local pydir=( "${ED}"/usr/lib/${impl}* )
+		[[ -d ${pydir} ]] || continue
+
+		# check for packages installing outside site-packages
+		case ${CATEGORY}/${PN} in
+			dev-lang/python|dev-python/pypy*)
+				;;
+			*)
+				while IFS= read -d $'\0' -r f; do
+					outside_site+=( "${f}" )
+				done < <(
+					find "${pydir}" -mindepth 1 -maxdepth 1 \
+						'!' -name site-packages -print0
+				)
+				;;
+		esac
+
+		local sitedir=( "${pydir}"/site-packages )
 		[[ -d ${sitedir} ]] || continue
 
 		# check for bad package versions
@@ -196,6 +214,14 @@ python_site_check() {
 		eqawarn "instead of /usr/lib (use \$(python_get_sitedir)):"
 		eqawarn
 		eqatag -v python-site.libdir "${bad_libdirs[@]#${ED}}"
+	fi
+
+	if [[ ${outside_site[@]} ]]; then
+		eqawarn
+		eqawarn "QA Notice: Files found installed directly into Python stdlib,"
+		eqawarn "instead of site-packages (use \$(python_get_sitedir)):"
+		eqawarn
+		eqatag -v python-site.stdlib "${outside_site[@]}"
 	fi
 }
 

--- a/metadata/install-qa-check.d/60python-site
+++ b/metadata/install-qa-check.d/60python-site
@@ -15,6 +15,8 @@ python_site_check() {
 		# NB: setuptools/discovery.py is a good source of ideas
 		benchmark benchmarks dist doc docs examples scripts tasks
 		test tests tools util utils
+		# catch double-prefix installs, e.g. https://bugs.gentoo.org/618134
+		lib $(get_libdir) usr
 		.pytest_cache .hypothesis _trial_temp
 	)
 

--- a/metadata/install-qa-check.d/60python-site
+++ b/metadata/install-qa-check.d/60python-site
@@ -24,6 +24,7 @@ python_site_check() {
 	local missing=()
 	local stray=()
 
+	local bad_versions=()
 	local stray_packages=()
 
 	# Avoid running the check if sufficiently new gpep517 is not installed
@@ -41,6 +42,18 @@ python_site_check() {
 		# NB: using ${impl}* to catch pypy3.* for pypy3
 		local sitedir=( "${ED}"/usr/lib/${impl}*/site-packages )
 		[[ -d ${sitedir} ]] || continue
+
+		# check for bad package versions
+		while IFS= read -d $'\0' -r f; do
+			bad_versions+=( "${f#${ED}}" )
+		done < <(
+			find "${sitedir}" -maxdepth 1 '(' \
+				-name '*-0.0.0.dist-info' -o \
+				-name '*-UNKNOWN.dist-info' -o \
+				-name '*-0.0.0.egg-info' -o \
+				-name '*-UNKNOWN.egg-info' \
+				')' -print0
+		)
 
 		# check for stray files in site-packages
 		while IFS= read -d $'\0' -r f; do
@@ -146,6 +159,14 @@ python_site_check() {
 		eqawarn
 		eqawarn "For more information on bytecode files and related issues, please see:"
 		eqawarn "  https://projects.gentoo.org/python/guide/qawarn.html#compiled-bytecode-related-warnings"
+	fi
+
+	if [[ ${bad_versions[@]} ]]; then
+		eqawarn
+		eqawarn "QA Notice: The following Python packages were installed with"
+		eqawarn "invalid/suspicious versions in the site-packages directory:"
+		eqawarn
+		eqatag -v python-site.bad_version "${bad_versions[@]}"
 	fi
 
 	if [[ ${stray_packages[@]} ]]; then


### PR DESCRIPTION
- [x] Check for stray files / invalid packages (moved from distutils-r1)
- [x] Check for invalid versions
- [x] Check for packages installing to `/usr/lib64/python*`?
- [x] Check for random packages installing straight to `/usr/lib/python*`?
- [x] Check for `*.egg` and `*.egg-info` files