### PR TITLE
sys-libs/libomp: drop ppc (isn't supported)

### DIFF
--- a/profiles/arch/powerpc/ppc32/package.mask
+++ b/profiles/arch/powerpc/ppc32/package.mask
@@ -1,5 +1,9 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
+
+# Sam James <sam@gentoo.org> (2024-03-23)
+# sys-libs/libomp does not support ppc32 (bug #907213).
+sys-libs/libomp
 
 # Sam James <sam@gentoo.org> (2023-05-06)
 # Broken bundled Eigen, fails to compile. See bug #865191.

--- a/profiles/arch/powerpc/ppc32/package.use.mask
+++ b/profiles/arch/powerpc/ppc32/package.use.mask
@@ -1,6 +1,10 @@
 # Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Sam James <sam@gentoo.org> (2024-03-23)
+# sys-libs/libomp does not support ppc32 (bug #907213).
+sys-devel/clang-runtime openmp
+
 # Matt Jolly <kangie@gentoo.org> (2024-03-02)
 # Fails tests, potential false negatives #911402
 app-antivirus/clamav system-mspack

--- a/sys-libs/libomp/libomp-15.0.7-r6.ebuild
+++ b/sys-libs/libomp/libomp-15.0.7-r6.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -11,7 +11,7 @@ HOMEPAGE="https://openmp.llvm.org"
 
 LICENSE="Apache-2.0-with-LLVM-exceptions || ( UoI-NCSA MIT )"
 SLOT="0/${LLVM_SOABI}"
-KEYWORDS="amd64 arm arm64 ppc ppc64 ~riscv x86 ~amd64-linux ~x64-macos"
+KEYWORDS="amd64 arm arm64 ppc64 ~riscv x86 ~amd64-linux ~x64-macos"
 IUSE="
 	debug hwloc offload ompt test
 	llvm_targets_AMDGPU llvm_targets_NVPTX

--- a/sys-libs/libomp/libomp-16.0.6.ebuild
+++ b/sys-libs/libomp/libomp-16.0.6.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -12,7 +12,7 @@ HOMEPAGE="https://openmp.llvm.org"
 
 LICENSE="Apache-2.0-with-LLVM-exceptions || ( UoI-NCSA MIT )"
 SLOT="0/${LLVM_SOABI}"
-KEYWORDS="amd64 arm arm64 ~loong ppc ppc64 ~riscv x86 ~amd64-linux ~x64-macos"
+KEYWORDS="amd64 arm arm64 ~loong ppc64 ~riscv x86 ~amd64-linux ~x64-macos"
 IUSE="
 	debug gdb-plugin hwloc offload ompt test
 	llvm_targets_AMDGPU llvm_targets_NVPTX

--- a/sys-libs/libomp/libomp-17.0.6.ebuild
+++ b/sys-libs/libomp/libomp-17.0.6.ebuild
@@ -12,7 +12,7 @@ HOMEPAGE="https://openmp.llvm.org"
 
 LICENSE="Apache-2.0-with-LLVM-exceptions || ( UoI-NCSA MIT )"
 SLOT="0/${LLVM_SOABI}"
-KEYWORDS="amd64 arm arm64 ~loong ppc ppc64 ~riscv x86 ~amd64-linux ~x64-macos"
+KEYWORDS="amd64 arm arm64 ~loong ppc64 ~riscv x86 ~amd64-linux ~x64-macos"
 IUSE="
 	debug gdb-plugin hwloc offload ompt test
 	llvm_targets_AMDGPU llvm_targets_NVPTX

--- a/sys-libs/libomp/libomp-18.1.2.ebuild
+++ b/sys-libs/libomp/libomp-18.1.2.ebuild
@@ -12,7 +12,7 @@ HOMEPAGE="https://openmp.llvm.org"
 
 LICENSE="Apache-2.0-with-LLVM-exceptions || ( UoI-NCSA MIT )"
 SLOT="0/${LLVM_SOABI}"
-KEYWORDS="~amd64 ~arm ~arm64 ~loong ~ppc ~ppc64 ~riscv ~x86 ~amd64-linux ~x64-macos"
+KEYWORDS="~amd64 ~arm ~arm64 ~loong ~ppc64 ~riscv ~x86 ~amd64-linux ~x64-macos"
 IUSE="
 	debug gdb-plugin hwloc offload ompt test
 	llvm_targets_AMDGPU llvm_targets_NVPTX


### PR DESCRIPTION
It never worked.

Bug: https://bugs.gentoo.org/600148
Bug: https://bugs.gentoo.org/708344
Closes: https://bugs.gentoo.org/907213