### PR TITLE
mail-filter/spamassassin: Fix sa_txrep test when no dbm

### DIFF
--- a/mail-filter/spamassassin/files/4.0.1-tests-sa_txrep.t-no-dbm.patch
+++ b/mail-filter/spamassassin/files/4.0.1-tests-sa_txrep.t-no-dbm.patch
@@ -1,0 +1,16 @@
+https://bugs.gentoo.org/933406
+--- a/t/sa_txrep.t
++++ b/t/sa_txrep.t
+@@ -4,7 +4,11 @@ use lib '.'; use lib 't';
+ use SATest; sa_t_init("sa_txrep");
+ 
+ 
+-use Test::More tests => 8;
++use Test::More;
++
++my @dbmods = grep eval "require $_", ('DB_File', 'GDBM_File', 'SDBM_File');
++plan skip_all => "No db module is available" unless @dbmods;
++plan tests => 8;
+ 
+ # ---------------------------------------------------------------------------
+ 

--- a/mail-filter/spamassassin/spamassassin-4.0.1.ebuild
+++ b/mail-filter/spamassassin/spamassassin-4.0.1.ebuild
@@ -91,6 +91,7 @@ VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/openpgp-keys/spamassassin.apache.org.asc
 PATCHES=(
 	"${FILESDIR}/mention-geoip.cf-in-init.pre.patch"
 	"${FILESDIR}/4.0.0-tests-dnsbl_subtests.t_001_load-URIDNSBL.patch"
+	"${FILESDIR}/4.0.1-tests-sa_txrep.t-no-dbm.patch"
 )
 
 # There are a few renames and use-dependent ones in src_install as well.


### PR DESCRIPTION
mail-filter/spamassassin: Fix sa_txrep test when no dbm

Upstream's fix is way more involved.  We'll let that wait for 4.0.2, I guess.  https://github.com/apache/spamassassin/commit/1c6fe5993ce48099aa73eb1d87419f50f922a0a6

Closes: https://bugs.gentoo.org/933406
Closes: https://github.com/gentoo/gentoo/pull/36986

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
