### PR TITLE
dev-util/qbs: workaround hangs when running inside sandbox

### DIFF
--- a/dev-util/qbs/files/qbs-2.4.1-ldconfig.patch
+++ b/dev-util/qbs/files/qbs-2.4.1-ldconfig.patch
@@ -1,0 +1,13 @@
+diff --git a/share/qbs/modules/cpp/LinuxGCC.qbs b/share/qbs/modules/cpp/LinuxGCC.qbs
+index 4b594a0aa..9ad2a613b 100644
+--- a/share/qbs/modules/cpp/LinuxGCC.qbs
++++ b/share/qbs/modules/cpp/LinuxGCC.qbs
+@@ -48,7 +48,7 @@ UnixGCC {
+             var paths = [];
+             var ldconfig = new Process();
+             try {
+-                var success = ldconfig.exec("ldconfig", ["-vNX"]);
++                var success = ldconfig.exec("env", ["ldconfig", ["-vNX"]]);
+                 if (success === -1)
+                     return;
+                 var line;

--- a/dev-util/qbs/qbs-2.4.1.ebuild
+++ b/dev-util/qbs/qbs-2.4.1.ebuild
@@ -45,6 +45,7 @@ CMAKE_SKIP_TESTS=(
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-2.3.1-qtver.patch
+	"${FILESDIR}"/${PN}-2.4.1-ldconfig.patch
 )
 
 python_check_deps() {


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/939142

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
