### PR TITLE
media-gfx/gscan2pdf: tesseract is dropping opencl support

### DIFF
--- a/media-gfx/gscan2pdf/gscan2pdf-2.13.2-r1.ebuild
+++ b/media-gfx/gscan2pdf/gscan2pdf-2.13.2-r1.ebuild
@@ -58,7 +58,7 @@ BDEPEND="
 
 		app-text/djvu[jpeg,tiff]
 		app-text/poppler[utils]
-		app-text/tesseract[-opencl,osd(+),png,tiff]
+		app-text/tesseract[-opencl(-),osd(+),png,tiff]
 		app-text/unpaper
 		media-gfx/imagemagick[djvu,jpeg,png,tiff,perl,postscript,truetype]
 		media-gfx/sane-backends[sane_backends_test]


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/930367