### PR TITLE
net-firewall/firewalld: CONFIG_NFT_OBJREF removed for kernels > 6.1

### DIFF
--- a/net-firewall/firewalld/firewalld-2.0.1.ebuild
+++ b/net-firewall/firewalld/firewalld-2.0.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -124,7 +124,6 @@ pkg_setup() {
 	~NFT_LOG
 	~NFT_MASQ
 	~NFT_NAT
-	~NFT_OBJREF
 	~NFT_QUEUE
 	~NFT_QUOTA
 	~NFT_REDIR
@@ -151,6 +150,11 @@ pkg_setup() {
 	# bug #853055
 	if kernel_is -lt 5 18 ; then
 		CONFIG_CHECK+=" ~NFT_COUNTER"
+	fi
+
+	# bug #926685
+	if kernel_is -le 6 1 ; then
+		CONFIG_CHECK+=" ~NFT_OBJREF"
 	fi
 
 	linux-info_pkg_setup

--- a/net-firewall/firewalld/firewalld-2.0.2.ebuild
+++ b/net-firewall/firewalld/firewalld-2.0.2.ebuild
@@ -124,7 +124,6 @@ pkg_setup() {
 	~NFT_LOG
 	~NFT_MASQ
 	~NFT_NAT
-	~NFT_OBJREF
 	~NFT_QUEUE
 	~NFT_QUOTA
 	~NFT_REDIR
@@ -151,6 +150,11 @@ pkg_setup() {
 	# bug #853055
 	if kernel_is -lt 5 18 ; then
 		CONFIG_CHECK+=" ~NFT_COUNTER"
+	fi
+
+	# bug #926685
+	if kernel_is -le 6 1 ; then
+		CONFIG_CHECK+=" ~NFT_OBJREF"
 	fi
 
 	linux-info_pkg_setup

--- a/net-firewall/firewalld/firewalld-2.1.0.ebuild
+++ b/net-firewall/firewalld/firewalld-2.1.0.ebuild
@@ -124,7 +124,6 @@ pkg_setup() {
 	~NFT_LOG
 	~NFT_MASQ
 	~NFT_NAT
-	~NFT_OBJREF
 	~NFT_QUEUE
 	~NFT_QUOTA
 	~NFT_REDIR
@@ -151,6 +150,11 @@ pkg_setup() {
 	# bug #853055
 	if kernel_is -lt 5 18 ; then
 		CONFIG_CHECK+=" ~NFT_COUNTER"
+	fi
+
+	# bug #926685
+	if kernel_is -le 6 1 ; then
+		CONFIG_CHECK+=" ~NFT_OBJREF"
 	fi
 
 	linux-info_pkg_setup

--- a/net-firewall/firewalld/firewalld-2.1.1-r1.ebuild
+++ b/net-firewall/firewalld/firewalld-2.1.1-r1.ebuild
@@ -124,7 +124,6 @@ pkg_setup() {
 	~NFT_LOG
 	~NFT_MASQ
 	~NFT_NAT
-	~NFT_OBJREF
 	~NFT_QUEUE
 	~NFT_QUOTA
 	~NFT_REDIR
@@ -151,6 +150,11 @@ pkg_setup() {
 	# bug #853055
 	if kernel_is -lt 5 18 ; then
 		CONFIG_CHECK+=" ~NFT_COUNTER"
+	fi
+
+	# bug #926685
+	if kernel_is -le 6 1 ; then
+		CONFIG_CHECK+=" ~NFT_OBJREF"
 	fi
 
 	linux-info_pkg_setup

--- a/net-firewall/firewalld/firewalld-2.1.1.ebuild
+++ b/net-firewall/firewalld/firewalld-2.1.1.ebuild
@@ -124,7 +124,6 @@ pkg_setup() {
 	~NFT_LOG
 	~NFT_MASQ
 	~NFT_NAT
-	~NFT_OBJREF
 	~NFT_QUEUE
 	~NFT_QUOTA
 	~NFT_REDIR
@@ -151,6 +150,11 @@ pkg_setup() {
 	# bug #853055
 	if kernel_is -lt 5 18 ; then
 		CONFIG_CHECK+=" ~NFT_COUNTER"
+	fi
+
+	# bug #926685
+	if kernel_is -le 6 1 ; then
+		CONFIG_CHECK+=" ~NFT_OBJREF"
 	fi
 
 	linux-info_pkg_setup


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/926685
Signed-off-by: Cristian Othón Martínez Vera <cfuga@cfuga.mx>
