### PR TITLE
media-libs/opensubdiv: 3.6.0 update

### DIFF
--- a/media-libs/opensubdiv/files/opensubdiv-3.6.0-cudaflags.patch
+++ b/media-libs/opensubdiv/files/opensubdiv-3.6.0-cudaflags.patch
@@ -1,0 +1,20 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -595,7 +595,7 @@ if(CUDA_FOUND)
+     )
+     set(OSD_GPU TRUE)
+ 
+-    if (UNIX)
++    if (FALSE)
+         list( APPEND CUDA_NVCC_FLAGS -Xcompiler -fPIC )
+         # Use OSD_CUDA_NVCC_FLAGS to specify --gpu-architecture or other CUDA
+         # compilation options. The overrides here are only for compatibility
+@@ -609,7 +609,7 @@ if(CUDA_FOUND)
+         endif()
+     endif()
+ 
+-    if (DEFINED OSD_CUDA_NVCC_FLAGS)
++    if (FALSE)
+         list( APPEND CUDA_NVCC_FLAGS ${OSD_CUDA_NVCC_FLAGS})
+     endif()
+ 

--- a/media-libs/opensubdiv/files/opensubdiv-3.6.0-use-gnuinstalldirs.patch
+++ b/media-libs/opensubdiv/files/opensubdiv-3.6.0-use-gnuinstalldirs.patch
@@ -1,0 +1,38 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -25,6 +25,7 @@
+ cmake_minimum_required(VERSION 3.12)
+ 
+ project(OpenSubdiv)
++include(GNUInstallDirs)
+ 
+ # Set C++ standard requirements, allowing overrides
+ if (NOT DEFINED CMAKE_CXX_STANDARD)
+@@ -81,15 +82,15 @@ if (NOT DEFINED CMAKE_INSTALL_PREFIX)
+ endif()
+ 
+ if (NOT DEFINED CMAKE_INCDIR_BASE)
+-    set( CMAKE_INCDIR_BASE include/opensubdiv )
++    set( CMAKE_INCDIR_BASE ${CMAKE_INSTALL_INCLUDEDIR}/opensubdiv )
+ endif()
+ 
+ if (NOT DEFINED CMAKE_BINDIR_BASE)
+-    set( CMAKE_BINDIR_BASE bin )
++    set( CMAKE_BINDIR_BASE ${CMAKE_INSTALL_BINDIR} )
+ endif()
+ 
+ if (NOT DEFINED CMAKE_LIBDIR_BASE)
+-    set( CMAKE_LIBDIR_BASE lib )
++    set( CMAKE_LIBDIR_BASE ${CMAKE_INSTALL_LIBDIR} )
+ endif()
+ 
+ if (NOT DEFINED CMAKE_FRAMEWORKDIR_BASE)
+@@ -101,7 +102,7 @@ if (NOT DEFINED CMAKE_PLUGINDIR_BASE)
+ endif()
+ 
+ if (NOT DEFINED CMAKE_DOCDIR_BASE)
+-    set( CMAKE_DOCDIR_BASE share/doc/opensubdiv )
++    set( CMAKE_DOCDIR_BASE ${CMAKE_INSTALL_DOCDIR} )
+ else()
+     if (IS_ABSOLUTE ${CMAKE_DOCDIR_BASE})
+         set( CMAKE_DOCDIR_BASE "${CMAKE_DOCDIR_BASE}" )

--- a/media-libs/opensubdiv/metadata.xml
+++ b/media-libs/opensubdiv/metadata.xml
@@ -10,10 +10,19 @@
 		<name>Proxy Maintainers</name>
 	</maintainer>
 	<use>
+		<flag name="glew">
+			Enable support for OpenGL Extension Wrangler Library (<pkg>media-libs/glew</pkg>)
+		</flag>
+		<flag name="glfw">
+			Enable support for OpenGL FrameWork (<pkg>media-libs/glfw</pkg>)
+		</flag>
 		<flag name="ptex">
 			Adds support for faster per-face texture mapping through
 			<pkg>media-libs/ptex</pkg>
 		</flag>
