### PR TITLE
app-crypt/gnupg: fix dirmngr behind a proxy

### DIFF
--- a/app-crypt/gnupg/files/gnupg-2.4.4-dirmngr-proxy.patch
+++ b/app-crypt/gnupg/files/gnupg-2.4.4-dirmngr-proxy.patch
@@ -1,0 +1,91 @@
+diff -urP gnupg-2.4.4.orig/dirmngr/http.c gnupg-2.4.4/dirmngr/http.c
+--- gnupg-2.4.4.orig/dirmngr/http.c	2024-01-25 03:06:42.000000000 -0700
++++ gnupg-2.4.4/dirmngr/http.c	2024-02-15 21:10:28.849074727 -0700
+@@ -2362,7 +2362,6 @@
+  * NULL, decode the string and use this as input from teh server.  On
+  * success the final output token is stored at PROXY->OUTTOKEN and
+  * OUTTOKLEN.  IF the authentication succeeded OUTTOKLEN is zero. */
+-#ifdef USE_TLS
+ static gpg_error_t
+ proxy_get_token (proxy_info_t proxy, const char *inputstring)
+ {
+@@ -2530,11 +2529,9 @@
+ 
+ #endif /*!HAVE_W32_SYSTEM*/
+ }
+-#endif /*USE_TLS*/
+ 
+ 
+ /* Use the CONNECT method to proxy our TLS stream.  */
+-#ifdef USE_TLS
+ static gpg_error_t
+ run_proxy_connect (http_t hd, proxy_info_t proxy,
+                    const char *httphost, const char *server,
+@@ -2556,6 +2553,7 @@
+    * RFC-4559 - SPNEGO-based Kerberos and NTLM HTTP Authentication
+    */
+   auth_basic = !!proxy->uri->auth;
++  hd->keep_alive = 0;
+ 
+   /* For basic authentication we need to send just one request.  */
+   if (auth_basic
+@@ -2577,16 +2575,15 @@
+                          httphost ? httphost : server,
+                          port,
+                          authhdr ? authhdr : "",
+-                         auth_basic? "" : "Connection: keep-alive\r\n");
++                         hd->keep_alive? "Connection: keep-alive\r\n" : "");
+   if (!request)
+     {
+       err = gpg_error_from_syserror ();
+       goto leave;
+     }
+-  hd->keep_alive = !auth_basic; /* We may need to send more requests.  */
+ 
+   if (opt_debug || (hd->flags & HTTP_FLAG_LOG_RESP))
+-    log_debug_with_string (request, "http.c:proxy:request:");
++    log_debug_string (request, "http.c:proxy:request:");
+ 
+   if (!hd->fp_write)
+     {
+@@ -2610,16 +2607,6 @@
+   if (err)
+     goto leave;
+ 
+-  {
+-    unsigned long count = 0;
+-
+-    while (es_getc (hd->fp_read) != EOF)
+-      count++;
+-    if (opt_debug)
+-      log_debug ("http.c:proxy_connect: skipped %lu bytes of response-body\n",
+-                 count);
+-  }
+-
+   /* Reset state.  */
+   es_clearerr (hd->fp_read);
+   ((cookie_t)(hd->read_cookie))->up_to_empty_line = 1;
+@@ -2743,7 +2730,6 @@
+   xfree (tmpstr);
+   return err;
+ }
+-#endif /*USE_TLS*/
+ 
+ 
+ /* Make a request string using a standard proxy.  On success the
+@@ -2903,7 +2889,6 @@
+       goto leave;
+     }
+ 
+-#if USE_TLS
+   if (use_http_proxy && hd->uri->use_tls)
+     {
+       err = run_proxy_connect (hd, proxy, httphost, server, port);
+@@ -2915,7 +2900,6 @@
+        * clear the flag to indicate this.  */
+       use_http_proxy = 0;
+     }
+-#endif	/* USE_TLS */
+ 
+ #if HTTP_USE_NTBTLS
+   err = run_ntbtls_handshake (hd);

