### PR TITLE
media-gfx/qrencode: Added optfeature message for code decodification

### DIFF
--- a/media-gfx/qrencode/qrencode-4.1.1-r1.ebuild
+++ b/media-gfx/qrencode/qrencode-4.1.1-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit multilib-minimal
+inherit multilib-minimal optfeature
 
 DESCRIPTION="C library for encoding data in a QR Code symbol"
 HOMEPAGE="https://fukuchi.org/works/qrencode/"
@@ -40,4 +40,8 @@ multilib_src_test() {
 multilib_src_install() {
 	default
 	find "${ED}" -name '*.la' -delete || die
+}
+
+pkg_postinst() {
+	optfeature "Install to decode the generated QR codes" media-gfx/zbar
 }


### PR DESCRIPTION
<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.

---

qrencode only encodes text to Qrcodes. AFAIK, it does not decode them.
media-gfx/zbar provides "zbarimg" which is able to decode qr codes. 
I believe that most people that encode message into QR-codes would want to know how to decode them (I am certainly in this camp :sweat_smile: ). Hence the optfeature.

A USE flag seemed way to overkill.

Would love to get some feedback.