### PR TITLE
app-misc/qlcplus: Drop Werror CFLAG

### DIFF
--- a/app-misc/qlcplus/qlcplus-4.12.7.ebuild
+++ b/app-misc/qlcplus/qlcplus-4.12.7.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -52,6 +52,10 @@ src_prepare() {
 
 	## Remove Werror-flag since there are some warnings with gcc-9.x
 	sed -e "s/QMAKE_CXXFLAGS += -Werror/#&/g" \
+		-i variables.pri || die
+
+	## Remove Werror-flag since there are some warnings with gcc-9.x
+	sed -e "s/unix:QMAKE_CFLAGS += -Werror/#&/g" \
 		-i variables.pri || die
 }
 


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/920457

Upstream had that `-Werror` flag for some time in CXXFLAGs but added it to `unix:CLFAGS` as well "recently"