### PR TITLE
sys-cluster/charliecloud: don't pass -W to sphinx-build

### DIFF
--- a/sys-cluster/charliecloud/charliecloud-0.38.ebuild
+++ b/sys-cluster/charliecloud/charliecloud-0.38.ebuild
@@ -55,6 +55,8 @@ DEPEND="
 
 src_prepare() {
 	default
+	# Remove -W from SPHINXOPTS to prevent failure due to warnings
+	sed -i 's#^SPHINXOPTS .*=.*#SPHINXOPTS =#' doc/Makefile.am || die "Makefile patching failed"
 	eautoreconf
 }
 

--- a/sys-cluster/charliecloud/charliecloud-9999.ebuild
+++ b/sys-cluster/charliecloud/charliecloud-9999.ebuild
@@ -57,6 +57,8 @@ DEPEND="
 
 src_prepare() {
 	default
+	# Remove -W from SPHINXOPTS to prevent failure due to warnings
+	sed -i 's#^SPHINXOPTS .*=.*#SPHINXOPTS =#' doc/Makefile.am || die "Makefile patching failed"
 	eautoreconf
 }
 


### PR DESCRIPTION
This effectively works like -Werror and causes build failures
such as #941591 from simple deprecation warnings.

Closes: https://bugs.gentoo.org/941591

This also drops the oldest version from tree. 

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
