### PR TITLE
www-apps/tt-rss: Mark 99999999 as compatible with PHP 8.3

### DIFF
--- a/www-apps/tt-rss/tt-rss-99999999.ebuild
+++ b/www-apps/tt-rss/tt-rss-99999999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -13,7 +13,7 @@ SLOT="${PV}" # Single live slot.
 IUSE="+acl daemon gd +mysqli postgres"
 REQUIRED_USE="|| ( mysqli postgres )"
 
-PHP_SLOTS="8.2 8.1"
+PHP_SLOTS="8.3 8.2 8.1"
 PHP_USE="gd?,mysqli?,postgres?,curl,fileinfo,intl,json(+),pdo,unicode,xml"
 
 php_rdepend() {


### PR DESCRIPTION
Upstream has recommended PHP 8.3 for two months:
https://git.tt-rss.org/fox/tt-rss.git/commit/?id=7883f024e7f0c2262256be310044c7ceb2ff3247