### PR TITLE
dev-libs/gobject-introspection: enable py3.12

### DIFF
--- a/dev-libs/gobject-introspection/gobject-introspection-1.78.1.ebuild
+++ b/dev-libs/gobject-introspection/gobject-introspection-1.78.1.ebuild
@@ -3,12 +3,12 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..11} )
+PYTHON_COMPAT=( python3_{10..12} )
 PYTHON_REQ_USE="xml(+)"
 inherit gnome.org meson python-single-r1 xdg
 
 DESCRIPTION="Introspection system for GObject-based libraries"
-HOMEPAGE="https://wiki.gnome.org/Projects/GObjectIntrospection"
+HOMEPAGE="https://gi.readthedocs.io"
 
 LICENSE="LGPL-2+ GPL-2+"
 SLOT="0"
@@ -22,6 +22,9 @@ RDEPEND="
 	>=dev-libs/gobject-introspection-common-${PV}
 	>=dev-libs/glib-2.$(($(ver_cut 2) - 1)).0:2
 	dev-libs/libffi:=
+	$(python_gen_cond_dep '
+		dev-python/setuptools[${PYTHON_USEDEP}]
+	' 3.12)
 	doctool? (
 		$(python_gen_cond_dep '
 			dev-python/mako[${PYTHON_USEDEP}]


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/917029

---

Run-time dependency on setuptools for distutils.
https://gitlab.gnome.org/GNOME/gobject-introspection/-/merge_requests/444

HOMEPAGE has moved.
