### PR TITLE
net-p2p/freenet: Add dep on dev-java/commons-io

### DIFF
--- a/net-p2p/freenet/freenet-0.7.5_p1497-r1.ebuild
+++ b/net-p2p/freenet/freenet-0.7.5_p1497-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -31,6 +31,7 @@ IUSE="+nss"
 CP_DEPEND="
 	dev-java/bcprov:0
 	dev-java/commons-compress:0
+	dev-java/commons-io:1
 	dev-java/fec:0
 	dev-java/freenet-ext:29
 	dev-java/jbitcollider-core:0


### PR DESCRIPTION
The dev-java/commons-io library is always installed thanks to a transitive dependency through dev-java/commons-compress, but it doesn't get picked up by the classpath builder in the ebuild, resulting in runtime errors. Add a direct dep to force it to be present in the classpath.

Closes: https://bugs.gentoo.org/929961