### PR TITLE
sys-apps/darwin-miscutils: EAPI8 bump, ebuild improvments

### DIFF
--- a/sys-apps/darwin-miscutils/darwin-miscutils-10-r1.ebuild
+++ b/sys-apps/darwin-miscutils/darwin-miscutils-10-r1.ebuild
@@ -1,0 +1,152 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit edo toolchain-funcs
+
+# from 10.8
+MISC_VER=31
+SHELL_VER=170
+# from 10.7.4
+DEV_VER=55
+MD_VER=147 # 148 in 10.8 has no md, bug #428530
+
+DESCRIPTION="Miscellaneous commands used on Darwin/Mac OS X systems, Mountain
+Lion 10.8"
+HOMEPAGE="
+	https://www.opensource.apple.com/
+	https://github.com/apple-oss-distributions"
+SRC_URI="
+	https://github.com/apple-oss-distributions/adv_cmds/blob/c8dbac91aa855b2d05282f45709b318f8bc3693d/md/md.1 \
+		-> adv_cmds-md-${MD_VER}.1
+	https://github.com/apple-oss-distributions/adv_cmds/blob/c8dbac91aa855b2d05282f45709b318f8bc3693d/md/md.c \
+		-> adv_cmds-md-${MD_VER}.c
+	https://opensource.apple.com/tarballs/misc_cmds/misc_cmds-${MISC_VER}.tar.gz
+	https://opensource.apple.com/tarballs/shell_cmds/shell_cmds-${SHELL_VER}.tar.gz
+	https://opensource.apple.com/tarballs/developer_cmds/developer_cmds-${DEV_VER}.tar.gz"
+S="${WORKDIR}"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~arm64-macos ~ppc-macos ~x64-macos"
+
+src_prepare() {
+	cd "${S}"/shell_cmds-${SHELL_VER} || die
+	eapply "${FILESDIR}"/${PN}-6-w64.patch
+
+	mkdir -p "${S}"/adv_cmds-${MD_VER}/md || die
+	cp "${DISTDIR}"/adv_cmds-md-${MD_VER}.c \
+		"${S}"/adv_cmds-${MD_VER}/md/md.c || die
+	cp "${DISTDIR}"/adv_cmds-md-${MD_VER}.1 \
+		"${S}"/adv_cmds-${MD_VER}/md/md.1 || die
+
+	eapply_user
+}
+
+src_compile() {
+	local flags=(
+		${CFLAGS}
+		-I.
+		-D__FBSDID=__RCSID
+		-Wsystem-headers
+		-Du_int=uint32_t
+		-include stdint.h
+		${LDFLAGS}
+	)
+
+	local TS="${S}/misc_cmds-${MISC_VER}"
+	local t
+	# tsort is provided by corepatch
+	for t in leave units calendar; do
+		cd "${TS}/${t}" || die
+		echo "in ${TS}/${t}:"
+		edo $(tc-getCC) ${flags[@]} -o ${t} *.c
+	done
+	# compile cal separately
+	cd "${TS}/ncal" || die
+	echo "in ${TS}/ncal:"
+	edo $(tc-getCC) ${flags[@]} -c calendar.c
+	edo $(tc-getCC) ${flags[@]} -c easter.c
+	edo $(tc-getCC) ${flags[@]} -c ncal.c
+	edo $(tc-getCC) ${flags[@]} -o cal calendar.o easter.o ncal.o
+
+	TS="${S}/shell_cmds-${SHELL_VER}"
+	# only pick those tools not provided by corepatch, findutils
+	for t in \
+		apply getopt hostname jot kill killall \
+		lastcomm renice script shlock time whereis;
+	do
+		echo "in ${TS}/${t}:"
+		cd "${TS}/${t}" || die
+		edo $(tc-getCC) ${flags[@]} -o ${t} ${t}.c
+	done
+	cd "${TS}/w" || die
+	sed -i -e '/#include <libutil.h>/d' w.c || die
+	echo "in ${TS}/w:"
+	edo $(tc-getCC) ${flags[@]} -DHAVE_UTMPX=1 -lresolv -o w w.c pr_time.c proc_compare.c
+
+	TS="${S}/developer_cmds-${DEV_VER}"
+	# only pick those tools that do not conflict (no ctags and indent)
+	# do not install lorder, mkdep and vgrind as they are a non-prefix-aware
+	# shell scripts
+	# don't install rpcgen, as it is heavily related to the OS it runs
+	# on (and this is the Snow Leopard version)
+	for t in asa hexdump unifdef what ; do
+		echo "in ${TS}/${t}:"
+		cd "${TS}/${t}" || die
+		edo $(tc-getCC) ${flags[@]} -o ${t} *.c
+	done
+
+	TS="${S}/adv_cmds-${MD_VER}"
+	for t in md ; do
+		echo "in ${TS}/${t}:"
+		cd "${TS}/${t}" || die
+		edo $(tc-getCC) ${flags[@]} -o ${t} *.c
+	done
+}
+
+src_install() {
+	mkdir -p "${ED}"/bin || die
+	mkdir -p "${ED}"/usr/bin || die
+
+	local TS="${S}/misc_cmds-${MISC_VER}"
+	local t
+	for t in leave units calendar ; do
+		cp "${TS}/${t}/${t}" "${ED}"/usr/bin/ || die
+		doman "${TS}/${t}/${t}.1"
+	done
+	# copy cal separately
+	cp "${TS}/ncal/cal" "${ED}"/usr/bin/ || die
+	dosym cal /usr/bin/ncal
+	doman "${TS}/ncal/ncal.1"
+	dosym ncal.1 /usr/share/man/man1/cal.1
+
+	TS="${S}/shell_cmds-${SHELL_VER}"
+	for t in \
+		apply getopt jot killall lastcomm \
+		renice script shlock time w whereis;
+	do
+		cp "${TS}/${t}/${t}" "${ED}"/usr/bin/ || die
+		[[ -f "${TS}/${t}/${t}.1" ]] && doman "${TS}/${t}/${t}.1"
+		[[ -f "${TS}/${t}/${t}.8" ]] && doman "${TS}/${t}/${t}.8"
+	done
+	cp "${TS}/w/w" "${ED}"/usr/bin/uptime || die
+	doman "${TS}/w/uptime.1"
+	for t in hostname kill; do
+		cp "${TS}/${t}/${t}" "${ED}"/bin/ || die
+		doman "${TS}/${t}/${t}.1"
+	done
+
+	TS="${S}/developer_cmds-${DEV_VER}"
+	for t in asa hexdump unifdef what ; do
+		cp "${TS}/${t}/${t}" "${ED}"/usr/bin/ || die
+		doman "${TS}/${t}/${t}.1"
+	done
+
+	TS="${S}/adv_cmds-${MD_VER}"
+	for t in md ; do
+		cp "${TS}/${t}/${t}" "${ED}"/usr/bin/ || die
+		doman "${TS}/${t}/${t}.1"
+	done
+}

