### PR TITLE
xfce-extra/xfce4-smartbookmark-plugin: bump EAPI, remove empty IUSE

### DIFF
--- a/xfce-extra/xfce4-smartbookmark-plugin/xfce4-smartbookmark-plugin-0.5.2-r1.ebuild
+++ b/xfce-extra/xfce4-smartbookmark-plugin/xfce4-smartbookmark-plugin-0.5.2-r1.ebuild
@@ -1,0 +1,37 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DESCRIPTION="Smart bookmark plug-in for the Xfce desktop environment"
+HOMEPAGE="
+	https://goodies.xfce.org/projects/panel-plugins/xfce4-smartbookmark-plugin
+	https://gitlab.xfce.org/panel-plugins/xfce4-smartbookmark-plugin
+"
+SRC_URI="https://archive.xfce.org/src/panel-plugins/${PN}/${PV%.*}/${P}.tar.bz2"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~ppc ~ppc64 ~riscv ~sparc ~x86 ~amd64-linux ~x86-linux"
+
+DEPEND="
+	>=xfce-base/libxfce4ui-4.12:=[gtk3(+)]
+	>=xfce-base/xfce4-panel-4.12:=
+"
+RDEPEND="${DEPEND}"
+BDEPEND="
+	dev-util/intltool
+	sys-devel/gettext
+	virtual/pkgconfig
+"
+
+src_prepare() {
+	# substitute default bugtracker
+	sed -i -e '/bugs/s:bugs\.debian:bugs.gentoo:' src/smartbookmark.c || die
+	default
+}
+
+src_install() {
+	default
+	find "${D}" -name '*.la' -delete || die
+}


### PR DESCRIPTION
This is an upgraded part of https://github.com/gentoo/gentoo/pull/37793

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
