### PR TITLE
media-libs/libfpx: EAPI8 bump, fix bug #847412

### DIFF
--- a/media-libs/libfpx/libfpx-1.3.1_p10-r1.ebuild
+++ b/media-libs/libfpx/libfpx-1.3.1_p10-r1.ebuild
@@ -1,0 +1,52 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit flag-o-matic libtool
+
+DESCRIPTION="Library for manipulating FlashPIX images"
+HOMEPAGE="https://github.com/ImageMagick/libfpx"
+SRC_URI="mirror://imagemagick/delegates/${P/_p/-}.tar.bz2"
+S="${WORKDIR}/${P/_p/-}"
+
+LICENSE="Flashpix"
+SLOT="0/1"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
+IUSE="static-libs"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-1.2.0.13-export-symbols.patch
+	"${FILESDIR}"/${PN}-1.3.1_p10-musl-1.2.3-null.patch
+)
+
+src_prepare() {
+	default
+
+	# we're not windows, even though we don't define __unix by default
+	[[ ${CHOST} == *-darwin* ]] && append-flags -D__unix
+
+	elibtoolize
+}
+
+src_configure() {
+	append-ldflags -Wl,--no-undefined
+	econf \
+		$(use_enable static-libs static) \
+		LIBS="-lstdc++ -lm"
+}
+
+src_install() {
+	default
+
+	# bug 847412
+	if ! use static-libs; then
+		find "${ED}" -type f -name '*.la' -delete || die
+	fi
+
+	dodoc AUTHORS ChangeLog doc/*.txt
+
+	docinto pdf
+	dodoc doc/*.pdf
+	docompress -x /usr/share/doc/${PF}/pdf
+}


### PR DESCRIPTION
Another simple `EAPI8` bump

```diff
--- libfpx-1.3.1_p10.ebuild	2024-01-25 20:28:08.501777586 +0100
+++ libfpx-1.3.1_p10-r1.ebuild	2024-01-25 20:31:12.811518602 +0100
@@ -1,20 +1,20 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
+
 inherit flag-o-matic libtool
 
-DESCRIPTION="A library for manipulating FlashPIX images"
+DESCRIPTION="Library for manipulating FlashPIX images"
 HOMEPAGE="https://github.com/ImageMagick/libfpx"
 SRC_URI="mirror://imagemagick/delegates/${P/_p/-}.tar.bz2"
+S="${WORKDIR}/${P/_p/-}"
 
 LICENSE="Flashpix"
 SLOT="0/1"
-KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
 IUSE="static-libs"
 
-S=${WORKDIR}/${P/_p/-}
-
 PATCHES=(
 	"${FILESDIR}"/${PN}-1.2.0.13-export-symbols.patch
 	"${FILESDIR}"/${PN}-1.3.1_p10-musl-1.2.3-null.patch
@@ -39,6 +39,11 @@
 src_install() {
 	default
 
+	# bug 847412
+	if ! use static-libs; then
+		find "${ED}" -type f -name '*.la' -delete || die
+	fi
+
 	dodoc AUTHORS ChangeLog doc/*.txt
 
 	docinto pdf
```

Signed-off-by: Michael Mair-Keimberger <mmk@levelnine.at>

Closes: https://bugs.gentoo.org/847412