### PR TITLE
tree-sitter-grammar.eclass: extended packaging

### DIFF
--- a/eclass/tree-sitter-grammar.eclass
+++ b/eclass/tree-sitter-grammar.eclass
@@ -163,6 +163,8 @@ tree-sitter-grammar_src_compile() {
 	if [[ -f "${S}/pyproject.toml" ]]; then
 		sed -e "/SONAME_MINOR :=/s/:=.*$/:= $(_get_tsg_abi_ver)/" -i "${S}/Makefile" || die
 		emake \
+			CC="$(tc-getCC)" \
+			AR="$(tc-getAR)" \
 			STRIP="" \
 			PREFIX="${EPREFIX}/usr" \
 			LIBDIR="${EPREFIX}/usr/$(get_libdir)"

--- a/eclass/tree-sitter-grammar.eclass
+++ b/eclass/tree-sitter-grammar.eclass
@@ -206,6 +206,19 @@ tree-sitter-grammar_src_install() {
 
 		dolib.so "${WORKDIR}/${soname}"
 		dosym "${soname}" /usr/$(get_libdir)/lib${PN}$(get_libname)
+		# Install symlinks to grammars so that they can be found by NeoVim.
+		# /usr/$(get_libdir)/tree-sitter gets added to the NeoVim runtimepath.
+		# See neovim/runtime/doc/treesitter.txt for info.
+		keepdir /usr/$(get_libdir)/tree-sitter
+		dosym ../"${soname}" \
+			/usr/$(get_libdir)/tree-sitter/parser/${PN##tree-sitter-}$(get_libname)
+
+		# Install queries (e.g. highlight.scm) so that they can be found by NeoVim.
+		if [[ -d "${S}/../queries" ]]; then
+			keepdir /usr/share/tree-sitter
+			insinto /usr/share/tree-sitter
+			doins -r "${S}/../queries"
+		fi
 	fi
 
 	local binding


### PR DESCRIPTION
1) put grammar library to additional well-known path 2) also put queries

See-Also: https://pkgs.alpinelinux.org/contents?branch=edge&name=tree%2dsitter%2dlua&arch=x86_64&repo=community
See-Also: https://pkgs.alpinelinux.org/contents?branch=edge&name=tree%2dsitter%2dcss&arch=x86_64&repo=community

Closes: https://bugs.gentoo.org/933833
Closes: https://bugs.gentoo.org/922146

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
