### PR TITLE
🩹 media-libs/gstreamer-1.22.11: fix libs_baseparse test

### DIFF
--- a/media-libs/gstreamer/gstreamer-1.22.11.ebuild
+++ b/media-libs/gstreamer/gstreamer-1.22.11.ebuild
@@ -35,7 +35,7 @@ DOCS=( AUTHORS ChangeLog NEWS MAINTAINERS README.md RELEASE )
 
 multilib_src_configure() {
 	local emesonargs=(
-		-Dtools=$(multilib_is_native_abi && echo enabled || echo disabled)
+		-Dtools=$(usex test enabled $(multilib_is_native_abi && echo enabled || echo disabled))
 		-Dbenchmarks=disabled
 		-Dexamples=disabled
 		-Dcheck=enabled


### PR DESCRIPTION
_Hello everyone,_

Missing tools are forcing the `libs_baseparse` test to fail when building with `ABI_X86="32 64"`.
The bug was introduced in 28ac0ad4.

#### Addressing concerns about the installed files
_[commented](https://github.com/gentoo/gentoo/pull/36461#issuecomment-2082508379) by @leio:_
>   We can't just go and enable installation of tools when tests are enabled when another flag is meant to control it. USE=test mustn't as a general rule affect the installed files (there are some practical exceptions when it makes sense vs effort to not do so, but this one isn't one of those).

I've compared the installed files for 
  - `ABI_X86="32 64" USE="-test" media-libs/gstreamer-1.22.11::gentoo`
  - `ABI_X86="32 64" USE="test" media-libs/gstreamer-1.22.11::mim`

<details>
<summary>diff -u gstreamer-1.22.11::{gentoo-use-no-test,mim-use-test}.txt</summary>

```diff
--- gstreamer-1.22.11::gentoo-use-no-test.txt	2024-04-29 15:10:57.786900068 +0300
+++ gstreamer-1.22.11::mim-use-test.txt	2024-04-29 15:15:37.756465145 +0300
@@ -3,6 +3,7 @@
 /usr/bin/gst-inspect-1.0
 /usr/bin/gst-launch-1.0
 /usr/bin/gst-stats-1.0
+/usr/bin/gst-tester-1.0
 /usr/bin/gst-typefind-1.0
 /usr/include
 /usr/include/gstreamer-1.0
```

</details>

As far as I can see, the fix itself **doesn't affect the installed files**.

_Best regards!_