### PR TITLE
app-i18n/{fcitx,libime}: fix missing cstdint for gcc 15

### DIFF
--- a/app-i18n/fcitx/fcitx-5.1.10-r1.ebuild
+++ b/app-i18n/fcitx/fcitx-5.1.10-r1.ebuild
@@ -1,0 +1,127 @@
+# Copyright 2023-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+MY_PN="fcitx5"
+
+inherit cmake unpacker xdg
+
+DESCRIPTION="Fcitx 5 is a generic input method framework"
+HOMEPAGE="https://fcitx-im.org/ https://github.com/fcitx/fcitx5"
+SRC_URI="https://download.fcitx-im.org/fcitx5/fcitx5/fcitx5-${PV}_dict.tar.zst -> ${P}.tar.zst"
+
+S="${WORKDIR}/${MY_PN}-${PV}"
+LICENSE="LGPL-2+ Unicode-DFS-2016"
+SLOT="5"
+KEYWORDS="~amd64 ~arm64 ~loong ~riscv ~x86"
+IUSE="+autostart doc +emoji +enchant +keyboard presage +server systemd test wayland +X"
+REQUIRED_USE="
+	|| ( wayland X )
+	X? ( keyboard )
+	wayland? ( keyboard )
+"
+
+RESTRICT="!test? ( test )"
+
+RDEPEND="
+	!app-i18n/fcitx:4
+	dev-libs/libfmt
+	sys-devel/gettext
+	virtual/libintl
+	x11-libs/cairo[X?]
+	x11-libs/gdk-pixbuf:2
+	x11-libs/pango[X?]
+	doc? (
+		app-text/doxygen
+		dev-texlive/texlive-fontutils
+	)
+	emoji? ( sys-libs/zlib )
+	enchant? ( app-text/enchant:2 )
+	keyboard? (
+		app-text/iso-codes
+		dev-libs/expat
+		dev-libs/json-c:=
+		x11-misc/xkeyboard-config
+		x11-libs/libxkbcommon[X?,wayland?]
+	)
+	systemd? (
+		sys-apps/systemd
+	)
+	!systemd? (
+		dev-libs/libuv
+		sys-apps/dbus
+	)
+	wayland? (
+		dev-libs/glib:2
+		dev-libs/wayland
+		dev-libs/wayland-protocols
+		dev-util/wayland-scanner
+	)
+	X? (
+		dev-libs/glib:2
+		>=x11-libs/xcb-imdkit-1.0.3:5
+		x11-libs/libX11
+		x11-libs/libxkbfile
+		x11-libs/xcb-util
+		x11-libs/xcb-util-keysyms
+		x11-libs/xcb-util-wm
+	)
+"
+DEPEND="${RDEPEND}"
+BDEPEND="
+	virtual/pkgconfig
+	kde-frameworks/extra-cmake-modules:0
+"
+
+PATCHES=(
+	"${FILESDIR}/${P}-include-cstdint-for-gcc-15.patch"
+)
+
+src_configure() {
+	local mycmakeargs=(
+		-DENABLE_DBUS=on
+		-DENABLE_XDGAUTOSTART=$(usex autostart)
+		-DENABLE_SERVER=$(usex server)
+		-DENABLE_KEYBOARD=$(usex keyboard)
+		-DENABLE_TEST=$(usex test)
+		-DENABLE_ENCHANT=$(usex enchant)
+		-DENABLE_EMOJI=$(usex emoji)
+		-DENABLE_PRESAGE=$(usex presage)
+		-DENABLE_WAYLAND=$(usex wayland)
+		-DENABLE_X11=$(usex X)
+		-DENABLE_DOC=$(usex doc)
+		-DUSE_SYSTEMD=$(usex systemd)
+	)
+	cmake_src_configure
+}
+
+src_compile() {
+	cmake_src_compile
+	use doc && cmake_src_compile doc
+}
+
+src_install() {
+	cmake_src_install
+	use doc && dodoc -r "${BUILD_DIR}"/doc/*
+}
+
+src_test() {
+	# break by sandbox
+	local CMAKE_SKIP_TESTS=(
+		testdbus
+		testservicewatcher
+	)
+	cmake_src_test
+}
+
+pkg_postinst() {
+	xdg_pkg_postinst
+
+	elog
+	elog "Follow the instrcutions on:"
+	elog "https://wiki.gentoo.org/wiki/Fcitx#Using_Fcitx"
+	elog "https://fcitx-im.org/wiki/Setup_Fcitx_5"
+	elog "https://fcitx-im.org/wiki/Using_Fcitx_5_on_Wayland"
+	elog
+}

--- a/app-i18n/fcitx/files/fcitx-5.1.10-include-cstdint-for-gcc-15.patch
+++ b/app-i18n/fcitx/files/fcitx-5.1.10-include-cstdint-for-gcc-15.patch
@@ -1,0 +1,12 @@
+https://github.com/fcitx/fcitx5/pull/1119
+
+--- a/src/lib/fcitx-utils/inputbuffer.h
++++ b/src/lib/fcitx-utils/inputbuffer.h
+@@ -7,6 +7,7 @@
+ #ifndef _FCITX_UTILS_INPUTBUFFER_H_
+ #define _FCITX_UTILS_INPUTBUFFER_H_
+ 
++#include <cstdint>
+ #include <cstring>
+ #include <memory>
+ #include <string>

--- a/app-i18n/libime/files/libime-1.1.8-include-cstdint-for-gcc-15.patch
+++ b/app-i18n/libime/files/libime-1.1.8-include-cstdint-for-gcc-15.patch
@@ -1,0 +1,12 @@
+https://github.com/fcitx/libime/pull/78
+
+--- a/src/libime/table/autophrasedict.h
++++ b/src/libime/table/autophrasedict.h
+@@ -8,6 +8,7 @@
+ 
+ #include "libimetable_export.h"
+ #include <cstddef>
++#include <cstdint>
+ #include <fcitx-utils/macros.h>
+ #include <functional>
+ #include <istream>

--- a/app-i18n/libime/libime-1.1.8-r1.ebuild
+++ b/app-i18n/libime/libime-1.1.8-r1.ebuild
@@ -1,0 +1,54 @@
+# Copyright 2023-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit cmake unpacker
+
+DESCRIPTION="Fcitx5 Next generation of fcitx "
+HOMEPAGE="https://fcitx-im.org/"
+SRC_URI="https://download.fcitx-im.org/fcitx5/libime/libime-${PV}_dict.tar.zst"
+
+LICENSE="LGPL-2+"
+SLOT="5"
+KEYWORDS="~amd64 ~arm64 ~loong ~riscv ~x86"
+IUSE="+data doc test"
+RESTRICT="!test? ( test )"
+
+RDEPEND="
+	>=app-i18n/fcitx-5.1.5:5
+	app-arch/zstd:=
+	dev-libs/boost:=
+"
+DEPEND="${RDEPEND}"
+BDEPEND="
+	kde-frameworks/extra-cmake-modules:0
+	virtual/pkgconfig
+	doc? (
+		app-text/doxygen
+		dev-texlive/texlive-fontutils
+	)
+"
+
+PATCHES=(
+	"${FILESDIR}/${P}-include-cstdint-for-gcc-15.patch"
+)
+
+src_configure() {
+	local mycmakeargs=(
+		-DENABLE_DATA=$(usex data)
+		-DENABLE_DOC=$(usex doc)
+		-DENABLE_TEST=$(usex test)
+	)
+	cmake_src_configure
+}
+
+src_compile() {
+	cmake_src_compile
+	use doc && cmake_src_compile doc
+}
+
+src_install() {
+	cmake_src_install
+	use doc && dodoc -r "${BUILD_DIR}"/doc/*
+}


### PR DESCRIPTION
- **app-i18n/fcitx: fix missing cstdint for GCC 15**
- **app-i18n/libime: fix missing cstdint for GCC 15**

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
