### PR TITLE
selinux-policy-2.eclass: Load unconfined module for all policy types.

### DIFF
--- a/eclass/selinux-policy-2.eclass
+++ b/eclass/selinux-policy-2.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # Eclass for installing SELinux policy, and optionally
@@ -260,13 +260,9 @@ selinux-policy-2_pkg_postinst() {
 	local COMMAND
 
 	for i in ${POLICY_TYPES}; do
-		if [[ "${MODS}" = "unconfined" ]]; then
-			case ${i} in
-			strict|mcs|mls)
-				einfo "Ignoring loading of unconfined module in ${i} module store.";
-				continue
-				;;
-			esac
+		if [[ "${i}" == "strict" ]] && [[ "${MODS}" = "unconfined" ]]; then
+			einfo "Ignoring loading of unconfined module in strict module store.";
+			continue;
 		fi
 
 		einfo "Inserting the following modules into the $i module store: ${MODS}"


### PR DESCRIPTION
Currently, there doesn't seem to be a reason to block the loading of unconfined policy module on strict, mcs, and mls policy types. Let's ensure we load the unconfined policy module unconditionally in the eclass.

The loading of the unconfined policy module was initially blocked in 82e30f21ab85b6de3ebc45ae10b28b9bd280e4a1, however as far as I can tell, there is no longer a reason to do this. Considering there are use flags for sec-policy/selinux-base and sec-policy/selinux-base-policy for the unconfined policy module, and using the unconfined policy module is supported for strict, mcs, and mls policy types, it makes sense to no longer block the loading of the policy module. It is also worth mentioning that grabbing an selinux stage3 has the unconfined policy module already loaded. Unfortunately, the reasoning behind blocking the loading in the aforementioned commit is not mentioned, so cc'ing @perfinion, @0xC0ncord and @thesamesam on this.

Closes: [#933709](https://bugs.gentoo.org/933709)

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
