### PR TITLE
dev-util/open-vcdiff: EAPI8 bump, fix bug 804447

### DIFF
--- a/dev-util/open-vcdiff/open-vcdiff-0.8.4-r2.ebuild
+++ b/dev-util/open-vcdiff/open-vcdiff-0.8.4-r2.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
 
 DESCRIPTION="An encoder/decoder for the VCDIFF (RFC3284) format"
 HOMEPAGE="https://github.com/google/open-vcdiff"
@@ -10,12 +10,13 @@ SRC_URI="https://dev.gentoo.org/~floppym/dist/${P}.tar.gz"
 LICENSE="Apache-2.0"
 SLOT="0/0"
 KEYWORDS="~amd64 ~x86"
-IUSE=""
 
 PATCHES=( "${FILESDIR}"/${P}-gcc6.patch )
 
-src_configure() {
-	econf --disable-static
+src_prepare() {
+	sed -i -e "s|^docdir =.*|docdir = \"${EPREFIX}/usr/share/doc/${PF}\"|g" \
+		Makefile.in || die
+	default
 }
 
 src_install() {


### PR DESCRIPTION
Another `EAPI8` bump.
I've also removed `src_configure` since `--disable-static` is used with `EAPI8` anyway.

Signed-off-by: Michael Mair-Keimberger <mmk@levelnine.at>

Closes: https://bugs.gentoo.org/804447