### PR TITLE
media-plugins/vdr-freecell: dont call g++ directly

### DIFF
--- a/media-plugins/vdr-freecell/vdr-freecell-0.0.2-r5.ebuild
+++ b/media-plugins/vdr-freecell/vdr-freecell-0.0.2-r5.ebuild
@@ -25,6 +25,9 @@ src_prepare() {
 	eapply "${FILESDIR}/${P}-gentoo.diff"
 	eapply "${FILESDIR}/${P}_vdr-1.5.4-compile.diff"
 	eapply "${FILESDIR}/${P}_compilefix.patch"
+
+	# do not call g++ directly, Bug #934766
+	sed -e 's|MAKEDEP = g++ -MM -MG|MAKEDEP = $(CXX) -MM -MG|' -i Makefile || die
 }
 
 src_install() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/934766

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
