### PR TITLE
Flag fixes for ROCm libraries

### DIFF
--- a/dev-libs/rccl/rccl-6.1.1.ebuild
+++ b/dev-libs/rccl/rccl-6.1.1.ebuild
@@ -48,6 +48,8 @@ src_prepare() {
 }
 
 src_configure() {
+	rocm_use_hipcc
+
 	# https://github.com/llvm/llvm-project/issues/71711 - fix issue of clang
 	append-ldflags -Wl,-z,noexecstack
 
@@ -59,7 +61,7 @@ src_configure() {
 		-Wno-dev
 	)
 
-	CXX=hipcc cmake_src_configure
+	cmake_src_configure
 }
 
 src_test() {

--- a/dev-libs/rocm-device-libs/rocm-device-libs-6.1.1.ebuild
+++ b/dev-libs/rocm-device-libs/rocm-device-libs-6.1.1.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 LLVM_COMPAT=( 18 )
-inherit cmake llvm-r1
+inherit cmake flag-o-matic llvm-r1
 
 MY_P=llvm-project-rocm-${PV}
 components=( "amd/device-libs" )
@@ -66,12 +66,17 @@ src_prepare() {
 }
 
 src_configure() {
+	# Do not trust CMake with autoselecting Clang, as it autoselects the latest one
+	# producing too modern LLVM bitcode and causing linker errors in other packages.
+	# Clean up unsupported flags for the switched compiler, see #936099
+	local -x CC="$(get_llvm_prefix)/bin/clang"
+	local -x CXX="$(get_llvm_prefix)/bin/clang++"
+	strip-unsupported-flags
+
 	local mycmakeargs=(
 		-DLLVM_DIR="$(get_llvm_prefix)"
 	)
-	# do not trust CMake with autoselecting Clang, as it autoselects the latest one
-	# producing too modern LLVM bitcode and causing linker errors in other packages
-	CC="$(get_llvm_prefix)/bin/clang" CXX="$(get_llvm_prefix)/bin/clang++" cmake_src_configure
+	cmake_src_configure
 }
 
 src_install() {

--- a/dev-libs/rocm-device-libs/rocm-device-libs-6.1.2.ebuild
+++ b/dev-libs/rocm-device-libs/rocm-device-libs-6.1.2.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 LLVM_COMPAT=( 18 )
-inherit cmake llvm-r1
+inherit cmake flag-o-matic llvm-r1
 
 MY_P=llvm-project-rocm-${PV}
 components=( "amd/device-libs" )
@@ -67,12 +67,17 @@ src_prepare() {
 }
 
 src_configure() {
+	# Do not trust CMake with autoselecting Clang, as it autoselects the latest one
+	# producing too modern LLVM bitcode and causing linker errors in other packages.
+	# Clean up unsupported flags for the switched compiler, see #936099
+	local -x CC="$(get_llvm_prefix)/bin/clang"
+	local -x CXX="$(get_llvm_prefix)/bin/clang++"
+	strip-unsupported-flags
+
 	local mycmakeargs=(
 		-DLLVM_DIR="$(get_llvm_prefix)"
 	)
-	# do not trust CMake with autoselecting Clang, as it autoselects the latest one
-	# producing too modern LLVM bitcode and causing linker errors in other packages
-	CC="$(get_llvm_prefix)/bin/clang" CXX="$(get_llvm_prefix)/bin/clang++" cmake_src_configure
+	cmake_src_configure
 }
 
 src_install() {

--- a/dev-util/Tensile/Tensile-6.1.1.ebuild
+++ b/dev-util/Tensile/Tensile-6.1.1.ebuild
@@ -88,6 +88,8 @@ src_prepare() {
 }
 
 src_configure() {
+	rocm_use_hipcc
+
 	distutils-r1_src_configure
 	if use client; then
 		local mycmakeargs=(
@@ -97,7 +99,7 @@ src_configure() {
 			-DTensile_LIBRARY_FORMAT=msgpack
 			-DAMDGPU_TARGETS="$(get_amdgpu_flags)"
 		)
-		CXX=hipcc cmake_src_configure
+		cmake_src_configure
 	fi
 }
 

--- a/dev-util/hipify-clang/hipify-clang-6.1.1.ebuild
+++ b/dev-util/hipify-clang/hipify-clang-6.1.1.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 LLVM_COMPAT=( 18 )
 
-inherit cmake llvm-r1
+inherit cmake flag-o-matic llvm-r1
 
 DESCRIPTION="A set of tools to translate CUDA source code into portable HIP C++"
 HOMEPAGE="https://github.com/ROCm/HIPIFY"
@@ -36,6 +36,10 @@ src_prepare() {
 }
 
 src_configure() {
+	# 928906: CMakeLists.txt ignores CC/CXX, switches compiler to clang
+	# and fails if non-compatible CFLAGS/CXXFLAGS are used
+	strip-unsupported-flags
+
 	local mycmakeargs=(
 		-DCMAKE_PREFIX_PATH="$(get_llvm_prefix)/$(get_libdir)/cmake/llvm"
 	)

--- a/sci-libs/composable-kernel/composable-kernel-6.1.1.ebuild
+++ b/sci-libs/composable-kernel/composable-kernel-6.1.1.ebuild
@@ -43,6 +43,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-6.1.1-enable-examples.patch
 	"${FILESDIR}"/${PN}-6.1.1-fix-clang-17-no-offload-uniform-block.patch
 	"${FILESDIR}"/${PN}-6.1.1-no-git-no-hash.patch
+	"${FILESDIR}"/${PN}-6.1.1-fix-libcxx.patch
 )
 
 src_prepare() {
@@ -51,6 +52,8 @@ src_prepare() {
 }
 
 src_configure() {
+	rocm_use_hipcc
+
 	if ! use debug; then
 		append-cflags "-DNDEBUG"
 		append-cxxflags "-DNDEBUG"
@@ -73,7 +76,7 @@ src_configure() {
 		)
 	fi
 
-	CXX=hipcc cmake_src_configure
+	cmake_src_configure
 }
 
 src_test() {

--- a/sci-libs/composable-kernel/files/composable-kernel-6.1.1-fix-libcxx.patch
+++ b/sci-libs/composable-kernel/files/composable-kernel-6.1.1-fix-libcxx.patch
@@ -1,0 +1,25 @@
+libc++ has no std::numeric_limits<__Float16> implementation and treats f8_t as is_integral.
+
+Bug for is_integral: https://github.com/llvm/llvm-project/issues/102767
+Bug for numeric_limits: https://github.com/ROCm/composable_kernel/issues/1460
+--- a/library/include/ck/library/utility/check_err.hpp
++++ b/library/include/ck/library/utility/check_err.hpp
+@@ -146,7 +146,7 @@ check_err(const Range& out,
+     bool res{true};
+     int err_count  = 0;
+     double err     = 0;
+-    double max_err = std::numeric_limits<ranges::range_value_t<Range>>::min();
++    double max_err = NumericLimits<ranges::range_value_t<Range>>::Min();
+     for(std::size_t i = 0; i < ref.size(); ++i)
+     {
+         const double o = type_convert<float>(*std::next(std::begin(out), i));
+@@ -178,7 +178,8 @@ check_err(const Range& out,
+ template <typename Range, typename RefRange>
+ std::enable_if_t<(std::is_same_v<ranges::range_value_t<Range>, ranges::range_value_t<RefRange>> &&
+                   std::is_integral_v<ranges::range_value_t<Range>> &&
+-                  !std::is_same_v<ranges::range_value_t<Range>, bhalf_t>)
++                  !std::is_same_v<ranges::range_value_t<Range>, bhalf_t> &&
++                  !std::is_same_v<ranges::range_value_t<Range>, f8_t>)
+ #ifdef CK_EXPERIMENTAL_BIT_INT_EXTENSION_INT4
+                      || std::is_same_v<ranges::range_value_t<Range>, int4_t>
+ #endif

--- a/sci-libs/hipBLASLt/files/hipBLASLt-6.1.1-fix-libcxx.patch
+++ b/sci-libs/hipBLASLt/files/hipBLASLt-6.1.1-fix-libcxx.patch
@@ -1,0 +1,57 @@
+# libc++ issue: https://github.com/llvm/llvm-project/issues/98734
+diff --git a/library/src/amd_detail/rocblaslt/src/rocblaslt_mat.cpp b/library/src/amd_detail/rocblaslt/src/rocblaslt_mat.cpp
+index 82cc81f..94e62d4 100644
+--- a/library/src/amd_detail/rocblaslt/src/rocblaslt_mat.cpp
++++ b/library/src/amd_detail/rocblaslt/src/rocblaslt_mat.cpp
+@@ -28,6 +28,7 @@
+ #include "handle.h"
+ #include "rocblaslt_mat_utils.hpp"
+ #include "tensile_host.hpp"
++#include <array>
+ 
+ #include <hip/hip_runtime_api.h>
+ 
+@@ -602,7 +603,7 @@ rocblaslt_status
+     std::vector<int64_t>            ldc_vec, batch_stride_c_vec, num_batches_c_vec;
+     std::vector<int64_t>            ldd_vec, batch_stride_d_vec, num_batches_d_vec;
+     std::vector<int64_t>            lde_vec, batch_stride_e_vec, num_batches_e_vec;
+-    std::vector<int8_t[16]>         alpha_1(matmul_descr.size());
++    std::vector<std::array<int8_t, 16>>         alpha_1(matmul_descr.size());
+ 
+     std::vector<bool> gradient_vec;
+ 
+@@ -692,10 +693,10 @@ rocblaslt_status
+             return validArgs;
+ 
+         const void* alphaTmp = nullptr;
+-        memset(alpha_1[i], 0, sizeof(int8_t) * 16);
++        memset(alpha_1[i].data(), 0, sizeof(int8_t) * 16);
+         if(scaleAlphaVec)
+         {
+-            setTo1(compute_type, (void*)alpha_1[i], &alphaTmp);
++            setTo1(compute_type, (void*)alpha_1[i].data(), &alphaTmp);
+         }
+         else
+         {
+@@ -867,7 +868,7 @@ rocblaslt_status
+     std::vector<int64_t> lde_vec, batch_stride_e_vec, num_batches_e_vec;
+     std::vector<bool>    gradient_vec;
+ 
+-    std::vector<int8_t[16]> alpha_1(m.size());
++    std::vector<std::array<int8_t, 16>> alpha_1(m.size());
+ 
+     for(int i = 0; i < m.size(); i++)
+     {
+@@ -924,10 +925,10 @@ rocblaslt_status
+             return validArgs;
+ 
+         const void* alphaTmp = nullptr;
+-        memset(alpha_1[i], 0, sizeof(int8_t) * 16);
++        memset(alpha_1[i].data(), 0, sizeof(int8_t) * 16);
+         if(scaleAlphaVec)
+         {
+-            setTo1(compute_type, (void*)alpha_1[i], &alphaTmp);
++            setTo1(compute_type, (void*)alpha_1[i].data(), &alphaTmp);
+         }
+         else
+         {

--- a/sci-libs/hipBLASLt/files/hipBLASLt-6.1.1-no-arch.patch
+++ b/sci-libs/hipBLASLt/files/hipBLASLt-6.1.1-no-arch.patch
@@ -37,7 +37,7 @@ Related upstream bug: https://github.com/ROCm/hipBLASLt/issues/535
      else()
 --- a/library/src/amd_detail/rocblaslt/src/CMakeLists.txt
 +++ b/library/src/amd_detail/rocblaslt/src/CMakeLists.txt
-@@ -100,7 +100,16 @@ if( BUILD_WITH_TENSILE )
+@@ -100,7 +100,17 @@ if( BUILD_WITH_TENSILE )
    set( Tensile_INC
      ${CMAKE_CURRENT_SOURCE_DIR}/src/amd_detail/rocblaslt/src/Tensile
    )
@@ -45,7 +45,8 @@ Related upstream bug: https://github.com/ROCm/hipBLASLt/issues/535
 +  set_target_properties( TensileHost PROPERTIES POSITION_INDEPENDENT_CODE ON )
  
 +  set( Tensile_SRC
-+  src/amd_detail/rocblaslt/src/tensile_host.cpp
++  ${CMAKE_CURRENT_SOURCE_DIR}/src/amd_detail/rocblaslt/src/tensile_host.cpp
++  ${PROJECT_SOURCE_DIR}/tensilelite/Tensile/Source/lib/source/msgpack/MessagePack.cpp
 +  )
 +
 +  set( Tensile_INC

--- a/sci-libs/hipBLASLt/hipBLASLt-6.1.1-r1.ebuild
+++ b/sci-libs/hipBLASLt/hipBLASLt-6.1.1-r1.ebuild
@@ -49,6 +49,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-6.1.1-no-arch.patch
 	"${FILESDIR}"/${PN}-6.1.1-no-git.patch
 	"${FILESDIR}"/${PN}-6.1.1-clang-19.patch
+	"${FILESDIR}"/${PN}-6.1.1-fix-libcxx.patch
 )
 
 python_check_deps() {
@@ -83,6 +84,8 @@ src_prepare() {
 }
 
 src_configure() {
+	rocm_use_hipcc
+
 	local targets="$(get_amdgpu_flags)"
 	local build_with_tensile=$([ "${AMDGPU_TARGETS[@]}" = "" ] && echo OFF || echo ON )
 
@@ -95,7 +98,7 @@ src_configure() {
 
 	use test && mycmakeargs+=( -DBUILD_FORTRAN_CLIENTS=ON )
 
-	CXX=hipcc cmake_src_configure
+	cmake_src_configure
 }
 
 src_compile() {

--- a/sci-libs/hipCUB/hipCUB-6.1.1.ebuild
+++ b/sci-libs/hipCUB/hipCUB-6.1.1.ebuild
@@ -37,6 +37,8 @@ src_prepare() {
 }
 
 src_configure() {
+	rocm_use_hipcc
+
 	local mycmakeargs=(
 		-DAMDGPU_TARGETS="$(get_amdgpu_flags)"
 		-DBUILD_TEST=$(usex test ON OFF)
@@ -44,7 +46,7 @@ src_configure() {
 		-DBUILD_FILE_REORG_BACKWARD_COMPATIBILITY=OFF
 	)
 
-	CXX=hipcc cmake_src_configure
+	cmake_src_configure
 }
 
 src_test() {

--- a/sci-libs/hipFFT/hipFFT-6.1.1.ebuild
+++ b/sci-libs/hipFFT/hipFFT-6.1.1.ebuild
@@ -25,6 +25,10 @@ RDEPEND="dev-util/hip
 DEPEND="${RDEPEND}"
 
 src_configure() {
+	# Note: hipcc is enforced; clang fails when libc++ is enabled
+	# with an error similar to https://github.com/boostorg/config/issues/392
+	rocm_use_hipcc
+
 	local mycmakeargs=(
 		-DROCM_SYMLINK_LIBS=OFF
 		-DBUILD_CLIENTS_TESTS=OFF

--- a/sci-libs/hipRAND/hipRAND-6.1.1.ebuild
+++ b/sci-libs/hipRAND/hipRAND-6.1.1.ebuild
@@ -25,11 +25,13 @@ RDEPEND="dev-util/hip
 DEPEND="${RDEPEND}"
 
 src_configure() {
+	rocm_use_hipcc
+
 	local mycmakeargs=(
 		-DAMDGPU_TARGETS="$(get_amdgpu_flags)"
 		-DBUILD_FILE_REORG_BACKWARD_COMPATIBILITY=OFF
 		-DROCM_SYMLINK_LIBS=OFF
 	)
 
-	CXX=hipcc cmake_src_configure
+	cmake_src_configure
 }

--- a/sci-libs/hipSOLVER/hipSOLVER-6.1.1.ebuild
+++ b/sci-libs/hipSOLVER/hipSOLVER-6.1.1.ebuild
@@ -36,6 +36,8 @@ PATCHES=(
 )
 
 src_configure() {
+	rocm_use_hipcc
+
 	local mycmakeargs=(
 		-DAMDGPU_TARGETS="$(get_amdgpu_flags)"
 		-DBUILD_FILE_REORG_BACKWARD_COMPATIBILITY=OFF
@@ -43,5 +45,5 @@ src_configure() {
 		-DBUILD_WITH_SPARSE=$(usex sparse ON OFF)
 	)
 
-	CXX=hipcc cmake_src_configure
+	cmake_src_configure
 }

--- a/sci-libs/miopen/miopen-6.1.1.ebuild
+++ b/sci-libs/miopen/miopen-6.1.1.ebuild
@@ -58,6 +58,8 @@ src_prepare() {
 }
 
 src_configure() {
+	rocm_use_hipcc
+
 	if ! use debug; then
 		append-cflags "-DNDEBUG"
 		append-cxxflags "-DNDEBUG"
@@ -91,7 +93,7 @@ src_configure() {
 		check_amdgpu
 	fi
 
-	CXX=hipcc cmake_src_configure
+	cmake_src_configure
 }
 
 src_test() {

--- a/sci-libs/rocBLAS/rocBLAS-6.1.1.ebuild
+++ b/sci-libs/rocBLAS/rocBLAS-6.1.1.ebuild
@@ -58,9 +58,7 @@ src_prepare() {
 }
 
 src_configure() {
-	addpredict /dev/random
-	addpredict /dev/kfd
-	addpredict /dev/dri/
+	rocm_use_hipcc
 
 	local mycmakeargs=(
 		-DCMAKE_SKIP_RPATH=ON
@@ -86,7 +84,7 @@ src_configure() {
 		)
 	fi
 
-	CXX=hipcc cmake_src_configure
+	cmake_src_configure
 }
 
 src_compile() {

--- a/sci-libs/rocFFT/rocFFT-6.1.1.ebuild
+++ b/sci-libs/rocFFT/rocFFT-6.1.1.ebuild
@@ -101,6 +101,8 @@ src_prepare() {
 }
 
 src_configure() {
+	rocm_use_hipcc
+
 	local mycmakeargs=(
 		-DCMAKE_SKIP_RPATH=ON
 		-DAMDGPU_TARGETS="$(get_amdgpu_flags)"
@@ -112,7 +114,7 @@ src_configure() {
 		-DBUILD_FILE_REORG_BACKWARD_COMPATIBILITY=OFF
 	)
 
-	CXX=hipcc cmake_src_configure
+	cmake_src_configure
 }
 
 src_test() {

--- a/sci-libs/rocPRIM/rocPRIM-6.1.1.ebuild
+++ b/sci-libs/rocPRIM/rocPRIM-6.1.1.ebuild
@@ -42,6 +42,8 @@ src_prepare() {
 }
 
 src_configure() {
+	rocm_use_hipcc
+
 	local mycmakeargs=(
 		-DCMAKE_SKIP_RPATH=ON
 		-DAMDGPU_TARGETS="$(get_amdgpu_flags)"
@@ -51,7 +53,7 @@ src_configure() {
 		-DROCM_SYMLINK_LIBS=OFF
 	)
 
-	CXX=hipcc cmake_src_configure
+	cmake_src_configure
 }
 
 src_test() {

--- a/sci-libs/rocRAND/rocRAND-6.1.1.ebuild
+++ b/sci-libs/rocRAND/rocRAND-6.1.1.ebuild
@@ -33,6 +33,8 @@ BDEPEND="dev-build/rocm-cmake
 	>=dev-build/cmake-3.22"
 
 src_configure() {
+	rocm_use_hipcc
+
 	local mycmakeargs=(
 		-DCMAKE_SKIP_RPATH=ON
 		-DAMDGPU_TARGETS="$(get_amdgpu_flags)"
@@ -42,7 +44,7 @@ src_configure() {
 		-DBUILD_BENCHMARK=$(usex benchmark ON OFF)
 	)
 
-	CXX=hipcc cmake_src_configure
+	cmake_src_configure
 }
 
 src_test() {

--- a/sci-libs/rocSOLVER/rocSOLVER-6.1.1.ebuild
+++ b/sci-libs/rocSOLVER/rocSOLVER-6.1.1.ebuild
@@ -32,6 +32,8 @@ BDEPEND="test? ( dev-cpp/gtest
 RESTRICT="!test? ( test )"
 
 src_configure() {
+	rocm_use_hipcc
+
 	local mycmakeargs=(
 		-DCMAKE_SKIP_RPATH=ON
 		-DAMDGPU_TARGETS="$(get_amdgpu_flags)"
@@ -43,7 +45,7 @@ src_configure() {
 		-DBUILD_CLIENTS_BENCHMARKS=$(usex benchmark ON OFF)
 	)
 
-	CXX=hipcc cmake_src_configure
+	cmake_src_configure
 }
 
 src_test() {

--- a/sci-libs/rocSPARSE/rocSPARSE-6.1.1.ebuild
+++ b/sci-libs/rocSPARSE/rocSPARSE-6.1.1.ebuild
@@ -90,8 +90,7 @@ src_prepare() {
 }
 
 src_configure() {
-	addpredict /dev/kfd
-	addpredict /dev/dri/
+	rocm_use_hipcc
 
 	local mycmakeargs=(
 		-DCMAKE_SKIP_RPATH=ON
@@ -103,7 +102,7 @@ src_configure() {
 		-DBUILD_CLIENTS_BENCHMARKS=$(usex benchmark ON OFF)
 	)
 
-	CXX=hipcc cmake_src_configure
+	cmake_src_configure
 }
 
 src_test() {

--- a/sci-libs/rocThrust/rocThrust-6.1.1.ebuild
+++ b/sci-libs/rocThrust/rocThrust-6.1.1.ebuild
@@ -32,6 +32,8 @@ BDEPEND=">=dev-build/cmake-3.22"
 PATCHES=( "${FILESDIR}/${PN}-4.0-operator_new.patch" )
 
 src_configure() {
+	rocm_use_hipcc
+
 	local mycmakeargs=(
 		-DCMAKE_SKIP_RPATH=ON
 		-DAMDGPU_TARGETS="$(get_amdgpu_flags)"
@@ -40,7 +42,7 @@ src_configure() {
 		-DBUILD_FILE_REORG_BACKWARD_COMPATIBILITY=OFF
 	)
 
-	CXX=hipcc cmake_src_configure
+	cmake_src_configure
 }
 
 src_test() {

--- a/sci-libs/rocWMMA/rocWMMA-6.1.1.ebuild
+++ b/sci-libs/rocWMMA/rocWMMA-6.1.1.ebuild
@@ -44,6 +44,8 @@ PATCHES=(
 )
 
 src_configure() {
+	rocm_use_hipcc
+
 	# ld.lld bug https://github.com/llvm/llvm-project/issues/61101
 	filter-lto
 
@@ -55,7 +57,7 @@ src_configure() {
 		-DROCWMMA_BUILD_TESTS="$(usex test)"
 	)
 	use test && mycmakeargs+=(-DROCWMMA_USE_SYSTEM_GOOGLETEST=ON)
-	CC=hipcc CXX=hipcc cmake_src_configure
+	cmake_src_configure
 }
 
 src_test() {


### PR DESCRIPTION
This adds a new function `rocm_use_hipcc` in `rocm.eclass` to be used in every `src_configure`, where compiler is switched to hipcc (a. k. a. clang):
```
	export CC=hipcc CXX=hipcc
	strip-unsupported-flags
```

Why not `if ! tc-is-clang ; then strip-unsupported-flags; fi` - because user may want to set systemwide `clang-19` with `CXXFLAGS="-fawesome-clang-19-only-flag"` in `/etc/portage/make.conf`, and ROCm needs clang-18 due to LLVM-bitcode compatibility.

Why not `if [[ -n "${have_switched_compiler}" ]] ; then strip-unsupported-flags && filter-lto; fi` because while `strip-unsupported-flags` does pretty good job, `filter-lto` is too extreme: for example it removes both `-flto` (working flag for clang) and `-flto=16` (gcc-only flag).

Also roctracer and hipBLASLt were not compatible with libc++ (in `sys-devel/clang-common[default-libcxx]` systems), added `append-cxxflags -stdlib=libstdc++` there.

Closes: https://bugs.gentoo.org/936099
Closes: https://bugs.gentoo.org/935998
Closes: https://bugs.gentoo.org/862837
Closes: https://bugs.gentoo.org/854111
Closes: https://bugs.gentoo.org/937276
Closes: https://bugs.gentoo.org/928906

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
