### PR TITLE
sys-apps/isapnptools: Fix iterator type for C99, update EAPI 7 -> 8

### DIFF
--- a/sys-apps/isapnptools/files/isapnptools-1.27-incompatible-pointer-types.patch
+++ b/sys-apps/isapnptools/files/isapnptools-1.27-incompatible-pointer-types.patch
@@ -1,0 +1,20 @@
+--- a/src/resource.c	2024-04-27 08:02:26.232607532 -0000
++++ b/src/resource.c	2024-04-27 08:04:14.600217480 -0000
+@@ -285,7 +285,7 @@
+ void allocate_pci_resources( void )
+ {
+    char *line = 0;
+-   int lineMax = 0;
++   size_t lineMax = 0;
+ 
+    FILE *fp = fopen( "/proc/bus/pci/devices", "rt" );
+    if( !fp )
+@@ -354,7 +354,7 @@
+ 	int io_end;
+     /* Avoid allocating DMA channels used by other devices in /proc. */
+     if ((input = fopen("/proc/interrupts", "r")) != NULL) {
+-      fscanf(input, "%*[^\n]\n"); /* skip first line */
++      (void)fscanf(input, "%*[^\n]\n"); /* skip first line */
+       while (fscanf (input, "%d%*[^\n]\n", &interrupt_num) == 1) {
+ #if 0
+ 		  snprintf(progress_report_buf,

--- a/sys-apps/isapnptools/isapnptools-1.27-r1.ebuild
+++ b/sys-apps/isapnptools/isapnptools-1.27-r1.ebuild
@@ -1,0 +1,31 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DESCRIPTION="Tools for configuring ISA PnP devices"
+HOMEPAGE="https://wiki.gentoo.org/wiki/No_homepage"
+SRC_URI="ftp://metalab.unc.edu/pub/Linux/system/hardware/${P}.tgz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="-* ~amd64 ~x86"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-include.patch
+	"${FILESDIR}"/${P}-fno-common.patch
+	"${FILESDIR}"/${P}-incompatible-pointer-types.patch
+)
+
+src_install() {
+	default
+
+	dodir /sbin
+	mv "${ED}"/{usr/sbin/isapnp,sbin/} || die
+
+	docinto txt
+	dodoc doc/{README*,*.txt} test/*.txt
+	dodoc etc/isapnp.*
+
+	newinitd "${FILESDIR}"/isapnp.rc isapnp
+}


### PR DESCRIPTION
Also explicitly void function whose input we intentionally ignore

Closes: https://bugs.gentoo.org/919391