### PR TITLE
flag-o-matic.eclass: allow -mstrict-align and -mvector-strict-align

### DIFF
--- a/eclass/flag-o-matic.eclass
+++ b/eclass/flag-o-matic.eclass
@@ -129,6 +129,10 @@ _setup-allowed-flags() {
 		# needed for arm64 (and in particular SCS)
 		-ffixed-x18
 
+		# needed for riscv (to prevent unaligned vector access)
+		# See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=115789
+		-mstrict-align -mvector-strict-align
+
 		# gcc 4.5
 		-mno-fma4 -mno-movbe -mno-xop -mno-lwp
 		# gcc 4.6


### PR DESCRIPTION
It is needed to make sure vector unaligned load/store aren't inserted when the riscv cpu does not allow them.

See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=115789

