### PR TITLE
sys-devel/clang-common: add -Xarch_host to CET and stack-protector flags to fix GPU compilation

### DIFF
--- a/sys-devel/clang-common/clang-common-15.0.7-r8.ebuild
+++ b/sys-devel/clang-common/clang-common-15.0.7-r8.ebuild
@@ -3,16 +3,17 @@
 
 EAPI=8
 
-inherit bash-completion-r1 llvm.org multilib
+inherit bash-completion-r1 llvm.org
 
 DESCRIPTION="Common files shared between multiple slots of clang"
 HOMEPAGE="https://llvm.org/"
 
 LICENSE="Apache-2.0-with-LLVM-exceptions UoI-NCSA"
 SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~riscv ~sparc ~x86 ~amd64-linux ~ppc-macos ~x64-macos"
 IUSE="
-	default-compiler-rt default-libcxx default-lld
-	bootstrap-prefix cet hardened llvm-libunwind
+	default-compiler-rt default-libcxx default-lld llvm-libunwind
+	hardened stricter
 "
 
 PDEPEND="
@@ -62,73 +63,6 @@ pkg_pretend() {
 	fi
 }
 
-_doclang_cfg() {
-	local triple="${1}"
-
-	local tool
-	for tool in ${triple}-clang{,++}; do
-		newins - "${tool}.cfg" <<-EOF
-			# This configuration file is used by ${tool} driver.
-			@gentoo-common.cfg
-			@gentoo-common-ld.cfg
-		EOF
-	done
-
-	if use kernel_Darwin; then
-		cat >> "${ED}/etc/clang/${triple}-clang++.cfg" <<-EOF || die
-			-lc++abi
-		EOF
-	fi
-
-	newins - "${triple}-clang-cpp.cfg" <<-EOF
-		# This configuration file is used by the ${triple}-clang-cpp driver.
-		@gentoo-common.cfg
-	EOF
-
-	# Install symlinks for triples with other vendor strings since some
-	# programs insist on mangling the triple.
-	local vendor
-	for vendor in gentoo pc unknown; do
-		local vendor_triple="${triple%%-*}-${vendor}-${triple#*-*-}"
-		for tool in clang{,++,-cpp}; do
-			if [[ ! -f "${ED}/etc/clang/${vendor_triple}-${tool}.cfg" ]]; then
-				dosym "${triple}-${tool}.cfg" "/etc/clang/${vendor_triple}-${tool}.cfg"
-			fi
-		done
-	done
-}
-
-doclang_cfg() {
-	local triple="${1}"
-
-	_doclang_cfg ${triple}
-
-	# LLVM may have different arch names in some cases. For example in x86
-	# profiles the triple uses i686, but llvm will prefer i386 if invoked
-	# with "clang" on x86 or "clang -m32" on x86_64. The gentoo triple will
-	# be used if invoked through ${CHOST}-clang{,++,-cpp} though.
-	#
-	# To make sure the correct triples are installed,
-	# see Triple::getArchTypeName() in llvm/lib/TargetParser/Triple.cpp
-	# and compare with CHOST values in profiles.
-
-	local abi=${triple%%-*}
-	case ${abi} in
-		armv4l|armv4t|armv5tel|armv6j|armv7a)
-			_doclang_cfg ${triple/${abi}/arm}
-			;;
-		i686)
-			_doclang_cfg ${triple/${abi}/i386}
-			;;
-		sparc)
-			_doclang_cfg ${triple/${abi}/sparcel}
-			;;
-		sparc64)
-			_doclang_cfg ${triple/${abi}/sparcv9}
-			;;
-	esac
-}
-
 src_install() {
 	newbashcomp bash-autocomplete.sh clang
 
@@ -157,42 +91,16 @@ src_install() {
 		-include "${EPREFIX}/usr/include/gentoo/maybe-stddefs.h"
 	EOF
 
-	# clang-cpp does not like link args being passed to it when directly
-	# invoked, so use a separate configuration file.
-	newins - gentoo-common-ld.cfg <<-EOF
-		# This file contains flags common to clang and clang++
-		@gentoo-hardened-ld.cfg
-	EOF
-
 	# Baseline hardening (bug #851111)
+	# (-fstack-clash-protection is omitted because of a possible Clang bug,
+	# see bug #892537 and bug #865339.)
 	newins - gentoo-hardened.cfg <<-EOF
 		# Some of these options are added unconditionally, regardless of
 		# USE=hardened, for parity with sys-devel/gcc.
-		-Xarch_host -fstack-clash-protection
 		-Xarch_host -fstack-protector-strong
 		-fPIE
 		-include "${EPREFIX}/usr/include/gentoo/fortify.h"
 	EOF
-
-	if use amd64; then
-		cat >> "${ED}/etc/clang/gentoo-hardened.cfg" <<-EOF || die
-			-Xarch_host -fcf-protection=$(usex cet full none)
-		EOF
-	fi
-
-	if use kernel_Darwin; then
-		newins - gentoo-hardened-ld.cfg <<-EOF
-			# There was -Wl,-z,relro here, but it's not supported on Mac
-			# TODO: investigate whether -bind_at_load or -read_only_stubs will do the job
-		EOF
-	else
-		newins - gentoo-hardened-ld.cfg <<-EOF
-			# Some of these options are added unconditionally, regardless of
-			# USE=hardened, for parity with sys-devel/gcc.
-			-Wl,-z,relro
-			-Wl,-z,now
-		EOF
-	fi
 
 	dodir /usr/include/gentoo
 
@@ -219,24 +127,15 @@ src_install() {
 	#  define __GENTOO_HAS_FEATURE(x) 0
 	# endif
 	#
-	# if defined(__STDC_HOSTED__) && __STDC_HOSTED__ == 1
-	#  define __GENTOO_NOT_FREESTANDING 1
-	# else
-	#  define __GENTOO_NOT_FREESTANDING 0
-	# endif
-	#
-	# if defined(__OPTIMIZE__) && __OPTIMIZE__ > 0 && __GENTOO_NOT_FREESTANDING > 0
+	# if defined(__OPTIMIZE__) && __OPTIMIZE__ > 0
 	#  if !defined(__SANITIZE_ADDRESS__) && !__GENTOO_HAS_FEATURE(address_sanitizer) && !__GENTOO_HAS_FEATURE(memory_sanitizer)
 	#   define _FORTIFY_SOURCE ${fortify_level}
 	#  endif
 	# endif
 	# undef __GENTOO_HAS_FEATURE
-	# undef __GENTOO_NOT_FREESTANDING
 	#endif
 	EOF
 
-	# TODO: Maybe -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_FAST for
-	# non-hardened?
 	if use hardened ; then
 		cat >> "${ED}/etc/clang/gentoo-hardened.cfg" <<-EOF || die
 			# Options below are conditional on USE=hardened.
@@ -244,43 +143,33 @@ src_install() {
 
 			# Analogue to GLIBCXX_ASSERTIONS
 			# https://libcxx.llvm.org/UsingLibcxx.html#assertions-mode
-			# https://libcxx.llvm.org/Hardening.html#using-hardened-mode
-			-D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_EXTENSIVE
-		EOF
-
-		cat >> "${ED}/etc/clang/gentoo-hardened-ld.cfg" <<-EOF || die
-			# Options below are conditional on USE=hardened.
+			-D_LIBCPP_ENABLE_ASSERTIONS=1
 		EOF
 	fi
 
-	# We only install config files for supported ABIs because unprefixed tools
-	# might be used for crosscompilation where e.g. PIE may not be supported.
-	# See bug #912237 and bug #901247. Just ${CHOST} won't do due to bug #912685.
-	local abi
-	for abi in $(get_all_abis); do
-		local abi_chost=$(get_abi_CHOST "${abi}")
-		doclang_cfg "${abi_chost}"
-	done
+	if use stricter; then
+		newins - gentoo-stricter.cfg <<-EOF
+			# This file increases the strictness of older clang versions
+			# to match the newest upstream version.
 
-	if use kernel_Darwin; then
+			# clang-16 defaults
+			-Werror=implicit-function-declaration
+			-Werror=implicit-int
+			-Werror=incompatible-function-pointer-types
+		EOF
+
 		cat >> "${ED}/etc/clang/gentoo-common.cfg" <<-EOF || die
-			# Gentoo Prefix on Darwin
-			-Wl,-search_paths_first
-			-Wl,-rpath,${EPREFIX}/usr/lib
-			-L ${EPREFIX}/usr/lib
-			-isystem ${EPREFIX}/usr/include
-			-isysroot ${EPREFIX}/MacOSX.sdk
+			@gentoo-stricter.cfg
 		EOF
-		if use bootstrap-prefix ; then
-			# bootstrap-prefix is only set during stage2 of bootstrapping
-			# Prefix, where EPREFIX is set to EPREFIX/tmp.
-			# Here we need to point it at the future lib dir of the stage3's
-			# EPREFIX.
-			cat >> "${ED}/etc/clang/gentoo-common.cfg" <<-EOF || die
-				-Wl,-rpath,${EPREFIX}/../usr/lib
-			EOF
-		fi
 	fi
+
+	local tool
+	for tool in clang{,++,-cpp}; do
+		newins - "${tool}.cfg" <<-EOF
+			# This configuration file is used by ${tool} driver.
+			@gentoo-common.cfg
+		EOF
+	done
 }
 
 pkg_preinst() {

--- a/sys-devel/clang-common/clang-common-16.0.6-r3.ebuild
+++ b/sys-devel/clang-common/clang-common-16.0.6-r3.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit bash-completion-r1 llvm.org multilib
+inherit bash-completion-r1 llvm.org
 
 DESCRIPTION="Common files shared between multiple slots of clang"
 HOMEPAGE="https://llvm.org/"
@@ -13,7 +13,7 @@ SLOT="0"
 KEYWORDS="~amd64 ~arm ~arm64 ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86 ~amd64-linux ~arm64-macos ~ppc-macos ~x64-macos"
 IUSE="
 	default-compiler-rt default-libcxx default-lld
-	bootstrap-prefix cet hardened llvm-libunwind
+	bootstrap-prefix hardened llvm-libunwind
 "
 
 PDEPEND="
@@ -63,73 +63,6 @@ pkg_pretend() {
 	fi
 }
 
-_doclang_cfg() {
-	local triple="${1}"
-
-	local tool
-	for tool in ${triple}-clang{,++}; do
-		newins - "${tool}.cfg" <<-EOF
-			# This configuration file is used by ${tool} driver.
-			@gentoo-common.cfg
-			@gentoo-common-ld.cfg
-		EOF
-	done
-
-	if use kernel_Darwin; then
-		cat >> "${ED}/etc/clang/${triple}-clang++.cfg" <<-EOF || die
-			-lc++abi
-		EOF
-	fi
-
-	newins - "${triple}-clang-cpp.cfg" <<-EOF
-		# This configuration file is used by the ${triple}-clang-cpp driver.
-		@gentoo-common.cfg
-	EOF
-
-	# Install symlinks for triples with other vendor strings since some
-	# programs insist on mangling the triple.
-	local vendor
-	for vendor in gentoo pc unknown; do
-		local vendor_triple="${triple%%-*}-${vendor}-${triple#*-*-}"
-		for tool in clang{,++,-cpp}; do
-			if [[ ! -f "${ED}/etc/clang/${vendor_triple}-${tool}.cfg" ]]; then
-				dosym "${triple}-${tool}.cfg" "/etc/clang/${vendor_triple}-${tool}.cfg"
-			fi
-		done
-	done
-}
-
-doclang_cfg() {
-	local triple="${1}"
-
-	_doclang_cfg ${triple}
-
-	# LLVM may have different arch names in some cases. For example in x86
-	# profiles the triple uses i686, but llvm will prefer i386 if invoked
-	# with "clang" on x86 or "clang -m32" on x86_64. The gentoo triple will
-	# be used if invoked through ${CHOST}-clang{,++,-cpp} though.
-	#
-	# To make sure the correct triples are installed,
-	# see Triple::getArchTypeName() in llvm/lib/TargetParser/Triple.cpp
-	# and compare with CHOST values in profiles.
-
-	local abi=${triple%%-*}
-	case ${abi} in
-		armv4l|armv4t|armv5tel|armv6j|armv7a)
-			_doclang_cfg ${triple/${abi}/arm}
-			;;
-		i686)
-			_doclang_cfg ${triple/${abi}/i386}
-			;;
-		sparc)
-			_doclang_cfg ${triple/${abi}/sparcel}
-			;;
-		sparc64)
-			_doclang_cfg ${triple/${abi}/sparcv9}
-			;;
-	esac
-}
-
 src_install() {
 	newbashcomp bash-autocomplete.sh clang
 
@@ -158,42 +91,15 @@ src_install() {
 		-include "${EPREFIX}/usr/include/gentoo/maybe-stddefs.h"
 	EOF
 
-	# clang-cpp does not like link args being passed to it when directly
-	# invoked, so use a separate configuration file.
-	newins - gentoo-common-ld.cfg <<-EOF
-		# This file contains flags common to clang and clang++
-		@gentoo-hardened-ld.cfg
-	EOF
-
 	# Baseline hardening (bug #851111)
 	newins - gentoo-hardened.cfg <<-EOF
 		# Some of these options are added unconditionally, regardless of
 		# USE=hardened, for parity with sys-devel/gcc.
-		-fstack-clash-protection
-		-fstack-protector-strong
+		-Xarch_host -fstack-clash-protection
+		-Xarch_host -fstack-protector-strong
 		-fPIE
 		-include "${EPREFIX}/usr/include/gentoo/fortify.h"
 	EOF
-
-	if use amd64; then
-		cat >> "${ED}/etc/clang/gentoo-hardened.cfg" <<-EOF || die
-			-fcf-protection=$(usex cet full none)
-		EOF
-	fi
-
-	if use kernel_Darwin; then
-		newins - gentoo-hardened-ld.cfg <<-EOF
-			# There was -Wl,-z,relro here, but it's not supported on Mac
-			# TODO: investigate whether -bind_at_load or -read_only_stubs will do the job
-		EOF
-	else
-		newins - gentoo-hardened-ld.cfg <<-EOF
-			# Some of these options are added unconditionally, regardless of
-			# USE=hardened, for parity with sys-devel/gcc.
-			-Wl,-z,relro
-			-Wl,-z,now
-		EOF
-	fi
 
 	dodir /usr/include/gentoo
 
@@ -220,24 +126,15 @@ src_install() {
 	#  define __GENTOO_HAS_FEATURE(x) 0
 	# endif
 	#
-	# if defined(__STDC_HOSTED__) && __STDC_HOSTED__ == 1
-	#  define __GENTOO_NOT_FREESTANDING 1
-	# else
-	#  define __GENTOO_NOT_FREESTANDING 0
-	# endif
-	#
-	# if defined(__OPTIMIZE__) && __OPTIMIZE__ > 0 && __GENTOO_NOT_FREESTANDING > 0
+	# if defined(__OPTIMIZE__) && __OPTIMIZE__ > 0
 	#  if !defined(__SANITIZE_ADDRESS__) && !__GENTOO_HAS_FEATURE(address_sanitizer) && !__GENTOO_HAS_FEATURE(memory_sanitizer)
 	#   define _FORTIFY_SOURCE ${fortify_level}
 	#  endif
 	# endif
 	# undef __GENTOO_HAS_FEATURE
-	# undef __GENTOO_NOT_FREESTANDING
 	#endif
 	EOF
 
-	# TODO: Maybe -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_FAST for
-	# non-hardened?
 	if use hardened ; then
 		cat >> "${ED}/etc/clang/gentoo-hardened.cfg" <<-EOF || die
 			# Options below are conditional on USE=hardened.
@@ -245,22 +142,16 @@ src_install() {
 
 			# Analogue to GLIBCXX_ASSERTIONS
 			# https://libcxx.llvm.org/UsingLibcxx.html#assertions-mode
-			# https://libcxx.llvm.org/Hardening.html#using-hardened-mode
-			-D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_EXTENSIVE
-		EOF
-
-		cat >> "${ED}/etc/clang/gentoo-hardened-ld.cfg" <<-EOF || die
-			# Options below are conditional on USE=hardened.
+			-D_LIBCPP_ENABLE_ASSERTIONS=1
 		EOF
 	fi
 
-	# We only install config files for supported ABIs because unprefixed tools
-	# might be used for crosscompilation where e.g. PIE may not be supported.
-	# See bug #912237 and bug #901247. Just ${CHOST} won't do due to bug #912685.
-	local abi
-	for abi in $(get_all_abis); do
-		local abi_chost=$(get_abi_CHOST "${abi}")
-		doclang_cfg "${abi_chost}"
+	local tool
+	for tool in clang{,++,-cpp}; do
+		newins - "${tool}.cfg" <<-EOF
+			# This configuration file is used by ${tool} driver.
+			@gentoo-common.cfg
+		EOF
 	done
 
 	if use kernel_Darwin; then
@@ -281,6 +172,9 @@ src_install() {
 				-Wl,-rpath,${EPREFIX}/../usr/lib
 			EOF
 		fi
+		cat >> "${ED}/etc/clang/clang++.cfg" <<-EOF || die
+			-lc++abi
+		EOF
 	fi
 }
 

--- a/sys-devel/clang-common/clang-common-17.0.6-r3.ebuild
+++ b/sys-devel/clang-common/clang-common-17.0.6-r3.ebuild
@@ -10,6 +10,7 @@ HOMEPAGE="https://llvm.org/"
 
 LICENSE="Apache-2.0-with-LLVM-exceptions UoI-NCSA"
 SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86 ~amd64-linux ~arm64-macos ~ppc-macos ~x64-macos"
 IUSE="
 	default-compiler-rt default-libcxx default-lld
 	bootstrap-prefix cet hardened llvm-libunwind
@@ -235,8 +236,6 @@ src_install() {
 	#endif
 	EOF
 
-	# TODO: Maybe -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_FAST for
-	# non-hardened?
 	if use hardened ; then
 		cat >> "${ED}/etc/clang/gentoo-hardened.cfg" <<-EOF || die
 			# Options below are conditional on USE=hardened.
@@ -245,7 +244,7 @@ src_install() {
 			# Analogue to GLIBCXX_ASSERTIONS
 			# https://libcxx.llvm.org/UsingLibcxx.html#assertions-mode
 			# https://libcxx.llvm.org/Hardening.html#using-hardened-mode
-			-D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_EXTENSIVE
+			-D_LIBCPP_ENABLE_ASSERTIONS=1
 		EOF
 
 		cat >> "${ED}/etc/clang/gentoo-hardened-ld.cfg" <<-EOF || die

--- a/sys-devel/clang-common/clang-common-18.1.2-r2.ebuild
+++ b/sys-devel/clang-common/clang-common-18.1.2-r2.ebuild
@@ -169,15 +169,15 @@ src_install() {
 	newins - gentoo-hardened.cfg <<-EOF
 		# Some of these options are added unconditionally, regardless of
 		# USE=hardened, for parity with sys-devel/gcc.
-		-fstack-clash-protection
-		-fstack-protector-strong
+		-Xarch_host -fstack-clash-protection
+		-Xarch_host -fstack-protector-strong
 		-fPIE
 		-include "${EPREFIX}/usr/include/gentoo/fortify.h"
 	EOF
 
 	if use amd64; then
 		cat >> "${ED}/etc/clang/gentoo-hardened.cfg" <<-EOF || die
-			-fcf-protection=$(usex cet full none)
+			-Xarch_host -fcf-protection=$(usex cet full none)
 		EOF
 	fi
 
@@ -236,6 +236,8 @@ src_install() {
 	#endif
 	EOF
 
+	# TODO: Maybe -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_FAST for
+	# non-hardened?
 	if use hardened ; then
 		cat >> "${ED}/etc/clang/gentoo-hardened.cfg" <<-EOF || die
 			# Options below are conditional on USE=hardened.
@@ -244,7 +246,7 @@ src_install() {
 			# Analogue to GLIBCXX_ASSERTIONS
 			# https://libcxx.llvm.org/UsingLibcxx.html#assertions-mode
 			# https://libcxx.llvm.org/Hardening.html#using-hardened-mode
-			-D_LIBCPP_ENABLE_ASSERTIONS=1
+			-D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_EXTENSIVE
 		EOF
 
 		cat >> "${ED}/etc/clang/gentoo-hardened-ld.cfg" <<-EOF || die


### PR DESCRIPTION
Add `-Xarch_host` to CPU-specific flags, so that it does not affects heterogenous code (e. g. HIP).

For stack-protector flags: fixes compiler crashes like https://github.com/llvm/llvm-project/issues/83777. `>=sys-devel/clang-18.1.0` does not try to apply these flags to GPU code, but current ROCm libraries use Clang 17, so add `-Xarch_host` for 18.1.0 too. This will allow to drop `-fno-stack-protector` patches from rocm-comgr, hip and hipcc eventually.

For `-fcf-protection`: fixes error: option 'cf-protection=return' cannot be specified on this target.

For `-fPIE`: do not touch, as at least since Clang 15 it only affects host relocation model.
See also: https://github.com/llvm/llvm-project/blob/llvmorg-15.0.7/clang/test/Driver/hip-fpie-option.hip

Related upstream bug: https://github.com/llvm/llvm-project/issues/86450
Closes: https://bugs.gentoo.org/927752