### PR TITLE
media-libs/mlt: fix ld.lld errors: version script assignment failed: symbol not defined

### DIFF
--- a/media-libs/mlt/mlt-7.22.0-r1.ebuild
+++ b/media-libs/mlt/mlt-7.22.0-r1.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 PYTHON_COMPAT=( python3_{9..12} )
-inherit python-single-r1 cmake
+inherit python-single-r1 cmake flag-o-matic
 
 DESCRIPTION="Open source multimedia framework for television broadcasting"
 HOMEPAGE="https://www.mltframework.org/"
@@ -110,6 +110,9 @@ src_prepare() {
 }
 
 src_configure() {
+	# Workaround for bug #919981
+	append-ldflags $(test-flags-CCLD -Wl,--undefined-version)
+
 	local mycmakeargs=(
 		-DCMAKE_SKIP_RPATH=ON
 		-DCLANG_FORMAT=OFF

--- a/media-libs/mlt/mlt-7.22.0.ebuild
+++ b/media-libs/mlt/mlt-7.22.0.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 PYTHON_COMPAT=( python3_{9..12} )
-inherit python-single-r1 cmake
+inherit python-single-r1 cmake flag-o-matic
 
 DESCRIPTION="Open source multimedia framework for television broadcasting"
 HOMEPAGE="https://www.mltframework.org/"
@@ -103,6 +103,9 @@ src_prepare() {
 }
 
 src_configure() {
+	# Workaround for bug #919981
+	append-ldflags $(test-flags-CCLD -Wl,--undefined-version)
+
 	local mycmakeargs=(
 		-DCMAKE_SKIP_RPATH=ON
 		-DCLANG_FORMAT=OFF


### PR DESCRIPTION
ld.lld 17 fix, similar to https://github.com/gentoo/gentoo/pull/34595

Closes: https://bugs.gentoo.org/919981