### PR TITLE
dev-debug/gdb: support for AMD GPU debugging via USE=rocm

### DIFF
--- a/dev-debug/gdb/gdb-15.1.ebuild
+++ b/dev-debug/gdb/gdb-15.1.ebuild
@@ -72,11 +72,14 @@ SRC_URI="
 
 LICENSE="GPL-3+ LGPL-2.1+"
 SLOT="0"
-IUSE="cet debuginfod guile lzma multitarget nls +python +server sim source-highlight test vanilla xml xxhash zstd"
+IUSE="cet debuginfod guile lzma multitarget nls +python rocm +server sim source-highlight test vanilla xml xxhash zstd"
 if [[ -n ${REGULAR_RELEASE} ]] ; then
 	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~x64-macos ~x64-solaris"
 fi
-REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
+REQUIRED_USE="
+	python? ( ${PYTHON_REQUIRED_USE} )
+	rocm? ( multitarget )
+"
 RESTRICT="!test? ( test )"
 
 RDEPEND="
@@ -93,6 +96,7 @@ RDEPEND="
 	python? ( ${PYTHON_DEPS} )
 	guile? ( >=dev-scheme/guile-2.0 )
 	xml? ( dev-libs/expat )
+	rocm? ( dev-libs/rocdbgapi )
 	source-highlight? (
 		dev-util/source-highlight
 	)
@@ -208,6 +212,7 @@ src_configure() {
 		--without-zlib
 		--with-system-zlib
 		--with-separate-debug-dir="${EPREFIX}"/usr/lib/debug
+		--with-amd-dbgapi=$(usex rocm)
 		$(use_with xml expat)
 		$(use_with lzma)
 		$(use_enable nls)

--- a/dev-debug/gdb/gdb-9999.ebuild
+++ b/dev-debug/gdb/gdb-9999.ebuild
@@ -72,11 +72,14 @@ SRC_URI="
 
 LICENSE="GPL-3+ LGPL-2.1+"
 SLOT="0"
-IUSE="cet debuginfod guile lzma multitarget nls +python +server sim source-highlight test vanilla xml xxhash zstd"
+IUSE="cet debuginfod guile lzma multitarget nls +python rocm +server sim source-highlight test vanilla xml xxhash zstd"
 if [[ -n ${REGULAR_RELEASE} ]] ; then
 	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~x64-macos ~x64-solaris"
 fi
-REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
+REQUIRED_USE="
+	python? ( ${PYTHON_REQUIRED_USE} )
+	rocm? ( multitarget )
+"
 RESTRICT="!test? ( test )"
 
 RDEPEND="
@@ -93,6 +96,7 @@ RDEPEND="
 	python? ( ${PYTHON_DEPS} )
 	guile? ( >=dev-scheme/guile-2.0 )
 	xml? ( dev-libs/expat )
+	rocm? ( dev-libs/rocdbgapi )
 	source-highlight? (
 		dev-util/source-highlight
 	)
@@ -216,6 +220,7 @@ src_configure() {
 		--without-zlib
 		--with-system-zlib
 		--with-separate-debug-dir="${EPREFIX}"/usr/lib/debug
+		--with-amd-dbgapi=$(usex rocm)
 		$(use_with xml expat)
 		$(use_with lzma)
 		$(use_enable nls)

--- a/dev-debug/gdb/metadata.xml
+++ b/dev-debug/gdb/metadata.xml
@@ -10,6 +10,7 @@
 		<flag name="lzma">Support lzma compression in ELF debug info</flag>
 		<flag name="multitarget">Support all known targets in one gdb binary</flag>
 		<flag name="python">Enable support for the new internal scripting language, as well as extended pretty printers</flag>
+		<flag name="rocm">Enable support for AMD GPU debugging via <pkg>dev-libs/rocdbgapi</pkg></flag>
 		<flag name="server">Install the "gdbserver" program (useful for embedded/remote targets)</flag>
 		<flag name="sim">Build gdb's simulators for various hardware platforms. See https://sourceware.org/gdb/wiki/Sim.</flag>
 		<flag name="source-highlight">Enable listing highlighting via <pkg>dev-util/source-highlight</pkg></flag>

--- a/profiles/arch/amd64/package.use.mask
+++ b/profiles/arch/amd64/package.use.mask
@@ -17,6 +17,10 @@
 
 #--- END OF EXAMPLES ---
 
+# Sv. Lockal <lockalsash@gmail.com> (2024-07-28)
+# Masked in base profile, supported on this arch
+dev-debug/gdb -rocm
+
 # orbea <orbea@riseup.net> (2024-07-19)
 # Unmask the dynarec flag which has amd64 asm.
 games-emulation/rmg -dynarec

--- a/profiles/base/package.use.mask
+++ b/profiles/base/package.use.mask
@@ -6,6 +6,10 @@
 # This file is only for generic masks. For arch-specific masks (i.e.
 # mask everywhere, unmask on arch/*) use arch/base.
 
+# Sv. Lockal <lockalsash@gmail.com> (2024-07-28)
+# Only available for amd64.
+dev-debug/gdb rocm
+
 # Viorel Munteanu <ceamac@gentoo.org> (2024-07-26)
 # Branch 7.1 needs a new BDEPEND for doc
 >=app-emulation/virtualbox-7.1 doc


### PR DESCRIPTION
This adds ability to debug AMD GPU code with recently added `dev-libs/rocdbgapi` library. This feature was introduced in GDB 13 and documented at:
* https://sourceware.org/gdb/current/onlinedocs/gdb.html/AMD-GPU.html
* https://sourceware.org/git/?p=binutils-gdb.git;a=commit;h=18b4d0736bc570c6d2e3e5f6ebc2ad4617d93847

As described in binutils-gdb commit message, this feature requires `--enable-targets=all`, and if no `--with-amd-dbgapi=yes/no` specified, it tries to probe for library and enable if found (which is undesirable for Gentoo), therefore it is better to set this flag explicitly.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