+		<flag name="python">
+			Use <pkg>dev-lang/python</pkg> to process source and documentation source files
+			</flag>
 		<flag name="tbb">
 			Enable multithreading with the Intel Threads Building Blocks through
 			<pkg>dev-cpp/tbb</pkg>

--- a/media-libs/opensubdiv/opensubdiv-3.6.0.ebuild
+++ b/media-libs/opensubdiv/opensubdiv-3.6.0.ebuild
@@ -3,7 +3,9 @@
 
 EAPI=8
 
-inherit cmake cuda toolchain-funcs
+PYTHON_COMPAT=( python3_{10..12} )
+
+inherit cmake cuda flag-o-matic python-any-r1 toolchain-funcs virtualx
 
 MY_PV="$(ver_rs "1-3" '_')"
 
@@ -17,28 +19,58 @@ S="${WORKDIR}/OpenSubdiv-${MY_PV}"
 LICENSE="Apache-2.0"
 SLOT="0"
 KEYWORDS="~amd64 ~arm ~arm64 ~x86"
-IUSE="cuda examples opencl openmp ptex tbb test tutorials"
+IUSE="X cuda doc examples +glew +glfw opencl +opengl openmp ptex python tbb test tutorials"
 RESTRICT="!test? ( test )"
 
-RDEPEND="
-	examples? (
-		media-libs/glew:=
-		media-libs/glfw:=
-		x11-libs/libXinerama
-	)
-	cuda? ( dev-util/nvidia-cuda-toolkit:* )
-	opencl? ( virtual/opencl )
-	ptex? ( media-libs/ptex )
+# TODO needed for stringify due to unwrapped KERNEL_FILES in opensubdiv/{far,osd}/CMakeLists.txt
+REQUIRED_USE="
+	|| ( opencl opengl )
 "
-DEPEND="
-	${RDEPEND}
+
+BDEPEND="
+	doc? (
+		app-text/doxygen
+		dev-python/docutils
+	)
+	python? ( ${PYTHON_DEPS} )
+"
+
+RDEPEND="
+	opengl? (
+		media-libs/libglvnd
+		glew? (
+			media-libs/glew:=
+		)
+		glfw? (
+			media-libs/glfw:=
+			X? (
+				x11-libs/libX11
+				x11-libs/libXcursor
+				x11-libs/libXi
+				x11-libs/libXinerama
+				x11-libs/libXrandr
+				x11-libs/libXxf86vm
+			)
+		)
+	)
+	opencl? ( virtual/opencl )
+	openmp? ( || (
+		sys-devel/gcc:*[openmp]
+		sys-libs/libomp
+	) )
+	ptex? ( media-libs/ptex )
 	tbb? ( dev-cpp/tbb:= )
 "
 
