### PR TITLE
media-gfx/mcomix: remove github upstream metadata

### DIFF
--- a/media-gfx/mcomix/metadata.xml
+++ b/media-gfx/mcomix/metadata.xml
@@ -7,6 +7,5 @@
   </maintainer>
   <upstream>
     <remote-id type="sourceforge">mcomix</remote-id>
-    <remote-id type="github">multiSnow/mcomix3</remote-id>
   </upstream>
 </pkgmetadata>


### PR DESCRIPTION
MComix does not have an official Github presence. Furthermore, the linked repository a) has been archived and b) used to contain the mcomix3 fork before MComix officially supported GTK3.