### PR TITLE
app-emulation/virt-firmware: Add "noshim" USE flag for disabling shim checking

### DIFF
--- a/app-emulation/virt-firmware/files/no_shim_check.patch
+++ b/app-emulation/virt-firmware/files/no_shim_check.patch
@@ -1,0 +1,14 @@
+diff --git a/virt/firmware/bootcfg/main.py b/virt/firmware/bootcfg/main.py
+index 7294efa..32302da 100644
+--- a/virt/firmware/bootcfg/main.py
++++ b/virt/firmware/bootcfg/main.py
+@@ -80,9 +80,6 @@ def create_boot_entry(efiuki, options):
+ 
+ 
+ def add_uki(cfg, options):
+-    if not options.shim and not firmware_loads_efi_binary(cfg, options.adduki):
+-        logging.error('shim binary needed but not found or specified')
+-        sys.exit(1)
+     if not options.title:
+         logging.error('entry title not specified')
+         sys.exit(1)

--- a/app-emulation/virt-firmware/metadata.xml
+++ b/app-emulation/virt-firmware/metadata.xml
@@ -12,6 +12,13 @@
     Variable stores (OVMF_VARS.fd) can be modified, for example to enroll
     secure boot certificates.
   </longdescription>
+  <use>
+    <flag name="noshim">
+      Completely disables checking for <pkg>sys-boot/shim</pkg> in your
+      EFI; useful when you want to use <pkg>sys-kernel/installkernel</pkg>
+      with the efistub USE flag.
+    </flag>
+  </use>
   <upstream>
     <remote-id type="pypi">virt-firmware</remote-id>
     <remote-id type="gitlab">kraxel/virt-firmware</remote-id>

--- a/app-emulation/virt-firmware/virt-firmware-24.4.ebuild
+++ b/app-emulation/virt-firmware/virt-firmware-24.4.ebuild
@@ -18,6 +18,7 @@ HOMEPAGE="
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~amd64 ~arm ~arm64 ~x86"
+IUSE="noshim"
 
 # Currently requires files in /boot and read/write to efivars
 RESTRICT="test"
@@ -28,6 +29,13 @@ RDEPEND="
 "
 
 distutils_enable_tests unittest
+
+src_prepare() {
+	if use noshim; then
+		PATCHES+=( "${FILESDIR}"/no_shim_check.patch )
+	fi
+	default
+}
 
 python_test() {
 	eunittest tests

--- a/app-emulation/virt-firmware/virt-firmware-24.7.ebuild
+++ b/app-emulation/virt-firmware/virt-firmware-24.7.ebuild
@@ -17,6 +17,7 @@ HOMEPAGE="
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~amd64 ~arm ~arm64 ~x86"
+IUSE="noshim"
 
 RDEPEND="
 	dev-python/cryptography[${PYTHON_USEDEP}]
@@ -31,6 +32,13 @@ BDEPEND="
 "
 
 distutils_enable_tests unittest
+
+src_prepare() {
+	if use noshim; then
+		PATCHES+=( "${FILESDIR}"/no_shim_check.patch )
+	fi
+	default
+}
 
 python_test() {
 	eunittest tests


### PR DESCRIPTION
This PR adds a USE flag to disable checking for shim in virt-firmware
I made this because on my systemd UKI setup, with sys-kernel/installkernel's efistub USE flag, kernel installs resulted in
```
ERROR: shim binary needed but not found or specified
```
except shim shouldn't be needed at all if the kernel is signed.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.