### PR TITLE
 sys-kernel/*-kernel: fix applying savedconfig on alt arches

### DIFF
--- a/eclass/kernel-build.eclass
+++ b/eclass/kernel-build.eclass
@@ -243,7 +243,7 @@ kernel-build_src_configure() {
 		MAKEARGS+=( KBZIP2="lbzip2" )
 	fi
 
-	[[ -f .config ]] || die "Ebuild error: please copy default config into .config"
+	[[ -f .config ]] || die "Ebuild error: No .config, kernel-build_merge_configs was not called."
 
 	if [[ -z "${KV_LOCALVERSION}" ]]; then
 		KV_LOCALVERSION=$(sed -n -e 's#^CONFIG_LOCALVERSION="\(.*\)"$#\1#p' \
@@ -602,10 +602,13 @@ kernel-build_pkg_postinst() {
 # 3. Config saved via USE=savedconfig (if applicable).
 # 4. Module signing key specified via MODULES_SIGN_KEY* variables.
 # 5. User-supplied configs from ${BROOT}/etc/kernel/config.d/*.config.
+#
+# This function must be called by the ebuild in the src_prepare phase.
 kernel-build_merge_configs() {
 	debug-print-function ${FUNCNAME} "${@}"
 
-	[[ -f .config ]] || die "${FUNCNAME}: .config does not exist"
+	[[ -f .config ]] ||
+		die "${FUNCNAME}: No .config, please copy default config into .config"
 	has .config "${@}" &&
 		die "${FUNCNAME}: do not specify .config as parameter"
 

--- a/sys-kernel/gentoo-kernel/gentoo-kernel-5.10.224.ebuild
+++ b/sys-kernel/gentoo-kernel/gentoo-kernel-5.10.224.ebuild
@@ -73,18 +73,15 @@ src_prepare() {
 
 	# prepare the default config
 	case ${ARCH} in
+		arm | hppa)
+			> .config || die
+		;;
 		amd64)
 			cp "${DISTDIR}/kernel-x86_64-fedora.config.${CONFIG_VER}" .config || die
-			;;
-		arm)
-			return
 			;;
 		arm64)
 			cp "${DISTDIR}/kernel-aarch64-fedora.config.${CONFIG_VER}" .config || die
 			biendian=true
-			;;
-		hppa)
-			return
 			;;
 		ppc)
 			# assume powermac/powerbook defconfig

--- a/sys-kernel/gentoo-kernel/gentoo-kernel-5.15.165.ebuild
+++ b/sys-kernel/gentoo-kernel/gentoo-kernel-5.15.165.ebuild
@@ -78,18 +78,15 @@ src_prepare() {
 
 	# prepare the default config
 	case ${ARCH} in
+		arm | hppa | sparc)
+			> .config || die
+		;;
 		amd64)
 			cp "${DISTDIR}/kernel-x86_64-fedora.config.${CONFIG_VER}" .config || die
-			;;
-		arm)
-			return
 			;;
 		arm64)
 			cp "${DISTDIR}/kernel-aarch64-fedora.config.${CONFIG_VER}" .config || die
 			biendian=true
-			;;
-		hppa)
-			return
 			;;
 		ppc)
 			# assume powermac/powerbook defconfig
@@ -99,9 +96,6 @@ src_prepare() {
 		ppc64)
 			cp "${DISTDIR}/kernel-ppc64le-fedora.config.${CONFIG_VER}" .config || die
 			biendian=true
-			;;
-		sparc)
-			return
 			;;
 		x86)
 			cp "${DISTDIR}/kernel-i686-fedora.config.${CONFIG_VER}" .config || die

--- a/sys-kernel/gentoo-kernel/gentoo-kernel-6.1.106.ebuild
+++ b/sys-kernel/gentoo-kernel/gentoo-kernel-6.1.106.ebuild
@@ -79,18 +79,15 @@ src_prepare() {
 
 	# prepare the default config
 	case ${ARCH} in
+		arm | hppa | riscv | sparc)
+			> .config || die
+		;;
 		amd64)
 			cp "${DISTDIR}/kernel-x86_64-fedora.config.${CONFIG_VER}" .config || die
-			;;
-		arm)
-			return
 			;;
 		arm64)
 			cp "${DISTDIR}/kernel-aarch64-fedora.config.${CONFIG_VER}" .config || die
 			biendian=true
-			;;
-		hppa)
-			return
 			;;
 		ppc)
 			# assume powermac/powerbook defconfig
@@ -100,12 +97,6 @@ src_prepare() {
 		ppc64)
 			cp "${DISTDIR}/kernel-ppc64le-fedora.config.${CONFIG_VER}" .config || die
 			biendian=true
-			;;
-		riscv)
-			return
-			;;
-		sparc)
-			return
 			;;
 		x86)
 			cp "${DISTDIR}/kernel-i686-fedora.config.${CONFIG_VER}" .config || die

--- a/sys-kernel/gentoo-kernel/gentoo-kernel-6.1.107.ebuild
+++ b/sys-kernel/gentoo-kernel/gentoo-kernel-6.1.107.ebuild
@@ -79,18 +79,15 @@ src_prepare() {
 
 	# prepare the default config
 	case ${ARCH} in
+		arm | hppa | riscv | sparc)
+			> .config || die
+		;;
 		amd64)
 			cp "${DISTDIR}/kernel-x86_64-fedora.config.${CONFIG_VER}" .config || die
-			;;
-		arm)
-			return
 			;;
 		arm64)
 			cp "${DISTDIR}/kernel-aarch64-fedora.config.${CONFIG_VER}" .config || die
 			biendian=true
-			;;
-		hppa)
-			return
 			;;
 		ppc)
 			# assume powermac/powerbook defconfig
@@ -100,12 +97,6 @@ src_prepare() {
 		ppc64)
 			cp "${DISTDIR}/kernel-ppc64le-fedora.config.${CONFIG_VER}" .config || die
 			biendian=true
-			;;
-		riscv)
-			return
-			;;
-		sparc)
-			return
 			;;
 		x86)
 			cp "${DISTDIR}/kernel-i686-fedora.config.${CONFIG_VER}" .config || die

--- a/sys-kernel/gentoo-kernel/gentoo-kernel-6.10.6.ebuild
+++ b/sys-kernel/gentoo-kernel/gentoo-kernel-6.10.6.ebuild
@@ -81,21 +81,15 @@ src_prepare() {
 
 	# prepare the default config
 	case ${ARCH} in
+		arm | hppa | loong | riscv | sparc)
+			> .config || die
+		;;
 		amd64)
 			cp "${DISTDIR}/kernel-x86_64-fedora.config.${CONFIG_VER}" .config || die
-			;;
-		arm)
-			return
 			;;
 		arm64)
 			cp "${DISTDIR}/kernel-aarch64-fedora.config.${CONFIG_VER}" .config || die
 			biendian=true
-			;;
-		hppa)
-			return
-			;;
-		loong)
-			return
 			;;
 		ppc)
 			# assume powermac/powerbook defconfig
@@ -105,12 +99,6 @@ src_prepare() {
 		ppc64)
 			cp "${DISTDIR}/kernel-ppc64le-fedora.config.${CONFIG_VER}" .config || die
 			biendian=true
-			;;
-		riscv)
-			return
-			;;
-		sparc)
-			return
 			;;
 		x86)
 			cp "${DISTDIR}/kernel-i686-fedora.config.${CONFIG_VER}" .config || die

--- a/sys-kernel/gentoo-kernel/gentoo-kernel-6.10.7.ebuild
+++ b/sys-kernel/gentoo-kernel/gentoo-kernel-6.10.7.ebuild
@@ -81,21 +81,15 @@ src_prepare() {
 
 	# prepare the default config
 	case ${ARCH} in
+		arm | hppa | loong | riscv | sparc)
+			> .config || die
+		;;
 		amd64)
 			cp "${DISTDIR}/kernel-x86_64-fedora.config.${CONFIG_VER}" .config || die
-			;;
-		arm)
-			return
 			;;
 		arm64)
 			cp "${DISTDIR}/kernel-aarch64-fedora.config.${CONFIG_VER}" .config || die
 			biendian=true
-			;;
-		hppa)
-			return
-			;;
-		loong)
-			return
 			;;
 		ppc)
 			# assume powermac/powerbook defconfig
@@ -105,12 +99,6 @@ src_prepare() {
 		ppc64)
 			cp "${DISTDIR}/kernel-ppc64le-fedora.config.${CONFIG_VER}" .config || die
 			biendian=true
-			;;
-		riscv)
-			return
-			;;
-		sparc)
-			return
 			;;
 		x86)
 			cp "${DISTDIR}/kernel-i686-fedora.config.${CONFIG_VER}" .config || die

--- a/sys-kernel/gentoo-kernel/gentoo-kernel-6.6.47.ebuild
+++ b/sys-kernel/gentoo-kernel/gentoo-kernel-6.6.47.ebuild
@@ -81,21 +81,15 @@ src_prepare() {
 
 	# prepare the default config
 	case ${ARCH} in
+		arm | hppa | loong | riscv | sparc)
+			> .config || die
+		;;
 		amd64)
 			cp "${DISTDIR}/kernel-x86_64-fedora.config.${CONFIG_VER}" .config || die
-			;;
-		arm)
-			return
 			;;
 		arm64)
 			cp "${DISTDIR}/kernel-aarch64-fedora.config.${CONFIG_VER}" .config || die
 			biendian=true
-			;;
-		hppa)
-			return
-			;;
-		loong)
-			return
 			;;
 		ppc)
 			# assume powermac/powerbook defconfig
@@ -105,12 +99,6 @@ src_prepare() {
 		ppc64)
 			cp "${DISTDIR}/kernel-ppc64le-fedora.config.${CONFIG_VER}" .config || die
 			biendian=true
-			;;
-		riscv)
-			return
-			;;
-		sparc)
-			return
 			;;
 		x86)
 			cp "${DISTDIR}/kernel-i686-fedora.config.${CONFIG_VER}" .config || die

--- a/sys-kernel/gentoo-kernel/gentoo-kernel-6.6.48.ebuild
+++ b/sys-kernel/gentoo-kernel/gentoo-kernel-6.6.48.ebuild
@@ -81,21 +81,15 @@ src_prepare() {
 
 	# prepare the default config
 	case ${ARCH} in
+		arm | hppa | loong | riscv | sparc)
+			> .config || die
+		;;
 		amd64)
 			cp "${DISTDIR}/kernel-x86_64-fedora.config.${CONFIG_VER}" .config || die
-			;;
-		arm)
-			return
 			;;
 		arm64)
 			cp "${DISTDIR}/kernel-aarch64-fedora.config.${CONFIG_VER}" .config || die
 			biendian=true
-			;;
-		hppa)
-			return
-			;;
-		loong)
-			return
 			;;
 		ppc)
 			# assume powermac/powerbook defconfig
@@ -105,12 +99,6 @@ src_prepare() {
 		ppc64)
 			cp "${DISTDIR}/kernel-ppc64le-fedora.config.${CONFIG_VER}" .config || die
 			biendian=true
-			;;
-		riscv)
-			return
-			;;
-		sparc)
-			return
 			;;
 		x86)
 			cp "${DISTDIR}/kernel-i686-fedora.config.${CONFIG_VER}" .config || die

--- a/sys-kernel/vanilla-kernel/vanilla-kernel-5.10.224.ebuild
+++ b/sys-kernel/vanilla-kernel/vanilla-kernel-5.10.224.ebuild
@@ -76,18 +76,15 @@ src_prepare() {
 
 	# prepare the default config
 	case ${ARCH} in
+		arm | hppa)
+			> .config || die
+		;;
 		amd64)
 			cp "${DISTDIR}/kernel-x86_64-fedora.config.${CONFIG_VER}" .config || die
-			;;
-		arm)
-			return
 			;;
 		arm64)
 			cp "${DISTDIR}/kernel-aarch64-fedora.config.${CONFIG_VER}" .config || die
 			biendian=true
-			;;
-		hppa)
-			return
 			;;
 		ppc)
 			# assume powermac/powerbook defconfig

--- a/sys-kernel/vanilla-kernel/vanilla-kernel-5.10.9999.ebuild
+++ b/sys-kernel/vanilla-kernel/vanilla-kernel-5.10.9999.ebuild
@@ -65,18 +65,15 @@ src_prepare() {
 
 	# prepare the default config
 	case ${ARCH} in
+		arm | hppa)
+			> .config || die
+		;;
 		amd64)
 			cp "${DISTDIR}/kernel-x86_64-fedora.config.${CONFIG_VER}" .config || die
-			;;
-		arm)
-			return
 			;;
 		arm64)
 			cp "${DISTDIR}/kernel-aarch64-fedora.config.${CONFIG_VER}" .config || die
 			biendian=true
-			;;
-		hppa)
-			return
 			;;
 		ppc)
 			# assume powermac/powerbook defconfig

--- a/sys-kernel/vanilla-kernel/vanilla-kernel-5.15.165.ebuild
+++ b/sys-kernel/vanilla-kernel/vanilla-kernel-5.15.165.ebuild
@@ -76,18 +76,15 @@ src_prepare() {
 
 	# prepare the default config
 	case ${ARCH} in
+		arm | hppa)
+			> .config || die
+		;;
 		amd64)
 			cp "${DISTDIR}/kernel-x86_64-fedora.config.${CONFIG_VER}" .config || die
-			;;
-		arm)
-			return
 			;;
 		arm64)
 			cp "${DISTDIR}/kernel-aarch64-fedora.config.${CONFIG_VER}" .config || die
 			biendian=true
-			;;
-		hppa)
-			return
 			;;
 		ppc)
 			# assume powermac/powerbook defconfig

--- a/sys-kernel/vanilla-kernel/vanilla-kernel-5.15.9999.ebuild
+++ b/sys-kernel/vanilla-kernel/vanilla-kernel-5.15.9999.ebuild
@@ -65,18 +65,15 @@ src_prepare() {
 
 	# prepare the default config
 	case ${ARCH} in
+		arm | hppa)
+			> .config || die
+		;;
 		amd64)
 			cp "${DISTDIR}/kernel-x86_64-fedora.config.${CONFIG_VER}" .config || die
-			;;
-		arm)
-			return
 			;;
 		arm64)
 			cp "${DISTDIR}/kernel-aarch64-fedora.config.${CONFIG_VER}" .config || die
 			biendian=true
-			;;
-		hppa)
-			return
 			;;
 		ppc)
 			# assume powermac/powerbook defconfig

--- a/sys-kernel/vanilla-kernel/vanilla-kernel-6.1.106.ebuild
+++ b/sys-kernel/vanilla-kernel/vanilla-kernel-6.1.106.ebuild
@@ -76,18 +76,15 @@ src_prepare() {
 
 	# prepare the default config
 	case ${ARCH} in
+		arm | hppa)
+			> .config || die
+		;;
 		amd64)
 			cp "${DISTDIR}/kernel-x86_64-fedora.config.${CONFIG_VER}" .config || die
-			;;
-		arm)
-			return
 			;;
 		arm64)
 			cp "${DISTDIR}/kernel-aarch64-fedora.config.${CONFIG_VER}" .config || die
 			biendian=true
-			;;
-		hppa)
-			return
 			;;
 		ppc)
 			# assume powermac/powerbook defconfig

--- a/sys-kernel/vanilla-kernel/vanilla-kernel-6.1.107.ebuild
+++ b/sys-kernel/vanilla-kernel/vanilla-kernel-6.1.107.ebuild
@@ -76,18 +76,15 @@ src_prepare() {
 
 	# prepare the default config
 	case ${ARCH} in
+		arm | hppa)
+			> .config || die
+		;;
 		amd64)
 			cp "${DISTDIR}/kernel-x86_64-fedora.config.${CONFIG_VER}" .config || die
-			;;
-		arm)
-			return
 			;;
 		arm64)
 			cp "${DISTDIR}/kernel-aarch64-fedora.config.${CONFIG_VER}" .config || die
 			biendian=true
-			;;
-		hppa)
-			return
 			;;
 		ppc)
 			# assume powermac/powerbook defconfig

--- a/sys-kernel/vanilla-kernel/vanilla-kernel-6.10.6.ebuild
+++ b/sys-kernel/vanilla-kernel/vanilla-kernel-6.10.6.ebuild
@@ -77,21 +77,15 @@ src_prepare() {
 
 	# prepare the default config
 	case ${ARCH} in
+		arm | hppa | loong)
+			> .config || die
+		;;
 		amd64)
 			cp "${DISTDIR}/kernel-x86_64-fedora.config.${CONFIG_VER}" .config || die
-			;;
-		arm)
-			return
 			;;
 		arm64)
 			cp "${DISTDIR}/kernel-aarch64-fedora.config.${CONFIG_VER}" .config || die
 			biendian=true
-			;;
-		hppa)
-			return
-			;;
-		loong)
-			return
 			;;
 		ppc)
 			# assume powermac/powerbook defconfig

--- a/sys-kernel/vanilla-kernel/vanilla-kernel-6.10.7.ebuild
+++ b/sys-kernel/vanilla-kernel/vanilla-kernel-6.10.7.ebuild
@@ -77,21 +77,15 @@ src_prepare() {
 
 	# prepare the default config
 	case ${ARCH} in
+		arm | hppa | loong)
+			> .config || die
+		;;
 		amd64)
 			cp "${DISTDIR}/kernel-x86_64-fedora.config.${CONFIG_VER}" .config || die
-			;;
-		arm)
-			return
 			;;
 		arm64)
 			cp "${DISTDIR}/kernel-aarch64-fedora.config.${CONFIG_VER}" .config || die
 			biendian=true
-			;;
-		hppa)
-			return
-			;;
-		loong)
-			return
 			;;
 		ppc)
 			# assume powermac/powerbook defconfig

--- a/sys-kernel/vanilla-kernel/vanilla-kernel-6.6.47.ebuild
+++ b/sys-kernel/vanilla-kernel/vanilla-kernel-6.6.47.ebuild
@@ -77,21 +77,15 @@ src_prepare() {
 
 	# prepare the default config
 	case ${ARCH} in
+		arm | hppa | loong)
+			> .config || die
+		;;
 		amd64)
 			cp "${DISTDIR}/kernel-x86_64-fedora.config.${CONFIG_VER}" .config || die
-			;;
-		arm)
-			return
 			;;
 		arm64)
 			cp "${DISTDIR}/kernel-aarch64-fedora.config.${CONFIG_VER}" .config || die
 			biendian=true
-			;;
-		hppa)
-			return
-			;;
-		loong)
-			return
 			;;
 		ppc)
 			# assume powermac/powerbook defconfig

--- a/sys-kernel/vanilla-kernel/vanilla-kernel-6.6.48.ebuild
+++ b/sys-kernel/vanilla-kernel/vanilla-kernel-6.6.48.ebuild
@@ -77,21 +77,15 @@ src_prepare() {
 
 	# prepare the default config
 	case ${ARCH} in
+		arm | hppa | loong)
+			> .config || die
+		;;
 		amd64)
 			cp "${DISTDIR}/kernel-x86_64-fedora.config.${CONFIG_VER}" .config || die
-			;;
-		arm)
-			return
 			;;
 		arm64)
 			cp "${DISTDIR}/kernel-aarch64-fedora.config.${CONFIG_VER}" .config || die
 			biendian=true
-			;;
-		hppa)
-			return
-			;;
-		loong)
-			return
 			;;
 		ppc)
 			# assume powermac/powerbook defconfig

--- a/sys-kernel/vanilla-kernel/vanilla-kernel-6.6.9999.ebuild
+++ b/sys-kernel/vanilla-kernel/vanilla-kernel-6.6.9999.ebuild
@@ -66,21 +66,15 @@ src_prepare() {
 
 	# prepare the default config
 	case ${ARCH} in
+		arm | hppa | loong)
+			> .config || die
+		;;
 		amd64)
 			cp "${DISTDIR}/kernel-x86_64-fedora.config.${CONFIG_VER}" .config || die
-			;;
-		arm)
-			return
 			;;
 		arm64)
 			cp "${DISTDIR}/kernel-aarch64-fedora.config.${CONFIG_VER}" .config || die
 			biendian=true
-			;;
-		hppa)
-			return
-			;;
-		loong)
-			return
 			;;
 		ppc)
 			# assume powermac/powerbook defconfig


### PR DESCRIPTION
On arches where we do not supply a default .config will still want to
call kernel-build_merge_configs to apply the savedconfig. Otherwise we
end up with no .config in src_configure.

Closes: https://bugs.gentoo.org/938725

CC @gentoo/dist-kernel @mgorny 

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
