### PR TITLE
media-sound/alacenc-0.4.0: fix musl build

### DIFF
--- a/media-sound/alacenc/alacenc-0.4.0.ebuild
+++ b/media-sound/alacenc/alacenc-0.4.0.ebuild
@@ -15,6 +15,10 @@ KEYWORDS="~amd64 ~x86"
 
 BDEPEND="virtual/pkgconfig"
 
+PATCHES=(
+	"${FILESDIR}/${P}-musl.patch"
+)
+
 src_install() {
 	dobin "${BUILD_DIR}/alacenc"
 	einstalldocs

--- a/media-sound/alacenc/files/alacenc-0.4.0-musl.patch
+++ b/media-sound/alacenc/files/alacenc-0.4.0-musl.patch
@@ -1,0 +1,30 @@
+# Include endian.h because otherwise constants like BYTE_ORDER,
+# LITTLE_ENDIAN or BIG_ENDIAN as well as functions like
+# toBigEndian are missing when building with musl.
+# On glibc these symbols are present without including
+# endian.h, however including it anyway is fine.
+#
+# Related bug: https://bugs.gentoo.org/927902
+--- a/types.h
++++ b/types.h
+@@ -40,6 +40,7 @@
+ #include <fstream>
+ #include <array>
+ #include <cstdint>
++#include <endian.h>
+ 
+ class Error : public std::runtime_error
+ {
+# There is no typedef for uint in musl, so replace it
+# Upstream PR: https://github.com/flacon/alacenc/pull/4
+--- a/atoms.cpp
++++ b/atoms.cpp
+@@ -655,7 +655,7 @@ OutFile &operator<<(OutFile &os, const FreeAtom &atom)
+ {
+     os << uint32_t(atom.mSize);
+     os << "free";
+-    for (uint i = 0; i < atom.mSize - 8; ++i) {
++    for (unsigned int i = 0; i < atom.mSize - 8; ++i) {
+         os << '\0';
+     }
+     return os;


### PR DESCRIPTION
- Add patch for including missing endian.h header file.
- Replace use of 'uint' with 'unsigned int'.

Tested on default/linux/amd64/23.0/musl.
Also tested that glibc build still works.

Closes: https://bugs.gentoo.org/927902