### PR TITLE
x11-misc/clipmenu: Add support for ignoring applications

### DIFF
--- a/x11-misc/clipmenu/clipmenu-6.2.0-r1.ebuild
+++ b/x11-misc/clipmenu/clipmenu-6.2.0-r1.ebuild
@@ -12,7 +12,7 @@ SRC_URI="https://github.com/cdown/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
 LICENSE="Unlicense"
 SLOT="0"
 KEYWORDS="amd64 x86"
-IUSE="+dmenu fzf rofi"
+IUSE="+dmenu fzf rofi xdotool"
 REQUIRED_USE="?? ( dmenu fzf rofi )"
 
 RDEPEND="
@@ -21,6 +21,7 @@ RDEPEND="
 	dmenu? ( x11-misc/dmenu )
 	fzf? ( app-shells/fzf )
 	rofi? ( x11-misc/rofi )
+    xdotool? ( x11-misc/xdotool )
 "
 
 src_prepare() {

--- a/x11-misc/clipmenu/metadata.xml
+++ b/x11-misc/clipmenu/metadata.xml
@@ -13,5 +13,6 @@
 		<flag name="dmenu">Use dmenu as default launcher</flag>
 		<flag name="rofi">Use rofi as default launcher</flag>
 		<flag name="fzf">Use fzf as default launcher</flag>
+                <flag name="xdotool">Add support for ignoring specified applications</flag>
 	</use>
 </pkgmetadata>


### PR DESCRIPTION
<!-- Please put the pull request description above -->
Clipmenu allows users to ignore specified applications at launch using the following syntax

`CM_IGNORE_WINDOW="KeePassXC" clipmenud`

When running the following command without xdotool installed you receive the following error

`WARN: CM_IGNORE_WINDOW does not work without xdotool, which is not installed`

The following pull request adds x11-misc/xdotool as an optional dependency masked by the use flag 'xdotool'

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
