### PR TITLE
net-libs/libsrsirc: EAPI8 bump

### DIFF
--- a/net-libs/libsrsirc/libsrsirc-0.0.14-r2.ebuild
+++ b/net-libs/libsrsirc/libsrsirc-0.0.14-r2.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
 
-DESCRIPTION="A lightweight, cross-platform IRC library"
+DESCRIPTION="Lightweight, cross-platform IRC library"
 HOMEPAGE="https://github.com/fstd/libsrsirc"
 SRC_URI="http://penenen.de/${P}.tar.gz"
 LICENSE="BSD"
@@ -12,8 +12,7 @@ SLOT="0"
 KEYWORDS="~amd64 ~x86"
 IUSE="static-libs ssl"
 
-DEPEND="
-	ssl? ( dev-libs/openssl:0= )"
+DEPEND="ssl? ( dev-libs/openssl:0= )"
 RDEPEND="${DEPEND}"
 
 src_configure() {


### PR DESCRIPTION
Another simple `EAPI8` bump.