### PR TITLE
Misc builddeps

### DIFF
--- a/media-libs/libva/libva-2.20.0.ebuild
+++ b/media-libs/libva/libva-2.20.0.ebuild
@@ -33,7 +33,10 @@ RDEPEND="
 		x11-libs/libxcb:=[${MULTILIB_USEDEP}]
 	)
 "
-DEPEND="${RDEPEND}"
+DEPEND="
+	${RDEPEND}
+	X? ( x11-base/xorg-proto )
+"
 BDEPEND="
 	wayland? ( dev-util/wayland-scanner )
 	virtual/pkgconfig

--- a/sys-apps/pkgcore/pkgcore-0.12.23-r1.ebuild
+++ b/sys-apps/pkgcore/pkgcore-0.12.23-r1.ebuild
@@ -22,16 +22,19 @@ HOMEPAGE="https://github.com/pkgcore/pkgcore"
 LICENSE="BSD MIT"
 SLOT="0"
 
+if [[ ${PV} == *9999 ]]; then
+	COMMON_DEPEND="~dev-python/snakeoil-9999[${PYTHON_USEDEP}]"
+else
+	COMMON_DEPEND=">=dev-python/snakeoil-0.10.4[${PYTHON_USEDEP}]"
+fi
+
 RDEPEND="
+	${COMMON_DEPEND}
 	>=app-shells/bash-5.0[readline]
 	dev-python/lxml[${PYTHON_USEDEP}]
 "
-if [[ ${PV} == *9999 ]]; then
-	RDEPEND+=" ~dev-python/snakeoil-9999[${PYTHON_USEDEP}]"
-else
-	RDEPEND+=" >=dev-python/snakeoil-0.10.4[${PYTHON_USEDEP}]"
-fi
 BDEPEND="
+	${COMMON_DEPEND}
 	>=dev-python/flit-core-3.8[${PYTHON_USEDEP}]
 	test? (
 		dev-vcs/git

--- a/sys-apps/pkgcore/pkgcore-0.12.23.ebuild
+++ b/sys-apps/pkgcore/pkgcore-0.12.23.ebuild
@@ -22,16 +22,19 @@ HOMEPAGE="https://github.com/pkgcore/pkgcore"
 LICENSE="BSD MIT"
 SLOT="0"
 
+if [[ ${PV} == *9999 ]]; then
+	COMMON_DEPEND="~dev-python/snakeoil-9999[${PYTHON_USEDEP}]"
+else
+	COMMON_DEPEND=">=dev-python/snakeoil-0.10.4[${PYTHON_USEDEP}]"
+fi
+
 RDEPEND="
+	${COMMON_DEPEND}
 	>=app-shells/bash-5.0[readline]
 	dev-python/lxml[${PYTHON_USEDEP}]
 "
-if [[ ${PV} == *9999 ]]; then
-	RDEPEND+=" ~dev-python/snakeoil-9999[${PYTHON_USEDEP}]"
-else
-	RDEPEND+=" >=dev-python/snakeoil-0.10.4[${PYTHON_USEDEP}]"
-fi
 BDEPEND="
+	${COMMON_DEPEND}
 	>=dev-python/flit-core-3.8[${PYTHON_USEDEP}]
 	test? (
 		dev-vcs/git

--- a/sys-apps/pkgcore/pkgcore-0.12.24.ebuild
+++ b/sys-apps/pkgcore/pkgcore-0.12.24.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -22,16 +22,19 @@ HOMEPAGE="https://github.com/pkgcore/pkgcore"
 LICENSE="BSD MIT"
 SLOT="0"
 
+if [[ ${PV} == *9999 ]]; then
+	COMMON_DEPEND="~dev-python/snakeoil-9999[${PYTHON_USEDEP}]"
+else
+	COMMON_DEPEND=">=dev-python/snakeoil-0.10.4[${PYTHON_USEDEP}]"
+fi
+
 RDEPEND="
+	${COMMON_DEPEND}
 	>=app-shells/bash-5.0[readline]
 	dev-python/lxml[${PYTHON_USEDEP}]
 "
-if [[ ${PV} == *9999 ]]; then
-	RDEPEND+=" ~dev-python/snakeoil-9999[${PYTHON_USEDEP}]"
-else
-	RDEPEND+=" >=dev-python/snakeoil-0.10.4[${PYTHON_USEDEP}]"
-fi
 BDEPEND="
+	${COMMON_DEPEND}
 	>=dev-python/flit-core-3.8[${PYTHON_USEDEP}]
 	test? (
 		dev-vcs/git

--- a/sys-apps/pkgcore/pkgcore-9999.ebuild
+++ b/sys-apps/pkgcore/pkgcore-9999.ebuild
@@ -22,16 +22,19 @@ HOMEPAGE="https://github.com/pkgcore/pkgcore"
 LICENSE="BSD MIT"
 SLOT="0"
 
+if [[ ${PV} == *9999 ]]; then
+	COMMON_DEPEND="~dev-python/snakeoil-9999[${PYTHON_USEDEP}]"
+else
+	COMMON_DEPEND=">=dev-python/snakeoil-0.10.4[${PYTHON_USEDEP}]"
+fi
+
 RDEPEND="
+	${COMMON_DEPEND}
 	>=app-shells/bash-5.0[readline]
 	dev-python/lxml[${PYTHON_USEDEP}]
 "
-if [[ ${PV} == *9999 ]]; then
-	RDEPEND+=" ~dev-python/snakeoil-9999[${PYTHON_USEDEP}]"
-else
-	RDEPEND+=" >=dev-python/snakeoil-0.10.4[${PYTHON_USEDEP}]"
-fi
 BDEPEND="
+	${COMMON_DEPEND}
 	>=dev-python/flit-core-3.8[${PYTHON_USEDEP}]
 	test? (
 		dev-vcs/git


### PR DESCRIPTION
Packages with missing build dependencies:
- pkgcore: build + runtime dep only listed for runtime
- libva: assumes xorg was locally built and its bdeps are available