### PR TITLE
sys-apps/irqbalance: version 1.9.4 doesn't work in systemd-based installations

### DIFF
--- a/sys-apps/irqbalance/files/irqbalance-1.9.4-drop-protectkerneltunables.patch
+++ b/sys-apps/irqbalance/files/irqbalance-1.9.4-drop-protectkerneltunables.patch
@@ -1,0 +1,25 @@
+https://github.com/Irqbalance/irqbalance/issues/308
+https://github.com/Irqbalance/irqbalance/commit/f2c8309a4198d8f51069a783905049c5b7eb7600
+
+From f2c8309a4198d8f51069a783905049c5b7eb7600 Mon Sep 17 00:00:00 2001
+From: Neil Horman <nhorman@openssl.org>
+Date: Mon, 1 Apr 2024 08:05:14 -0400
+Subject: [PATCH] Drop ProtectKernelTunables
+
+It makes /proc/irq read only
+---
+ misc/irqbalance.service | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/misc/irqbalance.service b/misc/irqbalance.service
+index 87e19c1..b731cc6 100644
+--- a/misc/irqbalance.service
++++ b/misc/irqbalance.service
+@@ -23,7 +23,6 @@ PrivateNetwork=yes
+ PrivateUsers=true
+ ProtectHostname=yes 
+ ProtectClock=yes 
+-ProtectKernelTunables=yes 
+ ProtectKernelModules=yes 
+ ProtectKernelLogs=yes 
+ ProtectControlGroups=yes 

--- a/sys-apps/irqbalance/irqbalance-1.9.4-r2.ebuild
+++ b/sys-apps/irqbalance/irqbalance-1.9.4-r2.ebuild
@@ -33,6 +33,10 @@ RDEPEND="
 	selinux? ( sec-policy/selinux-irqbalance )
 "
 
+PATCHES=(
+	"${FILESDIR}"/${P}-drop-protectkerneltunables.patch
+)
+
 pkg_setup() {
 	CONFIG_CHECK="~PCI_MSI"
 	linux-info_pkg_setup


### PR DESCRIPTION
There's an option (ProtectKernelTunables) in the systemd unit that doesn't
allow irqbalance to work. The upstream patch drops the option from the
unit file.

Signed-off-by: Cristian Othón Martínez Vera <cfuga@cfuga.mx>
