### PR TITLE
net-irc/weechat: add missing dependency with USE=relay-api

### DIFF
--- a/net-irc/weechat/weechat-4.3.2-r1.ebuild
+++ b/net-irc/weechat/weechat-4.3.2-r1.ebuild
@@ -57,6 +57,7 @@ RDEPEND="
 		virtual/libcrypt:=
 	)
 	python? ( ${PYTHON_DEPS} )
+	relay-api? ( dev-libs/cJSON )
 	ruby? (
 		|| (
 			dev-lang/ruby:3.3

--- a/net-irc/weechat/weechat-9999.ebuild
+++ b/net-irc/weechat/weechat-9999.ebuild
@@ -57,6 +57,7 @@ RDEPEND="
 		virtual/libcrypt:=
 	)
 	python? ( ${PYTHON_DEPS} )
+	relay-api? ( dev-libs/cJSON )
 	ruby? (
 		|| (
 			dev-lang/ruby:3.3


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/933748

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
