### PR TITLE
Xfce extra

### DIFF
--- a/x11-themes/xfwm4-themes/xfwm4-themes-4.10.0-r2.ebuild
+++ b/x11-themes/xfwm4-themes/xfwm4-themes-4.10.0-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -9,7 +9,7 @@ SRC_URI="https://archive.xfce.org/src/art/${PN}/${PV%.*}/${P}.tar.bz2"
 
 LICENSE="GPL-3"
 SLOT="0"
-KEYWORDS="amd64 arm ~hppa ~ia64 ppc ppc64 ~sparc x86 ~amd64-linux ~x86-linux"
+KEYWORDS="amd64 arm ~arm64 ~hppa ~ia64 ppc ppc64 ~sparc x86 ~amd64-linux ~x86-linux"
 RESTRICT="binchecks strip"
 
 RDEPEND=">=xfce-base/xfwm4-4.10"

--- a/xfce-extra/xfce4-clipman-plugin/xfce4-clipman-plugin-1.6.6.ebuild
+++ b/xfce-extra/xfce4-clipman-plugin/xfce4-clipman-plugin-1.6.6.ebuild
@@ -16,7 +16,7 @@ SRC_URI="
 
 LICENSE="GPL-2+"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm ~hppa ~ia64 ppc ppc64 ~riscv ~sparc x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~alpha amd64 arm ~arm64 ~hppa ~ia64 ppc ppc64 ~riscv ~sparc x86 ~amd64-linux ~x86-linux"
 IUSE="X qrcode wayland"
 
 DEPEND="

--- a/xfce-extra/xfce4-eyes-plugin/xfce4-eyes-plugin-4.6.0.ebuild
+++ b/xfce-extra/xfce4-eyes-plugin/xfce4-eyes-plugin-4.6.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -11,7 +11,7 @@ SRC_URI="https://archive.xfce.org/src/panel-plugins/${PN}/${PV%.*}/${P}.tar.bz2"
 
 LICENSE="GPL-2+"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm ~hppa ~ia64 ~ppc ~ppc64 ~riscv ~sparc x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~alpha amd64 arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~riscv ~sparc x86 ~amd64-linux ~x86-linux"
 
 RDEPEND="
 	>=dev-libs/glib-2.20

--- a/xfce-extra/xfce4-kbdleds-plugin/xfce4-kbdleds-plugin-0.2.3.ebuild
+++ b/xfce-extra/xfce4-kbdleds-plugin/xfce4-kbdleds-plugin-0.2.3.ebuild
@@ -11,7 +11,7 @@ SRC_URI="https://dev.gentoo.org/~mgorny/dist/${P}.tar.bz2"
 
 LICENSE="GPL-2+"
 SLOT="0"
-KEYWORDS="~amd64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~riscv ~x86"
 
 DEPEND="
 	xfce-base/libxfce4ui:=

--- a/xfce-extra/xfce4-mount-plugin/xfce4-mount-plugin-1.1.6.ebuild
+++ b/xfce-extra/xfce4-mount-plugin/xfce4-mount-plugin-1.1.6.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -16,7 +16,7 @@ SRC_URI="
 
 LICENSE="GPL-2+"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm ~hppa ~ia64 ppc ppc64 ~riscv ~sparc x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~alpha amd64 arm ~arm64 ~hppa ~ia64 ppc ppc64 ~riscv ~sparc x86 ~amd64-linux ~x86-linux"
 
 DEPEND="
 	>=dev-libs/glib-2.50.0

--- a/xfce-extra/xfce4-netload-plugin/xfce4-netload-plugin-1.4.1.ebuild
+++ b/xfce-extra/xfce4-netload-plugin/xfce4-netload-plugin-1.4.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -16,7 +16,7 @@ SRC_URI="
 
 LICENSE="GPL-2+"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm ~hppa ~ia64 ~ppc ~ppc64 ~riscv ~sparc x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~alpha amd64 arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~riscv ~sparc x86 ~amd64-linux ~x86-linux"
 
 DEPEND="
 	>=dev-libs/glib-2.50.0

--- a/xfce-extra/xfce4-notes-plugin/xfce4-notes-plugin-1.11.0.ebuild
+++ b/xfce-extra/xfce4-notes-plugin/xfce4-notes-plugin-1.11.0.ebuild
@@ -16,7 +16,7 @@ SRC_URI="
 
 LICENSE="GPL-2+"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm ~hppa ~ia64 ppc ppc64 ~riscv ~sparc x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~alpha amd64 arm ~arm64 ~hppa ~ia64 ppc ppc64 ~riscv ~sparc x86 ~amd64-linux ~x86-linux"
 
 DEPEND="
 	>=dev-libs/glib-2.30:2

--- a/xfce-extra/xfce4-sensors-plugin/xfce4-sensors-plugin-1.4.4.ebuild
+++ b/xfce-extra/xfce4-sensors-plugin/xfce4-sensors-plugin-1.4.4.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://archive.xfce.org/src/panel-plugins/${PN}/${PV%.*}/${P}.tar.bz2"
 
 LICENSE="GPL-2+"
 SLOT="0"
-KEYWORDS="amd64 ppc ppc64 ~riscv x86"
+KEYWORDS="amd64 ~arm64 ppc ppc64 ~riscv x86"
 IUSE="+acpi hddtemp libnotify lm-sensors video_cards_nvidia"
 REQUIRED_USE="|| ( hddtemp lm-sensors acpi )"
 

--- a/xfce-extra/xfce4-timer-plugin/xfce4-timer-plugin-1.7.2.ebuild
+++ b/xfce-extra/xfce4-timer-plugin/xfce4-timer-plugin-1.7.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -14,7 +14,7 @@ SRC_URI="https://archive.xfce.org/src/panel-plugins/${PN}/${PV%.*}/${P}.tar.bz2"
 
 LICENSE="GPL-2+"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm ~hppa ~ia64 ppc ppc64 ~riscv ~sparc x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~alpha amd64 arm ~arm64 ~hppa ~ia64 ppc ppc64 ~riscv ~sparc x86 ~amd64-linux ~x86-linux"
 
 DEPEND="
 	>=dev-libs/glib-2.26.0

--- a/xfce-extra/xfce4-verve-plugin/xfce4-verve-plugin-2.0.1.ebuild
+++ b/xfce-extra/xfce4-verve-plugin/xfce4-verve-plugin-2.0.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -9,7 +9,7 @@ SRC_URI="https://archive.xfce.org/src/panel-plugins/${PN}/${PV%.*}/${P}.tar.bz2"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm ~hppa ~ia64 ppc ppc64 ~riscv ~sparc x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~alpha amd64 arm ~arm64 ~hppa ~ia64 ppc ppc64 ~riscv ~sparc x86 ~amd64-linux ~x86-linux"
 IUSE=""
 
 RDEPEND=">=xfce-base/libxfce4ui-4.12:=


### PR DESCRIPTION
While attempting to upgrade my wifes PC from a 2010 ASUS E35M to a 2024 Raspberry Pi5 :) I came across a few xfce-extra packages that need the ~arm64 keyword.

There are a few more odds and ends to come too. 