### PR TITLE
meson.eclass: updates

### DIFF
--- a/dev-libs/efl/efl-1.27.0.ebuild
+++ b/dev-libs/efl/efl-1.27.0.ebuild
@@ -155,8 +155,6 @@ src_prepare() {
 
 src_configure() {
 	local emesonargs=(
-		-Dbuildtype=plain
-
 		-D buffer=false
 		-D build-tests=false
 		-D cocoa=false

--- a/dev-libs/glib/glib-2.78.4-r1.ebuild
+++ b/dev-libs/glib/glib-2.78.4-r1.ebuild
@@ -188,8 +188,6 @@ multilib_src_configure() {
 	#fi
 
 	local emesonargs=(
-		-Dbuildtype=plain
-
 		$(meson_feature debug glib_debug)
 		-Ddefault_library=$(usex static-libs both shared)
 		-Druntime_dir="${EPREFIX}"/run

--- a/dev-libs/glib/glib-2.78.4-r1.ebuild
+++ b/dev-libs/glib/glib-2.78.4-r1.ebuild
@@ -188,7 +188,9 @@ multilib_src_configure() {
 	#fi
 
 	local emesonargs=(
-		-Dbuildtype=$(usex debug debug plain)
+		-Dbuildtype=plain
+
+		$(meson_feature debug glib_debug)
 		-Ddefault_library=$(usex static-libs both shared)
 		-Druntime_dir="${EPREFIX}"/run
 		$(meson_feature selinux)

--- a/dev-util/intel_clc/intel_clc-24.0.2.ebuild
+++ b/dev-util/intel_clc/intel_clc-24.0.2.ebuild
@@ -59,6 +59,8 @@ pkg_setup() {
 src_configure() {
 	PKG_CONFIG_PATH="$(get_llvm_prefix)/$(get_libdir)/pkgconfig"
 
+	use debug && EMESON_BUILDTYPE=debug
+
 	local emesonargs=(
 		-Dllvm=enabled
 		-Dshared-llvm=enabled
@@ -75,7 +77,6 @@ src_configure() {
 		-Dlibunwind=disabled
 		-Dzstd=disabled
 
-		-Dbuildtype=$(usex debug debug plain)
 		-Db_ndebug=$(usex debug false true)
 	)
 	meson_src_configure

--- a/dev-util/intel_clc/intel_clc-9999.ebuild
+++ b/dev-util/intel_clc/intel_clc-9999.ebuild
@@ -59,6 +59,8 @@ pkg_setup() {
 src_configure() {
 	PKG_CONFIG_PATH="$(get_llvm_prefix)/$(get_libdir)/pkgconfig"
 
+	use debug && EMESON_BUILDTYPE=debug
+
 	local emesonargs=(
 		-Dllvm=enabled
 		-Dshared-llvm=enabled
@@ -75,7 +77,6 @@ src_configure() {
 		-Dlibunwind=disabled
 		-Dzstd=disabled
 
-		-Dbuildtype=$(usex debug debug plain)
 		-Db_ndebug=$(usex debug false true)
 	)
 	meson_src_configure

--- a/eclass/meson.eclass
+++ b/eclass/meson.eclass
@@ -435,8 +435,9 @@ meson_src_configure() {
 meson_src_compile() {
 	debug-print-function ${FUNCNAME} "$@"
 
+	pushd "${BUILD_DIR}" > /dev/null || die
+
 	local mesoncompileargs=(
-		-C "${BUILD_DIR}"
 		--jobs "$(get_makeopts_jobs 0)"
 		--load-average "$(get_makeopts_loadavg 0)"
 	)
@@ -451,6 +452,8 @@ meson_src_compile() {
 	set -- meson compile "${mesoncompileargs[@]}"
 	echo "$@" >&2
 	"$@" || die -n "compile failed"
+
+	popd > /dev/null || die
 }
 
 # @FUNCTION: meson_src_test
@@ -460,9 +463,10 @@ meson_src_compile() {
 meson_src_test() {
 	debug-print-function ${FUNCNAME} "$@"
 
+	pushd "${BUILD_DIR}" > /dev/null || die
+
 	local mesontestargs=(
 		--print-errorlogs
-		-C "${BUILD_DIR}"
 		--num-processes "$(makeopts_jobs "${MAKEOPTS}")"
 		"$@"
 	)
@@ -470,6 +474,8 @@ meson_src_test() {
 	set -- meson test "${mesontestargs[@]}"
 	echo "$@" >&2
 	"$@" || die -n "tests failed"
+
+	popd > /dev/null || die
 }
 
 # @FUNCTION: meson_install
@@ -479,8 +485,9 @@ meson_src_test() {
 meson_install() {
 	debug-print-function ${FUNCNAME} "$@"
 
+	pushd "${BUILD_DIR}" > /dev/null || die
+
 	local mesoninstallargs=(
-		-C "${BUILD_DIR}"
 		--destdir "${D}"
 		--no-rebuild
 		"$@"
@@ -489,6 +496,8 @@ meson_install() {
 	set -- meson install "${mesoninstallargs[@]}"
 	echo "$@" >&2
 	"$@" || die -n "install failed"
+
+	popd > /dev/null || die
 }
 
 # @FUNCTION: meson_src_install

--- a/eclass/meson.eclass
+++ b/eclass/meson.eclass
@@ -425,7 +425,7 @@ meson_src_configure() {
 		export -n {C,CPP,CXX,F,OBJC,OBJCXX,LD}FLAGS PKG_CONFIG_{LIBDIR,PATH}
 		echo meson setup "${MESONARGS[@]}" >&2
 		meson setup "${MESONARGS[@]}"
-	) || die
+	) || die -n
 }
 
 # @FUNCTION: meson_src_compile
@@ -450,7 +450,7 @@ meson_src_compile() {
 
 	set -- meson compile "${mesoncompileargs[@]}"
 	echo "$@" >&2
-	"$@" || die "compile failed"
+	"$@" || die -n "compile failed"
 }
 
 # @FUNCTION: meson_src_test
@@ -469,7 +469,7 @@ meson_src_test() {
 
 	set -- meson test "${mesontestargs[@]}"
 	echo "$@" >&2
-	"$@" || die "tests failed"
+	"$@" || die -n "tests failed"
 }
 
 # @FUNCTION: meson_install
@@ -488,7 +488,7 @@ meson_install() {
 
 	set -- meson install "${mesoninstallargs[@]}"
 	echo "$@" >&2
-	"$@" || die "install failed"
+	"$@" || die -n "install failed"
 }
 
 # @FUNCTION: meson_src_install

--- a/media-libs/mesa-amber/mesa-amber-21.3.9-r1.ebuild
+++ b/media-libs/mesa-amber/mesa-amber-21.3.9-r1.ebuild
@@ -157,6 +157,8 @@ multilib_src_configure() {
 		echo "${drivers//$'\n'/,}"
 	}
 
+	use debug && EMESON_BUILDTYPE=debug
+
 	emesonargs+=(
 		-Damber=true
 		$(meson_use test build-tests)
@@ -177,7 +179,6 @@ multilib_src_configure() {
 		-Ddri-drivers=$(driver_list "${DRI_DRIVERS[*]}")
 		-Dgallium-drivers=''
 		-Dvulkan-drivers=''
-		-Dbuildtype=$(usex debug debug plain)
 		-Db_ndebug=$(usex debug false true)
 	)
 	meson_src_configure

--- a/media-libs/mesa/mesa-24.0.2.ebuild
+++ b/media-libs/mesa/mesa-24.0.2.ebuild
@@ -383,6 +383,8 @@ multilib_src_configure() {
 		emesonargs+=(-Dglx=disabled)
 	fi
 
+	use debug && EMESON_BUILDTYPE=debug
+
 	emesonargs+=(
 		$(meson_use test build-tests)
 		-Dshared-glapi=enabled
@@ -402,7 +404,6 @@ multilib_src_configure() {
 		-Dvideo-codecs=$(usex proprietary-codecs "all" "all_free")
 		-Dgallium-drivers=$(driver_list "${GALLIUM_DRIVERS[*]}")
 		-Dvulkan-drivers=$(driver_list "${VULKAN_DRIVERS[*]}")
-		-Dbuildtype=$(usex debug debug plain)
 		-Db_ndebug=$(usex debug false true)
 	)
 	meson_src_configure

--- a/media-libs/mesa/mesa-9999.ebuild
+++ b/media-libs/mesa/mesa-9999.ebuild
@@ -369,6 +369,8 @@ multilib_src_configure() {
 		emesonargs+=(-Dglx=disabled)
 	fi
 
+	use debug && EMESON_BUILDTYPE=debug
+
 	emesonargs+=(
 		$(meson_use test build-tests)
 		-Dshared-glapi=enabled
@@ -390,7 +392,6 @@ multilib_src_configure() {
 		-Dvideo-codecs=$(usex proprietary-codecs "all" "all_free")
 		-Dgallium-drivers=$(driver_list "${GALLIUM_DRIVERS[*]}")
 		-Dvulkan-drivers=$(driver_list "${VULKAN_DRIVERS[*]}")
-		-Dbuildtype=$(usex debug debug plain)
 		-Db_ndebug=$(usex debug false true)
 	)
 	meson_src_configure

--- a/media-libs/rubberband/rubberband-3.3.0-r1.ebuild
+++ b/media-libs/rubberband/rubberband-3.3.0-r1.ebuild
@@ -33,6 +33,8 @@ BDEPEND="
 	test? ( dev-libs/boost[${MULTILIB_USEDEP}] )
 "
 
+EMESON_BUILDTYPE=release
+
 src_prepare() {
 	sed -i \
 		-e "s/if have_jni/if get_option('jni')/g" \
@@ -60,7 +62,6 @@ multilib_src_configure() {
 	fi
 
 	local emesonargs=(
-		-Dbuildtype=release
 		-Dfft=fftw
 		-Dresampler=libsamplerate
 		-Ddefault_library=$(use static-libs && echo "both" || echo "shared")

--- a/sys-apps/systemd-utils/systemd-utils-255.4.ebuild
+++ b/sys-apps/systemd-utils/systemd-utils-255.4.ebuild
@@ -253,7 +253,7 @@ multilib_src_configure() {
 }
 
 multilib_src_compile() {
-	local targets=()
+	local targets=() optional_targets=()
 	if multilib_is_native_abi; then
 		if use boot; then
 			local efi_arch= efi_arch_alt=
@@ -275,7 +275,10 @@ multilib_src_compile() {
 				src/boot/efi/addon${efi_arch}.efi.stub
 			)
 			if [[ -n ${efi_arch_alt} ]]; then
-				targets+=(
+				# If we have a multilib toolchain, meson.build will build the
+				# "alt" arch (ia32). There's no easy way to detect this, so try
+				# to build it and ignore failure.
+				optional_targets+=(
 					src/boot/efi/systemd-boot${efi_arch_alt}.efi
 					src/boot/efi/linux${efi_arch_alt}.efi.stub
 					src/boot/efi/addon${efi_arch_alt}.efi.stub
@@ -392,8 +395,11 @@ multilib_src_compile() {
 			)
 		fi
 	fi
-	if multilib_is_native_abi || use udev; then
+	if [[ ${#targets[@]} -ne 0 ]]; then
 		meson_src_compile "${targets[@]}"
+	fi
+	if [[ ${#optional_targets[@]} -ne 0 ]]; then
+		nonfatal meson_src_compile "${optional_targets[@]}"
 	fi
 }
 

--- a/sys-auth/elogind/elogind-252.9.ebuild
+++ b/sys-auth/elogind/elogind-252.9.ebuild
@@ -97,6 +97,8 @@ src_configure() {
 
 	python_setup
 
+	EMESON_BUILDTYPE="$(usex debug debug release)"
+
 	local emesonargs=(
 		-Ddocdir="${EPREFIX}/usr/share/doc/${PF}"
 		-Dhtmldir="${EPREFIX}/usr/share/doc/${PF}/html"
@@ -114,7 +116,6 @@ src_configure() {
 		-Ddefault-kill-user-processes=false
 		-Dacl=$(usex acl true false)
 		-Daudit=$(usex audit true false)
-		-Dbuildtype=$(usex debug debug release)
 		-Dhtml=$(usex doc auto false)
 		-Dpam=$(usex pam true false)
 		-Dselinux=$(usex selinux true false)

--- a/x11-base/xorg-server/xorg-server-21.1.11.ebuild
+++ b/x11-base/xorg-server/xorg-server-21.1.11.ebuild
@@ -110,13 +110,14 @@ src_configure() {
 	# bug #835653
 	use x86 && replace-flags -Os -O2
 
+	use debug && EMESON_BUILDTYPE=debug
+
 	# localstatedir is used for the log location; we need to override the default
 	#	from ebuild.sh
 	# sysconfdir is used for the xorg.conf location; same applies
 	local emesonargs=(
 		--localstatedir "${EPREFIX}/var"
 		--sysconfdir "${EPREFIX}/etc/X11"
-		-Dbuildtype=$(usex debug debug plain)
 		-Db_ndebug=$(usex debug false true)
 		$(meson_use !minimal dri1)
 		$(meson_use !minimal dri2)

--- a/x11-base/xorg-server/xorg-server-9999.ebuild
+++ b/x11-base/xorg-server/xorg-server-9999.ebuild
@@ -105,13 +105,14 @@ src_configure() {
 	# bug #835653
 	use x86 && replace-flags -Os -O2
 
+	use debug && EMESON_BUILDTYPE=debug
+
 	# localstatedir is used for the log location; we need to override the default
 	#	from ebuild.sh
 	# sysconfdir is used for the xorg.conf location; same applies
 	local emesonargs=(
 		--localstatedir "${EPREFIX}/var"
 		--sysconfdir "${EPREFIX}/etc/X11"
-		-Dbuildtype=$(usex debug debug plain)
 		-Db_ndebug=$(usex debug false true)
 		$(meson_use !minimal dri1)
 		$(meson_use !minimal dri2)

--- a/x11-wm/mutter/mutter-45.2-r1.ebuild
+++ b/x11-wm/mutter/mutter-45.2-r1.ebuild
@@ -152,6 +152,8 @@ python_check_deps() {
 }
 
 src_configure() {
+	use debug && EMESON_BUILDTYPE=debug
+
 	local emesonargs=(
 		# Mutter X11 renderer only supports gles2 and GLX, thus do NOT pass
 		#
@@ -166,7 +168,6 @@ src_configure() {
 		# - https://bugs.gentoo.org/835786
 		# - https://forums.gentoo.org/viewtopic-p-8695669.html
 
-		-Dbuildtype=$(usex debug debug plain)
 		-Dopengl=true
 		$(meson_use wayland gles2)
 		#gles2_libname

--- a/x11-wm/mutter/mutter-9999.ebuild
+++ b/x11-wm/mutter/mutter-9999.ebuild
@@ -150,6 +150,8 @@ python_check_deps() {
 }
 
 src_configure() {
+	use debug && EMESON_BUILDTYPE=debug
+
 	local emesonargs=(
 		# Mutter X11 renderer only supports gles2 and GLX, thus do NOT pass
 		#
@@ -164,7 +166,6 @@ src_configure() {
 		# - https://bugs.gentoo.org/835786
 		# - https://forums.gentoo.org/viewtopic-p-8695669.html
 
-		-Dbuildtype=$(usex debug debug plain)
 		-Dopengl=true
 		$(meson_use wayland gles2)
 		#gles2_libname


### PR DESCRIPTION
The principal thing here for me is my commit:
- [meson.eclass: set working directory to BUILD_DIR](https://github.com/gentoo/gentoo/commit/c8e49fbe4dc3ca48bd0fb1df6e24a02b3582e7b0)

In the interest of batching metadata updates, I also added the changes proposed here: https://public-inbox.gentoo.org/gentoo-dev/20240326150152.1932785-1-floppym@gentoo.org/T/

- [meson.eclass: call die -n in phase helpers](https://github.com/gentoo/gentoo/commit/ca0982e360a57df5c074b1dc9c4216f377c5ca06)
- [sys-apps/systemd-utils: add workaround for no-multilib](https://github.com/gentoo/gentoo/commit/081cd0ab664b0135b28d1ef0a512d12b7dc414f4)


and also included #35593 since it performs a mass update of ebuilds that would be affected by this:
- [dev-libs/glib: set glib_debug rather than buildtype](https://github.com/gentoo/gentoo/commit/ecf6be402664579dfe151229691d7791b8cca8a2)
- [*/*: -Dbuildtype -> EMESON_BUILDTYPE](https://github.com/gentoo/gentoo/commit/cb7dbd4cbc2d754ce082732de13acf775d4403a0)


/cc @thesamesam @floppym @mgorny @mjsir911