### PR TITLE
gnome-extra/mousetweaks: EAPI8 bump

### DIFF
--- a/gnome-extra/mousetweaks/mousetweaks-3.32.0-r1.ebuild
+++ b/gnome-extra/mousetweaks/mousetweaks-3.32.0-r1.ebuild
@@ -1,0 +1,28 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit gnome2
+
+DESCRIPTION="Mouse accessibility enhancements for the GNOME desktop"
+HOMEPAGE="https://wiki.gnome.org/Projects/Mousetweaks"
+
+LICENSE="GPL-3+"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~ia64 ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86"
+
+RDEPEND="
+	>=dev-libs/glib-2.25.9:2
+	>=x11-libs/gtk+-3:3[X]
+	>=gnome-base/gsettings-desktop-schemas-0.1
+	x11-libs/libX11
+	x11-libs/libXtst
+	x11-libs/libXfixes
+	x11-libs/libXcursor
+"
+DEPEND="${RDEPEND}"
+BDEPEND="dev-util/glib-utils
+	>=sys-devel/gettext-0.19.8
+	virtual/pkgconfig
+"


### PR DESCRIPTION
Another rather simple `EAPI8` bump.

```diff
--- mousetweaks-3.32.0.ebuild	2024-01-17 20:05:13.070817519 +0100
+++ mousetweaks-3.32.0-r1.ebuild	2024-02-17 14:02:34.236615702 +0100
@@ -1,7 +1,8 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
+
 inherit gnome2
 
 DESCRIPTION="Mouse accessibility enhancements for the GNOME desktop"
@@ -9,21 +10,19 @@
 
 LICENSE="GPL-3+"
 SLOT="0"
-KEYWORDS="~alpha amd64 ~arm arm64 ~ia64 ~loong ~ppc ~ppc64 ~riscv ~sparc x86"
-IUSE=""
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~ia64 ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86"
 
 RDEPEND="
 	>=dev-libs/glib-2.25.9:2
 	>=x11-libs/gtk+-3:3[X]
 	>=gnome-base/gsettings-desktop-schemas-0.1
-
 	x11-libs/libX11
 	x11-libs/libXtst
 	x11-libs/libXfixes
 	x11-libs/libXcursor
 "
-DEPEND="${RDEPEND}
-	dev-util/glib-utils
+DEPEND="${RDEPEND}"
+BDEPEND="dev-util/glib-utils
 	>=sys-devel/gettext-0.19.8
 	virtual/pkgconfig
 "
```