### PR TITLE
dev-debug/scap-driver: fix test code for HAS_CLASS_CREATE_1

### DIFF
--- a/dev-debug/scap-driver/files/0.17.3-fix-kmod-build-on-6.4+.patch
+++ b/dev-debug/scap-driver/files/0.17.3-fix-kmod-build-on-6.4+.patch
@@ -1,0 +1,12 @@
+diff --git a/driver/configure/CLASS_CREATE_1/test.c b/driver/configure/CLASS_CREATE_1/test.c
+index 675113b..72c5406 100644
+--- a/driver/configure/CLASS_CREATE_1/test.c
++++ b/driver/configure/CLASS_CREATE_1/test.c
+@@ -21,6 +21,7 @@ MODULE_AUTHOR("the Falco authors");
+ static int class_create_test_init(void)
+ {
+ 	struct class *g_ppm_class = class_create("test");
++	(void)g_ppm_class;
+ 	return 0;
+ }
+ 

--- a/dev-debug/scap-driver/scap-driver-0.17.3-r1.ebuild
+++ b/dev-debug/scap-driver/scap-driver-0.17.3-r1.ebuild
@@ -22,6 +22,10 @@ CONFIG_CHECK="HAVE_SYSCALL_TRACEPOINTS ~TRACEPOINTS"
 # This version can be found in the corresponding *sysdig* tree in cmake/modules/driver.cmake
 DRIVER_VERSION="7.2.0+driver"
 
+PATCHES=(
+	"${FILESDIR}"/${PV}-fix-kmod-build-on-6.4+.patch
+)
+
 src_configure() {
 	local mycmakeargs=(
 		# we will use linux-mod, so just pretend to use bundled deps


### PR DESCRIPTION
otherwise test will failed because of -Werror=unused-variable, then build will failed w/ kernel 6.4+ because of incorrect parameter of class_create

patch has been submited to upstream, see
https://github.com/falcosecurity/libs/pull/2058

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
