### PR TITLE
app-emulation/spice: enable py3.12

### DIFF
--- a/app-emulation/spice/spice-0.15.1-r1.ebuild
+++ b/app-emulation/spice/spice-0.15.1-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10,11} )
+PYTHON_COMPAT=( python3_{10..12} )
 # Port to meson once https://gitlab.freedesktop.org/spice/spice/-/issues/75 is fixed
 inherit autotools python-any-r1 readme.gentoo-r1 xdg-utils
 

--- a/app-emulation/spice/spice-0.15.2.ebuild
+++ b/app-emulation/spice/spice-0.15.2.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..11} )
+PYTHON_COMPAT=( python3_{10..12} )
 inherit meson python-any-r1 readme.gentoo-r1 xdg-utils
 
 DESCRIPTION="SPICE server"

--- a/app-emulation/spice/spice-9999.ebuild
+++ b/app-emulation/spice/spice-9999.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..11} )
+PYTHON_COMPAT=( python3_{10..12} )
 inherit meson python-any-r1 readme.gentoo-r1 xdg-utils
 
 DESCRIPTION="SPICE server"


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/929311