### PR TITLE
x11-libs/libxklavier: Remove undefined symbol

### DIFF
--- a/x11-libs/libxklavier/files/clang-17.patch
+++ b/x11-libs/libxklavier/files/clang-17.patch
@@ -1,0 +1,14 @@
+--- ./libxklavier/libxklavier.public.old	2024-01-10 18:54:48.527283381 -0500
++++ ./libxklavier/libxklavier.public	2024-01-10 18:54:56.486180329 -0500
+@@ -81,11 +81,10 @@ xkl_engine_set_secondary_groups_mask
+ xkl_engine_set_window_transparent
+ xkl_engine_start_listen
+ xkl_engine_state_change_get_type
+ xkl_engine_stop_listen
+ xkl_engine_ungrab_key
+-xkl_engine_VOID__FLAGS_INT_BOOLEAN
+ xkl_engine_VOID__ENUM_INT_BOOLEAN
+ xkl_get_country_name
+ xkl_get_language_name
+ xkl_get_last_error
+ xkl_restore_names_prop

--- a/x11-libs/libxklavier/libxklavier-5.4-r1.ebuild
+++ b/x11-libs/libxklavier/libxklavier-5.4-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -34,6 +34,8 @@ BDEPEND="
 	virtual/pkgconfig
 	vala? ( $(vala_depend) )
 "
+
+PATCHES=( "${FILESDIR}"/clang-17.patch )
 
 src_prepare() {
 	default


### PR DESCRIPTION
Symbol xkl_engine_VOID__FLAGS_INT_BOOLEAN is not defined. Upstream is dead per https://www.freedesktop.org/wiki/Software/LibXklavier/.

This change allows libxklavier to build with clang-17 by deleting the undefined symbol from the version symbol map.

Despite upstream status, the following packages still depend on libxklavier:

    app-accessibility/caribou
    dev-libs/eekboard
    dev-libs/input-pad
    gnome-base/libgnomekbd
    gnome-extra/cinnamon-control-center
    gnome-extra/cinnamon-settings-daemon
    mate-base/libmatekbd
    mate-base/mate-control-center
    mate-base/mate-settings-daemon
    mate-extra/mate-screensaver
    x11-misc/lightdm
    xfce-base/xfce4-settings
    xfce-extra/xfce4-screensaver
    xfce-extra/xfce4-xkb-plugin

Fixes Gentoo bug 915208