### PR TITLE
dev-vcs/git: Fix cross-compiling when build host lacks curl

### DIFF
--- a/dev-vcs/git/git-2.45.2.ebuild
+++ b/dev-vcs/git/git-2.45.2.ebuild
@@ -306,6 +306,10 @@ git_emake() {
 		OPTCFLAGS="${CFLAGS}"
 		OPTLDFLAGS="${LDFLAGS}"
 
+		CURL_CONFIG="${ESYSROOT}/usr/bin/curl-config"
+		CURL_CFLAGS="$($(tc-getPKG_CONFIG) --cflags libcurl)"
+		CURL_LDFLAGS="$($(tc-getPKG_CONFIG) --libs libcurl)"
+
 		PERL_PATH="${EPREFIX}/usr/bin/perl"
 		PERL_MM_OPT=""
 

--- a/dev-vcs/git/git-9999-r1.ebuild
+++ b/dev-vcs/git/git-9999-r1.ebuild
@@ -306,6 +306,10 @@ git_emake() {
 		OPTCFLAGS="${CFLAGS}"
 		OPTLDFLAGS="${LDFLAGS}"
 
+		CURL_CONFIG="${ESYSROOT}/usr/bin/curl-config"
+		CURL_CFLAGS="$($(tc-getPKG_CONFIG) --cflags libcurl)"
+		CURL_LDFLAGS="$($(tc-getPKG_CONFIG) --libs libcurl)"
+
 		PERL_PATH="${EPREFIX}/usr/bin/perl"
 		PERL_MM_OPT=""
 

--- a/dev-vcs/git/git-9999-r2.ebuild
+++ b/dev-vcs/git/git-9999-r2.ebuild
@@ -306,6 +306,10 @@ git_emake() {
 		OPTCFLAGS="${CFLAGS}"
 		OPTLDFLAGS="${LDFLAGS}"
 
+		CURL_CONFIG="${ESYSROOT}/usr/bin/curl-config"
+		CURL_CFLAGS="$($(tc-getPKG_CONFIG) --cflags libcurl)"
+		CURL_LDFLAGS="$($(tc-getPKG_CONFIG) --libs libcurl)"
+
 		PERL_PATH="${EPREFIX}/usr/bin/perl"
 		PERL_MM_OPT=""
 

--- a/dev-vcs/git/git-9999-r3.ebuild
+++ b/dev-vcs/git/git-9999-r3.ebuild
@@ -306,6 +306,10 @@ git_emake() {
 		OPTCFLAGS="${CFLAGS}"
 		OPTLDFLAGS="${LDFLAGS}"
 
+		CURL_CONFIG="${ESYSROOT}/usr/bin/curl-config"
+		CURL_CFLAGS="$($(tc-getPKG_CONFIG) --cflags libcurl)"
+		CURL_LDFLAGS="$($(tc-getPKG_CONFIG) --libs libcurl)"
+
 		PERL_PATH="${EPREFIX}/usr/bin/perl"
 		PERL_MM_OPT=""
 

--- a/dev-vcs/git/git-9999.ebuild
+++ b/dev-vcs/git/git-9999.ebuild
@@ -306,6 +306,10 @@ git_emake() {
 		OPTCFLAGS="${CFLAGS}"
 		OPTLDFLAGS="${LDFLAGS}"
 
+		CURL_CONFIG="${ESYSROOT}/usr/bin/curl-config"
+		CURL_CFLAGS="$($(tc-getPKG_CONFIG) --cflags libcurl)"
+		CURL_LDFLAGS="$($(tc-getPKG_CONFIG) --libs libcurl)"
+
 		PERL_PATH="${EPREFIX}/usr/bin/perl"
 		PERL_MM_OPT=""
 


### PR DESCRIPTION
The Makefile tries to run curl-config, which is practically always present on the build host, but we shouldn't assume that, and it could return the wrong values when cross-compiling.

It's just a shell script, so we can safely call the copy under ESYSROOT for the version check. For the CFLAGS and LDFLAGS, leverage pkg-config instead, as it will correctly adjust the paths.

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.