### PR TITLE
gui-apps/waybar: drop logind requirement for mpris

### DIFF
--- a/gui-apps/waybar/waybar-0.10.0.ebuild
+++ b/gui-apps/waybar/waybar-0.10.0.ebuild
@@ -21,7 +21,6 @@ LICENSE="MIT"
 SLOT="0"
 IUSE="evdev experimental jack +libinput +logind mpd mpris network pipewire pulseaudio sndio systemd test tray +udev upower wifi"
 REQUIRED_USE="
-	mpris? ( logind )
 	upower? ( logind )
 "
 

--- a/gui-apps/waybar/waybar-9999.ebuild
+++ b/gui-apps/waybar/waybar-9999.ebuild
@@ -21,7 +21,6 @@ LICENSE="MIT"
 SLOT="0"
 IUSE="evdev experimental jack +libinput +logind mpd mpris network pipewire pulseaudio sndio systemd test tray +udev upower wifi"
 REQUIRED_USE="
-	mpris? ( logind )
 	upower? ( logind )
 "
 


### PR DESCRIPTION
upstream dropped the requirement from their build in
f3063e86aab08786ac03e6ddd5c9004fe36a52d1

Signed-off-by: Robert Günzler <r@gnzler.io>
