### PR TITLE
=app-pda/usbmuxd-1.1.1: Cap app-pda/libplist version to <2.3

### DIFF
--- a/app-pda/usbmuxd/usbmuxd-1.1.1.ebuild
+++ b/app-pda/usbmuxd/usbmuxd-1.1.1.ebuild
@@ -21,6 +21,9 @@ DEPEND="
 	>=app-pda/libplist-2.0:=
 	virtual/libusb:1"
 
+# See bug #926999
+DEPEND="${DEPEND} <app-pda/libplist-2.3"
+
 RDEPEND="
 	${DEPEND}
 	virtual/udev


### PR DESCRIPTION
This solves compile errors due to new plist.h being used by not-yet-updated usbmuxd 1.1.1

Bug: https://bugs.gentoo.org/926999