### PR TITLE
net-mail/*: EAPI 8 packages: rempve empty IUSE

### DIFF
--- a/net-mail/dot-forward/dot-forward-0.71-r5.ebuild
+++ b/net-mail/dot-forward/dot-forward-0.71-r5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -13,7 +13,6 @@ SRC_URI+=" https://dev.gentoo.org/~sam/distfiles/${CATEGORY}/${PN}/${P}-fix-buil
 LICENSE="public-domain"
 SLOT="0"
 KEYWORDS="~alpha amd64 arm ~hppa ~ia64 ~m68k ~mips ppc ppc64 ~s390 sparc x86"
-IUSE=""
 
 # See bug 97850
 RESTRICT="test"

--- a/net-mail/list-remote-forwards/list-remote-forwards-0.0.3.ebuild
+++ b/net-mail/list-remote-forwards/list-remote-forwards-0.0.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -15,7 +15,6 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 LICENSE="AGPL-3"
 SLOT="0"
 KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
-IUSE=""
 
 # dev-haskell/dns and dev-haskell/resolv conflict
 # https://github.com/sol/doctest/issues/119

--- a/net-mail/mailbox-count/mailbox-count-0.0.6.ebuild
+++ b/net-mail/mailbox-count/mailbox-count-0.0.6.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -13,7 +13,6 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 LICENSE="AGPL-3"
 SLOT="0"
 KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
-IUSE=""
 
 RDEPEND="
 	>=dev-haskell/cmdargs-0.10


### PR DESCRIPTION
moved EAPI8 stuff from https://github.com/gentoo/gentoo/pull/37861

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
