### PR TITLE
media-libs/libggi: Fix incompatible function pointer types

### DIFF
--- a/media-libs/libggi/files/libggi-2.2.2-incompatible-types.patch
+++ b/media-libs/libggi/files/libggi-2.2.2-incompatible-types.patch
@@ -1,0 +1,11 @@
+--- a/display/X/helper/dga/dga.c	2024-03-27 20:58:09.954061371 +0400
++++ b/display/X/helper/dga/dga.c	2024-03-27 20:58:26.408971886 +0400
+@@ -261,7 +261,7 @@
+ 
+ /* This function performs the CheckMode operation and returns
+  * the number of the best mode.  */
+-static int ggi_xdga_validate_mode(ggi_visual * vis, int num,
++static int ggi_xdga_validate_mode(ggi_visual * vis, long int num,
+ 				  ggi_mode * mode)
+ {
+ 	ggi_x_priv *priv;

--- a/media-libs/libggi/libggi-2.2.2-r2.ebuild
+++ b/media-libs/libggi/libggi-2.2.2-r2.ebuild
@@ -29,6 +29,7 @@ DOCS=( ChangeLog ChangeLog.1999 FAQ NEWS README )
 
 PATCHES=(
 	"${FILESDIR}/${P}-slibtool.patch" # 775584
+	"${FILESDIR}/${P}-incompatible-types.patch" # 880931
 )
 
 src_prepare() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/880931