### PR TITLE
net-dialup/ppp: fix invalid function signatures

### DIFF
--- a/net-dialup/ppp/files/ppp-2.4.9-fix-function-signatures.patch
+++ b/net-dialup/ppp/files/ppp-2.4.9-fix-function-signatures.patch
@@ -1,0 +1,24 @@
+pppd converts mplscp_nakci to an `int (*)(fsm *, u_char *, int, int)`. Having an
+incorrect signature causes clang to warn and -Werror out.
+
+--- a/pppd/mplscp.c
++++ b/pppd/mplscp.c
+@@ -25,7 +25,7 @@ static void mplscp_resetci (fsm *);	/* Reset our CI */
+ static int  mplscp_cilen (fsm *);	/* Return length of our CI */
+ static void mplscp_addci (fsm *, u_char *, int *); 	/* Add our CI */
+ static int  mplscp_ackci (fsm *, u_char *, int);	/* Peer ack'd our CI */
+-static int  mplscp_nakci (fsm *, u_char *, int);	/* Peer nak'd our CI */
++static int  mplscp_nakci (fsm *, u_char *, int, int);	/* Peer nak'd our CI */
+ static int  mplscp_rejci (fsm *, u_char *, int);	/* Peer rej'd our CI */
+ static int  mplscp_reqci (fsm *, u_char *, int *, int); /* Rcv CI */
+ static void mplscp_up (fsm *);		/* We're UP */
+@@ -218,7 +218,7 @@ mplscp_ackci(fsm *f, u_char *p, int  len) {
+  *	1 - Nak was good.
+  */
+ static int
+-mplscp_nakci(fsm *f, u_char *p, int len) {
++mplscp_nakci(fsm *f, u_char *p, int len, int unused) {
+ 
+   return 1;
+ }
+

--- a/net-dialup/ppp/ppp-2.4.9-r10.ebuild
+++ b/net-dialup/ppp/ppp-2.4.9-r10.ebuild
@@ -41,6 +41,7 @@ src_prepare() {
 	eapply "${FILESDIR}"/${P}-fix-clang-nested-functions.patch
 	eapply "${FILESDIR}"/${P}-fix-openssl-sysroot-clang.patch
 	eapply "${FILESDIR}"/${P}-pppol2tp-ipv6.patch
+	eapply "${FILESDIR}"/${P}-fix-function-signatures.patch
 
 	#IPX Support is removed in kernel >= 5.15
 	sed -i 's/-DIPX_CHANGE //' pppd/Makefile.linux || die


### PR DESCRIPTION
mplscp_nakci is used in as a function that takes `(fsm *, u_char *, int, int)`. Implicitly converting causes Clang to complain.

**Please note**: 

1. I don't expect this is the best way to apply this patch. `pppd/mplscp.c` is added by the `"${WORKDIR}"/patches` bundle in this ebuild. I've never uploaded to dev.gentoo.org, so I presume I lack access to upload an updated tarball.
2. `pkgcheck scan --commits --net` exited with a handful of existing errors in the ebuild that this patch doesn't address:

```
  UnstableOnly: for arch: [ hppa ], all versions are unstable: [ 2.4.9-r10, 2.5.0-r7 ]
  ExcessiveLineLength: version 2.4.9-r10: excessive line length (over 120 characters) on lines: 221, 222
  NonexistentBlocker: version 2.4.9-r10: nonexistent blocker RDEPEND="!<net-misc/netifrc-0.7.1-r2": no matches in repo history
  RedundantVersion: version 2.4.9-r10: slot(0) keywords are overshadowed by version: 2.5.0-r7
  UseFlagWithoutDeps: version 2.4.9-r10: special small-files USE flag without effect on dependencies: [ ipv6 ]
  VariableOrderWrong: version 2.4.9-r10: variable S should occur before IUSE
  NonexistentBlocker: version 2.5.0-r7: nonexistent blocker RDEPEND="!<net-misc/netifrc-0.7.1-r2": no matches in repo history
  PotentialStable: version 2.5.0-r7: slot(0), stabled arches: [ amd64, arm, arm64, ppc, ppc64, sparc, x86 ], potential: [ ~hppa ]
  NewerEAPIAvailable: version 2.4.9-r10: ebuild eligible for newer EAPI=8
  IncorrectCopyright: version 2.4.9-r10: incorrect copyright year 2023: '# Copyright 1999-2023 Gentoo Authors'
```

Happy to fix those if we want to push this PR through, but I expect it'll take a different form if my first note is correct. 

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
