### PR TITLE
net-libs/libmicrohttpd: mute QA warning with clang

### DIFF
--- a/net-libs/libmicrohttpd/libmicrohttpd-0.9.76.ebuild
+++ b/net-libs/libmicrohttpd/libmicrohttpd-0.9.76.ebuild
@@ -30,6 +30,7 @@ PATCHES=( "${FILESDIR}"/${PN}-0.9.75-fix-testsuite-with-lto.patch )
 
 # All checks in libmicrohttpd's configure are correct
 # Gentoo Bug #898662
+# Gentoo Bug #923760
 QA_CONFIG_IMPL_DECL_SKIP=(
 	'pthread_sigmask'
 	'CreateThread'
@@ -64,6 +65,7 @@ QA_CONFIG_IMPL_DECL_SKIP=(
 	'sysctlbyname'
 	'usleep'
 	'nanosleep'
+	'stpncpy'
 )
 
 multilib_src_configure() {

--- a/net-libs/libmicrohttpd/libmicrohttpd-0.9.77.ebuild
+++ b/net-libs/libmicrohttpd/libmicrohttpd-0.9.77.ebuild
@@ -27,6 +27,12 @@ BDEPEND="ssl? ( virtual/pkgconfig )"
 
 DOCS=( AUTHORS NEWS COPYING README ChangeLog )
 
+# All checks in libmicrohttpd's configure are correct
+# Gentoo Bug #923760
+QA_CONFIG_IMPL_DECL_SKIP=(
+	'stpncpy'
+)
+
 pkg_pretend() {
 	if use kernel_linux ; then
 		CONFIG_CHECK=""

--- a/net-libs/libmicrohttpd/libmicrohttpd-1.0.1.ebuild
+++ b/net-libs/libmicrohttpd/libmicrohttpd-1.0.1.ebuild
@@ -27,6 +27,12 @@ BDEPEND="ssl? ( virtual/pkgconfig )"
 
 DOCS=( AUTHORS NEWS COPYING README ChangeLog )
 
+# All checks in libmicrohttpd's configure are correct
+# Gentoo Bug #923760
+QA_CONFIG_IMPL_DECL_SKIP=(
+	'stpncpy'
+)
+
 pkg_pretend() {
 	if use kernel_linux ; then
 		CONFIG_CHECK=""


### PR DESCRIPTION
This is actually a workaround for clang bug.

No revbumps as this PR just mutes false positive QA warnings.