### PR TITLE
sys-apps/portage: fix invalid python bytecompile stage

### DIFF
--- a/app-portage/gentoolkit/gentoolkit-9999.ebuild
+++ b/app-portage/gentoolkit/gentoolkit-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -95,8 +95,8 @@ my_src_install() {
 	)
 
 	meson_src_install
-	python_optimize "${pydirs[@]}"
 	python_fix_shebang "${pydirs[@]}"
+	python_optimize "${pydirs[@]}"
 }
 
 pkg_postinst() {

--- a/sys-apps/portage/portage-3.0.57-r1.ebuild
+++ b/sys-apps/portage/portage-3.0.57-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -187,8 +187,8 @@ my_src_install() {
 	)
 
 	meson_src_install
-	python_optimize "${pydirs[@]}"
 	python_fix_shebang "${pydirs[@]}"
+	python_optimize "${pydirs[@]}"
 }
 
 pkg_preinst() {

--- a/sys-apps/portage/portage-3.0.59-r1.ebuild
+++ b/sys-apps/portage/portage-3.0.59-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -185,8 +185,8 @@ my_src_install() {
 	)
 
 	meson_src_install
-	python_optimize "${pydirs[@]}"
 	python_fix_shebang "${pydirs[@]}"
+	python_optimize "${pydirs[@]}"
 }
 
 pkg_preinst() {

--- a/sys-apps/portage/portage-3.0.60-r1.ebuild
+++ b/sys-apps/portage/portage-3.0.60-r1.ebuild
@@ -185,8 +185,8 @@ my_src_install() {
 	)
 
 	meson_src_install
-	python_optimize "${pydirs[@]}"
 	python_fix_shebang "${pydirs[@]}"
+	python_optimize "${pydirs[@]}"
 }
 
 pkg_preinst() {

--- a/sys-apps/portage/portage-9999.ebuild
+++ b/sys-apps/portage/portage-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -185,8 +185,8 @@ my_src_install() {
 	)
 
 	meson_src_install
-	python_optimize "${pydirs[@]}"
 	python_fix_shebang "${pydirs[@]}"
+	python_optimize "${pydirs[@]}"
 }
 
 pkg_preinst() {


### PR DESCRIPTION
python software needs to have two postprocessing passes run:
- fix up shebangs of bin scripts
- optimize importable libraries in sitedir

For some reason, both directories get both passes applied, which doesn't actually do anything useful. Worse, the shebang fixing happens *after* the optimizing, which means that if any shebang fixing occurs in the sitedir, it invalidates the bytecode.