### PR TITLE
dev-libs/isa-l: add no-fortify-source patch

### DIFF
--- a/dev-libs/isa-l/files/isa-l-2.31.0_no-fortify-source.patch
+++ b/dev-libs/isa-l/files/isa-l-2.31.0_no-fortify-source.patch
@@ -1,0 +1,38 @@
+From: Filip Kobierski <fkobi@pm.me>
+Date: Fri, 6 Sep 2024 12:49:09 +0200
+Upstream hardcodes FORTIFY_SOURCE to 2. This patch removes it so it is not redefined when we set it.
+This fixes https://bugs.gentoo.org/935525
+
+---
+ configure.ac | 1 -
+ make.inc     | 2 +-
+ 2 files changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index 72500ee..72bbb54 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -301,7 +301,6 @@ my_CFLAGS="\
+ -Wstrict-prototypes \
+ -Wtype-limits \
+ -fstack-protector \
+--D_FORTIFY_SOURCE=2 \
+ "
+ AC_SUBST([my_CFLAGS])
+ 
+diff --git a/make.inc b/make.inc
+index 33baf49..0cfc571 100644
+--- a/make.inc
++++ b/make.inc
+@@ -57,7 +57,7 @@ DEBUG_yasm = -g dwarf2
+ DEBUG_nasm = -g
+ 
+ # Default arch= build options
+-CFLAGS_    = -Wall -Wchar-subscripts -Wformat-security -Wnested-externs -Wpointer-arith -Wshadow -Wstrict-prototypes -Wtype-limits -fstack-protector -D_FORTIFY_SOURCE=2
++CFLAGS_    = -Wall -Wchar-subscripts -Wformat-security -Wnested-externs -Wpointer-arith -Wshadow -Wstrict-prototypes -Wtype-limits -fstack-protector
+ ASFLAGS_   = -f elf64
+ ARFLAGS_   = cr $@
+ STRIP_gcc  = strip -d -R .comment $@
+-- 
+2.44.2
+

--- a/dev-libs/isa-l/isa-l-2.31.0.ebuild
+++ b/dev-libs/isa-l/isa-l-2.31.0.ebuild
@@ -36,6 +36,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-2.30.0_fix-shebang.patch
 	"${FILESDIR}"/${PN}-2.31.0_makefile-no-D.patch
 	"${FILESDIR}"/${PN}-2.31.0_makefile-x86.patch
+	"${FILESDIR}"/${PN}-2.31.0_no-fortify-source.patch
 	"${FILESDIR}"/${PN}-2.31.0_user-ldflags.patch
 )
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/935525

quick small change

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
