### PR TITLE
dev-lang/zig: fix building with `doc` USE-flag enabled on 9999

### DIFF
--- a/dev-lang/zig/zig-9999.ebuild
+++ b/dev-lang/zig/zig-9999.ebuild
@@ -178,8 +178,8 @@ src_compile() {
 
 	if use doc; then
 		cd "${BUILD_DIR}" || die
-		edo ./stage3/bin/zig build std-docs --prefix "${S}/docgen/"
-		edo ./stage3/bin/zig build langref --prefix "${S}/docgen/"
+		edo ./stage3/bin/zig build std-docs --zig-lib-dir "${BUILD_DIR}/stage3/lib/zig/" --prefix "${S}/docgen/"
+		edo ./stage3/bin/zig build langref --zig-lib-dir "${BUILD_DIR}/stage3/lib/zig/" --prefix "${S}/docgen/"
 	fi
 }
 


### PR DESCRIPTION
<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
