### PR TITLE
kernel-build.eclass: set toolchain variables more comprehensibly

### DIFF
--- a/eclass/kernel-build.eclass
+++ b/eclass/kernel-build.eclass
@@ -187,6 +187,10 @@ kernel-build_src_configure() {
 	fi
 
 	# force ld.bfd if we can find it easily
+	local HOSTLD="$(tc-getBUILD_LD)"
+	if type -P "${HOSTLD}.bfd" &>/dev/null; then
+		HOSTLD+=.bfd
+	fi
 	local LD="$(tc-getLD)"
 	if type -P "${LD}.bfd" &>/dev/null; then
 		LD+=.bfd
@@ -198,6 +202,8 @@ kernel-build_src_configure() {
 
 		HOSTCC="$(tc-getBUILD_CC)"
 		HOSTCXX="$(tc-getBUILD_CXX)"
+		HOSTLD="${HOSTLD}"
+		HOSTAR="$(tc-getBUILD_AR)"
 		HOSTCFLAGS="${BUILD_CFLAGS}"
 		HOSTLDFLAGS="${BUILD_LDFLAGS}"
 
@@ -210,6 +216,7 @@ kernel-build_src_configure() {
 		STRIP="$(tc-getSTRIP)"
 		OBJCOPY="$(tc-getOBJCOPY)"
 		OBJDUMP="$(tc-getOBJDUMP)"
+		READELF="$(tc-getREADELF)"
 
 		# we need to pass it to override colliding Gentoo envvar
 		ARCH=$(tc-arch-kernel)


### PR DESCRIPTION
Building on llvm profiles is problematic if toolchain variables are not properly set. So set HOSTLD and HOSTAR to match at least the kernels own LLVM=1 variable to ensure a smoother build for end users.

For example an unset HOSTLD causes issues as it defaults to GNU ld otherwise.

https://docs.kernel.org/kbuild/llvm.html#the-llvm-argument

@AndrewAmmerlaan @mgorny 

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
