### PR TITLE
x11-misc/xkeyboard-config: Enforce >= python3_11 dependency

### DIFF
--- a/x11-misc/xkeyboard-config/xkeyboard-config-2.42.ebuild
+++ b/x11-misc/xkeyboard-config/xkeyboard-config-2.42.ebuild
@@ -7,7 +7,7 @@ PYTHON_COMPAT=( python3_{11..12} )
 inherit meson python-any-r1
 
 DESCRIPTION="X keyboard configuration database"
-HOMEPAGE="https://www.freedesktop.org/wiki/Software/XKeyboardConfig https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/XKeyboardConfig/ https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config"
 
 if [[ ${PV} == 9999 ]]; then
 	EGIT_REPO_URI="https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config.git"
@@ -26,8 +26,8 @@ BDEPEND="
 	dev-lang/perl
 	dev-libs/libxslt
 	sys-devel/gettext
+	${PYTHON_DEPS}
 	test? (
-		${PYTHON_DEPS}
 		x11-apps/xkbcomp
 		x11-libs/libxkbcommon
 		$(python_gen_any_dep '
@@ -47,7 +47,7 @@ python_check_deps() {
 }
 
 pkg_setup() {
-	use test && python-any-r1_pkg_setup
+	python-any-r1_pkg_setup
 }
 
 src_prepare() {

--- a/x11-misc/xkeyboard-config/xkeyboard-config-9999.ebuild
+++ b/x11-misc/xkeyboard-config/xkeyboard-config-9999.ebuild
@@ -7,7 +7,7 @@ PYTHON_COMPAT=( python3_{11..12} )
 inherit meson python-any-r1
 
 DESCRIPTION="X keyboard configuration database"
-HOMEPAGE="https://www.freedesktop.org/wiki/Software/XKeyboardConfig https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config"
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/XKeyboardConfig/ https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config"
 
 if [[ ${PV} == 9999 ]]; then
 	EGIT_REPO_URI="https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config.git"
@@ -26,8 +26,8 @@ BDEPEND="
 	dev-lang/perl
 	dev-libs/libxslt
 	sys-devel/gettext
+	${PYTHON_DEPS}
 	test? (
-		${PYTHON_DEPS}
 		x11-apps/xkbcomp
 		x11-libs/libxkbcommon
 		$(python_gen_any_dep '
@@ -47,7 +47,7 @@ python_check_deps() {
 }
 
 pkg_setup() {
-	use test && python-any-r1_pkg_setup
+	python-any-r1_pkg_setup
 }
 
 src_prepare() {


### PR DESCRIPTION
Python is now always listed as a dependency, as `xkeyboard-config` uses python during the build process whether or not the `test` USE flag is set.

Always call `python-any-r1_pkg_setup` during package setup so that the `PYTHON_COMPAT` value is used/enforced. This fixes a build error if the system's default python is an incompatible version.

Updated trivial homepage url change pkgcheck complained about.

Closes: https://bugs.gentoo.org/936137
Closes: https://bugs.gentoo.org/933984

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
