### PR TITLE
x11-libs/libdrm: Add IUSE=doc to control man pages

### DIFF
--- a/x11-libs/libdrm/libdrm-2.4.122-r1.ebuild
+++ b/x11-libs/libdrm/libdrm-2.4.122-r1.ebuild
@@ -26,7 +26,7 @@ done
 
 LICENSE="MIT"
 SLOT="0"
-IUSE="${IUSE_VIDEO_CARDS} test tools udev valgrind"
+IUSE="${IUSE_VIDEO_CARDS} doc test tools udev valgrind"
 RESTRICT="!test? ( test )"
 
 COMMON_DEPEND="
@@ -40,9 +40,10 @@ RDEPEND="${COMMON_DEPEND}
 	)
 	udev? ( virtual/udev )"
 BDEPEND="${PYTHON_DEPS}
-	$(python_gen_any_dep 'dev-python/docutils[${PYTHON_USEDEP}]')"
+	doc? ( $(python_gen_any_dep 'dev-python/docutils[${PYTHON_USEDEP}]') )"
 
 python_check_deps() {
+	use doc || return 0
 	python_has_version "dev-python/docutils[${PYTHON_USEDEP}]"
 }
 
@@ -70,6 +71,7 @@ multilib_src_configure() {
 		# valgrind installs its .pc file to the pkgconfig for the primary arch
 		-Dvalgrind=$(usex valgrind auto disabled)
 		$(meson_native_use_bool tools install-test-programs)
+		$(meson_native_use_feature doc man-pages)
 	)
 
 	if use test || { multilib_is_native_abi && use tools; }; then

--- a/x11-libs/libdrm/libdrm-2.4.123-r1.ebuild
+++ b/x11-libs/libdrm/libdrm-2.4.123-r1.ebuild
@@ -26,7 +26,7 @@ done
 
 LICENSE="MIT"
 SLOT="0"
-IUSE="${IUSE_VIDEO_CARDS} test tools udev valgrind"
+IUSE="${IUSE_VIDEO_CARDS} doc test tools udev valgrind"
 RESTRICT="!test? ( test )"
 
 COMMON_DEPEND="
@@ -40,9 +40,10 @@ RDEPEND="${COMMON_DEPEND}
 	)
 	udev? ( virtual/udev )"
 BDEPEND="${PYTHON_DEPS}
-	$(python_gen_any_dep 'dev-python/docutils[${PYTHON_USEDEP}]')"
+	doc? ( $(python_gen_any_dep 'dev-python/docutils[${PYTHON_USEDEP}]') )"
 
 python_check_deps() {
+	use doc || return 0
 	python_has_version "dev-python/docutils[${PYTHON_USEDEP}]"
 }
 
@@ -70,6 +71,7 @@ multilib_src_configure() {
 		# valgrind installs its .pc file to the pkgconfig for the primary arch
 		-Dvalgrind=$(usex valgrind auto disabled)
 		$(meson_native_use_bool tools install-test-programs)
+		$(meson_native_use_feature doc man-pages)
 	)
 
 	if use test || { multilib_is_native_abi && use tools; }; then

--- a/x11-libs/libdrm/libdrm-9999.ebuild
+++ b/x11-libs/libdrm/libdrm-9999.ebuild
@@ -26,7 +26,7 @@ done
 
 LICENSE="MIT"
 SLOT="0"
-IUSE="${IUSE_VIDEO_CARDS} test tools udev valgrind"
+IUSE="${IUSE_VIDEO_CARDS} doc test tools udev valgrind"
 RESTRICT="!test? ( test )"
 
 COMMON_DEPEND="
@@ -40,9 +40,10 @@ RDEPEND="${COMMON_DEPEND}
 	)
 	udev? ( virtual/udev )"
 BDEPEND="${PYTHON_DEPS}
-	$(python_gen_any_dep 'dev-python/docutils[${PYTHON_USEDEP}]')"
+	doc? ( $(python_gen_any_dep 'dev-python/docutils[${PYTHON_USEDEP}]') )"
 
 python_check_deps() {
+	use doc || return 0
 	python_has_version "dev-python/docutils[${PYTHON_USEDEP}]"
 }
 
@@ -70,6 +71,7 @@ multilib_src_configure() {
 		# valgrind installs its .pc file to the pkgconfig for the primary arch
 		-Dvalgrind=$(usex valgrind auto disabled)
 		$(meson_native_use_bool tools install-test-programs)
+		$(meson_native_use_feature doc man-pages)
 	)
 
 	if use test || { multilib_is_native_abi && use tools; }; then


### PR DESCRIPTION
The man pages are just man3 and man7, so unlikely to be used.

Avoids a circular dependency as well:
```
(x11-libs/libdrm-2.4.122:0/0::gentoo, ebuild scheduled for merge) depends on
 (dev-python/docutils-0.21.2-1:0/0::gentoo, binary scheduled for merge) (buildtime)
  (dev-python/pillow-10.4.0:0/0::gentoo, ebuild scheduled for merge) (runtime)
   (media-libs/libwebp-1.3.2:0/7::gentoo, ebuild scheduled for merge) (buildtime_slot_op)
    (virtual/opengl-7.0-r2:0/0::gentoo, ebuild scheduled for merge) (buildtime)
     (media-libs/mesa-24.1.6:0/0::gentoo, ebuild scheduled for merge) (runtime)
      (x11-libs/libdrm-2.4.122:0/0::gentoo, ebuild scheduled for merge) (buildtime)
```