### PR TITLE
app-text/htmlrecode: bump EAPI, fix QA issues

### DIFF
--- a/app-text/htmlrecode/htmlrecode-1.3.1-r2.ebuild
+++ b/app-text/htmlrecode/htmlrecode-1.3.1-r2.ebuild
@@ -1,0 +1,40 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs
+
+DESCRIPTION="Recodes HTML file using a new character set"
+HOMEPAGE="https://bisqwit.iki.fi/source/htmlrecode.html"
+SRC_URI="https://bisqwit.iki.fi/src/arch/${P}.tar.bz2"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86"
+
+PATCHES=( "${FILESDIR}/${P}-ar.patch" )
+
+src_prepare() {
+	touch .depend argh/.depend || die
+	default
+}
+
+src_configure() { :; }
+
+src_compile() {
+	local makeopts=(
+		AR="$(tc-getAR)"
+		CPPDEBUG=
+		CXX="$(tc-getCXX)"
+		CXXFLAGS="${CXXFLAGS}"
+		LDFLAGS="${LDFLAGS}"
+	)
+	emake "${makeopts[@]}" -C argh libargh.a
+	emake "${makeopts[@]}" htmlrecode
+}
+
+src_install() {
+	dobin htmlrecode
+	dodoc README.html
+}


### PR DESCRIPTION
do we need this software from 2009 with no maintainer?

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
