### PR TITLE
dev-tcltk/tktreectrl: EAPI8 bump, use https

### DIFF
--- a/dev-tcltk/tktreectrl/tktreectrl-2.4.1-r1.ebuild
+++ b/dev-tcltk/tktreectrl/tktreectrl-2.4.1-r1.ebuild
@@ -1,0 +1,48 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit virtualx
+
+DESCRIPTION="Flexible listbox widget for Tk"
+HOMEPAGE="https://tktreectrl.sourceforge.net/"
+SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
+
+LICENSE="tcltk"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86 ~amd64-linux ~x86-linux"
+IUSE="debug shellicon threads"
+
+RDEPEND=">=dev-lang/tk-8.4:0="
+DEPEND="${RDEPEND}"
+
+PATCHES=( "${FILESDIR}"/2.2.9-as-needed.patch )
+
+QA_CONFIG_IMPL_DECL_SKIP=(
+	stat64 # used to test for Large File Support
+)
+
+src_configure() {
+	local myeconfargs=(
+		$(use_enable threads)
+		$(use_enable shellicon)
+		$(use_enable amd64 64bit)
+		$(use_enable debug symbols)
+		--with-x
+		--enable-shared
+	)
+
+	econf ${myeconfargs[@]}
+}
+
+src_test() {
+	virtx emake test
+}
+
+src_install() {
+	default
+	mv \
+		"${ED}"/usr/lib*/treectrl${PV}/htmldoc \
+		"${ED}"/usr/share/doc/${PF}/ || die
+}


### PR DESCRIPTION
Another `EAPI8` bump.

I've also looked into bug #828839.
From what i've found is that `X` cannot really be disabled with this package (and to be honest, i think it doesn't make sense either). Trying to disable `X` results in following configure warning:
```
checking for X... disabled
checking for X11 header files... checking for X11 libraries... checking for XCreateWindow in -lXwindow... no
could not find any!  Using -lX11
```

This means `-lX11` is being used regardless of the flag. And since `dev-lang/tk` depends anyway on `libX11` it never fails.

I've looked into other package and i've decided to go with simply enable `X` per default. It similar to what for example `dev-tcltk/blk` does.
However i couldn't reproduce the QA warning from the bug in any case. This might be because this happend on `musl` on the bug. It would be nice if someone with a `musl` system could test it.

The other bug #906870 however i could reproduce and i've simply fixed it with:
```
QA_CONFIG_IMPL_DECL_SKIP=(
	stat64 # used to test for Large File Support
)
```


Signed-off-by: Michael Mair-Keimberger <mmk@levelnine.at>

Bug: https://bugs.gentoo.org/828839
Closes: https://bugs.gentoo.org/906870