### PR TITLE
app-emulation/hercules-sdl: fix modern-C99, file collision

### DIFF
--- a/app-emulation/hercules-sdl/files/hercules-sdl-4.7.0-backport-pr658.patch
+++ b/app-emulation/hercules-sdl/files/hercules-sdl-4.7.0-backport-pr658.patch
@@ -1,0 +1,46 @@
+https://bugs.gentoo.org/931607
+https://github.com/SDL-Hercules-390/hyperion/pull/658
+
+From 655f179dbf34a3b1e9714691462faa9732257937 Mon Sep 17 00:00:00 2001
+From: matoro <matoro@users.noreply.github.com>
+Date: Thu, 9 May 2024 12:36:01 -0400
+Subject: [PATCH] Add missing includes to configure script
+
+This is needed for gcc 14 and clang 16 as they both make implicit
+function definitions a hard error.  In a configure script, this means
+these tests will switch from passing to failing, which likely means
+features will get unintentionally flipped as configure now thinks you
+don't have support.
+
+See: https://wiki.gentoo.org/wiki/Modern_C_porting
+See: https://bugs.gentoo.org/931607
+---
+ autoconf/hercules.m4 | 1 +
+ configure.ac         | 2 ++
+ 2 files changed, 3 insertions(+)
+
+diff --git a/autoconf/hercules.m4 b/autoconf/hercules.m4
+index cb962f5e0..4d35cb039 100755
+--- a/autoconf/hercules.m4
++++ b/autoconf/hercules.m4
+@@ -380,6 +380,7 @@ AC_DEFUN([HC_CHECK_NEED_GETOPT_OPTRESET],
+             AC_TRY_LINK(
+                 [],
+                 [
++                    #include <unistd.h>
+                     extern int optreset;
+                     optreset=1;
+                     getopt(0,0,0);
+diff --git a/configure.ac b/configure.ac
+index f444a9b1e..bfe31357d 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -1872,6 +1872,8 @@ if test "$GCC" = "yes"; then
+                             -g -O2 -fomit-frame-pointer
+                     */
+ 
++                    #include <string.h>
++
+                     int foo ()
+                     {
+                         char a[50000+16];

--- a/app-emulation/hercules-sdl/hercules-sdl-4.7.0-r1.ebuild
+++ b/app-emulation/hercules-sdl/hercules-sdl-4.7.0-r1.ebuild
@@ -1,0 +1,89 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools fcaps
+
+DESCRIPTION="The SoftDevLabs (SDL) version of the Hercules 4.x Hyperion Emulator"
+HOMEPAGE="https://sdl-hercules-390.github.io/html/"
+SRC_URI="https://github.com/SDL-Hercules-390/hyperion/archive/refs/tags/Release_${PV/.0/}.tar.gz -> ${P/.0/}.tar.gz"
+
+S="${WORKDIR}/hyperion-Release_${PV/.0/}"
+LICENSE="QPL-1.0"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc64"
+# In theory USE=object-rexx and USE=regina-rexx are not mutually-exclusive.
+# In practice they functionally are as the Gentoo packages conflict, and
+# additionally Hercules only supports calling out to one of them at runtime,
+# controlled by the HREXX_PACKAGE environment variable.
+IUSE="bzip2 debug object-rexx regina-rexx test"
+RESTRICT="!test? ( test )"
+FILECAPS=(
+	-M 755 cap_sys_nice\=eip usr/bin/hercules --
+	-M 755 cap_sys_nice\=eip usr/bin/herclin --
+	-M 755 cap_net_admin+ep usr/bin/hercifc
+)
+
+RDEPEND="
+	!app-emulation/hercules
+	dev-libs/libltdl
+	net-libs/libnsl:0
+	sys-libs/zlib
+	bzip2? ( app-arch/bzip2 )
+	object-rexx? ( dev-lang/oorexx )
+	regina-rexx? ( dev-lang/regina-rexx )"
+DEPEND="${RDEPEND}
+	~app-emulation/hercules-sdl-crypto-${PV}
+	~app-emulation/hercules-sdl-decnumber-${PV}
+	~app-emulation/hercules-sdl-softfloat-${PV}
+	~app-emulation/hercules-sdl-telnet-${PV}"
+# Neither package support needs to be compiled-in for tests,
+# but the "rexx" command needs to be available
+BDEPEND="${RDEPEND}
+	test? ( || ( dev-lang/regina-rexx dev-lang/oorexx ) )"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-4.4.1-htmldir.patch"
+	"${FILESDIR}/${PN}-4.7.0-backport-pr658.patch"
+)
+
+src_prepare() {
+	rm -rf crypto decNumber SoftFloat telnet || die
+	sed -i 's#/lib${hc_cv_pkg_lib_subdir}#/lib#g' configure.ac || die
+	sed -i 's#_pkgname}${hc_cv_pkg_lib_suffix}#_pkgname}#g' configure.ac || die
+
+	default
+	eautoreconf
+}
+
+src_configure() {
+	local -x ac_cv_lib_bz2_BZ2_bzBuffToBuffDecompress=$(usex bzip2)
+	econf \
+		$(use_enable bzip2 cckd-bzip2) \
+		$(use_enable bzip2 het-bzip2) \
+		$(use_enable object-rexx) \
+		$(use_enable regina-rexx) \
+		$(use_enable debug) \
+		--enable-custom="Gentoo ${PF}.ebuild" \
+		--disable-optimization \
+		--disable-setuid-hercifc \
+		--disable-capabilities \
+		--enable-ipv6 \
+		--enable-enhanced-configincludes \
+		--disable-fthreads \
+		--enable-shared \
+		--enable-automatic-operator \
+		--enable-extpkgs="${SYSROOT}/usr/$(get_libdir)/${PN}"
+}
+
+src_install() {
+	default
+	dodoc RELEASE.NOTES
+
+	insinto /usr/share/hercules
+	doins hercules.cnf
+
+	# No static archives.  Have to leave .la files for modules. #720342
+	find "${ED}/usr/$(get_libdir)" -name "*.la" -delete || die
+}


### PR DESCRIPTION
Touching just configure.ac is fine as we call eautoreconf in ebuild.

See: https://github.com/SDL-Hercules-390/hyperion/pull/658
Closes: https://bugs.gentoo.org/931607
Closes: https://bugs.gentoo.org/931610

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
