### PR TITLE
www-client/firefox: support aarch64-unknown-linux-musl

### DIFF
--- a/www-client/firefox/firefox-115.10.0.ebuild
+++ b/www-client/firefox/firefox-115.10.0.ebuild
@@ -693,6 +693,8 @@ src_prepare() {
 			export RUST_TARGET="x86_64-unknown-linux-musl"
 		elif use x86 ; then
 			export RUST_TARGET="i686-unknown-linux-musl"
+		elif use arm64 ; then
+			export RUST_TARGET="aarch64-unknown-linux-musl"
 		else
 			die "Unknown musl chost, please post your rustc -vV along with emerge --info on Gentoo's bug #915651"
 		fi

--- a/www-client/firefox/firefox-115.9.0.ebuild
+++ b/www-client/firefox/firefox-115.9.0.ebuild
@@ -693,6 +693,8 @@ src_prepare() {
 			export RUST_TARGET="x86_64-unknown-linux-musl"
 		elif use x86 ; then
 			export RUST_TARGET="i686-unknown-linux-musl"
+		elif use arm64 ; then
+			export RUST_TARGET="aarch64-unknown-linux-musl"
 		else
 			die "Unknown musl chost, please post your rustc -vV along with emerge --info on Gentoo's bug #915651"
 		fi

--- a/www-client/firefox/firefox-115.9.1.ebuild
+++ b/www-client/firefox/firefox-115.9.1.ebuild
@@ -693,6 +693,8 @@ src_prepare() {
 			export RUST_TARGET="x86_64-unknown-linux-musl"
 		elif use x86 ; then
 			export RUST_TARGET="i686-unknown-linux-musl"
+		elif use arm64 ; then
+			export RUST_TARGET="aarch64-unknown-linux-musl"
 		else
 			die "Unknown musl chost, please post your rustc -vV along with emerge --info on Gentoo's bug #915651"
 		fi

--- a/www-client/firefox/firefox-125.0.2.ebuild
+++ b/www-client/firefox/firefox-125.0.2.ebuild
@@ -635,6 +635,8 @@ src_prepare() {
 			export RUST_TARGET="x86_64-unknown-linux-musl"
 		elif use x86 ; then
 			export RUST_TARGET="i686-unknown-linux-musl"
+		elif use arm64 ; then
+			export RUST_TARGET="aarch64-unknown-linux-musl"
 		else
 			die "Unknown musl chost, please post your rustc -vV along with emerge --info on Gentoo's bug #915651"
 		fi

--- a/www-client/firefox/firefox-125.0.2.ebuild
+++ b/www-client/firefox/firefox-125.0.2.ebuild
@@ -1046,7 +1046,7 @@ src_configure() {
 	fi
 
 	# elf-hack
-	# Filter "-z,pack-relative-relocs" and let the build system handle it instead. 
+	# Filter "-z,pack-relative-relocs" and let the build system handle it instead.
 	if use amd64 || use x86 ; then
 		filter-flags "-z,pack-relative-relocs"
 

--- a/www-client/firefox/firefox-125.0.3.ebuild
+++ b/www-client/firefox/firefox-125.0.3.ebuild
@@ -631,6 +631,8 @@ src_prepare() {
 			export RUST_TARGET="x86_64-unknown-linux-musl"
 		elif use x86 ; then
 			export RUST_TARGET="i686-unknown-linux-musl"
+		elif use arm64 ; then
+			export RUST_TARGET="aarch64-unknown-linux-musl"
 		else
 			die "Unknown musl chost, please post your rustc -vV along with emerge --info on Gentoo's bug #915651"
 		fi

--- a/www-client/firefox/firefox-125.0.3.ebuild
+++ b/www-client/firefox/firefox-125.0.3.ebuild
@@ -1042,7 +1042,7 @@ src_configure() {
 	fi
 
 	# elf-hack
-	# Filter "-z,pack-relative-relocs" and let the build system handle it instead. 
+	# Filter "-z,pack-relative-relocs" and let the build system handle it instead.
 	if use amd64 || use x86 ; then
 		filter-flags "-z,pack-relative-relocs"
 


### PR DESCRIPTION
Workaround for rust-bin broke firefox built for arm64.
This PR or #35268 will fix this.
<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
