### PR TITLE
x11-misc/xdg-utils: X use flag for xprop,xset dependencies

### DIFF
--- a/net-misc/freerdp/freerdp-2.11.1.ebuild
+++ b/net-misc/freerdp/freerdp-2.11.1.ebuild
@@ -52,7 +52,9 @@ RDEPEND="
 	gstreamer? (
 		media-libs/gstreamer:1.0
 		media-libs/gst-plugins-base:1.0
-		x11-libs/libXrandr
+		X? (
+			x11-libs/libXrandr
+		)
 	)
 	icu? ( dev-libs/icu:0= )
 	jpeg? ( media-libs/libjpeg-turbo:0= )

--- a/net-misc/freerdp/freerdp-2.11.2.ebuild
+++ b/net-misc/freerdp/freerdp-2.11.2.ebuild
@@ -52,7 +52,9 @@ RDEPEND="
 	gstreamer? (
 		media-libs/gstreamer:1.0
 		media-libs/gst-plugins-base:1.0
-		x11-libs/libXrandr
+		X? (
+			x11-libs/libXrandr
+		)
 	)
 	icu? ( dev-libs/icu:0= )
 	jpeg? ( media-libs/libjpeg-turbo:0= )

--- a/net-misc/freerdp/freerdp-2.11.5.ebuild
+++ b/net-misc/freerdp/freerdp-2.11.5.ebuild
@@ -52,7 +52,9 @@ RDEPEND="
 	gstreamer? (
 		media-libs/gstreamer:1.0
 		media-libs/gst-plugins-base:1.0
-		x11-libs/libXrandr
+		X? (
+			x11-libs/libXrandr
+		)
 	)
 	icu? ( dev-libs/icu:0= )
 	jpeg? ( media-libs/libjpeg-turbo:0= )

--- a/net-misc/freerdp/freerdp-2.9999.ebuild
+++ b/net-misc/freerdp/freerdp-2.9999.ebuild
@@ -52,7 +52,9 @@ RDEPEND="
 	gstreamer? (
 		media-libs/gstreamer:1.0
 		media-libs/gst-plugins-base:1.0
-		x11-libs/libXrandr
+		X? (
+			x11-libs/libXrandr
+		)
 	)
 	icu? ( dev-libs/icu:0= )
 	jpeg? ( media-libs/libjpeg-turbo:0= )

--- a/net-misc/freerdp/freerdp-3.2.0.ebuild
+++ b/net-misc/freerdp/freerdp-3.2.0.ebuild
@@ -54,7 +54,9 @@ RDEPEND="
 	gstreamer? (
 		media-libs/gstreamer:1.0
 		media-libs/gst-plugins-base:1.0
-		x11-libs/libXrandr
+		X? (
+			x11-libs/libXrandr
+		)
 	)
 	icu? ( dev-libs/icu:0= )
 	jpeg? ( media-libs/libjpeg-turbo:0= )

--- a/net-misc/freerdp/freerdp-9999.ebuild
+++ b/net-misc/freerdp/freerdp-9999.ebuild
@@ -54,7 +54,9 @@ RDEPEND="
 	gstreamer? (
 		media-libs/gstreamer:1.0
 		media-libs/gst-plugins-base:1.0
-		x11-libs/libXrandr
+		X? (
+			x11-libs/libXrandr
+		)
 	)
 	icu? ( dev-libs/icu:0= )
 	jpeg? ( media-libs/libjpeg-turbo:0= )

--- a/x11-misc/xdg-utils/xdg-utils-1.1.3_p20210805-r1.ebuild
+++ b/x11-misc/xdg-utils/xdg-utils-1.1.3_p20210805-r1.ebuild
@@ -16,7 +16,7 @@ S="${WORKDIR}"/xdg-utils-${MY_COMMIT}
 LICENSE="MIT"
 SLOT="0"
 KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~loong ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux"
-IUSE="dbus doc gnome"
+IUSE="dbus doc gnome X"
 REQUIRED_USE="gnome? ( dbus )"
 
 RDEPEND="
@@ -30,8 +30,10 @@ RDEPEND="
 		)
 	)
 	x11-misc/shared-mime-info
-	x11-apps/xprop
-	x11-apps/xset
+	X? (
+		x11-apps/xprop
+		x11-apps/xset
+	)
 "
 BDEPEND="
 	>=app-text/xmlto-0.0.28-r3[text(+)]

--- a/x11-misc/xdg-utils/xdg-utils-1.2.1.ebuild
+++ b/x11-misc/xdg-utils/xdg-utils-1.2.1.ebuild
@@ -19,7 +19,7 @@ fi
 LICENSE="MIT"
 SLOT="0"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux"
-IUSE="dbus doc gnome"
+IUSE="dbus doc gnome X"
 REQUIRED_USE="gnome? ( dbus )"
 
 RDEPEND="
@@ -33,8 +33,10 @@ RDEPEND="
 		)
 	)
 	x11-misc/shared-mime-info
-	x11-apps/xprop
-	x11-apps/xset
+	X? (
+		x11-apps/xprop
+		x11-apps/xset
+	)
 "
 BDEPEND="
 	>=app-text/xmlto-0.0.28-r3[text(+)]


### PR DESCRIPTION
Create new use flag, X for xset & xprop dependencies

These 2 packages are no use on wayland only systems.