### PR TITLE
neovim treesitter dependency bump

### DIFF
--- a/app-editors/neovim/neovim-9999.ebuild
+++ b/app-editors/neovim/neovim-9999.ebuild
@@ -51,7 +51,7 @@ DEPEND="${LUA_DEPS}
 	>=dev-libs/libuv-1.46.0:=
 	>=dev-libs/libvterm-0.3.3
 	>=dev-libs/msgpack-3.0.0:=
-	>=dev-libs/tree-sitter-0.20.8:=
+	>=dev-libs/tree-sitter-0.20.9:=
 	>=dev-libs/libtermkey-0.22
 	>=dev-libs/unibilium-2.0.0:0=
 "


### PR DESCRIPTION
Neovim-9999 fails to build on treesitter 0.20.8
Bug:https://bugs.gentoo.org/922963