### PR TITLE
games-util/lutris: Enable py3_13

### DIFF
--- a/dev-python/moddb/moddb-0.11.0.ebuild
+++ b/dev-python/moddb/moddb-0.11.0.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..13} )
 
 inherit distutils-r1
 

--- a/dev-python/pypresence/pypresence-4.3.0.ebuild
+++ b/dev-python/pypresence/pypresence-4.3.0.ebuild
@@ -1,10 +1,10 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..13} )
 
 inherit distutils-r1
 

--- a/games-util/lutris/lutris-0.5.17.ebuild
+++ b/games-util/lutris/lutris-0.5.17.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..13} )
 PYTHON_REQ_USE="sqlite,threads(+)"
 
 inherit meson python-single-r1 optfeature virtualx xdg

--- a/games-util/lutris/lutris-9999.ebuild
+++ b/games-util/lutris/lutris-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..13} )
 PYTHON_REQ_USE="sqlite,threads(+)"
 
 inherit meson python-single-r1 optfeature virtualx xdg


### PR DESCRIPTION
```
tests/runners/test_pcsx2.py::TestPCSX2Runner::test_play PASSED                [  1/109]
tests/runners/test_pcsx2.py::TestPCSX2Runner::test_play_full_boot PASSED      [  2/109]
tests/runners/test_pcsx2.py::TestPCSX2Runner::test_play_fullscreen PASSED     [  3/109]
tests/runners/test_pcsx2.py::TestPCSX2Runner::test_play_iso_does_not_exist PASSED [  4/109]
tests/runners/test_pcsx2.py::TestPCSX2Runner::test_play_nogui PASSED          [  5/109]
tests/runners/test_runners.py::ImportRunnerTest::test_game_config_overrides_all PASSED [  6/109]
tests/runners/test_runners.py::ImportRunnerTest::test_get_system_config PASSED [  7/109]
tests/runners/test_runners.py::ImportRunnerTest::test_import_module PASSED    [  8/109]
tests/runners/test_runners.py::ImportRunnerTest::test_options PASSED          [  9/109]
tests/runners/test_runners.py::ImportRunnerTest::test_runner_config_overrides_system_config PASSED [ 10/109]
tests/runners/test_runners.py::ImportRunnerTest::test_runner_modules PASSED   [ 11/109]
tests/runners/test_runners.py::ImportRunnerTest::test_system_config_with_no_system_yml PASSED [ 12/109]
tests/runners/test_scummvm.py::TestScummvm::test_custom_data_dir PASSED       [ 13/109]
tests/runners/test_scummvm.py::TestScummvm::test_no_executable PASSED         [ 14/109]
tests/runners/test_snes9x.py::TestSnes9x::test_set_option PASSED              [ 15/109]
tests/runners/test_vita3k.py::TestVita3kRunner::test_empty_title_id PASSED    [ 16/109]
tests/runners/test_vita3k.py::TestVita3kRunner::test_play PASSED              [ 17/109]
tests/runners/test_vita3k.py::TestVita3kRunner::test_play_fullscreen PASSED   [ 18/109]
tests/test_api.py::TestApi::test_get_default_runner_version_info PASSED       [ 19/109]
tests/test_dialogs.py::TestGameDialogCommon::test_get_runner_liststore PASSED [ 20/109]
tests/test_dialogs.py::TestGameDialog::test_dialog PASSED                     [ 21/109]
tests/test_dialogs.py::TestSort::test_both_none PASSED                        [ 22/109]
tests/test_dialogs.py::TestSort::test_one_none PASSED                         [ 23/109]
tests/test_dialogs.py::TestSort::test_sort_int PASSED                         [ 24/109]
tests/test_dialogs.py::TestSort::test_sort_mismatched_types PASSED            [ 25/109]
tests/test_dialogs.py::TestSort::test_sort_strings_with_caps PASSED           [ 26/109]
tests/test_dialogs.py::TestSort::test_sort_strings_with_no_caps PASSED        [ 27/109]
tests/test_dialogs.py::TestSort::test_sort_strings_with_one_caps PASSED       [ 28/109]
tests/test_glxinfo.py::TestAMDGlxInfo::test_can_get_name_of_display PASSED    [ 29/109]
tests/test_glxinfo.py::TestNvidiaGlxInfo::test_can_get_name_of_display PASSED [ 30/109]
tests/test_installer.py::TestScriptInterpreter::test_get_command_doesnt_return_private_methods PASSED [ 31/109]
tests/test_installer.py::TestScriptInterpreter::test_get_command_returns_a_method PASSED [ 32/109]
tests/test_installer.py::TestScriptInterpreter::test_move_requires_src_and_dst PASSED [ 33/109]
tests/test_installer.py::TestScriptInterpreter::test_script_with_correct_values_is_valid PASSED [ 34/109]
tests/test_lutris_wrapper.py::LutrisWrapperTestCase::test_cleanup_children PASSED [ 35/109]
tests/test_lutris_wrapper.py::LutrisWrapperTestCase::test_excluded_initial_process PASSED [ 36/109]
tests/test_moddb_helper.py::ModDBHelperTests::test_ctor_custom_method PASSED  [ 37/109]
tests/test_moddb_helper.py::ModDBHelperTests::test_ctor_default_method PASSED [ 38/109]
tests/test_moddb_helper.py::ModDBHelperTests::test_is_moddb_url_has_www_success PASSED [ 39/109]
tests/test_moddb_helper.py::ModDBHelperTests::test_is_moddb_url_no_slug_has_www_success PASSED [ 40/109]
tests/test_moddb_helper.py::ModDBHelperTests::test_is_moddb_url_no_slug_no_www_success PASSED [ 41/109]
tests/test_moddb_helper.py::ModDBHelperTests::test_is_moddb_url_no_slug_other_subdomain_failure PASSED [ 42/109]
tests/test_moddb_helper.py::ModDBHelperTests::test_is_moddb_url_no_slug_random_domain_failure PASSED [ 43/109]
tests/test_moddb_helper.py::ModDBHelperTests::test_is_moddb_url_no_www_success PASSED [ 44/109]
tests/test_moddb_helper.py::ModDBHelperTests::test_is_moddb_url_other_subdomain_failure PASSED [ 45/109]
tests/test_moddb_helper.py::ModDBHelperTests::test_is_moddb_url_random_domain_failure PASSED [ 46/109]
tests/test_moddb_helper.py::ModDBHelperTests::test_transform_url_missing_lib_noop PASSED [ 47/109]
tests/test_moddb_helper.py::ModDBHelperTests::test_transform_url_multiple_mirror_select_lowest_capacity PASSED [ 48/109]
tests/test_moddb_helper.py::ModDBHelperTests::test_transform_url_no_mirrors_throws PASSED [ 49/109]
tests/test_moddb_helper.py::ModDBHelperTests::test_transform_url_page_type_correct_happy_path PASSED [ 50/109]
tests/test_moddb_helper.py::ModDBHelperTests::test_transform_url_page_type_incorrect_throws PASSED [ 51/109]
tests/test_moddb_helper.py::ModDBHelperTests::test_transform_url_single_mirror_happy_path PASSED [ 52/109]
tests/test_moddb_helper.py::ModDBHelperTests::test_transform_url_url_is_mirror_no_www_throws PASSED [ 53/109]
tests/test_moddb_helper.py::ModDBHelperTests::test_transform_url_url_is_mirror_with_www_throws PASSED [ 54/109]
tests/test_moddb_helper.py::ModDBHelperTests::test_transform_url_url_match_happy_path PASSED [ 55/109]
tests/test_moddb_helper.py::ModDBHelperTests::test_transform_url_url_not_match_throws PASSED [ 56/109]
tests/test_pga.py::TestPersonnalGameArchive::test_add_game PASSED             [ 57/109]
tests/test_pga.py::TestPersonnalGameArchive::test_can_filter_by_installed_games PASSED [ 58/109]
tests/test_pga.py::TestPersonnalGameArchive::test_delete_game PASSED          [ 59/109]
tests/test_pga.py::TestPersonnalGameArchive::test_filter PASSED               [ 60/109]
tests/test_pga.py::TestPersonnalGameArchive::test_game_with_same_slug_is_updated PASSED [ 61/109]
tests/test_pga.py::TestPersonnalGameArchive::test_get_game_list PASSED        [ 62/109]
tests/test_pga.py::TestDbCreator::test_can_create_table PASSED                [ 63/109]
tests/test_pga.py::TestDbCreator::test_can_generate_fields PASSED             [ 64/109]
tests/test_pga.py::TestMigration::test_add_field PASSED                       [ 65/109]
tests/test_pga.py::TestMigration::test_can_know_if_table_exists PASSED        [ 66/109]
tests/test_pga.py::TestMigration::test_can_migrate PASSED                     [ 67/109]
tests/test_pga.py::TestMigration::test_cant_add_existing_field PASSED         [ 68/109]
tests/test_pga.py::TestMigration::test_cant_create_empty_table PASSED         [ 69/109]
tests/test_pga.py::TestMigration::test_get_schema PASSED                      [ 70/109]
tests/test_registry.py::TestWineRegistry::test_can_clear_a_key PASSED         [ 71/109]
tests/test_registry.py::TestWineRegistry::test_can_get_dword_value PASSED     [ 72/109]
tests/test_registry.py::TestWineRegistry::test_can_get_meta PASSED            [ 73/109]
tests/test_registry.py::TestWineRegistry::test_can_get_string_value PASSED    [ 74/109]
tests/test_registry.py::TestWineRegistry::test_can_get_timestamp_as_float PASSED [ 75/109]
tests/test_registry.py::TestWineRegistry::test_can_get_timestamp_as_int PASSED [ 76/109]
tests/test_registry.py::TestWineRegistry::test_can_load_registry PASSED       [ 77/109]
tests/test_registry.py::TestWineRegistry::test_can_query_registry PASSED      [ 78/109]
tests/test_registry.py::TestWineRegistry::test_can_render_key PASSED          [ 79/109]
tests/test_registry.py::TestWineRegistry::test_can_render_system_reg PASSED   [ 80/109]
tests/test_registry.py::TestWineRegistry::test_can_set_value_to_a_new_key PASSED [ 81/109]
tests/test_registry.py::TestWineRegistry::test_can_set_value_to_a_new_sub_key PASSED [ 82/109]
tests/test_registry.py::TestWineRegistry::test_can_set_value_to_existing_subkey PASSED [ 83/109]
tests/test_registry.py::TestWineRegistry::test_render_user_reg PASSED         [ 84/109]
tests/test_registry.py::TestWineRegistryKey::test_creation_by_key_def_parses PASSED [ 85/109]
tests/test_registry.py::TestWineRegistryKey::test_creation_by_path_parses PASSED [ 86/109]
tests/test_registry.py::TestWineRegistryKey::test_parse_registry_key PASSED   [ 87/109]
tests/test_resources.py::TestInstallerUrls::test_action_rungame PASSED        [ 88/109]
tests/test_resources.py::TestInstallerUrls::test_action_rungame_launch_config PASSED [ 89/109]
tests/test_resources.py::TestInstallerUrls::test_action_rungameid PASSED      [ 90/109]
tests/test_resources.py::TestInstallerUrls::test_legacy_url PASSED            [ 91/109]
tests/test_utils.py::TestFileUtils::test_file_ids_are_correctly_transformed PASSED [ 92/109]
tests/test_utils.py::TestFileUtils::test_file_ids_are_substitued PASSED       [ 93/109]
tests/test_utils.py::TestSteamUtils::test_dict_to_vdf PASSED                  [ 94/109]
tests/test_utils.py::TestStringUtils::test_get_formatted_playtime PASSED      [ 95/109]
tests/test_utils.py::TestStringUtils::test_gtk_safe_urls PASSED               [ 96/109]
tests/test_utils.py::TestStringUtils::test_parse_playtime PASSED              [ 97/109]
tests/test_utils.py::TestStringUtils::test_slugify_with_nonwestern_name PASSED [ 98/109]
tests/test_utils.py::TestVersionSort::test_parse_version PASSED               [ 99/109]
tests/test_utils.py::TestVersionSort::test_version_sorting_supports_extra_strings PASSED [100/109]
tests/test_utils.py::TestVersionSort::test_versions_are_correctly_sorted PASSED [101/109]
tests/test_utils.py::TestVersionSort::test_versions_can_be_reversed PASSED    [102/109]
tests/test_utils.py::TestEvilConfigParser::test_config_parse_can_write_to_disk PASSED [103/109]
tests/test_utils.py::TestUnpackDependencies::test_dependency_options PASSED   [104/109]
tests/test_utils.py::TestUnpackDependencies::test_multiple_dependencies PASSED [105/109]
tests/test_utils.py::TestUnpackDependencies::test_single_dependency PASSED    [106/109]
tests/test_utils.py::TestUnpackDependencies::test_strips_extra_commas PASSED  [107/109]
tests/test_utils.py::TestSubstitute::test_can_sub_game_files_with_dashes_in_key PASSED [108/109]
tests/test_wine.py::TestDllOverrides::test_env_format PASSED                  [109/109]
```

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
