### PR TITLE
dev-util/codeblocks: fix DoxyBlocks plugin startup segfault; fix Scintilla buffer over-read warning

### DIFF
--- a/dev-util/codeblocks/codeblocks-20.03-r7.ebuild
+++ b/dev-util/codeblocks/codeblocks-20.03-r7.ebuild
@@ -51,6 +51,7 @@ PATCHES=(
 	"${FILESDIR}"/${P}-env.patch
 	"${WORKDIR}"/patches/
 	"${FILESDIR}"/${P}_fix_DoxyBlocks_startup_segfault.patch
+	"${FILESDIR}"/${P}_Scintilla_fix_buffer_over-read_with_absolute_reference.patch
 	)
 
 src_prepare() {

--- a/dev-util/codeblocks/codeblocks-20.03-r7.ebuild
+++ b/dev-util/codeblocks/codeblocks-20.03-r7.ebuild
@@ -1,0 +1,97 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+WX_GTK_VER="3.0-gtk3"
+
+inherit autotools flag-o-matic wxwidgets xdg
+
+DESCRIPTION="The open source, cross platform, free C, C++ and Fortran IDE"
+HOMEPAGE="https://codeblocks.org/"
+LICENSE="GPL-3"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86"
+SRC_URI="mirror://sourceforge/${PN}/${P}.tar.xz
+	https://dev.gentoo.org/~leio/distfiles/${P}-fortran.tar.xz
+	https://dev.gentoo.org/~leio/distfiles/${P}-fortran-update-v1.7.tar.xz
+	https://dev.gentoo.org/~leio/distfiles/${P}-fortran-update-v1.8.tar.xz
+	https://dev.gentoo.org/~leio/distfiles/${P}-codecompletion-symbolbrowser-update.tar.xz
+"
+
+# USE="fortran" enables FortranProject plugin (updated to v1.8 2021-05-29 [r230])
+# that is delivered with Code::Blocks 20.03 source code.
+# https://sourceforge.net/projects/fortranproject
+# https://cbfortran.sourceforge.io
+
+IUSE="contrib debug fortran"
+
+BDEPEND="virtual/pkgconfig"
+
+RDEPEND="app-arch/zip
+	dev-libs/glib:2
+	>=dev-libs/tinyxml-2.6.2-r3
+	>=dev-util/astyle-3.1-r2:0/3.1
+	x11-libs/gtk+:3
+	x11-libs/wxGTK:${WX_GTK_VER}[X]
+	contrib? (
+		app-admin/gamin
+		app-arch/bzip2
+		app-text/hunspell:=
+		dev-libs/boost:=
+		dev-libs/libgamin
+		media-libs/fontconfig
+		sys-libs/zlib
+	)"
+
+DEPEND="${RDEPEND}
+	x11-base/xorg-proto"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-env.patch
+	"${WORKDIR}"/patches/
+	"${FILESDIR}"/${P}_fix_DoxyBlocks_startup_segfault.patch
+	)
+
+src_prepare() {
+	default
+	# Force to use bundled Squirrel-3.1 (patched version is used by upstream) due to it's API was changed
+	sed -i '/PKG_CHECK_MODULES(\[SQUIRREL\]/c\HAVE_SQUIRREL=no' configure.ac || die # Bug 884601
+	eautoreconf
+}
+
+src_configure() {
+	# Bug 858338
+	append-flags -fno-strict-aliasing
+
+	setup-wxwidgets
+
+	# USE="contrib -fortran" setup:
+	use fortran || CONF_WITH_LST=$(use_with contrib contrib-plugins all,-FortranProject)
+	# USE="contrib fortran" setup:
+	use fortran && CONF_WITH_LST=$(use_with contrib contrib-plugins all)
+	# USE="-contrib fortran" setup:
+	use contrib || CONF_WITH_LST=$(use_with fortran contrib-plugins FortranProject)
+
+	local myeconfargs=(
+		--disable-pch
+		$(use_with contrib boost-libdir "${ESYSROOT}/usr/$(get_libdir)")
+		$(use_enable debug)
+		${CONF_WITH_LST}
+	)
+
+	econf "${myeconfargs[@]}"
+}
+
+src_install() {
+	default
+	find "${ED}" -type f -name '*.la' -delete || die
+}
+
+pkg_postinst() {
+	xdg_pkg_postinst
+}
+
+pkg_postrm() {
+	xdg_pkg_postrm
+}

