### PR TITLE
dev-cpp/abseil-cpp: fix patchfile name

### DIFF
--- a/dev-cpp/abseil-cpp/abseil-cpp-20230802.0-r4.ebuild
+++ b/dev-cpp/abseil-cpp/abseil-cpp-20230802.0-r4.ebuild
@@ -37,7 +37,7 @@ PATCHES=(
 src_prepare() {
 	cmake_src_prepare
 
-	use ppc && eapply "${FILESDIR}/${PN}-atomic-patch"
+	use ppc && eapply "${FILESDIR}/${PN}-atomic.patch"
 
 	# un-hardcode abseil compiler flags
 	sed -i \

--- a/dev-cpp/abseil-cpp/abseil-cpp-20240116.2-r4.ebuild
+++ b/dev-cpp/abseil-cpp/abseil-cpp-20240116.2-r4.ebuild
@@ -37,7 +37,7 @@ PATCHES=(
 src_prepare() {
 	cmake_src_prepare
 
-	use ppc && eapply "${FILESDIR}/${PN}-atomic-patch"
+	use ppc && eapply "${FILESDIR}/${PN}-atomic.patch"
 
 	# un-hardcode abseil compiler flags
 	sed -i \

--- a/dev-cpp/abseil-cpp/abseil-cpp-20240722.0.ebuild
+++ b/dev-cpp/abseil-cpp/abseil-cpp-20240722.0.ebuild
@@ -38,7 +38,7 @@ PATCHES=(
 src_prepare() {
 	cmake_src_prepare
 
-	use ppc && eapply "${FILESDIR}/${PN}-atomic-patch"
+	use ppc && eapply "${FILESDIR}/${PN}-atomic.patch"
 
 	# un-hardcode abseil compiler flags
 	sed -i \


### PR DESCRIPTION
I'm pretty sure this is a typo because the file `${FILESDIR}/${PN}-atomic-patch` doesn't exists (and since it's a conditional patch it wasn't noticed), however i haven't tested if the patch actually applies.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
