### PR TITLE
net-libs/webkit-gtk: Fixes ARM64 non-jumbo build

### DIFF
--- a/net-libs/webkit-gtk/files/2.42.3-arm64-non-jumbo-fix-925621.patch
+++ b/net-libs/webkit-gtk/files/2.42.3-arm64-non-jumbo-fix-925621.patch
@@ -1,0 +1,29 @@
+From 56001e951362a5064027b1af81283e523e35559b Mon Sep 17 00:00:00 2001
+From: Dennis Camera <dennis.camera+webkit@riiengineering.ch>
+Date: Mon, 4 Mar 2024 09:27:54 -0800
+Subject: [PATCH] [JSC] A64DOpcode include <mutex>
+ https://bugs.webkit.org/show_bug.cgi?id=270394
+
+Reviewed by Michael Catanzaro.
+
+When UNIFIED_BUILDS are disabled, the build fails due to missing std::call_once.
+
+* Source/JavaScriptCore/disassembler/ARM64/A64DOpcode.h: include <mutex>.
+
+Canonical link: https://commits.webkit.org/275630@main
+---
+ Source/JavaScriptCore/disassembler/ARM64/A64DOpcode.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/Source/JavaScriptCore/disassembler/ARM64/A64DOpcode.h b/Source/JavaScriptCore/disassembler/ARM64/A64DOpcode.h
+index 0392bcb6e20a0..202aa4d1d81de 100644
+--- a/Source/JavaScriptCore/disassembler/ARM64/A64DOpcode.h
++++ b/Source/JavaScriptCore/disassembler/ARM64/A64DOpcode.h
+@@ -25,6 +25,7 @@
+ 
+ #pragma once
+ 
++#include <mutex>
+ #include <stdint.h>
+ #include <wtf/Assertions.h>
+ #include <wtf/DataLog.h>

--- a/net-libs/webkit-gtk/webkit-gtk-2.42.3-r410.ebuild
+++ b/net-libs/webkit-gtk/webkit-gtk-2.42.3-r410.ebuild
@@ -153,6 +153,7 @@ src_prepare() {
 
 	# Fix USE=-jumbo-build compilation on arm64
 	eapply "${FILESDIR}"/2.42.1-arm64-non-jumbo-fix.patch
+	eapply "${FILESDIR}"/2.42.3-arm64-non-jumbo-fix-925621.patch
 }
 
 src_configure() {

--- a/net-libs/webkit-gtk/webkit-gtk-2.42.3-r600.ebuild
+++ b/net-libs/webkit-gtk/webkit-gtk-2.42.3-r600.ebuild
@@ -154,6 +154,7 @@ src_prepare() {
 
 	# Fix USE=-jumbo-build compilation on arm64
 	eapply "${FILESDIR}"/2.42.1-arm64-non-jumbo-fix.patch
+	eapply "${FILESDIR}"/2.42.3-arm64-non-jumbo-fix-925621.patch
 }
 
 src_configure() {

--- a/net-libs/webkit-gtk/webkit-gtk-2.42.3.ebuild
+++ b/net-libs/webkit-gtk/webkit-gtk-2.42.3.ebuild
@@ -151,6 +151,7 @@ src_prepare() {
 
 	# Fix USE=-jumbo-build compilation on arm64
 	eapply "${FILESDIR}"/2.42.1-arm64-non-jumbo-fix.patch
+	eapply "${FILESDIR}"/2.42.3-arm64-non-jumbo-fix-925621.patch
 }
 
 src_configure() {

--- a/net-libs/webkit-gtk/webkit-gtk-2.42.4-r410.ebuild
+++ b/net-libs/webkit-gtk/webkit-gtk-2.42.4-r410.ebuild
@@ -155,6 +155,7 @@ src_prepare() {
 
 	# Fix USE=-jumbo-build compilation on arm64
 	eapply "${FILESDIR}"/2.42.1-arm64-non-jumbo-fix.patch
+	eapply "${FILESDIR}"/2.42.3-arm64-non-jumbo-fix-925621.patch
 	# Fix assert failure on some machines, bug #920704
 	eapply "${FILESDIR}"/2.42.4-wasm-assert-fix.patch
 }

--- a/net-libs/webkit-gtk/webkit-gtk-2.42.4-r600.ebuild
+++ b/net-libs/webkit-gtk/webkit-gtk-2.42.4-r600.ebuild
@@ -156,6 +156,7 @@ src_prepare() {
 
 	# Fix USE=-jumbo-build compilation on arm64
 	eapply "${FILESDIR}"/2.42.1-arm64-non-jumbo-fix.patch
+	eapply "${FILESDIR}"/2.42.3-arm64-non-jumbo-fix-925621.patch
 	# Fix assert failure on some machines, bug #920704
 	eapply "${FILESDIR}"/2.42.4-wasm-assert-fix.patch
 }

--- a/net-libs/webkit-gtk/webkit-gtk-2.42.4.ebuild
+++ b/net-libs/webkit-gtk/webkit-gtk-2.42.4.ebuild
@@ -153,6 +153,7 @@ src_prepare() {
 
 	# Fix USE=-jumbo-build compilation on arm64
 	eapply "${FILESDIR}"/2.42.1-arm64-non-jumbo-fix.patch
+	eapply "${FILESDIR}"/2.42.3-arm64-non-jumbo-fix-925621.patch
 	# Fix assert failure on some machines, bug #920704
 	eapply "${FILESDIR}"/2.42.4-wasm-assert-fix.patch
 }

--- a/net-libs/webkit-gtk/webkit-gtk-2.42.5-r410.ebuild
+++ b/net-libs/webkit-gtk/webkit-gtk-2.42.5-r410.ebuild
@@ -155,6 +155,7 @@ src_prepare() {
 
 	# Fix USE=-jumbo-build compilation on arm64
 	eapply "${FILESDIR}"/2.42.1-arm64-non-jumbo-fix.patch
+	eapply "${FILESDIR}"/2.42.3-arm64-non-jumbo-fix-925621.patch
 	# Fix assert failure on some machines, bug #920704
 	eapply "${FILESDIR}"/2.42.4-wasm-assert-fix.patch
 	# Fix compilation on x86, bug #924873

--- a/net-libs/webkit-gtk/webkit-gtk-2.42.5-r600.ebuild
+++ b/net-libs/webkit-gtk/webkit-gtk-2.42.5-r600.ebuild
@@ -156,6 +156,7 @@ src_prepare() {
 
 	# Fix USE=-jumbo-build compilation on arm64
 	eapply "${FILESDIR}"/2.42.1-arm64-non-jumbo-fix.patch
+	eapply "${FILESDIR}"/2.42.3-arm64-non-jumbo-fix-925621.patch
 	# Fix assert failure on some machines, bug #920704
 	eapply "${FILESDIR}"/2.42.4-wasm-assert-fix.patch
 	# Fix compilation on x86, bug #924873

--- a/net-libs/webkit-gtk/webkit-gtk-2.42.5.ebuild
+++ b/net-libs/webkit-gtk/webkit-gtk-2.42.5.ebuild
@@ -153,6 +153,7 @@ src_prepare() {
 
 	# Fix USE=-jumbo-build compilation on arm64
 	eapply "${FILESDIR}"/2.42.1-arm64-non-jumbo-fix.patch
+	eapply "${FILESDIR}"/2.42.3-arm64-non-jumbo-fix-925621.patch
 	# Fix assert failure on some machines, bug #920704
 	eapply "${FILESDIR}"/2.42.4-wasm-assert-fix.patch
 	# Fix compilation on x86, bug #924873


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/925621