### PR TITLE
net-libs/libssh: crank up test timeouts

### DIFF
--- a/net-libs/libssh/libssh-0.10.6-r1.ebuild
+++ b/net-libs/libssh/libssh-0.10.6-r1.ebuild
@@ -118,6 +118,10 @@ multilib_src_compile() {
 	multilib_is_native_abi && use doc && cmake_src_compile docs
 }
 
+multilib_src_test() {
+	cmake_src_test --timeout 3000
+}
+
 multilib_src_install() {
 	cmake_src_install
 	multilib_is_native_abi && use doc && local HTML_DOCS=( "${BUILD_DIR}"/doc/html/. )

--- a/net-libs/libssh/libssh-9999.ebuild
+++ b/net-libs/libssh/libssh-9999.ebuild
@@ -113,6 +113,10 @@ multilib_src_compile() {
 	multilib_is_native_abi && use doc && cmake_src_compile docs
 }
 
+multilib_src_test() {
+	cmake_src_test --timeout 3000
+}
+
 multilib_src_install() {
 	cmake_src_install
 	multilib_is_native_abi && use doc && local HTML_DOCS=( "${BUILD_DIR}"/doc/html/. )


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/935899

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
