### PR TITLE
sys-fs/zfs: introduce scrub script

### DIFF
--- a/sys-fs/zfs/files/scrub-gentoo
+++ b/sys-fs/zfs/files/scrub-gentoo
@@ -1,0 +1,45 @@
+#!/bin/sh -eu
+
+# scrub script
+# based on https://wiki.alpinelinux.org/wiki/ZFS_scrub_and_trim
+
+# directly exit successfully when zfs module is not loaded
+if ! [ -d /sys/module/zfs ]; then
+	exit 0
+fi
+
+# [auto] / enable / disable
+PROPERTY_NAME="org.gentoo:periodic-scrub"
+
+get_property () {
+	# Detect the ${PROPERTY_NAME} property on a given pool.
+	pool="$1"
+	zpool get -pH -o value "${PROPERTY_NAME}" "${pool}" 2>/dev/null || return 1
+}
+
+scrub_if_not_scrub_in_progress () {
+	pool="$1"
+	if ! zpool status "${pool}" | grep -q "scrub in progress"; then
+		# Ignore errors and continue with scrubbing other pools.
+		zpool scrub "${pool}" || true
+	fi
+}
+
+# Scrub all healthy pools that are not already scrubbing as per their configs.
+zpool list -H -o health,name 2>&1 | awk -F'\t' '$1 == "ONLINE" {print $2}' | \
+while read pool
+do
+	# read user-defined config
+	ret=$(get_property "${pool}")
+	if [ $? -ne 0 ] || [ "disable" = "${ret}" ]; then
+		:
+	elif [ "-" = "${ret}" ] || [ "auto" = "${ret}" ] || [ "enable" = "${ret}" ]; then
+		scrub_if_not_scrub_in_progress "${pool}"
+	else
+		cat > /dev/stderr <<EOF
+$0: [WARNING] illegal value "${ret}" for property "${PROPERTY_NAME}" of ZFS dataset "${pool}".
+$0: Acceptable choices for this property are: auto, enable, disable. The default is auto.
+EOF
+	fi
+done
+

--- a/sys-fs/zfs/zfs-2.2.4-r1.ebuild
+++ b/sys-fs/zfs/zfs-2.2.4-r1.ebuild
@@ -105,6 +105,8 @@ RESTRICT="test"
 
 PATCHES=(
 	"${FILESDIR}"/2.1.5-dracut-zfs-missing.patch
+	"${FILESDIR}"/2.2.2-no-USER_NS.patch
+	"${FILESDIR}"/2.2.3-musl.patch
 )
 
 pkg_pretend() {


### PR DESCRIPTION
Introduce scrub script for automation on OpenRC systems. By default this script triggers scrubbing all online pools. To disable scrub on certain pool user need to add user-defined property
`org.gentoo:periodic-scrub=disable`:

```
zpool set org.gentoo:periodic-scrub=disable rpool
```

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [ ] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [ ] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [ ] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
