### PR TITLE
dev-util/bpftool: relax binutils-libs dependency, do not USE=llvm by default

### DIFF
--- a/dev-util/bpftool/bpftool-7.5.0-r1.ebuild
+++ b/dev-util/bpftool/bpftool-7.5.0-r1.ebuild
@@ -27,14 +27,14 @@ S="${S_K}/tools/bpf/bpftool"
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~amd64 ~arm ~arm64 ~loong ~ppc ~ppc64 ~riscv ~x86"
-IUSE="caps +llvm"
+IUSE="caps llvm"
 
 RDEPEND="
-	sys-libs/binutils-libs:=
 	sys-libs/zlib:=
 	virtual/libelf:=
 	caps? ( sys-libs/libcap:= )
 	llvm? ( sys-devel/llvm:= )
+	!llvm? ( sys-libs/binutils-libs:= )
 "
 DEPEND="
 	${RDEPEND}


### PR DESCRIPTION

Discussion on IRC found that the binutils-libs dependency can be relaxed and that default-enabling llvm is also not really necessary. This should help with the adoption of sys-devel/bpf-toolchain.

Closes: https://bugs.gentoo.org/938347

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
