### PR TITLE
sci-electronics/kicad: live ebuild dependency fix

### DIFF
--- a/sci-electronics/kicad/kicad-9999.ebuild
+++ b/sci-electronics/kicad/kicad-9999.ebuild
@@ -66,6 +66,11 @@ COMMON_DEPEND="
 		media-gfx/cairosvg
 	)
 "
+
+if [[ ${PV} == 9999 ]] ; then
+	COMMON_DEPEND+="dev-libs/protobuf"
+fi
+
 DEPEND="${COMMON_DEPEND}"
 RDEPEND="${COMMON_DEPEND}
 	sci-electronics/electronics-menu


### PR DESCRIPTION
KiCad 9 will depend on dev-libs/protobuf, which is already present
in the current source tree.

Closes: https://bugs.gentoo.org/939153
Signed-off-by: Zoltan Puskas <zoltan@sinustrom.info>

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
