### PR TITLE
media-gfx/prusaslicer:  fix build with opencascade-7.8.0, move definition of S, 2.7.2 re-enable tests

### DIFF
--- a/media-gfx/prusaslicer/files/prusaslicer-2.7.2-opencascade-7.8.0.patch
+++ b/media-gfx/prusaslicer/files/prusaslicer-2.7.2-opencascade-7.8.0.patch
@@ -1,0 +1,18 @@
+diff --git a/src/occt_wrapper/CMakeLists.txt b/src/occt_wrapper/CMakeLists.txt
+index d8dd8e1..d27055f 100644
+--- a/src/occt_wrapper/CMakeLists.txt
++++ b/src/occt_wrapper/CMakeLists.txt
+@@ -22,11 +22,8 @@ generate_export_header(OCCTWrapper)
+ find_package(OpenCASCADE REQUIRED)
+ 
+ set(OCCT_LIBS
+-    TKXDESTEP
+-    TKSTEP
+-    TKSTEP209
+-    TKSTEPAttr
+-    TKSTEPBase
++    TKDESTEP
++    TKDESTL
+     TKXCAF
+     TKXSBase
+     TKVCAF

--- a/media-gfx/prusaslicer/prusaslicer-2.6.1.ebuild
+++ b/media-gfx/prusaslicer/prusaslicer-2.6.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -59,6 +59,10 @@ PATCHES=(
 S="${WORKDIR}/${MY_PN}-version_${MY_PV}"
 
 src_prepare() {
+	if has_version ">=sci-libs/opencascade-7.8.0"; then
+		eapply "${FILESDIR}/prusaslicer-2.7.2-opencascade-7.8.0.patch"
+	fi
+
 	sed -i -e 's/PrusaSlicer-${SLIC3R_VERSION}+UNKNOWN/PrusaSlicer-${SLIC3R_VERSION}+Gentoo/g' version.inc || die
 
 	sed -i -e 's/find_package(OpenCASCADE 7.6.2 REQUIRED)/find_package(OpenCASCADE REQUIRED)/g' \

--- a/media-gfx/prusaslicer/prusaslicer-2.6.1.ebuild
+++ b/media-gfx/prusaslicer/prusaslicer-2.6.1.ebuild
@@ -13,6 +13,8 @@ DESCRIPTION="A mesh slicer to generate G-code for fused-filament-fabrication (3D
 HOMEPAGE="https://www.prusa3d.com/prusaslicer/"
 SRC_URI="https://github.com/prusa3d/PrusaSlicer/archive/refs/tags/version_${MY_PV}.tar.gz -> ${P}.tar.gz"
 
+S="${WORKDIR}/${MY_PN}-version_${MY_PV}"
+
 LICENSE="AGPL-3 Boost-1.0 GPL-2 LGPL-3 MIT"
 SLOT="0"
 KEYWORDS="amd64 ~arm64 ~x86"
@@ -55,8 +57,6 @@ PATCHES=(
 	"${FILESDIR}/${PN}-2.6.0-disable-noisy-asserts.patch"
 	"${FILESDIR}/${PN}-2.6.0-dont-force-link-to-wayland-and-x11.patch"
 )
-
-S="${WORKDIR}/${MY_PN}-version_${MY_PV}"
 
 src_prepare() {
 	if has_version ">=sci-libs/opencascade-7.8.0"; then

--- a/media-gfx/prusaslicer/prusaslicer-2.7.1.ebuild
+++ b/media-gfx/prusaslicer/prusaslicer-2.7.1.ebuild
@@ -13,6 +13,8 @@ DESCRIPTION="A mesh slicer to generate G-code for fused-filament-fabrication (3D
 HOMEPAGE="https://www.prusa3d.com/prusaslicer/"
 SRC_URI="https://github.com/prusa3d/PrusaSlicer/archive/refs/tags/version_${MY_PV}.tar.gz -> ${P}.tar.gz"
 
+S="${WORKDIR}/${MY_PN}-version_${MY_PV}"
+
 LICENSE="AGPL-3 Boost-1.0 GPL-2 LGPL-3 MIT"
 SLOT="0"
 KEYWORDS="amd64 ~arm64 ~x86"
@@ -55,8 +57,6 @@ PATCHES=(
 	"${FILESDIR}/${PN}-2.6.0-libexpat-double-definition-fix.patch"
 	"${FILESDIR}/${PN}-2.6.0-dont-force-link-to-wayland-and-x11.patch"
 )
-
-S="${WORKDIR}/${MY_PN}-version_${MY_PV}"
 
 src_prepare() {
 	if has_version ">=sci-libs/opencascade-7.8.0"; then

--- a/media-gfx/prusaslicer/prusaslicer-2.7.1.ebuild
+++ b/media-gfx/prusaslicer/prusaslicer-2.7.1.ebuild
@@ -59,6 +59,10 @@ PATCHES=(
 S="${WORKDIR}/${MY_PN}-version_${MY_PV}"
 
 src_prepare() {
+	if has_version ">=sci-libs/opencascade-7.8.0"; then
+		eapply "${FILESDIR}/prusaslicer-2.7.2-opencascade-7.8.0.patch"
+	fi
+
 	sed -i -e 's/PrusaSlicer-${SLIC3R_VERSION}+UNKNOWN/PrusaSlicer-${SLIC3R_VERSION}+Gentoo/g' version.inc || die
 
 	sed -i -e 's/find_package(OpenCASCADE 7.6.2 REQUIRED)/find_package(OpenCASCADE REQUIRED)/g' \

--- a/media-gfx/prusaslicer/prusaslicer-2.7.2.ebuild
+++ b/media-gfx/prusaslicer/prusaslicer-2.7.2.ebuild
@@ -59,6 +59,10 @@ PATCHES=(
 S="${WORKDIR}/${MY_PN}-version_${MY_PV}"
 
 src_prepare() {
+	if has_version ">=sci-libs/opencascade-7.8.0"; then
+		eapply "${FILESDIR}/prusaslicer-2.7.2-opencascade-7.8.0.patch"
+	fi
+
 	sed -i -e 's/PrusaSlicer-${SLIC3R_VERSION}+UNKNOWN/PrusaSlicer-${SLIC3R_VERSION}+Gentoo/g' version.inc || die
 
 	sed -i -e 's/find_package(OpenCASCADE 7.6.2 REQUIRED)/find_package(OpenCASCADE REQUIRED)/g' \

--- a/media-gfx/prusaslicer/prusaslicer-2.7.2.ebuild
+++ b/media-gfx/prusaslicer/prusaslicer-2.7.2.ebuild
@@ -20,7 +20,7 @@ SLOT="0"
 KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE="test"
 
-RESTRICT="test"
+RESTRICT="!test? ( test )"
 
 RDEPEND="
 	dev-cpp/eigen:3
@@ -89,4 +89,11 @@ src_configure() {
 	)
 
 	cmake_src_configure
+}
+
+src_test() {
+	CMAKE_SKIP_TESTS=(
+		"^libslic3r_tests$"
+	)
+	cmake_src_test
 }

--- a/media-gfx/prusaslicer/prusaslicer-2.7.2.ebuild
+++ b/media-gfx/prusaslicer/prusaslicer-2.7.2.ebuild
@@ -13,6 +13,8 @@ DESCRIPTION="A mesh slicer to generate G-code for fused-filament-fabrication (3D
 HOMEPAGE="https://www.prusa3d.com/prusaslicer/"
 SRC_URI="https://github.com/prusa3d/PrusaSlicer/archive/refs/tags/version_${MY_PV}.tar.gz -> ${P}.tar.gz"
 
+S="${WORKDIR}/${MY_PN}-version_${MY_PV}"
+
 LICENSE="AGPL-3 Boost-1.0 GPL-2 LGPL-3 MIT"
 SLOT="0"
 KEYWORDS="~amd64 ~arm64 ~x86"
@@ -55,8 +57,6 @@ PATCHES=(
 	"${FILESDIR}/${PN}-2.6.0-libexpat-double-definition-fix.patch"
 	"${FILESDIR}/${PN}-2.6.0-dont-force-link-to-wayland-and-x11.patch"
 )
-
-S="${WORKDIR}/${MY_PN}-version_${MY_PV}"
 
 src_prepare() {
 	if has_version ">=sci-libs/opencascade-7.8.0"; then


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/927774