### PR TITLE
app-misc/openrgb-9999: Fix dodoc

### DIFF
--- a/app-misc/openrgb/openrgb-9999.ebuild
+++ b/app-misc/openrgb/openrgb-9999.ebuild
@@ -81,7 +81,7 @@ src_configure() {
 src_install() {
 	emake INSTALL_ROOT="${ED}" install
 
-	dodoc README.md OpenRGB.patch
+	dodoc README.md
 
 	rm -r "${ED}"/usr/lib/udev/ || die
 	udev_dorules 60-openrgb.rules


### PR DESCRIPTION
OpenRGB.patch [has been removed](https://gitlab.com/CalcProgrammer1/OpenRGB/-/commit/243ce886e1c23aa5dd144267167b8e1fc13b413d)

---

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.