### PR TITLE
dev-libs/cgilib: EAPI8 bump, fix bug #842870

### DIFF
--- a/dev-libs/cgilib/cgilib-0.7-r2.ebuild
+++ b/dev-libs/cgilib/cgilib-0.7-r2.ebuild
@@ -1,0 +1,34 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools
+
+DESCRIPTION="Simple and lightweight interface to the CGI for C and C++ programs"
+HOMEPAGE="https://www.infodrom.org/projects/cgilib/"
+SRC_URI="https://www.infodrom.org/projects/cgilib/download/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ppc ~ppc64 ~s390 ~sparc ~x86"
+IUSE="static-libs"
+
+DOCS=( AUTHORS ChangeLog README cookies.txt )
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_configure() {
+	econf $(use_enable static-libs static)
+}
+
+src_install() {
+	default
+
+	if ! use static-libs; then
+		find "${ED}" -name '*.la' -delete || die
+	fi
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/842870

Simple `EAPI8` bump.

```diff
--- cgilib-0.7-r1.ebuild	2024-08-26 09:12:01.951875721 +0200
+++ cgilib-0.7-r2.ebuild	2024-09-04 00:47:42.106832741 +0200
@@ -1,16 +1,17 @@
 # Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
+
 inherit autotools
 
-DESCRIPTION="A simple and lightweight interface to the CGI for C and C++ programs"
+DESCRIPTION="Simple and lightweight interface to the CGI for C and C++ programs"
 HOMEPAGE="https://www.infodrom.org/projects/cgilib/"
 SRC_URI="https://www.infodrom.org/projects/cgilib/download/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm ~hppa ~ia64 ppc ppc64 ~s390 sparc x86"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ia64 ~ppc ~ppc64 ~s390 ~sparc ~x86"
 IUSE="static-libs"
 
 DOCS=( AUTHORS ChangeLog README cookies.txt )
@@ -21,6 +22,13 @@
 }
 
 src_configure() {
-	econf \
-		$(use_enable static-libs static)
+	econf $(use_enable static-libs static)
+}
+
+src_install() {
+	default
+
+	if ! use static-libs; then
+		find "${ED}" -name '*.la' -delete || die
+	fi
 }
```

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
