### PR TITLE
dev-embedded/esptool: make python multi-impl

### DIFF
--- a/dev-embedded/esptool/esptool-4.7.0-r2.ebuild
+++ b/dev-embedded/esptool/esptool-4.7.0-r2.ebuild
@@ -5,7 +5,6 @@ EAPI=8
 
 PYTHON_COMPAT=( python3_{10..12} )
 DISTUTILS_USE_PEP517=setuptools
-DISTUTILS_SINGLE_IMPL=1
 
 inherit distutils-r1
 


### PR DESCRIPTION
There seems to be no reason why esptool is python single-impl.

Being python single-impl causes issues for consumer of the dev-embedded/esptool dependency. For example, dev-embedded/esp-idf (from ::guru), currently declares the dev-embedded/esptool dependency without [${PYTHON_USEDEP}] as consequence of this.