### PR TITLE
sci-calculators/transcalc: Fix passing incompatible pointer type

### DIFF
--- a/sci-calculators/transcalc/files/transcalc-0.14-gcc14-build-fix.patch
+++ b/sci-calculators/transcalc/files/transcalc-0.14-gcc14-build-fix.patch
@@ -1,0 +1,15 @@
+Bug: https://bugs.gentoo.org/927899
+--- a/src/print_trans.c
++++ b/src/print_trans.c
+@@ -61,8 +61,9 @@ get_trans_text ()
+   gchar *retval = NULL;
+   trans_label *tlabel;
+   int i;
+-  const gchar *newch1=NULL, *newch2 = NULL;
+-  const gchar *tmpstr=NULL;
++  gchar *newch1=NULL;
++  const gchar *newch2 = NULL;
++  gchar *tmpstr=NULL;
+   GString *s = g_string_new (NULL);
+ 
+ 

--- a/sci-calculators/transcalc/transcalc-0.14-r3.ebuild
+++ b/sci-calculators/transcalc/transcalc-0.14-r3.ebuild
@@ -1,0 +1,33 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="Microwave and RF transmission line calculator"
+HOMEPAGE="http://transcalc.sourceforge.net"
+SRC_URI="http://transcalc.sourceforge.net/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86 ~amd64-linux ~x86-linux"
+
+RDEPEND="x11-libs/gtk+:2"
+DEPEND="${RDEPEND}"
+
+# patch from debian
+PATCHES=(
+	"${FILESDIR}"/${P}-fd-perm.patch
+	"${FILESDIR}"/${P}-fno-common.patch
+	"${FILESDIR}"/${P}-gcc14-build-fix.patch
+)
+
+src_prepare() {
+	default
+
+	# respect flags
+	sed -i -e 's|^CFLAGS=|#CFLAGS=|g' configure || die
+	# syntax errors
+	sed -i \
+		-e 's/ythesize/ynthesize/g' \
+		src/{setup_menu.c,help.h} docs/transcalc.sgml README || die
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/927899