### PR TITLE
x11-misc/xdg-utils: avoid circular dependency with kservice

### DIFF
--- a/x11-misc/xdg-utils/xdg-utils-1.2.1-r4.ebuild
+++ b/x11-misc/xdg-utils/xdg-utils-1.2.1-r4.ebuild
@@ -35,6 +35,14 @@ RDEPEND="
 	)
 	plasma? (
 		virtual/pkgconfig
+	)
+	X? (
+		x11-apps/xprop
+		x11-apps/xset
+	)
+"
+PDEPEND="
+	plasma? (
 		|| (
 			(
 				kde-frameworks/kservice:6
@@ -45,10 +53,6 @@ RDEPEND="
 				dev-qt/qtpaths:5
 			)
 		)
-	)
-	X? (
-		x11-apps/xprop
-		x11-apps/xset
 	)
 "
 BDEPEND="


### PR DESCRIPTION
 * Error: circular dependencies:

(x11-misc/xdg-utils-1.2.1-r3:0/0::gentoo, ebuild scheduled for merge) depends on
 (kde-frameworks/kservice-5.116.0:5/5.116::gentoo, ebuild scheduled for merge) (runtime)
  (kde-frameworks/kf-env-5:5/5::gentoo, ebuild scheduled for merge) (runtime)
   (x11-misc/xdg-utils-1.2.1-r3:0/0::gentoo, ebuild scheduled for merge) (runtime)

It might be possible to break this cycle
by applying the following change:
- x11-misc/xdg-utils-1.2.1-r3 (Change USE: -plasma)

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
