### PR TITLE
sys-apps/i2c-tools: Add 32-bit LFS support

### DIFF
--- a/sys-apps/i2c-tools/i2c-tools-4.3-r2.ebuild
+++ b/sys-apps/i2c-tools/i2c-tools-4.3-r2.ebuild
@@ -36,13 +36,14 @@ src_prepare() {
 src_configure() {
 	use python && distutils-r1_src_configure
 
+	append-lfs-flags
 	export BUILD_DYNAMIC_LIB=1
 	export USE_STATIC_LIB=0
 	export BUILD_STATIC_LIB=0
 }
 
 src_compile() {
-	emake AR="$(tc-getAR)" CC="$(tc-getCC)" EXTRA="eeprog"
+	emake AR="$(tc-getAR)" CC="$(tc-getCC)" CFLAGS="${CFLAGS} ${CPPFLAGS}" EXTRA="eeprog"
 
 	if use python ; then
 		cd py-smbus || die


### PR DESCRIPTION
The i2c-tools build doesn't natively support 32-bit LFS.  Call append-lfs-flags to bring it in.

Additionally, it appears the Makefile ignores CPPFLAGS, so hack that into CFLAGS.