### PR TITLE
media-sound/sox: add BDEPEND on dev-build/autoconf-archive, #904367

### DIFF
--- a/media-sound/sox/sox-14.4.2_p20210509-r2.ebuild
+++ b/media-sound/sox/sox-14.4.2_p20210509-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -25,6 +25,7 @@ IUSE="alsa amr ao encode flac id3tag ladspa mad magic ogg openmp oss opus png pu
 BDEPEND="
 	app-arch/unzip
 	virtual/pkgconfig
+	dev-build/autoconf-archive
 "
 RDEPEND="
 	dev-libs/libltdl:0=


### PR DESCRIPTION
There's a missing dependency on dev-build/autoconf-archive.  eautoreconf generates a faulty configure script if the AX_APPEND_COMPILE_FLAGS function is not defined anywhere.