### PR TITLE
www-client/chromium: fix ppc64 patchset for 123

### DIFF
--- a/www-client/chromium/chromium-123.0.6312.105.ebuild
+++ b/www-client/chromium/chromium-123.0.6312.105.ebuild
@@ -457,6 +457,7 @@ src_prepare() {
 		done
 		PATCHES+=( "${WORKDIR}/ppc64le" )
 		PATCHES+=( "${WORKDIR}/debian/patches/fixes/rust-clanglib.patch" )
+		PATCHES+=( "${WORKDIR}/debian/patches/fixes/blink-fonts-shape-result.patch" )
 	fi
 
 	default


### PR DESCRIPTION
Fixes the following error:

```
FAILED: obj/third_party/blink/renderer/platform/platform/shape_result.o
clang++ -MD -MF obj/third_party/blink/renderer/platform/platform/shape_result.o.d -DUSE_UDEV -DUSE_AURA=1 -DUSE_GLIB=1 -DUSE_OZONE=1 -DOFFICIAL_BUILD -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -DNO_UNWIND_TABLES -D_GNU_SOURCE -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_EXTENSIVE -D_LIBCPP_DISABLE_VISIBILITY_ANNOTATIONS -D_LIBCXXABI_DISABLE_VISIBILITY_ANNOTATIONS -DCR_LIBCXX_REVISION=834e97d73f13a166af65952fb681071eec87a2c4 -DNDEBUG -DNVALGRIND -DDYNAMIC_ANNOTATIONS_ENABLED=0 -DBLINK_IMPLEMENTATION=1 -DINSIDE_BLINK -DBLINK_PLATFORM_IMPLEMENTATION=1 -DGLIB_VERSION_MAX_ALLOWED=GLIB_VERSION_2_56 -DGLIB_VERSION_MIN_REQUIRED=GLIB_VERSION_2_56 -DBASE_USE_PERFETTO_CLIENT_LIBRARY=1 -DSK_ENABLE_SKSL -DSK_UNTIL_CRBUG_1187654_IS_FIXED -DSK_USER_CONFIG_HEADER=\"../../skia/config/SkUserConfig.h\" -DSK_WIN_FONTMGR_NO_SIMULATIONS -DSK_DISABLE_LEGACY_INIT_DECODERS -DSK_SLUG_DISABLE_LEGACY_DESERIALIZE -DSK_DISABLE_LEGACY_VULKAN_BACKENDSEMAPHORE -DSK_DISABLE_LEGACY_CREATE_CHARACTERIZATION -DSK_DISABLE_LEGACY_VULKAN_MUTABLE_TEXTURE_STATE -DSK_CODEC_DECODES_JPEG -DSK_ENCODE_JPEG -DSK_ENCODE_PNG -DSK_ENCODE_WEBP -DSK_GANESH -DSK_GPU_WORKAROUNDS_HEADER=\"gpu/config/gpu_driver_bug_workaround_autogen.h\" -DSK_GL -DSK_VULKAN=1 -DSK_GRAPHITE -DSK_DAWN -DVK_USE_PLATFORM_XCB_KHR -DVK_USE_PLATFORM_WAYLAND_KHR -DUSE_EGL -DLIBYUV_DISABLE_NEON -DLIBYUV_DISABLE_LSX -DLIBYUV_DISABLE_LASX -DWTF_USE_WEBAUDIO_PFFFT=1 -DUSING_SYSTEM_ICU=1 -DICU_UTIL_DATA_IMPL=ICU_UTIL_DATA_STATIC -DU_IMPORT=U_EXPORT -DGOOGLE_PROTOBUF_NO_RTTI -DGOOGLE_PROTOBUF_NO_STATIC_INITIALIZER -DGOOGLE_PROTOBUF_INTERNAL_DONATE_STEAL_INLINE=0 -DHAVE_PTHREAD -DV8_DEPRECATION_WARNINGS -DV8_USE_PERFETTO -DCPPGC_SLIM_WRITE_BARRIER -DWEBRTC_ENABLE_AVX2 -DWEBRTC_NON_STATIC_TRACE_EVENT_HANDLERS=0 -DWEBRTC_CHROMIUM_BUILD -DWEBRTC_POSIX -DWEBRTC_LINUX -DABSL_ALLOCATOR_NOTHROW=1 -DWEBRTC_USE_X11 -DWEBRTC_USE_PIPEWIRE -DWEBRTC_USE_GIO -DLOGGING_INSIDE_WEBRTC -DLEVELDB_PLATFORM_CHROMIUM=1 -DCRASHPAD_ZLIB_SOURCE_EXTERNAL -DUSE_SYSTEM_ZLIB=1 -DUSE_SYSTEM_LIBJPEG -DLIBGAV1_MAX_BITDEPTH=10 -DLIBGAV1_THREADPOOL_USE_STD_MUTEX -DLIBGAV1_ENABLE_LOGGING=0 -DLIBGAV1_PUBLIC= -I../../third_party/pffft/src -I../.. -Igen -I../../buildtools/third_party/libc++ -I../../third_party/perfetto/include -Igen/third_party/perfetto/build_config -Igen/third_party/perfetto -Igen/shim_headers/zlib_shim -Igen/shim_headers/icui18n_shim -Igen/shim_headers/icuuc_shim -I../../third_party/skia -Igen/third_party/skia -I../../third_party/wuffs/src/release/c -I../../third_party/vulkan/include -I../../third_party/vulkan-deps/vulkan-headers/src/include -I../../third_party/wayland/src/src -I../../third_party/wayland/include/src -Igen/third_party/dawn/include -I../../third_party/dawn/include -Igen/shim_headers/libpng_shim -Igen/shim_headers/libwebp_shim -I../../net/third_party/quiche/overrides -I../../net/third_party/quiche/src/quiche/common/platform/default -I../../net/third_party/quiche/src -Igen/shim_headers/zstd_shim -I../../third_party/khronos -I../../gpu -I../../third_party/libyuv/include -Igen/shim_headers/flac_shim -Igen/shim_headers/openh264_shim -I../../base/allocator/partition_allocator/src -Igen/base/allocator/partition_allocator/src -I../../third_party/abseil-cpp -I../../third_party/boringssl/src/include -I../../third_party/protobuf/src -Igen/protoc_out -I../../third_party/ipcz/include -I../../third_party/ced/src -Igen/net/third_party/quiche/src -I../../v8/include -I../../third_party/webrtc_overrides -I../../third_party/webrtc -Igen/third_party/webrtc -I../../third_party/libwebm/source -I../../third_party/mesa_headers -I../../third_party/leveldatabase -I../../third_party/leveldatabase/src -I../../third_party/leveldatabase/src/include -I../../third_party/crashpad/crashpad -I../../third_party/crashpad/crashpad/compat/linux -I../../third_party/crashpad/crashpad/compat/non_win -I../../third_party/libaom/source/libaom -I../../third_party/libaom/source/config/linux/ppc64 -I../../third_party/ots/src/include -Igen/v8/include -I../../third_party/fp16/src/include -I../../third_party/emoji-segmenter/src -I../../third_party/libgav1/src -I../../third_party/libgav1/src/src -I../../third_party/one_euro_filter/src -I../../third_party/snappy/src -I../../third_party/snappy/linux -Wimplicit-fallthrough -Wextra-semi -Wunreachable-code-aggressive -Wthread-safety -Wno-missing-field-initializers -Wno-unused-parameter -Wno-psabi -Wloop-analysis -Wno-unneeded-internal-declaration -Wenum-compare-conditional -Wno-ignored-pragma-optimize -Wno-deprecated-builtins -Wno-bitfield-constant-conversion -Wno-deprecated-this-capture -Wno-invalid-offsetof -Wno-vla-extension -Wno-thread-safety-reference-return -Wshadow -fno-delete-null-pointer-checks -fno-ident -fno-strict-aliasing -fstack-protector -fno-unwind-tables -fno-asynchronous-unwind-tables -fPIC -pthread -fcolor-diagnostics -fmerge-all-constants -fcomplete-member-pointers -no-canonical-prefixes -ftrivial-auto-var-init=pattern -fno-omit-frame-pointer -fvisibility=hidden -Wheader-hygiene -Wstring-conversion -Wtautological-overlap-compare -Wconversion -Wno-float-conversion -Wno-sign-conversion -Wno-implicit-float-conversion -Wno-implicit-int-conversion -Wexit-time-destructors -Wglobal-constructors -isystem/usr/include/glib-2.0 -isystem/usr/lib64/glib-2.0/include -isystem/usr/lib64/libffi/include -Wno-redundant-parens -Wno-redundant-parens -DPROTOBUF_ALLOW_DEPRECATED=1 -isystem/usr/include/nss -isystem/usr/include/nspr -isystem/usr/include/dbus-1.0 -isystem/usr/lib64/dbus-1.0/include -isystem/usr/include/libpng16 -isystem/usr/include/freetype2 -isystem/usr/include/harfbuzz -isystem/usr/include/freetype2 -isystem/usr/include/glib-2.0 -isystem/usr/lib64/glib-2.0/include -Wno-c++11-narrowing-const-reference -std=c++20 -Wno-trigraphs -gsimple-template-names -fno-exceptions -fno-rtti -nostdinc++ -isystem../../third_party/libc++/src/include -isystem../../third_party/libc++abi/src/include -fvisibility-inlines-hidden -O2 -pipe -mcpu=power9 -mtune=power9 -fstack-protector-strong -D_FORTIFY_SOURCE=2 -Wno-unknown-warning-option -c ../../third_party/blink/renderer/platform/fonts/shaping/shape_result.cc -o obj/third_party/blink/renderer/platform/platform/shape_result.o
../../third_party/blink/renderer/platform/fonts/shaping/shape_result.cc:88:1: error: static assertion failed due to requirement '::WTF::internal::SizesEqual<72, 64>::value': ShapeResult should stay small
   88 | ASSERT_SIZE(ShapeResult, SameSizeAsShapeResult);
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../third_party/blink/renderer/platform/wtf/size_assertions.h:26:17: note: expanded from macro 'ASSERT_SIZE'
   26 |   static_assert(::WTF::internal::SizesEqual<sizeof(type),                   \
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   27 |                                             sizeof(same_size_type)>::value, \
      |                                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```