### PR TITLE
media-sound/bluez-alsa: fix openrc daemon start

### DIFF
--- a/media-sound/bluez-alsa/bluez-alsa-4.1.1-r1.ebuild
+++ b/media-sound/bluez-alsa/bluez-alsa-4.1.1-r1.ebuild
@@ -90,7 +90,7 @@ multilib_src_install_all() {
 	find "${ED}" -type f -name "*.la" -delete || die
 
 	newinitd "${FILESDIR}"/bluealsa-init.d bluealsa
-	newconfd "${FILESDIR}"/bluealsa-conf.d-2 bluealsa
+	newconfd "${FILESDIR}"/bluealsa-conf.d-2-r1 bluealsa
 	#systemd_dounit "${FILESDIR}"/bluealsa.service
 
 	# Add config file to alsa datadir as well to preserve changes in /etc

--- a/media-sound/bluez-alsa/files/bluealsa-conf.d-2-r1
+++ b/media-sound/bluez-alsa/files/bluealsa-conf.d-2-r1
@@ -1,0 +1,4 @@
+# Config file for /etc/init.d/bluealsa
+
+# Allow additional options to be set
+BLUEALSA_CONF="-S -p a2dp-source -p a2dp-sink"


### PR DESCRIPTION
media-sound/bluez-alsa: revbump 4.1.1-r1, fix openrc daemon start

Closes: https://bugs.gentoo.org/921681
Signed-off-by: Vladimir Shupilov <alliancetrooper@proton.me>