### PR TITLE
java-vm-2.eclass: remove function set_java_env

### DIFF
--- a/eclass/java-vm-2.eclass
+++ b/eclass/java-vm-2.eclass
@@ -164,58 +164,6 @@ get_system_arch() {
 }
 
 
-# @FUNCTION: set_java_env
-# @DESCRIPTION:
-# Installs a vm env file.
-# DEPRECATED, use java-vm_install-env instead.
-
-set_java_env() {
-	debug-print-function ${FUNCNAME} $*
-
-	local platform="$(get_system_arch)"
-	local env_file="${ED}${JAVA_VM_CONFIG_DIR}/${VMHANDLE}"
-
-	if [[ ${1} ]]; then
-		local source_env_file="${1}"
-	else
-		local source_env_file="${FILESDIR}/${VMHANDLE}.env"
-	fi
-
-	if [[ ! -f ${source_env_file} ]]; then
-		die "Unable to find the env file: ${source_env_file}"
-	fi
-
-	dodir ${JAVA_VM_CONFIG_DIR}
-	sed \
-		-e "s/@P@/${P}/g" \
-		-e "s/@PN@/${PN}/g" \
-		-e "s/@PV@/${PV}/g" \
-		-e "s/@PF@/${PF}/g" \
-		-e "s/@SLOT@/${SLOT}/g" \
-		-e "s/@PLATFORM@/${platform}/g" \
-		-e "s/@LIBDIR@/$(get_libdir)/g" \
-		-e "/^LDPATH=.*lib\\/\\\"/s|\"\\(.*\\)\"|\"\\1${platform}/:\\1${platform}/server/\"|" \
-		< "${source_env_file}" \
-		> "${env_file}" || die "sed failed"
-
-	(
-		echo "VMHANDLE=\"${VMHANDLE}\""
-		echo "BUILD_ONLY=\"${JAVA_VM_BUILD_ONLY}\""
-	) >> "${env_file}"
-
-	eprefixify ${env_file}
-
-	[[ -n ${JAVA_PROVIDE} ]] && echo "PROVIDES=\"${JAVA_PROVIDE}\"" >> ${env_file}
-
-	local java_home=$(source "${env_file}"; echo ${JAVA_HOME})
-	[[ -z ${java_home} ]] && die "No JAVA_HOME defined in ${env_file}"
-
-	# Make the symlink
-	dodir "${JAVA_VM_DIR}"
-	dosym "${java_home}" "${JAVA_VM_DIR}/${VMHANDLE}"
-}
-
-
 # @FUNCTION: java-vm_install-env
 # @DESCRIPTION:
 #


### PR DESCRIPTION
Deprecated with commit #436dd062c on 2016-08-02

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
