### PR TITLE
media-plugins/kodi-*: fix pkgcheck issues WARN

### DIFF
--- a/media-plugins/kodi-audiodecoder-modplug/kodi-audiodecoder-modplug-3.0.0.ebuild
+++ b/media-plugins/kodi-audiodecoder-modplug/kodi-audiodecoder-modplug-3.0.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="Modplug decoder addon for Kodi"
 HOMEPAGE="https://github.com/xbmc/audiodecoder.modplug"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/xbmc/audiodecoder.modplug.git"
 	inherit git-r3
 	DEPEND="~media-tv/kodi-9999"
@@ -27,7 +26,6 @@ esac
 
 LICENSE="GPL-2+"
 SLOT="0"
-
 
 DEPEND+="
 	>=media-libs/libmodplug-0.8.9.0

--- a/media-plugins/kodi-audiodecoder-modplug/kodi-audiodecoder-modplug-9999.ebuild
+++ b/media-plugins/kodi-audiodecoder-modplug/kodi-audiodecoder-modplug-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="Modplug decoder addon for Kodi"
 HOMEPAGE="https://github.com/xbmc/audiodecoder.modplug"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/xbmc/audiodecoder.modplug.git"
 	inherit git-r3
 	DEPEND="~media-tv/kodi-9999"
@@ -27,7 +26,6 @@ esac
 
 LICENSE="GPL-2+"
 SLOT="0"
-
 
 DEPEND+="
 	>=media-libs/libmodplug-0.8.9.0

--- a/media-plugins/kodi-audiodecoder-nosefart/kodi-audiodecoder-nosefart-3.0.0.ebuild
+++ b/media-plugins/kodi-audiodecoder-nosefart/kodi-audiodecoder-nosefart-3.0.0.ebuild
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="Nosefart decoder addon for Kodi"
 HOMEPAGE="https://github.com/xbmc/audiodecoder.nosefart"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/xbmc/audiodecoder.nosefart"
 	inherit git-r3
 	;;

--- a/media-plugins/kodi-audiodecoder-nosefart/kodi-audiodecoder-nosefart-9999.ebuild
+++ b/media-plugins/kodi-audiodecoder-nosefart/kodi-audiodecoder-nosefart-9999.ebuild
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="Nosefart decoder addon for Kodi"
 HOMEPAGE="https://github.com/xbmc/audiodecoder.nosefart"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/xbmc/audiodecoder.nosefart"
 	inherit git-r3
 	;;

--- a/media-plugins/kodi-audiodecoder-sacd/kodi-audiodecoder-sacd-0.1.1.ebuild
+++ b/media-plugins/kodi-audiodecoder-sacd/kodi-audiodecoder-sacd-0.1.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="Super Audio CD ISO-Image decoder addon for Kodi"
 HOMEPAGE="https://github.com/xbmc/audiodecoder.sacd"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/xbmc/audiodecoder.sacd.git"
 	inherit git-r3
 	DEPEND="~media-tv/kodi-9999"
@@ -27,7 +26,6 @@ esac
 
 LICENSE="GPL-2+"
 SLOT="0"
-
 
 DEPEND+="
 	media-sound/wavpack

--- a/media-plugins/kodi-audiodecoder-sacd/kodi-audiodecoder-sacd-9999.ebuild
+++ b/media-plugins/kodi-audiodecoder-sacd/kodi-audiodecoder-sacd-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="Super Audio CD ISO-Image decoder addon for Kodi"
 HOMEPAGE="https://github.com/xbmc/audiodecoder.sacd"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/xbmc/audiodecoder.sacd.git"
 	inherit git-r3
 	DEPEND="~media-tv/kodi-9999"
@@ -27,7 +26,6 @@ esac
 
 LICENSE="GPL-2+"
 SLOT="0"
-
 
 DEPEND+="
 	media-sound/wavpack

--- a/media-plugins/kodi-audiodecoder-sidplay/kodi-audiodecoder-sidplay-3.0.0.ebuild
+++ b/media-plugins/kodi-audiodecoder-sidplay/kodi-audiodecoder-sidplay-3.0.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="SidPlay decoder addon for Kodi"
 HOMEPAGE="https://github.com/xbmc/audiodecoder.sidplay"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/xbmc/audiodecoder.sidplay.git"
 	inherit git-r3
 	;;
@@ -25,7 +24,6 @@ esac
 
 LICENSE="GPL-2"
 SLOT="0"
-
 
 DEPEND="
 	=media-tv/kodi-19*

--- a/media-plugins/kodi-audiodecoder-sidplay/kodi-audiodecoder-sidplay-9999.ebuild
+++ b/media-plugins/kodi-audiodecoder-sidplay/kodi-audiodecoder-sidplay-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="SidPlay decoder addon for Kodi"
 HOMEPAGE="https://github.com/xbmc/audiodecoder.sidplay"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/xbmc/audiodecoder.sidplay.git"
 	inherit git-r3
 	;;
@@ -25,7 +24,6 @@ esac
 
 LICENSE="GPL-2"
 SLOT="0"
-
 
 DEPEND="
 	~media-tv/kodi-9999

--- a/media-plugins/kodi-audiodecoder-snesapu/kodi-audiodecoder-snesapu-3.0.0.ebuild
+++ b/media-plugins/kodi-audiodecoder-snesapu/kodi-audiodecoder-snesapu-3.0.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="SPC decoder addon for Kodi"
 HOMEPAGE="https://github.com/xbmc/audiodecoder.snesapu"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/xbmc/audiodecoder.snesapu.git"
 	inherit git-r3
 	;;
@@ -25,7 +24,6 @@ esac
 
 LICENSE="GPL-2"
 SLOT="0"
-
 
 DEPEND="
 	=media-tv/kodi-19*

--- a/media-plugins/kodi-audiodecoder-snesapu/kodi-audiodecoder-snesapu-9999.ebuild
+++ b/media-plugins/kodi-audiodecoder-snesapu/kodi-audiodecoder-snesapu-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="SPC decoder addon for Kodi"
 HOMEPAGE="https://github.com/xbmc/audiodecoder.snesapu"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/xbmc/audiodecoder.snesapu.git"
 	inherit git-r3
 	;;
@@ -25,7 +24,6 @@ esac
 
 LICENSE="GPL-2"
 SLOT="0"
-
 
 DEPEND="
 	~media-tv/kodi-9999

--- a/media-plugins/kodi-audiodecoder-stsound/kodi-audiodecoder-stsound-3.0.0.ebuild
+++ b/media-plugins/kodi-audiodecoder-stsound/kodi-audiodecoder-stsound-3.0.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="SPC decoder addon for Kodi"
 HOMEPAGE="https://github.com/xbmc/audiodecoder.stsound"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/xbmc/audiodecoder.stsound.git"
 	inherit git-r3
 	;;
@@ -25,7 +24,6 @@ esac
 
 LICENSE="GPL-2"
 SLOT="0"
-
 
 DEPEND="
 	=media-tv/kodi-19*

--- a/media-plugins/kodi-audiodecoder-stsound/kodi-audiodecoder-stsound-9999.ebuild
+++ b/media-plugins/kodi-audiodecoder-stsound/kodi-audiodecoder-stsound-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="SPC decoder addon for Kodi"
 HOMEPAGE="https://github.com/xbmc/audiodecoder.stsound"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/xbmc/audiodecoder.stsound.git"
 	inherit git-r3
 	;;
@@ -25,7 +24,6 @@ esac
 
 LICENSE="GPL-2"
 SLOT="0"
-
 
 DEPEND="
 	~media-tv/kodi-9999

--- a/media-plugins/kodi-audiodecoder-timidity/kodi-audiodecoder-timidity-3.0.0.ebuild
+++ b/media-plugins/kodi-audiodecoder-timidity/kodi-audiodecoder-timidity-3.0.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="Timidity decoder addon for Kodi"
 HOMEPAGE="https://github.com/xbmc/audiodecoder.timidity"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/xbmc/audiodecoder.timidity.git"
 	inherit git-r3
 	;;
@@ -25,7 +24,6 @@ esac
 
 LICENSE="GPL-2"
 SLOT="0"
-
 
 DEPEND="
 	=media-tv/kodi-19*

--- a/media-plugins/kodi-audiodecoder-timidity/kodi-audiodecoder-timidity-9999.ebuild
+++ b/media-plugins/kodi-audiodecoder-timidity/kodi-audiodecoder-timidity-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="Timidity decoder addon for Kodi"
 HOMEPAGE="https://github.com/xbmc/audiodecoder.timidity"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/xbmc/audiodecoder.timidity.git"
 	inherit git-r3
 	;;
@@ -25,7 +24,6 @@ esac
 
 LICENSE="GPL-2"
 SLOT="0"
-
 
 DEPEND="
 	~media-tv/kodi-9999

--- a/media-plugins/kodi-audiodecoder-vgmstream/kodi-audiodecoder-vgmstream-3.0.0.ebuild
+++ b/media-plugins/kodi-audiodecoder-vgmstream/kodi-audiodecoder-vgmstream-3.0.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="vgmstream decoder addon for Kodi"
 HOMEPAGE="https://github.com/xbmc/audiodecoder.vgmstream"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/xbmc/audiodecoder.vgmstream"
 	inherit git-r3
 	;;
@@ -25,7 +24,6 @@ esac
 
 LICENSE="GPL-2"
 SLOT="0"
-
 
 DEPEND="
 	=media-tv/kodi-19*

--- a/media-plugins/kodi-audiodecoder-vgmstream/kodi-audiodecoder-vgmstream-9999.ebuild
+++ b/media-plugins/kodi-audiodecoder-vgmstream/kodi-audiodecoder-vgmstream-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="vgmstream decoder addon for Kodi"
 HOMEPAGE="https://github.com/xbmc/audiodecoder.vgmstream"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/xbmc/audiodecoder.vgmstream"
 	inherit git-r3
 	;;
@@ -25,7 +24,6 @@ esac
 
 LICENSE="GPL-2"
 SLOT="0"
