### PR TITLE
sys-apps/hd-idle: fix and clarify systemd dropin example file

### DIFF
--- a/sys-apps/hd-idle/files/hd-idle-service-dropin.conf
+++ b/sys-apps/hd-idle/files/hd-idle-service-dropin.conf
@@ -1,0 +1,35 @@
+# Copyright 1999-2024 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+# override settings for hd-idle
+
+# hd-idle command line options
+# Options are:
+#  -a                      Set (partial) device name of disks for subsequent
+#                          idle-time parameters (-i). This parameter is optional
+#                          in the sense that there's a default entry for all
+#                          disks which are not named otherwise by using this
+#                          parameter.
+#  -i <idle_time>          Idle time in seconds.
+#  -l <logfile>            Name of logfile (written only after a disk has spun
+#                          up). Please note that this option might cause the
+#                          disk which holds the logfile to spin up just because
+#                          another disk had some activity. This option should
+#                          not be used on systems with more than one disk
+#                          except for tuning purposes. On single-disk systems,
+#                          this option should not cause any additional spinups.
+#
+# Options not exactly useful here:
+#  -t <disk>               Spin-down the specfified disk immediately and exit.
+#  -d                      Debug mode. This will prevent hd-idle from
+#                          becoming a daemon and print debugging info to
+#                          stdout/stderr
+#  -h                      Print usage information.
+
+[Service]
+# To override, uncomment the following ExecStart lines (including the first) to unset and
+# then override ExecStart as needed.
+# Remember to "systemctl daemon-reload" and restart the service
+# after each change.
+#ExecStart=
+#ExecStart=/usr/sbin/hd-idle -i 180 -l /var/log/hd-idle.log

--- a/sys-apps/hd-idle/hd-idle-1.05-r3.ebuild
+++ b/sys-apps/hd-idle/hd-idle-1.05-r3.ebuild
@@ -1,0 +1,33 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit linux-info systemd
+
+DESCRIPTION="Utility for spinning down hard disks after a period of idle time"
+HOMEPAGE="https://hd-idle.sourceforge.net/"
+SRC_URI="https://downloads.sourceforge.net/${PN}/${P}.tgz"
+S="${WORKDIR}/${PN}"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="amd64 x86"
+
+CONFIG_CHECK="~PROC_FS"
+
+DOCS=( debian/changelog README )
+
+src_install() {
+	default
+	systemd_newunit "${FILESDIR}"/hd-idle.service ${PN}.service
+	systemd_install_serviced "${FILESDIR}"/hd-idle-service-dropin.conf
+	newinitd "${FILESDIR}"/hd-idle-init hd-idle
+	newconfd "${FILESDIR}"/hd-idle-conf hd-idle
+
+	elog "The systemd unit file for hd-idle no longer sources ${EPREFIX}/etc/conf.d/hd-idle ."
+	elog "Configuration is still done via ${EPREFIX}/etc/conf.d/hd-idle for OpenRC systems"
+	elog "while for systemd systems, a systemd drop-in file located at"
+	elog "${EPREFIX}/etc/systemd/system/hd-idle.service.d/00gentoo.conf"
+	elog "is used for configuration."
+}


### PR DESCRIPTION
As reported in the bug linked below, the provided sample drop-in file was incomplete and not clearly specifying how to use it. 

Closes: https://bugs.gentoo.org/937799

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
