### PR TITLE
dev-libs/gobject-introspection-1.78.1: add Python 3.12 support

### DIFF
--- a/dev-libs/gobject-introspection/gobject-introspection-1.76.1.ebuild
+++ b/dev-libs/gobject-introspection/gobject-introspection-1.76.1.ebuild
@@ -8,7 +8,7 @@ PYTHON_REQ_USE="xml(+)"
 inherit gnome.org meson python-single-r1 xdg
 
 DESCRIPTION="Introspection system for GObject-based libraries"
-HOMEPAGE="https://wiki.gnome.org/Projects/GObjectIntrospection"
+HOMEPAGE="https://gi.readthedocs.io"
 
 LICENSE="LGPL-2+ GPL-2+"
 SLOT="0"

--- a/dev-libs/gobject-introspection/gobject-introspection-1.78.1.ebuild
+++ b/dev-libs/gobject-introspection/gobject-introspection-1.78.1.ebuild
@@ -3,12 +3,12 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..11} )
+PYTHON_COMPAT=( python3_{10..12} )
 PYTHON_REQ_USE="xml(+)"
 inherit gnome.org meson python-single-r1 xdg
 
 DESCRIPTION="Introspection system for GObject-based libraries"
-HOMEPAGE="https://wiki.gnome.org/Projects/GObjectIntrospection"
+HOMEPAGE="https://gi.readthedocs.io"
 
 LICENSE="LGPL-2+ GPL-2+"
 SLOT="0"


### PR DESCRIPTION
_Hello everyone,_

I've been using `gobject-introspection` with Python 3.12 for about 3 months now and haven't encountered any issues, so I think it's safe to add 3.12 to `PYTHON_COMPAT`.

These changes also:
  - update `HOMEPAGE` to [`https://gi.readthedocs.io`](https://gi.readthedocs.io)

Closes: https://bugs.gentoo.org/917029

_Best regards!_