### PR TITLE
app-emulation/virt-manager: Add py3_13 support

### DIFF
--- a/app-emulation/virt-manager/virt-manager-4.1.0-r2.ebuild
+++ b/app-emulation/virt-manager/virt-manager-4.1.0-r2.ebuild
@@ -1,0 +1,106 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+PYTHON_COMPAT=( python3_{10..13} )
+DISTUTILS_SINGLE_IMPL=1
+DISTUTILS_USE_SETUPTOOLS=no
+inherit gnome2 distutils-r1 optfeature
+
+DESCRIPTION="A graphical tool for administering virtual machines"
+HOMEPAGE="https://virt-manager.org https://github.com/virt-manager/virt-manager"
+
+if [[ ${PV} == *9999* ]]; then
+	EGIT_REPO_URI="https://github.com/virt-manager/virt-manager.git"
+	EGIT_BRANCH="main"
+	SRC_URI=""
+	inherit git-r3
+else
+	SRC_URI="https://virt-manager.org/download/sources/${PN}/${P}.tar.gz"
+	KEYWORDS="~amd64 ~arm64 ~ppc64 ~x86"
+fi
+
+LICENSE="GPL-2"
+SLOT="0"
+IUSE="gui policykit sasl"
+
+RDEPEND="
+	${PYTHON_DEPS}
+	|| ( dev-libs/libisoburn app-cdr/cdrtools )
+	>=app-emulation/libvirt-glib-1.0.0[introspection]
+	>=sys-libs/libosinfo-0.2.10[introspection]
+	$(python_gen_cond_dep '
+		dev-libs/libxml2[python,${PYTHON_USEDEP}]
+		dev-python/argcomplete[${PYTHON_USEDEP}]
+		>=dev-python/libvirt-python-6.10.0[${PYTHON_USEDEP}]
+		dev-python/pygobject:3[${PYTHON_USEDEP}]
+		dev-python/requests[${PYTHON_USEDEP}]
+	')
+	gui? (
+		gnome-base/dconf
+		>=net-libs/gtk-vnc-0.3.8[gtk3(+),introspection]
+		net-misc/spice-gtk[usbredir,gtk3,introspection,sasl?]
+		sys-apps/dbus[X]
+		x11-libs/gtk+:3[introspection]
+		x11-libs/gtksourceview:4[introspection]
+		x11-libs/vte:2.91[introspection]
+		policykit? ( sys-auth/polkit[introspection] )
+	)
+"
+DEPEND="${RDEPEND}"
+BDEPEND="dev-python/docutils"
+
+DOCS=( README.md NEWS.md )
+
+DISTUTILS_ARGS=(
+	--no-update-icon-cache
+	--no-compile-schemas
+)
+
+EPYTEST_IGNORE=(
+	# Wants to use /tmp osinfo config?
+	tests/test_cli.py
+
+	# These seem to be essentially coverage tests
+	tests/test_checkprops.py
+)
+
+distutils_enable_tests pytest
+
+python_configure() {
+	esetup.py configure --default-graphics=spice
+}
+
+python_test() {
+	export VIRTINST_TEST_SUITE_FORCE_LIBOSINFO=0
+
+	epytest
+}
+
+python_install() {
+	esetup.py install
+}
+
+pkg_preinst() {
+	if use gui ; then
+		gnome2_pkg_preinst
+
+		cd "${ED}" || die
+		export GNOME2_ECLASS_ICONS=$(find 'usr/share/virt-manager/icons' -maxdepth 1 -mindepth 1 -type d 2> /dev/null || die)
+	else
+		rm -r "${ED}/usr/share/virt-manager/ui/" || die
+		rm -r "${ED}/usr/share/virt-manager/icons/" || die
+		rm -r "${ED}/usr/share/icons/" || die
+		rm -r "${ED}/usr/share/applications/virt-manager.desktop" || die
+		rm -r "${ED}/usr/bin/virt-manager" || die
+	fi
+}
+
+pkg_postinst() {
+	use gui && gnome2_pkg_postinst
+
+	optfeature "SSH_ASKPASS program implementation" lxqt-base/lxqt-openssh-askpass net-misc/ssh-askpass-fullscreen net-misc/x11-ssh-askpass
+	optfeature "QEMU host support" app-emulation/qemu[usbredir,spice]
+	optfeature "virt-install --location ISO support" dev-libs/libisoburn
+}

--- a/app-emulation/virt-manager/virt-manager-9999.ebuild
+++ b/app-emulation/virt-manager/virt-manager-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..13} )
 DISTUTILS_SINGLE_IMPL=1
 DISTUTILS_USE_SETUPTOOLS=no
 inherit gnome2 distutils-r1 optfeature


