### PR TITLE
dev-python/Nuitka: dev-util/patchelf optfeature

### DIFF
--- a/dev-python/Nuitka/Nuitka-2.0.1.ebuild
+++ b/dev-python/Nuitka/Nuitka-2.0.1.ebuild
@@ -48,5 +48,5 @@ python_test() {
 }
 
 pkg_postinst() {
-	optfeature "support for stand-alone executables" app-admin/chrpath
+	optfeature "support for stand-alone executables" dev-util/patchelf
 }

--- a/dev-python/Nuitka/Nuitka-2.0.2.ebuild
+++ b/dev-python/Nuitka/Nuitka-2.0.2.ebuild
@@ -48,5 +48,5 @@ python_test() {
 }
 
 pkg_postinst() {
-	optfeature "support for stand-alone executables" app-admin/chrpath
+	optfeature "support for stand-alone executables" dev-util/patchelf
 }

--- a/dev-python/Nuitka/Nuitka-2.0.ebuild
+++ b/dev-python/Nuitka/Nuitka-2.0.ebuild
@@ -48,5 +48,5 @@ python_test() {
 }
 
 pkg_postinst() {
-	optfeature "support for stand-alone executables" app-admin/chrpath
+	optfeature "support for stand-alone executables" dev-util/patchelf
 }


### PR DESCRIPTION
`chrpath` has been replaced with `patchelf`, see https://github.com/Nuitka/Nuitka/blob/2.0/Changelog.rst#L6381-L6382
Closes: https://bugs.gentoo.org/924586