### PR TITLE
net-wireless/sigutils-0.3.0: fixes missing build dependency

### DIFF
--- a/net-wireless/sigutils/sigutils-0.3.0.ebuild
+++ b/net-wireless/sigutils/sigutils-0.3.0.ebuild
@@ -17,6 +17,7 @@ IUSE=""
 DEPEND="
 	sci-libs/fftw:3.0=
 	sci-libs/volk:=
+	media-libs/libsndfile:=
 "
 RDEPEND="${DEPEND}"
 BDEPEND=""

--- a/www-misc/htdig/htdig-3.2.0_beta6-r5.ebuild
+++ b/www-misc/htdig/htdig-3.2.0_beta6-r5.ebuild
@@ -8,8 +8,8 @@ inherit autotools flag-o-matic
 MY_PV="${PV/_beta/b}"
 
 DESCRIPTION="HTTP/HTML indexing and searching system"
-HOMEPAGE="http://www.htdig.org"
-SRC_URI="http://www.htdig.org/files/${PN}-${MY_PV}.tar.gz"
+HOMEPAGE="https://htdig.sourceforge.net/"
+SRC_URI="mirror://sourceforge/${PN}/${P}-${MY_PV}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/911808