### PR TITLE
app-emulation/qemu: also allow python[ensurepip]

### DIFF
--- a/app-emulation/qemu/qemu-8.1.5.ebuild
+++ b/app-emulation/qemu/qemu-8.1.5.ebuild
@@ -276,7 +276,7 @@ BDEPEND="
 	dev-lang/perl
 	>=dev-build/meson-0.63.0
 	app-alternatives/ninja
-	dev-python/pip[${PYTHON_USEDEP}]
+	|| ( dev-python/pip[${PYTHON_USEDEP}] dev-lang/python[ensurepip(-)] )
 	virtual/pkgconfig
 	doc? (
 		>=dev-python/sphinx-1.6.0[${PYTHON_USEDEP}]

--- a/app-emulation/qemu/qemu-8.2.3.ebuild
+++ b/app-emulation/qemu/qemu-8.2.3.ebuild
@@ -281,7 +281,7 @@ BDEPEND="
 	dev-lang/perl
 	>=dev-build/meson-0.63.0
 	app-alternatives/ninja
-	dev-python/pip[${PYTHON_USEDEP}]
+	|| ( dev-python/pip[${PYTHON_USEDEP}] dev-lang/python[ensurepip(-)] )
 	virtual/pkgconfig
 	doc? (
 		>=dev-python/sphinx-1.6.0[${PYTHON_USEDEP}]

--- a/app-emulation/qemu/qemu-8.2.5-r1.ebuild
+++ b/app-emulation/qemu/qemu-8.2.5-r1.ebuild
@@ -281,7 +281,7 @@ BDEPEND="
 	dev-lang/perl
 	>=dev-build/meson-0.63.0
 	app-alternatives/ninja
-	dev-python/pip[${PYTHON_USEDEP}]
+	|| ( dev-python/pip[${PYTHON_USEDEP}] dev-lang/python[ensurepip(-)] )
 	virtual/pkgconfig
 	doc? (
 		>=dev-python/sphinx-1.6.0[${PYTHON_USEDEP}]

--- a/app-emulation/qemu/qemu-8.2.6-r1.ebuild
+++ b/app-emulation/qemu/qemu-8.2.6-r1.ebuild
@@ -281,7 +281,7 @@ BDEPEND="
 	dev-lang/perl
 	>=dev-build/meson-0.63.0
 	app-alternatives/ninja
-	dev-python/pip[${PYTHON_USEDEP}]
+	|| ( dev-python/pip[${PYTHON_USEDEP}] dev-lang/python[ensurepip(-)] )
 	virtual/pkgconfig
 	doc? (
 		>=dev-python/sphinx-1.6.0[${PYTHON_USEDEP}]

--- a/app-emulation/qemu/qemu-9.0.1-r1.ebuild
+++ b/app-emulation/qemu/qemu-9.0.1-r1.ebuild
@@ -281,7 +281,7 @@ BDEPEND="
 	dev-lang/perl
 	>=dev-build/meson-0.63.0
 	app-alternatives/ninja
-	dev-python/pip[${PYTHON_USEDEP}]
+	|| ( dev-python/pip[${PYTHON_USEDEP}] dev-lang/python[ensurepip(-)] )
 	virtual/pkgconfig
 	doc? (
 		>=dev-python/sphinx-1.6.0[${PYTHON_USEDEP}]

--- a/app-emulation/qemu/qemu-9.0.2-r1.ebuild
+++ b/app-emulation/qemu/qemu-9.0.2-r1.ebuild
@@ -281,7 +281,7 @@ BDEPEND="
 	dev-lang/perl
 	>=dev-build/meson-0.63.0
 	app-alternatives/ninja
-	dev-python/pip[${PYTHON_USEDEP}]
+	|| ( dev-python/pip[${PYTHON_USEDEP}] dev-lang/python[ensurepip(-)] )
 	virtual/pkgconfig
 	doc? (
 		>=dev-python/sphinx-1.6.0[${PYTHON_USEDEP}]

--- a/app-emulation/qemu/qemu-9999.ebuild
+++ b/app-emulation/qemu/qemu-9999.ebuild
@@ -280,7 +280,7 @@ BDEPEND="
 	dev-lang/perl
 	>=dev-build/meson-0.63.0
 	app-alternatives/ninja
-	dev-python/pip[${PYTHON_USEDEP}]
+	|| ( dev-python/pip[${PYTHON_USEDEP}] dev-lang/python[ensurepip(-)] )
 	virtual/pkgconfig
 	doc? (
 		>=dev-python/sphinx-1.6.0[${PYTHON_USEDEP}]


### PR DESCRIPTION
according to [upstream comment][0] python[ensurepip] should also work as a fallback if pip is missing. tested and confirmed to build fine with qemu-9.0.2.

[0]: https://gitlab.com/qemu-project/qemu/-/commit/81e2b198a8c
Bug: https://bugs.gentoo.org/913084

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
