### PR TITLE
net-misc/jwhois: last rite

### DIFF
--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -33,6 +33,14 @@
 
 #--- END OF EXAMPLES ---
 
+# NHOrus <jy6x2b32pie9@yahoo.com> (2024-06-24)
+# Last release was 18 years ago, last time code was touched was 9 years ago
+# Software is broken, ebuild is broken, there's healthy replacement in
+# the tree, net-misc/whois
+# Bugs #871429, #504844, #881619, #900284, #919809.
+# Will be removed in 30 days
+net-misc/jwhois
+
 # Arthur Zamarin <arthurzam@gentoo.org> (2024-06-23)
 # EAPI=6, waiting for a version bump, no reverse-dependencies.
 # Removal on 2024-07-23.  Bugs #934756, #924303.


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/919809

Last riting, because it's dead, unmaintainable and superseded.

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
