### PR TITLE
net-libs/ngtcp2: fix tests for >=1.5.0

### DIFF
--- a/net-libs/ngtcp2/ngtcp2-1.5.0.ebuild
+++ b/net-libs/ngtcp2/ngtcp2-1.5.0.ebuild
@@ -19,7 +19,7 @@ HOMEPAGE="https://github.com/ngtcp2/ngtcp2/"
 LICENSE="MIT"
 SLOT="0/0"
 IUSE="+gnutls openssl +ssl static-libs test"
-REQUIRED_USE="ssl? ( || ( gnutls openssl ) )"
+REQUIRED_USE="ssl? ( || ( gnutls openssl ) ) test? ( static-libs )"
 
 BDEPEND="virtual/pkgconfig"
 RDEPEND="
@@ -43,6 +43,7 @@ multilib_src_configure() {
 		-DENABLE_WOLFSSL=OFF
 		-DCMAKE_DISABLE_FIND_PACKAGE_Libev=ON
 		-DCMAKE_DISABLE_FIND_PACKAGE_Libnghttp3=ON
+		-DBUILD_TESTING=$(usex test)
 	)
 	cmake_src_configure
 }

--- a/net-libs/ngtcp2/ngtcp2-9999.ebuild
+++ b/net-libs/ngtcp2/ngtcp2-9999.ebuild
@@ -19,7 +19,7 @@ HOMEPAGE="https://github.com/ngtcp2/ngtcp2/"
 LICENSE="MIT"
 SLOT="0/0"
 IUSE="+gnutls openssl +ssl static-libs test"
-REQUIRED_USE="ssl? ( || ( gnutls openssl ) )"
+REQUIRED_USE="ssl? ( || ( gnutls openssl ) ) test? ( static-libs )"
 
 BDEPEND="virtual/pkgconfig"
 RDEPEND="
@@ -43,6 +43,7 @@ multilib_src_configure() {
 		-DENABLE_WOLFSSL=OFF
 		-DCMAKE_DISABLE_FIND_PACKAGE_Libev=ON
 		-DCMAKE_DISABLE_FIND_PACKAGE_Libnghttp3=ON
+		-DBUILD_TESTING=$(usex test)
 	)
 	cmake_src_configure
 }


### PR DESCRIPTION
In 1.5.0 moved to gating tests behind -DBUILD_TESTING

See https://github.com/ngtcp2/ngtcp2/pull/1189

Corresponding Gentoo commit for nghttp2 is https://github.com/gentoo/gentoo/commit/2d6a77b5adaa5160199e3b4de2cf754aa8717c9e

Bug: https://bugs.gentoo.org/931998

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
