### PR TITLE
x11-plugins/gkrellsun-1.0.0: Make errors fatal, fix build

### DIFF
--- a/x11-plugins/gkrellsun/files/gkrellsun-1.0.0-r6-include.patch
+++ b/x11-plugins/gkrellsun/files/gkrellsun-1.0.0-r6-include.patch
@@ -1,0 +1,16 @@
+includes exist for a reason. No reason to use badly written extern declarations
+diff -ru gkrellsun-1.0.0.orig/src20/gkrellsun.c gkrellsun-1.0.0/src20/gkrellsun.c
+--- a/src20/gkrellsun.c	2024-04-01 09:51:43.815461580 +0000
++++ b/src20/gkrellsun.c	2024-04-01 09:53:30.245006285 +0000
+@@ -15,10 +15,9 @@
+ #endif
+ 
+ #include <math.h>
++#include <glib.h>
+ 
+ /* splint */
+-extern gchar* g_string_free (/*@only@*/ GString *, gboolean);
+-extern void pango_font_description_free (/*@owned@*/PangoFontDescription *);
+ 
+ #define PLUGIN_HEIGHT 54
+ #define SUN_WIDTH 54

--- a/x11-plugins/gkrellsun/files/gkrellsun-1.0.0-r6-makefile-fixes.patch
+++ b/x11-plugins/gkrellsun/files/gkrellsun-1.0.0-r6-makefile-fixes.patch
@@ -1,0 +1,83 @@
+Call inner make in sane way, with error propagation. So build will fail on errors
+--- a/Makefile	2024-04-01 09:38:48.800355255 +0000
++++ b/Makefile	2024-04-01 09:40:12.944908086 +0000
+@@ -2,7 +2,7 @@
+ TMP=.
+ 
+ all: comment
+-	cd src20; make; cd ..
++	$(MAKE) -C src20
+ 
+ comment:
+ 	@echo
+@@ -12,12 +12,12 @@
+ 	@echo 
+ 
+ install: comment
+-	cd src20; make install; cd ..
++	$(MAKE) -C src20 install
+ 
+ distclean: clean
+ 
+ clean:
+-	cd src20; make clean; cd ..
++	$(MAKE) -C src20 clean
+ 	rm -f gkrellsun*.zip gkrellsun*.tar.gz
+ 
+ dist:
+Don't call gcc directly, remove -O2 -Wall flags, respect user's pkg-config
+--- a/src20/Makefile
++++ b/src20/Makefile
+@@ -1,8 +1,8 @@
+ PACKAGE ?= gkrellsun
+ 
+-GTK_CONFIG ?=pkg-config gtk+-2.0
+-GTK_INCLUDE ?= `pkg-config gtk+-2.0 --cflags`
+-GTK_LIB ?= `pkg-config gtk+-2.0 --libs`
++PKG_CONFIG ?= pkg-config
++GTK_INCLUDE ?= $(shell ${PKG_CONFIG} gtk+-2.0 --cflags)
++GTK_LIB ?= $(shell ${PKG_CONFIG} gtk+-2.0 --libs)
+ 
+ INSTALL ?= install
+ 
+@@ -11,7 +11,7 @@ INSTALLDIR ?= $(DESTDIR)$(PREFIX)
+ PLUGINDIR ?= $(INSTALLDIR)/lib/gkrellm2/plugins
+ LOCALEDIR ?= $(INSTALLDIR)/share/locale
+ 
+-FLAGS = -O2 -Wall -fPIC $(GTK_INCLUDE)
++FLAGS = -fPIC $(GTK_INCLUDE)
+ #FLAGS = -g -Wall -fPIC $(GTK_INCLUDE)
+ LIBS = $(GTK_LIB)
+ LFLAGS = -shared
+@@ -25,7 +25,7 @@ endif
+ FLAGS += -DPACKAGE="\"$(PACKAGE)\""
+ export PACKAGE LOCALEDIR
+ 
+-CC = gcc $(CFLAGS) $(FLAGS)
++CC = $(CC)
+ 
+ OBJS = gkrellsun.o CalcEphem.o Moon.o MoonRise.o
+ 
+@@ -37,10 +37,10 @@ all: gkrellsun.so
+ 
+ gkrellsun.so: $(OBJS)
+ 	(cd po && ${MAKE})
+-	$(CC) $(OBJS) -o gkrellsun.so $(LFLAGS) $(LIBS)
++	$(CC) $(CFLAGS) $(FLAGS) $(OBJS) -o gkrellsun.so $(LFLAGS) $(LIBS)
+ 
+ suninfo: suninfo.o CalcEphem.o Moon.o MoonRise.o
+-	$(CC) $^ -o suninfo -lm $(LIBS)
++	$(CC) $(CFLAGS) $(FLAGS) $^ -o suninfo -lm $(LIBS)
+ 
+ clean:
+ 	rm -f *.o core *.so* *.bak *~
+@@ -49,7 +49,8 @@ gkrellsun.o: gkrellsun.c $(IMAGES)
+ 
+ $(OBJS): CalcEphem.h Moon.h MoonRise.h
+ 
+-#%.o: %.c
++%.o: %.c
++	$(CC) $(CFLAGS) $(FLAGS) -c -o $@ $<
+ 
+ install: gkrellsun.so
+ 	(cd po && ${MAKE} install )

--- a/x11-plugins/gkrellsun/gkrellsun-1.0.0-r6.ebuild
+++ b/x11-plugins/gkrellsun/gkrellsun-1.0.0-r6.ebuild
@@ -1,0 +1,38 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit gkrellm-plugin multilib toolchain-funcs
+
+DESCRIPTION="A GKrellM plugin that shows sunrise and sunset times"
+HOMEPAGE="https://gkrellsun.sourceforge.net/"
+SRC_URI="mirror://sourceforge/gkrellsun/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="1"
+KEYWORDS="~alpha ~amd64 ~hppa ~ia64 ~ppc sparc x86"
+IUSE="nls"
+
+RDEPEND="app-admin/gkrellm:2[X]"
+DEPEND="${RDEPEND}
+	nls? ( sys-devel/gettext )"
+BDEPEND="virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-reenable.patch
+	"${FILESDIR}"/${P}-Respect-LDFLAGS.patch
+	"${FILESDIR}"/${P}-r6-makefile-fixes.patch
+	"${FILESDIR}"/${P}-r6-include.patch
+)
+
+src_configure() {
+	PLUGIN_SO=( src20/gkrellsun$(get_modname) )
+	default
+}
+
+src_compile() {
+	tc-export PKG_CONFIG
+	use nls && local myconf="enable_nls=1"
+	emake CC="$(tc-getCC)" ${myconf}
+}


### PR DESCRIPTION
There is a way to correctly call make in subdirectory. New revision uses it.
Also, uses proper include in main C file, like it does in other files for glib dependency. This fixes compilation error.

Closes: https://bugs.gentoo.org/901369