### PR TITLE
media-libs/libva-intel-media-driver: bump libva version requirement

### DIFF
--- a/media-libs/libva-intel-media-driver/libva-intel-media-driver-24.3.1-r1.ebuild
+++ b/media-libs/libva-intel-media-driver/libva-intel-media-driver-24.3.1-r1.ebuild
@@ -30,7 +30,7 @@ IUSE="+redistributable test X"
 RESTRICT="!test? ( test )"
 
 DEPEND=">=media-libs/gmmlib-22.3.20:=[${MULTILIB_USEDEP}]
-	>=media-libs/libva-2.21.0[X?,${MULTILIB_USEDEP}]
+	>=media-libs/libva-2.22.0[X?,${MULTILIB_USEDEP}]
 "
 RDEPEND="${DEPEND}"
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/937513

@mattst88 A straight forward diagnosis and resolution.
<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
