### PR TITLE
eclass: attempt to remove icedtea{,-bin} from eclasses

### DIFF
--- a/eclass/java-utils-2.eclass
+++ b/eclass/java-utils-2.eclass
@@ -2637,10 +2637,6 @@ java-pkg_setup-vm() {
 	debug-print-function ${FUNCNAME} $*
 
 	local vendor="$(java-pkg_get-vm-vendor)"
-	if [[ "${vendor}" == icedtea* ]] && java-pkg_is-vm-version-ge "1.8" ; then
-		addpredict "/dev/random"
-		addpredict "/proc/self/coredump_filter"
-	fi
 }
 
 # @FUNCTION: java-pkg_needs-vm

--- a/eclass/java-vm-2.eclass
+++ b/eclass/java-vm-2.eclass
@@ -225,7 +225,7 @@ set_java_env() {
 # Environment variables within this file will be resolved. You should
 # escape the $ when referring to variables that should be resolved later
 # such as ${JAVA_HOME}. Subshells may be used but avoid using double
-# quotes. See icedtea-bin.env.sh for a good example.
+# quotes.
 
 java-vm_install-env() {
 	debug-print-function ${FUNCNAME} "$*"


### PR DESCRIPTION
@fordfrog 
going though the eclasses for cleanup from the last rited `dev-java/icedtea{,-bin}` i am not sure, could we even drop the whole [java-pkg_setup-vm()](https://github.com/gentoo/gentoo/blob/master/eclass/java-utils-2.eclass#L2632-L2644) and [java-pkg_get-vm-vendor()](https://github.com/gentoo/gentoo/blob/master/eclass/java-utils-2.eclass#L2672-L2681) or even more?

also, i am getting confused about `java-pkg_get-current-vm()` which seems to appear twice in java-utils-2.eclass:

```
java-pkg_get-current-vm() {
	echo ${GENTOO_VM}
}
```

```
# @FUNCTION: java-pkg_get-current-vm
# @INTERNAL
# @RETURN: The current VM being used
java-pkg_get-current-vm() {
	java-config -f
}
```