### PR TITLE
dev-lang/spidermonkey-115.15.0: fix compilation with clang-18 and llvm's libc++

### DIFF
--- a/dev-lang/spidermonkey/files/spidermonkey-115.15.0-llvm-clang-18.patch
+++ b/dev-lang/spidermonkey/files/spidermonkey-115.15.0-llvm-clang-18.patch
@@ -1,0 +1,42 @@
+# This file is fetched from https://d2mfgivbiy2fiw.cloudfront.net/file/data/rwpvsmwwvh35bpcsfw4t/PHID-FILE-mxdzufadfb2lsy24j5mh/D186421.1728057072.diff
+# Bug assigned to this issue is at https://bugzilla.mozilla.org/show_bug.cgi?id=1849070
+# The solution of the issue is at https://phabricator.services.mozilla.com/D186421
+# 
+# Current patch file is introduced by Denis Pronin, email: dannftk@yandex.ru
+
+diff --git a/js/src/builtin/intl/Locale.cpp b/js/src/builtin/intl/Locale.cpp
+--- a/js/src/builtin/intl/Locale.cpp
++++ b/js/src/builtin/intl/Locale.cpp
+@@ -799,12 +799,14 @@
+ 
+ static inline auto FindUnicodeExtensionType(JSLinearString* unicodeExtension,
+                                             UnicodeKey key) {
+   JS::AutoCheckCannotGC nogc;
+   return unicodeExtension->hasLatin1Chars()
+-             ? FindUnicodeExtensionType(unicodeExtension->latin1Chars(nogc),
+-                                        unicodeExtension->length(), key)
++             ? FindUnicodeExtensionType(
++                   reinterpret_cast<const char*>(
++                       unicodeExtension->latin1Chars(nogc)),
++                   unicodeExtension->length(), key)
+              : FindUnicodeExtensionType(unicodeExtension->twoByteChars(nogc),
+                                         unicodeExtension->length(), key);
+ }
+ 
+ // Return the sequence of types for the Unicode extension keyword specified by
+@@ -917,11 +919,13 @@
+ }
+ 
+ static inline auto BaseNameParts(JSLinearString* baseName) {
+   JS::AutoCheckCannotGC nogc;
+   return baseName->hasLatin1Chars()
+-             ? BaseNameParts(baseName->latin1Chars(nogc), baseName->length())
++             ? BaseNameParts(
++                   reinterpret_cast<const char*>(baseName->latin1Chars(nogc)),
++                   baseName->length())
+              : BaseNameParts(baseName->twoByteChars(nogc), baseName->length());
+ }
+ 
+ // Intl.Locale.prototype.maximize ()
+ static bool Locale_maximize(JSContext* cx, const CallArgs& args) {
+

--- a/dev-lang/spidermonkey/spidermonkey-115.15.0.ebuild
+++ b/dev-lang/spidermonkey/spidermonkey-115.15.0.ebuild
@@ -267,6 +267,7 @@ src_prepare() {
 
 	eapply "${WORKDIR}"/firefox-patches
 	eapply "${WORKDIR}"/spidermonkey-patches
+	eapply "${FILESDIR}"/spidermonkey-${PV}-llvm-clang-18.patch
 
 	default
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/940720

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
