### PR TITLE
media-gfx/fig2dev: add ghostscript support

### DIFF
--- a/media-gfx/fig2dev/fig2dev-3.2.9-r3.ebuild
+++ b/media-gfx/fig2dev/fig2dev-3.2.9-r3.ebuild
@@ -1,0 +1,95 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs
+
+#MY_P="${PN}.${PV}"
+
+DESCRIPTION="Set of tools for creating TeX documents with graphics"
+HOMEPAGE="https://www.xfig.org/"
+SRC_URI="https://downloads.sourceforge.net/mcj/${P}.tar.xz
+	mirror://gentoo/fig2mpdf-1.1.2.tar.bz2"
+#S="${WORKDIR}/${MY_P}"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x64-solaris"
+IUSE="+ghostscript"
+
+RDEPEND="
+	media-libs/libpng
+	media-libs/libjpeg-turbo:=
+	x11-apps/rgb
+	x11-libs/libXpm
+	!media-gfx/transfig
+	ghostscript? ( app-text/ghostscript-gpl )
+"
+DEPEND="${RDEPEND}"
+BDEPEND="
+	app-text/rman
+	sys-devel/gcc
+"
+
+DOCS=( README CHANGES NOTES )
+HTML_DOCS=( "${WORKDIR}/fig2mpdf/doc/." )
+
+sed_Imakefile() {
+	# see fig2dev/Imakefile for details
+	vars2subs="BINDIR=${EPREFIX}/usr/bin
+			MANDIR=${EPREFIX}/usr/share/man/man\$\(MANSUFFIX\)
+			XFIGLIBDIR=${EPREFIX}/usr/share/xfig
+			PNGINC=-I${EPREFIX}/usr/include/X11
+			XPMINC=-I${EPREFIX}/usr/include/X11
+			USEINLINE=-DUSE_INLINE
+			RGB=${EPREFIX}/usr/share/X11/rgb.txt
+			FIG2DEV_LIBDIR=${EPREFIX}/usr/share/fig2dev"
+
+	for variable in ${vars2subs} ; do
+		varname=${variable%%=*}
+		varval=${variable##*=}
+		sed -i "s:^\(XCOMM\)*[[:space:]]*${varname}[[:space:]]*=.*$:${varname} = ${varval}:" "$@" || die
+	done
+}
+
+src_configure() {
+	# export IMAKECPP=${IMAKECPP:-${CHOST}-gcc -E}
+	# CC="$(tc-getBUILD_CC)" LD="$(tc-getLD)" xmkmf || die
+	econf --enable-transfig
+}
+
+src_compile() {
+	# emake CC="$(tc-getBUILD_CC)" LD="$(tc-getLD)" Makefiles
+
+	local myemakeargs=(
+		CC="$(tc-getCC)"
+		AR="$(tc-getAR)"
+		RANLIB="$(tc-getRANLIB)"
+		CDEBUGFLAGS="${CFLAGS}"
+		LOCAL_LDFLAGS="${LDFLAGS}"
+		USRLIBDIR="${EPREFIX}/usr/$(get_libdir)"
+	)
+	emake "${myemakeargs[@]}"
+}
+
+src_install() {
+	local myemakeargs=(
+		DESTDIR="${D}"
+		INSTDATFLAGS="-m 644"
+		INSTMANFLAGS="-m 644"
+	)
+	emake "${myemakeargs[@]}" install
+
+	dobin "${WORKDIR}/fig2mpdf/fig2mpdf"
+	doman "${WORKDIR}/fig2mpdf/fig2mpdf.1"
+
+	einstalldocs
+
+	rm "${ED}/usr/share/doc/${PF}/html/"{Makefile,*.lfig,*.pdf,*.tex} || die
+}
+
+pkg_postinst() {
+	elog "Note, that defaults are changed and now if you don't want to ship"
+	elog "personal information into output files, use fig2dev with -a option."
+}

--- a/media-gfx/fig2dev/metadata.xml
+++ b/media-gfx/fig2dev/metadata.xml
@@ -9,6 +9,9 @@
 		<email>proxy-maint@gentoo.org</email>
 		<name>Proxy Maintainers</name>
 	</maintainer>
+	<use>
+		<flag name="ghostscript">Require <pkg>app-text/ghostscript-gpl</pkg> to export PDF an bitmap formats</flag>
+	</use>
 	<upstream>
 		<remote-id type="sourceforge">mcj</remote-id>
 	</upstream>

--- a/sci-mathematics/ginac/ginac-1.8.7-r3.ebuild
+++ b/sci-mathematics/ginac/ginac-1.8.7-r3.ebuild
@@ -1,0 +1,76 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+PYTHON_COMPAT=( python3_{9..12} )
+
+inherit python-any-r1
+
+DESCRIPTION="C++ library and tools for symbolic calculations"
+HOMEPAGE="https://www.ginac.de/"
+SRC_URI="http://www.ginac.de/${P}.tar.bz2"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86 ~amd64-linux ~x86-linux"
+IUSE="doc examples"
+
+RDEPEND=">=sci-libs/cln-1.2.2"
+DEPEND="${RDEPEND}"
+BDEPEND="
+	${PYTHON_DEPS}
+	virtual/pkgconfig
+	doc? (
+		app-text/doxygen
+		dev-texlive/texlive-fontsrecommended
+		>=media-gfx/fig2dev-3.2.9-r3[ghostscript]
+		dev-texlive/texlive-latexextra
+		virtual/texi2dvi
+	)"
+
+PATCHES=( "${FILESDIR}"/${PN}-1.8.2-pkgconfig.patch )
+
+src_configure() {
+	econf \
+		--disable-rpath \
+		--disable-static
+}
+
+src_compile() {
+	emake
+
+	if use doc; then
+		local -x VARTEXFONTS="${T}"/fonts
+		emake -C doc/reference html pdf
+		emake -C doc/tutorial ginac.pdf ginac.html
+	fi
+}
+
+src_install() {
+	default
+
+	if use doc; then
+		pushd doc >/dev/null || die
+		newdoc tutorial/ginac.pdf tutorial.pdf
+		newdoc reference/reference.pdf reference.pdf
+
+		docinto html/reference
+		dodoc -r reference/html_files/.
+
+		docinto html
+		newdoc tutorial/ginac.html tutorial.html
+		popd >/dev/null || die
+	fi
+
+	if use examples; then
+		pushd doc >/dev/null || die
+		docinto examples
+		dodoc examples/*.cpp examples/ginac-examples.*
+		docompress -x /usr/share/doc/${PF}/examples
+		popd >/dev/null || die
+	fi
+
+	# no static archives
+	find "${ED}" -name '*.la' -delete || die
+}


### PR DESCRIPTION
This PR adds ghostscript support for `media-gfx/fig2dev`. Thus `sci-mathematics/ginac` can now depend on `media-gfx/fig2dev` instead of `media-gfx/transfig` (see https://bugs.gentoo.org/926432). This removes the last dependency on `media-gfx/transfig` and allows to last-rite it.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.