### PR TITLE
net-misc/netkit-timed-0.17: porting to C99/C23

### DIFF
--- a/net-misc/netkit-timed/files/netkit-timed-0.17-accept-build-flags.patch
+++ b/net-misc/netkit-timed/files/netkit-timed-0.17-accept-build-flags.patch
@@ -1,0 +1,23 @@
+was sed -i -e '/^LDFLAGS=/d' configure || die "sed configure"
+--- a/configure	2024-05-09 06:02:18.884496589 -0000
++++ b/configure	2024-05-09 06:02:26.304490777 -0000
+@@ -115,7 +115,6 @@
+      echo 'no'
+ fi
+ 
+-LDFLAGS=
+ LIBS=
+ 
+ rm -f __conftest*
+was sed -i -e "s|ar -cruv|\${AR} -cruv|g" timed/lib/Makefile || die
+--- a/timed/lib/Makefile	2024-05-09 06:02:18.886496588 -0000
++++ b/timed/lib/Makefile	2024-05-09 06:02:31.568486653 -0000
+@@ -7,7 +7,7 @@
+ OBJS = byteorder.o measure.o cksum.o
+ 
+ libtimed.a: $(OBJS)
+-	ar -cruv $@ $^
++	${AR} -cruv $@ $^
+ 
+ install: ;
+ clean:

--- a/net-misc/netkit-timed/files/netkit-timed-0.17-c23-port.patch
+++ b/net-misc/netkit-timed/files/netkit-timed-0.17-c23-port.patch
@@ -1,0 +1,65 @@
+#bug https://bugs.gentoo.org/715776
+#bug https://bugs.gentoo.org/919876
+and general port to C23
+--- a/configure
++++ b/configure
+@@ -134,6 +100,7 @@
+ 
+ echo -n 'Checking for BSD signal semantics... '
+ cat <<EOF >__conftest.c
++#define _DEFAULT_SOURCE
+ #include <unistd.h>
+ #include <signal.h>
+ int count=0;
+--- a/timed/lib/cksum.c
++++ b/timed/lib/cksum.c
+@@ -41,6 +41,7 @@
+ #ident "$Revision: 1.4 $"
+ #endif
+ 
++#define _DEFAULT_SOURCE
+ #include <sys/types.h>
+ #include <sys/time.h>
+ #include "timed-extern.h"
+--- a/timed/timed/globals.h
++++ b/timed/timed/globals.h
+@@ -37,6 +37,7 @@
+ #ident "$Revision: 1.5 $"
+ #endif
+ 
++#define _DEFAULT_SOURCE
+ #include <sys/param.h>
+ #include <sys/time.h>
+ #include <sys/socket.h>
+--- a/timed/timedc/cmds.c
++++ b/timed/timedc/cmds.c
+@@ -41,6 +41,7 @@
+ #ident "$Revision: 1.11 $"
+ #endif
+ 
++#define _DEFAULT_SOURCE
+ #include "timedc.h"
+ #include <string.h>
+ #include <sys/file.h>
+--- a/timed/timedc/timedc.c
++++ b/timed/timedc/timedc.c
+@@ -45,6 +45,7 @@
+ #ident "$Revision: 1.8 $"
+ #endif
+ 
++#define _DEFAULT_SOURCE
+ #include "timedc.h"
+ #include <string.h>
+ #include <signal.h>
+--- a/timed/timed/networkdelta.c
++++ b/timed/timed/networkdelta.c
+@@ -40,8 +40,8 @@
+ #ifdef sgi
+ #ident "$Revision: 1.4 $"
+ #endif
+-#include <math.h>
+ #include "globals.h"
++#include <math.h>
+ 
+ static long median(float, float*, long*, long*, unsigned int);
+ 

--- a/net-misc/netkit-timed/files/netkit-timed-0.17-c99-port.patch
+++ b/net-misc/netkit-timed/files/netkit-timed-0.17-c99-port.patch
@@ -1,0 +1,44 @@
+Simple port to C99
+#bug https://bugs.gentoo.org/919876
+--- a/timed/lib/measure.c
++++ b/timed/lib/measure.c
+@@ -75,7 +75,7 @@ measure(u_long maxmsec,			/* wait this many msec at most */
+ 	struct sockaddr_in *xaddr,
+ 	int doprint)			/* print complaints on stderr */
+ {
+-	size_t length;
++	socklen_t length;
+ 	int measure_status;
+ 	int rcvcount, trials = 0;
+ 	int cc, count;
+--- a/timed/timed/correct.c
++++ b/timed/timed/correct.c
+@@ -165,7 +165,7 @@ adjclock(struct timeval *corr)
+ 		}
+ 	} else {
+ 		syslog(LOG_WARNING,
+-		       "clock correction %d sec too large to adjust",
++		       "clock correction %ld sec too large to adjust",
+ 		       adj.tv_sec);
+ 		(void) gettimeofday(&now, 0);
+ 		timevaladd(&now, corr);
+--- a/timed/timed/networkdelta.c
++++ b/timed/timed/networkdelta.c
+@@ -40,7 +40,7 @@ char nd_rcsid[] =
+ #ifdef sgi
+ #ident "$Revision: 1.4 $"
+ #endif
+-
++#include <math.h>
+ #include "globals.h"
+ 
+ static long median(float, float*, long*, long*, unsigned int);
+@@ -238,7 +238,7 @@ median(float a,				/* initial guess for the median */
+ 				        (long)a, pass, npts);
+ 			return a;
+ 		}
+-		eps = AFAC*abs(aa - a);
++		eps = AFAC*fabsf(aa - a);
+ 		*eps_ptr = eps;
+ 		a = aa;
+ 	}

--- a/net-misc/netkit-timed/netkit-timed-0.17-r12.ebuild
+++ b/net-misc/netkit-timed/netkit-timed-0.17-r12.ebuild
@@ -9,17 +9,17 @@ DESCRIPTION="Netkit - timed: Time daemon"
 HOMEPAGE="https://wiki.linuxfoundation.org/networking/netkit"
 SRC_URI="http://ftp.linux.org.uk/pub/linux/Networking/netkit/${P}.tar.gz"
 
-KEYWORDS="amd64 ~mips ppc ppc64 sparc x86"
 LICENSE="BSD GPL-2"
 SLOT="0"
+KEYWORDS="~amd64 ~x86"
 
-src_prepare() {
-	eapply "${FILESDIR}"/0.17-CFLAG-DEF-fix.patch
-	eapply "${FILESDIR}"/0.17-timed-opt-parsing.patch
-	sed -i -e '/^LDFLAGS=/d' configure || die "sed configure"
-	sed -i -e "s|ar -cruv|\${AR} -cruv|g" timed/lib/Makefile || die
-	default
-}
+PATCHES=(
+	"${FILESDIR}/0.17-CFLAG-DEF-fix.patch"
+	"${FILESDIR}/0.17-timed-opt-parsing.patch"
+	"${FILESDIR}/${P}-c99-port.patch"
+	"${FILESDIR}/${P}-accept-build-flags.patch"
+	"${FILESDIR}/${P}-c23-port.patch"
+)
 
 src_configure() {
 	tc-export AR


### PR DESCRIPTION
Changing code to semantically identical, but syntactically correct. There's some warnings remain that I don't want to touch, because I don't understand the code and swapping float to double or adding brakets around assignment that ought to be inside if block can cause unintended consequences.

Closes: https://bugs.gentoo.org/919876