### PR TITLE
Adjusting reverse dependencies of QScintilla in preparation to Qt6

### DIFF
--- a/app-editors/juffed/juffed-0.10_p20200103-r1.ebuild
+++ b/app-editors/juffed/juffed-0.10_p20200103-r1.ebuild
@@ -23,7 +23,7 @@ RDEPEND="
 	dev-qt/qtsingleapplication[X]
 	dev-qt/qtwidgets:5
 	dev-qt/qtxml:5
-	x11-libs/qscintilla
+	x11-libs/qscintilla[qt5(+)]
 "
 DEPEND="${RDEPEND}"
 BDEPEND="dev-qt/linguist-tools:5"

--- a/dev-db/sqlitebrowser/sqlitebrowser-3.12.2-r2.ebuild
+++ b/dev-db/sqlitebrowser/sqlitebrowser-3.12.2-r2.ebuild
@@ -32,7 +32,7 @@ DEPEND="
 	>=dev-qt/qtprintsupport-5.5:5
 	>=dev-qt/qtwidgets-5.5:5
 	>=dev-qt/qtxml-5.5:5
-	>=x11-libs/qscintilla-2.8.10:=
+	>=x11-libs/qscintilla-2.8.10:=[qt5(+)]
 	sqlcipher? ( dev-db/sqlcipher )
 "
 

--- a/dev-db/sqlitebrowser/sqlitebrowser-9999.ebuild
+++ b/dev-db/sqlitebrowser/sqlitebrowser-9999.ebuild
@@ -32,7 +32,7 @@ DEPEND="
 	>=dev-qt/qtprintsupport-5.5:5
 	>=dev-qt/qtwidgets-5.5:5
 	>=dev-qt/qtxml-5.5:5
-	>=x11-libs/qscintilla-2.8.10:=
+	>=x11-libs/qscintilla-2.8.10:=[qt5(+)]
 	sqlcipher? ( dev-db/sqlcipher )
 "
 

--- a/dev-db/sqliteman/sqliteman-1.2.2-r6.ebuild
+++ b/dev-db/sqliteman/sqliteman-1.2.2-r6.ebuild
@@ -19,7 +19,7 @@ RDEPEND="
 	dev-qt/qtgui:5
 	dev-qt/qtsql:5[sqlite]
 	dev-qt/qtwidgets:5
-	>=x11-libs/qscintilla-2.10.3:="
+	>=x11-libs/qscintilla-2.10.3:=[qt5(+)]"
 DEPEND="${RDEPEND}"
 
 PATCHES=(

--- a/media-gfx/openscad/openscad-2021.01-r5.ebuild
+++ b/media-gfx/openscad/openscad-2021.01-r5.ebuild
@@ -46,7 +46,7 @@ RDEPEND="
 	media-libs/lib3mf
 	sci-mathematics/cgal:=
 	x11-libs/cairo
-	>=x11-libs/qscintilla-2.10.3:=
+	>=x11-libs/qscintilla-2.10.3:=[qt5(+)]
 	emacs? ( >=app-editors/emacs-23.1:* )
 "
 DEPEND="${RDEPEND}"

--- a/media-gfx/openscad/openscad-9999.ebuild
+++ b/media-gfx/openscad/openscad-9999.ebuild
@@ -54,7 +54,7 @@ RDEPEND="
 		dev-qt/qtsvg:5
 		dev-qt/qtwidgets:5
 		x11-libs/libX11
-		x11-libs/qscintilla:=
+		x11-libs/qscintilla:=[qt5(+)]
 		dbus? ( dev-qt/qtdbus:5 )
 		gamepad? ( dev-qt/qtgamepad:5 )
 	)

--- a/sci-mathematics/octave/octave-7.3.0-r3.ebuild
+++ b/sci-mathematics/octave/octave-7.3.0-r3.ebuild
@@ -31,7 +31,7 @@ RDEPEND="
 	app-arch/zip
 	app-text/ghostscript-gpl
 	sys-apps/texinfo
-	dev-libs/libpcre2
+	dev-libs/libpcre:=
 	sys-libs/ncurses:=
 	sys-libs/zlib
 	virtual/blas
@@ -49,7 +49,7 @@ RDEPEND="
 		dev-qt/qtopengl:5
 		dev-qt/qtprintsupport:5
 		dev-qt/qtwidgets:5
