### PR TITLE
sys-apps/systemd: enable kernel-install by default, drop dummy config

### DIFF
--- a/sys-apps/systemd/systemd-254.5-r2.ebuild
+++ b/sys-apps/systemd/systemd-254.5-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2011-2023 Gentoo Authors
+# Copyright 2011-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -23,14 +23,11 @@ else
 	MY_P=${MY_PN}-${MY_PV}
 	S=${WORKDIR}/${MY_P}
 	SRC_URI="https://github.com/systemd/${MY_PN}/archive/v${MY_PV}/${MY_P}.tar.gz"
-
-	if [[ ${PV} != *rc* ]] ; then
-		KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
-	fi
+	KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86"
 fi
 
 inherit bash-completion-r1 linux-info meson-multilib pam python-single-r1
-inherit secureboot systemd toolchain-funcs udev
+inherit secureboot systemd toolchain-funcs udev usr-ldscript
 
 DESCRIPTION="System and service manager for Linux"
 HOMEPAGE="http://systemd.io/"
@@ -39,7 +36,7 @@ LICENSE="GPL-2 LGPL-2.1 MIT public-domain"
 SLOT="0/2"
 IUSE="
 	acl apparmor audit boot cgroup-hybrid cryptsetup curl +dns-over-tls elfutils
-	fido2 +gcrypt gnutls homed http idn importd iptables kernel-install +kmod
+	fido2 +gcrypt gnutls homed http idn importd iptables +kernel-install +kmod
 	+lz4 lzma +openssl pam pcre pkcs11 policykit pwquality qrcode
 	+resolvconf +seccomp selinux split-usr +sysv-utils test tpm ukify vanilla xkb +zstd
 "
@@ -58,14 +55,14 @@ RESTRICT="!test? ( test )"
 MINKV="4.15"
 
 COMMON_DEPEND="
-	>=sys-apps/util-linux-2.32:0=[${MULTILIB_USEDEP}]
+	>=sys-apps/util-linux-2.30:0=[${MULTILIB_USEDEP}]
 	sys-libs/libcap:0=[${MULTILIB_USEDEP}]
 	virtual/libcrypt:=[${MULTILIB_USEDEP}]
 	acl? ( sys-apps/acl:0= )
-	apparmor? ( >=sys-libs/libapparmor-2.13:0= )
+	apparmor? ( sys-libs/libapparmor:0= )
 	audit? ( >=sys-process/audit-2:0= )
 	cryptsetup? ( >=sys-fs/cryptsetup-2.0.1:0= )
-	curl? ( >=net-misc/curl-7.32.0:0= )
+	curl? ( net-misc/curl:0= )
 	elfutils? ( >=dev-libs/elfutils-0.158:0= )
 	fido2? ( dev-libs/libfido2:0= )
 	gcrypt? ( >=dev-libs/libgcrypt-1.4.5:0=[${MULTILIB_USEDEP}] )
@@ -82,12 +79,12 @@ COMMON_DEPEND="
 	iptables? ( net-firewall/iptables:0= )
 	openssl? ( >=dev-libs/openssl-1.1.0:0= )
 	pam? ( sys-libs/pam:=[${MULTILIB_USEDEP}] )
-	pkcs11? ( >=app-crypt/p11-kit-0.23.3:0= )
+	pkcs11? ( app-crypt/p11-kit:0= )
 	pcre? ( dev-libs/libpcre2 )
-	pwquality? ( >=dev-libs/libpwquality-1.4.1:0= )
-	qrcode? ( >=media-gfx/qrencode-3:0= )
+	pwquality? ( dev-libs/libpwquality:0= )
+	qrcode? ( media-gfx/qrencode:0= )
 	seccomp? ( >=sys-libs/libseccomp-2.3.3:0= )
