### PR TITLE
profiles: powerpc/*,hppa,sparc: Drop dev-util/cmake[gui] mask

### DIFF
--- a/profiles/arch/hppa/package.use.mask
+++ b/profiles/arch/hppa/package.use.mask
@@ -71,10 +71,6 @@ sys-apps/openrc-navi s6
 # Qt not keyworded here.
 app-text/doxygen gui
 
-# Sam James <sam@gentoo.org> (2023-09-22)
-# Qt 6 not keyworded here.
-dev-build/cmake gui
-
 # Sam James <sam@gentoo.org> (2023-09-18)
 # x11-libs/gtksourceview:4 not keyworded here
 media-gfx/inkscape sourceview

--- a/profiles/arch/hppa/package.use.stable.mask
+++ b/profiles/arch/hppa/package.use.stable.mask
@@ -17,6 +17,10 @@
 
 #--- END OF EXAMPLES ---
 
+# Sam James <sam@gentoo.org> (2024-07-31)
+# Qt 6 not stable here.
+dev-build/cmake gui
+
 # Andrew Ammerlaan <andrewammerlaan@gentoo.org> (2024-07-25)
 # Moved to stable.mask, issue is fixed in unstable v40
 # Sam James <sam@gentoo.org> (2024-06-19)

--- a/profiles/arch/powerpc/ppc32/package.use.mask
+++ b/profiles/arch/powerpc/ppc32/package.use.mask
@@ -49,10 +49,6 @@ dev-python/nbconvert test
 dev-perl/DBD-mysql mysql
 
 # Sam James <sam@gentoo.org> (2023-09-22)
-# Qt 6 not keyworded here.
-dev-build/cmake gui
-
-# Sam James <sam@gentoo.org> (2023-09-22)
 # sys-apps/flatpak is not keyworded here
 sys-apps/xdg-desktop-portal flatpak
 

--- a/profiles/arch/powerpc/ppc64/package.use.mask
+++ b/profiles/arch/powerpc/ppc64/package.use.mask
@@ -24,10 +24,6 @@ app-emulation/libvirt -virtiofsd
 # media-libs/shaderc is keyworded here.
 media-libs/libplacebo -shaderc
 
-# Sam James <sam@gentoo.org> (2023-09-22)
-# Qt 6 not keyworded here.
-dev-build/cmake gui
-
 # Alexey Sokolov <alexey+gentoo@asokolov.org> (2023-08-14)
 # OpenMW is only playtested with LuaJIT, and in fact unit tests fail with Lua-5.
 # Therefore apply mask/force to override the profile's defaults, and invert on

--- a/profiles/arch/sparc/package.use.mask
+++ b/profiles/arch/sparc/package.use.mask
@@ -120,10 +120,6 @@ dev-qt/qtgui vulkan
 sys-apps/openrc s6
 sys-apps/openrc-navi s6
 
-# Sam James <sam@gentoo.org> (2023-09-22)
-# Qt 6 not keyworded here.
-dev-build/cmake gui
-
 # Sam James <sam@gentoo.org> (2023-07-21)
 # Requires app-emulation/qemu.
 sys-kernel/gentoo-kernel test

--- a/profiles/arch/sparc/package.use.stable.mask
+++ b/profiles/arch/sparc/package.use.stable.mask
@@ -1,6 +1,10 @@
 # Copyright 2019-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Sam James <sam@gentoo.org> (2024-07-31)
+# Qt 6 not stable here.
+dev-build/cmake gui
+
 # Eli Schwartz <eschwartz93@gmail.com> (2024-02-05)
 # app-text/mupdf is not stable. bug #923811
 net-print/cups-filters pdf


### PR DESCRIPTION
Qt6 has been keyworded here.