### PR TITLE
dev-python/urwidtrees: add python-3.12 support

### DIFF
--- a/dev-python/urwidtrees/urwidtrees-1.0.3-r2.ebuild
+++ b/dev-python/urwidtrees/urwidtrees-1.0.3-r2.ebuild
@@ -1,10 +1,10 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..12} )
 
 inherit distutils-r1
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/929519