### PR TITLE
dev-libs/libclc: Use correct LLVM_COMPAT version

### DIFF
--- a/dev-libs/libclc/libclc-18.1.4.ebuild
+++ b/dev-libs/libclc/libclc-18.1.4.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-LLVM_COMPAT=( 17 )
+LLVM_COMPAT=( 18 )
 PYTHON_COMPAT=( python3_{10..12} )
 inherit cmake llvm.org llvm-r1 python-any-r1
 


### PR DESCRIPTION
libclc 18 should be compiled against llvm 18