### PR TITLE
Fix samba uintptr_t redefinition

### DIFF
--- a/net-fs/samba/files/cmocka-config_h.patch
+++ b/net-fs/samba/files/cmocka-config_h.patch
@@ -1,0 +1,23 @@
+--- ./third_party/cmocka/cmocka.h.orig	2024-03-26 10:23:03.378410042 +0100
++++ ./third_party/cmocka/cmocka.h	2024-03-26 10:24:51.526922405 +0100
+@@ -14,6 +14,11 @@
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
++
++#ifdef HAVE_CONFIG_H
++#include "config.h"
++#endif
++
+ #ifndef CMOCKA_H_
+ #define CMOCKA_H_
+ 
+@@ -111,7 +114,7 @@
+     ((LargestIntegralType)(value))
+ 
+ /* Smallest integral type capable of holding a pointer. */
+-#if !defined(_UINTPTR_T) && !defined(_UINTPTR_T_DEFINED)
++#if !defined(HAVE_UINTPTR_T) && !defined(_UINTPTR_T) && !defined(_UINTPTR_T_DEFINED) && !defined(__DEFINED_uintptr_t)
+ # if defined(_WIN32)
+     /* WIN32 is an ILP32 platform */
+     typedef unsigned int uintptr_t;

--- a/net-fs/samba/samba-4.18.10.ebuild
+++ b/net-fs/samba/samba-4.18.10.ebuild
@@ -146,6 +146,7 @@ BDEPEND="${PYTHON_DEPS}
 PATCHES=(
 	"${FILESDIR}"/${PN}-4.18.4-pam.patch
 	"${FILESDIR}"/ldb-2.5.2-skip-wav-tevent-check.patch
+	"${FILESDIR}"/cmocka-config_h.patch
 )
 
 CONFDIR="${FILESDIR}/4.4"

--- a/net-fs/samba/samba-4.18.8.ebuild
+++ b/net-fs/samba/samba-4.18.8.ebuild
@@ -146,6 +146,7 @@ BDEPEND="${PYTHON_DEPS}
 PATCHES=(
 	"${FILESDIR}"/${PN}-4.18.4-pam.patch
 	"${FILESDIR}"/ldb-2.5.2-skip-wav-tevent-check.patch
+	"${FILESDIR}"/cmocka-config_h.patch
 )
 
 CONFDIR="${FILESDIR}/4.4"

--- a/net-fs/samba/samba-4.18.9.ebuild
+++ b/net-fs/samba/samba-4.18.9.ebuild
@@ -146,6 +146,7 @@ BDEPEND="${PYTHON_DEPS}
 PATCHES=(
 	"${FILESDIR}"/${PN}-4.18.4-pam.patch
 	"${FILESDIR}"/ldb-2.5.2-skip-wav-tevent-check.patch
+	"${FILESDIR}"/cmocka-config_h.patch
 )
 
 CONFDIR="${FILESDIR}/4.4"

--- a/net-fs/samba/samba-4.19.4.ebuild
+++ b/net-fs/samba/samba-4.19.4.ebuild
@@ -146,6 +146,7 @@ BDEPEND="${PYTHON_DEPS}
 PATCHES=(
 	"${FILESDIR}"/${PN}-4.18.4-pam.patch
 	"${FILESDIR}"/ldb-2.5.2-skip-wav-tevent-check.patch
+	"${FILESDIR}"/cmocka-config_h.patch
 )
 
 CONFDIR="${FILESDIR}/4.4"

--- a/sys-libs/ldb/files/cmocka-config_h.patch
+++ b/sys-libs/ldb/files/cmocka-config_h.patch
@@ -1,0 +1,23 @@
+--- ./third_party/cmocka/cmocka.h.orig	2024-03-26 10:23:03.378410042 +0100
++++ ./third_party/cmocka/cmocka.h	2024-03-26 10:24:51.526922405 +0100
+@@ -14,6 +14,11 @@
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
++
++#ifdef HAVE_CONFIG_H
++#include "config.h"
++#endif
++
+ #ifndef CMOCKA_H_
+ #define CMOCKA_H_
+ 
+@@ -111,7 +114,7 @@
+     ((LargestIntegralType)(value))
+ 
+ /* Smallest integral type capable of holding a pointer. */
+-#if !defined(_UINTPTR_T) && !defined(_UINTPTR_T_DEFINED)
++#if !defined(HAVE_UINTPTR_T) && !defined(_UINTPTR_T) && !defined(_UINTPTR_T_DEFINED) && !defined(__DEFINED_uintptr_t)
+ # if defined(_WIN32)
+     /* WIN32 is an ILP32 platform */
+     typedef unsigned int uintptr_t;

