### PR TITLE
sys-process/rtirq: change homepage and add remote-id

### DIFF
--- a/sys-process/rtirq/metadata.xml
+++ b/sys-process/rtirq/metadata.xml
@@ -9,4 +9,7 @@
 		<email>proxy-maint@gentoo.org</email>
 		<name>Proxy Maintainers</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">rncbc/rtirq</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/sys-process/rtirq/rtirq-20240120.ebuild
+++ b/sys-process/rtirq/rtirq-20240120.ebuild
@@ -6,7 +6,7 @@ EAPI="8"
 inherit linux-info systemd
 
 DESCRIPTION="Modify realtime scheduling policy and priority of IRQ handlers"
-HOMEPAGE="https://www.rncbc.org/archive/#rtirq"
+HOMEPAGE="https://github.com/rncbc/rtirq"
 SRC_URI="https://www.rncbc.org/archive/${P}.tar.gz
 	https://www.rncbc.org/archive/old/${P}.tar.gz"
 

--- a/sys-process/rtirq/rtirq-20240220.ebuild
+++ b/sys-process/rtirq/rtirq-20240220.ebuild
@@ -6,7 +6,7 @@ EAPI="8"
 inherit linux-info systemd
 
 DESCRIPTION="Modify realtime scheduling policy and priority of IRQ handlers"
-HOMEPAGE="https://www.rncbc.org/archive/#rtirq"
+HOMEPAGE="https://github.com/rncbc/rtirq"
 SRC_URI="https://www.rncbc.org/archive/${P}.tar.gz
 	https://www.rncbc.org/archive/old/${P}.tar.gz"
 


### PR DESCRIPTION
rncbc.org does not contain any information about rtirq. Lets change homepage to github repo.

Closes: https://bugs.gentoo.org/930201