### PR TITLE
use.desc: Add global http2 flag

### DIFF
--- a/dev-php/swoole/metadata.xml
+++ b/dev-php/swoole/metadata.xml
@@ -5,9 +5,6 @@
 <email>php-bugs@gentoo.org</email>
 <name>PHP Project</name>
 </maintainer>
-<use>
-<flag name="http2">Add support for HTTP/2 protocol via <pkg>net-libs/nghttp2</pkg></flag>
-</use>
 <upstream>
   <remote-id type="github">swoole/swoole-src</remote-id>
 </upstream>

--- a/dev-python/twisted/metadata.xml
+++ b/dev-python/twisted/metadata.xml
@@ -11,7 +11,6 @@
 	</upstream>
 	<use>
 		<flag name="conch">include Twisted SSHv2 implementation</flag>
-		<flag name="http2">include http2 support</flag>
 		<flag name="serial">include serial port support</flag>
 	</use>
 	<longdescription>Twisted is an event-based framework for internet

--- a/dev-python/urllib3/metadata.xml
+++ b/dev-python/urllib3/metadata.xml
@@ -11,7 +11,4 @@
 		<remote-id type="cpe">cpe:/a:urllib3:urllib3</remote-id>
 		<remote-id type="github">urllib3/urllib3</remote-id>
 	</upstream>
-	<use>
-		<flag name="http2">Enable HTTP/2.0 support.</flag>
-	</use>
 </pkgmetadata>

--- a/dev-util/ostree/metadata.xml
+++ b/dev-util/ostree/metadata.xml
@@ -34,7 +34,6 @@
 		<flag name="dracut">Install dracut module</flag>
 		<flag name="gpg">Enable GPG support</flag>
 		<flag name="grub">Enable grub configuration generator</flag>
-		<flag name="http2">Use http2</flag>
 		<flag name="httpd">Enable ostree trivial-httpd entrypoint</flag>
 		<flag name="libmount">Use libmount</flag>
 		<flag name="sodium">Use libsodium for ed25519</flag>

--- a/net-analyzer/wireshark/metadata.xml
+++ b/net-analyzer/wireshark/metadata.xml
@@ -36,7 +36,6 @@
 		<flag name="dpauxmon">Install dpauxmon, an external capture interface (extcap) that captures DisplayPort AUX channel data from linux kernel drivers</flag>
 		<flag name="dumpcap">Install dumpcap, to dump network traffic from inside wireshark</flag>
 		<flag name="editcap">Install editcap, to edit and/or translate the format of capture files</flag>
-		<flag name="http2">Use <pkg>net-libs/nghttp2</pkg> for HTTP/2 support</flag>
 		<flag name="ilbc">Build with iLBC support in RTP Player using <pkg>media-libs/libilbc</pkg></flag>
 		<flag name="libxml2">Use <pkg>dev-libs/libxml2</pkg> for handling XML configuration in dissectors</flag>
 		<flag name="maxminddb">Use <pkg>dev-libs/libmaxminddb</pkg> for IP address geolocation</flag>

--- a/net-libs/libwebsockets/metadata.xml
+++ b/net-libs/libwebsockets/metadata.xml
@@ -18,7 +18,6 @@
 		<flag name="client">The client part of the library and libwebsockets-test-client</flag>
 		<flag name="extensions">Compile with extensions (permessage-deflate)</flag>
 		<flag name="generic-sessions">With the Generic Sessions plugin</flag>
-		<flag name="http2">Support the HTTP/2 protocol</flag>
 		<flag name="http-proxy">Support for rewriting HTTP proxying</flag>
 		<flag name="lejp">With the Lightweight JSON Parser</flag>
 		<flag name="libev">Support event loops via <pkg>dev-libs/libev</pkg></flag>

--- a/net-misc/curl/metadata.xml
+++ b/net-misc/curl/metadata.xml
@@ -15,7 +15,6 @@
 		<flag name="gnutls">Enable gnutls ssl backend</flag>
 		<flag name="gopher">Enable Gopher protocol support</flag>
 		<flag name="hsts">Enable HTTP Strict Transport Security</flag>
-		<flag name="http2">Enable HTTP/2.0 support</flag>
 		<flag name="imap">Enable Internet Message Access Protocol support</flag>
 		<flag name="mbedtls">Enable mbedtls ssl backend</flag>
 		<flag name="nghttp3">Enable HTTP/3.0 support using <pkg>net-libs/nghttp3</pkg> and <pkg>net-libs/ngtcp2</pkg></flag>

--- a/net-misc/wget2/metadata.xml
+++ b/net-misc/wget2/metadata.xml
@@ -7,7 +7,6 @@
 	</maintainer>
 	<use>
 		<flag name="gpgme">Build <pkg>app-crypt/gpgme</pkg> backend</flag>
-		<flag name="http2">Enable HTTP/2.0 support via <pkg>net-libs/nghttp2</pkg></flag>
 		<flag name="openssl">Enable crypto support via <pkg>dev-libs/openssl</pkg></flag>
 		<flag name="psl">Use public suffix list via <pkg>net-libs/libpsl</pkg></flag>
 	</use>

--- a/profiles/use.desc
+++ b/profiles/use.desc
@@ -132,6 +132,7 @@ hdf5 - Add support for the Hierarchical Data Format v5
 headers-only - Install only C headers instead of whole package. Mainly used by sys-devel/crossdev for toolchain bootstrap.
 heif - Enable support for ISO/IEC 23008-12:2017 HEIF/HEIC image format
 hscolour - Include coloured haskell sources to generated documentation (dev-haskell/hscolour)
+http2 - Enable support for the HTTP/2 protocol
 ibm - Add support for IBM ppc64 specific systems
 iconv - Enable support for the iconv character set conversion library
 icu - Enable ICU (Internationalization Components for Unicode) support, using dev-libs/icu


### PR DESCRIPTION
Add a global http2 flag to enable HTTP/2 protocol support.  It is used consistently in 9 packages.

CC @gentoo/qa 