### PR TITLE
net-libs/webkit-gtk: Adds upstream 2.44.3 fixes, minor ebuild fixes

### DIFF
--- a/net-libs/webkit-gtk/files/2.44.3-fix-clang-lto-crash.patch
+++ b/net-libs/webkit-gtk/files/2.44.3-fix-clang-lto-crash.patch
@@ -1,0 +1,44 @@
+From 4854b944b345990e4100319662777856fe8ea4aa Mon Sep 17 00:00:00 2001
+From: Adrian Perez de Castro <aperez@igalia.com>
+Date: Thu, 15 Aug 2024 13:15:42 -0700
+Subject: [PATCH] Cherry-pick 282306@main (96fb0b0c6c46).
+ https://bugs.webkit.org/show_bug.cgi?id=274780
+
+    [WPE][GTK] Crash in WebCore::TextDecorationPainter::paintBackgroundDecorations when compiled with Clang with LTO enabled
+    https://bugs.webkit.org/show_bug.cgi?id=274780
+
+    Reviewed by Michael Catanzaro.
+
+    Clang seem to have some issue when inlining assignment and move
+    operators in LTO builds, generating code that tries to perform OOB
+    access to Vector data. Replacing an assignmenmt with a Vector::swap(),
+    which is semantically equivalent in this case (the moved-from object
+    is not used again in the function) workarounds the compiler issue.
+
+    * Source/WebCore/rendering/TextDecorationPainter.cpp:
+    (WebCore::translateIntersectionPointsToSkipInkBoundaries):
+
+    Canonical link: https://commits.webkit.org/282306@main
+
+Canonical link: https://commits.webkit.org/274313.374@webkitglib/2.44
+---
+ Source/WebCore/rendering/TextDecorationPainter.cpp | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/Source/WebCore/rendering/TextDecorationPainter.cpp b/Source/WebCore/rendering/TextDecorationPainter.cpp
+index 229857f64ad4..a58bbd86f452 100644
+--- a/Source/WebCore/rendering/TextDecorationPainter.cpp
++++ b/Source/WebCore/rendering/TextDecorationPainter.cpp
+@@ -140,8 +140,10 @@ static DashArray translateIntersectionPointsToSkipInkBoundaries(const DashArray&
+             else
+                 intermediateTuples.append(*i);
+         }
+-    } else
+-        intermediateTuples = tuples;
++    } else {
++        // XXX(274780): A plain assignment or move here makes Clang generate bad code in LTO builds.
++        intermediateTuples.swap(tuples);
++    }
+ 
+     // Step 3: Output the space between the ranges, but only if the space warrants an underline.
+     float previous = 0;

--- a/net-libs/webkit-gtk/files/2.44.3-fix-wasm.patch
+++ b/net-libs/webkit-gtk/files/2.44.3-fix-wasm.patch
@@ -1,0 +1,48 @@
+From 9140ce712aa87091613874d802787ab476be0e39 Mon Sep 17 00:00:00 2001
+From: Michael Catanzaro <mcatanzaro@redhat.com>
+Date: Wed, 14 Aug 2024 14:58:05 -0500
+Subject: [PATCH] Revert "Cherry-pick 272448.770@safari-7618-branch
+ (6d311cd7fefc). https://bugs.webkit.org/show_bug.cgi?id=271175"
+ https://bugs.webkit.org/show_bug.cgi?id=278113
+
+This reverts commit 279c9d7963182cc35cf4e0bfebe87df2d83eaef8.
+
+This broke wasm, and I don't know how to fix it.
+
+Canonical link: https://commits.webkit.org/274313.373@webkitglib/2.44
+---
+ .../stress/many-calls-results-on-stack.js     | 39 -------------------
+ Source/JavaScriptCore/wasm/WasmBBQJIT.cpp     | 19 ---------
+ 2 files changed, 58 deletions(-)
+ delete mode 100644 JSTests/wasm/stress/many-calls-results-on-stack.js
+
+diff --git a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+index 9049865e8ce7..3f142cf5e90f 100644
+--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
++++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+@@ -3958,25 +3958,6 @@ void BBQJIT::returnValuesFromCall(Vector<Value, N>& results, const FunctionSigna
+                     ASSERT(m_validFPRs.contains(returnLocation.asFPR(), Width::Width128));
+                     m_fprSet.add(returnLocation.asFPR(), Width::Width128);
+                 }
+-            } else {
+-                ASSERT(returnLocation.isStackArgument());
+-                // FIXME: Ideally, we would leave these values where they are but a subsequent call could clobber them before they are used.
+-                // That said, stack results are very rare so this isn't too painful.
+-                // Even if we did leave them where they are, we'd need to flush them to their canonical location at the next branch otherwise
+-                // we could have something like (assume no result regs for simplicity):
+-                // call (result i32 i32) $foo
+-                // if (result i32) // Stack: i32(StackArgument:8) i32(StackArgument:0)
+-                //   // Stack: i32(StackArgument:8)
+-                // else
+-                //   call (result i32 i32) $bar // Stack: i32(StackArgument:8) we have to flush the stack argument to make room for the result of bar
+-                //   drop // Stack: i32(Stack:X) i32(StackArgument:8) i32(StackArgument:0)
+-                //   drop // Stack: i32(Stack:X) i32(StackArgument:8)
+-                // end
+-                // return // Stack i32(*Conflicting locations*)
+-
+-                Location canonicalLocation = canonicalSlot(result);
+-                emitMoveMemory(result.type(), returnLocation, canonicalLocation);
+-                returnLocation = canonicalLocation;
+             }
+         }
+         bind(result, returnLocation);

