### PR TITLE
gui-apps/swappy: Remove dependency on x11-base/xorg-proto

### DIFF
--- a/gui-apps/swappy/swappy-1.5.1.ebuild
+++ b/gui-apps/swappy/swappy-1.5.1.ebuild
@@ -29,9 +29,8 @@ COMMON_DEPEND="
 RDEPEND="${COMMON_DEPEND}
 	media-fonts/fontawesome[otf]
 "
-DEPEND="${COMMON_DEPEND}
-	x11-base/xorg-proto
-"
+DEPEND="${COMMON_DEPEND}"
+
 BDEPEND="
 	app-text/scdoc
 	sys-devel/gettext


### PR DESCRIPTION
Remove uneeded dependency on x11-base/xorg-proto. 