### PR TITLE
dev-python/twisted: add more IDEPEND for regen-cache

### DIFF
--- a/dev-python/twisted/twisted-24.7.0.ebuild
+++ b/dev-python/twisted/twisted-24.7.0.ebuild
@@ -56,6 +56,8 @@ RDEPEND="
 	)
 "
 IDEPEND="
+	>=dev-python/attrs-19.2.0[${PYTHON_USEDEP}]
+	>=dev-python/constantly-15.1[${PYTHON_USEDEP}]
 	>=dev-python/zope-interface-5[${PYTHON_USEDEP}]
 "
 BDEPEND="


### PR DESCRIPTION
Two additional IDEPEND are needed that were missed in the previous commit on this issue (6aaa83fb8842d3e4c3b47f7715377893b2a97d15). twisted-regen-cache should run without error now that attrs and constantly deps are correctly pulled in.

PS this one was on me for not listening to my inner warning flags saying "make sure you test to make sure there aren't other import statements that are hit in the process."

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
