### PR TITLE
dev-haskell/*, dev-lang/whitespace, dev-util/shelltestrunner: add missing remote-id

### DIFF
--- a/dev-haskell/byteable/metadata.xml
+++ b/dev-haskell/byteable/metadata.xml
@@ -5,4 +5,7 @@
 		<email>haskell@gentoo.org</email>
 		<name>Gentoo Haskell</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">vincenthz/hs-byteable</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-haskell/conduit-combinators/metadata.xml
+++ b/dev-haskell/conduit-combinators/metadata.xml
@@ -5,4 +5,7 @@
 		<email>haskell@gentoo.org</email>
 		<name>Gentoo Haskell</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">snoyberg/mono-traversable</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-haskell/cprng-aes/metadata.xml
+++ b/dev-haskell/cprng-aes/metadata.xml
@@ -5,4 +5,7 @@
 		<email>haskell@gentoo.org</email>
 		<name>Gentoo Haskell</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">vincenthz/hs-cprng-aes</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-haskell/crypto-api/metadata.xml
+++ b/dev-haskell/crypto-api/metadata.xml
@@ -19,4 +19,7 @@
 		one cryptographic algorithm (ex: padding) is within
 		scope of this package.
 	</longdescription>
+	<upstream>
+		<remote-id type="github">haskell-github-trust/crypto-api</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-haskell/crypto-cipher-tests/metadata.xml
+++ b/dev-haskell/crypto-cipher-tests/metadata.xml
@@ -5,4 +5,7 @@
 		<email>haskell@gentoo.org</email>
 		<name>Gentoo Haskell</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">vincenthz/hs-crypto-cipher</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-haskell/crypto-cipher-types/metadata.xml
+++ b/dev-haskell/crypto-cipher-types/metadata.xml
@@ -5,4 +5,7 @@
 		<email>haskell@gentoo.org</email>
 		<name>Gentoo Haskell</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">vincenthz/hs-crypto-cipher</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-haskell/crypto-random/metadata.xml
+++ b/dev-haskell/crypto-random/metadata.xml
@@ -5,4 +5,7 @@
 		<email>haskell@gentoo.org</email>
 		<name>Gentoo Haskell</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">vincenthz/hs-crypto-random</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-haskell/cryptonite-conduit/metadata.xml
+++ b/dev-haskell/cryptonite-conduit/metadata.xml
@@ -12,4 +12,7 @@
 		with contribution, this could provide cipher conduits too,
 		and probably other things.
 	</longdescription>
+	<upstream>
+		<remote-id type="github">haskell-crypto/cryptonite-conduit</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-haskell/css-text/metadata.xml
+++ b/dev-haskell/css-text/metadata.xml
@@ -5,4 +5,7 @@
 		<email>haskell@gentoo.org</email>
 		<name>Gentoo Haskell</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">yesodweb/css-text</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-haskell/dlist/metadata.xml
+++ b/dev-haskell/dlist/metadata.xml
@@ -8,4 +8,7 @@
 	<use>
 		<flag name="werror">Enable -Werror</flag>
 	</use>
+	<upstream>
+		<remote-id type="github">spl/dlist</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-haskell/easy-file/metadata.xml
+++ b/dev-haskell/easy-file/metadata.xml
@@ -5,4 +5,7 @@
 		<email>haskell@gentoo.org</email>
 		<name>Gentoo Haskell</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">kazu-yamamoto/easy-file</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-haskell/edit-distance/metadata.xml
+++ b/dev-haskell/edit-distance/metadata.xml
@@ -5,4 +5,7 @@
 		<email>haskell@gentoo.org</email>
 		<name>Gentoo Haskell</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">haskellari/edit-distance</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-haskell/filemanip/metadata.xml
+++ b/dev-haskell/filemanip/metadata.xml
@@ -5,4 +5,7 @@
 		<email>haskell@gentoo.org</email>
 		<name>Gentoo Haskell</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">bos/filemanip</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-haskell/findbin/metadata.xml
+++ b/dev-haskell/findbin/metadata.xml
@@ -5,4 +5,7 @@
 		<email>haskell@gentoo.org</email>
 		<name>Gentoo Haskell</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">audreyt/findbin</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-haskell/getopt-generics/metadata.xml
+++ b/dev-haskell/getopt-generics/metadata.xml
@@ -5,4 +5,7 @@
 		<email>haskell@gentoo.org</email>
 		<name>Gentoo Haskell</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">soenkehahn/getopt-generics</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-haskell/haskell-lexer/metadata.xml
+++ b/dev-haskell/haskell-lexer/metadata.xml
@@ -5,4 +5,7 @@
 		<email>haskell@gentoo.org</email>
 		<name>Gentoo Haskell</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">yav/haskell-lexer</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-haskell/haskell-src-exts/metadata.xml
+++ b/dev-haskell/haskell-src-exts/metadata.xml
@@ -5,4 +5,7 @@
 		<email>haskell@gentoo.org</email>
 		<name>Gentoo Haskell</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">haskell-suite/haskell-src-exts</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-haskell/hinotify/metadata.xml
+++ b/dev-haskell/hinotify/metadata.xml
@@ -5,4 +5,7 @@
 		<email>haskell@gentoo.org</email>
 		<name>Gentoo Haskell</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">kolmodin/hinotify</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-haskell/http-media/metadata.xml
+++ b/dev-haskell/http-media/metadata.xml
@@ -32,4 +32,7 @@
 		
 		The API is agnostic to your choice of server.
 	</longdescription>
+	<upstream>
+		<remote-id type="github">zmthy/http-media</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-haskell/ieee754/metadata.xml
+++ b/dev-haskell/ieee754/metadata.xml
@@ -5,4 +5,7 @@
 		<email>haskell@gentoo.org</email>
 		<name>Gentoo Haskell</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">patperry/hs-ieee754</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-haskell/js-chart/metadata.xml
+++ b/dev-haskell/js-chart/metadata.xml
@@ -5,4 +5,7 @@
 		<email>haskell@gentoo.org</email>
 		<name>Gentoo Haskell</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">jonascarpay/js-chart</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-haskell/language-javascript/metadata.xml
+++ b/dev-haskell/language-javascript/metadata.xml
@@ -5,4 +5,7 @@
 		<email>haskell@gentoo.org</email>
 		<name>Gentoo Haskell</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">erikd/language-javascript</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-haskell/leancheck/metadata.xml
+++ b/dev-haskell/leancheck/metadata.xml
@@ -5,4 +5,7 @@
 		<email>haskell@gentoo.org</email>
 		<name>Gentoo Haskell</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">rudymatela/leancheck</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-haskell/libyaml/metadata.xml
+++ b/dev-haskell/libyaml/metadata.xml
@@ -9,4 +9,7 @@
 		<flag name="unicode">Enable unicode output. Otherwise, unicode characters will be escaped.</flag>
 		<flag name="system-libyaml">Use the system-wide libyaml instead of the bundled copy</flag>
 	</use>
+	<upstream>
+		<remote-id type="github">snoyberg/yaml</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-haskell/lift-type/metadata.xml
+++ b/dev-haskell/lift-type/metadata.xml
@@ -5,4 +5,7 @@
 		<email>haskell@gentoo.org</email>
 		<name>Gentoo Haskell</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">parsonsmatt/lift-type</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-haskell/logging-facade/metadata.xml
+++ b/dev-haskell/logging-facade/metadata.xml
@@ -5,4 +5,7 @@
 		<email>haskell@gentoo.org</email>
 		<name>Gentoo Haskell</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">sol/logging-facade</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-haskell/microlens-aeson/metadata.xml
+++ b/dev-haskell/microlens-aeson/metadata.xml
@@ -5,4 +5,7 @@
 		<email>haskell@gentoo.org</email>
 		<name>Gentoo Haskell</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">fosskers/microlens-aeson</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-haskell/monad-control/metadata.xml
+++ b/dev-haskell/monad-control/metadata.xml
@@ -5,4 +5,7 @@
 		<email>haskell@gentoo.org</email>
 		<name>Gentoo Haskell</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">basvandijk/monad-control</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-haskell/monad-loops/metadata.xml
+++ b/dev-haskell/monad-loops/metadata.xml
@@ -5,4 +5,7 @@
 		<email>haskell@gentoo.org</email>
 		<name>Gentoo Haskell</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">mokus0/monad-loops</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-haskell/mono-traversable/metadata.xml
+++ b/dev-haskell/mono-traversable/metadata.xml
@@ -5,4 +5,7 @@
 		<email>haskell@gentoo.org</email>
 		<name>Gentoo Haskell</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">snoyberg/mono-traversable</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-haskell/nats/metadata.xml
+++ b/dev-haskell/nats/metadata.xml
@@ -10,4 +10,7 @@
 		<flag name="hashable">enable hashable instances</flag>
 		<flag name="template-haskell">enable template_haskell</flag>
 	</use>
+	<upstream>
+		<remote-id type="github">ekmett/nats</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-haskell/netlink/metadata.xml
+++ b/dev-haskell/netlink/metadata.xml
@@ -5,4 +5,7 @@
 		<email>haskell@gentoo.org</email>
 		<name>Gentoo Haskell</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">Ongy/netlink-hs</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-haskell/network-bsd/metadata.xml
+++ b/dev-haskell/network-bsd/metadata.xml
@@ -10,4 +10,7 @@
 		
 		See newer versions of &lt;https://hackage.haskell.org/package/network-bsd network-bsd&gt; for more information.
 	</longdescription>
+	<upstream>
+		<remote-id type="github">haskell/network-bsd</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-haskell/pgp-wordlist/metadata.xml
+++ b/dev-haskell/pgp-wordlist/metadata.xml
@@ -20,4 +20,7 @@
 		For further information, see
 		&lt;http://en.wikipedia.org/wiki/PGP_word_list Wikipedia&gt;.
 	</longdescription>
+	<upstream>
+		<remote-id type="github">quchen/pgp-wordlist</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-haskell/primitive-addr/metadata.xml
+++ b/dev-haskell/primitive-addr/metadata.xml
@@ -5,4 +5,7 @@
 		<email>haskell@gentoo.org</email>
 		<name>Gentoo Haskell</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">byteverse/primitive-addr</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-haskell/quickcheck-classes-base/metadata.xml
+++ b/dev-haskell/quickcheck-classes-base/metadata.xml
@@ -9,4 +9,7 @@
 		<flag name="binary-laws">Include infrastructure for testing class laws of binary type constructors. Disabling `unary-laws` while keeping `binary-laws` enabled is an unsupported configuration.</flag>
 		<flag name="unary-laws">Include infrastructure for testing class laws of unary type constructors.</flag>
 	</use>
+	<upstream>
+		<remote-id type="github">andrewthad/quickcheck-classes</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-haskell/quickcheck-classes/metadata.xml
+++ b/dev-haskell/quickcheck-classes/metadata.xml
@@ -13,4 +13,7 @@
 		<flag name="unary-laws">Include infrastructure for testing class laws of unary type constructors. It is required that this flag match the value that the `unary-laws` flag was given when building `quickcheck-classes-base`.</flag>
 		<flag name="vector">You can disable the use of the `vector` package using `-f-vector`.  This may be useful for accelerating builds in sandboxes for expert users.</flag>
 	</use>
+	<upstream>
+		<remote-id type="github">andrewthad/quickcheck-classes</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-haskell/random-bytestring/metadata.xml
+++ b/dev-haskell/random-bytestring/metadata.xml
@@ -8,4 +8,7 @@
 	<use>
 		<flag name="pcg">compile with support for PCG from pcg-random</flag>
 	</use>
+	<upstream>
+		<remote-id type="github">larskuhtz/random-bytestring</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-haskell/raw-strings-qq/metadata.xml
+++ b/dev-haskell/raw-strings-qq/metadata.xml
@@ -5,4 +5,7 @@
 		<email>haskell@gentoo.org</email>
 		<name>Gentoo Haskell</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">23Skidoo/raw-strings-qq</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-haskell/regex-applicative/metadata.xml
+++ b/dev-haskell/regex-applicative/metadata.xml
@@ -9,4 +9,7 @@
 		regex-applicative is a Haskell library for parsing using regular expressions.
 		Parsers can be built using Applicative interface.
 	</longdescription>
+	<upstream>
+		<remote-id type="github">UnkindPartition/regex-applicative</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-haskell/resourcet/metadata.xml
+++ b/dev-haskell/resourcet/metadata.xml
@@ -5,4 +5,7 @@
 		<email>haskell@gentoo.org</email>
 		<name>Gentoo Haskell</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">snoyberg/conduit</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-haskell/safesemaphore/metadata.xml
+++ b/dev-haskell/safesemaphore/metadata.xml
@@ -5,4 +5,7 @@
 		<email>haskell@gentoo.org</email>
 		<name>Gentoo Haskell</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">ChrisKuklewicz/SafeSemaphore</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-haskell/semigroups/metadata.xml
+++ b/dev-haskell/semigroups/metadata.xml
@@ -5,4 +5,7 @@
 		<email>haskell@gentoo.org</email>
 		<name>Gentoo Haskell</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">ekmett/semigroups</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-haskell/should-not-typecheck/metadata.xml
+++ b/dev-haskell/should-not-typecheck/metadata.xml
@@ -8,4 +8,7 @@
 	<longdescription>
 		For examples and an introduction to the library please take a look at the &lt;https://github.com/CRogers/should-not-typecheck#should-not-typecheck- README&gt; on github.
 	</longdescription>
+	<upstream>
+		<remote-id type="github">CRogers/should-not-typecheck</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-haskell/skein/metadata.xml
+++ b/dev-haskell/skein/metadata.xml
@@ -31,4 +31,7 @@
 		This package includes Skein v1.3. Versions of this package
 		before 1.0.0 implemented Skein v1.1.
 	</longdescription>
+	<upstream>
+		<remote-id type="github">meteficha/skein</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-haskell/smallcheck/metadata.xml
+++ b/dev-haskell/smallcheck/metadata.xml
@@ -5,4 +5,7 @@
 		<email>haskell@gentoo.org</email>
 		<name>Gentoo Haskell</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">Bodigrim/smallcheck</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-haskell/string-conversions/metadata.xml
+++ b/dev-haskell/string-conversions/metadata.xml
@@ -10,4 +10,7 @@
 		of different string types
 		into values of other string types.
 	</longdescription>
+	<upstream>
+		<remote-id type="github">soenkehahn/string-conversions</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-haskell/tasty-hunit/metadata.xml
+++ b/dev-haskell/tasty-hunit/metadata.xml
@@ -5,4 +5,7 @@
 		<email>haskell@gentoo.org</email>
 		<name>Gentoo Haskell</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">UnkindPartition/tasty</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-haskell/tasty-kat/metadata.xml
+++ b/dev-haskell/tasty-kat/metadata.xml
@@ -5,4 +5,7 @@
 		<email>haskell@gentoo.org</email>
 		<name>Gentoo Haskell</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">vincenthz/tasty-kat</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-haskell/tasty-smallcheck/metadata.xml
+++ b/dev-haskell/tasty-smallcheck/metadata.xml
@@ -5,4 +5,7 @@
 		<email>haskell@gentoo.org</email>
 		<name>Gentoo Haskell</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">UnkindPartition/tasty</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-haskell/temporary-rc/metadata.xml
+++ b/dev-haskell/temporary-rc/metadata.xml
@@ -5,4 +5,7 @@
 		<email>haskell@gentoo.org</email>
 		<name>Gentoo Haskell</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">UnkindPartition/temporary</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-haskell/test-framework-leancheck/metadata.xml
+++ b/dev-haskell/test-framework-leancheck/metadata.xml
@@ -5,4 +5,7 @@
 		<email>haskell@gentoo.org</email>
 		<name>Gentoo Haskell</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">rudymatela/test-framework-leancheck</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-haskell/test-framework-th/metadata.xml
+++ b/dev-haskell/test-framework-th/metadata.xml
@@ -5,4 +5,7 @@
 		<email>haskell@gentoo.org</email>
 		<name>Gentoo Haskell</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">finnsson/test-generator</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-haskell/time-manager/metadata.xml
+++ b/dev-haskell/time-manager/metadata.xml
@@ -5,4 +5,7 @@
 		<email>haskell@gentoo.org</email>
 		<name>Gentoo Haskell</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">yesodweb/wai</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-haskell/timeit/metadata.xml
+++ b/dev-haskell/timeit/metadata.xml
@@ -5,4 +5,7 @@
 		<email>haskell@gentoo.org</email>
 		<name>Gentoo Haskell</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">merijn/timeit</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-haskell/type-equality/metadata.xml
+++ b/dev-haskell/type-equality/metadata.xml
@@ -15,4 +15,7 @@
 		producing equality proofs, providing some form of
 		decidable equality on types.
 	</longdescription>
+	<upstream>
+		<remote-id type="github">hesselink/type-equality</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-haskell/unbounded-delays/metadata.xml
+++ b/dev-haskell/unbounded-delays/metadata.xml
@@ -5,4 +5,7 @@
 		<email>haskell@gentoo.org</email>
 		<name>Gentoo Haskell</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">basvandijk/unbounded-delays</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-haskell/unicode-transforms/metadata.xml
+++ b/dev-haskell/unicode-transforms/metadata.xml
@@ -5,4 +5,7 @@
 		<email>haskell@gentoo.org</email>
 		<name>Gentoo Haskell</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">composewell/unicode-transforms</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-haskell/uniplate/metadata.xml
+++ b/dev-haskell/uniplate/metadata.xml
@@ -5,4 +5,7 @@
 		<email>haskell@gentoo.org</email>
 		<name>Gentoo Haskell</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">ndmitchell/uniplate</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-haskell/utf8-string/metadata.xml
+++ b/dev-haskell/utf8-string/metadata.xml
@@ -5,4 +5,7 @@
 		<email>haskell@gentoo.org</email>
 		<name>Gentoo Haskell</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">glguy/utf8-string</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-haskell/wcwidth/metadata.xml
+++ b/dev-haskell/wcwidth/metadata.xml
@@ -15,4 +15,7 @@
 		the widths assigned by it. The command line tool can compile a width table
 		to Haskell code that assigns widths to the Char type.
 	</longdescription>
+	<upstream>
+		<remote-id type="github">solidsnack/wcwidth</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-haskell/x11/metadata.xml
+++ b/dev-haskell/x11/metadata.xml
@@ -5,4 +5,7 @@
 		<email>haskell@gentoo.org</email>
 		<name>Gentoo Haskell</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">xmonad/X11</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-haskell/x509/metadata.xml
+++ b/dev-haskell/x509/metadata.xml
@@ -5,4 +5,7 @@
 		<email>haskell@gentoo.org</email>
 		<name>Gentoo Haskell</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">haskell-tls/hs-certificate</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-lang/whitespace/metadata.xml
+++ b/dev-lang/whitespace/metadata.xml
@@ -5,4 +5,7 @@
 		<email>haskell@gentoo.org</email>
 		<name>Gentoo Haskell</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">haroldl/whitespace-nd</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-util/shelltestrunner/metadata.xml
+++ b/dev-util/shelltestrunner/metadata.xml
@@ -12,4 +12,7 @@
 		and exit status.  Tests can be run selectively, in parallel, with a
 		timeout, in color, and/or with differences highlighted.
 	</longdescription>
+	<upstream>
+		<remote-id type="github">simonmichael/shelltestrunner</remote-id>
+	</upstream>
 </pkgmetadata>


### PR DESCRIPTION
Hi,
just a few additional remote-id's for haskell packages.