### PR TITLE
app-editors/qhexedit2: upgrade to Python 3.12

### DIFF
--- a/app-editors/qhexedit2/qhexedit2-0.8.9_p20210525-r3.ebuild
+++ b/app-editors/qhexedit2/qhexedit2-0.8.9_p20210525-r3.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{10..12} )
 inherit python-r1 qmake-utils
 
 EGIT_COMMIT="541139125be034b90b6811a84faa1413e357fd94"


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/929299