### PR TITLE
media-sound/streamripper: Fix call to undeclared function 'strcpy'

### DIFF
--- a/media-sound/streamripper/files/streamripper-1.64.6-fix-build-clang16.patch
+++ b/media-sound/streamripper/files/streamripper-1.64.6-fix-build-clang16.patch
@@ -1,0 +1,11 @@
+https://bugs.gentoo.org/930509
+--- a/lib/argv.c
++++ b/lib/argv.c
+@@ -67,6 +67,7 @@ extern char *malloc ();		/* Standard memory allocater */
+ extern char *realloc ();	/* Standard memory reallocator */
+ extern void free ();		/* Free malloc'd memory */
+ extern char *strdup ();		/* Duplicate a string */
++extern char *strcpy ();		/* Copy a string */
+ #endif
+ 
+ #endif	/* ANSI_PROTOTYPES */

--- a/media-sound/streamripper/streamripper-1.64.6-r1.ebuild
+++ b/media-sound/streamripper/streamripper-1.64.6-r1.ebuild
@@ -1,0 +1,45 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit autotools
+
+DESCRIPTION="Extracts and records individual MP3 file tracks from shoutcast streams"
+HOMEPAGE="https://streamripper.sourceforge.net"
+SRC_URI="mirror://sourceforge/${PN}/${P}.tar.gz"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
+IUSE="vorbis"
+
+RDEPEND="
+	media-libs/libmad
+	media-libs/faad2
+	>=dev-libs/glib-2.16
+	vorbis? ( media-libs/libvorbis )"
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-fix-autotools.patch
+	"${FILESDIR}"/${P}-fix-build-clang16.patch
+)
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_configure() {
+	econf \
+		--without-included-libmad \
+		--without-included-argv \
+		$(use_with vorbis ogg)
+}
+
+src_install() {
+	default
+	dodoc parse_rules.txt
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/930509