### PR TITLE
java-utils-2.eclass: default to default_src_prepare for future EAPI

### DIFF
--- a/eclass/java-utils-2.eclass
+++ b/eclass/java-utils-2.eclass
@@ -1,4 +1,4 @@
-# Copyright 2004-2023 Gentoo Authors
+# Copyright 2004-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: java-utils-2.eclass
@@ -1972,7 +1972,10 @@ etestng() {
 # src_prepare Searches for bundled jars
 # Don't call directly, but via java-pkg-2_src_prepare!
 java-utils-2_src_prepare() {
-	eapply_user
+	case ${EAPI} in
+		[678]) eapply_user ;;
+		*) default_src_prepare ;;
+	esac
 
 	# Check for files in JAVA_RM_FILES array.
 	if [[ ${JAVA_RM_FILES[@]} ]]; then


### PR DESCRIPTION
Presently patches from a PATCHES array are not getting applied unless "default" or "eapply_user" is set in the ebuild. In cases where nothing else needs to be prepared it still needs src_prepare in the ebuild

src_prepare() {
	default
}

With this change, starting from EAPI 9 this will no longer be needed. In cases where any other changes are done in the prepare phase it would only need java-pkg-2_src_prepare be added:

src_prepare() {
	java-pkg-2_src_prepare
	cp, rm, mv, sed or other changes
}

Bug: https://bugs.gentoo.org/780585