### PR TITLE
media-sound/vmpk: force QT5

### DIFF
--- a/media-sound/vmpk/vmpk-0.8.7.ebuild
+++ b/media-sound/vmpk/vmpk-0.8.7.ebuild
@@ -40,6 +40,7 @@ src_prepare() {
 src_configure() {
 	local mycmakeargs=(
 		-DENABLE_DBUS=$(usex dbus)
+		-DUSE_QT=5
 	)
 	cmake_src_configure
 }


### PR DESCRIPTION
QT6 support seems broken, so explicitly use QT5 for build. This also matches the QT5 dependencies already present.
This should fix the linker errors on systems with QT6 installed.

Bug: https://bugs.gentoo.org/937561

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
