### PR TITLE
app-crypt/certbot: patch cryptography warnings

### DIFF
--- a/app-crypt/certbot/certbot-2.11.0-r1.ebuild
+++ b/app-crypt/certbot/certbot-2.11.0-r1.ebuild
@@ -1,0 +1,69 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DISTUTILS_USE_PEP517=setuptools
+PYTHON_COMPAT=( python3_{10..13} )
+
+inherit distutils-r1
+
+if [[ "${PV}" == *9999 ]]; then
+	inherit git-r3
+
+	EGIT_REPO_URI="https://github.com/certbot/certbot.git"
+	EGIT_SUBMODULES=()
+	EGIT_CHECKOUT_DIR="${WORKDIR}/${P}"
+else
+	SRC_URI="
+		https://github.com/certbot/certbot/archive/v${PV}.tar.gz
+			-> ${P}.gh.tar.gz
+	"
+	KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~riscv ~x86"
+fi
+
+DESCRIPTION="Let’s Encrypt client to automate deployment of X.509 certificates"
+HOMEPAGE="
+	https://github.com/certbot/certbot/
+	https://pypi.org/project/certbot/
+	https://letsencrypt.org/
+"
+
+S="${WORKDIR}/${P}/${PN}"
+LICENSE="Apache-2.0"
+SLOT="0"
+
+IUSE="selinux"
+
+BDEPEND="
+	test? (
+		dev-python/typing-extensions[${PYTHON_USEDEP}]
+	)
+"
+
+# See certbot/setup.py for acme >= dep
+RDEPEND="
+	>=app-crypt/acme-${PV}[${PYTHON_USEDEP}]
+	>=dev-python/ConfigArgParse-1.5.3[${PYTHON_USEDEP}]
+	>=dev-python/configobj-5.0.6[${PYTHON_USEDEP}]
+	>=dev-python/cryptography-3.2.1[${PYTHON_USEDEP}]
+	>=dev-python/distro-1.0.1[${PYTHON_USEDEP}]
+	>=dev-python/josepy-1.13.0[${PYTHON_USEDEP}]
+	>=dev-python/parsedatetime-2.4[${PYTHON_USEDEP}]
+	dev-python/pyrfc3339[${PYTHON_USEDEP}]
+	>=dev-python/pytz-2019.3[${PYTHON_USEDEP}]
+	selinux? ( sec-policy/selinux-certbot )
+"
+
+PATCHES=(
+	"${FILESDIR}"/certbot-2.10.0-cryptography-43.0.0-datetime-warnings.patch
+)
+
+distutils_enable_sphinx docs \
+	dev-python/sphinx-rtd-theme
+distutils_enable_tests pytest
+
+python_test() {
+	local -x PYTEST_DISABLE_PLUGIN_AUTOLOAD=1
+	epytest
+}

--- a/app-crypt/certbot/files/certbot-2.10.0-cryptography-43.0.0-datetime-warnings.patch
+++ b/app-crypt/certbot/files/certbot-2.10.0-cryptography-43.0.0-datetime-warnings.patch
@@ -1,0 +1,18 @@
+# https://bugs.gentoo.org/937889
+--- a/certbot/ocsp.py
++++ b/certbot/ocsp.py
+@@ -235,11 +235,11 @@ def _check_ocsp_response(response_ocsp: 'ocsp.OCSPResponse', request_ocsp: 'ocsp
+     # https://github.com/openssl/openssl/blob/ef45aa14c5af024fcb8bef1c9007f3d1c115bd85/crypto/ocsp/ocsp_cl.c#L338-L391
+     # thisUpdate/nextUpdate are expressed in UTC/GMT time zone
+     now = datetime.now(pytz.UTC).replace(tzinfo=None)
+-    if not response_ocsp.this_update:
++    if not response_ocsp.this_update_utc:
+         raise AssertionError('param thisUpdate is not set.')
+-    if response_ocsp.this_update > now + timedelta(minutes=5):
++    if response_ocsp.this_update_utc > now + timedelta(minutes=5):
+         raise AssertionError('param thisUpdate is in the future.')
+-    if response_ocsp.next_update and response_ocsp.next_update < now - timedelta(minutes=5):
++    if response_ocsp.next_update_utc and response_ocsp.next_update_utc < now - timedelta(minutes=5):
+         raise AssertionError('param nextUpdate is in the past.')
+ 
+ 


### PR DESCRIPTION
app-crypt/certbot: patch cryptography warnings

Bug: https://bugs.gentoo.org/937889
Closes: https://github.com/gentoo/gentoo/pull/38775

<!-- Please put the pull request description above -->

---

For reviewer ease of access:
```diff
--- certbot-2.11.0.ebuild       2024-09-25 20:21:26.140871708 -0400
+++ certbot-2.11.0-r1.ebuild    2024-09-28 16:21:18.475705972 -0400
@@ -46,7 +46,7 @@
        >=app-crypt/acme-${PV}[${PYTHON_USEDEP}]
        >=dev-python/ConfigArgParse-1.5.3[${PYTHON_USEDEP}]
        >=dev-python/configobj-5.0.6[${PYTHON_USEDEP}]
-       >=dev-python/cryptography-3.2.1[${PYTHON_USEDEP}]
+       >=dev-python/cryptography-43.0.0[${PYTHON_USEDEP}]
        >=dev-python/distro-1.0.1[${PYTHON_USEDEP}]
        >=dev-python/josepy-1.13.0[${PYTHON_USEDEP}]
        >=dev-python/parsedatetime-2.4[${PYTHON_USEDEP}]
@@ -55,6 +55,10 @@
        selinux? ( sec-policy/selinux-certbot )
 "

+PATCHES=(
+       "${FILESDIR}"/certbot-2.10.0-cryptography-43.0.0-datetime-warnings.patch
+)
+
 distutils_enable_sphinx docs \
        dev-python/sphinx-rtd-theme
 distutils_enable_tests pytest
```

---

Upstream doesn't seem like [they're going to be very responsive](https://github.com/certbot/certbot/issues/9967#issuecomment-2251124561) to addressing these warnings.  Feels like they'll get to upgrading to cryptography 43.0.0 when they feel like it.

So, since all we have is cryptography 43.0.x in the tree, lets just patch in the fix.  The certbot code is already dealing in UTC, so it seems pretty straight forward.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
