### PR TITLE
dev-lang/python: make test failures verbose, both pgo & src_test

### DIFF
--- a/dev-lang/python/python-3.13.0_beta1_p1.ebuild
+++ b/dev-lang/python/python-3.13.0_beta1_p1.ebuild
@@ -239,6 +239,7 @@ src_configure() {
 			-m test
 			"-j$(makeopts_jobs)"
 			--pgo-extended
+			--verbose3
 			-u-network
 
 			# We use a timeout because of how often we've had hang issues
@@ -408,6 +409,7 @@ src_test() {
 	local -x LOGNAME=buildbot
 
 	local test_opts=(
+		--verbose3
 		-u-network
 		-j "$(makeopts_jobs)"
 


### PR DESCRIPTION
Test failure logs are very terse otherwise and hard to tell what's going on.

Bug: https://bugs.gentoo.org/931888

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
