### PR TITLE
net-ftp/frox: EAPI8 bump, fix bug #724924

### DIFF
--- a/net-ftp/frox/frox-0.7.18-r9.ebuild
+++ b/net-ftp/frox/frox-0.7.18-r9.ebuild
@@ -1,0 +1,93 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools toolchain-funcs
+
+DESCRIPTION="Transparent ftp proxy"
+HOMEPAGE="https://frox.sourceforge.net/"
+SRC_URI="https://frox.sourceforge.net/download/${P}.tar.bz2"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86"
+IUSE="clamav ssl transparent"
+
+DEPEND="
+	acct-group/ftpproxy
+	acct-user/ftpproxy
+	clamav? ( >=app-antivirus/clamav-0.80 )
+	kernel_linux? ( >=sys-kernel/linux-headers-2.6 )
+	ssl? (
+		dev-libs/openssl:0=
+	)
+"
+
+RDEPEND="${DEPEND}"
+
+# INSTALL has useful filewall rules
+DOCS=(
+	BUGS README
+	doc/CREDITS doc/ChangeLog doc/FAQ doc/INSTALL
+	doc/INTERNALS doc/README.transdata doc/RELEASE
+	doc/SECURITY doc/TODO
+)
+
+pkg_setup() {
+	use clamav && ewarn "Virus scanner potentialy broken in chroot - see bug #81035"
+}
+
+src_prepare() {
+	HTML_DOCS=( doc/*.html doc/*.sgml )
+
+	default
+
+	eapply "${FILESDIR}/${PV}-respect-CFLAGS.patch"
+	eapply "${FILESDIR}/${PV}-netfilter-includes.patch"
+	eapply "${FILESDIR}/${P}-config.patch"
+	eapply "${FILESDIR}/${P}-no-common.patch"
+
+	if use clamav ; then
+		sed -e "s:^# VirusScanner.*:# VirusScanner '\"/usr/bin/clamscan\" \"%s\"':" \
+			-i "src/${PN}.conf" || die
+	fi
+
+	mv configure.in configure.ac || die
+	eautoreconf
+}
+
+src_configure() {
+	local myeconfargs=(
+		--enable-http-cache --enable-local-cache
+		--enable-procname
+		--enable-configfile=/etc/frox.conf
+		$(use_enable !kernel_linux libiptc)
+		$(use_enable clamav virus-scan)
+		$(use_enable ssl)
+		$(use_enable transparent transparent-data)
+		$(use_enable !transparent ntp)
+	)
+
+	econf "${myeconfargs[@]}"
+}
+
+src_compile() {
+	emake AR="$(tc-getAR)"
+}
+
+src_install() {
+	default
+
+	keepdir /var/log/"${PN}"
+
+	fowners ftpproxy:ftpproxy /var/log/frox
+
+	newman "doc/${PN}.man" "${PN}.man.8"
+	newman "doc/${PN}.conf.man" "${PN}.conf.man.5"
+
+	newinitd "${FILESDIR}/${PN}.initd" "${PN}"
+
+	insinto /etc
+	newins "src/${PN}.conf" "${PN}.conf.example"
+}


### PR DESCRIPTION
Another simple fix for calling `ar` directly.

```diff
--- frox-0.7.18-r8.ebuild	2024-01-17 20:05:13.376815452 +0100
+++ frox-0.7.18-r9.ebuild	2024-01-18 20:43:46.536241394 +0100
@@ -1,17 +1,17 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
-inherit autotools
+inherit autotools toolchain-funcs
 
-DESCRIPTION="A transparent ftp proxy"
-SRC_URI="http://frox.sourceforge.net/download/${P}.tar.bz2"
-HOMEPAGE="http://frox.sourceforge.net/"
+DESCRIPTION="Transparent ftp proxy"
+HOMEPAGE="https://frox.sourceforge.net/"
+SRC_URI="https://frox.sourceforge.net/download/${P}.tar.bz2"
 
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="0"
-KEYWORDS="amd64 ~ppc x86"
+KEYWORDS="~amd64 ~ppc ~x86"
 IUSE="clamav ssl transparent"
 
 DEPEND="
@@ -72,6 +72,10 @@
 	econf "${myeconfargs[@]}"
 }
 
+src_compile() {
+	emake AR="$(tc-getAR)"
+}
+
 src_install() {
 	default
 
```

Signed-off-by: Michael Mair-Keimberger <mmk@levelnine.at>

Closes: https://bugs.gentoo.org/724924