### PR TITLE
media-tv/kodi: fix typos in PATCHES

### DIFF
--- a/media-tv/kodi/kodi-21.0-r1.ebuild
+++ b/media-tv/kodi/kodi-21.0-r1.ebuild
@@ -259,8 +259,8 @@ BDEPEND="
 	)
 "
 
-PATHCES=(
-	"${FILESDIR}"/kodi-21-fix-gcc14.ebuild
+PATCHES=(
+	"${FILESDIR}"/kodi-21-fix-gcc14.patch
 )
 
 # bug #544020


### PR DESCRIPTION
Fixes: eef3a99ed8f0e12d70bb434ecb3715cd3c7c9ce2
Closes: https://bugs.gentoo.org/932651

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
