### PR TITLE
dev-db/mariadb: add patch related with libxml2 2.12 from upstream for <=10.6.17 & fix dtrace issue

### DIFF
--- a/dev-db/mariadb/files/mariadb-10.6.17-libxml-2.12.patch
+++ b/dev-db/mariadb/files/mariadb-10.6.17-libxml-2.12.patch
@@ -1,0 +1,167 @@
+From cae18632aea530eb73a9f15ee4fd0d924e01a8d3 Mon Sep 17 00:00:00 2001
+From: Jan Tojnar <jtojnar@gmail.com>
+Date: Sun, 7 Jan 2024 10:19:54 +0100
+Subject: [PATCH] MDEV-33439 Fix build with libxml2 2.12
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+libxml2 2.12.0 made `xmlGetLastError()` return `const` pointer:
+
+https://gitlab.gnome.org/GNOME/libxml2/-/commit/61034116d0a3c8b295c6137956adc3ae55720711
+
+Clang 16 does not like this:
+
+    error: assigning to 'xmlErrorPtr' (aka '_xmlError *') from 'const xmlError *' (aka 'const _xmlError *') discards qualifiers
+    error: cannot initialize a variable of type 'xmlErrorPtr' (aka '_xmlError *') with an rvalue of type 'const xmlError *' (aka 'const _xmlError *')
+
+Let’s update the variables to `const`.
+For older versions, it will be automatically converted.
+
+But then `xmlResetError(xmlError*)` will not like the `const` pointer:
+
+    error: no matching function for call to 'xmlResetError'
+    note: candidate function not viable: 1st argument ('const xmlError *' (aka 'const _xmlError *')) would lose const qualifier
+
+Let’s replace it with `xmlResetLastError()`.
+
+ALso remove `LIBXMLDOC::Xerr` protected member property.
+It was introduced in 65b0e5455b547a3d574fa77b34cce23ae3bea0a0
+along with the `xmlResetError` calls.
+It does not appear to be used for anything.
+---
+ storage/connect/libdoc.cpp | 39 +++++++++++++++++++-------------------
+ 1 file changed, 19 insertions(+), 20 deletions(-)
+
+diff --git a/storage/connect/libdoc.cpp b/storage/connect/libdoc.cpp
+index 14e1e44895c..01b38366d63 100644
+--- a/storage/connect/libdoc.cpp
++++ b/storage/connect/libdoc.cpp
+@@ -93,7 +93,6 @@ class LIBXMLDOC : public XMLDOCUMENT {
+   xmlXPathContextPtr Ctxp;
+   xmlXPathObjectPtr  Xop;
+   xmlXPathObjectPtr  NlXop;
+-  xmlErrorPtr        Xerr;
+   char              *Buf;                  // Temporary
+   bool               Nofreelist;
+ }; // end of class LIBXMLDOC
+@@ -327,7 +326,6 @@ LIBXMLDOC::LIBXMLDOC(char *nsl, char *nsdf, char *enc, PFBLOCK fp)
+   Ctxp = NULL;
+   Xop = NULL;
+   NlXop = NULL;
+-  Xerr = NULL;
+   Buf = NULL;
+   Nofreelist = false;
+   } // end of LIBXMLDOC constructor
+@@ -365,8 +363,8 @@ bool LIBXMLDOC::ParseFile(PGLOBAL g, char *fn)
+       Encoding = (char*)Docp->encoding;
+ 
+     return false;
+-  } else if ((Xerr = xmlGetLastError()))
+-    xmlResetError(Xerr);
++  } else if (xmlGetLastError())
++    xmlResetLastError();
+ 
+   return true;
+   } // end of ParseFile
+@@ -505,9 +503,9 @@ int LIBXMLDOC::DumpDoc(PGLOBAL g, char *ofn)
+ #if 1
+   // This function does not crash (
+   if (xmlSaveFormatFileEnc((const char *)ofn, Docp, Encoding, 0) < 0) {
+-    xmlErrorPtr err = xmlGetLastError();
++    const xmlError *err = xmlGetLastError();
+     strcpy(g->Message, (err) ? err->message : "Error saving XML doc");
+-    xmlResetError(Xerr);
++    xmlResetLastError();
+     rc = -1;
+     } // endif Save
+ //  rc = xmlDocDump(of, Docp);
+@@ -546,8 +544,8 @@ void LIBXMLDOC::CloseDoc(PGLOBAL g, PFBLOCK xp)
+     if (Nlist) {
+       xmlXPathFreeNodeSet(Nlist);
+ 
+-      if ((Xerr = xmlGetLastError()))
+-        xmlResetError(Xerr);
++      if (xmlGetLastError())
++        xmlResetLastError();
+ 
+       Nlist = NULL;
+       } // endif Nlist
+@@ -555,8 +553,8 @@ void LIBXMLDOC::CloseDoc(PGLOBAL g, PFBLOCK xp)
+     if (Xop) {
+       xmlXPathFreeObject(Xop);
+ 
+-      if ((Xerr = xmlGetLastError()))
+-        xmlResetError(Xerr);
++      if (xmlGetLastError())
++        xmlResetLastError();
+ 
+       Xop = NULL;
+       } // endif Xop
+@@ -564,8 +562,8 @@ void LIBXMLDOC::CloseDoc(PGLOBAL g, PFBLOCK xp)
+     if (NlXop) {
+       xmlXPathFreeObject(NlXop);
+ 
+-      if ((Xerr = xmlGetLastError()))
+-        xmlResetError(Xerr);
++      if (xmlGetLastError())
++        xmlResetLastError();
+ 
+       NlXop = NULL;
+       } // endif NlXop
+@@ -573,8 +571,8 @@ void LIBXMLDOC::CloseDoc(PGLOBAL g, PFBLOCK xp)
+     if (Ctxp) {
+       xmlXPathFreeContext(Ctxp);
+ 
+-      if ((Xerr = xmlGetLastError()))
+-        xmlResetError(Xerr);
++      if (xmlGetLastError())
++        xmlResetLastError();
+ 
+       Ctxp = NULL;
+       } // endif Ctxp
+@@ -590,6 +588,7 @@ void LIBXMLDOC::CloseDoc(PGLOBAL g, PFBLOCK xp)
+ /******************************************************************/
+ xmlNodeSetPtr LIBXMLDOC::GetNodeList(PGLOBAL g, xmlNodePtr np, char *xp)
+   {
++  const xmlError *xerr;
+   xmlNodeSetPtr nl;
+ 
+   if (trace(1))
+@@ -649,11 +648,11 @@ xmlNodeSetPtr LIBXMLDOC::GetNodeList(PGLOBAL g, xmlNodePtr np, char *xp)
+     } else
+       xmlXPathFreeObject(Xop);            // Caused node not found
+ 
+-    if ((Xerr = xmlGetLastError())) {
+-      strcpy(g->Message, Xerr->message);
+-      xmlResetError(Xerr);
++    if ((xerr = xmlGetLastError())) {
++      strcpy(g->Message, xerr->message);
++      xmlResetLastError();
+       return NULL;
+-      } // endif Xerr
++      } // endif xerr
+ 
+     } // endif Xop
+ 
+@@ -1079,7 +1078,7 @@ void XML2NODE::AddText(PGLOBAL g, PCSZ txtp)
+ /******************************************************************/
+ void XML2NODE::DeleteChild(PGLOBAL g, PXNODE dnp)
+   {
+-  xmlErrorPtr xerr;
++  const xmlError *xerr;
+ 
+   if (trace(1))
+     htrc("DeleteChild: node=%p\n", dnp);
+@@ -1122,7 +1121,7 @@ void XML2NODE::DeleteChild(PGLOBAL g, PXNODE dnp)
+   if (trace(1))
+     htrc("DeleteChild: errmsg=%-.256s\n", xerr->message);
+ 
+-  xmlResetError(xerr);
++  xmlResetLastError();
+   } // end of DeleteChild
+ 
+ /* -------------------- class XML2NODELIST ---------------------- */
+-- 
+2.26.2
+

