### PR TITLE
sci-biology/velvet-1.2.10: Fix incompatible pointer types.

### DIFF
--- a/sci-biology/velvet/files/velvet-1.2.10-incompatible-pointers.patch
+++ b/sci-biology/velvet/files/velvet-1.2.10-incompatible-pointers.patch
@@ -1,0 +1,27 @@
+diff --git a/velvet_1.2.10.orig/src/readSet.c b/velvet_1.2.10/src/readSet.c
+index f58122e..26e579c 100644
+--- a/src/readSet.c
++++ b/src/readSet.c
+@@ -638,7 +638,8 @@ static void readFastXFile(int fileType, SequencesWriter *seqWriteInfo, char *fil
+ 	FileGZOrAuto file;
+ 	IDnum counter = 0;
+ 
+-        file.gzFile = file.autoFile = NULL;
++        file.autoFile = NULL;
++        file.gzFile = NULL;
+         if (fileType == AUTO) {
+         	file.autoFile = openFileAuto(filename);
+                 if (!file.autoFile)
+@@ -677,8 +678,10 @@ static void readFastXPair(int fileType, SequencesWriter *seqWriteInfo, char *fil
+ 	if (cat==REFERENCE)
+ 		exitErrorf(EXIT_FAILURE, false, "Cannot read reference sequence in 'separate' read mode");
+ 
+-        file1.gzFile = file1.autoFile = NULL;
+-        file2.gzFile = file2.autoFile = NULL;
++        file1.autoFile = NULL;
++        file2.autoFile = NULL;
++        file1.autoFile = NULL;
++        file2.autoFile = NULL;
+         if (fileType == AUTO) {
+         	file1.autoFile = openFileAuto(filename1);
+                 if (!file1.autoFile)

--- a/sci-biology/velvet/velvet-1.2.10.ebuild
+++ b/sci-biology/velvet/velvet-1.2.10.ebuild
@@ -16,7 +16,16 @@ SLOT="0"
 KEYWORDS="~amd64 ~x86"
 IUSE="doc openmp"
 
-BDEPEND="doc? ( virtual/latex-base )"
+BDEPEND="doc? ( virtual/latex-base )
+        openmp? (
+                || (
+                        sys-devel/gcc[openmp]
+                        sys-devel/clang-runtime[openmp]
+                )
+        )
+"
+
+PATCHES=( "${FILESDIR}/${P}-incompatible-pointers.patch" )
 
 src_prepare() {
 	default
@@ -49,7 +58,7 @@ src_prepare() {
 		CFLAGS="${CFLAGS}"
 		OPT="${CFLAGS}"
 	)
-	use openmp && MAKE_XOPTS+=( OPENMP=1 )
+	use openmp && MAKE_XOPTS+=( OPENMP=1 ) && tc-check-openmp
 	[[ ! -z "${VELVET_MAXKMERLENGTH}" ]] && MAKE_XOPTS+=( MAXKMERLENGTH=${VELVET_MAXKMERLENGTH} )
 	[[ ! -z "${VELVET_CATEGORIES}" ]] && MAKE_XOPTS+=( CATEGORIES=${VELVET_CATEGORIES} )
 	[[ ! -z "${VELVET_BIGASSEMBLY}" ]] && MAKE_XOPTS+=( BIGASSEMBLY=${VELVET_BIGASSEMBLY} )


### PR DESCRIPTION
C99 porting. Split multi-assignments of NULLs into multiple lines Also added dependencies on OpenMP if USE=openmp is enabled

Closes: https://bugs.gentoo.org/919223