### PR TITLE
dev-db/hsqldb: avoid to install hsqldbtest.jar

### DIFF
--- a/dev-db/hsqldb/hsqldb-1.8.1.3-r5.ebuild
+++ b/dev-db/hsqldb/hsqldb-1.8.1.3-r5.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 JAVA_PKG_IUSE="doc source test"
 
@@ -11,8 +11,9 @@ MY_PV=$(ver_rs 1- '_')
 MY_P="${PN}_${MY_PV}"
 
 DESCRIPTION="The leading SQL relational database engine written in Java"
-HOMEPAGE="http://hsqldb.org"
+HOMEPAGE="https://hsqldb.org"
 SRC_URI="https://downloads.sourceforge.net/${PN}/${MY_P}.zip"
+S="${WORKDIR}/${PN}"
 
 LICENSE="BSD GPL-2"
 SLOT="0"
@@ -33,8 +34,6 @@ PATCHES=(
 	"${FILESDIR}/resolve-config-softlinks.patch"
 	"${FILESDIR}/${P}-java7.patch"
 )
-
-S="${WORKDIR}/${PN}"
 
 HSQLDB_JAR=/usr/share/hsqldb/lib/hsqldb.jar
 HSQLDB_HOME=/var/lib/hsqldb
@@ -90,7 +89,7 @@ src_test() {
 }
 
 src_install() {
-	java-pkg_dojar lib/hsql*.jar
+	java-pkg_dojar lib/hsql{db{,util},tool,jdbc}.jar
 
 	if use doc; then
 		dodoc doc/*.txt


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/896402

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
