### PR TITLE
media-libs/gst-plugins-bad: 1.22.3-r4: Add the v4l2codecs use flag

### DIFF
--- a/media-libs/gst-plugins-bad/gst-plugins-bad-1.22.3-r4.ebuild
+++ b/media-libs/gst-plugins-bad/gst-plugins-bad-1.22.3-r4.ebuild
@@ -1,0 +1,112 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+GST_ORG_MODULE="gst-plugins-bad"
+PYTHON_COMPAT=( python3_{10..11} )
+inherit gstreamer-meson python-any-r1
+
+DESCRIPTION="Less plugins for GStreamer"
+HOMEPAGE="https://gstreamer.freedesktop.org/"
+
+LICENSE="LGPL-2"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~mips ~ppc ~ppc64 ~riscv ~sparc ~x86"
+
+# TODO: egl and gtk IUSE only for transition
+IUSE="X bzip2 +egl gles2 gtk +introspection +opengl +orc v4l2codecs vaapi vnc wayland qsv" # Keep default IUSE mirrored with gst-plugins-base where relevant
+
+# X11 is automagic for now, upstream #709530 - only used by librfb USE=vnc plugin
+# We mirror opengl/gles2 from -base to ensure no automagic openglmixers plugin (with "opengl?" it'd still get built with USE=-opengl here)
+# FIXME	gtk? ( >=media-plugins/gst-plugins-gtk-${PV}:${SLOT}[${MULTILIB_USEDEP}] )
+# Baseline requirement for libva is 1.6, but 1.10 gets more features
+RDEPEND="
+	!media-plugins/gst-plugins-va
+	!media-plugins/gst-transcoder
+
+	>=media-libs/gstreamer-${PV}:${SLOT}[${MULTILIB_USEDEP},introspection?]
+	>=media-libs/gst-plugins-base-${PV}:${SLOT}[${MULTILIB_USEDEP},egl?,introspection?,gles2=,opengl=]
+	introspection? ( >=dev-libs/gobject-introspection-1.31.1:= )
+
+	bzip2? ( >=app-arch/bzip2-1.0.6-r4[${MULTILIB_USEDEP}] )
+	vnc? ( X? ( x11-libs/libX11[${MULTILIB_USEDEP}] ) )
+	wayland? (
+		>=dev-libs/wayland-1.4.0[${MULTILIB_USEDEP}]
+		>=x11-libs/libdrm-2.4.55[${MULTILIB_USEDEP}]
+		>=dev-libs/wayland-protocols-1.15
+	)
+
+	orc? ( >=dev-lang/orc-0.4.33[${MULTILIB_USEDEP}] )
+
+	qsv? (
+		dev-libs/libgudev[${MULTILIB_USEDEP}]
+		media-libs/libva[wayland?,X?,${MULTILIB_USEDEP}]
+		media-libs/oneVPL[wayland?,X?,${MULTILIB_USEDEP}]
+		x11-libs/libdrm[${MULTILIB_USEDEP}]
+	)
+
+	vaapi? ( >=media-libs/libva-1.10[${MULTILIB_USEDEP}] )
+"
+
+DEPEND="${RDEPEND}"
+
+BDEPEND="
+	${PYTHON_DEPS}
+	dev-util/glib-utils
+"
+
+DOCS=( AUTHORS ChangeLog NEWS README.md RELEASE )
+
+# FIXME: gstharness.c:889:gst_harness_new_with_padnames: assertion failed: (element != NULL)
+RESTRICT="test"
+
+PATCHES=(
+	"${FILESDIR}"/0001-meson-Fix-libdrm-and-vaapi-configure-checks.patch
+	"${FILESDIR}"/0002-meson-Add-feature-options-for-optional-va-deps-libdr.patch
+)
+
+src_prepare() {
+	default
+	addpredict /dev # Prevent sandbox violations bug #570624
+}
+
+multilib_src_configure() {
+	GST_PLUGINS_NOAUTO="shm ipcpipeline librfb msdk hls v4l2codecs"
+
+	local emesonargs=(
+		-Dshm=enabled
+		-Dipcpipeline=enabled
+		-Dhls=disabled
+		$(meson_feature vnc librfb)
+		$(meson_feature v4l2codecs v4l2codecs)
+		$(meson_feature wayland)
+	)
+
+	if use qsv; then
+		emesonargs+=(
+			-Dmsdk=enabled
+			-Dmfx_api=oneVPL
+		)
+	else
+		emesonargs+=( -Dmsdk=disabled )
+	fi
+
+	# XXX: See comment above IUSE wrt egl; this was actually typo'd with
+	# myconf for ages and nothing exploded.
+	#if use opengl || use gles2; then
+	#	emesonargs+=( -Dgl=enabled )
+	#else
+	#	emesonargs+=( -Dgl=disabled )
+	#fi
+
+	gstreamer_multilib_src_configure "$(meson_feature vaapi va)"
+}
+
+multilib_src_test() {
+	# Tests are slower than upstream expects
+	CK_DEFAULT_TIMEOUT=300 gstreamer_multilib_src_test
+}
+
+multilib_src_install_all() {
+	einstalldocs
+	find "${ED}" -name '*.la' -delete || die
+}

--- a/profiles/arch/arm64/use.mask
+++ b/profiles/arch/arm64/use.mask
@@ -144,3 +144,6 @@ video_cards_r100
 video_cards_r200
 video_cards_r300
 video_cards_r600
+
+# Unmask v4l2codecs for arm64
+-v4l2codecs

--- a/profiles/base/use.mask
+++ b/profiles/base/use.mask
@@ -70,3 +70,6 @@ netlink
 # These are specific to Mac OS X
 aqua
 coreaudio
+
+# v4l2codecs is only available for arm64
+v4l2codecs

--- a/profiles/use.desc
+++ b/profiles/use.desc
@@ -353,6 +353,7 @@ upnp-av - Enable UPnP audio/video streaming support
 upower - Enable power management support
 usb - Add USB support to applications that have optional USB support (e.g. cups)
 v4l - Enable support for video4linux (using linux-headers or userspace libv4l libraries)
+v4l2codecs - Enable support for v4l2 stateless hardware video decoding
 vaapi - Enable Video Acceleration API for hardware decoding
 vala - Enable bindings for dev-lang/vala
 valgrind - Enable annotations for accuracy. May slow down runtime slightly. Safe to use even if not currently using dev-debug/valgrind


### PR DESCRIPTION
Add the v4lcodecs use flag description and only unmask for arm64.

This is an upstreaming of the change in chromiumos: https://chromium-review.googlesource.com/c/chromiumos/overlays/chromiumos-overlay/+/5297402/2