### PR TITLE
sci-libs/hipBLASLt: enforce libstdc++ as build with libc++ fails

### DIFF
--- a/sci-libs/hipBLASLt/hipBLASLt-6.1.1.ebuild
+++ b/sci-libs/hipBLASLt/hipBLASLt-6.1.1.ebuild
@@ -9,7 +9,7 @@ PYTHON_COMPAT=( python3_{10..13} )
 # gfx941 and gfx942 assembly uses directives of LLVM >= 18.1.0
 LLVM_COMPAT=( 18 )
 
-inherit cmake python-any-r1 llvm-r1 prefix rocm
+inherit cmake flag-o-matic python-any-r1 llvm-r1 prefix rocm
 DESCRIPTION="General matrix-matrix operations library for AMD Instinct accelerators"
 HOMEPAGE="https://github.com/ROCm/hipBLASLt"
 SRC_URI="https://github.com/ROCm/hipBLASLt/archive/rocm-${PV}.tar.gz -> ${P}.tar.gz"
@@ -95,6 +95,8 @@ src_configure() {
 
 	use test && mycmakeargs+=( -DBUILD_FORTRAN_CLIENTS=ON )
 
+	# enforce libstdc++, as libc++ fails: https://github.com/llvm/llvm-project/issues/98734
+	append-cxxflags --stdlib=libstdc++
 	CXX=hipcc cmake_src_configure
 }
 


### PR DESCRIPTION
Relevant libc++ bug: https://github.com/llvm/llvm-project/issues/98734

Closes: https://bugs.gentoo.org/935998

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
