### PR TITLE
app-admin/logrotate: cronhourly to install cron file into cron.hourly

### DIFF
--- a/app-admin/logrotate/logrotate-3.21.0-r1.ebuild
+++ b/app-admin/logrotate/logrotate-3.21.0-r1.ebuild
@@ -1,0 +1,105 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/openpgp-keys/kamildudka.asc
+inherit systemd tmpfiles verify-sig
+
+DESCRIPTION="Rotates, compresses, and mails system logs"
+HOMEPAGE="https://github.com/logrotate/logrotate"
+SRC_URI="https://github.com/${PN}/${PN}/releases/download/${PV}/${P}.tar.xz"
+SRC_URI+=" verify-sig? ( https://github.com/${PN}/${PN}/releases/download/${PV}/${P}.tar.xz.asc )"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+IUSE="acl +cron cronhourly selinux"
+
+DEPEND="
+	>=dev-libs/popt-1.5
+	selinux? ( sys-libs/libselinux )
+	acl? ( virtual/acl )
+"
+RDEPEND="
+	${DEPEND}
+	selinux? ( sec-policy/selinux-logrotate )
+	cron? ( virtual/cron )
+"
+BDEPEND="verify-sig? ( sec-keys/openpgp-keys-kamildudka )"
+
+REQUIRED_USE="cronhourly? ( cron )"
+
+STATEFILE="${EPREFIX}/var/lib/misc/logrotate.status"
+OLDSTATEFILE="${EPREFIX}/var/lib/logrotate.status"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-3.15.0-ignore-hidden.patch
+)
+
+move_old_state_file() {
+	elog "logrotate state file is now located at ${STATEFILE}"
+	elog "See bug #357275"
+	if [[ -e "${OLDSTATEFILE}" ]] ; then
+		elog "Moving your current state file to new location: ${STATEFILE}"
+		mv -n "${OLDSTATEFILE}" "${STATEFILE}" || die
+	fi
+}
+
+install_cron_file() {
+	if use cronhourly; then
+		exeinto /etc/cron.hourly
+	else
+		exeinto /etc/cron.daily
+	fi
+	newexe "${S}"/examples/logrotate.cron "${PN}"
+}
+
+src_prepare() {
+	default
+
+	sed -i -e 's#/usr/sbin/logrotate#/usr/bin/logrotate#' examples/logrotate.{cron,service} || die
+}
+
+src_configure() {
+	econf \
+		$(use_with acl) \
+		$(use_with selinux) \
+		--with-state-file-path="${STATEFILE}"
+}
+
+src_install() {
+	dobin logrotate
+	doman logrotate.8
+	dodoc ChangeLog.md
+
+	insinto /etc
+	doins "${FILESDIR}"/logrotate.conf
+
+	use cron && install_cron_file
+
+	systemd_dounit examples/logrotate.{service,timer}
+	newtmpfiles "${FILESDIR}"/${PN}.tmpfiles ${PN}.conf
+
+	keepdir /etc/logrotate.d
+}
+
+pkg_postinst() {
+	elog
+	elog "The ${PN} binary is now installed under /usr/bin. Please"
+	elog "update your links"
+	elog
+
+	move_old_state_file
+
+	tmpfiles_process ${PN}.conf
+
+	if [[ -z ${REPLACING_VERSIONS} ]] ; then
+		elog "If you wish to have logrotate e-mail you updates, please"
+		elog "emerge virtual/mailx and configure logrotate in"
+		elog "/etc/logrotate.conf appropriately"
+		elog
+		elog "Additionally, /etc/logrotate.conf may need to be modified"
+		elog "for your particular needs. See man logrotate for details."
+	fi
+}

--- a/app-admin/logrotate/metadata.xml
+++ b/app-admin/logrotate/metadata.xml
@@ -21,6 +21,7 @@
 	<use>
 		<flag name="acl">Installs acl support</flag>
 		<flag name="cron">Installs cron file</flag>
+		<flag name="cronhourly">Installs cron file for hourly run rather than daily</flag>
 		<flag name="selinux">Installs Security Enhanced Linux support</flag>
 	</use>
 	<upstream>


### PR DESCRIPTION
rather than cron.daily.

The alternative is to copy the existing cron.daily/logrotate file into cron.hourly, then remove the cron.daily/logrotate file and then rely on the fact that this file will never into the future get updated (Install logrotate with USE=-cron).

Additionally, using USE=-cron for logrotate will drop the virtual/cron dependency.

For these reasons I think it's safer to rather add an extra IUSE to install for hourly rather than daily use.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
