### PR TITLE
dev-libs/libfmt: Add CPE tag and lfs flags

### DIFF
--- a/dev-libs/libfmt/libfmt-10.0.0.ebuild
+++ b/dev-libs/libfmt/libfmt-10.0.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit cmake
+inherit cmake flag-o-matic
 
 DESCRIPTION="Small, safe and fast formatting library"
 HOMEPAGE="https://github.com/fmtlib/fmt"
@@ -23,6 +23,7 @@ IUSE="test"
 RESTRICT="!test? ( test )"
 
 src_configure() {
+	append-lfs-flags
 	local mycmakeargs=(
 		-DFMT_CMAKE_DIR="$(get_libdir)/cmake/fmt"
 		-DFMT_LIB_DIR="$(get_libdir)"

--- a/dev-libs/libfmt/libfmt-10.1.0.ebuild
+++ b/dev-libs/libfmt/libfmt-10.1.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit cmake
+inherit cmake flag-o-matic
 
 DESCRIPTION="Small, safe and fast formatting library"
 HOMEPAGE="https://github.com/fmtlib/fmt"
@@ -23,6 +23,7 @@ IUSE="test"
 RESTRICT="!test? ( test )"
 
 src_configure() {
+	append-lfs-flags
 	local mycmakeargs=(
 		-DFMT_CMAKE_DIR="$(get_libdir)/cmake/fmt"
 		-DFMT_LIB_DIR="$(get_libdir)"

--- a/dev-libs/libfmt/libfmt-10.1.1.ebuild
+++ b/dev-libs/libfmt/libfmt-10.1.1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit cmake
+inherit cmake flag-o-matic
 
 DESCRIPTION="Small, safe and fast formatting library"
 HOMEPAGE="https://github.com/fmtlib/fmt"
@@ -23,6 +23,7 @@ IUSE="test"
 RESTRICT="!test? ( test )"
 
 src_configure() {
+	append-lfs-flags
 	local mycmakeargs=(
 		-DFMT_CMAKE_DIR="$(get_libdir)/cmake/fmt"
 		-DFMT_LIB_DIR="$(get_libdir)"

--- a/dev-libs/libfmt/libfmt-10.2.0.ebuild
+++ b/dev-libs/libfmt/libfmt-10.2.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit cmake
+inherit cmake flag-o-matic
 
 DESCRIPTION="Small, safe and fast formatting library"
 HOMEPAGE="https://github.com/fmtlib/fmt"
@@ -23,6 +23,7 @@ IUSE="test"
 RESTRICT="!test? ( test )"
 
 src_configure() {
+	append-lfs-flags
 	local mycmakeargs=(
 		-DFMT_CMAKE_DIR="$(get_libdir)/cmake/fmt"
 		-DFMT_LIB_DIR="$(get_libdir)"

--- a/dev-libs/libfmt/libfmt-10.2.1.ebuild
+++ b/dev-libs/libfmt/libfmt-10.2.1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit cmake
+inherit cmake flag-o-matic
 
 DESCRIPTION="Small, safe and fast formatting library"
 HOMEPAGE="https://github.com/fmtlib/fmt"
@@ -23,6 +23,7 @@ IUSE="test"
 RESTRICT="!test? ( test )"
 
 src_configure() {
+	append-lfs-flags
 	local mycmakeargs=(
 		-DFMT_CMAKE_DIR="$(get_libdir)/cmake/fmt"
 		-DFMT_LIB_DIR="$(get_libdir)"

--- a/dev-libs/libfmt/libfmt-9.1.0-r1.ebuild
+++ b/dev-libs/libfmt/libfmt-9.1.0-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit cmake
+inherit cmake flag-o-matic
 
 DESCRIPTION="Small, safe and fast formatting library"
 HOMEPAGE="https://github.com/fmtlib/fmt"
@@ -23,6 +23,7 @@ IUSE="test"
 RESTRICT="!test? ( test )"
 
 src_configure() {
+	append-lfs-flags
 	local mycmakeargs=(
 		-DFMT_CMAKE_DIR="$(get_libdir)/cmake/fmt"
 		-DFMT_LIB_DIR="$(get_libdir)"

--- a/dev-libs/libfmt/libfmt-9999.ebuild
+++ b/dev-libs/libfmt/libfmt-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit cmake
+inherit cmake flag-o-matic
 
 DESCRIPTION="Small, safe and fast formatting library"
 HOMEPAGE="https://github.com/fmtlib/fmt"
@@ -23,6 +23,7 @@ IUSE="test"
 RESTRICT="!test? ( test )"
 
 src_configure() {
+	append-lfs-flags
 	local mycmakeargs=(
 		-DFMT_CMAKE_DIR="$(get_libdir)/cmake/fmt"
 		-DFMT_LIB_DIR="$(get_libdir)"

--- a/dev-libs/libfmt/metadata.xml
+++ b/dev-libs/libfmt/metadata.xml
@@ -8,5 +8,6 @@
 	<upstream>
 		<bugs-to>https://github.com/fmtlib/fmt/issues</bugs-to>
 		<remote-id type="github">fmtlib/fmt</remote-id>
+		<remote-id type="cpe">cpe:/a:fmt_project:fmt</remote-id>
 	</upstream>
 </pkgmetadata>


### PR DESCRIPTION
Some changes I found in ChromeOS that hadn't been upstreamed: https://chromium-review.googlesource.com/c/chromiumos/overlays/portage-stable/+/5263682

Package was tested to build with ChromeOS.