### PR TITLE
dev-java/freenet-ext: re-include onionnetworks-fec - W I P

### DIFF
--- a/dev-java/freenet-ext/files/freenet-ext-29-csrc.patch
+++ b/dev-java/freenet-ext/files/freenet-ext-29-csrc.patch
@@ -1,0 +1,132 @@
+Adopt patches from dev-java/fec which had sources in a dev-space hosted tarball
+
+--- a/fec/src/csrc/Makefile
++++ b/fec/src/csrc/Makefile
+@@ -21,32 +21,28 @@ fec: libfec8.so libfec16.so test.c
+ 	$(CC) $(CFLAGS) -DGF_BITS=8 -o fec fec8.o test.c
+ 
+ libfec8.so: fec8.o fec8-jinterf.o
+-	$(CC) $(LDFLAGS) -shared fec8-jinterf.o fec8.o -o libfec8.so
++	$(CC) $(LDFLAGS) -shared fec8-jinterf.o fec8.o -o libfec8.so \
++		-Wl,-soname=libfec8.so
+ 
+ fec8-jinterf.o: fec-jinterf.c
+ 	$(CC) $(CFLAGS) -DGF_BITS=8 -c \
+ 		-I$(JAVA_HOME)/include/linux fec-jinterf.c \
+ 		-o fec8-jinterf.o
+ 
+-fec8.o: fec.h fec8.S
+-	$(CC) $(CFLAGS) -DGF_BITS=8 -c -o fec8.o fec8.S
+-
+-fec8.S: fec.c Makefile
+-	$(CC) $(CFLAGS) -DGF_BITS=8 -S -o fec8.S fec.c
++fec8.o: fec.h fec.c
++	$(CC) $(CFLAGS) -DGF_BITS=8 -c -o fec8.o fec.c
+ 
+ libfec16.so: fec16.o fec16-jinterf.o
+-	$(CC) $(LDFLAGS) -shared fec16-jinterf.o fec16.o -o libfec16.so
++	$(CC) $(LDFLAGS) -shared fec16-jinterf.o fec16.o -o libfec16.so \
++		-Wl,-soname=libfec16.so
+ 
+ fec16-jinterf.o: fec-jinterf.c
+ 	$(CC) $(CFLAGS) -DGF_BITS=16 -c \
+ 		-I$(JAVA_HOME)/include/linux fec-jinterf.c \
+ 		-o fec16-jinterf.o
+ 
+-fec16.o: fec.h fec16.S
+-	$(CC) $(CFLAGS) -DGF_BITS=16 -c -o fec16.o fec16.S
+-
+-fec16.S: fec.c Makefile
+-	$(CC) $(CFLAGS) -DGF_BITS=16 -S -o fec16.S fec.c
++fec16.o: fec.h fec.c
++	$(CC) $(CFLAGS) -DGF_BITS=16 -c -o fec16.o fec.c
+ 
+ clean:
+ 	- rm -f *.o *.S fec *.so
+--- a/fec/src/csrc/Makefile.nmake
++++ b/fec/src/csrc/Makefile.nmake
+@@ -1,42 +1,42 @@
+-MAKE=nmake -f Makefile.nmake
+-
+-CPP=cl.exe
+-
+-CPP_OPTS=/nologo /I $(JAVA_HOME)/include /I $(JAVA_HOME)/include/win32 \
+-	/D WIN32 /D _WINDOWS /D _MBCS /D _USRDLL /D FEC_EXPORTS /D GF_BITS=$(BITS) \
+-	/D inline=__inline
+-
+-CPP_OPTS=/MT /W3 /Ot /D NDEBUG $(CPP_OPTS)
+-
+-LIBS=kernel32.lib user32.lib
+-
+-LDFLAGS=$(LIBS) /nologo /dll /incremental:no \
+-	/out:fec$(BITS).dll /implib:fec$(BITS).lib \
+-	/OPT:REF /MAP /DEF:fec$(BITS).def
+-
+-LD=link.exe
+-
+-LDOBJS= fec$(BITS).obj fec$(BITS)-jinterf.obj
+-
+-all: release-all
+-
+-feclib: fec$(BITS).dll
+-
+-release-all:
+-	$(MAKE) BITS=8 MODE=Release feclib
+-	$(MAKE) BITS=16 MODE=Release feclib
+-
+-clean:
+-	del *.dll *.obj *.lib *.pdb *.exp *.map
+-
+-fec$(BITS).dll : $(DEF_FILE) $(LDOBJS)
+-	$(LD) $(LDFLAGS) $(LDOBJS)
+-
+-fec$(BITS).obj : fec.c
+-	$(CPP) $(CPP_OPTS) /Fo"fec$(BITS).obj" /c fec.c
+-
+-fec$(BITS)-jinterf.obj : fec-jinterf.c
+-	$(CPP) $(CPP_OPTS) /Fo"fec$(BITS)-jinterf.obj" /c fec-jinterf.c
+-
+-.c.obj::
+-	$(CPP) $(CPP_OPTS) /c $<
++MAKE=nmake -f Makefile.nmake
++
++CPP=cl.exe
++
++CPP_OPTS=/nologo /I $(JAVA_HOME)/include /I $(JAVA_HOME)/include/win32 \
++	/D WIN32 /D _WINDOWS /D _MBCS /D _USRDLL /D FEC_EXPORTS /D GF_BITS=$(BITS) \
++	/D inline=__inline
++
++CPP_OPTS=/MT /W3 /Ot /D NDEBUG $(CPP_OPTS)
++
++LIBS=kernel32.lib user32.lib
++
++LDFLAGS=$(LIBS) /nologo /dll /incremental:no \
++	/out:fec$(BITS).dll /implib:fec$(BITS).lib \
++	/OPT:REF /MAP /DEF:fec$(BITS).def
++
++LD=link.exe
++
++LDOBJS= fec$(BITS).obj fec$(BITS)-jinterf.obj
++
++all: release-all
++
++feclib: fec$(BITS).dll
++
++release-all:
++	$(MAKE) BITS=8 MODE=Release feclib
++	$(MAKE) BITS=16 MODE=Release feclib
++
++clean:
++	del *.dll *.obj *.lib *.pdb *.exp *.map
++
++fec$(BITS).dll : $(DEF_FILE) $(LDOBJS)
++	$(LD) $(LDFLAGS) $(LDOBJS)
++
++fec$(BITS).obj : fec.c
++	$(CPP) $(CPP_OPTS) /Fo"fec$(BITS).obj" /c fec.c
++
++fec$(BITS)-jinterf.obj : fec-jinterf.c
++	$(CPP) $(CPP_OPTS) /Fo"fec$(BITS)-jinterf.obj" /c fec-jinterf.c
++
++.c.obj::
++	$(CPP) $(CPP_OPTS) /c $<

