### PR TITLE
toolchain-funcs.eclass: Add tc-has-64bit-time_t

### DIFF
--- a/eclass/tests/toolchain-funcs.sh
+++ b/eclass/tests/toolchain-funcs.sh
@@ -210,6 +210,16 @@ if type -P gcc &>/dev/null; then
 	tbegin "tc-get-c-rtlib (gcc)"
 	[[ $(CC=gcc tc-get-c-rtlib) == libgcc ]]
 	tend $?
+
+	tbegin "tc-is-lto (gcc, -fno-lto)"
+	CC=gcc CFLAGS=-fno-lto tc-is-lto
+	[[ $? -eq 1 ]]
+	tend $?
+
+	tbegin "tc-is-lto (gcc, -flto)"
+	CC=gcc CFLAGS=-flto tc-is-lto
+	[[ $? -eq 0 ]]
+	tend $?
 fi
 
 if type -P clang &>/dev/null; then
@@ -232,6 +242,16 @@ if type -P clang &>/dev/null; then
 		[[ $(CC=clang CFLAGS="--rtlib=${rtlib}" tc-get-c-rtlib) == ${rtlib} ]]
 		tend $?
 	done
+
+	tbegin "tc-is-lto (clang, -fno-lto)"
+	CC=clang CFLAGS=-fno-lto tc-is-lto
+	[[ $? -eq 1 ]]
+	tend $?
+
+	tbegin "tc-is-lto (clang, -flto)"
+	CC=clang CFLAGS=-flto tc-is-lto
+	[[ $? -eq 0 ]]
+	tend $?
 fi
 
 texit

--- a/eclass/tests/toolchain-funcs.sh
+++ b/eclass/tests/toolchain-funcs.sh
@@ -220,6 +220,26 @@ if type -P gcc &>/dev/null; then
 	CC=gcc CFLAGS=-flto tc-is-lto
 	[[ $? -eq 0 ]]
 	tend $?
+
+	case $(gcc -dumpmachine) in
+		i*86*-gnu*|arm*-gnu*|powerpc-*-gnu)
+			tbegin "tc-has-64bit-time_t (_TIME_BITS=32)"
+			CC=gcc CFLAGS="-U_TIME_BITS -D_TIME_BITS=32" tc-has-64bit-time_t
+			[[ $? -eq 1 ]]
+			tend $?
+
+			tbegin "tc-has-64bit-time_t (_TIME_BITS=64)"
+			CC=gcc CFLAGS="-U_FILE_OFFSET_BITS -U_TIME_BITS -D_FILE_OFFSET_BITS=64 -D_TIME_BITS=64" tc-has-64bit-time_t
+			[[ $? -eq 0 ]]
+			tend $?
+			;;
+		*)
+			tbegin "tc-has-64bit-time_t"
+			CC=gcc tc-has-64bit-time_t
+			[[ $? -eq 0 ]]
+			tend $?
+			;;
+	esac
 fi
 
 if type -P clang &>/dev/null; then

--- a/eclass/toolchain-funcs.eclass
+++ b/eclass/toolchain-funcs.eclass
@@ -1234,6 +1234,7 @@ tc-get-build-ptr-size() {
 # @RETURN: Shell true if we are using LTO, shell false otherwise
 tc-is-lto() {
 	local f="${T}/test-lto.o"
+	local ret=1
 
 	case $(tc-get-compiler-type) in
 		clang)
@@ -1241,14 +1242,15 @@ tc-is-lto() {
 			# If LTO is used, clang will output bytecode and llvm-bcanalyzer
 			# will run successfully.  Otherwise, it will output plain object
 			# file and llvm-bcanalyzer will exit with error.
-			llvm-bcanalyzer "${f}" &>/dev/null && return 0
+			llvm-bcanalyzer "${f}" &>/dev/null && ret=0
 			;;
 		gcc)
 			$(tc-getCC) ${CFLAGS} -c -o "${f}" -x c - <<<"" || die
-			[[ $($(tc-getREADELF) -S "${f}") == *.gnu.lto* ]] && return 0
+			[[ $($(tc-getREADELF) -S "${f}") == *.gnu.lto* ]] && ret=0
 			;;
 	esac
-	return 1
+	rm -f "${f}" || die
+	return "${ret}"
 }
 
 fi

--- a/eclass/toolchain-funcs.eclass
+++ b/eclass/toolchain-funcs.eclass
@@ -1,4 +1,4 @@
-# Copyright 2002-2023 Gentoo Authors
+# Copyright 2002-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: toolchain-funcs.eclass
@@ -1251,6 +1251,16 @@ tc-is-lto() {
 	esac
 	rm -f "${f}" || die
 	return "${ret}"
+}
+
+# @FUNCTION: tc-has-64bit-time_t
+# @RETURN: Shell true if time_t is at least 64 bits long, false otherwise
+tc-has-64bit-time_t() {
+	$(tc-getCC) ${CFLAGS} ${CPPFLAGS} -c -x c - -o /dev/null <<-EOF &>/dev/null
+		#include <sys/types.h>
+		int test[sizeof(time_t) >= 8 ? 1 : -1];
+	EOF
+	return $?
 }
 
 fi


### PR DESCRIPTION
Add a helper function to check whether time_t is 64-bit.  This could be used e.g. to deselect tests that rely on timestamps exceeding Y2k38. It is meant to be more future-proof than hardcoding a list of 32-bit architectures, given the necessity of switching to 64-bit time_t in the future.