### PR TITLE
app-admin/sudo: Keep /etc/sudoers.d

### DIFF
--- a/app-admin/sudo/sudo-1.9.17_p2.ebuild
+++ b/app-admin/sudo/sudo-1.9.17_p2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2025 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -241,6 +241,10 @@ src_install() {
 
 	# bug #697812
 	find "${ED}" -type f -name "*.la" -delete || die
+
+	# Build system installs /etc/sudoers.d, let's make sure we
+	# keep having it.
+	keepdir /etc/sudoers.d
 }
 
 pkg_postinst() {

--- a/app-admin/sudo/sudo-9999.ebuild
+++ b/app-admin/sudo/sudo-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2025 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -241,6 +241,10 @@ src_install() {
 
 	# bug #697812
 	find "${ED}" -type f -name "*.la" -delete || die
+
+	# Build system installs /etc/sudoers.d, let's make sure we
+	# keep having it.
+	keepdir /etc/sudoers.d
 }
 
 pkg_postinst() {


### PR DESCRIPTION
Build system is creating the directory on `make install`, but it was rather random whether the directory will make it to the merged rootfs. This caused build failures on Flatcar sometimes.


~pkgcheck fails with `pkgcheck: error: parsing failed: failed to load make.globals`, I'm not on a running Gentoo system.~ I have switched to Gentoo since then.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
