### PR TITLE
sys-apps/ifplugd: fix incompatible pointer types

### DIFF
--- a/sys-apps/ifplugd/files/ifplugd-0.28-fix-if.h-include.patch
+++ b/sys-apps/ifplugd/files/ifplugd-0.28-fix-if.h-include.patch
@@ -1,0 +1,60 @@
+diff -ru a/src/ifmonitor.c b/src/ifmonitor.c
+--- a/src/ifmonitor.c	2024-04-25 13:35:56.625794510 +0000
++++ b/src/ifmonitor.c	2024-04-25 14:13:08.734022552 +0000
+@@ -27,7 +27,7 @@
+ #include <linux/types.h>
+ #include <linux/netlink.h>
+ #include <linux/rtnetlink.h>
+-#include <linux/if.h>
++#include <net/if.h>
+ #include <string.h>
+ #include <unistd.h>
+ #include <errno.h>
+diff -ru a/src/interface.c b/src/interface.c
+--- a/src/interface.c	2024-04-25 13:35:56.625794510 +0000
++++ b/src/interface.c	2024-04-25 14:12:49.510133122 +0000
+@@ -27,7 +27,7 @@
+ #include <linux/if_ether.h>
+ #include <sys/socket.h>
+ #include <sys/ioctl.h>
+-#include <linux/if.h>
++#include <net/if.h>
+ #include <syslog.h>
+ #include <string.h>
+ #include <errno.h>
+diff -ru a/src/wireless.15.h b/src/wireless.15.h
+--- a/src/wireless.15.h	2024-04-25 13:35:56.625794510 +0000
++++ b/src/wireless.15.h	2024-04-25 14:12:56.254094333 +0000
+@@ -71,7 +71,7 @@
+ 
+ #include <linux/types.h>		/* for "caddr_t" et al		*/
+ #include <linux/socket.h>		/* for "struct sockaddr" et al	*/
+-#include <linux/if.h>			/* for IFNAMSIZ and co... */
++#include <net/if.h>			/* for IFNAMSIZ and co... */
+ 
+ /***************************** VERSION *****************************/
+ /*
+diff -ru a/src/wireless.16.h b/src/wireless.16.h
+--- a/src/wireless.16.h	2024-04-25 13:35:56.625794510 +0000
++++ b/src/wireless.16.h	2024-04-25 14:12:42.710172234 +0000
+@@ -73,7 +73,7 @@
+  * at some point. Jean II */
+ #include <linux/types.h>		/* for "caddr_t" et al		*/
+ #include <linux/socket.h>		/* for "struct sockaddr" et al	*/
+-#include <linux/if.h>			/* for IFNAMSIZ and co... */
++#include <net/if.h>			/* for IFNAMSIZ and co... */
+ 
+ /***************************** VERSION *****************************/
+ /*
+diff -ru a/src/wireless.h b/src/wireless.h
+--- a/src/wireless.h	2024-04-25 13:35:56.625794510 +0000
++++ b/src/wireless.h	2024-04-25 14:13:02.574057982 +0000
+@@ -23,7 +23,7 @@
+ 
+ #include <sys/types.h>
+ #include <sys/socket.h>
+-#include <linux/if.h>
++#include <net/if.h>
+ #include <net/if_arp.h>
+ 
+ #include "wireless.16.h"

--- a/sys-apps/ifplugd/ifplugd-0.28-r12.ebuild
+++ b/sys-apps/ifplugd/ifplugd-0.28-r12.ebuild
@@ -1,0 +1,54 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="8"
+
+inherit autotools
+
+DESCRIPTION="Brings up/down ethernet ports automatically with cable detection"
+HOMEPAGE="http://0pointer.de/lennart/projects/ifplugd/"
+SRC_URI="http://0pointer.de/lennart/projects/ifplugd/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="doc selinux"
+
+DEPEND="virtual/pkgconfig
+	doc? ( www-client/lynx )
+	>=dev-libs/libdaemon-0.5"
+RDEPEND=">=dev-libs/libdaemon-0.5
+	>=sys-apps/baselayout-1.12
+	selinux? ( sec-policy/selinux-ifplugd )"
+
+PATCHES=(
+	"${FILESDIR}/${P}-nlapi.diff"
+	"${FILESDIR}/${P}-interface.patch"
+	"${FILESDIR}/${P}-strictalias.patch"
+	"${FILESDIR}/${P}-noip.patch"
+	"${FILESDIR}/${P}-musl.patch"
+	"${FILESDIR}/${P}-gcc10-compatibility.patch"
+	"${FILESDIR}/${P}-fix-if.h-include.patch"
+)
+
+DOCS=( doc/README doc/SUPPORTED_DRIVERS )
+HTML_DOCS=( doc/README.html doc/style.css )
+
+src_configure() {
+	eautoreconf
+	econf \
+		$(use_enable doc lynx) \
+		--with-initdir=/etc/init.d \
+		--disable-xmltoman \
+		--disable-subversion
+}
+
+src_install() {
+	default
+
+	# Remove init.d configuration as we no longer use it
+	rm -rf "${ED}/etc/ifplugd" "${ED}/etc/init.d/${PN}" || die
+
+	exeinto "/etc/${PN}"
+	newexe "${FILESDIR}/${PN}.action" "${PN}.action"
+}


### PR DESCRIPTION
After discussion switched include from linux/if.h to net/if.h libc version contains everything needed both in musl and glibc. eautoreconf automagics away implicit function declaration errors in configure
update EAPI 7 -> 8 in process

Closes: https://bugs.gentoo.org/921384
Closes: https://bugs.gentoo.org/908538