### PR TITLE
media-video/imagination: restrict test

### DIFF
--- a/media-video/imagination/imagination-3.6.ebuild
+++ b/media-video/imagination/imagination-3.6.ebuild
@@ -24,6 +24,10 @@ RDEPEND="${DEPEND}
 	media-video/ffmpeg"
 BDEPEND="dev-util/intltool"
 
+# restricting tests as they're no practical tests
+# to run ayway, see bug #935691
+RESTRICT="test"
+
 PATCHES=(
 	"${FILESDIR}"/${P}-cflags.patch
 	"${FILESDIR}"/${PN}-3.0-fix-htmldir.patch


### PR DESCRIPTION
Signed-off-by: Michael Mair-Keimberger <mmk@levelnine.at>

Closes: https://bugs.gentoo.org/935691

Restricting tests as they're no practical tests to run anyway.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
