### PR TITLE
java-pkg-2.eclass: remove unused eclass functions java-pkg-2_src_{compile,test} | java-utils-2.eclass: remove java-pkg_check-jikes | java-utils-2.eclass: stop mentioning java-ant-2 eclass

### DIFF
--- a/eclass/java-pkg-2.eclass
+++ b/eclass/java-pkg-2.eclass
@@ -59,96 +59,6 @@ java-pkg-2_src_prepare() {
 	java-utils-2_src_prepare
 }
 
-
-# @FUNCTION: java-pkg-2_src_compile
-# @DEPRECATED: none
-# @DESCRIPTION:
-# Default src_compile for java packages
-#
-# @CODE
-# Variables:
-#   EANT_BUILD_XML - controls the location of the build.xml (default: ./build.xml)
-#   EANT_FILTER_COMPILER - Calls java-pkg_filter-compiler with the value
-#   EANT_BUILD_TARGET - the ant target/targets to execute (default: jar)
-#   EANT_DOC_TARGET - the target to build extra docs under the doc use flag
-#                     (default: javadoc; declare empty to disable completely)
-#   EANT_GENTOO_CLASSPATH - @see eant documentation in java-utils-2.eclass
-#   EANT_EXTRA_ARGS - extra arguments to pass to eant
-#   EANT_ANT_TASKS - modifies the ANT_TASKS variable in the eant environment
-# @CODE
-java-pkg-2_src_compile() {
-	if [[ -e "${EANT_BUILD_XML:=build.xml}" ]]; then
-		# auto generate classpath
-		java-pkg_gen-cp EANT_GENTOO_CLASSPATH
-
-		[[ "${EANT_FILTER_COMPILER}" ]] && \
-			java-pkg_filter-compiler ${EANT_FILTER_COMPILER}
-		local antflags="${EANT_BUILD_TARGET:=jar}"
-		if has doc ${IUSE} && [[ -n "${EANT_DOC_TARGET=javadoc}" ]]; then
-			antflags="${antflags} $(use_doc ${EANT_DOC_TARGET})"
-		fi
-		local tasks
-		[[ ${EANT_ANT_TASKS} ]] && tasks="${ANT_TASKS} ${EANT_ANT_TASKS}"
-		ANT_TASKS="${tasks:-${ANT_TASKS}}" \
-			eant ${antflags} -f "${EANT_BUILD_XML}" ${EANT_EXTRA_ARGS} "${@}"
-	else
-		echo "${FUNCNAME}: ${EANT_BUILD_XML} not found so nothing to do."
-	fi
-}
-
-# @FUNCTION: java-pkg-2_src_test
-# @DEPRECATED: none
-# @DESCRIPTION:
-# src_test, not exported.
-java-pkg-2_src_test() {
-	[[ -e "${EANT_BUILD_XML:=build.xml}" ]] || return
-
-	if [[ ${EANT_TEST_TARGET} ]] || < "${EANT_BUILD_XML}" tr -d "\n" | grep -Eq "<target\b[^>]*\bname=[\"']test[\"']"; then
-		local opts task_re junit_re pkg
-
-		if [[ ${EANT_TEST_JUNIT_INTO} ]]; then
-			java-pkg_jar-from --into "${EANT_TEST_JUNIT_INTO}" junit
-		fi
-
-		if [[ ${EANT_TEST_GENTOO_CLASSPATH} ]]; then
-			EANT_GENTOO_CLASSPATH="${EANT_TEST_GENTOO_CLASSPATH}"
-		fi
-
-		ANT_TASKS=${EANT_TEST_ANT_TASKS:-${ANT_TASKS:-${EANT_ANT_TASKS}}}
-
-		task_re="\bdev-java/ant-junit(4)?(-[^:]+)?(:\S+)\b"
-		junit_re="\bdev-java/junit(-[^:]+)?(:\S+)\b"
-
-		if [[ ${DEPEND} =~ ${task_re} ]]; then
-			pkg="ant-junit${BASH_REMATCH[1]}${BASH_REMATCH[3]}"
-			pkg="${pkg%:0}"
-
-			if [[ ${ANT_TASKS} && "${ANT_TASKS}" != none ]]; then
-				ANT_TASKS="${ANT_TASKS} ${pkg}"
-			else
-				ANT_TASKS="${pkg}"
-			fi
-		elif [[ ${DEPEND} =~ ${junit_re} ]]; then
-			pkg="junit${BASH_REMATCH[2]}"
-			pkg="${pkg%:0}"
-
-			opts="-Djunit.jar=\"$(java-pkg_getjar ${pkg} junit.jar)\""
-
-			if [[ ${EANT_GENTOO_CLASSPATH} ]]; then
-				EANT_GENTOO_CLASSPATH+=",${pkg}"
-			else
-				EANT_GENTOO_CLASSPATH="${pkg}"
-			fi
-		fi
-
-		eant ${opts} -f "${EANT_BUILD_XML}" \
-			${EANT_EXTRA_ARGS} ${EANT_TEST_EXTRA_ARGS} ${EANT_TEST_TARGET:-test}
-
-	else
-		echo "${FUNCNAME}: No test target in ${EANT_BUILD_XML}"
-	fi
-}
-
 # @FUNCTION: java-pkg-2_pkg_preinst
 # @DESCRIPTION:
 # wrapper for java-utils-2_pkg_preinst
