### PR TITLE
app-dicts/freedict-*: EAPI8 bump, add missing remote-id

### DIFF
--- a/app-dicts/freedict-deu-eng/freedict-deu-eng-1.0.ebuild
+++ b/app-dicts/freedict-deu-eng/freedict-deu-eng-1.0.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 inherit freedict
 

--- a/app-dicts/freedict-deu-eng/metadata.xml
+++ b/app-dicts/freedict-deu-eng/metadata.xml
@@ -4,5 +4,7 @@
 	<!-- maintainer-needed -->
 	<upstream>
 		<remote-id type="sourceforge">freedict</remote-id>
+		<remote-id type="github">freedict/fd-dictionaries</remote-id>
 	</upstream>
+	<stabilize-allarches/>
 </pkgmetadata>

--- a/app-dicts/freedict-eng-fra/freedict-eng-fra-1.0.ebuild
+++ b/app-dicts/freedict-eng-fra/freedict-eng-fra-1.0.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 inherit freedict
 

--- a/app-dicts/freedict-eng-fra/metadata.xml
+++ b/app-dicts/freedict-eng-fra/metadata.xml
@@ -4,5 +4,7 @@
 	<!-- maintainer-needed -->
 	<upstream>
 		<remote-id type="sourceforge">freedict</remote-id>
+		<remote-id type="github">freedict/fd-dictionaries</remote-id>
 	</upstream>
+	<stabilize-allarches/>
 </pkgmetadata>

--- a/app-dicts/freedict-eng-ita/freedict-eng-ita-1.0.ebuild
+++ b/app-dicts/freedict-eng-ita/freedict-eng-ita-1.0.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 inherit freedict
 

--- a/app-dicts/freedict-eng-ita/metadata.xml
+++ b/app-dicts/freedict-eng-ita/metadata.xml
@@ -4,5 +4,7 @@
 	<!-- maintainer-needed -->
 	<upstream>
 		<remote-id type="sourceforge">freedict</remote-id>
+		<remote-id type="github">freedict/fd-dictionaries</remote-id>
 	</upstream>
+	<stabilize-allarches/>
 </pkgmetadata>

--- a/app-dicts/freedict-eng-swe/freedict-eng-swe-1.0.ebuild
+++ b/app-dicts/freedict-eng-swe/freedict-eng-swe-1.0.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 inherit freedict
 

--- a/app-dicts/freedict-eng-swe/metadata.xml
+++ b/app-dicts/freedict-eng-swe/metadata.xml
@@ -4,5 +4,7 @@
 	<!-- maintainer-needed -->
 	<upstream>
 		<remote-id type="sourceforge">freedict</remote-id>
+		<remote-id type="github">freedict/fd-dictionaries</remote-id>
 	</upstream>
+	<stabilize-allarches/>
 </pkgmetadata>

--- a/app-dicts/freedict-fra-eng/freedict-fra-eng-1.0.ebuild
+++ b/app-dicts/freedict-fra-eng/freedict-fra-eng-1.0.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 inherit freedict
 

--- a/app-dicts/freedict-fra-eng/metadata.xml
+++ b/app-dicts/freedict-fra-eng/metadata.xml
@@ -4,5 +4,7 @@
 	<!-- maintainer-needed -->
 	<upstream>
 		<remote-id type="sourceforge">freedict</remote-id>
+		<remote-id type="github">freedict/fd-dictionaries</remote-id>
 	</upstream>
+	<stabilize-allarches/>
 </pkgmetadata>

--- a/app-dicts/freedict-ita-eng/freedict-ita-eng-1.0.ebuild
+++ b/app-dicts/freedict-ita-eng/freedict-ita-eng-1.0.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 inherit freedict
 

--- a/app-dicts/freedict-ita-eng/metadata.xml
+++ b/app-dicts/freedict-ita-eng/metadata.xml
@@ -4,5 +4,7 @@
 	<!-- maintainer-needed -->
 	<upstream>
 		<remote-id type="sourceforge">freedict</remote-id>
+		<remote-id type="github">freedict/fd-dictionaries</remote-id>
 	</upstream>
+	<stabilize-allarches/>
 </pkgmetadata>


### PR DESCRIPTION
This PR updates all freedict ebuilds to `EAPI=8`. There are basically no other changes and since the ebuilds doesn't compile anything i've also kept the `KEYWORDS`.
Also, i'm wondering, since these ebuilds doesn't compile anything, if we should also add `<stabilize-allarches/>`?

Any thoughts?

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
