### PR TITLE
sys-fs/rar2fs: Add ~arm and ~arm64 architectures

### DIFF
--- a/sys-fs/rar2fs/rar2fs-1.29.6.ebuild
+++ b/sys-fs/rar2fs/rar2fs-1.29.6.ebuild
@@ -9,7 +9,7 @@ SRC_URI="https://github.com/hasse69/${PN}/releases/download/v${PV}/${P}.tar.gz"
 
 LICENSE="GPL-3"
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 IUSE="debug"
 
 # Note that upstream unrar sometimes breaks ABI without updating the SONAME


### PR DESCRIPTION
rar2fs has been working reliably on these ARM architectures for several year on ChromeOS.