### PR TITLE
dev-cpp/tbb: fix build with ld.lld (error: version script assignment of 'local' to symbol ...)

### DIFF
--- a/dev-cpp/tbb/tbb-2020.3.ebuild
+++ b/dev-cpp/tbb/tbb-2020.3.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-inherit flag-o-matic multilib-minimal multilib toolchain-funcs
+inherit flag-o-matic multilib-minimal multilib multibuild toolchain-funcs
 
 PV1="$(ver_cut 1)"
 PV2="$(ver_cut 2)"
@@ -40,6 +40,9 @@ src_prepare() {
 }
 
 multilib_src_configure() {
+	# Workaround for bug #912210
+	append-ldflags $(test-flags-CCLD -Wl,--undefined-version)
+
 	# pc files are for debian and fedora compatibility
 	# some deps use them
 	cat <<-EOF > ${PN}.pc.template

--- a/dev-cpp/tbb/tbb-2021.10.0.ebuild
+++ b/dev-cpp/tbb/tbb-2021.10.0.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-inherit cmake-multilib
+inherit cmake-multilib flag-o-matic
 
 DESCRIPTION="High level abstract threading library"
 HOMEPAGE="https://github.com/oneapi-src/oneTBB"
@@ -27,6 +27,9 @@ PATCHES=(
 )
 
 src_prepare() {
+	# Workaround for bug #912210
+	append-ldflags $(test-flags-CCLD -Wl,--undefined-version)
+
 	# Has an #error to force compilation as C but links with C++ library, dies
 	# with GLIBCXX_ASSERTIONS as a result.
 	sed -i -e '/tbb_add_c_test(SUBDIR tbbmalloc NAME test_malloc_pure_c DEPENDENCIES TBB::tbbmalloc)/d' test/CMakeLists.txt || die

--- a/dev-cpp/tbb/tbb-2021.11.0.ebuild
+++ b/dev-cpp/tbb/tbb-2021.11.0.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-inherit cmake-multilib
+inherit cmake-multilib flag-o-matic
 
 DESCRIPTION="High level abstract threading library"
 HOMEPAGE="https://github.com/oneapi-src/oneTBB"
@@ -35,6 +35,9 @@ src_prepare() {
 }
 
 src_configure() {
+	# Workaround for bug #912210
+	append-ldflags $(test-flags-CCLD -Wl,--undefined-version)
+
 	local mycmakeargs=(
 		-DTBB_TEST=$(usex test)
 		-DTBB_ENABLE_IPO=OFF

--- a/dev-cpp/tbb/tbb-2021.5.0-r1.ebuild
+++ b/dev-cpp/tbb/tbb-2021.5.0-r1.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-inherit cmake-multilib
+inherit cmake-multilib flag-o-matic
 
 DESCRIPTION="High level abstract threading library"
 HOMEPAGE="https://github.com/oneapi-src/oneTBB"
@@ -39,6 +39,12 @@ PATCHES=(
 )
 
 src_configure() {
+	# Workaround for bug #912210
+	append-ldflags $(test-flags-CCLD -Wl,--undefined-version)
+
+	# Workaround for bug #912210
+	append-ldflags $(test-flags-CCLD -Wl,--undefined-version)
+
 	local mycmakeargs=(
 		-DTBB_TEST=$(usex test)
 		-DTBB_ENABLE_IPO=OFF

--- a/dev-cpp/tbb/tbb-2021.7.0-r1.ebuild
+++ b/dev-cpp/tbb/tbb-2021.7.0-r1.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-inherit cmake-multilib
+inherit cmake-multilib flag-o-matic
 
 DESCRIPTION="High level abstract threading library"
 HOMEPAGE="https://github.com/oneapi-src/oneTBB"
@@ -27,6 +27,9 @@ PATCHES=(
 )
 
 src_configure() {
+	# Workaround for bug #912210
+	append-ldflags $(test-flags-CCLD -Wl,--undefined-version)
+
 	local mycmakeargs=(
 		-DTBB_TEST=$(usex test)
 		-DTBB_ENABLE_IPO=OFF

--- a/dev-cpp/tbb/tbb-2021.7.0.ebuild
+++ b/dev-cpp/tbb/tbb-2021.7.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -23,6 +23,9 @@ DEPEND="${RDEPEND}"
 BDEPEND="virtual/pkgconfig"
 
 src_configure() {
+	# Workaround for bug #912210
+	append-ldflags $(test-flags-CCLD -Wl,--undefined-version)
+
 	# bug #872287
 	filter-flags -D_GLIBCXX_ASSERTIONS
 	append-cppflags -U_GLIBCXX_ASSERTIONS

--- a/dev-cpp/tbb/tbb-2021.8.0.ebuild
+++ b/dev-cpp/tbb/tbb-2021.8.0.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-inherit cmake-multilib
+inherit cmake-multilib flag-o-matic
 
 DESCRIPTION="High level abstract threading library"
 HOMEPAGE="https://github.com/oneapi-src/oneTBB"
@@ -36,6 +36,9 @@ src_prepare() {
 }
 
 src_configure() {
+	# Workaround for bug #912210
+	append-ldflags $(test-flags-CCLD -Wl,--undefined-version)
+
 	local mycmakeargs=(
 		-DTBB_TEST=$(usex test)
 		-DTBB_ENABLE_IPO=OFF

--- a/dev-cpp/tbb/tbb-2021.9.0.ebuild
+++ b/dev-cpp/tbb/tbb-2021.9.0.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-inherit cmake-multilib
+inherit cmake-multilib flag-o-matic
 
 DESCRIPTION="High level abstract threading library"
 HOMEPAGE="https://github.com/oneapi-src/oneTBB"
@@ -35,6 +35,9 @@ src_prepare() {
 }
 
 src_configure() {
+	# Workaround for bug #912210
+	append-ldflags $(test-flags-CCLD -Wl,--undefined-version)
+
 	local mycmakeargs=(
 		-DTBB_TEST=$(usex test)
 		-DTBB_ENABLE_IPO=OFF


### PR DESCRIPTION
ld.lld 17 fix, adds `-Wl,--undefined-version` in a way, similar to other fixes like https://github.com/gentoo/gentoo/pull/34926

Closes: [#912210](https://bugs.gentoo.org/912210)