### PR TITLE
app-editors/xmlcopyeditor: fix dependencies

### DIFF
--- a/app-editors/xmlcopyeditor/files/xmlcopyeditor-1.3.1.0-libxml2-2.12.patch
+++ b/app-editors/xmlcopyeditor/files/xmlcopyeditor-1.3.1.0-libxml2-2.12.patch
@@ -1,0 +1,20 @@
+--- a/src/wraplibxml.cpp
++++ b/src/wraplibxml.cpp
+@@ -706,7 +706,7 @@
+ 
+ wxString WrapLibxml::getLastError()
+ {
+-	xmlErrorPtr err = xmlGetLastError();
++	const xmlError *err = xmlGetLastError();
+ 
+ 	if ( !err )
+ 		return nonParserError;
+@@ -722,7 +722,7 @@
+ 
+ std::pair<int, int> WrapLibxml::getErrorPosition()
+ {
+-	xmlErrorPtr err = xmlGetLastError();
++	const xmlError *err = xmlGetLastError();
+ 	if ( !err )
+ 		return std::make_pair ( 1, 1 );
+ 

--- a/app-editors/xmlcopyeditor/xmlcopyeditor-1.3.1.0-r1.ebuild
+++ b/app-editors/xmlcopyeditor/xmlcopyeditor-1.3.1.0-r1.ebuild
@@ -1,0 +1,50 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+WX_GTK_VER="3.2-gtk3"
+inherit autotools wxwidgets xdg
+
+DESCRIPTION="XML Copy Editor is a fast, free, validating XML editor"
+HOMEPAGE="https://xml-copy-editor.sourceforge.io"
+SRC_URI="https://downloads.sourceforge.net/xml-copy-editor/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 -ppc ~x86 ~amd64-linux ~x86-linux"  # -ppc due SSE2 requirement
+IUSE="aqua nls"
+
+RDEPEND="
+	app-text/enchant:2
+	>=dev-libs/libxml2-2.12.5
+	dev-libs/libxslt
+	dev-libs/xerces-c[cpu_flags_x86_sse2,icu]
+	dev-libs/libpcre2
+	x11-libs/wxGTK:${WX_GTK_VER}[X]
+"
+DEPEND="${RDEPEND}
+	dev-libs/boost
+"
+BDEPEND="
+	dev-util/intltool
+	virtual/pkgconfig
+"
+
+PATCHES=( "${FILESDIR}"/${P}-libxml2-2.12.patch )
+
+src_prepare() {
+	default
+
+	# bug #440744
+	sed -i  -e 's/ -Wall -g -fexceptions//g' configure.ac || die
+	eautoreconf
+}
+
+src_configure() {
+	setup-wxwidgets unicode
+	econf \
+		--with-gtk=3.0 \
+		--with-wx-config="${WX_CONFIG}" \
+		$(use_enable nls)
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/923446

---

~~- app-text/enchant:2 installs enchant-2.pc~~
- libxml2-2.12 compatibility (Filed https://sourceforge.net/p/xml-copy-editor/bugs/239/)
- uses libpcre2


```diff
--- xmlcopyeditor-1.3.1.0.ebuild
+++ xmlcopyeditor-1.3.1.0-r1.ebuild
@@ -17,10 +17,10 @@
 
 RDEPEND="
 	app-text/enchant:2
-	dev-libs/libxml2
+	>=dev-libs/libxml2-2.12.5
 	dev-libs/libxslt
 	dev-libs/xerces-c[cpu_flags_x86_sse2,icu]
-	dev-libs/libpcre
+	dev-libs/libpcre2
 	x11-libs/wxGTK:${WX_GTK_VER}[X]
 "
 DEPEND="${RDEPEND}
@@ -30,6 +30,8 @@
 	dev-util/intltool
 	virtual/pkgconfig
 "
+
+PATCHES=( "${FILESDIR}"/${P}-libxml2-2.12.patch )
 
 src_prepare() {
 	default

```
