### PR TITLE
sys-cluster/poolmon: EAPI8 bump, fix LICENSE

### DIFF
--- a/sys-cluster/poolmon/poolmon-0.6-r1.ebuild
+++ b/sys-cluster/poolmon/poolmon-0.6-r1.ebuild
@@ -1,18 +1,16 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
 
-DESCRIPTION="A director mailserver pool monitoring script for Dovecot"
+DESCRIPTION="Director mailserver pool monitoring script for Dovecot"
 HOMEPAGE="https://github.com/brandond/poolmon"
 SRC_URI="https://github.com/brandond/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
 
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE=""
 
-DEPEND=""
 RDEPEND="
 	dev-perl/IO-Socket-SSL
 	net-mail/dovecot


### PR DESCRIPTION
pretty simple `EAPI8` bump