### PR TITLE
sci-geosciences/gpscorrelate: Fix implicit declaration of func. malloc

### DIFF
--- a/sci-geosciences/gpscorrelate/files/gpscorrelate-2.0-fix-gcc14-malloc.patch
+++ b/sci-geosciences/gpscorrelate/files/gpscorrelate-2.0-fix-gcc14-malloc.patch
@@ -1,0 +1,12 @@
+diff --git a/gpx-read.c b/gpx-read.c
+index e57cc41..a53b01b 100644
+--- a/gpx-read.c
++++ b/gpx-read.c
+@@ -28,6 +28,7 @@
+ #include <stdio.h>
+ #include <string.h>
+ #include <locale.h>
++#include <stdlib.h>
+ #include <libxml/parser.h>
+ #include <libxml/tree.h>
+ 

--- a/sci-geosciences/gpscorrelate/gpscorrelate-2.0-r1.ebuild
+++ b/sci-geosciences/gpscorrelate/gpscorrelate-2.0-r1.ebuild
@@ -1,0 +1,52 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit desktop
+
+DESCRIPTION="Tool for adjusting EXIF tags of your photos with a recorded GPS trace"
+HOMEPAGE="https://dfandrich.github.io/gpscorrelate/"
+SRC_URI="https://github.com/dfandrich/${PN}/releases/download/${PV}/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~hppa ~x86"
+IUSE="gtk"
+
+BDEPEND="
+	app-text/docbook-xml-dtd:4.2
+	dev-libs/libxslt
+	virtual/pkgconfig
+"
+DEPEND="
+	dev-libs/libxml2:2
+	media-gfx/exiv2:=
+	gtk? ( x11-libs/gtk+:3 )
+"
+RDEPEND="${DEPEND}"
+
+PATCHES=(
+	"${FILESDIR}/${P}-desktop-pass-validation.patch"
+	"${FILESDIR}/${P}-respect-users-flags.patch"
+	"${FILESDIR}/${P}-exiv2-0.28.patch" # bug 906498
+	"${FILESDIR}/${P}-fix-gcc14-malloc.patch" # bug 923125
+)
+
+src_compile() {
+	emake gpscorrelate
+	use gtk && emake gpscorrelate-gui
+
+}
+
+src_install() {
+	dobin ${PN}
+	if use gtk; then
+		dobin ${PN}-gui
+		doicon -s scalable ${PN}-gui.svg
+		domenu ${PN}.desktop
+	fi
+	dodoc doc/*.html doc/*.png doc/*.xml
+	einstalldocs
+	doman doc/${PN}.1
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/923125