### PR TITLE
dev-util/roctracer: bugfixes for 6.1.1

### DIFF
--- a/dev-util/roctracer/roctracer-6.1.1.ebuild
+++ b/dev-util/roctracer/roctracer-6.1.1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..13} )
 LLVM_COMPAT=( 18 )
 ROCM_VERSION=${PV}
 
@@ -41,6 +41,10 @@ python_check_deps() {
 		"dev-python/ply[${PYTHON_USEDEP}]"
 }
 
+pkg_setup() {
+	python-any-r1_pkg_setup
+}
+
 src_prepare() {
 	cmake_src_prepare
 
@@ -56,6 +60,9 @@ src_prepare() {
 
 	# Fix search path for HIP cmake
 	sed -e "s,\${ROCM_PATH}/lib/cmake,/usr/$(get_libdir)/cmake,g" -i test/CMakeLists.txt || die
+
+	# bug #892732
+	sed -i -e 's/-Werror//' CMakeLists.txt || die
 }
 
 src_configure() {
@@ -63,6 +70,7 @@ src_configure() {
 		-DCMAKE_MODULE_PATH="${EPREFIX}/usr/$(get_libdir)/cmake/hip"
 		-DFILE_REORG_BACKWARD_COMPATIBILITY=OFF
 		-DWITH_TESTS=$(usex test)
+		-DPython3_EXECUTABLE="${PYTHON}"
 	)
 	use test && mycmakeargs+=(
 		-DHIP_ROOT_DIR="${EPREFIX}/usr"


### PR DESCRIPTION
* specify python executable for cmake, otherwise it uses latest
* remove -Werror from hardcoded flags
* enable py3.13 (not a bug, just for future)

Closes: https://bugs.gentoo.org/934969
Closes: https://bugs.gentoo.org/892732

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
