### PR TITLE
sys-apps/systemd: wire up BPF support

### DIFF
--- a/profiles/arch/alpha/package.use.mask
+++ b/profiles/arch/alpha/package.use.mask
@@ -1,6 +1,10 @@
 # Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Sam James <sam@gentoo.org> (2024-08-23)
+# dev-util/bpftool and/or sys-devel/bpf-toolchain not keyworded here
+sys-apps/systemd bpf
+
 # Hans de Graaff <graaff@gentoo.org> (2024-08-16)
 # Requires large parts of dev-ruby/rails to be keyworded
 dev-ruby/minitest-hooks test

--- a/profiles/arch/hppa/package.use.mask
+++ b/profiles/arch/hppa/package.use.mask
@@ -4,6 +4,10 @@
 # NOTE: When masking a USE flag due to missing keywords, please file a keyword
 # request bug for the hppa arch.
 
+# Sam James <sam@gentoo.org> (2024-08-23)
+# dev-util/bpftool and/or sys-devel/bpf-toolchain not keyworded here
+sys-apps/systemd bpf
+
 # Ulrich Müller <ulm@gentoo.org> (2024-08-03)
 # Needs dev-libs/openspecfun which is not yet keyworded
 sci-visualization/gnuplot amos

--- a/profiles/arch/ia64/package.use.mask
+++ b/profiles/arch/ia64/package.use.mask
@@ -1,6 +1,10 @@
 # Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Sam James <sam@gentoo.org> (2024-08-23)
+# dev-util/bpftool and/or sys-devel/bpf-toolchain not keyworded here
+sys-apps/systemd bpf
+
 # Matt Jolly <kangie@gentoo.org> (2024-08-14)
 # QUIC dependencies are not keyworded
 net-misc/curl http3 quic curl_quic_openssl curl_quic_ngtcp2

--- a/profiles/arch/loong/package.use.mask
+++ b/profiles/arch/loong/package.use.mask
@@ -1,6 +1,10 @@
 # Copyright 2022-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Sam James <sam@gentoo.org> (2024-08-23)
+# dev-util/bpftool and/or sys-devel/bpf-toolchain not keyworded here
+sys-apps/systemd bpf
+
 # WANG Xuerui <xen0n@gentoo.org> (2024-08-22)
 # dev-lang/spidermonkey gained JIT support for loong since version 107,
 # but the nearest packaged version is 115.

--- a/profiles/arch/s390/package.use.mask
+++ b/profiles/arch/s390/package.use.mask
@@ -1,6 +1,10 @@
 # Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Sam James <sam@gentoo.org> (2024-08-23)
+# dev-util/bpftool and/or sys-devel/bpf-toolchain not keyworded here
+sys-apps/systemd bpf
+
 # Matt Jolly <kangie@gentoo.org> (2024-08-14)
 # QUIC dependencies are not keyworded
 net-misc/curl http3 quic curl_quic_openssl curl_quic_ngtcp2

--- a/profiles/arch/sparc/package.use.mask
+++ b/profiles/arch/sparc/package.use.mask
@@ -1,6 +1,10 @@
 # Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Sam James <sam@gentoo.org> (2024-08-23)
+# dev-util/bpftool and/or sys-devel/bpf-toolchain not keyworded here
+sys-apps/systemd bpf
+
 # Ulrich Müller <ulm@gentoo.org> (2024-08-03)
 # Needs dev-libs/openspecfun which is not yet keyworded
 sci-visualization/gnuplot amos

--- a/sys-apps/systemd/files/256-bpf-gcc.patch
+++ b/sys-apps/systemd/files/256-bpf-gcc.patch
@@ -1,0 +1,10 @@
+--- a/meson.build
++++ b/meson.build
+@@ -1109,6 +1109,7 @@ else
+         elif bpf_compiler == 'gcc'
+                 bpf_gcc = find_program('bpf-gcc',
+                                        'bpf-none-gcc',
++                                       'bpf-unknown-none-gcc',
+                                        required : true,
+                                        version : '>= 13.1.0')
+                 bpf_gcc_found = bpf_gcc.found()

--- a/sys-apps/systemd/metadata.xml
+++ b/sys-apps/systemd/metadata.xml
@@ -11,6 +11,7 @@
 	<use>
 		<flag name="audit">Enable support for <pkg>sys-process/audit</pkg></flag>
 		<flag name="boot">Enable EFI boot manager and stub loader</flag>
+		<flag name="bpf">Enable BPF support for sandboxing and firewalling.</flag>
 		<flag name="cgroup-hybrid">Default to hybrid (legacy) cgroup hierarchy instead of unified (modern).</flag>
 		<flag name="curl">Enable support for uploading journals</flag>
 		<flag name="cryptsetup">Enable cryptsetup tools (includes unit generator for crypttab)</flag>

--- a/sys-apps/systemd/systemd-256.5.ebuild
+++ b/sys-apps/systemd/systemd-256.5.ebuild
@@ -33,7 +33,7 @@ HOMEPAGE="https://systemd.io/"
 LICENSE="GPL-2 LGPL-2.1 MIT public-domain"
 SLOT="0/2"
 IUSE="
