### PR TITLE
media-libs/libopenraw: remove typo

### DIFF
--- a/media-libs/libopenraw/files/libopenraw-0.3.7-slibtool.patch
+++ b/media-libs/libopenraw/files/libopenraw-0.3.7-slibtool.patch
@@ -1,0 +1,16 @@
+https://bugs.gentoo.org/913723
+https://gitlab.freedesktop.org/libopenraw/libopenraw/-/commit/eb873c75b09074d710e3f105b9c988a28058db53
+
+--- a/lib/Makefile.am
++++ b/lib/Makefile.am
+@@ -118,10 +118,8 @@ clean-local:
+ 	CARGO_TARGET_DIR=$(CARGO_TARGET_DIR) cargo clean $(CARGO_VERBOSE) $(CARGO_RELEASE_ARGS)
+ 	rm -f $(CARGO_TARGET_DIR)/.rustc_info.json
+ 
+-# The use of --all-static is necesary for the RUST_LIB
+ libopenraw_la_LDFLAGS = \
+ 	-version-info @LIBOPENRAW_VERSION_INFO@ \
+-	--all-static \
+ 	-lpthread -ldl
+ libopenraw_la_LIBADD = -ljpeg $(RUST_LIB) libopenraw_internals.la
+ libopenraw_la_SOURCES = \

--- a/media-libs/libopenraw/libopenraw-0.3.7.ebuild
+++ b/media-libs/libopenraw/libopenraw-0.3.7.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 CRATES=" "
-inherit cargo gnome2-utils
+inherit autotools cargo gnome2-utils
 
 DESCRIPTION="RAW image formats decoding library"
 HOMEPAGE="https://libopenraw.freedesktop.org/"
@@ -33,6 +33,15 @@ BDEPEND="
 	virtual/pkgconfig
 	test? ( net-misc/curl )
 "
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-0.3.7-slibtool.patch #913723
+)
+
+src_prepare() {
+	default
+	eautoreconf
+}
 
 src_configure() {
 	econf \


### PR DESCRIPTION
The libtool flag is `-all-static` and not `--all-static` which causes slibtool to fail while GNU libtool silently ignores the unknown flag. Additionally fixing the typo causes the build to fail with undefined references so just remove it instead.

Upstream already removed it themselves, but their change is not trivial to backport.

Closes: https://bugs.gentoo.org/913723
Upstream-Commit: https://gitlab.freedesktop.org/libopenraw/libopenraw/-/commit/eb873c75b09074d710e3f105b9c988a28058db53