### PR TITLE
sci-calculators/qalculate-qt: Switch to Qt6

### DIFF
--- a/sci-calculators/qalculate-qt/qalculate-qt-5.2.0-r1.ebuild
+++ b/sci-calculators/qalculate-qt/qalculate-qt-5.2.0-r1.ebuild
@@ -1,0 +1,32 @@
+# Copyright 2022-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+# Bump with sci-libs/libqalculate and sci-calculators/qalculate-gtk!
+
+inherit qmake-utils xdg
+
+DESCRIPTION="Qt-based UI for libqalculate"
+HOMEPAGE="https://github.com/Qalculate/qalculate-qt"
+SRC_URI="https://github.com/Qalculate/${PN}/releases/download/v${PV}/${P}.tar.gz"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64"
+
+DEPEND="
+	dev-qt/qtbase:6[gui,network,widgets]
+	>=sci-libs/libqalculate-${PV}:=
+"
+RDEPEND="${DEPEND}"
+BDEPEND="dev-qt/qttools:6[linguist]"
+
+src_configure() {
+	eqmake6 PREFIX="${EPREFIX}/usr"
+
+}
+
+src_install() {
+	emake INSTALL_ROOT="${ED}" install
+}


### PR DESCRIPTION
- Convert dependencies to Qt6 variants
- Convert build instructions to Qt6 variants
- Verified in-program that it was using Qt6
- Add xdg_icon_cache_update to fix QA warnings

Closes: https://bugs.gentoo.org/940133

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
