### PR TITLE
dev-python/virtualenvwrapper: add missing pip test dependency

### DIFF
--- a/dev-python/virtualenvwrapper/virtualenvwrapper-6.0.0.ebuild
+++ b/dev-python/virtualenvwrapper/virtualenvwrapper-6.0.0.ebuild
@@ -34,6 +34,9 @@ BDEPEND="
 	')
 	test? (
 		${RDEPEND}
+		$(python_gen_cond_dep '
+			dev-python/pip[${PYTHON_USEDEP}]
+		')
 	)
 "
 


### PR DESCRIPTION
* Host python pip is used in test_project_templates.sh for installing the testtemplate. Otherwise pip is used from the venv where its included by default meaning its not a runtime dependency.

Closes: https://bugs.gentoo.org/922666