### PR TITLE
sys-fs/reiser4progs: add patch to enable compiling with clang

### DIFF
--- a/sys-fs/reiser4progs/files/reiser4progs-2.0.5-clang.patch
+++ b/sys-fs/reiser4progs/files/reiser4progs-2.0.5-clang.patch
@@ -1,0 +1,65 @@
+Author: Denis Pronin <dannftk@yandex.ru>
+
+Description: if the project is built with clang you will see many errors and 
+compilation failures. This patch is given to fix this issue up
+
+https://bugs.gentoo.org/933169
+
+--- a/plugin/vol/volume.c
++++ b/plugin/vol/volume.c
+@@ -34,8 +34,8 @@
+ 	return max(min(val, high),low);
+ }
+ 
+-static int advise_stripe_size_simple(uint64_t *result, uint64_t block_count,
+-				     uint32_t block_size, int is_default,
++static int advise_stripe_size_simple(uint64_t *result, uint64_t block_count,
++				     uint32_t block_size, int is_default,
+ 				     int forced)
+ {
+ 	/*
+@@ -53,8 +53,8 @@
+ 	return 0;
+ }
+ 
+-static int advise_stripe_size_asym(uint64_t *result, uint64_t block_count,
+-				   uint32_t block_size, int is_default,
++static int advise_stripe_size_asym(uint64_t *result, uint64_t block_count,
++				   uint32_t block_size, int is_default,
+ 				   int forced)
+ {
+ 	uint64_t advised;
+@@ -150,7 +150,7 @@
+ 	return 0;
+ }
+ 
+-static uint64_t default_data_capacity_simple(uint64_t free_blocks)
++static uint64_t default_data_capacity_simple(uint64_t free_blocks, int data_brick)
+ {
+ 	return 0;
+ }
+
+--- a/libreiser4/filesystem.c
++++ b/libreiser4/filesystem.c
+@@ -352,6 +352,10 @@
+ 	return NULL;
+ }
+ 
++void reiser4_format_set_data_capacity(
++	reiser4_format_t *format,
++	count_t blocks);
++
+ void reiser4_set_data_capacity(reiser4_fs_t *fs, fs_hint_t *hint)
+ {
+ 	if (hint->data_capacity == 0) {
+@@ -363,6 +367,10 @@
+ 	reiser4_format_set_data_capacity(fs->format, hint->data_capacity);
+ }
+ 
++void reiser4_format_set_min_occup(
++	reiser4_format_t *format,
++	count_t blocks);
++
+ /**
+  * This is called at the end of the procedure of formatting a partition
+  */

--- a/sys-fs/reiser4progs/files/reiser4progs-2.0.5-fix-params-inconsistency-and-misuse.patch
+++ b/sys-fs/reiser4progs/files/reiser4progs-2.0.5-fix-params-inconsistency-and-misuse.patch
@@ -1,0 +1,48 @@
+Author: Denis Pronin <dannftk@yandex.ru>
+
+Description: the order of the factual parameters transferred when calling 
+'advise_stripe_size' in progs/mkfs/mkfs.c method of volume type has happened to 
+be invalid. Firstly, there must be given number of blocks, then block size since
+ API of volume requires exactly this order.
+Also there has been observed the fact of inconsistency of some functions 
+definitions in plugin/vol/volume.c do not correspond to the types of function 
+pointers assigned with the definitions mentioned. This patch fixes this 
+circumstance up
+
+https://bugs.gentoo.org/933169
+
+--- a/progs/mkfs/mkfs.c
++++ b/progs/mkfs/mkfs.c
+@@ -112,7 +112,7 @@
+ {
+ 	return plugcall((reiser4_vol_plug_t *)reiser4_profile_plug(PROF_VOL),
+ 			advise_stripe_size, &hint->stripe_size,
+-			hint->blksize, hint->blocks, is_default,
++			hint->blocks, hint->blksize, is_default,
+ 			forced);
+ }
+ 
+--- a/plugin/vol/volume.c
++++ b/plugin/vol/volume.c
+@@ -34,8 +34,8 @@
+ 	return max(min(val, high),low);
+ }
+ 
+-static int advise_stripe_size_simple(uint64_t *result, uint32_t block_size,
+-				     uint64_t block_count, int is_default,
++static int advise_stripe_size_simple(uint64_t *result, uint64_t block_count,
++				     uint32_t block_size, int is_default,
+ 				     int forced)
+ {
+ 	/*
+@@ -53,8 +53,8 @@
+ 	return 0;
+ }
+ 
+-static int advise_stripe_size_asym(uint64_t *result, uint32_t block_size,
+-				   uint64_t block_count, int is_default,
++static int advise_stripe_size_asym(uint64_t *result, uint64_t block_count,
++				   uint32_t block_size, int is_default,
+ 				   int forced)
+ {
+ 	uint64_t advised;

--- a/sys-fs/reiser4progs/reiser4progs-2.0.5.ebuild
+++ b/sys-fs/reiser4progs/reiser4progs-2.0.5.ebuild
@@ -24,6 +24,7 @@ DEPEND="${RDEPEND}
 PATCHES=(
 	"${FILESDIR}"/${PN}-1.0.7-readline-6.3.patch
 	"${FILESDIR}"/${P}-fix-params-inconsistency-and-misuse.patch
+	"${FILESDIR}"/${P}-clang.patch
 )
 
 src_prepare() {

--- a/sys-fs/reiser4progs/reiser4progs-2.0.5.ebuild
+++ b/sys-fs/reiser4progs/reiser4progs-2.0.5.ebuild
@@ -21,7 +21,10 @@ RDEPEND="!static? ( ${LIB_DEPEND//\[static-libs(+)]} )
 DEPEND="${RDEPEND}
 	static? ( ${LIB_DEPEND} )"
 
-PATCHES=( "${FILESDIR}"/${PN}-1.0.7-readline-6.3.patch )
+PATCHES=(
+	"${FILESDIR}"/${PN}-1.0.7-readline-6.3.patch
+	"${FILESDIR}"/${P}-fix-params-inconsistency-and-misuse.patch
+)
 
 src_prepare() {
 	printf '#!/bin/sh\ntrue\n' > run-ldconfig


### PR DESCRIPTION
https://bugs.gentoo.org/933169