### PR TITLE
profiles: only mask clang-runtime[sanitize] on 32-bit musl profiles

### DIFF
--- a/profiles/default/linux/arm/23.0/musl/package.use.stable.mask
+++ b/profiles/default/linux/arm/23.0/musl/package.use.stable.mask
@@ -1,6 +1,11 @@
 # Copyright 2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License, v2
 
+# Sam James <sam@gentoo.org> (2024-06-16)
+# Avoid pulling in sys-libs/compiler-rt-sanitizers which fails to build
+# See bug #928936.
+sys-devel/clang-runtime sanitize
+
 # Andreas K. Hüttel <dilfridge@gentoo.org> (2024-03-20)
 # Does not compile with musl-1.2.4
 sys-devel/gcc sanitize

--- a/profiles/default/linux/ppc/23.0/musl/package.use.mask
+++ b/profiles/default/linux/ppc/23.0/musl/package.use.mask
@@ -1,5 +1,10 @@
-# Copyright 2023 Gentoo Authors
+# Copyright 2023-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
+
+# Sam James <sam@gentoo.org> (2024-06-16)
+# Avoid pulling in sys-libs/compiler-rt-sanitizers which fails to build
+# See bug #928936.
+sys-devel/clang-runtime sanitize
 
 # Sam James <sam@gentoo.org> (2023-01-29)
 # Fails to build on combination of ppc* + musl because of mcontext.

--- a/profiles/default/linux/x86/23.0/i486/musl/package.use.mask
+++ b/profiles/default/linux/x86/23.0/i486/musl/package.use.mask
@@ -1,6 +1,11 @@
 # Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License, v2
 
+# Sam James <sam@gentoo.org> (2024-06-16)
+# Avoid pulling in sys-libs/compiler-rt-sanitizers which fails to build
+# See bug #928936.
+sys-devel/clang-runtime sanitize
+
 # Ian Jordan <immoloism@gmail.com> (2024-05-20)
 # Does not compile with musl-1.2.4+
 sys-devel/gcc sanitize
@@ -10,4 +15,3 @@ sys-devel/gcc sanitize
 # file-5.39-seccomp_sandbox.patch is okay
 # file-5.39-portage_sandbox.patch is broken
 sys-apps/file seccomp
-

--- a/profiles/default/linux/x86/23.0/i686/musl/package.use.mask
+++ b/profiles/default/linux/x86/23.0/i686/musl/package.use.mask
@@ -1,6 +1,11 @@
 # Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License, v2
 
+# Sam James <sam@gentoo.org> (2024-06-16)
+# Avoid pulling in sys-libs/compiler-rt-sanitizers which fails to build
+# See bug #928936.
+sys-devel/clang-runtime sanitize
+
 # Ian Jordan <immoloism@gmail.com> (2024-05-20)
 # Does not compile with musl-1.2.4+
 sys-devel/gcc sanitize

--- a/profiles/features/musl/package.use.mask
+++ b/profiles/features/musl/package.use.mask
@@ -1,11 +1,6 @@
 # Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-# Sam james <sam@gentoo.org> (2024-06-16)
-# Avoid pulling in sys-libs/compiler-rt-sanitizers which fails to build
-# See bug #928936.
-sys-devel/clang-runtime sanitize
-
 # Sam James <sam@gentoo.org> (2024-06-03)
 # Poor rendering performance otherwise (bug #931215) but it doesn't
 # work on musl.


### PR DESCRIPTION
The issue in the bug is only an issue on 32-bit musl platforms, not on 64-bit. The original mask was overzealous, narrow the mask to arm, ppc, and x86.

Bug: https://bugs.gentoo.org/928936

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
