### PR TITLE
Fixing automagic dependencies on gtk[wayland,X], hopefully for good

### DIFF
--- a/dev-libs/libportal/libportal-0.7.1-r1.ebuild
+++ b/dev-libs/libportal/libportal-0.7.1-r1.ebuild
@@ -1,0 +1,113 @@
+# Copyright 2022-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+PYTHON_COMPAT=( python3_{10..12} )
+inherit flag-o-matic meson python-any-r1 vala virtualx
+
+DESCRIPTION="Flatpak portal library"
+HOMEPAGE="https://github.com/flatpak/libportal"
+SRC_URI="https://github.com/flatpak/libportal/releases/download/${PV}/${P}.tar.xz"
+
+LICENSE="LGPL-3"
+SLOT="0/1-1-1-1" # soname of libportal{,-gtk3,-gtk4,-qt5}.so
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~ia64 ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86"
+IUSE="gtk gtk-doc +introspection qt5 test +vala wayland X"
+RESTRICT="!test? ( test )"
+REQUIRED_USE="
+	gtk-doc? ( introspection )
+	vala? ( introspection )
+"
+
+RDEPEND="
+	>=dev-libs/glib-2.58:2
+	introspection? ( dev-libs/gobject-introspection:= )
+	gtk? (
+		x11-libs/gtk+:3[X?,wayland?]
+		gui-libs/gtk:4[X?,wayland?]
+	)
+	qt5? (
+		dev-qt/qtcore:=
+		dev-qt/qtgui:=
+		dev-qt/qtx11extras:=
+		dev-qt/qtwidgets:=
+	)
+"
+DEPEND="${RDEPEND}
+	qt5? (
+		test? ( dev-qt/qttest:= )
+	)
+"
+BDEPEND="
+	dev-util/glib-utils
+	virtual/pkgconfig
+	gtk-doc? ( dev-util/gi-docgen )
+	qt5? (
+		test? ( dev-qt/linguist-tools )
+	)
+	test? (
+		${PYTHON_DEPS}
+		$(python_gen_any_dep '
+			dev-python/pytest[${PYTHON_USEDEP}]
+			dev-python/dbus-python[${PYTHON_USEDEP}]
+			dev-python/python-dbusmock[${PYTHON_USEDEP}]
+		')
+	)
+	vala? ( $(vala_depend) )
+"
+
+python_check_deps() {
+	python_has_version \
+		"dev-python/pytest[${PYTHON_USEDEP}]" \
+		"dev-python/dbus-python[${PYTHON_USEDEP}]" \
+		"dev-python/python-dbusmock[${PYTHON_USEDEP}]"
+}
+
+pkg_setup() {
+	if use test; then
+		python-any-r1_pkg_setup
+	fi
+}
+
+src_prepare() {
+	default
+	vala_setup
+}
+
+src_configure() {
+	# defang automagic dependencies
+	use wayland || append-cflags -DGENTOO_GTK_HIDE_WAYLAND
+	use X || append-cflags -DGENTOO_GTK_HIDE_X11
+
+	local emesonargs=(
+		$(meson_feature gtk backend-gtk3)
+		$(meson_feature gtk backend-gtk4)
+		$(meson_feature qt5 backend-qt5)
+		-Dportal-tests=false
+		$(meson_use introspection)
+		$(meson_use vala vapi)
+		$(meson_use gtk-doc docs)
+		$(meson_use test tests)
+	)
+	meson_src_configure
+}
+
+src_test() {
+	# Tests only exist for Qt5
+	if use qt5; then
+		virtx meson_src_test
+	else
+		# run meson_src_test to notice if tests are added
+		meson_src_test
+	fi
+}
+
+src_install() {
+	meson_src_install
+
+	if use gtk-doc; then
+		mkdir -p "${ED}"/usr/share/gtk-doc/html/ || die
+		mv "${ED}"/usr/share/doc/${PN}-1 "${ED}"/usr/share/gtk-doc/html/ || die
+	fi
+}

--- a/gui-libs/gtk/files/0001-gdk-add-a-poison-macro-to-hide-GDK_WINDOWING_.patch
+++ b/gui-libs/gtk/files/0001-gdk-add-a-poison-macro-to-hide-GDK_WINDOWING_.patch
@@ -1,0 +1,90 @@
+From 0537043f72ea1a634b101efa9e11cc0a22baaf71 Mon Sep 17 00:00:00 2001
+From: Eli Schwartz <eschwartz93@gmail.com>
+Date: Wed, 19 Jun 2024 21:28:31 -0400
+Subject: [PATCH] gdk: add a "poison" macro to hide GDK_WINDOWING_*
+
+Many packages perform automagic dependencies on gdk's backend
+implementations by checking if the macro is defined and then using the
+code it unlocks, rather than having a buildsystem option such as
+-Dwayland=true.
+
+It's unfeasible to patch every such package's source code to add
+configure options and respect them. Instead add a truly filthy hack and
+permit gtk itself to selectively show or hide the windowing system in
+use.
+
+By default, we assume this macro is never defined. It should only ever
+be defined inside an ebuild, as such:
+
+```
+use wayland || append-cflags -DGENTOO_GTK_HIDE_WAYLAND
+use X || append-cflags -DGENTOO_GTK_HIDE_X11
+```
+
+When seen, this will prevent code using "#ifdef GDK_WINDOWING_*" from
+seeing the define, so the automagic dependency won't be picked up. It
+will also cause any attempt to #include the backend-specific headers to
+bug out.
+
+Signed-off-by: Eli Schwartz <eschwartz93@gmail.com>
+---
+ gdk/gdkconfig.h.meson    | 7 +++++++
+ gdk/wayland/gdkwayland.h | 4 ++++
+ gdk/x11/gdkx.h           | 4 ++++
+ 3 files changed, 15 insertions(+)
+
+diff --git a/gdk/gdkconfig.h.meson b/gdk/gdkconfig.h.meson
+index d5b48f3184..22baab52ae 100644
+--- a/gdk/gdkconfig.h.meson
++++ b/gdk/gdkconfig.h.meson
+@@ -10,10 +10,17 @@
+ G_BEGIN_DECLS
+ 
+ 
++#ifndef GENTOO_GTK_HIDE_X11
+ #mesondefine GDK_WINDOWING_X11
++#endif
++
+ #mesondefine GDK_WINDOWING_BROADWAY
+ #mesondefine GDK_WINDOWING_MACOS
++
++#ifndef GENTOO_GTK_HIDE_WAYLAND
+ #mesondefine GDK_WINDOWING_WAYLAND
++#endif
++
+ #mesondefine GDK_WINDOWING_WIN32
+ 
+ #mesondefine GDK_RENDERING_CAIRO
+diff --git a/gdk/wayland/gdkwayland.h b/gdk/wayland/gdkwayland.h
+index 846445910e..5d84619295 100644
+--- a/gdk/wayland/gdkwayland.h
++++ b/gdk/wayland/gdkwayland.h
+@@ -24,6 +24,10 @@
+ 
+ #pragma once
+ 
++#ifdef GENTOO_GTK_HIDE_WAYLAND
++  #error "A Gentoo ebuild has hidden wayland and it cannot be used in this compilation unit. Please file a bug if you see this error."
++#endif
++
+ #include <gdk/gdk.h>
+ 
+ #define __GDKWAYLAND_H_INSIDE__
+diff --git a/gdk/x11/gdkx.h b/gdk/x11/gdkx.h
+index 6bef6b6de8..d4f8b94550 100644
+--- a/gdk/x11/gdkx.h
++++ b/gdk/x11/gdkx.h
+@@ -24,6 +24,10 @@
+ 
+ #pragma once
+ 
++#ifdef GENTOO_GTK_HIDE_X11
++  #error "A Gentoo ebuild has hidden x11 and it cannot be used in this compilation unit. Please file a bug if you see this error."
++#endif
++
+ #include <gdk/gdk.h>
+ 
+ #include <X11/Xlib.h>
+-- 
+2.44.2
+

--- a/gui-libs/gtk/gtk-4.14.3-r1.ebuild
+++ b/gui-libs/gtk/gtk-4.14.3-r1.ebuild
@@ -108,6 +108,13 @@ BDEPEND="
 	)
 "
 
