### PR TITLE
dev-java/jctools-core: duplicate test timeout value #939725

### DIFF
--- a/dev-java/jctools-core/files/jctools-core-4.0.3-increase-TEST_TIMEOUT.patch
+++ b/dev-java/jctools-core/files/jctools-core-4.0.3-increase-TEST_TIMEOUT.patch
@@ -1,5 +1,6 @@
 https://bugs.gentoo.org/863977
 https://bugs.gentoo.org/924135
+https://bugs.gentoo.org/939725 for 120000
 
 --- a/src/test/java/org/jctools/util/TestUtil.java
 +++ b/src/test/java/org/jctools/util/TestUtil.java
@@ -8,7 +9,7 @@ https://bugs.gentoo.org/924135
      public static final int CONCURRENT_TEST_DURATION = Integer.getInteger("org.jctools.concTestDurationMs", 500);
      public static final int CONCURRENT_TEST_THREADS = Integer.getInteger("org.jctools.concTestThreads", Math.min(4, Runtime.getRuntime().availableProcessors()));
 -    public static final int TEST_TIMEOUT = 30000;
-+    public static final int TEST_TIMEOUT = 60000;
++    public static final int TEST_TIMEOUT = 120000;
      private static final AtomicInteger threadIndex = new AtomicInteger();
      public static void sleepQuietly(long timeMs) {
          LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(timeMs));


### PR DESCRIPTION
This bug seems specific to slower hardware while it cannot be reproduced on other computers. We duplicate again, this time 'TEST_TIMEOUT = 120000'

Closes: https://bugs.gentoo.org/939725

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
