### PR TITLE
dev-util/gitlab-cli: BDEPEND on dev-lang/go-1.23

### DIFF
--- a/dev-util/gitlab-cli/gitlab-cli-1.46.0.ebuild
+++ b/dev-util/gitlab-cli/gitlab-cli-1.46.0.ebuild
@@ -14,6 +14,8 @@ LICENSE="MIT"
 SLOT="0"
 KEYWORDS="~amd64"
 
+BDEPEND=">=dev-lang/go-1.23"
+
 # tests communicate with gitlab.com and require a personal access token
 RESTRICT="test"
 


### PR DESCRIPTION
`dev-util/gitlab-cli-1.46` [requires Go 1.23.0](https://gitlab.com/gitlab-org/cli/-/blob/16dc43a8f0ae5c8c5310891117efaadfaa5743aa/go.mod#L3), which has not been stabilised yet. This change adds a `BDEPEND` on `dev-lang/go-1.23`.
<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
