### PR TITLE
dev-build/make: fix doc BDEPEND to use texi2dvi

### DIFF
--- a/dev-build/make/make-4.4.1-r1.ebuild
+++ b/dev-build/make/make-4.4.1-r1.ebuild
@@ -31,7 +31,7 @@ RDEPEND="
 	nls? ( virtual/libintl )
 "
 BDEPEND="
-	doc? ( sys-apps/texinfo )
+	doc? ( virtual/texi2dvi )
 	nls? ( sys-devel/gettext )
 	verify-sig? ( sec-keys/openpgp-keys-make )
 	test? ( dev-lang/perl )

--- a/dev-build/make/make-9999.ebuild
+++ b/dev-build/make/make-9999.ebuild
@@ -31,7 +31,7 @@ RDEPEND="
 	nls? ( virtual/libintl )
 "
 BDEPEND="
-	doc? ( sys-apps/texinfo )
+	doc? ( virtual/texi2dvi )
 	nls? ( sys-devel/gettext )
 	verify-sig? ( sec-keys/openpgp-keys-make )
 	test? ( dev-lang/perl )


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/927628

My bad