### PR TITLE
🐛 media-sound/audacity: fix various issues

### DIFF
--- a/media-sound/audacity/audacity-2.4.2-r4.ebuild
+++ b/media-sound/audacity/audacity-2.4.2-r4.ebuild
@@ -17,7 +17,7 @@ S="${WORKDIR}/${PN}-${MY_P}"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 ~arm64 ppc ppc64 ~riscv x86"
+KEYWORDS="~amd64 ~arm64 ~ppc ~ppc64 ~riscv ~x86"
 IUSE="alsa doc ffmpeg +flac id3tag jack +ladspa +lv2 mad ogg oss
 	portmidi +portmixer portsmf sbsms twolame vamp +vorbis +vst"
 
@@ -31,7 +31,7 @@ RDEPEND="dev-libs/expat
 	>=media-sound/lame-3.100-r3
 	x11-libs/wxGTK:${WX_GTK_VER}[X]
 	alsa? ( media-libs/alsa-lib )
-	ffmpeg? ( media-video/ffmpeg:= )
+	ffmpeg? ( <media-video/ffmpeg-5:= )
 	flac? ( media-libs/flac:=[cxx] )
 	id3tag? ( media-libs/libid3tag:= )
 	jack? ( virtual/jack )
@@ -51,11 +51,12 @@ RDEPEND="dev-libs/expat
 	vamp? ( media-libs/vamp-plugin-sdk )
 	vorbis? ( media-libs/libvorbis )
 "
-DEPEND="${RDEPEND}"
+DEPEND="${RDEPEND}
+	x11-base/xorg-proto"
 BDEPEND="app-arch/unzip
+	|| ( dev-lang/nasm dev-lang/yasm )
 	sys-devel/gettext
-	virtual/pkgconfig
-"
+	virtual/pkgconfig"
 
 REQUIRED_USE="portmidi? ( portsmf )"
 
@@ -64,8 +65,10 @@ PATCHES=(
 	"${FILESDIR}/${P}-fix-vertical-track-resizing.patch"
 	"${FILESDIR}/${P}-fix-gettimeofday.patch"
 	"${FILESDIR}/${P}-fix-metainfo.patch"
+	"${FILESDIR}/${P}-add-missing-include-limits.patch"
 	"${FILESDIR}/${P}-add-missing-include-portaudio.patch"
 	"${FILESDIR}/${P}-disable-ccache.patch"
+	"${FILESDIR}/${P}-fix-libflac-undefined-references.patch"
 )
 
 src_prepare() {

--- a/media-sound/audacity/audacity-3.4.2-r1.ebuild
+++ b/media-sound/audacity/audacity-3.4.2-r1.ebuild
@@ -36,8 +36,12 @@ LICENSE="GPL-2+
 	audiocom? ( ZLIB )
 "
 SLOT="0"
-IUSE="alsa audiocom ffmpeg +flac id3tag +ladspa +lv2 mpg123 ogg
+IUSE="alsa audiocom ffmpeg +flac id3tag +ladspa +lv2 mpg123 +ogg
 	opus +portmixer sbsms test twolame vamp +vorbis wavpack"
+REQUIRED_USE="
+	opus? ( ogg )
+	vorbis? ( ogg )
+"
 RESTRICT="!test? ( test )"
 
 # dev-db/sqlite:3 hard dependency.
@@ -65,7 +69,6 @@ RESTRICT="!test? ( test )"
 RDEPEND="dev-db/sqlite:3
 	dev-libs/expat
 	dev-libs/glib:2
-	dev-libs/rapidjson:=
 	media-libs/libjpeg-turbo:=
 	media-libs/libpng:=
 	media-libs/libsndfile
@@ -95,9 +98,12 @@ RDEPEND="dev-db/sqlite:3
 		media-libs/sratom
 		media-libs/suil
 	)
-	mpg123? ( media-sound/mpg123 )
+	mpg123? ( media-sound/mpg123-base )
 	ogg? ( media-libs/libogg )
-	opus? ( media-libs/opus )
+	opus? (
+		media-libs/opus
+		media-libs/opusfile
+	)
 	sbsms? ( media-libs/libsbsms )
 	twolame? ( media-sound/twolame )
 	vamp? ( media-libs/vamp-plugin-sdk )
@@ -105,11 +111,12 @@ RDEPEND="dev-db/sqlite:3
 	wavpack? ( media-sound/wavpack )
 "
 DEPEND="${RDEPEND}
+	dev-libs/rapidjson
+	x11-base/xorg-proto
 	test? ( <dev-cpp/catch-3:0 )"
-BDEPEND="
+BDEPEND="|| ( dev-lang/nasm dev-lang/yasm )
 	sys-devel/gettext
