### PR TITLE
app-crypt/pkcrack: Fix return with no value, in function

### DIFF
--- a/app-crypt/pkcrack/files/pkcrack-1.2.2-gcc14-build.patch
+++ b/app-crypt/pkcrack/files/pkcrack-1.2.2-gcc14-build.patch
@@ -1,0 +1,12 @@
+Bug: https://bugs.gentoo.org/924227
+--- a/src/zdmain.c
++++ b/src/zdmain.c
+@@ -53,7 +53,7 @@ char *c;
+         break;
+     default:
+         fprintf( stderr, "Usage: %s {<password> | <key0> <key1> <key2>} <cryptedzipfile> <plainzipfile>\n", argv[0] );
+-        return;
++        return 0;
+     }
+ 
+     zipdecrypt( argv[argc-2], argv[argc-1], key0, key1, key2 );

--- a/app-crypt/pkcrack/pkcrack-1.2.2-r2.ebuild
+++ b/app-crypt/pkcrack/pkcrack-1.2.2-r2.ebuild
@@ -1,0 +1,56 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+inherit toolchain-funcs
+
+DESCRIPTION="PkZip cipher breaker"
+HOMEPAGE="https://www.unix-ag.uni-kl.de/~conrad/krypto/pkcrack.html"
+SRC_URI="https://www.unix-ag.uni-kl.de/~conrad/krypto/pkcrack/${P}.tar.gz"
+
+LICENSE="pkcrack"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86"
+IUSE="test"
+RESTRICT="!test? ( test )"
+
+RDEPEND="!<app-text/html-xml-utils-5.3"
+BDEPEND="test? ( app-arch/zip[crypt] )"
+
+DOCS=(
+	doc/KNOWN_BUGS
+	doc/appnote.iz.txt
+	doc/README.W32
+	doc/pkzip.ps.gz
+	doc/CHANGES
+	doc/LIESMICH
+	doc/README.html
+	doc/README
+)
+
+PATCHES=(
+	"${FILESDIR}/${P}-build.patch"
+	"${FILESDIR}/${P}-gcc14-build.patch"
+)
+
+src_compile() {
+	cd src
+	emake CC="$(tc-getCC)" CFLAGS="${CFLAGS} ${LDFLAGS}" all
+}
+
+src_test() {
+	cd test
+	emake CC="$(tc-getCC)" CFLAGS="${CFLAGS} ${LDFLAGS}" all
+}
+
+src_install() {
+	einstalldocs
+	cd src
+	dobin pkcrack zipdecrypt findkey makekey
+	newbin extract "${PN}-extract"
+}
+
+pkg_postinst() {
+	ewarn "Due to file collision, extract utility was renamed to ${PN}-extract,"
+	ewarn "see bug#247394"
+}


### PR DESCRIPTION
And update EAPI 7 -> 8

Closes: https://bugs.gentoo.org/924227