### PR TITLE
dev-java/jakarta-xml-soap-api: drop SecurityManager

### DIFF
--- a/dev-java/jakarta-xml-soap-api/files/jakarta-xml-soap-api-1.4.2-dropSecurityManager.patch
+++ b/dev-java/jakarta-xml-soap-api/files/jakarta-xml-soap-api-1.4.2-dropSecurityManager.patch
@@ -1,0 +1,11 @@
+bug #923606
+--- a/api/src/test/java/javax/xml/soap/test/SAAJFactoryTest.java
++++ b/api/src/test/java/javax/xml/soap/test/SAAJFactoryTest.java
+@@ -167,7 +167,6 @@ public class SAAJFactoryTest {
+     private void enableSM() {
+         System.setSecurityManager(null);
+         System.setProperty("java.security.policy", classesDir + "javax/xml/soap/test.policy");
+-        System.setSecurityManager(new SecurityManager());
+     }
+ 
+     protected MessageFactory factory() throws Throwable {

--- a/dev-java/jakarta-xml-soap-api/jakarta-xml-soap-api-1.4.2-r1.ebuild
+++ b/dev-java/jakarta-xml-soap-api/jakarta-xml-soap-api-1.4.2-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2022-2023 Gentoo Authors
+# Copyright 2022-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -12,6 +12,7 @@ inherit java-pkg-2 java-pkg-simple
 DESCRIPTION="SOAP with Attachments API for Java (SAAJ) API (Eclipse Project for JAX-WS)"
 HOMEPAGE="https://projects.eclipse.org/projects/ee4j.jaxws"
 SRC_URI="https://github.com/jakartaee/saaj-api/archive/${PV}.tar.gz -> ${P}.tar.gz"
+S="${WORKDIR}/saaj-api-${PV}"
 
 # EDL-1.0 equivalent to BSD
 # - 'SPDX-License-Identifier: BSD-3-Clause' in source files' headers
@@ -35,7 +36,9 @@ RDEPEND="
 	${CP_DEPEND}
 "
 
-S="${WORKDIR}/saaj-api-${PV}"
+PATCHES=(
+	"${FILESDIR}/jakarta-xml-soap-api-1.4.2-dropSecurityManager.patch"
+)
 
 JAVA_SRC_DIR="api/src/main/java"
 
@@ -46,7 +49,7 @@ JAVA_TEST_EXTRA_ARGS=( -Xbootclasspath/a:target/classes )
 
 DOCS=( CONTRIBUTING.md NOTICE.md README.md )
 
-src_install() {
-	java-pkg-simple_src_install
-	einstalldocs # https://bugs.gentoo.org/789582
+src_prepare() {
+	default #780585
+	java-pkg-2_src_prepare
 }


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/923606