### PR TITLE
app-text/po4a: apply patch from upstream for xsl lookup

### DIFF
--- a/app-text/po4a/files/po4a-0.69-xmlcatalog.patch
+++ b/app-text/po4a/files/po4a-0.69-xmlcatalog.patch
@@ -1,0 +1,23 @@
+--- a/Po4aBuilder.pm	2024-09-14 15:48:58.642546000 +0800
++++ b/Po4aBuilder.pm	2024-09-14 15:50:38.415546000 +0800
+@@ -242,15 +242,17 @@ sub ACTION_man {
+         foreach $file (qw(po4a-display-man.xml po4a-display-pod.xml)) {
+             copy ( File::Spec->catdir("share", "doc", $file), $man1path) or die;
+         }
++	my $docbook_xsl_url   = "http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl";
++	my $local_docbook_xsl = `xmlcatalog --noout "" "$docbook_xsl_url"` =~ m,file://(.+\.xsl), && $1;
+         foreach $file (@{$self->rscan_dir($manpath, qr{\.xml$})}) {
+             if ($file =~ m,(.*/man(.))/([^/]*)\.xml$,) {
+                 my ($outdir, $section, $outfile) = ($1, $2, $3);
+-            if (-e "/usr/share/xml/docbook/stylesheet/docbook-xsl/manpages/docbook.xsl") { # Location on Debian at least
++            if ($local_docbook_xsl) {
+             print "Convert $outdir/$outfile.$section (local docbook.xsl file). ";
+-            system("xsltproc -o $outdir/$outfile.$section --nonet /usr/share/xml/docbook/stylesheet/docbook-xsl/manpages/docbook.xsl $file") and die;
++            system("xsltproc -o $outdir/$outfile.$section --nonet $local_docbook_xsl $file") and die;
+             } else { # Not found locally, use the XSL file online
+             print "Convert $outdir/$outfile.$section (online docbook.xsl file). ";
+-            system("xsltproc -o $outdir/$outfile.$section --nonet http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl $file") and die;
++            system("xsltproc -o $outdir/$outfile.$section --nonet $docbook_xsl_url $file") and die;
+             }
+             }
+             unlink "$file" || die;

--- a/app-text/po4a/po4a-0.69-r1.ebuild
+++ b/app-text/po4a/po4a-0.69-r1.ebuild
@@ -38,7 +38,10 @@ BDEPEND="app-text/docbook-xml-dtd:4.1.2
 		virtual/latex-base
 	)"
 
-PATCHES=( "${FILESDIR}"/${P}-man.patch )
+PATCHES=(
+	"${FILESDIR}"/${P}-man.patch
+	"${FILESDIR}"/${P}-xmlcatalog.patch
+)
 
 DIST_TEST="do"
 


### PR DESCRIPTION
otherwise build will failed w/:

1. can't find xsl file
2. can't get xsl from net because of -nonet option

patch is from upstream

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
