### PR TITLE
dev-java/apache-rat: fix javadoc installation

### DIFF
--- a/dev-java/apache-rat/apache-rat-0.15-r1.ebuild
+++ b/dev-java/apache-rat/apache-rat-0.15-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -100,7 +100,7 @@ src_install() {
 	java-pkg_dojar "${PN}-tasks.jar"
 	java-pkg_dolauncher "${PN}" --main org.apache.rat.Report
 
-	use doc && java-pkg_dojavadoc javadoc
+	use doc && java-pkg_dojavadoc target/api
 
 	if use source; then
 		java-pkg_dosrc "${PN}-core/src/main/java/*"


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/923813