### PR TITLE
app-text/atril: fix dependecies

### DIFF
--- a/app-text/atril/atril-1.28.0.ebuild
+++ b/app-text/atril/atril-1.28.0.ebuild
@@ -24,6 +24,7 @@ COMMON_DEPEND="
 	app-text/poppler[cairo]
 	dev-libs/glib:2
 	dev-libs/libxml2:2
+	>=mate-base/mate-desktop-1.27.1
 	sys-libs/zlib
 	x11-libs/gdk-pixbuf:2
 	x11-libs/gtk+:3[introspection?]


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/929039