### PR TITLE
x11-libs/vte: fix build of 0.76.3 with gcc-14

### DIFF
--- a/x11-libs/vte/files/vte-0.76.3-stdint.patch
+++ b/x11-libs/vte/files/vte-0.76.3-stdint.patch
@@ -1,0 +1,34 @@
+
+Fix compilation with gcc-14.
+
+Bug: https://bugs.gentoo.org/937617
+Bug: https://gitlab.gnome.org/GNOME/vte/-/issues/2807
+
+Patch from:
+https://gitlab.gnome.org/GNOME/vte/-/commit/0d393b6cd6a24f53eaefa16764b9453a1483acf5
+
+From 0d393b6cd6a24f53eaefa16764b9453a1483acf5 Mon Sep 17 00:00:00 2001
+From: Christian Persch <chpe@src.gnome.org>
+Date: Mon, 12 Aug 2024 18:42:37 +0200
+Subject: [PATCH] lib: Include stdint.h where needed
+
+Fixes: https://gitlab.gnome.org/GNOME/vte/-/issues/2807
+---
+ src/vte/vteregex.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/vte/vteregex.h b/src/vte/vteregex.h
+index 10c5088b8..c9e4f75db 100644
+--- a/src/vte/vteregex.h
++++ b/src/vte/vteregex.h
+@@ -23,6 +23,7 @@
+ 
+ #include <glib.h>
+ #include <glib-object.h>
++#include <stdint.h>
+ 
+ #include "vtemacros.h"
+ 
+-- 
+GitLab
+

--- a/x11-libs/vte/vte-0.76.3.ebuild
+++ b/x11-libs/vte/vte-0.76.3.ebuild
@@ -54,6 +54,8 @@ BDEPEND="
 	vala? ( $(vala_depend) )
 "
 
+PATCHES=( "${FILESDIR}/${PN}-0.76.3-stdint.patch" )
+
 src_prepare() {
 	default
 	use vala && vala_setup


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/937617

Note that this is for 0.76.3 only, ~I don't know if older releases are affected~ older releases are fine.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
