### PR TITLE
net-p2p/syncthing: Add ufw use flag to install net-firewall/ufw app p…

### DIFF
--- a/net-p2p/syncthing/files/syncthing.ufw
+++ b/net-p2p/syncthing/files/syncthing.ufw
@@ -1,0 +1,9 @@
+[syncthing]
+title=Syncthing
+description=Syncthing file synchronisation
+ports=22000|21027/udp
+
+[syncthing-gui]
+title=Syncthing-GUI
+description=Syncthing web gui
+ports=8384/tcp

--- a/net-p2p/syncthing/metadata.xml
+++ b/net-p2p/syncthing/metadata.xml
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-  <maintainer type="person">
-    <email>marecki@gentoo.org</email>
-    <name>Marek Szuba</name>
-  </maintainer>
-  <longdescription lang="en">
-      Syncthing replaces proprietary sync and cloud services with something open, trustworthy and decentralized.
-      Your data is your data alone and you deserve to choose where it is stored, if it is shared with some third party and how it's transmitted over the Internet.
-  </longdescription>
-  <use>
-    <flag name="tools">
-      Install stdiscosrv, strelaysrv and other tools to /usr/libexec/syncthing/.
-    </flag>
-  </use>
-  <upstream>
-    <remote-id type="github">syncthing/syncthing</remote-id>
-    <bugs-to>https://github.com/syncthing/syncthing/issues</bugs-to>
-  </upstream>
+	<maintainer type="person">
+		<email>marecki@gentoo.org</email>
+		<name>Marek Szuba</name>
+	</maintainer>
+	<longdescription lang="en"> Syncthing replaces proprietary sync and cloud services with
+		something open, trustworthy and decentralized. Your data is your data alone and you deserve
+		to choose where it is stored, if it is shared with some third party and how it's transmitted
+		over the Internet. </longdescription>
+	<use>
+		<flag name="tools"> Install stdiscosrv, strelaysrv and other tools to
+			/usr/libexec/syncthing/. </flag>
+		<flag name="ufw"> Install <pkg>net-firewall/ufw</pkg> rule set </flag>
+	</use>
+	<upstream>
+		<remote-id type="github">syncthing/syncthing</remote-id>
+		<bugs-to>https://github.com/syncthing/syncthing/issues</bugs-to>
+	</upstream>
 </pkgmetadata>

--- a/net-p2p/syncthing/syncthing-1.27.6-r1.ebuild
+++ b/net-p2p/syncthing/syncthing-1.27.6-r1.ebuild
@@ -1,0 +1,118 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit desktop go-module systemd xdg-utils
+
+DESCRIPTION="Open Source Continuous File Synchronization"
+HOMEPAGE="https://syncthing.net"
+SRC_URI="https://github.com/${PN}/${PN}/releases/download/v${PV}/${PN}-source-v${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="Apache-2.0 BSD BSD-2 CC0-1.0 ISC MIT MPL-2.0 Unlicense"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~loong ~ppc64 ~riscv ~x86"
+IUSE="selinux tools ufw"
+
+RDEPEND="acct-group/syncthing
+	acct-user/syncthing
+	tools? ( >=acct-user/stdiscosrv-1
+		>=acct-user/strelaysrv-1 )
+	selinux? ( sec-policy/selinux-syncthing )"
+BDEPEND=">=dev-lang/go-1.20.0"
+
+DOCS=( README.md AUTHORS CONTRIBUTING.md )
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-1.3.4-TestIssue5063_timeout.patch
+	"${FILESDIR}"/${PN}-1.18.4-tool_users.patch
+	"${FILESDIR}"/${PN}-1.27.4-tests_race.patch
+)
+
+S="${WORKDIR}"/${PN}
+
+src_prepare() {
+	# Bug #679280
+	xdg_environment_reset
+
+	default
+	sed -i \
+		's|^ExecStart=.*|ExecStart=/usr/libexec/syncthing/stdiscosrv|' \
+		cmd/stdiscosrv/etc/linux-systemd/stdiscosrv.service \
+		|| die
+	sed -i \
+		's|^ExecStart=.*|ExecStart=/usr/libexec/syncthing/strelaysrv|' \
+		cmd/strelaysrv/etc/linux-systemd/strelaysrv.service \
+		|| die
+}
+
+src_compile() {
+	GOARCH= go run build.go -version "v${PV}" -no-upgrade -build-out=bin/ \
+		${GOARCH:+-goarch="${GOARCH}"} \
+		build $(usex tools "all" "") || die "build failed"
+}
+
+src_test() {
+	go run build.go test || die "test failed"
+}
+
+src_install() {
+	local icon_size
+
+	doman man/*.[157]
+	einstalldocs
+
+	dobin bin/syncthing
+
+	domenu etc/linux-desktop/*.desktop
+	for icon_size in 32 64 128 256 512; do
+		newicon -s ${icon_size} assets/logo-${icon_size}.png ${PN}.png
+	done
+	newicon -s scalable assets/logo-only.svg ${PN}.svg
+
+	if use tools; then
+		exeinto /usr/libexec/syncthing
+		local exe
+		for exe in bin/* ; do
+			[[ "${exe}" == "bin/syncthing" ]] || doexe "${exe}"
+		done
+	fi
+
+	systemd_dounit etc/linux-systemd/system/${PN}{@,-resume}.service
+	systemd_douserunit etc/linux-systemd/user/${PN}.service
+	newconfd "${FILESDIR}"/${PN}.confd ${PN}
+	newinitd "${FILESDIR}"/${PN}.initd-r2 ${PN}
+
+	keepdir /var/log/${PN}
+	insinto /etc/logrotate.d
+	newins "${FILESDIR}"/${PN}.logrotate ${PN}
+
+	if use tools; then
+		systemd_dounit cmd/stdiscosrv/etc/linux-systemd/stdiscosrv.service
+		newconfd "${FILESDIR}"/stdiscosrv.confd stdiscosrv
+		newinitd "${FILESDIR}"/stdiscosrv.initd-r1 stdiscosrv
+
+		systemd_dounit cmd/strelaysrv/etc/linux-systemd/strelaysrv.service
+		newconfd "${FILESDIR}"/strelaysrv.confd strelaysrv
+		newinitd "${FILESDIR}"/strelaysrv.initd-r1 strelaysrv
+
+		insinto /etc/logrotate.d
+		newins "${FILESDIR}"/stdiscosrv.logrotate strelaysrv
+		newins "${FILESDIR}"/strelaysrv.logrotate strelaysrv
+	fi
+
+	if use ufw; then
+		insinto /etc/ufw/applications.d
+		newins "${FILESDIR}"/syncthing.ufw syncthing
+	fi
+}
+
+pkg_postinst() {
+	xdg_desktop_database_update
+	xdg_icon_cache_update
+}
+
+pkg_postrm() {
+	xdg_desktop_database_update
+	xdg_icon_cache_update
+}


### PR DESCRIPTION
…rofile

The ufw app profile file is downloaded from:

https://raw.githubusercontent.com/syncthing/syncthing/main/etc/firewall-ufw/syncthing

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
