### PR TITLE
x11-base/xwayland: 9999 drop secure-rpc

### DIFF
--- a/x11-base/xwayland/xwayland-9999.ebuild
+++ b/x11-base/xwayland/xwayland-9999.ebuild
@@ -87,7 +87,6 @@ src_configure() {
 		-Dglamor=true
 		-Dglx=true
 		-Dipv6=true
-		-Dsecure-rpc=false
 		-Dscreensaver=true
 		-Dsha1=libcrypto
 		-Dxace=true


### PR DESCRIPTION
option was removed

See-also: https://gitlab.freedesktop.org/xorg/xserver/-/commit/71b207a2ebc1465c7d9ad9262f60930f6a1d42ee

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
