### PR TITLE
www-client/firefox: add support for ppc64le on musl

### DIFF
--- a/www-client/firefox/firefox-128.1.0.ebuild
+++ b/www-client/firefox/firefox-128.1.0.ebuild
@@ -637,6 +637,8 @@ src_prepare() {
 			export RUST_TARGET="i686-unknown-linux-musl"
 		elif use arm64 ; then
 			export RUST_TARGET="aarch64-unknown-linux-musl"
+		elif use ppc64 ; then
+			export RUST_TARGET="powerpc64le-unknown-linux-musl"
 		else
 			die "Unknown musl chost, please post your rustc -vV along with emerge --info on Gentoo's bug #915651"
 		fi

--- a/www-client/firefox/firefox-129.0.ebuild
+++ b/www-client/firefox/firefox-129.0.ebuild
@@ -630,6 +630,8 @@ src_prepare() {
 			export RUST_TARGET="i686-unknown-linux-musl"
 		elif use arm64 ; then
 			export RUST_TARGET="aarch64-unknown-linux-musl"
+		elif use ppc64 ; then
+			export RUST_TARGET="powerpc64le-unknown-linux-musl"
 		else
 			die "Unknown musl chost, please post your rustc -vV along with emerge --info on Gentoo's bug #915651"
 		fi


### PR DESCRIPTION
It still does not add support for ppc64 (big-endian) because the USE flag "ppc64" is shared between ppc64 and ppc64le.

Fixing it on ppc64 would probably require adding a big-endian USE and there are some big-endian specific patches necessary. Since I don't have yet a big-endian Gentoo, this patch does not fix ppc64 on musl, but it currently does not work anyway.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
