### PR TITLE
media-libs/libmpris2client: EAPI8 bump, fix LICENSE

### DIFF
--- a/media-libs/libmpris2client/libmpris2client-0.1.0-r2.ebuild
+++ b/media-libs/libmpris2client/libmpris2client-0.1.0-r2.ebuild
@@ -1,0 +1,35 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit xdg-utils
+
+DESCRIPTION="Library to control MPRIS2 compatible players"
+HOMEPAGE="https://github.com/matiasdelellis/libmpris2client"
+SRC_URI="https://github.com/matiasdelellis/${PN}/releases/download/V${PV}/${P}.tar.bz2"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+RDEPEND=">=dev-libs/glib-2
+	x11-libs/gtk+:2"
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+DOCS=( AUTHORS NEWS README TODO )
+
+src_install() {
+	default
+
+	find "${ED}" -name '*.la' -delete || die
+}
+
+pkg_postinst() {
+	xdg_icon_cache_update
+}
+
+pkg_postrm() {
+	xdg_icon_cache_update
+}


### PR DESCRIPTION
another simple `EAPI8` bump

```diff
--- libmpris2client-0.1.0-r1.ebuild	2023-04-01 17:48:26.428948320 +0200
+++ libmpris2client-0.1.0-r2.ebuild	2024-04-01 14:27:29.188107903 +0200
@@ -1,28 +1,25 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
-inherit gnome2-utils
+EAPI=8
 
-DESCRIPTION="A library to control MPRIS2 compatible players"
+inherit xdg-utils
+
+DESCRIPTION="Library to control MPRIS2 compatible players"
 HOMEPAGE="https://github.com/matiasdelellis/libmpris2client"
 SRC_URI="https://github.com/matiasdelellis/${PN}/releases/download/V${PV}/${P}.tar.bz2"
 
-LICENSE="GPL-3"
+LICENSE="GPL-2+"
 SLOT="0"
-KEYWORDS="amd64 x86"
+KEYWORDS="~amd64 ~x86"
 
 RDEPEND=">=dev-libs/glib-2
 	x11-libs/gtk+:2"
-DEPEND="${RDEPEND}
-	virtual/pkgconfig"
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
 
 DOCS=( AUTHORS NEWS README TODO )
 
-src_configure() {
-	econf --disable-static
-}
-
 src_install() {
 	default
 
@@ -30,9 +27,9 @@
 }
 
 pkg_postinst() {
-	gnome2_icon_cache_update
+	xdg_icon_cache_update
 }
 
 pkg_postrm() {
-	gnome2_icon_cache_update
+	xdg_icon_cache_update
 }
```