### PR TITLE
dev-libs/hipother: bump 6.1.1-r1 fix collisions

### DIFF
--- a/dev-libs/hipother/hipother-6.1.1-r1.ebuild
+++ b/dev-libs/hipother/hipother-6.1.1-r1.ebuild
@@ -12,6 +12,10 @@ LICENSE="MIT"
 SLOT="0/$(ver_cut 1-2)"
 KEYWORDS="~amd64"
 
+RDEPEND="
+	!<dev-util/hip-6
+"
+
 src_install() {
 	insinto /usr/include
 	doins -r hipnv/include/hip

--- a/dev-util/hip/hip-6.1.1.ebuild
+++ b/dev-util/hip/hip-6.1.1.ebuild
@@ -59,6 +59,12 @@ BDEPEND="
 "
 RDEPEND="${DEPEND}
 	sys-devel/clang-runtime:=
+	opencl? (
+		!dev-libs/opencl-icd-loader
+		!dev-libs/rocm-opencl-runtime
+		!dev-util/clinfo
+		!dev-util/opencl-headers
+	)
 	video_cards_amdgpu? (
 		dev-util/hipcc:${SLOT}[${LLVM_USEDEP}]
 		>=dev-libs/rocm-device-libs-${PV}

--- a/dev-util/hip/hip-6.1.2.ebuild
+++ b/dev-util/hip/hip-6.1.2.ebuild
@@ -59,6 +59,12 @@ BDEPEND="
 "
 RDEPEND="${DEPEND}
 	sys-devel/clang-runtime:=
+	opencl? (
+		!dev-libs/opencl-icd-loader
+		!dev-libs/rocm-opencl-runtime
+		!dev-util/clinfo
+		!dev-util/opencl-headers
+	)
 	video_cards_amdgpu? (
 		dev-util/hipcc:${SLOT}[${LLVM_USEDEP}]
 		>=dev-libs/rocm-device-libs-${PV}

--- a/profiles/arch/base/package.use.mask
+++ b/profiles/arch/base/package.use.mask
@@ -1,6 +1,11 @@
 # Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Paul Zander <negril.nx+gentoo@gmail.com> (2024-08-12)
+# Builds a amd vendored opencl runtime that causes collisions.
+# Hardly useful outside of maintainer testing. #934963, #936317
+dev-util/hip opencl
+
 # matoro <matoro_gentoo@matoro.tk> (2024-07-14)
 # Abandoned upstream, does not take bug reports, unsupported in Gentoo.
 # Only remaining use is as a requirement for dev-lang/go on arm{,64}.


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/936317
