### PR TITLE
xfce-extra/xfce4-panel-profiles: remove empty IUSE & move DEPENDs

### DIFF
--- a/xfce-extra/xfce4-panel-profiles/xfce4-panel-profiles-1.0.14.ebuild
+++ b/xfce-extra/xfce4-panel-profiles/xfce4-panel-profiles-1.0.14.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -19,7 +19,6 @@ SRC_URI="
 LICENSE="GPL-3+"
 SLOT="0"
 KEYWORDS="~amd64 ~riscv ~x86"
-IUSE=""
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 
 BDEPEND="


### PR DESCRIPTION
- rework dependencies so they are move like xfce-base/xfce4-session

split from https://github.com/gentoo/gentoo/pull/38057

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
