### PR TITLE
net-libs/libsrsirc: Fix missing linking flag

### DIFF
--- a/net-libs/libsrsirc/files/libsrsirc-0.0.14-openssl-libs-configure.patch
+++ b/net-libs/libsrsirc/files/libsrsirc-0.0.14-openssl-libs-configure.patch
@@ -1,0 +1,20 @@
+--- libsrsirc-0.0.14.orig/configure	2024-04-04 20:07:02.865826089 +0000
++++ libsrsirc-0.0.14/configure	2024-04-04 20:08:24.153354192 +0000
+@@ -12216,7 +12216,7 @@
+   $as_echo_n "(cached) " >&6
+ else
+   ac_check_lib_save_LIBS=$LIBS
+-LIBS="-lssl  $LIBS"
++LIBS="-lssl -lcrypto $LIBS"
+ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ 
+@@ -12251,7 +12251,7 @@
+ #define HAVE_LIBSSL 1
+ _ACEOF
+ 
+-  LIBS="-lssl $LIBS"
++  LIBS="-lssl -lcrypto $LIBS"
+ 
+ else
+   as_fn_error $? "no crypto lib for ssl installed?" "$LINENO" 5

--- a/net-libs/libsrsirc/libsrsirc-0.0.14-r2.ebuild
+++ b/net-libs/libsrsirc/libsrsirc-0.0.14-r2.ebuild
@@ -15,6 +15,10 @@ IUSE="static-libs ssl"
 DEPEND="ssl? ( dev-libs/openssl:0= )"
 RDEPEND="${DEPEND}"
 
+PATCHES=(
+	"${FILESDIR}/${P}-openssl-libs-configure.patch"
+)
+
 src_configure() {
 	econf $(use_enable static-libs static) $(use_with ssl)
 }


### PR DESCRIPTION
Closes:https://bugs.gentoo.org/731260
Closes:https://bugs.gentoo.org/875275