### PR TITLE
limit dev-python/paho-mqtt to <2.0.0

### DIFF
--- a/net-analyzer/ospd-openvas/ospd-openvas-22.7.0.ebuild
+++ b/net-analyzer/ospd-openvas/ospd-openvas-22.7.0.ebuild
@@ -30,6 +30,7 @@ DEPEND="
 	>=dev-python/python-gnupg-0.4.8[${PYTHON_USEDEP}]
 	<dev-python/python-gnupg-0.6.0[${PYTHON_USEDEP}]
 	>=dev-python/paho-mqtt-1.5.1[${PYTHON_USEDEP}]
+	<dev-python/paho-mqtt-2.0.0[${PYTHON_USEDEP}]
 	>=dev-python/python-gnupg-0.4.8[${PYTHON_USEDEP}]
 	net-libs/paho-mqtt-c
 	app-misc/mosquitto


### PR DESCRIPTION
Breaking changes in dev-python/paho-mqtt-2.0.0 
https://forum.greenbone.net/t/paho-mqtt-2-0-0-breaking-changes-for-ospd-openvas-and-notus-scanner/16799