### PR TITLE
net-proxy/tayga: add myself as a maintainer & Fix "incompatible pointer to integer conversion" 

### DIFF
--- a/net-proxy/tayga/files/tayga-0.9.2-static-EAM.patch
+++ b/net-proxy/tayga/files/tayga-0.9.2-static-EAM.patch
@@ -4,7 +4,7 @@ Description: Support SIIT-DC styled EAM static maps
  .
 Author: Benda Xu <heroxbd@gentoo.org>
 Forwarded: Nathan Lutchansky <lutchann@litech.org>
-Last-Update: 2018-12-28
+Last-Update: 2024-01-09
 
 --- a/conffile.c
 +++ b/conffile.c
@@ -17,7 +17,7 @@ Last-Update: 2018-12-28
 +	unsigned int prefix4 = 32;
 +	if (slash) {
 +		prefix4 = atoi(slash+1);
-+		slash[0] = NULL;
++		slash[0] = '\0';
 +	}
 +
  	if (!inet_pton(AF_INET, args[0], &m->map4.addr)) {
@@ -33,7 +33,7 @@ Last-Update: 2018-12-28
 +	slash = strchr(args[1], '/');
 +	if (slash) {
 +		prefix6 = atoi(slash+1);
-+		slash[0] = NULL;
++		slash[0] = '\0';
 +	}
 +
 +	if ((32 - prefix4) != (128 - prefix6)) {

--- a/net-proxy/tayga/metadata.xml
+++ b/net-proxy/tayga/metadata.xml
@@ -1,8 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<maintainer type="person">
-<email>heroxbd@gentoo.org</email>
-<name>Benda Xu</name>
-</maintainer>
+	<maintainer type="person" proxied="yes">
+		<email>zhuyifei1999@gmail.com</email>
+		<name>YiFei Zhu</name>
+	</maintainer>
+	<maintainer type="person">
+		<email>heroxbd@gentoo.org</email>
+		<name>Benda Xu</name>
+	</maintainer>
+	<maintainer type="project" proxied="proxy">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
 </pkgmetadata>

--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -93,11 +93,6 @@ app-misc/utimer
 sys-block/noflushd
 
 # Michał Górny <mgorny@gentoo.org> (2023-12-31)
-# Buggy code that carries local patches already.  Last release in 2011.
-# Removal on 2024-01-30.  Bug #878629.
-net-proxy/tayga
-
-# Michał Górny <mgorny@gentoo.org> (2023-12-31)
 # Buggy code that carries local patches already.  The ebuild installs
 # junk files.  No upstream activity since 2009.
 # Removal on 2024-01-30.  Bug #874087.


### PR DESCRIPTION
This is two commits to fix https://bugs.gentoo.org/878629, one to add myself to maintainers and remove last-rite, and one to actually fix the bug.

The reason I need this package is that is a dependency of `net-misc/clatd::guru`, and I need `net-misc/clatd` to access the IPv4 internet in my IPv6-only workplace. Happy to proxy maintain this package.