### PR TITLE
sys-apps/gentoo-systemd-integration: bump EAPI, unify builds

### DIFF
--- a/sys-apps/gentoo-systemd-integration/gentoo-systemd-integration-9-r1.ebuild
+++ b/sys-apps/gentoo-systemd-integration/gentoo-systemd-integration-9-r1.ebuild
@@ -22,8 +22,7 @@ SLOT="0"
 RDEPEND="acct-group/floppy
 	acct-group/usb
 	>=sys-apps/systemd-207
-	!sys-fs/eudev
-	!sys-fs/udev"
+"
 DEPEND=">=sys-apps/systemd-207"
 BDEPEND="virtual/pkgconfig"
 

--- a/sys-apps/gentoo-systemd-integration/gentoo-systemd-integration-9-r1.ebuild
+++ b/sys-apps/gentoo-systemd-integration/gentoo-systemd-integration-9-r1.ebuild
@@ -13,7 +13,7 @@ if [[ ${PV} == 9999 ]]; then
 	inherit autotools git-r3
 else
 	SRC_URI="https://dev.gentoo.org/~floppym/dist/${P}.tar.gz"
-	KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
 fi
 
 LICENSE="BSD"

--- a/sys-apps/gentoo-systemd-integration/gentoo-systemd-integration-9999.ebuild
+++ b/sys-apps/gentoo-systemd-integration/gentoo-systemd-integration-9999.ebuild
@@ -10,7 +10,7 @@ if [[ ${PV} == 9999 ]]; then
 	inherit autotools git-r3
 else
 	SRC_URI="https://dev.gentoo.org/~floppym/dist/${P}.tar.gz"
-	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+	KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86"
 fi
 
 DESCRIPTION="systemd integration files for Gentoo"

--- a/sys-apps/gentoo-systemd-integration/gentoo-systemd-integration-9999.ebuild
+++ b/sys-apps/gentoo-systemd-integration/gentoo-systemd-integration-9999.ebuild
@@ -22,8 +22,7 @@ SLOT="0"
 RDEPEND="acct-group/floppy
 	acct-group/usb
 	>=sys-apps/systemd-207
-	!sys-fs/eudev
-	!sys-fs/udev"
+"
 DEPEND=">=sys-apps/systemd-207"
 BDEPEND="virtual/pkgconfig"
 


### PR DESCRIPTION
Please pay attention to the last commit, which deletes nonexistent blockers.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
