### PR TITLE
dev-java/cdi-api: fix installation for USE=source #940305

### DIFF
--- a/dev-java/cdi-api/cdi-api-4.0.1-r3.ebuild
+++ b/dev-java/cdi-api/cdi-api-4.0.1-r3.ebuild
@@ -93,11 +93,14 @@ src_compile() {
 }
 
 src_install() {
-	java-pkg-simple_src_install
-	java-pkg_dojar "lang-model.jar"
+	java-pkg_dojar {cdi-api,lang-model}.jar
+
+	use doc && java-pkg_dojavadoc target/api
 
 	if use source; then
-		java-pkg_dosrc "lang-model/src/main/java/*"
-		java-pkg_dosrc "api/src/main/java/*"
+		java-pkg_dosrc lang-model/src/main/java/*
+		java-pkg_dosrc api/src/main/java/*
 	fi
+
+	einstalldocs
 }


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/940305

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
