### PR TITLE
Fix circular dependencies in prefix-bootstrap with dev-lang/perl and perl-cleaner

### DIFF
--- a/app-admin/perl-cleaner/perl-cleaner-2.31-r1.ebuild
+++ b/app-admin/perl-cleaner/perl-cleaner-2.31-r1.ebuild
@@ -24,13 +24,13 @@ IUSE="pkgcore"
 
 RDEPEND="
 	app-shells/bash
+	dev-lang/perl
 	pkgcore? ( sys-apps/pkgcore )
 	!pkgcore? (
 		app-portage/portage-utils
 		sys-apps/portage
 	)
 "
-PDEPEND="dev-lang/perl"
 
 src_prepare() {
 	default

--- a/dev-lang/perl/perl-5.38.2-r5.ebuild
+++ b/dev-lang/perl/perl-5.38.2-r5.ebuild
@@ -72,6 +72,7 @@ DEPEND="${RDEPEND}"
 BDEPEND="${RDEPEND}"
 PDEPEND="
 	!minimal? (
+		>=app-admin/perl-cleaner-2.30
 		>=virtual/perl-CPAN-2.290.0
 		>=virtual/perl-Encode-3.120.0
 		>=virtual/perl-File-Temp-0.230.400-r2
@@ -80,7 +81,6 @@ PDEPEND="
 		virtual/perl-Test-Harness
 	)
 "
-IDEPEND="app-admin/perl-cleaner"
 # bug 390719, bug 523624
 # virtual/perl-Test-Harness is here for the bundled ExtUtils::MakeMaker
 

--- a/dev-lang/perl/perl-5.40.0_rc1.ebuild
+++ b/dev-lang/perl/perl-5.40.0_rc1.ebuild
@@ -72,6 +72,7 @@ DEPEND="${RDEPEND}"
 BDEPEND="${RDEPEND}"
 PDEPEND="
 	!minimal? (
+		>=app-admin/perl-cleaner-2.30
 		>=virtual/perl-CPAN-2.290.0
 		>=virtual/perl-Encode-3.120.0
 		>=virtual/perl-File-Temp-0.230.400-r2
@@ -80,7 +81,7 @@ PDEPEND="
 		virtual/perl-Test-Harness
 	)
 "
-IDEPEND="app-admin/perl-cleaner"
+
 # bug 390719, bug 523624
 # virtual/perl-Test-Harness is here for the bundled ExtUtils::MakeMaker
 


### PR DESCRIPTION
This PR reverts fe38b09da732bbee5c7cf411852b04eb76ebb40f and 00aadd9b5059a0675edb18cbb3278059b987ed24. Each commit is innocuous, but the combined result is circular dependencies during prefix bootstrap.

Overall this PR:

- moves `dev-lang/perl` from PDEPEND -> RDEPEND in `app-admin/perl-cleaner`
- moves `app-admin/perl-cleaner` from IDEPEND -> PDEPEND (`!minimal?`) in `dev-lang/perl`

I did restore the minimum version to the perl-cleaner dep; It's probably not required as all versions in-tree are above that, but it may help prevent users of super-old systems encountering issues during updates. Happy to drop this change from the PR if requested.
