### PR TITLE
mail-mta/opensmtpd-7.4.0_p1: Add missing include

### DIFF
--- a/mail-mta/opensmtpd/files/opensmtpd-7.4.0-missing-include.patch
+++ b/mail-mta/opensmtpd/files/opensmtpd-7.4.0-missing-include.patch
@@ -1,0 +1,11 @@
+diff -ur '--exclude=*.o' opensmtpd-7.4.0p1.orig/openbsd-compat/getdtablecount.c opensmtpd-7.4.0p1/openbsd-compat/getdtablecount.c
+--- a/openbsd-compat/getdtablecount.c	2024-04-01 07:25:41.230753002 +0000
++++ b/openbsd-compat/getdtablecount.c	2024-04-01 07:27:23.556124378 +0000
+@@ -20,6 +20,7 @@
+ 
+ #include <glob.h>
+ #include <unistd.h>
++#include <stdio.h>
+ 
+ void fatal(const char *, ...);
+ void fatalx(const char *, ...);

--- a/mail-mta/opensmtpd/opensmtpd-7.4.0_p1.ebuild
+++ b/mail-mta/opensmtpd/opensmtpd-7.4.0_p1.ebuild
@@ -57,6 +57,8 @@ QA_CONFIG_IMPL_DECL_SKIP=( closefrom )
 
 DOCS=( {CHANGES,README}.md )
 
+PATCHES=( "${FILESDIR}/${P}-missing-includes.patch" )
+
 src_unpack() {
 	if use verify-sig; then
 		# Too many levels of symbolic links


### PR DESCRIPTION
Fixes GCC-14 build error implicit declaration of function snprintf

Closes: https://bugs.gentoo.org/922951