### PR TITLE
media-libs/openjpeg: backport fix for CVE-2021-3575

### DIFF
--- a/media-libs/openjpeg/files/openjpeg-2.5.0-r7-off-by-one.patch
+++ b/media-libs/openjpeg/files/openjpeg-2.5.0-r7-off-by-one.patch
@@ -1,0 +1,40 @@
+From 7bd884f8750892de4f50bf4642fcfbe7011c6bdf Mon Sep 17 00:00:00 2001
+From: Even Rouault <even.rouault@spatialys.com>
+Date: Sun, 18 Feb 2024 17:02:25 +0100
+Subject: [PATCH] opj_decompress: fix off-by-one read heap-buffer-overflow in
+ sycc420_to_rgb() when x0 and y0 are odd (CVE-2021-3575, fixes #1347)
+
+---
+ src/bin/common/color.c | 12 ++++++++++--
+ 1 file changed, 10 insertions(+), 2 deletions(-)
+
+diff --git a/src/bin/common/color.c b/src/bin/common/color.c
+index 27f15f137..ae5d648da 100644
+--- a/src/bin/common/color.c
++++ b/src/bin/common/color.c
+@@ -358,7 +358,15 @@ static void sycc420_to_rgb(opj_image_t *img)
+     if (i < loopmaxh) {
+         size_t j;
+ 
+-        for (j = 0U; j < (maxw & ~(size_t)1U); j += 2U) {
++        if (offx > 0U) {
++            sycc_to_rgb(offset, upb, *y, 0, 0, r, g, b);
++            ++y;
++            ++r;
++            ++g;
++            ++b;
++        }
++
++        for (j = 0U; j < (loopmaxw & ~(size_t)1U); j += 2U) {
+             sycc_to_rgb(offset, upb, *y, *cb, *cr, r, g, b);
+ 
+             ++y;
+@@ -375,7 +383,7 @@ static void sycc420_to_rgb(opj_image_t *img)
+             ++cb;
+             ++cr;
+         }
+-        if (j < maxw) {
++        if (j < loopmaxw) {
+             sycc_to_rgb(offset, upb, *y, *cb, *cr, r, g, b);
+         }
+     }

--- a/media-libs/openjpeg/openjpeg-2.5.0-r7.ebuild
+++ b/media-libs/openjpeg/openjpeg-2.5.0-r7.ebuild
@@ -1,0 +1,104 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit cmake-multilib flag-o-matic
+
+# Make sure that test data are not newer than release;
+# otherwise we will see "Found-But-No-Test" test failures!
+#
+# To update: Go to https://github.com/uclouvain/openjpeg-data and grab the hash
+# of the latest possible commit whose commit date is older than the release
+# date.
+MY_TESTDATA_COMMIT="1f3d093030f9a0b43353ec6b48500f65786ff57a"
+
+DESCRIPTION="Open-source JPEG 2000 library"
+HOMEPAGE="https://www.openjpeg.org"
+SRC_URI="https://github.com/uclouvain/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz
+	test? ( https://github.com/uclouvain/openjpeg-data/archive/${MY_TESTDATA_COMMIT}.tar.gz -> ${PN}-data_20210926.tar.gz )"
+
+LICENSE="BSD-2"
+SLOT="2/7" # based on SONAME
+KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux ~arm64-macos ~ppc-macos ~x64-macos ~x64-solaris"
+IUSE="doc test"
+RESTRICT="!test? ( test )"
+
+RDEPEND="
+	media-libs/lcms:2
+	media-libs/libpng:0=
+	media-libs/tiff:=
+	sys-libs/zlib:=
+"
+DEPEND="${RDEPEND}"
+BDEPEND="doc? ( app-text/doxygen )"
+
+DOCS=( AUTHORS.md CHANGELOG.md NEWS.md README.md THANKS.md )
+
+PATCHES=(
+	"${FILESDIR}/${PN}-2.5.0-gnuinstalldirs-r2.patch" # bug #667150
+	"${FILESDIR}/${PN}-2.5.0-r7-off-by-one.patch" # bug 832007
+)
+
+src_prepare() {
+	if use test; then
+		mv "${WORKDIR}"/openjpeg-data-${MY_TESTDATA_COMMIT} "${WORKDIR}"/data ||
+			die "Failed to rename test data"
+	fi
+
+	cmake_src_prepare
+}
+
+multilib_src_configure() {
+	append-lfs-flags
+
+	local mycmakeargs=(
+		-DBUILD_PKGCONFIG_FILES=ON # always build pkgconfig files, bug #539834
+		-DBUILD_TESTING="$(multilib_native_usex test)"
+		-DBUILD_DOC=$(multilib_native_usex doc ON OFF)
+		-DBUILD_CODEC=$(multilib_is_native_abi && echo ON || echo OFF)
+		-DBUILD_STATIC_LIBS=OFF
+	)
+
+	# Cheat a little bit and force disabling fixed point magic
+	# The test suite is extremely fragile to small changes
+	# bug #715130, bug #715422
+	# https://github.com/uclouvain/openjpeg/issues/1017
+	if multilib_is_native_abi && use test ; then
+		append-cflags "-ffp-contract=off"
+	fi
+
+	cmake_src_configure
+}
+
+multilib_src_test() {
+	if ! multilib_is_native_abi ; then
+		elog "Cannot run tests for non-multilib abi."
+		return 0
+	fi
+
+	pushd "${BUILD_DIR}" > /dev/null || die
+	[[ -e CTestTestfile.cmake ]] || die "Test suite not available! Check source!"
+
+	elog "Note: Upstream maintains a list of known test failures."
+	elog "We collect all the known failures and skip them."
+	elog
+
+	local toskip=( "${S}"/tools/travis-ci/knownfailures-all.txt )
+	if use amd64 ; then
+		toskip+=( "${S}"/tools/travis-ci/knownfailures-*x86_64*.txt )
+	elif use x86 || use arm || use arm64; then
+		toskip+=( "${S}"/tools/travis-ci/knownfailures-*i386*.txt )
+	fi
+
+	local exp=$(sort "${toskip[@]}" | uniq | tr '\n' '|'; assert)
+	popd > /dev/null || die
+
+	local myctestargs=()
+	if [[ -n ${TEST_VERBOSE} ]]; then
+		myctestargs+=( --extra-verbose --output-on-failure )
+	fi
+	myctestargs+=( -E "(${exp::-1})" )
+
+	cmake_src_test
+}


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/832007