### PR TITLE
net-libs/pjproject: bump to 2.13.1-r1 to add IUSE=srtp 

### DIFF
--- a/net-libs/pjproject/files/pjproject-2.13.1-r1-config_site.h
+++ b/net-libs/pjproject/files/pjproject-2.13.1-r1-config_site.h
@@ -1,0 +1,86 @@
+/*
+ * Based off of the Asterisk config_site.h file.
+ *
+ * In general it's the same with some removals due to being ebuild-managed.
+ */
+
+#include <sys/select.h>
+
+#define GENTOO_INVALID	(Gentoo compile failure - please report a bug on bugs.gentoo.org)
+
+/* asterisk_malloc_debug.h is not required ... most of the operations are no-ops regardless
+ * and I can't see why asterisk is looking to compile this directly into pjproject */
+
+/* Ability to change this has ABI implications, force it on */
+/* Can be reconsidered in future:  https://bugs.gentoo.org/680496 */
+#define PJ_HAS_IPV6 1
+
+#define PJ_MAX_HOSTNAME (256)
+#define PJSIP_MAX_URL_SIZE (512)
+#ifdef PJ_HAS_LINUX_EPOLL
+#define PJ_IOQUEUE_MAX_HANDLES	(5000)
+#else
+#define PJ_IOQUEUE_MAX_HANDLES	(FD_SETSIZE)
+#endif
+#define PJ_IOQUEUE_HAS_SAFE_UNREG 1
+#define PJ_IOQUEUE_MAX_EVENTS_IN_SINGLE_POLL (16)
+
+#define PJ_SCANNER_USE_BITWISE	0
+#define PJ_OS_HAS_CHECK_STACK	0
+
+#ifndef PJ_LOG_MAX_LEVEL
+#define PJ_LOG_MAX_LEVEL		6
+#endif
+
+#define PJ_ENABLE_EXTRA_CHECK	1
+#define PJSIP_MAX_TSX_COUNT		((64*1024)-1)
+#define PJSIP_MAX_DIALOG_COUNT	((64*1024)-1)
+#define PJSIP_UDP_SO_SNDBUF_SIZE	(512*1024)
+#define PJSIP_UDP_SO_RCVBUF_SIZE	(512*1024)
+#define PJ_DEBUG			0
+#define PJSIP_SAFE_MODULE		0
+#define PJ_HAS_STRICMP_ALNUM		0
+
+/*
+ * Do not ever enable PJ_HASH_USE_OWN_TOLOWER because the algorithm is
+ * inconsistently used when calculating the hash value and doesn't
+ * convert the same characters as pj_tolower()/tolower().  Thus you
+ * can get different hash values if the string hashed has certain
+ * characters in it.  (ASCII '@', '[', '\\', ']', '^', and '_')
+ */
+#undef PJ_HASH_USE_OWN_TOLOWER
+
+/*
+  It is imperative that PJSIP_UNESCAPE_IN_PLACE remain 0 or undefined.
+  Enabling it will result in SEGFAULTS when URIs containing escape sequences are encountered.
+*/
+#undef PJSIP_UNESCAPE_IN_PLACE
+#define PJSIP_MAX_PKT_LEN			65535
+
+#undef PJ_TODO
+#define PJ_TODO(x)
+
+/* Defaults too low for WebRTC */
+#define PJ_ICE_MAX_CAND 64
+#define PJ_ICE_MAX_CHECKS (PJ_ICE_MAX_CAND * PJ_ICE_MAX_CAND)
+
+/* Increase limits to allow more formats */
+#define	PJMEDIA_MAX_SDP_FMT   64
+#define	PJMEDIA_MAX_SDP_BANDW   4
+#define	PJMEDIA_MAX_SDP_ATTR   (PJMEDIA_MAX_SDP_FMT*3 + 4)
+#define	PJMEDIA_MAX_SDP_MEDIA   16
+
+/*
+ * Turn off the periodic sending of CRLNCRLN.  Default is on (90 seconds),
+ * which conflicts with the global section's keep_alive_interval option in
+ * pjsip.conf.
+ */
+#define PJSIP_TCP_KEEP_ALIVE_INTERVAL	0
+#define PJSIP_TLS_KEEP_ALIVE_INTERVAL	0
+
+#define PJSIP_TSX_UAS_CONTINUE_ON_TP_ERROR 0
+#define PJ_SSL_SOCK_OSSL_USE_THREAD_CB 0
+#define PJSIP_AUTH_ALLOW_MULTIPLE_AUTH_HEADER 1
+
+/* Required to enable things like USE=video. */
+#define PJMEDIA_HAS_VIDEO GENTOO_INVALID

