### PR TITLE
media-libs/audiofile: replace deprecated template unary_function

### DIFF
--- a/media-libs/audiofile/audiofile-0.3.6-r6.ebuild
+++ b/media-libs/audiofile/audiofile-0.3.6-r6.ebuild
@@ -1,0 +1,59 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools gnome.org multilib-minimal
+
+DESCRIPTION="An elegant API for accessing audio files"
+HOMEPAGE="https://audiofile.68k.org/"
+
+LICENSE="GPL-2 LGPL-2.1"
+SLOT="0/1" # subslot = soname major version
+KEYWORDS="~amd64"
+IUSE="flac"
+
+RDEPEND="flac? ( >=media-libs/flac-1.2.1:=[${MULTILIB_USEDEP}] )"
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-0.3.6-gcc6-build-fixes.patch
+	"${FILESDIR}"/${PN}-0.3.6-CVE-2015-7747.patch
+	"${FILESDIR}"/${PN}-0.3.6-mingw32.patch
+	"${FILESDIR}"/${PN}-0.3.6-CVE-2017-68xx.patch
+	"${FILESDIR}"/${PN}-0.3.6-CVE-2018-13440-CVE-2018-17095.patch
+	"${FILESDIR}"/${PN}-0.3.6-strict-prototypes.patch
+	"${FILESDIR}"/${PN}-0.3.6-clang-deprecation.patch
+)
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+multilib_src_configure() {
+	# Tests depend on statically compiled binaries to work, so we'll have to
+	# delete them later rather than not compile them at all
+	local myconf=(
+		--enable-largefile
+		# static needed for tests, bug #869677
+		--enable-static
+		--disable-werror
+		--disable-examples
+		$(use_enable flac)
+	)
+	ECONF_SOURCE="${S}" econf "${myconf[@]}"
+}
+
+multilib_src_test() {
+	emake check
+}
+
+multilib_src_install_all() {
+	einstalldocs
+
+	# package provides .pc file
+	find "${ED}" -name '*.la' -delete || die
+	find "${ED}" -name '*.a' -delete || die
+}

--- a/media-libs/audiofile/files/audiofile-0.3.6-clang-deprecation.patch
+++ b/media-libs/audiofile/files/audiofile-0.3.6-clang-deprecation.patch
@@ -1,0 +1,69 @@
+diff --git a/libaudiofile/modules/SimpleModule.h b/libaudiofile/modules/SimpleModule.h
+index 03c6c69..a3c3eac 100644
+--- a/libaudiofile/modules/SimpleModule.h
++++ b/libaudiofile/modules/SimpleModule.h
+@@ -125,13 +125,17 @@ struct signConverter
+ 	static const int kScaleBits = (Format + 1) * CHAR_BIT - 1;
+ 	static const int kMinSignedValue = -1 << kScaleBits;
+ 
+-	struct signedToUnsigned : public std::unary_function<SignedType, UnsignedType>
++	struct signedToUnsigned
+ 	{
++		typedef SignedType argument_type;
++		typedef UnsignedType result_type;
+ 		UnsignedType operator()(SignedType x) { return x - kMinSignedValue; }
+ 	};
+ 
+-	struct unsignedToSigned : public std::unary_function<SignedType, UnsignedType>
++	struct unsignedToSigned
+ 	{
++		typedef SignedType argument_type;
++		typedef UnsignedType result_type;
+ 		SignedType operator()(UnsignedType x) { return x + kMinSignedValue; }
+ 	};
+ };
+@@ -323,8 +327,10 @@ private:
+ };
+ 
+ template <typename Arg, typename Result>
+-struct intToFloat : public std::unary_function<Arg, Result>
++struct intToFloat
+ {
++	typedef Arg argument_type;
++	typedef Result result_type;
+ 	Result operator()(Arg x) const { return x; }
+ };
+ 
+@@ -389,14 +395,18 @@ private:
+ };
+ 
+ template <typename Arg, typename Result, unsigned shift>
+-struct lshift : public std::unary_function<Arg, Result>
++struct lshift
+ {
++	typedef Arg argument_type;
++	typedef Result result_type;
+ 	Result operator()(const Arg &x) const { return x << shift; }
+ };
+ 
+ template <typename Arg, typename Result, unsigned shift>
+-struct rshift : public std::unary_function<Arg, Result>
++struct rshift
+ {
++	typedef Arg argument_type;
++	typedef Result result_type;
+ 	Result operator()(const Arg &x) const { return x >> shift; }
+ };
+ 
+@@ -491,8 +501,10 @@ private:
+ };
+ 
+ template <typename Arg, typename Result>
+-struct floatToFloat : public std::unary_function<Arg, Result>
++struct floatToFloat
+ {
++	typedef Arg argument_type;
++	typedef Result result_type;
+ 	Result operator()(Arg x) const { return x; }
+ };
+ 


### PR DESCRIPTION
Adds the patch from the bug to the tree.

Closes: https://bugs.gentoo.org/914349