### PR TITLE
media-gfx/krita: Fix package issues with new deps zug, immer, and lager

### DIFF
--- a/dev-libs/immer/immer-0.8.1-r1.ebuild
+++ b/dev-libs/immer/immer-0.8.1-r1.ebuild
@@ -1,0 +1,51 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit cmake
+
+DESCRIPTION="Library of persistent and immutable data structures written in C++"
+HOMEPAGE="https://sinusoid.es/immer/"
+SRC_URI="https://github.com/arximboldi/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="Boost-1.0"
+SLOT="0"
+KEYWORDS="~amd64 ~arm64 ~riscv"
+IUSE="test"
+RESTRICT="!test? ( test )"
+
+RDEPEND="
+	dev-libs/boost:=
+	dev-libs/boehm-gc
+"
+DEPEND="${RDEPEND}"
+BDEPEND="
+	test? (
+		<dev-cpp/catch-3:0
+		dev-libs/libfmt
+	)
+"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-fix-dvector-test.patch
+)
+
+src_configure() {
+	local mycmakeargs=(
+		-DCCACHE=no
+		-Dimmer_BUILD_DOCS=OFF # Recheck if documentation is in a better state when bumping
+		-Dimmer_BUILD_EXAMPLES=OFF
+		-Dimmer_BUILD_EXTRAS=OFF
+		-Dimmer_BUILD_TESTS=$(usex test)
+		-DDISABLE_WERROR=ON
+	)
+	cmake_src_configure
+}
+
+src_compile() {
+	cmake_src_compile
+	if use test; then
+		cmake_build tests
+	fi
+}

--- a/dev-libs/lager/lager-0.1.1-r1.ebuild
+++ b/dev-libs/lager/lager-0.1.1-r1.ebuild
@@ -1,0 +1,52 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit cmake
+
+DESCRIPTION="Library to assist value-oriented design"
+HOMEPAGE="https://sinusoid.es/lager/"
+SRC_URI="https://github.com/arximboldi/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~amd64 ~arm64 ~riscv"
+IUSE="test"
+RESTRICT="!test? ( test )"
+
+RDEPEND="
+	dev-libs/boost:=
+	dev-libs/zug
+	dev-libs/immer
+"
+DEPEND="${RDEPEND}"
+BDEPEND="
+	test? (
+		<dev-cpp/catch-3:0
+		dev-libs/cereal
+		dev-qt/qtcore
+		dev-qt/qtconcurrent
+		dev-qt/qtdeclarative
+	)
+"
+
+src_configure() {
+	local mycmakeargs=(
+		-DCCACHE=no
+		-Dlager_BUILD_DEBUGGER_EXAMPLES=OFF
+		-Dlager_BUILD_DOCS=OFF # Check if docs are more complete on version bumps
+		-Dlager_BUILD_EXAMPLES=OFF
+		-Dlager_BUILD_FAILURE_TESTS=OFF
+		-Dlager_BUILD_TESTS=$(usex test)
+	)
+
+	cmake_src_configure
+}
+
+src_compile() {
+	cmake_src_compile
+	if use test; then
+		cmake_build tests
+	fi
+}

--- a/dev-libs/zug/zug-0.1.1-r1.ebuild
+++ b/dev-libs/zug/zug-0.1.1-r1.ebuild
@@ -1,0 +1,42 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit cmake
+
+DESCRIPTION="Transducers for C++"
+HOMEPAGE="https://sinusoid.es/zug/"
+SRC_URI="https://github.com/arximboldi/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="Boost-1.0"
+SLOT="0"
+KEYWORDS="~amd64 ~arm64 ~riscv"
+IUSE="test"
+RESTRICT="!test? ( test )"
+
+DEPEND="dev-libs/boost:="
+
+BDEPEND="
+	test? ( <dev-cpp/catch-3:0 )
+"
+
+src_configure() {
+	local mycmakeargs=(
+		-DCCACHE=no
+		-DDISABLE_WERROR=yes
+		-Dzug_BUILD_DOCS=no # Recheck if documentation is in a better state when bumping
+		-Dzug_BUILD_EXAMPLES=no
+		-Dzug_BUILD_TESTS=$(usex test)
+	)
+
+	cmake_src_configure
+}
+
+src_compile() {
+	cmake_src_compile
+	if use test; then
+		cmake_build tests
+	fi
+
+}


### PR DESCRIPTION
As reported in:
https://bugs.gentoo.org/936024
https://bugs.gentoo.org/936025
https://bugs.gentoo.org/936026
https://bugs.gentoo.org/936027

Fix missing deps for tests of zug, immer and lager.
Also fix zug always adding `-Werror`.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
