### PR TITLE
.github: Add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+<!-- Please put the pull request description above -->
+
+---
+
+Please check all the boxes that apply:
+
+- [ ] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
+- [ ] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
+- [ ] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
+- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
+
+Please note that all boxes must be checked for the pull request to be merged.


### PR DESCRIPTION
The idea is to increase awareness of the AI policy, as well as other rules, and to inform users *before* they submit a PR.