--- a/sys-apps/darwin-miscutils/darwin-miscutils-11-r1.ebuild
+++ b/sys-apps/darwin-miscutils/darwin-miscutils-11-r1.ebuild
@@ -1,0 +1,153 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit edo toolchain-funcs
+
+# from macOS 10.12
+MISC_VER=33
+SHELL_VER=198
+# from DT 8.1
+DEV_VER=63
+# from 10.7.4
+MD_VER=147 # 148 in 10.8 has no md, bug #428530
+
+DESCRIPTION="Miscellaneous commands used on macOS, Sierra 10.12"
+HOMEPAGE="
+	https://www.opensource.apple.com/
+	https://github.com/apple-oss-distributions"
+SRC_URI="
+	https://github.com/apple-oss-distributions/adv_cmds/blob/c8dbac91aa855b2d05282f45709b318f8bc3693d/md/md.1 \
+		-> adv_cmds-md-${MD_VER}.1
+	https://github.com/apple-oss-distributions/adv_cmds/blob/c8dbac91aa855b2d05282f45709b318f8bc3693d/md/md.c \
+		-> adv_cmds-md-${MD_VER}.c
+	https://opensource.apple.com/tarballs/misc_cmds/misc_cmds-${MISC_VER}.tar.gz
+	https://opensource.apple.com/tarballs/shell_cmds/shell_cmds-${SHELL_VER}.tar.gz
+	https://opensource.apple.com/tarballs/developer_cmds/developer_cmds-${DEV_VER}.tar.gz"
+S="${WORKDIR}"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~arm64-macos ~ppc-macos ~x64-macos"
+
+src_prepare() {
+	cd "${S}"/shell_cmds-${SHELL_VER} || die
+	eapply "${FILESDIR}"/${PN}-6-w64.patch
+
+	mkdir -p "${S}"/adv_cmds-${MD_VER}/md || die
+	cp "${DISTDIR}"/adv_cmds-md-${MD_VER}.c \
+		"${S}"/adv_cmds-${MD_VER}/md/md.c || die
+	cp "${DISTDIR}"/adv_cmds-md-${MD_VER}.1 \
+		"${S}"/adv_cmds-${MD_VER}/md/md.1 || die
+
+	eapply_user
+}
+
+src_compile() {
+	local flags=(
+		${CFLAGS}
+		-I.
+		-D__FBSDID=__RCSID
+		-Wsystem-headers
+		-Du_int=uint32_t
+		-include stdint.h
+		${LDFLAGS}
+	)
+
+	local TS="${S}/misc_cmds-${MISC_VER}"
+	local t
+	# tsort is provided by coreutils
+	for t in leave units calendar; do
+		cd "${TS}/${t}" || die
+		echo "in ${TS}/${t}:"
+		edo $(tc-getCC) ${flags[@]} -o ${t} *.c
+	done
+	# compile cal separately
+	cd "${TS}/ncal" || die
+	echo "in ${TS}/ncal:"
+	edo $(tc-getCC) ${flags[@]} -c calendar.c
+	edo $(tc-getCC) ${flags[@]} -c easter.c
+	edo $(tc-getCC) ${flags[@]} -c ncal.c
+	edo $(tc-getCC) ${flags[@]} -o cal calendar.o easter.o ncal.o
+
+	TS="${S}/shell_cmds-${SHELL_VER}"
+	# only pick those tools not provided by coreutils, findutils
+	for t in \
+		apply getopt hexdump hostname jot kill killall \
+		lastcomm renice script shlock time whereis;
+	do
+		echo "in ${TS}/${t}:"
+		cd "${TS}/${t}" || die
+		edo $(tc-getCC) ${flags[@]} -o ${t} *.c
+	done
+	cd "${TS}/w" || die
+	sed -i -e '/#include <libutil.h>/d' w.c || die
+	echo "in ${TS}/w:"
+	edo $(tc-getCC) ${flags[@]} -DHAVE_UTMPX=1 -lresolv -o w *.c
+
+	TS="${S}/developer_cmds-${DEV_VER}"
+	# only pick those tools that do not conflict (no ctags and indent)
+	# do not install lorder, mkdep and vgrind as they are a non-prefix-aware
+	# shell scripts
+	# don't install rpcgen, as it is heavily related to the OS it runs
+	# on (and this is the Sierra version)
+	for t in asa unifdef what ; do
+		echo "in ${TS}/${t}:"
+		cd "${TS}/${t}" || die
+		edo $(tc-getCC) ${flags[@]} -o ${t} *.c
+	done
+
+	# provide this one for gcc-apple
+	TS="${S}/adv_cmds-${MD_VER}"
+	for t in md ; do
+		echo "in ${TS}/${t}:"
+		cd "${TS}/${t}" || die
+		edo $(tc-getCC) ${flags[@]} -o ${t} *.c
+	done
+}
+
+src_install() {
+	mkdir -p "${ED}"/bin || die
+	mkdir -p "${ED}"/usr/bin || die
+
+	local TS="${S}/misc_cmds-${MISC_VER}"
+	local t
+	for t in leave units calendar ; do
+		cp "${TS}/${t}/${t}" "${ED}"/usr/bin/ || die
+		doman "${TS}/${t}/${t}.1"
+	done
+	# copy cal separately
+	cp "${TS}/ncal/cal" "${ED}"/usr/bin/ || die
+	dosym cal /usr/bin/ncal
+	doman "${TS}/ncal/ncal.1"
+	dosym ncal.1 /usr/share/man/man1/cal.1
+
+	TS="${S}/shell_cmds-${SHELL_VER}"
+	for t in \
+		apply getopt hexdump hostname jot killall lastcomm \
+		renice script shlock time w whereis;
+	do
+		cp "${TS}/${t}/${t}" "${ED}"/usr/bin/ || die
+		[[ -f "${TS}/${t}/${t}.1" ]] && doman "${TS}/${t}/${t}.1"
+		[[ -f "${TS}/${t}/${t}.8" ]] && doman "${TS}/${t}/${t}.8"
+	done
+	cp "${TS}/w/w" "${ED}"/usr/bin/uptime || die
+	doman "${TS}/w/uptime.1"
+	for t in hostname kill; do
+		cp "${TS}/${t}/${t}" "${ED}"/bin/ || die
+		doman "${TS}/${t}/${t}.1"
+	done
+
+	TS="${S}/developer_cmds-${DEV_VER}"
+	for t in asa unifdef what ; do
+		cp "${TS}/${t}/${t}" "${ED}"/usr/bin/ || die
+		doman "${TS}/${t}/${t}.1"
+	done
+
+	TS="${S}/adv_cmds-${MD_VER}"
+	for t in md ; do
+		cp "${TS}/${t}/${t}" "${ED}"/usr/bin/ || die
+		doman "${TS}/${t}/${t}.1"
+	done
+}

