### PR TITLE
dev-util/ruff: disable unprefixed malloc on unsupported platforms

### DIFF
--- a/dev-util/ruff/ruff-0.3.7.ebuild
+++ b/dev-util/ruff/ruff-0.3.7.ebuild
@@ -399,7 +399,7 @@ BDEPEND="
 	>=virtual/rust-1.71
 "
 RDEPEND="
-	dev-libs/jemalloc:=
+	!elibc_musl? ( !elibc_Darwin? ( !elibc_bionic? ( dev-libs/jemalloc:= ) ) )
 "
 DEPEND="
 	${RDEPEND}
@@ -422,8 +422,11 @@ src_configure() {
 }
 
 src_compile() {
-	local -x CARGO_FEATURE_UNPREFIXED_MALLOC_ON_SUPPORTED_PLATFORMS=1
-	local -x JEMALLOC_OVERRIDE="${ESYSROOT}/usr/$(get_libdir)"/libjemalloc.so
+	# Gentoo bug #927338
+	if use !elibc_musl && use !elibc_Darwin && use !elibc_bionic; then
+		local -x CARGO_FEATURE_UNPREFIXED_MALLOC_ON_SUPPORTED_PLATFORMS=1
+		local -x JEMALLOC_OVERRIDE="${ESYSROOT}/usr/$(get_libdir)"/libjemalloc.so
+	fi
 	cargo_src_compile --bin ruff --bin ruff_shrinking
 
 	local releasedir


### PR DESCRIPTION
According to https://github.com/gnzlbg/jemallocator/blob/master/jemalloc-sys/build.rs#L36-L45:
```rust
const NO_UNPREFIXED_MALLOC: &[&str] = &["android", "dragonfly", "musl", "darwin"];
```

Closes: https://bugs.gentoo.org/927338
Closes: https://bugs.gentoo.org/928621