### PR TITLE
sys-kernel/linux-firmware: add python to makedeps, add separate dedup…

### DIFF
--- a/sys-kernel/linux-firmware/linux-firmware-99999999.ebuild
+++ b/sys-kernel/linux-firmware/linux-firmware-99999999.ebuild
@@ -40,6 +40,7 @@ RESTRICT="binchecks strip test
 BDEPEND="initramfs? ( app-alternatives/cpio )
 	compress-xz? ( app-arch/xz-utils )
 	compress-zstd? ( app-arch/zstd )
+	python
 	deduplicate? ( app-misc/rdfind )"
 
 #add anything else that collides to this
@@ -120,6 +121,7 @@ src_prepare() {
 		|| die
 
 	chmod +x copy-firmware.sh || die
+	chmod +x dedup-firmware.sh || die
 	cp "${FILESDIR}/${PN}-make-amd-ucode-img.bash" "${T}/make-amd-ucode-img" || die
 	chmod +x "${T}/make-amd-ucode-img" || die
 
@@ -136,6 +138,7 @@ src_prepare() {
 	# whitelist of misc files
 	local misc_files=(
 		copy-firmware.sh
+		dedup-firmware.sh
 		WHENCE
 		README
 	)
@@ -284,9 +287,9 @@ src_install() {
 	elif use compress-zstd; then
 		FW_OPTIONS+=( "--zstd" )
 	fi
-	! use deduplicate && FW_OPTIONS+=( "--ignore-duplicates" )
 	FW_OPTIONS+=( "${ED}/lib/firmware" )
 	./copy-firmware.sh "${FW_OPTIONS[@]}" || die
+	use deduplicate && ./dedup-firmware.sh "${ED}/lib/firmware" || die
 
 	pushd "${ED}/lib/firmware" &>/dev/null || die
 


### PR DESCRIPTION
… stage

Recently upstream has started running check_whence.py prior to the installation process, to ensure the WHENCE metadata is in the correct format.

In addition, the de-duplication stage is no longer forced onto everyone. So anyone interested, can run the separate target.

Both of those are done by yours truly, so direct any rotten tomatoes^W^Wpraise towards me ;-)

---

NOTE: the python part has landed already, the "don't force de-duplication" will be coming shortly.

Team, please note that I'm not a Gentoo user/developer so it's possible that this change is completely broken. Although it should be clear and indicative enough to illustrate the goal.

On somewhat related note, I would kindly request/suggest:
 - the de-duplication can now be moved to more appropriate, later stage - post savedconfig?
 - the `chmod` from `src_prepare()` could live in upstream - `copy-firmware.sh` `check_whence.py` or otherwise
 - the individual `free_software` and `unknown_license` arrays are somewhat fragile ... Debian has similar goals, so there is a potential for cooperation in getting this upstream eg. `copy-firmware.sh --only=free_software`


<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.

---
