### PR TITLE
sci-libs/spr: fix bug #930029

### DIFF
--- a/sci-libs/spr/spr-3.3.2-r2.ebuild
+++ b/sci-libs/spr/spr-3.3.2-r2.ebuild
@@ -40,7 +40,7 @@ src_configure() {
 
 src_install() {
 	default
-	if use static-libs; then
+	if ! use static-libs; then
 		find "${ED}" -name '*.la' -delete || die
 	fi
 }


### PR DESCRIPTION
@arthurzam 
simply forgot to add an `!` to the `if` statement.

Signed-off-by: Michael Mair-Keimberger <mmk@levelnine.at>

Closes: https://bugs.gentoo.org/930029