### PR TITLE
net-misc/vmnet: replace missing function with posix one, for musl

### DIFF
--- a/net-misc/vmnet/files/vmnet-0.4-replace-missing-musl-function.patch
+++ b/net-misc/vmnet/files/vmnet-0.4-replace-missing-musl-function.patch
@@ -1,0 +1,20 @@
+diff -ru vmnet-0.4.orig/vmnet.c vmnet-0.4/vmnet.c
+--- vmnet-0.4.orig/vmnet.c	2024-04-02 08:35:41.521216356 +0000
++++ vmnet-0.4/vmnet.c	2024-04-02 08:37:34.760604906 +0000
+@@ -50,6 +50,7 @@
+  */
+ 
+ #define _GNU_SOURCE
++#define _XOPEN_SOURCE 700
+ #include <errno.h>
+ #include <fcntl.h>
+ #include <pwd.h>
+@@ -197,7 +198,7 @@
+ 	int master, slave;
+ 	char name[1024];
+ 
+-	master = getpt();
++	master = posix_openpt(O_RDWR);
+ 	if (master < 0) {
+ 		return 0;
+ 	}

--- a/net-misc/vmnet/vmnet-0.4-r1.ebuild
+++ b/net-misc/vmnet/vmnet-0.4-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -25,6 +25,7 @@ DEPEND="${RDEPEND}"
 PATCHES=(
 	"${WORKDIR}"/${P/-/_}-1.diff
 	"${FILESDIR}"/${PN}-0.4-Fix-build-with-Clang-16.patch
+	"${FILESDIR}"/${PN}-0.4-replace-missing-musl-function.patch
 )
 
 src_compile() {


### PR DESCRIPTION
I'd rather drop this package, instead.

Closes: https://bugs.gentoo.org/897956
Closes: https://bugs.gentoo.org/907888