### PR TITLE
x11-libs/wxGTK: Fix missing [X?] on gtk3 dependency

### DIFF
--- a/x11-libs/wxGTK/wxGTK-3.2.2.1-r3.ebuild
+++ b/x11-libs/wxGTK/wxGTK-3.2.2.1-r3.ebuild
@@ -38,7 +38,7 @@ RDEPEND="
 		media-libs/libpng:0=[${MULTILIB_USEDEP}]
 		sys-libs/zlib[${MULTILIB_USEDEP}]
 		x11-libs/cairo[${MULTILIB_USEDEP}]
-		x11-libs/gtk+:3[wayland?,${MULTILIB_USEDEP}]
+		x11-libs/gtk+:3[wayland?,X?,${MULTILIB_USEDEP}]
 		x11-libs/gdk-pixbuf:2[${MULTILIB_USEDEP}]
 		x11-libs/libSM[${MULTILIB_USEDEP}]
 		x11-libs/libX11[${MULTILIB_USEDEP}]


### PR DESCRIPTION
    wxWidgets-3.2.2.1/src/unix/uiactionx11.cpp:35:10: fatal error: 'gdk/gdkx.h' file not found

Signed-off-by: Haelwenn (lanodan) Monnier <contact@hacktivis.me>
