### PR TITLE
net-misc/r8125: disable build with kernel 6.9 or later

### DIFF
--- a/net-misc/r8125/r8125-9.008.00-r1.ebuild
+++ b/net-misc/r8125/r8125-9.008.00-r1.ebuild
@@ -29,6 +29,10 @@ PATCHES=(
 CONFIG_CHECK="~!R8169"
 WARNING_R8169="CONFIG_R8169 is enabled. ${PN} will not be loaded unless kernel driver Realtek 8169 PCI Gigabit Ethernet (CONFIG_R8169) is DISABLED."
 
+pkg_pretend() {
+	kernel_is -ge 6 9 && die "This module is compatible only with Linux kernels before 6.9. Please downgrade your kernel."
+}
+
 src_compile() {
 	local modlist=( ${PN}=kernel/drivers/net/ethernet/realtek:src )
 	local modargs=(

--- a/net-misc/r8125/r8125-9.009.01-r1.ebuild
+++ b/net-misc/r8125/r8125-9.009.01-r1.ebuild
@@ -26,6 +26,10 @@ PATCHES=(
 CONFIG_CHECK="~!R8169"
 WARNING_R8169="CONFIG_R8169 is enabled. ${PN} will not be loaded unless kernel driver Realtek 8169 PCI Gigabit Ethernet (CONFIG_R8169) is DISABLED."
 
+pkg_pretend() {
+	kernel_is -ge 6 9 && die "This module is compatible only with Linux kernels before 6.9. Please downgrade your kernel."
+}
+
 src_compile() {
 	local modlist=( ${PN}=kernel/drivers/net/ethernet/realtek:src )
 	local modargs=(

--- a/net-misc/r8125/r8125-9.009.02-r1.ebuild
+++ b/net-misc/r8125/r8125-9.009.02-r1.ebuild
@@ -24,6 +24,10 @@ PATCHES=(
 CONFIG_CHECK="~!R8169"
 WARNING_R8169="CONFIG_R8169 is enabled. ${PN} will not be loaded unless kernel driver Realtek 8169 PCI Gigabit Ethernet (CONFIG_R8169) is DISABLED."
 
+pkg_pretend() {
+	kernel_is -ge 6 9 && die "This module is compatible only with Linux kernels before 6.9. Please downgrade your kernel."
+}
+
 src_compile() {
 	local modlist=( ${PN}=kernel/drivers/net/ethernet/realtek:src )
 	local modargs=(

--- a/net-misc/r8125/r8125-9.011.01-r1.ebuild
+++ b/net-misc/r8125/r8125-9.011.01-r1.ebuild
@@ -23,6 +23,10 @@ PATCHES=(
 CONFIG_CHECK="~!R8169"
 WARNING_R8169="CONFIG_R8169 is enabled. ${PN} will not be loaded unless kernel driver Realtek 8169 PCI Gigabit Ethernet (CONFIG_R8169) is DISABLED."
 
+pkg_pretend() {
+	kernel_is -ge 6 9 && die "This module is compatible only with Linux kernels before 6.9. Please downgrade your kernel."
+}
+
 src_compile() {
 	local modlist=( ${PN}=kernel/drivers/net/ethernet/realtek:src )
 	local modargs=(

--- a/net-misc/r8125/r8125-9.013.02-r1.ebuild
+++ b/net-misc/r8125/r8125-9.013.02-r1.ebuild
@@ -19,6 +19,10 @@ IUSE="+multi-tx-q ptp +rss use-firmware"
 CONFIG_CHECK="~!R8169"
 WARNING_R8169="CONFIG_R8169 is enabled. ${PN} will not be loaded unless kernel driver Realtek 8169 PCI Gigabit Ethernet (CONFIG_R8169) is DISABLED."
 
+pkg_pretend() {
+	kernel_is -ge 6 9 && die "This module is compatible only with Linux kernels before 6.9. Please downgrade your kernel."
+}
+
 src_compile() {
 	local modlist=( ${PN}=kernel/drivers/net/ethernet/realtek:src )
 	local modargs=(

--- a/net-misc/r8125/r8125-9.013.02.ebuild
+++ b/net-misc/r8125/r8125-9.013.02.ebuild
@@ -19,6 +19,10 @@ IUSE="+multi-tx-q ptp +rss use-firmware"
 CONFIG_CHECK="~!R8169"
 WARNING_R8169="CONFIG_R8169 is enabled. ${PN} will not be loaded unless kernel driver Realtek 8169 PCI Gigabit Ethernet (CONFIG_R8169) is DISABLED."
 
+pkg_pretend() {
+	kernel_is -ge 6 9 && die "This module is compatible only with Linux kernels before 6.9. Please downgrade your kernel."
+}
+
 src_compile() {
 	local modlist=( ${PN}=kernel/drivers/net/ethernet/realtek:src )
 	local modargs=(


### PR DESCRIPTION
The module is not compatible with the changes in the kernel 6.9.

See https://lore.kernel.org/all/7d82de21-9bde-4f66-99ce-f03ff994ef34@gmail.com/, https://lore.kernel.org/netdev/20240204-keee-u32-cleanup-v1-0-fb6e08329d9a@lunn.ch/

Not sure whether there is any better way to enforce kernel version.

Closes: https://bugs.gentoo.org/933359