### PR TITLE
app-office/libreoffice: Backport upstream patch to allow compilation with GCC 14

### DIFF
--- a/app-office/libreoffice/libreoffice-7.6.6.3.ebuild
+++ b/app-office/libreoffice/libreoffice-7.6.6.3.ebuild
@@ -298,6 +298,7 @@ PATCHES=(
 
 	# 24.2 branch
 	"${FILESDIR}/${P}-autoconf-2.72.patch" # bug 925162
+	"${FILESDIR}/${PN}-7.6.5.2-gcc14.patch"
 
 	# TODO: upstream
 	"${FILESDIR}/${PN}-7.6-unused-qt5network.patch"


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/928152