--- a/net-libs/pjproject/metadata.xml
+++ b/net-libs/pjproject/metadata.xml
@@ -22,6 +22,7 @@
 		<flag name="openh264">Include Open H.264 support in the build</flag>
 		<flag name="resample">Include resampling implementations in the build</flag>
 		<flag name="silk">Include SILK support in the build</flag>
+		<flag name="srtp">Enable support for encrypted voice transmission (secure RTP)</flag>
 		<flag name="v4l2">Include Video4Linux v2 support in the build</flag>
 		<flag name="vpx">Include VP8 and VP9 codec support in the build</flag>
 		<flag name="webrtc">Enable WebRTC support</flag>

--- a/net-libs/pjproject/pjproject-2.13.1-r1.ebuild
+++ b/net-libs/pjproject/pjproject-2.13.1-r1.ebuild
@@ -1,0 +1,142 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+# TODO: Figure out a way to disable SRTP from pjproject entirely.
+EAPI=8
+
+inherit autotools flag-o-matic toolchain-funcs
+
+DESCRIPTION="Open source SIP, Media, and NAT Traversal Library"
+HOMEPAGE="https://github.com/pjsip/pjproject https://www.pjsip.org/"
+SRC_URI="https://github.com/pjsip/${PN}/archive/refs/tags/${PV}.tar.gz -> ${P}.tar.gz"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~x86"
+
+LICENSE="GPL-2"
+SLOT="0/${PV}"
+
+# g729 not included due to special bcg729 handling.
+CODEC_FLAGS="g711 g722 g7221 gsm ilbc speex l16"
+VIDEO_FLAGS="sdl ffmpeg v4l2 openh264 libyuv vpx"
+SOUND_FLAGS="alsa portaudio"
+IUSE="amr debug epoll examples opus resample silk srtp ssl static-libs webrtc
+	${CODEC_FLAGS} g729
+	${VIDEO_FLAGS}
+	${SOUND_FLAGS}"
+
+RDEPEND="
+	alsa? ( media-libs/alsa-lib )
+	amr? ( media-libs/opencore-amr )
+	ffmpeg? ( media-video/ffmpeg:= )
+	g729? ( media-libs/bcg729 )
+	gsm? ( media-sound/gsm )
+	ilbc? ( media-libs/libilbc )
+	openh264? ( media-libs/openh264 )
+	opus? ( media-libs/opus )
+	portaudio? ( media-libs/portaudio )
+	resample? ( media-libs/libsamplerate )
+	sdl? ( media-libs/libsdl2 )
+	speex? (
+		media-libs/speex
+		media-libs/speexdsp
+	)
+	srtp? ( >=net-libs/libsrtp-2.3.0:= )
+	ssl? ( dev-libs/openssl:0= )
+"
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}/pjproject-2.13-r1-Make-sure-that-NOTIFY-tdata-is-set-before-sending-it_new.patch"
+	"${FILESDIR}/pjproject-2.13.1-fix-ptimesized-wav-input.patch"
+)
+
+src_prepare() {
+	default
+	rm configure || die "Unable to remove unwanted wrapper"
+	mv aconfigure.ac configure.ac || die "Unable to rename configure script source"
+	eautoreconf
+
+	cp "${FILESDIR}/pjproject-2.13.1-r1-config_site.h" "${S}/pjlib/include/pj/config_site.h" \
+		|| die "Unable to create config_site.h"
+}
+
+_pj_enable() {
+	usex "$1" '' "--disable-${2:-$1}"
+}
+
+_pj_get_define() {
+	local r="$(sed -nre "s/^#define[[:space:]]+$1[[:space:]]+//p" "${S}/pjlib/include/pj/config_site.h")"
+	[[ -z "${r}" ]] && die "Unable to fine #define $1 in config_site.h"
+	echo "$r"
+}
+
+_pj_set_define() {
+	local c=$(_pj_get_define "$1")
+	[[ "$c" = "$2" ]] && return 0
+	sed -re "s/^#define[[:space:]]+$1[[:space:]].*/#define $1 $2/" -i "${S}/pjlib/include/pj/config_site.h" \
+		|| die "sed failed updating $1 to $2."
+	[[ "$(_pj_get_define "$1")" != "$2" ]] && die "sed failed to perform update for $1 to $2."
+}
+
+_pj_use_set_define() {
+	_pj_set_define "$2" $(usex "$1" 1 0)
+}
+
+src_configure() {
+	local myconf=()
+	local videnable="--disable-video"
+	local t
+
+	use debug || append-cflags -DNDEBUG=1
+
+	for t in ${CODEC_FLAGS}; do
+		myconf+=( $(_pj_enable ${t} ${t}-codec) )
+	done
+	myconf+=( $(_pj_enable g729 bcg729) )
+
+	for t in ${VIDEO_FLAGS}; do
+		myconf+=( $(_pj_enable ${t}) )
+		use "${t}" && videnable="--enable-video"
+	done
+
+	[ "${videnable}" = "--enable-video" ] && _pj_set_define PJMEDIA_HAS_VIDEO 1 || _pj_set_define PJMEDIA_HAS_VIDEO 0
+
+	LD="$(tc-getCC)" econf \
+		--enable-shared \
+		${videnable} \
+		$(_pj_enable alsa sound) \
+		$(_pj_enable amr opencore-amr) \
+		$(_pj_enable epoll) \
+		$(_pj_enable opus) \
+		$(_pj_enable portaudio ext-sound) \
+		$(_pj_enable resample libsamplerate) \
+		$(_pj_enable resample resample-dll) \
+		$(_pj_enable resample) \
+		$(_pj_enable silk) \
+		$(_pj_enable speex speex-aec) \
+		$(_pj_enable ssl) \
+		$(_pj_enable webrtc libwebrtc) \
+		$(use_with gsm external-gsm) \
+		$(use_with portaudio external-pa) \
+		$(use_with speex external-speex) \
+		$(usex srtp --with-external-srtp --disable-libsrtp) \
+		"${myconf[@]}"
+}
+
+src_compile() {
+	emake dep LD="$(tc-getCC)"
+	emake LD="$(tc-getCC)"
+}
+
+src_install() {
+	default
+
+	newbin pjsip-apps/bin/pjsua-${CHOST} pjsua
+	newbin pjsip-apps/bin/pjsystest-${CHOST} pjsystest
+
+	if use examples; then
+		insinto "/usr/share/doc/${PF}/examples"
+		doins -r pjsip-apps/src/samples
+	fi
+
+	use static-libs || rm "${ED}/usr/$(get_libdir)"/*.a || die "Error removing static archives"
+}

--- a/profiles/arch/sparc/package.use.mask
+++ b/profiles/arch/sparc/package.use.mask
@@ -2,7 +2,9 @@
 # Distributed under the terms of the GNU General Public License v2
 
 # Jaco Kroon <jaco@uls.co.za> (2024-01-09)
-# net-misc/asterisk[srtp] depends on net-libs/libsrtp which is -sparc.
+# net-libs/pjproject[srtp] and net-misc/asterisk[srtp] depends on
+# net-libs/libsrtp which is -sparc.
+net-libs/pjproject srtp
 net-misc/asterisk srtp
 
 # Sam James <sam@gentoo.org> (2024-01-05)


### PR DESCRIPTION
Bump to make linking in libsrtp optional so we can keyword asterisk for sparc.

Bug: https://bugs.gentoo.org/919424