### PR TITLE
dev-cpp/benchmark: add patches for alpha architecture

### DIFF
--- a/dev-cpp/benchmark/benchmark-1.8.3-r1.ebuild
+++ b/dev-cpp/benchmark/benchmark-1.8.3-r1.ebuild
@@ -1,0 +1,39 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit cmake flag-o-matic
+
+DESCRIPTION="A microbenchmark support library"
+HOMEPAGE="https://github.com/google/benchmark"
+SRC_URI="https://github.com/google/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="Apache-2.0"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~x86"
+IUSE="debug doc test"
+RESTRICT="!test? ( test )"
+
+BDEPEND="doc? ( app-text/doxygen )
+	test? ( >=dev-cpp/gtest-1.11.0 )"
+PATCHES=(
+	"${FILESDIR}/${PN}-1.8.3-fix-32bit-test.patch"
+	"${FILESDIR}/${PN}-1.8.3-backport-pr1753.patch"
+	"${FILESDIR}/${PN}-1.8.3-backport-pr1756.patch"
+)
+
+src_configure() {
+	local mycmakeargs=(
+		-DBENCHMARK_ENABLE_ASSEMBLY_TESTS=OFF
+		-DBENCHMARK_ENABLE_DOXYGEN=$(usex doc)
+		-DBENCHMARK_ENABLE_GTEST_TESTS=$(usex test)
+		-DBENCHMARK_ENABLE_TESTING=$(usex test)
+		-DBENCHMARK_ENABLE_WERROR=OFF
+		-DBENCHMARK_USE_BUNDLED_GTEST=OFF
+	)
+
+	use debug || append-cppflags -DNDEBUG
+
+	cmake_src_configure
+}

