### PR TITLE
media-video/obs-studio: Fix compilation on GCC 15

### DIFF
--- a/media-video/obs-studio/files/json11-1.0.0-include-cstdint.patch
+++ b/media-video/obs-studio/files/json11-1.0.0-include-cstdint.patch
@@ -1,0 +1,12 @@
+diff --git a/json11.cpp b/json11.cpp
+index 9647846..8266a14 100644
+--- a/json11.cpp
++++ b/json11.cpp
+@@ -22,6 +22,7 @@
+ #include "json11.hpp"
+ #include <cassert>
+ #include <cmath>
++#include <cstdint>
+ #include <cstdlib>
+ #include <cstdio>
+ #include <limits>

--- a/media-video/obs-studio/obs-studio-30.2.3.ebuild
+++ b/media-video/obs-studio/obs-studio-30.2.3.ebuild
@@ -183,6 +183,10 @@ src_prepare() {
 	use wayland && filter-lto
 
 	cmake_src_prepare
+
+	pushd deps/json11 &> /dev/null || die
+		eapply "${FILESDIR}/json11-1.0.0-include-cstdint.patch"
+	popd &> /dev/null || die
 }
 
 src_configure() {

--- a/media-video/obs-studio/obs-studio-9999.ebuild
+++ b/media-video/obs-studio/obs-studio-9999.ebuild
@@ -185,6 +185,10 @@ src_prepare() {
 	use wayland && filter-lto
 
 	cmake_src_prepare
+
+	pushd deps/json11 &> /dev/null || die
+		eapply "${FILESDIR}/json11-1.0.0-include-cstdint.patch"
+	popd &> /dev/null || die
 }
 
 src_configure() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/938326

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
