### PR TITLE
xfce-extra/thunar-vcs-plugin: EAPI8 bump

### DIFF
--- a/xfce-extra/thunar-vcs-plugin/thunar-vcs-plugin-0.2.0-r1.ebuild
+++ b/xfce-extra/thunar-vcs-plugin/thunar-vcs-plugin-0.2.0-r1.ebuild
@@ -1,0 +1,50 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit xdg-utils
+
+DESCRIPTION="Adds Subversion and GIT actions to the context menu of thunar"
+HOMEPAGE="https://goodies.xfce.org/projects/thunar-plugins/thunar-vcs-plugin"
+SRC_URI="https://archive.xfce.org/src/thunar-plugins/${PN}/${PV%.*}/${P}.tar.bz2"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~riscv ~x86"
+IUSE="+git +subversion"
+
+RDEPEND=">=dev-libs/glib-2.32:2=
+	>=x11-libs/gtk+-3.20:3=
+	>=xfce-base/exo-0.11.4:=
+	>=xfce-base/libxfce4util-4.12:=
+	>=xfce-base/thunar-1.7:=
+	git? ( dev-vcs/git )
+	subversion? (
+		>=dev-libs/apr-0.9.7:=
+		>=dev-vcs/subversion-1.5:=
+	)"
+DEPEND="${RDEPEND}"
+BDEPEND="dev-util/intltool
+	virtual/pkgconfig"
+
+src_configure() {
+	local myconf=(
+		$(use_enable subversion)
+		$(use_enable git)
+	)
+	econf "${myconf[@]}"
+}
+
+src_install() {
+	default
+	find "${D}" -name '*.la' -delete || die
+}
+
+pkg_postinst() {
+	xdg_icon_cache_update
+}
+
+pkg_postrm() {
+	xdg_icon_cache_update
+}


### PR DESCRIPTION
Next `EAPI8` bump

```diff
--- thunar-vcs-plugin-0.2.0.ebuild	2024-01-17 20:05:13.996811264 +0100
+++ thunar-vcs-plugin-0.2.0-r1.ebuild	2024-04-01 14:40:24.173031324 +0200
@@ -1,9 +1,9 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
 
-inherit gnome2-utils
+inherit xdg-utils
 
 DESCRIPTION="Adds Subversion and GIT actions to the context menu of thunar"
 HOMEPAGE="https://goodies.xfce.org/projects/thunar-plugins/thunar-vcs-plugin"
@@ -11,7 +11,7 @@
 
 LICENSE="GPL-2+"
 SLOT="0"
-KEYWORDS="amd64 ~riscv x86"
+KEYWORDS="~amd64 ~riscv ~x86"
 IUSE="+git +subversion"
 
 RDEPEND=">=dev-libs/glib-2.32:2=
@@ -23,9 +23,9 @@
 	subversion? (
 		>=dev-libs/apr-0.9.7:=
 		>=dev-vcs/subversion-1.5:=
-		)"
-DEPEND="${RDEPEND}
-	dev-util/intltool
+	)"
+DEPEND="${RDEPEND}"
+BDEPEND="dev-util/intltool
 	virtual/pkgconfig"
 
 src_configure() {
@@ -42,9 +42,9 @@
 }
 
 pkg_postinst() {
-	gnome2_icon_cache_update
+	xdg_icon_cache_update
 }
 
 pkg_postrm() {
-	gnome2_icon_cache_update
+	xdg_icon_cache_update
 }
```