### PR TITLE
profiles/arch/amd64/no-multilib: unmask winetricks

### DIFF
--- a/profiles/arch/amd64/no-multilib/package.mask
+++ b/profiles/arch/amd64/no-multilib/package.mask
@@ -24,9 +24,7 @@ app-arch/stuffit
 app-benchmarks/cpuburn
 app-editors/emacs:18
 app-emulation/crossover-bin
-app-emulation/protontricks
 app-emulation/q4wine
-app-emulation/winetricks
 dev-embedded/libftd2xx
 dev-embedded/openocd
 dev-util/android-ndk


### PR DESCRIPTION
Since no-multilib can now use wine with 32-bit support via USE=wow64, winetricks and protontricks no longer rely on amd64 multilib.