### PR TITLE
update: lgogdownloader dependencies htmlcxx to htmltidy Signed-off-by…

### DIFF
--- a/games-util/lgogdownloader/lgogdownloader-3.13.ebuild
+++ b/games-util/lgogdownloader/lgogdownloader-3.13.ebuild
@@ -16,7 +16,7 @@ REQUIRED_USE="gui? ( ^^ ( qt5 qt6 ) )"
 
 RDEPEND="
 	>=app-crypt/rhash-1.3.3-r2:0=
-	dev-cpp/htmlcxx:0=
+	app-text/htmltidy
 	dev-libs/boost:=[zlib]
 	>=dev-libs/jsoncpp-1.7:0=
 	dev-libs/tinyxml2:0=

--- a/games-util/lgogdownloader/lgogdownloader-9999.ebuild
+++ b/games-util/lgogdownloader/lgogdownloader-9999.ebuild
@@ -15,7 +15,7 @@ REQUIRED_USE="gui? ( ^^ ( qt5 qt6 ) )"
 
 RDEPEND="
 	>=app-crypt/rhash-1.3.3-r2:0=
-	dev-cpp/htmlcxx:0=
+	app-text/htmltidy
 	dev-libs/boost:=[zlib]
 	>=dev-libs/jsoncpp-1.7:0=
 	dev-libs/tinyxml2:0=


### PR DESCRIPTION
… Tom Lauwers (spykyvenator@protonmail.com)

Please check all the boxes that apply:

- [*] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [*] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [*] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [*] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

lgogdownloader updated their deps (htmlcxx -> tinyhtml) in the last update (https://github.com/Sude-/lgogdownloader/releases/tag/v3.13)