### PR TITLE
profiles/base: unmask dev-lang/rust[profiler] for stable

### DIFF
--- a/profiles/base/package.use.stable.mask
+++ b/profiles/base/package.use.stable.mask
@@ -133,7 +133,7 @@ app-emulation/winetricks test
 # Georgy Yakovlev <gyakovlev@gentoo.org> (2019-12-21)
 # For bleeding edge features and testing, not generally suitable
 # for stable systems
-dev-lang/rust nightly profiler system-bootstrap
+dev-lang/rust nightly system-bootstrap
 
 # Andreas Sturmlechner <asturm@gentoo.org> (2019-12-09)
 # Declared experimental, and dev-cpp/websocketpp not stable yet


### PR DESCRIPTION
The profiler is required to build chromium >=121.

With the initial justification for masking the USE being somewhat flimsy, in the absence of rust maintainers to tell us otherwise we'll unmask it for stable and deal with any consequences.

Bug: https://bugs.gentoo.org/922982