### PR TITLE
sci-electronics/qelectrotech: keyword 0.80 for ~arm64

### DIFF
--- a/sci-electronics/qelectrotech/qelectrotech-0.80.ebuild
+++ b/sci-electronics/qelectrotech/qelectrotech-0.80.ebuild
@@ -14,7 +14,7 @@ if [[ ${PV} == *9999* ]]; then
 else
 	MY_P=qet-${PV/%0/.0}
 	SRC_URI="https://git.tuxfamily.org/qet/qet.git/snapshot/${MY_P}.tar.gz -> ${P}.tar.gz"
-	KEYWORDS="amd64 ~x86"
+	KEYWORDS="amd64 ~arm64 ~x86"
 	S="${WORKDIR}"/${MY_P}
 fi
 


### PR DESCRIPTION
Tested on MacBook Air (15-inch, M2, 2023).