### PR TITLE
media-gfx/openvdb: 11.0.0 fix abi-compat USE

### DIFF
--- a/media-gfx/openvdb/openvdb-11.0.0.ebuild
+++ b/media-gfx/openvdb/openvdb-11.0.0.ebuild
@@ -175,21 +175,22 @@ src_prepare() {
 }
 
 my_src_configure() {
-	local version
+	local version abi_version
 	version=$(ver_cut 1)
+	abi_version="${version}"
 	if use "abi$(( version + 1 ))-compat"; then
-		version=$(( version + 1 ))
+		abi_version=$(( version + 1 ))
 	elif use "abi$(( version - 1 ))-compat"; then
-		version=$(( version - 1 ))
+		abi_version=$(( version - 1 ))
 	elif use "abi$(( version - 2 ))-compat"; then
-		version=$(( version - 2 ))
+		abi_version=$(( version - 2 ))
 	fi
 
 	local mycmakeargs=(
 		-DCMAKE_FIND_PACKAGE_PREFER_CONFIG="yes"
 		-DCMAKE_INSTALL_DOCDIR="share/doc/${PF}/"
 
-		-DOPENVDB_ABI_VERSION_NUMBER="${version}"
+		-DOPENVDB_ABI_VERSION_NUMBER="${abi_version}"
 		-DOPENVDB_BUILD_DOCS="$(usex doc)"
 		-DOPENVDB_BUILD_UNITTESTS="$(usex test)"
 		-DOPENVDB_BUILD_VDB_LOD="$(usex utils)"


### PR DESCRIPTION
The values for `-DOPENVDB_USE_*_ABI` are derived from the initial value of `version`.
By changing the value of `version` depending on the abi*-compat USE-flag they are instead derived from the modified value for any USE="!abi11-compat".
That results in `usex abi*-compat`-queries on values outside of the supported +1/-2 range.

Closes: https://bugs.gentoo.org/929926