### PR TITLE
www-servers/lighttpd: lighttpd-9999.ebuild

### DIFF
--- a/www-servers/lighttpd/files/conf/lighttpd.conf-r3
+++ b/www-servers/lighttpd/files/conf/lighttpd.conf-r3
@@ -1,0 +1,307 @@
+###############################################################################
+# Default lighttpd.conf for Gentoo.
+###############################################################################
+
+# {{{ variables
+var.basedir  = "/var/www/localhost"
+var.logdir   = "/var/log/lighttpd"
+var.statedir = "/var/lib/lighttpd"
+# }}}
+
+# {{{ modules
+# At the very least, mod_access and mod_accesslog should be enabled.
+# All other modules should only be loaded if necessary.
+# NOTE: the order of modules is important.
+server.modules = (
+#    "mod_rewrite",
+#    "mod_redirect",
+#    "mod_alias",
+    "mod_access",
+#    "mod_magnet",
+#    "mod_auth",
+#    "mod_status",
+#    "mod_setenv",
+#    "mod_proxy",
+#    "mod_simple_vhost",
+#    "mod_evhost",
+#    "mod_userdir",
+#    "mod_deflate",
+#    "mod_ssi",
+#    "mod_expire",
+#    "mod_rrdtool",
+#    "mod_webdav",
+    "mod_accesslog"
+)
+# }}}
+
+# {{{ includes
+# Map file extensions to mime types for Content-Type using mime.conf
+# shipped with lighttpd code, based on Fedora /etc/mime.types mapping.
+# Option: comment out on embedded systems to save some memory and use
+# lighttpd built-in defaults, which include a subset of common web mime types.
+# Option: use lighttpd doc/scripts/create-mime.conf.pl to generate mapping
+# from Gentoo /etc/mime.types at lighttpd startup.
+include "/etc/lighttpd/mime.conf"
+# }}}
+
+# {{{ server settings
+server.username      = "lighttpd"
+server.groupname     = "lighttpd"
+
+server.document-root = var.basedir + "/htdocs"
+server.pid-file      = "/run/lighttpd.pid"
+
+server.errorlog      = var.logdir  + "/error.log"
+# log errors to syslog instead
+#   server.errorlog-use-syslog = "enable"
+
+server.indexfiles    = ("index.php", "index.html",
+						"index.htm", "default.htm")
+
+# server.tag           = "lighttpd"
+
+# event handler
+# see performance.txt
+#
+# for >= linux-2.6
+#   server.event-handler = "epoll"   # default on Linux
+# for FreeBSD
+#   server.event-handler = "kqueue"  # default on FreeBSD
+
+# chroot to directory (defaults to no chroot)
+# server.chroot      = "/"
+
+# bind to port (defaults to 80)
+# server.port          = 81
+
+# bind to name (defaults to all interfaces)
+# server.bind          = "grisu.home.kneschke.de"
+
+# error-handler for status 404
+# server.error-handler-404 = "/error-handler.html"
+# server.error-handler-404 = "/error-handler.php"
+
+# Format: <errorfile-prefix><status-code>.html
+# -> ..../status-404.html for 'File not found'
+# server.errorfile-prefix    = var.basedir + "/error/status-"
+
+# support for caching stat() calls
+# server.stat-cache-engine = "inotify"
+
+# If lighttpd was build with IPv6 support, and you would like to listen on IPv6,
+# uncomment the following:
+# server.use-ipv6 = "enable"
+
+# }}}
+
+# {{{ mod_staticfile
+
+# which extensions should not be handled via static-file transfer
+# (extensions that are usually handled by mod_cgi, mod_fastcgi, etc).
+static-file.exclude-extensions = (".php", ".pl", ".cgi", ".fcgi")
+# }}}
+
+# {{{ mod_accesslog
+accesslog.filename   = var.logdir + "/access.log"
+# }}}
+
+# {{{ mod_dirlisting
+# enable directory listings
+#   dir-listing.activate      = "enable"
+#
+# don't list hidden files/directories
+#   dir-listing.hide-dotfiles = "enable"
+#
+# use a different css for directory listings
+#   dir-listing.external-css  = "/path/to/dir-listing.css"
+#
+# list of regular expressions.  files that match any of the
+# specified regular expressions will be excluded from directory
+# listings.
+#   dir-listing.exclude = ("^\.", "~$")
+# }}}
+
+# {{{ mod_access
+# see access.txt
+
+url.access-deny = ("~", ".inc")
+# }}}
+
+# {{{ mod_userdir
+# see userdir.txt
+#
+# userdir.path = "public_html"
+# userdir.exclude-user = ("root")
+# }}}
+
+# {{{ mod_ssi
+# see ssi.txt
+#
+# ssi.extension = (".shtml")
+# }}}
+
+# {{{ mod_ssl
+# see ssl.txt
+#
+# ssl.engine    = "enable"
+# ssl.pemfile   = "server.pem"
+# }}}
+
+# {{{ mod_status
+# see status.txt
+#
+# status.status-url  = "/server-status"
+# status.config-url  = "/server-config"
+# }}}
+
+# {{{ mod_simple_vhost
+# see simple-vhost.txt
+#
+#  If you want name-based virtual hosting add the next three settings and load
+#  mod_simple_vhost
+#
+# document-root =
+#   virtual-server-root + virtual-server-default-host + virtual-server-docroot
+# or
+#   virtual-server-root + http-host + virtual-server-docroot
+#
+# simple-vhost.server-root   = "/home/weigon/wwwroot/servers/"
+# simple-vhost.default-host  = "grisu.home.kneschke.de"
+# simple-vhost.document-root = "/pages/"
+# }}}
+
+# {{{ mod_deflate
+# see compress.txt
+#
+# deflate.cache-dir   = var.statedir + "/cache/compress"
+# deflate.mimetypes   = ("text/plain", "text/html")
+# }}}
+
+# {{{ mod_proxy
+# see proxy.txt
+#
+# proxy.server               = ( ".php" =>
+#                               ( "localhost" =>
+#                                 (
+#                                   "host" => "192.168.0.101",
+#                                   "port" => 80
+#                                 )
+#                               )
+#                             )
+# }}}
+
+# {{{ mod_auth
+# see authentication.txt
+#
+# auth.backend               = "plain"
+# auth.backend.plain.userfile = "lighttpd.user"
+# auth.backend.plain.groupfile = "lighttpd.group"
+
+# auth.backend.ldap.hostname = "localhost"
+# auth.backend.ldap.base-dn  = "dc=my-domain,dc=com"
+# auth.backend.ldap.filter   = "(uid=$)"
+
+# auth.require               = ( "/server-status" =>
+#                               (
+#                                 "method"  => "digest",
+#                                 "realm"   => "download archiv",
+#                                 "require" => "user=jan"
+#                               ),
+#                               "/server-info" =>
+#                               (
+#                                 "method"  => "digest",
+#                                 "realm"   => "download archiv",
+#                                 "require" => "valid-user"
+#                               )
+#                             )
+# }}}
+
+# {{{ mod_rewrite
+# see rewrite.txt
+#
+# url.rewrite = (
+#	"^/$"		=>		"/server-status"
+# )
+# }}}
+
+# {{{ mod_redirect
+# see redirect.txt
+#
+# url.redirect = (
+#	"^/wishlist/(.+)"		=>		"http://www.123.org/$1"
+# )
+# }}}
+
+# {{{ mod_evhost
+# define a pattern for the host url finding
+# %% => % sign
+# %0 => domain name + tld
+# %1 => tld
+# %2 => domain name without tld
+# %3 => subdomain 1 name
+# %4 => subdomain 2 name
+#
+# evhost.path-pattern        = "/home/storage/dev/www/%3/htdocs/"
+# }}}
+
+# {{{ mod_expire
+# expire.url = (
+#	"/buggy/"		=>		"access 2 hours",
+#	"/asdhas/"		=>		"access plus 1 seconds 2 minutes"
+# )
+# }}}
+
+# {{{ mod_rrdtool
+# see rrdtool.txt
+#
+# rrdtool.binary  = "/usr/bin/rrdtool"
+# rrdtool.db-name = var.statedir + "/lighttpd.rrd"
+# }}}
+
+# {{{ mod_setenv
+# see setenv.txt
+#
+# setenv.add-request-header  = ( "TRAV_ENV" => "mysql://user@host/db" )
+# setenv.add-response-header = ( "X-Secret-Message" => "42" )
+# }}}
+
+# {{{ mod_webdav
+# see webdav.txt
+#
+# $HTTP["url"] =~ "^/dav($|/)" {
+#     webdav.activate = "enable"
+#     webdav.is-readonly = "enable"
+# }
+# }}}
+
+# {{{ extra rules
+#
+# set Content-Encoding and reset Content-Type for browsers that
+# support decompressing on-thy-fly (requires mod_setenv)
+# $HTTP["url"] =~ "\.gz$" {
+#     setenv.add-response-header = ("Content-Encoding" => "x-gzip")
+#     mimetype.assign = (".gz" => "text/plain")
+# }
+
+# $HTTP["url"] =~ "\.bz2$" {
+#     setenv.add-response-header = ("Content-Encoding" => "x-bzip2")
+#     mimetype.assign = (".bz2" => "text/plain")
+# }
+#
+# }}}
+
+# {{{ debug
+# debug.log-request-header   = "enable"
+# debug.log-response-header  = "enable"
+# debug.log-request-handling = "enable"
+# debug.log-file-not-found   = "enable"
+# }}}
+
+# {{{ cgi includes
+# uncomment for cgi support
+#   include "mod_cgi.conf"
+# uncomment for php/fastcgi support
+#   include "mod_fastcgi.conf"
+# }}}
+
+# vim: set ft=conf foldmethod=marker et :

