### PR TITLE
dev-embedded/u-boot-utils: Add a missing dependency

### DIFF
--- a/dev-embedded/u-boot-tools/u-boot-tools-2024.01.ebuild
+++ b/dev-embedded/u-boot-tools/u-boot-tools-2024.01.ebuild
@@ -20,7 +20,10 @@ SLOT="0"
 KEYWORDS="amd64 arm arm64 ppc ppc64 ~riscv x86"
 IUSE="envtools"
 
-RDEPEND="dev-libs/openssl:="
+RDEPEND="
+	dev-libs/openssl:=
+	net-libs/gnutls:=
+"
 DEPEND="${RDEPEND}"
 BDEPEND="
 	dev-lang/swig


### PR DESCRIPTION
Fixes a build in Flatcar:

x86_64-pc-linux-gnu-gcc -Wp,-MD,tools/.mkeficapsule.d -Wall -Wstrict-prototypes -O2 -fomit-frame-pointer  -O2 -pipe   -std=gnu11   -DCONFIG_FIT_SIGNATURE -DCONFIG_FIT_SIGNATURE_MAX_SIZE=0xffffffff -DCONFIG_FIT_CIPHER -include ./include/compiler.h -idirafterinclude -idirafter./arch/sandbox/include -I./scripts/dtc/libfdt -I./tools -DUSE_HOSTCC -D__KERNEL_STRICT_NAMES -D_GNU_SOURCE  -I/usr/include/uuid  -Wl,-O2 -Wl,--as-needed -o tools/mkeficapsule tools/mkeficapsule.c   -lgnutls -luuid

```
tools/mkeficapsule.c:21:10: fatal error: gnutls/gnutls.h: No such file or directory
    21 | #include <gnutls/gnutls.h>
       |          ^~~~~~~~~~~~~~~~~
compilation terminated.
```

The build system silently ignores missing gnutls by adding nothing to `CFLAGS` and adding `-lgnutls` to `LDLIBS`.

I'm not sure if I should also add a dependency on `sys-apps/util-linux` to make sure that `pkg-config --cflags uuid` also always works, since the package is the `profiles/default/linux/packages` list.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
