### PR TITLE
sys-power/uhubctl: Add LFS flags

### DIFF
--- a/sys-power/uhubctl/uhubctl-2.5.0.ebuild
+++ b/sys-power/uhubctl/uhubctl-2.5.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit toolchain-funcs
+inherit toolchain-funcs flag-o-matic
 
 DESCRIPTION="USB hub per-port power control"
 HOMEPAGE="https://github.com/mvp/uhubctl"
@@ -26,6 +26,10 @@ src_prepare() {
 		|| die
 
 	tc-export PKG_CONFIG
+}
+
+src_configure() {
+	append-lfs-flags
 }
 
 src_compile() {


### PR DESCRIPTION
The Makefile already uses CPPFLAGS, so the LFS flags just need to be inserted.

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
