### PR TITLE
Mesa gles2 drop fix

### DIFF
--- a/dev-debug/apitrace/apitrace-9.0-r4.ebuild
+++ b/dev-debug/apitrace/apitrace-9.0-r4.ebuild
@@ -21,7 +21,7 @@ DEPEND="${PYTHON_DEPS}
 	app-arch/brotli:=[${MULTILIB_USEDEP}]
 	>=app-arch/snappy-1.1.1[${MULTILIB_USEDEP}]
 	media-libs/libpng:0=
-	media-libs/mesa[egl(+),gles1,gles2,X?,${MULTILIB_USEDEP}]
+	media-libs/mesa[egl(+),gles1(+),gles2(+),opengl,X?,${MULTILIB_USEDEP}]
 	>=media-libs/waffle-1.6.0-r1[egl(+),${MULTILIB_USEDEP}]
 	sys-libs/zlib[${MULTILIB_USEDEP}]
 	sys-process/procps:=[${MULTILIB_USEDEP}]

--- a/dev-games/ogre/ogre-1.9.0-r3.ebuild
+++ b/dev-games/ogre/ogre-1.9.0-r3.ebuild
@@ -40,8 +40,8 @@ RDEPEND="
 	boost? ( dev-libs/boost:= )
 	cg? ( media-gfx/nvidia-cg-toolkit )
 	freeimage? ( media-libs/freeimage )
