### PR TITLE
app-laptop/tiny-dfr: Add a missing dependency

### DIFF
--- a/app-laptop/tiny-dfr/tiny-dfr-0.2.0.ebuild
+++ b/app-laptop/tiny-dfr/tiny-dfr-0.2.0.ebuild
@@ -225,6 +225,7 @@ SRC_URI="
 DEPEND="
 	dev-libs/libinput
 	x11-libs/pango
+	x11-libs/gdk-pixbuf
 "
 
 RDEPEND="${DEPEND}"


### PR DESCRIPTION
Closes: gentoo#923393