### PR TITLE
x11-misc/rofi-file-browser-extended: Fix incompatible pointer type

### DIFF
--- a/x11-misc/rofi-file-browser-extended/files/rofi-file-browser-extended-1.3.1-fix-gcc14-build-fix.patch
+++ b/x11-misc/rofi-file-browser-extended/files/rofi-file-browser-extended-1.3.1-fix-gcc14-build-fix.patch
@@ -1,0 +1,53 @@
+https://patch-diff.githubusercontent.com/raw/marvinkreis/rofi-file-browser-extended/pull/54.patch
+From: Brahmajit Das <brahmajit.xyz@gmail.com>
+Date: Tue, 30 Apr 2024 11:39:59 +0530
+Subject: [PATCH 1/1] Fix building with GCC 14 on i686
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+GCC 14 (and above) have enabled certain compiler flags such as
+Wincompatible-pointer-types that causes build time errors such as
+
+rofi-file-browser-extended-1.3.1/src/icons.c:52:57: error: passing argument 2 of ‘g_array_steal’ from incompatible pointer type [-Wincompatible-pointer-types]
+   52 |     char** icon_names_raw = g_array_steal ( icon_names, &num_icon_names );
+      |                                                         ^~~~~~~~~~~~~~~
+      |                                                         |
+      |                                                         long unsigned int *
+In file included from /usr/include/glib-2.0/glib.h:33,
+                 from /usr/include/glib-2.0/gmodule.h:30,
+                 from /var/tmp/portage/x11-misc/rofi-file-browser-extended-1.3.1-r1/work/rofi-file-browser-extended-1.3.1/src/icons.c:1:
+/usr/include/glib-2.0/glib/garray.h:86:54: note: expected ‘gsize *’ {aka ‘unsigned int *’} but argument is of type ‘long unsigned int *’
+   86 |                                    gsize            *len);
+      |                                    ~~~~~~~~~~~~~~~~~~^~~
+
+My patch attempts to fix this error and some other C99 related warnings.
+First reported on Gentoo linux, please reffer
+https://bugs.gentoo.org/928491 for more details
+
+Signed-off-by: Brahmajit Das <brahmajit.xyz@gmail.com>
+--- a/src/files.c
++++ b/src/files.c
+@@ -167,7 +167,7 @@ static bool match_glob_patterns ( const char *basename, FileBrowserFileData *fd
+ {
+     int len = strlen ( basename );
+     for ( int i = 0; i < fd->num_exclude_patterns; i++ ) {
+-        if ( g_pattern_match ( fd->exclude_patterns[i], len, basename, NULL ) ) {
++        if ( g_pattern_spec_match ( fd->exclude_patterns[i], len, basename, NULL ) ) {
+             return false;
+         }
+     }
+--- a/src/icons.c
++++ b/src/icons.c
+@@ -48,7 +48,7 @@ void request_icons_for_file ( FBFile *fbfile, int icon_size, FileBrowserIconData
+         }
+     }
+ 
+-    unsigned long num_icon_names;
++    gsize num_icon_names;
+     char** icon_names_raw = g_array_steal ( icon_names, &num_icon_names );
+ 
+     /* Create icon fetcher requests. */
+-- 
+2.45.0.rc1.218.g7b19149425.dirty
+

--- a/x11-misc/rofi-file-browser-extended/rofi-file-browser-extended-1.3.1-r2.ebuild
+++ b/x11-misc/rofi-file-browser-extended/rofi-file-browser-extended-1.3.1-r2.ebuild
@@ -1,0 +1,48 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit cmake
+
+DESCRIPTION="A file browser for rofi"
+HOMEPAGE="https://github.com/marvinkreis/rofi-file-browser-extended"
+
+if [[ ${PV} == "9999" ]]; then
+	inherit git-r3
+	EGIT_REPO_URI="https://github.com/marvinkreis/${PN}.git"
+else
+	SRC_URI="https://github.com/marvinkreis/${PN}/archive/refs/tags/${PV}.tar.gz -> ${P}.tar.gz"
+	KEYWORDS="~amd64 ~x86"
+fi
+
+LICENSE="MIT"
+SLOT="0"
+
+BDEPEND="virtual/pkgconfig"
+COMMON_DEPEND="
+	dev-libs/glib:2
+	x11-misc/rofi
+"
+DEPEND="
+	${COMMON_DEPEND}
+	x11-libs/cairo
+"
+RDEPEND="${COMMON_DEPEND}"
+
+PATCHES=(
+	# https://bugs.gentoo.org/880985 https://github.com/marvinkreis/rofi-file-browser-extended/pull/49
+	"${FILESDIR}/${PN}-1.3.1-fix-function-pointer-initialization.patch"
+	"${FILESDIR}/${PN}-1.3.1-fix-gcc14-build-fix.patch"
+)
+
+src_prepare() {
+	# Delete the lines in CMakeLists.txt that install the man page.
+	sed -i "45,56d" CMakeLists.txt || die
+	cmake_src_prepare
+}
+
+src_install() {
+	cmake_src_install
+	doman "doc/${PN}.1"
+}


### PR DESCRIPTION
And some other build time warnings

Closes: https://bugs.gentoo.org/928491