### PR TITLE
media-libs/libbsb: EAPI8 bump, fix bug #724744

### DIFF
--- a/media-libs/libbsb/libbsb-0.0.7-r2.ebuild
+++ b/media-libs/libbsb/libbsb-0.0.7-r2.ebuild
@@ -1,0 +1,28 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools toolchain-funcs
+
+DESCRIPTION="Portable C library for reading and writing BSB format image files"
+HOMEPAGE="https://libbsb.sourceforge.net/"
+SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
+
+LICENSE="LGPL-2.1+"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+DEPEND="media-libs/libpng
+	media-libs/tiff:="
+RDEPEND="${DEPEND}"
+
+# "make check" in 0.0.7 fails with newer tiff versions (4.0.0) altough the
+# tools work perfectly, so restrict test until this is fixed upstream
+RESTRICT="test"
+
+src_prepare(){
+	sed -i -e "s|ar crv|$(tc-getAR) crv|" Makefile.am || die
+	default
+	eautoreconf
+}


### PR DESCRIPTION
This fixes calling `ar` directly, bug #724744.
While looking at the build log i've also encounter the QA Warning mentioned in bug #899814
However, i've noticed that after using `eautoreconf` the QA Warning is gone - the wiki guide mentioned that this could fix it - which is why i've marked this bug as fixed too..

```diff
--- libbsb-0.0.7-r1.ebuild	2023-11-15 17:01:28.645049560 +0100
+++ libbsb-0.0.7-r2.ebuild	2024-01-16 20:40:57.367257438 +0100
@@ -1,16 +1,17 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
-DESCRIPTION="A portable C library for reading and writing BSB format image files"
-HOMEPAGE="http://libbsb.sourceforge.net/"
+inherit autotools toolchain-funcs
+
+DESCRIPTION="Portable C library for reading and writing BSB format image files"
+HOMEPAGE="https://libbsb.sourceforge.net/"
 SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
 
-LICENSE="LGPL-2.1"
+LICENSE="LGPL-2.1+"
 SLOT="0"
-KEYWORDS="amd64 x86"
-IUSE=""
+KEYWORDS="~amd64 ~x86"
 
 DEPEND="media-libs/libpng
 	media-libs/tiff:="
@@ -20,4 +21,8 @@
 # tools work perfectly, so restrict test until this is fixed upstream
 RESTRICT="test"
 
-DOCS=( README AUTHORS )
+src_prepare(){
+	sed -i -e "s|ar crv|$(tc-getAR) crv|" Makefile.am || die
+	default
+	eautoreconf
+}
```

Signed-off-by: Michael Mair-Keimberger <mmk@levelnine.at>

Closes: https://bugs.gentoo.org/724744
Closes: https://bugs.gentoo.org/899814