### PR TITLE
media-libs/libprojectm: update EAPI 7 -> 8, fix some packaging bugs

### DIFF
--- a/media-libs/libprojectm/files/libprojectm-3.1.12-GL_SMOOTH.patch
+++ b/media-libs/libprojectm/files/libprojectm-3.1.12-GL_SMOOTH.patch
@@ -1,0 +1,13 @@
+Unable to replicate error myself, but fix for https://bugs.gentoo.org/792204
+from https://github.com/projectM-visualizer/projectm/issues/449
+diff '--color=auto' -ru a/src/projectM-qt/qprojectmwidget.hpp b/src/projectM-qt/qprojectmwidget.hpp
+--- a/src/projectM-qt/qprojectmwidget.hpp	2024-06-26 10:48:30.825008203 -0000
++++ b/src/projectM-qt/qprojectmwidget.hpp	2024-06-26 10:49:03.265800570 -0000
+@@ -23,6 +23,7 @@
+ #define QPROJECTM_WIDGET_HPP
+ 
+ #include <iostream>
++#include <GL/gl.h>
+ #include "qprojectm.hpp"
+ #include <QGLWidget>
+ #include <QMutex>

--- a/media-libs/libprojectm/libprojectm-3.1.12-r2.ebuild
+++ b/media-libs/libprojectm/libprojectm-3.1.12-r2.ebuild
@@ -1,0 +1,74 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools
+
+DESCRIPTION="A graphical music visualization plugin similar to milkdrop"
+HOMEPAGE="https://github.com/projectM-visualizer/projectm"
+
+if [[ ${PV} == *9999 ]] ; then
+	EGIT_REPO_URI="https://github.com/projectM-visualizer/projectm.git"
+	inherit git-r3
+else
+	MY_PV="${PV/_/-}"
+	SRC_URI="https://github.com/projectM-visualizer/projectm/archive/v${MY_PV}.tar.gz -> ${P}.tar.gz"
+	KEYWORDS="amd64 arm arm64 ~loong ppc ppc64 ~riscv sparc x86"
+	S=${WORKDIR}/projectm-${MY_PV}/
+fi
+
+LICENSE="LGPL-2"
+SLOT="0/2"
+IUSE="gles2 jack pulseaudio qt5 sdl"
+REQUIRED_USE="
+	jack? ( qt5 )
+	pulseaudio? ( qt5 )
+"
+
+RDEPEND="
+	media-libs/glm
+	media-libs/libglvnd[X(+)]
+	jack? (
+		virtual/jack
+	)
+	qt5? (
+		dev-qt/qtcore:5
+		dev-qt/qtdeclarative:5
+		dev-qt/qtgui:5
+		dev-qt/qtwidgets:5
+		dev-qt/qtopengl:5
+	)
+	pulseaudio? (
+		media-libs/libpulse
+	)
+	sdl? ( >=media-libs/libsdl2-2.0.5 )
+	sys-libs/zlib"
+
+DEPEND="${RDEPEND}"
+BDEPEND="
+	virtual/pkgconfig
+"
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_configure() {
+	local myeconfargs=(
+		$(use_enable gles2 gles)
+		$(use_enable jack)
+		$(use_enable qt5 qt)
+		$(use_enable pulseaudio)
+		$(use_enable sdl)
+		--enable-emscripten=no
+	)
+	econf "${myeconfargs[@]}"
+}
+
+src_install() {
+	default
+	find "${ED}" -name '*.la' -delete || die
+	find "${ED}" -name '*.a' -delete || die
+}


### PR DESCRIPTION
As changes are trivial, and should not break anything, not keywording for testing Missing include prevents compilation only on aarch64, apparently

Closes: https://bugs.gentoo.org/891343
Closes: https://bugs.gentoo.org/792204


---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
