### PR TITLE
app-emulation/xen{,-tools}: use https for git clone

### DIFF
--- a/app-emulation/xen-tools/xen-tools-4.16.6_pre1-r1.ebuild
+++ b/app-emulation/xen-tools/xen-tools-4.16.6_pre1-r1.ebuild
@@ -11,7 +11,7 @@ inherit bash-completion-r1 flag-o-matic multilib python-single-r1 readme.gentoo-
 if [[ ${PV} == *9999 ]]; then
 	inherit git-r3
 	REPO="xen.git"
-	EGIT_REPO_URI="git://xenbits.xen.org/${REPO}"
+	EGIT_REPO_URI="https://xenbits.xen.org/git-http/${REPO}"
 	S="${WORKDIR}/${REPO}"
 else
 	KEYWORDS="amd64 ~arm ~arm64 x86"

--- a/app-emulation/xen-tools/xen-tools-4.16.6_pre1.ebuild
+++ b/app-emulation/xen-tools/xen-tools-4.16.6_pre1.ebuild
@@ -11,7 +11,7 @@ inherit bash-completion-r1 flag-o-matic multilib python-single-r1 readme.gentoo-
 if [[ ${PV} == *9999 ]]; then
 	inherit git-r3
 	REPO="xen.git"
-	EGIT_REPO_URI="git://xenbits.xen.org/${REPO}"
+	EGIT_REPO_URI="https://xenbits.xen.org/git-http/${REPO}"
 	S="${WORKDIR}/${REPO}"
 else
 	KEYWORDS="amd64 ~arm ~arm64 x86"

--- a/app-emulation/xen-tools/xen-tools-4.16.6_pre2.ebuild
+++ b/app-emulation/xen-tools/xen-tools-4.16.6_pre2.ebuild
@@ -11,7 +11,7 @@ inherit bash-completion-r1 flag-o-matic multilib python-single-r1 readme.gentoo-
 if [[ ${PV} == *9999 ]]; then
 	inherit git-r3
 	REPO="xen.git"
-	EGIT_REPO_URI="git://xenbits.xen.org/${REPO}"
+	EGIT_REPO_URI="https://xenbits.xen.org/git-http/${REPO}"
 	S="${WORKDIR}/${REPO}"
 else
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"

--- a/app-emulation/xen-tools/xen-tools-4.17.3.ebuild
+++ b/app-emulation/xen-tools/xen-tools-4.17.3.ebuild
@@ -11,7 +11,7 @@ inherit bash-completion-r1 flag-o-matic multilib python-single-r1 readme.gentoo-
 if [[ ${PV} == *9999 ]]; then
 	inherit git-r3
 	REPO="xen.git"
-	EGIT_REPO_URI="git://xenbits.xen.org/${REPO}"
+	EGIT_REPO_URI="https://xenbits.xen.org/git-http/${REPO}"
 	S="${WORKDIR}/${REPO}"
 else
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"

--- a/app-emulation/xen-tools/xen-tools-4.17.3_pre1-r1.ebuild
+++ b/app-emulation/xen-tools/xen-tools-4.17.3_pre1-r1.ebuild
@@ -11,7 +11,7 @@ inherit bash-completion-r1 flag-o-matic multilib python-single-r1 readme.gentoo-
 if [[ ${PV} == *9999 ]]; then
 	inherit git-r3
 	REPO="xen.git"
-	EGIT_REPO_URI="git://xenbits.xen.org/${REPO}"
+	EGIT_REPO_URI="https://xenbits.xen.org/git-http/${REPO}"
 	S="${WORKDIR}/${REPO}"
 else
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"

--- a/app-emulation/xen-tools/xen-tools-4.17.3_pre1.ebuild
+++ b/app-emulation/xen-tools/xen-tools-4.17.3_pre1.ebuild
@@ -11,7 +11,7 @@ inherit bash-completion-r1 flag-o-matic multilib python-single-r1 readme.gentoo-
 if [[ ${PV} == *9999 ]]; then
 	inherit git-r3
 	REPO="xen.git"
-	EGIT_REPO_URI="git://xenbits.xen.org/${REPO}"
+	EGIT_REPO_URI="https://xenbits.xen.org/git-http/${REPO}"
 	S="${WORKDIR}/${REPO}"
 else
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"

--- a/app-emulation/xen/xen-4.16.6_pre1.ebuild
+++ b/app-emulation/xen/xen-4.16.6_pre1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -9,7 +9,7 @@ inherit flag-o-matic mount-boot python-any-r1 toolchain-funcs
 
 if [[ ${PV} == *9999 ]]; then
 	inherit git-r3
-	EGIT_REPO_URI="git://xenbits.xen.org/xen.git"
+	EGIT_REPO_URI="https://xenbits.xen.org/git-http/xen.git"
 	SRC_URI=""
 else
 	KEYWORDS="amd64 ~arm -x86"

--- a/app-emulation/xen/xen-4.16.6_pre2.ebuild
+++ b/app-emulation/xen/xen-4.16.6_pre2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -9,7 +9,7 @@ inherit flag-o-matic mount-boot python-any-r1 toolchain-funcs
 
 if [[ ${PV} == *9999 ]]; then
 	inherit git-r3
-	EGIT_REPO_URI="git://xenbits.xen.org/xen.git"
+	EGIT_REPO_URI="https://xenbits.xen.org/git-http/xen.git"
 	SRC_URI=""
 else
 	KEYWORDS="~amd64 ~arm -x86"

--- a/app-emulation/xen/xen-4.17.3.ebuild
+++ b/app-emulation/xen/xen-4.17.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -9,7 +9,7 @@ inherit flag-o-matic mount-boot python-any-r1 secureboot toolchain-funcs
 
 if [[ ${PV} == *9999 ]]; then
 	inherit git-r3
-	EGIT_REPO_URI="git://xenbits.xen.org/xen.git"
+	EGIT_REPO_URI="https://xenbits.xen.org/git-http/xen.git"
 	SRC_URI=""
 else
 	KEYWORDS="~amd64 ~arm -x86"

--- a/app-emulation/xen/xen-4.17.3_pre1.ebuild
+++ b/app-emulation/xen/xen-4.17.3_pre1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -9,7 +9,7 @@ inherit flag-o-matic mount-boot python-any-r1 secureboot toolchain-funcs
 
 if [[ ${PV} == *9999 ]]; then
 	inherit git-r3
-	EGIT_REPO_URI="git://xenbits.xen.org/xen.git"
+	EGIT_REPO_URI="https://xenbits.xen.org/git-http/xen.git"
 	SRC_URI=""
 else
 	KEYWORDS="~amd64 ~arm -x86"


### PR DESCRIPTION
Hi,

This updates the xen ebuilds to use `https://` instead of `git://` for git clones. Since there are no live ebuilds in the main tree, this shouldn't be much of an issue but mostly a cosmetic fix. (but it should be fixed in case there is a live ebuild in an overlay from which these ebuilds descend from)