### PR TITLE
eclass/kernel-{build,install}.eclass: link to config,Sys.map in moddir

### DIFF
--- a/eclass/kernel-build.eclass
+++ b/eclass/kernel-build.eclass
@@ -448,6 +448,8 @@ kernel-build_src_install() {
 	# fix source tree and build dir symlinks
 	dosym "../../../${kernel_dir}" "/lib/modules/${KV_FULL}/build"
 	dosym "../../../${kernel_dir}" "/lib/modules/${KV_FULL}/source"
+	dosym "../../../${kernel_dir}/.config" "/lib/modules/${KV_FULL}/config"
+	dosym "../../../${kernel_dir}/System.map" "/lib/modules/${KV_FULL}/System.map"
 	if [[ "${image_path}" == *vmlinux* ]]; then
 		dosym "../../../${kernel_dir}/${image_path}" "/lib/modules/${KV_FULL}/vmlinux"
 	else

--- a/eclass/kernel-install.eclass
+++ b/eclass/kernel-install.eclass
@@ -623,6 +623,13 @@ kernel-install_pkg_preinst() {
 		rm "${ED}/lib/modules/${KV_FULL}"/{build,source} || die
 		dosym "../../../src/linux-${KV_FULL}" "/usr/lib/modules/${KV_FULL}/build"
 		dosym "../../../src/linux-${KV_FULL}" "/usr/lib/modules/${KV_FULL}/source"
+		local file
+		for file in .config System.map; do
+			if [[ -L "${ED}/lib/modules/${KV_FULL}/${file#.}" ]]; then
+				rm "${ED}/lib/modules/${KV_FULL}/${file#.}" || die
+				dosym "../../../src/linux-${KV_FULL}/${file}" "/usr/lib/modules/${KV_FULL}/${file#.}"
+			fi
+		done
 		for file in vmlinux vmlinuz; do
 			if [[ -L "${ED}/lib/modules/${KV_FULL}/${file}" ]]; then
 				rm "${ED}/lib/modules/${KV_FULL}/${file}" || die


### PR DESCRIPTION
The kernels `make rpm-pkg` and `make deb-pkg` install the `config` and `System.map` into the modules directory for easy access. Let's do the same here so our gpkg's are more symmetric to rpm's and deb's and tools that look for these files there can find it.

This also provides an easy location for the user to access the config. Considering that `/boot/config-x.y.z` does not always exist (the config instalation via `/sbin/installkernel` depends on layout and +/-systemd configuration).

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