--- a/dev-java/freenet-ext/files/freenet-ext-29-tests.patch
+++ b/dev-java/freenet-ext/files/freenet-ext-29-tests.patch
@@ -1,0 +1,53 @@
+fec/common/test/src/com/onionnetworks/util/BlockDigestInputStreamTest.java:47: error: ')' expected
+            assert("Equal Hashes",Util.arraysEqual(buf.b,buf.off,
+                                 ^
+fec/common/test/src/com/onionnetworks/util/BlockDigestInputStreamTest.java:48: error: ';' expected
+                                                   md.digest(),0,buf.len));
+                                                                         ^
+fec/common/test/src/com/onionnetworks/util/BzeroTest.java:24: error: ')' expected
+            assert("Empty: off="+off+",len="+len,checkArray(b2,b,off,len));
+                                                ^
+fec/common/test/src/com/onionnetworks/util/BzeroTest.java:24: error: ';' expected
+            assert("Empty: off="+off+",len="+len,checkArray(b2,b,off,len));
+                                                                         ^
+fec/common/test/src/com/onionnetworks/util/BzeroTest.java:37: error: ')' expected
+            assert("Filled : off="+off+",len="+len,checkArray(b2,b,off,len));
+                                                  ^
+fec/common/test/src/com/onionnetworks/util/BzeroTest.java:37: error: ';' expected
+            assert("Filled : off="+off+",len="+len,checkArray(b2,b,off,len));
+                                                                           ^
+6 errors
+
+--- a/fec/common/test/src/com/onionnetworks/util/BlockDigestInputStreamTest.java
++++ b/fec/common/test/src/com/onionnetworks/util/BlockDigestInputStreamTest.java
+@@ -44,8 +44,8 @@ public class BlockDigestInputStreamTest extends TestCase {
+             new DataInputStream(dis).readFully(b);
+             dis.close();
+             Buffer buf = bdis.getBlockDigests()[0];
+-            assert("Equal Hashes",Util.arraysEqual(buf.b,buf.off,
+-                                                   md.digest(),0,buf.len));
++            assert("Equal Hashes");Util.arraysEqual(buf.b,buf.off,
++                                                   md.digest(),0,buf.len);;
+         }
+     }
+ 
+--- a/fec/common/test/src/com/onionnetworks/util/BzeroTest.java
++++ b/fec/common/test/src/com/onionnetworks/util/BzeroTest.java
+@@ -21,7 +21,7 @@ public class BzeroTest extends TestCase {
+             int off = rand.nextInt(b.length);
+             int len = rand.nextInt(b.length-off);
+             Util.bzero(b,off,len);
+-            assert("Empty: off="+off+",len="+len,checkArray(b2,b,off,len));
++            assert("Empty: off="+off+",len="+len);checkArray(b2,b,off,len);;
+         }
+     }
+     
+@@ -34,7 +34,7 @@ public class BzeroTest extends TestCase {
+             int off = rand.nextInt(b.length);
+             int len = rand.nextInt(b.length-off);
+             Util.bzero(b,off,len);
+-            assert("Filled : off="+off+",len="+len,checkArray(b2,b,off,len));
++            assert("Filled : off="+off+",len="+len);checkArray(b2,b,off,len);;
+         }
+     }
+     

