### PR TITLE
dev-lang/{uasm,jwasm}, app-arch/7zip: fix mkdir race

### DIFF
--- a/app-arch/7zip/7zip-23.01.ebuild
+++ b/app-arch/7zip/7zip-23.01.ebuild
@@ -99,6 +99,7 @@ src_compile() {
 		args+=( MY_ASM=uasm )
 	fi
 
+	mkdir -p "${bdir}" || die  # Bug: https://bugs.gentoo.org/933619
 	emake ${args[@]}
 	popd > /dev/null || die "Unable to switch directory"
 }

--- a/app-arch/7zip/7zip-24.05.ebuild
+++ b/app-arch/7zip/7zip-24.05.ebuild
@@ -99,6 +99,7 @@ src_compile() {
 		args+=( MY_ASM=uasm )
 	fi
 
+	mkdir -p "${bdir}" || die  # Bug: https://bugs.gentoo.org/933619
 	emake ${args[@]}
 	popd > /dev/null || die "Unable to switch directory"
 }

--- a/app-arch/7zip/7zip-24.06.ebuild
+++ b/app-arch/7zip/7zip-24.06.ebuild
@@ -99,6 +99,7 @@ src_compile() {
 		args+=( MY_ASM=uasm )
 	fi
 
+	mkdir -p "${bdir}" || die  # Bug: https://bugs.gentoo.org/933619
 	emake ${args[@]}
 	popd > /dev/null || die "Unable to switch directory"
 }

--- a/dev-lang/jwasm/files/makefile-dep-fix.patch
+++ b/dev-lang/jwasm/files/makefile-dep-fix.patch
@@ -1,0 +1,22 @@
+Bug: https://bugs.gentoo.org/881519
+
+diff --git a/GccUnix.mak b/GccUnix.mak
+index 3f53d5b..8eb434e 100644
+--- a/GccUnix.mak
++++ b/GccUnix.mak
+@@ -31,13 +31,13 @@ include gccmod.inc
+ 
+ #.c.o:
+ #	$(CC) -c $(inc_dirs) $(c_flags) -o $(OUTD)/$*.o $<
+-$(OUTD)/%.o: %.c
++$(OUTD)/%.o: %.c | $(OUTD)
+ 	$(CC) -c $(inc_dirs) $(c_flags) -o $(OUTD)/$*.o $<
+ 
+ all:  $(OUTD) $(OUTD)/$(TARGET1)
+ 
+ $(OUTD):
+-	mkdir $(OUTD)
++	mkdir -p $(OUTD)
+ 
+ $(OUTD)/$(TARGET1) : $(OUTD)/main.o $(proj_obj)
+ ifeq ($(DEBUG),0)

--- a/dev-lang/jwasm/jwasm-2.13.ebuild
+++ b/dev-lang/jwasm/jwasm-2.13.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -19,7 +19,10 @@ BDEPEND=""
 
 S="${WORKDIR}/JWasm-${PV}"
 
-PATCHES=("${FILESDIR}"/${PN}-2.11-types-test.patch)
+PATCHES=(
+	"${FILESDIR}"/${PN}-2.11-types-test.patch
+	"${FILESDIR}/makefile-dep-fix.patch"
+)
 
 src_prepare() {
 	default

--- a/dev-lang/uasm/files/makefile-dep-fix.patch
+++ b/dev-lang/uasm/files/makefile-dep-fix.patch
@@ -1,0 +1,22 @@
+Bug: https://bugs.gentoo.org/933867
+
+diff --git a/gccLinux64.mak b/gccLinux64.mak
+index 9d4431a..e4fb10f 100644
+--- a/gccLinux64.mak
++++ b/gccLinux64.mak
+@@ -31,13 +31,13 @@ include gccmod.inc
+ 
+ #.c.o:
+ #	$(CC) -c $(inc_dirs) $(c_flags) -o $(OUTD)/$*.o $<
+-$(OUTD)/%.o: %.c
++$(OUTD)/%.o: %.c | $(OUTD)
+ 	$(CC) -D __UNIX__ -c $(inc_dirs) $(c_flags) $(CFLAGS) $(CPPFLAGS) -o $(OUTD)/$*.o $<
+ 
+ all:  $(OUTD) $(OUTD)/$(TARGET1)
+ 
+ $(OUTD):
+-	mkdir $(OUTD)
++	mkdir -p $(OUTD)
+ 
+ $(OUTD)/$(TARGET1) : $(OUTD)/main.o $(proj_obj)
+ ifeq ($(DEBUG),0)

--- a/dev-lang/uasm/uasm-2.56.2.ebuild
+++ b/dev-lang/uasm/uasm-2.56.2.ebuild
@@ -15,6 +15,7 @@ SLOT="0"
 KEYWORDS="~amd64"
 PATCHES=(
 	"${FILESDIR}/build-fix.patch"
+	"${FILESDIR}/makefile-dep-fix.patch"
 )
 
 src_prepare() {


### PR DESCRIPTION
~~I didn't really want to touch the makefiles of these projects, so went with creating the directory manually instead.~~

EDIT: Fixed the makefile for uasm and jwasm. 7zip, I don't want to touch so just doing `mkdir` in the ebuild instead.

Upstream ticket opened about this issue on 7zip: https://sourceforge.net/p/sevenzip/patches/446/

Closes: https://bugs.gentoo.org/881519
Closes: https://bugs.gentoo.org/933619
Closes: https://bugs.gentoo.org/933867

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
