### PR TITLE
ROCm 5.7.1 group bugfixes

### DIFF
--- a/dev-cpp/functional-plus/functional-plus-0.2.22.ebuild
+++ b/dev-cpp/functional-plus/functional-plus-0.2.22.ebuild
@@ -35,6 +35,12 @@ fplus_test_wrapper() {
 	$@
 }
 
+src_prepare() {
+	# avoid -Werror, bug 926538
+	sed -i 's/-Werror//' cmake/warnings.cmake || die
+	cmake_src_prepare
+}
+
 src_configure() {
 	cmake_src_configure
 	use test && fplus_test_wrapper cmake_src_configure

--- a/dev-libs/rocr-runtime/files/rocr-runtime-5.7.1-musl.patch
+++ b/dev-libs/rocr-runtime/files/rocr-runtime-5.7.1-musl.patch
@@ -1,0 +1,106 @@
+Fix compilation with musl.
+
+Bug: https://github.com/ROCm/ROCR-Runtime/issues/181
+--- a/core/inc/checked.h
++++ b/core/inc/checked.h
+@@ -58,7 +58,7 @@ template <uint64_t code, bool multiProcess = false> class Check final {
+   Check(const Check&) { object_ = uintptr_t(this) ^ uintptr_t(code); }
+   Check(Check&&) { object_ = uintptr_t(this) ^ uintptr_t(code); }
+ 
+-  ~Check() { object_ = NULL; }
++  ~Check() { object_ = uintptr_t(NULL); }
+ 
+   const Check& operator=(Check&& rhs) { return *this; }
+   const Check& operator=(const Check& rhs) { return *this; }
+--- a/core/runtime/default_signal.cpp
++++ b/core/runtime/default_signal.cpp
+@@ -57,7 +57,7 @@ int BusyWaitSignal::rtti_id_ = 0;
+ BusyWaitSignal::BusyWaitSignal(SharedSignal* abi_block, bool enableIPC)
+     : Signal(abi_block, enableIPC) {
+   signal_.kind = AMD_SIGNAL_KIND_USER;
+-  signal_.event_mailbox_ptr = NULL;
++  signal_.event_mailbox_ptr = uint64_t(NULL);
+ }
+ 
+ hsa_signal_value_t BusyWaitSignal::LoadRelaxed() {
+--- a/core/util/lnx/os_linux.cpp
++++ b/core/util/lnx/os_linux.cpp
+@@ -111,9 +111,12 @@ class os_thread {
+       }
+     }
+ 
++    int cores = 0;
++    cpu_set_t* cpuset = nullptr;
++
+     if (core::Runtime::runtime_singleton_->flag().override_cpu_affinity()) {
+-      int cores = get_nprocs_conf();
+-      cpu_set_t* cpuset = CPU_ALLOC(cores);
++      cores = get_nprocs_conf();
++      cpuset = CPU_ALLOC(cores);
+       if (cpuset == nullptr) {
+         fprintf(stderr, "CPU_ALLOC failed: %s\n", strerror(errno));
+         return;
+@@ -122,12 +125,6 @@ class os_thread {
+       for (int i = 0; i < cores; i++) {
+         CPU_SET(i, cpuset);
+       }
+-      err = pthread_attr_setaffinity_np(&attrib, CPU_ALLOC_SIZE(cores), cpuset);
+-      CPU_FREE(cpuset);
+-      if (err != 0) {
+-        fprintf(stderr, "pthread_attr_setaffinity_np failed: %s\n", strerror(err));
+-        return;
+-      }
+     }
+ 
+     err = pthread_create(&thread, &attrib, ThreadTrampoline, args.get());
+@@ -157,6 +154,14 @@ class os_thread {
+     if (err != 0) {
+       fprintf(stderr, "pthread_attr_destroy failed: %s\n", strerror(err));
+     }
++
++    if (thread && cores && cpuset) {
++      err = pthread_setaffinity_np(thread, CPU_ALLOC_SIZE(cores), cpuset);
++      CPU_FREE(cpuset);
++      if (err != 0) {
++        fprintf(stderr, "pthread_setaffinity_np failed: %s\n", strerror(err));
++      }
++    }
+   }
+ 
+   os_thread(os_thread&& rhs) {
+@@ -617,11 +622,13 @@ SharedMutex CreateSharedMutex() {
+     fprintf(stderr, "rw lock attribute init failed: %s\n", strerror(err));
+     return nullptr;
+   }
++#if defined(__GLIBC__)
+   err = pthread_rwlockattr_setkind_np(&attrib, PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP);
+   if (err != 0) {
+     fprintf(stderr, "Set rw lock attribute failure: %s\n", strerror(err));
+     return nullptr;
+   }
++#endif
+ 
+   pthread_rwlock_t* lock = new pthread_rwlock_t;
+   err = pthread_rwlock_init(lock, &attrib);
+--- a/core/util/utils.h
++++ b/core/util/utils.h
+@@ -74,7 +74,7 @@ static __forceinline void* _aligned_malloc(size_t size, size_t alignment) {
+   return aligned_alloc(alignment, size);
+ #else
+   void *mem = NULL;
+-  if (NULL != posix_memalign(&mem, alignment, size))
++  if (0 != posix_memalign(&mem, alignment, size))
+     return NULL;
+   return mem;
+ #endif
+--- a/image/util.h
++++ b/image/util.h
+@@ -95,7 +95,7 @@ static __forceinline void* _aligned_malloc(size_t size, size_t alignment) {
+   return aligned_alloc(alignment, size);
+ #else
+   void* mem = NULL;
+-  if (NULL != posix_memalign(&mem, alignment, size)) return NULL;
++  if (0 != posix_memalign(&mem, alignment, size)) return NULL;
+   return mem;
+ #endif
+ }

--- a/dev-libs/rocr-runtime/rocr-runtime-5.7.1-r2.ebuild
+++ b/dev-libs/rocr-runtime/rocr-runtime-5.7.1-r2.ebuild
@@ -3,9 +3,9 @@
 
 EAPI=8
 
-inherit cmake flag-o-matic llvm
-
 LLVM_MAX_SLOT=17
+
+inherit cmake flag-o-matic llvm
 
 if [[ ${PV} == *9999 ]] ; then
 	EGIT_REPO_URI="https://github.com/RadeonOpenCompute/ROCR-Runtime/"
@@ -22,6 +22,7 @@ HOMEPAGE="https://github.com/RadeonOpenCompute/ROCR-Runtime"
 PATCHES=(
 	"${FILESDIR}/${PN}-4.3.0_no-aqlprofiler.patch"
 	"${FILESDIR}/${PN}-5.7.1-extend-isa-compatibility-check.patch"
+	"${FILESDIR}/${PN}-5.7.1-musl.patch"
 )
 
 LICENSE="MIT"
@@ -33,8 +34,8 @@ COMMON_DEPEND="dev-libs/elfutils
 DEPEND="${COMMON_DEPEND}
 	>=dev-libs/roct-thunk-interface-${PV}
 	>=dev-libs/rocm-device-libs-${PV}
-	sys-devel/clang
-	sys-devel/lld"
+	sys-devel/clang:${LLVM_MAX_SLOT}=
+	sys-devel/lld:${LLVM_MAX_SLOT}="
 RDEPEND="${DEPEND}"
 BDEPEND="app-editors/vim-core"
 	# vim-core is needed for "xxd"

--- a/dev-libs/rocr-runtime/rocr-runtime-6.0.0-r1.ebuild
+++ b/dev-libs/rocr-runtime/rocr-runtime-6.0.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -21,6 +21,7 @@ DESCRIPTION="Radeon Open Compute Runtime"
 HOMEPAGE="https://github.com/RadeonOpenCompute/ROCR-Runtime"
 PATCHES=(
 	"${FILESDIR}/${PN}-4.3.0_no-aqlprofiler.patch"
+	"${FILESDIR}/${PN}-5.7.1-musl.patch"
 )
 
 LICENSE="MIT"
@@ -32,8 +33,8 @@ COMMON_DEPEND="dev-libs/elfutils
 DEPEND="${COMMON_DEPEND}
 	>=dev-libs/roct-thunk-interface-${PV}
 	>=dev-libs/rocm-device-libs-${PV}
-	sys-devel/clang
-	sys-devel/lld"
+	sys-devel/clang:${LLVM_MAX_SLOT}=
+	sys-devel/lld:${LLVM_MAX_SLOT}="
 RDEPEND="${DEPEND}"
 BDEPEND="app-editors/vim-core"
 	# vim-core is needed for "xxd"

--- a/dev-libs/roct-thunk-interface/files/roct-thunk-interface-5.7.1-musl.patch
+++ b/dev-libs/roct-thunk-interface/files/roct-thunk-interface-5.7.1-musl.patch
@@ -1,0 +1,61 @@
+Upstream PR: https://github.com/ROCm/ROCT-Thunk-Interface/pull/96
+Bug: https://github.com/ROCm/ROCT-Thunk-Interface/issues/65
+--- a/src/globals.c
++++ b/src/globals.c
+@@ -32,5 +32,9 @@ unsigned long kfd_open_count;
+ unsigned long system_properties_count;
+ pthread_mutex_t hsakmt_mutex = PTHREAD_MUTEX_INITIALIZER;
+ bool is_dgpu;
++
++#ifndef PAGE_SIZE
+ int PAGE_SIZE;
++#endif
++
+ int PAGE_SHIFT;
+--- a/src/libhsakmt.h
++++ b/src/libhsakmt.h
+@@ -62,7 +62,11 @@ extern HsaVersionInfo kfd_version_info;
+ 	do { if ((minor) > kfd_version_info.KernelInterfaceMinorVersion)\
+ 		return HSAKMT_STATUS_NOT_SUPPORTED; } while (0)
+ 
++/* Might be defined in limits.h on platforms where it is constant (used by musl) */
++/* See also: https://pubs.opengroup.org/onlinepubs/7908799/xsh/limits.h.html */
++#ifndef PAGE_SIZE
+ extern int PAGE_SIZE;
++#endif
+ extern int PAGE_SHIFT;
+ 
+ /* VI HW bug requires this virtual address alignment */
+--- a/src/openclose.c
++++ b/src/openclose.c
+@@ -116,7 +116,9 @@ static void clear_after_fork(void)
+ 
+ static inline void init_page_size(void)
+ {
++#ifndef PAGE_SIZE
+ 	PAGE_SIZE = sysconf(_SC_PAGESIZE);
++#endif
+ 	PAGE_SHIFT = ffs(PAGE_SIZE) - 1;
+ }
+ 
+--- a/src/topology.c
++++ b/src/topology.c
+@@ -32,6 +32,7 @@
+ #include <string.h>
+ #include <unistd.h>
+ #include <ctype.h>
++#include <limits.h>
+ 
+ #include <errno.h>
+ #include <sys/sysinfo.h>
+@@ -1369,6 +1370,10 @@ static int topology_create_temp_cpu_cache_list(int node,
+ 	 * which can be present twice in the string above. 29 is for the prefix
+ 	 * and the +6 is for the cache suffix
+ 	 */
++#ifndef MAXNAMLEN
++/* MAXNAMLEN is the BSD name for NAME_MAX. glibc aliases this as NAME_MAX, but not musl */
++#define MAXNAMLEN NAME_MAX
++#endif
+ 	const uint32_t MAXPATHSIZE = 29 + MAXNAMLEN + (MAXNAMLEN + 6);
+ 	cpu_cacheinfo_t *p_temp_cpu_ci_list; /* a list of cpu_ci */
+ 	char path[MAXPATHSIZE], node_dir[MAXPATHSIZE];

--- a/dev-libs/roct-thunk-interface/roct-thunk-interface-5.7.1-r1.ebuild
+++ b/dev-libs/roct-thunk-interface/roct-thunk-interface-5.7.1-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -26,7 +26,10 @@ BDEPEND="x11-libs/libdrm[video_cards_amdgpu]"
 
 CMAKE_BUILD_TYPE=Release
 
-PATCHES=( "${FILESDIR}/${PN}-6.0.0-functions.patch" )
+PATCHES=(
+	"${FILESDIR}/${PN}-5.7.0-functions.patch"
+	"${FILESDIR}/${PN}-5.7.1-musl.patch"
+)
 
 src_prepare() {
 	sed -e "s:get_version ( \"1.0.0\" ):get_version ( \"${PV}\" ):" -i CMakeLists.txt || die

--- a/dev-libs/roct-thunk-interface/roct-thunk-interface-6.0.0-r1.ebuild
+++ b/dev-libs/roct-thunk-interface/roct-thunk-interface-6.0.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -26,7 +26,10 @@ BDEPEND="x11-libs/libdrm[video_cards_amdgpu]"
 
 CMAKE_BUILD_TYPE=Release
 
-PATCHES=( "${FILESDIR}/${PN}-5.7.0-functions.patch" )
+PATCHES=(
+	"${FILESDIR}/${PN}-6.0.0-functions.patch"
+	"${FILESDIR}/${PN}-5.7.1-musl.patch"
+)
 
 src_prepare() {
 	sed -e "s:get_version ( \"1.0.0\" ):get_version ( \"${PV}\" ):" -i CMakeLists.txt || die

--- a/dev-util/rocm-smi/files/rocm-smi-5.7.1-set-soversion.patch
+++ b/dev-util/rocm-smi/files/rocm-smi-5.7.1-set-soversion.patch
@@ -5,7 +5,7 @@ This patch repeats approach of similar patch from Debian, additionally removing 
 https://salsa.debian.org/rocm-team/rocm-smi-lib/-/blob/master/debian/patches/0007-rocm_smi64-soversion.patch
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -30,27 +30,6 @@ set(SHARE_INSTALL_PREFIX
+@@ -30,18 +30,6 @@ set(SHARE_INSTALL_PREFIX
      "share/${ROCM_SMI}"
      CACHE STRING "Tests and Example install directory")
  
@@ -21,21 +21,12 @@ https://salsa.debian.org/rocm-team/rocm-smi-lib/-/blob/master/debian/patches/000
 -set(${AMD_SMI_LIBS_TARGET}_VERSION_PATCH "0")
 -set(${AMD_SMI_LIBS_TARGET}_VERSION_BUILD "0")
 -
--# The following default version values should be updated as appropriate for
--# ABI breaks (update MAJOR and MINOR), and ABI/API additions (update MINOR).
--# Until ABI stabilizes VERSION_MAJOR will be 0. This should be over-ridden
--# by git tags (through "git describe") when they are present.
--set(PKG_VERSION_MAJOR 1)
--set(PKG_VERSION_MINOR 0)
--set(PKG_VERSION_PATCH 0)
--set(PKG_VERSION_NUM_COMMIT 0)
--
- ## Define default variable and variables for the optional build target
- ##  rocm_smi_lib-dev
- set(CMAKE_INSTALL_PREFIX "/opt/rocm" CACHE STRING "Default installation directory.")
+ # The following default version values should be updated as appropriate for
+ # ABI breaks (update MAJOR and MINOR), and ABI/API additions (update MINOR).
+ # Until ABI stabilizes VERSION_MAJOR will be 0. This should be over-ridden
 --- a/oam/CMakeLists.txt
 +++ b/oam/CMakeLists.txt
-@@ -29,23 +29,10 @@ set(OAM_NAME "oam")
+@@ -29,23 +29,11 @@ set(OAM_NAME "oam")
  set(OAM_COMPONENT "lib${OAM_NAME}")
  set(OAM_TARGET "${OAM_NAME}")
  
@@ -56,13 +47,23 @@ https://salsa.debian.org/rocm-team/rocm-smi-lib/-/blob/master/debian/patches/000
 -else()
 -    set(SO_VERSION_STRING "${VERSION_MAJOR}.${VERSION_MINOR}")
 -endif ()
-+set(VERSION_MAJOR "1")
-+set(VERSION_MINOR "0")
++set(VERSION_MAJOR "@VERSION_MAJOR@")
++set(VERSION_MINOR "@VERSION_MINOR@")
 +
-+set(SO_VERSION_STRING "${VERSION_MAJOR}.${VERSION_MINOR}")
++set(SO_VERSION_MAJOR "1")
++set(SO_VERSION_STRING "1.0")
  set(${OAM_NAME}_VERSION_MAJOR "${VERSION_MAJOR}")
  set(${OAM_NAME}_VERSION_MINOR "${VERSION_MINOR}")
  set(${OAM_NAME}_VERSION_PATCH "0")
+@@ -78,7 +66,7 @@ target_include_directories(${OAM_TARGET} PRIVATE
+ 
+ ## Set the VERSION and SOVERSION values
+ set_property(TARGET ${OAM_TARGET} PROPERTY
+-             SOVERSION "${VERSION_MAJOR}")
++             SOVERSION "${SO_VERSION_MAJOR}")
+ set_property(TARGET ${OAM_TARGET} PROPERTY
+              VERSION "${SO_VERSION_STRING}")
+ 
 --- a/python_smi_tools/rsmiBindings.py.in
 +++ b/python_smi_tools/rsmiBindings.py.in
 @@ -9,19 +9,9 @@ from enum import Enum
@@ -90,7 +91,7 @@ https://salsa.debian.org/rocm-team/rocm-smi-lib/-/blob/master/debian/patches/000
  
 --- a/rocm_smi/CMakeLists.txt
 +++ b/rocm_smi/CMakeLists.txt
-@@ -31,17 +31,8 @@ set(ROCM_SMI_TARGET "${ROCM_SMI}64")
+@@ -31,23 +31,10 @@ set(ROCM_SMI_TARGET "${ROCM_SMI}64")
  ## Include common cmake modules
  include(utils)
  
@@ -105,8 +106,25 @@ https://salsa.debian.org/rocm-team/rocm-smi-lib/-/blob/master/debian/patches/000
 -get_version_from_tag("5.0.0.0" ${SO_VERSION_GIT_TAG_PREFIX} GIT)
 -
 -# VERSION_* variables should be set by get_version_from_tag
-+set(VERSION_MAJOR "1")
-+set(VERSION_MINOR "0")
- if ( ${ROCM_PATCH_VERSION} )
-     set ( VERSION_PATCH ${ROCM_PATCH_VERSION})
-     set(SO_VERSION_STRING "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}")
+-if ( ${ROCM_PATCH_VERSION} )
+-    set ( VERSION_PATCH ${ROCM_PATCH_VERSION})
+-    set(SO_VERSION_STRING "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}")
+-else()
+-    set(SO_VERSION_STRING "${VERSION_MAJOR}.${VERSION_MINOR}")
+-endif ()
++set(VERSION_MAJOR "@VERSION_MAJOR@")
++set(VERSION_MINOR "@VERSION_MINOR@")
++set(SO_VERSION_MAJOR "1")
++set(SO_VERSION_STRING "1.0")
+ set(${ROCM_SMI}_VERSION_MAJOR "${VERSION_MAJOR}")
+ set(${ROCM_SMI}_VERSION_MINOR "${VERSION_MINOR}")
+ set(${ROCM_SMI}_VERSION_PATCH "0")
+@@ -99,7 +86,7 @@ endif()
+ 
+ ## Set the VERSION and SOVERSION values
+ set_property(TARGET ${ROCM_SMI_TARGET} PROPERTY
+-             SOVERSION "${VERSION_MAJOR}")
++             SOVERSION "${SO_VERSION_MAJOR}")
+ set_property(TARGET ${ROCM_SMI_TARGET} PROPERTY
+              VERSION "${SO_VERSION_STRING}")
+ 

--- a/dev-util/rocm-smi/rocm-smi-5.7.1-r1.ebuild
+++ b/dev-util/rocm-smi/rocm-smi-5.7.1-r1.ebuild
@@ -37,8 +37,9 @@ PATCHES=(
 src_prepare() {
 	cmake_src_prepare
 
-	sed "s/\${PKG_VERSION_STR}/${PV}/g" \
-		-i CMakeLists.txt -i oam/CMakeLists.txt -i rocm_smi/CMakeLists.txt || die
+	sed "s/\${PKG_VERSION_STR}/${PV}/" -i CMakeLists.txt || die
+	sed -e "s/@VERSION_MAJOR@/$(ver_cut 1)/ ; s/@VERSION_MINOR@/$(ver_cut 2)/" \
+		-i oam/CMakeLists.txt -i rocm_smi/CMakeLists.txt || die
 }
 
 src_configure() {


### PR DESCRIPTION
This PR combines multiple fixes for recently merged 5.7.1 libraries:
- dev-libs/roct-thunk-interface: fix compilation with musl
- dev-libs/rocr-runtime: fix compilation with musl
- dev-util/rocm-smi: return correct version in rsmi_version_get
- dev-cpp/functional-plus: remove -Werror flag

Closes: https://bugs.gentoo.org/830944
Closes: https://bugs.gentoo.org/715434
Closes: https://bugs.gentoo.org/921322
Closes: https://bugs.gentoo.org/925448
Closes: https://bugs.gentoo.org/926538