### PR TITLE
net-print/libcupsfilters: add a patch to fix building with c++17

### DIFF
--- a/net-print/libcupsfilters/files/libcupsfilters-2.0.0-r3-c++17.patch
+++ b/net-print/libcupsfilters/files/libcupsfilters-2.0.0-r3-c++17.patch
@@ -1,0 +1,14 @@
+--- a/cupsfilters/pdftoraster.cxx
++++ b/cupsfilters/pdftoraster.cxx
+@@ -2198,7 +2198,11 @@
+ // For compatibility with g++ >= 4.7 compilers _GLIBCXX_THROW
+ // should be used as a guard, otherwise use traditional definition
+ #ifndef _GLIBCXX_THROW
++#if __cplusplus < 201703L
+ #define _GLIBCXX_THROW throw
++#else
++#define _GLIBCXX_THROW(...) noexcept(false)
++#endif
+ #endif
+ 
+ void * operator new(size_t size) _GLIBCXX_THROW (std::bad_alloc)

--- a/net-print/libcupsfilters/libcupsfilters-2.0.0-r3.ebuild
+++ b/net-print/libcupsfilters/libcupsfilters-2.0.0-r3.ebuild
@@ -39,6 +39,10 @@ BDEPEND="
 	test? ( media-fonts/dejavu )
 "
 
+PATCHES=(
+	"${FILESDIR}/${P}-r3-c++17.patch"
+)
+
 src_prepare() {
 	default
 


### PR DESCRIPTION
c++17 does not support dynamic exception specification any longer