### PR TITLE
app-office/libreoffice: live ebuilds dependencies update

### DIFF
--- a/app-office/libreoffice/libreoffice-24.2.9999.ebuild
+++ b/app-office/libreoffice/libreoffice-24.2.9999.ebuild
@@ -254,7 +254,7 @@ DEPEND="${COMMON_DEPEND}
 	x11-libs/libXt
 	x11-libs/libXtst
 	java? (
-		dev-java/ant-core
+		dev-java/ant:0
 		>=virtual/jdk-17
 	)
 	test? (

--- a/app-office/libreoffice/libreoffice-7.6.9999.ebuild
+++ b/app-office/libreoffice/libreoffice-7.6.9999.ebuild
@@ -234,7 +234,7 @@ DEPEND="${COMMON_DEPEND}
 	x11-libs/libXt
 	x11-libs/libXtst
 	java? (
-		dev-java/ant-core
+		dev-java/ant:0
 		>=virtual/jdk-11
 	)
 	test? (

--- a/app-office/libreoffice/libreoffice-9999.ebuild
+++ b/app-office/libreoffice/libreoffice-9999.ebuild
@@ -254,7 +254,7 @@ DEPEND="${COMMON_DEPEND}
 	x11-libs/libXt
 	x11-libs/libXtst
 	java? (
-		dev-java/ant-core
+		dev-java/ant:0
 		>=virtual/jdk-17
 	)
 	test? (


### PR DESCRIPTION
no longer depend on deprecated ant-core