### PR TITLE
dev-libs/libsecp256k1: fix build when CC is overridden to clang

### DIFF
--- a/dev-libs/libsecp256k1/files/0.3.0-fix-cross-compile.patch
+++ b/dev-libs/libsecp256k1/files/0.3.0-fix-cross-compile.patch
@@ -1,6 +1,6 @@
 https://github.com/bitcoin-core/secp256k1/pull/1159
 
-From 772e747bd9104d80fe531bed61f23f75342d7d63 Mon Sep 17 00:00:00 2001
+From dc87b08eea757aae95b1efc25fe543e91510df0a Mon Sep 17 00:00:00 2001
 From: Matt Whitlock <bitcoin@mattwhitlock.name>
 Date: Sun, 20 Nov 2022 01:46:07 -0500
 Subject: [PATCH] Makefile: build precomp generators using build-system
@@ -11,24 +11,26 @@ files need to be regenerated, then the generators need to be built for
 the *build* system, not for the *host* system. Autoconf supports this
 fairly cleanly via the `AX_PROG_CC_FOR_BUILD` macro (from Autoconf
 Archive), but Automake requires some hackery. When building the
-generators, we override the `CC`, `CFLAGS`, `CPPFLAGS`, and `LDFLAGS`
-variables to their build-system counterparts, whose names are suffixed
-with `_FOR_BUILD` and whose values are populated by the aforementioned
-Autoconf macro and may be overridden on the `make` command line. Since
-Automake lacks support for overriding `EXEEXT` on a per-program basis,
-we define a recipe that builds the generator binaries with names
-suffixed with `$(EXEEXT)` and then renames them suffixed with
+generators, we override the `CC` variable to its build-system
+counterpart, `CC_FOR_BUILD`, and we specify Automake per-program
+overrides for `CFLAGS`, `CPPFLAGS`, and `LDFLAGS`, setting their values
+respectively from the `CFLAGS_FOR_BUILD`, `CPPFLAGS_FOR_BUILD`, and
+`LDFLAGS_FOR_BUILD` variables, whose values in turn are populated by the
+aforementioned Autoconf macro and may be overridden on the `make`
+command line. Since Automake lacks support for overriding `EXEEXT` on a
+per-program basis, we define a recipe that builds the generator binaries
+with names suffixed with `$(EXEEXT)` and then renames them suffixed with
 `$(BUILD_EXEEXT)`.
 ---
- Makefile.am  | 30 ++++++++++++++++++++++++------
+ Makefile.am  | 35 +++++++++++++++++++++++++++--------
  configure.ac |  1 +
- 2 files changed, 25 insertions(+), 6 deletions(-)
+ 2 files changed, 28 insertions(+), 8 deletions(-)
 
 diff --git a/Makefile.am b/Makefile.am
-index 30b6a794d0..e929300298 100644
+index e3fdf4da..5e859c91 100644
 --- a/Makefile.am
 +++ b/Makefile.am
-@@ -180,8 +180,26 @@ endif
+@@ -186,15 +186,34 @@ endif
  endif
  
  ### Precomputed tables
@@ -36,9 +38,6 @@ index 30b6a794d0..e929300298 100644
 -CLEANFILES = $(EXTRA_PROGRAMS)
 +PROGRAMS_FOR_BUILD = precompute_ecmult precompute_ecmult_gen
 +$(addsuffix $(BUILD_EXEEXT),$(PROGRAMS_FOR_BUILD)) : override CC = $(CC_FOR_BUILD)
-+$(addsuffix $(BUILD_EXEEXT),$(PROGRAMS_FOR_BUILD)) : override CFLAGS = $(CFLAGS_FOR_BUILD)
-+$(addsuffix $(BUILD_EXEEXT),$(PROGRAMS_FOR_BUILD)) : override CPPFLAGS = $(CPPFLAGS_FOR_BUILD)
-+$(addsuffix $(BUILD_EXEEXT),$(PROGRAMS_FOR_BUILD)) : override LDFLAGS = $(LDFLAGS_FOR_BUILD)
 +# Automake has no support for PROGRAMS suffixed with BUILD_EXEEXT
 +# instead of EXEEXT, so if those extensions differ, then we define a
 +# recipe that builds the latter and renames it to the former. Since
