### PR TITLE
app-vim/vim-spell-*: EAPI8 bump

### DIFF
--- a/app-vim/vim-spell-cs/vim-spell-cs-20061021-r2.ebuild
+++ b/app-vim/vim-spell-cs/vim-spell-cs-20061021-r2.ebuild
@@ -1,0 +1,12 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+VIM_SPELL_LANGUAGE="Czech"
+
+inherit vim-spell
+
+HOMEPAGE="https://wiki.gentoo.org/wiki/No_homepage"
+LICENSE="GPL-2"
+KEYWORDS="~amd64 ~sparc ~x86"

--- a/app-vim/vim-spell-da/vim-spell-da-20060116-r2.ebuild
+++ b/app-vim/vim-spell-da/vim-spell-da-20060116-r2.ebuild
@@ -1,0 +1,12 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+VIM_SPELL_LANGUAGE="Danish"
+
+inherit vim-spell
+
+HOMEPAGE="https://wiki.gentoo.org/wiki/No_homepage"
+LICENSE="GPL-2"
+KEYWORDS="~alpha ~amd64 ~ia64 ~ppc ~sparc ~x86"

--- a/app-vim/vim-spell-de/vim-spell-de-20080213-r2.ebuild
+++ b/app-vim/vim-spell-de/vim-spell-de-20080213-r2.ebuild
@@ -1,0 +1,12 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+VIM_SPELL_LANGUAGE="German"
+
+inherit vim-spell
+
+HOMEPAGE="https://wiki.gentoo.org/wiki/No_homepage"
+LICENSE="GPL-2"
+KEYWORDS="~amd64 ~arm ~ppc ~sparc ~x86 ~amd64-linux ~x86-linux ~x64-macos"

--- a/app-vim/vim-spell-el/vim-spell-el-20080402-r2.ebuild
+++ b/app-vim/vim-spell-el/vim-spell-el-20080402-r2.ebuild
@@ -1,0 +1,12 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+VIM_SPELL_LANGUAGE="Greek"
+
+inherit vim-spell
+
+HOMEPAGE="https://wiki.gentoo.org/wiki/No_homepage"
+LICENSE="GPL-2"
+KEYWORDS="~amd64 ~x86"

--- a/app-vim/vim-spell-en/vim-spell-en-20060123-r2.ebuild
+++ b/app-vim/vim-spell-en/vim-spell-en-20060123-r2.ebuild
@@ -1,0 +1,12 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+VIM_SPELL_LANGUAGE="English"
+
+inherit vim-spell
+
+HOMEPAGE="https://wiki.gentoo.org/wiki/No_homepage"
+LICENSE="BSD LGPL-2.1 public-domain"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~ppc ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos"

--- a/app-vim/vim-spell-es/vim-spell-es-20060208-r2.ebuild
+++ b/app-vim/vim-spell-es/vim-spell-es-20060208-r2.ebuild
@@ -1,0 +1,12 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+VIM_SPELL_LANGUAGE="Spanish"
+
+inherit vim-spell
+
+HOMEPAGE="https://wiki.gentoo.org/wiki/No_homepage"
+LICENSE="GPL-2"
+KEYWORDS="~alpha ~amd64 ~ppc ~sparc ~x86"

--- a/app-vim/vim-spell-fr/vim-spell-fr-20060121-r2.ebuild
+++ b/app-vim/vim-spell-fr/vim-spell-fr-20060121-r2.ebuild
@@ -1,0 +1,12 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+VIM_SPELL_LANGUAGE="French"
+
+inherit vim-spell
+
+HOMEPAGE="https://wiki.gentoo.org/wiki/No_homepage"
+LICENSE="GPL-2"
+KEYWORDS="~amd64 ~ppc ~sparc ~x86"

--- a/app-vim/vim-spell-he/vim-spell-he-20100312-r2.ebuild
+++ b/app-vim/vim-spell-he/vim-spell-he-20100312-r2.ebuild
@@ -1,0 +1,12 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+VIM_SPELL_LANGUAGE="Hebrew"
+
+inherit vim-spell
+
+HOMEPAGE="https://wiki.gentoo.org/wiki/No_homepage"
+LICENSE="GPL-2"
+KEYWORDS="~amd64 ~arm64 ~x86"

--- a/app-vim/vim-spell-hu/vim-spell-hu-20100312-r2.ebuild
+++ b/app-vim/vim-spell-hu/vim-spell-hu-20100312-r2.ebuild
@@ -1,0 +1,12 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+VIM_SPELL_LANGUAGE="Hungarian"
+
+inherit vim-spell
+
+HOMEPAGE="https://wiki.gentoo.org/wiki/No_homepage"
+LICENSE="GPL-2"
+KEYWORDS="~amd64 ~x86"

--- a/app-vim/vim-spell-it/vim-spell-it-20100312-r2.ebuild
+++ b/app-vim/vim-spell-it/vim-spell-it-20100312-r2.ebuild
@@ -1,0 +1,12 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+VIM_SPELL_LANGUAGE="Italian"
+
+inherit vim-spell
+
+HOMEPAGE="https://wiki.gentoo.org/wiki/No_homepage"
+LICENSE="GPL-2"
+KEYWORDS="~amd64 ~x86"

--- a/app-vim/vim-spell-nl/vim-spell-nl-20051007-r2.ebuild
+++ b/app-vim/vim-spell-nl/vim-spell-nl-20051007-r2.ebuild
@@ -1,0 +1,12 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+VIM_SPELL_LANGUAGE="Dutch"
+
+inherit vim-spell
+
+HOMEPAGE="https://wiki.gentoo.org/wiki/No_homepage"
+LICENSE="GPL-2"
+KEYWORDS="~amd64 ~ppc ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos"

--- a/app-vim/vim-spell-pl/vim-spell-pl-20060218-r2.ebuild
+++ b/app-vim/vim-spell-pl/vim-spell-pl-20060218-r2.ebuild
@@ -1,0 +1,12 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+VIM_SPELL_LANGUAGE="Polish"
+
+inherit vim-spell
+
+HOMEPAGE="https://wiki.gentoo.org/wiki/No_homepage"
+LICENSE="CC-BY-SA-2.0"
+KEYWORDS="~amd64 ~ppc ~sparc ~x86"

--- a/app-vim/vim-spell-pt/vim-spell-pt-20100312-r2.ebuild
+++ b/app-vim/vim-spell-pt/vim-spell-pt-20100312-r2.ebuild
@@ -1,0 +1,12 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+VIM_SPELL_LANGUAGE="Portuguese"
+
+inherit vim-spell
+
+HOMEPAGE="https://wiki.gentoo.org/wiki/No_homepage"
+LICENSE="GPL-2 LGPL-2.1 MPL-1.1"
+KEYWORDS="~amd64 ~x86"

--- a/app-vim/vim-spell-ru/vim-spell-ru-20070506-r2.ebuild
+++ b/app-vim/vim-spell-ru/vim-spell-ru-20070506-r2.ebuild
@@ -1,0 +1,12 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+VIM_SPELL_LANGUAGE="Russian"
+
+inherit vim-spell
+
+HOMEPAGE="https://wiki.gentoo.org/wiki/No_homepage"
+LICENSE="myspell-ru_RU-AlexanderLebedev"
+KEYWORDS="~amd64 ~arm64 ~ppc ~sparc ~x86"


### PR DESCRIPTION
This updates the vim-spell-* ebuilds for `EAPI8`.
I made a revision bump and dropped stable keywords for all of them, but since they only install some files i wondering if we can keep `KEYWORDS` here?

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
