### PR TITLE
media-libs/libass: fix implicit dep on dev-libs/libunibreak

### DIFF
--- a/media-libs/libass/libass-0.17.1-r1.ebuild
+++ b/media-libs/libass/libass-0.17.1-r1.ebuild
@@ -1,0 +1,51 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/openpgp-keys/libass.asc
+inherit multilib-minimal verify-sig
+
+DESCRIPTION="Library for SSA/ASS subtitles rendering"
+HOMEPAGE="https://github.com/libass/libass"
+SRC_URI="https://github.com/libass/libass/releases/download/${PV}/${P}.tar.xz"
+SRC_URI+=" verify-sig? ( https://github.com/libass/libass/releases/download/${PV}/${P}.tar.xz.asc )"
+
+LICENSE="ISC"
+SLOT="0/9" # subslot = libass soname version
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~mips ~ppc ~ppc64 ~riscv ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
+IUSE="+fontconfig libunibreak test"
+RESTRICT="!test? ( test )"
+
+RDEPEND="
+	>=dev-libs/fribidi-0.19.5-r1[${MULTILIB_USEDEP}]
+	>=media-libs/freetype-2.5.0.1:2[${MULTILIB_USEDEP}]
+	>=virtual/libiconv-0-r1[${MULTILIB_USEDEP}]
+	>=media-libs/harfbuzz-1.2.3:=[truetype,${MULTILIB_USEDEP}]
+	fontconfig? ( >=media-libs/fontconfig-2.10.92[${MULTILIB_USEDEP}] )
+	libunibreak? ( dev-libs/libunibreak:= )
+"
+DEPEND="${RDEPEND}"
+BDEPEND="
+	virtual/pkgconfig
+	amd64? ( dev-lang/nasm )
+	x86? ( dev-lang/nasm )
+	test? ( media-libs/libpng[${MULTILIB_USEDEP}] )
+	verify-sig? ( sec-keys/openpgp-keys-libass )
+"
+
+DOCS=( Changelog )
+
+multilib_src_configure() {
+	ECONF_SOURCE="${S}" econf \
+		$(use_enable fontconfig) \
+		$(use_enable libunibreak) \
+		$(use_enable test) \
+		--disable-require-system-font-provider
+}
+
+multilib_src_install_all() {
+	einstalldocs
+
+	find "${ED}" -name '*.la' -type f -delete || die
+}

--- a/media-libs/libass/metadata.xml
+++ b/media-libs/libass/metadata.xml
@@ -4,6 +4,9 @@
   <maintainer type="project">
     <email>media-video@gentoo.org</email>
   </maintainer>
+  <use>
+    <flag name="libunibreak">Use <pkg>dev-libs/libunibreak</pkg> for Unicode line breaking algorithm</flag>
+  </use>
   <upstream>
     <remote-id type="github">libass/libass</remote-id>
   </upstream>

--- a/profiles/arch/alpha/package.use.mask
+++ b/profiles/arch/alpha/package.use.mask
@@ -1,6 +1,10 @@
 # Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# David Roman <davidroman96@gmail.com> (2024-10-04)
+# dev-libs/libunibreak is not keyworded
+media-libs/libass libunibreak
+
 # Sam James <sam@gentoo.org> (2024-08-23)
 # dev-util/bpftool and/or sys-devel/bpf-toolchain not keyworded here
 sys-apps/systemd bpf

--- a/profiles/arch/hppa/package.use.mask
+++ b/profiles/arch/hppa/package.use.mask
@@ -4,6 +4,10 @@
 # NOTE: When masking a USE flag due to missing keywords, please file a keyword
 # request bug for the hppa arch.
 
+# David Roman <davidroman96@gmail.com> (2024-10-04)
+# dev-libs/libunibreak is not keyworded
+media-libs/libass libunibreak
+
 # Sam James <sam@gentoo.org> (2024-08-23)
 # dev-util/bpftool and/or sys-devel/bpf-toolchain not keyworded here
 sys-apps/systemd bpf

--- a/profiles/arch/loong/package.use.mask
+++ b/profiles/arch/loong/package.use.mask
@@ -1,6 +1,10 @@
 # Copyright 2022-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# David Roman <davidroman96@gmail.com> (2024-10-04)
+# dev-libs/libunibreak is not keyworded
+media-libs/libass libunibreak
+
 # WANG Xuerui <xen0n@gentoo.org> (2024-09-27)
 # media-libs/libilbc needs porting
 media-video/ffmpeg libilbc

--- a/profiles/arch/mips/package.use.mask
+++ b/profiles/arch/mips/package.use.mask
@@ -1,6 +1,10 @@
 # Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# David Roman <davidroman96@gmail.com> (2024-10-04)
+# dev-libs/libunibreak is not keyworded
+media-libs/libass libunibreak
+
 # Arthur Zamarin <arthurzam@gentoo.org> (2024-09-08)
 # Packages needing dev-python/selenium.
 dev-python/aiohttp-cors test

--- a/profiles/arch/powerpc/ppc64/package.use.mask
+++ b/profiles/arch/powerpc/ppc64/package.use.mask
@@ -1,6 +1,10 @@
 # Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# David Roman <davidroman96@gmail.com> (2024-10-04)
+# dev-libs/libunibreak is not keyworded
+media-libs/libass libunibreak
+
 # Matt Jolly <kangie@gentoo.org> (2024-08-14)
 # QUIC dependencies are not keyworded
 net-misc/curl http3 quic curl_quic_openssl curl_quic_ngtcp2

--- a/profiles/arch/riscv/package.use.mask
+++ b/profiles/arch/riscv/package.use.mask
@@ -1,6 +1,10 @@
 # Copyright 2019-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# David Roman <davidroman96@gmail.com> (2024-10-04)
+# dev-libs/libunibreak not keyworded here
+media-libs/libass libunibreak
+
 # Paul Zander <negril.nx+gentoo@gmail.com> (2024-09-08)
 # needs re-keywording and clean-up of media-libs/opencollada
 media-libs/assimp collada

--- a/profiles/arch/sparc/package.use.mask
+++ b/profiles/arch/sparc/package.use.mask
@@ -1,6 +1,10 @@
 # Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# David Roman <davidroman96@gmail.com> (2024-10-04)
+# dev-libs/libunibreak not keyworded here
+media-libs/libass libunibreak
+
 # Sam James <sam@gentoo.org> (2024-08-23)
 # dev-util/bpftool and/or sys-devel/bpf-toolchain not keyworded here
 sys-apps/systemd bpf


### PR DESCRIPTION
Since version 0.17.0, ```media-libs/libass``` searches for ```dev-libs/libunibreak``` to optionally use the Unicode line breaking algorithm instead of ASS' much stricter rules.

This is a rebase of https://github.com/gentoo/gentoo/pull/31993

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
