### PR TITLE
app-misc/devtodo: EAPI8 bump, fix IndirectInherits

### DIFF
--- a/app-misc/devtodo/devtodo-0.1.20-r4.ebuild
+++ b/app-misc/devtodo/devtodo-0.1.20-r4.ebuild
@@ -1,0 +1,72 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools bash-completion-r1 flag-o-matic toolchain-funcs
+
+DESCRIPTION="Hierarchical command-line task manager"
+HOMEPAGE="https://swapoff.org/devtodo1.html"
+SRC_URI="https://swapoff.org/files/${PN}/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
+
+BDEPEND="virtual/pkgconfig"
+RDEPEND="
+	>=sys-libs/ncurses-5.2:0=
+	>=sys-libs/readline-4.1:0="
+DEPEND="${RDEPEND}"
+
+DOCS=( AUTHORS ChangeLog QuickStart README doc/scripts.sh doc/scripts.tcsh doc/todorc.example )
+
+PATCHES=(
+	"${FILESDIR}"/${P}-gentoo.patch
+	"${FILESDIR}"/${P}-gcc43.patch
+	"${FILESDIR}"/${P}-bashcom_spaces.patch
+)
+
+src_prepare() {
+	default
+
+	mv configure.{in,ac} || die
+
+	# fix regex.h issue on case-insensitive file-systems #332235
+	sed \
+		-e 's/Regex.h/DTRegex.h/' \
+		-i util/Lexer.h util/Makefile.{am,in} util/Regex.cc || die
+	mv util/{,DT}Regex.h || die
+
+	sed \
+		-e "/^LIBS/s:$: $($(tc-getPKG_CONFIG) --libs ncurses):g" \
+		-i src/Makefile.am  || die
+
+	eautoreconf
+}
+
+src_configure() {
+	replace-flags -O[23] -O1
+
+	local myeconfargs=(
+		--sysconfdir="${EPREFIX}/etc/devtodo"
+	)
+
+	econf "${myeconfargs[@]}"
+}
+
+src_install() {
+	default
+
+	newbashcomp contrib/${PN}.bash-completion ${PN}
+	rm contrib/${PN}.bash-completion || die 'rm failed'
+
+	bashcomp_alias devtodo tda tdd tde tdr todo
+
+	dodoc -r contrib
+}
+
+pkg_postinst() {
+	elog "Because of a conflict with app-misc/tdl, the tdl symbolic link"
+	elog "and manual page have been removed."
+}


### PR DESCRIPTION
simple bump. I've also updated the `DESCRIPTION` to how it described upstream.

```diff
--- devtodo-0.1.20-r3.ebuild	2024-01-17 20:05:11.880825557 +0100
+++ devtodo-0.1.20-r4.ebuild	2024-05-26 12:06:01.879078788 +0200
@@ -1,17 +1,17 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
-inherit autotools bash-completion-r1 flag-o-matic
+inherit autotools bash-completion-r1 flag-o-matic toolchain-funcs
 
-DESCRIPTION="A nice command line todo list for developers"
-HOMEPAGE="http://swapoff.org/DevTodo"
-SRC_URI="http://swapoff.org/files/${PN}/${P}.tar.gz"
+DESCRIPTION="Hierarchical command-line task manager"
+HOMEPAGE="https://swapoff.org/devtodo1.html"
+SRC_URI="https://swapoff.org/files/${PN}/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm ~hppa ~ia64 ~m68k ~mips ppc ppc64 ~s390 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
 
 BDEPEND="virtual/pkgconfig"
 RDEPEND="
```

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
