### PR TITLE
x11-wm/marco: fix QA Python "-native-symlink", fix #906826

### DIFF
--- a/x11-wm/marco/marco-1.26.2-r1.ebuild
+++ b/x11-wm/marco/marco-1.26.2-r1.ebuild
@@ -1,11 +1,14 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
 MATE2_LA_PUNT="yes"
+# For script meson_post_install.py
+# Bug 906826, tracker bug 762406
+PYTHON_COMPAT=( python3_{10..13} )
 
-inherit mate meson
+inherit mate meson python-any-r1
 
 KEYWORDS="amd64 ~arm ~arm64 ~loong ~riscv x86"
 
@@ -41,6 +44,8 @@ COMMON_DEPEND="
 	>=x11-libs/startup-notification-0.7
 	xinerama? ( x11-libs/libXinerama )
 "
+
+DEPEND="${PYTHON_DEPS}"
 
 RDEPEND="${COMMON_DEPEND}
 	gnome-extra/zenity

--- a/x11-wm/marco/marco-1.28.1-r1.ebuild
+++ b/x11-wm/marco/marco-1.28.1-r1.ebuild
@@ -4,8 +4,11 @@
 EAPI=8
 
 MATE2_LA_PUNT="yes"
+# For script meson_post_install.py
+# Bug 906826, tracker bug 762406
+PYTHON_COMPAT=( python3_{10..13} )
 
-inherit mate meson
+inherit mate meson python-any-r1
 
 MINOR=$(($(ver_cut 2) % 2))
 if [[ ${MINOR} -eq 0 ]]; then
@@ -45,6 +48,8 @@ COMMON_DEPEND="
 	>=x11-libs/startup-notification-0.7
 	xinerama? ( x11-libs/libXinerama )
 "
+
+DEPEND="${PYTHON_DEPS}"
 
 RDEPEND="${COMMON_DEPEND}
 	gnome-extra/zenity


### PR DESCRIPTION
Tested with Python 3.12, humanly verified to also be Python 3.11 compliant.

Closes: https://bugs.gentoo.org/906826

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
