### PR TITLE
app-emulation/libvirt: Drag in dev-python/pytest

### DIFF
--- a/app-emulation/libvirt/libvirt-10.0.0-r2.ebuild
+++ b/app-emulation/libvirt/libvirt-10.0.0-r2.ebuild
@@ -136,6 +136,11 @@ DEPEND="
 	${BDEPEND}
 	${RDEPEND}
 	${PYTHON_DEPS}
+	test? (
+		$(python_gen_any_dep '
+			dev-python/pytest[${PYTHON_USEDEP}]
+		')
+	)
 "
 # The 'circular' dependency on dev-python/libvirt-python is because of
 # virt-qemu-qmp-proxy.
@@ -150,6 +155,11 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-10.1.0-Fix-off-by-one-error-in-udevListInterfacesByStatus.patch
 	"${FILESDIR}"/${PN}-10.2.0-remote-check-for-negative-array-lengths-before-alloc.patch
 )
+
+python_check_deps() {
+	use test && python_has_version -d "dev-python/pytest[${PYTHON_USEDEP}]"
+	return 0
+}
 
 pkg_setup() {
 	# Check kernel configuration:

--- a/app-emulation/libvirt/libvirt-10.1.0-r1.ebuild
+++ b/app-emulation/libvirt/libvirt-10.1.0-r1.ebuild
@@ -136,6 +136,11 @@ DEPEND="
 	${BDEPEND}
 	${RDEPEND}
 	${PYTHON_DEPS}
+	test? (
+		$(python_gen_any_dep '
+			dev-python/pytest[${PYTHON_USEDEP}]
+		')
+	)
 "
 # The 'circular' dependency on dev-python/libvirt-python is because of
 # virt-qemu-qmp-proxy.
@@ -149,6 +154,11 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-9.6.0-fix-paths-for-apparmor.patch
 	"${FILESDIR}"/${PN}-10.2.0-remote-check-for-negative-array-lengths-before-alloc.patch
 )
+
+python_check_deps() {
+	use test && python_has_version -d "dev-python/pytest[${PYTHON_USEDEP}]"
+	return 0
+}
 
 pkg_setup() {
 	# Check kernel configuration:

--- a/app-emulation/libvirt/libvirt-10.2.0.ebuild
+++ b/app-emulation/libvirt/libvirt-10.2.0.ebuild
@@ -136,6 +136,11 @@ DEPEND="
 	${BDEPEND}
 	${RDEPEND}
 	${PYTHON_DEPS}
+	test? (
+		$(python_gen_any_dep '
+			dev-python/pytest[${PYTHON_USEDEP}]
+		')
+	)
 "
 # The 'circular' dependency on dev-python/libvirt-python is because of
 # virt-qemu-qmp-proxy.
@@ -148,6 +153,11 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-9.9.0-do-not-use-sysconfig.patch
 	"${FILESDIR}"/${PN}-9.6.0-fix-paths-for-apparmor.patch
 )
+
+python_check_deps() {
+	use test && python_has_version -d "dev-python/pytest[${PYTHON_USEDEP}]"
+	return 0
+}
 
 pkg_setup() {
 	# Check kernel configuration:

--- a/app-emulation/libvirt/libvirt-10.3.0-r1.ebuild
+++ b/app-emulation/libvirt/libvirt-10.3.0-r1.ebuild
@@ -136,6 +136,11 @@ DEPEND="
 	${BDEPEND}
 	${RDEPEND}
 	${PYTHON_DEPS}
+	test? (
+		$(python_gen_any_dep '
+			dev-python/pytest[${PYTHON_USEDEP}]
+		')
+	)
 "
 # The 'circular' dependency on dev-python/libvirt-python is because of
 # virt-qemu-qmp-proxy.
@@ -149,6 +154,11 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-9.6.0-fix-paths-for-apparmor.patch
 	"${FILESDIR}"/${PN}-10.3.0-vsh-Don-t-init-history-in-cmdComplete.patch
 )
+
+python_check_deps() {
+	use test && python_has_version -d "dev-python/pytest[${PYTHON_USEDEP}]"
+	return 0
+}
 
 pkg_setup() {
 	# Check kernel configuration:

--- a/app-emulation/libvirt/libvirt-9999.ebuild
+++ b/app-emulation/libvirt/libvirt-9999.ebuild
@@ -136,6 +136,11 @@ DEPEND="
 	${BDEPEND}
 	${RDEPEND}
 	${PYTHON_DEPS}
+	test? (
+		$(python_gen_any_dep '
+			dev-python/pytest[${PYTHON_USEDEP}]
+		')
+	)
 "
 # The 'circular' dependency on dev-python/libvirt-python is because of
 # virt-qemu-qmp-proxy.
@@ -148,6 +153,11 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-9.9.0-do-not-use-sysconfig.patch
 	"${FILESDIR}"/${PN}-9.6.0-fix-paths-for-apparmor.patch
 )
+
+python_check_deps() {
+	use test && python_has_version -d "dev-python/pytest[${PYTHON_USEDEP}]"
+	return 0
+}
 
 pkg_setup() {
 	# Check kernel configuration:


### PR DESCRIPTION
As of its upstream commit v9.10.0-rc1~114 libvirt introduced its own RPC generator written in python and also some tests for it. But these require pytest. Therefore, generate corresponding dependency if running tests.

Closes: https://bugs.gentoo.org/932652

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
