### PR TITLE
net-irc/weechat: fix installing of live ebuild

### DIFF
--- a/net-irc/weechat/weechat-9999.ebuild
+++ b/net-irc/weechat/weechat-9999.ebuild
@@ -89,7 +89,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-3.3-cmake_lua_version.patch
 )
 
-DOCS="AUTHORS.adoc ChangeLog.adoc Contributing.adoc ReleaseNotes.adoc README.adoc"
+DOCS="AUTHORS.md CHANGELOG.md CONTRIBUTING.md UPGRADING.md README.md"
 
 RESTRICT="!test? ( test )"
 


### PR DESCRIPTION
Doc files in root of weechat repository were converted from `*.adoc` to `*.md` after version 4.3 was released. 
This change adapts live ebuild to this change.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
