### PR TITLE
profiles: remove dev-games/mygui mask

### DIFF
--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -156,11 +156,6 @@ dev-python/prov
 # Removal on 2024-04-22.  Bug #892613.
 dev-python/sphinxcontrib-asyncio
 
-# Alexey Sokolov <alexey+gentoo@asokolov.org> (2023-03-23)
-# Source incompatible with mygui-3.4.1
-# https://bugs.gentoo.org/927634
->=dev-games/mygui-3.4.3
-
 # Conrad Kostecki <conikost@gentoo.org> (2024-03-22)
 # Stuck on old EAPI6. Last stable release over 10 years ago.
 # Not compatible with PHP8. Removal on 2024-04-22.


### PR DESCRIPTION
The only revdep is games-engines/openmw, and that one already has correct </>= deps on specific versions of dev-games/mygui.

Closes: https://bugs.gentoo.org/927634