-		x11-libs/qscintilla:=
+		x11-libs/qscintilla:=[qt5(+)]
 	)
 	hdf5? ( sci-libs/hdf5:= )
 	imagemagick? ( media-gfx/graphicsmagick:=[cxx] )
@@ -65,7 +65,7 @@ RDEPEND="
 	postscript? (
 		app-text/epstool
 		media-gfx/pstoedit
-		>=media-gfx/fig2dev-3.2.9-r1
+		media-gfx/transfig
 	)
 	qhull? ( media-libs/qhull:= )
 	qrupdate? ( sci-libs/qrupdate:= )
@@ -128,7 +128,10 @@ REQUIRED_USE="
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-5.1.0-pkgbuilddir.patch
+	"${FILESDIR}"/${PN}-4.2.2-ncurses-pkgconfig.patch
+	"${FILESDIR}"/${PN}-6.4.0-slibtool.patch
 	"${FILESDIR}"/${PN}-6.4.0-omit-qtchooser-qtver.patch
+	"${FILESDIR}"/${P}-docs-texinfo-7.0.patch
 )
 
 src_prepare() {
@@ -164,49 +167,41 @@ src_configure() {
 	# --with-sundials_ida (no-op) with USE="sundials"
 	# --without-sundials_ida (disables it) with USE="-sundials"
 	#
-	local myeconfargs=(
-		--localstatedir="${EPREFIX}/var/state/octave"
-		--with-blas="$($(tc-getPKG_CONFIG) --libs blas)"
-		--with-lapack="$($(tc-getPKG_CONFIG) --libs lapack)"
-		--disable-64
-		--enable-shared
-		--with-z
-		--with-bz2
-
-		# bug #901965
-		--without-libiconv-prefix
-		--without-libreadline-prefix
-
-		$(use_enable doc docs)
-		$(use_enable java)
-		$(use_enable json rapidjson)
-		$(use_enable readline)
-		$(use_with curl)
-		$(use_with fftw fftw3)
-		$(use_with fftw fftw3f)
-		$(use_enable fftw fftw-threads)
-		$(use_with glpk)
-		$(use_with hdf5)
-		$(use_with imagemagick magick GraphicsMagick++)
-		$(use_with opengl)
-		$(use_with fltk)
-		$(use_with ssl openssl)
-		$(use_with portaudio)
-		$(use_with qhull qhull_r)
-		$(use_with qrupdate)
-		$(use_with gui qt 5)
-		$(use_with sndfile)
-		$(use_with sparse arpack)
-		$(use_with sparse umfpack)
-		$(use_with sparse colamd)
-		$(use_with sparse ccolamd)
-		$(use_with sparse cholmod)
-		$(use_with sparse cxsparse)
-		$(use_with sundials sundials_ida)
+	econf \
+		--localstatedir="${EPREFIX}/var/state/octave" \
+		--with-blas="$($(tc-getPKG_CONFIG) --libs blas)" \
+		--with-lapack="$($(tc-getPKG_CONFIG) --libs lapack)" \
+		--disable-64 \
+		--enable-shared \
+		--with-z \
+		--with-bz2 \
+		$(use_enable doc docs) \
+		$(use_enable java) \
+		$(use_enable json rapidjson) \
+		$(use_enable readline) \
+		$(use_with curl) \
+		$(use_with fftw fftw3) \
+		$(use_with fftw fftw3f) \
+		$(use_enable fftw fftw-threads) \
+		$(use_with glpk) \
+		$(use_with hdf5) \
+		$(use_with imagemagick magick GraphicsMagick++) \
+		$(use_with opengl) \
+		$(use_with fltk) \
+		$(use_with ssl openssl) \
+		$(use_with portaudio) \
+		$(use_with qhull qhull_r) \
+		$(use_with qrupdate) \
+		$(use_with gui qt 5) \
+		$(use_with sndfile) \
+		$(use_with sparse arpack) \
+		$(use_with sparse umfpack) \
+		$(use_with sparse colamd) \
+		$(use_with sparse ccolamd) \
+		$(use_with sparse cholmod) \
+		$(use_with sparse cxsparse) \
+		$(use_with sundials sundials_ida) \
 		$(use_with X x)
-	)
-
-	econf "${myeconfargs[@]}"
 }
 
 src_compile() {

--- a/sci-mathematics/octave/octave-8.1.0-r1.ebuild
+++ b/sci-mathematics/octave/octave-8.1.0-r1.ebuild
@@ -31,7 +31,7 @@ RDEPEND="
 	app-arch/zip
 	app-text/ghostscript-gpl
 	sys-apps/texinfo
-	dev-libs/libpcre:=
+	dev-libs/libpcre2
 	sys-libs/ncurses:=
 	sys-libs/zlib
 	virtual/blas
@@ -49,7 +49,7 @@ RDEPEND="
 		dev-qt/qtopengl:5
 		dev-qt/qtprintsupport:5
 		dev-qt/qtwidgets:5
-		x11-libs/qscintilla:=
+		x11-libs/qscintilla:=[qt5(+)]
 	)
 	hdf5? ( sci-libs/hdf5:= )
 	imagemagick? ( media-gfx/graphicsmagick:=[cxx] )
@@ -128,10 +128,7 @@ REQUIRED_USE="
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-5.1.0-pkgbuilddir.patch
-	"${FILESDIR}"/${PN}-4.2.2-ncurses-pkgconfig.patch
-	"${FILESDIR}"/${PN}-6.4.0-slibtool.patch
 	"${FILESDIR}"/${PN}-6.4.0-omit-qtchooser-qtver.patch
-	"${FILESDIR}"/${P}-docs-texinfo-7.0.patch
 )
 
 src_prepare() {

--- a/sci-mathematics/octave/octave-8.2.0-r1.ebuild
+++ b/sci-mathematics/octave/octave-8.2.0-r1.ebuild
@@ -12,7 +12,7 @@ SRC_URI="mirror://gnu/${PN}/${P}.tar.xz"
 LICENSE="GPL-3"
 SLOT="0/${PV}"
 IUSE="curl doc fftw fltk +glpk gnuplot gui hdf5 imagemagick java json opengl portaudio postscript +qhull +qrupdate readline sndfile +sparse ssl sundials X zlib"
-KEYWORDS="amd64 arm arm64 ~hppa ~ppc ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux"
 
 # Although it is listed in INSTALL.OCTAVE as a build tool, Octave runs
 # "makeinfo" from sys-apps/texinfo at runtime to convert its texinfo
@@ -49,7 +49,7 @@ RDEPEND="
 		dev-qt/qtopengl:5
 		dev-qt/qtprintsupport:5
 		dev-qt/qtwidgets:5
-		x11-libs/qscintilla:=
+		x11-libs/qscintilla:=[qt5(+)]
 	)
 	hdf5? ( sci-libs/hdf5:= )
 	imagemagick? ( media-gfx/graphicsmagick:=[cxx] )