@@ -56,8 +55,21 @@ index 30b6a794d0..e929300298 100644
 +CLEANFILES = $(addsuffix $(BUILD_EXEEXT),$(PROGRAMS_FOR_BUILD))
  
  precompute_ecmult_SOURCES = src/precompute_ecmult.c
- precompute_ecmult_CPPFLAGS = $(SECP_INCLUDES)
-@@ -198,11 +216,11 @@ precompute_ecmult_gen_LDADD = $(SECP_LIBS) $(COMMON_LIB)
+-precompute_ecmult_CPPFLAGS = $(SECP_CONFIG_DEFINES)
++precompute_ecmult_CFLAGS = $(CFLAGS_FOR_BUILD)
++precompute_ecmult_CPPFLAGS = $(CPPFLAGS_FOR_BUILD) $(SECP_CONFIG_DEFINES)
++precompute_ecmult_LDFLAGS = $(LDFLAGS_FOR_BUILD)
+ precompute_ecmult_LDADD = $(COMMON_LIB)
+ 
+ precompute_ecmult_gen_SOURCES = src/precompute_ecmult_gen.c
+-precompute_ecmult_gen_CPPFLAGS = $(SECP_CONFIG_DEFINES)
++precompute_ecmult_gen_CFLAGS = $(CFLAGS_FOR_BUILD)
++precompute_ecmult_gen_CPPFLAGS = $(CPPFLAGS_FOR_BUILD) $(SECP_CONFIG_DEFINES)
++precompute_ecmult_gen_LDFLAGS = $(LDFLAGS_FOR_BUILD)
+ precompute_ecmult_gen_LDADD = $(COMMON_LIB)
+ 
+ # See Automake manual, Section "Errors with distclean".
+@@ -204,11 +223,11 @@ precompute_ecmult_gen_LDADD = $(COMMON_LIB)
  # This means that rebuilds of the prebuilt files always need to be
  # forced by deleting them, e.g., by invoking `make clean-precomp`.
  src/precomputed_ecmult.c:
@@ -74,10 +86,10 @@ index 30b6a794d0..e929300298 100644
  PRECOMP = src/precomputed_ecmult_gen.c src/precomputed_ecmult.c
  precomp: $(PRECOMP)
 diff --git a/configure.ac b/configure.ac
-index a2a15d2b82..013964f5ff 100644
+index a46a0a7b..3b88d0d0 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -35,6 +35,7 @@ m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
+@@ -32,6 +32,7 @@ m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
  AC_PROG_CC
  AM_PROG_AS
  AM_PROG_AR

