### PR TITLE
app-containers/containers-common: update live

### DIFF
--- a/app-containers/containers-common/containers-common-9999.ebuild
+++ b/app-containers/containers-common/containers-common-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -52,14 +52,6 @@ src_compile() {
 
 src_install() {
 	emake DESTDIR="${ED}" install
-
-	insinto /etc/containers
-	# https://github.com/containers/skopeo/raw/main/default-policy.json
-	doins pkg/config/containers.conf "${FILESDIR}/policy.json"
-
-	insinto /etc/containers/registries.d
-	# https://github.com/containers/skopeo/raw/main/default.yaml
-	doins "${FILESDIR}/default.yaml"
 
 	insinto /usr/share/containers
 	doins pkg/seccomp/seccomp.json pkg/subscriptions/mounts.conf


### PR DESCRIPTION
Because of upstream changes policy.json and default.yaml has to be moved from containers-common to containers-image

Upstream commit: https://github.com/containers/image/commit/45441676e34e6410ae8af6dbb46b6161c5c81a7c