### PR TITLE
sys-process/runit: fix path issue

### DIFF
--- a/sys-process/runit/runit-2.1.2-r6.ebuild
+++ b/sys-process/runit/runit-2.1.2-r6.ebuild
@@ -17,7 +17,7 @@ S=${WORKDIR}/admin/${P}/src
 LICENSE="BSD"
 SLOT="0"
 KEYWORDS="~alpha amd64 arm arm64 ~hppa ~m68k ~mips ppc ppc64 ~s390 sparc x86"
-IUSE="static"
+IUSE="split-usr static"
 
 RDEPEND="sys-apps/openrc"
 
@@ -50,11 +50,14 @@ src_configure() {
 }
 
 src_install() {
-	into /
 	dobin $(<../package/commands)
 	dodir /sbin
-	mv "${ED}"/bin/{runit-init,runit,utmpset} "${ED}"/sbin/ || die "dosbin"
-	dosym ../etc/runit/2 /sbin/runsvdir-start
+	mv "${ED}"/usr/bin/{runit-init,runit,utmpset} "${ED}"/sbin/ || die "dosbin"
+	if use split-usr ; then
+		dosym ../etc/runit/2 /sbin/runsvdir-start
+	else
+		dosym ../../etc/runit/2 /sbin/runsvdir-start
+	fi
 
 	DOCS=( ../package/{CHANGES,README,THANKS,TODO} )
 	HTML_DOCS=( ../doc/*.html )


### PR DESCRIPTION
 1. install binary to /usr
 2. handle symlink of /sbin/runsvdir-start by USE split-usr  
 
Closes: https://bugs.gentoo.org/904989
Closes: https://bugs.gentoo.org/935656

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
