### PR TITLE
dev-java/openjdk: fix handle of systemtap without dtrace-symlink

### DIFF
--- a/dev-java/openjdk/openjdk-11.0.24_p8.ebuild
+++ b/dev-java/openjdk/openjdk-11.0.24_p8.ebuild
@@ -163,11 +163,6 @@ src_configure() {
 		export JDK_HOME="${WORKDIR}/openjdk-bootstrap-${!xpakvar}"
 	fi
 
-	# Workaround for bug #938302
-	if use systemtap && has_version "dev-debug/systemtap[-dtrace-symlink(+)]" ; then
-		export DTRACE="${BROOT}"/usr/bin/stap-dtrace
-	fi
-
 	# Work around stack alignment issue, bug #647954.
 	use x86 && append-flags -mincoming-stack-boundary=2
 
@@ -231,6 +226,11 @@ src_configure() {
 		else
 			die "${zip} not found or not readable"
 		fi
+	fi
+
+	# Workaround for bug #938302
+	if use systemtap && has_version "dev-debug/systemtap[-dtrace-symlink(+)]" ; then
+		myconf+=( DTRACE="${BROOT}"/usr/bin/stap-dtrace )
 	fi
 
 	if use !system-bootstrap ; then

--- a/dev-java/openjdk/openjdk-17.0.12_p7.ebuild
+++ b/dev-java/openjdk/openjdk-17.0.12_p7.ebuild
@@ -177,11 +177,6 @@ src_configure() {
 		export JDK_HOME
 	fi
 
-	# Workaround for bug #938302
-	if use systemtap && has_version "dev-debug/systemtap[-dtrace-symlink(+)]" ; then
-		export DTRACE="${BROOT}"/usr/bin/stap-dtrace
-	fi
-
 	# Work around stack alignment issue, bug #647954. in case we ever have x86
 	use x86 && append-flags -mincoming-stack-boundary=2
 
@@ -240,6 +235,11 @@ src_configure() {
 		else
 			die "${zip} not found or not readable"
 		fi
+	fi
+
+	# Workaround for bug #938302
+	if use systemtap && has_version "dev-debug/systemtap[-dtrace-symlink(+)]" ; then
+		myconf+=( TRACE="${BROOT}"/usr/bin/stap-dtrace )
 	fi
 
 	if use !system-bootstrap ; then

--- a/dev-java/openjdk/openjdk-21.0.4_p7.ebuild
+++ b/dev-java/openjdk/openjdk-21.0.4_p7.ebuild
@@ -175,11 +175,6 @@ src_configure() {
 		export JDK_HOME
 	fi
 
-	# Workaround for bug #938302
-	if use systemtap && has_version "dev-debug/systemtap[-dtrace-symlink(+)]" ; then
-		export DTRACE="${BROOT}"/usr/bin/stap-dtrace
-	fi
-
 	# Work around stack alignment issue, bug #647954. in case we ever have x86
 	use x86 && append-flags -mincoming-stack-boundary=2
 
@@ -244,6 +239,11 @@ src_configure() {
 		else
 			die "${zip} not found or not readable"
 		fi
+	fi
+
+	# Workaround for bug #938302
+	if use systemtap && has_version "dev-debug/systemtap[-dtrace-symlink(+)]" ; then
+		myconf +=( DTRACE="${BROOT}"/usr/bin/stap-dtrace )
 	fi
 
 	if use !system-bootstrap ; then


### PR DESCRIPTION
openjdk accept DTRACE from command line instead of env, see jdk source line 297 of make/autoconf/util_paths.m4, otherwise build will failed:

 configure: WARNING: Ignoring value of DTRACE from the environment. Use command line variables instead.

Bug: https://bugs.gentoo.org/938302

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
