### PR TITLE
mount-boot.eclass: revises /boot checking for dist-kernels, add checks for ESP

### DIFF
--- a/eclass/mount-boot-utils.eclass
+++ b/eclass/mount-boot-utils.eclass
@@ -1,0 +1,109 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+# @ECLASS: mount-boot-utils.eclass
+# @MAINTAINER:
+# base-system@gentoo.org
+# @SUPPORTED_EAPIS: 6 7 8
+# @BLURB: functions for packages that install files into /boot or the ESP
+# @DESCRIPTION:
+# This eclass is really only useful for bootloaders and kernel installation.
+#
+# If the live system has a separate /boot partition or ESP configured, then this
+# function tries to ensure that it's mounted in rw mode, exiting with an error
+# if it can't.  It does nothing if /boot and ESP isn't a separate partition.
+#
+# This eclass provides the functions used by mount-boot.eclass in an "inherit-
+# safe" way. This allows these functions to be used in other eclasses cleanly.
+
+case ${EAPI} in
+	7|8) ;;
+	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
+esac
+
+# @FUNCTION: mount-boot_is_disabled
+# @INTERNAL
+# @DESCRIPTION:
+# Detect whether the current environment/build settings are such that we do not
+# want to mess with any mounts.
+mount-boot_is_disabled() {
+	# Since this eclass only deals with /boot, skip things when EROOT is active.
+	if [[ -n ${EROOT} ]]; then
+		return 0
+	fi
+
+	# If we're only building a package, then there's no need to check things.
+	if [[ ${MERGE_TYPE} == buildonly ]]; then
+		return 0
+	fi
+
+	# The user wants us to leave things be.
+	if [[ -n ${DONT_MOUNT_BOOT} ]]; then
+		return 0
+	fi
+
+	# OK, we want to handle things ourselves.
+	return 1
+}
+
+# @FUNCTION: mount-boot_check_status
+# @INTERNAL
+# @DESCRIPTION:
+# Check if /boot and ESP is sane, i.e., mounted as read-write if on a separate
+# partition.  Die if conditions are not fulfilled.  If nonfatal is used,
+# the function will return a non-zero status instead.
+mount-boot_check_status() {
+	# Get out fast if possible.
+	mount-boot_is_disabled && return 0
+
+	local partition=
+	local part_is_not_mounted=
+	local part_is_read_only=
+	local candidates=( /boot )
+
+	# If system is booted with UEFI, check for ESP as well
+	if [[ -d /sys/firmware/efi ]]; then
+		# Use same candidates for ESP as installkernel and eclean-kernel
+		candidates+=( /efi /boot/efi /boot/EFI )
+	fi
+
+	for partition in ${candidates[@]}; do
+		# note that /dev/BOOT is in the Gentoo default /etc/fstab file
+		local fstabstate=$(awk "!/^[[:blank:]]*#|^\/dev\/BOOT/ && \$2 == \"${partition}\" \
+			{ print 1; exit }" /etc/fstab || die "awk failed")
+
+		if [[ -z ${fstabstate} ]]; then
+			einfo "Assuming you do not have a separate ${partition} partition."
+		else
+			local procstate=$(awk "\$2 == \"${partition}\" { split(\$4, a, \",\"); \
+				for (i in a) if (a[i] ~ /^r[ow]\$/) { print a[i]; break }; exit }" \
+				/proc/mounts || die "awk failed")
+
+			if [[ -z ${procstate} ]]; then
+				eerror "Your ${partition} partition is not mounted"
+				eerror "Please mount it and retry."
+				die -n "${partition} not mounted"
+				part_is_not_mounted=1
+			else
+				if [[ ${procstate} == ro ]]; then
+					eerror "Your ${partition} partition, was detected as being mounted," \
+						"but is mounted read-only."
+					eerror "Please remount it as read-write and retry."
+					die -n "${partition} mounted read-only"
+					part_is_read_only=1
+				else
+					einfo "Your ${partition} partition was detected as being mounted."
+					einfo "Files will be installed there for ${PN} to function correctly."
+				fi
+			fi
+		fi
+	done
+
+	if [[ -n ${part_is_not_mounted} ]]; then
+		return 1
+	elif [[ -n ${part_is_read_only} ]]; then
+		return 2
+	else
+		return 0
+	fi
+}

