### PR TITLE
sys-fs/xfsdump: Fix implicit declaration of function basename

### DIFF
--- a/sys-fs/xfsdump/files/xfsdump-3.1.12-mimic-basename-for-nonglibc.patch
+++ b/sys-fs/xfsdump/files/xfsdump-3.1.12-mimic-basename-for-nonglibc.patch
@@ -1,0 +1,42 @@
+https://bugs.gentoo.org/937495
+From: Brahmajit Das <brahmajit.xyz@gmail.com>
+Date: Tue, 3 Sep 2024 06:14:54 +0000
+Subject: [PATCH 1/1] xfsdump: Mimic GNU basename() API for non-glibc library
+ e.g. musl
+
+musl only provides POSIX version of basename and it has also removed
+providing it via string.h header [1] which now results in compile errors
+with newer compilers e.g. clang-18
+
+[1] https://git.musl-libc.org/cgit/musl/commit/?id=725e17ed6dff4d0cd22487bb64470881e86a92e7
+
+Please also reffer: https://bugs.gentoo.org/937495
+
+Signed-off-by: Brahmajit Das <brahmajit.xyz@gmail.com>
+--- a/common/main.c
++++ b/common/main.c
+@@ -77,6 +77,9 @@
+ #define MINSTACKSZ	0x02000000
+ #define MAXSTACKSZ	0x08000000
+ 
++#if !defined(__GLIBC__)
++#define basename(src) (strrchr(src, '/') ? strrchr(src, '/') + 1 : src)
++#endif
+ 
+ /* declarations of externally defined global symbols *************************/
+ 
+--- a/invutil/invidx.c
++++ b/invutil/invidx.c
+@@ -41,6 +41,10 @@
+ #include "stobj.h"
+ #include "timeutil.h"
+ 
++#if !defined(__GLIBC__)
++#define basename(src) (strrchr(src, '/') ? strrchr(src, '/') + 1 : src)
++#endif
++
+ invidx_fileinfo_t *invidx_file;
+ int invidx_numfiles;
+ 
+-- 
+2.46.0

--- a/sys-fs/xfsdump/xfsdump-3.1.12-r1.ebuild
+++ b/sys-fs/xfsdump/xfsdump-3.1.12-r1.ebuild
@@ -1,0 +1,81 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit flag-o-matic toolchain-funcs
+
+DESCRIPTION="XFS dump/restore utilities"
+HOMEPAGE="https://xfs.wiki.kernel.org/ https://git.kernel.org/pub/scm/fs/xfs/xfsdump-dev.git/"
+SRC_URI="https://www.kernel.org/pub/linux/utils/fs/xfs/${PN}/${P}.tar.xz"
+
+LICENSE="LGPL-2.1"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~mips ~ppc ~ppc64 ~riscv ~sparc ~x86"
+IUSE="ncurses nls"
+
+RDEPEND="
+	>=sys-apps/attr-2.4.19
+	sys-apps/util-linux
+	sys-fs/e2fsprogs
+	>=sys-fs/xfsprogs-3.2.0
+	ncurses? ( sys-libs/ncurses:= )
+"
+DEPEND="${RDEPEND}"
+BDEPEND="
+	ncurses? ( virtual/pkgconfig )
+	nls? ( sys-devel/gettext )
+"
+
+PATCHES=(
+	# bug #335115
+	"${FILESDIR}"/${PN}-3.1.9-prompt-overflow.patch
+	# bug #311881
+	"${FILESDIR}"/${PN}-3.1.9-no-symlink.patch
+	# bug #561664
+	"${FILESDIR}"/${PN}-3.1.6-linguas.patch
+
+	"${FILESDIR}"/${PN}-3.1.9-fix-docs.patch
+	"${FILESDIR}"/${PN}-3.1.9-skip-inventory-debian-subfolder.patch
+	"${FILESDIR}"/${PN}-3.1.12-mimic-basename-for-nonglibc.patch
+)
+
+src_prepare() {
+	sed -i \
+		-e "/^PKG_DOC_DIR/s:@pkg_name@:${PF}:" \
+		include/builddefs.in \
+		|| die
+
+	# bug #605852
+	sed -i \
+		-e "s:enable_curses=[a-z]*:enable_curses=$(usex ncurses):" \
+		-e "s:libcurses=\"[^\"]*\":libcurses='$(use ncurses && $(tc-getPKG_CONFIG) --libs ncurses)':" \
+		configure || die
+
+	default
+}
+
+src_configure() {
+	# bug #184564
+	unset PLATFORM
+
+	# bug 925234
+	use elibc_musl && append-flags -D_LARGEFILE64_SOURCE
+
+	export OPTIMIZER="${CFLAGS}"
+	export DEBUG=-DNDEBUG
+
+	local myeconfargs=(
+		$(use_enable nls gettext)
+		--libdir="${EPREFIX}/$(get_libdir)"
+		--libexecdir="${EPREFIX}/usr/$(get_libdir)"
+		--sbindir="${EPREFIX}/sbin"
+	)
+
+	econf "${myeconfargs[@]}"
+}
+
+src_compile() {
+	# Enable verbose build
+	emake V=1
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/937495

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