--- a/sys-libs/ldb/ldb-2.6.2.ebuild
+++ b/sys-libs/ldb/ldb-2.6.2.ebuild
@@ -60,6 +60,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-1.1.31-fix_PKGCONFIGDIR-when-python-disabled.patch
 	"${FILESDIR}"/${PN}-2.4.2-skip-32bit-time_t-tests.patch
 	"${FILESDIR}"/${PN}-2.5.2-skip-waf-tevent-check.patch
+	"${FILESDIR}"/cmocka-config_h.patch
 )
 
 pkg_setup() {

--- a/sys-libs/ldb/ldb-2.7.2.ebuild
+++ b/sys-libs/ldb/ldb-2.7.2.ebuild
@@ -60,6 +60,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-1.1.31-fix_PKGCONFIGDIR-when-python-disabled.patch
 	"${FILESDIR}"/${PN}-2.4.2-skip-32bit-time_t-tests.patch
 	"${FILESDIR}"/${PN}-2.5.2-skip-waf-tevent-check.patch
+	"${FILESDIR}"/cmocka-config_h.patch
 )
 
 pkg_setup() {

--- a/sys-libs/ldb/ldb-2.8.0.ebuild
+++ b/sys-libs/ldb/ldb-2.8.0.ebuild
@@ -60,6 +60,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-1.1.31-fix_PKGCONFIGDIR-when-python-disabled.patch
 	"${FILESDIR}"/${PN}-2.4.2-skip-32bit-time_t-tests.patch
 	"${FILESDIR}"/${PN}-2.5.2-skip-waf-tevent-check.patch
+	"${FILESDIR}"/cmocka-config_h.patch
 )
 
 pkg_setup() {

--- a/sys-libs/tevent/files/cmocka-config_h.patch
+++ b/sys-libs/tevent/files/cmocka-config_h.patch
@@ -1,0 +1,23 @@
+--- ./third_party/cmocka/cmocka.h.orig	2024-03-26 10:23:03.378410042 +0100
++++ ./third_party/cmocka/cmocka.h	2024-03-26 10:24:51.526922405 +0100
+@@ -14,6 +14,11 @@
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
++
++#ifdef HAVE_CONFIG_H
++#include "config.h"
++#endif
++
+ #ifndef CMOCKA_H_
+ #define CMOCKA_H_
+ 
+@@ -111,7 +114,7 @@
+     ((LargestIntegralType)(value))
+ 
+ /* Smallest integral type capable of holding a pointer. */
+-#if !defined(_UINTPTR_T) && !defined(_UINTPTR_T_DEFINED)
++#if !defined(HAVE_UINTPTR_T) && !defined(_UINTPTR_T) && !defined(_UINTPTR_T_DEFINED) && !defined(__DEFINED_uintptr_t)
+ # if defined(_WIN32)
+     /* WIN32 is an ILP32 platform */
+     typedef unsigned int uintptr_t;

--- a/sys-libs/tevent/tevent-0.13.0.ebuild
+++ b/sys-libs/tevent/tevent-0.13.0.ebuild
@@ -42,6 +42,10 @@ BDEPEND="
 	virtual/pkgconfig
 "
 
+PATCHES=(
+	"${FILESDIR}"/cmocka-config_h.patch
+)
+
 WAF_BINARY="${S}/buildtools/bin/waf"
 
 pkg_setup() {

--- a/sys-libs/tevent/tevent-0.14.0.ebuild
+++ b/sys-libs/tevent/tevent-0.14.0.ebuild
@@ -42,6 +42,10 @@ BDEPEND="
 	virtual/pkgconfig
 "
 
+PATCHES=(
+	"${FILESDIR}"/cmocka-config_h.patch
+)
+
 WAF_BINARY="${S}/buildtools/bin/waf"
 
 check_samba_dep_versions() {

--- a/sys-libs/tevent/tevent-0.14.1.ebuild
+++ b/sys-libs/tevent/tevent-0.14.1.ebuild
@@ -41,6 +41,10 @@ BDEPEND="
 	virtual/pkgconfig
 "
 
+PATCHES=(
+	"${FILESDIR}"/cmocka-config_h.patch
+)
+
 WAF_BINARY="${S}/buildtools/bin/waf"
 
 check_samba_dep_versions() {

--- a/sys-libs/tevent/tevent-0.15.0.ebuild
+++ b/sys-libs/tevent/tevent-0.15.0.ebuild
@@ -41,6 +41,10 @@ BDEPEND="
 	virtual/pkgconfig
 "
 
+PATCHES=(
+	"${FILESDIR}"/cmocka-config_h.patch
+)
+
 WAF_BINARY="${S}/buildtools/bin/waf"
 
 check_samba_dep_versions() {


### PR DESCRIPTION
When building samba and its libraries (ldb, tevent) on a musl system the builds fail due to an incompatible redefinition of `uintptr_t` in its bundled cmocka library.

Including `config.h` and using the macros defined in it fixes the build.

Tested on: powerpc64-linux-musl and aarch64-linux-gnu.