### PR TITLE
sys-boot/gnu-efi: Fix failure if LLVM `binutils-plugin` USE flag is set

### DIFF
--- a/sys-boot/gnu-efi/gnu-efi-3.0.18-r3.ebuild
+++ b/sys-boot/gnu-efi/gnu-efi-3.0.18-r3.ebuild
@@ -42,6 +42,16 @@ check_and_set_objcopy() {
 		# llvm-objcopy does not support EFI target, try to use binutils objcopy or fail
 		tc-export OBJCOPY
 		OBJCOPY="${OBJCOPY/llvm-/}"
+		# Test OBJCOPY to see if it supports EFI targets, and return if it does
+		LC_ALL=C "${OBJCOPY}" --help | grep -q '\<pei-' && return 0
+		# If OBJCOPY does not support EFI targets, it is possible that the 'objcopy' on our path is
+		# still LLVM if the 'binutils-plugin' USE flag is set. In this case, we check to see if the
+		# '(prefix)/usr/bin/objcopy' binary is available (it should be, it's a dependency), and if
+		# so, we use the absolute path explicitly.
+		local binutils_objcopy="${EPREFIX}"/usr/bin/"${OBJCOPY}"
+		if [[ -e "${binutils_objcopy}" ]]; then
+			OBJCOPY="${binutils_objcopy}"
+		fi
 		LANG=C LC_ALL=C "${OBJCOPY}" --help | grep -q '\<pei-' || die "${OBJCOPY} (objcopy) does not support EFI target"
 	fi
 }

--- a/sys-boot/gnu-efi/gnu-efi-3.0.18-r5.ebuild
+++ b/sys-boot/gnu-efi/gnu-efi-3.0.18-r5.ebuild
@@ -42,6 +42,16 @@ check_and_set_objcopy() {
 		# llvm-objcopy does not support EFI target, try to use binutils objcopy or fail
 		tc-export OBJCOPY
 		OBJCOPY="${OBJCOPY/llvm-/}"
+		# Test OBJCOPY to see if it supports EFI targets, and return if it does
+		LC_ALL=C "${OBJCOPY}" --help | grep -q '\<pei-' && return 0
+		# If OBJCOPY does not support EFI targets, it is possible that the 'objcopy' on our path is
+		# still LLVM if the 'binutils-plugin' USE flag is set. In this case, we check to see if the
+		# '(prefix)/usr/bin/objcopy' binary is available (it should be, it's a dependency), and if
+		# so, we use the absolute path explicitly.
+		local binutils_objcopy="${EPREFIX}"/usr/bin/"${OBJCOPY}"
+		if [[ -e "${binutils_objcopy}" ]]; then
+			OBJCOPY="${binutils_objcopy}"
+		fi
 		if ! use arm && ! use riscv; then
 			# bug #939338
 			# objcopy does not understand PE/COFF on these arches: arm32, riscv64 and mips64le


### PR DESCRIPTION
This is a an additional patch for bug [931792](https://bugs.gentoo.org/931792) when `LLVM` has the `binutils-plugin` USE flag set and your system compiler is `LLVM`.  In that case, `LLVM` creates a `objcopy` binary (in addition to the `llvm-objcopy` version), and since `LLVM` is earlier in our system path than `/usr/bin` where the GNU `objcopy` is, the previous fix doesn't end up doing anything.  I got around this by explicitly using the `{prefix}/usr/bin` GNU path for `objcopy` if the initial `objcopy` test fails.

Let me know if you need this fixed in a different way, or if you need any additional information. It is the same repo as the linked issue, but with LLVM as your system compiler and the `binutils-plugin` USE flag enabled on it.

Bug: https://bugs.gentoo.org/931792

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
