### PR TITLE
net-misc/croc: skip network related tests

### DIFF
--- a/net-misc/croc/croc-9.6.15.ebuild
+++ b/net-misc/croc/croc-9.6.15.ebuild
@@ -43,5 +43,5 @@ src_install() {
 }
 
 src_test() {
-	ego test -work ./...
+	ego test -skip "Test(Comm|Send|PublicIP|LocalIP)" -work ./...
 }


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/930714