### PR TITLE
media-sound/klick: Enable py3.12

### DIFF
--- a/media-sound/klick/klick-0.12.2-r4.ebuild
+++ b/media-sound/klick/klick-0.12.2-r4.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{10..12} )
 
 inherit python-any-r1 scons-utils toolchain-funcs
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/929661