### PR TITLE
cargo.eclass: Optimize crate unpacking

### DIFF
--- a/eclass/cargo.eclass
+++ b/eclass/cargo.eclass
@@ -329,39 +329,49 @@ _cargo_gen_git_config() {
 cargo_src_unpack() {
 	debug-print-function ${FUNCNAME} "$@"
 
-	mkdir -p "${ECARGO_VENDOR}" || die
-	mkdir -p "${S}" || die
+	mkdir -p "${ECARGO_VENDOR}" "${S}" || die
 
 	local archive shasum pkg
+	local crates=()
 	for archive in ${A}; do
 		case "${archive}" in
 			*.crate)
-				# when called by pkgdiff-mg, do not unpack crates
-				[[ ${PKGBUMPING} == ${PVR} ]] && continue
-
-				ebegin "Loading ${archive} into Cargo registry"
-				tar -xf "${DISTDIR}"/${archive} -C "${ECARGO_VENDOR}/" || die
-				# generate sha256sum of the crate itself as cargo needs this
-				shasum=$(sha256sum "${DISTDIR}"/${archive} | cut -d ' ' -f 1)
-				pkg=$(basename ${archive} .crate)
-				cat <<- EOF > ${ECARGO_VENDOR}/${pkg}/.cargo-checksum.json
-				{
-					"package": "${shasum}",
-					"files": {}
-				}
-				EOF
-				# if this is our target package we need it in ${WORKDIR} too
-				# to make ${S} (and handle any revisions too)
-				if [[ ${P} == ${pkg}* ]]; then
-					tar -xf "${DISTDIR}"/${archive} -C "${WORKDIR}" || die
-				fi
-				eend $?
+				crates+=( "${archive}" )
 				;;
 			*)
-				unpack ${archive}
+				unpack "${archive}"
 				;;
 		esac
 	done
+
+	if [[ ${PKGBUMPING} != ${PVR} && ${crates[@]} ]]; then
+		pushd "${DISTDIR}" >/dev/null || die
+
+		ebegin "Unpacking crates"
+		printf '%s\0' "${crates[@]}" |
+			xargs -0 -P "$(makeopts_jobs)" -n 1 -t -- \
+				tar -x -C "${ECARGO_VENDOR}" -f
+		assert
+		eend $?
+
+		while read -d '' -r shasum archive; do
+			pkg=${archive%.crate}
+			cat <<- EOF > ${ECARGO_VENDOR}/${pkg}/.cargo-checksum.json || die
+			{
+				"package": "${shasum}",
+				"files": {}
+			}
+			EOF
+
+			# if this is our target package we need it in ${WORKDIR} too
+			# to make ${S} (and handle any revisions too)
+			if [[ ${P} == ${pkg}* ]]; then
+				tar -xf "${archive}" -C "${WORKDIR}" || die
+			fi
+		done < <(sha256sum -z "${crates[@]}" || die)
+
+		popd >/dev/null || die
+	fi
 
 	cargo_gen_config
 }


### PR DESCRIPTION
Unpack crates in parallel using xargs to utilize multicore systems better.  Perform checksumming via a single sha256sum invocation.

For dev-python/watchfiles, this speeds up unpacking on my machine from 2.6 s to 0.75 s (warm cache).

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
