### PR TITLE
🚑️💩🧪 dev-python/js2py: revbump to 0.74-r1

### DIFF
--- a/dev-python/js2py/files/js2py-0.74-CVE-2024-28397.patch
+++ b/dev-python/js2py/files/js2py-0.74-CVE-2024-28397.patch
@@ -1,0 +1,21 @@
+# https://nvd.nist.gov/vuln/detail/CVE-2024-28397
+# https://github.com/Marven11/CVE-2024-28397-js2py-Sandbox-Escape/blob/main/patch.txt
+# https://github.com/PiotrDabkowski/Js2Py/pull/323
+# https://github.com/Marven11/Js2Py/commit/56e244eb
+
+Author: Marven11 <110723864+Marven11@users.noreply.github.com>
+Date: Fri, 1 Mar 2024 12:53:58 +0800
+
+diff --git a/js2py/constructors/jsobject.py b/js2py/constructors/jsobject.py
+index c4e0ada3..b1806ea6 100644
+--- a/js2py/constructors/jsobject.py
++++ b/js2py/constructors/jsobject.py
+@@ -49,7 +49,7 @@ def getOwnPropertyNames(obj):
+             raise MakeError(
+                 'TypeError',
+                 'Object.getOwnPropertyDescriptor called on non-object')
+-        return obj.own.keys()
++        return list(obj.own.keys())
+ 
+     def create(obj):
+         if not (obj.is_object() or obj.is_null()):

--- a/dev-python/js2py/js2py-0.74-r1.ebuild
+++ b/dev-python/js2py/js2py-0.74-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -6,18 +6,19 @@ EAPI=8
 DISTUTILS_USE_PEP517=setuptools
 PYPI_NO_NORMALIZE=1
 PYPI_PN="Js2Py"
-PYTHON_COMPAT=( python3_{9..11} )
+PYTHON_COMPAT=( python3_{10..11} )
 
 inherit distutils-r1 pypi
 
 DESCRIPTION="JavaScript to Python Translator & JavaScript interpreter in Python"
-HOMEPAGE="http://piter.io/projects/js2py/
-	https://github.com/PiotrDabkowski/Js2Py/
+HOMEPAGE="http://piter.io/projects/js2py
+	https://github.com/PiotrDabkowski/Js2Py
 	https://pypi.org/project/Js2Py/"
 
 LICENSE="MIT"
 SLOT="0"
 KEYWORDS="amd64 ~arm arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sparc x86"
+RESTRICT="test"
 
 RDEPEND="
 	>=dev-python/pyjsparser-2.5.1[${PYTHON_USEDEP}]
@@ -25,15 +26,20 @@ RDEPEND="
 	>=dev-python/six-1.10.0[${PYTHON_USEDEP}]
 "
 
+PATCHES=(
+	"${FILESDIR}"/${P}-CVE-2024-28397.patch
+)
+
 python_test() {
 	pushd ./tests >/dev/null || die
 
-	# Tests require "node_failed.txt" file where the logs are kept
-	if [[ -f ./node_failed.txt ]] ; then
-		rm ./node_failed.txt || die
-	fi
-
+	# run.py requires "node_failed.txt" file
 	touch ./node_failed.txt || die
+
+	# https://bugs.gentoo.org/831356
+	# make run.py return a non-zero exit code if any test failed
+	echo 'sys.exit(len(FAILING))' >> ./run.py || die
+
 	"${EPYTHON}" ./run.py || die "tests failed with ${EPYTHON}"
 
 	popd >/dev/null || die

--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -33,6 +33,11 @@
 
 #--- END OF EXAMPLES ---
 
+# Aliaksei Urbanski <aliaksei.urbanski@gmail.com> (2024-06-24)
+# Js2Py is vulnerable to a sandbox escape (CVE-2024-28397)
+# Please remove it or upgrade to the latest revision!
+<dev-python/js2py-0.74-r1
+
 # NHOrus <jy6x2b32pie9@yahoo.com> (2024-06-24)
 # Masked for removal in 30 days.
 # It's a dependency of cinelerra, written for cinelerra.


### PR DESCRIPTION
_Hello everyone,_

These changes:
  - 🚑️ fix CVE-2024-28397
  - 💩 restrict the `test` feature since multiple tests are broken
  - 🧪 fix ignoring of test failures (bug [831356](https://bugs.gentoo.org/831356))
    * _**note:** this change has no effect now due to the restricted `test` feature_

Based on:
  - [dev-python/js2py-0.74](https://gitweb.gentoo.org/repo/gentoo.git/commit/dev-python/js2py/js2py-0.74.ebuild?id=1a4be78f) by @xgqt, @thesamesam, @SoapGentoo, and @mgorny
  - PiotrDabkowski/Js2Py#323 by @Marven11

_Best regards!_

---

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.