### PR TITLE
dev-db/mongodb: fix configure with --jobs option

### DIFF
--- a/dev-db/mongodb/mongodb-5.0.26.ebuild
+++ b/dev-db/mongodb/mongodb-5.0.26.ebuild
@@ -131,6 +131,7 @@ src_configure() {
 		MONGO_GIT_HASH="0b4f1ea980b5380a66425a90b414106a191365f4"
 
 		--disable-warnings-as-errors
+		--force-jobs # Reapply #906897, fix #935274
 		--jobs="$(makeopts_jobs)"
 		--use-system-boost
 		--use-system-pcre


### PR DESCRIPTION
Reapply fix from #906897.

Bug: https://bugs.gentoo.org/906897
Closes: https://bugs.gentoo.org/935274

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
