### PR TITLE
net-misc/lambdamoo: fix configure for C99 porting

### DIFF
--- a/net-misc/lambdamoo/files/lambdamoo-1.8.1-C99-configure.patch
+++ b/net-misc/lambdamoo/files/lambdamoo-1.8.1-C99-configure.patch
@@ -1,0 +1,111 @@
+Original minimal fix for bug https://bugs.gentoo.org/927734
+with it lambdaroo starts compiling
+diff -ur MOO-1.8.1.orig/configure.in MOO-1.8.1/configure.in
+--- a/configure.in	2024-04-01 07:02:38.948009581 +0000
++++ b/configure.in	2024-04-01 07:04:19.706417934 +0000
+@@ -260,7 +260,8 @@
+ SAVECC="$CC"
+ CC="$CC $opt"
+ AC_TEST_PROGRAM([
+-int main(int argc, char *argv) { void *ptr; exit(0); }
++#include <stdlib.h>
++int main(int argc, char **argv) { void *ptr; exit(0); }
+ ],
+ [have_ansi=1
+ break],
+diff -ur MOO-1.8.1.orig/config.h.in MOO-1.8.1/config.h.in
+--- a/config.h.in	2024-04-01 07:11:20.263972630 +0000
++++ b/config.h.in	2024-04-01 07:13:06.909341833 +0000
+@@ -253,6 +253,7 @@
+  */
+ 
+ #include <limits.h>
++#include <string.h>
+ 
+ #if INT_MAX == 2147483647
+    typedef int		int32;
+fix for old name of configure.in
+--- a/Makefile.in	2024-05-09 05:39:45.019672388 -0000
++++ b/Makefile.in	2024-05-09 05:40:41.162384171 -0000
+@@ -69,7 +69,7 @@
+ 
+ DISTFILES = $(SRCS) Makefile.in restart restart.sh \
+ 	Minimal.db README.Minimal \
+-	ChangeLog.txt README configure.in configure config.h.in \
++	ChangeLog.txt README configure.ac configure config.h.in \
+ 	MOOCodeSequences.txt AddingNewMOOTypes.txt pgperf aclocal.m4
+ 
+ COBJS = $(CSRCS:.c=.o)
+@@ -94,7 +94,7 @@
+ restart:
+ 	touch restart
+ 
+-configure: configure.in
++configure: configure.ac
+ 	# autoconf
+ 	@echo "Not running autoconf; you must do this by hand."
+ 	touch configure
+QA fixes from Sam, modified for configure.in, as they are applied
+before renaming
+https://github.com/gentoo/gentoo/pull/36033#issuecomment-2101077890
+diff --git a/configure.in b/configure.in
+index 685bdfe..24cfe64 100644
+--- a/configure.in
++++ b/configure.in
+@@ -381,8 +381,10 @@ dnl ***************************************************************************
+ echo "checking whether or not fstat() can tell how much data is in a FIFO"
+ AC_TEST_PROGRAM([#include <sys/types.h>
+ #include <sys/stat.h>
++#include <stdlib.h>
+ #include <fcntl.h>
+-main()
++#include <unistd.h>
++int main()
+ {
+ #ifdef NeXT
+ /* The NeXT claims to have FIFOs, but using them panics the kernel... */
+@@ -407,13 +409,15 @@ AC_TEST_PROGRAM([#include <sys/types.h>
+ #include <sys/time.h>
+ #include <sys/stat.h>
+ #include <fcntl.h>
++#include <stdlib.h>
++#include <unistd.h>
+ #ifndef FD_ZERO
+ #define	NFDBITS		(sizeof(fd_set)*8)
+ #define	FD_ZERO(p)	bzero((char *)(p), sizeof(*(p)))
+ #define	FD_SET(n, p)	((p)->fds_bits[0] |= (1L<<((n)%NFDBITS)))
+ #define	FD_ISSET(n, p)	((p)->fds_bits[0] &  (1L<<((n)%NFDBITS)))
+ #endif /* FD_ZERO */
+-main()
++int main()
+ {
+ #ifdef NeXT
+ /* The NeXT claims to have FIFOs, but using them panics the kernel... */
+@@ -443,7 +447,9 @@ AC_TEST_PROGRAM([#include <sys/types.h>
+ #include <poll.h>
+ #include <sys/stat.h>
+ #include <fcntl.h>
+-main()
++#include <stdlib.h>
++#include <unistd.h>
++int main()
+ {
+   int	rfd, wfd, result; struct pollfd fds[1];
+   unlink("/tmp/conftest-fifo");
+@@ -461,11 +467,14 @@ main()
+ dnl ***************************************************************************
+ echo checking whether POSIX-style non-blocking I/O works
+ AC_TEST_PROGRAM([#include <sys/types.h>
++#include <sys/stat.h>
+ #include <errno.h>
+ #include <fcntl.h>
+ #include <signal.h>
+-handler(int sig) { }
+-main ()
++#include <stdlib.h>
++#include <unistd.h>
++void handler(int sig) { return; }
++int main ()
+ { /* Testing a POSIX feature, so assume FIFOs */
+ #ifdef NeXT
+ /* The NeXT claims to have FIFOs, but using them panics the kernel... */

--- a/net-misc/lambdamoo/files/lambdamoo-1.8.1-respect-cflags.patch
+++ b/net-misc/lambdamoo/files/lambdamoo-1.8.1-respect-cflags.patch
@@ -1,0 +1,24 @@
+was sed -i Makefile.in -e '/ -o /s|$(CFLAGS)|& $(LDFLAGS)|g'
+--- a/Makefile.in	2024-05-09 05:12:18.249018601 -0000
++++ b/Makefile.in	2024-05-09 05:12:20.497004963 -0000
+@@ -79,16 +79,16 @@
+ OBJS = $(COBJS) $(YOBJS)
+ 
+ moo:	$(OBJS)
+-	$(CC) $(CFLAGS) $(OBJS) $(LIBRARIES) -o $@
++	$(CC) $(CFLAGS) $(LDFLAGS) $(OBJS) $(LIBRARIES) -o $@
+ 
+ pure_moo: moo
+-	purify $(CC) $(CFLAGS) $(OBJS) $(LIBRARIES) -o $@
++	purify $(CC) $(CFLAGS) $(LDFLAGS) $(OBJS) $(LIBRARIES) -o $@
+ 
+ client_bsd: client_bsd.o
+-	$(CC) $(CFLAGS) client_bsd.o $(LIBRARIES) -o $@
++	$(CC) $(CFLAGS) $(LDFLAGS) client_bsd.o $(LIBRARIES) -o $@
+ 
+ client_sysv: client_sysv.o
+-	$(CC) $(CFLAGS) client_sysv.o $(LIBRARIES) -o $@
++	$(CC) $(CFLAGS) $(LDFLAGS) client_sysv.o $(LIBRARIES) -o $@
+ 
+ # This rule gets around some "make"s' desire to `derive' it from `restart.sh'.
+ restart:

--- a/net-misc/lambdamoo/lambdamoo-1.8.1-r4.ebuild
+++ b/net-misc/lambdamoo/lambdamoo-1.8.1-r4.ebuild
@@ -1,0 +1,43 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="8"
+
+inherit autotools toolchain-funcs
+
+DESCRIPTION="networked mud that can be used for different types of collaborative software"
+HOMEPAGE="https://sourceforge.net/projects/lambdamoo/"
+SRC_URI="https://downloads.sourceforge.net/lambdamoo/LambdaMOO-${PV}.tar.gz"
+S=${WORKDIR}/MOO-${PV}
+
+LICENSE="LambdaMOO GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+DEPEND="app-alternatives/yacc"
+
+PATCHES=(
+	"${FILESDIR}/${PV}-enable-outbound.patch"
+	"${FILESDIR}/${P}-C99-configure.patch"
+	"${FILESDIR}/${P}-respect-cflags.patch"
+)
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_compile() {
+	emake \
+		CC="$(tc-getCC)" \
+		CFLAGS="${CFLAGS} -DHAVE_MKFIFO=1"
+}
+
+src_install() {
+	dosbin moo
+	insinto /usr/share/${PN}
+	doins Minimal.db
+	dodoc *.txt README*
+
+	newinitd "${FILESDIR}"/lambdamoo.rc ${PN}
+	newconfd "${FILESDIR}"/lambdamoo.conf ${PN}
+}


### PR DESCRIPTION
Add missing include, fix test program for configure.in

Closes: https://bugs.gentoo.org/927734