### PR TITLE
Revert "java-utils-2.eclass: eerror if java-utils-2 is inherited dire…

### DIFF
--- a/eclass/java-utils-2.eclass
+++ b/eclass/java-utils-2.eclass
@@ -34,12 +34,6 @@ export WANT_JAVA_CONFIG="2"
 
 has test ${JAVA_PKG_IUSE} && RESTRICT+=" !test? ( test )"
 
-# this eclass must be inherited after java-pkg-2 or java-pkg-opt-2
-# bug #207098
-if ! has java-pkg-2 ${INHERITED} && ! has java-pkg-opt-2 ${INHERITED}; then
-	eerror "java-utils-2 eclass must not be inherited directly."
-fi
-
 # @VARIABLE: JAVA_PKG_E_DEPEND
 # @INTERNAL
 # @DESCRIPTION:


### PR DESCRIPTION
…ctly"

This reverts commit 41faa907e3a36f4ed00aced3499d469abb865281.

Bug: https://bugs.gentoo.org/207098

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [ ] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [ ] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [ ] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
