### PR TITLE
profiles: mask dev-lang/python[jit] on musl

### DIFF
--- a/profiles/features/musl/package.use.mask
+++ b/profiles/features/musl/package.use.mask
@@ -1,6 +1,11 @@
 # Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Violet Purcell <vimproved@inventati.org> (2024-05-15)
+# Python does not support JIT on musl, see
+# https://peps.python.org/pep-0744/#support.
+dev-lang/python jit
+
 # Robert Förster <Dessa@gmake.de> (2024-05-06)
 # dev-db/mongodb is masked on musl
 dev-libs/mongo-c-driver test


### PR DESCRIPTION
As of now, Python does not support the new JIT on musl, see https://peps.python.org/pep-0744/#support. While it may still theoretically work, musl triples cause the hardcoded target triple check to fail.

Closes: https://bugs.gentoo.org/931772

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
