### PR TITLE
app-crypt/tpm2-openssl: Fix src_prepare and let upstream script setup…

### DIFF
--- a/app-crypt/tpm2-openssl/files/tpm2-openssl-1.2.0-Makefile-add-run-with-simulator-to-extra-dists.patch
+++ b/app-crypt/tpm2-openssl/files/tpm2-openssl-1.2.0-Makefile-add-run-with-simulator-to-extra-dists.patch
@@ -1,0 +1,28 @@
+From be35c35ace48647bb73ae5028db7e8caaccd038d Mon Sep 17 00:00:00 2001
+From: Adrian Freihofer <adrian.freihofer@gmail.com>
+Date: Fri, 8 Dec 2023 14:24:17 +0100
+Subject: [PATCH 1/2] Makefile: add run-with-simulator to extra dists
+
+The run-with-simulator script is executed by the make check step of
+the rpm build process. Therefore it should be packaged into the release
+tar bundles.
+
+Signed-off-by: Adrian Freihofer <adrian.freihofer@gmail.com>
+---
+ Makefile.am | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/Makefile.am b/Makefile.am
+index 160d84e..994a8e3 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -143,5 +143,6 @@ EXTRA_DIST = \
+     VERSION \
+     $(TESTS_SHELL) \
+     $(SH_LOG_COMPILER) \
++    test/run-with-simulator \
+     test/ec_pki/openssl.cnf \
+     test/rsa_pki/etc
+-- 
+2.43.0
+

--- a/app-crypt/tpm2-openssl/files/tpm2-openssl-1.2.0-tests-run-with-simulator-in-container.patch
+++ b/app-crypt/tpm2-openssl/files/tpm2-openssl-1.2.0-tests-run-with-simulator-in-container.patch
@@ -1,0 +1,132 @@
+diff --git a/home/salahx/Downloads/run-with-simulator b/home/salahx/Downloads/run-with-simulator
+new file mode 100755
+index 000000000000..e29b591f8d8b
+--- /dev/null
++++ b/test/run-with-simulator
+@@ -0,0 +1,126 @@
++#!/bin/bash
++# SPDX-License-Identifier: BSD-3-Clause
++
++SIM_PORT_DATA=2321
++SIM_PORT_CMD=$((SIM_PORT_DATA+1))
++
++# Run from top dir of this repository
++SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
++TOP_DIR="$(realpath "$SCRIPT_DIR/..")"
++cd "$TOP_DIR" || { echo "Error: cd to cd $TOP_DIR failed"; exit 1; }
++
++
++verify_simulator_is_running() {
++    local pid_tpm=$1
++
++    sleep 1
++    ss -lntp4 2> /dev/null | grep "${pid_tpm}" | grep -q "${SIM_PORT_DATA}"
++    ret_data=$?
++    ss -lntp4 2> /dev/null | grep "${pid_tpm}" | grep -q "${SIM_PORT_CMD}"
++    ret_cmd=$?
++    if [ $ret_data -eq 0 ] && [ $ret_cmd -eq 0 ]; then
++        echo "Simulator with PID ${pid_tpm} bound to port ${SIM_PORT_DATA} and ${SIM_PORT_CMD} successfully."
++        return 0
++    else
++        echo "Error: Port conflict? Cleaning up PID: ${pid_tpm}"
++        return 1
++    fi
++}
++
++build_tpm2_simulator_ibm() (
++    test -d ibmtpm && return
++    echo "---> compiling IBM tpm simulator"
++    mkdir ibmtpm
++    curl -Ls https://downloads.sourceforge.net/project/ibmswtpm2/ibmtpm1682.tar.gz | tar xz -C ibmtpm
++    cd ibmtpm/src && make
++)
++
++start_tpm2_simulator_ibm () {
++    build_tpm2_simulator_ibm || return 1
++
++    echo "---> starting IBM tpm simulator"
++    ibmtpm/src/tpm_server &
++    pid_tpm=$!
++    verify_simulator_is_running $pid_tpm
++}
++
++start_tpm2_simulator_swtpm () {
++    echo "---> starting swtpm simulator"
++    swtpm socket --tpm2 \
++        --server port=$SIM_PORT_DATA \
++        --ctrl type=tcp,port=$SIM_PORT_CMD \
++        --flags not-need-init \
++        --tpmstate dir="$PWD" \
++        --seccomp action=none &
++    pid_tpm=$!
++    verify_simulator_is_running $pid_tpm
++}
++
++start_dbusd () {
++    echo "---> starting dbus daemon"
++    dbus-daemon --session --print-address > /tmp/bus-socket-path.txt &
++    sleep 1
++    DBUS_SESSION_BUS_ADDRESS="$(tail -n1 /tmp/bus-socket-path.txt)"
++    export DBUS_SESSION_BUS_ADDRESS
++}
++
++start_tpm2_abrmd() {
++    local tabrmd_tcti=$1
++
++    echo "---> starting abrmd"
++    local tabrmd_name="com.intel.tss2.Tabrmd${SIM_PORT_DATA}"
++    tpm2-abrmd --session --dbus-name="${tabrmd_name}" --tcti "${tabrmd_tcti}:host=localhost,port=${SIM_PORT_DATA}" &
++    TCTI_ADDRESS="tabrmd:bus_name=${tabrmd_name},bus_type=session"
++    TPM2TOOLS_TCTI="$TCTI_ADDRESS"
++    TPM2OPENSSL_TCTI="$TCTI_ADDRESS"
++    export TPM2TOOLS_TCTI
++    export TPM2OPENSSL_TCTI
++    sleep 1
++#    busctl --address="${DBUS_SESSION_BUS_ADDRESS}" list | grep "$tabrmd_name"
++}
++
++start_tpm2_sim_env() {
++    local sim_type=$1
++
++    start_dbusd
++
++    if [ "$sim_type" = "swtpm" ]; then
++        start_tpm2_simulator_swtpm || return 1
++        start_tpm2_abrmd swtpm || return 1
++    elif [ "$sim_type" = "ibm" ]; then
++        start_tpm2_simulator_ibm || return 1
++        start_tpm2_abrmd mssim || return 1
++    else
++        echo "invalid tpm simulator typ"
++        return 1
++    fi
++}
++
++make_check () {
++    echo "Running make check"
++    openssl version
++    tpm2_getcap properties-fixed | head -n 20
++    make check
++}
++
++function cleanup()
++{
++    pkill -P $$
++}
++trap cleanup EXIT
++
++build_tpm2_openssl() {
++    ./bootstrap
++    ./configure CC=gcc --enable-op-digest --enable-op-cipher
++    make
++}
++
++SIM_TYPE=${1:-swtpm}
++SKIP_BUILD=${2:-build}
++if [ "$SKIP_BUILD" = "skip-build" ]; then
++    echo "Skipping the build"
++else
++    build_tpm2_openssl || { echo "Compiling tpm2-openssl failed"; exit 1; }
++fi
++start_tpm2_sim_env "${SIM_TYPE}" || { echo "Starting tpm2 simulator failed ($SIM_TYPE)"; exit 1; }
++make_check || { echo "tpm2-openssl make check failed"; exit 1; }


### PR DESCRIPTION
… TPM simulator

I had "eautoconf" and "default" reversed. Didn't cause a problem until I tried to use /etc/portage/patches to try to fix a bug. Upstream has a script that will setup the TPM simulator for us but forget to include in EXTRA_DIST so it was never packaged. I patched the in missing script (and removed a systemd-ism from it) and have the src_test run it. 