### PR TITLE
media-gfx/graphicsmagick: reinstate JPEG-2000 support, remove broken USE="svg"

### DIFF
--- a/media-gfx/graphicsmagick/graphicsmagick-1.3.43-r1.ebuild
+++ b/media-gfx/graphicsmagick/graphicsmagick-1.3.43-r1.ebuild
@@ -16,8 +16,8 @@ else
 	VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/openpgp-keys/bobfriesenhahn.asc
 	inherit verify-sig
 
-	SRC_URI="https://downloads.sourceforge.net/${PN}/${MY_P}.tar.xz"
-	SRC_URI+=" verify-sig? ( https://downloads.sourceforge.net/${PN}/${MY_P}.tar.xz.asc )"
+	SRC_URI="https://downloads.sourceforge.net/project/${PN}/${PN}-history/$(ver_cut 1-2)/${MY_P}.tar.xz"
+	SRC_URI+=" verify-sig? ( https://downloads.sourceforge.net/project/${PN}/${PN}-history/$(ver_cut 1-2)/${MY_P}.tar.xz.asc )"
 	S="${WORKDIR}/${MY_P}"
 
 	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~ppc ~ppc64 ~riscv ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos"

--- a/media-gfx/graphicsmagick/graphicsmagick-1.3.43-r1.ebuild
+++ b/media-gfx/graphicsmagick/graphicsmagick-1.3.43-r1.ebuild
@@ -7,10 +7,10 @@ inherit autotools toolchain-funcs
 
 MY_P=${P/graphicsm/GraphicsM}
 DESCRIPTION="Collection of tools and libraries for many image formats"
-HOMEPAGE="http://www.graphicsmagick.org/ https://hg.osdn.net/view/graphicsmagick/GM"
+HOMEPAGE="http://www.graphicsmagick.org/ https://foss.heptapod.net/graphicsmagick/graphicsmagick"
 
 if [[ ${PV} == 9999 ]] ; then
-	EHG_REPO_URI="http://hg.code.sf.net/p/${PN}/code"
+	EHG_REPO_URI="https://foss.heptapod.net/${PN}/${PN}"
 	inherit mercurial
 else
 	VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/openpgp-keys/bobfriesenhahn.asc

