### PR TITLE
games-fps/xonotic: workaround curl regression

### DIFF
--- a/games-fps/xonotic/xonotic-0.8.6-r1.ebuild
+++ b/games-fps/xonotic/xonotic-0.8.6-r1.ebuild
@@ -1,0 +1,107 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit desktop check-reqs toolchain-funcs xdg
+
+DESCRIPTION="Fork of Nexuiz, Deathmatch FPS based on DarkPlaces, an advanced Quake 1 engine"
+HOMEPAGE="https://xonotic.org/"
+SRC_URI="https://dl.xonotic.org/${P}.zip"
+S="${WORKDIR}/${PN^}"
+
+LICENSE="GPL-3+ GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~arm64 ~x86"
+IUSE="X +alsa ode +sdl"
+
+# note: many dependencies are used through dlopen()
+COMMON_UIDEPEND="
+	media-libs/libogg
+	media-libs/libtheora
+	media-libs/libvorbis"
+RDEPEND="
+	dev-libs/d0_blind_id
+	media-libs/libjpeg-turbo:=
+	media-libs/libpng
+	media-libs/freetype:2
+	<net-misc/curl-8.10.0
+	sys-libs/zlib:=
+	X? (
+		${COMMON_UIDEPEND}
+		media-libs/libglvnd[X]
+		x11-libs/libX11
+		x11-libs/libXext
+		x11-libs/libXpm
+		x11-libs/libXxf86vm
+		alsa? ( media-libs/alsa-lib )
+	)
+	ode? ( dev-games/ode:=[double-precision] )
+	sdl? (
+		${COMMON_UIDEPEND}
+		media-libs/libsdl2[joystick,opengl,sound,video]
+	)"
+DEPEND="
+	${RDEPEND}
+	X? ( x11-base/xorg-proto )"
+BDEPEND="app-arch/unzip"
+
+CHECKREQS_DISK_BUILD="1500M"
+CHECKREQS_DISK_USR="1200M"
+
+src_prepare() {
+	default
+
+	sed -e 's|-O3 ||' \
+		-e '/^LDFLAGS_RELEASE/s/$(OPTIM_RELEASE)/$(GENTOO_LDFLAGS)/' \
+		-i source/darkplaces/makefile.inc || die
+}
+
+src_compile() {
+	tc-export CC
+
+	# do not pass in array to keep the makefile.inc's += flags
+	local -x CPUOPTIMIZATIONS=${CFLAGS}
+
+	local emakeargs=(
+		-C source/darkplaces
+		DEFAULT_SNDAPI=$(usex alsa ALSA OSS)
+		DP_FS_BASEDIR="${EPREFIX}"/usr/share/${PN}
+		DP_LINK_ODE=$(usex ode shared no)
+		STRIP=:
+		GENTOO_LDFLAGS="${LDFLAGS}"
+	)
+
+	# split for bug 473352
+	emake "${emakeargs[@]}" sv-release
+	use X && emake "${emakeargs[@]}" cl-release
+	use sdl && emake "${emakeargs[@]}" sdl-release
+}
+
+src_install() {
+	newbin {source/darkplaces/darkplaces,${PN}}-dedicated
+
+	if use X || use sdl; then
+		if use X; then
+			newbin {source/darkplaces/darkplaces,${PN}}-glx
+			domenu misc/logos/${PN}-glx.desktop
+		fi
+		if use sdl; then
+			newbin {source/darkplaces/darkplaces,${PN}}-sdl
+			domenu misc/logos/${PN}.desktop
+		fi
+
+		local size
+		for size in 16 22 24 32 48 128 256 512; do
+			newicon -s ${size} misc/logos/icons_png/${PN}_${size}.png ${PN}.png
+		done
+		newicon -s scalable misc/logos/${PN}_icon.svg ${PN}.svg
+	fi
+
+	dodoc Docs/*.{md,txt}
+
+	insinto /usr/share/${PN}
+	doins -r key_0.d0pk server data
+
+	rm "${ED}"/usr/share/${PN}/server/.gitattributes || die
+}


### PR DESCRIPTION
With curl-8.10.0 xonotic is not able to download maps.

The only change is 
```diff
- net-misc/curl
+ <net-misc/curl-8.10.0
```


Debian detected some curl regressions, see https://qa.debian.org/excuses.php?package=curl 
CC: @Kangie (in case it may be needed to mask the latest curl release or any other action)

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
