### PR TITLE
dev-libs/libtrace{cmd,fs,event}: fix HOMEPAGE, use https:// instead of git:// for cloning

### DIFF
--- a/dev-libs/libtracecmd/libtracecmd-1.5.1.ebuild
+++ b/dev-libs/libtracecmd/libtracecmd-1.5.1.ebuild
@@ -6,10 +6,10 @@ EAPI=8
 inherit meson
 
 DESCRIPTION="Linux kernel tracecmd library"
-HOMEPAGE="https://git.kernel.org/pub/scm/libs/trace-cmd/trace-cmd.git/"
+HOMEPAGE="https://www.trace-cmd.org/"
 
 if [[ ${PV} =~ [9]{4,} ]]; then
-	EGIT_REPO_URI="git://git.kernel.org/pub/scm/utils/trace-cmd/trace-cmd.git/"
+	EGIT_REPO_URI="https://git.kernel.org/pub/scm/utils/trace-cmd/trace-cmd.git/"
 	inherit git-r3
 else
 	SRC_URI="https://git.kernel.org/pub/scm/utils/trace-cmd/trace-cmd.git/snapshot/trace-cmd-${P}.tar.gz -> ${P}.tar.gz"

--- a/dev-libs/libtracecmd/libtracecmd-1.5.2.ebuild
+++ b/dev-libs/libtracecmd/libtracecmd-1.5.2.ebuild
@@ -6,10 +6,10 @@ EAPI=8
 inherit meson
 
 DESCRIPTION="Linux kernel tracecmd library"
-HOMEPAGE="https://git.kernel.org/pub/scm/libs/trace-cmd/trace-cmd.git/"
+HOMEPAGE="https://www.trace-cmd.org/"
 
 if [[ ${PV} =~ [9]{4,} ]]; then
-	EGIT_REPO_URI="git://git.kernel.org/pub/scm/utils/trace-cmd/trace-cmd.git/"
+	EGIT_REPO_URI="https://git.kernel.org/pub/scm/utils/trace-cmd/trace-cmd.git/"
 	inherit git-r3
 else
 	SRC_URI="https://git.kernel.org/pub/scm/utils/trace-cmd/trace-cmd.git/snapshot/trace-cmd-${P}.tar.gz -> ${P}.tar.gz"

--- a/dev-libs/libtraceevent/libtraceevent-1.7.3.ebuild
+++ b/dev-libs/libtraceevent/libtraceevent-1.7.3.ebuild
@@ -6,10 +6,10 @@ EAPI=8
 inherit meson
 
 DESCRIPTION="Linux kernel trace event library"
-HOMEPAGE="https://git.kernel.org/pub/scm/libs/libtrace/libtraceevent.git/"
+HOMEPAGE="https://www.trace-cmd.org/"
 
 if [[ ${PV} =~ [9]{4,} ]]; then
-	EGIT_REPO_URI="git://git.kernel.org/pub/scm/libs/libtrace/libtraceevent.git/"
+	EGIT_REPO_URI="https://git.kernel.org/pub/scm/libs/libtrace/libtraceevent.git/"
 	inherit git-r3
 else
 	SRC_URI="https://git.kernel.org/pub/scm/libs/libtrace/libtraceevent.git/snapshot/${P}.tar.gz"

--- a/dev-libs/libtraceevent/libtraceevent-1.8.2.ebuild
+++ b/dev-libs/libtraceevent/libtraceevent-1.8.2.ebuild
@@ -6,10 +6,10 @@ EAPI=8
 inherit meson
 
 DESCRIPTION="Linux kernel trace event library"
-HOMEPAGE="https://git.kernel.org/pub/scm/libs/libtrace/libtraceevent.git/"
+HOMEPAGE="https://www.trace-cmd.org/"
 
 if [[ ${PV} =~ [9]{4,} ]]; then
-	EGIT_REPO_URI="git://git.kernel.org/pub/scm/libs/libtrace/libtraceevent.git/"
+	EGIT_REPO_URI="https://git.kernel.org/pub/scm/libs/libtrace/libtraceevent.git/"
 	inherit git-r3
 else
 	SRC_URI="https://git.kernel.org/pub/scm/libs/libtrace/libtraceevent.git/snapshot/${P}.tar.gz"

