### PR TITLE
meson.eclass: wire up LTO support directly into the meson options

### DIFF
--- a/eclass/meson.eclass
+++ b/eclass/meson.eclass
@@ -367,7 +367,7 @@ setup_meson_src_configure() {
 	)
 
 	if [[ -n ${EMESON_BUILDTYPE} ]]; then
-		MESONARGS+=( --buildtype "${EMESON_BUILDTYPE}" )
+		MESONARGS+=( -Dbuildtype="${EMESON_BUILDTYPE}" )
 	fi
 
 	if tc-is-cross-compiler; then


### PR DESCRIPTION
meson's builtin LTO support allows meson to introspect whether LTO is enabled and do some fancy things, such as forcing LTO off for a single target that is known to be special(ly bad) and not support LTO.

Includes:
- meson.eclass: refactor src_configure into a setter function
- demonstration of how this works for distutils-r1

/cc @floppym 