### PR TITLE
app-editors/neovim: bump minimal tree-sitter version

### DIFF
--- a/app-editors/neovim/neovim-9999.ebuild
+++ b/app-editors/neovim/neovim-9999.ebuild
@@ -51,7 +51,7 @@ DEPEND="${LUA_DEPS}
 	>=dev-libs/libuv-1.46.0:=
 	>=dev-libs/libvterm-0.3.3
 	>=dev-libs/msgpack-3.0.0:=
-	>=dev-libs/tree-sitter-0.20.8:=
+	>=dev-libs/tree-sitter-0.20.9:=
 	>=dev-libs/libtermkey-0.22
 	>=dev-libs/unibilium-2.0.0:0=
 "


### PR DESCRIPTION
Some time ago neovim's upstream made some changes that made it incompatible with `<dev-libs/tree-sitter-0.20.9`.
For example, this leads to following build failure:
```make
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: src/nvim/CMakeFiles/nvim_bin.dir/lua/treesitter.c.o: in function `node_rawquery':                                                                               
treesitter.c:(.text+0x3583): undefined reference to `ts_query_cursor_set_max_start_depth'                                                                                                                                                   
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: treesitter.c:(.text+0x3777): undefined reference to `ts_query_cursor_set_max_start_depth'
collect2: error: ld returned 1 exit status
```

Closes: https://bugs.gentoo.org/922963
Closes: https://bugs.gentoo.org/925193
Signed-off-by: Vadim Misbakh-Soloviov <mva@gentoo.org>