### PR TITLE
x11-libs/gl2ps: Fix dependencies

### DIFF
--- a/x11-libs/gl2ps/gl2ps-1.4.2-r1.ebuild
+++ b/x11-libs/gl2ps/gl2ps-1.4.2-r1.ebuild
@@ -1,0 +1,51 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+inherit cmake
+
+DESCRIPTION="OpenGL to PostScript printing library"
+HOMEPAGE="http://www.geuz.org/gl2ps/"
+SRC_URI="http://geuz.org/${PN}/src/${P}.tgz"
+
+LICENSE="LGPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
+IUSE="doc png zlib"
+
+RDEPEND="
+	media-libs/libglvnd
+	png? ( media-libs/libpng:0= )
+	zlib? ( sys-libs/zlib )"
+DEPEND="${RDEPEND}
+	doc? (
+		dev-tex/tth
+		dev-texlive/texlive-latex
+		dev-texlive/texlive-latexrecommended )"
+
+PATCHES=( "${FILESDIR}"/${PN}-1.4.2-cmake.patch )
+
+src_prepare() {
+	cmake_src_prepare
+	sed '/^install.*TODO\.txt/d' -i "${S}"/CMakeLists.txt || die
+}
+
+src_configure() {
+	local mycmakeargs=(
+		-DCMAKE_INSTALL_DOCDIR="share/doc/${PF}"
+		-DENABLE_DOC="$(usex doc)"
+		-DENABLE_PNG="$(usex png)"
+		-DENABLE_ZLIB="$(usex zlib)"
+		-DOpenGL_GL_PREFERENCE=GLVND
+	)
+	cmake_src_configure
+}
+
+src_install() {
+	cmake_src_install
+	if [[ ${CHOST} == *-darwin* ]] ; then
+		install_name_tool \
+			-id "${EPREFIX}"/usr/$(get_libdir)/libgl2ps.dylib \
+			"${D}${EPREFIX}"/usr/$(get_libdir)/libgl2ps.dylib || die
+	fi
+}


### PR DESCRIPTION
- GL/gl.h is required not freeglut (which is used by the examples but the existing patch has the effect of disabling them)
- Can't see any use of x11-libs/libXmu and it compiles fine without

```diff
--- gl2ps-1.4.2.ebuild
+++ gl2ps-1.4.2-r1.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 inherit cmake
 
 DESCRIPTION="OpenGL to PostScript printing library"
@@ -10,12 +10,11 @@
 
 LICENSE="LGPL-2"
 SLOT="0"
-KEYWORDS="amd64 arm arm64 ~hppa ppc ppc64 ~riscv x86 ~amd64-linux ~x86-linux ~ppc-macos"
+KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~riscv ~x86 ~amd64-linux ~x86-linux ~ppc-macos"
 IUSE="doc png zlib"
 
 RDEPEND="
-	media-libs/freeglut
-	x11-libs/libXmu
+	media-libs/libglvnd
 	png? ( media-libs/libpng:0= )
 	zlib? ( sys-libs/zlib )"
 DEPEND="${RDEPEND}
@@ -37,6 +36,7 @@
 		-DENABLE_DOC="$(usex doc)"
 		-DENABLE_PNG="$(usex png)"
 		-DENABLE_ZLIB="$(usex zlib)"
+		-DOpenGL_GL_PREFERENCE=GLVND
 	)
 	cmake_src_configure
 }
```
---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
Added with `pkgdev commit`

Please note that all boxes must be checked for the pull request to be merged.
