### PR TITLE
gui-libs/greetd: add sec-policy/selinux-xserver to RDEPEND for SELinux

### DIFF
--- a/gui-libs/greetd/greetd-0.10.3.ebuild
+++ b/gui-libs/greetd/greetd-0.10.3.ebuild
@@ -80,14 +80,17 @@ LICENSE="GPL-3+"
 LICENSE+=" Apache-2.0 MIT Unicode-DFS-2016 Unlicense"
 SLOT="0"
 KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
-IUSE="man"
+IUSE="man selinux"
 
 DEPEND="
 	acct-user/greetd
 	sys-auth/pambase
 	sys-libs/pam
 "
-RDEPEND="${DEPEND}"
+RDEPEND="
+	${DEPEND}
+	selinux? ( sec-policy/selinux-xserver )
+"
 BDEPEND="man? ( app-text/scdoc )"
 
 QA_FLAGS_IGNORED="usr/bin/.*greet.*"


### PR DESCRIPTION
For SELinux system, greetd requires sec-policy/selinux-xserver add runtime. Let's add it to RDEPEND.

Closes: https://bugs.gentoo.org/933707

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
