### PR TITLE
dev-lang/rust-bin: widen QA_PREBUILT glob

### DIFF
--- a/dev-lang/rust-bin/rust-bin-1.78.0.ebuild
+++ b/dev-lang/rust-bin/rust-bin-1.78.0.ebuild
@@ -55,7 +55,7 @@ RESTRICT="strip"
 
 QA_PREBUILT="
 	opt/${P}/bin/.*
-	opt/${P}/lib/.*.so
+	opt/${P}/lib/.*.so*
 	opt/${P}/libexec/.*
 	opt/${P}/lib/rustlib/.*/bin/.*
 	opt/${P}/lib/rustlib/.*/lib/.*


### PR DESCRIPTION
New .so file is a linker script pointing to a different file named like this: lib/libLLVM.so.18.1-rust-1.78.0-stable

Closes: https://bugs.gentoo.org/933364

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
