### PR TITLE
x11-base/xorg-server: Add Oz to replace-flags for x86

### DIFF
--- a/x11-base/xorg-server/xorg-server-21.1.13-r1.ebuild
+++ b/x11-base/xorg-server/xorg-server-21.1.13-r1.ebuild
@@ -111,6 +111,7 @@ PATCHES=(
 src_configure() {
 	# bug #835653
 	use x86 && replace-flags -Os -O2
+	use x86 && replace-flags -Oz -O2
 
 	# localstatedir is used for the log location; we need to override the default
 	#	from ebuild.sh

--- a/x11-base/xorg-server/xorg-server-9999.ebuild
+++ b/x11-base/xorg-server/xorg-server-9999.ebuild
@@ -104,6 +104,7 @@ PATCHES=(
 src_configure() {
 	# bug #835653
 	use x86 && replace-flags -Os -O2
+	use x86 && replace-flags -Oz -O2
 
 	use debug && EMESON_BUILDTYPE=debug
 


### PR DESCRIPTION
Like Os, Oz has the same issue so added a second line to replace the flag.

Bug: https://bugs.gentoo.org/835653

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
