### PR TITLE
net-p2p/deluge: Enable py313

### DIFF
--- a/dev-libs/boost/boost-1.85.0-r1.ebuild
+++ b/dev-libs/boost/boost-1.85.0-r1.ebuild
@@ -11,7 +11,7 @@ EAPI=8
 
 # FIXME: cleanup subslot after 1.85.0
 
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..13} )
 
 inherit flag-o-matic multiprocessing python-r1 toolchain-funcs multilib-minimal
 

--- a/dev-libs/boost/boost-1.86.0.ebuild
+++ b/dev-libs/boost/boost-1.86.0.ebuild
@@ -9,7 +9,7 @@ EAPI=8
 # (e.g. https://www.boost.org/users/history/version_1_83_0.html)
 # Note that the latter may sometimes feature patches not on the former too.
 
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..13} )
 
 inherit flag-o-matic multiprocessing python-r1 toolchain-funcs multilib-minimal
 

--- a/net-libs/libtorrent-rasterbar/libtorrent-rasterbar-2.0.10.ebuild
+++ b/net-libs/libtorrent-rasterbar/libtorrent-rasterbar-2.0.10.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..13} )
 
 inherit cmake python-single-r1
 

--- a/net-p2p/deluge/deluge-2.1.1-r5.ebuild
+++ b/net-p2p/deluge/deluge-2.1.1-r5.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..13} )
 DISTUTILS_USE_PEP517=setuptools
 DISTUTILS_SINGLE_IMPL=1
 inherit distutils-r1 systemd xdg

--- a/net-p2p/deluge/deluge-9999.ebuild
+++ b/net-p2p/deluge/deluge-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..13} )
 DISTUTILS_USE_PEP517=setuptools
 DISTUTILS_SINGLE_IMPL=1
 inherit distutils-r1 systemd xdg


### PR DESCRIPTION
Enable python3.13 support in Deluge

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
