### PR TITLE
x11-libs/libgxim: fix build issue

### DIFF
--- a/x11-libs/libgxim/files/libgxim-0.5.0-remove-macro.patch
+++ b/x11-libs/libgxim/files/libgxim-0.5.0-remove-macro.patch
@@ -1,0 +1,16 @@
+Fix a build issue due to the missing GNOME_ENABLE_DEBUG macro. 
+Patch by Hao Lin.
+https://bugs.gentoo.org/875056
+
+--- a/libgxim/gximcore.c
++++ b/libgxim/gximcore.c
+@@ -26,9 +26,7 @@
+ #endif
+ 
+ #include <glib/gi18n-lib.h>
+-#ifdef GNOME_ENABLE_DEBUG
+ #include <gdk/gdkx.h>
+-#endif /* GNOME_ENABLE_DEBUG */
+ #include "gximacc.h"
+ #include "gximconnection.h"
+ #include "gximmarshal.h"

--- a/x11-libs/libgxim/libgxim-0.5.0.ebuild
+++ b/x11-libs/libgxim/libgxim-0.5.0.ebuild
@@ -13,6 +13,10 @@ SRC_URI="https://bitbucket.org/tagoh/${PN}/downloads/${P}.tar.bz2"
 LICENSE="LGPL-2.1+"
 SLOT="0"
 KEYWORDS="amd64 ~x86"
+PATCHES=(
+	"${FILESDIR}"/${PN}-0.5.0-remove-macro.patch
+)
+
 IUSE="${USE_RUBY//ruby/ruby_targets_ruby} static-libs test"
 RESTRICT="!test? ( test )"
 


### PR DESCRIPTION
libgxim fails to build due to missing macro GNOME_ENABLE_DEBUG. The macro controls the include of the gdk/gdkx.h header. Missing the macro can cause implicit function declaration. The patch removes the macro over the gdk/gdkx.h include.

The upstream of libgxim seems to provide a similar fix but does not release a new version so the sources in the 0.5.0 tarball are still affected. See https://bitbucket.org/tagoh/libgxim/commits/274976ff39d9142169a18655f5013e66233ac9c8.

Bug: https://bugs.gentoo.org/875056
Reported-by: Toralf Förster <toralf@gentoo.org>

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
