### PR TITLE
net-p2p/biglybt: improve metatada, add optfeatures

### DIFF
--- a/net-p2p/biglybt/biglybt-3.6.0.0.ebuild
+++ b/net-p2p/biglybt/biglybt-3.6.0.0.ebuild
@@ -7,7 +7,7 @@ EAPI=8
 JAVA_PKG_IUSE="doc source"
 MAVEN_PROVIDES="com.${PN}:${PN}-core:${PV} com.${PN}:${PN}-ui:${PV}"
 
-inherit desktop java-pkg-2 java-pkg-simple xdg
+inherit desktop java-pkg-2 java-pkg-simple optfeature xdg
 
 DESCRIPTION="Feature-filled Bittorrent client based on the Azureus open source project"
 HOMEPAGE="https://www.biglybt.com"
@@ -99,4 +99,12 @@ src_install() {
 		java-pkg_dosrc "uis/src/*"
 	fi
 	default
+}
+
+pkg_postinst() {
+	xdg_pkg_postinst
+
+	optfeature_header "If you are using plugin proxies you might want to swap them for these native packages:"
+	optfeature "I2P SOCKS proxy" net-vpn/i2p net-vpn/i2pd
+	optfeature "TOR SOCKS proxy" net-vpn/tor
 }

--- a/net-p2p/biglybt/metadata.xml
+++ b/net-p2p/biglybt/metadata.xml
@@ -4,9 +4,18 @@
 	<maintainer type="project">
 		<email>java@gentoo.org</email>
 	</maintainer>
+	<longdescription>
+		BiglyBT is a BitTorrent client based on Vuze (previously Azureus) which first released in 2003.
+
+		It's killer feature is integration with I2P and TOR anonymyzing networks.
+		They are available as plugins or can be used with your local node using SOCKS.
+		BiglyBT is the only client in acrive development that can work on clearnet and I2P simultaneously,
+		cross-seeding the torrents and swarm-merging them.
+	</longdescription>
 	<upstream>
 		<bugs-to>https://github.com/BiglySoftware/BiglyBT/issues</bugs-to>
 		<doc>https://github.com/BiglySoftware/BiglyBT/wiki</doc>
 		<remote-id type="github">BiglySoftware/BiglyBT</remote-id>
 	</upstream>
+	<stabilize-allarches/>
 </pkgmetadata>


### PR DESCRIPTION
1. Added `stabilize-allarches` and `longdescription` to metadata
2. Added optfeatures to ebuild

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