--- a/dev-util/codeblocks/files/codeblocks-20.03_Scintilla_fix_buffer_over-read_with_absolute_reference.patch
+++ b/dev-util/codeblocks/files/codeblocks-20.03_Scintilla_fix_buffer_over-read_with_absolute_reference.patch
@@ -1,0 +1,24 @@
+Upstream patch: https://sourceforge.net/u/vic5/scintilla/ci/6d0ce3c92a1371372bd601cd572a078d5e4041a4/
+Upstream issue: https://sourceforge.net/p/scintilla/bugs/2019/
+Codeblocks forum discussion: https://forums.codeblocks.org/index.php?topic=24505.0
+
+lexers/LexMMIXAL.cxxDiffSwitch to side-by-side view
+--- a/src/sdk/wxscintilla/src/scintilla/lexers/LexMMIXAL.cxx
++++ b/src/sdk/wxscintilla/src/scintilla/lexers/LexMMIXAL.cxx
+@@ -99,12 +99,11 @@
+ 			}
+ 		} else if (sc.state == SCE_MMIXAL_REF) {			// REF
+ 			if (!IsAWordChar(sc.ch) ) {
+-				char s[100];
+-				sc.GetCurrent(s, sizeof(s));
++				char s0[100];
++				sc.GetCurrent(s0, sizeof(s0));
++				const char *s = s0;
+ 				if (*s == ':') {	// ignore base prefix for match
+-					for (size_t i = 0; i != sizeof(s); ++i) {
+-						*(s+i) = *(s+i+1);
+-					}
++					++s;
+ 				}
+ 				if (special_register.InList(s)) {
+ 					sc.ChangeState(SCE_MMIXAL_REGISTER);

--- a/dev-util/codeblocks/files/codeblocks-20.03_fix_DoxyBlocks_startup_segfault.patch
+++ b/dev-util/codeblocks/files/codeblocks-20.03_fix_DoxyBlocks_startup_segfault.patch
@@ -1,0 +1,61 @@
+Upstream patch: https://sourceforge.net/p/codeblocks/code/12074/
+Upstream issue: https://sourceforge.net/p/codeblocks/tickets/839/
+Gentoo issue: https://bugs.gentoo.org/925955
+
+--- a/src/plugins/contrib/DoxyBlocks/DoxyBlocks.cpp
++++ b/src/plugins/contrib/DoxyBlocks/DoxyBlocks.cpp
+@@ -101,8 +101,8 @@
+ 
+ // constructor
+ DoxyBlocks::DoxyBlocks() :
+-    m_pToolbar(0l),
+-    m_DoxyBlocksLog(0l),
++    m_pToolbar(nullptr),
++    m_DoxyBlocksLog(nullptr),
+     m_LogPageIndex(0),
+     m_bAutoVersioning(false)
+ {
+@@ -234,8 +234,10 @@
+  */
+ void DoxyBlocks::OnUpdateUI(wxUpdateUIEvent& WXUNUSED(event))
+ {
+-    if(Manager::Get()->GetProjectManager()->GetProjects()->GetCount() == 0){
+-        m_pToolbar->Enable(false);
++    if (Manager::Get()->GetProjectManager()->GetProjects()->GetCount() == 0)
++    {
++        if (m_pToolbar)
++            m_pToolbar->Enable(false);
+         wxMenuBar *menuBar =  Manager::Get()->GetAppFrame()->GetMenuBar();
+         menuBar->FindItem(ID_MENU_DOXYWIZARD)->Enable(false);
+         menuBar->FindItem(ID_MENU_EXTRACTPROJECT)->Enable(false);
+@@ -264,14 +266,15 @@
+             Manager::Get()->ProcessEvent(evt);
+         }
+     }
+-    m_DoxyBlocksLog = 0;
+-}
+-
+-cbConfigurationPanel *DoxyBlocks::GetConfigurationPanel(wxWindow *parent)
++    m_DoxyBlocksLog = nullptr;
++}
++
++cbConfigurationPanel* DoxyBlocks::GetConfigurationPanel(wxWindow *parent)
+ {
+     //create and display the configuration dialog for your plugin
+-    if(!IsAttached()){
+-        return 0;
++    if (!IsAttached())
++    {
++        return nullptr;
+     }
+ 
+     // Get the version string before instantiating the panel so that it is recorded before
+@@ -346,7 +349,7 @@
+ 
+ cbConfigurationPanel* DoxyBlocks::GetProjectConfigurationPanel(wxWindow* /*parent*/, cbProject* /*project*/)
+ {
+-    return 0;
++    return nullptr;
+ }
+ 
+ void DoxyBlocks::OnConfigure(wxCommandEvent & WXUNUSED(event))


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/925955