### PR TITLE
sys-kernel/dracut: gawk is a dependency 

### DIFF
--- a/sys-kernel/dracut/dracut-059-r7.ebuild
+++ b/sys-kernel/dracut/dracut-059-r7.ebuild
@@ -28,6 +28,7 @@ RDEPEND="
 	app-alternatives/cpio
 	>=app-shells/bash-4.0:0
 	sys-apps/coreutils[xattr(-)]
+	sys-apps/gawk
 	>=sys-apps/kmod-23[tools]
 	|| (
 		>=sys-apps/sysvinit-2.87-r3

--- a/sys-kernel/dracut/dracut-060_pre20231030-r2.ebuild
+++ b/sys-kernel/dracut/dracut-060_pre20231030-r2.ebuild
@@ -33,6 +33,7 @@ RDEPEND="
 	app-alternatives/cpio
 	>=app-shells/bash-4.0:0
 	sys-apps/coreutils[xattr(-)]
+	sys-apps/gawk
 	>=sys-apps/kmod-23[tools]
 	|| (
 		>=sys-apps/sysvinit-2.87-r3

--- a/sys-kernel/dracut/dracut-060_pre20240104-r2.ebuild
+++ b/sys-kernel/dracut/dracut-060_pre20240104-r2.ebuild
@@ -33,6 +33,7 @@ RDEPEND="
 	app-alternatives/cpio
 	>=app-shells/bash-4.0:0
 	sys-apps/coreutils[xattr(-)]
+	sys-apps/gawk
 	>=sys-apps/kmod-23[tools]
 	|| (
 		>=sys-apps/sysvinit-2.87-r3

--- a/sys-kernel/dracut/dracut-9999.ebuild
+++ b/sys-kernel/dracut/dracut-9999.ebuild
@@ -33,6 +33,7 @@ RDEPEND="
 	app-alternatives/cpio
 	>=app-shells/bash-4.0:0
 	sys-apps/coreutils[xattr(-)]
+	sys-apps/gawk
 	>=sys-apps/kmod-23[tools]
 	|| (
 		>=sys-apps/sysvinit-2.87-r3


### PR DESCRIPTION
see https://github.com/dracutdevs/dracut/commit/f32e95bcadbc5158843530407adc1e7b700561b1 and 
https://github.com/dracutdevs/dracut/pull/2329#pullrequestreview-1418039307 for v60

See https://github.com/gentoo/gentoo/blob/master/sys-kernel/dracut/files/059-gawk.patch for v59