### PR TITLE
net-im/discord: Add wayland support

### DIFF
--- a/net-im/discord/discord-0.0.57-r1.ebuild
+++ b/net-im/discord/discord-0.0.57-r1.ebuild
@@ -23,7 +23,7 @@ LICENSE="all-rights-reserved"
 SLOT="0"
 KEYWORDS="amd64"
 
-IUSE="appindicator +seccomp"
+IUSE="appindicator +seccomp wayland"
 RESTRICT="bindist mirror strip test"
 
 RDEPEND="
@@ -85,6 +85,12 @@ src_prepare() {
 	sed -i "/Exec/s:/usr/share/discord/Discord:${DESTDIR}/${MY_PN^}:" \
 		"${MY_PN}.desktop" ||
 		die "fixing of exec location on .desktop failed"
+	# USE wayland
+	if use wayland; then
+		sed -i '/Exec/s/Discord/Discord --enable-features=UseOzonePlatform --ozone-platform=wayland/' \
+			"${MY_PN}.desktop" ||
+			die "sed failed for wayland"
+	fi
 	# USE seccomp
 	if ! use seccomp; then
 		sed -i '/Exec/s/Discord/Discord --disable-seccomp-filter-sandbox/' \


### PR DESCRIPTION
Discord appears to support wayland when launched with these options, it just needs to be enabled manually.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