@@ -164,41 +164,49 @@ src_configure() {
 	# --with-sundials_ida (no-op) with USE="sundials"
 	# --without-sundials_ida (disables it) with USE="-sundials"
 	#
-	econf \
-		--localstatedir="${EPREFIX}/var/state/octave" \
-		--with-blas="$($(tc-getPKG_CONFIG) --libs blas)" \
-		--with-lapack="$($(tc-getPKG_CONFIG) --libs lapack)" \
-		--disable-64 \
-		--enable-shared \
-		--with-z \
-		--with-bz2 \
-		$(use_enable doc docs) \
-		$(use_enable java) \
-		$(use_enable json rapidjson) \
-		$(use_enable readline) \
-		$(use_with curl) \
-		$(use_with fftw fftw3) \
-		$(use_with fftw fftw3f) \
-		$(use_enable fftw fftw-threads) \
-		$(use_with glpk) \
-		$(use_with hdf5) \
-		$(use_with imagemagick magick GraphicsMagick++) \
-		$(use_with opengl) \
-		$(use_with fltk) \
-		$(use_with ssl openssl) \
-		$(use_with portaudio) \
-		$(use_with qhull qhull_r) \
-		$(use_with qrupdate) \
-		$(use_with gui qt 5) \
-		$(use_with sndfile) \
-		$(use_with sparse arpack) \
-		$(use_with sparse umfpack) \
-		$(use_with sparse colamd) \
-		$(use_with sparse ccolamd) \
-		$(use_with sparse cholmod) \
-		$(use_with sparse cxsparse) \
-		$(use_with sundials sundials_ida) \
+	local myeconfargs=(
+		--localstatedir="${EPREFIX}/var/state/octave"
+		--with-blas="$($(tc-getPKG_CONFIG) --libs blas)"
+		--with-lapack="$($(tc-getPKG_CONFIG) --libs lapack)"
+		--disable-64
+		--enable-shared
+		--with-z
+		--with-bz2
+
+		# bug #901965
+		--without-libiconv-prefix
+		--without-libreadline-prefix
+
+		$(use_enable doc docs)
+		$(use_enable java)
+		$(use_enable json rapidjson)
+		$(use_enable readline)
+		$(use_with curl)
+		$(use_with fftw fftw3)
+		$(use_with fftw fftw3f)
+		$(use_enable fftw fftw-threads)
+		$(use_with glpk)
+		$(use_with hdf5)
+		$(use_with imagemagick magick GraphicsMagick++)
+		$(use_with opengl)
+		$(use_with fltk)
+		$(use_with ssl openssl)
+		$(use_with portaudio)
+		$(use_with qhull qhull_r)
+		$(use_with qrupdate)
+		$(use_with gui qt 5)
+		$(use_with sndfile)
+		$(use_with sparse arpack)
+		$(use_with sparse umfpack)
+		$(use_with sparse colamd)
+		$(use_with sparse ccolamd)
+		$(use_with sparse cholmod)
+		$(use_with sparse cxsparse)
+		$(use_with sundials sundials_ida)
 		$(use_with X x)
+	)
+
+	econf "${myeconfargs[@]}"
 }
 
 src_compile() {

--- a/sci-mathematics/octave/octave-8.3.0-r2.ebuild
+++ b/sci-mathematics/octave/octave-8.3.0-r2.ebuild
@@ -12,7 +12,7 @@ SRC_URI="mirror://gnu/${PN}/${P}.tar.xz"
 LICENSE="GPL-3"
 SLOT="0/${PV}"
 IUSE="curl doc fftw fltk +glpk gnuplot gui hdf5 imagemagick java json opengl portaudio postscript +qhull +qrupdate readline sndfile +sparse ssl sundials X zlib"
-KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux"
+KEYWORDS="amd64 arm arm64 ~hppa ~ppc ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux"
 
 # Although it is listed in INSTALL.OCTAVE as a build tool, Octave runs
 # "makeinfo" from sys-apps/texinfo at runtime to convert its texinfo
@@ -49,7 +49,7 @@ RDEPEND="
 		dev-qt/qtopengl:5
 		dev-qt/qtprintsupport:5
 		dev-qt/qtwidgets:5
-		x11-libs/qscintilla:=
+		x11-libs/qscintilla:=[qt5(+)]
 	)
 	hdf5? ( sci-libs/hdf5:= )
 	imagemagick? ( media-gfx/graphicsmagick:=[cxx] )
