### PR TITLE
app-emulation/qemu-guest-agent: find sphinx

### DIFF
--- a/app-emulation/qemu-guest-agent/files/qemu-8.1.0-find-sphinx.patch
+++ b/app-emulation/qemu-guest-agent/files/qemu-8.1.0-find-sphinx.patch
@@ -1,0 +1,10 @@
+This gets confused by python-any-r1 and tries to find sphinx-build in ${T}.
+--- a/docs/meson.build
++++ b/docs/meson.build
+@@ -1,5 +1,4 @@
+-sphinx_build = find_program(fs.parent(python.full_path()) / 'sphinx-build',
+-                            required: get_option('docs'))
++sphinx_build = find_program('sphinx-build', required: get_option('docs'))
+ 
+ # Check if tools are available to build documentation.
+ build_docs = false

--- a/app-emulation/qemu-guest-agent/qemu-guest-agent-8.2.0.ebuild
+++ b/app-emulation/qemu-guest-agent/qemu-guest-agent-8.2.0.ebuild
@@ -27,6 +27,7 @@ BDEPEND="${PYTHON_DEPS}
 S="${WORKDIR}/${MY_P}"
 
 PATCHES=(
+	"${FILESDIR}"/qemu-8.1.0-find-sphinx.patch
 )
 
 src_configure() {


### PR DESCRIPTION
qemu-guest-agent v8.2.0 fails with the "cannot find sphinx" message. I copied and applied the similar patch from qemu ebuild, and it succeeded.