### PR TITLE
net-nntp/sabnzbd: fix tests, add dev-python/pytest-asyncio BDEPEND

### DIFF
--- a/net-nntp/sabnzbd/sabnzbd-4.2.3.ebuild
+++ b/net-nntp/sabnzbd/sabnzbd-4.2.3.ebuild
@@ -59,6 +59,7 @@ BDEPEND="
 			dev-python/flaky[${PYTHON_USEDEP}]
 			>=dev-python/lxml-4.5.0[${PYTHON_USEDEP}]
 			<dev-python/pyfakefs-5.4.0[${PYTHON_USEDEP}]
+			dev-python/pytest-asyncio[${PYTHON_USEDEP}]
 			dev-python/pytest-httpbin[${PYTHON_USEDEP}]
 			dev-python/pytest-httpserver[${PYTHON_USEDEP}]
 			dev-python/pytest-mock[${PYTHON_USEDEP}]

--- a/net-nntp/sabnzbd/sabnzbd-4.3.1.ebuild
+++ b/net-nntp/sabnzbd/sabnzbd-4.3.1.ebuild
@@ -60,6 +60,7 @@ BDEPEND="
 			dev-python/flaky[${PYTHON_USEDEP}]
 			>=dev-python/lxml-4.5.0[${PYTHON_USEDEP}]
 			<dev-python/pyfakefs-5.4.0[${PYTHON_USEDEP}]
+			dev-python/pytest-asyncio[${PYTHON_USEDEP}]
 			dev-python/pytest-httpbin[${PYTHON_USEDEP}]
 			dev-python/pytest-httpserver[${PYTHON_USEDEP}]
 			dev-python/pytest-mock[${PYTHON_USEDEP}]


### PR DESCRIPTION
Tinderbox caught missing dependency for pytest-asyncio, tested again from a clean system, works.

Closes: https://bugs.gentoo.org/932451

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
