### PR TITLE
eclass/freedict.eclass: support EAPI8

### DIFF
--- a/eclass/freedict.eclass
+++ b/eclass/freedict.eclass
@@ -6,14 +6,14 @@
 # maintainer-needed@gentoo.org
 # @AUTHOR:
 # Original author: Seemant Kulleen <seemant@gentoo.org>
-# @SUPPORTED_EAPIS: 7
+# @SUPPORTED_EAPIS: 7 8
 # @BLURB: Ease the installation of freedict translation dictionaries
 # @DESCRIPTION:
 # This eclass exists to ease the installation of freedict translation
 # dictionaries.
 
 case ${EAPI} in
-	7) ;;
+	7|8) ;;
 	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
 
@@ -23,12 +23,14 @@ _FREEDICT_ECLASS=1
 # @ECLASS_VARIABLE: FREEDICT_P
 # @DESCRIPTION:
 # Strips PN of 'freedict' prefix, to be used in SRC_URI and doins
-FREEDICT_P=${PN/freedict-/}
+FREEDICT_P="${PN/freedict-/}"
 
 [[ ${FORLANG} ]] && die "FORLANG is banned, set DESCRIPTION instead"
 [[ ${TOLANG} ]] && die "TOLANG is banned, set DESCRIPTION instead"
 
-HOMEPAGE="https://freedict.sourceforge.net/en/"
+HOMEPAGE="
+	https://freedict.sourceforge.net/en/
+	https://github.com/freedict/fd-dictionaries"
 SRC_URI="https://freedict.sourceforge.net/download/linux/${FREEDICT_P}.tar.gz"
 
 LICENSE="GPL-2+"


### PR DESCRIPTION
Hi

This adds support for `EAPI8` in `freedict.eclass`.
The changes are minor. I've basically only added the github homepage. I haven't send it to gentoo-dev, but if the changes are fine i'll send it there too.