### PR TITLE
net-misc/asterisk: mask USE=srtp for sparc.

### DIFF
--- a/profiles/arch/sparc/package.use.mask
+++ b/profiles/arch/sparc/package.use.mask
@@ -1,6 +1,10 @@
 # Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Jaco Kroon <jaco@uls.co.za> (2024-01-09)
+# net-misc/asterisk[srtp] depends on net-libs/libsrtp which is -sparc.
+net-misc/asterisk srtp
+
 # Sam James <sam@gentoo.org> (2024-01-05)
 # sys-apps/keyutils not stable here, because of test failures. bug #636252
 app-benchmarks/stress-ng keyutils


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/919424