### PR TITLE
🚩🩹 gui-apps/swaybg: fix missing format support

### DIFF
--- a/gui-apps/swaybg/swaybg-1.2.1.ebuild
+++ b/gui-apps/swaybg/swaybg-1.2.1.ebuild
@@ -18,13 +18,18 @@ fi
 
 LICENSE="MIT"
 SLOT="0"
-IUSE="gdk-pixbuf +man"
+IUSE="+gdk-pixbuf gif jpeg +man tiff"
+REQUIRED_USE="
+	gif? ( gdk-pixbuf )
+	jpeg? ( gdk-pixbuf )
+	tiff? ( gdk-pixbuf )
+"
 
 DEPEND="
 	dev-libs/wayland
 	>=dev-libs/wayland-protocols-1.26
 	x11-libs/cairo
-	gdk-pixbuf? ( x11-libs/gdk-pixbuf )
+	gdk-pixbuf? ( x11-libs/gdk-pixbuf[gif(+)?,jpeg?,tiff?] )
 "
 RDEPEND="${DEPEND}"
 BDEPEND="

--- a/gui-apps/swaybg/swaybg-9999.ebuild
+++ b/gui-apps/swaybg/swaybg-9999.ebuild
@@ -18,13 +18,18 @@ fi
 
 LICENSE="MIT"
 SLOT="0"
-IUSE="gdk-pixbuf +man"
+IUSE="+gdk-pixbuf gif jpeg +man tiff"
+REQUIRED_USE="
+	gif? ( gdk-pixbuf )
+	jpeg? ( gdk-pixbuf )
+	tiff? ( gdk-pixbuf )
+"
 
 DEPEND="
 	dev-libs/wayland
 	>=dev-libs/wayland-protocols-1.26
 	x11-libs/cairo
-	gdk-pixbuf? ( x11-libs/gdk-pixbuf )
+	gdk-pixbuf? ( x11-libs/gdk-pixbuf[gif(+)?,jpeg?,tiff?] )
 "
 RDEPEND="${DEPEND}"
 BDEPEND="


### PR DESCRIPTION
_Hello everyone,_

I've found that, depending on `gdk-pixbuf` configuration, support for some image formats might be missing in `swaybg`.
This PR adds `gif`, `jpeg`, and `tiff` USE flags for `1.2.1` and `9999` in order to ensure that necessary formats are supported.

_Best regards!_

---

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.