### PR TITLE
media-libs/imlib2: fix missing multilib dependency

### DIFF
--- a/media-libs/imlib2/imlib2-1.12.2.ebuild
+++ b/media-libs/imlib2/imlib2-1.12.2.ebuild
@@ -37,7 +37,7 @@ RDEPEND="
 	text? ( media-libs/freetype:2[${MULTILIB_USEDEP}] )
 	mp3? ( media-libs/libid3tag:=[${MULTILIB_USEDEP}] )
 	png? ( >=media-libs/libpng-1.6.10:0=[${MULTILIB_USEDEP}] )
-	raw? ( media-libs/libraw:= )
+	raw? ( media-libs/libraw:=[${MULTILIB_USEDEP}] )
 	svg? ( >=gnome-base/librsvg-2.46.0:=[${MULTILIB_USEDEP}] )
 	tiff? ( >=media-libs/tiff-4.0.4:=[${MULTILIB_USEDEP}] )
 	webp? ( media-libs/libwebp:=[${MULTILIB_USEDEP}] )


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/931091

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
