### PR TITLE
net-wireless/wpa_supplicant: fix building of the live ebuild

### DIFF
--- a/net-wireless/wpa_supplicant/wpa_supplicant-9999.ebuild
+++ b/net-wireless/wpa_supplicant/wpa_supplicant-9999.ebuild
@@ -124,7 +124,9 @@ src_prepare() {
 
 	# bug (912315)
 	eapply "${FILESDIR}/${PN}-2.10-allow-legacy-renegotiation.patch"
-	eapply "${FILESDIR}/${P}-Drop-security-level-to-0-with-OpenSSL-3.0-wh.patch"
+	if [ "${PV}" != 9999 ]; then
+		eapply "${FILESDIR}/${PN}-2.10-Drop-security-level-to-0-with-OpenSSL-3.0-wh.patch"
+	fi
 
 	# bug (640492)
 	sed -i 's#-Werror ##' wpa_supplicant/Makefile || die


### PR DESCRIPTION
Do not apply a patch that already exists in the upstream source.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
