### PR TITLE
app-forensics/foremost, app-misc/*: use HTTPS, fix LICENSE

### DIFF
--- a/app-forensics/foremost/foremost-1.5.7-r4.ebuild
+++ b/app-forensics/foremost/foremost-1.5.7-r4.ebuild
@@ -6,10 +6,10 @@ EAPI=7
 inherit toolchain-funcs prefix
 
 DESCRIPTION="Console program to recover files based on their headers and footers"
-HOMEPAGE="http://foremost.sourceforge.net/"
+HOMEPAGE="https://foremost.sourceforge.net/"
 #SRC_URI="https://downloads.sourceforge.net/${PN}/${P}.tar.gz"
 # starting to hate sf.net ...
-SRC_URI="http://foremost.sourceforge.net/pkg/${P}.tar.gz"
+SRC_URI="https://foremost.sourceforge.net/pkg/${P}.tar.gz"
 
 LICENSE="public-domain"
 SLOT="0"

--- a/app-misc/cdctl/cdctl-0.16.ebuild
+++ b/app-misc/cdctl/cdctl-0.16.ebuild
@@ -6,7 +6,7 @@ EAPI=7
 inherit autotools toolchain-funcs
 
 DESCRIPTION="Utility to control your cd/dvd drive"
-HOMEPAGE="http://cdctl.sourceforge.net/"
+HOMEPAGE="https://cdctl.sourceforge.net/"
 SRC_URI="https://downloads.sourceforge.net/cdctl/${P}.tar.gz"
 S="${WORKDIR}/${PN}"
 

--- a/app-misc/dailystrips/dailystrips-1.0.28-r4.ebuild
+++ b/app-misc/dailystrips/dailystrips-1.0.28-r4.ebuild
@@ -3,8 +3,8 @@
 
 EAPI=8
 
-DESCRIPTION="dailystrips automatically downloads your favorite online comics from the web"
-HOMEPAGE="http://dailystrips.sourceforge.net/"
+DESCRIPTION="Dailystrips automatically downloads your favorite online comics from the web"
+HOMEPAGE="https://dailystrips.sourceforge.net/"
 SRC_URI="https://downloads.sourceforge.net/dailystrips/${P}.tar.gz"
 
 LICENSE="GPL-2"

--- a/app-misc/muttprint/muttprint-0.73-r5.ebuild
+++ b/app-misc/muttprint/muttprint-0.73-r5.ebuild
@@ -6,11 +6,11 @@ EAPI=7
 inherit autotools
 
 DESCRIPTION="Script for pretty printing of your mails"
-HOMEPAGE="http://muttprint.sourceforge.net"
+HOMEPAGE="https://muttprint.sourceforge.net"
 SRC_URI="https://downloads.sourceforge.net/muttprint/${P}.tar.gz"
 
+LICENSE="GPL-2+"
 SLOT="0"
-LICENSE="GPL-2"
 KEYWORDS="amd64 ppc ppc64 x86"
 IUSE="doc"
 

--- a/app-misc/nut/nut-20.1.ebuild
+++ b/app-misc/nut/nut-20.1.ebuild
@@ -6,10 +6,10 @@ EAPI=7
 inherit toolchain-funcs
 
 DESCRIPTION="Record what you eat and analyze your nutrient levels"
-HOMEPAGE="http://nut.sourceforge.net/"
+HOMEPAGE="https://nut.sourceforge.net/"
 SRC_URI="https://downloads.sourceforge.net/${PN}/${P}.tar.gz"
 
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="0"
 KEYWORDS="~alpha amd64 ~arm ppc x86"
 

--- a/app-misc/pfm/pfm-2.12.3-r1.ebuild
+++ b/app-misc/pfm/pfm-2.12.3-r1.ebuild
@@ -5,8 +5,8 @@ EAPI=7
 
 inherit perl-module
 
-DESCRIPTION="A terminal-based file manager written in Perl"
-HOMEPAGE="http://p-f-m.sourceforge.net/"
+DESCRIPTION="Terminal-based file manager written in Perl"
+HOMEPAGE="https://p-f-m.sourceforge.net/"
 SRC_URI="https://downloads.sourceforge.net/p-f-m/${P}.tar.gz"
 
 LICENSE="GPL-2"

--- a/app-misc/wipe/wipe-2.3.1.ebuild
+++ b/app-misc/wipe/wipe-2.3.1.ebuild
@@ -6,10 +6,10 @@ EAPI=7
 inherit autotools
 
 DESCRIPTION="Secure file wiping utility based on Peter Gutman's patterns"
-HOMEPAGE="http://wipe.sourceforge.net/"
+HOMEPAGE="https://wipe.sourceforge.net/"
 SRC_URI="https://downloads.sourceforge.net/wipe/${P}.tar.bz2"
 
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="0"
 KEYWORDS="amd64 ppc ~ppc64 x86"
 


### PR DESCRIPTION
Hi,

just a few minor fixes to use `https` instead of `http` and fix a few `LICENSES`.