### PR TITLE
gui-libs/aquamarine: Add missing dependency

### DIFF
--- a/gui-libs/aquamarine/aquamarine-0.1.1-r1.ebuild
+++ b/gui-libs/aquamarine/aquamarine-0.1.1-r1.ebuild
@@ -34,6 +34,7 @@ RDEPEND="
 	x11-libs/pixman
 	virtual/libudev
 	sys-apps/hwdata
+	>=sys-auth/seatd-0.8.0
 "
 DEPEND="
 	${RDEPEND}

--- a/gui-libs/aquamarine/aquamarine-9999.ebuild
+++ b/gui-libs/aquamarine/aquamarine-9999.ebuild
@@ -34,6 +34,7 @@ RDEPEND="
 	x11-libs/pixman
 	virtual/libudev
 	sys-apps/hwdata
+	>=sys-auth/seatd-0.8.0
 "
 DEPEND="
 	${RDEPEND}


### PR DESCRIPTION
Add missing dependency on libseat to gui-libs/aquamarine.

Closes https://bugs.gentoo.org/936614.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
