### PR TITLE
media-sound/awesfx: update EAPI 7 -> 8, fix wrong function signature

### DIFF
--- a/media-sound/awesfx/awesfx-0.5.2-r1.ebuild
+++ b/media-sound/awesfx/awesfx-0.5.2-r1.ebuild
@@ -1,0 +1,47 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools
+
+DESCRIPTION="AWE32 Sound Driver Utility Programs"
+HOMEPAGE="https://github.com/tiwai/awesfx"
+SRC_URI="https://github.com/tiwai/${PN}/archive/refs/tags/v${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~sparc ~x86"
+IUSE=""
+
+DEPEND="media-libs/alsa-lib"
+RDEPEND="${DEPEND}"
+
+BANK_LOC="${EPREFIX}/usr/share/sounds/sf2"
+
+DOCS=( AUTHORS ChangeLog README SBKtoSF2.txt samples/README-bank )
+
+PATCHES="${FILESDIR}/${P}-return-type.patch"
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_configure() {
+	econf \
+		--with-sfpath=${BANK_LOC}
+}
+
+src_install() {
+	default
+
+	rm "${ED}"/usr/share/sounds/sf2/README-bank || die
+	newinitd "${FILESDIR}"/sfxload.initd sfxload
+	newconfd "${FILESDIR}"/sfxload.confd sfxload
+}
+
+pkg_postinst() {
+	elog "Copy your SoundFont files from the original CDROM"
+	elog "shipped with your soundcard to ${BANK_LOC}."
+}

--- a/media-sound/awesfx/files/awesfx-0.5.2-return-type.patch
+++ b/media-sound/awesfx/files/awesfx-0.5.2-return-type.patch
@@ -1,0 +1,12 @@
+diff -ru a/alsa.c b/alsa.c
+--- a/alsa.c	2024-06-05 19:43:42.987168221 -0000
++++ b/alsa.c	2024-06-05 19:44:48.530787408 -0000
+@@ -139,7 +139,7 @@
+ 	return snd_hwdep_ioctl(hwdep, SNDRV_EMUX_IOCTL_MISC_MODE, &mode);
+ }
+ 
+-void seq_set_gus_bank(int bank)
++int seq_set_gus_bank(int bank)
+ {
+ 	struct sndrv_emux_misc_mode mode;
+ 	mode.port = -1;


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/831176

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
