### PR TITLE
Fix the GRUB configuration script for memtest86+ EFI builds

### DIFF
--- a/sys-apps/memtest86+/files/39_memtest86+-r2
+++ b/sys-apps/memtest86+/files/39_memtest86+-r2
@@ -87,7 +87,7 @@ EOF
         fi
 
         cat <<EOF
-        ${submenu_indentation}chainloader "${path}"
+        ${submenu_indentation}linux "${path}"
 ${submenu_indentation}}
 ${submenu_indentation}fi
 EOF
@@ -112,7 +112,7 @@ EOF
         fi
 
         cat <<EOF
-        ${submenu_indentation}chainloader "${path}"
+        ${submenu_indentation}linux "${path}"
 ${submenu_indentation}}
 ${submenu_indentation}fi
 EOF


### PR DESCRIPTION
The current GRUB configuration script for memtest86+ doesn't produce working entries as it tries to load the executable images using the `chainloader` command, this fails to load the images.

The executables produced by the build appear to be using the Linux EFI boot stub and thus can be loaded using the `linux` command instead. This patch does just that.

Closes: https://bugs.gentoo.org/931825

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