--- a/sys-apps/darwin-miscutils/darwin-miscutils-12-r1.ebuild
+++ b/sys-apps/darwin-miscutils/darwin-miscutils-12-r1.ebuild
@@ -1,0 +1,157 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit edo toolchain-funcs
+
+# from macOS 10.13
+MISC_VER=34
+SHELL_VER=203
+# from DT 8.2.1
+DEV_VER=63
+# from 10.7.4
+MD_VER=147 # adv_cmds-148 in 10.8 has no md, bug #428530
+
+DESCRIPTION="Miscellaneous commands used on macOS, High Sierra 10.13"
+HOMEPAGE="
+	https://www.opensource.apple.com/
+	https://github.com/apple-oss-distributions"
+SRC_URI="
+	https://github.com/apple-oss-distributions/adv_cmds/blob/c8dbac91aa855b2d05282f45709b318f8bc3693d/md/md.1 \
+		-> adv_cmds-md-${MD_VER}.1
+	https://github.com/apple-oss-distributions/adv_cmds/blob/c8dbac91aa855b2d05282f45709b318f8bc3693d/md/md.c \
+		-> adv_cmds-md-${MD_VER}.c
+	https://642666.bugs.gentoo.org/attachment.cgi?id=511988 -> adv_cmds-md-${MD_VER}-compile.patch
+	https://opensource.apple.com/tarballs/misc_cmds/misc_cmds-${MISC_VER}.tar.gz
+	https://opensource.apple.com/tarballs/shell_cmds/shell_cmds-${SHELL_VER}.tar.gz
+	https://opensource.apple.com/tarballs/developer_cmds/developer_cmds-${DEV_VER}.tar.gz"
+S="${WORKDIR}"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~arm64-macos ~ppc-macos ~x64-macos"
+
+# for ncal
+DEPEND="sys-libs/ncurses:="
+RDEPEND="${DEPEND}"
+
+src_prepare() {
+	cd "${S}"/shell_cmds-${SHELL_VER} || die
+	eapply "${FILESDIR}"/${PN}-6-w64.patch
+
+	mkdir -p "${S}"/adv_cmds-${MD_VER}/md || die
+	cd "${S}"/adv_cmds-${MD_VER} || die
+	cp "${DISTDIR}"/adv_cmds-md-${MD_VER}.c md/md.c || die
+	cp "${DISTDIR}"/adv_cmds-md-${MD_VER}.1 md/md.1 || die
+	eapply "${DISTDIR}"/adv_cmds-md-${MD_VER}-compile.patch
+	eapply "${FILESDIR}"/${PN}-12-md-register.patch
+
+	cd "${S}" || die
+	eapply_user
+}
+
+src_compile() {
+	local flags=(
+		${CFLAGS}
+		-I.
+		-D__FBSDID=__RCSID
+		-Du_int=uint32_t
+		-include stdint.h
+	)
+
+	local TS="${S}/misc_cmds-${MISC_VER}"
+	local t
+	# tsort is provided by coreutils
+	for t in leave units calendar; do
+		cd "${TS}/${t}" || die
+		echo "in ${TS}/${t}:"
+		edo $(tc-getCC) ${flags[@]} -o ${t} ${LDFLAGS} *.c
+	done
+	# compile cal separately
+	cd "${TS}/ncal" || die
+	echo "in ${TS}/ncal:"
+	edo $(tc-getCC) ${flags[@]} -c calendar.c
+	edo $(tc-getCC) ${flags[@]} -c easter.c
+	edo $(tc-getCC) ${flags[@]} -c ncal.c
+	edo $(tc-getCC) -o cal ${LDFLAGS} -lncurses calendar.o easter.o ncal.o
+
+	TS="${S}/shell_cmds-${SHELL_VER}"
+	# only pick those tools not provided by coreutils, findutils
+	for t in \
+		apply getopt hexdump hostname jot kill killall \
+		lastcomm renice script shlock time whereis;
+	do
+		echo "in ${TS}/${t}:"
+		cd "${TS}/${t}" || die
+		edo $(tc-getCC) ${flags[@]} -o ${t} ${LDFLAGS} *.c
+	done
+	cd "${TS}/w" || die
+	sed -i -e '/#include <libutil.h>/d' w.c || die
+	echo "in ${TS}/w:"
+	edo $(tc-getCC) ${flags[@]} -DHAVE_UTMPX=1 ${LDFLAGS} -lresolv -o w *.c
+
+	TS="${S}/developer_cmds-${DEV_VER}"
+	# only pick those tools that do not conflict (no ctags and indent)
+	# do not install lorder, mkdep and vgrind as they are a non-prefix-aware
+	# shell scripts
+	# don't install rpcgen, as it is heavily related to the OS it runs
+	# on (and this is the High Sierra version)
+	for t in asa unifdef what ; do
+		echo "in ${TS}/${t}:"
+		cd "${TS}/${t}" || die
+		edo $(tc-getCC) ${flags[@]} -o ${t} ${LDFLAGS} *.c
+	done
+
+	# provide this one for gcc-apple
+	TS="${S}/adv_cmds-${MD_VER}"
+	for t in md ; do
+		echo "in ${TS}/${t}:"
+		cd "${TS}/${t}" || die
+		edo $(tc-getCC) ${flags[@]} -o ${t} ${LDFLAGS} *.c
+	done
+}
+
+src_install() {
+	mkdir -p "${ED}"/{,usr/}bin || die
+
+	local TS="${S}/misc_cmds-${MISC_VER}"
+	local t
+	for t in leave units calendar ; do
+		cp "${TS}/${t}/${t}" "${ED}"/usr/bin/ || die
+		doman "${TS}/${t}/${t}.1"
+	done
+	# copy cal separately
+	cp "${TS}/ncal/cal" "${ED}"/usr/bin/ncal || die
+	dosym ncal /usr/bin/cal
+	doman "${TS}/ncal/ncal.1"
+	dosym ncal.1 /usr/share/man/man1/cal.1
+
+	TS="${S}/shell_cmds-${SHELL_VER}"
+	for t in \
+		apply getopt hexdump hostname jot killall lastcomm \
+		renice script shlock time w whereis;
+	do
+		cp "${TS}/${t}/${t}" "${ED}"/usr/bin/ || die
+		[[ -f "${TS}/${t}/${t}.1" ]] && doman "${TS}/${t}/${t}.1"
+		[[ -f "${TS}/${t}/${t}.8" ]] && doman "${TS}/${t}/${t}.8"
+	done
+	cp "${TS}/w/w" "${ED}"/usr/bin/uptime || die
+	doman "${TS}/w/uptime.1"
+	for t in hostname kill; do
+		cp "${TS}/${t}/${t}" "${ED}"/bin/ || die
+		doman "${TS}/${t}/${t}.1"
+	done
+
+	TS="${S}/developer_cmds-${DEV_VER}"
+	for t in asa unifdef what ; do
+		cp "${TS}/${t}/${t}" "${ED}"/usr/bin/ || die
+		doman "${TS}/${t}/${t}.1"
+	done
+
+	TS="${S}/adv_cmds-${MD_VER}"
+	for t in md ; do
+		cp "${TS}/${t}/${t}" "${ED}"/usr/bin/ || die
+		doman "${TS}/${t}/${t}.1"
+	done
+}

