### PR TITLE
media-sound/streamripper: Fix includes and wrongly named C99 types

### DIFF
--- a/media-sound/streamripper/files/streamripper-1.64.6-fix-c99.patch
+++ b/media-sound/streamripper/files/streamripper-1.64.6-fix-c99.patch
@@ -1,0 +1,43 @@
+We live in modern world and have ANSI C here. Plus, nothing defines ANSI_PROTOTYPES
+Include unconditionally
+diff -ru '--exclude=*.o' streamripper-1.64.6.orig/lib/argv.c streamripper-1.64.6/lib/argv.c
+--- streamripper-1.64.6.orig/lib/argv.c	2024-04-03 16:06:09.968107390 +0000
++++ streamripper-1.64.6/lib/argv.c	2024-04-03 16:08:19.399346736 +0000
+@@ -52,25 +52,10 @@
+ 
+ /*  Routines imported from standard C runtime libraries. */
+ 
+-#ifdef ANSI_PROTOTYPES
+-
+ #include <stddef.h>
+ #include <string.h>
+ #include <stdlib.h>
+ 
+-#else	/* !ANSI_PROTOTYPES */
+-
+-#if !defined _WIN32 || defined __GNUC__
+-extern char *memcpy ();		/* Copy memory region */
+-extern int strlen ();		/* Count length of string */
+-extern char *malloc ();		/* Standard memory allocater */
+-extern char *realloc ();	/* Standard memory reallocator */
+-extern void free ();		/* Free malloc'd memory */
+-extern char *strdup ();		/* Duplicate a string */
+-#endif
+-
+-#endif	/* ANSI_PROTOTYPES */
+-
+ 
+ #ifndef NULL
+ #define NULL 0
+diff -ru streamripper-1.64.6.orig/lib/ripstream.c streamripper-1.64.6/lib/ripstream.c
+--- streamripper-1.64.6.orig/lib/ripstream.c	2024-04-03 16:17:53.035975536 +0000
++++ streamripper-1.64.6/lib/ripstream.c	2024-04-03 16:23:36.372938434 +0000
+@@ -714,7 +714,7 @@
+     char bigbuf[HEADER_SIZE] = "";
+     ID3V2frame id3v2frame;
+ #ifndef WIN32
+-    __uint32_t framesize = 0;
++    uint32_t framesize = 0;
+ #else
+     unsigned long int framesize = 0;
+ #endif

--- a/media-sound/streamripper/streamripper-1.64.6-r1.ebuild
+++ b/media-sound/streamripper/streamripper-1.64.6-r1.ebuild
@@ -1,0 +1,45 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools
+
+DESCRIPTION="Extracts and records individual MP3 file tracks from shoutcast streams"
+HOMEPAGE="https://streamripper.sourceforge.net"
+SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
+IUSE="vorbis"
+
+RDEPEND="
+	media-libs/libmad
+	media-libs/faad2
+	>=dev-libs/glib-2.16
+	vorbis? ( media-libs/libvorbis )"
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-fix-autotools.patch
+	"${FILESDIR}"/${P}-fix-c99.patch
+)
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_configure() {
+	econf \
+		--without-included-libmad \
+		--without-included-argv \
+		$(use_with vorbis ogg)
+}
+
+src_install() {
+	default
+	dodoc parse_rules.txt
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/896432
Closes: https://bugs.gentoo.org/713314