-	selinux? ( >=sys-libs/libselinux-2.1.9:0= )
+	selinux? ( sys-libs/libselinux:0= )
 	tpm? ( app-crypt/tpm2-tss:0= )
 	xkb? ( >=x11-libs/libxkbcommon-0.4.1:0= )
 	zstd? ( >=app-arch/zstd-1.4.0:0=[${MULTILIB_USEDEP}] )
@@ -184,11 +181,6 @@ QA_FLAGS_IGNORED="usr/lib/systemd/boot/efi/.*"
 QA_EXECSTACK="usr/lib/systemd/boot/efi/*"
 
 pkg_pretend() {
-	if use split-usr; then
-		eerror "Please complete the migration to merged-usr."
-		eerror "https://wiki.gentoo.org/wiki/Merge-usr"
-		die "systemd no longer supports split-usr"
-	fi
 	if [[ ${MERGE_TYPE} != buildonly ]]; then
 		if use test && has pid-sandbox ${FEATURES}; then
 			ewarn "Tests are known to fail with PID sandboxing enabled."
@@ -248,6 +240,7 @@ src_unpack() {
 
 src_prepare() {
 	local PATCHES=(
+		"${FILESDIR}/systemd-253-initrd-generators.patch"
 	)
 
 	if ! use vanilla; then
@@ -256,6 +249,9 @@ src_prepare() {
 			"${FILESDIR}/gentoo-journald-audit-r1.patch"
 		)
 	fi
+
+	# Fails with split-usr.
+	sed -i -e '2i exit 77' test/test-rpm-macros.sh || die
 
 	default
 }
@@ -272,13 +268,14 @@ src_configure() {
 multilib_src_configure() {
 	local myconf=(
 		--localstatedir="${EPREFIX}/var"
-		# default is developer, bug 918671
-		-Dmode=release
 		-Dsupport-url="https://gentoo.org/support/"
 		-Dpamlibdir="$(getpam_mod_dir)"
 		# avoid bash-completion dep
 		-Dbashcompletiondir="$(get_bashcompdir)"
-		-Dsplit-bin=false
+		$(meson_use split-usr)
+		$(meson_use split-usr split-bin)
+		-Drootprefix="$(usex split-usr "${EPREFIX:-/}" "${EPREFIX}/usr")"
+		-Drootlibdir="${EPREFIX}/usr/$(get_libdir)"
 		# Disable compatibility with sysvinit
 		-Dsysvinit-path=
 		-Dsysvrcnd-path=
@@ -350,7 +347,6 @@ multilib_src_configure() {
 		$(meson_native_true timesyncd)
 		$(meson_native_true tmpfiles)
 		$(meson_native_true vconsole)
-		$(meson_native_enabled vmspawn)
 	)
 
 	meson_src_configure "${myconf[@]}"
@@ -363,6 +359,9 @@ multilib_src_test() {
 }
 
 multilib_src_install_all() {
+	local rootprefix=$(usex split-usr '' /usr)
+	local sbin=$(usex split-usr sbin bin)
+
 	# meson doesn't know about docdir
 	mv "${ED}"/usr/share/doc/{systemd,${PF}} || die
 
@@ -373,11 +372,11 @@ multilib_src_install_all() {
 	doins "${FILESDIR}"/legacy.conf
 
 	if ! use resolvconf; then
-		rm -f "${ED}"/usr/bin/resolvconf || die
+		rm -f "${ED}${rootprefix}/${sbin}"/resolvconf || die
 	fi
 
 	if ! use sysv-utils; then
-		rm "${ED}"/usr/bin/{halt,init,poweroff,reboot,shutdown} || die
+		rm "${ED}${rootprefix}/${sbin}"/{halt,init,poweroff,reboot,shutdown} || die
 		rm "${ED}"/usr/share/man/man1/init.1 || die
 		rm "${ED}"/usr/share/man/man8/{halt,poweroff,reboot,shutdown}.8 || die
 	fi
@@ -393,7 +392,7 @@ multilib_src_install_all() {
 
 	keepdir /etc/udev/hwdb.d
 
-	keepdir /usr/lib/systemd/{system-sleep,system-shutdown}
+	keepdir "${rootprefix}"/lib/systemd/{system-sleep,system-shutdown}
 	keepdir /usr/lib/{binfmt.d,modules-load.d}
 	keepdir /usr/lib/systemd/user-generators
 	keepdir /var/lib/systemd
@@ -401,6 +400,19 @@ multilib_src_install_all() {
 
 	if use pam; then
 		newpamd "${FILESDIR}"/systemd-user.pam systemd-user
+	fi
+
+	if use split-usr; then
+		# Avoid breaking boot/reboot
+		dosym ../../../lib/systemd/systemd /usr/lib/systemd/systemd
+		dosym ../../../lib/systemd/systemd-shutdown /usr/lib/systemd/systemd-shutdown
+	fi
+
+	gen_usr_ldscript -a systemd udev
+
+	if use kernel-install; then
+		# Dummy config, remove to make room for sys-kernel/installkernel
+		rm "${ED}/usr/lib/kernel/install.conf" || die
 	fi
 
 	use ukify && python_fix_shebang "${ED}"
@@ -457,6 +469,20 @@ pkg_preinst() {
 		dosym ../../../etc/sysctl.conf /usr/lib/sysctl.d/99-sysctl.conf
 	fi
 
+	if ! use split-usr; then
+		local dir
+		for dir in bin sbin lib usr/sbin; do
+			if [[ ! -L ${EROOT}/${dir} ]]; then
+				eerror "'${EROOT}/${dir}' is not a symbolic link."
+				FAIL=1
+			fi
+		done
+		if [[ ${FAIL} ]]; then
+			eerror "Migration to system layout with merged directories must be performed before"
+			eerror "installing ${CATEGORY}/${PN} with USE=\"-split-usr\" to avoid run-time breakage."
+			die "System layout with split directories still used"
+		fi
+	fi
 	if ! use boot && has_version "sys-apps/systemd[gnuefi(-)]"; then
 		ewarn "The 'gnuefi' USE flag has been renamed to 'boot'."
 		ewarn "Make sure to enable the 'boot' USE flag if you use systemd-boot."
@@ -486,12 +512,6 @@ pkg_postinst() {
 
 	if [[ -L ${EROOT}/var/lib/systemd/timesync ]]; then
 		rm "${EROOT}/var/lib/systemd/timesync"
-	fi
-
-	if [[ -z ${ROOT} && -d /run/systemd/system ]]; then
-		ebegin "Reexecuting system manager (systemd)"
-		systemctl daemon-reexec
-		eend $? || FAIL=1
 	fi
 
 	if [[ ${FAIL} ]]; then

--- a/sys-apps/systemd/systemd-254.7-r1.ebuild
+++ b/sys-apps/systemd/systemd-254.7-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2011-2023 Gentoo Authors
+# Copyright 2011-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -23,7 +23,7 @@ else
 	MY_P=${MY_PN}-${MY_PV}
 	S=${WORKDIR}/${MY_P}
 	SRC_URI="https://github.com/systemd/${MY_PN}/archive/v${MY_PV}/${MY_P}.tar.gz"
-	KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86"
+	KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86"
 fi
 
 inherit bash-completion-r1 linux-info meson-multilib pam python-single-r1
@@ -36,7 +36,7 @@ LICENSE="GPL-2 LGPL-2.1 MIT public-domain"
 SLOT="0/2"
 IUSE="
 	acl apparmor audit boot cgroup-hybrid cryptsetup curl +dns-over-tls elfutils
-	fido2 +gcrypt gnutls homed http idn importd iptables kernel-install +kmod
+	fido2 +gcrypt gnutls homed http idn importd iptables +kernel-install +kmod
 	+lz4 lzma +openssl pam pcre pkcs11 policykit pwquality qrcode
 	+resolvconf +seccomp selinux split-usr +sysv-utils test tpm ukify vanilla xkb +zstd
 "
@@ -409,6 +409,11 @@ multilib_src_install_all() {
 	fi
 
 	gen_usr_ldscript -a systemd udev
+
+	if use kernel-install; then
+		# Dummy config, remove to make room for sys-kernel/installkernel
+		rm "${ED}/usr/lib/kernel/install.conf" || die
+	fi
 
 	use ukify && python_fix_shebang "${ED}"
 	use boot && secureboot_auto_sign

--- a/sys-apps/systemd/systemd-254.8-r1.ebuild
+++ b/sys-apps/systemd/systemd-254.8-r1.ebuild
@@ -36,7 +36,7 @@ LICENSE="GPL-2 LGPL-2.1 MIT public-domain"
 SLOT="0/2"
 IUSE="
 	acl apparmor audit boot cgroup-hybrid cryptsetup curl +dns-over-tls elfutils
-	fido2 +gcrypt gnutls homed http idn importd iptables kernel-install +kmod
+	fido2 +gcrypt gnutls homed http idn importd iptables +kernel-install +kmod
 	+lz4 lzma +openssl pam pcre pkcs11 policykit pwquality qrcode
 	+resolvconf +seccomp selinux split-usr +sysv-utils test tpm ukify vanilla xkb +zstd
 "
@@ -410,6 +410,11 @@ multilib_src_install_all() {
 	fi
 
 	gen_usr_ldscript -a systemd udev
+
+	if use kernel-install; then
+		# Dummy config, remove to make room for sys-kernel/installkernel
+		rm "${ED}/usr/lib/kernel/install.conf" || die
+	fi
 
 	use ukify && python_fix_shebang "${ED}"
 	use boot && secureboot_auto_sign

--- a/sys-apps/systemd/systemd-9999.ebuild
+++ b/sys-apps/systemd/systemd-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2011-2023 Gentoo Authors
+# Copyright 2011-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -39,7 +39,7 @@ LICENSE="GPL-2 LGPL-2.1 MIT public-domain"
 SLOT="0/2"
 IUSE="
 	acl apparmor audit boot cgroup-hybrid cryptsetup curl +dns-over-tls elfutils
-	fido2 +gcrypt gnutls homed http idn importd iptables kernel-install +kmod
+	fido2 +gcrypt gnutls homed http idn importd iptables +kernel-install +kmod
 	+lz4 lzma +openssl pam pcre pkcs11 policykit pwquality qrcode
 	+resolvconf +seccomp selinux split-usr +sysv-utils test tpm ukify vanilla xkb +zstd
 "
@@ -401,6 +401,11 @@ multilib_src_install_all() {
 
 	if use pam; then
 		newpamd "${FILESDIR}"/systemd-user.pam systemd-user
+	fi
+
+	if use kernel-install; then
+		# Dummy config, remove to make room for sys-kernel/installkernel
+		rm "${ED}/usr/lib/kernel/install.conf" || die
 	fi
 
 	use ukify && python_fix_shebang "${ED}"

--- a/sys-kernel/installkernel/installkernel-15-r1.ebuild
+++ b/sys-kernel/installkernel/installkernel-15-r1.ebuild
@@ -89,7 +89,7 @@ src_install() {
 		fi
 	fi
 
-	insinto /etc/kernel
+	insinto /usr/lib/kernel
 	doins "${T}/install.conf"
 
 	exeinto /usr/lib/kernel/install.d


### PR DESCRIPTION
On systemd profiles `sys-kernel/installkernel` automatically pulls in systemd's kernel-install via `USE=systemd`, enable this flag by default to reduce configuration steps on these profiles. Note that this is not required in systemd-utils since this package is only relevant for non-systemd profiles.

Systemd installs a dummy config file to `/usr/lib/kernel/install.conf`. This is a bit unfortunate because it prevents `sys-kernel/installkernel` from installing a config file there, which then must install the config file to `/etc/kernel/install.conf` instead. Clean up the dummy config to make room for installkernel's config. Note that systemd-utils does not install this dummy config, so no changes are required there.