### PR TITLE
dev-java/openjdk-bin: force remove 'lib/lib*splashscreen*'

### DIFF
--- a/dev-java/openjdk-bin/openjdk-bin-21.0.3_p9-r1.ebuild
+++ b/dev-java/openjdk-bin/openjdk-bin-21.0.3_p9-r1.ebuild
@@ -106,7 +106,8 @@ src_install() {
 		fi
 
 		if use headless-awt ; then
-			rm -v lib/lib*{[jx]awt,splashscreen}* || die
+			# do not die if not available, -f for bug #934974
+			rm -fv lib/lib*{[jx]awt,splashscreen}* || die
 		fi
 	fi
 


### PR DESCRIPTION
for building with headless-awt, splashscreen and frieds need to get removed. it should not die if something cannot be removed because it does not exist.

Closes: https://bugs.gentoo.org/934974

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
