### PR TITLE
sys-block/arcconf: Fix arm64 Build for 4.16.00.26273

### DIFF
--- a/sys-block/arcconf/arcconf-4.16.00.26273.ebuild
+++ b/sys-block/arcconf/arcconf-4.16.00.26273.ebuild
@@ -31,5 +31,5 @@ pkg_setup() {
 }
 
 src_install() {
-	dobin $(usex arm64 'arm/linuxarm_x64/cmdline/' '')arcconf
+	dobin $(usex arm64 'linuxarm_x64/cmdline/' '')arcconf
 }


### PR DESCRIPTION
This pull request updates the ebuild for arcconf 4.16.00.26273. The update addresses a build failure caused by a change in the executable file path on arm64. The path in the ebuild has been modified to reflect these changes, ensuring successful building on arm64 systems.

![grafik](https://github.com/gentoo/gentoo/assets/22028333/c14dd8c7-dea5-4c0a-8ade-14619478bf23)