### PR TITLE
licenses: Rename OFL to OFL-1.0

### DIFF
--- a/profiles/license_groups
+++ b/profiles/license_groups
@@ -43,7 +43,7 @@ FREE-SOFTWARE @FSF-APPROVED @OSI-APPROVED-FREE @MISC-FREE
 
 # FSF-approved licenses for "free documentation" and "works of
 # practical use besides software and documentation" (including fonts)
-FSF-APPROVED-OTHER Arphic CC-BY-2.0 CC-BY-2.5 CC-BY-3.0 CC-BY-4.0 CC-BY-SA-2.0 CC-BY-SA-2.5 CC-BY-SA-3.0 CC-BY-SA-4.0 FDL-1.1 FDL-1.1+ FDL-1.2 FDL-1.2+ FDL-1.3 FDL-1.3+ Free-Art-1.2 Free-Art-1.3 GPL-1 GPL-1+ GPL-2 GPL-2+ GPL-3 GPL-3+ IPAfont OFL OFL-1.0 OFL-1.1 OPL
+FSF-APPROVED-OTHER Arphic CC-BY-2.0 CC-BY-2.5 CC-BY-3.0 CC-BY-4.0 CC-BY-SA-2.0 CC-BY-SA-2.5 CC-BY-SA-3.0 CC-BY-SA-4.0 FDL-1.1 FDL-1.1+ FDL-1.2 FDL-1.2+ FDL-1.3 FDL-1.3+ Free-Art-1.2 Free-Art-1.3 GPL-1 GPL-1+ GPL-2 GPL-2+ GPL-3 GPL-3+ IPAfont OFL-1.0 OFL-1.1 OPL
 
 # Misc licenses for free documents and other works (including fonts)
 # that follow the definition at https://freedomdefined.org/ but are NOT


### PR DESCRIPTION
Apparently the OFL license label for the SIL Open Font License version 1.0 causes confusion. 25 of the 29 packages in the Gentoo repository that are currently labelled OFL are really licensed as OFL version 1.1 rather than OFL version 1.0.

Bug: https://bugs.gentoo.org/931823
<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
