### PR TITLE
dev-ml/*: remove vendored `csexp` and `pp` before the build process

### DIFF
--- a/dev-ml/dune-build-info/dune-build-info-3.16.0-r1.ebuild
+++ b/dev-ml/dune-build-info/dune-build-info-3.16.0-r1.ebuild
@@ -7,21 +7,23 @@ inherit dune
 
 DESCRIPTION="Embed locations informations inside executable and libraries"
 HOMEPAGE="https://github.com/ocaml/dune"
-SRC_URI="https://github.com/ocaml/dune/archive/${PV}.tar.gz
-	-> dune-${PV}.tar.gz"
+SRC_URI="https://github.com/ocaml/dune/archive/${PV}.tar.gz -> dune-${PV}.tar.gz"
 S="${WORKDIR}/dune-${PV}"
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 arm ~arm64 ~ppc ppc64 x86"
+KEYWORDS="amd64 ppc64 x86"
 IUSE="+ocamlopt"
 RESTRICT="test"
 
-RDEPEND="
-	>=dev-ml/dune-3.12
-	~dev-ml/dune-private-libs-${PV}:=[ocamlopt=]
-"
+RDEPEND=">=dev-ml/dune-3.12"
 DEPEND="${RDEPEND}"
+
+src_prepare() {
+	default
+
+	rm -r vendor/{csexp,pp} || die
+}
 
 src_configure() {
 	:

--- a/dev-ml/dune-configurator/dune-configurator-3.16.0-r1.ebuild
+++ b/dev-ml/dune-configurator/dune-configurator-3.16.0-r1.ebuild
@@ -5,19 +5,28 @@ EAPI=8
 
 inherit dune
 
-DESCRIPTION="Embed locations informations inside executable and libraries"
+DESCRIPTION="Helper library for gathering system configuration"
 HOMEPAGE="https://github.com/ocaml/dune"
 SRC_URI="https://github.com/ocaml/dune/archive/${PV}.tar.gz -> dune-${PV}.tar.gz"
 S="${WORKDIR}/dune-${PV}"
 
-LICENSE="MIT"
+LICENSE="Apache-2.0"
 SLOT="0/${PV}"
-KEYWORDS="amd64 ppc64 x86"
+KEYWORDS="amd64 arm arm64 ~ppc ppc64 ~riscv x86"
 IUSE="+ocamlopt"
 RESTRICT="test"
 
-RDEPEND=">=dev-ml/dune-3.12"
-DEPEND="${RDEPEND}"
+BDEPEND=">=dev-ml/dune-3.12"
+DEPEND="
+	>=dev-ml/csexp-1.5:=[ocamlopt?]
+"
+RDEPEND="${DEPEND}"
+
+src_prepare() {
+	default
+
+	rm -r vendor/{csexp,pp} || die
+}
 
 src_configure() {
 	:

--- a/dev-ml/dune-private-libs/dune-private-libs-3.16.0-r4.ebuild
+++ b/dev-ml/dune-private-libs/dune-private-libs-3.16.0-r4.ebuild
@@ -5,9 +5,10 @@ EAPI=8
 
 inherit dune
 
-DESCRIPTION="Helper library for gathering system configuration"
+DESCRIPTION="Private libraries of Dune"
 HOMEPAGE="https://github.com/ocaml/dune"
-SRC_URI="https://github.com/ocaml/dune/archive/${PV}.tar.gz -> dune-${PV}.tar.gz"
+SRC_URI="https://github.com/ocaml/dune/archive/${PV}.tar.gz
+	-> dune-${PV}.tar.gz"
 S="${WORKDIR}/dune-${PV}"
 
 LICENSE="Apache-2.0"
@@ -18,16 +19,18 @@ RESTRICT="test"
 
 BDEPEND=">=dev-ml/dune-3.12"
 DEPEND="
-	>=dev-ml/csexp-1.5:=[ocamlopt?]
+	dev-ml/csexp:=[ocamlopt?]
 "
-RDEPEND="${DEPEND}"
+RDEPEND="${DEPEND}
+	!dev-ml/stdune
+	!dev-ml/dyn
+	!dev-ml/ordering
+"
 
 src_prepare() {
 	default
 
-	# This enables dune-configurator to use the vendored csexp module
-	sed -i 's/stdune.csexp/dune-configurator.csexp/' \
-		vendor/csexp/src/dune || die
+	rm -r vendor/{csexp,pp} || die
 }
 
 src_configure() {
@@ -35,5 +38,9 @@ src_configure() {
 }
 
 src_compile() {
-	dune-compile ${PN}
+	dune-compile ordering dyn stdune ${PN}
+}
+
+src_install() {
+	dune-install ordering dyn stdune ${PN}
 }

--- a/dev-ml/dune-site/dune-site-3.16.0-r1.ebuild
+++ b/dev-ml/dune-site/dune-site-3.16.0-r1.ebuild
@@ -5,36 +5,34 @@ EAPI=8
 
 inherit dune
 
-DESCRIPTION="Private libraries of Dune"
+DESCRIPTION="Embed locations informations inside executable and libraries"
 HOMEPAGE="https://github.com/ocaml/dune"
 SRC_URI="https://github.com/ocaml/dune/archive/${PV}.tar.gz
 	-> dune-${PV}.tar.gz"
 S="${WORKDIR}/dune-${PV}"
 
-LICENSE="Apache-2.0"
+LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="amd64 arm arm64 ~ppc ppc64 ~riscv x86"
+KEYWORDS="amd64 arm ~arm64 ~ppc ppc64 x86"
 IUSE="+ocamlopt"
 RESTRICT="test"
 
-BDEPEND=">=dev-ml/dune-3.12"
-DEPEND="
-	dev-ml/csexp:=[ocamlopt?]
+RDEPEND="
+	>=dev-ml/dune-3.12
+	~dev-ml/dune-private-libs-${PV}:=[ocamlopt=]
 "
-RDEPEND="${DEPEND}
-	!dev-ml/stdune
-	!dev-ml/dyn
-	!dev-ml/ordering
-"
+DEPEND="${RDEPEND}"
+
+src_prepare() {
+	default
+
+	rm -r vendor/{csexp,pp} || die
+}
 
 src_configure() {
 	:
 }
 
 src_compile() {
-	dune-compile ordering dyn stdune ${PN}
-}
-
-src_install() {
-	dune-install ordering dyn stdune ${PN}
+	dune-compile ${PN}
 }

--- a/dev-ml/xdg/xdg-3.16.0-r1.ebuild
+++ b/dev-ml/xdg/xdg-3.16.0-r1.ebuild
@@ -20,6 +20,12 @@ RESTRICT="test"
 BDEPEND=">=dev-ml/dune-3.12"
 RDEPEND="${DEPEND}"
 
+src_prepare() {
+	default
+
+	rm -r vendor/{csexp,pp} || die
+}
+
 src_configure() {
 	:
 }


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/940360

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
