### PR TITLE
toolchain.eclass: Try harder to disable cet automagic

### DIFF
--- a/eclass/toolchain.eclass
+++ b/eclass/toolchain.eclass
@@ -1526,10 +1526,20 @@ toolchain_src_configure() {
 	fi
 
 	if in_iuse cet ; then
-		if [[ ${CTARGET} == i[[34567]]86-*-linux* || ${CTARGET} == x86_64-*-gnu* ]] ; then
-			confgcc+=( $(use_enable cet) )
-		fi
-		[[ ${CTARGET} == aarch64-*-gnu* ]] && confgcc+=( $(use_enable cet standard-branch-protection) )
+		# Usage: triple_arch triple_env cet_name
+		enable_cet_for() {
+			if [[ ${CTARGET} == ${1}-* ]] ; then
+				if use cet && [[ ${CTARGET} == *-${2}* ]]; then
+					confgcc+=( --enable-${3} )
+				else
+					confgcc+=( --disable-${3} )
+				fi
+			fi
+		}
+
+		enable_cet_for 'i[34567]86' 'linux' 'cet'
+		enable_cet_for 'x86_64' 'gnu' 'cet'
+		enable_cet_for 'aarch64' 'gnu' 'standard-branch-protection'
 	fi
 
 	if in_iuse systemtap ; then


### PR DESCRIPTION
On arches that support USE=cet (those being amd64, arm64, and, x86) always pass --enable-cet or --disable-cet (or aarch64 standard-branch-protection equivalent) to prevent any configure automagic from happening.

Preserve the same CTARGET logic so only pass --enable-cet if the target environment supports it and if `use cet`.

Also fix the regex `i[[34567]]86` as that matches an i, followed by any of the digits from 3 to 7 or the [ character, followed by ], followed by 8, followed by 6. The regex originated in config/cet.m4 which uses [] for quotes.

The automatic specifically breaks gcc[d] on musl because it prevents the code from using an internal assembly implementation for a function and deferring to using an implementation that would be provided by sys-libs/libucontext which results in undefined symbol errors:

```
/usr/lib/gcc/x86_64-pc-linux-musl/11/../../../../x86_64-pc-linux-musl/bin/ld:
/usr/lib/gcc/x86_64-pc-linux-musl/11/libgphobos.a(fiber.o): in function `_D4core6thread5fiber5Fiber9initStackMFNbNiZv':
(.text._D4core6thread5fiber5Fiber9initStackMFNbNiZv+0x2e): undefined reference to `getcontext'
/usr/lib/gcc/x86_64-pc-linux-musl/11/../../../../x86_64-pc-linux-musl/bin/ld: (.text._D4core6thread5fiber5Fiber9initStackMFNbNiZv+0x5f): undefined reference to `makecontext'
/usr/lib/gcc/x86_64-pc-linux-musl/11/../../../../x86_64-pc-linux-musl/bin/ld: /usr/lib/gcc/x86_64-pc-linux-musl/11/libgphobos.a(fiber.o): in function `_D4core6thread5fiber5Fiber12_staticCtor1FZv':
(.text._D4core6thread5fiber5Fiber12_staticCtor1FZv+0x1c): undefined reference to `getcontext'
```

Bug: https://bugs.gentoo.org/939874

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
