### PR TITLE
media-radio/chirp: make dependency to dev-python/suds-community mandatory

### DIFF
--- a/media-radio/chirp/chirp-20240606-r1.ebuild
+++ b/media-radio/chirp/chirp-20240606-r1.ebuild
@@ -1,0 +1,60 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+PYTHON_COMPAT=( python3_{10..12} )
+DISTUTILS_SINGLE_IMPL=1
+DISTUTILS_USE_PEP517=setuptools
+
+inherit distutils-r1
+
+DESCRIPTION="A free, open-source tool for programming your radio"
+HOMEPAGE="https://chirpmyradio.com/"
+SRC_URI="https://archive.chirpmyradio.com/${PN}_next/next-${PV}/${P}.tar.gz"
+
+LICENSE="GPL-3+"
+SLOT="0"
+KEYWORDS="amd64 ~x86"
+IUSE="+gui"
+
+RDEPEND="$(python_gen_cond_dep '
+	dev-python/pyserial[${PYTHON_USEDEP}]
+	dev-python/requests[${PYTHON_USEDEP}]
+	dev-python/six[${PYTHON_USEDEP}]
+	gui? (
+		dev-python/suds-community[${PYTHON_USEDEP}]
+		dev-python/wxpython:4.0[${PYTHON_USEDEP}]
+		dev-python/yattag[${PYTHON_USEDEP}]
+	)
+')"
+BDEPEND="test? ( $(python_gen_cond_dep '
+	dev-python/ddt[${PYTHON_USEDEP}]
+	dev-python/pytest-xdist[${PYTHON_USEDEP}]
+	dev-python/pyyaml[${PYTHON_USEDEP}]
+') )"
+
+distutils_enable_tests pytest
+
+# The alias map is an internal developer file not included in release tarballs.
+# Other disabled tests require Internet access.
+EPYTEST_DESELECT=(
+	tests/unit/test_directory.py::TestAliasMap
+	tests/unit/test_network_sources.py
+	tests/unit/test_repeaterbook.py
+)
+
+python_test() {
+	# From the contents of tests/ upstream currently only runs unit and driver
+	# tests, and the latter can take so long that they have even got a special
+	# script for only running them on drivers whose code has changed
+	# with respect to origin/master.
+	epytest tests/unit/
+}
+
+src_install() {
+	distutils-r1_src_install
+	if ! use gui; then
+		rm "${ED}"/usr/bin/${PN} || die
+	fi
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/935431

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
