### PR TITLE
net-libs/accounts-qml: fix bug# 922194

### DIFF
--- a/net-libs/accounts-qml/accounts-qml-0.7_p20231028.ebuild
+++ b/net-libs/accounts-qml/accounts-qml-0.7_p20231028.ebuild
@@ -124,6 +124,7 @@ src_install() {
 		emake -C "${BUILD_DIR}" INSTALL_ROOT="${D}" install_subtargets
 	}
 
+	local QT_QPA_PLATFORM=offscreen
 	multibuild_foreach_variant my_src_install
 	use doc && local HTML_DOCS=( doc/html )
 	einstalldocs


### PR DESCRIPTION
- **net-libs/accounts-qml: fix bug# 922194**
~~Adds boilerplate directly from the pgo section of the _www-client/firefox_ ebuild, using `virtx`/`virtwl` to set the environment.  Also adds `X` to `IUSE` to differentiate between the two.~~
Add `local QT_QPA_PLATFORM=offscreen` to fix breakage.

Closes: https://bugs.gentoo.org/922194
Closes: https://github.com/gentoo/gentoo/pull/34832
Signed-off-by: Peter Levine <plevine457@gmail.com>