### PR TITLE
🐛 dev-qt/qtwebengine: fix re2 compatibility

### DIFF
--- a/dev-qt/qtwebengine/files/qtwebengine-5.15.14_p20240510-re2.patch
+++ b/dev-qt/qtwebengine/files/qtwebengine-5.15.14_p20240510-re2.patch
@@ -1,0 +1,14 @@
+# https://bugs.gentoo.org/913923
+
+    Fix missing {-no,}-webengine-re2 command line options
+
+--- a/src/core/configure.json
++++ b/src/core/configure.json
+@@ -16,6 +16,7 @@
+             "webengine-icu": { "type": "enum", "name": "webengine-system-icu", "values": { "system": "yes", "qt": "no" } },
+             "webengine-ffmpeg": { "type": "enum", "name": "webengine-system-ffmpeg", "values": { "system": "yes", "qt": "no" } },
+             "webengine-opus": { "type": "enum", "name": "webengine-system-opus", "values": { "system": "yes", "qt": "no" } },
++            "webengine-re2": { "type": "enum", "name": "webengine-system-re2", "values": { "system": "yes", "qt": "no" } },
+             "webengine-webp": { "type": "enum", "name": "webengine-system-libwebp", "values": { "system": "yes", "qt": "no" } },
+             "webengine-pepper-plugins": "boolean",
+             "webengine-printing-and-pdf": "boolean",

--- a/dev-qt/qtwebengine/qtwebengine-5.15.14_p20240510.ebuild
+++ b/dev-qt/qtwebengine/qtwebengine-5.15.14_p20240510.ebuild
@@ -41,7 +41,6 @@ RDEPEND="
 	dev-libs/libevent:=
 	dev-libs/libxml2[icu]
 	dev-libs/libxslt
-	dev-libs/re2:=
 	=dev-qt/qtcore-${QT5_PV}*
 	=dev-qt/qtdeclarative-${QT5_PV}*
 	=dev-qt/qtgui-${QT5_PV}*
@@ -102,6 +101,7 @@ BDEPEND="${PYTHON_DEPS}
 PATCHES=(
 	"${WORKDIR}/${PATCHSET}"
 	"${FILESDIR}/${PN}-5.15.13_p20240510-gcc15.patch"
+	"${FILESDIR}/${P}-re2.patch"
 )
 
 python_check_deps() {
@@ -231,6 +231,7 @@ src_configure() {
 		$(usex screencast -webengine-webrtc-pipewire '')
 		-qt-ffmpeg # bug 831487
 		$(qt_use system-icu webengine-icu)
+		-no-webengine-re2 # bug 913923
 	)
 	qt5-build_src_configure
 }


### PR DESCRIPTION
_Hello everyone,_

Use bundled **re2** to avoid [the compatibility issue](https://bugs.gentoo.org/913923) for [qtwebengine-5.15.14_p20240510](https://gitweb.gentoo.org/repo/gentoo.git/tree/dev-qt/qtwebengine/qtwebengine-5.15.14_p20240510.ebuild?id=71aa9caf).

_Best regards!_

---

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.