### PR TITLE
net-proxy/tayga: Avoid maintainer mode due to config.h.in

### DIFF
--- a/net-proxy/tayga/tayga-0.9.2-r4.ebuild
+++ b/net-proxy/tayga/tayga-0.9.2-r4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -24,6 +24,9 @@ src_prepare() {
 	default
 	sed -e '/^CFLAGS/d' \
 		-i configure.ac || die "sed failed"
+	# Workaround for bug #939535:
+	# eautoreconf does not run autoheader with --force
+	rm config.h.in || die "rm config.h.in failed"
 	eautoreconf
 }
 


### PR DESCRIPTION
eautoreconf does not guarantee updating the timestamp of that file, causing make to rebuild it on maintainer mode. Remove it so we get a fresh file.

Closes: https://bugs.gentoo.org/939535

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
