### PR TITLE
sys-boot/cromwell-bin: EAPI8 bump

### DIFF
--- a/sys-boot/cromwell-bin/cromwell-bin-2.40-r2.ebuild
+++ b/sys-boot/cromwell-bin/cromwell-bin-2.40-r2.ebuild
@@ -1,0 +1,21 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit mount-boot
+
+DESCRIPTION="Xbox boot loader precompiled binaries from xbox-linux.org"
+HOMEPAGE="https://sourceforge.net/projects/xbox-linux/"
+SRC_URI="mirror://sourceforge/xbox-linux/cromwell-${PV}.tar.gz"
+S="${WORKDIR}/cromwell-${PV}"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="-* ~x86"
+RESTRICT="${RESTRICT} strip"
+
+src_install() {
+	insinto /boot/${PN}
+	doins cromwell{,_1024}.bin xromwell.xbe
+}


### PR DESCRIPTION
Hi,

The changes for this ebuild are pretty simple, however i've only tested the changes with `ebuild ... install`.

```diff
--- cromwell-bin-2.40-r1.ebuild	2023-04-01 17:48:26.733943483 +0200
+++ cromwell-bin-2.40-r2.ebuild	2024-03-17 19:28:02.690218803 +0100
@@ -1,27 +1,21 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
 
 inherit mount-boot
 
 DESCRIPTION="Xbox boot loader precompiled binaries from xbox-linux.org"
 HOMEPAGE="https://sourceforge.net/projects/xbox-linux/"
 SRC_URI="mirror://sourceforge/xbox-linux/cromwell-${PV}.tar.gz"
-LICENSE="GPL-2"
+S="${WORKDIR}/cromwell-${PV}"
 
+LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="-* x86"
-IUSE=""
+KEYWORDS="-* ~x86"
 RESTRICT="${RESTRICT} strip"
 
-DEPEND=""
-RDEPEND=""
-
-S=${WORKDIR}/cromwell-${PV}
-
 src_install() {
-	dodir /boot/${PN}
 	insinto /boot/${PN}
 	doins cromwell{,_1024}.bin xromwell.xbe
 }
```