### PR TITLE
dev-cpp/sdbus-c++ now works with sys-libs/basu, instead of elogind or systemd

### DIFF
--- a/dev-cpp/sdbus-c++/sdbus-c++-1.4.0.ebuild
+++ b/dev-cpp/sdbus-c++/sdbus-c++-1.4.0.ebuild
@@ -16,11 +16,9 @@ REQUIRED_USE="?? ( elogind systemd )"
 RESTRICT="!test? ( test )"
 
 RDEPEND="
-	|| (
-		elogind? ( >=sys-auth/elogind-236 )
-		systemd? ( >=sys-apps/systemd-236:= )
-		>=sys-libs/basu-0.2.1
-	)
+	elogind? ( >=sys-auth/elogind-236 )
+	systemd? ( >=sys-apps/systemd-236:= )
+	!elogind? ( !systemd? ( >=sys-libs/basu-0.2.1 ) )
 	tools? ( dev-libs/expat )
 "
 

--- a/dev-cpp/sdbus-c++/sdbus-c++-1.4.0.ebuild
+++ b/dev-cpp/sdbus-c++/sdbus-c++-1.4.0.ebuild
@@ -12,12 +12,15 @@ LICENSE="LGPL-2.1+ Nokia-Qt-LGPL-Exception-1.1" # Nothing to do with Qt but exce
 SLOT="0/1"
 KEYWORDS="~amd64"
 IUSE="doc +elogind systemd test tools"
-REQUIRED_USE="^^ ( elogind systemd )"
+REQUIRED_USE="?? ( elogind systemd )"
 RESTRICT="!test? ( test )"
 
 RDEPEND="
-	elogind? ( >=sys-auth/elogind-236 )
-	systemd? ( >=sys-apps/systemd-236:= )
+	|| (
+		elogind? ( >=sys-auth/elogind-236 )
+		systemd? ( >=sys-apps/systemd-236:= )
+		>=sys-libs/basu-0.2.1
+	)
 	tools? ( dev-libs/expat )
 "
 


### PR DESCRIPTION
[https://github.com/Kistler-Group/sdbus-cpp](https://github.com/Kistler-Group/sdbus-cpp) - as developer states, the dependency is either systemd/elogind/basu, not just systemd/elogind as it was in this ebuild. So I fixed this and now you can use sdbus-c++ without elogind or systemd.