### PR TITLE
net-misc/vncsnapshot: EAPI8 bump, fix LICENSE, use https

### DIFF
--- a/net-misc/vncsnapshot/vncsnapshot-1.2a-r1.ebuild
+++ b/net-misc/vncsnapshot/vncsnapshot-1.2a-r1.ebuild
@@ -1,0 +1,61 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs
+
+DESCRIPTION="Command-line tool for taking JPEG snapshots of VNC servers"
+HOMEPAGE="https://vncsnapshot.sourceforge.net/"
+SRC_URI="https://downloads.sourceforge.net/${PN}/${P}-src.tar.bz2"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~arm64 ~ppc ~x86"
+
+DEPEND="
+	media-libs/libjpeg-turbo:=
+	sys-libs/zlib
+"
+RDEPEND="${DEPEND}"
+
+PATCHES=(
+	"${FILESDIR}/${P}-amd64grey.patch"
+)
+
+src_prepare() {
+	default
+
+	sed \
+		-e 's:-I/usr/local/include::g' \
+		-e 's:-L/usr/local/lib::g' \
+		-e '/^all:/s|$(SUBDIRS:.dir=.all)||g' \
+		-e '/^vnc/s|$| $(SUBDIRS:.dir=.all)|g' \
+		-i Makefile || die
+
+	# Preserve make instance
+	sed -i -e 's/make/$(MAKE)/' Makefile || die
+
+	# Respect RANLIB
+	sed -i -e 's/ranlib/$(RANLIB)/' rdr/Makefile || die
+}
+
+src_compile() {
+	# We override CDEBUGFLAGS instead of CFLAGS because otherwise
+	# we lose the INCLUDES in the makefile. The same flags are used
+	# for both.
+	# bug #295741
+	local args=(
+		AR="$(tc-getAR)"
+		CDEBUGFLAGS="${CXXFLAGS}"
+		CC="$(tc-getCC)"
+		CXX="$(tc-getCXX)"
+		RANLIB="$(tc-getRANLIB)"
+	)
+	emake "${args[@]}"
+}
+
+src_install() {
+	dobin vncsnapshot
+	newman vncsnapshot.man1 vncsnapshot.1
+}


### PR DESCRIPTION
another simple `EAPI8` bump

```diff
--- vncsnapshot-1.2a.ebuild	2024-05-30 10:53:18.864286324 +0200
+++ vncsnapshot-1.2a-r1.ebuild	2024-09-04 15:15:30.114911223 +0200
@@ -1,21 +1,21 @@
 # Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 inherit toolchain-funcs
 
-DESCRIPTION="A command-line tool for taking JPEG snapshots of VNC servers"
-HOMEPAGE="http://vncsnapshot.sourceforge.net/"
+DESCRIPTION="Command-line tool for taking JPEG snapshots of VNC servers"
+HOMEPAGE="https://vncsnapshot.sourceforge.net/"
 SRC_URI="https://downloads.sourceforge.net/${PN}/${P}-src.tar.bz2"
 
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="0"
-KEYWORDS="~amd64 ~arm64 ppc x86"
+KEYWORDS="~amd64 ~arm64 ~ppc ~x86"
 
 DEPEND="
+	media-libs/libjpeg-turbo:=
 	sys-libs/zlib
-	virtual/jpeg
 "
 RDEPEND="${DEPEND}"
```

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