-
 
 DEPEND="
 	~media-tv/kodi-9999

--- a/media-plugins/kodi-audioencoder-flac/kodi-audioencoder-flac-19.0.0-r1.ebuild
+++ b/media-plugins/kodi-audioencoder-flac/kodi-audioencoder-flac-19.0.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="Flac encoder addon for Kodi"
 HOMEPAGE="https://github.com/xbmc/audioencoder.flac"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/xbmc/audioencoder.flac.git"
 	inherit git-r3
 	DEPEND="~media-tv/kodi-9999"
@@ -27,7 +26,6 @@ esac
 
 LICENSE="GPL-2+"
 SLOT="0"
-
 
 DEPEND+="
 	>=media-libs/libogg-1.3.5

--- a/media-plugins/kodi-audioencoder-flac/kodi-audioencoder-flac-9999.ebuild
+++ b/media-plugins/kodi-audioencoder-flac/kodi-audioencoder-flac-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="Flac encoder addon for Kodi"
 HOMEPAGE="https://github.com/xbmc/audioencoder.flac"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/xbmc/audioencoder.flac.git"
 	inherit git-r3
 	DEPEND="~media-tv/kodi-9999"
@@ -27,7 +26,6 @@ esac
 
 LICENSE="GPL-2+"
 SLOT="0"
-
 
 DEPEND+="
 	>=media-libs/libogg-1.3.5

--- a/media-plugins/kodi-audioencoder-lame/kodi-audioencoder-lame-19.0.0.ebuild
+++ b/media-plugins/kodi-audioencoder-lame/kodi-audioencoder-lame-19.0.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="Lame MP3 encoder addon for Kodi"
 HOMEPAGE="https://github.com/xbmc/audioencoder.lame"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/xbmc/audioencoder.lame.git"
 	inherit git-r3
 	DEPEND="~media-tv/kodi-9999"
@@ -27,7 +26,6 @@ esac
 
 LICENSE="GPL-2+"
 SLOT="0"
-
 
 DEPEND+="
 	>=media-sound/lame-3.100

--- a/media-plugins/kodi-audioencoder-lame/kodi-audioencoder-lame-9999.ebuild
+++ b/media-plugins/kodi-audioencoder-lame/kodi-audioencoder-lame-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="Lame MP3 encoder addon for Kodi"
 HOMEPAGE="https://github.com/xbmc/audioencoder.lame"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/xbmc/audioencoder.lame.git"
 	inherit git-r3
 	DEPEND="~media-tv/kodi-9999"
@@ -27,7 +26,6 @@ esac
 
 LICENSE="GPL-2+"
 SLOT="0"
-
 
 DEPEND+="
 	>=media-sound/lame-3.100

--- a/media-plugins/kodi-audioencoder-vorbis/kodi-audioencoder-vorbis-19.0.0.ebuild
+++ b/media-plugins/kodi-audioencoder-vorbis/kodi-audioencoder-vorbis-19.0.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="Vorbis encoder addon for Kodi"
 HOMEPAGE="https://github.com/xbmc/audioencoder.vorbis"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/xbmc/audioencoder.vorbis.git"
 	inherit git-r3
 	DEPEND="~media-tv/kodi-9999"
@@ -27,7 +26,6 @@ esac
 
 LICENSE="GPL-2+"
 SLOT="0"
-
 
 DEPEND+="
 	>=media-libs/libogg-1.3.5

--- a/media-plugins/kodi-audioencoder-vorbis/kodi-audioencoder-vorbis-9999.ebuild
+++ b/media-plugins/kodi-audioencoder-vorbis/kodi-audioencoder-vorbis-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="Vorbis encoder addon for Kodi"
 HOMEPAGE="https://github.com/xbmc/audioencoder.vorbis"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/xbmc/audioencoder.vorbis.git"
 	inherit git-r3
 	DEPEND="~media-tv/kodi-9999"
@@ -27,7 +26,6 @@ esac
 
 LICENSE="GPL-2+"
 SLOT="0"
-
 
 DEPEND+="
 	>=media-libs/libogg-1.3.5

--- a/media-plugins/kodi-audioencoder-wav/kodi-audioencoder-wav-19.0.0.ebuild
+++ b/media-plugins/kodi-audioencoder-wav/kodi-audioencoder-wav-19.0.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="WAV encoder addon for Kodi"
 HOMEPAGE="https://github.com/xbmc/audioencoder.wav"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/xbmc/audioencoder.wav.git"
 	inherit git-r3
 	;;
@@ -25,7 +24,6 @@ esac
 
 LICENSE="GPL-2"
 SLOT="0"
-
 
 DEPEND="
 	=media-tv/kodi-19*

--- a/media-plugins/kodi-audioencoder-wav/kodi-audioencoder-wav-9999.ebuild
+++ b/media-plugins/kodi-audioencoder-wav/kodi-audioencoder-wav-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="WAV encoder addon for Kodi"
 HOMEPAGE="https://github.com/xbmc/audioencoder.wav"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/xbmc/audioencoder.wav.git"
 	inherit git-r3
 	;;
@@ -25,7 +24,6 @@ esac
 
 LICENSE="GPL-2"
 SLOT="0"
-
 
 DEPEND="
 	~media-tv/kodi-9999

--- a/media-plugins/kodi-game-libretro-bnes/kodi-game-libretro-bnes-0.83.0.8.ebuild
+++ b/media-plugins/kodi-game-libretro-bnes/kodi-game-libretro-bnes-0.83.0.8.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,9 +8,8 @@ inherit kodi-addon
 DESCRIPTION="bNES GameClient for Kodi"
 HOMEPAGE="https://github.com/kodi-game/game.libretro.bnes"
 
-
 if [[ ${PV} == *9999 ]]; then
-	
+
 	EGIT_REPO_URI="https://github.com/kodi-game/game.libretro.bnes.git"
 	inherit git-r3
 	DEPEND="~media-tv/kodi-9999"
@@ -24,7 +23,6 @@ fi
 
 LICENSE="GPL-2"
 SLOT="0"
-
 
 DEPEND+="
 	games-emulation/libretro-bnes

--- a/media-plugins/kodi-game-libretro-bnes/kodi-game-libretro-bnes-9999.ebuild
+++ b/media-plugins/kodi-game-libretro-bnes/kodi-game-libretro-bnes-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,9 +8,8 @@ inherit kodi-addon
 DESCRIPTION="bNES GameClient for Kodi"
 HOMEPAGE="https://github.com/kodi-game/game.libretro.bnes"
 
-
 if [[ ${PV} == *9999 ]]; then
-	
+
 	EGIT_REPO_URI="https://github.com/kodi-game/game.libretro.bnes.git"
 	inherit git-r3
 	DEPEND="~media-tv/kodi-9999"
@@ -24,7 +23,6 @@ fi
 
 LICENSE="GPL-2"
 SLOT="0"
-
 
 DEPEND+="
 	games-emulation/libretro-bnes

--- a/media-plugins/kodi-game-libretro-dosbox/kodi-game-libretro-dosbox-0.74.0.9.ebuild
+++ b/media-plugins/kodi-game-libretro-dosbox/kodi-game-libretro-dosbox-0.74.0.9.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,9 +8,8 @@ inherit kodi-addon
 DESCRIPTION="DOSBox GameClient for Kodi"
 HOMEPAGE="https://github.com/kodi-game/game.libretro.dosbox"
 
-
 if [[ ${PV} == *9999 ]]; then
-	
+
 	EGIT_REPO_URI="https://github.com/kodi-game/game.libretro.dosbox.git"
 	inherit git-r3
 	DEPEND="
@@ -28,7 +27,6 @@ fi
 
 LICENSE="GPL-2"
 SLOT="0"
-
 
 DEPEND="
 	${DEPEND}

--- a/media-plugins/kodi-game-libretro-dosbox/kodi-game-libretro-dosbox-9999.ebuild
+++ b/media-plugins/kodi-game-libretro-dosbox/kodi-game-libretro-dosbox-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,9 +8,8 @@ inherit kodi-addon
 DESCRIPTION="DOSBox GameClient for Kodi"
 HOMEPAGE="https://github.com/kodi-game/game.libretro.dosbox"
 
-
 if [[ ${PV} == *9999 ]]; then
-	
+
 	EGIT_REPO_URI="https://github.com/kodi-game/game.libretro.dosbox.git"
 	inherit git-r3
 	DEPEND="
@@ -28,7 +27,6 @@ fi
 
 LICENSE="GPL-2"
 SLOT="0"
-
 
 DEPEND="
 	${DEPEND}

--- a/media-plugins/kodi-game-libretro-nestopia/kodi-game-libretro-nestopia-1.51.0.16.ebuild
+++ b/media-plugins/kodi-game-libretro-nestopia/kodi-game-libretro-nestopia-1.51.0.16.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,9 +8,8 @@ inherit kodi-addon
 DESCRIPTION="Nestopia GameClient for Kodi"
 HOMEPAGE="https://github.com/kodi-game/game.libretro.nestopia"
 
-
 if [[ ${PV} == *9999 ]]; then
-	
+
 	EGIT_REPO_URI="https://github.com/kodi-game/game.libretro.nestopia.git"
 	inherit git-r3
 	DEPEND="
@@ -28,7 +27,6 @@ fi
 
 LICENSE="GPL-2"
 SLOT="0"
-
 
 DEPEND="
 	${DEPEND}

--- a/media-plugins/kodi-game-libretro-nestopia/kodi-game-libretro-nestopia-9999.ebuild
+++ b/media-plugins/kodi-game-libretro-nestopia/kodi-game-libretro-nestopia-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,9 +8,8 @@ inherit kodi-addon
 DESCRIPTION="Nestopia GameClient for Kodi"
 HOMEPAGE="https://github.com/kodi-game/game.libretro.nestopia"
 
-
 if [[ ${PV} == *9999 ]]; then
-	
+
 	EGIT_REPO_URI="https://github.com/kodi-game/game.libretro.nestopia.git"
 	inherit git-r3
 	DEPEND="
