### PR TITLE
net-dns/bind: Fix USE=doc+verify-sig

### DIFF
--- a/net-dns/bind/bind-9.16.48.ebuild
+++ b/net-dns/bind/bind-9.16.48.ebuild
@@ -99,6 +99,13 @@ PATCHES=(
 	"${FILESDIR}/ldap-library-path-on-multilib-machines.patch"
 )
 
+src_unpack() {
+	if use verify-sig; then
+		verify-sig_verify_detached "${DISTDIR}"/${P}.tar.xz{,.asc}
+	fi
+	default
+}
+
 src_prepare() {
 	default
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/924995
Bug: https://bugs.gentoo.org/924895