### PR TITLE
app-admin/puppet: 8.6.0, 8.5.1 require dev-ruby/facter-4.4.1

### DIFF
--- a/app-admin/puppet/puppet-8.5.1.ebuild
+++ b/app-admin/puppet/puppet-8.5.1.ebuild
@@ -24,7 +24,7 @@ ruby_add_rdepend "
 	hiera? ( dev-ruby/hiera )
 	dev-ruby/json:=
 	dev-ruby/semantic_puppet
-	>=dev-ruby/facter-3.0.0
+	>=dev-ruby/facter-4.4.1
 	dev-ruby/deep_merge
 	dev-ruby/concurrent-ruby
 	augeas? ( dev-ruby/ruby-augeas )

--- a/app-admin/puppet/puppet-8.6.0.ebuild
+++ b/app-admin/puppet/puppet-8.6.0.ebuild
@@ -24,7 +24,7 @@ ruby_add_rdepend "
 	hiera? ( dev-ruby/hiera )
 	dev-ruby/json:=
 	dev-ruby/semantic_puppet
-	>=dev-ruby/facter-3.0.0
+	>=dev-ruby/facter-4.4.1
 	dev-ruby/deep_merge
 	dev-ruby/concurrent-ruby
 	augeas? ( dev-ruby/ruby-augeas )


### PR DESCRIPTION
Puppet 8 doesn't officially support Facter 3, Only facter 4. I updated this to 4.4.1 because that's the oldest stable facter version we have in the repo. In theory we could set it to 4.0.0.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
