### PR TITLE
{kernel-build,secureboot}.eclass: check and fail early if key or cert in DER format 

### DIFF
--- a/eclass/kernel-build.eclass
+++ b/eclass/kernel-build.eclass
@@ -131,7 +131,7 @@ fi
 # Call python-any-r1 and secureboot pkg_setup
 kernel-build_pkg_setup() {
 	python-any-r1_pkg_setup
-	if [[ ${KERNEL_IUSE_MODULES_SIGN} ]]; then
+	if [[ ${KERNEL_IUSE_MODULES_SIGN} && ${MERGE_TYPE} != binary ]]; then
 		secureboot_pkg_setup
 
 		# Sanity check: fail early if key/cert in DER format or does not exist


### PR DESCRIPTION
This replaces the "file exists and is readable" checks with a dummy call to openssl, this has several advantages:
- If the key/cert file exists, but it is in DER format, openssl complains and causes the build to fail early (Bug 936402)
- If a pkcs11 URI is used, the validity of this URI is also checked early.

CC @gentoo/dist-kernel 

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
