### PR TITLE
dev-libs/libotf: EAPI8 bump

### DIFF
--- a/dev-libs/libotf/libotf-0.9.16-r1.ebuild
+++ b/dev-libs/libotf/libotf-0.9.16-r1.ebuild
@@ -1,0 +1,49 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools
+
+DESCRIPTION="Library for handling OpenType fonts (OTF)"
+HOMEPAGE="https://www.nongnu.org/m17n/"
+SRC_URI="mirror://nongnu/m17n/${P}.tar.gz"
+
+LICENSE="LGPL-2.1"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86 ~amd64-linux ~x86-linux"
+IUSE="static-libs X"
+
+RDEPEND=">=media-libs/freetype-2.4.9
+	X? (
+		x11-libs/libX11
+		x11-libs/libXaw
+		x11-libs/libXt
+	)"
+DEPEND="${RDEPEND}
+	X? (
+		x11-base/xorg-proto
+		x11-libs/libICE
+		x11-libs/libXmu
+	)"
+BDEPEND="virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-0.9.13-build.patch
+	"${FILESDIR}"/${PN}-0.9.16-freetype_pkgconfig.patch
+)
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_configure() {
+	export ac_cv_header_X11_Xaw_Command_h=$(usex X)
+	econf $(use_enable static-libs static)
+}
+
+src_install() {
+	default
+	find "${ED}" -name "*.la" -delete || die
+}


### PR DESCRIPTION
pretty simple `EAPI8` bump

```diff
--- libotf-0.9.16.ebuild	2024-03-09 16:29:31.438667577 +0100
+++ libotf-0.9.16-r1.ebuild	2024-04-05 21:15:38.217539616 +0200
@@ -1,16 +1,17 @@
 # Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
+
 inherit autotools
 
 DESCRIPTION="Library for handling OpenType fonts (OTF)"
-HOMEPAGE="http://www.nongnu.org/m17n/"
+HOMEPAGE="https://www.nongnu.org/m17n/"
 SRC_URI="mirror://nongnu/m17n/${P}.tar.gz"
 
 LICENSE="LGPL-2.1"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~loong ppc ppc64 ~riscv sparc x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86 ~amd64-linux ~x86-linux"
 IUSE="static-libs X"
 
 RDEPEND=">=media-libs/freetype-2.4.9
@@ -20,14 +21,12 @@
 		x11-libs/libXt
 	)"
 DEPEND="${RDEPEND}
-	virtual/pkgconfig
 	X? (
 		x11-base/xorg-proto
 		x11-libs/libICE
 		x11-libs/libXmu
 	)"
-
-DOCS="AUTHORS ChangeLog NEWS README"
+BDEPEND="virtual/pkgconfig"
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-0.9.13-build.patch
```