### PR TITLE
dev-db/influxdb: install correcty init.d files

### DIFF
--- a/dev-db/influxdb/influxdb-2.7.3-r1.ebuild
+++ b/dev-db/influxdb/influxdb-2.7.3-r1.ebuild
@@ -263,8 +263,8 @@ src_install() {
 	doexe usr/lib/influxdb/scripts/influxd-systemd-start.sh
 	exeinto /usr/share/influxdb
 	doexe usr/share/influxdb/influxdb2-upgrade.sh
-	newconfd "${FILESDIR}"/influxdb.confd influxdb
-	newinitd "${FILESDIR}"/influxdb.initd influxdb
+	newconfd "${FILESDIR}"/influxdb.confd-r1 influxdb
+	newinitd "${FILESDIR}"/influxdb.initd-r1 influxdb
 	keepdir /var/log/influxdb
 	fowners influxdb:influxdb /var/log/influxdb
 


### PR DESCRIPTION
Commit 27d408eda1c027c48312e7b9ae96b01cae508474 introduced new init and confd scripts but the newly added `r1` ebuild doesn't use them. This PR fixes that.