### PR TITLE
app-editors/vim: add missing xorg-proto dep

### DIFF
--- a/app-editors/vim/vim-9.0.2167.ebuild
+++ b/app-editors/vim/vim-9.0.2167.ebuild
@@ -58,7 +58,9 @@ RDEPEND="
 	tcl? ( dev-lang/tcl:0= )
 	X? ( x11-libs/libXt )
 "
-DEPEND="${RDEPEND}"
+DEPEND="${RDEPEND}
+	X? ( x11-base/xorg-proto )
+"
 # configure runs the Lua interpreter
 BDEPEND="
 	dev-build/autoconf

--- a/app-editors/vim/vim-9999.ebuild
+++ b/app-editors/vim/vim-9999.ebuild
@@ -58,7 +58,9 @@ RDEPEND="
 	tcl? ( dev-lang/tcl:0= )
 	X? ( x11-libs/libXt )
 "
-DEPEND="${RDEPEND}"
+DEPEND="${RDEPEND}
+	X? ( x11-base/xorg-proto )
+"
 # configure runs the Lua interpreter
 BDEPEND="
 	dev-build/autoconf


### PR DESCRIPTION
Add a dependency on x11-base/xorg-proto when building with USE=X.

Closes: https://bugs.gentoo.org/924670