### PR TITLE
app-crypt/cfssl: rename mkbundle to mkbundle.cfssl

### DIFF
--- a/app-crypt/cfssl/cfssl-1.4.1-r1.ebuild
+++ b/app-crypt/cfssl/cfssl-1.4.1-r1.ebuild
@@ -14,8 +14,6 @@ SLOT="0"
 KEYWORDS="amd64"
 IUSE="hardened"
 
-RDEPEND="!!dev-lang/mono" #File collision (bug 614364)
-
 PATCHES=(
 	"${FILESDIR}/${P}-build-fix.patch"
 )
@@ -30,4 +28,10 @@ src_compile() {
 src_install() {
 	dobin bin/*
 	dodoc CHANGELOG README.md
+	mv -iv "${ED}"/usr/bin/mkbundle{,.cfssl} || die
+}
+
+pkg_postinst() {
+	ewarn "Please note that mkbundle is renamed to mkbundle.cfssl, to avoid"
+	ewarn "collision with mkbundle in dev-lang/mono"
 }

--- a/app-crypt/cfssl/cfssl-1.6.4-r1.ebuild
+++ b/app-crypt/cfssl/cfssl-1.6.4-r1.ebuild
@@ -14,8 +14,6 @@ SLOT="0"
 KEYWORDS="~amd64 ~arm64"
 IUSE="hardened"
 
-RDEPEND="!!dev-lang/mono" #File collision (bug 614364)
-
 PATCHES=(
 	"${FILESDIR}/${PN}-1.4.1-build-fix.patch"
 )
@@ -30,4 +28,10 @@ src_compile() {
 src_install() {
 	dobin bin/*
 	dodoc CHANGELOG README.md
+	mv -iv "${ED}"/usr/bin/mkbundle{,.cfssl} || die
+}
+
+pkg_postinst() {
+	ewarn "Please note that mkbundle is renamed to mkbundle.cfssl, to avoid"
+	ewarn "collision with mkbundle in dev-lang/mono"
 }


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/614364

mkbundle in cfssl is collided with dev-lang/mono, so we rename mkbundle to mkbundle.cfssl.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
