### PR TITLE
dev-util/codeblocks: 20.03_p13518 add KEYWORDS="~amd64 ~x86"

### DIFF
--- a/dev-util/codeblocks/codeblocks-20.03-r6.ebuild
+++ b/dev-util/codeblocks/codeblocks-20.03-r6.ebuild
@@ -8,7 +8,7 @@ WX_GTK_VER="3.0-gtk3"
 inherit autotools flag-o-matic wxwidgets xdg
 
 DESCRIPTION="The open source, cross platform, free C, C++ and Fortran IDE"
-HOMEPAGE="https://codeblocks.org/"
+HOMEPAGE="https://www.codeblocks.org/"
 SRC_URI="https://downloads.sourceforge.net/${PN}/${P}.tar.xz
 	https://dev.gentoo.org/~leio/distfiles/${P}-fortran.tar.xz
 	https://dev.gentoo.org/~leio/distfiles/${P}-fortran-update-v1.7.tar.xz

--- a/dev-util/codeblocks/codeblocks-20.03-r7.ebuild
+++ b/dev-util/codeblocks/codeblocks-20.03-r7.ebuild
@@ -8,7 +8,7 @@ WX_GTK_VER="3.0-gtk3"
 inherit autotools flag-o-matic multiprocessing wxwidgets xdg
 
 DESCRIPTION="The open source, cross platform, free C, C++ and Fortran IDE"
-HOMEPAGE="https://codeblocks.org/"
+HOMEPAGE="https://www.codeblocks.org/"
 SRC_URI="https://downloads.sourceforge.net/${PN}/${P}.tar.xz
 	https://dev.gentoo.org/~leio/distfiles/${P}-fortran.tar.xz
 	https://dev.gentoo.org/~leio/distfiles/${P}-fortran-update-v1.7.tar.xz

--- a/dev-util/codeblocks/codeblocks-20.03_p13518.ebuild
+++ b/dev-util/codeblocks/codeblocks-20.03_p13518.ebuild
@@ -27,6 +27,7 @@ SRC_URI="
 
 LICENSE="GPL-3"
 SLOT="0"
+KEYWORDS="~amd64"
 
 IUSE="fortran contrib debug"
 

--- a/dev-util/codeblocks/codeblocks-20.03_p13518.ebuild
+++ b/dev-util/codeblocks/codeblocks-20.03_p13518.ebuild
@@ -27,7 +27,7 @@ SRC_URI="
 
 LICENSE="GPL-3"
 SLOT="0"
-KEYWORDS="~amd64"
+KEYWORDS="~amd64 ~x86"
 
 IUSE="fortran contrib debug"
 

--- a/dev-util/codeblocks/codeblocks-20.03_p13518.ebuild
+++ b/dev-util/codeblocks/codeblocks-20.03_p13518.ebuild
@@ -13,7 +13,7 @@ FP_NAME=fortranproject
 FP_REV=378
 
 DESCRIPTION="The open source, cross platform, free C, C++ and Fortran IDE"
-HOMEPAGE="https://codeblocks.org/"
+HOMEPAGE="https://www.codeblocks.org/"
 
 # svn export --ignore-externals https://svn.code.sf.net/p/codeblocks/code/trunk@${REV} codeblocks-20.03_p${REV}
 # tar -cjf codeblocks-20.03_p${REV}.tar.bz2 codeblocks-20.03_p${REV}

--- a/dev-util/codeblocks/codeblocks-9999.ebuild
+++ b/dev-util/codeblocks/codeblocks-9999.ebuild
@@ -8,7 +8,7 @@ WX_GTK_VER="3.2-gtk3"
 inherit autotools flag-o-matic multiprocessing subversion wxwidgets xdg
 
 DESCRIPTION="The open source, cross platform, free C, C++ and Fortran IDE"
-HOMEPAGE="https://codeblocks.org/"
+HOMEPAGE="https://www.codeblocks.org/"
 LICENSE="GPL-3"
 SLOT="0"
 ESVN_REPO_URI="svn://svn.code.sf.net/p/${PN}/code/trunk"


### PR DESCRIPTION
<!-- Please put the pull request description above -->

Add KEYWORDS="~amd64 ~x86" for `dev-util/codeblocks-20.03_p13518` that depends on `wxGTK:3.2-gtk3`.

Closes: https://bugs.gentoo.org/939114

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
