### PR TITLE
LLVM: fix missing `dev-python/myst-parser` for manpage build in 18+

### DIFF
--- a/eclass/llvm.org.eclass
+++ b/eclass/llvm.org.eclass
@@ -268,17 +268,17 @@ llvm.org_set_globals() {
 	fi
 
 	if [[ ${LLVM_MANPAGES} ]]; then
+		IUSE+=" doc"
+
 		# use pregenerated tarball if available
 		local manpage_dist=$(llvm_manpage_get_dist)
 		if [[ -n ${manpage_dist} ]]; then
-			IUSE+=" doc"
 			SRC_URI+="
 				!doc? (
 					https://dev.gentoo.org/~mgorny/dist/llvm/${manpage_dist}
 				)
 			"
 		else
-			IUSE+=" +doc"
 			# NB: this is not always the correct dep but it does no harm
 			BDEPEND+=" dev-python/sphinx"
 		fi

--- a/eclass/llvm.org.eclass
+++ b/eclass/llvm.org.eclass
@@ -294,9 +294,6 @@ llvm.org_set_globals() {
 					https://dev.gentoo.org/~mgorny/dist/llvm/${LLVM_MANPAGE_DIST}
 				)
 			"
-		else
-			# NB: this is not always the correct dep but it does no harm
-			BDEPEND+=" dev-python/sphinx"
 		fi
 	fi
 

--- a/eclass/llvm.org.eclass
+++ b/eclass/llvm.org.eclass
@@ -268,14 +268,30 @@ llvm.org_set_globals() {
 	fi
 
 	if [[ ${LLVM_MANPAGES} ]]; then
-		IUSE+=" doc"
+		# @ECLASS_VARIABLE: LLVM_MANPAGE_DIST
+		# @OUTPUT_VARIABLE
+		# @DESCRIPTION:
+		# The filename of the prebuilt manpage tarball for this version.
+		LLVM_MANPAGE_DIST=
+		if [[ ${_LLVM_SOURCE_TYPE} == tar && ${PV} != *_rc* ]]; then
+			case ${PV} in
+				14*|15*|16.0.[0-3])
+					LLVM_MANPAGE_DIST="llvm-${PV}-manpages.tar.bz2"
+					;;
+				16*)
+					LLVM_MANPAGE_DIST="llvm-16.0.4-manpages.tar.bz2"
+					;;
+				17*)
+					LLVM_MANPAGE_DIST="llvm-17.0.1-manpages.tar.bz2"
+					;;
+			esac
+		fi
 
-		# use pregenerated tarball if available
-		local manpage_dist=$(llvm_manpage_get_dist)
-		if [[ -n ${manpage_dist} ]]; then
+		IUSE+=" doc"
+		if [[ -n ${LLVM_MANPAGE_DIST} ]]; then
 			SRC_URI+="
 				!doc? (
-					https://dev.gentoo.org/~mgorny/dist/llvm/${manpage_dist}
+					https://dev.gentoo.org/~mgorny/dist/llvm/${LLVM_MANPAGE_DIST}
 				)
 			"
 		else
@@ -436,32 +452,12 @@ get_lit_flags() {
 	echo "-vv;-j;${LIT_JOBS:-$(makeopts_jobs)}"
 }
 
-# @FUNCTION: llvm_manpage_get_dist
-# @DESCRIPTION:
-# Output the filename of the manpage dist for this version,
-# if available.  Otherwise returns without output.
-llvm_manpage_get_dist() {
-	if [[ ${_LLVM_SOURCE_TYPE} == tar && ${PV} != *_rc* ]]; then
-		case ${PV} in
-			14*|15*|16.0.[0-3])
-				echo "llvm-${PV}-manpages.tar.bz2"
-				;;
-			16*)
-				echo "llvm-16.0.4-manpages.tar.bz2"
-				;;
-			17*)
-				echo "llvm-17.0.1-manpages.tar.bz2"
-				;;
-		esac
-	fi
-}
-
 # @FUNCTION: llvm_are_manpages_built
 # @DESCRIPTION:
 # Return true (0) if manpages are going to be built from source,
 # false (1) if preinstalled manpages will be used.
 llvm_are_manpages_built() {
-	use doc || [[ -z $(llvm_manpage_get_dist) ]]
+	use doc || [[ -z ${LLVM_MANPAGE_DIST} ]]
 }
 
 # @FUNCTION: llvm_install_manpages

