### PR TITLE
app-office/libreoffice: [zxcvbn-c] replace `std::basic_string<int>` with `std::vector<int>`

### DIFF
--- a/app-office/libreoffice/files/libreoffice-24.2.4.2-no-std-basic_string-int.patch
+++ b/app-office/libreoffice/files/libreoffice-24.2.4.2-no-std-basic_string-int.patch
@@ -1,0 +1,119 @@
+https://git.libreoffice.org/core/commit/d91ab7de467abea6c01c9dd8473f81ac1f29513c
+From d91ab7de467abea6c01c9dd8473f81ac1f29513c Mon Sep 17 00:00:00 2001
+From: Stephan Bergmann <stephan.bergmann@allotropia.de>
+Date: Tue, 6 Feb 2024 13:27:59 +0100
+Subject: [PATCH] external/zxcvbn-c: There is no std::basic_string<int>
+
+...and at least LLVM 19 trunk libc++ complains about it now since
+<c3668779c13596e223c26fbd49670d18cd638c40> "[libc++] Remove deprecated
+char_traits base template (#72694)" with
+
+> In file included from dict-generate.cpp:25:
+> In file included from ~/llvm/inst/bin/../include/c++/v1/iostream:43:
+> In file included from ~/llvm/inst/bin/../include/c++/v1/ios:223:
+> In file included from ~/llvm/inst/bin/../include/c++/v1/__locale:24:
+> ~/llvm/inst/bin/../include/c++/v1/string:746:43: error: implicit instantiation of undefined template 'std::char_traits<int>'
+>   746 |   static_assert((is_same<_CharT, typename traits_type::char_type>::value),
+>       |                                           ^
+> dict-generate.cpp:861:18: note: in instantiation of template class 'std::basic_string<int>' requested here
+>   861 |     StringOfInts Chld;
+>       |                  ^
+> ~/llvm/inst/bin/../include/c++/v1/__fwd/string.h:23:29: note: template is declared here
+>    23 | struct _LIBCPP_TEMPLATE_VIS char_traits;
+>       |                             ^
+
+etc., so use a std::vector<int> instead
+
+Change-Id: I51e8296edf7b16925ff01679e671525256055552
+Reviewed-on: https://gerrit.libreoffice.org/c/core/+/163048
+Tested-by: Jenkins
+Reviewed-by: Stephan Bergmann <stephan.bergmann@allotropia.de>
+--- /dev/null
++++ b/external/zxcvbn-c/0001-There-is-no-std-basic_string-int.patch.1
+@@ -0,0 +1,72 @@
++From 92c6ea875231876ca264187326ce2d615d5ad543 Mon Sep 17 00:00:00 2001
++From: Stephan Bergmann <stephan.bergmann@allotropia.de>
++Date: Tue, 6 Feb 2024 13:14:08 +0100
++Subject: There is no std::basic_string<int>
++
++...and at least LLVM 19 trunk libc++ complains about it now since
++<c3668779c13596e223c26fbd49670d18cd638c40> "[libc++] Remove deprecated
++char_traits base template (#72694)" with
++
++> In file included from dict-generate.cpp:25:
++> In file included from ~/llvm/inst/bin/../include/c++/v1/iostream:43:
++> In file included from ~/llvm/inst/bin/../include/c++/v1/ios:223:
++> In file included from ~/llvm/inst/bin/../include/c++/v1/__locale:24:
++> ~/llvm/inst/bin/../include/c++/v1/string:746:43: error: implicit instantiation of undefined template 'std::char_traits<int>'
++>   746 |   static_assert((is_same<_CharT, typename traits_type::char_type>::value),
++>       |                                           ^
++> dict-generate.cpp:861:18: note: in instantiation of template class 'std::basic_string<int>' requested here
++>   861 |     StringOfInts Chld;
++>       |                  ^
++> ~/llvm/inst/bin/../include/c++/v1/__fwd/string.h:23:29: note: template is declared here
++>    23 | struct _LIBCPP_TEMPLATE_VIS char_traits;
++>       |                             ^
++
++etc., so use a std::vector<int> instead
++---
++ dict-generate.cpp | 12 ++++++------
++ 1 file changed, 6 insertions(+), 6 deletions(-)
++
++diff --git a/dict-generate.cpp b/dict-generate.cpp
++index eebcca9..fcfaaea 100644
++--- a/dict-generate.cpp
+++++ b/dict-generate.cpp
++@@ -22,6 +22,7 @@
++  *
++  **********************************************************************************/
++ 
+++#include <algorithm>
++ #include <iostream>
++ #include <string>
++ #include <fstream>
++@@ -387,7 +388,7 @@ typedef map<string, Entry> EntryMap_t;
++ typedef list<string> StringList_t;
++ typedef list<NodeSPtr> NodeList_t;
++ typedef set<StringInt> StringIntSet_t;
++-typedef basic_string<int> StringOfInts;
+++typedef vector<int> StringOfInts;
++ typedef vector<unsigned int> UintVect;
++ typedef vector<uint64_t> Uint64Vect;
++ typedef vector<StringInt *> StrIntPtrVect_t;
++@@ -864,15 +865,14 @@ void CreateArrays(NodeSPtr Root, StringIntSet_t & StrSet, StringOfInts & ChildAd
++     for(Itc = Root->ChildBegin(); Itc != Root->ChildEnd(); ++Itc)
++     {
++         int i = Itc->second->GetAddr();
++-        Chld += i;
+++        Chld.push_back(i);
++     }
++     // Find where in pointer array the child pointer string is
++-    StringOfInts::size_type x = ChildAddrs.find(Chld);
++-    if (x == StringOfInts::npos)
+++    StringOfInts::size_type x = search(ChildAddrs.begin(), ChildAddrs.end(), Chld.begin(), Chld.end()) - ChildAddrs.begin();
+++    if (x == ChildAddrs.size())
++     {
++         // Not found, add it
++-        x = ChildAddrs.length();
++-        ChildAddrs += Chld;
+++        ChildAddrs.insert(ChildAddrs.end(), Chld.begin(), Chld.end());
++     }
++     // Val will contain the final node data
++     uint64_t Val = Its->i;
++-- 
++2.43.0
++
+--- a/external/zxcvbn-c/UnpackedTarball_zxcvbn-c.mk
++++ b/external/zxcvbn-c/UnpackedTarball_zxcvbn-c.mk
+@@ -11,8 +11,11 @@ $(eval $(call gb_UnpackedTarball_UnpackedTarball,zxcvbn-c))
+ 
+ $(eval $(call gb_UnpackedTarball_set_tarball,zxcvbn-c,$(ZXCVBN_C_TARBALL)))
+ 
++# * external/zxcvbn-c/0001-There-is-no-std-basic_string-int.patch.1 sent upstream as
++#   <https://github.com/tsyrogit/zxcvbn-c/pull/31> "There is no std::basic_string<int>":
+ $(eval $(call gb_UnpackedTarball_add_patches,zxcvbn-c,\
+ 	external/zxcvbn-c/zxcvbn-c-2.5-do-not-use-stdafx.patch \
++	external/zxcvbn-c/0001-There-is-no-std-basic_string-int.patch.1 \
+ ))
+ 
+ # vim: set noet sw=4 ts=4:

--- a/app-office/libreoffice/libreoffice-24.2.4.2-r10.ebuild
+++ b/app-office/libreoffice/libreoffice-24.2.4.2-r10.ebuild
@@ -323,6 +323,7 @@ PATCHES=(
 
 	# git master
 	"${FILESDIR}/${PN}-24.2.3.2-fix-bashism.patch" # bug #928733
+	"${FILESDIR}/${PN}-24.2.4.2-no-std-basic_string-int.patch" # bug #923950
 	# bug #917618, thx to Debian:
 	"${WORKDIR}/${PN}-24.2.3.2-icu-74/${PN}-24.2.3.2-icu-74.2-reviewed-breakIterator-customizations.patch"
 	"${WORKDIR}/${PN}-24.2.3.2-icu-74/${PN}-24.2.3.2-icu-74.2-breakiterator-updates.patch"


### PR DESCRIPTION
Merged upstream at [tsyrogit/zxcvbn-c#31](https://www.github.com/tsyrogit/zxcvbn-c/pull/31)
Backports the patch for compiling the latest libreoffice release with bundled zxcvbn-c and Clang 19

Closes: https://bugs.gentoo.org/923950
Upstream-PR: https://gerrit.libreoffice.org/c/core/+/163048
Upstream-Commit: https://git.libreoffice.org/core/commit/d91ab7de467abea6c01c9dd8473f81ac1f29513c

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
