### PR TITLE
media-libs/libmatemixer: fix undefined references

### DIFF
--- a/media-libs/libmatemixer/files/libmatemixer-1.26.1-slibtool.patch
+++ b/media-libs/libmatemixer/files/libmatemixer-1.26.1-slibtool.patch
@@ -1,0 +1,74 @@
+https://bugs.gentoo.org/785232
+https://bugs.gentoo.org/921214
+https://github.com/mate-desktop/libmatemixer/pull/37
+https://github.com/mate-desktop/libmatemixer/commit/cb9e62b6d101cb42cdcf3ec7617616e6c4a4bb35
+
+From cb9e62b6d101cb42cdcf3ec7617616e6c4a4bb35 Mon Sep 17 00:00:00 2001
+From: orbea <orbea@riseup.net>
+Date: Thu, 12 May 2022 18:34:52 -0700
+Subject: [PATCH] backends: Add missing dependencies
+
+When building the backends with slibtool they will fail with undefined
+references to libmatemixer.la. This is because they use -no-undefined
+which slibtool explicitly supports while GNU libtool will silently
+ignore it.
+
+Gentoo Bug: https://bugs.gentoo.org/785232
+---
+ backends/alsa/Makefile.am  | 1 +
+ backends/null/Makefile.am  | 4 +++-
+ backends/oss/Makefile.am   | 1 +
+ backends/pulse/Makefile.am | 1 +
+ 4 files changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/backends/alsa/Makefile.am b/backends/alsa/Makefile.am
+index 798ce8b..44990b5 100644
+--- a/backends/alsa/Makefile.am
++++ b/backends/alsa/Makefile.am
+@@ -43,6 +43,7 @@ libmatemixer_alsa_la_SOURCES =                                  \
+ 	alsa-types.h
+ 
+ libmatemixer_alsa_la_LIBADD =                                   \
++	$(top_builddir)/libmatemixer/libmatemixer.la            \
+ 	$(GLIB_LIBS)                                            \
+ 	$(UDEV_LIBS)						\
+ 	$(ALSA_LIBS)
+diff --git a/backends/null/Makefile.am b/backends/null/Makefile.am
+index f0371a7..11d4b7f 100644
+--- a/backends/null/Makefile.am
++++ b/backends/null/Makefile.am
+@@ -18,7 +18,9 @@ libmatemixer_null_la_SOURCES =                                  \
+ 	null-backend.c                                          \
+ 	null-backend.h
+ 
+-libmatemixer_null_la_LIBADD = $(GLIB_LIBS)
++libmatemixer_null_la_LIBADD =                                   \
++	$(top_builddir)/libmatemixer/libmatemixer.la            \
++	$(GLIB_LIBS)
+ 
+ libmatemixer_null_la_LDFLAGS =                                  \
+ 	-avoid-version                                          \
+diff --git a/backends/oss/Makefile.am b/backends/oss/Makefile.am
+index d9e1fa7..cc5735f 100644
+--- a/backends/oss/Makefile.am
++++ b/backends/oss/Makefile.am
+@@ -32,6 +32,7 @@ libmatemixer_oss_la_SOURCES =                                   \
+ 	oss-types.h
+ 
+ libmatemixer_oss_la_LIBADD =                                    \
++	$(top_builddir)/libmatemixer/libmatemixer.la            \
+ 	$(GLIB_LIBS)                                            \
+ 	$(OSS_LIBS)
+ 
+diff --git a/backends/pulse/Makefile.am b/backends/pulse/Makefile.am
+index b07cc7e..a079af1 100644
+--- a/backends/pulse/Makefile.am
++++ b/backends/pulse/Makefile.am
+@@ -62,6 +62,7 @@ libmatemixer_pulse_la_SOURCES =                                 \
+ 	pulse-types.h
+ 
+ libmatemixer_pulse_la_LIBADD =                                  \
++	$(top_builddir)/libmatemixer/libmatemixer.la            \
+ 	$(GLIB_LIBS)                                            \
+ 	$(PULSEAUDIO_LIBS)
+ 

--- a/media-libs/libmatemixer/libmatemixer-1.26.1.ebuild
+++ b/media-libs/libmatemixer/libmatemixer-1.26.1.ebuild
@@ -38,6 +38,14 @@ RDEPEND="${COMMON_DEPEND}
 DEPEND="${COMMON_DEPEND}
 "
 
+PATCHES=(
+	"${FILESDIR}"/${PN}-1.26.1-slibtool.patch #921214
+)
+
+src_prepare() {
+	mate_src_prepare
+}
+
 src_configure() {
 	mate_src_configure \
 		--disable-null \


### PR DESCRIPTION
Restores prematurely removed patch to fix undefined references exposed by slibtool.

Bug: https://bugs.gentoo.org/785232
Closes: https://bugs.gentoo.org/921214
Upstream-PR: https://github.com/mate-desktop/libmatemixer/pull/37
Upstream-Commit: https://github.com/mate-desktop/libmatemixer/commit/cb9e62b6d101cb42cdcf3ec7617616e6c4a4bb35