### PR TITLE
net-libs/libmicrohttpd: fix ebuild file

### DIFF
--- a/net-libs/libmicrohttpd/libmicrohttpd-1.0.1.ebuild
+++ b/net-libs/libmicrohttpd/libmicrohttpd-1.0.1.ebuild
@@ -15,7 +15,7 @@ S="${WORKDIR}"/${MY_P}
 LICENSE="|| ( LGPL-2.1+ !ssl? ( GPL-2+-with-eCos-exception-2 ) )"
 SLOT="0/12"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
-IUSE="debug +epoll +eventfd ssl static-libs test +thread-names verify-sig"
+IUSE="debug +epoll +eventfd ssl static-libs test +thread-names"
 REQUIRED_USE="epoll? ( kernel_linux )"
 RESTRICT="!test? ( test )"
 


### PR DESCRIPTION
`verify-sig` USE flag was added accidentally and non-functional currently.
