### PR TITLE
*/*: drop qt from maintainers for end-user applications + their deps

### DIFF
--- a/app-backup/luckybackup/metadata.xml
+++ b/app-backup/luckybackup/metadata.xml
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer type="project">
-		<email>qt@gentoo.org</email>
-		<name>Gentoo Qt Project</name>
-	</maintainer>
+	<!-- maintainer-needed -->
 	<upstream>
 		<remote-id type="sourceforge">luckybackup</remote-id>
 	</upstream>

--- a/app-crypt/qca/metadata.xml
+++ b/app-crypt/qca/metadata.xml
@@ -2,10 +2,6 @@
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
 	<maintainer type="project">
-		<email>qt@gentoo.org</email>
-		<name>Gentoo Qt Project</name>
-	</maintainer>
-	<maintainer type="project">
 		<email>kde@gentoo.org</email>
 		<name>Gentoo KDE Project</name>
 	</maintainer>

--- a/app-editors/focuswriter/metadata.xml
+++ b/app-editors/focuswriter/metadata.xml
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer type="project">
-		<email>qt@gentoo.org</email>
-		<name>Gentoo Qt Project</name>
-	</maintainer>
+	<!-- maintainer-needed -->
 	<upstream>
 		<bugs-to>https://gottcode.org/focuswriter/bugs/</bugs-to>
 		<remote-id type="github">gottcode/focuswriter</remote-id>

--- a/app-editors/juffed/metadata.xml
+++ b/app-editors/juffed/metadata.xml
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer type="project">
-		<email>qt@gentoo.org</email>
-		<name>Gentoo Qt Project</name>
-	</maintainer>
+	<!-- maintainer-needed -->
 	<upstream>
 		<remote-id type="sourceforge">juffed</remote-id>
 		<remote-id type="github">Mezomish/juffed</remote-id>

--- a/app-editors/qxmledit/metadata.xml
+++ b/app-editors/qxmledit/metadata.xml
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer type="project">
-		<email>qt@gentoo.org</email>
-		<name>Gentoo Qt Project</name>
-	</maintainer>
+	<!-- maintainer-needed -->
 	<longdescription lang="en">
 		QXmlEdit is a simple XML editor based on Qt libraries. Its main features are
 		unusual data visualization modes, nice XML manipulation and presentation

--- a/app-editors/tea/metadata.xml
+++ b/app-editors/tea/metadata.xml
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer type="project">
-		<email>qt@gentoo.org</email>
-		<name>Gentoo Qt Project</name>
-	</maintainer>
+	<!-- maintainer-needed -->
 	<longdescription>
 		A very small Qt text editor. It has lots of extra features including syntax
 		highlighting and a built in file manager as well as a built in image viewer.

--- a/app-emulation/q4wine/metadata.xml
+++ b/app-emulation/q4wine/metadata.xml
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer type="project">
-		<email>qt@gentoo.org</email>
-		<name>Gentoo Qt Project</name>
-	</maintainer>
+	<!-- maintainer-needed -->
 	<use>
 		<flag name="ico">Enable ico support via <pkg>media-gfx/icoutils</pkg></flag>
 		<flag name="iso">Support unprivileged mounting of ISO9660 images via <pkg>sys-fs/fuseiso</pkg></flag>

--- a/app-text/cb2bib/metadata.xml
+++ b/app-text/cb2bib/metadata.xml
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer type="project">
-		<email>qt@gentoo.org</email>
-		<name>Gentoo Qt Project</name>
-	</maintainer>
+	<!-- maintainer-needed -->
 	<upstream>
 		<bugs-to>mailto:webmaster@molspaces.com</bugs-to>
 	</upstream>

--- a/app-text/qpdfview/metadata.xml
+++ b/app-text/qpdfview/metadata.xml
@@ -5,10 +5,6 @@
 		<email>grozin@gentoo.org</email>
 		<name>Andrey Grozin</name>
 	</maintainer>
-	<maintainer type="project">
-		<email>qt@gentoo.org</email>
-		<name>Gentoo Qt Project</name>
-	</maintainer>
 	<use>
 		<flag name="fitz">
 			Use experimental fitz rendering, provided by <pkg>app-text/mupdf</pkg>,

--- a/dev-db/sqliteman/metadata.xml
+++ b/dev-db/sqliteman/metadata.xml
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer type="project">
-		<email>qt@gentoo.org</email>
-		<name>Gentoo Qt Project</name>
-	</maintainer>
+	<!-- maintainer-needed -->
 	<upstream>
 		<remote-id type="sourceforge">sqliteman</remote-id>
 	</upstream>

--- a/dev-libs/libdbusmenu-lxqt/metadata.xml
+++ b/dev-libs/libdbusmenu-lxqt/metadata.xml
@@ -5,10 +5,6 @@
 		<email>lxqt@gentoo.org</email>
 		<name>LXQt</name>
 	</maintainer>
-	<maintainer type="project">
-		<email>qt@gentoo.org</email>
-		<name>Gentoo Qt Project</name>
-	</maintainer>
 	<upstream>
 		<remote-id type="github">lxqt/libdbusmenu-lxqt</remote-id>
 	</upstream>

--- a/dev-libs/libqtxdg/metadata.xml
+++ b/dev-libs/libqtxdg/metadata.xml
@@ -5,10 +5,6 @@
 		<email>lxqt@gentoo.org</email>
 		<name>LXQt</name>
 	</maintainer>
-	<maintainer type="project">
-		<email>qt@gentoo.org</email>
-		<name>Gentoo Qt Project</name>
-	</maintainer>
 	<upstream>
 		<remote-id type="github">lxqt/libqtxdg</remote-id>
 	</upstream>

--- a/dev-libs/qcustomplot/metadata.xml
+++ b/dev-libs/qcustomplot/metadata.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer type="project">
-		<email>qt@gentoo.org</email>
-		<name>Gentoo Qt Project</name>
-	</maintainer>
+	<!-- maintainer-needed -->
 </pkgmetadata>

--- a/dev-libs/qoauth/metadata.xml
+++ b/dev-libs/qoauth/metadata.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer type="project">
-		<email>qt@gentoo.org</email>
-		<name>Gentoo Qt Project</name>
-	</maintainer>
+	<!-- maintainer-needed -->
 </pkgmetadata>

--- a/dev-python/qscintilla-python/metadata.xml
+++ b/dev-python/qscintilla-python/metadata.xml
@@ -2,10 +2,6 @@
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
 	<maintainer type="project">
-		<email>qt@gentoo.org</email>
-		<name>Gentoo Qt Project</name>
-	</maintainer>
-	<maintainer type="project">
 		<email>python@gentoo.org</email>
 		<name>Python</name>
 	</maintainer>

--- a/dev-util/xxdiff/metadata.xml
+++ b/dev-util/xxdiff/metadata.xml
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer type="project">
-		<email>qt@gentoo.org</email>
-		<name>Gentoo Qt Project</name>
-	</maintainer>
+	<!-- maintainer-needed -->
 	<upstream>
 		<remote-id type="sourceforge">xxdiff</remote-id>
 	</upstream>

--- a/dev-vcs/qgit/metadata.xml
+++ b/dev-vcs/qgit/metadata.xml
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer type="project">
-		<email>qt@gentoo.org</email>
-		<name>Gentoo Qt Project</name>
-	</maintainer>
+	<!-- maintainer-needed -->
 	<upstream>
 		<remote-id type="github">tibirna/qgit</remote-id>
 	</upstream>

--- a/media-gfx/fotowall/metadata.xml
+++ b/media-gfx/fotowall/metadata.xml
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer type="project">
-		<email>qt@gentoo.org</email>
-		<name>Gentoo Qt Project</name>
-	</maintainer>
+	<!-- maintainer-needed -->
 	<use>
 		<flag name="webcam">Enable webcam support</flag>
 	</use>

--- a/media-gfx/nomacs/metadata.xml
+++ b/media-gfx/nomacs/metadata.xml
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer type="project">
-		<email>qt@gentoo.org</email>
-		<name>Gentoo Qt Project</name>
-	</maintainer>
+	<!-- maintainer-needed -->
 	<upstream>
 		<bugs-to>https://nomacs.org/redmine/projects/nomacs</bugs-to>
 		<remote-id type="github">nomacs/nomacs</remote-id>

--- a/media-gfx/photoqt/metadata.xml
+++ b/media-gfx/photoqt/metadata.xml
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer type="project">
-		<email>qt@gentoo.org</email>
-		<name>Gentoo Qt Project</name>
-	</maintainer>
+	<!-- maintainer-needed -->
 	<use>
 		<flag name="devil">Support additional image formats using <pkg>media-libs/devil</pkg></flag>
 		<flag name="freeimage">Support additional image formats using <pkg>media-libs/freeimage</pkg></flag>

--- a/media-gfx/phototonic/metadata.xml
+++ b/media-gfx/phototonic/metadata.xml
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-  <maintainer type="project">
-    <email>qt@gentoo.org</email>
-    <name>Gentoo Qt Project</name>
-  </maintainer>
+  <!-- maintainer-needed -->
   <upstream>
     <remote-id type="github">oferkv/phototonic</remote-id>
   </upstream>

--- a/media-sound/bempc/metadata.xml
+++ b/media-sound/bempc/metadata.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-  <maintainer type="project">
-    <email>qt@gentoo.org</email>
-    <name>Gentoo Qt Project</name>
-  </maintainer>
-  </pkgmetadata>
+	<!-- maintainer-needed -->
+</pkgmetadata>

--- a/media-sound/musique/metadata.xml
+++ b/media-sound/musique/metadata.xml
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer type="project">
-		<email>qt@gentoo.org</email>
-		<name>Gentoo Qt Project</name>
-	</maintainer>
+	<!-- maintainer-needed -->
 	<upstream>
 		<remote-id type="github">flaviotordini/musique</remote-id>
 	</upstream>

--- a/media-sound/qastools/metadata.xml
+++ b/media-sound/qastools/metadata.xml
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer type="project">
-		<email>qt@gentoo.org</email>
-		<name>Gentoo Qt Project</name>
-	</maintainer>
+	<!-- maintainer-needed -->
 	<upstream>
 		<remote-id type="sourceforge">qastools</remote-id>
 	</upstream>

--- a/media-sound/qtagger/metadata.xml
+++ b/media-sound/qtagger/metadata.xml
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer type="project">
-		<email>qt@gentoo.org</email>
-		<name>Gentoo Qt Project</name>
-	</maintainer>
+	<!-- maintainer-needed -->
 	<upstream>
 		<remote-id type="github">DOOMer/qtagger</remote-id>
 	</upstream>

--- a/media-sound/qtgain/metadata.xml
+++ b/media-sound/qtgain/metadata.xml
@@ -5,8 +5,4 @@
     <email>sound@gentoo.org</email>
     <name>Gentoo Sound project</name>
   </maintainer>
-<maintainer type="project">
-    <email>qt@gentoo.org</email>
-    <name>Gentoo Qt Project</name>
-  </maintainer>
 </pkgmetadata>

--- a/media-video/baka-mplayer/metadata.xml
+++ b/media-video/baka-mplayer/metadata.xml
@@ -6,10 +6,6 @@
     <name>Christopher Steward</name>
   </maintainer>
   <maintainer type="project">
-    <email>qt@gentoo.org</email>
-    <name>Gentoo Qt Project</name>
-  </maintainer>
-  <maintainer type="project">
     <email>media-video@gentoo.org</email>
     <name>Gentoo Video project</name>
   </maintainer>

--- a/media-video/smplayer/metadata.xml
+++ b/media-video/smplayer/metadata.xml
@@ -2,10 +2,6 @@
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
   <maintainer type="project">
-    <email>qt@gentoo.org</email>
-    <name>Gentoo Qt Project</name>
-  </maintainer>
-  <maintainer type="project">
     <email>media-video@gentoo.org</email>
     <name>Gentoo Video project</name>
   </maintainer>

--- a/net-analyzer/nmapsi/metadata.xml
+++ b/net-analyzer/nmapsi/metadata.xml
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer type="project">
-		<email>qt@gentoo.org</email>
-		<name>Gentoo Qt Project</name>
-	</maintainer>
+	<!-- maintainer-needed -->
 	<upstream>
 		<remote-id type="github">nmapsi4/nmapsi4</remote-id>
 		<remote-id type="sourceforge">nmapsi</remote-id>

--- a/net-misc/qtm/metadata.xml
+++ b/net-misc/qtm/metadata.xml
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer type="project">
-		<email>qt@gentoo.org</email>
-		<name>Gentoo Qt Project</name>
-	</maintainer>
+	<!-- maintainer-needed -->
 	<upstream>
 		<remote-id type="sourceforge">catkin</remote-id>
 	</upstream>

--- a/sci-electronics/qelectrotech/metadata.xml
+++ b/sci-electronics/qelectrotech/metadata.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer type="project">
-		<email>qt@gentoo.org</email>
-		<name>Gentoo Qt Project</name>
-	</maintainer>
+	<!-- maintainer-needed -->
 </pkgmetadata>

--- a/sci-visualization/kst/metadata.xml
+++ b/sci-visualization/kst/metadata.xml
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer type="project">
-		<email>qt@gentoo.org</email>
-		<name>Gentoo Qt Project</name>
-	</maintainer>
+	<!-- maintainer-needed -->
 	<upstream>
 		<remote-id type="sourceforge">kst</remote-id>
 		<bugs-to>https://bugs.kde.org/</bugs-to>

--- a/x11-libs/qscintilla/metadata.xml
+++ b/x11-libs/qscintilla/metadata.xml
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer type="project">
-		<email>qt@gentoo.org</email>
-		<name>Gentoo Qt Project</name>
-	</maintainer>
+	<!-- maintainer-needed -->
 	<use>
 		<flag name="designer">Build plugin for Qt Designer</flag>
 	</use>

--- a/x11-libs/qtermwidget/metadata.xml
+++ b/x11-libs/qtermwidget/metadata.xml
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer type="project">
-		<email>qt@gentoo.org</email>
-		<name>Gentoo Qt Project</name>
-	</maintainer>
+	<!-- maintainer-needed -->
 	<longdescription lang="en">
 		QTermWidget is an opensource project based on konsole (a KDE application).
 		The main goal of this project is to provide unicode-enabled, embeddable

--- a/x11-misc/kaqaz/metadata.xml
+++ b/x11-misc/kaqaz/metadata.xml
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer type="project">
-		<email>qt@gentoo.org</email>
-		<name>Gentoo Qt Project</name>
-	</maintainer>
+	<!-- maintainer-needed -->
 	<upstream>
 		<remote-id type="github">sialan-labs/kaqaz</remote-id>
 	</upstream>

--- a/x11-misc/qcomicbook/metadata.xml
+++ b/x11-misc/qcomicbook/metadata.xml
@@ -1,14 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer type="project">
-		<email>desktop-misc@gentoo.org</email>
-		<name>Gentoo Desktop Miscellaneous Project</name>
-	</maintainer>
-	<maintainer type="project">
-		<email>qt@gentoo.org</email>
-		<name>Gentoo Qt Project</name>
-	</maintainer>
+	<!-- maintainer-needed -->
 	<upstream>
 		<remote-id type="github">stolowski/QComicBook</remote-id>
 	</upstream>

--- a/x11-misc/qlipper/metadata.xml
+++ b/x11-misc/qlipper/metadata.xml
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer type="project">
-		<email>qt@gentoo.org</email>
-		<name>Gentoo Qt Project</name>
-	</maintainer>
+	<!-- maintainer-needed -->
 	<upstream>
 		<remote-id type="github">pvanek/qlipper</remote-id>
 	</upstream>

--- a/x11-misc/qps/metadata.xml
+++ b/x11-misc/qps/metadata.xml
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer type="project">
-		<email>qt@gentoo.org</email>
-		<name>Gentoo Qt Project</name>
-	</maintainer>
+	<!-- maintainer-needed -->
 	<upstream>
 		<remote-id type="github">lxqt/qps</remote-id>
 	</upstream>

--- a/x11-misc/qtfm/metadata.xml
+++ b/x11-misc/qtfm/metadata.xml
@@ -1,12 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-<maintainer type="project">
-	<email>qt@gentoo.org</email>
-	<name>Gentoo Qt Project</name>
-</maintainer>
-<use>
-<flag name="dbus">Install the qtfm-tray removable device manager</flag>
-<flag name="shared">Install the libQtFM shared library and headers</flag>
-</use>
+	<!-- maintainer-needed -->
+	<use>
+		<flag name="dbus">Install the qtfm-tray removable device manager</flag>
+		<flag name="shared">Install the libQtFM shared library and headers</flag>
+	</use>
 </pkgmetadata>

--- a/x11-misc/qxkb/metadata.xml
+++ b/x11-misc/qxkb/metadata.xml
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer type="project">
-		<email>qt@gentoo.org</email>
-		<name>Gentoo Qt Project</name>
-	</maintainer>
+	<!-- maintainer-needed -->
 	<upstream>
 		<remote-id type="github">disels/qxkb</remote-id>
 	</upstream>

--- a/x11-misc/screengrab/metadata.xml
+++ b/x11-misc/screengrab/metadata.xml
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer type="project">
-		<email>qt@gentoo.org</email>
-		<name>Gentoo Qt Project</name>
-	</maintainer>
+	<!-- maintainer-needed -->
 	<upstream>
 		<maintainer status="active">
 			<email>agaida@siduction.org</email>

--- a/x11-terms/qterminal/metadata.xml
+++ b/x11-terms/qterminal/metadata.xml
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer type="project">
-		<email>qt@gentoo.org</email>
-		<name>Gentoo Qt Project</name>
-	</maintainer>
+	<!-- maintainer-needed -->
 	<upstream>
 		<remote-id type="github">qterminal/qterminal</remote-id>
 	</upstream>

--- a/x11-themes/qtcurve/metadata.xml
+++ b/x11-themes/qtcurve/metadata.xml
@@ -2,10 +2,6 @@
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
   <maintainer type="project">
-    <email>qt@gentoo.org</email>
-    <name>Gentoo Qt Project</name>
-  </maintainer>
-  <maintainer type="project">
     <email>kde@gentoo.org</email>
     <name>Gentoo KDE Project</name>
   </maintainer>

--- a/x11-themes/smplayer-skins/metadata.xml
+++ b/x11-themes/smplayer-skins/metadata.xml
@@ -2,10 +2,6 @@
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
 	<maintainer type="project">
-		<email>qt@gentoo.org</email>
-		<name>Gentoo Qt Project</name>
-	</maintainer>
-	<maintainer type="project">
 		<email>media-video@gentoo.org</email>
 		<name>Gentoo Video project</name>
 	</maintainer>

--- a/x11-themes/smplayer-themes/metadata.xml
+++ b/x11-themes/smplayer-themes/metadata.xml
@@ -2,10 +2,6 @@
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
 	<maintainer type="project">
-		<email>qt@gentoo.org</email>
-		<name>Gentoo Qt Project</name>
-	</maintainer>
-	<maintainer type="project">
 		<email>media-video@gentoo.org</email>
 		<name>Gentoo Video project</name>
 	</maintainer>


### PR DESCRIPTION
Bare some exceptions, nowadays Gentoo's Qt project mostly only exists to maintain Qt itself and not and not end-user applications + their non-Qt deps.

Putting this here for a bit first before ML up-for-grabs in case anything we should actually keep but haven't realized their relevance.

Maybe @gentoo/kde  or @gentoo/lxqt will want to pickup something (e.g. qterminal+qtermwidget+screengrab for lxqt, maybe nothing for kde given e.g. qca+qtcurve already have kde), feel free to take & remove qt now and I'll just remove it from this list when I rebase. Anyone else that happen to look can feel free to take them too, will send the final up-for-grabs later. Remember to update bugs if taking anything.

Currently kept:
- dev-qt/*: `¯\_(ツ)_/¯`
- dev-qt/qt-creator: Qt is the upstream, and frequently needs fixing on Qt bumps due to private api uses and so may as well keep it, separate note given this probably belong in dev-util or so rather than dev-qt (should probably move it later)
- dev-util/qbs: Qt is the upstream too and is optionally usable with qt-creator, albeit unsure if anyone even uses it and had no interest in maintaining it... but maybe I'll (finally) bump it later given it's blocking qtscript:5 removal
- dev-libs/double-conversion: not Qt but qtbase/core depends on it making it important and no need to dump it on sci-only -- has a pending bump so maybe I'll look later
- dev-python/PyQt* and sip: closely related and Qt6's often needs fixing+sync'ing with Qt bumps, easier if we do it -- hope never have to pickup pyside6 though :eyes:
- net-libs/telepathy-qt: already on the chopping block, not worth removing 4 lines!

Considered but not kept:
- qscintilla & friends: recently been worked on and has same upstream as PyQt* but not sure if it makes sense for us to maintain it

TODO: should check if anything needs treecleaning in ::qt later, like q4wine if we don't maintain it (**Edit:** suppose could move the live ebuilds to ::gentoo for future maintainers in case they want to keep them, unless they seem in a poor state or out of sync)