### PR TITLE
app-text/qpdf: Fix compilation on GCC 15

### DIFF
--- a/app-text/qpdf/files/qpdf-11.9.1-include-cstdint.patch
+++ b/app-text/qpdf/files/qpdf-11.9.1-include-cstdint.patch
@@ -1,0 +1,37 @@
+https://github.com/qpdf/qpdf/commit/6918f0b7eb0160059d712ee19ba0ce2d65b9f89c
+
+From: Christopher Fore <csfore@posteo.net>
+Date: Mon, 5 Aug 2024 09:41:50 -0400
+Subject: [PATCH] libtests: include cstdint for GCC 15
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+GCC 15 starts to no longer include this by default, requiring it to be
+explicitly included.
+
+Error message:
+libtests/cxx11.cc:75:16: error: ‘uint8_t’ was not declared in this scope
+   75 |     check_size<uint8_t>(1, false);
+      |                ^~~~~~~
+libtests/cxx11.cc:10:1: note: ‘uint8_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
+    9 | #include <regex>
+  +++ |+#include <cstdint>
+   10 | #include <type_traits>
+
+Signed-off-by: Christopher Fore <csfore@posteo.net>
+---
+ libtests/cxx11.cc | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/libtests/cxx11.cc b/libtests/cxx11.cc
+index 59c74fa86..953ad00f9 100644
+--- a/libtests/cxx11.cc
++++ b/libtests/cxx11.cc
+@@ -1,5 +1,6 @@
+ #include <qpdf/assert_test.h>
+ 
++#include <cstdint>
+ #include <cstdlib>
+ #include <cstring>
+ #include <functional>

--- a/app-text/qpdf/qpdf-11.9.1.ebuild
+++ b/app-text/qpdf/qpdf-11.9.1.ebuild
@@ -54,6 +54,10 @@ QA_CONFIG_IMPL_DECL_SKIP=(
 
 VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/openpgp-keys/jberkenbilt.asc
 
+PATCHES=(
+	"${FILESDIR}/${PN}-11.9.1-include-cstdint.patch" #937571
+)
+
 src_unpack() {
 	if use verify-sig ; then
 		verify-sig_verify_detached "${DISTDIR}"/${P}.tar.gz{,.asc}


### PR DESCRIPTION
- Patch is from upstream
- Tests pass

Error:
```
/var/tmp/portage/app-text/qpdf-11.9.1/work/qpdf-11.9.1/libtests/cxx11.cc:75:16: error: `uint8_t' was not declared in this scope
   75 |     check_size<uint8_t>(1, false);
      |                ^~~~~~~

/var/tmp/portage/app-text/qpdf-11.9.1/work/qpdf-11.9.1/libtests/cxx11.cc:10:1: note: `uint8_t' is defined in header `<cstdint>';
this is probably fixable by adding `#include <cstdint>'
    9 | #include <regex>
  +++ |+#include <cstdint>
   10 | #include <type_traits>
```

Closes: https://bugs.gentoo.org/937571

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
