### PR TITLE
net-im/discord: enable wayland at runtime, #934886

### DIFF
--- a/net-im/discord/files/launcher.sh
+++ b/net-im/discord/files/launcher.sh
@@ -1,0 +1,17 @@
+#!/bin/env bash
+# coding: UTF-8
+
+
+declare -a discord_parameters
+
+SECCOMP=false
+
+[[ ! "${SECCOMP}" ]] && discord_parameters+=( --disable-seccomp-filter-sandbox )
+
+[[ -n "${WAYLAND_DISPLAY}" ]] && discord_parameters+=(
+	--enable-features=UseOzonePlatform
+	--ozone-platform=wayland
+	--enable-wayland-ime
+)
+
+@@DESTDIR@@/Discord "${discord_parameters[@]}" "$@"


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/934886

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
