### PR TITLE
x11-terms/terminator: enable py3.12

### DIFF
--- a/x11-terms/terminator/terminator-2.1.3.ebuild
+++ b/x11-terms/terminator/terminator-2.1.3.ebuild
@@ -1,10 +1,10 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..12} )
 inherit distutils-r1 optfeature verify-sig virtualx xdg
 
 DESCRIPTION="Multiple GNOME terminals in one window"


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/929894