### PR TITLE
app-crypt/tpm2-tss: Exclude TCTIs with automagic external dependencies

### DIFF
--- a/app-crypt/tpm2-tss/files/tpm2-tss-4.1.1-Remove-bash-syntax.patch
+++ b/app-crypt/tpm2-tss/files/tpm2-tss-4.1.1-Remove-bash-syntax.patch
@@ -1,0 +1,28 @@
+From 03726ba7684d672201dd773a49b7bec86ca877f5 Mon Sep 17 00:00:00 2001
+From: David Seifert <soap@gentoo.org>
+Date: Tue, 7 May 2024 20:37:14 +0200
+Subject: [PATCH] Remove bash syntax
+
+* `==` is bash and not POSIX
+Bug: https://bugs.gentoo.org/931239
+Signed-off-by: David Seifert <soap@gentoo.org>
+---
+ configure.ac | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index a763b683..eb6051ea 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -652,7 +652,7 @@ AS_IF([test "x$enable_self_generated_certificate" = xyes],
+ 	[AC_DEFINE([SELF_GENERATED_CERTIFICATE], [1], [Allow usage of self generated root certificate])],
+ 	[AS_IF([test "x$integration_tcti" != "xdevice"], [AC_DEFINE([FAPI_TEST_EK_CERT_LESS], [1], [Perform integration tests without EK certificate verification])])])
+ 
+-AM_CONDITIONAL([INIT_CA], [test "x$enable_self_generated_certificate" == xyes])
++AM_CONDITIONAL([INIT_CA], [test "x$enable_self_generated_certificate" = xyes])
+ 
+ AS_IF([test "x$enable_integration" = "xyes" && test "x$enable_self_generated_certificate" != "xyes" && test "x$integration_tcti" != "xdevice"],
+       [AC_MSG_WARN([Running integration tests without EK certificate verification, use --enable-self-generated-certificate for full test coverage])])
+-- 
+2.43.2
+

--- a/app-crypt/tpm2-tss/files/tpm2-tss-4.1.1-int-log-compiler-common.sh-Remove-dependency-on-whic.patch
+++ b/app-crypt/tpm2-tss/files/tpm2-tss-4.1.1-int-log-compiler-common.sh-Remove-dependency-on-whic.patch
@@ -1,0 +1,32 @@
+From ce2ca92af5f215e9c3fa262ea40de0c1d2ff71a3 Mon Sep 17 00:00:00 2001
+From: Christopher Byrne <salah.coronya@gmail.com>
+Date: Fri, 3 May 2024 10:30:34 -0500
+Subject: [PATCH] int-log-compiler-common.sh: Remove dependency on which
+
+Signed-off-by: Christopher Byrne <salah.coronya@gmail.com>
+---
+ script/int-log-compiler-common.sh | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/script/int-log-compiler-common.sh b/script/int-log-compiler-common.sh
+index 5d0b3b95..5dddd77a 100755
+--- a/script/int-log-compiler-common.sh
++++ b/script/int-log-compiler-common.sh
+@@ -55,12 +55,12 @@ sanity_test ()
+         exit 1
+     fi
+ 
+-    if [ -z "$(which ${sock_tool})" ]; then
++    if [ -z "$(command -v ${sock_tool})" ]; then
+         echo "ss not on PATH; exiting"
+         exit 1
+     fi
+ 
+-    if [[ ! -z ${simulator_bin} && -z "$(which ${simulator_bin})" ]]; then
++    if [[ ! -z ${simulator_bin} && -z "$(command -v ${simulator_bin})" ]]; then
+         echo "${simulator_bin} not on PATH; exiting"
+         exit 1
+     fi
+-- 
+2.43.2
+

