### PR TITLE
dev-libs/stb: also install deprecated header files

### DIFF
--- a/dev-libs/stb/stb-20240201.ebuild
+++ b/dev-libs/stb/stb-20240201.ebuild
@@ -22,6 +22,7 @@ src_prepare() {
 	# Move the header files in a folder so they don't pollute the include dir
 	mkdir stb || die
 	mv *.h stb/ || die
+	mv deprecated stb/ || die
 }
 
 src_install() {


### PR DESCRIPTION
A program I was trying to add to ::guru depend on a deprecated header file.