### PR TITLE
dev-util/perf: fix build on ia64

### DIFF
--- a/dev-util/perf/files/perf-6.6-ia64.patch
+++ b/dev-util/perf/files/perf-6.6-ia64.patch
@@ -1,0 +1,12 @@
+diff --git a/tools/arch/ia64/include/asm/barrier.h b/tools/arch/ia64/include/asm/barrier.h
+index 6fffe5682713..9753f11d79ad 100644
+--- a/tools/arch/ia64/include/asm/barrier.h
++++ b/tools/arch/ia64/include/asm/barrier.h
+@@ -14,6 +14,7 @@
+ #ifndef _TOOLS_LINUX_ASM_IA64_BARRIER_H
+ #define _TOOLS_LINUX_ASM_IA64_BARRIER_H
+
++#include <asm/intrinsics.h>
+ #include <linux/compiler.h>
+
+ /*

--- a/dev-util/perf/perf-6.6.ebuild
+++ b/dev-util/perf/perf-6.6.ebuild
@@ -176,6 +176,7 @@ src_prepare() {
 
 	pushd "${S_K}" >/dev/null || die
 	eapply "${FILESDIR}"/perf-6.4-libtracefs.patch
+	eapply "${FILESDIR}"/perf-6.6-ia64.patch
 	popd || die
 
 	# Drop some upstream too-developer-oriented flags and fix the


### PR DESCRIPTION
Upstream no longer taking patches for ia64.