### PR TITLE
media-libs/glm: install CMake config files

### DIFF
--- a/media-libs/glm/glm-1.0.0-r1.ebuild
+++ b/media-libs/glm/glm-1.0.0-r1.ebuild
@@ -1,0 +1,69 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit cmake flag-o-matic
+
+DESCRIPTION="OpenGL Mathematics"
+HOMEPAGE="http://glm.g-truc.net/"
+SRC_URI="https://github.com/g-truc/glm/archive/${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="|| ( HappyBunny MIT )"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86"
+IUSE="test cpu_flags_x86_sse2 cpu_flags_x86_sse3 cpu_flags_x86_avx cpu_flags_x86_avx2"
+RESTRICT="!test? ( test )"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-0.9.9.6-simd.patch
+	"${FILESDIR}"/${P}-clang.patch
+	"${FILESDIR}"/${PN}-0.9.9.8-big-endian-tests.patch
+)
+
+DOCS=( manual.md readme.md )
+
+src_configure() {
+	# Header-only library
+	local mycmakeargs=(
+		-DGLM_BUILD_INSTALL=ON
+		-DGLM_BUILD_LIBRARY=OFF
+		-DGLM_BUILD_TESTS=$(usex test)
+	)
+
+	if use test; then
+		# See https://github.com/g-truc/glm/pull/1087
+		# https://bugs.gentoo.org/818235
+		test-flag-CXX -fno-ipa-modref && append-cxxflags -fno-ipa-modref
+
+		mycmakeargs+=(
+			-DGLM_TEST_ENABLE=ON
+			-DGLM_TEST_ENABLE_SIMD_SSE2="$(usex cpu_flags_x86_sse2 ON OFF)"
+			-DGLM_TEST_ENABLE_SIMD_SSE3="$(usex cpu_flags_x86_sse3 ON OFF)"
+			-DGLM_TEST_ENABLE_SIMD_AVX="$(usex cpu_flags_x86_avx ON OFF)"
+			-DGLM_TEST_ENABLE_SIMD_AVX2="$(usex cpu_flags_x86_avx2 ON OFF)"
+		)
+	fi
+
+	cmake_src_configure
+
+	sed \
+		-e "s:@CMAKE_INSTALL_PREFIX@:${EPREFIX}/usr:" \
+		-e "s:@GLM_VERSION@:$(ver_cut 1-3):" \
+		"${FILESDIR}"/glm.pc.in \
+		> "${BUILD_DIR}/glm.pc" || die
+}
+
+src_compile() {
+	# Header-only library
+	if use test; then
+		cmake_src_compile
+	fi
+}
+
+src_install() {
+	cmake_src_install
+
+	insinto /usr/share/pkgconfig
+	doins "${BUILD_DIR}/glm.pc"
+}


### PR DESCRIPTION
Was not installing the config files which since 1.0 are generated at build-time.

Now installing:

```
/usr/share/glm/glmConfig.cmake
/usr/share/glm/glmConfigVersion.cmake
```

Other tidy-ups:

* No longer installing:

```
/usr/include/glm/CMakeLists.txt
/usr/share/cmake/cmake_uninstall.cmake.in
```

* EAPI 8
* DOCS

```diff
--- glm-1.0.0.ebuild
+++ glm-1.0.0-r1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 inherit cmake flag-o-matic
 
@@ -21,22 +21,31 @@
 	"${FILESDIR}"/${PN}-0.9.9.8-big-endian-tests.patch
 )
 
+DOCS=( manual.md readme.md )
+
 src_configure() {
 	# Header-only library
+	local mycmakeargs=(
+		-DGLM_BUILD_INSTALL=ON
+		-DGLM_BUILD_LIBRARY=OFF
+		-DGLM_BUILD_TESTS=$(usex test)
+	)
+
 	if use test; then
 		# See https://github.com/g-truc/glm/pull/1087
 		# https://bugs.gentoo.org/818235
 		test-flag-CXX -fno-ipa-modref && append-cxxflags -fno-ipa-modref
 
-		local mycmakeargs=(
+		mycmakeargs+=(
 			-DGLM_TEST_ENABLE=ON
 			-DGLM_TEST_ENABLE_SIMD_SSE2="$(usex cpu_flags_x86_sse2 ON OFF)"
 			-DGLM_TEST_ENABLE_SIMD_SSE3="$(usex cpu_flags_x86_sse3 ON OFF)"
 			-DGLM_TEST_ENABLE_SIMD_AVX="$(usex cpu_flags_x86_avx ON OFF)"
 			-DGLM_TEST_ENABLE_SIMD_AVX2="$(usex cpu_flags_x86_avx2 ON OFF)"
 		)
-		cmake_src_configure
 	fi
+
+	cmake_src_configure
 
 	sed \
 		-e "s:@CMAKE_INSTALL_PREFIX@:${EPREFIX}/usr:" \
@@ -53,10 +62,8 @@
 }
 
 src_install() {
-	doheader -r glm
+	cmake_src_install
+
 	insinto /usr/share/pkgconfig
 	doins "${BUILD_DIR}/glm.pc"
-	insinto /usr/share
-	doins -r cmake
-	dodoc readme.md manual.md
 }
```