### PR TITLE
dev-java/xerces: set JAVADOC_ARGS="-source 8"

### DIFF
--- a/dev-java/xerces/xerces-2.12.2-r2.ebuild
+++ b/dev-java/xerces/xerces-2.12.2-r2.ebuild
@@ -37,6 +37,7 @@ HTML_DOCS=( {LICENSE.DOM-documentation,LICENSE.DOM-software,LICENSE-SAX,Readme}.
 
 S="${WORKDIR}/${P//./_}"
 
+JAVADOC_ARGS="-source 8"
 JAVA_SRC_DIR="src"
 JAVA_RESOURCE_DIRS="resources"
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/922332