### PR TITLE
virtual/opengl: Depend on libglvnd instead of mesa

### DIFF
--- a/profiles/default/linux/package.use.force
+++ b/profiles/default/linux/package.use.force
@@ -1,0 +1,6 @@
+# Copyright 2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+# Matt Turner <mattst88@gentoo.org> (2024-12-11)
+# Forced on to avoid potential breakage.
+virtual/opengl X

--- a/virtual/opengl/opengl-8.ebuild
+++ b/virtual/opengl/opengl-8.ebuild
@@ -1,0 +1,18 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit multilib-build
+
+DESCRIPTION="Virtual for OpenGL implementation"
+
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x64-solaris"
+IUSE="X"
+
+RDEPEND="
+	|| (
+		media-libs/libglvnd[X?,${MULTILIB_USEDEP}]
+		dev-util/mingw64-runtime
+	)"


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/925627
Closes: https://bugs.gentoo.org/301337
Closes: https://bugs.gentoo.org/890334