### PR TITLE
sci-biology/hmmer-2.3.2-r5: Add missing include into configure

### DIFF
--- a/sci-biology/hmmer/files/hmmer-2.3.2-fix-missing-include-in-configure.patch
+++ b/sci-biology/hmmer/files/hmmer-2.3.2-fix-missing-include-in-configure.patch
@@ -1,0 +1,18 @@
+--- a/squid/configure	2024-05-08 09:21:15.751063495 -0000
++++ b/squid/configure	2024-05-08 09:22:50.491502934 -0000
+@@ -2493,6 +2493,7 @@
+ cat confdefs.h >>conftest.$ac_ext
+ cat >>conftest.$ac_ext <<_ACEOF
+ /* end confdefs.h.  */
++#include <stdlib.h>
+ int
+ main ()
+ {
+@@ -3500,6 +3501,7 @@
+ cat >>conftest.$ac_ext <<_ACEOF
+ /* end confdefs.h.  */
+ #include <ctype.h>
++#include <stdlib.h>
+ #if ((' ' & 0x0FF) == 0x020)
+ # define ISLOWER(c) ('a' <= (c) && (c) <= 'z')
+ # define TOUPPER(c) (ISLOWER(c) ? 'A' + ((c) - 'a') : (c))

--- a/sci-biology/hmmer/hmmer-2.3.2-r5.ebuild
+++ b/sci-biology/hmmer/hmmer-2.3.2-r5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -20,6 +20,7 @@ BDEPEND="test? ( dev-lang/perl )"
 PATCHES=(
 	"${FILESDIR}/${P}-fix-perl-shebangs.patch"
 	"${FILESDIR}/${P}-fix-build-system-destdir.patch"
+	"${FILESDIR}/${P}-fix-missing-include-in-configure.patch"
 )
 
 src_configure() {


### PR DESCRIPTION
There are no autotools source files, so we can't just autoreconf the problem out of existence

Closes: https://bugs.gentoo.org/900551

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
