### PR TITLE
net-vpn/tailscale: fix version reporting

### DIFF
--- a/net-vpn/tailscale/tailscale-1.72.0.ebuild
+++ b/net-vpn/tailscale/tailscale-1.72.0.ebuild
@@ -31,9 +31,9 @@ RESTRICT="test"
 # ebuild equivalent.
 build_dist() {
 	ego build -tags xversion -ldflags "
-		-X tailscale.com/version.Long=${VERSION_LONG}
-		-X tailscale.com/version.Short=${VERSION_SHORT}
-		-X tailscale.com/version.GitCommit=${VERSION_GIT_HASH}" "$@"
+		-X tailscale.com/version.longStamp=${VERSION_LONG}
+		-X tailscale.com/version.shortStamp=${VERSION_SHORT}
+		-X tailscale.com/version.gitCommitStamp=${VERSION_GIT_HASH}" "$@"
 }
 
 src_compile() {


### PR DESCRIPTION
Currently, the Tailscale daemon reports its version as 1.66.1-ERR-BuildInfo in the control panel because the actual version isn't set correctly, due to an upstream variable name change.

See #32246 for a previous attempt.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
