### PR TITLE
sys-apps/toybox: fix menuconfig

### DIFF
--- a/sys-apps/toybox/files/toybox-0.8.10-ncurses-build-fix.patch
+++ b/sys-apps/toybox/files/toybox-0.8.10-ncurses-build-fix.patch
@@ -1,0 +1,30 @@
+From c1122e2c2406cbed14bf37e1c6d5bf875fbdf375 Mon Sep 17 00:00:00 2001
+From: "Michael T. Kloos" <michael@michaelkloos.com>
+Date: Fri, 8 Apr 2022 08:28:42 -0400
+Subject: [PATCH] Adjusted the linker flags for kconfig mconf (menuconfig)
+
+For some reason, this breaks on my Gentoo systems.  There,
+libcurses does not contain nodelay, so the linking fails
+with symbol resolution errors regarding the nodelay symbol.
+
+I have changed it to use pkg-config --libs ncurses, which,
+in my case, adds -ltinfo to fix this issue.
+
+Signed-off-by: Michael T. Kloos <michael@michaelkloos.com>
+---
+ kconfig/Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/kconfig/Makefile b/kconfig/Makefile
+index 2e8e5dcd7..083026d37 100644
+--- a/kconfig/Makefile
++++ b/kconfig/Makefile
+@@ -67,7 +67,7 @@ gen_config.h: .config
+ 
+ kconfig/mconf: $(SHIPPED)
+ 	$(HOSTCC) -o $@ kconfig/mconf.c kconfig/zconf.tab.c \
+-		kconfig/lxdialog/*.c -lcurses -DCURSES_LOC="<ncurses.h>" \
++		kconfig/lxdialog/*.c `pkg-config --libs ncurses` -DCURSES_LOC="<ncurses.h>" \
+ 		-DKBUILD_NO_NLS=1 -DPROJECT_NAME=\"$(KCONFIG_PROJECT)\"
+ 
+ kconfig/conf: $(SHIPPED)

--- a/sys-apps/toybox/metadata.xml
+++ b/sys-apps/toybox/metadata.xml
@@ -5,6 +5,9 @@
     <email>patrick@gentoo.org</email>
     <name>Patrick Lauer</name>
   </maintainer>
+  <use>
+    <flag name="ncurses">Enable support for running make menuconfig</flag>
+  </use>
   <upstream>
     <remote-id type="github">landley/toybox</remote-id>
     <remote-id type="cpe">cpe:/a:toybox_project:toybox</remote-id>

--- a/sys-apps/toybox/toybox-0.8.10-r1.ebuild
+++ b/sys-apps/toybox/toybox-0.8.10-r1.ebuild
@@ -26,7 +26,7 @@ RDEPEND="${DEPEND}"
 
 # For menuconfig support bug #924193
 BDEPEND="
-	ncurses?(
+	ncurses? (
 		sys-libs/ncurses
 		virtual/pkgconfig
 	)

--- a/sys-apps/toybox/toybox-0.8.10-r1.ebuild
+++ b/sys-apps/toybox/toybox-0.8.10-r1.ebuild
@@ -1,0 +1,72 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit multiprocessing savedconfig toolchain-funcs
+
+IUSE="ncurses"
+
+if [[ ${PV} == 9999 ]]; then
+	inherit git-r3
+	EGIT_REPO_URI="https://github.com/landley/toybox.git"
+else
+	SRC_URI="https://landley.net/code/toybox/downloads/${P}.tar.gz"
+	KEYWORDS="~amd64 ~arm64 ~x86"
+fi
+
+DESCRIPTION="Common linux commands in a multicall binary"
+HOMEPAGE="https://landley.net/code/toybox/"
+
+LICENSE="0BSD"
+SLOT="0"
+
+DEPEND="virtual/libcrypt:="
+RDEPEND="${DEPEND}"
+
+# For menuconfig support bug #924193
+BDEPEND="
+	ncurses?(
+		sys-libs/ncurses
+		virtual/pkgconfig
+	)
+"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-ncurses-build-fix.patch
+)
+
+src_prepare() {
+	default
+	restore_config .config
+}
+
+src_configure() {
+	tc-export CC STRIP
+	export HOSTCC="$(tc-getBUILD_CC)"
+	# Respect CFLAGS
+	export OPTIMIZE="${CFLAGS}"
+
+	if [[ -f .config ]]; then
+		yes "" | emake -j1 oldconfig > /dev/null
+		return 0
+	else
+		einfo "Could not locate user configfile, so we will save a default one"
+		emake -j1 defconfig > /dev/null
+	fi
+}
+
+src_compile() {
+	unset CROSS_COMPILE
+	export CPUS=$(makeopts_jobs)
+	emake V=1 NOSTRIP=1
+}
+
+src_test() {
+	emake V=1 tests
+}
+
+src_install() {
+	save_config .config
+	dobin toybox
+}


### PR DESCRIPTION
Add a useflag for ncurses for users that want to use menuconfig. Let me know if this should be added to all the versions, patch will work on all of them.  I made the BDEPEND conditional because most users don't need to customize with menuconfig, but for those that do it's there....