### PR TITLE
app-arch/torrentzip: Fix 1.2 regression

### DIFF
--- a/app-arch/torrentzip/files/torrentzip-1.2-checksum-detection.patch
+++ b/app-arch/torrentzip/files/torrentzip-1.2-checksum-detection.patch
@@ -1,0 +1,51 @@
+From 016915e16f32105590a6dc11a4adc988b2f8d9a9 Mon Sep 17 00:00:00 2001
+From: Alexander Miller <alex.miller@gmx.de>
+Date: Mon, 4 Mar 2024 19:26:21 +0100
+Subject: [PATCH] Fix broken detection of missing or wrong TORRENTZIPPED-...
+ comment
+
+The commit listed below introduces a regression where in MigrateZip(),
+variable rc would be clobbered when its value is still needed. That
+completely breaks handling of zips that should be re-zipped because
+of missing or out of date TORRENTZIPPED-... comment.
+
+Rewrite the offending code such that it no longer touches the variable.
+
+Fixes: cf11c900079e ("Check for more errors while reading zip entries")
+---
+ src/trrntzip.c | 20 ++++++++++++--------
+ 1 file changed, 12 insertions(+), 8 deletions(-)
+
+diff --git a/src/trrntzip.c b/src/trrntzip.c
+index e55d217..49f796e 100644
+--- a/src/trrntzip.c
++++ b/src/trrntzip.c
+@@ -379,16 +379,20 @@ int MigrateZip(const char *zip_path, const char *pDir, WORKSPACE *ws,
+ 
+   CHECK_DYNAMIC_STRING_ARRAY(ws->FileNameArray, ws->iElements);
+   // Get the filelist from the zip file in original order in ws->FileNameArray
+-  rc = GetFileList(UnZipHandle, ws);
+-  if (rc != TZ_OK) {
++  switch (GetFileList(UnZipHandle, ws)) {
++  case TZ_OK:
++    break;
++  case TZ_CRITICAL:
+     logprint3(stderr, mig->fProcessLog, ErrorLog(ws),
+-              rc == TZ_CRITICAL
+-                  ? "Error allocating memory!\n"
+-                  : "Could not list contents of \"%s\". File is corrupted or "
+-                    "contains entries with bad names.\n",
+-              szZipFileName);
++              "Error allocating memory!\n");
++    unzClose(UnZipHandle);
++    return TZ_CRITICAL;
++  default:
++    logprint3(stderr, mig->fProcessLog, ErrorLog(ws),
++              "Could not list contents of \"%s\". File is corrupted or "
++              "contains entries with bad names.\n", szZipFileName);
+     unzClose(UnZipHandle);
+-    return rc;
++    return TZ_ERR;
+   }
+   CHECK_DYNAMIC_STRING_ARRAY(ws->FileNameArray, ws->iElements);
+ 

--- a/app-arch/torrentzip/torrentzip-1.2-r1.ebuild
+++ b/app-arch/torrentzip/torrentzip-1.2-r1.ebuild
@@ -23,3 +23,6 @@ DEPEND="
 "
 
 DOCS=(AUTHORS NEWS.md README.md)
+PATCHES=(
+	"${FILESDIR}-${P}-checksum-detection.patch"
+)


### PR DESCRIPTION
TorrentZip 1.2 skips files although their checksum comment doesn't match or is entirely missing, which is a serious problem.

Pick the patch from upstream git main that fixes the issue.

See: https://github.com/0-wiz-0/trrntzip/pull/3#issuecomment-1975326415