### PR TITLE
x11-libs/libclxclient: bump EAPI, fix pkgcheck issues

### DIFF
--- a/x11-libs/libclxclient/libclxclient-3.9.2-r1.ebuild
+++ b/x11-libs/libclxclient/libclxclient-3.9.2-r1.ebuild
@@ -1,0 +1,47 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs
+
+DESCRIPTION="C++ wrapper library around the X Window System API"
+HOMEPAGE="https://kokkinizita.linuxaudio.org/linuxaudio/index.html"
+SRC_URI="https://kokkinizita.linuxaudio.org/linuxaudio/downloads/clxclient-${PV}.tar.bz2"
+S="${WORKDIR}/clxclient-${PV}"
+
+LICENSE="LGPL-2.1"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~sparc ~x86"
+
+CDEPEND="
+	dev-libs/libclthreads
+	media-libs/freetype:2
+	x11-libs/libX11
+	x11-libs/libXft
+"
+RDEPEND="${CDEPEND}"
+DEPEND="${CDEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+DOCS=( AUTHORS )
+
+PATCHES=(
+	"${FILESDIR}/${P}-Makefile.patch"
+	"${FILESDIR}/${P}-enumip-include-fix.patch"
+)
+
+src_compile() {
+	tc-export CXX
+	local prefix="${EPREFIX}/usr"
+	cd "${S}/source"
+	emake INCDIR="${prefix}/include" LIBDIR="${prefix}/$(get_libdir)" PKGCONFIG="$(tc-getPKG_CONFIG)"
+}
+
+src_install() {
+	default
+
+	local prefix="${ED}/usr"
+	cd "${S}/source"
+	emake INCDIR="${prefix}/include" LIBDIR="${prefix}/$(get_libdir)" PKGCONFIG="$(tc-getPKG_CONFIG)" install
+}


### PR DESCRIPTION
I am splitting https://github.com/gentoo/gentoo/pull/37798 into separate commits and improving them

- remove unused inherit (multilib)
- remove empty IUSE
- fix variable order
- add https  (labeled as suspicious rename)


---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
