### PR TITLE
sci-mathematics/planarity: fix remote-id in metadata.xml

### DIFF
--- a/sci-mathematics/planarity/metadata.xml
+++ b/sci-mathematics/planarity/metadata.xml
@@ -19,8 +19,6 @@
   </maintainer>
 
   <upstream>
-    <remote-id type="github">
-      graph-algorithms/edge-addition-planarity-suite
-    </remote-id>
+    <remote-id type="github">graph-algorithms/edge-addition-planarity-suite</remote-id>
   </upstream>
 </pkgmetadata>


### PR DESCRIPTION
The `<remote-id>` tag cannot contain arbitrary whitespace; pkgcheck was complaining about this, and the "Upstream" URL at https://packages.gentoo.org/packages/sci-mathematics/planarity is currently broken since there are extra %20 characters in it that make it point to a non-existing page.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
