### PR TITLE
x11-base/xorg-server: backport upstream patch to port to modern C (C99)

### DIFF
--- a/x11-base/xorg-server/files/xorg-server-21.1.10-fix-c99-32bit.patch
+++ b/x11-base/xorg-server/files/xorg-server-21.1.10-fix-c99-32bit.patch
@@ -1,0 +1,54 @@
+https://bugs.gentoo.org/925876
+https://gitlab.freedesktop.org/xorg/xserver/-/commit/e89edec497bac581ca9b614fb00c25365580f045
+
+From e89edec497bac581ca9b614fb00c25365580f045 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jos=C3=A9=20Exp=C3=B3sito?= <jexposit@redhat.com>
+Date: Fri, 19 Jan 2024 13:05:51 +0100
+Subject: [PATCH] ephyr: Fix incompatible pointer type build error
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Fix a compilation error on 32 bits architectures with gcc 14:
+
+  ephyr_glamor_xv.c: In function ‘ephyr_glamor_xv_init’:
+  ephyr_glamor_xv.c:154:31: error: assignment to ‘SetPortAttributeFuncPtr’ {aka ‘int (*)(struct _KdScreenInfo *, long unsigned int,  int,  void *)’} from incompatible pointer type ‘int (*)(KdScreenInfo *, Atom,  INT32,  void *)’ {aka ‘int (*)(struct _KdScreenInfo *, long unsigned int,  long int,  void *)’} [-Wincompatible-pointer-types]
+    154 |     adaptor->SetPortAttribute = ephyr_glamor_xv_set_port_attribute;
+        |                               ^
+  ephyr_glamor_xv.c:155:31: error: assignment to ‘GetPortAttributeFuncPtr’ {aka ‘int (*)(struct _KdScreenInfo *, long unsigned int,  int *, void *)’} from incompatible pointer type ‘int (*)(KdScreenInfo *, Atom,  INT32 *, void *)’ {aka ‘int (*)(struct _KdScreenInfo *, long unsigned int,  long int *, void *)’} [-Wincompatible-pointer-types]
+    155 |     adaptor->GetPortAttribute = ephyr_glamor_xv_get_port_attribute;
+        |                               ^
+
+Build error logs:
+https://koji.fedoraproject.org/koji/taskinfo?taskID=111964273
+
+Signed-off-by: José Expósito <jexposit@redhat.com>
+---
+ hw/kdrive/ephyr/ephyr_glamor_xv.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/hw/kdrive/ephyr/ephyr_glamor_xv.c b/hw/kdrive/ephyr/ephyr_glamor_xv.c
+index 4dd15cf41..b5eae48c8 100644
+--- a/hw/kdrive/ephyr/ephyr_glamor_xv.c
++++ b/hw/kdrive/ephyr/ephyr_glamor_xv.c
+@@ -50,16 +50,16 @@ ephyr_glamor_xv_stop_video(KdScreenInfo *screen, void *data, Bool cleanup)
+ 
+ static int
+ ephyr_glamor_xv_set_port_attribute(KdScreenInfo *screen,
+-                                   Atom attribute, INT32 value, void *data)
++                                   Atom attribute, int value, void *data)
+ {
+-    return glamor_xv_set_port_attribute(data, attribute, value);
++    return glamor_xv_set_port_attribute(data, attribute, (INT32)value);
+ }
+ 
+ static int
+ ephyr_glamor_xv_get_port_attribute(KdScreenInfo *screen,
+-                                   Atom attribute, INT32 *value, void *data)
++                                   Atom attribute, int *value, void *data)
+ {
+-    return glamor_xv_get_port_attribute(data, attribute, value);
++    return glamor_xv_get_port_attribute(data, attribute, (INT32 *)value);
+ }
+ 
+ static void

--- a/x11-base/xorg-server/xorg-server-21.1.13.ebuild
+++ b/x11-base/xorg-server/xorg-server-21.1.13.ebuild
@@ -104,6 +104,8 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-1.18-support-multiple-Files-sections.patch
 	# pending upstream backport, bug #885763
 	"${FILESDIR}"/${PN}-21.1.10-c99.patch
+	# backport of upstream commit, bug #925876
+	"${FILESDIR}"/${PN}-21.1.10-fix-c99-32bit.patch
 )
 
 src_configure() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/925876
Link: https://gitlab.freedesktop.org/xorg/xserver/-/commit/e89edec497bac581ca9b614fb00c25365580f045

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
