### PR TITLE
net-misc/gns3-*: drop sentry-sdk dependency

### DIFF
--- a/net-misc/gns3-gui/gns3-gui-2.2.48.1.ebuild
+++ b/net-misc/gns3-gui/gns3-gui-2.2.48.1.ebuild
@@ -21,7 +21,6 @@ RDEPEND="
 	>=dev-python/distro-1.9.0[${PYTHON_USEDEP}]
 	>=dev-python/jsonschema-4.22.0[${PYTHON_USEDEP}]
 	>=dev-python/psutil-6.0.0[${PYTHON_USEDEP}]
-	>=dev-python/sentry-sdk-2.7.1[${PYTHON_USEDEP}]
 	>=dev-python/truststore-0.9.1[${PYTHON_USEDEP}]
 	~net-misc/gns3-server-${PV}[${PYTHON_USEDEP}]
 	dev-python/PyQt5[gui,network,svg,websockets,widgets,${PYTHON_USEDEP}]

--- a/net-misc/gns3-gui/gns3-gui-2.2.49.ebuild
+++ b/net-misc/gns3-gui/gns3-gui-2.2.49.ebuild
@@ -21,7 +21,6 @@ RDEPEND="
 	>=dev-python/distro-1.9.0[${PYTHON_USEDEP}]
 	>=dev-python/jsonschema-4.23.0[${PYTHON_USEDEP}]
 	>=dev-python/psutil-6.0.0[${PYTHON_USEDEP}]
-	>=dev-python/sentry-sdk-2.12[${PYTHON_USEDEP}]
 	>=dev-python/truststore-0.9.1[${PYTHON_USEDEP}]
 	~net-misc/gns3-server-${PV}[${PYTHON_USEDEP}]
 	dev-python/PyQt5[gui,network,svg,websockets,widgets,${PYTHON_USEDEP}]

--- a/net-misc/gns3-server/gns3-server-2.2.48.1.ebuild
+++ b/net-misc/gns3-server/gns3-server-2.2.48.1.ebuild
@@ -30,7 +30,6 @@ RDEPEND="
 	>=dev-python/platformdirs-2.4.0[${PYTHON_USEDEP}]
 	>=dev-python/psutil-6.0.0[${PYTHON_USEDEP}]
 	>=dev-python/py-cpuinfo-9.0.0[${PYTHON_USEDEP}]
-	>=dev-python/sentry-sdk-2.7.1[${PYTHON_USEDEP}]
 	>=dev-python/truststore-0.9.1[${PYTHON_USEDEP}]
 	net-misc/ubridge
 	sys-apps/busybox[static]

--- a/net-misc/gns3-server/gns3-server-2.2.49.ebuild
+++ b/net-misc/gns3-server/gns3-server-2.2.49.ebuild
@@ -30,7 +30,6 @@ RDEPEND="
 	>=dev-python/platformdirs-2.4.0[${PYTHON_USEDEP}]
 	>=dev-python/psutil-6.0.0[${PYTHON_USEDEP}]
 	>=dev-python/py-cpuinfo-9.0.0[${PYTHON_USEDEP}]
-	>=dev-python/sentry-sdk-2.12[${PYTHON_USEDEP}]
 	>=dev-python/truststore-0.9.1[${PYTHON_USEDEP}]
 	net-misc/ubridge
 	sys-apps/busybox[static]


### PR DESCRIPTION
Upstream is going to make sentry-sdk optional and it should be already possible to run gns3 without it.
see: https://github.com/GNS3/gns3-server/issues/2423

I've made some basic tests and for me gns3 was running fine without `sentry-sdk` installed.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
