### PR TITLE
dev-texlive/texlive-latexextra: Added optfeature message for svg support

### DIFF
--- a/dev-texlive/texlive-latexextra/texlive-latexextra-2023_p69752-r2.ebuild
+++ b/dev-texlive/texlive-latexextra/texlive-latexextra-2023_p69752-r2.ebuild
@@ -3947,7 +3947,7 @@ TEXLIVE_MODULE_SRC_CONTENTS="
 	zref-vario.source.r68846
 "
 
-inherit texlive-module
+inherit optfeature texlive-module
 
 DESCRIPTION="TeXLive LaTeX additional packages"
 
@@ -3991,3 +3991,7 @@ TEXLIVE_MODULE_BINSCRIPTS="
 	texmf-dist/scripts/wordcount/wordcount.sh
 	texmf-dist/scripts/yplan/yplan
 "
+
+pkg_postinst() {
+	optfeature "Install for SVG (Scalable Vector Graphics) support" media-gfx/inkscape
+}


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/928388

This was the old PR: https://github.com/gentoo/gentoo/pull/36090

Florian suggested using optfeature instead