### PR TITLE
app-editors/helix: Remove `grammar` USE flag

### DIFF
--- a/app-editors/helix/helix-23.05.ebuild
+++ b/app-editors/helix/helix-23.05.ebuild
@@ -263,11 +263,9 @@ S="${WORKDIR}"
 LICENSE="0BSD Apache-2.0 Apache-2.0-with-LLVM-exceptions BSD Boost-1.0 ISC MIT MPL-2.0 Unicode-DFS-2016 Unlicense ZLIB"
 SLOT="0"
 KEYWORDS="~amd64"
-IUSE="+grammar"
 
 QA_FLAGS_IGNORED="
 	usr/bin/hx
-	usr/share/helix/runtime/grammars/.*\.so
 "
 
 DOCS=(
@@ -278,7 +276,7 @@ DOCS=(
 )
 
 src_compile() {
-	use grammar || local -x HELIX_DISABLE_AUTO_GRAMMAR_BUILD=1
+	local -x HELIX_DISABLE_AUTO_GRAMMAR_BUILD=1
 
 	cargo_src_compile
 }
@@ -286,12 +284,10 @@ src_compile() {
 src_install() {
 	cargo_src_install --path helix-term
 
-	rm -r runtime/grammars/.gitkeep || die
-	rm -r runtime/grammars/sources || die
+	insinto /usr/share/helix/runtime
+	doins -r runtime/{queries,themes,tutor}
 
 	insinto /usr/share/helix
-	doins -r runtime
-
 	dodoc -r "${DOCS[@]}"
 
 	doicon -s 256x256 contrib/${PN}.png

--- a/app-editors/helix/helix-23.10-r2.ebuild
+++ b/app-editors/helix/helix-23.10-r2.ebuild
@@ -277,14 +277,11 @@ S="${WORKDIR}"
 LICENSE="0BSD Apache-2.0 Apache-2.0-with-LLVM-exceptions BSD Boost-1.0 ISC MIT MPL-2.0 Unicode-DFS-2016 Unlicense ZLIB"
 SLOT="0"
 KEYWORDS="amd64"
-IUSE="+grammar"
 
-BDEPEND="grammar? ( dev-vcs/git )"
 RDEPEND="dev-vcs/git"
 
 QA_FLAGS_IGNORED="
 	usr/bin/hx
-	usr/share/helix/runtime/grammars/.*\.so
 "
 
 DOCS=(
@@ -299,7 +296,7 @@ PATCHES=(
 )
 
 src_compile() {
-	use grammar || local -x HELIX_DISABLE_AUTO_GRAMMAR_BUILD=1
+	local -x HELIX_DISABLE_AUTO_GRAMMAR_BUILD=1
 
 	cargo_src_compile
 }
@@ -307,12 +304,10 @@ src_compile() {
 src_install() {
 	cargo_src_install --path helix-term
 
-	rm -r runtime/grammars/.gitkeep || die
-	rm -r runtime/grammars/sources || die
+	insinto /usr/share/helix/runtime
+	doins -r runtime/{queries,themes,tutor}
 
 	insinto /usr/share/helix
-	doins -r runtime
-
 	dodoc -r "${DOCS[@]}"
 
 	doicon -s 256x256 contrib/${PN}.png
@@ -329,11 +324,16 @@ src_install() {
 }
 
 pkg_postinst() {
-	einfo "The runtime files (grammars, queries, themes) have been"
+	einfo "The runtime files (queries, themes) have been"
 	einfo "installed in '/usr/share/helix/runtime'. The environment variable"
 	einfo "HELIX_RUNTIME was also installed on your system. In running shell instances"
 	einfo "you need to run 'source /etc/profile' to pick up the new variable"
 	einfo "or manually set the environment variable HELIX_RUNTIME=/usr/share/helix/runtime."
+	einfo ""
+	einfo "Grammars are not installed yet. To fetch and install them, run:"
+	einfo ""
+	einfo "  hx --grammar fetch"
+	einfo "  hx --grammar build"
 	xdg_desktop_database_update
 	xdg_icon_cache_update
 }

--- a/app-editors/helix/helix-24.03.ebuild
+++ b/app-editors/helix/helix-24.03.ebuild
@@ -290,14 +290,11 @@ S="${WORKDIR}"
 LICENSE="0BSD Apache-2.0 Apache-2.0-with-LLVM-exceptions BSD Boost-1.0 ISC MIT MPL-2.0 Unicode-DFS-2016 Unlicense ZLIB"
 SLOT="0"
 KEYWORDS="~amd64"
-IUSE="+grammar"
 
-BDEPEND="grammar? ( dev-vcs/git )"
 RDEPEND="dev-vcs/git"
 
 QA_FLAGS_IGNORED="
 	usr/bin/hx
-	usr/share/helix/runtime/grammars/.*\.so
 "
 
 DOCS=(
@@ -308,7 +305,7 @@ DOCS=(
 )
 
 src_compile() {
-	use grammar || local -x HELIX_DISABLE_AUTO_GRAMMAR_BUILD=1
+	local -x HELIX_DISABLE_AUTO_GRAMMAR_BUILD=1
 
 	cargo_src_compile
 }
@@ -316,12 +313,10 @@ src_compile() {
 src_install() {
 	cargo_src_install --path helix-term
 
-	rm -r runtime/grammars/.gitkeep || die
-	rm -r runtime/grammars/sources || die
+	insinto /usr/share/helix/runtime
+	doins -r runtime/{queries,themes,tutor}
 
 	insinto /usr/share/helix
-	doins -r runtime
-
 	dodoc -r "${DOCS[@]}"
 
 	doicon -s 256x256 contrib/${PN}.png
@@ -338,11 +333,16 @@ src_install() {
 }
 
 pkg_postinst() {
-	einfo "The runtime files (grammars, queries, themes) have been"
+	einfo "The runtime files (queries, themes) have been"
 	einfo "installed in '/usr/share/helix/runtime'. The environment variable"
 	einfo "HELIX_RUNTIME was also installed on your system. In running shell instances"
 	einfo "you need to run 'source /etc/profile' to pick up the new variable"
 	einfo "or manually set the environment variable HELIX_RUNTIME=/usr/share/helix/runtime."
+	einfo ""
+	einfo "Grammars are not installed yet. To fetch and install them, run:"
+	einfo ""
+	einfo "  hx --grammar fetch"
+	einfo "  hx --grammar build"
 	xdg_desktop_database_update
 	xdg_icon_cache_update
 }

--- a/app-editors/helix/metadata.xml
+++ b/app-editors/helix/metadata.xml
@@ -13,9 +13,6 @@
 		<email>proxy-maint@gentoo.org</email>
 		<name>Proxy Maintainers</name>
 	</maintainer>
-	<use>
-		<flag name="grammar">Build and install grammar language files</flag>
-	</use>
 	<upstream>
 		<bugs-to>https://github.com/helix-editor/helix/issues</bugs-to>
 		<changelog>https://github.com/helix-editor/helix/commits/master</changelog>


### PR DESCRIPTION
Fetching grammars is done with git, therefore doing that during the package build is not the best, because git rigtfully complains about "unsafe directories".

Instead of micromanaging grammar builds, notify the user how to do it after installation. The procedure is to run:

```
hx --grammar fetch
hx --grammar build
```

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
