### PR TITLE
profiles: Mask app-emulation/genymotion-bin on musl

### DIFF
--- a/profiles/features/musl/package.mask
+++ b/profiles/features/musl/package.mask
@@ -180,6 +180,7 @@ app-editors/sublime-text
 app-editors/vscode
 app-editors/vscodium
 app-emulation/crossover-bin
+app-emulation/genymotion-bin
 app-misc/kryoflux-dtc
 app-office/libreoffice-bin
 app-office/libreoffice-bin-debug


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/925509