### PR TITLE
app-emulation/cloud-init: Update test deps

### DIFF
--- a/app-emulation/cloud-init/cloud-init-23.4.ebuild
+++ b/app-emulation/cloud-init/cloud-init-23.4.ebuild
@@ -40,8 +40,8 @@ CDEPEND="
 BDEPEND="
 	${CDEPEND}
 	test? (
-		>=dev-python/httpretty-0.7.1[${PYTHON_USEDEP}]
 		dev-python/mock[${PYTHON_USEDEP}]
+		dev-python/passlib[${PYTHON_USEDEP}]
 		dev-python/pytest-mock[${PYTHON_USEDEP}]
 		dev-python/responses[${PYTHON_USEDEP}]
 		dev-python/setuptools[${PYTHON_USEDEP}]

--- a/app-emulation/cloud-init/cloud-init-9999.ebuild
+++ b/app-emulation/cloud-init/cloud-init-9999.ebuild
@@ -39,8 +39,8 @@ CDEPEND="
 BDEPEND="
 	${CDEPEND}
 	test? (
-		>=dev-python/httpretty-0.7.1[${PYTHON_USEDEP}]
 		dev-python/mock[${PYTHON_USEDEP}]
+		dev-python/passlib[${PYTHON_USEDEP}]
 		dev-python/pytest-mock[${PYTHON_USEDEP}]
 		dev-python/responses[${PYTHON_USEDEP}]
 		dev-python/setuptools[${PYTHON_USEDEP}]


### PR DESCRIPTION
Passlib was added as a test dependency in 23.3. It will be a runtime dependency on python >= 3.12, where the crypt module is removed.

Httpretty was dropped as a test dependency in 22.4.