### PR TITLE
sci-electronics/kicad: fix build error with libgit2-1.8.0

### DIFF
--- a/sci-electronics/kicad/files/kicad-8.0.1-fix-libgit2-1.8.0-compatibility.patch
+++ b/sci-electronics/kicad/files/kicad-8.0.1-fix-libgit2-1.8.0-compatibility.patch
@@ -1,0 +1,39 @@
+From 27b71f9a9381d0ab7552bfb27d6d48c6cc5171b1 Mon Sep 17 00:00:00 2001
+From: Huang Rui <vowstar@gmail.com>
+Date: Fri, 22 Mar 2024 18:18:40 +0800
+Subject: [PATCH] libgit2-1.8.0 compatibility: adjusted parent pointer type
+
+- Adjusted parent pointer type in git_commit_create call for compatibility
+  with libgit2 1.8.0 and above.
+- Included preprocessor checks to maintain support for versions older than
+  1.8.0.
+- Ensures consistent function behavior across different libgit2 versions.
+
+Fixes https://gitlab.com/kicad/code/kicad/-/issues/17536
+Signed-off-by: Huang Rui <vowstar@gmail.com>
+---
+ kicad/project_tree_pane.cpp | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/kicad/project_tree_pane.cpp b/kicad/project_tree_pane.cpp
+index 6ac4b04034cf..99ad026bc9c2 100644
+--- a/kicad/project_tree_pane.cpp
++++ b/kicad/project_tree_pane.cpp
+@@ -2233,7 +2233,14 @@ void PROJECT_TREE_PANE::onGitCommit( wxCommandEvent& aEvent )
+         }
+ 
+         git_oid           oid;
++    // Check if the libgit2 library version is 1.8.0 or higher
++#if ( LIBGIT2_VER_MAJOR > 1 ) || ( LIBGIT2_VER_MAJOR == 1 && LIBGIT2_VER_MINOR >= 8 )
++        // For libgit2 version 1.8.0 and above
++        git_commit* const parents[1] = { parent };
++#else
++        // For libgit2 versions older than 1.8.0
+         const git_commit* parents[1] = { parent };
++#endif
+ 
+         if( git_commit_create( &oid, repo, "HEAD", author, author, nullptr, commit_msg.mb_str(), tree,
+                            1, parents ) != 0 )
+-- 
+2.44.0
+

--- a/sci-electronics/kicad/kicad-8.0.0.ebuild
+++ b/sci-electronics/kicad/kicad-8.0.0.ebuild
@@ -80,6 +80,10 @@ fi
 
 CHECKREQS_DISK_BUILD="1500M"
 
+PATCHES=(
+	"${FILESDIR}"/${PN}-8.0.1-fix-libgit2-1.8.0-compatibility.patch
+)
+
 pkg_setup() {
 	[[ ${MERGE_TYPE} != binary ]] && use openmp && tc-check-openmp
 

--- a/sci-electronics/kicad/kicad-8.0.1.ebuild
+++ b/sci-electronics/kicad/kicad-8.0.1.ebuild
@@ -80,6 +80,10 @@ fi
 
 CHECKREQS_DISK_BUILD="1500M"
 
+PATCHES=(
+	"${FILESDIR}"/${PN}-8.0.1-fix-libgit2-1.8.0-compatibility.patch
+)
+
 pkg_setup() {
 	[[ ${MERGE_TYPE} != binary ]] && use openmp && tc-check-openmp
 


### PR DESCRIPTION
See also: https://gitlab.com/kicad/code/kicad/-/issues/17536

Closes: https://bugs.gentoo.org/927503