### PR TITLE
dev-libs/libpfm: include header for __WORDSIZE on musl

### DIFF
--- a/dev-libs/libpfm/files/libpfm-4.13.0-musl-WORDSIZE_undeclared.patch
+++ b/dev-libs/libpfm/files/libpfm-4.13.0-musl-WORDSIZE_undeclared.patch
@@ -1,0 +1,17 @@
+https://bugs.gentoo.org/935529
+
+__WORDSIZE__ is used for getting correct ABI struct sizes, its undeclared on musl unless you include the bits/reg.h header.
+
+--- a/include/perfmon/pfmlib.h    2023-03-29 02:44:33.000000000 +0300
++++ b/include/perfmon/pfmlib.h  2024-08-24 12:45:29.084265290 +0300
+@@ -38,6 +38,9 @@
+ #include <unistd.h>
+ #include <inttypes.h>
+ #include <stdio.h>
++#ifndef __GLIBC__
++#include <bits/reg.h>
++#endif
+ 
+ #define LIBPFM_VERSION         (4 << 16 | 0)
+ #define PFM_MAJ_VERSION(v)     ((v)>>16)
+

--- a/dev-libs/libpfm/libpfm-4.13.0.ebuild
+++ b/dev-libs/libpfm/libpfm-4.13.0.ebuild
@@ -14,6 +14,10 @@ SLOT="0/4"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~loong ~mips ~ppc ~ppc64 ~riscv ~sparc ~x86"
 IUSE="static-libs"
 
+PATCHES=(
+	"${FILESDIR}"/libpfm-4.13.0-musl-WORDSIZE_undeclared.patch
+)
+
 src_prepare() {
 	default
 
@@ -29,8 +33,7 @@ src_compile() {
 }
 
 src_test() {
-	cd tests || die
-	./validate || die
+	./tests/validate -A || die
 }
 
 src_install() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/935529

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
