### PR TITLE
net-dialup/sercd: EAPI8, fix LICENSE

### DIFF
--- a/net-dialup/sercd/sercd-3.0.0-r2.ebuild
+++ b/net-dialup/sercd/sercd-3.0.0-r2.ebuild
@@ -1,13 +1,13 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
 
 DESCRIPTION="RFC2217-compliant serial port redirector"
-HOMEPAGE="https://sourceforge.net/projects/sercd"
+HOMEPAGE="https://sourceforge.net/projects/sercd/"
 SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
 
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
 
@@ -16,10 +16,6 @@ IUSE="xinetd"
 RDEPEND="xinetd? ( virtual/inetd )"
 
 DOCS=( AUTHORS README )
-
-src_prepare() {
-	eapply_user
-}
 
 src_install() {
 	default


### PR DESCRIPTION
simple `EAPI8` bump