### PR TITLE
dev-libs/olm: fix compilation on Clang 19

### DIFF
--- a/dev-libs/olm/files/olm-3.2.16-clang-19-const.patch
+++ b/dev-libs/olm/files/olm-3.2.16-clang-19-const.patch
@@ -1,0 +1,17 @@
+Fixes compilation on Clang 19.
+Patch by Marco Rebhan <me@dblsaiko.net>
+Fixes https://bugs.gentoo.org/940764
+
+Signed-off-by: Gavin D. Howard <gavin@gavinhoward.com>
+
+--- a/include/olm/list.hh
++++ b/include/olm/list.hh
+@@ -99,7 +99,7 @@ public:
+             return *this;
+         }
+         T * this_pos = _data;
+-        T * const other_pos = other._data;
++        T const * other_pos = other._data;
+         while (other_pos != other._end) {
+             *this_pos = *other;
+             ++this_pos;

--- a/dev-libs/olm/metadata.xml
+++ b/dev-libs/olm/metadata.xml
@@ -11,7 +11,7 @@
 	</maintainer>
 	<upstream>
 		<bugs-to>https://gitlab.matrix.org/matrix-org/olm</bugs-to>
-		<remote-id type="gitlab">matrix-org/olm</remote-id>
+		<remote-id type="github">matrix-org/olm</remote-id>
 	</upstream>
 	<longdescription lang="en">
 		Official, audited implementation of the olm and megolm cryptographic

--- a/dev-libs/olm/olm-3.2.16-r1.ebuild
+++ b/dev-libs/olm/olm-3.2.16-r1.ebuild
@@ -1,0 +1,28 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit cmake
+
+DESCRIPTION="Implementation of the Double Ratchet cryptographic ratchet in C++"
+HOMEPAGE="https://gitlab.matrix.org/matrix-org/olm"
+SRC_URI="https://gitlab.matrix.org/matrix-org/${PN}/-/archive/${PV}/${P}.tar.bz2"
+
+LICENSE="Apache-2.0"
+SLOT="0"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~x86"
+IUSE="test"
+RESTRICT="!test? ( test )"
+
+PATCHES=(
+	"${FILESDIR}/${P}-cmake.patch" # TODO: upstream
+	"${FILESDIR}/${P}-clang-19-const.patch"
+)
+
+src_configure() {
+	local mycmakeargs=(
+		-DBUILD_TESTING=$(usex test)
+	)
+	cmake_src_configure
+}


### PR DESCRIPTION
In addition, I fixed a broken remote-id.

Closes: https://bugs.gentoo.org/940764

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
