### PR TITLE
vdr-plugin-2.eclass: fix behaviour with LINGUAS="en"

### DIFF
--- a/eclass/vdr-plugin-2.eclass
+++ b/eclass/vdr-plugin-2.eclass
@@ -286,7 +286,7 @@ vdr_linguas_support() {
 			|| die "sed failed for Linguas"
 	done
 
-	strip-linguas ${PLUGIN_LINGUAS} en
+	strip-linguas ${PLUGIN_LINGUAS}
 }
 
 # @FUNCTION: vdr_i18n


### PR DESCRIPTION
when LINGUAS="en" is defined, vdr-plugin-2_src_install() stops erroneously

Closes: https://bugs.gentoo.org/796731

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
