### PR TITLE
dev-python/python3-discogs-client: Remove redundant PYPI_PN

### DIFF
--- a/dev-python/python3-discogs-client/python3-discogs-client-2.7.ebuild
+++ b/dev-python/python3-discogs-client/python3-discogs-client-2.7.ebuild
@@ -5,7 +5,6 @@ EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
 PYPI_NO_NORMALIZE=1
-PYPI_PN="python3-discogs-client"
 PYTHON_COMPAT=( python3_{10..12} )
 
 inherit distutils-r1

--- a/dev-python/python3-discogs-client/python3-discogs-client-9999.ebuild
+++ b/dev-python/python3-discogs-client/python3-discogs-client-9999.ebuild
@@ -5,7 +5,6 @@ EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
 PYPI_NO_NORMALIZE=1
-PYPI_PN="python3-discogs-client"
 PYTHON_COMPAT=( python3_{10..12} )
 
 inherit distutils-r1


### PR DESCRIPTION
Just was poking around new pypi facilities and got confused by this.