### PR TITLE
net-misc/netdate: EAPI8 bump, fix bug #494590, #725204

### DIFF
--- a/net-misc/netdate/netdate-1.2-r2.ebuild
+++ b/net-misc/netdate/netdate-1.2-r2.ebuild
@@ -1,0 +1,27 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs
+
+DESCRIPTION="Utility to set date and time by ARPA Internet RFC 868"
+HOMEPAGE="ftp://ftp.suse.com/pub/people/kukuk/ipv6/"
+SRC_URI="ftp://ftp.suse.com/pub/people/kukuk/ipv6/${P}.tar.bz2"
+S="${WORKDIR}/${PN}"
+
+LICENSE="public-domain"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~mips ~s390 ~sparc ~x86"
+
+DOCS=( README )
+
+src_compile(){
+	emake CC="$(tc-getCC)"
+}
+
+src_install() {
+	dobin "${PN}"
+	doman "${PN}.8"
+	einstalldocs
+}


### PR DESCRIPTION
Another pretty simple `EAPI8` bump.
I've also updated the ebuild to fix the two open bugs. One was about `net-misc/netdate` description, where I've simply used the the description of the man page. (as mentioned on the bug)


```diff 
--- netdate-1.2-r1.ebuild	2024-01-17 20:05:13.489814688 +0100
+++ netdate-1.2-r2.ebuild	2024-02-07 20:39:57.702506867 +0100
@@ -1,20 +1,25 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
 
-DESCRIPTION="utility to synchronize the time with ntp-servers"
+inherit toolchain-funcs
+
+DESCRIPTION="Utility to set date and time by ARPA Internet RFC 868"
 HOMEPAGE="ftp://ftp.suse.com/pub/people/kukuk/ipv6/"
 SRC_URI="ftp://ftp.suse.com/pub/people/kukuk/ipv6/${P}.tar.bz2"
+S="${WORKDIR}/${PN}"
 
 LICENSE="public-domain"
 SLOT="0"
-KEYWORDS="amd64 arm ~mips ~s390 sparc x86"
-
-S="${WORKDIR}/${PN}"
+KEYWORDS="~amd64 ~arm ~mips ~s390 ~sparc ~x86"
 
 DOCS=( README )
 
+src_compile(){
+	emake CC="$(tc-getCC)"
+}
+
 src_install() {
 	dobin "${PN}"
 	doman "${PN}.8"
```

Signed-off-by: Michael Mair-Keimberger <mmk@levelnine.at>

Closes: https://bugs.gentoo.org/494590
Closes: https://bugs.gentoo.org/725204