### PR TITLE
dev-python/cython: Move `-Wno-error=incompatible-pointer-types` hack to the package

### DIFF
--- a/dev-python/cython/cython-0.29.37.1-r1.ebuild
+++ b/dev-python/cython/cython-0.29.37.1-r1.ebuild
@@ -1,0 +1,97 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DISTUTILS_EXT=1
+DISTUTILS_USE_PEP517=setuptools
+PYTHON_TESTED=( python3_{10..11} )
+# 3.12 not tested yet for https://github.com/cython/cython/issues/5285.
+PYTHON_COMPAT=( "${PYTHON_TESTED[@]}" python3_12 pypy3 )
+PYTHON_REQ_USE="threads(+)"
+
+inherit distutils-r1 multiprocessing toolchain-funcs elisp-common
+
+DESCRIPTION="A Python to C compiler"
+HOMEPAGE="
+	https://cython.org/
+	https://github.com/cython/cython/
+	https://pypi.org/project/Cython/
+"
+SRC_URI="
+	https://github.com/cython/cython/archive/${PV}.tar.gz
+		-> ${P}.gh.tar.gz
+"
+
+LICENSE="Apache-2.0"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~arm64-macos ~ppc-macos ~x64-macos ~x64-solaris"
+IUSE="emacs test"
+RESTRICT="!test? ( test )"
+
+RDEPEND="
+	emacs? ( >=app-editors/emacs-23.1:* )
+"
+BDEPEND="
+	${RDEPEND}
+	test? (
+		$(python_gen_cond_dep '
+			dev-python/numpy[${PYTHON_USEDEP}]
+		' "${PYTHON_TESTED[@]}")
+	)
+"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-0.29.22-spawn-multiprocessing.patch"
+	"${FILESDIR}/${PN}-0.29.23-test_exceptions-py310.patch"
+	"${FILESDIR}/${PN}-0.29.23-pythran-parallel-install.patch"
+	# workaround for https://bugs.gentoo.org/918983
+	# https://github.com/cython/cython/issues/2747
+	"${FILESDIR}/${PN}-0.29.37.1-no-warn-ptr-types.patch"
+)
+
+SITEFILE=50cython-gentoo.el
+
+distutils_enable_sphinx docs
+
+python_compile() {
+	# Python gets confused when it is in sys.path before build.
+	local -x PYTHONPATH=
+
+	distutils-r1_python_compile
+}
+
+python_compile_all() {
+	use emacs && elisp-compile Tools/cython-mode.el
+}
+
+python_test() {
+	if ! has "${EPYTHON/./_}" "${PYTHON_TESTED[@]}"; then
+		einfo "Skipping tests on ${EPYTHON} (xfail)"
+		return
+	fi
+
+	tc-export CC
+	# https://github.com/cython/cython/issues/1911
+	local -x CFLAGS="${CFLAGS} -fno-strict-overflow"
+	"${PYTHON}" runtests.py -vv -j "$(makeopts_jobs)" --work-dir "${BUILD_DIR}"/tests ||
+		die "Tests fail with ${EPYTHON}"
+}
+
+python_install_all() {
+	local DOCS=( CHANGES.rst README.rst ToDo.txt USAGE.txt )
+	distutils-r1_python_install_all
+
+	if use emacs; then
+		elisp-install ${PN} Tools/cython-mode.*
+		elisp-site-file-install "${FILESDIR}/${SITEFILE}"
+	fi
+}
+
+pkg_postinst() {
+	use emacs && elisp-site-regen
+}
+
+pkg_postrm() {
+	use emacs && elisp-site-regen
+}

