### PR TITLE
dev-python/pycurl: crank up timeout

### DIFF
--- a/dev-python/pycurl/pycurl-7.45.3.ebuild
+++ b/dev-python/pycurl/pycurl-7.45.3.ebuild
@@ -83,7 +83,7 @@ python_test() {
 		tests/option_constants_test.py::OptionConstantsTest::test_socks5_gssapi_nec_setopt
 	)
 
-	epytest -p flaky -p timeout --timeout=30 tests
+	epytest -p flaky -p timeout --timeout=120 tests
 }
 
 python_install_all() {


### PR DESCRIPTION
Needed to pass on sparc.

Bug: https://bugs.gentoo.org/917128

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
