### PR TITLE
net-dialup/wvdial: EAPI8 bump

### DIFF
--- a/net-dialup/wvdial/wvdial-1.61-r1.ebuild
+++ b/net-dialup/wvdial/wvdial-1.61-r1.ebuild
@@ -1,0 +1,46 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit readme.gentoo-r1
+
+DESCRIPTION="Excellent program to automatically configure PPP sessions"
+HOMEPAGE="https://code.google.com/archive/p/wvstreams/"
+SRC_URI="https://wvstreams.googlecode.com/files/${P}.tar.gz"
+
+LICENSE="LGPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~hppa ~ppc ~sparc ~x86"
+
+DEPEND=">=net-libs/wvstreams-4.4"
+RDEPEND="${DEPEND}
+	net-dialup/ppp:=
+"
+BDEPEND="virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}/${P}-destdir.patch"
+	"${FILESDIR}/${P}-as-needed.patch"
+	"${FILESDIR}/${P}-parallel-make.patch"
+)
+
+DOC_CONTENTS="
+	Use wvdialconf to automagically generate a configuration file.
+	Users have to be member of the dialout AND the uucp group to use
+	wvdial
+"
+
+src_configure() {
+	# Hand made configure...
+	./configure || die
+}
+
+src_install() {
+	default
+	readme.gentoo_create_doc
+}
+
+pkg_postinst() {
+	readme.gentoo_print_elog
+}


### PR DESCRIPTION
Another simple `EAPI8` bump

```diff
--- wvdial-1.61.ebuild	2023-04-01 17:48:26.518946893 +0200
+++ wvdial-1.61-r1.ebuild	2024-03-17 19:49:02.704358949 +0100
@@ -1,7 +1,8 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
+
 inherit readme.gentoo-r1
 
 DESCRIPTION="Excellent program to automatically configure PPP sessions"
@@ -10,16 +11,13 @@
 
 LICENSE="LGPL-2"
 SLOT="0"
-KEYWORDS="~alpha amd64 ~hppa ppc sparc x86"
-IUSE=""
+KEYWORDS="~alpha ~amd64 ~hppa ~ppc ~sparc ~x86"
 
-COMMON_DEPEND=">=net-libs/wvstreams-4.4"
-DEPEND="${COMMON_DEPEND}
-	virtual/pkgconfig
-"
-RDEPEND="${COMMON_DEPEND}
+DEPEND=">=net-libs/wvstreams-4.4"
+RDEPEND="${DEPEND}
 	net-dialup/ppp:=
 "
+BDEPEND="virtual/pkgconfig"
 
 PATCHES=(
 	"${FILESDIR}/${P}-destdir.patch"
```