### PR TITLE
sys-apps/asahi-nvram: fix remote-id in metadata.xml

### DIFF
--- a/sys-apps/asahi-nvram/metadata.xml
+++ b/sys-apps/asahi-nvram/metadata.xml
@@ -10,8 +10,6 @@
 		<name>Gentoo Asahi Project</name>
 	</maintainer>
 	<upstream>
-		<remote-id type="github">
-			WhatAmISupposedToPutHere/asahi-nvram
-		</remote-id>
+		<remote-id type="github">WhatAmISupposedToPutHere/asahi-nvram</remote-id>
 	</upstream>
 </pkgmetadata>


### PR DESCRIPTION
Like <https://github.com/gentoo/gentoo/pull/38257>, `<remote-id>` tags cannot contain arbitrary whitespace.
This whitespace surprising doesn't break the "Upstream" URL at https://packages.gentoo.org/packages/sys-apps/asahi-nvram for some reason even though the URL is rendered with an extra space. :-)

Found with `git grep '<remote-id[^<]*> *$'` it was the only instance remaining of this problem.

Signed-off-by: Emanuele Torre <torreemanuele6@gmail.com>

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
