### PR TITLE
sys-apps/pmount: fix a bug in bundled realpath

### DIFF
--- a/sys-apps/pmount/files/pmount-0.9.99_alpha-fix-buggy-realpath-implementation.patch
+++ b/sys-apps/pmount/files/pmount-0.9.99_alpha-fix-buggy-realpath-implementation.patch
@@ -1,0 +1,31 @@
+Fix bug in realpath implementation bundled with pmount which caused it to
+likely fail on paths with several symlinks.
+
+The issue was first noticed by failure in tests:
+Gentoo-Bug: https://bugs.gentoo.org/741810
+--- pmount-0.9.99-alpha/src/realpath.c.orig	2024-01-21 09:19:55.776224329 +0300
++++ pmount-0.9.99-alpha/src/realpath.c	2024-01-21 09:30:46.751233027 +0300
+@@ -128,6 +128,7 @@
+ 		} else {
+ #ifdef resolve_symlinks		/* Richard Gooch dislikes sl resolution */
+ 			int m;
++			char *old_buf;
+ 
+ 			/* Note: readlink doesn't add the null byte. */
+ 			link_path[n] = '\0';
+@@ -141,12 +142,13 @@
+ 
+ 			/* Insert symlink contents into path. */
+ 			m = strlen(path);
+-			if (buf)
+-				free(buf);
++			old_buf = buf; /* path might point to buf at this point */
+ 			buf = xmalloc(m + n + 1);
+ 			memcpy(buf, link_path, n);
+ 			memcpy(buf + n, path, m + 1);
+ 			path = buf;
++			if (old_buf)
++				free(old_buf);
+ #endif
+ 		}
+ 		*npath++ = '/';

--- a/sys-apps/pmount/pmount-0.9.99_alpha-r8.ebuild
+++ b/sys-apps/pmount/pmount-0.9.99_alpha-r8.ebuild
@@ -1,0 +1,93 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit bash-completion-r1
+
+DESCRIPTION="Policy based mounter that gives the ability to mount removable devices as a user"
+HOMEPAGE="https://launchpad.net/pmount"
+SRC_URI="mirror://debian/pool/main/p/${PN}/${PN}_${PV/_/-}.orig.tar.bz2"
+S="${WORKDIR}"/${P/_/-}
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+IUSE="crypt"
+
+# cryptsetup is executed at runtime only, no libraries used AFAICT
+# but in DEPEND too as it's checked during configure
+RDEPEND="
+	acct-group/plugdev
+	>=sys-apps/util-linux-2.17.2
+	crypt? ( >=sys-fs/cryptsetup-1.0.6-r2 )"
+DEPEND="${RDEPEND}"
+BDEPEND="
+	dev-util/intltool
+	sys-devel/gettext"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-0.9.19-testsuite-missing-dir.patch
+	"${FILESDIR}"/${P}-locale-regex.patch
+	"${FILESDIR}"/${P}-exfat-support.patch
+	"${FILESDIR}"/${P}-limits-musl.patch
+	"${FILESDIR}"/${P}-missing-includes.patch
+	"${FILESDIR}"/${P}-fix-buggy-realpath-implementation.patch
+)
+
+src_prepare() {
+	# Restore default value from pmount <= 0.9.23 wrt #393633
+	sed -i -e '/^not_physically_logged_allow/s:=.*:= yes:' etc/pmount.conf || die
+
+	cat <<-EOF > po/POTFILES.skip || die
+	src/conffile.c
+	src/configuration.c
+	src/loop.c
+	EOF
+
+	default
+}
+
+src_configure() {
+	econf --disable-hal
+}
+
+src_test() {
+	local testdir=${S}/tests/check_fstab
+
+	ln -s a "${testdir}/b" &&
+		ln -s d "${testdir}/c" &&
+		ln -s c "${testdir}/e" ||
+		die "Unable to create fake symlinks required for testsuite"
+
+	emake check
+}
+
+src_install() {
+	# Must be run SETUID+SETGID, bug #250106
+	exeinto /usr/bin
+	exeopts -m 6710 -g plugdev
+	doexe src/{p,pu}mount
+
+	dodoc AUTHORS ChangeLog TODO
+	doman man/{{p,pu}mount.1,pmount.conf.5}
+
+	insinto /etc
+	doins etc/pmount.{allow,conf}
+
+	keepdir /media #501772
+
+	newbashcomp "${FILESDIR}/${PN}.bash-completion" "${PN}"
+	bashcomp_alias pmount pumount
+}
+
+pkg_postinst() {
+	elog
+	elog "This package has been installed setuid and setgid."
+
+	elog "The permissions are as such that only users that belong to the plugdev"
+	elog "group are allowed to run this. But if a script run by root mounts a"
+	elog "device, members of the plugdev group will have access to it."
+	elog
+	elog "Please add your user to the plugdev group to be able to mount USB drives"
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/741810