### PR TITLE
media-gfx/gnuclad: EAPI8, fix LICENSE

### DIFF
--- a/media-gfx/gnuclad/gnuclad-0.2.4-r1.ebuild
+++ b/media-gfx/gnuclad/gnuclad-0.2.4-r1.ebuild
@@ -1,0 +1,30 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools
+
+DESCRIPTION="Cladogram tree generator mainly used by the GNU/Linux distro timeline project"
+HOMEPAGE="https://launchpad.net/gnuclad/"
+SRC_URI="https://launchpad.net/gnuclad/trunk/$(ver_cut 1-2)/+download/${P}.tar.gz"
+
+LICENSE="GPL-3+"
+SLOT="0"
+KEYWORDS="~amd64"
+IUSE="examples"
+
+PATCHES=(
+	"${FILESDIR}/${P}"-werror.patch
+)
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_install() {
+	default
+	doman doc/man/gnuclad.1
+	use examples && dodoc -r example
+}


### PR DESCRIPTION
Very simple `EAPI8` bump

```diff
--- gnuclad-0.2.4.ebuild	2024-01-17 20:05:13.164816884 +0100
+++ gnuclad-0.2.4-r1.ebuild	2024-03-12 20:22:05.332390706 +0100
@@ -1,22 +1,19 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
 
-inherit autotools eapi7-ver
+inherit autotools
 
 DESCRIPTION="Cladogram tree generator mainly used by the GNU/Linux distro timeline project"
 HOMEPAGE="https://launchpad.net/gnuclad/"
-SRC_URI="http://launchpad.net/gnuclad/trunk/$(ver_cut 1-2)/+download/${P}.tar.gz"
+SRC_URI="https://launchpad.net/gnuclad/trunk/$(ver_cut 1-2)/+download/${P}.tar.gz"
 
-LICENSE="GPL-3"
+LICENSE="GPL-3+"
 SLOT="0"
-KEYWORDS="amd64"
+KEYWORDS="~amd64"
 IUSE="examples"
 
-DEPEND=""
-RDEPEND=""
-
 PATCHES=(
 	"${FILESDIR}/${P}"-werror.patch
 )
@@ -28,8 +25,6 @@
 
 src_install() {
 	default
-
 	doman doc/man/gnuclad.1
-
 	use examples && dodoc -r example
 }
```