### PR TITLE
fix/musl/gnu efi

### DIFF
--- a/sys-boot/gnu-efi/gnu-efi-3.0.18-r4.ebuild
+++ b/sys-boot/gnu-efi/gnu-efi-3.0.18-r4.ebuild
@@ -1,0 +1,128 @@
+# Copyright 2004-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit flag-o-matic toolchain-funcs
+
+DESCRIPTION="Library for build EFI Applications"
+HOMEPAGE="https://sourceforge.net/projects/gnu-efi/"
+SRC_URI="https://downloads.sourceforge.net/gnu-efi/${P}.tar.bz2"
+
+# inc/, lib/ dirs (README.efilib)
+# - BSD-2
+# gnuefi dir:
+# - BSD (3-cluase): crt0-efi-ia32.S
+# - GPL-2+ : setjmp_ia32.S
+LICENSE="GPL-2+ BSD BSD-2"
+SLOT="0"
+KEYWORDS="-* ~amd64 ~arm ~arm64 ~ia64 ~riscv ~x86"
+IUSE="abi_x86_32 abi_x86_64 custom-cflags"
+REQUIRED_USE="
+	amd64? ( || ( abi_x86_32 abi_x86_64 ) )
+	x86? ( || ( abi_x86_32 abi_x86_64 ) )
+"
+
+# for ld.bfd and objcopy
+BDEPEND="sys-devel/binutils"
+
+# These objects get run early boot (i.e. not inside of Linux),
+# so doing these QA checks on them doesn't make sense.
+QA_EXECSTACK="usr/*/lib*efi.a:* usr/*/crt*.o"
+RESTRICT="strip"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-clang.patch
+	"${FILESDIR}"/${PN}-3.0.18-remove-linux-headers.patch
+)
+
+check_and_set_objcopy() {
+	if [[ ${MERGE_TYPE} != "binary" ]]; then
+		# bug #931792
+		# llvm-objcopy does not support EFI target, try to use binutils objcopy or fail
+		tc-export OBJCOPY
+		OBJCOPY="${OBJCOPY/llvm-/}"
+		LANG=C LC_ALL=C "${OBJCOPY}" --help | grep -q '\<pei-' || die "${OBJCOPY} (objcopy) does not support EFI target"
+	fi
+}
+
+check_comppiler() {
+	if [[ ${MERGE_TYPE} != "binary" ]]; then
+		tc-is-gcc || tc-is-clang || die "Unsupported compiler"
+	fi
+}
+
+pkg_pretend() {
+	check_comppiler
+	check_and_set_objcopy
+}
+
+pkg_setup() {
+	check_and_set_objcopy
+}
+
+src_prepare() {
+	default
+	sed -i -e "s/-Werror//" Make.defaults || die
+}
+
+efimake() {
+	local arch=
+	case ${CHOST} in
+		arm*) arch=arm ;;
+		aarch64*) arch=aarch64 ;;
+		ia64*) arch=ia64 ;;
+		i?86*) arch=ia32 ;;
+		riscv64*) arch=riscv64;;
+		x86_64*) arch=x86_64 ;;
+		*) die "Unknown CHOST" ;;
+	esac
+
+	local args=(
+		ARCH="${arch}"
+		HOSTCC="${BUILD_CC}"
+		CC="${CC}"
+		AS="${AS}"
+		LD="${LD}"
+		AR="${AR}"
+		OBJCOPY="${OBJCOPY}"
+		PREFIX="${EPREFIX}/usr"
+		LIBDIR='$(PREFIX)'/$(get_libdir)
+	)
+	emake -j1 "${args[@]}" "$@"
+}
+
+src_compile() {
+	tc-export BUILD_CC AR AS CC LD OBJCOPY
+
+	if ! use custom-cflags; then
+		unset CFLAGS CPPFLAGS LDFLAGS
+	fi
+
+	# work around musl: include first the compiler include dir, then the system one
+	# bug #933080, #938012
+	local CPPINCLUDEDIR
+	if tc-is-gcc; then
+		CPPINCLUDEDIR=$(LANG=C ${CC} -print-search-dirs 2> /dev/null | grep ^install: | cut -f2 -d' ')/include
+	elif tc-is-clang; then
+		CPPINCLUDEDIR=$(LANG=C ${CC} -print-resource-dir 2> /dev/null)/include
+	fi
+	append-cflags "-nostdinc -isystem ${CPPINCLUDEDIR} -isystem ${ESYSROOT}/usr/include"
+
+	if use amd64 || use x86; then
+		use abi_x86_32 && CHOST=i686 ABI=x86 efimake
+		use abi_x86_64 && CHOST=x86_64 ABI=amd64 efimake
+	else
+		efimake
+	fi
+}
+
+src_install() {
+	if use amd64 || use x86; then
+		use abi_x86_32 && CHOST=i686 ABI=x86 efimake INSTALLROOT="${D}" install
+		use abi_x86_64 && CHOST=x86_64 ABI=amd64 efimake INSTALLROOT="${D}" install
+	else
+		efimake INSTALLROOT="${D}" install
+	fi
+	einstalldocs
+}

