### PR TITLE
www-client/elinks: wire up the upstream support for python scripting

### DIFF
--- a/www-client/elinks/elinks-0.16.1.1-r3.ebuild
+++ b/www-client/elinks/elinks-0.16.1.1-r3.ebuild
@@ -38,7 +38,7 @@ RDEPEND="
 		>=sys-libs/gpm-1.20.0-r5
 	)
 	guile? ( >=dev-scheme/guile-1.6.4-r1[deprecated] )
-	idn? ( net-dns/libidn2:= )
+	idn? ( net-dns/libidn:= )
 	javascript? (
 		dev-cpp/libxmlpp:5.0
 		dev-lang/mujs:=
@@ -67,9 +67,13 @@ BDEPEND="
 	virtual/pkgconfig
 	nls? ( sys-devel/gettext )
 	test? (
-		net-dns/libidn2
+		net-dns/libidn
 	)
 "
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-0.16.1.1-perl-5.38.patch
+)
 
 pkg_setup() {
 	use lua && lua-single_pkg_setup

--- a/www-client/elinks/elinks-0.16.1.1-r3.ebuild
+++ b/www-client/elinks/elinks-0.16.1.1-r3.ebuild
@@ -97,6 +97,7 @@ src_configure() {
 		-Ddocdir="${EPREFIX}"/usr/share/doc/${PF}
 		-Dhtmldoc=false
 		-Dpdfdoc=false
+		-Dapidoc=false
 		-D88-colors=true
 		-D256-colors=true
 		$(meson_use bittorrent)

--- a/www-client/elinks/elinks-9999.ebuild
+++ b/www-client/elinks/elinks-9999.ebuild
@@ -93,6 +93,7 @@ src_configure() {
 		-Ddocdir="${EPREFIX}"/usr/share/doc/${PF}
 		-Dhtmldoc=false
 		-Dpdfdoc=false
+		-Dapidoc=false
 		-D88-colors=true
 		-D256-colors=true
 		$(meson_use bittorrent)


### PR DESCRIPTION
Previously hard disabled, now available via USE=python.

@Moult this is the (correct) implementation of https://github.com/rkd77/elinks/pull/307

...

I also fixed a nit that I had when building it and happening to have doxygen installed.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
