### PR TITLE
x11-misc/copyq: fix plugin dir envvar patch

### DIFF
--- a/x11-misc/copyq/copyq-7.1.0-r1.ebuild
+++ b/x11-misc/copyq/copyq-7.1.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -69,7 +69,7 @@ PATCHES=(
 	"${FILESDIR}/copyq-7.1.0-fix-qt-6.6.0-build.patch"
 	"${FILESDIR}/copyq-7.1.0-fix-test-failure-due-to-invalid-regex.patch"
 	"${FILESDIR}/copyq-7.1.0-fix-gpg-2.1-support.patch"
-	"${FILESDIR}/copyq-7.1.0-support-plugin-dir-envvar.patch"
+	"${FILESDIR}/copyq-7.1.0-support-plugin-dir-envvar-r1.patch"
 )
 
 src_prepare() {

--- a/x11-misc/copyq/files/copyq-7.1.0-support-plugin-dir-envvar-r1.patch
+++ b/x11-misc/copyq/files/copyq-7.1.0-support-plugin-dir-envvar-r1.patch
@@ -1,6 +1,6 @@
-From 32b45b42f0d9dbdaae077f81d11fff7bd2455492 Mon Sep 17 00:00:00 2001
+From 6d20653b924481048fa017dc40cf9d7360f95a13 Mon Sep 17 00:00:00 2001
 From: Alfred Wingate <parona@protonmail.com>
-Date: Wed, 6 Dec 2023 06:16:36 +0200
+Date: Tue, 30 Jan 2024 20:44:18 +0200
 Subject: [PATCH] itemfactory: Add support for setting plugin dir in the
  environment
 
@@ -12,11 +12,11 @@ Signed-off-by: Alfred Wingate <parona@protonmail.com>
  bool findPluginDir(QDir *pluginsDir)
  {
 +    QString pluginDirEnv = qEnvironmentVariable("COPYQ_PLUGIN_DIR");
-+    if ( !pluginDirEnv.isEmpty() )
++    if ( !pluginDirEnv.isEmpty() ) {
 +        pluginsDir->setPath(pluginDirEnv);
-+
-+    if ( pluginsDir->isReadable() )
-+        return true;
++        if ( pluginsDir->isReadable() )
++            return true;
++    }
 +
  #ifdef COPYQ_PLUGIN_PREFIX
      pluginsDir->setPath(COPYQ_PLUGIN_PREFIX);


### PR DESCRIPTION
* Fixes issue where plugins can't be found.
* Didn't appreciate the fact that QDir will initialise at . if empty...