### PR TITLE
dev-lang/rust: Lower x86 baseline for no sse2 support

### DIFF
--- a/dev-lang/rust/files/1.82.0-i586-baseline.patch
+++ b/dev-lang/rust/files/1.82.0-i586-baseline.patch
@@ -1,0 +1,44 @@
+Bug: https://bugs.gentoo.org/741708
+From: Ian Jordan <immoloism@gmail.com>
+Date: Thu, 01 Nov 204 15:28:39 +0100
+Subject: Change Pentium4 baseline to i586
+
+Based on the Debian patch at https://sources.debian.org/patches/rustc/1.80.1%2Bdfsg1-1/behaviour/d-rustc-i686-baseline.patch/
+This lowers baseline from Pentium4 to i586.
+
+Thanks-to: Debian Rust Maintainers <pkg-rust-maintainers@alioth-lists.debian.net>
+
+--- a/compiler/rustc_target/src/spec/targets/i686_unknown_linux_gnu.rs
++++ b/compiler/rustc_target/src/spec/targets/i686_unknown_linux_gnu.rs
+@@ -2,7 +2,7 @@ use crate::spec::{base, Cc, LinkerFlavor, Lld, SanitizerSet, StackProbeType, Tar
+ 
+ pub fn target() -> Target {
+     let mut base = base::linux_gnu::opts();
+-    base.cpu = "pentium4".into();
++    base.cpu = "pentiumpro".into();
+     base.max_atomic_width = Some(64);
+     base.supported_sanitizers = SanitizerSet::ADDRESS;
+     base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-m32"]);
+--- a/tests/ui/abi/homogenous-floats-target-feature-mixup.rs
++++ b/tests/ui/abi/homogenous-floats-target-feature-mixup.rs
+@@ -24,7 +24,8 @@ fn main() {
+     match std::env::var("TARGET") {
+         Ok(s) => {
+             // Skip this tests on i586-unknown-linux-gnu where sse2 is disabled
+-            if s.contains("i586") {
++            // Debian: our i686 doesn't have SSE 2..
++            if s.contains("i586") || s.contains("i686") {
+                 return
+             }
+         }
+--- a/tests/ui/sse2.rs
++++ b/tests/ui/sse2.rs
+@@ -16,7 +16,7 @@ fn main() {
+         }
+         Err(_) => return,
+     }
+-    if cfg!(any(target_arch = "x86", target_arch = "x86_64")) {
++    if cfg!(any(target_arch = "x86_64")) {
+         assert!(cfg!(target_feature = "sse2"),
+                 "SSE2 was not detected as available on an x86 platform");
+     }

--- a/dev-lang/rust/rust-1.82.0.ebuild
+++ b/dev-lang/rust/rust-1.82.0.ebuild
@@ -129,7 +129,6 @@ REQUIRED_USE="|| ( ${ALL_LLVM_TARGETS[*]} )
 	rust-analyzer? ( rust-src )
 	test? ( ${ALL_LLVM_TARGETS[*]} )
 	wasm? ( llvm_targets_WebAssembly )
-	x86? ( cpu_flags_x86_sse2 )
 "
 
 # we don't use cmake.eclass, but can get a warning
@@ -306,6 +305,14 @@ src_prepare() {
 	#	terminal_size tracing-tree; do
 	#	clear_vendor_checksums "${i}"
 	#done
+
+	# Rust baselines to Pentium4 on x86, this patch lowers the baseline to i586 when sse2 is not set.
+	if use x86; then
+		if ! use cpu_flags_x86_sse2; then
+			eapply "${FILESDIR}/1.82.0-i586-baseline.patch"
+			grep -rl cmd.args.push\(\"-march=i686\" . | xargs sed  -i 's/march=i686/-march=i586/g' || die
+		fi
+	fi
 
 	if ! use system-bootstrap; then
 		has_version sys-devel/gcc || esetup_unwind_hack


### PR DESCRIPTION
This is a conditional patch which will lower Rust's baseline from Pentium4 to PentiumPro when cpu_flags_x86_sse2 isn't set. We can still use sse2 enabled bootstraps to build this so no further changes are required.

This is ready for further testing so sending as a PR to allow this.

Closes: https://bugs.gentoo.org/741708

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
