### PR TITLE
media-gfx/gimp: depend on librsvg 2.46.0 or higher

### DIFF
--- a/media-gfx/gimp/gimp-2.99.16.ebuild
+++ b/media-gfx/gimp/gimp-2.99.16.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -35,7 +35,7 @@ COMMON_DEPEND="
 	>=dev-libs/json-glib-1.4.4
 	dev-libs/libxml2:2
 	dev-libs/libxslt
-	>=gnome-base/librsvg-2.40.21:2
+	>=gnome-base/librsvg-2.46.0:2
 	>=media-gfx/mypaint-brushes-2.0.2:=
 	>=media-libs/babl-0.1.98[introspection,lcms,vala?]
 	>=media-libs/fontconfig-2.12.6

--- a/media-gfx/gimp/gimp-9999.ebuild
+++ b/media-gfx/gimp/gimp-9999.ebuild
@@ -34,7 +34,7 @@ COMMON_DEPEND="
 	>=dev-libs/json-glib-1.4.4
 	dev-libs/libxml2:2
 	dev-libs/libxslt
-	>=gnome-base/librsvg-2.40.21:2
+	>=gnome-base/librsvg-2.46.0:2
 	>=media-gfx/mypaint-brushes-2.0.2:=
 	>=media-libs/babl-0.1.98[introspection,lcms,vala?]
 	>=media-libs/fontconfig-2.12.6


### PR DESCRIPTION
RsvgRectangle is introduced in librsvg 2.46 and is required by gimp 2.99.16

Closes: https://bugs.gentoo.org/920531