### PR TITLE
x11-misc/xrootconsole: EAPI8 bump, fix LICENSE

### DIFF
--- a/x11-misc/xrootconsole/xrootconsole-0.6-r2.ebuild
+++ b/x11-misc/xrootconsole/xrootconsole-0.6-r2.ebuild
@@ -1,0 +1,43 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs
+
+DESCRIPTION="Utility that displays its input in a text box on your root window"
+HOMEPAGE="https://sourceforge.net/projects/xrootconsole/"
+SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86"
+
+RDEPEND="x11-libs/libX11"
+DEPEND="
+	${RDEPEND}
+	x11-base/xorg-proto
+"
+BDEPEND="virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}/${P}.noversion.patch"
+	"${FILESDIR}/${P}.makefile.patch"
+	"${FILESDIR}/${P}.manpage.patch"
+)
+
+src_compile() {
+	tc-export CC PKG_CONFIG
+	emake
+}
+
+src_install() {
+	dodir /usr/bin
+
+	emake \
+		MANDIR="${ED}/usr/share/man/man1" \
+		BINDIR="${ED}/usr/bin/" \
+		install
+
+	einstalldocs
+}


### PR DESCRIPTION
another simple `EAPI8` bump.

```diff
--- xrootconsole-0.6-r1.ebuild	2024-01-17 20:05:13.960811507 +0100
+++ xrootconsole-0.6-r2.ebuild	2024-04-06 16:23:20.635987066 +0200
@@ -1,26 +1,24 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
 
 inherit toolchain-funcs
 
-DESCRIPTION="A utility that displays its input in a text box on your root window"
+DESCRIPTION="Utility that displays its input in a text box on your root window"
 HOMEPAGE="https://sourceforge.net/projects/xrootconsole/"
 SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
 
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="0"
-KEYWORDS="amd64 ppc x86"
-
-RDEPEND="
-	x11-libs/libX11"
+KEYWORDS="~amd64 ~ppc ~x86"
 
+RDEPEND="x11-libs/libX11"
 DEPEND="
 	${RDEPEND}
 	x11-base/xorg-proto
-	virtual/pkgconfig
 "
+BDEPEND="virtual/pkgconfig"
 
 PATCHES=(
 	"${FILESDIR}/${P}.noversion.patch"
@@ -28,8 +26,6 @@
 	"${FILESDIR}/${P}.manpage.patch"
 )
 
-DOCS=( TODO NEWS CREDITS )
-
 src_compile() {
 	tc-export CC PKG_CONFIG
 	emake
@@ -39,8 +35,8 @@
 	dodir /usr/bin
 
 	emake \
-		MANDIR="${D}usr/share/man/man1" \
-		BINDIR="${D}usr/bin/" \
+		MANDIR="${ED}/usr/share/man/man1" \
+		BINDIR="${ED}/usr/bin/" \
 		install
 
 	einstalldocs
```