### PR TITLE
games-board/stockfish: fix clang build failure

### DIFF
--- a/games-board/stockfish/stockfish-16-r1.ebuild
+++ b/games-board/stockfish/stockfish-16-r1.ebuild
@@ -22,6 +22,12 @@ DEPEND="|| ( app-arch/unzip app-arch/zip )"
 
 S="${WORKDIR}/Stockfish-sf_${PV}/src"
 
+pkg_setup() {
+	if ! tc-is-clang && ! tc-is-gcc; then
+		die "Unsupported compiler: $(tc-getCC)"
+	fi
+}
+
 src_prepare() {
 	default
 
@@ -66,11 +72,16 @@ src_compile() {
 	use ppc && my_arch=ppc
 	use ppc64 && my_arch=ppc64
 
+	# Bug 919781: COMP is a fixed string like clang/gcc to set tools for PGO
+	local comp
+	tc-is-gcc && comp="gcc"
+	tc-is-clang && comp="clang"
+
 	# There's a nice hack in the Makefile that overrides the value of CXX with
 	# COMPILER to support Travis CI and we abuse it to make sure that we
 	# build with our compiler of choice.
 	emake profile-build ARCH="${my_arch}" \
-		COMP="$(tc-getCXX)" \
+		COMP="${comp}" \
 		COMPILER="$(tc-getCXX)" \
 		debug=$(usex debug "yes" "no") \
 		optimize=$(usex optimize "yes" "no")

--- a/games-board/stockfish/stockfish-16.1.ebuild
+++ b/games-board/stockfish/stockfish-16.1.ebuild
@@ -26,6 +26,12 @@ DEPEND="|| ( app-arch/unzip app-arch/zip )"
 
 S="${WORKDIR}/Stockfish-sf_${PV}/src"
 
+pkg_setup() {
+	if ! tc-is-clang && ! tc-is-gcc; then
+		die "Unsupported compiler: $(tc-getCC)"
+	fi
+}
+
 src_prepare() {
 	default
 
@@ -72,11 +78,16 @@ src_compile() {
 	use ppc && my_arch=ppc
 	use ppc64 && my_arch=ppc64
 
+	# Bug 919781: COMP is a fixed string like clang/gcc to set tools for PGO
+	local comp
+	tc-is-gcc && comp="gcc"
+	tc-is-clang && comp="clang"
+
 	# There's a nice hack in the Makefile that overrides the value of CXX with
 	# COMPILER to support Travis CI and we abuse it to make sure that we
 	# build with our compiler of choice.
 	emake profile-build ARCH="${my_arch}" \
-		COMP="$(tc-getCXX)" \
+		COMP="${comp}" \
 		COMPILER="$(tc-getCXX)" \
 		debug=$(usex debug "yes" "no") \
 		optimize=$(usex optimize "yes" "no")

--- a/games-board/stockfish/stockfish-16.ebuild
+++ b/games-board/stockfish/stockfish-16.ebuild
@@ -22,6 +22,12 @@ DEPEND="|| ( app-arch/unzip app-arch/zip )"
 
 S="${WORKDIR}/Stockfish-sf_${PV}/src"
 
+pkg_setup() {
+	if ! tc-is-clang && ! tc-is-gcc; then
+		die "Unsupported compiler: $(tc-getCC)"
+	fi
+}
+
 src_prepare() {
 	default
 
@@ -61,11 +67,16 @@ src_compile() {
 	use ppc && my_arch=ppc
 	use ppc64 && my_arch=ppc64
 
+	# Bug 919781: COMP is a fixed string like clang/gcc to set tools for PGO
+	local comp
+	tc-is-gcc && comp="gcc"
+	tc-is-clang && comp="clang"
+
 	# There's a nice hack in the Makefile that overrides the value of CXX with
 	# COMPILER to support Travis CI and we abuse it to make sure that we
 	# build with our compiler of choice.
 	emake profile-build ARCH="${my_arch}" \
-		COMP="$(tc-getCXX)" \
+		COMP="${comp}" \
 		COMPILER="$(tc-getCXX)" \
 		debug=$(usex debug "yes" "no") \
 		optimize=$(usex optimize "yes" "no")

--- a/games-board/stockfish/stockfish-17.ebuild
+++ b/games-board/stockfish/stockfish-17.ebuild
@@ -26,6 +26,12 @@ DEPEND="|| ( app-arch/unzip app-arch/zip )"
 
 S="${WORKDIR}/Stockfish-sf_${PV}/src"
 
+pkg_setup() {
+	if ! tc-is-clang && ! tc-is-gcc; then
+		die "Unsupported compiler: $(tc-getCC)"
+	fi
+}
+
 src_prepare() {
 	default
 
@@ -72,11 +78,16 @@ src_compile() {
 	use ppc && my_arch=ppc
 	use ppc64 && my_arch=ppc64
 
+	# Bug 919781: COMP is a fixed string like clang/gcc to set tools for PGO
+	local comp
+	tc-is-gcc && comp="gcc"
+	tc-is-clang && comp="clang"
+
 	# There's a nice hack in the Makefile that overrides the value of CXX with
 	# COMPILER to support Travis CI and we abuse it to make sure that we
 	# build with our compiler of choice.
 	emake profile-build ARCH="${my_arch}" \
-		COMP="$(tc-getCXX)" \
+		COMP="${comp}" \
 		COMPILER="$(tc-getCXX)" \
 		debug=$(usex debug "yes" "no") \
 		optimize=$(usex optimize "yes" "no")


### PR DESCRIPTION
`COMP` should be a fixed string like clang/gcc to set tools for PGO (not `clang-18` or `clang++`).
Possible values are described in [documentation](https://disservin.github.io/stockfish-docs/stockfish-wiki/Compiling-from-source.html#compilers).
Note that even though `COMP` refers to C compiler name, Makefile only calls only C++ compiler provided in `COMPILER` parameter.

Closes: https://bugs.gentoo.org/919781

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
