### PR TITLE
net-misc/trurl: fix 9999

### DIFF
--- a/net-misc/trurl/trurl-9999.ebuild
+++ b/net-misc/trurl/trurl-9999.ebuild
@@ -29,10 +29,6 @@ DEPEND=">=net-misc/curl-7.81.0"
 RDEPEND="${DEPEND}"
 BDEPEND="test? ( ${PYTHON_DEPS} )"
 
-PATCHES=(
-	"${FILESDIR}"/${PN}-0.14-fix-makefile.patch
-)
-
 pkg_setup() {
 	use test && python-any-r1_pkg_setup
 }


### PR DESCRIPTION
The patch has been upstreamed.

Ref: https://github.com/curl/trurl/commit/5cb314b40e7203e78
Signed-off-by: Emanuele Torre <torreemanuele6@gmail.com>

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
