### PR TITLE
media-gfx/gifsicle: add missing braces

### DIFF
--- a/media-gfx/gifsicle/gifsicle-1.94.ebuild
+++ b/media-gfx/gifsicle/gifsicle-1.94.ebuild
@@ -12,7 +12,7 @@ SLOT="0"
 KEYWORDS="~alpha amd64 ppc ~ppc64 ~sparc x86 ~amd64-linux ~x86-linux ~ppc-macos"
 IUSE="X"
 
-PATCHES=( "${FILESDIR}/$P-CVE-2023-46009.patch" )
+PATCHES=( "${FILESDIR}/${P}-CVE-2023-46009.patch" )
 
 RDEPEND="
 	X? (


### PR DESCRIPTION
This just fixes the missing `{}` braces.