### PR TITLE
app-i18n/ibus-libpinyin: enable py3.12

### DIFF
--- a/app-i18n/ibus-libpinyin/ibus-libpinyin-1.15.2.ebuild
+++ b/app-i18n/ibus-libpinyin/ibus-libpinyin-1.15.2.ebuild
@@ -1,9 +1,9 @@
-# Copyright 2015-2023 Gentoo Authors
+# Copyright 2015-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 LUA_COMPAT=( lua5-{1..3} )
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{9..12} )
 
 inherit autotools gnome2-utils lua-single python-single-r1
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/929320

Added python compatibility to ebuild for 3.12. This has been locally tested with no issues. 

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
  - [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
