### PR TITLE
media-video/obs-studio: add py3.13 support drop 3.9

### DIFF
--- a/media-video/obs-studio/obs-studio-30.2.3.ebuild
+++ b/media-video/obs-studio/obs-studio-30.2.3.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 CMAKE_REMOVE_MODULES_LIST=( FindFreetype )
 LUA_COMPAT=( luajit )
-PYTHON_COMPAT=( python3_{9..12} )
+PYTHON_COMPAT=( python3_{9..13} )
 
 inherit cmake flag-o-matic lua-single optfeature python-single-r1 xdg
 

--- a/media-video/obs-studio/obs-studio-30.2.3.ebuild
+++ b/media-video/obs-studio/obs-studio-30.2.3.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 CMAKE_REMOVE_MODULES_LIST=( FindFreetype )
 LUA_COMPAT=( luajit )
-PYTHON_COMPAT=( python3_{9..13} )
+PYTHON_COMPAT=( python3_{10..13} )
 
 inherit cmake flag-o-matic lua-single optfeature python-single-r1 xdg
 


### PR DESCRIPTION
Tested on my machine with no issue at runtime or compile

```
>>> Test phase: media-video/obs-studio-30.2.3
 * Source directory (CMAKE_USE_DIR): "/var/tmp/portage/media-video/obs-studio-30.2.3/work/obs-studio-30.2.3"
 * Build directory  (BUILD_DIR):     "/var/tmp/portage/media-video/obs-studio-30.2.3/work/obs-studio-30.2.3_build"
ctest -j 32 --test-load 32
Test project /var/tmp/portage/media-video/obs-studio-30.2.3/work/obs-studio-30.2.3_build
    Start 1: test_serializer
    Start 2: test_darray
    Start 3: test_bitstream
    Start 4: test_os_path
1/4 Test #1: test_serializer ..................   Passed    0.03 sec
2/4 Test #3: test_bitstream ...................   Passed    0.02 sec
3/4 Test #2: test_darray ......................   Passed    0.02 sec
4/4 Test #4: test_os_path .....................   Passed    0.02 sec

100% tests passed, 0 tests failed out of 4

Total Test time (real) =   0.03 sec
 * Tests succeeded.
>>> Completed testing media-video/obs-studio-30.2.3
```

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
