### PR TITLE
sys-cluster/ampi: Fix missing include

### DIFF
--- a/sys-cluster/ampi/ampi-0_pre20140616.ebuild
+++ b/sys-cluster/ampi/ampi-0_pre20140616.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -15,6 +15,8 @@ KEYWORDS="amd64 arm ~arm64 ~hppa ~ia64 ~ppc ppc64 ~riscv ~sparc x86"
 
 RDEPEND="virtual/mpi"
 DEPEND="${RDEPEND}"
+
+PATCHES=( "${FILESDIR}"/"${P}"-missing-include.patch )
 
 src_prepare() {
 	default

--- a/sys-cluster/ampi/files/ampi-0_pre20140616-missing-include.patch
+++ b/sys-cluster/ampi/files/ampi-0_pre20140616-missing-include.patch
@@ -1,0 +1,10 @@
+--- a/ADtoolStubs/OO/support.c	2024-04-04 13:10:23.506762461 +0000
++++ b/ADtoolStubs/OO/support.c	2024-04-04 13:11:34.033298264 +0000
+@@ -8,6 +8,7 @@
+ */
+ #include <stdlib.h>
+ #include <assert.h>
++#include <stdio.h>
+ #include "ampi/adTool/support.h"
+ 
+ MPI_Comm ADTOOL_AMPI_COMM_WORLD_SHADOW;


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/881323