### PR TITLE
php-ext-source-r3.eclass: Rebuild exts should dev-lang/php[threads,de…

### DIFF
--- a/eclass/php-ext-source-r3.eclass
+++ b/eclass/php-ext-source-r3.eclass
@@ -100,6 +100,11 @@ esac
 # php_targets_php7-0? ( dev-lang/php:7.0[mysql?,pdo,pcre(+)] )
 # @CODE
 
+# Whenever certain PHP USE flags change, we need to also rebuild all
+# extensions.
+IUSE+="threads debug"
+[ -n "${PHP_EXT_NEEDED_USE}" ] && PHP_EXT_NEEDED_USE+=,
+PHP_EXT_NEEDED_USE+=threads=,debug=
 
 # Make sure at least one target is installed. First, start a USE
 # conditional like "php?", but only when PHP_EXT_OPTIONAL_USE is
@@ -113,9 +118,7 @@ for _php_target in ${USE_PHP}; do
 	REQUIRED_USE+="php_targets_${_php_target} "
 	_php_slot=${_php_target/php}
 	_php_slot=${_php_slot/-/.}
-	if [[ ${PHP_EXT_NEEDED_USE} ]] ; then
-		_php_slot+=[${PHP_EXT_NEEDED_USE}]
-	fi
+	_php_slot+=[${PHP_EXT_NEEDED_USE}]
 	PHPDEPEND+=" php_targets_${_php_target}? ( dev-lang/php:${_php_slot} )"
 done
 


### PR DESCRIPTION
…bug] change.

If these use flags change then the extension dir changes too, requiring extensions to be rebuilt.

The downside of this change is that different versions of PHP can no longer have different USE values for threads and debug.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [ ] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [ ] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [ ] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
