### PR TITLE
dev-perl/Tk: fix tests on 64-bit big-endian

### DIFF
--- a/dev-perl/Tk/Tk-804.36.0-r3.ebuild
+++ b/dev-perl/Tk/Tk-804.36.0-r3.ebuild
@@ -1,0 +1,70 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DIST_AUTHOR=SREZIC
+DIST_VERSION=804.036
+DIST_EXAMPLES=("examples/*")
+inherit perl-module virtualx
+
+DESCRIPTION="A Perl Module for Tk"
+
+LICENSE+=" tcltk BSD"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux"
+
+DEPEND="
+	media-libs/freetype
+	media-libs/libjpeg-turbo:=
+	>=media-libs/libpng-1.4:0
+	x11-libs/libX11
+	x11-libs/libXft
+"
+RDEPEND="${DEPEND}"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-804.034-xorg.patch
+	"${FILESDIR}"/${PN}-804.036-configure-clang16.patch
+	"${FILESDIR}"/${PN}-804.036-crash.patch
+	"${FILESDIR}"/${PN}-804.036-incompatible-function-pointer-types.patch
+	"${FILESDIR}"/${PN}-804.036-Fix-STRLEN-vs-int-pointer-confusion-in-Tcl_GetByteAr.patch
+)
+
+PERL_RM_FILES=( "t/pod.t" )
+
+src_prepare() {
+	myconf=( X11ROOT="${EPREFIX}"/usr XFT=1 -I"${EPREFIX}"/usr/include/ -l"${EPREFIX}"/usr/$(get_libdir) )
+	mydoc="ToDo VERSIONS"
+
+	perl-module_src_prepare
+	# fix detection logic for Prefix, bug #385621
+	sed -i -e "s:/usr:${EPREFIX}/usr:g" myConfig || die
+	# having this around breaks with perl-module and a case-IN-sensitive fs
+	rm build_ptk || die
+
+	# Remove all bundled libs, fixes #488194
+	local BUNDLED="PNG/libpng \
+					PNG/zlib \
+					JPEG/jpeg"
+
+	# Move files required for tests temporarily
+
+	mkdir -p "${T}/stash" || die "can't create temporary stash"
+	mv "${S}/JPEG/jpeg/testimg.jpg" "${T}/stash/testimg.jpg" || die "can't move testimg.jpg"
+
+	for dir in ${BUNDLED}; do
+		einfo "Removing bundled: ${dir}"
+		rm -r "${S}/${dir}" || die "Can't remove bundle"
+		# Makefile.PL can copy files to ${S}/${dir}, so recreate them back.
+		mkdir -p "${S}/${dir}" || die "Can't restore bundled dir"
+		sed -i "\#^${dir}#d" "${S}"/MANIFEST || die 'Can not remove bundled libs from MANIFEST'
+	done
+
+	# Restore test files
+	mv "${T}/stash/testimg.jpg" "${S}/JPEG/jpeg/testimg.jpg" || die "can't restore testimg.jpg"
+}
+
+src_test() {
+	virtx perl-module_src_test
+}

--- a/dev-perl/Tk/files/Tk-804.036-Fix-STRLEN-vs-int-pointer-confusion-in-Tcl_GetByteAr.patch
+++ b/dev-perl/Tk/files/Tk-804.036-Fix-STRLEN-vs-int-pointer-confusion-in-Tcl_GetByteAr.patch
@@ -1,0 +1,48 @@
+https://bugs.gentoo.org/916814
+https://salsa.debian.org/georgesk/perl-tk/-/blob/master/debian/patches/80-Fix-STRLEN-vs-int-pointer-confusion-in-Tcl_GetByteAr.patch?ref_type=heads
+
+From a26233c844c52f49ef9cca5f88dd9063aac60d0f Mon Sep 17 00:00:00 2001
+From: Niko Tyni <ntyni@debian.org>
+Date: Thu, 11 Jan 2024 18:28:58 +0000
+Subject: [PATCH] Fix STRLEN vs int pointer confusion in
+ Tcl_GetByteArrayFromObj()
+
+Perl 5.37.2, more precisely commit
+
+ https://github.com/Perl/perl5/commit/1ef9039bccbfe64f47f201b6cfb7d6d23e0b08a7
+
+changed the implementation of SvPV() et al., breaking t/balloon.t,
+t/canvas2.t and t/photo.t on big-endian 64-bit architectures such as
+ppc64 and s390x because StringMatchGIF() no longer recognized GIF files.
+
+This is because Tcl_GetByteArrayFromObj() was calling SvPV() with an int
+pointer instead of a correct STRLEN pointer, and the new implementation
+is more sensitive to this: it assigns the pointers as-is, resulting in
+the int pointer pointing at the wrong end of the 64-bit length.
+
+Other functions taking a length pointer, at least Tcl_GetStringFromObj()
+already seem to do things correctly, so presumably this is not a
+systematic issue.
+---
+ objGlue.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/objGlue.c b/objGlue.c
+index d4927ea..dbd6a50 100644
+--- a/objGlue.c
++++ b/objGlue.c
+@@ -627,7 +627,10 @@ Tcl_GetByteArrayFromObj(Tcl_Obj * objPtr, int * lengthPtr)
+  sv_utf8_downgrade(objPtr, 0);
+  if (lengthPtr)
+   {
+-   return (unsigned char *) SvPV(objPtr, *lengthPtr);
++   STRLEN len;
++   unsigned char *s = SvPV(objPtr, len);
++   *lengthPtr = len;
++   return s;
+   }
+  else
+   {
+-- 
+2.30.2
+


### PR DESCRIPTION
See: https://salsa.debian.org/georgesk/perl-tk/-/blob/master/debian/patches/80-Fix-STRLEN-vs-int-pointer-confusion-in-Tcl_GetByteAr.patch?ref_type=heads
Bug: https://bugs.gentoo.org/916814