### PR TITLE
net-libs/grpc: fix build against abseil-cpp-20240722.0

### DIFF
--- a/net-libs/grpc/files/grpc-1.65.0-vlog.patch
+++ b/net-libs/grpc/files/grpc-1.65.0-vlog.patch
@@ -1,0 +1,17 @@
+
+Fix build with abseil-cpp-20240722.0 which no longer implicitly
+includes absl/log/vlog_is_on.h
+
+See: https://github.com/abseil/abseil-cpp/releases/tag/20240722.0
+Bug: https://bugs.gentoo.org/939015
+
+--- grpc-1.65.1/src/core/util/log.cc~	2024-07-17 00:53:49.000000000 +0200
++++ grpc-1.65.1/src/core/util/log.cc	2024-09-04 09:28:18.494476262 +0200
+@@ -19,6 +19,7 @@
+ #include <grpc/support/port_platform.h>
+ 
+ #include "absl/log/log.h"
++#include "absl/log/vlog_is_on.h"
+ 
+ #include <stdio.h>
+ #include <string.h>

--- a/net-libs/grpc/grpc-1.65.1.ebuild
+++ b/net-libs/grpc/grpc-1.65.1.ebuild
@@ -56,6 +56,7 @@ BDEPEND="
 
 PATCHES=(
 	"${FILESDIR}/${PN}-1.65.0-system-gtest.patch"
+	"${FILESDIR}/${PN}-1.65.0-vlog.patch"
 )
 
 python_check_deps() {


### PR DESCRIPTION
Fix build against abseil-cpp-20240722.0

Closes: https://bugs.gentoo.org/939015

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
