### PR TITLE
media-gfx/blender: add 4.0.2-r1, cleanup

### DIFF
--- a/media-gfx/blender/blender-3.3.15.ebuild
+++ b/media-gfx/blender/blender-3.3.15.ebuild
@@ -22,8 +22,8 @@ else
 	KEYWORDS="~amd64 ~arm ~arm64"
 fi
 
-SLOT="${PV%.*}"
 LICENSE="|| ( GPL-3 BL )"
+SLOT="${PV%.*}"
 IUSE="+bullet +dds +fluid +openexr +tbb \
 	alembic collada +color-management cuda +cycles \
 	debug doc +embree +ffmpeg +fftw +gmp headless jack jemalloc jpeg2k \
@@ -94,7 +94,7 @@ RDEPEND="${PYTHON_DEPS}
 	)
 	opensubdiv? ( >=media-libs/opensubdiv-3.4.0 )
 	openvdb? (
-		>=media-gfx/openvdb-9.0.0:=[nanovdb?]
+		<media-gfx/openvdb-11.0.0:=[nanovdb?]
 		dev-libs/c-blosc:=
 	)
 	optix? ( <dev-libs/optix-7.5.0 )

--- a/media-gfx/blender/blender-3.3.8.ebuild
+++ b/media-gfx/blender/blender-3.3.8.ebuild
@@ -22,8 +22,8 @@ else
 	KEYWORDS="amd64 ~arm ~arm64"
 fi
 
-SLOT="${PV%.*}"
 LICENSE="|| ( GPL-3 BL )"
+SLOT="${PV%.*}"
 IUSE="+bullet +dds +fluid +openexr +tbb \
 	alembic collada +color-management cuda +cycles \
 	debug doc +embree +ffmpeg +fftw +gmp headless jack jemalloc jpeg2k \
@@ -94,7 +94,7 @@ RDEPEND="${PYTHON_DEPS}
 	)
 	opensubdiv? ( >=media-libs/opensubdiv-3.4.0 )
 	openvdb? (
-		>=media-gfx/openvdb-9.0.0:=[nanovdb?]
+		<media-gfx/openvdb-11.0.0:=[nanovdb?]
 		dev-libs/c-blosc:=
 	)
 	optix? ( <dev-libs/optix-7.5.0 )

--- a/media-gfx/blender/blender-3.6.8.ebuild
+++ b/media-gfx/blender/blender-3.6.8.ebuild
@@ -23,8 +23,8 @@ else
 	KEYWORDS="amd64 ~arm ~arm64"
 fi
 
-SLOT="${PV%.*}"
 LICENSE="|| ( GPL-3 BL )"
+SLOT="${PV%.*}"
 IUSE="+bullet +dds +fluid +openexr +tbb
 	alembic collada +color-management cuda +cycles cycles-bin-kernels
 	debug doc +embree +ffmpeg +fftw +gmp jack jemalloc jpeg2k
@@ -89,7 +89,7 @@ RDEPEND="${PYTHON_DEPS}
 	openpgl? ( media-libs/openpgl:0/0.5 )
 	opensubdiv? ( >=media-libs/opensubdiv-3.4.0 )
 	openvdb? (
-		>=media-gfx/openvdb-9.0.0:=[nanovdb?]
+		<media-gfx/openvdb-11.0.0:=[nanovdb?]
 		dev-libs/c-blosc:=
 	)
 	optix? ( <dev-libs/optix-7.5.0 )

--- a/media-gfx/blender/files/blender-4.0.1-openvdb-11.patch
+++ b/media-gfx/blender/files/blender-4.0.1-openvdb-11.patch
@@ -1,3 +1,5 @@
+From: Paul Zander <negril.nx+gentoo@gmail.com>
+Change lookup for OpenVDB-11
 --- a/intern/cycles/scene/image_vdb.cpp	2023-11-23 14:42:38.772685628 +0100
 +++ b/intern/cycles/scene/image_vdb.cpp	2023-11-23 15:19:55.475804922 +0100
 @@ -11,7 +11,14 @@

