### PR TITLE
app-misc/rox-filer: Fix compilation when gcc-14 is used

### DIFF
--- a/app-misc/rox-filer/files/rox-filer-2.11-gcc14.patch
+++ b/app-misc/rox-filer/files/rox-filer-2.11-gcc14.patch
@@ -1,0 +1,35 @@
+From 7b67706cbd30811ca555e14f8c43c6485ac77092 Mon Sep 17 00:00:00 2001
+From: P Purkayastha <ppurka@gmail.com>
+Date: Sat, 17 Feb 2024 23:11:10 +0000
+Subject: [PATCH 1/1] Fix compilation when gcc 14 is used. See
+ https://bugs.gentoo.org/924712
+
+---
+ log.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/log.c b/log.c
+index 07973a6..34b21a4 100644
+--- a/log.c
++++ b/log.c
+@@ -140,7 +140,7 @@ void log_show_window()
+ 	GtkCellRenderer *renderer;
+ 	gchar *ids[] = {"Log viewer", NULL};
+ 
+-	builder = get_gtk_builder(&ids);
++	builder = get_gtk_builder(ids);
+ 
+ 	tv = GTK_TREE_VIEW(gtk_builder_get_object(builder, "log_list"));
+ 	gtk_tree_view_set_model(tv, GTK_TREE_MODEL(log));
+@@ -163,7 +163,7 @@ void log_show_window()
+ 							   NULL);
+ 	gtk_tree_view_append_column(tv, column);
+ 
+-	dialog = gtk_builder_get_object(builder, "Log viewer");
++	dialog = GTK_WIDGET(gtk_builder_get_object(builder, "Log viewer"));
+ 	g_signal_connect(G_OBJECT(dialog),
+ 			 "response", (GCallback) log_dialog_response, NULL);
+ 
+-- 
+2.43.0
+

--- a/app-misc/rox-filer/rox-filer-2.11-r1.ebuild
+++ b/app-misc/rox-filer/rox-filer-2.11-r1.ebuild
@@ -1,0 +1,76 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit desktop virtualx
+
+DESCRIPTION="ROX-Filer a drag and drop spatial file manager"
+HOMEPAGE="http://rox.sourceforge.net/desktop/ROX-Filer.html"
+SRC_URI="https://download.sourceforge.net/rox/${P}.tar.bz2"
+
+LICENSE="GPL-2+ LGPL-2+"
+SLOT="0"
+KEYWORDS="amd64 ~arm ~arm64 x86"
+
+COMMON_DEPEND="dev-lang/perl
+	dev-libs/libxml2:2
+	gnome-base/libglade:2.0
+	x11-libs/gtk+:2
+	x11-libs/libSM"
+RDEPEND="${COMMON_DEPEND}
+	x11-misc/shared-mime-info"
+DEPEND="${COMMON_DEPEND}
+	dev-util/intltool
+	sys-devel/gettext"
+BDEPEND="virtual/pkgconfig"
+
+S="${WORKDIR}/${P}/ROX-Filer/src"
+
+PATCHES=(
+	"${FILESDIR}/${P}-in-source-build.patch"
+	"${FILESDIR}/${P}-gcc10.patch"
+	"${FILESDIR}/${P}-gcc14.patch"
+)
+
+src_prepare() {
+	default
+
+	sed -i -e 's:g_strdup(getenv("APP_DIR")):"/usr/share/rox":' \
+		main.c || die "sed failed"
+}
+
+src_configure() {
+	econf LIBS="-lm -ldl"
+}
+
+src_install() {
+	cd "${WORKDIR}/${P}"/ROX-Filer || die
+	dodir /usr/share/applications  /usr/share/pixmaps  /usr/share/rox/Help
+	insinto /usr/share/rox
+	doins -r Messages Options.xml ROX images style.css .DirIcon Templates.ui
+	insinto /usr/share/rox/Help
+	doins Help/*.html Help/README*
+
+	doman ../rox.1
+
+	newbin ROX-Filer rox
+
+	dosym text-x-diff.png /usr/share/rox/ROX/MIME/text-x-patch.png
+	dosym application-x-font-afm.png /usr/share/rox/ROX/MIME/application-x-font-type1.png
+	dosym application-xml.png /usr/share/rox/ROX/MIME/application-xml-dtd.png
+	dosym application-xml.png /usr/share/rox/ROX/MIME/application-xml-external-parsed-entity.png
+	dosym application-xml.png /usr/share/rox/ROX/MIME/application-rdf+xml.png
+	dosym application-xml.png /usr/share/rox/ROX/MIME/application-x-xbel.png
+	dosym application-x-shellscript.png /usr/share/rox/ROX/MIME/application-javascript.png
+	dosym application-x-bzip-compressed-tar.png /usr/share/rox/ROX/MIME/application-x-xz-compressed-tar.png
+	dosym application-x-bzip-compressed-tar.png /usr/share/rox/ROX/MIME/application-x-lzma-compressed-tar.png
+	dosym application-x-bzip-compressed-tar.png /usr/share/rox/ROX/MIME/application-x-lzo.png
+	dosym application-x-bzip.png /usr/share/rox/ROX/MIME/application-x-xz.png
+	dosym application-x-gzip.png /usr/share/rox/ROX/MIME/application-x-lzma.png
+	dosym application-msword.png /usr/share/rox/ROX/MIME/application-rtf.png
+
+	dosym ../rox/.DirIcon /usr/share/pixmaps/rox.png
+
+	domenu "${FILESDIR}"/rox.desktop
+}


### PR DESCRIPTION
Minor revision app-misc/rox-filer-2.11-r1

Bug: https://bugs.gentoo.org/924712
Signed-off-by: Punarbasu Purkayastha <ppurka@gmail.com>

Ebuild diff:
```diff
...rtage/app-misc/rox-filer » diff -u rox-filer-2.11.ebuild rox-filer-2.11-r1.ebuild
--- rox-filer-2.11.ebuild       2021-03-13 10:31:46.827833250 +0000
+++ rox-filer-2.11-r1.ebuild    2024-02-17 23:13:50.518786223 +0000
@@ -30,6 +30,7 @@
 PATCHES=(
        "${FILESDIR}/${P}-in-source-build.patch"
        "${FILESDIR}/${P}-gcc10.patch"
+       "${FILESDIR}/${P}-gcc14.patch"
 )
 
 src_prepare() {
```