### PR TITLE
sys-boot/plymouth-openrc-plugin:

### DIFF
--- a/sys-boot/plymouth-openrc-plugin/plymouth-openrc-plugin-0.3.0.ebuild
+++ b/sys-boot/plymouth-openrc-plugin/plymouth-openrc-plugin-0.3.0.ebuild
@@ -14,7 +14,7 @@ SLOT="0"
 KEYWORDS="~alpha ~amd64 ~arm ~ppc ~ppc64 ~sparc ~x86"
 IUSE="debug"
 
-DEPEND="|| ( sys-apps/openrc sys-apps/openrc-navi )"
+DEPEND="|| ( >=sys-apps/openrc-0.55 >=sys-apps/openrc-navi-0.55 )"
 RDEPEND="${DEPEND}
 	sys-boot/plymouth
 	!sys-apps/systemd"


### PR DESCRIPTION
Specify minimum version number in sys-apps/openrc and sys-apps/openrc-navi dependencies
Closes: https://bugs.gentoo.org/939663
Signed-off-by: VNAT <xepjk@protonmail.com>

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
