### PR TITLE
Include also "client-server" section in MySQL/MariaDB init scripts.

### DIFF
--- a/dev-db/mysql-init-scripts/files/init.d-2.3
+++ b/dev-db/mysql-init-scripts/files/init.d-2.3
@@ -18,7 +18,7 @@ depend() {
 }
 
 get_config() {
-	my_print_defaults --defaults-file="$1" mysqld server mariadb |
+	my_print_defaults --defaults-file="$1" client-server mysqld server mariadb |
 	sed -n -e "s/^--$2=//p"
 }
 

--- a/dev-db/mysql-init-scripts/files/init.d-s6-2.3
+++ b/dev-db/mysql-init-scripts/files/init.d-s6-2.3
@@ -9,7 +9,7 @@ depend() {
 }
 
 get_config() {
-	my_print_defaults --defaults-file="$1" mysqld server mariadb |
+	my_print_defaults --defaults-file="$1" client-server mysqld server mariadb |
 	sed -n -e "s/^--$2=//p"
 }
 

--- a/dev-db/mysql-init-scripts/files/init.d-supervise-2.3
+++ b/dev-db/mysql-init-scripts/files/init.d-supervise-2.3
@@ -15,7 +15,7 @@ depend() {
 }
 
 get_config() {
-	my_print_defaults --defaults-file="$1" mysqld server mariadb |
+	my_print_defaults --defaults-file="$1" client-server mysqld server mariadb |
 	sed -n -e "s/^--$2=//p"
 }
 


### PR DESCRIPTION
For users customizing their MariaDB config files, there's [client-server] section available (https://mariadb.com/kb/en/configuring-mariadb-with-option-files/) which is encouraged to hold socket option used in this init script.
MySQL doesn't seem to support it but we already look at [mariadb] section as well. I take it that extraneous sections are OK to be included here.

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
