### PR TITLE
kernel-{build,release}.eclass: make kernel install paths match release

### DIFF
--- a/eclass/kernel-build.eclass
+++ b/eclass/kernel-build.eclass
@@ -239,6 +239,19 @@ kernel-build_src_configure() {
 		local relfile=${WORKDIR}/build/include/config/kernel.release
 		KV_FULL=$(<"${relfile}") || die
 	fi
+
+	# Make sure we are about to build the correct kernel
+	if [[ ${PV} != *9999 ]]; then
+		local expected_ver=$(dist-kernel_PV_to_KV "${PV}")
+
+		if [[ ${KV_FULL} != ${expected_ver}* ]]; then
+			eerror "Kernel version does not match PV!"
+			eerror "Source version: ${KV_FULL}"
+			eerror "Expected (PV*): ${expected_ver}*"
+			eerror "Please ensure you are applying the correct patchset."
+			die "Kernel version mismatch: got ${KV_FULL}, expected ${expected_ver}*"
+		fi
+	fi
 }
 
 # @FUNCTION: kernel-build_src_compile

--- a/eclass/kernel-build.eclass
+++ b/eclass/kernel-build.eclass
@@ -235,14 +235,22 @@ kernel-build_src_configure() {
 	cp -pR "${WORKDIR}"/modprep "${WORKDIR}"/build || die
 
 	# Now that we have a release file, set KV_FULL
+	local relfile=${WORKDIR}/build/include/config/kernel.release
 	if [[ -z ${KV_FULL} ]]; then
-		local relfile=${WORKDIR}/build/include/config/kernel.release
 		KV_FULL=$(<"${relfile}") || die
 	fi
 
 	# Make sure we are about to build the correct kernel
 	if [[ ${PV} != *9999 ]]; then
 		local expected_ver=$(dist-kernel_PV_to_KV "${PV}")
+		local expected_rel=$(<"${relfile}")
+
+		if [[ ${KV_FULL} != ${expected_rel} ]]; then
+			eerror "KV_FULL mismatch!"
+			eerror "KV_FULL:  ${KV_FULL}"
+			eerror "Expected: ${expected_rel}"
+			die "KV_FULL mismatch: got ${KV_FULL}, expected ${expected_rel}"
+		fi
 
 		if [[ ${KV_FULL} != ${expected_ver}* ]]; then
 			eerror "Kernel version does not match PV!"

--- a/eclass/kernel-install.eclass
+++ b/eclass/kernel-install.eclass
@@ -595,11 +595,11 @@ kernel-install_pkg_preinst() {
 		local expected_ver=$(dist-kernel_PV_to_KV "${PV}")
 
 		if [[ ${KV_FULL} != ${expected_ver}* ]]; then
-			eerror "Kernel release mismatch!"
-			eerror "  expected (PV): ${expected_ver}*"
-			eerror "          found: ${KV_FULL}"
-			eerror "Please verify that you are applying the correct patches."
-			die "Kernel release mismatch (${KV_FULL} instead of ${expected_ver}*)"
+			eerror "Kernel version does not match PV!"
+			eerror "Source version: ${KV_FULL}"
+			eerror "Expected (PV*): ${expected_ver}*"
+			eerror "Please ensure you are applying the correct patchset."
+			die "Kernel version mismatch: got ${KV_FULL}, expected ${expected_ver}*"
 		fi
 	fi
 


### PR DESCRIPTION
This aligns the kernel install directory path, modules path, and `eselect kernel` name, and fixes a subtle issue with how Catalyst passes the kernel release to dracut while we're at it. It also eliminates most of the duplicated sourcing of the kernel release string in both eclasses.

Not sure if I have gotten the order of KV_FULL sets quite right, but tested with a dist-kernel and a bin kernel and both
worked as expected, including `emerge --config ` on both.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
