### PR TITLE
sys-libs/zlib-ng: Add USE="minizip" for consistency with Zlib

### DIFF
--- a/sys-libs/zlib-ng/metadata.xml
+++ b/sys-libs/zlib-ng/metadata.xml
@@ -7,6 +7,7 @@
 	</maintainer>
 	<use>
 		<flag name="compat">Enable compatibility to <pkg>sys-libs/zlib</pkg></flag>
+		<flag name="minizip">include the minizip-ng library for quick and dirty zip extraction</flag>
 	</use>
 	<upstream>
 		<remote-id type="github">zlib-ng/zlib-ng</remote-id>

--- a/sys-libs/zlib-ng/zlib-ng-2.1.6-r2.ebuild
+++ b/sys-libs/zlib-ng/zlib-ng-2.1.6-r2.ebuild
@@ -21,12 +21,14 @@ CPU_USE=(
 	arm_{crc32,neon}
 	ppc_{altivec,vsx2,vsx3}
 )
-IUSE="compat ${CPU_USE[@]/#/cpu_flags_} test"
+IUSE="compat minizip ${CPU_USE[@]/#/cpu_flags_} test"
 
 RESTRICT="!test? ( test )"
 
 DEPEND="
 	test? ( dev-cpp/gtest )
+	compat? ( minizip? ( sys-libs/minizip-ng[compat(+)] ) )
+	!compat? ( minizip? ( sys-libs/minizip-ng[-compat] ) )
 "
 RDEPEND="
 	compat? ( !sys-libs/zlib )


### PR DESCRIPTION
I've been trying to convert my system over to zlib-ng like Fedora:
https://discussion.fedoraproject.org/t/f40-change-proposal-transitioning-to-zlib-ng-as-a-compatible-replacement-for-zlib-system-wide/95807
https://fedoraproject.org/wiki/Changes/MinizipNGTransition

I forgot about Minizip so let's add a USE flag for it. Long term I think we also need a virtual/zlib package (right now I have sys-libs/zlib in package.provided to satisfy the dependency) but that will involve tree-wide changes everywhere so I'll leave that to someone else.