### PR TITLE
app-text/cedilla: EAPI8 bump, fix LICENSE

### DIFF
--- a/app-text/cedilla/cedilla-0.7-r1.ebuild
+++ b/app-text/cedilla/cedilla-0.7-r1.ebuild
@@ -1,0 +1,31 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DESCRIPTION="UTF-8 to postscript converter"
+HOMEPAGE="http://www.pps.jussieu.fr/~jch/software/cedilla/
+	https://github.com/jech/cedilla"
+SRC_URI="http://www.pps.jussieu.fr/~jch/software/files/${P}.tar.gz"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+DEPEND="dev-lisp/clisp"
+RDEPEND="${DEPEND}"
+
+PATCHES=( "${FILESDIR}"/cedilla-gentoo-r1.patch )
+
+src_compile() {
+	./compile-cedilla || die "Compile failed."
+}
+
+src_install() {
+	sed "s#${ED}##g" -i cedilla || die "sed failed"
+	dodir /usr/share/man/man1/
+
+	./install-cedilla || die "Install failed."
+
+	einstalldocs
+}

--- a/app-text/cedilla/metadata.xml
+++ b/app-text/cedilla/metadata.xml
@@ -5,4 +5,7 @@
 		<email>titanofold@gentoo.org</email>
 		<name>Aaron W. Swenson</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">jech/cedilla</remote-id>
+	</upstream>
 </pkgmetadata>


### PR DESCRIPTION
another simple `EAPI8` bump

``` diff
--- cedilla-0.7.ebuild	2023-04-01 17:48:25.848957518 +0200
+++ cedilla-0.7-r1.ebuild	2024-04-01 14:49:11.242558503 +0200
@@ -1,15 +1,16 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
 
 DESCRIPTION="UTF-8 to postscript converter"
-HOMEPAGE="http://www.pps.jussieu.fr/~jch/software/cedilla/"
+HOMEPAGE="http://www.pps.jussieu.fr/~jch/software/cedilla/
+	https://github.com/jech/cedilla"
 SRC_URI="http://www.pps.jussieu.fr/~jch/software/files/${P}.tar.gz"
 
-KEYWORDS="amd64 x86"
+LICENSE="GPL-2+"
 SLOT="0"
-LICENSE="GPL-2"
+KEYWORDS="~amd64 ~x86"
 
 DEPEND="dev-lisp/clisp"
 RDEPEND="${DEPEND}"
@@ -21,7 +22,7 @@
 }
 
 src_install() {
-	sed "s#${ED%/}##g" -i cedilla || die "sed failed"
+	sed "s#${ED}##g" -i cedilla || die "sed failed"
 	dodir /usr/share/man/man1/
 
 	./install-cedilla || die "Install failed."
```