### PR TITLE
net-wireless/wireless-tools: Fix implicit declaration of basename

### DIFF
--- a/net-wireless/wireless-tools/files/wireless-tools-30-fix-basename-musl.patch
+++ b/net-wireless/wireless-tools/files/wireless-tools-30-fix-basename-musl.patch
@@ -1,0 +1,63 @@
+https://bugs.gentoo.org/936594
+From: Brahmajit Das <brahmajit.xyz@gmail.com>
+Date: Tue, 30 Jul 2024 07:02:54 +0000
+Subject: [PATCH 1/1] Fix implicit declaration of function basename on musl
+
+On musl there is only one implementation of basename, which comes from
+the libgen.h header file. However, in this case the code is using GNU
+implementation of basename, which is not available on musl. This results
+in build error:
+
+ifrename.c:1816:15: error: implicit declaration of function basename [-Wimplicit-function-declaration]
+
+Taking refernce from https://github.com/kmod-project/kmod/pull/32 we can
+use a portable implementation of the basename API on musl (or globally).
+But I'm open to better ideas.
+
+Please also refer: https://bugs.gentoo.org/936594
+
+Signed-off-by: Brahmajit Das <brahmajit.xyz@gmail.com>
+--- a/ifrename.c
++++ b/ifrename.c
+@@ -45,6 +45,7 @@
+ #define _GNU_SOURCE
+ #endif
+ 
++#include <string.h>
+ #include <getopt.h>		/* getopt_long() */
+ #include <linux/sockios.h>	/* SIOCSIFNAME */
+ #include <fnmatch.h>		/* fnmatch() */
+@@ -454,6 +455,18 @@ struct sysfs_metadata	sysfs_global =
+   0, { NULL, NULL, NULL, NULL, NULL },
+ };
+ 
++#if !defined(__GLIBC__)
++/*
++ * Use portable implementation for basename API
++ * https://github.com/kmod-project/kmod/pull/32
++ */
++char *gnu_basename(char *s)
++{
++  char *p = strrchr(s, '/');
++  return p ? p+1 : s;
++}
++#endif
++
+ /******************** INTERFACE NAME MANAGEMENT ********************/
+ /*
+  * Bunch of low level function for managing interface names.
+@@ -1813,7 +1826,11 @@ mapping_getsysfs(int			skfd,
+ 	  /* Here, we have a link name or a parent directory name */
+ 
+ 	  /* Keep only the last component of path name, save it */
++#if !defined(__GLIBC__)
++	  p = gnu_basename(linkpath);
++#else
+ 	  p = basename(linkpath);
++#endif
+ 	  sdup = strdup(p);
+ 	  free(linkpath);
+ 	}
+-- 
+2.45.2
+

--- a/net-wireless/wireless-tools/wireless-tools-30_pre9-r2.ebuild
+++ b/net-wireless/wireless-tools/wireless-tools-30_pre9-r2.ebuild
@@ -1,0 +1,63 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs
+
+# The following works with both pre-releases and releases
+MY_P=${PN/-/_}.${PV/_/.}
+S="${WORKDIR}/${MY_P/\.pre*/}"
+
+DESCRIPTION="A collection of tools to configure IEEE 802.11 wireless LAN cards"
+HOMEPAGE="http://www.hpl.hp.com/personal/Jean_Tourrilhes/Linux/Tools.html"
+SRC_URI="http://www.hpl.hp.com/personal/Jean_Tourrilhes/Linux/${MY_P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~mips ~ppc ~ppc64 ~riscv ~sparc ~x86"
+IUSE="multicall"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-29-asneeded.patch
+	"${FILESDIR}"/${PN}-30-fix-basename-musl.patch
+)
+
+src_prepare() {
+	default
+
+	sed -i \
+		-e "s:^\(CC\) = gcc:\1 = $(tc-getCC):" \
+		-e "s:^\(AR\) = ar:\1 = $(tc-getAR):" \
+		-e "s:^\(RANLIB\) = ranlib:\1 = $(tc-getRANLIB):" \
+		-e "s:^\(CFLAGS=-Os\):#\1:" \
+		-e "s:\(@\$(LDCONFIG).*\):#\1:" \
+		-e "s:^\(INSTALL_MAN= \$(PREFIX)\)/man:\1/usr/share/man:" \
+		-e "s:^\(INSTALL_LIB= \$(PREFIX)\)/lib:\1/$(get_libdir)/:" \
+		-e "s:^\(INSTALL_INC= \$(PREFIX)\)/include:\1/usr/include:" \
+		-e "s:^\(BUILD_STATIC = y\):#\1:" \
+		-e '/\$(CC)/s:-Wl,-s\>::' \
+		"${S}"/Makefile || die
+}
+
+src_compile() {
+	emake
+
+	use multicall && emake iwmulticall
+}
+
+src_install() {
+	emake PREFIX="${ED}" install
+
+	if use multicall; then
+		# 'make install-iwmulticall' will overwrite some of the tools
+		# with symlinks - this is intentional (brix)
+		emake PREFIX="${ED}" install-iwmulticall
+	fi
+
+	has cs ${LINGUAS-cs} || rm -rf "${ED}"/usr/share/man/cs
+	has fr ${LINGUAS-fr} || rm -rf "${ED}"/usr/share/man/fr.{ISO8859-1,UTF-8}
+
+	dodoc CHANGELOG.h HOTPLUG-UDEV.txt IFRENAME-VS-XXX.txt PCMCIA.txt README
+	has fr ${LINGUAS-fr} && dodoc README.fr
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/936594

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
