### PR TITLE
net-p2p/ncdc: fix building with Clang 16 for 1.24

### DIFF
--- a/net-p2p/ncdc/files/ncdc-1.24-fix-clang16-c99-errors.patch
+++ b/net-p2p/ncdc/files/ncdc-1.24-fix-clang16-c99-errors.patch
@@ -1,0 +1,72 @@
+Upstream PR: https://code.blicky.net/yorhel/ncdc/pulls/108 .
+
+From 42590da4741baf93889773df96e0f3546d2e7f20 Mon Sep 17 00:00:00 2001
+From: Eric Joldasov <bratishkaerik@landless-city.net>
+Date: Tue, 9 Apr 2024 00:09:53 +0500
+Subject: [PATCH] Fix Clang 16 errors for invalid C99 constructs
+ (-Wincompatible-pointer-types)
+
+These errors were caused by `t_title` function having "void" parameter
+instead of "ui_tab_t *tab", like everywhere else:
+
+```
+src/uit_conn.c:398:41: error: initialization of char * (*)(ui_tab_t *) from incompatible pointer type char * (*)(void) [-Wincompatible-pointer-types]
+  398 | ui_tab_type_t uit_conn[1] = { { t_draw, t_title, t_key, t_close } };
+      |                                         ^~~~~~~
+```
+
+Also renamed `t` param in `t_title` of "src/uit_main.c" to `tab`,
+for consistency with other functions.
+
+This error appeared only in 1.24 release cycle, because changing
+prototypes from "()" to "(void)" in 2cf47a7ec9f35d1afaf24a6f9644fbecf6df92df
+changed meaning of the type from "any parameters, including ui_tab_t *"
+to "no parameters at all", and this is where Clang starts to complain.
+
+Bug: https://bugs.gentoo.org/928946
+Signed-off-by: Eric Joldasov <bratishkaerik@landless-city.net>
+---
+ src/uit_conn.c | 2 +-
+ src/uit_dl.c   | 2 +-
+ src/uit_main.c | 2 +-
+ 3 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/src/uit_conn.c b/src/uit_conn.c
+index f0fa171..ba00cb3 100644
+--- a/src/uit_conn.c
++++ b/src/uit_conn.c
+@@ -97,7 +97,7 @@ static void t_close(ui_tab_t *tab) {
+ }
+ 
+ 
+-static char *t_title(void) {
++static char *t_title(ui_tab_t *tab) {
+   return g_strdup("Connection list");
+ }
+ 
+diff --git a/src/uit_dl.c b/src/uit_dl.c
+index 118f323..f8cda84 100644
+--- a/src/uit_dl.c
++++ b/src/uit_dl.c
+@@ -124,7 +124,7 @@ static void t_close(ui_tab_t *tab) {
+ }
+ 
+ 
+-static char *t_title(void) {
++static char *t_title(ui_tab_t *tab) {
+   return g_strdup("Download queue");
+ }
+ 
+diff --git a/src/uit_main.c b/src/uit_main.c
+index e3fdfad..79b3ffa 100644
+--- a/src/uit_main.c
++++ b/src/uit_main.c
+@@ -65,7 +65,7 @@ static void t_draw(ui_tab_t *t) {
+ }
+ 
+ 
+-static char *t_title(ui_tab_t *t) {
++static char *t_title(ui_tab_t *tab) {
+   return g_strdup_printf("Welcome to ncdc %s!", main_version);
+ }
+ 

--- a/net-p2p/ncdc/ncdc-1.24-r1.ebuild
+++ b/net-p2p/ncdc/ncdc-1.24-r1.ebuild
@@ -11,10 +11,11 @@ SRC_URI="
 	https://dev.yorhel.nl/download/${P}.tar.gz
 	verify-sig? ( https://dev.yorhel.nl/download/${P}.tar.gz.asc )
 "
-KEYWORDS="~amd64 ~ppc ~sparc ~x86"
-
 LICENSE="MIT"
 SLOT="0"
+
+KEYWORDS="~amd64 ~ppc ~sparc ~x86"
+
 IUSE="geoip"
 
 RDEPEND="
@@ -35,6 +36,10 @@ BDEPEND="
 "
 
 VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/openpgp-keys/yoranheling.asc
+
+PATCHES=(
+	"${FILESDIR}/ncdc-1.24-fix-clang16-c99-errors.patch"
+)
 
 src_configure() {
 	local myeconfargs=(


### PR DESCRIPTION
Release 1.23.1 is unaffected. All information is in the patch. Upstream PR: https://code.blicky.net/yorhel/ncdc/pulls/108 .

Closes: https://bugs.gentoo.org/928946

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.