### PR TITLE
sci-libs/mpfi-1.5.4: Port to C99 by fixing incompatible pointers

### DIFF
--- a/sci-libs/mpfi/files/mpfi-1.5.4-c99-incompatible-pointers.patch
+++ b/sci-libs/mpfi/files/mpfi-1.5.4-c99-incompatible-pointers.patch
@@ -1,0 +1,48 @@
+diff --git a/mpfi-1.5.4.orig/src/div_ext.c b/mpfi-1.5.4/src/div_ext.c
+index 30cd3db..52b37cd 100644
+--- a/src/div_ext.c
++++ b/src/div_ext.c
+@@ -59,17 +59,17 @@ mpfi_div_ext (mpfi_ptr res1, mpfi_ptr res2, mpfi_srcptr op1, mpfi_srcptr op2)
+       mpfr_init2 (tmp1, mpfi_get_prec(res1));
+       mpfr_init2 (tmp2, mpfi_get_prec(res2));
+       if ( mpfr_number_p (&(op2->left)) ) {
+-        tmp = mpfr_div (&(tmp2), &(op1->right), &(op2->left), MPFI_RNDD);
++        tmp = mpfr_div (&(tmp2[0]), &(op1->right), &(op2->left), MPFI_RNDD);
+       }
+       else { /* denominator has infinite left endpoint */
+-        mpfr_set_zero (&(tmp2), 1);
++        mpfr_set_zero (&(tmp2[0]), 1);
+       }
+ 
+       if ( mpfr_number_p (&(op2->right)) ) {
+-        tmp = mpfr_div ( &(tmp1), &(op1->right), &(op2->right), MPFI_RNDU);
++        tmp = mpfr_div ( &(tmp1[0]), &(op1->right), &(op2->right), MPFI_RNDU);
+       }
+       else { /* denominator has infinite right endpoint */
+-        mpfr_set_zero( &(tmp1), -1);
++        mpfr_set_zero( &(tmp1[0]), -1);
+       }
+ 
+       mpfr_set_inf (&(res1->left), -1);
+@@ -86,17 +86,17 @@ mpfi_div_ext (mpfi_ptr res1, mpfi_ptr res2, mpfi_srcptr op1, mpfi_srcptr op2)
+       mpfr_init2 (tmp1, mpfi_get_prec(res1));
+       mpfr_init2 (tmp2, mpfi_get_prec(res2));
+       if ( mpfr_number_p (&(op2->left)) ) {
+-        tmp = mpfr_div (&(tmp1), &(op1->left), &(op2->left), MPFI_RNDU);
++        tmp = mpfr_div (&(tmp1[0]), &(op1->left), &(op2->left), MPFI_RNDU);
+       }
+       else { /* denominator has infinite left endpoint */
+-        mpfr_set_zero (&(tmp1), -1);
++        mpfr_set_zero (&(tmp1[0]), -1);
+       }
+ 
+       if ( mpfr_number_p (&(op2->right)) ) {
+-        tmp = mpfr_div ( &(tmp2), &(op1->left), &(op2->right), MPFI_RNDD);
++        tmp = mpfr_div ( &(tmp2[0]), &(op1->left), &(op2->right), MPFI_RNDD);
+       }
+       else { /* denominator has infinite right endpoint */
+-        mpfr_set_zero( &(tmp2), 1);
++        mpfr_set_zero( &(tmp2[0]), 1);
+       }
+       mpfr_set_inf (&(res1->left), -1);
+       mpfr_set (&(res1->right), tmp1, MPFI_RNDU);

--- a/sci-libs/mpfi/mpfi-1.5.4.ebuild
+++ b/sci-libs/mpfi/mpfi-1.5.4.ebuild
@@ -20,6 +20,8 @@ DEPEND="
 	dev-libs/mpfr:0="
 RDEPEND="${DEPEND}"
 
+PATCHES=("${FILESDIR}/${P}-c99-incompatible-pointers.patch")
+
 src_prepare() {
 	default
 	eautoreconf


### PR DESCRIPTION
There's a difference between a pointer to struct and pointer to 1-element array embedding said struct, from modern compiler point of view. Disambigue that difference in code by taking the address of zeroth element instead of whole array.

Upstream has an updated tarball mpfi-1.5.4 with file missing tests folder, in current tarball, to successfully enable `make check`, ebuild test and FEATURES=test. Beyond the missing file, newer tarball includes also major changes, autotools and other code differences I do not feel qualified to judge. Upstream can't or doesn't semver their code.

This is why the package is not revision-bumped, still on tarball from 2019 instead of tarball from 2022 and doesn't have tests enabled.

Closes: https://bugs.gentoo.org/921351