### PR TITLE
app-emulation/qemu: Add missing ninja BDEPEND

### DIFF
--- a/app-emulation/qemu/qemu-8.1.5.ebuild
+++ b/app-emulation/qemu/qemu-8.1.5.ebuild
@@ -275,6 +275,7 @@ BDEPEND="
 	$(python_gen_impl_dep)
 	dev-lang/perl
 	>=dev-build/meson-0.63.0
+	app-alternatives/ninja
 	dev-python/pip[${PYTHON_USEDEP}]
 	virtual/pkgconfig
 	doc? (

--- a/app-emulation/qemu/qemu-8.2.2.ebuild
+++ b/app-emulation/qemu/qemu-8.2.2.ebuild
@@ -280,6 +280,7 @@ BDEPEND="
 	$(python_gen_impl_dep)
 	dev-lang/perl
 	>=dev-build/meson-0.63.0
+	app-alternatives/ninja
 	dev-python/pip[${PYTHON_USEDEP}]
 	virtual/pkgconfig
 	doc? (

--- a/app-emulation/qemu/qemu-9999.ebuild
+++ b/app-emulation/qemu/qemu-9999.ebuild
@@ -280,6 +280,7 @@ BDEPEND="
 	$(python_gen_impl_dep)
 	dev-lang/perl
 	>=dev-build/meson-0.63.0
+	app-alternatives/ninja
 	dev-python/pip[${PYTHON_USEDEP}]
 	virtual/pkgconfig
 	doc? (


### PR DESCRIPTION
```
ERROR: Cannot find Ninja

 * ERROR: app-emulation/qemu-7.2.8::portage-stable failed (configure phase):
 *   configure failed
 *
 * Call stack:
 *               ebuild.sh, line  125:  Called src_configure
 *             environment, line 5053:  Called qemu_src_configure 'softmmu'
 *             environment, line 4914:  Called die
 * The specific snippet of code:
 *       ../configure "${conf_opts[@]}" || die "configure failed"
```

BUG=b:323026468
TEST=bazel build --config=hash_tracer @portage//host/app-emulation/qemu

Change-Id: I82ba9126ebef4d608ed89961ede03072ff412516
