### PR TITLE
net-libs/libnetfilter_log: fix LICENSE, fix bug #840972

### DIFF
--- a/net-libs/libnetfilter_log/libnetfilter_log-1.0.2-r1.ebuild
+++ b/net-libs/libnetfilter_log/libnetfilter_log-1.0.2-r1.ebuild
@@ -1,0 +1,42 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit linux-info verify-sig
+
+DESCRIPTION="Interface to packets that have been logged by the kernel packet filter"
+HOMEPAGE="https://www.netfilter.org/projects/libnetfilter_log/"
+SRC_URI="https://www.netfilter.org/projects/${PN}/files/${P}.tar.bz2
+	verify-sig? ( https://www.netfilter.org/projects/${PN}/files/${P}.tar.bz2.sig )"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~riscv ~sparc ~x86"
+IUSE="doc"
+VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/openpgp-keys/netfilter.org.asc
+
+RDEPEND=">=net-libs/libnfnetlink-1.0.0
+	>=net-libs/libmnl-1.0.3"
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig
+	doc? ( app-text/doxygen )
+	verify-sig? ( sec-keys/openpgp-keys-netfilter )"
+
+CONFIG_CHECK="~NETFILTER_NETLINK_LOG"
+
+pkg_setup() {
+	linux-info_pkg_setup
+	kernel_is lt 2 6 14 && die "requires at least 2.6.14 kernel version"
+}
+
+src_configure() {
+	econf \
+		$(use_enable doc html-doc) \
+		$(use_enable doc man-pages)
+}
+
+src_install() {
+	default
+	find "${ED}" -name '*.la' -delete || die
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/840972

```diff
--- libnetfilter_log-1.0.2.ebuild	2024-02-05 20:40:42.715710076 +0100
+++ libnetfilter_log-1.0.2-r1.ebuild	2024-09-04 18:42:22.644320832 +0200
@@ -10,9 +10,9 @@
 SRC_URI="https://www.netfilter.org/projects/${PN}/files/${P}.tar.bz2
 	verify-sig? ( https://www.netfilter.org/projects/${PN}/files/${P}.tar.bz2.sig )"
 
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="0"
-KEYWORDS="amd64 ~ia64 ppc ~riscv ~sparc x86"
+KEYWORDS="~amd64 ~ia64 ~ppc ~riscv ~sparc ~x86"
 IUSE="doc"
 VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/openpgp-keys/netfilter.org.asc
 
@@ -35,3 +35,8 @@
 		$(use_enable doc html-doc) \
 		$(use_enable doc man-pages)
 }
+
+src_install() {
+	default
+	find "${ED}" -name '*.la' -delete || die
+}
```

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
