### PR TITLE
net-im/discord: enable explicit wayland support

### DIFF
--- a/net-im/discord/discord-0.0.58-r2.ebuild
+++ b/net-im/discord/discord-0.0.58-r2.ebuild
@@ -93,8 +93,14 @@ src_prepare() {
 
 	# USE seccomp in launcher
 	if use seccomp; then
-		sed --in-place --expression '/^SECCOMP=/s/false/true/' \
+		sed --in-place --expression '/^EBUILD_SECCOMP=/s/false/true/' \
 			"${T}/launcher.sh" || die "sed failed for seccomp"
+	fi
+
+	# USE wayland in launcher
+	if use wayland; then
+		sed --in-place --expression '/^EBUILD_WAYLAND=/s/false/true/' \
+			"${T}/launcher.sh" || die "sed failed for wayland"
 	fi
 }
 

--- a/net-im/discord/files/launcher.sh
+++ b/net-im/discord/files/launcher.sh
@@ -4,10 +4,13 @@
 
 declare -a discord_parameters
 
-SECCOMP=false
+# Variables set during ebuild configuration
+EBUILD_SECCOMP=false
+EBUILD_WAYLAND=false
 
-"${SECCOMP}" || discord_parameters+=( --disable-seccomp-filter-sandbox )
+"${EBUILD_SECCOMP}" || discord_parameters+=( --disable-seccomp-filter-sandbox )
 
+"${EBUILD_WAYLAND}" && \
 [[ -n "${WAYLAND_DISPLAY}" ]] && discord_parameters+=(
 	--enable-features=UseOzonePlatform
 	--ozone-platform=wayland

--- a/net-im/discord/files/launcher.sh
+++ b/net-im/discord/files/launcher.sh
@@ -6,7 +6,7 @@ declare -a discord_parameters
 
 SECCOMP=false
 
-[[ ! "${SECCOMP}" ]] && discord_parameters+=( --disable-seccomp-filter-sandbox )
+"${SECCOMP}" || discord_parameters+=( --disable-seccomp-filter-sandbox )
 
 [[ -n "${WAYLAND_DISPLAY}" ]] && discord_parameters+=(
 	--enable-features=UseOzonePlatform


### PR DESCRIPTION
First commit, fix a bug I introduced in commit 6368a566a8b05f09e5edfad5d4f7577a83c6334b.
Second, `wayland` USE flag does actually something.

Follow-up from #37287.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
