### PR TITLE
sci-libs/{hip,roc}SPARSE: fix wrong find regextype

### DIFF
--- a/sci-libs/hipSPARSE/hipSPARSE-5.1.3-r1.ebuild
+++ b/sci-libs/hipSPARSE/hipSPARSE-5.1.3-r1.ebuild
@@ -71,7 +71,7 @@ src_prepare() {
 		mkdir -p "${BUILD_DIR}"/clients/matrices
 		# compile and use the mtx2bin converter. Do not use any optimization flags!
 		edo $(tc-getCXX) deps/convert.cpp -o deps/convert
-		find "${WORKDIR}" -maxdepth 2 -regextype grep -E -regex ".*/(.*)/\1\.mtx" -print0 |
+		find "${WORKDIR}" -maxdepth 2 -regextype egrep -regex ".*/(.*)/\1\.mtx" -print0 |
 			while IFS= read -r -d '' mtxfile; do
 				destination=${BUILD_DIR}/clients/matrices/$(basename -s '.mtx' ${mtxfile}).bin
 				ebegin "Converting ${mtxfile} to ${destination}"

--- a/sci-libs/hipSPARSE/hipSPARSE-5.7.1.ebuild
+++ b/sci-libs/hipSPARSE/hipSPARSE-5.7.1.ebuild
@@ -69,7 +69,7 @@ src_prepare() {
 		mkdir -p "${BUILD_DIR}"/clients/matrices
 		# compile and use the mtx2bin converter. Do not use any optimization flags!
 		edo $(tc-getCXX) deps/convert.cpp -o deps/convert
-		find "${WORKDIR}" -maxdepth 2 -regextype grep -E -regex ".*/(.*)/\1\.mtx" -print0 |
+		find "${WORKDIR}" -maxdepth 2 -regextype egrep -regex ".*/(.*)/\1\.mtx" -print0 |
 			while IFS= read -r -d '' mtxfile; do
 				destination=${BUILD_DIR}/clients/matrices/$(basename -s '.mtx' ${mtxfile}).bin
 				ebegin "Converting ${mtxfile} to ${destination}"

--- a/sci-libs/hipSPARSE/hipSPARSE-6.1.1.ebuild
+++ b/sci-libs/hipSPARSE/hipSPARSE-6.1.1.ebuild
@@ -57,7 +57,7 @@ src_prepare() {
 		mkdir -p "${BUILD_DIR}"/clients/matrices
 		# compile and use the mtx2bin converter. Do not use any optimization flags!
 		edo $(tc-getCXX) deps/convert.cpp -o deps/convert
-		find "${WORKDIR}" -maxdepth 2 -regextype grep -E -regex ".*/(.*)/\1\.mtx" -print0 |
+		find "${WORKDIR}" -maxdepth 2 -regextype egrep -regex ".*/(.*)/\1\.mtx" -print0 |
 			while IFS= read -r -d '' mtxfile; do
 				destination=${BUILD_DIR}/clients/matrices/$(basename -s '.mtx' ${mtxfile}).bin
 				ebegin "Converting ${mtxfile} to ${destination}"

--- a/sci-libs/rocSPARSE/rocSPARSE-5.1.3-r1.ebuild
+++ b/sci-libs/rocSPARSE/rocSPARSE-5.1.3-r1.ebuild
@@ -94,7 +94,7 @@ src_prepare() {
 		mkdir -p "${BUILD_DIR}"/clients/matrices
 		# compile and use the mtx2csr converter. Do not use any optimization flags, because it causes error!
 		edo $(tc-getCXX) deps/convert.cpp -o deps/convert
-		find "${WORKDIR}" -maxdepth 2 -regextype grep -E -regex ".*/(.*)/\1\.mtx" -print0 |
+		find "${WORKDIR}" -maxdepth 2 -regextype egrep -regex ".*/(.*)/\1\.mtx" -print0 |
 			while IFS= read -r -d '' mtxfile; do
 				destination=${BUILD_DIR}/clients/matrices/$(basename -s '.mtx' ${mtxfile}).csr
 				ebegin "Converting ${mtxfile} to ${destination}"

--- a/sci-libs/rocSPARSE/rocSPARSE-5.7.1-r2.ebuild
+++ b/sci-libs/rocSPARSE/rocSPARSE-5.7.1-r2.ebuild
@@ -95,7 +95,7 @@ src_prepare() {
 		mkdir -p "${BUILD_DIR}"/clients/matrices
 		# compile and use the mtx2csr converter. Do not use any optimization flags, because it causes error!
 		edo $(tc-getCXX) deps/convert.cpp -o deps/convert
-		find "${WORKDIR}" -maxdepth 2 -regextype grep -E -regex ".*/(.*)/\1\.mtx" -print0 |
+		find "${WORKDIR}" -maxdepth 2 -regextype egrep -regex ".*/(.*)/\1\.mtx" -print0 |
 			while IFS= read -r -d '' mtxfile; do
 				destination=${BUILD_DIR}/clients/matrices/$(basename -s '.mtx' ${mtxfile}).csr
 				ebegin "Converting ${mtxfile} to ${destination}"


### PR DESCRIPTION
The command line argument for `find -regextype` is still `egrep`, not `grep -E`. So fix it for now.

Needs proper fixing eventually.