### PR TITLE
dev-python/pyopengl_accelerate: enable python3_12

### DIFF
--- a/dev-python/pyopengl_accelerate/pyopengl_accelerate-3.1.7.ebuild
+++ b/dev-python/pyopengl_accelerate/pyopengl_accelerate-3.1.7.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 DISTUTILS_EXT=1
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{10..11} )
+PYTHON_COMPAT=( python3_{10..12} )
 
 inherit distutils-r1
 


### PR DESCRIPTION
needed for x11-wm/xpra-5

Bug: https://bugs.gentoo.org/912679