### PR TITLE
app-vim/{frawor,mediawiki,pfsyntax,vimcdoc,vim-nftables}: add missing remote-id

### DIFF
--- a/app-vim/frawor/metadata.xml
+++ b/app-vim/frawor/metadata.xml
@@ -6,7 +6,7 @@
 		<name>Gentoo Vim Project</name>
 	</maintainer>
 	<upstream>
-		<remote-id type="bitbucket">ZyX_I/frawor</remote-id>
+		<remote-id type="github">vim-scripts/frawor</remote-id>
 	</upstream>
 	<stabilize-allarches/>
 </pkgmetadata>

--- a/app-vim/mediawiki/mediawiki-20151115.ebuild
+++ b/app-vim/mediawiki/mediawiki-20151115.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,11 +8,11 @@ inherit vim-plugin
 COMMIT_HASH="26e5737264354be41cb11d16d48132779795e168"
 DESCRIPTION="vim plugin: MediaWiki syntax highlighting"
 HOMEPAGE="https://github.com/chikamichi/mediawiki.vim"
-LICENSE="public-domain"
-KEYWORDS="~amd64 ~hppa ~mips ~ppc ~ppc64 ~x86"
-IUSE=""
 SRC_URI="https://github.com/chikamichi/mediawiki.vim/archive/${COMMIT_HASH}.tar.gz -> ${P}.tar.gz"
 S="${WORKDIR}/${PN}.vim-${COMMIT_HASH}"
+
+LICENSE="public-domain"
+KEYWORDS="~amd64 ~hppa ~mips ~ppc ~ppc64 ~x86"
 
 VIM_PLUGIN_HELPTEXT=\
 "This holds a syntax highlighter for MediaWiki-based projects, mostly Wikipedia.

--- a/app-vim/mediawiki/metadata.xml
+++ b/app-vim/mediawiki/metadata.xml
@@ -8,5 +8,8 @@
 		<email>vim@gentoo.org</email>
 		<name>Gentoo Vim Project</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">chikamichi/mediawiki.vim</remote-id>
+	</upstream>
 	<stabilize-allarches/>
 </pkgmetadata>

--- a/app-vim/pfsyntax/metadata.xml
+++ b/app-vim/pfsyntax/metadata.xml
@@ -5,5 +5,8 @@
     <email>vim@gentoo.org</email>
     <name>Gentoo Vim Project</name>
   </maintainer>
+  <upstream>
+    <remote-id type="github">vim-scripts/pf.vim</remote-id>
+  </upstream>
   <stabilize-allarches/>
 </pkgmetadata>

--- a/app-vim/vim-nftables/metadata.xml
+++ b/app-vim/vim-nftables/metadata.xml
@@ -8,5 +8,8 @@
   <maintainer type="project">
     <email>vim@gentoo.org</email>
   </maintainer>
+  <upstream>
+    <remote-id type="github">nfnty/vim-nftables</remote-id>
+  </upstream>
   <stabilize-allarches/>
 </pkgmetadata>

--- a/app-vim/vimcdoc/metadata.xml
+++ b/app-vim/vimcdoc/metadata.xml
@@ -5,5 +5,8 @@
 		<email>vim@gentoo.org</email>
 		<name>Gentoo Vim Project</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="sourceforge">vimcdoc</remote-id>
+	</upstream>
 	<stabilize-allarches/>
 </pkgmetadata>


### PR DESCRIPTION
Hi,

just some minor updates for `app-vim` packages, mostly adding the missing `remote-id`.