### PR TITLE
verify-sig.eclass: avoid calling unpack on sig files

### DIFF
--- a/eclass/verify-sig.eclass
+++ b/eclass/verify-sig.eclass
@@ -426,10 +426,14 @@ verify-sig_src_unpack() {
 			verify-sig_verify_detached \
 				"${DISTDIR}/${f%.*}" "${DISTDIR}/${f}"
 		done
-	fi
 
-	# finally, unpack the distfiles
-	default_src_unpack
+		# finally, unpack the distfiles
+		if [[ ${#distfiles[@]} -gt 0 ]]; then
+			unpack "${distfiles[@]}"
+		fi
+	else
+		default_src_unpack
+	fi
 }
 
 fi


### PR DESCRIPTION
If we already know unpack cannot handle the file, no point in asking it to process it.

This also avoids a message from the unpack implementation in Portage:

unpack foo.tar.gz.asc: file format not recognized. Ignoring.