@@ -28,7 +27,6 @@ fi
 
 LICENSE="GPL-2"
 SLOT="0"
-
 
 DEPEND="
 	${DEPEND}

--- a/media-plugins/kodi-game-libretro-snes9x/kodi-game-libretro-snes9x-1.60.0.20.ebuild
+++ b/media-plugins/kodi-game-libretro-snes9x/kodi-game-libretro-snes9x-1.60.0.20.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,9 +8,8 @@ inherit kodi-addon
 DESCRIPTION="Snes9x GameClient for Kodi"
 HOMEPAGE="https://github.com/kodi-game/game.libretro.snes9x"
 
-
 if [[ ${PV} == *9999 ]]; then
-	
+
 	EGIT_REPO_URI="https://github.com/kodi-game/game.libretro.snes9x.git"
 	inherit git-r3
 	DEPEND="${DEPEND}
@@ -26,7 +25,6 @@ fi
 
 LICENSE="GPL-2"
 SLOT="0"
-
 
 DEPEND="
 	${DEPEND}

--- a/media-plugins/kodi-game-libretro-snes9x/kodi-game-libretro-snes9x-9999.ebuild
+++ b/media-plugins/kodi-game-libretro-snes9x/kodi-game-libretro-snes9x-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,9 +8,8 @@ inherit kodi-addon
 DESCRIPTION="Snes9x GameClient for Kodi"
 HOMEPAGE="https://github.com/kodi-game/game.libretro.snes9x"
 
-
 if [[ ${PV} == *9999 ]]; then
-	
+
 	EGIT_REPO_URI="https://github.com/kodi-game/game.libretro.snes9x.git"
 	inherit git-r3
 	DEPEND="${DEPEND}
@@ -26,7 +25,6 @@ fi
 
 LICENSE="GPL-2"
 SLOT="0"
-
 
 DEPEND="
 	${DEPEND}

--- a/media-plugins/kodi-game-libretro-twentyfortyeight/kodi-game-libretro-twentyfortyeight-1.0.0.118.ebuild
+++ b/media-plugins/kodi-game-libretro-twentyfortyeight/kodi-game-libretro-twentyfortyeight-1.0.0.118.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,9 +8,8 @@ inherit kodi-addon
 DESCRIPTION="2048 for Kodi"
 HOMEPAGE="https://github.com/kodi-game/game.libretro.2048"
 
-
 if [[ ${PV} == *9999 ]]; then
-	
+
 	EGIT_REPO_URI="https://github.com/kodi-game/game.libretro.2048.git"
 	inherit git-r3
 else
@@ -22,7 +21,6 @@ fi
 
 LICENSE="GPL-2"
 SLOT="0"
-
 
 DEPEND="
 	=media-tv/kodi-19*

--- a/media-plugins/kodi-game-libretro-twentyfortyeight/kodi-game-libretro-twentyfortyeight-9999.ebuild
+++ b/media-plugins/kodi-game-libretro-twentyfortyeight/kodi-game-libretro-twentyfortyeight-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,9 +8,8 @@ inherit kodi-addon
 DESCRIPTION="2048 for Kodi"
 HOMEPAGE="https://github.com/kodi-game/game.libretro.2048"
 
-
 if [[ ${PV} == *9999 ]]; then
-	
+
 	EGIT_REPO_URI="https://github.com/kodi-game/game.libretro.2048.git"
 	inherit git-r3
 else
@@ -22,7 +21,6 @@ fi
 
 LICENSE="GPL-2"
 SLOT="0"
-
 
 DEPEND="
 	~media-tv/kodi-9999

--- a/media-plugins/kodi-game-libretro/kodi-game-libretro-19.0.0.ebuild
+++ b/media-plugins/kodi-game-libretro/kodi-game-libretro-19.0.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="Libretro compatibility layer for the Kodi Game API"
 HOMEPAGE="https://github.com/kodi-game/game.libretro"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/kodi-game/game.libretro.git"
 	inherit git-r3
 	;;
@@ -25,7 +24,6 @@ esac
 
 LICENSE="GPL-2"
 SLOT="0"
-
 
 DEPEND="
 	=media-tv/kodi-19*

--- a/media-plugins/kodi-game-libretro/kodi-game-libretro-9999.ebuild
+++ b/media-plugins/kodi-game-libretro/kodi-game-libretro-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="Libretro compatibility layer for the Kodi Game API"
 HOMEPAGE="https://github.com/kodi-game/game.libretro"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/kodi-game/game.libretro.git"
 	inherit git-r3
 	;;
@@ -25,7 +24,6 @@ esac
 
 LICENSE="GPL-2"
 SLOT="0"
-
 
 DEPEND="
 	~media-tv/kodi-9999

--- a/media-plugins/kodi-imagedecoder-heif/kodi-imagedecoder-heif-19.0.0.ebuild
+++ b/media-plugins/kodi-imagedecoder-heif/kodi-imagedecoder-heif-19.0.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ HOMEPAGE="https://github.com/xbmc/imagedecoder.heif"
 
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/xbmc/${KODI_PLUGIN_NAME}.git"
 	inherit git-r3
 	DEPEND="=media-tv/kodi-9999*"
@@ -28,7 +28,6 @@ esac
 
 LICENSE="GPL-2+"
 SLOT="0"
-
 
 DEPEND+="
 	>=media-libs/libde265-1.0.8

--- a/media-plugins/kodi-imagedecoder-heif/kodi-imagedecoder-heif-9999.ebuild
+++ b/media-plugins/kodi-imagedecoder-heif/kodi-imagedecoder-heif-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ HOMEPAGE="https://github.com/xbmc/imagedecoder.heif"
 
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/xbmc/${KODI_PLUGIN_NAME}.git"
 	inherit git-r3
 	DEPEND="=media-tv/kodi-9999*"
@@ -28,7 +28,6 @@ esac
 
 LICENSE="GPL-2+"
 SLOT="0"
-
 
 DEPEND+="
 	>=media-libs/libde265-1.0.8

--- a/media-plugins/kodi-imagedecoder-raw/kodi-imagedecoder-raw-19.0.0.ebuild
+++ b/media-plugins/kodi-imagedecoder-raw/kodi-imagedecoder-raw-19.0.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ HOMEPAGE="https://github.com/xbmc/imagedecoder.raw"
 
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/xbmc/${KODI_PLUGIN_NAME}.git"
 	inherit git-r3
 	DEPEND="~media-tv/kodi-9999"
@@ -27,7 +27,6 @@ esac
 
 LICENSE="GPL-2+"
 SLOT="0"
-
 
 DEPEND+="
 	>=media-libs/libjpeg-turbo-2.1.1

--- a/media-plugins/kodi-imagedecoder-raw/kodi-imagedecoder-raw-9999.ebuild
+++ b/media-plugins/kodi-imagedecoder-raw/kodi-imagedecoder-raw-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ HOMEPAGE="https://github.com/xbmc/imagedecoder.raw"
 
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/xbmc/${KODI_PLUGIN_NAME}.git"
 	inherit git-r3
 	DEPEND="~media-tv/kodi-9999"
@@ -27,7 +27,6 @@ esac
 
 LICENSE="GPL-2+"
 SLOT="0"
-
 
 DEPEND+="
 	>=media-libs/libjpeg-turbo-2.1.1

--- a/media-plugins/kodi-inputstream-adaptive/kodi-inputstream-adaptive-19.0.0.ebuild
+++ b/media-plugins/kodi-inputstream-adaptive/kodi-inputstream-adaptive-19.0.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="Kodi's Adaptive inputstream addon"
 HOMEPAGE="https://github.com/peak3d/inputstream.adaptive.git"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/peak3d/inputstream.adaptive.git"
 	EGIT_BRANCH="Matrix"
 	inherit git-r3

--- a/media-plugins/kodi-inputstream-adaptive/kodi-inputstream-adaptive-9999.ebuild
+++ b/media-plugins/kodi-inputstream-adaptive/kodi-inputstream-adaptive-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="Kodi's Adaptive inputstream addon"
 HOMEPAGE="https://github.com/peak3d/inputstream.adaptive.git"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/peak3d/inputstream.adaptive.git"
 	EGIT_BRANCH="Matrix"
 	inherit git-r3

--- a/media-plugins/kodi-inputstream-ffmpegdirect/kodi-inputstream-ffmpegdirect-19.0.0.ebuild
+++ b/media-plugins/kodi-inputstream-ffmpegdirect/kodi-inputstream-ffmpegdirect-19.0.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="Kodi's FFMpeg Direct Inputstream addon"
 HOMEPAGE="https://github.com/xbmc/inputstream.ffmpegdirect"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/xbmc/inputstream.ffmpegdirect.git"
 	EGIT_BRANCH="Matrix"
 	inherit git-r3
@@ -26,7 +25,6 @@ esac
 
 LICENSE="GPL-2"
 SLOT="0"