--- a/app-crypt/gnupg/gnupg-2.4.4-r1.ebuild
+++ b/app-crypt/gnupg/gnupg-2.4.4-r1.ebuild
@@ -1,0 +1,197 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+# Maintainers should:
+# 1. Join the "Gentoo" project at https://dev.gnupg.org/project/view/27/
+# 2. Subscribe to release tasks like https://dev.gnupg.org/T6159
+# (find the one for the current release then subscribe to it +
+# any subsequent ones linked within so you're covered for a while.)
+
+VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/openpgp-keys/gnupg.asc
+# in-source builds are not supported: https://dev.gnupg.org/T6313#166339
+inherit flag-o-matic out-of-source multiprocessing systemd toolchain-funcs verify-sig
+
+MY_P="${P/_/-}"
+
+DESCRIPTION="The GNU Privacy Guard, a GPL OpenPGP implementation"
+HOMEPAGE="https://gnupg.org/"
+SRC_URI="mirror://gnupg/gnupg/${MY_P}.tar.bz2"
+SRC_URI+=" verify-sig? ( mirror://gnupg/gnupg/${P}.tar.bz2.sig )"
+S="${WORKDIR}/${MY_P}"
+
+LICENSE="GPL-3+"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~arm64-macos ~ppc-macos ~x64-macos ~x64-solaris"
+IUSE="bzip2 doc ldap nls readline selinux +smartcard ssl test +tofu tpm tools usb user-socket wks-server"
+RESTRICT="!test? ( test )"
+REQUIRED_USE="test? ( tofu )"
+
+# Existence of executables is checked during configuration.
+# Note: On each bump, update dep bounds on each version from configure.ac!
+DEPEND="
+	>=dev-libs/libassuan-2.5.0
+	>=dev-libs/libgcrypt-1.9.1:=
+	>=dev-libs/libgpg-error-1.46
+	>=dev-libs/libksba-1.6.3
+	>=dev-libs/npth-1.2
+	>=net-misc/curl-7.10
+	sys-libs/zlib
+	bzip2? ( app-arch/bzip2 )
+	ldap? ( net-nds/openldap:= )
+	readline? ( sys-libs/readline:0= )
+	smartcard? ( usb? ( virtual/libusb:1 ) )
+	tofu? ( >=dev-db/sqlite-3.27 )
+	tpm? ( >=app-crypt/tpm2-tss-2.4.0:= )
+	ssl? ( >=net-libs/gnutls-3.2:0= )
+"
+RDEPEND="
+	${DEPEND}
+	nls? ( virtual/libintl )
+	selinux? ( sec-policy/selinux-gpg )
+	wks-server? ( virtual/mta )
+"
+PDEPEND="
+	app-crypt/pinentry
+"
+BDEPEND="
+	virtual/pkgconfig
+	doc? ( sys-apps/texinfo )
+	nls? ( sys-devel/gettext )
+	verify-sig? ( sec-keys/openpgp-keys-gnupg )
+"
+
+DOCS=(
+	ChangeLog NEWS README THANKS TODO VERSION
+	doc/FAQ doc/DETAILS doc/HACKING doc/TRANSLATE doc/OpenPGP doc/KEYSERVER
+)
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-2.1.20-gpgscm-Use-shorter-socket-path-lengts-to-improve-tes.patch
+	"${FILESDIR}"/${P}-dirmngr-proxy.patch #924606
+)
+
+src_prepare() {
+	default
+
+	GNUPG_SYSTEMD_UNITS=(
+		dirmngr.service
+		dirmngr.socket
+		gpg-agent-browser.socket
+		gpg-agent-extra.socket
+		gpg-agent.service
+		gpg-agent.socket
+		gpg-agent-ssh.socket
+	)
+
+	cp "${GNUPG_SYSTEMD_UNITS[@]/#/${FILESDIR}/}" "${T}" || die
+
+	# Inject SSH_AUTH_SOCK into user's sessions after enabling gpg-agent-ssh.socket in systemctl --user mode,
+	# idea borrowed from libdbus, see
+	#   https://gitlab.freedesktop.org/dbus/dbus/-/blob/master/bus/systemd-user/dbus.socket.in#L6
+	#
+	# This cannot be upstreamed, as it requires determining the exact prefix of 'systemctl',
+	# which in turn requires discovery in Autoconf, something that upstream deeply resents.
+	sed -e "/DirectoryMode=/a ExecStartPost=-${EPREFIX}/bin/systemctl --user set-environment SSH_AUTH_SOCK=%t/gnupg/S.gpg-agent.ssh" \
+		-i "${T}"/gpg-agent-ssh.socket || die
+}
+
+my_src_configure() {
+	# Upstream don't support LTO, bug #854222.
+	filter-lto
+
+	local myconf=(
+		$(use_enable bzip2)
+		$(use_enable nls)
+		$(use_enable smartcard scdaemon)
+		$(use_enable ssl gnutls)
+		$(use_enable test all-tests)
+		$(use_enable test tests)
+		$(use_enable tofu)
+		$(use_enable tofu keyboxd)
+		$(use_enable tofu sqlite)
+		$(usex tpm '--with-tss=intel' '--disable-tpm2d')
+		$(use smartcard && use_enable usb ccid-driver || echo '--disable-ccid-driver')
+		$(use_enable wks-server wks-tools)
+		$(use_with ldap)
+		$(use_with readline)
+
+		# Hardcode mailprog to /usr/libexec/sendmail even if it does not exist.
+		# As of GnuPG 2.3, the mailprog substitution is used for the binary called
+		# by wks-client & wks-server; and if it's autodetected but not not exist at
+		# build time, then then 'gpg-wks-client --send' functionality will not
+		# work. This has an unwanted side-effect in stage3 builds: there was a
+		# [R]DEPEND on virtual/mta, which also brought in virtual/logger, bloating
+		# the build where the install guide previously make the user chose the
+		# logger & mta early in the install.
+		--with-mailprog=/usr/libexec/sendmail
+
+		--disable-ntbtls
+		--enable-gpgsm
+		--enable-large-secmem
+
+		CC_FOR_BUILD="$(tc-getBUILD_CC)"
+		GPG_ERROR_CONFIG="${ESYSROOT}/usr/bin/${CHOST}-gpg-error-config"
+		KSBA_CONFIG="${ESYSROOT}/usr/bin/ksba-config"
+		LIBASSUAN_CONFIG="${ESYSROOT}/usr/bin/libassuan-config"
+		LIBGCRYPT_CONFIG="${ESYSROOT}/usr/bin/${CHOST}-libgcrypt-config"
+		NPTH_CONFIG="${ESYSROOT}/usr/bin/npth-config"
+
+		$("${S}/configure" --help | grep -o -- '--without-.*-prefix')
+	)
+
+	if use prefix && use usb; then
+		# bug #649598
+		append-cppflags -I"${ESYSROOT}/usr/include/libusb-1.0"
+	fi
+
+	# bug #663142
+	if use user-socket; then
+		myconf+=( --enable-run-gnupg-user-socket )
+	fi
+
+	# glib fails and picks up clang's internal stdint.h causing weird errors
+	tc-is-clang && export gl_cv_absolute_stdint_h="${ESYSROOT}"/usr/include/stdint.h
+
+	econf "${myconf[@]}"
+}
+
+my_src_compile() {
+	default
+
+	use doc && emake -C doc html
+}
+
+my_src_test() {
+	export TESTFLAGS="--parallel=$(makeopts_jobs)"
+
+	default
+}
+
+my_src_install() {
+	emake DESTDIR="${D}" install
+
+	use tools && dobin tools/{gpgconf,gpgsplit,gpg-check-pattern} tools/make-dns-cert
+
+	dosym gpg /usr/bin/gpg2
+	dosym gpgv /usr/bin/gpgv2
+	echo ".so man1/gpg.1" > "${ED}"/usr/share/man/man1/gpg2.1 || die
+	echo ".so man1/gpgv.1" > "${ED}"/usr/share/man/man1/gpgv2.1 || die
+
+	dodir /etc/env.d
+	echo "CONFIG_PROTECT=/usr/share/gnupg/qualified.txt" >> "${ED}"/etc/env.d/30gnupg || die
+
+	use doc && dodoc doc/gnupg.html/*
+}
+
+my_src_install_all() {
+	einstalldocs
+
+	use tools && dobin tools/{convert-from-106,mail-signed-keys,lspgpot}
+	use doc && dodoc doc/*.png
+
+	# Dropped upstream in https://git.gnupg.org/cgi-bin/gitweb.cgi?p=gnupg.git;a=commitdiff;h=eae28f1bd4a5632e8f8e85b7248d1c4d4a10a5ed.
+	dodoc "${FILESDIR}"/README-systemd
+	systemd_douserunit "${GNUPG_SYSTEMD_UNITS[@]/#/${T}/}"
+}


### PR DESCRIPTION
Adapted from upstream patches:
https://dev.gnupg.org/rG04cbc3074aa98660b513a80f623a7e9f0702c7c9 https://dev.gnupg.org/rG848546b05ab0ff6abd47724ecfab73bf32dd4c01


Closes: https://bugs.gentoo.org/924606
Bug: https://bugs.gentoo.org/835949