### PR TITLE
app-editors/neovim: fix finding luajit in live

### DIFF
--- a/app-editors/neovim/neovim-9999.ebuild
+++ b/app-editors/neovim/neovim-9999.ebuild
@@ -81,6 +81,7 @@ src_prepare() {
 }
 
 src_configure() {
+	ln -s "${BROOT}"/usr/bin/luajit "${BUILD_DIR}"/luajit || die
 	# TODO: Investigate USE_BUNDLED, doesn't seem to be needed right now
 	local mycmakeargs=(
 		# appends -flto


### PR DESCRIPTION
Commit 7b054106ef5a1fd742fb23886173d8c5a842d715 was lost with commit beea6ed74eb77f3f16cb60e441cf51afd08ccc71, thus introducing bug 922138.

Closes: https://bugs.gentoo.org/922138