### PR TITLE
Destabilize Haskell

### DIFF
--- a/app-admin/haskell-updater/haskell-updater-1.3.2-r1.ebuild
+++ b/app-admin/haskell-updater/haskell-updater-1.3.2-r1.ebuild
@@ -13,7 +13,7 @@ HOMEPAGE="https://github.com/gentoo-haskell/haskell-updater#readme"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos"
 
 DEPEND=">=dev-lang/ghc-6.12.1:="
 

--- a/app-arch/pack/pack-0.0.0.1.ebuild
+++ b/app-arch/pack/pack-0.0.0.1.ebuild
@@ -17,7 +17,7 @@ S=${WORKDIR}/${MY_P}
 
 LICENSE="public-domain"
 SLOT="0"
-KEYWORDS="amd64 ~x86"
+KEYWORDS="~amd64 ~x86"
 
 RDEPEND="
 	dev-lang/ghc:=

--- a/app-portage/hackport/hackport-0.7.2.2.ebuild
+++ b/app-portage/hackport/hackport-0.7.2.2.ebuild
@@ -14,7 +14,7 @@ HOMEPAGE="https://hackage.haskell.org/package/hackport"
 
 LICENSE="GPL-3+"
 SLOT="0"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 GHC_BOOTSTRAP_PACKAGES=(
 	cabal-doctest

--- a/app-text/pandoc/pandoc-2.18-r2.ebuild
+++ b/app-text/pandoc/pandoc-2.18-r2.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="GPL-2+"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="embed-data-files trypandoc"
 
 RDEPEND=">=dev-haskell/aeson-0.7:=[profile?] <dev-haskell/aeson-2.1:=[profile?]

--- a/dev-haskell/abstract-deque/abstract-deque-0.3.ebuild
+++ b/dev-haskell/abstract-deque/abstract-deque-0.3.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="usecas"
 
 RDEPEND="dev-haskell/random:=[profile?]

--- a/dev-haskell/abstract-par/abstract-par-0.3.3-r1.ebuild
+++ b/dev-haskell/abstract-par/abstract-par-0.3.3-r1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-lang/ghc-7.4.1:=

--- a/dev-haskell/adjunctions/adjunctions-4.4.ebuild
+++ b/dev-haskell/adjunctions/adjunctions-4.4.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-haskell/comonad-4:=[profile?] <dev-haskell/comonad-6:=[profile?]

--- a/dev-haskell/aeson-pretty/aeson-pretty-0.8.9.ebuild
+++ b/dev-haskell/aeson-pretty/aeson-pretty-0.8.9.ebuild
@@ -16,7 +16,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="lib-only"
 
 RDEPEND=">=dev-haskell/base-compat-0.9:=[profile?]

--- a/dev-haskell/aeson/aeson-2.0.3.0.ebuild
+++ b/dev-haskell/aeson/aeson-2.0.3.0.ebuild
@@ -16,7 +16,7 @@ HOMEPAGE="https://github.com/haskell/aeson"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="cffi +ordered-keymap"
 
 RDEPEND=">=dev-haskell/attoparsec-0.14.2:=[profile?] <dev-haskell/attoparsec-0.15:=[profile?]

--- a/dev-haskell/alex/alex-3.2.7.1.ebuild
+++ b/dev-haskell/alex/alex-3.2.7.1.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="doc"
 
 RDEPEND=">=dev-lang/ghc-8.4.3:=

--- a/dev-haskell/alsa-core/alsa-core-0.5.0.1-r2.ebuild
+++ b/dev-haskell/alsa-core/alsa-core-0.5.0.1-r2.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-haskell/extensible-exceptions-0.1.1:=[profile?] <dev-haskell/extensible-exceptions-0.2:=[profile?]

--- a/dev-haskell/alsa-mixer/alsa-mixer-0.3.0.ebuild
+++ b/dev-haskell/alsa-mixer/alsa-mixer-0.3.0.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-haskell/alsa-core-0.5:=[profile?] <dev-haskell/alsa-core-0.6:=[profile?]

--- a/dev-haskell/ansi-terminal/ansi-terminal-0.10.3.ebuild
+++ b/dev-haskell/ansi-terminal/ansi-terminal-0.10.3.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="example"
 
 RDEPEND=">=dev-haskell/colour-2.1.0:=[profile?]

--- a/dev-haskell/ansi-wl-pprint/ansi-wl-pprint-0.6.9.ebuild
+++ b/dev-haskell/ansi-wl-pprint/ansi-wl-pprint-0.6.9.ebuild
@@ -20,7 +20,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz
 		-> ${CABAL_DISTFILE}"
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="examples"
 
 RDEPEND=">=dev-haskell/ansi-terminal-0.9.1:=[profile?] <dev-haskell/ansi-terminal-0.12:=[profile?]

--- a/dev-haskell/appar/appar-0.1.8.ebuild
+++ b/dev-haskell/appar/appar-0.1.8.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-haskell/fail-4.9:=[profile?] <dev-haskell/fail-4.10:=[profile?]

--- a/dev-haskell/asn1-encoding/asn1-encoding-0.9.6.ebuild
+++ b/dev-haskell/asn1-encoding/asn1-encoding-0.9.6.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-haskell/asn1-types-0.3.0:=[profile?] <dev-haskell/asn1-types-0.4:=[profile?]

--- a/dev-haskell/asn1-parse/asn1-parse-0.9.5.ebuild
+++ b/dev-haskell/asn1-parse/asn1-parse-0.9.5.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-haskell/asn1-encoding-0.9:=[profile?]

--- a/dev-haskell/asn1-types/asn1-types-0.3.3.ebuild
+++ b/dev-haskell/asn1-types/asn1-types-0.3.3.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND="dev-haskell/hourglass:=[profile?]

--- a/dev-haskell/assoc/assoc-1.0.2.ebuild
+++ b/dev-haskell/assoc/assoc-1.0.2.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-haskell/bifunctors-5.5.5:=[profile?] <dev-haskell/bifunctors-5.6:=[profile?]

--- a/dev-haskell/async/async-2.2.4-r1.ebuild
+++ b/dev-haskell/async/async-2.2.4-r1.ebuild
@@ -16,7 +16,7 @@ HOMEPAGE="https://github.com/simonmar/async"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND="
 	>=dev-haskell/hashable-1.1.2.0:=[profile?] <dev-haskell/hashable-1.5:=[profile?]

--- a/dev-haskell/atomic-primops/atomic-primops-0.8.4.ebuild
+++ b/dev-haskell/atomic-primops/atomic-primops-0.8.4.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="debug"
 
 RDEPEND="dev-haskell/primitive:=[profile?]

--- a/dev-haskell/attoparsec-iso8601/attoparsec-iso8601-1.0.2.1.ebuild
+++ b/dev-haskell/attoparsec-iso8601/attoparsec-iso8601-1.0.2.1.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-haskell/attoparsec-0.14.2:=[profile?] <dev-haskell/attoparsec-0.15:=[profile?]
 	>=dev-haskell/base-compat-batteries-0.10.0:=[profile?] <dev-haskell/base-compat-batteries-0.13:=[profile?]

--- a/dev-haskell/attoparsec/attoparsec-0.14.4.ebuild
+++ b/dev-haskell/attoparsec/attoparsec-0.14.4.ebuild
@@ -16,7 +16,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-haskell/scientific-0.3.1:=[profile?] <dev-haskell/scientific-0.4:=[profile?]
 	>=dev-lang/ghc-8.4.3:=

--- a/dev-haskell/auto-update/auto-update-0.1.6.ebuild
+++ b/dev-haskell/auto-update/auto-update-0.1.6.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-lang/ghc-7.4.1:=

--- a/dev-haskell/aws/aws-0.22-r5.ebuild
+++ b/dev-haskell/aws/aws-0.22-r5.ebuild
@@ -16,7 +16,7 @@ HOMEPAGE="https://github.com/aristidb/aws"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="examples"
 
 RESTRICT=test # requires aws account

--- a/dev-haskell/base-compat-batteries/base-compat-batteries-0.12.1.ebuild
+++ b/dev-haskell/base-compat-batteries/base-compat-batteries-0.12.1.ebuild
@@ -20,7 +20,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND="~dev-haskell/base-compat-0.12.1:=[profile?]
 	>=dev-haskell/contravariant-1.5:=[profile?] <dev-haskell/contravariant-1.6:=[profile?]

--- a/dev-haskell/base-compat/base-compat-0.12.1.ebuild
+++ b/dev-haskell/base-compat/base-compat-0.12.1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-lang/ghc-8.4.3:=
 "

--- a/dev-haskell/base-orphans/base-orphans-0.8.6.ebuild
+++ b/dev-haskell/base-orphans/base-orphans-0.8.6.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-lang/ghc-8.4.3:=
 "

--- a/dev-haskell/base16-bytestring/base16-bytestring-0.1.1.7.ebuild
+++ b/dev-haskell/base16-bytestring/base16-bytestring-0.1.1.7.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux"
 IUSE=""
 
 RDEPEND=">=dev-lang/ghc-7.4.1:=

--- a/dev-haskell/base64-bytestring/base64-bytestring-1.0.0.3.ebuild
+++ b/dev-haskell/base64-bytestring/base64-bytestring-1.0.0.3.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-lang/ghc-7.4.1:=

--- a/dev-haskell/basement/basement-0.0.12.ebuild
+++ b/dev-haskell/basement/basement-0.0.12.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-lang/ghc-8.4.3:= <dev-lang/ghc-9.1:=
 "

--- a/dev-haskell/bencode/bencode-0.6.1.1.ebuild
+++ b/dev-haskell/bencode/bencode-0.6.1.1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND="dev-haskell/parsec:=[profile?]

--- a/dev-haskell/bifunctors/bifunctors-5.5.11.ebuild
+++ b/dev-haskell/bifunctors/bifunctors-5.5.11.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="+semigroups +tagged"
 
 RDEPEND=">=dev-haskell/base-orphans-0.8.4:=[profile?] <dev-haskell/base-orphans-1:=[profile?]

--- a/dev-haskell/binary-orphans/binary-orphans-1.0.2.ebuild
+++ b/dev-haskell/binary-orphans/binary-orphans-1.0.2.ebuild
@@ -17,7 +17,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-haskell/onetuple-0.3:=[profile?] <dev-haskell/onetuple-0.4:=[profile?]
 	>=dev-lang/ghc-8.4.3:=

--- a/dev-haskell/binary/binary-0.8.8.0-r1.ebuild
+++ b/dev-haskell/binary/binary-0.8.8.0-r1.ebuild
@@ -19,7 +19,7 @@ HOMEPAGE="https://github.com/kolmodin/binary"
 LICENSE="BSD"
 SLOT="0/${PV}"
 # Keep in sync with relevant ghc versions (CABAL_CORE_LIB_GHC_PV)
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux"
 
 RESTRICT=test # circular depend: test-framework->base-orphans->cabal->semigroups->nats->binary
 

--- a/dev-haskell/blaze-builder/blaze-builder-0.4.2.1.ebuild
+++ b/dev-haskell/blaze-builder/blaze-builder-0.4.2.1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-haskell/text-0.10:=[profile?] <dev-haskell/text-1.3:=[profile?]
 	>=dev-lang/ghc-8.4.3:= <dev-lang/ghc-9.1:=

--- a/dev-haskell/blaze-html/blaze-html-0.9.1.2-r2.ebuild
+++ b/dev-haskell/blaze-html/blaze-html-0.9.1.2-r2.ebuild
@@ -15,7 +15,7 @@ HOMEPAGE="https://jaspervdj.be/blaze"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-haskell/blaze-builder-0.3:=[profile?] <dev-haskell/blaze-builder-0.5:=[profile?]
 	>=dev-haskell/blaze-markup-0.8:=[profile?] <dev-haskell/blaze-markup-0.9:=[profile?]

--- a/dev-haskell/blaze-markup/blaze-markup-0.8.2.8-r1.ebuild
+++ b/dev-haskell/blaze-markup/blaze-markup-0.8.2.8-r1.ebuild
@@ -15,7 +15,7 @@ HOMEPAGE="https://jaspervdj.be/blaze"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND="
 	>=dev-haskell/blaze-builder-0.3:=[profile?] <dev-haskell/blaze-builder-0.5:=[profile?]

--- a/dev-haskell/bloomfilter/bloomfilter-2.0.1.0.ebuild
+++ b/dev-haskell/bloomfilter/bloomfilter-2.0.1.0.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux"
 IUSE=""
 
 RDEPEND=">=dev-lang/ghc-7.4.1:= <dev-lang/ghc-9.1

--- a/dev-haskell/bsb-http-chunked/bsb-http-chunked-0.0.0.4.ebuild
+++ b/dev-haskell/bsb-http-chunked/bsb-http-chunked-0.0.0.4.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-lang/ghc-7.10.1:=

--- a/dev-haskell/byteable/byteable-0.1.1.ebuild
+++ b/dev-haskell/byteable/byteable-0.1.1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux"
 IUSE=""
 
 RDEPEND=">=dev-lang/ghc-7.4.1:=

--- a/dev-haskell/byteorder/byteorder-1.0.4.ebuild
+++ b/dev-haskell/byteorder/byteorder-1.0.4.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-lang/ghc-7.4.1:=

--- a/dev-haskell/bytestring-builder/bytestring-builder-0.10.8.2.0.ebuild
+++ b/dev-haskell/bytestring-builder/bytestring-builder-0.10.8.2.0.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-lang/ghc-7.4.1:=

--- a/dev-haskell/c2hs/c2hs-0.28.8.ebuild
+++ b/dev-haskell/c2hs/c2hs-0.28.8.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="regression"
 
 RESTRICT=test # needs unprefixed 'cpp'

--- a/dev-haskell/cabal-doctest/cabal-doctest-1.0.9.ebuild
+++ b/dev-haskell/cabal-doctest/cabal-doctest-1.0.9.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-haskell/cabal-1.10:=[profile?] <dev-haskell/cabal-3.8:=[profile?]
 	>=dev-lang/ghc-8.4.3:=

--- a/dev-haskell/cabal-install/cabal-install-3.4.1.0-r3.ebuild
+++ b/dev-haskell/cabal-install/cabal-install-3.4.1.0-r3.ebuild
@@ -17,7 +17,7 @@ HOMEPAGE="https://www.haskell.org/cabal/"
 LICENSE="BSD"
 SLOT="0"
 # Keep in sync with relevant dev-haskell/cabal versions
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="+lukko +native-dns"
 
 CABAL_CHDEPS=(

--- a/dev-haskell/cabal/cabal-3.4.1.0-r1.ebuild
+++ b/dev-haskell/cabal/cabal-3.4.1.0-r1.ebuild
@@ -20,7 +20,7 @@ HOMEPAGE="https://www.haskell.org/cabal/"
 LICENSE="BSD"
 SLOT="0/${PV}"
 # Keep in sync with relevant ghc versions (CABAL_CORE_LIB_GHC_PV)
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux"
 
 RESTRICT=test # circular deps: cabal -> quickcheck -> cabal
 

--- a/dev-haskell/call-stack/call-stack-0.3.0.ebuild
+++ b/dev-haskell/call-stack/call-stack-0.3.0.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-lang/ghc-8.4.3:=

--- a/dev-haskell/case-insensitive/case-insensitive-1.2.1.0.ebuild
+++ b/dev-haskell/case-insensitive/case-insensitive-1.2.1.0.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-haskell/hashable-1.0:=[profile?]

--- a/dev-haskell/cassava/cassava-0.5.2.0-r1.ebuild
+++ b/dev-haskell/cassava/cassava-0.5.2.0-r1.ebuild
@@ -20,7 +20,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-haskell/attoparsec-0.11.3.0:=[profile?] <dev-haskell/attoparsec-0.15:=[profile?]
 	<dev-haskell/hashable-1.5:=[profile?]

--- a/dev-haskell/cereal/cereal-0.5.8.1.ebuild
+++ b/dev-haskell/cereal/cereal-0.5.8.1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-haskell/bytestring-builder-0.10.4:=[profile?] <dev-haskell/bytestring-builder-1:=[profile?]

--- a/dev-haskell/charset/charset-0.3.7.1-r1.ebuild
+++ b/dev-haskell/charset/charset-0.3.7.1-r1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-haskell/semigroups-0.8.3.1:=[profile?] <dev-haskell/semigroups-1:=[profile?]

--- a/dev-haskell/chell/chell-0.4.0.2.ebuild
+++ b/dev-haskell/chell/chell-0.4.0.2.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="+color-output"
 
 RDEPEND=">=dev-haskell/options-1.0:=[profile?] <dev-haskell/options-2.0:=[profile?]

--- a/dev-haskell/cipher-aes/cipher-aes-0.2.11.ebuild
+++ b/dev-haskell/cipher-aes/cipher-aes-0.2.11.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="cpu_flags_x86_aes cpu_flags_x86_ssse3"
 
 RDEPEND="dev-haskell/byteable:=[profile?]

--- a/dev-haskell/citeproc/citeproc-0.7.ebuild
+++ b/dev-haskell/citeproc/citeproc-0.7.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD-2"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="executable icu"
 
 # Many tests for this package are known to fail and this is acceptable for

--- a/dev-haskell/clientsession/clientsession-0.9.1.2.ebuild
+++ b/dev-haskell/clientsession/clientsession-0.9.1.2.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="test"
 
 RDEPEND=">=dev-haskell/base64-bytestring-0.1.1.1:=[profile?]

--- a/dev-haskell/clock/clock-0.7.2.ebuild
+++ b/dev-haskell/clock/clock-0.7.2.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RESTRICT=test # circular depend: tasty->clock[test]->tasty

--- a/dev-haskell/cmdargs/cmdargs-0.10.20.ebuild
+++ b/dev-haskell/cmdargs/cmdargs-0.10.20.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="+quotation testprog"
 
 RDEPEND=">=dev-haskell/semigroups-0.18:=[profile?]

--- a/dev-haskell/code-page/code-page-0.1.3.ebuild
+++ b/dev-haskell/code-page/code-page-0.1.3.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-lang/ghc-7.4.1:=

--- a/dev-haskell/colour/colour-2.3.5.ebuild
+++ b/dev-haskell/colour/colour-2.3.5.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 # circular dependencies: colour -> ansi-terminal -> test-framework -> colour
 RESTRICT=test

--- a/dev-haskell/commonmark-extensions/commonmark-extensions-0.2.3.2.ebuild
+++ b/dev-haskell/commonmark-extensions/commonmark-extensions-0.2.3.2.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-haskell/commonmark-0.2.2:=[profile?] <dev-haskell/commonmark-0.3:=[profile?]
 	>=dev-haskell/emojis-0.1:=[profile?] <dev-haskell/emojis-0.2:=[profile?]

--- a/dev-haskell/commonmark-pandoc/commonmark-pandoc-0.2.1.2.ebuild
+++ b/dev-haskell/commonmark-pandoc/commonmark-pandoc-0.2.1.2.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-haskell/commonmark-0.2:=[profile?] <dev-haskell/commonmark-0.3:=[profile?]
 	>=dev-haskell/commonmark-extensions-0.2.1:=[profile?] <dev-haskell/commonmark-extensions-0.3:=[profile?]

--- a/dev-haskell/commonmark/commonmark-0.2.2.ebuild
+++ b/dev-haskell/commonmark/commonmark-0.2.2.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-haskell/unicode-data-0.3:=[profile?]
 	dev-haskell/unicode-transforms:=[profile?]

--- a/dev-haskell/comonad/comonad-5.0.8-r1.ebuild
+++ b/dev-haskell/comonad/comonad-5.0.8-r1.ebuild
@@ -16,7 +16,7 @@ HOMEPAGE="https://github.com/ekmett/comonad/"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="+indexed-traversable"
 
 RDEPEND=">=dev-haskell/distributive-0.5.2:=[profile?] <dev-haskell/distributive-1:=[profile?]

--- a/dev-haskell/concurrent-output/concurrent-output-1.10.11.ebuild
+++ b/dev-haskell/concurrent-output/concurrent-output-1.10.11.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD-2"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-haskell/ansi-terminal-0.9.1:=[profile?] <dev-haskell/ansi-terminal-0.11.0:=[profile?]

--- a/dev-haskell/conduit-combinators/conduit-combinators-1.3.0.ebuild
+++ b/dev-haskell/conduit-combinators/conduit-combinators-1.3.0.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-lang/ghc-8.0.1:=

--- a/dev-haskell/conduit-extra/conduit-extra-1.3.4.ebuild
+++ b/dev-haskell/conduit-extra/conduit-extra-1.3.4.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RESTRICT=test # requires network

--- a/dev-haskell/conduit/conduit-1.3.4.2.ebuild
+++ b/dev-haskell/conduit/conduit-1.3.4.2.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND="dev-haskell/exceptions:=[profile?]
 	>=dev-haskell/mono-traversable-1.0.7:=[profile?]

--- a/dev-haskell/configurator/configurator-0.3.0.0-r1.ebuild
+++ b/dev-haskell/configurator/configurator-0.3.0.0-r1.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-haskell/attoparsec-0.10.0.2:=[profile?]

--- a/dev-haskell/connection/connection-0.3.1-r1.ebuild
+++ b/dev-haskell/connection/connection-0.3.1-r1.ebuild
@@ -15,7 +15,7 @@ HOMEPAGE="https://github.com/vincenthz/hs-connection"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND="dev-haskell/basement:=[profile?]
 	dev-haskell/data-default-class:=[profile?]

--- a/dev-haskell/constraints/constraints-0.13.3.ebuild
+++ b/dev-haskell/constraints/constraints-0.13.3.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD-2"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-haskell/hashable-1.2:=[profile?] <dev-haskell/hashable-1.5:=[profile?]
 	>=dev-haskell/transformers-compat-0.5:=[profile?] <dev-haskell/transformers-compat-1:=[profile?]

--- a/dev-haskell/contravariant/contravariant-1.5.3.ebuild
+++ b/dev-haskell/contravariant/contravariant-1.5.3.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="+semigroups +statevar +tagged"
 
 RDEPEND=">=dev-haskell/transformers-compat-0.5:=[profile?] <dev-haskell/transformers-compat-1:=[profile?]

--- a/dev-haskell/convertible/convertible-1.1.1.0.ebuild
+++ b/dev-haskell/convertible/convertible-1.1.1.0.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND="dev-haskell/mtl:=[profile?]

--- a/dev-haskell/cookie/cookie-0.4.4.ebuild
+++ b/dev-haskell/cookie/cookie-0.4.4.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND="dev-haskell/data-default-class:=[profile?]

--- a/dev-haskell/cprng-aes/cprng-aes-0.6.1.ebuild
+++ b/dev-haskell/cprng-aes/cprng-aes-0.6.1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND="dev-haskell/byteable:=[profile?]

--- a/dev-haskell/criterion-measurement/criterion-measurement-0.1.2.0.ebuild
+++ b/dev-haskell/criterion-measurement/criterion-measurement-0.1.2.0.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-haskell/aeson-0.8:=[profile?]

--- a/dev-haskell/criterion/criterion-1.5.11.0.ebuild
+++ b/dev-haskell/criterion/criterion-1.5.11.0.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="embed-data-files"
 
 RDEPEND=">=dev-haskell/aeson-1:=[profile?] <dev-haskell/aeson-2.1:=[profile?]

--- a/dev-haskell/crypto-api-tests/crypto-api-tests-0.3-r1.ebuild
+++ b/dev-haskell/crypto-api-tests/crypto-api-tests-0.3-r1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND="dev-haskell/cereal:=[profile?]

--- a/dev-haskell/crypto-api/crypto-api-0.13.3.ebuild
+++ b/dev-haskell/crypto-api/crypto-api-0.13.3.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="all-cpolys"
 
 RDEPEND=">=dev-haskell/cereal-0.2:=[profile?]

--- a/dev-haskell/crypto-cipher-tests/crypto-cipher-tests-0.0.11-r1.ebuild
+++ b/dev-haskell/crypto-cipher-tests/crypto-cipher-tests-0.0.11-r1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-haskell/byteable-0.1.1:=[profile?] <dev-haskell/byteable-0.2:=[profile?]

--- a/dev-haskell/crypto-cipher-types/crypto-cipher-types-0.0.9.ebuild
+++ b/dev-haskell/crypto-cipher-types/crypto-cipher-types-0.0.9.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-haskell/byteable-0.1.1:=[profile?]

--- a/dev-haskell/crypto-random/crypto-random-0.0.9.ebuild
+++ b/dev-haskell/crypto-random/crypto-random-0.0.9.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND="dev-haskell/securemem:=[profile?]

--- a/dev-haskell/cryptohash-md5/cryptohash-md5-0.11.100.1.ebuild
+++ b/dev-haskell/cryptohash-md5/cryptohash-md5-0.11.100.1.ebuild
@@ -15,7 +15,7 @@ HOMEPAGE="https://github.com/hvr/cryptohash-md5"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-lang/ghc-7.4.1:=
 "

--- a/dev-haskell/cryptohash-sha1/cryptohash-sha1-0.11.100.1.ebuild
+++ b/dev-haskell/cryptohash-sha1/cryptohash-sha1-0.11.100.1.ebuild
@@ -15,7 +15,7 @@ HOMEPAGE="https://github.com/hvr/cryptohash-sha1"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-lang/ghc-7.4.1:=
 "

--- a/dev-haskell/cryptohash-sha256/cryptohash-sha256-0.11.101.0.ebuild
+++ b/dev-haskell/cryptohash-sha256/cryptohash-sha256-0.11.101.0.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-lang/ghc-7.4.1:=

--- a/dev-haskell/cryptonite-conduit/cryptonite-conduit-0.2.2.ebuild
+++ b/dev-haskell/cryptonite-conduit/cryptonite-conduit-0.2.2.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RESTRICT=test # test suite fails to build

--- a/dev-haskell/cryptonite/cryptonite-0.28.ebuild
+++ b/dev-haskell/cryptonite/cryptonite-0.28.ebuild
@@ -16,7 +16,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="cpu_flags_x86_rdrand cpu_flags_x86_aes cpu_flags_x86_sse cpu_flags_x86_sse4_1 +integer-gmp +target-attributes"
 
 RDEPEND=">=dev-haskell/basement-0.0.6:=[profile?]

--- a/dev-haskell/css-text/css-text-0.1.3.0.ebuild
+++ b/dev-haskell/css-text/css-text-0.1.3.0.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RESTRICT=test # fails test, not sure if it's severe

--- a/dev-haskell/data-default-class/data-default-class-0.1.2.0.ebuild
+++ b/dev-haskell/data-default-class/data-default-class-0.1.2.0.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
 IUSE=""
 
 RDEPEND=">=dev-lang/ghc-7.4.1:=

--- a/dev-haskell/data-default-instances-containers/data-default-instances-containers-0.0.1.ebuild
+++ b/dev-haskell/data-default-instances-containers/data-default-instances-containers-0.0.1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
 IUSE=""
 
 RDEPEND="dev-haskell/data-default-class:=[profile?]

--- a/dev-haskell/data-default-instances-dlist/data-default-instances-dlist-0.0.1.ebuild
+++ b/dev-haskell/data-default-instances-dlist/data-default-instances-dlist-0.0.1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
 IUSE=""
 
 RDEPEND="dev-haskell/data-default-class:=[profile?]

--- a/dev-haskell/data-default-instances-old-locale/data-default-instances-old-locale-0.0.1.ebuild
+++ b/dev-haskell/data-default-instances-old-locale/data-default-instances-old-locale-0.0.1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
 IUSE=""
 
 RDEPEND="dev-haskell/data-default-class:=[profile?]

--- a/dev-haskell/data-default/data-default-0.7.1.1.ebuild
+++ b/dev-haskell/data-default/data-default-0.7.1.1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
 IUSE=""
 
 RDEPEND=">=dev-haskell/data-default-class-0.1.2.0:=[profile?]

--- a/dev-haskell/data-fix/data-fix-0.3.2-r1.ebuild
+++ b/dev-haskell/data-fix/data-fix-0.3.2-r1.ebuild
@@ -15,7 +15,7 @@ HOMEPAGE="https://github.com/spell-music/data-fix"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND="
 	>=dev-haskell/hashable-1.2.7.0:=[profile?] <dev-haskell/hashable-1.5:=[profile?]

--- a/dev-haskell/data-ordlist/data-ordlist-0.4.7.0.ebuild
+++ b/dev-haskell/data-ordlist/data-ordlist-0.4.7.0.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux"
 IUSE=""
 
 RDEPEND=">=dev-lang/ghc-7.4.1:=

--- a/dev-haskell/dav/dav-1.3.4.ebuild
+++ b/dev-haskell/dav/dav-1.3.4.ebuild
@@ -18,7 +18,7 @@ SRC_URI="https://hackage.haskell.org/package/${MY_P}/${MY_P}.tar.gz"
 
 LICENSE="GPL-3"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-haskell/case-insensitive-0.4:=[profile?]

--- a/dev-haskell/dbus/dbus-1.2.27.ebuild
+++ b/dev-haskell/dbus/dbus-1.2.27.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="Apache-2.0"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 PATCHES=(
 	"${FILESDIR}/${PN}-1.2.22-disable-integration-tests.patch"

--- a/dev-haskell/dec/dec-0.0.3.ebuild
+++ b/dev-haskell/dec/dec-0.0.3.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-haskell/void-0.7.2:=[profile?] <dev-haskell/void-0.8:=[profile?]

--- a/dev-haskell/dense-linear-algebra/dense-linear-algebra-0.1.0.0.ebuild
+++ b/dev-haskell/dense-linear-algebra/dense-linear-algebra-0.1.0.0.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD-2"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-haskell/math-functions-0.1.7:=[profile?]

--- a/dev-haskell/deriving-compat/deriving-compat-0.6.ebuild
+++ b/dev-haskell/deriving-compat/deriving-compat-0.6.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-haskell/th-abstraction-0.4:=[profile?] <dev-haskell/th-abstraction-0.5:=[profile?]
 	>=dev-haskell/transformers-compat-0.5:=[profile?]

--- a/dev-haskell/diff/diff-0.4.0.ebuild
+++ b/dev-haskell/diff/diff-0.4.0.ebuild
@@ -17,7 +17,7 @@ SRC_URI="https://hackage.haskell.org/package/${MY_P}/${MY_P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-lang/ghc-7.4.1:=

--- a/dev-haskell/digest/digest-0.0.1.2.ebuild
+++ b/dev-haskell/digest/digest-0.0.1.2.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux"
 IUSE=""
 
 RDEPEND=">=dev-lang/ghc-7.4.1:=

--- a/dev-haskell/disk-free-space/disk-free-space-0.1.0.1.ebuild
+++ b/dev-haskell/disk-free-space/disk-free-space-0.1.0.1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-lang/ghc-7.4.1:=

--- a/dev-haskell/distributive/distributive-0.6.2.1.ebuild
+++ b/dev-haskell/distributive/distributive-0.6.2.1.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-haskell/base-orphans-0.5.2:=[profile?] <dev-haskell/base-orphans-1:=[profile?]
 	>=dev-haskell/tagged-0.7:=[profile?] <dev-haskell/tagged-1:=[profile?]

--- a/dev-haskell/dlist/dlist-1.0.ebuild
+++ b/dev-haskell/dlist/dlist-1.0.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
 IUSE="werror"
 
 RDEPEND=">=dev-lang/ghc-7.4.1:=

--- a/dev-haskell/dns/dns-4.0.1.ebuild
+++ b/dev-haskell/dns/dns-4.0.1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RESTRICT=test # uses internet to test resolver

--- a/dev-haskell/doclayout/doclayout-0.4.ebuild
+++ b/dev-haskell/doclayout/doclayout-0.4.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-haskell/emojis-0.1.2:=[profile?]
 	dev-haskell/safe:=[profile?]

--- a/dev-haskell/doctemplates/doctemplates-0.10.0.2.ebuild
+++ b/dev-haskell/doctemplates/doctemplates-0.10.0.2.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND="dev-haskell/aeson:=[profile?]
 	>=dev-haskell/doclayout-0.4:=[profile?] <dev-haskell/doclayout-0.5:=[profile?]

--- a/dev-haskell/doctest/doctest-0.20.0.ebuild
+++ b/dev-haskell/doctest/doctest-0.20.0.ebuild
@@ -20,7 +20,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-haskell/base-compat-0.7.0:=[profile?]
 	>=dev-haskell/code-page-0.1:=[profile?]

--- a/dev-haskell/easy-file/easy-file-0.2.2.ebuild
+++ b/dev-haskell/easy-file/easy-file-0.2.2.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-lang/ghc-7.4.1:=

--- a/dev-haskell/echo/echo-0.1.3.ebuild
+++ b/dev-haskell/echo/echo-0.1.3.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="examples"
 
 RDEPEND=">=dev-lang/ghc-7.4.1:=

--- a/dev-haskell/ed25519/ed25519-0.0.5.0-r1.ebuild
+++ b/dev-haskell/ed25519/ed25519-0.0.5.0-r1.ebuild
@@ -16,7 +16,7 @@ HOMEPAGE="https://thoughtpolice.github.com/hs-ed25519"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RESTRICT=test # bitrotten test suite
 

--- a/dev-haskell/edit-distance/edit-distance-0.2.2.1-r1.ebuild
+++ b/dev-haskell/edit-distance/edit-distance-0.2.2.1-r1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux"
 IUSE=""
 
 RDEPEND=">=dev-haskell/random-1.0:=[profile?]

--- a/dev-haskell/email-validate/email-validate-2.3.2.15.ebuild
+++ b/dev-haskell/email-validate/email-validate-2.3.2.15.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 PATCHES=( "${FILESDIR}/${PN}-2.3.2.15-fix-doctest.patch" )
 

--- a/dev-haskell/emojis/emojis-0.1.2.ebuild
+++ b/dev-haskell/emojis/emojis-0.1.2.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND="dev-haskell/text:=[profile?]
 	>=dev-lang/ghc-8.4.3:=

--- a/dev-haskell/enclosed-exceptions/enclosed-exceptions-1.0.3.ebuild
+++ b/dev-haskell/enclosed-exceptions/enclosed-exceptions-1.0.3.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-haskell/lifted-base-0.2:=[profile?]

--- a/dev-haskell/entropy/entropy-0.4.1.6-r1.ebuild
+++ b/dev-haskell/entropy/entropy-0.4.1.6-r1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="halvm"
 
 RDEPEND=">=dev-lang/ghc-7.10.1:= <dev-lang/ghc-9.1

--- a/dev-haskell/erf/erf-2.0.0.0-r1.ebuild
+++ b/dev-haskell/erf/erf-2.0.0.0-r1.ebuild
@@ -13,7 +13,7 @@ HOMEPAGE="https://hackage.haskell.org/package/erf"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND="
 	>=dev-lang/ghc-8.8.1:=

--- a/dev-haskell/errorcall-eq-instance/errorcall-eq-instance-0.3.0.ebuild
+++ b/dev-haskell/errorcall-eq-instance/errorcall-eq-instance-0.3.0.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND="dev-haskell/base-orphans:=[profile?]

--- a/dev-haskell/errors/errors-2.3.0.ebuild
+++ b/dev-haskell/errors/errors-2.3.0.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-haskell/exceptions-0.6:=[profile?] <dev-haskell/exceptions-0.11:=[profile?]

--- a/dev-haskell/exceptions/exceptions-0.10.4-r3.ebuild
+++ b/dev-haskell/exceptions/exceptions-0.10.4-r3.ebuild
@@ -19,7 +19,7 @@ HOMEPAGE="https://github.com/ekmett/exceptions/"
 LICENSE="BSD"
 SLOT="0/${PV}"
 # Keep in sync with relevant ghc versions (CABAL_CORE_LIB_GHC_PV)
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND="
 	>=dev-lang/ghc-8.10.6:=

--- a/dev-haskell/extensible-exceptions/extensible-exceptions-0.1.1.4.ebuild
+++ b/dev-haskell/extensible-exceptions/extensible-exceptions-0.1.1.4.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
 IUSE=""
 
 RDEPEND=">=dev-lang/ghc-7.4.1:=

--- a/dev-haskell/extra/extra-1.7.10.ebuild
+++ b/dev-haskell/extra/extra-1.7.10.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-haskell/clock-0.7:=[profile?]
 	>=dev-lang/ghc-8.4.3:=

--- a/dev-haskell/fail/fail-4.9.0.0.ebuild
+++ b/dev-haskell/fail/fail-4.9.0.0.ebuild
@@ -17,7 +17,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux"
 IUSE=""
 
 RDEPEND=">=dev-lang/ghc-7.4.1:=

--- a/dev-haskell/fast-logger/fast-logger-3.0.1.ebuild
+++ b/dev-haskell/fast-logger/fast-logger-3.0.1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-haskell/auto-update-0.1.2:=[profile?]

--- a/dev-haskell/fdo-notify/fdo-notify-0.3.1.ebuild
+++ b/dev-haskell/fdo-notify/fdo-notify-0.3.1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-haskell/dbus-0.10.7:=[profile?]

--- a/dev-haskell/feed/feed-1.3.2.1.ebuild
+++ b/dev-haskell/feed/feed-1.3.2.1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 PATCHES=( "${FILESDIR}/${PN}-1.3.2.1-disable-doctest.patch" )
 

--- a/dev-haskell/fgl/fgl-5.7.0.3.ebuild
+++ b/dev-haskell/fgl/fgl-5.7.0.3.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-lang/ghc-7.8.2:=
 "

--- a/dev-haskell/file-embed/file-embed-0.0.11.2.ebuild
+++ b/dev-haskell/file-embed/file-embed-0.0.11.2.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-lang/ghc-8.0.2:=

--- a/dev-haskell/filemanip/filemanip-0.3.6.3.ebuild
+++ b/dev-haskell/filemanip/filemanip-0.3.6.3.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND="dev-haskell/mtl:=[profile?]

--- a/dev-haskell/filepath-bytestring/filepath-bytestring-1.4.2.1.9.ebuild
+++ b/dev-haskell/filepath-bytestring/filepath-bytestring-1.4.2.1.9.ebuild
@@ -13,7 +13,7 @@ HOMEPAGE="https://hackage.haskell.org/package/filepath-bytestring"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 CABAL_CHDEPS=(
 	'filepath >= 1.4.2 && <= 1.4.2.1' 'filepath >= 1.4.2'

--- a/dev-haskell/findbin/findbin-0.0.5-r1.ebuild
+++ b/dev-haskell/findbin/findbin-0.0.5-r1.ebuild
@@ -17,7 +17,7 @@ SRC_URI="https://hackage.haskell.org/package/${MY_P}/${MY_P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-lang/ghc-7.4.1:=

--- a/dev-haskell/fingertree/fingertree-0.1.4.2.ebuild
+++ b/dev-haskell/fingertree/fingertree-0.1.4.2.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-lang/ghc-7.4.1:=

--- a/dev-haskell/foldl/foldl-1.4.12-r1.ebuild
+++ b/dev-haskell/foldl/foldl-1.4.12-r1.ebuild
@@ -15,7 +15,7 @@ HOMEPAGE="https://hackage.haskell.org/package/foldl"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 PATCHES=( "${FILESDIR}/${PN}-1.4.12-cabal-doctest.patch" )
 

--- a/dev-haskell/foundation/foundation-0.0.26.1.ebuild
+++ b/dev-haskell/foundation/foundation-0.0.26.1.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="experimental"
 
 RESTRICT=test # hangs indefinitely

--- a/dev-haskell/free/free-5.1.9.ebuild
+++ b/dev-haskell/free/free-5.1.9.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-haskell/comonad-5.0.8:=[profile?] <dev-haskell/comonad-6:=[profile?]
 	>=dev-haskell/distributive-0.5.2:=[profile?] <dev-haskell/distributive-1:=[profile?]

--- a/dev-haskell/generic-deriving/generic-deriving-1.14.1.ebuild
+++ b/dev-haskell/generic-deriving/generic-deriving-1.14.1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-haskell/th-abstraction-0.4:=[profile?] <dev-haskell/th-abstraction-0.5:=[profile?]
 	>=dev-lang/ghc-8.4.3:=

--- a/dev-haskell/generics-sop/generics-sop-0.5.1.1.ebuild
+++ b/dev-haskell/generics-sop/generics-sop-0.5.1.1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-haskell/sop-core-0.5.0:=[profile?] <dev-haskell/sop-core-0.5.1:=[profile?]
 	>=dev-haskell/th-abstraction-0.4:=[profile?] <dev-haskell/th-abstraction-0.5:=[profile?]

--- a/dev-haskell/getopt-generics/getopt-generics-0.13.0.4.ebuild
+++ b/dev-haskell/getopt-generics/getopt-generics-0.13.0.4.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-haskell/base-compat-0.8:=[profile?]

--- a/dev-haskell/ghc-byteorder/ghc-byteorder-4.11.0.0.10.ebuild
+++ b/dev-haskell/ghc-byteorder/ghc-byteorder-4.11.0.0.10.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-lang/ghc-8.4.3:=

--- a/dev-haskell/ghc-paths/ghc-paths-0.1.0.12-r1.ebuild
+++ b/dev-haskell/ghc-paths/ghc-paths-0.1.0.12-r1.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-lang/ghc-7.4.1:=

--- a/dev-haskell/git-lfs/git-lfs-1.2.0-r1.ebuild
+++ b/dev-haskell/git-lfs/git-lfs-1.2.0-r1.ebuild
@@ -13,7 +13,7 @@ HOMEPAGE="https://hackage.haskell.org/package/git-lfs"
 
 LICENSE="AGPL-3"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 CABAL_CHDEPS=(
 	'aeson >= 1.3 && < 2.1' 'aeson >= 1.3'

--- a/dev-haskell/glob/glob-0.10.2.ebuild
+++ b/dev-haskell/glob/glob-0.10.2.ebuild
@@ -24,7 +24,7 @@ SRC_URI="https://hackage.haskell.org/package/${CABAL_P}/${CABAL_P}.tar.gz
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-haskell/dlist-0.4:=[profile?]
 	>=dev-haskell/transformers-compat-0.3:=[profile?]

--- a/dev-haskell/hackage-security/hackage-security-0.6.1.0.ebuild
+++ b/dev-haskell/hackage-security/hackage-security-0.6.1.0.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="+lukko"
 
 RDEPEND=">=dev-haskell/base16-bytestring-0.1.1:=[profile?] <dev-haskell/base16-bytestring-1.1:=[profile?]

--- a/dev-haskell/haddock-library/haddock-library-1.10.0-r2.ebuild
+++ b/dev-haskell/haddock-library/haddock-library-1.10.0-r2.ebuild
@@ -15,7 +15,7 @@ HOMEPAGE="https://www.haskell.org/haddock/"
 
 LICENSE="BSD-2"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux"
 
 CABAL_CHDEPS=(
 	'hspec                          >= 2.4.4    && < 2.8' 'hspec >=2.4.4'

--- a/dev-haskell/happy/happy-1.19.12.ebuild
+++ b/dev-haskell/happy/happy-1.19.12.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD-2"
 SLOT="0"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="doc"
 
 RDEPEND=">=dev-haskell/mtl-2.2.1:=

--- a/dev-haskell/hashable/hashable-1.4.0.2-r1.ebuild
+++ b/dev-haskell/hashable/hashable-1.4.0.2-r1.ebuild
@@ -17,7 +17,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="random-initial-seed"
 
 RDEPEND=">=dev-haskell/base-orphans-0.8.6:=[profile?]

--- a/dev-haskell/haskeline/haskeline-0.8.2-r1.ebuild
+++ b/dev-haskell/haskeline/haskeline-0.8.2-r1.ebuild
@@ -17,7 +17,7 @@ HOMEPAGE="https://github.com/judah/haskeline"
 LICENSE="BSD"
 SLOT="0/${PV}"
 # Keep in sync with relevant ghc versions (CABAL_CORE_LIB_GHC_PV)
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux"
 IUSE="+terminfo"
 
 RESTRICT=test # test requires example executable which does not work correctly

--- a/dev-haskell/haskell-lexer/haskell-lexer-1.1.ebuild
+++ b/dev-haskell/haskell-lexer/haskell-lexer-1.1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-lang/ghc-7.4.1:=

--- a/dev-haskell/haskell-src-exts/haskell-src-exts-1.23.1.ebuild
+++ b/dev-haskell/haskell-src-exts/haskell-src-exts-1.23.1.ebuild
@@ -14,7 +14,7 @@ HOMEPAGE="https://github.com/haskell-suite/haskell-src-exts"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-lang/ghc-8.4.3:=
 "

--- a/dev-haskell/hdbc-postgresql/hdbc-postgresql-2.5.0.0.ebuild
+++ b/dev-haskell/hdbc-postgresql/hdbc-postgresql-2.5.0.0.ebuild
@@ -18,7 +18,7 @@ SRC_URI="https://hackage.haskell.org/package/${MY_P}/${MY_P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-db/postgresql-7:*

--- a/dev-haskell/hdbc-sqlite3/hdbc-sqlite3-2.3.3.1-r1.ebuild
+++ b/dev-haskell/hdbc-sqlite3/hdbc-sqlite3-2.3.3.1-r1.ebuild
@@ -18,7 +18,7 @@ SRC_URI="https://hackage.haskell.org/package/${MY_P}/${MY_P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="+splitbase"
 
 RDEPEND=">=dev-db/sqlite-3.0

--- a/dev-haskell/hdbc/hdbc-2.4.0.3.ebuild
+++ b/dev-haskell/hdbc/hdbc-2.4.0.3.ebuild
@@ -18,7 +18,7 @@ SRC_URI="https://hackage.haskell.org/package/${MY_P}/${MY_P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RESTRICT="test" # Requires unmaintaned dev-haskell/testpack

--- a/dev-haskell/hedgehog/hedgehog-1.0.5.ebuild
+++ b/dev-haskell/hedgehog/hedgehog-1.0.5.ebuild
@@ -15,7 +15,7 @@ HOMEPAGE="https://hedgehog.qa"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 CABAL_CHDEPS=(
 	'template-haskell                >= 2.10       && < 2.18' 'template-haskell >=2.10'

--- a/dev-haskell/hinotify/hinotify-0.3.10.ebuild
+++ b/dev-haskell/hinotify/hinotify-0.3.10.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-haskell/async-2.0:=[profile?] <dev-haskell/async-2.3:=[profile?]

--- a/dev-haskell/hjsmin/hjsmin-0.2.0.4.ebuild
+++ b/dev-haskell/hjsmin/hjsmin-0.2.0.4.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RESTRICT=test # Requires network access?

--- a/dev-haskell/hostname/hostname-1.0-r1.ebuild
+++ b/dev-haskell/hostname/hostname-1.0-r1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-lang/ghc-7.4.1:=

--- a/dev-haskell/hourglass/hourglass-0.2.12.ebuild
+++ b/dev-haskell/hourglass/hourglass-0.2.12.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-lang/ghc-7.4.1:= <dev-lang/ghc-9.1:=

--- a/dev-haskell/hscolour/hscolour-1.24.4.ebuild
+++ b/dev-haskell/hscolour/hscolour-1.24.4.ebuild
@@ -17,7 +17,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="LGPL-2.1"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-lang/ghc-7.4.1:=

--- a/dev-haskell/hslogger/hslogger-1.3.1.0-r2.ebuild
+++ b/dev-haskell/hslogger/hslogger-1.3.1.0-r2.ebuild
@@ -16,7 +16,7 @@ HOMEPAGE="https://github.com/haskell-hvr/hslogger/wiki"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux"
 
 RDEPEND="
 	>=dev-haskell/network-3.0:=[profile?] <dev-haskell/network-3.2

--- a/dev-haskell/hslua-aeson/hslua-aeson-2.2.0.ebuild
+++ b/dev-haskell/hslua-aeson/hslua-aeson-2.2.0.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-haskell/aeson-1.5:=[profile?] <dev-haskell/aeson-2.1:=[profile?]
 	>=dev-haskell/hashable-1.2:=[profile?] <dev-haskell/hashable-1.5:=[profile?]

--- a/dev-haskell/hslua-classes/hslua-classes-2.2.0.ebuild
+++ b/dev-haskell/hslua-classes/hslua-classes-2.2.0.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-haskell/hslua-core-2.1:=[profile?] <dev-haskell/hslua-core-2.3:=[profile?]
 	>=dev-haskell/hslua-marshalling-2.1:=[profile?] <dev-haskell/hslua-marshalling-2.3:=[profile?]

--- a/dev-haskell/hslua-core/hslua-core-2.2.0.ebuild
+++ b/dev-haskell/hslua-core/hslua-core-2.2.0.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-haskell/lua-2.2:=[profile?] <dev-haskell/lua-2.3:=[profile?]
 	>=dev-lang/ghc-8.10.1:=

--- a/dev-haskell/hslua-marshalling/hslua-marshalling-2.2.0.ebuild
+++ b/dev-haskell/hslua-marshalling/hslua-marshalling-2.2.0.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-haskell/hslua-core-2.2:=[profile?] <dev-haskell/hslua-core-2.3:=[profile?]
 	>=dev-lang/ghc-8.4.3:=

--- a/dev-haskell/hslua-module-doclayout/hslua-module-doclayout-1.0.4.ebuild
+++ b/dev-haskell/hslua-module-doclayout/hslua-module-doclayout-1.0.4.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-haskell/doclayout-0.2:=[profile?] <dev-haskell/doclayout-0.5:=[profile?]
 	>=dev-haskell/hslua-2.1:=[profile?] <dev-haskell/hslua-2.3:=[profile?]

--- a/dev-haskell/hslua-module-path/hslua-module-path-1.0.2.ebuild
+++ b/dev-haskell/hslua-module-path/hslua-module-path-1.0.2.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-haskell/hslua-core-2.1:=[profile?] <dev-haskell/hslua-core-2.3:=[profile?]
 	>=dev-haskell/hslua-marshalling-2.1:=[profile?] <dev-haskell/hslua-marshalling-2.3:=[profile?]

--- a/dev-haskell/hslua-module-system/hslua-module-system-1.0.2.ebuild
+++ b/dev-haskell/hslua-module-system/hslua-module-system-1.0.2.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-haskell/exceptions-0.8:=[profile?] <dev-haskell/exceptions-0.11:=[profile?]
 	>=dev-haskell/hslua-core-2.1:=[profile?] <dev-haskell/hslua-core-2.3:=[profile?]

--- a/dev-haskell/hslua-module-text/hslua-module-text-1.0.2.ebuild
+++ b/dev-haskell/hslua-module-text/hslua-module-text-1.0.2.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-haskell/hslua-core-2.1:=[profile?] <dev-haskell/hslua-core-2.3:=[profile?]
 	>=dev-haskell/hslua-marshalling-2.1:=[profile?] <dev-haskell/hslua-marshalling-2.3:=[profile?]

--- a/dev-haskell/hslua-module-version/hslua-module-version-1.0.2.ebuild
+++ b/dev-haskell/hslua-module-version/hslua-module-version-1.0.2.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-haskell/hslua-core-2.1:=[profile?] <dev-haskell/hslua-core-2.3:=[profile?]
 	>=dev-haskell/hslua-marshalling-2.1:=[profile?] <dev-haskell/hslua-marshalling-2.3:=[profile?]

--- a/dev-haskell/hslua-objectorientation/hslua-objectorientation-2.2.0.ebuild
+++ b/dev-haskell/hslua-objectorientation/hslua-objectorientation-2.2.0.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-haskell/hslua-core-2.2:=[profile?] <dev-haskell/hslua-core-2.3:=[profile?]
 	>=dev-haskell/hslua-marshalling-2.2:=[profile?] <dev-haskell/hslua-marshalling-2.3:=[profile?]

--- a/dev-haskell/hslua-packaging/hslua-packaging-2.2.0.ebuild
+++ b/dev-haskell/hslua-packaging/hslua-packaging-2.2.0.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-haskell/hslua-core-2.2:=[profile?] <dev-haskell/hslua-core-2.3:=[profile?]
 	>=dev-haskell/hslua-marshalling-2.2:=[profile?] <dev-haskell/hslua-marshalling-2.3:=[profile?]

--- a/dev-haskell/hslua/hslua-2.2.0.ebuild
+++ b/dev-haskell/hslua/hslua-2.2.0.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-haskell/hslua-aeson-2.2:=[profile?] <dev-haskell/hslua-aeson-2.3:=[profile?]
 	>=dev-haskell/hslua-classes-2.2:=[profile?] <dev-haskell/hslua-classes-2.3:=[profile?]

--- a/dev-haskell/hspec-contrib/hspec-contrib-0.5.1.ebuild
+++ b/dev-haskell/hspec-contrib/hspec-contrib-0.5.1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RESTRICT=test # test-suite fails to build

--- a/dev-haskell/hspec-core/hspec-core-2.9.4.ebuild
+++ b/dev-haskell/hspec-core/hspec-core-2.9.4.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-haskell/ansi-terminal-0.6.2:=[profile?]
 	dev-haskell/call-stack:=[profile?]

--- a/dev-haskell/hspec-discover/hspec-discover-2.9.4.ebuild
+++ b/dev-haskell/hspec-discover/hspec-discover-2.9.4.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-lang/ghc-8.4.3:=
 "

--- a/dev-haskell/hspec-expectations/hspec-expectations-0.8.2.ebuild
+++ b/dev-haskell/hspec-expectations/hspec-expectations-0.8.2.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND="dev-haskell/call-stack:=[profile?]

--- a/dev-haskell/hspec-meta/hspec-meta-2.9.3.ebuild
+++ b/dev-haskell/hspec-meta/hspec-meta-2.9.3.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND="dev-haskell/ansi-terminal:=[profile?]
 	dev-haskell/call-stack:=[profile?]

--- a/dev-haskell/hspec-wai/hspec-wai-0.10.1.ebuild
+++ b/dev-haskell/hspec-wai/hspec-wai-0.10.1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND="dev-haskell/base-compat:=[profile?]

--- a/dev-haskell/hspec/hspec-2.9.4.ebuild
+++ b/dev-haskell/hspec/hspec-2.9.4.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND="~dev-haskell/hspec-core-2.9.4:=[profile?]
 	~dev-haskell/hspec-discover-2.9.4:=[profile?]

--- a/dev-haskell/hsyaml/hsyaml-0.2.1.0.ebuild
+++ b/dev-haskell/hsyaml/hsyaml-0.2.1.0.ebuild
@@ -16,7 +16,7 @@ HOMEPAGE="https://github.com/hvr/HsYAML"
 
 LICENSE="GPL-2"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-haskell/fail-4.9.0.0:=[profile?] <dev-haskell/fail-4.10:=[profile?]
 	>=dev-haskell/mtl-2.2.1:=[profile?] <dev-haskell/mtl-2.3:=[profile?]

--- a/dev-haskell/html-conduit/html-conduit-1.3.2.1.ebuild
+++ b/dev-haskell/html-conduit/html-conduit-1.3.2.1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND="dev-haskell/attoparsec:=[profile?]

--- a/dev-haskell/html/html-1.0.1.2-r1.ebuild
+++ b/dev-haskell/html/html-1.0.1.2-r1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
 IUSE=""
 
 RDEPEND=">=dev-lang/ghc-7.4.1:=

--- a/dev-haskell/http-api-data/http-api-data-0.4.3.ebuild
+++ b/dev-haskell/http-api-data/http-api-data-0.4.3.ebuild
@@ -16,7 +16,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="text-show"
 
 RDEPEND=">=dev-haskell/attoparsec-0.13.2.2:=[profile?] <dev-haskell/attoparsec-0.15:=[profile?]

--- a/dev-haskell/http-client-restricted/http-client-restricted-0.0.5.ebuild
+++ b/dev-haskell/http-client-restricted/http-client-restricted-0.0.5.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-haskell/connection-0.2.5:=[profile?]
 	dev-haskell/data-default:=[profile?]

--- a/dev-haskell/http-client-tls/http-client-tls-0.3.6.1.ebuild
+++ b/dev-haskell/http-client-tls/http-client-tls-0.3.6.1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RESTRICT=test # requires network access
 

--- a/dev-haskell/http-client/http-client-0.7.11.ebuild
+++ b/dev-haskell/http-client/http-client-0.7.11.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND="dev-haskell/async:=[profile?]
 	>=dev-haskell/base64-bytestring-1.0:=[profile?]

--- a/dev-haskell/http-conduit/http-conduit-2.3.8.ebuild
+++ b/dev-haskell/http-conduit/http-conduit-2.3.8.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RESTRICT=test # needs network

--- a/dev-haskell/http-date/http-date-0.0.8.ebuild
+++ b/dev-haskell/http-date/http-date-0.0.8.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RESTRICT=test # Ambiguous module name ‘Data.Time’: it was found in multiple packages: pulseaudio-0.0.2.1 time-1.8.0.2

--- a/dev-haskell/http-media/http-media-0.8.0.0.ebuild
+++ b/dev-haskell/http-media/http-media-0.8.0.0.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-haskell/case-insensitive-1.0:=[profile?] <dev-haskell/case-insensitive-1.3:=[profile?]

--- a/dev-haskell/http-types/http-types-0.12.3.ebuild
+++ b/dev-haskell/http-types/http-types-0.12.3.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-haskell/case-insensitive-0.2:=[profile?] <dev-haskell/case-insensitive-1.3:=[profile?]

--- a/dev-haskell/http/http-4000.4.1-r1.ebuild
+++ b/dev-haskell/http/http-4000.4.1-r1.ebuild
@@ -17,7 +17,7 @@ HOMEPAGE="https://github.com/haskell/HTTP"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND="
 	>=dev-haskell/network-2.6:=[profile?] <dev-haskell/network-3.2:=[profile?]

--- a/dev-haskell/http2/http2-3.0.1.ebuild
+++ b/dev-haskell/http2/http2-3.0.1.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RESTRICT=test # test suite requires too new dependencies
 

--- a/dev-haskell/httpd-shed/httpd-shed-0.4.1.1-r1.ebuild
+++ b/dev-haskell/httpd-shed/httpd-shed-0.4.1.1-r1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="buildexamples"
 
 RDEPEND=">=dev-lang/ghc-7.4.1:=

--- a/dev-haskell/hunit/hunit-1.6.2.0.ebuild
+++ b/dev-haskell/hunit/hunit-1.6.2.0.ebuild
@@ -17,7 +17,7 @@ SRC_URI="https://hackage.haskell.org/package/${MY_P}/${MY_P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-haskell/call-stack-0.3.0:=[profile?]

--- a/dev-haskell/ieee754/ieee754-0.7.8.ebuild
+++ b/dev-haskell/ieee754/ieee754-0.7.8.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-lang/ghc-7.4.1:=

--- a/dev-haskell/ifelse/ifelse-0.85-r1.ebuild
+++ b/dev-haskell/ifelse/ifelse-0.85-r1.ebuild
@@ -17,7 +17,7 @@ SRC_URI="https://hackage.haskell.org/package/${MY_P}/${MY_P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux"
 IUSE=""
 
 RDEPEND="dev-haskell/mtl:=[profile?]

--- a/dev-haskell/indexed-traversable-instances/indexed-traversable-instances-0.1.ebuild
+++ b/dev-haskell/indexed-traversable-instances/indexed-traversable-instances-0.1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD-2"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 CABAL_CHDEPS=(
 	'base                  >=4.5      && <4.16' 'base >=4.5'

--- a/dev-haskell/indexed-traversable/indexed-traversable-0.1.2.ebuild
+++ b/dev-haskell/indexed-traversable/indexed-traversable-0.1.2.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD-2"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-lang/ghc-8.4.3:=
 "

--- a/dev-haskell/integer-logarithms/integer-logarithms-1.0.3.1-r2.ebuild
+++ b/dev-haskell/integer-logarithms/integer-logarithms-1.0.3.1-r2.ebuild
@@ -16,7 +16,7 @@ HOMEPAGE="https://github.com/haskellari/integer-logarithms"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND="
 	>=dev-lang/ghc-8.4.3:=

--- a/dev-haskell/invariant/invariant-0.5.5.ebuild
+++ b/dev-haskell/invariant/invariant-0.5.5.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD-2"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-haskell/bifunctors-5.2:=[profile?] <dev-haskell/bifunctors-6:=[profile?]
 	>=dev-haskell/comonad-5:=[profile?] <dev-haskell/comonad-6:=[profile?]

--- a/dev-haskell/iproute/iproute-1.7.8.ebuild
+++ b/dev-haskell/iproute/iproute-1.7.8.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RESTRICT=test # Ambiguous modules: byte-order-0.1.2.0 byteorder-1.0.4

--- a/dev-haskell/ipynb/ipynb-0.2.ebuild
+++ b/dev-haskell/ipynb/ipynb-0.2.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-haskell/aeson-1.5.2.0:=[profile?]
 	dev-haskell/base64-bytestring:=[profile?]

--- a/dev-haskell/jira-wiki-markup/jira-wiki-markup-1.4.0.ebuild
+++ b/dev-haskell/jira-wiki-markup/jira-wiki-markup-1.4.0.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-haskell/mtl-2.2:=[profile?] <dev-haskell/mtl-2.3:=[profile?]
 	>=dev-haskell/parsec-3.1:=[profile?] <dev-haskell/parsec-3.2:=[profile?]

--- a/dev-haskell/js-chart/js-chart-2.9.4.1.ebuild
+++ b/dev-haskell/js-chart/js-chart-2.9.4.1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-lang/ghc-8.4.3:=
 "

--- a/dev-haskell/juicypixels/juicypixels-3.3.5.ebuild
+++ b/dev-haskell/juicypixels/juicypixels-3.3.5.ebuild
@@ -17,7 +17,7 @@ SRC_URI="https://hackage.haskell.org/package/${MY_P}/${MY_P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="mmap"
 
 CABAL_CHDEPS=(

--- a/dev-haskell/kan-extensions/kan-extensions-5.2.5.ebuild
+++ b/dev-haskell/kan-extensions/kan-extensions-5.2.5.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-haskell/adjunctions-4.2:=[profile?] <dev-haskell/adjunctions-5:=[profile?]
 	>=dev-haskell/comonad-4:=[profile?] <dev-haskell/comonad-6:=[profile?]

--- a/dev-haskell/language-c/language-c-0.8.3-r1.ebuild
+++ b/dev-haskell/language-c/language-c-0.8.3-r1.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND="dev-haskell/syb:=[profile?]

--- a/dev-haskell/language-haskell-extract/language-haskell-extract-0.2.4-r1.ebuild
+++ b/dev-haskell/language-haskell-extract/language-haskell-extract-0.2.4-r1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND="dev-haskell/regex-posix:=[profile?]

--- a/dev-haskell/language-javascript/language-javascript-0.6.0.14.ebuild
+++ b/dev-haskell/language-javascript/language-javascript-0.6.0.14.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-haskell/blaze-builder-0.2:=[profile?]

--- a/dev-haskell/leancheck/leancheck-0.9.3.ebuild
+++ b/dev-haskell/leancheck/leancheck-0.9.3.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-lang/ghc-7.4.1:=

--- a/dev-haskell/lens/lens-5.1.1.ebuild
+++ b/dev-haskell/lens/lens-5.1.1.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD-2"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-haskell/assoc-1.0.2:=[profile?] <dev-haskell/assoc-1.1:=[profile?]
 	>=dev-haskell/base-orphans-0.5.2:=[profile?] <dev-haskell/base-orphans-1:=[profile?]

--- a/dev-haskell/libmpd/libmpd-0.9.2.0.ebuild
+++ b/dev-haskell/libmpd/libmpd-0.9.2.0.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-haskell/attoparsec-0.10.1:=[profile?] <dev-haskell/attoparsec-1:=[profile?]

--- a/dev-haskell/libyaml/libyaml-0.1.2.ebuild
+++ b/dev-haskell/libyaml/libyaml-0.1.2.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="+unicode system-libyaml"
 
 RDEPEND=">=dev-haskell/conduit-1.2.8:=[profile?] <dev-haskell/conduit-1.4:=[profile?]

--- a/dev-haskell/lift-type/lift-type-0.1.0.1.ebuild
+++ b/dev-haskell/lift-type/lift-type-0.1.0.1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-lang/ghc-8.4.3:=
 "

--- a/dev-haskell/lifted-async/lifted-async-0.10.2.ebuild
+++ b/dev-haskell/lifted-async/lifted-async-0.10.2.ebuild
@@ -15,7 +15,7 @@ HOMEPAGE="https://github.com/maoe/lifted-async"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 CABAL_CHDEPS=(
 	'base >= 4.5 && < 4.16' 'base >= 4.5'

--- a/dev-haskell/lifted-base/lifted-base-0.2.3.12.ebuild
+++ b/dev-haskell/lifted-base/lifted-base-0.2.3.12.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux"
 IUSE=""
 
 RDEPEND=">=dev-haskell/monad-control-0.3:=[profile?]

--- a/dev-haskell/logging-facade/logging-facade-0.3.0.ebuild
+++ b/dev-haskell/logging-facade/logging-facade-0.3.0.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND="dev-haskell/call-stack:=[profile?]

--- a/dev-haskell/logict/logict-0.7.0.3.ebuild
+++ b/dev-haskell/logict/logict-0.7.0.3.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND="dev-haskell/fail:=[profile?]

--- a/dev-haskell/lpeg/lpeg-1.0.3.ebuild
+++ b/dev-haskell/lpeg/lpeg-1.0.3.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="rely-on-shared-lpeg-library"
 
 RDEPEND=">=dev-haskell/lua-2.1:=[profile?] <dev-haskell/lua-2.3:=[profile?]

--- a/dev-haskell/lua-arbitrary/lua-arbitrary-1.0.1.ebuild
+++ b/dev-haskell/lua-arbitrary/lua-arbitrary-1.0.1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-haskell/lua-2.0:=[profile?] <dev-haskell/lua-2.3:=[profile?]
 	>=dev-haskell/quickcheck-2.7:=[profile?] <dev-haskell/quickcheck-3:=[profile?]

--- a/dev-haskell/lua/lua-2.2.0.ebuild
+++ b/dev-haskell/lua/lua-2.2.0.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="system-lua"
 
 RDEPEND=">=dev-lang/ghc-8.4.3:=

--- a/dev-haskell/lukko/lukko-0.1.1.3-r1.ebuild
+++ b/dev-haskell/lukko/lukko-0.1.1.3-r1.ebuild
@@ -16,7 +16,7 @@ HOMEPAGE="https://hackage.haskell.org/package/lukko"
 
 LICENSE="GPL-2 BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-lang/ghc-8.8.1:=
 "

--- a/dev-haskell/magic/magic-1.1.ebuild
+++ b/dev-haskell/magic/magic-1.1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-lang/ghc-7.4.1:=

--- a/dev-haskell/markdown-unlit/markdown-unlit-0.5.0.ebuild
+++ b/dev-haskell/markdown-unlit/markdown-unlit-0.5.0.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND="dev-haskell/base-compat:=[profile?]

--- a/dev-haskell/math-functions/math-functions-0.3.3.0.ebuild
+++ b/dev-haskell/math-functions/math-functions-0.3.3.0.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD-2"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-haskell/data-default-class-0.1.2.0:=[profile?]

--- a/dev-haskell/memory/memory-0.15.0-r1.ebuild
+++ b/dev-haskell/memory/memory-0.15.0-r1.ebuild
@@ -16,7 +16,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-haskell/basement-0.0.7:=[profile?]

--- a/dev-haskell/microlens-aeson/microlens-aeson-2.5.0.ebuild
+++ b/dev-haskell/microlens-aeson/microlens-aeson-2.5.0.ebuild
@@ -13,7 +13,7 @@ HOMEPAGE="https://github.com/fosskers/microlens-aeson/"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-haskell/aeson-2.0:=[profile?]
 	>=dev-haskell/attoparsec-0.10:=[profile?]

--- a/dev-haskell/microlens-mtl/microlens-mtl-0.2.0.1.ebuild
+++ b/dev-haskell/microlens-mtl/microlens-mtl-0.2.0.1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-haskell/microlens-0.4:=[profile?] <dev-haskell/microlens-0.5:=[profile?]

--- a/dev-haskell/microlens-th/microlens-th-0.4.3.10.ebuild
+++ b/dev-haskell/microlens-th/microlens-th-0.4.3.10.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-haskell/microlens-0.4.0:=[profile?] <dev-haskell/microlens-0.5:=[profile?]
 	>=dev-haskell/th-abstraction-0.4.1:=[profile?] <dev-haskell/th-abstraction-0.5:=[profile?]

--- a/dev-haskell/microlens/microlens-0.4.11.2.ebuild
+++ b/dev-haskell/microlens/microlens-0.4.11.2.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-lang/ghc-7.8.2:=

--- a/dev-haskell/microstache/microstache-1.0.2.ebuild
+++ b/dev-haskell/microstache/microstache-1.0.2.ebuild
@@ -20,7 +20,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-haskell/aeson-0.11:=[profile?] <dev-haskell/aeson-2.1:=[profile?]
 	>=dev-haskell/unordered-containers-0.2.5:=[profile?] <dev-haskell/unordered-containers-0.3:=[profile?]

--- a/dev-haskell/mime-types/mime-types-0.1.0.9.ebuild
+++ b/dev-haskell/mime-types/mime-types-0.1.0.9.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND="dev-haskell/text:=[profile?]

--- a/dev-haskell/missingh/missingh-1.4.3.0-r1.ebuild
+++ b/dev-haskell/missingh/missingh-1.4.3.0-r1.ebuild
@@ -17,7 +17,7 @@ HOMEPAGE="https://hackage.haskell.org/package/MissingH"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux"
 
 RESTRICT=test # tests are present for removed modules
 

--- a/dev-haskell/mmap/mmap-0.5.9.ebuild
+++ b/dev-haskell/mmap/mmap-0.5.9.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
 # IUSE="test"
 IUSE=""
 

--- a/dev-haskell/mmorph/mmorph-1.1.3.ebuild
+++ b/dev-haskell/mmorph/mmorph-1.1.3.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-haskell/mtl-2.1:=[profile?] <dev-haskell/mtl-2.3:=[profile?]

--- a/dev-haskell/mockery/mockery-0.3.5.ebuild
+++ b/dev-haskell/mockery/mockery-0.3.5.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND="dev-haskell/base-compat:=[profile?]

--- a/dev-haskell/monad-control/monad-control-1.0.2.3.ebuild
+++ b/dev-haskell/monad-control/monad-control-1.0.2.3.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux"
 IUSE=""
 
 RDEPEND=">=dev-haskell/stm-2.3:=[profile?] <dev-haskell/stm-3:=[profile?]

--- a/dev-haskell/monad-logger/monad-logger-0.3.32.ebuild
+++ b/dev-haskell/monad-logger/monad-logger-0.3.32.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="+template-haskell"
 
 RDEPEND=">=dev-haskell/conduit-1.0:=[profile?] <dev-haskell/conduit-1.4:=[profile?]

--- a/dev-haskell/monad-loops/monad-loops-0.4.3.ebuild
+++ b/dev-haskell/monad-loops/monad-loops-0.4.3.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="public-domain"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-lang/ghc-7.4.1:=

--- a/dev-haskell/monad-par-extras/monad-par-extras-0.3.3-r1.ebuild
+++ b/dev-haskell/monad-par-extras/monad-par-extras-0.3.3-r1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-haskell/abstract-par-0.3:=[profile?] <dev-haskell/abstract-par-0.4:=[profile?]

--- a/dev-haskell/monad-par/monad-par-0.3.5-r1.ebuild
+++ b/dev-haskell/monad-par/monad-par-0.3.5-r1.ebuild
@@ -16,7 +16,7 @@ HOMEPAGE="https://github.com/simonmar/monad-par"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="chaselev"
 
 RDEPEND=">=dev-haskell/abstract-deque-0.1.4:=[profile?]

--- a/dev-haskell/monads-tf/monads-tf-0.1.0.3.ebuild
+++ b/dev-haskell/monads-tf/monads-tf-0.1.0.3.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-haskell/transformers-0.2.0.0:=[profile?] <dev-haskell/transformers-0.6:=[profile?]

--- a/dev-haskell/mono-traversable/mono-traversable-1.0.15.1.ebuild
+++ b/dev-haskell/mono-traversable/mono-traversable-1.0.15.1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND="dev-haskell/hashable:=[profile?]

--- a/dev-haskell/mountpoints/mountpoints-1.0.2.ebuild
+++ b/dev-haskell/mountpoints/mountpoints-1.0.2.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="LGPL-2.1"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-lang/ghc-7.4.1:=

--- a/dev-haskell/mtl/mtl-2.2.2-r1.ebuild
+++ b/dev-haskell/mtl/mtl-2.2.2-r1.ebuild
@@ -17,7 +17,7 @@ HOMEPAGE="https://github.com/haskell/mtl"
 LICENSE="BSD"
 SLOT="0/${PV}"
 # Keep in sync with relevant ghc versions (CABAL_CORE_LIB_GHC_PV)
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
 
 RDEPEND="
 	>=dev-lang/ghc-8.10.6:=

--- a/dev-haskell/mwc-random/mwc-random-0.14.0.0.ebuild
+++ b/dev-haskell/mwc-random/mwc-random-0.14.0.0.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-haskell/math-functions-0.2.1.0:=[profile?]

--- a/dev-haskell/nanospec/nanospec-0.2.2.ebuild
+++ b/dev-haskell/nanospec/nanospec-0.2.2.ebuild
@@ -13,7 +13,7 @@ HOMEPAGE="https://github.com/hspec/nanospec#readme"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND="
 	>=dev-lang/ghc-8.4.3:=

--- a/dev-haskell/nats/nats-1.1.2-r1.ebuild
+++ b/dev-haskell/nats/nats-1.1.2-r1.ebuild
@@ -19,7 +19,7 @@ SRC_URI="
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="+binary +hashable +template-haskell"
 
 RDEPEND=">=dev-lang/ghc-7.4.1:=

--- a/dev-haskell/netlink/netlink-1.1.1.0-r1.ebuild
+++ b/dev-haskell/netlink/netlink-1.1.1.0-r1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-haskell/cereal-0.3:=[profile?]
 	>=dev-haskell/monad-loops-0.3:=[profile?]

--- a/dev-haskell/network-bsd/network-bsd-2.8.1.0-r1.ebuild
+++ b/dev-haskell/network-bsd/network-bsd-2.8.1.0-r1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-lang/ghc-7.8.2:=

--- a/dev-haskell/network-byte-order/network-byte-order-0.1.6.ebuild
+++ b/dev-haskell/network-byte-order/network-byte-order-0.1.6.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-lang/ghc-7.10.1:=

--- a/dev-haskell/network-info/network-info-0.2.0.10.ebuild
+++ b/dev-haskell/network-info/network-info-0.2.0.10.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-lang/ghc-7.4.1:=

--- a/dev-haskell/network-multicast/network-multicast-0.3.2.ebuild
+++ b/dev-haskell/network-multicast/network-multicast-0.3.2.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="public-domain"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND="dev-haskell/network:=[profile?]

--- a/dev-haskell/network-uri/network-uri-2.6.4.1.ebuild
+++ b/dev-haskell/network-uri/network-uri-2.6.4.1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux"
 
 RESTRICT=test # circular depend: network-uri[test]->criterion->js-flot->http->network-uri
 

--- a/dev-haskell/network/network-3.1.2.5.ebuild
+++ b/dev-haskell/network/network-3.1.2.5.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux"
 IUSE="devel"
 
 RDEPEND=">=dev-lang/ghc-8.4.3:=

--- a/dev-haskell/old-locale/old-locale-1.0.0.7.ebuild
+++ b/dev-haskell/old-locale/old-locale-1.0.0.7.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux"
 IUSE=""
 
 RDEPEND=">=dev-lang/ghc-7.4.1:=

--- a/dev-haskell/old-time/old-time-1.1.0.3-r1.ebuild
+++ b/dev-haskell/old-time/old-time-1.1.0.3-r1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux"
 IUSE=""
 
 RDEPEND=">=dev-haskell/old-locale-1.0:=[profile?] <dev-haskell/old-locale-1.1:=[profile?]

--- a/dev-haskell/onetuple/onetuple-0.3.1.ebuild
+++ b/dev-haskell/onetuple/onetuple-0.3.1.ebuild
@@ -16,7 +16,7 @@ HOMEPAGE="https://hackage.haskell.org/package/OneTuple"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-haskell/base-orphans-0.8.6:=[profile?]
 	>=dev-haskell/hashable-1.3.5.0:=[profile?] <dev-haskell/hashable-1.5:=[profile?]

--- a/dev-haskell/only/only-0.1.ebuild
+++ b/dev-haskell/only/only-0.1.ebuild
@@ -17,7 +17,7 @@ SRC_URI="https://hackage.haskell.org/package/${MY_P}/${MY_P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-lang/ghc-7.4.1:=

--- a/dev-haskell/options/options-1.2.1.1.ebuild
+++ b/dev-haskell/options/options-1.2.1.1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RESTRICT=test # circular depends: options[test]->chell->options

--- a/dev-haskell/optparse-applicative/optparse-applicative-0.16.1.0.ebuild
+++ b/dev-haskell/optparse-applicative/optparse-applicative-0.16.1.0.ebuild
@@ -17,7 +17,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-haskell/ansi-wl-pprint-0.6.8:=[profile?] <dev-haskell/ansi-wl-pprint-0.7:=[profile?]
 	>=dev-haskell/transformers-compat-0.3:=[profile?] <dev-haskell/transformers-compat-0.8:=[profile?]

--- a/dev-haskell/pandoc-lua-marshal/pandoc-lua-marshal-0.1.6.ebuild
+++ b/dev-haskell/pandoc-lua-marshal/pandoc-lua-marshal-0.1.6.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-haskell/hslua-2.1:=[profile?] <dev-haskell/hslua-2.3:=[profile?]
 	>=dev-haskell/hslua-marshalling-2.1:=[profile?] <dev-haskell/hslua-marshalling-2.3:=[profile?]

--- a/dev-haskell/pandoc-types/pandoc-types-1.22.2.ebuild
+++ b/dev-haskell/pandoc-types/pandoc-types-1.22.2.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-haskell/aeson-0.6.2:=[profile?] <dev-haskell/aeson-2.1:=[profile?]
 	>=dev-haskell/quickcheck-2.10:=[profile?] <dev-haskell/quickcheck-2.15:=[profile?]

--- a/dev-haskell/parallel-io/parallel-io-0.3.5.ebuild
+++ b/dev-haskell/parallel-io/parallel-io-0.3.5.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">dev-haskell/extensible-exceptions-0.1.0.1:=[profile?]
 	>=dev-haskell/random-1.0:=[profile?] <dev-haskell/random-1.3:=[profile?]

--- a/dev-haskell/parallel/parallel-3.2.2.0.ebuild
+++ b/dev-haskell/parallel/parallel-3.2.2.0.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-lang/ghc-7.4.1:=

--- a/dev-haskell/parsec-numbers/parsec-numbers-0.1.0.ebuild
+++ b/dev-haskell/parsec-numbers/parsec-numbers-0.1.0.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="parsec1"
 
 RDEPEND=">=dev-lang/ghc-7.4.1:=

--- a/dev-haskell/parsec/parsec-3.1.14.0-r2.ebuild
+++ b/dev-haskell/parsec/parsec-3.1.14.0-r2.ebuild
@@ -19,7 +19,7 @@ HOMEPAGE="https://github.com/haskell/parsec"
 LICENSE="BSD"
 SLOT="0/${PV}"
 # Keep in sync with relevant ghc versions (CABAL_CORE_LIB_GHC_PV)
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux"
 
 RESTRICT=test # circular dependencies: dev-haskell/base-orphans->cabal->parsec[test]->test-framework-hunit->test-framework->base-orphans
 

--- a/dev-haskell/parsec1/parsec1-1.0.0.7.ebuild
+++ b/dev-haskell/parsec1/parsec1-1.0.0.7.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-lang/ghc-8.0.1:=

--- a/dev-haskell/parsers/parsers-0.12.10-r1.ebuild
+++ b/dev-haskell/parsers/parsers-0.12.10-r1.ebuild
@@ -20,7 +20,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="+attoparsec +binary +parsec"
 
 RDEPEND=">=dev-haskell/base-orphans-0.3:=[profile?] <dev-haskell/base-orphans-1:=[profile?]

--- a/dev-haskell/path-pieces/path-pieces-0.2.1.ebuild
+++ b/dev-haskell/path-pieces/path-pieces-0.2.1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-haskell/text-0.5:=[profile?]

--- a/dev-haskell/patience/patience-0.1.1-r1.ebuild
+++ b/dev-haskell/patience/patience-0.1.1-r1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-lang/ghc-7.4.1:=

--- a/dev-haskell/pcre-light/pcre-light-0.4.1.0.ebuild
+++ b/dev-haskell/pcre-light/pcre-light-0.4.1.0.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 #IUSE="use-pkg-config"
 IUSE=""
 

--- a/dev-haskell/pem/pem-0.2.4.ebuild
+++ b/dev-haskell/pem/pem-0.2.4.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND="dev-haskell/basement:=[profile?]

--- a/dev-haskell/persistent-sqlite/persistent-sqlite-2.13.1.0.ebuild
+++ b/dev-haskell/persistent-sqlite/persistent-sqlite-2.13.1.0.ebuild
@@ -14,7 +14,7 @@ HOMEPAGE="https://www.yesodweb.com/book/persistent"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="build-sanity-exe"
 
 RDEPEND=">=dev-db/sqlite-3.0

--- a/dev-haskell/persistent-template/persistent-template-2.12.0.0.ebuild
+++ b/dev-haskell/persistent-template/persistent-template-2.12.0.0.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-lang/ghc-8.4.3:=
 "

--- a/dev-haskell/persistent-test/persistent-test-2.13.1.3.ebuild
+++ b/dev-haskell/persistent-test/persistent-test-2.13.1.3.ebuild
@@ -13,7 +13,7 @@ HOMEPAGE="https://www.yesodweb.com/book/persistent"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-haskell/aeson-1.0:=[profile?]
 	>=dev-haskell/blaze-html-0.9:=[profile?]

--- a/dev-haskell/persistent/persistent-2.14.0.3.ebuild
+++ b/dev-haskell/persistent/persistent-2.14.0.3.ebuild
@@ -14,7 +14,7 @@ HOMEPAGE="https://www.yesodweb.com/book/persistent"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-haskell/aeson-1.0:=[profile?] <dev-haskell/aeson-2.1:=[profile?]
 	dev-haskell/attoparsec:=[profile?]

--- a/dev-haskell/pgp-wordlist/pgp-wordlist-0.1.0.3.ebuild
+++ b/dev-haskell/pgp-wordlist/pgp-wordlist-0.1.0.3.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RESTRICT=test # ambiguous packages: AC-Vector-Fancy vector

--- a/dev-haskell/pretty-hex/pretty-hex-1.0.ebuild
+++ b/dev-haskell/pretty-hex/pretty-hex-1.0.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-lang/ghc-7.4.1:=

--- a/dev-haskell/pretty-show/pretty-show-1.10.ebuild
+++ b/dev-haskell/pretty-show/pretty-show-1.10.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-haskell/haskell-lexer-1.1:=[profile?] <dev-haskell/haskell-lexer-2:=[profile?]
 	dev-haskell/text:=[profile?]

--- a/dev-haskell/prettyprinter-ansi-terminal/prettyprinter-ansi-terminal-1.1.2.ebuild
+++ b/dev-haskell/prettyprinter-ansi-terminal/prettyprinter-ansi-terminal-1.1.2.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD-2"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-haskell/ansi-terminal-0.4.0:=[profile?]

--- a/dev-haskell/prettyprinter/prettyprinter-1.7.0.ebuild
+++ b/dev-haskell/prettyprinter/prettyprinter-1.7.0.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD-2"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-haskell/fail-4.9.0.0:=[profile?] <dev-haskell/fail-4.10:=[profile?]

--- a/dev-haskell/primitive-addr/primitive-addr-0.1.0.2.ebuild
+++ b/dev-haskell/primitive-addr/primitive-addr-0.1.0.2.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-haskell/primitive-0.6.4:=[profile?] <dev-haskell/primitive-0.8:=[profile?]

--- a/dev-haskell/primitive/primitive-0.7.3.0.ebuild
+++ b/dev-haskell/primitive/primitive-0.7.3.0.ebuild
@@ -15,7 +15,7 @@ HOMEPAGE="https://github.com/haskell/primitive"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux"
 
 RESTRICT=test # circular depends: primitive[test]->tasty->wcwidth->attoparsec->scientific->primitive
 

--- a/dev-haskell/profunctors/profunctors-5.6.2-r1.ebuild
+++ b/dev-haskell/profunctors/profunctors-5.6.2-r1.ebuild
@@ -15,7 +15,7 @@ HOMEPAGE="https://github.com/ekmett/profunctors/"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND="
 	>=dev-haskell/base-orphans-0.8.4:=[profile?] <dev-haskell/base-orphans-0.10:=[profile?]

--- a/dev-haskell/psqueues/psqueues-0.2.7.3.ebuild
+++ b/dev-haskell/psqueues/psqueues-0.2.7.3.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-haskell/hashable-1.1.2.3:=[profile?] <dev-haskell/hashable-1.5:=[profile?]
 	>=dev-lang/ghc-8.4.3:=

--- a/dev-haskell/puremd5/puremd5-2.1.3.ebuild
+++ b/dev-haskell/puremd5/puremd5-2.1.3.ebuild
@@ -17,7 +17,7 @@ SRC_URI="https://hackage.haskell.org/package/${MY_P}/${MY_P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="test"
 RESTRICT="!test? ( test )"
 

--- a/dev-haskell/quickcheck-classes-base/quickcheck-classes-base-0.6.2.0.ebuild
+++ b/dev-haskell/quickcheck-classes-base/quickcheck-classes-base-0.6.2.0.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="+binary-laws +unary-laws"
 
 RDEPEND="dev-haskell/contravariant:=[profile?]

--- a/dev-haskell/quickcheck-classes/quickcheck-classes-0.6.4.0.ebuild
+++ b/dev-haskell/quickcheck-classes/quickcheck-classes-0.6.4.0.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="+aeson +binary-laws +semigroupoids +semirings +unary-laws +vector"
 
 RDEPEND=">=dev-haskell/base-orphans-0.1:=[profile?]

--- a/dev-haskell/quickcheck-instances/quickcheck-instances-0.3.27.ebuild
+++ b/dev-haskell/quickcheck-instances/quickcheck-instances-0.3.27.ebuild
@@ -16,7 +16,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-haskell/case-insensitive-1.2.0.4:=[profile?] <dev-haskell/case-insensitive-1.3:=[profile?]
 	>=dev-haskell/data-fix-0.3:=[profile?] <dev-haskell/data-fix-0.4:=[profile?]

--- a/dev-haskell/quickcheck-io/quickcheck-io-0.2.0.ebuild
+++ b/dev-haskell/quickcheck-io/quickcheck-io-0.2.0.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-haskell/hunit-1.2.5:=[profile?]

--- a/dev-haskell/quickcheck/quickcheck-2.14.2.ebuild
+++ b/dev-haskell/quickcheck/quickcheck-2.14.2.ebuild
@@ -18,7 +18,7 @@ SRC_URI="https://hackage.haskell.org/package/${MY_P}/${MY_P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux"
 IUSE="+template-haskell"
 
 RDEPEND=">=dev-haskell/splitmix-0.1:=[profile?] <dev-haskell/splitmix-0.2:=[profile?]

--- a/dev-haskell/random/random-1.2.1.ebuild
+++ b/dev-haskell/random/random-1.2.1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
 
 # circular depend: random[test]->mwc-random->math-functions[test]->vector-th-unbox->vector->random
 RESTRICT=test

--- a/dev-haskell/raw-strings-qq/raw-strings-qq-1.1.ebuild
+++ b/dev-haskell/raw-strings-qq/raw-strings-qq-1.1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-lang/ghc-7.4.1:=

--- a/dev-haskell/reducers/reducers-3.12.3-r1.ebuild
+++ b/dev-haskell/reducers/reducers-3.12.3-r1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-haskell/fingertree-0.1:=[profile?] <dev-haskell/fingertree-0.2:=[profile?]

--- a/dev-haskell/reflection/reflection-2.1.6.ebuild
+++ b/dev-haskell/reflection/reflection-2.1.6.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-lang/ghc-8.4.3:=
 "

--- a/dev-haskell/regex-applicative/regex-applicative-0.3.3.1.ebuild
+++ b/dev-haskell/regex-applicative/regex-applicative-0.3.3.1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-lang/ghc-7.8.2:=

--- a/dev-haskell/regex-base/regex-base-0.94.0.1.ebuild
+++ b/dev-haskell/regex-base/regex-base-0.94.0.1.ebuild
@@ -15,7 +15,7 @@ HOMEPAGE="https://wiki.haskell.org/Regular_expressions"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
 
 RDEPEND=">=dev-haskell/mtl-1.1:=[profile?] <dev-haskell/mtl-2.3:=[profile?]
 	>=dev-haskell/text-1.2.3:=[profile?] <dev-haskell/text-1.3:=[profile?]

--- a/dev-haskell/regex-compat/regex-compat-0.95.2.1-r1.ebuild
+++ b/dev-haskell/regex-compat/regex-compat-0.95.2.1-r1.ebuild
@@ -16,7 +16,7 @@ HOMEPAGE="https://wiki.haskell.org/Regular_expressions"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-haskell/regex-base-0.94:=[profile?] <dev-haskell/regex-base-0.95:=[profile?]
 	>=dev-haskell/regex-posix-0.96:=[profile?] <dev-haskell/regex-posix-0.97:=[profile?]

--- a/dev-haskell/regex-posix/regex-posix-0.96.0.0.ebuild
+++ b/dev-haskell/regex-posix/regex-posix-0.96.0.0.ebuild
@@ -16,7 +16,7 @@ HOMEPAGE="https://hackage.haskell.org/package/regex-posix"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
 
 RDEPEND=">=dev-haskell/fail-4.9:=[profile?] <dev-haskell/fail-4.10:=[profile?]
 	>=dev-haskell/regex-base-0.94:=[profile?] <dev-haskell/regex-base-0.95:=[profile?]

--- a/dev-haskell/regex-tdfa/regex-tdfa-1.3.2.ebuild
+++ b/dev-haskell/regex-tdfa/regex-tdfa-1.3.2.ebuild
@@ -14,7 +14,7 @@ HOMEPAGE="https://wiki.haskell.org/Regular_expressions"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 PATCHES=(
 	"${FILESDIR}/${PN}-1.3.2-disable-doctests.patch"

--- a/dev-haskell/resolv/resolv-0.1.2.0-r1.ebuild
+++ b/dev-haskell/resolv/resolv-0.1.2.0-r1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="GPL-2+"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RESTRICT=test # fails to build test suite

--- a/dev-haskell/resource-pool/resource-pool-0.2.3.2.ebuild
+++ b/dev-haskell/resource-pool/resource-pool-0.2.3.2.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND="dev-haskell/hashable:=[profile?]

--- a/dev-haskell/resourcet/resourcet-1.2.4.2.ebuild
+++ b/dev-haskell/resourcet/resourcet-1.2.4.2.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-haskell/mtl-2.0:=[profile?] <dev-haskell/mtl-2.3:=[profile?]

--- a/dev-haskell/retry/retry-0.9.0.0.ebuild
+++ b/dev-haskell/retry/retry-0.9.0.0.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-haskell/exceptions-0.5:=[profile?]
 	>=dev-haskell/random-1:=[profile?]

--- a/dev-haskell/rio/rio-0.1.21.0.ebuild
+++ b/dev-haskell/rio/rio-0.1.21.0.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND="dev-haskell/hashable:=[profile?]
 	dev-haskell/microlens:=[profile?]

--- a/dev-haskell/safe-exceptions/safe-exceptions-0.1.7.0.ebuild
+++ b/dev-haskell/safe-exceptions/safe-exceptions-0.1.7.0.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-haskell/exceptions-0.8:=[profile?]

--- a/dev-haskell/safe/safe-0.3.19.ebuild
+++ b/dev-haskell/safe/safe-0.3.19.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-lang/ghc-7.10.1:=

--- a/dev-haskell/safesemaphore/safesemaphore-0.10.1.ebuild
+++ b/dev-haskell/safesemaphore/safesemaphore-0.10.1.ebuild
@@ -17,7 +17,7 @@ SRC_URI="https://hackage.haskell.org/package/${MY_P}/${MY_P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux"
 IUSE=""
 
 RDEPEND="dev-haskell/stm:=[profile?]

--- a/dev-haskell/sandi/sandi-0.5.ebuild
+++ b/dev-haskell/sandi/sandi-0.5.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="+conduit"
 
 RDEPEND=">=dev-lang/ghc-7.4.1:=

--- a/dev-haskell/scientific/scientific-0.3.7.0-r2.ebuild
+++ b/dev-haskell/scientific/scientific-0.3.7.0-r2.ebuild
@@ -16,7 +16,7 @@ HOMEPAGE="https://github.com/basvandijk/scientific"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND="
 	>=dev-haskell/hashable-1.2.7.0:=[profile?] <dev-haskell/hashable-1.5:=[profile?]

--- a/dev-haskell/securemem/securemem-0.1.10.ebuild
+++ b/dev-haskell/securemem/securemem-0.1.10.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-haskell/byteable-0.1.1:=[profile?]

--- a/dev-haskell/semialign/semialign-1.2.0.1.ebuild
+++ b/dev-haskell/semialign/semialign-1.2.0.1.ebuild
@@ -17,7 +17,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-haskell/hashable-1.2.7.0:=[profile?] <dev-haskell/hashable-1.5:=[profile?]
 	>=dev-haskell/indexed-traversable-0.1.1:=[profile?] <dev-haskell/indexed-traversable-0.2:=[profile?]

--- a/dev-haskell/semigroupoids/semigroupoids-5.3.7-r1.ebuild
+++ b/dev-haskell/semigroupoids/semigroupoids-5.3.7-r1.ebuild
@@ -14,7 +14,7 @@ HOMEPAGE="https://github.com/ekmett/semigroupoids"
 
 LICENSE="BSD-2"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-haskell/base-orphans-0.8.4:=[profile?] <dev-haskell/base-orphans-1:=[profile?]
 	>=dev-haskell/bifunctors-5.5.9:=[profile?] <dev-haskell/bifunctors-6:=[profile?]

--- a/dev-haskell/semigroups/semigroups-0.20.ebuild
+++ b/dev-haskell/semigroups/semigroups-0.20.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-lang/ghc-8.4.3:=
 "

--- a/dev-haskell/semirings/semirings-0.6-r2.ebuild
+++ b/dev-haskell/semirings/semirings-0.6-r2.ebuild
@@ -16,7 +16,7 @@ HOMEPAGE="https://github.com/chessai/semirings"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND="
 	dev-haskell/base-compat-batteries:=[profile?]

--- a/dev-haskell/servant-server/servant-server-0.19.1.ebuild
+++ b/dev-haskell/servant-server/servant-server-0.19.1.ebuild
@@ -20,7 +20,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="examples"
 
 PATCHES=( "${FILESDIR}/${PN}-0.18.3-add-examples-flag.patch" )

--- a/dev-haskell/servant/servant-0.19.ebuild
+++ b/dev-haskell/servant/servant-0.19.ebuild
@@ -20,7 +20,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-haskell/aeson-1.4.1.0:=[profile?] <dev-haskell/aeson-3:=[profile?]
 	>=dev-haskell/attoparsec-0.13.2.2:=[profile?] <dev-haskell/attoparsec-0.15:=[profile?]

--- a/dev-haskell/setenv/setenv-0.1.1.3.ebuild
+++ b/dev-haskell/setenv/setenv-0.1.1.3.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-lang/ghc-7.4.1:=

--- a/dev-haskell/setlocale/setlocale-1.0.0.9.ebuild
+++ b/dev-haskell/setlocale/setlocale-1.0.0.9.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-lang/ghc-7.6.1:=

--- a/dev-haskell/sha/sha-1.6.4.4.ebuild
+++ b/dev-haskell/sha/sha-1.6.4.4.ebuild
@@ -18,7 +18,7 @@ SRC_URI="https://hackage.haskell.org/package/${MY_P}/${MY_P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux"
 IUSE="exe"
 
 RDEPEND=">=dev-lang/ghc-7.8.2:=

--- a/dev-haskell/shakespeare/shakespeare-2.0.30.ebuild
+++ b/dev-haskell/shakespeare/shakespeare-2.0.30.ebuild
@@ -14,7 +14,7 @@ HOMEPAGE="https://www.yesodweb.com/book/shakespearean-templates"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND="<dev-haskell/aeson-3:=[profile?]
 	dev-haskell/blaze-html:=[profile?]

--- a/dev-haskell/shelly/shelly-1.9.0.ebuild
+++ b/dev-haskell/shelly/shelly-1.9.0.ebuild
@@ -16,7 +16,7 @@ HOMEPAGE="https://github.com/yesodweb/Shelly.hs"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="examples lifted"
 
 CABAL_CHDEPS=(

--- a/dev-haskell/should-not-typecheck/should-not-typecheck-2.1.0.ebuild
+++ b/dev-haskell/should-not-typecheck/should-not-typecheck-2.1.0.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-haskell/hunit-1.2:=[profile?]

--- a/dev-haskell/silently/silently-1.2.5.1.ebuild
+++ b/dev-haskell/silently/silently-1.2.5.1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-lang/ghc-7.4.1:=

--- a/dev-haskell/simple-reflect/simple-reflect-0.3.3.ebuild
+++ b/dev-haskell/simple-reflect/simple-reflect-0.3.3.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-lang/ghc-7.4.1:=

--- a/dev-haskell/simple-sendfile/simple-sendfile-0.2.28.ebuild
+++ b/dev-haskell/simple-sendfile/simple-sendfile-0.2.28.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="+allow-bsd"
 
 RDEPEND="dev-haskell/network:=[profile?]

--- a/dev-haskell/singleton-bool/singleton-bool-0.1.5-r1.ebuild
+++ b/dev-haskell/singleton-bool/singleton-bool-0.1.5-r1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-haskell/tagged-0.8.5:=[profile?] <dev-haskell/tagged-0.9:=[profile?]

--- a/dev-haskell/skein/skein-1.0.9.4.ebuild
+++ b/dev-haskell/skein/skein-1.0.9.4.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="big-endian force-endianness reference"
 
 RDEPEND=">=dev-haskell/cereal-0.3:=[profile?] <dev-haskell/cereal-0.6:=[profile?]

--- a/dev-haskell/skylighting-core/skylighting-core-0.12.3.1.ebuild
+++ b/dev-haskell/skylighting-core/skylighting-core-0.12.3.1.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="executable"
 PATCHES=( "${FILESDIR}/skylighting-increase-timeouts.patch" )
 

--- a/dev-haskell/skylighting/skylighting-0.12.3.1.ebuild
+++ b/dev-haskell/skylighting/skylighting-0.12.3.1.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="executable"
 
 RDEPEND="~dev-haskell/skylighting-core-0.12.3.1:=[profile?]

--- a/dev-haskell/smallcheck/smallcheck-1.2.0.ebuild
+++ b/dev-haskell/smallcheck/smallcheck-1.2.0.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND="dev-haskell/logict:=[profile?]

--- a/dev-haskell/socks/socks-0.6.1.ebuild
+++ b/dev-haskell/socks/socks-0.6.1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND="dev-haskell/basement:=[profile?]

--- a/dev-haskell/sop-core/sop-core-0.5.0.2.ebuild
+++ b/dev-haskell/sop-core/sop-core-0.5.0.2.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-lang/ghc-8.4.3:=
 "

--- a/dev-haskell/split/split-0.2.3.4.ebuild
+++ b/dev-haskell/split/split-0.2.3.4.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86 ~ppc-macos"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86 ~ppc-macos"
 IUSE=""
 
 RDEPEND=">=dev-lang/ghc-7.4.1:=

--- a/dev-haskell/splitmix/splitmix-0.1.0.3.ebuild
+++ b/dev-haskell/splitmix/splitmix-0.1.0.3.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="optimised-mixer"
 
 RESTRICT=test # circular deps: dev-haskell/splitmix[test]->dev-haskell/base-compat-batteries->dev-haskell/quickcheck->dev-haskell/splitmix

--- a/dev-haskell/statevar/statevar-1.2.1.ebuild
+++ b/dev-haskell/statevar/statevar-1.2.1.ebuild
@@ -17,7 +17,7 @@ SRC_URI="https://hackage.haskell.org/package/${MY_P}/${MY_P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-haskell/stm-2.3.0.1:=[profile?] <dev-haskell/stm-2.6:=[profile?]

--- a/dev-haskell/statistics/statistics-0.15.2.0.ebuild
+++ b/dev-haskell/statistics/statistics-0.15.2.0.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD-2"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-haskell/aeson-0.6.0.0:=[profile?]

--- a/dev-haskell/stm-chans/stm-chans-3.0.0.4.ebuild
+++ b/dev-haskell/stm-chans/stm-chans-3.0.0.4.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-haskell/stm-2.4:=[profile?]

--- a/dev-haskell/stm/stm-2.5.0.1-r1.ebuild
+++ b/dev-haskell/stm/stm-2.5.0.1-r1.ebuild
@@ -14,7 +14,7 @@ HOMEPAGE="https://wiki.haskell.org/Software_transactional_memory"
 LICENSE="BSD"
 SLOT="0/${PV}"
 # Keep in sync with relevant ghc versions (CABAL_CORE_LIB_GHC_PV)
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux"
 
 CABAL_CHDEPS=(
 	'base  >= 4.3 && < 4.15' 'base >= 4.3'

--- a/dev-haskell/streaming-commons/streaming-commons-0.2.2.4.ebuild
+++ b/dev-haskell/streaming-commons/streaming-commons-0.2.2.4.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RESTRICT=test # requires network
 

--- a/dev-haskell/strict/strict-0.4.0.1.ebuild
+++ b/dev-haskell/strict/strict-0.4.0.1.ebuild
@@ -17,7 +17,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-haskell/assoc-1.0.1:=[profile?] <dev-haskell/assoc-1.1:=[profile?]
 	>=dev-haskell/hashable-1.2.7.0:=[profile?] <dev-haskell/hashable-1.5:=[profile?]

--- a/dev-haskell/string-conversions/string-conversions-0.4.0.1.ebuild
+++ b/dev-haskell/string-conversions/string-conversions-0.4.0.1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-haskell/text-0.11:=[profile?]

--- a/dev-haskell/string-qq/string-qq-0.0.4-r1.ebuild
+++ b/dev-haskell/string-qq/string-qq-0.0.4-r1.ebuild
@@ -13,7 +13,7 @@ HOMEPAGE="https://hackage.haskell.org/package/string-qq"
 
 LICENSE="public-domain"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 CABAL_CHDEPS=(
 	'text >=1.2 && <1.3' 'text >=1.2'

--- a/dev-haskell/stringbuilder/stringbuilder-0.5.1.ebuild
+++ b/dev-haskell/stringbuilder/stringbuilder-0.5.1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-lang/ghc-7.4.1:=

--- a/dev-haskell/syb/syb-0.7.2.1.ebuild
+++ b/dev-haskell/syb/syb-0.7.2.1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux"
 
 RDEPEND=">=dev-lang/ghc-8.4.3:=
 "

--- a/dev-haskell/system-fileio/system-fileio-0.3.16.4.ebuild
+++ b/dev-haskell/system-fileio/system-fileio-0.3.16.4.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 CABAL_CHDEPS=(

--- a/dev-haskell/system-filepath/system-filepath-0.4.14-r1.ebuild
+++ b/dev-haskell/system-filepath/system-filepath-0.4.14-r1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RESTRICT=test
 

--- a/dev-haskell/tagged/tagged-0.8.6.1.ebuild
+++ b/dev-haskell/tagged/tagged-0.8.6.1.ebuild
@@ -19,7 +19,7 @@ HOMEPAGE="https://github.com/ekmett/tagged"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-haskell/transformers-compat-0.5:=[profile?] <dev-haskell/transformers-compat-1:=[profile?]
 	>=dev-lang/ghc-7.8.2:=

--- a/dev-haskell/tagsoup/tagsoup-0.14.8.ebuild
+++ b/dev-haskell/tagsoup/tagsoup-0.14.8.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND="dev-haskell/text:=[profile?]

--- a/dev-haskell/tar/tar-0.5.1.1-r3.ebuild
+++ b/dev-haskell/tar/tar-0.5.1.1-r3.ebuild
@@ -16,7 +16,7 @@ HOMEPAGE="https://hackage.haskell.org/package/tar"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND="
 	>=dev-lang/ghc-8.8.1:=

--- a/dev-haskell/tasty-expected-failure/tasty-expected-failure-0.11.1.2.ebuild
+++ b/dev-haskell/tasty-expected-failure/tasty-expected-failure-0.11.1.2.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-haskell/tagged-0.7:=[profile?] <dev-haskell/tagged-0.9:=[profile?]

--- a/dev-haskell/tasty-golden/tasty-golden-2.3.1.1.ebuild
+++ b/dev-haskell/tasty-golden/tasty-golden-2.3.1.1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND="dev-haskell/async:=[profile?]

--- a/dev-haskell/tasty-hedgehog/tasty-hedgehog-1.1.0.0.ebuild
+++ b/dev-haskell/tasty-hedgehog/tasty-hedgehog-1.1.0.0.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-haskell/hedgehog-1.0.2:=[profile?]
 	>=dev-haskell/tagged-0.8:=[profile?] <dev-haskell/tagged-0.9:=[profile?]

--- a/dev-haskell/tasty-hslua/tasty-hslua-1.0.2.ebuild
+++ b/dev-haskell/tasty-hslua/tasty-hslua-1.0.2.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-haskell/hslua-core-2.0:=[profile?] <dev-haskell/hslua-core-2.3:=[profile?]
 	>=dev-haskell/tasty-0.11:=[profile?]

--- a/dev-haskell/tasty-hunit/tasty-hunit-0.10.0.3.ebuild
+++ b/dev-haskell/tasty-hunit/tasty-hunit-0.10.0.3.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND="dev-haskell/call-stack:=[profile?]

--- a/dev-haskell/tasty-kat/tasty-kat-0.0.3.ebuild
+++ b/dev-haskell/tasty-kat/tasty-kat-0.0.3.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND="dev-haskell/tasty:=[profile?]

--- a/dev-haskell/tasty-lua/tasty-lua-1.0.2.ebuild
+++ b/dev-haskell/tasty-lua/tasty-lua-1.0.2.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-haskell/file-embed-0.0:=[profile?] <dev-haskell/file-embed-0.1:=[profile?]
 	>=dev-haskell/hslua-core-2.0:=[profile?] <dev-haskell/hslua-core-2.3:=[profile?]

--- a/dev-haskell/tasty-quickcheck/tasty-quickcheck-0.10.1.1.ebuild
+++ b/dev-haskell/tasty-quickcheck/tasty-quickcheck-0.10.1.1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND="dev-haskell/optparse-applicative:=[profile?]

--- a/dev-haskell/tasty-rerun/tasty-rerun-1.1.18.ebuild
+++ b/dev-haskell/tasty-rerun/tasty-rerun-1.1.18.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-haskell/mtl-2.1.2:=[profile?]

--- a/dev-haskell/tasty-smallcheck/tasty-smallcheck-0.8.1.ebuild
+++ b/dev-haskell/tasty-smallcheck/tasty-smallcheck-0.8.1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND="dev-haskell/async:=[profile?]

--- a/dev-haskell/tasty-th/tasty-th-0.1.7.ebuild
+++ b/dev-haskell/tasty-th/tasty-th-0.1.7.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-haskell/haskell-src-exts-1.18.0:=[profile?]

--- a/dev-haskell/tasty/tasty-1.4.2.3.ebuild
+++ b/dev-haskell/tasty/tasty-1.4.2.3.ebuild
@@ -14,7 +14,7 @@ HOMEPAGE="https://github.com/UnkindPartition/tasty"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="+clock"
 
 RDEPEND="

--- a/dev-haskell/temporary-rc/temporary-rc-1.2.0.3.ebuild
+++ b/dev-haskell/temporary-rc/temporary-rc-1.2.0.3.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-haskell/exceptions-0.6:=[profile?]

--- a/dev-haskell/temporary/temporary-1.3.ebuild
+++ b/dev-haskell/temporary/temporary-1.3.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-haskell/exceptions-0.6:=[profile?]

--- a/dev-haskell/terminal-size/terminal-size-0.3.2.1.ebuild
+++ b/dev-haskell/terminal-size/terminal-size-0.3.2.1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-lang/ghc-7.4.1:=

--- a/dev-haskell/test-framework-hunit/test-framework-hunit-0.3.0.2-r1.ebuild
+++ b/dev-haskell/test-framework-hunit/test-framework-hunit-0.3.0.2-r1.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-haskell/extensible-exceptions-0.1.1:=[profile?] <dev-haskell/extensible-exceptions-0.2.0:=[profile?]

--- a/dev-haskell/test-framework-leancheck/test-framework-leancheck-0.0.1.ebuild
+++ b/dev-haskell/test-framework-leancheck/test-framework-leancheck-0.0.1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND="dev-haskell/leancheck:=[profile?]

--- a/dev-haskell/test-framework-quickcheck2/test-framework-quickcheck2-0.3.0.5-r2.ebuild
+++ b/dev-haskell/test-framework-quickcheck2/test-framework-quickcheck2-0.3.0.5-r2.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-haskell/extensible-exceptions-0.1.1:=[profile?] <dev-haskell/extensible-exceptions-0.2.0:=[profile?]

--- a/dev-haskell/test-framework-th/test-framework-th-0.2.4.ebuild
+++ b/dev-haskell/test-framework-th/test-framework-th-0.2.4.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND="dev-haskell/haskell-src-exts:=[profile?]

--- a/dev-haskell/test-framework/test-framework-0.8.2.0-r4.ebuild
+++ b/dev-haskell/test-framework/test-framework-0.8.2.0-r4.ebuild
@@ -16,7 +16,7 @@ HOMEPAGE="https://haskell.github.io/test-framework/"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND="
 	>=dev-haskell/ansi-terminal-0.4.0:=[profile?] <dev-haskell/ansi-terminal-1.1:=[profile?]

--- a/dev-haskell/texmath/texmath-0.12.5.1.ebuild
+++ b/dev-haskell/texmath/texmath-0.12.5.1.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="executable server"
 
 RDEPEND=">=dev-haskell/pandoc-types-1.20:=[profile?] <dev-haskell/pandoc-types-1.23:=[profile?]

--- a/dev-haskell/text-conversions/text-conversions-0.3.1.ebuild
+++ b/dev-haskell/text-conversions/text-conversions-0.3.1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="ISC"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND="<dev-haskell/base16-bytestring-2:=[profile?]

--- a/dev-haskell/text-icu/text-icu-0.7.1.0.ebuild
+++ b/dev-haskell/text-icu/text-icu-0.7.1.0.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RESTRICT=test # QuickCheck occasionally finds counterexamples
 # and fails to build: Duplicate instance declarations: instance NFData Ordering

--- a/dev-haskell/text-short/text-short-0.1.5-r1.ebuild
+++ b/dev-haskell/text-short/text-short-0.1.5-r1.ebuild
@@ -16,7 +16,7 @@ HOMEPAGE="https://hackage.haskell.org/package/text-short"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="debug"
 
 RDEPEND="

--- a/dev-haskell/text-show/text-show-3.9.7.ebuild
+++ b/dev-haskell/text-show/text-show-3.9.7.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-haskell/base-compat-batteries-0.11:=[profile?] <dev-haskell/base-compat-batteries-0.13:=[profile?]
 	>=dev-haskell/bifunctors-5.1:=[profile?] <dev-haskell/bifunctors-6:=[profile?]

--- a/dev-haskell/text/text-1.2.5.0-r1.ebuild
+++ b/dev-haskell/text/text-1.2.5.0-r1.ebuild
@@ -18,7 +18,7 @@ HOMEPAGE="https://github.com/haskell/text"
 LICENSE="BSD-2"
 SLOT="0/${PV}"
 # Keep in sync with relevant ghc versions (CABAL_CORE_LIB_GHC_PV)
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux"
 
 # break cyclic dependencies:
 RESTRICT=test

--- a/dev-haskell/tf-random/tf-random-0.5.ebuild
+++ b/dev-haskell/tf-random/tf-random-0.5.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-haskell/primitive-0.3:=[profile?]

--- a/dev-haskell/th-abstraction/th-abstraction-0.4.3.0.ebuild
+++ b/dev-haskell/th-abstraction/th-abstraction-0.4.3.0.ebuild
@@ -13,7 +13,7 @@ HOMEPAGE="https://github.com/glguy/th-abstraction"
 
 LICENSE="ISC"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-lang/ghc-8.4.3:=
 "

--- a/dev-haskell/th-compat/th-compat-0.1.3.ebuild
+++ b/dev-haskell/th-compat/th-compat-0.1.3.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-lang/ghc-8.4.3:=
 "

--- a/dev-haskell/th-lift-instances/th-lift-instances-0.1.19.ebuild
+++ b/dev-haskell/th-lift-instances/th-lift-instances-0.1.19.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND="dev-haskell/text:=[profile?]
 	>=dev-haskell/th-lift-0.8:=[profile?]

--- a/dev-haskell/th-lift/th-lift-0.8.2.ebuild
+++ b/dev-haskell/th-lift/th-lift-0.8.2.ebuild
@@ -15,7 +15,7 @@ HOMEPAGE="https://github.com/RyanGlScott/th-lift"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-haskell/th-abstraction-0.2.3:=[profile?] <dev-haskell/th-abstraction-0.5:=[profile?]
 	>=dev-lang/ghc-7.4.1:=

--- a/dev-haskell/these/these-1.1.1.1.ebuild
+++ b/dev-haskell/these/these-1.1.1.1.ebuild
@@ -17,7 +17,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-haskell/assoc-1:=[profile?] <dev-haskell/assoc-1.1:=[profile?]
 	>=dev-haskell/hashable-1.2.7.0:=[profile?] <dev-haskell/hashable-1.5:=[profile?]

--- a/dev-haskell/time-compat/time-compat-1.9.6.1-r1.ebuild
+++ b/dev-haskell/time-compat/time-compat-1.9.6.1-r1.ebuild
@@ -15,7 +15,7 @@ HOMEPAGE="https://github.com/haskellari/time-compat"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 PATCHES=( "${FILESDIR}/fix-resolution-test.patch" )
 

--- a/dev-haskell/time-locale-compat/time-locale-compat-0.1.1.5.ebuild
+++ b/dev-haskell/time-locale-compat/time-locale-compat-0.1.1.5.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND="dev-haskell/old-locale:=[profile?]

--- a/dev-haskell/time-manager/time-manager-0.0.0.ebuild
+++ b/dev-haskell/time-manager/time-manager-0.0.0.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND="dev-haskell/auto-update:=[profile?]

--- a/dev-haskell/timeit/timeit-2.0.ebuild
+++ b/dev-haskell/timeit/timeit-2.0.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-lang/ghc-7.8.2:=

--- a/dev-haskell/timezone-olson/timezone-olson-0.2.0.ebuild
+++ b/dev-haskell/timezone-olson/timezone-olson-0.2.0.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 CABAL_CHDEPS=(
 	'time >= 1.6 && < 1.10' 'time >= 1.6'

--- a/dev-haskell/timezone-series/timezone-series-0.1.9.ebuild
+++ b/dev-haskell/timezone-series/timezone-series-0.1.9.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 CABAL_CHDEPS=(

--- a/dev-haskell/tls-session-manager/tls-session-manager-0.0.4.ebuild
+++ b/dev-haskell/tls-session-manager/tls-session-manager-0.0.4.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND="dev-haskell/auto-update:=[profile?]

--- a/dev-haskell/tls/tls-1.5.8.ebuild
+++ b/dev-haskell/tls/tls-1.5.8.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="+compat +network"
 
 RDEPEND="dev-haskell/asn1-encoding:=[profile?]

--- a/dev-haskell/torrent/torrent-10000.1.1.ebuild
+++ b/dev-haskell/torrent/torrent-10000.1.1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-haskell/bencode-0.2:=[profile?]

--- a/dev-haskell/transformers-base/transformers-base-0.4.5.2.ebuild
+++ b/dev-haskell/transformers-base/transformers-base-0.4.5.2.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux"
 IUSE="+orphaninstances"
 
 RDEPEND=">=dev-haskell/stm-2.3:=[profile?]

--- a/dev-haskell/transformers-compat/transformers-compat-0.6.6.ebuild
+++ b/dev-haskell/transformers-compat/transformers-compat-0.6.6.ebuild
@@ -18,7 +18,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux"
 IUSE=""
 
 RDEPEND=">=dev-haskell/fail-4.9:=[profile?] <dev-haskell/fail-4.10:=[profile?]

--- a/dev-haskell/transformers/transformers-0.5.6.2-r1.ebuild
+++ b/dev-haskell/transformers/transformers-0.5.6.2-r1.ebuild
@@ -17,7 +17,7 @@ HOMEPAGE="https://hackage.haskell.org/package/transformers"
 LICENSE="BSD"
 SLOT="0/${PV}"
 # Keep in sync with relevant ghc versions (CABAL_CORE_LIB_GHC_PV)
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux"
 
 RDEPEND="
 	>=dev-lang/ghc-8.10.6:=

--- a/dev-haskell/tree-diff/tree-diff-0.2.1.1.ebuild
+++ b/dev-haskell/tree-diff/tree-diff-0.2.1.1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="GPL-2+"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-haskell/ansi-terminal-0.10:=[profile?] <dev-haskell/ansi-terminal-0.12:=[profile?]
 	>=dev-haskell/ansi-wl-pprint-0.6.8.2:=[profile?] <dev-haskell/ansi-wl-pprint-0.7:=[profile?]

--- a/dev-haskell/trifecta/trifecta-2.1.2.ebuild
+++ b/dev-haskell/trifecta/trifecta-2.1.2.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-haskell/ansi-terminal-0.6:=[profile?] <dev-haskell/ansi-terminal-0.12:=[profile?]
 	>=dev-haskell/blaze-builder-0.3.0.1:=[profile?] <dev-haskell/blaze-builder-0.5:=[profile?]

--- a/dev-haskell/type-equality/type-equality-1.ebuild
+++ b/dev-haskell/type-equality/type-equality-1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-lang/ghc-7.4.1:=

--- a/dev-haskell/typed-process/typed-process-0.2.6.0.ebuild
+++ b/dev-haskell/typed-process/typed-process-0.2.6.0.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND="dev-haskell/async:=[profile?]

--- a/dev-haskell/unbounded-delays/unbounded-delays-0.1.1.0.ebuild
+++ b/dev-haskell/unbounded-delays/unbounded-delays-0.1.1.0.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-lang/ghc-7.4.1:=

--- a/dev-haskell/unicode-collation/unicode-collation-0.1.3.3.ebuild
+++ b/dev-haskell/unicode-collation/unicode-collation-0.1.3.3.ebuild
@@ -13,7 +13,7 @@ HOMEPAGE="https://github.com/jgm/unicode-collation"
 
 LICENSE="BSD-2"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="doctests executable"
 
 RDEPEND="dev-haskell/th-lift-instances:=[profile?]

--- a/dev-haskell/unicode-data/unicode-data-0.3.0.ebuild
+++ b/dev-haskell/unicode-data/unicode-data-0.3.0.ebuild
@@ -16,7 +16,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz
 
 LICENSE="Apache-2.0"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-lang/ghc-8.4.3:=
 "

--- a/dev-haskell/unicode-transforms/unicode-transforms-0.3.7.1-r1.ebuild
+++ b/dev-haskell/unicode-transforms/unicode-transforms-0.3.7.1-r1.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-haskell/text-1.1.1:=[profile?] <dev-haskell/text-1.3:=[profile?]

--- a/dev-haskell/uniplate/uniplate-1.6.13.ebuild
+++ b/dev-haskell/uniplate/uniplate-1.6.13.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-haskell/hashable-1.1.2.3:=[profile?]

--- a/dev-haskell/unix-compat/unix-compat-0.5.2.ebuild
+++ b/dev-haskell/unix-compat/unix-compat-0.5.2.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="old-time"
 
 RDEPEND=">=dev-lang/ghc-7.4.1:=

--- a/dev-haskell/unix-time/unix-time-0.4.7.ebuild
+++ b/dev-haskell/unix-time/unix-time-0.4.7.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RESTRICT=test # QuickCheck finds counterxamples:

--- a/dev-haskell/unliftio-core/unliftio-core-0.1.2.0.ebuild
+++ b/dev-haskell/unliftio-core/unliftio-core-0.1.2.0.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-lang/ghc-7.8.2:=

--- a/dev-haskell/unliftio/unliftio-0.2.18.ebuild
+++ b/dev-haskell/unliftio/unliftio-0.2.18.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">dev-haskell/async-2.1.1:=[profile?]
 	>=dev-haskell/stm-2.4.3:=[profile?]

--- a/dev-haskell/unordered-containers/unordered-containers-0.2.17.0.ebuild
+++ b/dev-haskell/unordered-containers/unordered-containers-0.2.17.0.ebuild
@@ -16,7 +16,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-haskell/hashable-1.2.5:=[profile?] <dev-haskell/hashable-1.5:=[profile?]
 	>=dev-lang/ghc-8.4.3:=

--- a/dev-haskell/utf8-light/utf8-light-0.4.2.ebuild
+++ b/dev-haskell/utf8-light/utf8-light-0.4.2.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-lang/ghc-7.4.1:= <dev-lang/ghc-9.1

--- a/dev-haskell/utf8-string/utf8-string-1.0.1.1.ebuild
+++ b/dev-haskell/utf8-string/utf8-string-1.0.1.1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
 IUSE=""
 
 RDEPEND=">=dev-lang/ghc-7.4.1:=

--- a/dev-haskell/uuid-types/uuid-types-1.0.5-r1.ebuild
+++ b/dev-haskell/uuid-types/uuid-types-1.0.5-r1.ebuild
@@ -15,7 +15,7 @@ HOMEPAGE="https://github.com/haskell-hvr/uuid"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND="
 	>=dev-haskell/hashable-1.2.7.0:=[profile?] <dev-haskell/hashable-1.5:=[profile?]

--- a/dev-haskell/uuid/uuid-1.3.15-r1.ebuild
+++ b/dev-haskell/uuid/uuid-1.3.15-r1.ebuild
@@ -15,7 +15,7 @@ HOMEPAGE="https://github.com/haskell-hvr/uuid"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND="
 	>=dev-haskell/cryptohash-md5-0.11.100:=[profile?] <dev-haskell/cryptohash-md5-0.12

--- a/dev-haskell/vault/vault-0.3.1.5-r2.ebuild
+++ b/dev-haskell/vault/vault-0.3.1.5-r2.ebuild
@@ -15,7 +15,7 @@ HOMEPAGE="https://github.com/HeinrichApfelmus/vault"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND="
 	>=dev-haskell/hashable-1.1.2.5:=[profile?] <dev-haskell/hashable-1.5:=[profile?]

--- a/dev-haskell/vector-algorithms/vector-algorithms-0.8.0.4.ebuild
+++ b/dev-haskell/vector-algorithms/vector-algorithms-0.8.0.4.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="+bench +boundschecks internalchecks +properties unsafechecks"
 
 RDEPEND=">=dev-haskell/primitive-0.3:=[profile?] <dev-haskell/primitive-0.8:=[profile?]

--- a/dev-haskell/vector-binary-instances/vector-binary-instances-0.2.5.1.ebuild
+++ b/dev-haskell/vector-binary-instances/vector-binary-instances-0.2.5.1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-haskell/vector-0.6:=[profile?] <dev-haskell/vector-0.13:=[profile?]

--- a/dev-haskell/vector-th-unbox/vector-th-unbox-0.2.1.7.ebuild
+++ b/dev-haskell/vector-th-unbox/vector-th-unbox-0.2.1.7.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-haskell/vector-0.7.1:=[profile?] <dev-haskell/vector-0.13:=[profile?]

--- a/dev-haskell/vector/vector-0.12.3.1.ebuild
+++ b/dev-haskell/vector/vector-0.12.3.1.ebuild
@@ -21,7 +21,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="+boundschecks internalchecks unsafechecks"
 
 PATCHES=(

--- a/dev-haskell/void/void-0.7.3.ebuild
+++ b/dev-haskell/void/void-0.7.3.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="safe"
 
 RDEPEND=">=dev-haskell/hashable-1.1:=[profile?]

--- a/dev-haskell/wai-app-static/wai-app-static-3.1.7.2-r1.ebuild
+++ b/dev-haskell/wai-app-static/wai-app-static-3.1.7.2-r1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="print"
 
 RDEPEND=">=dev-haskell/blaze-html-0.5:=[profile?]

--- a/dev-haskell/wai-extra/wai-extra-3.1.4.1.ebuild
+++ b/dev-haskell/wai-extra/wai-extra-3.1.4.1.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="examples"
 
 RDEPEND="dev-haskell/aeson:=[profile?]

--- a/dev-haskell/wai-logger/wai-logger-2.3.6.ebuild
+++ b/dev-haskell/wai-logger/wai-logger-2.3.6.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 GHC_BOOTSTRAP_PACKAGES=(

--- a/dev-haskell/wai/wai-3.2.3.ebuild
+++ b/dev-haskell/wai/wai-3.2.3.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-haskell/http-types-0.7:=[profile?]
 	>=dev-haskell/network-2.2.1.5:=[profile?]

--- a/dev-haskell/warp-tls/warp-tls-3.2.12.ebuild
+++ b/dev-haskell/warp-tls/warp-tls-3.2.12.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-haskell/cryptonite-0.12:=[profile?]

--- a/dev-haskell/warp/warp-3.3.21.ebuild
+++ b/dev-haskell/warp/warp-3.3.21.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="+allow-sendfilefd debug +x509"
 
 RDEPEND=">=dev-haskell/auto-update-0.1.3:=[profile?] <dev-haskell/auto-update-0.2:=[profile?]

--- a/dev-haskell/wcwidth/wcwidth-0.0.2.ebuild
+++ b/dev-haskell/wcwidth/wcwidth-0.0.2.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="cli"
 
 RDEPEND=">=dev-lang/ghc-7.4.1:=

--- a/dev-haskell/witherable/witherable-0.4.2-r1.ebuild
+++ b/dev-haskell/witherable/witherable-0.4.2-r1.ebuild
@@ -15,7 +15,7 @@ HOMEPAGE="https://github.com/fumieval/witherable"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND="
 	>=dev-haskell/base-orphans-0.8.4:=[profile?] <dev-haskell/base-orphans-0.10:=[profile?]

--- a/dev-haskell/wl-pprint-annotated/wl-pprint-annotated-0.1.0.1-r2.ebuild
+++ b/dev-haskell/wl-pprint-annotated/wl-pprint-annotated-0.1.0.1-r2.ebuild
@@ -15,7 +15,7 @@ HOMEPAGE="https://github.com/minad/wl-pprint-annotated#readme"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND="
 	>=dev-haskell/text-0.11:=[profile?] <dev-haskell/text-2.1

--- a/dev-haskell/word8/word8-0.1.3.ebuild
+++ b/dev-haskell/word8/word8-0.1.3.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-lang/ghc-7.4.1:=

--- a/dev-haskell/x11-xft/x11-xft-0.3.4.ebuild
+++ b/dev-haskell/x11-xft/x11-xft-0.3.4.ebuild
@@ -15,7 +15,7 @@ HOMEPAGE="https://hackage.haskell.org/package/X11-xft"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-haskell/utf8-string-0.1:=[profile?]
 	>=dev-haskell/x11-1.2.1:=[xinerama,profile?]

--- a/dev-haskell/x11/x11-1.10.2.ebuild
+++ b/dev-haskell/x11/x11-1.10.2.ebuild
@@ -15,7 +15,7 @@ HOMEPAGE="https://github.com/xmonad/X11"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
 IUSE="+xinerama"
 
 # add +xinerama to IUSE and RDEPEND on libXScrnSaver and libXinerama below

--- a/dev-haskell/x509-store/x509-store-1.6.7.ebuild
+++ b/dev-haskell/x509-store/x509-store-1.6.7.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-haskell/asn1-encoding-0.9:=[profile?] <dev-haskell/asn1-encoding-0.10:=[profile?]

--- a/dev-haskell/x509-system/x509-system-1.6.6.ebuild
+++ b/dev-haskell/x509-system/x509-system-1.6.6.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND="dev-haskell/mtl:=[profile?]

--- a/dev-haskell/x509-validation/x509-validation-1.6.11.ebuild
+++ b/dev-haskell/x509-validation/x509-validation-1.6.11.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-haskell/asn1-encoding-0.9:=[profile?] <dev-haskell/asn1-encoding-0.10:=[profile?]

--- a/dev-haskell/x509/x509-1.7.5.ebuild
+++ b/dev-haskell/x509/x509-1.7.5.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-haskell/asn1-encoding-0.9:=[profile?] <dev-haskell/asn1-encoding-0.10:=[profile?]

--- a/dev-haskell/xml-conduit/xml-conduit-1.9.1.1.ebuild
+++ b/dev-haskell/xml-conduit/xml-conduit-1.9.1.1.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-haskell/attoparsec-0.10:=[profile?]
 	>=dev-haskell/blaze-html-0.5:=[profile?]

--- a/dev-haskell/xml-hamlet/xml-hamlet-0.5.0.1.ebuild
+++ b/dev-haskell/xml-hamlet/xml-hamlet-0.5.0.1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND=">=dev-haskell/parsec-2.0:=[profile?] <dev-haskell/parsec-3.2:=[profile?]

--- a/dev-haskell/xml-types/xml-types-0.3.8.ebuild
+++ b/dev-haskell/xml-types/xml-types-0.3.8.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND="dev-haskell/text:=[profile?]

--- a/dev-haskell/xml/xml-1.3.14.ebuild
+++ b/dev-haskell/xml/xml-1.3.14.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND="dev-haskell/text:=[profile?]

--- a/dev-haskell/xss-sanitize/xss-sanitize-0.3.6.ebuild
+++ b/dev-haskell/xss-sanitize/xss-sanitize-0.3.6.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD-2"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-haskell/attoparsec-0.10.0.3:=[profile?] <dev-haskell/attoparsec-1:=[profile?]
 	>=dev-haskell/css-text-0.1.1:=[profile?] <dev-haskell/css-text-0.2:=[profile?]

--- a/dev-haskell/yaml/yaml-0.11.8.0.ebuild
+++ b/dev-haskell/yaml/yaml-0.11.8.0.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="examples executable"
 
 RDEPEND=">=dev-haskell/aeson-0.11:=[profile?]

--- a/dev-haskell/yesod-core/yesod-core-1.6.23.1.ebuild
+++ b/dev-haskell/yesod-core/yesod-core-1.6.23.1.ebuild
@@ -13,7 +13,7 @@ HOMEPAGE="https://www.yesodweb.com/"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RESTRICT=test # requires network access
 

--- a/dev-haskell/yesod-form/yesod-form-1.7.0.ebuild
+++ b/dev-haskell/yesod-form/yesod-form-1.7.0.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="+network-uri"
 
 RDEPEND="dev-haskell/aeson:=[profile?]

--- a/dev-haskell/yesod-persistent/yesod-persistent-1.6.0.8.ebuild
+++ b/dev-haskell/yesod-persistent/yesod-persistent-1.6.0.8.ebuild
@@ -13,7 +13,7 @@ HOMEPAGE="https://www.yesodweb.com/"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND="dev-haskell/blaze-builder:=[profile?]
 	dev-haskell/conduit:=[profile?]

--- a/dev-haskell/yesod-static/yesod-static-1.6.1.0.ebuild
+++ b/dev-haskell/yesod-static/yesod-static-1.6.1.0.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND="dev-haskell/async:=[profile?]

--- a/dev-haskell/yesod-test/yesod-test-1.6.12.ebuild
+++ b/dev-haskell/yesod-test/yesod-test-1.6.12.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE=""
 
 RDEPEND="dev-haskell/aeson:=[profile?]

--- a/dev-haskell/yesod/yesod-1.6.2.ebuild
+++ b/dev-haskell/yesod/yesod-1.6.2.ebuild
@@ -13,7 +13,7 @@ HOMEPAGE="https://www.yesodweb.com/"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND="dev-haskell/aeson:=[profile?]
 	>=dev-haskell/conduit-1.3:=[profile?]

--- a/dev-haskell/zip-archive/zip-archive-0.4.1.ebuild
+++ b/dev-haskell/zip-archive/zip-archive-0.4.1.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="executable"
 
 RDEPEND=">=dev-haskell/digest-0.0.0.1:=[profile?]

--- a/dev-haskell/zlib/zlib-0.6.2.3.ebuild
+++ b/dev-haskell/zlib/zlib-0.6.2.3.ebuild
@@ -16,7 +16,7 @@ HOMEPAGE="https://hackage.haskell.org/package/zlib"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86 ~ppc-macos"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86 ~ppc-macos"
 IUSE="bundled-c-zlib non-blocking-ffi"
 
 RDEPEND=">=dev-lang/ghc-8.4.3:=

--- a/dev-lang/ghc/ghc-9.0.2-r4.ebuild
+++ b/dev-lang/ghc/ghc-9.0.2-r4.ebuild
@@ -121,7 +121,7 @@ BUMP_LIBRARIES=(
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="big-endian doc elfutils ghcbootstrap ghcmakebinary +gmp llvm numa profile test unregisterised"
 IUSE+=" binary"
 RESTRICT="!test? ( test )"

--- a/dev-lang/whitespace/whitespace-0.4.ebuild
+++ b/dev-lang/whitespace/whitespace-0.4.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 ~x86"
+KEYWORDS="~amd64 ~x86"
 IUSE=""
 
 RDEPEND="dev-haskell/random:=

--- a/dev-util/shelltestrunner/shelltestrunner-1.9.ebuild
+++ b/dev-util/shelltestrunner/shelltestrunner-1.9.ebuild
@@ -12,7 +12,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="test"
 RESTRICT="!test? ( test )"
 

--- a/dev-vcs/darcs/darcs-2.16.5-r5.ebuild
+++ b/dev-vcs/darcs/darcs-2.16.5-r5.ebuild
@@ -14,7 +14,7 @@ HOMEPAGE="http://darcs.net/"
 
 LICENSE="GPL-2+"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="curl +terminfo +threaded"
 
 CABAL_CHDEPS=(

--- a/dev-vcs/git-annex/git-annex-10.20220624.ebuild
+++ b/dev-vcs/git-annex/git-annex-10.20220624.ebuild
@@ -14,7 +14,7 @@ HOMEPAGE="https://git-annex.branchable.com/"
 
 LICENSE="AGPL-3"
 SLOT="0"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86 ~amd64-linux"
 IUSE="+assistant +benchmark +dbus debug doc +gitlfs +magicmime +pairing +torrentparser +webapp"
 
 REQUIRED_USE="webapp? ( assistant )"

--- a/dev-vcs/git-repair/git-repair-1.20220404.ebuild
+++ b/dev-vcs/git-repair/git-repair-1.20220404.ebuild
@@ -13,7 +13,7 @@ HOMEPAGE="https://git-repair.branchable.com/"
 
 LICENSE="AGPL-3"
 SLOT="0"
-KEYWORDS="amd64 ~x86"
+KEYWORDS="~amd64 ~x86"
 
 GHC_BOOTSTRAP_PACKAGES=(
 	async

--- a/dev-vcs/git-repair/git-repair-1.20230814.ebuild
+++ b/dev-vcs/git-repair/git-repair-1.20230814.ebuild
@@ -13,7 +13,7 @@ HOMEPAGE="https://git-repair.branchable.com/"
 
 LICENSE="AGPL-3"
 SLOT="0"
-KEYWORDS="amd64 ~x86"
+KEYWORDS="~amd64 ~x86"
 
 GHC_BOOTSTRAP_PACKAGES=(
 	async

--- a/net-mail/list-remote-forwards/list-remote-forwards-0.0.3.ebuild
+++ b/net-mail/list-remote-forwards/list-remote-forwards-0.0.3.ebuild
@@ -14,7 +14,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="AGPL-3"
 SLOT="0"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 # dev-haskell/dns and dev-haskell/resolv conflict
 # https://github.com/sol/doctest/issues/119

--- a/net-mail/mailbox-count/mailbox-count-0.0.6.ebuild
+++ b/net-mail/mailbox-count/mailbox-count-0.0.6.ebuild
@@ -12,7 +12,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="AGPL-3"
 SLOT="0"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND="
 	>=dev-haskell/cmdargs-0.10

--- a/net-misc/haeredes/haeredes-0.5.4.ebuild
+++ b/net-misc/haeredes/haeredes-0.5.4.ebuild
@@ -12,7 +12,7 @@ SRC_URI="https://michael.orlitzky.com/code/releases/${P}.tar.gz"
 
 LICENSE="AGPL-3+"
 SLOT="0"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 # The test suite requires network access.
 RESTRICT="test"

--- a/net-misc/hath/hath-0.5.8.ebuild
+++ b/net-misc/hath/hath-0.5.8.ebuild
@@ -12,7 +12,7 @@ SRC_URI="https://michael.orlitzky.com/code/releases/${P}.tar.gz"
 
 LICENSE="AGPL-3+"
 SLOT="0"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 
 RDEPEND=">=dev-haskell/cmdargs-0.10:=
 	>=dev-haskell/split-0.2:=

--- a/x11-misc/xmobar/xmobar-0.44.1.ebuild
+++ b/x11-misc/xmobar/xmobar-0.44.1.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="alsa dbus mpd mpris +rtsopts timezone uvmeter +weather wifi xft xpm"
 
 RDEPEND=">=dev-haskell/aeson-1.4.7.1:=[profile?]

--- a/x11-wm/xmonad-contrib/xmonad-contrib-0.17.0.ebuild
+++ b/x11-wm/xmonad-contrib/xmonad-contrib-0.17.0.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="+xft"
 
 RDEPEND=">=dev-haskell/mtl-1:=[profile?] <dev-haskell/mtl-3:=[profile?]

--- a/x11-wm/xmonad/xmonad-0.17.0.ebuild
+++ b/x11-wm/xmonad/xmonad-0.17.0.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ~arm64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="no-autorepeat-keys"
 
 RDEPEND="dev-haskell/data-default-class:=[profile?]


### PR DESCRIPTION
Haskell is very difficult to package, and stabilizations have not happened in nearly a year. Let's acknowledge reality and drop old stable keywords.