### PR TITLE
(dist-)kernel-{install,utils}.eclass: fix finding config during cleanup

### DIFF
--- a/eclass/dist-kernel-utils.eclass
+++ b/eclass/dist-kernel-utils.eclass
@@ -160,7 +160,7 @@ dist-kernel_PV_to_KV() {
 }
 
 # @FUNCTION: dist-kernel_get_module_suffix
-# @USAGE: <kernel_dir>
+# @USAGE: <kernel_config>
 # @DESCRIPTION:
 # Returns the suffix for kernel modules based on the CONFIG_MODULES_COMPESS_*
 # setting in the kernel config and USE=modules-compress.
@@ -169,7 +169,7 @@ dist-kernel_get_module_suffix() {
 
 	[[ ${#} -eq 1 ]] || die "${FUNCNAME}: invalid arguments"
 
-	local config=${1}/.config
+	local config=${1}
 
 	if ! in_iuse modules-compress || ! use modules-compress; then
 		echo .ko
@@ -198,7 +198,19 @@ dist-kernel_compressed_module_cleanup() {
 
 	[[ ${#} -ne 1 ]] && die "${FUNCNAME}: invalid arguments"
 	local path=${1}
-	local preferred=$(dist-kernel_get_module_suffix "${path}/source")
+	local config_path=/usr/src/linux-${KV_FULL}/.config
+
+	local option
+	for option in config source/.config build/.config; do
+		if [[ -f ${path}/${option} ]]; then
+			config_path=${path}/${option}
+			break
+		fi
+	done
+
+	local preferred=
+	[[ -f ${config_path} ]] && preferred=$(dist-kernel_get_module_suffix "${config_path}")
+
 	local basename suffix
 
 	while read -r basename; do

--- a/eclass/kernel-install.eclass
+++ b/eclass/kernel-install.eclass
@@ -769,7 +769,7 @@ kernel-install_compress_modules() {
 		if [[ -z ${KV_FULL} ]]; then
 			KV_FULL=${PV}${KV_LOCALVERSION}
 		fi
-		local suffix=$(dist-kernel_get_module_suffix "${ED}/usr/src/linux-${KV_FULL}")
+		local suffix=$(dist-kernel_get_module_suffix "${ED}/usr/src/linux-${KV_FULL}/.config")
 		local compress=()
 		# Options taken from linux-mod-r1.eclass.
 		# We don't instruct the compressor to parallelize because it applies


### PR DESCRIPTION
The source symlink does not exist on all systems

Closes: https://bugs.gentoo.org/937569

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
