### PR TITLE
games-rpg/gwiz: Add autoreconf

### DIFF
--- a/games-rpg/gwiz/gwiz-0.8-r1.ebuild
+++ b/games-rpg/gwiz/gwiz-0.8-r1.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-inherit desktop flag-o-matic toolchain-funcs
+inherit desktop flag-o-matic toolchain-funcs autotools
 
 DESCRIPTION="Clone of old-school Wizardry(tm) games by SirTech"
 HOMEPAGE="https://icculus.org/gwiz/"
@@ -27,6 +27,7 @@ src_prepare() {
 
 	tc-export CC
 	append-cflags -std=gnu89 # build with gcc5 (bug #572532)
+	eautoreconf # fixes configure problems for free (bug #880811)
 }
 
 src_install() {


### PR DESCRIPTION
It fixes many configure-time problems for free. Like this one.

Closes: https://bugs.gentoo.org/880811