### PR TITLE
sec-keys/openpgp-keys-gentoo-developers: always update information about the Web of Trust

### DIFF
--- a/sec-keys/openpgp-keys-gentoo-developers/files/keyring-mangler.py
+++ b/sec-keys/openpgp-keys-gentoo-developers/files/keyring-mangler.py
@@ -35,7 +35,7 @@ gentoo_auth = sys.argv[1]
 active_devs = sys.argv[2]
 armored_output = sys.argv[3]
 
-gpg = gnupg.GPG(verbose=False, gnupghome=os.environ["GNUPGHOME"])
+gpg = gnupg.GPG(verbose=False, gnupghome=os.environ["GNUPGHOME"], options="--auto-check-trustdb")
 gpg.encoding = "utf-8"
 
 with open(gentoo_auth, "r", encoding="utf8") as keyring:


### PR DESCRIPTION
Installing this package may fail if no-auto-check-trustdb is defined in /etc/gnupg/gpg.conf. This commit circumvent the issue by forcing --auto-check-trustdb which takes precedence over configuration file.

Bug: https://bugs.gentoo.org/940913

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
