### PR TITLE
net-proxy/tayga: fix -Wint-coversion warnings with Clang

### DIFF
--- a/net-proxy/tayga/files/tayga-0.9.2-replace-null-with-nul.patch
+++ b/net-proxy/tayga/files/tayga-0.9.2-replace-null-with-nul.patch
@@ -1,0 +1,23 @@
+Clang's -Wint-conversion warns about conversion from NULL to '\0'. Suppress the
+warning.
+
+--- a/conffile.c
++++ b/conffile.c
+@@ -222,7 +222,7 @@ static void config_map(int ln, int arg_count, char **args)
+ 	unsigned int prefix4 = 32;
+ 	if (slash) {
+ 		prefix4 = atoi(slash+1);
+-		slash[0] = NULL;
++		slash[0] = '\0';
+ 	}
+ 
+ 	if (!inet_pton(AF_INET, args[0], &m->map4.addr)) {
+@@ -237,7 +237,7 @@ static void config_map(int ln, int arg_count, char **args)
+ 	slash = strchr(args[1], '/');
+ 	if (slash) {
+ 		prefix6 = atoi(slash+1);
+-		slash[0] = NULL;
++		slash[0] = '\0';
+ 	}
+ 
+ 	if ((32 - prefix4) != (128 - prefix6)) {

--- a/net-proxy/tayga/tayga-0.9.2-r5.ebuild
+++ b/net-proxy/tayga/tayga-0.9.2-r5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -18,6 +18,7 @@ PATCHES=(
 	"${FILESDIR}"/${P}-manpage-RFC.patch
 	"${FILESDIR}"/${P}-release-reserved-addr.patch
 	"${FILESDIR}"/${PN}-0.9.2-Fix-implicit-function-declaration.patch
+	"${FILESDIR}"/${PN}-0.9.2-replace-null-with-nul.patch
 )
 
 src_prepare() {


### PR DESCRIPTION
Clang warns about the conversion from NULL -> char here. With -Werror, the build breaks. Tayga's upstream was last updated >10y ago, so just carry a local patch.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
