### PR TITLE
dev-php/pecl-yaml-2.2.3: Fix [-Wincompatible-pointer-types] warning

### DIFF
--- a/dev-php/pecl-yaml/files/pecl-yaml-2.2.3-c99-incompatible-pointer-types.patch
+++ b/dev-php/pecl-yaml/files/pecl-yaml-2.2.3-c99-incompatible-pointer-types.patch
@@ -1,0 +1,24 @@
+bug https://bugs.gentoo.org/922688
+upstream commit: https://github.com/php/pecl-file_formats-yaml/commit/e7bffc01c496ef36ce672c612984b13a27426788
+From e7bffc01c496ef36ce672c612984b13a27426788 Mon Sep 17 00:00:00 2001
+From: Remi Collet <remi@remirepo.net>
+Date: Mon, 6 Mar 2023 09:29:07 +0100
+Subject: [PATCH] Fix [-Wincompatible-pointer-types] warning
+
+---
+ parse.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/parse.c b/parse.c
+index e63f3d8..17f70ba 100644
+--- a/parse.c
++++ b/parse.c
+@@ -531,7 +531,7 @@ void handle_sequence (parser_state_t *state, zval *retval) {
+ 		/* apply callbacks to the collected node */
+ 		if (Y_FILTER_FAILURE == apply_filter(
+ 				retval, src_event, state->callbacks)) {
+-			zval_ptr_dtor(&retval);
++			zval_ptr_dtor(retval);
+ 			ZVAL_UNDEF(retval);
+ 			goto done;
+ 			//TODO Sean-Der

--- a/dev-php/pecl-yaml/pecl-yaml-2.2.3.ebuild
+++ b/dev-php/pecl-yaml/pecl-yaml-2.2.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -18,3 +18,4 @@ KEYWORDS="~amd64 ~arm64 ~x86"
 
 DEPEND="dev-libs/libyaml"
 RDEPEND="${DEPEND}"
+PATCHES=( "${FILESDIR}/${P}-c99-incompatible-pointer-types.patch" )


### PR DESCRIPTION
Upstream patch

Closes: https://bugs.gentoo.org/922688