### PR TITLE
kde-frameworks/kauth: requires wayland backend unconditionally from k…

### DIFF
--- a/kde-frameworks/kauth/kauth-6.3.0-r1.ebuild
+++ b/kde-frameworks/kauth/kauth-6.3.0-r1.ebuild
@@ -17,7 +17,7 @@ DEPEND="
 	>=dev-qt/qtbase-${QTMIN}:6[dbus,gui]
 	=kde-frameworks/kcoreaddons-${PVCUT}*:6
 	policykit? (
-		=kde-frameworks/kwindowsystem-${PVCUT}*:6
+		=kde-frameworks/kwindowsystem-${PVCUT}*:6[wayland]
 		>=sys-auth/polkit-qt-0.113.0[qt6(-)]
 	)
 "


### PR DESCRIPTION
…windowsystem

https://invent.kde.org/frameworks/kauth/-/commit/382b6ae8c7cc19cb2c1b1f5e8f32f767f09222ce

Closes: https://bugs.gentoo.org/934246

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
