### PR TITLE
www-client/qutebrowser: add an explicit `kerberos` USE-flag

### DIFF
--- a/dev-python/PyQt6-WebEngine/PyQt6-WebEngine-6.7.0.ebuild
+++ b/dev-python/PyQt6-WebEngine/PyQt6-WebEngine-6.7.0.ebuild
@@ -18,12 +18,15 @@ HOMEPAGE="https://www.riverbankcomputing.com/software/pyqtwebengine/"
 LICENSE="GPL-3"
 SLOT="0"
 KEYWORDS="amd64 ~arm64"
-IUSE="debug quick +widgets"
+IUSE="debug kerberos quick +widgets"
 
 RDEPEND="
 	>=dev-python/PyQt6-${QT_PV%:*}[gui,ssl,${PYTHON_USEDEP}]
 	>=dev-qt/qtbase-${QT_PV}[gui,widgets?]
 	>=dev-qt/qtwebengine-${QT_PV}[widgets]
+	kerberos? (
+		>=dev-qt/qtwebengine-${QT_PV}[kerberos]
+	)
 	quick? (
 		dev-python/PyQt6[qml]
 		>=dev-qt/qtwebengine-${QT_PV}[qml]

--- a/www-client/qutebrowser/qutebrowser-3.2.1.ebuild
+++ b/www-client/qutebrowser/qutebrowser-3.2.1.ebuild
@@ -27,7 +27,7 @@ HOMEPAGE="https://qutebrowser.org/"
 
 LICENSE="GPL-3+"
 SLOT="0"
-IUSE="+adblock pdf widevine"
+IUSE="+adblock kerberos pdf widevine"
 
 RDEPEND="
 	$(python_gen_cond_dep '
@@ -41,6 +41,7 @@ RDEPEND="
 		dev-python/zipp[${PYTHON_USEDEP}]
 		dev-qt/qtbase:6[icu,sqlite]
 		adblock? ( dev-python/adblock[${PYTHON_USEDEP}] )
+		kerberos? ( dev-python/PyQt6-WebEngine[${PYTHON_USEDEP}] )
 		pdf? ( www-plugins/pdfjs )
 		widevine? ( www-plugins/chrome-binary-plugins )
 	')

--- a/www-client/qutebrowser/qutebrowser-9999.ebuild
+++ b/www-client/qutebrowser/qutebrowser-9999.ebuild
@@ -27,7 +27,7 @@ HOMEPAGE="https://qutebrowser.org/"
 
 LICENSE="GPL-3+"
 SLOT="0"
-IUSE="+adblock pdf widevine"
+IUSE="+adblock kerberos pdf widevine"
 
 RDEPEND="
 	$(python_gen_cond_dep '
@@ -41,6 +41,7 @@ RDEPEND="
 		dev-python/zipp[${PYTHON_USEDEP}]
 		dev-qt/qtbase:6[icu,sqlite]
 		adblock? ( dev-python/adblock[${PYTHON_USEDEP}] )
+		kerberos? ( dev-python/PyQt6-WebEngine[${PYTHON_USEDEP}] )
 		pdf? ( www-plugins/pdfjs )
 		widevine? ( www-plugins/chrome-binary-plugins )
 	')


### PR DESCRIPTION
Ref: https://github.com/qutebrowser/qutebrowser/issues/4595#issuecomment-2369165892

Signed-Off-By: Sviatoslav Sydorenko <webknjaz@redhat.com>
<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
