### PR TITLE
app-editors/kakoune: don't call c++ directly

### DIFF
--- a/app-editors/kakoune/kakoune-2024.05.18.ebuild
+++ b/app-editors/kakoune/kakoune-2024.05.18.ebuild
@@ -17,6 +17,7 @@ BDEPEND="virtual/pkgconfig"
 
 src_prepare() {
 	sed -i '/CXXFLAGS-debug-no = -O3 -g3/d' Makefile || die
+	sed -i '/CXX = c++/d' Makefile || die
 	default
 }
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/936540

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
