### PR TITLE
net-misc/freerdp: Require x11-libs/libXrandr if gstreamer and X Use flag are set

### DIFF
--- a/net-misc/freerdp/freerdp-2.11.1.ebuild
+++ b/net-misc/freerdp/freerdp-2.11.1.ebuild
@@ -52,7 +52,9 @@ RDEPEND="
 	gstreamer? (
 		media-libs/gstreamer:1.0
 		media-libs/gst-plugins-base:1.0
-		x11-libs/libXrandr
+		X? (
+			x11-libs/libXrandr
+		)
 	)
 	icu? ( dev-libs/icu:0= )
 	jpeg? ( media-libs/libjpeg-turbo:0= )

--- a/net-misc/freerdp/freerdp-2.11.2.ebuild
+++ b/net-misc/freerdp/freerdp-2.11.2.ebuild
@@ -52,7 +52,9 @@ RDEPEND="
 	gstreamer? (
 		media-libs/gstreamer:1.0
 		media-libs/gst-plugins-base:1.0
-		x11-libs/libXrandr
+		X? (
+			x11-libs/libXrandr
+		)
 	)
 	icu? ( dev-libs/icu:0= )
 	jpeg? ( media-libs/libjpeg-turbo:0= )

--- a/net-misc/freerdp/freerdp-2.11.5.ebuild
+++ b/net-misc/freerdp/freerdp-2.11.5.ebuild
@@ -52,7 +52,9 @@ RDEPEND="
 	gstreamer? (
 		media-libs/gstreamer:1.0
 		media-libs/gst-plugins-base:1.0
-		x11-libs/libXrandr
+		X? (
+			x11-libs/libXrandr
+		)
 	)
 	icu? ( dev-libs/icu:0= )
 	jpeg? ( media-libs/libjpeg-turbo:0= )

--- a/net-misc/freerdp/freerdp-2.9999.ebuild
+++ b/net-misc/freerdp/freerdp-2.9999.ebuild
@@ -52,7 +52,9 @@ RDEPEND="
 	gstreamer? (
 		media-libs/gstreamer:1.0
 		media-libs/gst-plugins-base:1.0
-		x11-libs/libXrandr
+		X? (
+			x11-libs/libXrandr
+		)
 	)
 	icu? ( dev-libs/icu:0= )
 	jpeg? ( media-libs/libjpeg-turbo:0= )

--- a/net-misc/freerdp/freerdp-3.2.0.ebuild
+++ b/net-misc/freerdp/freerdp-3.2.0.ebuild
@@ -54,7 +54,9 @@ RDEPEND="
 	gstreamer? (
 		media-libs/gstreamer:1.0
 		media-libs/gst-plugins-base:1.0
-		x11-libs/libXrandr
+		X? (
+			x11-libs/libXrandr
+		)
 	)
 	icu? ( dev-libs/icu:0= )
 	jpeg? ( media-libs/libjpeg-turbo:0= )

--- a/net-misc/freerdp/freerdp-9999.ebuild
+++ b/net-misc/freerdp/freerdp-9999.ebuild
@@ -54,7 +54,9 @@ RDEPEND="
 	gstreamer? (
 		media-libs/gstreamer:1.0
 		media-libs/gst-plugins-base:1.0
-		x11-libs/libXrandr
+		X? (
+			x11-libs/libXrandr
+		)
 	)
 	icu? ( dev-libs/icu:0= )
 	jpeg? ( media-libs/libjpeg-turbo:0= )


### PR DESCRIPTION
Require x11-libs/libXrandr if both gstreamer and X flags are set since wayland only systems would not use x11-libs/libXrandr. 