### PR TITLE
dev-libs/cxxopts: pass cmake options

### DIFF
--- a/dev-libs/cxxopts/cxxopts-3.0.0-r1.ebuild
+++ b/dev-libs/cxxopts/cxxopts-3.0.0-r1.ebuild
@@ -27,7 +27,7 @@ src_prepare() {
 }
 
 src_configure() {
-	local -a mycmakeopts=(
+	local mycmakeargs=(
 		-DCXXOPTS_BUILD_EXAMPLES:BOOL=OFF
 		-DCXXOPTS_BUILD_TESTS:BOOL=$(usex test)
 		-DCXXOPTS_ENABLE_INSTALL:BOOL=ON

--- a/dev-libs/cxxopts/cxxopts-3.2.0-r1.ebuild
+++ b/dev-libs/cxxopts/cxxopts-3.2.0-r1.ebuild
@@ -29,7 +29,7 @@ src_prepare() {
 }
 
 src_configure() {
-	local -a mycmakeopts=(
+	local mycmakeargs=(
 		-DCXXOPTS_BUILD_EXAMPLES:BOOL=OFF
 		-DCXXOPTS_BUILD_TESTS:BOOL=$(usex test)
 		-DCXXOPTS_ENABLE_INSTALL:BOOL=ON


### PR DESCRIPTION
previously mycmakeopts was used to pass them, which is simply ignored,
needs to be mycmakeargs

Signed-off-by: Robert Günzler <r@gnzler.io>
