### PR TITLE
go-env.eclass: Export PKG_CONFIG

### DIFF
--- a/eclass/go-env.eclass
+++ b/eclass/go-env.eclass
@@ -27,7 +27,7 @@ inherit toolchain-funcs
 # (e.g. "emerge-aarch64-cross-linux-gnu foo" run on x86_64 will emerge "foo" for x86_64
 #  instead of aarch64)
 go-env_set_compile_environment() {
-	tc-export CC CXX
+	tc-export CC CXX PKG_CONFIG
 
 	export GOARCH="$(go-env_goarch)"
 	use arm && export GOARM=$(go-env_goarm)


### PR DESCRIPTION
Go files may have cgo specifiers that use pkg-config to search for libraries to link. An example of this is:

    // #cgo pkg-config: gpgme

One case where this occurs is when building one of the go deps of app-containers/podman-4.9.2.

If the ebuild doesn't export the correct PKG_CONFIG, this results in build failures during cross-compilation. Go will find the host (CBUILD) pkg-config instead of the CHOST version which performs the lookup in the correct sysroot.

Fix cross-compilation by exporting PKG_CONFIG in go-env_set_compile_environment.