### PR TITLE
toolchain.eclass: fix installation of gcc[test] packages from binary

### DIFF
--- a/eclass/toolchain.eclass
+++ b/eclass/toolchain.eclass
@@ -2325,7 +2325,7 @@ create_revdep_rebuild_entry() {
 #---->> pkg_pre* <<----
 
 toolchain_pkg_preinst() {
-	if use test ; then
+	if [[ ${MERGE_TYPE} != binary ]] && use test ; then
 		# Install as orphaned to allow comparison across more versions even
 		# after unmerged. Also useful for historical records and tracking
 		# down regressions a while after they first appeared, but were only


### PR DESCRIPTION
Error message:
/var/tmp/portage/sys-devel/gcc-13.2.1_p20240210/temp/environment: line 4414: cd: /var/tmp/portage/sys-devel/gcc-13.2.1_p20240210/temp/test-results: No such file or directory

At the point of (re)installation of a gcc binary package, the temporary directory usually doesn't exist at all.