### PR TITLE
games-strategy/xbattleai: Port to C99, update EAPI 7 -> 8

### DIFF
--- a/games-strategy/xbattleai/files/xbattleai-1.2.2-C99.patch
+++ b/games-strategy/xbattleai/files/xbattleai-1.2.2-C99.patch
@@ -1,0 +1,43 @@
+https://bugs.gentoo.org/882271
+Also change to automake file as consequence of eautoreconf
+--- a/Makefile.in	2024-05-10 09:49:47.696279770 -0000
++++ b/Makefile.in	2024-05-10 09:50:14.532113463 -0000
+@@ -144,13 +144,13 @@
+ .PHONY: config
+ config: ${SRC_DIR}/Makefile ${SRC_DIR}/config.h
+ 
+-${SRC_DIR}/configure: ${SRC_DIR}/configure.in
++${SRC_DIR}/configure: ${SRC_DIR}/configure.ac
+ 	@${ECHO} "The configure script is out of date; rebuilding..."
+ 	autoconf
+ 	@${ECHO} >> ${SRC_DIR}/config.h.in
+ 	@${ECHO} >> $@
+ 
+-${SRC_DIR}/config.h.in: ${SRC_DIR}/configure.in
++${SRC_DIR}/config.h.in: ${SRC_DIR}/configure.ac
+ 	@${ECHO} "The config.h.in header is out of date; rebuilding..."
+ 	autoheader
+ 	@${ECHO} >> $@
+--- a/sound.c	2024-05-10 09:53:25.753928428 -0000
++++ b/sound.c	2024-05-10 09:54:18.646600643 -0000
+@@ -51,6 +51,8 @@
+ #ifdef HAVE_LINUX_SOUNDCARD_H
+ # include <linux/soundcard.h>
+ #endif
++
++#include <sys/ioctl.h>
+ #include "extern.h"
+ #include "options2.h"
+ #include "constant.h"
+--- a/victory.c	2024-05-10 09:53:25.752928434 -0000
++++ b/victory.c	2024-05-10 09:55:09.470285679 -0000
+@@ -7,6 +7,9 @@
+ # include <stdlib.h>
+ #endif
+ 
++#include <string.h>
++#include <unistd.h>
++
+ #include "constant.h"
+ #include "extern.h"
+ 

--- a/games-strategy/xbattleai/xbattleai-1.2.2-r3.ebuild
+++ b/games-strategy/xbattleai/xbattleai-1.2.2-r3.ebuild
@@ -1,0 +1,52 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs autotools
+
+DESCRIPTION="A multi-player game of strategy and coordination"
+HOMEPAGE="https://inf.ug.edu.pl/~piotao/xbattle/mirror/www.lysator.liu.se/XBattleAI/"
+SRC_URI="https://inf.ug.edu.pl/~piotao/xbattle/mirror/www.lysator.liu.se/XBattleAI/${P}.tgz"
+
+LICENSE="xbattle"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+# Since this uses similar code and the same binary name as the original XBattle,
+# we want to make sure you can't install both at the same time
+RDEPEND="
+	dev-lang/tcl:0
+	dev-lang/tk:0
+	x11-libs/libX11
+	x11-libs/libXext
+"
+DEPEND="
+	${RDEPEND}
+	x11-base/xorg-proto
+"
+BDEPEND="
+	app-text/rman
+	x11-misc/imake
+"
+
+DOCS=( CONTRIBUTORS README README.AI TODO xbattle.dot )
+
+PATCHES=(
+	"${FILESDIR}"/${P}-sandbox.patch
+	"${FILESDIR}"/${P}-C99.patch
+)
+
+src_prepare() {
+	default
+	rm -f xbcs/foo.xbc~ || die
+	rm config.cache || die
+
+	tc-export CC
+	eautoreconf
+}
+
+src_install() {
+	default
+	mv "${ED}/usr/bin/"{,xb_}gauntletCampaign || die
+}

--- a/games-strategy/xbattleai/xbattleai-1.2.2-r3.ebuild
+++ b/games-strategy/xbattleai/xbattleai-1.2.2-r3.ebuild
@@ -6,8 +6,8 @@ EAPI=8
 inherit toolchain-funcs autotools
 
 DESCRIPTION="A multi-player game of strategy and coordination"
-HOMEPAGE="https://inf.ug.edu.pl/~piotao/xbattle/mirror/www.lysator.liu.se/XBattleAI/"
-SRC_URI="https://inf.ug.edu.pl/~piotao/xbattle/mirror/www.lysator.liu.se/XBattleAI/${P}.tgz"
+HOMEPAGE="https://inf.ug.edu.pl/~piotao/zasoby/xbattle/mirror/www.lysator.liu.se/XBattleAI/"
+SRC_URI="https://inf.ug.edu.pl/~piotao/zasoby/xbattle/mirror/www.lysator.liu.se/XBattleAI/${P}.tgz"
 
 LICENSE="xbattle"
 SLOT="0"


### PR DESCRIPTION
Autoreconf fixes configuration failure due to C99 error, includes are added unconditionally, because we now live in sane, homogenous world, those are system files that ought to be on by default on any linux system with libc and I don't want to touch autoconfig files any more than what I need to.

Closes: https://bugs.gentoo.org/882271

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
