### PR TITLE
dev-lang/rust: Disable lto by default and use thin

### DIFF
--- a/dev-lang/rust/rust-1.76.0-r1.ebuild
+++ b/dev-lang/rust/rust-1.76.0-r1.ebuild
@@ -42,7 +42,7 @@ LLVM_TARGET_USEDEPS=${ALL_LLVM_TARGETS[@]/%/(-)?}
 
 LICENSE="|| ( MIT Apache-2.0 ) BSD BSD-1 BSD-2 BSD-4"
 
-IUSE="big-endian clippy cpu_flags_x86_sse2 debug dist doc llvm-libunwind +lto miri nightly parallel-compiler profiler rustfmt rust-analyzer rust-src system-bootstrap system-llvm test wasm ${ALL_LLVM_TARGETS[*]}"
+IUSE="big-endian clippy cpu_flags_x86_sse2 debug dist doc llvm-libunwind lto miri nightly parallel-compiler profiler rustfmt rust-analyzer rust-src system-bootstrap system-llvm test wasm ${ALL_LLVM_TARGETS[*]}"
 
 # Please keep the LLVM dependency block separate. Since LLVM is slotted,
 # we need to *really* make sure we're not pulling more than one slot
@@ -469,7 +469,8 @@ src_configure() {
 		deny-warnings = $(usex wasm $(usex doc false true) true)
 		backtrace-on-ice = true
 		jemalloc = false
-		lto = "$(usex lto fat off)"
+		# See https://github.com/rust-lang/rust/issues/121124
+		lto = "$(usex lto thin off)"
 		[dist]
 		src-tarball = false
 		compression-formats = ["xz"]


### PR DESCRIPTION
We've had a few issues with `lto` on, and it isn't on by default generally among Gentoo packages, so this commit flips it to be off by default.

Additionally, in an [upstream ticket](https://github.com/rust-lang/rust/issues/121124) it was suggested to use `thin` `lto` rather than `fat` `lto`, so this commit makes that adjustment as well.

Bug: https://bugs.gentoo.org/924301