### PR TITLE
media-libs/x265: build cli for native_abi only, fix bug 939909

### DIFF
--- a/media-libs/x265/x265-3.5-r6.ebuild
+++ b/media-libs/x265/x265-3.5-r6.ebuild
@@ -6,7 +6,7 @@ EAPI=8
 inherit cmake flag-o-matic multilib-minimal multibuild
 
 DESCRIPTION="Library for encoding video streams into the H.265/HEVC format"
-HOMEPAGE="http://x265.org/ https://bitbucket.org/multicoreware/x265_git/"
+HOMEPAGE="https://www.x265.org/ https://bitbucket.org/multicoreware/x265_git/"
 
 if [[ ${PV} = 9999* ]]; then
 	inherit git-r3
@@ -108,7 +108,7 @@ multilib_src_configure() {
 		-DGIT_ARCHETYPE=1 #814116
 		-DLIB_INSTALL_DIR="$(get_libdir)"
 	)
-	if multilib_is_native_abi; then
+	if ! multilib_is_native_abi; then
 		mycmakeargs+=(
 			-DENABLE_CLI="no"
 		)

--- a/media-libs/x265/x265-3.6-r1.ebuild
+++ b/media-libs/x265/x265-3.6-r1.ebuild
@@ -6,7 +6,7 @@ EAPI=8
 inherit cmake flag-o-matic multilib-minimal multibuild
 
 DESCRIPTION="Library for encoding video streams into the H.265/HEVC format"
-HOMEPAGE="http://x265.org/ https://bitbucket.org/multicoreware/x265_git/"
+HOMEPAGE="https://www.x265.org/ https://bitbucket.org/multicoreware/x265_git/"
 
 if [[ ${PV} = 9999* ]]; then
 	inherit git-r3
@@ -108,7 +108,7 @@ multilib_src_configure() {
 		-DGIT_ARCHETYPE=1 #814116
 		-DLIB_INSTALL_DIR="$(get_libdir)"
 	)
-	if multilib_is_native_abi; then
+	if ! multilib_is_native_abi; then
 		mycmakeargs+=(
 			-DENABLE_CLI="no"
 		)

--- a/media-libs/x265/x265-9999.ebuild
+++ b/media-libs/x265/x265-9999.ebuild
@@ -6,7 +6,7 @@ EAPI=8
 inherit cmake flag-o-matic multilib-minimal multibuild
 
 DESCRIPTION="Library for encoding video streams into the H.265/HEVC format"
-HOMEPAGE="http://x265.org/ https://bitbucket.org/multicoreware/x265_git/"
+HOMEPAGE="https://www.x265.org/ https://bitbucket.org/multicoreware/x265_git/"
 
 if [[ ${PV} = 9999* ]]; then
 	inherit git-r3
@@ -108,7 +108,7 @@ multilib_src_configure() {
 		-DGIT_ARCHETYPE=1 #814116
 		-DLIB_INSTALL_DIR="$(get_libdir)"
 	)
-	if multilib_is_native_abi; then
+	if ! multilib_is_native_abi; then
 		mycmakeargs+=(
 			-DENABLE_CLI="no"
 		)


### PR DESCRIPTION
Old logic was $(multilib_is_native_abi || echo "-DENABLE_CLI=OFF"), so we need ! here.

Closes: https://bugs.gentoo.org/939909

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
