### PR TITLE
net-wireless/rtl_433: Fix etc installation

### DIFF
--- a/net-wireless/rtl_433/rtl_433-9999.ebuild
+++ b/net-wireless/rtl_433/rtl_433-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -41,9 +41,4 @@ src_configure() {
 		-DBUILD_TESTING="$(usex test)"
 	)
 	cmake_src_configure
-}
-
-src_install() {
-	cmake_src_install
-	mv "${ED}/usr/etc" "${ED}/" || die
 }


### PR DESCRIPTION
Upstream now uses correct install destination for etc.

Closes: https://bugs.gentoo.org/926165