### PR TITLE
app-editors/neovim: 9999 needs dev-libs/libutf8proc to build

### DIFF
--- a/app-editors/neovim/neovim-9999.ebuild
+++ b/app-editors/neovim/neovim-9999.ebuild
@@ -53,6 +53,7 @@ DEPEND="${LUA_DEPS}
 	>=dev-libs/msgpack-3.0.0:=
 	>=dev-libs/tree-sitter-0.22.6:=
 	>=dev-libs/unibilium-2.0.0:0=
+	>=dev-libs/libutf8proc-2.9.0:=
 "
 RDEPEND="
 	${DEPEND}


### PR DESCRIPTION
With upstream commit 32e16cb0b6[0],neovim now needs utfproc to build

[0]: https://github.com/neovim/neovim/commit/32e16cb0b6b046ba45d3e14c0fdb0383ad8bee1e

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
