### PR TITLE
dev-util/memprof: Fix passing of incompatible pointer type

### DIFF
--- a/dev-util/memprof/files/memprof-0.6.2-gcc14-build-fix.patch
+++ b/dev-util/memprof/files/memprof-0.6.2-gcc14-build-fix.patch
@@ -1,0 +1,23 @@
+Bug: https://bugs.gentoo.org/923021
+--- a/src/process.c
++++ b/src/process.c
+@@ -526,7 +526,7 @@ input_func (GIOChannel  *source,
+ 	    gpointer     data)
+ {
+ 	MIInfo info;
+-	guint count;
++	gsize count;
+ 	MPProcess *input_process = data;
+ 	MPProcess *process = NULL;
+   
+--- a/src/profile.c
++++ b/src/profile.c
+@@ -31,7 +31,7 @@ block_create_stack_list (Block *block, MPProcess *process, GHashTable *skip_hash
+ 
+     for (element = block->stack; element != NULL; element = element->parent)
+     {
+-	const char *symbol = process_locate_symbol (process, (guint)element->address);
++	const char *symbol = process_locate_symbol (process, (gsize)element->address);
+ 
+ 	if (symbol && g_hash_table_lookup (skip_hash, symbol))
+ 	    continue;

--- a/dev-util/memprof/memprof-0.6.2-r2.ebuild
+++ b/dev-util/memprof/memprof-0.6.2-r2.ebuild
@@ -1,0 +1,41 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DESCRIPTION="Profiling and leak detection tool"
+HOMEPAGE="https://www.secretlabs.de/projects/memprof/"
+SRC_URI="https://www.secretlabs.de/projects/memprof/releases/${P}.tar.gz"
+
+LICENSE="GPL-3"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="nls"
+
+RDEPEND="
+	dev-libs/glib:2
+	>=gnome-base/libglade-2
+	>=x11-libs/gtk+-2.6:2
+	nls? ( virtual/libintl )"
+DEPEND="${RDEPEND}"
+BDEPEND="
+	virtual/pkgconfig
+	nls? (
+		dev-util/intltool
+		sys-devel/gettext
+	)"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-binutils.patch
+	"${FILESDIR}"/${P}-desktop.patch
+	"${FILESDIR}"/${P}-gcc14-build-fix.patch
+)
+
+src_configure() {
+	econf $(use_enable nls)
+}
+
+src_install() {
+	default
+	find "${ED}" -name '*.la' -delete || die
+}


### PR DESCRIPTION
And update EAPI 7 -> 8

Closes: https://bugs.gentoo.org/923021