### PR TITLE
dev-libs/libxml2: build with legacy stubs to avoid ABI breakage

### DIFF
--- a/dev-libs/libxml2/libxml2-2.13.1-r1.ebuild
+++ b/dev-libs/libxml2/libxml2-2.13.1-r1.ebuild
@@ -106,6 +106,7 @@ multilib_src_configure() {
 			$(use_enable static-libs static) \
 			$(multilib_native_use_with readline) \
 			$(multilib_native_use_with readline history) \
+			--with-legacy \
 			"$@"
 	}
 

--- a/dev-libs/libxml2/libxml2-9999.ebuild
+++ b/dev-libs/libxml2/libxml2-9999.ebuild
@@ -106,6 +106,7 @@ multilib_src_configure() {
 			$(use_enable static-libs static) \
 			$(multilib_native_use_with readline) \
 			$(multilib_native_use_with readline history) \
+			--with-legacy \
 			"$@"
 	}
 


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/935452

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
