### PR TITLE
media-video/ffmpegthumbnailer:

### DIFF
--- a/media-video/ffmpegthumbnailer/metadata.xml
+++ b/media-video/ffmpegthumbnailer/metadata.xml
@@ -4,6 +4,10 @@
 	<maintainer type="project">
 		<email>media-video@gentoo.org</email>
 	</maintainer>
+	<use>
+		<flag name="gnome">Install thumbnailer definition file to /usr/share/thumbnailers
+			for nautilus based file managers</flag>
+	</use>
 	<upstream>
 		<remote-id type="google-code">ffmpegthumbnailer</remote-id>
 		<remote-id type="github">dirkvdb/ffmpegthumbnailer</remote-id>


### PR DESCRIPTION
Add explanation for what the gnome use flag does.

I added this since the gnome flag seems unintuitive at first sight:

It seems that if you don't use gnome desktop environment, you don't have to enable it, but in reality, it enables gnome's nautilus, or anything based on nautilus like nemo, to use it's thumbnailing feature.

So, I added a explanation to hopefully clear that up

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