--- a/media-gfx/blender/files/blender-4.0.2-CUDA_NVCC_FLAGS.patch
+++ b/media-gfx/blender/files/blender-4.0.2-CUDA_NVCC_FLAGS.patch
@@ -1,0 +1,14 @@
+From: Paul Zander <negril.nx+gentoo@gmail.com>
+insert CUDA_NVCC_FLAGS into the custom nvcc call so we can use CUDAHOSTCXX, e.g. a different gcc version for cuda code
+diff --git a/intern/cycles/kernel/CMakeLists.txt b/intern/cycles/kernel/CMakeLists.txt
+index 604ccb8..160ee20 100644
+--- a/intern/cycles/kernel/CMakeLists.txt
++++ b/intern/cycles/kernel/CMakeLists.txt
+@@ -752,6 +752,7 @@ if(WITH_CYCLES_DEVICE_OPTIX AND WITH_CYCLES_CUDA_BINARIES)
+       -I "${CMAKE_CURRENT_SOURCE_DIR}/device/cuda"
+       --use_fast_math
+       -Wno-deprecated-gpu-targets
++      ${CUDA_NVCC_FLAGS}
+       -o ${output})
+ 
+     if(WITH_NANOVDB)

--- a/media-gfx/blender/files/blender-4.0.2-FindClang.patch
+++ b/media-gfx/blender/files/blender-4.0.2-FindClang.patch
@@ -1,0 +1,14 @@
+From: Paul Zander <negril.nx+gentoo@gmail.com>
+look for the merged clang library so we can find clang
+diff --git a/build_files/cmake/Modules/FindClang.cmake b/build_files/cmake/Modules/FindClang.cmake
+index 1957c63..5620b84 100644
+--- a/build_files/cmake/Modules/FindClang.cmake
++++ b/build_files/cmake/Modules/FindClang.cmake
+@@ -85,6 +85,7 @@ set(_CLANG_FIND_COMPONENTS
+   clangAST
+   clangLex
+   clangBasic
++  clang-cpp
+ )
+ 
+ set(_CLANG_LIBRARIES)

