### PR TITLE
sys-fs/rar2fs: remove proxied maintainer

### DIFF
--- a/sys-fs/rar2fs/metadata.xml
+++ b/sys-fs/rar2fs/metadata.xml
@@ -1,16 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer type="person" proxied="yes">
-		<email>fdegros@chromium.org</email>
-		<name>François Degros</name>
-	</maintainer>
-
-	<maintainer type="project" proxied="proxy">
-		<email>proxy-maint@gentoo.org</email>
-		<name>Proxy Maintainers</name>
-	</maintainer>
-
+	<!--maintainer-needed-->
 	<upstream>
 		<remote-id type="github">hasse69/rar2fs</remote-id>
 	</upstream>


### PR DESCRIPTION
This reverts commit 97a76082713f8e3b28b16f52c04042ff9e6f2168.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
