### PR TITLE
media-libs/embree: add 3.14.5-r1, 4.3.1-r1 fix 938522

### DIFF
--- a/media-libs/embree/embree-3.13.5-r1.ebuild
+++ b/media-libs/embree/embree-3.13.5-r1.ebuild
@@ -38,6 +38,7 @@ DOCS=( CHANGELOG.md README.md readme.pdf )
 PATCHES=(
 	"${FILESDIR}"/${PN}-3.13.5-fix-openimageio-test.patch
 	"${FILESDIR}"/${PN}-3.13.5-fix-arm64.patch
+	"${FILESDIR}/${PN}-4.3.2-fix-output-operator.patch"
 )
 
 pkg_setup() {

--- a/media-libs/embree/embree-4.3.1-r1.ebuild
+++ b/media-libs/embree/embree-4.3.1-r1.ebuild
@@ -34,6 +34,7 @@ DOCS=( CHANGELOG.md README.md readme.pdf )
 
 PATCHES=(
 	"${FILESDIR}/embree-4.3.1-dont-install-tutorials.patch"
+	"${FILESDIR}/${PN}-4.3.2-fix-output-operator.patch"
 )
 
 pkg_setup() {

--- a/media-libs/embree/files/embree-4.3.2-fix-output-operator.patch
+++ b/media-libs/embree/files/embree-4.3.2-fix-output-operator.patch
@@ -1,0 +1,43 @@
+https://github.com/RenderKit/embree/commit/cda4cf1919bb2a748e78915fbd6e421a1056638d.patch
+https://bugs.gentoo.org/938522
+https://bugs.gentoo.org/937275
+
+From cda4cf1919bb2a748e78915fbd6e421a1056638d Mon Sep 17 00:00:00 2001
+From: Daniel Opitz <daniel.opitz@intel.com>
+Date: Mon, 13 May 2024 10:17:51 +0200
+Subject: [PATCH] fix output operator, issue #486
+
+---
+ kernels/geometry/pointi.h     | 4 ++--
+ kernels/subdiv/bezier_curve.h | 2 +-
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/kernels/geometry/pointi.h b/kernels/geometry/pointi.h
+index f81edb9035..aba8ec4ab3 100644
+--- a/kernels/geometry/pointi.h
++++ b/kernels/geometry/pointi.h
+@@ -210,9 +210,9 @@ namespace embree
+     };
+ 
+     /*! output operator */
+-    friend __forceinline embree_ostream operator<<(embree_ostream cout, const PointMi& line)
++    friend __forceinline embree_ostream operator<<(embree_ostream cout, const PointMi& point)
+     {
+-      return cout << "Line" << M << "i {" << line.v0 << ", " << line.geomID() << ", " << line.primID() << "}";
++      return cout << "Point" << M << "i {" << point.geomID() << ", " << point.primID() << "}";
+     }
+ 
+    public:
+diff --git a/kernels/subdiv/bezier_curve.h b/kernels/subdiv/bezier_curve.h
+index 257e0afd40..5e3b5c83b3 100644
+--- a/kernels/subdiv/bezier_curve.h
++++ b/kernels/subdiv/bezier_curve.h
+@@ -135,7 +135,7 @@ namespace embree
+       }
+       
+       friend embree_ostream operator<<(embree_ostream cout, const QuadraticBezierCurve& a) {
+-        return cout << "QuadraticBezierCurve ( (" << a.u.lower << ", " << a.u.upper << "), " << a.v0 << ", " << a.v1 << ", " << a.v2 << ")";
++        return cout << "QuadraticBezierCurve (" << a.v0 << ", " << a.v1 << ", " << a.v2 << ")";
+       }
+     };
+   


### PR DESCRIPTION
Fixed upstream in 4.3.3

Bug: https://bugs.gentoo.org/937275
Closes: https://bugs.gentoo.org/938522

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
