### PR TITLE
*/*:  Use new cargo_target_dir helper

### DIFF
--- a/app-benchmarks/hyperfine/hyperfine-1.16.1.ebuild
+++ b/app-benchmarks/hyperfine/hyperfine-1.16.1.ebuild
@@ -159,7 +159,7 @@ KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv"
 QA_FLAGS_IGNORED="usr/bin/${PN}"
 
 src_install() {
-	local build_dir="$(dirname $(find target/ -name ${PN}.bash -print -quit))"
+	local build_dir="$(dirname $(find "$(cargo_target_dir)" -name ${PN}.bash -print -quit))"
 
 	newbashcomp "${build_dir}/${PN}.bash" "${PN}"
 

--- a/app-benchmarks/hyperfine/hyperfine-1.18.0.ebuild
+++ b/app-benchmarks/hyperfine/hyperfine-1.18.0.ebuild
@@ -190,7 +190,7 @@ src_prepare() {
 }
 
 src_install() {
-	local build_dir="$(dirname $(find target/ -name ${PN}.bash -print -quit))"
+	local build_dir="$(dirname $(find "$(cargo_target_dir)" -name ${PN}.bash -print -quit))"
 
 	newbashcomp "${build_dir}/${PN}.bash" "${PN}"
 

--- a/app-containers/aardvark-dns/aardvark-dns-1.10.0.ebuild
+++ b/app-containers/aardvark-dns/aardvark-dns-1.10.0.ebuild
@@ -38,7 +38,7 @@ src_unpack() {
 
 src_prepare() {
 	default
-	sed -i -e "s|m0755 bin|m0755 target/$(usex debug debug release)|g;" Makefile || die
+	sed -i -e "s|m0755 bin|m0755 $(cargo_target_dir)|g;" Makefile || die
 }
 
 src_install() {

--- a/app-containers/aardvark-dns/aardvark-dns-1.11.0.ebuild
+++ b/app-containers/aardvark-dns/aardvark-dns-1.11.0.ebuild
@@ -38,7 +38,7 @@ src_unpack() {
 
 src_prepare() {
 	default
-	sed -i -e "s|m0755 bin|m0755 target/$(usex debug debug release)|g;" Makefile || die
+	sed -i -e "s|m0755 bin|m0755 $(cargo_target_dir)|g;" Makefile || die
 }
 
 src_install() {

--- a/app-containers/aardvark-dns/aardvark-dns-1.9.0.ebuild
+++ b/app-containers/aardvark-dns/aardvark-dns-1.9.0.ebuild
@@ -38,7 +38,7 @@ src_unpack() {
 
 src_prepare() {
 	default
-	sed -i -e "s|m0755 bin|m0755 target/$(usex debug debug release)|g;" Makefile || die
+	sed -i -e "s|m0755 bin|m0755 $(cargo_target_dir)|g;" Makefile || die
 }
 
 src_install() {

--- a/app-containers/aardvark-dns/aardvark-dns-9999.ebuild
+++ b/app-containers/aardvark-dns/aardvark-dns-9999.ebuild
@@ -38,7 +38,7 @@ src_unpack() {
 
 src_prepare() {
 	default
-	sed -i -e "s|m0755 bin|m0755 target/$(usex debug debug release)|g;" Makefile || die
+	sed -i -e "s|m0755 bin|m0755 $(cargo_target_dir)|g;" Makefile || die
 }
 
 src_install() {

--- a/app-containers/netavark/netavark-1.10.2.ebuild
+++ b/app-containers/netavark/netavark-1.10.2.ebuild
@@ -44,7 +44,7 @@ src_unpack() {
 
 src_prepare() {
 	default
-	sed -i -e "s|m0755 bin|m0755 target/$(usex debug debug release)|g;" Makefile || die
+	sed -i -e "s|m0755 bin|m0755 $(cargo_target_dir)|g;" Makefile || die
 }
 
 src_compile() {

--- a/app-containers/netavark/netavark-1.10.3.ebuild
+++ b/app-containers/netavark/netavark-1.10.3.ebuild
@@ -44,7 +44,7 @@ src_unpack() {
 
 src_prepare() {
 	default
-	sed -i -e "s|m0755 bin|m0755 target/$(usex debug debug release)|g;" Makefile || die
+	sed -i -e "s|m0755 bin|m0755 $(cargo_target_dir)|g;" Makefile || die
 }
 
 src_compile() {

--- a/app-containers/netavark/netavark-1.11.0.ebuild
+++ b/app-containers/netavark/netavark-1.11.0.ebuild
@@ -44,7 +44,7 @@ src_unpack() {
 
 src_prepare() {
 	default
-	sed -i -e "s|m0755 bin|m0755 target/$(usex debug debug release)|g;" Makefile || die
+	sed -i -e "s|m0755 bin|m0755 $(cargo_target_dir)|g;" Makefile || die
 }
 
 src_compile() {

--- a/app-containers/netavark/netavark-1.9.0.ebuild
+++ b/app-containers/netavark/netavark-1.9.0.ebuild
@@ -44,7 +44,7 @@ src_unpack() {
 
 src_prepare() {
 	default
-	sed -i -e "s|m0755 bin|m0755 target/$(usex debug debug release)|g;" Makefile || die
+	sed -i -e "s|m0755 bin|m0755 $(cargo_target_dir)|g;" Makefile || die
 }
 
 src_compile() {

--- a/app-containers/netavark/netavark-9999.ebuild
+++ b/app-containers/netavark/netavark-9999.ebuild
@@ -44,7 +44,7 @@ src_unpack() {
 
 src_prepare() {
 	default
-	sed -i -e "s|m0755 bin|m0755 target/$(usex debug debug release)|g;" Makefile || die
+	sed -i -e "s|m0755 bin|m0755 $(cargo_target_dir)|g;" Makefile || die
 }
 
 src_compile() {

--- a/app-crypt/rpm-sequoia/rpm-sequoia-1.6.0.ebuild
+++ b/app-crypt/rpm-sequoia/rpm-sequoia-1.6.0.ebuild
@@ -290,9 +290,9 @@ src_compile() {
 }
 
 src_install() {
-	newlib.so target/$(usex debug debug release)/librpm_sequoia.so librpm_sequoia.so.1
+	newlib.so "$(cargo_target_dir)"/librpm_sequoia.so librpm_sequoia.so.1
 	dosym librpm_sequoia.so.1 /usr/$(get_libdir)/librpm_sequoia.so
 
 	insinto /usr/$(get_libdir)/pkgconfig
-	doins target/$(usex debug debug release)/rpm-sequoia.pc
+	doins "$(cargo_target_dir)"/rpm-sequoia.pc
 }

--- a/app-emulation/ruffle/ruffle-0_p20240422.ebuild
+++ b/app-emulation/ruffle/ruffle-0_p20240422.ebuild
@@ -742,9 +742,7 @@ src_install() {
 	make_desktop_entry ${PN} ${PN^} ${PN} "AudioVideo;Player;Emulator;" \
 		"MimeType=application/x-shockwave-flash;application/vnd.adobe.flash.movie;"
 
-	# TODO: swap with /gentoo after https://github.com/gentoo/gentoo/pull/29510
-	cd target/$(usex debug{,} release) || die
-
+	cd "$(cargo_target_dir)" || die
 	newbin ${PN}_desktop ${PN}
 	newbin exporter ${PN}_exporter
 	dobin ${PN}_scanner

--- a/app-emulation/ruffle/ruffle-0_p20240521.ebuild
+++ b/app-emulation/ruffle/ruffle-0_p20240521.ebuild
@@ -723,9 +723,7 @@ src_install() {
 	make_desktop_entry ${PN} ${PN^} ${PN} "AudioVideo;Player;Emulator;" \
 		"MimeType=application/x-shockwave-flash;application/vnd.adobe.flash.movie;"
 
-	# TODO: swap with /gentoo after https://github.com/gentoo/gentoo/pull/29510
-	cd target/$(usex debug{,} release) || die
-
+	cd "$(cargo_target_dir)" || die
 	newbin ${PN}_desktop ${PN}
 	newbin exporter ${PN}_exporter
 	dobin ${PN}_scanner

--- a/app-emulation/ruffle/ruffle-9999.ebuild
+++ b/app-emulation/ruffle/ruffle-9999.ebuild
@@ -75,9 +75,7 @@ src_install() {
 	make_desktop_entry ${PN} ${PN^} ${PN} "AudioVideo;Player;Emulator;" \
 		"MimeType=application/x-shockwave-flash;application/vnd.adobe.flash.movie;"
 
-	# TODO: swap with /gentoo after https://github.com/gentoo/gentoo/pull/29510
-	cd target/$(usex debug{,} release) || die
-
+	cd "$(cargo_target_dir)" || die
 	newbin ${PN}_desktop ${PN}
 	newbin exporter ${PN}_exporter
 	dobin ${PN}_scanner

--- a/app-forensics/yara-x/yara-x-0.4.0.ebuild
+++ b/app-forensics/yara-x/yara-x-0.4.0.ebuild
@@ -571,8 +571,8 @@ src_test() {
 }
 
 src_install() {
-	dobin target/$(usex debug "debug" "release")/yr
-	dolib.so target/$(usex debug "debug" "release")/*.so
+	dobin "$(cargo_target_dir)"/yr
+	dolib.so "$(cargo_target_dir)"/*.so
 
 	wrap_python ${FUNCNAME}
 }

--- a/app-misc/broot/broot-1.36.1.ebuild
+++ b/app-misc/broot/broot-1.36.1.ebuild
@@ -367,7 +367,7 @@ src_install() {
 
 	doman "${T}"/${PN}.1
 
-	local build_dir=( target/$(usex debug{,} release)/build/${PN}-*/out )
+	local build_dir=( "$(cargo_target_dir)"/build/${PN}-*/out )
 	cd ${build_dir[0]} || die
 
 	newbashcomp ${PN}.bash ${PN}

