### PR TITLE
java-utils-2.eclass: solve Unexpected tag in "funcvar" state, prepend "QA Notice" to eqawarn, improve message of java-pkg_die, eerror if java-utils-2 is inherited directly

### DIFF
--- a/eclass/java-utils-2.eclass
+++ b/eclass/java-utils-2.eclass
@@ -34,6 +34,12 @@ export WANT_JAVA_CONFIG="2"
 
 has test ${JAVA_PKG_IUSE} && RESTRICT+=" !test? ( test )"
 
+# this eclass must be inherited after java-pkg-2 or java-pkg-opt-2
+# bug #207098
+if ! has java-pkg-2 ${INHERITED} && ! has java-pkg-opt-2 ${INHERITED}; then
+	eerror "java-utils-2 eclass must not be inherited directly."
+fi
+
 # @VARIABLE: JAVA_PKG_E_DEPEND
 # @INTERNAL
 # @DESCRIPTION:

--- a/eclass/java-utils-2.eclass
+++ b/eclass/java-utils-2.eclass
@@ -319,12 +319,15 @@ java-pkg_doexamples() {
 # arguments are passed through to find.
 #
 # @CODE
+# Parameters:
+# $1 - jar file
+# $2 - resource tree directory
+# $* - arguments to pass to find
+#
+# Example:
 #	java-pkg_addres ${PN}.jar resources ! -name "*.html"
 # @CODE
 #
-# @param $1 - jar file
-# @param $2 - resource tree directory
-# @param $* - arguments to pass to find
 java-pkg_addres() {
 	debug-print-function ${FUNCNAME} $*
 

--- a/eclass/java-utils-2.eclass
+++ b/eclass/java-utils-2.eclass
@@ -1646,10 +1646,6 @@ java-pkg_set-current-vm() {
 	export GENTOO_VM=${1}
 }
 
-java-pkg_get-current-vm() {
-	echo ${GENTOO_VM}
-}
-
 java-pkg_current-vm-matches() {
 	has $(java-pkg_get-current-vm) ${@}
 	return $?

--- a/eclass/java-utils-2.eclass
+++ b/eclass/java-utils-2.eclass
@@ -2934,7 +2934,7 @@ java-pkg_ensure-dep() {
 #		if is-java-strict; then
 #			die "${dev_error}"
 #		else
-			eqawarn "java-pkg_ensure-dep: ${dev_error}"
+			eqawarn "QA Notice: java-pkg_ensure-dep: ${dev_error}"
 #			eerror "Because you have ${target_pkg} installed,"
 #			eerror "the package will build without problems, but please"
 #			eerror "report this to https://bugs.gentoo.org."
@@ -2945,7 +2945,7 @@ java-pkg_ensure-dep() {
 #		if is-java-strict; then
 #			die "${dev_error}"
 #		else
-			eqawarn "java-pkg_ensure-dep: ${dev_error}"
+			eqawarn "QA Notice: java-pkg_ensure-dep: ${dev_error}"
 #			eerror "The package will build without problems, but may fail to run"
 #			eerror "if you don't have ${target_pkg} installed,"
 #			eerror "so please report this to https://bugs.gentoo.org."

--- a/eclass/java-utils-2.eclass
+++ b/eclass/java-utils-2.eclass
@@ -2816,7 +2816,7 @@ java-pkg_die() {
 	echo "!!! When you file a bug report, please include the following information:" >&2
 	echo "GENTOO_VM=${GENTOO_VM}  CLASSPATH=\"${CLASSPATH}\" JAVA_HOME=\"${JAVA_HOME}\"" >&2
 	echo "JAVACFLAGS=\"${JAVACFLAGS}\" COMPILER=\"${GENTOO_COMPILER}\"" >&2
-	echo "and of course, the output of emerge --info =${P}" >&2
+	echo "and of course, the output of emerge --info =${CATEGORY}/${PF}" >&2
 }
 
 


### PR DESCRIPTION
- https://marc.info/?l=gentoo-dev&m=169587778912788&w=2
- https://marc.info/?l=gentoo-dev&m=169587779812791&w=2
- https://marc.info/?l=gentoo-dev&m=169587780312809&w=2
- https://marc.info/?l=gentoo-dev&m=169587780912812&w=2