### PR TITLE
games-emulation/nestopia-jg: drop media-libs/soxr dependency

### DIFF
--- a/games-emulation/nestopia-jg/nestopia-jg-9999.ebuild
+++ b/games-emulation/nestopia-jg/nestopia-jg-9999.ebuild
@@ -23,7 +23,6 @@ SLOT="1"
 
 DEPEND="
 	media-libs/jg:1=
-	media-libs/soxr
 "
 RDEPEND="
 	${DEPEND}


### PR DESCRIPTION
This was removed upstream.