### PR TITLE
net-libs/grpc: replace bash colon with "true" command

### DIFF
--- a/net-libs/grpc/grpc-1.62.1.ebuild
+++ b/net-libs/grpc/grpc-1.62.1.ebuild
@@ -100,7 +100,7 @@ src_prepare() {
 					"absl::any"
 					"absl::optional"
 					"absl::variant")
-	: "$(echo "${extra_libs[@]}" | "${EPYTHON}" -c 'import sys;print("\\n\\1".join(sys.stdin.read().split()))')"
+	true "$(echo "${extra_libs[@]}" | "${EPYTHON}" -c 'import sys;print("\\n\\1".join(sys.stdin.read().split()))')"
 	local rstring="${_}"
 	sed -i -E "s/( +)gtest/\1${rstring}/g" "CMakeLists.txt" || die
 


### PR DESCRIPTION
QA doesn't like this apparently.

Closes: https://bugs.gentoo.org/935336

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
