### PR TITLE
dev-libs/oneDNN: musl: fix compilation failure due to missing header

### DIFF
--- a/dev-libs/oneDNN/files/oneDNN-3.3.3-include-cstdint.patch
+++ b/dev-libs/oneDNN/files/oneDNN-3.3.3-include-cstdint.patch
@@ -1,0 +1,13 @@
+Fix for dims.hpp:25:28: error: int64_t was not declared in this scope
+Bug: https://bugs.gentoo.org/922778
+Upstream fix: https://github.com/oneapi-src/oneDNN/pull/1792
+--- a/tests/benchdnn/utils/dims.hpp
++++ b/tests/benchdnn/utils/dims.hpp
+@@ -18,6 +18,7 @@
+ #define UTILS_DIMS_T_HPP
+ 
+ #include <cassert>
++#include <cstdint>
+ #include <iostream>
+ #include <string>
+ #include <vector>

--- a/dev-libs/oneDNN/oneDNN-3.3.3.ebuild
+++ b/dev-libs/oneDNN/oneDNN-3.3.3.ebuild
@@ -31,6 +31,10 @@ DEPEND="
 "
 RDEPEND="${DEPEND}"
 
+PATCHES=(
+	"${FILESDIR}/${PN}-3.3.3-include-cstdint.patch"
+)
+
 src_configure() {
 	local mycmakeargs=(
 		-DDNNL_LIBRARY_TYPE=$(usex static-libs STATIC SHARED)


### PR DESCRIPTION
Applies to 3.3.3; will be applicable to 3.3.4 (in case of ebuild bump).

Upstream PR: https://github.com/oneapi-src/oneDNN/pull/1792
Closes: https://bugs.gentoo.org/922778