### PR TITLE
media-libs/openexr: 3.2.2 rework x86 test skip

### DIFF
--- a/media-libs/openexr/openexr-3.2.2.ebuild
+++ b/media-libs/openexr/openexr-3.2.2.ebuild
@@ -52,10 +52,6 @@ src_prepare() {
 	sed -e "s:if(INSTALL_DOCS):if(OPENEXR_INSTALL_DOCS):" \
 		-i docs/CMakeLists.txt || die
 
-	if use x86; then
-		eapply "${FILESDIR}/${PN}-3.1.5-drop-failing-testDwaLookups.patch"
-	fi
-
 	cmake_src_prepare
 
 	if use test; then
@@ -121,6 +117,16 @@ src_configure() {
 	)
 
 	cmake_src_configure
+}
+
+src_test() {
+    local CMAKE_SKIP_TESTS=()
+
+    use x86 && CMAKE_SKIP_TESTS+=(
+        '^OpenEXR.testDwaLookups$'
+    )
+
+    cmake_src_test
 }
 
 src_install() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/927173