### PR TITLE
app-containers/buildah: mask 1.34.0

### DIFF
--- a/app-containers/buildah/buildah-1.34.0.ebuild
+++ b/app-containers/buildah/buildah-1.34.0.ebuild
@@ -29,7 +29,7 @@ if [[ ${PV} == 9999* ]]; then
 	EGIT_REPO_URI="https://github.com/containers/buildah.git"
 else
 	SRC_URI="https://github.com/containers/buildah/archive/v${PV}.tar.gz -> ${P}.tar.gz"
-	KEYWORDS="amd64 arm64"
+	# KEYWORDS="amd64 arm64"
 fi
 
 RDEPEND="

--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -33,6 +33,11 @@
 
 #--- END OF EXAMPLES ---
 
+# Rahil Bhimjiani <me@rahil.rocks> (2024-02-14)
+# buildah-1.34.0 isn't getting security fixes from upstream
+# https://github.com/containers/buildah/issues/5320
+=app-containers/buildah-1.34.0
+
 # Michał Górny <mgorny@gentoo.org> (2024-02-14)
 # Abandoned upstream in 2020.  Has a fork that has last been released
 # in 2021.  No revdeps.


### PR DESCRIPTION
Stable buildah users need to downgrade to 1.33.5 so
Depends on: ~~https://bugs.gentoo.org/924456~~