### PR TITLE
app-laptop/pbbuttonsd: several fixes

### DIFF
--- a/app-laptop/pbbuttonsd/files/pbbuttonsd-0.8.1a-fix-build-with-dash.patch
+++ b/app-laptop/pbbuttonsd/files/pbbuttonsd-0.8.1a-fix-build-with-dash.patch
@@ -1,0 +1,105 @@
+https://bugs.gentoo.org/886071
+diff --git a/Makefile.in b/Makefile.in
+index 038769f..d6b3293 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -821,7 +821,7 @@ install-data-local:
+ 	@for dir in power power/scripts.d power/event.d; do \
+ 		$(INSTALL) -d $(DESTDIR)$(sysconfdir)/$$dir; \
+ 		src=`basename $$dir`; \
+-		if [ $$src == $$dir ]; then src=""; fi; \
++		if [ "$$src" = "$$dir" ]; then src=""; fi; \
+ 		for file in $(srcdir)/scripts/$$src/*; do \
+ 			name=`basename $$file`; \
+ 			if [ "$$src" != "" ] && [ "$$src" != "scripts.d" ]; then \
+@@ -838,7 +838,7 @@ dist-hook:
+ 	@for dir in scripts scripts/scripts.d scripts/event.d; do \
+ 		$(INSTALL) -d $(distdir)/$$dir; \
+ 		for file in $(srcdir)/$$dir/*; do \
+-			if [ `basename $$file` == "laptop-mode" ]; then \
++			if [ `basename $$file` = "laptop-mode" ]; then \
+ 				continue; \
+ 			elif test -x $$file; then \
+ 				$(INSTALL_SCRIPT) $$file $(distdir)/$$dir/; \
+@@ -850,7 +850,7 @@ dist-hook:
+ 	$(INSTALL) -d $(distdir)/srcdoc;
+ 	$(INSTALL) -d $(distdir)/doc/images;
+ 	@for file in $(srcdir)/srcdoc/*; do \
+-		if [ `basename $$file` == "index.html" ]; then \
++		if [ `basename $$file` = "index.html" ]; then \
+ 			$(INSTALL_DATA) $$file $(distdir)/doc/; \
+ 		else \
+ 			$(INSTALL_DATA) $$file $(distdir)/srcdoc/; \
+diff --git a/configure.in b/configure.in
+index 33fed13..bded359 100644
+--- a/configure.in
++++ b/configure.in
+@@ -53,7 +53,7 @@ case "$ac_laptop" in
+     POWERBOOK | powerbook | pb | PB )
+ 		ac_laptop="Apple PowerBook"
+ 		AC_DEFINE_UNQUOTED(SYS_POWERBOOK, "", [machine to build the package for])
+-		PB_OBJECTS+=" driver_backlight_pmu.$OBJEXT module_pmac.$OBJEXT"
++		PB_OBJECTS="${PB_OBJECTS} driver_backlight_pmu.$OBJEXT module_pmac.$OBJEXT"
+ 		;;
+ 	MACBOOK | macbook | mb | MB )
+ 		ac_laptop="Apple MacBook (Intel based)"
+@@ -63,8 +63,8 @@ case "$ac_laptop" in
+ 			AC_DEFINE_UNQUOTED(WITH_SMBIOS, 1, [SMBIOS available]),
+ 			AC_MSG_ERROR([SMBios library not available. Please install development files for libsmbios.]), [/* dummy */])
+ 		PKG_CHECK_MODULES(LIBPCI, libpci)
+-		PB_OBJECTS+=" driver_backlight_x1600.$OBJEXT driver_backlight_gma950.$OBJEXT module_acpi.$OBJEXT module_imac.$OBJEXT"
+-		PB_LIBS+=" -lsmbios $LIBPCI_LIBS"
++		PB_OBJECTS="${PB_OBJECTS} driver_backlight_x1600.$OBJEXT driver_backlight_gma950.$OBJEXT module_acpi.$OBJEXT module_imac.$OBJEXT"
++		PB_LIBS="${PB_LIBS$} -lsmbios $LIBPCI_LIBS"
+ 		LCD_FADINGSPEED="448"
+ 		LCD_AUTOADJMODE="linear"
+ 		LCD_AUTOADJPARMBAT="0,10,80,30"
+@@ -113,7 +113,7 @@ AC_ARG_WITH(pmud, [  --with-pmud             use pmud as low level power manager
+ 	pbb_with_pmud=$withval, )
+ if test "$pbb_with_pmud" = "yes"; then
+ 	AC_DEFINE_UNQUOTED(WITH_PMUD, 1, [use pmud as basement])
+-	PB_OBJECTS+="tcp.$OBJEXT"
++	PB_OBJECTS="${PB_OBJECTS} tcp.$OBJEXT"
+ fi
+ 
+ pbb_with_oss=yes
+@@ -121,7 +121,7 @@ AC_ARG_WITH(oss,  [  --with-oss              enable OSS support in pbbuttonsd (d
+ 	pbb_with_oss=$withval, )
+ if test "$pbb_with_oss" = "yes"; then
+ 	AC_DEFINE_UNQUOTED(WITH_OSS, 1, [enable OSS support])
+-	PB_OBJECTS+=" driver_mixer_oss.$OBJEXT"
++	PB_OBJECTS="${PB_OBJECTS} driver_mixer_oss.$OBJEXT"
+ fi
+ 
+ pbb_with_alsa=yes
+@@ -131,8 +131,8 @@ if test "$pbb_with_alsa" = "yes"; then
+ 	AM_PATH_ALSA(1.0.0, [pbb_have_alsa=yes], [pbb_have_alsa=no]) 
+ 	if test "$pbb_have_alsa" = "yes"; then
+ 		AC_DEFINE_UNQUOTED(WITH_ALSA, 1, [enable ALSA support])
+-		PB_OBJECTS+=" driver_mixer_alsa.$OBJEXT"
+-		PB_LIBS+=$ALSA_LIBS
++		PB_OBJECTS="${PB_OBJECTS} driver_mixer_alsa.$OBJEXT"
++		PB_LIBS="${PB_LIBS} $ALSA_LIBS"
+ 	fi
+ fi
+ 
+@@ -141,8 +141,8 @@ AC_ARG_WITH(ibam, [  --with-ibam             enable IBAM support in pbbuttonsd (
+ 	pbb_with_ibam=$withval, )
+ if test "$pbb_with_ibam" = "yes"; then
+ 	AC_DEFINE_UNQUOTED(WITH_IBAM, 1, [enable IBAM support])
+-	PB_OBJECTS+=" ibam_stub.$OBJEXT"
+-	PB_LIBS+=" -lstdc++"
++	PB_OBJECTS="${PB_OBJECTS} ibam_stub.$OBJEXT"
++	PB_LIBS="${PB_LIBS} -lstdc++"
+ fi
+ 
+ AC_ARG_WITH(doxygen-docs,
+@@ -188,7 +188,7 @@ AC_MSG_RESULT($with_doxygen_docs)
+ 
+ AM_CONDITIONAL(DEBUG, test "$enable_debug" = yes)
+ if test "$enable_debug" = "yes"; then
+-	PB_OBJECTS+=" module_peep.$OBJEXT"
++	PB_OBJECTS="${PB_OBJECTS} module_peep.$OBJEXT"
+ else
+ 	enable_debug=no;
+ fi

--- a/app-laptop/pbbuttonsd/files/pbbuttonsd-0.8.1a-fix-multiple-definition-in-alsa-and-oss.patch
+++ b/app-laptop/pbbuttonsd/files/pbbuttonsd-0.8.1a-fix-multiple-definition-in-alsa-and-oss.patch
@@ -1,0 +1,13 @@
+https://bugs.gentoo.org/771093
+https://bugs.gentoo.org/771864
+--- a/src/driver_mixer_alsa.c
++++ b/src/driver_mixer_alsa.c
+@@ -32,7 +32,7 @@
+ 
+ #define SECTION "MODULE MIXER ALSA"
+ 
+-struct driver_alsamixer {
++static struct driver_alsamixer {
+ 	char *card;	 /* name of the soundcard (usually "default" is fine) */
+ 	GString *channels;	/* channel names to use */
+ 	struct {

--- a/app-laptop/pbbuttonsd/pbbuttonsd-0.8.1a-r1.ebuild
+++ b/app-laptop/pbbuttonsd/pbbuttonsd-0.8.1a-r1.ebuild
@@ -1,0 +1,147 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools flag-o-matic toolchain-funcs
+
+DESCRIPTION="Handles power management and special keys on laptops"
+HOMEPAGE="http://pbbuttons.berlios.de"
+SRC_URI="mirror://sourceforge/pbbuttons/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86"
+IUSE="acpi alsa doc ibam oss"
+
+RDEPEND="
+	dev-libs/glib
+	alsa? ( media-libs/alsa-lib )"
+# USE=macbook requires C++ version of libsmbios, which was dropped by upstream
+# if you are brave enough, you are welcome to fix it
+# See: https://bugs.gentoo.org/881503
+#      https://github.com/dell/libsmbios/issues/27
+# macbooc dependencies:
+#	macbook? (
+#		sys-apps/pciutils
+#		sys-libs/libsmbios
+#	)
+DEPEND="${RDEPEND}"
+BDEPEND="doc? ( app-text/doxygen )"
+PATCHES=(
+	"${FILESDIR}"/${PN}-0.8.1-cpufreq.patch
+	"${FILESDIR}"/${PN}-0.8.1-fnmode.patch
+	"${FILESDIR}"/${PN}-0.8.1-laptopmode.sh.patch
+	"${FILESDIR}"/${PN}-0.8.1-lm.patch
+	"${FILESDIR}"/${PN}-0.8.1-lz.patch
+	"${FILESDIR}"/${P}-fix-multiple-definition-in-alsa-and-oss.patch
+	"${FILESDIR}"/${P}-fix-build-with-dash.patch
+)
+
+src_prepare() {
+	# Don't link with g++ if we don't use ibam
+	use ibam || eapply "${FILESDIR}"/${PN}-0.8.1-g++.patch
+
+	default
+	eautoconf
+}
+
+src_configure() {
+	# Fix crash bug on some systems
+	replace-flags -O? -O1
+
+	local laptop
+#	if use macbook; then
+#		laptop=macbook
+#	elif
+	if use x86 || use amd64; then
+		if use acpi; then
+			laptop=acpi
+		else
+			laptop=i386
+		fi
+	# Default to PowerBook
+	else
+		laptop=powerbook
+	fi
+
+	econf \
+		$(use_with alsa) \
+		$(use_with doc doxygen_docs) \
+		$(use_with ibam) \
+		$(use_with oss) \
+		laptop="${laptop}"
+
+}
+
+src_compile() {
+	# Thanks to Stefan Bruda for this workaround
+	# Using -j1 fixes a parallel build issue with the docs
+	if use doc; then
+		emake -j1 AR="$(tc-getAR)"
+	else
+		emake AR="$(tc-getAR)"
+	fi
+}
+
+src_install() {
+	default
+
+	if use ibam; then
+		keepdir /var/lib/ibam
+	else
+		rmdir "${ED}/var/lib/ibam" || die
+	fi
+
+	keepdir /var/lib/pbbuttons
+
+	rm "${ED}"/usr/$(get_libdir)/libpbb.a || die
+
+	newinitd "${FILESDIR}"/pbbuttonsd.rc6 pbbuttonsd
+	dodoc README
+	use doc && dodoc -r doc/
+
+	dodir /etc/power/resume.d
+	keepdir /etc/power/resume.d
+	dodir /etc/power/suspend.d
+	keepdir /etc/power/suspend.d
+	exeinto /etc/power/scripts.d
+	doexe "${FILESDIR}"/wireless
+	dosym ../scripts.d/wireless /etc/power/resume.d/wireless
+}
+
+pkg_postinst() {
+	if [ -e /etc/pbbuttonsd.conf ]; then
+		ewarn "The pbbuttonsd.cnf file replaces /etc/pbuttonsd.conf with a new"
+		ewarn "file (/etc/pbbuttonsd.conf) and a new format. Please check the"
+		ewarn "manual page with 'man pbbuttonsd.cnf' for details."
+		ewarn
+	fi
+
+#	if use macbook; then
+#		ewarn "Macbook and Macbook Pro users should make sure to have applesmc"
+#		ewarn "loaded before starting pbbuttonsdm otherwise auto-adjustments"
+#		ewarn "will not work and pbbuttonsd may segfault."
+#		ewarn
+#	fi
+
+	ewarn "Ensure that the evdev kernel module is loaded otherwise"
+	ewarn "pbbuttonsd won't work. SysV IPC is also required."
+	ewarn
+	ewarn "If you need extra security, you can tell pbbuttonsd to only accept"
+	ewarn "input from one user. You can set the userallowed option in"
+	ewarn "/etc/pbbuttonsd.cnf to limit access."
+	ewarn
+
+	if use ibam; then
+		elog "To properly initialize the IBaM battery database, you will"
+		elog "need to perform a full discharge/charge cycle. For more"
+		elog "details, please see the pbbuttonsd man page."
+		elog
+	fi
+
+	elog "A script is now available to reset your wirless connection on resume."
+	elog "Simply uncomment the commented command and set the correct device to"
+	elog "use it. You can find the script in /etc/power/resume.d/wireless"
+
+}


### PR DESCRIPTION
- update EAPI 7 -> 8
- fix several build failures
- drop USE=macbook due to missing lib in dependency, see 881503
- fix compilation and install with /bin/sh -> dash

Closes: https://bugs.gentoo.org/771864
Closes: https://bugs.gentoo.org/881503
Closes: https://bugs.gentoo.org/886071