--- a/sys-apps/darwin-miscutils/darwin-miscutils-6-r2.ebuild
+++ b/sys-apps/darwin-miscutils/darwin-miscutils-6-r2.ebuild
@@ -1,0 +1,132 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit edo toolchain-funcs
+
+MISC_VER=23
+SHELL_VER=118
+DEV_VER=49
+
+DESCRIPTION="Miscellaneous commands used on Darwin/Mac OS X systems, Leopard"
+HOMEPAGE="
+	https://www.opensource.apple.com/
+	https://github.com/apple-oss-distributions"
+SRC_URI="
+	https://opensource.apple.com/tarballs/misc_cmds/misc_cmds-${MISC_VER}.tar.gz
+	https://opensource.apple.com/tarballs/shell_cmds/shell_cmds-${SHELL_VER}.tar.gz
+	https://opensource.apple.com/tarballs/developer_cmds/developer_cmds-${DEV_VER}.tar.gz"
+S="${WORKDIR}"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~arm64-macos ~ppc-macos ~x64-macos"
+
+src_prepare() {
+	eapply -p0 "${FILESDIR}"/${PN}-5-w.patch
+	eapply -p0 "${FILESDIR}"/${PN}-5-stdlib.patch
+	eapply -p0 "${FILESDIR}"/${PN}-6-w64.patch
+	cd "${S}"/developer_cmds-${DEV_VER} || die
+	eapply "${FILESDIR}"/${PN}-5-error.patch
+	# deal with OSX Lion and above
+	sed -i -e 's/getline/ugetline/g' unifdef/unifdef.c || die
+
+	eapply_user
+}
+
+src_compile() {
+	local TS="${S}/misc_cmds-${MISC_VER}"
+	# tsort is provided by corepatch
+	local t
+	for t in leave units calendar; do
+		cd "${TS}/${t}" || die
+		echo "in ${TS}/${t}:"
+		edo $(tc-getCC) -o ${t} *.c
+	done
+	# compile cal separately
+	cd "${TS}/ncal" || die
+	echo "in ${TS}/ncal:"
+	local flags
+	flags[0]=-I.
+	flags[1]=-D__FBSDID=__RCSID
+	flags[2]=-Wsystem-headers
+	edo $(tc-getCC) ${flags[@]} -c calendar.c
+	edo $(tc-getCC) ${flags[@]} -c easter.c
+	edo $(tc-getCC) ${flags[@]} -c ncal.c
+	edo $(tc-getCC) ${flags[@]} -o cal calendar.o easter.o ncal.o
+
+	TS="${S}/shell_cmds-${SHELL_VER}"
+	# only pick those tools not provided by corepatch, findutils
+	for t in \
+		alias apply getopt hostname jot kill \
+		lastcomm renice shlock time whereis;
+	do
+		echo "in ${TS}/${t}:"
+		cd "${TS}/${t}" || die
+		edo $(tc-getCC) -o ${t} ${t}.c
+	done
+	# script and killall need additonal flags
+	for t in \
+		killall script
+	do
+		echo "in ${TS}/${t}:"
+		cd "${TS}/${t}" || die
+		edo $(tc-getCC) -D__FBSDID=__RCSID -o ${t} ${t}.c
+	done
+	cd "${TS}/w" || die
+	echo "in ${TS}/w:"
+	edo $(tc-getCC) -DHAVE_UTMPX=1 -lresolv -o w w.c pr_time.c proc_compare.c
+
+	TS="${S}/developer_cmds-${DEV_VER}"
+	# only pick those tools that do not conflict (no ctags and indent)
+	# do not install lorder, mkdep and vgrind as they are a non-prefix-aware
+	# shell scripts
+	# don't install rpcgen, as it is heavily related to the OS it runs
+	# on (and this is the Leopard version)
+	for t in asa error hexdump unifdef what ; do
+		echo "in ${TS}/${t}:"
+		cd "${TS}/${t}" || die
+		sed -i -e '/^__FBSDID/d' *.c || die
+		edo $(tc-getCC) -o ${t} *.c
+	done
+}
+
+src_install() {
+	mkdir -p "${ED}"/bin || die
+	mkdir -p "${ED}"/usr/bin || die
+
+	local TS="${S}/misc_cmds-${MISC_VER}"
+	local t
+	for t in leave units calendar ; do
+		cp "${TS}/${t}/${t}" "${ED}"/usr/bin/ || die
+		doman "${TS}/${t}/${t}.1"
+	done
+	# copy cal separately
+	cp "${TS}/ncal/cal" "${ED}"/usr/bin/ || die
+	dosym cal /usr/bin/ncal
+	doman "${TS}/ncal/ncal.1"
+	dosym ncal.1 /usr/share/man/man1/cal.1
+
+	TS="${S}/shell_cmds-${SHELL_VER}"
+	for t in \
+		alias apply getopt jot killall lastcomm \
+		renice script shlock su time w whereis;
+	do
+		cp "${TS}/${t}/${t}" "${ED}"/usr/bin/ || die
+		[[ -f "${TS}/${t}/${t}.1" ]] && doman "${TS}/${t}/${t}.1"
+		[[ -f "${TS}/${t}/${t}.8" ]] && doman "${TS}/${t}/${t}.8"
+	done
+	cp "${TS}/w/w" "${ED}"/usr/bin/uptime || die
+	doman "${TS}/w/uptime.1"
+	for t in hostname kill; do
+		cp "${TS}/${t}/${t}" "${ED}"/bin/ || die
+		doman "${TS}/${t}/${t}.1"
+	done
+
+	TS="${S}/developer_cmds-${DEV_VER}"
+	for t in asa error hexdump unifdef what ; do
+		cp "${TS}/${t}/${t}" "${ED}"/usr/bin/ || die
+		doman "${TS}/${t}/${t}.1"
+	done
+}

