### PR TITLE
dev-libs/libpthread-stubs: keyword 0.5 for ~amd64

### DIFF
--- a/dev-libs/libpthread-stubs/libpthread-stubs-0.5.ebuild
+++ b/dev-libs/libpthread-stubs/libpthread-stubs-0.5.ebuild
@@ -9,7 +9,7 @@ XORG_TARBALL_SUFFIX="xz"
 inherit xorg-3
 
 DESCRIPTION="Pthread functions stubs for platforms missing them"
-KEYWORDS="~amd64 ~ppc-macos ~x64-macos"
+KEYWORDS="~ppc-macos ~x64-macos"
 
 # there is nothing to compile for this package, all its contents are produced by
 # configure. the only make job that matters is make install

--- a/dev-libs/libpthread-stubs/libpthread-stubs-0.5.ebuild
+++ b/dev-libs/libpthread-stubs/libpthread-stubs-0.5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -9,7 +9,7 @@ XORG_TARBALL_SUFFIX="xz"
 inherit xorg-3
 
 DESCRIPTION="Pthread functions stubs for platforms missing them"
-KEYWORDS="~ppc-macos ~x64-macos"
+KEYWORDS="~amd64 ~ppc-macos ~x64-macos"
 
 # there is nothing to compile for this package, all its contents are produced by
 # configure. the only make job that matters is make install


### PR DESCRIPTION
I'm not entirely sure why this library wasn't keyworded for ~amd64 as its a dep for Brave