### PR TITLE
kde-plasma/krdp: fix libc++ builds

### DIFF
--- a/kde-plasma/krdp/krdp-6.1.4.ebuild
+++ b/kde-plasma/krdp/krdp-6.1.4.ebuild
@@ -8,7 +8,7 @@ ECM_TEST="true"
 KFMIN=6.3.0
 PVCUT=$(ver_cut 1-3)
 QTMIN=6.7.1
-inherit ecm plasma.kde.org
+inherit ecm flag-o-matic plasma.kde.org toolchain-funcs
 
 DESCRIPTION="Library and examples for creating an RDP server"
 HOMEPAGE+=" https://quantumproductions.info/articles/2023-08/remote-desktop-using-rdp-protocol-plasma-wayland"
@@ -40,3 +40,11 @@ RDEPEND="${COMMON_DEPEND}
 	>=kde-frameworks/kirigami-${KFMIN}:6
 "
 BDEPEND=">=kde-frameworks/kcmutils-${KFMIN}:6"
+
+src_configure() {
+	# std::jthread and std::stop_token are implemented as experimental in libcxx
+	# enable these experimental libraries on clang systems
+	# https://libcxx.llvm.org/Status/Cxx20.html#note-p0660
+	[[ $(tc-get-cxx-stdlib) == 'libc++' ]] && append-cxxflags -fexperimental-library
+	ecm_src_configure
+}


### PR DESCRIPTION
libc++ marks the implementations of jthread and stop_token as experimental.
Explicitly enable these libraries on libc++ systems See: https://libcxx.llvm.org/Status/Cxx20.html#note-p0660

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
