### PR TITLE
app-shells/atuin: Removed tests needing network

### DIFF
--- a/app-shells/atuin/atuin-18.0.1.ebuild
+++ b/app-shells/atuin/atuin-18.0.1.ebuild
@@ -470,7 +470,9 @@ DOCS=(
 src_prepare() {
 	default
 
+	# Need network
 	rm atuin/tests/sync.rs || die
+	rm atuin/tests/users.rs || die
 }
 
 src_configure() {


### PR DESCRIPTION
Upstream introduced a new test which creates a server and simulates user registration, password change, etc. All tests in that file need network, therefore the entire file was removed.

Closes: https://bugs.gentoo.org/925163