### PR TITLE
Add support for git-credential-netrc

### DIFF
--- a/dev-vcs/git/git-2.46.0.ebuild
+++ b/dev-vcs/git/git-2.46.0.ebuild
@@ -333,6 +333,10 @@ src_compile() {
 		git_emake gitweb
 	fi
 
+	if use perl ; then
+		git_emake -C contrib/credential/netrc
+	fi
+
 	if [[ ${CHOST} == *-darwin* ]] && tc-is-clang ; then
 		git_emake -C contrib/credential/osxkeychain
 	fi
@@ -482,6 +486,12 @@ src_test() {
 
 	# And bail if there was a problem
 	[[ ${rc} -eq 0 ]] || die "Tests failed. Please file a bug!"
+
+	if use perl ; then
+		make -C contrib/credential/netrc test || \
+		make -C contrib/credential/netrc testverbose || \
+		die "Tests failed for git-credential-netrc failed.  Please file a bug!"
+	fi
 }
 
 src_install() {
@@ -606,6 +616,12 @@ src_install() {
 		done
 	else
 		rm -rf "${ED}"/usr/share/gitweb
+	fi
+
+	if use perl ; then
+		pushd contrib/credential/netrc &>/dev/null || die
+		dobin git-credential-netrc
+		popd &>/dev/null || die
 	fi
 
 	if ! use subversion ; then

--- a/dev-vcs/git/git-2.46.1.ebuild
+++ b/dev-vcs/git/git-2.46.1.ebuild
@@ -333,6 +333,10 @@ src_compile() {
 		git_emake gitweb
 	fi
 
+	if use perl ; then
+		git_emake -C contrib/credential/netrc
+	fi
+
 	if [[ ${CHOST} == *-darwin* ]] && tc-is-clang ; then
 		git_emake -C contrib/credential/osxkeychain
 	fi
@@ -482,6 +486,12 @@ src_test() {
 
 	# And bail if there was a problem
 	[[ ${rc} -eq 0 ]] || die "Tests failed. Please file a bug!"
+
+	if use perl ; then
+		make -C contrib/credential/netrc test || \
+		make -C contrib/credential/netrc testverbose || \
+		die "Tests failed for git-credential-netrc failed.  Please file a bug!"
+	fi
 }
 
 src_install() {
@@ -606,6 +616,12 @@ src_install() {
 		done
 	else
 		rm -rf "${ED}"/usr/share/gitweb
+	fi
+
+	if use perl ; then
+		pushd contrib/credential/netrc &>/dev/null || die
+		dobin git-credential-netrc
+		popd &>/dev/null || die
 	fi
 
 	if ! use subversion ; then

--- a/dev-vcs/git/git-9999.ebuild
+++ b/dev-vcs/git/git-9999.ebuild
@@ -333,6 +333,10 @@ src_compile() {
 		git_emake gitweb
 	fi
 
+	if use perl ; then
+		git_emake -C contrib/credential/netrc
+	fi
+
 	if [[ ${CHOST} == *-darwin* ]] && tc-is-clang ; then
 		git_emake -C contrib/credential/osxkeychain
 	fi
@@ -482,6 +486,12 @@ src_test() {
 
 	# And bail if there was a problem
 	[[ ${rc} -eq 0 ]] || die "Tests failed. Please file a bug!"
+
+	if use perl ; then
+		make -C contrib/credential/netrc test || \
+		make -C contrib/credential/netrc testverbose || \
+		die "Tests failed for git-credential-netrc failed.  Please file a bug!"
+	fi
 }
 
 src_install() {
@@ -606,6 +616,12 @@ src_install() {
 		done
 	else
 		rm -rf "${ED}"/usr/share/gitweb
+	fi
+
+	if use perl ; then
+		pushd contrib/credential/netrc &>/dev/null || die
+		dobin git-credential-netrc
+		popd &>/dev/null || die
 	fi
 
 	if ! use subversion ; then


### PR DESCRIPTION
This adds support for the `git-credential-netrc` helper.  I believe this addition mirrors the behavior before in Fedora, but I could be wrong.

This is my first time contributing to an ebuild so please let me know if there's anything else I need to do.  At he very least, I was able to test this locally and its installs and runs correctly.  

Final note, the `git-credential-netrc` helper has the ability to automatically decrypt netrc files with gpg if they are named `.netrc.gpg`.  This also worked for me locally, but I'm not sure how to mark this functionality with the `gpg` use flag.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.


Please note that all boxes must be checked for the pull request to be merged.