--- a/media-gfx/blender/files/blender-4.0.2-r1-osl-1.13.patch
+++ b/media-gfx/blender/files/blender-4.0.2-r1-osl-1.13.patch
@@ -1,0 +1,342 @@
+From 798a0b301e640e73ae12e6f8a36a66746893bff1 Mon Sep 17 00:00:00 2001
+From: Brecht Van Lommel <brecht@blender.org>
+Date: Sun, 10 Dec 2023 17:08:47 +0100
+Subject: [PATCH] Cycles: update OSL to work with version 1.13.5
+
+This keeps compatibility with older stable versions, but not
+older unreleased versions in the 1.13.x series.
+
+Ref #113157
+
+Pull Request: https://projects.blender.org/blender/blender/pulls/116004
+---
+ intern/cycles/device/cpu/device_impl.cpp      |  2 +-
+ .../device/cpu/kernel_thread_globals.cpp      |  6 ++-
+ .../cycles/device/cpu/kernel_thread_globals.h |  3 +-
+ intern/cycles/kernel/device/cpu/globals.h     |  1 +
+ intern/cycles/kernel/osl/closures.cpp         | 52 ++++++++++++++++++-
+ intern/cycles/kernel/osl/globals.cpp          |  3 +-
+ intern/cycles/kernel/osl/globals.h            |  4 +-
+ intern/cycles/kernel/osl/osl.h                |  5 ++
+ intern/cycles/kernel/osl/services.cpp         | 27 ++++++++--
+ intern/cycles/kernel/osl/services.h           | 21 +++++++-
+ intern/cycles/kernel/osl/types.h              |  4 +-
+ 11 files changed, 115 insertions(+), 13 deletions(-)
+
+diff --git a/intern/cycles/device/cpu/device_impl.cpp b/intern/cycles/device/cpu/device_impl.cpp
+index cbbdb844323..ba838233855 100644
+--- a/intern/cycles/device/cpu/device_impl.cpp
++++ b/intern/cycles/device/cpu/device_impl.cpp
+@@ -313,7 +313,7 @@ void CPUDevice::get_cpu_kernel_thread_globals(
+   kernel_thread_globals.clear();
+   void *osl_memory = get_cpu_osl_memory();
+   for (int i = 0; i < info.cpu_threads; i++) {
+-    kernel_thread_globals.emplace_back(kernel_globals, osl_memory, profiler);
++    kernel_thread_globals.emplace_back(kernel_globals, osl_memory, profiler, i);
+   }
+ }
+ 
+diff --git a/intern/cycles/device/cpu/kernel_thread_globals.cpp b/intern/cycles/device/cpu/kernel_thread_globals.cpp
+index 546061a5086..998a63aa334 100644
+--- a/intern/cycles/device/cpu/kernel_thread_globals.cpp
++++ b/intern/cycles/device/cpu/kernel_thread_globals.cpp
+@@ -12,14 +12,16 @@ CCL_NAMESPACE_BEGIN
+ 
+ CPUKernelThreadGlobals::CPUKernelThreadGlobals(const KernelGlobalsCPU &kernel_globals,
+                                                void *osl_globals_memory,
+-                                               Profiler &cpu_profiler)
++                                               Profiler &cpu_profiler,
++                                               const int thread_index)
+     : KernelGlobalsCPU(kernel_globals), cpu_profiler_(cpu_profiler)
+ {
+   clear_runtime_pointers();
+ 
+ #ifdef WITH_OSL
+-  OSLGlobals::thread_init(this, static_cast<OSLGlobals *>(osl_globals_memory));
++  OSLGlobals::thread_init(this, static_cast<OSLGlobals *>(osl_globals_memory), thread_index);
+ #else
++  (void)thread_index;
+   (void)osl_globals_memory;
+ #endif
+ 
+diff --git a/intern/cycles/device/cpu/kernel_thread_globals.h b/intern/cycles/device/cpu/kernel_thread_globals.h
+index dc4b693702a..3dbc35fefa3 100644
+--- a/intern/cycles/device/cpu/kernel_thread_globals.h
++++ b/intern/cycles/device/cpu/kernel_thread_globals.h
+@@ -23,7 +23,8 @@ class CPUKernelThreadGlobals : public KernelGlobalsCPU {
+    * without OSL support. Will avoid need to those unnamed pointers and casts. */
+   CPUKernelThreadGlobals(const KernelGlobalsCPU &kernel_globals,
+                          void *osl_globals_memory,
+-                         Profiler &cpu_profiler);
++                         Profiler &cpu_profiler,
++                         const int thread_index);
+ 
+   ~CPUKernelThreadGlobals();
+ 
+diff --git a/intern/cycles/kernel/device/cpu/globals.h b/intern/cycles/kernel/device/cpu/globals.h
+index 90a274b2bcf..d0495883e27 100644
+--- a/intern/cycles/kernel/device/cpu/globals.h
++++ b/intern/cycles/kernel/device/cpu/globals.h
+@@ -49,6 +49,7 @@ typedef struct KernelGlobalsCPU {
+   OSLGlobals *osl = nullptr;
+   OSLShadingSystem *osl_ss = nullptr;
+   OSLThreadData *osl_tdata = nullptr;
++  int osl_thread_index = 0;
+ #endif
+ 
+ #ifdef __PATH_GUIDING__
+diff --git a/intern/cycles/kernel/osl/closures.cpp b/intern/cycles/kernel/osl/closures.cpp
+index 808e13f48d6..4a5906873af 100644
+--- a/intern/cycles/kernel/osl/closures.cpp
++++ b/intern/cycles/kernel/osl/closures.cpp
+@@ -110,7 +110,17 @@ void osl_eval_nodes<SHADER_TYPE_SURFACE>(const KernelGlobalsCPU *kg,
+   if (sd->object == OBJECT_NONE && sd->lamp == LAMP_NONE) {
+     /* background */
+     if (kg->osl->background_state) {
++#if OSL_LIBRARY_VERSION_CODE >= 11304
++      ss->execute(*octx,
++                  *(kg->osl->background_state),
++                  kg->osl_thread_index,
++                  0,
++                  *globals,
++                  nullptr,
++                  nullptr);
++#else
+       ss->execute(octx, *(kg->osl->background_state), *globals);
++#endif
+     }
+   }
+   else {
+@@ -150,8 +160,18 @@ void osl_eval_nodes<SHADER_TYPE_SURFACE>(const KernelGlobalsCPU *kg,
+         globals->dPdy = TO_VEC3(tmp_dP.dy);
+       }
+ 
+-      /* execute bump shader */
++/* execute bump shader */
++#if OSL_LIBRARY_VERSION_CODE >= 11304
++      ss->execute(*octx,
++                  *(kg->osl->bump_state[shader]),
++                  kg->osl_thread_index,
++                  0,
++                  *globals,
++                  nullptr,
++                  nullptr);
++#else
+       ss->execute(octx, *(kg->osl->bump_state[shader]), *globals);
++#endif
+ 
+       /* reset state */
+       sd->P = P;
+@@ -164,7 +184,17 @@ void osl_eval_nodes<SHADER_TYPE_SURFACE>(const KernelGlobalsCPU *kg,
+ 
+     /* surface shader */
+     if (kg->osl->surface_state[shader]) {
++#if OSL_LIBRARY_VERSION_CODE >= 11304
++      ss->execute(*octx,
++                  *(kg->osl->surface_state[shader]),
++                  kg->osl_thread_index,
++                  0,
++                  *globals,
++                  nullptr,
++                  nullptr);
++#else
+       ss->execute(octx, *(kg->osl->surface_state[shader]), *globals);
++#endif
+     }
+   }
+ 
+@@ -208,7 +238,17 @@ void osl_eval_nodes<SHADER_TYPE_VOLUME>(const KernelGlobalsCPU *kg,
+   int shader = sd->shader & SHADER_MASK;
+ 
+   if (kg->osl->volume_state[shader]) {
++#if OSL_LIBRARY_VERSION_CODE >= 11304
++    ss->execute(*octx,
++                *(kg->osl->volume_state[shader]),
++                kg->osl_thread_index,
++                0,
++                *globals,
++                nullptr,
++                nullptr);
++#else
+     ss->execute(octx, *(kg->osl->volume_state[shader]), *globals);
++#endif
+   }
+ 
+   /* flatten closure tree */
+@@ -245,7 +285,17 @@ void osl_eval_nodes<SHADER_TYPE_DISPLACEMENT>(const KernelGlobalsCPU *kg,
+   int shader = sd->shader & SHADER_MASK;
+ 
+   if (kg->osl->displacement_state[shader]) {
++#if OSL_LIBRARY_VERSION_CODE >= 11304
++    ss->execute(*octx,
++                *(kg->osl->displacement_state[shader]),
++                kg->osl_thread_index,
++                0,
++                *globals,
++                nullptr,
++                nullptr);
++#else
+     ss->execute(octx, *(kg->osl->displacement_state[shader]), *globals);
++#endif
+   }
+ 
+   /* get back position */
+diff --git a/intern/cycles/kernel/osl/globals.cpp b/intern/cycles/kernel/osl/globals.cpp
+index c4f055af7f7..573ddb6f362 100644
+--- a/intern/cycles/kernel/osl/globals.cpp
++++ b/intern/cycles/kernel/osl/globals.cpp
+@@ -14,7 +14,7 @@
+ 
+ CCL_NAMESPACE_BEGIN
+ 
+-void OSLGlobals::thread_init(KernelGlobalsCPU *kg, OSLGlobals *osl_globals)
++void OSLGlobals::thread_init(KernelGlobalsCPU *kg, OSLGlobals *osl_globals, const int thread_index)
+ {
+   /* no osl used? */
+   if (!osl_globals->use) {
+@@ -37,6 +37,7 @@ void OSLGlobals::thread_init(KernelGlobalsCPU *kg, OSLGlobals *osl_globals)
+ 
+   kg->osl_ss = (OSLShadingSystem *)ss;
+   kg->osl_tdata = tdata;
++  kg->osl_thread_index = thread_index;
+ }
+ 
+ void OSLGlobals::thread_free(KernelGlobalsCPU *kg)
+diff --git a/intern/cycles/kernel/osl/globals.h b/intern/cycles/kernel/osl/globals.h
+index 9656ef08306..cf24c62613b 100644
+--- a/intern/cycles/kernel/osl/globals.h
++++ b/intern/cycles/kernel/osl/globals.h
+@@ -45,7 +45,9 @@ struct OSLGlobals {
+   }
+ 
+   /* per thread data */
+-  static void thread_init(struct KernelGlobalsCPU *kg, OSLGlobals *osl_globals);
++  static void thread_init(struct KernelGlobalsCPU *kg,
++                          OSLGlobals *osl_globals,
++                          const int thread_init);
+   static void thread_free(struct KernelGlobalsCPU *kg);
+ 
+   bool use;
+diff --git a/intern/cycles/kernel/osl/osl.h b/intern/cycles/kernel/osl/osl.h
+index 347b635632a..3238eb5096b 100644
+--- a/intern/cycles/kernel/osl/osl.h
++++ b/intern/cycles/kernel/osl/osl.h
+@@ -52,6 +52,11 @@ ccl_device_inline void shaderdata_to_shaderglobals(KernelGlobals kg,
+ 
+   /* shader data to be used in services callbacks */
+   globals->renderstate = sd;
++#if OSL_LIBRARY_VERSION_CODE >= 11304
++  globals->shadingStateUniform = nullptr;
++  globals->thread_index = 0;
++  globals->shade_index = 0;
++#endif
+ 
+   /* hacky, we leave it to services to fetch actual object matrix */
+   globals->shader2common = sd;
+diff --git a/intern/cycles/kernel/osl/services.cpp b/intern/cycles/kernel/osl/services.cpp
+index 02dc1cd1aec..93595b0a458 100644
+--- a/intern/cycles/kernel/osl/services.cpp
++++ b/intern/cycles/kernel/osl/services.cpp
+@@ -1165,7 +1165,18 @@ bool OSLRenderServices::get_userdata(
+   return false; /* disabled by lockgeom */
+ }
+ 
+-#if OSL_LIBRARY_VERSION_CODE >= 11100
++#if OSL_LIBRARY_VERSION_CODE >= 11304
++TextureSystem::TextureHandle *OSLRenderServices::get_texture_handle(OSLUStringHash filename,
++                                                                    OSL::ShadingContext *context,
++                                                                    const TextureOpt *opt)
++{
++  return get_texture_handle(to_ustring(filename), context, opt);
++}
++
++TextureSystem::TextureHandle *OSLRenderServices::get_texture_handle(OSL::ustring filename,
++                                                                    OSL::ShadingContext *,
++                                                                    const TextureOpt *)
++#elif OSL_LIBRARY_VERSION_CODE >= 11100
+ TextureSystem::TextureHandle *OSLRenderServices::get_texture_handle(OSLUStringHash filename,
+                                                                     OSL::ShadingContext *)
+ #else
+@@ -1616,7 +1627,17 @@ bool OSLRenderServices::environment(OSLUStringHash filename,
+   return status;
+ }
+ 
+-#if OSL_LIBRARY_VERSION_CODE >= 11100
++#if OSL_LIBRARY_VERSION_CODE >= 11304
++bool OSLRenderServices::get_texture_info(OSLUStringHash filename,
++                                         TextureHandle *texture_handle,
++                                         TexturePerthread *texture_thread_info,
++                                         OSL::ShaderGlobals *,
++                                         int subimage,
++                                         OSLUStringHash dataname,
++                                         TypeDesc datatype,
++                                         void *data,
++                                         OSLUStringHash *)
++#elif OSL_LIBRARY_VERSION_CODE >= 11100
+ bool OSLRenderServices::get_texture_info(OSLUStringHash filename,
+                                          TextureHandle *texture_handle,
+                                          TexturePerthread *texture_thread_info,
+@@ -1627,7 +1648,7 @@ bool OSLRenderServices::get_texture_info(OSLUStringHash filename,
+                                          void *data,
+                                          OSLUStringHash *)
+ #else
+-bool OSLRenderServices::get_texture_info(OSL::ShaderGlobals *sg,
++bool OSLRenderServices::get_texture_info(OSL::ShaderGlobals *,
+                                          OSLUStringHash filename,
+                                          TextureHandle *texture_handle,
+                                          int subimage,
+diff --git a/intern/cycles/kernel/osl/services.h b/intern/cycles/kernel/osl/services.h
+index b674fa7c7a7..62d8a4c5416 100644
+--- a/intern/cycles/kernel/osl/services.h
++++ b/intern/cycles/kernel/osl/services.h
+@@ -189,7 +189,14 @@ class OSLRenderServices : public OSL::RendererServices {
+                   void *val,
+                   bool derivatives) override;
+ 
+-#if OSL_LIBRARY_VERSION_CODE >= 11100
++#if OSL_LIBRARY_VERSION_CODE >= 11304
++  TextureSystem::TextureHandle *get_texture_handle(OSL::ustring filename,
++                                                   OSL::ShadingContext *context,
++                                                   const TextureOpt *options) override;
++  TextureSystem::TextureHandle *get_texture_handle(OSLUStringHash filename,
++                                                   OSL::ShadingContext *context,
++                                                   const TextureOpt *options) override;
++#elif OSL_LIBRARY_VERSION_CODE >= 11100
+   TextureSystem::TextureHandle *get_texture_handle(OSLUStringHash filename,
+                                                    OSL::ShadingContext *context) override;
+ #else
+@@ -245,7 +252,17 @@ class OSLRenderServices : public OSL::RendererServices {
+                    float *dresultdt,
+                    OSLUStringHash *errormessage) override;
+ 
+-#if OSL_LIBRARY_VERSION_CODE >= 11100
++#if OSL_LIBRARY_VERSION_CODE >= 11304
++  bool get_texture_info(OSLUStringHash filename,
++                        TextureHandle *texture_handle,
++                        TexturePerthread *texture_thread_info,
++                        OSL::ShaderGlobals *sg,
++                        int subimage,
++                        OSLUStringHash dataname,
++                        TypeDesc datatype,
++                        void *data,
++                        OSLUStringHash *errormessage) override;
++#elif OSL_LIBRARY_VERSION_CODE >= 11100
+   bool get_texture_info(OSLUStringHash filename,
+                         TextureHandle *texture_handle,
+                         TexturePerthread *texture_thread_info,
+diff --git a/intern/cycles/kernel/osl/types.h b/intern/cycles/kernel/osl/types.h
+index 71c808ff91b..8cb5779961a 100644
+--- a/intern/cycles/kernel/osl/types.h
++++ b/intern/cycles/kernel/osl/types.h
+@@ -86,8 +86,10 @@ struct ShaderGlobals {
+   ccl_private void *tracedata;
+   ccl_private void *objdata;
+   void *context;
+-#if OSL_LIBRARY_VERSION_CODE >= 11302
++#if OSL_LIBRARY_VERSION_CODE >= 11304
+   void *shadingStateUniform;
++  int thread_index;
++  int shade_index;
+ #endif
+   void *renderer;
+   ccl_private void *object2common;

--- a/profiles/arch/amd64/package.use.mask
+++ b/profiles/arch/amd64/package.use.mask
@@ -17,6 +17,10 @@
 
 #--- END OF EXAMPLES ---
 
+# Paul Zander <negril.nx+gentoo@gmail.com> (2024-04-20)
+# only keyworded for amd64 currently
+media-gfx/blender -gnome
+
 # Ionen Wolkens <ionen@gentoo.org> (2024-04-16)
 # dev-qt/qtlanguageserver:6 is keyworded here
 dev-qt/qtdeclarative:6 -qmlls

--- a/profiles/arch/base/package.use.mask
+++ b/profiles/arch/base/package.use.mask
@@ -1,6 +1,10 @@
 # Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Paul Zander <negril.nx+gentoo@gmail.com> (2024-04-20)
+# only keyworded for amd64 currently
+media-gfx/blender gnome
+
 # Ionen Wolkens <ionen@gentoo.org> (2024-04-16)
 # dev-qt/qtlanguageserver:6 currently has very few keywords
 dev-qt/qtdeclarative:6 qmlls


### PR DESCRIPTION
hopefully fixed osl build
re-added hip flag in 4.0.2-r1
hide test code in release versions

Bug: https://bugs.gentoo.org/693200
Closes: https://bugs.gentoo.org/925534
Closes: https://bugs.gentoo.org/927835
Closes: https://bugs.gentoo.org/927715
Closes: https://bugs.gentoo.org/927281
Closes: https://bugs.gentoo.org/925534