### PR TITLE
dev-lang/python: Use CHOST rather than ARCH for test skips

### DIFF
--- a/dev-lang/python/python-3.13.0_beta1_p3.ebuild
+++ b/dev-lang/python/python-3.13.0_beta1_p3.ebuild
@@ -33,7 +33,7 @@ LICENSE="PSF-2"
 SLOT="${PYVER}"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
 IUSE="
-	big-endian bluetooth build +debug +ensurepip examples gdbm +gil jit
+	bluetooth build +debug +ensurepip examples gdbm +gil jit
 	libedit +ncurses pgo +readline +sqlite +ssl test tk valgrind
 "
 REQUIRED_USE="jit? ( ${LLVM_REQUIRED_USE} )"
@@ -250,8 +250,8 @@ src_configure() {
 	)
 
 	# Arch-specific skips.  See #931888 for a collection of these.
-	case ${ARCH} in
-		alpha)
+	case ${CHOST} in
+		alpha*)
 			test_opts+=(
 				-x test_builtin
 				-x test_capi
@@ -267,30 +267,30 @@ src_configure() {
 				-x test_strtod
 			)
 			;;
-		ia64)
+		ia64*)
 			test_opts+=(
 				-x test_ctypes
 				-x test_external_inspection
 			)
 			;;
-		mips)
+		mips*)
 			test_opts+=(
 				-x test_ctypes
 				-x test_external_inspection
 				-x test_statistics
 			)
 			;;
-		ppc64)
-			if use big-endian; then
-				test_opts+=( -x test_descr )
-			fi
+		powerpc64-*) # big endian
+			test_opts+=(
+				-x test_descr
+			)
 			;;
-		riscv)
+		riscv*)
 			test_opts+=(
 				-x test_urllib2
 			)
 			;;
-		sparc)
+		sparc*)
 			test_opts+=(
 				# bug 788022
 				-x test_multiprocessing_fork
@@ -339,13 +339,13 @@ src_configure() {
 		)
 
 		# Arch-specific skips.  See #931888 for a collection of these.
-		case ${ARCH} in
-			alpha)
+		case ${CHOST} in
+			alpha*)
 				profile_task_flags+=(
 					-x test_os
 				)
 				;;
-			hppa)
+			hppa*)
 				profile_task_flags+=(
 					-x test_descr
 					# bug 931908
@@ -353,20 +353,18 @@ src_configure() {
 					-x test_os
 				)
 				;;
-			ia64)
+			ia64*)
 				profile_task_flags+=(
 					-x test_signal
 				)
 				;;
-			ppc64)
-				if use big-endian; then
-					profile_task_flags+=(
-						# bug 931908
-						-x test_exceptions
-					)
-				fi
+			powerpc64-*) # big endian
+				profile_task_flags+=(
+					# bug 931908
+					-x test_exceptions
+				)
 				;;
-			riscv)
+			riscv*)
 				profile_task_flags+=(
 					-x test_statistics
 				)


### PR DESCRIPTION
Use CHOST rather than ARCH+big-endian flag to determine the host. This simplifies the rules for ppc64 (BE).

CC @matoro

---

Please check all the boxes that apply:

- [ ] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [ ] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [ ] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