--- a/dev-java/freenet-ext/freenet-ext-29-r2.ebuild
+++ b/dev-java/freenet-ext/freenet-ext-29-r2.ebuild
@@ -1,0 +1,146 @@
+# Copyright 2023-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+JAVA_PKG_IUSE="doc source test"
+MAVEN_ID="" # Empty since we only pick what's not packaged
+JAVA_TESTING_FRAMEWORKS="junit"
+
+inherit flag-o-matic toolchain-funcs java-pkg-2 java-pkg-simple
+
+DESCRIPTION="Freenet REference Daemon"
+HOMEPAGE="https://github.com/hyphanet/contrib/"
+SRC_URI="https://github.com/hyphanet/contrib/archive/v${PV}.tar.gz -> freenet-ext-${PV}.tar.gz"
+S="${WORKDIR}/contrib-${PV}"
+
+LICENSE="public-domain"
+SLOT="29"
+KEYWORDS="~amd64 ~arm ~arm64 ~x86"
+
+CP_DEPEND="dev-java/log4j-12-api:2"
+
+DEPEND="${CP_DEPEND}
+	dev-libs/gmp:0=
+	>=virtual/jdk-1.8:*
+"
+RDEPEND="${CP_DEPEND}
+	!dev-java/fec:0
+	dev-libs/gmp
+	>=virtual/jre-1.8:*
+"
+
+PATCHES=(
+	"${FILESDIR}/freenet-ext-29-convert-jcpuid.patch"
+	"${FILESDIR}/freenet-ext-29-csrc.patch"
+	"${FILESDIR}/freenet-ext-29-tests.patch"
+)
+
+# Including onionnetworks' fec would cause net-p2p/freenet these test failures:
+# There were 3 failures:
+# 1) testSimpleRev(freenet.client.CodeTest)
+# java.lang.NullPointerException: inStream parameter is null
+# 	at java.base/java.util.Objects.requireNonNull(Objects.java:248)
+# 	at java.base/java.util.Properties.load(Properties.java:406)
+# 	at com.onionnetworks.fec.DefaultFECCodeFactory.<init>(DefaultFECCodeFactory.java:42)
+# 	at com.onionnetworks.fec.FECCodeFactory.getDefault(FECCodeFactory.java:46)
+# 	at freenet.client.CodeTest.testSimpleRev(CodeTest.java:97)
+# 2) testShifted(freenet.client.CodeTest)
+# java.lang.NullPointerException: inStream parameter is null
+# 	at java.base/java.util.Objects.requireNonNull(Objects.java:248)
+# 	at java.base/java.util.Properties.load(Properties.java:406)
+# 	at com.onionnetworks.fec.DefaultFECCodeFactory.<init>(DefaultFECCodeFactory.java:42)
+# 	at com.onionnetworks.fec.FECCodeFactory.getDefault(FECCodeFactory.java:46)
+# 	at freenet.client.CodeTest.testShifted(CodeTest.java:126)
+# 3) testSimple(freenet.client.CodeTest)
+# java.lang.NullPointerException: inStream parameter is null
+# 	at java.base/java.util.Objects.requireNonNull(Objects.java:248)
+# 	at java.base/java.util.Properties.load(Properties.java:406)
+# 	at com.onionnetworks.fec.DefaultFECCodeFactory.<init>(DefaultFECCodeFactory.java:42)
+# 	at com.onionnetworks.fec.FECCodeFactory.getDefault(FECCodeFactory.java:46)
+# 	at freenet.client.CodeTest.testSimple(CodeTest.java:112)
+#
+# FAILURES!!!
+# Tests run: 1051,  Failures: 3
+
+JAVA_RESOURCE_DIRS="res"
+JAVA_SRC_DIR=(
+	fec/{src,common/{src,tools}} # this is what causes above mentioned test failures
+	freenet_ext
+	java/{freenet,net/i2p}
+)
+JAVA_TEST_GENTOO_CLASSPATH="junit"
+JAVA_TEST_SRC_DIR="fec/common/test/src"
+
+src_prepare() {
+	default #780585
+	java-pkg-2_src_prepare
+	mkdir res || die
+	mv {fec/lib,res}/fec.properties || die
+}
+
+src_compile() {
+	java-pkg-simple_src_compile
+
+	local compile_lib
+	compile_lib() {
+		local name="${1}"
+		local file="${2}"
+		shift 2
+
+		"$(tc-getCC)" "${@}" ${CFLAGS} $(java-pkg_get-jni-cflags) \
+			${LDFLAGS} -shared -fPIC "-Wl,-soname,lib${name}.so" \
+			"${file}" -o "lib${name}.so"
+	}
+
+	cd "${S}/NativeBigInteger/jbigi" || die "unable to cd to jbigi"
+	compile_lib jbigi src/jbigi.c -Iinclude -lgmp ||
+		die "unable to build jbigi"
+
+	if use amd64 || use x86; then
+		cd "${S}/jcpuid" || die "unable to cd to jcpuid"
+		compile_lib jcpuid src/jcpuid.c -Iinclude ||
+			die "unable to build jcpuid"
+	fi
+
+	cd "${S}"/fec/src/csrc || die
+	append-flags -fPIC
+	emake CC=$(tc-getCC) CFLAGS="${CFLAGS} $(java-pkg_get-jni-cflags)"
+}
+
+src_test () {
+	# fec/common/test/src/com/onionnetworks/util/BlockDigestInputStreamTest.java:47:
+	# error: incompatible types: String cannot be converted to boolean
+	#             assert("Equal Hashes");Util.arraysEqual(buf.b,buf.off,
+	#                    ^
+	# fec/common/test/src/com/onionnetworks/util/BzeroTest.java:24:
+	# error: incompatible types: String cannot be converted to boolean
+	#             assert("Empty: off="+off+",len="+len);checkArray(b2,b,off,len);;
+	#                                             ^
+	# fec/common/test/src/com/onionnetworks/util/BzeroTest.java:37:
+	# error: incompatible types: String cannot be converted to boolean
+	#             assert("Filled : off="+off+",len="+len);checkArray(b2,b,off,len);;
+	#                                               ^
+	# 3 errors
+	rm fec/common/test/src/com/onionnetworks/util/BlockDigestInputStreamTest.java || die
+	rm fec/common/test/src/com/onionnetworks/util/BzeroTest.java || die
+
+	# only 3 tests are run while " grep -nr 'public void test' " gives 38 matches
+	java-pkg-simple_src_test
+}
+
+src_install() {
+	java-pkg-simple_src_install
+
+	# this jar file compiled from dev-java/fec lets freenet pass tests
+#	java-pkg_dojar "${FILESDIR}/fec.jar"
+
+	java-pkg_doso NativeBigInteger/jbigi/libjbigi.so
+
+	# net-p2p/freenet would pass tests without them
+	java-pkg_doso fec/src/csrc/libfec{8,16}.so
+
+	if use amd64 || use x86; then
+		java-pkg_doso jcpuid/libjcpuid.so
+	fi
+}


### PR DESCRIPTION
Java compilation part is done.
Java tests compilation errors documented in patch and ebuild. Sofiles src/csrc/libfec{8,16}.so done.

Replacing dev-java/fec with corresponding parts integrated here would lead to test failures in net-p2p/freenet.

Bug: https://bugs.gentoo.org/936539

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
