### PR TITLE
x11-plugins/wmDownload: ensude GCC-14 and C99 compatibility

### DIFF
--- a/x11-plugins/wmDownload/files/wmDownload-0.1.2a-shorten-integers.patch
+++ b/x11-plugins/wmDownload/files/wmDownload-0.1.2a-shorten-integers.patch
@@ -1,0 +1,13 @@
+unsigned shorts are enough for libdockapp. Ought to be enough for size of widget
+diff -ru wmDownload.orig/wmDownload.c wmDownload/wmDownload.c
+--- wmDownload.orig/wmDownload.c	2024-04-02 06:30:58.407108657 +0000
++++ wmDownload/wmDownload.c	2024-04-02 06:32:26.445684633 +0000
+@@ -266,7 +266,7 @@
+ 
+ int main (int argc, char **argv)
+ {
+-	unsigned int height, width;
++	unsigned short height, width;
+ 	
+ 	DACallbacks callbacks = { NULL, buttonPressCallback, NULL, NULL, NULL, NULL, NULL }; 
+ 

--- a/x11-plugins/wmDownload/wmDownload-0.1.2a-r5.ebuild
+++ b/x11-plugins/wmDownload/wmDownload-0.1.2a-r5.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 inherit toolchain-funcs
 
 DESCRIPTION="dockapp that displays how much data you've received on each eth and ppp device"
@@ -11,7 +11,6 @@ HOMEPAGE="https://wmdownload.sourceforge.net/"
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~amd64 ~ppc ~sparc ~x86"
-IUSE=""
 
 RDEPEND=">=x11-libs/libdockapp-0.7:=
 	x11-libs/libX11
@@ -24,6 +23,8 @@ S="${WORKDIR}/${PN}"
 PATCHES=(
 	"${FILESDIR}"/${P}-makefile.patch
 	"${FILESDIR}"/${PN}-strtouq-musl.patch
+	"${FILESDIR}"/${P}-shorten-integers.patch
+
 )
 DOCS=( CHANGELOG CREDITS HINTS README TODO )
 


### PR DESCRIPTION
Switching unsigned ints to unsigned shorts: That's (pointers to) what library craves.

Closes: https://bugs.gentoo.org/919225