### PR TITLE
meson.eclass */*: EMESON_BUILDTYPE & deduplicate some debug logic

### DIFF
--- a/dev-libs/efl/efl-1.27.0.ebuild
+++ b/dev-libs/efl/efl-1.27.0.ebuild
@@ -155,8 +155,6 @@ src_prepare() {
 
 src_configure() {
 	local emesonargs=(
-		-Dbuildtype=plain
-
 		-D buffer=false
 		-D build-tests=false
 		-D cocoa=false

--- a/dev-libs/glib/glib-2.78.4-r1.ebuild
+++ b/dev-libs/glib/glib-2.78.4-r1.ebuild
@@ -187,7 +187,9 @@ multilib_src_configure() {
 	#fi
 
 	local emesonargs=(
-		-Dbuildtype=$(usex debug debug plain)
+		-Dbuildtype=plain
+
+		$(meson_feature debug glib_debug)
 		-Ddefault_library=$(usex static-libs both shared)
 		-Druntime_dir="${EPREFIX}"/run
 		$(meson_feature selinux)

--- a/dev-libs/glib/glib-2.78.4-r1.ebuild
+++ b/dev-libs/glib/glib-2.78.4-r1.ebuild
@@ -187,8 +187,6 @@ multilib_src_configure() {
 	#fi
 
 	local emesonargs=(
-		-Dbuildtype=plain
-
 		$(meson_feature debug glib_debug)
 		-Ddefault_library=$(usex static-libs both shared)
 		-Druntime_dir="${EPREFIX}"/run

--- a/dev-util/intel_clc/intel_clc-24.0.2.ebuild
+++ b/dev-util/intel_clc/intel_clc-24.0.2.ebuild
@@ -59,6 +59,8 @@ pkg_setup() {
 src_configure() {
 	PKG_CONFIG_PATH="$(get_llvm_prefix)/$(get_libdir)/pkgconfig"
 
+	use debug && EMESON_BUILDTYPE=debug
+
 	local emesonargs=(
 		-Dllvm=enabled
 		-Dshared-llvm=enabled
@@ -75,7 +77,6 @@ src_configure() {
 		-Dlibunwind=disabled
 		-Dzstd=disabled
 
-		-Dbuildtype=$(usex debug debug plain)
 		-Db_ndebug=$(usex debug false true)
 	)
 	meson_src_configure

--- a/dev-util/intel_clc/intel_clc-9999.ebuild
+++ b/dev-util/intel_clc/intel_clc-9999.ebuild
@@ -59,6 +59,8 @@ pkg_setup() {
 src_configure() {
 	PKG_CONFIG_PATH="$(get_llvm_prefix)/$(get_libdir)/pkgconfig"
 
+	use debug && EMESON_BUILDTYPE=debug
+
 	local emesonargs=(
 		-Dllvm=enabled
 		-Dshared-llvm=enabled
@@ -75,7 +77,6 @@ src_configure() {
 		-Dlibunwind=disabled
 		-Dzstd=disabled
 
-		-Dbuildtype=$(usex debug debug plain)
 		-Db_ndebug=$(usex debug false true)
 	)
 	meson_src_configure

--- a/media-libs/mesa-amber/mesa-amber-21.3.9-r1.ebuild
+++ b/media-libs/mesa-amber/mesa-amber-21.3.9-r1.ebuild
@@ -157,6 +157,8 @@ multilib_src_configure() {
 		echo "${drivers//$'\n'/,}"
 	}
 
+	use debug && EMESON_BUILDTYPE=debug
+
 	emesonargs+=(
 		-Damber=true
 		$(meson_use test build-tests)
@@ -177,7 +179,6 @@ multilib_src_configure() {
 		-Ddri-drivers=$(driver_list "${DRI_DRIVERS[*]}")
 		-Dgallium-drivers=''
 		-Dvulkan-drivers=''
-		-Dbuildtype=$(usex debug debug plain)
 		-Db_ndebug=$(usex debug false true)
 	)
 	meson_src_configure

--- a/media-libs/mesa/mesa-24.0.2.ebuild
+++ b/media-libs/mesa/mesa-24.0.2.ebuild
@@ -383,6 +383,8 @@ multilib_src_configure() {
 		emesonargs+=(-Dglx=disabled)
 	fi
 
+	use debug && EMESON_BUILDTYPE=debug
+
 	emesonargs+=(
 		$(meson_use test build-tests)
 		-Dshared-glapi=enabled
@@ -402,7 +404,6 @@ multilib_src_configure() {
 		-Dvideo-codecs=$(usex proprietary-codecs "all" "all_free")
 		-Dgallium-drivers=$(driver_list "${GALLIUM_DRIVERS[*]}")
 		-Dvulkan-drivers=$(driver_list "${VULKAN_DRIVERS[*]}")
-		-Dbuildtype=$(usex debug debug plain)
 		-Db_ndebug=$(usex debug false true)
 	)
 	meson_src_configure

--- a/media-libs/mesa/mesa-9999.ebuild
+++ b/media-libs/mesa/mesa-9999.ebuild
@@ -371,6 +371,8 @@ multilib_src_configure() {
 		emesonargs+=(-Dglx=disabled)
 	fi
 
+	use debug && EMESON_BUILDTYPE=debug
+
 	emesonargs+=(
 		$(meson_use test build-tests)
 		-Dshared-glapi=enabled
@@ -392,7 +394,6 @@ multilib_src_configure() {
 		-Dvideo-codecs=$(usex proprietary-codecs "all" "all_free")
 		-Dgallium-drivers=$(driver_list "${GALLIUM_DRIVERS[*]}")
 		-Dvulkan-drivers=$(driver_list "${VULKAN_DRIVERS[*]}")
-		-Dbuildtype=$(usex debug debug plain)
 		-Db_ndebug=$(usex debug false true)
 	)
 	meson_src_configure

--- a/media-libs/rubberband/rubberband-3.3.0-r1.ebuild
+++ b/media-libs/rubberband/rubberband-3.3.0-r1.ebuild
@@ -33,6 +33,8 @@ BDEPEND="
 	test? ( dev-libs/boost[${MULTILIB_USEDEP}] )
 "
 
+EMESON_BUILDTYPE=release
+
 src_prepare() {
 	sed -i \
 		-e "s/if have_jni/if get_option('jni')/g" \
@@ -60,7 +62,6 @@ multilib_src_configure() {
 	fi
 
 	local emesonargs=(
-		-Dbuildtype=release
 		-Dfft=fftw
 		-Dresampler=libsamplerate
 		-Ddefault_library=$(use static-libs && echo "both" || echo "shared")

--- a/sys-auth/elogind/elogind-252.9.ebuild
+++ b/sys-auth/elogind/elogind-252.9.ebuild
@@ -97,6 +97,8 @@ src_configure() {
 
 	python_setup
 
+	EMESON_BUILDTYPE="$(usex debug debug release)"
+
 	local emesonargs=(
 		-Ddocdir="${EPREFIX}/usr/share/doc/${PF}"
 		-Dhtmldir="${EPREFIX}/usr/share/doc/${PF}/html"
@@ -114,7 +116,6 @@ src_configure() {
 		-Ddefault-kill-user-processes=false
 		-Dacl=$(usex acl true false)
 		-Daudit=$(usex audit true false)
-		-Dbuildtype=$(usex debug debug release)
 		-Dhtml=$(usex doc auto false)
 		-Dpam=$(usex pam true false)
 		-Dselinux=$(usex selinux true false)

--- a/x11-base/xorg-server/xorg-server-21.1.11.ebuild
+++ b/x11-base/xorg-server/xorg-server-21.1.11.ebuild
@@ -110,13 +110,14 @@ src_configure() {
 	# bug #835653
 	use x86 && replace-flags -Os -O2
 
+	use debug && EMESON_BUILDTYPE=debug
+
 	# localstatedir is used for the log location; we need to override the default
 	#	from ebuild.sh
 	# sysconfdir is used for the xorg.conf location; same applies
 	local emesonargs=(
 		--localstatedir "${EPREFIX}/var"
 		--sysconfdir "${EPREFIX}/etc/X11"
-		-Dbuildtype=$(usex debug debug plain)
 		-Db_ndebug=$(usex debug false true)
 		$(meson_use !minimal dri1)
 		$(meson_use !minimal dri2)

--- a/x11-base/xorg-server/xorg-server-9999.ebuild
+++ b/x11-base/xorg-server/xorg-server-9999.ebuild
@@ -105,13 +105,14 @@ src_configure() {
 	# bug #835653
 	use x86 && replace-flags -Os -O2
 
+	use debug && EMESON_BUILDTYPE=debug
+
 	# localstatedir is used for the log location; we need to override the default
 	#	from ebuild.sh
 	# sysconfdir is used for the xorg.conf location; same applies
 	local emesonargs=(
 		--localstatedir "${EPREFIX}/var"
 		--sysconfdir "${EPREFIX}/etc/X11"
-		-Dbuildtype=$(usex debug debug plain)
 		-Db_ndebug=$(usex debug false true)
 		$(meson_use !minimal dri1)
 		$(meson_use !minimal dri2)

--- a/x11-wm/mutter/mutter-45.2-r1.ebuild
+++ b/x11-wm/mutter/mutter-45.2-r1.ebuild
@@ -152,6 +152,8 @@ python_check_deps() {
 }
 
 src_configure() {
+	use debug && EMESON_BUILDTYPE=debug
+
 	local emesonargs=(
 		# Mutter X11 renderer only supports gles2 and GLX, thus do NOT pass
 		#
@@ -166,7 +168,6 @@ src_configure() {
 		# - https://bugs.gentoo.org/835786
 		# - https://forums.gentoo.org/viewtopic-p-8695669.html
 
-		-Dbuildtype=$(usex debug debug plain)
 		-Dopengl=true
 		$(meson_use wayland gles2)
 		#gles2_libname

--- a/x11-wm/mutter/mutter-9999.ebuild
+++ b/x11-wm/mutter/mutter-9999.ebuild
@@ -150,6 +150,8 @@ python_check_deps() {
 }
 
 src_configure() {
+	use debug && EMESON_BUILDTYPE=debug
+
 	local emesonargs=(
 		# Mutter X11 renderer only supports gles2 and GLX, thus do NOT pass
 		#
@@ -164,7 +166,6 @@ src_configure() {
 		# - https://bugs.gentoo.org/835786
 		# - https://forums.gentoo.org/viewtopic-p-8695669.html
 
-		-Dbuildtype=$(usex debug debug plain)
 		-Dopengl=true
 		$(meson_use wayland gles2)
 		#gles2_libname


### PR DESCRIPTION
Not sure if this PR is an overstep or if the commits are grouped together but this will help to potentially avoid issues like https://bugs.gentoo.org/925949

Also, EMESON_BUILDTYPE hasn't been used anywhere previously?

> 15:47 < mjsir911> question about EMESON_BUILDTYPE: is anything actually using it? Is this intended to be used in ebuilds or specified by users calling emerge? I'm a bit confused
> 15:48 <@sam_> I had no idea it existed until you mentioned it
> 15:48 <@sam_> or i forgot about it
> 15:48 <@sam_> i think the former though ;)

Of note is that commit d0668710dab3af3842b4cae50ebd6d2b393641e3 introduces a change in the build process for some packages
eg glib that didn't previously set `-Db_ndebug` when `use debug`