### PR TITLE
sys-apps/systemd: call pam_selinux.so in pam config for systemd-user

### DIFF
--- a/sys-apps/systemd/files/systemd-user-selinux.pam
+++ b/sys-apps/systemd/files/systemd-user-selinux.pam
@@ -1,0 +1,7 @@
+account include system-auth
+
+session required pam_selinux.so close
+session required pam_selinux.so nottys open
+session required pam_loginuid.so
+session include system-auth
+session optional pam_systemd.so

--- a/sys-apps/systemd/systemd-254.13.ebuild
+++ b/sys-apps/systemd/systemd-254.13.ebuild
@@ -397,7 +397,11 @@ multilib_src_install_all() {
 	keepdir /var/log/journal
 
 	if use pam; then
-		newpamd "${FILESDIR}"/systemd-user.pam systemd-user
+		if use selinux; then
+			newpamd "${FILESDIR}"/systemd-user-selinux.pam systemd-user
+		else
+			newpamd "${FILESDIR}"/systemd-user.pam systemd-user
+		fi
 	fi
 
 	if use split-usr; then

--- a/sys-apps/systemd/systemd-254.16.ebuild
+++ b/sys-apps/systemd/systemd-254.16.ebuild
@@ -397,7 +397,11 @@ multilib_src_install_all() {
 	keepdir /var/log/journal
 
 	if use pam; then
-		newpamd "${FILESDIR}"/systemd-user.pam systemd-user
+		if use selinux; then
+			newpamd "${FILESDIR}"/systemd-user-selinux.pam systemd-user
+		else
+			newpamd "${FILESDIR}"/systemd-user.pam systemd-user
+		fi
 	fi
 
 	if use split-usr; then

--- a/sys-apps/systemd/systemd-254.17.ebuild
+++ b/sys-apps/systemd/systemd-254.17.ebuild
@@ -397,7 +397,11 @@ multilib_src_install_all() {
 	keepdir /var/log/journal
 
 	if use pam; then
-		newpamd "${FILESDIR}"/systemd-user.pam systemd-user
+		if use selinux; then
+			newpamd "${FILESDIR}"/systemd-user-selinux.pam systemd-user
+		else
+			newpamd "${FILESDIR}"/systemd-user.pam systemd-user
+		fi
 	fi
 
 	if use split-usr; then

--- a/sys-apps/systemd/systemd-254.18.ebuild
+++ b/sys-apps/systemd/systemd-254.18.ebuild
@@ -397,7 +397,11 @@ multilib_src_install_all() {
 	keepdir /var/log/journal
 
 	if use pam; then
-		newpamd "${FILESDIR}"/systemd-user.pam systemd-user
+		if use selinux; then
+			newpamd "${FILESDIR}"/systemd-user-selinux.pam systemd-user
+		else
+			newpamd "${FILESDIR}"/systemd-user.pam systemd-user
+		fi
 	fi
 
 	if use split-usr; then

--- a/sys-apps/systemd/systemd-255.10.ebuild
+++ b/sys-apps/systemd/systemd-255.10.ebuild
@@ -408,7 +408,11 @@ multilib_src_install_all() {
 	keepdir /var/log/journal
 
 	if use pam; then
-		newpamd "${FILESDIR}"/systemd-user.pam systemd-user
+		if use selinux; then
+			newpamd "${FILESDIR}"/systemd-user-selinux.pam systemd-user
+		else
+			newpamd "${FILESDIR}"/systemd-user.pam systemd-user
+		fi
 	fi
 
 	if use kernel-install; then

--- a/sys-apps/systemd/systemd-255.11.ebuild
+++ b/sys-apps/systemd/systemd-255.11.ebuild
@@ -408,7 +408,11 @@ multilib_src_install_all() {
 	keepdir /var/log/journal
 
 	if use pam; then
-		newpamd "${FILESDIR}"/systemd-user.pam systemd-user
+		if use selinux; then
+			newpamd "${FILESDIR}"/systemd-user-selinux.pam systemd-user
+		else
+			newpamd "${FILESDIR}"/systemd-user.pam systemd-user
+		fi
 	fi
 
 	if use kernel-install; then

--- a/sys-apps/systemd/systemd-255.12.ebuild
+++ b/sys-apps/systemd/systemd-255.12.ebuild
@@ -408,7 +408,11 @@ multilib_src_install_all() {
 	keepdir /var/log/journal
 
 	if use pam; then
-		newpamd "${FILESDIR}"/systemd-user.pam systemd-user
+		if use selinux; then
+			newpamd "${FILESDIR}"/systemd-user-selinux.pam systemd-user
+		else
+			newpamd "${FILESDIR}"/systemd-user.pam systemd-user
+		fi
 	fi
 
 	if use kernel-install; then

--- a/sys-apps/systemd/systemd-255.7-r1.ebuild
+++ b/sys-apps/systemd/systemd-255.7-r1.ebuild
@@ -408,7 +408,11 @@ multilib_src_install_all() {
 	keepdir /var/log/journal
 
 	if use pam; then
-		newpamd "${FILESDIR}"/systemd-user.pam systemd-user
+		if use selinux; then
+			newpamd "${FILESDIR}"/systemd-user-selinux.pam systemd-user
+		else
+			newpamd "${FILESDIR}"/systemd-user.pam systemd-user
+		fi
 	fi
 
 	if use kernel-install; then

--- a/sys-apps/systemd/systemd-256.1-r3.ebuild
+++ b/sys-apps/systemd/systemd-256.1-r3.ebuild
@@ -432,7 +432,11 @@ multilib_src_install_all() {
 	keepdir /var/log/journal
 
 	if use pam; then
-		newpamd "${FILESDIR}"/systemd-user.pam systemd-user
+		if use selinux; then
+			newpamd "${FILESDIR}"/systemd-user-selinux.pam systemd-user
+		else
+			newpamd "${FILESDIR}"/systemd-user.pam systemd-user
+		fi
 	fi
 
 	if use kernel-install; then

--- a/sys-apps/systemd/systemd-256.2.ebuild
+++ b/sys-apps/systemd/systemd-256.2.ebuild
@@ -432,7 +432,11 @@ multilib_src_install_all() {
 	keepdir /var/log/journal
 
 	if use pam; then
-		newpamd "${FILESDIR}"/systemd-user.pam systemd-user
+		if use selinux; then
+			newpamd "${FILESDIR}"/systemd-user-selinux.pam systemd-user
+		else
+			newpamd "${FILESDIR}"/systemd-user.pam systemd-user
+		fi
 	fi
 
 	if use kernel-install; then

--- a/sys-apps/systemd/systemd-256.4.ebuild
+++ b/sys-apps/systemd/systemd-256.4.ebuild
@@ -432,7 +432,11 @@ multilib_src_install_all() {
 	keepdir /var/log/journal
 
 	if use pam; then
-		newpamd "${FILESDIR}"/systemd-user.pam systemd-user
+		if use selinux; then
+			newpamd "${FILESDIR}"/systemd-user-selinux.pam systemd-user
+		else
+			newpamd "${FILESDIR}"/systemd-user.pam systemd-user
+		fi
 	fi
 
 	if use kernel-install; then

--- a/sys-apps/systemd/systemd-256.5.ebuild
+++ b/sys-apps/systemd/systemd-256.5.ebuild
@@ -440,7 +440,11 @@ multilib_src_install_all() {
 	keepdir /var/log/journal
 
 	if use pam; then
-		newpamd "${FILESDIR}"/systemd-user.pam systemd-user
+		if use selinux; then
+			newpamd "${FILESDIR}"/systemd-user-selinux.pam systemd-user
+		else
+			newpamd "${FILESDIR}"/systemd-user.pam systemd-user
+		fi
 	fi
 
 	if use kernel-install; then

--- a/sys-apps/systemd/systemd-256.6.ebuild
+++ b/sys-apps/systemd/systemd-256.6.ebuild
@@ -440,7 +440,11 @@ multilib_src_install_all() {
 	keepdir /var/log/journal
 
 	if use pam; then
-		newpamd "${FILESDIR}"/systemd-user.pam systemd-user
+		if use selinux; then
+			newpamd "${FILESDIR}"/systemd-user-selinux.pam systemd-user
+		else
+			newpamd "${FILESDIR}"/systemd-user.pam systemd-user
+		fi
 	fi
 
 	if use kernel-install; then

--- a/sys-apps/systemd/systemd-9999.ebuild
+++ b/sys-apps/systemd/systemd-9999.ebuild
@@ -439,7 +439,11 @@ multilib_src_install_all() {
 	keepdir /var/log/journal
 
 	if use pam; then
-		newpamd "${FILESDIR}"/systemd-user.pam systemd-user
+		if use selinux; then
+			newpamd "${FILESDIR}"/systemd-user-selinux.pam systemd-user
+		else
+			newpamd "${FILESDIR}"/systemd-user.pam systemd-user
+		fi
 	fi
 
 	if use kernel-install; then


### PR DESCRIPTION
Currently, systemd --user sessions get launched with the wrong context, init_t. Let's fix our pam config for systemd-user by calling pam_selinux.so with close and nottys open like upstream does.

Closes: https://bugs.gentoo.org/908759

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
