### PR TITLE
net-libs/gloox: add examples USE flag

### DIFF
--- a/net-libs/gloox/gloox-1.0.28.ebuild
+++ b/net-libs/gloox/gloox-1.0.28.ebuild
@@ -15,7 +15,7 @@ LICENSE="GPL-3"
 # Check upstream changelog: https://camaya.net/gloox/changelog/
 SLOT="0/18"
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~ppc ~ppc64 ~sparc ~x86"
-IUSE="debug gnutls idn ssl static-libs test +xhtmlim zlib"
+IUSE="debug examples gnutls idn ssl static-libs test +xhtmlim zlib"
 RESTRICT="!test? ( test )"
 
 DEPEND="
@@ -34,12 +34,12 @@ src_prepare() {
 
 src_configure() {
 	local myeconfargs=(
-		--without-examples # not installed anyway so don't build them
 		$(usex debug "--enable-debug" '')
 		$(use_enable static-libs static)
 		$(use_enable xhtmlim)
-		$(use_with idn libidn)
+		$(use_with examples)
 		$(use_with gnutls)
+		$(use_with idn libidn)
 		$(use_with ssl openssl)
 		$(use_with test tests)
 		$(use_with zlib)
@@ -50,4 +50,11 @@ src_configure() {
 src_install() {
 	default
 	find "${ED}" -name "*.la" -delete || die
+
+	if use examples; then
+		# unhide the libs directory
+		mv "${S}"/src/examples/.libs "${S}"/src/examples/libs
+
+		dodoc -r src/examples/
+	fi
 }


### PR DESCRIPTION
As suggested in by @juippis in https://github.com/gentoo/gentoo/pull/38217#discussion_r1734092857

This documents example c++ code and object files & executables generated from it.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
