### PR TITLE
games-emulation/gambatte-jg: update dependencies

### DIFF
--- a/games-emulation/gambatte-jg/gambatte-jg-9999.ebuild
+++ b/games-emulation/gambatte-jg/gambatte-jg-9999.ebuild
@@ -29,8 +29,7 @@ REQUIRED_USE="|| ( examples jgmodule shared )"
 
 DEPEND="
 	examples? (
-		media-libs/libglvnd
-		media-libs/libsdl2[opengl,sound,video]
+		media-libs/libsdl2[sound,video]
 		media-libs/speexdsp
 	)
 	jgmodule? (


### PR DESCRIPTION
Upstream decided to use the SDL renderer instead of opengl for gambatte-example.

Upstream-Commit: https://gitlab.com/jgemu/gambatte/-/commit/9c11623a72412e821c594772ca335885c34b453b
Upstream-Commit: https://gitlab.com/jgemu/gambatte/-/commit/d0932d38f0df4ddc3a18e3465276eea9ff743166