### PR TITLE
dev-libs/bglibs: Fix implicit declaration of function sigblock

### DIFF
--- a/dev-libs/bglibs/bglibs-2.04-r3.ebuild
+++ b/dev-libs/bglibs/bglibs-2.04-r3.ebuild
@@ -1,0 +1,80 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs
+
+DESCRIPTION="Bruce Guenter's Libraries Collection"
+HOMEPAGE="https://untroubled.org/bglibs/"
+SRC_URI="https://untroubled.org/bglibs/archive/${P}.tar.gz"
+
+LICENSE="LGPL-2.1+"
+SLOT="0/2"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~loong ~mips ~ppc ~ppc64 ~riscv ~sparc ~x86"
+IUSE="doc"
+
+BDEPEND="
+	sys-apps/which
+	dev-build/libtool
+	doc? (
+		app-text/doxygen
+		dev-texlive/texlive-latexrecommended
+		dev-texlive/texlive-latex
+		dev-texlive/texlive-latexextra
+		virtual/latex-base
+	)
+"
+
+PATCHES=(
+	"${FILESDIR}"/bglibs-2.04-stack-buffers.patch
+	"${FILESDIR}"/bglibs-2.04-musl-signal-fix.patch
+)
+
+src_prepare() {
+	default
+	# disable tests as we want them manually
+	sed -i '/^all:/s|selftests||' Makefile || die
+	sed -i '/selftests/d' TARGETS || die
+}
+
+src_configure() {
+	echo "${ED}/usr/bin" > conf-bin || die
+	echo "${ED}/usr/$(get_libdir)/bglibs" > conf-lib || die
+	echo "${ED}/usr/include" > conf-include || die
+	echo "${ED}/usr/share/man" > conf-man || die
+	echo "$(tc-getCC) ${CFLAGS}" > conf-cc || die
+	echo "$(tc-getCC) ${LDFLAGS}" > conf-ld || die
+}
+
+src_compile() {
+	# Parallel build fails, bug #343617
+	MAKEOPTS+=" -j1" default
+
+	if use doc; then
+		emake -C doc/latex pdf
+	fi
+}
+
+src_test() {
+	einfo "Running selftests"
+	emake selftests
+}
+
+src_install() {
+	default
+
+	# Install .so into LDPATH
+	mv "${ED}"/usr/$(get_libdir)/bglibs/libbg.so.2.0.0 "${ED}"/usr/$(get_libdir)/ || die
+	dosym libbg.so.2.0.0 /usr/$(get_libdir)/libbg.so.2
+	dosym libbg.so.2.0.0 /usr/$(get_libdir)/libbg.so
+	dosym ../libbg.so.2.0.0 /usr/$(get_libdir)/bglibs/libbg.so.2.0.0
+
+	rm "${ED}"/usr/$(get_libdir)/bglibs/libbg.la || die
+
+	dodoc ANNOUNCEMENT NEWS README ChangeLog TODO VERSION
+	dodoc -r doc/html/
+	if use doc; then
+		dodoc doc/latex/refman.pdf
+	fi
+}

--- a/dev-libs/bglibs/files/bglibs-2.04-musl-signal-fix.patch
+++ b/dev-libs/bglibs/files/bglibs-2.04-musl-signal-fix.patch
@@ -1,0 +1,77 @@
+Don't use sig_unblock and other such functions, they are deprecated.
+https://bugs.gentoo.org/938087
+--- a/net/bindu.c
++++ b/net/bindu.c
+@@ -21,6 +21,7 @@
+ #include <sys/socket.h>
+ #include <sys/un.h>
+ #include <unistd.h>
++#include <string.h>
+ #include "socket.h"
+ 
+ /** Bind a UNIX domain address (path) to a socket. */
+--- a/net/connectu.c
++++ b/net/connectu.c
+@@ -21,6 +21,7 @@
+ #include <sys/socket.h>
+ #include <sys/un.h>
+ #include <unistd.h>
++#include <string.h>
+ #include "socket.h"
+ 
+ /** Make an UNIX domain connection. */
+--- a/unix/sig_all.c
++++ b/unix/sig_all.c
+@@ -32,25 +32,17 @@ void sig_all_default(void)
+ void sig_all_block(void)
+ {
+   int i;
+-#ifdef HASSIGPROCMASK
+   sigset_t set;
+   sigemptyset(&set);
+   for (i = 1; i < SIGMAX; i++)
+     if (i != SIGPROF || i != SIGSEGV)
+       sigaddset(&set, i);
+   sigprocmask(SIG_BLOCK, &set, 0);
+-#else
+-  sigblock(~(1 << (SIGPROF-1)) & ~(1 << (SIGSEGV-1)));
+-#endif
+ }
+ 
+ void sig_all_unblock(void)
+ {
+-#ifdef HASSIGPROCMASK
+   sigset_t set;
+   sigemptyset(&set);
+   sigprocmask(SIG_UNBLOCK, &set, 0);
+-#else
+-  sigsetmask(0);
+-#endif
+ }
+--- a/unix/sig_block.c
++++ b/unix/sig_block.c
+@@ -21,24 +21,16 @@
+ 
+ void sig_block(int s)
+ {
+-#ifdef HASSIGPROCMASK
+   sigset_t set;
+   sigemptyset(&set);
+   sigaddset(&set, s);
+   sigprocmask(SIG_BLOCK, &set, 0);
+-#else
+-  sigblock(1 << (s - 1));
+-#endif
+ }
+ 
+ void sig_unblock(int s)
+ {
+-#ifdef HASSIGPROCMASK
+   sigset_t set;
+   sigemptyset(&set);
+   sigaddset(&set, s);
+   sigprocmask(SIG_UNBLOCK, &set, 0);
+-#else
+-  sigsetmask(sigsetmask(~0) & ~(1 << (s - 1)));
+-#endif
+ }


### PR DESCRIPTION
And update EAPI 7 -> 8

Closes: https://bugs.gentoo.org/938087

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
