### PR TITLE
dev-cpp/json11: Fix compilation on GCC 15

### DIFF
--- a/dev-cpp/json11/files/json11-1.0.0-include-cstdint.patch
+++ b/dev-cpp/json11/files/json11-1.0.0-include-cstdint.patch
@@ -1,0 +1,12 @@
+diff --git a/json11.cpp b/json11.cpp
+index 9647846..8266a14 100644
+--- a/json11.cpp
++++ b/json11.cpp
+@@ -22,6 +22,7 @@
+ #include "json11.hpp"
+ #include <cassert>
+ #include <cmath>
++#include <cstdint>
+ #include <cstdlib>
+ #include <cstdio>
+ #include <limits>

--- a/dev-cpp/json11/json11-1.0.0-r1.ebuild
+++ b/dev-cpp/json11/json11-1.0.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2022-2023 Gentoo Authors
+# Copyright 2022-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -16,4 +16,5 @@ KEYWORDS="amd64 x86"
 PATCHES=(
 	"${FILESDIR}"/${P}-fix-multiarch-install.patch
 	"${FILESDIR}"/${PN}-1.0.0-json11.pc-do-not-state-the-defaults.patch
+	"${FILESDIR}"/${PN}-1.0.0-include-cstdint.patch
 )


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/937530

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
