### PR TITLE
app-misc/tmux: add sixel flag to compile with sixel support

### DIFF
--- a/app-misc/tmux/metadata.xml
+++ b/app-misc/tmux/metadata.xml
@@ -7,6 +7,7 @@
 	</maintainer>
 	<use>
 		<flag name="utempter">Include libutempter support</flag>
+		<flag name="sixel">Enable sixel support</flag>
 	</use>
 	<longdescription>
 		tmux is a "terminal multiplexer", it enables a number of terminals

--- a/app-misc/tmux/tmux-3.5-r1.ebuild
+++ b/app-misc/tmux/tmux-3.5-r1.ebuild
@@ -21,7 +21,7 @@ fi
 
 LICENSE="ISC"
 SLOT="0"
-IUSE="debug jemalloc selinux systemd utempter vim-syntax"
+IUSE="debug jemalloc selinux sixel systemd utempter vim-syntax"
 
 DEPEND="
 	dev-libs/libevent:=
@@ -71,6 +71,7 @@ src_configure() {
 		--sysconfdir="${EPREFIX}"/etc
 		$(use_enable debug)
 		$(use_enable jemalloc)
+		$(use_enable sixel)
 		$(use_enable systemd)
 		$(use_enable utempter)
 

--- a/app-misc/tmux/tmux-3.5a.ebuild
+++ b/app-misc/tmux/tmux-3.5a.ebuild
@@ -21,7 +21,7 @@ fi
 
 LICENSE="ISC"
 SLOT="0"
-IUSE="debug jemalloc selinux systemd utempter vim-syntax"
+IUSE="debug jemalloc selinux sixel systemd utempter vim-syntax"
 
 DEPEND="
 	dev-libs/libevent:=
@@ -71,6 +71,7 @@ src_configure() {
 		--sysconfdir="${EPREFIX}"/etc
 		$(use_enable debug)
 		$(use_enable jemalloc)
+		$(use_enable sixel)
 		$(use_enable systemd)
 		$(use_enable utempter)
 

--- a/app-misc/tmux/tmux-9999.ebuild
+++ b/app-misc/tmux/tmux-9999.ebuild
@@ -21,11 +21,12 @@ fi
 
 LICENSE="ISC"
 SLOT="0"
-IUSE="debug selinux systemd utempter vim-syntax"
+IUSE="debug jemalloc selinux sixel systemd utempter vim-syntax"
 
 DEPEND="
 	dev-libs/libevent:=
 	sys-libs/ncurses:=
+	jemalloc? ( dev-libs/jemalloc:= )
 	systemd? ( sys-apps/systemd:= )
 	utempter? ( sys-libs/libutempter )
 	kernel_Darwin? ( dev-libs/libutf8proc:= )
@@ -42,8 +43,12 @@ RDEPEND="
 	vim-syntax? ( app-vim/vim-tmux )
 "
 
-# BSD only functions
-QA_CONFIG_IMPL_DECL_SKIP=( strtonum recallocarray )
+QA_CONFIG_IMPL_DECL_SKIP=(
+	# BSD only functions
+	strtonum recallocarray
+	# missing on musl, tmux has fallback impl which it uses
+	b64_ntop
+)
 
 DOCS=( CHANGES README )
 
@@ -64,6 +69,8 @@ src_configure() {
 	local myeconfargs=(
 		--sysconfdir="${EPREFIX}"/etc
 		$(use_enable debug)
+		$(use_enable jemalloc)
+		$(use_enable sixel)
 		$(use_enable systemd)
 		$(use_enable utempter)
 


### PR DESCRIPTION
Add flag that allows to compile tmux with enabled sixel support. I tested that it compiles and that it works.