### PR TITLE
media-sound/cmus-2.11.0 add USE flag "cue" and "wav" 

### DIFF
--- a/media-sound/cmus/cmus-2.11.0.ebuild
+++ b/media-sound/cmus/cmus-2.11.0.ebuild
@@ -20,9 +20,9 @@ S="${WORKDIR}/${P/_/-}"
 
 LICENSE="GPL-2"
 SLOT="0"
-IUSE="aac alsa ao cddb cdio debug discid elogind examples ffmpeg +flac jack libsamplerate
+IUSE="aac alsa ao cddb cdio +cue debug discid elogind examples ffmpeg +flac jack libsamplerate
 	+mad mikmod modplug mp4 musepack opus oss pidgin pulseaudio sndio systemd tremor +unicode
-	+vorbis wavpack"
+	+vorbis +wav wavpack"
 
 # Both CONFIG_TREMOR=y and CONFIG_VORBIS=y are required to link to tremor libs instead of vorbis libs
 REQUIRED_USE="
@@ -82,7 +82,6 @@ src_configure() {
 	local debuglevel=1
 	use debug && debuglevel=2
 	local myconf=(
-		CONFIG_CUE=y
 		CONFIG_ARTS=n
 		CONFIG_SUN=n
 		CONFIG_SNDIO=n
@@ -91,6 +90,8 @@ src_configure() {
 		CONFIG_ROAR=n
 	)
 
+	my_config cue CONFIG_CUE
+	my_config wav CONFIG_WAV
 	my_config cddb CONFIG_CDDB
 	my_config cdio CONFIG_CDIO
 	my_config discid CONFIG_DISCID

--- a/media-sound/cmus/metadata.xml
+++ b/media-sound/cmus/metadata.xml
@@ -7,12 +7,14 @@
 	</maintainer>
 	<use>
 		<flag name="cdio">Use libcdio for CD support </flag>
+		<flag name="cue">Use cue for CUE sheets support </flag>
 		<flag name="discid">Enable reading the ID of the inserted CD</flag>
 		<flag name="elogind">Enable MPRIS support via <pkg>sys-auth/elogind</pkg></flag>
 		<flag name="pidgin">Install support script for <pkg>net-im/pidgin</pkg></flag>
 		<flag name="sndio">Add support for <pkg>media-sound/sndio</pkg></flag>
 		<flag name="systemd">Enable MPRIS support via <pkg>sys-apps/systemd</pkg></flag>
 		<flag name="tremor">Use libivorbis from <pkg>media-libs/tremor</pkg> instead of <pkg>media-libs/libvorbis</pkg></flag>
+		<flag name="wav">Enable WAV support </flag>
 	</use>
 	<upstream>
 		<remote-id type="github">cmus/cmus</remote-id>


### PR DESCRIPTION
two USE flags are missing "cue" and "wav" both should be optional.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
