### PR TITLE
media-libs/noise-suppression-for-voice: Fix tests with gcc[-sanitize]

### DIFF
--- a/media-libs/noise-suppression-for-voice/files/noise-suppression-for-voice-1.03-tests.patch
+++ b/media-libs/noise-suppression-for-voice/files/noise-suppression-for-voice-1.03-tests.patch
@@ -1,0 +1,28 @@
+From bf7a468427048f91b0759b9f5eb320cf61ca3ea9 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Kacper=20S=C5=82omi=C5=84ski?=
+ <kacper.slominski72@gmail.com>
+Date: Sat, 17 Feb 2024 15:25:53 +0100
+Subject: [PATCH] Get rid of -fsanitize=undefined for tests
+
+Upstream PR: https://github.com/werman/noise-suppression-for-voice/pull/189
+
+---
+ src/common/CMakeLists.txt | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/src/common/CMakeLists.txt b/src/common/CMakeLists.txt
+index 4c2300e..273d76e 100644
+--- a/src/common/CMakeLists.txt
++++ b/src/common/CMakeLists.txt
+@@ -33,8 +33,6 @@ if (BUILD_TESTS)
+             $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/external/catch2>
+             $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
+     target_link_libraries(common_plugin_tests PRIVATE ${LIBRARIES})
+-    target_compile_options(common_plugin_tests PRIVATE -fsanitize=undefined)
+-    target_link_options(common_plugin_tests PRIVATE -fsanitize=undefined)
+ 
+     include(CTest)
+     include(Catch)
+-- 
+2.43.0
+

--- a/media-libs/noise-suppression-for-voice/noise-suppression-for-voice-1.03.ebuild
+++ b/media-libs/noise-suppression-for-voice/noise-suppression-for-voice-1.03.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2020-2023 Gentoo Authors
+# Copyright 2020-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -14,13 +14,18 @@ if [[ "${PV}" == "9999" ]]; then
 else
 	SRC_URI="https://github.com/werman/noise-suppression-for-voice/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 	KEYWORDS="~amd64 ~x86"
+
+	PATCHES=(
+		"${FILESDIR}/${P}-tests.patch"
+	)
 fi
 
 LICENSE="GPL-3+"
 SLOT="0"
 
-IUSE="+ladspa lv2 vst vst3"
+IUSE="+ladspa lv2 vst vst3 test"
 REQUIRED_USE="|| ( ladspa lv2 vst vst3 )"
+RESTRICT="!test? ( test )"
 
 COMMON_DEPEND="
 	media-libs/freetype
@@ -44,8 +49,14 @@ src_configure() {
 		-DBUILD_LV2_PLUGIN=$(usex lv2 ON OFF)
 		-DBUILD_VST_PLUGIN=$(usex vst ON OFF)
 		-DBUILD_VST3_PLUGIN=$(usex vst3 ON OFF)
+		-DBUILD_TESTS=$(usex test ON OFF)
 		-DBUILD_AU_PLUGIN=OFF
 		-DBUILD_AUV3_PLUGIN=OFF
 	)
 	cmake_src_configure
+}
+
+src_test() {
+	cp "${BUILD_DIR}/src/common/CTestTestfile.cmake" "${BUILD_DIR}/CTestTestfile.cmake" || die
+	cmake_src_test
 }

--- a/media-libs/noise-suppression-for-voice/noise-suppression-for-voice-9999.ebuild
+++ b/media-libs/noise-suppression-for-voice/noise-suppression-for-voice-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2020-2023 Gentoo Authors
+# Copyright 2020-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -14,13 +14,18 @@ if [[ "${PV}" == "9999" ]]; then
 else
 	SRC_URI="https://github.com/werman/noise-suppression-for-voice/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 	KEYWORDS="~amd64 ~x86"
+
+	PATCHES=(
+		"${FILESDIR}/${P}-tests.patch"
+	)
 fi
 
 LICENSE="GPL-3+"
 SLOT="0"
 
-IUSE="+ladspa lv2 vst vst3"
+IUSE="+ladspa lv2 vst vst3 test"
 REQUIRED_USE="|| ( ladspa lv2 vst vst3 )"
+RESTRICT="!test? ( test )"
 
 COMMON_DEPEND="
 	media-libs/freetype
@@ -44,8 +49,14 @@ src_configure() {
 		-DBUILD_LV2_PLUGIN=$(usex lv2 ON OFF)
 		-DBUILD_VST_PLUGIN=$(usex vst ON OFF)
 		-DBUILD_VST3_PLUGIN=$(usex vst3 ON OFF)
+		-DBUILD_TESTS=$(usex test ON OFF)
 		-DBUILD_AU_PLUGIN=OFF
 		-DBUILD_AUV3_PLUGIN=OFF
 	)
 	cmake_src_configure
+}
+
+src_test() {
+	cp "${BUILD_DIR}/src/common/CTestTestfile.cmake" "${BUILD_DIR}/CTestTestfile.cmake" || die
+	cmake_src_test
 }


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/924145