### PR TITLE
media-gfx/oxipng: fix linker name for arm64

### DIFF
--- a/media-gfx/oxipng/oxipng-9.0.0.ebuild
+++ b/media-gfx/oxipng/oxipng-9.0.0.ebuild
@@ -113,6 +113,14 @@ BDEPEND=">=virtual/rust-1.66.0"
 
 QA_FLAGS_IGNORED="usr/bin/${PN}"
 
+src_prepare() {
+	# Remove the linker configs (in `.cargo/config.toml`) specific to GitHub CI.
+	# https://bugs.gentoo.org/924946
+	rm -rv "${S}/.cargo/config.toml" || die
+
+	default_src_prepare
+}
+
 src_install() {
 	cargo_src_install
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/924946

The upstream oxipng source has `.cargo/config.toml` file, which changes the cargo build config.
It has linker settings for arm64 cross compilation on GitHub CI, but the linker name does not match with the name in arm64 Gentoo.
This pull request simply removes the config file to let cargo proceed the build with the default config.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
