### PR TITLE
mail-filter/courier-pythonfilter: add missing config install

### DIFF
--- a/mail-filter/courier-pythonfilter/courier-pythonfilter-3.0.6-r1.ebuild
+++ b/mail-filter/courier-pythonfilter/courier-pythonfilter-3.0.6-r1.ebuild
@@ -1,0 +1,24 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+PYTHON_COMPAT=( python3_{9,10,11,12,13} )
+PYPI_NO_NORMALIZE=1
+DISTUTILS_USE_PEP517=setuptools
+inherit distutils-r1 pypi
+
+DESCRIPTION="Python filtering architecture for the Courier MTA"
+HOMEPAGE="https://pypi.org/project/courier-pythonfilter/"
+
+LICENSE="GPL-3"
+SLOT="0"
+KEYWORDS="~amd64"
+
+DEPEND="mail-mta/courier"
+
+src_install() {
+	insinto /etc
+
+	doins pythonfilter.conf
+	doins pythonfilter-modules.conf
+}


### PR DESCRIPTION
add missing install step which install essential default config for this filter to properly function

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
