### PR TITLE
app-crypt/mhash: fix compilation on GCC 14

### DIFF
--- a/app-crypt/mhash/files/mhash-0.9.9.9-cast-temp-64bit.patch
+++ b/app-crypt/mhash/files/mhash-0.9.9.9-cast-temp-64bit.patch
@@ -1,0 +1,13 @@
+diff --git a/lib/tiger.c b/lib/tiger.c
+index 8f15df4..8d28f27 100644
+--- a/lib/tiger.c
++++ b/lib/tiger.c
+@@ -254,7 +254,7 @@ void tiger_final(struct tiger_ctx *ctx)
+ 	register mutils_word64 i, j;
+ 	/* Force 64-bit alignment */
+ 	mutils_word64 temp_64bit[TIGER_DATASIZE/8];
+-	mutils_word8 *temp = temp_64bit;
++	mutils_word8 *temp = (mutils_word8 *) temp_64bit;
+ 	i = ctx->index;
+ 	
+ #if defined(WORDS_BIGENDIAN)

--- a/app-crypt/mhash/mhash-0.9.9.9-r3.ebuild
+++ b/app-crypt/mhash/mhash-0.9.9.9-r3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -27,6 +27,7 @@ PATCHES=(
 	"${FILESDIR}"/${P}-alignment.patch
 	"${FILESDIR}"/${P}-no-malloc-check.patch
 	"${FILESDIR}"/${P}-hmac-uaf-test.patch
+	"${FILESDIR}"/${P}-cast-temp-64bit.patch
 )
 
 DOCS=( doc/example.c doc/skid2-authentication )


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/919700