### PR TITLE
media-sound/audacity: wire up tests

### DIFF
--- a/media-sound/audacity/audacity-9999.ebuild
+++ b/media-sound/audacity/audacity-9999.ebuild
@@ -39,6 +39,7 @@ SLOT="0"
 IUSE="alsa audiocom ffmpeg +flac id3tag +ladspa +lv2 mpg123 ogg
 	opus +portmixer sbsms test twolame vamp +vorbis wavpack"
 RESTRICT="!test? ( test )"
+REQUIRED_USE="test? ( mpg123 )"
 
 # dev-db/sqlite:3 hard dependency.
 # dev-libs/glib:2, x11-libs/gtk+:3 hard dependency, from
@@ -65,6 +66,7 @@ RESTRICT="!test? ( test )"
 RDEPEND="dev-db/sqlite:3
 	dev-libs/expat
 	dev-libs/glib:2
+	dev-libs/rapidjson
 	media-libs/libsndfile
 	media-libs/libsoundtouch:=
 	media-libs/portaudio[alsa?]
@@ -127,8 +129,8 @@ PATCHES=(
 src_prepare() {
 	cmake_src_prepare
 
-	local header_subs="${S}/lib-src/header-substitutes"
-	cat <<-EOF >"${header_subs}/allegro.h" || die
+	local header_subs="${S}/libraries/lib-note-track"
+	cat <<-EOF >"${header_subs}/WrapAllegro.h" || die
 	/* Hack the allegro.h header substitute to use system headers.  */
 	#include <portsmf/allegro.h>
 	EOF

--- a/media-sound/audacity/audacity-9999.ebuild
+++ b/media-sound/audacity/audacity-9999.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 WX_GTK_VER="3.2-gtk3"
 
-inherit cmake wxwidgets xdg
+inherit cmake wxwidgets xdg virtualx
 
 DESCRIPTION="Free crossplatform audio editor"
 HOMEPAGE="https://www.audacityteam.org/"
@@ -37,10 +37,8 @@ LICENSE="GPL-2+
 "
 SLOT="0"
 IUSE="alsa audiocom ffmpeg +flac id3tag +ladspa +lv2 mpg123 ogg
-	opus +portmixer sbsms twolame vamp +vorbis wavpack"
-
-# The testsuite consists of two tests, 50% of which fail.
-RESTRICT="test"
+	opus +portmixer sbsms test twolame vamp +vorbis wavpack"
+RESTRICT="!test? ( test )"
 
 # dev-db/sqlite:3 hard dependency.
 # dev-libs/glib:2, x11-libs/gtk+:3 hard dependency, from
@@ -103,7 +101,8 @@ RDEPEND="dev-db/sqlite:3
 	vorbis? ( media-libs/libvorbis )
 	wavpack? ( media-sound/wavpack )
 "
-DEPEND="${RDEPEND}"
+DEPEND="${RDEPEND}
+	test? ( dev-cpp/catch:0 )"
 BDEPEND="app-arch/unzip
 	sys-devel/gettext
 	virtual/pkgconfig
@@ -120,6 +119,9 @@ PATCHES=(
 
 	# For has_networking
 	"${FILESDIR}/${PN}-3.3.3-local-threadpool-libraries.patch"
+
+	# Allows running tests without conan
+	"${FILESDIR}/${PN}-3.3.3-remove-conan-test-dependency.patch"
 )
 
 src_prepare() {
@@ -199,9 +201,15 @@ src_configure() {
 		## Keep watch of PA_HAS_OSS in lib-src/portmixer/CMakeLists.txt;
 		## AFAICT it introduces no deps as-is, but that could change.
 		## Similar goes for PA_HAS_JACK.
+
+		-Daudacity_has_tests=$(usex test ON OFF)
 	)
 
 	cmake_src_configure
+}
+
+src_test() {
+	virtx cmake_src_test
 }
 
 src_install() {

--- a/media-sound/audacity/files/audacity-3.3.3-remove-conan-test-dependency.patch
+++ b/media-sound/audacity/files/audacity-3.3.3-remove-conan-test-dependency.patch
@@ -1,0 +1,39 @@
+https://bugs.gentoo.org/916258
+https://github.com/audacity/audacity/discussions/5841
+https://github.com/matoro/audacity/commit/270be88a9390eb25c2f4b16030f6897f08a6a685
+
+From 270be88a9390eb25c2f4b16030f6897f08a6a685 Mon Sep 17 00:00:00 2001
+From: matoro <matoro@users.noreply.github.com>
+Date: Mon, 15 Jan 2024 20:21:08 -0500
+Subject: [PATCH] Remove dependency on conan for unit tests
+
+These run fine with catch2 installed from system package manager; there
+is no reason to enforce conan dependency.
+---
+ CMakeLists.txt | 12 ++++--------
+ 1 file changed, 4 insertions(+), 8 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index cbe79a43b933..7b682c4e729d 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -228,15 +228,11 @@ cmd_option( ${_OPT}has_url_schemes_support
+    "Build custom URL schemes support into Audacity"
+    Off)
+ 
+-include( CMakeDependentOption )
+-
+-cmake_dependent_option(
+-   ${_OPT}has_tests
++cmd_option( ${_OPT}has_tests
+    "Enables automated testing support"
+-   On
+-   "${_OPT}conan_enabled"
+-   Off
+-)
++   On)
++
++include( CMakeDependentOption )
+ 
+ cmake_dependent_option(
+    ${_OPT}has_audiocom_upload


### PR DESCRIPTION
And updates live ebuild.  Tested test suite passing on both, including a handful of new tests in 3.4.0.  Patch not submitted upstream.

See:  https://github.com/audacity/audacity/discussions/5841