### PR TITLE
app-editors/vscode: fix fcitx:5 doesn't work under native wayland

### DIFF
--- a/app-editors/vscode/vscode-1.87.0-r1.ebuild
+++ b/app-editors/vscode/vscode-1.87.0-r1.ebuild
@@ -1,0 +1,136 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit desktop pax-utils xdg optfeature
+
+DESCRIPTION="Multiplatform Visual Studio Code from Microsoft"
+HOMEPAGE="https://code.visualstudio.com"
+SRC_URI="
+	amd64? ( https://update.code.visualstudio.com/${PV}/linux-x64/stable -> ${P}-amd64.tar.gz )
+	arm? ( https://update.code.visualstudio.com/${PV}/linux-armhf/stable -> ${P}-arm.tar.gz )
+	arm64? ( https://update.code.visualstudio.com/${PV}/linux-arm64/stable -> ${P}-arm64.tar.gz )
+"
+S="${WORKDIR}"
+
+LICENSE="
+	Apache-2.0
+	BSD
+	BSD-1
+	BSD-2
+	BSD-4
+	CC-BY-4.0
+	ISC
+	LGPL-2.1+
+	Microsoft-vscode
+	MIT
+	MPL-2.0
+	openssl
+	PYTHON
+	TextMate-bundle
+	Unlicense
+	UoI-NCSA
+	W3C
+"
+SLOT="0"
+KEYWORDS="-* ~amd64 ~arm ~arm64"
+IUSE="egl kerberos wayland "
+REQURED_USE="
+	wayland-ime? ( wayland )
+"
+RESTRICT="mirror strip bindist"
+
+RDEPEND="
+	>=app-accessibility/at-spi2-core-2.46.0:2
+	app-crypt/libsecret[crypt]
+	app-misc/ca-certificates
+	dev-libs/expat
+	dev-libs/glib:2
+	dev-libs/nspr
+	dev-libs/nss
+	media-libs/alsa-lib
+	media-libs/libcanberra[gtk3]
+	media-libs/libglvnd
+	media-libs/mesa
+	net-misc/curl
+	sys-apps/dbus
+	sys-libs/zlib
+	sys-process/lsof
+	x11-libs/cairo
+	x11-libs/gtk+:3
+	x11-libs/libdrm
+	x11-libs/libX11
+	x11-libs/libxcb
+	x11-libs/libXcomposite
+	x11-libs/libXdamage
+	x11-libs/libXext
+	x11-libs/libXfixes
+	x11-libs/libxkbcommon
+	x11-libs/libxkbfile
+	x11-libs/libXrandr
+	x11-libs/libXScrnSaver
+	x11-libs/pango
+	x11-misc/xdg-utils
+	kerberos? ( app-crypt/mit-krb5 )
+"
+
+QA_PREBUILT="*"
+
+src_install() {
+	if use amd64; then
+		cd "${WORKDIR}/VSCode-linux-x64" || die
+	elif use arm; then
+		cd "${WORKDIR}/VSCode-linux-armhf" || die
+	elif use arm64; then
+		cd "${WORKDIR}/VSCode-linux-arm64" || die
+	else
+		die "Visual Studio Code only supports amd64, arm and arm64"
+	fi
+
+	# Cleanup
+	rm -r ./resources/app/ThirdPartyNotices.txt || die
+
+	# Disable update server
+	sed -e "/updateUrl/d" -i ./resources/app/product.json || die
+
+	if ! use kerberos; then
+		rm -r ./resources/app/node_modules.asar.unpacked/kerberos || die
+	fi
+
+	# Install
+	pax-mark m code
+	mkdir -p "${ED}/opt/${PN}" || die
+	cp -r . "${ED}/opt/${PN}" || die
+	fperms 4711 /opt/${PN}/chrome-sandbox
+
+	dosym -r "/opt/${PN}/bin/code" "usr/bin/vscode"
+	dosym -r "/opt/${PN}/bin/code" "usr/bin/code"
+
+	local EXEC_EXTRA_FLAGS=()
+	if use wayland; then
+		EXEC_EXTRA_FLAGS+=( "--ozone-platform-hint=auto" )
+		EXEC_EXTRA_FLAGS+=( "--enable-wayland-ime" )
+	fi
+	if use egl; then
+		EXEC_EXTRA_FLAGS+=( "--use-gl=egl" )
+	fi
+
+	sed "s|@exec_extra_flags@|${EXEC_EXTRA_FLAGS[*]}|g" \
+		"${FILESDIR}/code-url-handler.desktop" \
+		> "${T}/code-url-handler.desktop" || die
+
+	sed "s|@exec_extra_flags@|${EXEC_EXTRA_FLAGS[*]}|g" \
+		"${FILESDIR}/code.desktop" \
+		> "${T}/code.desktop" || die
+
+	domenu "${T}/code.desktop"
+	domenu "${T}/code-url-handler.desktop"
+	newicon "resources/app/resources/linux/code.png" "vscode.png"
+}
+
+pkg_postinst() {
+	xdg_pkg_postinst
+	optfeature "desktop notifications" x11-libs/libnotify
+	optfeature "keyring support inside vscode" "virtual/secret-service"
+}


### PR DESCRIPTION
Just a small fix and make app-i18n/fcitx:5 working in vscode under wayland