### PR TITLE
dev-libs/libevdev: enable py3.12

### DIFF
--- a/dev-libs/libevdev/libevdev-1.13.1.ebuild
+++ b/dev-libs/libevdev/libevdev-1.13.1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..12} )
 
 inherit meson-multilib python-any-r1
 

--- a/dev-libs/libevdev/libevdev-9999.ebuild
+++ b/dev-libs/libevdev/libevdev-9999.ebuild
@@ -1,9 +1,9 @@
 # Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..12} )
 
 inherit meson-multilib python-any-r1
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/919907