### PR TITLE
dev-java/javatoolkit: switch to PEP517

### DIFF
--- a/dev-java/javatoolkit/javatoolkit-0.6.7-r2.ebuild
+++ b/dev-java/javatoolkit/javatoolkit-0.6.7-r2.ebuild
@@ -1,0 +1,40 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_REQ_USE="xml(+)"
+DISTUTILS_USE_PEP517=setuptools
+
+inherit distutils-r1 prefix
+
+DESCRIPTION="Collection of Gentoo-specific tools for Java"
+HOMEPAGE="https://wiki.gentoo.org/wiki/Project:Java"
+SRC_URI="https://gitweb.gentoo.org/proj/${PN}.git/snapshot/${P}.tar.bz2"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~sparc ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x64-solaris"
+
+python_prepare_all() {
+	hprefixify src/py/buildparser src/py/findclass setup.py
+
+	# Install the man page manually
+	sed -i '/data_files =/ d' setup.py || die
+
+	distutils-r1_python_prepare_all
+}
+
+python_install() {
+	distutils-r1_python_install
+
+	# The java eclasses expect the scripts to be in a special location
+	python_scriptinto /usr/libexec/${PN}
+	python_doexe "${D}$(python_get_scriptdir)"/*
+}
+
+python_install_all() {
+	doman src/man/*
+	distutils-r1_python_install_all
+}


### PR DESCRIPTION
Commit 5c70bf44a9aa9973e6e08941c9b0bcdb7c8d4560 set USE_PEP517 to setuptools but this changes the install location for some of the files.

Closes: https://bugs.gentoo.org/933409

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
