### PR TITLE
dev-db/mydumper: Fix implicit declaration of function open

### DIFF
--- a/dev-db/mydumper/files/mydumper-0.15-fix-call-to-open.patch
+++ b/dev-db/mydumper/files/mydumper-0.15-fix-call-to-open.patch
@@ -1,0 +1,42 @@
+From https://github.com/mydumper/mydumper/pull/1557
+From: Brahmajit Das <brahmajit.xyz@gmail.com>
+Date: Sun, 7 Jul 2024 20:40:30 +0000
+Subject: [PATCH] Fix building on musl libc
+
+On musl libc we are getting buid errors:
+mydumper/src/mydumper_stream.c:100:9: error: implicit declaration of function 'open'; did you mean 'popen'? [-Wimplicit-
+function-declaration]
+  100 |       f=open(sf->filename,O_RDONLY);
+      |         ^~~~
+      |         popen
+mydumper/src/mydumper_stream.c:100:27: error: 'O_RDONLY' undeclared (first use in this function)
+  100 |       f=open(sf->filename,O_RDONLY);
+      |                           ^~~~~~~~
+This probably due to musl being more strict. Fix was to include the
+fcntl.h header file as the Linux Manual Page suggests open should come
+from fcntl.h
+
+First reported on Gentoo Linux with musl profile
+
+Bug: https://bugs.gentoo.org/935389
+Signed-off-by: Brahmajit Das <brahmajit.xyz@gmail.com>
+--- a/src/mydumper_common.c
++++ b/src/mydumper_common.c
+@@ -20,6 +20,7 @@
+ */
+ #include "string.h"
+ #include <stdlib.h>
++#include <fcntl.h>
+ #include <mysql.h>
+ #include <glib.h>
+ #include <glib/gstdio.h>
+--- a/src/mydumper_stream.c
++++ b/src/mydumper_stream.c
+@@ -26,6 +26,7 @@
+ #include "mydumper_stream.h"
+ #include <sys/file.h>
+ #include <errno.h>
++#include <fcntl.h>
+ 
+ extern GAsyncQueue *stream_queue;
+ 

--- a/dev-db/mydumper/mydumper-0.15.2.8-r1.ebuild
+++ b/dev-db/mydumper/mydumper-0.15.2.8-r1.ebuild
@@ -1,0 +1,57 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit cmake flag-o-matic
+
+MY_PV="$(ver_rs 3 -)"
+MY_P="${PN}-${MY_PV}"
+
+DESCRIPTION="A high-performance multi-threaded backup (and restore) toolset for MySQL"
+HOMEPAGE="https://github.com/mydumper/mydumper"
+SRC_URI="https://github.com/mydumper/mydumper/archive/v${MY_PV}.tar.gz -> ${MY_P}.tar.gz"
+S="${WORKDIR}/${MY_P}"
+
+LICENSE="GPL-3+"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="doc"
+
+RDEPEND="app-arch/zstd
+	dev-db/mysql-connector-c:=
+	dev-libs/glib:2
+	dev-libs/libpcre
+	dev-libs/openssl:=
+	sys-libs/zlib:="
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig
+	doc? ( dev-python/sphinx )"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-0.13.1-atomic.patch" #654314
+
+	"${FILESDIR}"/${PN}-0.15-Do-not-overwrite-the-user-CFLAGS.patch
+
+	"${FILESDIR}"/${PN}-0.15-fix-call-to-open.patch
+)
+
+src_prepare() {
+	# fix doc install path
+	sed -i -e "s|share/doc/mydumper|share/doc/${PF}|" docs/CMakeLists.txt || die
+
+	cmake_src_prepare
+}
+
+src_configure() {
+	# -Werror=lto-type-mismatch
+	# https://bugs.gentoo.org/855239
+	#
+	# Fixed upstream in git master:
+	# https://github.com/mydumper/mydumper/pull/1413
+	filter-lto
+
+	local mycmakeargs=(-DBUILD_DOCS=$(usex doc))
+
+	cmake_src_configure
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/935389

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
