### PR TITLE
sys-block/sas2ircu: fix check for IA32_EMULATION

### DIFF
--- a/sys-block/sas2ircu/sas2ircu-20-r2.ebuild
+++ b/sys-block/sas2ircu/sas2ircu-20-r2.ebuild
@@ -54,7 +54,7 @@ pkg_setup() {
 	if ! use x86; then
 		# For newer kernels it needs to be enabled as well, don't know
 		# how to check for that short of running the binary.
-		local CONFIG_CHECK="CONFIG_IA32_EMULATION"
+		local CONFIG_CHECK="IA32_EMULATION"
 		check_extra_config
 	fi
 }


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/938260

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
