### PR TITLE
net-irc/irssistats: Fix compilation with clang

### DIFF
--- a/net-irc/irssistats/files/irssistats-0.75-clang.patch
+++ b/net-irc/irssistats/files/irssistats-0.75-clang.patch
@@ -1,0 +1,49 @@
+diff --git a/irssistats-0.75.orig/irssistats.c b/irssistats-0.75/irssistats.c
+index b8a282e..589fb03 100644
+--- a/irssistats.c
++++ b/irssistats.c
+@@ -22,12 +22,14 @@
+  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+  */
+ 
++#define _XOPEN_SOURCE
+ #include <sys/types.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <time.h>
+ #include <string.h>
+ #include <locale.h>
++#include <ctype.h>
+ #ifdef __WIN32__
+ #define GLOBALCONF "irssistats.conf"
+ #else
+@@ -1560,19 +1562,19 @@ void gen_xhtml(char *xhtmlfile)
+   fclose(fic);
+ }
+ 
+-void parse_config(char *configfile)
++void expand(char *path)
+ {
+-  void expand(char *path)
++  char temp[MAXLINELENGTH];
++  if (*path=='~')
+   {
+-    char temp[MAXLINELENGTH];
+-    if (*path=='~')
+-    {
+-      snprintf(temp,MAXLINELENGTH-1,"%s%s",getenv("HOME"),path+1);
+-      temp[MAXLINELENGTH-1]='\0';
+-      strcpy(path,temp);
+-    }
++    snprintf(temp,MAXLINELENGTH-1,"%s%s",getenv("HOME"),path+1);
++    temp[MAXLINELENGTH-1]='\0';
++    strcpy(path,temp);
+   }
+-  
++}
++
++void parse_config(char *configfile)
++{
+   FILE *fic;
+   char line[MAXLINELENGTH];
+   char keyword[MAXLINELENGTH];

--- a/net-irc/irssistats/irssistats-0.75-r2.ebuild
+++ b/net-irc/irssistats/irssistats-0.75-r2.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
 
 inherit toolchain-funcs
 
@@ -16,10 +16,11 @@ KEYWORDS="amd64 ppc sparc x86"
 
 DEPEND="net-irc/irssi"
 
-src_prepare() {
-	default
-	eapply "${FILESDIR}/${P}-Makefile.patch"
-}
+PATCHES=(
+	"${FILESDIR}/${P}-Makefile.patch"
+	"${FILESDIR}/${P}-clang.patch"
+)
+
 
 src_compile() {
 	emake CC="$(tc-getCC)" CFLAGS="${CFLAGS}" LDFLAGS="${LDFLAGS}"


### PR DESCRIPTION
To make irssistat compile with clang-glibc, one need only to extract nested function, add POSIX macro and missing include of ctypes.h

Closes: https://bugs.gentoo.org/897866