### PR TITLE
sys-fs/bcachefs-tools: Re-ignore sandbox tests, add myself as maintainer

### DIFF
--- a/sys-fs/bcachefs-tools/bcachefs-tools-1.4.1.ebuild
+++ b/sys-fs/bcachefs-tools/bcachefs-tools-1.4.1.ebuild
@@ -225,6 +225,9 @@ src_test() {
 		'tests/test_fixture.py::test_leak'
 		'tests/test_fixture.py::test_check'
 		# Fails in portage because of usersandbox; ensure that these pass before bumping!
+		'tests/test_basic.py::test_format'
+		'tests/test_basic.py::test_fsck'
+		'tests/test_basic.py::test_list'
 		'tests/test_basic.py::test_list_inodes'
 		'tests/test_basic.py::test_list_dirent'
 	)

--- a/sys-fs/bcachefs-tools/metadata.xml
+++ b/sys-fs/bcachefs-tools/metadata.xml
@@ -5,6 +5,10 @@
 		<email>Matt.Jolly@footclan.ninja</email>
 		<name>Matt Jolly</name>
 	</maintainer>
+	<maintainer type="person" proxied="yes">
+		<email>csfore@posteo.net</email>
+		<name>Christopher Fore</name>
+	</maintainer>
 	<maintainer type="project" proxied="proxy">
 		<email>proxy-maint@gentoo.org</email>
 		<name>Proxy Maintainers</name>


### PR DESCRIPTION
I cannot seem to get these tests to fail for me but re-ignoring them is likely the best idea in the meantime.

The current maintainer is also happy with me becoming a co-maintainer of this package.

Closes: https://bugs.gentoo.org/922821