### PR TITLE
games-util/heroic-bin: remove resolution from gamescope command

### DIFF
--- a/games-util/heroic-bin/heroic-bin-2.13.0-r1.ebuild
+++ b/games-util/heroic-bin/heroic-bin-2.13.0-r1.ebuild
@@ -107,7 +107,7 @@ src_prepare() {
 
 		sed -i 's/Name=Heroic Games Launcher/Name=Heroic Games Launcher (Gamescope)/g' \
 			"${WORKDIR}"/com.heroicgameslauncher.hgl.gamescope.${PV}.desktop || die
-		sed -i 's/Exec=heroic-run %u/Exec=env GDK_BACKEND=wayland gamescope -w 1920 -h 1080 -f -R --RT --force-grab-cursor --prefer-vk-device --adaptive-sync --nested-unfocused-refresh 30 -- heroic-run --ozone-platform=x11 --enable-features=UseOzonePlatform,WaylandWindowDecorations/g' \
+		sed -i 's/Exec=heroic-run %u/Exec=env GDK_BACKEND=wayland gamescope -f -R --RT --force-grab-cursor --prefer-vk-device --adaptive-sync --nested-unfocused-refresh 30 -- heroic-run --ozone-platform=x11 --enable-features=UseOzonePlatform,WaylandWindowDecorations/g' \
 			"${WORKDIR}"/com.heroicgameslauncher.hgl.gamescope.${PV}.desktop || die
 	fi
 }

--- a/games-util/heroic-bin/heroic-bin-2.14.1-r1.ebuild
+++ b/games-util/heroic-bin/heroic-bin-2.14.1-r1.ebuild
@@ -107,7 +107,7 @@ src_prepare() {
 
 		sed -i 's/Name=Heroic Games Launcher/Name=Heroic Games Launcher (Gamescope)/g' \
 			"${WORKDIR}"/com.heroicgameslauncher.hgl.gamescope.${PV}.desktop || die
-		sed -i 's/Exec=heroic-run %u/Exec=env GDK_BACKEND=wayland gamescope -w 1920 -h 1080 -f -R --RT --force-grab-cursor --prefer-vk-device --adaptive-sync --nested-unfocused-refresh 30 -- heroic-run --ozone-platform=x11 --enable-features=UseOzonePlatform,WaylandWindowDecorations/g' \
+		sed -i 's/Exec=heroic-run %u/Exec=env GDK_BACKEND=wayland gamescope -f -R --RT --force-grab-cursor --prefer-vk-device --adaptive-sync --nested-unfocused-refresh 30 -- heroic-run --ozone-platform=x11 --enable-features=UseOzonePlatform,WaylandWindowDecorations/g' \
 			"${WORKDIR}"/com.heroicgameslauncher.hgl.gamescope.${PV}.desktop || die
 	fi
 }


### PR DESCRIPTION
* the problem is that exist more resolution that just 1080p :)
* also pipewire detect the resolution of the screen (gamescope is nested)

@voyageur sorry this was a mistake of my part I forget to remove the resolution, also is not needed since pipewire also detect by default.
gamescope output of my external screen:
```
mrduarte@GentooLegion ~ $ GDK_BACKEND=wayland gamescope -f -R --RT --force-grab-cursor --prefer-vk-device --adaptive-sync -- heroic-run --ozone-platform=x11 --enable-features=UseOzonePlatform,WaylandWindowDecorations
vblank: Using timerfd.
wlserver: [backend/headless/backend.c:67] Creating headless backend
ATTENTION: default value of option vk_khr_present_wait overridden by environment.
ATTENTION: default value of option vk_khr_present_wait overridden by environment.
DRM kernel driver 'nvidia-drm' in use. NVK requires nouveau.
vulkan: selecting physical device 'AMD Radeon Graphics (RADV RENOIR)': queue family 1 (general queue family 0)
vulkan: physical device supports DRM format modifiers
vulkan: supported DRM formats for sampling usage:
vulkan: stuff...
vulkan: Creating Gamescope nested swapchain with format 64 and colorspace 0
wlserver: stuff...
wlserver: [xwayland/server.c:108] Starting Xwayland on :1
wlserver: [types/wlr_compositor.c:692] New wlr_surface 0x55f36cc10690 (res 0x55f36cc12e90)
wlserver: [xwayland/server.c:273] Xserver is ready
pipewire: stream state changed: connecting
pipewire: stream state changed: paused
pipewire: stream available on node ID: 63
vulkan: Creating Gamescope nested swapchain with format 64 and colorspace 0
pipewire: renegotiating stream params (size: 1360x768)
```