### PR TITLE
media-video/gaupol: Fix QA/pkgcheck issue

### DIFF
--- a/media-video/gaupol/gaupol-1.15-r1.ebuild
+++ b/media-video/gaupol/gaupol-1.15-r1.ebuild
@@ -28,7 +28,7 @@ BDEPEND="
 		app-dicts/myspell-en
 		|| (
 			app-text/enchant[hunspell]
-			app-text/enchant[nuspell]
+			>app-text/enchant-2.0.0[nuspell]
 		)
 		app-text/gspell[introspection]
 	)


### PR DESCRIPTION
Older versions of enchant did not have the nuspell flag.

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
