### PR TITLE
app-emulation/libvirt: 9999: s/yajl/json-c/

### DIFF
--- a/app-emulation/libvirt/libvirt-9999.ebuild
+++ b/app-emulation/libvirt/libvirt-9999.ebuild
@@ -111,7 +111,7 @@ RDEPEND="
 	qemu? (
 		>=app-emulation/qemu-4.2
 		app-crypt/swtpm
-		>=dev-libs/yajl-2.0.3:=
+		dev-libs/json-c
 	)
 	rbd? ( sys-cluster/ceph )
 	sasl? ( >=dev-libs/cyrus-sasl-2.1.26 )
@@ -297,7 +297,7 @@ src_configure() {
 		$(meson_feature pcap libpcap)
 		$(meson_feature policykit polkit)
 		$(meson_feature qemu driver_qemu)
-		$(meson_feature qemu yajl)
+		$(meson_feature qemu json_c)
 		$(meson_feature rbd storage_rbd)
 		$(meson_feature sasl)
 		$(meson_feature selinux)


### PR DESCRIPTION
Libvirt no longer uses yajl and uses json-c instead, make the necessary adjustments to the dependencies and meson options in the live ebuild.

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
