### PR TITLE
net-libs/libpri: EAPI8 bump, use https

### DIFF
--- a/net-libs/libpri/libpri-1.6.0-r1.ebuild
+++ b/net-libs/libpri/libpri-1.6.0-r1.ebuild
@@ -1,0 +1,32 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs
+
+MY_P="${P/_/-}"
+
+DESCRIPTION="Primary Rate ISDN (PRI) library"
+HOMEPAGE="https://www.asterisk.org/"
+SRC_URI="https://downloads.asterisk.org/pub/telephony/${PN}/releases/${MY_P}.tar.gz"
+S="${WORKDIR}/${MY_P}"
+
+SLOT="0"
+LICENSE="GPL-2"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~sparc ~x86"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-1.4.13-multilib.patch"
+	"${FILESDIR}/${PN}-1.6.0-respect-user-flags.patch"
+	"${FILESDIR}/${PN}-1.4.13-no-static-lib.patch"
+)
+
+src_compile() {
+	tc-export CC
+	default
+}
+src_install() {
+	emake INSTALL_PREFIX="${D}" LIBDIR="${D}/usr/$(get_libdir)" install
+	dodoc ChangeLog README TODO
+}


### PR DESCRIPTION
Simple `EAPI8` bump:

```diff
--- libpri-1.6.0.ebuild	2024-02-05 20:40:42.715710076 +0100
+++ libpri-1.6.0-r1.ebuild	2024-02-21 17:41:16.792618141 +0100
@@ -1,21 +1,20 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="6"
+EAPI=8
 
 inherit toolchain-funcs
 
 MY_P="${P/_/-}"
-S="${WORKDIR}/${MY_P}"
 
 DESCRIPTION="Primary Rate ISDN (PRI) library"
-HOMEPAGE="http://www.asterisk.org/"
-SRC_URI="http://downloads.asterisk.org/pub/telephony/${PN}/releases/${MY_P}.tar.gz"
+HOMEPAGE="https://www.asterisk.org/"
+SRC_URI="https://downloads.asterisk.org/pub/telephony/${PN}/releases/${MY_P}.tar.gz"
+S="${WORKDIR}/${MY_P}"
 
 SLOT="0"
 LICENSE="GPL-2"
-KEYWORDS="amd64 ~arm ~arm64 ~ppc ~ppc64 ~sparc x86"
-IUSE=""
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~sparc ~x86"
 
 PATCHES=(
 	"${FILESDIR}/${PN}-1.4.13-multilib.patch"
```