### PR TITLE
media-libs/nvidia-vaapi-driver: fix building with musl

### DIFF
--- a/media-libs/nvidia-vaapi-driver/files/nvidia-vaapi-driver-0.0.11_musl-support.patch
+++ b/media-libs/nvidia-vaapi-driver/files/nvidia-vaapi-driver-0.0.11_musl-support.patch
@@ -1,0 +1,27 @@
+From https://github.com/elFarto/nvidia-vaapi-driver/pull/273
+From: "Azamat H. Hackimov" <azamat.hackimov@gmail.com>
+Date: Fri, 9 Feb 2024 20:54:17 +0300
+Subject: [PATCH] Fix building with musl
+
+qsort_r invocations uses `__compar_d_fn_t` typedef that defined only in
+glibc. Added missing typedef to fix compilation on musl systems.
+
+See: https://bugs.gentoo.org/924146
+
+Signed-off-by: Azamat H. Hackimov <azamat.hackimov@gmail.com>
+--- a/src/hevc.c
++++ b/src/hevc.c
+@@ -3,6 +3,10 @@
+ #include "vabackend.h"
+ #include <stdlib.h>
+ 
++#if !defined(__GLIBC__)
++typedef int (*__compar_d_fn_t) (const void *, const void *, void *);
++#endif
++
+ static const uint8_t ff_hevc_diag_scan4x4_x[16] = {
+     0, 0, 1, 0,
+     1, 2, 0, 1,
+-- 
+2.43.0
+

--- a/media-libs/nvidia-vaapi-driver/nvidia-vaapi-driver-0.0.11.ebuild
+++ b/media-libs/nvidia-vaapi-driver/nvidia-vaapi-driver-0.0.11.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2023 Gentoo Authors
+# Copyright 2023-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -20,3 +20,7 @@ RDEPEND="media-libs/gst-plugins-bad
 DEPEND="${RDEPEND}
 	>=media-libs/nv-codec-headers-11.1.5.1"
 BDEPEND="virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}/nvidia-vaapi-driver-0.0.11_musl-support.patch"
+)


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/924146