### PR TITLE
media-sound/audacity: add myself as maintainer (again)

### DIFF
--- a/media-sound/audacity/metadata.xml
+++ b/media-sound/audacity/metadata.xml
@@ -10,6 +10,10 @@
     <name>Richard Ash</name>
     <description>Upstream - please CC on bugs that concerns upstream</description>
   </maintainer>
+  <maintainer type="person" proxied="yes">
+    <email>mehw.is.me@inventati.org</email>
+    <name>Matthew White</name>
+  </maintainer>
   <upstream>
     <remote-id type="github">audacity/audacity</remote-id>
   </upstream>


### PR DESCRIPTION
@floppym I'm adding myself as maintainer again after fixing my bugzilla account's email address.

See also:
- 77348568b0bfd1713c2589ef756dae7f3fa0df5c
- 0709977edc2401e81a05f30dcce909bb855407e1
- https://github.com/gentoo/gentoo/pull/32128#pullrequestreview-1651803940 - 
- https://github.com/gentoo/gentoo/pull/32128#issuecomment-1742335121 - 
- https://github.com/gentoo/gentoo/pull/33155#issuecomment-1745134157