### PR TITLE
profiles/features/musl: media-video/obs-studio mask browser USE flag

### DIFF
--- a/profiles/features/musl/package.use.mask
+++ b/profiles/features/musl/package.use.mask
@@ -1,6 +1,10 @@
 # Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Ian Jordan <immoloism@gmail.com> (2024-08-01)
+# Browser uses a prebuilt binary built agasint glibc (bug #934005)
+media-video/obs-studio browser 
+
 # Andrew Ammerlaan <andrewammerlaan@gentoo.org> (2024-07-25)
 # Requires systemd-detect-virt
 app-emulation/virt-firmware test


### PR DESCRIPTION
Browser binary is currently built against glibc so masking for now.

Bug: https://bugs.gentoo.org/934005

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
