### PR TITLE
🐛 dev-qt/qtmultimedia-6.7.2: fix build with [gstreamer,-v4l]

### DIFF
--- a/dev-qt/qtmultimedia/files/qtmultimedia-6.7.2-gstreamer-no-v4l.patch
+++ b/dev-qt/qtmultimedia/files/qtmultimedia-6.7.2-gstreamer-no-v4l.patch
@@ -1,0 +1,20 @@
+# https://bugs.gentoo.org/934582
+
+--- a/src/plugins/multimedia/gstreamer/mediacapture/qgstreamercamera.cpp
++++ b/src/plugins/multimedia/gstreamer/mediacapture/qgstreamercamera.cpp
+@@ -718,6 +718,7 @@ int QGstreamerCamera::getV4L2Parameter(quint32 id) const
+         return control.value;
+     });
+ }
++#endif // QT_CONFIG(linux_v4l)
+ 
+ QGstreamerCustomCamera::QGstreamerCustomCamera(QCamera *camera)
+     : QGstreamerCameraBase{
+@@ -766,6 +767,4 @@ void QGstreamerCustomCamera::setActive(bool active)
+     emit activeChanged(active);
+ }
+ 
+-#endif
+-
+ QT_END_NAMESPACE
+

--- a/dev-qt/qtmultimedia/qtmultimedia-6.7.2.ebuild
+++ b/dev-qt/qtmultimedia/qtmultimedia-6.7.2.ebuild
@@ -53,6 +53,10 @@ DEPEND="
 "
 BDEPEND="~dev-qt/qtshadertools-${PV}:6"
 
+PATCHES=(
+	"${FILESDIR}"/${P}-gstreamer-no-v4l.patch
+)
+
 CMAKE_SKIP_TESTS=(
 	# unimportant and expects all backends to be available (bug #928420)
 	tst_backends

--- a/profiles/base/package.use.force
+++ b/profiles/base/package.use.force
@@ -1,11 +1,6 @@
 # Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-# Ionen Wolkens <ionen@gentoo.org> (2024-06-18)
-# Disabling currently breaks build with USE=gstreamer, so forcing as
-# a quick workaround until this is more closely looked at (bug #934582)
->=dev-qt/qtmultimedia-6.7.2 v4l
-
 # Sam James <sam@gentoo.org> (2024-06-03)
 # Poor rendering performance otherwise (bug #931215).
 kde-plasma/kwin caps


### PR DESCRIPTION
_Hello everyone,_

These changes closes [934582](https://bugs.gentoo.org/934582).

_Best regards!_

---

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