--- a/sys-apps/darwin-miscutils/darwin-miscutils-8-r1.ebuild
+++ b/sys-apps/darwin-miscutils/darwin-miscutils-8-r1.ebuild
@@ -1,0 +1,128 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit edo toolchain-funcs
+
+MISC_VER=27
+SHELL_VER=149
+DEV_VER=53.1
+
+DESCRIPTION="Miscellaneous commands used on Darwin/Mac OS X systems, Snow Leopard 10.6.3"
+HOMEPAGE="
+	https://www.opensource.apple.com/
+	https://github.com/apple-oss-distributions"
+SRC_URI="
+	https://opensource.apple.com/tarballs/misc_cmds/misc_cmds-${MISC_VER}.tar.gz
+	https://opensource.apple.com/tarballs/shell_cmds/shell_cmds-${SHELL_VER}.tar.gz
+	https://opensource.apple.com/tarballs/developer_cmds/developer_cmds-${DEV_VER}.tar.gz"
+S="${WORKDIR}"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~arm64-macos ~ppc-macos ~x64-macos"
+
+src_prepare() {
+	cd "${S}"/shell_cmds-${SHELL_VER} || die
+	eapply "${FILESDIR}"/${PN}-6-w64.patch
+	# deal with OSX Lion and above
+	cd "${S}"/developer_cmds-${DEV_VER} || die
+	sed -i -e 's/getline/ugetline/g' unifdef/unifdef.c || die
+
+	eapply_user
+}
+
+src_compile() {
+	local flags=(
+		${CFLAGS}
+		-I.
+		-D__FBSDID=__RCSID
+		-Wsystem-headers
+		-Du_int=uint32_t
+		-include stdint.h
+		${LDFLAGS}
+	)
+
+	local TS="${S}/misc_cmds-${MISC_VER}"
+	local t
+	# tsort is provided by corepatch
+	for t in leave units calendar; do
+		cd "${TS}/${t}"
+		echo "in ${TS}/${t}:"
+		edo $(tc-getCC) ${flags[@]} -o ${t} *.c
+	done
+	# compile cal separately
+	cd "${TS}/ncal" || die
+	echo "in ${TS}/ncal:"
+	edo $(tc-getCC) ${flags[@]} -c calendar.c
+	edo $(tc-getCC) ${flags[@]} -c easter.c
+	edo $(tc-getCC) ${flags[@]} -c ncal.c
+	edo $(tc-getCC) ${flags[@]} -o cal calendar.o easter.o ncal.o
+
+	TS="${S}/shell_cmds-${SHELL_VER}"
+	# only pick those tools not provided by corepatch, findutils
+	for t in \
+		alias apply getopt hostname jot kill killall \
+		lastcomm renice script shlock time whereis;
+	do
+		echo "in ${TS}/${t}:"
+		cd "${TS}/${t}" || die
+		edo $(tc-getCC) ${flags[@]} -o ${t} ${t}.c
+	done
+	cd "${TS}/w" || die
+	sed -i -e '/#include <libutil.h>/d' w.c || die
+	echo "in ${TS}/w:"
+	edo $(tc-getCC) ${flags[@]} -DHAVE_UTMPX=1 -lresolv -o w w.c pr_time.c proc_compare.c
+
+	TS="${S}/developer_cmds-${DEV_VER}"
+	# only pick those tools that do not conflict (no ctags and indent)
+	# do not install lorder, mkdep and vgrind as they are a non-prefix-aware
+	# shell scripts
+	# don't install rpcgen, as it is heavily related to the OS it runs
+	# on (and this is the Snow Leopard version)
+	for t in asa hexdump unifdef what ; do
+		echo "in ${TS}/${t}:"
+		cd "${TS}/${t}" || die
+		edo $(tc-getCC) ${flags[@]} -o ${t} *.c
+	done
+}
+
+src_install() {
+	mkdir -p "${ED}"/bin || die
+	mkdir -p "${ED}"/usr/bin || die
+
+	local TS="${S}/misc_cmds-${MISC_VER}"
+	local t
+	for t in leave units calendar ; do
+		cp "${TS}/${t}/${t}" "${ED}"/usr/bin/ || die
+		doman "${TS}/${t}/${t}.1"
+	done
+	# copy cal separately
+	cp "${TS}/ncal/cal" "${ED}"/usr/bin/ || die
+	dosym cal /usr/bin/ncal
+	doman "${TS}/ncal/ncal.1"
+	dosym ncal.1 /usr/share/man/man1/cal.1
+
+	TS="${S}/shell_cmds-${SHELL_VER}"
+	for t in \
+		alias apply getopt jot killall lastcomm \
+		renice script shlock time w whereis;
+	do
+		cp "${TS}/${t}/${t}" "${ED}"/usr/bin/ || die
+		[[ -f "${TS}/${t}/${t}.1" ]] && doman "${TS}/${t}/${t}.1"
+		[[ -f "${TS}/${t}/${t}.8" ]] && doman "${TS}/${t}/${t}.8"
+	done
+	cp "${TS}/w/w" "${ED}"/usr/bin/uptime || die
+	doman "${TS}/w/uptime.1"
+	for t in hostname kill; do
+		cp "${TS}/${t}/${t}" "${ED}"/bin/ || die
+		doman "${TS}/${t}/${t}.1"
+	done
+
+	TS="${S}/developer_cmds-${DEV_VER}"
+	for t in asa hexdump unifdef what ; do
+		cp "${TS}/${t}/${t}" "${ED}"/usr/bin/ || die
+		doman "${TS}/${t}/${t}.1"
+	done
+}

