### PR TITLE
Port dev-scheme/guile-1.8.8 and app-office/texmacs-2.1 to new guile mechanism 

### DIFF
--- a/app-office/texmacs/texmacs-2.1-r1.ebuild
+++ b/app-office/texmacs/texmacs-2.1-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -18,7 +18,7 @@ KEYWORDS="~amd64 ~ppc ~x86 ~amd64-linux ~x86-linux"
 
 RDEPEND="
 	app-text/ghostscript-gpl
-	<dev-scheme/guile-1.9[debug?,deprecated]
+	<dev-scheme/guile-1.9:12[debug?,deprecated]
 	media-libs/freetype
 	x11-apps/xmodmap
 	x11-libs/libXext

--- a/app-office/texmacs/texmacs-2.1-r100.ebuild
+++ b/app-office/texmacs/texmacs-2.1-r100.ebuild
@@ -1,0 +1,62 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+GUILE_COMPAT=( 1-8 )
+GUILE_REQ_USE="debug?,deprecated"
+inherit cmake xdg guile-single
+
+MY_P=${P/tex/TeX}-src
+
+DESCRIPTION="Wysiwyg text processor with high-quality maths"
+HOMEPAGE="https://www.texmacs.org/"
+SRC_URI="https://www.texmacs.org/Download/ftp/tmftp/source/${MY_P}.tar.gz"
+
+S="${WORKDIR}/${MY_P}"
+
+LICENSE="GPL-3"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86 ~amd64-linux ~x86-linux"
+IUSE="debug jpeg netpbm sqlite svg spell"
+REQUIRED_USE="${GUILE_REQUIRED_USE}"
+
+RDEPEND="
+	${GUILE_DEPS}
+	app-text/ghostscript-gpl
+	media-libs/freetype
+	x11-apps/xmodmap
+	x11-libs/libXext
+	virtual/latex-base
+	>=dev-qt/qtcore-5.9.1:5
+	>=dev-qt/qtgui-5.9.1:5
+	>=dev-qt/qtwidgets-5.9.1:5
+	>=dev-qt/qtprintsupport-5.9.1:5
+	sqlite? ( dev-db/sqlite )
+	jpeg? ( virtual/imagemagick-tools[jpeg] )
+	netpbm? ( media-libs/netpbm )
+	spell? ( app-text/aspell )
+	svg? ( || ( media-gfx/inkscape gnome-base/librsvg:2 ) )
+"
+DEPEND="${RDEPEND}"
+BDEPEND="x11-base/xorg-proto"
+
+src_prepare() {
+	cmake_src_prepare
+	guile_bump_sources
+}
+
+src_configure() {
+	local mycmakeargs=(
+		-DUSE_SQLITE3=$(usex sqlite 1 0)
+		-DDEBUG_ASSERT=$(usex debug 1 0)
+	)
+	cmake_src_configure
+}
+
+src_install() {
+	cmake_src_install
+
+	# guile-single_src_install not needed, Guile 1.8 does not have .go
+	# files...
+}

