### PR TITLE
dev-util/xmlindent: EAPI8 bump, use https, fix LICENSE

### DIFF
--- a/dev-util/xmlindent/xmlindent-0.2.17-r3.ebuild
+++ b/dev-util/xmlindent/xmlindent-0.2.17-r3.ebuild
@@ -1,0 +1,34 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs
+
+DESCRIPTION="XML stream reformatter for ASCII text, but not UTF-8, written in ANSI C"
+HOMEPAGE="https://xmlindent.sourceforge.net/"
+SRC_URI="mirror://sourceforge/xmlindent/${P}.tar.gz"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+DEPEND="app-alternatives/lex"
+
+src_prepare() {
+	default
+	sed -i Makefile \
+		-e 's|gcc|$(CC)|g' \
+		-e 's|-g|$(CFLAGS) $(LDFLAGS) |g' \
+		|| die "sed failed"
+}
+
+src_compile() {
+	tc-export CC
+	emake
+}
+
+src_install() {
+	dobin "${PN}"
+	doman *.1
+}


### PR DESCRIPTION
Simple `EAPI8` bump.

```diff
--- xmlindent-0.2.17-r2.ebuild	2024-02-05 20:40:42.627710570 +0100
+++ xmlindent-0.2.17-r3.ebuild	2024-02-17 11:54:24.536886285 +0100
@@ -1,16 +1,17 @@
 # Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
 
 inherit toolchain-funcs
 
 DESCRIPTION="XML stream reformatter for ASCII text, but not UTF-8, written in ANSI C"
-HOMEPAGE="http://xmlindent.sourceforge.net/"
+HOMEPAGE="https://xmlindent.sourceforge.net/"
 SRC_URI="mirror://sourceforge/xmlindent/${P}.tar.gz"
-LICENSE="GPL-2"
+
+LICENSE="GPL-2+"
 SLOT="0"
-KEYWORDS="amd64 x86"
+KEYWORDS="~amd64 ~x86"
 
 DEPEND="app-alternatives/lex"
 
```