### PR TITLE
distutils-r1.eclass: improved scikit-build-core

### DIFF
--- a/dev-python/pyzmq/pyzmq-26.0.0.ebuild
+++ b/dev-python/pyzmq/pyzmq-26.0.0.ebuild
@@ -54,10 +54,9 @@ distutils_enable_tests pytest
 # 	dev-python/myst-parser
 
 src_configure() {
-	export ZMQ_DRAFT_API=$(usex drafts '1' '0')
-
-	# TODO: remove this when we update the eclass
-	export SKBUILD_INSTALL_STRIP=false
+	DISTUTILS_ARGS=(
+		-DZMQ_DRAFT_API="$(usex drafts)"
+	)
 }
 
 src_test() {

--- a/eclass/distutils-r1.eclass
+++ b/eclass/distutils-r1.eclass
@@ -448,6 +448,12 @@ unset -f _distutils_set_globals
 # An array containing options to be passed to the build system.
 # Supported by a subset of build systems used by the eclass.
 #
+# For maturin, the arguments will be passed as `maturin build`
+# arguments.
+#
+# For meson-python, the arguments will be passed as `meson setup`
+# arguments.
+#
 # For setuptools, the arguments will be passed as first parameters
 # to setup.py invocations (via esetup.py), as well as to the PEP517
 # backend.  For future compatibility, only global options should be used


### PR DESCRIPTION
Add support for passing CMake arguments, pass some sane defaults and copy some hacks over from `cmake.eclass`.