--- a/sys-devel/clang/clang-18.1.0_rc2.ebuild
+++ b/sys-devel/clang/clang-18.1.0_rc2.ebuild
@@ -33,10 +33,6 @@ RDEPEND="
 "
 BDEPEND="
 	${PYTHON_DEPS}
-	doc? ( $(python_gen_cond_dep '
-		dev-python/myst-parser[${PYTHON_USEDEP}]
-		dev-python/sphinx[${PYTHON_USEDEP}]
-	') )
 	xml? ( virtual/pkgconfig )
 "
 PDEPEND="
@@ -54,6 +50,15 @@ LLVM_TEST_COMPONENTS=(
 )
 LLVM_USE_TARGETS=llvm
 llvm.org_set_globals
+
+[[ -n ${LLVM_MANPAGE_DIST} ]] && BDEPEND+=" doc? ( "
+BDEPEND+="
+	$(python_gen_cond_dep '
+		dev-python/myst-parser[${PYTHON_USEDEP}]
+		dev-python/sphinx[${PYTHON_USEDEP}]
+	')
+"
+[[ -n ${LLVM_MANPAGE_DIST} ]] && BDEPEND+=" ) "
 
 # Multilib notes:
 # 1. ABI_* flags control ABIs libclang* is built for only.

--- a/sys-devel/clang/clang-19.0.0.9999.ebuild
+++ b/sys-devel/clang/clang-19.0.0.9999.ebuild
@@ -33,10 +33,6 @@ RDEPEND="
 "
 BDEPEND="
 	${PYTHON_DEPS}
-	doc? ( $(python_gen_cond_dep '
-		dev-python/myst-parser[${PYTHON_USEDEP}]
-		dev-python/sphinx[${PYTHON_USEDEP}]
-	') )
 	xml? ( virtual/pkgconfig )
 "
 PDEPEND="
@@ -54,6 +50,15 @@ LLVM_TEST_COMPONENTS=(
 )
 LLVM_USE_TARGETS=llvm
 llvm.org_set_globals
+
+[[ -n ${LLVM_MANPAGE_DIST} ]] && BDEPEND+=" doc? ( "
+BDEPEND+="
+	$(python_gen_cond_dep '
+		dev-python/myst-parser[${PYTHON_USEDEP}]
+		dev-python/sphinx[${PYTHON_USEDEP}]
+	')
+"
+[[ -n ${LLVM_MANPAGE_DIST} ]] && BDEPEND+=" ) "
 
 # Multilib notes:
 # 1. ABI_* flags control ABIs libclang* is built for only.

--- a/sys-devel/clang/clang-19.0.0_pre20240210.ebuild
+++ b/sys-devel/clang/clang-19.0.0_pre20240210.ebuild
@@ -33,10 +33,6 @@ RDEPEND="
 "
 BDEPEND="
 	${PYTHON_DEPS}
-	doc? ( $(python_gen_cond_dep '
-		dev-python/myst-parser[${PYTHON_USEDEP}]
-		dev-python/sphinx[${PYTHON_USEDEP}]
-	') )
 	xml? ( virtual/pkgconfig )
 "
 PDEPEND="
@@ -54,6 +50,15 @@ LLVM_TEST_COMPONENTS=(
 )
 LLVM_USE_TARGETS=llvm
 llvm.org_set_globals
+
+[[ -n ${LLVM_MANPAGE_DIST} ]] && BDEPEND+=" doc? ( "
+BDEPEND+="
+	$(python_gen_cond_dep '
+		dev-python/myst-parser[${PYTHON_USEDEP}]
+		dev-python/sphinx[${PYTHON_USEDEP}]
+	')
+"
+[[ -n ${LLVM_MANPAGE_DIST} ]] && BDEPEND+=" ) "
 
 # Multilib notes:
 # 1. ABI_* flags control ABIs libclang* is built for only.

--- a/sys-devel/llvm/llvm-18.1.0_rc2.ebuild
+++ b/sys-devel/llvm/llvm-18.1.0_rc2.ebuild
@@ -50,10 +50,6 @@ BDEPEND="
 	kernel_Darwin? (
 		<sys-libs/libcxx-${LLVM_VERSION}.9999
 	)
-	doc? ( $(python_gen_any_dep '
-		dev-python/myst-parser[${PYTHON_USEDEP}]
-		dev-python/sphinx[${PYTHON_USEDEP}]
-	') )
 	libffi? ( virtual/pkgconfig )
 "
 # There are no file collisions between these versions but having :0
@@ -73,8 +69,17 @@ LLVM_MANPAGES=1
 LLVM_USE_TARGETS=provide
 llvm.org_set_globals
 
+[[ -n ${LLVM_MANPAGE_DIST} ]] && BDEPEND+=" doc? ( "
+BDEPEND+="
+	$(python_gen_any_dep '
+		dev-python/myst-parser[${PYTHON_USEDEP}]
+		dev-python/sphinx[${PYTHON_USEDEP}]
+	')
+"
+[[ -n ${LLVM_MANPAGE_DIST} ]] && BDEPEND+=" ) "
+
 python_check_deps() {
-	use doc || return 0
+	llvm_are_manpages_built || return 0
 
 	python_has_version -b "dev-python/myst-parser[${PYTHON_USEDEP}]" &&
 	python_has_version -b "dev-python/sphinx[${PYTHON_USEDEP}]"

--- a/sys-devel/llvm/llvm-19.0.0.9999.ebuild
+++ b/sys-devel/llvm/llvm-19.0.0.9999.ebuild
@@ -50,10 +50,6 @@ BDEPEND="
 	kernel_Darwin? (
 		<sys-libs/libcxx-${LLVM_VERSION}.9999
 	)
-	doc? ( $(python_gen_any_dep '
-		dev-python/myst-parser[${PYTHON_USEDEP}]
-		dev-python/sphinx[${PYTHON_USEDEP}]
-	') )
 	libffi? ( virtual/pkgconfig )
 "
 # There are no file collisions between these versions but having :0
@@ -73,8 +69,17 @@ LLVM_MANPAGES=1
 LLVM_USE_TARGETS=provide
 llvm.org_set_globals
 
+[[ -n ${LLVM_MANPAGE_DIST} ]] && BDEPEND+=" doc? ( "
+BDEPEND+="
+	$(python_gen_any_dep '
+		dev-python/myst-parser[${PYTHON_USEDEP}]
+		dev-python/sphinx[${PYTHON_USEDEP}]
+	')
+"
+[[ -n ${LLVM_MANPAGE_DIST} ]] && BDEPEND+=" ) "
+
 python_check_deps() {
-	use doc || return 0
+	llvm_are_manpages_built || return 0
 
 	python_has_version -b "dev-python/myst-parser[${PYTHON_USEDEP}]" &&
 	python_has_version -b "dev-python/sphinx[${PYTHON_USEDEP}]"

--- a/sys-devel/llvm/llvm-19.0.0_pre20240210.ebuild
+++ b/sys-devel/llvm/llvm-19.0.0_pre20240210.ebuild
@@ -50,10 +50,6 @@ BDEPEND="
 	kernel_Darwin? (
 		<sys-libs/libcxx-${LLVM_VERSION}.9999
 	)
-	doc? ( $(python_gen_any_dep '
-		dev-python/myst-parser[${PYTHON_USEDEP}]
-		dev-python/sphinx[${PYTHON_USEDEP}]
-	') )
 	libffi? ( virtual/pkgconfig )
 "
 # There are no file collisions between these versions but having :0
@@ -73,8 +69,17 @@ LLVM_MANPAGES=1
 LLVM_USE_TARGETS=provide
 llvm.org_set_globals
 
+[[ -n ${LLVM_MANPAGE_DIST} ]] && BDEPEND+=" doc? ( "
+BDEPEND+="
+	$(python_gen_any_dep '
+		dev-python/myst-parser[${PYTHON_USEDEP}]
+		dev-python/sphinx[${PYTHON_USEDEP}]
+	')
+"
+[[ -n ${LLVM_MANPAGE_DIST} ]] && BDEPEND+=" ) "
+
 python_check_deps() {
-	use doc || return 0
+	llvm_are_manpages_built || return 0
 
 	python_has_version -b "dev-python/myst-parser[${PYTHON_USEDEP}]" &&
 	python_has_version -b "dev-python/sphinx[${PYTHON_USEDEP}]"


### PR DESCRIPTION
CC @gentoo/llvm 