### PR TITLE
net-vpn/i2p: restrict to >=virtual/jdk-11:* for #932030

### DIFF
--- a/net-vpn/i2p/i2p-2.3.0-r3.ebuild
+++ b/net-vpn/i2p/i2p-2.3.0-r3.ebuild
@@ -41,12 +41,13 @@ CP_DEPEND="
 	sys-devel/gettext:0[java]
 	www-servers/tomcat:9
 "
+# jdk-11 for bug #932030
 DEPEND="
 	dev-libs/gmp:0=
 	${CP_DEPEND}
-	>=virtual/jdk-1.8:*
+	>=virtual/jdk-11:*
 	test? (
-		dev-java/ant:0[junit4]
+		>=dev-java/ant-1.10.14-r3:0[junit4]
 		dev-java/hamcrest:0
 		dev-java/junit:4
 		dev-java/mockito:4
@@ -74,21 +75,6 @@ EANT_GENTOO_CLASSPATH_EXTRA+=":${S}/router/java/build/router.jar"
 EANT_GENTOO_CLASSPATH_EXTRA+=":${S}/apps/ministreaming/java/build/mstreaming.jar"
 
 DOCS=( README.md history.txt )
-
-pkg_pretend() {
-	# see https://bugs.gentoo.org/831290
-	if [[ "`java-config --show-active-vm`" = *-8 ]] &&
-		[[ "`java-config --query MERGE_VM --package=ant-core`" != *-8 ]]
-	then
-		eerror "dev-java/ant-core was emerged with a newer version of the JDK."
-		eerror "It will fail to build with virtual/jdk:1.8 due to #831290."
-		eerror "Please switch to a newer JDK"
-		eerror "  eselect java-vm set system ..."
-		eerror "Or remerge dev-java/ant-core with virtual/jdk:1.8"
-		eerror "  emerge dev-java/ant-core"
-		die 'bad JDK for ant-core'
-	fi
-}
 
 src_prepare() {
 	default # apply PATCHES


### PR DESCRIPTION
- Updates to >=dev-java/ant-1.10.14-r3
- Removes obsolete check for MERGE_VM

Closes: https://bugs.gentoo.org/932030

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
