### PR TITLE
net-analyzer/wireshark: install headers and pkgconfig file

### DIFF
--- a/net-analyzer/wireshark/wireshark-4.2.4-r1.ebuild
+++ b/net-analyzer/wireshark/wireshark-4.2.4-r1.ebuild
@@ -282,7 +282,9 @@ src_test() {
 }
 
 src_install() {
-	cmake_src_install
+	# bug #928577
+	# https://gitlab.com/wireshark/wireshark/-/commit/fe7bfdf6caac9204ab5f34eeba7b0f4a0314d3cd
+	cmake_src_install install-headers
 
 	# FAQ is not required as is installed from help/faq.txt
 	dodoc AUTHORS ChangeLog NEWS README* doc/randpkt.txt doc/README*

--- a/net-analyzer/wireshark/wireshark-9999.ebuild
+++ b/net-analyzer/wireshark/wireshark-9999.ebuild
@@ -282,7 +282,9 @@ src_test() {
 }
 
 src_install() {
-	cmake_src_install
+	# bug #928577
+	# https://gitlab.com/wireshark/wireshark/-/commit/fe7bfdf6caac9204ab5f34eeba7b0f4a0314d3cd
+	cmake_src_install install-headers
 
 	# FAQ is not required as is installed from help/faq.txt
 	dodoc AUTHORS ChangeLog NEWS README* doc/randpkt.txt doc/README*


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/928577

```
 * CMP: =net-analyzer/wireshark-4.2.4 with net-analyzer/wireshark-4.2.4-r1/image
 *  FILES:-usr/bin/dumpcap (-rwx--x--- root:pcap)
 *  FILES:+usr/bin/dumpcap (-rwxr-xr-x root:root)
 *  FILES:+usr/include/wireshark/cfile.h
 *  FILES:+usr/include/wireshark/cli_main.h
 *  FILES:+usr/include/wireshark/file.h
 *  FILES:+usr/include/wireshark/wireshark.h
 *  FILES:+usr/include/wireshark/ws_attributes.h
 *  FILES:+usr/include/wireshark/ws_codepoints.h
 *  FILES:+usr/include/wireshark/ws_compiler_tests.h
 *  FILES:+usr/include/wireshark/ws_diag_control.h
 *  FILES:+usr/include/wireshark/ws_exit_codes.h
 *  FILES:+usr/include/wireshark/ws_log_defs.h
 *  FILES:+usr/include/wireshark/ws_posix_compat.h
 *  FILES:+usr/include/wireshark/ws_symbol_export.h
 *  FILES:+usr/include/wireshark/ws_version.h
 *  FILES:+usr/lib64/cmake/wireshark/WiresharkConfig.cmake
 *  FILES:+usr/lib64/cmake/wireshark/WiresharkConfigVersion.cmake
 *  FILES:+usr/lib64/cmake/wireshark/WiresharkTargets-relwithdebinfo.cmake
 *  FILES:+usr/lib64/cmake/wireshark/WiresharkTargets.cmake
 *  FILES:+usr/lib64/pkgconfig/wireshark.pc
 ```