### PR TITLE
media-libs/libjxl-0.9.1-r1: fix gdk_pixbuf_update execution

### DIFF
--- a/media-libs/libjxl/libjxl-0.9.1-r1.ebuild
+++ b/media-libs/libjxl/libjxl-0.9.1-r1.ebuild
@@ -102,9 +102,9 @@ multilib_src_install() {
 }
 
 pkg_postinst() {
-	use gdk-pixbuf && multilib_foreach_impl gnome2_gdk_pixbuf_update
+	use gdk-pixbuf && multilib_foreach_abi gnome2_gdk_pixbuf_update
 }
 
 pkg_postrm() {
-	use gdk-pixbuf && multilib_foreach_impl gnome2_gdk_pixbuf_update
+	use gdk-pixbuf && multilib_foreach_abi gnome2_gdk_pixbuf_update
 }


### PR DESCRIPTION
_Hello everyone,_

`gnome2_gdk_pixbuf_update` was never executed since `multilib_foreach_impl` doesn't exist.
`multilib_foreach_abi` should be used instead.

~These changes also add [a backported patch](https://github.com/libjxl/libjxl/pull/3218) in order to fix [a known issue](https://github.com/libjxl/libjxl/issues/3144).~ See [this discussion](https://github.com/gentoo/gentoo/pull/35826#discussion_r1530949770).

_Best regards!_