### PR TITLE
app-text/opensp: Use @AR@ in intl/Makefile.in

### DIFF
--- a/app-text/opensp/files/opensp-1.5.2-fix-ar-intl.patch
+++ b/app-text/opensp/files/opensp-1.5.2-fix-ar-intl.patch
@@ -1,0 +1,12 @@
+diff --git a/intl/Makefile.in b/intl/Makefile.in
+--- a/intl/Makefile.in
++++ b/intl/Makefile.in
+@@ -44,7 +44,7 @@ mkinstalldirs = $(SHELL) $(MKINSTALLDIRS)
+ 
+ l = @INTL_LIBTOOL_SUFFIX_PREFIX@
+ 
+-AR = ar
++AR = @AR@
+ CC = @CC@
+ LIBTOOL = @LIBTOOL@
+ RANLIB = @RANLIB@

--- a/app-text/opensp/opensp-1.5.2-r10.ebuild
+++ b/app-text/opensp/opensp-1.5.2-r10.ebuild
@@ -34,6 +34,7 @@ PATCHES=(
 	"${FILESDIR}"/${P}-fix-segfault.patch
 	"${FILESDIR}"/${P}-c11-using.patch
 	"${FILESDIR}"/${P}-configure-clang16.patch
+	"${FILESDIR}"/${P}-fix-ar-intl.patch
 )
 
 src_prepare() {


### PR DESCRIPTION
Otherwise it uses an hardcoded `ar` which isn't available with USE="-native-symlinks".

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
