### PR TITLE
app-vim/{colorschemes,molokai,zenburn}: add blockers

### DIFF
--- a/app-vim/colorschemes/colorschemes-20140623-r2.ebuild
+++ b/app-vim/colorschemes/colorschemes-20140623-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -16,6 +16,11 @@ VIM_PLUGIN_HELPTEXT=\
 color schemes, use :colorscheme schemename (tab completion is available
 for scheme names). To automatically set a scheme at startup, please see
 :help vimrc."
+
+RDEPEND="
+	!app-vim/molokai
+	!app-vim/zenburn
+"
 
 src_prepare() {
 	default

--- a/app-vim/molokai/molokai-0.1_p20151115-r2.ebuild
+++ b/app-vim/molokai/molokai-0.1_p20151115-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -13,3 +13,5 @@ SRC_URI="https://github.com/tomasr/molokai/archive/${COMMIT}.tar.gz -> ${P}.tar.
 
 LICENSE="vim"
 KEYWORDS="amd64 x86"
+
+RDEPEND="!app-vim/colorschemes"

--- a/app-vim/zenburn/zenburn-2.25-r2.ebuild
+++ b/app-vim/zenburn/zenburn-2.25-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -15,3 +15,5 @@ S="${WORKDIR}/${MY_PN}-${PV}"
 LICENSE="GPL-1"
 SLOT="0"
 KEYWORDS="amd64 ppc ppc64 x86"
+
+RDEPEND="!app-vim/colorschemes"


### PR DESCRIPTION
`app-vim/colorschemes` comes with molokai and zenburn includes, thus adding blockers to prevent file collision.