### PR TITLE
media-video/dvbsnoop: fix bugs #724842, #899866, use https

### DIFF
--- a/media-video/dvbsnoop/dvbsnoop-1.4.50-r3.ebuild
+++ b/media-video/dvbsnoop/dvbsnoop-1.4.50-r3.ebuild
@@ -1,0 +1,29 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools toolchain-funcs
+
+DESCRIPTION="DVB/MPEG stream analyzer program"
+HOMEPAGE="https://sourceforge.net/projects/dvbsnoop/"
+SRC_URI="mirror://sourceforge/dvbsnoop/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86"
+
+DEPEND="virtual/linuxtv-dvb-headers"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-crc32.patch
+)
+
+src_configure(){
+	default
+	eautoreconf
+}
+
+src_compile(){
+	emake AR="$(tc-getAR)"
+}


### PR DESCRIPTION
Two simple fixes:

```diff
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
+inherit autotools toolchain-funcs
+
 DESCRIPTION="DVB/MPEG stream analyzer program"
+HOMEPAGE="https://sourceforge.net/projects/dvbsnoop/"
 SRC_URI="mirror://sourceforge/dvbsnoop/${P}.tar.gz"
-HOMEPAGE="http://dvbsnoop.sourceforge.net/"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 ~ppc x86"
+KEYWORDS="~amd64 ~ppc ~x86"
 
 DEPEND="virtual/linuxtv-dvb-headers"
 
 PATCHES=(
 	"${FILESDIR}"/${P}-crc32.patch
 )
+
+src_configure(){
+	default
+	eautoreconf
+}
+
+src_compile(){
+	emake AR="$(tc-getAR)"
+}
```

Signed-off-by: Michael Mair-Keimberger <mmk@levelnine.at>

Closes: https://bugs.gentoo.org/724842
Closes: https://bugs.gentoo.org/899866