### PR TITLE
net-misc/networkmanager: ~hppa keyword

### DIFF
--- a/net-libs/libndp/libndp-1.9.ebuild
+++ b/net-libs/libndp/libndp-1.9.ebuild
@@ -11,7 +11,7 @@ SRC_URI="http://libndp.org/files/${P}.tar.gz"
 LICENSE="LGPL-2.1+"
 SLOT="0"
 
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86"
 
 multilib_src_configure() {
 	ECONF_SOURCE="${S}" \

--- a/net-misc/libteam/libteam-1.32-r1.ebuild
+++ b/net-misc/libteam/libteam-1.32-r1.ebuild
@@ -10,7 +10,7 @@ if [[ ${PV} == *9999 ]] ; then
 	inherit git-r3
 else
 	SRC_URI="https://github.com/jpirko/libteam/archive/v${PV}.tar.gz -> ${P}.tar.gz"
-	KEYWORDS="amd64 ~arm arm64 ~loong ppc ppc64 ~riscv x86"
+	KEYWORDS="amd64 ~arm arm64 ~hppa ~loong ppc ppc64 ~riscv x86"
 fi
 
 DESCRIPTION="Library and tools set for controlling team network device"

--- a/net-misc/libteam/libteam-9999.ebuild
+++ b/net-misc/libteam/libteam-9999.ebuild
@@ -10,7 +10,7 @@ if [[ ${PV} == *9999 ]] ; then
 	inherit git-r3
 else
 	SRC_URI="https://github.com/jpirko/libteam/archive/v${PV}.tar.gz -> ${P}.tar.gz"
-	KEYWORDS="~amd64 ~arm ~arm64 ~loong ~ppc ~ppc64 ~riscv ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~x86"
 fi
 
 DESCRIPTION="Library and tools set for controlling team network device"

--- a/net-misc/networkmanager/networkmanager-1.48.4.ebuild
+++ b/net-misc/networkmanager/networkmanager-1.48.4.ebuild
@@ -14,7 +14,7 @@ HOMEPAGE="https://wiki.gnome.org/Projects/NetworkManager"
 LICENSE="GPL-2+ LGPL-2.1+"
 SLOT="0"
 
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86"
 
 IUSE="audit bluetooth +concheck connection-sharing debug dhclient dhcpcd elogind gnutls +gtk-doc +introspection iptables iwd psl libedit +nss nftables +modemmanager ofono ovs policykit +ppp resolvconf selinux syslog systemd teamd test +tools vala +wext +wifi"
 RESTRICT="!test? ( test )"

--- a/net-wireless/wireless-regdb/wireless-regdb-20240508.ebuild
+++ b/net-wireless/wireless-regdb/wireless-regdb-20240508.ebuild
@@ -13,7 +13,7 @@ S="${WORKDIR}/${MY_P}"
 
 LICENSE="ISC"
 SLOT="0"
-KEYWORDS="~alpha amd64 arm arm64 ~loong ~mips ppc ppc64 ~riscv sparc x86"
+KEYWORDS="~alpha amd64 arm arm64 ~hppa ~loong ~mips ppc ppc64 ~riscv sparc x86"
 REQUIRED_USE="kernel_linux"
 
 pkg_pretend() {

--- a/net-wireless/wpa_supplicant/wpa_supplicant-2.10-r5.ebuild
+++ b/net-wireless/wpa_supplicant/wpa_supplicant-2.10-r5.ebuild
@@ -13,7 +13,7 @@ if [ "${PV}" = "9999" ]; then
 	inherit git-r3
 	EGIT_REPO_URI="https://w1.fi/hostap.git"
 else
-	KEYWORDS="~alpha amd64 arm arm64 ~loong ~mips ppc ppc64 ~riscv ~sparc x86"
+	KEYWORDS="~alpha amd64 arm arm64 ~hppa ~loong ~mips ppc ppc64 ~riscv ~sparc x86"
 	SRC_URI="https://w1.fi/releases/${P}.tar.gz"
 fi
 

--- a/net-wireless/wpa_supplicant/wpa_supplicant-9999.ebuild
+++ b/net-wireless/wpa_supplicant/wpa_supplicant-9999.ebuild
@@ -13,7 +13,7 @@ if [ "${PV}" = "9999" ]; then
 	inherit git-r3
 	EGIT_REPO_URI="https://w1.fi/hostap.git"
 else
-	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~loong ~mips ~ppc ~ppc64 ~riscv ~sparc ~x86"
+	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~mips ~ppc ~ppc64 ~riscv ~sparc ~x86"
 	SRC_URI="https://w1.fi/releases/${P}.tar.gz"
 fi
 

--- a/profiles/arch/hppa/package.use.mask
+++ b/profiles/arch/hppa/package.use.mask
@@ -4,6 +4,11 @@
 # NOTE: When masking a USE flag due to missing keywords, please file a keyword
 # request bug for the hppa arch.
 
+# Ian Jordan <immoloism@gmail.com> (2024-11-11)
+# net-misc/networkmanager modemmanger and iwd not keyworded
+net-misc/networkmanager modemmanager iwd
+
+
 # Felix Janda <felix.janda@posteo.de> (2024-10-20)
 # requires dev-libs/libcss and net-libs/libdom to be keyworded
 www-client/elinks libcss

--- a/profiles/arch/hppa/use.mask
+++ b/profiles/arch/hppa/use.mask
@@ -181,10 +181,6 @@ ocamlopt
 # sys-devel/gcc fails to build with USE=d (bug #178896).
 d
 
-# Jeroen Roovers <jer@gentoo.org> (2007-05-02)
-# Lack of user/dev support for WiFi (bug #176517)
-networkmanager
-
 # Samuli Suominen <drac@gentoo.org> (2007-03-02)
 # See bug #157881#c3
 battery
@@ -231,10 +227,6 @@ ieee1394
 # Guy Martin <gmsoft@gentoo.org> (2005-06-25)
 # mono is not yet supported on hppa
 mono
-
-# Guy Martin <gmsoft@gentoo.org> (2004-08-08)
-# Wifi stuff not test yet because of lack of hardware
-wifi
 
 # Guy Martin <gmsoft@gentoo.org> (2003-02-26)
 # No lirc support on hppa


### PR DESCRIPTION
Starting keyword request so we can add networkmanager support to all installcds in Gentoo.

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
