### PR TITLE
games-engines/renpy: Add missing dependency on dev-python/future

### DIFF
--- a/games-engines/renpy/renpy-8.1.3-r1.ebuild
+++ b/games-engines/renpy/renpy-8.1.3-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -28,6 +28,7 @@ DEPEND="
 		>=dev-python/pygame_sdl2-8.1.1[${PYTHON_USEDEP}]
 		>=dev-lang/python-exec-0.3[${PYTHON_USEDEP}]
 		dev-python/ecdsa[${PYTHON_USEDEP}]
+		dev-python/future[${PYTHON_USEDEP}]
 	')
 	media-libs/glew:0
 	media-libs/libpng:0


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/921026
Signed-off-by: Haelwenn (lanodan) Monnier <contact@hacktivis.me>
