### PR TITLE
dev-libs/libsodium: add 1.0.19-r2; drop 'minimal' USE

### DIFF
--- a/app-crypt/minisign/minisign-0.11-r1.ebuild
+++ b/app-crypt/minisign/minisign-0.11-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2019-2023 Gentoo Authors
+# Copyright 2019-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -19,10 +19,8 @@ fi
 LICENSE="ISC"
 SLOT="0"
 
-IUSE=""
-
 BDEPEND="virtual/pkgconfig"
-DEPEND="dev-libs/libsodium:=[-minimal]"
+DEPEND="dev-libs/libsodium:=[-minimal(-)]"
 RDEPEND="${DEPEND}"
 
 src_configure() {

--- a/app-crypt/minisign/minisign-9999.ebuild
+++ b/app-crypt/minisign/minisign-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2019-2023 Gentoo Authors
+# Copyright 2019-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -19,10 +19,8 @@ fi
 LICENSE="ISC"
 SLOT="0"
 
-IUSE=""
-
 BDEPEND="virtual/pkgconfig"
-DEPEND="dev-libs/libsodium:=[-minimal]"
+DEPEND="dev-libs/libsodium:=[-minimal(-)]"
 RDEPEND="${DEPEND}"
 
 src_configure() {

--- a/dev-lang/php/php-8.1.20-r2.ebuild
+++ b/dev-lang/php/php-8.1.20-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -110,7 +110,7 @@ COMMON_DEPEND="
 	readline? ( sys-libs/readline:0= )
 	session-mm? ( dev-libs/mm )
 	snmp? ( >=net-analyzer/net-snmp-5.2 )
-	sodium? ( dev-libs/libsodium:=[-minimal] )
+	sodium? ( dev-libs/libsodium:=[-minimal(-)] )
 	spell? ( >=app-text/aspell-0.50 )
 	sqlite? ( >=dev-db/sqlite-3.7.6.3 )
 	ssl? ( >=dev-libs/openssl-1.0.2:0= )

--- a/dev-lang/php/php-8.1.26-r1.ebuild
+++ b/dev-lang/php/php-8.1.26-r1.ebuild
@@ -110,7 +110,7 @@ COMMON_DEPEND="
 	readline? ( sys-libs/readline:0= )
 	session-mm? ( dev-libs/mm )
 	snmp? ( >=net-analyzer/net-snmp-5.2 )
-	sodium? ( dev-libs/libsodium:=[-minimal] )
+	sodium? ( dev-libs/libsodium:=[-minimal(-)] )
 	spell? ( >=app-text/aspell-0.50 )
 	sqlite? ( >=dev-db/sqlite-3.7.6.3 )
 	ssl? ( >=dev-libs/openssl-1.0.2:0= )

--- a/dev-lang/php/php-8.2.13-r2.ebuild
+++ b/dev-lang/php/php-8.2.13-r2.ebuild
@@ -110,7 +110,7 @@ COMMON_DEPEND="
 	readline? ( sys-libs/readline:0= )
 	session-mm? ( dev-libs/mm )
 	snmp? ( >=net-analyzer/net-snmp-5.2 )
-	sodium? ( dev-libs/libsodium:=[-minimal] )
+	sodium? ( dev-libs/libsodium:=[-minimal(-)] )
 	spell? ( >=app-text/aspell-0.50 )
 	sqlite? ( >=dev-db/sqlite-3.7.6.3 )
 	ssl? ( >=dev-libs/openssl-1.0.2:0= )

--- a/dev-lang/php/php-8.3.0-r2.ebuild
+++ b/dev-lang/php/php-8.3.0-r2.ebuild
@@ -111,7 +111,7 @@ COMMON_DEPEND="
 	readline? ( sys-libs/readline:0= )
 	session-mm? ( dev-libs/mm )
 	snmp? ( net-analyzer/net-snmp )
-	sodium? ( dev-libs/libsodium:=[-minimal] )
+	sodium? ( dev-libs/libsodium:=[-minimal(-)] )
 	spell? ( app-text/aspell )
 	sqlite? ( dev-db/sqlite )
 	ssl? ( dev-libs/openssl:0= )

--- a/dev-libs/libsodium/libsodium-1.0.19-r2.ebuild
+++ b/dev-libs/libsodium/libsodium-1.0.19-r2.ebuild
@@ -1,0 +1,73 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/openpgp-keys/libsodium.minisig
+VERIFY_SIG_METHOD=minisig
+inherit autotools multilib-minimal verify-sig
+
+DESCRIPTION="Portable fork of NaCl, a higher-level cryptographic library"
+HOMEPAGE="https://libsodium.org"
+
+if [[ ${PV} == *_p* ]] ; then
+	MY_P=${PN}-$(ver_cut 1-3)-stable-$(ver_cut 5-)
+
+	# We use _pN to represent 'stable releases'
+	# These are backports from upstream to the last release branch
+	# See https://download.libsodium.org/libsodium/releases/README.html
+	SRC_URI="
+		https://dev.gentoo.org/~sam/distfiles/${CATEGORY}/${PN}/${MY_P}.tar.gz -> ${P}.tar.gz
+		verify-sig? ( https://dev.gentoo.org/~sam/distfiles/dev-libs/libsodium/${MY_P}.tar.gz.minisig -> ${P}.tar.gz.minisig )
+	"
+else
+	SRC_URI="
+		https://download.libsodium.org/${PN}/releases/${P}.tar.gz
+		verify-sig? ( https://download.libsodium.org/${PN}/releases/${P}.tar.gz.minisig )
+	"
+fi
+
+S="${WORKDIR}"/${PN}-stable
+
+LICENSE="ISC"
+SLOT="0/26"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~arm64-macos ~x64-macos"
+IUSE="+asm static-libs +urandom"
+
+CPU_USE=( cpu_flags_x86_{aes,sse4_1} )
+IUSE+=" ${CPU_USE[@]}"
+
+BDEPEND=" verify-sig? ( sec-keys/minisig-keys-libsodium )"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-1.0.10-cpuflags.patch
+)
+
+src_prepare() {
+	default
+
+	eautoreconf
+}
+
+multilib_src_configure() {
+	local myeconfargs=(
+		$(use_enable asm)
+		$(use_enable cpu_flags_x86_aes aesni)
+		$(use_enable cpu_flags_x86_sse4_1 sse4_1)
+		$(use_enable static-libs static)
+		$(use_enable !urandom blocking-random)
+	)
+
+	# --disable-pie is needed on x86, see bug #512734
+	# TODO: Check if still needed?
+	if [[ ${ABI} == x86 ]] ; then
+		myeconfargs+=( --disable-pie )
+	fi
+
+	ECONF_SOURCE="${S}" econf "${myeconfargs[@]}"
+}
+
+multilib_src_install_all() {
+	default
+	find "${ED}" -type f -name "*.la" -delete || die
+}

--- a/net-libs/tox/tox-0.2.13-r1.ebuild
+++ b/net-libs/tox/tox-0.2.13-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -21,7 +21,7 @@ RESTRICT="!test? ( test )"
 
 BDEPEND="virtual/pkgconfig"
 DEPEND="
-	dev-libs/libsodium:=[asm,urandom,-minimal]
+	dev-libs/libsodium:=[asm,urandom,-minimal(-)]
 	av? (
 		media-libs/libvpx:=
 		media-libs/opus

--- a/net-libs/tox/tox-0.2.18-r3.ebuild
+++ b/net-libs/tox/tox-0.2.18-r3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -22,7 +22,7 @@ REQUIRED_USE="?? ( log-debug log-error log-info log-trace log-warn )
 RESTRICT="!test? ( test )"
 
 BDEPEND="virtual/pkgconfig"
-DEPEND="dev-libs/libsodium:=[asm,urandom,-minimal]
+DEPEND="dev-libs/libsodium:=[asm,urandom,-minimal(-)]
 	av? (
 		media-libs/libvpx:=
 		media-libs/opus

--- a/net-libs/tox/tox-9999.ebuild
+++ b/net-libs/tox/tox-9999.ebuild
@@ -1,33 +1,40 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-inherit cmake git-r3 systemd
+inherit cmake systemd
 
 DESCRIPTION="Encrypted P2P, messaging, and audio/video calling platform"
-HOMEPAGE="https://tox.chat"
-SRC_URI=""
-EGIT_REPO_URI="https://github.com/TokTok/c-toxcore.git"
+HOMEPAGE="https://tox.chat https://github.com/TokTok/c-toxcore"
+
+if [[ ${PV} == 9999 ]]; then
+	inherit git-r3
+	EGIT_REPO_URI="https://github.com/TokTok/c-toxcore.git"
+else
+	MY_P="c-toxcore-${PV}"
+	SRC_URI="https://github.com/TokTok/c-toxcore/releases/download/v${PV}/${MY_P}.tar.gz"
+	KEYWORDS="~amd64 ~arm ~x86"
+	S="${WORKDIR}/${MY_P}"
+fi
 
 LICENSE="GPL-3+"
 SLOT="0/0.2"
-KEYWORDS=""
 IUSE="+av debug daemon dht-node ipv6 key-utils log-debug +log-error log-info log-trace log-warn test"
-RESTRICT="!test? ( test )"
 
 REQUIRED_USE="?? ( log-debug log-error log-info log-trace log-warn )
 		daemon? ( dht-node )"
+RESTRICT="!test? ( test )"
 
 BDEPEND="virtual/pkgconfig"
-DEPEND="dev-libs/libsodium:=[asm,urandom,-minimal]
+DEPEND="dev-libs/libsodium:=[asm,urandom,-minimal(-)]
 	av? (
 		media-libs/libvpx:=
 		media-libs/opus
 	)
 	daemon? ( dev-libs/libconfig:= )"
-RDEPEND="
-	${DEPEND}
+
+RDEPEND="${DEPEND}
 	daemon? (
 		acct-group/tox
 		acct-user/tox
@@ -37,7 +44,7 @@ RDEPEND="
 src_prepare() {
 	cmake_src_prepare
 
-	#remove faulty tests
+	#Remove faulty tests
 	for testname in lan_discovery save_load; do
 		sed -i -e "/^auto_test(${testname})$/d" ./auto_tests/CMakeLists.txt || die
 	done
@@ -55,12 +62,16 @@ src_configure() {
 		-DDHT_BOOTSTRAP=$(usex dht-node ON OFF)
 		-DENABLE_SHARED=ON
 		-DENABLE_STATIC=OFF
-		-DMUST_BUILD_TOXAV=$(usex av ON OFF))
+		-DFULLY_STATIC=OFF
+		-DMUST_BUILD_TOXAV=$(usex av ON OFF)
+	)
+
 	if use test; then
 		mycmakeargs+=(
 			-DTEST_TIMEOUT_SECONDS=150
 			-DNON_HERMETIC_TESTS=OFF
-			-DUSE_IPV6=$(usex ipv6 ON OFF))
+			-DUSE_IPV6=$(usex ipv6 ON OFF)
+		)
 	else
 		mycmakeargs+=(-DUSE_IPV6=OFF)
 	fi
@@ -77,8 +88,9 @@ src_configure() {
 		mycmakeargs+=(-DMIN_LOGGER_LEVEL="ERROR")
 	else
 		mycmakeargs+=(-DMIN_LOGGER_LEVEL="")
-		einfo "Logging Disabled"
+		einfo "Logging disabled"
 	fi
+
 	cmake_src_configure
 }
 
@@ -104,9 +116,9 @@ pkg_postinst() {
 		ewarn "developers and is on their TODO list. For more information,"
 		ewarn "please see 'https://github.com/toktok/c-toxcore/issues/1144'"
 		ewarn ""
-		ewarn "There is currently an unresolved issuer with tox DHT Bootstrap node"
-		ewarn "that causes the program to be built with a null libray reference."
+		ewarn "There is currently an unresolved issue with tox DHT Bootstrap node"
+		ewarn "that causes the program to be built with a null library reference."
 		ewarn "This causes an infinite loop for certain revdep-rebuild commands."
-		ewarn "If you aren't running a node, consider disabling the dht node use flag"
+		ewarn "If you aren't running a node, please consider disabling the dht-node use flag."
 	fi
 }


### PR DESCRIPTION
The 'minimal' USE drastically changes the ABI for libsodium and all we do with it in portage is variations on
'`RDEPEND=dev-libs/libsodium:=[...,-minimal]`'.

It does not pass the 'sniff test' and should never have been added, this commit corrects the oversight.

Bug: https://bugs.gentoo.org/921614