### PR TITLE
app-cdr/gaffitter: fix bug #933664

### DIFF
--- a/app-cdr/gaffitter/gaffitter-1.0.0.ebuild
+++ b/app-cdr/gaffitter/gaffitter-1.0.0.ebuild
@@ -27,8 +27,18 @@ src_prepare() {
 	cmake_src_prepare
 }
 
+src_configure(){
+	local mycmakeargs=(
+		-DCMAKE_SKIP_RPATH=ON
+	)
+	cmake_src_configure
+}
+
 src_install() {
 	newbin "${BUILD_DIR}"/fit ${PN}
+	dolib.so "${BUILD_DIR}"/src/optimizers/liboptimizers.so
+	dolib.so "${BUILD_DIR}"/src/util/libutil.so
+
 	einstalldocs
 
 	if use scripts; then


### PR DESCRIPTION
There were actually two issues.

The run `insecure RUNPATHs` is fixed with setting `CMAKE_SKIP_RPATH=ON`.
The other one was because i didn't installed the missing `*.so` files, this is fixed with the `dolib.so` calls.

I hope thats correct and sorry for the inconvenience.

@arthurzam 

Signed-off-by: Michael Mair-Keimberger <mmk@levelnine.at>

Closes: https://bugs.gentoo.org/933664


---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
