### PR TITLE
kde-frameworks/kauth: add missing kde-frameworks/kwindowsystem, #933440

### DIFF
--- a/kde-frameworks/kauth/kauth-6.2.0.ebuild
+++ b/kde-frameworks/kauth/kauth-6.2.0.ebuild
@@ -16,6 +16,7 @@ IUSE="+policykit"
 DEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6[dbus,gui]
 	=kde-frameworks/kcoreaddons-${PVCUT}*:6
+	=kde-frameworks/kwindowsystem-${PVCUT}*:6
 	policykit? ( >=sys-auth/polkit-qt-0.113.0[qt6(-)] )
 "
 RDEPEND="${DEPEND}"


### PR DESCRIPTION
Not actually tested, system currently under heavy update for Python 3.12.

Closes: https://bugs.gentoo.org/933440

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