@@ -158,4 +68,4 @@ java-pkg-2_pkg_preinst() {
 
 fi
 
-EXPORT_FUNCTIONS pkg_setup src_prepare src_compile pkg_preinst
+EXPORT_FUNCTIONS pkg_setup src_prepare pkg_preinst

--- a/eclass/java-utils-2.eclass
+++ b/eclass/java-utils-2.eclass
@@ -204,9 +204,9 @@ JAVA_PKG_COMPILERS_CONF=${JAVA_PKG_COMPILERS_CONF:="/etc/java-config-2/build/com
 #
 # Useful for local testing.
 #
-# Use jikes and javac, in that order
+# Use <other compiler> and javac, in that order
 # @CODE
-#	JAVA_PKG_FORCE_COMPILER="jikes javac"
+#	JAVA_PKG_FORCE_COMPILER="<other compiler> javac"
 # @CODE
 
 # @ECLASS_VARIABLE: JAVA_PKG_FORCE_ANT_TASKS
@@ -2307,9 +2307,6 @@ java-pkg_init() {
 
 	# TODO we will probably want to set JAVAC and JAVACFLAGS
 
-	# Do some QA checks
-	java-pkg_check-jikes
-
 	# Can't use unset here because Portage does not save the unset
 	# see https://bugs.gentoo.org/show_bug.cgi?id=189417#c11
 
@@ -2964,12 +2961,6 @@ java-pkg_check-versioned-jar() {
 
 	if [[ ${jar} =~ ${PV} ]]; then
 		java-pkg_announce-qa-violation "installing versioned jar '${jar}'"
-	fi
-}
-
-java-pkg_check-jikes() {
-	if has jikes ${IUSE}; then
-		java-pkg_announce-qa-violation "deprecated USE flag 'jikes' in IUSE"
 	fi
 }
 

--- a/eclass/java-utils-2.eclass
+++ b/eclass/java-utils-2.eclass
@@ -1648,6 +1648,10 @@ java-pkg_set-current-vm() {
 	export GENTOO_VM=${1}
 }
 
+# @FUNCTION: java-pkg_current-vm-matches
+# @USAGE: <vm_string1> [<vm_string2> [<vm_string3>...]]
+# @RETURN: 0: the current vm matches any of the provided strings
+# @RETURN: 1: the current vm does not match any of the provided strings
 java-pkg_current-vm-matches() {
 	has $(java-pkg_get-current-vm) ${@}
 	return $?
@@ -2321,7 +2325,7 @@ java-pkg_init() {
 	export ANT_RESPECT_JAVA_HOME=
 }
 
-# @FUNCTION: java-pkg-init-compiler_
+# @FUNCTION: java-pkg_init-compiler_
 # @INTERNAL
 # @DESCRIPTION:
 # This function attempts to figure out what compiler should be used. It does
@@ -2342,9 +2346,7 @@ java-pkg_init() {
 # If the user doesn't defined anything in JAVA_PKG_COMPILERS_CONF, or no
 # suitable compiler was found there, then the default is to use javac provided
 # by the current VM.
-#
-#
-# @RETURN name of the compiler to use
+# @RETURN: name of the compiler to use
 java-pkg_init-compiler_() {
 	debug-print-function ${FUNCNAME} $*
 
@@ -2946,6 +2948,12 @@ java-pkg_ensure-dep() {
 	fi
 }
 
+# @FUNCTION: java-pkg_check-phase
+# @INTERNAL
+# @USAGE: <phase_name>
+# @DESCRIPTION:
+# Checks whether the phase specified in $1 is the current active phase. If not,
+# a helpful QA message is displayed
 java-pkg_check-phase() {
 	local phase=${1}
 	local funcname=${FUNCNAME[1]}
@@ -2955,6 +2963,12 @@ java-pkg_check-phase() {
 	fi
 }
 
+# @FUNCTION: java-pkg_check-versioned-jar
+# @INTERNAL
+# @USAGE: <jar_filename>
+# @DESCRIPTION:
+# Checks whether the jar specified in $1 contains ${PV}. If it does, a helpful
+# QA message is displayed
 java-pkg_check-versioned-jar() {
 	local jar=${1}
 
@@ -2963,6 +2977,12 @@ java-pkg_check-versioned-jar() {
 	fi
 }
 
+# @FUNCTION: java-pkg_announce-qa-violation
+# @INTERNAL
+# @USAGE: [--nodie] <msg>
+# @DESCRIPTION:
+# Prints out the <msg> as a QA message. If ${JAVA_PKG_STRICT} is set, then die
+# is called. This can be overridden by providing --nodie
 java-pkg_announce-qa-violation() {
 	local nodie
 	if [[ ${1} == "--nodie" ]]; then
@@ -2979,6 +2999,10 @@ increment-qa-violations() {
 	export JAVA_PKG_QA_VIOLATIONS
 }
 
+# @FUNCTION: is-java-strict
+# @INTERNAL
+# @RETURN: 0: JAVA_PKG_STRICT is set
+# @RETURN: 1: JAVA_PKG_STRICT is not set
 is-java-strict() {
 	[[ -n ${JAVA_PKG_STRICT} ]]
 	return $?

--- a/eclass/java-utils-2.eclass
+++ b/eclass/java-utils-2.eclass
@@ -9,13 +9,12 @@
 # @SUPPORTED_EAPIS: 6 7 8
 # @BLURB: Base eclass for Java packages
 # @DESCRIPTION:
-# This eclass provides functionality which is used by java-pkg-2.eclass,
-# java-pkg-opt-2.eclass and java-ant-2 eclass, as well as from ebuilds.
+# This eclass provides functionality which is used by java-pkg-2.eclass and
+# java-pkg-opt-2.eclass as well as from ebuilds.
 #
 # This eclass should not be inherited this directly from an ebuild. Instead,
 # you should inherit java-pkg-2 for Java packages or java-pkg-opt-2 for packages
-# that have optional Java support. In addition you can inherit java-ant-2 for
-# Ant-based packages.
+# that have optional Java support.
 
 if [[ -z ${_JAVA_UTILS_2_ECLASS} ]] ; then
 _JAVA_UTILS_2_ECLASS=1
@@ -101,7 +100,7 @@ JAVA_PKG_ALLOW_VM_CHANGE=${JAVA_PKG_ALLOW_VM_CHANGE:="yes"}
 # @DEFAULT_UNSET
 # @DESCRIPTION:
 # Specify a non-standard Java source version for compilation (via javac -source
-# parameter or Ant equivalent via build.xml rewriting done by java-ant-2 eclass).
+# parameter).
 # Normally this is determined from the jdk version specified in DEPEND.
 # See java-pkg_get-source function below.
 #


### PR DESCRIPTION
<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
