### PR TITLE
sys-apps/pcsc-lite: fix udev rule for pcscd hotplug, #902847

### DIFF
--- a/sys-apps/pcsc-lite/files/99-pcscd-hotplug-r2.rules
+++ b/sys-apps/pcsc-lite/files/99-pcscd-hotplug-r2.rules
@@ -1,6 +1,6 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # We add this here so that it runs after ccid's and ifd-gempc's rules;
 # if we just added a pcscd-owned device, we hotplug the pcscd service.
-ACTION=="add", ENV{PCSCD}=="1", GROUP="pcscd", TAG+="systemd", ENV{SYSTEMD_WANTS}+="pcscd.service", RUN+="pcscd.sh"
+ACTION=="add", ENV{ID_SMARTCARD_READER}=="1", GROUP="pcscd", TAG+="systemd", ENV{SYSTEMD_WANTS}+="pcscd.service", RUN+="pcscd.sh"

--- a/sys-apps/pcsc-lite/pcsc-lite-2.0.0-r1.ebuild
+++ b/sys-apps/pcsc-lite/pcsc-lite-2.0.0-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..11} )
 
 inherit python-single-r1 systemd tmpfiles udev multilib-minimal
 
@@ -70,7 +70,7 @@ multilib_src_install_all() {
 		newexe "${FILESDIR}"/pcscd-udev pcscd.sh
 
 		insinto "$(get_udevdir)"/rules.d
-		newins "${FILESDIR}"/99-pcscd-hotplug-r1.rules 99-pcscd-hotplug.rules
+		newins "${FILESDIR}"/99-pcscd-hotplug-r2.rules 99-pcscd-hotplug.rules
 	fi
 
 	python_fix_shebang "${ED}"/usr/bin/pcsc-spy

--- a/sys-apps/pcsc-lite/pcsc-lite-2.0.1-r1.ebuild
+++ b/sys-apps/pcsc-lite/pcsc-lite-2.0.1-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..11} )
+PYTHON_COMPAT=( python3_{10..12} )
 
 inherit python-single-r1 systemd tmpfiles udev multilib-minimal
 
@@ -70,7 +70,7 @@ multilib_src_install_all() {
 		newexe "${FILESDIR}"/pcscd-udev pcscd.sh
 
 		insinto "$(get_udevdir)"/rules.d
-		newins "${FILESDIR}"/99-pcscd-hotplug-r1.rules 99-pcscd-hotplug.rules
+		newins "${FILESDIR}"/99-pcscd-hotplug-r2.rules 99-pcscd-hotplug.rules
 	fi
 
 	python_fix_shebang "${ED}"/usr/bin/pcsc-spy


### PR DESCRIPTION
Based on `udevadm info /sys/devices/[…]`, an environment variable `ID_SMARTCARD_READER=1` is displayed for such devices, instead of `PCSCD`; tested with two devices I own.

Closes: https://bugs.gentoo.org/902847

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
