### PR TITLE
www-servers/uwsgi: OpenRC init.d stop timeout should reflect the default shutdown time

### DIFF
--- a/www-servers/uwsgi/files/uwsgi.initd-r7
+++ b/www-servers/uwsgi/files/uwsgi.initd-r7
@@ -128,7 +128,8 @@ stop() {
 	else
 		ebegin "Stopping uWSGI application ${PROGNAME}"
 	fi
-	start-stop-daemon --stop --signal QUIT --pidfile "${PIDFILE}"
+	# retry should be set higher than uwsgi worker-reload-mercy (default 60)
+	start-stop-daemon --stop --signal QUIT --retry 90 --pidfile "${PIDFILE}"
 	eend $?
 }
 


### PR DESCRIPTION
If we don't wait long enough for uwsgi to shut down all it's workers properly OpenRC can lose track of the pid or think the daemon has crashed if shutdown finishes after OpenRC has given up.