### PR TITLE
app-misc/ddcutil: fix command not found error

### DIFF
--- a/app-misc/ddcutil/files/ddcutil-1.4.1-no-werror.patch
+++ b/app-misc/ddcutil/files/ddcutil-1.4.1-no-werror.patch
@@ -19,7 +19,7 @@ index c12f15c..27d2124 100644
  dnl AC_MSG_NOTICE([DBG = |$DBG|])
 
 -AM_CONDITIONAL(WARNINGS_ARE_ERRORS_COND, [test "x$ddcutil_version_suffix" != "x"] )
-+AM_CONDITIONAL(WARNINGS_ARE_ERRORS_COND, 0)
++AM_CONDITIONAL(WARNINGS_ARE_ERRORS_COND, [test 0])
 
  AS_IF( [test 0$DBG -ne 0],
     AC_MSG_NOTICE([debug messages enabled]),


### PR DESCRIPTION
Hello,

This is a trivial fix for `ddcutil-1.4.1-no-werror.patch`, applied by:
- `ddcutil-1.4.1.ebuild`
- `ddcutil-1.4.5.ebuild`
- `ddcutil-2.0.0-r2.ebuild`
- `ddcutil-2.1.4.ebuild`

Fixes:
```
 * QA Notice: command not found:
 *
 *      ./configure: line 2975: 0: command not found
```

Thanks.