### PR TITLE
media-sound/audacity-3.4.2: fix build with USE="-lv2"

### DIFF
--- a/media-sound/audacity/audacity-3.4.2.ebuild
+++ b/media-sound/audacity/audacity-3.4.2.ebuild
@@ -128,6 +128,9 @@ PATCHES=(
 
 	# #920363
 	"${FILESDIR}/audacity-3.4.2-audiocom-std-string.patch"
+
+	# Fix build with USE="-lv2"
+	"${FILESDIR}/audacity-3.4.2-fix-build-with-use-lv2-off.patch"
 )
 
 src_prepare() {

--- a/media-sound/audacity/files/audacity-3.4.2-fix-build-with-use-lv2-off.patch
+++ b/media-sound/audacity/files/audacity-3.4.2-fix-build-with-use-lv2-off.patch
@@ -1,0 +1,36 @@
+From e10034c19ed1911b730637fbc722030eb3dfd04b Mon Sep 17 00:00:00 2001
+From: Chris Mayo <aklhfex@gmail.com>
+Date: Wed, 22 Nov 2023 19:29:05 +0000
+Subject: [PATCH] Fix build with -Daudacity_use_lv2=off
+
+libraries/lib-lv2/LV2Utils.h:18:10: fatal error: lilv/lilv.h: No such file or directory
+   18 | #include "lilv/lilv.h" // for lilv_free
+      |          ^~~~~~~~~~~~~
+compilation terminated.
+---
+ libraries/CMakeLists.txt | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/libraries/CMakeLists.txt b/libraries/CMakeLists.txt
+index b1ebefa1b023..879cd948791d 100644
+--- a/libraries/CMakeLists.txt
++++ b/libraries/CMakeLists.txt
+@@ -50,7 +50,6 @@ set( LIBRARIES
+    lib-vst3
+    lib-snapping
+    lib-vst
+-   lib-lv2
+    lib-ladspa
+    lib-audio-unit
+    lib-playable-track
+@@ -63,6 +62,10 @@ set( LIBRARIES
+    lib-viewport
+ )
+ 
++if ( ${_OPT}use_lv2 )
++   list( APPEND LIBRARIES lib-lv2)
++endif()
++
+ if ( ${_OPT}has_networking )
+    list( APPEND LIBRARIES lib-network-manager)
+ endif()


### PR DESCRIPTION
_Hello everyone,_

Due to a bug in the upstream, **Audacity** `3.4.2` can't be built with `USE="-lv2"`.
Thanks to @cjmayo, there is [a fix](https://github.com/audacity/audacity/pull/5669) available [in the upstream](https://github.com/audacity/audacity/commit/e10034c19ed1911b730637fbc722030eb3dfd04b).

Closes: https://bugs.gentoo.org/928380

_Best regards!_