### PR TITLE
sci-physics/vgm: add patch for >=sci-physics/root-6.32.00

### DIFF
--- a/sci-physics/vgm/files/vgm-5.2-r1-root-6.32-TesselatedSolid.patch
+++ b/sci-physics/vgm/files/vgm-5.2-r1-root-6.32-TesselatedSolid.patch
@@ -1,0 +1,31 @@
+adapt RootGM::TessellatedSolid for ROOT 6.32.00
+
+Bug: https://github.com/vmc-project/vgm/pull/16
+---
+ packages/RootGM/source/solids/TessellatedSolid.cxx | 13 ++++++++-----
+ 1 file changed, 8 insertions(+), 5 deletions(-)
+
+--- a/packages/RootGM/source/solids/TessellatedSolid.cxx
++++ b/packages/RootGM/source/solids/TessellatedSolid.cxx
+@@ -178,13 +178,16 @@ VGM::ThreeVector RootGM::TessellatedSolid::Vertex(int ifacet, int index) const
+ {
+   CheckVertexIndex(ifacet, index);
+ 
+-  const TGeoFacet& facet = fTessellated->GetFacet(ifacet);
++#if ROOT_VERSION_CODE > ROOT_VERSION(6, 30, 4)
++  const auto& rvertex =  fTessellated->GetVertex((fTessellated->GetFacet(ifacet))[index]);
++#else
++  const auto& rvertex =  fTessellated->GetFacet(ifacet).GetVertex(index);
++#endif
+ 
+   VGM::ThreeVector vertex;
+-  vertex.push_back(facet.GetVertex(index).fVec[0] * RootGM::Units::Length());
+-  vertex.push_back(facet.GetVertex(index).fVec[1] * RootGM::Units::Length());
+-  vertex.push_back(facet.GetVertex(index).fVec[2] * RootGM::Units::Length());
++  vertex.push_back(rvertex.fVec[0] * RootGM::Units::Length());
++  vertex.push_back(rvertex.fVec[1] * RootGM::Units::Length());
++  vertex.push_back(rvertex.fVec[2] * RootGM::Units::Length());
+ 
+   return vertex;
+ }
+-

--- a/sci-physics/vgm/vgm-5.2-r1.ebuild
+++ b/sci-physics/vgm/vgm-5.2-r1.ebuild
@@ -45,6 +45,10 @@ DOCS=(
 	doc/VGMhistory.txt
 )
 
+PATCHES=(
+	"${FILESDIR}"/${PN}-5.2-r1-root-6.32-TesselatedSolid.patch
+)
+
 src_configure() {
 	local mycmakeargs=(
 		-DCLHEP_DIR="${EPREFIX}/usr"


### PR DESCRIPTION
ROOT 6.32.00 carries an incompatible API change in TessellatedSolid, this backports an upstream fix to adapt to the API change.

see also:
- https://github.com/root-project/root/pull/14327
- https://github.com/vmc-project/vgm/pull/16


<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
