### PR TITLE
www-apps/rutorrent: remove google-code from metadata

### DIFF
--- a/www-apps/rutorrent/metadata.xml
+++ b/www-apps/rutorrent/metadata.xml
@@ -11,7 +11,6 @@
 	</maintainer>
 	<stabilize-allarches/>
 	<upstream>
-		<remote-id type="google-code">rutorrent</remote-id>
 		<remote-id type="github">Novik/ruTorrent</remote-id>
 	</upstream>
 </pkgmetadata>


### PR DESCRIPTION
The package has moved to github and the google-code mirror does not work any longer.