--- a/app-portage/emlop/emlop-0.6.1.ebuild
+++ b/app-portage/emlop/emlop-0.6.1.ebuild
@@ -100,12 +100,12 @@ src_install() {
 	cargo_src_install
 	dodoc README.md CHANGELOG.md
 	# bash
-	./target/$(usex debug debug release)/emlop complete bash > emlop || die
+	"$(cargo_target_dir)"/emlop complete bash > emlop || die
 	dobashcomp emlop
 	# zsh
-	./target/$(usex debug debug release)/emlop complete zsh > _emlop || die
+	"$(cargo_target_dir)"/emlop complete zsh > _emlop || die
 	dozshcomp _emlop
 	# fish
-	./target/$(usex debug debug release)/emlop complete fish > emlop.fish || die
+	"$(cargo_target_dir)"/emlop complete fish > emlop.fish || die
 	dofishcomp emlop.fish
 }

--- a/app-portage/emlop/emlop-0.7.0.ebuild
+++ b/app-portage/emlop/emlop-0.7.0.ebuild
@@ -115,12 +115,12 @@ src_install() {
 	cargo_src_install
 	dodoc README.md CHANGELOG.md emlop.toml
 	# bash
-	./target/$(usex debug debug release)/emlop complete bash > emlop || die
+	"$(cargo_target_dir)"/emlop complete bash > emlop || die
 	dobashcomp emlop
 	# zsh
-	./target/$(usex debug debug release)/emlop complete zsh > _emlop || die
+	"$(cargo_target_dir)"/emlop complete zsh > _emlop || die
 	dozshcomp _emlop
 	# fish
-	./target/$(usex debug debug release)/emlop complete fish > emlop.fish || die
+	"$(cargo_target_dir)"/emlop complete fish > emlop.fish || die
 	dofishcomp emlop.fish
 }