--- a/sys-apps/darwin-miscutils/darwin-miscutils-9-r1.ebuild
+++ b/sys-apps/darwin-miscutils/darwin-miscutils-9-r1.ebuild
@@ -1,0 +1,125 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit edo toolchain-funcs
+
+MISC_VER=31
+SHELL_VER=162
+DEV_VER=55
+
+DESCRIPTION="Miscellaneous commands used on Darwin/Mac OS X systems, Lion 10.7"
+HOMEPAGE="
+	https://www.opensource.apple.com/
+	https://github.com/apple-oss-distributions"
+SRC_URI="
+	https://opensource.apple.com/tarballs/misc_cmds/misc_cmds-${MISC_VER}.tar.gz
+	https://opensource.apple.com/tarballs/shell_cmds/shell_cmds-${SHELL_VER}.tar.gz
+	https://opensource.apple.com/tarballs/developer_cmds/developer_cmds-${DEV_VER}.tar.gz"
+S="${WORKDIR}"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~arm64-macos ~ppc-macos ~x64-macos"
+
+src_prepare() {
+	cd "${S}"/shell_cmds-${SHELL_VER} || die
+	eapply "${FILESDIR}"/${PN}-6-w64.patch
+
+	eapply_user
+}
+
+src_compile() {
+	local flags=(
+		${CFLAGS}
+		-I.
+		-D__FBSDID=__RCSID
+		-Wsystem-headers
+		-Du_int=uint32_t
+		-include stdint.h
+		${LDFLAGS}
+	)
+
+	local TS="${S}/misc_cmds-${MISC_VER}"
+	local t
+	# tsort is provided by corepatch
+	for t in leave units calendar; do
+		cd "${TS}/${t}" || die
+		echo "in ${TS}/${t}:"
+		edo $(tc-getCC) ${flags[@]} -o ${t} *.c
+	done
+	# compile cal separately
+	cd "${TS}/ncal" || die
+	echo "in ${TS}/ncal:"
+	edo $(tc-getCC) ${flags[@]} -c calendar.c
+	edo $(tc-getCC) ${flags[@]} -c easter.c
+	edo $(tc-getCC) ${flags[@]} -c ncal.c
+	edo $(tc-getCC) ${flags[@]} -o cal calendar.o easter.o ncal.o
+
+	TS="${S}/shell_cmds-${SHELL_VER}"
+	# only pick those tools not provided by corepatch, findutils
+	for t in \
+		alias apply getopt hostname jot kill killall \
+		lastcomm renice script shlock time whereis;
+	do
+		echo "in ${TS}/${t}:"
+		cd "${TS}/${t}" || die
+		edo $(tc-getCC) ${flags[@]} -o ${t} ${t}.c
+	done
+	cd "${TS}/w" || die
+	sed -i -e '/#include <libutil.h>/d' w.c || die
+	echo "in ${TS}/w:"
+	edo $(tc-getCC) ${flags[@]} -DHAVE_UTMPX=1 -lresolv -o w w.c pr_time.c proc_compare.c
+
+	TS="${S}/developer_cmds-${DEV_VER}"
+	# only pick those tools that do not conflict (no ctags and indent)
+	# do not install lorder, mkdep and vgrind as they are a non-prefix-aware
+	# shell scripts
+	# don't install rpcgen, as it is heavily related to the OS it runs
+	# on (and this is the Snow Leopard version)
+	for t in asa hexdump unifdef what ; do
+		echo "in ${TS}/${t}:"
+		cd "${TS}/${t}" || die
+		edo $(tc-getCC) ${flags[@]} -o ${t} *.c
+	done
+}
+
+src_install() {
+	mkdir -p "${ED}"/bin || die
+	mkdir -p "${ED}"/usr/bin || die
+
+	local TS="${S}/misc_cmds-${MISC_VER}"
+	local t
+	for t in leave units calendar ; do
+		cp "${TS}/${t}/${t}" "${ED}"/usr/bin/ || die
+		doman "${TS}/${t}/${t}.1"
+	done
+	# copy cal separately
+	cp "${TS}/ncal/cal" "${ED}"/usr/bin/ || die
+	dosym cal /usr/bin/ncal
+	doman "${TS}/ncal/ncal.1"
+	dosym ncal.1 /usr/share/man/man1/cal.1
+
+	TS="${S}/shell_cmds-${SHELL_VER}"
+	for t in \
+		alias apply getopt jot killall lastcomm \
+		renice script shlock time w whereis;
+	do
+		cp "${TS}/${t}/${t}" "${ED}"/usr/bin/ || die
+		[[ -f "${TS}/${t}/${t}.1" ]] && doman "${TS}/${t}/${t}.1"
+		[[ -f "${TS}/${t}/${t}.8" ]] && doman "${TS}/${t}/${t}.8"
+	done
+	cp "${TS}/w/w" "${ED}"/usr/bin/uptime || die
+	doman "${TS}/w/uptime.1"
+	for t in hostname kill; do
+		cp "${TS}/${t}/${t}" "${ED}"/bin/ || die
+		doman "${TS}/${t}/${t}.1"
+	done
+
+	TS="${S}/developer_cmds-${DEV_VER}"
+	for t in asa hexdump unifdef what ; do
+		cp "${TS}/${t}/${t}" "${ED}"/usr/bin/ || die
+		doman "${TS}/${t}/${t}.1"
+	done
+}

