### PR TITLE
dev-libs/fddl: disambiguate variable name from std::array

### DIFF
--- a/dev-libs/fddl/fddl-20111124-r2.ebuild
+++ b/dev-libs/fddl/fddl-20111124-r2.ebuild
@@ -1,0 +1,40 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit cmake vcs-snapshot
+
+DESCRIPTION="Free Decision Diagram Library"
+HOMEPAGE="http://itval.sourceforge.net/ https://github.com/atomopawn/FDDL"
+SRC_URI="https://dev.gentoo.org/~pinkbyte/distfiles/snapshots/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+DOCS=( AUTHORS ChangeLog INSTALL RELEASE )
+
+PATCHES=( "${FILESDIR}/${P}-disambiguate-variable-name.patch" )
+
+src_prepare() {
+	cmake_src_prepare
+
+	# Remove references to files that were not shipped,
+	# prefer dynamic linking
+	sed -i \
+		-e 's|unaryoperation.cpp||g' \
+		-e 's|unaryoperation.h||g' \
+		-e 's|binaryoperation.cpp||g' \
+		-e 's|binaryoperation.h||g' \
+		-e '/add_library/s/FDDL /FDDL SHARED /' \
+		-e '/add_library/s/FDDL /FDDL SHARED /' \
+		-e "/^install/s:DESTINATION lib:DESTINATION $(get_libdir):" \
+		src/CMakeLists.txt || die
+	# Do not build tests that depend on above files
+	sed -i   \
+		{,tests/}CMakeLists.txt \
+		-e '/test_unaryop/d' \
+		-e '/test_binaryop/d' \
+		|| die
+}

--- a/dev-libs/fddl/files/fddl-20111124-disambiguate-variable-name.patch
+++ b/dev-libs/fddl/files/fddl-20111124-disambiguate-variable-name.patch
@@ -1,0 +1,65 @@
+Disambiguate variable name from std::array.
+
+FAILED: tests/CMakeFiles/test_dynarray.dir/test_dynarray.cpp.o
+/usr/bin/x86_64-pc-linux-gnu-g++    -O2 -pipe -march=x86-64 -mtune=generic -MD -MT tests/CMakeFiles/test_dynarray.dir/test_dynarray.cpp.o -MF tests/CMakeFiles/test_dynarray.dir/test_dynarray.cpp.o.d -o tests/CMakeFiles/test_dynarray.dir/test_dynarray.cpp.o -c /var/tmp/portage/dev-libs/fddl-20111124-r1/work/fddl-20111124/tests/test_dynarray.cpp
+/var/tmp/portage/dev-libs/fddl-20111124-r1/work/fddl-20111124/tests/test_dynarray.cpp: In function ‘bool test_access()’:
+/var/tmp/portage/dev-libs/fddl-20111124-r1/work/fddl-20111124/tests/test_dynarray.cpp:9:11: error: reference to ‘array’ is ambiguous
+    9 |         *(array[0])=50;
+      |           ^~~~~
+In file included from /usr/lib/gcc/x86_64-pc-linux-gnu/13/include/g++-v13/bits/memory_resource.h:47,
+                 from /usr/lib/gcc/x86_64-pc-linux-gnu/13/include/g++-v13/string:58,
+                 from /usr/lib/gcc/x86_64-pc-linux-gnu/13/include/g++-v13/bits/locale_classes.h:40,
+                 from /usr/lib/gcc/x86_64-pc-linux-gnu/13/include/g++-v13/bits/ios_base.h:41,
+                 from /usr/lib/gcc/x86_64-pc-linux-gnu/13/include/g++-v13/ios:44,
+                 from /usr/lib/gcc/x86_64-pc-linux-gnu/13/include/g++-v13/ostream:40,
+                 from /usr/lib/gcc/x86_64-pc-linux-gnu/13/include/g++-v13/iostream:41,
+                 from /var/tmp/portage/dev-libs/fddl-20111124-r1/work/fddl-20111124/tests/test_dynarray.cpp:1:
+/usr/lib/gcc/x86_64-pc-linux-gnu/13/include/g++-v13/tuple:2005:45: note: candidates are: ‘template<class _Tp, long unsigned int _Nm> struct std::array’
+ 2005 |   template<typename _Tp, size_t _Nm> struct array;
+      |                                             ^~~~~
+/var/tmp/portage/dev-libs/fddl-20111124-r1/work/fddl-20111124/tests/test_dynarray.cpp:6:15: note:                 ‘DynArray<int> array’
+    6 | DynArray<int> array;
+      |               ^~~~~
+
+diff -Nuar a/tests/test_dynarray.cpp b/tests/test_dynarray.cpp
+--- a/tests/test_dynarray.cpp	2024-03-28 14:52:14.811666764 +0000
++++ b/tests/test_dynarray.cpp	2024-03-28 14:51:55.379667423 +0000
+@@ -3,18 +3,18 @@
+ 
+ using namespace std;
+ 
+-DynArray<int> array;
++DynArray<int> test_array;
+ 
+ bool test_access(){
+-	*(array[0])=50;
+-	if (*(array[0]) != 50)
++	*(test_array[0])=50;
++	if (*(test_array[0]) != 50)
+ 		return false;
+ 	return true;
+ }
+ 
+ bool test_extend(){
+-	*(array[1024]) = 9999;
+-	if (*(array[1024]) != 9999)
++	*(test_array[1024]) = 9999;
++	if (*(test_array[1024]) != 9999)
+ 		return false;
+ 	return true;
+ }
+@@ -23,12 +23,12 @@
+ 	unsigned int fac = 1;
+ 	for (unsigned int i=1;i<11;i++){
+ 		fac = fac * i;
+-		*(array[fac]) = i;
++		*(test_array[fac]) = i;
+ 	}
+ 	fac = 1;
+ 	for (unsigned int i=1; i<11;i++){
+ 		fac = fac * i;
+-		if (*(array[fac]) != i){
++		if (*(test_array[fac]) != i){
+ 			return false;
+ 		}
+ 	}


### PR DESCRIPTION
Hello,

This is a trivial fix to disambiguate a variable named `array` from `std::array` in the file `test/test_dynarray.cpp`, letting `dev-libs/fddl` to compile fine.

Thanks.

```
$ diff fddl-20111124-r1.ebuild fddl-20111124-r2.ebuild 
1c1
< # Copyright 1999-2021 Gentoo Authors
---
> # Copyright 1999-2024 Gentoo Authors
14c14
< KEYWORDS="amd64 x86"
---
> KEYWORDS="~amd64 ~x86"
16a17,18
> 
> PATCHES=( "${FILESDIR}/${P}-disambiguate-variable-name.patch" )
```