### PR TITLE
games-arcade/xjump: Fix C99 incompatible function pointer types

### DIFF
--- a/games-arcade/xjump/files/xjump-2.7.5-c99.patch
+++ b/games-arcade/xjump/files/xjump-2.7.5-c99.patch
@@ -1,0 +1,16 @@
+Polymorphism, C way
+--- a/record.c	2024-04-04 11:22:00.801603415 +0000
++++ b/record.c	2024-04-04 11:26:16.515731335 +0000
+@@ -198,8 +198,11 @@
+ 
+ /* ソート比較関数 */
+ 
+-static int sort_cmp( record_t *r1, record_t *r2 )
++static int sort_cmp(const void *v1, const void *v2 )
+ {
++ const record_t *r1 = (const record_t *) v1;
++ const record_t *r2 = (const record_t *) v2;
++
+   if( r1->score > r2->score )
+     return -1;
+   else if( r1->score < r2->score )

--- a/games-arcade/xjump/xjump-2.7.5-r2.ebuild
+++ b/games-arcade/xjump/xjump-2.7.5-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -32,6 +32,7 @@ PATCHES=(
 	"${WORKDIR}"/debian/patches/04_makefile_respect_cflags.patch
 	"${WORKDIR}"/debian/patches/05_unneded_deps.patch
 	"${FILESDIR}"/${P}-ldflags.patch
+	"${FILESDIR}"/${P}-c99.patch
 )
 
 src_prepare() {


### PR DESCRIPTION
This is how C does polymorphism. With void*

Fix: https://bugs.gentoo.org/882927