-	virtual/pkgconfig
-"
+	virtual/pkgconfig"
 
 PATCHES=(
 	# Equivalent to previous versions
@@ -188,12 +195,13 @@ src_configure() {
 		-Daudacity_use_libmp3lame=system
 		-Daudacity_use_libmpg123=$(usex mpg123 system off)
 		-Daudacity_use_libogg=$(usex ogg system off)
-		-Daudacity_use_libopus=$(usex flac system off)
+		-Daudacity_use_libopus=$(usex opus system off)
 		-Daudacity_use_libsndfile=system
 		-Daudacity_use_libvorbis=$(usex vorbis system off)
 		-Daudacity_use_lv2=$(usex lv2 system off)
 		-Daudacity_use_midi=system
 		-Daudacity_use_nyquist=local
+		-Daudacity_use_opusfile=$(usex opus system off)
 		-Daudacity_use_pch=off
 		-Daudacity_use_portaudio=system
 		-Daudacity_use_portmixer=$(usex portmixer system off)

--- a/media-sound/audacity/audacity-9999.ebuild
+++ b/media-sound/audacity/audacity-9999.ebuild
@@ -36,8 +36,12 @@ LICENSE="GPL-2+
 	audiocom? ( ZLIB )
 "
 SLOT="0"
-IUSE="alsa audiocom ffmpeg +flac id3tag +ladspa +lv2 mpg123 ogg
+IUSE="alsa audiocom ffmpeg +flac id3tag +ladspa +lv2 mpg123 +ogg
 	opus +portmixer sbsms test twolame vamp +vorbis wavpack"
+REQUIRED_USE="
+	opus? ( ogg )
+	vorbis? ( ogg )
+"
 RESTRICT="!test? ( test )"
 
 # dev-db/sqlite:3 hard dependency.
@@ -65,7 +69,6 @@ RESTRICT="!test? ( test )"
 RDEPEND="dev-db/sqlite:3
 	dev-libs/expat
 	dev-libs/glib:2
-	dev-libs/rapidjson:=
 	media-libs/libjpeg-turbo:=
 	media-libs/libpng:=
 	media-libs/libsndfile
@@ -95,9 +98,12 @@ RDEPEND="dev-db/sqlite:3
 		media-libs/sratom
 		media-libs/suil
 	)
-	mpg123? ( media-sound/mpg123 )
+	mpg123? ( media-sound/mpg123-base )
 	ogg? ( media-libs/libogg )
-	opus? ( media-libs/opus )
+	opus? (
+		media-libs/opus
+		media-libs/opusfile
+	)
 	sbsms? ( media-libs/libsbsms )
 	twolame? ( media-sound/twolame )
 	vamp? ( media-libs/vamp-plugin-sdk )
@@ -105,11 +111,12 @@ RDEPEND="dev-db/sqlite:3
 	wavpack? ( media-sound/wavpack )
 "
 DEPEND="${RDEPEND}
+	dev-libs/rapidjson
+	x11-base/xorg-proto
 	test? ( <dev-cpp/catch-3:0 )"
-BDEPEND="
+BDEPEND="|| ( dev-lang/nasm dev-lang/yasm )
 	sys-devel/gettext
-	virtual/pkgconfig
-"
+	virtual/pkgconfig"
 
 PATCHES=(
 	# Equivalent to previous versions
@@ -192,12 +199,13 @@ src_configure() {
 		-Daudacity_use_libmp3lame=system
 		-Daudacity_use_libmpg123=$(usex mpg123 system off)
 		-Daudacity_use_libogg=$(usex ogg system off)
-		-Daudacity_use_libopus=$(usex flac system off)
+		-Daudacity_use_libopus=$(usex opus system off)
 		-Daudacity_use_libsndfile=system
 		-Daudacity_use_libvorbis=$(usex vorbis system off)
 		-Daudacity_use_lv2=$(usex lv2 system off)
 		-Daudacity_use_midi=system
 		-Daudacity_use_nyquist=local
+		-Daudacity_use_opusfile=$(usex opus system off)
 		-Daudacity_use_pch=off
 		-Daudacity_use_portaudio=system
 		-Daudacity_use_portmixer=$(usex portmixer system off)

--- a/media-sound/audacity/files/audacity-2.4.2-add-missing-include-limits.patch
+++ b/media-sound/audacity/files/audacity-2.4.2-add-missing-include-limits.patch
@@ -1,0 +1,10 @@
+--- a/include/audacity/Types.h
++++ b/include/audacity/Types.h
+@@ -44,6 +44,7 @@
+ 
+ #include <algorithm>
+ #include <functional>
++#include <limits>
+ #include <type_traits>
+ #include <vector>
+ #include <wx/debug.h> // for wxASSERT

--- a/media-sound/audacity/files/audacity-2.4.2-fix-libflac-undefined-references.patch
+++ b/media-sound/audacity/files/audacity-2.4.2-fix-libflac-undefined-references.patch
@@ -1,0 +1,61 @@
+From be29286502be6c41b76e652b02862fe987c1f49b Mon Sep 17 00:00:00 2001
+From: Matthew White <mehw.is.me@inventati.org>
+Date: Sun, 14 Apr 2024 04:03:34 +0000
+Subject: [PATCH] libflac: fix undefined references when libflac is disabled
+
+In the upstream master branch:
+ - future commit 2fbfd3e0a5ab803e2072cbac1b2be685c3adcf05 disabled
+   ondemand (aka OD) in CMakeLists.txt.
+ - future commit cbf1bb558e094e24cbb54c3bbd2bd45a1abbfb2a expunged
+   ondemand fully.
+
+Closes: https://bugs.gentoo.org/741969
+Closes: https://bugs.gentoo.org/884747
+---
+ src/CMakeLists.txt         | 6 ++++--
+ src/ProjectFileManager.cpp | 4 +++-
+ 2 files changed, 7 insertions(+), 3 deletions(-)
+
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 93dc50c82..b2c4496ab 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -702,8 +702,10 @@ list( APPEND SOURCES
+       ondemand/ODComputeSummaryTask.h
+       ondemand/ODDecodeFFmpegTask.cpp
+       ondemand/ODDecodeFFmpegTask.h
+-      ondemand/ODDecodeFlacTask.cpp
+-      ondemand/ODDecodeFlacTask.h
++      $<$<BOOL:${USE_LIBFLAC}>:
++         ondemand/ODDecodeFlacTask.cpp
++         ondemand/ODDecodeFlacTask.h
++      >
+       ondemand/ODDecodeTask.cpp
+       ondemand/ODDecodeTask.h
+       ondemand/ODManager.cpp
+diff --git a/src/ProjectFileManager.cpp b/src/ProjectFileManager.cpp
+index de5eeee98..106c52c31 100644
+--- a/src/ProjectFileManager.cpp
++++ b/src/ProjectFileManager.cpp
+@@ -51,7 +51,9 @@ Paul Licameli split from AudacityProject.cpp
+ #include "import/ImportMIDI.h"
+ #include "commands/CommandContext.h"
+ #include "ondemand/ODComputeSummaryTask.h"
++#ifdef USE_LIBFLAC
+ #include "ondemand/ODDecodeFlacTask.h"
++#endif
+ #include "ondemand/ODManager.h"
+ #include "ondemand/ODTask.h"
+ #include "toolbars/SelectionBar.h"
+@@ -276,7 +278,7 @@ void ProjectFileManager::EnqueueODTasks()
+          while((odFlags|createdODTasks) != createdODTasks)
+          {
+             std::unique_ptr<ODTask> newTask;
+-#ifdef EXPERIMENTAL_OD_FLAC
++#if defined(EXPERIMENTAL_OD_FLAC) && defined(USE_LIBFLAC)
+             if(!(createdODTasks&ODTask::eODFLAC) && (odFlags & ODTask::eODFLAC)) {
+                newTask = std::make_unique<ODDecodeFlacTask>();
+                createdODTasks = createdODTasks | ODTask::eODFLAC;
+-- 
+2.44.0
+

--- a/media-sound/audacity/metadata.xml
+++ b/media-sound/audacity/metadata.xml
@@ -21,8 +21,8 @@
     <flag name="audiocom">Enable integrated uploading to audio.com</flag>
     <flag name="id3tag">Enables ID3 tagging with id3tag library</flag>
     <flag name="lv2">Add support for Ladspa V2</flag>
-    <flag name="mpg123">Use <pkg>media-sound/mpg123</pkg> instead of
-      <pkg>media-libs/libmad</pkg> for decoding MPEG decoding</flag>
+    <flag name="mpg123">Use <pkg>media-sound/mpg123-base</pkg> instead of
+      <pkg>media-libs/libmad</pkg> for MPEG decoding</flag>
     <flag name="portmidi">Enable support for MIDI via <pkg>media-libs/portmidi</pkg></flag>
     <flag name="portmixer">Enable the internal portmixer feature</flag>
     <flag name="portsmf">Enable support for Portable Standard Midi File Library</flag>


### PR DESCRIPTION
_Hello everyone,_

The `flac` USE flag was mistakenly used instead of the `opus` USE flag for configuring.

Also, **Audacity** `3.4.2` [introduced](https://github.com/audacity/audacity/pull/5370) a brand new `USE_OPUSFILE` option which must be set properly.

These changes:
  - fix the `opus` USE flag
  - add proper `REQUIRED_USE`
  - replace `media-sound/mpg123` with `media-sound/mpg123-base`
  - move `dev-libs/rapidjson` from `RDEPEND` to `DEPEND`
  - fix missing `#include <limits>` for `2.4.2-r3`
  - limit `media-video/ffmpeg` to `<5` for `2.4.2-r3`
  - add `x11-base/xorg-proto` to `DEPEND`
  - add some ASM to `BDEPEND`
  - add `audacity-3.4.2-audiocom-std-string.patch` to `PATCHES` for `3.3.3-r1`
  - add `audacity-2.4.2-fix-libflac-undefined-references.patch` to `PATCHES` for `2.4.2-r4`
  - reset `KEYWORDS` for `2.4.2-r4` and `3.3.3-r1`

<details>
<summary>Closes:</summary>

- https://bugs.gentoo.org/741969
- https://bugs.gentoo.org/884747
- https://bugs.gentoo.org/910723
- https://bugs.gentoo.org/922595
- https://bugs.gentoo.org/927659

</details>

_Best regards!_