### PR TITLE
games-engines/scummvm: ICB GCC14 fix

### DIFF
--- a/games-engines/scummvm/files/scummvm-2.8.1-icb-gcc14.patch
+++ b/games-engines/scummvm/files/scummvm-2.8.1-icb-gcc14.patch
@@ -1,0 +1,33 @@
+From https://patch-diff.githubusercontent.com/raw/scummvm/scummvm/pull/5655.patch
+From: Christian Krause <chkr@plauener.de>
+Date: Tue, 6 Feb 2024 23:54:44 +0100
+Subject: [PATCH] ICB: compile fix for GCC 14
+
+- cast const away to allow modification (as intended according to
+  existing comments)
+--- a/engines/icb/common/px_array.h
++++ b/engines/icb/common/px_array.h
+@@ -100,9 +100,9 @@ const Type &T_MYACTARRAY::operator[](uint32 n) const {
+ 	// It is permissable to look at an element that has not been defined, as the constructor assures
+ 	// that the contents are valid
+ 	if (n >= m_userPosition) {
+-		// We must cast this to a type that can change
+-		((const rcActArray<Type> *)this)->ResizeArray(n);
+-		((const rcActArray<Type> *)this)->m_userPosition = n + 1;
++		// Remove any 'constness' for a resize
++		(const_cast<rcActArray<Type> *>(this))->ResizeArray(n);
++		(const_cast<rcActArray<Type> *>(this))->m_userPosition = n + 1;
+ 	}
+ 
+ 	return (*(m_contents[n]));
+@@ -304,8 +304,8 @@ template <class Type> const Type rcIntArray<Type>::operator[](uint32 index) cons
+ 	// It is permissable to look at an element that has not been defined, as it will have been set to 0
+ 	if (index >= m_userPosition) {
+ 		// Remove any 'constness' for a resize
+-		((const rcIntArray<Type> *)this)->ResizeArray(index);
+-		((const rcIntArray<Type> *)this)->m_userPosition = index + 1;
++		(const_cast<rcIntArray<Type> *>(this))->ResizeArray(index);
++		(const_cast<rcIntArray<Type> *>(this))->m_userPosition = index + 1;
+ 	}
+ 
+ 	return m_contents[index];

--- a/games-engines/scummvm/scummvm-2.8.1-r1.ebuild
+++ b/games-engines/scummvm/scummvm-2.8.1-r1.ebuild
@@ -1,0 +1,146 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+inherit desktop flag-o-matic toolchain-funcs xdg
+
+DESCRIPTION="Reimplementation of the SCUMM game engine used in Lucasarts adventures"
+HOMEPAGE="https://www.scummvm.org/"
+
+if [[ ${PV} == *9999* ]]; then
+	inherit git-r3
+	EGIT_REPO_URI="https://github.com/scummvm/scummvm"
+else
+	SRC_URI="https://downloads.scummvm.org/frs/scummvm/${PV}/${P}.tar.xz"
+	KEYWORDS="~amd64 ~arm64 ~ppc ~ppc64 ~riscv ~x86"
+	S=${WORKDIR}/${P/_/}
+fi
+
+LICENSE="GPL-2+ LGPL-2.1 BSD GPL-3-with-font-exception"
+SLOT="0"
+IUSE="
+	a52 aac alsa debug flac fluidsynth fribidi gif +gtk jpeg lua mpeg2
+	mp3 +net opengl png sndio speech theora truetype unsupported vorbis
+	zlib
+"
+RESTRICT="test"  # it only looks like there's a test there #77507
+
+DEPEND="
+	>=media-libs/libsdl2-2.0.0[sound,joystick,video]
+	a52? ( media-libs/a52dec )
+	aac? ( media-libs/faad2 )
+	alsa? ( media-libs/alsa-lib )
+	flac? ( media-libs/flac:= )
+	fluidsynth? ( media-sound/fluidsynth:= )
+	fribidi? ( dev-libs/fribidi )
+	gif? ( media-libs/giflib )
+	gtk? (
+		dev-libs/glib:2
+		x11-libs/gtk+:3
+	)
+	jpeg? ( media-libs/libjpeg-turbo:= )
+	mp3? ( media-libs/libmad )
+	mpeg2? ( media-libs/libmpeg2 )
+	net? (
+		media-libs/sdl2-net
+		net-misc/curl
+	)
+	opengl? (
+		|| (
+			virtual/opengl
+			media-libs/mesa[gles2]
+			media-libs/mesa[gles1]
+		)
+	)
+	png? ( media-libs/libpng:0 )
+	sndio? ( media-sound/sndio:= )
+	speech? ( app-accessibility/speech-dispatcher )
+	truetype? ( media-libs/freetype:2 )
+	theora? ( media-libs/libtheora )
+	vorbis? (
+		media-libs/libogg
+		media-libs/libvorbis
+	)
+	zlib? ( sys-libs/zlib:= )
+"
+RDEPEND="
+	${DEPEND}
+"
+BDEPEND="
+	app-arch/xz-utils
+	truetype? ( virtual/pkgconfig )
+	x86? ( dev-lang/nasm )
+"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-icb-gcc14.patch
+)
+
+src_prepare() {
+	default
+
+	# -g isn't needed for nasm here
+	sed -i \
+		-e '/NASMFLAGS/ s/-g//' \
+		configure || die
+	sed -i \
+		-e '/INSTALL.*doc/d' \
+		-e '/INSTALL.*\/pixmaps/d' \
+		-e 's/-s //' \
+		ports.mk || die
+}
+
+src_configure() {
+	use x86 && append-ldflags -Wl,-z,noexecstack
+	tc-export STRINGS
+
+	local myconf=(
+		--backend=sdl
+		--host=${CHOST}
+		--enable-verbose-build
+		--prefix="${EPREFIX}/usr"
+		--libdir="${EPREFIX}/usr/$(get_libdir)"
+		--opengl-mode=$(usex opengl auto none)
+		--with-sdl-prefix="${EPREFIX}/usr"
+		$(use_enable a52)
+		$(use_enable aac faad)
+		$(use_enable alsa)
+		$(use_enable debug)
+		$(use_enable !debug release-mode)
+		$(use_enable flac)
+		$(usex fluidsynth '' --disable-fluidsynth)
+		$(use_enable fribidi)
+		$(use_enable gif)
+		$(use_enable gtk)
+		$(use_enable jpeg)
+		$(use_enable lua)
+		$(use_enable mp3 mad)
+		$(use_enable mpeg2)
+		$(use_enable net libcurl)
+		$(use_enable net sdlnet)
+		$(use_enable png)
+		$(use_enable sndio)
+		$(use_enable speech tts)
+		$(use_enable theora theoradec)
+		$(use_enable truetype freetype2)
+		$(usex unsupported --enable-all-engines '')
+		$(use_enable vorbis)
+		$(use_enable zlib)
+		$(use_enable x86 nasm)
+	)
+	echo "configure ${myconf[@]}"
+	# not an autoconf script, so don't call econf
+	SDL_CONFIG="sdl2-config" \
+	./configure "${myconf[@]}" ${EXTRA_ECONF} || die
+}
+
+src_compile() {
+	emake \
+		AR="$(tc-getAR) cru" \
+		RANLIB="$(tc-getRANLIB)"
+}
+
+src_install() {
+	default
+	doicon -s scalable icons/scummvm.svg
+}


### PR DESCRIPTION
Fix compile time issues with GCC14 systems.

Closes: https://bugs.gentoo.org/932350

I've left `MissingUseDepDefault: version 2.8.1-r1: RDEPEND="media-libs/mesa[gles2]": USE flag 'gles2' missing from packages: [ media-libs/mesa-24.1.0_rc4, media-libs/mesa-9999 ]` as didn't have time to look into this one and fully test but this patch overcomes the main issue users will face right now.
---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
