### PR TITLE
eclass/vim-spell.eclass: support EAPI8

### DIFF
--- a/eclass/vim-spell.eclass
+++ b/eclass/vim-spell.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: vim-spell.eclass
@@ -6,7 +6,7 @@
 # Vim Maintainers <vim@gentoo.org>
 # @AUTHOR:
 # Ciaran McCreesh <ciaranm@gentoo.org>
-# @SUPPORTED_EAPIS: 6 7
+# @SUPPORTED_EAPIS: 6 7 8
 # @BLURB: Eclass for managing Vim spell files.
 # @DESCRIPTION:
 # How to make a vim spell file package using prebuilt spell lists
@@ -39,15 +39,14 @@
 #     <?xml version="1.0" encoding="UTF-8"?>
 #     <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 #     <pkgmetadata>
-#        <maintainer type="person">
-#                <email>your@email.tld</email>
-#                <name>Your Name</name>
-#        </maintainer>
-#        <maintainer type="project">
-#                <email>vim@gentoo.org</email>
-#                <name>Vim Maintainers</name>
-#        </maintainer>
-#
+#     	<maintainer type="person">
+#     		<email>your@email.tld</email>
+#     		<name>Your Name</name>
+#     	</maintainer>
+#     	<maintainer type="project">
+#     		<email>vim@gentoo.org</email>
+#     		<name>Vim Maintainers</name>
+#     	</maintainer>
 #     	<longdescription lang="en">
 #     		Vim spell files for French (fr). Supported character sets are
 #     		UTF-8 and latin1.
@@ -64,7 +63,7 @@
 # for another language rather than keeping them Gentoo-specific.
 
 case ${EAPI} in
-	6|7) ;;
+	6|7|8) ;;
 	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
 


### PR DESCRIPTION
Similar to https://github.com/gentoo/gentoo/pull/36165 this adds `EAPI8` support in `vim-spell.eclass`. Again i haven't changed much, just fixed the indentation in the comments.
Since there are still some ebuilds at `EAPI6` i also couldn't remove `EAPI6` support. (my plan was to bump them next, but then directly to `EAPI8`) 
Changes were not sent to gentoo-dev yet. If the changes are fine i'll do that next.