### PR TITLE
Revert "dev-java/javatoolkit: migrated to pep517"

### DIFF
--- a/dev-java/javatoolkit/javatoolkit-0.6.7.ebuild
+++ b/dev-java/javatoolkit/javatoolkit-0.6.7.ebuild
@@ -3,9 +3,9 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{10..13} )
+PYTHON_COMPAT=( python3_{10..12} )
 PYTHON_REQ_USE="xml(+)"
-DISTUTILS_USE_PEP517=setuptools
+DISTUTILS_USE_SETUPTOOLS=no
 
 inherit distutils-r1 prefix
 


### PR DESCRIPTION
This reverts commit 5c70bf44a9aa9973e6e08941c9b0bcdb7c8d4560.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
