### PR TITLE
app-editors/vscodium: fix dead link in pkg_postinstall()

### DIFF
--- a/app-editors/vscodium/vscodium-1.91.0.24190.ebuild
+++ b/app-editors/vscodium/vscodium-1.91.0.24190.ebuild
@@ -122,7 +122,7 @@ src_install() {
 pkg_postinst() {
 	xdg_pkg_postinst
 	elog "When compared to the regular VSCode, VSCodium has a few quirks"
-	elog "More information at: https://github.com/VSCodium/vscodium/blob/master/DOCS.md"
+	elog "More information at: https://github.com/VSCodium/vscodium/blob/master/docs/index.md"
 	optfeature "desktop notifications" x11-libs/libnotify
 	optfeature "keyring support inside vscode" "virtual/secret-service"
 }

--- a/app-editors/vscodium/vscodium-1.91.1.24193.ebuild
+++ b/app-editors/vscodium/vscodium-1.91.1.24193.ebuild
@@ -122,7 +122,7 @@ src_install() {
 pkg_postinst() {
 	xdg_pkg_postinst
 	elog "When compared to the regular VSCode, VSCodium has a few quirks"
-	elog "More information at: https://github.com/VSCodium/vscodium/blob/master/DOCS.md"
+	elog "More information at: https://github.com/VSCodium/vscodium/blob/master/docs/index.md"
 	optfeature "desktop notifications" x11-libs/libnotify
 	optfeature "keyring support inside vscode" "virtual/secret-service"
 }


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/936201

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
