### PR TITLE
dev-util/rocm-smi: keep the patch for builtin amdgpu in 5.7.1

### DIFF
--- a/dev-util/rocm-smi/rocm-smi-5.7.1-r2.ebuild
+++ b/dev-util/rocm-smi/rocm-smi-5.7.1-r2.ebuild
@@ -32,6 +32,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-5.7.1-set-soversion.patch
 	"${FILESDIR}"/${PN}-5.7.1-no-strip.patch
 	"${FILESDIR}"/${PN}-5.7.1-remove-example.patch
+	"${FILESDIR}"/${PN}-5.4.2-detect-builtin-amdgpu.patch
 )
 
 src_prepare() {


### PR DESCRIPTION
The patch is still needed when amdgpu builtin kernel module.