### PR TITLE
net-misc/tinyssh: fix include path to sodium

### DIFF
--- a/net-misc/tinyssh/tinyssh-20240101-r2.ebuild
+++ b/net-misc/tinyssh/tinyssh-20240101-r2.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 inherit systemd toolchain-funcs
 
@@ -46,10 +46,11 @@ src_compile() {
 
 	if use sodium
 	then
+		# -I${includedir}/sodium needed as tinyssh uses `#include "crypto_auth_hmacsha256.h"` rather than `#include <sodium.h>`
 		emake \
 			CC="$(tc-getCC)" \
 			LIBS="$("${PKG_CONFIG}" --libs libsodium)" \
-			CFLAGS="${CFLAGS} $("${PKG_CONFIG}" --cflags libsodium)" \
+			CFLAGS="${CFLAGS} $("${PKG_CONFIG}" --cflags libsodium) -I$("${PKG_CONFIG}" --variable=includedir libsodium)/sodium/" \
 			LDFLAGS="${LDFLAGS}"
 	else
 		emake CC="$(tc-getCC)"

--- a/net-misc/tinyssh/tinyssh-99999999.ebuild
+++ b/net-misc/tinyssh/tinyssh-99999999.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 inherit systemd toolchain-funcs
 
@@ -45,10 +45,11 @@ src_compile() {
 
 	if use sodium
 	then
+		# -I${includedir}/sodium needed as tinyssh uses `#include "crypto_auth_hmacsha256.h"` rather than `#include <sodium.h>`
 		emake \
 			CC="$(tc-getCC)" \
 			LIBS="$("${PKG_CONFIG}" --libs libsodium)" \
-			CFLAGS="${CFLAGS} $("${PKG_CONFIG}" --cflags libsodium)" \
+			CFLAGS="${CFLAGS} $("${PKG_CONFIG}" --cflags libsodium) -I$("${PKG_CONFIG}" --variable=includedir libsodium)/sodium/" \
 			LDFLAGS="${LDFLAGS}"
 	else
 		emake CC="$(tc-getCC)"

--- a/net-misc/tinyssh/tinyssh-99999999.ebuild
+++ b/net-misc/tinyssh/tinyssh-99999999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -28,10 +28,11 @@ RDEPEND="
 	sys-apps/ucspi-tcp
 "
 
-src_prepare() {
-	# Leave optimization level to user CFLAGS
-	sed -i 's/-Os -fomit-frame-pointer -funroll-loops//g' ./conf-cc || die
+PATCHES=(
+	"${FILESDIR}/tinyssh-20240101_conf_cflags.patch"
+)
 
+src_prepare() {
 	# Use make-tinysshcc.sh script, which has no tests and doesn't execute
 	# binaries. See https://github.com/janmojzis/tinyssh/issues/2
 	sed -i 's/make-tinyssh\.sh/make-tinysshcc.sh/g' ./Makefile || die


### PR DESCRIPTION
<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
