### PR TITLE
dev-java/jctools-core: 4.0.5-r1 adjust slot 3 -> 0

### DIFF
--- a/dev-java/jctools-core/jctools-core-4.0.5-r1.ebuild
+++ b/dev-java/jctools-core/jctools-core-4.0.5-r1.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://github.com/JCTools/JCTools/archive/v${PV}.tar.gz -> jctools-${P
 S="${WORKDIR}/JCTools-${PV}/jctools-core"
 
 LICENSE="Apache-2.0"
-SLOT="3"
+SLOT="0"
 KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~x86"
 
 DEPEND="


### PR DESCRIPTION
it was accidentally added with the wrong (old) slot

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