--- a/app-crypt/tpm2-tss/tpm2-tss-4.1.1-r1.ebuild
+++ b/app-crypt/tpm2-tss/tpm2-tss-4.1.1-r1.ebuild
@@ -1,0 +1,112 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools flag-o-matic linux-info multilib-minimal tmpfiles udev
+
+DESCRIPTION="TCG Trusted Platform Module 2.0 Software Stack"
+HOMEPAGE="https://github.com/tpm2-software/tpm2-tss"
+SRC_URI="https://github.com/tpm2-software/${PN}/releases/download/${PV}/${P}.tar.gz"
+
+LICENSE="BSD-2"
+SLOT="0/4"
+KEYWORDS="~amd64 ~arm ~arm64 ~loong ~ppc64 ~riscv ~x86"
+IUSE="doc +fapi +openssl mbedtls +policy static-libs test"
+RESTRICT="!test? ( test )"
+
+REQUIRED_USE="
+	^^ ( mbedtls openssl )
+	fapi? ( openssl !mbedtls )
+	policy? ( openssl !mbedtls )
+"
+
+RDEPEND="
+	acct-group/tss
+	acct-user/tss
+	sys-apps/util-linux:=[${MULTILIB_USEDEP}]
+	fapi? (
+		dev-libs/json-c:=[${MULTILIB_USEDEP}]
+		>=net-misc/curl-7.80.0[${MULTILIB_USEDEP}]
+	)
+	mbedtls? ( net-libs/mbedtls:=[${MULTILIB_USEDEP}] )
+	openssl? ( dev-libs/openssl:=[${MULTILIB_USEDEP}] )
+"
+
+DEPEND="
+	${RDEPEND}
+	test? ( app-crypt/swtpm
+		dev-libs/uthash
+		dev-util/cmocka
+		fapi? ( >=net-misc/curl-7.80.0 ) )
+"
+
+BDEPEND="
+	sys-apps/acl
+	virtual/pkgconfig
+	doc? ( app-text/doxygen )
+"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-4.0.2-Dont-install-files-into-run.patch"
+	"${FILESDIR}/${PN}-4.1.1-int-log-compiler-common.sh-Remove-dependency-on-whic.patch"
+	"${FILESDIR}/${PN}-4.1.1-Remove-bash-syntax.patch"
+)
+
+pkg_setup() {
+	local CONFIG_CHECK="~TCG_TPM"
+	linux-info_pkg_setup
+	kernel_is ge 4 12 0 || ewarn "At least kernel 4.12.0 is required"
+}
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+multilib_src_configure() {
+	# Fails with inlining
+	filter-flags -fno-semantic-interposition
+	# tests fail with LTO enabbled. See bug 865275 and 865279
+	filter-lto
+
+	local myconf=(
+		--localstatedir=/var
+		$(multilib_native_use_enable doc doxygen-doc)
+		$(use_enable fapi)
+		$(use_enable policy)
+		$(use_enable static-libs static)
+		$(multilib_native_use_enable test unit)
+		$(multilib_native_use_enable test integration)
+		$(multilib_native_use_enable test self-generated-certificate)
+		--disable-tcti-libtpms
+		--disable-tcti-spi-ltt2go
+		--disable-tcti-spi-ftdi
+		--disable-tcti-i2c-ftdi
+		--disable-defaultflags
+		--disable-weakcrypto
+		--with-crypto="$(usex mbedtls mbed ossl)"
+		--with-runstatedir=/run
+		--with-udevrulesdir="$(get_udevdir)/rules.d"
+		--with-udevrulesprefix=60-
+		--without-sysusersdir
+		--with-tmpfilesdir="/usr/lib/tmpfiles.d"
+	)
+
+	ECONF_SOURCE=${S} econf "${myconf[@]}"
+}
+
+multilib_src_install() {
+	default
+	keepdir /var/lib/tpm2-tss/system/keystore
+	find "${ED}" -name '*.la' -delete || die
+}
+
+pkg_postinst() {
+	tmpfiles_process tpm2-tss-fapi.conf
+	udev_reload
+}
+
+pkg_postrm() {
+	udev_reload
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/931513

I'm not expecting a while lot of demand for the excluded TCTIs, but if there are I'm imagining a TPM2_TCTI USE_EXPAND variable may be needed.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
