### PR TITLE
app-crypt/swtpm: Fix build with slibtool

### DIFF
--- a/app-crypt/swtpm/files/swtpm-0.8.2-slibtool.patch
+++ b/app-crypt/swtpm/files/swtpm-0.8.2-slibtool.patch
@@ -1,0 +1,24 @@
+diff --git a/src/swtpm_localca/Makefile.am b/src/swtpm_localca/Makefile.am
+index 74532a8..41b61ec 100644
+--- a/src/swtpm_localca/Makefile.am
++++ b/src/swtpm_localca/Makefile.am
+@@ -30,7 +30,6 @@ swtpm_localca_LDADD = \
+ 	$(top_builddir)/src/utils/libswtpm_utils.la
+ 
+ swtpm_localca_LDFLAGS = \
+-	-L$(top_builddir)/src/utils -lswtpm_utils \
+ 	$(MY_LDFLAGS) \
+ 	$(GLIB_LIBS) \
+ 	$(GMP_LIBS) \
+diff --git a/src/swtpm_setup/Makefile.am b/src/swtpm_setup/Makefile.am
+index c0f916b..61188c9 100644
+--- a/src/swtpm_setup/Makefile.am
++++ b/src/swtpm_setup/Makefile.am
+@@ -32,7 +32,6 @@ swtpm_setup_LDADD = \
+ 	$(top_builddir)/src/utils/libswtpm_utils.la
+ 
+ swtpm_setup_LDFLAGS = \
+-	-L$(top_builddir)/src/utils -lswtpm_utils \
+ 	$(MY_LDFLAGS) \
+ 	$(HARDENING_LDFLAGS) \
+ 	$(GLIB_LIBS) \

--- a/app-crypt/swtpm/swtpm-0.8.2.ebuild
+++ b/app-crypt/swtpm/swtpm-0.8.2.ebuild
@@ -46,6 +46,7 @@ BDEPEND="${PYTHON_DEPS}"
 PATCHES=(
 	"${FILESDIR}/${PN}-0.6.0-fix-localca-path.patch"
 	"${FILESDIR}/${PN}-0.5.0-build-sys-Remove-WError.patch"
+	"${FILESDIR}/${PN}-0.8.2-slibtool.patch"
 )
 
 src_prepare() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/931269

I'm not an autotools/libtool expert. The patch does work, but I'm not sure if it right. I do believe the deleted lines were extraneous, but I can't rule out a bug in slibtool.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
