### PR TITLE
app-text/t1utils: EAPI8 bump, improve ebuild

### DIFF
--- a/app-text/t1utils/t1utils-1.42-r1.ebuild
+++ b/app-text/t1utils/t1utils-1.42-r1.ebuild
@@ -1,0 +1,14 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DESCRIPTION="Type 1 Font utilities"
+HOMEPAGE="https://www.lcdf.org/type/#t1utils"
+SRC_URI="https://www.lcdf.org/type/${P}.tar.gz"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x64-solaris"
+
+DOCS=( NEWS.md README.md )


### PR DESCRIPTION
Simple `EAPI8` bump. I've also removed the blocker on the ancient freetype version.

```diff
--- t1utils-1.42.ebuild	2024-01-17 20:05:11.958825030 +0100
+++ t1utils-1.42-r1.ebuild	2024-09-02 20:45:40.520086562 +0200
@@ -1,18 +1,14 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 DESCRIPTION="Type 1 Font utilities"
-SRC_URI="http://www.lcdf.org/type/${P}.tar.gz"
-HOMEPAGE="http://www.lcdf.org/type/#t1utils"
-KEYWORDS="~alpha amd64 arm arm64 ~hppa ~ia64 ~loong ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x64-solaris"
-SLOT="0"
-LICENSE="BSD"
-IUSE=""
+HOMEPAGE="https://www.lcdf.org/type/#t1utils"
+SRC_URI="https://www.lcdf.org/type/${P}.tar.gz"
 
-DEPEND=""
-RDEPEND="${DEPEND}
-	!<media-libs/freetype-1.4_pre20080316"
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x64-solaris"
 
 DOCS=( NEWS.md README.md )
```

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
