### PR TITLE
games-puzzle/magiccube4d: bump EAPI 6 -> 8, fix save state crash, unmask

### DIFF
--- a/games-puzzle/magiccube4d/files/magiccube4d-2.2-overflow.patch
+++ b/games-puzzle/magiccube4d/files/magiccube4d-2.2-overflow.patch
@@ -1,0 +1,20 @@
+Fix an sprintf() overflow that causes the game to crash on startup when save
+state exists on disk.  The target variable of the sprintf() call is unused.
+
+Author: Bryan Gardiner <bog@khumba.net>
+Fixes: https://bugs.gentoo.org/921536
+
+diff -ru magiccube4d-src-2_2/MacroManager.cpp magiccube4d-src-2_2-b/MacroManager.cpp
+--- magiccube4d-src-2_2/MacroManager.cpp	2003-06-09 14:01:07.000000000 -0700
++++ magiccube4d-src-2_2-b/MacroManager.cpp	2024-01-01 08:18:33.506996196 -0800
+@@ -246,10 +246,6 @@
+     int face, stickerwithinface;
+     struct stickerspec sticker;
+     char name[1234];
+-    char format[10];
+-    sprintf(format, " @%%%d[^@]@(", (int)sizeof(name) - 1);
+-    sprintf(format, " @%%[^@]@(");  /* ARGH! FIX THIS-- maybe the other way
+-                                       worked after all, check it out */
+     /* FIX THIS!  overflow is quite likely if the final delimiter is missing
+        in the file */
+ 

--- a/games-puzzle/magiccube4d/magiccube4d-2.2-r2.ebuild
+++ b/games-puzzle/magiccube4d/magiccube4d-2.2-r2.ebuild
@@ -1,31 +1,41 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
 inherit desktop
 
 MY_PV="${PV/./_}"
 DESCRIPTION="Four-dimensional analog of Rubik's cube"
-HOMEPAGE="https://www.superliminal.com/cube/cube.htm"
-SRC_URI="https://www.superliminal.com/cube/mc4d-src-${MY_PV}.tgz
+HOMEPAGE="https://superliminal.com/cube/cube.htm"
+SRC_URI="https://superliminal.com/cube/mc4d-src-${MY_PV}.tgz
 	https://superliminal.com/cube/cube_transp.gif -> ${PN}.gif"
 
 LICENSE="free-noncomm"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE=""
 
 DEPEND="x11-libs/libXaw"
 RDEPEND="${DEPEND}"
 
 S="${WORKDIR}/${PN}-src-${MY_PV}"
 
+PATCHES=(
+	"${FILESDIR}/${PN}-EventHandler.patch"
+	"${FILESDIR}/${PN}-2.2-gcc41.patch"
+	"${FILESDIR}/${PN}-2.2-64bit-ptr.patch"
+	"${FILESDIR}/${PN}-2.2-ldflags.patch"
+	"${FILESDIR}/${PN}-2.2-overflow.patch"
+)
+
+DOCS=(
+	ChangeLog
+	MagicCube4D-unix.txt
+	readme-unix.txt
+	Intro.txt
+)
+
 src_prepare() {
 	default
-	eapply "${FILESDIR}"/${PN}-EventHandler.patch \
-		"${FILESDIR}/${P}"-gcc41.patch \
-		"${FILESDIR}/${P}"-64bit-ptr.patch \
-		"${FILESDIR}"/${P}-ldflags.patch
 	sed -i \
 		-e "s:-Werror::" \
 		configure \
@@ -38,7 +48,6 @@ src_compile() {
 
 src_install() {
 	dobin magiccube4d
-	dodoc ChangeLog MagicCube4D-unix.txt readme-unix.txt Intro.txt
 	doicon "${DISTDIR}"/${PN}.gif
 	make_desktop_entry ${PN} "Magic Cube 4D" /usr/share/pixmaps/${PN}.gif
 }

--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -193,7 +193,6 @@ games-mud/gmudix
 games-mud/kildclient
 games-puzzle/color-lines
 games-puzzle/hangman
-games-puzzle/magiccube4d
 games-puzzle/scramble
 games-puzzle/zaz
 games-simulation/cannonsmash


### PR DESCRIPTION
This updates magiccube4d from EAPI 6 to 8 to prevent it from being tree-cleaned, drops it from package.mask, and also adds a patch to fix a crash that happens when opening the game for a second time.

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
