### PR TITLE
dev-libs/mm, dev-libs/ossp-uuid: retarget at new upstream for OSSP software; dev-libs/ossp-uuid says licence=ISC, isn't

### DIFF
--- a/dev-libs/mm/metadata.xml
+++ b/dev-libs/mm/metadata.xml
@@ -2,4 +2,7 @@
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
 <!-- maintainer-needed -->
+<upstream>
+	<remote-id type="sourcehut">~nabijaczleweli/ossp</remote-id>
+</upstream>
 </pkgmetadata>

--- a/dev-libs/mm/mm-1.4.2-r2.ebuild
+++ b/dev-libs/mm/mm-1.4.2-r2.ebuild
@@ -4,8 +4,8 @@
 EAPI=8
 
 DESCRIPTION="Shared Memory Abstraction Library"
-HOMEPAGE="http://www.ossp.org/pkg/lib/mm/"
-SRC_URI="ftp://ftp.ossp.org/pkg/lib/mm/${P}.tar.gz"
+HOMEPAGE="https://sr.ht/~nabijaczleweli/ossp"
+SRC_URI="https://lfs.nabijaczleweli.xyz/0022-OSSP.org-mirror/ftp.ossp.org/ossp-ftp/pkg/lib/mm/${P}.tar.gz"
 
 LICENSE="mm"
 SLOT="1.2"

--- a/dev-libs/ossp-uuid/metadata.xml
+++ b/dev-libs/ossp-uuid/metadata.xml
@@ -2,4 +2,7 @@
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
 <!-- maintainer-needed -->
+<upstream>
+	<remote-id type="sourcehut">~nabijaczleweli/ossp</remote-id>
+</upstream>
 </pkgmetadata>

--- a/dev-libs/ossp-uuid/ossp-uuid-1.6.2-r7.ebuild
+++ b/dev-libs/ossp-uuid/ossp-uuid-1.6.2-r7.ebuild
@@ -10,8 +10,8 @@ GENTOO_DEPEND_ON_PERL="no"
 inherit perl-module
 
 DESCRIPTION="An ISO-C:1999 API with CLI for generating DCE, ISO/IEC and RFC compliant UUID"
-HOMEPAGE="http://www.ossp.org/pkg/lib/uuid/"
-SRC_URI="ftp://ftp.ossp.org/pkg/lib/uuid/${MY_P}.tar.gz"
+HOMEPAGE="https://sr.ht/~nabijaczleweli/ossp"
+SRC_URI="https://lfs.nabijaczleweli.xyz/0022-OSSP.org-mirror/ftp.ossp.org/ossp-ftp/pkg/lib/uuid/${MY_P}.tar.gz"
 S="${WORKDIR}/${MY_P}"
 
 LICENSE="ISC"


### PR DESCRIPTION
I'm the new upstream for OSSP software (https://sr.ht/~nabijaczleweli/ossp).

As part of this, I'm evaluating which downstreams package it, and if I need to unfreeze anything beside ossp-uuid.

All of the ossp-uuid patches will be fixed by the subsequent release, but for now just point the two OSSP packages at the new upstream (most importantly the distribution tarballs, which point at the old upstream's FTP, which is dying, dead, or broken at any given time) and fix ossp-uuid's licence stanza. It's not ISC, it's rse's special thing.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
