### PR TITLE
java-pkg-2.eclass: deprecate functions which depend on java-ant-2.eclass, remove unused for commons.apache.org packages

### DIFF
--- a/eclass/java-ant-2.eclass
+++ b/eclass/java-ant-2.eclass
@@ -2,6 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: java-ant-2.eclass
+# @DEPRECATED: none
 # @MAINTAINER:
 # java@gentoo.org
 # @AUTHOR:

--- a/eclass/java-pkg-2.eclass
+++ b/eclass/java-pkg-2.eclass
@@ -39,12 +39,6 @@ DEPEND="${JAVA_PKG_E_DEPEND}"
 # Nothing special for RDEPEND... just the same as DEPEND.
 RDEPEND="${DEPEND}"
 
-# Commons packages follow the same rules so do it here
-if [[ ${CATEGORY} = dev-java && ${PN} = commons-* ]]; then
-	HOMEPAGE="http://commons.apache.org/${PN#commons-}/"
-	SRC_URI="mirror://apache/${PN/-///}/source/${P}-src.tar.gz"
-fi
-
 
 # @FUNCTION: java-pkg-2_pkg_setup
 # @DESCRIPTION:

--- a/eclass/java-pkg-2.eclass
+++ b/eclass/java-pkg-2.eclass
@@ -1,4 +1,4 @@
-# Copyright 2004-2023 Gentoo Authors
+# Copyright 2004-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: java-pkg-2.eclass
@@ -63,6 +63,7 @@ java-pkg-2_src_prepare() {
 
 
 # @FUNCTION: java-pkg-2_src_compile
+# @DEPRECATED: none
 # @DESCRIPTION:
 # Default src_compile for java packages
 #
@@ -98,6 +99,7 @@ java-pkg-2_src_compile() {
 }
 
 # @FUNCTION: java-pkg-2_src_test
+# @DEPRECATED: none
 # @DESCRIPTION:
 # src_test, not exported.
 java-pkg-2_src_test() {

--- a/eclass/java-utils-2.eclass
+++ b/eclass/java-utils-2.eclass
@@ -1140,7 +1140,7 @@ java-pkg_jarfrom() {
 # @USAGE: [--build-only] [--runtime-only] [--with-dependencies] <package1>[,<package2>...]
 # @DESCRIPTION:
 # Get the classpath provided by any number of packages
-# Among other things, this can be passed to 'javac -classpath' or 'ant -lib'.
+# Among other things, this can be passed to 'javac -classpath'.
 # The providing packages are recorded as dependencies into package.env DEPEND
 # line, unless "--build-only" is passed as the very first argument, for jars
 # that have to be present only at build time and are not needed on runtime


### PR DESCRIPTION
<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
