### PR TITLE
dev-db/redis: move acct-{user,group} to IDEPEND

### DIFF
--- a/dev-db/redis/redis-6.2.14-r1.ebuild
+++ b/dev-db/redis/redis-6.2.14-r1.ebuild
@@ -36,9 +36,12 @@ COMMON_DEPEND="
 
 RDEPEND="
 	${COMMON_DEPEND}
+	selinux? ( sec-policy/selinux-redis )
+"
+
+IDEPEND="
 	acct-group/redis
 	acct-user/redis
-	selinux? ( sec-policy/selinux-redis )
 "
 
 BDEPEND="

--- a/dev-db/redis/redis-7.0.15-r1.ebuild
+++ b/dev-db/redis/redis-7.0.15-r1.ebuild
@@ -27,9 +27,12 @@ COMMON_DEPEND="
 
 RDEPEND="
 	${COMMON_DEPEND}
+	selinux? ( sec-policy/selinux-redis )
+"
+
+IDEPEND="
 	acct-group/redis
 	acct-user/redis
-	selinux? ( sec-policy/selinux-redis )
 "
 
 BDEPEND="

--- a/dev-db/redis/redis-7.2.4-r1.ebuild
+++ b/dev-db/redis/redis-7.2.4-r1.ebuild
@@ -30,9 +30,12 @@ COMMON_DEPEND="
 
 RDEPEND="
 	${COMMON_DEPEND}
+	selinux? ( sec-policy/selinux-redis )
+"
+
+IDEPEND="
 	acct-group/redis
 	acct-user/redis
-	selinux? ( sec-policy/selinux-redis )
 "
 
 BDEPEND="


### PR DESCRIPTION
src_install makes a call to diropts and passes -o and -g options with redis as the value, before this change acct-user/redis and acct-group/redis were in RDEPEND which could cause failures during src_install if redis was built as a binpkg or with --onlydeps --onlydeps-with-rdeps=n --onlydeps-with-ideps=y