### PR TITLE
xfce-extra/xfce4-kbdleds-plugin: fix undefined references

### DIFF
--- a/xfce-extra/xfce4-kbdleds-plugin/files/xfce4-kbdleds-plugin-0.2.3-x11-libs.patch
+++ b/xfce-extra/xfce4-kbdleds-plugin/files/xfce4-kbdleds-plugin-0.2.3-x11-libs.patch
@@ -1,0 +1,40 @@
+https://github.com/oco2000/xfce4-kbdleds-plugin/pull/10
+https://github.com/oco2000/xfce4-kbdleds-plugin/commit/190434d67843c2ec392aa4a2cab46e8479d2d34d
+
+From 128f5cd7d042007d91b2ec7cb744e64a81468566 Mon Sep 17 00:00:00 2001
+From: orbea <orbea@riseup.net>
+Date: Sun, 17 Mar 2024 08:37:11 -0700
+Subject: [PATCH] panel-plugin: add missing x11 linker flags
+
+The configure.ac.in has XDT_CHECK_LIBX11_REQUIRE, but fails to use the
+provided $(LIBX11_CFLAGS) and $(LIBX11_LIBS) variables in the build.
+
+While the build has -no-undefined GNU libtool will silently ignore that
+flag, but when built with slibtool instead it correctly passes
+-Wl,--no-undefined to the linker revealing this issue.
+
+Gentoo issue: https://bugs.gentoo.org/913681
+---
+ panel-plugin/Makefile.am | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/panel-plugin/Makefile.am b/panel-plugin/Makefile.am
+index 5f355fe..bb3b225 100644
+--- a/panel-plugin/Makefile.am
++++ b/panel-plugin/Makefile.am
+@@ -22,6 +22,7 @@ libkbdleds_la_SOURCES = \
+ 	kbdleds-dialogs.h
+ 
+ libkbdleds_la_CFLAGS = \
++	$(LIBX11_CFLAGS) \
+ 	$(LIBXFCE4UTIL_CFLAGS) \
+ 	$(LIBXFCE4UI_CFLAGS) \
+ 	$(LIBXFCE4PANEL_CFLAGS) \
+@@ -35,6 +36,7 @@ libkbdleds_la_LDFLAGS = \
+        $(PLATFORM_LDFLAGS)
+ 
+ libkbdleds_la_LIBADD = \
++	$(LIBX11_LIBS) \
+ 	$(LIBXFCE4UTIL_LIBS) \
+ 	$(LIBXFCE4UI_LIBS) \
+ 	$(LIBXFCE4PANEL_LIBS)

--- a/xfce-extra/xfce4-kbdleds-plugin/xfce4-kbdleds-plugin-0.2.3.ebuild
+++ b/xfce-extra/xfce4-kbdleds-plugin/xfce4-kbdleds-plugin-0.2.3.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-inherit xdg-utils
+inherit autotools xdg-utils
 
 DESCRIPTION="A panel plug-in to show state of Caps, Num and Scroll Lock keys"
 HOMEPAGE="https://github.com/oco2000/xfce4-kbdleds-plugin"
@@ -23,8 +23,17 @@ BDEPEND="
 	sys-devel/gettext
 	virtual/pkgconfig"
 
-# https://github.com/oco2000/xfce4-kbdleds-plugin/pull/7
-PATCHES=( "${FILESDIR}/${P}-xfce-4.16.patch" )
+PATCHES=(
+	# https://github.com/oco2000/xfce4-kbdleds-plugin/pull/7
+	"${FILESDIR}/${P}-xfce-4.16.patch"
+	# https://github.com/oco2000/xfce4-kbdleds-plugin/pull/10
+	"${FILESDIR}/${P}-x11-libs.patch" #913681
+)
+
+src_prepare() {
+	default
+	eautoreconf
+}
 
 src_install() {
 	default


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/913681
Upstream-PR: https://github.com/oco2000/xfce4-kbdleds-plugin/pull/10
Ustream-Commit: https://github.com/oco2000/xfce4-kbdleds-plugin/commit/190434d67843c2ec392aa4a2cab46e8479d2d34d