### PR TITLE
sci-libs/opencascade: fix bugs 936901 & 937763

### DIFF
--- a/sci-libs/opencascade/opencascade-7.7.2-r1.ebuild
+++ b/sci-libs/opencascade/opencascade-7.7.2-r1.ebuild
@@ -52,8 +52,11 @@ RDEPEND="
 		media-libs/fontconfig
 		media-libs/freetype:2
 	)
-	opengl? (
+	gles2-only? (
 		media-libs/libglvnd
+	)
+	opengl? (
+		media-libs/libglvnd[X]
 	)
 	X? (
 		x11-libs/libX11

--- a/sci-libs/opencascade/opencascade-7.8.1.ebuild
+++ b/sci-libs/opencascade/opencascade-7.8.1.ebuild
@@ -51,8 +51,11 @@ RDEPEND="
 		media-libs/fontconfig
 		media-libs/freetype:2
 	)
-	opengl? (
+	gles2-only? (
 		media-libs/libglvnd
+	)
+	opengl? (
+		media-libs/libglvnd[X]
 	)
 	X? (
 		x11-libs/libX11

--- a/sci-libs/opencascade/opencascade-9999.ebuild
+++ b/sci-libs/opencascade/opencascade-9999.ebuild
@@ -51,8 +51,11 @@ RDEPEND="
 		media-libs/fontconfig
 		media-libs/freetype:2
 	)
-	opengl? (
+	gles2-only? (
 		media-libs/libglvnd
+	)
+	opengl? (
+		media-libs/libglvnd[X]
 	)
 	X? (
 		x11-libs/libX11

--- a/sci-libs/opencascade/opencascade-9999.ebuild
+++ b/sci-libs/opencascade/opencascade-9999.ebuild
@@ -97,8 +97,6 @@ BDEPEND="
 "
 
 PATCHES=(
-	"${FILESDIR}/${PN}-7.5.1-0005-fix-write-permissions-on-scripts.patch"
-	"${FILESDIR}/${PN}-7.5.1-0006-fix-creation-of-custom.sh-script.patch"
 	"${FILESDIR}/${PN}-7.7.0-fix-installation-of-cmake-config-files.patch"
 	"${FILESDIR}/${PN}-7.7.0-avoid-pre-stripping-binaries.patch"
 	"${FILESDIR}/${PN}-7.7.0-build-against-vtk-9.2.patch"


### PR DESCRIPTION
- fix missing libGL (7.7.2-r1, 7.8.1, 9999)
    
    This is a due-diligence update of the dependency on media-libs/libglvnd.
    There are no other known reports of this issue outside of automated testing.
    
    Given that this ebuild already fails on systems where media-libs/libglvnd[X] isn't already pulled by other packages it seems to be the better choice to avoid the huge rebuild and refrain from rev-bumping.

- drop obsolete patches from (9999)