+# CUDA_RUNTIME is statically linked
+DEPEND="
+	${RDEPEND}
+	cuda? ( dev-util/nvidia-cuda-toolkit:= )
+"
+
 PATCHES=(
-	"${FILESDIR}/${PN}-3.3.0-use-gnuinstalldirs.patch"
-	"${FILESDIR}/${PN}-3.4.3-install-tutorials-into-bin.patch"
-	# "${FILESDIR}/${PN}-3.4.4-tbb-2021.patch"
+	"${FILESDIR}/${PN}-3.6.0-use-gnuinstalldirs.patch"
+	"${FILESDIR}/${PN}-3.6.0-cudaflags.patch"
 )
 
 pkg_pretend() {
@@ -47,47 +79,124 @@ pkg_pretend() {
 
 pkg_setup() {
 	[[ ${MERGE_TYPE} != binary ]] && use openmp && tc-check-openmp
+
+	if use cuda; then
+		# When building binary packages we build all major targets unless specified otherwise
+		if [[ -z "${CUDAARCHS+x}" ]]; then
+			case ${MERGE_TYPE} in
+				source)    CUDAARCHS="native" ;;
+				# buildonly) CUDAARCHS="all" ;;
+				buildonly) CUDAARCHS="all-major" ;;
+			esac
+		fi
+
+		# check if user provided --gpu-architecture/-arch flag instead of CUDAARCHS
+		for f in ${NVCCFLAGS}; do
+			if [[ ${f} == -arch* || ${f} == --gpu-architecture* ]]; then
+				CUDAARCHS="NVCC"
+				break
+			fi
+		done
+
+		if [[ "${CUDAARCHS}" == "NVCC" ]]; then
+			unset  CUDAARCHS
+		else
+			export CUDAARCHS
+		fi
+	fi
 }
 
 src_prepare() {
 	cmake_src_prepare
 
+	sed \
+		-e "/install(/s/^/#DONOTINSTALL /g" \
+		-i \
+			regression/*/CMakeLists.txt \
+			tools/stringify/CMakeLists.txt \
+		|| die
+
+	sed \
+		-e "/install( TARGETS osd_static_[cg]pu/s/^/#DONOTINSTALL /g" \
+		-i \
+			opensubdiv/CMakeLists.txt \
+		|| die
+
 	use cuda && cuda_src_prepare
 }
 
 src_configure() {
-	# GLTESTS are disabled as portage is unable to open a display during test phase
-	# TODO: virtx work?
 	local mycmakeargs=(
-		-DGLEW_LOCATION="${ESYSROOT}/usr/$(get_libdir)"
-		-DGLFW_LOCATION="${ESYSROOT}/usr/$(get_libdir)"
-		-DNO_CLEW=ON
-		-DNO_CUDA=$(usex !cuda)
-		# Docs needed Python 2 so disabled
-		# bug #815172
-		-DNO_DOC=ON
-		-DNO_EXAMPLES=$(usex !examples)
-		-DNO_GLTESTS=ON
-		-DNO_OMP=$(usex !openmp)
-		-DNO_OPENCL=$(usex !opencl)
-		-DNO_PTEX=$(usex !ptex)
-		-DNO_REGRESSION=$(usex !test)
-		-DNO_TBB=$(usex !tbb)
-		-DNO_TESTS=$(usex !test)
-		-DNO_TUTORIALS=$(usex !tutorials)
+		-DCMAKE_INSTALL_BINDIR="share/${PN}/bin"
+
+		# DirectX
+		-DNO_DX="yes"
+
+		# MacOS
+		-DNO_MACOS_FRAMEWORK="yes"
+		-DNO_METAL="yes"
+
+		-DNO_DOC="$(usex !doc)"
+		-DNO_EXAMPLES="$(usex !examples)"
+		-DNO_TUTORIALS="$(usex !tutorials)"
+		-DNO_REGRESSION="$(usex !test)"
+		-DNO_TESTS="$(usex !test)"
+
+		-DNO_PTEX="$(usex !ptex)"
+
+		# GUI
+		-DNO_OPENGL="$(usex !opengl)"
+
+		# Backends
+		-DNO_CUDA="$(usex !cuda)"
+		-DNO_OMP="$(usex !openmp)"
+		-DNO_TBB="$(usex !tbb)"
+		-DNO_OPENCL="$(usex !opencl)"
 	)
 
 	if use cuda; then
-		# old cmake CUDA module doesn't use environment variable to initialize flags
-		mycmakeargs+=( -DCUDA_NVCC_FLAGS="${NVCCFLAGS}" )
+		# The old cmake CUDA module doesn't use environment variable to initialize flags
+		mycmakeargs+=(
+			-DCUDA_NVCC_FLAGS="-forward-unknown-opts ${NVCCFLAGS}"
+		)
+	fi
 
-		# check if user provided --gpu-architecture/-arch flag and prevent cmake from overriding it if so
-		for f in ${NVCCFLAGS}; do
-			if [[ ${f} == -arch* || ${f} == --gpu-architecture* ]]; then
-				mycmakeargs+=( -DOSD_CUDA_NVCC_FLAGS="" )
-				break
-			fi
-		done
+	if use opencl; then
+		mycmakeargs+=(
+			# not packaged https://github.com/martijnberger/clew
+			-DNO_CLEW="yes"
+		)
+	fi
+
+	if use opengl; then
+		mycmakeargs+=(
+			-DNO_GLTESTS="$(usex !test)"
+			-DNO_GLEW="$(usex !glew)"
+			-DNO_GLFW="$(usex !glfw)"
+		)
+		if use glew; then
+			mycmakeargs+=(
+				-DGLEW_LOCATION="${ESYSROOT}/usr/$(get_libdir)"
+			)
+		fi
+		if use glfw; then
+			mycmakeargs+=(
+				-DGLFW_LOCATION="${ESYSROOT}/usr/$(get_libdir)"
+				-DNO_GLFW_X11="$(usex !X)"
+			)
+		fi
+	fi
+
+	if use ptex; then
+		mycmakeargs+=(
+			-DPTEX_LOCATION="${ESYSROOT}/usr/$(get_libdir)"
+		)
+	fi
+
+	if ! use python; then
+		mycmakeargs+=(
+			-DCMAKE_DISABLE_FIND_PACKAGE_Python="yes"
+		)
 	fi
 
 	cmake_src_configure
@@ -95,27 +204,26 @@ src_configure() {
 
 src_test() {
 	CMAKE_SKIP_TESTS=(
-		"far_tutorial_1_2"
+		# Fails due to for CL & CUDA kernels, works outside
+		"glImaging"
 	)
 
-	cmake_src_test
-}
+	# "far_tutorial_1_2 breaks with gcc and > -O1"
+	tc-is-gcc && is-flagq '-O@(2|3|fast)' && CMAKE_SKIP_TESTS+=( "far_tutorial_1_2" )
 
-src_install() {
-	cmake_src_install
+	use cuda && cuda_add_sandbox -w
 
-	rm -f "${ED}/usr/$(get_libdir)/libosdCPU.a" || die
-	if use cuda || use opencl ; then
-		rm -f "${ED}/usr/$(get_libdir)/libosdGPU.a" || die
-	fi
-	if use test; then
-		rm -f \
-			"${ED}/usr/bin/bfr_evaluate" \
-			"${ED}/usr/bin/far_perf" \
-			"${ED}/usr/bin/far_regression" \
-			"${ED}/usr/bin/hbr_baseline" \
-			"${ED}/usr/bin/hbr_regression" \
-			"${ED}/usr/bin/osd_regression" \
-			|| die
-	fi
+	virtx cmake_src_test
+
+	local KERNELS=( CPU )
+	use openmp && KERNELS+=( OPENMP )
+	use tbb && KERNELS+=( TBB )
+
+	# use cuda && KERNELS+=( CUDA )
+	# use opencl && KERNELS+=( CL )
+
+	use opengl && use X && KERNELS+=( XFB )
+	use opengl && KERNELS+=( GLSL )
+
+	virtx "${BUILD_DIR}/bin/glImaging" -w test -l 3 -s 256 256 -a -k "$(IFS=","; echo "${KERNELS[*]}")"
 }


### PR DESCRIPTION
Removed all automagic dependencies.

Changed CUDA interaction as a test-case for better binpkg support.
  - We adhere to CUDAARCHS or NVCCFLAGS.
  - For `MERGE_TYPE=source` we fall back to native.
  - For `MERGE_TYPE=buildonly` we fall back to all-major.
  - Removed clunky OSD_CUDA_NVCC_FLAGS which defaulted to ancient ARCHS.

Replace src_install logic that removed extra files in favour of never installing them via src_prepare.

Closes: https://bugs.gentoo.org/922952
Closes: https://bugs.gentoo.org/922950
Closes: https://bugs.gentoo.org/904070