### PR TITLE
dev-util/rgbds: fix the live ebuild install

### DIFF
--- a/dev-util/rgbds/rgbds-9999.ebuild
+++ b/dev-util/rgbds/rgbds-9999.ebuild
@@ -34,5 +34,5 @@ src_compile() {
 
 src_install() {
 	emake DESTDIR="${D}" PREFIX="${EPREFIX}"/usr Q= STRIP= install
-	dodoc README.rst
+	dodoc README.md
 }


### PR DESCRIPTION
Upstream renamed `README.rst` to `README.md`.