### PR TITLE
media-libs/libnsgif: wire up tests

### DIFF
--- a/media-libs/libnsgif/files/libnsgif-1.0.0-make-test-failures-fatal.patch
+++ b/media-libs/libnsgif/files/libnsgif-1.0.0-make-test-failures-fatal.patch
@@ -1,0 +1,27 @@
+https://bugs.gentoo.org/918642
+https://github.com/gentoo/gentoo/pull/35142
+
+commit 6537507d754ad049dbdc324ec6bdea8b30416d48
+Author: matoro <matoro@users.noreply.github.com>
+Date:   Fri Feb 16 12:44:14 2024 -0500
+
+    test: nsgif: make failing tests fatal
+    
+    Right now, failing or erroring tests is not currently considered fatal.
+    This makes any instance of either fatal.
+    
+    See: https://github.com/gentoo/gentoo/pull/35142
+
+diff --git a/test/runtest.sh b/test/runtest.sh
+index fd84847..ef7274c 100755
+--- a/test/runtest.sh
++++ b/test/runtest.sh
+@@ -68,7 +68,7 @@ done
+ echo "Tests:${GIFTESTTOTC} Pass:${GIFTESTPASSC} Fail:${GIFTESTFAILC} Error:${GIFTESTERRC}"
+ 
+ # exit code
+-if [ "${GIFTESTERRC}" -gt 0 ]; then
++if [ "${GIFTESTERRC}" -gt 0 ] || [ "${GIFTESTFAILC}" -gt 0 ]; then
+ 	exit 1
+ fi
+ 

--- a/media-libs/libnsgif/libnsgif-1.0.0-r1.ebuild
+++ b/media-libs/libnsgif/libnsgif-1.0.0-r1.ebuild
@@ -20,6 +20,8 @@ BDEPEND="
 	virtual/pkgconfig
 "
 
+PATCHES=( "${FILESDIR}/${PN}-1.0.0-make-test-failures-fatal.patch" )
+
 src_prepare() {
 	default
 	sed -e '1i#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"' \
@@ -33,6 +35,10 @@ _emake() {
 
 src_compile() {
 	_emake
+}
+
+src_test() {
+	_emake test
 }
 
 src_install() {

--- a/media-libs/libnsgif/libnsgif-9999.ebuild
+++ b/media-libs/libnsgif/libnsgif-9999.ebuild
@@ -17,6 +17,8 @@ BDEPEND="
 	virtual/pkgconfig
 "
 
+PATCHES=( "${FILESDIR}/${PN}-1.0.0-make-test-failures-fatal.patch" )
+
 src_prepare() {
 	default
 }
@@ -28,6 +30,10 @@ _emake() {
 
 src_compile() {
 	_emake
+}
+
+src_test() {
+	_emake test
 }
 
 src_install() {


### PR DESCRIPTION
Test failures are currently not fatal, so this includes a downstream patch to change that.

Bug: https://bugs.gentoo.org/918642