### PR TITLE
sys-libs/slang: readd "fix the build with LLD 17" patch to 2.3.3-r1

### DIFF
--- a/sys-libs/slang/slang-2.3.3-r1.ebuild
+++ b/sys-libs/slang/slang-2.3.3-r1.ebuild
@@ -37,6 +37,7 @@ DEPEND="${RDEPEND}"
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-2.3.3-slsh-libs.patch
+	"${FILESDIR}"/${PN}-2.3.3-remove-undefined-symbol-from-version-script.patch
 )
 
 src_prepare() {


### PR DESCRIPTION
This patch was originally added in https://github.com/gentoo/gentoo/pull/35129, but for some reason was lost in r1

Closes: https://bugs.gentoo.org/927906