### PR TITLE
dev-python/ldap3: enable py3.12

### DIFF
--- a/dev-python/ldap3/ldap3-2.9.1.ebuild
+++ b/dev-python/ldap3/ldap3-2.9.1.ebuild
@@ -1,10 +1,10 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} pypy3 )
+PYTHON_COMPAT=( python3_{9..12} pypy3 )
 inherit distutils-r1
 
 DESCRIPTION="A strictly RFC 4511 conforming LDAP V3 pure Python client"


### PR DESCRIPTION
Buildbot tests pass on the ldap part with py 3.12