### PR TITLE
dev-libs/rocr-runtime: fix musl patch for 6.1.1

### DIFF
--- a/dev-libs/rocr-runtime/files/rocr-runtime-6.1.0-musl.patch
+++ b/dev-libs/rocr-runtime/files/rocr-runtime-6.1.0-musl.patch
@@ -1,9 +1,9 @@
 Fix compilation and symbol search with musl.
 
 Bug: https://github.com/ROCm/ROCR-Runtime/issues/181
---- src.orig/core/inc/checked.h
-+++ src/core/inc/checked.h
-@@ -58,7 +58,7 @@ template <uint64_t code, bool multiProce
+--- a/core/inc/checked.h
++++ b/core/inc/checked.h
+@@ -58,7 +58,7 @@ template <uint64_t code, bool multiProcess = false> class Check final {
    Check(const Check&) { object_ = uintptr_t(this) ^ uintptr_t(code); }
    Check(Check&&) { object_ = uintptr_t(this) ^ uintptr_t(code); }
  
@@ -12,8 +12,8 @@ Bug: https://github.com/ROCm/ROCR-Runtime/issues/181
  
    const Check& operator=(Check&& rhs) { return *this; }
    const Check& operator=(const Check& rhs) { return *this; }
---- src.orig/core/runtime/default_signal.cpp
-+++ src/core/runtime/default_signal.cpp
+--- a/core/runtime/default_signal.cpp
++++ b/core/runtime/default_signal.cpp
 @@ -57,7 +57,7 @@ int BusyWaitSignal::rtti_id_ = 0;
  BusyWaitSignal::BusyWaitSignal(SharedSignal* abi_block, bool enableIPC)
      : Signal(abi_block, enableIPC) {
@@ -23,61 +23,19 @@ Bug: https://github.com/ROCm/ROCR-Runtime/issues/181
  }
  
  hsa_signal_value_t BusyWaitSignal::LoadRelaxed() {
---- src.orig/core/util/lnx/os_linux.cpp
-+++ src/core/util/lnx/os_linux.cpp
-@@ -130,9 +130,12 @@ class os_thread {
-       }
-     }
+--- a/core/runtime/hsa.cpp
++++ b/core/runtime/hsa.cpp
+@@ -155,7 +155,7 @@ template <class T> struct ValidityError<const T*> {
  
-+    int cores = 0;
-+    cpu_set_t* cpuset = nullptr;
-+
-     if (core::Runtime::runtime_singleton_->flag().override_cpu_affinity()) {
--      int cores = get_nprocs_conf();
--      cpu_set_t* cpuset = CPU_ALLOC(cores);
-+      cores = get_nprocs_conf();
-+      cpuset = CPU_ALLOC(cores);
-       if (cpuset == nullptr) {
-         fprintf(stderr, "CPU_ALLOC failed: %s\n", strerror(errno));
-         return;
-@@ -642,11 +645,13 @@ SharedMutex CreateSharedMutex() {
-     fprintf(stderr, "rw lock attribute init failed: %s\n", strerror(err));
-     return nullptr;
-   }
-+#if defined(__GLIBC__)
-   err = pthread_rwlockattr_setkind_np(&attrib, PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP);
-   if (err != 0) {
-     fprintf(stderr, "Set rw lock attribute failure: %s\n", strerror(err));
-     return nullptr;
-   }
-+#endif
- 
-   pthread_rwlock_t* lock = new pthread_rwlock_t;
-   err = pthread_rwlock_init(lock, &attrib);
---- src.orig/core/util/utils.h
-+++ src/core/util/utils.h
-@@ -74,7 +74,7 @@ static __forceinline void* _aligned_mall
-   return aligned_alloc(alignment, size);
- #else
-   void *mem = NULL;
--  if (NULL != posix_memalign(&mem, alignment, size))
-+  if (0 != posix_memalign(&mem, alignment, size))
-     return NULL;
-   return mem;
- #endif
---- src.orig/image/util.h
-+++ src/image/util.h
-@@ -99,7 +99,7 @@ static __forceinline void* _aligned_mall
-   return aligned_alloc(alignment, size);
- #else
-   void* mem = NULL;
--  if (NULL != posix_memalign(&mem, alignment, size)) return NULL;
-+  if (0 != posix_memalign(&mem, alignment, size)) return NULL;
-   return mem;
- #endif
+ template <class T>
+ static __forceinline bool IsValid(T* ptr) {
+-  return (ptr == NULL) ? NULL : ptr->IsValid();
++  return (ptr == NULL) ? false : ptr->IsValid();
  }
---- src.orig/core/util/lnx/os_linux.cpp
-+++ src/core/util/lnx/os_linux.cpp
+ 
+ namespace AMD {
+--- a/core/util/lnx/os_linux.cpp
++++ b/core/util/lnx/os_linux.cpp
 @@ -65,6 +65,16 @@
  #include <cpuid.h>
  #endif
@@ -95,7 +53,7 @@ Bug: https://github.com/ROCm/ROCR-Runtime/issues/181
  namespace rocr {
  namespace os {
  
-@@ -299,7 +309,7 @@ static int callback(struct dl_phdr_info* info, size_t size, void* data) {
+@@ -296,7 +306,7 @@ static int callback(struct dl_phdr_info* info, size_t size, void* data) {
          for (int j = 0;; j++) {
            if (dyn_section[j].d_tag == DT_NULL) break;
  
@@ -104,3 +62,39 @@ Bug: https://github.com/ROCm/ROCR-Runtime/issues/181
  
            if (dyn_section[j].d_tag == DT_STRSZ) limit = dyn_section[j].d_un.d_val;
          }
+@@ -642,11 +652,13 @@ SharedMutex CreateSharedMutex() {
+     fprintf(stderr, "rw lock attribute init failed: %s\n", strerror(err));
+     return nullptr;
+   }
++#if defined(__GLIBC__)
+   err = pthread_rwlockattr_setkind_np(&attrib, PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP);
+   if (err != 0) {
+     fprintf(stderr, "Set rw lock attribute failure: %s\n", strerror(err));
+     return nullptr;
+   }
++#endif
+ 
+   pthread_rwlock_t* lock = new pthread_rwlock_t;
+   err = pthread_rwlock_init(lock, &attrib);
+--- a/core/util/utils.h
++++ b/core/util/utils.h
+@@ -74,7 +74,7 @@ static __forceinline void* _aligned_malloc(size_t size, size_t alignment) {
+   return aligned_alloc(alignment, size);
+ #else
+   void *mem = NULL;
+-  if (NULL != posix_memalign(&mem, alignment, size))
++  if (0 != posix_memalign(&mem, alignment, size))
+     return NULL;
+   return mem;
+ #endif
+--- a/image/util.h
++++ b/image/util.h
+@@ -99,7 +99,7 @@ static __forceinline void* _aligned_malloc(size_t size, size_t alignment) {
+   return aligned_alloc(alignment, size);
+ #else
+   void* mem = NULL;
+-  if (NULL != posix_memalign(&mem, alignment, size)) return NULL;
++  if (0 != posix_memalign(&mem, alignment, size)) return NULL;
+   return mem;
+ #endif
+ }


### PR DESCRIPTION
This reapplies changes rocr-runtime-5.7.1-musl.patch more carefully.
Few files were not patched due to bad patch application.
No revbump, as it only affects broken musl target.

Closes: https://bugs.gentoo.org/935627

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
