### PR TITLE
git-r3.eclass: Git LFS fixes, Ability to checkout ignored submodules

### DIFF
--- a/eclass/git-r3.eclass
+++ b/eclass/git-r3.eclass
@@ -813,13 +813,17 @@ git-r3_fetch() {
 
 		if [[ ${EGIT_LFS} ]]; then
 			# Fetch the LFS files from the current ref (if any)
-			local lfs_fetch_command=( git lfs fetch "${r}" )
+			local lfs_fetch_command=( git lfs fetch "${r}" "${remote_ref}" )
 
 			case "${EGIT_LFS_CLONE_TYPE}" in
 				shallow)
-					lfs_fetch_command+=(
-						--prune
-					)
+					if [[ -d ${GIT_DIR}/lfs/objects ]] && ! rmdir "${GIT_DIR}"/lfs/objects 2> /dev/null; then
+						# Only prune if the lfs directory is not empty.
+						# The prune command can take a very long time to resolve even if there are no lfs objects.
+						lfs_fetch_command+=(
+							--prune
+						)
+					fi
 					;;
 				single)
 					;;

--- a/eclass/git-r3.eclass
+++ b/eclass/git-r3.eclass
@@ -429,6 +429,7 @@ _git-r3_set_submodules() {
 
 		l=${l#submodule.}
 		local subname=${l%%.url=*}
+		local is_manually_specified=
 
 		# filter out on EGIT_SUBMODULES
 		if declare -p EGIT_SUBMODULES &>/dev/null; then
@@ -449,13 +450,14 @@ _git-r3_set_submodules() {
 				continue
 			else
 				einfo "Using submodule ${parent_path}${subname}"
+				is_manually_specified=1
 			fi
 		fi
 
 		# skip modules that have 'update = none', bug #487262.
 		local upd=$(echo "${data}" | git config -f /dev/fd/0 \
 			submodule."${subname}".update)
-		[[ ${upd} == none ]] && continue
+		[[ ${upd} == none && ! ${is_manually_specified} ]] && continue
 
 		# https://github.com/git/git/blob/master/refs.c#L31
 		# we are more restrictive than git itself but that should not


### PR DESCRIPTION
@mgorny While updating the blender ebuild to use the new LFS features, I noticed a few issues with my implementation.

The first commit is kinda simple and fixed some things I overlooked the first time around.

The second commit is only showing what I changed to get the `tests/data` submodule to checkout from the blender repo:
https://projects.blender.org/blender/blender/src/branch/main/.gitmodules

The current git eclass code is working as intended. But I noticed that sometimes you might want to checkout submodules that are "ignored" per default.

I tried to work around this at first in the blender ebuild itself, but it became very cumbersome. So I'm wondering if there could be some sort of eclass variable that could be set to skip the `none` check for specified sub modules. Perhaps if the submodule has been explicitly requested via `EGIT_SUBMODULES`, the `== none` check will be skipped?