### PR TITLE
app-text/htmldoc: add 1.9.18 with "don't fortify source" patch

### DIFF
--- a/app-text/htmldoc/files/htmldoc-1.9.20_do-not-fortify-source.patch
+++ b/app-text/htmldoc/files/htmldoc-1.9.20_do-not-fortify-source.patch
@@ -1,0 +1,23 @@
+From: Filip Kobierski <fkobi@pm.me>
+
+https://bugs.gentoo.org/893274
+---
+ configure.ac | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index ab4a53d..9149d76 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -296,8 +296,6 @@ AS_IF([test -n "$GXX"], [
+     ], [
+ 	# Otherwise use the Fortify enhancements to catch any unbounded
+ 	# string operations...
+-	CFLAGS="$CFLAGS -D_FORTIFY_SOURCE=3"
+-	CXXFLAGS="$CXXFLAGS -D_FORTIFY_SOURCE=3"
+     ])
+ 
+     dnl Set optimization flags...
+-- 
+2.45.2
+

--- a/app-text/htmldoc/htmldoc-1.9.20.ebuild
+++ b/app-text/htmldoc/htmldoc-1.9.20.ebuild
@@ -1,0 +1,54 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools flag-o-matic toolchain-funcs xdg
+
+DESCRIPTION="Convert HTML pages into a PDF document"
+HOMEPAGE="https://www.msweet.org/htmldoc/"
+SRC_URI="https://github.com/michaelrsweet/${PN}/releases/download/v${PV}/${P}-source.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ppc ~ppc64 ~sparc ~x86"
+IUSE="fltk ssl"
+
+BDEPEND="virtual/pkgconfig"
+DEPEND="
+	media-libs/libjpeg-turbo:=
+	>=media-libs/libpng-1.4:0=
+	net-libs/gnutls:=
+	net-print/cups
+	sys-libs/zlib
+	fltk? ( x11-libs/fltk:1 )
+"
+RDEPEND="${DEPEND}"
+
+PATCHES=( "${FILESDIR}"/htmldoc-1.9.20_do-not-fortify-source.patch )
+
+src_prepare() {
+	default
+	eautoreconf
+
+	# Fix the documentation path in a few places. Some Makefiles aren't
+	# autotoolized =(
+	for file in configure doc/Makefile doc/htmldoc.man; do
+		sed -i "${file}" \
+			-e "s:/doc/htmldoc:/doc/${PF}/html:g" \
+		|| die "failed to fix documentation path in ${file}"
+	done
+}
+
+src_configure() {
+	filter-lto # -Werror=odr issues
+	local myeconfargs=(
+		$(use_with fltk gui)
+	)
+
+	CC="$(tc-getCC)" CXX="$(tc-getCXX)" econf "${myeconfargs[@]}"
+}
+
+src_install() {
+	emake STRIPPROG="true" DSTROOT="${ED}" install
+}


### PR DESCRIPTION
IDK if it should close https://bugs.gentoo.org/show_bug.cgi?id=893274 as it adds a new version not plagued with the issue.

Also the new version should get stabilized quicker than usual because of https://nvd.nist.gov/vuln/detail/CVE-2022-27114 ([source](https://repology.org/project/htmldoc/cves?version=1.9.16))



---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
