### PR TITLE
app-arch/unar: test ObjC support in gcc

### DIFF
--- a/app-arch/unar/unar-1.10.8.ebuild
+++ b/app-arch/unar/unar-1.10.8.ebuild
@@ -35,7 +35,7 @@ PATCHES=( "${FILESDIR}"/${P}-Wint-conversion.patch )
 
 check_objc_toolchain() {
 	if tc-is-gcc; then
-		has_version 'sys-devel/gcc[-objc]' &&
+		echo "int main(void) { return 0; }" | $(tc-getCC) -x objective-c - &>/dev/null ||
 			die "GCC requires sys-devel/gcc with USE=objc"
 	elif tc-is-clang; then
 		has_version 'gnustep-base/gnustep-make[-libobjc2]' &&


### PR DESCRIPTION
* Previous "has_version 'sys-devel/gcc[-objc]'" check would require objc to be enabled in all gcc slots even if the gcc version in question isn't used.

Bug: https://bugs.gentoo.org/732846

I have a use case where I have older gcc versions installed with unnecessary use flags disabled.