--- a/www-servers/lighttpd/lighttpd-9999.ebuild
+++ b/www-servers/lighttpd/lighttpd-9999.ebuild
@@ -1,0 +1,217 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+LUA_COMPAT=( lua5-{1..4} )
+VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/openpgp-keys/lighttpd.asc
+inherit lua-single meson readme.gentoo-r1 systemd tmpfiles verify-sig
+
+DESCRIPTION="Lightweight high-performance web server"
+HOMEPAGE="https://www.lighttpd.net https://github.com/lighttpd"
+if [[ ${PV} == *9999* ]] ; then
+	EGIT_REPO_URI="https://git.lighttpd.net/lighttpd/lighttpd1.4.git"
+	inherit git-r3
+else
+	SRC_URI="
+		https://download.lighttpd.net/lighttpd/releases-1.4.x/${P}.tar.xz
+		verify-sig? ( https://download.lighttpd.net/lighttpd/releases-$(ver_cut 1-2).x/${P}.tar.xz.asc )
+	"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+fi
+
+LICENSE="BSD GPL-2"
+SLOT="0"
+IUSE="+brotli dbi gnutls kerberos ldap +lua maxminddb mbedtls +nettle nss +pcre php sasl selinux ssl test unwind webdav xattr +zlib zstd"
+RESTRICT="!test? ( test )"
+
+REQUIRED_USE="
+	lua? ( ${LUA_REQUIRED_USE} )
+"
+
+# Match the bundled xxhash version for the minimum version
+COMMON_DEPEND="
+	acct-group/lighttpd
+	acct-user/lighttpd
+	>=dev-libs/xxhash-0.8.2
+	virtual/libcrypt:=
+	brotli? ( app-arch/brotli:= )
+	dbi? (
+		dev-db/libdbi
+	)
+	gnutls? ( net-libs/gnutls )
+	kerberos? ( virtual/krb5 )
+	ldap? ( >=net-nds/openldap-2.1.26:= )
+	lua? ( ${LUA_DEPS} )
+	maxminddb? ( dev-libs/libmaxminddb )
+	mbedtls? ( net-libs/mbedtls )
+	nettle? ( dev-libs/nettle:= )
+	nss? ( dev-libs/nss )
+	pcre? ( dev-libs/libpcre2 )
+	php? ( dev-lang/php:*[cgi] )
+	sasl? ( dev-libs/cyrus-sasl )
+	ssl? ( >=dev-libs/openssl-0.9.7:= )
+	unwind? ( sys-libs/libunwind:= )
+	webdav? (
+		dev-libs/libxml2
+		dev-db/sqlite
+	)
+	xattr? ( kernel_linux? ( sys-apps/attr ) )
+	zlib? ( >=sys-libs/zlib-1.1 )
+	zstd? ( app-arch/zstd:= )
+"
+DEPEND="
+	${COMMON_DEPEND}
+	elibc_musl? ( sys-libs/queue-standalone )
+"
+RDEPEND="
+	${COMMON_DEPEND}
+	selinux? ( sec-policy/selinux-apache )
+"
+BDEPEND="
+	virtual/pkgconfig
+	test? ( virtual/perl-Test-Harness )
+	verify-sig? ( sec-keys/openpgp-keys-lighttpd )
+"
+
+# update certain parts of lighttpd.conf based on conditionals
+update_config() {
+	local config="${ED}/etc/lighttpd/lighttpd.conf"
+
+	# Enable php/mod_fastcgi settings
+	if use php; then
+		sed -i -e 's|#.*\(include.*fastcgi.*$\)|\1|' ${config} || die
+	fi
+
+	# Automatically listen on IPv6 if built with USE=ipv6 (which we now always do)
+	# bug #234987
+	sed -i -e 's|# server.use-ipv6|server.use-ipv6|' ${config} || die
+}
+
+pkg_setup() {
+	if use lua; then
+		lua-single_pkg_setup
+	fi
+
+	if ! use pcre ; then
+		ewarn "It is highly recommended that you build ${PN}"
+		ewarn "with perl regular expressions support via USE=pcre."
+		ewarn "Otherwise you lose support for some core options such"
+		ewarn "as conditionals and modules such as mod_re{write,direct}."
+	fi
+
+	DOC_CONTENTS="IPv6 migration guide:\n
+		https://wiki.lighttpd.net/IPv6-Config
+	"
+}
+
+src_configure() {
+	local emesonargs=(
+		-Dmoduledir="$(get_libdir)"/${PN}
+
+		$(meson_feature brotli with_brotli)
+
+		# TODO: revisit (was off in autotools ebuild)
+		-Dwith_bzip=disabled
+
+		$(meson_feature dbi with_dbi)
+
+		# Unpackaged in Gentoo
+		-Dwith_libdeflate=disabled
+		# Obsolete
+		-Dwith_fam=disabled
+
+		$(meson_use gnutls with_gnutls)
+		$(meson_feature kerberos with_krb5)
+		$(meson_feature ldap with_ldap)
+
+		$(meson_feature unwind with_libunwind)
+
+		$(meson_use lua with_lua)
+		-Dlua_version=${ELUA}
+
+		$(meson_feature maxminddb with_maxminddb)
+		$(meson_use mbedtls with_mbedtls)
+
+		$(meson_use nettle with_nettle)
+		$(meson_use nss with_nss)
+
+		# Obsolete
+		-Dwith_pcre=disabled
+
+		$(meson_use pcre with_pcre2)
+
+		$(meson_feature sasl with_sasl)
+		$(meson_use ssl with_openssl)
+
+		-Dwith_xxhash=enabled
+		$(meson_feature webdav with_webdav_props)
+
+		# Unpackaged in Gentoo
+		-Dwith_wolfssl=false
+
+		$(meson_use xattr with_xattr)
+		$(meson_feature zlib with_zlib)
+		$(meson_feature zstd with_zstd)
+	)
+
+	meson_src_configure
+}
+
+src_install() {
+	meson_src_install
+
+	# Init script stuff
+	newinitd "${FILESDIR}"/lighttpd.initd-r2 lighttpd
+	newconfd "${FILESDIR}"/lighttpd.confd lighttpd
+
+	# Configs
+	insinto /etc/lighttpd
+	newins "${FILESDIR}"/conf/lighttpd.conf-r2 lighttpd.conf
+	doins "${FILESDIR}"/conf/mod_cgi.conf
+	doins "${FILESDIR}"/conf/mod_fastcgi.conf
+
+	# Update lighttpd.conf directives based on conditionals
+	update_config
+
+	# Docs
+	dodoc AUTHORS README NEWS doc/scripts/*.sh
+	newdoc doc/config/lighttpd.conf lighttpd.conf.distrib
+	readme.gentoo_create_doc
+
+	docinto txt
+	dodoc doc/outdated/*.txt
+
+	doman doc/*.8
+
+	# Logrotate
+	insinto /etc/logrotate.d
+	newins "${FILESDIR}"/lighttpd.logrotate-r1 lighttpd
+
+	keepdir /var/l{ib,og}/lighttpd /var/www/localhost/htdocs
+	fowners lighttpd:lighttpd /var/l{ib,og}/lighttpd
+	fperms 0750 /var/l{ib,og}/lighttpd
+
+	systemd_newunit "${FILESDIR}"/${PN}.service-r1 ${PN}.service
+	newtmpfiles "${FILESDIR}"/${PN}.tmpfiles.conf ${PN}.conf
+}
+
+pkg_postinst() {
+	tmpfiles_process ${PN}.conf
+
+	readme.gentoo_print_elog
+
+	if [[ -f ${EROOT}/etc/lighttpd.conf ]] ; then
+		elog
+		elog "Gentoo has a customized configuration,"
+		elog "which is now located in ${EROOT}/etc/lighttpd. Please migrate your"
+		elog "existing configuration."
+	fi
+
+	if use brotli || use zstd || use zlib ; then
+		elog
+		elog "Remember to clean your cache directory when using"
+		elog "output compression!"
+		elog "https://wiki.lighttpd.net/Docs_ModDeflate"
+	fi
+}

--- a/www-servers/lighttpd/lighttpd-9999.ebuild
+++ b/www-servers/lighttpd/lighttpd-9999.ebuild
@@ -22,7 +22,7 @@ fi
 
 LICENSE="BSD GPL-2"
 SLOT="0"
-IUSE="+brotli dbi gnutls kerberos ldap +lua maxminddb mbedtls +nettle nss +pcre php sasl selinux ssl test unwind webdav xattr +zlib zstd"
+IUSE="+brotli dbi gnutls kerberos ldap libdeflate +lua maxminddb mbedtls +nettle nss +pcre php sasl selinux ssl test unwind webdav xattr +zlib zstd"
 RESTRICT="!test? ( test )"
 
 REQUIRED_USE="
@@ -42,6 +42,7 @@ COMMON_DEPEND="
 	gnutls? ( net-libs/gnutls )
 	kerberos? ( virtual/krb5 )
 	ldap? ( >=net-nds/openldap-2.1.26:= )
+	libdeflate? ( app-arch/libdeflate )
 	lua? ( ${LUA_DEPS} )
 	maxminddb? ( dev-libs/libmaxminddb )
 	mbedtls? ( net-libs/mbedtls )
@@ -116,14 +117,14 @@ src_configure() {
 
 		$(meson_feature dbi with_dbi)
 
-		# Unpackaged in Gentoo
-		-Dwith_libdeflate=disabled
 		# Obsolete
 		-Dwith_fam=disabled
 
 		$(meson_use gnutls with_gnutls)
 		$(meson_feature kerberos with_krb5)
 		$(meson_feature ldap with_ldap)
+
+		$(meson_feature libdeflate with_libdeflate)
 
 		$(meson_feature unwind with_libunwind)
 

--- a/www-servers/lighttpd/lighttpd-9999.ebuild
+++ b/www-servers/lighttpd/lighttpd-9999.ebuild
@@ -200,9 +200,10 @@ src_install() {
 
 	# Configs
 	insinto /etc/lighttpd
-	newins "${FILESDIR}"/conf/lighttpd.conf-r2 lighttpd.conf
+	newins "${FILESDIR}"/conf/lighttpd.conf-r3 lighttpd.conf
 	doins "${FILESDIR}"/conf/mod_cgi.conf
 	doins "${FILESDIR}"/conf/mod_fastcgi.conf
+	doins doc/config/conf.d/mime.conf
 
 	# Update lighttpd.conf directives based on conditionals
 	update_config

--- a/www-servers/lighttpd/metadata.xml
+++ b/www-servers/lighttpd/metadata.xml
@@ -15,11 +15,15 @@
 	</longdescription>
 	<use>
 		<flag name="brotli">Enable output compression via <pkg>app-arch/brotli</pkg> (recommended)</flag>
+		<flag name="crypto-gnutls">Use <pkg>net-libs/gnutls</pkg> as crypto library</flag>
+		<flag name="crypto-mbedtls">Use <pkg>net-libs/mbedtls</pkg> as crypto library</flag>
+		<flag name="crypto-nettle">Use <pkg>dev-libs/nettle</pkg> as crypto library</flag>
+		<flag name="crypto-openssl">Use <pkg>dev-libs/openssl</pkg> as crypto library</flag>
 		<flag name="gnutls">Build module for TLS via <pkg>net-libs/gnutls</pkg></flag>
 		<flag name="libdeflate">Enable output compression via <pkg>app-arch/libdeflate</pkg></flag>
 		<flag name="maxminddb">Add support for geolocation using <pkg>dev-libs/libmaxminddb</pkg></flag>
 		<flag name="mbedtls">Build module for TLS via <pkg>net-libs/mbedtls</pkg></flag>
-		<flag name="nettle">Use <pkg>dev-libs/nettle</pkg> as crypto backend</flag>
+		<flag name="nettle">Use <pkg>dev-libs/nettle</pkg> as crypto library</flag>
 		<flag name="nss">Build module for TLS via Mozilla's Network Security Services</flag>
 		<flag name="webdav">Enable webdav properties</flag>
 		<flag name="zlib">Enable output compression via gzip or deflate algorithms from <pkg>sys-libs/zlib</pkg></flag>

--- a/www-servers/lighttpd/metadata.xml
+++ b/www-servers/lighttpd/metadata.xml
@@ -16,6 +16,7 @@
 	<use>
 		<flag name="brotli">Enable output compression via <pkg>app-arch/brotli</pkg> (recommended)</flag>
 		<flag name="gnutls">Build module for TLS via <pkg>net-libs/gnutls</pkg></flag>
+		<flag name="libdeflate">Enable output compression via <pkg>app-arch/libdeflate</pkg></flag>
 		<flag name="maxminddb">Add support for geolocation using <pkg>dev-libs/libmaxminddb</pkg></flag>
 		<flag name="mbedtls">Build module for TLS via <pkg>net-libs/mbedtls</pkg></flag>
 		<flag name="nettle">Use <pkg>dev-libs/nettle</pkg> as crypto backend</flag>


### PR DESCRIPTION
lighttpd-9999.ebuild

Follow-up to #35790

* create lighttpd-9999.ebuild
* USE_LIBDEFLATE flag
   (TODO: drop ~s390 from ebuild KEYWORDS; file rekeywording bug)
* USE_CRYPTO_* flags to select crypto library used by lighttpd
   (What should happen to USE_NETTLE flag?)
* use upstream mime.conf (large list of mime-types)

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.