### PR TITLE
x11-misc/zim, x11-plugins/wm*: add missing remote-id

### DIFF
--- a/x11-misc/zim/metadata.xml
+++ b/x11-misc/zim/metadata.xml
@@ -5,13 +5,16 @@
 		<email>voyageur@gentoo.org</email>
 		<name>Bernard Cafarelli</name>
 	</maintainer>
-<longdescription lang="en">
-Zim is a graphical text editor used to maintain a collection of wiki pages.
-Each page can contain links to other pages, simple formatting and images. Pages
-are stored in a folder structure, like in an outliner, and can have
-attachments. Creating a new page is as easy as linking to a nonexistent page.
-All data is stored in plain text files with wiki formatting. Various plugins
-provide additional functionality, like a task list manager, an equation editor,
-a tray icon, and support for version control.
-</longdescription>
+	<longdescription lang="en">
+		Zim is a graphical text editor used to maintain a collection of wiki pages.
+		Each page can contain links to other pages, simple formatting and images. Pages
+		are stored in a folder structure, like in an outliner, and can have
+		attachments. Creating a new page is as easy as linking to a nonexistent page.
+		All data is stored in plain text files with wiki formatting. Various plugins
+		provide additional functionality, like a task list manager, an equation editor,
+		a tray icon, and support for version control.
+	</longdescription>
+	<upstream>
+		<remote-id type="github">zim-desktop-wiki/zim-desktop-wiki</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/x11-plugins/wmamixer/metadata.xml
+++ b/x11-plugins/wmamixer/metadata.xml
@@ -1,14 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<maintainer type="person">
-	<email>voyageur@gentoo.org</email>
-	<name>Bernard Cafarelli</name>
-</maintainer>
+	<maintainer type="person">
+		<email>voyageur@gentoo.org</email>
+		<name>Bernard Cafarelli</name>
+	</maintainer>
+	<longdescription>
+		Wmamixer is a fork of wmsmixer and is an ALSA mixer dockapp for Window Maker.
 
-<longdescription>
-Wmamixer is a fork of wmsmixer and is an ALSA mixer dockapp for Window Maker.
-
-The code for the ALSA part was taken and adapted from amixer and alsamixer programs from alsa-utils package.
-</longdescription>
+		The code for the ALSA part was taken and adapted from amixer and alsamixer programs from alsa-utils package.
+	</longdescription>
+	<upstream>
+		<remote-id type="github">gryf/wmamixer</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/x11-plugins/wmblob/metadata.xml
+++ b/x11-plugins/wmblob/metadata.xml
@@ -5,4 +5,7 @@
 		<email>voyageur@gentoo.org</email>
 		<name>Bernard Cafarelli</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">bbidulock/wmblob</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/x11-plugins/wmnetload/metadata.xml
+++ b/x11-plugins/wmnetload/metadata.xml
@@ -6,11 +6,14 @@
 		<name>Bernard Cafarelli</name>
 	</maintainer>
 	<longdescription>
-	wmnetload is a network interface monitor dockapp  for Window Maker. It is
-	designed to fit well with  dockapps like wmcpuload and wmmemmon. It tracks
-	whether the interface is functioning and displays current network interface
-	throughput, along with an auto-scaling graph of recent network activity (the
-	graph separates upstream and downstream traffic load cleanly without resorting
-	to colors).
+		wmnetload is a network interface monitor dockapp  for Window Maker. It is
+		designed to fit well with  dockapps like wmcpuload and wmmemmon. It tracks
+		whether the interface is functioning and displays current network interface
+		throughput, along with an auto-scaling graph of recent network activity (the
+		graph separates upstream and downstream traffic load cleanly without resorting
+		to colors).
 	</longdescription>
+	<upstream>
+		<remote-id type="github">bbidulock/wmnetload</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/x11-plugins/wmsystray/metadata.xml
+++ b/x11-plugins/wmsystray/metadata.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<maintainer type="person">
-	<email>voyageur@gentoo.org</email>
-	<name>Bernard Cafarelli</name>
-</maintainer>
-
+	<maintainer type="person">
+		<email>voyageur@gentoo.org</email>
+		<name>Bernard Cafarelli</name>
+	</maintainer>
+	<upstream>
+		<remote-id type="github">bbidulock/wmsystray</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/x11-plugins/wmtimer/metadata.xml
+++ b/x11-plugins/wmtimer/metadata.xml
@@ -1,15 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<maintainer type="person">
-	<email>voyageur@gentoo.org</email>
-	<name>Bernard Cafarelli</name>
-</maintainer>
-
-<longdescription>
-WMTimer is a dockable alarm clock for Windowmaker or Blackbox which can be run 
-in alarm, countdown timer, or chronograph mode. In alarm or timer mode, you can 
-either execute a command or sound the system bell when the time is reached. 
-WMTimer is configurable through the command line or the GTK GUI.
-</longdescription>
+	<maintainer type="person">
+		<email>voyageur@gentoo.org</email>
+		<name>Bernard Cafarelli</name>
+	</maintainer>
+	<longdescription>
+		WMTimer is a dockable alarm clock for Windowmaker or Blackbox which can be run 
+		in alarm, countdown timer, or chronograph mode. In alarm or timer mode, you can 
+		either execute a command or sound the system bell when the time is reached. 
+		WMTimer is configurable through the command line or the GTK GUI.
+	</longdescription>
+	<upstream>
+		<remote-id type="github">bbidulock/wmtimer</remote-id>
+	</upstream>
 </pkgmetadata>


### PR DESCRIPTION
Hi @voyageur 

I've update some of your packages `metadata.xml` to include missing remote-id's. Also updated some of the indentations.