### PR TITLE
media-libs/fluidsynth-dssi: EAPI8 bump, fix LICENSE, fix bug #847400

### DIFF
--- a/media-libs/fluidsynth-dssi/fluidsynth-dssi-1.0.0-r2.ebuild
+++ b/media-libs/fluidsynth-dssi/fluidsynth-dssi-1.0.0-r2.ebuild
@@ -1,0 +1,37 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools
+
+DESCRIPTION="DSSI Soft Synth Interface"
+HOMEPAGE="https://dssi.sourceforge.net/"
+SRC_URI="https://downloads.sourceforge.net/dssi/${P}.tar.gz"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86"
+
+BDEPEND="virtual/pkgconfig"
+DEPEND="
+	media-libs/dssi
+	media-libs/liblo
+	media-sound/fluidsynth:=
+	x11-libs/gtk+:2
+"
+RDEPEND="${DEPEND}"
+
+PATCHES=(
+	"${FILESDIR}/${PV}-fluidsynth2.patch"
+)
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_install() {
+	default
+	find "${ED}" -name '*.la' -delete || die
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/847400

Another simple `EAPI8` with some other fixes.

```diff
--- fluidsynth-dssi-1.0.0-r1.ebuild	2024-05-30 10:53:18.789286638 +0200
+++ fluidsynth-dssi-1.0.0-r2.ebuild	2024-09-03 18:57:12.262946148 +0200
@@ -1,7 +1,7 @@
 # Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 inherit autotools
 
@@ -9,10 +9,9 @@
 HOMEPAGE="https://dssi.sourceforge.net/"
 SRC_URI="https://downloads.sourceforge.net/dssi/${P}.tar.gz"
 
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="0"
-KEYWORDS="amd64 ~ppc x86"
-IUSE=""
+KEYWORDS="~amd64 ~ppc ~x86"
 
 BDEPEND="virtual/pkgconfig"
 DEPEND="
@@ -31,3 +30,7 @@
 	default
 	eautoreconf
 }
+
+src_install() {
+	find "${ED}" -name '*.la' -delete || die
+}
```

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
