### PR TITLE
dev-util/gnome-builder: Added support for rust-analyzer

### DIFF
--- a/dev-util/gnome-builder/gnome-builder-44.2-r1.ebuild
+++ b/dev-util/gnome-builder/gnome-builder-44.2-r1.ebuild
@@ -219,7 +219,7 @@ src_configure() {
 		-Dplugin_retab=true
 		-Dplugin_rstcheck=true
 		-Dplugin_rubocop=true
-		-Dplugin_rust_analyzer=false # rust-analyzer not packaged
+		-Dplugin_rust_analyzer=true
 		-Dplugin_serve_d=true
 		-Dplugin_shellcheck=true
 		-Dplugin_shellcmd=true
@@ -267,6 +267,7 @@ pkg_postinst() {
 
 	optfeature_header "Language support"
 	optfeature "Rust's Cargo build system" virtual/rust
+	optfeature "Rust-analyzer" || dev-lang/rust[rust-analyzer] dev-lang/rust-bin[rust-analyzer]
 	optfeature "CMake" dev-build/cmake
 	optfeature "Java Maven build system" dev-java/maven-bin
 	optfeature "Meson Build system" dev-build/meson


### PR DESCRIPTION
Commented changes in the bug https://bugs.gentoo.org/914751 to add support for rust-analyzer