### PR TITLE
mate-base/mate-applets: fix gtksourceview depend verisons

### DIFF
--- a/mate-base/mate-applets/mate-applets-1.26.1-r2.ebuild
+++ b/mate-base/mate-applets/mate-applets-1.26.1-r2.ebuild
@@ -31,7 +31,7 @@ COMMON_DEPEND="
 	>=sys-apps/dbus-1.10.0
 	x11-libs/gdk-pixbuf:2
 	>=x11-libs/gtk+-3.22:3
-	x11-libs/gtksourceview
+	x11-libs/gtksourceview:3.0
 	>=x11-libs/libnotify-0.7
 	x11-libs/libX11
 	>=x11-libs/libwnck-3.0:3

--- a/mate-base/mate-applets/mate-applets-1.27.1.ebuild
+++ b/mate-base/mate-applets/mate-applets-1.27.1.ebuild
@@ -31,7 +31,7 @@ COMMON_DEPEND="
 	>=sys-apps/dbus-1.10.0
 	x11-libs/gdk-pixbuf:2
 	>=x11-libs/gtk+-3.22:3
-	x11-libs/gtksourceview
+	x11-libs/gtksourceview:4
 	>=x11-libs/libnotify-0.7
 	x11-libs/libX11
 	>=x11-libs/libwnck-3.0:3


### PR DESCRIPTION
Change between 1.26 and 27 have changed required x11-libs/gtksourceview versions required.

This commit solves issues for new MATE users of both versions.

Closes: https://bugs.gentoo.org/922890