### PR TITLE
app-metrics/chrony_exporter: fix tests

### DIFF
--- a/app-metrics/chrony_exporter/chrony_exporter-0.10.1.ebuild
+++ b/app-metrics/chrony_exporter/chrony_exporter-0.10.1.ebuild
@@ -20,6 +20,12 @@ DEPEND="acct-group/chrony_exporter
 
 BDEPEND="dev-util/promu"
 
+src_prepare() {
+	default
+	# No need to enable the race detector for tests (#935442)
+	sed -i -e '/test-flags := -race/d' Makefile.common || die
+}
+
 src_compile() {
 	promu build -v --cgo --prefix bin || die
 }


### PR DESCRIPTION
Disable the race detector for tests, which are all simple single-threaded input/output verification.

Closes: https://bugs.gentoo.org/935442

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
