### PR TITLE
app-containers/containers-image: bump to 5.29.2-r1

### DIFF
--- a/app-containers/containers-image/containers-image-5.29.2-r1.ebuild
+++ b/app-containers/containers-image/containers-image-5.29.2-r1.ebuild
@@ -23,6 +23,7 @@ RESTRICT='test'
 BDEPEND=">=dev-go/go-md2man-2.0.3"
 PATCHES=(
 	"${FILESDIR}"/moving-policy-json-default-yaml.patch
+	"${FILESDIR}"/prevent-downloading-mods-5.29.2.patch
 )
 
 src_compile() {

--- a/app-containers/containers-image/containers-image-9999.ebuild
+++ b/app-containers/containers-image/containers-image-9999.ebuild
@@ -21,6 +21,9 @@ SLOT="0"
 # https://github.com/gentoo/gentoo/pull/35012#discussion_r1473740969
 RESTRICT='test'
 BDEPEND=">=dev-go/go-md2man-2.0.3"
+PATCHES=(
+	"${FILESDIR}"/prevent-downloading-mods-5.29.2.patch
+)
 
 src_compile() {
 	emake docs

--- a/app-containers/containers-image/files/prevent-downloading-mods-5.29.2.patch
+++ b/app-containers/containers-image/files/prevent-downloading-mods-5.29.2.patch
@@ -1,0 +1,10 @@
+--- a/Makefile
++++ b/Makefile
+@@ -15,7 +15,6 @@
+ BUILDTAGS = btrfs_noversion libdm_no_deferred_remove
+ BUILDFLAGS := -tags "$(BUILDTAGS)"
+ 
+-PACKAGES := $(shell GO111MODULE=on go list $(BUILDFLAGS) ./...)
+ SOURCE_DIRS = $(shell echo $(PACKAGES) | awk 'BEGIN{FS="/"; RS=" "}{print $$4}' | uniq)
+ 
+ PREFIX ?= ${DESTDIR}/usr


### PR DESCRIPTION
Apologies from my side, I let the bug slip in

Closes: https://bugs.gentoo.org/show_bug.cgi?id=923700