### PR TITLE
media-gfx/darktable: fix automagic dependency on media-libs/libheif

### DIFF
--- a/media-gfx/darktable/darktable-4.6.0.ebuild
+++ b/media-gfx/darktable/darktable-4.6.0.ebuild
@@ -148,6 +148,7 @@ src_configure() {
 		-DUSE_COLORD=$(usex colord)
 		-DUSE_GMIC=OFF
 		-DUSE_GRAPHICSMAGICK=$(usex graphicsmagick)
+		-DUSE_HEIF=$(usex heif)
 		-DUSE_JXL=$(usex jpegxl)
 		-DUSE_KWALLET=$(usex kwallet)
 		-DUSE_LIBSECRET=$(usex keyring)

--- a/media-gfx/darktable/darktable-4.6.1.ebuild
+++ b/media-gfx/darktable/darktable-4.6.1.ebuild
@@ -149,6 +149,7 @@ src_configure() {
 		-DUSE_COLORD=$(usex colord)
 		-DUSE_GMIC=OFF
 		-DUSE_GRAPHICSMAGICK=$(usex graphicsmagick)
+		-DUSE_HEIF=$(usex heif)
 		-DUSE_JXL=$(usex jpegxl)
 		-DUSE_KWALLET=$(usex kwallet)
 		-DUSE_LIBSECRET=$(usex keyring)


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/934008
Signed-off-by: Cristian Othón Martínez Vera <cfuga@cfuga.mx>

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
