### PR TITLE
games-emulation/ppsspp: wire up tests

### DIFF
--- a/games-emulation/ppsspp/files/ppsspp-1.15.4-backport-ce83fec.patch
+++ b/games-emulation/ppsspp/files/ppsspp-1.15.4-backport-ce83fec.patch
@@ -1,0 +1,23 @@
+https://bugs.gentoo.org/915888
+https://github.com/hrydgard/ppsspp/commit/ce83fec20651222131ef9b88ba2dfb0554b66608
+
+From ce83fec20651222131ef9b88ba2dfb0554b66608 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Henrik=20Rydg=C3=A5rd?= <hrydgard@gmail.com>
+Date: Sun, 29 Oct 2023 23:39:25 -0600
+Subject: [PATCH] Linux buildfix attempt
+
+---
+ unittest/TestThreadManager.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/unittest/TestThreadManager.cpp b/unittest/TestThreadManager.cpp
+index f6a11f2fa363..10a8b581b768 100644
+--- a/unittest/TestThreadManager.cpp
++++ b/unittest/TestThreadManager.cpp
+@@ -1,5 +1,6 @@
+ #include <thread>
+ #include <vector>
++#include <cstdio>
+ 
+ #include "Common/Log.h"
+ #include "Common/TimeUtil.h"

--- a/games-emulation/ppsspp/ppsspp-1.15.4.ebuild
+++ b/games-emulation/ppsspp/ppsspp-1.15.4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -15,8 +15,8 @@ SRC_URI="https://github.com/hrydgard/${PN}/releases/download/v${PV}/${P}.tar.xz"
 LICENSE="Apache-2.0 BSD BSD-2 GPL-2 JSON MIT"
 SLOT="0"
 KEYWORDS="amd64"
-IUSE="discord qt5"
-RESTRICT="test"
+IUSE="discord qt5 test"
+RESTRICT="!test? ( test )"
 
 RDEPEND="
 	app-arch/snappy:=
@@ -43,6 +43,7 @@ BDEPEND="${PYTHON_DEPS}"
 PATCHES=(
 	"${FILESDIR}"/${PN}-CMakeLists-flags.patch
 	"${FILESDIR}"/${PN}-disable-ccache-autodetection.patch
+	"${FILESDIR}"/${PN}-1.15.4-backport-ce83fec.patch
 )
 
 pkg_setup() {
@@ -60,6 +61,11 @@ src_configure() {
 		-DUSE_SYSTEM_ZSTD=ON
 		-DUSE_DISCORD=$(usex discord)
 		-DUSING_QT_UI=$(usex qt5)
+		-DUNITTEST=$(usex test)
 	)
 	cmake_src_configure
+}
+
+src_test() {
+	cmake_src_test -E glslang-testsuite
 }

--- a/games-emulation/ppsspp/ppsspp-1.16.4.ebuild
+++ b/games-emulation/ppsspp/ppsspp-1.16.4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -21,8 +21,8 @@ fi
 
 LICENSE="Apache-2.0 BSD BSD-2 GPL-2 JSON MIT"
 SLOT="0"
-IUSE="discord qt5"
-RESTRICT="test"
+IUSE="discord qt5 test"
+RESTRICT="!test? ( test )"
 
 RDEPEND="
 	app-arch/snappy:=
@@ -53,6 +53,7 @@ BDEPEND="
 PATCHES=(
 	"${FILESDIR}"/${PN}-CMakeLists-flags.patch
 	"${FILESDIR}"/${PN}-disable-ccache-autodetection.patch
+	"${FILESDIR}"/${PN}-1.15.4-backport-ce83fec.patch
 )
 
 pkg_setup() {
@@ -70,6 +71,11 @@ src_configure() {
 		-DUSE_SYSTEM_ZSTD=ON
 		-DUSE_DISCORD=$(usex discord)
 		-DUSING_QT_UI=$(usex qt5)
+		-DUNITTEST=$(usex test)
 	)
 	cmake_src_configure
+}
+
+src_test() {
+	cmake_src_test -E glslang-testsuite
 }

--- a/games-emulation/ppsspp/ppsspp-1.16.ebuild
+++ b/games-emulation/ppsspp/ppsspp-1.16.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -21,8 +21,8 @@ fi
 
 LICENSE="Apache-2.0 BSD BSD-2 GPL-2 JSON MIT"
 SLOT="0"
-IUSE="discord qt5"
-RESTRICT="test"
+IUSE="discord qt5 test"
+RESTRICT="!test? ( test )"
 
 RDEPEND="
 	app-arch/snappy:=
@@ -54,6 +54,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-1.16-MIPSTables-fix-includes.patch
 	"${FILESDIR}"/${PN}-CMakeLists-flags.patch
 	"${FILESDIR}"/${PN}-disable-ccache-autodetection.patch
+	"${FILESDIR}"/${PN}-1.15.4-backport-ce83fec.patch
 )
 
 pkg_setup() {
@@ -71,6 +72,11 @@ src_configure() {
 		-DUSE_SYSTEM_ZSTD=ON
 		-DUSE_DISCORD=$(usex discord)
 		-DUSING_QT_UI=$(usex qt5)
+		-DUNITTEST=$(usex test)
 	)
 	cmake_src_configure
+}
+
+src_test() {
+	cmake_src_test -E glslang-testsuite
 }


### PR DESCRIPTION
The one excluded test is pulled in from a submodule.

Bug: https://bugs.gentoo.org/915888