### PR TITLE
net-misc/frr: Fix implicit declaration of function basename

### DIFF
--- a/net-misc/frr/files/frr-9.1-mimic-gnu-basename-api-for-non-glibc.patch
+++ b/net-misc/frr/files/frr-9.1-mimic-gnu-basename-api-for-non-glibc.patch
@@ -1,0 +1,26 @@
+https://github.com/FRRouting/frr/commit/0ef71391f0fb15039550a09c218977fa3e1abaf1.patch
+From: Khem Raj <raj.khem@gmail.com>
+Date: Fri, 15 Mar 2024 14:34:06 -0700
+Subject: [PATCH] zebra: Mimic GNU basename() API for non-glibc library e.g.
+ musl
+
+musl only provides POSIX version of basename and it has also removed
+providing it via string.h header [1] which now results in compile errors
+with newer compilers e.g. clang-18
+
+[1] https://git.musl-libc.org/cgit/musl/commit/?id=725e17ed6dff4d0cd22487bb64470881e86a92e7
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+--- a/zebra/zebra_netns_notify.c
++++ b/zebra/zebra_netns_notify.c
+@@ -42,6 +42,10 @@
+ #define ZEBRA_NS_POLLING_INTERVAL_MSEC     1000
+ #define ZEBRA_NS_POLLING_MAX_RETRIES  200
+ 
++#if !defined(__GLIBC__)
++#define basename(src) (strrchr(src, '/') ? strrchr(src, '/') + 1 : src)
++#endif
++
+ DEFINE_MTYPE_STATIC(ZEBRA, NETNS_MISC, "ZebraNetNSInfo");
+ static struct event *zebra_netns_notify_current;
+ 

--- a/net-misc/frr/frr-9.1-r1.ebuild
+++ b/net-misc/frr/frr-9.1-r1.ebuild
@@ -1,0 +1,141 @@
+# Copyright 2020-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+PYTHON_COMPAT=( python3_{10..12} )
+inherit autotools pam python-single-r1 systemd
+
+DESCRIPTION="The FRRouting Protocol Suite"
+HOMEPAGE="https://frrouting.org/"
+SRC_URI="https://github.com/FRRouting/frr/archive/${P}.tar.gz"
+# FRR tarballs have weird format.
+S="${WORKDIR}/frr-${P}"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~arm64 ~x86"
+IUSE="doc fpm grpc ipv6 nhrp ospfapi pam rpki snmp test"
+REQUIRED_USE="${PYTHON_REQUIRED_USE}"
+RESTRICT="!test? ( test )"
+
+COMMON_DEPEND="
+	${PYTHON_DEPS}
+	acct-user/frr
+	dev-libs/json-c:0=
+	dev-libs/protobuf-c:0=
+	>=net-libs/libyang-2.0.0
+	<net-libs/libyang-2.1.111
+	sys-libs/libcap
+	sys-libs/readline:0=
+	virtual/libcrypt:=
+	grpc? ( net-libs/grpc:= )
+	nhrp? ( net-dns/c-ares:0= )
+	pam? ( sys-libs/pam )
+	rpki? ( >=net-libs/rtrlib-0.8.0[ssh] )
+	snmp? ( net-analyzer/net-snmp:= )
+"
+BDEPEND="
+	app-alternatives/lex
+	app-alternatives/yacc
+	doc? ( dev-python/sphinx )
+"
+DEPEND="
+	${COMMON_DEPEND}
+	elibc_musl? ( sys-libs/queue-standalone )
+	test? ( $(python_gen_cond_dep 'dev-python/pytest[${PYTHON_USEDEP}]') )
+"
+RDEPEND="
+	${COMMON_DEPEND}
+	$(python_gen_cond_dep 'dev-python/ipaddr[${PYTHON_USEDEP}]')
+"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-7.5-ipctl-forwarding.patch
+	"${FILESDIR}"/${PN}-8.4.1-logrotate.patch
+	"${FILESDIR}"/${PN}-9.1-mimic-gnu-basename-api-for-non-glibc.patch
+)
+
+src_prepare() {
+	default
+
+	python_fix_shebang tools
+	eautoreconf
+}
+
+src_configure() {
+	local myconf=(
+		--with-pkg-extra-version="-gentoo"
+		--enable-configfile-mask=0640
+		--enable-logfile-mask=0640
+		--libdir="${EPREFIX}"/usr/lib/frr
+		--sbindir="${EPREFIX}"/usr/lib/frr
+		--libexecdir="${EPREFIX}"/usr/lib/frr
+		--sysconfdir="${EPREFIX}"/etc/frr
+		--localstatedir="${EPREFIX}"/run/frr
+		--with-moduledir="${EPREFIX}"/usr/lib/frr/modules
+		--enable-user=frr
+		--enable-group=frr
+		--enable-vty-group=frr
+		--enable-multipath=64
+		$(use_enable doc)
+		$(use_enable fpm)
+		$(use_enable grpc)
+		$(use_enable ipv6 ospf6d)
+		$(use_enable ipv6 ripngd)
+		$(use_enable ipv6 rtadv)
+		$(use_enable kernel_linux realms)
+		$(use_enable nhrp nhrpd)
+		$(usex ospfapi '--enable-ospfclient' '' '' '')
+		$(use_enable rpki)
+		$(use_enable snmp)
+	)
+
+	econf "${myconf[@]}"
+}
+
+src_compile() {
+	default
+
+	use doc && emake -C doc html
+}
+
+src_test() {
+	local -x PYTEST_DISABLE_PLUGIN_AUTOLOAD=1
+	default
+}
+
+src_install() {
+	default
+	find "${ED}" -name '*.la' -delete || die
+
+	# Install user documentation if asked
+	use doc && dodoc -r doc/user/_build/html
+
+	# Create configuration directory with correct permissions
+	# Create logs directory with the correct permissions
+	diropts -ofrr -gfrr -m0775
+	keepdir /var/log/frr /etc/frr
+
+	# Install the default configuration files
+	insinto /etc/frr
+	doins tools/etc/frr/{vtysh.conf,frr.conf,daemons}
+
+	# Fix permissions/owners.
+	fowners frr:frr /etc/frr/{vtysh.conf,frr.conf,daemons}
+	fperms 640 /etc/frr/{vtysh.conf,frr.conf,daemons}
+
+	# Install logrotate configuration
+	insinto /etc/logrotate.d
+	newins redhat/frr.logrotate frr
+
+	# Install PAM configuration file
+	use pam && newpamd "${FILESDIR}"/frr.pam frr
+
+	# Install init scripts
+	systemd_dounit tools/frr.service
+	newinitd "${FILESDIR}"/frr-openrc-v2 frr
+
+	# Conflict files, installed by net-libs/libsmi, bug #758383
+	rm "${ED}"/usr/share/yang/ietf-interfaces.yang || die
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/938756

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
