### PR TITLE
net-firewall/rtsp-conntrack: Fix implicit declaration of strlcpy

### DIFF
--- a/net-firewall/rtsp-conntrack/files/rtsp-conntrack-5.3-strlcpy.patch
+++ b/net-firewall/rtsp-conntrack/files/rtsp-conntrack-5.3-strlcpy.patch
@@ -1,0 +1,29 @@
+https://patch-diff.githubusercontent.com/raw/maru-sama/rtsp-linux/pull/12.patch
+From: Brahmajit Das <brahmajit.xyz@gmail.com>
+Date: Sun, 28 Apr 2024 01:48:03 +0530
+Subject: [PATCH 1/1] Fix build with Linux 6.8
+
+With commit
+https://github.com/torvalds/linux/commit/57f22c8dab6b266ae36b89b073a4a33dea71e762
+strlcpy has been removed in favor of strscpy. Thus giving us build error
+such as nf_conntrack_rtsp.c: error: implicit declaration of function
+strlcpy.
+
+First reported on Gentoo Linux, please reffer:
+https://bugs.gentoo.org/928590
+
+Signed-off-by: Brahmajit Das <brahmajit.xyz@gmail.com>
+--- a/nf_conntrack_rtsp.c
++++ b/nf_conntrack_rtsp.c
+@@ -550,7 +550,7 @@ init(void)
+ 		}
+ 
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(3,6,0)
+-		strlcpy(hlpr->name, tmpname, sizeof(hlpr->name));
++		strscpy(hlpr->name, tmpname, sizeof(hlpr->name));
+ #else
+ 		hlpr->name = tmpname;
+ #endif
+-- 
+2.44.0
+

--- a/net-firewall/rtsp-conntrack/rtsp-conntrack-5.3-r2.ebuild
+++ b/net-firewall/rtsp-conntrack/rtsp-conntrack-5.3-r2.ebuild
@@ -1,0 +1,31 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit linux-mod-r1
+
+DESCRIPTION="RTSP conntrack module for Netfilter"
+HOMEPAGE="https://mike.it-loops.com/rtsp"
+SRC_URI="https://github.com/maru-sama/rtsp-linux/archive/${PV}.tar.gz -> ${P}.tar.gz"
+S="${WORKDIR}/rtsp-linux-${PV}"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+CONFIG_CHECK="NF_CONNTRACK"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-strlcpy.patch
+)
+
+src_compile() {
+	local modlist=(
+		nf_conntrack_rtsp=net/netfilter
+		nf_nat_rtsp=net/ipv4/netfilter
+	)
+	local modargs=( KERNELDIR="${KV_OUT_DIR}" )
+
+	linux-mod-r1_src_compile
+}


### PR DESCRIPTION
Ditching strlcpy in favor of strscpy

Closes: https://bugs.gentoo.org/928590