### PR TITLE
x11-libs/wxGTK: fix ld.lld errors: version script assignment failed: symbol not defined

### DIFF
--- a/x11-libs/wxGTK/wxGTK-3.0.4-r5.ebuild
+++ b/x11-libs/wxGTK/wxGTK-3.0.4-r5.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-inherit multilib-minimal
+inherit multilib-minimal flag-o-matic
 
 DESCRIPTION="GTK+ version of wxWidgets, a cross-platform C++ GUI toolkit"
 HOMEPAGE="https://wxwidgets.org/"
@@ -53,6 +53,9 @@ PATCHES=(
 )
 
 multilib_src_configure() {
+	# Workaround for bug #915154
+	append-ldflags $(test-flags-CCLD -Wl,--undefined-version)
+
 	local myconf=(
 		# X independent options
 		--with-zlib=sys

--- a/x11-libs/wxGTK/wxGTK-3.0.5.1-r1.ebuild
+++ b/x11-libs/wxGTK/wxGTK-3.0.5.1-r1.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-inherit multilib-minimal
+inherit multilib-minimal flag-o-matic
 
 WXSUBVERSION=${PV}-gtk3				# 3.0.5.1-gtk3
 WXVERSION=${WXSUBVERSION%.*}			# 3.0.5
@@ -92,6 +92,9 @@ src_prepare() {
 }
 
 multilib_src_configure() {
+	# Workaround for bug #915154
+	append-ldflags $(test-flags-CCLD -Wl,--undefined-version)
+
 	# X independent options
 	local myeconfargs=(
 		--with-zlib=sys

--- a/x11-libs/wxGTK/wxGTK-3.2.1.ebuild
+++ b/x11-libs/wxGTK/wxGTK-3.2.1.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-inherit multilib-minimal
+inherit multilib-minimal flag-o-matic
 
 WXSUBVERSION=${PV}-gtk3				# 3.2.1-gtk3
 WXVERSION=${PV}							# 3.2.1
@@ -124,6 +124,9 @@ src_prepare() {
 }
 
 multilib_src_configure() {
+	# Workaround for bug #915154
+	append-ldflags $(test-flags-CCLD -Wl,--undefined-version)
+
 	# X independent options
 	local myeconfargs=(
 		--with-zlib=sys

--- a/x11-libs/wxGTK/wxGTK-3.2.2.1-r1.ebuild
+++ b/x11-libs/wxGTK/wxGTK-3.2.2.1-r1.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-inherit multilib-minimal
+inherit multilib-minimal flag-o-matic
 
 WXSUBVERSION="${PV}-gtk3"				# 3.2.1-gtk3
 WXVERSION="$(ver_cut 1-3)"				# 3.2.1
@@ -126,6 +126,9 @@ src_prepare() {
 }
 
 multilib_src_configure() {
+	# Workaround for bug #915154
+	append-ldflags $(test-flags-CCLD -Wl,--undefined-version)
+
 	# X independent options
 	local myeconfargs=(
 		--with-zlib=sys

--- a/x11-libs/wxGTK/wxGTK-3.2.2.1-r2.ebuild
+++ b/x11-libs/wxGTK/wxGTK-3.2.2.1-r2.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-inherit multilib-minimal
+inherit multilib-minimal flag-o-matic
 
 WXSUBVERSION="${PV}-gtk3"				# 3.2.1-gtk3
 WXVERSION="$(ver_cut 1-3)"				# 3.2.1
@@ -126,6 +126,9 @@ src_prepare() {
 }
 
 multilib_src_configure() {
+	# Workaround for bug #915154
+	append-ldflags $(test-flags-CCLD -Wl,--undefined-version)
+
 	# X independent options
 	local myeconfargs=(
 		--with-zlib=sys

--- a/x11-libs/wxGTK/wxGTK-3.2.2.1-r3.ebuild
+++ b/x11-libs/wxGTK/wxGTK-3.2.2.1-r3.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit multilib-minimal
+inherit multilib-minimal flag-o-matic
 
 WXSUBVERSION="${PV}-gtk3"				# 3.2.1-gtk3
 WXVERSION="$(ver_cut 1-3)"				# 3.2.1
@@ -126,6 +126,9 @@ src_prepare() {
 }
 
 multilib_src_configure() {
+	# Workaround for bug #915154
+	append-ldflags $(test-flags-CCLD -Wl,--undefined-version)
+
 	# X independent options
 	local myeconfargs=(
 		--with-zlib=sys


### PR DESCRIPTION
ld.lld 17 fix, similar to https://github.com/gentoo/gentoo/pull/34595

Closes: https://bugs.gentoo.org/915154