### PR TITLE
net-vpn/wireguard-tools: update EAPI 7 -> 8, added "doas" USE flag

### DIFF
--- a/net-vpn/wireguard-tools/files/1.0.20210424-doas.patch
+++ b/net-vpn/wireguard-tools/files/1.0.20210424-doas.patch
@@ -1,0 +1,11 @@
+--- a/work/wireguard-tools-1.0.20210424/src/wg-quick/linux.bash
++++ b/work/wireguard-tools-1.0.20210424/src/wg-quick/linux.bash
+@@ -82,7 +82,7 @@ read_bool() {
+ }
+ 
+ auto_su() {
+-	[[ $UID == 0 ]] || exec sudo -p "$PROGRAM must be run as root. Please enter the password for %u to continue: " -- "$BASH" -- "$SELF" "${ARGS[@]}"
++	[[ $UID == 0 ]] || exec doas -- "$BASH" -- "$SELF" "${ARGS[@]}"
+ }
+ 
+ add_if() {

--- a/net-vpn/wireguard-tools/files/1.0.20210914-doas.patch
+++ b/net-vpn/wireguard-tools/files/1.0.20210914-doas.patch
@@ -1,0 +1,11 @@
+--- a/work/wireguard-tools-1.0.20210914/src/wg-quick/linux.bash
++++ b/work/wireguard-tools-1.0.20210914/src/wg-quick/linux.bash
+@@ -82,7 +82,7 @@ read_bool() {
+ }
+ 
+ auto_su() {
+-	[[ $UID == 0 ]] || exec sudo -p "$PROGRAM must be run as root. Please enter the password for %u to continue: " -- "$BASH" -- "$SELF" "${ARGS[@]}"
++	[[ $UID == 0 ]] || exec doas -- "$BASH" -- "$SELF" "${ARGS[@]}"
+ }
+ 
+ add_if() {

--- a/net-vpn/wireguard-tools/metadata.xml
+++ b/net-vpn/wireguard-tools/metadata.xml
@@ -7,5 +7,6 @@
 	</maintainer>
 	<use>
 		<flag name="wg-quick">Install the wg-quick(8) helper tool. Most users want to use this.</flag>
+		<flag name="doas">Use app-admin/doas instead of app-admin/sudo for wg-quick.</flag>
 	</use>
 </pkgmetadata>

--- a/net-vpn/wireguard-tools/wireguard-tools-1.0.20210424-r1.ebuild
+++ b/net-vpn/wireguard-tools/wireguard-tools-1.0.20210424-r1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 inherit linux-info bash-completion-r1 systemd toolchain-funcs
 
@@ -13,20 +13,21 @@ if [[ ${PV} == 9999 ]]; then
 	EGIT_REPO_URI="https://git.zx2c4.com/wireguard-tools"
 else
 	SRC_URI="https://git.zx2c4.com/wireguard-tools/snapshot/wireguard-tools-${PV}.tar.xz"
-	KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~m68k ~mips ppc ppc64 ~s390 sparc x86"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86"
 fi
 
 LICENSE="GPL-2"
 SLOT="0"
-IUSE="+wg-quick selinux"
+IUSE="+wg-quick doas selinux"
+REQUIRED_USE="doas? ( wg-quick )"
 
 BDEPEND="virtual/pkgconfig"
-DEPEND=""
 RDEPEND="${DEPEND}
 	wg-quick? (
 		|| ( net-firewall/nftables net-firewall/iptables )
 		virtual/resolvconf
 	)
+	doas? ( app-admin/doas )
 	selinux? ( sec-policy/selinux-wireguard )
 "
 
@@ -76,6 +77,13 @@ pkg_setup() {
 		ewarn
 	fi
 	linux-info_pkg_setup
+}
+
+src_prepare() {
+	if use doas; then
+		eapply -p3 "${FILESDIR}/${PV}-doas.patch"
+	fi
+	default
 }
 
 src_compile() {

--- a/net-vpn/wireguard-tools/wireguard-tools-1.0.20210424.ebuild
+++ b/net-vpn/wireguard-tools/wireguard-tools-1.0.20210424.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 inherit linux-info bash-completion-r1 systemd toolchain-funcs
 
@@ -13,20 +13,21 @@ if [[ ${PV} == 9999 ]]; then
 	EGIT_REPO_URI="https://git.zx2c4.com/wireguard-tools"
 else
 	SRC_URI="https://git.zx2c4.com/wireguard-tools/snapshot/wireguard-tools-${PV}.tar.xz"
-	KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~m68k ~mips ppc ppc64 ~s390 sparc x86"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86"
 fi
 
 LICENSE="GPL-2"
 SLOT="0"
-IUSE="+wg-quick selinux"
+IUSE="+wg-quick doas selinux"
+REQUIRED_USE="doas? ( wg-quick )"
 
 BDEPEND="virtual/pkgconfig"
-DEPEND=""
 RDEPEND="${DEPEND}
 	wg-quick? (
 		|| ( net-firewall/nftables net-firewall/iptables )
 		virtual/resolvconf
 	)
+	doas? ( app-admin/doas )
 	selinux? ( sec-policy/selinux-wireguard )
 "
 
@@ -76,6 +77,13 @@ pkg_setup() {
 		ewarn
 	fi
 	linux-info_pkg_setup
+}
+
+src_prepare() {
+	if use doas; then
+		eapply -p3 "${FILESDIR}/${PV}-doas.patch"
+	fi
+	default
 }
 
 src_compile() {

--- a/net-vpn/wireguard-tools/wireguard-tools-1.0.20210914-r1.ebuild
+++ b/net-vpn/wireguard-tools/wireguard-tools-1.0.20210914-r1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 inherit linux-info bash-completion-r1 systemd toolchain-funcs
 
@@ -13,20 +13,21 @@ if [[ ${PV} == 9999 ]]; then
 	EGIT_REPO_URI="https://git.zx2c4.com/wireguard-tools"
 else
 	SRC_URI="https://git.zx2c4.com/wireguard-tools/snapshot/wireguard-tools-${PV}.tar.xz"
-	KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~m68k ~mips ppc ppc64 ~s390 sparc x86"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
 fi
 
 LICENSE="GPL-2"
 SLOT="0"
-IUSE="+wg-quick selinux"
+IUSE="+wg-quick doas selinux"
+REQUIRED_USE="doas? ( wg-quick )"
 
 BDEPEND="virtual/pkgconfig"
-DEPEND=""
 RDEPEND="${DEPEND}
 	wg-quick? (
 		|| ( net-firewall/nftables net-firewall/iptables )
 		virtual/resolvconf
 	)
+	doas? ( app-admin/doas )
 	selinux? ( sec-policy/selinux-wireguard )
 "
 
@@ -76,6 +77,13 @@ pkg_setup() {
 		ewarn
 	fi
 	linux-info_pkg_setup
+}
+
+src_prepare() {
+	if use doas; then
+		eapply -p3 "${FILESDIR}/${PV}-doas.patch"
+	fi
+	default
 }
 
 src_compile() {

--- a/net-vpn/wireguard-tools/wireguard-tools-1.0.20210914.ebuild
+++ b/net-vpn/wireguard-tools/wireguard-tools-1.0.20210914.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=8
+EAPI=7
 
 inherit linux-info bash-completion-r1 systemd toolchain-funcs
 
@@ -13,21 +13,20 @@ if [[ ${PV} == 9999 ]]; then
 	EGIT_REPO_URI="https://git.zx2c4.com/wireguard-tools"
 else
 	SRC_URI="https://git.zx2c4.com/wireguard-tools/snapshot/wireguard-tools-${PV}.tar.xz"
-	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+	KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86"
 fi
 
 LICENSE="GPL-2"
 SLOT="0"
-IUSE="+wg-quick doas selinux"
-REQUIRED_USE="doas? ( wg-quick )"
+IUSE="+wg-quick selinux"
 
 BDEPEND="virtual/pkgconfig"
+DEPEND=""
 RDEPEND="${DEPEND}
 	wg-quick? (
 		|| ( net-firewall/nftables net-firewall/iptables )
 		virtual/resolvconf
 	)
-	doas? ( app-admin/doas )
 	selinux? ( sec-policy/selinux-wireguard )
 "
 
@@ -77,13 +76,6 @@ pkg_setup() {
 		ewarn
 	fi
 	linux-info_pkg_setup
-}
-
-src_prepare() {
-	if use doas; then
-		eapply -p3 "${FILESDIR}/${PV}-doas.patch"
-	fi
-	default
 }
 
 src_compile() {

--- a/net-vpn/wireguard-tools/wireguard-tools-1.0.20210914.ebuild
+++ b/net-vpn/wireguard-tools/wireguard-tools-1.0.20210914.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 inherit linux-info bash-completion-r1 systemd toolchain-funcs
 
@@ -13,20 +13,21 @@ if [[ ${PV} == 9999 ]]; then
 	EGIT_REPO_URI="https://git.zx2c4.com/wireguard-tools"
 else
 	SRC_URI="https://git.zx2c4.com/wireguard-tools/snapshot/wireguard-tools-${PV}.tar.xz"
-	KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
 fi
 
 LICENSE="GPL-2"
 SLOT="0"
-IUSE="+wg-quick selinux"
+IUSE="+wg-quick doas selinux"
+REQUIRED_USE="doas? ( wg-quick )"
 
 BDEPEND="virtual/pkgconfig"
-DEPEND=""
 RDEPEND="${DEPEND}
 	wg-quick? (
 		|| ( net-firewall/nftables net-firewall/iptables )
 		virtual/resolvconf
 	)
+	doas? ( app-admin/doas )
 	selinux? ( sec-policy/selinux-wireguard )
 "
 
@@ -76,6 +77,13 @@ pkg_setup() {
 		ewarn
 	fi
 	linux-info_pkg_setup
+}
+
+src_prepare() {
+	if use doas; then
+		eapply -p3 "${FILESDIR}/${PV}-doas.patch"
+	fi
+	default
 }
 
 src_compile() {


### PR DESCRIPTION
Created a patch for "doas" USE flag based on src/wg-quick/openbsd.bash

If the user had installed app-admin/doas and the user use wg-quick (without app-admin/sudo installed), wg-quick will fail by the lack of sudo.

This commit will fix that for app-admin/doas users patching the src/wg-quick/linux.bash [1] using the equivalent line [2] for app-admin/doas from src/wg-quick/openbsd.bash.

[1] https://github.com/WireGuard/wireguard-tools/blob/13f4ac4cb74b5a833fa7f825ba785b1e5774e84f/src/wg-quick/linux.bash#L85
[2] https://github.com/WireGuard/wireguard-tools/blob/13f4ac4cb74b5a833fa7f825ba785b1e5774e84f/src/wg-quick/openbsd.bash#L86