### PR TITLE
sys-fs/cryptsetup: add USE=passwdqc flag

### DIFF
--- a/sys-fs/cryptsetup/cryptsetup-2.7.5-r1.ebuild
+++ b/sys-fs/cryptsetup/cryptsetup-2.7.5-r1.ebuild
@@ -1,0 +1,155 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+# TODO: meson
+inherit linux-info tmpfiles
+
+DESCRIPTION="Tool to setup encrypted devices with dm-crypt"
+HOMEPAGE="https://gitlab.com/cryptsetup/cryptsetup"
+SRC_URI="https://www.kernel.org/pub/linux/utils/${PN}/v$(ver_cut 1-2)/${P/_/-}.tar.xz"
+S="${WORKDIR}"/${P/_/-}
+
+LICENSE="GPL-2+"
+SLOT="0/12" # libcryptsetup.so version
+if [[ ${PV} != *_rc* ]] ; then
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+fi
+
+CRYPTO_BACKENDS="gcrypt kernel nettle +openssl"
+# we don't support nss since it doesn't allow cryptsetup to be built statically
+# and it's missing ripemd160 support so it can't provide full backward compatibility
+IUSE="${CRYPTO_BACKENDS} +argon2 fips nls pwquality passwdqc ssh static static-libs test +udev urandom"
+RESTRICT="!test? ( test )"
+# bug #496612, bug #832711, bug #843863
+REQUIRED_USE="
+	?? ( pwquality passwdqc )
+	^^ ( ${CRYPTO_BACKENDS//+/} )
+	static? ( !ssh !udev !fips )
+	static-libs? ( !passwdqc )
+	fips? ( !kernel !nettle )
+"
+
+LIB_DEPEND="
+	dev-libs/json-c:=[static-libs(+)]
+	dev-libs/popt[static-libs(+)]
+	>=sys-apps/util-linux-2.31-r1[static-libs(+)]
+	argon2? ( app-crypt/argon2:=[static-libs(+)] )
+	gcrypt? (
+		dev-libs/libgcrypt:0=[static-libs(+)]
+		dev-libs/libgpg-error[static-libs(+)]
+	)
+	nettle? ( >=dev-libs/nettle-2.4[static-libs(+)] )
+	openssl? ( dev-libs/openssl:0=[static-libs(+)] )
+	pwquality? ( dev-libs/libpwquality[static-libs(+)] )
+	passwdqc? ( sys-auth/passwdqc )
+	ssh? ( net-libs/libssh[static-libs(+)] )
+	sys-fs/lvm2[static-libs(+)]
+"
+# We have to always depend on ${LIB_DEPEND} rather than put behind
+# !static? () because we provide a shared library which links against
+# these other packages. bug #414665
+RDEPEND="
+	static-libs? ( ${LIB_DEPEND} )
+	${LIB_DEPEND//\[static-libs\([+-]\)\]}
+	udev? ( virtual/libudev:= )
+"
+DEPEND="
+	${RDEPEND}
+	static? ( ${LIB_DEPEND} )
+"
+# vim-core needed for xxd in tests
+BDEPEND="
+	virtual/pkgconfig
+	test? ( app-editors/vim-core )
+"
+
+PATCHES=( "${FILESDIR}"/${P}-compat-test-passwdqc.patch )
+
+pkg_setup() {
+	local CONFIG_CHECK="~DM_CRYPT ~CRYPTO ~CRYPTO_CBC ~CRYPTO_SHA256"
+	local WARNING_DM_CRYPT="CONFIG_DM_CRYPT:\tis not set (required for cryptsetup)\n"
+	local WARNING_CRYPTO_SHA256="CONFIG_CRYPTO_SHA256:\tis not set (required for cryptsetup)\n"
+	local WARNING_CRYPTO_CBC="CONFIG_CRYPTO_CBC:\tis not set (required for kernel 2.6.19)\n"
+	local WARNING_CRYPTO="CONFIG_CRYPTO:\tis not set (required for cryptsetup)\n"
+	check_extra_config
+}
+
+src_prepare() {
+	default
+
+	sed -i '/^LOOPDEV=/s:$: || exit 0:' tests/{compat,mode}-test || die
+}
+
+src_configure() {
+	local myeconfargs=(
+		--disable-internal-argon2
+		--disable-asciidoc
+		--enable-shared
+		--sbindir="${EPREFIX}"/sbin
+		# for later use
+		--with-default-luks-format=LUKS2
+		--with-tmpfilesdir="${EPREFIX}/usr/lib/tmpfiles.d"
+		--with-crypto_backend=$(for x in ${CRYPTO_BACKENDS//+/} ; do usev ${x} ; done)
+		$(use_enable argon2 libargon2)
+		$(use_enable nls)
+		$(use_enable pwquality)
+		$(use_enable passwdqc)
+		$(use_enable !static external-tokens)
+		$(use_enable static static-cryptsetup)
+		$(use_enable static-libs static)
+		$(use_enable udev)
+		$(use_enable !urandom dev-random)
+		$(use_enable ssh ssh-token)
+		$(usev !argon2 '--with-luks2-pbkdf=pbkdf2')
+		$(use_enable fips)
+	)
+
+	econf "${myeconfargs[@]}"
+}
+
+src_test() {
+	if [[ ! -e /dev/mapper/control ]] ; then
+		ewarn "No /dev/mapper/control found -- skipping tests"
+		return 0
+	fi
+
+	local p
+	for p in /dev/mapper /dev/loop* ; do
+		addwrite ${p}
+	done
+
+	default
+}
+
+src_install() {
+	default
+
+	if use static ; then
+		mv "${ED}"/sbin/cryptsetup{.static,} || die
+		mv "${ED}"/sbin/veritysetup{.static,} || die
+		mv "${ED}"/sbin/integritysetup{.static,} || die
+
+		if use ssh ; then
+			mv "${ED}"/sbin/cryptsetup-ssh{.static,} || die
+		fi
+	fi
+
+	find "${ED}" -type f -name "*.la" -delete || die
+
+	dodoc docs/v*ReleaseNotes
+
+	newconfd "${FILESDIR}"/2.4.3-dmcrypt.confd dmcrypt
+	newinitd "${FILESDIR}"/2.4.3-dmcrypt.rc dmcrypt
+}
+
+pkg_postinst() {
+	tmpfiles_process cryptsetup.conf
+
+	if use kernel ; then
+		ewarn "Note that kernel backend is very slow for this type of operation"
+		ewarn "and is provided mainly for embedded systems wanting to avoid"
+		ewarn "userspace crypto libraries."
+	fi
+}

--- a/sys-fs/cryptsetup/files/cryptsetup-2.7.5-compat-test-passwdqc.patch
+++ b/sys-fs/cryptsetup/files/cryptsetup-2.7.5-compat-test-passwdqc.patch
@@ -1,0 +1,58 @@
+https://gitlab.com/cryptsetup/cryptsetup/-/commit/64fb1c1b2673e7f366b789943d1627c859a70b1f.patch
+https://gitlab.com/cryptsetup/cryptsetup/-/merge_requests/737
+
+From 64fb1c1b2673e7f366b789943d1627c859a70b1f Mon Sep 17 00:00:00 2001
+From: Gabi Falk <gabifalk@gmx.com>
+Date: Sun, 22 Dec 2024 16:00:00 +0000
+Subject: [PATCH] tests/compat-test: Adjust test for compatibility with
+ passwdqc
+
+Unlike libpwquality, passwdqc does not consider 'compatkey' a strong
+password and rejects 512 character long passwords.
+
+Closes: https://gitlab.com/cryptsetup/cryptsetup/-/issues/928
+Signed-off-by: Gabi Falk <gabifalk@gmx.com>
+---
+ tests/compat-test | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/tests/compat-test b/tests/compat-test
+index 0b2463dd..f01f3032 100755
+--- a/tests/compat-test
++++ b/tests/compat-test
+@@ -250,7 +250,7 @@ echo $PWD1 | $CRYPTSETUP luksAddKey $IMG $FAST_PBKDF_OPT 2>/dev/null && fail
+ echo -e "$PWD1\n$PWD2" | $CRYPTSETUP luksAddKey $IMG $FAST_PBKDF_OPT || fail
+ echo -e "$PWD0\n$PWD1" | $CRYPTSETUP luksAddKey $IMG $FAST_PBKDF_OPT 2>/dev/null && fail
+ echo "[4] change key"
+-echo -e "$PWD1\n$PWD0\n" | $CRYPTSETUP luksChangeKey $FAST_PBKDF_OPT $IMG || fail
++echo -e "$PWD1\n$PWD0\n" | $CRYPTSETUP luksChangeKey --force-password $FAST_PBKDF_OPT $IMG || fail
+ echo -e "$PWD1\n$PWD2\n" | $CRYPTSETUP luksChangeKey $FAST_PBKDF_OPT $IMG 2>/dev/null && fail
+ [ $? -ne 2 ] && fail "luksChangeKey should return EPERM exit code"
+ echo "[5] remove key"
+@@ -941,7 +941,7 @@ prepare "[35] Interactive format of device." wipe
+ expect_run - >/dev/null <<EOF
+ proc abort {} { send_error "Timeout. "; exit 2 }
+ set timeout $EXPECT_TIMEOUT
+-eval spawn $CRYPTSETUP_RAW luksFormat --type luks1 $FAST_PBKDF_OPT -v $LOOPDEV
++eval spawn $CRYPTSETUP_RAW luksFormat --type luks1 --force-password $FAST_PBKDF_OPT -v $LOOPDEV
+ expect timeout abort "Are you sure? (Type 'yes' in capital letters):"
+ send "YES\n"
+ expect timeout abort "Enter passphrase for $EXPECT_DEV:"
+@@ -971,7 +971,7 @@ expect timeout abort "Are you sure? (Type 'yes' in capital letters):"
+ send "YES\n"
+ expect timeout abort "Command successful."
+ expect timeout abort eof
+-eval spawn $CRYPTSETUP_RAW luksFormat --type luks1 $FAST_PBKDF_OPT -v $LOOPDEV
++eval spawn $CRYPTSETUP_RAW luksFormat --type luks1 --force-password $FAST_PBKDF_OPT -v $LOOPDEV
+ expect timeout abort "Are you sure? (Type 'yes' in capital letters):"
+ send "YES\n"
+ expect timeout abort "Enter passphrase for $EXPECT_DEV:"
+@@ -1105,7 +1105,7 @@ echo -n "$LONG_PWD" >$KEYE
+ expect_run - >/dev/null <<EOF
+ proc abort {} { send_error "Timeout. "; exit 2 }
+ set timeout $EXPECT_TIMEOUT
+-eval spawn $CRYPTSETUP_RAW luksFormat --type luks1 $FAST_PBKDF_OPT -v $LOOPDEV
++eval spawn $CRYPTSETUP_RAW luksFormat --type luks1 --force-password $FAST_PBKDF_OPT -v $LOOPDEV
+ expect timeout abort "Are you sure? (Type 'yes' in capital letters):"
+ send "YES\n"
+ expect timeout abort "Enter passphrase for $EXPECT_DEV:"

--- a/sys-fs/cryptsetup/metadata.xml
+++ b/sys-fs/cryptsetup/metadata.xml
@@ -13,6 +13,7 @@
 	<flag name="nettle">Use <pkg>dev-libs/nettle</pkg> crypto backend</flag>
 	<flag name="openssl">Use <pkg>dev-libs/openssl</pkg> crypto backend</flag>
 	<flag name="pwquality">Use <pkg>dev-libs/libpwquality</pkg> for password quality checking</flag>
+	<flag name="passwdqc">Use <pkg>sys-auth/passwdqc</pkg> for password quality checking</flag>
 	<flag name="ssh">Build cryptsetup-ssh for experimental support of token via SSH-server</flag>
 	<flag name="urandom">Use /dev/urandom instead of /dev/random</flag>
 </use>


### PR DESCRIPTION
libpasswdqc has been supported by cryptsetup for almost as long as pwquality, and might be regarded as a potentially better implementation of password strength checker.

As this is my first pull request for Gentoo, I'm uncertain if this change requires a revision bump.