### PR TITLE
dev-lang/rust: add patch to disable setting CMAKE_ASM_COMPILER

### DIFF
--- a/dev-lang/rust/files/1.79.0-revert-8c40426.patch
+++ b/dev-lang/rust/files/1.79.0-revert-8c40426.patch
@@ -1,0 +1,18 @@
+This reverts commit 8c40426051a667673cdac9975f84cb6acd4e245f.
+
+https://bugs.gentoo.org/933382
+
+diff --git a/src/bootstrap/src/core/build_steps/llvm.rs b/src/bootstrap/src/core/build_steps/llvm.rs
+index d4473e24039..58f351d17fa 100644
+--- a/src/bootstrap/src/core/build_steps/llvm.rs
++++ b/src/bootstrap/src/core/build_steps/llvm.rs
+@@ -724,8 +724,7 @@ fn configure_cmake(
+             }
+         }
+         cfg.define("CMAKE_C_COMPILER", sanitize_cc(&cc))
+-            .define("CMAKE_CXX_COMPILER", sanitize_cc(&cxx))
+-            .define("CMAKE_ASM_COMPILER", sanitize_cc(&cc));
++            .define("CMAKE_CXX_COMPILER", sanitize_cc(&cxx));
+     }
+ 
+     cfg.build_arg("-j").build_arg(builder.jobs().to_string());

--- a/dev-lang/rust/rust-1.79.0.ebuild
+++ b/dev-lang/rust/rust-1.79.0.ebuild
@@ -170,6 +170,7 @@ PATCHES=(
 	#"${FILESDIR}"/1.72.0-bump-libc-deps-to-0.2.146.patch  # pending refresh
 	"${FILESDIR}"/1.78.0-ignore-broken-and-non-applicable-tests.patch
 	"${FILESDIR}"/1.67.0-doc-wasm.patch
+	"${FILESDIR}"/1.79.0-revert-8c40426.patch
 )
 
 clear_vendor_checksums() {


### PR DESCRIPTION
This is apparently not (or no longer) consumed by the bundled LLVM, which makes our QA complain.

See: https://github.com/rust-lang/rust/commit/8c40426051a667673cdac9975f84cb6acd4e245f
Closes: https://bugs.gentoo.org/933382

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
