### PR TITLE
mail-filter/spamprobe: EAPI8 bump, fix bug #724748

### DIFF
--- a/mail-filter/spamprobe/spamprobe-1.4d-r3.ebuild
+++ b/mail-filter/spamprobe/spamprobe-1.4d-r3.ebuild
@@ -1,0 +1,50 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs
+
+DESCRIPTION="Fast, intelligent, automatic spam detector using Bayesian analysis"
+HOMEPAGE="https://spamprobe.sourceforge.net/"
+SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
+
+LICENSE="QPL-1.0"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86"
+IUSE="berkdb gif jpeg png"
+
+RDEPEND="
+	berkdb? ( >=sys-libs/db-3.2:* )
+	gif? ( media-libs/giflib:= )
+	jpeg? ( media-libs/libjpeg-turbo:= )
+	png? ( media-libs/libpng:0= )
+"
+DEPEND="${RDEPEND}"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-1.4b-gcc43.patch
+	"${FILESDIR}"/${P}-libpng14.patch
+	"${FILESDIR}"/${P}+db-5.0.patch
+	"${FILESDIR}"/${P}-gcc47.patch
+	"${FILESDIR}"/${P}-giflib5.patch
+	"${FILESDIR}"/${P}-gcc11-const-comp.patch
+)
+
+src_configure() {
+	econf \
+		$(use_with gif) \
+		$(use_with jpeg) \
+		$(use_with png)
+}
+
+src_compile() {
+	emake AR="$(tc-getAR)"
+}
+
+src_install() {
+	default
+
+	insinto /usr/share/${PN}/contrib
+	doins contrib/*
+}


### PR DESCRIPTION
Simple fix for calling `ar` directly:

```diff
--- spamprobe-1.4d-r2.ebuild	2023-04-01 17:48:26.383949034 +0200
+++ spamprobe-1.4d-r3.ebuild	2024-01-17 19:31:52.466972720 +0100
@@ -1,21 +1,23 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
+
+inherit toolchain-funcs
 
 DESCRIPTION="Fast, intelligent, automatic spam detector using Bayesian analysis"
-HOMEPAGE="http://spamprobe.sourceforge.net/"
+HOMEPAGE="https://spamprobe.sourceforge.net/"
 SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
 
 LICENSE="QPL-1.0"
 SLOT="0"
-KEYWORDS="amd64 ~ppc x86"
+KEYWORDS="~amd64 ~ppc ~x86"
 IUSE="berkdb gif jpeg png"
 
 RDEPEND="
 	berkdb? ( >=sys-libs/db-3.2:* )
 	gif? ( media-libs/giflib:= )
-	jpeg? ( virtual/jpeg:0 )
+	jpeg? ( media-libs/libjpeg-turbo:= )
 	png? ( media-libs/libpng:0= )
 "
 DEPEND="${RDEPEND}"
@@ -36,6 +38,10 @@
 		$(use_with png)
 }
 
+src_compile() {
+	emake AR="$(tc-getAR)"
+}
+
 src_install() {
 	default
 
```

Signed-off-by: Michael Mair-Keimberger <mmk@levelnine.at>

Closes: https://bugs.gentoo.org/724748