### PR TITLE
www-servers/nginx: remove HTTP_POSTPONE=no for nginx-vod module

### DIFF
--- a/www-servers/nginx/nginx-1.26.2-r1.ebuild
+++ b/www-servers/nginx/nginx-1.26.2-r1.ebuild
@@ -632,7 +632,6 @@ src_configure() {
 
 	if use nginx_modules_http_vod; then
 		http_enabled=1
-		export HTTP_POSTPONE=no
 		myconf+=( --add-module=${HTTP_VOD_MODULE_WD} )
 	fi
 

--- a/www-servers/nginx/nginx-1.27.1-r1.ebuild
+++ b/www-servers/nginx/nginx-1.27.1-r1.ebuild
@@ -632,7 +632,6 @@ src_configure() {
 
 	if use nginx_modules_http_vod; then
 		http_enabled=1
-		export HTTP_POSTPONE=no
 		myconf+=( --add-module=${HTTP_VOD_MODULE_WD} )
 	fi
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/933347

postpone filter is always built in nginx since 1.17, as seen in https://github.com/nginx/nginx/commit/8a779e20672d66c17f5e8dfa94344bcd5cd6f576

so we need to remove export HTTP_POSTPONE=no, otherwise compile will failed as described in [933347](https://bugs.gentoo.org/933347)  multiple definition of `ngx_http_postpone_filter_module';

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
