### PR TITLE
tree-sitter-grammar.eclass: extended packaging

### DIFF
--- a/eclass/tree-sitter-grammar.eclass
+++ b/eclass/tree-sitter-grammar.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: tree-sitter-grammar.eclass
@@ -108,7 +108,16 @@ tree-sitter-grammar_src_install() {
 
 	dolib.so "${WORKDIR}/${soname}"
 	dosym "${soname}" \
-		  /usr/$(get_libdir)/lib${PN}$(get_libname)
+		/usr/$(get_libdir)/lib${PN}$(get_libname)
+	keepdir /usr/$(get_libdir)/tree-sitter
+	dosym ../"${soname}" \
+		/usr/$(get_libdir)/tree-sitter/${PN##tree-sitter-}$(get_libname)
+
+	if [[ -d "${S}/../queries" ]]; then
+		keepdir /usr/share/tree-sitter
+		insinto /usr/share/tree-sitter
+		doins -r "${S}/../queries"
+	fi
 }
 
 fi


### PR DESCRIPTION
1) installing grammar library to additional well-known path
2) also installing queries

See-Also: https://pkgs.alpinelinux.org/contents?branch=edge&name=tree%2dsitter%2dlua&arch=x86_64&repo=community
See-Also: https://pkgs.alpinelinux.org/contents?branch=edge&name=tree%2dsitter%2dcss&arch=x86_64&repo=community