### PR TITLE
app-arch/zstd: Fix cross build

### DIFF
--- a/app-arch/zstd/files/zstd-1.5.5-fix-cross-build.patch
+++ b/app-arch/zstd/files/zstd-1.5.5-fix-cross-build.patch
@@ -1,0 +1,24 @@
+From 3d06ef443c7b111742cf68b98bd2e42997e845b6 Mon Sep 17 00:00:00 2001
+From: Michal Rostecki <vadorovsky@protonmail.com>
+Date: Fri, 23 Feb 2024 00:22:50 +0100
+Subject: [PATCH] build: Allow cross building of gen_html
+
+---
+ build/meson/contrib/gen_html/meson.build | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/build/meson/contrib/gen_html/meson.build b/build/meson/contrib/gen_html/meson.build
+index 3f302538..cabff209 100644
+--- a/build/meson/contrib/gen_html/meson.build
++++ b/build/meson/contrib/gen_html/meson.build
+@@ -17,7 +17,6 @@ gen_html_includes = include_directories(join_paths(zstd_rootdir, 'programs'),
+ gen_html = executable('gen_html',
+   join_paths(zstd_rootdir, 'contrib/gen_html/gen_html.cpp'),
+   include_directories: gen_html_includes,
+-  native: true,
+   install: false)
+ 
+ # Update zstd manual
+-- 
+2.43.2
+

--- a/app-arch/zstd/zstd-1.5.5-r1.ebuild
+++ b/app-arch/zstd/zstd-1.5.5-r1.ebuild
@@ -26,6 +26,8 @@ DEPEND="${RDEPEND}"
 MESON_PATCHES=(
 	# Workaround until Valgrind bugfix lands
 	"${FILESDIR}"/${PN}-1.5.4-no-find-valgrind.patch
+	# Fix for cross builds
+	"${FILESDIR}"/${PN}-1.5.5-fix-cross-build.patch
 )
 
 PATCHES=(

--- a/app-arch/zstd/zstd-1.5.5.ebuild
+++ b/app-arch/zstd/zstd-1.5.5.ebuild
@@ -26,6 +26,8 @@ DEPEND="${RDEPEND}"
 MESON_PATCHES=(
 	# Workaround until Valgrind bugfix lands
 	"${FILESDIR}"/${PN}-1.5.4-no-find-valgrind.patch
+	# Fix for cross builds
+	"${FILESDIR}"/${PN}-1.5.5-fix-cross-build.patch
 )
 
 PATCHES=(


### PR DESCRIPTION
zstd comes with the gen_html utility, used for generating documentation. Meson configuration marks it as `native`, which means building it natively even during cross builds. That was done by developers on purpose[0] and it makes sense for manual cross builds.

However, that doesn't work for cross builds with emerge. We need to disable the `native` option on our own and the change is not upstreamable.

[0] https://github.com/facebook/zstd/commit/132a1ad2915652aa86f32362c36a52e9b03fe695

Bug: https://bugs.gentoo.org/925287