### PR TITLE
meson.eclass: preserve exit status in phase funcs

### DIFF
--- a/eclass/meson.eclass
+++ b/eclass/meson.eclass
@@ -425,7 +425,10 @@ meson_src_configure() {
 		export -n {C,CPP,CXX,F,OBJC,OBJCXX,LD}FLAGS PKG_CONFIG_{LIBDIR,PATH}
 		echo meson setup "${MESONARGS[@]}" >&2
 		meson setup "${MESONARGS[@]}"
-	) || die -n
+	)
+	local rv=$?
+	[[ ${rv} -eq 0 ]] || die -n "configure failed"
+	return ${rv}
 }
 
 # @FUNCTION: meson_src_compile
@@ -451,9 +454,12 @@ meson_src_compile() {
 
 	set -- meson compile "${mesoncompileargs[@]}"
 	echo "$@" >&2
-	"$@" || die -n "compile failed"
+	"$@"
+	local rv=$?
+	[[ ${rv} -eq 0 ]] || die -n "compile failed"
 
 	popd > /dev/null || die
+	return ${rv}
 }
 
 # @FUNCTION: meson_src_test
@@ -473,9 +479,12 @@ meson_src_test() {
 
 	set -- meson test "${mesontestargs[@]}"
 	echo "$@" >&2
-	"$@" || die -n "tests failed"
+	"$@"
+	local rv=$?
+	[[ ${rv} -eq 0 ]] || die -n "tests failed"
 
 	popd > /dev/null || die
+	return ${rv}
 }
 
 # @FUNCTION: meson_install
@@ -495,9 +504,12 @@ meson_install() {
 
 	set -- meson install "${mesoninstallargs[@]}"
 	echo "$@" >&2
-	"$@" || die -n "install failed"
+	"$@"
+	local rv=$?
+	[[ ${rv} -eq 0 ]] || die -n "install failed"
 
 	popd > /dev/null || die
+	return ${rv}
 }
 
 # @FUNCTION: meson_src_install


### PR DESCRIPTION
When the functions are called with nonfatal, we need to ensure 'popd' does not clobber the exit status of the called command.

Update meson_src_configure as well just for consistency.

Closes: https://bugs.gentoo.org/930119