### PR TITLE
toolchain-funcs.eclass: Fix tc-is-lto not to leave stray files and add tests

### DIFF
--- a/eclass/tests/toolchain-funcs.sh
+++ b/eclass/tests/toolchain-funcs.sh
@@ -210,6 +210,16 @@ if type -P gcc &>/dev/null; then
 	tbegin "tc-get-c-rtlib (gcc)"
 	[[ $(CC=gcc tc-get-c-rtlib) == libgcc ]]
 	tend $?
+
+	tbegin "tc-is-lto (gcc, -fno-lto)"
+	CC=gcc CFLAGS=-fno-lto tc-is-lto
+	[[ $? -eq 1 ]]
+	tend $?
+
+	tbegin "tc-is-lto (gcc, -flto)"
+	CC=gcc CFLAGS=-flto tc-is-lto
+	[[ $? -eq 0 ]]
+	tend $?
 fi
 
 if type -P clang &>/dev/null; then
@@ -232,6 +242,16 @@ if type -P clang &>/dev/null; then
 		[[ $(CC=clang CFLAGS="--rtlib=${rtlib}" tc-get-c-rtlib) == ${rtlib} ]]
 		tend $?
 	done
+
+	tbegin "tc-is-lto (clang, -fno-lto)"
+	CC=clang CFLAGS=-fno-lto tc-is-lto
+	[[ $? -eq 1 ]]
+	tend $?
+
+	tbegin "tc-is-lto (clang, -flto)"
+	CC=clang CFLAGS=-flto tc-is-lto
+	[[ $? -eq 0 ]]
+	tend $?
 fi
 
 texit

--- a/eclass/toolchain-funcs.eclass
+++ b/eclass/toolchain-funcs.eclass
@@ -1234,6 +1234,7 @@ tc-get-build-ptr-size() {
 # @RETURN: Shell true if we are using LTO, shell false otherwise
 tc-is-lto() {
 	local f="${T}/test-lto.o"
+	local ret=1
 
 	case $(tc-get-compiler-type) in
 		clang)
@@ -1241,14 +1242,15 @@ tc-is-lto() {
 			# If LTO is used, clang will output bytecode and llvm-bcanalyzer
 			# will run successfully.  Otherwise, it will output plain object
 			# file and llvm-bcanalyzer will exit with error.
-			llvm-bcanalyzer "${f}" &>/dev/null && return 0
+			llvm-bcanalyzer "${f}" &>/dev/null && ret=0
 			;;
 		gcc)
 			$(tc-getCC) ${CFLAGS} -c -o "${f}" -x c - <<<"" || die
-			[[ $($(tc-getREADELF) -S "${f}") == *.gnu.lto* ]] && return 0
+			[[ $($(tc-getREADELF) -S "${f}") == *.gnu.lto* ]] && ret=0
 			;;
 	esac
-	return 1
+	rm -f "${f}" || die
+	return "${ret}"
 }
 
 fi


### PR DESCRIPTION
CC @gentoo/toolchain 
