### PR TITLE
media-libs/gst-plugins-bad: add v4l2codecs USE flag

### DIFF
--- a/media-libs/gst-plugins-bad/gst-plugins-bad-1.22.11-r1.ebuild
+++ b/media-libs/gst-plugins-bad/gst-plugins-bad-1.22.11-r1.ebuild
@@ -11,7 +11,7 @@ HOMEPAGE="https://gstreamer.freedesktop.org/"
 LICENSE="LGPL-2"
 KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~loong ~mips ppc ppc64 ~riscv ~sparc x86"
 
-IUSE="X bzip2 +introspection +orc udev vaapi vnc wayland"
+IUSE="X bzip2 +introspection +orc udev vaapi vnc v4l2codecs wayland"
 
 # X11 is automagic for now, upstream #709530 - only used by librfb USE=vnc plugin
 # Baseline requirement for libva is 1.6, but 1.10 gets more features
@@ -54,7 +54,7 @@ src_prepare() {
 }
 
 multilib_src_configure() {
-	GST_PLUGINS_NOAUTO="bz2 hls ipcpipeline librfb shm va wayland"
+	GST_PLUGINS_NOAUTO="bz2 hls ipcpipeline librfb shm va v4l2codecs wayland"
 
 	local emesonargs=(
 		-Dshm=enabled
@@ -65,6 +65,7 @@ multilib_src_configure() {
 		-Dudev=$(usex udev $(usex vaapi enabled disabled) disabled)
 		$(meson_feature vnc librfb)
 		-Dx11=$(usex X $(usex vnc enabled disabled) disabled)
+		$(meson_feature v4l2codecs)
 		$(meson_feature wayland)
 	)
 

--- a/media-libs/gst-plugins-bad/metadata.xml
+++ b/media-libs/gst-plugins-bad/metadata.xml
@@ -7,5 +7,6 @@
 	</maintainer>
 	<use>
 		<flag name="bzip2">Enable bzip2 encoder/decoder plugin</flag>
+		<flag name="v4l2codecs">Enable v4l2 codecs plugin</flag>
 	</use>
 </pkgmetadata>


### PR DESCRIPTION
This use flag enables the v4l2codecs gst plugins.

Closes: https://bugs.gentoo.org/936210
---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
