### PR TITLE
app-text/wv2: fix bug #841964

### DIFF
--- a/app-text/wv2/wv2-0.4.2-r4.ebuild
+++ b/app-text/wv2/wv2-0.4.2-r4.ebuild
@@ -1,0 +1,44 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit cmake flag-o-matic
+
+DESCRIPTION="Excellent MS Word filter lib, used in most Office suites"
+HOMEPAGE="https://wvware.sourceforge.net"
+SRC_URI="https://downloads.sourceforge.net/wvware/${P}.tar.bz2"
+
+LICENSE="LGPL-2"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm64 ~hppa ~ppc ~ppc64 ~sparc ~x86"
+IUSE="zlib"
+
+RDEPEND="dev-libs/glib
+	>=gnome-extra/libgsf-1.8:=
+	virtual/libiconv
+	zlib? ( sys-libs/zlib )"
+DEPEND="${RDEPEND}"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-glib.patch
+	"${FILESDIR}"/${P}-libgsf.patch
+)
+
+DOCS=( AUTHORS ChangeLog README RELEASE THANKS TODO )
+
+src_configure() {
+	# Due to ICU 59 requiring C++11 now
+	append-cxxflags -std=c++11
+
+	local mycmakeargs=(
+		-DWITH_ZLIB=$(usex zlib)
+	)
+
+	cmake_src_configure
+}
+
+src_install() {
+	cmake_src_install
+	find "${ED}" -name '*.la' -delete || die
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/841964

```diff
--- wv2-0.4.2-r3.ebuild	2024-05-30 10:53:18.526287742 +0200
+++ wv2-0.4.2-r4.ebuild	2024-09-04 19:02:49.835921810 +0200
@@ -11,7 +11,7 @@
 
 LICENSE="LGPL-2"
 SLOT="0"
-KEYWORDS="~alpha amd64 ~arm64 ~hppa ~ia64 ppc ppc64 sparc x86"
+KEYWORDS="~alpha ~amd64 ~arm64 ~hppa ~ia64 ~ppc ~ppc64 ~sparc ~x86"
 IUSE="zlib"
 
 RDEPEND="dev-libs/glib
@@ -37,3 +37,8 @@
 
 	cmake_src_configure
 }
+
+src_install() {
+	cmake_src_install
+	find "${ED}" -name '*.la' -delete || die
+}
```

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
