### PR TITLE
sys-apps/proot: handle docutils-0.21 dropping console scripts

### DIFF
--- a/sys-apps/proot/proot-5.3.0.ebuild
+++ b/sys-apps/proot/proot-5.3.0.ebuild
@@ -42,7 +42,14 @@ src_compile() {
 		CHECK_VERSION="true" \
 		CAREBUILDENV="ok" \
 		proot $(use care && echo "care")
-	emake -C doc SUFFIX=".py" proot/man.1
+
+	# Docutils >=0.21 dropped .py console scripts
+	# bug #930449
+	if has_version ">=dev-python/docutils-0.21" ; then
+		emake -C doc proot/man.1
+	else
+		emake -C doc SUFFIX=".py" proot/man.1
+	fi
 }
 
 src_install() {

--- a/sys-apps/proot/proot-5.4.0.ebuild
+++ b/sys-apps/proot/proot-5.4.0.ebuild
@@ -42,7 +42,14 @@ src_compile() {
 		CHECK_VERSION="true" \
 		CAREBUILDENV="ok" \
 		proot $(use care && echo "care")
-	emake -C doc SUFFIX=".py" proot/man.1
+
+	# Docutils >=0.21 dropped .py console scripts
+	# bug #930449
+	if has_version ">=dev-python/docutils-0.21" ; then
+		emake -C doc proot/man.1
+	else
+		emake -C doc SUFFIX=".py" proot/man.1
+	fi
 }
 
 src_install() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/930449

https://docutils.sourceforge.io/RELEASE-NOTES.html#release-0-21-2024-04-09

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
