### PR TITLE
media-libs/audiofile: fix removed std::unary_function in c++17

### DIFF
--- a/media-libs/audiofile/audiofile-0.3.6-r6.ebuild
+++ b/media-libs/audiofile/audiofile-0.3.6-r6.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -24,6 +24,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-0.3.6-CVE-2017-68xx.patch
 	"${FILESDIR}"/${PN}-0.3.6-CVE-2018-13440-CVE-2018-17095.patch
 	"${FILESDIR}"/${PN}-0.3.6-strict-prototypes.patch
+	"${FILESDIR}"/${PN}-0.3.6-fix-unary-function.patch
 )
 
 src_prepare() {

--- a/media-libs/audiofile/files/audiofile-0.3.6-fix-unary-function.patch
+++ b/media-libs/audiofile/files/audiofile-0.3.6-fix-unary-function.patch
@@ -1,0 +1,69 @@
+Replace std::unary_function with typedefs (deprecated in c++11 and removed in c++17).
+Bug: https://bugs.gentoo.org/914349
+--- a/libaudiofile/modules/SimpleModule.h
++++ b/libaudiofile/modules/SimpleModule.h
+@@ -125,13 +125,17 @@ struct signConverter
+ 	static const int kScaleBits = (Format + 1) * CHAR_BIT - 1;
+ 	static const int kMinSignedValue = 0-(1U<<kScaleBits);
+ 
+-	struct signedToUnsigned : public std::unary_function<SignedType, UnsignedType>
++	struct signedToUnsigned
+ 	{
++		typedef SignedType argument_type;
++		typedef UnsignedType result_type;
+ 		UnsignedType operator()(SignedType x) { return x - kMinSignedValue; }
+ 	};
+ 
+-	struct unsignedToSigned : public std::unary_function<SignedType, UnsignedType>
++	struct unsignedToSigned
+ 	{
++		typedef SignedType argument_type;
++		typedef UnsignedType result_type;
+ 		SignedType operator()(UnsignedType x) { return x + kMinSignedValue; }
+ 	};
+ };
+@@ -323,8 +327,10 @@ private:
+ };
+ 
+ template <typename Arg, typename Result>
+-struct intToFloat : public std::unary_function<Arg, Result>
++struct intToFloat
+ {
++	typedef Arg argument_type;
++	typedef Result result_type;
+ 	Result operator()(Arg x) const { return x; }
+ };
+ 
+@@ -389,14 +395,18 @@ private:
+ };
+ 
+ template <typename Arg, typename Result, unsigned shift>
+-struct lshift : public std::unary_function<Arg, Result>
++struct lshift
+ {
++	typedef Arg argument_type;
++	typedef Result result_type;
+ 	Result operator()(const Arg &x) const { return x << shift; }
+ };
+ 
+ template <typename Arg, typename Result, unsigned shift>
+-struct rshift : public std::unary_function<Arg, Result>
++struct rshift
+ {
++	typedef Arg argument_type;
++	typedef Result result_type;
+ 	Result operator()(const Arg &x) const { return x >> shift; }
+ };
+ 
+@@ -491,8 +501,10 @@ private:
+ };
+ 
+ template <typename Arg, typename Result>
+-struct floatToFloat : public std::unary_function<Arg, Result>
++struct floatToFloat
+ {
++	typedef Arg argument_type;
++	typedef Result result_type;
+ 	Result operator()(Arg x) const { return x; }
+ };
+ 


### PR DESCRIPTION
media-libs/audiofile: fix removed std::unary_function in c++17

Compilation fails with Clang (should be a warning with GCC):

```bash
In file included from /var/tmp/portage/media-libs/audiofile-0.3.6-r5/work/audiofile-0.3.6/libaudiofile/modules/Module.cpp:26:
/var/tmp/portage/media-libs/audiofile-0.3.6-r5/work/audiofile-0.3.6/libaudiofile/modules/SimpleModule.h:128:40: error: no template named 'unary_function' in namespace 'std'; did you mean '__unary_function'?
  128 |         struct signedToUnsigned : public std::unary_function<SignedType, UnsignedType>
      |                                          ~~~~~^~~~~~~~~~~~~~
      |                                               __unary_function
/usr/include/c++/v1/__functional/unary_function.h:46:1: note: '__unary_function' declared here
   46 | using __unary_function = __unary_function_keep_layout_base<_Arg, _Result>;
      | ^
```

The patch replaces `unary_function` with typedefs.
Closes: https://bugs.gentoo.org/914349
Closes https://github.com/gentoo/gentoo/pull/33614 PR if merged