### PR TITLE
mail-filter/bmf: EAPI8 bump, fixes bug #724662, #727634

### DIFF
--- a/mail-filter/bmf/bmf-0.9.4-r4.ebuild
+++ b/mail-filter/bmf/bmf-0.9.4-r4.ebuild
@@ -1,0 +1,55 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs
+
+DESCRIPTION="Fast and small Bayesian spam filter"
+HOMEPAGE="https://sourceforge.net/projects/bmf/"
+SRC_URI="mirror://sourceforge/bmf/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86"
+IUSE="mysql berkdb"
+
+DEPEND="
+	mysql? ( dev-db/mysql-connector-c:0= )
+	berkdb? ( >=sys-libs/db-3.2.9:= )"
+RDEPEND="${DEPEND}"
+
+PATCHES=( "${FILESDIR}/${P}_QA.patch" )
+
+src_prepare() {
+	# respect CFLAGS/LDFLAGS/CC
+	sed -i \
+		-e '/D_LINUX/s/CFLAGS="$CCDBG/CFLAGS+=" $CCDBG/' \
+		-e 's/LDFLAGS="$LDDBG/LDFLAGS+=" $LDDBG/' \
+		-e "s/CC=gcc/CC=$(tc-getCC)/" \
+		"${S}/configure" || die
+
+	# include mysql headers
+	sed -i -e '/HAVE_MYSQL/s/HAVE_MYSQL/HAVE_MYSQL `mysql_config --include`/' \
+		"${S}/configure" || die
+
+	# We don't need to be root to run install
+	sed -i -e 's/install: checkroot bmf/install: bmf/' Makefile.in || die
+
+	default
+}
+
+src_configure() {
+	# this is not an autotools script
+	./configure \
+		$(use_with mysql) \
+		$(use_with berkdb libdb) || die
+}
+
+pkg_postinst() {
+	elog
+	elog "Important: Remember to train bmf before you start using it."
+	elog "See the README file for further instructions on training and using bmf"
+	elog "with procmail."
+	elog
+}


### PR DESCRIPTION
Another `EAPI8` bump and some fixes:

```diff
--- bmf-0.9.4-r3.ebuild	2024-01-11 21:38:14.267603493 +0100
+++ bmf-0.9.4-r4.ebuild	2024-01-13 15:54:06.230705324 +0100
@@ -1,29 +1,32 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
-inherit toolchain-funcs
+EAPI=8
 
-IUSE="mysql berkdb"
+inherit toolchain-funcs
 
-DESCRIPTION="A fast and small Bayesian spam filter"
-HOMEPAGE="http://bmf.sourceforge.net/"
+DESCRIPTION="Fast and small Bayesian spam filter"
+HOMEPAGE="https://sourceforge.net/projects/bmf/"
 SRC_URI="mirror://sourceforge/bmf/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 ~ppc x86"
+KEYWORDS="~amd64 ~ppc ~x86"
+IUSE="mysql berkdb"
 
-DEPEND="mysql? ( dev-db/mysql-connector-c:0= )
-	berkdb? ( >=sys-libs/db-3.2.9 )"
+DEPEND="
+	mysql? ( dev-db/mysql-connector-c:0= )
+	berkdb? ( >=sys-libs/db-3.2.9:= )"
 RDEPEND="${DEPEND}"
 
 PATCHES=( "${FILESDIR}/${P}_QA.patch" )
-DOCS=( README AUTHORS ChangeLog )
 
 src_prepare() {
-	# respect CFLAGS
-	sed -i -e '/D_LINUX/s/CFLAGS="$CCDBG/CFLAGS+=" $CCDBG/' \
+	# respect CFLAGS/LDFLAGS/CC
+	sed -i \
+		-e '/D_LINUX/s/CFLAGS="$CCDBG/CFLAGS+=" $CCDBG/' \
+		-e 's/LDFLAGS="$LDDBG/LDFLAGS+=" $LDDBG/' \
+		-e "s/CC=gcc/CC=$(tc-getCC)/" \
 		"${S}/configure" || die
 
 	# include mysql headers
@@ -43,10 +46,6 @@
 		$(use_with berkdb libdb) || die
 }
 
-src_compile() {
-	emake CC="$(tc-getCC)"
-}
-
 pkg_postinst() {
 	elog
 	elog "Important: Remember to train bmf before you start using it."
```

Signed-off-by: Michael Mair-Keimberger <mmk@levelnine.at>

Closes: https://bugs.gentoo.org/724662
Closes: https://bugs.gentoo.org/727634