### PR TITLE
net-firewall/ufw: add missing dependency for setuptools

### DIFF
--- a/net-firewall/ufw/ufw-0.36.1.ebuild
+++ b/net-firewall/ufw/ufw-0.36.1.ebuild
@@ -19,7 +19,12 @@ KEYWORDS="amd64 ~arm arm64 ~ia64 ~loong ppc ppc64 ~riscv sparc x86"
 IUSE="examples ipv6"
 
 RDEPEND="net-firewall/iptables[ipv6(+)?]"
-BDEPEND="sys-devel/gettext"
+BDEPEND="
+	sys-devel/gettext
+	$(python_gen_cond_dep '
+		dev-python/setuptools[${PYTHON_USEDEP}]
+	' python3_12)
+"
 
 PATCHES=(
 	# Move files away from /lib/ufw.


### PR DESCRIPTION
* With python3.12 distutils isnt included with the interpeter but is instead bundled in setuptools.

Closes: https://bugs.gentoo.org/933481

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
