### PR TITLE
sys-apps/usermode-utilities: Fix passing incompatible pointer types

### DIFF
--- a/sys-apps/usermode-utilities/files/usermode-utilities-gcc14-build-fix.patch
+++ b/sys-apps/usermode-utilities/files/usermode-utilities-gcc14-build-fix.patch
@@ -1,0 +1,13 @@
+Bug: https://bugs.gentoo.org/933391
+--- a/umlfs/uml_mount.c
++++ b/umlfs/uml_mount.c
+@@ -11,7 +11,8 @@ static int init_fuse(int argc, char **argv)
+ 
+ 	if (fuse_parse_cmdline(&args, &mountpoint, NULL, NULL) == -1)
+ 		return -EINVAL;
+-        return fuse_mount(mountpoint, &args);
++
++	return fuse_mount(mountpoint, (char *)&args);
+ }
+ 
+ int main(int argc, char **argv)

--- a/sys-apps/usermode-utilities/usermode-utilities-20070815-r6.ebuild
+++ b/sys-apps/usermode-utilities/usermode-utilities-20070815-r6.ebuild
@@ -1,0 +1,48 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+inherit toolchain-funcs
+
+DESCRIPTION="Tools for use with Usermode Linux virtual machines"
+HOMEPAGE="http://user-mode-linux.sourceforge.net/"
+SRC_URI="http://user-mode-linux.sourceforge.net/uml_utilities_${PV}.tar.bz2"
+
+S="${WORKDIR}"/tools-${PV}
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~x86"
+IUSE="fuse"
+
+RDEPEND="
+	fuse? ( sys-fs/fuse:0= )
+	sys-libs/readline:0=
+"
+DEPEND="${RDEPEND}"
+
+PATCHES=(
+	# Merge previous patches with fix for bug #331099
+	"${FILESDIR}"/${P}-rollup.patch
+	# Fix owner of humfsify; bug #364531
+	"${FILESDIR}"/${P}-humfsify-owner.patch
+	"${FILESDIR}"/${P}-headers.patch #580816
+	# Fix build /w clang-16, bug #898550
+	"${FILESDIR}"/${PN}-fix-memset.patch
+	"${FILESDIR}"/${PN}-gcc14-build-fix.patch
+)
+
+src_prepare() {
+	default
+	sed -i -e 's:-o \$(BIN):$(LDFLAGS) -o $(BIN):' "${S}"/*/Makefile || die "LDFLAGS sed failed"
+	sed -i -e 's:-o \$@:$(LDFLAGS) -o $@:' "${S}"/moo/Makefile || die "LDFLAGS sed (moo) failed"
+	if ! use fuse; then
+		einfo "Skipping build of umlmount to avoid sys-fs/fuse dependency."
+		sed -i -e 's/\<umlfs\>//' Makefile || die "sed to remove sys-fs/fuse dependency failed"
+	fi
+}
+
+src_compile() {
+	tc-export AR CC
+	emake CFLAGS="${CFLAGS} ${CPPFLAGS} -DTUNTAP -D_FILE_OFFSET_BITS=64 -D_LARGEFILE64_SOURCE -g -Wall" all
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/933391

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
