### PR TITLE
net-mail/signify: EAPI8 bump, use HTTPS

### DIFF
--- a/net-mail/signify/signify-1.14-r2.ebuild
+++ b/net-mail/signify/signify-1.14-r2.ebuild
@@ -1,0 +1,33 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DESCRIPTION="A (semi-)random e-mail signature rotator"
+HOMEPAGE="https://signify.sourceforge.net/"
+SRC_URI="mirror://debian/pool/main/s/${PN}/${PN}_${PV}-1.tar.gz"
+S="${WORKDIR}/${PN}"
+
+LICENSE="public-domain"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~sparc ~x86"
+
+RDEPEND="!app-crypt/signify
+	dev-lang/perl"
+DEPEND="${RDEPEND}"
+
+src_prepare() {
+	default
+	sed -i 's/head -1/head -n1/' Makefile || die
+}
+
+src_compile(){ :; }
+
+src_install() {
+	emake PREFIX="${ED}"/usr MANDIR="${ED}"/usr/share/man install
+	einstalldocs
+
+	docinto examples
+	dodoc examples/{Columned,Complex,Simple,SimpleOrColumned}
+	docompress -x /usr/share/doc/${PF}/examples
+}


### PR DESCRIPTION
Simple EAPI8 bump.

There are also two open bugs about file collisions with `app-crypt/signify`.
I think both bugs can be closed as both packages already have soft blocker against each other.
The bugs are:
https://bugs.gentoo.org/580908
https://bugs.gentoo.org/792432

```diff
--- signify-1.14-r1.ebuild	2024-01-17 20:05:13.446814979 +0100
+++ signify-1.14-r2.ebuild	2024-02-06 19:22:20.440027570 +0100
@@ -1,29 +1,30 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
 
 DESCRIPTION="A (semi-)random e-mail signature rotator"
-HOMEPAGE="http://signify.sf.net/"
+HOMEPAGE="https://signify.sourceforge.net/"
 SRC_URI="mirror://debian/pool/main/s/${PN}/${PN}_${PV}-1.tar.gz"
+S="${WORKDIR}/${PN}"
 
 LICENSE="public-domain"
 SLOT="0"
-KEYWORDS="~amd64 ppc sparc x86"
+KEYWORDS="~amd64 ~ppc ~sparc ~x86"
 
 RDEPEND="!app-crypt/signify
 	dev-lang/perl"
 DEPEND="${RDEPEND}"
 
-S=${WORKDIR}/${PN}
-
 src_prepare() {
 	default
 	sed -i 's/head -1/head -n1/' Makefile || die
 }
 
+src_compile(){ :; }
+
 src_install() {
-	emake PREFIX="${ED%/}"/usr MANDIR="${ED%/}"/usr/share/man install
+	emake PREFIX="${ED}"/usr MANDIR="${ED}"/usr/share/man install
 	einstalldocs
 
 	docinto examples
```