### PR TITLE
www-apps/hugo: add check-reqs verification for the build

### DIFF
--- a/www-apps/hugo/hugo-0.128.2.ebuild
+++ b/www-apps/hugo/hugo-0.128.2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit go-module shell-completion
+inherit check-reqs go-module shell-completion
 
 DESCRIPTION="Fast static HTML and CSS website generator"
 HOMEPAGE="https://gohugo.io https://github.com/gohugoio/hugo"
@@ -41,6 +41,27 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-0.121.0-unbundle-libwebp-and-libsass.patch
 	"${FILESDIR}"/${PN}-0.128.0-skip-some-tests.patch
 )
+
+_check_reqs() {
+	if [[ ${MERGE_TYPE} = binary ]] ; then
+		return 0
+	fi
+
+	if has test ${FEATURES}; then
+		CHECKREQS_DISK_BUILD="4G"
+	else
+		CHECKREQS_DISK_BUILD="1500M"
+	fi
+	check-reqs_${EBUILD_PHASE_FUNC}
+}
+
+pkg_pretend() {
+	_check_reqs
+}
+
+pkg_setup() {
+	_check_reqs
+}
 
 src_configure() {
 	export CGO_ENABLED=1


### PR DESCRIPTION
I happened to notice while cleaning up old directories in /var/tmp/portage, that hugo took up 3.5 GB of space in a build that had tests enabled. Surprisingly large compared to some other pretty large packages. Make sure that users can actually handle this.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
