### PR TITLE
sys-boot/os-prober: Make boot-detected-twice patch POSIX sh compliant

### DIFF
--- a/sys-boot/os-prober/files/os-prober-1.81-boot-detected-twice-v3.patch
+++ b/sys-boot/os-prober/files/os-prober-1.81-boot-detected-twice-v3.patch
@@ -1,0 +1,57 @@
+diff --git a/common.sh b/common.sh
+index cc7a335..820caea 100644
+--- a/common.sh
++++ b/common.sh
+@@ -326,3 +326,26 @@ umount() {
+ 	fi
+ }
+ 
++list_mounts() {
++	if [ -f /proc/self/mountinfo ]; then
++		local x dev mount devs found mountinfo_placeholders
++		found=:
++
++		# mountinfo may have 10 or 11 fields depending on mount namespaces
++		if [ $(head -n1 /proc/self/mountinfo | wc -w) -eq 10 ]; then
++			mountinfo_placeholders="x x"
++		else
++			mountinfo_placeholders="x x x"
++		fi
++
++		while read -r x x dev x mount ${mountinfo_placeholders} fs x; do
++			if [ -L "/sys/dev/block/$dev" ]; then
++				devs="/dev/`readlink \"/sys/dev/block/$dev\" | rev | cut -d/ -f1 | rev`"
++				printf '%s %s %s\n' "$(mapdevfs "$devs")" "$mount" "$fs"
++				found="return 0"
++			fi
++		done < /proc/self/mountinfo
++		$found
++	fi
++	grep "^/dev/" /proc/mounts | parse_proc_mounts
++}
+diff --git a/linux-boot-prober b/linux-boot-prober
+index bacf219..804d9fe 100755
+--- a/linux-boot-prober
++++ b/linux-boot-prober
+@@ -17,7 +17,7 @@ bootmnt=
+ bootsv=
+ bootuuid=
+ 
+-grep "^/dev/" /proc/mounts | parse_proc_mounts >"$OS_PROBER_TMP/mounted-map" || true
++list_mounts >"$OS_PROBER_TMP/mounted-map" || true
+ 
+ if [ -z "$1" ]; then
+ 	ERR=y
+diff --git a/os-prober b/os-prober
+index b76d85b..8b0c89b 100755
+--- a/os-prober
++++ b/os-prober
+@@ -128,7 +128,7 @@ done
+ 
+ # We need to properly canonicalize partitions with mount points and partitions
+ # used in RAID
+-grep "^/dev/" /proc/mounts | parse_proc_mounts >"$OS_PROBER_TMP/mounted-map" || true
++list_mounts >"$OS_PROBER_TMP/mounted-map" || true
+ : >"$OS_PROBER_TMP/swaps-map"
+ if [ -f /proc/swaps ]; then
+ 	grep "^/dev/" /proc/swaps | parse_proc_swaps >"$OS_PROBER_TMP/swaps-map" || true

--- a/sys-boot/os-prober/os-prober-1.81-r3.ebuild
+++ b/sys-boot/os-prober/os-prober-1.81-r3.ebuild
@@ -1,0 +1,103 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+inherit readme.gentoo-r1 toolchain-funcs
+
+DESCRIPTION="Utility to detect other OSs on a set of drives"
+HOMEPAGE="https://salsa.debian.org/installer-team/os-prober"
+
+if [[ ${PV} == 9999 ]]; then
+	inherit git-r3
+	EGIT_REPO_URI="https://salsa.debian.org/installer-team/${PN}.git"
+else
+	SRC_URI="mirror://debian/pool/main/${PN::1}/${PN}/${PN}_${PV}.tar.xz"
+	KEYWORDS="~amd64 ~x86"
+fi
+
+LICENSE="GPL-3"
+SLOT="0"
+
+# grub-mount needed per bug #607518
+RDEPEND="sys-boot/grub:2[mount]"
+
+# bug 594250
+QA_MULTILIB_PATHS="usr/lib/os-prober/.*"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-1.79-mdraid-detection.patch
+	"${FILESDIR}"/${PN}-1.79-btrfs-subvolume-detection.patch
+	"${FILESDIR}"/${PN}-1.79-use-fstab-name.patch
+	"${FILESDIR}"/${PN}-1.79-mounted-boot-partition-fix.patch
+	"${FILESDIR}"/${PN}-1.79-fix-busy-umount-message.patch
+	"${FILESDIR}"/${PN}-1.79-efi-chroot-blkid-fallback.patch
+	"${FILESDIR}"/${PN}-1.81-boot-detected-twice-v3.patch
+)
+
+DOC_CONTENTS="
+	If you intend for os-prober to detect versions of Windows installed on
+	NTFS-formatted partitions, your system must be capable of reading the
+	NTFS filesystem. One way to do this is by installing sys-fs/ntfs3g.
+
+	NOTE: Since sys-boot/grub-2.06-rc1, grub-mkconfig disables os-prober by default.
+	To enable it, add GRUB_DISABLE_OS_PROBER=false to /etc/default/grub.
+"
+
+src_prepare() {
+	default
+	# use default GNU rules
+	rm Makefile || die 'rm Makefile failed'
+}
+
+src_compile() {
+	tc-export CC
+	emake newns
+}
+
+src_install() {
+	dobin os-prober linux-boot-prober
+
+	# Note: as no shared libraries are installed, /usr/lib is correct
+	exeinto /usr/lib/os-prober
+	doexe newns
+
+	insinto /usr/share/os-prober
+	doins common.sh
+
+	keepdir /var/lib/os-prober
+
+	local debarch=${ARCH%-*} dir
+
+	case ${debarch} in
+		amd64)		debarch=x86 ;;
+		ppc|ppc64)	debarch=powerpc ;;
+	esac
+
+	for dir in os-probes{,/mounted,/init} linux-boot-probes{,/mounted}; do
+		exeinto /usr/lib/${dir}
+		doexe ${dir}/common/*
+		if [[ -d ${dir}/${debarch} ]]; then
+			for exe in ${dir}/${debarch}/*; do
+				[[ ! -d "${exe}" ]] && doexe "${exe}"
+			done
+		fi
+		if [[ -d ${dir}/${debarch}/efi ]]; then
+			exeinto /usr/lib/${dir}/efi
+			doexe ${dir}/${debarch}/efi/*
+		fi
+	done
+
+	if use amd64 || use x86; then
+		exeinto /usr/lib/os-probes/mounted
+		doexe os-probes/mounted/powerpc/20macosx
+	fi
+
+	einstalldocs
+	dodoc debian/changelog
+
+	readme.gentoo_create_doc
+}
+
+pkg_postinst() {
+	readme.gentoo_print_elog
+}


### PR DESCRIPTION
This versions modfies the patch added by -r2 to be POSIX sh compliant. For this we just replace the '==' in line 15 with '-eq'.

Closes: https://bugs.gentoo.org/932098

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
