### PR TITLE
dev-lang/luau: install headers and libraries

### DIFF
--- a/dev-lang/luau/luau-0.645.ebuild
+++ b/dev-lang/luau/luau-0.645.ebuild
@@ -22,7 +22,8 @@ fi
 
 LICENSE="MIT"
 SLOT="0"
-
+IUSE="test"
+RESTRICT="!test? ( test )"
 DOCS=( CONTRIBUTING.md README.md SECURITY.md )
 
 src_test() {
@@ -30,9 +31,24 @@ src_test() {
 	"${BUILD_DIR}/Luau.Conformance" || die
 }
 
+src_configure() {
+	local mycmakeargs=(
+		-DLUAU_BUILD_TESTS=$(usex test)
+	)
+	cmake_src_configure
+}
+
 src_install() {
+	dolib.a "${BUILD_DIR}"/libLuau.*.a
+
 	exeinto /usr/bin
 	doexe "${BUILD_DIR}"/luau{,-analyze,-ast,-compile,-reduce}
+
+	insinto /usr/include/Luau
+	doins "${S}"/VM/include/*.h
+	doins "${S}"/Compiler/include/luacode.h
+	doins "${S}"/CodeGen/include/luacodegen.h
+	doins "${S}"/{Config,Common,Compiler,CodeGen,Ast,Analysis,EqSat}/include/Luau/*.h
 
 	einstalldocs
 }


### PR DESCRIPTION
This PR adds the installation of Luau libraries and headers. I put all of the lua*.h headers into the Luau directory so it won't conflict with existing Lua installations. Please let me know if this should be changed. 

I also added a use flag for tests because the amount of ninja steps gets doubled if the tests are built.

pkgcheck output:
```
dev-lang/luau
  UnstableOnly: for arch: [ x86 ], all versions are unstable: [ 0.637, 0.640, 0.645 ]
  PotentialStable: version 0.637: slot(0), stabled arch: [ amd64 ], potential: [ ~x86 ]
  RedundantVersion: version 0.640: slot(0) keywords are overshadowed by version: 0.645
```

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
