### PR TITLE
dev-util/bpftool: fix python shebang for python-exec[-native-symlinks]

### DIFF
--- a/dev-util/bpftool/bpftool-7.5.0-r2.ebuild
+++ b/dev-util/bpftool/bpftool-7.5.0-r2.ebuild
@@ -54,6 +54,7 @@ BDEPEND="
 CONFIG_CHECK="~DEBUG_INFO_BTF"
 
 pkg_setup() {
+	python-any-r1_pkg_setup
 	use llvm && llvm-r1_pkg_setup
 }
 
@@ -104,6 +105,9 @@ src_prepare() {
 
 	# remove -Werror (bug 887981)
 	sed -i -e 's/\-Werror//g' ../../lib/bpf/Makefile || die
+
+	# fix up python shebangs (bug 940781)
+	python_fix_shebang "${S_K}"/scripts/bpf_doc.py
 }
 
 bpftool_make() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/940781

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
