### PR TITLE
dev-libs/rocm-opencl-runtime: fix linker error for ld.lld: error: version script assignment issue

### DIFF
--- a/dev-libs/rocm-opencl-runtime/rocm-opencl-runtime-5.1.3.ebuild
+++ b/dev-libs/rocm-opencl-runtime/rocm-opencl-runtime-5.1.3.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-inherit cmake edo flag-o-matic prefix
+inherit cmake edo flag-o-matic toolchain-funcs prefix
 
 DESCRIPTION="Radeon Open Compute OpenCL Compatible Runtime"
 HOMEPAGE="https://github.com/RadeonOpenCompute/ROCm-OpenCL-Runtime"
@@ -59,6 +59,14 @@ src_prepare() {
 }
 
 src_configure() {
+	# Fix ld.lld linker error: https://github.com/RadeonOpenCompute/ROCm-OpenCL-Runtime/issues/155
+	# ideally we want !tc-ld-is-bfd for best future-proofing, but it needs
+	# https://github.com/gentoo/gentoo/pull/28355
+	# mold needs this too but right now tc-ld-is-mold is also not available
+	if tc-ld-is-lld; then
+		append-ldflags -Wl,--undefined-version
+	fi
+
 	# Reported upstream: https://github.com/RadeonOpenCompute/ROCm-OpenCL-Runtime/issues/120
 	append-cflags -fcommon
 

--- a/dev-libs/rocm-opencl-runtime/rocm-opencl-runtime-5.3.3-r1.ebuild
+++ b/dev-libs/rocm-opencl-runtime/rocm-opencl-runtime-5.3.3-r1.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-inherit cmake edo flag-o-matic
+inherit cmake edo flag-o-matic toolchain-funcs
 
 DESCRIPTION="Radeon Open Compute OpenCL Compatible Runtime"
 HOMEPAGE="https://github.com/RadeonOpenCompute/ROCm-OpenCL-Runtime"
@@ -46,6 +46,14 @@ src_prepare() {
 }
 
 src_configure() {
+	# Fix ld.lld linker error: https://github.com/RadeonOpenCompute/ROCm-OpenCL-Runtime/issues/155
+	# ideally we want !tc-ld-is-bfd for best future-proofing, but it needs
+	# https://github.com/gentoo/gentoo/pull/28355
+	# mold needs this too but right now tc-ld-is-mold is also not available
+	if tc-ld-is-lld; then
+		append-ldflags -Wl,--undefined-version
+	fi
+
 	# Reported upstream: https://github.com/RadeonOpenCompute/ROCm-OpenCL-Runtime/issues/120
 	append-cflags -fcommon
 

--- a/dev-libs/rocm-opencl-runtime/rocm-opencl-runtime-5.4.3-r1.ebuild
+++ b/dev-libs/rocm-opencl-runtime/rocm-opencl-runtime-5.4.3-r1.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-inherit cmake edo flag-o-matic
+inherit cmake edo flag-o-matic toolchain-funcs
 
 DESCRIPTION="Radeon Open Compute OpenCL Compatible Runtime"
 HOMEPAGE="https://github.com/RadeonOpenCompute/ROCm-OpenCL-Runtime"
@@ -53,6 +53,14 @@ if [[ ${PV} == "9999" ]]; then
 	fi
 }
 src_prepare() {
+	# Fix ld.lld linker error: https://github.com/RadeonOpenCompute/ROCm-OpenCL-Runtime/issues/155
+	# ideally we want !tc-ld-is-bfd for best future-proofing, but it needs
+	# https://github.com/gentoo/gentoo/pull/28355
+	# mold needs this too but right now tc-ld-is-mold is also not available
+	if tc-ld-is-lld; then
+		append-ldflags -Wl,--undefined-version
+	fi
+
 	cmake_src_prepare
 
 	pushd ${CLR_S} || die

--- a/dev-libs/rocm-opencl-runtime/rocm-opencl-runtime-5.5.1.ebuild
+++ b/dev-libs/rocm-opencl-runtime/rocm-opencl-runtime-5.5.1.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-inherit cmake edo flag-o-matic
+inherit cmake edo flag-o-matic toolchain-funcs
 
 DESCRIPTION="Radeon Open Compute OpenCL Compatible Runtime"
 HOMEPAGE="https://github.com/RadeonOpenCompute/ROCm-OpenCL-Runtime"
@@ -61,6 +61,14 @@ src_prepare() {
 }
 
 src_configure() {
+	# Fix ld.lld linker error: https://github.com/RadeonOpenCompute/ROCm-OpenCL-Runtime/issues/155
+	# ideally we want !tc-ld-is-bfd for best future-proofing, but it needs
+	# https://github.com/gentoo/gentoo/pull/28355
+	# mold needs this too but right now tc-ld-is-mold is also not available
+	if tc-ld-is-lld; then
+		append-ldflags -Wl,--undefined-version
+	fi
+
 	# Reported upstream: https://github.com/RadeonOpenCompute/ROCm-OpenCL-Runtime/issues/120
 	append-cflags -fcommon
 

--- a/dev-libs/rocm-opencl-runtime/rocm-opencl-runtime-5.7.1-r1.ebuild
+++ b/dev-libs/rocm-opencl-runtime/rocm-opencl-runtime-5.7.1-r1.ebuild
@@ -1,10 +1,10 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
 ROCM_SKIP_GLOBALS=1
-inherit cmake edo flag-o-matic rocm
+inherit cmake edo flag-o-matic toolchain-funcs rocm
 
 DESCRIPTION="Radeon Open Compute OpenCL Compatible Runtime"
 HOMEPAGE="https://github.com/ROCm-Developer-Tools/clr"
@@ -48,6 +48,14 @@ OB		git-r3_checkout
 }
 
 src_configure() {
+	# Fix ld.lld linker error: https://github.com/RadeonOpenCompute/ROCm-OpenCL-Runtime/issues/155
+	# ideally we want !tc-ld-is-bfd for best future-proofing, but it needs
+	# https://github.com/gentoo/gentoo/pull/28355
+	# mold needs this too but right now tc-ld-is-mold is also not available
+	if tc-ld-is-lld; then
+		append-ldflags -Wl,--undefined-version
+	fi
+
 	# Reported upstream: https://github.com/RadeonOpenCompute/ROCm-OpenCL-Runtime/issues/120
 	append-cflags -fcommon
 

--- a/dev-libs/rocm-opencl-runtime/rocm-opencl-runtime-6.0.0.ebuild
+++ b/dev-libs/rocm-opencl-runtime/rocm-opencl-runtime-6.0.0.ebuild
@@ -1,10 +1,10 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
 ROCM_SKIP_GLOBALS=1
-inherit cmake edo flag-o-matic rocm
+inherit cmake edo flag-o-matic toolchain-funcs rocm
 
 DESCRIPTION="Radeon Open Compute OpenCL Compatible Runtime"
 HOMEPAGE="https://github.com/ROCm-Developer-Tools/clr"
@@ -48,6 +48,14 @@ OB		git-r3_checkout
 }
 
 src_configure() {
+	# Fix ld.lld linker error: https://github.com/RadeonOpenCompute/ROCm-OpenCL-Runtime/issues/155
+	# ideally we want !tc-ld-is-bfd for best future-proofing, but it needs
+	# https://github.com/gentoo/gentoo/pull/28355
+	# mold needs this too but right now tc-ld-is-mold is also not available
+	if tc-ld-is-lld; then
+		append-ldflags -Wl,--undefined-version
+	fi
+
 	# Reported upstream: https://github.com/RadeonOpenCompute/ROCm-OpenCL-Runtime/issues/120
 	append-cflags -fcommon
 

--- a/dev-libs/rocm-opencl-runtime/rocm-opencl-runtime-9999.ebuild
+++ b/dev-libs/rocm-opencl-runtime/rocm-opencl-runtime-9999.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-inherit cmake edo flag-o-matic
+inherit cmake edo flag-o-matic toolchain-funcs
 
 DESCRIPTION="Radeon Open Compute OpenCL Compatible Runtime"
 HOMEPAGE="https://github.com/RadeonOpenCompute/ROCm-OpenCL-Runtime"
@@ -59,6 +59,14 @@ src_prepare() {
 }
 
 src_configure() {
+	# Fix ld.lld linker error: https://github.com/RadeonOpenCompute/ROCm-OpenCL-Runtime/issues/155
+	# ideally we want !tc-ld-is-bfd for best future-proofing, but it needs
+	# https://github.com/gentoo/gentoo/pull/28355
+	# mold needs this too but right now tc-ld-is-mold is also not available
+	if tc-ld-is-lld; then
+		append-ldflags -Wl,--undefined-version
+	fi
+
 	# Reported upstream: https://github.com/RadeonOpenCompute/ROCm-OpenCL-Runtime/issues/120
 	append-cflags -fcommon
 


### PR DESCRIPTION
Upstream bug: https://github.com/RadeonOpenCompute/ROCm-OpenCL-Runtime/issues/155

Fix is needed for all ebuilds for ld.lld 17.x linker.
Used common approach from https://github.com/search?q=repo%3Agentoo%2Fgentoo%20ideally%20we%20want%20!tc-ld-is-bfd%20for%20best%20future-proofing&type=code