### PR TITLE
dev-python/docutils: Add --no-datestamp to documentation build

### DIFF
--- a/dev-python/docutils/docutils-0.20.1-r1.ebuild
+++ b/dev-python/docutils/docutils-0.20.1-r1.ebuild
@@ -33,7 +33,7 @@ python_compile_all() {
 	cp docutils/writers/html4css1/html4css1.css . || die
 
 	cd tools || die
-	"${EPYTHON}" buildhtml.py --input-encoding=utf-8 \
+	"${EPYTHON}" buildhtml.py --input-encoding=utf-8 --no-datestamp \
 		--stylesheet-path=../html4css1.css, --traceback ../docs || die
 }
 


### PR DESCRIPTION
Datestamps cause the build to be non-reproducible and are of little use.  Adding --no-datestamp here causes binpkgs to be equivalent when built multiple times.