### PR TITLE
app-arch/zstd: enforce non-executable stack

### DIFF
--- a/app-arch/zstd/zstd-1.5.6.ebuild
+++ b/app-arch/zstd/zstd-1.5.6.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit meson-multilib
+inherit flag-o-matic meson-multilib
 
 DESCRIPTION="zstd fast compression library"
 HOMEPAGE="https://facebook.github.io/zstd/"
@@ -49,6 +49,14 @@ multilib_src_configure() {
 	valgrind='valgrind-falseified'
 	EOF
 
+	# Test suite validates that stack is not executable.  Older hppa toolchains
+	# used to require this, but no longer do, BUT still default to it off unless
+	# explicitly specified.  See #903923
+	# The cmake build sets these, but the meson build doesn't, so set it manually.
+	# https://github.com/facebook/zstd/blob/979b047/build/cmake/CMakeModules/AddZstdCompilationFlags.cmake#L77-L82
+	append-flags $(test-flags "-Wa,--noexecstack")
+	append-ldflags $(test-flags "-Wl,-z,noexecstack")
+
 	local emesonargs=(
 		-Ddefault_library=$(multilib_native_usex static-libs both shared)
 
@@ -64,4 +72,8 @@ multilib_src_configure() {
 	)
 
 	meson_src_configure
+}
+
+multilib_src_test() {
+	meson_src_test --timeout-multiplier=2
 }


### PR DESCRIPTION
Including on platforms which have it disabled by default, namely hppa.

Closes: https://bugs.gentoo.org/903923
Bug: https://bugs.gentoo.org/930880

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