--- a/dev-libs/libsecp256k1/files/0.4.0-fix-cross-compile.patch
+++ b/dev-libs/libsecp256k1/files/0.4.0-fix-cross-compile.patch
@@ -1,0 +1,99 @@
+https://github.com/bitcoin-core/secp256k1/pull/1159
+
+From 4764fb33a47e93769ee8b9353a270989227bc2f0 Mon Sep 17 00:00:00 2001
+From: Matt Whitlock <bitcoin@mattwhitlock.name>
+Date: Sun, 20 Nov 2022 01:46:07 -0500
+Subject: [PATCH] Makefile: build precomp generators using build-system
+ toolchain
+
+When cross-compiling libsecp256k1, if the `precomputed_ecmult*.c` source
+files need to be regenerated, then the generators need to be built for
+the *build* system, not for the *host* system. Autoconf supports this
+fairly cleanly via the `AX_PROG_CC_FOR_BUILD` macro (from Autoconf
+Archive), but Automake requires some hackery. When building the
+generators, we override the `CC` variable to its build-system
+counterpart, `CC_FOR_BUILD`, and we specify Automake per-program
+overrides for `CFLAGS`, `CPPFLAGS`, and `LDFLAGS`, setting their values
+respectively from the `CFLAGS_FOR_BUILD`, `CPPFLAGS_FOR_BUILD`, and
+`LDFLAGS_FOR_BUILD` variables, whose values in turn are populated by the
+aforementioned Autoconf macro and may be overridden on the `make`
+command line. Since Automake lacks support for overriding `EXEEXT` on a
+per-program basis, we define a recipe that builds the generator binaries
+with names suffixed with `$(EXEEXT)` and then renames them suffixed with
+`$(BUILD_EXEEXT)`.
+---
+ Makefile.am  | 35 +++++++++++++++++++++++++++--------
+ configure.ac |  1 +
+ 2 files changed, 28 insertions(+), 8 deletions(-)
+
+diff --git a/Makefile.am b/Makefile.am
+index 32bc729a..de43723f 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -185,15 +185,34 @@ endif
+ endif
+ 
+ ### Precomputed tables
+-EXTRA_PROGRAMS = precompute_ecmult precompute_ecmult_gen
+-CLEANFILES = $(EXTRA_PROGRAMS)
++PROGRAMS_FOR_BUILD = precompute_ecmult precompute_ecmult_gen
++$(addsuffix $(BUILD_EXEEXT),$(PROGRAMS_FOR_BUILD)) : override CC = $(CC_FOR_BUILD)
++# Automake has no support for PROGRAMS suffixed with BUILD_EXEEXT
++# instead of EXEEXT, so if those extensions differ, then we define a
++# recipe that builds the latter and renames it to the former. Since
++# Cygwin toolchains always append '.exe' to the output file name given
++# by '-o', we ignore rename failures since the toolchain will have
++# already created the right output file. (Note: The leading spaces
++# before ifneq and endif here are a hack so Automake won't try to
++# interpret them as an Automake conditional.)
++ ifneq ($(BUILD_EXEEXT),$(EXEEXT))
++%$(BUILD_EXEEXT) : %$(EXEEXT)
++	mv -- '$<' '$@' || :
++ endif
++
++EXTRA_PROGRAMS = $(PROGRAMS_FOR_BUILD)
++CLEANFILES = $(addsuffix $(BUILD_EXEEXT),$(PROGRAMS_FOR_BUILD))
+ 
+ precompute_ecmult_SOURCES = src/precompute_ecmult.c
+-precompute_ecmult_CPPFLAGS = $(SECP_CONFIG_DEFINES) -DVERIFY
++precompute_ecmult_CFLAGS = $(CFLAGS_FOR_BUILD)
++precompute_ecmult_CPPFLAGS = $(CPPFLAGS_FOR_BUILD) $(SECP_CONFIG_DEFINES) -DVERIFY
++precompute_ecmult_LDFLAGS = $(LDFLAGS_FOR_BUILD)
+ precompute_ecmult_LDADD = $(COMMON_LIB)
+ 
+ precompute_ecmult_gen_SOURCES = src/precompute_ecmult_gen.c
+-precompute_ecmult_gen_CPPFLAGS = $(SECP_CONFIG_DEFINES) -DVERIFY
++precompute_ecmult_gen_CFLAGS = $(CFLAGS_FOR_BUILD)
++precompute_ecmult_gen_CPPFLAGS = $(CPPFLAGS_FOR_BUILD) $(SECP_CONFIG_DEFINES) -DVERIFY
++precompute_ecmult_gen_LDFLAGS = $(LDFLAGS_FOR_BUILD)
+ precompute_ecmult_gen_LDADD = $(COMMON_LIB)
+ 
+ # See Automake manual, Section "Errors with distclean".
+@@ -203,11 +222,11 @@ precompute_ecmult_gen_LDADD = $(COMMON_LIB)
+ # This means that rebuilds of the prebuilt files always need to be
+ # forced by deleting them.
+ src/precomputed_ecmult.c:
+-	$(MAKE) $(AM_MAKEFLAGS) precompute_ecmult$(EXEEXT)
+-	./precompute_ecmult$(EXEEXT)
++	$(MAKE) $(AM_MAKEFLAGS) precompute_ecmult$(BUILD_EXEEXT)
++	./precompute_ecmult$(BUILD_EXEEXT)
+ src/precomputed_ecmult_gen.c:
+-	$(MAKE) $(AM_MAKEFLAGS) precompute_ecmult_gen$(EXEEXT)
+-	./precompute_ecmult_gen$(EXEEXT)
++	$(MAKE) $(AM_MAKEFLAGS) precompute_ecmult_gen$(BUILD_EXEEXT)
++	./precompute_ecmult_gen$(BUILD_EXEEXT)
+ 
+ PRECOMP = src/precomputed_ecmult_gen.c src/precomputed_ecmult.c
+ precomp: $(PRECOMP)
+diff --git a/configure.ac b/configure.ac
+index e3877850..48072cb3 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -37,6 +37,7 @@ fi
+ AC_PROG_CC
+ AM_PROG_AS
+ AM_PROG_AR
++AX_PROG_CC_FOR_BUILD
+ 
+ # Clear some cache variables as a workaround for a bug that appears due to a bad
+ # interaction between AM_PROG_AR and LT_INIT when combining MSVC's archiver lib.exe.

