### PR TITLE
app-text/discount: C99 Fixes

### DIFF
--- a/app-text/discount/discount-2.2.7c-r1.ebuild
+++ b/app-text/discount/discount-2.2.7c-r1.ebuild
@@ -1,0 +1,71 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs
+
+DESCRIPTION="A Markdown-to HTML translator written in C"
+HOMEPAGE="http://www.pell.portland.or.us/~orc/Code/discount/"
+SRC_URI="https://github.com/Orc/discount/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="BSD"
+SLOT="0/2.2.7"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~ia64 ~ppc ~ppc64 ~riscv ~sparc ~x86"
+IUSE="minimal test"
+RESTRICT="!test? ( test )"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-2.2.7c-C99-fix.patch
+)
+
+src_prepare() {
+	default
+
+	# for QA, we remove the Makefile’s usage of install -s.
+	# Drop ldconfig invocation.
+	# Force “librarian.sh” to respect LDFLAGS ($FLAGS should have CFLAGS
+	# at that point).
+	sed -i \
+		-e '/INSTALL_PROGRAM/s,\$_strip ,,' \
+		-e 's/\(LDCONFIG=\).*/\1:/' \
+		-e 's/\(.\)\$FLAGS/& \1$LDFLAGS/' \
+		configure.inc || die "sed configure.inc failed"
+}
+
+src_configure() {
+	local configure_call=(
+		./configure.sh
+		--libdir="${EPREFIX}/usr/$(get_libdir)"
+		--prefix="${EPREFIX}/usr"
+		--mandir="${EPREFIX}/usr/share/man"
+		--shared
+		--pkg-config
+		$(usex minimal '' --enable-all-features)
+		# Enable deterministic HTML generation behavior. Otherwise, will
+		# actually call rand() as part of its serialization code...
+		--debian-glitch
+	)
+	einfo "Running ${configure_call[@]}"
+	CC="$(tc-getCC)" AR="$(tc-getAR)" \
+	"${configure_call[@]}" || die
+}
+
+src_compile() {
+	emake libmarkdown
+	emake
+}
+
+src_install() {
+	emake \
+		DESTDIR="${D}" \
+		$(usex minimal install install.everything) \
+		SAMPLE_PFX="${PN}-"
+}
+
+pkg_postinst() {
+	if ! use minimal; then
+		elog 'Sample binaries with overly-generic names have been'
+		elog "prefixed with \"${PN}-\"."
+	fi
+}

--- a/app-text/discount/files/discount-2.2.7c-C99-fix.patch
+++ b/app-text/discount/files/discount-2.2.7c-C99-fix.patch
@@ -1,0 +1,38 @@
+FROM: https://github.com/Orc/discount/issues/283
+FROM: Atri Bhattacharya <badshah400@gmail.com>
+
+--- a/main.c
++++ b/main.c
+@@ -100,14 +100,15 @@ free_it(char *object, void *ctx)
+ }
+ 
+ char *
+-external_codefmt(char *src, int len, char *lang)
++external_codefmt(const char *src, const int len, void *lang)
+ {
+     int extra = 0;
+     int i, x;
+     char *res;
++    char *ec_lang = (char *)lang;
+ 
+-    if ( lang == 0 )
+-	lang = "generic_code";
++    if ( ec_lang == 0 )
++	ec_lang = "generic_code";
+ 
+     for ( i=0; i < len; i++) {
+ 	if ( src[i] == '&' )
+@@ -117,11 +118,11 @@ external_codefmt(char *src, int len, cha
+     }
+ 
+     /* 80 characters for the format wrappers */
+-    if ( (res = malloc(len+extra+80+strlen(lang))) ==0 )
++    if ( (res = malloc(len+extra+80+strlen(ec_lang))) ==0 )
+ 	/* out of memory?  drat! */
+ 	return 0;
+ 
+-    sprintf(res, "<pre><code class=\"%s\">\n", lang);
++    sprintf(res, "<pre><code class=\"%s\">\n", ec_lang);
+     x = strlen(res);
+     for ( i=0; i < len; i++ ) {
+ 	switch (src[i]) {


### PR DESCRIPTION
Cherrypicked patch from Atri Bhattacharya to fix C99 compile time errors. Upstream are not interested in this as it works in v3 so this seems the best way forward.

Closes: https://bugs.gentoo.org/894560

---

Please check all the boxes that apply:

- [X ] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [ X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X ] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
