### PR TITLE
Mail mta/nullmailer tmpfs

### DIFF
--- a/mail-mta/nullmailer/files/init.d-nullmailer-r6
+++ b/mail-mta/nullmailer/files/init.d-nullmailer-r6
@@ -42,8 +42,21 @@ checkconfig() {
 	fi
 }
 
+checkdirtree() {
+	checkpath --directory \
+		  --owner nullmail:nullmail \
+		  --mode 0770 \
+		  /var/spool/nullmailer/{failed,queue,tmp} \
+		  /var/log/nullmailer
+	checkpath --pipe \
+		  --owner nullmail:nullmail \
+		  --mode 0660 \
+		  /var/spool/nullmailer/trigger
+}
+
 start_pre() {
 	checkconfig
+	checkdirtree # Account for setups where /var/spool/nullmailer is on tmpfs
 }
 
 stop_pre() {

--- a/mail-mta/nullmailer/files/init.d-nullmailer-r6
+++ b/mail-mta/nullmailer/files/init.d-nullmailer-r6
@@ -1,5 +1,5 @@
 #!/sbin/openrc-run
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2024 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License, v2 or later
 
 command="/usr/sbin/nullmailer-send"


### PR DESCRIPTION
Added a function to an init script to ensure directory structure

This is useful for running nullmailer fully in tmpfs, which prevents failing to
get a SMART notification if a drive starts failing and fs gets remounted as
read-only.

Updated copyright year

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
