### PR TITLE
media-video/imagination: add missing build dependency

### DIFF
--- a/media-video/imagination/imagination-3.6.ebuild
+++ b/media-video/imagination/imagination-3.6.ebuild
@@ -22,6 +22,7 @@ DEPEND="
 	x11-libs/pango"
 RDEPEND="${DEPEND}
 	media-video/ffmpeg"
+BDEPEND="dev-util/intltool"
 
 PATCHES=(
 	"${FILESDIR}"/${P}-cflags.patch


### PR DESCRIPTION
Signed-off-by: Michael Mair-Keimberger <mmk@levelnine.at>

Closes: https://bugs.gentoo.org/935621

@ConiKost 
sorry for the inconvenience.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
