### PR TITLE
dev-embedded/arduino-ctags: Fix modern C build failure

### DIFF
--- a/dev-embedded/arduino-ctags/files/arduino-ctags-20161123-gcc-unused-attribute.patch
+++ b/dev-embedded/arduino-ctags/files/arduino-ctags-20161123-gcc-unused-attribute.patch
@@ -223,3 +223,14 @@ Thanks-to: <s.zharkoff@gmail.com>
  {
  	tagEntryInfo tag;
  	initTagEntry (&tag, vStringValue (function));
+--- a/routines.c
++++ b/routines.c
+@@ -526,7 +526,7 @@ static boolean isPathSeparator (const int c)
+
+ #if ! defined (HAVE_STAT_ST_INO)
+
+-static void canonicalizePath (char *const path __unused__)
++static void canonicalizePath (char *const path __arduino_unused__)
+ {
+ #if defined (MSDOS_STYLE_PATH)
+        char *p;


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/883239
Closes: https://bugs.gentoo.org/874969

Per bugs, this seems to have been broken since gcc-12. This just expands the already present patch to one more attribute replacement.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
