### PR TITLE
media-sound/audacity: add missing depend media-libs/opusfile

### DIFF
--- a/media-sound/audacity/audacity-3.4.2.ebuild
+++ b/media-sound/audacity/audacity-3.4.2.ebuild
@@ -70,6 +70,7 @@ RDEPEND="dev-db/sqlite:3
 	media-libs/libpng:=
 	media-libs/libsndfile
 	media-libs/libsoundtouch:=
+	media-libs/opusfile
 	media-libs/portaudio[alsa?]
 	media-libs/portmidi
 	media-libs/portsmf:=


### PR DESCRIPTION
- media-libs/opusfile is a must-have dependency. Even if you disable the opus use flag, the build still fails without it.

Closes: https://bugs.gentoo.org/927659