--- a/sys-boot/refind/files/refind-0.14.2-fix-freestanding-on-musl.patch
+++ b/sys-boot/refind/files/refind-0.14.2-fix-freestanding-on-musl.patch
@@ -1,0 +1,63 @@
+On amd64, musl typedefs wchar_t to int, conflicting with -fshort-wchar.
+Also, /usr/include is searched before the compiler provided include directory.
+As a workaround, use -nostdinc and switch them around.
+
+Add missing `#include <stddef.h>` where wchar_t was defined indirectly by
+other standard includefiles.
+
+We need and extra -D for clang, where wchar_t is defined in
+/usr/include/allbits.h and gets included by other headers, conflicting with
+wchar_t already defined in stddef.h.
+
+See also:	https://bugs.gentoo.org/938012
+			https://bugs.gentoo.org/881131
+			https://bugs.gentoo.org/832018
+
+--- a/Make.common
++++ b/Make.common
+@@ -79,7 +79,7 @@
+ #
+ 
+ # ...for both GNU-EFI and TianoCore....
+-OPTIMFLAGS      = -Os -fno-strict-aliasing -fno-tree-loop-distribute-patterns
++OPTIMFLAGS      = -Os -fno-strict-aliasing -ffreestanding -nostdinc -isystem $(CPPINCLUDEDIR) -isystem $(EPREFIX)/usr/include $(EXTRACFLAGS)
+ CFLAGS          = $(OPTIMFLAGS) -fno-stack-protector -fshort-wchar -Wall
+ 
+ # ...for GNU-EFI....
+@@ -168,7 +168,7 @@
+   SUBSYSTEM_LDFLAG = -defsym=EFI_SUBSYSTEM=0xa
+   LDFLAGS         += --warn-common --no-undefined --fatal-warnings
+ 
+-  ARCH_CFLAGS = -fno-merge-constants -ffreestanding -DEFIAARCH64
++  ARCH_CFLAGS = -fno-merge-constants -ffreestanding -DEFIAARCH64 -nostdinc -isystem $(CPPINCLUDEDIR) -isystem $(EPREFIX)/usr/include $(EXTRACFLAGS)
+   ifeq ($(MAKEWITH),TIANO)
+     ARCH_CFLAGS += -mcmodel=large -Wno-address -Wno-missing-braces -Wno-array-bounds -ffunction-sections -fdata-sections
+   endif
+--- a/libeg/lodepng.h
++++ b/libeg/lodepng.h
+@@ -32,6 +32,7 @@
+ #ifndef LODEPNG_H
+ #define LODEPNG_H
+ 
++#include <stddef.h>
+ #include <string.h> /*for size_t*/
+ 
+ // Below block of lines required for GNU-EFI and TianoCore (program hangs
+--- a/libeg/nanojpeg.c
++++ b/libeg/nanojpeg.c
+@@ -211,6 +211,7 @@
+ 
+ #ifdef  _NJ_EXAMPLE_PROGRAM
+ 
++#include <stddef.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>
+@@ -275,6 +276,7 @@
+ #endif
+ 
+ #if NJ_USE_LIBC
++    #include <stddef.h>
+     #include <stdlib.h>
+     #include <string.h>
+     #define njAllocMem malloc

