### PR TITLE
app-editors/vscode,vscodium: Drop unused libcanberra dep

### DIFF
--- a/app-editors/vscodium/vscodium-1.90.0.24158-r1.ebuild
+++ b/app-editors/vscodium/vscodium-1.90.0.24158-r1.ebuild
@@ -5,12 +5,20 @@ EAPI=8
 
 inherit desktop pax-utils xdg optfeature
 
-DESCRIPTION="Multiplatform Visual Studio Code from Microsoft"
-HOMEPAGE="https://code.visualstudio.com"
+# Usage: arch_src_uri <gentoo arch> <upstream arch>
+arch_src_uri() {
+	echo "${1}? (
+		https://github.com/VSCodium/${PN}/releases/download/${PV}/VSCodium-linux-${2}-${PV}.tar.gz
+			-> ${P}-${1}.tar.gz
+	)"
+}
+
+DESCRIPTION="A community-driven, freely-licensed binary distribution of Microsoft's VSCode"
+HOMEPAGE="https://vscodium.com/"
 SRC_URI="
-	amd64? ( https://update.code.visualstudio.com/${PV}/linux-x64/stable -> ${P}-amd64.tar.gz )
-	arm? ( https://update.code.visualstudio.com/${PV}/linux-armhf/stable -> ${P}-arm.tar.gz )
-	arm64? ( https://update.code.visualstudio.com/${PV}/linux-arm64/stable -> ${P}-arm64.tar.gz )
+	$(arch_src_uri amd64 x64)
+	$(arch_src_uri arm armhf)
+	$(arch_src_uri arm64 arm64)
 "
 S="${WORKDIR}"
 
@@ -23,7 +31,6 @@ LICENSE="
 	CC-BY-4.0
 	ISC
 	LGPL-2.1+
-	Microsoft-vscode
 	MIT
 	MPL-2.0
 	openssl
@@ -36,7 +43,7 @@ LICENSE="
 SLOT="0"
 KEYWORDS="-* amd64 ~arm ~arm64"
 IUSE="egl kerberos wayland"
-RESTRICT="mirror strip bindist"
+RESTRICT="strip bindist"
 
 RDEPEND="
 	>=app-accessibility/at-spi2-core-2.46.0:2
@@ -47,10 +54,10 @@ RDEPEND="
 	dev-libs/nspr
 	dev-libs/nss
 	media-libs/alsa-lib
-	media-libs/libcanberra[gtk3]
 	media-libs/libglvnd
 	media-libs/mesa
 	net-misc/curl
+	net-print/cups
 	sys-apps/dbus
 	sys-libs/zlib
 	sys-process/lsof
@@ -75,58 +82,47 @@ RDEPEND="
 QA_PREBUILT="*"
 
 src_install() {
-	if use amd64; then
-		cd "${WORKDIR}/VSCode-linux-x64" || die
-	elif use arm; then
-		cd "${WORKDIR}/VSCode-linux-armhf" || die
-	elif use arm64; then
-		cd "${WORKDIR}/VSCode-linux-arm64" || die
-	else
-		die "Visual Studio Code only supports amd64, arm and arm64"
-	fi
-
-	# Cleanup
-	rm -r ./resources/app/ThirdPartyNotices.txt || die
-
-	# Disable update server
-	sed -e "/updateUrl/d" -i ./resources/app/product.json || die
+	# Cleanup license file - it exists only in amd64 tarball
+	rm -f "${S}/resources/app/LICENSE.txt" || die
 
 	if ! use kerberos; then
-		rm -r ./resources/app/node_modules.asar.unpacked/kerberos || die
+		rm -rf "${S}/resources/app/node_modules.asar.unpacked/kerberos" || die
 	fi
 
 	# Install
-	pax-mark m code
+	pax-mark m codium
 	mkdir -p "${ED}/opt/${PN}" || die
 	cp -r . "${ED}/opt/${PN}" || die
 	fperms 4711 /opt/${PN}/chrome-sandbox
 
-	dosym -r "/opt/${PN}/bin/code" "usr/bin/vscode"
-	dosym -r "/opt/${PN}/bin/code" "usr/bin/code"
+	dosym -r "/opt/${PN}/bin/codium" "usr/bin/vscodium"
+	dosym -r "/opt/${PN}/bin/codium" "usr/bin/codium"
 
 	local EXEC_EXTRA_FLAGS=()
 	if use wayland; then
-		EXEC_EXTRA_FLAGS+=( "--ozone-platform-hint=auto" "--enable-wayland-ime" )
+		EXEC_EXTRA_FLAGS+=( "--ozone-platform-hint=auto" )
 	fi
 	if use egl; then
 		EXEC_EXTRA_FLAGS+=( "--use-gl=egl" )
 	fi
 
 	sed "s|@exec_extra_flags@|${EXEC_EXTRA_FLAGS[*]}|g" \
-		"${FILESDIR}/code-url-handler.desktop" \
-		> "${T}/code-url-handler.desktop" || die
+		"${FILESDIR}/vscodium-url-handler.desktop" \
+		> "${T}/vscodium-url-handler.desktop" || die
 
 	sed "s|@exec_extra_flags@|${EXEC_EXTRA_FLAGS[*]}|g" \
-		"${FILESDIR}/code.desktop" \
-		> "${T}/code.desktop" || die
+		"${FILESDIR}/vscodium.desktop" \
+		> "${T}/vscodium.desktop" || die
 
-	domenu "${T}/code.desktop"
-	domenu "${T}/code-url-handler.desktop"
-	newicon "resources/app/resources/linux/code.png" "vscode.png"
+	domenu "${T}/vscodium.desktop"
+	domenu "${T}/vscodium-url-handler.desktop"
+	newicon "resources/app/resources/linux/code.png" "vscodium.png"
 }
 
 pkg_postinst() {
 	xdg_pkg_postinst
+	elog "When compared to the regular VSCode, VSCodium has a few quirks"
+	elog "More information at: https://github.com/VSCodium/vscodium/blob/master/DOCS.md"
 	optfeature "desktop notifications" x11-libs/libnotify
 	optfeature "keyring support inside vscode" "virtual/secret-service"
 }

--- a/app-editors/vscodium/vscodium-1.90.1.24165-r1.ebuild
+++ b/app-editors/vscodium/vscodium-1.90.1.24165-r1.ebuild
@@ -5,12 +5,20 @@ EAPI=8
 
 inherit desktop pax-utils xdg optfeature
 
-DESCRIPTION="Multiplatform Visual Studio Code from Microsoft"
-HOMEPAGE="https://code.visualstudio.com"
+# Usage: arch_src_uri <gentoo arch> <upstream arch>
+arch_src_uri() {
+	echo "${1}? (
+		https://github.com/VSCodium/${PN}/releases/download/${PV}/VSCodium-linux-${2}-${PV}.tar.gz
+			-> ${P}-${1}.tar.gz
+	)"
+}
+
+DESCRIPTION="A community-driven, freely-licensed binary distribution of Microsoft's VSCode"
+HOMEPAGE="https://vscodium.com/"
 SRC_URI="
-	amd64? ( https://update.code.visualstudio.com/${PV}/linux-x64/stable -> ${P}-amd64.tar.gz )
-	arm? ( https://update.code.visualstudio.com/${PV}/linux-armhf/stable -> ${P}-arm.tar.gz )
-	arm64? ( https://update.code.visualstudio.com/${PV}/linux-arm64/stable -> ${P}-arm64.tar.gz )
+	$(arch_src_uri amd64 x64)
+	$(arch_src_uri arm armhf)
+	$(arch_src_uri arm64 arm64)
 "
 S="${WORKDIR}"
 
@@ -23,7 +31,6 @@ LICENSE="
 	CC-BY-4.0
 	ISC
 	LGPL-2.1+
-	Microsoft-vscode
 	MIT
 	MPL-2.0
 	openssl
@@ -36,7 +43,7 @@ LICENSE="
 SLOT="0"
 KEYWORDS="-* amd64 ~arm ~arm64"
 IUSE="egl kerberos wayland"
-RESTRICT="mirror strip bindist"
+RESTRICT="strip bindist"
 
 RDEPEND="
 	>=app-accessibility/at-spi2-core-2.46.0:2
@@ -47,10 +54,10 @@ RDEPEND="
 	dev-libs/nspr
 	dev-libs/nss
 	media-libs/alsa-lib
-	media-libs/libcanberra[gtk3]
 	media-libs/libglvnd
 	media-libs/mesa
 	net-misc/curl
+	net-print/cups
 	sys-apps/dbus
 	sys-libs/zlib
 	sys-process/lsof
@@ -75,58 +82,47 @@ RDEPEND="
 QA_PREBUILT="*"
 
 src_install() {
-	if use amd64; then
-		cd "${WORKDIR}/VSCode-linux-x64" || die
-	elif use arm; then
-		cd "${WORKDIR}/VSCode-linux-armhf" || die
-	elif use arm64; then
-		cd "${WORKDIR}/VSCode-linux-arm64" || die
-	else
-		die "Visual Studio Code only supports amd64, arm and arm64"
-	fi
-
-	# Cleanup
-	rm -r ./resources/app/ThirdPartyNotices.txt || die
-
-	# Disable update server
-	sed -e "/updateUrl/d" -i ./resources/app/product.json || die
+	# Cleanup license file - it exists only in amd64 tarball
+	rm -f "${S}/resources/app/LICENSE.txt" || die
 
 	if ! use kerberos; then
-		rm -r ./resources/app/node_modules.asar.unpacked/kerberos || die
+		rm -rf "${S}/resources/app/node_modules.asar.unpacked/kerberos" || die
 	fi
 
 	# Install
-	pax-mark m code
+	pax-mark m codium
 	mkdir -p "${ED}/opt/${PN}" || die
 	cp -r . "${ED}/opt/${PN}" || die
 	fperms 4711 /opt/${PN}/chrome-sandbox
 
-	dosym -r "/opt/${PN}/bin/code" "usr/bin/vscode"
-	dosym -r "/opt/${PN}/bin/code" "usr/bin/code"
+	dosym -r "/opt/${PN}/bin/codium" "usr/bin/vscodium"
+	dosym -r "/opt/${PN}/bin/codium" "usr/bin/codium"
 
 	local EXEC_EXTRA_FLAGS=()
 	if use wayland; then
-		EXEC_EXTRA_FLAGS+=( "--ozone-platform-hint=auto" "--enable-wayland-ime" )
+		EXEC_EXTRA_FLAGS+=( "--ozone-platform-hint=auto" )
 	fi
 	if use egl; then
 		EXEC_EXTRA_FLAGS+=( "--use-gl=egl" )
 	fi
 
 	sed "s|@exec_extra_flags@|${EXEC_EXTRA_FLAGS[*]}|g" \
-		"${FILESDIR}/code-url-handler.desktop" \
-		> "${T}/code-url-handler.desktop" || die
+		"${FILESDIR}/vscodium-url-handler.desktop" \
+		> "${T}/vscodium-url-handler.desktop" || die
 
 	sed "s|@exec_extra_flags@|${EXEC_EXTRA_FLAGS[*]}|g" \
-		"${FILESDIR}/code.desktop" \
-		> "${T}/code.desktop" || die
+		"${FILESDIR}/vscodium.desktop" \
+		> "${T}/vscodium.desktop" || die
 
-	domenu "${T}/code.desktop"
-	domenu "${T}/code-url-handler.desktop"
-	newicon "resources/app/resources/linux/code.png" "vscode.png"
+	domenu "${T}/vscodium.desktop"
+	domenu "${T}/vscodium-url-handler.desktop"
+	newicon "resources/app/resources/linux/code.png" "vscodium.png"
 }
 
 pkg_postinst() {
 	xdg_pkg_postinst
+	elog "When compared to the regular VSCode, VSCodium has a few quirks"
+	elog "More information at: https://github.com/VSCodium/vscodium/blob/master/DOCS.md"
 	optfeature "desktop notifications" x11-libs/libnotify
 	optfeature "keyring support inside vscode" "virtual/secret-service"
 }


### PR DESCRIPTION
This dependency is not actually used:

https://github.com/search?q=repo%3Amicrosoft%2Fvscode%20canberra&type=code

The only place it is mentioned is in a CI config, but it isn't used in the actual source code anywhere.

PR Discussion: https://github.com/gentoo/gentoo/pull/33221

Bug: https://bugs.gentoo.org/859406

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
