### PR TITLE
net-analyzer/nagtrap: treeclean request

### DIFF
--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -33,6 +33,14 @@
 
 #--- END OF EXAMPLES ---
 
+# Filip Kobierski <fkobi@pm.me> (2024.08.07)
+# It's been in the tree for over ten years, without a maintainer.
+# During this time it has recieved 4 non-generic commits.
+# SRC_URI redirect to nagios, which is packaged already.
+# Only we and one derivative ship it. Bug #937515
+# Removal on 2024.09.07
+net-analyzer/nagtrap
+
 # Michał Górny <mgorny@gentoo.org> (2024-08-06)
 # Superseded by dev-libs/libayatana-*.  No revdeps left.
 # Removal on 2024-09-05.  Bug #936881.


### PR DESCRIPTION
Git holds package's history since 2015.
Since then it has recieved these non-generic changes:
- Shorter DESCRIPTION in 2015
- EAPI bump (2 to 7!) in 2017
- Fix net-analyzer/snmptt dependency in 2020
- fix installation of config, ${D} usage

That's nearly 10 years without version updates nor a maintainer.

Only we and one Gentoo derivative (LigurOS) ships it.
HOMEPAGE is dead and SRC_URI redirects to Nagios stuff, which is in the tree.

This makes me believe this package is obsolete and only burdens the tree.

https://bugs.gentoo.org/937515

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
