### PR TITLE
xfce-extra/xfce4-hdaps: bump EAPI, remove empty IUSE

### DIFF
--- a/xfce-extra/xfce4-hdaps/xfce4-hdaps-1.0.3-r1.ebuild
+++ b/xfce-extra/xfce4-hdaps/xfce4-hdaps-1.0.3-r1.ebuild
@@ -1,0 +1,45 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit xdg-utils
+
+DESCRIPTION="Show the status of the IBM Hard Drive Active Protection System"
+HOMEPAGE="https://michael.orlitzky.com/code/xfce4-hdaps.xhtml"
+SRC_URI="https://michael.orlitzky.com/code/releases/${P}.tar.xz"
+
+LICENSE="AGPL-3+"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+DEPEND="
+	>=x11-libs/gtk+-3.20:3
+	x11-libs/libX11
+	>=xfce-base/libxfce4ui-4.14
+	>=xfce-base/libxfce4util-4.14
+	>=xfce-base/xfce4-panel-4.14:=
+"
+RDEPEND="
+	${DEPEND}
+	app-laptop/hdapsd
+	app-laptop/tp_smapi
+"
+BDEPEND="
+	dev-util/intltool
+	sys-devel/gettext
+	virtual/pkgconfig
+"
+
+src_install() {
+	default
+	find "${D}" -name '*.la' -delete || die
+}
+
+pkg_postinst() {
+	xdg_icon_cache_update
+}
+
+pkg_postrm() {
+	xdg_icon_cache_update
+}


### PR DESCRIPTION
This is an upgraded part of https://github.com/gentoo/gentoo/pull/37793

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
