### PR TITLE
dev-util/clion: fix permissions of deliverable in clion-2024.1.ebuild

### DIFF
--- a/dev-util/clion/clion-2024.1.ebuild
+++ b/dev-util/clion/clion-2024.1.ebuild
@@ -94,6 +94,8 @@ src_install() {
 		fperms 755 "${dir}"/jbr/lib/{chrome-sandbox,jcef_helper,jexec,jspawnhelper}
 	fi
 
+	fperms 755 "${dir}"/plugins/clion-radler/DotFiles/linux-x64/Rider.Backend
+
 	dosym -r "${EPREFIX}/usr/bin/ninja" "${dir}"/bin/ninja/linux/x64/ninja
 
 	make_wrapper "${PN}" "${dir}/bin/${PN}.sh"


### PR DESCRIPTION
Set 755 permissions to `"${dir}"/plugins/clion-radler/DotFiles/linux-x64/Rider.Backend`. This is to fix the following error upon CLion startup and further inability to start the Main window:
`com.intellij.diagnostic.PluginException: Cannot run program "/opt/clion/plugins/clion-radler/DotFiles/linux-x64/Rider.Backend": error=13, Permission denied [Plugin: org.jetbrains.plugins.clion.radler]`

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits. (performed locally)

Please note that all boxes must be checked for the pull request to be merged.
