### PR TITLE
app-emulation/qemu-guest-agent: Fix cross-compilation issue

### DIFF
--- a/app-emulation/qemu-guest-agent/qemu-guest-agent-8.2.0.ebuild
+++ b/app-emulation/qemu-guest-agent/qemu-guest-agent-8.2.0.ebuild
@@ -52,6 +52,9 @@ src_configure() {
 		--host-cc="$(tc-getBUILD_CC)"
 	)
 
+	# Meson will not use a cross-file unless cross_prefix is set.
+	tc-is-cross-compiler && myconf+=( --cross-prefix="${CHOST}-" )
+
 	edo ./configure "${myconf[@]}"
 }
 


### PR DESCRIPTION
The fix is borrowed from app-emulation/qemu. Passing cross-prefix is necessary to make meson do a cross-build, otherwise the build system will try to use intrinsics suitable for build machine instead of host machine, when building some crypto stuff.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
