### PR TITLE
app-misc/jq: don't use the runpath patch

### DIFF
--- a/app-misc/jq/jq-1.7.1.ebuild
+++ b/app-misc/jq/jq-1.7.1.ebuild
@@ -30,7 +30,6 @@ RDEPEND="
 "
 PATCHES=(
 	"${FILESDIR}"/jq-1.6-r3-never-bundle-oniguruma.patch
-	"${FILESDIR}"/jq-1.7-runpath.patch
 )
 
 RESTRICT="!test? ( test )"


### PR DESCRIPTION
Note: Note slibtoolize is only available with `dev-build/slibtool-9999` currently and will be usable in the next release.

Strange patch that was added without explanation in commit ed98a0926d3e99ce9e76fb16311b491797cd1042. It also breaks the build with slibtoolize where the ./libtool script no longer exists and the sed fails.

Gentoo-Commit: https://gitweb.gentoo.org/repo/gentoo.git/commit/app-misc/jq?id=ed98a0926d3e99ce9e76fb16311b491797cd1042