### PR TITLE
sys-apps/bleachbit: fix gtk+3 dependency

### DIFF
--- a/sys-apps/bleachbit/bleachbit-4.6.0.ebuild
+++ b/sys-apps/bleachbit/bleachbit-4.6.0.ebuild
@@ -23,7 +23,7 @@ RDEPEND="
 		dev-python/chardet[${PYTHON_USEDEP}]
 		dev-python/pygobject:3[${PYTHON_USEDEP}]
 	')
-	x11-libs/gtk+:3
+	x11-libs/gtk+:3[introspection]
 "
 BDEPEND="
 	sys-devel/gettext


### PR DESCRIPTION
bleachbit requires `gtk+:3[introspection]`
```
ValueError: Namespace Gtk not available
```