### PR TITLE
dev-cpp/abseil-cpp: Fix compilation on GCC 15

### DIFF
--- a/dev-cpp/abseil-cpp/abseil-cpp-20230125.3-r5.ebuild
+++ b/dev-cpp/abseil-cpp/abseil-cpp-20230125.3-r5.ebuild
@@ -1,0 +1,68 @@
+# Copyright 2020-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+PYTHON_COMPAT=( python3_{10..12} )
+
+inherit cmake-multilib python-any-r1
+
+DESCRIPTION="Abseil Common Libraries (C++), LTS Branch"
+HOMEPAGE="https://abseil.io/"
+SRC_URI="https://github.com/abseil/abseil-cpp/archive/${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="Apache-2.0"
+SLOT="0/${PV%%.*}.0"
+KEYWORDS="~amd64 ~arm ~arm64 ~loong ~ppc64 ~riscv ~x86"
+IUSE="test"
+
+RDEPEND=">=dev-cpp/gtest-1.13.0[${MULTILIB_USEDEP}]"
+DEPEND="${RDEPEND}"
+BDEPEND="
+	${PYTHON_DEPS}
+	test? (
+		sys-libs/timezone-data
+	)
+"
+
+RESTRICT="!test? ( test )"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-20230125.2-musl-1.2.4.patch #906218
+	"${FILESDIR}"/${PN}-random-tests.patch #935417
+	"${FILESDIR}/${PN}-20230802.0-conditional-use-of-lzcnt.patch" #934337
+	"${FILESDIR}/${PN}-include-cstdint.patch" #937307
+)
+
+src_prepare() {
+	cmake_src_prepare
+
+	# un-hardcode abseil compiler flags
+	sed -i \
+		-e '/"-maes",/d' \
+		-e '/"-msse4.1",/d' \
+		-e '/"-mfpu=neon"/d' \
+		-e '/"-march=armv8-a+crypto"/d' \
+		absl/copts/copts.py || die
+
+	# now generate cmake files
+	python_fix_shebang absl/copts/generate_copts.py
+	absl/copts/generate_copts.py || die
+}
+
+multilib_src_configure() {
+	local mycmakeargs=(
+		# We use -std=c++14 here so that abseil-cpp's string_view is used
+		# See the discussion in https://github.com/gentoo/gentoo/pull/32281.
+		-DCMAKE_CXX_STANDARD=14
+		-DABSL_ENABLE_INSTALL=TRUE
+		-DABSL_USE_EXTERNAL_GOOGLETEST=ON
+		-DABSL_PROPAGATE_CXX_STD=TRUE
+		# TEST_HELPERS needed for protobuf (bug #915902)
+		-DABSL_BUILD_TEST_HELPERS=ON
+		-DABSL_BUILD_TESTING=$(usex test ON OFF)
+		$(usex test -DBUILD_TESTING=ON '') # intentional usex, it used both variables for tests.
+	)
+
+	cmake_src_configure
+}

--- a/dev-cpp/abseil-cpp/abseil-cpp-20230802.0-r4.ebuild
+++ b/dev-cpp/abseil-cpp/abseil-cpp-20230802.0-r4.ebuild
@@ -1,0 +1,68 @@
+# Copyright 2020-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+PYTHON_COMPAT=( python3_{10..12} )
+
+inherit cmake-multilib python-any-r1
+
+DESCRIPTION="Abseil Common Libraries (C++), LTS Branch"
+HOMEPAGE="https://abseil.io/"
+SRC_URI="https://github.com/abseil/abseil-cpp/archive/${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="Apache-2.0"
+SLOT="0/${PV%%.*}"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~loong ~ppc64 ~riscv ~sparc ~x86"
+IUSE="test"
+
+RDEPEND=">=dev-cpp/gtest-1.13.0[${MULTILIB_USEDEP}]"
+DEPEND="${RDEPEND}"
+BDEPEND="
+	${PYTHON_DEPS}
+	test? (
+		sys-libs/timezone-data
+	)
+"
+
+RESTRICT="!test? ( test )"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-20230802.0-sdata-tests.patch"
+	"${FILESDIR}/${PN}-random-tests.patch" #935417
+	"${FILESDIR}/${PN}-20230802.0-conditional-use-of-lzcnt.patch" #934337
+	"${FILESDIR}/${PN}-include-cstdint.patch"
+)
+
+src_prepare() {
+	cmake_src_prepare
+
+	# un-hardcode abseil compiler flags
+	sed -i \
+		-e '/"-maes",/d' \
+		-e '/"-msse4.1",/d' \
+		-e '/"-mfpu=neon"/d' \
+		-e '/"-march=armv8-a+crypto"/d' \
+		absl/copts/copts.py || die
+
+	# now generate cmake files
+	python_fix_shebang absl/copts/generate_copts.py
+	absl/copts/generate_copts.py || die
+}
+
+multilib_src_configure() {
+	local mycmakeargs=(
+		# We use -std=c++14 here so that abseil-cpp's string_view is used
+		# See the discussion in https://github.com/gentoo/gentoo/pull/32281.
+		-DCMAKE_CXX_STANDARD=14
+		-DABSL_ENABLE_INSTALL=TRUE
+		-DABSL_USE_EXTERNAL_GOOGLETEST=ON
+		-DABSL_PROPAGATE_CXX_STD=TRUE
+		# TEST_HELPERS needed for protobuf (bug #915902)
+		-DABSL_BUILD_TEST_HELPERS=ON
+		-DABSL_BUILD_TESTING=$(usex test ON OFF)
+		$(usex test -DBUILD_TESTING=ON '') # intentional usex, it used both variables for tests.
+	)
+
+	cmake_src_configure
+}

