### PR TITLE
Fix dev-ruby/io-event-1.6.5 and dev-ruby/io-event-1.5.1 testsuite fails

### DIFF
--- a/dev-ruby/io-event/files/io-event-1.6.5-update-test-hooks.patch
+++ b/dev-ruby/io-event/files/io-event-1.6.5-update-test-hooks.patch
@@ -1,0 +1,157 @@
+From c2ffc28e97a08534e003eaf25abfa35279274263 Mon Sep 17 00:00:00 2001
+From: Samuel Williams <samuel.williams@oriontransfer.co.nz>
+Date: Wed, 4 Sep 2024 20:53:04 +1200
+Subject: [PATCH] Update test before/after hooks.
+
+---
+ test/io/event/selector.rb             | 12 ++++--------
+ test/io/event/selector/buffered_io.rb |  4 ++--
+ test/io/event/selector/cancellable.rb |  7 +++----
+ test/io/event/selector/file_io.rb     |  4 ++--
+ test/io/event/selector/process_io.rb  |  4 ++--
+ test/io/event/selector/queue.rb       |  4 ++--
+ 6 files changed, 15 insertions(+), 20 deletions(-)
+
+diff --git a/test/io/event/selector.rb b/test/io/event/selector.rb
+index 760369a6..ee1a53f8 100644
+--- a/test/io/event/selector.rb
++++ b/test/io/event/selector.rb
+@@ -622,14 +622,12 @@ def transfer
+ 		end
+ 
+ 		with 'an instance' do
+-			def before
++			before do
+ 				@loop = Fiber.current
+ 				@selector = subject.new(@loop)
+-				super
+ 			end
+ 			
+-			def after
+-				super
++			after do
+ 				@selector&.close
+ 			end
+ 			
+@@ -642,14 +640,12 @@ def after
+ end
+ 
+ describe IO::Event::Debug::Selector do
+-	def before
++	before do
+ 		@loop = Fiber.current
+ 		@selector = subject.new(IO::Event::Selector.new(loop))
+-		super
+ 	end
+ 	
+-	def after
+-		super
++	after do
+ 		@selector&.close
+ 	end
+ 	
+diff --git a/test/io/event/selector/buffered_io.rb b/test/io/event/selector/buffered_io.rb
+index 3659d717..3b74d569 100644
+--- a/test/io/event/selector/buffered_io.rb
++++ b/test/io/event/selector/buffered_io.rb
+@@ -80,12 +80,12 @@
+ 	next unless klass.instance_methods.include?(:io_read)
+ 	
+ 	describe(klass, unique: name) do
+-		def before
++		before do
+ 			@loop = Fiber.current
+ 			@selector = subject.new(@loop)
+ 		end
+ 		
+-		def after
++		after do
+ 			@selector&.close
+ 		end
+ 		
+diff --git a/test/io/event/selector/cancellable.rb b/test/io/event/selector/cancellable.rb
+index 2dfa2bae..cb6c1f2a 100644
+--- a/test/io/event/selector/cancellable.rb
++++ b/test/io/event/selector/cancellable.rb
+@@ -15,8 +15,7 @@
+ 		let(:input) {pipe.first}
+ 		let(:output) {pipe.last}
+ 		
+-		def after
+-			super
++		after do
+ 			input.close
+ 			output.close
+ 		end
+@@ -70,12 +69,12 @@ def after
+ 	next unless klass.instance_methods.include?(:io_read)
+ 	
+ 	describe(klass, unique: name) do
+-		def before
++		before do
+ 			@loop = Fiber.current
+ 			@selector = subject.new(@loop)
+ 		end
+ 		
+-		def after
++		after do
+ 			@selector&.close
+ 		end
+ 		
+diff --git a/test/io/event/selector/file_io.rb b/test/io/event/selector/file_io.rb
+index 70a2c962..395a45e3 100644
+--- a/test/io/event/selector/file_io.rb
++++ b/test/io/event/selector/file_io.rb
+@@ -49,12 +49,12 @@
+ 	next unless klass.instance_methods.include?(:io_read)
+ 	
+ 	describe(klass, unique: name) do
+-		def before
++		before do
+ 			@loop = Fiber.current
+ 			@selector = subject.new(@loop)
+ 		end
+ 		
+-		def after
++		after do
+ 			@selector&.close
+ 		end
+ 		
+diff --git a/test/io/event/selector/process_io.rb b/test/io/event/selector/process_io.rb
+index cb8c73de..1ccff956 100644
+--- a/test/io/event/selector/process_io.rb
++++ b/test/io/event/selector/process_io.rb
+@@ -43,12 +43,12 @@
+ 	klass = IO::Event::Selector.const_get(name)
+ 	
+ 	describe(klass, unique: name) do
+-		def before
++		before do
+ 			@loop = Fiber.current
+ 			@selector = subject.new(@loop)
+ 		end
+ 		
+-		def after
++		after do
+ 			@selector&.close
+ 		end
+ 		
+diff --git a/test/io/event/selector/queue.rb b/test/io/event/selector/queue.rb
+index e62af5c4..8017dc36 100644
+--- a/test/io/event/selector/queue.rb
++++ b/test/io/event/selector/queue.rb
+@@ -198,12 +198,12 @@ def object.transfer
+ 	klass = IO::Event::Selector.const_get(name)
+ 	
+ 	describe(klass, unique: name) do
+-		def before
++		before do
+ 			@loop = Fiber.current
+ 			@selector = subject.new(@loop)
+ 		end
+ 		
+-		def after
++		after do
+ 			@selector&.close
+ 		end
+ 		

