### PR TITLE
app-crypt/tpm2-pkcs11: Fix stripping logic

### DIFF
--- a/app-crypt/tpm2-pkcs11/files/tpm2-pkcs11-1.9.0-Remove-incorrect-append-in-configure-ac.patch
+++ b/app-crypt/tpm2-pkcs11/files/tpm2-pkcs11-1.9.0-Remove-incorrect-append-in-configure-ac.patch
@@ -1,0 +1,26 @@
+From 03bc2732826443328550358ba8f2c79195922bc8 Mon Sep 17 00:00:00 2001
+From: Christopher Byrne <salah.coronya@gmail.com>
+Date: Wed, 7 Feb 2024 14:55:38 -0600
+Subject: [PATCH] configure: Change mistaken += to =
+
+Signed-off-by: Christopher Byrne <salah.coronya@gmail.com>
+---
+ configure.ac | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index 771004b..0f1457e 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -540,7 +540,7 @@ and submitting patches upstream!])
+ # Rather than nesting these and making them ugly just use a counter.
+ AX_CHECK_COMPILE_FLAG([-fdata-sections], [strip=y])
+ AX_CHECK_COMPILE_FLAG([-ffunction-sections], [strip="y$strip"])
+-AX_CHECK_LINK_FLAG([[-Wl,--gc-sections]], [strip+="y$strip"])
++AX_CHECK_LINK_FLAG([[-Wl,--gc-sections]], [strip="y$strip"])
+ 
+ AS_IF([test x"$strip" = xyyy], [
+   EXTRA_CFLAGS="$EXTRA_CFLAGS -fdata-sections -ffunction-sections"
+-- 
+2.43.0
+

--- a/app-crypt/tpm2-pkcs11/tpm2-pkcs11-1.9.0-r1.ebuild
+++ b/app-crypt/tpm2-pkcs11/tpm2-pkcs11-1.9.0-r1.ebuild
@@ -1,0 +1,70 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+PYTHON_COMPAT=( python3_{10..11} )
+PYTHON_REQ_USE="sqlite"
+
+inherit autotools python-single-r1
+
+DESCRIPTION="A PKCS#11 interface for TPM2 hardware"
+HOMEPAGE="https://tpm2-software.github.io/"
+SRC_URI="https://github.com/tpm2-software/tpm2-pkcs11/releases/download/${PV}/${P}.tar.gz"
+
+LICENSE="BSD-2"
+SLOT="0"
+KEYWORDS="~amd64"
+
+IUSE="fapi test"
+REQUIRED_USE="( ${PYTHON_REQUIRED_USE} )"
+
+# Units tests only for now
+RESTRICT="!test? ( test )"
+
+RDEPEND="${PYTHON_DEPS}
+	app-crypt/p11-kit
+	app-crypt/tpm2-abrmd
+	app-crypt/tpm2-tools[fapi?]
+	!fapi? ( app-crypt/tpm2-tss:= )
+	fapi? ( >=app-crypt/tpm2-tss-3.0.1:=[fapi] )
+	dev-db/sqlite:3
+	dev-libs/libyaml
+	dev-libs/openssl:=
+	$(python_gen_cond_dep '
+	dev-python/bcrypt[${PYTHON_USEDEP}]
+	dev-python/cryptography[${PYTHON_USEDEP}]
+	dev-python/pyasn1[${PYTHON_USEDEP}]
+	dev-python/pyasn1-modules[${PYTHON_USEDEP}]
+	dev-python/pyyaml[${PYTHON_USEDEP}]
+	dev-python/tpm2-pytss[${PYTHON_USEDEP}]
+	')
+"
+
+DEPEND="test? ( dev-util/cmocka )
+	${RDEPEND}"
+BDEPEND="${PYTHON_DEPS}
+	dev-build/autoconf-archive
+	virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-1.9.0-Remove-incorrect-append-in-configure-ac.patch"
+)
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_configure() {
+	econf \
+		$(use_enable fapi) \
+		$(use_enable test unit)
+}
+
+src_install() {
+	default
+	python_domodule tools/tpm2_pkcs11
+	python_newscript tools/tpm2_ptool.py tpm2_ptool
+	find "${ED}" -name '*.la' -delete || die
+}


### PR DESCRIPTION
The stripping logic in configure.ac is incorrect. += (Append, bash-only) was used instead of = (assignment). 

Sent upstream: https://github.com/tpm2-software/tpm2-pkcs11/pull/855