--- a/sys-boot/refind/refind-0.14.2-r2.ebuild
+++ b/sys-boot/refind/refind-0.14.2-r2.ebuild
@@ -1,0 +1,172 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit optfeature secureboot toolchain-funcs
+
+DESCRIPTION="The UEFI Boot Manager by Rod Smith"
+HOMEPAGE="https://www.rodsbooks.com/refind/"
+SRC_URI="https://downloads.sourceforge.net/project/${PN}/${PV}/${PN}-src-${PV}.tar.gz"
+
+LICENSE="BSD CC-BY-SA-3.0 CC-BY-SA-4.0 FDL-1.3 GPL-2+ GPL-3+ LGPL-3+"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+FS_USE="btrfs +ext2 +ext4 hfs +iso9660 ntfs reiserfs"
+IUSE="${FS_USE} doc"
+
+DEPEND="sys-boot/gnu-efi"
+
+# for ld.bfd and objcopy
+BDEPEND="sys-devel/binutils"
+
+DOCS=( README.txt NEWS.txt )
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-0.14.0.2-clang.patch
+	"${FILESDIR}"/${P}-fix-gnu-efi-3.0.18.patch
+	"${FILESDIR}"/${P}-fix-freestanding-on-musl.patch
+)
+
+checktools() {
+	if [[ ${MERGE_TYPE} != "binary" ]]; then
+		# bug #832018
+		tc-export LD
+		tc-ld-force-bfd
+		# the makefile calls LD directly, so try to fix LD too
+		LD="${LD/.lld/.bfd}"
+		tc-ld-is-lld "${LD}" && die "Linking with lld produces broken executables and may lead to unbootable system"
+
+		# bug #732256
+		# llvm-objcopy does not support EFI target, try to use binutils objcopy or fail
+		tc-export OBJCOPY
+		OBJCOPY="${OBJCOPY/llvm-/}"
+		LANG=C LC_ALL=C "${OBJCOPY}" --help | grep -q '\<pei-' || die "${OBJCOPY} (objcopy) does not support EFI target"
+
+		tc-is-gcc || tc-is-clang || die "Unsupported compiler"
+	fi
+}
+
+pkg_pretend() {
+	checktools
+}
+
+pkg_setup() {
+	if use x86; then
+		export EFIARCH=ia32
+		export BUILDARCH=ia32
+	elif use amd64; then
+		export EFIARCH=x64
+		export BUILDARCH=x86_64
+	fi
+	secureboot_pkg_setup
+
+	# this does not only check, but also exports LD and OBJCOPY
+	checktools
+}
+
+src_prepare() {
+	default
+
+	# bug #598647 - PIE not supported
+	sed -e '/^CFLAGS/s/$/ -fno-PIE/' -i Make.common || die
+	sed -e '1 i\.NOTPARALLEL:' -i filesystems/Makefile || die
+
+	cp "${FILESDIR}"/refind-sbat-gentoo-${PV}.csv refind-sbat-gentoo.csv || die
+}
+
+src_compile() {
+	# Update fs targets depending on uses
+	local fs fs_names=()
+	for fs in ${FS_USE}; do
+		fs=${fs#+}
+		if use "${fs}"; then
+			fs_names+=( ${fs} )
+		fi
+	done
+	fs_names=( "${fs_names[@]/%/_gnuefi}" )
+
+	# Prepare flags
+	local make_flags=(
+		ARCH="${BUILDARCH}"
+		CC="$(tc-getCC)"
+		AS="$(tc-getAS)"
+		LD="${LD}"
+		AR="$(tc-getAR)"
+		RANLIB="$(tc-getRANLIB)"
+		OBJCOPY="${OBJCOPY}"
+		GNUEFILIB="${ESYSROOT}/usr/$(get_libdir)"
+		EFILIB="${ESYSROOT}/usr/$(get_libdir)"
+		EFICRT0="${ESYSROOT}/usr/$(get_libdir)"
+		FILESYSTEMS="${fs_names[*]}"
+		FILESYSTEMS_GNUEFI="${fs_names[*]}"
+		REFIND_SBAT_CSV=refind-sbat-gentoo.csv
+	)
+
+	# see the comments in "${FILESDIR}"/${P}-fix-freestanding-on-musl.patch
+	tc-export CC
+	if tc-is-gcc; then
+		local -x CPPINCLUDEDIR=$(LANG=C ${CC} -print-search-dirs 2> /dev/null | grep ^install: | cut -f2 -d' ')/include
+	elif tc-is-clang; then
+		local -x CPPINCLUDEDIR=$(LANG=C ${CC} -print-resource-dir 2> /dev/null)/include
+		local -x EXTRACFLAGS=-D__DEFINED_wchar_t
+	fi
+
+	emake "${make_flags[@]}" all_gnuefi
+}
+
+src_install() {
+	exeinto "/usr/$(get_libdir)/${PN}"
+	doexe refind-install
+	dosym -r "/usr/$(get_libdir)/${PN}/refind-install" "/usr/sbin/refind-install"
+
+	doman "docs/man/"*
+	use doc && DOCS+=( docs/refind docs/Styles )
+	einstalldocs
+
+	insinto "/usr/$(get_libdir)/${PN}/refind"
+	doins "refind/refind_${EFIARCH}.efi"
+	doins "refind.conf-sample"
+	doins -r images icons fonts banners
+
+	if [[ -d "drivers_${EFIARCH}" ]]; then
+		doins -r "drivers_${EFIARCH}"
+	fi
+
+	insinto "/usr/$(get_libdir)/${PN}/refind/tools_${EFIARCH}"
+	doins "gptsync/gptsync_${EFIARCH}.efi"
+
+	insinto "/etc/refind.d"
+	doins -r "keys"
+
+	dosbin "mkrlconf"
+	dosbin "mvrefind"
+	dosbin "refind-mkdefault"
+
+	secureboot_auto_sign --in-place
+}
+
+pkg_postinst() {
+	elog "rEFInd has been built and installed into ${EROOT}/usr/$(get_libdir)/${PN}"
+	elog "You will need to use the command 'refind-install' to install"
+	elog "the binaries into your EFI System Partition"
+
+	optfeature_header "refind-install requires additional packages to be fully functional:"
+	optfeature "binary signing for use with SecureBoot" app-crypt/sbsigntools
+	optfeature "writing to NVRAM" sys-boot/efibootmgr
+	optfeature "ESP management" sys-apps/gptfdisk
+	elog ""
+
+	if [[ -z "${REPLACING_VERSIONS}" ]]; then
+		elog "A sample configuration can be found at"
+		elog "${EROOT}/usr/$(get_libdir)/${PN}/refind/refind.conf-sample"
+	else
+		if ver_test "${REPLACING_VERSIONS}" -lt "0.12.0"; then
+			ewarn "This new version uses sys-apps/gptfdisk instead of sys-block/parted"
+			ewarn "to manage ESP"
+			ewarn ""
+		fi
+		ewarn "Note that this installation will not update any EFI binaries"
+		ewarn "on your EFI System Partition - this needs to be done manually"
+	fi
+}


### PR DESCRIPTION
- **sys-boot/gnu-efi: Fix compilation on musl amd64**
- **sys-boot/refind: fix build on musl**

Tested with gcc and with clang on: glibc, in a prefix, and on musl.  Also I tested refind boots (in a VM, did not try all combinations on real hardware).