### PR TITLE
media-libs/libmpd: Fix returning ‘void *’ from a int return type func

### DIFF
--- a/media-libs/libmpd/files/libmpd-11.8.17-return-0-instead-of-null.patch
+++ b/media-libs/libmpd/files/libmpd-11.8.17-return-0-instead-of-null.patch
@@ -1,0 +1,35 @@
+https://bugs.gentoo.org/932791
+From: Brahmajit Das <brahmajit.xyz@gmail.com>
+Date: Fri, 14 Jun 2024 17:48:26 +0000
+Subject: [PATCH 1/1] src/libmpd-playlist.c: Return 0 instead of NULL
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+First reported on Gentoo Linux with GCC 14. GCC 14 comes with
+-Wint-conversion enabled, thus resulting in build errors such as
+libmpd-playlist.c: In function ‘mpd_playlist_load’:
+libmpd-playlist.c:783:24: error: returning ‘void *’ from a function with return type ‘int’ makes integer from pointer without a cast [-Wint-conversion]
+  783 |                 return NULL;
+      |                        ^~~~
+make[2]: *** [Makefile:367: libmpd-playlist.lo] Error 1
+
+NULL is defined as ((void *)0) where as mpd_playlist_load has a return
+type of int, thus returning 0 would be more appropriate.
+
+Refer: https://bugs.gentoo.org/932791
+Signed-off-by: Brahmajit Das <brahmajit.xyz@gmail.com>
+--- a/src/libmpd-playlist.c
++++ b/src/libmpd-playlist.c
+@@ -780,7 +780,7 @@ int mpd_playlist_load(MpdObj *mi, const char *path)
+ 	if(mpd_lock_conn(mi))
+ 	{
+ 		debug_printf(DEBUG_ERROR,"lock failed\n");
+-		return NULL;
++		return 0;
+ 	}
+     mpd_sendLoadCommand(mi->connection,path);
+ 	mpd_finishCommand(mi->connection);
+-- 
+2.45.2
+

--- a/media-libs/libmpd/libmpd-11.8.17-r2.ebuild
+++ b/media-libs/libmpd/libmpd-11.8.17-r2.ebuild
@@ -1,0 +1,41 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DESCRIPTION="A library handling connections to a MPD server"
+HOMEPAGE="https://gmpclient.org/"
+SRC_URI="http://download.sarine.nl/Programs/gmpc/$(ver_cut 1-2)/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~ia64 ~loong ~ppc ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux"
+IUSE="doc static-libs"
+
+BDEPEND="
+	virtual/pkgconfig
+	doc? ( app-text/doxygen )
+"
+DEPEND=">=dev-libs/glib-2.16:2"
+RDEPEND="${DEPEND}"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-remove-strndup.patch
+	"${FILESDIR}"/${P}-return-0-instead-of-null.patch
+)
+
+src_configure() {
+	econf $(use_enable static-libs static)
+}
+
+src_compile() {
+	emake
+	use doc && emake -C doc doc
+}
+
+src_install() {
+	use doc && local HTML_DOCS=( doc/html/* )
+	default
+	find "${D}" -name '*.la' -type f -delete || die
+	rm "${ED}"/usr/share/doc/${PF}/{README,ChangeLog} || die
+}


### PR DESCRIPTION
And update EAPI 7 -> 8

Closes: https://bugs.gentoo.org/932791

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
