### PR TITLE
net-vpn/i2pd: drop `i2p-hardening` USE flag

### DIFF
--- a/net-vpn/i2pd/i2pd-2.52.0.ebuild
+++ b/net-vpn/i2pd/i2pd-2.52.0.ebuild
@@ -12,7 +12,7 @@ SRC_URI="https://github.com/PurpleI2P/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
 LICENSE="BSD"
 SLOT="0"
 KEYWORDS="amd64 ~arm ~arm64 ~ia64 ~ppc ~ppc64 ~sparc ~x86"
-IUSE="cpu_flags_x86_aes i2p-hardening +upnp"
+IUSE="cpu_flags_x86_aes +upnp"
 
 RDEPEND="
 	acct-user/i2pd
@@ -29,16 +29,10 @@ DOCS=( ../README.md ../contrib/i2pd.conf ../contrib/tunnels.conf )
 
 PATCHES=( "${FILESDIR}/${P}-miniupnp.patch" )
 
-pkg_pretend() {
-	if use i2p-hardening && ! tc-is-gcc; then
-		die "i2p-hardening requires gcc"
-	fi
-}
-
 src_configure() {
 	local mycmakeargs=(
 		-DWITH_AESNI=$(usex cpu_flags_x86_aes ON OFF)
-		-DWITH_HARDENING=$(usex i2p-hardening ON OFF)
+		-DWITH_HARDENING=OFF # worsens or matches the non-hardened profiles
 		-DWITH_STATIC=OFF
 		-DWITH_UPNP=$(usex upnp ON OFF)
 		-DWITH_LIBRARY=ON

--- a/net-vpn/i2pd/i2pd-2.53.1.ebuild
+++ b/net-vpn/i2pd/i2pd-2.53.1.ebuild
@@ -12,7 +12,7 @@ SRC_URI="https://github.com/PurpleI2P/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
 LICENSE="BSD"
 SLOT="0"
 KEYWORDS="~amd64 ~arm ~arm64 ~ia64 ~ppc ~ppc64 ~sparc ~x86"
-IUSE="cpu_flags_x86_aes i2p-hardening +upnp"
+IUSE="cpu_flags_x86_aes +upnp"
 
 DEPEND="
 	dev-libs/boost:=
@@ -30,16 +30,10 @@ CMAKE_USE_DIR="${WORKDIR}/${P}/build"
 
 DOCS=( ../README.md ../contrib/i2pd.conf ../contrib/tunnels.conf )
 
-pkg_pretend() {
-	if use i2p-hardening && ! tc-is-gcc; then
-		die "i2p-hardening requires gcc"
-	fi
-}
-
 src_configure() {
 	local mycmakeargs=(
 		-DWITH_AESNI=$(usex cpu_flags_x86_aes ON OFF)
-		-DWITH_HARDENING=$(usex i2p-hardening ON OFF)
+		-DWITH_HARDENING=OFF # worsens or matches the non-hardened profiles
 		-DWITH_STATIC=OFF
 		-DWITH_UPNP=$(usex upnp ON OFF)
 		-DWITH_LIBRARY=ON

--- a/net-vpn/i2pd/metadata.xml
+++ b/net-vpn/i2pd/metadata.xml
@@ -9,11 +9,6 @@
 		<email>proxy-maint@gentoo.org</email>
 		<name>Proxy Maintainers</name>
 	</maintainer>
-	<use>
-		<flag name="i2p-hardening">
-			Compile with hardening on vanilla compilers/linkers
-		</flag>
-	</use>
 	<upstream>
 		<remote-id type="github">PurpleI2P/i2pd</remote-id>
 	</upstream>


### PR DESCRIPTION
Sam James and Eli Schwartz suggested that it should be done:
"[the hardening] matches the defaults or makes them worse"
No revbump as it was turned off by default.


Closes: https://bugs.gentoo.org/909080

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
