### PR TITLE
net-p2p/bitcoin-core: patch for GCC 15 compatibility

### DIFF
--- a/net-p2p/bitcoin-core/bitcoin-core-25.1-r2.ebuild
+++ b/net-p2p/bitcoin-core/bitcoin-core-25.1-r2.ebuild
@@ -95,6 +95,7 @@ DOCS=(
 
 PATCHES=(
 	"${DISTDIR}/${PN}-miniupnpc-2.2.8-compat.patch"
+	"${FILESDIR}/25.0-gcc15.patch"
 	"${FILESDIR}/25.0-syslibs.patch"
 	"${FILESDIR}/init.patch"
 )

--- a/net-p2p/bitcoin-core/bitcoin-core-25.2.ebuild
+++ b/net-p2p/bitcoin-core/bitcoin-core-25.2.ebuild
@@ -96,6 +96,7 @@ DOCS=(
 
 PATCHES=(
 	"${DISTDIR}/${PN}-miniupnpc-2.2.8-compat.patch"
+	"${FILESDIR}/25.0-gcc15.patch"
 	"${FILESDIR}/25.0-syslibs.patch"
 	"${FILESDIR}/init.patch"
 )

--- a/net-p2p/bitcoin-core/bitcoin-core-26.0-r1.ebuild
+++ b/net-p2p/bitcoin-core/bitcoin-core-26.0-r1.ebuild
@@ -95,6 +95,7 @@ DOCS=(
 
 PATCHES=(
 	"${DISTDIR}/${PN}-miniupnpc-2.2.8-compat.patch"
+	"${FILESDIR}/25.0-gcc15.patch"
 	"${FILESDIR}/26.0-syslibs.patch"
 	"${FILESDIR}/26.0-init.patch"
 )

--- a/net-p2p/bitcoin-core/bitcoin-core-26.1.ebuild
+++ b/net-p2p/bitcoin-core/bitcoin-core-26.1.ebuild
@@ -96,6 +96,7 @@ DOCS=(
 
 PATCHES=(
 	"${DISTDIR}/${PN}-miniupnpc-2.2.8-compat.patch"
+	"${FILESDIR}/25.0-gcc15.patch"
 	"${FILESDIR}/26.0-syslibs.patch"
 	"${FILESDIR}/26.0-init.patch"
 )

--- a/net-p2p/bitcoin-core/bitcoin-core-26.2.ebuild
+++ b/net-p2p/bitcoin-core/bitcoin-core-26.2.ebuild
@@ -94,6 +94,7 @@ DOCS=(
 )
 
 PATCHES=(
+	"${FILESDIR}/25.0-gcc15.patch"
 	"${FILESDIR}/26.0-syslibs.patch"
 	"${FILESDIR}/26.0-init.patch"
 )

--- a/net-p2p/bitcoin-core/bitcoin-core-27.0.ebuild
+++ b/net-p2p/bitcoin-core/bitcoin-core-27.0.ebuild
@@ -96,6 +96,8 @@ DOCS=(
 
 PATCHES=(
 	"${DISTDIR}/${PN}-miniupnpc-2.2.8-compat.patch"
+	"${FILESDIR}/25.0-gcc15.patch"
+	"${FILESDIR}/27.0-gcc15.patch"
 	"${FILESDIR}/27.0-syslibs.patch"
 	"${FILESDIR}/26.0-init.patch"
 )

--- a/net-p2p/bitcoin-core/bitcoin-core-27.1.ebuild
+++ b/net-p2p/bitcoin-core/bitcoin-core-27.1.ebuild
@@ -96,6 +96,8 @@ DOCS=(
 
 PATCHES=(
 	"${DISTDIR}/${PN}-miniupnpc-2.2.8-compat.patch"
+	"${FILESDIR}/25.0-gcc15.patch"
+	"${FILESDIR}/27.0-gcc15.patch"
 	"${FILESDIR}/27.0-syslibs.patch"
 	"${FILESDIR}/26.0-init.patch"
 )

--- a/net-p2p/bitcoin-core/files/25.0-gcc15.patch
+++ b/net-p2p/bitcoin-core/files/25.0-gcc15.patch
@@ -1,0 +1,37 @@
+From 74eebed6491d38d9c076bebc99d073cdd129003a Mon Sep 17 00:00:00 2001
+From: Matt Whitlock <bitcoin@mattwhitlock.name>
+Date: Wed, 7 Aug 2024 22:04:40 -0400
+Subject: [PATCH] add missing #include <cstdint> for GCC 15
+
+---
+ src/chainparamsbase.h   | 1 +
+ src/node/interface_ui.h | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/src/chainparamsbase.h b/src/chainparamsbase.h
+index d593cff722..09751b12b9 100644
+--- a/src/chainparamsbase.h
++++ b/src/chainparamsbase.h
+@@ -5,6 +5,7 @@
+ #ifndef BITCOIN_CHAINPARAMSBASE_H
+ #define BITCOIN_CHAINPARAMSBASE_H
+ 
++#include <cstdint>
+ #include <memory>
+ #include <string>
+ 
+diff --git a/src/node/interface_ui.h b/src/node/interface_ui.h
+index 22c241cb78..f0c804b7cf 100644
+--- a/src/node/interface_ui.h
++++ b/src/node/interface_ui.h
+@@ -6,6 +6,7 @@
+ #ifndef BITCOIN_NODE_INTERFACE_UI_H
+ #define BITCOIN_NODE_INTERFACE_UI_H
+ 
++#include <cstdint>
+ #include <functional>
+ #include <memory>
+ #include <string>
+-- 
+2.45.2
+

--- a/net-p2p/bitcoin-core/files/27.0-gcc15.patch
+++ b/net-p2p/bitcoin-core/files/27.0-gcc15.patch
@@ -1,0 +1,61 @@
+From e866aecd9b5697aee1291bc4daf48d09824804d4 Mon Sep 17 00:00:00 2001
+From: Matt Whitlock <bitcoin@mattwhitlock.name>
+Date: Wed, 7 Aug 2024 21:14:28 -0400
+Subject: [PATCH] policy/feerate.h: avoid constraint self-dependency
+
+In file included from /usr/lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/format:48,
+                 from /usr/lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/chrono_io.h:39,
+                 from /usr/lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/chrono:3362,
+                 from ./util/time.h:9,
+                 from ./primitives/block.h:12,
+                 from ./blockencodings.h:8,
+                 from blockencodings.cpp:5:
+/usr/lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/type_traits: In substitution of 'template<class _Up>  requires !(is_same_v<std::optional<_Tp>, typename std::remove_cvref<_It2>::type>) && (is_constructible_v<_Tp, const _Up&>) && (__construct_from_contained_value<_Up, typename std::remove_cv< <template-parameter-1-1> >::type>) constexpr std::optional<CFeeRate>::optional(const std::optional<_Tp>&) [with _Up = CFeeRate]':
+/usr/lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/type_traits:1140:25:   required by substitution of 'template<class _Tp, class ... _Args> using std::__is_constructible_impl = std::__bool_constant<__is_constructible(_Tp, _Args ...)> [with _Tp = CFeeRate; _Args = {std::optional<CFeeRate>&}]'
+ 1140 |       = __bool_constant<__is_constructible(_Tp, _Args...)>;
+      |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/usr/lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/type_traits:1145:12:   required from 'struct std::is_constructible<CFeeRate, std::optional<CFeeRate>&>'
+ 1145 |     struct is_constructible
+      |            ^~~~~~~~~~~~~~~~
+/usr/lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/type_traits:178:35:   required by substitution of 'template<class ... _Bn> std::__detail::__first_t<std::integral_constant<bool, false>, typename std::enable_if<(!(bool)(_Bn::value)), void>::type ...> std::__detail::__or_fn(int) [with _Bn = {std::is_constructible<CFeeRate, std::optional<CFeeRate>&>, std::is_convertible<std::optional<CFeeRate>&, CFeeRate>, std::is_constructible<CFeeRate, std::optional<CFeeRate> >, std::is_convertible<std::optional<CFeeRate>, CFeeRate>, std::is_constructible<CFeeRate, const std::optional<CFeeRate>&>, std::is_convertible<const std::optional<CFeeRate>&, CFeeRate>, std::is_constructible<CFeeRate, const std::optional<CFeeRate> >, std::is_convertible<const std::optional<CFeeRate>, CFeeRate>}]'
+  178 |                                      __enable_if_t<!bool(_Bn::value)>...>;
+      |                                                               ^~~~~
+/usr/lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/type_traits:196:41:   required from 'struct std::__or_<std::is_constructible<CFeeRate, std::optional<CFeeRate>&>, std::is_convertible<std::optional<CFeeRate>&, CFeeRate>, std::is_constructible<CFeeRate, std::optional<CFeeRate> >, std::is_convertible<std::optional<CFeeRate>, CFeeRate>, std::is_constructible<CFeeRate, const std::optional<CFeeRate>&>, std::is_convertible<const std::optional<CFeeRate>&, CFeeRate>, std::is_constructible<CFeeRate, const std::optional<CFeeRate> >, std::is_convertible<const std::optional<CFeeRate>, CFeeRate> >'
+  196 |     : decltype(__detail::__or_fn<_Bn...>(0))
+      |                ~~~~~~~~~~~~~~~~~~~~~~~~~^~~
+/usr/lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/optional:824:45:   required from 'constexpr const bool std::optional<CFeeRate>::__construct_from_contained_value<CFeeRate, CFeeRate>'
+  824 |           = !__converts_from_optional<_Tp, _From>::value;
+      |                                                    ^~~~~
+/usr/lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/optional:884:7:   required by substitution of 'template<class _Up>  requires !(is_same_v<std::optional<_Tp>, typename std::remove_cvref<_It2>::type>) && (is_constructible_v<_Tp, const _Up&>) && (__construct_from_contained_value<_Up, typename std::remove_cv< <template-parameter-1-1> >::type>) constexpr std::optional<CFeeRate>::optional(const std::optional<_Tp>&) [with _Up = CFeeRate]'
+  884 |           && __construct_from_contained_value<_Up>
+      |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+./validation.h:164:41:   required from here
+  164 |         return MempoolAcceptResult(state);
+      |                                         ^
+/usr/lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/optional:886:2:   required by the constraints of 'template<class _Tp> template<class _Up>  requires !(is_same_v<std::optional<_Tp>, typename std::remove_cvref<_It2>::type>) && (is_constructible_v<_Tp, const _Up&>) && (__construct_from_contained_value<_Up, typename std::remove_cv< <template-parameter-1-1> >::type>) constexpr std::optional<_Tp>::optional(const std::optional<_From>&)'
+/usr/lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/optional:884:14: error: satisfaction of atomic constraint '__construct_from_contained_value<_Up, typename std::remove_cv< <template-parameter-1-1> >::type> [with _Tp = _Tp; _Up = _Up]' depends on itself
+  884 |           && __construct_from_contained_value<_Up>
+      |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+---
+ src/policy/feerate.h | 4 +---
+ 1 file changed, 1 insertion(+), 3 deletions(-)
+
+diff --git a/src/policy/feerate.h b/src/policy/feerate.h
+index 2e50172914..63ddf6827d 100644
+--- a/src/policy/feerate.h
++++ b/src/policy/feerate.h
+@@ -38,10 +38,8 @@ private:
+ public:
+     /** Fee rate of 0 satoshis per kvB */
+     CFeeRate() : nSatoshisPerK(0) { }
+-    template<typename I>
++    template<std::integral I>
+     explicit CFeeRate(const I _nSatoshisPerK): nSatoshisPerK(_nSatoshisPerK) {
+-        // We've previously had bugs creep in from silent double->int conversion...
+-        static_assert(std::is_integral<I>::value, "CFeeRate should be used without floats");
+     }
+ 
+     /**
+-- 
+2.45.2
+


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/937531

It might bear mentioning: I did not revbump any ebuilds since the added patches do not alter the final build products and only have the effect of allowing previously failing build configurations to succeed.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] `pkgcheck scan --commits --net` is still broken (`KeyError: 'autotools'`).

Please note that all boxes must be checked for the pull request to be merged.
