### PR TITLE
media-gfx/fig2dev: requires media-gfx/graphicsmagick on run-time to create bitmaps

### DIFF
--- a/media-gfx/fig2dev/fig2dev-3.2.9-r4.ebuild
+++ b/media-gfx/fig2dev/fig2dev-3.2.9-r4.ebuild
@@ -24,7 +24,14 @@ RDEPEND="
 	x11-apps/rgb
 	x11-libs/libXpm
 	!media-gfx/transfig
-	ghostscript? ( app-text/ghostscript-gpl )
+	ghostscript?
+	(
+		app-text/ghostscript-gpl
+		|| (
+			media-gfx/graphicsmagick[imagemagick,jpeg,png,postscript,tiff]
+			media-gfx/imagemagick[jpeg,png,postscript,tiff]
+		)
+	)
 "
 DEPEND="${RDEPEND}"
 BDEPEND="


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/932558

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
