### PR TITLE
x11-misc/x11vnc: fix build on 32bit arches with 64bit time_t

### DIFF
--- a/x11-misc/x11vnc/files/x11vnc-0.9.16-fix-build-on-32bit.patch
+++ b/x11-misc/x11vnc/files/x11vnc-0.9.16-fix-build-on-32bit.patch
@@ -1,0 +1,105 @@
+From daecf59cc8b294265666482a4766aaa3148c308b Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Sat, 30 Nov 2019 11:43:32 -0800
+Subject: [PATCH] Fix build on 32bit arches with 64bit time_t
+
+time element is deprecated on new input_event structure in kernel's
+input.h [1]
+
+[1] https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit?id=152194fe9c3f
+---
+ src/uinput.c | 25 +++++++++++++++++++++----
+ 1 file changed, 21 insertions(+), 4 deletions(-)
+
+diff --git a/src/uinput.c b/src/uinput.c
+index 28fbad39..d71bcde7 100644
+--- a/src/uinput.c
++++ b/src/uinput.c
+@@ -54,6 +54,11 @@ so, delete this exception statement from your version.
+ #include <linux/input.h>
+ #include <linux/uinput.h>
+ 
++#ifndef input_event_sec
++#define input_event_sec time.tv_sec
++#define input_event_usec time.tv_usec
++#endif
++
+ #if !defined(EV_SYN) || !defined(SYN_REPORT)
+ #undef UINPUT_OK
+ #endif
+@@ -710,6 +715,7 @@ void parse_uinput_str(char *in) {
+ static void ptr_move(int dx, int dy) {
+ #ifdef UINPUT_OK
+ 	struct input_event ev;
++	struct timeval tval;
+ 	int d = direct_rel_fd < 0 ? fd : direct_rel_fd;
+ 
+ 	if (injectable && strchr(injectable, 'M') == NULL) {
+@@ -720,7 +726,9 @@ static void ptr_move(int dx, int dy) {
+ 
+ 	if (db) fprintf(stderr, "ptr_move(%d, %d) fd=%d\n", dx, dy, d);
+ 
+-	gettimeofday(&ev.time, NULL);
++	gettimeofday(&tval, NULL);
++	ev.input_event_sec = tval.tv_sec;
++	ev.input_event_usec = tval.tv_usec;
+ 	ev.type = EV_REL;
+ 	ev.code = REL_Y;
+ 	ev.value = dy;
+@@ -755,6 +763,7 @@ static void apply_tslib(int *x, int *y) {
+ static void ptr_abs(int x, int y, int p) {
+ #ifdef UINPUT_OK
+ 	struct input_event ev;
++	struct timeval tval;
+ 	int x0, y0;
+ 	int d = direct_abs_fd < 0 ? fd : direct_abs_fd;
+ 
+@@ -773,7 +782,9 @@ static void ptr_abs(int x, int y, int p) {
+ 
+ 	if (db) fprintf(stderr, "ptr_abs(%d, %d => %d %d, p=%d) fd=%d\n", x0, y0, x, y, p, d);
+ 
+-	gettimeofday(&ev.time, NULL);
++	gettimeofday(&tval, NULL);
++	ev.input_event_sec = tval.tv_sec;
++	ev.input_event_usec = tval.tv_usec;
+ 	ev.type = EV_ABS;
+ 	ev.code = ABS_Y;
+ 	ev.value = y;
+@@ -950,6 +961,7 @@ if (0) {usleep(100*1000) ;}
+ static void button_click(int down, int btn) {
+ #ifdef UINPUT_OK
+ 	struct input_event ev;
++	struct timeval tval;
+ 	int d = direct_btn_fd < 0 ? fd : direct_btn_fd;
+ 
+ 	if (injectable && strchr(injectable, 'B') == NULL) {
+@@ -959,7 +971,9 @@ static void button_click(int down, int btn) {
+ 	if (db) fprintf(stderr, "button_click: btn %d %s fd=%d\n", btn, down ? "down" : "up", d);
+ 
+ 	memset(&ev, 0, sizeof(ev));
+-	gettimeofday(&ev.time, NULL);
++	gettimeofday(&tval, NULL);
++	ev.input_event_sec = tval.tv_sec;
++	ev.input_event_usec = tval.tv_usec;
+ 	ev.type = EV_KEY;
+ 	ev.value = down;
+ 
+@@ -1230,6 +1244,7 @@ void uinput_pointer_command(int mask, int x, int y, rfbClientPtr client) {
+ void uinput_key_command(int down, int keysym, rfbClientPtr client) {
+ #ifdef UINPUT_OK
+ 	struct input_event ev;
++	struct timeval tval;
+ 	int scancode;
+ 	allowed_input_t input;
+ 	int d = direct_key_fd < 0 ? fd : direct_key_fd;
+@@ -1253,7 +1268,9 @@ void uinput_key_command(int down, int keysym, rfbClientPtr client) {
+ 	if (db) fprintf(stderr, "uinput_key_command: %d -> %d %s fd=%d\n", keysym, scancode, down ? "down" : "up", d);
+ 
+ 	memset(&ev, 0, sizeof(ev));
+-	gettimeofday(&ev.time, NULL);
++	gettimeofday(&tval, NULL);
++	ev.input_event_sec = tval.tv_sec;
++	ev.input_event_usec = tval.tv_usec;
+ 	ev.type = EV_KEY;
+ 	ev.code = (unsigned char) scancode;
+ 	ev.value = down;

--- a/x11-misc/x11vnc/x11vnc-0.9.16-r8.ebuild
+++ b/x11-misc/x11vnc/x11vnc-0.9.16-r8.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -45,6 +45,7 @@ PATCHES=(
 	"${FILESDIR}"/${P}-CVE-2020-29074.patch
 	"${FILESDIR}"/${P}-implicit-function-declaration.patch
 	"${FILESDIR}"/${P}-libressl.patch # 903001
+	"${FILESDIR}"/${P}-fix-build-on-32bit.patch
 )
 
 src_prepare() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/936857

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
