### PR TITLE
app-text/scrollkeeper-dtd: EAPI8 bump, use https

### DIFF
--- a/app-text/scrollkeeper-dtd/scrollkeeper-dtd-1.0-r2.ebuild
+++ b/app-text/scrollkeeper-dtd/scrollkeeper-dtd-1.0-r2.ebuild
@@ -1,0 +1,54 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DTD_FILE="scrollkeeper-omf.dtd"
+
+DESCRIPTION="DTD from the Scrollkeeper package"
+HOMEPAGE="https://scrollkeeper.sourceforge.net/"
+SRC_URI="https://scrollkeeper.sourceforge.net/dtds/scrollkeeper-omf-1.0/${DTD_FILE}"
+S="${WORKDIR}"
+
+LICENSE="FDL-1.1"
+SLOT="1.0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-solaris"
+
+RDEPEND=">=dev-libs/libxml2-2.4.19"
+DEPEND="${RDEPEND}"
+
+src_unpack() { :; }
+
+src_configure() { :; }
+
+src_compile() { :; }
+
+src_install() {
+	insinto /usr/share/xml/scrollkeeper/dtds
+	doins "${DISTDIR}/${DTD_FILE}"
+}
+
+pkg_postinst() {
+	einfo "Installing catalog..."
+
+	# Install regular DOCTYPE catalog entry
+	"${EROOT}"/usr/bin/xmlcatalog --noout --add "public" \
+		"-//OMF//DTD Scrollkeeper OMF Variant V1.0//EN" \
+		"${EROOT}"/usr/share/xml/scrollkeeper/dtds/${DTD_FILE} \
+		"${EROOT}"/etc/xml/catalog
+
+	# Install catalog entry for calls like: xmllint --dtdvalid URL ...
+	"${EROOT}"/usr/bin/xmlcatalog --noout --add "system" \
+		"${SRC_URI}" \
+		"${EROOT}"/usr/share/xml/scrollkeeper/dtds/${DTD_FILE} \
+		"${EROOT}"/etc/xml/catalog
+}
+
+pkg_postrm() {
+	# Remove all sk-dtd from the cache
+	einfo "Cleaning catalog..."
+
+	"${EROOT}"/usr/bin/xmlcatalog --noout --del \
+		"${EROOT}"/usr/share/xml/scrollkeeper/dtds/${DTD_FILE} \
+		"${EROOT}"/etc/xml/catalog
+}


### PR DESCRIPTION
Pretty simple `EAPI8` bump, also removed a blocker to `!<app-text/scrollkeeper-9999-r1"` which seems to be removed before the git migration..

```diff
--- scrollkeeper-dtd-1.0-r1.ebuild	2024-03-20 20:47:16.708564262 +0100
+++ scrollkeeper-dtd-1.0-r2.ebuild	2024-03-20 20:52:00.677064676 +0100
@@ -1,24 +1,21 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
 
 DTD_FILE="scrollkeeper-omf.dtd"
 
 DESCRIPTION="DTD from the Scrollkeeper package"
-HOMEPAGE="http://scrollkeeper.sourceforge.net/"
-SRC_URI="http://scrollkeeper.sourceforge.net/dtds/scrollkeeper-omf-1.0/${DTD_FILE}"
+HOMEPAGE="https://scrollkeeper.sourceforge.net/"
+SRC_URI="https://scrollkeeper.sourceforge.net/dtds/scrollkeeper-omf-1.0/${DTD_FILE}"
+S="${WORKDIR}"
 
 LICENSE="FDL-1.1"
 SLOT="1.0"
-KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-solaris"
-IUSE=""
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-solaris"
 
 RDEPEND=">=dev-libs/libxml2-2.4.19"
-DEPEND="${RDEPEND}
-	!<app-text/scrollkeeper-9999-r1"
-
-S="${WORKDIR}"
+DEPEND="${RDEPEND}"
 
 src_unpack() { :; }
 
@@ -35,23 +32,23 @@
 	einfo "Installing catalog..."
 
 	# Install regular DOCTYPE catalog entry
-	"${EROOT}"usr/bin/xmlcatalog --noout --add "public" \
+	"${EROOT}"/usr/bin/xmlcatalog --noout --add "public" \
 		"-//OMF//DTD Scrollkeeper OMF Variant V1.0//EN" \
-		"${EROOT}"usr/share/xml/scrollkeeper/dtds/${DTD_FILE} \
-		"${EROOT}"etc/xml/catalog
+		"${EROOT}"/usr/share/xml/scrollkeeper/dtds/${DTD_FILE} \
+		"${EROOT}"/etc/xml/catalog
 
 	# Install catalog entry for calls like: xmllint --dtdvalid URL ...
-	"${EROOT}"usr/bin/xmlcatalog --noout --add "system" \
+	"${EROOT}"/usr/bin/xmlcatalog --noout --add "system" \
 		"${SRC_URI}" \
-		"${EROOT}"usr/share/xml/scrollkeeper/dtds/${DTD_FILE} \
-		"${EROOT}"etc/xml/catalog
+		"${EROOT}"/usr/share/xml/scrollkeeper/dtds/${DTD_FILE} \
+		"${EROOT}"/etc/xml/catalog
 }
 
 pkg_postrm() {
 	# Remove all sk-dtd from the cache
 	einfo "Cleaning catalog..."
 
-	"${EROOT}"usr/bin/xmlcatalog --noout --del \
-		"${EROOT}"usr/share/xml/scrollkeeper/dtds/${DTD_FILE} \
-		"${EROOT}"etc/xml/catalog
+	"${EROOT}"/usr/bin/xmlcatalog --noout --del \
+		"${EROOT}"/usr/share/xml/scrollkeeper/dtds/${DTD_FILE} \
+		"${EROOT}"/etc/xml/catalog
 }
```