### PR TITLE
app-emulation/x48: Enable feature-macro locked libc extensions

### DIFF
--- a/app-emulation/x48/files/x48-0.6.4-configure.patch
+++ b/app-emulation/x48/files/x48-0.6.4-configure.patch
@@ -1,0 +1,11 @@
+--- a/configure.ac	2024-05-12 12:01:50.591368113 -0000
++++ b/configure.ac	2024-05-12 12:05:39.116023749 -0000
+@@ -10,6 +10,8 @@
+ AC_CONFIG_SRCDIR([config.h.in])
+ AC_CONFIG_HEADER([config.h])
+ 
++
++AC_USE_SYSTEM_EXTENSIONS
+ # Checks for programs.
+ AC_PROG_CC
+ AC_PROG_INSTALL

--- a/app-emulation/x48/x48-0.6.4-r3.ebuild
+++ b/app-emulation/x48/x48-0.6.4-r3.ebuild
@@ -1,0 +1,74 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools
+
+DESCRIPTION="HP48 Calculator Emulator"
+HOMEPAGE="
+	http://x48.berlios.de/
+	https://sourceforge.net/projects/x48.berlios/
+"
+SRC_URI="https://downloads.sourceforge.net/x48.berlios/${P}.tar.bz2"
+
+S=${WORKDIR}
+
+LICENSE="GPL-3"
+
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="readline"
+
+RDEPEND="
+	x11-libs/libX11
+	x11-libs/libXext
+	readline? ( sys-libs/readline:0= )"
+DEPEND="${RDEPEND}
+	virtual/pkgconfig
+	x11-libs/libXt"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-static.patch
+	"${FILESDIR}"/${P}-void_return.patch
+	"${FILESDIR}"/${P}-configure.patch
+	)
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_configure() {
+	econf $(use_enable readline)
+}
+
+src_install() {
+	default
+
+	insinto /usr/share/"${PN}"/romdump
+	doins -r romdump/{README,ROMDump*}
+}
+
+pkg_postinst() {
+	elog "The X48 emulator requires an HP48 ROM image to run."
+	elog
+	elog "If you own an HP-48 calculator, you can use the ROMDump utility"
+	elog "included with this package to obtain it from your calculator."
+	elog "The instructions of how to do this are included in the package."
+	elog
+	elog "Alternatively, HP has provided the ROM images for non-commercial"
+	elog "use only."
+	elog
+	elog "Due to confusion over the legal status of these ROMs you must"
+	elog "manually download one from http://www.hpcalc.org/hp48/pc/emulators/"
+	elog
+	elog "If you do not know which one to use, try 'HP 48GX Revision R ROM.'"
+	elog
+	elog "Once you have a ROM, you will need to install it by running:"
+	elog
+	elog "x48 -rom gxrom-r"
+	elog
+	elog "You will only have to do this the first time you run X48. The"
+	elog "ROM will be stored in ~/.hp48/rom for future runs."
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/871468

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
