### PR TITLE
dev-libs/libdnet: disable tests for <1.16.4

### DIFF
--- a/dev-libs/libdnet/libdnet-1.14-r2.ebuild
+++ b/dev-libs/libdnet/libdnet-1.14-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -16,9 +16,8 @@ S="${WORKDIR}/${PN}-${P}"
 LICENSE="LGPL-2"
 SLOT="0"
 KEYWORDS="~alpha amd64 arm ~arm64 ~hppa ~ia64 ~mips ppc ppc64 ~riscv sparc x86"
-IUSE="python test"
+IUSE="python"
 REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
-RESTRICT="!test? ( test )"
 
 DEPEND="python? ( ${PYTHON_DEPS} )"
 RDEPEND="${DEPEND}"

--- a/dev-libs/libdnet/libdnet-1.16.1.ebuild
+++ b/dev-libs/libdnet/libdnet-1.16.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -15,16 +15,14 @@ S="${WORKDIR}/${PN}-${P}"
 LICENSE="LGPL-2"
 SLOT="0"
 KEYWORDS="~alpha amd64 arm ~arm64 ~hppa ~ia64 ~mips ppc ppc64 ~riscv sparc x86"
-IUSE="python test"
-RESTRICT="!test? ( test )"
+IUSE="python"
 
 REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
 
 DEPEND="dev-libs/libbsd
 	python? ( ${PYTHON_DEPS} )"
 RDEPEND="${DEPEND}"
-BDEPEND="python? ( dev-python/cython[${PYTHON_USEDEP}] )
-	test? ( dev-libs/check )"
+BDEPEND="python? ( dev-python/cython[${PYTHON_USEDEP}] )"
 
 DOCS=( README.md THANKS )
 
@@ -55,7 +53,7 @@ src_prepare() {
 src_configure() {
 	econf \
 		$(use_with python) \
-		$(use_enable test check)
+		--without-check
 }
 
 src_compile() {

--- a/dev-libs/libdnet/libdnet-1.16.2.ebuild
+++ b/dev-libs/libdnet/libdnet-1.16.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -15,16 +15,14 @@ S="${WORKDIR}/${PN}-${P}"
 LICENSE="LGPL-2"
 SLOT="0"
 KEYWORDS="~alpha amd64 arm ~arm64 ~hppa ~ia64 ~mips ppc ppc64 ~riscv sparc x86"
-IUSE="python test"
-RESTRICT="!test? ( test )"
+IUSE="python"
 
 REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
 
 DEPEND="dev-libs/libbsd
 	python? ( ${PYTHON_DEPS} )"
 RDEPEND="${DEPEND}"
-BDEPEND="python? ( dev-python/cython[${PYTHON_USEDEP}] )
-	test? ( dev-libs/check )"
+BDEPEND="python? ( dev-python/cython[${PYTHON_USEDEP}] )"
 
 DOCS=( README.md THANKS )
 
@@ -55,7 +53,7 @@ src_prepare() {
 src_configure() {
 	econf \
 		$(use_with python) \
-		$(use_enable test check)
+		--without-check
 }
 
 src_compile() {


### PR DESCRIPTION
Uses an old --with-check=<explicit path>, which appears to work but then actually no-ops the test suite.  >=1.16.4 have an --enable/--disable toggle that actually works.

Bug: https://bugs.gentoo.org/913838

See https://github.com/gentoo/gentoo/pull/34411