### PR TITLE
x11-apps/xdm: Fix -Wincompatible-pointer-types warning from GCC 14 

### DIFF
--- a/x11-apps/xdm/files/xdm-1.1.15-gcc14.patch
+++ b/x11-apps/xdm/files/xdm-1.1.15-gcc14.patch
@@ -1,0 +1,28 @@
+https://gitlab.freedesktop.org/xorg/app/xdm/-/merge_requests/22
+From: Alan Coopersmith <alan.coopersmith@oracle.com>
+Date: Mon, 25 Mar 2024 13:06:28 -0700
+Subject: [PATCH] Define _CONST_X_STRING when including Xaw & Xt headers
+
+Fixes build when building against libXaw 1.0.16 since
+xorg/lib/libxaw@d0fcbd97 changed the definition of XawListChange
+in <X11/Xaw/List.h> from _Xconst char * to String *, where
+String is defined as const if _CONST_X_STRING is defined.
+
+This also clears up 105 of the 162 -Wdiscarded-qualifiers warnings.
+
+Closes: #16
+Fixes: bccb777 ("Fix -Wincompatible-pointer-types warning from gcc (issue #15)")
+Signed-off-by: Alan Coopersmith <alan.coopersmith@oracle.com>
+--- a/configure.ac
++++ b/configure.ac
+@@ -417,6 +417,7 @@ AC_SUBST(XDM_PIXMAPDIR)
+ # Packages used by multiple programs
+ 
+ PKG_CHECK_MODULES(XDM_TOOLKIT, xaw7)
++XDM_TOOLKIT_CFLAGS="$XDM_TOOLKIT_CFLAGS -D_CONST_X_STRING"
+ PKG_CHECK_MODULES(DMCP, xdmcp)
+ PKG_CHECK_MODULES(XLIB, x11)
+ PKG_CHECK_MODULES(AUTH, xau)
+-- 
+GitLab
+

--- a/x11-apps/xdm/xdm-1.1.15-r1.ebuild
+++ b/x11-apps/xdm/xdm-1.1.15-r1.ebuild
@@ -1,0 +1,84 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+XORG_TARBALL_SUFFIX="xz"
+XORG_EAUTORECONF=yes
+inherit xorg-3 pam systemd
+
+DEFAULTVT=vt7
+
+DESCRIPTION="X.Org xdm application"
+
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+IUSE="pam systemd truetype xinerama xpm"
+
+RDEPEND="
+	x11-apps/sessreg
+	x11-apps/xconsole
+	x11-apps/xinit
+	x11-apps/xrdb
+	x11-apps/xsm
+	x11-libs/libX11
+	x11-libs/libXau
+	x11-libs/libXaw
+	x11-libs/libXdmcp
+	x11-libs/libXext
+	x11-libs/libXmu
+	x11-libs/libXt
+	virtual/libcrypt:=
+	pam? ( sys-libs/pam )
+	systemd? ( >=sys-apps/systemd-209:= )
+	truetype? (
+		x11-libs/libXrender
+		x11-libs/libXft
+	)
+	xinerama? ( x11-libs/libXinerama )
+	xpm? ( x11-libs/libXpm )
+	elibc_glibc? ( dev-libs/libbsd )"
+DEPEND="${RDEPEND}
+	x11-base/xorg-proto"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-1.1.15-gcc14.patch"
+)
+
+src_prepare() {
+	sed -i -e 's:^Alias=.*$:Alias=display-manager.service:' \
+		xdm.service.in || die
+
+	# Disable XDM-AUTHORIZATION-1 (bug #445662).
+	# it causes issue with libreoffice and SDL games (bug #306223).
+	sed -i -e '/authorize/a DisplayManager*authName:	MIT-MAGIC-COOKIE-1' \
+			config/xdm-config.in || die
+
+	xorg-3_src_prepare
+}
+
+src_configure() {
+	local XORG_CONFIGURE_OPTIONS=(
+		--enable-ipv6
+		$(use_with pam)
+		$(use_with systemd systemd-daemon)
+		$(use_with truetype xft)
+		$(use_with xinerama)
+		$(use_enable xpm xpm-logos)
+		--with-systemdsystemunitdir="$(systemd_get_systemunitdir)"
+		--with-default-vt=${DEFAULTVT}
+		--with-xdmconfigdir=/etc/X11/xdm
+	)
+	xorg-3_src_configure
+}
+
+src_install() {
+	xorg-3_src_install
+
+	exeinto /usr/$(get_libdir)/X11/xdm
+	doexe "${FILESDIR}"/Xsession
+
+	use pam && pamd_mimic system-local-login xdm auth account session
+
+	# Keep /var/lib/xdm. This is where authfiles are stored. See #286350.
+	keepdir /var/lib/xdm
+}


### PR DESCRIPTION
Fixes build when building against libXaw 1.0.16 since
xorg/lib/libxaw@d0fcbd97 changed the definition of XawListChange
in <X11/Xaw/List.h> from _Xconst char * to String *, where
String is defined as const if _CONST_X_STRING is defined.

Closes: https://bugs.gentoo.org/927712
Signed-off-by: Brahmajit Das <brahmajit.xyz@gmail.com>
