### PR TITLE
sys-process/ftop: EAPI8 bump, fix LICENSE

### DIFF
--- a/sys-process/ftop/ftop-1.0-r2.ebuild
+++ b/sys-process/ftop/ftop-1.0-r2.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
 
 inherit autotools
 
@@ -9,7 +9,7 @@ DESCRIPTION="Monitor open files and filesystems"
 HOMEPAGE="https://wiki.gentoo.org/wiki/No_homepage"
 SRC_URI="https://dev.gentoo.org/~monsieurp/packages/${P}.tar.bz2"
 
-LICENSE="GPL-3"
+LICENSE="GPL-3+"
 SLOT="0"
 KEYWORDS="amd64 ~hppa ~riscv ~x86"
 


### PR DESCRIPTION
Very simple `EAPI8` bump.
Since i've only raised the `EAPI` (and fixed the `LICENSE`) i've decided to keep the `KEYWORDS`. 
Hope that's fine.