### PR TITLE
x11-libs/gtksourceview: fix compilation of 3.24.11 with gcc-14

### DIFF
--- a/x11-libs/gtksourceview/files/3.24.11-gcc14.patch
+++ b/x11-libs/gtksourceview/files/3.24.11-gcc14.patch
@@ -1,0 +1,62 @@
+
+Patch from:
+https://gitlab.gnome.org/GNOME/gtksourceview/-/commit/16db686c0b3170d9ec4d7c7eda4a8e9c0fb1c544
+
+From 16db686c0b3170d9ec4d7c7eda4a8e9c0fb1c544 Mon Sep 17 00:00:00 2001
+From: Martin Blanchard <martin.blanchard@codethink.co.uk>
+Date: Mon, 26 Feb 2018 14:26:59 +0000
+Subject: [PATCH] View: fix includes (implicit declarations)
+
+https://bugzilla.gnome.org/show_bug.cgi?id=793842
+---
+ gtksourceview/gtksourceview.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/gtksourceview/gtksourceview.c b/gtksourceview/gtksourceview.c
+index 7d567157c..4e086464f 100644
+--- a/gtksourceview/gtksourceview.c
++++ b/gtksourceview/gtksourceview.c
+@@ -40,8 +40,9 @@
+ #include "gtksourcemark.h"
+ #include "gtksourcemarkattributes.h"
+ #include "gtksourcestylescheme.h"
+-#include "gtksourcecompletionprovider.h"
++#include "gtksourcecompletion.h"
+ #include "gtksourcecompletion-private.h"
++#include "gtksourcecompletionprovider.h"
+ #include "gtksourcegutter.h"
+ #include "gtksourcegutter-private.h"
+ #include "gtksourcegutterrendererlines.h"
+
+Patch from:
+https://gitlab.gnome.org/GNOME/gtksourceview/-/commit/b25e71c57fc934a7ce36e51826af9fa7c2cf9a80
+
+From b25e71c57fc934a7ce36e51826af9fa7c2cf9a80 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?S=C3=A9bastien=20Wilmet?= <swilmet@gnome.org>
+Date: Thu, 14 Dec 2017 13:03:15 +0100
+Subject: [PATCH] View: fix assignment from incompatible pointer type
+
+GLib now propagates types with g_object_ref().
+
+At that code path we are sure that buffer is a GtkSourceBuffer since
+there is a condition if (GTK_SOURCE_IS_BUFFER (buffer)).
+---
+ gtksourceview/gtksourceview.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/gtksourceview/gtksourceview.c b/gtksourceview/gtksourceview.c
+index 21424be97..e642ce360 100644
+--- a/gtksourceview/gtksourceview.c
++++ b/gtksourceview/gtksourceview.c
+@@ -1531,7 +1531,7 @@ set_source_buffer (GtkSourceView *view,
+ 	{
+ 		GtkSourceBufferInternal *buffer_internal;
+ 
+-		view->priv->source_buffer = g_object_ref (buffer);
++		view->priv->source_buffer = g_object_ref (GTK_SOURCE_BUFFER (buffer));
+ 
+ 		g_signal_connect (buffer,
+ 				  "highlight-updated",
+-- 
+GitLab
+

--- a/x11-libs/gtksourceview/gtksourceview-3.24.11-r2.ebuild
+++ b/x11-libs/gtksourceview/gtksourceview-3.24.11-r2.ebuild
@@ -1,0 +1,54 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+VALA_USE_DEPEND="vapigen"
+inherit gnome2 vala virtualx
+
+DESCRIPTION="A text widget implementing syntax highlighting and other features"
+HOMEPAGE="https://wiki.gnome.org/Projects/GtkSourceView"
+
+LICENSE="GPL-2+ LGPL-2.1+"
+SLOT="3.0/3"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~ia64 ~loong ~mips ~ppc ~ppc64 ~riscv ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
+IUSE="glade +introspection +vala"
+REQUIRED_USE="vala? ( introspection )"
+
+RDEPEND="
+	>=dev-libs/glib-2.48:2
+	>=dev-libs/libxml2-2.6:2
+	>=x11-libs/gtk+-3.20:3[introspection?]
+	glade? ( >=dev-util/glade-3.9:3.10 )
+	introspection? ( >=dev-libs/gobject-introspection-1.42:= )
+"
+DEPEND="${RDEPEND}"
+BDEPEND="
+	dev-util/glib-utils
+	>=dev-build/gtk-doc-am-1.25
+	>=sys-devel/gettext-0.19.4
+	virtual/pkgconfig
+	vala? ( $(vala_depend) )
+"
+
+PATCHES=( "${FILESDIR}/3.24.11-gcc14.patch" )
+
+src_configure() {
+	use vala && vala_setup
+
+	gnome2_src_configure \
+		$(use_enable glade glade-catalog) \
+		$(use_enable introspection) \
+		$(use_enable vala)
+}
+
+src_test() {
+	virtx emake check
+}
+
+src_install() {
+	gnome2_src_install
+
+	insinto /usr/share/${PN}-3.0/language-specs
+	doins "${FILESDIR}"/2.0/gentoo.lang
+}


### PR DESCRIPTION
I excavated some patches to make gtksourceview-3.24.11 build with gcc-14.

Closes: https://bugs.gentoo.org/919080

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
