### PR TITLE
net-vpn/tailscale: Require go 1.22 or newer

### DIFF
--- a/net-vpn/tailscale/metadata.xml
+++ b/net-vpn/tailscale/metadata.xml
@@ -9,4 +9,7 @@
 		<name>Patrick McLean</name>
 		<email>chutzpah@gentoo.org</email>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">tailscale/tailscale</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/net-vpn/tailscale/tailscale-1.60.0.ebuild
+++ b/net-vpn/tailscale/tailscale-1.60.0.ebuild
@@ -21,7 +21,7 @@ SLOT="0"
 KEYWORDS="~amd64 ~arm ~arm64 ~riscv ~x86"
 
 RDEPEND="net-firewall/iptables"
-BDEPEND=">=dev-lang/go-1.21"
+BDEPEND=">=dev-lang/go-1.22"
 
 RESTRICT="test"
 


### PR DESCRIPTION
Currently fails to build with: go.mod requires go >= 1.22.0 (running go 1.21.6; GOTOOLCHAIN=local)