### PR TITLE
media-gfx/blender: clang/lld build fixes

### DIFF
--- a/media-gfx/blender/blender-3.3.6-r1.ebuild
+++ b/media-gfx/blender/blender-3.3.6-r1.ebuild
@@ -214,6 +214,9 @@ src_prepare() {
 }
 
 src_configure() {
+	# Workaround for bug #922600
+	append-ldflags $(test-flags-CCLD -Wl,--undefined-version)
+
 	append-lfs-flags
 
 	local mycmakeargs=(

--- a/media-gfx/blender/blender-3.3.8.ebuild
+++ b/media-gfx/blender/blender-3.3.8.ebuild
@@ -214,6 +214,9 @@ src_prepare() {
 }
 
 src_configure() {
+	# Workaround for bug #922600
+	append-ldflags $(test-flags-CCLD -Wl,--undefined-version)
+
 	append-lfs-flags
 
 	local mycmakeargs=(

--- a/media-gfx/blender/blender-3.4.1-r3.ebuild
+++ b/media-gfx/blender/blender-3.4.1-r3.ebuild
@@ -221,6 +221,9 @@ src_prepare() {
 }
 
 src_configure() {
+	# Workaround for bug #922600
+	append-ldflags $(test-flags-CCLD -Wl,--undefined-version)
+
 	append-lfs-flags
 	blender_get_version
 

--- a/media-gfx/blender/blender-3.5.1-r1.ebuild
+++ b/media-gfx/blender/blender-3.5.1-r1.ebuild
@@ -224,6 +224,9 @@ src_prepare() {
 }
 
 src_configure() {
+	# Workaround for bug #922600
+	append-ldflags $(test-flags-CCLD -Wl,--undefined-version)
+
 	append-lfs-flags
 	blender_get_version
 

--- a/media-gfx/blender/blender-3.6.0.ebuild
+++ b/media-gfx/blender/blender-3.6.0.ebuild
@@ -224,6 +224,9 @@ src_prepare() {
 }
 
 src_configure() {
+	# Workaround for bug #922600
+	append-ldflags $(test-flags-CCLD -Wl,--undefined-version)
+
 	append-lfs-flags
 	blender_get_version
 

--- a/media-gfx/blender/blender-3.6.5.ebuild
+++ b/media-gfx/blender/blender-3.6.5.ebuild
@@ -222,6 +222,9 @@ src_prepare() {
 }
 
 src_configure() {
+	# Workaround for bug #922600
+	append-ldflags $(test-flags-CCLD -Wl,--undefined-version)
+
 	append-lfs-flags
 	blender_get_version
 

--- a/media-gfx/blender/blender-4.0.1.ebuild
+++ b/media-gfx/blender/blender-4.0.1.ebuild
@@ -141,6 +141,10 @@ BDEPEND="
 	)
 "
 
+PATCHES=(
+	"${FILESDIR}/${PN}-4.0.1-fix-cflags-cleaner.patch"  # to be dropped for releases after Dec 8, 2023
+)
+
 blender_check_requirements() {
 	[[ ${MERGE_TYPE} != binary ]] && use openmp && tc-check-openmp
 

--- a/media-gfx/blender/blender-4.0.1.ebuild
+++ b/media-gfx/blender/blender-4.0.1.ebuild
@@ -237,6 +237,9 @@ src_prepare() {
 }
 
 src_configure() {
+	# Workaround for bug #922600
+	append-ldflags $(test-flags-CCLD -Wl,--undefined-version)
+
 	append-lfs-flags
 	blender_get_version
 

--- a/media-gfx/blender/blender-9999.ebuild
+++ b/media-gfx/blender/blender-9999.ebuild
@@ -235,6 +235,9 @@ src_prepare() {
 }
 
 src_configure() {
+	# Workaround for bug #922600
+	append-ldflags $(test-flags-CCLD -Wl,--undefined-version)
+
 	append-lfs-flags
 	blender_get_version
 

--- a/media-gfx/blender/files/blender-4.0.1-fix-cflags-cleaner.patch
+++ b/media-gfx/blender/files/blender-4.0.1-fix-cflags-cleaner.patch
@@ -1,0 +1,39 @@
+Fix CMake Error: string sub-command REGEX, mode REPLACE needs at least 6 arguments total to command.
+https://bugs.gentoo.org/922324
+https://github.com/blender/blender/commit/ecd307041e4181f721bf5d2248c02ffe980edcba
+--- a/build_files/cmake/macros.cmake
++++ b/build_files/cmake/macros.cmake
+@@ -750,11 +750,11 @@ macro(remove_c_flag
+   _flag)
+ 
+   foreach(f ${ARGV})
+-    string(REGEX REPLACE ${f} "" CMAKE_C_FLAGS ${CMAKE_C_FLAGS})
+-    string(REGEX REPLACE ${f} "" CMAKE_C_FLAGS_DEBUG ${CMAKE_C_FLAGS_DEBUG})
+-    string(REGEX REPLACE ${f} "" CMAKE_C_FLAGS_RELEASE ${CMAKE_C_FLAGS_RELEASE})
+-    string(REGEX REPLACE ${f} "" CMAKE_C_FLAGS_MINSIZEREL ${CMAKE_C_FLAGS_MINSIZEREL})
+-    string(REGEX REPLACE ${f} "" CMAKE_C_FLAGS_RELWITHDEBINFO ${CMAKE_C_FLAGS_RELWITHDEBINFO})
++    string(REGEX REPLACE ${f} "" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
++    string(REGEX REPLACE ${f} "" CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}")
++    string(REGEX REPLACE ${f} "" CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE}")
++    string(REGEX REPLACE ${f} "" CMAKE_C_FLAGS_MINSIZEREL "${CMAKE_C_FLAGS_MINSIZEREL}")
++    string(REGEX REPLACE ${f} "" CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO}")
+   endforeach()
+   unset(f)
+ endmacro()
+@@ -763,11 +763,11 @@ macro(remove_cxx_flag
+   _flag)
+ 
+   foreach(f ${ARGV})
+-    string(REGEX REPLACE ${f} "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
+-    string(REGEX REPLACE ${f} "" CMAKE_CXX_FLAGS_DEBUG ${CMAKE_CXX_FLAGS_DEBUG})
+-    string(REGEX REPLACE ${f} "" CMAKE_CXX_FLAGS_RELEASE ${CMAKE_CXX_FLAGS_RELEASE})
+-    string(REGEX REPLACE ${f} "" CMAKE_CXX_FLAGS_MINSIZEREL ${CMAKE_CXX_FLAGS_MINSIZEREL})
+-    string(REGEX REPLACE ${f} "" CMAKE_CXX_FLAGS_RELWITHDEBINFO ${CMAKE_CXX_FLAGS_RELWITHDEBINFO})
++    string(REGEX REPLACE ${f} "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
++    string(REGEX REPLACE ${f} "" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
++    string(REGEX REPLACE ${f} "" CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
++    string(REGEX REPLACE ${f} "" CMAKE_CXX_FLAGS_MINSIZEREL "${CMAKE_CXX_FLAGS_MINSIZEREL}")
++    string(REGEX REPLACE ${f} "" CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
+   endforeach()
+   unset(f)
+ endmacro()


### PR DESCRIPTION
Fix 2 separate issues when building in clang/ld.lld environment:
* configure fails with "string sub-command REGEX, mode REPLACE needs at least 6 arguments"
* ld.lld: error: version script assignment of 'global' to symbol '_bss_start' failed: symbol not defined

Closes: https://bugs.gentoo.org/922324
Closes: https://bugs.gentoo.org/922600