### PR TITLE
sys-apps/debianutils: drop installkernel use flag

### DIFF
--- a/profiles/features/prefix/package.use.mask
+++ b/profiles/features/prefix/package.use.mask
@@ -14,10 +14,6 @@ x11-base/xorg-server elogind
 # depends on systemd
 sys-apps/ipmitool openbmc
 
-# Fabian Groffen <grobian@gentoo.org> (2020-06-07)
-# installing kernels has no business in Prefix
-sys-apps/debianutils installkernel
-
 # Benda Xu <heroxbd@gentoo.org> (2019-08-20)
 # avoid gnome-extra/gnome-user-share, which depends on systemd.
 gnome-base/gnome-extra-apps share

--- a/sys-apps/debianutils/debianutils-5.14-r1.ebuild
+++ b/sys-apps/debianutils/debianutils-5.14-r1.ebuild
@@ -12,11 +12,7 @@ SRC_URI="mirror://debian/pool/main/d/${PN}/${PN}_${PV}.tar.xz"
 LICENSE="BSD GPL-2 SMAIL"
 SLOT="0"
 KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~x86-linux"
-IUSE="+installkernel static"
-
-PDEPEND="
-	installkernel? ( sys-kernel/installkernel )
-"
+IUSE="static"
 
 PATCHES=( "${FILESDIR}"/${PN}-3.4.2-no-bs-namespace.patch )
 

--- a/sys-apps/debianutils/metadata.xml
+++ b/sys-apps/debianutils/metadata.xml
@@ -5,10 +5,4 @@
 		<email>base-system@gentoo.org</email>
 		<name>Gentoo Base System</name>
 	</maintainer>
-	<use>
-		<flag name="installkernel">
-			Install /sbin/installkernel script (for Linux).
-			installkernel is required whenever a kernel will be installed via make install
-		</flag>
-	</use>
 </pkgmetadata>


### PR DESCRIPTION
Random packages requiring some tool from Debian should not cause the kernel installation process to change.

The dropping of the debianutils dependency in ca-certificates has already caused some surprises due to installkernel being depcleaned. The origin of the problem lies here in debianutils, users unknowingly use and rely on `installkernel` but do not have it in their world file because it was implicitly pulled in by some package that happens to use the `run-parts` command.

And also the other way around. If I am one of the users that wants to do everything manually, I should not have my `make install` unknowingly altered by some package that I installed which pulled debianutils into the depgraph.

Drop this unused runtime dependency (which is against policy to begin with) and its accompanying flag. 
This will be accompanied with the following news item:

```
Title: installkernel is no longer implicitly installed
Author: Andrew Ammerlaan <andrewammerlaan@gentoo.org>
Posted: 2024-02-26
Revision: 1
News-Item-Format: 2.0
Display-If-Installed: sys-kernel/installkernel
Display-If-Installed: >=sys-apps/debianutils-5.14-r1
Display-If-Installed: app-misc/ca-certificates

/sbin/installkernel is a script called by the kernel's "make install"
as well as by the distribution kernel's post-install phase. If you are
reading this then chances are you use and rely on installkernel[1] and
what follows is essential for you.

Previously sys-kernel/installkernel was implicitly installed on many
systems via a dependency in sys-apps/debianutils. This dependency was
toggled by the "installkernel" USE flag, and enabled by default.

Until recently, sys-apps/debianutils was in turn pulled in by
app-misc/ca-certificates, an essential package installed on many
systems. However, this dependency of app-misc/ca-certificates on 
sys-apps/debianutils was removed[2]. As a result many users may find
that sys-apps/debianutils and therefore sys-kernel/installkernel are no
longer part of the dependency graph and will therefore be cleaned up by
"emerge --depclean".

Removing sys-kernel/installkernel from your system WILL change the way
kernels are installed by "make install"! Instead of the versioned
/boot/vmlinuz-x.y.z that you are used to, "make install" will simply
copy bzImage (or equivalent for your arch) into /boot. This image may
not be picked up by your bootloader or its configuration tools.

To avoid surprises from such implicit dependencies from happening again
in the future, the dependency on sys-kernel/installkernel in
sys-apps/debianutils is removed. And as such, sys-kernel/installkernel
is only installed on the system if it is either explicitly selected or
pulled in via the distribution kernels (e.g. gentoo-kernel(-bin)).


User Action Required (all users)
====================

Users who currently have sys-kernel/installkernel installed, must
ensure that it is explicitly selected by emerging it:

	emerge --noreplace sys-kernel/installkernel

Users who find that sys-kernel/installkernel has already been cleaned
from their systems and are therefore affected by the change in kernel
installation described above should re-install sys-kernel/installkernel
and then re-install their kernel.

	emerge sys-kernel/installkernel
	cd /usr/src/linux       # (or other location of the kernel sources)
	make install

Note that this re-installation is not required for users of the
distribution kernels (e.g. gentoo-kernel(-bin)).


[1] https://wiki.gentoo.org/wiki/Installkernel
[2] https://gitweb.gentoo.org/repo/gentoo.git/commit/?id=6e6ccafd58bc7401fa371d2f255d72ddae0131e6
````