### PR TITLE
app-emulation/dxvk-9999: Force fallback for libdisplay-info

### DIFF
--- a/app-emulation/dxvk/dxvk-9999.ebuild
+++ b/app-emulation/dxvk/dxvk-9999.ebuild
@@ -128,6 +128,7 @@ multilib_src_configure() {
 	local emesonargs=(
 		--prefix="${EPREFIX}"/usr/lib/${PN}
 		--{bin,lib}dir=x${MULTILIB_ABI_FLAG: -2}
+		--force-fallback-for=libdisplay-info
 		$(meson_use {,enable_}d3d9)
 		$(meson_use {,enable_}d3d10)
 		$(meson_use {,enable_}d3d11)


### PR DESCRIPTION
Without this 64bit dxvk doesn't compile for me