### PR TITLE
profiles/arch/riscv: mask USE=webengine

### DIFF
--- a/profiles/arch/riscv/use.mask
+++ b/profiles/arch/riscv/use.mask
@@ -1,5 +1,9 @@
-# Copyright 2019-2023 Gentoo Authors
+# Copyright 2019-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
+
+# Yongxiang Liang <tanekliang@gmail.com> (2024-01-16)
+# Requires qtwebengine, which is not ported to riscv
+webengine
 
 # Unmask the flag which corresponds to ARCH.
 -riscv


### PR DESCRIPTION
- profiles/arch/riscv/rv64gc/lp64: make USE=webengine
