### PR TITLE
net-analyzer/nagios-check_mysql_health: EAPI8 bump

### DIFF
--- a/net-analyzer/nagios-check_mysql_health/nagios-check_mysql_health-2.2.2-r1.ebuild
+++ b/net-analyzer/nagios-check_mysql_health/nagios-check_mysql_health-2.2.2-r1.ebuild
@@ -1,0 +1,39 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+MY_PN="${PN#nagios-}"
+MY_P="${MY_PN}-${PV}"
+
+DESCRIPTION="Nagios plugin for checking MySQL server health"
+HOMEPAGE="https://labs.consol.de/nagios/check_mysql_health/"
+SRC_URI="https://labs.consol.de/assets/downloads/nagios/${MY_P}.tar.gz"
+S="${WORKDIR}/${MY_P}"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+# Found by grepping for "use " in the built
+# plugins-scripts/check_mysql_health.
+RDEPEND="
+	dev-perl/DBD-mysql
+	dev-perl/DBI
+	virtual/perl-Data-Dumper
+	virtual/perl-File-Temp
+	virtual/perl-Net-Ping
+	virtual/perl-Time-HiRes
+	"
+
+src_configure() {
+	# Should match net-analyzer/{monitoring,nagios}-plugins.
+	econf --libexecdir="/usr/$(get_libdir)/nagios/plugins"
+}
+
+# Here we should have a pkg_preinst() that creates the nagios user/group
+# (using the same command from e.g. net-analyzer/nagios-plugins). But
+# right now, the build system for check_mysql_health has a bug: it
+# doesn't use the configured user (INSTALL_OPTIONS aren't passed to
+# /usr/bin/install), so it's pointless. Don't forget to inherit
+# user.eclass!


### PR DESCRIPTION
again, a pretty simpe `EAPI8` bump.

```diff
--- nagios-check_mysql_health-2.2.2.ebuild	2023-04-01 17:48:26.504947115 +0200
+++ nagios-check_mysql_health-2.2.2-r1.ebuild	2024-04-14 20:41:54.418959950 +0200
@@ -1,30 +1,30 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
 
 MY_PN="${PN#nagios-}"
 MY_P="${MY_PN}-${PV}"
 
-DESCRIPTION="A nagios plugin for checking MySQL server health"
+DESCRIPTION="Nagios plugin for checking MySQL server health"
 HOMEPAGE="https://labs.consol.de/nagios/check_mysql_health/"
 SRC_URI="https://labs.consol.de/assets/downloads/nagios/${MY_P}.tar.gz"
+S="${WORKDIR}/${MY_P}"
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="amd64 x86"
-IUSE=""
+KEYWORDS="~amd64 ~x86"
 
 # Found by grepping for "use " in the built
 # plugins-scripts/check_mysql_health.
-RDEPEND="dev-perl/DBD-mysql
+RDEPEND="
+	dev-perl/DBD-mysql
 	dev-perl/DBI
 	virtual/perl-Data-Dumper
 	virtual/perl-File-Temp
 	virtual/perl-Net-Ping
-	virtual/perl-Time-HiRes"
-
-S="${WORKDIR}/${MY_P}"
+	virtual/perl-Time-HiRes
+	"
 
 src_configure() {
 	# Should match net-analyzer/{monitoring,nagios}-plugins.
```