### PR TITLE
dev-python/tpm2-pytss: Fix compile for newer tpm2-tss, cryptogrpahy

### DIFF
--- a/dev-python/tpm2-pytss/files/tpm2-pytss-2.2.1-Revert-test-skip-some-FAPI-tests-if-testing-agains-t.patch
+++ b/dev-python/tpm2-pytss/files/tpm2-pytss-2.2.1-Revert-test-skip-some-FAPI-tests-if-testing-agains-t.patch
@@ -1,0 +1,83 @@
+From a04715c5ef5bc3d6b30b1354d64db1762bc42b9c Mon Sep 17 00:00:00 2001
+From: Erik Larsson <who+github@cnackers.org>
+Date: Fri, 12 Apr 2024 19:49:52 +0200
+Subject: [PATCH 1/2] Revert "test: skip some FAPI tests if testing agains
+ tpm2-tss master branch."
+
+This reverts commit 9e948984676b38f71e923a6e167340dc99554ac0.
+
+Fixed in tpm2-tss master branch, so remove the temporary fixes.
+
+Signed-off-by: Erik Larsson <who+github@cnackers.org>
+---
+ test/test_fapi.py | 19 +++++--------------
+ 1 file changed, 5 insertions(+), 14 deletions(-)
+
+diff --git a/test/test_fapi.py b/test/test_fapi.py
+index f702fc9..6b77c66 100644
+--- a/test/test_fapi.py
++++ b/test/test_fapi.py
+@@ -13,7 +13,7 @@ from cryptography.hazmat.primitives.asymmetric.padding import PSS
+ 
+ from tpm2_pytss import *
+ 
+-from tpm2_pytss.internal.utils import is_bug_fixed, _lib_version_atleast
++from tpm2_pytss.internal.utils import is_bug_fixed
+ 
+ from .TSS2_BaseTest import TpmSimulator
+ from tpm2_pytss.TSS2_Exception import TSS2_Exception
+@@ -614,8 +614,7 @@ class Common:
+         self.fapi.sign(key_path, b"\x22" * 32)
+ 
+     @pytest.mark.skipif(
+-        _lib_version_atleast("tss2-fapi", "4.0.1-170")
+-        or not is_bug_fixed(fixed_in="3.2", backports=["2.4.7", "3.0.5", "3.1.1"]),
++        not is_bug_fixed(fixed_in="3.2", backports=["2.4.7", "3.0.5", "3.1.1"]),
+         reason="tpm2-tss bug, see #2084",
+     )
+     def test_write_authorize_nv(self, esys):
+@@ -662,8 +661,7 @@ class Common:
+             self.fapi.quote(path=key_path, pcrs=[7, 9])
+ 
+     @pytest.mark.skipif(
+-        _lib_version_atleast("tss2-fapi", "4.0.1-170")
+-        or not is_bug_fixed(fixed_in="3.2", backports=["2.4.7", "3.0.5", "3.1.1"]),
++        not is_bug_fixed(fixed_in="3.2", backports=["2.4.7", "3.0.5", "3.1.1"]),
+         reason="tpm2-tss bug, see #2084",
+     )
+     def test_authorize_policy(self, sign_key):
+@@ -728,9 +726,7 @@ class Common:
+             self.fapi.quote(path=key_path, pcrs=[7, 9])
+ 
+     @pytest.mark.skipif(
+-        _lib_version_atleast("tss2-fapi", "4.0.1-170")
+-        or not is_bug_fixed(fixed_in="3.2"),
+-        reason="tpm2-tss bug, see #2080",
++        not is_bug_fixed(fixed_in="3.2"), reason="tpm2-tss bug, see #2080"
+     )
+     def test_policy_signed(self, cryptography_key):
+         # create external signing key used by the signing authority external to the TPM
+@@ -792,10 +788,6 @@ class Common:
+         with pytest.raises(TSS2_Exception):
+             self.fapi.sign(path=key_path, digest=b"\x11" * 32)
+ 
+-    @pytest.mark.skipif(
+-        _lib_version_atleast("tss2-fapi", "4.0.1-170"),
+-        reason="issue on master branch.",
+-    )
+     def test_policy_branched(self):
+         pcr_index = 15
+         pcr_data = b"ABCDEF"
+@@ -913,8 +905,7 @@ class Common:
+         self.fapi.delete(path=nv_path)
+ 
+     @pytest.mark.skipif(
+-        _lib_version_atleast("tss2-fapi", "4.0.1-170")
+-        or not is_bug_fixed(fixed_in="3.2", backports=["2.4.7", "3.0.5", "3.1.1"]),
++        not is_bug_fixed(fixed_in="3.2", backports=["2.4.7", "3.0.5", "3.1.1"]),
+         reason="tpm2-tss bug, see #2089",
+     )
+     def test_policy_action(self):
+-- 
+2.43.2
+

