### PR TITLE
go-env.eclass: add implicit IUSE for abi_mips_*

### DIFF
--- a/eclass/go-env.eclass
+++ b/eclass/go-env.eclass
@@ -16,6 +16,8 @@ _GO_ENV_ECLASS=1
 
 inherit flag-o-matic toolchain-funcs
 
+IUSE+=" abi_mips_o32 abi_mips_n64"
+
 # @FUNCTION: go-env_set_compile_environment
 # @DESCRIPTION:
 # Set up basic compile environment: CC, CXX, and GOARCH.


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/935414

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
