### PR TITLE
www-servers/nginx: add patch for http_security from upstream

### DIFF
--- a/www-servers/nginx/files/http_security-nginx-1.26.2.patch
+++ b/www-servers/nginx/files/http_security-nginx-1.26.2.patch
@@ -1,0 +1,26 @@
+From 7d37ace7431ea9704faa98f29876bcd72ef4b1ff Mon Sep 17 00:00:00 2001
+From: Ervin Hegedus <airween@gmail.com>
+Date: Tue, 23 Apr 2024 21:42:02 +0200
+Subject: [PATCH] fix: Added missing header for conftest
+
+---
+ config | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/config b/config
+index c6e7467..3bf06a8 100644
+--- a/config
++++ b/config
+@@ -10,7 +10,8 @@
+ 
+ ngx_feature_name=
+ ngx_feature_run=no
+-ngx_feature_incs="#include <modsecurity/modsecurity.h>"
++ngx_feature_incs="#include <modsecurity/modsecurity.h>
++#include <stdio.h>"
+ ngx_feature_libs="-lmodsecurity"
+ ngx_feature_test='printf("hello");'
+ ngx_modsecurity_opt_I=
+-- 
+2.26.2
+

--- a/www-servers/nginx/nginx-1.26.2-r2.ebuild
+++ b/www-servers/nginx/nginx-1.26.2-r2.ebuild
@@ -219,8 +219,8 @@ LICENSE="BSD-2 BSD SSLeay MIT GPL-2 GPL-2+
 	nginx_modules_http_security? ( Apache-2.0 )
 	nginx_modules_http_push_stream? ( GPL-3 )"
 
-SLOT="mainline"
-KEYWORDS="~amd64 ~arm ~arm64 ~loong ~ppc ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux"
+SLOT="0"
+KEYWORDS="amd64 arm arm64 ~loong ~ppc ~ppc64 ~riscv x86 ~amd64-linux ~x86-linux"
 
 RESTRICT="!test? ( test )"
 
@@ -336,7 +336,7 @@ CDEPEND="
 RDEPEND="${CDEPEND}
 	app-misc/mime-types[nginx]
 	selinux? ( sec-policy/selinux-nginx )
-	!www-servers/nginx:0"
+	!www-servers/nginx:mainline"
 DEPEND="${CDEPEND}
 	arm? ( dev-libs/libatomic_ops )
 	libatomic? ( dev-libs/libatomic_ops )"
@@ -456,6 +456,12 @@ src_prepare() {
 	if use nginx_modules_http_upload_progress; then
 		cd "${HTTP_UPLOAD_PROGRESS_MODULE_WD}" || die
 		eapply "${FILESDIR}"/http_uploadprogress-nginx-1.23.0.patch
+		cd "${S}" || die
+	fi
+
+	if use nginx_modules_http_security ; then
+		cd "${HTTP_SECURITY_MODULE_WD}" || die
+		eapply "${FILESDIR}/http_security-nginx-1.26.2.patch"
 		cd "${S}" || die
 	fi
 

--- a/www-servers/nginx/nginx-1.27.1-r2.ebuild
+++ b/www-servers/nginx/nginx-1.27.1-r2.ebuild
@@ -219,8 +219,8 @@ LICENSE="BSD-2 BSD SSLeay MIT GPL-2 GPL-2+
 	nginx_modules_http_security? ( Apache-2.0 )
 	nginx_modules_http_push_stream? ( GPL-3 )"
 
-SLOT="0"
-KEYWORDS="amd64 arm arm64 ~loong ~ppc ~ppc64 ~riscv x86 ~amd64-linux ~x86-linux"
+SLOT="mainline"
+KEYWORDS="~amd64 ~arm ~arm64 ~loong ~ppc ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux"
 
 RESTRICT="!test? ( test )"
 
@@ -336,7 +336,7 @@ CDEPEND="
 RDEPEND="${CDEPEND}
 	app-misc/mime-types[nginx]
 	selinux? ( sec-policy/selinux-nginx )
-	!www-servers/nginx:mainline"
+	!www-servers/nginx:0"
 DEPEND="${CDEPEND}
 	arm? ( dev-libs/libatomic_ops )
 	libatomic? ( dev-libs/libatomic_ops )"
@@ -456,6 +456,12 @@ src_prepare() {
 	if use nginx_modules_http_upload_progress; then
 		cd "${HTTP_UPLOAD_PROGRESS_MODULE_WD}" || die
 		eapply "${FILESDIR}"/http_uploadprogress-nginx-1.23.0.patch
+		cd "${S}" || die
+	fi
+
+	if use nginx_modules_http_security ; then
+		cd "${HTTP_SECURITY_MODULE_WD}" || die
+		eapply "${FILESDIR}/http_security-nginx-1.26.2.patch"
 		cd "${S}" || die
 	fi
 


### PR DESCRIPTION
some module define nginx_feature_test as:
  nginx_feature_test='printf("hello");'

such as https://github.com/owasp-modsecurity/ModSecurity-nginx/blob/master/config#L16

which will cause following compilation error when compiling with modern
compiler (such as clang 18):

objs/autotest.c:7:5: error: call to undeclared library function 'printf' with type 'int (const char *, ...)'; ISO C99 and later do not support Implicit function declarations [-Wimplicit-function-declaration]

see also: https://github.com/nginx/nginx/pull/115

Closes: https://bugs.gentoo.org/933598

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
