### PR TITLE
media-libs/gst-plugins-bad: enable debugutils and transcode

### DIFF
--- a/media-libs/gst-plugins-bad/gst-plugins-bad-1.20.5-r1.ebuild
+++ b/media-libs/gst-plugins-bad/gst-plugins-bad-1.20.5-r1.ebuild
@@ -49,6 +49,8 @@ BDEPEND="
 	dev-util/glib-utils
 "
 
+GST_PLUGINS_ENABLED="debugutils transcode"
+
 DOCS=( AUTHORS ChangeLog NEWS README.md RELEASE )
 
 # FIXME: gstharness.c:889:gst_harness_new_with_padnames: assertion failed: (element != NULL)

--- a/media-libs/gst-plugins-bad/gst-plugins-bad-1.20.6.ebuild
+++ b/media-libs/gst-plugins-bad/gst-plugins-bad-1.20.6.ebuild
@@ -49,6 +49,8 @@ BDEPEND="
 	dev-util/glib-utils
 "
 
+GST_PLUGINS_ENABLED="debugutils transcode"
+
 DOCS=( AUTHORS ChangeLog NEWS README.md RELEASE )
 
 # FIXME: gstharness.c:889:gst_harness_new_with_padnames: assertion failed: (element != NULL)

--- a/media-libs/gst-plugins-bad/gst-plugins-bad-1.22.3-r1.ebuild
+++ b/media-libs/gst-plugins-bad/gst-plugins-bad-1.22.3-r1.ebuild
@@ -49,6 +49,8 @@ BDEPEND="
 	dev-util/glib-utils
 "
 
+GST_PLUGINS_ENABLED="debugutils transcode"
+
 DOCS=( AUTHORS ChangeLog NEWS README.md RELEASE )
 
 # FIXME: gstharness.c:889:gst_harness_new_with_padnames: assertion failed: (element != NULL)

--- a/media-libs/gst-plugins-bad/gst-plugins-bad-1.22.3-r3.ebuild
+++ b/media-libs/gst-plugins-bad/gst-plugins-bad-1.22.3-r3.ebuild
@@ -54,6 +54,8 @@ BDEPEND="
 	dev-util/glib-utils
 "
 
+GST_PLUGINS_ENABLED="debugutils transcode"
+
 DOCS=( AUTHORS ChangeLog NEWS README.md RELEASE )
 
 # FIXME: gstharness.c:889:gst_harness_new_with_padnames: assertion failed: (element != NULL)

--- a/media-libs/gst-plugins-bad/gst-plugins-bad-1.22.3.ebuild
+++ b/media-libs/gst-plugins-bad/gst-plugins-bad-1.22.3.ebuild
@@ -49,6 +49,8 @@ BDEPEND="
 	dev-util/glib-utils
 "
 
+GST_PLUGINS_ENABLED="debugutils transcode"
+
 DOCS=( AUTHORS ChangeLog NEWS README.md RELEASE )
 
 # FIXME: gstharness.c:889:gst_harness_new_with_padnames: assertion failed: (element != NULL)


### PR DESCRIPTION
media-plugins/gst-transcoder was removed from portage
because it was merged to media-libs/gst-plugins-bad,
however debugutils and transcode gst plugins were not enabled
which caused "RuntimeError: unknown type name: GstCpuThrottlingClock"
and "debugutilsbad GStreamer plug-in not found on the system"
in media-video/pitivi

Closes: https://bugs.gentoo.org/868609