### PR TITLE
x11-libs/libdrm: add hppa symbol-check patch

### DIFF
--- a/x11-libs/libdrm/files/libdrm-2.4.120-backport-pr353.patch
+++ b/x11-libs/libdrm/files/libdrm-2.4.120-backport-pr353.patch
@@ -1,0 +1,62 @@
+https://bugs.gentoo.org/927204
+https://gitlab.freedesktop.org/mesa/drm/-/merge_requests/353
+
+From 525e80447fee011734af464b3b5d478b2b7b17af Mon Sep 17 00:00:00 2001
+From: Matt Turner <mattst88@gmail.com>
+Date: Fri, 22 Mar 2024 11:20:17 -0400
+Subject: [PATCH 1/2] symbols-check: Add _GLOBAL_OFFSET_TABLE_
+
+This is exported on hppa/parisc.
+
+See also: https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/26978
+
+Bug: https://bugs.gentoo.org/927204
+---
+ symbols-check.py | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/symbols-check.py b/symbols-check.py
+index 2e7ba68d1..47bc3bead 100644
+--- a/symbols-check.py
++++ b/symbols-check.py
+@@ -7,6 +7,7 @@ import subprocess
+ 
+ # This list contains symbols that _might_ be exported for some platforms
+ PLATFORM_SYMBOLS = [
++    '_GLOBAL_OFFSET_TABLE_',
+     '__bss_end__',
+     '__bss_start__',
+     '__bss_start',
+-- 
+GitLab
+
+
+From c45ffb1edf19faff79238934abe01fd92e9e3d0a Mon Sep 17 00:00:00 2001
+From: Matt Turner <mattst88@gmail.com>
+Date: Fri, 22 Mar 2024 11:21:39 -0400
+Subject: [PATCH 2/2] symbols-check: Add _fbss, _fdata, _ftext
+
+These are exported on mips/mips64.
+
+See also: https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/11955
+---
+ symbols-check.py | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/symbols-check.py b/symbols-check.py
+index 47bc3bead..c63c0d112 100644
+--- a/symbols-check.py
++++ b/symbols-check.py
+@@ -17,6 +17,9 @@ PLATFORM_SYMBOLS = [
+     '_end',
+     '_fini',
+     '_init',
++    '_fbss',
++    '_fdata',
++    '_ftext',
+ ]
+ 
+ 
+-- 
+GitLab
+

--- a/x11-libs/libdrm/libdrm-2.4.120.ebuild
+++ b/x11-libs/libdrm/libdrm-2.4.120.ebuild
@@ -42,6 +42,8 @@ RDEPEND="${COMMON_DEPEND}
 BDEPEND="${PYTHON_DEPS}
 	$(python_gen_any_dep 'dev-python/docutils[${PYTHON_USEDEP}]')"
 
+PATCHES=( "${FILESDIR}/${PN}-2.4.120-backport-pr353.patch" )
+
 python_check_deps() {
 	python_has_version "dev-python/docutils[${PYTHON_USEDEP}]"
 }


### PR DESCRIPTION
See: https://gitlab.freedesktop.org/mesa/drm/-/merge_requests/353
Closes: https://bugs.gentoo.org/927204

No revbump since this is test-only fix.