### PR TITLE
net-mail/mairix: EAPI8 bump

### DIFF
--- a/net-mail/mairix/mairix-0.24.ebuild
+++ b/net-mail/mairix/mairix-0.24.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
 
 inherit toolchain-funcs
 


### PR DESCRIPTION
Another `EAPI8` bump.
Since I've only changed the EAPI i decided not todo an revbump and keep the stable keywords. I think there is really no need todo a revbump here.