+PATCHES=(
+	# Gentoo-specific patch to add a "poison" macro support, allowing other ebuilds
+	# with USE="-wayland -X" to trick gtk into claiming that it wasn't built with
+	# such support.
+	"${FILESDIR}"/0001-gdk-add-a-poison-macro-to-hide-GDK_WINDOWING_.patch
+)
+
 python_check_deps() {
 	python_has_version "dev-python/pygobject:3[${PYTHON_USEDEP}]" || return
 }

--- a/net-libs/gtk-vnc/gtk-vnc-1.3.1-r1.ebuild
+++ b/net-libs/gtk-vnc/gtk-vnc-1.3.1-r1.ebuild
@@ -1,0 +1,63 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+PYTHON_COMPAT=( python3_{10..12} )
+
+inherit flag-o-matic gnome.org vala meson python-any-r1 xdg
+
+DESCRIPTION="VNC viewer widget for GTK"
+HOMEPAGE="https://wiki.gnome.org/Projects/gtk-vnc https://gitlab.gnome.org/GNOME/gtk-vnc"
+
+LICENSE="LGPL-2.1+"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~ia64 ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86"
+IUSE="+introspection pulseaudio sasl +vala wayland X"
+REQUIRED_USE="vala? ( introspection )"
+
+RDEPEND="
+	>=dev-libs/glib-2.56.0:2
+	>=x11-libs/gdk-pixbuf-2.36.0:2
+	>=dev-libs/libgcrypt-1.8.0:0=
+	>=net-libs/gnutls-3.6.0:0=
+	>=sys-libs/zlib-1.2.11
+	sasl? ( >=dev-libs/cyrus-sasl-2.1.27:2 )
+	>=x11-libs/gtk+-3.22.0:3[introspection?,wayland?,X?]
+	>=x11-libs/cairo-1.15.0
+	>=x11-libs/libX11-1.6.5
+	pulseaudio? ( media-libs/libpulse )
+	introspection? ( >=dev-libs/gobject-introspection-1.56.0:= )
+"
+# Keymap databases code is generated with python3; configure picks up $PYTHON exported from python-any-r1_pkg_setup
+# perl for pod2man
+DEPEND="${RDEPEND}"
+BDEPEND="
+	${PYTHON_DEPS}
+	>=dev-lang/perl-5
+	dev-util/glib-utils
+	>=sys-devel/gettext-0.19.8
+	virtual/pkgconfig
+	vala? ( $(vala_depend) )
+"
+
+src_prepare() {
+	default
+
+	use vala & vala_setup
+}
+
+src_configure() {
+	# defang automagic dependencies, bug #927952
+	use wayland || append-cflags -DGENTOO_GTK_HIDE_WAYLAND
+	use X || append-cflags -DGENTOO_GTK_HIDE_X11
+
+	local emesonargs=(
+		$(meson_feature introspection)
+		$(meson_feature pulseaudio)
+		$(meson_feature sasl)
+		-Dwith-coroutine=auto # gthread on windows, libc ucontext elsewhere; neither has extra deps
+		$(meson_feature vala with-vala)
+	)
+	meson_src_configure
+}

