### PR TITLE
dev-libs/re2: build using cmake

### DIFF
--- a/dev-libs/re2/files/re2-build-static-libtesting.patch
+++ b/dev-libs/re2/files/re2-build-static-libtesting.patch
@@ -1,0 +1,19 @@
+Bug: https://bugs.gentoo.org/940734
+
+Building with CMake, the benchmark binary is linked with libtesting.so shared
+library.  This means that libtesting.so needs to be installed for runtime symbol
+resolution.  Better to build libtesting.a statically just like the Makefile does.
+Also, quiet QA warning about an insecure RPATH.
+
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -182,7 +182,8 @@
+       util/pcre.cc
+       )
+ 
+-  add_library(testing ${TESTING_SOURCES})
++  add_library(testing STATIC ${TESTING_SOURCES})
++  set(CMAKE_SKIP_RPATH TRUE)
+   if(BUILD_SHARED_LIBS AND WIN32)
+     target_compile_definitions(testing PRIVATE -DRE2_BUILD_TESTING_DLL)
+   endif()

--- a/dev-libs/re2/re2-0.2024.07.02-r2.ebuild
+++ b/dev-libs/re2/re2-0.2024.07.02-r2.ebuild
@@ -1,0 +1,68 @@
+# Copyright 2012-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit cmake-multilib
+
+# Different date format used upstream.
+RE2_VER=${PV#0.}
+RE2_VER=${RE2_VER//./-}
+
+DESCRIPTION="An efficient, principled regular expression library"
+HOMEPAGE="https://github.com/google/re2"
+SRC_URI="https://github.com/google/re2/archive/${RE2_VER}.tar.gz -> re2-${RE2_VER}.tar.gz"
+S="${WORKDIR}/re2-${RE2_VER}"
+
+LICENSE="BSD"
+# NOTE: Always run libre2 through abi-compliance-checker!
+# https://abi-laboratory.pro/tracker/timeline/re2/
+SONAME="11"
+SLOT="0/${SONAME}"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~loong ~ppc64 ~riscv ~sparc ~x86"
+IUSE="benchmark icu test test-full"
+REQUIRED_USE="
+	test? ( benchmark )
+	test-full? ( test )"
+
+RESTRICT="!test? ( test )"
+
+BDEPEND="test? ( dev-cpp/gtest[${MULTILIB_USEDEP}] )"
+RDEPEND="
+	>=dev-cpp/abseil-cpp-20240116.2-r3:=[${MULTILIB_USEDEP}]
+	benchmark? ( dev-cpp/benchmark[${MULTILIB_USEDEP}] )
+	icu? ( dev-libs/icu:0=[${MULTILIB_USEDEP}] )
+"
+DEPEND="${RDEPEND}"
+
+DOCS=( README doc/syntax.txt )
+HTML_DOCS=( doc/syntax.html )
+
+PATCHES=( "${FILESDIR}/re2-build-static-libtesting.patch" )
+
+src_configure() {
+	local mycmakeargs=(
+		-DRE2_USE_ICU=$(usex icu)
+	)
+	if use test || use benchmark; then
+		mycmakeargs+=( -DRE2_BUILD_TESTING=YES )
+	else
+		mycmakeargs+=( -DRE2_BUILD_TESTING=NO )
+	fi
+
+	cmake-multilib_src_configure
+}
+
+src_test() {
+	use test-full || local CMAKE_SKIP_TESTS=( '.*(exhaustive|dfa|random).*' )
+
+	cmake-multilib_src_test
+}
+
+multilib_src_install() {
+	cmake_src_install
+
+	if multilib_is_native_abi && use benchmark; then
+		newbin regexp_benchmark re2-bench
+	fi
+}


### PR DESCRIPTION
Supports building re2 with CMake.  A patch is included to support building and linking the benchmarking binary statically, as the Makefile version does, instead of having to install a `libtesting.so` library just to resolve symbols for an auxiliary binary.

Closes: https://bugs.gentoo.org/940734

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
