### PR TITLE
games-board/domination: drop unneeded dependencies, update EAPI 7 -> 8

### DIFF
--- a/games-board/domination/domination-1.1.1.6-r3.ebuild
+++ b/games-board/domination/domination-1.1.1.6-r3.ebuild
@@ -1,31 +1,21 @@
 # Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
-EANT_BUILD_TARGET="game"
-inherit desktop java-pkg-2 java-ant-2
+inherit desktop java-pkg-2
 
 DESCRIPTION="The well-known board game, written in java"
-HOMEPAGE="https://domination.sourceforge.net"
-SRC_URI="https://downloads.sourceforge.net/domination/Domination_${PV}.zip"
+HOMEPAGE="https://domination.sourceforge.io/"
+SRC_URI="https://downloads.sourceforge.net/project/domination/Domination/${PV}/Domination_${PV}.zip"
 S="${WORKDIR}"/Domination
 
 LICENSE="GPL-3"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
 
-RDEPEND=">=virtual/jre-1.8:*"
-DEPEND=">=virtual/jdk-1.8:*"
 BDEPEND="app-arch/unzip"
-
-pkg_setup() {
-	java-pkg-2_pkg_setup
-}
-
-src_compile() {
-	java-pkg-2_src_compile
-}
+RDEPEND=">=virtual/jre-1.8:*"
 
 src_install() {
 	newbin "${S}"/FlashGUI.sh ${PN}


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/881843