### PR TITLE
dev-debug/peda: enable py3.12

### DIFF
--- a/dev-debug/peda/peda-1.2.ebuild
+++ b/dev-debug/peda/peda-1.2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..11} )
+PYTHON_COMPAT=( python3_{10..12} )
 
 inherit python-single-r1 wrapper
 

--- a/dev-debug/peda/peda-9999.ebuild
+++ b/dev-debug/peda/peda-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..11} )
+PYTHON_COMPAT=( python3_{10..12} )
 
 inherit python-single-r1 wrapper
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/929392