### PR TITLE
autotools.eclass: Run eautoheader with --force

### DIFF
--- a/eclass/autotools.eclass
+++ b/eclass/autotools.eclass
@@ -312,7 +312,13 @@ eautoreconf() {
 	else
 		eautoconf --force
 	fi
-	[[ ${AT_NOEAUTOHEADER} != "yes" ]] && eautoheader
+	if [[ ${AT_NOEAUTOHEADER} != "yes" ]] ; then
+		if [[ ${WANT_AUTOCONF} == "2.1" ]] ; then
+			eautoheader
+		else
+			eautoheader --force
+		fi
+	fi
 	[[ ${AT_NOEAUTOMAKE} != "yes" ]] && FROM_EAUTORECONF="yes" eautomake ${AM_OPTS}
 
 	if [[ ${AT_NOELIBTOOLIZE} != "yes" ]] ; then


### PR DESCRIPTION
To quote Eli [1] (I can't explain it better than this):

  autotools.eclass runs autoheader without options (and in
  particular without --force). This will only remake config.h.in
  if there are actual changes to the content, which in turn means
  that it will be out of date compared to aclocal.m4 (which we very
  much expect to have changes).

  So `make` sees that the header is out of date, and runs autoheader
  yet again, this time updating the timestamp for `make` purposes.

This causes QA warning that "maintainer mode" is detected.

autoheader and autoconf added --force option at the same time [2], so no reason only autoconf has that option in the eclass and not autoheader.

Like, autoconf, a check on WANT_AUTOCONF != 2.1 is added because the feature was added in autoconf 2.52.

[1] https://bugs.gentoo.org/939468#c6
[2] https://git.savannah.gnu.org/gitweb/?p=autoconf.git;a=commitdiff;h=dbf7fc61

Closes: https://bugs.gentoo.org/939468
Closes: https://bugs.gentoo.org/939535

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
