### PR TITLE
net-analyzer/mping: EAPI8 bump, use https

### DIFF
--- a/net-analyzer/mping/mping-2.01.ebuild
+++ b/net-analyzer/mping/mping-2.01.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 DESCRIPTION="IPv4/6 round-robin multiping client"
-HOMEPAGE="http://mping.uninett.no"
-SRC_URI="http://mping.uninett.no/${P}.tar.gz"
+HOMEPAGE="https://mping.uninett.no"
+SRC_URI="https://mping.uninett.no/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"


### PR DESCRIPTION
This is a very simple `EAPI8` bump and also uses `https` instead of `http` in `HOMEPAGE` and `SRC_URI`.
Since the changes are minimal i was thinking to simple update only the stable ebuild. Would that be fine?

```diff
--- mping-2.01.ebuild	2024-01-17 20:05:13.323815810 +0100
+++ mping-2.01-r1.ebuild	2024-09-04 13:53:09.960396216 +0200
@@ -1,15 +1,15 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 DESCRIPTION="IPv4/6 round-robin multiping client"
-HOMEPAGE="http://mping.uninett.no"
-SRC_URI="http://mping.uninett.no/${P}.tar.gz"
+HOMEPAGE="https://mping.uninett.no"
+SRC_URI="https://mping.uninett.no/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 ppc ppc64 sparc x86"
+KEYWORDS="~amd64 ~ppc ~ppc64 ~sparc ~x86"
 
 PATCHES=(
 	"${FILESDIR}"/${P}-RFC3542.patch
```

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
