### PR TITLE
app-emulation/libvirt: Update live ebuild

### DIFF
--- a/app-emulation/libvirt/files/libvirt-10.7.0-fix-paths-for-apparmor.patch
+++ b/app-emulation/libvirt/files/libvirt-10.7.0-fix-paths-for-apparmor.patch
@@ -1,0 +1,88 @@
+From 9e543b61227ce4e34f02bb54db226f2284c6e359 Mon Sep 17 00:00:00 2001
+Message-ID: <9e543b61227ce4e34f02bb54db226f2284c6e359.1726482829.git.mprivozn@redhat.com>
+From: Michal Privoznik <mprivozn@redhat.com>
+Date: Tue, 15 Mar 2022 05:23:29 +0100
+Subject: [PATCH] libvirt-10.7.0-fix-paths-for-apparmor.patch
+
+Signed-off-by: Michal Privoznik <mprivozn@redhat.com>
+---
+ src/security/apparmor/libvirt-qemu.in                       | 1 +
+ src/security/apparmor/meson.build                           | 6 +++---
+ src/security/apparmor/usr.lib.libvirt.virt-aa-helper.local  | 1 -
+ ...t-aa-helper.in => usr.libexec.libvirt.virt-aa-helper.in} | 4 ++--
+ .../apparmor/usr.libexec.libvirt.virt-aa-helper.local       | 1 +
+ 5 files changed, 7 insertions(+), 6 deletions(-)
+ delete mode 100644 src/security/apparmor/usr.lib.libvirt.virt-aa-helper.local
+ rename src/security/apparmor/{usr.lib.libvirt.virt-aa-helper.in => usr.libexec.libvirt.virt-aa-helper.in} (94%)
+ create mode 100644 src/security/apparmor/usr.libexec.libvirt.virt-aa-helper.local
+
+diff --git a/src/security/apparmor/libvirt-qemu.in b/src/security/apparmor/libvirt-qemu.in
+index 8f17256554..fc9df7ee34 100644
+--- a/src/security/apparmor/libvirt-qemu.in
++++ b/src/security/apparmor/libvirt-qemu.in
+@@ -97,6 +97,7 @@
+   /usr/share/sgabios/** r,
+   /usr/share/slof/** r,
+   /usr/share/vgabios/** r,
++  /usr/share/seavgabios/** r,
+ 
+   # pki for libvirt-vnc and libvirt-spice (LP: #901272, #1690140)
+   /etc/pki/CA/ r,
+diff --git a/src/security/apparmor/meson.build b/src/security/apparmor/meson.build
+index b9257c816d..c1b79fef27 100644
+--- a/src/security/apparmor/meson.build
++++ b/src/security/apparmor/meson.build
+@@ -1,5 +1,5 @@
+ apparmor_gen_profiles = [
+-  'usr.lib.libvirt.virt-aa-helper',
++  'usr.libexec.libvirt.virt-aa-helper',
+   'usr.sbin.libvirtd',
+   'usr.sbin.virtqemud',
+   'usr.sbin.virtxend',
+@@ -82,8 +82,8 @@ if not conf.has('WITH_APPARMOR_3')
+   # AppArmor 3.x, upstream's preference is to avoid creating these
+   # files in order to limit the amount of filesystem clutter.
+   install_data(
+-    'usr.lib.libvirt.virt-aa-helper.local',
++    'usr.libexec.libvirt.virt-aa-helper.local',
+     install_dir: apparmor_dir / 'local',
+-    rename: 'usr.lib.libvirt.virt-aa-helper',
++    rename: 'usr.libexec.libvirt.virt-aa-helper',
+   )
+ endif
+diff --git a/src/security/apparmor/usr.lib.libvirt.virt-aa-helper.local b/src/security/apparmor/usr.lib.libvirt.virt-aa-helper.local
+deleted file mode 100644
+index c0990e51d0..0000000000
+--- a/src/security/apparmor/usr.lib.libvirt.virt-aa-helper.local
++++ /dev/null
+@@ -1 +0,0 @@
+-# Site-specific additions and overrides for 'usr.lib.libvirt.virt-aa-helper'
+diff --git a/src/security/apparmor/usr.lib.libvirt.virt-aa-helper.in b/src/security/apparmor/usr.libexec.libvirt.virt-aa-helper.in
+similarity index 94%
+rename from src/security/apparmor/usr.lib.libvirt.virt-aa-helper.in
+rename to src/security/apparmor/usr.libexec.libvirt.virt-aa-helper.in
+index 44645c6989..38fd3bfb88 100644
+--- a/src/security/apparmor/usr.lib.libvirt.virt-aa-helper.in
++++ b/src/security/apparmor/usr.libexec.libvirt.virt-aa-helper.in
+@@ -72,9 +72,9 @@ profile virt-aa-helper @libexecdir@/virt-aa-helper {
+   /**/disk{,.*} r,
+ 
+ @BEGIN_APPARMOR_3@
+-  include if exists <local/usr.lib.libvirt.virt-aa-helper>
++  include if exists <local/usr.libexec.libvirt.virt-aa-helper>
+ @END_APPARMOR_3@
+ @BEGIN_APPARMOR_2@
+-  #include <local/usr.lib.libvirt.virt-aa-helper>
++  #include <local/usr.libexec.libvirt.virt-aa-helper>
+ @END_APPARMOR_2@
+ }
+diff --git a/src/security/apparmor/usr.libexec.libvirt.virt-aa-helper.local b/src/security/apparmor/usr.libexec.libvirt.virt-aa-helper.local
+new file mode 100644
+index 0000000000..974653d797
+--- /dev/null
++++ b/src/security/apparmor/usr.libexec.libvirt.virt-aa-helper.local
+@@ -0,0 +1 @@
++# Site-specific additions and overrides for 'usr.libexec.libvirt.virt-aa-helper'
+-- 
+2.44.2
+

--- a/app-emulation/libvirt/libvirt-9999.ebuild
+++ b/app-emulation/libvirt/libvirt-9999.ebuild
@@ -157,7 +157,7 @@ PDEPEND="
 PATCHES=(
 	"${FILESDIR}"/${PN}-9.4.0-fix_paths_in_libvirt-guests_sh.patch
 	"${FILESDIR}"/${PN}-9.9.0-do-not-use-sysconfig.patch
-	"${FILESDIR}"/${PN}-9.6.0-fix-paths-for-apparmor.patch
+	"${FILESDIR}"/${PN}-10.7.0-fix-paths-for-apparmor.patch
 )
 
 python_check_deps() {


### PR DESCRIPTION
The libvirt-9.4.0-do-not-use-sysconfig.patch does not apply cleanly anymore (because of libvirt's upstream commit of 5f6ccb087545aec6e57b5ef98d707be11c7b6259). Rebase it and update the live ebuild.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