--- a/profiles/features/big-endian/package.use.mask
+++ b/profiles/features/big-endian/package.use.mask
@@ -45,6 +45,7 @@ gui-libs/gtk wayland
 gnome-base/gnome-control-center wayland
 sys-apps/xdg-desktop-portal-gnome wayland
 net-libs/webkit-gtk:6 wayland
+dev-libs/libportal wayland
 
 # matoro <matoro_gentoo@matoro.tk> (2023-04-10)
 # media-libs/libldac casualties (#80238)

--- a/x11-libs/gtk+/files/0001-gdk-add-a-poison-macro-to-hide-GDK_WINDOWING_.patch
+++ b/x11-libs/gtk+/files/0001-gdk-add-a-poison-macro-to-hide-GDK_WINDOWING_.patch
@@ -1,0 +1,89 @@
+From 25bdad805bb9e16032baf4480e9c1e432ddef49b Mon Sep 17 00:00:00 2001
+From: Eli Schwartz <eschwartz93@gmail.com>
+Date: Wed, 19 Jun 2024 21:28:31 -0400
+Subject: [PATCH] gdk: add a "poison" macro to hide GDK_WINDOWING_*
+
+Many packages perform automagic dependencies on gdk's backend
+implementations by checking if the macro is defined and then using the
+code it unlocks, rather than having a buildsystem option such as
+-Dwayland=true.
+
+It's unfeasible to patch every such package's source code to add
+configure options and respect them. Instead add a truly filthy hack and
+permit gtk itself to selectively show or hide the windowing system in
+use.
+
+By default, we assume this macro is never defined. It should only ever
+be defined inside an ebuild, as such:
+
+```
+use wayland || append-cflags -DGENTOO_GTK_HIDE_WAYLAND
+use X || append-cflags -DGENTOO_GTK_HIDE_X11
+```
+
+When seen, this will prevent code using "#ifdef GDK_WINDOWING_*" from
+seeing the define, so the automagic dependency won't be picked up. It
+will also cause any attempt to #include the backend-specific headers to
+bug out.
+
+Signed-off-by: Eli Schwartz <eschwartz93@gmail.com>
+---
+ gdk/gdkconfig.h.meson    | 7 +++++++
+ gdk/wayland/gdkwayland.h | 4 ++++
+ gdk/x11/gdkx.h           | 4 ++++
+ 3 files changed, 15 insertions(+)
+
+diff --git a/gdk/gdkconfig.h.meson b/gdk/gdkconfig.h.meson
+index 7db19e0470..6bee207e94 100644
+--- a/gdk/gdkconfig.h.meson
++++ b/gdk/gdkconfig.h.meson
+@@ -10,9 +10,16 @@
+ G_BEGIN_DECLS
+ 
+ 
++#ifndef GENTOO_GTK_HIDE_X11
+ #mesondefine GDK_WINDOWING_X11
++#endif
++
+ #mesondefine GDK_WINDOWING_BROADWAY
++
++#ifndef GENTOO_GTK_HIDE_WAYLAND
+ #mesondefine GDK_WINDOWING_WAYLAND
++#endif
++
+ #mesondefine GDK_WINDOWING_WIN32
+ #mesondefine GDK_WINDOWING_QUARTZ
+ 
+diff --git a/gdk/wayland/gdkwayland.h b/gdk/wayland/gdkwayland.h
+index 2b79295add..5f0e9cfa81 100644
+--- a/gdk/wayland/gdkwayland.h
++++ b/gdk/wayland/gdkwayland.h
+@@ -25,6 +25,10 @@
+ #ifndef __GDK_WAYLAND_H__
+ #define __GDK_WAYLAND_H__
+ 
++#ifdef GENTOO_GTK_HIDE_WAYLAND
++  #error "A Gentoo ebuild has hidden wayland and it cannot be used in this compilation unit. Please file a bug if you see this error."
++#endif
++
+ #include <gdk/gdk.h>
+ 
+ #define __GDKWAYLAND_H_INSIDE__
+diff --git a/gdk/x11/gdkx.h b/gdk/x11/gdkx.h
+index 1f64bccb6d..256c83015e 100644
+--- a/gdk/x11/gdkx.h
++++ b/gdk/x11/gdkx.h
+@@ -25,6 +25,10 @@
+ #ifndef __GDK_X_H__
+ #define __GDK_X_H__
+ 
++#ifdef GENTOO_GTK_HIDE_X11
++  #error "A Gentoo ebuild has hidden x11 and it cannot be used in this compilation unit. Please file a bug if you see this error."
++#endif
++
+ #include <gdk/gdk.h>
+ 
+ #include <X11/Xlib.h>
+-- 
+2.44.2
+

