### PR TITLE
dev-python/regex: disable pypy3

### DIFF
--- a/dev-python/aiohttp/aiohttp-3.9.1.ebuild
+++ b/dev-python/aiohttp/aiohttp-3.9.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -40,8 +40,8 @@ BDEPEND="
 		dev-python/pytest-forked[${PYTHON_USEDEP}]
 		dev-python/pytest-mock[${PYTHON_USEDEP}]
 		dev-python/pytest-xdist[${PYTHON_USEDEP}]
-		dev-python/re-assert[${PYTHON_USEDEP}]
 		$(python_gen_cond_dep '
+			dev-python/re-assert[${PYTHON_USEDEP}]
 			dev-python/time-machine[${PYTHON_USEDEP}]
 		' 'python3*')
 		test-rust? (
@@ -107,6 +107,14 @@ python_test() {
 			# on PyPy3 but the test suite needs an explicit switch,
 			# sigh
 			local -x AIOHTTP_NO_EXTENSIONS=1
+
+			EPYTEST_IGNORE+=(
+				# Skip tests requiring dev-python/re-assert -> dev-python/regex
+				tests/test_streams.py
+				tests/test_urldispatch.py
+				tests/test_client_session.py
+				tests/test_web_response.py
+			)
 			;;
 	esac
 

--- a/dev-python/aiohttp/aiohttp-3.9.2.ebuild
+++ b/dev-python/aiohttp/aiohttp-3.9.2.ebuild
@@ -40,8 +40,8 @@ BDEPEND="
 		dev-python/pytest-forked[${PYTHON_USEDEP}]
 		dev-python/pytest-mock[${PYTHON_USEDEP}]
 		dev-python/pytest-xdist[${PYTHON_USEDEP}]
-		dev-python/re-assert[${PYTHON_USEDEP}]
 		$(python_gen_cond_dep '
+			dev-python/re-assert[${PYTHON_USEDEP}]
 			dev-python/time-machine[${PYTHON_USEDEP}]
 		' 'python3*')
 		test-rust? (
@@ -107,6 +107,14 @@ python_test() {
 			# on PyPy3 but the test suite needs an explicit switch,
 			# sigh
 			local -x AIOHTTP_NO_EXTENSIONS=1
+
+			EPYTEST_IGNORE+=(
+				# Skip tests requiring dev-python/re-assert -> dev-python/regex
+				tests/test_streams.py
+				tests/test_urldispatch.py
+				tests/test_client_session.py
+				tests/test_web_response.py
+			)
 			;;
 	esac
 

--- a/dev-python/aiohttp/aiohttp-3.9.3.ebuild
+++ b/dev-python/aiohttp/aiohttp-3.9.3.ebuild
@@ -40,8 +40,8 @@ BDEPEND="
 		dev-python/pytest-forked[${PYTHON_USEDEP}]
 		dev-python/pytest-mock[${PYTHON_USEDEP}]
 		dev-python/pytest-xdist[${PYTHON_USEDEP}]
-		dev-python/re-assert[${PYTHON_USEDEP}]
 		$(python_gen_cond_dep '
+			dev-python/re-assert[${PYTHON_USEDEP}]
 			dev-python/time-machine[${PYTHON_USEDEP}]
 		' 'python3*')
 		test-rust? (
@@ -107,6 +107,14 @@ python_test() {
 			# on PyPy3 but the test suite needs an explicit switch,
 			# sigh
 			local -x AIOHTTP_NO_EXTENSIONS=1
+
+			EPYTEST_IGNORE+=(
+				# Skip tests requiring dev-python/re-assert -> dev-python/regex
+				tests/test_streams.py
+				tests/test_urldispatch.py
+				tests/test_client_session.py
+				tests/test_web_response.py
+			)
 			;;
 	esac
 

--- a/dev-python/astroid/astroid-3.0.2.ebuild
+++ b/dev-python/astroid/astroid-3.0.2.ebuild
@@ -28,13 +28,16 @@ RDEPEND="
 		>=dev-python/typing-extensions-4.0.0[${PYTHON_USEDEP}]
 	' 3.10)
 "
+# dev-python/regex isn't available for pypy
 BDEPEND="
 	dev-python/setuptools-scm[${PYTHON_USEDEP}]
 	test? (
 		dev-python/attrs[${PYTHON_USEDEP}]
 		>=dev-python/numpy-1.17.0[${PYTHON_USEDEP}]
 		dev-python/python-dateutil[${PYTHON_USEDEP}]
-		dev-python/regex[${PYTHON_USEDEP}]
+		$(python_gen_cond_dep '
+			dev-python/regex[${PYTHON_USEDEP}]
+		' 'python*')
 	)
 "
 

--- a/dev-python/astroid/astroid-3.0.3.ebuild
+++ b/dev-python/astroid/astroid-3.0.3.ebuild
@@ -28,13 +28,16 @@ RDEPEND="
 		>=dev-python/typing-extensions-4.0.0[${PYTHON_USEDEP}]
 	' 3.10)
 "
+# dev-python/regex isn't available for pypy
 BDEPEND="
 	dev-python/setuptools-scm[${PYTHON_USEDEP}]
 	test? (
 		dev-python/attrs[${PYTHON_USEDEP}]
 		>=dev-python/numpy-1.17.0[${PYTHON_USEDEP}]
 		dev-python/python-dateutil[${PYTHON_USEDEP}]
-		dev-python/regex[${PYTHON_USEDEP}]
+		$(python_gen_cond_dep '
+			dev-python/regex[${PYTHON_USEDEP}]
+		' 'python*')
 	)
 "
 

--- a/dev-python/lark/lark-1.1.9.ebuild
+++ b/dev-python/lark/lark-1.1.9.ebuild
@@ -18,10 +18,13 @@ LICENSE="MIT"
 SLOT="0"
 KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~arm64-macos ~x64-macos"
 
+# dev-python/regex doesn't support pypy
 BDEPEND="
 	test? (
 		dev-python/atomicwrites[${PYTHON_USEDEP}]
-		dev-python/regex[${PYTHON_USEDEP}]
+		$(python_gen_cond_dep '
+			dev-python/regex[${PYTHON_USEDEP}]
+		' 'python*')
 	)
 "
 
@@ -32,13 +35,6 @@ python_test() {
 		# require dev-python/js2py which is a really bad quality package
 		tests/test_nearley/test_nearley.py
 	)
-
-	if has "${EPYTHON}" pypy3 python3.{8,9}; then
-		EPYTEST_IGNORE+=(
-			# test using Python 3.10+ syntax
-			tests/test_pattern_matching.py
-		)
-	fi
 
 	epytest
 }

--- a/dev-python/re-assert/re-assert-1.1.0-r1.ebuild
+++ b/dev-python/re-assert/re-assert-1.1.0-r1.ebuild
@@ -1,10 +1,10 @@
-# Copyright 2020-2023 Gentoo Authors
+# Copyright 2020-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{10..12} pypy3 )
+PYTHON_COMPAT=( python3_{10..12} )
 
 inherit distutils-r1
 

--- a/dev-python/regex/regex-2023.12.25.ebuild
+++ b/dev-python/regex/regex-2023.12.25.ebuild
@@ -5,7 +5,9 @@ EAPI=8
 
 DISTUTILS_EXT=1
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{10..12} pypy3 )
+# pypy isn't supported upstream because of its UTF8 representation for strings
+# See https://github.com/mrabarnett/mrab-regex/issues/521#issuecomment-1936260187.
+PYTHON_COMPAT=( python3_{10..12} )
 
 inherit distutils-r1 pypi
 

--- a/dev-python/rfc3987/rfc3987-1.3.8-r2.ebuild
+++ b/dev-python/rfc3987/rfc3987-1.3.8-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -18,8 +18,12 @@ LICENSE="GPL-3"
 SLOT="0"
 KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux ~arm64-macos ~x64-macos"
 
+# dev-python/regex doesn't support pypy. The package falls back to re and has most
+# functionality without it.
 RDEPEND="
-	dev-python/regex[${PYTHON_USEDEP}]
+	$(python_gen_cond_dep '
+		dev-python/regex[${PYTHON_USEDEP}]
+	' 'python*')
 "
 BDEPEND="
 	${RDEPEND}

--- a/dev-python/tox/tox-4.12.1.ebuild
+++ b/dev-python/tox/tox-4.12.1.ebuild
@@ -42,8 +42,8 @@ BDEPEND="
 		dev-python/psutil[${PYTHON_USEDEP}]
 		dev-python/pytest-mock[${PYTHON_USEDEP}]
 		dev-python/pytest-xdist[${PYTHON_USEDEP}]
-		dev-python/re-assert[${PYTHON_USEDEP}]
 		$(python_gen_cond_dep '
+			dev-python/re-assert[${PYTHON_USEDEP}]
 			dev-python/time-machine[${PYTHON_USEDEP}]
 		' 'python*')
 	)
@@ -81,6 +81,11 @@ python_test() {
 		'tests/tox_env/python/pip/test_pip_install.py::test_constrain_package_deps[explicit+requirements-True-True]'
 		'tests/tox_env/python/pip/test_pip_install.py::test_constrain_package_deps[requirements_indirect-True-True]'
 		'tests/tox_env/python/pip/test_pip_install.py::test_constrain_package_deps[requirements_constraints_indirect-True-True]'
+	)
+
+	[[ ${EPYTHON} == pypy3 ]] && EPYTEST_IGNORE+=(
+		# requires dev-python/re-assert
+		tests/session/cmd/test_sequential.py
 	)
 
 	epytest


### PR DESCRIPTION
It's unsupported upstream and on x86 at least, it ends up showing up precisely
because of the UTF8-vs-ASCII strings representation problem.

(See also mrabarnett/mrab-regex#404 where the
test issues got fixed but upstream made clear that it's unsupported and
also can't really work properly.)

Bug: mrabarnett/mrab-regex#404
Bug: mrabarnett/mrab-regex#521
Closes: https://bugs.gentoo.org/924136
Signed-off-by: Sam James <sam@gentoo.org>