### PR TITLE
python-r1.eclass: get rid of python.eclass mention

### DIFF
--- a/eclass/python-r1.eclass
+++ b/eclass/python-r1.eclass
@@ -129,10 +129,6 @@ inherit multibuild python-utils-r1
 # depend on another Python package being built for the same Python
 # implementations.
 #
-# The generate USE-flag list is compatible with packages using python-r1
-# and python-distutils-ng eclasses. It must not be used on packages
-# using python.eclass.
-#
 # Example use:
 # @CODE
 # RDEPEND="dev-python/foo[${PYTHON_USEDEP}]"


### PR DESCRIPTION
<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
