### PR TITLE
net-misc/nextcloud-client: search libdir for VFS plugins

### DIFF
--- a/net-misc/nextcloud-client/files/nextcloud-client-3.13.0-plugin-path.patch
+++ b/net-misc/nextcloud-client/files/nextcloud-client-3.13.0-plugin-path.patch
@@ -1,0 +1,38 @@
+diff '--color=auto' -ur desktop-3.13.0.orig/CMakeLists.txt desktop-3.13.0/CMakeLists.txt
+--- desktop-3.13.0.orig/CMakeLists.txt	2024-05-26 13:34:36.566090600 -0700
++++ desktop-3.13.0/CMakeLists.txt	2024-05-26 14:25:47.942256544 -0700
+@@ -275,6 +275,10 @@
+ file( GLOB TRANS_FILES ${CMAKE_SOURCE_DIR}/translations/client_*.ts)
+ set(TRANSLATIONS ${TRANS_FILES})
+ 
++set(PLUGIN_PATH CACHE PATH "From where to load plugins. The default is 1) the
++same directory as the executable 2) the Qt plugins directory. This option
++prepends a directory.")
++
+ if(BUILD_CLIENT)
+     add_subdirectory(src)
+     if(NOT BUILD_LIBRARIES_ONLY)
+diff '--color=auto' -ur desktop-3.13.0.orig/config.h.in desktop-3.13.0/config.h.in
+--- desktop-3.13.0.orig/config.h.in	2024-05-26 13:34:36.569423843 -0700
++++ desktop-3.13.0/config.h.in	2024-05-26 14:25:15.675979286 -0700
+@@ -61,4 +61,6 @@
+ 
+ #cmakedefine CFAPI_SHELL_EXTENSIONS_LIB_NAME "@CFAPI_SHELL_EXTENSIONS_LIB_NAME@"
+ 
++#cmakedefine PLUGIN_PATH "@PLUGIN_PATH@"
++
+ #endif
+diff '--color=auto' -ur desktop-3.13.0.orig/src/gui/main.cpp desktop-3.13.0/src/gui/main.cpp
+--- desktop-3.13.0.orig/src/gui/main.cpp	2024-05-26 13:34:36.586090059 -0700
++++ desktop-3.13.0/src/gui/main.cpp	2024-05-26 14:26:18.811880764 -0700
+@@ -125,6 +125,10 @@
+     }
+ #endif
+ 
++#if defined(PLUGIN_PATH)
++    QCoreApplication::addLibraryPath( PLUGIN_PATH );
++#endif
++
+     // if the application is already running, notify it.
+     if (app.isRunning()) {
+         qCInfo(lcApplication) << "Already running, exiting...";

--- a/net-misc/nextcloud-client/nextcloud-client-3.13.0-r1.ebuild
+++ b/net-misc/nextcloud-client/nextcloud-client-3.13.0-r1.ebuild
@@ -1,0 +1,118 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit cmake virtualx xdg
+
+DESCRIPTION="Desktop Syncing Client for Nextcloud"
+HOMEPAGE="https://github.com/nextcloud/desktop"
+SRC_URI="
+	https://github.com/nextcloud/desktop/archive/v${PV/_/-}.tar.gz -> ${P}.tar.gz
+"
+S="${WORKDIR}/desktop-${PV/_/-}"
+
+LICENSE="CC-BY-3.0 GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~x86"
+IUSE="doc dolphin nautilus test webengine"
+RESTRICT="!test? ( test )"
+
+# slot op for qtqui as this package uses private API parts of qtqui
+# src/gui/generalsettings.cpp:#include <private/qzipwriter_p.h>
+RDEPEND="
+	>=dev-db/sqlite-3.34:3
+	>=dev-libs/openssl-1.1.0:0=
+	dev-libs/qtkeychain:=[qt5(+)]
+	dev-qt/qtcore:5
+	dev-qt/qtdbus:5
+	dev-qt/qtdeclarative:5
+	dev-qt/qtgui:5=
+	dev-qt/qtnetwork:5[ssl]
+	dev-qt/qtquickcontrols2:5
+	dev-qt/qtsql:5[sqlite]
+	dev-qt/qtsvg:5
+	dev-qt/qtwebsockets:5
+	dev-qt/qtwidgets:5
+	net-libs/libcloudproviders
+	kde-frameworks/karchive:5
+	sys-libs/zlib
+	dolphin? (
+		kde-frameworks/kcoreaddons:5
+		kde-frameworks/kio:5
+	)
+	nautilus? ( dev-python/nautilus-python )
+	webengine? ( dev-qt/qtwebengine:5[widgets] )
+"
+DEPEND="
+	${RDEPEND}
+	dev-qt/qtconcurrent:5
+	dev-qt/qtxml:5
+	|| ( gnome-base/librsvg media-gfx/inkscape )
+	doc? (
+		dev-python/sphinx
+		dev-tex/latexmk
+		dev-texlive/texlive-latexextra
+		virtual/latex-base
+	)
+	test? (
+		dev-qt/qttest:5
+		dev-util/cmocka
+	)
+"
+BDEPEND="
+	dev-qt/linguist-tools:5
+	dolphin? ( kde-frameworks/extra-cmake-modules )
+"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-3.6.6-no-redefine-fortify-source.patch
+	"${FILESDIR}"/${P}-plugin-path.patch
+)
+
+src_prepare() {
+	# Keep tests in ${T}
+	sed -i -e "s#\"/tmp#\"${T}#g" test/test*.cpp || die
+
+	cmake_src_prepare
+}
+
+src_configure() {
+	local mycmakeargs=(
+		-DCMAKE_INSTALL_DOCDIR=/usr/share/doc/${PF}
+		-DBUILD_UPDATER=OFF
+		$(cmake_use_find_package doc Sphinx)
+		$(cmake_use_find_package doc PdfLatex)
+		$(cmake_use_find_package webengine Qt5WebEngine)
+		$(cmake_use_find_package webengine Qt5WebEngineWidgets)
+		-DBUILD_SHELL_INTEGRATION_DOLPHIN=$(usex dolphin)
+		-DBUILD_SHELL_INTEGRATION_NAUTILUS=$(usex nautilus)
+		-DBUILD_TESTING=$(usex test)
+		-DPLUGIN_PATH="${EPREFIX}/usr/$(get_libdir)"
+	)
+
+	cmake_src_configure
+}
+
+src_test() {
+	TEST_VERBOSE=1 virtx cmake_src_test
+}
+
+src_compile() {
+	local compile_targets=(all)
+	if use doc; then
+		compile_targets+=(doc doc-man)
+	fi
+	cmake_src_compile ${compile_targets[@]}
+}
+
+pkg_postinst() {
+	xdg_pkg_postinst
+
+	if ! has_version -r "dev-libs/qtkeychain[keyring]"; then
+		elog "dev-libs/qtkeychain has not been build with the 'keyring' USE flag."
+		elog "Please consider enabling the 'keyring' USE flag. Otherwise you may"
+		elog "have to authenticate manually every time you start the nextlcoud client."
+		elog "See https://bugs.gentoo.org/912844 for more information."
+	fi
+}


### PR DESCRIPTION
When enabling VFS on Nextcloud Desktop, the application crashes with a SIGSEGV. This is due to faulty logic deciding which warning dialog to show the user. No dialog is chosen and a null pointer dereference occurs. No dialog is chosen because the VFS plugins aren't stored in the Qt library path; strace and the Qt dialogs reveal it searches in:

- /usr/bin next to the nextcloud binary
- /usr/lib64/qt5/plugins

I'm not sure what other ebuilds do, but this ebuild installs the VFS plugins in /usr/lib64. We could move them to either of the two locations above if it makes sense. This PR is just a different way to handle it that also works without changing the ebuild layout. It sets a new CMake variable pointing to the current libdir, plumbs it through to config.h, and main() adds this to QCoreApplication's library path. I have no stake in the solution; whatever makes sense is fine with me.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
