### PR TITLE
x11-libs/wxGTK-3.0.5.1: remove auto_ptr

### DIFF
--- a/x11-libs/wxGTK/files/wxGTK-3.0.5.1-excise-autoptr.patch
+++ b/x11-libs/wxGTK/files/wxGTK-3.0.5.1-excise-autoptr.patch
@@ -1,0 +1,322 @@
+Direct replacement of auto_ptr, equivalent to parts of upstream commits:
+https://github.com/wxWidgets/wxWidgets/commit/b8c9cd35288a5c94f88ea83bf8c9ee644f99ece1
+https://github.com/wxWidgets/wxWidgets/commit/11a5728b327d5f16ef284d737f6329d38ae4d4b1
+made by diffing new-er upstream version with fixes included and current file
+diff --git a/tests/archive/archivetest.cpp b/tests/archive/archivetest.cpp
+index fa122d1..845ee0b 100644
+--- a/tests/archive/archivetest.cpp
++++ b/tests/archive/archivetest.cpp
+@@ -32,7 +32,6 @@
+ #include <sys/stat.h>
+ 
+ using std::string;
+-using std::auto_ptr;
+ 
+ 
+ // Check whether member templates can be used
+@@ -559,7 +558,7 @@ TestEntry& ArchiveTestCase<ClassFactoryT>::Add(const char *name,
+ template <class ClassFactoryT>
+ void ArchiveTestCase<ClassFactoryT>::CreateArchive(wxOutputStream& out)
+ {
+-    auto_ptr<OutputStreamT> arc(m_factory->NewStream(out));
++    wxScopedPtr<OutputStreamT> arc(m_factory->NewStream(out));
+     TestEntries::iterator it;
+ 
+     OnCreateArchive(*arc);
+@@ -587,7 +586,7 @@ void ArchiveTestCase<ClassFactoryT>::CreateArchive(wxOutputStream& out)
+ 
+         if ((choices & 2) || testEntry.IsText()) {
+             // try PutNextEntry(EntryT *pEntry)
+-            auto_ptr<EntryT> entry(m_factory->NewEntry());
++            wxScopedPtr<EntryT> entry(m_factory->NewEntry());
+             entry->SetName(name, wxPATH_UNIX);
+             if (setIsDir)
+                 entry->SetIsDir();
+@@ -701,8 +700,8 @@ template <class ClassFactoryT>
+ void ArchiveTestCase<ClassFactoryT>::ModifyArchive(wxInputStream& in,
+                                                    wxOutputStream& out)
+ {
+-    auto_ptr<InputStreamT> arcIn(m_factory->NewStream(in));
+-    auto_ptr<OutputStreamT> arcOut(m_factory->NewStream(out));
++    wxScopedPtr<InputStreamT> arcIn(m_factory->NewStream(in));
++    wxScopedPtr<OutputStreamT> arcOut(m_factory->NewStream(out));
+     EntryT *pEntry;
+ 
+     const wxString deleteName = wxT("bin/bin1000");
+@@ -714,7 +713,7 @@ void ArchiveTestCase<ClassFactoryT>::ModifyArchive(wxInputStream& in,
+     arcOut->CopyArchiveMetaData(*arcIn);
+ 
+     while ((pEntry = arcIn->GetNextEntry()) != NULL) {
+-        auto_ptr<EntryT> entry(pEntry);
++        wxScopedPtr<EntryT> entry(pEntry);
+         OnSetNotifier(*entry);
+         wxString name = entry->GetName(wxPATH_UNIX);
+ 
+@@ -759,7 +758,7 @@ void ArchiveTestCase<ClassFactoryT>::ModifyArchive(wxInputStream& in,
+ 
+     // try adding a new entry
+     TestEntry& testEntry = Add(newName.mb_str(), newData);
+-    auto_ptr<EntryT> newentry(m_factory->NewEntry());
++    wxScopedPtr<EntryT> newentry(m_factory->NewEntry());
+     newentry->SetName(newName);
+     newentry->SetDateTime(testEntry.GetDateTime());
+     newentry->SetSize(testEntry.GetLength());
+@@ -782,7 +781,7 @@ void ArchiveTestCase<ClassFactoryT>::ExtractArchive(wxInputStream& in)
+     typedef std::list<EntryPtr> Entries;
+     typedef typename Entries::iterator EntryIter;
+ 
+-    auto_ptr<InputStreamT> arc(m_factory->NewStream(in));
++    wxScopedPtr<InputStreamT> arc(m_factory->NewStream(in));
+     int expectedTotal = m_testEntries.size();
+     EntryPtr entry;
+     Entries entries;
+@@ -991,7 +990,7 @@ void ArchiveTestCase<ClassFactoryT>::TestIterator(wxInputStream& in)
+     typedef std::list<EntryT*> ArchiveCatalog;
+     typedef typename ArchiveCatalog::iterator CatalogIter;
+ 
+-    auto_ptr<InputStreamT> arc(m_factory->NewStream(in));
++    wxScopedPtr<InputStreamT> arc(m_factory->NewStream(in));
+     size_t count = 0;
+ 
+ #ifdef WXARC_MEMBER_TEMPLATES
+@@ -1003,7 +1002,7 @@ void ArchiveTestCase<ClassFactoryT>::TestIterator(wxInputStream& in)
+ #endif
+ 
+     for (CatalogIter it = cat.begin(); it != cat.end(); ++it) {
+-        auto_ptr<EntryT> entry(*it);
++        wxScopedPtr<EntryT> entry(*it);
+         count += m_testEntries.count(entry->GetName(wxPATH_UNIX));
+     }
+ 
+@@ -1020,7 +1019,7 @@ void ArchiveTestCase<ClassFactoryT>::TestPairIterator(wxInputStream& in)
+     typedef std::map<wxString, EntryT*> ArchiveCatalog;
+     typedef typename ArchiveCatalog::iterator CatalogIter;
+ 
+-    auto_ptr<InputStreamT> arc(m_factory->NewStream(in));
++    wxScopedPtr<InputStreamT> arc(m_factory->NewStream(in));
+     size_t count = 0;
+ 
+ #ifdef WXARC_MEMBER_TEMPLATES
+@@ -1032,7 +1031,7 @@ void ArchiveTestCase<ClassFactoryT>::TestPairIterator(wxInputStream& in)
+ #endif
+ 
+     for (CatalogIter it = cat.begin(); it != cat.end(); ++it) {
+-        auto_ptr<EntryT> entry(it->second);
++        wxScopedPtr<EntryT> entry(it->second);
+         count += m_testEntries.count(entry->GetName(wxPATH_UNIX));
+     }
+ 
+@@ -1049,7 +1048,7 @@ void ArchiveTestCase<ClassFactoryT>::TestSmartIterator(wxInputStream& in)
+     typedef typename ArchiveCatalog::iterator CatalogIter;
+     typedef wxArchiveIterator<InputStreamT, Ptr<EntryT> > Iter;
+ 
+-    auto_ptr<InputStreamT> arc(m_factory->NewStream(in));
++    wxScopedPtr<InputStreamT> arc(m_factory->NewStream(in));
+ 
+ #ifdef WXARC_MEMBER_TEMPLATES
+     ArchiveCatalog cat((Iter)*arc, Iter());
+@@ -1080,7 +1079,7 @@ void ArchiveTestCase<ClassFactoryT>::TestSmartPairIterator(wxInputStream& in)
+     typedef wxArchiveIterator<InputStreamT,
+                 std::pair<wxString, Ptr<EntryT> > > PairIter;
+ 
+-    auto_ptr<InputStreamT> arc(m_factory->NewStream(in));
++    wxScopedPtr<InputStreamT> arc(m_factory->NewStream(in));
+ 
+ #ifdef WXARC_MEMBER_TEMPLATES
+     ArchiveCatalog cat((PairIter)*arc, PairIter());
+@@ -1108,8 +1107,8 @@ void ArchiveTestCase<ClassFactoryT>::ReadSimultaneous(TestInputStream& in)
+ 
+     // create two archive input streams
+     TestInputStream in2(in);
+-    auto_ptr<InputStreamT> arc(m_factory->NewStream(in));
+-    auto_ptr<InputStreamT> arc2(m_factory->NewStream(in2));
++    wxScopedPtr<InputStreamT> arc(m_factory->NewStream(in));
++    wxScopedPtr<InputStreamT> arc2(m_factory->NewStream(in2));
+ 
+     // load the catalog
+ #ifdef WXARC_MEMBER_TEMPLATES
+@@ -1201,7 +1200,7 @@ protected:
+     void CreateArchive(wxOutputStream& out);
+     void ExtractArchive(wxInputStream& in);
+ 
+-    auto_ptr<wxArchiveClassFactory> m_factory;  // factory to make classes
++    wxScopedPtr<wxArchiveClassFactory> m_factory;  // factory to make classes
+     int m_options;                              // test options
+ };
+ 
+@@ -1241,7 +1240,7 @@ void CorruptionTestCase::runTest()
+ 
+ void CorruptionTestCase::CreateArchive(wxOutputStream& out)
+ {
+-    auto_ptr<wxArchiveOutputStream> arc(m_factory->NewStream(out));
++    wxScopedPtr<wxArchiveOutputStream> arc(m_factory->NewStream(out));
+ 
+     arc->PutNextDirEntry(wxT("dir"));
+     arc->PutNextEntry(wxT("file"));
+@@ -1250,8 +1249,8 @@ void CorruptionTestCase::CreateArchive(wxOutputStream& out)
+ 
+ void CorruptionTestCase::ExtractArchive(wxInputStream& in)
+ {
+-    auto_ptr<wxArchiveInputStream> arc(m_factory->NewStream(in));
+-    auto_ptr<wxArchiveEntry> entry(arc->GetNextEntry());
++    wxScopedPtr<wxArchiveInputStream> arc(m_factory->NewStream(in));
++    wxScopedPtr<wxArchiveEntry> entry(arc->GetNextEntry());
+ 
+     while (entry.get() != NULL) {
+         char buf[1024];
+@@ -1259,7 +1258,6 @@ void CorruptionTestCase::ExtractArchive(wxInputStream& in)
+         while (arc->IsOk())
+             arc->Read(buf, sizeof(buf));
+ 
+-        auto_ptr<wxArchiveEntry> next(arc->GetNextEntry());
+-        entry = next;
++        entry.reset(arc->GetNextEntry());
+     }
+ }
+diff --git a/tests/archive/archivetest.h b/tests/archive/archivetest.h
+index 7a1a306..37a083c 100644
+--- a/tests/archive/archivetest.h
++++ b/tests/archive/archivetest.h
+@@ -13,7 +13,7 @@
+ 
+ #include "wx/archive.h"
+ #include "wx/wfstream.h"
+-
++#include "wx/scopedptr.h"
+ 
+ ///////////////////////////////////////////////////////////////////////////////
+ // Bit flags for options for the tests
+@@ -213,7 +213,7 @@ protected:
+ 
+     typedef std::map<wxString, TestEntry*> TestEntries;
+     TestEntries m_testEntries;              // test data
+-    std::auto_ptr<ClassFactoryT> m_factory; // factory to make classes
++    wxScopedPtr<ClassFactoryT> m_factory; // factory to make classes
+     int m_options;                          // test options
+     wxDateTime m_timeStamp;                 // timestamp to give test entries
+     int m_id;                               // select between the possibilites
+diff --git a/tests/archive/ziptest.cpp b/tests/archive/ziptest.cpp
+index 3e9cff3..dc3fef5 100644
+--- a/tests/archive/ziptest.cpp
++++ b/tests/archive/ziptest.cpp
+@@ -22,7 +22,6 @@
+ #include "wx/zipstrm.h"
+ 
+ using std::string;
+-using std::auto_ptr;
+ 
+ 
+ ///////////////////////////////////////////////////////////////////////////////
+@@ -186,7 +185,7 @@ void ZipPipeTestCase::runTest()
+     TestInputStream in(out, m_id % ((m_options & PipeIn) ? 4 : 3));
+     wxZipInputStream zip(in);
+ 
+-    auto_ptr<wxZipEntry> entry(zip.GetNextEntry());
++    wxScopedPtr<wxZipEntry> entry(zip.GetNextEntry());
+     CPPUNIT_ASSERT(entry.get() != NULL);
+ 
+     if ((m_options & PipeIn) == 0)
+diff --git a/tests/net/socket.cpp b/tests/net/socket.cpp
+index acd91ae..7e27fc4 100644
+--- a/tests/net/socket.cpp
++++ b/tests/net/socket.cpp
+@@ -28,10 +28,11 @@
+ #include "wx/url.h"
+ #include "wx/sstream.h"
+ #include "wx/evtloop.h"
++#include "wx/scopedptr.h"
+ #include <memory>
+ 
+-typedef std::auto_ptr<wxSockAddress> wxSockAddressPtr;
+-typedef std::auto_ptr<wxSocketClient> wxSocketClientPtr;
++typedef wxScopedPtr<wxSockAddress> wxSockAddressPtr;
++typedef wxScopedPtr<wxSocketClient> wxSocketClientPtr;
+ 
+ static wxString gs_serverHost(wxGetenv("WX_TEST_SERVER"));
+ 
+@@ -257,7 +258,7 @@ void SocketTestCase::UrlTest()
+ 
+     wxURL url("http://" + gs_serverHost);
+ 
+-    const std::auto_ptr<wxInputStream> in(url.GetInputStream());
++    const wxScopedPtr<wxInputStream> in(url.GetInputStream());
+     CPPUNIT_ASSERT( in.get() );
+ 
+     wxStringOutputStream out;
+diff --git a/tests/streams/largefile.cpp b/tests/streams/largefile.cpp
+index 9c6c481..59fca24 100644
+--- a/tests/streams/largefile.cpp
++++ b/tests/streams/largefile.cpp
+@@ -33,6 +33,7 @@
+ 
+ #include "wx/filename.h"
+ #include "wx/wfstream.h"
++#include "wx/scopedptr.h"
+ 
+ #ifdef __WINDOWS__
+     #include "wx/msw/wrapwin.h"
+@@ -51,7 +52,6 @@
+     #define fileno _fileno
+ #endif
+ 
+-using std::auto_ptr;
+ 
+ 
+ ///////////////////////////////////////////////////////////////////////////////
+@@ -120,7 +120,7 @@ void LargeFileTest::runTest()
+ 
+     // write a large file
+     {
+-        auto_ptr<wxOutputStream> out(MakeOutStream(tmpfile.m_name));
++        wxScopedPtr<wxOutputStream> out(MakeOutStream(tmpfile.m_name));
+ 
+         // write 'A's at [ 0x7fffffbf, 0x7fffffff [
+         pos = 0x7fffffff - size;
+@@ -154,7 +154,7 @@ void LargeFileTest::runTest()
+ 
+     // read the large file back
+     {
+-        auto_ptr<wxInputStream> in(MakeInStream(tmpfile.m_name));
++        wxScopedPtr<wxInputStream> in(MakeInStream(tmpfile.m_name));
+         char buf[size];
+ 
+         if (haveLFS) {
+@@ -218,7 +218,7 @@ protected:
+ 
+ wxInputStream *LargeFileTest_wxFile::MakeInStream(const wxString& name) const
+ {
+-    auto_ptr<wxFileInputStream> in(new wxFileInputStream(name));
++    wxScopedPtr<wxFileInputStream> in(new wxFileInputStream(name));
+     CPPUNIT_ASSERT(in->IsOk());
+     return in.release();
+ }
+@@ -250,7 +250,7 @@ protected:
+ 
+ wxInputStream *LargeFileTest_wxFFile::MakeInStream(const wxString& name) const
+ {
+-    auto_ptr<wxFFileInputStream> in(new wxFFileInputStream(name));
++    wxScopedPtr<wxFFileInputStream> in(new wxFFileInputStream(name));
+     CPPUNIT_ASSERT(in->IsOk());
+     return in.release();
+ }
+diff --git a/wxWidgets-3.0.5.1/src/stc/scintilla/src/Editor.cxx.old b/wxWidgets-3.0.5.1/src/stc/scintilla/src/Editor.cxx
+index 2081df2..a8c8572 100644
+--- a/src/stc/scintilla/src/Editor.cxx
++++ b/src/stc/scintilla/src/Editor.cxx
+@@ -41,6 +41,7 @@
+ #include "Selection.h"
+ #include "PositionCache.h"
+ #include "Editor.h"
++#include "wx/scopedptr.h"
+ 
+ #ifdef SCI_NAMESPACE
+ using namespace Scintilla;
+@@ -5706,7 +5707,7 @@ long Editor::FindText(
+ 
+ 	Sci_TextToFind *ft = reinterpret_cast<Sci_TextToFind *>(lParam);
+ 	int lengthFound = istrlen(ft->lpstrText);
+-	std::auto_ptr<CaseFolder> pcf(CaseFolderForEncoding());
++	wxScopedPtr<CaseFolder> pcf(CaseFolderForEncoding());
+ 	int pos = pdoc->FindText(ft->chrg.cpMin, ft->chrg.cpMax, ft->lpstrText,
+ 	        (wParam & SCFIND_MATCHCASE) != 0,
+ 	        (wParam & SCFIND_WHOLEWORD) != 0,

--- a/x11-libs/wxGTK/wxGTK-3.0.5.1-r2.ebuild
+++ b/x11-libs/wxGTK/wxGTK-3.0.5.1-r2.ebuild
@@ -14,7 +14,7 @@ DESCRIPTION="GTK+ version of wxWidgets, a cross-platform C++ GUI toolkit"
 HOMEPAGE="https://wxwidgets.org/"
 SRC_URI="
 	https://github.com/wxWidgets/wxWidgets/releases/download/v${PV}/wxWidgets-${PV}.tar.bz2
-	https://dev.gentoo.org/~leio/distfiles/wxGTK-3.0.5_p20210214.tar.xz
+	https://dev.gentoo.org/~leio/distfiles/wxGTK-${WXVERSION}_p20210214.tar.xz
 	doc? ( https://github.com/wxWidgets/wxWidgets/releases/download/v${WXVERSION}/wxWidgets-${WXVERSION}-docs-html.tar.bz2 )"
 S="${WORKDIR}/wxWidgets-${PV}"
 
@@ -64,6 +64,8 @@ PATCHES=(
 	"${FILESDIR}"/wxGTK-ignore-c++-abi.patch #676878
 	"${FILESDIR}"/${PN}-configure-tests.patch
 	"${FILESDIR}"/${PN}-3.0.5.1-configure-modern-c.patch
+	"${FILESDIR}"/${PN}-3.0.5.1-excise-autoptr.patch
+
 )
 
 src_prepare() {


### PR DESCRIPTION
Backports fixes from 3.2.2, using existing wxScopedPtr

Closes: https://bugs.gentoo.org/910441