### PR TITLE
app-crypt/certbot: bump supported python version

### DIFF
--- a/app-crypt/certbot/certbot-2.8.0.ebuild
+++ b/app-crypt/certbot/certbot-2.8.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..12} )
 DISTUTILS_USE_PEP517=setuptools
 
 inherit distutils-r1


### PR DESCRIPTION
Support for python 3.12 was added in Certbot 2.8.0.

Pull: https://github.com/certbot/certbot/pull/9852
Issue: https://github.com/certbot/certbot/issues/9779