### PR TITLE
media-plugins/gst-plugins-vaapi and media-libs/gst-plugins-base: mesa now uses opengl useflag

### DIFF
--- a/media-libs/gst-plugins-base/gst-plugins-base-1.22.11-r1.ebuild
+++ b/media-libs/gst-plugins-base/gst-plugins-base-1.22.11-r1.ebuild
@@ -1,0 +1,145 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+GST_ORG_MODULE="gst-plugins-base"
+
+inherit flag-o-matic gstreamer-meson
+
+DESCRIPTION="Basepack of plugins for gstreamer"
+HOMEPAGE="https://gstreamer.freedesktop.org/"
+
+LICENSE="GPL-2+ LGPL-2+"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~mips ~ppc ~ppc64 ~riscv ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x64-solaris"
+
+# For OpenGL we have three separate concepts, with a list of possibilities in each:
+#  * opengl APIs - opengl and/or gles2; USE=opengl and USE=gles2 enable these accordingly; if neither is enabled, OpenGL helper library and elements are not built at all and all the other options aren't relevant
+#  * opengl platforms - glx and/or egl; also cgl, wgl, eagl for non-linux; USE="X opengl" enables glx platform; USE="egl" enables egl platform. Rest is up for relevant prefix teams.
+#  * opengl windowing system - x11, wayland, win32, cocoa, android, viv_fb, gbm and/or dispmanx; USE=X enables x11 (but for WSI it's automagic - FIXME), USE=wayland enables wayland, USE=gbm enables gbm (automagic upstream - FIXME); rest is up for relevant prefix/arch teams/contributors to test and provide patches
+# With the following limitations:
+#  * If opengl and/or gles2 is enabled, a platform has to be enabled - x11 or egl in our case, but x11 (glx) is acceptable only with opengl
+#  * If opengl and/or gles2 is enabled, a windowing system has to be enabled - x11, wayland or gbm in our case
+#  * glx platform requires opengl API (but we don't REQUIRED_USE that as USE=X is common, glx is just disabled with USE=-opengl or USE=-X)
+#  * wayland, gbm and most other non-glx WSIs require egl platform
+# Additionally there is optional dmabuf support with egl for additional dmabuf based upload/download/eglimage options;
+#  and optional graphene usage for gltransformation and glvideoflip elements and more GLSL Uniforms support in glshader;
+#  and libpng/jpeg are required for gloverlay element;
+
+# Keep default IUSE options for relevant ones mirrored with gst-plugins-gtk and gst-plugins-bad
+IUSE="alsa +egl gbm +gles2 +introspection ivorbis +ogg opengl +orc +pango theora +vorbis wayland +X"
+GL_REQUIRED_USE="
+	|| ( gbm wayland X )
+	wayland? ( egl )
+	gbm? ( egl )
+"
+REQUIRED_USE="
+	ivorbis? ( ogg )
+	theora? ( ogg )
+	vorbis? ( ogg )
+	opengl? ( || ( egl X ) ${GL_REQUIRED_USE} )
+	gles2? ( egl ${GL_REQUIRED_USE} )
+"
+
+# Dependencies needed by opengl library and plugin (enabled via USE gles2 and/or opengl)
+# dmabuf automagic from libdrm headers (drm_fourcc.h) and EGL, so ensure it with USE=egl (platform independent header used only, thus no MULTILIB_USEDEP); provides dmabuf based upload/download/eglimage options
+GL_DEPS="
+	>=media-libs/mesa-9.0[opengl(+)?,gbm(+)?,wayland?,${MULTILIB_USEDEP}]
+	egl? (
+		x11-libs/libdrm
+	)
+	gbm? (
+		>=dev-libs/libgudev-147[${MULTILIB_USEDEP}]
+		>=x11-libs/libdrm-2.4.55[${MULTILIB_USEDEP}]
+	)
+	wayland? (
+		>=dev-libs/wayland-1.20.0[${MULTILIB_USEDEP}]
+		>=dev-libs/wayland-protocols-1.15
+	)
+
+	>=media-libs/graphene-1.4.0[${MULTILIB_USEDEP}]
+	media-libs/libpng:0[${MULTILIB_USEDEP}]
+	media-libs/libjpeg-turbo:0=[${MULTILIB_USEDEP}]
+" # graphene for optional gltransformation and glvideoflip elements and more GLSL Uniforms support in glshader; libpng/jpeg for gloverlay element
+# >=media-libs/graphene-1.4.0[${MULTILIB_USEDEP}]
+
+RDEPEND="
+	app-text/iso-codes
+	>=sys-libs/zlib-1.2.8-r1[${MULTILIB_USEDEP}]
+	alsa? ( >=media-libs/alsa-lib-1.0.27.2[${MULTILIB_USEDEP}] )
+	introspection? ( >=dev-libs/gobject-introspection-1.31.1:= )
+	ivorbis? ( >=media-libs/tremor-0_pre20130223[${MULTILIB_USEDEP}] )
+	ogg? ( >=media-libs/libogg-1.3.0[${MULTILIB_USEDEP}] )
+	orc? ( >=dev-lang/orc-0.4.33[${MULTILIB_USEDEP}] )
+	pango? ( >=x11-libs/pango-1.36.3[${MULTILIB_USEDEP}] )
+	theora? ( >=media-libs/libtheora-1.1.1[encode,${MULTILIB_USEDEP}] )
+	vorbis? ( >=media-libs/libvorbis-1.3.3-r1[${MULTILIB_USEDEP}] )
+	X? (
+		>=x11-libs/libX11-1.6.2[${MULTILIB_USEDEP}]
+		>=x11-libs/libXext-1.3.2[${MULTILIB_USEDEP}]
+		>=x11-libs/libXv-1.0.10[${MULTILIB_USEDEP}]
+	)
+
+	gles2? ( ${GL_DEPS} )
+	opengl? ( ${GL_DEPS} )
+"
+DEPEND="${RDEPEND}
+	dev-util/glib-utils
+	X? ( x11-base/xorg-proto )
+"
+
+DOCS=( AUTHORS NEWS README.md RELEASE )
+
+PATCHES=(
+)
+
+multilib_src_configure() {
+	filter-flags -mno-sse -mno-sse2 -mno-sse4.1 #610340
+
+	# opus: split to media-plugins/gst-plugins-opus
+	GST_PLUGINS_NOAUTO="alsa gl ogg pango theora vorbis x11 xshm xvideo"
+
+	local emesonargs=(
+		-Dtools=enabled
+
+		$(meson_feature alsa)
+		$(meson_feature ogg)
+		$(meson_feature pango)
+		$(meson_feature theora)
+		$(meson_feature vorbis)
+		$(meson_feature X x11)
+		$(meson_feature X xshm)
+		$(meson_feature X xvideo)
+	)
+
+	if use opengl || use gles2; then
+		# because meson doesn't likes extraneous commas
+		local gl_api=( $(use opengl && echo opengl) $(use gles2 && echo gles2) )
+		local gl_platform=( $(use X && use opengl && echo glx) $(use egl && echo egl) )
+		local gl_winsys=(
+			$(use X && echo x11)
+			$(use wayland && echo wayland)
+			$(use egl && echo egl)
+			$(use gbm && echo gbm)
+		)
+
+		emesonargs+=(
+			-Dgl=enabled
+			-Dgl-graphene=enabled
+			-Dgl_api=$(IFS=, ; echo "${gl_api[*]}")
+			-Dgl_platform=$(IFS=, ; echo "${gl_platform[*]}")
+			-Dgl_winsys=$(IFS=, ; echo "${gl_winsys[*]}")
+		)
+	else
+		emesonargs+=(
+			-Dgl=disabled
+			-Dgl_api=
+			-Dgl_platform=
+			-Dgl_winsys=
+		)
+	fi
+
+	# Workaround EGL/eglplatform.h being built with X11 present
+	use X || export CFLAGS="${CFLAGS} -DEGL_NO_X11"
+
+	gstreamer_multilib_src_configure
+}