--- a/dev-cpp/abseil-cpp/abseil-cpp-20240116.2-r4.ebuild
+++ b/dev-cpp/abseil-cpp/abseil-cpp-20240116.2-r4.ebuild
@@ -1,0 +1,68 @@
+# Copyright 2020-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+PYTHON_COMPAT=( python3_{10..12} )
+
+inherit cmake-multilib python-any-r1
+
+DESCRIPTION="Abseil Common Libraries (C++), LTS Branch"
+HOMEPAGE="https://abseil.io/"
+SRC_URI="https://github.com/abseil/abseil-cpp/archive/${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="Apache-2.0"
+SLOT="0/${PV%%.*}"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~loong ~ppc64 ~riscv ~sparc ~x86"
+IUSE="test"
+
+RDEPEND=">=dev-cpp/gtest-1.13.0[${MULTILIB_USEDEP}]"
+DEPEND="${RDEPEND}"
+BDEPEND="
+	${PYTHON_DEPS}
+	test? (
+		sys-libs/timezone-data
+	)
+"
+
+RESTRICT="!test? ( test )"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-20230802.0-sdata-tests.patch"
+	"${FILESDIR}/${PN}-random-tests.patch" #935417
+	"${FILESDIR}/${PN}-20230802.0-conditional-use-of-lzcnt.patch" #934337
+	"${FILESDIR}/${PN}-include-cstdint.patch" #937307
+)
+
+src_prepare() {
+	cmake_src_prepare
+
+	# un-hardcode abseil compiler flags
+	sed -i \
+		-e '/"-maes",/d' \
+		-e '/"-msse4.1",/d' \
+		-e '/"-mfpu=neon"/d' \
+		-e '/"-march=armv8-a+crypto"/d' \
+		absl/copts/copts.py || die
+
+	# now generate cmake files
+	python_fix_shebang absl/copts/generate_copts.py
+	absl/copts/generate_copts.py || die
+}
+
+multilib_src_configure() {
+	local mycmakeargs=(
+		# We use -std=c++14 here so that abseil-cpp's string_view is used
+		# See the discussion in https://github.com/gentoo/gentoo/pull/32281.
+		-DCMAKE_CXX_STANDARD=14
+		-DABSL_ENABLE_INSTALL=TRUE
+		-DABSL_USE_EXTERNAL_GOOGLETEST=ON
+		-DABSL_PROPAGATE_CXX_STD=TRUE
+		# TEST_HELPERS needed for protobuf (bug #915902)
+		-DABSL_BUILD_TEST_HELPERS=ON
+		-DABSL_BUILD_TESTING=$(usex test ON OFF)
+		$(usex test -DBUILD_TESTING=ON '') # intentional usex, it used both variables for tests.
+	)
+
+	cmake_src_configure
+}

--- a/dev-cpp/abseil-cpp/files/abseil-cpp-include-cstdint.patch
+++ b/dev-cpp/abseil-cpp/files/abseil-cpp-include-cstdint.patch
@@ -1,0 +1,33 @@
+https://github.com/abseil/abseil-cpp/commit/809e5de7b92950849289236a5a09e9cb4f32c7b9
+
+From: Christopher Fore <csfore@posteo.net>
+Date: Mon, 5 Aug 2024 10:48:19 -0400
+Subject: [PATCH] container/internal: Explicitly include <cstdint>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+GCC 15 will no longer include <cstdint> by default, resulting in build
+failures in projects that do not explicitly include it.
+
+Error:
+absl/container/internal/container_memory.h:66:27: error: ‘uintptr_t’ does not name a type
+   66 |   assert(reinterpret_cast<uintptr_t>(p) % Alignment == 0 &&
+      |                           ^~~~~~~~~
+absl/container/internal/container_memory.h:31:1: note: ‘uintptr_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
+   30 | #include "absl/utility/utility.h"
+  +++ |+#include <cstdint>
+   31 |
+
+See-also: https://gcc.gnu.org/pipermail/gcc-cvs/2024-August/407124.html
+Signed-off-by: Christopher Fore <csfore@posteo.net>
+--- a/absl/container/internal/container_memory.h
++++ b/absl/container/internal/container_memory.h
+@@ -17,6 +17,7 @@
+ 
+ #include <cassert>
+ #include <cstddef>
++#include <cstdint>
+ #include <cstring>
+ #include <memory>
+ #include <new>


### PR DESCRIPTION
- Tests pass
- Include patch from upstream including <cstdint>

Closes: https://bugs.gentoo.org/937307

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