--- a/sys-apps/darwin-miscutils/metadata.xml
+++ b/sys-apps/darwin-miscutils/metadata.xml
@@ -5,4 +5,10 @@
 		<email>prefix@gentoo.org</email>
 		<name>Gentoo Prefix</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">apple-oss-distributions/adv_cmds</remote-id>
+		<remote-id type="github">apple-oss-distributions/misc_cmds</remote-id>
+		<remote-id type="github">apple-oss-distributions/shell_cmds</remote-id>
+		<remote-id type="github">apple-oss-distributions/developer_cmds</remote-id>
+	</upstream>
 </pkgmetadata>


### PR DESCRIPTION
Hi,

This updates `sys-apps/darwin-miscutils` for `EAPI8`. Afaics every version is for a different MacOS Version, which is why i've updated all of them. So far, the prominet changes are:
* adding a lot of missing `|| die`
* updated all SRC_URI's and added Apple's github homepage
* quoted some variables and defined the variable `t` as local where it's used.
* using `edo` for compiling files - and removed a lot of `echo`'s with this
* using `eapply` instead of `epatch`
* fixed `AbsoluteSymlink`

I don't have any MacOS so i couldn't test much here. I only made sure the patches can be applied.

Open issues:
* SRC_URI are able to download the files, but most of the files get `Filesize does not match recorded size`. I haven't updated the manifest since i cannot test it. This probably should be fixed.
* The `md` source file for version 10,11 and 12 is also directly downloaded from github via `https://github.com/apple-oss-distributions/adv_cmds/blob/c8dbac91aa855b2d05282f45709b318f8bc3693d/md/md.c -> adv_cmds-md-${MD_VER}.c`. This works and the `SIZE` matches that of the `Manifest`, but i'm not sure if it's fine to use such links.
* ~~Since i added the github links i also though about to update `metadata.xml`, However since we download sources from multiple repositories I wasn't sure if I could add multiple upstream. I would add something like this:~~

```
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
<pkgmetadata>
	<maintainer type="project">
		<email>prefix@gentoo.org</email>
		<name>Gentoo Prefix</name>
	</maintainer>
	<upstream>
		<remote-id type="github">apple-oss-distributions/adv_cmds</remote-id>
		<remote-id type="github">apple-oss-distributions/misc_cmds</remote-id>
		<remote-id type="github">apple-oss-distributions/shell_cmds</remote-id>
		<remote-id type="github">apple-oss-distributions/developer_cmds</remote-id>
	</upstream>
</pkgmetadata>
```