### PR TITLE
dev-libs/libbase58, net-libs/libblkmaker: fix installing la files

### DIFF
--- a/dev-libs/libbase58/libbase58-0.1.4-r2.ebuild
+++ b/dev-libs/libbase58/libbase58-0.1.4-r2.ebuild
@@ -53,4 +53,6 @@ src_install() {
 		# It's hard to control this directory with multilib_is_native_abi && use tools, hence -f.
 		rm -rf "${ED}/TRASH" || die
 	fi
+
+	find "${ED}" -name '*.la' -delete || die
 }

--- a/net-libs/libblkmaker/libblkmaker-0.6.0-r2.ebuild
+++ b/net-libs/libblkmaker/libblkmaker-0.6.0-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -26,4 +26,9 @@ DEPEND="${RDEPEND}
 src_prepare() {
 	default
 	eautoreconf
+}
+
+src_install() {
+	default
+	find "${ED}" -name '*.la' -delete || die
 }


### PR DESCRIPTION
This fixes two very simple bugs where `.la` files were installed (without having static libs)
Since the changes are minimal i didn't do a revbump. I did however compile tested it (with tests enabled - both were successful).

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
