### PR TITLE
sys-fs/mdadm: Do not call gcc directly

### DIFF
--- a/sys-fs/mdadm/files/mdadm-4.3-do-not-call-gcc-directly.patch
+++ b/sys-fs/mdadm/files/mdadm-4.3-do-not-call-gcc-directly.patch
@@ -1,0 +1,50 @@
+From b7028334f2dfbb0b11cf1fa34ecb89d5287c367b Mon Sep 17 00:00:00 2001
+From: Gwendal Grignou <gwendal@chromium.org>
+Date: Wed, 15 May 2024 14:30:59 -0700
+Subject: [PATCH] Makefile: Do not call gcc directly
+
+When mdadm is compiled with clang, direct gcc will fail.
+Make sure to use $(CC) variable instead.
+
+Note that Clang does not support --help=warnings --
+-print-diagnostic-options should be used instead.
+So with Clang, the compilation will go through, but the
+extra warning flags will never be added.
+
+Signed-off-by: Gwendal Grignou <gwendal@chromium.org>
+---
+ Makefile | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index adac7905..ec8c4226 100644
+--- a/Makefile
++++ b/Makefile
+@@ -56,21 +56,21 @@ CWFLAGS += -Wp -O3
+ endif
+ 
+ ifeq ($(origin FALLTHROUGH), undefined)
+-	FALLTHROUGH := $(shell gcc -Q --help=warnings 2>&1 | grep "implicit-fallthrough" | wc -l)
++	FALLTHROUGH := $(shell $(CC) $(CFLAGS) -Q --help=warnings 2>&1 | grep "implicit-fallthrough" | wc -l)
+ 	ifneq "$(FALLTHROUGH)"  "0"
+ 	CWFLAGS += -Wimplicit-fallthrough=0
+ 	endif
+ endif
+ 
+ ifeq ($(origin FORMATOVERFLOW), undefined)
+-	FORMATOVERFLOW := $(shell gcc -Q --help=warnings 2>&1 | grep "format-overflow" | wc -l)
++	FORMATOVERFLOW := $(shell $(CC) $(CFLAGS) -Q --help=warnings 2>&1 | grep "format-overflow" | wc -l)
+ 	ifneq "$(FORMATOVERFLOW)"  "0"
+ 	CWFLAGS += -Wformat-overflow
+ 	endif
+ endif
+ 
+ ifeq ($(origin STRINGOPOVERFLOW), undefined)
+-	STRINGOPOVERFLOW := $(shell gcc -Q --help=warnings 2>&1 | grep "stringop-overflow" | wc -l)
++	STRINGOPOVERFLOW := $(shell $(CC) $(CFLAGS) -Q --help=warnings 2>&1 | grep "stringop-overflow" | wc -l)
+ 	ifneq "$(STRINGOPOVERFLOW)"  "0"
+ 	CWFLAGS += -Wstringop-overflow
+ 	endif
+-- 
+2.45.0.215.g3402c0e53f-goog
+

--- a/sys-fs/mdadm/mdadm-4.3-r1.ebuild
+++ b/sys-fs/mdadm/mdadm-4.3-r1.ebuild
@@ -37,6 +37,7 @@ PATCHES=(
 	"${FILESDIR}/${PN}"-4.3-ldflags.patch
 	"${FILESDIR}/${PN}"-4.3-no-udev.patch
 	"${FILESDIR}/${PN}"-4.3-musl125-1.patch
+	"${FILESDIR}/${PN}"-4.3-do-not-call-gcc-directly.patch # 931972
 	"${WORKDIR}/debian/patches/debian/0001-fix-manpages.patch"
 	"${WORKDIR}/debian/patches/debian/0003-host-name-in-default-mailfrom.patch"
 	"${WORKDIR}/debian/patches/debian/0004-exit-gracefully-when-md-device-not-found.patch"


### PR DESCRIPTION
When gcc is not used (clang is used on Chromeos), emerge will fails.

Closes: https://bugs.gentoo.org/931972

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
