### PR TITLE
media-gfx/sane-airscan: Modern C fixes

### DIFF
--- a/media-gfx/sane-airscan/files/sane-airscan-0.99.27-c99-fixes.patch
+++ b/media-gfx/sane-airscan/files/sane-airscan-0.99.27-c99-fixes.patch
@@ -1,0 +1,61 @@
+From c042a6895fe6f663d4bcb8c27d1c7b34fbd68b48 Mon Sep 17 00:00:00 2001
+From: Alexander Pevzner <pzz@apevzner.com>
+Date: Sat, 2 Dec 2023 21:49:40 +0300
+Subject: [PATCH 1/2] Fixed missed #include <stdlib.h> (see #305)
+
+This code used to compile on everywhere, but explicit #include <stdlib.h>
+was actually missed. Seems that sometimes it can cause problems.
+---
+ airscan-xml.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/airscan-xml.c b/airscan-xml.c
+index f376f31..5071ca9 100644
+--- a/airscan-xml.c
++++ b/airscan-xml.c
+@@ -9,6 +9,7 @@
+ #include "airscan.h"
+ 
+ #include <fnmatch.h>
++#include <stdlib.h>
+ 
+ #include <libxml/parser.h>
+ #include <libxml/tree.h>
+-- 
+2.43.0
+
+From 144e7d4187c73566ffc2780ac91ab7e1826826e0 Mon Sep 17 00:00:00 2001
+From: Alexander Pevzner <pzz@apevzner.com>
+Date: Sat, 2 Dec 2023 22:29:55 +0300
+Subject: [PATCH 2/2] Fixed build with recent versions of libxml2 (fixes #305)
+
+libxml2 recently changed a prototype of the xmlStructuredErrorFunc callback,
+adding const modifier to the second parameter.
+
+Adding an explicit cast seems to fix the problem (but I will not be surprised, if
+this fix will not work equally well on all distros).
+
+Found for a first time and fixed on Arch linux on about 2 Dec 2023 (Arch is rolling
+release, so there is no explicit release number)
+---
+ airscan-xml.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/airscan-xml.c b/airscan-xml.c
+index 5071ca9..10f290c 100644
+--- a/airscan-xml.c
++++ b/airscan-xml.c
+@@ -124,7 +124,7 @@ xml_rd_parse (xmlDoc **doc, const char *xml_text, size_t xml_len)
+         goto DONE;
+     }
+
+-    ctxt->sax->serror = xml_rd_error_callback;
++    ctxt->sax->serror = (xmlStructuredErrorFunc) xml_rd_error_callback;
+
+     /* Parse the document */
+     if (xmlCtxtResetPush(ctxt, xml_text, xml_len, NULL, NULL)) {
+--
+2.43.0
+
+
+

--- a/media-gfx/sane-airscan/sane-airscan-0.99.27-r1.ebuild
+++ b/media-gfx/sane-airscan/sane-airscan-0.99.27-r1.ebuild
@@ -1,0 +1,43 @@
+# Copyright 2021-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs
+
+DESCRIPTION="SANE backend for AirScan (eSCL) and WSD document scanners"
+HOMEPAGE="https://github.com/alexpevzner/sane-airscan"
+SRC_URI="https://github.com/alexpevzner/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+DEPEND="
+	net-dns/avahi
+	net-libs/gnutls
+	dev-libs/libxml2
+	media-libs/libjpeg-turbo
+	media-libs/libpng
+"
+RDEPEND="${DEPEND}
+	media-gfx/sane-backends
+"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-0.99.27-makefile-fixes.patch"
+	"${FILESDIR}/${PN}-0.99.27-c99-fixes.patch"
+)
+
+src_compile() {
+	emake \
+		CFLAGS="${CFLAGS}" \
+		CPPFLAGS="${CPPFLAGS}" \
+		LDFLAGS="${LDFLAGS}" \
+		CC="$(tc-getCC)" \
+		AR="$(tc-getAR)"
+}
+
+src_install() {
+	emake DESTDIR="${D}" COMPRESS= STRIP= install
+}


### PR DESCRIPTION
Fixes building with Modern C compilers. Patches are taken from fedora

https://src.fedoraproject.org/rpms/sane-airscan/c/913879a64e0624df2f09fbdbb058ea0aa9ecb21d

Closes: https://bugs.gentoo.org/924887