### PR TITLE
net-print/poster: EAPI8 bump, fix HOMEPAGE

### DIFF
--- a/net-print/poster/poster-20060221-r4.ebuild
+++ b/net-print/poster/poster-20060221-r4.ebuild
@@ -1,0 +1,30 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs
+
+DESCRIPTION="Small utility for making a poster from an EPS file or a one-page PS document"
+HOMEPAGE="https://ctan.org/pkg/poster"
+SRC_URI="mirror://kde/printing/${P}.tar.bz2"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86"
+
+PATCHES=(
+	"${FILESDIR}/${P}-fix_gs_crash.patch"
+	"${FILESDIR}/${P}-fix_duplicate_DocumentMedia.patch"
+	"${FILESDIR}/${P}-fix_cutmarks.patch"
+)
+
+src_compile() {
+	$(tc-getCC) ${CFLAGS} ${LDFLAGS} ${PN}.c -lm -o ${PN} || die
+}
+
+src_install() {
+	dobin ${PN}
+	doman ${PN}.1
+	dodoc README ChangeLog
+}


### PR DESCRIPTION
Simple `EAPI8` bump.
The old `HOMEPAGE` was pretty dead so i've updated the `HOMEPAGE` to https://printing.kde.org/downloads

```diff
--- poster-20060221-r3.ebuild	2023-04-01 17:48:26.593945704 +0200
+++ poster-20060221-r4.ebuild	2024-02-11 17:30:59.371579355 +0100
@@ -1,18 +1,17 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
 
 inherit toolchain-funcs
 
 DESCRIPTION="Small utility for making a poster from an EPS file or a one-page PS document"
+HOMEPAGE="https://ctan.org/pkg/poster"
 SRC_URI="mirror://kde/printing/${P}.tar.bz2"
-HOMEPAGE="https://printing.kde.org/downloads"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 ~ppc x86"
-IUSE=""
+KEYWORDS="~amd64 ~ppc ~x86"
 
 PATCHES=(
 	"${FILESDIR}/${P}-fix_gs_crash.patch"
```