--- a/media-plugins/gst-plugins-vaapi/gst-plugins-vaapi-1.22.11-r1.ebuild
+++ b/media-plugins/gst-plugins-vaapi/gst-plugins-vaapi-1.22.11-r1.ebuild
@@ -1,0 +1,98 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+inherit gstreamer-meson
+
+MY_PN="gstreamer-vaapi"
+DESCRIPTION="Hardware accelerated video decoding through VA-API plugin for GStreamer"
+HOMEPAGE="https://gitlab.freedesktop.org/gstreamer/gstreamer-vaapi"
+SRC_URI="https://gstreamer.freedesktop.org/src/${MY_PN}/${MY_PN}-${PV}.tar.xz"
+
+LICENSE="LGPL-2.1+"
+SLOT="1.0"
+KEYWORDS="~amd64 ~arm64 ~loong ~ppc64 ~riscv ~x86"
+IUSE="+drm +egl +gles2 opengl wayland +X" # Keep default enabled IUSE in sync with gst-plugins-base and libva
+
+# gst-vaapi configure is based around GL platform mainly, unlike gst-plugins-bad that goes by GL API mainly; for less surprises,
+# we design gst-vaapi ebuild in terms of GL API as main choice as well, meaning that USE opengl and/or gles2 is required to
+# enable opengl support at all and choices get chained from there.
+# One or multiple video output are required: drm, x11, glx, egl and/or wayland;
+# but GL API is our main trigger, thus USE=egl should be ineffective if neither gles2 or opengl is enabled;
+# So "|| ( drm egl opengl wayland X )" would be wrong, because egl isn't built with USE="egl -opengl -gles2", ending up with no video outputs.
+# As we ensure at least one working GL output with other REQUIRED_USE, we can put gles2/opengl in REQUIRED_USE instead of egl, solving the issue.
+# gles2 API only supported windowing system (on linux) is EGL, so require it
+# opengl API only supported windowing systems (on linux) are EGL and GLX, so require one of them (glx is enabled with USE="opengl X")
+REQUIRED_USE="
+	|| ( drm gles2 opengl wayland X )
+	gles2? ( egl )
+	opengl? ( || ( egl X ) )
+	wayland? ( drm )
+"
+
+# glx doesn't require libva-glx (libva[opengl]) afaics, only by tests/test-display.c
+# USE flag behavior:
+# 'drm' enables vaapi drm support
+# 'egl' enables EGL platform support (but only if also 'opengl||gles2')
+# - 'egl' is exposed as a USE flag mainly to get EGL support instead of or in addition to GLX support with desktop GL while keeping it optional for pure GLX cases;
+#   it's always required with USE=gles2, thus USE="gles2 opengl X" will require and build desktop GL EGL platform support as well on top of GLX, which doesn't add extra deps at that point.
+# 'gles2' enables GLESv2 or GLESv3 based GL API support
+# 'opengl' enables desktop OpenGL based GL API support
+# 'wayland' enables non-GL Wayland support; wayland EGL support when combined with 'egl' (but only if also 'opengl||gles2')
+# 'X' enables non-GL X support; GLX support when combined with 'opengl'
+# gst-plugins-bad still needed for codecparsers (GL libraries moved to -base); checked for 1.14 (recheck for 1.16)
+GST_REQ="${PV}"
+GL_DEPS="
+	>=media-libs/gst-plugins-base-${GST_REQ}:${SLOT}[egl?,gles2?,opengl?,wayland?,X?]
+	media-libs/mesa[opengl(+)?,X?,${MULTILIB_USEDEP}]
+"
+RDEPEND="
+	>=media-libs/gst-plugins-base-${GST_REQ}:${SLOT}[${MULTILIB_USEDEP}]
+	>=media-libs/gst-plugins-bad-${GST_REQ}:${SLOT}[${MULTILIB_USEDEP}]
+	>=media-libs/libva-1.10.0:=[drm(+)?,wayland?,X?,${MULTILIB_USEDEP}]
+	drm? (
+		>=virtual/libudev-208:=[${MULTILIB_USEDEP}]
+		>=x11-libs/libdrm-2.4.98[${MULTILIB_USEDEP}]
+	)
+	gles2? ( ${GL_DEPS} )
+	opengl? ( ${GL_DEPS} )
+	wayland? ( >=dev-libs/wayland-1.11.0[${MULTILIB_USEDEP}] )
+	X? (
+		>=x11-libs/libX11-1.6.2[${MULTILIB_USEDEP}]
+		>=x11-libs/libXrandr-1.4.2[${MULTILIB_USEDEP}]
+		x11-libs/libXrender[${MULTILIB_USEDEP}] )
+"
+DEPEND="${RDEPEND}"
+
+S="${WORKDIR}/${MY_PN}-${PV}"
+
+# FIXME: "Failed to create vaapipostproc element"
+RESTRICT="test"
+
+multilib_src_configure() {
+	GST_PLUGINS_NOAUTO="wayland"
+
+	local emesonargs=(
+		-Dencoders=enabled
+		$(meson_feature drm)
+		$(meson_feature X x11)
+		$(meson_feature wayland)
+	)
+
+	if use opengl || use gles2; then
+		emesonargs+=( $(meson_feature egl) )
+	else
+		emesonargs+=( -Degl=disabled )
+	fi
+
+	if use opengl && use X; then
+		emesonargs+=( -Dglx=enabled )
+	else
+		emesonargs+=( -Dglx=disabled )
+	fi
+
+	# Workaround EGL/eglplatform.h being built with X11 present
+	use X || export CFLAGS="${CFLAGS} -DEGL_NO_X11"
+
+	gstreamer_multilib_src_configure
+}


### PR DESCRIPTION
This ebuild conver the change in this mesa commit: https://gitweb.gentoo.org/repo/gentoo.git/commit/?id=847bd6034a9b3d885de3419a53084595bef9e8ac

I don't sure I missed any other gst-plugins since I only use this two, also I try to make condition useflag, but was not working well. That I removed gles2 and egl and add opengl

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
