### PR TITLE
sci-libs/opencascasde: fix vtk_components.patch

### DIFF
--- a/sci-libs/opencascade/files/opencascade-7.8.1-vtk_components.patch
+++ b/sci-libs/opencascade/files/opencascade-7.8.1-vtk_components.patch
@@ -6,7 +6,7 @@ index 7d25a37..79257d1 100644
    set (ENV{VTK_DIR} "${3RDPARTY_VTK_DIR}")
  endif()
  
--find_package(VTK)
+-find_package(VTK QUIET)
 +find_package(VTK
 +  COMPONENTS
 +    CommonCore


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/930016