### PR TITLE
app-editors/ghostwriter: drop myself as a maintainer

### DIFF
--- a/app-editors/ghostwriter/metadata.xml
+++ b/app-editors/ghostwriter/metadata.xml
@@ -5,14 +5,6 @@
 		<email>kde@gentoo.org</email>
 		<name>Gentoo KDE Project</name>
 	</maintainer>
-	<maintainer type="person" proxied="yes">
-		<email>davidroman96@gmail.com</email>
-		<name>David Roman</name>
-	</maintainer>
-	<maintainer type="project" proxied="proxy">
-		<email>proxy-maint@gentoo.org</email>
-		<name>Proxy Maintainers</name>
-	</maintainer>
 	<upstream>
 		<remote-id type="github">wereturtle/ghostwriter</remote-id>
 		<bugs-to>https://bugs.kde.org/</bugs-to>


### PR DESCRIPTION
Drop myself as a maintainer. It's already (and better) maintained by the KDE team and nowadays I don't use ghostwritter as much.