### PR TITLE
net-libs/webkit-gtk: Fixes build on x86 for 2.42.5

### DIFF
--- a/net-libs/webkit-gtk/files/2.42.5-x86-build-fix.patch
+++ b/net-libs/webkit-gtk/files/2.42.5-x86-build-fix.patch
@@ -1,0 +1,33 @@
+From 3d5373575695b293b8559155431d0079a6153aff Mon Sep 17 00:00:00 2001
+From: Michael Catanzaro <mcatanzaro@redhat.com>
+Date: Mon, 5 Feb 2024 11:00:49 -0600
+Subject: [PATCH] =?UTF-8?q?[GTK]=20[2.42.5]=20LowLevelInterpreter.cpp:339:?=
+ =?UTF-8?q?21:=20error:=20=E2=80=98t6=E2=80=99=20was=20not=20declared=20in?=
+ =?UTF-8?q?=20this=20scope=20https://bugs.webkit.org/show=5Fbug.cgi=3Fid?=
+ =?UTF-8?q?=3D268739?=
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Unreviewed build fix. Seems a backport went badly, and we didn't notice
+because the code is architecture-specific.
+
+* Source/JavaScriptCore/llint/LowLevelInterpreter.cpp:
+(JSC::CLoop::execute):
+---
+ Source/JavaScriptCore/llint/LowLevelInterpreter.cpp | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/Source/JavaScriptCore/llint/LowLevelInterpreter.cpp b/Source/JavaScriptCore/llint/LowLevelInterpreter.cpp
+index 5064ead6cd2e..9a2e2653b121 100644
+--- a/Source/JavaScriptCore/llint/LowLevelInterpreter.cpp
++++ b/Source/JavaScriptCore/llint/LowLevelInterpreter.cpp
+@@ -336,8 +336,6 @@ JSValue CLoop::execute(OpcodeID entryOpcodeID, void* executableAddress, VM* vm,
+     UNUSED_VARIABLE(t2);
+     UNUSED_VARIABLE(t3);
+     UNUSED_VARIABLE(t5);
+-    UNUSED_VARIABLE(t6);
+-    UNUSED_VARIABLE(t7);
+ 
+     struct StackPointerScope {
+         StackPointerScope(CLoopStack& stack)

--- a/net-libs/webkit-gtk/webkit-gtk-2.42.5-r410.ebuild
+++ b/net-libs/webkit-gtk/webkit-gtk-2.42.5-r410.ebuild
@@ -157,6 +157,8 @@ src_prepare() {
 	eapply "${FILESDIR}"/2.42.1-arm64-non-jumbo-fix.patch
 	# Fix assert failure on some machines, bug #920704
 	eapply "${FILESDIR}"/2.42.4-wasm-assert-fix.patch
+	# Fix compilation on x86, bug #924873
+	eapply "${FILESDIR}"/2.42.5-x86-build-fix.patch
 }
 
 src_configure() {

--- a/net-libs/webkit-gtk/webkit-gtk-2.42.5-r600.ebuild
+++ b/net-libs/webkit-gtk/webkit-gtk-2.42.5-r600.ebuild
@@ -158,6 +158,8 @@ src_prepare() {
 	eapply "${FILESDIR}"/2.42.1-arm64-non-jumbo-fix.patch
 	# Fix assert failure on some machines, bug #920704
 	eapply "${FILESDIR}"/2.42.4-wasm-assert-fix.patch
+	# Fix compilation on x86, bug #924873
+	eapply "${FILESDIR}"/2.42.5-x86-build-fix.patch
 }
 
 src_configure() {

--- a/net-libs/webkit-gtk/webkit-gtk-2.42.5.ebuild
+++ b/net-libs/webkit-gtk/webkit-gtk-2.42.5.ebuild
@@ -155,6 +155,8 @@ src_prepare() {
 	eapply "${FILESDIR}"/2.42.1-arm64-non-jumbo-fix.patch
 	# Fix assert failure on some machines, bug #920704
 	eapply "${FILESDIR}"/2.42.4-wasm-assert-fix.patch
+	# Fix compilation on x86, bug #924873
+	eapply "${FILESDIR}"/2.42.5-x86-build-fix.patch
 }
 
 src_configure() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/924873