### PR TITLE
net-vpn/networkmanager-openconnect: require gcr built with gtk

### DIFF
--- a/net-vpn/networkmanager-openconnect/networkmanager-openconnect-1.2.10-r1.ebuild
+++ b/net-vpn/networkmanager-openconnect/networkmanager-openconnect-1.2.10-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -26,7 +26,7 @@ DEPEND="
 	gtk? (
 		>=app-crypt/libsecret-0.18
 
-		>=app-crypt/gcr-3.4:0=
+		>=app-crypt/gcr-3.4:0=[gtk]
 		>=x11-libs/gtk+-3.12:3
 
 		>=gui-libs/gtk-4.0:4


### PR DESCRIPTION
When not built with USE=gtk, gcr does not install the gcr-3.pc file, which leads to a configure-time failure building this package.

Closes: https://bugs.gentoo.org/914395

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
