### PR TITLE
net-p2p/amule: use xdg-open instead of mplayer for media previews

### DIFF
--- a/net-p2p/amule/amule-2.3.3-r3.ebuild
+++ b/net-p2p/amule/amule-2.3.3-r3.ebuild
@@ -17,7 +17,7 @@ else
 fi
 
 DESCRIPTION="aMule, the all-platform eMule p2p client"
-HOMEPAGE="http://www.amule.org/"
+HOMEPAGE="https://www.amule.org/"
 
 LICENSE="GPL-2+"
 SLOT="0"

--- a/net-p2p/amule/amule-2.3.3-r4.ebuild
+++ b/net-p2p/amule/amule-2.3.3-r4.ebuild
@@ -17,7 +17,7 @@ else
 fi
 
 DESCRIPTION="aMule, the all-platform eMule p2p client"
-HOMEPAGE="http://www.amule.org/"
+HOMEPAGE="https://www.amule.org/"
 
 LICENSE="GPL-2+"
 SLOT="0"

--- a/net-p2p/amule/amule-2.3.3-r4.ebuild
+++ b/net-p2p/amule/amule-2.3.3-r4.ebuild
@@ -52,6 +52,7 @@ BDEPEND="
 PATCHES=(
 	"${FILESDIR}/${PN}-2.3.2-disable-version-check.patch"
 	"${FILESDIR}/${PN}-2.3.3-fix-exception.patch"
+	"${FILESDIR}/${P}-autoconf-2.70.patch"
 	"${FILESDIR}/${PN}-2.3.3-backport-pr368.patch"
 	"${FILESDIR}/${PN}-2.3.3-wx3.2.patch"
 	"${FILESDIR}/${PN}-2.3.3-use-xdg-open-as-preview-default.patch"

--- a/net-p2p/amule/amule-9999.ebuild
+++ b/net-p2p/amule/amule-9999.ebuild
@@ -17,7 +17,7 @@ else
 fi
 
 DESCRIPTION="aMule, the all-platform eMule p2p client"
-HOMEPAGE="http://www.amule.org/"
+HOMEPAGE="https://www.amule.org/"
 
 LICENSE="GPL-2+"
 SLOT="0"

--- a/net-p2p/amule/files/amule-2.3.3-use-xdg-open-as-preview-default.patch
+++ b/net-p2p/amule/files/amule-2.3.3-use-xdg-open-as-preview-default.patch
@@ -1,0 +1,17 @@
+commit f54a851586ff3762e0426ea9265ffb3499f93ad5
+Author: Adeodato Simó <dato@net.com.org.es>
+Date:   Sun Mar 1 14:10:15 2009 +0100
+
+    src/DownloadListCtrl.cpp: use xdg-open as default instead of mplayer.
+
+--- a/src/DownloadListCtrl.cpp
++++ b/src/DownloadListCtrl.cpp
+@@ -1429,7 +1429,7 @@ void CDownloadListCtrl::PreviewFile(CPar
+ 			_("File preview"), wxOK, this);
+ 		// Since newer versions for some reason mplayer does not automatically
+ 		// select video output device and needs a parameter, go figure...
+-		command = wxT("xterm -T \"aMule Preview\" -iconic -e mplayer ") QUOTE wxT("$file") QUOTE;
++		command = wxT("xterm -T \"aMule Preview\" -iconic -e xdg-open ") QUOTE wxT("$file") QUOTE;
+ 	} else {
+ 		command = thePrefs::GetVideoPlayer();
+ 	}


### PR DESCRIPTION
Also call setup-wxwidgets() from src_configure()

Closes: https://bugs.gentoo.org/931622
Closes: https://bugs.gentoo.org/935481

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