--- a/dev-cpp/benchmark/files/benchmark-1.8.3-backport-pr1753.patch
+++ b/dev-cpp/benchmark/files/benchmark-1.8.3-backport-pr1753.patch
@@ -1,0 +1,94 @@
+https://bugs.gentoo.org/922877
+https://github.com/google/benchmark/pull/1753
+
+From cdd4a6d48077a78d07e3b7f165383f6d5052108c Mon Sep 17 00:00:00 2001
+From: Sam James <sam@gentoo.org>
+Date: Fri, 2 Feb 2024 21:38:11 -0500
+Subject: [PATCH 1/3] CycleClock: Add support for Alpha architecture
+
+As documented, the real cycle counter is unsafe to use here, because it
+is a 32-bit integer which wraps every ~4s.  Use gettimeofday instead,
+which has a limitation of a low-precision real-time-clock (~1ms), but no
+wrapping.  Passes test suite.
+
+Signed-off-by: Sam James <sam@gentoo.org>
+---
+ src/cycleclock.h | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/src/cycleclock.h b/src/cycleclock.h
+index 931bba146..eff563e7f 100644
+--- a/src/cycleclock.h
++++ b/src/cycleclock.h
+@@ -218,6 +218,15 @@ inline BENCHMARK_ALWAYS_INLINE int64_t Now() {
+   uint64_t pcycle;
+   asm volatile("%0 = C15:14" : "=r"(pcycle));
+   return static_cast<double>(pcycle);
++#elif defined(__alpha__)
++  // Alpha has a cycle counter, the PCC register, but it is an unsigned 32-bit
++  // integer and thus wraps every ~4s, making using it for tick counts
++  // unreliable beyond this time range.  The real-time clock is low-precision,
++  // roughtly ~1ms, but it is the only option that can reasonable count
++  // indefinitely.
++  struct timeval tv;
++  gettimeofday(&tv, nullptr);
++  return static_cast<int64_t>(tv.tv_sec) * 1000000 + tv.tv_usec;
+ #else
+   // The soft failover to a generic implementation is automatic only for ARM.
+   // For other platforms the developer is expected to make an attempt to create
+
+From b1bec2fa5aed335b5be78720a9812cf27baf9df6 Mon Sep 17 00:00:00 2001
+From: Sam James <sam@gentoo.org>
+Date: Fri, 2 Feb 2024 21:46:06 -0500
+Subject: [PATCH 2/3] sysinfo: support parsing /proc/cpuinfo on Alpha
+
+And also, bail out if unable to parse /proc/cpuinfo.  This will
+preemptively alert users on platforms that need custom code for parsing
+/proc/cpuinfo.
+
+Signed-off-by: Sam James <sam@gentoo.org>
+---
+ src/sysinfo.cc | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/src/sysinfo.cc b/src/sysinfo.cc
+index 04d64dc5b..786bb1b41 100644
+--- a/src/sysinfo.cc
++++ b/src/sysinfo.cc
+@@ -513,7 +513,11 @@ int GetNumCPUs() {
+     std::cerr << "failed to open /proc/cpuinfo\n";
+     return -1;
+   }
++#if defined(__alpha__)
++  const std::string Key = "cpus detected";
++#else
+   const std::string Key = "processor";
++#endif
+   std::string ln;
+   while (std::getline(f, ln)) {
+     if (ln.empty()) continue;
+
+From 17f2f35e1ce650b4f8596a5c5df6a050588136c5 Mon Sep 17 00:00:00 2001
+From: Sam James <sam@gentoo.org>
+Date: Fri, 2 Feb 2024 21:49:24 -0500
+Subject: [PATCH 3/3] tabular_test: add a missing DoNotOptimize call
+
+Signed-off-by: Sam James <sam@gentoo.org>
+---
+ test/user_counters_tabular_test.cc | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/test/user_counters_tabular_test.cc b/test/user_counters_tabular_test.cc
+index 3e8fb1bf0..ffd3c0992 100644
+--- a/test/user_counters_tabular_test.cc
++++ b/test/user_counters_tabular_test.cc
+@@ -63,6 +63,9 @@ ADD_CASES(TC_CSVOut, {{"%csv_header,"
+ 
+ void BM_Counters_Tabular(benchmark::State& state) {
+   for (auto _ : state) {
++    // This test requires a non-zero CPU time to avoid divide-by-zero
++    auto iterations = state.iterations();
++    benchmark::DoNotOptimize(iterations);
+   }
+   namespace bm = benchmark;
+   state.counters.insert({

--- a/dev-cpp/benchmark/files/benchmark-1.8.3-backport-pr1756.patch
+++ b/dev-cpp/benchmark/files/benchmark-1.8.3-backport-pr1756.patch
@@ -1,0 +1,89 @@
+https://bugs.gentoo.org/922877
+https://github.com/google/benchmark/pull/1756
+
+From 3805709f137766c99922f647af9b97d49d14e772 Mon Sep 17 00:00:00 2001
+From: Sam James <sam@gentoo.org>
+Date: Tue, 13 Feb 2024 20:23:20 -0500
+Subject: [PATCH] sysinfo.cc: Always abort on GetNumCPUs failure
+
+Defines a wrapper function, CheckNumCPUs, which enforces that GetNumCPUs
+never returns fewer than one CPU.  There is no reasonable way to
+continue if we are unable to identify the number of CPUs.
+
+Signed-off-by: Sam James <sam@gentoo.org>
+---
+ src/sysinfo.cc | 28 +++++++++++++++++-----------
+ 1 file changed, 17 insertions(+), 11 deletions(-)
+
+diff --git a/src/sysinfo.cc b/src/sysinfo.cc
+index 786bb1b41..daeb98b02 100644
+--- a/src/sysinfo.cc
++++ b/src/sysinfo.cc
+@@ -474,12 +474,11 @@ std::string GetSystemName() {
+ #endif  // Catch-all POSIX block.
+ }
+ 
+-int GetNumCPUs() {
++int GetNumCPUsImpl() {
+ #ifdef BENCHMARK_HAS_SYSCTL
+   int num_cpu = -1;
+   if (GetSysctl("hw.ncpu", &num_cpu)) return num_cpu;
+-  fprintf(stderr, "Err: %s\n", strerror(errno));
+-  std::exit(EXIT_FAILURE);
++  PrintErrorAndDie("Err: ", strerror(errno));
+ #elif defined(BENCHMARK_OS_WINDOWS)
+   SYSTEM_INFO sysinfo;
+   // Use memset as opposed to = {} to avoid GCC missing initializer false
+@@ -493,8 +492,8 @@ int GetNumCPUs() {
+   // Returns -1 in case of a failure.
+   long num_cpu = sysconf(_SC_NPROCESSORS_ONLN);
+   if (num_cpu < 0) {
+-    fprintf(stderr, "sysconf(_SC_NPROCESSORS_ONLN) failed with error: %s\n",
+-            strerror(errno));
++    PrintErrorAndDie("sysconf(_SC_NPROCESSORS_ONLN) failed with error: ",
++                     strerror(errno));
+   }
+   return (int)num_cpu;
+ #elif defined(BENCHMARK_OS_QNX)
+@@ -510,8 +509,7 @@ int GetNumCPUs() {
+   int max_id = -1;
+   std::ifstream f("/proc/cpuinfo");
+   if (!f.is_open()) {
+-    std::cerr << "failed to open /proc/cpuinfo\n";
+-    return -1;
++    PrintErrorAndDie("Failed to open /proc/cpuinfo");
+   }
+ #if defined(__alpha__)
+   const std::string Key = "cpus detected";
+@@ -540,12 +538,10 @@ int GetNumCPUs() {
+     }
+   }
+   if (f.bad()) {
+-    std::cerr << "Failure reading /proc/cpuinfo\n";
+-    return -1;
++    PrintErrorAndDie("Failure reading /proc/cpuinfo");
+   }
+   if (!f.eof()) {
+-    std::cerr << "Failed to read to end of /proc/cpuinfo\n";
+-    return -1;
++    PrintErrorAndDie("Failed to read to end of /proc/cpuinfo");
+   }
+   f.close();
+ 
+@@ -559,6 +555,16 @@ int GetNumCPUs() {
+   BENCHMARK_UNREACHABLE();
+ }
+ 
++int GetNumCPUs() {
++  const int num_cpus = GetNumCPUsImpl();
++  if (num_cpus < 1) {
++    PrintErrorAndDie(
++        "Unable to extract number of CPUs.  If your platform uses "
++        "/proc/cpuinfo, custom support may need to be added.");
++  }
++  return num_cpus;
++}
++
+ class ThreadAffinityGuard final {
+  public:
+   ThreadAffinityGuard() : reset_affinity(SetAffinity()) {


### PR DESCRIPTION
Accepted upstream already.

See: https://github.com/google/benchmark/pull/1753
See: https://github.com/google/benchmark/pull/1756
Bug: https://bugs.gentoo.org/922877