### PR TITLE
net-wireless/iwgtk: Add dependency x11-base/xorg-proto to build

### DIFF
--- a/net-wireless/iwgtk/iwgtk-0.9.ebuild
+++ b/net-wireless/iwgtk/iwgtk-0.9.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2020-2023 Gentoo Authors
+# Copyright 2020-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -11,11 +11,8 @@ SRC_URI="https://github.com/J-Lentz/iwgtk/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 LICENSE="GPL-3+"
 SLOT="0"
 KEYWORDS="~amd64"
-IUSE=""
 
-BDEPEND="app-text/scdoc"
-
-DEPEND="
+COMMON_DEPEND="
 	app-accessibility/at-spi2-core:2
 	dev-libs/glib:2
 	gui-libs/gtk:4
@@ -25,7 +22,14 @@ DEPEND="
 	x11-libs/pango:0
 "
 
+BDEPEND="app-text/scdoc"
+
+DEPEND="
+	${COMMON_DEPEND}
+	x11-base/xorg-proto
+"
+
 RDEPEND="
-	${DEPEND}
+	${COMMON_DEPEND}
 	>=net-wireless/iwd-1.29
 "


### PR DESCRIPTION
Add dependency x11-base/xorg-proto to build

> meson.build:26:4: ERROR: Dependency lookup for gtk4 with method 'pkgconfig' failed: Could not generate cflags for gtk4:
> Package xproto was not found in the pkg-config search path.