### PR TITLE
media-gfx/graphviz: update USE X description

### DIFF
--- a/media-gfx/graphviz/metadata.xml
+++ b/media-gfx/graphviz/metadata.xml
@@ -35,7 +35,7 @@
 		<flag name="gtk2">Enables gtk+ output plugin -Tgtk (needs cairo)</flag>
 		<flag name="gts">Enables support for GNU Triangulated Surface Library (required for sfdp to work)</flag>
 		<flag name="lasi">Enables PostScript output via <pkg>media-libs/lasi</pkg>, for plugin -Tlasi (needs cairo)</flag>
-		<flag name="X">Builds dotty, lneato, unflatten, vimdot, builds plugin -Txlib, and enables support for x11 in various other modules (needs cairo)</flag>
+		<flag name="X">Builds unflatten, vimdot, builds plugin -Txlib, and enables support for x11 in various other modules (needs cairo)</flag>
 	</use>
 	<upstream>
 		<changelog>https://gitlab.com/graphviz/graphviz/-/blob/main/CHANGELOG.md</changelog>


### PR DESCRIPTION
Drop references to dotty and lneato which were removed in Graphviz 4.0.0.