### PR TITLE
app-text/html401: remove empty IUSE, fix VariableOrderWrong

### DIFF
--- a/app-text/html401/html401-19991224-r4.ebuild
+++ b/app-text/html401/html401-19991224-r4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -7,13 +7,12 @@ inherit sgml-catalog-r1
 DESCRIPTION="DTDs for the HyperText Markup Language 4.01"
 HOMEPAGE="https://www.w3.org/TR/html401/"
 SRC_URI="https://www.w3.org/TR/1999/REC-html401-${PV}/html40.tgz"
+S=${WORKDIR}
 
 LICENSE="W3C"
 SLOT="0"
 KEYWORDS="amd64 ppc ~s390 x86 ~amd64-linux ~x86-linux ~ppc-macos"
-IUSE=""
 
-S=${WORKDIR}
 PATCHES=( "${FILESDIR}"/${PN}-decl.diff )
 
 src_install() {


### PR DESCRIPTION
fixing CI/QA

also tried bumping EAPI but sgml-caalog-r1 does not support EAPI=8

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
