### PR TITLE
gui-apps/wmenu: add 9999

### DIFF
--- a/gui-apps/wmenu/wmenu-9999.ebuild
+++ b/gui-apps/wmenu/wmenu-9999.ebuild
@@ -1,0 +1,35 @@
+# Copyright 2023-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit meson
+
+DESCRIPTION="dynamic menu for wlroots compositors, maintains the look and feel of dmenu"
+HOMEPAGE="https://sr.ht/~adnano/wmenu/"
+
+if [[ "${PV}" == *9999* ]]; then
+	EGIT_REPO_URI="https://git.sr.ht/~adnano/wmenu"
+	inherit git-r3
+else
+	SRC_URI="https://git.sr.ht/~adnano/wmenu/archive/${PV}.tar.gz -> ${P}.tar.gz"
+	KEYWORDS="~amd64 ~arm64 ~x86"
+fi
+
+LICENSE="MIT"
+SLOT="0"
+
+BDEPEND="
+	app-text/scdoc
+	dev-util/wayland-scanner
+"
+RDEPEND="
+	x11-libs/cairo
+	x11-libs/pango
+	dev-libs/wayland
+	x11-libs/libxkbcommon
+"
+DEPEND="
+	${RDEPEND}
+	dev-libs/wayland-protocols
+"


### PR DESCRIPTION
Considering that wmenu is a new project and has major changes pretty often, I think it would be nice to see a 9999 version ebuild. At the very least include 9999 template into regular release versions.