### PR TITLE
sys-power/upower: fix tests with >=dev-python/python-dbusmock-0.30.1

### DIFF
--- a/sys-power/upower/files/upower-1.90.2-backport-pr207.patch
+++ b/sys-power/upower/files/upower-1.90.2-backport-pr207.patch
@@ -1,0 +1,43 @@
+https://bugs.gentoo.org/923794
+https://bugs.gentoo.org/927405
+https://gitlab.freedesktop.org/upower/upower/-/merge_requests/207
+https://bugs.debian.org/1059467
+https://github.com/martinpitt/python-dbusmock/pull/192
+
+From bd1e4698f480c6b94afa0536fc02e211ae5a87fb Mon Sep 17 00:00:00 2001
+From: Martin Pitt <martin@piware.de>
+Date: Thu, 28 Dec 2023 21:13:15 +0100
+Subject: [PATCH] linux: Adjust test_bluetooth_le_device for dbusmock 0.30.1
+
+dbusmock 0.30.1 changed the BlueZ template to set the default "Class"
+property to `MOCK_PHONE_CLASS` right away instead of in PairDevice() [1].
+
+test_bluetooth_le_device() relied on the previous implicit default of a
+"0" Class value. Set this explicitly to expect a "generic" device. This
+makes the test work with old and current dbusmock versions.
+
+https://bugs.debian.org/1059467
+
+[1] https://github.com/martinpitt/python-dbusmock/pull/192
+---
+ src/linux/integration-test.py | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/src/linux/integration-test.py b/src/linux/integration-test.py
+index e6861253..4c071e85 100755
+--- a/src/linux/integration-test.py
++++ b/src/linux/integration-test.py
+@@ -2162,7 +2162,9 @@ class Tests(dbusmock.DBusTestCase):
+ 
+         alias = 'Satechi M1 Mouse'
+         battery_level = 99
+-        device_properties = None
++        device_properties = {
++            'Class': dbus.UInt32(0, variant_level=1)
++        }
+ 
+         devs = self._add_bluez_battery_device(alias, device_properties, battery_level)
+         self.assertEqual(len(devs), 1)
+-- 
+GitLab
+

--- a/sys-power/upower/upower-1.90.2.ebuild
+++ b/sys-power/upower/upower-1.90.2.ebuild
@@ -51,6 +51,8 @@ BDEPEND="
 	)
 "
 
+PATCHES=( "${FILESDIR}/${PN}-1.90.2-backport-pr207.patch" )
+
 QA_MULTILIB_PATHS="usr/lib/${PN}/.*"
 
 python_check_deps() {


### PR DESCRIPTION
Test-only fix so no revbump.

Bug: https://bugs.gentoo.org/923794
Bug: https://bugs.gentoo.org/927405
See: https://gitlab.freedesktop.org/upower/upower/-/merge_requests/207
See: https://bugs.debian.org/1059467
See: https://github.com/martinpitt/python-dbusmock/pull/192