### PR TITLE
media-video/celluloid: add Codeberg remote-id

### DIFF
--- a/media-video/celluloid/metadata.xml
+++ b/media-video/celluloid/metadata.xml
@@ -7,5 +7,6 @@
 </maintainer>
 <upstream>
 	<remote-id type="github">celluloid-player/celluloid</remote-id>
+	<remote-id type="codeberg">celluloid-player/celluloid</remote-id>
 </upstream>
 </pkgmetadata>


### PR DESCRIPTION
Introduced by the upstream in https://github.com/celluloid-player/celluloid/commit/2a46ef63ee8f70e32a01c5cb5a1fed8d946db152.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
