### PR TITLE
sci-libs/libqalculate: Increase stack size on musl

### DIFF
--- a/sci-libs/libqalculate/libqalculate-5.3.0-r1.ebuild
+++ b/sci-libs/libqalculate/libqalculate-5.3.0-r1.ebuild
@@ -1,0 +1,87 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+# Bump with sci-calculators/qalculate-gtk and sci-calculators/qalculate-qt
+
+inherit flag-o-matic toolchain-funcs
+
+MY_PV="${PV//b/}"
+
+DESCRIPTION="A modern multi-purpose calculator library"
+HOMEPAGE="https://qalculate.github.io/"
+SRC_URI="https://github.com/Qalculate/${PN}/releases/download/v${MY_PV}/${P}.tar.gz"
+S="${WORKDIR}"/"${PN}-${MY_PV}"
+
+LICENSE="GPL-2+"
+# SONAME changes pretty often on bumps. Check!
+SLOT="0/23.3"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86 ~amd64-linux ~x86-linux"
+IUSE="curl icu gnuplot +hardened readline test"
+RESTRICT="!test? ( test )"
+
+DEPEND="dev-libs/gmp:=
+	dev-libs/libxml2:2
+	dev-libs/mpfr:=
+	virtual/libiconv
+	curl? ( net-misc/curl )
+	icu? ( dev-libs/icu:= )
+	readline? ( sys-libs/readline:= )"
+RDEPEND="${DEPEND}
+	gnuplot? ( >=sci-visualization/gnuplot-3.7 )"
+BDEPEND="dev-util/intltool
+	sys-devel/gettext
+	virtual/pkgconfig"
+
+src_prepare() {
+	default
+	cat >po/POTFILES.skip <<-EOF || die
+		# Required by make check
+		data/currencies.xml.in
+		data/datasets.xml.in
+		data/elements.xml.in
+		data/functions.xml.in
+		data/planets.xml.in
+		data/prefixes.xml.in
+		data/units.xml.in
+		data/variables.xml.in
+		src/defs2doc.cc
+	EOF
+}
+
+src_configure() {
+	# Needed for po-defs/Makefile
+	export CXX_FOR_BUILD="$(tc-getBUILD_CXX)"
+	export CXXCPP_FOR_BUILD="$(tc-getBUILD_CXX) -E"
+
+	# bug #792027
+	tc-export CC
+
+	# bug #924939
+	use elibc_musl && append-ldflags -Wl,-z,stack-size=2097152
+
+	local myeconfargs=(
+		$(use_enable test tests)
+		$(use_enable test unittests)
+		$(use_with curl libcurl)
+		$(use_with gnuplot gnuplot-call)
+		$(use_enable !hardened insecure)
+		$(use_with icu)
+		$(use_with readline)
+	)
+
+	econf "${myeconfargs[@]}"
+}
+
+src_install() {
+	# docs/reference/Makefile.am -> referencedir=
+	emake \
+		DESTDIR="${D}" \
+		referencedir="${EPREFIX}/usr/share/doc/${PF}/html" \
+		install
+
+	einstalldocs
+
+	find "${ED}" -name '*.la' -delete || die
+}


### PR DESCRIPTION
Originally discovered through unittests, certain equations given to libqalculate will result in a stack overflow, as witnessed using ASAN.

ASAN output example:

```
==8920==ERROR: AddressSanitizer: stack-overflow on address 0x7f6a6a4f4e38 (pc 0x7f6a6ab4b695 bp 0x7f6a6a4f6180 sp 0x7f6a6a4f4e00 T1)
    #0 0x7f6a6ab4b695 in MathStructure::merge_multiplication(MathStructure&, EvaluationOptions const&, MathStructure*, unsigned long, unsigned long, bool, bool) (/lib/libqalculate.so.23+0x54b695)
```
Closes: https://bugs.gentoo.org/924939

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
