### PR TITLE
games-board/gnome-mahjongg: add libadwaita[vala] dependency

### DIFF
--- a/games-board/gnome-mahjongg/gnome-mahjongg-3.40.1.ebuild
+++ b/games-board/gnome-mahjongg/gnome-mahjongg-3.40.1.ebuild
@@ -25,6 +25,7 @@ BDEPEND="
 	$(vala_depend)
 	dev-libs/appstream-glib
 	dev-util/itstool
+	gui-libs/libadwaita:1[vala]
 	>=sys-devel/gettext-0.19.8
 	virtual/pkgconfig
 "


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/910189
