### PR TITLE
net-misc/dropbear: generate ed25519 host key

### DIFF
--- a/net-misc/dropbear/files/dropbear.init.d
+++ b/net-misc/dropbear/files/dropbear.init.d
@@ -11,7 +11,7 @@ check_config() {
 	mkdir -p /etc/dropbear
 
 	local t k
-	for t in dss rsa ecdsa; do
+	for t in dss rsa ecdsa ed25519; do
 		k="/etc/dropbear/dropbear_${t}_host_key"
 		if [ ! -e ${k} ] ; then
 			# See if support is enabled for this key type.


### PR DESCRIPTION
it's supported and dropbear tries to load it, but it does not exist:

```log
dropbear[665539328]: Failed loading /etc/dropbear/dropbear_ed25519_host_key
```

```sh
# dropbear -V
Dropbear v2022.8
# dropbearkey -h                                                                                                                                                                                                  
Usage: dropbearkey -t <type> -f <filename> [-s bits]                                                                                                                                                                                           
-t type Type of key to generate. One of:                                                                                                                                                                                                       
                rsa                                                                                                                                                                                                                            
                dss                                                                                                                                                                                                                            
                ecdsa                                                                                                                                                                                                                          
                ed25519                                                                                                                                                                                                                        
-f filename    Use filename for the secret key.                                                                                                                                                                                                
               ~/.ssh/id_dropbear is recommended for client keys.                                                                                                                                                                              
-s bits Key size in bits, should be a multiple of 8 (optional)                                                                                                                                                                                 
           DSS has a fixed size of 1024 bits                                                                                                                                                                                                   
           ECDSA has sizes 256 384 521                                                                                                                                                                                                         
           Ed25519 has a fixed size of 256 bits                                                                                                                                                                                                
-y              Just print the publickey and fingerprint for the                                                                                                                                                                               
                private key in <filename>.
```

and after this patch:

```sh
# /etc/init.d/dropbear restart
 * Caching service dependencies ...                                                                                                                                                                                                      [ ok ]
 * Stopping dropbear ...                                                                                                                                                                                                                 [ ok ]
 * Generating /etc/dropbear/dropbear_ed25519_host_key ...
Generating 256 bit ed25519 key, this may take a while...
 * Starting dropbear ...
```
