### PR TITLE
media-gfx/sam2p: Fix clang -flto build failure

### DIFF
--- a/media-gfx/sam2p/sam2p-0.49.4_p20190718-r1.ebuild
+++ b/media-gfx/sam2p/sam2p-0.49.4_p20190718-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -48,7 +48,12 @@ src_configure() {
 }
 
 src_compile() {
-	emake GCC_STRIP=
+	emake GCC_STRIP= \
+		CC="$(tc-getCC)" \
+		CXX="$(tc-getCXX)" \
+		LD="$(tc-getCC)" \
+		LDXX="$(tc-getCXX)" \
+		LDY="$(tc-getCC)"
 }
 
 src_install() {


### PR DESCRIPTION
When compiling with clang and ld.lld build fails with the error message:

    ps_tiny.o: file not recognized: file format not recognized

This is because the build system does not properly honor standard buildtime flags and instead requires nonstandard flags be set to get the proper build result. This patch sets the necessary flags to successfully compile with clang and -flto.