### PR TITLE
kernel-install.eclass: fix gentoo-kernel-bin with llvm-objcopy

### DIFF
--- a/eclass/kernel-install.eclass
+++ b/eclass/kernel-install.eclass
@@ -650,7 +650,7 @@ kernel-install_extract_from_uki() {
 	local uki=${2}
 	local out=${3}
 
-	$(tc-getOBJCOPY) -O binary "-j.${extract_type}" "${uki}" "${out}" ||
+	$(tc-getOBJCOPY) "${uki}" --dump-section ".${extract_type}=${out}" ||
 		die "Failed to extract ${extract_type}"
 	chmod 644 "${out}" || die
 }


### PR DESCRIPTION
We ship the kernel in gentoo-kernel-bin in the form of an UKI, using objcopy we extract from this the kernel image (and if desired the generic initramfs).

However, llvm-objcopy does not properly handle the -O argument and as a result the extracted kernel image is of the same file type as the UKI (i.e. a PE32+ executable) instead of a regular kernel image. This causes issues in bootloader such as grub which differentiate between loading a normal kernel image and loading an EFI executable (such as an UKI). And also causes the signature verification to fail since the kernel image is bigger then it should be due to the additional headers.

Using the --dump-section argument instead resolves this problem.

See-also: https://github.com/llvm/llvm-project/issues/108946

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
