### PR TITLE
net-nds/jxplorer: update HOMEPAGE, add github upstream metadata 

### DIFF
--- a/net-nds/jxplorer/jxplorer-3.3.1.2-r1.ebuild
+++ b/net-nds/jxplorer/jxplorer-3.3.1.2-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -7,7 +7,7 @@ JAVA_PKG_IUSE="doc source test"
 inherit desktop java-pkg-2 java-ant-2 prefix virtualx
 
 DESCRIPTION="Fully functional LDAP browser written in Java"
-HOMEPAGE="http://jxplorer.org/"
+HOMEPAGE="https://jxplorer.org/"
 SRC_URI="mirror://sourceforge/${PN}/${P}-project.zip"
 S="${WORKDIR}/${PN}"
 

--- a/net-nds/jxplorer/metadata.xml
+++ b/net-nds/jxplorer/metadata.xml
@@ -6,6 +6,7 @@
 		<name>Java</name>
 	</maintainer>
 	<upstream>
+		<remote-id type="github">pegacat/jxplorer</remote-id>
 		<remote-id type="sourceforge">jxplorer</remote-id>
 	</upstream>
 </pkgmetadata>


### PR DESCRIPTION
building from the Github tarball would require more investigation. at least it would not install that empty directory `/usr/share/jxplorer/plugins` as the sources from sourceforge does.

generally i would opt for last riting this package as it seems to be unused. 
if this package was used by someone there should be bug reports about runtime errors which i get when starting it from cmdline.

using the `tar.bz2` from sourceforce instead of `.zip` we could have something like [this one](https://github.com/gentoo/gentoo/compare/master...vaukai:gentoo:jxplorer_simple) with tests running fine.