### PR TITLE
net-dialup/lrzsz: Fix information leak

### DIFF
--- a/net-dialup/lrzsz/files/lrzsz-0.12.20-fix-integer-overflow.patch
+++ b/net-dialup/lrzsz/files/lrzsz-0.12.20-fix-integer-overflow.patch
@@ -1,0 +1,22 @@
+https://src.fedoraproject.org/rpms/lrzsz/blob/rawhide/f/lrzsz-0.12.20.patch
+
+diff -urN lrzsz-0.12.20/src/zm.c lrzsz-0.12.20.new/src/zm.c
+--- lrzsz-0.12.20/src/zm.c	Tue Dec 29 09:48:38 1998
++++ lrzsz-0.12.20.new/src/zm.c	Tue Oct  8 12:46:58 2002
+@@ -431,10 +431,12 @@
+ 	VPRINTF(3,("zsdata: %lu %s", (unsigned long) length, 
+ 		Zendnames[(frameend-ZCRCE)&3]));
+ 	crc = 0;
+-	do {
+-		zsendline(*buf); crc = updcrc((0377 & *buf), crc);
+-		buf++;
+-	} while (--length>0);
++
++	for( ; length; length--) {
++	  zsendline(*buf); crc = updcrc((0377 & *buf), crc);
++	  buf++;
++	}
++
+ 	xsendline(ZDLE); xsendline(frameend);
+ 	crc = updcrc(frameend, crc);
+ 

--- a/net-dialup/lrzsz/lrzsz-0.12.20-r9.ebuild
+++ b/net-dialup/lrzsz/lrzsz-0.12.20-r9.ebuild
@@ -1,0 +1,76 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools toolchain-funcs
+
+DESCRIPTION="Communication package providing the X, Y, and ZMODEM file transfer protocols"
+HOMEPAGE="https://www.ohse.de/uwe/software/lrzsz.html"
+SRC_URI="
+	https://www.ohse.de/uwe/releases/${P}.tar.gz
+	https://dev.gentoo.org/~ceamac/${CATEGORY}/${PN}/${PN}-m4-${PV}.tar.bz2
+"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux"
+IUSE="nls"
+
+DEPEND="nls? ( virtual/libintl )"
+BDEPEND="nls? ( sys-devel/gettext )"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-autotools.patch
+	"${FILESDIR}"/${PN}-implicit-decl.patch
+	"${FILESDIR}"/${P}-automake-1.12.patch
+	"${FILESDIR}"/${P}-automake-1.13.patch
+	"${FILESDIR}"/${P}-gettext-0.20.patch
+	"${FILESDIR}"/${P}-AR.patch
+	"${FILESDIR}"/${P}-configure-clang16.patch
+	"${FILESDIR}"/${P}-gettext-0.22.patch
+	"${FILESDIR}"/${P}-disable-nls.patch
+	"${FILESDIR}"/${P}-c99.patch
+	"${FILESDIR}"/${P}-fix-integer-overflow.patch
+)
+
+DOCS=( AUTHORS COMPATABILITY ChangeLog NEWS \
+	README{,.cvs,.gettext,.isdn4linux,.tests} THANKS TODO )
+
+src_prepare() {
+	default
+
+	# automake is unhappy if this is missing
+	>> config.rpath || die
+	# This is too old.  Remove it so automake puts in a newer copy.
+	rm missing || die
+	# Autoheader does not like seeing this file.
+	rm acconfig.h || die
+	# embed default m4 files in case gettext is not installed
+	mv "${WORKDIR}"/m4 . || die
+
+	eautoreconf
+}
+
+src_configure() {
+	tc-export CC
+
+	econf $(use_enable nls)
+}
+
+src_test() {
+	# Don't use check target.
+	# See bug #120748 before changing this function.
+	emake vcheck
+}
+
+src_install() {
+	default
+
+	local x
+	for x in {r,s}{b,x,z} ; do
+		dosym l${x} /usr/bin/${x}
+		dosym l${x:0:1}z.1 /usr/share/man/man1/${x}.1
+		[ "${x:1:1}" = "z" ] || dosym l${x:0:1}z.1 /usr/share/man/man1/l${x}.1
+	done
+}


### PR DESCRIPTION
- Patch taken from Fedora (check patch file for link)
- Seems to still be affected by https://bugs.gentoo.org/836585
  - Tests pass otherwise ("All tests OK.")

Bug: https://bugs.gentoo.org/797247

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
