### PR TITLE
*/*: use `https://` instead of `git://` for cloning 

### DIFF
--- a/app-mobilephone/dfu-util/dfu-util-0.11.ebuild
+++ b/app-mobilephone/dfu-util/dfu-util-0.11.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 if [[ ${PV} == *9999 ]] ; then
-	EGIT_REPO_URI="git://git.code.sf.net/p/dfu-util/dfu-util"
+	EGIT_REPO_URI="https://git.code.sf.net/p/dfu-util/dfu-util"
 	inherit autotools git-r3
 else
 	SRC_URI="https://downloads.sourceforge.net/${PN}/${P}.tar.gz"

--- a/app-mobilephone/dfu-util/dfu-util-9999.ebuild
+++ b/app-mobilephone/dfu-util/dfu-util-9999.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 if [[ ${PV} == *9999 ]] ; then
-	EGIT_REPO_URI="git://git.code.sf.net/p/dfu-util/dfu-util"
+	EGIT_REPO_URI="https://git.code.sf.net/p/dfu-util/dfu-util"
 	inherit autotools git-r3
 else
 	SRC_URI="https://downloads.sourceforge.net/${PN}/${P}.tar.gz"

--- a/dev-embedded/urjtag/urjtag-2021.03.ebuild
+++ b/dev-embedded/urjtag/urjtag-2021.03.ebuild
@@ -8,16 +8,16 @@ PYTHON_COMPAT=( python3_{10..12} )
 inherit python-r1
 
 if [[ ${PV} == "9999" ]] ; then
-	EGIT_REPO_URI="git://git.code.sf.net/p/urjtag/git"
+	EGIT_REPO_URI="https://git.code.sf.net/p/urjtag/git"
 	inherit git-r3 autotools
 	S="${WORKDIR}/${P}/${PN}"
 else
-	SRC_URI="https://downloads.sourceforge.net/urjtag/${P}.tar.xz"
+	SRC_URI="https://downloads.sourceforge.net/project/${PN}/${PN}/${PV}/${P}.tar.xz"
 	KEYWORDS="amd64 ppc sparc x86"
 fi
 
 DESCRIPTION="Tool for communicating over JTAG with flash chips, CPUs, and many more"
-HOMEPAGE="https://urjtag.sourceforge.net/"
+HOMEPAGE="https://urjtag.sourceforge.io/"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/dev-embedded/urjtag/urjtag-9999.ebuild
+++ b/dev-embedded/urjtag/urjtag-9999.ebuild
@@ -8,7 +8,7 @@ PYTHON_COMPAT=( python3_{10..12} )
 inherit python-r1
 
 if [[ ${PV} == "9999" ]] ; then
-	EGIT_REPO_URI="git://git.code.sf.net/p/urjtag/git"
+	EGIT_REPO_URI="https://git.code.sf.net/p/urjtag/git"
 	inherit git-r3 autotools
 	S="${WORKDIR}/${P}/${PN}"
 else
@@ -17,7 +17,7 @@ else
 fi
 
 DESCRIPTION="Tool for communicating over JTAG with flash chips, CPUs, and many more"
-HOMEPAGE="https://urjtag.sourceforge.net/"
+HOMEPAGE="https://urjtag.sourceforge.io/"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/net-libs/libosmo-dsp/libosmo-dsp-0.4.0.ebuild
+++ b/net-libs/libosmo-dsp/libosmo-dsp-0.4.0.ebuild
@@ -5,12 +5,12 @@ EAPI=7
 
 inherit autotools
 
-DESCRIPTION="A library with SDR DSP primitives"
-HOMEPAGE="http://git.osmocom.org/libosmo-dsp/"
+DESCRIPTION="Library with SDR DSP primitives"
+HOMEPAGE="https://gitea.osmocom.org/sdr/libosmo-dsp/"
 
 if [[ ${PV} == 9999* ]]; then
 	inherit git-r3
-	EGIT_REPO_URI="git://git.osmocom.org/${PN}"
+	EGIT_REPO_URI="https://git.osmocom.org/${PN}"
 else
 	SRC_URI="https://dev.gentoo.org/~zerochaos/distfiles/${P}.tar.gz"
 	KEYWORDS="~amd64 ~arm ~riscv ~x86"

--- a/net-libs/libosmo-dsp/libosmo-dsp-9999.ebuild
+++ b/net-libs/libosmo-dsp/libosmo-dsp-9999.ebuild
@@ -1,16 +1,16 @@
 # Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 inherit autotools
 
-DESCRIPTION="A library with SDR DSP primitives"
-HOMEPAGE="http://git.osmocom.org/libosmo-dsp/"
+DESCRIPTION="Library with SDR DSP primitives"
+HOMEPAGE="https://gitea.osmocom.org/sdr/libosmo-dsp/"
 
 if [[ ${PV} == 9999* ]]; then
 	inherit git-r3
-	EGIT_REPO_URI="git://git.osmocom.org/${PN}"
+	EGIT_REPO_URI="https://git.osmocom.org/${PN}"
 else
 	SRC_URI="https://dev.gentoo.org/~zerochaos/distfiles/${P}.tar.xz"
 	KEYWORDS="~amd64 ~arm ~x86"


### PR DESCRIPTION
update some ebuilds to use `https://` instead of `git://` for cloning as it's more secure.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
