### PR TITLE
net-libs/meanwhile: fix building with USE=debug

### DIFF
--- a/net-libs/meanwhile/meanwhile-1.1.1.ebuild
+++ b/net-libs/meanwhile/meanwhile-1.1.1.ebuild
@@ -31,6 +31,8 @@ PATCHES=(
 
 src_prepare() {
 	default
+	# bug #935514
+	sed -i -e "s|-g -O0 -Weverything||g" configure.ac || die
 	eautoreconf
 }
 


### PR DESCRIPTION
Signed-off-by: Michael Mair-Keimberger <mmk@levelnine.at>

Closes: https://bugs.gentoo.org/935514

@eli-schwartz 
Hope that's correct.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
