### PR TITLE
media-gfx/gimp: gimp-2.10.x, fix media-libs/libheif-1.18 compat

### DIFF
--- a/media-gfx/gimp/files/gimp-2.10_libheif-1.18_unconditional_compat.patch
+++ b/media-gfx/gimp/files/gimp-2.10_libheif-1.18_unconditional_compat.patch
@@ -1,0 +1,23 @@
+Gentoo issue: https://bugs.gentoo.org/940915
+
+diff '--color=auto' -Naur a/configure.ac b/configure.ac
+--- a/configure.ac
++++ b/configure.ac
+@@ -1843,13 +1843,13 @@
+ can_import_avif=no
+ can_export_avif=no
+ if test "x$have_libheif" = xyes; then
+-  can_import_heic=`$PKG_CONFIG --variable=builtin_h265_decoder libheif`
+-  can_export_heic=`$PKG_CONFIG --variable=builtin_h265_encoder libheif`
++  can_import_heic=yes
++  can_export_heic=yes
+   if test "x$can_import_heic" = xyes; then
+     MIME_TYPES="$MIME_TYPES;image/heif;image/heic"
+   fi
+-  can_import_avif=`$PKG_CONFIG --variable=builtin_avif_decoder libheif`
+-  can_export_avif=`$PKG_CONFIG --variable=builtin_avif_encoder libheif`
++  can_import_avif=yes
++  can_export_avif=yes
+   if test "x$can_import_avif" = xyes; then
+     MIME_TYPES="$MIME_TYPES;image/avif"
+   fi

--- a/media-gfx/gimp/gimp-2.10.34-r3.ebuild
+++ b/media-gfx/gimp/gimp-2.10.34-r3.ebuild
@@ -12,13 +12,13 @@ HOMEPAGE="https://www.gimp.org/"
 SRC_URI="mirror://gimp/v$(ver_cut 1-2)/${P}.tar.bz2"
 LICENSE="GPL-3+ LGPL-3+"
 SLOT="0/2"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~x86"
+KEYWORDS="~alpha amd64 ~arm arm64 ~hppa ~loong ~ppc ppc64 ~riscv x86"
 
 IUSE="aalib alsa aqua debug doc gnome heif jpeg2k jpegxl mng openexr postscript udev unwind vector-icons webp wmf xpm cpu_flags_ppc_altivec cpu_flags_x86_mmx cpu_flags_x86_sse"
 
 RESTRICT="!test? ( test )"
 
-DEPEND="
+COMMON_DEPEND="
 	>=app-accessibility/at-spi2-core-2.46.0
 	>=app-text/poppler-0.50[cairo]
 	>=app-text/poppler-data-0.4.7
@@ -63,18 +63,19 @@ DEPEND="
 "
 
 RDEPEND="
-	${DEPEND}
+	${COMMON_DEPEND}
 	x11-themes/hicolor-icon-theme
 	gnome? ( gnome-base/gvfs )
 "
 
-BDEPEND="
+DEPEND="
+	${COMMON_DEPEND}
 	>=dev-lang/perl-5.10.0
 	dev-libs/appstream-glib
 	>=dev-build/gtk-doc-am-1
 	dev-util/gtk-update-icon-cache
 	>=dev-util/intltool-0.40.1
-	>=sys-devel/gettext-0.19.8
+	>=sys-devel/gettext-0.19
 	>=dev-build/libtool-2.2
 	virtual/pkgconfig
 "
