### PR TITLE
dev-python/pip: Add a missing dependency on typing-extensions

### DIFF
--- a/dev-python/pip/pip-24.2-r1.ebuild
+++ b/dev-python/pip/pip-24.2-r1.ebuild
@@ -47,6 +47,7 @@ RDEPEND="
 	' 3.10)
 	>=dev-python/truststore-0.9.1[${PYTHON_USEDEP}]
 
+	>=dev-python/typing-extensions-4.12.2[${PYTHON_USEDEP}]
 	>=dev-python/setuptools-39.2.0[${PYTHON_USEDEP}]
 "
 BDEPEND="


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/936866

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
