### PR TITLE
profiles/base: make.defaults: switch PHP_TARGETS to php8-2

### DIFF
--- a/profiles/base/make.defaults
+++ b/profiles/base/make.defaults
@@ -164,7 +164,7 @@ POSTGRES_TARGETS="postgres15"
 # Moreover, it should only contain targets that have a stable version
 # of PHP, to avoid pulling in an unstable PHP on stable systems.
 #
-PHP_TARGETS="php8-1"
+PHP_TARGETS="php8-2"
 
 # Alfredo Tupone <tupone@gentoo.org> (2024-03-15)
 #


### PR DESCRIPTION
As mentioned in the bug, it would be nice to have latest php-8.2 set as default in PHP_TARGETS.

Signed-off-by: Michael Mair-Keimberger <mmk@levelnine.at>

Bug: https://bugs.gentoo.org/918893


---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
