### PR TITLE
app-emacs/ws-butler: Use elisp test runner instead of default src_test

### DIFF
--- a/app-emacs/ws-butler/ws-butler-0.6_p20201117.ebuild
+++ b/app-emacs/ws-butler/ws-butler-0.6_p20201117.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -23,3 +23,5 @@ SLOT="0"
 KEYWORDS="~amd64 ~x86"
 
 SITEFILE="50${PN}-gentoo.el"
+
+elisp-enable-tests ert tests -l tests/run-test.el


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/922377