### PR TITLE
app-shells/bash-completion: disable py3.13

### DIFF
--- a/app-shells/bash-completion/bash-completion-2.14.0.ebuild
+++ b/app-shells/bash-completion/bash-completion-2.14.0.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 BASHCOMP_P=bashcomp-2.0.3
-PYTHON_COMPAT=( python3_{10..13} )
+PYTHON_COMPAT=( python3_{10..12} )
 
 inherit python-any-r1
 


### PR DESCRIPTION
* To add a target that isn't supported by bash-completions you have first modify the completions file to add the new target and symlink it.
* Symlinking is incorrectly done currently as dosym adds D already.

Closes: https://bugs.gentoo.org/931665

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