@@ -65,7 +65,7 @@ RDEPEND="
 	postscript? (
 		app-text/epstool
 		media-gfx/pstoedit
-		media-gfx/transfig
+		>=media-gfx/fig2dev-3.2.9-r1
 	)
 	qhull? ( media-libs/qhull:= )
 	qrupdate? ( sci-libs/qrupdate:= )

--- a/sci-mathematics/octave/octave-8.3.0.ebuild
+++ b/sci-mathematics/octave/octave-8.3.0.ebuild
@@ -49,7 +49,7 @@ RDEPEND="
 		dev-qt/qtopengl:5
 		dev-qt/qtprintsupport:5
 		dev-qt/qtwidgets:5
-		x11-libs/qscintilla:=
+		x11-libs/qscintilla:=[qt5(+)]
 	)
 	hdf5? ( sci-libs/hdf5:= )
 	imagemagick? ( media-gfx/graphicsmagick:=[cxx] )


### PR DESCRIPTION
We are proposing to add explicit qt5 and qt6 USE flags to x11-libs/qscintilla (see #33493). This series of commits adjusts the reverse dependencies of QScintilla to add the [qt5(+)] flag in the ebuilds that don't have it, so that the packages are rebuilt as needed.

Bug: https://bugs.gentoo.org/916232