### PR TITLE
dev-python/urwid: add missing optional test dependencies

### DIFF
--- a/dev-python/urwid/urwid-2.6.12-r1.ebuild
+++ b/dev-python/urwid/urwid-2.6.12-r1.ebuild
@@ -1,0 +1,57 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DISTUTILS_EXT=1
+DISTUTILS_USE_PEP517=setuptools
+PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_REQ_USE="ncurses"
+
+inherit distutils-r1 optfeature pypi
+
+DESCRIPTION="Curses-based user interface library for Python"
+HOMEPAGE="
+	https://urwid.org/
+	https://pypi.org/project/urwid/
+	https://github.com/urwid/urwid/
+"
+
+LICENSE="LGPL-2.1"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm64 ~loong ~mips ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux"
+IUSE="examples"
+
+RDEPEND="
+	dev-python/typing-extensions[${PYTHON_USEDEP}]
+	dev-python/wcwidth[${PYTHON_USEDEP}]
+"
+BDEPEND="
+	dev-python/setuptools-scm[${PYTHON_USEDEP}]
+	test? (
+		dev-python/exceptiongroup[${PYTHON_USEDEP}]
+		dev-python/pyserial[${PYTHON_USEDEP}]
+		dev-python/trio[${PYTHON_USEDEP}]
+		dev-python/twisted[${PYTHON_USEDEP}]
+		dev-python/pyzmq[${PYTHON_USEDEP}]
+	)
+"
+
+distutils_enable_tests unittest
+
+python_test() {
+	rm -rf urwid || die
+	eunittest
+}
+
+python_install_all() {
+	use examples && dodoc -r examples
+	distutils-r1_python_install_all
+}
+
+pkg_postinst() {
+	optfeature "Trio event loop" "dev-python/trio dev-python/exceptiongroup"
+	optfeature "Twister event loop" "dev-python/twisted"
+	optfeature "ZMQ event loop" "dev-python/pyzmq"
+	optfeature "LCD display support" "dev-python/pyserial"
+}


### PR DESCRIPTION
* New revision due to dropped keywords: arm, ia64, ppc, sparc.
* Also add them to optfeature.

Closes: https://bugs.gentoo.org/933476

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
