### PR TITLE
x11-themes/gtk-engines-unico: bump EAPI, fix variable order

### DIFF
--- a/x11-themes/gtk-engines-unico/gtk-engines-unico-1.0.3_pre20140109-r2.ebuild
+++ b/x11-themes/gtk-engines-unico/gtk-engines-unico-1.0.3_pre20140109-r2.ebuild
@@ -1,0 +1,52 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+MY_PN="${PN/gtk-engines-}"
+MY_PV="${PV/_pre/+14.04.}"
+MY_P="${MY_PN}_${MY_PV}"
+inherit autotools multilib-minimal
+
+DESCRIPTION="The Unico GTK+ 3.x theming engine"
+HOMEPAGE="https://launchpad.net/unico"
+SRC_URI="https://launchpad.net/ubuntu/+archive/primary/+files/${MY_P}.orig.tar.gz"
+S="${WORKDIR}/${MY_PN}-${MY_PV}"
+
+LICENSE="LGPL-2.1+"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~ppc64 ~x86"
+
+RDEPEND="
+	>=dev-libs/glib-2.26:2[${MULTILIB_USEDEP}]
+	>=x11-libs/cairo-1.10[glib,${MULTILIB_USEDEP}]
+	>=x11-libs/gtk+-3.5.2:3[${MULTILIB_USEDEP}]
+"
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-1.0.3_pre20140109-slibtool-lm.patch
+)
+
+src_prepare() {
+	default
+
+	eautoreconf
+}
+
+multilib_src_configure() {
+	# $(use_enable debug) controls CPPFLAGS -D_DEBUG and -DNDEBUG but they are currently
+	# unused in the code itself.
+	local myeconfargs=(
+		--disable-static
+		--disable-debug
+		--disable-maintainer-flags
+	)
+	ECONF_SOURCE=${S} econf "${myeconfargs[@]}"
+}
+
+multilib_src_install_all() {
+	einstalldocs
+	find "${ED}" -type f -name '*.la' -delete || die
+}


### PR DESCRIPTION
This was a part of https://github.com/gentoo/gentoo/pull/37795

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
