### PR TITLE
dev-lang/python: skip known failing tests on musl

### DIFF
--- a/dev-lang/python/python-3.13.0_beta1_p3.ebuild
+++ b/dev-lang/python/python-3.13.0_beta1_p3.ebuild
@@ -305,6 +305,22 @@ src_configure() {
 			;;
 	esac
 
+	# musl-specific skips
+	use elibc_musl && COMMON_TEST_SKIPS+=(
+		# various musl locale deficiencies
+		-x test__locale
+		-x test_c_locale_coercion
+		-x test_locale
+		-x test_re
+
+		# known issues with find_library on musl
+		# https://bugs.python.org/issue21622
+		-x test_ctypes
+
+		# fpathconf, ttyname errno values
+		-x test_os
+	)
+
 	if use pgo; then
 		local profile_task_flags=(
 			-m test
@@ -371,6 +387,22 @@ src_configure() {
 				)
 				;;
 		esac
+
+		# musl-specific skips
+		use elibc_musl && profile_task_flags+=(
+			# various musl locale deficiencies
+			-x test__locale
+			-x test_c_locale_coercion
+			-x test_locale
+			-x test_re
+
+			# known issues with find_library on musl
+			# https://bugs.python.org/issue21622
+			-x test_ctypes
+
+			# fpathconf, ttyname errno values
+			-x test_os
+		)
 
 		if has_version "app-arch/rpm" ; then
 			# Avoid sandbox failure (attempts to write to /var/lib/rpm)


### PR DESCRIPTION
Skips the following known failing tests on musl:

- test_ctypes
- test__locale
- test_c_locale_coercion
- test_locale
- test_os
- test_re

See https://git.alpinelinux.org/aports/tree/main/python3/APKBUILD.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
