### PR TITLE
media-video/obs-studio: add media-libs/intel-mediasdk runtime deps

### DIFF
--- a/media-video/obs-studio/obs-studio-30.1.2.ebuild
+++ b/media-video/obs-studio/obs-studio-30.1.2.ebuild
@@ -137,7 +137,9 @@ DEPEND="
 		dev-libs/qr-code-generator
 	)
 "
-RDEPEND="${DEPEND}"
+RDEPEND="${DEPEND}
+	qsv? ( media-libs/intel-mediasdk )
+"
 
 QA_PREBUILT="
 	usr/lib*/obs-plugins/chrome-sandbox

--- a/media-video/obs-studio/obs-studio-30.2.0-r1.ebuild
+++ b/media-video/obs-studio/obs-studio-30.2.0-r1.ebuild
@@ -137,7 +137,9 @@ DEPEND="
 		dev-libs/qr-code-generator
 	)
 "
-RDEPEND="${DEPEND}"
+RDEPEND="${DEPEND}
+	qsv? ( media-libs/intel-mediasdk )
+"
 
 QA_PREBUILT="
 	usr/lib*/obs-plugins/chrome-sandbox

--- a/media-video/obs-studio/obs-studio-30.2.1.ebuild
+++ b/media-video/obs-studio/obs-studio-30.2.1.ebuild
@@ -137,7 +137,9 @@ DEPEND="
 		dev-libs/qr-code-generator
 	)
 "
-RDEPEND="${DEPEND}"
+RDEPEND="${DEPEND}
+	qsv? ( media-libs/intel-mediasdk )
+"
 
 QA_PREBUILT="
 	usr/lib*/obs-plugins/chrome-sandbox

--- a/media-video/obs-studio/obs-studio-9999.ebuild
+++ b/media-video/obs-studio/obs-studio-9999.ebuild
@@ -137,7 +137,9 @@ DEPEND="
 		dev-libs/qr-code-generator
 	)
 "
-RDEPEND="${DEPEND}"
+RDEPEND="${DEPEND}
+	qsv? ( media-libs/intel-mediasdk )
+"
 
 QA_PREBUILT="
 	usr/lib*/obs-plugins/chrome-sandbox


### PR DESCRIPTION
Fixes: https://bugs.gentoo.org/936826

You can compile and install obs-studio with USE=qsv but you still cannot record/stream with QSV unless you also install the Intel Media SDK which has the Media Foundation Extensions.

I'm not sure if this is limited to iGPUs only and/or users of dedicated Intel GPUs have this package installed anyways but it has been a problem on my system with dedicated NVIDIA GPU and Intel iGPU.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
