### PR TITLE
dev-java/qdox: ant-task optional for slot 1.12

### DIFF
--- a/dev-java/qdox/metadata.xml
+++ b/dev-java/qdox/metadata.xml
@@ -12,4 +12,7 @@
 	<upstream>
 		<remote-id type="github">paul-hammant/qdox</remote-id>
 	</upstream>
+	<use>
+		<flag name="ant-task">Build the ant-task</flag>
+	</use>
 </pkgmetadata>


### PR DESCRIPTION
Allows to emerge dev-java/ant[junit] without circular dependencies

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
