### PR TITLE
media-gfx/simple-scan: fix libadwaita[vala] dependency

### DIFF
--- a/media-gfx/simple-scan/simple-scan-46.0.ebuild
+++ b/media-gfx/simple-scan/simple-scan-46.0.ebuild
@@ -35,7 +35,7 @@ BDEPEND="
 	dev-util/itstool
 	>=sys-devel/gettext-0.19.8
 	virtual/pkgconfig
-	gui-libs/libhandy:1[vala]
+	gui-libs/libadwaita:1[vala]
 	dev-libs/libgusb[vala]
 	colord? ( x11-misc/colord[vala] )
 "


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/932247
