### PR TITLE
gnome-extra/gnome-commander: Fix execution of tests

### DIFF
--- a/gnome-extra/gnome-commander/gnome-commander-1.18.1.ebuild
+++ b/gnome-extra/gnome-commander/gnome-commander-1.18.1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit gnome2 meson optfeature
+inherit gnome2 meson optfeature virtualx
 
 DESCRIPTION="A graphical, full featured, twin-panel file manager"
 HOMEPAGE="https://gcmd.github.io/"
@@ -48,6 +48,10 @@ src_configure() {
 		$(meson_use doc help)
 	)
 	meson_src_configure
+}
+
+src_test() {
+	virtx meson_src_test
 }
 
 pkg_postinst() {


### PR DESCRIPTION
Closes: gentoo#937484

When tests are executed on a headless machine or in a terminal (Ctrl-Alt-1), the tests are currently failing. This pull request fixes the test execution. I locally tested this using the following command:

`FEATURES=test emerge -j 1 -l 1 gnome-extra/gnome-commander`

