### PR TITLE
🐛 media-libs/aubio: revbump to 0.4.9-r4

### DIFF
--- a/media-libs/aubio/aubio-0.4.9-r2.ebuild
+++ b/media-libs/aubio/aubio-0.4.9-r2.ebuild
@@ -50,9 +50,11 @@ DOCS=( AUTHORS ChangeLog README.md )
 PYTHON_SRC_DIR="${S}"
 
 PATCHES=(
-	"${FILESDIR}"/${PN}-0.4.9-docdir.patch
+	"${FILESDIR}"/${P}-docdir.patch
+	"${FILESDIR}"/${P}-gcc-14.patch
+	"${FILESDIR}"/${P}-numpy-2.patch
+	"${FILESDIR}"/${P}-remove-universal-newlines.patch
 	"${FILESDIR}"/ffmpeg5.patch
-	"${FILESDIR}"/${PN}-0.4.9-remove-universal-newlines.patch
 )
 
 src_prepare() {

--- a/media-libs/aubio/files/aubio-0.4.9-gcc-14.patch
+++ b/media-libs/aubio/files/aubio-0.4.9-gcc-14.patch
@@ -1,0 +1,37 @@
+# https://bugs.gentoo.org/925102
+# https://github.com/aubio/aubio/commit/95ff046c
+
+From: Paul Brossier <piem@piem.org>
+Date: Thu, 2 Jul 2020 11:16:13 +0200
+Subject: [PATCH] [py] add const qualifiers to ufuncs prototypes for latest numpy
+
+---
+ python/ext/ufuncs.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/python/ext/ufuncs.c b/python/ext/ufuncs.c
+index d373d7258..e5641342e 100644
+--- a/python/ext/ufuncs.c
++++ b/python/ext/ufuncs.c
+@@ -3,8 +3,8 @@
+ 
+ typedef smpl_t (*aubio_unary_func_t)(smpl_t input);
+ 
+-static void aubio_PyUFunc_d_d(char **args, npy_intp *dimensions,
+-                            npy_intp* steps, void* data)
++static void aubio_PyUFunc_d_d(char **args, const npy_intp *dimensions,
++                            const npy_intp* steps, void* data)
+ {
+     npy_intp i;
+     npy_intp n = dimensions[0];
+@@ -22,8 +22,8 @@ static void aubio_PyUFunc_d_d(char **args, npy_intp *dimensions,
+     }
+ }
+ 
+-static void aubio_PyUFunc_f_f_As_d_d(char **args, npy_intp *dimensions,
+-                            npy_intp* steps, void* data)
++static void aubio_PyUFunc_f_f_As_d_d(char **args, const npy_intp *dimensions,
++                            const npy_intp* steps, void* data)
+ {
+     npy_intp i;
+     npy_intp n = dimensions[0];

--- a/media-libs/aubio/files/aubio-0.4.9-numpy-2.patch
+++ b/media-libs/aubio/files/aubio-0.4.9-numpy-2.patch
@@ -1,0 +1,13 @@
+diff --git a/python/tests/test_cvec.py b/python/tests/test_cvec.py
+index 73ee6549..e21418fc 100755
+--- a/python/tests/test_cvec.py
++++ b/python/tests/test_cvec.py
+@@ -43,7 +43,7 @@ class aubio_cvec_test_case(TestCase):
+         spec = cvec(1024)
+         spec.phas[39:-1] = -np.pi
+         assert_equal(spec.phas[0:39], 0)
+-        assert_equal(spec.phas[39:-1], -np.pi)
++        assert_equal(spec.phas[39:-1], np.asanyarray(-np.pi, spec.phas.dtype))
+         assert_equal(spec.norm, 0)
+ 
+     def test_assign_cvec_with_other_cvec(self):


### PR DESCRIPTION
_Hello everyone,_

These changes fix:
  - compile with `python-exec[-native-symlinks]` ([933405](https://bugs.gentoo.org/933405))
  - **GCC** `14` compatibility ([925102](https://bugs.gentoo.org/925102))
  - **NumPy** `2` compatibility
  - documentation issues:
    * partially missing docs on the first install
    * duplicated docs on reinstalls
  - missing `blas` USE flag ([589262](https://bugs.gentoo.org/589262))
  - missing `pytest` dependency

_Best regards!_

---

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
