### PR TITLE
app-emacs/calfw: Added patch for calfw time-ranges representation

### DIFF
--- a/app-emacs/calfw/calfw-1.6-r1.ebuild
+++ b/app-emacs/calfw/calfw-1.6-r1.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 inherit elisp
 
@@ -20,6 +20,10 @@ BDEPEND="${RDEPEND}"
 S="${WORKDIR}/emacs-${PN}-${PV}"
 SITEFILE="50${PN}-gentoo.el"
 DOCS="readme.md"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-time-ranges.patch
+)
 
 src_prepare() {
 	elisp_src_prepare

--- a/app-emacs/calfw/files/calfw-time-ranges.patch
+++ b/app-emacs/calfw/files/calfw-time-ranges.patch
@@ -1,0 +1,40 @@
+From 7b5d5b66c772ec9ae12c8b67fbcc4a7d43f86209 Mon Sep 17 00:00:00 2001
+From: Maxime Wack <MaximeWack@users.noreply.github.com>
+Date: Wed, 3 Feb 2021 12:51:20 +0100
+Subject: [PATCH 1/1] Fix cfw:org-get-timerange to display the correct
+ timerange
+
+Re-use start-date, as permitted by let*
+
+Fix the double displaying of timeranges with times
+---
+ calfw-org.el | 13 ++++++-------
+ 1 file changed, 6 insertions(+), 7 deletions(-)
+
+diff --git a/calfw-org.el b/calfw-org.el
+index 4590f1c..f098a76 100644
+--- a/calfw-org.el
++++ b/calfw-org.el
+@@ -238,14 +238,13 @@ If TEXT does not have a range, return nil."
+ 				(match-string 1 extra)))
+ 		      (total-days (string-to-number
+ 				   (match-string 2 extra)))
+-		      (start-date (time-subtract
+-				   (org-read-date nil t date-string)
+-				   (seconds-to-time (* 3600 24 (- cur-day 1)))))
++		      (start-date (org-read-date nil t date-string))
+ 		      (end-date (time-add
+-				 (org-read-date nil t date-string)
+-				 (seconds-to-time (* 3600 24 (- total-days cur-day))))))
+-		 (list (calendar-gregorian-from-absolute (time-to-days start-date))
+-		       (calendar-gregorian-from-absolute (time-to-days end-date)) text))
++				 start-date
++				 (seconds-to-time (* 3600 24 (- total-days 1))))))
++		       (unless (= cur-day total-days)
++             (list (calendar-gregorian-from-absolute (time-to-days start-date))
++		                  (calendar-gregorian-from-absolute (time-to-days end-date)) text)))
+ 	     )))))
+
+ (defun cfw:org-schedule-period-to-calendar (begin end)
+--
+2.44.2


### PR DESCRIPTION
<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.

Sidenotes:
[calfw](https://github.com/kiwanami/emacs-calfw) Sadly, has not been updated for a long time ([Latest commit was 7 years ago](https://github.com/kiwanami/emacs-calfw/commit/03abce97620a4a7f7ec5f911e669da9031ab9088).)

I realized that calfw struggled to show org-mode events with time-ranges (Describe [here](https://orgmode.org/manual/Timestamps.html#index-time-range) in the org manual).
For example:
```
* TODO Timerange example
<2024-09-07 Wed>-<2024-09-11 Sun>
```

This event would be shown like this: 

![No-patch](https://github.com/gentoo/gentoo/assets/65001595/f6443c60-57c7-4417-9c4a-9cdc1d4782f5)

However, @MaximeWack made a pull request (here: https://github.com/kiwanami/emacs-calfw/pull/134) with the patch that I added to this PR.
With @MaximeWack 's patch, now that org mode event is shown correctly:

![with-patch](https://github.com/gentoo/gentoo/assets/65001595/5717da43-06b3-43f8-89dc-9c53c0443a53)

I am not entirely familiar with what's Gentoo's standard procedure for when it comes to upstream fixes.

However, there doesn't appear to be a newer, more up-to-date calfw fork. 
And, calfw is a very neat package, specially for those of us who like to use Emacs a calendar; this time-range feature is very important.

Moreover, the patch, all things considered, is pretty small. 

Would love to hear some other perspectives.