-
 
 PATCHES=(
 	"${FILESDIR}"/${P}-gcc-13-fix.patch # Bug 915943

--- a/media-plugins/kodi-inputstream-ffmpegdirect/kodi-inputstream-ffmpegdirect-9999.ebuild
+++ b/media-plugins/kodi-inputstream-ffmpegdirect/kodi-inputstream-ffmpegdirect-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="Kodi's FFMpeg Direct Inputstream addon"
 HOMEPAGE="https://github.com/xbmc/inputstream.ffmpegdirect"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/xbmc/inputstream.ffmpegdirect.git"
 	EGIT_BRANCH="Matrix"
 	inherit git-r3
@@ -26,7 +25,6 @@ esac
 
 LICENSE="GPL-2"
 SLOT="0"
-
 
 BDEPEND="
 	virtual/pkgconfig

--- a/media-plugins/kodi-inputstream-rtmp/kodi-inputstream-rtmp-19.0.0.ebuild
+++ b/media-plugins/kodi-inputstream-rtmp/kodi-inputstream-rtmp-19.0.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ KODI_PLUGIN_NAME="inputstream.rtmp"
 
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/xbmc/${KODI_PLUGIN_NAME}.git"
 	EGIT_BRANCH="Matrix"
 	inherit git-r3
@@ -28,7 +28,6 @@ esac
 
 LICENSE="GPL-2+"
 SLOT="0"
-
 
 DEPEND+="
 	media-video/rtmpdump[ssl]

--- a/media-plugins/kodi-inputstream-rtmp/kodi-inputstream-rtmp-9999.ebuild
+++ b/media-plugins/kodi-inputstream-rtmp/kodi-inputstream-rtmp-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ KODI_PLUGIN_NAME="inputstream.rtmp"
 
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/xbmc/${KODI_PLUGIN_NAME}.git"
 	EGIT_BRANCH="Matrix"
 	inherit git-r3
@@ -28,7 +28,6 @@ esac
 
 LICENSE="GPL-2+"
 SLOT="0"
-
 
 DEPEND+="
 	media-video/rtmpdump[ssl]

--- a/media-plugins/kodi-peripheral-joystick/kodi-peripheral-joystick-19.0.0.ebuild
+++ b/media-plugins/kodi-peripheral-joystick/kodi-peripheral-joystick-19.0.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="Libretro compatibility layer for the Kodi Game API"
 HOMEPAGE="https://github.com/xbmc/peripheral.joystick"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_BRANCH="Matrix"
 	EGIT_REPO_URI="https://github.com/xbmc/peripheral.joystick.git"
 	inherit git-r3
@@ -26,7 +25,6 @@ esac
 
 LICENSE="GPL-2"
 SLOT="0"
-
 
 DEPEND="
 	=media-tv/kodi-19*

--- a/media-plugins/kodi-peripheral-joystick/kodi-peripheral-joystick-9999.ebuild
+++ b/media-plugins/kodi-peripheral-joystick/kodi-peripheral-joystick-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="Libretro compatibility layer for the Kodi Game API"
 HOMEPAGE="https://github.com/xbmc/peripheral.joystick"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_BRANCH="Matrix"
 	EGIT_REPO_URI="https://github.com/xbmc/peripheral.joystick.git"
 	inherit git-r3
@@ -26,7 +25,6 @@ esac
 
 LICENSE="GPL-2"
 SLOT="0"
-
 
 DEPEND="
 	~media-tv/kodi-9999

--- a/media-plugins/kodi-pvr-argustv/kodi-pvr-argustv-7.1.2.ebuild
+++ b/media-plugins/kodi-pvr-argustv/kodi-pvr-argustv-7.1.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="Kodi's ARGUS TV client addon"
 HOMEPAGE="https://github.com/kodi-pvr/pvr.argustv"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/kodi-pvr/pvr.argustv.git"
 	inherit git-r3
 	;;
@@ -25,7 +24,6 @@ esac
 
 LICENSE="GPL-2"
 SLOT="0"
-
 
 DEPEND="
 	=media-tv/kodi-19*

--- a/media-plugins/kodi-pvr-argustv/kodi-pvr-argustv-9999.ebuild
+++ b/media-plugins/kodi-pvr-argustv/kodi-pvr-argustv-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="Kodi's ARGUS TV client addon"
 HOMEPAGE="https://github.com/kodi-pvr/pvr.argustv"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/kodi-pvr/pvr.argustv.git"
 	inherit git-r3
 	;;
@@ -25,7 +24,6 @@ esac
 
 LICENSE="GPL-2"
 SLOT="0"
-
 
 DEPEND="
 	~media-tv/kodi-9999

--- a/media-plugins/kodi-pvr-demo/kodi-pvr-demo-7.1.4.ebuild
+++ b/media-plugins/kodi-pvr-demo/kodi-pvr-demo-7.1.4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="Demo PVR for Kodi"
 HOMEPAGE="https://github.com/kodi-pvr/pvr.demo"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/kodi-pvr/pvr.demo.git"
 	inherit git-r3
 	;;
@@ -25,7 +24,6 @@ esac
 
 LICENSE="GPL-2"
 SLOT="0"
-
 
 DEPEND="
 	=media-tv/kodi-19*

--- a/media-plugins/kodi-pvr-demo/kodi-pvr-demo-9999.ebuild
+++ b/media-plugins/kodi-pvr-demo/kodi-pvr-demo-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="Demo PVR for Kodi"
 HOMEPAGE="https://github.com/kodi-pvr/pvr.demo"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/kodi-pvr/pvr.demo.git"
 	inherit git-r3
 	;;
@@ -25,7 +24,6 @@ esac
 
 LICENSE="GPL-2"
 SLOT="0"
-
 
 DEPEND="
 	~media-tv/kodi-9999

--- a/media-plugins/kodi-pvr-dvblink/kodi-pvr-dvblink-9.1.2.ebuild
+++ b/media-plugins/kodi-pvr-dvblink/kodi-pvr-dvblink-9.1.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="Kodi's DVBLink client addon"
 HOMEPAGE="https://github.com/kodi-pvr/pvr.dvblink"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/kodi-pvr/pvr.dvblink.git"
 	inherit git-r3
 	;;
@@ -25,7 +24,6 @@ esac
 
 LICENSE="GPL-2"
 SLOT="0"
-
 
 DEPEND="
 	=media-tv/kodi-19*

--- a/media-plugins/kodi-pvr-dvblink/kodi-pvr-dvblink-9999.ebuild
+++ b/media-plugins/kodi-pvr-dvblink/kodi-pvr-dvblink-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="Kodi's DVBLink client addon"
 HOMEPAGE="https://github.com/kodi-pvr/pvr.dvblink"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/kodi-pvr/pvr.dvblink.git"
 	inherit git-r3
 	;;
@@ -25,7 +24,6 @@ esac
 
 LICENSE="GPL-2"
 SLOT="0"
-
 
 DEPEND="
 	~media-tv/kodi-9999

--- a/media-plugins/kodi-pvr-dvbviewer/kodi-pvr-dvbviewer-7.3.3.ebuild
+++ b/media-plugins/kodi-pvr-dvbviewer/kodi-pvr-dvbviewer-7.3.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="Kodi's DVBViewer client addon"
 HOMEPAGE="https://github.com/kodi-pvr/pvr.dvbviewer"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/kodi-pvr/pvr.dvbviewer.git"
 	inherit git-r3
 	;;
@@ -25,7 +24,6 @@ esac
 
 LICENSE="GPL-2"
 SLOT="0"
-
 
 DEPEND="
 	=media-tv/kodi-19*

--- a/media-plugins/kodi-pvr-dvbviewer/kodi-pvr-dvbviewer-9999.ebuild
+++ b/media-plugins/kodi-pvr-dvbviewer/kodi-pvr-dvbviewer-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="Kodi's DVBViewer client addon"
 HOMEPAGE="https://github.com/kodi-pvr/pvr.dvbviewer"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/kodi-pvr/pvr.dvbviewer.git"
 	inherit git-r3
 	;;
@@ -25,7 +24,6 @@ esac
 
 LICENSE="GPL-2"
 SLOT="0"
-
 
 DEPEND="
 	~media-tv/kodi-9999

--- a/media-plugins/kodi-pvr-filmon/kodi-pvr-filmon-6.1.2.ebuild
+++ b/media-plugins/kodi-pvr-filmon/kodi-pvr-filmon-6.1.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="Kodi's Filmon client addon"
 HOMEPAGE="https://github.com/kodi-pvr/pvr.filmon"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/kodi-pvr/pvr.filmon.git"
 	inherit git-r3
 	;;
@@ -25,7 +24,6 @@ esac
 
 LICENSE="GPL-2"
 SLOT="0"
-
 
 DEPEND="
 	=media-tv/kodi-19*

--- a/media-plugins/kodi-pvr-filmon/kodi-pvr-filmon-9999.ebuild
+++ b/media-plugins/kodi-pvr-filmon/kodi-pvr-filmon-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="Kodi's Filmon client addon"
 HOMEPAGE="https://github.com/kodi-pvr/pvr.filmon"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/kodi-pvr/pvr.filmon.git"
 	inherit git-r3
 	;;
@@ -25,7 +24,6 @@ esac
 
 LICENSE="GPL-2"
 SLOT="0"
-
 
 DEPEND="
 	~media-tv/kodi-9999

--- a/media-plugins/kodi-pvr-hts/kodi-pvr-hts-8.4.0.ebuild
+++ b/media-plugins/kodi-pvr-hts/kodi-pvr-hts-8.4.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,9 +8,8 @@ inherit kodi-addon
 DESCRIPTION="Tvheadend Live TV and Radio PVR client addon for Kodi"
 HOMEPAGE="https://github.com/kodi-pvr/pvr.hts"
 
-
 if [[ ${PV} == 9999 ]]; then
-	
+
 	EGIT_REPO_URI="https://github.com/kodi-pvr/pvr.hts.git"
 	inherit git-r3
 else
@@ -22,7 +21,6 @@ fi
 
 LICENSE="GPL-2"
 SLOT="0"
-
 
 DEPEND="
 	=media-tv/kodi-19*

--- a/media-plugins/kodi-pvr-hts/kodi-pvr-hts-9999.ebuild
+++ b/media-plugins/kodi-pvr-hts/kodi-pvr-hts-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,9 +8,8 @@ inherit kodi-addon
 DESCRIPTION="Tvheadend Live TV and Radio PVR client addon for Kodi"
 HOMEPAGE="https://github.com/kodi-pvr/pvr.hts"
 
-
 if [[ ${PV} == 9999 ]]; then
-	
+
 	EGIT_REPO_URI="https://github.com/kodi-pvr/pvr.hts.git"
 	inherit git-r3
 else
@@ -22,7 +21,6 @@ fi
 
 LICENSE="GPL-2"
 SLOT="0"
-
 
 DEPEND="
 	~media-tv/kodi-9999

--- a/media-plugins/kodi-pvr-iptvsimple/kodi-pvr-iptvsimple-7.6.9.ebuild
+++ b/media-plugins/kodi-pvr-iptvsimple/kodi-pvr-iptvsimple-7.6.9.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="Kodi's IPTVSimple client addon"
 HOMEPAGE="https://github.com/kodi-pvr/pvr.iptvsimple"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/kodi-pvr/pvr.iptvsimple.git"
 	inherit git-r3
 	;;
@@ -25,7 +24,6 @@ esac
 
 LICENSE="GPL-2"
 SLOT="0"
-
 
 DEPEND="
 	dev-libs/pugixml

--- a/media-plugins/kodi-pvr-iptvsimple/kodi-pvr-iptvsimple-9999.ebuild
+++ b/media-plugins/kodi-pvr-iptvsimple/kodi-pvr-iptvsimple-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="Kodi's IPTVSimple client addon"
 HOMEPAGE="https://github.com/kodi-pvr/pvr.iptvsimple"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/kodi-pvr/pvr.iptvsimple.git"
 	inherit git-r3
 	;;
@@ -25,7 +24,6 @@ esac
 
 LICENSE="GPL-2"
 SLOT="0"
-
 
 DEPEND="
 	dev-libs/pugixml

--- a/media-plugins/kodi-pvr-mediaportal-tvserver/kodi-pvr-mediaportal-tvserver-8.2.1.ebuild
+++ b/media-plugins/kodi-pvr-mediaportal-tvserver/kodi-pvr-mediaportal-tvserver-8.2.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="Kodi's MediaPortal TVServer client addon"
 HOMEPAGE="https://github.com/kodi-pvr/pvr.mediaportal.tvserver"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/kodi-pvr/pvr.mediaportal.tvserver.git"
 	inherit git-r3
 	DEPEND="~media-tv/kodi-9999"
@@ -27,7 +26,6 @@ esac
 
 LICENSE="GPL-2"
 SLOT="0"
-
 
 DEPEND+="
 	dev-libs/tinyxml

--- a/media-plugins/kodi-pvr-mediaportal-tvserver/kodi-pvr-mediaportal-tvserver-9999.ebuild
+++ b/media-plugins/kodi-pvr-mediaportal-tvserver/kodi-pvr-mediaportal-tvserver-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="Kodi's MediaPortal TVServer client addon"
 HOMEPAGE="https://github.com/kodi-pvr/pvr.mediaportal.tvserver"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/kodi-pvr/pvr.mediaportal.tvserver.git"
 	inherit git-r3
 	DEPEND="~media-tv/kodi-9999"
@@ -27,7 +26,6 @@ esac
 
 LICENSE="GPL-2"
 SLOT="0"
-
 
 DEPEND+="
 	dev-libs/tinyxml

--- a/media-plugins/kodi-pvr-mythtv/kodi-pvr-mythtv-7.3.1.ebuild
+++ b/media-plugins/kodi-pvr-mythtv/kodi-pvr-mythtv-7.3.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="MythTV PVR for Kodi"
 HOMEPAGE="https://github.com/janbar/pvr.mythtv"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/janbar/pvr.mythtv.git"
 	inherit git-r3
 	;;
@@ -25,7 +24,6 @@ esac
 
 LICENSE="GPL-2"
 SLOT="0"
-
 
 DEPEND="
 	sys-libs/zlib

--- a/media-plugins/kodi-pvr-mythtv/kodi-pvr-mythtv-9999.ebuild
+++ b/media-plugins/kodi-pvr-mythtv/kodi-pvr-mythtv-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="MythTV PVR for Kodi"
 HOMEPAGE="https://github.com/janbar/pvr.mythtv"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/janbar/pvr.mythtv.git"
 	inherit git-r3
 	;;
@@ -25,7 +24,6 @@ esac
 
 LICENSE="GPL-2"
 SLOT="0"
-
 
 DEPEND="
 	sys-libs/zlib

--- a/media-plugins/kodi-pvr-nextpvr/kodi-pvr-nextpvr-8.2.6.ebuild
+++ b/media-plugins/kodi-pvr-nextpvr/kodi-pvr-nextpvr-8.2.6.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="Kodi's NextPVR client addon"
 HOMEPAGE="https://github.com/kodi-pvr/pvr.nextpvr"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/kodi-pvr/pvr.nextpvr.git"
 	inherit git-r3
 	;;
@@ -25,7 +24,6 @@ esac
 
 LICENSE="GPL-2"
 SLOT="0"
-
 
 DEPEND="
 	=media-tv/kodi-19*

--- a/media-plugins/kodi-pvr-nextpvr/kodi-pvr-nextpvr-9999.ebuild
+++ b/media-plugins/kodi-pvr-nextpvr/kodi-pvr-nextpvr-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="Kodi's NextPVR client addon"
 HOMEPAGE="https://github.com/kodi-pvr/pvr.nextpvr"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/kodi-pvr/pvr.nextpvr.git"
 	inherit git-r3
 	;;
@@ -25,7 +24,6 @@ esac
 
 LICENSE="GPL-2"
 SLOT="0"
-
 
 DEPEND="
 	~media-tv/kodi-9999

--- a/media-plugins/kodi-pvr-njoy/kodi-pvr-njoy-7.1.1.ebuild
+++ b/media-plugins/kodi-pvr-njoy/kodi-pvr-njoy-7.1.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="Kodi's Njoy N7 client addon"
 HOMEPAGE="https://github.com/kodi-pvr/pvr.njoy"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/kodi-pvr/pvr.njoy.git"
 	inherit git-r3
 	;;
@@ -25,7 +24,6 @@ esac
 
 LICENSE="GPL-2"
 SLOT="0"
-
 
 DEPEND="
 	=media-tv/kodi-19*

--- a/media-plugins/kodi-pvr-njoy/kodi-pvr-njoy-9999.ebuild
+++ b/media-plugins/kodi-pvr-njoy/kodi-pvr-njoy-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="Kodi's Njoy N7 client addon"
 HOMEPAGE="https://github.com/kodi-pvr/pvr.njoy"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/kodi-pvr/pvr.njoy.git"
 	inherit git-r3
 	;;
@@ -25,7 +24,6 @@ esac
 
 LICENSE="GPL-2"
 SLOT="0"
-
 
 DEPEND="
 	~media-tv/kodi-9999

--- a/media-plugins/kodi-pvr-pctv/kodi-pvr-pctv-6.1.1.ebuild
+++ b/media-plugins/kodi-pvr-pctv/kodi-pvr-pctv-6.1.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="Kodi's PCTV client addon"
 HOMEPAGE="https://github.com/kodi-pvr/pvr.pctv"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/kodi-pvr/pvr.pctv.git"
 	inherit git-r3
 	;;
@@ -25,7 +24,6 @@ esac
 
 LICENSE="GPL-2"
 SLOT="0"
-
 
 DEPEND="
 	=media-tv/kodi-19*

--- a/media-plugins/kodi-pvr-pctv/kodi-pvr-pctv-9999.ebuild
+++ b/media-plugins/kodi-pvr-pctv/kodi-pvr-pctv-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="Kodi's PCTV client addon"
 HOMEPAGE="https://github.com/kodi-pvr/pvr.pctv"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/kodi-pvr/pvr.pctv.git"
 	inherit git-r3
 	;;
@@ -25,7 +24,6 @@ esac
 
 LICENSE="GPL-2"
 SLOT="0"
-
 
 DEPEND="
 	~media-tv/kodi-9999

--- a/media-plugins/kodi-pvr-stalker/kodi-pvr-stalker-7.1.1.ebuild
+++ b/media-plugins/kodi-pvr-stalker/kodi-pvr-stalker-7.1.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="Kodi's Stalker client addon"
 HOMEPAGE="https://github.com/kodi-pvr/pvr.stalker"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/kodi-pvr/pvr.stalker.git"
 	inherit git-r3
 	;;
@@ -25,7 +24,6 @@ esac
 
 LICENSE="GPL-2"
 SLOT="0"
-
 
 DEPEND="
 	=media-tv/kodi-19*

--- a/media-plugins/kodi-pvr-stalker/kodi-pvr-stalker-9999.ebuild
+++ b/media-plugins/kodi-pvr-stalker/kodi-pvr-stalker-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="Kodi's Stalker client addon"
 HOMEPAGE="https://github.com/kodi-pvr/pvr.stalker"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/kodi-pvr/pvr.stalker.git"
 	inherit git-r3
 	;;
@@ -25,7 +24,6 @@ esac
 
 LICENSE="GPL-2"
 SLOT="0"
-
 
 DEPEND="
 	~media-tv/kodi-9999

--- a/media-plugins/kodi-pvr-vbox/kodi-pvr-vbox-8.1.2.ebuild
+++ b/media-plugins/kodi-pvr-vbox/kodi-pvr-vbox-8.1.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="Kodi's VBox Home TV Gateway PVR client addon"
 HOMEPAGE="https://github.com/kodi-pvr/pvr.vbox"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/kodi-pvr/pvr.vbox.git"
 	inherit git-r3
 	;;
@@ -25,7 +24,6 @@ esac
 
 LICENSE="GPL-2"
 SLOT="0"
-
 
 DEPEND="
 	=media-tv/kodi-19*

--- a/media-plugins/kodi-pvr-vbox/kodi-pvr-vbox-9999.ebuild
+++ b/media-plugins/kodi-pvr-vbox/kodi-pvr-vbox-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="Kodi's VBox Home TV Gateway PVR client addon"
 HOMEPAGE="https://github.com/kodi-pvr/pvr.vbox"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/kodi-pvr/pvr.vbox.git"
 	inherit git-r3
 	;;
@@ -25,7 +24,6 @@ esac
 
 LICENSE="GPL-2"
 SLOT="0"
-
 
 DEPEND="
 	~media-tv/kodi-9999

--- a/media-plugins/kodi-pvr-vdr-vnsi/kodi-pvr-vdr-vnsi-19.0.5.ebuild
+++ b/media-plugins/kodi-pvr-vdr-vnsi/kodi-pvr-vdr-vnsi-19.0.5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="Kodi PVR addon VNSI"
 HOMEPAGE="https://github.com/kodi-pvr/pvr.vdr.vnsi"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/kodi-pvr/pvr.vdr.vnsi.git"
 	inherit git-r3
 	;;
@@ -25,7 +24,6 @@ esac
 
 LICENSE="GPL-2"
 SLOT="0"
-
 
 DEPEND="
 	=media-tv/kodi-19*

--- a/media-plugins/kodi-pvr-vdr-vnsi/kodi-pvr-vdr-vnsi-9999.ebuild
+++ b/media-plugins/kodi-pvr-vdr-vnsi/kodi-pvr-vdr-vnsi-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="Kodi PVR addon VNSI"
 HOMEPAGE="https://github.com/kodi-pvr/pvr.vdr.vnsi"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/kodi-pvr/pvr.vdr.vnsi.git"
 	inherit git-r3
 	;;
@@ -25,7 +24,6 @@ esac
 
 LICENSE="GPL-2"
 SLOT="0"
-
 
 DEPEND="
 	~media-tv/kodi-9999

--- a/media-plugins/kodi-pvr-vuplus/kodi-pvr-vuplus-7.4.9.ebuild
+++ b/media-plugins/kodi-pvr-vuplus/kodi-pvr-vuplus-7.4.9.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="Kodi's VuPlus client addon"
 HOMEPAGE="https://github.com/kodi-pvr/pvr.vuplus"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/kodi-pvr/pvr.vuplus.git"
 	inherit git-r3
 	;;
@@ -25,7 +24,6 @@ esac
 
 LICENSE="GPL-2"
 SLOT="0"
-
 
 DEPEND="
 	=media-tv/kodi-19*

--- a/media-plugins/kodi-pvr-vuplus/kodi-pvr-vuplus-9999.ebuild
+++ b/media-plugins/kodi-pvr-vuplus/kodi-pvr-vuplus-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="Kodi's VuPlus client addon"
 HOMEPAGE="https://github.com/kodi-pvr/pvr.vuplus"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/kodi-pvr/pvr.vuplus.git"
 	inherit git-r3
 	;;
@@ -25,7 +24,6 @@ esac
 
 LICENSE="GPL-2"
 SLOT="0"
-
 
 DEPEND="
 	~media-tv/kodi-9999

--- a/media-plugins/kodi-pvr-wmc/kodi-pvr-wmc-6.1.2.ebuild
+++ b/media-plugins/kodi-pvr-wmc/kodi-pvr-wmc-6.1.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="Kodi's Windows Media Center client addon"
 HOMEPAGE="https://github.com/kodi-pvr/pvr.wmc"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/kodi-pvr/pvr.wmc.git"
 	inherit git-r3
 	;;
@@ -25,7 +24,6 @@ esac
 
 LICENSE="GPL-2"
 SLOT="0"
-
 
 DEPEND="
 	=media-tv/kodi-19*

--- a/media-plugins/kodi-pvr-wmc/kodi-pvr-wmc-9999.ebuild
+++ b/media-plugins/kodi-pvr-wmc/kodi-pvr-wmc-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="Kodi's Windows Media Center client addon"
 HOMEPAGE="https://github.com/kodi-pvr/pvr.wmc"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/kodi-pvr/pvr.wmc.git"
 	inherit git-r3
 	;;
@@ -25,7 +24,6 @@ esac
 
 LICENSE="GPL-2"
 SLOT="0"
-
 
 DEPEND="
 	~media-tv/kodi-9999

--- a/media-plugins/kodi-pvr-zattoo/kodi-pvr-zattoo-19.7.9.ebuild
+++ b/media-plugins/kodi-pvr-zattoo/kodi-pvr-zattoo-19.7.9.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="Zattoo PVR addon for Kodi"
 HOMEPAGE="https://github.com/rbuehlma/pvr.zattoo"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/rbuehlma/pvr.zattoo.git"
 	inherit git-r3
 	DEPEND="~media-tv/kodi-9999"
@@ -27,7 +26,6 @@ esac
 
 LICENSE="GPL-2+"
 SLOT="0"
-
 
 DEPEND+="
 	dev-libs/rapidjson

--- a/media-plugins/kodi-pvr-zattoo/kodi-pvr-zattoo-9999.ebuild
+++ b/media-plugins/kodi-pvr-zattoo/kodi-pvr-zattoo-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="Zattoo PVR addon for Kodi"
 HOMEPAGE="https://github.com/rbuehlma/pvr.zattoo"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/rbuehlma/pvr.zattoo.git"
 	inherit git-r3
 	DEPEND="~media-tv/kodi-9999"
@@ -27,7 +26,6 @@ esac
 
 LICENSE="GPL-2+"
 SLOT="0"
-
 
 DEPEND+="
 	dev-libs/rapidjson

--- a/media-plugins/kodi-screensaver-asteroids/kodi-screensaver-asteroids-2.4.2-r1.ebuild
+++ b/media-plugins/kodi-screensaver-asteroids/kodi-screensaver-asteroids-2.4.2-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ KODI_PLUGIN_NAME="screensaver.asteroids"
 
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/xbmc/${KODI_PLUGIN_NAME}.git"
 	inherit git-r3
 	DEPEND="~media-tv/kodi-9999"
@@ -27,7 +27,6 @@ esac
 
 LICENSE="GPL-2+"
 SLOT="0"
-
 
 DEPEND+="
 	>=media-libs/glm-0.9.9.8-r1

--- a/media-plugins/kodi-screensaver-asteroids/kodi-screensaver-asteroids-9999.ebuild
+++ b/media-plugins/kodi-screensaver-asteroids/kodi-screensaver-asteroids-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ KODI_PLUGIN_NAME="screensaver.asteroids"
 
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/xbmc/${KODI_PLUGIN_NAME}.git"
 	inherit git-r3
 	DEPEND="~media-tv/kodi-9999"
@@ -27,7 +27,6 @@ esac
 
 LICENSE="GPL-2+"
 SLOT="0"
-
 
 DEPEND+="
 	>=media-libs/glm-0.9.9.8-r1

--- a/media-plugins/kodi-screensaver-asterwave/kodi-screensaver-asterwave-3.3.0.ebuild
+++ b/media-plugins/kodi-screensaver-asterwave/kodi-screensaver-asterwave-3.3.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ KODI_PLUGIN_NAME="screensaver.asterwave"
 
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/xbmc/${KODI_PLUGIN_NAME}.git"
 	inherit git-r3
 	DEPEND="~media-tv/kodi-9999"
@@ -27,7 +27,6 @@ esac
 
 LICENSE="GPL-2+"
 SLOT="0"
-
 
 DEPEND+="
 	>=media-libs/glm-0.9.9.8-r1

--- a/media-plugins/kodi-screensaver-asterwave/kodi-screensaver-asterwave-9999.ebuild
+++ b/media-plugins/kodi-screensaver-asterwave/kodi-screensaver-asterwave-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ KODI_PLUGIN_NAME="screensaver.asterwave"
 
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/xbmc/${KODI_PLUGIN_NAME}.git"
 	inherit git-r3
 	DEPEND="~media-tv/kodi-9999"
@@ -27,7 +27,6 @@ esac
 
 LICENSE="GPL-2+"
 SLOT="0"
-
 
 DEPEND+="
 	>=media-libs/glm-0.9.9.8-r1

--- a/media-plugins/kodi-screensaver-biogenesis/kodi-screensaver-biogenesis-2.3.2-r1.ebuild
+++ b/media-plugins/kodi-screensaver-biogenesis/kodi-screensaver-biogenesis-2.3.2-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -10,7 +10,7 @@ HOMEPAGE="https://github.com/xbmc/screensaver.biogenesis"
 
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/xbmc/screensaver.biogenesis.git"
 	inherit git-r3
 	DEPEND="~media-tv/kodi-9999"
@@ -26,6 +26,5 @@ esac
 
 LICENSE="GPL-2+"
 SLOT="0"
-
 
 RDEPEND="${DEPEND}"

--- a/media-plugins/kodi-screensaver-biogenesis/kodi-screensaver-biogenesis-9999.ebuild
+++ b/media-plugins/kodi-screensaver-biogenesis/kodi-screensaver-biogenesis-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -10,7 +10,7 @@ HOMEPAGE="https://github.com/xbmc/screensaver.biogenesis"
 
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/xbmc/screensaver.biogenesis.git"
 	inherit git-r3
 	DEPEND="~media-tv/kodi-9999"
@@ -26,6 +26,5 @@ esac
 
 LICENSE="GPL-2+"
 SLOT="0"
-
 
 RDEPEND="${DEPEND}"

--- a/media-plugins/kodi-screensaver-cpblobs/kodi-screensaver-cpblobs-3.4.0.ebuild
+++ b/media-plugins/kodi-screensaver-cpblobs/kodi-screensaver-cpblobs-3.4.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ KODI_PLUGIN_NAME="screensaver.cpblobs"
 
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/xbmc/${KODI_PLUGIN_NAME}.git"
 	inherit git-r3
 	DEPEND="~media-tv/kodi-9999"
@@ -27,7 +27,6 @@ esac
 
 LICENSE="GPL-2+"
 SLOT="0"
-
 
 DEPEND+="
 	>=media-libs/glm-0.9.9.8-r1

--- a/media-plugins/kodi-screensaver-cpblobs/kodi-screensaver-cpblobs-9999.ebuild
+++ b/media-plugins/kodi-screensaver-cpblobs/kodi-screensaver-cpblobs-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ KODI_PLUGIN_NAME="screensaver.cpblobs"
 
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/xbmc/${KODI_PLUGIN_NAME}.git"
 	inherit git-r3
 	DEPEND="~media-tv/kodi-9999"
@@ -27,7 +27,6 @@ esac
 
 LICENSE="GPL-2+"
 SLOT="0"
-
 
 DEPEND+="
 	>=media-libs/glm-0.9.9.8-r1

--- a/media-plugins/kodi-screensaver-greynetic/kodi-screensaver-greynetic-2.3.1-r1.ebuild
+++ b/media-plugins/kodi-screensaver-greynetic/kodi-screensaver-greynetic-2.3.1-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ KODI_PLUGIN_NAME="screensaver.greynetic"
 
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/xbmc/${KODI_PLUGIN_NAME}.git"
 	inherit git-r3
 	DEPEND="~media-tv/kodi-9999"
@@ -27,7 +27,6 @@ esac
 
 LICENSE="GPL-2+"
 SLOT="0"
-
 
 DEPEND+="
 	>=media-libs/glm-0.9.9.8-r1

--- a/media-plugins/kodi-screensaver-greynetic/kodi-screensaver-greynetic-9999.ebuild
+++ b/media-plugins/kodi-screensaver-greynetic/kodi-screensaver-greynetic-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ KODI_PLUGIN_NAME="screensaver.greynetic"
 
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/xbmc/${KODI_PLUGIN_NAME}.git"
 	inherit git-r3
 	DEPEND="~media-tv/kodi-9999"
@@ -27,7 +27,6 @@ esac
 
 LICENSE="GPL-2+"
 SLOT="0"
-
 
 DEPEND+="
 	>=media-libs/glm-0.9.9.8-r1

--- a/media-plugins/kodi-screensaver-matrixtrails/kodi-screensaver-matrixtrails-2.6.0.ebuild
+++ b/media-plugins/kodi-screensaver-matrixtrails/kodi-screensaver-matrixtrails-2.6.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ HOMEPAGE="https://github.com/xbmc/screensaver.matrixtrails"
 
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/xbmc/${KODI_PLUGIN_NAME}.git"
 	inherit git-r3
 	DEPEND="~media-tv/kodi-9999"
@@ -28,7 +28,6 @@ esac
 
 LICENSE="GPL-2+"
 SLOT="0"
-
 
 DEPEND+="
 	virtual/opengl

--- a/media-plugins/kodi-screensaver-matrixtrails/kodi-screensaver-matrixtrails-9999.ebuild
+++ b/media-plugins/kodi-screensaver-matrixtrails/kodi-screensaver-matrixtrails-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ HOMEPAGE="https://github.com/xbmc/screensaver.matrixtrails"
 
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/xbmc/${KODI_PLUGIN_NAME}.git"
 	inherit git-r3
 	DEPEND="~media-tv/kodi-9999"
@@ -28,7 +28,6 @@ esac
 
 LICENSE="GPL-2+"
 SLOT="0"
-
 
 DEPEND+="
 	virtual/opengl

--- a/media-plugins/kodi-screensaver-pingpong/kodi-screensaver-pingpong-2.2.2-r1.ebuild
+++ b/media-plugins/kodi-screensaver-pingpong/kodi-screensaver-pingpong-2.2.2-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ KODI_PLUGIN_NAME="screensaver.pingpong"
 
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/xbmc/${KODI_PLUGIN_NAME}.git"
 	inherit git-r3
 	DEPEND="~media-tv/kodi-9999"
@@ -27,7 +27,6 @@ esac
 
 LICENSE="GPL-2+"
 SLOT="0"
-
 
 DEPEND+="
 	>=media-libs/glm-0.9.9.8-r1

--- a/media-plugins/kodi-screensaver-pingpong/kodi-screensaver-pingpong-9999.ebuild
+++ b/media-plugins/kodi-screensaver-pingpong/kodi-screensaver-pingpong-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ KODI_PLUGIN_NAME="screensaver.pingpong"
 
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/xbmc/${KODI_PLUGIN_NAME}.git"
 	inherit git-r3
 	DEPEND="~media-tv/kodi-9999"
@@ -27,7 +27,6 @@ esac
 
 LICENSE="GPL-2+"
 SLOT="0"
-
 
 DEPEND+="
 	>=media-libs/glm-0.9.9.8-r1

--- a/media-plugins/kodi-screensaver-pyro/kodi-screensaver-pyro-3.3.0.ebuild
+++ b/media-plugins/kodi-screensaver-pyro/kodi-screensaver-pyro-3.3.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="Pyro screensaver for Kodi"
 HOMEPAGE="https://github.com/xbmc/screensaver.pyro"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_BRANCH="Matrix"
 	EGIT_REPO_URI="https://github.com/xbmc/screensaver.pyro.git"
 	inherit git-r3
@@ -26,7 +25,6 @@ esac
 
 LICENSE="GPL-2"
 SLOT="0"
-
 
 DEPEND="
 	=media-tv/kodi-19*

--- a/media-plugins/kodi-screensaver-pyro/kodi-screensaver-pyro-9999.ebuild
+++ b/media-plugins/kodi-screensaver-pyro/kodi-screensaver-pyro-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="Pyro screensaver for Kodi"
 HOMEPAGE="https://github.com/xbmc/screensaver.pyro"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_BRANCH="Matrix"
 	EGIT_REPO_URI="https://github.com/xbmc/screensaver.pyro.git"
 	inherit git-r3
@@ -26,7 +25,6 @@ esac
 
 LICENSE="GPL-2"
 SLOT="0"
-
 
 DEPEND="
 	~media-tv/kodi-9999

--- a/media-plugins/kodi-screensaver-shadertoy/kodi-screensaver-shadertoy-3.2.0.ebuild
+++ b/media-plugins/kodi-screensaver-shadertoy/kodi-screensaver-shadertoy-3.2.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ KODI_PLUGIN_NAME="screensaver.shadertoy"
 
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/xbmc/${KODI_PLUGIN_NAME}.git"
 	inherit git-r3
 	DEPEND="~media-tv/kodi-9999"
@@ -27,7 +27,6 @@ esac
 
 LICENSE="GPL-2+"
 SLOT="0"
-
 
 DEPEND+="
 	>=media-libs/glm-0.9.9.8-r1

--- a/media-plugins/kodi-screensaver-shadertoy/kodi-screensaver-shadertoy-9999.ebuild
+++ b/media-plugins/kodi-screensaver-shadertoy/kodi-screensaver-shadertoy-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ KODI_PLUGIN_NAME="screensaver.shadertoy"
 
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/xbmc/${KODI_PLUGIN_NAME}.git"
 	inherit git-r3
 	DEPEND="~media-tv/kodi-9999"
@@ -27,7 +27,6 @@ esac
 
 LICENSE="GPL-2+"
 SLOT="0"
-
 
 DEPEND+="
 	>=media-libs/glm-0.9.9.8-r1

--- a/media-plugins/kodi-screensaver-stars/kodi-screensaver-stars-2.4.0.ebuild
+++ b/media-plugins/kodi-screensaver-stars/kodi-screensaver-stars-2.4.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ KODI_PLUGIN_NAME="screensaver.stars"
 
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/xbmc/${KODI_PLUGIN_NAME}.git"
 	inherit git-r3
 	DEPEND="~media-tv/kodi-9999"
@@ -27,6 +27,5 @@ esac
 
 LICENSE="GPL-2+"
 SLOT="0"
-
 
 RDEPEND="${DEPEND}"

--- a/media-plugins/kodi-screensaver-stars/kodi-screensaver-stars-9999.ebuild
+++ b/media-plugins/kodi-screensaver-stars/kodi-screensaver-stars-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ KODI_PLUGIN_NAME="screensaver.stars"
 
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/xbmc/${KODI_PLUGIN_NAME}.git"
 	inherit git-r3
 	DEPEND="~media-tv/kodi-9999"
@@ -27,6 +27,5 @@ esac
 
 LICENSE="GPL-2+"
 SLOT="0"
-
 
 RDEPEND="${DEPEND}"

--- a/media-plugins/kodi-vfs-libarchive/kodi-vfs-libarchive-2.0.1-r1.ebuild
+++ b/media-plugins/kodi-vfs-libarchive/kodi-vfs-libarchive-2.0.1-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="Libarchive VFS add-on for Kodi"
 HOMEPAGE="https://github.com/xbmc/vfs.libarchive"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/xbmc/vfs.libarchive.git"
 	EGIT_BRANCH="Matrix"
 	inherit git-r3

--- a/media-plugins/kodi-vfs-libarchive/kodi-vfs-libarchive-9999.ebuild
+++ b/media-plugins/kodi-vfs-libarchive/kodi-vfs-libarchive-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="Libarchive VFS add-on for Kodi"
 HOMEPAGE="https://github.com/xbmc/vfs.libarchive"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/xbmc/vfs.libarchive.git"
 	EGIT_BRANCH="Matrix"
 	inherit git-r3

--- a/media-plugins/kodi-vfs-rar/kodi-vfs-rar-4.0.0.ebuild
+++ b/media-plugins/kodi-vfs-rar/kodi-vfs-rar-4.0.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="RAR VFS addon for Kodi"
 HOMEPAGE="https://github.com/xbmc/vfs.rar"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/xbmc/vfs.rar.git"
 	EGIT_BRANCH="Matrix"
 	inherit git-r3
@@ -28,7 +27,6 @@ esac
 
 LICENSE="GPL-2+"
 SLOT="0"
-
 
 DEPEND+="
 	dev-libs/tinyxml

--- a/media-plugins/kodi-vfs-rar/kodi-vfs-rar-9999.ebuild
+++ b/media-plugins/kodi-vfs-rar/kodi-vfs-rar-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="RAR VFS addon for Kodi"
 HOMEPAGE="https://github.com/xbmc/vfs.rar"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/xbmc/vfs.rar.git"
 	EGIT_BRANCH="Matrix"
 	inherit git-r3
@@ -28,7 +27,6 @@ esac
 
 LICENSE="GPL-2+"
 SLOT="0"
-
 
 DEPEND+="
 	dev-libs/tinyxml

--- a/media-plugins/kodi-vfs-sftp/kodi-vfs-sftp-2.0.0.ebuild
+++ b/media-plugins/kodi-vfs-sftp/kodi-vfs-sftp-2.0.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="SFTP VFS addon for Kodi"
 HOMEPAGE="https://github.com/xbmc/vfs.sftp"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/xbmc/vfs.sftp.git"
 	EGIT_BRANCH="Matrix"
 	inherit git-r3
@@ -26,7 +25,6 @@ esac
 
 LICENSE="GPL-2"
 SLOT="0"
-
 
 DEPEND="
 	net-libs/libssh[sftp]

--- a/media-plugins/kodi-vfs-sftp/kodi-vfs-sftp-9999.ebuild
+++ b/media-plugins/kodi-vfs-sftp/kodi-vfs-sftp-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="SFTP VFS addon for Kodi"
 HOMEPAGE="https://github.com/xbmc/vfs.sftp"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/xbmc/vfs.sftp.git"
 	EGIT_BRANCH="Matrix"
 	inherit git-r3
@@ -26,7 +25,6 @@ esac
 
 LICENSE="GPL-2"
 SLOT="0"
-
 
 DEPEND="
 	net-libs/libssh[sftp]

--- a/media-plugins/kodi-visualization-fishbmc/kodi-visualization-fishbmc-19.0.0.ebuild
+++ b/media-plugins/kodi-visualization-fishbmc/kodi-visualization-fishbmc-19.0.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ KODI_PLUGIN_NAME="visualization.fishbmc"
 
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/xbmc/${KODI_PLUGIN_NAME}.git"
 	inherit git-r3
 	DEPEND="~media-tv/kodi-9999"
@@ -27,7 +27,6 @@ esac
 
 LICENSE="GPL-2+"
 SLOT="0"
-
 
 DEPEND+="
 	>=media-libs/glm-0.9.9.8-r1

--- a/media-plugins/kodi-visualization-fishbmc/kodi-visualization-fishbmc-9999.ebuild
+++ b/media-plugins/kodi-visualization-fishbmc/kodi-visualization-fishbmc-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ KODI_PLUGIN_NAME="visualization.fishbmc"
 
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/xbmc/${KODI_PLUGIN_NAME}.git"
 	inherit git-r3
 	DEPEND="~media-tv/kodi-9999"
@@ -27,7 +27,6 @@ esac
 
 LICENSE="GPL-2+"
 SLOT="0"
-
 
 DEPEND+="
 	>=media-libs/glm-0.9.9.8-r1

--- a/media-plugins/kodi-visualization-goom/kodi-visualization-goom-19.0.0.ebuild
+++ b/media-plugins/kodi-visualization-goom/kodi-visualization-goom-19.0.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ KODI_PLUGIN_NAME="visualization.goom"
 
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/xbmc/${KODI_PLUGIN_NAME}.git"
 	inherit git-r3
 	DEPEND="~media-tv/kodi-9999"
@@ -27,7 +27,6 @@ esac
 
 LICENSE="GPL-2+"
 SLOT="0"
-
 
 DEPEND+="
 	>=media-libs/glm-0.9.9.8-r1

--- a/media-plugins/kodi-visualization-goom/kodi-visualization-goom-9999.ebuild
+++ b/media-plugins/kodi-visualization-goom/kodi-visualization-goom-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ KODI_PLUGIN_NAME="visualization.goom"
 
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/xbmc/${KODI_PLUGIN_NAME}.git"
 	inherit git-r3
 	DEPEND="~media-tv/kodi-9999"
@@ -27,7 +27,6 @@ esac
 
 LICENSE="GPL-2+"
 SLOT="0"
-
 
 DEPEND+="
 	>=media-libs/glm-0.9.9.8-r1

--- a/media-plugins/kodi-visualization-projectm/kodi-visualization-projectm-19.0.1.ebuild
+++ b/media-plugins/kodi-visualization-projectm/kodi-visualization-projectm-19.0.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ KODI_PLUGIN_NAME="visualization.projectm"
 
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/xbmc/${KODI_PLUGIN_NAME}.git"
 	inherit git-r3
 	DEPEND="~media-tv/kodi-9999"
@@ -27,7 +27,6 @@ esac
 
 LICENSE="GPL-2+"
 SLOT="0"
-
 
 DEPEND+="
 	virtual/opengl

--- a/media-plugins/kodi-visualization-projectm/kodi-visualization-projectm-9999.ebuild
+++ b/media-plugins/kodi-visualization-projectm/kodi-visualization-projectm-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ KODI_PLUGIN_NAME="visualization.projectm"
 
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/xbmc/${KODI_PLUGIN_NAME}.git"
 	inherit git-r3
 	DEPEND="~media-tv/kodi-9999"
@@ -27,7 +27,6 @@ esac
 
 LICENSE="GPL-2+"
 SLOT="0"
-
 
 DEPEND+="
 	virtual/opengl

--- a/media-plugins/kodi-visualization-shadertoy/kodi-visualization-shadertoy-19.1.1.ebuild
+++ b/media-plugins/kodi-visualization-shadertoy/kodi-visualization-shadertoy-19.1.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="Shadertoy visualizer for Kodi"
 HOMEPAGE="https://github.com/xbmc/visualization.shadertoy"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/xbmc/visualization.shadertoy.git"
 	inherit git-r3
 	;;
@@ -25,7 +24,6 @@ esac
 
 LICENSE="GPL-2"
 SLOT="0"
-
 
 DEPEND="
 	=media-tv/kodi-19*

--- a/media-plugins/kodi-visualization-shadertoy/kodi-visualization-shadertoy-9999.ebuild
+++ b/media-plugins/kodi-visualization-shadertoy/kodi-visualization-shadertoy-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,10 +8,9 @@ inherit kodi-addon
 DESCRIPTION="Shadertoy visualizer for Kodi"
 HOMEPAGE="https://github.com/xbmc/visualization.shadertoy"
 
-
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/xbmc/visualization.shadertoy.git"
 	inherit git-r3
 	;;
@@ -25,7 +24,6 @@ esac
 
 LICENSE="GPL-2"
 SLOT="0"
-
 
 DEPEND="
 	~media-tv/kodi-9999

--- a/media-plugins/kodi-visualization-spectrum/kodi-visualization-spectrum-19.0.0.ebuild
+++ b/media-plugins/kodi-visualization-spectrum/kodi-visualization-spectrum-19.0.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ KODI_PLUGIN_NAME="visualization.spectrum"
 
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/xbmc/${KODI_PLUGIN_NAME}.git"
 	inherit git-r3
 	DEPEND="~media-tv/kodi-9999"
@@ -27,7 +27,6 @@ esac
 
 LICENSE="GPL-2+"
 SLOT="0"
-
 
 DEPEND+="
 	>=media-libs/glm-0.9.9.8-r1

--- a/media-plugins/kodi-visualization-spectrum/kodi-visualization-spectrum-9999.ebuild
+++ b/media-plugins/kodi-visualization-spectrum/kodi-visualization-spectrum-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ KODI_PLUGIN_NAME="visualization.spectrum"
 
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/xbmc/${KODI_PLUGIN_NAME}.git"
 	inherit git-r3
 	DEPEND="~media-tv/kodi-9999"
@@ -27,7 +27,6 @@ esac
 
 LICENSE="GPL-2+"
 SLOT="0"
-
 
 DEPEND+="
 	>=media-libs/glm-0.9.9.8-r1

--- a/media-plugins/kodi-visualization-starburst/kodi-visualization-starburst-19.0.0.ebuild
+++ b/media-plugins/kodi-visualization-starburst/kodi-visualization-starburst-19.0.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ KODI_PLUGIN_NAME="visualization.starburst"
 
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/xbmc/${KODI_PLUGIN_NAME}.git"
 	inherit git-r3
 	DEPEND="~media-tv/kodi-9999"
@@ -27,7 +27,6 @@ esac
 
 LICENSE="GPL-2+"
 SLOT="0"
-
 
 DEPEND+="
 	>=media-libs/glm-0.9.9.8-r1

--- a/media-plugins/kodi-visualization-starburst/kodi-visualization-starburst-9999.ebuild
+++ b/media-plugins/kodi-visualization-starburst/kodi-visualization-starburst-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ KODI_PLUGIN_NAME="visualization.starburst"
 
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/xbmc/${KODI_PLUGIN_NAME}.git"
 	inherit git-r3
 	DEPEND="~media-tv/kodi-9999"
@@ -27,7 +27,6 @@ esac
 
 LICENSE="GPL-2+"
 SLOT="0"
-
 
 DEPEND+="
 	>=media-libs/glm-0.9.9.8-r1

--- a/media-plugins/kodi-visualization-waveform/kodi-visualization-waveform-19.0.1.ebuild
+++ b/media-plugins/kodi-visualization-waveform/kodi-visualization-waveform-19.0.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ KODI_PLUGIN_NAME="visualization.waveform"
 
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/xbmc/${KODI_PLUGIN_NAME}.git"
 	inherit git-r3
 	DEPEND="~media-tv/kodi-9999"
@@ -27,7 +27,6 @@ esac
 
 LICENSE="GPL-2+"
 SLOT="0"
-
 
 DEPEND+="
 	>=media-libs/glm-0.9.9.8-r1

--- a/media-plugins/kodi-visualization-waveform/kodi-visualization-waveform-9999.ebuild
+++ b/media-plugins/kodi-visualization-waveform/kodi-visualization-waveform-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,7 +11,7 @@ KODI_PLUGIN_NAME="visualization.waveform"
 
 case ${PV} in
 9999)
-	
+
 	EGIT_REPO_URI="https://github.com/xbmc/${KODI_PLUGIN_NAME}.git"
 	inherit git-r3
 	DEPEND="~media-tv/kodi-9999"
@@ -27,7 +27,6 @@ esac
 
 LICENSE="GPL-2+"
 SLOT="0"
-
 
 DEPEND+="
 	>=media-libs/glm-0.9.9.8-r1


### PR DESCRIPTION
warn: the kodi-* were made in bulk. They are to be squashed while merging.
I did not do that as it's easier to rework them if something were to be wrong.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
