### PR TITLE
sys-fs/btrfs-progs: add experimental USE flag

### DIFF
--- a/sys-fs/btrfs-progs/btrfs-progs-6.9.2.ebuild
+++ b/sys-fs/btrfs-progs/btrfs-progs-6.9.2.ebuild
@@ -35,7 +35,7 @@ HOMEPAGE="https://btrfs.readthedocs.io/en/latest/"
 
 LICENSE="GPL-2"
 SLOT="0/0" # libbtrfs soname
-IUSE="+convert +man reiserfs static static-libs udev +zstd"
+IUSE="+convert +man experimental reiserfs static static-libs udev +zstd"
 # Could support it with just !systemd => eudev, see mdadm, but let's
 # see if someone asks for it first.
 REQUIRED_USE="static? ( !udev )"
@@ -131,7 +131,7 @@ src_configure() {
 		--bindir="${EPREFIX}"/sbin
 
 		--enable-lzo
-		--disable-experimental
+		$(use_enable experimental)
 		--disable-python
 		$(use_enable convert)
 		$(use_enable man documentation)
@@ -170,6 +170,11 @@ src_install() {
 	)
 
 	emake V=1 DESTDIR="${D}" install "${makeargs[@]}"
+
+	if use experimental; then
+		exeinto /sbin
+		doexe btrfs-corrupt-block
+	fi
 
 	newbashcomp btrfs-completion btrfs
 }

--- a/sys-fs/btrfs-progs/metadata.xml
+++ b/sys-fs/btrfs-progs/metadata.xml
@@ -7,6 +7,7 @@
   </maintainer>
   <use>
     <flag name="convert">Build ext2 conversion utility (btrfs-convert)</flag>
+    <flag name="experimental">Enable unstable and experimental features and install btrfs-corrupt-block, as needed by xfstests</flag>
     <flag name="reiserfs">Enable reiserfs support in btrfs-convert tool.</flag>
     <flag name="static">Build static binaries in addition to the dynamic ones</flag>
   </use>


### PR DESCRIPTION
Adds an experimental USE flag to btrfs-progs, which feeds through to the --enable-experimental configure option. Also gets it to install btrfs-corrupt-block, which otherwise gets ignored by make install.

These changes are necessary to get the btrfs tests in https://github.com/kdave/xfstests working correctly.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
