### PR TITLE
profiles/base: mask dev-lang/ruby[static-libs]

### DIFF
--- a/profiles/base/package.use.mask
+++ b/profiles/base/package.use.mask
@@ -6,6 +6,11 @@
 # This file is only for generic masks. For arch-specific masks (i.e.
 # mask everywhere, unmask on arch/*) use arch/base.
 
+# Sam James <sam@gentoo.org> (2024-06-24)
+# Breaks installed gems in hard-to-debug ways.
+# bug #887223, bug #891367, bug #903891, bug #917139
+dev-lang/ruby static-libs
+
 # Alfredo Tupone <tupone@gentoo.org> (2024-05-28)
 # Not working, bug #931046
 >=sci-libs/caffe2-2.3.0 rocm


### PR DESCRIPTION
It breaks gem installation in mysterious ways and people keep tripping over it.

Closes: https://bugs.gentoo.org/887223
Closes: https://bugs.gentoo.org/891367
Closes: https://bugs.gentoo.org/903891
Closes: https://bugs.gentoo.org/917139

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
