### PR TITLE
app-misc/chkcrontab: migrate to PEP517 build

### DIFF
--- a/app-misc/chkcrontab/chkcrontab-1.7-r3.ebuild
+++ b/app-misc/chkcrontab/chkcrontab-1.7-r3.ebuild
@@ -1,0 +1,33 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DISTUTILS_USE_PEP517=setuptools
+PYTHON_COMPAT=( python3_{10..12} )
+inherit distutils-r1
+
+DESCRIPTION="A tool to detect crontab errors"
+HOMEPAGE="https://github.com/lyda/chkcrontab"
+SRC_URI="https://github.com/lyda/chkcrontab/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="Apache-2.0"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+distutils_enable_tests pytest
+
+PATCHES=(
+	"${FILESDIR}/${PN}-man.patch"
+	"${FILESDIR}/${PN}-py312.patch"
+)
+
+python_prepare_all() {
+	distutils-r1_python_prepare_all
+	sed -i 's/assertEquals/assertEqual/g' tests/test_check.py || die
+}
+
+python_install_all() {
+	doman doc/${PN}.1
+	distutils-r1_python_install_all
+}

--- a/app-misc/chkcrontab/files/chkcrontab-man.patch
+++ b/app-misc/chkcrontab/files/chkcrontab-man.patch
@@ -1,0 +1,12 @@
+diff --git a/setup.py b/setup.py
+index df72a6a..b2082c6 100755
+--- a/setup.py
++++ b/setup.py
+@@ -143,6 +143,7 @@ class InstallCmd(install):
+ 
+   def run(self):
+     install.run(self)
++    return
+     manpages = ['doc/chkcrontab.1']
+     if self.manprefix:
+       for manpage in manpages:

--- a/app-misc/chkcrontab/files/chkcrontab-py312.patch
+++ b/app-misc/chkcrontab/files/chkcrontab-py312.patch
@@ -1,0 +1,23 @@
+# https://github.com/gregorg/chkcrontab/pull/1
+diff --git a/chkcrontab_lib.py b/chkcrontab_lib.py
+index 57a7c1f..6334a77 100755
+--- a/chkcrontab_lib.py
++++ b/chkcrontab_lib.py
+@@ -822,12 +822,12 @@ def ParseLine(self, line, options ):
+     Returns:
+       A CronLine* class (must have a ValidateAndLog method).
+     """
+-    chkcrontab_cmd = re.compile('##*\s*chkcrontab:\s*(.*)=(.*)')
+-    assignment_line_re = re.compile('[a-zA-Z_][a-zA-Z0-9_]*\s*=(.*)')
+-    at_line_re = re.compile('@(\S+)\s+(\S+)\s+(.*)')
+-    cron_time_field_re = '[\*0-9a-zA-Z,/-]+'
++    chkcrontab_cmd = re.compile(r'##*\s*chkcrontab:\s*(.*)=(.*)')
++    assignment_line_re = re.compile(r'[a-zA-Z_][a-zA-Z0-9_]*\s*=(.*)')
++    at_line_re = re.compile(r'@(\S+)\s+(\S+)\s+(.*)')
++    cron_time_field_re = r'[\*0-9a-zA-Z,/-]+'
+     time_field_job_line_re = re.compile(
+-        '^\s*(%s)\s+(%s)\s+(%s)\s+(%s)\s+(%s)\s+(\S+)\s+(.*)' %
++        r'^\s*(%s)\s+(%s)\s+(%s)\s+(%s)\s+(%s)\s+(\S+)\s+(.*)' %
+         (cron_time_field_re, cron_time_field_re, cron_time_field_re,
+          cron_time_field_re, cron_time_field_re))
+ 


### PR DESCRIPTION
Tested on ~amd64, thanks!

```bash
--- chkcrontab-1.7-r2.ebuild    2023-01-25 14:11:28.149851271 +0000
+++ chkcrontab-1.7-r3.ebuild    2024-03-11 13:35:20.431449380 +0000
@@ -1,11 +1,10 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{9..11} )
-DISTUTILS_USE_SETUPTOOLS=no
-
+DISTUTILS_USE_PEP517=setuptools
+PYTHON_COMPAT=( python3_{10..12} )
 inherit distutils-r1
 
 DESCRIPTION="A tool to detect crontab errors"
@@ -14,11 +13,11 @@
 
 LICENSE="Apache-2.0"
 SLOT="0"
-KEYWORDS="amd64 x86"
-IUSE="test"
-RESTRICT="!test? ( test )"
+KEYWORDS="~amd64 ~x86"
+
+distutils_enable_tests pytest
 
-distutils_enable_tests setup.py
+PATCHES=( "${FILESDIR}/${PN}-man.patch" )
 
 python_install_all() {
        doman doc/${PN}.1
```