### PR TITLE
games-emulation/gambatte-jg: new USE flags

### DIFF
--- a/games-emulation/gambatte-jg/metadata.xml
+++ b/games-emulation/gambatte-jg/metadata.xml
@@ -9,6 +9,10 @@
 		<email>sam@gentoo.org</email>
 		<name>Sam James</name>
 	</maintainer>
+	<use>
+		<flag name="jgmodule">Build module for The Jolly Good API</flag>
+		<flag name="shared">Build shared library</flag>
+	</use>
 	<longdescription>
 		Gambatte JG is an emulator for the Nintendo Game Boy/Game Boy
 		Color. This is a fork of the final public revision of Gambatte.


### PR DESCRIPTION
* examples: Install the example frontend for libgambatte
* jgmodule: Install the module for The Jolly Good API
* shared: Install the shared libgambatte library

The old behavior was to only build the module for The Jolly Good API.