### PR TITLE
dev-texlive/texlive-latexextra: Added svg USE flag for inkscape support

### DIFF
--- a/dev-texlive/texlive-latexextra/metadata.xml
+++ b/dev-texlive/texlive-latexextra/metadata.xml
@@ -9,4 +9,7 @@
 		<email>tex@gentoo.org</email>
 		<name>Gentoo TeX Project</name>
 	</maintainer>
+	<use>
+		<flag name="svg">Add support for SVG (Scalable Vector Graphics)</flag>
+	</use>
 </pkgmetadata>

--- a/dev-texlive/texlive-latexextra/texlive-latexextra-2023_p69752-r2.ebuild
+++ b/dev-texlive/texlive-latexextra/texlive-latexextra-2023_p69752-r2.ebuild
@@ -3954,6 +3954,8 @@ DESCRIPTION="TeXLive LaTeX additional packages"
 LICENSE="Apache-2.0 Artistic BSD BSD-2 CC-BY-2.0 CC-BY-4.0 CC-BY-SA-3.0 CC-BY-SA-4.0 CC0-1.0 FDL-1.1 GPL-1 GPL-2 GPL-2+ GPL-3 GPL-3+ LGPL-2 LGPL-3 LPPL-1.0 LPPL-1.2 LPPL-1.3 LPPL-1.3a LPPL-1.3c MIT OFL TeX-other-free public-domain"
 SLOT="0"
 KEYWORDS="~amd64 ~arm64 ~ppc ~riscv ~x86"
+IUSE="svg"
+
 COMMON_DEPEND="
 	>=dev-texlive/texlive-latexrecommended-2023
 	>=dev-texlive/texlive-pictures-2023
@@ -3963,6 +3965,9 @@ RDEPEND="
 	${COMMON_DEPEND}
 	!<dev-texlive/texlive-xetex-2023
 	>=dev-tex/minted-2.9
+	svg? (
+		 media-gfx/inkscape
+	)
 "
 PDEPEND="
 	>=dev-tex/glossaries-4.53


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/928388

I didn't try to remove the svg related files because I thought it would have added too much complexity.
Plus, according to the eclass (https://devmanual.gentoo.org/eclass-reference/texlive-module.eclass/index.html), the TEXLIVE_MODULE_CONTENTS has to be set before inherit. I am guessing it can't be modified afterwards either.

Thanks in advance!

Have a nice week!