### PR TITLE
net-libs/libircclient: EAPI8 bump, use https, enable ipv6 unconditional

### DIFF
--- a/net-libs/libircclient/libircclient-1.10-r1.ebuild
+++ b/net-libs/libircclient/libircclient-1.10-r1.ebuild
@@ -1,0 +1,59 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools
+
+DESCRIPTION="Small but powerful library implementing the client-server IRC protocol"
+HOMEPAGE="https://www.ulduzsoft.com/libircclient/"
+SRC_URI="https://downloads.sourceforge.net/libircclient/${P}.tar.gz"
+
+LICENSE="LGPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~arm64 ~ppc ~ppc64 ~riscv ~sparc ~x86"
+IUSE="doc ssl static-libs threads"
+
+DEPEND="ssl? (
+		dev-libs/openssl:0=
+	)"
+RDEPEND="${DEPEND}"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-1.8-build.patch
+	"${FILESDIR}"/${PN}-1.10-shared.patch
+	"${FILESDIR}"/${PN}-1.8-static.patch
+	"${FILESDIR}"/${PN}-1.8-include.patch
+
+	# upstream patches (can usually be removed with next version bump)
+	"${FILESDIR}"/${PN}-1.10-openssl.patch
+)
+
+src_prepare() {
+	default
+	mv configure.in configure.ac || die
+	eautoconf
+}
+
+src_configure() {
+	local myeconfargs=(
+		$(use_enable threads)
+		$(use_enable ssl openssl)
+		$(use_enable ssl threads)
+		--enable-ipv6
+	)
+	econf "${myeconfargs[@]}"
+}
+
+src_compile() {
+	emake -C src $(usex static-libs "shared static" "shared")
+}
+
+src_install() {
+	emake -C src DESTDIR="${D}" install-shared $(usex static-libs "install-static" "")
+	insinto /usr/include/libircclient
+	doins include/*.h
+
+	dodoc Changelog THANKS
+	doman man/libircclient.1
+}


### PR DESCRIPTION
`EAPI8` bump with some minor changes. Most significant is that i've enabled `ipv6` unconditionally, which also fixes `UseFlagWithoutDeps`

```diff
--- libircclient-1.10.ebuild	2024-05-30 10:53:18.847286395 +0200
+++ libircclient-1.10-r1.ebuild	2024-09-03 16:18:08.290724115 +0200
@@ -1,17 +1,18 @@
 # Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
+
 inherit autotools
 
 DESCRIPTION="Small but powerful library implementing the client-server IRC protocol"
-HOMEPAGE="http://www.ulduzsoft.com/libircclient/"
+HOMEPAGE="https://www.ulduzsoft.com/libircclient/"
 SRC_URI="https://downloads.sourceforge.net/libircclient/${P}.tar.gz"
 
 LICENSE="LGPL-2+"
 SLOT="0"
-KEYWORDS="amd64 ~arm64 ppc ppc64 ~riscv sparc x86"
-IUSE="doc ipv6 ssl static-libs threads"
+KEYWORDS="~amd64 ~arm64 ~ppc ~ppc64 ~riscv ~sparc ~x86"
+IUSE="doc ssl static-libs threads"
 
 DEPEND="ssl? (
 		dev-libs/openssl:0=
@@ -37,9 +38,9 @@
 src_configure() {
 	local myeconfargs=(
 		$(use_enable threads)
-		$(use_enable ipv6)
 		$(use_enable ssl openssl)
 		$(use_enable ssl threads)
+		--enable-ipv6
 	)
 	econf "${myeconfargs[@]}"
 }
```

---
Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
