### PR TITLE
media-libs/sdl-gfx: EAPI8 bump, use https

### DIFF
--- a/media-libs/sdl-gfx/sdl-gfx-2.0.26-r2.ebuild
+++ b/media-libs/sdl-gfx/sdl-gfx-2.0.26-r2.ebuild
@@ -1,0 +1,43 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools multilib-minimal
+
+MY_P="${P/sdl-/SDL_}"
+DESCRIPTION="Graphics drawing primitives library for SDL"
+HOMEPAGE="https://www.ferzkopp.net/joomla/content/view/19/14/"
+SRC_URI="https://www.ferzkopp.net/Software/SDL_gfx-2.0/${MY_P}.tar.gz"
+S="${WORKDIR}/${MY_P}"
+
+LICENSE="ZLIB"
+SLOT="0/16" # libSDL_gfx.so.16
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~mips ~ppc ~ppc64 ~riscv ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
+IUSE="doc cpu_flags_x86_mmx"
+
+RDEPEND=">=media-libs/libsdl-1.2.15-r4[video,${MULTILIB_USEDEP}]"
+DEPEND="${RDEPEND}"
+
+src_prepare() {
+	default
+	sed -i -e 's/-O //' configure.in || die
+	mv configure.{in,ac} || die
+	eautoreconf
+}
+
+multilib_src_configure() {
+	ECONF_SOURCE="${S}" econf \
+		$(use_enable cpu_flags_x86_mmx mmx)
+}
+
+multilib_src_install_all() {
+	einstalldocs
+
+	if use doc ; then
+		docinto html
+		dodoc -r Docs/*
+	fi
+
+	find "${ED}" \( -name "*.a" -o -name "*.la" \) -delete || die
+}


### PR DESCRIPTION
`EAPI8` bump with some minor changes.
* removed `--disable-static` as it's passed per default
* removed the commented out `multilib_src_install()` - i don't see any reason to keep that?
* removed the `DOCS` variable - These files are being installed per default anyway.

```diff
--- sdl-gfx-2.0.26-r1.ebuild	2024-01-17 20:05:13.225816472 +0100
+++ sdl-gfx-2.0.26-r2.ebuild	2024-09-03 16:37:31.019640220 +0200
@@ -1,43 +1,36 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 inherit autotools multilib-minimal
 
 MY_P="${P/sdl-/SDL_}"
 DESCRIPTION="Graphics drawing primitives library for SDL"
-HOMEPAGE="http://www.ferzkopp.net/joomla/content/view/19/14/"
-SRC_URI="http://www.ferzkopp.net/Software/SDL_gfx-2.0/${MY_P}.tar.gz"
+HOMEPAGE="https://www.ferzkopp.net/joomla/content/view/19/14/"
+SRC_URI="https://www.ferzkopp.net/Software/SDL_gfx-2.0/${MY_P}.tar.gz"
 S="${WORKDIR}/${MY_P}"
 
 LICENSE="ZLIB"
 SLOT="0/16" # libSDL_gfx.so.16
-KEYWORDS="~alpha amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~mips ppc ppc64 ~riscv sparc x86 ~amd64-linux ~x86-linux ~ppc-macos"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~mips ~ppc ~ppc64 ~riscv ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
 IUSE="doc cpu_flags_x86_mmx"
 
 RDEPEND=">=media-libs/libsdl-1.2.15-r4[video,${MULTILIB_USEDEP}]"
 DEPEND="${RDEPEND}"
 
-DOCS=( AUTHORS ChangeLog README )
-
 src_prepare() {
 	default
 	sed -i -e 's/-O //' configure.in || die
-	mv configure.in configure.ac || die
+	mv configure.{in,ac} || die
 	eautoreconf
 }
 
 multilib_src_configure() {
 	ECONF_SOURCE="${S}" econf \
-		$(use_enable cpu_flags_x86_mmx mmx) \
-		--disable-static
+		$(use_enable cpu_flags_x86_mmx mmx)
 }
 
-#multilib_src_install() {
-#	emake DESTDIR="${D}" install
-#}
-
 multilib_src_install_all() {
 	einstalldocs
 
```

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
