### PR TITLE
dev-debug/gdb: Backport patches from upstream for 14.1

### DIFF
--- a/dev-debug/gdb/files/gdb-14.1-fix-dll-export-forwarding.patch
+++ b/dev-debug/gdb/files/gdb-14.1-fix-dll-export-forwarding.patch
@@ -1,0 +1,60 @@
+Bug: https://sourceware.org/bugzilla/show_bug.cgi?id=31112
+
+From https://sourceware.org/git/?p=binutils-gdb.git;a=commitdiff;h=43a608adb04251be8999304cf724f55b2d840ac3
+From: Hannes Domani <ssbssa@yahoo.de>
+Date: Wed, 6 Dec 2023 20:52:06 +0100
+Subject: [PATCH] Fix DLL export forwarding
+
+I noticed it when I was trying to set a breakpoint at ExitProcess:
+```
+(gdb) b ExitProcess
+Breakpoint 1 at 0x14001fdd0
+(gdb) r
+Starting program: C:\qiewer\heob\heob64.exe
+Warning:
+Cannot insert breakpoint 1.
+Cannot access memory at address 0x3dbf4120
+Cannot insert breakpoint 1.
+Cannot access memory at address 0x77644120
+```
+
+The problem doesn't exist in gdb 13.2, and the difference can easily be
+seen when printing ExitProcess.
+gdb 14.1:
+```
+(gdb) p ExitProcess
+$1 = {<text variable, no debug info>} 0x77644120 <UserHandleGrantAccess+36128>
+```
+gdb 13.2:
+```
+(gdb) p ExitProcess
+$1 = {<text variable, no debug info>} 0x77734120 <ntdll!RtlExitUserProcess>
+```
+
+The new behavior started with 9675da25357c7a3f472731ddc6eb3becc65b469a,
+where VMA was then calculated relative to FORWARD_DLL_NAME, while it was
+relative to DLL_NAME before.
+
+Fixed by calculating VMA relative to DLL_NAME again.
+
+Bug: https://sourceware.org/PR31112
+Approved-By: Tom Tromey <tom@tromey.com>
+
+(cherry picked from commit 2574cd903dd84e7081506e24c2e232ecda11a736)
+--- a/gdb/coff-pe-read.c
++++ b/gdb/coff-pe-read.c
+@@ -210,7 +210,10 @@ add_pe_forwarded_sym (minimal_symbol_reader &reader,
+ 			      " \"%s\" in dll \"%s\", pointing to \"%s\"\n"),
+ 		sym_name, dll_name, forward_qualified_name.c_str ());
+ 
+-  unrelocated_addr vma = msymbol.minsym->unrelocated_address ();
++  /* Calculate VMA as if it were relative to DLL_NAME/OBJFILE, even though
++     it actually points inside another dll (FORWARD_DLL_NAME).  */
++  unrelocated_addr vma = unrelocated_addr (msymbol.value_address ()
++					   - objfile->text_section_offset ());
+   msymtype = msymbol.minsym->type ();
+   section = msymbol.minsym->section_index ();
+ 
+-- 
+2.39.3
+

