### PR TITLE
app-editors/emacs: added alsa-utils as a dependecy for the alsa USE flag

### DIFF
--- a/app-editors/emacs/emacs-29.3-r3.ebuild
+++ b/app-editors/emacs/emacs-29.3-r3.ebuild
@@ -101,7 +101,7 @@ X_DEPEND="x11-libs/libICE
 RDEPEND="app-emacs/emacs-common[games?,gui(-)?]
 	sys-libs/ncurses:0=
 	acl? ( virtual/acl )
-	alsa? ( media-libs/alsa-lib )
+	alsa? ( media-libs/alsa-lib media-sound/alsa-utils )
 	dbus? ( sys-apps/dbus )
 	games? ( acct-group/gamestat )
 	gmp? ( dev-libs/gmp:0= )

--- a/app-editors/emacs/emacs-30.0.9999.ebuild
+++ b/app-editors/emacs/emacs-30.0.9999.ebuild
@@ -98,7 +98,7 @@ X_DEPEND="x11-libs/libICE
 RDEPEND="app-emacs/emacs-common[games?,gui(-)?]
 	sys-libs/ncurses:0=
 	acl? ( virtual/acl )
-	alsa? ( media-libs/alsa-lib )
+	alsa? ( media-libs/alsa-lib media-sound/alsa-utils )
 	dbus? ( sys-apps/dbus )
 	games? ( acct-group/gamestat )
 	gmp? ( dev-libs/gmp:0= )


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/931909

org-clock-play-sound uses "aplay" to play sounds; yet it is not an emacs dependency.  See Bugzilla link for more information
<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
