### PR TITLE
net-dialup/linux-atm: Port to C99, musl

### DIFF
--- a/net-dialup/linux-atm/files/linux-atm-2.5.2-c99-musl.patch
+++ b/net-dialup/linux-atm/files/linux-atm-2.5.2-c99-musl.patch
@@ -1,0 +1,120 @@
+Author: NHOrus <jy6x2b32pie9@yahoo.com>
+Bug: https://bugs.gentoo.org/897842
+Enabling the system extension that gate some POSIX features
+and fixing missing includes, 32/64 bit confusion, standard
+atexit function instead of non-standard, and function signature
+diff -pur a/configure.in b/configure.in
+--- a/configure.in
++++ b/configure.in
+@@ -34,6 +34,7 @@ dnl We have some special PERL scripts wh
+ AC_PATH_PROG(PERL, perl)
+ AC_SUBST(PERL)
+ 
++AC_USE_SYSTEM_EXTENSIONS
+ 
+ dnl Check for needed header files
+ AC_CHECK_HEADER(asm/errno.h, ,
+diff -pur a/src/lib/unix.c b/src/lib/unix.c
+--- a/src/lib/unix.c
++++ b/src/lib/unix.c
+@@ -10,6 +10,7 @@
+ #include <stdio.h>
+ #include <unistd.h>
+ #include <errno.h>
++#include <string.h>
+ #include <sys/types.h>
+ #include <sys/stat.h>
+ #include <sys/socket.h>
+diff -pur a/src/sigd/policy.c b/src/sigd/policy.c
+--- a/src/sigd/policy.c
++++ b/src/sigd/policy.c
+@@ -8,6 +8,7 @@
+ 
+ #include <atm.h>
+ #include <atmd.h>
++#include <string.h>
+ 
+ #include "proto.h" /* for "pretty" */
+ #include "policy.h"
+--- a/src/sigd/kernel.c	2024-04-27 11:36:41.203470908 +0000
++++ b/src/sigd/kernel.c	2024-04-27 11:37:36.533130285 +0000
+@@ -10,6 +10,7 @@
+ #include <stdio.h>
+ #include <errno.h>
+ #include <assert.h>
++#include <string.h>
+ 
+ #include <atm.h>
+ #include <linux/atmsvc.h>
+--- a/src/sigd/atmsigd.c	2024-04-27 11:44:38.489532622 +0000
++++ b/src/sigd/atmsigd.c	2024-04-27 11:45:57.233047858 +0000
+@@ -283,12 +283,12 @@ static void setup_signals(void)
+ /* ------------------------------- main ...  ------------------------------- */
+ 
+ 
+-static void trace_on_exit(int status,void *dummy)
++static void trace_on_exit(void)
+ {
+     char path[PATH_MAX+1];
+     FILE *file;
+ 
+-    if (!status) return;
++//    if (!status) return;
+     if (!dump_dir) file = stderr;
+     else {
+ 	sprintf(path,"atmsigd.%d.trace.exit",getpid());
+@@ -517,7 +517,7 @@ int main(int argc,char **argv)
+ 	    exit(0);
+ 	}
+     }
+-    (void) on_exit(trace_on_exit,NULL);
++    (void) atexit(trace_on_exit);
+     poll_loop();
+     close_all();
+     for (sig = entities; sig; sig = sig->next) stop_saal(&sig->saal);
+diff -pur a/src/led/address.c b/src/led/address.c
+--- a/src/led/address.c	2024-04-27 11:47:34.614448355 +0000
++++ b/src/led/address.c	2024-04-27 11:48:12.489215189 +0000
+@@ -33,6 +33,7 @@
+ #include <sys/ioctl.h>
+ #include <unistd.h>
+ #include <errno.h>
++#include <string.h>
+ 
+ #include <atm.h>
+ #include <linux/atmdev.h>
+diff -pur a/src/led/conn.c b/src/led/conn.c
+--- a/src/led/conn.c	2024-04-27 11:47:34.614448355 +0000
++++ b/src/led/conn.c	2024-04-27 11:49:05.809886934 +0000
+@@ -405,7 +405,7 @@ Conn_t *accept_conn(Conn_t *conn)
+ {
+         Conn_t *new;
+         struct sockaddr_atmsvc addr;
+-        size_t len;
++        socklen_t len;
+         int fd;
+         char buff[MAX_ATM_ADDR_LEN+1];
+ 
+diff -pur a/src/led/display.c b/src/led/display.c
+--- a/src/led/display.c	2024-04-27 11:47:34.615448349 +0000
++++ b/src/led/display.c	2024-04-27 11:49:32.985719633 +0000
+@@ -6,6 +6,7 @@
+ #include <config.h>
+ #endif
+ 
++#include <string.h>
+ #include <atm.h>
+ #include <atmd.h>
+ 
+diff -pur a/src/mpoad/io.c b/src/mpoad/io.c
+--- a/src/mpoad/io.c	2024-04-27 11:47:34.625448287 +0000
++++ b/src/mpoad/io.c	2024-04-27 11:53:32.099247593 +0000
+@@ -16,7 +16,7 @@
+ #include <syscall.h>
+ #include <linux/poll.h>
+ #define SYS_poll 168
+-_syscall3(int,poll,struct pollfd *,ufds,unsigned int,nfds,int,timeout);
++int _syscall3(int, int poll,struct pollfd *,int ufds,unsigned int,int nfds,int,int timeout);
+ #endif
+ #include <atm.h>
+ #include <linux/types.h>

--- a/net-dialup/linux-atm/files/linux-atm-2.5.2-remove-bad-define.patch
+++ b/net-dialup/linux-atm/files/linux-atm-2.5.2-remove-bad-define.patch
@@ -1,0 +1,34 @@
+previously was sed -i '/#define _LINUX_NETDEVICE_H/d' src/arpd/*.c in ebuild
+diff -ru linux-atm-2.5.2.orig/src/arpd/arp.c linux-atm-2.5.2/src/arpd/arp.c
+--- linux-atm-2.5.2.orig/src/arpd/arp.c	2024-05-08 11:33:01.308408399 +0000
++++ linux-atm-2.5.2/src/arpd/arp.c	2024-05-08 11:33:26.240260590 +0000
+@@ -15,7 +15,6 @@
+ #include <sys/types.h>
+ #include <sys/socket.h> /* for linux/if_arp.h */
+ #include <netinet/in.h> /* for ntohs, etc. */
+-#define _LINUX_NETDEVICE_H /* very crude hack for glibc2 */
+ #include <linux/types.h>
+ #include <linux/if_arp.h>
+ #include <linux/if_ether.h>
+diff -ru linux-atm-2.5.2.orig/src/arpd/io.c linux-atm-2.5.2/src/arpd/io.c
+--- linux-atm-2.5.2.orig/src/arpd/io.c	2024-05-08 11:33:01.308408399 +0000
++++ linux-atm-2.5.2/src/arpd/io.c	2024-05-08 11:33:26.240260590 +0000
+@@ -21,7 +21,6 @@
+ #include <atm.h>
+ #include <linux/atmclip.h> /* for CLIP_DEFAULT_IDLETIMER */
+ #include <linux/atmarp.h>
+-#define _LINUX_NETDEVICE_H /* glibc2 */
+ #include <linux/types.h>
+ #include <linux/if_arp.h>
+ 
+diff -ru linux-atm-2.5.2.orig/src/arpd/itf.c linux-atm-2.5.2/src/arpd/itf.c
+--- linux-atm-2.5.2.orig/src/arpd/itf.c	2024-05-08 11:33:01.308408399 +0000
++++ linux-atm-2.5.2/src/arpd/itf.c	2024-05-08 11:33:26.240260590 +0000
+@@ -12,7 +12,6 @@
+ #include <sys/types.h>
+ #include <linux/atmclip.h>
+ #include <sys/socket.h>
+-#define _LINUX_NETDEVICE_H /* glibc2 */
+ #include <linux/types.h>
+ #include <linux/if_arp.h>
+ 

--- a/net-dialup/linux-atm/linux-atm-2.5.2-r2.ebuild
+++ b/net-dialup/linux-atm/linux-atm-2.5.2-r2.ebuild
@@ -1,0 +1,45 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools flag-o-matic linux-info
+
+DESCRIPTION="Tools for ATM"
+HOMEPAGE="https://linux-atm.sourceforge.net/"
+SRC_URI="https://downloads.sourceforge.net/${PN}/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+EYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+
+BDEPEND="sys-devel/bison"
+
+RESTRICT="test"
+
+CONFIG_CHECK="~ATM"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-headers.patch
+	"${FILESDIR}"/${P}-linux-5.2-SIOCGSTAMP.patch
+	"${FILESDIR}"/${P}-linux-headers-5.19.patch
+	"${FILESDIR}"/${P}-c99-musl.patch
+	"${FILESDIR}"/${P}-remove-bad-define.patch
+)
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_configure() {
+	append-flags -fno-strict-aliasing
+	export YACC=bison -y
+	econf
+}
+
+src_install() {
+	default
+	find "${ED}" -name '*.la' -delete || die
+	dodoc doc/README* doc/atm*
+}


### PR DESCRIPTION
A bit more effort than expected: Missing includes, missing types, size types mismatches, non-portable function

Closes: https://bugs.gentoo.org/897842