### PR TITLE
dev-lang/rust: rebase and re-apply musl dynamic linking patch for 1.75

### DIFF
--- a/dev-lang/rust/files/1.75.0-musl-dynamic-linking.patch
+++ b/dev-lang/rust/files/1.75.0-musl-dynamic-linking.patch
@@ -1,0 +1,19 @@
+From e42709c46647dab342b826d30324f3e6e5590e00 Mon Sep 17 00:00:00 2001
+From: Jory Pratt <anarchy@gentoo.org>
+Date: Tue, 2 Aug 2022 18:32:53 -0500
+Subject: [PATCH] Enable dynamic linking by default for musl
+
+Signed-off-by: Jory Pratt <anarchy@gentoo.org>
+--- a/compiler/rustc_target/src/spec/base/linux_musl.rs
++++ b/compiler/rustc_target/src/spec/base/linux_musl.rs
+@@ -10,7 +10,7 @@ pub fn opts() -> TargetOptions {
+     base.crt_objects_fallback = Some(CrtObjectsFallback::Musl);
+ 
+     // These targets statically link libc by default
+-    base.crt_static_default = true;
++    base.crt_static_default = false;
+ 
+     base
+ }
+-- 
+2.35.1

--- a/dev-lang/rust/rust-1.75.0-r1.ebuild
+++ b/dev-lang/rust/rust-1.75.0-r1.ebuild
@@ -163,6 +163,7 @@ RESTRICT="test"
 VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/openpgp-keys/rust.asc
 
 PATCHES=(
+	"${FILESDIR}"/1.75.0-musl-dynamic-linking.patch
 	"${FILESDIR}"/1.74.1-cross-compile-libz.patch
 	#"${FILESDIR}"/1.72.0-bump-libc-deps-to-0.2.146.patch  # pending refresh
 	"${FILESDIR}"/1.70.0-ignore-broken-and-non-applicable-tests.patch


### PR DESCRIPTION
This somehow got lost in the 1.75 bump, but it is required for e.g. Firefox to compile on musl.