### PR TITLE
app-crypt/tpm2-tss: Hide write_all symbol to fix tpm2-abrmd crash on clang/lld

### DIFF
--- a/app-crypt/tpm2-tss/files/tpm2-tss-4.0.2-Hide-write-all-function.patch
+++ b/app-crypt/tpm2-tss/files/tpm2-tss-4.0.2-Hide-write-all-function.patch
@@ -1,0 +1,24 @@
+diff --git a/src/util/io.c b/src/util/io.c
+index c6446826..50c0fd6c 100644
+--- a/src/util/io.c
++++ b/src/util/io.c
+@@ -81,6 +81,7 @@ read_all (
+     return recvd_total;
+ }
+ 
++__attribute__ ((visibility("hidden")))
+ ssize_t
+ write_all (
+     SOCKET fd,
+diff --git a/src/util/io.h b/src/util/io.h
+index 25dd5c45..fec391d8 100644
+--- a/src/util/io.h
++++ b/src/util/io.h
+@@ -70,6 +70,7 @@ read_all (
+  * are detected. This is currently limited to interrupted system calls and
+  * short writes.
+  */
++__attribute__ ((visibility("hidden")))
+ ssize_t
+ write_all (
+     SOCKET fd,

--- a/app-crypt/tpm2-tss/tpm2-tss-4.0.2-r1.ebuild
+++ b/app-crypt/tpm2-tss/tpm2-tss-4.0.2-r1.ebuild
@@ -1,0 +1,110 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools flag-o-matic linux-info multilib-minimal tmpfiles udev
+
+DESCRIPTION="TCG Trusted Platform Module 2.0 Software Stack"
+HOMEPAGE="https://github.com/tpm2-software/tpm2-tss"
+SRC_URI="https://github.com/tpm2-software/${PN}/releases/download/${PV}/${P}.tar.gz"
+
+LICENSE="BSD-2"
+SLOT="0/4"
+KEYWORDS="~amd64 ~arm ~arm64 ~loong ~ppc64 ~riscv ~x86"
+IUSE="doc +fapi +openssl mbedtls +policy static-libs test"
+RESTRICT="!test? ( test )"
+
+REQUIRED_USE="
+	^^ ( mbedtls openssl )
+	fapi? ( openssl !mbedtls )
+	policy? ( openssl !mbedtls )
+"
+
+RDEPEND="
+	acct-group/tss
+	acct-user/tss
+	sys-apps/util-linux:=[${MULTILIB_USEDEP}]
+	fapi? (
+		dev-libs/json-c:=[${MULTILIB_USEDEP}]
+		>=net-misc/curl-7.80.0[${MULTILIB_USEDEP}]
+	)
+	mbedtls? ( net-libs/mbedtls:=[${MULTILIB_USEDEP}] )
+	openssl? ( dev-libs/openssl:=[${MULTILIB_USEDEP}] )
+"
+
+DEPEND="
+	${RDEPEND}
+	test? ( app-crypt/swtpm
+		dev-libs/uthash
+		dev-util/cmocka
+		fapi? ( >=net-misc/curl-7.80.0 ) )
+"
+
+BDEPEND="
+	sys-apps/acl
+	virtual/pkgconfig
+	doc? ( app-text/doxygen )
+"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-4.0.2-Dont-install-files-into-run.patch"
+	"${FILESDIR}/${PN}-4.0.1-Make-sysusers-and-tmpfiles-optional.patch"
+	"${FILESDIR}/${PN}-4.0.1-Do-not-consider-failures-to-write-files-in-sys-hard.patch"
+	"${FILESDIR}/${PN}-4.0.2-Hide-write-all-function.patch"
+)
+
+pkg_setup() {
+	local CONFIG_CHECK="~TCG_TPM"
+	linux-info_pkg_setup
+	kernel_is ge 4 12 0 || ewarn "At least kernel 4.12.0 is required"
+}
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+multilib_src_configure() {
+	# Fails with inlining
+	filter-flags -fno-semantic-interposition
+	# tests fail with LTO enabbled. See bug 865275 and 865279
+	filter-lto
+
+	local myconf=(
+		--localstatedir=/var
+		$(multilib_native_use_enable doc doxygen-doc)
+		$(use_enable fapi)
+		$(use_enable policy)
+		$(use_enable static-libs static)
+		$(multilib_native_use_enable test unit)
+		$(multilib_native_use_enable test integration)
+		$(multilib_native_use_enable test self-generated-certificate)
+		--disable-tcti-libtpms
+		--disable-defaultflags
+		--disable-weakcrypto
+		--with-crypto="$(usex mbedtls mbed ossl)"
+		--with-runstatedir=/run
+		--with-udevrulesdir="$(get_udevdir)/rules.d"
+		--with-udevrulesprefix=60-
+		--without-sysusersdir
+		--with-tmpfilesdir="/usr/lib/tmpfiles.d"
+	)
+
+	ECONF_SOURCE=${S} econf "${myconf[@]}"
+}
+
+multilib_src_install() {
+	default
+	keepdir /var/lib/tpm2-tss/system/keystore
+	find "${ED}" -name '*.la' -delete || die
+}
+
+pkg_postinst() {
+	tmpfiles_process tpm2-tss-fapi.conf
+	udev_reload
+}
+
+pkg_postrm() {
+	udev_reload
+}


### PR DESCRIPTION
This is mt fix for the tpm2-abrmd crash. Both tpm2-tss and tpm2-abrmd define a function called "write_all" with different arguments, and under clang/lld, the "wrong" one gets called, leading to a crash. 

There's a number of ways to work around the problem. Since "write_all" is an internal function, I decided to change the visibility of the function to "hidden" so its not exported. This did the job, the right function is now called by tpm2-abrmd.

Somebody with more compiler/linker knowledge than me should look over this to make sure this is the "right" thing to do, as opposed to some other solution.

Only 4.0.x series needs the patch. The TCTI machinery was redone in 4.1.x and the conflict doesn't happen there. 


<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
