### PR TITLE
app-misc/screen: remove nethack USE flag

### DIFF
--- a/app-misc/screen/files/screenrc
+++ b/app-misc/screen/files/screenrc
@@ -51,9 +51,6 @@
 # Don't display the copyright page
   startup_message off			# default: on
 
-# Uses nethack-style messages
-# nethack on				# default: off
-
 # Affects the copying of text regions
   crlf off				# default: off
 

--- a/app-misc/screen/metadata.xml
+++ b/app-misc/screen/metadata.xml
@@ -28,7 +28,6 @@
   </longdescription>
   <use>
     <flag name="multiuser">Enable multiuser support (by setting correct permissions)</flag>
-    <flag name="nethack">Express error messages in nethack style</flag>
   </use>
   <upstream>
     <remote-id type="cpe">cpe:/a:gnu:screen</remote-id>

--- a/app-misc/screen/screen-4.9.0-r3.ebuild
+++ b/app-misc/screen/screen-4.9.0-r3.ebuild
@@ -20,7 +20,7 @@ fi
 
 LICENSE="GPL-3+"
 SLOT="0"
-IUSE="debug nethack pam selinux multiuser"
+IUSE="debug pam selinux multiuser"
 
 DEPEND=">=sys-libs/ncurses-5.2:=
 	virtual/libcrypt:=
@@ -75,7 +75,6 @@ src_configure() {
 		append-cppflags -D_XOPEN_SOURCE=600
 	fi
 
-	use nethack || append-cppflags "-DNONETHACK"
 	use debug && append-cppflags "-DDEBUG"
 
 	local myeconfargs=(

--- a/app-misc/screen/screen-4.9.1-r1.ebuild
+++ b/app-misc/screen/screen-4.9.1-r1.ebuild
@@ -20,7 +20,7 @@ fi
 
 LICENSE="GPL-3+"
 SLOT="0"
-IUSE="debug nethack pam selinux multiuser"
+IUSE="debug pam selinux multiuser"
 
 DEPEND=">=sys-libs/ncurses-5.2:=
 	virtual/libcrypt:=
@@ -73,7 +73,6 @@ src_configure() {
 		append-cppflags -D_XOPEN_SOURCE=600
 	fi
 
-	use nethack || append-cppflags "-DNONETHACK"
 	use debug && append-cppflags "-DDEBUG"
 
 	local myeconfargs=(

--- a/app-misc/screen/screen-4.9.1.ebuild
+++ b/app-misc/screen/screen-4.9.1.ebuild
@@ -20,7 +20,7 @@ fi
 
 LICENSE="GPL-3+"
 SLOT="0"
-IUSE="debug nethack pam selinux multiuser"
+IUSE="debug pam selinux multiuser"
 
 DEPEND=">=sys-libs/ncurses-5.2:=
 	virtual/libcrypt:=
@@ -72,7 +72,6 @@ src_configure() {
 		append-cppflags -D_XOPEN_SOURCE=600
 	fi
 
-	use nethack || append-cppflags "-DNONETHACK"
 	use debug && append-cppflags "-DDEBUG"
 
 	local myeconfargs=(

--- a/app-misc/screen/screen-9999.ebuild
+++ b/app-misc/screen/screen-9999.ebuild
@@ -20,7 +20,7 @@ fi
 
 LICENSE="GPL-3+"
 SLOT="0"
-IUSE="debug nethack pam selinux multiuser"
+IUSE="debug pam selinux multiuser"
 
 DEPEND=">=sys-libs/ncurses-5.2:=
 	virtual/libcrypt:=
@@ -74,7 +74,6 @@ src_configure() {
 		append-cppflags -D_XOPEN_SOURCE=600
 	fi
 
-	use nethack || append-cppflags "-DNONETHACK"
 	use debug && append-cppflags "-DDEBUG"
 
 	local myeconfargs=(


### PR DESCRIPTION
Despite still being in the man pages, the nethack mode of screen was removed in 2015: https://github.com/jfjhh/screen/commit/9109409b2e0dbe15df2ffa76557f7d938d37fb08

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
