### PR TITLE
games-engines/openmw: fix build with gcc 14

### DIFF
--- a/games-engines/openmw/files/openmw-0.48.0-gcc14.patch
+++ b/games-engines/openmw/files/openmw-0.48.0-gcc14.patch
@@ -1,0 +1,13 @@
+Fix build with gcc 14
+https://bugs.gentoo.org/925105
+
+--- a/components/bsa/bsa_file.cpp
++++ b/components/bsa/bsa_file.cpp
+@@ -26,6 +26,7 @@
+ #include <components/files/constrainedfilestream.hpp>
+ 
+ #include <cassert>
++#include <algorithm>
+ 
+ #include <boost/filesystem/path.hpp>
+ #include <boost/filesystem/fstream.hpp>

--- a/games-engines/openmw/openmw-0.48.0.ebuild
+++ b/games-engines/openmw/openmw-0.48.0.ebuild
@@ -73,6 +73,10 @@ BDEPEND="
 	)
 "
 
+PATCHES=(
+	"${FILESDIR}/openmw-0.48.0-gcc14.patch"
+)
+
 src_prepare() {
 	cmake_src_prepare
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/925105