### PR TITLE
net-dns/knot-resolver: adding dep on sys-apps/openrc[caps]

### DIFF
--- a/net-dns/knot-resolver/knot-resolver-5.7.2-r1.ebuild
+++ b/net-dns/knot-resolver/knot-resolver-5.7.2-r1.ebuild
@@ -1,0 +1,102 @@
+# Copyright 2022-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+LUA_COMPAT=( luajit )
+
+inherit lua-single meson tmpfiles verify-sig
+
+DESCRIPTION="A scaleable caching DNS resolver"
+HOMEPAGE="https://www.knot-resolver.cz https://gitlab.nic.cz/knot/knot-resolver"
+SRC_URI="
+	https://secure.nic.cz/files/${PN}/${P}.tar.xz
+	verify-sig? ( https://secure.nic.cz/files/${PN}/${P}.tar.xz.asc )
+"
+
+LICENSE="Apache-2.0 BSD CC0-1.0 GPL-3+ LGPL-2.1+ MIT"
+SLOT="0"
+KEYWORDS="~amd64"
+IUSE="caps dnstap jemalloc kresc nghttp2 systemd test"
+RESTRICT="!test? ( test )"
+REQUIRED_USE="${LUA_REQUIRED_USE}"
+
+RDEPEND="
+	${LUA_DEPS}
+	acct-group/knot-resolver
+	acct-user/knot-resolver
+	dev-db/lmdb:=
+	dev-libs/libuv:=
+	net-dns/knot:=
+	net-libs/gnutls:=
+	caps? ( sys-libs/libcap-ng )
+	dnstap? (
+		dev-libs/fstrm
+		dev-libs/protobuf-c:=
+	)
+	jemalloc? ( dev-libs/jemalloc:= )
+	kresc? ( dev-libs/libedit )
+	nghttp2? ( net-libs/nghttp2:= )
+	systemd? ( sys-apps/systemd:= )
+	!sys-apps/openrc[-caps]
+"
+DEPEND="
+	${RDEPEND}
+	test? (
+		dev-util/cmocka
+	)
+"
+BDEPEND="
+	virtual/pkgconfig
+	verify-sig? ( >=sec-keys/openpgp-keys-knot-resolver-20240304 )
+"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-5.5.3-docdir.patch
+	"${FILESDIR}"/${PN}-5.5.3-nghttp-openssl.patch
+
+	# Bug #921567
+	"${FILESDIR}"/${PN}-5.7.0-r2-tmpfiles.patch
+)
+
+VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/openpgp-keys/${PN}.gpg
+
+src_unpack() {
+	if use verify-sig; then
+		verify-sig_verify_detached "${DISTDIR}"/${P}.tar.xz{,.asc}
+	fi
+
+	unpack ${P}.tar.xz
+}
+
+src_configure() {
+	local emesonargs=(
+		--localstatedir "${EPREFIX}"/var # double lib
+		# https://bugs.gentoo.org/870019
+		-Dauto_features=disabled
+		-Ddoc=disabled
+		-Ddocdir="${EPREFIX}"/usr/share/doc/${PF}
+		-Dopenssl=disabled
+		-Dmalloc=$(usex jemalloc jemalloc disabled)
+		$(meson_feature caps capng)
+		$(meson_feature dnstap)
+		$(meson_feature kresc client)
+		$(meson_feature nghttp2)
+		$(meson_feature test unit_tests)
+		$(meson_feature systemd systemd_files)
+	)
+
+	meson_src_configure
+}
+
+src_install() {
+	meson_src_install
+	fowners -R ${PN}: /etc/${PN}
+
+	newinitd "${FILESDIR}"/kresd.initd-r1 kresd
+	newconfd "${FILESDIR}"/kresd.confd-r1 kresd
+}
+
+pkg_postinst() {
+	tmpfiles_process knot-resolver.conf
+}


### PR DESCRIPTION
The init file needs it, so it’s only there if not on systemd

Closes: https://bugs.gentoo.org/939471

It doesn’t seem that there is a test for being on openrc rather than not on systemd, so I hope that it won’t break for people using other init.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
