### PR TITLE
dev-python/twisted: add IDEPEND for regen-cache

### DIFF
--- a/dev-python/twisted/twisted-24.7.0.ebuild
+++ b/dev-python/twisted/twisted-24.7.0.ebuild
@@ -55,6 +55,9 @@ RDEPEND="
 		>=dev-python/idna-2.4[${PYTHON_USEDEP}]
 	)
 "
+IDEPEND="
+	>=dev-python/zope-interface-5[${PYTHON_USEDEP}]
+"
 BDEPEND="
 	>=dev-python/hatch-fancy-pypi-readme-22.5.0[${PYTHON_USEDEP}]
 	>=dev-python/incremental-22.10.0[${PYTHON_USEDEP}]


### PR DESCRIPTION
twisted python_postinst makes a call to twisted-regen-cache which imports from zope.interface which was previously a RDEPEND but should be an IDEPEND as well

not revbumping since the only cases where a rebuild would be needed is on systems that installed twisted without any RDEPENDs which are likely limited to binpkg build systems where a postinst failure and a missing dep have no practical impact

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
