### PR TITLE
dev-build/samurai: fix segfault for phony targets

### DIFF
--- a/dev-build/samurai/files/samurai-1.2-phony_targets_fix.patch
+++ b/dev-build/samurai/files/samurai-1.2-phony_targets_fix.patch
@@ -1,0 +1,30 @@
+https://github.com/michaelforney/samurai/issues/66
+https://github.com/michaelforney/samurai/issues/81
+https://github.com/michaelforney/samurai/commit/fb61f22c7e690715d309c41812412c4f432ef53a
+
+From fb61f22c7e690715d309c41812412c4f432ef53a Mon Sep 17 00:00:00 2001
+From: Michael Forney <mforney@mforney.org>
+Date: Wed, 31 Mar 2021 14:04:29 -0700
+Subject: [PATCH] build: Don't try to print phony edges during dry-run
+
+This causes a segfault since phony edges have no command. It also
+messes up the nstarted/nfinished counts.
+
+Fixes #66.
+---
+ build.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/build.c b/build.c
+index 368e5f9..1cb736f 100644
+--- a/build.c
++++ b/build.c
+@@ -540,7 +540,7 @@ build(void)
+ 		while (work && numjobs < buildopts.maxjobs && numfail < buildopts.maxfail) {
+ 			e = work;
+ 			work = work->worknext;
+-			if (buildopts.dryrun) {
++			if (e->rule != &phonyrule && buildopts.dryrun) {
+ 				++nstarted;
+ 				printstatus(e, edgevar(e, "command", true));
+ 				++nfinished;

--- a/dev-build/samurai/metadata.xml
+++ b/dev-build/samurai/metadata.xml
@@ -5,9 +5,9 @@
 		<email>orbea@riseup.net</email>
 		<name>orbea</name>
 	</maintainer>
-	<maintainer type="person" proxied="proxy">
-		<email>sam@gentoo.org</email>
-		<name>Sam James</name>
+	<maintainer type="project" proxied="proxy">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
 	</maintainer>
 	<upstream>
 		<remote-id type="github">michaelforney/samurai</remote-id>

--- a/dev-build/samurai/samurai-1.2-r3.ebuild
+++ b/dev-build/samurai/samurai-1.2-r3.ebuild
@@ -20,6 +20,7 @@ SLOT="0"
 
 PATCHES=(
 	"${FILESDIR}/${P}-null_pointer_fix.patch" # 786951
+	"${FILESDIR}/${P}-phony_targets_fix.patch"
 )
 
 src_compile() {


### PR DESCRIPTION
Upstream-Issue: https://github.com/michaelforney/samurai/issues/66
Upstream-Issue: https://github.com/michaelforney/samurai/issues/81
Upstream-Commit: https://github.com/michaelforney/samurai/commit/fb61f22c7e690715d309c41812412c4f432ef53a