### PR TITLE
media-plugins/vamp-libxtract-plugins: EAPI8 bump

### DIFF
--- a/media-plugins/vamp-libxtract-plugins/vamp-libxtract-plugins-0.6.6.20121204-r1.ebuild
+++ b/media-plugins/vamp-libxtract-plugins/vamp-libxtract-plugins-0.6.6.20121204-r1.ebuild
@@ -1,0 +1,34 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs
+
+DESCRIPTION="Vamp plugin encapsulating many of the functions of the LibXtract library"
+HOMEPAGE="https://www.vamp-plugins.org/"
+SRC_URI="https://code.soundsoftware.ac.uk/attachments/download/618/${P}.tar.gz"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~ppc64 ~x86"
+
+RDEPEND="=sci-libs/fftw-3*
+	>=media-libs/libxtract-0.6.6
+	media-libs/vamp-plugin-sdk"
+DEPEND="${RDEPEND}"
+
+src_prepare() {
+	default
+	sed -e "s/-O3//" -e "s/ -Wl,-Bstatic//" -i Makefile || die "sed Makefile failed"
+}
+
+src_configure() {
+	tc-export CXX
+}
+
+src_install() {
+	insinto /usr/$(get_libdir)/vamp
+	doins vamp-libxtract.{so,cat}
+	einstalldocs
+}


### PR DESCRIPTION
very simple `EAPI8` bump...

```diff
--- vamp-libxtract-plugins-0.6.6.20121204.ebuild	2024-01-17 20:05:13.248816316 +0100
+++ vamp-libxtract-plugins-0.6.6.20121204-r1.ebuild	2024-04-08 19:06:46.753501276 +0200
@@ -1,7 +1,7 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
 
 inherit toolchain-funcs
 
@@ -11,8 +11,7 @@
 
 LICENSE="GPL-2+"
 SLOT="0"
-KEYWORDS="amd64 ~ppc ppc64 x86"
-IUSE=""
+KEYWORDS="~amd64 ~ppc ~ppc64 ~x86"
 
 RDEPEND="=sci-libs/fftw-3*
 	>=media-libs/libxtract-0.6.6
```