### PR TITLE
media-libs/opencv: 4.8.1-r1 unpack everything always

### DIFF
--- a/media-libs/opencv/opencv-4.8.1-r1.ebuild
+++ b/media-libs/opencv/opencv-4.8.1-r1.ebuild
@@ -242,10 +242,6 @@ pkg_setup() {
 	use java && java-pkg-opt-2_pkg_setup
 }
 
-src_unpack() {
-	unpack $(echo "${A}" | tr ' ' '\n' | grep -vP "(ade-0.1.2|NVIDIAOpticalFlowSDK)")
-}
-
 src_prepare() {
 	if use cuda; then
 		export CUDA_VERBOSE="$(usex debug "true" "false")"


### PR DESCRIPTION
Not filtering out these two archives adds about 1 MiB to `WORKDIR`, but doesn't rely on `sys-apps/grep[pcre]`. Since `pkgcheck` doesn't like them being zip files anyway this is going to change for `-4.9.0` either way.

Closes: https://bugs.gentoo.org/922450