### PR TITLE
app-emulation/punes: fix compilation with qt 6.7

### DIFF
--- a/app-emulation/punes/files/punes-0.111-qt6.7_Q_OBJECT.patch
+++ b/app-emulation/punes/files/punes-0.111-qt6.7_Q_OBJECT.patch
@@ -1,0 +1,17 @@
+https://github.com/punesemu/puNES/commit/6e51b1a6107ad3de97edd40ae4ec2d41b32d804f.patch
+From: Cosima Neidahl <opna2608@protonmail.com>
+Date: Fri, 31 May 2024 14:48:50 +0200
+Subject: [PATCH] Fix compatibility with Qt 6.7.1 (#403)
+
+Upstream QTBUG-105023 fix made it mandatory that arguments to QObject::findChild[ren] calls must be Q_OBJECTs.
+--- a/src/gui/dlgStdPad.hpp
++++ b/src/gui/dlgStdPad.hpp
+@@ -47,6 +47,8 @@ typedef struct _joy_list {
+ extern _joy_list joy_list;
+ 
+ class pixmapButton: public QPushButton {
++	Q_OBJECT
++
+ 	private:
+ 		QPixmap pixmap;
+ 

--- a/app-emulation/punes/punes-0.111-r1.ebuild
+++ b/app-emulation/punes/punes-0.111-r1.ebuild
@@ -1,0 +1,56 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit cmake xdg
+
+DESCRIPTION="Nintendo Entertainment System (NES) emulator"
+HOMEPAGE="https://github.com/punesemu/puNES"
+SRC_URI="https://github.com/punesemu/puNES/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+S="${WORKDIR}/puNES-${PV}"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="X cg ffmpeg"
+
+RDEPEND="
+	dev-qt/qtbase:6[gui,network,opengl,widgets]
+	dev-qt/qtsvg:6
+	media-libs/alsa-lib
+	media-libs/libglvnd[X?]
+	virtual/glu
+	virtual/udev
+	X? (
+		x11-libs/libX11
+		x11-libs/libXrandr
+	)
+	cg? ( media-gfx/nvidia-cg-toolkit )
+	ffmpeg? ( media-video/ffmpeg:= )
+"
+
+DEPEND="
+	${RDEPEND}
+	X? ( x11-base/xorg-proto )"
+BDEPEND="
+	virtual/pkgconfig
+	dev-qt/qttools[linguist]
+"
+
+PATCHES=(
+	"${FILESDIR}/punes-0.111-FULLSCREEN_RESFREQ-fix.patch"
+	"${FILESDIR}/punes-0.111-qt6.7_Q_OBJECT.patch"
+)
+
+src_configure() {
+	local mycmakeargs=(
+		-DENABLE_GIT_INFO=OFF
+		-DENABLE_QT6_LIBS=ON
+		-DDISABLE_PORTABLE_MODE=OFF
+		-DENABLE_FFMPEG=$(usex ffmpeg)
+		-DENABLE_FULLSCREEN_RESFREQ=$(usex X)
+		-DENABLE_OPENGL_CG=$(usex cg)
+	)
+	cmake_src_configure
+}


### PR DESCRIPTION
Apply upstream patch. Drop support for qt5.

Closes: https://bugs.gentoo.org/938933

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
