### PR TITLE
net-im/signal-desktop-bin: add tray-icon USE flag

### DIFF
--- a/net-im/signal-desktop-bin/metadata.xml
+++ b/net-im/signal-desktop-bin/metadata.xml
@@ -9,6 +9,13 @@
 		<email>proxy-maint@gentoo.org</email>
 		<name>Proxy Maintainers</name>
 	</maintainer>
+	<longdescription lang="en">
+		Signal is a private and secure internet messenger.
+		This is the official deb package adapted to work on Gentoo.
+	</longdescription>
+	<use>
+		<flag name="tray-icon">Start with --use-tray-icon by default</flag>
+	</use>
 	<upstream>
 		<remote-id type="github">signalapp/Signal-Desktop</remote-id>
 	</upstream>

--- a/net-im/signal-desktop-bin/signal-desktop-bin-7.5.1-r1.ebuild
+++ b/net-im/signal-desktop-bin/signal-desktop-bin-7.5.1-r1.ebuild
@@ -16,7 +16,7 @@ S="${WORKDIR}"
 LICENSE="GPL-3 MIT MIT-with-advertising BSD-1 BSD-2 BSD Apache-2.0 ISC openssl ZLIB APSL-2 icu Artistic-2 LGPL-2.1"
 SLOT="0"
 KEYWORDS="-* amd64"
-IUSE="+sound"
+IUSE="+sound tray-icon"
 RESTRICT="splitdebug"
 
 RDEPEND="
@@ -78,6 +78,10 @@ src_install() {
 
 	if has_version media-sound/apulse[-sdk] && ! has_version media-sound/pulseaudio; then
 		sed -i 's/Exec=/Exec=apulse /g' usr/share/applications/signal-desktop.desktop || die
+	fi
+
+	if use tray-icon; then
+		sed -i 's/%U/--use-tray-icon %U/g' usr/share/applications/signal-desktop.desktop || die
 	fi
 
 	doins -r usr/share/applications


### PR DESCRIPTION
[This discussion](https://forums.gentoo.org/viewtopic-t-1167987-highlight-signal+tray.html) made me change my `.desktop` file but with the update it got overwritten.

I have decided to upstream that change.

Also I have added a description in metadata explaining the origin of the package.