### PR TITLE
app-crypt/sbctl: Back-port bashism in kernel install hook

### DIFF
--- a/app-crypt/sbctl/files/sbctl-0.14-installkernel-bashism.patch
+++ b/app-crypt/sbctl/files/sbctl-0.14-installkernel-bashism.patch
@@ -1,0 +1,37 @@
+From 1167500b9da76febe85342e09b1bf9eeaf367ca6 Mon Sep 17 00:00:00 2001
+From: MithicSpirit <rpc01234@gmail.com>
+Date: Fri, 10 May 2024 17:51:59 -0400
+Subject: [PATCH] nit(91-sbctl.install): consistent syntax for tests
+
+Unifies usage of testing commands like `[]`, `test`, and `[[]]` to just
+use `[]` everywhere. This also improves compatibility, as `[[]]` is not
+available in POSIX sh.
+
+Bug: https://bugs.gentoo.org/934768
+Signed-off-by: Steffen Winter <steffen.winter@proton.me>
+--- a/contrib/kernel-install/91-sbctl.install
++++ b/contrib/kernel-install/91-sbctl.install
+@@ -31,7 +31,7 @@ add)
+ 
+ 	# exit without error if keys don't exist
+ 	# https://github.com/Foxboron/sbctl/issues/187
+-	if ! test -d /usr/share/secureboot/keys; then
++	if ! [ -d /usr/share/secureboot/keys ]; then
+ 		echo "Secureboot key directory doesn't exist, not signing!"
+ 		exit 0
+ 	fi
+@@ -39,10 +39,10 @@ add)
+ 	sbctl sign -s "$IMAGE_FILE" 1>/dev/null
+ 	;;
+ remove)
+-	if [[ -e "$IMAGE_FILE" ]]; then
+-	    [ "$KERNEL_INSTALL_VERBOSE" -gt 0 ] &&
+-		printf 'sbctl: Removing kernel %s from signing database\n' "$IMAGE_FILE"
+-	    sbctl remove-file "$IMAGE_FILE" 1>/dev/null
++	if [ -e "$IMAGE_FILE" ]; then
++		[ "$KERNEL_INSTALL_VERBOSE" -gt 0 ] &&
++			printf 'sbctl: Removing kernel %s from signing database\n' "$IMAGE_FILE"
++		sbctl remove-file "$IMAGE_FILE" 1>/dev/null
+ 	fi
+ 	;;
+ esac

--- a/app-crypt/sbctl/sbctl-0.14-r1.ebuild
+++ b/app-crypt/sbctl/sbctl-0.14-r1.ebuild
@@ -20,6 +20,10 @@ BDEPEND="app-text/asciidoc
 
 VERIFY_SIG_OPENPGP_KEY_PATH="/usr/share/openpgp-keys/foxboron.asc"
 
+PATCHES=(
+	"${FILESDIR}/sbctl-0.14-installkernel-bashism.patch"
+)
+
 src_unpack() {
 	if use verify-sig; then
 		verify-sig_verify_detached "${DISTDIR}"/${P}.tar.gz{,.sig}


### PR DESCRIPTION
<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
