### PR TITLE
www-client/firefox: fix PGO for 115.13.0, 115.14.0

### DIFF
--- a/www-client/firefox/firefox-115.13.0.ebuild
+++ b/www-client/firefox/firefox-115.13.0.ebuild
@@ -584,8 +584,8 @@ pkg_setup() {
 			# (PORTAGE_SCHEDULING_POLICY) update...
 			addpredict /proc
 
-			# May need a wider addpredict when using wayland+pgo.
-			addpredict /dev/dri
+			# Clear tons of conditions, since PGO is hardware-dependant.
+			addpredict /dev
 
 			# Allow access to GPU during PGO run
 			local ati_cards mesa_cards nvidia_cards render_cards

--- a/www-client/firefox/firefox-115.14.0.ebuild
+++ b/www-client/firefox/firefox-115.14.0.ebuild
@@ -584,8 +584,8 @@ pkg_setup() {
 			# (PORTAGE_SCHEDULING_POLICY) update...
 			addpredict /proc
 
-			# May need a wider addpredict when using wayland+pgo.
-			addpredict /dev/dri
+			# Clear tons of conditions, since PGO is hardware-dependant.
+			addpredict /dev
 
 			# Allow access to GPU during PGO run
 			local ati_cards mesa_cards nvidia_cards render_cards


### PR DESCRIPTION
 - fix PGO compilation: relax sandbox restrictions for /dev since PGO is hardware-dependant.

Closes: https://bugs.gentoo.org/936278

---
- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
