### PR TITLE
sys-auth/nss-pam-ldapd: Fix build on clang

### DIFF
--- a/sys-auth/nss-pam-ldapd/files/nss-pam-ldapd-0.9.12-configure-CFLAGS-decontamination.patch
+++ b/sys-auth/nss-pam-ldapd/files/nss-pam-ldapd-0.9.12-configure-CFLAGS-decontamination.patch
@@ -1,0 +1,55 @@
+diff --git a/configure.ac b/configure.ac
+index 12bf35c..beb13bf 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -101,39 +101,25 @@ then
+ fi
+ 
+ # check for debugging options
++DEBUG_CFLAGS=""
+ AC_ARG_ENABLE(debug,
+               AS_HELP_STRING([--enable-debug],
+                              [enable extensive debugging and logging]),
+-              [if test "x$enableval" != "xno" ; then CFLAGS="-g -DDEBUG $CFLAGS" ; fi])
++              [AS_IF([test "x$enableval" != "xno"],
++		    [AX_APPEND_COMPILE_FLAGS([-g -DDEBUG],[DEBUG_CFLAGS])]
++              )])
++AC_SUBST([DEBUG_CFLAGS])
+ 
+ # check for extra compiler warnings
+-DESIRED_CFLAGS=""
++EXTRA_CFLAGS=""
+ AC_ARG_ENABLE(warnings,
+               AS_HELP_STRING([--enable-warnings],
+                              [enable extra compiler warnings (gcc)]),
+-              [if test "x$enableval" != "no"
+-               then
+-                 CFLAGS="$CFLAGS -pedantic -Wall -Wshadow -Wpointer-arith -Wcast-align -Wstrict-prototypes -Wmissing-prototypes -Wnested-externs -Waggregate-return -Wmissing-declarations -Wunused -Wformat=2 -Wswitch-default -Wswitch-enum -Wfloat-equal -Wbad-function-cast -Wredundant-decls"
+-                 DESIRED_CFLAGS="$DESIRED_CFLAGS -Wextra -Wdeclaration-after-statement -Werror-implicit-function-declaration -Werror=implicit"
+-               fi])
+-test_gcc_flag() {
+-  AC_LANG_CONFTEST([AC_LANG_PROGRAM()])
+-  $CC -c conftest.c $CFLAGS $@ > /dev/null 2> /dev/null
+-  ret=$?
+-  rm -f conftest.o
+-  return $ret
+-}
+-for flag in $DESIRED_CFLAGS
+-do
+-  AC_MSG_CHECKING([whether $CC accepts $flag])
+-  if test_gcc_flag $flag
+-  then
+-    CFLAGS="$CFLAGS $flag"
+-    AC_MSG_RESULT([yes])
+-  else
+-    AC_MSG_RESULT([no])
+-  fi
+-done
++              [AS_IF([test "x$enableval" != "xno"],[
++                 AX_APPEND_COMPILE_FLAGS([-pedantic -Wall -Wshadow -Wpointer-arith -Wcast-align -Wstrict-prototypes -Wmissing-prototypes -Wnested-externs -Waggregate-return -Wmissing-declarations -Wunused -Wformat=2 -Wswitch-default -Wswitch-enum -Wfloat-equal -Wbad-function-cast -Wredundant-decls],[EXTRA_CFLAGS],[-Werror])
++                 AX_APPEND_COMPILE_FLAGS([-Wextra -Wdeclaration-after-statement -Werror-implicit-function-declaration -Werror=implicit],[EXTRA_CFLAGS],[-Werror])
++               ])])
++AC_SUBST([EXTRA_CFLAGS])
+ 
+ # check for Position Independent Code compiler option
+ PIC_CFLAGS=""

--- a/sys-auth/nss-pam-ldapd/nss-pam-ldapd-0.9.12-r4.ebuild
+++ b/sys-auth/nss-pam-ldapd/nss-pam-ldapd-0.9.12-r4.ebuild
@@ -52,6 +52,7 @@ PATCHES=(
 	"${FILESDIR}"/nss-pam-ldapd-0.9.11-tests.patch
 	"${FILESDIR}"/nss-pam-ldapd-0.9.11-tests-py39.patch
 	"${FILESDIR}"/nss-pam-ldapd-0.9.12-netdb-defines.patch
+	"${FILESDIR}"/nss-pam-ldapd-0.9.12-configure-CFLAGS-decontamination.patch
 )
 
 pkg_setup() {
@@ -63,6 +64,10 @@ src_prepare() {
 
 	touch pynslcd/__init__.py || die "Could not create __init__.py for pynslcd"
 	mv pynslcd/pynslcd.py pynslcd/main.py || die
+
+        find "${S}" -name Makefile.am -exec \
+        sed -e '/^AM_CFLAGS/ s/$/ \$(DEBUG_CFLAGS) \$(EXTRA_CFLAGS)/g' \
+        -i {} \; || die
 
 	eautoreconf
 }


### PR DESCRIPTION
Acutally, it shouldn't build at all. The problem here is AX_PTHREAD. It determines if the compile errors out on an unrecognized option, and if it does not, it adds -WError to its test. gcc does error out, clang does not. The config "pollutes" CFLAGS and those get passed to AX_PTHREAD. Because of --enable-warnings, one of those flags is -Wunused, when combined with -WError is causes the AX_PTHREAD tests to fail. 

My solution is to place the debugging and warning CFLAGS in DEBUG_CFLAGS and EXTRA_CFLAGS, then modify the Makefiles (with sed) to add those values to AM_CFLAGS. 

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
