### PR TITLE
dev-ml/dune-private-libs: install ordering, dyn, and stdune too

### DIFF
--- a/dev-ml/dune-private-libs/dune-private-libs-3.11.1-r2.ebuild
+++ b/dev-ml/dune-private-libs/dune-private-libs-3.11.1-r2.ebuild
@@ -30,3 +30,7 @@ src_configure() {
 src_compile() {
 	dune-compile ordering dyn stdune ${PN}
 }
+
+src_install() {
+	dune-install ordering dyn stdune ${PN}
+}

--- a/dev-ml/dune-private-libs/dune-private-libs-3.13.1-r2.ebuild
+++ b/dev-ml/dune-private-libs/dune-private-libs-3.13.1-r2.ebuild
@@ -30,3 +30,7 @@ src_configure() {
 src_compile() {
 	dune-compile ordering dyn stdune ${PN}
 }
+
+src_install() {
+	dune-install ordering dyn stdune ${PN}
+}

--- a/dev-ml/dune-private-libs/dune-private-libs-3.16.0-r2.ebuild
+++ b/dev-ml/dune-private-libs/dune-private-libs-3.16.0-r2.ebuild
@@ -30,3 +30,7 @@ src_configure() {
 src_compile() {
 	dune-compile ordering dyn stdune ${PN}
 }
+
+src_install() {
+	dune-install ordering dyn stdune ${PN}
+}


### PR DESCRIPTION
Some packages in the GURU repository ([`dev-ml/dune-rpc`](https://github.com/gentoo/guru/tree/master/dev-ml/dune-rpc) and [`dev-ml/ocamlc-loc`](https://github.com/gentoo/guru/tree/master/dev-ml/ocamlc-loc)) depend on the three libraries.

***

Please check all the boxes that apply:

*   \[x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
*   \[x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
*   \[x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
*   \[x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
