### PR TITLE
dev-db/sqlitebrowser: add patch to fix conflict that str macro brings in

### DIFF
--- a/dev-db/sqlitebrowser/files/sqlitebrowser-3.12.2-str-conflict-fix.patch
+++ b/dev-db/sqlitebrowser/files/sqlitebrowser-3.12.2-str-conflict-fix.patch
@@ -1,0 +1,13 @@
+--- a/src/version.h
++++ b/src/version.h
+@@ -4,8 +4,8 @@
+ #define MINOR_VERSION 12
+ #define PATCH_VERSION 2
+ 
+-#define str(s) #s
+-#define xstr(s) str(s)
++#define stringize(s) #s
++#define xstr(s) stringize(s)
+ #define APP_VERSION xstr(MAJOR_VERSION) "." xstr(MINOR_VERSION) "." xstr(PATCH_VERSION)
+ 
+ // If it is defined by the compiler, then it is a nightly build, and in the YYYYMMDD format.

--- a/dev-db/sqlitebrowser/sqlitebrowser-3.12.2-r2.ebuild
+++ b/dev-db/sqlitebrowser/sqlitebrowser-3.12.2-r2.ebuild
@@ -46,6 +46,10 @@ RDEPEND="
 	>=dev-qt/qtsvg-5.5:5
 "
 
+PATCHES=(
+	"${FILESDIR}/${P}-str-conflict-fix.patch"
+)
+
 src_prepare() {
 	cmake_src_prepare
 


### PR DESCRIPTION
sometimes expanding str() gives an error because it conflicts with str()
 method of, for example, std::ostringstream::str()

This patch is dedicated to fixing this circumstance