### PR TITLE
sys-apps/hd-idle: fix systemd dropin file install location

### DIFF
--- a/sys-apps/hd-idle/hd-idle-1.05-r4.ebuild
+++ b/sys-apps/hd-idle/hd-idle-1.05-r4.ebuild
@@ -1,0 +1,33 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit linux-info systemd
+
+DESCRIPTION="Utility for spinning down hard disks after a period of idle time"
+HOMEPAGE="https://hd-idle.sourceforge.net/"
+SRC_URI="https://downloads.sourceforge.net/${PN}/${P}.tgz"
+S="${WORKDIR}/${PN}"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="amd64 x86"
+
+CONFIG_CHECK="~PROC_FS"
+
+DOCS=( debian/changelog README )
+
+src_install() {
+	default
+	systemd_newunit "${FILESDIR}"/hd-idle.service ${PN}.service
+	systemd_install_serviced "${FILESDIR}"/hd-idle-service-dropin.conf ${PN}.service
+	newinitd "${FILESDIR}"/hd-idle-init hd-idle
+	newconfd "${FILESDIR}"/hd-idle-conf hd-idle
+
+	elog "The systemd unit file for hd-idle no longer sources ${EPREFIX}/etc/conf.d/hd-idle ."
+	elog "Configuration is still done via ${EPREFIX}/etc/conf.d/hd-idle for OpenRC systems"
+	elog "while for systemd systems, a systemd drop-in file located at"
+	elog "${EPREFIX}/etc/systemd/system/hd-idle.service.d/00gentoo.conf"
+	elog "is used for configuration."
+}


### PR DESCRIPTION
`systemd_install_serviced` needs to know the name of the service to use the appropriate path. 

Closes: https://bugs.gentoo.org/937799

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
