### PR TITLE
sys-boot/grub: install an sbat for grub-install --sbat ...

### DIFF
--- a/sys-boot/grub/files/sbat.csv
+++ b/sys-boot/grub/files/sbat.csv
@@ -1,0 +1,3 @@
+sbat,1,SBAT Version,sbat,1,https://github.com/rhboot/shim/blob/main/SBAT.md
+grub,3,Free Software Foundation,grub,%PV%,https//www.gnu.org/software/grub/
+grub.gentoo,1,Gentoo,grub,%PV%,https://bugs.gentoo.org/

--- a/sys-boot/grub/grub-2.12-r2.ebuild
+++ b/sys-boot/grub/grub-2.12-r2.ebuild
@@ -315,6 +315,10 @@ src_install() {
 	# https://bugs.gentoo.org/231935
 	dostrip -x /usr/lib/grub
 
+	sed -e "s/%PV%/${PV}/" "${FILESDIR}/sbat.csv" > "${T}/sbat.csv" || die
+	insinto /usr/share/grub
+	doins "${T}/sbat.csv"
+
 	if use elibc_musl; then
 		# https://bugs.gentoo.org/900348
 		QA_CONFIG_IMPL_DECL_SKIP=( re_{compile_pattern,match,search,set_syntax} )

--- a/sys-boot/grub/grub-9999.ebuild
+++ b/sys-boot/grub/grub-9999.ebuild
@@ -311,6 +311,10 @@ src_install() {
 	# https://bugs.gentoo.org/231935
 	dostrip -x /usr/lib/grub
 
+	sed -e "s/%PV%/${PV}/" "${FILESDIR}/sbat.csv" > "${T}/sbat.csv" || die
+	insinto /usr/share/grub
+	doins "${T}/sbat.csv"
+
 	if use elibc_musl; then
 		# https://bugs.gentoo.org/900348
 		QA_CONFIG_IMPL_DECL_SKIP=( re_{compile_pattern,match,search,set_syntax} )


### PR DESCRIPTION
Booting with sys-boot/shim requires that an sbat section is present in the EFI executable. Add an `sbat.csv` file that can optionally be included when building the grub EFI executable.

CC @floppym 

Closes: https://bugs.gentoo.org/925902