### PR TITLE
sys-cluster/openmpi: wire up tests

### DIFF
--- a/sys-cluster/openmpi/openmpi-4.1.6.ebuild
+++ b/sys-cluster/openmpi/openmpi-4.1.6.ebuild
@@ -137,6 +137,10 @@ multilib_src_compile() {
 	emake V=1
 }
 
+multilib_src_test() {
+	emake -C test check
+}
+
 multilib_src_install() {
 	default
 


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/922861