### PR TITLE
Cleanup incorrect MIT-with-advertising

### DIFF
--- a/app-editors/hyx/hyx-2021.06.09.ebuild
+++ b/app-editors/hyx/hyx-2021.06.09.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -9,7 +9,7 @@ DESCRIPTION="A minimalistic console hex editor with vim-like controls"
 HOMEPAGE="https://yx7.cc/code/"
 SRC_URI="https://yx7.cc/code/hyx/${P}.tar.xz"
 
-LICENSE="MIT-with-advertising"
+LICENSE="MIT"
 SLOT="0"
 KEYWORDS="amd64 x86"
 

--- a/app-misc/go-jira/go-jira-1.0.28.ebuild
+++ b/app-misc/go-jira/go-jira-1.0.28.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ HOMEPAGE="https://github.com/go-jira/jira"
 SRC_URI="https://github.com/go-jira/jira/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 SRC_URI+=" https://dev.gentoo.org/~williamh/dist/${P}-deps.tar.xz"
 
-LICENSE="Apache-2.0 BSD-2 BSD ISC MIT MIT-with-advertising"
+LICENSE="0BSD Apache-2.0 BSD BSD-2 ISC MIT"
 SLOT="0"
 KEYWORDS="amd64"
 

--- a/app-misc/neofetch/neofetch-7.1.0-r1.ebuild
+++ b/app-misc/neofetch/neofetch-7.1.0-r1.ebuild
@@ -15,7 +15,7 @@ fi
 
 DESCRIPTION="Simple information system script"
 HOMEPAGE="https://github.com/dylanaraps/neofetch"
