### PR TITLE
net-mail/randomsig: EAPI8 bump, use HTTPS, fix LICENSE

### DIFF
--- a/net-mail/randomsig/randomsig-1.10.0-r1.ebuild
+++ b/net-mail/randomsig/randomsig-1.10.0-r1.ebuild
@@ -1,0 +1,36 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+MY_P="${PN}-v${PV}"
+
+DESCRIPTION="Perl script for generating random .signature files"
+HOMEPAGE="https://suso.suso.org/xulu/Randomsig"
+SRC_URI="https://suso.suso.org/programs/randomsig/downloads/${MY_P}.tar.gz"
+S="${WORKDIR}/${MY_P}"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~s390 ~sparc ~x86"
+
+RDEPEND="dev-lang/perl"
+DEPEND="${RDEPEND}"
+
+src_prepare() {
+	default
+
+	sed -e "s:/usr/local/bin:${EPREFIX}/usr/bin:" \
+		-e "s:/usr/local/etc:${EPREFIX}/etc:" \
+		-i Makefile || die
+	sed -e "s:/usr/local/etc:${EPREFIX}/etc:" \
+		-i randomsig || die
+}
+
+src_install() {
+	dobin randomsig
+	einstalldocs
+
+	insinto /etc/randomsig
+	doins .randomsigrc .sigquotes .sigcancel .sigread
+}


### PR DESCRIPTION
Next `EAPI8` bump

```diff
--- randomsig-1.10.0.ebuild	2024-01-17 20:05:13.442815006 +0100
+++ randomsig-1.10.0-r1.ebuild	2024-02-06 19:31:44.705951662 +0100
@@ -1,23 +1,22 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
 
-MY_P=${PN}-v${PV}
+MY_P="${PN}-v${PV}"
 
-DESCRIPTION="randomsig - perl script for generating random .signature files"
-HOMEPAGE="http://suso.suso.org/programs/randomsig/"
-SRC_URI="http://suso.suso.org/programs/randomsig/downloads/${MY_P}.tar.gz"
+DESCRIPTION="Perl script for generating random .signature files"
+HOMEPAGE="https://suso.suso.org/xulu/Randomsig"
+SRC_URI="https://suso.suso.org/programs/randomsig/downloads/${MY_P}.tar.gz"
+S="${WORKDIR}/${MY_P}"
 
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="0"
-KEYWORDS="~amd64 ~s390 sparc x86"
+KEYWORDS="~amd64 ~s390 ~sparc ~x86"
 
 RDEPEND="dev-lang/perl"
 DEPEND="${RDEPEND}"
 
-S=${WORKDIR}/${MY_P}
-
 src_prepare() {
 	default
 
```