### PR TITLE
sys-apps/attr: Add missing libgen.h include for basename(3)

### DIFF
--- a/sys-apps/attr/attr-2.5.2-r2.ebuild
+++ b/sys-apps/attr/attr-2.5.2-r2.ebuild
@@ -24,6 +24,10 @@ IUSE="debug nls static-libs"
 
 BDEPEND="nls? ( sys-devel/gettext )"
 
+PATCHES=(
+	"${FILESDIR}/attr-2.5.2-libgen-header-basename.patch"
+)
+
 src_prepare() {
 	default
 

--- a/sys-apps/attr/files/attr-2.5.2-libgen-header-basename.patch
+++ b/sys-apps/attr/files/attr-2.5.2-libgen-header-basename.patch
@@ -1,0 +1,25 @@
+From ede99868de287b0b1eebe5d7603a08953e508330 Mon Sep 17 00:00:00 2001
+From: "Haelwenn (lanodan) Monnier" <contact@hacktivis.me>
+Date: Sat, 30 Mar 2024 10:11:41 +0100
+Subject: [PATCH] tools/attr.c: Add missing header for basename(3)
+List-Archive: https://lists.nongnu.org/archive/html/acl-devel/2024-03/msg00000.html
+
+---
+ tools/attr.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/tools/attr.c b/tools/attr.c
+index f12e4af..6a3c1e9 100644
+--- a/tools/attr.c
++++ b/tools/attr.c
+@@ -28,6 +28,7 @@
+ #include <errno.h>
+ #include <string.h>
+ #include <locale.h>
++#include <libgen.h>
+ 
+ #include <attr/attributes.h>
+ 
+-- 
+2.43.2
+


### PR DESCRIPTION
Fixes compilation issue with musl and modern C99 compilers.

Closes: https://bugs.gentoo.org/926294
