### PR TITLE
app-text/yelp-tools: enable py3.12

### DIFF
--- a/app-text/yelp-tools/yelp-tools-42.1.ebuild
+++ b/app-text/yelp-tools/yelp-tools-42.1.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..12} )
 inherit gnome2 meson python-single-r1
 
 DESCRIPTION="Collection of tools for building and converting documentation"


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/929371

Tested with py3.12, need it for net-nntp/pan (which is in GURU for now)

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
