### PR TITLE
dev-libs/mpdecimal: Add EPREFIX in configure option to fix build in Gentoo Prefix

### DIFF
--- a/dev-libs/mpdecimal/mpdecimal-4.0.0.ebuild
+++ b/dev-libs/mpdecimal/mpdecimal-4.0.0.ebuild
@@ -59,5 +59,5 @@ src_test() {
 
 src_install() {
 	default
-	rm -r "${ED}/removeme" || die
+	rm -r "${D}/removeme" || die
 }


### PR DESCRIPTION
dev-libs/mpdecimal: Add EPREFIX in configure option to fix build in Gentoo Prefix

I haven't added a "Signed-off-by" line because I don't think I am qualified/trusted to do this. EDIT: Signed after reading the documentation about the Certificate of Origin that the bot added to the PR.

In Prefix, I was seeing this error prior to this PR:

```
>>> Install dev-libs/mpdecimal-4.0.0 into /cvmfs/software.dumont.ca/2021.02/compat/linux/x86_64/var/tmp/portage/dev-libs/mpdecimal-4.0.0/image
make -j5 DESTDIR=/cvmfs/software.dumont.ca/2021.02/compat/linux/x86_64/var/tmp/portage/dev-libs/mpdecimal-4.0.0/image install 
cd libmpdec && make 
make[1]: Entering directory '/cvmfs/software.dumont.ca/2021.02/compat/linux/x86_64/var/tmp/portage/dev-libs/mpdecimal-4.0.0/work/mpdecimal-4.0.0/libmpdec'
make[1]: Nothing to be done for 'default'.
make[1]: Leaving directory '/cvmfs/software.dumont.ca/2021.02/compat/linux/x86_64/var/tmp/portage/dev-libs/mpdecimal-4.0.0/work/mpdecimal-4.0.0/libmpdec'
/cvmfs/software.dumont.ca/2021.02/compat/linux/x86_64/usr/bin/install -c -d -m 755 /cvmfs/software.dumont.ca/2021.02/compat/linux/x86_64/var/tmp/portage/dev-libs/mpdecimal-4.0.0/image/cvmfs/software.dumont.ca/2021.02/compat/linux/x86_64/usr/include
/cvmfs/software.dumont.ca/2021.02/compat/linux/x86_64/usr/bin/install -c -d -m 755 /cvmfs/software.dumont.ca/2021.02/compat/linux/x86_64/var/tmp/portage/dev-libs/mpdecimal-4.0.0/image/cvmfs/software.dumont.ca/2021.02/compat/linux/x86_64/usr/lib64
/cvmfs/software.dumont.ca/2021.02/compat/linux/x86_64/usr/bin/install -c -d -m 755 /cvmfs/software.dumont.ca/2021.02/compat/linux/x86_64/var/tmp/portage/dev-libs/mpdecimal-4.0.0/image/removeme
/cvmfs/software.dumont.ca/2021.02/compat/linux/x86_64/usr/bin/install -c -d -m 755 /cvmfs/software.dumont.ca/2021.02/compat/linux/x86_64/var/tmp/portage/dev-libs/mpdecimal-4.0.0/image/cvmfs/software.dumont.ca/2021.02/compat/linux/x86_64/usr/lib64/pkgconfig
/cvmfs/software.dumont.ca/2021.02/compat/linux/x86_64/usr/bin/install -c -d -m 755 /cvmfs/software.dumont.ca/2021.02/compat/linux/x86_64/var/tmp/portage/dev-libs/mpdecimal-4.0.0/image/cvmfs/software.dumont.ca/2021.02/compat/linux/x86_64/usr/share/man/man3
/cvmfs/software.dumont.ca/2021.02/compat/linux/x86_64/usr/bin/install -c -m 644 libmpdec/mpdecimal.h /cvmfs/software.dumont.ca/2021.02/compat/linux/x86_64/var/tmp/portage/dev-libs/mpdecimal-4.0.0/image/cvmfs/software.dumont.ca/2021.02/compat/linux/x86_64/usr/include
/cvmfs/software.dumont.ca/2021.02/compat/linux/x86_64/usr/bin/install -c -m 755 libmpdec/libmpdec.so.4.0.0 /cvmfs/software.dumont.ca/2021.02/compat/linux/x86_64/var/tmp/portage/dev-libs/mpdecimal-4.0.0/image/cvmfs/software.dumont.ca/2021.02/compat/linux/x86_64/usr/lib64
cd /cvmfs/software.dumont.ca/2021.02/compat/linux/x86_64/var/tmp/portage/dev-libs/mpdecimal-4.0.0/image/cvmfs/software.dumont.ca/2021.02/compat/linux/x86_64/usr/lib64 && ln -sf libmpdec.so.4.0.0 libmpdec.so.4 && ln -sf libmpdec.so.4.0.0 libmpdec.so
/cvmfs/software.dumont.ca/2021.02/compat/linux/x86_64/usr/bin/install -c -m 644 libmpdec/.pc/libmpdec.pc /cvmfs/software.dumont.ca/2021.02/compat/linux/x86_64/var/tmp/portage/dev-libs/mpdecimal-4.0.0/image/cvmfs/software.dumont.ca/2021.02/compat/linux/x86_64/usr/lib64/pkgconfig
/cvmfs/software.dumont.ca/2021.02/compat/linux/x86_64/usr/bin/install -c -m 644 doc/COPYRIGHT.txt /cvmfs/software.dumont.ca/2021.02/compat/linux/x86_64/var/tmp/portage/dev-libs/mpdecimal-4.0.0/image/removeme
/cvmfs/software.dumont.ca/2021.02/compat/linux/x86_64/usr/bin/install -c -m 644 doc/mpdecimal.3 /cvmfs/software.dumont.ca/2021.02/compat/linux/x86_64/var/tmp/portage/dev-libs/mpdecimal-4.0.0/image/cvmfs/software.dumont.ca/2021.02/compat/linux/x86_64/usr/share/man/man3
/cvmfs/software.dumont.ca/2021.02/compat/linux/x86_64/usr/bin/install -c -m 644 doc/libmpdec.3 /cvmfs/software.dumont.ca/2021.02/compat/linux/x86_64/var/tmp/portage/dev-libs/mpdecimal-4.0.0/image/cvmfs/software.dumont.ca/2021.02/compat/linux/x86_64/usr/share/man/man3
rm: cannot remove '/cvmfs/software.dumont.ca/2021.02/compat/linux/x86_64/var/tmp/portage/dev-libs/mpdecimal-4.0.0/image/cvmfs/software.dumont.ca/2021.02/compat/linux/x86_64/removeme': No such file or directory
 * ERROR: dev-libs/mpdecimal-4.0.0::gentoo failed (install phase):
 *   (no error message)
 * 
 * Call stack:
 *     ebuild.sh, line 136:  Called src_install
 *   environment, line 1515:  Called die
 * The specific snippet of code:
 *       rm -r "${ED}/removeme" || die
 * 
 * If you need support, post the output of `emerge --info '=dev-libs/mpdecimal-4.0.0::gentoo'`,
 * the complete build log and the output of `emerge -pqv '=dev-libs/mpdecimal-4.0.0::gentoo'`.
 * The complete build log is located at '/cvmfs/software.dumont.ca/2021.02/compat/linux/x86_64/var/tmp/portage/dev-libs/mpdecimal-4.0.0/temp/build.log'.
 * The ebuild environment file is located at '/cvmfs/software.dumont.ca/2021.02/compat/linux/x86_64/var/tmp/portage/dev-libs/mpdecimal-4.0.0/temp/environment'.
 * Working directory: '/cvmfs/software.dumont.ca/2021.02/compat/linux/x86_64/var/tmp/portage/dev-libs/mpdecimal-4.0.0/work/mpdecimal-4.0.0'
 * S: '/cvmfs/software.dumont.ca/2021.02/compat/linux/x86_64/var/tmp/portage/dev-libs/mpdecimal-4.0.0/work/mpdecimal-4.0.0'
```

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
