### PR TITLE
dev-util/hxd: EAPI8 bump, fix HOMEPAGE, LICENSE

### DIFF
--- a/dev-util/hxd/hxd-0.70.02-r3.ebuild
+++ b/dev-util/hxd/hxd-0.70.02-r3.ebuild
@@ -1,15 +1,15 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
 
 inherit toolchain-funcs
 
 DESCRIPTION="Binary to hexadecimal converter"
-HOMEPAGE="http://www-tet.ee.tu-berlin.de/solyga/linux/"
-SRC_URI="http://linux.xulin.de/c/${P}.tar.gz"
+HOMEPAGE="https://linux.xulin.de/c/"
+SRC_URI="https://linux.xulin.de/c/${P}.tar.gz"
 
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="0"
 KEYWORDS="~amd64 ~mips ~ppc ~sparc ~x86"
 


### PR DESCRIPTION
Simple `EAPI8` with some additional fixes.