### PR TITLE
x11-misc/clipmenu: minor fixes

### DIFF
--- a/x11-misc/clipmenu/clipmenu-6.2.0-r1.ebuild
+++ b/x11-misc/clipmenu/clipmenu-6.2.0-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit systemd
+inherit optfeature systemd
 
 DESCRIPTION="Clipboard management"
 HOMEPAGE="https://github.com/cdown/clipmenu"
@@ -49,6 +49,8 @@ src_install() {
 }
 
 pkg_postinst() {
+	optfeature "ignoring specific windows via CM_IGNORE_WINDOW" x11-misc/xdotool
+
 	if systemd_is_booted || has_version sys-apps/systemd; then
 		einfo ""
 		einfo "Make sure to import \$DISPLAY when using the systemd unit for clipmenud"

--- a/x11-misc/clipmenu/clipmenu-6.2.0-r1.ebuild
+++ b/x11-misc/clipmenu/clipmenu-6.2.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 Gentoo Authors
+# Copyright 2020-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -49,7 +49,18 @@ src_install() {
 }
 
 pkg_postinst() {
+	if systemd_is_booted || has_version sys-apps/systemd; then
+		einfo ""
+		einfo "Make sure to import \$DISPLAY when using the systemd unit for clipmenud"
+		einfo "without a desktop environment. Preferably check /etc/X11/xinit/xinitrc{,.d}"
+		einfo "for relevant examples, or at least include the following in your ~/.xinitrc"
+		einfo "before clipmenud:"
+		einfo ""
+		einfo "systemctl --user import-environment DISPLAY"
+	fi
+
 	if ! use dmenu && ! use fzf && ! use rofi ; then
+		ewarn ""
 		ewarn "Clipmenu has been installed without a launcher."
 		ewarn "You will need to set \$CM_LAUNCHER to a dmenu-compatible app for clipmenu to work."
 		ewarn "Please refer to the documents for more info."

--- a/x11-misc/clipmenu/clipmenu-6.2.0-r1.ebuild
+++ b/x11-misc/clipmenu/clipmenu-6.2.0-r1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 2020-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 inherit optfeature systemd
 

--- a/x11-misc/clipmenu/metadata.xml
+++ b/x11-misc/clipmenu/metadata.xml
@@ -9,6 +9,9 @@
 		<email>proxy-maint@gentoo.org</email>
 		<name>Proxy Maintainers</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">cdown/clipmenu</remote-id>
+	</upstream>
 	<use>
 		<flag name="dmenu">Use dmenu as default launcher</flag>
 		<flag name="rofi">Use rofi as default launcher</flag>


### PR DESCRIPTION
This PR is a proposal to apply a few accumulated minor fixes to x11-misc/clipmenu.

I believe the following is safe to do in-place since it doesn't change any pre-existing installations:

- add github upstream metadata
- notify systemd users about expected environment ([bug 844118](https://bugs.gentoo.org/844118))
- mention xdotool as an optional dependency ([bug 936496](https://bugs.gentoo.org/936496))

Given the ebuild does not compile anything, only installs scripts, I believe the following is also safe to do without bumping the revision:

- update EAPI 7 -> 8

I don't feel it's warranted to bump the revision, and start a new stabilization cycle solely for this, though I can certainly update the PR to include a revbump on one of those commits.

If necessary, I'm OK if we leave the EAPI bump out this time. I can do it with a followup snapshot ebuild I plan to propose later.

I'm also happy to squash/rearrange commits if deemed necessary, though I kept them separate on purpose for readability.

Please review, then either merge, or let me know how to further improve it.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.