### PR TITLE
dev-db/influxdb: fix config handling

### DIFF
--- a/dev-db/influxdb/files/influxdb.confd-r1
+++ b/dev-db/influxdb/files/influxdb.confd-r1
@@ -1,0 +1,18 @@
+#The convention in this file is to show the default setting commented
+#out.
+#To change the setting, uncomment it then change the value.
+
+#This is the influxd error log:
+#error_log="/var/log/influxdb/influxd.log"
+
+#This is the influxd output log:
+#output_log="/dev/null"
+
+#The influxd Config path location:
+#config_path="/etc/influxdb/."
+
+# Extra options to pass to influxd:
+#influxd_opts=""
+
+# Uncomment / edit to enable healthchecks
+#INFLUXDB_HEALTHCHECK_URI="127.0.0.1:8086/ping"

--- a/dev-db/influxdb/files/influxdb.initd-r1
+++ b/dev-db/influxdb/files/influxdb.initd-r1
@@ -1,0 +1,47 @@
+#!/sbin/openrc-run
+
+# Logging
+error_log="${error_log:-/var/log/influxdb/influxd.log}"
+output_log="${output_log:-/dev/null}"
+
+config_path="${config_path:-/etc/influxdb/.}"
+influxd_opts=${influxd_opts:-}
+
+command=/usr/bin/influxd
+command_args="${influxd_opts}"
+command_user="influxdb:influxdb"
+extra_commands="version"
+
+retry=SIGTERM/30/SIGKILL/10
+supervisor="supervise-daemon"
+
+# Max open files
+rc_ulimit="-n 65536"
+
+start_pre() {
+	# Check if config file exist
+	if [ -n "${config_path}" ] && [ ! -e "${config_path}" ]; then
+		checkpath -d -o "${command_user}" "$(dirname "${config_path}")"
+	fi
+	if [ -n "${error_log}" ] && [ ! -e "${error_log}" ]; then
+		checkpath -d -o "${command_user}" "$(dirname "${error_log}")"
+	fi
+	if [ -n "${output_log}" ] && [ ! -e "${output_log}" ]; then
+		checkpath -d -o "${command_user}" "$(dirname "${output_log}")"
+	fi
+	return 0
+}
+
+version() {
+	$command version
+}
+
+if [ -n "${INFLUXDB_HEALTHCHECK_URI}" ]; then
+	healthcheck_delay=300
+	healthcheck_timer=60
+
+	healthcheck() {
+		command -v wget || return 0
+		wget -Oq- "${INFLUXDB_HEALTHCHECK_URI}"
+	}
+fi

--- a/dev-db/influxdb/influxdb-2.7.3-r1.ebuild
+++ b/dev-db/influxdb/influxdb-2.7.3-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -267,6 +267,10 @@ src_install() {
 	newinitd "${FILESDIR}"/influxdb.initd influxdb
 	keepdir /var/log/influxdb
 	fowners influxdb:influxdb /var/log/influxdb
+
+	newenvd - "99${PN}" <<-_EOF_
+		INFLUXD_CONFIG_PATH="/etc/influxdb"
+	_EOF_
 }
 
 pkg_postinst() {


### PR DESCRIPTION
The config handling changed in v2 completly.
This means, the parameter "-config" is gone and does not exist anymore.

Instead, INFLUXD_CONFIG_PATH needs to be defined with the path, where InfluxDB v2 needs to look for config files.

For compatibility reason, we will use '/etc/influxdb'. This can be overriden by user.

Closes: https://bugs.gentoo.org/908437

