### PR TITLE
x11-drivers/nvidia-drivers: migrate checking for enabled lto, to tc-is-lto

### DIFF
--- a/x11-drivers/nvidia-drivers/nvidia-drivers-470.223.02.ebuild
+++ b/x11-drivers/nvidia-drivers/nvidia-drivers-470.223.02.ebuild
@@ -162,7 +162,7 @@ src_compile() {
 
 	local xnvflags=-fPIC #840389
 	# lto static libraries tend to cause problems without fat objects
-	is-flagq '-flto@(|=*)' && xnvflags+=" $(test-flags-CC -ffat-lto-objects)"
+	tc-is-lto && xnvflags+=" $(test-flags-CC -ffat-lto-objects)"
 
 	NV_ARGS=(
 		PREFIX="${EPREFIX}"/usr

--- a/x11-drivers/nvidia-drivers/nvidia-drivers-525.147.05.ebuild
+++ b/x11-drivers/nvidia-drivers/nvidia-drivers-525.147.05.ebuild
@@ -179,7 +179,7 @@ src_compile() {
 
 	local xnvflags=-fPIC #840389
 	# lto static libraries tend to cause problems without fat objects
-	is-flagq '-flto@(|=*)' && xnvflags+=" $(test-flags-CC -ffat-lto-objects)"
+	tc-is-lto && xnvflags+=" $(test-flags-CC -ffat-lto-objects)"
 
 	NV_ARGS=(
 		PREFIX="${EPREFIX}"/usr

--- a/x11-drivers/nvidia-drivers/nvidia-drivers-535.146.02.ebuild
+++ b/x11-drivers/nvidia-drivers/nvidia-drivers-535.146.02.ebuild
@@ -182,7 +182,7 @@ src_compile() {
 
 	local xnvflags=-fPIC #840389
 	# lto static libraries tend to cause problems without fat objects
-	is-flagq '-flto@(|=*)' && xnvflags+=" $(test-flags-CC -ffat-lto-objects)"
+	tc-is-lto && xnvflags+=" $(test-flags-CC -ffat-lto-objects)"
 
 	NV_ARGS=(
 		PREFIX="${EPREFIX}"/usr

--- a/x11-drivers/nvidia-drivers/nvidia-drivers-535.154.05.ebuild
+++ b/x11-drivers/nvidia-drivers/nvidia-drivers-535.154.05.ebuild
@@ -182,7 +182,7 @@ src_compile() {
 
 	local xnvflags=-fPIC #840389
 	# lto static libraries tend to cause problems without fat objects
-	is-flagq '-flto@(|=*)' && xnvflags+=" $(test-flags-CC -ffat-lto-objects)"
+	tc-is-lto && xnvflags+=" $(test-flags-CC -ffat-lto-objects)"
 
 	NV_ARGS=(
 		PREFIX="${EPREFIX}"/usr

--- a/x11-drivers/nvidia-drivers/nvidia-drivers-535.43.22.ebuild
+++ b/x11-drivers/nvidia-drivers/nvidia-drivers-535.43.22.ebuild
@@ -180,7 +180,7 @@ src_compile() {
 
 	local xnvflags=-fPIC #840389
 	# lto static libraries tend to cause problems without fat objects
-	is-flagq '-flto@(|=*)' && xnvflags+=" $(test-flags-CC -ffat-lto-objects)"
+	tc-is-lto && xnvflags+=" $(test-flags-CC -ffat-lto-objects)"
 
 	NV_ARGS=(
 		PREFIX="${EPREFIX}"/usr

--- a/x11-drivers/nvidia-drivers/nvidia-drivers-545.29.06-r1.ebuild
+++ b/x11-drivers/nvidia-drivers/nvidia-drivers-545.29.06-r1.ebuild
@@ -171,7 +171,7 @@ src_compile() {
 
 	local xnvflags=-fPIC #840389
 	# lto static libraries tend to cause problems without fat objects
-	is-flagq '-flto@(|=*)' && xnvflags+=" $(test-flags-CC -ffat-lto-objects)"
+	tc-is-lto && xnvflags+=" $(test-flags-CC -ffat-lto-objects)"
 
 	NV_ARGS=(
 		PREFIX="${EPREFIX}"/usr


### PR DESCRIPTION
This toolchain func was recently added, and is a lot more reliable than get-flagq, for example if the active flags contain `-flto -fno-lto` then tc-is-lto gets it correct. We would rather use this wherever possible.