### PR TITLE
dev-lang/fuzion: update homepage url

### DIFF
--- a/dev-lang/fuzion/fuzion-0.085-r1.ebuild
+++ b/dev-lang/fuzion/fuzion-0.085-r1.ebuild
@@ -6,7 +6,7 @@ EAPI=8
 inherit java-pkg-2
 
 DESCRIPTION="A language with a focus on simplicity, safety and correctness"
-HOMEPAGE="https://flang.dev/
+HOMEPAGE="https://fuzion-lang.dev/
 	https://github.com/tokiwa-software/fuzion/"
 
 if [[ "${PV}" == *9999* ]] ; then

--- a/dev-lang/fuzion/fuzion-0.086.ebuild
+++ b/dev-lang/fuzion/fuzion-0.086.ebuild
@@ -6,7 +6,7 @@ EAPI=8
 inherit java-pkg-2
 
 DESCRIPTION="A language with a focus on simplicity, safety and correctness"
-HOMEPAGE="https://flang.dev/
+HOMEPAGE="https://fuzion-lang.dev/
 	https://github.com/tokiwa-software/fuzion/"
 
 if [[ "${PV}" == *9999* ]] ; then

--- a/dev-lang/fuzion/metadata.xml
+++ b/dev-lang/fuzion/metadata.xml
@@ -11,8 +11,8 @@
     for performance and correctness.
   </longdescription>
   <upstream>
-    <changelog>https://flang.dev/release_notes.txt</changelog>
-    <doc>https://flang.dev/docs/index</doc>
+    <changelog>https://fuzion-lang.dev/release_notes.txt</changelog>
+    <doc>https://fuzion-lang.dev/docs/index</doc>
     <bugs-to>https://github.com/tokiwa-software/fuzion/issues/</bugs-to>
     <remote-id type="github">tokiwa-software/fuzion</remote-id>
   </upstream>


### PR DESCRIPTION
Main url is now https://fuzion-lang.dev, even tough https://flang.dev still exists. Changed due to name clash with gcc frontend for fortran which is also called flang.