-LICENSE="MIT-with-advertising"
+LICENSE="MIT"
 SLOT="0"
 
 PATCHES=(

--- a/app-misc/neofetch/neofetch-7.1.0.ebuild
+++ b/app-misc/neofetch/neofetch-7.1.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -15,7 +15,7 @@ fi
 
 DESCRIPTION="Simple information system script"
 HOMEPAGE="https://github.com/dylanaraps/neofetch"
-LICENSE="MIT-with-advertising"
+LICENSE="MIT"
 SLOT="0"
 IUSE="X"
 

--- a/app-misc/neofetch/neofetch-9999.ebuild
+++ b/app-misc/neofetch/neofetch-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -15,7 +15,7 @@ fi
 
 DESCRIPTION="Simple information system script"
 HOMEPAGE="https://github.com/dylanaraps/neofetch"
-LICENSE="MIT-with-advertising"
+LICENSE="MIT"
 SLOT="0"
 
 PATCHES=(

--- a/app-text/vgrep/vgrep-2.6.0.ebuild
+++ b/app-text/vgrep/vgrep-2.6.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="8"
@@ -9,7 +9,7 @@ DESCRIPTION="A pager for grep, git-grep and similar grep implementations"
 HOMEPAGE="https://github.com/vrothberg/vgrep"
 SRC_URI="https://github.com/vrothberg/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
-LICENSE="BSD GPL-3+ MIT MIT-with-advertising"
+LICENSE="Apache-2.0 BSD GPL-3 MIT"
 SLOT="0"
 KEYWORDS="amd64"
 

--- a/gui-libs/gtk-layer-shell/gtk-layer-shell-0.8.0.ebuild
+++ b/gui-libs/gtk-layer-shell/gtk-layer-shell-0.8.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2020-2023 Gentoo Authors
+# Copyright 2020-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -18,7 +18,7 @@ fi
 DESCRIPTION="Library to create desktop components for Wayland using the Layer Shell protocol"
 HOMEPAGE="https://github.com/wmww/gtk-layer-shell"
 
-LICENSE="MIT-with-advertising LGPL-3+"
+LICENSE="MIT LGPL-3+"
 SLOT="0"
 IUSE="examples gtk-doc introspection test vala"
 RESTRICT="!test? ( test )"

--- a/gui-libs/gtk-layer-shell/gtk-layer-shell-0.8.1.ebuild
+++ b/gui-libs/gtk-layer-shell/gtk-layer-shell-0.8.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2020-2023 Gentoo Authors
+# Copyright 2020-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -18,7 +18,7 @@ fi
 DESCRIPTION="Library to create desktop components for Wayland using the Layer Shell protocol"
 HOMEPAGE="https://github.com/wmww/gtk-layer-shell"
 
-LICENSE="MIT-with-advertising LGPL-3+"
+LICENSE="MIT LGPL-3+"
 SLOT="0"
 IUSE="examples gtk-doc introspection test vala"
 RESTRICT="!test? ( test )"

--- a/media-fonts/powerline-symbols/powerline-symbols-20170508.ebuild
+++ b/media-fonts/powerline-symbols/powerline-symbols-20170508.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -10,7 +10,7 @@ HOMEPAGE="https://github.com/powerline/powerline"
 SRC_URI="https://dev.gentoo.org/~johu/distfiles/${P}.tar.xz"
 # We're redistributing just the (unversioned) font from the upstream repo here
 
-LICENSE="MIT-with-advertising"
+LICENSE="MIT"
 SLOT="0"
 KEYWORDS="amd64 ~arm ~loong ~riscv x86"
 IUSE=""

--- a/media-gfx/imageworsener/imageworsener-1.3.3.ebuild
+++ b/media-gfx/imageworsener/imageworsener-1.3.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -10,7 +10,7 @@ DESCRIPTION="Utility for image scaling and processing"
 HOMEPAGE="https://entropymine.com/imageworsener/"
 SRC_URI="https://entropymine.com/${PN}/${P}.tar.gz"
 
-LICENSE="MIT-with-advertising"
+LICENSE="MIT"
 SLOT="0"
 KEYWORDS="amd64 x86"
 IUSE="jpeg png static-libs test webp zlib"

--- a/media-gfx/imageworsener/imageworsener-1.3.4.ebuild
+++ b/media-gfx/imageworsener/imageworsener-1.3.4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -10,7 +10,7 @@ DESCRIPTION="Utility for image scaling and processing"
 HOMEPAGE="https://entropymine.com/imageworsener/"
 SRC_URI="https://entropymine.com/${PN}/${P}.tar.gz"
 
-LICENSE="MIT-with-advertising"
+LICENSE="MIT"
 SLOT="0/3"  # because of libimageworsener.so.3.*.*
 KEYWORDS="~amd64 ~x86"
 IUSE="jpeg png static-libs test webp zlib"

--- a/media-gfx/imageworsener/imageworsener-1.3.5.ebuild
+++ b/media-gfx/imageworsener/imageworsener-1.3.5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -10,7 +10,7 @@ DESCRIPTION="Utility for image scaling and processing"
 HOMEPAGE="https://entropymine.com/imageworsener/"
 SRC_URI="https://entropymine.com/${PN}/${P}.tar.gz"
 
-LICENSE="MIT-with-advertising"
+LICENSE="MIT"
 SLOT="0/3"  # because of libimageworsener.so.3.*.*
 KEYWORDS="~amd64 ~x86"
 IUSE="jpeg png static-libs test webp zlib"

--- a/net-analyzer/tcping/tcping-1.3.6.ebuild
+++ b/net-analyzer/tcping/tcping-1.3.6.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,7 +8,7 @@ DESCRIPTION="Check if a desired port is reachable via TCP"
 HOMEPAGE="https://github.com/mkirchner/tcping"
 SRC_URI="https://github.com/mkirchner/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
 
-LICENSE="MIT-with-advertising"
+LICENSE="MIT"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
 

--- a/sys-apps/earlyoom/earlyoom-1.6.2.ebuild
+++ b/sys-apps/earlyoom/earlyoom-1.6.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2020-2023 Gentoo Authors
+# Copyright 2020-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,7 +8,7 @@ inherit systemd
 DESCRIPTION="Early OOM Daemon for Linux"
 HOMEPAGE="https://github.com/rfjakob/earlyoom"
 
-LICENSE="MIT-with-advertising"
+LICENSE="MIT"
 SLOT="0"
 if [ "${PV}" = "9999" ]; then
 	EGIT_REPO_URI="https://github.com/rfjakob/earlyoom.git"

--- a/sys-apps/earlyoom/earlyoom-1.7-r1.ebuild
+++ b/sys-apps/earlyoom/earlyoom-1.7-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2020-2023 Gentoo Authors
+# Copyright 2020-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -19,7 +19,7 @@ else
 	KEYWORDS="amd64 x86"
 fi
 
-LICENSE="MIT-with-advertising"
+LICENSE="MIT"
 SLOT="0"
 IUSE="man test"
 RESTRICT="!test? ( test )"

--- a/sys-apps/earlyoom/earlyoom-9999.ebuild
+++ b/sys-apps/earlyoom/earlyoom-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 Gentoo Authors
+# Copyright 2020-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -19,7 +19,7 @@ else
 	KEYWORDS="~amd64 ~x86"
 fi
 
-LICENSE="MIT-with-advertising"
+LICENSE="MIT"
 SLOT="0"
 IUSE="man test"
 RESTRICT="!test? ( test )"

--- a/sys-cluster/kops/kops-1.23.2.ebuild
+++ b/sys-cluster/kops/kops-1.23.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2021-2022 Gentoo Authors
+# Copyright 2021-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -9,7 +9,7 @@ DESCRIPTION="Kubernetes Operations"
 HOMEPAGE="https://kops.sigs.k8s.io/ https://github.com/kubernetes/kops/"
 SRC_URI="https://github.com/kubernetes/kops/archive/refs/tags/v${PV}.tar.gz -> ${P}.tar.gz"
 
-LICENSE="Apache-2.0 BSD-2 BSD-4 ECL-2.0 imagemagick ISC JSON MIT MIT-with-advertising MPL-2.0 unicode"
+LICENSE="Apache-2.0 BSD BSD-2 CC-BY-SA-4.0 MIT MPL-2.0 Unicode-DFS-2016"
 SLOT="0"
 KEYWORDS="~amd64"
 

--- a/x11-misc/svkbd/svkbd-0.2.1-r1.ebuild
+++ b/x11-misc/svkbd/svkbd-0.2.1-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2021 Gentoo Authors
+# Copyright 2021-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -9,7 +9,7 @@ DESCRIPTION="Simple Virtual Keyboard"
 HOMEPAGE="https://tools.suckless.org/x/svkbd/"
 SRC_URI="https://dl.suckless.org/tools/${P}.tar.gz"
 
-LICENSE="MIT-with-advertising"
+LICENSE="MIT"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
 

--- a/x11-terms/st-terminfo/st-terminfo-0.8.5.ebuild
+++ b/x11-terms/st-terminfo/st-terminfo-0.8.5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2022 Gentoo Authors
+# Copyright 2022-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -15,7 +15,7 @@ else
 	KEYWORDS="amd64 ~arm arm64 ~hppa ~m68k ppc64 ~riscv x86"
 fi
 
-LICENSE="MIT-with-advertising"
+LICENSE="MIT"
 SLOT="0"
 
 BDEPEND=">=sys-libs/ncurses-6.0"

--- a/x11-terms/st-terminfo/st-terminfo-0.9.ebuild
+++ b/x11-terms/st-terminfo/st-terminfo-0.9.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2022-2023 Gentoo Authors
+# Copyright 2022-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -15,7 +15,7 @@ else
 	KEYWORDS="amd64 ~arm arm64 ~hppa ~m68k ppc64 ~riscv x86"
 fi
 
-LICENSE="MIT-with-advertising"
+LICENSE="MIT"
 SLOT="0"
 
 BDEPEND=">=sys-libs/ncurses-6.0"

--- a/x11-terms/st-terminfo/st-terminfo-9999.ebuild
+++ b/x11-terms/st-terminfo/st-terminfo-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2022 Gentoo Authors
+# Copyright 2022-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -15,7 +15,7 @@ else
 	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~m68k ~ppc64 ~riscv ~x86"
 fi
 
-LICENSE="MIT-with-advertising"
+LICENSE="MIT"
 SLOT="0"
 
 BDEPEND=">=sys-libs/ncurses-6.0"

--- a/x11-terms/st/st-0.8.4-r1.ebuild
+++ b/x11-terms/st/st-0.8.4-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -9,7 +9,7 @@ DESCRIPTION="Simple terminal implementation for X"
 HOMEPAGE="https://st.suckless.org/"
 SRC_URI="https://dl.suckless.org/st/${P}.tar.gz"
 
-LICENSE="MIT-with-advertising"
+LICENSE="MIT"
 SLOT="0"
 KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc64 ~riscv ~x86"
 IUSE="savedconfig"

--- a/x11-terms/st/st-0.8.4.ebuild
+++ b/x11-terms/st/st-0.8.4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,7 +8,7 @@ DESCRIPTION="simple terminal implementation for X"
 HOMEPAGE="https://st.suckless.org/"
 SRC_URI="https://dl.suckless.org/st/${P}.tar.gz"
 
-LICENSE="MIT-with-advertising"
+LICENSE="MIT"
 SLOT="0"
 KEYWORDS="amd64 ~arm arm64 ~hppa ppc64 ~riscv x86"
 IUSE="savedconfig"

--- a/x11-terms/st/st-0.8.5.ebuild
+++ b/x11-terms/st/st-0.8.5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -16,7 +16,7 @@ else
 	KEYWORDS="amd64 ~arm arm64 ~hppa ~m68k ppc64 ~riscv x86"
 fi
 
-LICENSE="MIT-with-advertising"
+LICENSE="MIT"
 SLOT="0"
 
 RDEPEND="

--- a/x11-terms/st/st-0.9.ebuild
+++ b/x11-terms/st/st-0.9.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -16,7 +16,7 @@ else
 	KEYWORDS="amd64 ~arm arm64 ~hppa ~m68k ppc64 ~riscv x86"
 fi
 
-LICENSE="MIT-with-advertising"
+LICENSE="MIT"
 SLOT="0"
 
 RDEPEND="

--- a/x11-terms/st/st-9999.ebuild
+++ b/x11-terms/st/st-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -16,7 +16,7 @@ else
 	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~m68k ~ppc64 ~riscv ~x86"
 fi
 
-LICENSE="MIT-with-advertising"
+LICENSE="MIT"
 SLOT="0"
 
 RDEPEND="


### PR DESCRIPTION
Haven't gone through ebuilds where homepage / source 404's (sandy and stimg). Or if I found it too arduous (pycharm-community and skypeforlinux). The only valid uses of MIT-with-advertising that I can confirm are e16-keyedit and e16menuedit2.

And go-jira may have to have all-rights-reserved due to this https://github.com/coryb/kingpeon/issues/3