--- a/dev-python/tpm2-pytss/files/tpm2-pytss-2.2.1-cryptography-fixes-for-newer-version-of-cryptography.patch
+++ b/dev-python/tpm2-pytss/files/tpm2-pytss-2.2.1-cryptography-fixes-for-newer-version-of-cryptography.patch
@@ -1,0 +1,53 @@
+From 5a33c767be196328948baef569de084d97d62384 Mon Sep 17 00:00:00 2001
+From: Erik Larsson <who+github@cnackers.org>
+Date: Tue, 26 Mar 2024 13:25:10 +0100
+Subject: [PATCH] cryptography: fixes for newer version of cryptography
+
+Signed-off-by: Erik Larsson <who+github@cnackers.org>
+---
+ src/tpm2_pytss/internal/crypto.py | 1 +
+ test/test_encoding.py             | 2 +-
+ test/test_policy.py               | 2 +-
+ 3 files changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/src/tpm2_pytss/internal/crypto.py b/src/tpm2_pytss/internal/crypto.py
+index 42030c5..f9d8c34 100644
+--- a/src/tpm2_pytss/internal/crypto.py
++++ b/src/tpm2_pytss/internal/crypto.py
+@@ -25,6 +25,7 @@ from cryptography.hazmat.backends import default_backend
+ from cryptography.exceptions import UnsupportedAlgorithm, InvalidSignature
+ from typing import Tuple, Type, Any
+ import secrets
++import inspect
+ import sys
+ 
+ _curvetable = (
+diff --git a/test/test_encoding.py b/test/test_encoding.py
+index 1f58562..8cf4b51 100644
+--- a/test/test_encoding.py
++++ b/test/test_encoding.py
+@@ -1406,7 +1406,7 @@ class ToolsTest(TSS2_BaseTest):
+     def test_tools_decode_tpm2b_name(self):
+         if not self.has_tools:
+             self.skipTest("tools not in path")
+-        key = ec.generate_private_key(ec.SECP256R1).public_key()
++        key = ec.generate_private_key(ec.SECP256R1()).public_key()
+         kb = key.public_bytes(
+             serialization.Encoding.PEM, serialization.PublicFormat.SubjectPublicKeyInfo
+         )
+diff --git a/test/test_policy.py b/test/test_policy.py
+index f18aa8a..5f56e21 100644
+--- a/test/test_policy.py
++++ b/test/test_policy.py
+@@ -47,7 +47,7 @@ class TestPolicy(TSS2_EsapiTest):
+         super().setUp()
+         self._has_secp192r1 = True
+         try:
+-            ec.generate_private_key(ec.SECP192R1)
++            ec.generate_private_key(ec.SECP192R1())
+         except Exception:
+             self._has_secp192r1 = False
+ 
+-- 
+2.43.2
+

--- a/dev-python/tpm2-pytss/files/tpm2-pytss-2.2.1-scripts-update-regex-for-defines.patch
+++ b/dev-python/tpm2-pytss/files/tpm2-pytss-2.2.1-scripts-update-regex-for-defines.patch
@@ -1,0 +1,28 @@
+From b02fdc8e259fe977c1065389c042be69e2985bdf Mon Sep 17 00:00:00 2001
+From: Erik Larsson <who+github@cnackers.org>
+Date: Sat, 20 Apr 2024 10:32:55 +0200
+Subject: [PATCH 2/2] scripts: update regex for #defines
+
+Commit fdb3594b27aee315ad56af361512800266672582 in tpm2-tss changed
+the structure of some defines, so fix the regex.
+
+Signed-off-by: Erik Larsson <who+github@cnackers.org>
+---
+ scripts/prepare_headers.py | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/scripts/prepare_headers.py b/scripts/prepare_headers.py
+index 6ca9b64..a7529b3 100644
+--- a/scripts/prepare_headers.py
++++ b/scripts/prepare_headers.py
+@@ -32,6 +32,7 @@ def remove_common_guards(s):
+ 
+     # Restructure #defines with ...
+     s = re.sub("(#define [A-Za-z0-9_]+) +\(\(.*?\) \(.*?\)\)", "\g<1>...", s)
++    s = re.sub("(#define [A-Za-z0-9_]+) +\(\(\(.*?\) .*\)", "\g<1>...", s)
+     s = re.sub("(#define [A-Za-z0-9_]+) +\(\(.*?\).*?\) ", "\g<1>...", s)
+     s = re.sub(
+         "(#define [A-Za-z0-9_]+) .*\n.*?.*\)\)", "\g<1>...", s, flags=re.MULTILINE
+-- 
+2.43.2
+

--- a/dev-python/tpm2-pytss/tpm2-pytss-2.2.1.ebuild
+++ b/dev-python/tpm2-pytss/tpm2-pytss-2.2.1.ebuild
@@ -39,6 +39,12 @@ BDEPEND="
 	dev-python/setuptools-scm[${PYTHON_USEDEP}]
 "
 
+PATCHES=(
+	"${FILESDIR}/${PN}-2.2.1-cryptography-fixes-for-newer-version-of-cryptography.patch"
+	"${FILESDIR}/${PN}-2.2.1-Revert-test-skip-some-FAPI-tests-if-testing-agains-t.patch"
+	"${FILESDIR}/${PN}-2.2.1-scripts-update-regex-for-defines.patch"
+	)
+
 export SETUPTOOLS_SCM_PRETEND_VERSION=${PV}
 
 distutils_enable_tests pytest


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/931557

Fix compilation against newer app-crypt/tpm2-tss, dev-python/cryptography

The upstream patch for dev-python/cryptography would not apply cleanly due to a earlier commit, so I cherry-picked and fixed the conflicts manually.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
