### PR TITLE
Correct CUPS CPE string

### DIFF
--- a/net-print/cups/metadata.xml
+++ b/net-print/cups/metadata.xml
@@ -9,7 +9,7 @@
 		<flag name="openssl">Use <pkg>dev-libs/openssl</pkg> instead of <pkg>net-libs/gnutls</pkg> for TLS support</flag>
 	</use>
 	<upstream>
-		<remote-id type="cpe">cpe:/a:apple:cups</remote-id>
+		<remote-id type="cpe">cpe:/a:openprinting:cups</remote-id>
 		<remote-id type="github">OpenPrinting/cups</remote-id>
 	</upstream>
 </pkgmetadata>


### PR DESCRIPTION
We use the openprinting copy of CUPS, not the Apple one.

Closes: https://bugs.gentoo.org/930069