### PR TITLE
net-fs/nfs-utils: improve NFS versions handling

### DIFF
--- a/net-fs/nfs-utils/metadata.xml
+++ b/net-fs/nfs-utils/metadata.xml
@@ -9,10 +9,10 @@
     <flag name="junction">Enable NFS junction support in nfsref</flag>
     <flag name="ldap">Add ldap support</flag>
     <flag name="libmount">Link mount.nfs with libmount</flag>
-    <flag name="nfsdcld">Enable nfsdcld NFSv4 clientid tracking daemon</flag>
+    <flag name="nfsdcld">Enable nfsdcld NFSv4 clientid tracking daemon and tools</flag>
     <flag name="nfsidmap">Enable support for newer nfsidmap helper</flag>
-    <flag name="nfsv4">Enable support for NFSv4</flag>
-    <flag name="nfsv41">Enable support for NFSv4.1</flag>
+    <flag name="nfsv3">Enable support for NFSv2 and NFSv3</flag>
+    <flag name="nfsv4">Enable support for NFSv4 and above</flag>
     <flag name="uuid">Support UUID lookups in rpc.mountd</flag>
   </use>
   <upstream>


### PR DESCRIPTION
Improve NFS versions handling as `nfs-utils` provide NFSv4-only mode of operation (without backward compatibility with v2 and v3).

Rebase of #33175