### PR TITLE
net-proxy/trojan: add tcpfastopen, nat and reuseport use flag

### DIFF
--- a/net-proxy/trojan/metadata.xml
+++ b/net-proxy/trojan/metadata.xml
@@ -25,6 +25,9 @@
 	</longdescription>
 	<use>
 		<flag name="mysql">build with MySQL support</flag>
+		<flag name="nat">Build with NAT support</flag>
+		<flag name="reuseport">Build with SO_REUSEPORT support</flag>
+		<flag name="tcpfastopen">Force build with TCP Fast Open support</flag>
 	</use>
 	<upstream>
 		<remote-id type="github">trojan-gfw/trojan</remote-id>

--- a/net-proxy/trojan/trojan-1.16.0-r2.ebuild
+++ b/net-proxy/trojan/trojan-1.16.0-r2.ebuild
@@ -20,7 +20,7 @@ fi
 
 LICENSE="GPL-3+"
 SLOT="0"
-IUSE="mysql test"
+IUSE="mysql +nat +reuseport tcpfastopen test"
 
 # Some hiccups setting up local network server.
 RESTRICT="test"
@@ -50,6 +50,9 @@ src_prepare() {
 src_configure() {
 	local mycmakeargs=(
 		-DENABLE_MYSQL=$(usex mysql)
+		-DENABLE_NAT=$(usex nat)
+		-DENABLE_REUSE_PORT=$(usex reuseport)
+		-DFORCE_TCP_FASTOPEN=$(usex tcpfastopen)
 		-DSYSTEMD_SERVICE=ON
 		-DSYSTEMD_SERVICE_PATH=$(systemd_get_systemunitdir)
 	)


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/938213

Does not change the default build.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
