### PR TITLE
app-text/atril: add gvfs as RDEPEND

### DIFF
--- a/app-text/atril/atril-1.28.0.ebuild
+++ b/app-text/atril/atril-1.28.0.ebuild
@@ -52,6 +52,7 @@ COMMON_DEPEND="
 "
 
 RDEPEND="${COMMON_DEPEND}
+	gnome-base/gvfs
 	virtual/libintl
 "
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/612642