### PR TITLE
distutils-r1.eclass: some var cleanup

### DIFF
--- a/eclass/distutils-r1.eclass
+++ b/eclass/distutils-r1.eclass
@@ -1812,7 +1812,13 @@ distutils-r1_run_phase() {
 	local -x AR=${AR} CC=${CC} CPP=${CPP} CXX=${CXX}
 	tc-export AR CC CPP CXX
 
-	if [[ ${DISTUTILS_EXT} ]]; then
+	# Perform additional environment modifications only for python_compile
+	# phase.  This is the only phase where we expect to be calling the Python
+	# build system.  We want to localize the altered variables to avoid them
+	# leaking to other parts of multi-language ebuilds.  However, we want
+	# to avoid localizing them in other phases, particularly
+	# python_configure_all, where the ebuild may wish to alter them globally.
+	if [[ ${DISTUTILS_EXT} && ( ${1} == *compile* || ${1} == *test* ) ]]; then
 		local -x CPPFLAGS="${CPPFLAGS} $(usex debug '-UNDEBUG' '-DNDEBUG')"
 		# always generate .c files from .pyx files to ensure we get latest
 		# bug fixes from Cython (this works only when setup.py is using

--- a/eclass/distutils-r1.eclass
+++ b/eclass/distutils-r1.eclass
@@ -1828,6 +1828,10 @@ distutils-r1_run_phase() {
 		# Rust extensions are incompatible with C/C++ LTO compiler
 		# see e.g. https://bugs.gentoo.org/910220
 		if has cargo ${INHERITED}; then
+			local x
+			for x in $(all-flag-vars); do
+				local -x "${x}=${!x}"
+			done
 			filter-lto
 		fi
 	fi

--- a/eclass/distutils-r1.eclass
+++ b/eclass/distutils-r1.eclass
@@ -1813,11 +1813,6 @@ distutils-r1_run_phase() {
 	tc-export AR CC CPP CXX
 
 	if [[ ${DISTUTILS_EXT} ]]; then
-		if [[ ${BDEPEND} == *dev-python/cython* ]] ; then
-			# Workaround for https://github.com/cython/cython/issues/2747 (bug #918983)
-			local -x CFLAGS="${CFLAGS} $(test-flags-CC -Wno-error=incompatible-pointer-types)"
-		fi
-
 		local -x CPPFLAGS="${CPPFLAGS} $(usex debug '-UNDEBUG' '-DNDEBUG')"
 		# always generate .c files from .pyx files to ensure we get latest
 		# bug fixes from Cython (this works only when setup.py is using

--- a/eclass/distutils-r1.eclass
+++ b/eclass/distutils-r1.eclass
@@ -1824,16 +1824,16 @@ distutils-r1_run_phase() {
 		# bug fixes from Cython (this works only when setup.py is using
 		# cythonize() but it's better than nothing)
 		local -x CYTHON_FORCE_REGEN=1
+
+		# Rust extensions are incompatible with C/C++ LTO compiler
+		# see e.g. https://bugs.gentoo.org/910220
+		if has cargo ${INHERITED}; then
+			filter-lto
+		fi
 	fi
 
 	# silence warnings when pydevd is loaded on Python 3.11+
 	local -x PYDEVD_DISABLE_FILE_VALIDATION=1
-
-	# Rust extensions are incompatible with C/C++ LTO compiler
-	# see e.g. https://bugs.gentoo.org/910220
-	if has cargo ${INHERITED}; then
-		filter-lto
-	fi
 
 	# How to build Python modules in different worlds...
 	local ldopts

--- a/eclass/distutils-r1.eclass
+++ b/eclass/distutils-r1.eclass
@@ -197,6 +197,10 @@ _DISTUTILS_R1_ECLASS=1
 inherit flag-o-matic
 inherit multibuild multilib multiprocessing ninja-utils toolchain-funcs
 
+if [[ ${DISTUTILS_USE_PEP517} == meson-python ]]; then
+	inherit meson
+fi
+
 if [[ ! ${DISTUTILS_SINGLE_IMPL} ]]; then
 	inherit python-r1
 else
@@ -1386,9 +1390,19 @@ distutils_pep517_install() {
 			)
 			;;
 		meson-python)
+			# variables defined by setup_meson_src_configure
+			local MESONARGS=() BOOST_INCLUDEDIR BOOST_LIBRARYDIR NM READELF
+			# it also calls filter-lto
+			local x
+			for x in $(all-flag-vars); do
+				local -x "${x}=${!x}"
+			done
+
+			setup_meson_src_configure "${DISTUTILS_ARGS[@]}"
+
 			local -x NINJAOPTS=$(get_NINJAOPTS)
 			config_settings=$(
-				"${EPYTHON}" - "${DISTUTILS_ARGS[@]}" <<-EOF || die
+				"${EPYTHON}" - "${MESONARGS[@]}" <<-EOF || die
 					import json
 					import os
 					import shlex

--- a/eclass/meson.eclass
+++ b/eclass/meson.eclass
@@ -393,9 +393,6 @@ setup_meson_src_configure() {
 	tc-export NM
 	tc-getPROG READELF readelf >/dev/null
 
-	# https://bugs.gentoo.org/625396
-	python_export_utf8_locale
-
 	# https://bugs.gentoo.org/721786
 	export BOOST_INCLUDEDIR="${BOOST_INCLUDEDIR-${EPREFIX}/usr/include}"
 	export BOOST_LIBRARYDIR="${BOOST_LIBRARYDIR-${EPREFIX}/usr/$(get_libdir)}"
@@ -411,6 +408,9 @@ meson_src_configure() {
 	[[ -n "${NINJA_DEPEND}" ]] || ewarn "Unknown value '${NINJA}' for \${NINJA}"
 
 	BUILD_DIR="${BUILD_DIR:-${WORKDIR}/${P}-build}"
+
+	# https://bugs.gentoo.org/625396
+	python_export_utf8_locale
 
 	(
 		setup_meson_src_configure "$@"

--- a/eclass/python-utils-r1.eclass
+++ b/eclass/python-utils-r1.eclass
@@ -884,7 +884,7 @@ python_doheader() {
 	[[ ${EPYTHON} ]] || die 'No Python implementation set (EPYTHON is null).'
 
 	local includedir=$(python_get_includedir)
-	local d=${includedir#${EPREFIX}}
+	local d=${includedir#${ESYSROOT}}
 
 	(
 		insopts -m 0644


### PR DESCRIPTION
- remove obsolete `CFLAGS` hack for Cython
- make vars `local` only for `cython` and `test` phases
- make stuff `local` before calling `filter-lto`