### PR TITLE
media-video/tivodecode: EAPI8 bump, fix bug #724846

### DIFF
--- a/media-video/tivodecode/tivodecode-0.2_pre4.ebuild
+++ b/media-video/tivodecode/tivodecode-0.2_pre4.ebuild
@@ -1,16 +1,20 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
+
+inherit toolchain-funcs
 
 MY_P=${P/_/}
 DESCRIPTION="TiVo File Decoder"
-HOMEPAGE="http://tivodecode.sourceforge.net/"
+HOMEPAGE="https://tivodecode.sourceforge.net/"
 SRC_URI="mirror://sourceforge/${PN}/${MY_P}.tar.gz"
+S="${WORKDIR}/${MY_P}"
 
 LICENSE="BSD"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE=""
 
-S="${WORKDIR}/${MY_P}"
+src_compile(){
+	emake AR="$(tc-getAR)"
+}


### PR DESCRIPTION
Another simple fix for calling `ar` directly.

Signed-off-by: Michael Mair-Keimberger <mmk@levelnine.at>

Closes: https://bugs.gentoo.org/724846