### PR TITLE
dev-util/itstool: enable py3.12

### DIFF
--- a/dev-util/itstool/files/itstool-2.0.7-raw-string.patch
+++ b/dev-util/itstool/files/itstool-2.0.7-raw-string.patch
@@ -1,0 +1,74 @@
+From: https://github.com/itstool/itstool/pull/51/commits/32c7d07664dc37765100285d1202d488cd6a27e8
+From 32c7d07664dc37765100285d1202d488cd6a27e8 Mon Sep 17 00:00:00 2001
+From: Nils Philippsen <nils@tiptoe.de>
+Date: Mon, 9 Oct 2023 14:26:43 +0200
+Subject: [PATCH] Fix insufficiently quoted regular expressions
+
+These went under the radar until Python 3.12 started warning about them.
+
+Signed-off-by: Nils Philippsen <nils@tiptoe.de>
+---
+ itstool.in | 14 +++++++-------
+ 1 file changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/itstool.in b/itstool.in
+index c21ad4b..4452616 100755
+--- a/itstool.in
++++ b/itstool.in
+@@ -220,7 +220,7 @@ class Message (object):
+         if not isinstance(text, ustr_type):
+             text = ustr(text, 'utf-8')
+         self._message[-1] += text.replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;')
+-        if re.sub('\s+', ' ', text).strip() != '':
++        if re.sub(r'\s+', ' ', text).strip() != '':
+             self._empty = False
+ 
+     def add_entity_ref (self, name):
+@@ -318,7 +318,7 @@ class Message (object):
+                 message += '<_:%s-%i/>' % (msg.name, placeholder)
+                 placeholder += 1
+         if not self._preserve:
+-            message = re.sub('\s+', ' ', message).strip()
++            message = re.sub(r'\s+', ' ', message).strip()
+         return message
+ 
+     def get_preserve_space (self):
+@@ -456,9 +456,9 @@ class LocNote (object):
+             if self._preserve_space:
+                 return self.locnote
+             else:
+-                return re.sub('\s+', ' ', self.locnote).strip()
++                return re.sub(r'\s+', ' ', self.locnote).strip()
+         elif self.locnoteref is not None:
+-            return '(itstool) link: ' + re.sub('\s+', ' ', self.locnoteref).strip()
++            return '(itstool) link: ' + re.sub(r'\s+', ' ', self.locnoteref).strip()
+         return ''
+ 
+ 
+@@ -889,7 +889,7 @@ class Document (object):
+         trans = translations.ugettext('_\x04translator-credits')
+         if trans is None or trans == 'translator-credits':
+             return
+-        regex = re.compile('(.*) \<(.*)\>, (.*)')
++        regex = re.compile(r'(.*) \<(.*)\>, (.*)')
+         for credit in trans.split('\n'):
+             match = regex.match(credit)
+             if not match:
+@@ -924,7 +924,7 @@ class Document (object):
+             prevnode = None
+             if node.prev is not None and node.prev.type == 'text':
+                 prevtext = node.prev.content
+-                if re.sub('\s+', '', prevtext) == '':
++                if re.sub(r'\s+', '', prevtext) == '':
+                     prevnode = node.prev
+             for lang in sorted(list(translations.keys()), reverse=True):
+                 locale = self.get_its_locale_filter(node)
+@@ -1468,7 +1468,7 @@ def match_locale(extrange, locale):
+         localei += 1
+     return True
+ 
+-_locale_pattern = re.compile('([a-zA-Z0-9-]+)(_[A-Za-z0-9]+)?(@[A-Za-z0-9]+)?(\.[A-Za-z0-9]+)?')
++_locale_pattern = re.compile(r'([a-zA-Z0-9-]+)(_[A-Za-z0-9]+)?(@[A-Za-z0-9]+)?(\.[A-Za-z0-9]+)?')
+ def convert_locale (locale):
+     # Automatically convert POSIX-style locales to BCP47
+     match = _locale_pattern.match(locale)

--- a/dev-util/itstool/itstool-2.0.7-r2.ebuild
+++ b/dev-util/itstool/itstool-2.0.7-r2.ebuild
@@ -1,0 +1,38 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_REQ_USE="xml(+)"
+
+inherit python-single-r1
+
+DESCRIPTION="Translation tool for XML documents that uses gettext files and ITS rules"
+HOMEPAGE="http://itstool.org/"
+SRC_URI="http://files.itstool.org/itstool/${P}.tar.bz2"
+
+# files in /usr/share/itstool/its are under a special exception || GPL-3+
+LICENSE="GPL-3+"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x64-solaris"
+
+REQUIRED_USE="${PYTHON_REQUIRED_USE}"
+
+RDEPEND="${PYTHON_DEPS}
+	$(python_gen_cond_dep '
+		dev-libs/libxml2[python,${PYTHON_USEDEP}]
+	')"
+DEPEND="${RDEPEND}"
+
+DOCS=(ChangeLog NEWS) # AUTHORS, README are empty
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-2.0.7-missing-translation-fix.patch
+	"${FILESDIR}"/${PN}-2.0.7-raw-string.patch
+)
+
+src_test() {
+	:
+	#"${PYTHON}" tests/run_tests.py || die "test suite failed" # Test suite not shipped in tarball
+}


### PR DESCRIPTION
Closes:  https://bugs.gentoo.org/921725

---

Add patch from PR as was previously done because itstools does not appear to be actively maintained.

```diff
--- itstool-2.0.7-r1.ebuild
+++ itstool-2.0.7-r2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..11} )
+PYTHON_COMPAT=( python3_{10..12} )
 PYTHON_REQ_USE="xml(+)"
 
 inherit python-single-r1
@@ -15,7 +15,7 @@
 # files in /usr/share/itstool/its are under a special exception || GPL-3+
 LICENSE="GPL-3+"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x64-solaris"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x64-solaris"
 
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 
@@ -24,12 +24,13 @@
 		dev-libs/libxml2[python,${PYTHON_USEDEP}]
 	')"
 DEPEND="${RDEPEND}"
-BDEPEND=""
 
 DOCS=(ChangeLog NEWS) # AUTHORS, README are empty
 
-PATCHES="
-	"${FILESDIR}"/${PN}-2.0.7-missing-translation-fix.patch"
+PATCHES=(
+	"${FILESDIR}"/${PN}-2.0.7-missing-translation-fix.patch
+	"${FILESDIR}"/${PN}-2.0.7-raw-string.patch
+)
 
 src_test() {
 	:
```