### PR TITLE
media-libs/vidstab: adding test dependency

### DIFF
--- a/media-libs/vidstab/vidstab-1.1.1.ebuild
+++ b/media-libs/vidstab/vidstab-1.1.1.ebuild
@@ -19,7 +19,10 @@ fi
 
 LICENSE="GPL-2+"
 SLOT="0"
-IUSE="openmp cpu_flags_x86_sse2"
+IUSE="openmp cpu_flags_x86_sse2 test"
+
+RESTRICT="!test? ( test )"
+DEPEND="test? ( dev-lang/orc )"
 
 pkg_pretend() {
 	[[ ${MERGE_TYPE} != binary ]] && use openmp && tc-check-openmp

--- a/media-libs/vidstab/vidstab-9999.ebuild
+++ b/media-libs/vidstab/vidstab-9999.ebuild
@@ -19,7 +19,10 @@ fi
 
 LICENSE="GPL-2+"
 SLOT="0"
-IUSE="openmp cpu_flags_x86_sse2"
+IUSE="openmp cpu_flags_x86_sse2 test"
+
+RESTRICT="!test? ( test )"
+DEPEND="test? ( dev-lang/orc )"
 
 pkg_pretend() {
 	[[ ${MERGE_TYPE} != binary ]] && use openmp && tc-check-openmp


### PR DESCRIPTION
dev-lang/orc is required, iff FEATURES=test
therefore introducing USE=test and adding this dependency.

Merged from https://github.com/thinrope/pkalin/commit/8af40010830b5bf64d30a5ec7859171687ec77f2

Reported-by: Kalin KOZHUHAROV <kalin@thinrope.net>
Closes: https://bugs.gentoo.org/924218