### PR TITLE
net-print/npadmin: fix configure error on Clang/GCC-14

### DIFF
--- a/net-print/npadmin/files/npadmin-0.8.7-makefile.patch
+++ b/net-print/npadmin/files/npadmin-0.8.7-makefile.patch
@@ -1,0 +1,43 @@
+--- a/Makefile.in	2024-03-28 13:35:04.247099098 +0000
++++ b/Makefile.in	2024-03-28 13:33:44.610623716 +0000
+@@ -104,7 +104,7 @@
+ NROFF = nroff
+ DIST_COMMON =  README ./stamp-h.in AUTHORS COPYING ChangeLog INSTALL \
+ Makefile.am Makefile.in NEWS TODO acconfig.h aclocal.m4 config.h.in \
+-configure configure.in install-sh memcmp.c missing mkinstalldirs \
++configure configure.ac install-sh memcmp.c missing mkinstalldirs \
+ npadmin.spec.in snprintf.c
+ 
+ 
+@@ -118,19 +118,19 @@
+ all: all-redirect
+ .SUFFIXES:
+ .SUFFIXES: .C .S .c .o .s
+-$(srcdir)/Makefile.in: Makefile.am $(top_srcdir)/configure.in $(ACLOCAL_M4) 
++$(srcdir)/Makefile.in: Makefile.am $(top_srcdir)/configure.ac $(ACLOCAL_M4) 
+ 	cd $(top_srcdir) && $(AUTOMAKE) --gnu --include-deps Makefile
+ 
+ Makefile: $(srcdir)/Makefile.in  $(top_builddir)/config.status
+ 	cd $(top_builddir) \
+ 	  && CONFIG_FILES=$@ CONFIG_HEADERS= $(SHELL) ./config.status
+ 
+-$(ACLOCAL_M4):  configure.in 
++$(ACLOCAL_M4):  configure.ac
+ 	cd $(srcdir) && $(ACLOCAL)
+ 
+ config.status: $(srcdir)/configure $(CONFIG_STATUS_DEPENDENCIES)
+ 	$(SHELL) ./config.status --recheck
+-$(srcdir)/configure: $(srcdir)/configure.in $(ACLOCAL_M4) $(CONFIGURE_DEPENDENCIES)
++$(srcdir)/configure: $(srcdir)/configure.ac $(ACLOCAL_M4) $(CONFIGURE_DEPENDENCIES)
+ 	cd $(srcdir) && $(AUTOCONF)
+ 
+ config.h: stamp-h
+@@ -148,7 +148,7 @@
+ 		rm -f $(srcdir)/stamp-h.in; \
+ 		$(MAKE) $(srcdir)/stamp-h.in; \
+ 	else :; fi
+-$(srcdir)/stamp-h.in: $(top_srcdir)/configure.in $(ACLOCAL_M4) acconfig.h
++$(srcdir)/stamp-h.in: $(top_srcdir)/configure.ac $(ACLOCAL_M4) acconfig.h
+ 	cd $(top_srcdir) && $(AUTOHEADER)
+ 	@echo timestamp > $(srcdir)/stamp-h.in 2> /dev/null
+ 

--- a/net-print/npadmin/npadmin-0.8.7-r2.ebuild
+++ b/net-print/npadmin/npadmin-0.8.7-r2.ebuild
@@ -1,7 +1,8 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
+inherit autotools
 
 DESCRIPTION="Network printer command-line adminstration tool"
 SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
@@ -18,7 +19,13 @@ SLOT="0"
 PATCHES=(
 	"${FILESDIR}"/${P}-stdlib.patch
 	"${FILESDIR}"/${P}-gcc6.patch
+	"${FILESDIR}"/${P}-makefile.patch
 )
+
+src_prepare() {
+	default
+	eautoconf
+}
 
 src_install() {
 	dobin npadmin


### PR DESCRIPTION
Bundled configure used bad compiler check script. Running autoreconf fixed that problem.
Makefile.in contained old name of configure.in, fixed that in patch EAPI bump and revbump included as now npadmin may pull new compile flags

Closes: https://bugs.gentoo.org/875749