--- a/dev-python/cython/cython-3.0.8-r1.ebuild
+++ b/dev-python/cython/cython-3.0.8-r1.ebuild
@@ -1,0 +1,87 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DISTUTILS_EXT=1
+DISTUTILS_USE_PEP517=setuptools
+PYTHON_TESTED=( python3_{10..12} )
+PYTHON_COMPAT=( "${PYTHON_TESTED[@]}" pypy3 )
+PYTHON_REQ_USE="threads(+)"
+
+inherit distutils-r1 multiprocessing toolchain-funcs
+
+MY_P=${P/_rc/rc}
+DESCRIPTION="A Python to C compiler"
+HOMEPAGE="
+	https://cython.org/
+	https://github.com/cython/cython/
+	https://pypi.org/project/Cython/
+"
+SRC_URI="
+	https://github.com/cython/cython/archive/${PV/_rc/rc}.tar.gz
+		-> ${MY_P}.gh.tar.gz
+"
+S=${WORKDIR}/${MY_P}
+
+LICENSE="Apache-2.0"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~arm64-macos ~ppc-macos ~x64-macos ~x64-solaris"
+IUSE="test"
+RESTRICT="!test? ( test )"
+
+BDEPEND="
+	${RDEPEND}
+	test? (
+		$(python_gen_cond_dep '
+			dev-python/numpy[${PYTHON_USEDEP}]
+		' "${PYTHON_TESTED[@]}")
+	)
+"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-0.29.22-spawn-multiprocessing.patch"
+	"${FILESDIR}/${PN}-0.29.23-test_exceptions-py310.patch"
+	"${FILESDIR}/${PN}-0.29.23-pythran-parallel-install.patch"
+	# workaround for https://bugs.gentoo.org/918983
+	# https://github.com/cython/cython/issues/2747
+	"${FILESDIR}/${PN}-3.0.8-no-warn-ptr-types.patch"
+)
+
+distutils_enable_sphinx docs \
+	dev-python/jinja \
+	dev-python/sphinx-issues \
+	dev-python/sphinx-tabs
+
+python_compile() {
+	# Python gets confused when it is in sys.path before build.
+	local -x PYTHONPATH=
+
+	distutils-r1_python_compile
+}
+
+python_test() {
+	if ! has "${EPYTHON/./_}" "${PYTHON_TESTED[@]}"; then
+		einfo "Skipping tests on ${EPYTHON} (xfail)"
+		return
+	fi
+
+	# Needed to avoid confusing cache tests
+	unset CYTHON_FORCE_REGEN
+
+	tc-export CC
+	# https://github.com/cython/cython/issues/1911
+	local -x CFLAGS="${CFLAGS} -fno-strict-overflow"
+	"${PYTHON}" runtests.py \
+		-vv \
+		-j "$(makeopts_jobs)" \
+		--work-dir "${BUILD_DIR}"/tests \
+		--no-examples \
+		--no-code-style \
+		|| die "Tests fail with ${EPYTHON}"
+}
+
+python_install_all() {
+	local DOCS=( CHANGES.rst README.rst ToDo.txt USAGE.txt )
+	distutils-r1_python_install_all
+}

--- a/dev-python/cython/files/cython-0.29.37.1-no-warn-ptr-types.patch
+++ b/dev-python/cython/files/cython-0.29.37.1-no-warn-ptr-types.patch
@@ -1,0 +1,14 @@
+diff --git a/Cython/Compiler/ModuleNode.py b/Cython/Compiler/ModuleNode.py
+index e9bfa9fe9..43be47dd5 100644
+--- a/Cython/Compiler/ModuleNode.py
++++ b/Cython/Compiler/ModuleNode.py
+@@ -376,6 +376,9 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
+         self.generate_includes(env, modules, code, early=False)
+ 
+         code = globalstate['all_the_rest']
++        # Gentoo: workaround for https://github.com/cython/cython/issues/2747
++        # https://bugs.gentoo.org/918983
++        code.putln('#pragma GCC diagnostic ignored "-Wincompatible-pointer-types"')
+ 
+         self.generate_cached_builtins_decls(env, code)
+         self.generate_lambda_definitions(env, code)

--- a/dev-python/cython/files/cython-3.0.8-no-warn-ptr-types.patch
+++ b/dev-python/cython/files/cython-3.0.8-no-warn-ptr-types.patch
@@ -1,0 +1,14 @@
+diff --git a/Cython/Compiler/ModuleNode.py b/Cython/Compiler/ModuleNode.py
+index b46b6cee6..9f9f08d61 100644
+--- a/Cython/Compiler/ModuleNode.py
++++ b/Cython/Compiler/ModuleNode.py
+@@ -507,6 +507,9 @@ class ModuleNode(Nodes.Node, Nodes.BlockNode):
+         self.generate_includes(env, modules, code, early=False)
+ 
+         code = globalstate['module_code']
++        # Gentoo: workaround for https://github.com/cython/cython/issues/2747
++        # https://bugs.gentoo.org/918983
++        code.putln('#pragma GCC diagnostic ignored "-Wincompatible-pointer-types"')
+ 
+         self.generate_cached_builtins_decls(env, code)
+ 

--- a/eclass/distutils-r1.eclass
+++ b/eclass/distutils-r1.eclass
@@ -1813,11 +1813,6 @@ distutils-r1_run_phase() {
 	tc-export AR CC CPP CXX
 
 	if [[ ${DISTUTILS_EXT} ]]; then
-		if [[ ${BDEPEND} == *dev-python/cython* ]] ; then
-			# Workaround for https://github.com/cython/cython/issues/2747 (bug #918983)
-			local -x CFLAGS="${CFLAGS} $(test-flags-CC -Wno-error=incompatible-pointer-types)"
-		fi
-
 		local -x CPPFLAGS="${CPPFLAGS} $(usex debug '-UNDEBUG' '-DNDEBUG')"
 		# always generate .c files from .pyx files to ensure we get latest
 		# bug fixes from Cython (this works only when setup.py is using


### PR DESCRIPTION
Instead of altering `CFLAGS` in the eclass, add a `#pragma GCC...` to the generated files.

This avoids altering the environment and reduces the scope of hack somewhat. It requires files to be regenerated but we expect that anyway.