### PR TITLE
pipewire sound-server update for wireplumber 9999

### DIFF
--- a/media-video/pipewire/files/gentoo-sound-server-enable-audio-bluetooth.conf
+++ b/media-video/pipewire/files/gentoo-sound-server-enable-audio-bluetooth.conf
@@ -1,0 +1,6 @@
+wireplumber.profiles = {
+  main = {
+    hardware.audio = required
+    hardware.bluetooth = required
+  }
+}

--- a/media-video/pipewire/pipewire-1.0.3.ebuild
+++ b/media-video/pipewire/pipewire-1.0.3.ebuild
@@ -313,11 +313,17 @@ multilib_src_install_all() {
 
 	# Enable required wireplumber alsa and bluez monitors
 	if use sound-server; then
+		# Install sound-server enabler, alsa part, wireplumber 0.4.15 syntax, clean this up with wireplumber dep bump
 		dodir /etc/wireplumber/main.lua.d
 		echo "alsa_monitor.enabled = true" > "${ED}"/etc/wireplumber/main.lua.d/89-gentoo-sound-server-enable-alsa-monitor.lua || die
 
+		# Install sound-server enabler, bluetooth part, wireplumber 0.4.15 syntax, clean this up with wireplumber dep bump
 		dodir /etc/wireplumber/bluetooth.lua.d
 		echo "bluez_monitor.enabled = true" > "${ED}"/etc/wireplumber/bluetooth.lua.d/89-gentoo-sound-server-enable-bluez-monitor.lua || die
+
+		# Install sound-server enabler for wireplumber 0.4.81+ conf syntax
+		insinto /etc/pipewire/wireplumber.conf.d
+		doins "${FILESDIR}"/gentoo-sound-server-enable-audio-bluetooth.conf
 	fi
 
 	if use system-service; then

--- a/media-video/wireplumber/files/wireplumber-0.4.81-config-disable-sound-server-parts.patch
+++ b/media-video/wireplumber/files/wireplumber-0.4.81-config-disable-sound-server-parts.patch
@@ -1,0 +1,27 @@
+From ed5ce9c176db2e26ac9915b4d86c3a076a8093ae Mon Sep 17 00:00:00 2001
+From: "Igor V. Kovalenko" <igor.v.kovalenko@gmail.com>
+Date: Fri, 2 Feb 2024 22:00:03 +0300
+Subject: [PATCH] config: Disable alsa and bluez monitors by default
+
+---
+ src/config/wireplumber.conf | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/config/wireplumber.conf b/src/config/wireplumber.conf
+index 822b7967..ca0faa0a 100644
+--- a/src/config/wireplumber.conf
++++ b/src/config/wireplumber.conf
+@@ -64,8 +64,8 @@ wireplumber.profiles = {
+     support.settings = required
+     support.log-settings = required
+     metadata.sm-objects = required
+-    hardware.audio = required
+-    hardware.bluetooth = required
++    #hardware.audio = required
++    #hardware.bluetooth = required
+     hardware.video-capture = required
+     policy.standard = required
+     #policy.role-priority-system = optional
+-- 
+2.43.0
+

--- a/media-video/wireplumber/wireplumber-9999.ebuild
+++ b/media-video/wireplumber/wireplumber-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -70,7 +70,7 @@ RDEPEND="${DEPEND}
 DOCS=( {NEWS,README}.rst )
 
 PATCHES=(
-	"${FILESDIR}"/${PN}-0.4.15-config-disable-sound-server-parts.patch # defer enabling sound server parts to media-video/pipewire
+	"${FILESDIR}"/${PN}-0.4.81-config-disable-sound-server-parts.patch # defer enabling sound server parts to media-video/pipewire
 )
 
 src_configure() {


### PR DESCRIPTION
Updated `wireplumber` patch and `pipewire` enabler part for USE `sound-server`
Change to `pipewire` is backwards-compatible, as new enabler is not used by older (e.g. current `0.4.17`) wireplumber.