### PR TITLE
app-emulation/wine-vanilla, app-emulation/wine-staging, app-emulation/wine-proton: add comment how to fix linking with user patches

### DIFF
--- a/app-emulation/wine-proton/wine-proton-7.0.6.ebuild
+++ b/app-emulation/wine-proton/wine-proton-7.0.6.ebuild
@@ -178,6 +178,9 @@ src_prepare() {
 	eautoreconf
 	tools/make_requests || die # perl
 	dlls/winevulkan/make_vulkan -x vk.xml || die # python, needed for proton's
+	# tip: if need more for user patches, with portage can e.g. do
+    # echo "post_src_prepare() { tools/make_specfiles || die; }" \
+    #     > /etc/portage/env/app-emulation/wine-proton
 }
 
 src_configure() {

--- a/app-emulation/wine-proton/wine-proton-8.0.4.ebuild
+++ b/app-emulation/wine-proton/wine-proton-8.0.4.ebuild
@@ -181,6 +181,9 @@ src_prepare() {
 	eautoreconf
 	tools/make_requests || die # perl
 	dlls/winevulkan/make_vulkan -x vk.xml || die # python, needed for proton's
+	# tip: if need more for user patches, with portage can e.g. do
+    # echo "post_src_prepare() { tools/make_specfiles || die; }" \
+    #     > /etc/portage/env/app-emulation/wine-proton
 }
 
 src_configure() {

--- a/app-emulation/wine-proton/wine-proton-8.0.9999.ebuild
+++ b/app-emulation/wine-proton/wine-proton-8.0.9999.ebuild
@@ -182,6 +182,9 @@ src_prepare() {
 	eautoreconf
 	tools/make_requests || die # perl
 	dlls/winevulkan/make_vulkan -x vk.xml || die # python, needed for proton's
+	# tip: if need more for user patches, with portage can e.g. do
+    # echo "post_src_prepare() { tools/make_specfiles || die; }" \
+    #     > /etc/portage/env/app-emulation/wine-proton
 }
 
 src_configure() {

--- a/app-emulation/wine-staging/wine-staging-8.0.ebuild
+++ b/app-emulation/wine-staging/wine-staging-8.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2022-2023 Gentoo Authors
+# Copyright 2022-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -222,6 +222,9 @@ src_prepare() {
 	# always update for patches (including user's wrt #432348)
 	eautoreconf
 	tools/make_requests || die # perl
+	# tip: if need more for user patches, with portage can e.g. do
+    # echo "post_src_prepare() { tools/make_specfiles || die; }" \
+    #     > /etc/portage/env/app-emulation/wine-staging
 }
 
 src_configure() {

--- a/app-emulation/wine-staging/wine-staging-8.21.ebuild
+++ b/app-emulation/wine-staging/wine-staging-8.21.ebuild
@@ -259,6 +259,9 @@ src_prepare() {
 	# always update for patches (including user's wrt #432348)
 	eautoreconf
 	tools/make_requests || die # perl
+	# tip: if need more for user patches, with portage can e.g. do
+    # echo "post_src_prepare() { tools/make_specfiles || die; }" \
+    #     > /etc/portage/env/app-emulation/wine-staging
 }
 
 src_configure() {

--- a/app-emulation/wine-staging/wine-staging-9.0.ebuild
+++ b/app-emulation/wine-staging/wine-staging-9.0.ebuild
@@ -267,6 +267,9 @@ src_prepare() {
 	# always update for patches (including user's wrt #432348)
 	eautoreconf
 	tools/make_requests || die # perl
+	# tip: if need more for user patches, with portage can e.g. do
+    # echo "post_src_prepare() { tools/make_specfiles || die; }" \
+    #     > /etc/portage/env/app-emulation/wine-staging
 }
 
 src_configure() {

--- a/app-emulation/wine-staging/wine-staging-9999.ebuild
+++ b/app-emulation/wine-staging/wine-staging-9999.ebuild
@@ -267,6 +267,9 @@ src_prepare() {
 	# always update for patches (including user's wrt #432348)
 	eautoreconf
 	tools/make_requests || die # perl
+	# tip: if need more for user patches, with portage can e.g. do
+    # echo "post_src_prepare() { tools/make_specfiles || die; }" \
+    #     > /etc/portage/env/app-emulation/wine-staging
 }
 
 src_configure() {

--- a/app-emulation/wine-vanilla/wine-vanilla-7.0.2.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-7.0.2.ebuild
@@ -201,6 +201,9 @@ src_prepare() {
 	# always update for patches (including user's wrt #432348)
 	eautoreconf
 	tools/make_requests || die # perl
+	# tip: if need more for user patches, with portage can e.g. do
+    # echo "post_src_prepare() { tools/make_specfiles || die; }" \
+    #     > /etc/portage/env/app-emulation/wine-vanilla
 }
 
 src_configure() {

--- a/app-emulation/wine-vanilla/wine-vanilla-8.0.2.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-8.0.2.ebuild
@@ -198,6 +198,9 @@ src_prepare() {
 	# always update for patches (including user's wrt #432348)
 	eautoreconf
 	tools/make_requests || die # perl
+	# tip: if need more for user patches, with portage can e.g. do
+    # echo "post_src_prepare() { tools/make_specfiles || die; }" \
+    #     > /etc/portage/env/app-emulation/wine-vanilla
 }
 
 src_configure() {

--- a/app-emulation/wine-vanilla/wine-vanilla-8.21.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-8.21.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2022-2023 Gentoo Authors
+# Copyright 2022-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -213,6 +213,9 @@ src_prepare() {
 	# always update for patches (including user's wrt #432348)
 	eautoreconf
 	tools/make_requests || die # perl
+	# tip: if need more for user patches, with portage can e.g. do
+    # echo "post_src_prepare() { tools/make_specfiles || die; }" \
+    #     > /etc/portage/env/app-emulation/wine-vanilla
 }
 
 src_configure() {

--- a/app-emulation/wine-vanilla/wine-vanilla-9.0.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-9.0.ebuild
@@ -220,6 +220,9 @@ src_prepare() {
 	# always update for patches (including user's wrt #432348)
 	eautoreconf
 	tools/make_requests || die # perl
+	# tip: if need more for user patches, with portage can e.g. do
+    # echo "post_src_prepare() { tools/make_specfiles || die; }" \
+    #     > /etc/portage/env/app-emulation/wine-vanilla
 }
 
 src_configure() {

--- a/app-emulation/wine-vanilla/wine-vanilla-9999.ebuild
+++ b/app-emulation/wine-vanilla/wine-vanilla-9999.ebuild
@@ -220,6 +220,9 @@ src_prepare() {
 	# always update for patches (including user's wrt #432348)
 	eautoreconf
 	tools/make_requests || die # perl
+	# tip: if need more for user patches, with portage can e.g. do
+    # echo "post_src_prepare() { tools/make_specfiles || die; }" \
+    #     > /etc/portage/env/app-emulation/wine-vanilla
 }
 
 src_configure() {


### PR DESCRIPTION
When using adding some user patches to wine for exemple winehags is needed to run `tools/make_specfiles` to fix linking on the end of the compile (more info here: https://github.com/ValveSoftware/Proton/issues/7361#issuecomment-1863639235).

I don't know if other patches requires this but the compile also succeeds with line added (wine-staging compile with hags patches [still compiling]):
![image](https://github.com/gentoo/gentoo/assets/68701049/d201d725-413d-4ed4-a9a0-3a5c3650f31b)

Also wine-proton is compiling just fine with the new line (but I have no patches since need to be updated to wine 9.0 for hags patches to work).
