### PR TITLE
dev-python/Nuitka: add python 3.12

### DIFF
--- a/dev-python/Nuitka/Nuitka-2.3.ebuild
+++ b/dev-python/Nuitka/Nuitka-2.3.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
 PYPI_NO_NORMALIZE=1
-PYTHON_COMPAT=( python3_{10..11} )
+PYTHON_COMPAT=( python3_{10..12} )
 
 inherit distutils-r1 flag-o-matic optfeature pypi
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/929473

See [Nuitka/Nuitka#2433 (comment)](https://www.github.com/Nuitka/Nuitka/issues/2433#issuecomment-2141428492)

I get `RdependChange: version 2.3: RDEPEND modified without revbump` when running `pkgcheck scan --commits --net`, not sure if a revbump is required.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
