### PR TITLE
media-libs/lv2: enable py3.12, disable broken test

### DIFF
--- a/media-libs/lv2/lv2-1.18.10-r1.ebuild
+++ b/media-libs/lv2/lv2-1.18.10-r1.ebuild
@@ -1,0 +1,87 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_REQ_USE='threads(+)'
+
+inherit meson-multilib python-single-r1
+
+DESCRIPTION="A simple but extensible successor of LADSPA"
+HOMEPAGE="https://lv2plug.in/"
+SRC_URI="https://lv2plug.in/spec/${P}.tar.xz"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~mips ~ppc ~ppc64 ~riscv ~sparc ~x86"
+IUSE="doc plugins test"
+RESTRICT="!test? ( test )"
+REQUIRED_USE="${PYTHON_REQUIRED_USE}"
+
+BDEPEND="
+	plugins? ( virtual/pkgconfig )
+	doc? (
+		app-text/doxygen
+		dev-python/rdflib
+	)
+	test? (
+		dev-libs/sord[tools]
+		dev-python/rdflib
+	)
+"
+CDEPEND="
+	${PYTHON_DEPS}
+	plugins? (
+		media-libs/libsamplerate
+		media-libs/libsndfile
+		x11-libs/gtk+:2[${MULTILIB_USEDEP}]
+	)
+"
+DEPEND="
+	${CDEPEND}
+	doc? ( dev-python/markdown )
+"
+RDEPEND="
+	${CDEPEND}
+	$(python_gen_cond_dep '
+		dev-python/lxml[${PYTHON_USEDEP}]
+		dev-python/pygments[${PYTHON_USEDEP}]
+		dev-python/rdflib[${PYTHON_USEDEP}]
+	')
+"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-1.18.6-add-missing-lv2.h.patch"
+	"${FILESDIR}/${P}-tests-optional.patch"
+)
+
+src_prepare() {
+	default
+
+	# XXX: Drop this > 1.18.10, -Dstrict=false should prevent it now, bug #906047.
+	sed -i -e "/codespell = /s:get_option('tests'):false:" test/meson.build || die
+
+	# serdi >=0.32.0 doesn't pass, bug #930273.
+	sed -i -e "/serdi = /s:find_program(.*):disabler():" test/meson.build || die
+
+	# fix doc installation path
+	sed -iE "s%lv2_docdir = .*%lv2_docdir = '${EPREFIX}/usr/share/doc/${PF}'%g" meson.build || die
+}
+
+multilib_src_configure() {
+	local emesonargs=(
+		-Dlv2dir="${EPREFIX}"/usr/$(get_libdir)/lv2
+		-Dstrict=false
+		$(meson_native_use_feature doc docs)
+		$(meson_feature plugins)
+		$(meson_feature test tests)
+	)
+
+	meson_src_configure
+}
+
+multilib_src_install_all() {
+	local DOCS=( NEWS README.md )
+	einstalldocs
+}


### PR DESCRIPTION
* Also address false UnquotedVariable from pkgcheck which was confused by "'""'".

Closes: https://bugs.gentoo.org/929646
Bug: https://bugs.gentoo.org/930273

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
