### PR TITLE
subslot dev-libs/tree-sitter

### DIFF
--- a/app-editors/emacs/emacs-29.2-r2.ebuild
+++ b/app-editors/emacs/emacs-29.2-r2.ebuild
@@ -121,7 +121,7 @@ RDEPEND="app-emacs/emacs-common[games?,gui(-)?]
 	sqlite? ( dev-db/sqlite:3 )
 	ssl? ( net-libs/gnutls:0= )
 	systemd? ( sys-apps/systemd )
-	tree-sitter? ( dev-libs/tree-sitter )
+	tree-sitter? ( dev-libs/tree-sitter:= )
 	valgrind? ( dev-debug/valgrind )
 	zlib? ( sys-libs/zlib )
 	gui? (

--- a/app-editors/emacs/emacs-29.3-r1.ebuild
+++ b/app-editors/emacs/emacs-29.3-r1.ebuild
@@ -121,7 +121,7 @@ RDEPEND="app-emacs/emacs-common[games?,gui(-)?]
 	sqlite? ( dev-db/sqlite:3 )
 	ssl? ( net-libs/gnutls:0= )
 	systemd? ( sys-apps/systemd )
-	tree-sitter? ( dev-libs/tree-sitter )
+	tree-sitter? ( dev-libs/tree-sitter:= )
 	valgrind? ( dev-debug/valgrind )
 	zlib? ( sys-libs/zlib )
 	gui? (

--- a/app-editors/emacs/emacs-29.3.9999.ebuild
+++ b/app-editors/emacs/emacs-29.3.9999.ebuild
@@ -118,7 +118,7 @@ RDEPEND="app-emacs/emacs-common[games?,gui(-)?]
 	sqlite? ( dev-db/sqlite:3 )
 	ssl? ( net-libs/gnutls:0= )
 	systemd? ( sys-apps/systemd )
-	tree-sitter? ( dev-libs/tree-sitter )
+	tree-sitter? ( dev-libs/tree-sitter:= )
 	valgrind? ( dev-debug/valgrind )
 	zlib? ( sys-libs/zlib )
 	gui? (

--- a/app-editors/emacs/emacs-30.0.9999.ebuild
+++ b/app-editors/emacs/emacs-30.0.9999.ebuild
@@ -117,7 +117,7 @@ RDEPEND="app-emacs/emacs-common[games?,gui(-)?]
 	sqlite? ( dev-db/sqlite:3 )
 	ssl? ( net-libs/gnutls:0= )
 	systemd? ( sys-apps/systemd )
-	tree-sitter? ( dev-libs/tree-sitter )
+	tree-sitter? ( dev-libs/tree-sitter:= )
 	valgrind? ( dev-debug/valgrind )
 	xattr? ( sys-apps/attr )
 	zlib? ( sys-libs/zlib )

--- a/dev-libs/tree-sitter/tree-sitter-0.22.4-r1.ebuild
+++ b/dev-libs/tree-sitter/tree-sitter-0.22.4-r1.ebuild
@@ -1,0 +1,49 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+inherit optfeature toolchain-funcs
+
+DESCRIPTION="Tree-sitter is a parser generator tool and an incremental parsing library"
+HOMEPAGE="https://github.com/tree-sitter/tree-sitter"
+
+if [[ ${PV} == *9999* ]]; then
+	inherit git-r3
+	EGIT_REPO_URI="https://github.com/${PN}/${PN}"
+else
+	SRC_URI="https://github.com/${PN}/${PN}/archive/refs/tags/v${PV}.tar.gz -> ${P}.tar.gz"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~x64-macos"
+fi
+
+LICENSE="MIT"
+# soname is .0, but abi was broken unexpectedly
+# Bug #930039
+SLOT="0/1"
+RESTRICT="test" # tests are for CLI and not the lib
+
+PATCHES=(
+	"${FILESDIR}/${PN}-0.22.2-no-static.patch"
+)
+
+src_prepare() {
+	default
+	tc-export CC
+}
+
+src_compile() {
+	emake \
+		PREFIX="${EPREFIX}/usr" \
+		LIBDIR="${EPREFIX}/usr/$(get_libdir)" \
+		STRIP="" # bug 930020
+}
+
+src_install() {
+	emake DESTDIR="${D}" \
+		  PREFIX="${EPREFIX}/usr" \
+		  LIBDIR="${EPREFIX}/usr/$(get_libdir)" \
+		  install
+}
+
+pkg_postinst() {
+	optfeature "building and testing grammars" dev-util/tree-sitter-cli
+}

--- a/dev-python/tree-sitter/tree-sitter-0.21.0-r1.ebuild
+++ b/dev-python/tree-sitter/tree-sitter-0.21.0-r1.ebuild
@@ -43,7 +43,7 @@ SLOT="0"
 KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~loong ppc ppc64 ~riscv ~s390 ~sparc x86 ~x64-macos"
 
 # setuptools is needed for distutils import
-DEPEND=">=dev-libs/tree-sitter-0.22.1"
+DEPEND=">=dev-libs/tree-sitter-0.22.1:="
 RDEPEND="${DEPEND}
 	$(python_gen_cond_dep '
 		dev-python/setuptools[${PYTHON_USEDEP}]

--- a/dev-util/pkgcheck/pkgcheck-0.10.27-r2.ebuild
+++ b/dev-util/pkgcheck/pkgcheck-0.10.27-r2.ebuild
@@ -12,8 +12,12 @@ if [[ ${PV} == *9999 ]] ; then
 		https://github.com/pkgcore/pkgcheck.git"
 	inherit git-r3
 else
-	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~x64-macos"
+	KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~loong ppc ppc64 ~riscv ~s390 sparc x86 ~x64-macos"
 	inherit pypi
+	SRC_URI+="
+		https://gitlab.gentoo.org/pkgcore/pkgcheck/-/commit/9103513e26f9f2aeade5b563a49697c0e2665e3e.patch
+			-> ${P}-git-2.43.2.patch
+	"
 fi
 
 DESCRIPTION="pkgcore-based QA utility for ebuild repos"
@@ -29,17 +33,17 @@ if [[ ${PV} == *9999 ]]; then
 		~sys-apps/pkgcore-9999[${PYTHON_USEDEP}]"
 else
 	RDEPEND="
-		>=dev-python/snakeoil-0.10.7[${PYTHON_USEDEP}]
-		>=sys-apps/pkgcore-0.12.25[${PYTHON_USEDEP}]"
+		>=dev-python/snakeoil-0.10.4[${PYTHON_USEDEP}]
+		>=sys-apps/pkgcore-0.12.21[${PYTHON_USEDEP}]"
 fi
 RDEPEND+="
-	>=dev-libs/tree-sitter-0.20.9
-	>=dev-libs/tree-sitter-bash-0.20.5
+	dev-libs/tree-sitter:=
+	>=dev-libs/tree-sitter-bash-0.20.4
 	dev-python/chardet[${PYTHON_USEDEP}]
 	dev-python/lazy-object-proxy[${PYTHON_USEDEP}]
 	dev-python/lxml[${PYTHON_USEDEP}]
 	dev-python/pathspec[${PYTHON_USEDEP}]
-	>=dev-python/tree-sitter-0.20.4[${PYTHON_USEDEP}]
+	>=dev-python/tree-sitter-0.19.0[${PYTHON_USEDEP}]
 	emacs? (
 		>=app-editors/emacs-24.1:*
 		app-emacs/ebuild-mode
@@ -55,15 +59,15 @@ BDEPEND="${RDEPEND}
 	)
 "
 
+PATCHES=(
+	"${DISTDIR}"/${P}-git-2.43.2.patch
+)
+
 SITEFILE="50${PN}-gentoo.el"
 
 distutils_enable_tests pytest
 
 export USE_SYSTEM_TREE_SITTER_BASH=1
-
-EPYTEST_DESELECT=(
-	tests/checks/test_git.py::TestGitPkgCommitsCheck::test_missing_move
-)
 
 src_compile() {
 	distutils-r1_src_compile

--- a/dev-util/pkgcheck/pkgcheck-0.10.28-r1.ebuild
+++ b/dev-util/pkgcheck/pkgcheck-0.10.28-r1.ebuild
@@ -12,12 +12,8 @@ if [[ ${PV} == *9999 ]] ; then
 		https://github.com/pkgcore/pkgcheck.git"
 	inherit git-r3
 else
-	KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~loong ppc ppc64 ~riscv ~s390 sparc x86 ~x64-macos"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~x64-macos"
 	inherit pypi
-	SRC_URI+="
-		https://gitlab.gentoo.org/pkgcore/pkgcheck/-/commit/9103513e26f9f2aeade5b563a49697c0e2665e3e.patch
-			-> ${P}-git-2.43.2.patch
-	"
 fi
 
 DESCRIPTION="pkgcore-based QA utility for ebuild repos"
@@ -33,17 +29,17 @@ if [[ ${PV} == *9999 ]]; then
 		~sys-apps/pkgcore-9999[${PYTHON_USEDEP}]"
 else
 	RDEPEND="
-		>=dev-python/snakeoil-0.10.4[${PYTHON_USEDEP}]
-		>=sys-apps/pkgcore-0.12.21[${PYTHON_USEDEP}]"
+		>=dev-python/snakeoil-0.10.7[${PYTHON_USEDEP}]
+		>=sys-apps/pkgcore-0.12.25[${PYTHON_USEDEP}]"
 fi
 RDEPEND+="
-	dev-libs/tree-sitter
-	>=dev-libs/tree-sitter-bash-0.20.4
+	>=dev-libs/tree-sitter-0.20.9:=
+	>=dev-libs/tree-sitter-bash-0.20.5
 	dev-python/chardet[${PYTHON_USEDEP}]
 	dev-python/lazy-object-proxy[${PYTHON_USEDEP}]
 	dev-python/lxml[${PYTHON_USEDEP}]
 	dev-python/pathspec[${PYTHON_USEDEP}]
-	>=dev-python/tree-sitter-0.19.0[${PYTHON_USEDEP}]
+	>=dev-python/tree-sitter-0.20.4[${PYTHON_USEDEP}]
 	emacs? (
 		>=app-editors/emacs-24.1:*
 		app-emacs/ebuild-mode
@@ -59,15 +55,15 @@ BDEPEND="${RDEPEND}
 	)
 "
 
-PATCHES=(
-	"${DISTDIR}"/${P}-git-2.43.2.patch
-)
-
 SITEFILE="50${PN}-gentoo.el"
 
 distutils_enable_tests pytest
 
 export USE_SYSTEM_TREE_SITTER_BASH=1
+
+EPYTEST_DESELECT=(
+	tests/checks/test_git.py::TestGitPkgCommitsCheck::test_missing_move
+)
 
 src_compile() {
 	distutils-r1_src_compile

--- a/dev-util/rizin/rizin-0.6.3-r1.ebuild
+++ b/dev-util/rizin/rizin-0.6.3-r1.ebuild
@@ -3,10 +3,10 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..11} )
 
 # This is the commit that the CI for the release commit used
-BINS_COMMIT="1203a9a2f51e32337c8434d9f4f7c4543552e271"
+BINS_COMMIT="903588ed69d7717069955322b31dad5e666b338a"
 
 inherit meson python-any-r1
 
@@ -15,7 +15,7 @@ HOMEPAGE="https://rizin.re/"
 
 SRC_URI="mirror+https://github.com/rizinorg/rizin/releases/download/v${PV}/rizin-src-v${PV}.tar.xz
 	test? ( https://github.com/rizinorg/rizin-testbins/archive/${BINS_COMMIT}.tar.gz -> rizin-testbins-${BINS_COMMIT}.tar.gz )"
-KEYWORDS="~amd64 ~arm64 ~x86"
+KEYWORDS="amd64 ~arm64 ~x86"
 
 LICENSE="Apache-2.0 BSD LGPL-3 MIT"
 SLOT="0/${PV}"
@@ -28,13 +28,11 @@ RESTRICT="test? ( fetch ) !test? ( test )"
 RDEPEND="
 	app-arch/lz4:0=
 	app-arch/xz-utils
-	app-arch/zstd:=
 	>=dev-libs/capstone-5:0=
 	dev-libs/libmspack
 	dev-libs/libzip:0=
 	dev-libs/openssl:0=
-	dev-libs/libpcre2:0=
-	>=dev-libs/tree-sitter-0.19.0
+	>=dev-libs/tree-sitter-0.19.0:=
 	dev-libs/xxhash
 	sys-apps/file
 	sys-libs/zlib:0=
@@ -44,6 +42,7 @@ BDEPEND="${PYTHON_DEPS}"
 
 PATCHES=(
 	"${FILESDIR}/${PN}-0.4.0-never-rebuild-parser.patch"
+	"${FILESDIR}/${PN}-0.5.2-find-tree-sitter-parser.patch"
 )
 
 S="${WORKDIR}/${PN}-v${PV}"
@@ -75,12 +74,11 @@ src_configure() {
 		-Duse_sys_capstone=enabled
 		-Duse_sys_libmspack=enabled
 		-Duse_sys_libzip=enabled
-		-Duse_sys_libzstd=enabled
 		-Duse_sys_lz4=enabled
 		-Duse_sys_lzma=enabled
 		-Duse_sys_magic=enabled
-		-Duse_sys_openssl=enabled
-		-Duse_sys_pcre2=enabled
+		# https://github.com/rizinorg/rizin/issues/3841
+		# -Duse_sys_openssl=enabled
 		-Duse_sys_tree_sitter=enabled
 		-Duse_sys_xxhash=enabled
 		-Duse_sys_zlib=enabled

--- a/dev-util/rizin/rizin-0.7.1-r1.ebuild
+++ b/dev-util/rizin/rizin-0.7.1-r1.ebuild
@@ -1,12 +1,12 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..11} )
+PYTHON_COMPAT=( python3_{10..12} )
 
 # This is the commit that the CI for the release commit used
-BINS_COMMIT="903588ed69d7717069955322b31dad5e666b338a"
+BINS_COMMIT="1203a9a2f51e32337c8434d9f4f7c4543552e271"
 
 inherit meson python-any-r1
 
@@ -15,7 +15,7 @@ HOMEPAGE="https://rizin.re/"
 
 SRC_URI="mirror+https://github.com/rizinorg/rizin/releases/download/v${PV}/rizin-src-v${PV}.tar.xz
 	test? ( https://github.com/rizinorg/rizin-testbins/archive/${BINS_COMMIT}.tar.gz -> rizin-testbins-${BINS_COMMIT}.tar.gz )"
-KEYWORDS="amd64 ~arm64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 
 LICENSE="Apache-2.0 BSD LGPL-3 MIT"
 SLOT="0/${PV}"
@@ -28,11 +28,13 @@ RESTRICT="test? ( fetch ) !test? ( test )"
 RDEPEND="
 	app-arch/lz4:0=
 	app-arch/xz-utils
+	app-arch/zstd:=
 	>=dev-libs/capstone-5:0=
 	dev-libs/libmspack
 	dev-libs/libzip:0=
 	dev-libs/openssl:0=
-	>=dev-libs/tree-sitter-0.19.0
+	dev-libs/libpcre2:0=
+	>=dev-libs/tree-sitter-0.19.0:=
 	dev-libs/xxhash
 	sys-apps/file
 	sys-libs/zlib:0=
@@ -42,7 +44,6 @@ BDEPEND="${PYTHON_DEPS}"
 
 PATCHES=(
 	"${FILESDIR}/${PN}-0.4.0-never-rebuild-parser.patch"
-	"${FILESDIR}/${PN}-0.5.2-find-tree-sitter-parser.patch"
 )
 
 S="${WORKDIR}/${PN}-v${PV}"
@@ -74,11 +75,12 @@ src_configure() {
 		-Duse_sys_capstone=enabled
 		-Duse_sys_libmspack=enabled
 		-Duse_sys_libzip=enabled
+		-Duse_sys_libzstd=enabled
 		-Duse_sys_lz4=enabled
 		-Duse_sys_lzma=enabled
 		-Duse_sys_magic=enabled
-		# https://github.com/rizinorg/rizin/issues/3841
-		# -Duse_sys_openssl=enabled
+		-Duse_sys_openssl=enabled
+		-Duse_sys_pcre2=enabled
 		-Duse_sys_tree_sitter=enabled
 		-Duse_sys_xxhash=enabled
 		-Duse_sys_zlib=enabled

--- a/dev-util/tree-sitter-cli/tree-sitter-cli-0.20.9-r1.ebuild
+++ b/dev-util/tree-sitter-cli/tree-sitter-cli-0.20.9-r1.ebuild
@@ -206,7 +206,7 @@ KEYWORDS="amd64 arm arm64 ~loong ppc ppc64 ~riscv ~s390 sparc x86"
 # Test seems to require files (grammar definitions) that we don't have.
 RESTRICT="test"
 
-BDEPEND="~dev-libs/tree-sitter-${PV}"
+BDEPEND="~dev-libs/tree-sitter-${PV}:="
 RDEPEND="${BDEPEND}"
 
 QA_FLAGS_IGNORED="usr/bin/${MY_PN}"

--- a/dev-util/tree-sitter-cli/tree-sitter-cli-0.22.1-r1.ebuild
+++ b/dev-util/tree-sitter-cli/tree-sitter-cli-0.22.1-r1.ebuild
@@ -28,7 +28,7 @@ KEYWORDS="~amd64 ~arm ~arm64 ~loong ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
 # Test seems to require files (grammar definitions) that we don't have.
 RESTRICT="test"
 
-BDEPEND="~dev-libs/tree-sitter-${PV}"
+BDEPEND="~dev-libs/tree-sitter-${PV}:="
 RDEPEND="${BDEPEND}"
 
 QA_FLAGS_IGNORED="usr/bin/${MY_PN}"

--- a/dev-util/tree-sitter-cli/tree-sitter-cli-0.22.2-r1.ebuild
+++ b/dev-util/tree-sitter-cli/tree-sitter-cli-0.22.2-r1.ebuild
@@ -29,7 +29,7 @@ KEYWORDS="amd64 arm arm64 ~loong ppc ppc64 ~riscv ~s390 sparc x86"
 # Test seems to require files (grammar definitions) that we don't have.
 RESTRICT="test"
 
-BDEPEND="~dev-libs/tree-sitter-${PV}"
+BDEPEND="~dev-libs/tree-sitter-${PV}:="
 RDEPEND="${BDEPEND}"
 
 QA_FLAGS_IGNORED="usr/bin/${MY_PN}"

--- a/dev-util/tree-sitter-cli/tree-sitter-cli-0.22.4-r1.ebuild
+++ b/dev-util/tree-sitter-cli/tree-sitter-cli-0.22.4-r1.ebuild
@@ -26,7 +26,7 @@ KEYWORDS="~amd64 ~arm ~arm64 ~loong ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
 # Test seems to require files (grammar definitions) that we don't have.
 RESTRICT="test"
 
-BDEPEND="~dev-libs/tree-sitter-${PV}"
+BDEPEND="~dev-libs/tree-sitter-${PV}:="
 RDEPEND="${BDEPEND}"
 
 QA_FLAGS_IGNORED="usr/bin/${MY_PN}"

--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -33,6 +33,10 @@
 
 #--- END OF EXAMPLES ---
 
+# Matthew Smith <matthew@gentoo.org> (2024-04-15)
+# Unexpected ABI break, bug #930039
+=dev-libs/tree-sitter-0.22.4
+
 # Fabian Groffen <grobian@gentoo.org> (2024-04-13)
 # Python wrapper around liblmsensors, no reverse dependencies
 # Removal on 2024-05-13, bug #929495


### PR DESCRIPTION
Some versions of dev-python/tree-sitter and app-editors/neovim already had the subslot := operator.