### PR TITLE
media-gfx/plantuml: drop non-existing PlantUML icon

### DIFF
--- a/media-gfx/plantuml/plantuml-1.2024.4-r2.ebuild
+++ b/media-gfx/plantuml/plantuml-1.2024.4-r2.ebuild
@@ -13,28 +13,21 @@ S="${WORKDIR}/${P}"
 
 LICENSE="GPL-3"
 SLOT="0"
-KEYWORDS="~amd64 ~x86"
-IUSE="ant-task"
+KEYWORDS="amd64 ~x86"
 
 DEPEND=">=virtual/jdk-1.8:*
-	ant-task? ( >=dev-java/ant-1.10.14-r3:0 )"
+	>=dev-java/ant-1.10.14-r1:0"
 RDEPEND=">=virtual/jre-1.8:*
-	media-gfx/graphviz
-	ant-task? ( >=dev-java/ant-1.10.14-r3:0 )"
+	media-gfx/graphviz"
 
 JAVA_AUTOMATIC_MODULE_NAME="net.sourceforge.plantuml"
+JAVA_CLASSPATH_EXTRA="ant"
 JAVA_MAIN_CLASS="net.sourceforge.plantuml.Run"
 JAVA_RESOURCE_DIRS="res"
 JAVA_SRC_DIR="src"
 
 src_prepare() {
 	java-pkg-2_src_prepare
-	if use ant-task; then
-		# src/net/sourceforge/plantuml/ant/readme.md
-		JAVA_GENTOO_CLASSPATH+="ant"
-	else
-		rm src/net/sourceforge/plantuml/ant/{CheckZip,PlantUml}Task.java || die
-	fi
 
 	# java-pkg-simple wants resources in a separate directory
 	cp -r src res || die
@@ -46,5 +39,5 @@ src_prepare() {
 
 src_install() {
 	java-pkg-simple_src_install
-	make_desktop_entry plantuml PlantUML
+	make_desktop_entry plantuml
 }

--- a/media-gfx/plantuml/plantuml-1.2024.5-r1.ebuild
+++ b/media-gfx/plantuml/plantuml-1.2024.5-r1.ebuild
@@ -13,21 +13,28 @@ S="${WORKDIR}/${P}"
 
 LICENSE="GPL-3"
 SLOT="0"
-KEYWORDS="amd64 ~x86"
+KEYWORDS="~amd64 ~x86"
+IUSE="ant-task"
 
 DEPEND=">=virtual/jdk-1.8:*
-	>=dev-java/ant-1.10.14-r1:0"
+	ant-task? ( >=dev-java/ant-1.10.14-r3:0 )"
 RDEPEND=">=virtual/jre-1.8:*
-	media-gfx/graphviz"
+	media-gfx/graphviz
+	ant-task? ( >=dev-java/ant-1.10.14-r3:0 )"
 
 JAVA_AUTOMATIC_MODULE_NAME="net.sourceforge.plantuml"
-JAVA_CLASSPATH_EXTRA="ant"
 JAVA_MAIN_CLASS="net.sourceforge.plantuml.Run"
 JAVA_RESOURCE_DIRS="res"
 JAVA_SRC_DIR="src"
 
 src_prepare() {
 	java-pkg-2_src_prepare
+	if use ant-task; then
+		# src/net/sourceforge/plantuml/ant/readme.md
+		JAVA_GENTOO_CLASSPATH+="ant"
+	else
+		rm src/net/sourceforge/plantuml/ant/{CheckZip,PlantUml}Task.java || die
+	fi
 
 	# java-pkg-simple wants resources in a separate directory
 	cp -r src res || die
@@ -39,5 +46,5 @@ src_prepare() {
 
 src_install() {
 	java-pkg-simple_src_install
-	make_desktop_entry plantuml PlantUML
+	make_desktop_entry plantuml
 }


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/930373

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