### PR DESCRIPTION
```
tests/test_capabilities.py::testCapsCPUFeaturesNewSyntax PASSED                 [ 1/99]
tests/test_capabilities.py::testCapsUtilFuncs PASSED                            [ 2/99]
tests/test_capabilities.py::testDomainCapabilities PASSED                       [ 3/99]
tests/test_capabilities.py::testDomainCapabilitiesx86 PASSED                    [ 4/99]
tests/test_capabilities.py::testDomainCapabilitiesAArch64 PASSED                [ 5/99]
tests/test_cloner.py::test_clone_unmanaged PASSED                               [ 6/99]
tests/test_cloner.py::test_generate_name PASSED                                 [ 7/99]
tests/test_conn.py::test_misc PASSED                                            [ 8/99]
tests/test_conn.py::test_default_uri PASSED                                     [ 9/99]
tests/test_conn.py::test_poll PASSED                                            [10/99]
tests/test_disk.py::test_disk_numtotarget PASSED                                [11/99]
tests/test_disk.py::test_disk_dir_searchable PASSED                             [12/99]
tests/test_disk.py::test_disk_path_in_use_kernel PASSED                         [13/99]
tests/test_disk.py::test_disk_diskbackend_misc PASSED                           [14/99]
tests/test_disk.py::test_disk_diskbackend_parse PASSED                          [15/99]
tests/test_disk.py::test_disk_rbd_path PASSED                                   [16/99]
tests/test_misc.py::test_misc_cpu_topology PASSED                               [17/99]
tests/test_misc.py::test_misc_guest_osinfo_metadata PASSED                      [18/99]
tests/test_misc.py::test_misc_nonpredicatble_generate PASSED                    [19/99]
tests/test_misc.py::test_misc_support_cornercases PASSED                        [20/99]
tests/test_misc.py::test_misc_osxml_cornercases PASSED                          [21/99]
tests/test_misc.py::test_misc_cpu_cornercases PASSED                            [22/99]
tests/test_misc.py::test_misc_meter PASSED                                      [23/99]
tests/test_nodedev.py::testFunkyChars PASSED                                    [24/99]
tests/test_nodedev.py::testNetDevice PASSED                                     [25/99]
tests/test_nodedev.py::testPCIDevice PASSED                                     [26/99]
tests/test_nodedev.py::testUSBDevDevice PASSED                                  [27/99]
tests/test_nodedev.py::testSCSIDevice PASSED                                    [28/99]
tests/test_nodedev.py::testStorageDevice PASSED                                 [29/99]
tests/test_nodedev.py::testSCSIBus PASSED                                       [30/99]
tests/test_nodedev.py::testDRMDevice PASSED                                     [31/99]
tests/test_nodedev.py::testDASDMdev PASSED                                      [32/99]
tests/test_nodedev.py::testAPQNMdev PASSED                                      [33/99]
tests/test_nodedev.py::testPCIMdev PASSED                                       [34/99]
tests/test_nodedev.py::testPCIMdevNewFormat PASSED                              [35/99]
tests/test_nodedev.py::testNodeDev2USB1 PASSED                                  [36/99]
tests/test_nodedev.py::testNodeDev2USB2 PASSED                                  [37/99]
tests/test_nodedev.py::testNodeDev2PCI PASSED                                   [38/99]
tests/test_nodedev.py::testNodeDevFail PASSED                                   [39/99]
tests/test_osdict.py::test_list_os PASSED                                       [40/99]
tests/test_osdict.py::test_recommended_resources PASSED                         [41/99]
tests/test_osdict.py::test_urldetct_matching_distros PASSED                     [42/99]
tests/test_osdict.py::test_tree_url PASSED                                      [43/99]
tests/test_osdict.py::test_kernel_url PASSED                                    [44/99]
tests/test_osdict.py::test_related_to PASSED                                    [45/99]
tests/test_osdict.py::test_drivers PASSED                                       [46/99]
tests/test_storage.py::testDirPool PASSED                                       [47/99]
tests/test_storage.py::testFSPool PASSED                                        [48/99]
tests/test_storage.py::testNetFSPool PASSED                                     [49/99]
tests/test_storage.py::testLVPool PASSED                                        [50/99]
tests/test_storage.py::testDiskPool PASSED                                      [51/99]
tests/test_storage.py::testISCSIPool PASSED                                     [52/99]
tests/test_storage.py::testSCSIPool PASSED                                      [53/99]
tests/test_storage.py::testMpathPool PASSED                                     [54/99]
tests/test_storage.py::testGlusterPool PASSED                                   [55/99]
tests/test_storage.py::testRBDPool PASSED                                       [56/99]
tests/test_storage.py::testMisc PASSED                                          [57/99]
tests/test_storage.py::testEnumerateLogical PASSED                              [58/99]
tests/test_uriparse.py::testURIs PASSED                                         [59/99]
tests/test_uriparse.py::test_magicuri_connver PASSED                            [60/99]
tests/test_urldetect.py::test_debian PASSED                                     [61/99]
tests/test_urldetect.py::test_ubuntu PASSED                                     [62/99]
tests/test_urldetect.py::test_fedora PASSED                                     [63/99]
tests/test_urldetect.py::test_rhel PASSED                                       [64/99]
tests/test_urldetect.py::test_centos PASSED                                     [65/99]
tests/test_urldetect.py::test_opensuse PASSED                                   [66/99]
tests/test_urldetect.py::test_suse PASSED                                       [67/99]
tests/test_urldetect.py::test_mageia PASSED                                     [68/99]
tests/test_urldetect.py::test_misc PASSED                                       [69/99]
tests/test_xmlparse.py::testAlterGuest PASSED                                   [70/99]
tests/test_xmlparse.py::testAlterCpuMode PASSED                                 [71/99]
tests/test_xmlparse.py::testAlterDisk PASSED                                    [72/99]
tests/test_xmlparse.py::testAlterDevicesBootorder PASSED                        [73/99]
tests/test_xmlparse.py::testSingleDisk PASSED                                   [74/99]
tests/test_xmlparse.py::testAlterChars PASSED                                   [75/99]
tests/test_xmlparse.py::testAlterNics PASSED                                    [76/99]
tests/test_xmlparse.py::testQEMUXMLNS PASSED                                    [77/99]
tests/test_xmlparse.py::testAddRemoveDevices PASSED                             [78/99]
tests/test_xmlparse.py::testChangeKVMMedia PASSED                               [79/99]
tests/test_xmlparse.py::testGuestBootorder PASSED                               [80/99]
tests/test_xmlparse.py::testDiskChangeBus PASSED                                [81/99]
tests/test_xmlparse.py::testChangeSnapshot PASSED                               [82/99]
tests/test_xmlparse.py::testFSPool PASSED                                       [83/99]
tests/test_xmlparse.py::testISCSIPool PASSED                                    [84/99]
tests/test_xmlparse.py::testGlusterPool PASSED                                  [85/99]
tests/test_xmlparse.py::testRBDPool PASSED                                      [86/99]
tests/test_xmlparse.py::testVol PASSED                                          [87/99]
tests/test_xmlparse.py::testNetMulti PASSED                                     [88/99]
tests/test_xmlparse.py::testNetOpen PASSED                                      [89/99]
tests/test_xmlparse.py::testNetVfPool PASSED                                    [90/99]
tests/test_xmlparse.py::testCPUUnknownClear PASSED                              [91/99]
tests/test_xmlparse.py::testDomainRoundtrip PASSED                              [92/99]
tests/test_xmlparse.py::testYesNoUnexpectedParse PASSED                         [93/99]
tests/test_xmlparse.py::testXMLBuilderCoverage PASSED                           [94/99]
tests/test_xmlparse.py::testReplaceChildParse PASSED                            [95/99]
tests/test_xmlparse.py::testGuestXMLDeviceMatch PASSED                          [96/99]
tests/test_xmlparse.py::testControllerAttachedDevices PASSED                    [97/99]
tests/test_xmlparse.py::testRefreshMachineType PASSED                           [98/99]
tests/test_xmlparse.py::testDiskSourceAbspath PASSED                            [99/99]
```

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