--- a/eclass/mount-boot.eclass
+++ b/eclass/mount-boot.eclass
@@ -1,90 +1,27 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: mount-boot.eclass
 # @MAINTAINER:
 # base-system@gentoo.org
 # @SUPPORTED_EAPIS: 6 7 8
-# @BLURB: functions for packages that install files into /boot
+# @BLURB: eclass for packages that install files into /boot or the ESP
 # @DESCRIPTION:
-# This eclass is really only useful for bootloaders.
+# This eclass is really only useful for bootloaders and kernel installation.
 #
-# If the live system has a separate /boot partition configured, then this
-# function tries to ensure that it's mounted in rw mode, exiting with an
-# error if it can't.  It does nothing if /boot isn't a separate partition.
+# If the live system has a separate /boot partition or ESP configured, then this
+# function tries to ensure that it's mounted in rw mode, exiting with an error
+# if it can't.  It does nothing if /boot and ESP isn't a separate partition.
+#
+# This eclass exports the functions provided by mount-boot-utils.eclass to
+# the pkg_pretend and pkg_{pre,post}{inst,rm} phases.
 
 case ${EAPI} in
-	6|7|8) ;;
+	7|8) ;;
 	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
 
-# @FUNCTION: mount-boot_is_disabled
-# @INTERNAL
-# @DESCRIPTION:
-# Detect whether the current environment/build settings are such that we do not
-# want to mess with any mounts.
-mount-boot_is_disabled() {
-	# Since this eclass only deals with /boot, skip things when EROOT is active.
-	if [[ ${EROOT:-/} != / ]] ; then
-		return 0
-	fi
-
-	# If we're only building a package, then there's no need to check things.
-	if [[ ${MERGE_TYPE} == buildonly ]] ; then
-		return 0
-	fi
-
-	# The user wants us to leave things be.
-	if [[ -n ${DONT_MOUNT_BOOT} ]] ; then
-		return 0
-	fi
-
-	# OK, we want to handle things ourselves.
-	return 1
-}
-
-# @FUNCTION: mount-boot_check_status
-# @INTERNAL
-# @DESCRIPTION:
-# Check if /boot is sane, i.e., mounted as read-write if on a separate
-# partition.  Die if conditions are not fulfilled.  If nonfatal is used,
-# the function will return a non-zero status instead.
-mount-boot_check_status() {
-	# Get out fast if possible.
-	mount-boot_is_disabled && return 0
-
-	# note that /dev/BOOT is in the Gentoo default /etc/fstab file
-	local fstabstate=$(awk '!/^[[:blank:]]*#|^\/dev\/BOOT/ && $2 == "/boot" \
-		{ print 1; exit }' /etc/fstab || die "awk failed")
-
-	if [[ -z ${fstabstate} ]] ; then
-		einfo "Assuming you do not have a separate /boot partition."
-		return 0
-	fi
-
-	local procstate=$(awk '$2 == "/boot" { split($4, a, ","); \
-		for (i in a) if (a[i] ~ /^r[ow]$/) { print a[i]; break }; exit }' \
-		/proc/mounts || die "awk failed")
-
-	if [[ -z ${procstate} ]] ; then
-		eerror "Your boot partition is not mounted at /boot."
-		eerror "Please mount it and retry."
-		die -n "/boot not mounted"
-		return 1
-	fi
-
-	if [[ ${procstate} == ro ]] ; then
-		eerror "Your boot partition, detected as being mounted at /boot," \
-			"is read-only."
-		eerror "Please remount it as read-write and retry."
-		die -n "/boot mounted read-only"
-		return 2
-	fi
-
-	einfo "Your boot partition was detected as being mounted at /boot."
-	einfo "Files will be installed there for ${PN} to function correctly."
-	return 0
-}
+inherit mount-boot-utils
 
 mount-boot_pkg_pretend() {
 	mount-boot_check_status

--- a/sys-firmware/intel-microcode/intel-microcode-20240531_p20240526-r1.ebuild
+++ b/sys-firmware/intel-microcode/intel-microcode-20240531_p20240526-r1.ebuild
@@ -83,7 +83,15 @@ MICROCODE_SIGNATURES_DEFAULT=""
 # exclude specific CPU: MICROCODE_SIGNATURES="-s !0x00000686"
 
 pkg_pretend() {
-	use initramfs && mount-boot_pkg_pretend
+	if use initramfs; then
+		if [[ -z ${ROOT} ]] && use dist-kernel; then
+			# Check, but don't die because we can fix the problem and then
+			# emerge --config ... to re-run installation.
+			nonfatal mount-boot_check_status
+		else
+			mount-boot_pkg_pretend
+		fi
+	fi
 }
 
 src_prepare() {
@@ -191,7 +199,7 @@ pkg_preinst() {
 	fi
 
 	# Make sure /boot is available if needed.
-	use initramfs && mount-boot_pkg_preinst
+	use initramfs && ! use dist-kernel && mount-boot_pkg_preinst
 
 	local _initramfs_file="${ED}/boot/intel-uc.img"
 
@@ -284,21 +292,22 @@ pkg_preinst() {
 
 pkg_prerm() {
 	# Make sure /boot is mounted so that we can remove /boot/intel-uc.img!
-	use initramfs && mount-boot_pkg_prerm
+	use initramfs && ! use dist-kernel && mount-boot_pkg_prerm
 }
 
 pkg_postrm() {
 	# Don't forget to umount /boot if it was previously mounted by us.
-	use initramfs && mount-boot_pkg_postrm
+	use initramfs && ! use dist-kernel && mount-boot_pkg_postrm
 }
 
 pkg_postinst() {
-	# Don't forget to umount /boot if it was previously mounted by us.
 	if use initramfs; then
 		if [[ -z ${ROOT} ]] && use dist-kernel; then
 			dist-kernel_reinstall_initramfs "${KV_DIR}" "${KV_FULL}"
+		else
+			# Don't forget to umount /boot if it was previously mounted by us.
+			mount-boot_pkg_postinst
 		fi
-		mount-boot_pkg_postinst
 	fi
 
 	# We cannot give detailed information if user is affected or not:

--- a/sys-kernel/linux-firmware/linux-firmware-20240410.ebuild
+++ b/sys-kernel/linux-firmware/linux-firmware-20240410.ebuild
@@ -69,7 +69,15 @@ QA_PREBUILT="*"
 PATCHES=( "${FILESDIR}"/${PN}-copy-firmware-r4.patch )
 
 pkg_pretend() {
-	use initramfs && mount-boot_pkg_pretend
+	if use initramfs; then
+		if [[ -z ${ROOT} ]] && use dist-kernel; then
+			# Check, but don't die because we can fix the problem and then
+			# emerge --config ... to re-run installation.
+			nonfatal mount-boot_check_status
+		else
+			mount-boot_pkg_pretend
+		fi
+	fi
 }
 
 pkg_setup() {
@@ -379,7 +387,7 @@ pkg_preinst() {
 	fi
 
 	# Make sure /boot is available if needed.
-	use initramfs && mount-boot_pkg_preinst
+	use initramfs && ! use dist-kernel && mount-boot_pkg_preinst
 }
 
 pkg_postinst() {
@@ -397,21 +405,22 @@ pkg_postinst() {
 		fi
 	done
 
-	# Don't forget to umount /boot if it was previously mounted by us.
 	if use initramfs; then
 		if [[ -z ${ROOT} ]] && use dist-kernel; then
 			dist-kernel_reinstall_initramfs "${KV_DIR}" "${KV_FULL}"
+		else
+			# Don't forget to umount /boot if it was previously mounted by us.
+			mount-boot_pkg_postinst
 		fi
-		mount-boot_pkg_postinst
 	fi
 }
 
 pkg_prerm() {
 	# Make sure /boot is mounted so that we can remove /boot/amd-uc.img!
-	use initramfs && mount-boot_pkg_prerm
+	use initramfs && ! use dist-kernel && mount-boot_pkg_prerm
 }
 
 pkg_postrm() {
 	# Don't forget to umount /boot if it was previously mounted by us.
-	use initramfs && mount-boot_pkg_postrm
+	use initramfs && ! use dist-kernel && mount-boot_pkg_postrm
 }

--- a/sys-kernel/linux-firmware/linux-firmware-20240513.ebuild
+++ b/sys-kernel/linux-firmware/linux-firmware-20240513.ebuild
@@ -69,7 +69,15 @@ QA_PREBUILT="*"
 PATCHES=( "${FILESDIR}"/${PN}-copy-firmware-r4.patch )
 
 pkg_pretend() {
-	use initramfs && mount-boot_pkg_pretend
+	if use initramfs; then
+		if [[ -z ${ROOT} ]] && use dist-kernel; then
+			# Check, but don't die because we can fix the problem and then
+			# emerge --config ... to re-run installation.
+			nonfatal mount-boot_check_status
+		else
+			mount-boot_pkg_pretend
+		fi
+	fi
 }
 
 pkg_setup() {
@@ -379,7 +387,7 @@ pkg_preinst() {
 	fi
 
 	# Make sure /boot is available if needed.
-	use initramfs && mount-boot_pkg_preinst
+	use initramfs && ! use dist-kernel && mount-boot_pkg_preinst
 }
 
 pkg_postinst() {
@@ -397,21 +405,22 @@ pkg_postinst() {
 		fi
 	done
 
-	# Don't forget to umount /boot if it was previously mounted by us.
 	if use initramfs; then
 		if [[ -z ${ROOT} ]] && use dist-kernel; then
 			dist-kernel_reinstall_initramfs "${KV_DIR}" "${KV_FULL}"
+		else
+			# Don't forget to umount /boot if it was previously mounted by us.
+			mount-boot_pkg_postinst
 		fi
-		mount-boot_pkg_postinst
 	fi
 }
 
 pkg_prerm() {
 	# Make sure /boot is mounted so that we can remove /boot/amd-uc.img!
-	use initramfs && mount-boot_pkg_prerm
+	use initramfs && ! use dist-kernel && mount-boot_pkg_prerm
 }
 
 pkg_postrm() {
 	# Don't forget to umount /boot if it was previously mounted by us.
-	use initramfs && mount-boot_pkg_postrm
+	use initramfs && ! use dist-kernel && mount-boot_pkg_postrm
 }

--- a/sys-kernel/linux-firmware/linux-firmware-20240610-r1.ebuild
+++ b/sys-kernel/linux-firmware/linux-firmware-20240610-r1.ebuild
@@ -69,7 +69,15 @@ QA_PREBUILT="*"
 PATCHES=( "${FILESDIR}"/${PN}-copy-firmware-r4.patch )
 
 pkg_pretend() {
-	use initramfs && mount-boot_pkg_pretend
+	if use initramfs; then
+		if [[ -z ${ROOT} ]] && use dist-kernel; then
+			# Check, but don't die because we can fix the problem and then
+			# emerge --config ... to re-run installation.
+			nonfatal mount-boot_check_status
+		else
+			mount-boot_pkg_pretend
+		fi
+	fi
 }
 
 pkg_setup() {
@@ -374,7 +382,7 @@ pkg_preinst() {
 	fi
 
 	# Make sure /boot is available if needed.
-	use initramfs && mount-boot_pkg_preinst
+	use initramfs && ! use dist-kernel && mount-boot_pkg_preinst
 }
 
 pkg_postinst() {
@@ -392,21 +400,22 @@ pkg_postinst() {
 		fi
 	done
 
-	# Don't forget to umount /boot if it was previously mounted by us.
 	if use initramfs; then
 		if [[ -z ${ROOT} ]] && use dist-kernel; then
 			dist-kernel_reinstall_initramfs "${KV_DIR}" "${KV_FULL}"
+		else
+			# Don't forget to umount /boot if it was previously mounted by us.
+			mount-boot_pkg_postinst
 		fi
-		mount-boot_pkg_postinst
 	fi
 }
 
 pkg_prerm() {
 	# Make sure /boot is mounted so that we can remove /boot/amd-uc.img!
-	use initramfs && mount-boot_pkg_prerm
+	use initramfs && ! use dist-kernel && mount-boot_pkg_prerm
 }
 
 pkg_postrm() {
 	# Don't forget to umount /boot if it was previously mounted by us.
-	use initramfs && mount-boot_pkg_postrm
+	use initramfs && ! use dist-kernel && mount-boot_pkg_postrm
 }

--- a/sys-kernel/linux-firmware/linux-firmware-99999999.ebuild
+++ b/sys-kernel/linux-firmware/linux-firmware-99999999.ebuild
@@ -84,7 +84,15 @@ pkg_setup() {
 }
 
 pkg_pretend() {
-	use initramfs && mount-boot_pkg_pretend
+	if use initramfs; then
+		if [[ -z ${ROOT} ]] && use dist-kernel; then
+			# Check, but don't die because we can fix the problem and then
+			# emerge --config ... to re-run installation.
+			nonfatal mount-boot_check_status
+		else
+			mount-boot_pkg_pretend
+		fi
+	fi
 }
 
 src_unpack() {
@@ -375,7 +383,7 @@ pkg_preinst() {
 	fi
 
 	# Make sure /boot is available if needed.
-	use initramfs && mount-boot_pkg_preinst
+	use initramfs && ! use dist-kernel && mount-boot_pkg_preinst
 }
 
 pkg_postinst() {
@@ -393,21 +401,22 @@ pkg_postinst() {
 		fi
 	done
 
-	# Don't forget to umount /boot if it was previously mounted by us.
 	if use initramfs; then
 		if [[ -z ${ROOT} ]] && use dist-kernel; then
 			dist-kernel_reinstall_initramfs "${KV_DIR}" "${KV_FULL}"
+		else
+			# Don't forget to umount /boot if it was previously mounted by us.
+			mount-boot_pkg_postinst
 		fi
-		mount-boot_pkg_postinst
 	fi
 }
 
 pkg_prerm() {
 	# Make sure /boot is mounted so that we can remove /boot/amd-uc.img!
-	use initramfs && mount-boot_pkg_prerm
+	use initramfs && ! use dist-kernel && mount-boot_pkg_prerm
 }
 
 pkg_postrm() {
 	# Don't forget to umount /boot if it was previously mounted by us.
-	use initramfs && mount-boot_pkg_postrm
+	use initramfs && ! use dist-kernel && mount-boot_pkg_postrm
 }


### PR DESCRIPTION
User facing changes:
- When installing a dist-kernel, we nonfatally check if `/boot` (and ESP) are mounted earlier, in the `pkg_pretend` phase.
- When using dist-kernels, the lack of mounted `/boot` (and ESP) is less noisy when installing CPU microcode packages (many new users ran into this issue)
- Installing an out-of-tree kernel module that should be in the initramfs when using dist-kernels checks for mounted `/boot` (and ESP)
- `/boot` mount checks also check for the ESP on UEFI platforms

CC @gentoo/dist-kernel @mgorny @thesamesam @gentoo/base-system @chithanh @ZeroChaos-  @mpagano @ionenwks 

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
