### PR TITLE
gui-wm/hyprland: add libliftoff dependency

### DIFF
--- a/gui-wm/hyprland/hyprland-0.39.1-r2.ebuild
+++ b/gui-wm/hyprland/hyprland-0.39.1-r2.ebuild
@@ -28,6 +28,7 @@ HYPRPM_RDEPEND="
 	app-alternatives/ninja
 	dev-build/cmake
 	dev-build/meson
+	dev-libs/libliftoff
 	dev-vcs/git
 	virtual/pkgconfig
 "


### PR DESCRIPTION
hyprpm needs libliftoff to update plugins

Closes: https://bugs.gentoo.org/931222