### PR TITLE
add USE flags for "cue" and "wav"

### DIFF
--- a/media-sound/cmus/cmus-2.11.0.ebuild
+++ b/media-sound/cmus/cmus-2.11.0.ebuild
@@ -20,9 +20,9 @@ S="${WORKDIR}/${P/_/-}"
 
 LICENSE="GPL-2"
 SLOT="0"
-IUSE="aac alsa ao cddb cdio debug discid elogind examples ffmpeg +flac jack libsamplerate
+IUSE="aac alsa ao cddb cdio +cue debug discid elogind examples ffmpeg +flac jack libsamplerate
 	+mad mikmod modplug mp4 musepack opus oss pidgin pulseaudio sndio systemd tremor +unicode
-	+vorbis wavpack"
+	+vorbis +wav wavpack"
 
 # Both CONFIG_TREMOR=y and CONFIG_VORBIS=y are required to link to tremor libs instead of vorbis libs
 REQUIRED_USE="
@@ -82,7 +82,6 @@ src_configure() {
 	local debuglevel=1
 	use debug && debuglevel=2
 	local myconf=(
-		CONFIG_CUE=y
 		CONFIG_ARTS=n
 		CONFIG_SUN=n
 		CONFIG_SNDIO=n
@@ -91,6 +90,8 @@ src_configure() {
 		CONFIG_ROAR=n
 	)
 
+	my_config cue CONFIG_CUE
+	my_config wav CONFIG_WAV
 	my_config cddb CONFIG_CDDB
 	my_config cdio CONFIG_CDIO
 	my_config discid CONFIG_DISCID


### PR DESCRIPTION
two USE flags are missing "cue" and "wav" both should be optional.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [ x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [ x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [ x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
