### PR TITLE
games-action/prismlauncher-9999: Add missing dependency on dev-qt/qtn…

### DIFF
--- a/games-action/prismlauncher/prismlauncher-9999.ebuild
+++ b/games-action/prismlauncher/prismlauncher-9999.ebuild
@@ -54,6 +54,7 @@ QT_DEPS="
 		>=dev-qt/qtcore-${MIN_QT_5_VERSION}:5
 		>=dev-qt/qtgui-${MIN_QT_5_VERSION}:5
 		>=dev-qt/qtnetwork-${MIN_QT_5_VERSION}:5
+		>=dev-qt/qtnetworkauth-${MIN_QT_5_VERSION}:5
 		>=dev-qt/qttest-${MIN_QT_5_VERSION}:5
 		>=dev-qt/qtwidgets-${MIN_QT_5_VERSION}:5
 		>=dev-qt/qtxml-${MIN_QT_5_VERSION}:5
@@ -62,6 +63,7 @@ QT_DEPS="
 	qt6? (
 		>=dev-qt/qtbase-${MIN_QT_6_VERSION}:6[concurrent,gui,network,widgets,xml(+)]
 		>=dev-qt/qt5compat-${MIN_QT_6_VERSION}:6
+		>=dev-qt/qtnetworkauth-${MIN_QT_6_VERSION}:6
 	)
 "
 


### PR DESCRIPTION
It was added [here](https://github.com/PrismLauncher/PrismLauncher/commit/80d8e3ee06e8f71503523d4f388b1f729ae7a75e)

---

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
