### PR TITLE
dev-cpp/scitokens-cpp: backport fix for invalid vector access

### DIFF
--- a/dev-cpp/scitokens-cpp/files/scitokens-cpp-1.1.0-invalid-vector-access.patch
+++ b/dev-cpp/scitokens-cpp/files/scitokens-cpp-1.1.0-invalid-vector-access.patch
@@ -1,0 +1,24 @@
+Fix invalid std::vector access (visible with tests on hardened systems)
+
+From: Mattias Ellert <mattias.ellert@physics.uu.se>
+Bug: https://github.com/scitokens/scitokens-cpp/pull/126
+Bug: https://bugs.gentoo.org/922679
+
+---
+ src/scitokens_internal.cpp | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+--- a/src/scitokens_internal.cpp
++++ b/src/scitokens_internal.cpp
+@@ -978,9 +978,9 @@ bool scitokens::Validator::store_public_ec_key(const std::string &issuer,
+     auto x_num = BN_num_bytes(x_bignum.get());
+     auto y_num = BN_num_bytes(y_bignum.get());
+     std::vector<unsigned char> x_bin;
+-    x_bin.reserve(x_num);
++    x_bin.resize(x_num);
+     std::vector<unsigned char> y_bin;
+-    y_bin.reserve(y_num);
++    y_bin.resize(y_num);
+     BN_bn2bin(x_bignum.get(), &x_bin[0]);
+     BN_bn2bin(y_bignum.get(), &y_bin[0]);
+     std::string x_str(reinterpret_cast<char *>(&x_bin[0]), x_num);

--- a/dev-cpp/scitokens-cpp/scitokens-cpp-1.0.2-r2.ebuild
+++ b/dev-cpp/scitokens-cpp/scitokens-cpp-1.0.2-r2.ebuild
@@ -1,0 +1,61 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit cmake
+
+if [[ ${PV} == *9999* ]]; then
+	inherit git-r3
+	EGIT_REPO_URI="https://github.com/scitokens/scitokens-cpp"
+else
+	SRC_URI="https://github.com/scitokens/${PN}/archive/refs/tags/v${PV}.tar.gz -> ${P}.tar.gz"
+	KEYWORDS="~amd64 ~x86"
+fi
+
+DESCRIPTION="C++ implementation of the SciTokens library with a C library interface"
+HOMEPAGE="https://scitokens.org/"
+
+LICENSE="Apache-2.0"
+SLOT="0"
+IUSE="test"
+
+DEPEND="
+	dev-cpp/jwt-cpp[picojson]
+	dev-db/sqlite
+	dev-libs/openssl:0=
+	net-misc/curl:0=
+	kernel_linux? ( sys-apps/util-linux )
+"
+RDEPEND="${DEPEND}"
+BDEPEND="
+	virtual/pkgconfig
+	test? ( dev-cpp/gtest )
+"
+RESTRICT="!test? ( test )"
+
+PATCHES=(
+		"${FILESDIR}"/${PN}-1.1.0-invalid-vector-access.patch
+)
+
+src_prepare() {
+	# Unbundle dev-cpp/gtest, dev-cpp/jwt-cpp
+	rm -r vendor || die
+	# Fix include path for picojson.
+	find src/ \( -name '*.cpp' -o -name '*.h' \) -type f -print0 | \
+		xargs -0 sed -r -e "s:picojson/picojson\.h:picojson.h:g" -i || die
+	# Disable network-based tests relying on external services.
+	if use test; then
+		sed -i	-e '/^TEST_F/s#RefreshTest#DISABLED_RefreshTest#' \
+			-e '/^TEST_F/s#RefreshExpiredTest#DISABLED_RefreshExpiredTest#' test/main.cpp || die
+	fi
+	cmake_src_prepare
+}
+
+src_configure() {
+	local mycmakeargs=(
+		-DSCITOKENS_BUILD_UNITTESTS="$(usex test)"
+		-DSCITOKENS_EXTERNAL_GTEST=YES
+	)
+	cmake_src_configure
+}

--- a/dev-cpp/scitokens-cpp/scitokens-cpp-1.1.0-r1.ebuild
+++ b/dev-cpp/scitokens-cpp/scitokens-cpp-1.1.0-r1.ebuild
@@ -1,0 +1,61 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit cmake
+
+if [[ ${PV} == *9999* ]]; then
+	inherit git-r3
+	EGIT_REPO_URI="https://github.com/scitokens/scitokens-cpp"
+else
+	SRC_URI="https://github.com/scitokens/${PN}/archive/refs/tags/v${PV}.tar.gz -> ${P}.tar.gz"
+	KEYWORDS="~amd64 ~x86"
+fi
+
+DESCRIPTION="C++ implementation of the SciTokens library with a C library interface"
+HOMEPAGE="https://scitokens.org/"
+
+LICENSE="Apache-2.0"
+SLOT="0"
+IUSE="test"
+
+DEPEND="
+	dev-cpp/jwt-cpp[picojson]
+	dev-db/sqlite
+	dev-libs/openssl:0=
+	net-misc/curl:0=
+	kernel_linux? ( sys-apps/util-linux )
+"
+RDEPEND="${DEPEND}"
+BDEPEND="
+	virtual/pkgconfig
+	test? ( dev-cpp/gtest )
+"
+RESTRICT="!test? ( test )"
+
+PATCHES=(
+		"${FILESDIR}"/${PN}-1.1.0-invalid-vector-access.patch
+)
+
+src_prepare() {
+	# Unbundle dev-cpp/gtest, dev-cpp/jwt-cpp
+	rm -r vendor || die
+	# Fix include path for picojson.
+	find src/ \( -name '*.cpp' -o -name '*.h' \) -type f -print0 | \
+		xargs -0 sed -r -e "s:picojson/picojson\.h:picojson.h:g" -i || die
+	# Disable network-based tests relying on external services.
+	if use test; then
+		sed -i	-e '/^TEST_F/s#RefreshTest#DISABLED_RefreshTest#' \
+			-e '/^TEST_F/s#RefreshExpiredTest#DISABLED_RefreshExpiredTest#' test/main.cpp || die
+	fi
+	cmake_src_prepare
+}
+
+src_configure() {
+	local mycmakeargs=(
+		-DSCITOKENS_BUILD_UNITTESTS="$(usex test)"
+		-DSCITOKENS_EXTERNAL_GTEST=YES
+	)
+	cmake_src_configure
+}


### PR DESCRIPTION
Fixes tests on hardened systems and potential runtime errors. 

@amadio :
I revbumped latest stable (of course dropping stable keywords) in case we want to re-stabilize that version including the fix. I also added a revbumped version of `1.1.0-r2` (revbump to make sure the fix, which could potentially also cause runtime issues, reaches all users). 

Closes: https://bugs.gentoo.org/922679