### PR TITLE
mate-extra/mate-polkit: check +daemon in sys-auth/polkit

### DIFF
--- a/mate-extra/mate-polkit/mate-polkit-1.26.0-r1.ebuild
+++ b/mate-extra/mate-polkit/mate-polkit-1.26.0-r1.ebuild
@@ -22,7 +22,7 @@ COMMON_DEPEND="x11-libs/gdk-pixbuf:2
 
 RDEPEND="${COMMON_DEPEND}
 	>=dev-libs/glib-2.50:2
-	>=sys-auth/polkit-0.102
+	>=sys-auth/polkit-0.102[daemon]
 	accountsservice? ( sys-apps/accountsservice )"
 
 BDEPEND="${COMMON_DEPEND}

--- a/mate-extra/mate-polkit/mate-polkit-1.27.1.ebuild
+++ b/mate-extra/mate-polkit/mate-polkit-1.27.1.ebuild
@@ -23,7 +23,7 @@ COMMON_DEPEND="x11-libs/gdk-pixbuf:2
 
 RDEPEND="${COMMON_DEPEND}
 	>=dev-libs/glib-2.50:2
-	>=sys-auth/polkit-0.102
+	>=sys-auth/polkit-0.102[daemon]
 	accountsservice? ( sys-apps/accountsservice )"
 
 BDEPEND="${COMMON_DEPEND}


### PR DESCRIPTION
This isn't applied on all profiles, adding check in the meantime until this is fixed in all profiles.

Closes: https://bugs.gentoo.org/922510