### PR TITLE
media-sound/quodlibet: add python3_12 support

### DIFF
--- a/media-sound/quodlibet/files/quodlibet-4.6.0-python312.patch
+++ b/media-sound/quodlibet/files/quodlibet-4.6.0-python312.patch
@@ -1,0 +1,72 @@
+From a8b6f6bb34864a6821174edbf7802b689e440db3 Mon Sep 17 00:00:00 2001
+From: LuK1337 <priv.luk@gmail.com>
+Date: Wed, 23 Aug 2023 17:13:23 +0200
+Subject: [PATCH] Fix startup on Python 3.12
+
+---
+ quodlibet/_import.py           | 6 ++++++
+ quodlibet/util/config.py       | 2 +-
+ quodlibet/util/importhelper.py | 6 +++---
+ 3 files changed, 10 insertions(+), 4 deletions(-)
+
+diff --git a/quodlibet/_import.py b/quodlibet/_import.py
+index 5e76b67295..22bd5e3140 100644
+--- a/quodlibet/_import.py
++++ b/quodlibet/_import.py
+@@ -8,6 +8,7 @@
+ 
+ import sys
+ import importlib
++import importlib.util
+ 
+ 
+ class RedirectImportHook:
+@@ -31,6 +32,11 @@ def __init__(self, name, packages):
+         self._name = name
+         self._packages = packages
+ 
++    def find_spec(self, fullname, path, target=None):
++        loader = self.find_module(fullname, path)
++        if loader is not None:
++            return importlib.util.spec_from_loader(fullname, loader)
++
+     def find_module(self, fullname, path=None):
+         package = fullname.split(".")[0]
+         if package in self._packages:
+diff --git a/quodlibet/util/config.py b/quodlibet/util/config.py
+index 1c214ac0b4..f0688f9bf9 100644
+--- a/quodlibet/util/config.py
++++ b/quodlibet/util/config.py
+@@ -377,7 +377,7 @@ def read(self, filename):
+             with open(filename, "rb") as fileobj:
+                 fileobj = StringIO(
+                     fileobj.read().decode("utf-8", "surrogateescape"))
+-                self._config.readfp(fileobj, filename)
++                self._config.read_file(fileobj, filename)
+         except (IOError, OSError):
+             return
+ 
+diff --git a/quodlibet/util/importhelper.py b/quodlibet/util/importhelper.py
+index f14b11f4b6..c82ded5878 100644
+--- a/quodlibet/util/importhelper.py
++++ b/quodlibet/util/importhelper.py
+@@ -92,8 +92,8 @@ def load_module(name, package, path):
+     except KeyError:
+         pass
+ 
+-    loader = importlib.find_loader(fullname, [path])
+-    if loader is None:
++    spec = importlib.machinery.PathFinder.find_spec(fullname, [path])
++    if spec is None:
+         return
+ 
+     # modules need a parent package
+@@ -101,7 +101,7 @@ def load_module(name, package, path):
+         spec = importlib.machinery.ModuleSpec(package, None, is_package=True)
+         sys.modules[package] = importlib.util.module_from_spec(spec)
+ 
+-    mod = loader.load_module(fullname)
++    mod = spec.loader.load_module(fullname)
+ 
+     # make it accessible from the parent, like __import__ does
+     vars(sys.modules[package])[name] = mod

--- a/media-sound/quodlibet/quodlibet-4.6.0-r2.ebuild
+++ b/media-sound/quodlibet/quodlibet-4.6.0-r2.ebuild
@@ -1,0 +1,62 @@
+# Copyright 2022-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+PYTHON_COMPAT=( python3_{10..12} )
+DISTUTILS_USE_PEP517=setuptools
+inherit distutils-r1 xdg
+
+DESCRIPTION="audio library tagger, manager, and player for GTK+"
+HOMEPAGE="https://quodlibet.readthedocs.io/"
+SRC_URI="https://github.com/${PN}/${PN}/archive/release-${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~ppc64 ~x86"
+IUSE="+dbus gstreamer +udev"
+
+RDEPEND="dev-libs/keybinder:3[introspection]
+	dev-python/feedparser[${PYTHON_USEDEP}]
+	dev-python/pygobject:3[${PYTHON_USEDEP}]
+	media-libs/mutagen[${PYTHON_USEDEP}]
+	net-libs/libsoup:3.0[introspection]
+	x11-libs/gtk+[introspection]
+	gstreamer? (
+		media-libs/gstreamer:1.0
+		media-libs/gst-plugins-base:1.0
+		media-libs/gst-plugins-good:1.0
+		media-plugins/gst-plugins-meta:1.0
+		)
+	!gstreamer? ( media-libs/xine-lib )
+	dbus? (
+		app-misc/media-player-info
+		dev-python/dbus-python[${PYTHON_USEDEP}]
+		)
+	udev? ( virtual/udev )"
+DEPEND="dev-util/intltool"
+
+S="${WORKDIR}/${PN}-release-${PV}"
+
+PATCHES=(
+	 "${FILESDIR}/${PN}-4.6.0-python312.patch"
+)
+
+src_prepare() {
+	local qlconfig=quodlibet/config.py
+
+	if ! use gstreamer; then
+		sed -i -e '/backend/s:gstbe:xinebe:' ${qlconfig} || die
+	fi
+
+	sed -i -e '/gst_pipeline/s:"":"alsasink":' ${qlconfig} || die
+
+	distutils-r1_src_prepare
+}
+
+src_install() {
+	distutils-r1_src_install
+	dodoc README.rst
+
+	# fix location of desktop file
+	mv "${ED}/usr/share/appdata" "${ED}/usr/share/metainfo" || die "Failed to fix desktop file location"
+}


### PR DESCRIPTION
Uses upstream patch for python 3.12 support referenced in bug 925283. Switched to PEP517 setuptools with no changes observed from concerns in bug 909994 due to extended setuptools usage. And just in time for maintainer to retire...

Closes: https://bugs.gentoo.org/909994
Closes: https://bugs.gentoo.org/925283

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
