### PR TITLE
x11-apps/*: remove empty IUSE

### DIFF
--- a/x11-apps/radeon-profile-daemon/radeon-profile-daemon-20190603-r1.ebuild
+++ b/x11-apps/radeon-profile-daemon/radeon-profile-daemon-20190603-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -14,10 +14,10 @@ else
 	SRC_URI="https://github.com/marazmista/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
 	KEYWORDS="~amd64 ~x86"
 fi
+S="${WORKDIR}/${P}/${PN}"
+
 LICENSE="GPL-2"
 SLOT="0"
-
-IUSE=""
 
 RDEPEND="
 	!<x11-apps/radeon-profile-20200504-r1
@@ -25,8 +25,6 @@ RDEPEND="
 	dev-qt/qtnetwork:5
 "
 DEPEND="${RDEPEND}"
-
-S="${WORKDIR}/${P}/${PN}"
 
 PATCHES=(
 	"${FILESDIR}/${PN}-20190603-run_subdir.patch"

--- a/x11-apps/radeon-profile-daemon/radeon-profile-daemon-99999999.ebuild
+++ b/x11-apps/radeon-profile-daemon/radeon-profile-daemon-99999999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -14,10 +14,10 @@ else
 	SRC_URI="https://github.com/marazmista/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
 	KEYWORDS="~amd64 ~x86"
 fi
+S="${WORKDIR}/${P}/${PN}"
+
 LICENSE="GPL-2"
 SLOT="0"
-
-IUSE=""
 
 RDEPEND="
 	!<x11-apps/radeon-profile-20200504-r1
@@ -25,8 +25,6 @@ RDEPEND="
 	dev-qt/qtnetwork:5
 "
 DEPEND="${RDEPEND}"
-
-S="${WORKDIR}/${P}/${PN}"
 
 PATCHES=(
 	"${FILESDIR}/${PN}-20190603-run_subdir.patch"

--- a/x11-apps/radeon-profile/radeon-profile-20200824-r1.ebuild
+++ b/x11-apps/radeon-profile/radeon-profile-20200824-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -14,12 +14,10 @@ else
 	SRC_URI="https://github.com/marazmista/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
 	KEYWORDS="~amd64 ~x86"
 fi
+S="${WORKDIR}/${P}/${PN}"
+
 LICENSE="GPL-2"
 SLOT="0"
-
-IUSE=""
-
-S="${WORKDIR}/${P}/${PN}"
 
 RDEPEND="
 	!<x11-apps/radeon-profile-daemon-20190603-r1

--- a/x11-apps/radeon-profile/radeon-profile-20200824.ebuild
+++ b/x11-apps/radeon-profile/radeon-profile-20200824.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -14,12 +14,10 @@ else
 	SRC_URI="https://github.com/marazmista/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
 	KEYWORDS="~amd64 ~x86"
 fi
+S="${WORKDIR}/${P}/${PN}"
+
 LICENSE="GPL-2"
 SLOT="0"
-
-IUSE=""
-
-S="${WORKDIR}/${P}/${PN}"
 
 RDEPEND="
 	!<x11-apps/radeon-profile-daemon-20190603-r1

--- a/x11-apps/radeon-profile/radeon-profile-99999999.ebuild
+++ b/x11-apps/radeon-profile/radeon-profile-99999999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -14,12 +14,10 @@ else
 	SRC_URI="https://github.com/marazmista/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
 	KEYWORDS="~amd64 ~x86"
 fi
+S="${WORKDIR}/${P}/${PN}"
+
 LICENSE="GPL-2"
 SLOT="0"
-
-IUSE=""
-
-S="${WORKDIR}/${P}/${PN}"
 
 RDEPEND="
 	!<x11-apps/radeon-profile-daemon-20190603-r1

--- a/x11-apps/xbacklight/xbacklight-1.2.3.ebuild
+++ b/x11-apps/xbacklight/xbacklight-1.2.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -7,7 +7,6 @@ inherit xorg-3
 
 DESCRIPTION="Sets backlight level using the RandR 1.2 BACKLIGHT output property"
 KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~mips ppc ppc64 ~riscv sparc x86"
-IUSE=""
 
 RDEPEND="x11-libs/libxcb
 	>=x11-libs/xcb-util-0.3.8"

--- a/x11-apps/xrandr/xrandr-1.5.2.ebuild
+++ b/x11-apps/xrandr/xrandr-1.5.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -6,10 +6,9 @@ XORG_TARBALL_SUFFIX="xz"
 
 inherit xorg-3
 
-DESCRIPTION="primitive command line interface to RandR extension"
+DESCRIPTION="A primitive command line interface to RandR extension"
 
 KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~loong ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux"
-IUSE=""
 
 RDEPEND=">=x11-libs/libXrandr-1.5
 	x11-libs/libXrender


### PR DESCRIPTION
radeon-profile*s are a mess

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