-	gles2? ( >=media-libs/mesa-9.0.0[gles2] )
-	gles3? ( >=media-libs/mesa-10.0.0[gles2] )
+	gles2? ( >=media-libs/mesa-9.0.0[gles2(+),opengl] )
+	gles3? ( >=media-libs/mesa-10.0.0[gles2(+),opengl] )
 	gl3plus? ( >=media-libs/mesa-9.2.5 )
 	ois? ( dev-games/ois )
 	threads? (

--- a/dev-libs/efl/efl-1.27.0.ebuild
+++ b/dev-libs/efl/efl-1.27.0.ebuild
@@ -49,7 +49,7 @@ RDEPEND="${LUA_DEPS}
 	sys-apps/dbus
 	sys-libs/zlib
 	X? (
-		!opengl? ( media-libs/mesa[egl(+),gles2] )
+		!opengl? ( media-libs/mesa[egl(+),gles2(+),opengl] )
 		media-libs/freetype
 		x11-libs/libX11
 		x11-libs/libXScrnSaver
@@ -113,7 +113,7 @@ RDEPEND="${LUA_DEPS}
 	vnc? ( net-libs/libvncserver )
 	wayland? (
 		dev-libs/wayland
-		media-libs/mesa[gles2,wayland]
+		media-libs/mesa[gles2(+),opengl,wayland]
 		x11-libs/libxkbcommon
 	)
 	webp? ( media-libs/libwebp:= )

--- a/games-arcade/jazz2/jazz2-0.6.7.ebuild
+++ b/games-arcade/jazz2/jazz2-0.6.7.ebuild
@@ -18,7 +18,7 @@ RDEPEND="
 	media-libs/libopenmpt
 	media-libs/libsdl2[video]
 	media-libs/openal
-	gles2-only? ( media-libs/mesa[gles2] )
+	gles2-only? ( media-libs/mesa[gles2(+),opengl] )
 	!gles2-only? ( virtual/opengl )
 "
 

--- a/games-engines/scummvm/scummvm-2.8.0.ebuild
+++ b/games-engines/scummvm/scummvm-2.8.0.ebuild
@@ -48,7 +48,7 @@ DEPEND="
 	opengl? (
 		|| (
 			virtual/opengl
-			media-libs/mesa[gles2]
+			media-libs/mesa[gles2(+),opengl]
 			media-libs/mesa[gles1]
 		)
 	)

--- a/games-engines/scummvm/scummvm-2.8.1.ebuild
+++ b/games-engines/scummvm/scummvm-2.8.1.ebuild
@@ -48,7 +48,7 @@ DEPEND="
 	opengl? (
 		|| (
 			virtual/opengl
-			media-libs/mesa[gles2]
+			media-libs/mesa[gles2(+),opengl]
 			media-libs/mesa[gles1]
 		)
 	)

--- a/games-engines/scummvm/scummvm-9999.ebuild
+++ b/games-engines/scummvm/scummvm-9999.ebuild
@@ -48,7 +48,7 @@ DEPEND="
 	opengl? (
 		|| (
 			virtual/opengl
-			media-libs/mesa[gles2]
+			media-libs/mesa[gles2(+),opengl]
 			media-libs/mesa[gles1]
 		)
 	)

--- a/gui-libs/wlroots/wlroots-0.15.1-r1.ebuild
+++ b/gui-libs/wlroots/wlroots-0.15.1-r1.ebuild
@@ -25,7 +25,7 @@ DEPEND="
 	>=dev-libs/libinput-1.14.0:0=
 	>=dev-libs/wayland-1.20.0
 	>=dev-libs/wayland-protocols-1.24
-	media-libs/mesa[egl(+),gles2,gbm(+)]
+	media-libs/mesa[egl(+),gles2(+),opengl,gbm(+)]
 	sys-auth/seatd:=
 	virtual/libudev
 	vulkan? (

--- a/gui-libs/wlroots/wlroots-0.16.2-r2.ebuild
+++ b/gui-libs/wlroots/wlroots-0.16.2-r2.ebuild
@@ -26,7 +26,7 @@ REQUIRED_USE="
 
 DEPEND="
 	>=dev-libs/wayland-1.21.0
-	media-libs/mesa[egl(+),gles2]
+	media-libs/mesa[egl(+),gles2(+),opengl]
 	sys-auth/seatd:=
 	virtual/libudev
 	>=x11-libs/libdrm-2.4.114

--- a/gui-libs/wlroots/wlroots-0.17.2.ebuild
+++ b/gui-libs/wlroots/wlroots-0.17.2.ebuild
@@ -29,7 +29,7 @@ REQUIRED_USE="
 DEPEND="
 	>=dev-libs/wayland-1.22.0
 	media-libs/libglvnd
-	media-libs/mesa[egl(+),gles2]
+	media-libs/mesa[egl(+),gles2(+),opengl]
 	>=x11-libs/libdrm-2.4.114
 	x11-libs/libxkbcommon
 	>=x11-libs/pixman-0.42.0

--- a/gui-libs/wlroots/wlroots-0.17.3.ebuild
+++ b/gui-libs/wlroots/wlroots-0.17.3.ebuild
@@ -29,7 +29,7 @@ REQUIRED_USE="
 DEPEND="
 	>=dev-libs/wayland-1.22.0
 	media-libs/libglvnd
-	media-libs/mesa[egl(+),gles2(+)]
+	media-libs/mesa[egl(+),gles2(+),opengl]
 	>=x11-libs/libdrm-2.4.114
 	x11-libs/libxkbcommon
 	>=x11-libs/pixman-0.42.0

--- a/gui-libs/wlroots/wlroots-9999.ebuild
+++ b/gui-libs/wlroots/wlroots-9999.ebuild
@@ -28,7 +28,7 @@ REQUIRED_USE="
 
 DEPEND="
 	>=dev-libs/wayland-1.22.0
-	media-libs/mesa[egl(+),gles2(+)]
+	media-libs/mesa[egl(+),gles2(+),opengl]
 	>=x11-libs/libdrm-2.4.120
 	x11-libs/libxkbcommon
 	>=x11-libs/pixman-0.42.0

--- a/gui-wm/hyprland/hyprland-0.37.1.ebuild
+++ b/gui-wm/hyprland/hyprland-0.37.1.ebuild
@@ -40,7 +40,7 @@ WLROOTS_RDEPEND="
 	>=dev-libs/wayland-1.22
 	media-libs/libdisplay-info
 	media-libs/libglvnd
-	media-libs/mesa[egl(+),gles2]
+	media-libs/mesa[egl(+),gles2(+),opengl]
 	sys-apps/hwdata:=
 	sys-auth/seatd:=
 	>=x11-libs/libdrm-2.4.118

--- a/gui-wm/hyprland/hyprland-0.39.1-r2.ebuild
+++ b/gui-wm/hyprland/hyprland-0.39.1-r2.ebuild
@@ -38,7 +38,7 @@ HYPRPM_RDEPEND="
 WLROOTS_DEPEND="
 	>=dev-libs/wayland-1.22
 	media-libs/libglvnd
-	media-libs/mesa[egl(+),gles2]
+	media-libs/mesa[egl(+),gles2(+),opengl]
 	>=x11-libs/libdrm-2.4.114
 	x11-libs/libxkbcommon
 	>=x11-libs/pixman-0.42.0

--- a/gui-wm/hyprland/hyprland-0.40.0.ebuild
+++ b/gui-wm/hyprland/hyprland-0.40.0.ebuild
@@ -38,8 +38,7 @@ HYPRPM_RDEPEND="
 WLROOTS_DEPEND="
 	>=dev-libs/wayland-1.22
 	media-libs/libglvnd
-	|| ( <media-libs/mesa-24.1[egl(+),gles2]
-		 >=media-libs/mesa-24.1[egl(+)] )
+	media-libs/mesa[egl(+),gles2(+),opengl]
 	>=x11-libs/libdrm-2.4.114
 	x11-libs/libxkbcommon
 	>=x11-libs/pixman-0.42.0

--- a/gui-wm/hyprland/hyprland-9999.ebuild
+++ b/gui-wm/hyprland/hyprland-9999.ebuild
@@ -38,8 +38,7 @@ HYPRPM_RDEPEND="
 WLROOTS_DEPEND="
 	>=dev-libs/wayland-1.22
 	media-libs/libglvnd
-	|| ( <media-libs/mesa-24.1[egl(+),gles2]
-		 >=media-libs/mesa-24.1[egl(+)] )
+	media-libs/mesa[egl(+),gles2(+),opengl]
 	>=x11-libs/libdrm-2.4.114
 	x11-libs/libxkbcommon
 	>=x11-libs/pixman-0.42.0

--- a/gui-wm/sway/sway-1.9.ebuild
+++ b/gui-wm/sway/sway-1.9.ebuild
@@ -34,7 +34,7 @@ DEPEND="
 	>=x11-libs/libxkbcommon-1.5.0:0=
 	x11-libs/pango
 	x11-libs/pixman
-	media-libs/mesa[gles2,libglvnd(+)]
+	media-libs/mesa[gles2(+),opengl,libglvnd(+)]
 	swaybar? ( x11-libs/gdk-pixbuf:2 )
 	tray? ( || (
 		sys-apps/systemd

--- a/gui-wm/sway/sway-9999.ebuild
+++ b/gui-wm/sway/sway-9999.ebuild
@@ -34,7 +34,7 @@ DEPEND="
 	>=x11-libs/libxkbcommon-1.5.0:0=
 	x11-libs/pango
 	x11-libs/pixman
-	media-libs/mesa[gles2,libglvnd(+)]
+	media-libs/mesa[gles2(+),opengl,libglvnd(+)]
 	swaybar? ( x11-libs/gdk-pixbuf:2 )
 	tray? ( || (
 		sys-apps/systemd

--- a/gui-wm/wayfire/wayfire-0.8.0-r1.ebuild
+++ b/gui-wm/wayfire/wayfire-0.8.0-r1.ebuild
@@ -29,7 +29,7 @@ WLROOTS_CDEPEND="
 	>=dev-libs/libinput-1.14.0:=
 	>=dev-libs/wayland-1.21
 	media-libs/libglvnd
-	media-libs/mesa[egl(+),gles2]
+	media-libs/mesa[egl(+),gles2(+),opengl]
 	sys-apps/hwdata:=
 	sys-auth/seatd:=
 	>=x11-libs/libdrm-2.4.114:=

--- a/gui-wm/wayfire/wayfire-0.8.0-r2.ebuild
+++ b/gui-wm/wayfire/wayfire-0.8.0-r2.ebuild
@@ -29,7 +29,7 @@ WLROOTS_CDEPEND="
 	>=dev-libs/libinput-1.14.0:=
 	>=dev-libs/wayland-1.21
 	media-libs/libglvnd
-	media-libs/mesa[egl(+),gles2]
+	media-libs/mesa[egl(+),gles2(+),opengl]
 	sys-apps/hwdata:=
 	sys-auth/seatd:=
 	>=x11-libs/libdrm-2.4.114:=

--- a/kde-plasma/kinfocenter/kinfocenter-5.27.11.ebuild
+++ b/kde-plasma/kinfocenter/kinfocenter-5.27.11.ebuild
@@ -35,7 +35,7 @@ DEPEND="
 	>=kde-frameworks/kservice-${KFMIN}:5
 	>=kde-frameworks/kwidgetsaddons-${KFMIN}:5
 	>=kde-frameworks/solid-${KFMIN}:5
-	gles2-only? ( media-libs/mesa[gles2] )
+	gles2-only? ( media-libs/mesa[gles2(+),opengl] )
 	usb? ( virtual/libusb:1 )
 "
 RDEPEND="${DEPEND}

--- a/kde-plasma/kinfocenter/kinfocenter-6.0.4.ebuild
+++ b/kde-plasma/kinfocenter/kinfocenter-6.0.4.ebuild
@@ -30,7 +30,7 @@ DEPEND="
 	>=kde-frameworks/kservice-${KFMIN}:6
 	>=kde-frameworks/kwidgetsaddons-${KFMIN}:6
 	>=kde-frameworks/solid-${KFMIN}:6
-	gles2-only? ( media-libs/mesa[gles2] )
+	gles2-only? ( media-libs/mesa[gles2(+),opengl] )
 	usb? ( virtual/libusb:1 )
 "
 RDEPEND="${DEPEND}

--- a/kde-plasma/kwin/kwin-5.27.11.ebuild
+++ b/kde-plasma/kwin/kwin-5.27.11.ebuild
@@ -68,7 +68,7 @@ COMMON_DEPEND="
 	x11-libs/xcb-util-keysyms
 	x11-libs/xcb-util-wm
 	accessibility? ( media-libs/libqaccessibilityclient:5 )
-	gles2-only? ( media-libs/mesa[gles2] )
+	gles2-only? ( media-libs/mesa[gles2(+),opengl] )
 	lock? ( >=kde-plasma/kscreenlocker-${PVCUT}:5 )
 	plasma? ( >=kde-frameworks/krunner-${KFMIN}:5 )
 	screencast? ( >=media-video/pipewire-0.3:= )

--- a/kde-plasma/kwin/kwin-6.0.4.1.ebuild
+++ b/kde-plasma/kwin/kwin-6.0.4.1.ebuild
@@ -71,7 +71,7 @@ COMMON_DEPEND="
 	x11-libs/xcb-util-keysyms
 	x11-libs/xcb-util-wm
 	accessibility? ( media-libs/libqaccessibilityclient:6 )
-	gles2-only? ( media-libs/mesa[gles2] )
+	gles2-only? ( media-libs/mesa[gles2(+),opengl] )
 	lock? ( >=kde-plasma/kscreenlocker-${PVCUT}:6 )
 	screencast? ( >=media-video/pipewire-0.3:= )
 	shortcuts? ( >=kde-plasma/kglobalacceld-${PVCUT}:6 )

--- a/mate-base/mate-session-manager/mate-session-manager-1.26.1.ebuild
+++ b/mate-base/mate-session-manager/mate-session-manager-1.26.1.ebuild
@@ -36,7 +36,7 @@ COMMON_DEPEND="
 	x11-libs/libXrender
 	x11-libs/libXtst
 	x11-libs/pango
-	gles2? ( media-libs/mesa[egl(+),gles2] )
+	gles2? ( media-libs/mesa[egl(+),gles2(+),opengl] )
 	systemd? ( sys-apps/systemd )
 	elogind? ( sys-auth/elogind )
 "

--- a/mate-base/mate-session-manager/mate-session-manager-1.28.0.ebuild
+++ b/mate-base/mate-session-manager/mate-session-manager-1.28.0.ebuild
@@ -36,7 +36,7 @@ COMMON_DEPEND="
 	x11-libs/libXrender
 	x11-libs/libXtst
 	x11-libs/pango
-	gles2? ( media-libs/mesa[egl(+),gles2] )
+	gles2? ( media-libs/mesa[egl(+),gles2(+),opengl] )
 	systemd? ( sys-apps/systemd )
 	elogind? ( sys-auth/elogind )
 "

--- a/media-libs/cogl/cogl-1.22.8-r2.ebuild
+++ b/media-libs/cogl/cogl-1.22.8-r2.ebuild
@@ -36,7 +36,7 @@ DEPEND="
 	>=x11-libs/libXfixes-3
 	>=x11-libs/libXrandr-1.2
 	virtual/opengl
-	gles2? ( media-libs/mesa[gles2] )
+	gles2? ( media-libs/mesa[gles2(+),opengl] )
 	gstreamer? (
 		media-libs/gstreamer:1.0
 		media-libs/gst-plugins-base:1.0

--- a/media-libs/gst-plugins-base/gst-plugins-base-1.22.11.ebuild
+++ b/media-libs/gst-plugins-base/gst-plugins-base-1.22.11.ebuild
@@ -43,7 +43,7 @@ REQUIRED_USE="
 # Dependencies needed by opengl library and plugin (enabled via USE gles2 and/or opengl)
 # dmabuf automagic from libdrm headers (drm_fourcc.h) and EGL, so ensure it with USE=egl (platform independent header used only, thus no MULTILIB_USEDEP); provides dmabuf based upload/download/eglimage options
 GL_DEPS="
-	>=media-libs/mesa-9.0[egl(+)?,gbm(+)?,gles2?,wayland?,${MULTILIB_USEDEP}]
+	>=media-libs/mesa-9.0[egl(+)?,gbm(+)?,gles2(+)?,opengl,wayland?,${MULTILIB_USEDEP}]
 	egl? (
 		x11-libs/libdrm
 	)

--- a/media-libs/libprojectm/libprojectm-3.1.12.ebuild
+++ b/media-libs/libprojectm/libprojectm-3.1.12.ebuild
@@ -26,7 +26,7 @@ REQUIRED_USE="
 	pulseaudio? ( qt5 )
 "
 
-RDEPEND="gles2? ( media-libs/mesa[gles2] )
+RDEPEND="gles2? ( media-libs/mesa[gles2(+),opengl] )
 	media-libs/glm
 	media-libs/mesa[X(+)]
 	jack? (

--- a/media-plugins/gst-plugins-vaapi/gst-plugins-vaapi-1.22.11.ebuild
+++ b/media-plugins/gst-plugins-vaapi/gst-plugins-vaapi-1.22.11.ebuild
@@ -44,7 +44,7 @@ REQUIRED_USE="
 GST_REQ="${PV}"
 GL_DEPS="
 	>=media-libs/gst-plugins-base-${GST_REQ}:${SLOT}[egl?,gles2?,opengl?,wayland?,X?]
-	media-libs/mesa[gles2?,egl(+)?,X?,${MULTILIB_USEDEP}]
+	media-libs/mesa[gles2(+)?,opengl,egl(+)?,X?,${MULTILIB_USEDEP}]
 "
 RDEPEND="
 	>=media-libs/gst-plugins-base-${GST_REQ}:${SLOT}[${MULTILIB_USEDEP}]

--- a/media-tv/kodi/kodi-19.5-r1.ebuild
+++ b/media-tv/kodi/kodi-19.5-r1.ebuild
@@ -97,7 +97,7 @@ COMMON_TARGET_DEPEND="${PYTHON_DEPS}
 		x11-libs/libxkbcommon
 	)
 	gles? (
-		!raspberry-pi? ( media-libs/mesa[gles2] )
+		!raspberry-pi? ( media-libs/mesa[gles2(+),opengl] )
 	)
 	lcms? ( media-libs/lcms:2 )
 	libusb? ( virtual/libusb:1 )
@@ -122,7 +122,7 @@ COMMON_TARGET_DEPEND="${PYTHON_DEPS}
 	!gles? ( media-libs/glu )
 	>=dev-libs/openssl-1.1.1k:0=
 	raspberry-pi? (
-		|| ( media-libs/raspberrypi-userland media-libs/raspberrypi-userland-bin media-libs/mesa[egl(+),gles2,video_cards_vc4] )
+		|| ( media-libs/raspberrypi-userland media-libs/raspberrypi-userland-bin media-libs/mesa[egl(+),gles2(+),opengl,video_cards_vc4] )
 	)
 	pulseaudio? ( media-sound/pulseaudio )
 	samba? ( >=net-fs/samba-3.4.6[smbclient(+)] )

--- a/media-tv/kodi/kodi-20.3.ebuild
+++ b/media-tv/kodi/kodi-20.3.ebuild
@@ -149,7 +149,7 @@ COMMON_TARGET_DEPEND="${PYTHON_DEPS}
 	)
 	gles? (
 		!raspberry-pi? (
-			media-libs/mesa[gles2]
+			media-libs/mesa[gles2(+),opengl]
 		)
 	)
 	!gles? (
@@ -183,7 +183,7 @@ COMMON_TARGET_DEPEND="${PYTHON_DEPS}
 		|| (
 			media-libs/raspberrypi-userland
 			media-libs/raspberrypi-userland-bin
-			media-libs/mesa[gles2,video_cards_vc4]
+			media-libs/mesa[gles2(+),opengl,video_cards_vc4]
 		)
 	)
 	samba? (

--- a/media-tv/kodi/kodi-20.5.ebuild
+++ b/media-tv/kodi/kodi-20.5.ebuild
@@ -149,7 +149,7 @@ COMMON_TARGET_DEPEND="${PYTHON_DEPS}
 	)
 	gles? (
 		!raspberry-pi? (
-			media-libs/mesa[gles2]
+			media-libs/mesa[gles2(+),opengl]
 		)
 	)
 	!gles? (
@@ -183,7 +183,7 @@ COMMON_TARGET_DEPEND="${PYTHON_DEPS}
 		|| (
 			media-libs/raspberrypi-userland
 			media-libs/raspberrypi-userland-bin
-			media-libs/mesa[gles2,video_cards_vc4]
+			media-libs/mesa[gles2(+),opengl,video_cards_vc4]
 		)
 	)
 	samba? (

--- a/media-tv/kodi/kodi-21.0.ebuild
+++ b/media-tv/kodi/kodi-21.0.ebuild
@@ -159,7 +159,7 @@ COMMON_TARGET_DEPEND="${PYTHON_DEPS}
 		x11-libs/libxkbcommon
 	)
 	gles? (
-		media-libs/mesa[gles2]
+		media-libs/mesa[gles2(+),opengl]
 	)
 	!gles? (
 		media-libs/glu

--- a/media-tv/kodi/kodi-21.9999.ebuild
+++ b/media-tv/kodi/kodi-21.9999.ebuild
@@ -159,7 +159,7 @@ COMMON_TARGET_DEPEND="${PYTHON_DEPS}
 		x11-libs/libxkbcommon
 	)
 	gles? (
-		media-libs/mesa[gles2]
+		media-libs/mesa[gles2(+),opengl]
 	)
 	!gles? (
 		media-libs/glu

--- a/media-tv/kodi/kodi-9999.ebuild
+++ b/media-tv/kodi/kodi-9999.ebuild
@@ -159,7 +159,7 @@ COMMON_TARGET_DEPEND="${PYTHON_DEPS}
 		x11-libs/libxkbcommon
 	)
 	gles? (
-		media-libs/mesa[gles2]
+		media-libs/mesa[gles2(+),opengl]
 	)
 	!gles? (
 		media-libs/glu

--- a/sys-apps/kmscon/kmscon-9.0.0.ebuild
+++ b/sys-apps/kmscon/kmscon-9.0.0.ebuild
@@ -23,7 +23,7 @@ COMMON_DEPEND="
 	media-libs/mesa[X(+)]
 	drm? ( x11-libs/libdrm
 		>=media-libs/mesa-8.0.3[egl(+),gbm(+)] )
-	gles2? ( >=media-libs/mesa-8.0.3[gles2] )
+	gles2? ( >=media-libs/mesa-8.0.3[gles2(+),opengl] )
 	systemd? ( sys-apps/systemd )
 	pango? ( x11-libs/pango dev-libs/glib:2 )
 	pixman? ( x11-libs/pixman )"

--- a/www-plugins/lightspark/lightspark-0.8.6.1.ebuild
+++ b/www-plugins/lightspark/lightspark-0.8.6.1.ebuild
@@ -35,7 +35,7 @@ RDEPEND="
 	x11-libs/pango
 	curl? ( net-misc/curl:= )
 	ffmpeg? ( media-video/ffmpeg:= )
-	gles2-only? ( media-libs/mesa:=[gles2] )
+	gles2-only? ( media-libs/mesa:=[gles2(+),opengl] )
 	!gles2-only? (
 		>=media-libs/glew-1.5.3:=
 		virtual/opengl:0=

--- a/www-plugins/lightspark/lightspark-0.8.7.ebuild
+++ b/www-plugins/lightspark/lightspark-0.8.7.ebuild
@@ -34,7 +34,7 @@ RDEPEND="
 	x11-libs/pango
 	curl? ( net-misc/curl:= )
 	ffmpeg? ( media-video/ffmpeg:= )
-	gles2-only? ( media-libs/mesa:=[gles2] )
+	gles2-only? ( media-libs/mesa:=[gles2(+),opengl] )
 	!gles2-only? (
 		>=media-libs/glew-1.5.3:=
 		virtual/opengl:0=

--- a/x11-apps/mesa-progs/mesa-progs-8.5.0.ebuild
+++ b/x11-apps/mesa-progs/mesa-progs-8.5.0.ebuild
@@ -24,7 +24,7 @@ SLOT="0"
 IUSE="gles2 wayland X"
 
 RDEPEND="
-	media-libs/mesa[${MULTILIB_USEDEP},egl(+),gles2?,wayland?,X?]
+	media-libs/mesa[${MULTILIB_USEDEP},egl(+),gles2(+)?,opengl,wayland?,X?]
 	wayland? ( dev-libs/wayland[${MULTILIB_USEDEP}] )
 	X? (
 		x11-libs/libX11[${MULTILIB_USEDEP}]

--- a/x11-wm/muffin/muffin-6.0.1.ebuild
+++ b/x11-wm/muffin/muffin-6.0.1.ebuild
@@ -74,7 +74,7 @@ COMDEPEND="
 		>=dev-libs/libinput-1.7:=
 		>=dev-libs/wayland-1.13.0
 		>=dev-libs/wayland-protocols-1.19
-		media-libs/mesa[gbm(+),gles2]
+		media-libs/mesa[gbm(+),gles2(+),opengl]
 		x11-base/xwayland
 		x11-libs/libdrm
 


### PR DESCRIPTION
Fixes builds with a bunch of packages when mesa does not have the gles2 use flag (currently only mesa-9999)
see bug #929992
see commit https://github.com/gentoo/gentoo/commit/847bd6034a9b3d885de3419a53084595bef9e8ac

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
