### PR TITLE
gnome-extra/gnome-system-monitor: Fix clang compilation failure

### DIFF
--- a/gnome-extra/gnome-system-monitor/files/gnome-system-monitor-46.0-fix-clang-compilation.patch
+++ b/gnome-extra/gnome-system-monitor/files/gnome-system-monitor-46.0-fix-clang-compilation.patch
@@ -1,0 +1,18 @@
+https://gitlab.gnome.org/GNOME/gnome-system-monitor/-/commit/a738bcc9765032f52d89aebc976d4f7674c65ca9.patch
+From: "David C. Manuelda" <StormByte@gmail.com>
+Date: Sun, 1 Sep 2024 13:45:29 +0300
+Subject: [PATCH] Fixed clang compilation failure
+
+--- a/src/proctable.cpp
++++ b/src/proctable.cpp
+@@ -103,7 +103,7 @@ cb_tree_button_pressed (GtkGestureClick*,
+     gtk_tree_selection_select_path (selection, path);
+   gtk_tree_path_free (path);
+ 
+-  GdkRectangle rect = { x, y, 1, 1 };
++  GdkRectangle rect = { (gint)x, (gint)y, 1, 1 };
+ 
+   gtk_popover_set_pointing_to (GTK_POPOVER (app->proc_popover_menu), &rect);
+   gtk_popover_popup (GTK_POPOVER (app->proc_popover_menu));
+-- 
+GitLab

--- a/gnome-extra/gnome-system-monitor/gnome-system-monitor-46.0-r2.ebuild
+++ b/gnome-extra/gnome-system-monitor/gnome-system-monitor-46.0-r2.ebuild
@@ -1,0 +1,59 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+inherit gnome.org gnome2-utils meson xdg
+
+DESCRIPTION="The Gnome System Monitor"
+HOMEPAGE="https://apps.gnome.org/SystemMonitor/"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~loong ~ppc ~ppc64 ~riscv ~x86"
+
+IUSE="systemd X"
+
+RDEPEND="
+	>=dev-cpp/glibmm-2.68:2.68
+	>=dev-libs/glib-2.56.0:2
+	>=gui-libs/gtk-4.12.0:4[X(+)?]
+	>=dev-cpp/gtkmm-4.0.0:4.0
+	>=gnome-base/libgtop-2.41.2:2=
+	>=gui-libs/libadwaita-1.4.0:1
+	>=gnome-base/librsvg-2.46:2
+	>=dev-libs/libxml2-2.0:2
+	X? ( >=x11-libs/libwnck-2.91.0:3 )
+	systemd? ( >=sys-apps/systemd-44:0= )
+"
+# eautoreconf requires gnome-base/gnome-common
+DEPEND="${RDEPEND}"
+BDEPEND="
+	dev-util/glib-utils
+	dev-util/itstool
+	>=sys-devel/gettext-0.19.8
+	virtual/pkgconfig
+	>=sys-auth/polkit-0.114
+" # polkit needed at buildtime for ITS rules of policy files, first available in 0.114
+
+PATCHES=(
+	"${FILESDIR}/${PN}-46.0-fix-clang-compilation.patch"
+)
+
+src_configure() {
+	local emesonargs=(
+		$(meson_use X wnck)
+		$(meson_use systemd)
+		-Ddevelopment=false
+	)
+	meson_src_configure
+}
+
+pkg_postinst() {
+	xdg_pkg_postinst
+	gnome2_schemas_update
+}
+
+pkg_postrm() {
+	xdg_pkg_postrm
+	gnome2_schemas_update
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/937539

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
