### PR TITLE
net-dns/dnsdist: build fixes for gcc-15 & boost-1.86.0

### DIFF
--- a/net-dns/dnsdist/dnsdist-1.9.6-r1.ebuild
+++ b/net-dns/dnsdist/dnsdist-1.9.6-r1.ebuild
@@ -1,0 +1,117 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+LUA_COMPAT=( lua5-{1..4} luajit )
+
+inherit flag-o-matic lua-single
+
+DESCRIPTION="A highly DNS-, DoS- and abuse-aware loadbalancer"
+HOMEPAGE="https://dnsdist.org"
+
+SRC_URI="https://downloads.powerdns.com/releases/${P}.tar.bz2"
+LICENSE="GPL-2"
+SLOT="0"
+
+KEYWORDS="~amd64 ~x86"
+
+IUSE="bpf cdb dnscrypt dnstap doh doh3 ipcipher lmdb quic regex snmp +ssl systemd test web xdp"
+RESTRICT="!test? ( test )"
+REQUIRED_USE="${LUA_REQUIRED_USE}
+		dnscrypt? ( ssl )
+		doh? ( ssl )
+		doh3? ( ssl quic )
+		ipcipher? ( ssl )
+		quic? ( ssl )"
+
+RDEPEND="acct-group/dnsdist
+	acct-user/dnsdist
+	bpf? ( dev-libs/libbpf:= )
+	cdb? ( dev-db/tinycdb:= )
+	dev-libs/boost:=
+	sys-libs/libcap
+	dev-libs/libedit
+	dev-libs/libsodium:=
+	dnstap? ( dev-libs/fstrm )
+	doh? ( net-libs/nghttp2:= )
+	doh3? ( net-libs/quiche:= )
+	lmdb? ( dev-db/lmdb:= )
+	quic? ( net-libs/quiche )
+	regex? ( dev-libs/re2:= )
+	snmp? ( net-analyzer/net-snmp:= )
+	ssl? ( dev-libs/openssl:= )
+	systemd? ( sys-apps/systemd:0= )
+	xdp? ( net-libs/xdp-tools )
+	${LUA_DEPS}
+"
+
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}/1.9.6-boost-1.86.0.patch"
+	"${FILESDIR}/1.9.6-json11-gcc15.patch"
+)
+
+src_prepare() {
+	default
+
+	# clean up duplicate file
+	rm -f README.md
+}
+
+src_configure() {
+	# bug #822855
+	append-lfs-flags
+
+	# some things can only be enabled/disabled by defines
+	! use dnstap && append-cppflags -DDISABLE_PROTOBUF
+	! use web && append-cppflags -DDISABLE_BUILTIN_HTML
+
+	sed 's/hardcode_libdir_flag_spec_CXX='\''$wl-rpath $wl$libdir'\''/hardcode_libdir_flag_spec_CXX='\''$wl-rpath $wl\/$libdir'\''/g' \
+		-i "${S}/configure"
+
+	local myeconfargs=(
+		--sysconfdir=/etc/dnsdist
+		--with-lua="${ELUA}"
+		--without-h2o
+		--enable-tls-providers
+		--without-gnutls
+		$(use_with bpf ebpf)
+		$(use_with cdb cdb)
+		$(use_enable doh dns-over-https)
+		$(use_enable doh3 dns-over-http3)
+		$(use_enable dnscrypt)
+		$(use_enable dnstap)
+		$(use_enable ipcipher)
+		$(use_with lmdb )
+		$(use_enable quic dns-over-quic)
+		$(use_with regex re2)
+		$(use_with snmp net-snmp)
+		$(use_enable ssl dns-over-tls)
+		$(use_enable systemd) \
+		$(use_enable test unit-tests)
+		$(use_with xdp xsk)
+	)
+
+	econf "${myeconfargs[@]}"
+}
+
+src_install() {
+	default
+
+	insinto /etc/dnsdist
+	doins "${FILESDIR}"/dnsdist.conf.example
+
+	newconfd "${FILESDIR}"/dnsdist.confd ${PN}
+	newinitd "${FILESDIR}"/dnsdist.initd ${PN}
+}
+
+pkg_postinst() {
+	elog "dnsdist provides multiple instances support. You can create more instances"
+	elog "by symlinking the dnsdist init script to another name."
+	elog
+	elog "The name must be in the format dnsdist.<suffix> and dnsdist will use the"
+	elog "/etc/dnsdist/dnsdist-<suffix>.conf configuration file instead of the default."
+}

