### PR TITLE
sys-apps/accountsservice: enable py3.12, c99 porting, backport test fix

### DIFF
--- a/sys-apps/accountsservice/accountsservice-23.13.9.ebuild
+++ b/sys-apps/accountsservice/accountsservice-23.13.9.ebuild
@@ -1,8 +1,8 @@
-# Copyright 2011-2023 Gentoo Authors
+# Copyright 2011-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..12} )
 inherit meson python-any-r1 systemd
 
 DESCRIPTION="D-Bus interfaces for querying and manipulating user account information"
@@ -58,6 +58,8 @@ PATCHES=(
 	# From Alpine Linux
 	# https://gitlab.freedesktop.org/accountsservice/accountsservice/-/merge_requests/97
 	"${FILESDIR}"/${PN}-23.13.9-musl-fixes.patch
+	"${FILESDIR}"/${PN}-23.13.9-c99-fixes.patch #930715
+	"${FILESDIR}"/${PN}-23.13.9-test-fix.patch
 )
 
 python_check_deps() {

--- a/sys-apps/accountsservice/files/accountsservice-23.13.9-c99-fixes.patch
+++ b/sys-apps/accountsservice/files/accountsservice-23.13.9-c99-fixes.patch
@@ -1,0 +1,50 @@
+https://bugs.gentoo.org/930715
+https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/da65bee12d9118fe1a49c8718d428fe61d232339
+
+From da65bee12d9118fe1a49c8718d428fe61d232339 Mon Sep 17 00:00:00 2001
+From: Ray Strode <rstrode@redhat.com>
+Date: Tue, 11 Apr 2023 10:09:07 -0400
+Subject: [PATCH] mocklibc: Fix compiler warning
+
+print_indent is defined in one file and used in another without a
+forward declaration. That leads to a compiler warning/error.
+
+This commit fixes that.
+---
+ subprojects/mocklibc.wrap                           |  2 ++
+ subprojects/packagefiles/mocklibc-print-indent.diff | 13 +++++++++++++
+ 2 files changed, 15 insertions(+)
+ create mode 100644 subprojects/packagefiles/mocklibc-print-indent.diff
+
+diff --git a/subprojects/mocklibc.wrap b/subprojects/mocklibc.wrap
+index af82298..539ee83 100644
+--- a/subprojects/mocklibc.wrap
++++ b/subprojects/mocklibc.wrap
+@@ -8,3 +8,5 @@ source_hash = b2236a6af1028414783e9734a46ea051916ec226479d6a55a3bb823bff68f120
+ patch_url = https://wrapdb.mesonbuild.com/v1/projects/mocklibc/1.0/2/get_zip
+ patch_filename = mocklibc-1.0-2-wrap.zip
+ patch_hash = 0280f96a2eeb3c023e5acf4e00cef03d362868218d4a85347ea45137c0ef6c56
++
++diff_files = mocklibc-print-indent.diff
+diff --git a/subprojects/packagefiles/mocklibc-print-indent.diff b/subprojects/packagefiles/mocklibc-print-indent.diff
+new file mode 100644
+index 0000000..4aaed40
+--- /dev/null
++++ b/subprojects/packagefiles/mocklibc-print-indent.diff
+@@ -0,0 +1,13 @@
++diff -up mocklibc-1.0/src/netgroup-debug.c.print-indent mocklibc-1.0/src/netgroup-debug.c
++--- mocklibc-1.0/src/netgroup-debug.c.print-indent	2023-04-11 10:20:53.717381559 -0400
+++++ mocklibc-1.0/src/netgroup-debug.c	2023-04-11 10:21:02.296270333 -0400
++@@ -21,6 +21,9 @@
++ #include <stdio.h>
++ #include <stdlib.h>
++ 
+++void print_indent (FILE        *stream,
+++                   unsigned int indent);
+++
++ void netgroup_debug_print_entry(struct entry *entry, FILE *stream, unsigned int indent) {
++   print_indent(stream, indent);
++ 
+-- 
+GitLab
+

--- a/sys-apps/accountsservice/files/accountsservice-23.13.9-test-fix.patch
+++ b/sys-apps/accountsservice/files/accountsservice-23.13.9-test-fix.patch
@@ -1,0 +1,41 @@
+https://gitlab.freedesktop.org/accountsservice/accountsservice/-/commit/ad0365b77b583da06bcd1e8da4c1bed74129895a
+
+From ad0365b77b583da06bcd1e8da4c1bed74129895a Mon Sep 17 00:00:00 2001
+From: Ray Strode <rstrode@redhat.com>
+Date: Thu, 28 Sep 2023 09:29:07 -0400
+Subject: [PATCH] tests: s/assertEquals/assertEqual/
+
+CI is currently failing with:
+
+Traceback (most recent call last):
+  File "/home/user/accountsservice/_build/../tests/test-libaccountsservice.py", line 118, in test_multiple_inflight_get_user_by_id_calls
+    self.assertEquals(user.get_user_name(), 'pizza')
+    ^^^^^^^^^^^^^^^^^
+AttributeError: 'TestAccountsServicePreExistingUser' object has no attribute 'assertEquals'. Did you mean: 'assertEqual'?
+
+I have no idea if assertEquals was dropped, or if CI has been failing
+all this time or what.
+
+This commit makes the suggested change.
+---
+ tests/test-libaccountsservice.py | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/tests/test-libaccountsservice.py b/tests/test-libaccountsservice.py
+index f0261b1..f2fcbc2 100644
+--- a/tests/test-libaccountsservice.py
++++ b/tests/test-libaccountsservice.py
+@@ -115,8 +115,8 @@ class TestAccountsServicePreExistingUser(AccountsServiceTestBase):
+             self.assertTrue(user_objects[instance].is_loaded())
+ 
+         for user in user_objects:
+-            self.assertEquals(user.get_user_name(), 'pizza')
+-            self.assertEquals(user.get_uid(), 2001)
++            self.assertEqual(user.get_user_name(), 'pizza')
++            self.assertEqual(user.get_uid(), 2001)
+ 
+ @unittest.skipUnless(have_accounts_service,
+                      'AccountsService gi introspection not available')
+-- 
+GitLab
+


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/929806
Closes: https://bugs.gentoo.org/930715