-	acl apparmor audit boot cgroup-hybrid cryptsetup curl +dns-over-tls elfutils
+	acl apparmor audit boot bpf cgroup-hybrid cryptsetup curl +dns-over-tls elfutils
 	fido2 +gcrypt gnutls homed http idn importd iptables +kernel-install +kmod
 	+lz4 lzma +openssl pam pcre pkcs11 policykit pwquality qrcode
 	+resolvconf +seccomp selinux split-usr +sysv-utils test tpm ukify vanilla xkb +zstd
@@ -158,6 +158,10 @@ BDEPEND="
 	>=sys-apps/coreutils-8.16
 	sys-devel/gettext
 	virtual/pkgconfig
+	bpf? (
+		dev-util/bpftool
+		sys-devel/bpf-toolchain
+	)
 	test? (
 		app-text/tree
 		dev-lang/perl
@@ -223,6 +227,7 @@ pkg_pretend() {
 			~!SYSFS_DEPRECATED_V2"
 
 		use acl && CONFIG_CHECK+=" ~TMPFS_POSIX_ACL"
+		use bpf && CONFIG_CHECK+=" ~BPF ~BPF_SYSCALL ~BPF_LSM ~DEBUG_INFO_BTF"
 		use seccomp && CONFIG_CHECK+=" ~SECCOMP ~SECCOMP_FILTER"
 
 		if kernel_is -ge 5 10 20; then
@@ -268,6 +273,7 @@ src_unpack() {
 src_prepare() {
 	local PATCHES=(
 		"${FILESDIR}/systemd-test-process-util.patch"
+		"${FILESDIR}/256-bpf-gcc.patch"
 	)
 
 	if ! use vanilla; then
@@ -311,6 +317,8 @@ multilib_src_configure() {
 		$(meson_native_use_bool apparmor)
 		$(meson_native_use_bool audit)
 		$(meson_native_use_bool boot bootloader)
+		$(meson_native_use_bool bpf bpf-framework)
+		-Dbpf-compiler=gcc
 		$(meson_native_use_bool cryptsetup libcryptsetup)
 		$(meson_native_use_bool curl libcurl)
 		$(meson_native_use_bool dns-over-tls dns-over-tls)

--- a/sys-apps/systemd/systemd-9999.ebuild
+++ b/sys-apps/systemd/systemd-9999.ebuild
@@ -33,7 +33,7 @@ HOMEPAGE="https://systemd.io/"
 LICENSE="GPL-2 LGPL-2.1 MIT public-domain"
 SLOT="0/2"
 IUSE="
-	acl apparmor audit boot cgroup-hybrid cryptsetup curl +dns-over-tls elfutils
+	acl apparmor audit boot bpf cgroup-hybrid cryptsetup curl +dns-over-tls elfutils
 	fido2 +gcrypt gnutls homed http idn importd iptables +kernel-install +kmod
 	+lz4 lzma +openssl pam pcre pkcs11 policykit pwquality qrcode
 	+resolvconf +seccomp selinux split-usr +sysv-utils test tpm ukify vanilla xkb +zstd
@@ -158,6 +158,10 @@ BDEPEND="
 	>=sys-apps/coreutils-8.16
 	sys-devel/gettext
 	virtual/pkgconfig
+	bpf? (
+		dev-util/bpftool
+		sys-devel/bpf-toolchain
+	)
 	test? (
 		app-text/tree
 		dev-lang/perl
@@ -223,6 +227,7 @@ pkg_pretend() {
 			~!SYSFS_DEPRECATED_V2"
 
 		use acl && CONFIG_CHECK+=" ~TMPFS_POSIX_ACL"
+		use bpf && CONFIG_CHECK+=" ~BPF ~BPF_SYSCALL ~BPF_LSM ~DEBUG_INFO_BTF"
 		use seccomp && CONFIG_CHECK+=" ~SECCOMP ~SECCOMP_FILTER"
 
 		if kernel_is -ge 5 10 20; then
@@ -268,6 +273,7 @@ src_unpack() {
 src_prepare() {
 	local PATCHES=(
 		"${FILESDIR}/systemd-test-process-util.patch"
+		"${FILESDIR}/256-bpf-gcc.patch"
 	)
 
 	if ! use vanilla; then
@@ -311,6 +317,8 @@ multilib_src_configure() {
 		$(meson_native_use_bool apparmor)
 		$(meson_native_use_bool audit)
 		$(meson_native_use_bool boot bootloader)
+		$(meson_native_use_bool bpf bpf-framework)
+		-Dbpf-compiler=gcc
 		$(meson_native_use_bool cryptsetup libcryptsetup)
 		$(meson_native_use_bool curl libcurl)
 		$(meson_native_use_bool dns-over-tls dns-over-tls)


### PR DESCRIPTION
TODO:
* Send the patch upstream (we could use a cross file but we should upstream this anyway, especially as Fedora is using the same tuple)
* Clang support?

Bug: https://bugs.gentoo.org/917228

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
