### PR TITLE
app-admin/pydf: add Python 3.12 support

### DIFF
--- a/app-admin/pydf/pydf-12-r2.ebuild
+++ b/app-admin/pydf/pydf-12-r2.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{10..12} )
 
 inherit python-r1
 


### PR DESCRIPTION
_Hello everyone,_

I've been using `pydf` with Python 3.12 for about 3 months now and haven't encountered any issues, so I think it's safe to add 3.12 to `PYTHON_COMPAT`.

Closes: https://bugs.gentoo.org/923658

_Best regards!_