### PR TITLE
www-client/firefox: use RUST_TOOLCHAIN_ABI

### DIFF
--- a/eclass/rust-toolchain.eclass
+++ b/eclass/rust-toolchain.eclass
@@ -16,7 +16,11 @@ case ${EAPI} in
 	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
 
-inherit multilib-build
+# @ECLASS_VARIABLE: RUST_TOOLCHAIN_MULTILIB
+# @DESCRIPTION:
+# Controls whether multilib-build is inherited. Ebuilds may set this to
+# 'no' if they only need helper functions instead.
+: "${RUST_TOOLCHAIN_MULTILIB:=yes}"
 
 # @ECLASS_VARIABLE: RUST_TOOLCHAIN_BASEURL
 # @DESCRIPTION:
@@ -24,6 +28,10 @@ inherit multilib-build
 # rust_arch_uri and rust_all_arch_uris functions when
 # generating the URI output list.
 : "${RUST_TOOLCHAIN_BASEURL:=https://static.rust-lang.org/dist/}"
+
+if [[ ${RUST_TOOLCHAIN_MULTILIB} != "no" ]] ; then
+	inherit multilib-build
+fi
 
 # @FUNCTION: rust_abi
 # @USAGE: [CHOST-value]

--- a/www-client/firefox/firefox-122.0.1.ebuild
+++ b/www-client/firefox/firefox-122.0.1.ebuild
@@ -37,8 +37,10 @@ MOZ_P="${MOZ_PN}-${MOZ_PV}"
 MOZ_PV_DISTFILES="${MOZ_PV}${MOZ_PV_SUFFIX}"
 MOZ_P_DISTFILES="${MOZ_PN}-${MOZ_PV_DISTFILES}"
 
+RUST_TOOLCHAIN_MULTILIB=no
+
 inherit autotools check-reqs desktop flag-o-matic gnome2-utils linux-info llvm multiprocessing \
-	optfeature pax-utils python-any-r1 readme.gentoo-r1 toolchain-funcs virtualx xdg
+	optfeature pax-utils python-any-r1 readme.gentoo-r1 rust-toolchain toolchain-funcs virtualx xdg
 
 MOZ_SRC_BASE_URI="https://archive.mozilla.org/pub/${MOZ_PN}/releases/${MOZ_PV}"
 
@@ -674,16 +676,8 @@ src_prepare() {
 	# Make cargo respect MAKEOPTS
 	export CARGO_BUILD_JOBS="$(makeopts_jobs)"
 
-	# Workaround for bgo#915651
-	if ! use elibc_glibc ; then
-		if use amd64 ; then
-			export RUST_TARGET="x86_64-unknown-linux-musl"
-		elif use x86 ; then
-			export RUST_TARGET="i686-unknown-linux-musl"
-		else
-			die "Unknown musl chost, please post your rustc -vV along with emerge --info on Gentoo's bug #915651"
-		fi
-	fi
+	# Respect RUST_TARGET, #748849 and #915651
+	export RUST_TARGET=$(rust_abi)
 
 	# Make LTO respect MAKEOPTS
 	sed -i -e "s/multiprocessing.cpu_count()/$(makeopts_jobs)/" \


### PR DESCRIPTION
Unfortunately this doesn't fix building firefox with rust-bin for me. I'm starting to think the problem lies deeper in how rust-bin is built upstream. The rust-toolchain update is worthy on its own though, and I don't want this idea to get lost, so here's a PR so we won't forget!