### PR TITLE
dev-python/pybind11: add patch for gcc14

### DIFF
--- a/dev-python/pybind11/files/pybind11-2.13.1-gcc14-fix.patch
+++ b/dev-python/pybind11/files/pybind11-2.13.1-gcc14-fix.patch
@@ -1,0 +1,23 @@
+Patch source: https://github.com/pybind/pybind11/commit/51c2aa16de5b50fe4be6a0016d6090d4a831899e
+From 51c2aa16de5b50fe4be6a0016d6090d4a831899e Mon Sep 17 00:00:00 2001
+From: wenqing <wenqing.wang@ufz.de>
+Date: Fri, 28 Jun 2024 16:12:32 +0200
+Subject: [PATCH] Fixed a compilation error with gcc 14 (#5208)
+
+---
+ include/pybind11/typing.h | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/include/pybind11/typing.h b/include/pybind11/typing.h
+index c8ba18d499..b0feb9464a 100644
+--- a/include/pybind11/typing.h
++++ b/include/pybind11/typing.h
+@@ -14,6 +14,8 @@
+ #include "cast.h"
+ #include "pytypes.h"
+ 
++#include <algorithm>
++
+ PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
+ PYBIND11_NAMESPACE_BEGIN(typing)
+ 

--- a/dev-python/pybind11/pybind11-2.13.1-r1.ebuild
+++ b/dev-python/pybind11/pybind11-2.13.1-r1.ebuild
@@ -1,0 +1,76 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DISTUTILS_USE_PEP517=setuptools
+PYTHON_COMPAT=( python3_{10..13} pypy3 )
+
+inherit cmake distutils-r1
+
+DESCRIPTION="AST-based Python refactoring library"
+HOMEPAGE="
+	https://pybind11.readthedocs.io/en/stable/
+	https://github.com/pybind/pybind11/
+	https://pypi.org/project/pybind11/
+"
+SRC_URI="
+	https://github.com/pybind/pybind11/archive/v${PV}.tar.gz
+		-> ${P}.gh.tar.gz
+"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~arm64-macos ~x64-macos"
+
+RDEPEND="
+	dev-cpp/eigen:3
+"
+BDEPEND="
+	test? (
+		<dev-cpp/catch-3:0
+		>=dev-cpp/catch-2.13.9:0
+		dev-libs/boost
+	)
+"
+
+PATCHES=( "${FILESDIR}/${P}-gcc14-fix.patch" )
+
+EPYTEST_XDIST=1
+distutils_enable_tests pytest
+
+python_prepare_all() {
+	cmake_src_prepare
+	distutils-r1_python_prepare_all
+}
+
+python_configure() {
+	local mycmakeargs=(
+		# disable forced lto
+		-DHAS_FLTO=OFF
+		# https://github.com/pybind/pybind11/issues/5087
+		-DPYBIND11_FINDPYTHON=OFF
+		-DPYBIND11_INSTALL=ON
+		-DPYBIND11_TEST=$(usex test)
+	)
+	cmake_src_configure
+}
+
+python_compile() {
+	distutils-r1_python_compile
+	# Compilation only does anything for tests
+	use test && cmake_src_compile
+}
+
+python_test() {
+	cmake_build cpptest test_cmake_build
+
+	local -x PYTEST_DISABLE_PLUGIN_AUTOLOAD=1
+	cd "${BUILD_DIR}/tests" || die
+	epytest "${S}/tests"
+}
+
+python_install() {
+	distutils-r1_python_install
+	cmake_src_install
+}


### PR DESCRIPTION
When compiling a plugin using pybind it fails at build time with:
```
In file included from /usr/include/pybind11/pybind11.h:19,
                 from common-cdm/cdmpy.cpp:3:
/usr/include/pybind11/typing.h: In constructor ‘constexpr pybind11::typing::StringLiteral<N>::StringLiteral(const char (&)[N])’:
/usr/include/pybind11/typing.h:104:58: error: ‘copy_n’ is not a member of ‘std’; did you mean ‘copy’?
  104 |     constexpr StringLiteral(const char (&str)[N]) { std::copy_n(str, N, name); }
      |                                                          ^~~~~~
      |                                                          copy
```

this was fixed in upstream by https://github.com/pybind/pybind11/commit/51c2aa16de5b50fe4be6a0016d6090d4a831899e. There is no release with that patch so it's added downstream

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
