### PR TITLE
dev-lang/zig: add "test-c-import" step in 9999

### DIFF
--- a/dev-lang/zig/zig-9999.ebuild
+++ b/dev-lang/zig/zig-9999.ebuild
@@ -179,7 +179,7 @@ src_test() {
 	local ZIG_TEST_ARGS="-Dstatic-llvm=false -Denable-llvm -Dskip-non-native \
 		-Doptimize=ReleaseSafe -Dtarget=$(get_zig_target) -Dcpu=$(get_zig_mcpu)"
 	local ZIG_TEST_STEPS=(
-		test-cases test-fmt test-behavior test-compiler-rt test-universal-libc test-compare-output
+		test-fmt test-cases test-behavior test-c-import test-compiler-rt test-universal-libc test-compare-output
 		test-standalone test-c-abi test-link test-stack-traces test-cli test-asm-link test-translate-c
 		test-run-translated-c test-std
 	)


### PR DESCRIPTION
Extracted from "test-behaviour" in
https://www.github.com/ziglang/zig/pull/19016 .