### PR TITLE
sci-libs/caffe2: do not move torch headers; symlink them

### DIFF
--- a/sci-libs/caffe2/caffe2-2.1.2-r3.ebuild
+++ b/sci-libs/caffe2/caffe2-2.1.2-r3.ebuild
@@ -223,16 +223,14 @@ src_install() {
 	rm -rf python
 	mkdir -p python/torch/include || die
 	mv "${ED}"/usr/lib/python*/site-packages/caffe2 python/ || die
-	mv "${ED}"/usr/include/torch python/torch/include || die
 	if use cuda; then
 		mv "${ED}${S}"/nvfuser python/nvfuser || die
 		mv "${ED}"/usr/$(get_libdir)/nvfuser.so python/nvfuser/_C.so || die
 	fi
-	rm -rf "${ED}${S}"/test
-	rm -rf "${ED}${S}"/third_party
 	cp torch/version.py python/torch/ || die
 	python_domodule python/caffe2
 	python_domodule python/torch
+	ln -s ../../../../../include/torch "${D}$(python_get_sitedir)"/torch/include/torch || die # bug 923269
 	if use cuda; then
 		python_domodule python/nvfuser
 	fi


### PR DESCRIPTION
This allows to use provided CMake configuration to build other projects (like intel-extension-for-pytorch).

Additionally, cleanup few lines that does not affect installation.

Closes: https://bugs.gentoo.org/923269