--- a/app-shells/atuin/atuin-18.0.1.ebuild
+++ b/app-shells/atuin/atuin-18.0.1.ebuild
@@ -480,7 +480,7 @@ src_configure() {
 src_compile() {
 	cargo_src_compile
 
-	ATUIN_BIN="target/$(usex debug debug release)/${PN}"
+	ATUIN_BIN="$(cargo_target_dir)/${PN}"
 
 	# Prepare shell completion generation
 	mkdir completions || die

--- a/app-shells/atuin/atuin-18.1.0.ebuild
+++ b/app-shells/atuin/atuin-18.1.0.ebuild
@@ -491,7 +491,7 @@ src_configure() {
 src_compile() {
 	cargo_src_compile
 
-	ATUIN_BIN="target/$(usex debug debug release)/${PN}"
+	ATUIN_BIN="$(cargo_target_dir)/${PN}"
 
 	# Prepare shell completion generation
 	mkdir completions || die

--- a/app-shells/atuin/atuin-18.2.0.ebuild
+++ b/app-shells/atuin/atuin-18.2.0.ebuild
@@ -493,7 +493,7 @@ src_configure() {
 src_compile() {
 	cargo_src_compile
 
-	ATUIN_BIN="target/$(usex debug debug release)/${PN}"
+	ATUIN_BIN="$(cargo_target_dir)/${PN}"
 
 	# Prepare shell completion generation
 	mkdir completions || die

--- a/app-text/mdbook/mdbook-0.4.37.ebuild
+++ b/app-text/mdbook/mdbook-0.4.37.ebuild
@@ -269,7 +269,7 @@ src_compile() {
 		if tc-is-cross-compiler; then
 			ewarn "html docs were skipped due to cross-compilation"
 		else
-			target/$(usex debug{,} release)/${PN} build -d html guide || die
+			"$(cargo_target_dir)"/${PN} build -d html guide || die
 		fi
 	fi
 }

--- a/app-text/mdbook/mdbook-0.4.40.ebuild
+++ b/app-text/mdbook/mdbook-0.4.40.ebuild
@@ -280,7 +280,7 @@ src_compile() {
 		if tc-is-cross-compiler; then
 			ewarn "html docs were skipped due to cross-compilation"
 		else
-			target/$(usex debug{,} release)/${PN} build -d html guide || die
+			"$(cargo_target_dir)"/${PN} build -d html guide || die
 		fi
 	fi
 }

--- a/dev-lang/starlark-rust/starlark-rust-0.8.0.ebuild
+++ b/dev-lang/starlark-rust/starlark-rust-0.8.0.ebuild
@@ -195,11 +195,11 @@ src_prepare() {
 
 src_test() {
 	source "${FILESDIR}/test/features.bash" || die
-	test-features_main "${PWD}/target/release/starlark" || die
+	test-features_main "${PWD}/$(cargo_target_dir)/starlark" || die
 }
 
 src_install() {
-	dobin target/release/starlark
+	dobin "$(cargo_target_dir)/starlark"
 	ln "${ED}/usr/bin/starlark"{,-rust} || die
 	dodoc -r {docs,{CHANGELOG,README}.md}
 }

--- a/dev-util/maturin/maturin-1.4.0.ebuild
+++ b/dev-util/maturin/maturin-1.4.0.ebuild
@@ -513,7 +513,7 @@ python_compile_all() {
 	use !doc || mdbook build -d html guide || die
 
 	if ! tc-is-cross-compiler; then
-		local maturin=target/$(usex debug{,} release)/maturin
+		local maturin=$(cargo_target_dir)/maturin
 		${maturin} completions bash > "${T}"/${PN} || die
 		${maturin} completions fish > "${T}"/${PN}.fish || die
 		${maturin} completions zsh > "${T}"/_${PN} || die

--- a/dev-util/maturin/maturin-1.5.1-r1.ebuild
+++ b/dev-util/maturin/maturin-1.5.1-r1.ebuild
@@ -513,7 +513,7 @@ python_compile_all() {
 	use !doc || mdbook build -d html guide || die
 
 	if ! tc-is-cross-compiler; then
-		local maturin=target/$(usex debug{,} release)/maturin
+		local maturin=$(cargo_target_dir)/maturin
 		${maturin} completions bash > "${T}"/${PN} || die
 		${maturin} completions fish > "${T}"/${PN}.fish || die
 		${maturin} completions zsh > "${T}"/_${PN} || die

--- a/dev-util/maturin/maturin-1.6.0.ebuild
+++ b/dev-util/maturin/maturin-1.6.0.ebuild
@@ -522,7 +522,7 @@ python_compile_all() {
 	use !doc || mdbook build -d html guide || die
 
 	if ! tc-is-cross-compiler; then
-		local maturin=target/$(usex debug{,} release)/maturin
+		local maturin=$(cargo_target_dir)/maturin
 		${maturin} completions bash > "${T}"/${PN} || die
 		${maturin} completions fish > "${T}"/${PN}.fish || die
 		${maturin} completions zsh > "${T}"/_${PN} || die

--- a/dev-util/ruff/ruff-0.4.6.ebuild
+++ b/dev-util/ruff/ruff-0.4.6.ebuild
@@ -419,7 +419,7 @@ src_compile() {
 	cargo_src_compile --bin ruff
 
 	local releasedir
-	releasedir=target/$(usex 'debug' 'debug' 'release')
+	releasedir=$(cargo_target_dir)
 
 	${releasedir}/ruff generate-shell-completion bash > ruff-completion.bash || die
 	${releasedir}/ruff generate-shell-completion zsh > ruff-completion.zsh || die
@@ -435,7 +435,7 @@ src_test() {
 }
 
 src_install() {
-	local releasedir=target/$(usex 'debug' 'debug' 'release')
+	local releasedir=$(cargo_target_dir)
 
 	dobin ${releasedir}/ruff
 

--- a/dev-util/ruff/ruff-0.4.7.ebuild
+++ b/dev-util/ruff/ruff-0.4.7.ebuild
@@ -419,7 +419,7 @@ src_compile() {
 	cargo_src_compile --bin ruff
 
 	local releasedir
-	releasedir=target/$(usex 'debug' 'debug' 'release')
+	releasedir=$(cargo_target_dir)
 
 	${releasedir}/ruff generate-shell-completion bash > ruff-completion.bash || die
 	${releasedir}/ruff generate-shell-completion zsh > ruff-completion.zsh || die
@@ -435,7 +435,7 @@ src_test() {
 }
 
 src_install() {
-	local releasedir=target/$(usex 'debug' 'debug' 'release')
+	local releasedir=$(cargo_target_dir)
 
 	dobin ${releasedir}/ruff
 

--- a/dev-util/ruff/ruff-0.4.8.ebuild
+++ b/dev-util/ruff/ruff-0.4.8.ebuild
@@ -415,7 +415,7 @@ src_compile() {
 	cargo_src_compile --bin ruff
 
 	local releasedir
-	releasedir=target/$(usex 'debug' 'debug' 'release')
+	releasedir=$(cargo_target_dir)
 
 	${releasedir}/ruff generate-shell-completion bash > ruff-completion.bash || die
 	${releasedir}/ruff generate-shell-completion zsh > ruff-completion.zsh || die
@@ -431,7 +431,7 @@ src_test() {
 }
 
 src_install() {
-	local releasedir=target/$(usex 'debug' 'debug' 'release')
+	local releasedir=$(cargo_target_dir)
 
 	dobin ${releasedir}/ruff
 

--- a/dev-vcs/git-absorb/git-absorb-0.6.11-r1.ebuild
+++ b/dev-vcs/git-absorb/git-absorb-0.6.11-r1.ebuild
@@ -96,7 +96,7 @@ QA_FLAGS_IGNORED="usr/bin/${PN}"
 src_compile() {
 	cargo_src_compile
 
-	GIT_ABSORB_BIN="target/$(usex debug debug release)/${PN}"
+	GIT_ABSORB_BIN="$(cargo_target_dir)/${PN}"
 
 	# Prepare shell completion generation
 	mkdir completions || die

--- a/dev-vcs/git-absorb/git-absorb-0.6.13-r1.ebuild
+++ b/dev-vcs/git-absorb/git-absorb-0.6.13-r1.ebuild
@@ -132,7 +132,7 @@ src_compile() {
 
 	cargo_src_compile
 
-	GIT_ABSORB_BIN="target/$(usex debug debug release)/${PN}"
+	GIT_ABSORB_BIN="$(cargo_target_dir)/${PN}"
 
 	# Prepare shell completion generation
 	mkdir completions || die

--- a/dev-vcs/git-absorb/git-absorb-0.6.13.ebuild
+++ b/dev-vcs/git-absorb/git-absorb-0.6.13.ebuild
@@ -124,7 +124,7 @@ QA_FLAGS_IGNORED="usr/bin/${PN}"
 src_compile() {
 	cargo_src_compile
 
-	GIT_ABSORB_BIN="target/$(usex debug debug release)/${PN}"
+	GIT_ABSORB_BIN="$(cargo_target_dir)/${PN}"
 
 	# Prepare shell completion generation
 	mkdir completions || die

--- a/dev-vcs/mercurial/mercurial-6.5.3.ebuild
+++ b/dev-vcs/mercurial/mercurial-6.5.3.ebuild
@@ -281,7 +281,7 @@ python_install_all() {
 		RM_CONTRIB+=( chg )
 	fi
 	if use rust; then
-		dobin rust/target/release/rhg
+		dobin "rust/$(cargo_target_dir)/rhg"
 	fi
 
 	for f in ${RM_CONTRIB[@]}; do

--- a/dev-vcs/mercurial/mercurial-6.6.2.ebuild
+++ b/dev-vcs/mercurial/mercurial-6.6.2.ebuild
@@ -291,7 +291,7 @@ python_install_all() {
 		RM_CONTRIB+=( chg )
 	fi
 	if use rust; then
-		dobin rust/target/release/rhg
+		dobin "rust/$(cargo_target_dir)/rhg"
 	fi
 
 	for f in ${RM_CONTRIB[@]}; do

--- a/dev-vcs/mercurial/mercurial-6.7.4.ebuild
+++ b/dev-vcs/mercurial/mercurial-6.7.4.ebuild
@@ -302,7 +302,7 @@ python_install_all() {
 		RM_CONTRIB+=( chg )
 	fi
 	if use rust; then
-		dobin rust/target/release/rhg
+		dobin "rust/$(cargo_target_dir)/rhg"
 	fi
 
 	for f in ${RM_CONTRIB[@]}; do

--- a/dev-vcs/mercurial/mercurial-9999.ebuild
+++ b/dev-vcs/mercurial/mercurial-9999.ebuild
@@ -130,7 +130,7 @@ python_install_all() {
 		RM_CONTRIB+=( chg )
 	fi
 	if use rust; then
-		dobin rust/target/release/rhg
+		dobin "rust/$(cargo_target_dir)/rhg"
 	fi
 
 	for f in ${RM_CONTRIB[@]}; do

--- a/eclass/cargo.eclass
+++ b/eclass/cargo.eclass
@@ -319,6 +319,16 @@ _cargo_gen_git_config() {
 	fi
 }
 
+# @FUNCTION: cargo_target_dir
+# @DESCRIPTION:
+# Return the directory within target that contains the build, e.g.
+# target/aarch64-unknown-linux-gnu/release.
+cargo_target_dir() {
+	local abi
+	tc-is-cross-compiler && abi=$(rust_abi)
+	echo "${CARGO_TARGET_DIR:-target}${abi+/}${abi}/$(usex debug debug release)"
+}
+
 # @FUNCTION: cargo_src_unpack
 # @DESCRIPTION:
 # Unpacks the package and the cargo registry.

--- a/gui-libs/greetd/greetd-0.10.0.ebuild
+++ b/gui-libs/greetd/greetd-0.10.0.ebuild
@@ -107,10 +107,7 @@ src_compile() {
 }
 
 src_install() {
-	# if USE=debug, install binaries from the debug directory; else
-	# install binaries from the release directory
-	# https://bugs.gentoo.org/889052
-	dobin target/$(usex debug debug release)/{agreety,fakegreet,greetd}
+	dobin "$(cargo_target_dir)"/{agreety,fakegreet,greetd}
 
 	insinto /etc/greetd
 	doins config.toml

--- a/gui-libs/greetd/greetd-0.9.0.ebuild
+++ b/gui-libs/greetd/greetd-0.9.0.ebuild
@@ -94,10 +94,7 @@ src_compile() {
 }
 
 src_install() {
-	# if USE=debug, install binaries from the debug directory; else
-	# install binaries from the release directory
-	# https://bugs.gentoo.org/889052
-	dobin target/$(usex debug debug release)/{agreety,fakegreet,greetd}
+	dobin "$(cargo_target_dir)"/{agreety,fakegreet,greetd}
 
 	insinto /etc/greetd
 	doins config.toml

--- a/net-misc/geckodriver/geckodriver-0.34.0.ebuild
+++ b/net-misc/geckodriver/geckodriver-0.34.0.ebuild
@@ -224,6 +224,6 @@ src_install() {
 
 	mkdir -p "${D}"/usr/$(get_libdir)/firefox || die "Failed to create /usr/lib*/firefox directory."
 	exeinto /usr/$(get_libdir)/firefox
-	doexe target/release/geckodriver
+	doexe "$(cargo_target_dir)"/geckodriver
 	dosym -r /usr/$(get_libdir)/firefox/geckodriver /usr/bin/geckodriver
 }

--- a/net-misc/hurl/hurl-4.1.0.ebuild
+++ b/net-misc/hurl/hurl-4.1.0.ebuild
@@ -195,8 +195,7 @@ QA_FLAGS_IGNORED=(
 QA_PRESTRIPPED="${QA_FLAGS_IGNORED[*]}"
 
 src_install() {
-	local target_dir="$(usex debug debug release)"
-	dobin target/"${target_dir}"/hurl{,fmt}
+	dobin "$(cargo_target_dir)"/hurl{,fmt}
 	doman docs/manual/hurl{,fmt}.1
 
 	dodoc CHANGELOG.md README.md LICENSE

--- a/sys-apps/bat/bat-0.23.0-r1.ebuild
+++ b/sys-apps/bat/bat-0.23.0-r1.ebuild
@@ -218,8 +218,8 @@ src_install() {
 
 	einstalldocs
 
-	local build_dir=( target/$(usex debug{,} release)/build/${PN}-*/out )
-	cd ${build_dir[0]} || die "Cannot change directory to ${PN} build"
+	local build_dir=( "$(cargo_target_dir)"/build/${PN}-*/out )
+	cd "${build_dir[0]}" || die "Cannot change directory to ${PN} build"
 
 	doman assets/manual/bat.1
 

--- a/sys-apps/bat/bat-0.24.0-r1.ebuild
+++ b/sys-apps/bat/bat-0.24.0-r1.ebuild
@@ -247,8 +247,8 @@ src_install() {
 
 	einstalldocs
 
-	local build_dir=( target/$(usex debug{,} release)/build/${PN}-*/out )
-	cd ${build_dir[0]} || die "Cannot change directory to ${PN} build"
+	local build_dir=( "$(cargo_target_dir)"/build/${PN}-*/out )
+	cd "${build_dir[0]}" || die "Cannot change directory to ${PN} build"
 
 	doman assets/manual/bat.1
 

--- a/sys-apps/ripgrep/ripgrep-14.1.0.ebuild
+++ b/sys-apps/ripgrep/ripgrep-14.1.0.ebuild
@@ -99,21 +99,21 @@ src_install() {
 	cargo_src_install
 
 	newbashcomp - rg <<-EOF
-	$(target/$(usex debug debug release)/rg --generate complete-bash)
+	"$(cargo_target_dir)"/rg --generate complete-bash)
 	EOF
 
 	insinto /usr/share/fish/vendor_completions.d
 	newins - rg.fish <<-EOF
-	$(target/$(usex debug debug release)/rg --generate complete-fish)
+	"$(cargo_target_dir)"/rg --generate complete-fish)
 	EOF
 
 	insinto /usr/share/zsh/site-functions
 	newins - _rg <<-EOF
-	$(target/$(usex debug debug release)/rg --generate complete-zsh)
+	"$(cargo_target_dir)"/rg --generate complete-zsh)
 	EOF
 
 	dodoc CHANGELOG.md FAQ.md GUIDE.md README.md
 	newman - rg.1 <<-EOF
-	$(target/$(usex debug debug release)/rg --generate man)
+	"$(cargo_target_dir)"/rg --generate man)
 	EOF
 }

--- a/sys-block/thin-provisioning-tools/thin-provisioning-tools-1.0.10.ebuild
+++ b/sys-block/thin-provisioning-tools/thin-provisioning-tools-1.0.10.ebuild
@@ -175,7 +175,7 @@ src_install() {
 	emake \
 		DESTDIR="${D}" \
 		DATADIR="${ED}/usr/share" \
-		PDATA_TOOLS="target/$(usex debug debug release)/pdata_tools" \
+		PDATA_TOOLS="$(cargo_target_dir)/pdata_tools" \
 		install
 
 	einstalldocs

--- a/sys-block/thin-provisioning-tools/thin-provisioning-tools-9999.ebuild
+++ b/sys-block/thin-provisioning-tools/thin-provisioning-tools-9999.ebuild
@@ -175,7 +175,7 @@ src_install() {
 	emake \
 		DESTDIR="${D}" \
 		DATADIR="${ED}/usr/share" \
-		PDATA_TOOLS="target/$(usex debug debug release)/pdata_tools" \
+		PDATA_TOOLS="$(cargo_target_dir)/pdata_tools" \
 		install
 
 	einstalldocs

--- a/sys-process/procs/procs-0.14.4.ebuild
+++ b/sys-process/procs/procs-0.14.4.ebuild
@@ -280,14 +280,14 @@ QA_FLAGS_IGNORED="usr/bin/procs"
 src_install() {
 	cargo_src_install
 
-	target/$(usex debug debug release)/procs --gen-completion bash || die
+	"$(cargo_target_dir)"/procs --gen-completion bash || die
 	newbashcomp procs.bash procs
 
-	target/$(usex debug debug release)/procs --gen-completion zsh || die
+	"$(cargo_target_dir)"/procs --gen-completion zsh || die
 	insinto /usr/share/zsh/site-functions
 	doins _procs
 
-	target/$(usex debug debug release)/procs --gen-completion fish || die
+	"$(cargo_target_dir)"/procs --gen-completion fish || die
 	insinto /usr/share/fish/vendor_completions.d
 	doins procs.fish
 }

--- a/sys-process/procs/procs-0.14.5.ebuild
+++ b/sys-process/procs/procs-0.14.5.ebuild
@@ -308,14 +308,14 @@ QA_FLAGS_IGNORED="usr/bin/procs"
 src_install() {
 	cargo_src_install
 
-	target/$(usex debug debug release)/procs --gen-completion bash || die
+	"$(cargo_target_dir)"/procs --gen-completion bash || die
 	newbashcomp procs.bash procs
 
-	target/$(usex debug debug release)/procs --gen-completion zsh || die
+	"$(cargo_target_dir)"/procs --gen-completion zsh || die
 	insinto /usr/share/zsh/site-functions
 	doins _procs
 
-	target/$(usex debug debug release)/procs --gen-completion fish || die
+	"$(cargo_target_dir)"/procs --gen-completion fish || die
 	insinto /usr/share/fish/vendor_completions.d
 	doins procs.fish
 }

--- a/x11-terms/wezterm/wezterm-20240203.110809-r1.ebuild
+++ b/x11-terms/wezterm/wezterm-20240203.110809-r1.ebuild
@@ -791,10 +791,10 @@ src_compile() {
 
 src_install() {
 	exeinto /usr/bin
-	doexe target/$(usex debug "debug" "release")/wezterm
-	doexe target/$(usex debug "debug" "release")/wezterm-gui
-	doexe target/$(usex debug "debug" "release")/wezterm-mux-server
-	doexe target/$(usex debug "debug" "release")/strip-ansi-escapes
+	doexe "$(cargo_target_dir)/wezterm"
+	doexe "$(cargo_target_dir)/wezterm-gui"
+	doexe "$(cargo_target_dir)/wezterm-mux-server"
+	doexe "$(cargo_target_dir)/strip-ansi-escapes"
 
 	insinto /usr/share/icons/hicolor/128x128/apps
 	newins assets/icon/terminal.png org.wezfurlong.wezterm.png


### PR DESCRIPTION
Several Cargo-based ebuilds cannot use `cargo_src_install` for various reasons and manually install binaries from within the target directory instead. It is common to see `target/$(usex debug debug release)`, but this lacks the target ABI when cross-compiling, so I have written an eclass helper function that I have submitted to gentoo-dev.

While that's under review, I have fixed up all the affected ebuilds to use this helper. I have done this across all versions, including stable versions, without revbumps because although the existing ebuilds are not broken for native builds right now, I would like to eventually set the target ABI all the time to better support multilib cases like net-libs/quiche. For the moment, the function basically returns what was explicitly written before, so no change in behaviour is expected, except that cross-compiling now works. I have build tested all the packages using their latest keyworded versions (except starlark-rust, which is already broken) and it all went fine.

Please let me know if you'd rather I was more conservative with your package.

P.S. I noticed some ebuilds did doc generation in a way that would break when cross-compiling. I haven't attempted to fix that, but please be aware of it.

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.