### PR TITLE
app-shells/nushell: make X11 optional

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -11,6 +11,7 @@ Andrew Ammerlaan <andrewammerlaan@gentoo.org> <andrewammerlaan@riseup.net>
 Andrew Ammerlaan <andrewammerlaan@gentoo.org> <andrew.ammerlaan@ru.nl>
 Andrew Ammerlaan <andrewammerlaan@gentoo.org> <nowa-ammerlaan@riseup.net>
 Arsen Arsenović <arsen@gentoo.org> <arsen@aarsen.me>
+Christopher Bayliss <cjbdev@icloud.com> <cjb@cjb.sh>
 Florian Schmaus <flow@gentoo.org> <flo@geekplace.eu>
 Ionen Wolkens <ionen@gentoo.org> <sudinave@gmail.com>
 Joonas Niilola <juippis@gentoo.org> <juippis@gmail.com>
@@ -18,9 +19,9 @@ Maciej Barć <xgqt@gentoo.org> <xgqt@protonmail.com>
 Maciej Barć <xgqt@gentoo.org> <xgqt@riseup.net>
 Marek Szuba <marecki@gentoo.org> <Marek.Szuba@cern.ch>
 Martin Dummer <martin.dummer@gmx.net> <martin.dummer@ts.fujitsu.com>
+Michal Privoznik <michal.privoznik@gmail.com> Michal Prívozník <michal.privoznik@gmail.com>
 Michal Privoznik <michal.privoznik@gmail.com> <miso.privoznik@gmail.com>
 Michal Privoznik <michal.privoznik@gmail.com> <mprivozn@redhat.com>
-Michal Privoznik <michal.privoznik@gmail.com> Michal Prívozník <michal.privoznik@gmail.com>
 Petr Vaněk <arkamar@gentoo.org> <arkamar () atlas ! cz>
 Petr Vaněk <arkamar@gentoo.org> <arkamar@atlas.cz>
 Petr Vaněk <arkamar@gentoo.org> <pv@excello.cz>

--- a/app-shells/nushell/nushell-0.91.0.ebuild
+++ b/app-shells/nushell/nushell-0.91.0.ebuild
@@ -663,7 +663,7 @@ LICENSE+="
 "
 SLOT="0"
 KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv"
-IUSE="dataframe extra"
+IUSE="dataframe extra X"
 
 DEPEND="
 	>=dev-libs/libgit2-0.99:=
@@ -673,8 +673,10 @@ DEPEND="
 	net-libs/nghttp2:=
 	net-misc/curl
 	dev-db/sqlite:3=
-	x11-libs/libX11
-	x11-libs/libxcb
+	X? (
+		x11-libs/libX11
+		x11-libs/libxcb
+	)
 "
 RDEPEND="${DEPEND}"
 BDEPEND="

--- a/app-shells/nushell/nushell-0.92.1.ebuild
+++ b/app-shells/nushell/nushell-0.92.1.ebuild
@@ -657,7 +657,7 @@ LICENSE+="
 "
 SLOT="0"
 KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv"
-IUSE="dataframe"
+IUSE="dataframe X"
 
 DEPEND="
 	>=dev-libs/libgit2-0.99:=
@@ -667,8 +667,10 @@ DEPEND="
 	net-libs/nghttp2:=
 	net-misc/curl
 	dev-db/sqlite:3=
-	x11-libs/libX11
-	x11-libs/libxcb
+	X? (
+		x11-libs/libX11
+		x11-libs/libxcb
+	)
 "
 RDEPEND="${DEPEND}"
 BDEPEND="


### PR DESCRIPTION
X11 is use for clipboard support on X systems as far as I can tell, but that isn't needed on systems without X.

I also corrected my email address in .mailcap
<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
