### PR TITLE
gnome-extra/gnome-browser-connector: enable py3.12

### DIFF
--- a/gnome-extra/gnome-browser-connector/gnome-browser-connector-42.1.ebuild
+++ b/gnome-extra/gnome-browser-connector/gnome-browser-connector-42.1.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=(python3_{10..12})
 
 inherit gnome.org meson python-single-r1 xdg
 


### PR DESCRIPTION
enable py3.12