--- a/net-libs/webkit-gtk/webkit-gtk-2.44.3-r410.ebuild
+++ b/net-libs/webkit-gtk/webkit-gtk-2.44.3-r410.ebuild
@@ -13,6 +13,8 @@ DESCRIPTION="Open source web browser engine"
 HOMEPAGE="https://www.webkitgtk.org"
 SRC_URI="https://www.webkitgtk.org/releases/${MY_P}.tar.xz"
 
+S="${WORKDIR}/${MY_P}"
+
 LICENSE="LGPL-2+ BSD"
 SLOT="4.1/0" # soname version of libwebkit2gtk-4.1
 KEYWORDS="~amd64 ~arm ~arm64 ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86"
@@ -112,8 +114,6 @@ BDEPEND="
 	wayland? ( dev-util/wayland-scanner )
 "
 
-S="${WORKDIR}/${MY_P}"
-
 CHECKREQS_DISK_BUILD="18G" # and even this might not be enough, bug #417307
 
 # We cannot use PATCHES because src_prepare() calls cmake_src_prepare and
@@ -149,6 +149,10 @@ src_prepare() {
 	eapply "${FILESDIR}"/2.42.3-arm64-non-jumbo-fix-925621.patch
 	# Fix USE=-jumbo-build on all arches
 	eapply "${FILESDIR}"/2.44.1-non-unified-build-fixes.patch
+	# Recommended upstream fixes for 2.44.3
+	# https://lists.webkit.org/pipermail/webkit-gtk/2024-August/004002.html
+	eapply "${FILESDIR}"/${PV}-fix-clang-lto-crash.patch
+	eapply "${FILESDIR}"/${PV}-fix-wasm.patch
 }
 
 src_configure() {

--- a/net-libs/webkit-gtk/webkit-gtk-2.44.3-r600.ebuild
+++ b/net-libs/webkit-gtk/webkit-gtk-2.44.3-r600.ebuild
@@ -13,6 +13,8 @@ DESCRIPTION="Open source web browser engine"
 HOMEPAGE="https://www.webkitgtk.org"
 SRC_URI="https://www.webkitgtk.org/releases/${MY_P}.tar.xz"
 
+S="${WORKDIR}/${MY_P}"
+
 LICENSE="LGPL-2+ BSD"
 SLOT="6/0" # soname version of libwebkit2gtk-6.0
 KEYWORDS="~amd64 ~arm ~arm64 ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86"
@@ -31,9 +33,12 @@ RESTRICT="test"
 # TODO: gst-plugins-base[X] is only needed when build configuration ends up
 #       with GLX set, but that's a bit automagic too to fix
 # Softblocking <webkit-gtk-2.38:4 and <webkit-gtk-2.44:4.1 as since 2.44 this SLOT ships the WebKitWebDriver binary;
-# WebKitWebDriver is an automation tool for web developers, which lets one control the browser via WebDriver API - only one SLOT can ship it
-# TODO: There is build-time conditional depend on gtk-4.13.4 for using more efficient DmaBuf buffer type instead of EglImage, and gtk-4.13.7 for a11y support - ensure it at some point with a min dep
-# TODO: at-spi2-core (atspi-2.pc) is checked at build time, but not linked to in the gtk4 SLOT - is it an upstream check bug and only gtk-4.14 a11y support is used?
+# WebKitWebDriver is an automation tool for web developers, which lets one control the browser via
+# WebDriver API - only one SLOT can ship it
+# TODO: There is build-time conditional depend on gtk-4.13.4 for using more efficient DmaBuf buffer type instead of
+#       EglImage, and gtk-4.13.7 for a11y support - ensure it at some point with a min dep
+# TODO: at-spi2-core (atspi-2.pc) is checked at build time, but not linked to in the gtk4 SLOT - is it an upstream
+#       check bug and only gtk-4.14 a11y support is used?
 RDEPEND="
 	>=x11-libs/cairo-1.16.0[X?]
 	>=media-libs/fontconfig-2.13.0:1.0
@@ -116,8 +121,6 @@ BDEPEND="
 	wayland? ( dev-util/wayland-scanner )
 "
 
-S="${WORKDIR}/${MY_P}"
-
 CHECKREQS_DISK_BUILD="18G" # and even this might not be enough, bug #417307
 
 # We cannot use PATCHES because src_prepare() calls cmake_src_prepare and
@@ -153,6 +156,10 @@ src_prepare() {
 	eapply "${FILESDIR}"/2.42.3-arm64-non-jumbo-fix-925621.patch
 	# Fix USE=-jumbo-build on all arches
 	eapply "${FILESDIR}"/2.44.1-non-unified-build-fixes.patch
+	# Recommended upstream fixes for 2.44.3
+	# https://lists.webkit.org/pipermail/webkit-gtk/2024-August/004002.html
+	eapply "${FILESDIR}"/${PV}-fix-clang-lto-crash.patch
+	eapply "${FILESDIR}"/${PV}-fix-wasm.patch
 }
 
 src_configure() {

--- a/net-libs/webkit-gtk/webkit-gtk-2.44.3.ebuild
+++ b/net-libs/webkit-gtk/webkit-gtk-2.44.3.ebuild
@@ -13,6 +13,8 @@ DESCRIPTION="Open source web browser engine"
 HOMEPAGE="https://www.webkitgtk.org"
 SRC_URI="https://www.webkitgtk.org/releases/${MY_P}.tar.xz"
 
+S="${WORKDIR}/${MY_P}"
+
 LICENSE="LGPL-2+ BSD"
 SLOT="4/37" # soname version of libwebkit2gtk-4.0
 KEYWORDS="~amd64 ~arm ~arm64 ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86"
@@ -110,8 +112,6 @@ BDEPEND="
 	wayland? ( dev-util/wayland-scanner )
 "
 
-S="${WORKDIR}/${MY_P}"
-
 CHECKREQS_DISK_BUILD="18G" # and even this might not be enough, bug #417307
 
 # We cannot use PATCHES because src_prepare() calls cmake_src_prepare and
@@ -147,6 +147,10 @@ src_prepare() {
 	eapply "${FILESDIR}"/2.42.3-arm64-non-jumbo-fix-925621.patch
 	# Fix USE=-jumbo-build on all arches
 	eapply "${FILESDIR}"/2.44.1-non-unified-build-fixes.patch
+	# Recommended upstream fixes for 2.44.3
+	# https://lists.webkit.org/pipermail/webkit-gtk/2024-August/004002.html
+	eapply "${FILESDIR}"/${PV}-fix-clang-lto-crash.patch
+	eapply "${FILESDIR}"/${PV}-fix-wasm.patch
 }
 
 src_configure() {


### PR DESCRIPTION
* Adds upstream patches on top of 2.44.3 as suggested on https://lists.webkit.org/pipermail/webkit-gtk/2024-August/004002.html

* Fixes minor issues reported by `pkgcheck`

* No revbump since this is still unstable

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
