### PR TITLE
media-libs/opus: add USE flags for deep-plc, dred, and osce

### DIFF
--- a/media-libs/opus/metadata.xml
+++ b/media-libs/opus/metadata.xml
@@ -11,6 +11,9 @@
 	</maintainer>
 	<use>
 		<flag name="custom-modes">Enable non-Opus modes, e.g. 44.1 kHz and 2^n frames</flag>
+		<flag name="deep-plc">Enable Deep Packet Loss Concealment (PLC)</flag>
+		<flag name="dred">Enable Deep REDundancy (DRED)</flag>
+		<flag name="osce">Enable Opus Speech Coding Enhancement (OSCE)</flag>
 	</use>
 	<upstream>
 		<remote-id type="github">xiph/opus</remote-id>

--- a/media-libs/opus/opus-1.5.2.ebuild
+++ b/media-libs/opus/opus-1.5.2.ebuild
@@ -14,7 +14,11 @@ LICENSE="BSD"
 SLOT="0"
 KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~loong ~m68k ~mips ppc ppc64 ~riscv sparc x86"
 INTRINSIC_FLAGS="cpu_flags_x86_sse cpu_flags_arm_neon"
-IUSE="custom-modes debug doc hardened static-libs test ${INTRINSIC_FLAGS}"
+IUSE="custom-modes debug deep-plc dred doc hardened osce static-libs test ${INTRINSIC_FLAGS}"
+REQUIRED_USE="
+	dred? ( deep-plc )
+	osce? ( deep-plc )
+"
 RESTRICT="!test? ( test )"
 
 BDEPEND="
@@ -38,6 +42,9 @@ multilib_src_configure() {
 		$(meson_feature test tests)
 		$(meson_use debug assertions)
 		$(meson_use hardened hardening)
+		$(meson_feature deep-plc)
+		$(meson_feature dred)
+		$(meson_feature osce)
 
 		$(meson_native_use_feature doc docs)
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/936909
See-Also: https://opus-codec.org/demo/opus-1.5/

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
