### PR TITLE
media-gfx/hugin: Fixes build with boost >=1.85

### DIFF
--- a/media-gfx/hugin/files/boost-1.85-932315.patch
+++ b/media-gfx/hugin/files/boost-1.85-932315.patch
@@ -1,0 +1,25 @@
+# HG changeset patch
+# User tmodes
+# Date 1710260877 -3600
+#      Tue Mar 12 17:27:57 2024 +0100
+# Node ID 4d081490b48aaff820cee7601b8624b37b652c06
+# Parent  4b55f17c4e72d6c2f8b4930e3367ff52e1741b45
+Fixed deprecated boost::filesystem::copy_option enum
+
+diff -r 4b55f17c4e72 -r 4d081490b48a src/hugin_base/hugin_utils/filesystem.h
+--- a/src/hugin_base/hugin_utils/filesystem.h	Tue Mar 12 17:27:29 2024 +0100
++++ b/src/hugin_base/hugin_utils/filesystem.h	Tue Mar 12 17:27:57 2024 +0100
+@@ -64,6 +64,12 @@
+     #endif
+     #include <boost/filesystem.hpp>
+     namespace fs = boost::filesystem;
+-    #define OVERWRITE_EXISTING boost::filesystem::copy_option::overwrite_if_exists
++    #if BOOST_VERSION>=107400
++      // in Boost 1.74 and later filesystem::copy_option is deprecated
++      // use filesystem::copy_options instead
++      #define OVERWRITE_EXISTING boost::filesystem::copy_options::overwrite_existing
++    #else
++      #define OVERWRITE_EXISTING boost::filesystem::copy_option::overwrite_if_exists
++    #endif
+ #endif
+ #endif // _HUGIN_UTILS_FILESYSTEM_H

--- a/media-gfx/hugin/hugin-2023.0.0-r1.ebuild
+++ b/media-gfx/hugin/hugin-2023.0.0-r1.ebuild
@@ -62,6 +62,9 @@ pkg_setup() {
 }
 
 src_prepare() {
+	# Fix build with boost >=1.85
+	eapply "${FILESDIR}/boost-1.85-932315.patch"
+
 	sed -i \
 		-e "/COMMAND.*GZIP/d" \
 		-e "s/\.gz//g" \


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/932315

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
