### PR TITLE
www-client/chromium: fix ppc64 patchset for 124

### DIFF
--- a/www-client/chromium/chromium-124.0.6367.78.ebuild
+++ b/www-client/chromium/chromium-124.0.6367.78.ebuild
@@ -457,7 +457,6 @@ src_prepare() {
 		done
 		PATCHES+=( "${WORKDIR}/ppc64le" )
 		PATCHES+=( "${WORKDIR}/debian/patches/fixes/rust-clanglib.patch" )
-		PATCHES+=( "${WORKDIR}/debian/patches/fixes/blink-fonts-shape-result.patch" )
 	fi
 
 	default


### PR DESCRIPTION
The patch does not exist in the new patchset so must be removed. Unfortunately I get black in the title bar, tabs and some of the icons. Not sure if it's because of the new lto use or what else.

![image](https://github.com/gentoo/gentoo/assets/1047358/799b692b-13e9-4ce4-90ef-cce39fa4afae)