### PR TITLE
media-gfx/opencsg: drop dependency on Qt 5

### DIFF
--- a/media-gfx/opencsg/files/opencsg-1.6.0-cmake.patch
+++ b/media-gfx/opencsg/files/opencsg-1.6.0-cmake.patch
@@ -1,0 +1,61 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+new file mode 100644
+index 0000000..0ba23fe
+--- /dev/null
++++ b/CMakeLists.txt
+@@ -0,0 +1,12 @@
++cmake_minimum_required(VERSION 3.16)
++project(opencsg VERSION 1.6.0 LANGUAGES CXX)
++
++option(BUILD_EXAMPLE "Build example program" ON)
++option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
++
++include(GNUInstallDirs)
++
++add_subdirectory(src)
++if(BUILD_EXAMPLE)
++    add_subdirectory(example)
++endif()
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+new file mode 100644
+index 0000000..323a491
+--- /dev/null
++++ b/src/CMakeLists.txt
+@@ -0,0 +1,37 @@
++add_library(opencsg
++    area.cpp area.h
++    batch.cpp batch.h
++    channelManager.cpp channelManager.h
++    context.cpp context.h
++    frameBufferObject.cpp frameBufferObject.h
++    frameBufferObjectExt.cpp frameBufferObjectExt.h
++    glad/include/KHR/khrplatform.h
++    glad/include/glad/gl.h
++    glad/src/gl.cpp
++    occlusionQuery.cpp occlusionQuery.h
++    offscreenBuffer.h
++    opencsgConfig.h
++    opencsgRender.cpp opencsgRender.h
++    openglExt.h
++    openglHelper.cpp openglHelper.h
++    primitive.cpp
++    primitiveHelper.cpp primitiveHelper.h
++    renderGoldfeather.cpp
++    renderSCS.cpp
++    scissorMemo.cpp scissorMemo.h
++    settings.cpp settings.h
++)
++target_include_directories(opencsg PUBLIC
++    ${CMAKE_SOURCE_DIR}/include
++)
++
++set_target_properties(opencsg PROPERTIES
++    VERSION ${PROJECT_VERSION}
++    SOVERSION ${PROJECT_VERSION_MAJOR}
++    PUBLIC_HEADER ${CMAKE_SOURCE_DIR}/include/opencsg.h
++)
++
++install(TARGETS opencsg
++    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
++    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
++)

--- a/media-gfx/opencsg/opencsg-1.6.0-r1.ebuild
+++ b/media-gfx/opencsg/opencsg-1.6.0-r1.ebuild
@@ -1,0 +1,36 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit cmake
+
+MY_P="OpenCSG-${PV}"
+
+DESCRIPTION="The Constructive Solid Geometry rendering library"
+HOMEPAGE="https://www.opencsg.org"
+SRC_URI="https://www.opencsg.org/${MY_P}.tar.gz"
+S="${WORKDIR}/${MY_P}"
+
+LICENSE="GPL-2+"
+SLOT="0/1.6"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
+IUSE="doc"
+RESTRICT="test"
+
+DOCS=( build.txt changelog.txt )
+
+PATCHES=( "${FILESDIR}"/${PN}-1.6.0-cmake.patch )
+
+src_configure() {
+	local mycmakeargs=(
+		-DBUILD_EXAMPLE=OFF
+	)
+	cmake_src_configure
+}
+
+src_install() {
+	cmake_src_install
+	use doc && local HTML_DOCS=( doc/. )
+	einstalldocs
+}


### PR DESCRIPTION
and virtual/opengl.

```
$ lddtree /usr/lib64/libopencsg.so.1.6.0
libopencsg.so.1.6.0 => /usr/lib64/libopencsg.so.1.6.0 (interpreter => none)
    libstdc++.so.6 => /usr/lib/gcc/x86_64-pc-linux-gnu/13/libstdc++.so.6
        libm.so.6 => /usr/lib64/libm.so.6
        ld-linux-x86-64.so.2 => /usr/lib64/ld-linux-x86-64.so.2
    libgcc_s.so.1 => /usr/lib/gcc/x86_64-pc-linux-gnu/13/libgcc_s.so.1
    libc.so.6 => /usr/lib64/libc.so.6
```

Carrying a patch to replace the build system is a bit extreme (reported upstream last year) but Qt 5 is not necessary.

```diff
--- opencsg-1.6.0.ebuild
+++ opencsg-1.6.0-r1.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-inherit qmake-utils
+inherit cmake
 
 MY_P="OpenCSG-${PV}"
 
@@ -18,33 +18,19 @@
 IUSE="doc"
 RESTRICT="test"
 
-RDEPEND="
-	virtual/opengl
-"
-
-# qtgui is needed for opengles2 feature by
-# /usr/lib64/qt5/mkspecs/feature/unix/opengl.prf
-DEPEND="${RDEPEND}
-	dev-qt/qtcore:5
-	dev-qt/qtgui:5
-"
-
 DOCS=( build.txt changelog.txt )
 
-PATCHES=( "${FILESDIR}"/${PN}-1.6.0-includepath.patch )
+PATCHES=( "${FILESDIR}"/${PN}-1.6.0-cmake.patch )
 
 src_configure() {
-	eqmake5 opencsg.pro INSTALLDIR="${EPREFIX}/usr" LIBDIR="$(get_libdir)"
-}
-
-src_compile() {
-	# rebuild Makefiles in subdirs
-	emake INSTALLDIR="${EPREFIX}/usr" LIBDIR="$(get_libdir)" qmake_all
-	emake sub-src
+	local mycmakeargs=(
+		-DBUILD_EXAMPLE=OFF
+	)
+	cmake_src_configure
 }
 
 src_install() {
-	emake -C src INSTALL_ROOT="${ED}" install
+	cmake_src_install
 	use doc && local HTML_DOCS=( doc/. )
 	einstalldocs
 }
```

