### PR TITLE
sci-libs/rpp: fix compilation with USE=test

### DIFF
--- a/sci-libs/rpp/rpp-6.1.1.ebuild
+++ b/sci-libs/rpp/rpp-6.1.1.ebuild
@@ -29,7 +29,10 @@ DEPEND="${RDEPEND}"
 BDEPEND="
 	>=dev-build/cmake-3.22
 	>=dev-libs/half-1.12.0-r1
-	test? ( dev-cpp/gtest )
+	test? (
+		dev-cpp/gtest
+		media-libs/opencv:=
+	)
 "
 
 IUSE="cpu_flags_x86_avx2 cpu_flags_x86_fma3 cpu_flags_x86_f16c test"
@@ -54,7 +57,10 @@ src_prepare() {
 		-i CMakeLists.txt || die
 
 	cmake_src_prepare
-	use test && rcc_test_wrapper cmake_src_prepare
+	if use test; then
+		local PATCHES=()
+		rcc_test_wrapper cmake_src_prepare
+	fi
 }
 
 src_configure() {


### PR DESCRIPTION
* fixes "patch -p1 failed with rpp-6.1.1-skip-install-license.patch"
* tests require opencv

Closes: https://bugs.gentoo.org/934981

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
