### PR TITLE
RFC: linux-mod-r1.eclass: add USE=initramfs for dist-kernels

### DIFF
--- a/eclass/linux-info.eclass
+++ b/eclass/linux-info.eclass
@@ -158,6 +158,14 @@ KERNEL_DIR="${KERNEL_DIR:-${ROOT%/}/usr/src/linux}"
 # This is a user flag and should under _no circumstances_ be set in the ebuild.
 : "${SKIP_KERNEL_CHECK:=""}"
 
+# @ECLASS_VARIABLE: SKIP_KERNEL_BINPKG_ENV_RESET
+# @DEFAULT_UNSET
+# @DESCRIPTION:
+# If set, do not reset the kernel environment variables when merging a package
+# as a binpkg.
+# Main use-case is for kernel modules, i.e. linux-mod-r1.eclass.
+# This should be set before running linux-info_pkg_setup
+
 # And to ensure all the weirdness with crosscompile
 inherit toolchain-funcs
 [[ ${EAPI} == 6 ]] && inherit eapi7-ver
@@ -696,12 +704,12 @@ linux-info_get_any_version() {
 		die "${FUNCNAME}() called on non-Linux system, please fix the ebuild"
 	fi
 
-	if [[ ${MERGE_TYPE} == binary && -z ${LINUX_INFO_BINARY_RESET} ]]; then
+	if [[ ${MERGE_TYPE} == binary && -z ${SKIP_KERNEL_BINPKG_ENV_RESET} ]]; then
 		unset KV_FULL _LINUX_CONFIG_EXISTS_DONE KV_OUT_DIR
-		LINUX_INFO_BINARY_RESET=1
+		SKIP_KERNEL_BINPKG_ENV_RESET=1
 	fi
 
-	if [[ ${MERGE_TYPE} != binary ]] && ! get_version; then
+	if ! get_version; then
 		ewarn "Unable to calculate Linux Kernel version for build, attempting to use running version"
 	fi
 

--- a/eclass/linux-mod-r1.eclass
+++ b/eclass/linux-mod-r1.eclass
@@ -661,6 +661,11 @@ _modules_check_migration() {
 # Handles linux-info bits to provide usable sources, KV_ variables,
 # and CONFIG_CHECK use.
 _modules_prepare_kernel() {
+	# The modules we build are specific to each kernel version, we don't
+	# want to reset the environment to use the user selected kernel version.
+	# Bug 931213, 926063
+	SKIP_KERNEL_BINPKG_ENV_RESET=1
+
 	get_version
 
 	# linux-info allows skipping checks if SKIP_KERNEL_CHECK is set and

--- a/profiles/use.desc
+++ b/profiles/use.desc
@@ -142,6 +142,7 @@ imagemagick - Enable optional support for the ImageMagick or GraphicsMagick imag
 imap - Add support for IMAP (Internet Mail Application Protocol)
 imlib - Add support for imlib, an image loading and rendering library
 infiniband - Enable Infiniband RDMA transport support
+initramfs - Include kernel modules in the initramfs, and re-install the kernel (only effective for distribution kernels)
 inotify - Enable inotify filesystem monitoring support
 introspection - Add support for GObject based introspection
 iodbc - Add support for iODBC library

--- a/sys-firmware/intel-microcode/intel-microcode-20221108_p20221102.ebuild
+++ b/sys-firmware/intel-microcode/intel-microcode-20221108_p20221102.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="7"
 
-inherit linux-info mount-boot
+inherit dist-kernel-utils linux-info mount-boot
 
 # Find updates by searching and clicking the first link (hopefully it's the one):
 # https://www.intel.com/content/www/us/en/search.html?keyword=Processor+Microcode+Data+File
@@ -23,13 +23,20 @@ SRC_URI="https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/arc
 LICENSE="intel-ucode"
 SLOT="0"
 KEYWORDS="-* amd64 x86"
-IUSE="hostonly initramfs +split-ucode vanilla"
-REQUIRED_USE="|| ( initramfs split-ucode )"
+IUSE="dist-kernel hostonly +initramfs +split-ucode vanilla"
+REQUIRED_USE="!dist-kernel? ( || ( initramfs split-ucode ) )"
 
-BDEPEND=">=sys-apps/iucode_tool-2.3"
-
+BDEPEND="
+	>=sys-apps/iucode_tool-2.3
+	dist-kernel? (
+		initramfs? ( sys-kernel/installkernel )
+	)
+"
 # !<sys-apps/microcode-ctl-1.17-r2 due to bug #268586
-RDEPEND="hostonly? ( sys-apps/iucode_tool )"
+RDEPEND="
+	dist-kernel? ( virtual/dist-kernel )
+	hostonly? ( sys-apps/iucode_tool )
+"
 
 RESTRICT="binchecks strip"
 
@@ -132,9 +139,18 @@ src_install() {
 		--list
 	)
 
+	# Instruct Dracut on whether or not we want the microcode in initramfs
+	# Use here 15 instead of 10, intel-microcode overwrites linux-firmware
+	(
+		insinto /usr/lib/dracut/dracut.conf.d
+		newins - 15-${PN}.conf <<<"early_microcode=$(usex initramfs)"
+	)
+
 	# The earlyfw cpio needs to be in /boot because it must be loaded before
 	# rootfs is mounted.
-	use initramfs && dodir /boot && opts+=( --write-earlyfw="${ED}/boot/intel-uc.img" )
+	if ! use dist-kernel && use initramfs; then
+		dodir /boot && opts+=( --write-earlyfw="${ED}/boot/intel-uc.img" )
+	fi
 
 	keepdir /lib/firmware/intel-ucode
 	opts+=( --write-firmware="${ED}/lib/firmware/intel-ucode" )
@@ -188,7 +204,9 @@ pkg_preinst() {
 
 		# The earlyfw cpio needs to be in /boot because it must be loaded before
 		# rootfs is mounted.
-		use initramfs && opts+=( --write-earlyfw=${_initramfs_file} )
+		if ! use dist-kernel && use initramfs; then
+			opts+=( --write-earlyfw=${_initramfs_file} )
+		fi
 
 		if use split-ucode; then
 			opts+=( --write-firmware="${ED}/lib/firmware/intel-ucode" )
@@ -259,7 +277,12 @@ pkg_postrm() {
 
 pkg_postinst() {
 	# Don't forget to umount /boot if it was previously mounted by us.
-	use initramfs && mount-boot_pkg_postinst
+	if use initramfs; then
+		if [[ -z ${ROOT} ]] && use dist-kernel; then
+			dist-kernel_reinstall_initramfs "${KV_DIR}" "${KV_FULL}"
+		fi
+		mount-boot_pkg_postinst
+	fi
 
 	# We cannot give detailed information if user is affected or not:
 	# If MICROCODE_BLACKLIST wasn't modified, user can still use MICROCODE_SIGNATURES

--- a/sys-firmware/intel-microcode/intel-microcode-20230214_p20230212.ebuild
+++ b/sys-firmware/intel-microcode/intel-microcode-20230214_p20230212.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-inherit linux-info mount-boot
+inherit dist-kernel-utils linux-info mount-boot
 
 # Find updates by searching and clicking the first link (hopefully it's the one):
 # https://www.intel.com/content/www/us/en/search.html?keyword=Processor+Microcode+Data+File
@@ -23,13 +23,20 @@ SRC_URI="https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/arc
 LICENSE="intel-ucode"
 SLOT="0"
 KEYWORDS="-* amd64 x86"
-IUSE="hostonly initramfs +split-ucode vanilla"
-REQUIRED_USE="|| ( initramfs split-ucode )"
+IUSE="dist-kernel hostonly +initramfs +split-ucode vanilla"
+REQUIRED_USE="!dist-kernel? ( || ( initramfs split-ucode ) )"
 
 BDEPEND=">=sys-apps/iucode_tool-2.3"
-
 # !<sys-apps/microcode-ctl-1.17-r2 due to bug #268586
-RDEPEND="hostonly? ( sys-apps/iucode_tool )"
+RDEPEND="
+	dist-kernel? ( virtual/dist-kernel )
+	hostonly? ( sys-apps/iucode_tool )
+"
+IDEPEND="
+	dist-kernel? (
+		initramfs? ( sys-kernel/installkernel )
+	)
+"
 
 RESTRICT="binchecks strip"
 
@@ -132,9 +139,18 @@ src_install() {
 		--list
 	)
 
+	# Instruct Dracut on whether or not we want the microcode in initramfs
+	# Use here 15 instead of 10, intel-microcode overwrites linux-firmware
+	(
+		insinto /usr/lib/dracut/dracut.conf.d
+		newins - 15-${PN}.conf <<<"early_microcode=$(usex initramfs)"
+	)
+
 	# The earlyfw cpio needs to be in /boot because it must be loaded before
 	# rootfs is mounted.
-	use initramfs && dodir /boot && opts+=( --write-earlyfw="${ED}/boot/intel-uc.img" )
+	if ! use dist-kernel && use initramfs; then
+		dodir /boot && opts+=( --write-earlyfw="${ED}/boot/intel-uc.img" )
+	fi
 
 	keepdir /lib/firmware/intel-ucode
 	opts+=( --write-firmware="${ED}/lib/firmware/intel-ucode" )
@@ -188,7 +204,9 @@ pkg_preinst() {
 
 		# The earlyfw cpio needs to be in /boot because it must be loaded before
 		# rootfs is mounted.
-		use initramfs && opts+=( --write-earlyfw=${_initramfs_file} )
+		if ! use dist-kernel && use initramfs; then
+			opts+=( --write-earlyfw=${_initramfs_file} )
+		fi
 
 		if use split-ucode; then
 			opts+=( --write-firmware="${ED}/lib/firmware/intel-ucode" )
@@ -259,7 +277,12 @@ pkg_postrm() {
 
 pkg_postinst() {
 	# Don't forget to umount /boot if it was previously mounted by us.
-	use initramfs && mount-boot_pkg_postinst
+	if use initramfs; then
+		if [[ -z ${ROOT} ]] && use dist-kernel; then
+			dist-kernel_reinstall_initramfs "${KV_DIR}" "${KV_FULL}"
+		fi
+		mount-boot_pkg_postinst
+	fi
 
 	# We cannot give detailed information if user is affected or not:
 	# If MICROCODE_BLACKLIST wasn't modified, user can still use MICROCODE_SIGNATURES

--- a/sys-firmware/intel-microcode/intel-microcode-20230512_p20230512.ebuild
+++ b/sys-firmware/intel-microcode/intel-microcode-20230512_p20230512.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-inherit linux-info mount-boot
+inherit dist-kernel-utils linux-info mount-boot
 
 # Find updates by searching and clicking the first link (hopefully it's the one):
 # https://www.intel.com/content/www/us/en/search.html?keyword=Processor+Microcode+Data+File
@@ -23,13 +23,20 @@ SRC_URI="https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/arc
 LICENSE="intel-ucode"
 SLOT="0"
 KEYWORDS="-* amd64 x86"
-IUSE="hostonly initramfs +split-ucode vanilla"
-REQUIRED_USE="|| ( initramfs split-ucode )"
+IUSE="dist-kernel hostonly +initramfs +split-ucode vanilla"
+REQUIRED_USE="!dist-kernel? ( || ( initramfs split-ucode ) )"
 
 BDEPEND=">=sys-apps/iucode_tool-2.3"
-
 # !<sys-apps/microcode-ctl-1.17-r2 due to bug #268586
-RDEPEND="hostonly? ( sys-apps/iucode_tool )"
+RDEPEND="
+	dist-kernel? ( virtual/dist-kernel )
+	hostonly? ( sys-apps/iucode_tool )
+"
+IDEPEND="
+	dist-kernel? (
+		initramfs? ( sys-kernel/installkernel )
+	)
+"
 
 RESTRICT="binchecks strip"
 
@@ -132,9 +139,18 @@ src_install() {
 		--list
 	)
 
+	# Instruct Dracut on whether or not we want the microcode in initramfs
+	# Use here 15 instead of 10, intel-microcode overwrites linux-firmware
+	(
+		insinto /usr/lib/dracut/dracut.conf.d
+		newins - 15-${PN}.conf <<<"early_microcode=$(usex initramfs)"
+	)
+
 	# The earlyfw cpio needs to be in /boot because it must be loaded before
 	# rootfs is mounted.
-	use initramfs && dodir /boot && opts+=( --write-earlyfw="${ED}/boot/intel-uc.img" )
+	if ! use dist-kernel && use initramfs; then
+		dodir /boot && opts+=( --write-earlyfw="${ED}/boot/intel-uc.img" )
+	fi
 
 	keepdir /lib/firmware/intel-ucode
 	opts+=( --write-firmware="${ED}/lib/firmware/intel-ucode" )
@@ -188,7 +204,9 @@ pkg_preinst() {
 
 		# The earlyfw cpio needs to be in /boot because it must be loaded before
 		# rootfs is mounted.
-		use initramfs && opts+=( --write-earlyfw=${_initramfs_file} )
+		if ! use dist-kernel && use initramfs; then
+			opts+=( --write-earlyfw=${_initramfs_file} )
+		fi
 
 		if use split-ucode; then
 			opts+=( --write-firmware="${ED}/lib/firmware/intel-ucode" )
@@ -259,7 +277,12 @@ pkg_postrm() {
 
 pkg_postinst() {
 	# Don't forget to umount /boot if it was previously mounted by us.
-	use initramfs && mount-boot_pkg_postinst
+	if use initramfs; then
+		if [[ -z ${ROOT} ]] && use dist-kernel; then
+			dist-kernel_reinstall_initramfs "${KV_DIR}" "${KV_FULL}"
+		fi
+		mount-boot_pkg_postinst
+	fi
 
 	# We cannot give detailed information if user is affected or not:
 	# If MICROCODE_BLACKLIST wasn't modified, user can still use MICROCODE_SIGNATURES

--- a/sys-firmware/intel-microcode/intel-microcode-20230613_p20230520.ebuild
+++ b/sys-firmware/intel-microcode/intel-microcode-20230613_p20230520.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-inherit linux-info mount-boot
+inherit dist-kernel-utils linux-info mount-boot
 
 # Find updates by searching and clicking the first link (hopefully it's the one):
 # https://www.intel.com/content/www/us/en/search.html?keyword=Processor+Microcode+Data+File
@@ -44,13 +44,21 @@ S="${WORKDIR}"
 LICENSE="intel-ucode"
 SLOT="0"
 KEYWORDS="-* amd64 x86"
-IUSE="hostonly initramfs +split-ucode vanilla"
-REQUIRED_USE="|| ( initramfs split-ucode )"
+IUSE="dist-kernel hostonly +initramfs +split-ucode vanilla"
+REQUIRED_USE="!dist-kernel? ( || ( initramfs split-ucode ) )"
 RESTRICT="binchecks strip"
 
 BDEPEND=">=sys-apps/iucode_tool-2.3"
 # !<sys-apps/microcode-ctl-1.17-r2 due to bug #268586
-RDEPEND="hostonly? ( sys-apps/iucode_tool )"
+RDEPEND="
+	dist-kernel? ( virtual/dist-kernel )
+	hostonly? ( sys-apps/iucode_tool )
+"
+IDEPEND="
+	dist-kernel? (
+		initramfs? ( sys-kernel/installkernel )
+	)
+"
 
 # Blacklist bad microcode here.
 # 0x000406f1 aka 06-4f-01 aka CPUID 406F1 require newer microcode loader
@@ -138,9 +146,18 @@ src_install() {
 		--list
 	)
 
+	# Instruct Dracut on whether or not we want the microcode in initramfs
+	# Use here 15 instead of 10, intel-microcode overwrites linux-firmware
+	(
+		insinto /usr/lib/dracut/dracut.conf.d
+		newins - 15-${PN}.conf <<<"early_microcode=$(usex initramfs)"
+	)
+
 	# The earlyfw cpio needs to be in /boot because it must be loaded before
 	# rootfs is mounted.
-	use initramfs && dodir /boot && opts+=( --write-earlyfw="${ED}/boot/intel-uc.img" )
+	if ! use dist-kernel && use initramfs; then
+		dodir /boot && opts+=( --write-earlyfw="${ED}/boot/intel-uc.img" )
+	fi
 
 	keepdir /lib/firmware/intel-ucode
 	opts+=( --write-firmware="${ED}/lib/firmware/intel-ucode" )
@@ -194,7 +211,9 @@ pkg_preinst() {
 
 		# The earlyfw cpio needs to be in /boot because it must be loaded before
 		# rootfs is mounted.
-		use initramfs && opts+=( --write-earlyfw=${_initramfs_file} )
+		if ! use dist-kernel && use initramfs; then
+			opts+=( --write-earlyfw=${_initramfs_file} )
+		fi
 
 		if use split-ucode; then
 			opts+=( --write-firmware="${ED}/lib/firmware/intel-ucode" )
@@ -265,7 +284,12 @@ pkg_postrm() {
 
 pkg_postinst() {
 	# Don't forget to umount /boot if it was previously mounted by us.
-	use initramfs && mount-boot_pkg_postinst
+	if use initramfs; then
+		if [[ -z ${ROOT} ]] && use dist-kernel; then
+			dist-kernel_reinstall_initramfs "${KV_DIR}" "${KV_FULL}"
+		fi
+		mount-boot_pkg_postinst
+	fi
 
 	# We cannot give detailed information if user is affected or not:
 	# If MICROCODE_BLACKLIST wasn't modified, user can still use MICROCODE_SIGNATURES

--- a/sys-firmware/intel-microcode/intel-microcode-20230808_p20230804.ebuild
+++ b/sys-firmware/intel-microcode/intel-microcode-20230808_p20230804.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-inherit linux-info mount-boot
+inherit dist-kernel-utils linux-info mount-boot
 
 # Find updates by searching and clicking the first link (hopefully it's the one):
 # https://www.intel.com/content/www/us/en/search.html?keyword=Processor+Microcode+Data+File
@@ -44,13 +44,21 @@ S="${WORKDIR}"
 LICENSE="intel-ucode"
 SLOT="0"
 KEYWORDS="-* amd64 x86"
-IUSE="hostonly initramfs +split-ucode vanilla"
-REQUIRED_USE="|| ( initramfs split-ucode )"
+IUSE="dist-kernel hostonly +initramfs +split-ucode vanilla"
+REQUIRED_USE="!dist-kernel? ( || ( initramfs split-ucode ) )"
 RESTRICT="binchecks strip"
 
 BDEPEND=">=sys-apps/iucode_tool-2.3"
 # !<sys-apps/microcode-ctl-1.17-r2 due to bug #268586
-RDEPEND="hostonly? ( sys-apps/iucode_tool )"
+RDEPEND="
+	dist-kernel? ( virtual/dist-kernel )
+	hostonly? ( sys-apps/iucode_tool )
+"
+IDEPEND="
+	dist-kernel? (
+		initramfs? ( sys-kernel/installkernel )
+	)
+"
 
 # Blacklist bad microcode here.
 # 0x000406f1 aka 06-4f-01 aka CPUID 406F1 require newer microcode loader
@@ -138,9 +146,18 @@ src_install() {
 		--list
 	)
 
+	# Instruct Dracut on whether or not we want the microcode in initramfs
+	# Use here 15 instead of 10, intel-microcode overwrites linux-firmware
+	(
+		insinto /usr/lib/dracut/dracut.conf.d
+		newins - 15-${PN}.conf <<<"early_microcode=$(usex initramfs)"
+	)
+
 	# The earlyfw cpio needs to be in /boot because it must be loaded before
 	# rootfs is mounted.
-	use initramfs && dodir /boot && opts+=( --write-earlyfw="${ED}/boot/intel-uc.img" )
+	if ! use dist-kernel && use initramfs; then
+		dodir /boot && opts+=( --write-earlyfw="${ED}/boot/intel-uc.img" )
+	fi
 
 	keepdir /lib/firmware/intel-ucode
 	opts+=( --write-firmware="${ED}/lib/firmware/intel-ucode" )
@@ -194,7 +211,9 @@ pkg_preinst() {
 
 		# The earlyfw cpio needs to be in /boot because it must be loaded before
 		# rootfs is mounted.
-		use initramfs && opts+=( --write-earlyfw=${_initramfs_file} )
+		if ! use dist-kernel && use initramfs; then
+			opts+=( --write-earlyfw=${_initramfs_file} )
+		fi
 
 		if use split-ucode; then
 			opts+=( --write-firmware="${ED}/lib/firmware/intel-ucode" )
@@ -265,7 +284,12 @@ pkg_postrm() {
 
 pkg_postinst() {
 	# Don't forget to umount /boot if it was previously mounted by us.
-	use initramfs && mount-boot_pkg_postinst
+	if use initramfs; then
+		if [[ -z ${ROOT} ]] && use dist-kernel; then
+			dist-kernel_reinstall_initramfs "${KV_DIR}" "${KV_FULL}"
+		fi
+		mount-boot_pkg_postinst
+	fi
 
 	# We cannot give detailed information if user is affected or not:
 	# If MICROCODE_BLACKLIST wasn't modified, user can still use MICROCODE_SIGNATURES

--- a/sys-firmware/intel-microcode/intel-microcode-20230808_p20231007.ebuild
+++ b/sys-firmware/intel-microcode/intel-microcode-20230808_p20231007.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-inherit linux-info mount-boot
+inherit dist-kernel-utils linux-info mount-boot
 
 # Find updates by searching and clicking the first link (hopefully it's the one):
 # https://www.intel.com/content/www/us/en/search.html?keyword=Processor+Microcode+Data+File
@@ -44,13 +44,21 @@ S="${WORKDIR}"
 LICENSE="intel-ucode"
 SLOT="0"
 KEYWORDS="-* amd64 x86"
-IUSE="hostonly initramfs +split-ucode vanilla"
-REQUIRED_USE="|| ( initramfs split-ucode )"
+IUSE="dist-kernel hostonly +initramfs +split-ucode vanilla"
+REQUIRED_USE="!dist-kernel? ( || ( initramfs split-ucode ) )"
 RESTRICT="binchecks strip"
 
 BDEPEND=">=sys-apps/iucode_tool-2.3"
 # !<sys-apps/microcode-ctl-1.17-r2 due to bug #268586
-RDEPEND="hostonly? ( sys-apps/iucode_tool )"
+RDEPEND="
+	dist-kernel? ( virtual/dist-kernel )
+	hostonly? ( sys-apps/iucode_tool )
+"
+IDEPEND="
+	dist-kernel? (
+		initramfs? ( sys-kernel/installkernel )
+	)
+"
 
 # Blacklist bad microcode here.
 # 0x000406f1 aka 06-4f-01 aka CPUID 406F1 require newer microcode loader
@@ -138,9 +146,18 @@ src_install() {
 		--list
 	)
 
+	# Instruct Dracut on whether or not we want the microcode in initramfs
+	# Use here 15 instead of 10, intel-microcode overwrites linux-firmware
+	(
+		insinto /usr/lib/dracut/dracut.conf.d
+		newins - 15-${PN}.conf <<<"early_microcode=$(usex initramfs)"
+	)
+
 	# The earlyfw cpio needs to be in /boot because it must be loaded before
 	# rootfs is mounted.
-	use initramfs && dodir /boot && opts+=( --write-earlyfw="${ED}/boot/intel-uc.img" )
+	if ! use dist-kernel && use initramfs; then
+		dodir /boot && opts+=( --write-earlyfw="${ED}/boot/intel-uc.img" )
+	fi
 
 	keepdir /lib/firmware/intel-ucode
 	opts+=( --write-firmware="${ED}/lib/firmware/intel-ucode" )
@@ -194,7 +211,9 @@ pkg_preinst() {
 
 		# The earlyfw cpio needs to be in /boot because it must be loaded before
 		# rootfs is mounted.
-		use initramfs && opts+=( --write-earlyfw=${_initramfs_file} )
+		if ! use dist-kernel && use initramfs; then
+			opts+=( --write-earlyfw=${_initramfs_file} )
+		fi
 
 		if use split-ucode; then
 			opts+=( --write-firmware="${ED}/lib/firmware/intel-ucode" )
@@ -265,7 +284,12 @@ pkg_postrm() {
 
 pkg_postinst() {
 	# Don't forget to umount /boot if it was previously mounted by us.
-	use initramfs && mount-boot_pkg_postinst
+	if use initramfs; then
+		if [[ -z ${ROOT} ]] && use dist-kernel; then
+			dist-kernel_reinstall_initramfs "${KV_DIR}" "${KV_FULL}"
+		fi
+		mount-boot_pkg_postinst
+	fi
 
 	# We cannot give detailed information if user is affected or not:
 	# If MICROCODE_BLACKLIST wasn't modified, user can still use MICROCODE_SIGNATURES

--- a/sys-firmware/intel-microcode/intel-microcode-20231114_p20231114.ebuild
+++ b/sys-firmware/intel-microcode/intel-microcode-20231114_p20231114.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-inherit linux-info mount-boot
+inherit dist-kernel-utils linux-info mount-boot
 
 # Find updates by searching and clicking the first link (hopefully it's the one):
 # https://www.intel.com/content/www/us/en/search.html?keyword=Processor+Microcode+Data+File
@@ -44,13 +44,21 @@ S="${WORKDIR}"
 LICENSE="intel-ucode"
 SLOT="0"
 KEYWORDS="-* amd64 x86"
-IUSE="hostonly initramfs +split-ucode vanilla"
-REQUIRED_USE="|| ( initramfs split-ucode )"
+IUSE="dist-kernel hostonly +initramfs +split-ucode vanilla"
+REQUIRED_USE="!dist-kernel? ( || ( initramfs split-ucode ) )"
 RESTRICT="binchecks strip"
 
 BDEPEND=">=sys-apps/iucode_tool-2.3"
 # !<sys-apps/microcode-ctl-1.17-r2 due to bug #268586
-RDEPEND="hostonly? ( sys-apps/iucode_tool )"
+RDEPEND="
+	dist-kernel? ( virtual/dist-kernel )
+	hostonly? ( sys-apps/iucode_tool )
+"
+IDEPEND="
+	dist-kernel? (
+		initramfs? ( sys-kernel/installkernel )
+	)
+"
 
 # Blacklist bad microcode here.
 # 0x000406f1 aka 06-4f-01 aka CPUID 406F1 require newer microcode loader
@@ -138,9 +146,18 @@ src_install() {
 		--list
 	)
 
+	# Instruct Dracut on whether or not we want the microcode in initramfs
+	# Use here 15 instead of 10, intel-microcode overwrites linux-firmware
+	(
+		insinto /usr/lib/dracut/dracut.conf.d
+		newins - 15-${PN}.conf <<<"early_microcode=$(usex initramfs)"
+	)
+
 	# The earlyfw cpio needs to be in /boot because it must be loaded before
 	# rootfs is mounted.
-	use initramfs && dodir /boot && opts+=( --write-earlyfw="${ED}/boot/intel-uc.img" )
+	if ! use dist-kernel && use initramfs; then
+		dodir /boot && opts+=( --write-earlyfw="${ED}/boot/intel-uc.img" )
+	fi
 
 	keepdir /lib/firmware/intel-ucode
 	opts+=( --write-firmware="${ED}/lib/firmware/intel-ucode" )
@@ -194,7 +211,9 @@ pkg_preinst() {
 
 		# The earlyfw cpio needs to be in /boot because it must be loaded before
 		# rootfs is mounted.
-		use initramfs && opts+=( --write-earlyfw=${_initramfs_file} )
+		if ! use dist-kernel && use initramfs; then
+			opts+=( --write-earlyfw=${_initramfs_file} )
+		fi
 
 		if use split-ucode; then
 			opts+=( --write-firmware="${ED}/lib/firmware/intel-ucode" )
@@ -265,7 +284,12 @@ pkg_postrm() {
 
 pkg_postinst() {
 	# Don't forget to umount /boot if it was previously mounted by us.
-	use initramfs && mount-boot_pkg_postinst
+	if use initramfs; then
+		if [[ -z ${ROOT} ]] && use dist-kernel; then
+			dist-kernel_reinstall_initramfs "${KV_DIR}" "${KV_FULL}"
+		fi
+		mount-boot_pkg_postinst
+	fi
 
 	# We cannot give detailed information if user is affected or not:
 	# If MICROCODE_BLACKLIST wasn't modified, user can still use MICROCODE_SIGNATURES

--- a/sys-fs/zfs-kmod/zfs-kmod-2.1.14.ebuild
+++ b/sys-fs/zfs-kmod/zfs-kmod-2.1.14.ebuild
@@ -1,9 +1,10 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-inherit autotools dist-kernel-utils flag-o-matic linux-mod-r1 multiprocessing
+MODULES_INITRAMFS_IUSE=+initramfs
+inherit autotools flag-o-matic linux-mod-r1 multiprocessing
 
 DESCRIPTION="Linux ZFS kernel module for sys-fs/zfs"
 HOMEPAGE="https://github.com/openzfs/zfs"
@@ -64,13 +65,6 @@ PATCHES=(
 
 pkg_pretend() {
 	use rootfs || return 0
-
-	if has_version virtual/dist-kernel && ! use dist-kernel; then
-		ewarn "You have virtual/dist-kernel installed, but"
-		ewarn "USE=\"dist-kernel\" is not enabled for ${CATEGORY}/${PN}"
-		ewarn "It's recommended to globally enable dist-kernel USE flag"
-		ewarn "to auto-trigger initrd rebuilds with kernel updates"
-	fi
 }
 
 pkg_setup() {
@@ -151,10 +145,6 @@ src_install() {
 
 pkg_postinst() {
 	linux-mod-r1_pkg_postinst
-
-	if [[ -z ${ROOT} ]] && use dist-kernel ; then
-		dist-kernel_reinstall_initramfs "${KV_DIR}" "${KV_FULL}"
-	fi
 
 	if use x86 || use arm ; then
 		ewarn "32-bit kernels will likely require increasing vmalloc to"

--- a/sys-fs/zfs-kmod/zfs-kmod-2.1.15.ebuild
+++ b/sys-fs/zfs-kmod/zfs-kmod-2.1.15.ebuild
@@ -3,7 +3,8 @@
 
 EAPI=8
 
-inherit autotools dist-kernel-utils flag-o-matic linux-mod-r1 multiprocessing
+MODULES_INITRAMFS_IUSE=+initramfs
+inherit autotools flag-o-matic linux-mod-r1 multiprocessing
 
 DESCRIPTION="Linux ZFS kernel module for sys-fs/zfs"
 HOMEPAGE="https://github.com/openzfs/zfs"
@@ -64,13 +65,6 @@ PATCHES=(
 
 pkg_pretend() {
 	use rootfs || return 0
-
-	if has_version virtual/dist-kernel && ! use dist-kernel; then
-		ewarn "You have virtual/dist-kernel installed, but"
-		ewarn "USE=\"dist-kernel\" is not enabled for ${CATEGORY}/${PN}"
-		ewarn "It's recommended to globally enable dist-kernel USE flag"
-		ewarn "to auto-trigger initrd rebuilds with kernel updates"
-	fi
 }
 
 pkg_setup() {
@@ -151,10 +145,6 @@ src_install() {
 
 pkg_postinst() {
 	linux-mod-r1_pkg_postinst
-
-	if [[ -z ${ROOT} ]] && use dist-kernel ; then
-		dist-kernel_reinstall_initramfs "${KV_DIR}" "${KV_FULL}"
-	fi
 
 	if use x86 || use arm ; then
 		ewarn "32-bit kernels will likely require increasing vmalloc to"

--- a/sys-fs/zfs-kmod/zfs-kmod-2.2.2-r1.ebuild
+++ b/sys-fs/zfs-kmod/zfs-kmod-2.2.2-r1.ebuild
@@ -3,7 +3,8 @@
 
 EAPI=8
 
-inherit autotools dist-kernel-utils flag-o-matic linux-mod-r1 multiprocessing
+MODULES_INITRAMFS_IUSE=+initramfs
+inherit autotools flag-o-matic linux-mod-r1 multiprocessing
 
 DESCRIPTION="Linux ZFS kernel module for sys-fs/zfs"
 HOMEPAGE="https://github.com/openzfs/zfs"
@@ -66,13 +67,6 @@ PATCHES=(
 
 pkg_pretend() {
 	use rootfs || return 0
-
-	if has_version virtual/dist-kernel && ! use dist-kernel; then
-		ewarn "You have virtual/dist-kernel installed, but"
-		ewarn "USE=\"dist-kernel\" is not enabled for ${CATEGORY}/${PN}"
-		ewarn "It's recommended to globally enable dist-kernel USE flag"
-		ewarn "to auto-trigger initrd rebuilds with kernel updates"
-	fi
 }
 
 pkg_setup() {
@@ -193,10 +187,6 @@ pkg_postinst() {
 	[[ -f ${newko[0]} ]] && _old_layout_cleanup
 
 	linux-mod-r1_pkg_postinst
-
-	if [[ -z ${ROOT} ]] && use dist-kernel ; then
-		dist-kernel_reinstall_initramfs "${KV_DIR}" "${KV_FULL}"
-	fi
 
 	if use x86 || use arm ; then
 		ewarn "32-bit kernels will likely require increasing vmalloc to"

--- a/sys-fs/zfs-kmod/zfs-kmod-2.2.2.ebuild
+++ b/sys-fs/zfs-kmod/zfs-kmod-2.2.2.ebuild
@@ -3,7 +3,8 @@
 
 EAPI=8
 
-inherit autotools dist-kernel-utils flag-o-matic linux-mod-r1 multiprocessing
+MODULES_INITRAMFS_IUSE=+initramfs
+inherit autotools flag-o-matic linux-mod-r1 multiprocessing
 
 DESCRIPTION="Linux ZFS kernel module for sys-fs/zfs"
 HOMEPAGE="https://github.com/openzfs/zfs"
@@ -65,13 +66,6 @@ PATCHES=(
 
 pkg_pretend() {
 	use rootfs || return 0
-
-	if has_version virtual/dist-kernel && ! use dist-kernel; then
-		ewarn "You have virtual/dist-kernel installed, but"
-		ewarn "USE=\"dist-kernel\" is not enabled for ${CATEGORY}/${PN}"
-		ewarn "It's recommended to globally enable dist-kernel USE flag"
-		ewarn "to auto-trigger initrd rebuilds with kernel updates"
-	fi
 }
 
 pkg_setup() {
@@ -192,10 +186,6 @@ pkg_postinst() {
 	[[ -f ${newko[0]} ]] && _old_layout_cleanup
 
 	linux-mod-r1_pkg_postinst
-
-	if [[ -z ${ROOT} ]] && use dist-kernel ; then
-		dist-kernel_reinstall_initramfs "${KV_DIR}" "${KV_FULL}"
-	fi
 
 	if use x86 || use arm ; then
 		ewarn "32-bit kernels will likely require increasing vmalloc to"

--- a/sys-fs/zfs-kmod/zfs-kmod-2.2.3.ebuild
+++ b/sys-fs/zfs-kmod/zfs-kmod-2.2.3.ebuild
@@ -3,7 +3,8 @@
 
 EAPI=8
 
-inherit autotools dist-kernel-utils flag-o-matic linux-mod-r1 multiprocessing
+MODULES_INITRAMFS_IUSE=+initramfs
+inherit autotools flag-o-matic linux-mod-r1 multiprocessing
 
 DESCRIPTION="Linux ZFS kernel module for sys-fs/zfs"
 HOMEPAGE="https://github.com/openzfs/zfs"
@@ -64,13 +65,6 @@ PATCHES=(
 
 pkg_pretend() {
 	use rootfs || return 0
-
-	if has_version virtual/dist-kernel && ! use dist-kernel; then
-		ewarn "You have virtual/dist-kernel installed, but"
-		ewarn "USE=\"dist-kernel\" is not enabled for ${CATEGORY}/${PN}"
-		ewarn "It's recommended to globally enable dist-kernel USE flag"
-		ewarn "to auto-trigger initrd rebuilds with kernel updates"
-	fi
 }
 
 pkg_setup() {
@@ -191,10 +185,6 @@ pkg_postinst() {
 	[[ -f ${newko[0]} ]] && _old_layout_cleanup
 
 	linux-mod-r1_pkg_postinst
-
-	if [[ -z ${ROOT} ]] && use dist-kernel ; then
-		dist-kernel_reinstall_initramfs "${KV_DIR}" "${KV_FULL}"
-	fi
 
 	if use x86 || use arm ; then
 		ewarn "32-bit kernels will likely require increasing vmalloc to"

--- a/sys-fs/zfs-kmod/zfs-kmod-2.2.4.ebuild
+++ b/sys-fs/zfs-kmod/zfs-kmod-2.2.4.ebuild
@@ -3,7 +3,8 @@
 
 EAPI=8
 
-inherit autotools dist-kernel-utils flag-o-matic linux-mod-r1 multiprocessing
+MODULES_INITRAMFS_IUSE=+initramfs
+inherit autotools flag-o-matic linux-mod-r1 multiprocessing
 
 DESCRIPTION="Linux ZFS kernel module for sys-fs/zfs"
 HOMEPAGE="https://github.com/openzfs/zfs"
@@ -64,13 +65,6 @@ PATCHES=(
 
 pkg_pretend() {
 	use rootfs || return 0
-
-	if has_version virtual/dist-kernel && ! use dist-kernel; then
-		ewarn "You have virtual/dist-kernel installed, but"
-		ewarn "USE=\"dist-kernel\" is not enabled for ${CATEGORY}/${PN}"
-		ewarn "It's recommended to globally enable dist-kernel USE flag"
-		ewarn "to auto-trigger initrd rebuilds with kernel updates"
-	fi
 }
 
 pkg_setup() {
@@ -191,10 +185,6 @@ pkg_postinst() {
 	[[ -f ${newko[0]} ]] && _old_layout_cleanup
 
 	linux-mod-r1_pkg_postinst
-
-	if [[ -z ${ROOT} ]] && use dist-kernel ; then
-		dist-kernel_reinstall_initramfs "${KV_DIR}" "${KV_FULL}"
-	fi
 
 	if use x86 || use arm ; then
 		ewarn "32-bit kernels will likely require increasing vmalloc to"

--- a/sys-fs/zfs-kmod/zfs-kmod-9999.ebuild
+++ b/sys-fs/zfs-kmod/zfs-kmod-9999.ebuild
@@ -3,7 +3,8 @@
 
 EAPI=8
 
-inherit autotools dist-kernel-utils flag-o-matic linux-mod-r1 multiprocessing
+MODULES_INITRAMFS_IUSE=+initramfs
+inherit autotools flag-o-matic linux-mod-r1 multiprocessing
 
 DESCRIPTION="Linux ZFS kernel module for sys-fs/zfs"
 HOMEPAGE="https://github.com/openzfs/zfs"
@@ -64,13 +65,6 @@ PATCHES=(
 
 pkg_pretend() {
 	use rootfs || return 0
-
-	if has_version virtual/dist-kernel && ! use dist-kernel; then
-		ewarn "You have virtual/dist-kernel installed, but"
-		ewarn "USE=\"dist-kernel\" is not enabled for ${CATEGORY}/${PN}"
-		ewarn "It's recommended to globally enable dist-kernel USE flag"
-		ewarn "to auto-trigger initrd rebuilds with kernel updates"
-	fi
 }
 
 pkg_setup() {
@@ -191,10 +185,6 @@ pkg_postinst() {
 	[[ -f ${newko[0]} ]] && _old_layout_cleanup
 
 	linux-mod-r1_pkg_postinst
-
-	if [[ -z ${ROOT} ]] && use dist-kernel ; then
-		dist-kernel_reinstall_initramfs "${KV_DIR}" "${KV_FULL}"
-	fi
 
 	if use x86 || use arm ; then
 		ewarn "32-bit kernels will likely require increasing vmalloc to"

--- a/sys-kernel/linux-firmware/linux-firmware-20240220-r2.ebuild
+++ b/sys-kernel/linux-firmware/linux-firmware-20240220-r2.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
-inherit linux-info mount-boot savedconfig multiprocessing
+inherit dist-kernel-utils linux-info mount-boot savedconfig multiprocessing
 
 # In case this is a real snapshot, fill in commit below.
 # For normal, tagged releases, leave blank
@@ -29,7 +29,7 @@ LICENSE="GPL-2 GPL-2+ GPL-3 BSD MIT || ( MPL-1.1 GPL-2 )
 	redistributable? ( linux-fw-redistributable BSD-2 BSD BSD-4 ISC MIT )
 	unknown-license? ( all-rights-reserved )"
 SLOT="0"
-IUSE="bindist compress-xz compress-zstd deduplicate initramfs +redistributable savedconfig unknown-license"
+IUSE="bindist compress-xz compress-zstd deduplicate dist-kernel +initramfs +redistributable savedconfig unknown-license"
 REQUIRED_USE="initramfs? ( redistributable )
 	?? ( compress-xz compress-zstd )
 	savedconfig? ( !deduplicate )"
@@ -62,7 +62,14 @@ RDEPEND="!savedconfig? (
 			!sys-firmware/alsa-firmware[alsa_cards_sb16]
 			!sys-firmware/alsa-firmware[alsa_cards_ymfpci]
 		)
-	)"
+	)
+	dist-kernel? ( virtual/dist-kernel )
+"
+IDEPEND="
+	dist-kernel? (
+		initramfs? ( sys-kernel/installkernel )
+	)
+"
 
 QA_PREBUILT="*"
 PATCHES=( "${FILESDIR}"/${PN}-copy-firmware-r4.patch )
@@ -84,8 +91,8 @@ pkg_setup() {
 				eerror "Kernels <5.19 do not support ZSTD-compressed firmware files"
 			fi
 		fi
-		linux-info_pkg_setup
 	fi
+	linux-info_pkg_setup
 }
 
 src_unpack() {
@@ -110,7 +117,7 @@ src_prepare() {
 
 	chmod +x copy-firmware.sh || die
 
-	if use initramfs; then
+	if use initramfs && ! use dist-kernel; then
 		if [[ -d "${S}/amd-ucode" ]]; then
 			local UCODETMP="${T}/ucode_tmp"
 			local UCODEDIR="${UCODETMP}/kernel/x86/microcode"
@@ -351,7 +358,13 @@ src_install() {
 
 	popd &>/dev/null || die
 
-	if use initramfs ; then
+	# Instruct Dracut on whether or not we want the microcode in initramfs
+	(
+		insinto /usr/lib/dracut/dracut.conf.d
+		newins - 10-${PN}.conf <<<"early_microcode=$(usex initramfs)"
+	)
+
+	if use initramfs && ! use dist-kernel; then
 		insinto /boot
 		doins "${S}"/amd-uc.img
 	fi
@@ -391,7 +404,12 @@ pkg_postinst() {
 	done
 
 	# Don't forget to umount /boot if it was previously mounted by us.
-	use initramfs && mount-boot_pkg_postinst
+	if use initramfs; then
+		if [[ -z ${ROOT} ]] && use dist-kernel; then
+			dist-kernel_reinstall_initramfs "${KV_DIR}" "${KV_FULL}"
+		fi
+		mount-boot_pkg_postinst
+	fi
 }
 
 pkg_prerm() {

--- a/sys-kernel/linux-firmware/linux-firmware-20240312.ebuild
+++ b/sys-kernel/linux-firmware/linux-firmware-20240312.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
-inherit linux-info mount-boot savedconfig multiprocessing
+inherit dist-kernel-utils linux-info mount-boot savedconfig multiprocessing
 
 # In case this is a real snapshot, fill in commit below.
 # For normal, tagged releases, leave blank
@@ -29,7 +29,7 @@ LICENSE="GPL-2 GPL-2+ GPL-3 BSD MIT || ( MPL-1.1 GPL-2 )
 	redistributable? ( linux-fw-redistributable BSD-2 BSD BSD-4 ISC MIT )
 	unknown-license? ( all-rights-reserved )"
 SLOT="0"
-IUSE="bindist compress-xz compress-zstd deduplicate initramfs +redistributable savedconfig unknown-license"
+IUSE="bindist compress-xz compress-zstd deduplicate dist-kernel +initramfs +redistributable savedconfig unknown-license"
 REQUIRED_USE="initramfs? ( redistributable )
 	?? ( compress-xz compress-zstd )
 	savedconfig? ( !deduplicate )"
@@ -62,7 +62,14 @@ RDEPEND="!savedconfig? (
 			!sys-firmware/alsa-firmware[alsa_cards_sb16]
 			!sys-firmware/alsa-firmware[alsa_cards_ymfpci]
 		)
-	)"
+	)
+	dist-kernel? ( virtual/dist-kernel )
+"
+IDEPEND="
+	dist-kernel? (
+		initramfs? ( sys-kernel/installkernel )
+	)
+"
 
 QA_PREBUILT="*"
 PATCHES=( "${FILESDIR}"/${PN}-copy-firmware-r4.patch )
@@ -84,8 +91,8 @@ pkg_setup() {
 				eerror "Kernels <5.19 do not support ZSTD-compressed firmware files"
 			fi
 		fi
-		linux-info_pkg_setup
 	fi
+	linux-info_pkg_setup
 }
 
 src_unpack() {
@@ -110,7 +117,7 @@ src_prepare() {
 
 	chmod +x copy-firmware.sh || die
 
-	if use initramfs; then
+	if use initramfs && ! use dist-kernel; then
 		if [[ -d "${S}/amd-ucode" ]]; then
 			local UCODETMP="${T}/ucode_tmp"
 			local UCODEDIR="${UCODETMP}/kernel/x86/microcode"
@@ -351,7 +358,13 @@ src_install() {
 
 	popd &>/dev/null || die
 
-	if use initramfs ; then
+	# Instruct Dracut on whether or not we want the microcode in initramfs
+	(
+		insinto /usr/lib/dracut/dracut.conf.d
+		newins - 10-${PN}.conf <<<"early_microcode=$(usex initramfs)"
+	)
+
+	if use initramfs && ! use dist-kernel; then
 		insinto /boot
 		doins "${S}"/amd-uc.img
 	fi
@@ -391,7 +404,12 @@ pkg_postinst() {
 	done
 
 	# Don't forget to umount /boot if it was previously mounted by us.
-	use initramfs && mount-boot_pkg_postinst
+	if use initramfs; then
+		if [[ -z ${ROOT} ]] && use dist-kernel; then
+			dist-kernel_reinstall_initramfs "${KV_DIR}" "${KV_FULL}"
+		fi
+		mount-boot_pkg_postinst
+	fi
 }
 
 pkg_prerm() {

--- a/sys-kernel/linux-firmware/linux-firmware-20240410.ebuild
+++ b/sys-kernel/linux-firmware/linux-firmware-20240410.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
-inherit linux-info mount-boot savedconfig multiprocessing
+inherit dist-kernel-utils linux-info mount-boot savedconfig multiprocessing
 
 # In case this is a real snapshot, fill in commit below.
 # For normal, tagged releases, leave blank
@@ -29,7 +29,7 @@ LICENSE="GPL-2 GPL-2+ GPL-3 BSD MIT || ( MPL-1.1 GPL-2 )
 	redistributable? ( linux-fw-redistributable BSD-2 BSD BSD-4 ISC MIT )
 	unknown-license? ( all-rights-reserved )"
 SLOT="0"
-IUSE="bindist compress-xz compress-zstd deduplicate initramfs +redistributable savedconfig unknown-license"
+IUSE="bindist compress-xz compress-zstd deduplicate dist-kernel +initramfs +redistributable savedconfig unknown-license"
 REQUIRED_USE="initramfs? ( redistributable )
 	?? ( compress-xz compress-zstd )
 	savedconfig? ( !deduplicate )"
@@ -62,7 +62,14 @@ RDEPEND="!savedconfig? (
 			!sys-firmware/alsa-firmware[alsa_cards_sb16]
 			!sys-firmware/alsa-firmware[alsa_cards_ymfpci]
 		)
-	)"
+	)
+	dist-kernel? ( virtual/dist-kernel )
+"
+IDEPEND="
+	dist-kernel? (
+		initramfs? ( sys-kernel/installkernel )
+	)
+"
 
 QA_PREBUILT="*"
 PATCHES=( "${FILESDIR}"/${PN}-copy-firmware-r4.patch )
@@ -84,8 +91,8 @@ pkg_setup() {
 				eerror "Kernels <5.19 do not support ZSTD-compressed firmware files"
 			fi
 		fi
-		linux-info_pkg_setup
 	fi
+	linux-info_pkg_setup
 }
 
 src_unpack() {
@@ -110,7 +117,7 @@ src_prepare() {
 
 	chmod +x copy-firmware.sh || die
 
-	if use initramfs; then
+	if use initramfs && ! use dist-kernel; then
 		if [[ -d "${S}/amd-ucode" ]]; then
 			local UCODETMP="${T}/ucode_tmp"
 			local UCODEDIR="${UCODETMP}/kernel/x86/microcode"
@@ -351,7 +358,13 @@ src_install() {
 
 	popd &>/dev/null || die
 
-	if use initramfs ; then
+	# Instruct Dracut on whether or not we want the microcode in initramfs
+	(
+		insinto /usr/lib/dracut/dracut.conf.d
+		newins - 10-${PN}.conf <<<"early_microcode=$(usex initramfs)"
+	)
+
+	if use initramfs && ! use dist-kernel; then
 		insinto /boot
 		doins "${S}"/amd-uc.img
 	fi
@@ -391,7 +404,12 @@ pkg_postinst() {
 	done
 
 	# Don't forget to umount /boot if it was previously mounted by us.
-	use initramfs && mount-boot_pkg_postinst
+	if use initramfs; then
+		if [[ -z ${ROOT} ]] && use dist-kernel; then
+			dist-kernel_reinstall_initramfs "${KV_DIR}" "${KV_FULL}"
+		fi
+		mount-boot_pkg_postinst
+	fi
 }
 
 pkg_prerm() {

--- a/sys-kernel/linux-firmware/linux-firmware-99999999.ebuild
+++ b/sys-kernel/linux-firmware/linux-firmware-99999999.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
-inherit linux-info mount-boot savedconfig multiprocessing
+inherit dist-kernel-utils linux-info mount-boot savedconfig multiprocessing
 
 # In case this is a real snapshot, fill in commit below.
 # For normal, tagged releases, leave blank
@@ -29,7 +29,7 @@ LICENSE="GPL-2 GPL-2+ GPL-3 BSD MIT || ( MPL-1.1 GPL-2 )
 	redistributable? ( linux-fw-redistributable BSD-2 BSD BSD-4 ISC MIT )
 	unknown-license? ( all-rights-reserved )"
 SLOT="0"
-IUSE="compress-xz compress-zstd deduplicate initramfs +redistributable savedconfig unknown-license"
+IUSE="compress-xz compress-zstd deduplicate dist-kernel +initramfs +redistributable savedconfig unknown-license"
 REQUIRED_USE="initramfs? ( redistributable )
 	?? ( compress-xz compress-zstd )
 	savedconfig? ( !deduplicate )"
@@ -61,7 +61,14 @@ RDEPEND="!savedconfig? (
 			!sys-firmware/alsa-firmware[alsa_cards_sb16]
 			!sys-firmware/alsa-firmware[alsa_cards_ymfpci]
 		)
-	)"
+	)
+	dist-kernel? ( virtual/dist-kernel )
+"
+IDEPEND="
+	dist-kernel? (
+		initramfs? ( sys-kernel/installkernel )
+	)
+"
 
 QA_PREBUILT="*"
 
@@ -78,8 +85,8 @@ pkg_setup() {
 				eerror "Kernels <5.19 do not support ZSTD-compressed firmware files"
 			fi
 		fi
-		linux-info_pkg_setup
 	fi
+	linux-info_pkg_setup
 }
 
 pkg_pretend() {
@@ -107,7 +114,7 @@ src_prepare() {
 
 	chmod +x copy-firmware.sh || die
 
-	if use initramfs; then
+	if use initramfs && ! use dist-kernel; then
 		if [[ -d "${S}/amd-ucode" ]]; then
 			local UCODETMP="${T}/ucode_tmp"
 			local UCODEDIR="${UCODETMP}/kernel/x86/microcode"
@@ -355,7 +362,13 @@ src_install() {
 
 	popd &>/dev/null || die
 
-	if use initramfs ; then
+	# Instruct Dracut on whether or not we want the microcode in initramfs
+	(
+		insinto /usr/lib/dracut/dracut.conf.d
+		newins - 10-${PN}.conf <<<"early_microcode=$(usex initramfs)"
+	)
+
+	if use initramfs && ! use dist-kernel; then
 		insinto /boot
 		doins "${S}"/amd-uc.img
 	fi
@@ -391,7 +404,12 @@ pkg_postinst() {
 	done
 
 	# Don't forget to umount /boot if it was previously mounted by us.
-	use initramfs && mount-boot_pkg_postinst
+	if use initramfs; then
+		if [[ -z ${ROOT} ]] && use dist-kernel; then
+			dist-kernel_reinstall_initramfs "${KV_DIR}" "${KV_FULL}"
+		fi
+		mount-boot_pkg_postinst
+	fi
 }
 
 pkg_prerm() {


### PR DESCRIPTION
The idea here is to add a flag (`USE=initramfs`)  that lets the user control if the kernel modules installed by a given package should be part of the initramfs (Bug 928271). If the flag is enabled we configure dracut to include the module, and then trigger reinstallation of the kernel via `installkernel`.

This solves the problem where a distribution kernel users wants to include some external kernel module in the initramfs and have this setting persist (and actually work) across kernel upgrades.

Packages for which it makes sense to by default always include the module and re-install the initramfs (i.e. `zfs`) can set `IUSE="+initramfs"`.

**Caveat**: We still end up installing the kernel+initramfs (or UKI) multiple times, the first time (the kernel upgrade) dracut will warn (but not fail) that the modules explicitly specified to be included cannot be found. Consecutive re-installations will then fix that problem (Bug 923025, nothing to do about this for now). It's not a huge problem since an initramfs rebuild does not actually take that long, and kernel upgrades are not super frequent.

We also add here a `USE=dist-kernel` flag to the packages installing CPU microcode, this flag alters the way the existing `USE=initramfs` behaves, instead of installing `/boot/intel-uc.img` and `/boot/amd-ucode` (which are useless when using dist-kernels) we toggle dracut's `early_microcode` setting and then trigger kernel re-installation. This ensures that we actually have the latest CPU microcode in the initramfs/UKI when the CPU microcode package is updated. In essence this results in more or less the same behaviour between kernel modules and CPU microcode with respect to the `initramfs` and `dist-kernel` flags, with the exception that CPU microcode packages are not rebuilt on kernel upgrade since they are prebuilt binaries.

CC @gentoo/dist-kernel @gentoo/kernel @ionen @mgorny @gentoo/base-system 