### PR TITLE
x11-libs/qwtpolar: bump EAPI, fix pkgcheck issues

### DIFF
--- a/x11-libs/qwtpolar/qwtpolar-1.1.1-r4.ebuild
+++ b/x11-libs/qwtpolar/qwtpolar-1.1.1-r4.ebuild
@@ -1,0 +1,60 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit qmake-utils
+
+DESCRIPTION="Library for displaying values on a polar coordinate system"
+HOMEPAGE="https://qwtpolar.sourceforge.io/"
+SRC_URI="https://downloads.sourceforge.net/project/${PN}/${PN}/${PV}/${P}.tar.bz2"
+
+LICENSE="qwt"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+RDEPEND="
+	dev-qt/qtcore:5
+	dev-qt/qtgui:5
+	dev-qt/qtprintsupport:5
+	dev-qt/qtsvg:5
+	dev-qt/qtwidgets:5
+	<x11-libs/qwt-6.2:6=[designer,qt5(+),svg,-polar(-)]
+"
+DEPEND="${RDEPEND}
+	dev-qt/qtconcurrent:5
+"
+
+src_prepare() {
+	default
+
+	local qtplugindir="${EPREFIX}$(qt5_get_plugindir)"
+
+	sed \
+		-e "/QWT_POLAR_INSTALL_PREFIX /s:=.*$:= ${EPREFIX}/usr:g" \
+		-e "/QWT_POLAR_INSTALL_LIBS/s:lib:$(get_libdir):g" \
+		-e "/QWT_POLAR_INSTALL_DOCS/s:doc:share/doc/${PF}:g" \
+		-e "/QWT_POLAR_INSTALL_PLUGINS/s:=.*$:= ${qtplugindir}/designer/:g" \
+		-e "/QWT_POLAR_INSTALL_FEATURES/s:=.*$:= ${qtplugindir}/features/:g" \
+		-e "/= QwtPolarDesigner/ d" \
+		-e "/= QwtPolarExamples/d" \
+		-i ${PN}config.pri || die
+
+	sed \
+		-e "s:{QWT_POLAR_ROOT}/lib:{QWT_POLAR_ROOT}/$(get_libdir):" \
+		-i src/src.pro || die
+	echo "INCLUDEPATH += ${EPREFIX}/usr/include/qwt6" >> src/src.pro
+	cat >> designer/designer.pro <<- EOF
+	INCLUDEPATH += "${EPREFIX}"/usr/include/qwt6
+	LIBS += -L"${S}/$(get_libdir)"
+	EOF
+}
+
+src_configure() {
+	eqmake5
+}
+
+src_install() {
+	emake DESTDIR="${D}" INSTALL_ROOT="${D}" install
+	einstalldocs
+}


### PR DESCRIPTION
This is an upgraded part of PR https://github.com/gentoo/gentoo/pull/37798

- fix src_uri redirect
- remove empty IUSE

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
