### PR TITLE
🐍 media-libs/libaom: add Python 3.13 support

### DIFF
--- a/media-libs/libaom/libaom-3.9.1.ebuild
+++ b/media-libs/libaom/libaom-3.9.1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..13} )
 inherit cmake-multilib flag-o-matic multiprocessing python-any-r1
 
 if [[ ${PV} == *9999* ]]; then

--- a/media-libs/libaom/libaom-9999.ebuild
+++ b/media-libs/libaom/libaom-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..13} )
 inherit cmake-multilib flag-o-matic multiprocessing python-any-r1
 
 if [[ ${PV} == *9999* ]]; then

--- a/media-libs/libaom/metadata.xml
+++ b/media-libs/libaom/metadata.xml
@@ -4,4 +4,7 @@
 	<maintainer type="project">
 		<email>media-video@gentoo.org</email>
 	</maintainer>
+	<upstream>
+		<bugs-to>https://aomedia.issues.chromium.org/issues</bugs-to>
+	</upstream>
 </pkgmetadata>


### PR DESCRIPTION
_Hello everyone,_

It would be nice to have an ability to build **libaom** `3.9.1` and `9999` with Python 3.13.
This PR also adds the `bugs-to` url to `metadata.xml`.

_Best regards!_

---

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