--- a/media-gfx/graphicsmagick/graphicsmagick-1.3.43-r1.ebuild
+++ b/media-gfx/graphicsmagick/graphicsmagick-1.3.43-r1.ebuild
@@ -69,6 +69,7 @@ BDEPEND+=" virtual/pkgconfig"
 PATCHES=(
 	"${FILESDIR}"/${PN}-1.3.41-flags.patch
 	"${FILESDIR}"/${PN}-1.3.41-perl.patch
+	"${FILESDIR}"/${PN}-1.3.43-bashism.patch
 )
 
 pkg_pretend() {

--- a/media-gfx/graphicsmagick/graphicsmagick-1.3.43-r1.ebuild
+++ b/media-gfx/graphicsmagick/graphicsmagick-1.3.43-r1.ebuild
@@ -28,7 +28,7 @@ fi
 LICENSE="MIT"
 SLOT="0/${PV%.*}"
 IUSE="bzip2 +cxx debug dynamic-loading fpx heif imagemagick jbig jpeg jpeg2k jpegxl lcms lzma"
-IUSE+=" openmp perl png postscript q16 q32 static-libs svg tcmalloc tiff truetype"
+IUSE+=" openmp perl png postscript q16 q32 static-libs tcmalloc tiff truetype"
 IUSE+=" webp wmf X zlib zstd"
 
 RDEPEND="
@@ -46,7 +46,6 @@ RDEPEND="
 	perl? ( dev-lang/perl:= )
 	png? ( media-libs/libpng:= )
 	postscript? ( app-text/ghostscript-gpl )
-	svg? ( dev-libs/libxml2 )
 	tcmalloc? ( dev-util/google-perftools:= )
 	tiff? ( media-libs/tiff:= )
 	truetype? (
@@ -127,7 +126,6 @@ src_configure() {
 		--with-fontpath="${EPREFIX}"/usr/share/fonts
 		--with-gs-font-dir="${EPREFIX}"/usr/share/fonts/urw-fonts
 		--with-windows-font-dir="${EPREFIX}"/usr/share/fonts/corefonts
-		$(use_with svg xml)
 		$(use_with zlib)
 		$(use_with zstd)
 		$(use_with X x)

--- a/media-gfx/graphicsmagick/graphicsmagick-9999.ebuild
+++ b/media-gfx/graphicsmagick/graphicsmagick-9999.ebuild
@@ -16,8 +16,8 @@ else
 	VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/openpgp-keys/bobfriesenhahn.asc
 	inherit verify-sig
 
-	SRC_URI="https://downloads.sourceforge.net/${PN}/${MY_P}.tar.xz"
-	SRC_URI+=" verify-sig? ( https://downloads.sourceforge.net/${PN}/${MY_P}.tar.xz.asc )"
+	SRC_URI="https://downloads.sourceforge.net/project/${PN}/${PN}-history/$(ver_cut 1-2)/${MY_P}.tar.xz"
+	SRC_URI+=" verify-sig? ( https://downloads.sourceforge.net/project/${PN}/${PN}-history/$(ver_cut 1-2)/${MY_P}.tar.xz.asc )"
 	S="${WORKDIR}/${MY_P}"
 
 	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~ppc ~ppc64 ~riscv ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos"

--- a/media-gfx/graphicsmagick/graphicsmagick-9999.ebuild
+++ b/media-gfx/graphicsmagick/graphicsmagick-9999.ebuild
@@ -7,10 +7,10 @@ inherit autotools toolchain-funcs
 
 MY_P=${P/graphicsm/GraphicsM}
 DESCRIPTION="Collection of tools and libraries for many image formats"
-HOMEPAGE="http://www.graphicsmagick.org/ https://hg.osdn.net/view/graphicsmagick/GM"
+HOMEPAGE="http://www.graphicsmagick.org/ https://foss.heptapod.net/graphicsmagick/graphicsmagick"
 
 if [[ ${PV} == 9999 ]] ; then
-	EHG_REPO_URI="http://hg.code.sf.net/p/${PN}/code"
+	EHG_REPO_URI="https://foss.heptapod.net/${PN}/${PN}"
 	inherit mercurial
 else
 	VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/openpgp-keys/bobfriesenhahn.asc

--- a/media-gfx/graphicsmagick/graphicsmagick-9999.ebuild
+++ b/media-gfx/graphicsmagick/graphicsmagick-9999.ebuild
@@ -28,7 +28,7 @@ fi
 LICENSE="MIT"
 SLOT="0/${PV%.*}"
 IUSE="bzip2 +cxx debug dynamic-loading fpx heif imagemagick jbig jpeg jpeg2k jpegxl lcms lzma"
-IUSE+=" openmp perl png postscript q16 q32 static-libs svg tcmalloc tiff truetype"
+IUSE+=" openmp perl png postscript q16 q32 static-libs tcmalloc tiff truetype"
 IUSE+=" webp wmf X zlib zstd"
 
 RDEPEND="
@@ -46,7 +46,6 @@ RDEPEND="
 	perl? ( dev-lang/perl:= )
 	png? ( media-libs/libpng:= )
 	postscript? ( app-text/ghostscript-gpl )
-	svg? ( dev-libs/libxml2 )
 	tcmalloc? ( dev-util/google-perftools:= )
 	tiff? ( media-libs/tiff:= )
 	truetype? (
@@ -126,7 +125,6 @@ src_configure() {
 		--with-fontpath="${EPREFIX}"/usr/share/fonts
 		--with-gs-font-dir="${EPREFIX}"/usr/share/fonts/urw-fonts
 		--with-windows-font-dir="${EPREFIX}"/usr/share/fonts/corefonts
-		$(use_with svg xml)
 		$(use_with zlib)
 		$(use_with zstd)
 		$(use_with X x)

--- a/media-gfx/graphicsmagick/metadata.xml
+++ b/media-gfx/graphicsmagick/metadata.xml
@@ -26,5 +26,6 @@
 	</use>
 	<upstream>
 		<remote-id type="sourceforge">graphicsmagick</remote-id>
+		<remote-id type="heptapod">graphicsmagick/graphicsmagick</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/media-gfx/tuxpaint/tuxpaint-0.9.31-r1.ebuild
+++ b/media-gfx/tuxpaint/tuxpaint-0.9.31-r1.ebuild
@@ -1,0 +1,65 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit desktop optfeature toolchain-funcs xdg
+
+DESCRIPTION="Drawing program designed for young children"
+HOMEPAGE="https://www.tuxpaint.org/"
+SRC_URI="https://downloads.sourceforge.net/${PN}/${P}.tar.gz"
+S="${WORKDIR}"/${P}
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86"
+
+RDEPEND="
+	app-text/libpaper:=
+	dev-libs/fribidi
+	gnome-base/librsvg:2
+	media-gfx/libimagequant
+	>=media-libs/freetype-2:2
+	>=media-libs/libpng-1.2:0=
+	media-libs/libsdl2[X,joystick]
+	media-libs/sdl2-gfx
+	media-libs/sdl2-image[png]
+	media-libs/sdl2-mixer
+	media-libs/sdl2-pango
+	media-libs/sdl2-ttf
+	sys-libs/zlib
+	x11-libs/cairo
+"
+DEPEND="${RDEPEND}"
+BDEPEND="
+	dev-util/gperf
+	media-gfx/graphicsmagick[jpeg,png]
+	sys-devel/gettext
+"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-Makefile.patch
+)
+
+src_compile() {
+	emake CC="$(tc-getCC)" GENTOO_LIBDIR="$(get_libdir)"
+}
+
+src_install() {
+	emake DESTDIR="${D}" GENTOO_LIBDIR="$(get_libdir)" install
+	local file size
+	for file in data/images/icon[0-9]*x[0-9]*.png; do
+		size=${file##*/icon}
+		size=${size%%x*}
+		newicon -s "${size}" "${file}" tux4kids-tuxpaint.png
+	done
+	newmenu src/tuxpaint.desktop tux4kids-tuxpaint.desktop
+	docinto /usr/share/doc/${PF}
+	dodoc docs/*.txt
+	dodoc docs/en/*.txt
+}
+
+pkg_postinst() {
+	xdg_pkg_postinst
+	optfeature "additional graphic stamps" media-gfx/tuxpaint-stamps
+}

--- a/profiles/arch/hppa/package.use.mask
+++ b/profiles/arch/hppa/package.use.mask
@@ -29,6 +29,10 @@ dev-lang/php capstone
 # sys-apps/xdg-desktop-portal not keyworded here yet
 x11-base/xwayland libei
 
+# Holger Hoffstätte <holger@applied-asynchrony.com> (2024-05-19)
+# media-libs/jasper not yet keyworded here: https://bugs.gentoo.org/921559
+media-gfx/graphicsmagick jpeg2k
+
 # James Le Cuirot (2023-12-12)
 # USE=bpf depends on sys-devel/clang which is not keyworded on hppa
 media-libs/libv4l bpf

--- a/virtual/imagemagick-tools/imagemagick-tools-0-r2.ebuild
+++ b/virtual/imagemagick-tools/imagemagick-tools-0-r2.ebuild
@@ -1,0 +1,21 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="Virtual for imagemagick command line tools"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~arm64-macos ~ppc-macos ~x64-macos ~x64-solaris"
+IUSE="jpeg perl png svg tiff"
+
+# This virtual is to be used **ONLY** for depending on the runtime
+# tools of imagemagick/graphicsmagick. It should and cannot be used
+# for linking against, as subslots are not transitively passed on.
+# For linking, you will need to depend on the respective libraries
+# in all consuming ebuilds and use appropriate sub-slot operators.
+# See also: https://bugs.gentoo.org/314431
+RDEPEND="
+	|| (
+		media-gfx/imagemagick[jpeg?,perl?,png?,svg?,tiff?]
+		media-gfx/graphicsmagick[imagemagick,jpeg?,perl?,png?,svg(-),tiff?]
+	)"


### PR DESCRIPTION
This reinstates JPEG-2000 support, removes the broken "svg" USE flag and tidies up the imagemagick virtual to make svg optional. Also update HOMEPAGE, git repo and SRC_URI as they changed upstream.

The last commit (updating SRC_URI) is now being flagged by pkgcheck as SuspiciousSrcUriChange (probably a security measure?), so if we prefer server-side redirects then this could be skipped.

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