--- a/x11-libs/gtk+/gtk+-3.24.41-r1.ebuild
+++ b/x11-libs/gtk+/gtk+-3.24.41-r1.ebuild
@@ -1,0 +1,204 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit gnome2 meson-multilib multilib toolchain-funcs virtualx
+
+DESCRIPTION="Gimp ToolKit +"
+HOMEPAGE="https://www.gtk.org/"
+
+LICENSE="LGPL-2+"
+SLOT="3"
+IUSE="aqua broadway cloudproviders colord cups examples gtk-doc +introspection sysprof test vim-syntax wayland +X xinerama"
+REQUIRED_USE="
+	|| ( aqua wayland X )
+	test? ( X )
+	xinerama? ( X )
+"
+RESTRICT="!test? ( test )"
+
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-solaris"
+
+COMMON_DEPEND="
+	>=app-accessibility/at-spi2-core-2.46.0[introspection?,${MULTILIB_USEDEP}]
+	>=dev-libs/fribidi-0.19.7[${MULTILIB_USEDEP}]
+	>=dev-libs/glib-2.57.2:2[${MULTILIB_USEDEP}]
+	media-libs/fontconfig[${MULTILIB_USEDEP}]
+	>=media-libs/harfbuzz-2.2.0:=
+	>=media-libs/libepoxy-1.4[X(+)?,egl(+),${MULTILIB_USEDEP}]
+	virtual/libintl[${MULTILIB_USEDEP}]
+	>=x11-libs/cairo-1.14[aqua?,glib,svg(+),X?,${MULTILIB_USEDEP}]
+	>=x11-libs/gdk-pixbuf-2.30:2[introspection?,${MULTILIB_USEDEP}]
+	>=x11-libs/pango-1.44.0[introspection?,${MULTILIB_USEDEP}]
+	x11-misc/shared-mime-info
+
+	cloudproviders? ( net-libs/libcloudproviders[${MULTILIB_USEDEP}] )
+	colord? ( >=x11-misc/colord-0.1.9:0=[${MULTILIB_USEDEP}] )
+	cups? ( >=net-print/cups-2.0[${MULTILIB_USEDEP}] )
+	introspection? ( >=dev-libs/gobject-introspection-1.39:= )
+	sysprof? ( >=dev-util/sysprof-capture-3.33.2:3[${MULTILIB_USEDEP}] )
+	wayland? (
+		>=dev-libs/wayland-1.14.91[${MULTILIB_USEDEP}]
+		>=dev-libs/wayland-protocols-1.32
+		media-libs/mesa[wayland,${MULTILIB_USEDEP}]
+		>=x11-libs/libxkbcommon-0.2[${MULTILIB_USEDEP}]
+	)
+	X? (
+		media-libs/libglvnd[X(+),${MULTILIB_USEDEP}]
+		x11-libs/libX11[${MULTILIB_USEDEP}]
+		x11-libs/libXcomposite[${MULTILIB_USEDEP}]
+		x11-libs/libXcursor[${MULTILIB_USEDEP}]
+		x11-libs/libXdamage[${MULTILIB_USEDEP}]
+		x11-libs/libXext[${MULTILIB_USEDEP}]
+		x11-libs/libXfixes[${MULTILIB_USEDEP}]
+		>=x11-libs/libXi-1.8[${MULTILIB_USEDEP}]
+		>=x11-libs/libXrandr-1.5[${MULTILIB_USEDEP}]
+		xinerama? ( x11-libs/libXinerama[${MULTILIB_USEDEP}] )
+	)
+"
+DEPEND="${COMMON_DEPEND}
+	X? ( x11-base/xorg-proto )
+"
+RDEPEND="${COMMON_DEPEND}
+	>=dev-util/gtk-update-icon-cache-3
+"
+# librsvg for svg icons (PDEPEND to avoid circular dep), bug #547710
+PDEPEND="
+	gnome-base/librsvg[${MULTILIB_USEDEP}]
+	>=x11-themes/adwaita-icon-theme-3.14
+	vim-syntax? ( app-vim/gtk-syntax )
+"
+BDEPEND="
+	app-text/docbook-xml-dtd:4.1.2
+	app-text/docbook-xsl-stylesheets
+	dev-libs/gobject-introspection-common
+	dev-libs/libxslt
+	>=dev-util/gdbus-codegen-2.48
+	dev-util/glib-utils
+	>=dev-build/gtk-doc-am-1.20
+	wayland? ( dev-util/wayland-scanner )
+	>=sys-devel/gettext-0.19.7
+	virtual/pkgconfig
+	x11-libs/gdk-pixbuf:2
+	gtk-doc? (
+		app-text/docbook-xml-dtd:4.3
+		>=dev-util/gtk-doc-1.20
+	)
+	test? ( sys-apps/dbus )
+"
+
+MULTILIB_CHOST_TOOLS=(
+	/usr/bin/gtk-query-immodules-3.0$(get_exeext)
+)
+
+PATCHES=(
+	# gtk-update-icon-cache is installed by dev-util/gtk-update-icon-cache
+	"${FILESDIR}"/${PN}-3.24.36-update-icon-cache.patch
+	# Gentoo-specific patch to add a "poison" macro support, allowing other ebuilds
+	# with USE="-wayland -X" to trick gtk into claiming that it wasn't built with
+	# such support.
+	"${FILESDIR}"/0001-gdk-add-a-poison-macro-to-hide-GDK_WINDOWING_.patch
+)
+
+src_prepare() {
+	default
+
+	# The border-image-excess-size.ui test is known to fail on big-endian platforms
+	# See https://gitlab.gnome.org/GNOME/gtk/-/issues/5904
+	if [[ $(tc-endian) == big ]]; then
+		sed -i \
+			-e "/border-image-excess-size.ui/d" \
+			-e "/^xfails =/a 'border-image-excess-size.ui'," \
+			testsuite/reftests/meson.build || die
+	fi
+}
+
+multilib_src_configure() {
+	local emesonargs=(
+		$(meson_use aqua quartz_backend)
+		$(meson_use broadway broadway_backend)
+		$(meson_use cloudproviders)
+		$(meson_use examples demos)
+		$(meson_use examples)
+		$(meson_native_use_bool gtk-doc gtk_doc)
+		$(meson_native_use_bool introspection)
+		$(meson_use sysprof profiler)
+		$(meson_use wayland wayland_backend)
+		$(meson_use X x11_backend)
+		-Dcolord=$(usex colord yes no)
+		-Dprint_backends=$(usex cups cups,file,lpr file,lpr)
+		-Dxinerama=$(usex xinerama yes no)
+		# Include backend immodules into gtk itself, to avoid problems like
+		# https://gitlab.gnome.org/GNOME/gnome-shell/issues/109 from a
+		# user overridden GTK_IM_MODULE envvar
+		-Dbuiltin_immodules=backend
+		-Dman=true
+		$(meson_use test tests)
+		-Dtracker3=false
+	)
+	meson_src_configure
+}
+
+multilib_src_compile() {
+	meson_src_compile
+}
+
+multilib_src_test() {
+	virtx dbus-run-session meson test -C "${BUILD_DIR}" --timeout-multiplier 4 || die
+}
+
+multilib_src_install() {
+	meson_src_install
+}
+
+multilib_src_install_all() {
+	insinto /etc/gtk-3.0
+	doins "${FILESDIR}"/settings.ini
+	# Skip README.win32.md that would get installed by default
+	DOCS=( NEWS README.md )
+	einstalldocs
+}
+
+pkg_preinst() {
+	gnome2_pkg_preinst
+
+	multilib_pkg_preinst() {
+		# Make immodules.cache belongs to gtk+ alone
+		local cache="/usr/$(get_libdir)/gtk-3.0/3.0.0/immodules.cache"
+
+		if [[ -e ${EROOT}${cache} ]]; then
+			cp "${EROOT}${cache}" "${ED}${cache}" || die
+		else
+			touch "${ED}${cache}" || die
+		fi
+	}
+	multilib_parallel_foreach_abi multilib_pkg_preinst
+}
+
+pkg_postinst() {
+	gnome2_pkg_postinst
+
+	multilib_pkg_postinst() {
+		gnome2_query_immodules_gtk3 \
+			|| die "Update immodules cache failed (for ${ABI})"
+	}
+	multilib_parallel_foreach_abi multilib_pkg_postinst
+
+	if ! has_version "app-text/evince"; then
+		elog "Please install app-text/evince for print preview functionality."
+		elog "Alternatively, check \"gtk-print-preview-command\" documentation and"
+		elog "add it to your settings.ini file."
+	fi
+}
+
+pkg_postrm() {
+	gnome2_pkg_postrm
+
+	if [[ -z ${REPLACED_BY_VERSION} ]]; then
+		multilib_pkg_postrm() {
+			rm -f "${EROOT}/usr/$(get_libdir)/gtk-3.0/3.0.0/immodules.cache"
+		}
+		multilib_foreach_abi multilib_pkg_postrm
+	fi
+}

