### PR TITLE
sci-misc/oww-0.86.5-r1: fix missing build-time dependency

### DIFF
--- a/sci-misc/oww/oww-0.86.5-r1.ebuild
+++ b/sci-misc/oww/oww-0.86.5-r1.ebuild
@@ -18,7 +18,9 @@ RDEPEND="
 	net-misc/curl
 	gtk? ( x11-libs/gtk+:2 )"
 DEPEND="${RDEPEND}"
-BDEPEND="virtual/pkgconfig"
+BDEPEND="
+	virtual/pkgconfig
+	dev-util/intltool"
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-0.86.4-build.patch


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/831137