### PR TITLE
www-client/firefox{,-bin}: Disable ad attribution api by default

### DIFF
--- a/www-client/firefox-bin/files/gentoo-default-prefs.js
+++ b/www-client/firefox-bin/files/gentoo-default-prefs.js
@@ -1,11 +1,12 @@
-pref("general.smoothScroll",               true);
-pref("general.autoScroll",                 false);
-pref("browser.urlbar.hideGoButton",        true);
-pref("browser.shell.checkDefaultBrowser",  false);
-pref("browser.EULA.override",              true);
-pref("general.useragent.locale",           "chrome://global/locale/intl.properties");
-pref("intl.locale.requested",              "");
+pref("general.smoothScroll",                        true);
+pref("general.autoScroll",                          false);
+pref("browser.urlbar.hideGoButton",                 true);
+pref("browser.shell.checkDefaultBrowser",           false);
+pref("browser.EULA.override",                       true);
+pref("general.useragent.locale",                    "chrome://global/locale/intl.properties");
+pref("intl.locale.requested",                       "");
 /* Disable DoH by default */
-pref("network.trr.mode",                   5);
+pref("network.trr.mode",                            5);
 /* Disable use of Mozilla Normandy service by default */
-pref("app.normandy.enabled",               false);
+pref("app.normandy.enabled",                        false);
+pref("dom.private-attribution.submission.enabled",  false);

--- a/www-client/firefox/files/gentoo-default-prefs.js
+++ b/www-client/firefox/files/gentoo-default-prefs.js
@@ -1,11 +1,12 @@
-pref("general.smoothScroll",               true);
-pref("general.autoScroll",                 false);
-pref("browser.urlbar.hideGoButton",        true);
-pref("browser.shell.checkDefaultBrowser",  false);
-pref("browser.EULA.override",              true);
-pref("general.useragent.locale",           "chrome://global/locale/intl.properties");
-pref("intl.locale.requested",              "");
+pref("general.smoothScroll",                        true);
+pref("general.autoScroll",                          false);
+pref("browser.urlbar.hideGoButton",                 true);
+pref("browser.shell.checkDefaultBrowser",           false);
+pref("browser.EULA.override",                       true);
+pref("general.useragent.locale",                    "chrome://global/locale/intl.properties");
+pref("intl.locale.requested",                       "");
 /* Disable DoH by default */
-pref("network.trr.mode",                   5);
+pref("network.trr.mode",                            5);
 /* Disable use of Mozilla Normandy service by default */
-pref("app.normandy.enabled",               false);
+pref("app.normandy.enabled",                        false);
+pref("dom.private-attribution.submission.enabled",  false);


### PR DESCRIPTION

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
