### PR TITLE
Force sys-devel/binutils[cet] and remove BDEPEND from gcc on amd64 to fix cross-compiling 

### DIFF
--- a/profiles/arch/amd64/package.use.force
+++ b/profiles/arch/amd64/package.use.force
@@ -1,5 +1,10 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
+
+# James Le Cuirot <chewi@gentoo.org> (2024-07-02)
+# Needed to build gcc. Force here rather than using BDEPEND to simplify
+# cross-compile scenarios.
+sys-devel/binutils cet
 
 # Michał Górny <mgorny@gentoo.org> (2023-10-06)
 # Require ABIs matching MULTILIB_ABIS in gcc dependencies -- otherwise

--- a/sys-devel/gcc/gcc-11.4.1_p20240111.ebuild
+++ b/sys-devel/gcc/gcc-11.4.1_p20240111.ebuild
@@ -48,7 +48,6 @@ if [[ ${CATEGORY} != cross-* ]] ; then
 	# bug #830454
 	RDEPEND="elibc_glibc? ( sys-libs/glibc[cet(-)?] )"
 	DEPEND="${RDEPEND}"
-	BDEPEND="amd64? ( >=${CATEGORY}/binutils-2.30[cet(-)?] )"
 fi
 
 src_prepare() {

--- a/sys-devel/gcc/gcc-11.4.1_p20240501.ebuild
+++ b/sys-devel/gcc/gcc-11.4.1_p20240501.ebuild
@@ -48,7 +48,6 @@ if [[ ${CATEGORY} != cross-* ]] ; then
 	# bug #830454
 	RDEPEND="elibc_glibc? ( sys-libs/glibc[cet(-)?] )"
 	DEPEND="${RDEPEND}"
-	BDEPEND="amd64? ( >=${CATEGORY}/binutils-2.30[cet(-)?] )"
 fi
 
 src_prepare() {

--- a/sys-devel/gcc/gcc-11.4.1_p20240612.ebuild
+++ b/sys-devel/gcc/gcc-11.4.1_p20240612.ebuild
@@ -48,7 +48,6 @@ if [[ ${CATEGORY} != cross-* ]] ; then
 	# bug #830454
 	RDEPEND="elibc_glibc? ( sys-libs/glibc[cet(-)?] )"
 	DEPEND="${RDEPEND}"
-	BDEPEND="amd64? ( >=${CATEGORY}/binutils-2.30[cet(-)?] )"
 fi
 
 src_prepare() {

--- a/sys-devel/gcc/gcc-11.4.1_p20240619.ebuild
+++ b/sys-devel/gcc/gcc-11.4.1_p20240619.ebuild
@@ -48,7 +48,6 @@ if [[ ${CATEGORY} != cross-* ]] ; then
 	# bug #830454
 	RDEPEND="elibc_glibc? ( sys-libs/glibc[cet(-)?] )"
 	DEPEND="${RDEPEND}"
-	BDEPEND="amd64? ( >=${CATEGORY}/binutils-2.30[cet(-)?] )"
 fi
 
 src_prepare() {

--- a/sys-devel/gcc/gcc-11.4.1_p20240626.ebuild
+++ b/sys-devel/gcc/gcc-11.4.1_p20240626.ebuild
@@ -48,7 +48,6 @@ if [[ ${CATEGORY} != cross-* ]] ; then
 	# bug #830454
 	RDEPEND="elibc_glibc? ( sys-libs/glibc[cet(-)?] )"
 	DEPEND="${RDEPEND}"
-	BDEPEND="amd64? ( >=${CATEGORY}/binutils-2.30[cet(-)?] )"
 fi
 
 src_prepare() {

--- a/sys-devel/gcc/gcc-11.5.9999.ebuild
+++ b/sys-devel/gcc/gcc-11.5.9999.ebuild
@@ -45,7 +45,6 @@ if [[ ${CATEGORY} != cross-* ]] ; then
 	# bug #830454
 	RDEPEND="elibc_glibc? ( sys-libs/glibc[cet(-)?] )"
 	DEPEND="${RDEPEND}"
-	BDEPEND="amd64? ( >=${CATEGORY}/binutils-2.30[cet(-)?] )"
 fi
 
 src_prepare() {

--- a/sys-devel/gcc/gcc-12.3.1_p20240209.ebuild
+++ b/sys-devel/gcc/gcc-12.3.1_p20240209.ebuild
@@ -48,7 +48,6 @@ if [[ ${CATEGORY} != cross-* ]] ; then
 	# bug #830454
 	RDEPEND="elibc_glibc? ( sys-libs/glibc[cet(-)?] )"
 	DEPEND="${RDEPEND}"
-	BDEPEND="amd64? ( >=${CATEGORY}/binutils-2.30[cet(-)?] )"
 fi
 
 src_prepare() {

--- a/sys-devel/gcc/gcc-12.3.1_p20240502.ebuild
+++ b/sys-devel/gcc/gcc-12.3.1_p20240502.ebuild
@@ -48,7 +48,6 @@ if [[ ${CATEGORY} != cross-* ]] ; then
 	# bug #830454
 	RDEPEND="elibc_glibc? ( sys-libs/glibc[cet(-)?] )"
 	DEPEND="${RDEPEND}"
-	BDEPEND="amd64? ( >=${CATEGORY}/binutils-2.30[cet(-)?] )"
 fi
 
 src_prepare() {

--- a/sys-devel/gcc/gcc-12.3.1_p20240613.ebuild
+++ b/sys-devel/gcc/gcc-12.3.1_p20240613.ebuild
@@ -48,7 +48,6 @@ if [[ ${CATEGORY} != cross-* ]] ; then
 	# bug #830454
 	RDEPEND="elibc_glibc? ( sys-libs/glibc[cet(-)?] )"
 	DEPEND="${RDEPEND}"
-	BDEPEND="amd64? ( >=${CATEGORY}/binutils-2.30[cet(-)?] )"
 fi
 
 src_prepare() {

--- a/sys-devel/gcc/gcc-12.4.0.ebuild
+++ b/sys-devel/gcc/gcc-12.4.0.ebuild
@@ -48,7 +48,6 @@ if [[ ${CATEGORY} != cross-* ]] ; then
 	# bug #830454
 	RDEPEND="elibc_glibc? ( sys-libs/glibc[cet(-)?] )"
 	DEPEND="${RDEPEND}"
-	BDEPEND="amd64? ( >=${CATEGORY}/binutils-2.30[cet(-)?] )"
 fi
 
 src_prepare() {

--- a/sys-devel/gcc/gcc-12.4.1_p20240627.ebuild
+++ b/sys-devel/gcc/gcc-12.4.1_p20240627.ebuild
@@ -48,7 +48,6 @@ if [[ ${CATEGORY} != cross-* ]] ; then
 	# bug #830454
 	RDEPEND="elibc_glibc? ( sys-libs/glibc[cet(-)?] )"
 	DEPEND="${RDEPEND}"
-	BDEPEND="amd64? ( >=${CATEGORY}/binutils-2.30[cet(-)?] )"
 fi
 
 src_prepare() {

--- a/sys-devel/gcc/gcc-12.5.9999.ebuild
+++ b/sys-devel/gcc/gcc-12.5.9999.ebuild
@@ -45,7 +45,6 @@ if [[ ${CATEGORY} != cross-* ]] ; then
 	# bug #830454
 	RDEPEND="elibc_glibc? ( sys-libs/glibc[cet(-)?] )"
 	DEPEND="${RDEPEND}"
-	BDEPEND="amd64? ( >=${CATEGORY}/binutils-2.30[cet(-)?] )"
 fi
 
 src_prepare() {

--- a/sys-devel/gcc/gcc-13.2.0.ebuild
+++ b/sys-devel/gcc/gcc-13.2.0.ebuild
@@ -48,7 +48,6 @@ if [[ ${CATEGORY} != cross-* ]] ; then
 	# bug #830454
 	RDEPEND="elibc_glibc? ( sys-libs/glibc[cet(-)?] )"
 	DEPEND="${RDEPEND}"
-	BDEPEND=">=${CATEGORY}/binutils-2.30[cet(-)?]"
 fi
 
 src_prepare() {

--- a/sys-devel/gcc/gcc-13.2.1_p20240210.ebuild
+++ b/sys-devel/gcc/gcc-13.2.1_p20240210.ebuild
@@ -48,7 +48,6 @@ if [[ ${CATEGORY} != cross-* ]] ; then
 	# bug #830454
 	RDEPEND="elibc_glibc? ( sys-libs/glibc[cet(-)?] )"
 	DEPEND="${RDEPEND}"
-	BDEPEND="amd64? ( >=${CATEGORY}/binutils-2.30[cet(-)?] )"
 fi
 
 src_prepare() {

--- a/sys-devel/gcc/gcc-13.2.1_p20240503.ebuild
+++ b/sys-devel/gcc/gcc-13.2.1_p20240503.ebuild
@@ -48,7 +48,6 @@ if [[ ${CATEGORY} != cross-* ]] ; then
 	# bug #830454
 	RDEPEND="elibc_glibc? ( sys-libs/glibc[cet(-)?] )"
 	DEPEND="${RDEPEND}"
-	BDEPEND="amd64? ( >=${CATEGORY}/binutils-2.30[cet(-)?] )"
 fi
 
 src_prepare() {

--- a/sys-devel/gcc/gcc-13.3.0.ebuild
+++ b/sys-devel/gcc/gcc-13.3.0.ebuild
@@ -47,7 +47,6 @@ if [[ ${CATEGORY} != cross-* ]] ; then
 	# bug #830454
 	RDEPEND="elibc_glibc? ( sys-libs/glibc[cet(-)?] )"
 	DEPEND="${RDEPEND}"
-	BDEPEND="amd64? ( >=${CATEGORY}/binutils-2.30[cet(-)?] )"
 fi
 
 src_prepare() {

--- a/sys-devel/gcc/gcc-13.3.1_p20240614.ebuild
+++ b/sys-devel/gcc/gcc-13.3.1_p20240614.ebuild
@@ -48,7 +48,6 @@ if [[ ${CATEGORY} != cross-* ]] ; then
 	# bug #830454
 	RDEPEND="elibc_glibc? ( sys-libs/glibc[cet(-)?] )"
 	DEPEND="${RDEPEND}"
-	BDEPEND="amd64? ( >=${CATEGORY}/binutils-2.30[cet(-)?] )"
 fi
 
 src_prepare() {

--- a/sys-devel/gcc/gcc-13.3.1_p20240628.ebuild
+++ b/sys-devel/gcc/gcc-13.3.1_p20240628.ebuild
@@ -48,7 +48,6 @@ if [[ ${CATEGORY} != cross-* ]] ; then
 	# bug #830454
 	RDEPEND="elibc_glibc? ( sys-libs/glibc[cet(-)?] )"
 	DEPEND="${RDEPEND}"
-	BDEPEND="amd64? ( >=${CATEGORY}/binutils-2.30[cet(-)?] )"
 fi
 
 src_prepare() {

--- a/sys-devel/gcc/gcc-13.4.9999.ebuild
+++ b/sys-devel/gcc/gcc-13.4.9999.ebuild
@@ -47,7 +47,6 @@ if [[ ${CATEGORY} != cross-* ]] ; then
 	# bug #830454
 	RDEPEND="elibc_glibc? ( sys-libs/glibc[cet(-)?] )"
 	DEPEND="${RDEPEND}"
-	BDEPEND="amd64? ( >=${CATEGORY}/binutils-2.30[cet(-)?] )"
 fi
 
 src_prepare() {

--- a/sys-devel/gcc/gcc-14.1.1_p20240518.ebuild
+++ b/sys-devel/gcc/gcc-14.1.1_p20240518.ebuild
@@ -38,7 +38,6 @@ if [[ ${CATEGORY} != cross-* ]] ; then
 	# bug #830454
 	RDEPEND="elibc_glibc? ( sys-libs/glibc[cet(-)?] )"
 	DEPEND="${RDEPEND}"
-	BDEPEND="amd64? ( >=${CATEGORY}/binutils-2.30[cet(-)?] )"
 fi
 
 src_prepare() {

--- a/sys-devel/gcc/gcc-14.1.1_p20240615.ebuild
+++ b/sys-devel/gcc/gcc-14.1.1_p20240615.ebuild
@@ -38,7 +38,6 @@ if [[ ${CATEGORY} != cross-* ]] ; then
 	# bug #830454
 	RDEPEND="elibc_glibc? ( sys-libs/glibc[cet(-)?] )"
 	DEPEND="${RDEPEND}"
-	BDEPEND="amd64? ( >=${CATEGORY}/binutils-2.30[cet(-)?] )"
 fi
 
 src_prepare() {

--- a/sys-devel/gcc/gcc-14.1.1_p20240622.ebuild
+++ b/sys-devel/gcc/gcc-14.1.1_p20240622.ebuild
@@ -38,7 +38,6 @@ if [[ ${CATEGORY} != cross-* ]] ; then
 	# bug #830454
 	RDEPEND="elibc_glibc? ( sys-libs/glibc[cet(-)?] )"
 	DEPEND="${RDEPEND}"
-	BDEPEND="amd64? ( >=${CATEGORY}/binutils-2.30[cet(-)?] )"
 fi
 
 src_prepare() {

--- a/sys-devel/gcc/gcc-14.1.1_p20240629.ebuild
+++ b/sys-devel/gcc/gcc-14.1.1_p20240629.ebuild
@@ -38,7 +38,6 @@ if [[ ${CATEGORY} != cross-* ]] ; then
 	# bug #830454
 	RDEPEND="elibc_glibc? ( sys-libs/glibc[cet(-)?] )"
 	DEPEND="${RDEPEND}"
-	BDEPEND="amd64? ( >=${CATEGORY}/binutils-2.30[cet(-)?] )"
 fi
 
 src_prepare() {

--- a/sys-devel/gcc/gcc-14.1.9999.ebuild
+++ b/sys-devel/gcc/gcc-14.1.9999.ebuild
@@ -34,7 +34,6 @@ if [[ ${CATEGORY} != cross-* ]] ; then
 	# bug #830454
 	RDEPEND="elibc_glibc? ( sys-libs/glibc[cet(-)?] )"
 	DEPEND="${RDEPEND}"
-	BDEPEND="amd64? ( >=${CATEGORY}/binutils-2.30[cet(-)?] )"
 fi
 
 src_prepare() {

--- a/sys-devel/gcc/gcc-15.0.0_pre20240609-r1.ebuild
+++ b/sys-devel/gcc/gcc-15.0.0_pre20240609-r1.ebuild
@@ -36,7 +36,6 @@ if [[ ${CATEGORY} != cross-* ]] ; then
 	# bug #830454
 	RDEPEND="elibc_glibc? ( sys-libs/glibc[cet(-)?] )"
 	DEPEND="${RDEPEND}"
-	BDEPEND="amd64? ( >=${CATEGORY}/binutils-2.30[cet(-)?] )"
 fi
 
 src_prepare() {

--- a/sys-devel/gcc/gcc-15.0.0_pre20240616.ebuild
+++ b/sys-devel/gcc/gcc-15.0.0_pre20240616.ebuild
@@ -36,7 +36,6 @@ if [[ ${CATEGORY} != cross-* ]] ; then
 	# bug #830454
 	RDEPEND="elibc_glibc? ( sys-libs/glibc[cet(-)?] )"
 	DEPEND="${RDEPEND}"
-	BDEPEND="amd64? ( >=${CATEGORY}/binutils-2.30[cet(-)?] )"
 fi
 
 src_prepare() {

--- a/sys-devel/gcc/gcc-15.0.0_pre20240623-r1.ebuild
+++ b/sys-devel/gcc/gcc-15.0.0_pre20240623-r1.ebuild
@@ -36,7 +36,6 @@ if [[ ${CATEGORY} != cross-* ]] ; then
 	# bug #830454
 	RDEPEND="elibc_glibc? ( sys-libs/glibc[cet(-)?] )"
 	DEPEND="${RDEPEND}"
-	BDEPEND="amd64? ( >=${CATEGORY}/binutils-2.30[cet(-)?] )"
 fi
 
 src_prepare() {

--- a/sys-devel/gcc/gcc-15.0.0_pre20240630.ebuild
+++ b/sys-devel/gcc/gcc-15.0.0_pre20240630.ebuild
@@ -36,7 +36,6 @@ if [[ ${CATEGORY} != cross-* ]] ; then
 	# bug #830454
 	RDEPEND="elibc_glibc? ( sys-libs/glibc[cet(-)?] )"
 	DEPEND="${RDEPEND}"
-	BDEPEND="amd64? ( >=${CATEGORY}/binutils-2.30[cet(-)?] )"
 fi
 
 src_prepare() {

--- a/sys-devel/gcc/gcc-15.0.9999.ebuild
+++ b/sys-devel/gcc/gcc-15.0.9999.ebuild
@@ -34,7 +34,6 @@ if [[ ${CATEGORY} != cross-* ]] ; then
 	# bug #830454
 	RDEPEND="elibc_glibc? ( sys-libs/glibc[cet(-)?] )"
 	DEPEND="${RDEPEND}"
-	BDEPEND="amd64? ( >=${CATEGORY}/binutils-2.30[cet(-)?] )"
 fi
 
 src_prepare() {


### PR DESCRIPTION
As discussed in #gentoo-toolchain, gcc needs this `binutils[cet]` enabled, and up till now, we've enforced this with `BDEPEND`. However, this prevents other architectures from building gcc for amd64 due to PMS limitations.

We may drop the flag eventually now that wider x86 support is being backed out, but binutils currently still enables it.

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.