### PR TITLE
app-arch/libdeflate: 1.19, 9999 update ebuilds

### DIFF
--- a/app-arch/libdeflate/files/libdeflate-1.19-make-gzip-tests-conditional.patch
+++ b/app-arch/libdeflate/files/libdeflate-1.19-make-gzip-tests-conditional.patch
@@ -1,0 +1,37 @@
+Only build these when the user enables zlib and gzip support
+diff --git a/programs/CMakeLists.txt b/programs/CMakeLists.txt
+index e707a25..fcfaf12 100644
+--- a/programs/CMakeLists.txt
++++ b/programs/CMakeLists.txt
+@@ -80,22 +80,28 @@ if(LIBDEFLATE_BUILD_TESTS)
+     target_link_libraries(libdeflate_test_utils PUBLIC
+                           libdeflate_prog_utils ZLIB::ZLIB)
+ 
++    if(LIBDEFLATE_GZIP_SUPPORT AND LIBDEFLATE_ZLIB_SUPPORT)
+     # Build the benchmark and checksum programs.
+     add_executable(benchmark benchmark.c)
+     target_link_libraries(benchmark PRIVATE libdeflate_test_utils)
+     add_executable(checksum checksum.c)
+     target_link_libraries(checksum PRIVATE libdeflate_test_utils)
++    endif()
+ 
+     # Build the unit test programs and register them with CTest.
+     set(UNIT_TEST_PROGS
+-        test_checksums
+         test_custom_malloc
+         test_incomplete_codes
+         test_invalid_streams
+         test_litrunlen_overflow
+         test_overread
+         test_slow_decompression
+-        test_trailing_bytes
+     )
++    if(LIBDEFLATE_GZIP_SUPPORT AND LIBDEFLATE_ZLIB_SUPPORT)
++      list(APPEND UNIT_TEST_PROGS
++        test_checksums
++        test_trailing_bytes
++      )
++    endif()
+     foreach(PROG ${UNIT_TEST_PROGS})
+         add_executable(${PROG} ${PROG}.c)
+         target_link_libraries(${PROG} PRIVATE libdeflate_test_utils)

--- a/app-arch/libdeflate/libdeflate-1.19.ebuild
+++ b/app-arch/libdeflate/libdeflate-1.19.ebuild
@@ -18,14 +18,31 @@ fi
 
 LICENSE="MIT"
 SLOT="0"
-IUSE="+gzip static-libs +utils +zlib test"
-RESTRICT="!test? ( test )"
+# the zlib USE-flag enables support for zlib
+# the test USE-flag programs depend on sys-libs/zlib for comparison tests
+IUSE="+gzip +utils +zlib test"
+
+RESTRICT="
+	!test? ( test )
+"
+
+REQUIRED_USE="
+	utils? ( gzip )
+"
+
+DEPEND="
+	test? ( sys-libs/zlib )
+"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-1.19-make-gzip-tests-conditional.patch"
+)
 
 src_configure() {
 	local mycmakeargs=(
 		-DLIBDEFLATE_BUILD_SHARED_LIB="yes"
-		-DLIBDEFLATE_BUILD_STATIC_LIB="$(usex static-libs)"
-		-DLIBDEFLATE_USE_SHARED_LIB="$(usex !static-libs)"
+		-DLIBDEFLATE_BUILD_STATIC_LIB="no"
+		-DLIBDEFLATE_USE_SHARED_LIB="yes"
 
 		-DLIBDEFLATE_COMPRESSION_SUPPORT="yes"
 		-DLIBDEFLATE_DECOMPRESSION_SUPPORT="yes"

--- a/app-arch/libdeflate/libdeflate-9999.ebuild
+++ b/app-arch/libdeflate/libdeflate-9999.ebuild
@@ -18,14 +18,31 @@ fi
 
 LICENSE="MIT"
 SLOT="0"
-IUSE="+gzip static-libs +utils +zlib test"
-RESTRICT="!test? ( test )"
+# the zlib USE-flag enables support for zlib
+# the test USE-flag programs depend on sys-libs/zlib for comparison tests
+IUSE="+gzip +utils +zlib test"
+
+RESTRICT="
+	!test? ( test )
+"
+
+REQUIRED_USE="
+	utils? ( gzip )
+"
+
+DEPEND="
+	test? ( sys-libs/zlib )
+"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-1.19-make-gzip-tests-conditional.patch"
+)
 
 src_configure() {
 	local mycmakeargs=(
 		-DLIBDEFLATE_BUILD_SHARED_LIB="yes"
-		-DLIBDEFLATE_BUILD_STATIC_LIB="$(usex static-libs)"
-		-DLIBDEFLATE_USE_SHARED_LIB="$(usex !static-libs)"
+		-DLIBDEFLATE_BUILD_STATIC_LIB="no"
+		-DLIBDEFLATE_USE_SHARED_LIB="yes"
 
 		-DLIBDEFLATE_COMPRESSION_SUPPORT="yes"
 		-DLIBDEFLATE_DECOMPRESSION_SUPPORT="yes"

--- a/app-arch/libdeflate/metadata.xml
+++ b/app-arch/libdeflate/metadata.xml
@@ -12,6 +12,7 @@
 	</maintainer>
 	<use>
 		<flag name="gzip">Support the gzip format</flag>
+		<flag name="test">Build the test programs (requires <pkg>sys-libs/zlib</pkg>)</flag>
 		<flag name="utils">Build the libdeflate-gzip program</flag>
 		<flag name="zlib">Support the zlib format</flag>
 	</use>


### PR DESCRIPTION
Make tests that depend on `USE="gzip zlib"` conditional.
Add test time dependency on `sys-libs/zlib`.

Closes: https://github.com/gentoo/gentoo/pull/35036