--- a/dev-ruby/io-event/io-event-1.5.1-r1.ebuild
+++ b/dev-ruby/io-event/io-event-1.5.1-r1.ebuild
@@ -1,0 +1,40 @@
+# Copyright 2022-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+USE_RUBY="ruby31 ruby32 ruby33"
+
+RUBY_FAKEGEM_EXTENSIONS=(ext/extconf.rb)
+RUBY_FAKEGEM_EXTRADOC="readme.md"
+RUBY_FAKEGEM_GEMSPEC="${PN}.gemspec"
+RUBY_FAKEGEM_RECIPE_TEST="sus"
+
+inherit ruby-fakegem
+
+DESCRIPTION="An event loop"
+HOMEPAGE="https://github.com/socketry/io-event"
+SRC_URI="https://github.com/socketry/io-event/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="MIT"
+SLOT="$(ver_cut 1)"
+KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~riscv ~sparc ~x86"
+IUSE="+io-uring"
+
+RDEPEND="io-uring? ( sys-libs/liburing:= )"
+DEPEND="${RDEPEND}"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-1.6.5-update-test-hooks.patch
+)
+
+all_ruby_prepare() {
+	sed -i -E 's/require_relative "(.+)"/require File.expand_path("\1")/g' "${RUBY_FAKEGEM_GEMSPEC}" || die
+
+	# Avoid dependency on unpackaged covered package
+	rm -f config/sus.rb || die
+
+	if ! use io-uring ; then
+		sed -i -e "s:have_library('uring'):have_library('idonotexist_uring'):" ext/extconf.rb || die
+	fi
+}

--- a/dev-ruby/io-event/io-event-1.6.5-r1.ebuild
+++ b/dev-ruby/io-event/io-event-1.6.5-r1.ebuild
@@ -24,6 +24,10 @@ IUSE="+io-uring"
 RDEPEND="io-uring? ( sys-libs/liburing:= )"
 DEPEND="${RDEPEND}"
 
+PATCHES=(
+	"${FILESDIR}"/${PN}-1.6.5-update-test-hooks.patch
+)
+
 all_ruby_prepare() {
 	sed -i -E 's/require_relative "(.+)"/require File.expand_path("\1")/g' "${RUBY_FAKEGEM_GEMSPEC}" || die
 


### PR DESCRIPTION
This change backports upstream commit to fix the testsuite failures.
Closes: https://bugs.gentoo.org/941411

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.