### PR TITLE
dev-python/importlib-resources: enable py3.12

### DIFF
--- a/dev-python/importlib-resources/importlib-resources-6.4.0.ebuild
+++ b/dev-python/importlib-resources/importlib-resources-6.4.0.ebuild
@@ -4,8 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-# backport from py3.12
-PYTHON_COMPAT=( pypy3 python3_{10..11} )
+PYTHON_COMPAT=( pypy3 python3_{10..12} )
 
 inherit distutils-r1 pypi
 


### PR DESCRIPTION
importlib-resources supports py3.12 (test pass). Needed also by one of the packages on ::guru