### PR TITLE
sys-apps/dog: Fix implicit declaration of function strfry

### DIFF
--- a/sys-apps/dog/dog-1.7-r7.ebuild
+++ b/sys-apps/dog/dog-1.7-r7.ebuild
@@ -1,0 +1,43 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs
+
+DESCRIPTION="Dog is better than cat"
+HOMEPAGE="https://wiki.gentoo.org/wiki/No_homepage"
+SRC_URI="mirror://gentoo/${P}.tar.gz"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm64 ~mips ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-check-ctime.diff
+	"${FILESDIR}"/${PV}-manpage-touchup.patch
+	"${FILESDIR}"/${P}-64bit-goodness.patch
+	"${FILESDIR}"/${P}-strfry.patch
+	"${FILESDIR}"/${P}-musl-strfry-fix.patch
+)
+
+src_prepare() {
+	default
+
+	if [[ "${CHOST}" == *-solaris* ]]; then
+		sed -i '/gcc.*-o dog/s/$/ -lsocket -lnsl/' \
+			Makefile || die "sed Makefile failed"
+	fi
+
+	sed -i \
+		-e 's,^CFLAGS,#CFLAGS,' \
+		-e "s,gcc,$(tc-getCC)," \
+		-e 's:-o dog:$(LDFLAGS) -o dog:g' \
+		Makefile || die "sed Makefile failed"
+}
+
+src_install() {
+	dobin "${PN}"
+	doman "${PN}.1"
+	einstalldocs
+}

--- a/sys-apps/dog/files/dog-1.7-musl-strfry-fix.patch
+++ b/sys-apps/dog/files/dog-1.7-musl-strfry-fix.patch
@@ -1,0 +1,15 @@
+See bug #938613
+--- a/dog.c
++++ b/dog.c
+@@ -77,9 +77,11 @@
+ #endif
+ 
+ #if ALLOW_LINUX_EXTENSIONS
++#if defined(__GLIBC__)
+ #define ALLOW_STRFRY			1
+ extern char *strfry __P ((char *__string));
+ #else
++#endif
+ #define ALLOW_STRFRY			0
+ #endif
+ 


### PR DESCRIPTION
Closes: implicit declaration of function strfry

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
