### PR TITLE
app-misc/hivex added python 3.12 compat

### DIFF
--- a/app-misc/hivex/hivex-1.3.23-r1.ebuild
+++ b/app-misc/hivex/hivex-1.3.23-r1.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 USE_RUBY="ruby31 ruby32"
 RUBY_OPTIONAL=yes
-PYTHON_COMPAT=( python3_{10..11} )
+PYTHON_COMPAT=( python3_{10..12} )
 inherit perl-module ruby-ng python-single-r1 strip-linguas
 
 DESCRIPTION="Library for reading and writing Windows Registry 'hive' binary files"


### PR DESCRIPTION
updated ebuild to allow building it with python 3.12 which is now default
<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
