### PR TITLE
media-libs/mesa: Control whether RadeonSI and Radv use LLVM

### DIFF
--- a/media-libs/mesa/mesa-9999.ebuild
+++ b/media-libs/mesa/mesa-9999.ebuild
@@ -52,7 +52,7 @@ for card in ${VIDEO_CARDS}; do
 done
 
 IUSE="${IUSE_VIDEO_CARDS}
-	cpu_flags_x86_sse2 d3d9 debug +llvm
+	+amd-llvm cpu_flags_x86_sse2 d3d9 debug +llvm
 	lm-sensors opencl +opengl osmesa +proprietary-codecs selinux
 	test unwind vaapi valgrind vdpau vulkan
 	vulkan-overlay wayland +X xa +zstd"
@@ -458,6 +458,7 @@ multilib_src_configure() {
 		$(meson_feature unwind libunwind)
 		$(meson_feature zstd)
 		$(meson_use cpu_flags_x86_sse2 sse2)
+		-Damd-use-llvm=$(usex amd-llvm true false)
 		-Dintel-clc=$(usex video_cards_intel system auto)
 		-Dvalgrind=$(usex valgrind auto disabled)
 		-Dvideo-codecs=$(usex proprietary-codecs "all" "all_free")

--- a/media-libs/mesa/metadata.xml
+++ b/media-libs/mesa/metadata.xml
@@ -6,6 +6,7 @@
     <name>X11</name>
   </maintainer>
   <use>
+    <flag name="amd-llvm">Enable LLVM backend for RadeonSI and Radv drivers.</flag>
     <flag name="d3d9">Enable Direct 3D9 API through Nine state tracker. Can be used together with patched wine.</flag>
     <flag name="gles1">Enable GLESv1 support.</flag>
     <flag name="llvm">Enable LLVM backend for Gallium3D.</flag>


### PR DESCRIPTION
This uses the new amd-use-llvm meson option to control whether RadeonSI and Radv use the LLVM backend or just use ACO

USE=-amd-llvm will be ACO only RadeonSI and Radv

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [ x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [ x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [ ]x This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