--- a/net-dns/dnsdist/files/1.9.6-boost-1.86.0.patch
+++ b/net-dns/dnsdist/files/1.9.6-boost-1.86.0.patch
@@ -1,0 +1,35 @@
+
+Fix compilation with boost-1.86.
+Patch path prefix adapted for dnsdist.
+
+From: https://github.com/PowerDNS/pdns/commit/eed56000b1d68ac083b8e8bea4ff0ea30a1579c4
+
+From eed56000b1d68ac083b8e8bea4ff0ea30a1579c4 Mon Sep 17 00:00:00 2001
+From: Michael Cho <michael@michaelcho.dev>
+Date: Thu, 15 Aug 2024 22:49:17 -0400
+Subject: [PATCH] Fix build with boost 1.86.0
+
+Boost 1.86.0 changes seem to no longer indirectly include header which
+causes build to fail with:
+```
+uuid-utils.cc:38:58:
+error: 'random' is not a class, namespace, or enumeration
+```
+
+boost/random/mersenne_twister.hpp has been available since Boost 1.21.2
+---
+ pdns/uuid-utils.cc | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/pdns/uuid-utils.cc b/pdns/uuid-utils.cc
+index c59e0a0d0daa..301daff0bb1e 100644
+--- a/uuid-utils.cc
++++ b/uuid-utils.cc
+@@ -30,6 +30,7 @@
+ #endif /* BOOST_PENDING_INTEGER_LOG2_HPP */
+ #endif /* BOOST_VERSION */
+ 
++#include <boost/random/mersenne_twister.hpp>
+ #include <boost/uuid/uuid_generators.hpp>
+ 
+ // The default of:

--- a/net-dns/dnsdist/files/1.9.6-json11-gcc15.patch
+++ b/net-dns/dnsdist/files/1.9.6-json11-gcc15.patch
@@ -1,0 +1,19 @@
+
+Fix compilation with gcc-15
+
+Bug: https://bugs.gentoo.org/937628
+Bug: https://github.com/PowerDNS/pdns/issues/14549
+
+Signed-off-by: Holger Hoffstätte <holger@applied-asynchrony.com>
+
+diff -rup dnsdist-1.9.6/ext/json11/json11.cpp dnsdist-1.9.6-gcc15/ext/json11/json11.cpp
+--- dnsdist-1.9.6/ext/json11/json11.cpp	2024-07-15 11:46:15.000000000 +0200
++++ dnsdist-1.9.6-gcc15/ext/json11/json11.cpp	2024-08-09 18:03:51.090140981 +0200
+@@ -22,6 +22,7 @@
+ #include "json11.hpp"
+ #include <cassert>
+ #include <cmath>
++#include <cstdint>
+ #include <cstdlib>
+ #include <cstdio>
+ #include <limits>

--- a/net-dns/dnsdist/metadata.xml
+++ b/net-dns/dnsdist/metadata.xml
@@ -1,10 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<maintainer type="person">
-		<email>nativemad@gentoo.org</email>
-		<name>Andreas Schuerch</name>
-	</maintainer>
 	<maintainer type="person" proxied="yes">
 		<email>holger@applied-asynchrony.com</email>
 		<name>Holger Hoffstätte</name>
@@ -12,6 +8,10 @@
 	<maintainer type="project" proxied="proxy">
 		<email>proxy-maint@gentoo.org</email>
 		<name>Proxy Maintainers</name>
+	</maintainer>
+	<maintainer type="person">
+		<email>nativemad@gentoo.org</email>
+		<name>Andreas Schuerch</name>
 	</maintainer>
 	<longdescription lang="en">
 		dnsdist is a highly DNS-, DoS- and abuse-aware loadbalancer. Its goal in life is to route traffic to the best server, delivering top performance to legitimate users while shunting or blocking abusive traffic.


### PR DESCRIPTION
Reported & fixed upstream.
Also reorder maintainers for bug handling.

Closes: https://bugs.gentoo.org/937628
Closes: https://bugs.gentoo.org/938947

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