--- a/dev-libs/libtraceevent/libtraceevent-1.8.3.ebuild
+++ b/dev-libs/libtraceevent/libtraceevent-1.8.3.ebuild
@@ -6,10 +6,10 @@ EAPI=8
 inherit meson
 
 DESCRIPTION="Linux kernel trace event library"
-HOMEPAGE="https://git.kernel.org/pub/scm/libs/libtrace/libtraceevent.git/"
+HOMEPAGE="https://www.trace-cmd.org/"
 
 if [[ ${PV} =~ [9]{4,} ]]; then
-	EGIT_REPO_URI="git://git.kernel.org/pub/scm/libs/libtrace/libtraceevent.git/"
+	EGIT_REPO_URI="https://git.kernel.org/pub/scm/libs/libtrace/libtraceevent.git/"
 	inherit git-r3
 else
 	SRC_URI="https://git.kernel.org/pub/scm/libs/libtrace/libtraceevent.git/snapshot/${P}.tar.gz"

--- a/dev-libs/libtracefs/libtracefs-1.7.0.ebuild
+++ b/dev-libs/libtracefs/libtracefs-1.7.0.ebuild
@@ -6,10 +6,10 @@ EAPI=8
 inherit meson
 
 DESCRIPTION="Linux kernel trace file system library"
-HOMEPAGE="https://git.kernel.org/pub/scm/libs/libtrace/libtracefs.git/"
+HOMEPAGE="https://www.trace-cmd.org/"
 
 if [[ ${PV} =~ [9]{4,} ]]; then
-	EGIT_REPO_URI="git://git.kernel.org/pub/scm/libs/libtrace/libtracefs.git/"
+	EGIT_REPO_URI="https://git.kernel.org/pub/scm/libs/libtrace/libtracefs.git/"
 	inherit git-r3
 else
 	SRC_URI="https://git.kernel.org/pub/scm/libs/libtrace/libtracefs.git/snapshot/${P}.tar.gz"

--- a/dev-libs/libtracefs/libtracefs-1.8.0.ebuild
+++ b/dev-libs/libtracefs/libtracefs-1.8.0.ebuild
@@ -6,10 +6,10 @@ EAPI=8
 inherit meson
 
 DESCRIPTION="Linux kernel trace file system library"
-HOMEPAGE="https://git.kernel.org/pub/scm/libs/libtrace/libtracefs.git/"
+HOMEPAGE="https://www.trace-cmd.org/"
 
 if [[ ${PV} =~ [9]{4,} ]]; then
-	EGIT_REPO_URI="git://git.kernel.org/pub/scm/libs/libtrace/libtracefs.git/"
+	EGIT_REPO_URI="https://git.kernel.org/pub/scm/libs/libtrace/libtracefs.git/"
 	inherit git-r3
 else
 	SRC_URI="https://git.kernel.org/pub/scm/libs/libtrace/libtracefs.git/snapshot/${P}.tar.gz"

--- a/dev-libs/libtracefs/libtracefs-1.8.1.ebuild
+++ b/dev-libs/libtracefs/libtracefs-1.8.1.ebuild
@@ -6,10 +6,10 @@ EAPI=8
 inherit meson
 
 DESCRIPTION="Linux kernel trace file system library"
-HOMEPAGE="https://git.kernel.org/pub/scm/libs/libtrace/libtracefs.git/"
+HOMEPAGE="https://www.trace-cmd.org/"
 
 if [[ ${PV} =~ [9]{4,} ]]; then
-	EGIT_REPO_URI="git://git.kernel.org/pub/scm/libs/libtrace/libtracefs.git/"
+	EGIT_REPO_URI="https://git.kernel.org/pub/scm/libs/libtrace/libtracefs.git/"
 	inherit git-r3
 else
 	SRC_URI="https://git.kernel.org/pub/scm/libs/libtrace/libtracefs.git/snapshot/${P}.tar.gz"


### PR DESCRIPTION
Updates `HOMEPAGE` and uses https:// instead of git:// for cloning

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
