### PR TITLE
dev-libs/nss: backport fix for test with low timeout

### DIFF
--- a/dev-libs/nss/files/nss-3.90.2-backport-D180718.patch
+++ b/dev-libs/nss/files/nss-3.90.2-backport-D180718.patch
@@ -1,0 +1,35 @@
+https://github.com/nss-dev/nss/commit/6ab861ba652985ce5985a3fb1ddc87a15aac5027
+https://bugzilla.mozilla.org/show_bug.cgi?id=1835357
+https://phabricator.services.mozilla.com/D180718
+
+From 6ab861ba652985ce5985a3fb1ddc87a15aac5027 Mon Sep 17 00:00:00 2001
+From: Robert Relyea <rrelyea@redhat.com>
+Date: Mon, 12 Jun 2023 11:18:03 -0700
+Subject: [PATCH] Bug 1835357 dbtests.sh failure in "certutil dump keys with
+ explicit default trust flags" r=jschanck
+
+ Fix the time value so we don't fail on slower or overloaded platforms.
+
+ bob
+
+Differential Revision: https://phabricator.services.mozilla.com/D180718
+
+--HG--
+extra : rebase_source : 3fb50de29dbf5f635cae10e962eb995c25cd108a
+---
+ tests/dbtests/dbtests.sh | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tests/dbtests/dbtests.sh b/tests/dbtests/dbtests.sh
+index b0b195d4d0..c82ea85caf 100755
+--- a/tests/dbtests/dbtests.sh
++++ b/tests/dbtests/dbtests.sh
+@@ -366,7 +366,7 @@ dbtest_main()
+       RARRAY=($dtime)
+       TIMEARRAY=(${RARRAY[1]//./ })
+       echo "${TIMEARRAY[0]} seconds"
+-      test ${TIMEARRAY[0]} -lt 2
++      test ${TIMEARRAY[0]} -lt 5
+       ret=$?
+       html_msg ${ret} 0 "certutil dump keys with explicit default trust flags"
+     fi

--- a/dev-libs/nss/nss-3.90.2-r1.ebuild
+++ b/dev-libs/nss/nss-3.90.2-r1.ebuild
@@ -40,6 +40,7 @@ PATCHES=(
 	"${FILESDIR}"/nss-3.87-use-clang-as-bgo892686.patch
 	"${FILESDIR}"/nss-3.90.2-bmo-1885749-disable-ASM-C25519-on-non-X86_64.patch
 	"${FILESDIR}"/nss-3.90-remove-support-of-curve25519.patch
+	"${FILESDIR}/${PN}-3.90.2-backport-D180718.patch"
 )
 
 src_prepare() {


### PR DESCRIPTION
See: https://github.com/nss-dev/nss/commit/6ab861ba652985ce5985a3fb1ddc87a15aac5027
See: https://bugzilla.mozilla.org/show_bug.cgi?id=1835357
See: https://phabricator.services.mozilla.com/D180718
Bug: https://bugs.gentoo.org/928403