### PR TITLE
app-arch/7zip: add ~arm64 keyword

### DIFF
--- a/app-arch/7zip/7zip-23.01.ebuild
+++ b/app-arch/7zip/7zip-23.01.ebuild
@@ -17,7 +17,7 @@ S="${WORKDIR}"
 
 LICENSE="LGPL-2 BSD rar? ( unRAR )"
 SLOT="0"
-KEYWORDS="~amd64"
+KEYWORDS="~amd64 ~arm64"
 IUSE="uasm jwasm rar"
 REQUIRED_USE="?? ( uasm jwasm )"
 

--- a/app-arch/7zip/7zip-24.05.ebuild
+++ b/app-arch/7zip/7zip-24.05.ebuild
@@ -17,7 +17,7 @@ S="${WORKDIR}"
 
 LICENSE="LGPL-2 BSD rar? ( unRAR )"
 SLOT="0"
-KEYWORDS="~amd64"
+KEYWORDS="~amd64 ~arm64"
 IUSE="uasm jwasm rar"
 REQUIRED_USE="?? ( uasm jwasm )"
 

--- a/app-arch/7zip/7zip-24.06.ebuild
+++ b/app-arch/7zip/7zip-24.06.ebuild
@@ -17,7 +17,7 @@ S="${WORKDIR}"
 
 LICENSE="LGPL-2 BSD rar? ( unRAR )"
 SLOT="0"
-KEYWORDS="~amd64"
+KEYWORDS="~amd64 ~arm64"
 IUSE="uasm jwasm rar"
 REQUIRED_USE="?? ( uasm jwasm )"
 

--- a/profiles/arch/amd64/package.use.mask
+++ b/profiles/arch/amd64/package.use.mask
@@ -17,6 +17,10 @@
 
 #--- END OF EXAMPLES ---
 
+# Jared Allard <jared@rgst.io> (2024-06-21)
+# uasm and jwasm include amd64-specific ASM
+app-arch/7zip -uasm -jwasm
+
 # Andrew Ammerlaan <andrewammerlaan@gentoo.org> (2024-04-25)
 # ROCm and Level-Zero are amd64-only at the moment
 sys-apps/hwloc -rocm -l0

--- a/profiles/arch/base/package.use.mask
+++ b/profiles/arch/base/package.use.mask
@@ -1,6 +1,10 @@
 # Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Jared Allard <jared@rgst.io> (2024-06-21)
+# uasm and jwasm include amd64-specific ASM
+app-arch/7zip uasm jwasm
+
 # Andrew Ammerlaan <andrewammerlaan@gentoo.org> (2024-04-25)
 # ROCm and Level-Zero are amd64-only at the moment
 sys-apps/hwloc rocm l0


### PR DESCRIPTION
Adds the `~arm64` keyword to app-arch/7zip because I've
been able to use it in a few different use-cases successfully
now.

As part of this, the USE flags `uasm` and `jwasm` are now masked
by default and unmasked on amd64, as it causes amd64-specific
asm to be used.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
