### PR TITLE
media-sound/whipper: fix dev-python/ruamel-yaml in RDEPEND

### DIFF
--- a/media-sound/whipper/whipper-0.10.0-r1.ebuild
+++ b/media-sound/whipper/whipper-0.10.0-r1.ebuild
@@ -1,0 +1,58 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+PYTHON_COMPAT=( python3_{9..11} )
+
+DISTUTILS_USE_PEP517="setuptools"
+
+inherit distutils-r1
+
+DESCRIPTION="A Python CD-DA ripper preferring accuracy over speed (forked from morituri)"
+HOMEPAGE="https://github.com/whipper-team/whipper"
+SRC_URI="https://github.com/whipper-team/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="GPL-3+"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+DEPEND="media-libs/libsndfile:="
+# bug https://bugs.gentoo.org/923339
+# upstream https://github.com/whipper-team/whipper/issues/605
+# upstream https://github.com/whipper-team/whipper/issues/606
+RDEPEND="
+	${DEPEND}
+	app-cdr/cdrdao
+	>=dev-libs/libcdio-paranoia-0.94_p2
+	dev-python/musicbrainzngs[${PYTHON_USEDEP}]
+	>=dev-python/pycdio-2.1.0[${PYTHON_USEDEP}]
+	dev-python/pygobject:3[${PYTHON_USEDEP}]
+	dev-python/discid[${PYTHON_USEDEP}]
+	<dev-python/ruamel-yaml-0.18.0[${PYTHON_USEDEP}]
+	dev-python/setuptools[${PYTHON_USEDEP}]
+	media-libs/mutagen[${PYTHON_USEDEP}]
+	media-sound/sox[flac]"
+BDEPEND="
+	dev-python/setuptools-scm[${PYTHON_USEDEP}]
+	test? ( dev-python/twisted[${PYTHON_USEDEP}] )"
+
+distutils_enable_tests unittest
+
+PATCHES=( "${FILESDIR}/${PN}-0.7.0-cdparanoia-name-fix.patch" )
+
+python_prepare_all() {
+	# accurip test totally depends on network access
+	rm "${PN}"/test/test_common_accurip.py || die
+
+	# Test fails with
+	# Log [82 chars]28Z\n\nRipping phase information:\n  Drive: HL[2290 chars]31\n
+	# !=
+	# Log [82 chars]28Z\nRipping phase information:\n  Drive: HL-D[2274 chars]31\n
+	# assertion. TODO: fix test.
+	rm "${PN}"/test/test_result_logger.py || die
+
+	export SETUPTOOLS_SCM_PRETEND_VERSION=${PV}
+
+	distutils-r1_python_prepare_all
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/923339