### PR TITLE
sys-apps/iproute2: 6.9.0: fix compilation on musl-based systems with C99

### DIFF
--- a/sys-apps/iproute2/iproute2-6.9.0.ebuild
+++ b/sys-apps/iproute2/iproute2-6.9.0.ebuild
@@ -51,6 +51,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-6.9.0-mtu.patch # bug #291907
 	"${FILESDIR}"/${PN}-6.8.0-configure-nomagic-nolibbsd.patch # bug #643722 & #911727
 	"${FILESDIR}"/${PN}-6.8.0-disable-libbsd-fallback.patch # bug #911727
+	"${FILESDIR}"/${PN}-6.6.0-musl-c99.patch # bug #922622 & #932617
 )
 
 src_prepare() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/932617

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
