### PR TITLE
net-misc/sunshine: fix broken systemd user service

### DIFF
--- a/net-misc/sunshine/sunshine-0.22.2-r1.ebuild
+++ b/net-misc/sunshine/sunshine-0.22.2-r1.ebuild
@@ -350,6 +350,7 @@ src_configure() {
 		-DSUNSHINE_REQUIRE_TRAY=$(usex trayicon)
 		-DSUNSHINE_SYSTEM_WAYLAND_PROTOCOLS=yes
 		-DSYSTEMD_USER_UNIT_INSTALL_DIR=$(systemd_get_userunitdir)
+		-DSUNSHINE_EXECUTABLE_PATH=/usr/bin/sunshine
 		-DUDEV_RULES_INSTALL_DIR=$(get_udevdir)/rules.d
 	)
 	CMAKE_USE_DIR="${S}" cmake_src_configure


### PR DESCRIPTION
The [systemd service unit file](https://github.com/LizardByte/Sunshine/blob/2da6fb050af2d0f46374e620cf13842fdbf06cb1/packaging/linux/sunshine.service.in#L10) of sunshine requires proper `SUNSHINE_EXECUTABLE_PATH` option. We can pass `/usr/bin/sunshine` for it just like [the official Arch PKGBUILD](https://github.com/LizardByte/Sunshine/blob/2da6fb050af2d0f46374e620cf13842fdbf06cb1/packaging/linux/Arch/PKGBUILD#L77).