--- a/dev-scheme/guile/guile-1.8.8-r100.ebuild
+++ b/dev-scheme/guile/guile-1.8.8-r100.ebuild
@@ -1,0 +1,152 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools flag-o-matic elisp-common
+
+DESCRIPTION="GNU Ubiquitous Intelligent Language for Extensions"
+HOMEPAGE="https://www.gnu.org/software/guile/"
+SRC_URI="mirror://gnu/guile/${P}.tar.gz"
+
+LICENSE="LGPL-2.1"
+SLOT="$(ver_cut 1-2)"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~m68k ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos"
+IUSE="debug debug-freelist debug-malloc +deprecated discouraged emacs networking nls readline +regex +threads"
+RESTRICT="!regex? ( test )"
+
+RDEPEND="
+	>=dev-libs/gmp-4.1:0=
+	dev-libs/libltdl:0=
+	sys-devel/gettext
+	sys-libs/ncurses:0=
+	virtual/libcrypt:=
+	readline? ( sys-libs/readline:0= )
+"
+DEPEND="${RDEPEND}"
+BDEPEND="
+	sys-apps/texinfo
+	dev-build/libtool
+	emacs? ( >=app-editors/emacs-23.1:* )
+"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-fix_guile-config.patch
+	"${FILESDIR}"/${P}-gcc46.patch
+	"${FILESDIR}"/${P}-gcc5.patch
+	"${FILESDIR}"/${P}-makeinfo-5.patch
+	"${FILESDIR}"/${P}-gtexinfo-5.patch
+	"${FILESDIR}"/${P}-readline.patch
+	"${FILESDIR}"/${P}-tinfo.patch
+	"${FILESDIR}"/${P}-sandbox.patch
+	"${FILESDIR}"/${P}-mkdir-mask.patch
+	"${FILESDIR}"/${PN}-1.8.8-texinfo-6.7.patch
+)
+
+DOCS=( AUTHORS ChangeLog GUILE-VERSION HACKING NEWS README THANKS )
+
+# Where to install data files.
+GUILE_DATA="${EPREFIX}/usr/share/guile-data/${SLOT}"
+GUILE_PCDIR="${EPREFIX}/usr/share/guile-data/${SLOT}/pkgconfig"
+
+src_prepare() {
+	default
+
+	sed \
+		-e "s/AM_CONFIG_HEADER/AC_CONFIG_HEADERS/g" \
+		-e "/AM_PROG_CC_STDC/d" \
+		-i guile-readline/configure.in || die
+
+	mv "${S}"/configure.{in,ac} || die
+	mv "${S}"/guile-readline/configure.{in,ac} || die
+
+	eautoreconf
+}
+
+src_configure() {
+	# See bug #178499.  filter-flags no longer works since the compiler
+	# will vectorize by default when optimizing.
+	append-flags -fno-tree-vectorize -fno-strict-aliasing
+
+	#will fail for me if posix is disabled or without modules -- hkBst
+	myconf=(
+		--program-suffix="-${SLOT}"
+		--infodir="${GUILE_DATA}/info"
+		--includedir="${EPREFIX}/usr/include/guile/${SLOT}"
+
+		--disable-error-on-warning
+		--disable-static
+		--enable-posix
+		$(use_enable networking)
+		$(use_enable readline)
+		$(use_enable regex)
+		$(use deprecated || use_enable discouraged)
+		$(use_enable deprecated)
+		$(use_enable emacs elisp)
+		$(use_enable nls)
+		--disable-rpath
+		$(use_enable debug-freelist)
+		$(use_enable debug-malloc)
+		$(use_enable debug guile-debug)
+		$(use_with threads)
+		--with-modules
+	)
+	econf "${myconf[@]}" EMACS=no
+}
+
+src_compile() {
+	emake
+
+	# Above we have disabled the build system's Emacs support;
+	# for USE=emacs we compile (and install) the files manually
+	if use emacs; then
+		cd emacs || die
+		elisp-compile *.el || die
+	fi
+}
+
+src_install() {
+	default
+
+	dodir "${GUILE_PCDIR}"
+	sed -e "/libdir/i bindir=${ESYSROOT}/usr/bin" \
+		-e "/libguileinterface/a guile=\${bindir}/guile-${SLOT}" \
+		-i "${ED}"/usr/$(get_libdir)/pkgconfig/guile-1.8.pc || die
+	mv "${ED}"/usr/$(get_libdir)/pkgconfig/guile-1.8.pc "${D}/${GUILE_PCDIR}"/guile-1.8.pc || die
+
+	sed -i "1s/guile/guile-1.8/" "${ED}"/usr/bin/guile-config-1.8 || die
+
+	for script in PROGRAM autofrisk doc-snarf generate-autoload punify \
+				  read-scheme-source scan-api snarf-guile-m4-docs use2dot \
+				  api-diff  display-commentary frisk lint read-rfc822 \
+				  read-text-outline snarf-check-and-output-texi summarize-guile-TODO; do
+		sed "s/GUILE-guile/GUILE-guile-1.8/" \
+			-i "${ED}"/usr/share/guile/1.8/scripts/${script}-1.8 || die
+		mv "${ED}"/usr/share/guile/1.8/scripts/${script}{-1.8,} || die
+	done
+
+	mv "${ED}"/usr/share/aclocal/guile{,-"${SLOT}"}.m4 || die
+	find "${ED}" -name '*.la' -delete || die
+
+	# GUILE_LOAD_PATH for TeXmacs (bug #23493)
+	newenvd - "50guile${SLOT}" <<-EOF
+	PKG_CONFIG_PATH="${GUILE_PCDIR}"
+	GUILE_LOAD_PATH="${EPREFIX}/usr/share/guile/${SLOT}"
+	EOF
+
+	# necessary for registering slib, see bug 206896
+	keepdir /usr/share/guile/site
+
+	if use emacs; then
+		elisp-install ${PN}-${SLOT} emacs/*.{el,elc}
+		elisp-make-site-file "50${PN}-${SLOT}-gentoo.el"
+	fi
+}
+
+pkg_postinst() {
+	use emacs && elisp-site-regen
+}
+
+pkg_postrm() {
+	use emacs && elisp-site-regen
+}

--- a/dev-scheme/guile/guile-1.8.8-r5.ebuild
+++ b/dev-scheme/guile/guile-1.8.8-r5.ebuild
@@ -66,8 +66,9 @@ src_prepare() {
 }
 
 src_configure() {
-	# see bug #178499
-	filter-flags -ftree-vectorize
+	# See bug #178499.  filter-flags no longer works since the compiler
+	# will vectorize by default when optimizing.
+	append-flags -fno-tree-vectorize -fno-strict-aliasing
 
 	#will fail for me if posix is disabled or without modules -- hkBst
 	myconf=(

--- a/profiles/desc/guile_single_target.desc
+++ b/profiles/desc/guile_single_target.desc
@@ -3,5 +3,6 @@
 
 # This file contains descriptions of GUILE_SINGLE_TARGET USE_EXPAND flags.
 
+1-8 - Build only for GNU Guile 1.8.
 2-2 - Build only for GNU Guile 2.2.
 3-0 - Build only for GNU Guile 3.0.

--- a/profiles/desc/guile_targets.desc
+++ b/profiles/desc/guile_targets.desc
@@ -3,5 +3,6 @@
 
 # This file contains descriptions of GUILE_TARGETS USE_EXPAND flags.
 
+1-8 - Build only for GNU Guile 1.8
 2-2 - Build only for GNU Guile 2.2
 3-0 - Build only for GNU Guile 3.0

--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -252,6 +252,7 @@ dev-scheme/guile:2.2
 dev-scheme/guile:3.0
 >=dev-build/make-4.4.1-r100
 >=app-office/gnucash-5.8-r100
+>=app-office/texmacs-2.1-r100
 >=app-shells/gash-0.3.0-r100
 >=dev-build/remake-4.3.1.1.6-r100
 >=dev-debug/gdb-15.1-r100

--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -247,6 +247,7 @@ kde-misc/latte-dock
 www-apps/haunt
 dev-scheme/guile-commonmark
 >=dev-scheme/guile-reader-0.6.3-r100
+dev-scheme/guile:1.8
 dev-scheme/guile:2.2
 dev-scheme/guile:3.0
 >=dev-build/make-4.4.1-r100


### PR DESCRIPTION
I've confirmed that I can install dev-scheme/guile-1.8.8-r100 and dev-scheme/guile-2.2.7-r100 alongside each other, and that app-office/texmacs-2.1-r100 compiles and runs in that case (and uses Guile 1.8).

Both dev-scheme/guile-1.8.8-r4 and app-office/texmacs-2.1-r1 were already masked due to lack of upstream support for the former, unsure if they should be unmasked after we unmask all the r100 packages.

Bug: https://bugs.gentoo.org/689408
Bug: https://bugs.gentoo.org/436400

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
