### PR TITLE
dev-libs/tlsh: ensure symbol visibility on BE

### DIFF
--- a/dev-libs/tlsh/files/tlsh-4.8.2-big-endian.patch
+++ b/dev-libs/tlsh/files/tlsh-4.8.2-big-endian.patch
@@ -1,0 +1,15 @@
+__SPARC is defined on big endian platforms to fix bug 861710, but upstream
+disables use of default linkage visibility on SPARC systems.  This causes
+symbols to not be exported, causing issues such as bug 934445.
+
+--- tlsh-4.8.2/include/tlsh.h.old	2021-09-09 05:56:28.000000000 +0000
++++ tlsh-4.8.2/include/tlsh.h	2024-06-17 05:48:17.206665205 +0000
+@@ -110,7 +110,7 @@
+ // #include <WinFunctions.h>
+ 	#define TLSH_API
+ #else 
+-	#if defined(__SPARC) || defined(_AS_MK_OS_RH73)
++	#if defined(_AS_MK_OS_RH73)
+ 	   #define TLSH_API
+ 	#else
+ 	   #define TLSH_API __attribute__ ((visibility("default")))

--- a/dev-libs/tlsh/tlsh-4.8.2-r1.ebuild
+++ b/dev-libs/tlsh/tlsh-4.8.2-r1.ebuild
@@ -1,0 +1,40 @@
+# Copyright 2022-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+CMAKE_IN_SOURCE_BUILD=1
+inherit cmake toolchain-funcs flag-o-matic
+
+DESCRIPTION="Fuzzy matching library"
+HOMEPAGE="https://github.com/trendmicro/tlsh"
+SRC_URI="https://github.com/trendmicro/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="|| ( Apache-2.0 BSD )"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~ia64 ~ppc ~ppc64 ~x86"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-big-endian.patch
+	"${FILESDIR}"/${P}-gnuinstalldirs.patch
+	"${FILESDIR}"/${P}-respect-flags.patch
+)
+
+src_prepare() {
+	# https://github.com/trendmicro/tlsh/issues/131
+	[[ "$(tc-endian)" == "big" ]] && append-flags "-D__SPARC"
+	cmake_src_prepare
+}
+
+src_configure() {
+	local mycmakeargs=(
+		-DTLSH_CHECKSUM_1B=1
+		-DTLSH_SHARED_LIBRARY=1
+	)
+	cmake_src_configure
+}
+
+src_install() {
+	cmake_src_install
+	find "${ED}" -name '*.a' -delete || die # Remove the static lib
+}


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/934445

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
