### PR TITLE
sys-apps/baselayout: ROOTPATH should have host paths on Prefix

### DIFF
--- a/sys-apps/baselayout/baselayout-2.14-r2.ebuild
+++ b/sys-apps/baselayout/baselayout-2.14-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -209,6 +209,7 @@ src_prepare() {
 		hprefixify -w '/PATH=/' etc/env.d/50baselayout
 		hprefixify -w 1 etc/env.d/50baselayout
 		echo PATH=/usr/sbin:/sbin:/usr/bin:/bin >> etc/env.d/99host
+		echo ROOTPATH=/usr/sbin:/sbin:/usr/bin:/bin >> etc/env.d/99host
 		echo MANPATH=/usr/share/man >> etc/env.d/99host
 
 		# change branding

--- a/sys-apps/baselayout/baselayout-9999.ebuild
+++ b/sys-apps/baselayout/baselayout-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -209,6 +209,7 @@ src_prepare() {
 		hprefixify -w '/PATH=/' etc/env.d/50baselayout
 		hprefixify -w 1 etc/env.d/50baselayout
 		echo PATH=/usr/sbin:/sbin:/usr/bin:/bin >> etc/env.d/99host
+		echo ROOTPATH=/usr/sbin:/sbin:/usr/bin:/bin >> etc/env.d/99host
 		echo MANPATH=/usr/share/man >> etc/env.d/99host
 
 		# change branding


### PR DESCRIPTION
Same as PATH, ROOTPATH should be modified to contain host paths. This fixes app-shells/zsh not having host paths when EUID=1000 or root user, because it sets ROOTPATH as PATH in /etc/zsh/zprofile, which make zsh's behavior align with bash.

Closes: https://bugs.gentoo.org/924032