### PR TITLE
media-plugins/audacious-plugins: Fix scrobbler bug with latest libxml2

### DIFF
--- a/media-plugins/audacious-plugins/audacious-plugins-4.3.1-r3.ebuild
+++ b/media-plugins/audacious-plugins/audacious-plugins-4.3.1-r3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -113,6 +113,15 @@ src_prepare() {
 	if ! use nls; then
 		sed -e "/SUBDIRS/s/ po//" -i Makefile || die "Failed to sed" # bug #512698
 	fi
+
+	# Remove use of deprecated xmlParseMemory function from the scrobbler
+	# which relies on the old SAX1 parser being available
+	# https://github.com/audacious-media-player/audacious-plugins/commit/c9246b1c8b09553250c40d222115c2c0865779e2
+	eapply "${FILESDIR}/${PN}-libxml2-no_sax1.patch"
+	# Fix bug where including the null byte causes XML parsing errors with
+	# the scrobbler code
+	# https://github.com/audacious-media-player/audacious-plugins/commit/5103ba0f504f1a98cac7babca3a0e45ca969f7f8
+	eapply "${FILESDIR}/${PN}-libxml2-no_null_byte.patch"
 }
 
 src_configure() {

--- a/media-plugins/audacious-plugins/files/audacious-plugins-libxml2-no_null_byte.patch
+++ b/media-plugins/audacious-plugins/files/audacious-plugins-libxml2-no_null_byte.patch
@@ -1,0 +1,29 @@
+commit 5103ba0f504f1a98cac7babca3a0e45ca969f7f8
+Author: Thomas Lange <thomas-lange2@gmx.de>
+Date:   Sat Jan 13 19:08:28 2024 +0100
+
+    scrobbler2: Fix XML parsing of Last.fm API responses
+    
+    Due to an off-by-one-error newer libxml2 versions failed to parse valid XML.
+    Parser error: "Extra content at the end of the document"
+    
+    See also: https://github.com/orgs/audacious-media-player/discussions/100
+
+diff --git a/src/scrobbler2/scrobbler_xml_parsing.cc b/src/scrobbler2/scrobbler_xml_parsing.cc
+index 3320a32b0..46542f135 100644
+--- a/src/scrobbler2/scrobbler_xml_parsing.cc
++++ b/src/scrobbler2/scrobbler_xml_parsing.cc
+@@ -10,7 +10,7 @@ static gboolean prepare_data () {
+     received_data[received_data_size] = '\0';
+     AUDDBG("Data received from last.fm:\n%s\n%%%%End of data%%%%\n", received_data);
+ 
+-    doc = xmlReadMemory(received_data, received_data_size+1, nullptr, nullptr, 0);
++    doc = xmlReadMemory(received_data, received_data_size, nullptr, nullptr, 0);
+     received_data_size = 0;
+     if (doc == nullptr) {
+         AUDDBG("Document not parsed successfully.\n");
+@@ -297,4 +297,3 @@ gboolean read_session_key(String &error_code, String &error_detail) {
+     clean_data();
+     return result;
+ }
+-

--- a/media-plugins/audacious-plugins/files/audacious-plugins-libxml2-no_sax1.patch
+++ b/media-plugins/audacious-plugins/files/audacious-plugins-libxml2-no_sax1.patch
@@ -1,0 +1,37 @@
+commit c9246b1c8b09553250c40d222115c2c0865779e2
+Author: Thomas Lange <thomas-lange2@gmx.de>
+Date:   Sat Nov 25 21:11:29 2023 +0100
+
+    scrobbler2: Don't use deprecated xmlParseMemory function
+    
+    It's only available with the old SAX1 handler which
+    may not be enabled anymore for recent libxml2 versions.
+    
+    Its successor xmlReadMemory() was introduced with version 2.6.0,
+    released in 2003. No real need for a version check then.
+
+diff --git a/src/scrobbler2/scrobbler.h b/src/scrobbler2/scrobbler.h
+index 9236a3159..78f0fdc41 100644
+--- a/src/scrobbler2/scrobbler.h
++++ b/src/scrobbler2/scrobbler.h
+@@ -14,6 +14,7 @@
+ #include <pthread.h>
+ #include <string.h>
+ #include <glib.h>
++#include <libxml/parser.h>
+ #include <libxml/xpath.h>
+ 
+ //audacious includes
+diff --git a/src/scrobbler2/scrobbler_xml_parsing.cc b/src/scrobbler2/scrobbler_xml_parsing.cc
+index 6f2a6d31a..3320a32b0 100644
+--- a/src/scrobbler2/scrobbler_xml_parsing.cc
++++ b/src/scrobbler2/scrobbler_xml_parsing.cc
+@@ -10,7 +10,7 @@ static gboolean prepare_data () {
+     received_data[received_data_size] = '\0';
+     AUDDBG("Data received from last.fm:\n%s\n%%%%End of data%%%%\n", received_data);
+ 
+-    doc = xmlParseMemory(received_data, received_data_size+1);
++    doc = xmlReadMemory(received_data, received_data_size+1, nullptr, nullptr, 0);
+     received_data_size = 0;
+     if (doc == nullptr) {
+         AUDDBG("Document not parsed successfully.\n");


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/931065

As described in bug 931065, I encountered an issue with submitting scrobbles via Audacious after upgrading libxml2. Backporting the fix from upstream (not yet in a release) resolved the issue.

I included the no SAX1 patch as well, so both patches would apply cleanly. However, you could also adapt the null byte patch to the old function call. The primary issue is the `+1`, which leads to a null byte being included in the input and confusing libxml2.