### PR TITLE
dev-python/pillow: fix build with USE="-truetype"

### DIFF
--- a/dev-python/pillow/pillow-10.3.0.ebuild
+++ b/dev-python/pillow/pillow-10.3.0.ebuild
@@ -82,8 +82,8 @@ python_configure_all() {
 		[build_ext]
 		debug = True
 		disable_platform_guessing = True
-		vendor_raqm = False
-		vendor_fribidi = False
+		$(usex truetype "vendor_raqm = False" "") # BUG 935124
+		$(usex truetype "vendor_fribidi = False" "") # ditto
 		$(usepil truetype)_freetype = True
 		$(usepil jpeg)_jpeg = True
 		$(usepil jpeg2k)_jpeg2000 = True


### PR DESCRIPTION
Build fails if USE="-truetype" due to implied flags conflicing with the vendor_{raqm,fribidi} = False flags. Guard them behind a usex so that they are only enabled if USE="truetype"

Bug: https://bugs.gentoo.org/935124

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
