### PR TITLE
 sys-apps/kexec-tools: fix kernel installation hooks

### DIFF
--- a/sys-apps/kexec-tools/files/kexec-auto-load
+++ b/sys-apps/kexec-tools/files/kexec-auto-load
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+
+# Defaults
+LAYOUT=compat
+BOOTPART=/boot
+KNAME=kernel
+INITRD=initramfs.img
+
+instkern_state=/var/lib/misc/installkernel
+if [[ -s ${instkern_state} ]]; then
+	# If we have a log file, set defaults from there.
+	IFS=$'\t' read -r -a LastKernArray <<< "$(tail -n1 ${instkern_state})"
+	LAYOUT="${LastKernArray[4]}"
+	BOOTPART="${LastKernArray[7]}"
+	KNAME="${LastKernArray[8]}"
+	if [[ "${LastKernArray[9]}" != unknown && ${LAYOUT} != uki ]]; then
+		INITRD="${LastKernArray[9]}"
+	else
+		INITRD=
+	fi
+fi
+
+if [[ ${LAYOUT} == uki ]]; then
+	echo "WARNING: kexec currently does not support UKIs"
+	KPARAM=
+else
+	if [[ -f /etc/kernel/cmdline ]]; then
+		KPARAM="$(tr -s "${IFS}" ' ' </etc/kernel/cmdline)"
+	elif [[ -f /usr/lib/kernel/cmdline ]]; then
+		KPARAM="$(tr -s "${IFS}" ' ' </usr/lib/kernel/cmdline)"
+	else
+		KPARAM=
+	fi
+fi
+
+
+# /etc/kexec.conf overrides installkernel.log
+kexec_conf=/etc/kexec.conf
+if [[ -f ${kexec_conf} ]]; then
+	source ${kexec_conf}
+fi
+
+if [[ -z ${DONT_MOUNT_BOOT} ]]; then
+	# Borrowed from mount-boot-utils.eclass
+	# note that /dev/BOOT is in the Gentoo default /etc/fstab file
+	fstabstate=$(awk "!/^[[:blank:]]*#|^\/dev\/BOOT/ && \$2 == \"${BOOTPART}\" \
+		{ print 1; exit }" /etc/fstab || die "awk failed")
+
+	if [[ -z ${fstabstate} ]]; then
+		echo "Assuming you do not have a separate ${BOOTPART} partition."
+	else
+		procstate=$(awk "\$2 == \"${BOOTPART}\" { split(\$4, a, \",\"); \
+			for (i in a) if (a[i] ~ /^r[ow]\$/) { print a[i]; break }; exit }" \
+			/proc/mounts || die "awk failed")
+
+		if [[ -z ${procstate} ]]; then
+			echo "ERROR: Your ${BOOTPART} partition is not mounted"
+			exit 1
+		fi
+	fi
+fi
+
+if [[ ! -d ${BOOTPART} ]]; then
+	echo "ERROR: BOOTPART=${BOOTPART} not found"
+	exit 1
+fi
+
+KEXEC_ARGS=()
+
+if [[ -f ${BOOTPART}/${KNAME} ]]; then
+	KEXEC_ARGS+=( --load "${BOOTPART}/${KNAME}" )
+else
+	echo "ERROR: KNAME=${KNAME} not found"
+	exit 1
+fi
+
+if [[ -n ${INITRD} ]]; then
+	if [[ -f ${BOOTPART}/${INITRD} ]]; then
+		KEXEC_ARGS+=( --initrd "${BOOTPART}/${INITRD}" )
+	else
+		echo "WARNING: INITRD=${INITRD} not found"
+	fi
+fi
+
+if [[ -n ${KPARAM} ]]; then
+	KEXEC_ARGS+=(  --command-line "${KPARAM}" )
+elif [[ ! -f /etc/kernel/cmdline && ! -f /usr/lib/kernel/cmdline ]]; then
+	# If it is still empty and we did not intentionally set it empty then reuse.
+	KEXEC_OPT_ARGS+=" --reuse-cmdline "
+fi
+
+KEXEC_ARGS+=( ${KEXEC_OPT_ARGS} )
+
+echo "Calling kexec with arguments: ${KEXEC_ARGS[@]}"
+exec kexec "${KEXEC_ARGS[@]}"

