### PR TITLE
net-libs/rpcsvc-proto: Stop using /lib/cpp as the default

### DIFF
--- a/net-libs/rpcsvc-proto/rpcsvc-proto-1.4.4-r1.ebuild
+++ b/net-libs/rpcsvc-proto/rpcsvc-proto-1.4.4-r1.ebuild
@@ -27,13 +27,12 @@ src_prepare() {
 	# Bug 718138, 870031, 870061.
 	local x cpp=
 	for x in {${CHOST}-,}{,clang-}cpp; do
-		if type -P "${x}" >/dev/null; then
-			cpp=${x}
+		if cpp="$(type -P "${x}")"; then
 			break
 		fi
 	done
 	[[ -n ${cpp} ]] || die "Unable to find cpp"
-	sed -i -e "s/CPP = \"cpp\";/CPP = \"${cpp}\";/" rpcgen/rpc_main.c || die
+	sed -i -e "s|CPP = \"/lib/cpp\";|CPP = \"${cpp}\";|" rpcgen/rpc_main.c || die
 }
 
 src_install() {


### PR DESCRIPTION
rpcgen will try and use /lib/cpp by default and then fall back to "cpp".
This change makes it so we use the specified cpp as the default.

Bug: https://bugs.gentoo.org/870031
Signed-off-by: Raul E Rangel <rrangel@chromium.org>
