### PR TITLE
media-video/mkvtoolnix: fix libcxx incompatibility

### DIFF
--- a/media-video/mkvtoolnix/files/mkvtoolnix-84.0.0-fix-libcxx-c++20.patch
+++ b/media-video/mkvtoolnix/files/mkvtoolnix-84.0.0-fix-libcxx-c++20.patch
@@ -1,0 +1,44 @@
+https://bugs.gentoo.org/933417
+https://gitlab.com/mbunkus/mkvtoolnix/-/issues/3695
+https://gitlab.com/mbunkus/mkvtoolnix/-/commit/7e1bea9527616ab6ab38425e7290579f05dd9bb1
+
+From 7e1bea9527616ab6ab38425e7290579f05dd9bb1 Mon Sep 17 00:00:00 2001
+From: Moritz Bunkus <mo@bunkus.online>
+Date: Tue, 30 Apr 2024 16:05:35 +0200
+Subject: [PATCH] replace removed `std::result_of` with `std::invoke_result`
+
+`std::result_of` was deprecated in C++17 & removed in C++20. A lot of
+compilers still make it available even when running in C++20 mode,
+while others don't.
+
+Therefore replace it with equivalent use of `std::invoke_result`.
+
+Fixes #3695.
+--- a/NEWS.md
++++ b/NEWS.md
+@@ -1,3 +1,11 @@
++# Version ?
++
++## Bug fixes
++
++* fixed compilation of `src/common/sorting.h` with certain compilers due to
++  the deprecation & removal of `std::result_of<>` in C++20. Fixes #3695.
++
++
+ # Version 84.0 "Sleeper" 2024-04-28
+ 
+ ## New features and enhancements
+--- a/src/common/sorting.h
++++ b/src/common/sorting.h
+@@ -27,7 +27,7 @@ namespace mtx::sort {
+ 
+ template<  typename Titer
+          , typename Tcriterion_maker
+-         , typename Tcriterion = typename std::result_of< Tcriterion_maker(typename std::iterator_traits<Titer>::value_type) >::type
++         , typename Tcriterion = typename std::invoke_result< Tcriterion_maker, typename std::iterator_traits<Titer>::value_type >::type
+          , typename Tcomparator = std::less<Tcriterion>
+          >
+ void
+-- 
+GitLab
+

--- a/media-video/mkvtoolnix/mkvtoolnix-84.0-r1.ebuild
+++ b/media-video/mkvtoolnix/mkvtoolnix-84.0-r1.ebuild
@@ -73,6 +73,10 @@ if [[ ${PV} != *9999 ]] ; then
 	BDEPEND+="verify-sig? ( sec-keys/openpgp-keys-mkvtoolnix )"
 fi
 
+PATCHES=(
+	"${FILESDIR}"/mkvtoolnix-84.0.0-fix-libcxx-c++20.patch
+)
+
 src_prepare() {
 	default
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/933417

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