--- a/dev-db/mariadb/mariadb-10.11.10.ebuild
+++ b/dev-db/mariadb/mariadb-10.11.10.ebuild
@@ -355,6 +355,12 @@ src_configure() {
 		mycmakeargs+=( -DWITH_SSL=bundled )
 	fi
 
+	if use systemtap && has_version "dev-debug/systemtap[-dtrace-symlink(+)]" ; then
+		mycmakeargs+=(
+			-DDTRACE="${BROOT}"/usr/bin/stap-dtrace
+		)
+	fi
+
 	# bfd.h is only used starting with 10.1 and can be controlled by NOT_FOR_DISTRIBUTION
 	mycmakeargs+=(
 		-DWITH_READLINE=$(usex bindist 1 0)

--- a/dev-db/mariadb/mariadb-10.6.14.ebuild
+++ b/dev-db/mariadb/mariadb-10.6.14.ebuild
@@ -219,6 +219,7 @@ src_prepare() {
 	eapply "${FILESDIR}"/${PN}-10.6.11-gssapi.patch
 	eapply "${FILESDIR}"/${PN}-10.6.11-include.patch
 	eapply "${FILESDIR}"/${PN}-10.6.12-gcc-13.patch
+	eapply "${FILESDIR}"/${PN}-10.6.17-libxml-2.12.patch
 
 	eapply_user
 
@@ -360,6 +361,12 @@ src_configure() {
 		mycmakeargs+=( -DWITH_SSL=system -DCLIENT_PLUGIN_SHA256_PASSWORD=STATIC )
 	else
 		mycmakeargs+=( -DWITH_SSL=bundled )
+	fi
+
+	if use systemtap && has_version "dev-debug/systemtap[-dtrace-symlink(+)]" ; then
+		mycmakeargs+=(
+			-DDTRACE="${BROOT}"/usr/bin/stap-dtrace
+		)
 	fi
 
 	# bfd.h is only used starting with 10.1 and can be controlled by NOT_FOR_DISTRIBUTION

--- a/dev-db/mariadb/mariadb-10.6.17.ebuild
+++ b/dev-db/mariadb/mariadb-10.6.17.ebuild
@@ -218,6 +218,7 @@ src_prepare() {
 	eapply "${WORKDIR}"/mariadb-patches
 	eapply "${FILESDIR}"/${PN}-10.6.11-gssapi.patch
 	eapply "${FILESDIR}"/${PN}-10.6.12-gcc-13.patch
+	eapply "${FILESDIR}"/${PN}-10.6.17-libxml-2.12.patch
 
 	eapply_user
 
@@ -359,6 +360,12 @@ src_configure() {
 		mycmakeargs+=( -DWITH_SSL=system -DCLIENT_PLUGIN_SHA256_PASSWORD=STATIC )
 	else
 		mycmakeargs+=( -DWITH_SSL=bundled )
+	fi
+
+	if use systemtap && has_version "dev-debug/systemtap[-dtrace-symlink(+)]" ; then
+		mycmakeargs+=(
+			-DDTRACE="${BROOT}"/usr/bin/stap-dtrace
+		)
 	fi
 
 	# bfd.h is only used starting with 10.1 and can be controlled by NOT_FOR_DISTRIBUTION


### PR DESCRIPTION
dev-db/mariadb: fix build failed
1. <=10.6.17 add patch related with libxml2 2.12 from upstream, don't know why https://bugs.gentoo.org/917537 without mariadb included
   see https://github.com/MariaDB/server/commit/cae18632aea530eb73a9f15ee4fd0d924e01a8d3
2. if systemtap build w/o dtrace-symlink, build will failed w/:
   DTRACE-NOTFOUND: command not found

Bug: https://bugs.gentoo.org/917537
Closes: https://bugs.gentoo.org/943306

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
