### PR TITLE
dev-qt/qtwebengine: add opengl as a rdepend

### DIFF
--- a/dev-qt/qtwebengine/qtwebengine-6.7.0.ebuild
+++ b/dev-qt/qtwebengine/qtwebengine-6.7.0.ebuild
@@ -70,6 +70,7 @@ RDEPEND="
 	designer? ( ~dev-qt/qttools-${PV}:6[designer] )
 	geolocation? ( ~dev-qt/qtpositioning-${PV}:6 )
 	kerberos? ( virtual/krb5 )
+	opengl? ( media-libs/libglvnd[X] )
 	pulseaudio? ( media-libs/libpulse[glib] )
 	screencast? (
 		dev-libs/glib:2

--- a/dev-qt/qtwebengine/qtwebengine-6.7.1.ebuild
+++ b/dev-qt/qtwebengine/qtwebengine-6.7.1.ebuild
@@ -70,6 +70,7 @@ RDEPEND="
 	designer? ( ~dev-qt/qttools-${PV}:6[designer] )
 	geolocation? ( ~dev-qt/qtpositioning-${PV}:6 )
 	kerberos? ( virtual/krb5 )
+	opengl? ( media-libs/libglvnd[X] )
 	pulseaudio? ( media-libs/libpulse[glib] )
 	screencast? (
 		dev-libs/glib:2

--- a/dev-qt/qtwebengine/qtwebengine-6.7.9999.ebuild
+++ b/dev-qt/qtwebengine/qtwebengine-6.7.9999.ebuild
@@ -70,6 +70,7 @@ RDEPEND="
 	designer? ( ~dev-qt/qttools-${PV}:6[designer] )
 	geolocation? ( ~dev-qt/qtpositioning-${PV}:6 )
 	kerberos? ( virtual/krb5 )
+	opengl? ( media-libs/libglvnd[X] )
 	pulseaudio? ( media-libs/libpulse[glib] )
 	screencast? (
 		dev-libs/glib:2

--- a/dev-qt/qtwebengine/qtwebengine-6.8.9999.ebuild
+++ b/dev-qt/qtwebengine/qtwebengine-6.8.9999.ebuild
@@ -70,6 +70,7 @@ RDEPEND="
 	designer? ( ~dev-qt/qttools-${PV}:6[designer] )
 	geolocation? ( ~dev-qt/qtpositioning-${PV}:6 )
 	kerberos? ( virtual/krb5 )
+	opengl? ( media-libs/libglvnd[X] )
 	pulseaudio? ( media-libs/libpulse[glib] )
 	screencast? (
 		dev-libs/glib:2

--- a/dev-qt/qtwebengine/qtwebengine-6.9999.ebuild
+++ b/dev-qt/qtwebengine/qtwebengine-6.9999.ebuild
@@ -70,6 +70,7 @@ RDEPEND="
 	designer? ( ~dev-qt/qttools-${PV}:6[designer] )
 	geolocation? ( ~dev-qt/qtpositioning-${PV}:6 )
 	kerberos? ( virtual/krb5 )
+	opengl? ( media-libs/libglvnd[X] )
 	pulseaudio? ( media-libs/libpulse[glib] )
 	screencast? (
 		dev-libs/glib:2


### PR DESCRIPTION
* when built on non-desktop profile systems, the qtwebengine[opengl] build fails because it needs opengl (GL/glx.h)

I've made this a rdepend because in theory qtwebengine[opengl] would depend on opengl at runtime, but I'm not sure how to verify this.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
