### PR TITLE
media-gfx/fontforge: enable py3.12

### DIFF
--- a/media-gfx/fontforge/fontforge-20230101.ebuild
+++ b/media-gfx/fontforge/fontforge-20230101.ebuild
@@ -1,9 +1,9 @@
-# Copyright 2004-2023 Gentoo Authors
+# Copyright 2004-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{10..12} )
 inherit python-single-r1 xdg cmake
 
 DESCRIPTION="postscript font editor and converter"


### PR DESCRIPTION
* Tests pass.

Closes: https://bugs.gentoo.org/917026