--- a/dev-debug/gdb/files/gdb-14.1-fix-list-segfault.patch
+++ b/dev-debug/gdb/files/gdb-14.1-fix-list-segfault.patch
@@ -1,0 +1,101 @@
+Bug: https://bugs.gentoo.org/922336
+Bug: https://sourceware.org/bugzilla/show_bug.cgi?id=31256
+
+From https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;h=0068bd6fb3579dd8df7561e038cb3fe27f122b0e
+From: Guinevere Larsen <blarsen@redhat.com>
+To: gdb-patches@sourceware.org
+Cc: Guinevere Larsen <blarsen@redhat.com>
+Subject: [PATCH] gdb: fix "list ." related crash
+Date: Tue, 23 Jan 2024 11:50:43 +0100
+
+When a user attempts to use the "list ." command with an inferior that
+doesn't have debug symbols, GDB would crash. This was reported as PR
+gdb/31256.
+
+The crash would happen when attempting to get the current symtab_and_line
+for the stop location, because the symtab would return a null pointer
+and we'd attempt to dereference it to print the line.
+
+This commit fixes that by checking for an empty symtab and erroring out
+of the function if it happens.
+
+Bug: https://sourceware.org/PR31256
+--- a/gdb/cli/cli-cmds.c
++++ b/gdb/cli/cli-cmds.c
+@@ -1291,6 +1291,8 @@ list_command (const char *arg, int from_tty)
+ 	      set_default_source_symtab_and_line ();
+ 	      cursal = get_current_source_symtab_and_line ();
+ 	    }
++	  if (cursal.symtab == nullptr)
++	    error (_("No debug information available to print source lines."));
+ 	  list_around_line (arg, cursal);
+ 	  /* Set the repeat args so just pressing "enter" after using "list ."
+ 	     will print the following lines instead of the same lines again. */
+--- /dev/null
++++ b/gdb/testsuite/gdb.base/list-nodebug.c
+@@ -0,0 +1,21 @@
++/* This testcase is part of GDB, the GNU debugger.
++
++   Copyright 2024 Free Software Foundation, Inc.
++
++   This program is free software; you can redistribute it and/or modify
++   it under the terms of the GNU General Public License as published by
++   the Free Software Foundation; either version 3 of the License, or
++   (at your option) any later version.
++
++   This program is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++   GNU General Public License for more details.
++
++   You should have received a copy of the GNU General Public License
++   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
++
++int main ()
++{
++    return 0;
++}
+--- /dev/null
++++ b/gdb/testsuite/gdb.base/list-nodebug.exp
+@@ -0,0 +1,37 @@
++# Copyright 2024 Free Software Foundation, Inc.
++
++# This program is free software; you can redistribute it and/or modify
++# it under the terms of the GNU General Public License as published by
++# the Free Software Foundation; either version 3 of the License, or
++# (at your option) any later version.
++#
++# This program is distributed in the hope that it will be useful,
++# but WITHOUT ANY WARRANTY; without even the implied warranty of
++# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++# GNU General Public License for more details.
++#
++# You should have received a copy of the GNU General Public License
++# along with this program.  If not, see <http://www.gnu.org/licenses/>.
++
++# Test that using the command "list" in a file with no debug information
++# will not crash GDB and will give reasonable output.
++
++standard_testfile .c
++
++if {[prepare_for_testing "failed to prepare" ${testfile} ${srcfile} \
++    {nodebug}]} {
++    return -1
++}
++
++if {![runto_main]} {
++    untested "couldn't run to main"
++    return
++}
++
++# Check that GDB doesn't crash when we use list . on an inferior with
++# no debug information
++gdb_test "list ." "No debug.*" "first 'list .'"
++# This should be called twice because the first list invocation since
++# printing a frame may take a different codepath, which wouldn't
++# trigger the crash.
++gdb_test "list ." "No debug.*" "second 'list .'"
+-- 
+2.43.0
+
+

--- a/dev-debug/gdb/files/gdb-14.1-fix-print-global-variable-stubs.patch
+++ b/dev-debug/gdb/files/gdb-14.1-fix-print-global-variable-stubs.patch
@@ -1,0 +1,109 @@
+Bug: https://sourceware.org/bugzilla/show_bug.cgi?id=31128
+
+From https://sourceware.org/git/?p=binutils-gdb.git;a=commit;h=bc23ea51f8a83e9524dfb553baa8baacb29e68a9
+From: Hannes Domani <ssbssa@yahoo.de>
+Date: Fri, 8 Dec 2023 19:06:14 +0100
+Subject: [PATCH] Fix printing of global variable stubs if no inferior is
+ running
+
+Since 3c45e9f915ae4aeab7312d6fc55a947859057572 gdb crashes when trying
+to print a global variable stub without a running inferior, because of
+a missing nullptr-check (the block_scope function took care of that
+check before it was converted to a method).
+
+With this check it works again:
+```
+(gdb) print s
+$1 = <incomplete type>
+```
+
+Bug: https://sourceware.org/PR31128
+Approved-By: Tom Tromey <tom@tromey.com>
+(cherry picked from commit 576745e26c0ec76a53ba45b20af464628a50b3e4)
+--- a/gdb/cp-namespace.c
++++ b/gdb/cp-namespace.c
+@@ -1026,7 +1026,11 @@ cp_lookup_transparent_type (const char *name)
+ 
+   /* If that doesn't work and we're within a namespace, look there
+      instead.  */
+-  scope = get_selected_block (0)->scope ();
++  const block *block = get_selected_block (0);
++  if (block == nullptr)
++    return nullptr;
++
++  scope = block->scope ();
+ 
+   if (scope[0] == '\0')
+     return NULL;
+--- /dev/null
++++ b/gdb/testsuite/gdb.cp/print-global-stub.cc
+@@ -0,0 +1,31 @@
++/* This testcase is part of GDB, the GNU debugger.
++
++   Copyright 2023 Free Software Foundation, Inc.
++
++   This program is free software; you can redistribute it and/or modify
++   it under the terms of the GNU General Public License as published by
++   the Free Software Foundation; either version 3 of the License, or
++   (at your option) any later version.
++
++   This program is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++   GNU General Public License for more details.
++
++   You should have received a copy of the GNU General Public License
++   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
++
++struct S
++{
++  S (int);
++  virtual ~S ();
++
++  int m_i;
++};
++
++S s (5);
++
++int main ()
++{
++  return 0;
++}
+--- /dev/null
++++ b/gdb/testsuite/gdb.cp/print-global-stub.exp
+@@ -0,0 +1,32 @@
++# Copyright (C) 2023 Free Software Foundation, Inc.
++
++# This program is free software; you can redistribute it and/or modify
++# it under the terms of the GNU General Public License as published by
++# the Free Software Foundation; either version 3 of the License, or
++# (at your option) any later version.
++#
++# This program is distributed in the hope that it will be useful,
++# but WITHOUT ANY WARRANTY; without even the implied warranty of
++# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++# GNU General Public License for more details.
++#
++# You should have received a copy of the GNU General Public License
++# along with this program.  If not, see <http://www.gnu.org/licenses/>.
++
++# This file is part of the GDB testsuite.
++# It tests printing of a global stub without inferior.
++
++require allow_cplus_tests
++
++standard_testfile .cc
++set objfile [standard_output_file ${testfile}.o]
++
++if { [gdb_compile $srcdir/$subdir/$srcfile $objfile object \
++	  {c++ debug}] != "" } {
++    untested "failed to compile"
++    return -1
++}
++
++clean_restart $objfile
++
++gdb_test "print s" " = <incomplete type>"
+-- 
+2.39.3
+

--- a/dev-debug/gdb/gdb-14.1-r1.ebuild
+++ b/dev-debug/gdb/gdb-14.1-r1.ebuild
@@ -1,0 +1,317 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+# See https://sourceware.org/gdb/wiki/DistroAdvice for general packaging
+# tips & notes.
+
+PYTHON_COMPAT=( python3_{10..12} )
+inherit flag-o-matic python-single-r1 strip-linguas toolchain-funcs
+
+export CTARGET=${CTARGET:-${CHOST}}
+
+if [[ ${CTARGET} == ${CHOST} ]] ; then
+	if [[ ${CATEGORY} == cross-* ]] ; then
+		export CTARGET=${CATEGORY#cross-}
+	fi
+fi
+
+is_cross() { [[ ${CHOST} != ${CTARGET} ]] ; }
+
+case ${PV} in
+	9999*)
+		# live git tree
+		EGIT_REPO_URI="https://sourceware.org/git/binutils-gdb.git"
+		inherit git-r3
+		SRC_URI=""
+		;;
+	*.*.50_p2???????|*.*.90_p2???????)
+		# Weekly snapshots
+		MY_PV="${PV/_p/.}"
+		SRC_URI="
+			https://sourceware.org/pub/gdb/snapshots/branch/gdb-weekly-${MY_PV}.tar.xz
+			https://sourceware.org/pub/gdb/snapshots/current/gdb-weekly-${MY_PV}.tar.xz
+			https://dev.gentoo.org/~sam/distfiles/${CATEGORY}/${PN}/gdb-weekly-${MY_PV}.tar.xz
+		"
+		S="${WORKDIR}/${PN}-${MY_PV}"
+
+		# e.g. 13.1.90_p20230325 is a snapshot on the stable branch, so it's fine
+		if [[ ${PV} == *.[123456789].9?_p2??????? ]] ; then
+			REGULAR_RELEASE=1
+		fi
+		;;
+	*.*.9?)
+		# Prereleases
+		MY_PV="${PV/_p/.}"
+		SRC_URI="
+			https://sourceware.org/pub/gdb/snapshots/branch/gdb-${MY_PV}.tar.xz
+			https://dev.gentoo.org/~sam/distfiles/${CATEGORY}/${PN}/gdb-${MY_PV}.tar.xz
+		"
+		S="${WORKDIR}/${PN}-${MY_PV}"
+		;;
+	*)
+		# Normal upstream release
+		SRC_URI="
+			mirror://gnu/gdb/${P}.tar.xz
+			https://sourceware.org/pub/gdb/releases/${P}.tar.xz
+		"
+
+		REGULAR_RELEASE=1
+esac
+
+PATCH_DEV=""
+PATCH_VER=""
+DESCRIPTION="GNU debugger"
+HOMEPAGE="https://sourceware.org/gdb/"
+SRC_URI="
+	${SRC_URI}
+	${PATCH_DEV:+https://dev.gentoo.org/~${PATCH_DEV}/distfiles/${CATEGORY}/${PN}/${P}-patches-${PATCH_VER}.tar.xz}
+	${PATCH_VER:+mirror://gentoo/${P}-patches-${PATCH_VER}.tar.xz}
+"
+
+LICENSE="GPL-3+ LGPL-2.1+"
+SLOT="0"
+IUSE="cet debuginfod guile lzma multitarget nls +python +server sim source-highlight test vanilla xml xxhash zstd"
+if [[ -n ${REGULAR_RELEASE} ]] ; then
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~x64-macos ~x64-solaris"
+fi
+REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
+RESTRICT="!test? ( test )"
+
+RDEPEND="
+	dev-libs/mpfr:=
+	dev-libs/gmp:=
+	>=sys-libs/ncurses-5.2-r2:=
+	>=sys-libs/readline-7:=
+	sys-libs/zlib
+	elibc_glibc? ( net-libs/libnsl:= )
+	debuginfod? (
+		dev-libs/elfutils[debuginfod(-)]
+	)
+	lzma? ( app-arch/xz-utils )
+	python? ( ${PYTHON_DEPS} )
+	guile? ( >=dev-scheme/guile-2.0 )
+	xml? ( dev-libs/expat )
+	source-highlight? (
+		dev-util/source-highlight
+	)
+	xxhash? (
+		dev-libs/xxhash
+	)
+	zstd? ( app-arch/zstd:= )
+"
+DEPEND="${RDEPEND}"
+BDEPEND="
+	app-arch/xz-utils
+	sys-apps/texinfo
+	app-alternatives/yacc
+	nls? ( sys-devel/gettext )
+	source-highlight? ( virtual/pkgconfig )
+	test? ( dev-util/dejagnu )
+"
+
+QA_CONFIG_IMPL_DECL_SKIP=(
+	MIN # gnulib FP (bug #898688)
+)
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-8.3.1-verbose-build.patch
+	"${FILESDIR}"/${PN}-14.1-fix-list-segfault.patch
+	"${FILESDIR}"/${PN}-14.1-fix-print-global-variable-stubs.patch
+	"${FILESDIR}"/${PN}-14.1-fix-dll-export-forwarding.patch
+)
+
+pkg_setup() {
+	use python && python-single-r1_pkg_setup
+}
+
+src_prepare() {
+	default
+
+	strip-linguas -u bfd/po opcodes/po
+
+	# Avoid using ancient termcap from host on Prefix systems
+	sed -i -e 's/termcap tinfow/tinfow/g' \
+		gdb/configure{.ac,} || die
+}
+
+gdb_branding() {
+	printf "Gentoo ${PV} "
+
+	if ! use vanilla && [[ -n ${PATCH_VER} ]] ; then
+		printf "p${PATCH_VER}"
+	else
+		printf "vanilla"
+	fi
+
+	[[ -n ${EGIT_COMMIT} ]] && printf " ${EGIT_COMMIT}"
+}
+
+src_configure() {
+	strip-unsupported-flags
+
+	# See https://www.gnu.org/software/make/manual/html_node/Parallel-Output.html
+	# Avoid really confusing logs from subconfigure spam, makes logs far
+	# more legible.
+	MAKEOPTS="--output-sync=line ${MAKEOPTS}"
+
+	local myconf=(
+		# portage's econf() does not detect presence of --d-d-t
+		# because it greps only top-level ./configure. But not
+		# libiberty's or gdb's configure.
+		--disable-dependency-tracking
+		--disable-silent-rules
+
+		--with-pkgversion="$(gdb_branding)"
+		--with-bugurl='https://bugs.gentoo.org/'
+		--disable-werror
+		# Disable modules that are in a combined binutils/gdb tree. bug #490566
+		--disable-{binutils,etc,gas,gold,gprof,gprofng,ld}
+
+		$(use_with debuginfod)
+
+		$(use_enable test unit-tests)
+
+		# Allow user to opt into CET for host libraries.
+		# Ideally we would like automagic-or-disabled here.
+		# But the check does not quite work on i686: bug #760926.
+		$(use_enable cet)
+
+		# Helps when cross-compiling. Not to be confused with --with-sysroot.
+		--with-build-sysroot="${ESYSROOT}"
+	)
+
+	is_cross && myconf+=(
+		--with-sysroot="\${prefix}/${CTARGET}"
+		--includedir="\${prefix}/include/${CTARGET}"
+		--with-gdb-datadir="\${datadir}/gdb/${CTARGET}"
+	)
+
+	# gdbserver only works for native targets (CHOST==CTARGET).
+	# it also doesn't support all targets, so rather than duplicate
+	# the target list (which changes between versions), use the
+	# "auto" value when things are turned on, which is triggered
+	# whenever no --enable or --disable is given
+	if is_cross || use !server ; then
+		myconf+=( --disable-gdbserver )
+	fi
+
+	myconf+=(
+		--enable-64-bit-bfd
+		--disable-install-libbfd
+		--disable-install-libiberty
+		--enable-obsolete
+		# This only disables building in the readline subdir.
+		# For gdb itself, it'll use the system version.
+		--disable-readline
+		--with-system-readline
+		# This only disables building in the zlib subdir.
+		# For gdb itself, it'll use the system version.
+		--without-zlib
+		--with-system-zlib
+		--with-separate-debug-dir="${EPREFIX}"/usr/lib/debug
+		$(use_with xml expat)
+		$(use_with lzma)
+		$(use_enable nls)
+		$(use_enable sim)
+		$(use_enable source-highlight)
+		$(use multitarget && echo --enable-targets=all)
+		$(use_with python python "${EPYTHON}")
+		$(use_with xxhash)
+		$(use_with guile)
+		$(use_with zstd)
+
+		# Find libraries using the toolchain sysroot rather than the configured
+		# prefix. Needed when cross-compiling.
+		#
+		# Check which libraries to apply this to with:
+		# "${S}"/gdb/configure --help | grep without-lib | sort
+		--without-lib{babeltrace,expat,gmp,iconv,ipt,lzma,mpfr,xxhash}-prefix
+	)
+
+	# source-highlight is detected with pkg-config: bug #716558
+	export ac_cv_path_pkg_config_prog_path="$(tc-getPKG_CONFIG)"
+
+	export CC_FOR_BUILD="$(tc-getBUILD_CC)"
+
+	# ensure proper compiler is detected for Clang builds: bug #831202
+	export GCC_FOR_TARGET="${CC_FOR_TARGET:-$(tc-getCC)}"
+
+	econf "${myconf[@]}"
+}
+
+src_test() {
+	# Run the unittests (nabbed invocation from Fedora's spec file) at least
+	emake -k -C gdb run GDBFLAGS='-batch -ex "maintenance selftest"'
+
+	# Too many failures
+	# In fact, gdb's test suite needs some work to get passing.
+	# See e.g. https://sourceware.org/gdb/wiki/TestingGDB.
+	# As of 11.2, on amd64: "# of unexpected failures    8600"
+	# Also, ia64 kernel crashes when gdb testsuite is running.
+	#emake -k check
+}
+
+src_install() {
+	emake DESTDIR="${D}" install
+
+	find "${ED}"/usr -name libiberty.a -delete || die
+
+	# Delete translations that conflict with binutils-libs. bug #528088
+	# Note: Should figure out how to store these in an internal gdb dir.
+	if use nls ; then
+		find "${ED}" \
+			-regextype posix-extended -regex '.*/(bfd|opcodes)[.]g?mo$' \
+			-delete || die
+	fi
+
+	# Don't install docs when building a cross-gdb
+	if [[ ${CTARGET} != ${CHOST} ]] ; then
+		rm -rf "${ED}"/usr/share/{doc,info,locale} || die
+		local f
+		for f in "${ED}"/usr/share/man/*/* ; do
+			if [[ ${f##*/} != ${CTARGET}-* ]] ; then
+				mv "${f}" "${f%/*}/${CTARGET}-${f##*/}" || die
+			fi
+		done
+		return 0
+	fi
+
+	# Install it by hand for now:
+	# https://sourceware.org/ml/gdb-patches/2011-12/msg00915.html
+	# Only install if it exists due to the twisted behavior (see
+	# notes in src_configure above).
+	[[ -e gdbserver/gdbreplay ]] && dobin gdbserver/gdbreplay
+
+	docinto gdb
+	dodoc gdb/CONTRIBUTE gdb/README gdb/MAINTAINERS \
+		gdb/NEWS gdb/PROBLEMS
+	docinto sim
+	dodoc sim/{MAINTAINERS,README-HACKING}
+
+	if use server ; then
+		docinto gdbserver
+		dodoc gdbserver/README
+	fi
+
+	# Remove shared info pages
+	rm -f "${ED}"/usr/share/info/{annotate,bfd,configure,ctf-spec,standards}.info*
+
+	if use python ; then
+		python_optimize "${ED}"/usr/share/gdb/python/gdb
+	fi
+}
+
+pkg_postinst() {
+	# Portage doesn't unmerge files in /etc
+	rm -vf "${EROOT}"/etc/skel/.gdbinit
+
+	if use prefix && [[ ${CHOST} == *-darwin* ]] ; then
+		ewarn "gdb is unable to get a mach task port when installed by Prefix"
+		ewarn "Portage, unprivileged.  To make gdb fully functional you'll"
+		ewarn "have to perform the following steps:"
+		ewarn "  % sudo chgrp procmod ${EPREFIX}/usr/bin/gdb"
+		ewarn "  % sudo chmod g+s ${EPREFIX}/usr/bin/gdb"
+	fi
+}


### PR DESCRIPTION
- fix-list-segfault.patch: Fixes segfault encountered when running gdb on an executable without debugging symbols

- fix-dll-export-forwarding.patch: Fixes virtual memory address (VMA) calculating by making it relative to DLL_NAME again.

- fix-print-global-variable-stubs.patch: Fixes printing of global variable stubs if no inferior is running by adding a missing nullptr check

All tests pass.

Closes: https://bugs.gentoo.org/922336