--- a/x11-libs/gtk+/gtk+-3.24.42-r1.ebuild
+++ b/x11-libs/gtk+/gtk+-3.24.42-r1.ebuild
@@ -95,6 +95,10 @@ MULTILIB_CHOST_TOOLS=(
 PATCHES=(
 	# gtk-update-icon-cache is installed by dev-util/gtk-update-icon-cache
 	"${FILESDIR}"/${PN}-3.24.36-update-icon-cache.patch
+	# Gentoo-specific patch to add a "poison" macro support, allowing other ebuilds
+	# with USE="-wayland -X" to trick gtk into claiming that it wasn't built with
+	# such support.
+	"${FILESDIR}"/0001-gdk-add-a-poison-macro-to-hide-GDK_WINDOWING_.patch
 )
 
 src_prepare() {

--- a/x11-libs/wxGTK/wxGTK-3.2.2.1-r5.ebuild
+++ b/x11-libs/wxGTK/wxGTK-3.2.2.1-r5.ebuild
@@ -1,0 +1,262 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit multilib-minimal flag-o-matic
+
+WXSUBVERSION="${PV}-gtk3"				# 3.2.1-gtk3
+WXVERSION="$(ver_cut 1-3)"				# 3.2.1
+# Make sure that this matches the number of components in ${PV}
+WXRELEASE="$(ver_cut 1-2)-gtk3"			# 3.2-gtk3
+WXRELEASE_NODOT=${WXRELEASE//./}		# 32-gtk3
+
+DESCRIPTION="GTK version of wxWidgets, a cross-platform C++ GUI toolkit"
+HOMEPAGE="https://wxwidgets.org/"
+SRC_URI="
+	https://github.com/wxWidgets/wxWidgets/releases/download/v${PV}/wxWidgets-${PV}.tar.bz2
+	doc? ( https://github.com/wxWidgets/wxWidgets/releases/download/v${PV}/wxWidgets-${PV}-docs-html.tar.bz2 )"
+S="${WORKDIR}/wxWidgets-${PV}"
+
+LICENSE="wxWinLL-3 GPL-2 doc? ( wxWinFDL-3 )"
+SLOT="${WXRELEASE}"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~mips ~ppc ~ppc64 ~riscv ~sparc ~x86 ~amd64-linux ~x86-linux"
+IUSE="+X curl doc debug keyring gstreamer libnotify +lzma opengl pch sdl +spell test tiff wayland webkit X"
+REQUIRED_USE="test? ( tiff ) tiff? ( X ) spell? ( X ) keyring? ( X )"
+RESTRICT="!test? ( test )"
+
+RDEPEND="
+	>=app-eselect/eselect-wxwidgets-20131230
+	dev-libs/expat[${MULTILIB_USEDEP}]
+	dev-libs/libpcre2[pcre16,pcre32,unicode]
+	sdl? ( media-libs/libsdl2[${MULTILIB_USEDEP}] )
+	curl? ( net-misc/curl )
+	lzma? ( app-arch/xz-utils )
+	X? (
+		>=dev-libs/glib-2.22:2[${MULTILIB_USEDEP}]
+		media-libs/libjpeg-turbo:=[${MULTILIB_USEDEP}]
+		media-libs/libpng:0=[${MULTILIB_USEDEP}]
+		sys-libs/zlib[${MULTILIB_USEDEP}]
+		x11-libs/cairo[${MULTILIB_USEDEP}]
+		x11-libs/gtk+:3[wayland?,X?,${MULTILIB_USEDEP}]
+		x11-libs/gdk-pixbuf:2[${MULTILIB_USEDEP}]
+		x11-libs/libSM[${MULTILIB_USEDEP}]
+		x11-libs/libX11[${MULTILIB_USEDEP}]
+		x11-libs/libXtst
+		x11-libs/libXxf86vm[${MULTILIB_USEDEP}]
+		media-libs/fontconfig
+		x11-libs/pango[${MULTILIB_USEDEP}]
+		keyring? ( app-crypt/libsecret )
+		gstreamer? (
+			media-libs/gstreamer:1.0[${MULTILIB_USEDEP}]
+			media-libs/gst-plugins-base:1.0[${MULTILIB_USEDEP}]
+			media-libs/gst-plugins-bad:1.0[${MULTILIB_USEDEP}]
+		)
+		libnotify? ( x11-libs/libnotify[${MULTILIB_USEDEP}] )
+		opengl? (
+			virtual/opengl[${MULTILIB_USEDEP}]
+			wayland? ( dev-libs/wayland )
+		)
+		spell? ( app-text/gspell:= )
+		tiff? ( media-libs/tiff:=[${MULTILIB_USEDEP}] )
+		webkit? ( net-libs/webkit-gtk:4= )
+	)"
+DEPEND="${RDEPEND}
+	opengl? ( virtual/glu[${MULTILIB_USEDEP}] )
+	X? ( x11-base/xorg-proto )"
+BDEPEND="
+	test? ( >=dev-util/cppunit-1.8.0 )
+	>=app-eselect/eselect-wxwidgets-20131230
+	virtual/pkgconfig"
+
+# Note about the gst-plugin-base dep: The build system queries for it,
+# but doesn't link it for some reason?  Either way - probably best to
+# depend on it anyway.
+# Note about the wayland dep: Appears to be only required for the OpenGL
+# canvas, and it seems impossible to disable the X dependency, unless
+# I'm missing something.  This is an automagic header dep, though.
+
+PATCHES=(
+	#"${WORKDIR}"/wxGTK-3.0.5_p20210214/
+	"${FILESDIR}/${PN}-3.2.1-gtk3-translation-domain.patch"
+	#"${FILESDIR}"/wxGTK-ignore-c++-abi.patch #676878
+	"${FILESDIR}/${PN}-3.2.1-configure-tests.patch"
+	"${FILESDIR}/${PN}-3.2.1-wayland-control.patch"
+	"${FILESDIR}/${PN}-3.2.1-prefer-lib64-in-tests.patch"
+	"${FILESDIR}/${PN}-3.2.2.1-dont-break-flags.patch"
+	"${FILESDIR}/${PN}-3.2.2.1-backport-pr24197.patch"
+)
+
+src_prepare() {
+	default
+
+	# find . -iname Makefile.in -not -path ./samples'/*' \
+	#        | xargs grep -l WX_RELEASE
+	local versioned_makefiles=(
+		./tests/benchmarks/Makefile.in
+		./tests/Makefile.in
+		./utils/emulator/src/Makefile.in
+		./utils/execmon/Makefile.in
+		./utils/wxrc/Makefile.in
+		./utils/helpview/src/Makefile.in
+		./utils/hhp2cached/Makefile.in
+		./utils/screenshotgen/src/Makefile.in
+		./utils/ifacecheck/src/Makefile.in
+		./Makefile.in
+		./demos/life/Makefile.in
+		./demos/bombs/Makefile.in
+		./demos/fractal/Makefile.in
+		./demos/forty/Makefile.in
+		./demos/poem/Makefile.in
+	)
+
+	# Versionating
+	sed -i \
+		-e "s:\(WX_RELEASE = \).*:\1${WXRELEASE}:"\
+		-e "s:\(WX_RELEASE_NODOT = \).*:\1${WXRELEASE_NODOT}:"\
+		-e "s:\(WX_VERSION = \).*:\1${WXVERSION}:"\
+		-e "s:aclocal):aclocal/wxwin${WXRELEASE_NODOT}.m4):" \
+		"${versioned_makefiles[@]}" || die
+
+	sed -i \
+		-e "s:\(WX_VERSION=\).*:\1${WXVERSION}:" \
+		-e "s:\(WX_RELEASE=\).*:\1${WXRELEASE}:" \
+		-e "s:\(WX_SUBVERSION=\).*:\1${WXSUBVERSION}:" \
+		-e '/WX_VERSION_TAG=/ s:${WX_RELEASE}:3.0:' \
+		configure || die
+}
+
+multilib_src_configure() {
+	# defang automagic dependencies, bug #927952
+	use wayland || append-cflags -DGENTOO_GTK_HIDE_WAYLAND
+	use X || append-cflags -DGENTOO_GTK_HIDE_X11
+
+	# Workaround for bug #915154
+	append-ldflags $(test-flags-CCLD -Wl,--undefined-version)
+
+	# X independent options
+	local myeconfargs=(
+		--with-zlib=sys
+		--with-expat=sys
+		--enable-compat30
+		--enable-xrc
+		$(use_with sdl)
+		$(use_with lzma liblzma)
+		# Currently defaults to curl, could change.  Watch the VDB!
+		$(use_enable curl webrequest)
+
+		# PCHes are unstable and are disabled in-tree where possible
+		# See bug #504204
+		# Commits 8c4774042b7fdfb08e525d8af4b7912f26a2fdce, fb809aeadee57ffa24591e60cfb41aecd4823090
+		$(use_enable pch precomp-headers)
+
+		# Don't hard-code libdir's prefix for wx-config
+		--libdir='${prefix}'/$(get_libdir)
+	)
+
+	# By default, we now build with the GLX GLCanvas because some software like
+	# PrusaSlicer does not yet support EGL:
+	#
+	# https://github.com/prusa3d/PrusaSlicer/issues/9774 .
+	#
+	# A solution for this is being developed upstream:
+	#
+	# https://github.com/wxWidgets/wxWidgets/issues/22325 .
+	#
+	# Any software that needs to use OpenGL under Wayland can be patched like
+	# this to run under xwayland:
+	#
+	# https://github.com/visualboyadvance-m/visualboyadvance-m/commit/aca206a721265366728222d025fec30ee500de82 .
+	#
+	# Check that the macro wxUSE_GLCANVAS_EGL is set to 1.
+	#
+	myeconfargs+=( "--disable-glcanvasegl" )
+
+	# debug in >=2.9
+	# there is no longer separate debug libraries (gtk2ud)
+	# wxDEBUG_LEVEL=1 is the default and we will leave it enabled
+	# wxDEBUG_LEVEL=2 enables assertions that have expensive runtime costs.
+	# apps can disable these features by building w/ -NDEBUG or wxDEBUG_LEVEL_0.
+	# http://docs.wxwidgets.org/3.0/overview_debugging.html
+	# https://groups.google.com/group/wx-dev/browse_thread/thread/c3c7e78d63d7777f/05dee25410052d9c
+	use debug && myeconfargs+=( --enable-debug=max )
+
+	# wxGTK options
+	#   --enable-graphics_ctx - needed for webkit, editra
+	#   --without-gnomevfs - bug #203389
+	use X && myeconfargs+=(
+		--enable-graphics_ctx
+		--with-gtkprint
+		--enable-gui
+		--with-gtk=3
+		--with-libpng=sys
+		--with-libjpeg=sys
+
+		# Choosing to enable this unconditionally seems fair, pcre2 is
+		# almost certain to be installed.
+		--with-regex=sys
+		--without-gnomevfs
+		$(use_enable gstreamer mediactrl)
+		$(multilib_native_use_enable webkit webview)
+		$(use_with libnotify)
+		$(use_with opengl)
+		$(use_with tiff libtiff sys)
+		$(use_enable keyring secretstore)
+		$(use_enable spell spellcheck)
+		$(use_enable test tests)
+		$(use_enable wayland)
+	)
+
+	# wxBase options
+	! use X && myeconfargs+=( --disable-gui )
+
+	# wxWidgets installs a configuration file with a reference to EGREP.
+	# Autoconf discovers these programs via full paths, which is
+	# unnecessary and fails if a build happened on a merged-usr system
+	# but is being used on a split-usr system.  Bug #927920.
+	export ac_cv_path_SED="sed"
+	export ac_cv_path_EGREP="grep -E"
+	export ac_cv_path_EGREP_TRADITIONAL="grep -E"
+	export ac_cv_path_FGREP="grep -F"
+	export ac_cv_path_GREP="grep"
+	export ac_cv_path_lt_DD="dd"
+
+	ECONF_SOURCE="${S}" econf "${myeconfargs[@]}"
+}
+
+multilib_src_test() {
+	emake -C tests
+	(cd tests && ./test '~[.]~[net]') || die
+}
+
+multilib_src_install_all() {
+	cd docs || die
+	dodoc changes.txt readme.txt
+	newdoc base/readme.txt base_readme.txt
+	newdoc gtk/readme.txt gtk_readme.txt
+
+	use doc && HTML_DOCS=( "${WORKDIR}"/wxWidgets-${PV}-docs-html/. )
+	einstalldocs
+
+	# Unversioned links
+	rm "${ED}"/usr/bin/wx-config || die
+	rm "${ED}"/usr/bin/wxrc || die
+
+	# version bakefile presets
+	pushd "${ED}"/usr/share/bakefile/presets >/dev/null || die
+	local f
+	for f in wx*; do
+		mv "${f}" "${f/wx/wx32gtk3}" || die
+	done
+	popd >/dev/null || die
+}
+
+pkg_postinst() {
+	has_version -b app-eselect/eselect-wxwidgets \
+		&& eselect wxwidgets update
+}
+
+pkg_postrm() {
+	has_version -b app-eselect/eselect-wxwidgets \
+		&& eselect wxwidgets update
+}

--- a/xfce-base/libxfce4ui/libxfce4ui-4.18.6-r1.ebuild
+++ b/xfce-base/libxfce4ui/libxfce4ui-4.18.6-r1.ebuild
@@ -1,0 +1,79 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit flag-o-matic xdg-utils vala
+
+DESCRIPTION="Unified widget and session management libs for Xfce"
+HOMEPAGE="
+	https://docs.xfce.org/xfce/libxfce4ui/start
+	https://gitlab.xfce.org/xfce/libxfce4ui/
+"
+SRC_URI="https://archive.xfce.org/src/xfce/${PN}/${PV%.*}/${P}.tar.bz2"
+
+LICENSE="LGPL-2+ GPL-2+"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~mips ~ppc ~ppc64 ~riscv ~sparc ~x86 ~amd64-linux ~x86-linux"
+IUSE="glade +introspection startup-notification system-info vala wayland"
+REQUIRED_USE="vala? ( introspection )"
+
+DEPEND="
+	>=dev-libs/glib-2.66.0
+	>=x11-libs/gtk+-3.24.0:3[introspection?,wayland?,X]
+	x11-libs/libX11
+	x11-libs/libICE
+	x11-libs/libSM
+	>=xfce-base/libxfce4util-4.17.2:=[introspection?,vala?]
+	>=xfce-base/xfconf-4.12:=
+	glade? ( dev-util/glade:3.10 )
+	introspection? ( >=dev-libs/gobject-introspection-1.66:= )
+	startup-notification? ( x11-libs/startup-notification )
+	system-info? (
+		dev-libs/libgudev
+		gnome-base/libgtop
+		>=media-libs/libepoxy-1.2
+	)
+"
+RDEPEND="
+	${DEPEND}
+"
+BDEPEND="
+	dev-lang/perl
+	dev-util/intltool
+	sys-devel/gettext
+	virtual/pkgconfig
+	vala? ( $(vala_depend) )
+"
+
+src_configure() {
+	# defang automagic dependencies, bug #873520
+	use wayland || append-cflags -DGENTOO_GTK_HIDE_WAYLAND
+
+	local myconf=(
+		$(use_enable introspection)
+		$(use_enable system-info glibtop)
+		$(use_enable system-info epoxy)
+		$(use_enable system-info gudev)
+		$(use_enable startup-notification)
+		$(use_enable vala)
+		$(use_enable glade gladeui2)
+		--with-vendor-info=Gentoo
+	)
+
+	use vala && vala_setup
+	econf "${myconf[@]}"
+}
+
+src_install() {
+	emake -j1 DESTDIR="${D}" install
+	find "${D}" -name '*.la' -delete || die
+}
+
+pkg_postinst() {
+	xdg_icon_cache_update
+}
+
+pkg_postrm() {
+	xdg_icon_cache_update
+}


### PR DESCRIPTION
There is a bug in how gtk 3 and gtk 4 are built against by other packages. GTK supports optionally enabling X and wayland support -- when you do so, the ABI of GTK changes.

It is historically common for X11 packages to check for a macro provided by GTK that says "built with X11 support". This goes back to the days when X11 was the only backend shipped with GTK, and the main use of the macro was to check whether to use X11 or rather to use, say, the win32 or Quartz (macOS) backends. The pattern has continued now that Linux has two backends.

The result of this is that many packages really need to support their own IUSE="X wayland" (because they can conditionally build code for that) and also need to make sure that USE flag is actually respected. Failure to do this means that when rebuilding GTK with different USE flags, all applications linking to GTK need to be rebuilt too, but portage doesn't know that.

It also means that binhosts -- such as the one officially hosted by Gentoo -- have bad binaries that don't actually match the packages users have installed. This is particularly bad since it breaks expectations and is quite hard to debug. This has hit people a bunch of times when trying to install the xfce desktop environment, in particular.

There are a couple possible solutions that have been considered, both by me and others.

- simply demand upstream software implements configure options allowing automagic dependencies to be selected in src_configure. Advantage: every software should be doing this!!! Disadvantage: they currently do not and demanding they do it doesn't actually mean they are doing it. We can't just refuse to fix ebuilds that are broken, because it's upstream's job to fix it.

- bind packages tightly to whether gtk is built with wayland, via gtk[wayland=]. Advantage: metadata is always valid, and all builds of the package which have wayland symbols also depend on wayland support. Disadvantage: users have to toggle USE="wayland" on all packages at the same time, and cannot build libxfce4ui without wayland support, then enable wayland for gtk, without rebuilding.

- package.use.force gtk[wayland]. Advantage: nobody can rebuild gtk without part of its ABI, so other packages always have the symbols they need. Disadvantage: nobody can rebuild gtk without functionality they don't use.

- adopt new functionality in EAPI 9. Currently we have slot dependencies, which PMS carves out as a carefully scoped case where it performs delayed metadata lookup at the time of building a package, and updates RDEPEND values in place for the built package (to write out the exact slot value being built against). A similar trick could be used to expand "?" and "=" USE dependencies to also support looking up the value of the USE that was built against, e.g.
  ```
  RDEPEND="
      x11-libs/gtk+:3[X:?,wayland:?]
  "
  ```
  meaning that building, say, libxfce4ui on a system with gtk+[wayland] installed would propagate that dependency, but building it on a system without a wayland-enabled gtk+ would not require any specific build of gtk+. Advantage: packages could accurately model how they were built. Disadvantage: any fix that requires "wait for new EAPI to be agreed on and implemented" isn't a practical solution to current problems today.

- What I propose in this patchset. Hack a custom gentoo feature into the GTK headers. GTK normally behaves exactly as it's supposed to upstream, but we add the ability to pass a define via `append-cflags` that makes the GTK headers tell an outright lie and claim its API doesn't exist. Which is what we want -- we want packages to be able to compile *as if* GTK wasn't built with support for a given backend. This disables the automagic as if option 1 (implementing configure options) was carried out. Advantage: automatically support proper control of features. Disadvantage: requires patching GTK and then still adding workarounds for each package that needs it.


---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
