### PR TITLE
app-misc/hyfetch: remove unexpected directory in site-packages

### DIFF
--- a/app-misc/hyfetch/files/hyfetch-1.4.11-neofetch.patch
+++ b/app-misc/hyfetch/files/hyfetch-1.4.11-neofetch.patch
@@ -1,0 +1,22 @@
+From: Bailey Kasin <baileykasin@gmail.com>
+Date: Mon, 02 Oct 2023 23:02:10 -0700
+Subject: [PATCH] use system neowofetch
+
+Signed-off-by: Bailey Kasin <baileykasin@gmail.com>
+Forwarded: not-needed
+
+---
+diff --git a/hyfetch/neofetch_util.py b/hyfetch/neofetch_util.py
+index 17829ac..1fcfcfc 100644
+--- a/hyfetch/neofetch_util.py
++++ b/hyfetch/neofetch_util.py
+@@ -285,7 +285,7 @@ def run_neofetch_cmd(args: str, pipe: bool = False) -> str | None:
+     Run neofetch command
+     """
+     if platform.system() != 'Windows':
+-        full_cmd = ['/usr/bin/env', 'bash', get_command_path(), *shlex.split(args)]
++        full_cmd = ['/usr/bin/neowofetch', *shlex.split(args)]
+ 
+     else:
+         cmd = get_command_path().replace("\\", "/").replace("C:/", "/c/")
+

--- a/app-misc/hyfetch/files/hyfetch-1.4.11-pyproject.patch
+++ b/app-misc/hyfetch/files/hyfetch-1.4.11-pyproject.patch
@@ -1,0 +1,116 @@
+From 4b926d90e8f2a5eebfdd68105facff1f99694f5a Mon Sep 17 00:00:00 2001
+From: Bailey Kasin <baileykasin@gmail.com>
+Date: Thu, 28 Sep 2023 13:05:22 -0700
+Subject: [PATCH] [+] Start switch to pyproject.toml
+
+Signed-off-by: Bailey Kasin <baileykasin@gmail.com>
+---
+ pyproject.toml | 37 +++++++++++++++++++++++++++++++++++
+ setup.py       | 52 ++------------------------------------------------
+ 2 files changed, 39 insertions(+), 50 deletions(-)
+ create mode 100644 pyproject.toml
+ mode change 100755 => 100644 setup.py
+
+diff --git a/pyproject.toml b/pyproject.toml
+new file mode 100644
+index 000000000..d30f10c0b
+--- /dev/null
++++ b/pyproject.toml
+@@ -0,0 +1,38 @@
++[build-system]
++requires = ["setuptools", "typing_extensions"]
++build-backend = "setuptools.build_meta"
++
++[project]
++name = "HyFetch"
++authors = [{ name = "Azalea Gui", email = "me@hydev.org" }]
++description = "neofetch with flags <3"
++readme = "README.md"
++requires-python = ">=3.7"
++license = { text = "MIT License" }
++classifiers = [
++    "License :: OSI Approved :: MIT License",
++    "Programming Language :: Python :: 3",
++    "Programming Language :: Python :: 3.7",
++    "Programming Language :: Python :: 3.8",
++    "Programming Language :: Python :: 3.9",
++    "Programming Language :: Python :: 3.10",
++    "Programming Language :: Python :: 3.11",
++    "Programming Language :: Python :: 3.12",
++]
++dependencies = [
++    "typing_extensions",
++    'psutil ; platform_system=="Windows"',
++    'colorama>=0.4.6 ; platform_system=="Windows"'
++]
++dynamic = ["version"]
++
++[tool.setuptools]
++packages = ["hyfetch", "hyfetch.distros"]
++license-files = ["LICENSE.md"]
++script-files = ["hyfetch/scripts/neowofetch"]
++
++[tool.setuptools.dynamic]
++version = {attr = "hyfetch.__version__"}
++
++[project.scripts]
++hyfetch = "hyfetch.main:run"
+diff --git a/setup.py b/setup.py
+index 95260a40..60684932 100755
+--- a/setup.py	2023-12-02 00:22:33.000000000 -0000
++++ b/setup.py	2024-05-03 08:58:46.479797868 -0000
+@@ -1,52 +1,3 @@
+-#!/usr/bin/env python3
+-from pathlib import Path
+-from setuptools import setup, find_namespace_packages
++from setuptools import setup
+ 
+-# The directory containing this file
+-HERE = Path(__file__).parent
+-
+-# Load version without importing it (see issue #192 if you are confused)
+-for l in (HERE / 'hyfetch' / '__version__.py').read_text().strip().splitlines():
+-    exec(l)
+-
+-# The text of the README file
+-README = (HERE / "README.md").read_text('utf-8')
+-
+-# This call to setup() does all the work
+-setup(
+-    name="HyFetch",
+-    version=VERSION,
+-    description="neofetch with flags <3",
+-    long_description=README,
+-    long_description_content_type="text/markdown",
+-    url="https://github.com/hykilpikonna/HyFetch",
+-    author="Azalea Gui",
+-    author_email="me@hydev.org",
+-    license="MIT",
+-    classifiers=[
+-        "License :: OSI Approved :: MIT License",
+-        "Programming Language :: Python :: 3",
+-        "Programming Language :: Python :: 3.7",
+-        "Programming Language :: Python :: 3.8",
+-        "Programming Language :: Python :: 3.9",
+-        "Programming Language :: Python :: 3.10",
+-        "Programming Language :: Python :: 3.11",
+-    ],
+-    packages=find_namespace_packages(),
+-    package_data={'hyfetch': ['hyfetch/*']},
+-    include_package_data=True,
+-    install_requires=[
+-        # Universal dependencies
+-        'setuptools', 'typing_extensions',
+-        
+-        # Windows dependencies
+-        'psutil ; platform_system=="Windows"',
+-        'colorama>=0.4.6 ; platform_system=="Windows"',
+-    ],
+-    entry_points={
+-        "console_scripts": [
+-            "hyfetch=hyfetch.main:run",
+-        ]
+-    },
+-    scripts=['hyfetch/scripts/neowofetch']
+-)
++setup()

--- a/app-misc/hyfetch/files/hyfetch-9999-pyproject.patch
+++ b/app-misc/hyfetch/files/hyfetch-9999-pyproject.patch
@@ -1,0 +1,117 @@
+From 4b926d90e8f2a5eebfdd68105facff1f99694f5a Mon Sep 17 00:00:00 2001
+From: Bailey Kasin <baileykasin@gmail.com>
+Date: Thu, 28 Sep 2023 13:05:22 -0700
+Subject: [PATCH] [+] Start switch to pyproject.toml
+
+Signed-off-by: Bailey Kasin <baileykasin@gmail.com>
+---
+ pyproject.toml | 37 +++++++++++++++++++++++++++++++++++
+ setup.py       | 52 ++------------------------------------------------
+ 2 files changed, 39 insertions(+), 50 deletions(-)
+ create mode 100644 pyproject.toml
+ mode change 100755 => 100644 setup.py
+
+diff --git a/pyproject.toml b/pyproject.toml
+new file mode 100644
+index 000000000..d30f10c0b
+--- /dev/null
++++ b/pyproject.toml
+@@ -0,0 +1,38 @@
++[build-system]
++requires = ["setuptools", "typing_extensions"]
++build-backend = "setuptools.build_meta"
++
++[project]
++name = "HyFetch"
++authors = [{ name = "Azalea Gui", email = "me@hydev.org" }]
++description = "neofetch with flags <3"
++readme = "README.md"
++requires-python = ">=3.7"
++license = { text = "MIT License" }
++classifiers = [
++    "License :: OSI Approved :: MIT License",
++    "Programming Language :: Python :: 3",
++    "Programming Language :: Python :: 3.7",
++    "Programming Language :: Python :: 3.8",
++    "Programming Language :: Python :: 3.9",
++    "Programming Language :: Python :: 3.10",
++    "Programming Language :: Python :: 3.11",
++    "Programming Language :: Python :: 3.12",
++]
++dependencies = [
++    "typing_extensions",
++    'psutil ; platform_system=="Windows"',
++    'colorama>=0.4.6 ; platform_system=="Windows"'
++]
++dynamic = ["version"]
++
++[tool.setuptools]
++packages = ["hyfetch", "hyfetch.distros"]
++license-files = ["LICENSE.md"]
++script-files = ["hyfetch/scripts/neowofetch"]
++
++[tool.setuptools.dynamic]
++version = {attr = "hyfetch.__version__"}
++
++[project.scripts]
++hyfetch = "hyfetch.main:run"
+diff --git a/setup.py b/setup.py
+index 95260a40..60684932 100755
+--- a/setup.py	2023-12-02 00:22:33.000000000 -0000
++++ b/setup.py	2024-05-03 08:58:46.479797868 -0000
+@@ -1,53 +1,3 @@
+-#!/usr/bin/env python3
+-from pathlib import Path
+-from setuptools import setup, find_namespace_packages
++from setuptools import setup
+ 
+-# The directory containing this file
+-HERE = Path(__file__).parent
+-
+-# Load version without importing it (see issue #192 if you are confused)
+-for l in (HERE / 'hyfetch' / '__version__.py').read_text().strip().splitlines():
+-    exec(l)
+-
+-# The text of the README file
+-README = (HERE / "README.md").read_text('utf-8')
+-
+-# This call to setup() does all the work
+-setup(
+-    name="HyFetch",
+-    version=VERSION,
+-    description="neofetch with flags <3",
+-    long_description=README,
+-    long_description_content_type="text/markdown",
+-    url="https://github.com/hykilpikonna/HyFetch",
+-    author="Azalea Gui",
+-    author_email="me@hydev.org",
+-    license="MIT",
+-    classifiers=[
+-        "License :: OSI Approved :: MIT License",
+-        "Programming Language :: Python :: 3",
+-        "Programming Language :: Python :: 3.7",
+-        "Programming Language :: Python :: 3.8",
+-        "Programming Language :: Python :: 3.9",
+-        "Programming Language :: Python :: 3.10",
+-        "Programming Language :: Python :: 3.11",
+-        "Programming Language :: Python :: 3.12",
+-    ],
+-    packages=find_namespace_packages(),
+-    package_data={'hyfetch': ['hyfetch/*']},
+-    include_package_data=True,
+-    install_requires=[
+-        # Universal dependencies
+-        'setuptools', 'typing_extensions',
+-        
+-        # Windows dependencies
+-        'psutil ; platform_system=="Windows"',
+-        'colorama>=0.4.6 ; platform_system=="Windows"',
+-    ],
+-    entry_points={
+-        "console_scripts": [
+-            "hyfetch=hyfetch.main:run",
+-        ]
+-    },
+-    scripts=['hyfetch/scripts/neowofetch']
+-)
++setup()

--- a/app-misc/hyfetch/hyfetch-1.4.11-r1.ebuild
+++ b/app-misc/hyfetch/hyfetch-1.4.11-r1.ebuild
@@ -3,9 +3,10 @@
 
 EAPI=8
 
-DISTUTILS_USE_PEP517=setuptools
 PYTHON_COMPAT=( python3_{10..12} )
-inherit optfeature distutils-r1
+DISTUTILS_USE_PEP517=setuptools
+
+inherit optfeature distutils-r1 shell-completion
 
 DESCRIPTION="Neofetch with LGBTQ+ pride flags!"
 HOMEPAGE="https://github.com/hykilpikonna/hyfetch"
@@ -20,9 +21,26 @@ fi
 LICENSE="MIT"
 SLOT="0"
 
+PATCHES=(
+	"${FILESDIR}"/${PN}-1.4.11-pyproject.patch
+	"${FILESDIR}"/${PN}-1.4.11-neofetch.patch
+)
+
 RDEPEND="
 		dev-python/typing-extensions[${PYTHON_USEDEP}]
 "
+
+python_install() {
+	newbashcomp hyfetch/scripts/autocomplete.bash ${PN}
+	newzshcomp hyfetch/scripts/autocomplete.zsh _${PN}
+
+	distutils-r1_python_install
+
+	dodir /usr/bin/
+	mv neofetch "${D}/usr/bin/neowofetch" || die
+
+	rm -r "${D}/usr/lib/${EPYTHON}/site-packages/hyfetch/scripts" || die
+}
 
 pkg_postinst() {
 	optfeature "displaying images" "media-libs/imlib2 www-client/w3m[imlib]"

--- a/app-misc/hyfetch/hyfetch-9999.ebuild
+++ b/app-misc/hyfetch/hyfetch-9999.ebuild
@@ -1,11 +1,12 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-DISTUTILS_USE_PEP517=setuptools
 PYTHON_COMPAT=( python3_{10..12} )
-inherit optfeature distutils-r1
+DISTUTILS_USE_PEP517=setuptools
+
+inherit optfeature distutils-r1 shell-completion
 
 DESCRIPTION="Neofetch with LGBTQ+ pride flags!"
 HOMEPAGE="https://github.com/hykilpikonna/hyfetch"
@@ -20,9 +21,26 @@ fi
 LICENSE="MIT"
 SLOT="0"
 
+PATCHES=(
+	"${FILESDIR}"/${PN}-9999-pyproject.patch
+	"${FILESDIR}"/${PN}-1.4.11-neofetch.patch
+)
+
 RDEPEND="
 		dev-python/typing-extensions[${PYTHON_USEDEP}]
 "
+
+python_install() {
+	newbashcomp hyfetch/scripts/autocomplete.bash ${PN}
+	newzshcomp hyfetch/scripts/autocomplete.zsh _${PN}
+
+	distutils-r1_python_install
+
+	dodir /usr/bin/
+	mv neofetch "${D}/usr/bin/neowofetch" || die
+
+	rm -r "${D}/usr/lib/${EPYTHON}/site-packages/hyfetch/scripts" || die
+}
 
 pkg_postinst() {
 	optfeature "displaying images" "media-libs/imlib2 www-client/w3m[imlib]"


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/922206
Removes site-packages/tools which wasn't supposed to be included at all, installs the contents of site-packages/hyfetch/scripts to the proper locations and deletes the folder. This has the addded benefit of bringing this version of the package more inline with how other distros package this project.