### PR TITLE
app-eselect/eselect-zig: remove old zig:0 and zig-bin:0 blockers

### DIFF
--- a/app-eselect/eselect-zig/eselect-zig-1-r1.ebuild
+++ b/app-eselect/eselect-zig/eselect-zig-1-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2023 Gentoo Authors
+# Copyright 2023-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -10,11 +10,7 @@ LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~riscv ~x86"
 
-RDEPEND="
-	app-admin/eselect
-	!dev-lang/zig:0
-	!dev-lang/zig-bin:0
-"
+RDEPEND="app-admin/eselect"
 
 S="${WORKDIR}"
 


### PR DESCRIPTION
Not needed since they were removed from tree
and migration completed.