### PR TITLE
kernel-build.eclass: identify dist-kernels, and warn users

### DIFF
--- a/eclass/kernel-build.eclass
+++ b/eclass/kernel-build.eclass
@@ -382,6 +382,22 @@ kernel-build_src_install() {
 	local module_ver
 	module_ver=$(<"${relfile}") || die
 
+	# warn when trying to "make" a dist-kernel
+	cat <<-EOF >> "${ED}${kernel_dir}/Makefile" || die
+
+		_GENTOO_IS_USER_SHELL:=\$(shell [ -t 0 ] && echo 1)
+		ifdef _GENTOO_IS_USER_SHELL
+		\$(warning !!!! WARNING !!!!)
+		\$(warning This kernel was configured and installed by the package manager.)
+		\$(warning "make" should not be run manually here.)
+		\$(warning See also: https://wiki.gentoo.org/wiki/Project:Distribution_Kernel)
+		\$(warning See also: https://wiki.gentoo.org/wiki/Kernel/Configuration)
+		\$(warning !!!! WARNING !!!!)
+		endif
+	EOF
+	# add a dist-kernel identifier file
+	echo "${CATEGORY}/${PF}:${SLOT}" > "${ED}${kernel_dir}/dist-kernel" || die
+
 	# fix source tree and build dir symlinks
 	dosym "../../../${kernel_dir}" "/lib/modules/${module_ver}/build"
 	dosym "../../../${kernel_dir}" "/lib/modules/${module_ver}/source"

--- a/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-5.10.218.ebuild
+++ b/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-5.10.218.ebuild
@@ -108,6 +108,11 @@ src_test() {
 }
 
 src_install() {
+	local kernel_dir="${BINPKG}/image/usr/src/linux-${KPV}"
+
+	# Overwrite the identifier in the prebuilt package
+	echo "${CATEGORY}/${PF}:${SLOT}" > "${kernel_dir}/dist-kernel" || die
+
 	mv "${BINPKG}"/image/{lib,usr} "${ED}"/ || die
 
 	# FIXME: requires proper mount-boot

--- a/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-5.10.219.ebuild
+++ b/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-5.10.219.ebuild
@@ -108,6 +108,11 @@ src_test() {
 }
 
 src_install() {
+	local kernel_dir="${BINPKG}/image/usr/src/linux-${KPV}"
+
+	# Overwrite the identifier in the prebuilt package
+	echo "${CATEGORY}/${PF}:${SLOT}" > "${kernel_dir}/dist-kernel" || die
+
 	mv "${BINPKG}"/image/{lib,usr} "${ED}"/ || die
 
 	# FIXME: requires proper mount-boot

--- a/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-5.10.220.ebuild
+++ b/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-5.10.220.ebuild
@@ -108,6 +108,11 @@ src_test() {
 }
 
 src_install() {
+	local kernel_dir="${BINPKG}/image/usr/src/linux-${KPV}"
+
+	# Overwrite the identifier in the prebuilt package
+	echo "${CATEGORY}/${PF}:${SLOT}" > "${kernel_dir}/dist-kernel" || die
+
 	mv "${BINPKG}"/image/{lib,usr} "${ED}"/ || die
 
 	# FIXME: requires proper mount-boot

--- a/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-5.15.160.ebuild
+++ b/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-5.15.160.ebuild
@@ -108,6 +108,11 @@ src_test() {
 }
 
 src_install() {
+	local kernel_dir="${BINPKG}/image/usr/src/linux-${KPV}"
+
+	# Overwrite the identifier in the prebuilt package
+	echo "${CATEGORY}/${PF}:${SLOT}" > "${kernel_dir}/dist-kernel" || die
+
 	mv "${BINPKG}"/image/{lib,usr} "${ED}"/ || die
 
 	# FIXME: requires proper mount-boot

--- a/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-5.15.161.ebuild
+++ b/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-5.15.161.ebuild
@@ -108,6 +108,11 @@ src_test() {
 }
 
 src_install() {
+	local kernel_dir="${BINPKG}/image/usr/src/linux-${KPV}"
+
+	# Overwrite the identifier in the prebuilt package
+	echo "${CATEGORY}/${PF}:${SLOT}" > "${kernel_dir}/dist-kernel" || die
+
 	mv "${BINPKG}"/image/{lib,usr} "${ED}"/ || die
 
 	# FIXME: requires proper mount-boot

--- a/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-6.1.92.ebuild
+++ b/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-6.1.92.ebuild
@@ -108,6 +108,11 @@ src_test() {
 }
 
 src_install() {
+	local kernel_dir="${BINPKG}/image/usr/src/linux-${KPV}"
+
+	# Overwrite the identifier in the prebuilt package
+	echo "${CATEGORY}/${PF}:${SLOT}" > "${kernel_dir}/dist-kernel" || die
+
 	mv "${BINPKG}"/image/{lib,usr} "${ED}"/ || die
 
 	# FIXME: requires proper mount-boot

--- a/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-6.1.93.ebuild
+++ b/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-6.1.93.ebuild
@@ -108,6 +108,11 @@ src_test() {
 }
 
 src_install() {
+	local kernel_dir="${BINPKG}/image/usr/src/linux-${KPV}"
+
+	# Overwrite the identifier in the prebuilt package
+	echo "${CATEGORY}/${PF}:${SLOT}" > "${kernel_dir}/dist-kernel" || die
+
 	mv "${BINPKG}"/image/{lib,usr} "${ED}"/ || die
 
 	# FIXME: requires proper mount-boot

--- a/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-6.1.94.ebuild
+++ b/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-6.1.94.ebuild
@@ -108,6 +108,11 @@ src_test() {
 }
 
 src_install() {
+	local kernel_dir="${BINPKG}/image/usr/src/linux-${KPV}"
+
+	# Overwrite the identifier in the prebuilt package
+	echo "${CATEGORY}/${PF}:${SLOT}" > "${kernel_dir}/dist-kernel" || die
+
 	mv "${BINPKG}"/image/{lib,usr} "${ED}"/ || die
 
 	# FIXME: requires proper mount-boot

--- a/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-6.1.95.ebuild
+++ b/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-6.1.95.ebuild
@@ -108,6 +108,11 @@ src_test() {
 }
 
 src_install() {
+	local kernel_dir="${BINPKG}/image/usr/src/linux-${KPV}"
+
+	# Overwrite the identifier in the prebuilt package
+	echo "${CATEGORY}/${PF}:${SLOT}" > "${kernel_dir}/dist-kernel" || die
+
 	mv "${BINPKG}"/image/{lib,usr} "${ED}"/ || die
 
 	# FIXME: requires proper mount-boot

--- a/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-6.6.32.ebuild
+++ b/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-6.6.32.ebuild
@@ -134,6 +134,9 @@ src_install() {
 		fi
 	fi
 
+	# Overwrite the identifier in the prebuilt package
+	echo "${CATEGORY}/${PF}:${SLOT}" > "${kernel_dir}/dist-kernel" || die
+
 	mv "${BINPKG}"/image/{lib,usr} "${ED}"/ || die
 
 	# FIXME: requires proper mount-boot

--- a/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-6.6.33.ebuild
+++ b/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-6.6.33.ebuild
@@ -134,6 +134,9 @@ src_install() {
 		fi
 	fi
 
+	# Overwrite the identifier in the prebuilt package
+	echo "${CATEGORY}/${PF}:${SLOT}" > "${kernel_dir}/dist-kernel" || die
+
 	mv "${BINPKG}"/image/{lib,usr} "${ED}"/ || die
 
 	# FIXME: requires proper mount-boot

--- a/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-6.6.34.ebuild
+++ b/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-6.6.34.ebuild
@@ -134,6 +134,9 @@ src_install() {
 		fi
 	fi
 
+	# Overwrite the identifier in the prebuilt package
+	echo "${CATEGORY}/${PF}:${SLOT}" > "${kernel_dir}/dist-kernel" || die
+
 	mv "${BINPKG}"/image/{lib,usr} "${ED}"/ || die
 
 	# FIXME: requires proper mount-boot

--- a/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-6.6.35.ebuild
+++ b/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-6.6.35.ebuild
@@ -134,6 +134,9 @@ src_install() {
 		fi
 	fi
 
+	# Overwrite the identifier in the prebuilt package
+	echo "${CATEGORY}/${PF}:${SLOT}" > "${kernel_dir}/dist-kernel" || die
+
 	mv "${BINPKG}"/image/{lib,usr} "${ED}"/ || die
 
 	# FIXME: requires proper mount-boot

--- a/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-6.9.4.ebuild
+++ b/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-6.9.4.ebuild
@@ -134,6 +134,9 @@ src_install() {
 		fi
 	fi
 
+	# Overwrite the identifier in the prebuilt package
+	echo "${CATEGORY}/${PF}:${SLOT}" > "${kernel_dir}/dist-kernel" || die
+
 	mv "${BINPKG}"/image/{lib,usr} "${ED}"/ || die
 
 	# FIXME: requires proper mount-boot

--- a/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-6.9.5.ebuild
+++ b/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-6.9.5.ebuild
@@ -134,6 +134,9 @@ src_install() {
 		fi
 	fi
 
+	# Overwrite the identifier in the prebuilt package
+	echo "${CATEGORY}/${PF}:${SLOT}" > "${kernel_dir}/dist-kernel" || die
+
 	mv "${BINPKG}"/image/{lib,usr} "${ED}"/ || die
 
 	# FIXME: requires proper mount-boot

--- a/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-6.9.6.ebuild
+++ b/sys-kernel/gentoo-kernel-bin/gentoo-kernel-bin-6.9.6.ebuild
@@ -134,6 +134,9 @@ src_install() {
 		fi
 	fi
 
+	# Overwrite the identifier in the prebuilt package
+	echo "${CATEGORY}/${PF}:${SLOT}" > "${kernel_dir}/dist-kernel" || die
+
 	mv "${BINPKG}"/image/{lib,usr} "${ED}"/ || die
 
 	# FIXME: requires proper mount-boot


### PR DESCRIPTION
Many, many, new users at some point make the mistake of running "make ...." in the source directory of a distribution kernel.

This returns a vague error due to the absence of the kernel source files:

```
make[2]: *** No rule to make target 'arch/x86/entry/syscalls/syscall_32.tbl', needed by 'arch/x86/include/generated/uapi/asm/unistd_32.h'.  Stop.
make[1]: *** [arch/x86/Makefile:248: archheaders] Error 2
make: *** [Makefile:234: __sub-make] Error 2
```

Here we append to the kernel Makefile a warning that should make it more clear what is going wrong.

We also add a "dist-kernel" file containing the package atom of the ebuild that installed this kernel. This makes it possible for ebuilds/eclasses or whatever other tools to check if a kernel is a Gentoo distribution kernel.

Example output:
```
andrew-gentoo-pc linux-6.6.35-gentoo-dist # make
Makefile:2064: !!!! WARNING !!!!
Makefile:2065: This kernel was configured and installed by the package manager.
Makefile:2066: "make" should not be run manually here.
Makefile:2067: See also: https://wiki.gentoo.org/wiki/Project:Distribution_Kernel
Makefile:2068: See also: https://wiki.gentoo.org/wiki/Kernel/Configuration
Makefile:2069: !!!! WARNING !!!!
/usr/src/linux-6.6.35-gentoo-dist/Makefile:2064: !!!! WARNING !!!!
/usr/src/linux-6.6.35-gentoo-dist/Makefile:2065: This kernel was configured and installed by the package manager.
/usr/src/linux-6.6.35-gentoo-dist/Makefile:2066: "make" should not be run manually here.
/usr/src/linux-6.6.35-gentoo-dist/Makefile:2067: See also: https://wiki.gentoo.org/wiki/Project:Distribution_Kernel
/usr/src/linux-6.6.35-gentoo-dist/Makefile:2068: See also: https://wiki.gentoo.org/wiki/Kernel/Configuration
/usr/src/linux-6.6.35-gentoo-dist/Makefile:2069: !!!! WARNING !!!!
make[2]: *** No rule to make target 'arch/x86/entry/syscalls/syscall_32.tbl', needed by 'arch/x86/include/generated/uapi/asm/unistd_32.h'.  Stop.
make[1]: *** [arch/x86/Makefile:248: archheaders] Error 2
make: *** [Makefile:234: __sub-make] Error 2
```

@mgorny @thesamesam please let me know what you think of this, and specifically if this manipulation of the Makefile could have unintended side-effects.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
