### PR TITLE
app-text/aspell: Fix compilation on GCC 15

### DIFF
--- a/app-text/aspell/aspell-0.60.8.1-r1.ebuild
+++ b/app-text/aspell/aspell-0.60.8.1-r1.ebuild
@@ -1,0 +1,113 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools flag-o-matic libtool
+
+MY_P="${P/_/-}"
+
+DESCRIPTION="Free and Open Source spell checker designed to replace Ispell"
+HOMEPAGE="http://aspell.net/"
+SRC_URI="mirror://gnu/aspell/${MY_P}.tar.gz"
+S="${WORKDIR}/${MY_P}"
+
+LICENSE="LGPL-2.1"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos"
+IUSE="nls unicode"
+
+# All available language app-dicts/aspell-* packages.
+LANGUAGES=( af am ar ast az be bg bn br ca cs csb cy da de de-1901 el en eo es et fa
+	fi fo fr fy ga gd gl grc gu gv he hi hil hr hsb hu hus hy ia id is it kn ku
+	ky la lt lv mg mi mk ml mn mr ms mt nb nds nl nn no ny or pa pl pt-PT pt-BR
+	qu ro ru rw sc sk sl sr sv sw ta te tet tk tl tn tr uk uz vi wa yi zu
+)
+
+for LANG in ${LANGUAGES[@]}; do
+	IUSE+=" l10n_${LANG}"
+
+	case ${LANG} in
+		de-1901)
+			DICT="de-alt"
+			;;
+		pt-BR)
+			DICT="pt-br"
+			;;
+		pt-PT)
+			DICT="pt"
+			;;
+		*)
+			DICT="${LANG}"
+			;;
+	esac
+
+	PDEPEND+=" l10n_${LANG}? ( app-dicts/aspell-${DICT} )"
+done
+unset DICT LANG LANGUAGES
+
+RDEPEND="
+	sys-libs/ncurses:=[unicode(+)?]
+	nls? ( virtual/libintl )
+"
+
+DEPEND="${RDEPEND}"
+
+BDEPEND="
+	virtual/pkgconfig
+	nls? ( sys-devel/gettext )
+"
+
+HTML_DOCS=( manual/aspell{,-dev}.html )
+
+PATCHES=(
+	"${FILESDIR}/${PN}-0.60.5-nls.patch"
+	"${FILESDIR}/${PN}-0.60.5-solaris.patch"
+	"${FILESDIR}/${PN}-0.60.6-darwin-bundles.patch"
+	"${FILESDIR}/${PN}-0.60.6.1-clang.patch"
+	"${FILESDIR}/${PN}-0.60.6.1-unicode.patch"
+	"${FILESDIR}/${PN}-0.60.8.1-gcc-15-fix.patch"
+)
+
+src_prepare() {
+	default
+
+	rm m4/lt* m4/libtool.m4 || die
+	eautoreconf
+	elibtoolize --reverse-deps
+
+	# Parallel install of libtool libraries doesn't always work.
+	# https://lists.gnu.org/archive/html/libtool/2011-03/msg00003.html
+	# This has to be after automake has run so that we don't clobber
+	# the default target that automake creates for us.
+	echo 'install-filterLTLIBRARIES: install-libLTLIBRARIES' >> Makefile.in || die
+
+	# The unicode patch breaks on Darwin as NCURSES_WIDECHAR won't get set any more.
+	[[ ${CHOST} == *-darwin* ]] || [[ ${CHOST} == *-musl* ]] && use unicode && append-cppflags -DNCURSES_WIDECHAR=1
+}
+
+src_configure() {
+	local myeconfargs=(
+		--disable-static
+		$(use_enable nls)
+		$(use_enable unicode)
+		--sysconfdir="${EPREFIX}"/etc/aspell
+	)
+
+	econf "${myeconfargs[@]}"
+}
+
+src_install() {
+	default
+
+	docinto examples
+	dodoc "${S}"/examples/*.c
+
+	# Install Aspell/Ispell compatibility scripts.
+	newbin scripts/ispell ispell-aspell
+	newbin scripts/spell spell-aspell
+
+	# As static build has been disabled,
+	# all .la files can be deleted unconditionally.
+	find "${ED}" -type f -name '*.la' -delete || die
+}

--- a/app-text/aspell/files/aspell-0.60.8.1-gcc-15-fix.patch
+++ b/app-text/aspell/files/aspell-0.60.8.1-gcc-15-fix.patch
@@ -1,0 +1,39 @@
+https://git.savannah.gnu.org/cgit/aspell.git/commit/?id=ee6cbb12ff36a1e6618d7388a78dd4e0a2b44041
+
+From ee6cbb12ff36a1e6618d7388a78dd4e0a2b44041 Mon Sep 17 00:00:00 2001
+From: Sergei Trofimovich <slyich@gmail.com>
+Date: Sun, 21 Jul 2024 22:01:50 +0100
+Subject: modules/speller/default/vector_hash-t.hpp: fix gcc-15 build
+
+Uncoming `gcc-15` added extra checks for template instantiation that is
+guaranteed to fail in
+  https://gcc.gnu.org/git/?p=gcc.git;a=commitdiff;h=313afcfdabeab3e6705ac0bd1273627075be0023
+
+As a result `aspell` build now fails as:
+
+    In file included from modules/speller/default/readonly_ws.cpp:51:
+    modules/speller/default/vector_hash-t.hpp: In member function 'void aspeller::VectorHashTable<Parms>::recalc_size()':
+    modules/speller/default/vector_hash-t.hpp:186:43: error: 'class aspeller::VectorHashTable<Parms>' has no member named 'e'
+      186 |     for (iterator i = begin(); i != this->e; ++i, ++this->_size);
+          |                                           ^
+    modules/speller/default/vector_hash-t.hpp:186:59: error: 'class aspeller::VectorHashTable<Parms>' has no member named '_size'; did you mean 'size'?
+      186 |     for (iterator i = begin(); i != this->e; ++i, ++this->_size);
+          |                                                           ^~~~~
+          |                                                           size
+
+It looks like `_size` is `size_` mis-spelling and `e` was not introduced
+here.
+--- a/modules/speller/default/vector_hash-t.hpp
++++ b/modules/speller/default/vector_hash-t.hpp
+@@ -183,7 +183,7 @@ namespace aspeller {
+   template<class Parms>
+   void VectorHashTable<Parms>::recalc_size() {
+     size_ = 0;
+-    for (iterator i = begin(); i != this->e; ++i, ++this->_size);
++    for (iterator i = begin(), e = end(); i != e; ++i, ++size_);
+   }
+ 
+ }
+-- 
+cgit v1.1
+


### PR DESCRIPTION
- Add patch from upstream that addresses the error below

```
In member function 'void aspeller::VectorHashTable<Parms>::recalc_size()':
error: 'class aspeller::VectorHashTable<Parms>' has no member named 'e'
  186 |     for (iterator i = begin(); i != this->e; ++i, ++this->_size);
```

Closes: https://bugs.gentoo.org/936494

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