--- a/dev-libs/libsecp256k1/libsecp256k1-0.3.0.ebuild
+++ b/dev-libs/libsecp256k1/libsecp256k1-0.3.0.ebuild
@@ -27,7 +27,7 @@ BDEPEND="
 "
 
 PATCHES=(
-	"${FILESDIR}/0.2.0-fix-cross-compile.patch"
+	"${FILESDIR}/0.3.0-fix-cross-compile.patch"
 )
 
 S="${WORKDIR}/${MyPN}-${PV}"

--- a/dev-libs/libsecp256k1/libsecp256k1-0.3.1.ebuild
+++ b/dev-libs/libsecp256k1/libsecp256k1-0.3.1.ebuild
@@ -27,7 +27,7 @@ BDEPEND="
 "
 
 PATCHES=(
-	"${FILESDIR}/0.2.0-fix-cross-compile.patch"
+	"${FILESDIR}/0.3.0-fix-cross-compile.patch"
 )
 
 S="${WORKDIR}/${MyPN}-${PV}"

--- a/dev-libs/libsecp256k1/libsecp256k1-0.3.2.ebuild
+++ b/dev-libs/libsecp256k1/libsecp256k1-0.3.2.ebuild
@@ -27,7 +27,7 @@ BDEPEND="
 "
 
 PATCHES=(
-	"${FILESDIR}/0.2.0-fix-cross-compile.patch"
+	"${FILESDIR}/0.3.0-fix-cross-compile.patch"
 )
 
 S="${WORKDIR}/${MyPN}-${PV}"

--- a/dev-libs/libsecp256k1/libsecp256k1-0.4.0.ebuild
+++ b/dev-libs/libsecp256k1/libsecp256k1-0.4.0.ebuild
@@ -27,7 +27,7 @@ BDEPEND="
 "
 
 PATCHES=(
-	"${FILESDIR}/0.2.0-fix-cross-compile.patch"
+	"${FILESDIR}/0.4.0-fix-cross-compile.patch"
 )
 
 S="${WORKDIR}/${MyPN}-${PV}"

--- a/dev-libs/libsecp256k1/libsecp256k1-0.4.1.ebuild
+++ b/dev-libs/libsecp256k1/libsecp256k1-0.4.1.ebuild
@@ -27,7 +27,7 @@ BDEPEND="
 "
 
 PATCHES=(
-	"${FILESDIR}/0.2.0-fix-cross-compile.patch"
+	"${FILESDIR}/0.4.0-fix-cross-compile.patch"
 )
 
 S="${WORKDIR}/${MyPN}-${PV}"


### PR DESCRIPTION
The libsecp256k1 build system detects compiler flag feature support using `${CC}` but then builds the build-time executables using `${CC_FOR_BUILD}`. When `CC` and `CC_FOR_BUILD` refer to different brands or versions of compilers, the feature detection for one will not be applicable to the other. Previous to this commit, our cross-compilation support patch attempted to override the flags when building the build-time executables, but it was doing so in a way that Automake does not respect. This commit fixes the patch so that Automake will _actually_ use `CFLAGS_FOR_BUILD`, `CPPFLAGS_FOR_BUILD`, and `LDFLAGS_FOR_BUILD` when building the build-time executables.

**Note:** No revbump is needed since these ebuilds were failing to build on affected systems, and there are no changes in the installed files on unaffected systems.

Closes: https://bugs.gentoo.org/895048

@thesamesam