### PR TITLE
media-gfx/krita: restrict libjxl dep

### DIFF
--- a/media-gfx/krita/krita-5.1.5-r1.ebuild
+++ b/media-gfx/krita/krita-5.1.5-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -70,7 +70,7 @@ RDEPEND="${PYTHON_DEPS}
 	fftw? ( sci-libs/fftw:3.0= )
 	gif? ( media-libs/giflib )
 	gsl? ( sci-libs/gsl:= )
-	jpegxl? ( >=media-libs/libjxl-0.7.0_pre20220825 )
+	jpegxl? ( <media-libs/libjxl-0.9.0 )
 	heif? ( >=media-libs/libheif-1.11:=[x265] )
 	mypaint-brush-engine? ( media-libs/libmypaint:= )
 	openexr? ( media-libs/openexr:= )


### PR DESCRIPTION
Signed-off-by: Andrew Udvare <audvare@gmail.com>

Krita 5.1.5 cannot be built with >= libjxl 0.9.0:

```
/var/tmp/portage/media-gfx/krita-5.1.5/work/krita-5.1.5/plugins/impex/jxl/JPEGXLImport.cpp: In member function ‘virtual KisImportExportErrorCode JPEGXLImport::convert(KisDocument*, QIODevice*, KisPropertiesConfigurationSP)’:
/var/tmp/portage/media-gfx/krita-5.1.5/work/krita-5.1.5/plugins/impex/jxl/JPEGXLImport.cpp:357:55: error: cannot convert ‘std::nullptr_t’ to ‘JxlColorProfileTarget’
  357 |                                                       nullptr,
      |                                                       ^~~~~~~
      |                                                       |
      |                                                       std::nullptr_t
In file included from /usr/include/jxl/decode_cxx.h:18,
                 from /var/tmp/portage/media-gfx/krita-5.1.5/work/krita-5.1.5/plugins/impex/jxl/JPEGXLImport.cpp:11:
/usr/include/jxl/decode.h:750:50: note:   initializing argument 2 of ‘JxlDecoderStatus JxlDecoderGetColorAsEncodedProfile(const JxlDecoder*, JxlColorProfileTarget, JxlColorEncoding*)’
  750 |     const JxlDecoder* dec, JxlColorProfileTarget target,
      |                            ~~~~~~~~~~~~~~~~~~~~~~^~~~~~
/var/tmp/portage/media-gfx/krita-5.1.5/work/krita-5.1.5/plugins/impex/jxl/JPEGXLImport.cpp:460:63: error: cannot convert ‘std::nullptr_t’ to ‘JxlColorProfileTarget’
  460 |                     != JxlDecoderGetICCProfileSize(dec.get(), nullptr, JXL_COLOR_PROFILE_TARGET_DATA, &iccSize)) {
      |                                                               ^~~~~~~
      |                                                               |
      |                                                               std::nullptr_t
/usr/include/jxl/decode.h:776:50: note:   initializing argument 2 of ‘JxlDecoderStatus JxlDecoderGetICCProfileSize(const JxlDecoder*, JxlColorProfileTarget, size_t*)’
  776 |     const JxlDecoder* dec, JxlColorProfileTarget target, size_t* size);
      |                            ~~~~~~~~~~~~~~~~~~~~~~^~~~~~
/var/tmp/portage/media-gfx/krita-5.1.5/work/krita-5.1.5/plugins/impex/jxl/JPEGXLImport.cpp:469:55: error: cannot convert ‘std::nullptr_t’ to ‘JxlColorProfileTarget’
  469 |                                                       nullptr,
      |                                                       ^~~~~~~
      |                                                       |
      |                                                       std::nullptr_t
/usr/include/jxl/decode.h:794:50: note:   initializing argument 2 of ‘JxlDecoderStatus JxlDecoderGetColorAsICCProfile(const JxlDecoder*, JxlColorProfileTarget, uint8_t*, size_t)’
  794 |     const JxlDecoder* dec, JxlColorProfileTarget target, uint8_t* icc_profile,
      |                            ~~~~~~~~~~~~~~~~~~~~~~^~~~~~
/var/tmp/portage/media-gfx/krita-5.1.5/work/krita-5.1.5/plugins/impex/jxl/JPEGXLImport.cpp: In instantiation of ‘void imageOutCallback(void*, size_t, size_t, size_t, const void*) [with channelsType = float; bool swap = true; LinearizePolicy policy = LinearizePolicy::LinearFromPQ; bool applyOOTF = true; size_t = long unsigned int]’:
/var/tmp/portage/media-gfx/krita-5.1.5/work/krita-5.1.5/plugins/impex/jxl/JPEGXLImport.cpp:159:16:   required from ‘void (* generateCallbackWithPolicy(const JPEGXLImportData&))(void*, size_t, size_t, size_t, const void*) [with channelsType = float; bool swap = true; LinearizePolicy policy = LinearizePolicy::LinearFromPQ; JxlImageOutCallback = void (*)(void*, long unsigned int, long unsigned int, long unsigned int, const void*)]’
/var/tmp/portage/media-gfx/krita-5.1.5/work/krita-5.1.5/plugins/impex/jxl/JPEGXLImport.cpp:170:93:   required from ‘void (* generateCallbackWithSwap(const JPEGXLImportData&))(void*, size_t, size_t, size_t, const void*) [with channelsType = float; bool swap = true; JxlImageOutCallback = void (*)(void*, long unsigned int, long unsigned int, long unsigned int, const void*)]’
/var/tmp/portage/media-gfx/krita-5.1.5/work/krita-5.1.5/plugins/impex/jxl/JPEGXLImport.cpp:188:60:   required from ‘void (* generateCallbackWithType(const JPEGXLImportData&))(void*, size_t, size_t, size_t, const void*) [with channelsType = float; JxlImageOutCallback = void (*)(void*, long unsigned int, long unsigned int, long unsigned int, const void*)]’
/var/tmp/portage/media-gfx/krita-5.1.5/work/krita-5.1.5/plugins/impex/jxl/JPEGXLImport.cpp:198:47:   required from here
/var/tmp/portage/media-gfx/krita-5.1.5/work/krita-5.1.5/plugins/impex/jxl/JPEGXLImport.cpp:104:23: warning: unused variable ‘lCoef’ [-Wunused-variable]
  104 |         const double *lCoef = data->lCoef.constData();
      |                       ^~~~~
/var/tmp/portage/media-gfx/krita-5.1.5/work/krita-5.1.5/plugins/impex/jxl/JPEGXLImport.cpp: In instantiation of ‘void imageOutCallback(void*, size_t, size_t, size_t, const void*) [with channelsType = float; bool swap = true; LinearizePolicy policy = LinearizePolicy::LinearFromPQ; bool applyOOTF = false; size_t = long unsigned int]’:
/var/tmp/portage/media-gfx/krita-5.1.5/work/krita-5.1.5/plugins/impex/jxl/JPEGXLImport.cpp:161:16:   required from ‘void (* generateCallbackWithPolicy(const JPEGXLImportData&))(void*, size_t, size_t, size_t, const void*) [with channelsType = float; bool swap = true; LinearizePolicy policy = LinearizePolicy::LinearFromPQ; JxlImageOutCallback = void (*)(void*, long unsigned int, long unsigned int, long unsigned int, const void*)]’
```