### PR TITLE
net-im/discord: Added optfeature message regarding emoji support

### DIFF
--- a/net-im/discord/discord-0.0.44-r1.ebuild
+++ b/net-im/discord/discord-0.0.44-r1.ebuild
@@ -128,6 +128,8 @@ src_install() {
 pkg_postinst() {
 	xdg_pkg_postinst
 
+	optfeature_header "Install the following packages for additional support:"
 	optfeature "sound support" \
 		media-sound/pulseaudio media-sound/apulse[sdk] media-video/pipewire
+	optfeature "emoji support" media-fonts/noto-emoji
 }


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/923148
Wiki article: https://wiki.gentoo.org/wiki/Discord#Discord_doesn.27t_show_emojis_or_other_glyphs_correctly