### PR TITLE
net-wireless/blueman: run eautoreconf

### DIFF
--- a/net-wireless/blueman/blueman-2.4.2.ebuild
+++ b/net-wireless/blueman/blueman-2.4.2.ebuild
@@ -97,12 +97,10 @@ pkg_setup() {
 }
 
 src_prepare() {
-	if [[ ${PV} == 9999 ]]; then
+		# Run else fails on newer automake: https://bugs.gentoo.org/936065
 		eautoreconf
-	else
 		# remove this when upstream switches to automake with .pyc fix
 		eautomake
-	fi
 	distutils-r1_src_prepare
 }
 


### PR DESCRIPTION
Just run it else we need to require old version.

Closes: https://bugs.gentoo.org/936065

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X ] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
