### PR TITLE
sys-apps/iproute2: fix compilation on musl-based systems with modern C (C99)

### DIFF
--- a/sys-apps/iproute2/files/iproute2-6.6.0-musl-c99.patch
+++ b/sys-apps/iproute2/files/iproute2-6.6.0-musl-c99.patch
@@ -1,0 +1,75 @@
+From 12416003e4c691afc732d26f0a07c3890c24b396 Mon Sep 17 00:00:00 2001
+From: Gabi Falk <gabifalk@gmx.com>
+Date: Fri, 10 May 2024 14:36:12 +0000
+Subject: [PATCH] bridge/vlan.c: bridge/vlan.c: fix build with gcc 14 on musl
+ systems
+
+On glibc based systems the definition of 'struct timeval' is pulled in
+with inclusion of <stdlib.h> header, but on musl based systems it
+doesn't work this way.  Missing definition triggers an
+incompatible-pointer-types error with gcc 14 (warning on previous
+versions of gcc):
+
+../include/json_print.h:80:30: warning: 'struct timeval' declared inside parameter list will not be visible outside of this definition or declaration
+   80 | _PRINT_FUNC(tv, const struct timeval *)
+      |                              ^~~~~~~
+../include/json_print.h:50:37: note: in definition of macro '_PRINT_FUNC'
+   50 |                                     type value);                        \
+      |                                     ^~~~
+../include/json_print.h:80:30: warning: 'struct timeval' declared inside parameter list will not be visible outside of this definition or declaration
+   80 | _PRINT_FUNC(tv, const struct timeval *)
+      |                              ^~~~~~~
+../include/json_print.h:55:45: note: in definition of macro '_PRINT_FUNC'
+   55 |                                             type value)                 \
+      |                                             ^~~~
+../include/json_print.h: In function 'print_tv':
+../include/json_print.h:58:48: error: passing argument 5 of 'print_color_tv' from incompatible pointer type [-Wincompatible-pointer-types]
+   58 |                                                value);                  \
+      |                                                ^~~~~
+      |                                                |
+      |                                                const struct timeval *
+
+Link: https://lore.kernel.org/netdev/20240510143613.1531283-1-gabifalk@gmx.com/T/#u
+Signed-off-by: Gabi Falk <gabifalk@gmx.com>
+---
+ bridge/vlan.c | 1 +
+ bridge/vni.c  | 1 +
+ vdpa/vdpa.c   | 1 +
+ 3 files changed, 3 insertions(+)
+
+diff --git a/bridge/vlan.c b/bridge/vlan.c
+index 5352eb24..0a7e6c45 100644
+--- a/bridge/vlan.c
++++ b/bridge/vlan.c
+@@ -4,6 +4,7 @@
+ #include <unistd.h>
+ #include <fcntl.h>
+ #include <sys/socket.h>
++#include <sys/time.h>
+ #include <net/if.h>
+ #include <netinet/in.h>
+ #include <linux/if_bridge.h>
+diff --git a/bridge/vni.c b/bridge/vni.c
+index a7abe6de..e1f981fc 100644
+--- a/bridge/vni.c
++++ b/bridge/vni.c
+@@ -10,6 +10,7 @@
+ #include <string.h>
+ #include <fcntl.h>
+ #include <sys/socket.h>
++#include <sys/time.h>
+ #include <net/if.h>
+ #include <netinet/in.h>
+ #include <linux/if_link.h>
+diff --git a/vdpa/vdpa.c b/vdpa/vdpa.c
+index 6e4a9c11..43f87824 100644
+--- a/vdpa/vdpa.c
++++ b/vdpa/vdpa.c
+@@ -3,6 +3,7 @@
+ #include <stdio.h>
+ #include <getopt.h>
+ #include <errno.h>
++#include <sys/time.h>
+ #include <linux/genetlink.h>
+ #include <linux/if_ether.h>
+ #include <linux/vdpa.h>

--- a/sys-apps/iproute2/iproute2-6.6.0-r1.ebuild
+++ b/sys-apps/iproute2/iproute2-6.6.0-r1.ebuild
@@ -53,6 +53,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-5.7.0-mix-signal.h-include.patch
 	"${FILESDIR}"/${PN}-6.4.0-disable-libbsd-fallback.patch # bug #911727
 	"${FILESDIR}"/${PN}-6.6.0-configure-Add-_GNU_SOURCE-to-strlcpy-configure-test.patch
+	"${FILESDIR}"/${PN}-6.6.0-musl-c99.patch # bug #922622
 )
 
 src_prepare() {

--- a/sys-apps/iproute2/iproute2-6.6.0-r3.ebuild
+++ b/sys-apps/iproute2/iproute2-6.6.0-r3.ebuild
@@ -55,6 +55,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-6.6.0-configure-Add-_GNU_SOURCE-to-strlcpy-configure-test.patch
 	"${FILESDIR}"/${PN}-6.6.0-revert-CONF_USR_DIR.patch
 	"${FILESDIR}"/${PN}-6.6.0-makefile-use-usr-share-config.patch
+	"${FILESDIR}"/${PN}-6.6.0-musl-c99.patch # bug #922622
 )
 
 src_prepare() {

--- a/sys-apps/iproute2/iproute2-6.6.0.ebuild
+++ b/sys-apps/iproute2/iproute2-6.6.0.ebuild
@@ -52,6 +52,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-6.5.0-configure-nomagic-nolibbsd.patch # bug #643722 & #911727
 	"${FILESDIR}"/${PN}-5.7.0-mix-signal.h-include.patch
 	"${FILESDIR}"/${PN}-6.4.0-disable-libbsd-fallback.patch # bug #911727
+	"${FILESDIR}"/${PN}-6.6.0-musl-c99.patch # bug #922622
 )
 
 src_prepare() {

--- a/sys-apps/iproute2/iproute2-6.8.0-r2.ebuild
+++ b/sys-apps/iproute2/iproute2-6.8.0-r2.ebuild
@@ -52,6 +52,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-6.8.0-configure-nomagic-nolibbsd.patch # bug #643722 & #911727
 	"${FILESDIR}"/${PN}-5.7.0-mix-signal.h-include.patch
 	"${FILESDIR}"/${PN}-6.8.0-disable-libbsd-fallback.patch # bug #911727
+	"${FILESDIR}"/${PN}-6.6.0-musl-c99.patch # bug #922622
 )
 
 src_prepare() {

--- a/sys-apps/iproute2/iproute2-9999.ebuild
+++ b/sys-apps/iproute2/iproute2-9999.ebuild
@@ -52,6 +52,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-6.8.0-configure-nomagic-nolibbsd.patch # bug #643722 & #911727
 	"${FILESDIR}"/${PN}-5.7.0-mix-signal.h-include.patch
 	"${FILESDIR}"/${PN}-6.8.0-disable-libbsd-fallback.patch # bug #911727
+	"${FILESDIR}"/${PN}-6.6.0-musl-c99.patch # bug #922622
 )
 
 src_prepare() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/922622

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.