### PR TITLE
dev-java/batik: Append to variable gjl_java_args instead of replacing it

### DIFF
--- a/dev-java/batik/batik-1.17.ebuild
+++ b/dev-java/batik/batik-1.17.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -229,7 +229,7 @@ src_install() {
 	_EOF_
 	java-pkg_register-environment-variable \
 		gjl_java_args \
-		"-Djava.security.policy=file:${EPREFIX}${java_policy_file}"
+		"\$gjl_java_args -Djava.security.policy=file:${EPREFIX}${java_policy_file}"
 
 	if use doc; then
 		java-pkg_dojavadoc target/api


### PR DESCRIPTION
Before this fix all launchers for apps that depend on batik get there `gil_java_args` variable overwritten. Now the relevant config for batik is appended, keeping the previous content of the variable.

Closes: https://bugs.gentoo.org/922221