### PR TITLE
dev-util/rgbds: fix bison dependency

### DIFF
--- a/dev-util/rgbds/rgbds-0.6.1.ebuild
+++ b/dev-util/rgbds/rgbds-0.6.1.ebuild
@@ -20,7 +20,10 @@ SLOT="0"
 
 DEPEND="media-libs/libpng"
 RDEPEND="${DEPEND}"
-BDEPEND="virtual/pkgconfig"
+BDEPEND="
+	sys-devel/bison
+	virtual/pkgconfig
+"
 
 src_compile() {
 	append-flags -DNDEBUG

--- a/dev-util/rgbds/rgbds-0.7.0.ebuild
+++ b/dev-util/rgbds/rgbds-0.7.0.ebuild
@@ -20,8 +20,10 @@ SLOT="0"
 
 DEPEND="media-libs/libpng"
 RDEPEND="${DEPEND}"
-BDEPEND="app-alternatives/yacc[bison]
-	virtual/pkgconfig"
+BDEPEND="
+	sys-devel/bison
+	virtual/pkgconfig
+"
 
 src_compile() {
 	append-flags -DNDEBUG

--- a/dev-util/rgbds/rgbds-9999.ebuild
+++ b/dev-util/rgbds/rgbds-9999.ebuild
@@ -20,8 +20,10 @@ SLOT="0"
 
 DEPEND="media-libs/libpng"
 RDEPEND="${DEPEND}"
-BDEPEND="app-alternatives/yacc[bison]
-	virtual/pkgconfig"
+BDEPEND="
+	sys-devel/bison
+	virtual/pkgconfig
+"
 
 src_compile() {
 	append-flags -DNDEBUG


### PR DESCRIPTION
The build uses bison directly and does not use yacc.