### PR TITLE
x11-misc/*: use https instead of http

### DIFF
--- a/x11-misc/ftmenu/ftmenu-0.4.0-r2.ebuild
+++ b/x11-misc/ftmenu/ftmenu-0.4.0-r2.ebuild
@@ -3,8 +3,8 @@
 
 EAPI=8
 
-DESCRIPTION="A tray menu for the Fluxbox toolbar"
-HOMEPAGE="http://ftmenu.sourceforge.net/"
+DESCRIPTION="Tray menu for the Fluxbox toolbar"
+HOMEPAGE="https://ftmenu.sourceforge.net/"
 SRC_URI="https://downloads.sourceforge.net/${PN}/${P}.tar.gz"
 
 LICENSE="GPL-3"

--- a/x11-misc/gromit/gromit-20041213-r2.ebuild
+++ b/x11-misc/gromit/gromit-20041213-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -6,8 +6,8 @@ EAPI=8
 inherit toolchain-funcs
 
 DESCRIPTION="GRaphics Over MIscellaneous Things, a presentation helper"
-HOMEPAGE="http://www.home.unix-ag.org/simon/gromit"
-SRC_URI="http://www.home.unix-ag.org/simon/gromit/${P}.tar.gz"
+HOMEPAGE="https://www.home.unix-ag.org/simon/gromit"
+SRC_URI="https://www.home.unix-ag.org/simon/gromit/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/x11-misc/menumaker/menumaker-0.99.12.ebuild
+++ b/x11-misc/menumaker/menumaker-0.99.12.ebuild
@@ -8,7 +8,7 @@ PYTHON_COMPAT=( python3_10 )
 inherit autotools python-single-r1
 
 DESCRIPTION="Utility that scans through the system and generates a menu of installed programs"
-HOMEPAGE="http://menumaker.sourceforge.net/"
+HOMEPAGE="https://menumaker.sourceforge.net/"
 SRC_URI="https://downloads.sourceforge.net/${PN}/${P}.tar.gz"
 
 LICENSE="BSD"

--- a/x11-misc/menumaker/menumaker-0.99.14.ebuild
+++ b/x11-misc/menumaker/menumaker-0.99.14.ebuild
@@ -8,7 +8,7 @@ PYTHON_COMPAT=( python3_{10..11} )
 inherit autotools python-single-r1
 
 DESCRIPTION="Utility that scans through the system and generates a menu of installed programs"
-HOMEPAGE="http://menumaker.sourceforge.net/"
+HOMEPAGE="https://menumaker.sourceforge.net/"
 SRC_URI="https://downloads.sourceforge.net/${PN}/${P}.tar.gz"
 
 LICENSE="BSD"

--- a/x11-misc/xnots/xnots-0.2.1-r2.ebuild
+++ b/x11-misc/xnots/xnots-0.2.1-r2.ebuild
@@ -5,8 +5,8 @@ EAPI=8
 
 inherit flag-o-matic toolchain-funcs
 
-DESCRIPTION="A desktop sticky note program for the unix geek"
-HOMEPAGE="http://xnots.sourceforge.net https://github.com/thePalindrome/xnots"
+DESCRIPTION="Desktop sticky note program for the unix geek"
+HOMEPAGE="https://xnots.sourceforge.net https://github.com/thePalindrome/xnots"
 SRC_URI="https://downloads.sourceforge.net/xnots/${P}.tar.gz"
 
 LICENSE="GPL-2"


### PR DESCRIPTION
Simple `http` -> `https` fixes for some `x11-misc` packages.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
