### PR TITLE
app-cdr/cdrtools: Remove dependency x11-misc/makedepend

### DIFF
--- a/app-cdr/cdrtools/cdrtools-3.02_alpha09-r3.ebuild
+++ b/app-cdr/cdrtools/cdrtools-3.02_alpha09-r3.ebuild
@@ -18,7 +18,6 @@ IUSE="acl caps nls unicode selinux"
 
 BDEPEND="
 	nls? ( >=sys-devel/gettext-0.18.1.1 )
-	x11-misc/makedepend
 "
 RDEPEND="
 	acl? ( virtual/acl )

--- a/app-cdr/cdrtools/cdrtools-3.02_alpha09-r5.ebuild
+++ b/app-cdr/cdrtools/cdrtools-3.02_alpha09-r5.ebuild
@@ -18,7 +18,6 @@ IUSE="acl caps nls unicode selinux"
 
 BDEPEND="
 	nls? ( >=sys-devel/gettext-0.18.1.1 )
-	x11-misc/makedepend
 "
 RDEPEND="
 	acl? ( virtual/acl )


### PR DESCRIPTION
Remove x11-misc/makedepend as build does not seem to require it. 