### PR TITLE
app-eselect/eselect-repository: add sync methods as optfeature

### DIFF
--- a/app-eselect/eselect-repository/eselect-repository-14.ebuild
+++ b/app-eselect/eselect-repository/eselect-repository-14.ebuild
@@ -1,10 +1,10 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
 PYTHON_COMPAT=( python3_{10..12} )
-inherit python-single-r1
+inherit optfeature python-single-r1
 
 DESCRIPTION="Manage repos.conf via eselect"
 HOMEPAGE="https://github.com/projg2/eselect-repository/"
@@ -55,4 +55,12 @@ src_test() {
 src_install() {
 	emake "${MAKEARGS[@]}" DESTDIR="${D}" install
 	einstalldocs
+}
+
+pkg_postinst() {
+	if [[ -z ${REPLACING_VERSIONS} ]]; then
+		optfeature_header "To sync remote repositories you may need to install the following packages:"
+		optfeature "Git repositories (the most commonly-encountered kind)" dev-vcs/git
+		optfeature "Mercurial repositories" dev-vcs/mercurial
+	fi
 }


### PR DESCRIPTION
We have documentation in the wiki for using eselect-repository to (e.g.) enable syncing ::gentoo via Git, however nothing actually ensures that dev-vcs/git is available. While we can update the Wiki it seems prudent to provide a postinst message as well.

-----

For comment; seems reasonable enough. I picked git and mercurial as the only non-rsync repos in `repositories.xml`, though really 'git' seems sufficient.