### PR TITLE
x11-themes/adwaita-icon-theme: Fix install for Gentoo Prefix systems.

### DIFF
--- a/x11-themes/adwaita-icon-theme-legacy/adwaita-icon-theme-legacy-46.2.ebuild
+++ b/x11-themes/adwaita-icon-theme-legacy/adwaita-icon-theme-legacy-46.2.ebuild
@@ -35,6 +35,6 @@ src_test() {
 src_install() {
 	meson_src_install
 	# https://gitlab.gnome.org/GNOME/adwaita-icon-theme-legacy/-/issues/3
-	mv "${D}"/usr/share/licenses/adwaita-icon-theme \
-		"${D}"/usr/share/licenses/adwaita-icon-theme-legacy || die
+	mv "${ED}"/usr/share/licenses/adwaita-icon-theme \
+		"${ED}"/usr/share/licenses/adwaita-icon-theme-legacy || die
 }


### PR DESCRIPTION
Change `mv` of install files to support Gentoo Prefix installation.

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
