### PR TITLE
dev-libs/liborcus: fix build with USE=-python

### DIFF
--- a/dev-libs/liborcus/liborcus-0.19.2.ebuild
+++ b/dev-libs/liborcus/liborcus-0.19.2.ebuild
@@ -57,6 +57,6 @@ src_configure() {
 
 src_install() {
 	default
-	python_optimize
+	use python && python_optimize
 	find "${D}" -name '*.la' -type f -delete || die
 }


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/922983