### PR TITLE
{dist-,}kernel-{utils,install}.eclass: fix module cleanup when using binpkgs

### DIFF
--- a/eclass/tests/dist-kernel-utils.sh
+++ b/eclass/tests/dist-kernel-utils.sh
@@ -20,9 +20,68 @@ test_PV_to_KV() {
 	tend $?
 }
 
+test_compressed_module_cleanup() {
+	mkdir -p "${tmpdir}/source" || die
+	pushd "${tmpdir}" >/dev/null || die
+
+	local module option fail=0
+	for option in NONE GZIP XZ ZSTD; do
+		tbegin "CONFIG_MODULE_COMPRESS_${option}"
+		echo "CONFIG_MODULE_COMPRESS_${option}=y" > source/.config
+
+		touch a.ko b.ko.gz c.ko.xz d.ko.gz e.ko f.ko.xz || die
+		# ensure some files are older
+		touch -d "2 hours ago" d.ko e.ko.xz f.ko.gz || die
+
+		IUSE=modules-compress dist-kernel_compressed_module_cleanup .
+
+		local to_keep=( a.ko b.ko.gz c.ko.xz )
+		local to_remove=()
+
+		case ${option} in
+			NONE)
+				to_keep+=( d.ko e.ko f.ko.xz )
+				to_remove+=( d.ko.gz e.ko.xz f.ko.gz )
+				;;
+			GZIP)
+				to_keep+=( d.ko.gz e.ko f.ko.gz )
+				to_remove+=( d.ko e.ko.xz f.ko.xz )
+				;;
+			XZ)
+				to_keep+=( d.ko.gz e.ko.xz f.ko.xz )
+				to_remove+=( d.ko e.ko f.ko.gz )
+				;;
+			ZSTD)
+				to_keep+=( d.ko.gz e.ko f.ko.xz )
+				to_remove+=( d.ko e.ko.xz f.ko.gz )
+				;;
+		esac
+
+		for module in "${to_keep[@]}"; do
+			if [[ ! -f ${module} ]]; then
+				eerror "Module ${module} was removed"
+				fail=1
+			fi
+		done
+
+		for module in "${to_remove[@]}"; do
+			if [[ -f ${module} ]]; then
+				eerror "Module ${module} was not removed"
+				fail=1
+			fi
+		done
+		tend ${fail}
+	done
+
+	popd >/dev/null || die
+}
+
+
 test_PV_to_KV 6.0_rc1 6.0.0-rc1
 test_PV_to_KV 6.0 6.0.0
 test_PV_to_KV 6.0.1_rc1 6.0.1-rc1
 test_PV_to_KV 6.0.1 6.0.1
+
+test_compressed_module_cleanup
 
 texit

--- a/eclass/tests/tests-common.sh
+++ b/eclass/tests/tests-common.sh
@@ -55,6 +55,8 @@ has() {
 }
 use() { has "$1" ${IUSE} ; }
 
+in_iuse() { use "$@" ; }
+
 die() {
 	echo "die: $*" 1>&2
 	exit 1


### PR DESCRIPTION
**Problem:** When installing a binpkg of a kernel or kernel module with a different compression then is already installed, the wrong version of this kernel module is cleaned up by `dist-kernel_compressed_module_cleanup`. This happens because the file in `EROOT` can actually be newer then the file in the to-be-installed binpkg.

**Proposed solution:** Replace the current `x -nt y` based check with a new check that determines which compression we want based on `USE=modules-sign` and the kernel config. Remove then all modules that do not have the suffix we want.

CC @mgorny  and also CC @ionenwks since this indirectly effects `linux-mod-r1.eclass`.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
