### PR TITLE
app-arch/libdeflate: add REQUIRED_USE for tests

### DIFF
--- a/app-arch/libdeflate/libdeflate-1.19.ebuild
+++ b/app-arch/libdeflate/libdeflate-1.19.ebuild
@@ -19,6 +19,7 @@ fi
 LICENSE="MIT"
 SLOT="0"
 IUSE="+gzip static-libs +utils +zlib test"
+REQUIRED_USE="test? ( gzip zlib )"
 RESTRICT="!test? ( test )"
 
 src_configure() {

--- a/app-arch/libdeflate/libdeflate-9999.ebuild
+++ b/app-arch/libdeflate/libdeflate-9999.ebuild
@@ -19,6 +19,7 @@ fi
 LICENSE="MIT"
 SLOT="0"
 IUSE="+gzip static-libs +utils +zlib test"
+REQUIRED_USE="test? ( gzip zlib )"
 RESTRICT="!test? ( test )"
 
 src_configure() {


### PR DESCRIPTION
The tests require both the `gzip` and `zlib` USE flags to be enabled.