### PR TITLE
profiles: mask dev-util/bpftool-7.5.0-r2

### DIFF
--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -33,6 +33,11 @@
 
 #--- END OF EXAMPLES ---
 
+# Holger Hoffstätte <holger@applied-asynchrony.com> (2024-10-11)
+# Vendors an unreleased libbpf version and generates ABI-breaking code.
+# Bug #941185.
+=dev-util/bpftool-7.5.0-r2
+
 # Michał Górny <mgorny@gentoo.org> (2024-10-10)
 # Gentoo package not updated for 4 years now.  No tests upstream.
 # No revdeps.


### PR DESCRIPTION
Generates ABI-breaking code and would need a matching but yet unreleased libbpf version to build against.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
