### PR TITLE
kernel-{build,install}.eclass: install vmlinu{x,z} symlink

### DIFF
--- a/eclass/kernel-build.eclass
+++ b/eclass/kernel-build.eclass
@@ -385,6 +385,11 @@ kernel-build_src_install() {
 	# fix source tree and build dir symlinks
 	dosym "../../../${kernel_dir}" "/lib/modules/${module_ver}/build"
 	dosym "../../../${kernel_dir}" "/lib/modules/${module_ver}/source"
+	if [[ "${image_path}" == *vmlinux* ]]; then
+		dosym "../../../${kernel_dir}/${image_path}" "/lib/modules/${module_ver}/vmlinux"
+	else
+		dosym "../../../${kernel_dir}/${image_path}" "/lib/modules/${module_ver}/vmlinuz"
+	fi
 
 	if [[ ${KERNEL_IUSE_MODULES_SIGN} ]]; then
 		secureboot_sign_efi_file "${image}"

--- a/eclass/kernel-install.eclass
+++ b/eclass/kernel-install.eclass
@@ -621,6 +621,7 @@ kernel-install_extract_from_uki() {
 
 	$(tc-getOBJCOPY) -O binary "-j.${extract_type}" "${uki}" "${out}" ||
 		die "Failed to extract ${extract_type}"
+	chmod 644 "${out}" || die
 }
 
 # @FUNCTION: kernel-install_install_all


### PR DESCRIPTION
Some other distributions install (a symlink to) the kernel image at `/lib/modules`. Tools such as `kernel-install list`, `kernel-install inspect`, `dracut` and `ukify` look for the kernel image here (by default). So lets install this symlink to make manual invocation of dracut and ukify a bit easier. As well as make it possible to use other kernel-install features such as list, inspect and add-all.

Before this change:
```
andrew@andrew-gentoo-laptop ~ % kernel-install inspect
Kernel image not installed to '/usr/lib/modules/6.7.3-gentoo-dist/vmlinuz', requiring manual kernel image pathspecification.
andrew@andrew-gentoo-laptop ~ % kernel-install list
VERSION            HAS KERNEL PATH
6.7.3-gentoo-dist           ✗ /usr/lib/modules/6.7.3-gentoo-dist
```
After this change:
```
andrew-gentoo-pc ~ # kernel-install list
VERSION           HAS KERNEL PATH
6.7.3-gentoo-dist          ✓ /usr/lib/modules/6.7.3-gentoo-dist
andrew-gentoo-pc ~ # kernel-install inspect
Machine ID: 204b505c963976da92752bb45b5adc9c
Kernel Image Type: pe
Layout: uki
Boot Root: /boot
Entry Token Type: literal
Entry Token: linux
Entry Directory: /boot/linux/6.7.3-gentoo-dist
Kernel Version: 6.7.3-gentoo-dist
Kernel: /usr/lib/modules/6.7.3-gentoo-dist/vmlinuz
Initrds: (unset)
Initrd Generator: dracut
UKI Generator: ukify
Plugins: /usr/lib/kernel/install.d/00-00machineid-directory.install
/usr/lib/kernel/install.d/10-copy-prebuilt.install
/usr/lib/kernel/install.d/50-depmod.install
/usr/lib/kernel/install.d/50-dracut.install
/usr/lib/kernel/install.d/51-dracut-rescue.install
/usr/lib/kernel/install.d/60-ukify.install
/usr/lib/kernel/install.d/90-compat.install
/usr/lib/kernel/install.d/90-loaderentry.install
/usr/lib/kernel/install.d/90-uki-copy.install
Plugin Environment: LC_COLLATE=C.UTF-8
KERNEL_INSTALL_VERBOSE=0
KERNEL_INSTALL_IMAGE_TYPE=pe
KERNEL_INSTALL_MACHINE_ID=204b505c963976da92752bb45b5adc9c
KERNEL_INSTALL_ENTRY_TOKEN=linux
KERNEL_INSTALL_BOOT_ROOT=/boot
KERNEL_INSTALL_LAYOUT=uki
KERNEL_INSTALL_INITRD_GENERATOR=dracut
KERNEL_INSTALL_UKI_GENERATOR=ukify
KERNEL_INSTALL_STAGING_AREA=/tmp/kernel-install.staging.XXXXXX
Plugin Arguments: add|remove
6.7.3-gentoo-dist
/boot/linux/6.7.3-gentoo-dist
/usr/lib/modules/6.7.3-gentoo-dist/vmlinuz
[INITRD...]
```

Note also, the `kernel-install` manual:
```
/usr/lib/modules/KERNEL-VERSION/vmlinuz
Location for installed kernel images. This is the recommended location for OS package managers
to install kernel images into (as applicable), from which kernel-install add then copies it into
the final boot partition.

Added in version 255.
```
And the dracut manual:
```
--kernel-image <file>
Specifies the kernel image, which to include in the UEFI executable. The default is
/lib/modules/<KERNEL-VERSION>/vmlinuz or /boot/vmlinuz-<KERNEL-VERSION>.
```


Note also that this "unlocks" the ability to do `kernel-install add-all` on Gentoo, which may be convenient in some setups that want to bulk instal multiple kernel versions.

Note that with regards to naming the kernel image `vmlinuz` or `vmlinux` we stick to the convention set by `sys-kernel/installkernel[-systemd]`.