### PR TITLE
media-gfx/mandelbulber: fix dependency, bug #935157

### DIFF
--- a/media-gfx/mandelbulber/mandelbulber-2.31.ebuild
+++ b/media-gfx/mandelbulber/mandelbulber-2.31.ebuild
@@ -21,7 +21,7 @@ RDEPEND="
 	dev-qt/qtcore:5
 	dev-qt/qtconcurrent:5
 	dev-qt/qtgui:5
-	dev-qt/qtmultimedia:5
+	dev-qt/qtmultimedia:5[qml]
 	dev-qt/qtnetwork:5
 	dev-qt/qttest:5
 	dev-qt/qtwidgets:5


### PR DESCRIPTION
Signed-off-by: Michael Mair-Keimberger <mmk@levelnine.at>

Closes: https://bugs.gentoo.org/935157

@ConiKost 
sorry, missed that dependency.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
