### PR TITLE
media-libs/lib3mf: Fix compilation on GCC 15

### DIFF
--- a/media-libs/lib3mf/files/lib3mf-2.2.0-include-cstdint.patch
+++ b/media-libs/lib3mf/files/lib3mf-2.2.0-include-cstdint.patch
@@ -1,0 +1,13 @@
+diff --git a/Source/Common/Platform/NMR_ImportStream_Unique_Memory.cpp b/Source/Common/Platform/NMR_ImportStream_Unique_Memory.cpp
+index 43fd428..e966aa0 100644
+--- a/Source/Common/Platform/NMR_ImportStream_Unique_Memory.cpp
++++ b/Source/Common/Platform/NMR_ImportStream_Unique_Memory.cpp
+@@ -35,6 +35,8 @@ This is a platform independent class for keeping data in a memory stream that ow
+ #include "Common/NMR_Exception.h"
+ #include "Common/NMR_Exception_Windows.h"
+ 
++#include <cstdint>
++
+ namespace NMR {
+ 
+ 	CImportStream_Unique_Memory::CImportStream_Unique_Memory()

--- a/media-libs/lib3mf/lib3mf-2.2.0.ebuild
+++ b/media-libs/lib3mf/lib3mf-2.2.0.ebuild
@@ -36,6 +36,7 @@ PATCHES=(
 	"${FILESDIR}"/${P}-0001-use-system-provided-act-binary.patch
 	"${FILESDIR}"/${P}-0002-Gentoo-specific-remove-add_dependencies.patch
 	"${FILESDIR}"/${P}-0001-remove-std-and-opt-flags.patch
+	"${FILESDIR}"/${P}-include-cstdint.patch
 )
 
 src_configure() {


### PR DESCRIPTION
- Tests pass
- Patched file is not an installed header

Note: Upstream PR fixes an additional file that does not error on 2.2.0
Upstream: https://github.com/3MFConsortium/lib3mf/pull/387
Closes: https://bugs.gentoo.org/937423

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