--- a/sys-apps/kexec-tools/files/kexec.conf
+++ b/sys-apps/kexec-tools/files/kexec.conf
@@ -1,16 +1,32 @@
-# Kernel image pathname, relative from /boot.
-KNAME="bzimage"
+# Kernel image partition.
+# Default: partition that last kernel image was installed on
+#BOOTPART="/boot"
 
-# Additional arguments passed to kexec (8)
-# Following arguments are support:
+# Path to (unified) kernel image, relative to BOOTPART.
+# Default: last installed kernel image
+#KNAME="kernel"
+
+# Path to the initramfs image, relative to BOOTPART
+# Default: initramfs belonging to last kernel image, if any
+#INITRD="initramfs.img"
+
+# Kernel cmdline to use,
+# Default: contents of {/etc,/usr/lib}/kernel/cmdline if exists, otherwise --reuse-cmdline is used
+#KPARAM="quiet"
+
+# Additional arguments passed to kexec
+#KEXEC_OPT_ARGS=""
+
+# Do not try to mount /boot
+#DONT_MOUNT_BOOT="yes"
+
 #
-# --reuse-cmdline
-#   Use the current boot command line
+# The below is currently used by the OpenRC script only
 #
-# --command-line=string
-#   Use a different command line
-#
-# --initrd=file
-#   Specify an initrd to use
-#
-KEXEC_OPT_ARGS="--reuse-cmdline"
+
+# Load kexec kernel image into memory during shutdown instead of bootup
+# (default: yes)
+#LOAD_DURING_SHUTDOWN="yes"
+
+# Root partition (should be autodetected)
+#ROOTPART="/dev/hda3"

--- a/sys-apps/kexec-tools/files/kexec.conf-2.0.4
+++ b/sys-apps/kexec-tools/files/kexec.conf-2.0.4
@@ -13,12 +13,12 @@
 #ROOTPART="/dev/hda3"
 
 # Kernel image pathname, relative from BOOTPART.
-# If it's one of 
+# If it's one of
 # {kernel-genkernel,bzImage,vmlinuz,kernel}-<currently running kernel version>,
 # or bzImage, vmlinuz (without suffix),
 # then it's automaticaly detected.
 # Setting it to "-" will disable kexec.
-#KNAME="vmlinuz-3.9.0"
+#KNAME="kernel"
 
 # Initrd
 # Same automatic detection restriction as for KNAME apply.
@@ -31,4 +31,4 @@
 #KPARAM="splash=silent,theme:emergence"
 
 # Do not try to mount /boot
-# DONT_MOUNT_BOOT="yes"
+#DONT_MOUNT_BOOT="yes"

--- a/sys-apps/kexec-tools/files/kexec.service
+++ b/sys-apps/kexec-tools/files/kexec.service
@@ -9,8 +9,8 @@ ConditionPathExists=!/nokexec
 Type=oneshot
 RemainAfterExit=yes
 EnvironmentFile=/etc/kexec.conf
-ExecStart=/usr/sbin/kexec -l /boot/${KNAME} ${KEXEC_OPT_ARGS}
-ExecStop=/usr/sbin/kexec -l /boot/${KNAME} ${KEXEC_OPT_ARGS}
+ExecStart=/usr/sbin/kexec-auto-load
+ExecStop=/usr/sbin/kexec-auto-load
 
 [Install]
 WantedBy=multi-user.target

