### PR TITLE
net-libs/nodejs: Adjust CFLAGS to prevent miscompilations.

### DIFF
--- a/net-libs/nodejs/nodejs-22.4.1.ebuild
+++ b/net-libs/nodejs/nodejs-22.4.1.ebuild
@@ -116,6 +116,10 @@ src_configure() {
 
 	# LTO compiler flags are handled by configure.py itself
 	filter-lto
+	# GCC with -ftree-vectorize miscompiles node's exception handling code
+	# causing it to fail to catch exceptions sometimes
+	# https://gcc.gnu.org/bugzilla/show_bug.cgi?id=116057
+	tc-is-gcc && append-cxxflags -fno-tree-vectorize
 	# nodejs unconditionally links to libatomic #869992
 	# specifically it requires __atomic_is_lock_free which
 	# is not yet implemented by sys-libs/compiler-rt (see
@@ -274,6 +278,6 @@ src_test() {
 pkg_postinst() {
 	if use npm; then
 		ewarn "remember to run: source /etc/profile if you plan to use nodejs"
-		ewarn "	in your current shell"
+		ewarn " in your current shell"
 	fi
 }


### PR DESCRIPTION
With -ftree-vectorize (enabled by default with -O2) GCC miscompiles
node's exception handling code, causing it to fail to catch exceptions
sometimes. Disable it.

This bug also causes build fails for www-client/firefox.

Upstream bug: https://issues.chromium.org/issues/42204492

Closes: https://bugs.gentoo.org/936013

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
