### PR TITLE
sci-physics/lhapdf: Fix compilation on GCC 15

### DIFF
--- a/sci-physics/lhapdf/files/lhapdf-6.5.4-include-cstdint.patch
+++ b/sci-physics/lhapdf/files/lhapdf-6.5.4-include-cstdint.patch
@@ -1,0 +1,31 @@
+https://gitlab.com/hepcedar/lhapdf/merge_requests/96
+
+From: Christopher Fore <csfore@posteo.net>
+Date: Wed, 14 Aug 2024 20:38:03 -0400
+Subject: [PATCH] yamlcpp: Explicitly include <cstdint>
+
+GCC 15 will no longer include <cstdint> by default, resulting in build
+failures in projects that do not explicitly include it.
+
+Error:
+emitterutils.cpp:221:11: error: 'uint16_t' was not declared in this scope
+  221 | std::pair<uint16_t, uint16_t> EncodeUTF16SurrogatePair(int codePoint) {
+      |           ^~~~~~~~
+emitterutils.cpp:13:1:
+note: 'uint16_t' is defined in header '<cstdint>';
+this is probably fixable by adding '#include <cstdint>'
+   12 | #include "yaml-cpp/null.h"
+  +++ |+#include <cstdint>
+   13 | #include "yaml-cpp/ostream_wrapper.h"
+
+See-also: https://gcc.gnu.org/pipermail/gcc-cvs/2024-August/407124.html
+See-also: https://bugs.gentoo.org/937778
+Signed-off-by: Christopher Fore <csfore@posteo.net>
+--- a/src/yamlcpp/emitterutils.cpp
++++ b/src/yamlcpp/emitterutils.cpp
+@@ -1,4 +1,5 @@
+ #include <algorithm>
++#include <cstdint>
+ #include <iomanip>
+ #include <sstream>
+ 

--- a/sci-physics/lhapdf/lhapdf-6.5.4-r1.ebuild
+++ b/sci-physics/lhapdf/lhapdf-6.5.4-r1.ebuild
@@ -42,6 +42,10 @@ BDEPEND="
 	')
 "
 
+PATCHES=(
+	"${FILESDIR}"/${PN}-6.5.4-include-cstdint.patch
+)
+
 pkg_setup() {
 	use python && python-single-r1_pkg_setup
 }


### PR DESCRIPTION
- Include patch from upstream MR (refer to patch file)

Closes: https://bugs.gentoo.org/937778

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