--- a/sys-boot/lilo/lilo-24.2-r2.ebuild
+++ b/sys-boot/lilo/lilo-24.2-r2.ebuild
@@ -1,0 +1,200 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit optfeature toolchain-funcs
+
+DOLILO_V="0.6"
+
+DESCRIPTION="LInux LOader, the original Linux bootloader"
+HOMEPAGE="https://www.joonet.de/lilo/"
+
+DOLILO_TAR="dolilo-${DOLILO_V}.tar.bz2"
+SRC_URI="
+	https://www.joonet.de/lilo/ftp/sources/${P}.tar.gz
+	mirror://gentoo/${DOLILO_TAR}
+"
+
+LICENSE="BSD GPL-2"
+SLOT="0"
+KEYWORDS="-* ~amd64 ~x86"
+
+IUSE="static minimal pxeserial device-mapper"
+
+DEPEND=">=sys-devel/bin86-0.15.5"
+RDEPEND="device-mapper? ( >=sys-fs/lvm2-2.02.45 )"
+
+# Bootloaders should not be using arbitrary CFLAGS without good reason.  A bootloader
+# is typically only executed once to boot the system, and it should work the first time.
+QA_FLAGS_IGNORED="/sbin/lilo"
+
+src_prepare() {
+	default
+
+	# this patch is needed when booting PXE and the device you're using
+	# emulates vga console via serial console.
+	# IE..  B.B.o.o.o.o.t.t.i.i.n.n.g.g....l.l.i.i.n.n.u.u.x.x and stair stepping.
+	use pxeserial && eapply "${FILESDIR}/${PN}-24.1-novga.patch"
+
+	eapply "${FILESDIR}/${PN}-24.2-add-nvme-support.patch"
+	eapply "${FILESDIR}/${PN}-24.x-fix-gcc-10.patch"
+	eapply "${FILESDIR}/${PN}-24.x-check-for-__GLIBC__.patch"
+
+	# Do not strip and have parallel make
+	# FIXME: images/Makefile does weird stuff
+	sed -i Makefile src/Makefile \
+		-e '/strip/d;s|^	make|	$(MAKE)|g' \
+		-e '/images install/d' \
+		-e '/images all/d' \
+		|| die "sed strip failed"
+}
+
+src_configure() {
+	if ! use device-mapper; then
+		sed -i make.vars -e 's|-DDEVMAPPER||g' || die
+	fi
+}
+
+src_compile() {
+	# lilo needs this. bug #140209
+	export LC_ALL=C
+
+	# we explicitly prevent the custom CFLAGS for stability reasons
+	if use static; then
+		local target=alles
+	else
+		local target=all
+	fi
+
+	emake CC="$(tc-getCC) ${LDFLAGS}" ${target}
+}
+
+src_install() {
+	emake DESTDIR="${ED}" install
+
+	if use !minimal; then
+		into /
+		dosbin "${WORKDIR}"/dolilo/dolilo
+
+		into /usr
+		dosbin keytab-lilo.pl
+
+		insinto /etc
+		newins "${FILESDIR}"/lilo.conf lilo.conf.example
+
+		newconfd "${WORKDIR}"/dolilo/dolilo.conf.d dolilo.example
+
+		dodoc CHANGELOG* readme/README.* readme/INCOMPAT README
+		docinto samples ; dodoc sample/*
+	fi
+
+	# This we don't use
+	rm -r "${ED}/etc/initramfs" || die
+	# This should be in /usr/lib and it should have the .install suffix
+	dodir /usr/lib/kernel
+	for dir in postinst.d postrm.d; do
+		mv "${ED}/etc/kernel/${dir}" "${ED}/usr/lib/kernel/${dir}" || die
+		mv "${ED}/usr/lib/kernel/${dir}/zz-runlilo" "${ED}/usr/lib/kernel/${dir}/90-runlilo.install" || die
+	done
+	# Insert wrapper for systemd's kernel-install
+	exeinto /usr/lib/kernel/install.d
+	newexe - 90-runlilo.install <<-EOF
+		#!/bin/sh
+		if [ "\${1}" = "add" ]; then
+			exec "\$(dirname \${0})/../postinst.d/90-runlilo.install"
+		elif [ "\${1}" = "remove" ]; then
+			exec "\$(dirname \${0})/../postrm.d/90-runlilo.install"
+		fi
+	EOF
+}
+
+# Check whether LILO is installed
+# This function is from /usr/sbin/mkboot from debianutils, with copyright:
+#
+#   Debian GNU/Linux
+#   Copyright 1996-1997 Guy Maor <maor@debian.org>
+#
+# Modified for Gentoo for use with the lilo ebuild by:
+#   Martin Schlemmer <azarah@gentoo.org> (16 Mar 2003)
+#
+lilocheck() {
+	local bootpart=
+	local rootpart="$(mount | grep -v "tmpfs" | grep -v "rootfs" | grep "on / " | cut -f1 -d " ")"
+
+	echo
+	ebegin "Checking whether LILO can be safely updated"
+
+	if [ "$(whoami)" != "root" ]; then
+		eend 1
+		eerror "Only root can check for LILO"
+		return 1
+	fi
+
+	if [ -z "${rootpart}" ]; then
+		eend 1
+		eerror "Could not determine root partition"
+		return 1
+	fi
+
+	if [ ! -f /etc/lilo.conf -o ! -x /sbin/lilo ]; then
+		eend 1
+		eerror "No LILO configuration in place"
+		return 1
+	fi
+
+	bootpart="$(sed -n "s:^boot[ ]*=[ ]*\(.*\)[ ]*:\1:p" /etc/lilo.conf)"
+
+	if [ -z "${bootpart}" ]; then
+		# lilo defaults to current root when 'boot=' is not present
+		bootpart="${rootpart}"
+	fi
+
+	if ! dd if=${bootpart} ibs=16 count=1 2>&- | grep -q 'LILO'; then
+		eend 1
+		eerror "No LILO signature on ${bootpart}"
+		ewarn "Check your /etc/lilo.conf, or run /sbin/lilo by hand."
+		return 1
+	fi
+
+	if grep -q "^[[:space:]]*password[[:space:]]*=[[:space:]]*\"\"" /etc/lilo.conf; then
+		eend 1
+		eerror "Interactive password entry configured"
+		ewarn "Run /sbin/lilo -p by hand."
+		return 1
+	fi
+
+	einfo "LILO on ${bootpart} is safe to update"
+	eend 0
+	return 0
+}
+
+pkg_postinst() {
+	if [ ! -e "${ROOT}/boot/boot.b" -a ! -L "${ROOT}/boot/boot.b" ]; then
+		[ -f "${ROOT}/boot/boot-menu.b" ] && \
+			ln -snf boot-menu.b "${ROOT}/boot/boot.b"
+	fi
+
+	if [[ -z "${ROOT}" ]] && use !minimal; then
+		if lilocheck; then
+			einfo "Running DOLILO to complete the install"
+			# do not redirect to /dev/null because it may display some input
+			# prompt
+			/sbin/dolilo
+			if [ "$?" -ne 0 ]; then
+				eerror "You must manually configure and run LILO"
+			fi
+		fi
+		echo
+	fi
+	if use !minimal; then
+		echo
+		einfo "Issue 'dolilo' instead of 'lilo' to have a friendly wrapper that"
+		einfo "handles mounting and unmounting /boot for you. It can do more, "
+		einfo "edit /etc/conf.d/dolilo to harness its full potential."
+		echo
+	fi
+
+	optfeature "automatically updating lilo's configuration on each kernel installation" \
+		sys-kernel/installkernel
+}


### PR DESCRIPTION
- add missing executable permission
- add hook for systemd's kernel-install
- compatibility with all current booting layouts
- warn when using UKIs (not supported by the kernel)
- only set initramfs path if we are actually using one
- set cmdline option for the installed kernel from the usual locations
- fix parsing initrd/cmdline in systemd service file
- do not assume /boot in systemd service file
- fix default name of the kernel image in kexec openrc config file

And while doing this anyway, also fix lilo, the one other package that installs an installation hook in the wrong directory.

CC @floppym @mschiff @dwfreed 

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
