### PR TITLE
sci-biology/maq: Fix assignment to incompatible pointer type

### DIFF
--- a/sci-biology/maq/files/maq-0.7.1-gcc14-build-fix.patch
+++ b/sci-biology/maq/files/maq-0.7.1-gcc14-build-fix.patch
@@ -1,0 +1,23 @@
+Bug: https://bugs.gentoo.org/921137
+--- a/fastq2bfq.c
++++ b/fastq2bfq.c
+@@ -15,7 +15,7 @@ int64_t fastq2bfq(FILE *fp_fq, const char *fn_bfq, int n_reads)
+ 	char name[256], str[1024];
+ 	int l, is_new = 0, l_prefix = 0;
+ 	bit64_t n;
+-	gzFile *fp = 0;
++	gzFile fp = 0;
+ 	INIT_SEQ(seq); INIT_SEQ(qual);
+ 	seq_set_block_size(256);
+ 	n = 0;
+--- a/simulate.c
++++ b/simulate.c
+@@ -74,7 +74,7 @@ int maq_simutrain(int argc, char *argv[])
+ {
+ 	fqc_t *fqc;
+ 	FILE *fp;
+-	gzFile *fpout;
++	gzFile fpout;
+ 	if (argc < 3) {
+ 		fprintf(stderr, "Usage: maq simutrain <simupars.dat> <known_reads.fastq>\n");
+ 		return 1;

--- a/sci-biology/maq/maq-0.7.1-r4.ebuild
+++ b/sci-biology/maq/maq-0.7.1-r4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -6,7 +6,7 @@ EAPI=8
 inherit autotools
 
 DESCRIPTION="Mapping and Assembly with Qualities, mapping NGS reads to reference genomes"
-HOMEPAGE="http://maq.sourceforge.net/"
+HOMEPAGE="https://maq.sourceforge.net/"
 SRC_URI="
 	mirror://sourceforge/${PN}/${P}.tar.bz2
 	mirror://sourceforge/${PN}/calib-36.dat.gz"
@@ -23,6 +23,7 @@ PATCHES=(
 	"${FILESDIR}"/${P}-bfr-overfl.patch
 	"${FILESDIR}"/${P}-gcc-4.7.patch
 	"${FILESDIR}"/${P}-remove-64bit-flag.patch
+	"${FILESDIR}"/${P}-gcc14-build-fix.patch
 )
 
 src_prepare() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/921137