### PR TITLE
gui-apps/wf-shell: inherit xdg eclass to update icon cache

### DIFF
--- a/gui-apps/wf-shell/wf-shell-0.8.1.ebuild
+++ b/gui-apps/wf-shell/wf-shell-0.8.1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit meson
+inherit meson xdg
 
 DESCRIPTION="Compiz like 3D wayland compositor"
 HOMEPAGE="https://github.com/WayfireWM/wf-shell"

--- a/gui-apps/wf-shell/wf-shell-9999.ebuild
+++ b/gui-apps/wf-shell/wf-shell-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit meson
+inherit meson xdg
 
 DESCRIPTION="Compiz like 3D wayland compositor"
 HOMEPAGE="https://github.com/WayfireWM/wf-shell"


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/927164