### PR TITLE
net-mail/automx2: upgrade to Python 3.12

### DIFF
--- a/net-mail/automx2/automx2-2022.1-r1.ebuild
+++ b/net-mail/automx2/automx2-2022.1-r1.ebuild
@@ -1,0 +1,46 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DISTUTILS_USE_PEP517=setuptools
+PYTHON_COMPAT=( python3_{11,12} )
+
+inherit distutils-r1
+
+DESCRIPTION="Email client autoconfiguration service"
+HOMEPAGE="https://rseichter.github.io/automx2/"
+SRC_URI="https://github.com/rseichter/automx2/archive/${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="GPL-3+"
+SLOT="0"
+KEYWORDS="~amd64"
+
+RDEPEND="acct-user/automx2
+	dev-python/flask[${PYTHON_USEDEP}]
+	dev-python/flask-migrate[${PYTHON_USEDEP}]
+	dev-python/flask-sqlalchemy[${PYTHON_USEDEP}]
+	dev-python/ldap3[${PYTHON_USEDEP}]
+"
+
+distutils_enable_tests unittest
+
+python_prepare_all() {
+	sed -i -e "/('scripts'/d" setup.py || die
+	distutils-r1_python_prepare_all
+}
+
+python_test() {
+	local -x AUTOMX2_CONF="tests/unittest.conf"
+	eunittest tests/
+}
+
+python_install_all() {
+	local DOCS=( "${S}"/docs/*.adoc "${S}"/contrib/*sample.conf )
+	local HTML_DOCS=( "${S}"/docs/*.{html,svg} )
+	newconfd "${FILESDIR}/confd" "${PN}"
+	newinitd "${FILESDIR}/init-r1" "${PN}"
+	insinto /etc
+	newins "${FILESDIR}/conf" "${PN}.conf"
+	distutils-r1_python_install_all
+}

--- a/net-mail/automx2/metadata.xml
+++ b/net-mail/automx2/metadata.xml
@@ -10,7 +10,7 @@
 		(autoconfig) in one tool.
 	</longdescription>
 	<upstream>
-		<doc>https://github.com/rseichter/automx2/blob/master/doc/automx2.pdf</doc>
+		<doc>https://rseichter.github.io/automx2/</doc>
 		<maintainer>
 			<email>automx2@seichter.de</email>
 			<name>Ralph Seichter</name>


### PR DESCRIPTION
- Support Python version 3.12 in ebuild.
- Fix documentation URLs.

Closes: https://bugs.gentoo.org/929715

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
