### PR TITLE
dev-util/codeblocks: fix USE="contrib" race condition

### DIFF
--- a/dev-util/codeblocks/codeblocks-20.03-r6.ebuild
+++ b/dev-util/codeblocks/codeblocks-20.03-r6.ebuild
@@ -9,15 +9,16 @@ inherit autotools flag-o-matic wxwidgets xdg
 
 DESCRIPTION="The open source, cross platform, free C, C++ and Fortran IDE"
 HOMEPAGE="https://codeblocks.org/"
-LICENSE="GPL-3"
-SLOT="0"
-KEYWORDS="amd64 ~ppc x86"
 SRC_URI="https://downloads.sourceforge.net/${PN}/${P}.tar.xz
 	https://dev.gentoo.org/~leio/distfiles/${P}-fortran.tar.xz
 	https://dev.gentoo.org/~leio/distfiles/${P}-fortran-update-v1.7.tar.xz
 	https://dev.gentoo.org/~leio/distfiles/${P}-fortran-update-v1.8.tar.xz
 	https://dev.gentoo.org/~leio/distfiles/${P}-codecompletion-symbolbrowser-update.tar.xz
 "
+
+LICENSE="GPL-3"
+SLOT="0"
+KEYWORDS="amd64 ~ppc x86"
 
 # USE="fortran" enables FortranProject plugin (updated to v1.8 2021-05-29 [r230])
 # that is delivered with Code::Blocks 20.03 source code.

--- a/dev-util/codeblocks/codeblocks-20.03-r7.ebuild
+++ b/dev-util/codeblocks/codeblocks-20.03-r7.ebuild
@@ -9,15 +9,16 @@ inherit autotools flag-o-matic wxwidgets xdg
 
 DESCRIPTION="The open source, cross platform, free C, C++ and Fortran IDE"
 HOMEPAGE="https://codeblocks.org/"
-LICENSE="GPL-3"
-SLOT="0"
-KEYWORDS="amd64 ~ppc ~x86"
 SRC_URI="https://downloads.sourceforge.net/${PN}/${P}.tar.xz
 	https://dev.gentoo.org/~leio/distfiles/${P}-fortran.tar.xz
 	https://dev.gentoo.org/~leio/distfiles/${P}-fortran-update-v1.7.tar.xz
 	https://dev.gentoo.org/~leio/distfiles/${P}-fortran-update-v1.8.tar.xz
 	https://dev.gentoo.org/~leio/distfiles/${P}-codecompletion-symbolbrowser-update.tar.xz
 "
+
+LICENSE="GPL-3"
+SLOT="0"
+KEYWORDS="amd64 ~ppc ~x86"
 
 # USE="fortran" enables FortranProject plugin (updated to v1.8 2021-05-29 [r230])
 # that is delivered with Code::Blocks 20.03 source code.

--- a/dev-util/codeblocks/codeblocks-20.03-r7.ebuild
+++ b/dev-util/codeblocks/codeblocks-20.03-r7.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 WX_GTK_VER="3.0-gtk3"
 
-inherit autotools flag-o-matic wxwidgets xdg
+inherit autotools flag-o-matic multiprocessing wxwidgets xdg
 
 DESCRIPTION="The open source, cross platform, free C, C++ and Fortran IDE"
 HOMEPAGE="https://codeblocks.org/"
@@ -83,6 +83,18 @@ src_configure() {
 	)
 
 	econf "${myeconfargs[@]}"
+}
+
+src_compile() {
+	if use contrib; then
+		if (( $(get_makeopts_jobs) > 8 )); then
+			emake -j8  # Bug 930819
+		else
+			emake
+		fi
+	else
+		emake
+	fi
 }
 
 src_install() {

--- a/dev-util/codeblocks/codeblocks-9999.ebuild
+++ b/dev-util/codeblocks/codeblocks-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -11,8 +11,6 @@ DESCRIPTION="The open source, cross platform, free C, C++ and Fortran IDE"
 HOMEPAGE="https://codeblocks.org/"
 LICENSE="GPL-3"
 SLOT="0"
-KEYWORDS=""
-SRC_URI=""
 ESVN_REPO_URI="svn://svn.code.sf.net/p/${PN}/code/trunk"
 ESVN_FETCH_CMD="svn checkout --ignore-externals"
 ESVN_UPDATE_CMD="svn update --ignore-externals"


### PR DESCRIPTION
I don't sure if it fixes race condition for SmartIndent plugin as all appropriate targets are already in `.NOTPARALLEL` section and I'm not able to reproduce this issue on my 4-cores CPU.

Closes: https://bugs.gentoo.org/930819