### PR TITLE
mail-filter/procmail: fix modern C issues

### DIFF
--- a/mail-filter/procmail/files/procmail-3.24-modern-c.patch
+++ b/mail-filter/procmail/files/procmail-3.24-modern-c.patch
@@ -1,0 +1,255 @@
+From 8cfd570fd14c8fb9983859767ab1851bfd064b64 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jaroslav=20=C5=A0karvada?= <jskarvad@redhat.com>
+Date: Wed, 31 Jan 2024 18:41:21 +0100
+Subject: [PATCH] Fixed build with gcc-14
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Jaroslav Škarvada <jskarvad@redhat.com>
+---
+ initmake     |   4 +-
+ src/autoconf | 173 ++++++++++++++++++++++++++-------------------------
+ 2 files changed, 91 insertions(+), 86 deletions(-)
+
+diff --git a/initmake b/initmake
+index b901add..703d651 100755
+--- a/initmake
++++ b/initmake
+@@ -124,7 +124,7 @@ else
+ fi
+ 
+ cat >_autotst.c <<HERE
+-main()
++int main()
+ { return 0;
+ }
+ HERE
+@@ -200,7 +200,7 @@ cat >_autotst.c <<HERE
+ #include <sys/types.h>
+ #include <stdio.h>
+ #include <sys/stat.h>
+-main()
++int main()
+ { struct stat buf;return!&buf;
+ }
+ HERE
+diff --git a/src/autoconf b/src/autoconf
+index 7c46487..97c0bce 100755
+--- a/src/autoconf
++++ b/src/autoconf
+@@ -363,6 +363,7 @@ cat >_autotst.c <<HERE
+ #include <unistd.h>		/* getpid() getppid() */
+ #endif
+ #include <stdio.h>
++#include <stdlib.h>
+ #include <time.h>
+ #include <fcntl.h>
+ #include <signal.h>		/* SIGKILL */
+@@ -416,6 +417,16 @@ cat >_autotst.c <<HERE
+ int dolock,child[NR_of_forks],timeout,fdcollect;
+ char dirlocktest[]="_locktest";
+ 
++int killchildren()
++{ int i;
++  i=NR_of_forks;
++  do
++     if(child[--i]>0)
++	kill(child[i],SIGTERM),child[i]=0;
++  while(i);
++  return 0;
++}
++
+ void stimeout()
+ { timeout=1;close(fdcollect);killchildren();
+ }
+@@ -437,7 +448,79 @@ unsigned sfork()
+   return pid;
+ }
+ 
+-int main(argc,argv)char*argv[];
++static int oldfdlock;
++#ifdef F_SETLKW
++static struct flock flck;		/* why can't it be a local variable? */
++#endif
++#ifdef F_LOCK
++static off_t oldlockoffset;
++#endif
++
++int fdlock(int fd)
++{ int i;unsigned gobble[GOBBLE>>2];
++  for(i=GOBBLE>>2;i;gobble[--i]=~(unsigned)0);		 /* SunOS crash test */
++  oldfdlock=fd;fd=0;
++  if(MSK_fcntl&dolock)
++#ifdef F_SETLKW
++   { static unsigned extra;
++     flck.l_type=F_WRLCK;flck.l_whence=SEEK_SET;flck.l_start=tell(oldfdlock);
++     if(!extra--)
++	extra=MIN_locks/4,flck.l_len=2,i|=fcntl(oldfdlock,F_SETLK,&flck);
++     flck.l_len=0;fd|=fcntl(oldfdlock,F_SETLKW,&flck);
++   }
++#else
++     fd=1;
++#endif
++  if(MSK_lockf&dolock)
++#ifdef F_LOCK
++     oldlockoffset=tell(oldfdlock),fd|=lockf(oldfdlock,F_LOCK,(off_t)0);
++#else
++     fd=1;
++#endif
++  if(MSK_flock&dolock)
++#ifdef LOCK_EX
++     fd|=flock(oldfdlock,LOCK_EX);
++#else
++     fd=1;
++#endif
++  return fd;
++}
++
++int sfdlock(int fd)
++{ int i;unsigned gobble[GOBBLE>>2];
++  for(i=GOBBLE>>2;i;gobble[--i]=~(unsigned)0);		 /* SunOS crash test */
++  return fdlock(fd);
++}
++
++int fdunlock()
++{ int i;unsigned gobble[GOBBLE];
++  for(i=GOBBLE;i;gobble[--i]=~(unsigned)0);  /* some SunOS libs mess this up */
++  if(MSK_flock&dolock)
++#ifdef LOCK_EX
++     i|=flock(oldfdlock,LOCK_UN);
++#else
++     i=1;
++#endif
++  if(MSK_lockf&dolock)
++#ifdef F_LOCK
++   { lseek(oldfdlock,oldlockoffset,SEEK_SET);
++     i|=lockf(oldfdlock,F_LOCK,(off_t)2);i|=lockf(oldfdlock,F_ULOCK,(off_t)0);
++   }
++#else
++     i=1;
++#endif
++  if(MSK_fcntl&dolock)
++#ifdef F_SETLKW
++     flck.l_type=F_UNLCK,flck.l_len=0,i|=fcntl(oldfdlock,F_SETLK,&flck);
++#else
++     i=1;
++#endif
++  if(!i)
++     for(i=GOBBLE;i&&gobble[--i]==~(unsigned)0;);
++  return i;
++}
++
++int main(argc,argv)int argc;char*argv[];
+ { int goodlock,testlock,i,pip[2],pipw[2];time_t otimet;unsigned dtimet;
+   static char filename[]="_locktst.l0";
+   close(0);goodlock=0;testlock=FIRST_lock;signal(SIGPIPE,SIG_DFL);
+@@ -576,88 +659,6 @@ skip_tests:
+   puts("Kernel-locking tests completed.");fprintf(stderr,"\n");
+   return EXIT_SUCCESS;
+ }
+-
+-int killchildren()
+-{ int i;
+-  i=NR_of_forks;
+-  do
+-     if(child[--i]>0)
+-	kill(child[i],SIGTERM),child[i]=0;
+-  while(i);
+-  return 0;
+-}
+-
+-int sfdlock(fd)
+-{ int i;unsigned gobble[GOBBLE>>2];
+-  for(i=GOBBLE>>2;i;gobble[--i]=~(unsigned)0);		 /* SunOS crash test */
+-  return fdlock(fd);
+-}
+-
+-static oldfdlock;
+-#ifdef F_SETLKW
+-static struct flock flck;		/* why can't it be a local variable? */
+-#endif
+-#ifdef F_LOCK
+-static off_t oldlockoffset;
+-#endif
+-
+-int fdlock(fd)
+-{ int i;unsigned gobble[GOBBLE>>2];
+-  for(i=GOBBLE>>2;i;gobble[--i]=~(unsigned)0);		 /* SunOS crash test */
+-  oldfdlock=fd;fd=0;
+-  if(MSK_fcntl&dolock)
+-#ifdef F_SETLKW
+-   { static unsigned extra;
+-     flck.l_type=F_WRLCK;flck.l_whence=SEEK_SET;flck.l_start=tell(oldfdlock);
+-     if(!extra--)
+-	extra=MIN_locks/4,flck.l_len=2,i|=fcntl(oldfdlock,F_SETLK,&flck);
+-     flck.l_len=0;fd|=fcntl(oldfdlock,F_SETLKW,&flck);
+-   }
+-#else
+-     fd=1;
+-#endif
+-  if(MSK_lockf&dolock)
+-#ifdef F_LOCK
+-     oldlockoffset=tell(oldfdlock),fd|=lockf(oldfdlock,F_LOCK,(off_t)0);
+-#else
+-     fd=1;
+-#endif
+-  if(MSK_flock&dolock)
+-#ifdef LOCK_EX
+-     fd|=flock(oldfdlock,LOCK_EX);
+-#else
+-     fd=1;
+-#endif
+-  return fd;
+-}
+-
+-int fdunlock()
+-{ int i;unsigned gobble[GOBBLE];
+-  for(i=GOBBLE;i;gobble[--i]=~(unsigned)0);  /* some SunOS libs mess this up */
+-  if(MSK_flock&dolock)
+-#ifdef LOCK_EX
+-     i|=flock(oldfdlock,LOCK_UN);
+-#else
+-     i=1;
+-#endif
+-  if(MSK_lockf&dolock)
+-#ifdef F_LOCK
+-   { lseek(oldfdlock,oldlockoffset,SEEK_SET);
+-     i|=lockf(oldfdlock,F_LOCK,(off_t)2);i|=lockf(oldfdlock,F_ULOCK,(off_t)0);
+-   }
+-#else
+-     i=1;
+-#endif
+-  if(MSK_fcntl&dolock)
+-#ifdef F_SETLKW
+-     flck.l_type=F_UNLCK,flck.l_len=0,i|=fcntl(oldfdlock,F_SETLK,&flck);
+-#else
+-     i=1;
+-#endif
+-  if(!i)
+-     for(i=GOBBLE;i&&gobble[--i]==~(unsigned)0;);
+-  return i;
+-}
+ HERE
+ 
+ if $MAKE _autotst >_autotst.rrr 2>&1
+@@ -1033,6 +1034,10 @@ cat >_autotst.c <<HERE
+ #ifndef NO_COMSAT
+ #include "network.h"
+ #endif
++#include <string.h>
++#include <unistd.h>
++int setrgid();
++int setresgid();
+ int main(){char a[2];
+  endpwent();endgrent();memmove(a,"0",1);bcopy("0",a,1);strcspn(a,"0");
+  strtol("0",(char**)0,10);strchr("0",'0');strpbrk(a,"0");rename(a,"0");
+@@ -1059,7 +1064,7 @@ echo 'Testing for memmove, strchr, strpbrk, strcspn, strtol, strstr,'
+ echo '	rename, setrgid, setegid, pow, opendir, mkdir, waitpid, fsync,'
+ echo '	ftruncate, strtod, strncasecmp, strerror, strlcat,'
+ echo '	memset, bzero, and _exit'
+-if $MAKE _autotst.$O >$DEVNULL 2>&1
++if $MAKE _autotst.$O >_autotst.rrr 2>&1
+ then
+ :
+ else

--- a/mail-filter/procmail/procmail-3.24-r1.ebuild
+++ b/mail-filter/procmail/procmail-3.24-r1.ebuild
@@ -1,0 +1,119 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit flag-o-matic toolchain-funcs prefix
+
+DESCRIPTION="Mail delivery agent/filter"
+HOMEPAGE="https://www.procmail.org/"
+SRC_URI="https://github.com/BuGlessRB/procmail/archive/refs/tags/v${PV}.tar.gz -> ${P}.gh.tar.gz"
+
+LICENSE="|| ( Artistic GPL-2 )"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
+IUSE="mbox selinux"
+
+DEPEND="
+	acct-group/mail
+	virtual/mta
+"
+RDEPEND="
+	${DEPEND}
+	selinux? ( sec-policy/selinux-procmail )
+"
+
+src_prepare() {
+	# disable flock, using both fcntl and flock style locking
+	# doesn't work with NFS with 2.6.17+ kernels, bug #156493
+
+	sed -e "s|/\*#define NO_flock_LOCK|#define NO_flock_LOCK|" \
+		-i config.h || die "sed failed"
+
+	eapply "${FILESDIR}/${P}-modern-c.patch"
+
+	if ! use mbox ; then
+		echo "# Use maildir-style mailbox in user's home directory" > "${S}"/procmailrc || die
+		echo 'DEFAULT=$HOME/.maildir/' >> "${S}"/procmailrc || die
+		cd "${S}" || die
+		eapply "${FILESDIR}/${P}-maildir.patch"
+	else
+		echo '# Use mbox-style mailbox in /var/spool/mail' > "${S}"/procmailrc || die
+		echo 'DEFAULT=${EPREFIX}/var/spool/mail/$LOGNAME' >> "${S}"/procmailrc || die
+	fi
+
+	# Do not use lazy bindings on lockfile and procmail
+	if [[ ${CHOST} != *-darwin* ]]; then
+		eapply "${FILESDIR}/${P}-lazy-bindings.patch"
+	fi
+
+	# Prefixify config.h
+	eapply "${FILESDIR}/${P}-gentoo-prefix.patch"
+	eprefixify config.h Makefile src/autoconf src/recommend.c
+
+	default
+}
+
+src_compile() {
+	# bug #875251, bug #896052
+	append-flags -std=gnu89
+	# bug #859517
+	filter-lto
+
+	# -finline-functions (implied by -O3) leaves strstr() in an infinite loop.
+	# To work around this, we append -fno-inline-functions to CFLAGS
+	# Since GCC 4.7 we also need -fno-ipa-cp-clone (bug #466552)
+	# If it's clang, ignore -fno-ipa-cp-clone, as clang doesn't support this
+	append-flags -fno-inline-functions
+	tc-is-clang || append-flags -fno-ipa-cp-clone
+
+	sed -e "s|CFLAGS0 = -O|CFLAGS0 = ${CFLAGS}|" \
+		-e "s|LDFLAGS0= -s|LDFLAGS0 = ${LDFLAGS}|" \
+		-e "s|LOCKINGTEST=__defaults__|#LOCKINGTEST=__defaults__|" \
+		-e "s|#LOCKINGTEST=/tmp|LOCKINGTEST=/tmp|" \
+		-i Makefile || die "sed failed"
+
+	emake CC="$(tc-getCC)"
+}
+
+src_install() {
+	cd "${S}"/new || die
+	insinto /usr/bin
+	insopts -m 6755
+	doins procmail
+
+	doins lockfile
+	fowners root:mail /usr/bin/lockfile
+	fperms 2755 /usr/bin/lockfile
+
+	dobin formail mailstat
+	insopts -m 0644
+
+	doman *.1 *.5
+
+	cd "${S}" || die
+	dodoc FAQ FEATURES HISTORY INSTALL KNOWN_BUGS README
+
+	insinto /etc
+	doins procmailrc
+
+	docinto examples
+	dodoc examples/*
+}
+
+pkg_postinst() {
+	if ! use mbox ; then
+		elog "Starting with mail-filter/procmail-3.22-r9 you'll need to ensure"
+		elog "that you configure a mail storage location using DEFAULT in"
+		elog "/etc/procmailrc, for example:"
+		elog "\tDEFAULT=\$HOME/.maildir/"
+	fi
+	if has sfperms ${FEATURES}; then
+		ewarn "FEATURES=sfperms removes the read-bit for others from"
+		ewarn "  /usr/bin/procmail"
+		ewarn "  /usr/bin/lockfile"
+		ewarn "If you use procmail from an MTA like Exim, you need to"
+		ewarn "re-add the read-bit or avoid the MTA checking the binary"
+		ewarn "exists."
+	fi
+}


### PR DESCRIPTION
Added the patch from the upstream pull request (thanks to Jaroslav Škarvada).

Link: https://github.com/BuGlessRB/procmail/pull/7
Closes: https://bugs.gentoo.org/919024

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
