### PR TITLE
app-editors/helix: Fix the build with clang

### DIFF
--- a/app-editors/helix/files/helix-23.10-update-rescript-grammar.patch
+++ b/app-editors/helix/files/helix-23.10-update-rescript-grammar.patch
@@ -1,0 +1,26 @@
+From 466b87c8e5c3a2f360794b005d8b6122aa6e648d Mon Sep 17 00:00:00 2001
+From: Nan Zhong <me@nanzho.ng>
+Date: Sun, 3 Dec 2023 19:46:00 -0500
+Subject: [PATCH] languages: update rescript grammar (#8962)
+
+This bump fixes a build failure of the grammer with clang.
+---
+ languages.toml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/languages.toml b/languages.toml
+index 10ed167b..f4ff483b 100644
+--- a/languages.toml
++++ b/languages.toml
+@@ -1523,7 +1523,7 @@ indent = { tab-width = 2, unit = "  " }
+ 
+ [[grammar]]
+ name = "rescript"
+-source = { git = "https://github.com/jaredramirez/tree-sitter-rescript", rev = "65609807c628477f3b94052e7ef895885ac51c3c" }
++source = { git = "https://github.com/jaredramirez/tree-sitter-rescript", rev = "467dcf99f68c47823d7b378779a6b282d7ef9782" }
+ 
+ [[language]]
+ name = "erlang"
+-- 
+2.43.2
+

--- a/app-editors/helix/files/helix-23.10-update-tree-sitter-d.patch
+++ b/app-editors/helix/files/helix-23.10-update-tree-sitter-d.patch
@@ -1,0 +1,27 @@
+From c2591445c90ae9c152cbc974122b77632de78e85 Mon Sep 17 00:00:00 2001
+From: Michal Rostecki <vadorovsky@protonmail.com>
+Date: Wed, 13 Dec 2023 01:37:03 +0000
+Subject: [PATCH] chore: Update tree-sitter-d (#9021)
+
+One of the included changes is gdamore/tree-sitter-d#22 which
+fixes the build of Helix when using clang as `CC`.
+---
+ languages.toml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/languages.toml b/languages.toml
+index 66b43472..7f1c6b76 100644
+--- a/languages.toml
++++ b/languages.toml
+@@ -2220,7 +2220,7 @@ formatter = { command = "dfmt" }
+ 
+ [[grammar]]
+ name = "d"
+-source = { git = "https://github.com/gdamore/tree-sitter-d", rev="601c4a1e8310fb2f3c43fa8a923d0d27497f3c04" }
++source = { git = "https://github.com/gdamore/tree-sitter-d", rev = "5566f8ce8fc24186fad06170bbb3c8d97c935d74" }
+ 
+ [[language]]
+ name = "vhs"
+-- 
+2.43.2
+

--- a/app-editors/helix/helix-23.10-r2.ebuild
+++ b/app-editors/helix/helix-23.10-r2.ebuild
@@ -296,6 +296,8 @@ DOCS=(
 
 PATCHES=(
 	"${FILESDIR}/helix-23.10-tree-sitter-gemini-path.patch"
+	"${FILESDIR}/helix-23.10-update-rescript-grammar.patch"
+	"${FILESDIR}/helix-23.10-update-tree-sitter-d.patch"
 )
 
 src_compile() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/918941
Closes: https://bugs.gentoo.org/912050