### PR TITLE
perl-module.eclass: Override CCFLAGS and LDDLFLAGS

### DIFF
--- a/eclass/perl-module.eclass
+++ b/eclass/perl-module.eclass
@@ -296,6 +296,8 @@ perl-module_src_configure() {
 			RANLIB="$(tc-getRANLIB)" \
 			OPTIMIZE="${CFLAGS}" \
 			LDFLAGS="${LDFLAGS}" \
+			CCFLAGS="${CFLAGS}" \
+            LDDLFLAGS="-shared ${LDFLAGS}" \
 			PREFIX="${EPREFIX}"/usr \
 			INSTALLDIRS=vendor \
 			INSTALLMAN3DIR='none' \


### PR DESCRIPTION
Otherwise host flags leak in and may break cross-building if `-march` is present.


