### PR TITLE
media-gfx/hugin: tiff USE for vigra

### DIFF
--- a/media-gfx/hugin/hugin-2023.0.0-r1.ebuild
+++ b/media-gfx/hugin/hugin-2023.0.0-r1.ebuild
@@ -31,7 +31,7 @@ CDEPEND="
 	media-libs/libpng:=
 	media-libs/openexr:=
 	media-libs/tiff:=
-	>=media-libs/vigra-1.11.1-r5[openexr]
+	>=media-libs/vigra-1.11.1-r5[openexr,tiff]
 	sci-libs/fftw:3.0=
 	sci-libs/flann
 	sys-libs/zlib

--- a/media-gfx/hugin/hugin-2024.0_beta1.ebuild
+++ b/media-gfx/hugin/hugin-2024.0_beta1.ebuild
@@ -33,7 +33,7 @@ CDEPEND="
 	media-libs/libpng:=
 	media-libs/openexr:=
 	media-libs/tiff:=
-	>=media-libs/vigra-1.11.1-r5[openexr]
+	>=media-libs/vigra-1.11.1-r5[openexr,tiff]
 	sci-libs/fftw:3.0=
 	sci-libs/flann
 	sys-libs/zlib

--- a/media-gfx/hugin/hugin-9999.ebuild
+++ b/media-gfx/hugin/hugin-9999.ebuild
@@ -35,7 +35,7 @@ CDEPEND="
 	media-libs/libpng:=
 	media-libs/openexr:=
 	media-libs/tiff:=
-	>=media-libs/vigra-1.11.1-r5[openexr]
+	>=media-libs/vigra-1.11.1-r5[openexr,tiff]
 	sci-libs/fftw:3.0=
 	sci-libs/flann
 	sys-libs/zlib


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/938945

As the bug report mentions, `media-gfx/hugin` crashes without `tiff` USE for `media-libs/vigra` even when TIFF is not used, affecting users with `-tiff` in `make.conf`, for whom a USE flag change should be required when emerging hugin (which is achieved by this PR).

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
