### PR TITLE
app-backup/mkstage4: keyword 0.4.3 for ~x86

### DIFF
--- a/app-backup/mkstage4/mkstage4-0.4.3.ebuild
+++ b/app-backup/mkstage4/mkstage4-0.4.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -9,7 +9,7 @@ SRC_URI="https://github.com/TheChymera/mkstage4/archive/${PV}.tar.gz -> ${P}.tar
 
 LICENSE="GPL-3"
 SLOT="0"
-KEYWORDS="~amd64"
+KEYWORDS="~amd64 ~x86"
 IUSE="test"
 RESTRICT="!test? ( test )"
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/923028