### PR TITLE
media-gfx/graphicsmagick: reinstate jpeg2k support

### DIFF
--- a/media-gfx/graphicsmagick/graphicsmagick-1.3.42-r1.ebuild
+++ b/media-gfx/graphicsmagick/graphicsmagick-1.3.42-r1.ebuild
@@ -69,6 +69,7 @@ BDEPEND+=" virtual/pkgconfig"
 PATCHES=(
 	"${FILESDIR}"/${PN}-1.3.41-flags.patch
 	"${FILESDIR}"/${PN}-1.3.41-perl.patch
+	"${FILESDIR}"/${PN}-1.3.42-autoconf-2.72-perl-lfs.patch
 )
 
 pkg_pretend() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/913069
