### PR TITLE
app-text/ebook2cw: remove empty IUSE

### DIFF
--- a/app-text/ebook2cw/ebook2cw-0.8.5.ebuild
+++ b/app-text/ebook2cw/ebook2cw-0.8.5.ebuild
@@ -10,13 +10,12 @@ SRC_URI="https://fkurz.net/ham/${PN}/${P}.tar.gz"
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~amd64"
-IUSE=""
 
 DEPEND="
 	media-sound/lame
 	media-libs/libvorbis
 	media-libs/libogg
-	"
+"
 
 src_prepare() {
 	# avoid prestripping of 'qrq' binary


### PR DESCRIPTION
Fixing gentoo CI QA

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
