### PR TITLE
dev-db/mongodb: add PATH to Environmnet, otherwise build failed w/ clang

### DIFF
--- a/dev-db/mongodb/files/mongodb-5.0.26-scons.patch
+++ b/dev-db/mongodb/files/mongodb-5.0.26-scons.patch
@@ -1,0 +1,27 @@
+https://jira.mongodb.org/browse/SERVER-94430 Upstream respond:
+
+> we intentionally do not ingest the environment PATH as this makes build
+> reproducibility and hermiticity much harder. Instead, you should set the
+> absolute paths to the tools you want to use on the command line, instead of
+> relying on the PATH.
+
+Gentoo bug https://bugs.gentoo.org/829340
+
+In Gentoo, we have LLVM slotted and we put clang in /usr/lib/llvm/18/bin (or
+whatever), not in /usr/bin, and if upstream strip PATH and construct it
+themselves, they surely won't contain this location.
+
+So we add PATH backup for scons.
+diff --git a/SConstruct b/SConstruct
+index 3d831c9..f07feeb 100644
+--- a/SConstruct
++++ b/SConstruct
+@@ -1201,7 +1201,7 @@ envDict = dict(BUILD_ROOT=buildDir,
+ if get_option('build-tools') == 'next':
+     SCons.Tool.DefaultToolpath.insert(0, os.path.abspath('site_scons/site_tools/next'))
+ 
+-env = Environment(variables=env_vars, **envDict)
++env = Environment(variables=env_vars, ENV={'PATH': os.environ['PATH']}, **envDict)
+ del envDict
+ 
+ if get_option('cache-signature-mode') == 'validate':

--- a/dev-db/mongodb/mongodb-5.0.26.ebuild
+++ b/dev-db/mongodb/mongodb-5.0.26.ebuild
@@ -76,6 +76,7 @@ PATCHES=(
 	"${FILESDIR}/${PN}-4.4.29-no-enterprise.patch"
 	"${FILESDIR}/${PN}-5.0.26-boost-1.85.patch"
 	"${FILESDIR}/${PN}-5.0.26-boost-1.85-extra.patch"
+	"${FILESDIR}/${PN}-5.0.26-scons.patch"
 )
 
 python_check_deps() {


### PR DESCRIPTION
patch had been submitted to upstream, see https://github.com/mongodb/mongo/pull/1600

Closes: https://bugs.gentoo.org/829340

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