@@ -85,9 +86,6 @@ PATCHES=(
 	"${FILESDIR}/${PN}-2.10_fix_test-appdata.patch" # Bugs 685210 (and duplicate 691070)
 	"${FILESDIR}/${PN}-2.10_fix_musl_backtrace_backend_switch.patch" #900148
 	"${FILESDIR}/${PN}-2.10_fix_configure_GCC13_implicit_function_declarations.patch" #899796
-	"${FILESDIR}/${P}_fix_strict-aliasing.patch" #917497
-	"${FILESDIR}/${P}_c99_tiff.patch" #919282
-	"${FILESDIR}/${P}_c99_metadata.patch" #919282
 )
 
 src_prepare() {
@@ -95,6 +93,10 @@ src_prepare() {
 
 	sed -i -e 's/== "xquartz"/= "xquartz"/' configure.ac || die #494864
 	sed 's/-DGIMP_DISABLE_DEPRECATED/-DGIMP_protect_DISABLE_DEPRECATED/g' -i configure.ac || die #615144
+
+	if use heif ; then
+		has_version -d ">=media-libs/libheif-1.18.0" && eapply "${FILESDIR}/${PN}-2.10_libheif-1.18_unconditional_compat.patch" # 940915
+	fi
 
 	gnome2_src_prepare  # calls eautoreconf
 
@@ -194,7 +196,7 @@ src_install() {
 	# precedence on PDF documents by default
 	mv "${ED}"/usr/share/applications/{,zzz-}gimp.desktop || die
 
-	find "${D}" -name '*.la' -type f -delete || die
+	find "${ED}" -name '*.la' -type f -delete || die
 
 	# Prevent dead symlink gimp-console.1 from downstream man page compression (bug #433527)
 	local gimp_app_version=$(ver_cut 1-2)

--- a/media-gfx/gimp/gimp-2.10.36-r3.ebuild
+++ b/media-gfx/gimp/gimp-2.10.36-r3.ebuild
@@ -12,13 +12,13 @@ HOMEPAGE="https://www.gimp.org/"
 SRC_URI="mirror://gimp/v$(ver_cut 1-2)/${P}.tar.bz2"
 LICENSE="GPL-3+ LGPL-3+"
 SLOT="0/2"
-KEYWORDS="~alpha amd64 ~arm arm64 ~hppa ~loong ~ppc ppc64 ~riscv x86"
+KEYWORDS="~alpha amd64 ~arm ~arm64 ~hppa ~loong ~ppc ppc64 ~riscv x86"
 
 IUSE="aalib alsa aqua debug doc gnome heif jpeg2k jpegxl mng openexr postscript udev unwind vector-icons webp wmf xpm cpu_flags_ppc_altivec cpu_flags_x86_mmx cpu_flags_x86_sse"
 
 RESTRICT="!test? ( test )"
 
-COMMON_DEPEND="
+DEPEND="
 	>=app-accessibility/at-spi2-core-2.46.0
 	>=app-text/poppler-0.50[cairo]
 	>=app-text/poppler-data-0.4.7
@@ -63,19 +63,18 @@ COMMON_DEPEND="
 "
 
 RDEPEND="
-	${COMMON_DEPEND}
+	${DEPEND}
 	x11-themes/hicolor-icon-theme
 	gnome? ( gnome-base/gvfs )
 "
 
-DEPEND="
-	${COMMON_DEPEND}
+BDEPEND="
 	>=dev-lang/perl-5.10.0
 	dev-libs/appstream-glib
 	>=dev-build/gtk-doc-am-1
 	dev-util/gtk-update-icon-cache
 	>=dev-util/intltool-0.40.1
-	>=sys-devel/gettext-0.19
+	>=sys-devel/gettext-0.19.8
 	>=dev-build/libtool-2.2
 	virtual/pkgconfig
 "
@@ -93,6 +92,10 @@ src_prepare() {
 
 	sed -i -e 's/== "xquartz"/= "xquartz"/' configure.ac || die #494864
 	sed 's/-DGIMP_DISABLE_DEPRECATED/-DGIMP_protect_DISABLE_DEPRECATED/g' -i configure.ac || die #615144
+
+	if use heif ; then
+		has_version -d ">=media-libs/libheif-1.18.0" && eapply "${FILESDIR}/${PN}-2.10_libheif-1.18_unconditional_compat.patch" # 940915
+	fi
 
 	gnome2_src_prepare  # calls eautoreconf
 
@@ -192,7 +195,7 @@ src_install() {
 	# precedence on PDF documents by default
 	mv "${ED}"/usr/share/applications/{,zzz-}gimp.desktop || die
 
-	find "${D}" -name '*.la' -type f -delete || die
+	find "${ED}" -name '*.la' -type f -delete || die
 
 	# Prevent dead symlink gimp-console.1 from downstream man page compression (bug #433527)
 	local gimp_app_version=$(ver_cut 1-2)

--- a/media-gfx/gimp/gimp-2.10.36-r4.ebuild
+++ b/media-gfx/gimp/gimp-2.10.36-r4.ebuild
@@ -12,20 +12,20 @@ HOMEPAGE="https://www.gimp.org/"
 SRC_URI="mirror://gimp/v$(ver_cut 1-2)/${P}.tar.bz2"
 LICENSE="GPL-3+ LGPL-3+"
 SLOT="0/2"
-KEYWORDS="~alpha amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv x86"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~x86"
 
 IUSE="aalib alsa aqua debug doc gnome heif jpeg2k jpegxl mng openexr postscript udev unwind vector-icons webp wmf xpm cpu_flags_ppc_altivec cpu_flags_x86_mmx cpu_flags_x86_sse"
 
 RESTRICT="!test? ( test )"
 
-COMMON_DEPEND="
-	>=app-accessibility/at-spi2-core-2.50.1
-	app-arch/bzip2
-	app-arch/xz-utils
+DEPEND="
+	>=app-accessibility/at-spi2-core-2.46.0
 	>=app-text/poppler-0.50[cairo]
 	>=app-text/poppler-data-0.4.7
 	>=dev-libs/glib-2.56.2:2
 	>=dev-libs/json-glib-1.2.6
+	dev-libs/libxml2:2
+	dev-libs/libxslt
 	>=gnome-base/librsvg-2.40.6:2
 	>=media-gfx/mypaint-brushes-2.0.2:=
 	>=media-libs/babl-0.1.98
@@ -44,11 +44,7 @@ COMMON_DEPEND="
 	>=x11-libs/cairo-1.12.2
 	>=x11-libs/gdk-pixbuf-2.31:2
 	>=x11-libs/gtk+-2.24.32:2
-	x11-libs/libX11
 	x11-libs/libXcursor
-	x11-libs/libXext
-	x11-libs/libXfixes
-	x11-libs/libXmu
 	>=x11-libs/pango-1.29.4
 	aalib? ( media-libs/aalib )
 	alsa? ( >=media-libs/alsa-lib-1.0.0 )
@@ -59,7 +55,7 @@ COMMON_DEPEND="
 	mng? ( media-libs/libmng:= )
 	openexr? ( >=media-libs/openexr-1.6.1:= )
 	postscript? ( app-text/ghostscript-gpl:= )
-	udev? ( dev-libs/libgudev )
+	udev? ( dev-libs/libgudev:= )
 	unwind? ( >=sys-libs/libunwind-1.1.0:= )
 	webp? ( >=media-libs/libwebp-0.6.0:= )
 	wmf? ( >=media-libs/libwmf-0.2.8 )
@@ -67,21 +63,15 @@ COMMON_DEPEND="
 "
 
 RDEPEND="
-	${COMMON_DEPEND}
+	${DEPEND}
 	x11-themes/hicolor-icon-theme
 	gnome? ( gnome-base/gvfs )
 "
 
-DEPEND="
-	${COMMON_DEPEND}
-	dev-libs/libxml2:2
-	dev-libs/libxslt
-"
-
 BDEPEND="
-	>=dev-build/gtk-doc-am-1
 	>=dev-lang/perl-5.10.0
 	dev-libs/appstream-glib
+	>=dev-build/gtk-doc-am-1
 	dev-util/gtk-update-icon-cache
 	>=dev-util/intltool-0.40.1
 	>=sys-devel/gettext-0.19.8
@@ -95,8 +85,9 @@ PATCHES=(
 	"${FILESDIR}/${PN}-2.10_fix_test-appdata.patch" # Bugs 685210 (and duplicate 691070)
 	"${FILESDIR}/${PN}-2.10_fix_musl_backtrace_backend_switch.patch" #900148
 	"${FILESDIR}/${PN}-2.10_fix_configure_GCC13_implicit_function_declarations.patch" #899796
-	"${FILESDIR}/${PN}-2.10.36_c99_tiff.patch" #919282
-	"${FILESDIR}/${PN}-2.10.36_c99_metadata.patch" #919282
+	"${FILESDIR}/${P}_fix_strict-aliasing.patch" #917497
+	"${FILESDIR}/${P}_c99_tiff.patch" #919282
+	"${FILESDIR}/${P}_c99_metadata.patch" #919282
 )
 
 src_prepare() {
@@ -104,6 +95,10 @@ src_prepare() {
 
 	sed -i -e 's/== "xquartz"/= "xquartz"/' configure.ac || die #494864
 	sed 's/-DGIMP_DISABLE_DEPRECATED/-DGIMP_protect_DISABLE_DEPRECATED/g' -i configure.ac || die #615144
+
+	if use heif ; then
+		has_version -d ">=media-libs/libheif-1.18.0" && eapply "${FILESDIR}/${PN}-2.10_libheif-1.18_unconditional_compat.patch" # 940915
+	fi
 
 	gnome2_src_prepare  # calls eautoreconf
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/940915

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
