### PR TITLE
net-analyzer/wireshark: fix build with USE=doc

### DIFF
--- a/net-analyzer/wireshark/wireshark-4.4.0.ebuild
+++ b/net-analyzer/wireshark/wireshark-4.4.0.ebuild
@@ -266,10 +266,10 @@ src_install() {
 	# https://gitlab.com/wireshark/wireshark/-/commit/fe7bfdf6caac9204ab5f34eeba7b0f4a0314d3cd
 	cmake_src_install install-headers
 
-	# prepare Relase Notes redirector if necessary (bug #939195)
-	local relnotes="doc/release-notes.html"
-
 	if ! use doc; then
+		# prepare Relase Notes redirector (bug #939195)
+		local relnotes="doc/release-notes.html"
+
 		# by default create a link for our specific version
 		local relversion="wireshark-${PV}.html"
 
@@ -278,11 +278,13 @@ src_install() {
 			relversion=""
 		fi
 
+		# patch version into redirector & install it
 		sed -e "s/#VERSION#/${relversion}/g" < "${FILESDIR}/release-notes.html" > ${relnotes} || die
+		dodoc ${relnotes}
 	fi
 
 	# FAQ is not required as is installed from help/faq.txt
-	dodoc AUTHORS ChangeLog README* doc/randpkt.txt doc/README* ${relnotes}
+	dodoc AUTHORS ChangeLog README* doc/randpkt.txt doc/README*
 
 	# install headers
 	insinto /usr/include/wireshark

--- a/net-analyzer/wireshark/wireshark-9999.ebuild
+++ b/net-analyzer/wireshark/wireshark-9999.ebuild
@@ -264,10 +264,10 @@ src_install() {
 	# https://gitlab.com/wireshark/wireshark/-/commit/fe7bfdf6caac9204ab5f34eeba7b0f4a0314d3cd
 	cmake_src_install install-headers
 
-	# prepare Relase Notes redirector if necessary (bug #939195)
-	local relnotes="doc/release-notes.html"
-
 	if ! use doc; then
+		# prepare Relase Notes redirector (bug #939195)
+		local relnotes="doc/release-notes.html"
+
 		# by default create a link for our specific version
 		local relversion="wireshark-${PV}.html"
 
@@ -276,11 +276,13 @@ src_install() {
 			relversion=""
 		fi
 
+		# patch version into redirector & install it
 		sed -e "s/#VERSION#/${relversion}/g" < "${FILESDIR}/release-notes.html" > ${relnotes} || die
+		dodoc ${relnotes}
 	fi
 
 	# FAQ is not required as is installed from help/faq.txt
-	dodoc AUTHORS ChangeLog README* doc/randpkt.txt doc/README* ${relnotes}
+	dodoc AUTHORS ChangeLog README* doc/randpkt.txt doc/README*
 
 	# install headers
 	insinto /usr/include/wireshark


### PR DESCRIPTION
As it turns out the build works the way it does, not the way I thought it did.
Now it works for either -doc/+doc.

Closes: https://bugs.gentoo.org/940910

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
