### PR TITLE
app-containers/crun: Depend on argp-standaolone on musl

### DIFF
--- a/app-containers/crun/crun-1.14.3.ebuild
+++ b/app-containers/crun/crun-1.14.3.ebuild
@@ -27,6 +27,7 @@ DEPEND="
 	sys-kernel/linux-headers
 	caps? ( sys-libs/libcap )
 	criu? ( >=sys-process/criu-3.15 )
+	elibc_musl? ( sys-libs/argp-standalone[static-libs] )
 	seccomp? ( sys-libs/libseccomp )
 	systemd? ( sys-apps/systemd:= )
 "


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/922292
Suggested-by: Han Puyu <w12101111@gmail.com>