### PR TITLE
dev-vcs/mercurial: dekeyword all for ~hppa

### DIFF
--- a/dev-python/pdm-backend/pdm-backend-2.3.0.ebuild
+++ b/dev-python/pdm-backend/pdm-backend-2.3.0.ebuild
@@ -37,9 +37,6 @@ BDEPEND="
 	test? (
 		dev-python/setuptools[${PYTHON_USEDEP}]
 		dev-vcs/git
-		!s390? ( !sparc? (
-			dev-vcs/mercurial
-		) )
 	)
 "
 # setuptools are used to build C extensions
@@ -72,11 +69,6 @@ src_test() {
 }
 
 python_test() {
-	local args=()
-	if ! has_version dev-vcs/mercurial; then
-		args+=( -k "not [hg" )
-	fi
-
 	local -x PYTEST_DISABLE_PLUGIN_AUTOLOAD=1
-	epytest "${args[@]}"
+	epytest -k "not [hg"
 }

--- a/dev-python/setuptools-scm/setuptools-scm-8.1.0.ebuild
+++ b/dev-python/setuptools-scm/setuptools-scm-8.1.0.ebuild
@@ -33,9 +33,6 @@ BDEPEND="
 		dev-python/build[${PYTHON_USEDEP}]
 		dev-python/typing-extensions[${PYTHON_USEDEP}]
 		dev-vcs/git
-		!sparc? (
-			dev-vcs/mercurial
-		)
 	)
 "
 

--- a/dev-vcs/mercurial/mercurial-6.5.3.ebuild
+++ b/dev-vcs/mercurial/mercurial-6.5.3.ebuild
@@ -171,7 +171,7 @@ SRC_URI="https://www.mercurial-scm.org/release/${P}.tar.gz
 LICENSE="GPL-2+
 	rust? ( 0BSD Apache-2.0 Apache-2.0-with-LLVM-exceptions BSD MIT MPL-2.0 PSF-2 Unicode-DFS-2016 Unlicense ZLIB )"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~loong ~m68k ~mips ppc ppc64 ~riscv x86 ~amd64-linux ~x86-linux ~arm64-macos ~ppc-macos ~x64-macos ~x64-solaris"
+KEYWORDS="~alpha amd64 arm arm64 ~ia64 ~loong ~m68k ~mips ppc ppc64 ~riscv x86 ~amd64-linux ~x86-linux ~arm64-macos ~ppc-macos ~x64-macos ~x64-solaris"
 IUSE="+chg emacs gpg test tk rust"
 
 BDEPEND="rust? ( ${RUST_DEPEND} )"

--- a/dev-vcs/mercurial/mercurial-6.6.2.ebuild
+++ b/dev-vcs/mercurial/mercurial-6.6.2.ebuild
@@ -181,7 +181,7 @@ LICENSE="GPL-2+
 	rust? (
 		0BSD Apache-2.0 Apache-2.0-with-LLVM-exceptions BSD Boost-1.0 MIT MPL-2.0 PSF-2 Unicode-DFS-2016 Unlicense ZLIB )"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~loong ~m68k ~mips ppc ppc64 ~riscv x86 ~amd64-linux ~x86-linux ~arm64-macos ~ppc-macos ~x64-macos ~x64-solaris"
+KEYWORDS="~alpha amd64 arm arm64 ~ia64 ~loong ~m68k ~mips ppc ppc64 ~riscv x86 ~amd64-linux ~x86-linux ~arm64-macos ~ppc-macos ~x64-macos ~x64-solaris"
 IUSE="+chg emacs gpg test tk rust"
 
 BDEPEND="rust? ( ${RUST_DEPEND} )"

--- a/dev-vcs/mercurial/mercurial-6.7.3.ebuild
+++ b/dev-vcs/mercurial/mercurial-6.7.3.ebuild
@@ -192,7 +192,7 @@ LICENSE="GPL-2+
 	rust? (
 		0BSD Apache-2.0 Apache-2.0-with-LLVM-exceptions BSD Boost-1.0 MIT MPL-2.0 PSF-2 Unicode-DFS-2016 Unlicense ZLIB )"
 SLOT="0"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux ~arm64-macos ~ppc-macos ~x64-macos ~x64-solaris"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux ~arm64-macos ~ppc-macos ~x64-macos ~x64-solaris"
 IUSE="+chg emacs gpg test tk rust"
 
 BDEPEND="rust? ( ${RUST_DEPEND} )"


### PR DESCRIPTION
Gets rid of weird conditional deps in `dev-python/pdm-backend` and `dev-python/setuptools-scm`.  They are not related to rust availability.  And then remove for hppa as tests hang there.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
