### PR TITLE
app-arch/lbzip2: fix archive corruption due to clang/avx512 miscompilation

### DIFF
--- a/app-arch/lbzip2/lbzip2-2.5_p20181227-r3.ebuild
+++ b/app-arch/lbzip2/lbzip2-2.5_p20181227-r3.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit autotools flag-o-matic
+inherit autotools flag-o-matic toolchain-funcs
 
 DESCRIPTION="Parallel bzip2 utility"
 HOMEPAGE="https://github.com/kjn/lbzip2/"
@@ -28,6 +28,10 @@ src_prepare() {
 
 src_configure() {
 	use static && append-ldflags -static
+
+	# fix clang miscompilation: #910438
+	# see also: https://github.com/llvm/llvm-project/issues/87189
+	tc-is-clang && test-flag-CC -mno-avx512f && append-cflags -mno-avx512f
 
 	local myeconfargs=(
 		$(use_enable debug tracing)


### PR DESCRIPTION
Reported as https://github.com/llvm/llvm-project/issues/87189, clang miscompiles lbzip2 when AVX-512 instructions (`x86-64-v3`) are enabled, resulting in corrupted archives (even breaking emerge, when enabled systemwide via `app-alternatives/bzip2`). Let's disable these instructions.

Closes: https://bugs.gentoo.org/910438

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
