### PR TITLE
net-firewall/itval: fix compiling and installation of ITVal binary

### DIFF
--- a/net-firewall/itval/files/itval-1.2_p20121104-fix-strstr-comparison.patch
+++ b/net-firewall/itval/files/itval-1.2_p20121104-fix-strstr-comparison.patch
@@ -1,0 +1,34 @@
+Fix comparison with strstr() result.
+
+FAILED: CMakeFiles/ITVal.dir/src/chains.cc.o
+/usr/bin/x86_64-pc-linux-gnu-g++  -I/var/tmp/portage/net-firewall/itval-1.2_p20121104-r1/work/ITVal-20121104 -I/var/tmp/portage/net-firewall/itval-1.2_p20121104-r1/work/ITVal-20121104/ITVal  -O2 -pipe -march=x86-64 -mtune=generic -MD -MT CMakeFiles/ITVal.dir/src/chains.cc.o -MF CMakeFiles/ITVal.dir/src/chains.cc.o.d -o CMakeFiles/ITVal.dir/src/chains.cc.o -c /var/tmp/portage/net-firewall/itval-1.2_p20121104-r1/work/ITVal-20121104/src/chains.cc
+/var/tmp/portage/net-firewall/itval-1.2_p20121104-r1/work/ITVal-20121104/src/chains.cc: In member function ‘void Firewall::BuildFWRules(char*)’:
+/var/tmp/portage/net-firewall/itval-1.2_p20121104-r1/work/ITVal-20121104/src/chains.cc:129:46: error: ordered comparison of pointer with integer zero (‘char*’ and ‘int’)
+  129 |    if (line == NULL || strstr(line, "Chain") < 0) {
+      |                        ~~~~~~~~~~~~~~~~~~~~~~^~~
+/var/tmp/portage/net-firewall/itval-1.2_p20121104-r1/work/ITVal-20121104/src/chains.cc: In member function ‘void Firewall::BuildVerboseFWRules(char*)’:
+/var/tmp/portage/net-firewall/itval-1.2_p20121104-r1/work/ITVal-20121104/src/chains.cc:348:46: error: ordered comparison of pointer with integer zero (‘char*’ and ‘int’)
+  348 |    if (line == NULL || strstr(line, "Chain") < 0) {
+      |                        ~~~~~~~~~~~~~~~~~~~~~~^~~
+
+diff -Nuar a/src/chains.cc b/src/chains.cc
+--- a/src/chains.cc	2024-03-28 15:30:35.835588726 +0000
++++ b/src/chains.cc	2024-03-28 15:30:28.507588974 +0000
+@@ -126,7 +126,7 @@
+    length = getline(&line, &bufsize, ruleFile);
+    lineNo++;
+    oldLine = line;
+-   if (line == NULL || strstr(line, "Chain") < 0) {
++   if (line == NULL || strstr(line, "Chain") == NULL) {
+       cout << "File <" << fname << ">" << "is not a valid rule file." << endl;
+       exit(-1);
+    }
+@@ -345,7 +345,7 @@
+    length = getline(&line, &bufsize, ruleFile);
+    lineNo++;
+    oldLine = line;
+-   if (line == NULL || strstr(line, "Chain") < 0) {
++   if (line == NULL || strstr(line, "Chain") == NULL) {
+       cout << "File <" << fname << "> is not a valid rule file." << endl;
+       exit(-1);
+    }

--- a/net-firewall/itval/itval-1.2_p20121104-r2.ebuild
+++ b/net-firewall/itval/itval-1.2_p20121104-r2.ebuild
@@ -1,0 +1,36 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+CMAKE_IN_SOURCE_BUILD=1
+inherit cmake
+
+MY_PN="ITVal"
+MY_PV="$(ver_cut 4)"
+MY_P="${MY_PN}-${MY_PV}"
+
+DESCRIPTION="Iptables policy testing and validation tool"
+HOMEPAGE="http://itval.sourceforge.net"
+SRC_URI="https://dev.gentoo.org/~pinkbyte/distfiles/snapshots/${MY_P}.tar.bz2"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+RDEPEND="
+	dev-libs/fddl
+"
+DEPEND="
+	${RDEPEND}
+	app-alternatives/yacc
+	app-alternatives/lex
+"
+S=${WORKDIR}/${MY_P}
+DOCS=( AUTHORS ChangeLog README RELEASE )
+
+PATCHES=( "${FILESDIR}/${P}-fix-strstr-comparison.patch" )
+
+src_install() {
+	cmake_src_install
+	doman man/ITVal.n
+}


### PR DESCRIPTION
Hello,

This is a trivial fix to address compiling and the installation of the `ITVal` binary.

The result of `strstr()` (`src/chains.cc`) requires a comparison to `NULL`, rather than to an integer, since the function returns a pointer.

Thanks.

```
$ diff itval-1.2_p20121104-r1.ebuild itval-1.2_p20121104-r2.ebuild 
18c18
< KEYWORDS="amd64 x86"
---
> KEYWORDS="~amd64 ~x86"
30a31,32
> PATCHES=( "${FILESDIR}/${P}-fix-strstr-comparison.patch" )
> 
32c34
<       default
---
>       cmake_src_install
```