### PR TITLE
media-libs/libsdl2: fix build with >=gui-libs/libdecor-0.2.0

### DIFF
--- a/media-libs/libsdl2/files/libsdl2-2.28.5-fix-libdecor-0.2.patch
+++ b/media-libs/libsdl2/files/libsdl2-2.28.5-fix-libdecor-0.2.patch
@@ -1,0 +1,19 @@
+Fix static build with libdecor 0.2.0
+
+Backports https://github.com/libsdl-org/SDL/commit/4ce935b9106a0311436e41c5f28f00db30a93de1 to libsdl2-2.28
+Bug: https://bugs.gentoo.org/936443
+--- a/src/video/wayland/SDL_waylandsym.h
++++ b/src/video/wayland/SDL_waylandsym.h
+@@ -221,10 +221,10 @@ SDL_WAYLAND_SYM(int, libdecor_dispatch, (struct libdecor *, int))
+ 
+ #if defined(SDL_VIDEO_DRIVER_WAYLAND_DYNAMIC_LIBDECOR) || defined(SDL_HAVE_LIBDECOR_VER_0_2_0)
+ /* Only found in libdecor 0.1.1 or higher, so failure to load them is not fatal. */
+-SDL_WAYLAND_SYM_OPT(void, libdecor_frame_get_min_content_size, (struct libdecor_frame *,\
++SDL_WAYLAND_SYM_OPT(void, libdecor_frame_get_min_content_size, (const struct libdecor_frame *,\
+                                                             int *,\
+                                                             int *))
+-SDL_WAYLAND_SYM_OPT(void, libdecor_frame_get_max_content_size, (struct libdecor_frame *,\
++SDL_WAYLAND_SYM_OPT(void, libdecor_frame_get_max_content_size, (const struct libdecor_frame *,\
+                                                             int *,\
+                                                             int *))
+ #endif

--- a/media-libs/libsdl2/libsdl2-2.28.5-r2.ebuild
+++ b/media-libs/libsdl2/libsdl2-2.28.5-r2.ebuild
@@ -105,6 +105,7 @@ MULTILIB_WRAPPED_HEADERS=(
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-2.0.16-static-libs.patch
+	"${FILESDIR}"/${PN}-2.28.5-fix-libdecor-0.2.patch
 )
 
 src_prepare() {


### PR DESCRIPTION
This applies https://github.com/libsdl-org/SDL/commit/4ce935b9106a0311436e41c5f28f00db30a93de1 to libsdl2-2.28.

No revbump (it is just a compilation fix).
Issue only affects libsdl-2.28 (no fix needed for 2.30).

Closes: https://bugs.gentoo.org/936443

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
