### PR TITLE
dev-util/github-cli: fix build failure when -ggdb3 is in CFLAGS

### DIFF
--- a/dev-util/github-cli/github-cli-2.27.0.ebuild
+++ b/dev-util/github-cli/github-cli-2.27.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -25,6 +25,13 @@ RDEPEND=">=dev-vcs/git-1.7.3"
 RESTRICT="test"
 
 src_unpack() {
+	# Filter LTO flags to avoid build failures.
+	filter-lto
+	# Filter '-ggdb3' flag to avoid build failures. bugs.gentoo.org/847991
+	filter-flags "-ggdb3"
+	# Go LDFLAGS are not the same as GCC/Binutils LDFLAGS
+	unset LDFLAGS
+
 	if [[ ${PV} == *9999 ]]; then
 		git-r3_src_unpack
 		go-module_live_vendor
@@ -35,12 +42,6 @@ src_unpack() {
 
 src_compile() {
 	[[ ${PV} == *9999 ]] || export GH_VERSION="v${PV}"
-	# Filter LTO flags to avoid build failures.
-	filter-lto
-	# Filter '-ggdb3' flag to avoid build failures. bugs.gentoo.org/847991
-	filter-flags "-ggdb3"
-	# Go LDFLAGS are not the same as GCC/Binutils LDFLAGS
-	unset LDFLAGS
 	# Once we set up cross compiling, this line will need to be adjusted
 	# to compile for the target.
 	# Everything else in this function happens on the host.

--- a/dev-util/github-cli/github-cli-2.31.0.ebuild
+++ b/dev-util/github-cli/github-cli-2.31.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -25,6 +25,13 @@ RDEPEND=">=dev-vcs/git-1.7.3"
 RESTRICT="test"
 
 src_unpack() {
+	# Filter LTO flags to avoid build failures.
+	filter-lto
+	# Filter '-ggdb3' flag to avoid build failures. bugs.gentoo.org/847991
+	filter-flags "-ggdb3"
+	# Go LDFLAGS are not the same as GCC/Binutils LDFLAGS
+	unset LDFLAGS
+
 	if [[ ${PV} == *9999 ]]; then
 		git-r3_src_unpack
 		go-module_live_vendor
@@ -35,12 +42,6 @@ src_unpack() {
 
 src_compile() {
 	[[ ${PV} == *9999 ]] || export GH_VERSION="v${PV}"
-	# Filter LTO flags to avoid build failures.
-	filter-lto
-	# Filter '-ggdb3' flag to avoid build failures. bugs.gentoo.org/847991
-	filter-flags "-ggdb3"
-	# Go LDFLAGS are not the same as GCC/Binutils LDFLAGS
-	unset LDFLAGS
 	# Once we set up cross compiling, this line will need to be adjusted
 	# to compile for the target.
 	# Everything else in this function happens on the host.

--- a/dev-util/github-cli/github-cli-2.32.1.ebuild
+++ b/dev-util/github-cli/github-cli-2.32.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -25,6 +25,13 @@ RDEPEND=">=dev-vcs/git-1.7.3"
 RESTRICT="test"
 
 src_unpack() {
+	# Filter LTO flags to avoid build failures.
+	filter-lto
+	# Filter '-ggdb3' flag to avoid build failures. bugs.gentoo.org/847991
+	filter-flags "-ggdb3"
+	# Go LDFLAGS are not the same as GCC/Binutils LDFLAGS
+	unset LDFLAGS
+
 	if [[ ${PV} == *9999 ]]; then
 		git-r3_src_unpack
 		go-module_live_vendor
@@ -35,12 +42,6 @@ src_unpack() {
 
 src_compile() {
 	[[ ${PV} == *9999 ]] || export GH_VERSION="v${PV}"
-	# Filter LTO flags to avoid build failures.
-	filter-lto
-	# Filter '-ggdb3' flag to avoid build failures. bugs.gentoo.org/847991
-	filter-flags "-ggdb3"
-	# Go LDFLAGS are not the same as GCC/Binutils LDFLAGS
-	unset LDFLAGS
 	# Once we set up cross compiling, this line will need to be adjusted
 	# to compile for the target.
 	# Everything else in this function happens on the host.

--- a/dev-util/github-cli/github-cli-2.33.0.ebuild
+++ b/dev-util/github-cli/github-cli-2.33.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -25,6 +25,13 @@ RDEPEND=">=dev-vcs/git-1.7.3"
 RESTRICT="test"
 
 src_unpack() {
+	# Filter LTO flags to avoid build failures.
+	filter-lto
+	# Filter '-ggdb3' flag to avoid build failures. bugs.gentoo.org/847991
+	filter-flags "-ggdb3"
+	# Go LDFLAGS are not the same as GCC/Binutils LDFLAGS
+	unset LDFLAGS
+
 	if [[ ${PV} == *9999 ]]; then
 		git-r3_src_unpack
 		go-module_live_vendor
@@ -35,12 +42,6 @@ src_unpack() {
 
 src_compile() {
 	[[ ${PV} == *9999 ]] || export GH_VERSION="v${PV}"
-	# Filter LTO flags to avoid build failures.
-	filter-lto
-	# Filter '-ggdb3' flag to avoid build failures. bugs.gentoo.org/847991
-	filter-flags "-ggdb3"
-	# Go LDFLAGS are not the same as GCC/Binutils LDFLAGS
-	unset LDFLAGS
 	# Once we set up cross compiling, this line will need to be adjusted
 	# to compile for the target.
 	# Everything else in this function happens on the host.

--- a/dev-util/github-cli/github-cli-2.42.0.ebuild
+++ b/dev-util/github-cli/github-cli-2.42.0.ebuild
@@ -25,6 +25,13 @@ RDEPEND=">=dev-vcs/git-1.7.3"
 RESTRICT="test"
 
 src_unpack() {
+	# Filter LTO flags to avoid build failures.
+	filter-lto
+	# Filter '-ggdb3' flag to avoid build failures. bugs.gentoo.org/847991
+	filter-flags "-ggdb3"
+	# Go LDFLAGS are not the same as GCC/Binutils LDFLAGS
+	unset LDFLAGS
+
 	if [[ ${PV} == *9999 ]]; then
 		git-r3_src_unpack
 		go-module_live_vendor
@@ -35,12 +42,6 @@ src_unpack() {
 
 src_compile() {
 	[[ ${PV} == *9999 ]] || export GH_VERSION="v${PV}"
-	# Filter LTO flags to avoid build failures.
-	filter-lto
-	# Filter '-ggdb3' flag to avoid build failures. bugs.gentoo.org/847991
-	filter-flags "-ggdb3"
-	# Go LDFLAGS are not the same as GCC/Binutils LDFLAGS
-	unset LDFLAGS
 	# Once we set up cross compiling, this line will need to be adjusted
 	# to compile for the target.
 	# Everything else in this function happens on the host.

--- a/dev-util/github-cli/github-cli-2.52.0.ebuild
+++ b/dev-util/github-cli/github-cli-2.52.0.ebuild
@@ -25,6 +25,13 @@ RDEPEND=">=dev-vcs/git-1.7.3"
 RESTRICT="test"
 
 src_unpack() {
+	# Filter LTO flags to avoid build failures.
+	filter-lto
+	# Filter '-ggdb3' flag to avoid build failures. bugs.gentoo.org/847991
+	filter-flags "-ggdb3"
+	# Go LDFLAGS are not the same as GCC/Binutils LDFLAGS
+	unset LDFLAGS
+
 	if [[ ${PV} == *9999 ]]; then
 		git-r3_src_unpack
 		go-module_live_vendor
@@ -35,12 +42,6 @@ src_unpack() {
 
 src_compile() {
 	[[ ${PV} == *9999 ]] || export GH_VERSION="v${PV}"
-	# Filter LTO flags to avoid build failures.
-	filter-lto
-	# Filter '-ggdb3' flag to avoid build failures. bugs.gentoo.org/847991
-	filter-flags "-ggdb3"
-	# Go LDFLAGS are not the same as GCC/Binutils LDFLAGS
-	unset LDFLAGS
 	# Once we set up cross compiling, this line will need to be adjusted
 	# to compile for the target.
 	# Everything else in this function happens on the host.

--- a/dev-util/github-cli/github-cli-9999.ebuild
+++ b/dev-util/github-cli/github-cli-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -25,6 +25,13 @@ RDEPEND=">=dev-vcs/git-1.7.3"
 RESTRICT="test"
 
 src_unpack() {
+	# Filter LTO flags to avoid build failures.
+	filter-lto
+	# Filter '-ggdb3' flag to avoid build failures. bugs.gentoo.org/847991
+	filter-flags "-ggdb3"
+	# Go LDFLAGS are not the same as GCC/Binutils LDFLAGS
+	unset LDFLAGS
+
 	if [[ ${PV} == *9999 ]]; then
 		git-r3_src_unpack
 		go-module_live_vendor
@@ -35,12 +42,6 @@ src_unpack() {
 
 src_compile() {
 	[[ ${PV} == *9999 ]] || export GH_VERSION="v${PV}"
-	# Filter LTO flags to avoid build failures.
-	filter-lto
-	# Filter '-ggdb3' flag to avoid build failures. bugs.gentoo.org/847991
-	filter-flags "-ggdb3"
-	# Go LDFLAGS are not the same as GCC/Binutils LDFLAGS
-	unset LDFLAGS
 	# Once we set up cross compiling, this line will need to be adjusted
 	# to compile for the target.
 	# Everything else in this function happens on the host.


### PR DESCRIPTION
After experiencing the bug described in https://bugs.gentoo.org/924496, I was surprised to see `filter-flags "-ggdb3"` in the ebuilds for this package.

I did some digging and found that go's goc does not use `CFLAGS`, `LDFLAGS`, etc by default; it only uses the `GOC_*FLAGS` environment variables.
What causes goc to use `CFLAGS` if `GOC_FLAGS` is unset or empty is the `go-env_set_compile_environment` function from the go-env eclass, that is indirectly called by the `go-module_live_vendor` and `go-module_src_unpack` functions from the go-module eclass that are being called from the `src_unpack` of this ebuild.

So, calling `filter-lto`, `filter-flags "-ggdb3"`, and `unset LDFLAGS` from `src_compile` before `emake` seems completely useless since those will only filter regular `*FLAGS` environment variable, and not the `GOC_*FLAGS` environment variables initialised from the `*FLAGS` variables earlier on in `src_unpack`.

Moving those filter/unset commands to the start of `src_unpack` makes them filter/unset `*FLAGS` variables before `GOC_*FLAGS` variables are set, and actually fix the build problem encounterede when `CFLAGS` contains "-ggdb3".

Bug: https://bugs.gentoo.org/847991
Closes: https://bugs.gentoo.org/924496
Signed-off-by: Emanuele Torre <torreemanuele6@gmail.com>

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
