### PR TITLE
app-shells/smrsh: EAPI8 bump, fix bug #722438

### DIFF
--- a/app-shells/smrsh/smrsh-8.15.2-r1.ebuild
+++ b/app-shells/smrsh/smrsh-8.15.2-r1.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 inherit toolchain-funcs
 
@@ -35,7 +35,7 @@ src_prepare() {
 
 src_compile() {
 	cd "${S}/${PN}" || die
-	/bin/sh Build || die
+	/bin/sh Build AR="$(tc-getAR)" RANLIB="$(tc-getRANLIB)" || die
 }
 
 src_install() {


### PR DESCRIPTION
Simple `EAPI8` bump and bugfix for app-shells/smrsh.
Please note that bug https://bugs.gentoo.org/729558 could probably be closed too because afaics it's a duplicate of #722438

Signed-off-by: Michael Mair-Keimberger <mmk@levelnine.at>

Closes: https://bugs.gentoo.org/722438