### PR TITLE
x11-plugins/pidgin-bot-sentry: EAPI8 bump, fix LICENSE

### DIFF
--- a/x11-plugins/pidgin-bot-sentry/pidgin-bot-sentry-1.3.0-r1.ebuild
+++ b/x11-plugins/pidgin-bot-sentry/pidgin-bot-sentry-1.3.0-r1.ebuild
@@ -1,26 +1,24 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
 
 MY_P="${P#pidgin-}"
 
 DESCRIPTION="Bot Sentry is a Pidgin plugin to prevent Instant Message (IM) spam"
-HOMEPAGE="http://pidgin-bs.sourceforge.net/"
+HOMEPAGE="https://sourceforge.net/projects/pidgin-bs/"
 SRC_URI="mirror://sourceforge/pidgin-bs/${MY_P}.tar.bz2"
+S="${WORKDIR}/${MY_P}"
 
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="0"
 KEYWORDS="~amd64 ~riscv ~x86"
-IUSE=""
 
 RDEPEND="net-im/pidgin[gtk]
 	x11-libs/gtk+:2"
-DEPEND="${RDEPEND}
-	>=dev-util/intltool-0.40
+DEPEND="${RDEPEND}"
+BDEPEND=">=dev-util/intltool-0.40
 	virtual/pkgconfig"
-
-S="${WORKDIR}/${MY_P}"
 
 src_install() {
 	default


### PR DESCRIPTION
another pretty simple `EAPI8` bump.