### PR TITLE
dev-libs/libspt: Fix passing gettimeofday from incompatible pointer type

### DIFF
--- a/dev-libs/libspt/files/libspt-gcc14-build-fix.patch
+++ b/dev-libs/libspt/files/libspt-gcc14-build-fix.patch
@@ -1,0 +1,16 @@
+Bug: https://bugs.gentoo.org/920642
+--- a/sptagent.c
++++ b/sptagent.c
+@@ -1032,7 +1032,11 @@ set_timefield(struct UTMP *utptr)
+ {
+ #ifdef HAVE_UTMP_UT_TV
+ #ifdef HAVE_GETTIMEOFDAY
+-    gettimeofday(&utptr->ut_tv, NULL);
++    // Refer the NOTES section of https://man7.org/linux/man-pages/man5/utmp.5.html
++    struct timeval tv;
++    gettimeofday(&tv, NULL);
++    (*utptr).ut_tv.tv_sec = tv.tv_sec;
++    (*utptr).ut_tv.tv_usec = tv.tv_usec;
+ #else
+     utptr->ut_tv.tv_sec = time(NULL);
+     utptr->ut_tv.ut_usec = 0;

--- a/dev-libs/libspt/libspt-1.1-r5.ebuild
+++ b/dev-libs/libspt/libspt-1.1-r5.ebuild
@@ -1,0 +1,51 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools
+
+DESCRIPTION="Library for handling root privilege"
+HOMEPAGE="http://www.j10n.org/libspt/"
+SRC_URI="http://www.j10n.org/${PN}/${P}.tar.bz2"
+
+LICENSE="BSD-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86"
+IUSE="suid"
+RESTRICT="test"
+
+RDEPEND="net-libs/libtirpc"
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-gentoo.patch"
+	"${FILESDIR}/${PN}-glibc-2.30.patch"
+	"${FILESDIR}/${PN}-rpc.patch"
+	"${FILESDIR}/${PN}-gcc14-build-fix.patch"
+)
+
+src_prepare() {
+	rm aclocal.m4
+
+	default
+	eautoreconf
+}
+
+src_configure() {
+	econf \
+		--disable-static \
+		--with-libtirpc
+}
+
+src_install() {
+	default
+
+	# no static archives
+	find "${ED}" -name '*.la' -delete || die
+
+	if use suid; then
+		fperms 4755 /usr/libexec/sptagent
+	fi
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/920642