### PR TITLE
games-misc/bsd-games: fix bsd-games-2.17_p28-r2 build

### DIFF
--- a/games-misc/bsd-games/bsd-games-2.17_p28-r2.ebuild
+++ b/games-misc/bsd-games/bsd-games-2.17_p28-r2.ebuild
@@ -52,6 +52,7 @@ src_prepare() {
 	eapply "${FILESDIR}"/${PN}-2.17-bg.patch
 	eapply "${FILESDIR}"/${PN}-2.17-gcc4.patch
 	eapply "${FILESDIR}"/${PN}-2.17-rename-getdate-clash.patch
+	eapply "${FILESDIR}"/${PN}-2.17-sigpause-gnusource.patch
 
 	default
 

--- a/games-misc/bsd-games/files/bsd-games-2.17-sigpause-gnusource.patch
+++ b/games-misc/bsd-games/files/bsd-games-2.17-sigpause-gnusource.patch
@@ -1,0 +1,14 @@
+sigpause(3) is only declared if _GNU_SOURCE is defined.
+
+--- a/hunt/hunt/otto.c
++++ b/hunt/hunt/otto.c
+@@ -43,6 +43,8 @@
+  *	Id: otto.c,v 1.14 2003/04/16 06:11:54 gregc Exp
+  */
+ 
++#define _GNU_SOURCE /* for sigpause(3) */
++
+ #include <sys/cdefs.h>
+ #ifndef lint
+ __RCSID("$NetBSD: otto.c,v 1.8 2004/11/05 21:30:32 dsl Exp $");
+


### PR DESCRIPTION
Currently, this version of the package does not build because `hunt/hunt/otto.c` uses the `sigpause()` function that is only declared if `_GNU_SOURCE` is defined in modern glibc.

    In file included from include/signal.h:40,
                     from hunt/hunt/otto.c:54:
    /usr/include/signal.h:173:12: note: declared here
      173 | extern int sigblock (int __mask) __THROW __attribute_deprecated__;
          |            ^~~~~~~~
    hunt/hunt/otto.c:179:20: warning: sigmask is deprecated
      179 |         old_mask = sigblock(sigmask(SIGALRM));
          |                    ^~~~~~~~~~~~~~~~~~~~~~~
    hunt/hunt/otto.c:181:9: error: implicit declaration of function ‘sigpause’; did you mean ‘pause’? [-Wimplicit-function-declaration]
      181 |         sigpause(old_mask);
          |         ^~~~~~~~
          |         pause

Signed-off-by: Emanuele Torre <torreemanuele6@gmail.com>

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
