### PR TITLE
sys-apps/systemd: add missing dependency libbpf

### DIFF
--- a/sys-apps/systemd/systemd-256.5.ebuild
+++ b/sys-apps/systemd/systemd-256.5.ebuild
@@ -59,6 +59,7 @@ COMMON_DEPEND="
 	acl? ( sys-apps/acl:0= )
 	apparmor? ( >=sys-libs/libapparmor-2.13:0= )
 	audit? ( >=sys-process/audit-2:0= )
+	bpf? ( >=dev-libs/libbpf-1.4.0:0= )
 	cryptsetup? ( >=sys-fs/cryptsetup-2.0.1:0= )
 	curl? ( >=net-misc/curl-7.32.0:0= )
 	elfutils? ( >=dev-libs/elfutils-0.158:0= )

--- a/sys-apps/systemd/systemd-256.6.ebuild
+++ b/sys-apps/systemd/systemd-256.6.ebuild
@@ -59,6 +59,7 @@ COMMON_DEPEND="
 	acl? ( sys-apps/acl:0= )
 	apparmor? ( >=sys-libs/libapparmor-2.13:0= )
 	audit? ( >=sys-process/audit-2:0= )
+	bpf? ( >=dev-libs/libbpf-1.4.0:0= )
 	cryptsetup? ( >=sys-fs/cryptsetup-2.0.1:0= )
 	curl? ( >=net-misc/curl-7.32.0:0= )
 	elfutils? ( >=dev-libs/elfutils-0.158:0= )


### PR DESCRIPTION
<!-- Please put the pull request description above -->

Systemd requires libbpf at both build time and runtime to enable BPF: https://github.com/systemd/systemd/blob/230f5613c97175985f878580ef2f5f1937963da6/meson.build#L1072

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
