### PR TITLE
dev-lang/rust: backport llvm patches for gcc-15

### DIFF
--- a/dev-lang/rust/files/1.81.0-backport-bug937164.patch
+++ b/dev-lang/rust/files/1.81.0-backport-bug937164.patch
@@ -1,0 +1,15 @@
+https://bugs.gentoo.org/937525
+https://bugs.gentoo.org/937164
+
+Unnecessary on 19+ because 2222fddfc0a2ff02036542511597839856289094 adds
+SmallVector and SmallVector is fixed by another patch.
+--- a/src/llvm-project/llvm/lib/Target/X86/MCTargetDesc/X86MCTargetDesc.h
++++ b/src/llvm-project/llvm/lib/Target/X86/MCTargetDesc/X86MCTargetDesc.h
+@@ -13,6 +13,7 @@
+ #ifndef LLVM_LIB_TARGET_X86_MCTARGETDESC_X86MCTARGETDESC_H
+ #define LLVM_LIB_TARGET_X86_MCTARGETDESC_X86MCTARGETDESC_H
+ 
++#include <cstdint>
+ #include <memory>
+ #include <string>
+ 

--- a/dev-lang/rust/files/1.81.0-backport-llvm-pr101761.patch
+++ b/dev-lang/rust/files/1.81.0-backport-llvm-pr101761.patch
@@ -1,0 +1,30 @@
+https://bugs.gentoo.org/937525
+https://bugs.gentoo.org/937164
+https://github.com/llvm/llvm-project/commit/7e44305041d96b064c197216b931ae3917a34ac1
+https://github.com/llvm/llvm-project/pull/101761
+
+From 7e44305041d96b064c197216b931ae3917a34ac1 Mon Sep 17 00:00:00 2001
+From: Sam James <sam@gentoo.org>
+Date: Fri, 2 Aug 2024 23:07:21 +0100
+Subject: [PATCH] [ADT] Add `<cstdint>` to SmallVector (#101761)
+
+SmallVector uses `uint32_t`, `uint64_t` without including `<cstdint>`
+which fails to build w/ GCC 15 after a change in libstdc++ [0]
+
+[0] https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=3a817a4a5a6d94da9127af3be9f84a74e3076ee2
+---
+ src/llvm-project/llvm/include/llvm/ADT/SmallVector.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/llvm-project/llvm/include/llvm/ADT/SmallVector.h b/src/llvm-project/llvm/include/llvm/ADT/SmallVector.h
+index 09676d792dfebd..17444147b102a9 100644
+--- a/src/llvm-project/llvm/include/llvm/ADT/SmallVector.h
++++ b/src/llvm-project/llvm/include/llvm/ADT/SmallVector.h
+@@ -19,6 +19,7 @@
+ #include <algorithm>
+ #include <cassert>
+ #include <cstddef>
++#include <cstdint>
+ #include <cstdlib>
+ #include <cstring>
+ #include <functional>

--- a/dev-lang/rust/files/1.81.0-backport-llvm-pr101766.patch
+++ b/dev-lang/rust/files/1.81.0-backport-llvm-pr101766.patch
@@ -1,0 +1,29 @@
+https://bugs.gentoo.org/937525
+https://bugs.gentoo.org/937164
+https://github.com/llvm/llvm-project/pull/101766
+
+From 5b69d0cf697f0d78406a5a7ed18eaa4f57a0580a Mon Sep 17 00:00:00 2001
+From: Sam James <sam@gentoo.org>
+Date: Fri, 2 Aug 2024 23:38:55 +0100
+Subject: [PATCH] [AMDGPU] Include `<cstdint>` in AMDGPUMCTargetDesc
+
+createAMDGPUELFObjectWriter uses `uint8_t` without including `<cstdint>`
+which fails to build w/ GCC 15 after a change in libstdc++ [0].
+
+[0] https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=3a817a4a5a6d94da9127af3be9f84a74e3076ee2
+---
+ src/llvm-project/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCTargetDesc.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/llvm-project/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCTargetDesc.h b/src/llvm-project/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCTargetDesc.h
+index 3ef00f75735b0d..879dbe1b279b18 100644
+--- a/src/llvm-project/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCTargetDesc.h
++++ b/src/llvm-project/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCTargetDesc.h
+@@ -15,6 +15,7 @@
+ #ifndef LLVM_LIB_TARGET_AMDGPU_MCTARGETDESC_AMDGPUMCTARGETDESC_H
+ #define LLVM_LIB_TARGET_AMDGPU_MCTARGETDESC_AMDGPUMCTARGETDESC_H
+ 
++#include <cstdint>
+ #include <memory>
+ 
+ namespace llvm {

--- a/dev-lang/rust/rust-1.81.0.ebuild
+++ b/dev-lang/rust/rust-1.81.0.ebuild
@@ -169,6 +169,9 @@ PATCHES=(
 	#"${FILESDIR}"/1.72.0-bump-libc-deps-to-0.2.146.patch  # pending refresh
 	"${FILESDIR}"/1.67.0-doc-wasm.patch
 	"${FILESDIR}"/1.79.0-revert-8c40426.patch
+	"${FILESDIR}/1.81.0-backport-bug937164.patch"
+	"${FILESDIR}/1.81.0-backport-llvm-pr101761.patch"
+	"${FILESDIR}/1.81.0-backport-llvm-pr101766.patch"
 )
 
 clear_vendor_checksums() {


### PR DESCRIPTION
No revbump since this is build-only.

Bug: https://bugs.gentoo.org/937164
Closes: https://bugs.gentoo.org/937525

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
