### PR TITLE
net-irc/kvirc: stop forcing emake

### DIFF
--- a/net-irc/kvirc/kvirc-9999.ebuild
+++ b/net-irc/kvirc/kvirc-9999.ebuild
@@ -4,7 +4,6 @@
 EAPI="8"
 DESCRIPTION="Advanced IRC Client"
 HOMEPAGE="https://www.kvirc.net/ https://github.com/kvirc/KVIrc"
-CMAKE_MAKEFILE_GENERATOR="emake"
 PYTHON_COMPAT=( python3_{10..12} )
 
 inherit cmake flag-o-matic python-single-r1 xdg


### PR DESCRIPTION
Partially revert 33d72cab6898eaeb782fe60eb1e1b8f794a655a5

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [ ] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [ ] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [ ] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
