### PR TITLE
www-client/chromium: put 121.0.6167.139 into stable channel

### DIFF
--- a/www-client/chromium/chromium-121.0.6167.139.ebuild
+++ b/www-client/chromium/chromium-121.0.6167.139.ebuild
@@ -76,7 +76,7 @@ SRC_URI="https://commondatastorage.googleapis.com/chromium-browser-official/${P}
 	pgo? ( https://github.com/elkablo/chromium-profiler/releases/download/v0.2/chromium-profiler-0.2.tar )"
 
 LICENSE="BSD"
-SLOT="0/beta"
+SLOT="0/stable"
 KEYWORDS="~amd64 ~arm64 ~ppc64"
 IUSE_SYSTEM_LIBS="+system-harfbuzz +system-icu +system-png +system-zstd"
 IUSE="+X ${IUSE_SYSTEM_LIBS} cups debug gtk4 +hangouts headless kerberos libcxx lto +official pax-kernel pgo +proprietary-codecs pulseaudio"


### PR DESCRIPTION
The 121 major version was released as stable. Commit d43ce7742277 ("www-client/chromium: drop 121.0.6167.85") dropped previous 121 ebuild that already had it's slot marked in stable channel.

Since I use
  www-client/chromium:0/stable **
in my package.accept_keywords, the above mentioned commit caused my update script to want to downgrade chromium back to 120.