### PR TITLE
app-text/html2text: add 2.2.3-r1 with new EAPI and no inherits

### DIFF
--- a/app-text/html2text/html2text-2.2.3-r1.ebuild
+++ b/app-text/html2text/html2text-2.2.3-r1.ebuild
@@ -1,0 +1,25 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+if [[ ${PV} == *9999* ]] ; then
+	inherit git-r3
+	EGIT_REPO_URI="https://github.com/grobian/html2text.git"
+else
+	SRC_URI="https://github.com/grobian/${PN}/releases/download/v${PV}/${P}.tar.gz"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~x86-linux ~arm64-macos ~ppc-macos ~x64-macos ~x64-solaris"
+fi
+
+DESCRIPTION="HTML to text converter"
+HOMEPAGE="https://github.com/grobian/html2text"
+
+LICENSE="GPL-2"
+SLOT="0"
+
+DEPEND="virtual/libiconv"
+RDEPEND="${DEPEND}"
+
+src_test() {
+	emake check
+}


### PR DESCRIPTION
fixing CI/QA

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
