### PR TITLE
app-crypt/tpm2-tss: Don't fail tmpfiles_process where /sys is restricted

### DIFF
--- a/app-crypt/tpm2-tss/files/tpm2-tss-4.0.1-Do-not-consider-failures-to-write-files-in-sys-hard.patch
+++ b/app-crypt/tpm2-tss/files/tpm2-tss-4.0.1-Do-not-consider-failures-to-write-files-in-sys-hard.patch
@@ -1,0 +1,27 @@
+From 0632885d08917092ffc8d98febd158745a74465a Mon Sep 17 00:00:00 2001
+From: Daan De Meyer <daan.j.demeyer@gmail.com>
+Date: Fri, 4 Aug 2023 16:07:52 +0200
+Subject: [PATCH] Do not consider failures to write files in /sys hard errors
+
+systemd-tmpfiles can run in containers, chroots, ... where writing to /sys will fail, so let's suffix these lines with "-" to avoid considering these cases hard errors.
+
+Signed-off-by: Daan De Meyer <daan.j.demeyer@gmail.com>
+---
+ dist/tmpfiles.d/tpm2-tss-fapi.conf.in | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/dist/tmpfiles.d/tpm2-tss-fapi.conf.in b/dist/tmpfiles.d/tpm2-tss-fapi.conf.in
+index 7ea3c652..51ff78e5 100644
+--- a/dist/tmpfiles.d/tpm2-tss-fapi.conf.in
++++ b/dist/tmpfiles.d/tpm2-tss-fapi.conf.in
+@@ -3,5 +3,5 @@ d       @localstatedir@/lib/tpm2-tss/system/keystore   2775 tss  tss   -
+ a+      @localstatedir@/lib/tpm2-tss/system/keystore   -    -    -     -           default:group:tss:rwx
+ d       @runstatedir@/tpm2-tss/eventlog                2775 tss  tss   -           -
+ a+      @runstatedir@/tpm2-tss/eventlog                -    -    -     -           default:group:tss:rwx
+-z	/sys/kernel/security/tpm[0-9]/binary_bios_measurements	0440  root tss	-	    -
+-z	/sys/kernel/security/ima/binary_runtime_measurements	0440  root tss	-	    -
++z-	/sys/kernel/security/tpm[0-9]/binary_bios_measurements	0440  root tss	-	    -
++z-	/sys/kernel/security/ima/binary_runtime_measurements	0440  root tss	-	    -
+-- 
+2.43.0
+

--- a/app-crypt/tpm2-tss/tpm2-tss-4.0.1-r1.ebuild
+++ b/app-crypt/tpm2-tss/tpm2-tss-4.0.1-r1.ebuild
@@ -1,0 +1,109 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools flag-o-matic linux-info multilib-minimal tmpfiles udev
+
+DESCRIPTION="TCG Trusted Platform Module 2.0 Software Stack"
+HOMEPAGE="https://github.com/tpm2-software/tpm2-tss"
+SRC_URI="https://github.com/tpm2-software/${PN}/releases/download/${PV}/${P}.tar.gz"
+
+LICENSE="BSD-2"
+SLOT="0/4"
+KEYWORDS="~amd64 ~arm ~arm64 ~loong ~ppc64 ~riscv ~x86"
+IUSE="doc +fapi +openssl mbedtls +policy static-libs test"
+RESTRICT="!test? ( test )"
+
+REQUIRED_USE="
+	^^ ( mbedtls openssl )
+	fapi? ( openssl !mbedtls )
+	policy? ( openssl !mbedtls )
+"
+
+RDEPEND="
+	acct-group/tss
+	acct-user/tss
+	sys-apps/util-linux:=[${MULTILIB_USEDEP}]
+	fapi? (
+		dev-libs/json-c:=[${MULTILIB_USEDEP}]
+		>=net-misc/curl-7.80.0[${MULTILIB_USEDEP}]
+	)
+	mbedtls? ( net-libs/mbedtls:=[${MULTILIB_USEDEP}] )
+	openssl? ( dev-libs/openssl:=[${MULTILIB_USEDEP}] )
+"
+
+DEPEND="
+	${RDEPEND}
+	test? ( app-crypt/swtpm
+		dev-libs/uthash
+		dev-util/cmocka
+		fapi? ( >=net-misc/curl-7.80.0 ) )
+"
+
+BDEPEND="
+	sys-apps/acl
+	virtual/pkgconfig
+	doc? ( app-text/doxygen )
+"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-4.0.0-Dont-install-files-into-run.patch"
+	"${FILESDIR}/${PN}-4.0.1-Make-sysusers-and-tmpfiles-optional.patch"
+	"${FILESDIR}/${PN}-4.0.1-Do-not-consider-failures-to-write-files-in-sys-hard.patch"
+)
+
+pkg_setup() {
+	local CONFIG_CHECK="~TCG_TPM"
+	linux-info_pkg_setup
+	kernel_is ge 4 12 0 || ewarn "At least kernel 4.12.0 is required"
+}
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+multilib_src_configure() {
+	# Fails with inlining
+	filter-flags -fno-semantic-interposition
+	# tests fail with LTO enabbled. See bug 865275 and 865279
+	filter-lto
+
+	local myconf=(
+		--localstatedir=/var
+		$(multilib_native_use_enable doc doxygen-doc)
+		$(use_enable fapi)
+		$(use_enable policy)
+		$(use_enable static-libs static)
+		$(multilib_native_use_enable test unit)
+		$(multilib_native_use_enable test integration)
+		$(multilib_native_use_enable test self-generated-certificate)
+		--disable-tcti-libtpms
+		--disable-defaultflags
+		--disable-weakcrypto
+		--with-crypto="$(usex mbedtls mbed ossl)"
+		--with-runstatedir=/run
+		--with-udevrulesdir="$(get_udevdir)/rules.d"
+		--with-udevrulesprefix=60-
+		--without-sysusersdir
+		--with-tmpfilesdir="/usr/lib/tmpfiles.d"
+	)
+
+	ECONF_SOURCE=${S} econf "${myconf[@]}"
+}
+
+multilib_src_install() {
+	default
+	keepdir /var/lib/tpm2-tss/system/keystore
+	find "${ED}" -name '*.la' -delete || die
+}
+
+pkg_postinst() {
+	tmpfiles_process tpm2-tss-fapi.conf
+	udev_reload
+}
+
+pkg_postrm() {
+	udev_reload
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/893636