### PR TITLE
sys-boot/grub: implement USE=secureboot via grub-mkstandalone

### DIFF
--- a/sys-boot/grub/grub-2.12-r5.ebuild
+++ b/sys-boot/grub/grub-2.12-r5.ebuild
@@ -16,11 +16,7 @@ EAPI=7
 # If any of the above applies to a user patch, the user should set the
 # corresponding variable in make.conf or the environment.
 
-if [[ ${PV} == 9999  ]]; then
-	GRUB_AUTORECONF=1
-	GRUB_BOOTSTRAP=1
-fi
-
+GRUB_AUTORECONF=1
 PYTHON_COMPAT=( python3_{10..12} )
 WANT_LIBTOOL=none
 VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/openpgp-keys/dkiper.gpg
@@ -50,6 +46,7 @@ if [[ ${PV} != 9999 ]]; then
 	else
 		SRC_URI="
 			mirror://gnu/${PN}/${P}.tar.xz
+			https://dev.gentoo.org/~floppym/dist/${P}-bash-completion.patch.gz
 			verify-sig? ( mirror://gnu/${PN}/${P}.tar.xz.sig )
 		"
 		S=${WORKDIR}/${P%_*}
@@ -162,6 +159,8 @@ src_prepare() {
 		"${FILESDIR}"/gfxpayload.patch
 		"${FILESDIR}"/grub-2.02_beta2-KERNEL_GLOBS.patch
 		"${FILESDIR}"/grub-2.06-test-words.patch
+		"${FILESDIR}"/grub-2.12-fwsetup.patch
+		"${WORKDIR}"/grub-2.12-bash-completion.patch
 	)
 
 	default
@@ -178,6 +177,10 @@ src_prepare() {
 	if [[ -n ${GRUB_AUTORECONF} ]]; then
 		eautoreconf
 	fi
+
+	# Avoid error due to extra_deps.lst missing from source tarball:
+	#       make[3]: *** No rule to make target 'grub-core/extra_deps.lst', needed by 'syminfo.lst'.  Stop.
+	echo "depends bli part_gpt" > grub-core/extra_deps.lst || die
 }
 
 grub_do() {


### PR DESCRIPTION
This makes it possible to create a pre-built grub EFI executable signed for secureboot via portage/`secureboot.eclass`.

It greatly simplifies setting up grub with secureboot, which is now a bit of a tricky section in the handbook, and makes it possible to get a signed grub EFI executable on systems that do not have the `SECUREBOOT_SIGN_KEY` available via a `sys-boot/grub[secureboot]` binpkg.

Unfortunately, since the use of boot partitions, and the mounting point of ESP's varies between systems we cannot rely on the default `/boot/grub/grub.cfg` location to configure grub. Instead the standalone executable reads the `grub.cfg` in the same directory it is in.

It is then up to the user to either:
- configure `sys-kernel/installkernel` to put the `grub.cfg` in a different location via `GRUB_CFG=`, or
- add a little `grub.cfg` that chainloads the real `grub.cfg`.

To make this even easier we could write some wrapper around grub-install which would optionally install the prebuilt standalone EFI executable plus an appropriate little `grub.cfg` to chainload the usual `grub.cfg`. But lets leave that for later.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
