### PR TITLE
media-sound/gtick: Fix various build system issues

### DIFF
--- a/media-sound/gtick/files/gtick-0.5.5-autotools.patch
+++ b/media-sound/gtick/files/gtick-0.5.5-autotools.patch
@@ -1,0 +1,27 @@
+--- a/configure.ac	2020-05-17 13:08:52.000000000 +0300
++++ b/configure.ac	2024-04-18 07:54:45.000000000 +0300
+@@ -24,7 +24,6 @@
+ 
+ # Checks for libraries.
+ AC_CHECK_LIB([m], [floor])
+-AC_CHECK_LIB([sndfile], [sf_open])
+ AC_CHECK_LIB([check], [fail_if])
+ AC_CHECK_LIB([dmalloc], [dmalloc_debug])
+ 
+@@ -71,7 +70,7 @@
+ fi
+ 
+ # GNU gettext
+-AM_GNU_GETTEXT
++AM_GNU_GETTEXT(external)
+ AM_GNU_GETTEXT_VERSION(0.19.8)
+ 
+ # directory containing configuration support files
+--- a/Makefile.am	2014-07-27 21:32:03.000000000 +0400
++++ b/Makefile.am	2024-04-18 07:54:01.400000000 +0300
+@@ -1,4 +1,4 @@
+-SUBDIRS = doc intl po src testsuite
++SUBDIRS = doc po src testsuite
+ 
+ EXTRA_DIST = config.rpath \
+ 	     autogen.sh \

--- a/media-sound/gtick/gtick-0.5.5-r1.ebuild
+++ b/media-sound/gtick/gtick-0.5.5-r1.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
-inherit desktop xdg-utils
+inherit autotools desktop xdg-utils
 
 DESCRIPTION="Metronome application supporting different meters and speeds ranging"
 HOMEPAGE="https://www.antcom.de/gtick"
@@ -14,7 +14,8 @@ SLOT="0"
 KEYWORDS="amd64 ~ppc ~sparc x86"
 IUSE="nls sndfile"
 
-RDEPEND="media-sound/pulseaudio
+RDEPEND="media-libs/libpulse
+	virtual/libintl
 	x11-libs/gtk+:2
 	sndfile? ( media-libs/libsndfile )"
 DEPEND="${RDEPEND}"
@@ -24,14 +25,17 @@ BDEPEND="virtual/pkgconfig
 RESTRICT="test"
 
 PATCHES=(
-	"${FILESDIR}"/${P}-desktop.patch
+	"${FILESDIR}"/${PN}-0.5.5-desktop.patch
+	"${FILESDIR}"/${PN}-0.5.5-autotools.patch
 )
 
 src_prepare() {
 	default
 
 	sed -i 's:^\(appdatadir = .*/\)appdata:\1metainfo:' \
-		Makefile.in || die
+		Makefile.{am,in} || die
+
+	eautoreconf
 }
 
 src_configure() {


### PR DESCRIPTION
* Fix automagic dependency on sndfile
* Fix broken SIGFPE config test on musl
* Use external libintl
* EAPI 8

Closes: https://bugs.gentoo.org/924246