### PR TITLE
net-misc/ubridge: Remove Garri from the proxied maintainers list

### DIFF
--- a/net-misc/ubridge/metadata.xml
+++ b/net-misc/ubridge/metadata.xml
@@ -5,10 +5,6 @@
 		<email>mmk@levelnine.at</email>
 		<name>Michael Mair-Keimberger</name>
 	</maintainer>
-	<maintainer type="person" proxied="yes">
-		<email>g.djavadyan@gmail.com</email>
-		<name>Garri Djavadyan</name>
-	</maintainer>
 	<maintainer type="project" proxied="proxy">
 		<email>proxy-maint@gentoo.org</email>
 		<name>Proxy Maintainers</name>


### PR DESCRIPTION
Garri steps down as a proxied maintainer for net-misc/ubridge as he is no longer exposed to Gentoo systems.