### PR TITLE
dev-scheme/guile: slot info similar to autoconf{,-vanilla}

### DIFF
--- a/dev-scheme/guile/guile-1.8.8-r102.ebuild
+++ b/dev-scheme/guile/guile-1.8.8-r102.ebuild
@@ -1,0 +1,171 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools flag-o-matic elisp-common
+
+DESCRIPTION="GNU Ubiquitous Intelligent Language for Extensions"
+HOMEPAGE="https://www.gnu.org/software/guile/"
+SRC_URI="mirror://gnu/guile/${P}.tar.gz"
+
+LICENSE="LGPL-2.1"
+SLOT="$(ver_cut 1-2)"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~m68k ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos"
+IUSE="debug debug-freelist debug-malloc +deprecated discouraged emacs networking nls readline +regex +threads"
+RESTRICT="!regex? ( test )"
+
+RDEPEND="
+	>=dev-libs/gmp-4.1:0=
+	dev-libs/libltdl:0=
+	sys-devel/gettext
+	sys-libs/ncurses:0=
+	virtual/libcrypt:=
+	readline? ( sys-libs/readline:0= )
+"
+DEPEND="${RDEPEND}"
+BDEPEND="
+	sys-apps/texinfo
+	dev-build/libtool
+	emacs? ( >=app-editors/emacs-23.1:* )
+"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-fix_guile-config.patch
+	"${FILESDIR}"/${P}-gcc46.patch
+	"${FILESDIR}"/${P}-gcc5.patch
+	"${FILESDIR}"/${P}-makeinfo-5.patch
+	"${FILESDIR}"/${P}-gtexinfo-5.patch
+	"${FILESDIR}"/${P}-readline.patch
+	"${FILESDIR}"/${P}-tinfo.patch
+	"${FILESDIR}"/${P}-sandbox.patch
+	"${FILESDIR}"/${P}-mkdir-mask.patch
+	"${FILESDIR}"/${PN}-1.8.8-texinfo-6.7.patch
+)
+
+DOCS=( AUTHORS ChangeLog GUILE-VERSION HACKING NEWS README THANKS )
+
+# Where to install data files.
+GUILE_DATA="${EPREFIX}/usr/share/guile-data/${SLOT}"
+GUILE_PCDIR="${EPREFIX}/usr/share/guile-data/${SLOT}/pkgconfig"
+GUILE_INFODIR="${EPREFIX}"/usr/share/guile-data/"${SLOT}"/info
+
+src_prepare() {
+	default
+
+	sed \
+		-e "s/AM_CONFIG_HEADER/AC_CONFIG_HEADERS/g" \
+		-e "/AM_PROG_CC_STDC/d" \
+		-i guile-readline/configure.in || die
+
+	mv "${S}"/configure.{in,ac} || die
+	mv "${S}"/guile-readline/configure.{in,ac} || die
+
+	eautoreconf
+}
+
+src_configure() {
+	# See bug #178499.  filter-flags no longer works since the compiler
+	# will vectorize by default when optimizing.
+	append-flags -fno-tree-vectorize -fno-strict-aliasing
+
+	#will fail for me if posix is disabled or without modules -- hkBst
+	myconf=(
+		--program-suffix="-${SLOT}"
+		--infodir="${GUILE_INFODIR}"
+		--includedir="${EPREFIX}/usr/include/guile/${SLOT}"
+
+		--disable-error-on-warning
+		--disable-static
+		--enable-posix
+		$(use_enable networking)
+		$(use_enable readline)
+		$(use_enable regex)
+		$(use deprecated || use_enable discouraged)
+		$(use_enable deprecated)
+		$(use_enable emacs elisp)
+		$(use_enable nls)
+		--disable-rpath
+		$(use_enable debug-freelist)
+		$(use_enable debug-malloc)
+		$(use_enable debug guile-debug)
+		$(use_with threads)
+		--with-modules
+	)
+	econf "${myconf[@]}" EMACS=no
+}
+
+src_compile() {
+	emake
+
+	# Above we have disabled the build system's Emacs support;
+	# for USE=emacs we compile (and install) the files manually
+	if use emacs; then
+		cd emacs || die
+		elisp-compile *.el || die
+	fi
+}
+
+# Akin to (and taken from) toolchain-autoconfs eclass
+guile_slot_info() {
+	rm -f dir || die
+
+	pushd "${D}/${GUILE_INFODIR}" >/dev/null || die
+	for f in *.info*; do
+		# Install convenience aliases for versioned Guile pages.
+		ln -s "$f" "${f/./-${SLOT}.}" || die
+	done
+	popd >/dev/null || die
+
+	docompress "${GUILE_INFODIR}"
+}
+
+src_install() {
+	default
+
+	dodir "${GUILE_PCDIR}"
+	sed -e "/libdir/i bindir=${ESYSROOT}/usr/bin" \
+		-e "/libguileinterface/a guile=\${bindir}/guile-${SLOT}" \
+		-i "${ED}"/usr/$(get_libdir)/pkgconfig/guile-1.8.pc || die
+	mv "${ED}"/usr/$(get_libdir)/pkgconfig/guile-1.8.pc "${D}/${GUILE_PCDIR}"/guile-1.8.pc || die
+
+	sed -i "1s/guile/guile-1.8/" "${ED}"/usr/bin/guile-config-1.8 || die
+
+	for script in PROGRAM autofrisk doc-snarf generate-autoload punify \
+				  read-scheme-source scan-api snarf-guile-m4-docs use2dot \
+				  api-diff  display-commentary frisk lint read-rfc822 \
+				  read-text-outline snarf-check-and-output-texi summarize-guile-TODO; do
+		sed "s/GUILE-guile/GUILE-guile-1.8/" \
+			-i "${ED}"/usr/share/guile/1.8/scripts/${script}-1.8 || die
+		mv "${ED}"/usr/share/guile/1.8/scripts/${script}{-1.8,} || die
+	done
+
+	mv "${ED}"/usr/share/aclocal/guile{,-"${SLOT}"}.m4 || die
+	find "${ED}" -name '*.la' -delete || die
+
+	guile_slot_info
+
+	local major="$(ver_cut 1 "${SLOT}")"
+	local minor="$(ver_cut 2 "${SLOT}")"
+	local idx="$((99999-(major*1000+minor)))"
+	newenvd - "50guile${idx}" <<-EOF
+	PKG_CONFIG_PATH="${GUILE_PCDIR}"
+	INFOPATH="${GUILE_INFODIR}"
+	EOF
+
+	# necessary for registering slib, see bug 206896
+	keepdir /usr/share/guile/site
+
+	if use emacs; then
+		elisp-install ${PN}-${SLOT} emacs/*.{el,elc}
+		elisp-make-site-file "50${PN}-${SLOT}-gentoo.el"
+	fi
+}
+
+pkg_postinst() {
+	use emacs && elisp-site-regen
+}
+
+pkg_postrm() {
+	use emacs && elisp-site-regen
+}

--- a/dev-scheme/guile/guile-2.2.7-r101.ebuild
+++ b/dev-scheme/guile/guile-2.2.7-r101.ebuild
@@ -1,0 +1,116 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DESCRIPTION="GNU Ubiquitous Intelligent Language for Extensions"
+HOMEPAGE="https://www.gnu.org/software/guile/"
+SRC_URI="mirror://gnu/guile/${P}.tar.xz"
+
+LICENSE="LGPL-3+"
+SLOT="$(ver_cut 1-2)"  # See (guile)Parallel Installations.
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos"
+IUSE="debug debug-malloc +deprecated +networking +nls +regex +threads" # upstream recommended +networking +nls
+REQUIRED_USE="regex" # workaround for bug 596322
+RESTRICT="strip"
+
+RDEPEND="
+	>=dev-libs/boehm-gc-7.0:=[threads?]
+	dev-libs/gmp:=
+	dev-libs/libffi:=
+	dev-libs/libltdl:=
+	dev-libs/libunistring:0=
+	sys-libs/ncurses:0=
+	sys-libs/readline:0=
+	virtual/libcrypt:=
+	!dev-scheme/guile:12
+"
+DEPEND="${RDEPEND}"
+BDEPEND="
+	virtual/pkgconfig
+	dev-build/libtool
+	sys-devel/gettext
+"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-2.2.3-gentoo-sandbox.patch"
+	"${FILESDIR}/${PN}-2.2.7-stack-up.patch"
+)
+
+# guile generates ELF files without use of C or machine code
+# It's a portage's false positive. bug #677600
+QA_PREBUILT='*[.]go'
+
+GUILE_INFODIR="${EPREFIX}"/usr/share/guile-data/"${SLOT}"/info
+
+DOCS=( GUILE-VERSION HACKING README )
+
+src_configure() {
+	# see bug #676468
+	mv prebuilt/32-bit-big-endian{,.broken} || die
+
+	econf \
+		--infodir="${GUILE_INFODIR}" \
+		--program-suffix="-${SLOT}" \
+		--disable-error-on-warning \
+		--disable-rpath \
+		--disable-static \
+		--enable-posix \
+		--without-libgmp-prefix \
+		--without-libiconv-prefix \
+		--without-libintl-prefix \
+		--without-libltdl-prefix \
+		--without-libreadline-prefix \
+		--without-libunistring-prefix \
+		$(use_enable debug guile-debug) \
+		$(use_enable debug-malloc) \
+		$(use_enable deprecated) \
+		$(use_enable networking) \
+		$(use_enable nls) \
+		$(use_enable regex) \
+		$(use_with threads)
+}
+
+# Akin to (and taken from) toolchain-autoconfs eclass
+guile_slot_info() {
+	rm -f dir || die
+
+	pushd "${D}/${GUILE_INFODIR}" >/dev/null || die
+	for f in *.info*; do
+		# Install convenience aliases for versioned Guile pages.
+		ln -s "$f" "${f/./-${SLOT}.}" || die
+	done
+	popd >/dev/null || die
+
+	docompress "${GUILE_INFODIR}"
+}
+
+src_install() {
+	default
+
+	# From Novell
+	# https://bugzilla.novell.com/show_bug.cgi?id=874028#c0
+	dodir /usr/share/gdb/auto-load/$(get_libdir)
+	mv "${ED}"/usr/$(get_libdir)/libguile-*-gdb.scm "${ED}"/usr/share/gdb/auto-load/$(get_libdir) || die
+
+	find "${D}" -name '*.la' -delete || die
+
+	# Move the pkg-config files to guile-data.  In future versions, this
+	# should be handled by --with-pkgconfigdir (patch waiting on
+	# upstream).
+	local pcdir=/usr/share/guile-data/"${SLOT}"
+	mkdir -p "${ED}${pcdir}" || die
+	mv "${ED}"/usr/share/aclocal/guile{,-"${SLOT}"}.m4 || die
+	mv "${ED}"/usr/$(get_libdir)/pkgconfig/ \
+	   "${ED}/${pcdir}" || die
+
+	guile_slot_info
+
+	local major="$(ver_cut 1 "${SLOT}")"
+	local minor="$(ver_cut 2 "${SLOT}")"
+	local idx="$((99999-(major*1000+minor)))"
+	newenvd - "50guile${idx}" <<-EOF
+	PKG_CONFIG_PATH="${datadir}/pkgconfig"
+	INFOPATH="${GUILE_INFODIR}"
+	EOF
+}

--- a/dev-scheme/guile/guile-3.0.10-r101.ebuild
+++ b/dev-scheme/guile/guile-3.0.10-r101.ebuild
@@ -1,0 +1,112 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DESCRIPTION="GNU Ubiquitous Intelligent Language for Extensions"
+HOMEPAGE="https://www.gnu.org/software/guile/"
+SRC_URI="mirror://gnu/guile/${P}.tar.xz"
+
+LICENSE="LGPL-3+"
+SLOT="$(ver_cut 1-2)"  # See (guile)Parallel Installations.
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~arm64-macos ~ppc-macos ~x64-macos"
+
+IUSE="debug debug-malloc +deprecated +jit +networking +nls +regex +threads" # upstream recommended +networking +nls
+REQUIRED_USE="regex" # workaround for bug #596322
+RESTRICT="strip"
+
+RDEPEND="
+	>=dev-libs/boehm-gc-7.0[threads?]
+	dev-libs/gmp:=
+	dev-libs/libffi:=
+	dev-libs/libatomic_ops
+	dev-libs/libunistring:=
+	sys-libs/ncurses:=
+	sys-libs/readline:=
+	virtual/libcrypt:=
+	!dev-scheme/guile:12
+"
+DEPEND="${RDEPEND}"
+BDEPEND="
+	virtual/pkgconfig
+	dev-build/libtool
+	sys-devel/gettext
+"
+
+# guile generates ELF files without use of C or machine code
+# It's false positive. bug #677600
+QA_PREBUILT='*[.]go'
+
+DOCS=( ABOUT-NLS AUTHORS ChangeLog GUILE-VERSION HACKING NEWS README THANKS )
+
+PATCHES=( "${FILESDIR}"/${PN}-2.2.3-gentoo-sandbox.patch )
+
+# Where to install data files.
+GUILE_DATA="${EPREFIX}/usr/share/guile-data/${SLOT}"
+GUILE_PCDIR="${EPREFIX}/usr/share/guile-data/${SLOT}/pkgconfig"
+GUILE_INFODIR="${GUILE_DATA}"/info
+
+src_configure() {
+	# see bug #676468
+	mv prebuilt/32-bit-big-endian{,.broken} || die
+
+	local -a myconf=(
+		--program-suffix="-${SLOT}"
+		--infodir="${GUILE_INFODIR}"
+		--with-pkgconfigdir="${GUILE_PCDIR}"
+
+		--disable-error-on-warning
+		--disable-rpath
+		--disable-lto
+		--enable-posix
+		--without-libgmp-prefix
+		--without-libiconv-prefix
+		--without-libintl-prefix
+		--without-libreadline-prefix
+		--without-libunistring-prefix
+		$(use_enable debug guile-debug)
+		$(use_enable debug-malloc)
+		$(use_enable deprecated)
+		$(use_enable jit)
+		$(use_enable networking)
+		$(use_enable nls)
+		$(use_enable regex)
+		$(use_with threads)
+	)
+	econf "${myconf[@]}"
+}
+
+# Akin to (and taken from) toolchain-autoconfs eclass
+guile_slot_info() {
+	rm -f dir || die
+
+	pushd "${D}/${GUILE_INFODIR}" >/dev/null || die
+	for f in *.info*; do
+		# Install convenience aliases for versioned Guile pages.
+		ln -s "$f" "${f/./-${SLOT}.}" || die
+	done
+	popd >/dev/null || die
+
+	docompress "${GUILE_INFODIR}"
+}
+
+src_install() {
+	default
+
+	# From Novell https://bugzilla.novell.com/show_bug.cgi?id=874028#c0
+	dodir /usr/share/gdb/auto-load/$(get_libdir)
+	mv "${ED}"/usr/$(get_libdir)/libguile-*-gdb.scm "${ED}"/usr/share/gdb/auto-load/$(get_libdir) || die
+
+	mv "${ED}"/usr/share/aclocal/guile{,-"${SLOT}"}.m4 || die
+	find "${ED}" -name '*.la' -delete || die
+
+	guile_slot_info
+
+	local major="$(ver_cut 1 "${SLOT}")"
+	local minor="$(ver_cut 2 "${SLOT}")"
+	local idx="$((99999-(major*1000+minor)))"
+	newenvd - "50guile${idx}" <<-EOF
+	PKG_CONFIG_PATH="${GUILE_PCDIR}"
+	INFOPATH="${GUILE_INFODIR}"
+	EOF
+}


### PR DESCRIPTION
This also changes the order of the PKG_CONFIG_PATH.  I think this should have no effect, as all the guile .pc names are pre-slotted.

Cc: @thesamesam @qookei

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
