### PR TITLE
app-editors/emacs: fix MissingInherits

### DIFF
--- a/app-editors/emacs/emacs-27.2-r16.ebuild
+++ b/app-editors/emacs/emacs-27.2-r16.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit autotools elisp-common readme.gentoo-r1 toolchain-funcs
+inherit autotools elisp-common flag-o-matic readme.gentoo-r1 toolchain-funcs
 
 if [[ ${PV##*.} = 9999 ]]; then
 	inherit git-r3


### PR DESCRIPTION
Add's missing `flag-o-matic` eclass. Was not even inherited inderectly, thus you see following warnings when building emacs:

```
>>> Configuring source in /var/tmp/portage/app-editors/emacs-27.2-r16/work/emacs-27.2 ...
/var/tmp/portage/app-editors/emacs-27.2-r16/temp/environment: line 2063: replace-flags: command not found
/var/tmp/portage/app-editors/emacs-27.2-r16/temp/environment: line 2064: append-flags: command not found
 * USE flag "alsa" overrides "-sound"; enabling sound support.
```

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
