### PR TITLE
profiles/prefix: reorder macos clang parents and override LDFLAGS

### DIFF
--- a/profiles/prefix/darwin/macos/14.0/arm64/clang/parent
+++ b/profiles/prefix/darwin/macos/14.0/arm64/clang/parent
@@ -1,2 +1,2 @@
-../../../features/clang-lld
 ..
+../../../features/clang-lld

--- a/profiles/prefix/darwin/macos/features/clang-lld/make.defaults
+++ b/profiles/prefix/darwin/macos/features/clang-lld/make.defaults
@@ -3,5 +3,10 @@
 
 LD=ld64.lld
 
+# This is the sort of equivalent of -Wl,--as-needed
+# It's already set in profiles/prefix/darwin, but profiles/features/llvm
+# appends --as-needed to it, so here we set it back to the previous value
+LDFLAGS="-Wl,-dead_strip_dylibs"
+
 # Several packages fail to build without this
 lt_cv_apple_cc_single_mod=yes


### PR DESCRIPTION
This is alternative to https://github.com/gentoo/gentoo/pull/35250

Bug: https://bugs.gentoo.org/758167

@grobian do you prefer this duplication instead?