### PR TITLE
media-libs/mesa: 24.1.0-r1, 9999 update to match meson.build options

### DIFF
--- a/media-libs/mesa/mesa-24.1.0-r1.ebuild
+++ b/media-libs/mesa/mesa-24.1.0-r1.ebuild
@@ -202,12 +202,14 @@ pkg_pretend() {
 		fi
 	fi
 
+	# VA
 	if use vaapi; then
 		if ! use video_cards_d3d12 &&
+		   ! use video_cards_nouveau &&
 		   ! use video_cards_r600 &&
 		   ! use video_cards_radeonsi &&
-		   ! use video_cards_nouveau; then
-			ewarn "Ignoring USE=vaapi      since VIDEO_CARDS does not contain d3d12, r600, radeonsi, or nouveau"
+		   ! use video_cards_virgl; then
+			ewarn "Ignoring USE=vaapi      since VIDEO_CARDS does not contain d3d12, nouveau, r600, radeonsi, or virgl"
 		fi
 	fi
 
@@ -316,9 +318,10 @@ multilib_src_configure() {
 	fi
 
 	if use video_cards_d3d12 ||
+	   use video_cards_nouveau ||
 	   use video_cards_r600 ||
 	   use video_cards_radeonsi ||
-	   use video_cards_nouveau; then
+	   use video_cards_virgl; then
 		emesonargs+=($(meson_feature vaapi gallium-va))
 		use vaapi && emesonargs+=( -Dva-libs-path="${EPREFIX}"/usr/$(get_libdir)/va/drivers )
 	else

--- a/media-libs/mesa/mesa-24.1.0-r1.ebuild
+++ b/media-libs/mesa/mesa-24.1.0-r1.ebuild
@@ -46,7 +46,7 @@ LICENSE="MIT SGI-B-2.0"
 SLOT="0"
 
 RADEON_CARDS="r300 r600 radeon radeonsi"
-VIDEO_CARDS="${RADEON_CARDS} d3d12 freedreno intel lavapipe lima nouveau nvk panfrost v3d vc4 virgl vivante vmware"
+VIDEO_CARDS="${RADEON_CARDS} d3d12 freedreno intel lavapipe lima nouveau nvk panfrost v3d vc4 virgl vivante vmware zink"
 for card in ${VIDEO_CARDS}; do
 	IUSE_VIDEO_CARDS+=" video_cards_${card}"
 done
@@ -55,7 +55,7 @@ IUSE="${IUSE_VIDEO_CARDS}
 	cpu_flags_x86_sse2 d3d9 debug +llvm
 	lm-sensors opencl +opengl osmesa +proprietary-codecs selinux
 	test unwind vaapi valgrind vdpau vulkan
-	vulkan-overlay wayland +X xa zink +zstd"
+	vulkan-overlay wayland +X xa +zstd"
 RESTRICT="!test? ( test )"
 REQUIRED_USE="
 	d3d9? (
@@ -73,10 +73,10 @@ REQUIRED_USE="
 	video_cards_lavapipe? ( llvm vulkan )
 	video_cards_radeon? ( x86? ( llvm ) amd64? ( llvm ) )
 	video_cards_r300?   ( x86? ( llvm ) amd64? ( llvm ) )
+	video_cards_zink? ( vulkan opengl )
 	video_cards_nvk? ( vulkan video_cards_nouveau )
 	vdpau? ( X )
 	xa? ( X )
-	zink? ( opengl vulkan )
 "
 
 LIBDRM_DEPSTRING=">=x11-libs/libdrm-2.4.119"
@@ -112,6 +112,7 @@ RDEPEND="
 	)
 	vdpau? ( >=x11-libs/libvdpau-1.5:=[${MULTILIB_USEDEP}] )
 	video_cards_radeonsi? ( virtual/libelf:0=[${MULTILIB_USEDEP}] )
+	video_cards_zink? ( media-libs/vulkan-loader:=[${MULTILIB_USEDEP}] )
 	selinux? ( sys-libs/libselinux[${MULTILIB_USEDEP}] )
 	wayland? ( >=dev-libs/wayland-1.18.0[${MULTILIB_USEDEP}] )
 	${LIBDRM_DEPSTRING}[video_cards_freedreno?,video_cards_intel?,video_cards_nouveau?,video_cards_vc4?,video_cards_vivante?,video_cards_vmware?,${MULTILIB_USEDEP}]
@@ -124,7 +125,6 @@ RDEPEND="
 		x11-libs/libXfixes[${MULTILIB_USEDEP}]
 		x11-libs/xcb-util-keysyms[${MULTILIB_USEDEP}]
 	)
-	zink? ( media-libs/vulkan-loader:=[${MULTILIB_USEDEP}] )
 	zstd? ( app-arch/zstd:=[${MULTILIB_USEDEP}] )
 "
 for card in ${RADEON_CARDS}; do
@@ -362,7 +362,7 @@ multilib_src_configure() {
 	gallium_enable video_cards_virgl virgl
 	gallium_enable video_cards_vivante etnaviv
 	gallium_enable video_cards_vmware svga
-	gallium_enable zink zink
+	gallium_enable video_cards_zink zink
 
 	gallium_enable video_cards_r300 r300
 	gallium_enable video_cards_r600 r600

--- a/media-libs/mesa/mesa-24.1.0-r1.ebuild
+++ b/media-libs/mesa/mesa-24.1.0-r1.ebuild
@@ -60,12 +60,15 @@ RESTRICT="!test? ( test )"
 REQUIRED_USE="
 	d3d9? (
 		|| (
+			video_cards_freedreno
 			video_cards_intel
+			video_cards_nouveau
+			video_cards_panfrost
 			video_cards_r300
 			video_cards_r600
 			video_cards_radeonsi
-			video_cards_nouveau
 			video_cards_vmware
+			video_cards_zink
 		)
 	)
 	llvm? ( ${LLVM_REQUIRED_USE} )
@@ -298,12 +301,15 @@ multilib_src_configure() {
 	use wayland && platforms+=",wayland"
 	emesonargs+=(-Dplatforms=${platforms#,})
 
-	if use video_cards_intel ||
+	if use video_cards_freedreno ||
+	   use video_cards_intel || # crocus i915 iris
+	   use video_cards_nouveau ||
+	   use video_cards_panfrost ||
 	   use video_cards_r300 ||
 	   use video_cards_r600 ||
 	   use video_cards_radeonsi ||
-	   use video_cards_nouveau ||
-	   use video_cards_vmware; then
+	   use video_cards_vmware || # swrast
+	   use video_cards_zink; then
 		emesonargs+=($(meson_use d3d9 gallium-nine))
 	else
 		emesonargs+=(-Dgallium-nine=false)

--- a/media-libs/mesa/mesa-24.1.0-r1.ebuild
+++ b/media-libs/mesa/mesa-24.1.0-r1.ebuild
@@ -225,9 +225,10 @@ pkg_pretend() {
 
 	if use xa; then
 		if ! use video_cards_freedreno &&
+		   ! use video_cards_intel &&
 		   ! use video_cards_nouveau &&
 		   ! use video_cards_vmware; then
-			ewarn "Ignoring USE=xa         since VIDEO_CARDS does not contain freedreno, nouveau, or vmware"
+			ewarn "Ignoring USE=xa         since VIDEO_CARDS does not contain freedreno, intel, nouveau, or vmware"
 		fi
 	fi
 
@@ -343,6 +344,7 @@ multilib_src_configure() {
 	fi
 
 	if use video_cards_freedreno ||
+	   use video_cards_intel ||
 	   use video_cards_nouveau ||
 	   use video_cards_vmware; then
 		emesonargs+=($(meson_feature xa gallium-xa))

--- a/media-libs/mesa/mesa-24.1.0-r1.ebuild
+++ b/media-libs/mesa/mesa-24.1.0-r1.ebuild
@@ -366,10 +366,10 @@ multilib_src_configure() {
 	fi
 
 	gallium_enable -- swrast
+	gallium_enable video_cards_d3d12 d3d12
 	gallium_enable video_cards_freedreno freedreno
 	gallium_enable video_cards_intel crocus i915 iris
 	gallium_enable video_cards_lima lima
-	gallium_enable video_cards_d3d12 d3d12
 	gallium_enable video_cards_nouveau nouveau
 	gallium_enable video_cards_panfrost panfrost
 	gallium_enable video_cards_v3d v3d
@@ -382,8 +382,8 @@ multilib_src_configure() {
 	gallium_enable video_cards_r300 r300
 	gallium_enable video_cards_r600 r600
 	gallium_enable video_cards_radeonsi radeonsi
-	if ! use video_cards_r300 && \
-		! use video_cards_r600; then
+	if ! use video_cards_r300 &&
+	   ! use video_cards_r600; then
 		gallium_enable video_cards_radeon r300 r600
 	fi
 

--- a/media-libs/mesa/mesa-24.1.0-r1.ebuild
+++ b/media-libs/mesa/mesa-24.1.0-r1.ebuild
@@ -195,10 +195,14 @@ pkg_pretend() {
 		if ! use video_cards_d3d12 &&
 		   ! use video_cards_freedreno &&
 		   ! use video_cards_intel &&
+		   ! use video_cards_lavapipe &&
+		   ! use video_cards_nouveau &&
+		   ! use video_cards_nvk &&
+		   ! use video_cards_panfrost &&
 		   ! use video_cards_radeonsi &&
 		   ! use video_cards_v3d &&
-		   ! use video_cards_nvk; then
-			ewarn "Ignoring USE=vulkan     since VIDEO_CARDS does not contain d3d12, freedreno, intel, radeonsi, v3d, or nvk"
+		   ! use video_cards_virgl; then
+			ewarn "Ignoring USE=vulkan     since VIDEO_CARDS does not contain d3d12, freedreno, intel, lavapipe, nouveau, nvk, panfrost, radeonsi, v3d, or virgl"
 		fi
 	fi
 
@@ -393,12 +397,15 @@ multilib_src_configure() {
 	fi
 
 	if use vulkan; then
-		vulkan_enable video_cards_lavapipe swrast
+		vulkan_enable video_cards_d3d12 microsoft-experimental
 		vulkan_enable video_cards_freedreno freedreno
 		vulkan_enable video_cards_intel intel intel_hasvk
-		vulkan_enable video_cards_d3d12 microsoft-experimental
+		vulkan_enable video_cards_lavapipe swrast
+		vulkan_enable video_cards_panfrost panfrost
 		vulkan_enable video_cards_radeonsi amd
 		vulkan_enable video_cards_v3d broadcom
+		vulkan_enable video_cards_vc4 broadcom
+		vulkan_enable video_cards_virgl virtio
 		if use video_cards_nvk; then
 			vulkan_enable video_cards_nvk nouveau
 			if ! multilib_is_native_abi; then

--- a/media-libs/mesa/mesa-24.1.0-r1.ebuild
+++ b/media-libs/mesa/mesa-24.1.0-r1.ebuild
@@ -215,11 +215,11 @@ pkg_pretend() {
 
 	if use vdpau; then
 		if ! use video_cards_d3d12 &&
-		   ! use video_cards_r300 &&
+		   ! use video_cards_nouveau &&
 		   ! use video_cards_r600 &&
 		   ! use video_cards_radeonsi &&
-		   ! use video_cards_nouveau; then
-			ewarn "Ignoring USE=vdpau      since VIDEO_CARDS does not contain d3d12, r300, r600, radeonsi, or nouveau"
+		   ! use video_cards_virgl; then
+			ewarn "Ignoring USE=vdpau      since VIDEO_CARDS does not contain d3d12, nouveau, r600, radeonsi, or virgl"
 		fi
 	fi
 
@@ -333,10 +333,10 @@ multilib_src_configure() {
 	fi
 
 	if use video_cards_d3d12 ||
-	   use video_cards_r300 ||
+	   use video_cards_nouveau ||
 	   use video_cards_r600 ||
 	   use video_cards_radeonsi ||
-	   use video_cards_nouveau; then
+	   use video_cards_virgl; then
 		emesonargs+=($(meson_feature vdpau gallium-vdpau))
 	else
 		emesonargs+=(-Dgallium-vdpau=disabled)

--- a/media-libs/mesa/mesa-9999.ebuild
+++ b/media-libs/mesa/mesa-9999.ebuild
@@ -202,12 +202,14 @@ pkg_pretend() {
 		fi
 	fi
 
+	# VA
 	if use vaapi; then
 		if ! use video_cards_d3d12 &&
+		   ! use video_cards_nouveau &&
 		   ! use video_cards_r600 &&
 		   ! use video_cards_radeonsi &&
-		   ! use video_cards_nouveau; then
-			ewarn "Ignoring USE=vaapi      since VIDEO_CARDS does not contain d3d12, r600, radeonsi, or nouveau"
+		   ! use video_cards_virgl; then
+			ewarn "Ignoring USE=vaapi      since VIDEO_CARDS does not contain d3d12, nouveau, r600, radeonsi, or virgl"
 		fi
 	fi
 
@@ -316,9 +318,10 @@ multilib_src_configure() {
 	fi
 
 	if use video_cards_d3d12 ||
+	   use video_cards_nouveau ||
 	   use video_cards_r600 ||
 	   use video_cards_radeonsi ||
-	   use video_cards_nouveau; then
+	   use video_cards_virgl; then
 		emesonargs+=($(meson_feature vaapi gallium-va))
 		use vaapi && emesonargs+=( -Dva-libs-path="${EPREFIX}"/usr/$(get_libdir)/va/drivers )
 	else

--- a/media-libs/mesa/mesa-9999.ebuild
+++ b/media-libs/mesa/mesa-9999.ebuild
@@ -46,7 +46,7 @@ LICENSE="MIT SGI-B-2.0"
 SLOT="0"
 
 RADEON_CARDS="r300 r600 radeon radeonsi"
-VIDEO_CARDS="${RADEON_CARDS} d3d12 freedreno intel lavapipe lima nouveau nvk panfrost v3d vc4 virgl vivante vmware"
+VIDEO_CARDS="${RADEON_CARDS} d3d12 freedreno intel lavapipe lima nouveau nvk panfrost v3d vc4 virgl vivante vmware zink"
 for card in ${VIDEO_CARDS}; do
 	IUSE_VIDEO_CARDS+=" video_cards_${card}"
 done
@@ -55,7 +55,7 @@ IUSE="${IUSE_VIDEO_CARDS}
 	cpu_flags_x86_sse2 d3d9 debug +llvm
 	lm-sensors opencl +opengl osmesa +proprietary-codecs selinux
 	test unwind vaapi valgrind vdpau vulkan
-	vulkan-overlay wayland +X xa zink +zstd"
+	vulkan-overlay wayland +X xa +zstd"
 RESTRICT="!test? ( test )"
 REQUIRED_USE="
 	d3d9? (
@@ -73,10 +73,10 @@ REQUIRED_USE="
 	video_cards_lavapipe? ( llvm vulkan )
 	video_cards_radeon? ( x86? ( llvm ) amd64? ( llvm ) )
 	video_cards_r300?   ( x86? ( llvm ) amd64? ( llvm ) )
+	video_cards_zink? ( vulkan opengl )
 	video_cards_nvk? ( vulkan video_cards_nouveau )
 	vdpau? ( X )
 	xa? ( X )
-	zink? ( opengl vulkan )
 "
 
 LIBDRM_DEPSTRING=">=x11-libs/libdrm-2.4.119"
@@ -112,6 +112,7 @@ RDEPEND="
 	)
 	vdpau? ( >=x11-libs/libvdpau-1.5:=[${MULTILIB_USEDEP}] )
 	video_cards_radeonsi? ( virtual/libelf:0=[${MULTILIB_USEDEP}] )
+	video_cards_zink? ( media-libs/vulkan-loader:=[${MULTILIB_USEDEP}] )
 	selinux? ( sys-libs/libselinux[${MULTILIB_USEDEP}] )
 	wayland? ( >=dev-libs/wayland-1.18.0[${MULTILIB_USEDEP}] )
 	${LIBDRM_DEPSTRING}[video_cards_freedreno?,video_cards_intel?,video_cards_nouveau?,video_cards_vc4?,video_cards_vivante?,video_cards_vmware?,${MULTILIB_USEDEP}]
@@ -124,7 +125,6 @@ RDEPEND="
 		x11-libs/libXfixes[${MULTILIB_USEDEP}]
 		x11-libs/xcb-util-keysyms[${MULTILIB_USEDEP}]
 	)
-	zink? ( media-libs/vulkan-loader:=[${MULTILIB_USEDEP}] )
 	zstd? ( app-arch/zstd:=[${MULTILIB_USEDEP}] )
 "
 for card in ${RADEON_CARDS}; do
@@ -362,7 +362,7 @@ multilib_src_configure() {
 	gallium_enable video_cards_virgl virgl
 	gallium_enable video_cards_vivante etnaviv
 	gallium_enable video_cards_vmware svga
-	gallium_enable zink zink
+	gallium_enable video_cards_zink zink
 
 	gallium_enable video_cards_r300 r300
 	gallium_enable video_cards_r600 r600

--- a/media-libs/mesa/mesa-9999.ebuild
+++ b/media-libs/mesa/mesa-9999.ebuild
@@ -60,12 +60,15 @@ RESTRICT="!test? ( test )"
 REQUIRED_USE="
 	d3d9? (
 		|| (
+			video_cards_freedreno
 			video_cards_intel
+			video_cards_nouveau
+			video_cards_panfrost
 			video_cards_r300
 			video_cards_r600
 			video_cards_radeonsi
-			video_cards_nouveau
 			video_cards_vmware
+			video_cards_zink
 		)
 	)
 	llvm? ( ${LLVM_REQUIRED_USE} )
@@ -298,12 +301,15 @@ multilib_src_configure() {
 	use wayland && platforms+=",wayland"
 	emesonargs+=(-Dplatforms=${platforms#,})
 
-	if use video_cards_intel ||
+	if use video_cards_freedreno ||
+	   use video_cards_intel || # crocus i915 iris
+	   use video_cards_nouveau ||
+	   use video_cards_panfrost ||
 	   use video_cards_r300 ||
 	   use video_cards_r600 ||
 	   use video_cards_radeonsi ||
-	   use video_cards_nouveau ||
-	   use video_cards_vmware; then
+	   use video_cards_vmware || # swrast
+	   use video_cards_zink; then
 		emesonargs+=($(meson_use d3d9 gallium-nine))
 	else
 		emesonargs+=(-Dgallium-nine=false)

--- a/media-libs/mesa/mesa-9999.ebuild
+++ b/media-libs/mesa/mesa-9999.ebuild
@@ -225,9 +225,10 @@ pkg_pretend() {
 
 	if use xa; then
 		if ! use video_cards_freedreno &&
+		   ! use video_cards_intel &&
 		   ! use video_cards_nouveau &&
 		   ! use video_cards_vmware; then
-			ewarn "Ignoring USE=xa         since VIDEO_CARDS does not contain freedreno, nouveau, or vmware"
+			ewarn "Ignoring USE=xa         since VIDEO_CARDS does not contain freedreno, intel, nouveau, or vmware"
 		fi
 	fi
 
@@ -343,6 +344,7 @@ multilib_src_configure() {
 	fi
 
 	if use video_cards_freedreno ||
+	   use video_cards_intel ||
 	   use video_cards_nouveau ||
 	   use video_cards_vmware; then
 		emesonargs+=($(meson_feature xa gallium-xa))

--- a/media-libs/mesa/mesa-9999.ebuild
+++ b/media-libs/mesa/mesa-9999.ebuild
@@ -366,10 +366,10 @@ multilib_src_configure() {
 	fi
 
 	gallium_enable -- swrast
+	gallium_enable video_cards_d3d12 d3d12
 	gallium_enable video_cards_freedreno freedreno
 	gallium_enable video_cards_intel crocus i915 iris
 	gallium_enable video_cards_lima lima
-	gallium_enable video_cards_d3d12 d3d12
 	gallium_enable video_cards_nouveau nouveau
 	gallium_enable video_cards_panfrost panfrost
 	gallium_enable video_cards_v3d v3d
@@ -382,8 +382,8 @@ multilib_src_configure() {
 	gallium_enable video_cards_r300 r300
 	gallium_enable video_cards_r600 r600
 	gallium_enable video_cards_radeonsi radeonsi
-	if ! use video_cards_r300 && \
-		! use video_cards_r600; then
+	if ! use video_cards_r300 &&
+	   ! use video_cards_r600; then
 		gallium_enable video_cards_radeon r300 r600
 	fi
 

--- a/media-libs/mesa/mesa-9999.ebuild
+++ b/media-libs/mesa/mesa-9999.ebuild
@@ -195,10 +195,14 @@ pkg_pretend() {
 		if ! use video_cards_d3d12 &&
 		   ! use video_cards_freedreno &&
 		   ! use video_cards_intel &&
+		   ! use video_cards_lavapipe &&
+		   ! use video_cards_nouveau &&
+		   ! use video_cards_nvk &&
+		   ! use video_cards_panfrost &&
 		   ! use video_cards_radeonsi &&
 		   ! use video_cards_v3d &&
-		   ! use video_cards_nvk; then
-			ewarn "Ignoring USE=vulkan     since VIDEO_CARDS does not contain d3d12, freedreno, intel, radeonsi, v3d, or nvk"
+		   ! use video_cards_virgl; then
+			ewarn "Ignoring USE=vulkan     since VIDEO_CARDS does not contain d3d12, freedreno, intel, lavapipe, nouveau, nvk, panfrost, radeonsi, v3d, or virgl"
 		fi
 	fi
 
@@ -393,12 +397,15 @@ multilib_src_configure() {
 	fi
 
 	if use vulkan; then
-		vulkan_enable video_cards_lavapipe swrast
+		vulkan_enable video_cards_d3d12 microsoft-experimental
 		vulkan_enable video_cards_freedreno freedreno
 		vulkan_enable video_cards_intel intel intel_hasvk
-		vulkan_enable video_cards_d3d12 microsoft-experimental
+		vulkan_enable video_cards_lavapipe swrast
+		vulkan_enable video_cards_panfrost panfrost
 		vulkan_enable video_cards_radeonsi amd
 		vulkan_enable video_cards_v3d broadcom
+		vulkan_enable video_cards_vc4 broadcom
+		vulkan_enable video_cards_virgl virtio
 		if use video_cards_nvk; then
 			vulkan_enable video_cards_nvk nouveau
 			if ! multilib_is_native_abi; then

--- a/media-libs/mesa/mesa-9999.ebuild
+++ b/media-libs/mesa/mesa-9999.ebuild
@@ -215,11 +215,11 @@ pkg_pretend() {
 
 	if use vdpau; then
 		if ! use video_cards_d3d12 &&
-		   ! use video_cards_r300 &&
+		   ! use video_cards_nouveau &&
 		   ! use video_cards_r600 &&
 		   ! use video_cards_radeonsi &&
-		   ! use video_cards_nouveau; then
-			ewarn "Ignoring USE=vdpau      since VIDEO_CARDS does not contain d3d12, r300, r600, radeonsi, or nouveau"
+		   ! use video_cards_virgl; then
+			ewarn "Ignoring USE=vdpau      since VIDEO_CARDS does not contain d3d12, nouveau, r600, radeonsi, or virgl"
 		fi
 	fi
 
@@ -333,10 +333,10 @@ multilib_src_configure() {
 	fi
 
 	if use video_cards_d3d12 ||
-	   use video_cards_r300 ||
+	   use video_cards_nouveau ||
 	   use video_cards_r600 ||
 	   use video_cards_radeonsi ||
-	   use video_cards_nouveau; then
+	   use video_cards_virgl; then
 		emesonargs+=($(meson_feature vdpau gallium-vdpau))
 	else
 		emesonargs+=(-Dgallium-vdpau=disabled)

--- a/profiles/arch/alpha/package.use.mask
+++ b/profiles/arch/alpha/package.use.mask
@@ -250,7 +250,7 @@ mail-filter/pyzor mysql
 
 # Matt Turner <mattst88@gentoo.org> (2020-08-11)
 # No drivers on this architecture support Vulkan
-media-libs/mesa vulkan vulkan-overlay zink
+media-libs/mesa video_cards_zink vulkan vulkan-overlay zink
 
 # Sergei Trofimovich <slyfox@gentoo.org> (2020-07-18)
 # net-libs/webkit-gtk has no alpha keywords

--- a/profiles/arch/hppa/package.use.mask
+++ b/profiles/arch/hppa/package.use.mask
@@ -250,7 +250,7 @@ dev-libs/efl avif lua_single_target_luajit physics
 
 # Matt Turner <mattst88@gentoo.org> (2020-08-11)
 # No drivers on this architecture support Vulkan
-media-libs/mesa vulkan vulkan-overlay zink
+media-libs/mesa video_cards_zink vulkan vulkan-overlay zink
 
 # Robin H. Johnson <robbat2@gentoo.org> (2020-07-02)
 # Mask io-uring & zbc pending keywording

--- a/profiles/arch/ia64/package.use.mask
+++ b/profiles/arch/ia64/package.use.mask
@@ -231,7 +231,7 @@ net-analyzer/wireshark gui ilbc
 
 # Matt Turner <mattst88@gentoo.org> (2020-08-11)
 # No drivers on this architecture support Vulkan
-media-libs/mesa vulkan vulkan-overlay zink
+media-libs/mesa video_cards_zink vulkan vulkan-overlay zink
 
 # Michał Górny <mgorny@gentoo.org> (2020-06-14)
 # Requires dev-python/networkx.

--- a/profiles/arch/powerpc/package.use.stable.mask
+++ b/profiles/arch/powerpc/package.use.stable.mask
@@ -45,7 +45,7 @@ media-sound/jack2 ieee1394
 
 # Sam James <sam@gentoo.org> (2020-07-30)
 # vulkan-loader and glslang are not yet stable on ppc
-media-libs/mesa vulkan vulkan-overlay zink
+media-libs/mesa video_cards_zink vulkan vulkan-overlay zink
 
 # Sergei Trofimovich <slyfox@gentoo.org> (2019-12-12)
 # Needs stable net-libs/webkit-gtk, bug #684702

--- a/profiles/arch/s390/package.use.mask
+++ b/profiles/arch/s390/package.use.mask
@@ -206,7 +206,7 @@ dev-python/diskcache test
 
 # Matt Turner <mattst88@gentoo.org> (2020-08-11)
 # No drivers on this architecture support Vulkan
-media-libs/mesa vulkan vulkan-overlay zink
+media-libs/mesa video_cards_zink vulkan vulkan-overlay zink
 
 # Hans de Graaff <graaff@gentoo.org> (2019-04-08)
 # Obsolete ruby version, no newer versions keyworded or stable.

--- a/profiles/arch/sparc/package.use.mask
+++ b/profiles/arch/sparc/package.use.mask
@@ -307,7 +307,7 @@ media-libs/libsdl2 fcitx4
 
 # Matt Turner <mattst88@gentoo.org> (2020-08-11)
 # No drivers on this architecture support Vulkan
-media-libs/mesa vulkan vulkan-overlay zink
+media-libs/mesa video_cards_zink vulkan vulkan-overlay zink
 
 # Robin H. Johnson <robbat2@gentoo.org> (2020-07-02)
 # Mask io-uring & zbc pending keywording

--- a/profiles/desc/video_cards.desc
+++ b/profiles/desc/video_cards.desc
@@ -43,3 +43,4 @@ virgl - VIDEO_CARDS setting to build driver for virgil (virtual 3D GPU)
 virtualbox - VIDEO_CARDS setting to build driver for virtualbox emulation
 vivante - VIDEO_CARDS setting to build etnaviv driver for vivante video cards
 vmware - VIDEO_CARDS setting to build driver for vmware video cards
+zink - VIDEO_CARDS setting to build Zink OpenGL-over-Vulkan Gallium driver


### PR DESCRIPTION
renamed zink -> video_cards_zink

Updated gallium-nine, gallium-va, gallium-vdpau, kmsro, gallium-drivers and vulkan-drivers to match meson.build.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
