### PR TITLE
media-gfx/pngnq: Fix passing incompatible pointer type

### DIFF
--- a/media-gfx/pngnq/files/pngnq-1.1-gcc14-build-fix.patch
+++ b/media-gfx/pngnq/files/pngnq-1.1-gcc14-build-fix.patch
@@ -1,0 +1,34 @@
+Bug: https://bugs.gentoo.org/919210
+Reported upstream: https://sourceforge.net/p/pngnq/patches/7/
+--- a/src/pngcomp.c
++++ b/src/pngcomp.c
+@@ -503,7 +503,7 @@ void printstats(struct statistics* stats, struct blockstats* bstats){
+   printf("Mean pixel color error: %f \n",stats->mean_error);
+   printf("Maximum pixel color error: %f \n",stats->max_error);
+   printf("Standard Deviation of error: %f\n",stats->stddev_error);
+-  printf("Image Dimensions %ld x %ld \n",image1_info.width,image1_info.height);
++  printf("Image Dimensions %lld x %lld \n", (long long int)image1_info.width, (long long int)image1_info.height);
+   printf("Number of pixels: %ld \n",stats->n_pixels);
+   printf("Number of exact pixels: %ld\n",stats->correct_pixels);
+   printf("Percentage correct pixels: %f\n",(float)stats->correct_pixels/(float)stats->n_pixels*100.0);
+--- a/src/rwpng.h
++++ b/src/rwpng.h
+@@ -29,6 +29,7 @@
+ 
+   ---------------------------------------------------------------------------*/
+ 
++#include "pngconf.h"
+ #ifndef TRUE
+ #  define TRUE 1
+ #  define FALSE 0
+@@ -65,8 +66,8 @@ typedef struct _rwpng_color_struct {
+ 
+ typedef struct _mainprog_info {
+     double gamma;
+-    ulg width;			/* read/write */
+-    ulg height;			/* read/write */
++    png_uint_32 width;	/* read/write */
++    png_uint_32 height;	/* read/write */
+     ulg rowbytes;		/* read */
+     void *png_ptr;		/* read/write */
+     void *info_ptr;		/* read/write */

--- a/media-gfx/pngnq/pngnq-1.1-r2.ebuild
+++ b/media-gfx/pngnq/pngnq-1.1-r2.ebuild
@@ -1,0 +1,31 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools
+
+DESCRIPTION="Pngnq is a tool for quantizing PNG images in RGBA format"
+HOMEPAGE="https://pngnq.sourceforge.net/"
+SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
+
+LICENSE="BSD pngnq rwpng"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+RDEPEND="media-libs/libpng:0="
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-1.0-libpng14.patch
+	"${FILESDIR}"/${PN}-1.0-libpng15.patch
+	"${FILESDIR}"/${PN}-1.0-Wimplicit-function-declaration.patch
+	"${FILESDIR}"/${PN}-1.1-autoconf-quoting.patch
+	"${FILESDIR}"/${PN}-1.1-gcc14-build-fix.patch
+)
+
+src_prepare() {
+	default
+	eautoreconf
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/919210