### PR TITLE
app-emulation/vendor-reset: Fix implicit declaration of function strlcpy

### DIFF
--- a/app-emulation/vendor-reset/files/vendor-reset-0.1.1-allow-correct-compilation-with-clang.patch
+++ b/app-emulation/vendor-reset/files/vendor-reset-0.1.1-allow-correct-compilation-with-clang.patch
@@ -1,0 +1,23 @@
+https://github.com/gnif/vendor-reset/commit/084881c6e9e11bdadaf05798e669568848e698a3.patch
+From: =?UTF-8?q?Marcus=20K=C3=B6hler?= <khler.marcus@gmail.com>
+Date: Mon, 25 Dec 2023 21:43:41 +0100
+Subject: [PATCH] Allow correct compilation with Clang/LLVM
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Marcus Köhler <khler.marcus@gmail.com>
+--- a/src/hook.c
++++ b/src/hook.c
+@@ -30,7 +30,11 @@ static bool hook_installed = false;
+ static int (*orig_pci_dev_specific_reset)(struct pci_dev *dev, int probe);
+ 
+ /* TCO breaks the hook, we must disable it for this function */
++#if defined(__GNUC__) && !defined(__llvm__)
+ __attribute__((optimize("-fno-optimize-sibling-calls")))
++#elif defined(__clang__)
++__attribute__((disable_tail_calls))
++#endif
+ static int hooked_pci_dev_specific_reset(struct pci_dev *dev, int probe)
+ {
+   int ret;

--- a/app-emulation/vendor-reset/files/vendor-reset-0.1.1-fix-build-on-kernel-6.8.patch
+++ b/app-emulation/vendor-reset/files/vendor-reset-0.1.1-fix-build-on-kernel-6.8.patch
@@ -1,0 +1,35 @@
+https://github.com/gnif/vendor-reset/commit/f72619e468846e0bab4426f5e71b069f88c33a11.patch
+From: Sakari <20642596+sakarie9@users.noreply.github.com>
+Date: Thu, 14 Mar 2024 10:59:15 +0800
+Subject: [PATCH] Fix build on kernel 6.8+
+
+--- a/src/amd/amdgpu/atom.c
++++ b/src/amd/amdgpu/atom.c
+@@ -28,6 +28,7 @@
+ #include <linux/sched.h>
+ #include <linux/slab.h>
+ #include <linux/delay.h>
++#include <linux/version.h>
+ #include <asm/unaligned.h>
+ 
+ //#include <drm/drm_util.h>
+@@ -39,6 +40,10 @@
+ #include "atom-names.h"
+ #include "atom-bits.h"
+ 
++#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 3, 0)
++#define strscpy strlcpy
++#endif
++
+ #define ATOM_COND_ABOVE 0
+ #define ATOM_COND_ABOVEOREQUAL 1
+ #define ATOM_COND_ALWAYS 2
+@@ -1424,7 +1429,7 @@ struct atom_context *amdgpu_atom_parse(struct card_info *card, void *bios)
+ 	if (*str != '\0')
+ 	{
+ 		pr_info("ATOM BIOS: %s\n", str);
+-		strlcpy(ctx->vbios_version, str, sizeof(ctx->vbios_version));
++		strscpy(ctx->vbios_version, str, sizeof(ctx->vbios_version));
+ 	}
+ 
+ 	return ctx;

--- a/app-emulation/vendor-reset/vendor-reset-0.1.1_pre20221205-r2.ebuild
+++ b/app-emulation/vendor-reset/vendor-reset-0.1.1_pre20221205-r2.ebuild
@@ -1,0 +1,44 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit linux-mod-r1
+
+if [[ ${PV} == *9999* ]]; then
+	EGIT_REPO_URI="https://github.com/gnif/vendor-reset.git"
+	EGIT_BRANCH="master"
+	inherit git-r3
+else
+	KEYWORDS="~amd64"
+	EGIT_COMMIT="4b466e92a2d9f76ce1082cde982c7be0be91e248"
+	SRC_URI="https://github.com/gnif/vendor-reset/archive/${EGIT_COMMIT}.tar.gz -> ${P}.tar.gz"
+fi
+
+DESCRIPTION="Linux kernel vendor specific hardware reset module"
+HOMEPAGE="https://github.com/gnif/vendor-reset"
+
+LICENSE="GPL-2"
+SLOT="0"
+
+S="${WORKDIR}/${PN}-${EGIT_COMMIT}"
+
+CONFIG_CHECK="FTRACE KPROBES PCI_QUIRKS KALLSYMS FUNCTION_TRACER"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-0.1.1-allow-correct-compilation-with-clang.patch"
+	"${FILESDIR}/${PN}-0.1.1-fix-build-on-kernel-6.8.patch"
+)
+
+src_compile() {
+	local modlist=( vendor-reset )
+	local modargs=( KDIR="${KV_OUT_DIR}" )
+	linux-mod-r1_src_compile
+}
+
+src_install() {
+	linux-mod-r1_src_install
+
+	insinto /etc/modules-load.d/
+	newins "${FILESDIR}"/modload.conf vendor-reset.conf
+}


### PR DESCRIPTION
Pulling C99 patches from upstream

Closes: https://bugs.gentoo.org/928306