### PR TITLE
media-gfx/freecad: Fix dependencies

### DIFF
--- a/media-gfx/freecad/files/freecad-1.0_rc2-Gentoo-specific-don-t-check-vcs.patch
+++ b/media-gfx/freecad/files/freecad-1.0_rc2-Gentoo-specific-don-t-check-vcs.patch
@@ -1,0 +1,15 @@
+--- a/src/Tools/SubWCRev.py
++++ b/src/Tools/SubWCRev.py
+@@ -510,12 +510,6 @@ def main():
+             bindir = a
+ 
+     vcs = [
+-        GitControl(),
+-        DebianGitHub(),
+-        BazaarControl(),
+-        Subversion(),
+-        MercurialControl(),
+-        DebianChangelog(),
+         UnknownControl(),
+     ]
+     for i in vcs:

--- a/media-gfx/freecad/freecad-1.0_rc2-r1.ebuild
+++ b/media-gfx/freecad/freecad-1.0_rc2-r1.ebuild
@@ -62,7 +62,7 @@ RDEPEND="
 		dev-qt/qtbase:6[concurrent,network,xml]
 	)
 	media-libs/freetype
-	sci-libs/opencascade:=[json,vtk]
+	sci-libs/opencascade:=[json]
 	sys-libs/zlib
 	cloud? (
 		dev-libs/openssl:=

--- a/media-gfx/freecad/freecad-1.0_rc2-r1.ebuild
+++ b/media-gfx/freecad/freecad-1.0_rc2-r1.ebuild
@@ -30,8 +30,8 @@ SLOT="0"
 IUSE="debug designer +gui +qt6 spacenav test X"
 
 FREECAD_EXPERIMENTAL_MODULES="cloud netgen pcl"
-FREECAD_STABLE_MODULES="addonmgr fem idf image inspection material
-	openscad part-design path points raytracing robot show smesh
+FREECAD_STABLE_MODULES="addonmgr fem idf inspection material
+	openscad part-design points robot show smesh
 	surface techdraw tux"
 
 for module in ${FREECAD_STABLE_MODULES}; do
@@ -61,7 +61,6 @@ REQUIRED_USE="
 	fem? ( smesh )
 	inspection? ( points )
 	openscad? ( smesh )
-	path? ( robot )
 	python_single_target_python3_12? ( gui? ( qt6 ) )
 "
 # There is no py3.12 support planned for pyside2
@@ -195,48 +194,50 @@ src_configure() {
 	append-ldflags -Wl,--copy-dt-needed-entries
 
 	local mycmakeargs=(
-		-DBUILD_ADDONMGR=$(usex addonmgr)
-		-DBUILD_ARCH=ON
-		-DBUILD_ASSEMBLY=OFF                    # Requires OndselSolver
-		-DBUILD_CLOUD=$(usex cloud)
-		-DBUILD_COMPLETE=OFF					# deprecated
-		-DBUILD_DRAFT=ON
 		-DBUILD_DESIGNER_PLUGIN=$(usex designer)
-		-DBUILD_ENABLE_CXX_STD:STRING="C++17"	# needed for current git master
+		-DBUILD_FORCE_DIRECTORY=ON				# force building in a dedicated directory
+		-DBUILD_GUI=$(usex gui)
+		-DBUILD_SMESH=$(usex smesh)
+		-DBUILD_VR=OFF
+		-DBUILD_WITH_CONDA=OFF
+
+		# Modules
+		-DBUILD_ADDONMGR=$(usex addonmgr)
+		-DBUILD_ASSEMBLY=OFF					# Requires OndselSolver
+		-DBUILD_BIM=ON
+		-DBUILD_CAM=ON
+		-DBUILD_CLOUD=$(usex cloud)
+		-DBUILD_DRAFT=ON
+		# see below for DRAWING
 		-DBUILD_FEM=$(usex fem)
 		-DBUILD_FEM_NETGEN=$(usex netgen)
-		-DBUILD_FLAT_MESH=ON
-		-DBUILD_FORCE_DIRECTORY=ON				# force building in a dedicated directory
-		-DBUILD_FREETYPE=ON						# automagic dep
-		-DBUILD_GUI=$(usex gui)
+		-DBUILD_FLAT_MESH=ON					# a submodule of MeshPart
+		-DBUILD_HELP=ON
 		-DBUILD_IDF=$(usex idf)
-		-DBUILD_IMAGE=$(usex image)
 		-DBUILD_IMPORT=ON						# import module for various file formats
 		-DBUILD_INSPECTION=$(usex inspection)
-		-DBUILD_JTREADER=OFF					# code has been removed upstream, but option is still there
+		-DBUILD_JTREADER=OFF					# uses an old proprietary library
 		-DBUILD_MATERIAL=$(usex material)
+		-DBUILD_MEASURE=ON
 		-DBUILD_MESH=ON
 		-DBUILD_MESH_PART=ON
 		-DBUILD_OPENSCAD=$(usex openscad)
 		-DBUILD_PART=ON
 		-DBUILD_PART_DESIGN=$(usex part-design)
-		-DBUILD_PATH=$(usex path)
+		-DBUILD_PLOT=ON
 		-DBUILD_POINTS=$(usex points)
-		-DBUILD_RAYTRACING=$(usex raytracing)
 		-DBUILD_REVERSEENGINEERING=OFF			# currently only an empty sandbox
 		-DBUILD_ROBOT=$(usex robot)
+		-DBUILD_SANDBOX=OFF
 		-DBUILD_SHOW=$(usex show)
 		-DBUILD_SKETCHER=ON						# needed by draft workspace
-		-DBUILD_SMESH=$(usex smesh)
 		-DBUILD_SPREADSHEET=ON
 		-DBUILD_START=ON
 		-DBUILD_SURFACE=$(usex surface)
 		-DBUILD_TECHDRAW=$(usex techdraw)
 		-DBUILD_TEST=ON							# always build test workbench for run-time testing
 		-DBUILD_TUX=$(usex tux)
-		-DBUILD_VR=OFF
 		-DBUILD_WEB=ON							# needed by start workspace
-		-DBUILD_WITH_CONDA=OFF
 
 		-DCMAKE_INSTALL_DATADIR=/usr/share/${PN}/data
 		-DCMAKE_INSTALL_DOCDIR=/usr/share/doc/${PF}

--- a/media-gfx/freecad/freecad-1.0_rc2-r1.ebuild
+++ b/media-gfx/freecad/freecad-1.0_rc2-r1.ebuild
@@ -62,8 +62,6 @@ RDEPEND="
 		dev-qt/qtbase:6[concurrent,network,xml]
 	)
 	media-libs/freetype
-	sci-libs/hdf5:=[fortran,zlib]
-	>=sci-libs/med-4.0.0-r1
 	sci-libs/opencascade:=[json,vtk]
 	sys-libs/zlib
 	cloud? (
@@ -113,6 +111,8 @@ RDEPEND="
 	openscad? ( media-gfx/openscad )
 	pcl? ( sci-libs/pcl:=[opengl,openni2,vtk] )
 	smesh? (
+		sci-libs/hdf5:=[fortran,zlib]
+		>=sci-libs/med-4.0.0-r1
 		!qt6? ( sci-libs/vtk:=[qt5] )
 		qt6? ( sci-libs/vtk:=[-qt5,qt6] )
 	)
@@ -156,7 +156,9 @@ BDEPEND="
 REQUIRED_USE="
 	${PYTHON_REQUIRED_USE}
 	designer? ( gui )
+	fem? ( smesh )
 	inspection? ( points )
+	openscad? ( smesh )
 	path? ( robot )
 	python_single_target_python3_12? ( gui? ( qt6 ) )
 "

--- a/media-gfx/freecad/freecad-1.0_rc2-r1.ebuild
+++ b/media-gfx/freecad/freecad-1.0_rc2-r1.ebuild
@@ -30,7 +30,7 @@ SLOT="0"
 IUSE="debug designer +gui +qt6 spacenav test X"
 
 FREECAD_EXPERIMENTAL_MODULES="cloud netgen pcl"
-FREECAD_STABLE_MODULES="addonmgr fem idf inspection material
+FREECAD_STABLE_MODULES="addonmgr fem idf inspection
 	openscad part-design points robot show smesh
 	surface techdraw tux"
 
@@ -217,7 +217,7 @@ src_configure() {
 		-DBUILD_IMPORT=ON						# import module for various file formats
 		-DBUILD_INSPECTION=$(usex inspection)
 		-DBUILD_JTREADER=OFF					# uses an old proprietary library
-		-DBUILD_MATERIAL=$(usex material)
+		-DBUILD_MATERIAL=ON
 		-DBUILD_MEASURE=ON
 		-DBUILD_MESH=ON
 		-DBUILD_MESH_PART=ON

--- a/media-gfx/freecad/freecad-1.0_rc2-r1.ebuild
+++ b/media-gfx/freecad/freecad-1.0_rc2-r1.ebuild
@@ -27,17 +27,18 @@ fi
 # examples are licensed CC-BY-SA (without note of specific version)
 LICENSE="LGPL-2 CC-BY-SA-4.0"
 SLOT="0"
-IUSE="debug designer +gui netgen pcl +qt6 smesh spacenav test X"
+IUSE="debug designer +gui netgen pcl +qt6 +smesh spacenav test X"
 # Modules are found in src/Mod/ and their options defined in:
 # cMake/FreeCAD_Helpers/InitializeFreeCADBuildOptions.cmake
 # To get their dependencies:
 # 'grep REQUIRES_MODS cMake/FreeCAD_Helpers/CheckInterModuleDependencies.cmake'
-IUSE+=" addonmgr bim cam cloud fem idf inspection mesh openscad points reverse robot surface +techdraw"
+IUSE+=" addonmgr +bim cam cloud fem idf inspection +mesh openscad points reverse robot surface +techdraw"
 
 REQUIRED_USE="
 	${PYTHON_REQUIRED_USE}
 	bim? ( mesh )
 	cam? ( mesh )
+	gui? ( bim )
 	designer? ( gui )
 	fem? ( smesh )
 	inspection? ( points )
@@ -47,6 +48,7 @@ REQUIRED_USE="
 	reverse? ( mesh points )
 	test? ( techdraw )
 "
+# Draft Workbench needs BIM
 # There is no py3.12 support planned for pyside2
 
 RESTRICT="!test? ( test )"

--- a/media-gfx/freecad/freecad-1.0_rc2-r1.ebuild
+++ b/media-gfx/freecad/freecad-1.0_rc2-r1.ebuild
@@ -117,10 +117,7 @@ RDEPEND="
 		spacenav? ( dev-libs/libspnav[X?] )
 	)
 	netgen? ( media-gfx/netgen[opencascade] )
-	openscad? (
-		media-gfx/openscad
-		$(python_gen_cond_dep 'dev-python/ply[${PYTHON_USEDEP}]')
-	)
+	openscad? ( $(python_gen_cond_dep 'dev-python/ply[${PYTHON_USEDEP}]') )
 	pcl? ( sci-libs/pcl:= )
 	smesh? (
 		sci-libs/hdf5:=[zlib]
@@ -339,6 +336,7 @@ pkg_postinst() {
 	optfeature_header "External programs used by FreeCAD"
 	optfeature "dependency graphs" media-gfx/graphviz
 	optfeature "importing and exporting 2D AutoCAD DWG files" media-gfx/libredwg
+	optfeature "importing OpenSCAD files, Mesh booleans" media-gfx/openscad
 	use bim && optfeature "working with COLLADA documents" dev-python/pycollada
 	( use fem || use mesh ) && optfeature "mesh generation" sci-libs/gmsh
 }

--- a/media-gfx/freecad/freecad-1.0_rc2-r1.ebuild
+++ b/media-gfx/freecad/freecad-1.0_rc2-r1.ebuild
@@ -131,7 +131,6 @@ DEPEND="${RDEPEND}
 	)
 "
 BDEPEND="
-	app-text/dos2unix
 	dev-lang/swig
 	test? (
 		$(python_gen_cond_dep 'dev-python/pyyaml[${PYTHON_USEDEP}]')
@@ -165,7 +164,7 @@ REQUIRED_USE="
 # There is no py3.12 support planned for pyside2
 
 PATCHES=(
-	"${FILESDIR}"/${PN}-9999-Gentoo-specific-don-t-check-vcs.patch
+	"${FILESDIR}"/${PN}-1.0_rc2-Gentoo-specific-don-t-check-vcs.patch
 	"${FILESDIR}"/${PN}-0.21.0-0001-Gentoo-specific-disable-ccache-usage.patch
 	"${FILESDIR}"/${PN}-9999-tests-src-Qt-only-build-test-for-BUILD_GUI-ON.patch
 )
@@ -183,8 +182,6 @@ pkg_setup() {
 src_prepare() {
 	# Fix desktop file
 	sed -e 's/Exec=FreeCAD/Exec=freecad/' -i src/XDGData/org.freecad.FreeCAD.desktop || die
-
-	find "${S}" -type f -exec dos2unix -q {} \; || die "failed to convert to unix line endings"
 
 	cmake_src_prepare
 }

--- a/media-gfx/freecad/freecad-1.0_rc2-r1.ebuild
+++ b/media-gfx/freecad/freecad-1.0_rc2-r1.ebuild
@@ -76,8 +76,7 @@ RDEPEND="
 		net-misc/curl
 	)
 	fem? (
-		!qt6? ( sci-libs/vtk:=[qt5,rendering] )
-		qt6? ( sci-libs/vtk:=[-qt5,qt6,rendering] )
+		sci-libs/vtk:=
 	)
 	gui? (
 		>=media-libs/coin-4.0.0
@@ -120,8 +119,7 @@ RDEPEND="
 	smesh? (
 		sci-libs/hdf5:=[zlib]
 		>=sci-libs/med-4.0.0-r1
-		!qt6? ( sci-libs/vtk:=[qt5] )
-		qt6? ( sci-libs/vtk:=[-qt5,qt6] )
+		sci-libs/vtk:=
 	)
 	$(python_gen_cond_dep '
 		dev-python/numpy[${PYTHON_USEDEP}]

--- a/media-gfx/freecad/freecad-1.0_rc2-r1.ebuild
+++ b/media-gfx/freecad/freecad-1.0_rc2-r1.ebuild
@@ -333,25 +333,14 @@ pkg_postinst() {
 	einfo "You can load a lot of additional workbenches using the integrated"
 	einfo "AddonManager."
 
-	# ToDo: check opencv, pysolar (::science), elmerfem (::science)
-	#		ifc++, ifcopenshell, z88 (no pkgs), calculix-ccx (::waebbl)
 	einfo "There are a lot of additional tools, for which FreeCAD has builtin"
 	einfo "support. Some of them are available in Gentoo. Take a look at"
 	einfo "https://wiki.freecad.org/Installing_additional_components"
-	optfeature_header "Computational utilities"
-	optfeature "Statistical computation with Python" dev-python/pandas
-	optfeature "Use scientific computation with Python" dev-python/scipy
-	optfeature "Use symbolic math with Python" dev-python/sympy
-	optfeature_header "Imaging, Plotting and Rendering utilities"
-	optfeature "Dependency graphs" media-gfx/graphviz
-	optfeature_header "Import / Export"
-	optfeature "Work with COLLADA documents" dev-python/pycollada
-	optfeature "Importing and exporting 2D AutoCAD DWG files" media-gfx/libredwg
-	optfeature "Importing and exporting geospatial data formats" sci-libs/gdal
-	optfeature "Working with projection data" sci-libs/proj
-	optfeature_header "Meshing and FEM"
-	optfeature "FEM mesh generator" sci-libs/gmsh
-	optfeature "Visualization" sci-visualization/paraview
+	optfeature_header "External programs used by FreeCAD"
+	optfeature "dependency graphs" media-gfx/graphviz
+	optfeature "importing and exporting 2D AutoCAD DWG files" media-gfx/libredwg
+	use bim && optfeature "working with COLLADA documents" dev-python/pycollada
+	( use fem || use mesh ) && optfeature "mesh generation" sci-libs/gmsh
 }
 
 pkg_postrm() {

--- a/media-gfx/freecad/freecad-1.0_rc2-r1.ebuild
+++ b/media-gfx/freecad/freecad-1.0_rc2-r1.ebuild
@@ -99,14 +99,13 @@ RDEPEND="
 			' python3_{10..11} )
 		)
 		qt6? (
-			designer? ( dev-qt/qttools:6[designer] )
-			dev-qt/qttools:6[widgets]
 			dev-qt/qtbase:6[gui,opengl,widgets]
 			dev-qt/qtsvg:6
+			dev-qt/qttools:6[designer?,widgets]
 			$(python_gen_cond_dep '
 				dev-python/matplotlib[${PYTHON_USEDEP}]
 				>=dev-python/pivy-0.6.5[${PYTHON_USEDEP}]
-				dev-python/pyside6:=[gui,svg,${PYTHON_USEDEP}]
+				dev-python/pyside6:=[designer,gui,svg,${PYTHON_USEDEP}]
 				dev-python/shiboken6:=[${PYTHON_USEDEP}]
 			' )
 		)

--- a/media-gfx/freecad/freecad-1.0_rc2-r1.ebuild
+++ b/media-gfx/freecad/freecad-1.0_rc2-r1.ebuild
@@ -90,7 +90,6 @@ RDEPEND="
 			dev-qt/qtsvg:5
 			dev-qt/qtwidgets:5
 			dev-qt/qtx11extras:5
-			pcl? ( sci-libs/pcl[qt5] )
 			$(python_gen_cond_dep '
 				dev-python/matplotlib[${PYTHON_USEDEP}]
 				>=dev-python/pivy-0.6.5[${PYTHON_USEDEP}]
@@ -103,7 +102,6 @@ RDEPEND="
 			dev-qt/qttools:6[widgets]
 			dev-qt/qtbase:6[gui,opengl,widgets]
 			dev-qt/qtsvg:6
-			pcl? ( sci-libs/pcl[-qt5,qt6(-)] )
 			$(python_gen_cond_dep '
 				dev-python/matplotlib[${PYTHON_USEDEP}]
 				>=dev-python/pivy-0.6.5[${PYTHON_USEDEP}]
@@ -115,7 +113,7 @@ RDEPEND="
 	)
 	netgen? ( media-gfx/netgen[opencascade] )
 	openscad? ( media-gfx/openscad )
-	pcl? ( sci-libs/pcl:=[opengl,openni2,vtk] )
+	pcl? ( sci-libs/pcl:= )
 	smesh? (
 		sci-libs/hdf5:=[zlib]
 		>=sci-libs/med-4.0.0-r1

--- a/media-gfx/freecad/freecad-1.0_rc2-r1.ebuild
+++ b/media-gfx/freecad/freecad-1.0_rc2-r1.ebuild
@@ -27,19 +27,22 @@ fi
 # examples are licensed CC-BY-SA (without note of specific version)
 LICENSE="LGPL-2 CC-BY-SA-4.0"
 SLOT="0"
-IUSE="debug designer +gui pcl +qt6 smesh spacenav test X"
+IUSE="debug designer +gui netgen pcl +qt6 smesh spacenav test X"
 # Modules are found in src/Mod/ and their options defined in:
 # cMake/FreeCAD_Helpers/InitializeFreeCADBuildOptions.cmake
 # To get their dependencies:
 # 'grep REQUIRES_MODS cMake/FreeCAD_Helpers/CheckInterModuleDependencies.cmake'
-IUSE+=" addonmgr cloud fem idf inspection netgen openscad points reverse robot surface +techdraw"
+IUSE+=" addonmgr bim cam cloud fem idf inspection mesh openscad points reverse robot surface +techdraw"
 
 REQUIRED_USE="
 	${PYTHON_REQUIRED_USE}
+	bim? ( mesh )
+	cam? ( mesh )
 	designer? ( gui )
 	fem? ( smesh )
 	inspection? ( points )
-	openscad? ( smesh )
+	mesh? ( smesh )
+	openscad? ( mesh )
 	python_single_target_python3_12? ( gui? ( qt6 ) )
 	reverse? ( mesh points )
 	test? ( techdraw )
@@ -174,6 +177,9 @@ src_configure() {
 	# Fix building tests
 	append-ldflags -Wl,--copy-dt-needed-entries
 
+	local fem_netgen
+	use fem && use netgen && fem_netgen=on || fem_netgen=off
+
 	local mycmakeargs=(
 		-DBUILD_DESIGNER_PLUGIN=$(usex designer)
 		-DBUILD_FORCE_DIRECTORY=ON				# force building in a dedicated directory
@@ -185,14 +191,14 @@ src_configure() {
 		# Modules
 		-DBUILD_ADDONMGR=$(usex addonmgr)
 		-DBUILD_ASSEMBLY=OFF					# Requires OndselSolver
-		-DBUILD_BIM=ON
-		-DBUILD_CAM=ON
+		-DBUILD_BIM=$(usex bim)
+		-DBUILD_CAM=$(usex cam)
 		-DBUILD_CLOUD=$(usex cloud)
 		-DBUILD_DRAFT=ON
 		# see below for DRAWING
 		-DBUILD_FEM=$(usex fem)
-		-DBUILD_FEM_NETGEN=$(usex netgen)
-		-DBUILD_FLAT_MESH=ON					# a submodule of MeshPart
+		-DBUILD_FEM_NETGEN=${fem_netgen}
+		-DBUILD_FLAT_MESH=$(usex mesh)			# a submodule of MeshPart
 		-DBUILD_HELP=ON
 		-DBUILD_IDF=$(usex idf)
 		-DBUILD_IMPORT=ON						# import module for various file formats
@@ -200,8 +206,8 @@ src_configure() {
 		-DBUILD_JTREADER=OFF					# uses an old proprietary library
 		-DBUILD_MATERIAL=ON
 		-DBUILD_MEASURE=ON
-		-DBUILD_MESH=ON
-		-DBUILD_MESH_PART=ON
+		-DBUILD_MESH=$(usex mesh)
+		-DBUILD_MESH_PART=$(usex mesh)
 		-DBUILD_OPENSCAD=$(usex openscad)
 		-DBUILD_PART=ON
 		-DBUILD_PART_DESIGN=ON

--- a/media-gfx/freecad/freecad-1.0_rc2-r1.ebuild
+++ b/media-gfx/freecad/freecad-1.0_rc2-r1.ebuild
@@ -71,6 +71,11 @@ RDEPEND="
 	media-libs/freetype
 	sci-libs/opencascade:=[json]
 	sys-libs/zlib
+	$(python_gen_cond_dep '
+		dev-python/numpy[${PYTHON_USEDEP}]
+		dev-python/pybind11[${PYTHON_USEDEP}]
+		dev-python/pyyaml[${PYTHON_USEDEP}]
+	')
 	cloud? (
 		dev-libs/openssl:=
 		net-misc/curl
@@ -122,23 +127,15 @@ RDEPEND="
 		>=sci-libs/med-4.0.0-r1
 		sci-libs/vtk:=
 	)
-	$(python_gen_cond_dep '
-		dev-python/numpy[${PYTHON_USEDEP}]
-		dev-python/pybind11[${PYTHON_USEDEP}]
-	')
 "
 DEPEND="${RDEPEND}
 	>=dev-cpp/eigen-3.3.1:3
 	dev-cpp/ms-gsl
-	test? (
-		$(python_gen_cond_dep 'dev-python/pyyaml[${PYTHON_USEDEP}]')
-		!qt6? ( dev-qt/qttest:5 )
-	)
+	test? ( !qt6? ( dev-qt/qttest:5 ) )
 "
 BDEPEND="
 	dev-lang/swig
 	test? (
-		$(python_gen_cond_dep 'dev-python/pyyaml[${PYTHON_USEDEP}]')
 		!qt6? ( dev-qt/qttest:5 )
 		dev-cpp/gtest
 	)
@@ -349,7 +346,6 @@ pkg_postinst() {
 	optfeature "Dependency graphs" media-gfx/graphviz
 	optfeature_header "Import / Export"
 	optfeature "Work with COLLADA documents" dev-python/pycollada
-	optfeature "YAML importer and emitter" dev-python/pyyaml
 	optfeature "Importing and exporting 2D AutoCAD DWG files" media-gfx/libredwg
 	optfeature "Importing and exporting geospatial data formats" sci-libs/gdal
 	optfeature "Working with projection data" sci-libs/proj

--- a/media-gfx/freecad/freecad-1.0_rc2-r1.ebuild
+++ b/media-gfx/freecad/freecad-1.0_rc2-r1.ebuild
@@ -77,6 +77,7 @@ RDEPEND="
 	)
 	fem? (
 		sci-libs/vtk:=
+		$(python_gen_cond_dep 'dev-python/ply[${PYTHON_USEDEP}]')
 	)
 	gui? (
 		>=media-libs/coin-4.0.0
@@ -112,7 +113,10 @@ RDEPEND="
 		spacenav? ( dev-libs/libspnav[X?] )
 	)
 	netgen? ( media-gfx/netgen[opencascade] )
-	openscad? ( media-gfx/openscad )
+	openscad? (
+		media-gfx/openscad
+		$(python_gen_cond_dep 'dev-python/ply[${PYTHON_USEDEP}]')
+	)
 	pcl? ( sci-libs/pcl:= )
 	smesh? (
 		sci-libs/hdf5:=[zlib]
@@ -122,7 +126,6 @@ RDEPEND="
 	$(python_gen_cond_dep '
 		dev-python/numpy[${PYTHON_USEDEP}]
 		dev-python/pybind11[${PYTHON_USEDEP}]
-		fem? ( dev-python/ply[${PYTHON_USEDEP}] )
 	')
 "
 DEPEND="${RDEPEND}

--- a/media-gfx/freecad/freecad-1.0_rc2-r1.ebuild
+++ b/media-gfx/freecad/freecad-1.0_rc2-r1.ebuild
@@ -301,7 +301,7 @@ src_test() {
 	local -x FREECAD_USER_HOME="${HOME}"
 	local -x FREECAD_USER_DATA="${T}"
 	local -x FREECAD_USER_TEMP="${T}"
-	./bin/FreeCADCmd --run-test 0 || die
+	./bin/FreeCADCmd --run-test 0 --set-config AppHomePath="${BUILD_DIR}/" || die
 }
 
 src_install() {

--- a/media-gfx/freecad/freecad-1.0_rc2-r1.ebuild
+++ b/media-gfx/freecad/freecad-1.0_rc2-r1.ebuild
@@ -32,7 +32,7 @@ IUSE="debug designer +gui pcl +qt6 smesh spacenav test X"
 # cMake/FreeCAD_Helpers/InitializeFreeCADBuildOptions.cmake
 # To get their dependencies:
 # 'grep REQUIRES_MODS cMake/FreeCAD_Helpers/CheckInterModuleDependencies.cmake'
-IUSE+=" addonmgr cloud fem idf inspection netgen openscad points robot surface techdraw"
+IUSE+=" addonmgr cloud fem idf inspection netgen openscad points robot surface +techdraw"
 
 REQUIRED_USE="
 	${PYTHON_REQUIRED_USE}
@@ -41,6 +41,7 @@ REQUIRED_USE="
 	inspection? ( points )
 	openscad? ( smesh )
 	python_single_target_python3_12? ( gui? ( qt6 ) )
+	test? ( techdraw )
 "
 # There is no py3.12 support planned for pyside2
 
@@ -286,18 +287,18 @@ src_configure() {
 # We use the FreeCADCmd binary instead of the FreeCAD binary here
 # for two reasons:
 # 1. It works out of the box with USE=-gui as well, not needing a guard
-# 2. We don't need virtualx.eclass and it's dependencies
-# The exported environment variables are needed, so freecad does know
-# where to save it's temporary files, and where to look and write it's
-# configuration. Without those, there are sandbox violation, when it
+# 2. We don't need virtualx.eclass and its dependencies
+# The environment variables are needed, so that FreeCAD knows
+# where to save its temporary files, and where to look and write its
+# configuration. Without those, there is a sandbox violation, when it
 # tries to create /var/lib/portage/home/.FreeCAD directory.
 src_test() {
-	pushd "${BUILD_DIR}" > /dev/null || die
-	export FREECAD_USER_HOME="${HOME}"
-	export FREECAD_USER_DATA="${T}"
-	export FREECAD_USER_TEMP="${T}"
-	nonfatal ./bin/FreeCADCmd --run-test 0
-	popd > /dev/null || die
+	cd "${BUILD_DIR}" || die
+
+	local -x FREECAD_USER_HOME="${HOME}"
+	local -x FREECAD_USER_DATA="${T}"
+	local -x FREECAD_USER_TEMP="${T}"
+	./bin/FreeCADCmd --run-test 0 || die
 }
 
 src_install() {

--- a/media-gfx/freecad/freecad-1.0_rc2-r1.ebuild
+++ b/media-gfx/freecad/freecad-1.0_rc2-r1.ebuild
@@ -84,14 +84,13 @@ RDEPEND="
 			dev-qt/qtopengl:5
 			dev-qt/qtprintsupport:5
 			dev-qt/qtsvg:5
-			dev-qt/qtwebengine:5[widgets]
 			dev-qt/qtwidgets:5
 			dev-qt/qtx11extras:5
 			pcl? ( sci-libs/pcl[qt5] )
 			$(python_gen_cond_dep '
 				dev-python/matplotlib[${PYTHON_USEDEP}]
 				>=dev-python/pivy-0.6.5[${PYTHON_USEDEP}]
-				dev-python/pyside2:=[gui,svg,webchannel,webengine,${PYTHON_USEDEP}]
+				dev-python/pyside2:=[gui,svg,${PYTHON_USEDEP}]
 				dev-python/shiboken2:=[${PYTHON_USEDEP}]
 			' python3_{10..11} )
 		)
@@ -100,12 +99,11 @@ RDEPEND="
 			dev-qt/qttools:6[widgets]
 			dev-qt/qtbase:6[gui,opengl,widgets]
 			dev-qt/qtsvg:6
-			dev-qt/qtwebengine:6[widgets]
 			pcl? ( sci-libs/pcl[-qt5,qt6(-)] )
 			$(python_gen_cond_dep '
 				dev-python/matplotlib[${PYTHON_USEDEP}]
 				>=dev-python/pivy-0.6.5[${PYTHON_USEDEP}]
-				dev-python/pyside6:=[gui,svg,webchannel,webengine,${PYTHON_USEDEP}]
+				dev-python/pyside6:=[gui,svg,${PYTHON_USEDEP}]
 				dev-python/shiboken6:=[${PYTHON_USEDEP}]
 			' )
 		)
@@ -256,7 +254,6 @@ src_configure() {
 		-DFREECAD_USE_PCL=$(usex pcl)
 		-DFREECAD_USE_PYBIND11=ON
 		-DFREECAD_USE_QT_FILEDIALOG=ON
-		-DFREECAD_USE_QTWEBMODULE:STRING="Qt WebEngine"
 
 		# install python modules to site-packages' dir. True only for the main package,
 		# sub-packages will still be installed inside /usr/lib64/freecad

--- a/media-gfx/freecad/freecad-1.0_rc2-r1.ebuild
+++ b/media-gfx/freecad/freecad-1.0_rc2-r1.ebuild
@@ -356,7 +356,7 @@ pkg_postinst() {
 	#		ifc++, ifcopenshell, z88 (no pkgs), calculix-ccx (::waebbl)
 	einfo "There are a lot of additional tools, for which FreeCAD has builtin"
 	einfo "support. Some of them are available in Gentoo. Take a look at"
-	einfo "https://wiki.freecadweb.org/Installing#External_software_supported_by_FreeCAD"
+	einfo "https://wiki.freecad.org/Installing_additional_components"
 	optfeature_header "Computational utilities"
 	optfeature "Statistical computation with Python" dev-python/pandas
 	optfeature "Use scientific computation with Python" dev-python/scipy

--- a/media-gfx/freecad/freecad-1.0_rc2-r1.ebuild
+++ b/media-gfx/freecad/freecad-1.0_rc2-r1.ebuild
@@ -32,7 +32,7 @@ IUSE="debug designer +gui pcl +qt6 smesh spacenav test X"
 # cMake/FreeCAD_Helpers/InitializeFreeCADBuildOptions.cmake
 # To get their dependencies:
 # 'grep REQUIRES_MODS cMake/FreeCAD_Helpers/CheckInterModuleDependencies.cmake'
-IUSE+=" addonmgr cloud fem idf inspection netgen openscad points robot surface +techdraw"
+IUSE+=" addonmgr cloud fem idf inspection netgen openscad points reverse robot surface +techdraw"
 
 REQUIRED_USE="
 	${PYTHON_REQUIRED_USE}
@@ -41,6 +41,7 @@ REQUIRED_USE="
 	inspection? ( points )
 	openscad? ( smesh )
 	python_single_target_python3_12? ( gui? ( qt6 ) )
+	reverse? ( mesh points )
 	test? ( techdraw )
 "
 # There is no py3.12 support planned for pyside2
@@ -206,7 +207,7 @@ src_configure() {
 		-DBUILD_PART_DESIGN=ON
 		-DBUILD_PLOT=ON
 		-DBUILD_POINTS=$(usex points)
-		-DBUILD_REVERSEENGINEERING=OFF			# currently only an empty sandbox
+		-DBUILD_REVERSEENGINEERING=$(usex reverse)
 		-DBUILD_ROBOT=$(usex robot)
 		-DBUILD_SANDBOX=OFF
 		-DBUILD_SHOW=$(usex gui)

--- a/media-gfx/freecad/freecad-1.0_rc2-r1.ebuild
+++ b/media-gfx/freecad/freecad-1.0_rc2-r1.ebuild
@@ -42,6 +42,30 @@ for module in ${FREECAD_EXPERIMENTAL_MODULES}; do
 done
 unset module
 
+# To get required dependencies:
+# 'grep REQUIRES_MODS cMake/FreeCAD_Helpers/CheckInterModuleDependencies.cmake'
+# We set the following requirements by default:
+# arch, draft, drawing, import, mesh, part, qt5, sketcher, spreadsheet, start, web.
+#
+# Additionally, we auto-enable mesh_part, flat_mesh and smesh
+# Fem actually needs smesh, but as long as we don't have a smesh package, we enable
+# smesh through the mesh USE flag. Note however, the fem<-smesh dependency isn't
+# reflected by the REQUIRES_MODS macro, but at
+# cMake/FreeCAD_Helpers/InitializeFreeCADBuildOptions.cmake:187.
+#
+# The increase in auto-enabled workbenches is due to their need in parts of the
+# test suite when compiled with a minimal set of USE flags.
+REQUIRED_USE="
+	${PYTHON_REQUIRED_USE}
+	designer? ( gui )
+	fem? ( smesh )
+	inspection? ( points )
+	openscad? ( smesh )
+	path? ( robot )
+	python_single_target_python3_12? ( gui? ( qt6 ) )
+"
+# There is no py3.12 support planned for pyside2
+
 RESTRICT="!test? ( test )"
 
 RDEPEND="
@@ -138,30 +162,6 @@ BDEPEND="
 		dev-cpp/gtest
 	)
 "
-
-# To get required dependencies:
-# 'grep REQUIRES_MODS cMake/FreeCAD_Helpers/CheckInterModuleDependencies.cmake'
-# We set the following requirements by default:
-# arch, draft, drawing, import, mesh, part, qt5, sketcher, spreadsheet, start, web.
-#
-# Additionally, we auto-enable mesh_part, flat_mesh and smesh
-# Fem actually needs smesh, but as long as we don't have a smesh package, we enable
-# smesh through the mesh USE flag. Note however, the fem<-smesh dependency isn't
-# reflected by the REQUIRES_MODS macro, but at
-# cMake/FreeCAD_Helpers/InitializeFreeCADBuildOptions.cmake:187.
-#
-# The increase in auto-enabled workbenches is due to their need in parts of the
-# test suite when compiled with a minimal set of USE flags.
-REQUIRED_USE="
-	${PYTHON_REQUIRED_USE}
-	designer? ( gui )
-	fem? ( smesh )
-	inspection? ( points )
-	openscad? ( smesh )
-	path? ( robot )
-	python_single_target_python3_12? ( gui? ( qt6 ) )
-"
-# There is no py3.12 support planned for pyside2
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-1.0_rc2-Gentoo-specific-don-t-check-vcs.patch

--- a/media-gfx/freecad/freecad-1.0_rc2-r1.ebuild
+++ b/media-gfx/freecad/freecad-1.0_rc2-r1.ebuild
@@ -27,7 +27,7 @@ fi
 # examples are licensed CC-BY-SA (without note of specific version)
 LICENSE="LGPL-2 CC-BY-SA-4.0"
 SLOT="0"
-IUSE="debug designer +gui +qt6 test"
+IUSE="debug designer +gui +qt6 spacenav test X"
 
 FREECAD_EXPERIMENTAL_MODULES="cloud netgen pcl"
 FREECAD_STABLE_MODULES="addonmgr fem idf image inspection material
@@ -50,7 +50,6 @@ RDEPEND="
 	dev-cpp/yaml-cpp
 	dev-libs/boost:=
 	dev-libs/libfmt:=
-	dev-libs/libspnav[X]
 	dev-libs/xerces-c[icu]
 	!qt6? (
 		dev-qt/qtconcurrent:5
@@ -110,6 +109,7 @@ RDEPEND="
 				dev-python/shiboken6:=[${PYTHON_USEDEP}]
 			' )
 		)
+		spacenav? ( dev-libs/libspnav[X?] )
 	)
 	netgen? ( media-gfx/netgen[opencascade] )
 	openscad? ( media-gfx/openscad )

--- a/media-gfx/freecad/freecad-1.0_rc2-r1.ebuild
+++ b/media-gfx/freecad/freecad-1.0_rc2-r1.ebuild
@@ -176,7 +176,6 @@ CHECKREQS_DISK_BUILD="2G"
 pkg_setup() {
 	check-reqs_pkg_setup
 	python-single-r1_pkg_setup
-	[[ -z ${CASROOT} ]] && die "\${CASROOT} not set, please run eselect opencascade"
 }
 
 src_prepare() {

--- a/media-gfx/freecad/freecad-1.0_rc2-r1.ebuild
+++ b/media-gfx/freecad/freecad-1.0_rc2-r1.ebuild
@@ -1,0 +1,382 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+PYTHON_COMPAT=( python3_{10..12} )
+
+inherit check-reqs cmake flag-o-matic optfeature python-single-r1 qmake-utils xdg
+
+DESCRIPTION="QT based Computer Aided Design application"
+HOMEPAGE="https://www.freecad.org/ https://github.com/FreeCAD/FreeCAD"
+
+MY_PN=FreeCAD
+MY_PV="${PV/_/}"
+
+if [[ ${PV} = *9999 ]]; then
+	inherit git-r3
+	EGIT_REPO_URI="https://github.com/${MY_PN}/${MY_PN}.git"
+	S="${WORKDIR}/freecad-${PV}"
+else
+	SRC_URI="https://github.com/${MY_PN}/${MY_PN}/archive/refs/tags/${MY_PV}.tar.gz -> ${P}.tar.gz"
+	KEYWORDS="~amd64"
+	S="${WORKDIR}/FreeCAD-${MY_PV}"
+fi
+
+# code is licensed LGPL-2
+# examples are licensed CC-BY-SA (without note of specific version)
+LICENSE="LGPL-2 CC-BY-SA-4.0"
+SLOT="0"
+IUSE="debug designer +gui +qt6 test"
+
+FREECAD_EXPERIMENTAL_MODULES="cloud netgen pcl"
+FREECAD_STABLE_MODULES="addonmgr fem idf image inspection material
+	openscad part-design path points raytracing robot show smesh
+	surface techdraw tux"
+
+for module in ${FREECAD_STABLE_MODULES}; do
+	IUSE="${IUSE} +${module}"
+done
+for module in ${FREECAD_EXPERIMENTAL_MODULES}; do
+	IUSE="${IUSE} ${module}"
+done
+unset module
+
+RESTRICT="!test? ( test )"
+
+RDEPEND="
+	${PYTHON_DEPS}
+	dev-cpp/gtest
+	dev-cpp/yaml-cpp
+	dev-libs/boost:=
+	dev-libs/libfmt:=
+	dev-libs/libspnav[X]
+	dev-libs/xerces-c[icu]
+	!qt6? (
+		dev-qt/qtconcurrent:5
+		dev-qt/qtcore:5
+		dev-qt/qtnetwork:5
+		dev-qt/qtxml:5
+		dev-qt/qtxmlpatterns:5
+	)
+	qt6? (
+		dev-qt/qtbase:6[concurrent,network,xml]
+	)
+	media-libs/freetype
+	sci-libs/hdf5:=[fortran,zlib]
+	>=sci-libs/med-4.0.0-r1
+	sci-libs/opencascade:=[json,vtk]
+	sys-libs/zlib
+	cloud? (
+		dev-libs/openssl:=
+		net-misc/curl
+	)
+	fem? (
+		!qt6? ( sci-libs/vtk:=[qt5,rendering] )
+		qt6? ( sci-libs/vtk:=[-qt5,qt6,rendering] )
+	)
+	gui? (
+		>=media-libs/coin-4.0.0
+		virtual/glu
+		virtual/opengl
+		!qt6? (
+			dev-qt/designer:5
+			dev-qt/qtgui:5
+			dev-qt/qtopengl:5
+			dev-qt/qtprintsupport:5
+			dev-qt/qtsvg:5
+			dev-qt/qtwebengine:5[widgets]
+			dev-qt/qtwidgets:5
+			dev-qt/qtx11extras:5
+			pcl? ( sci-libs/pcl[qt5] )
+			$(python_gen_cond_dep '
+				dev-python/matplotlib[${PYTHON_USEDEP}]
+				>=dev-python/pivy-0.6.5[${PYTHON_USEDEP}]
+				dev-python/pyside2:=[gui,svg,webchannel,webengine,${PYTHON_USEDEP}]
+				dev-python/shiboken2:=[${PYTHON_USEDEP}]
+			' python3_{10..11} )
+		)
+		qt6? (
+			designer? ( dev-qt/qttools:6[designer] )
+			dev-qt/qttools:6[widgets]
+			dev-qt/qtbase:6[gui,opengl,widgets]
+			dev-qt/qtsvg:6
+			dev-qt/qtwebengine:6[widgets]
+			pcl? ( sci-libs/pcl[-qt5,qt6(-)] )
+			$(python_gen_cond_dep '
+				dev-python/matplotlib[${PYTHON_USEDEP}]
+				>=dev-python/pivy-0.6.5[${PYTHON_USEDEP}]
+				dev-python/pyside6:=[gui,svg,webchannel,webengine,${PYTHON_USEDEP}]
+				dev-python/shiboken6:=[${PYTHON_USEDEP}]
+			' )
+		)
+	)
+	netgen? ( media-gfx/netgen[opencascade] )
+	openscad? ( media-gfx/openscad )
+	pcl? ( sci-libs/pcl:=[opengl,openni2,vtk] )
+	smesh? (
+		!qt6? ( sci-libs/vtk:=[qt5] )
+		qt6? ( sci-libs/vtk:=[-qt5,qt6] )
+	)
+	$(python_gen_cond_dep '
+		dev-python/numpy[${PYTHON_USEDEP}]
+		dev-python/pybind11[${PYTHON_USEDEP}]
+		fem? ( dev-python/ply[${PYTHON_USEDEP}] )
+	')
+"
+DEPEND="${RDEPEND}
+	>=dev-cpp/eigen-3.3.1:3
+	dev-cpp/ms-gsl
+	test? (
+		$(python_gen_cond_dep 'dev-python/pyyaml[${PYTHON_USEDEP}]')
+		!qt6? ( dev-qt/qttest:5 )
+	)
+"
+BDEPEND="
+	app-text/dos2unix
+	dev-lang/swig
+	test? (
+		$(python_gen_cond_dep 'dev-python/pyyaml[${PYTHON_USEDEP}]')
+		!qt6? ( dev-qt/qttest:5 )
+		dev-cpp/gtest
+	)
+"
+
+# To get required dependencies:
+# 'grep REQUIRES_MODS cMake/FreeCAD_Helpers/CheckInterModuleDependencies.cmake'
+# We set the following requirements by default:
+# arch, draft, drawing, import, mesh, part, qt5, sketcher, spreadsheet, start, web.
+#
+# Additionally, we auto-enable mesh_part, flat_mesh and smesh
+# Fem actually needs smesh, but as long as we don't have a smesh package, we enable
+# smesh through the mesh USE flag. Note however, the fem<-smesh dependency isn't
+# reflected by the REQUIRES_MODS macro, but at
+# cMake/FreeCAD_Helpers/InitializeFreeCADBuildOptions.cmake:187.
+#
+# The increase in auto-enabled workbenches is due to their need in parts of the
+# test suite when compiled with a minimal set of USE flags.
+REQUIRED_USE="
+	${PYTHON_REQUIRED_USE}
+	designer? ( gui )
+	inspection? ( points )
+	path? ( robot )
+	python_single_target_python3_12? ( gui? ( qt6 ) )
+"
+# There is no py3.12 support planned for pyside2
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-9999-Gentoo-specific-don-t-check-vcs.patch
+	"${FILESDIR}"/${PN}-0.21.0-0001-Gentoo-specific-disable-ccache-usage.patch
+	"${FILESDIR}"/${PN}-9999-tests-src-Qt-only-build-test-for-BUILD_GUI-ON.patch
+)
+
+DOCS=( CODE_OF_CONDUCT.md README.md )
+
+CHECKREQS_DISK_BUILD="2G"
+
+pkg_setup() {
+	check-reqs_pkg_setup
+	python-single-r1_pkg_setup
+	[[ -z ${CASROOT} ]] && die "\${CASROOT} not set, please run eselect opencascade"
+}
+
+src_prepare() {
+	# Fix desktop file
+	sed -e 's/Exec=FreeCAD/Exec=freecad/' -i src/XDGData/org.freecad.FreeCAD.desktop || die
+
+	find "${S}" -type f -exec dos2unix -q {} \; || die "failed to convert to unix line endings"
+
+	cmake_src_prepare
+}
+
+src_configure() {
+	# -Werror=odr, -Werror=lto-type-mismatch
+	# https://bugs.gentoo.org/875221
+	# https://github.com/FreeCAD/FreeCAD/issues/13173
+	filter-lto
+
+	# Fix building tests
+	append-ldflags -Wl,--copy-dt-needed-entries
+
+	local mycmakeargs=(
+		-DBUILD_ADDONMGR=$(usex addonmgr)
+		-DBUILD_ARCH=ON
+		-DBUILD_ASSEMBLY=OFF                    # Requires OndselSolver
+		-DBUILD_CLOUD=$(usex cloud)
+		-DBUILD_COMPLETE=OFF					# deprecated
+		-DBUILD_DRAFT=ON
+		-DBUILD_DESIGNER_PLUGIN=$(usex designer)
+		-DBUILD_ENABLE_CXX_STD:STRING="C++17"	# needed for current git master
+		-DBUILD_FEM=$(usex fem)
+		-DBUILD_FEM_NETGEN=$(usex netgen)
+		-DBUILD_FLAT_MESH=ON
+		-DBUILD_FORCE_DIRECTORY=ON				# force building in a dedicated directory
+		-DBUILD_FREETYPE=ON						# automagic dep
+		-DBUILD_GUI=$(usex gui)
+		-DBUILD_IDF=$(usex idf)
+		-DBUILD_IMAGE=$(usex image)
+		-DBUILD_IMPORT=ON						# import module for various file formats
+		-DBUILD_INSPECTION=$(usex inspection)
+		-DBUILD_JTREADER=OFF					# code has been removed upstream, but option is still there
+		-DBUILD_MATERIAL=$(usex material)
+		-DBUILD_MESH=ON
+		-DBUILD_MESH_PART=ON
+		-DBUILD_OPENSCAD=$(usex openscad)
+		-DBUILD_PART=ON
+		-DBUILD_PART_DESIGN=$(usex part-design)
+		-DBUILD_PATH=$(usex path)
+		-DBUILD_POINTS=$(usex points)
+		-DBUILD_RAYTRACING=$(usex raytracing)
+		-DBUILD_REVERSEENGINEERING=OFF			# currently only an empty sandbox
+		-DBUILD_ROBOT=$(usex robot)
+		-DBUILD_SHOW=$(usex show)
+		-DBUILD_SKETCHER=ON						# needed by draft workspace
+		-DBUILD_SMESH=$(usex smesh)
+		-DBUILD_SPREADSHEET=ON
+		-DBUILD_START=ON
+		-DBUILD_SURFACE=$(usex surface)
+		-DBUILD_TECHDRAW=$(usex techdraw)
+		-DBUILD_TEST=ON							# always build test workbench for run-time testing
+		-DBUILD_TUX=$(usex tux)
+		-DBUILD_VR=OFF
+		-DBUILD_WEB=ON							# needed by start workspace
+		-DBUILD_WITH_CONDA=OFF
+
+		-DCMAKE_INSTALL_DATADIR=/usr/share/${PN}/data
+		-DCMAKE_INSTALL_DOCDIR=/usr/share/doc/${PF}
+		-DCMAKE_INSTALL_INCLUDEDIR=/usr/include/${PN}
+		-DCMAKE_INSTALL_PREFIX=/usr/$(get_libdir)/${PN}
+
+		-DFREECAD_BUILD_DEBIAN=OFF
+
+		-DFREECAD_USE_EXTERNAL_SMESH=OFF		# no package in Gentoo
+		-DFREECAD_USE_EXTERNAL_ZIPIOS=OFF		# doesn't work yet, also no package in Gentoo tree
+		-DFREECAD_USE_FREETYPE=ON
+		-DFREECAD_USE_OCC_VARIANT:STRING="Official Version"
+		-DFREECAD_USE_PCL=$(usex pcl)
+		-DFREECAD_USE_PYBIND11=ON
+		-DFREECAD_USE_QT_FILEDIALOG=ON
+		-DFREECAD_USE_QTWEBMODULE:STRING="Qt WebEngine"
+
+		# install python modules to site-packages' dir. True only for the main package,
+		# sub-packages will still be installed inside /usr/lib64/freecad
+		-DINSTALL_TO_SITEPACKAGES=ON
+
+		# Use the version of shiboken2 that matches the selected python version
+		-DPYTHON_CONFIG_SUFFIX="-${EPYTHON}"
+		-DPython3_EXECUTABLE=${PYTHON}
+	)
+
+	if use debug; then
+		# BUILD_SANDBOX currently broken, see
+		# https://forum.freecadweb.org/viewtopic.php?f=4&t=36071&start=30#p504595
+		mycmakeargs+=(
+			-DBUILD_SANDBOX=OFF
+			-DBUILD_TEMPLATE=ON
+		)
+	else
+		mycmakeargs+=(
+			-DBUILD_SANDBOX=OFF
+			-DBUILD_TEMPLATE=OFF
+		)
+	fi
+
+	if use qt6; then
+		mycmakeargs+=(
+			-DFREECAD_QT_MAJOR_VERSION=6
+			-DFREECAD_QT_VERSION=6
+			-DQT_DEFAULT_MAJOR_VERSION=6
+			-DQt6Core_MOC_EXECUTABLE="$(qt6_get_bindir)/moc"
+			-DQt6Core_RCC_EXECUTABLE="$(qt6_get_bindir)/rcc"
+			-DBUILD_QT5=OFF
+			# Drawing module unmaintained and not ported to qt6
+			-DBUILD_DRAWING=OFF
+		)
+	else
+		mycmakeargs+=(
+			-DFREECAD_QT_MAJOR_VERSION=5
+			-DFREECAD_QT_VERSION=5
+			-DQT_DEFAULT_MAJOR_VERSION=5
+			-DQt5Core_MOC_EXECUTABLE="$(qt5_get_bindir)/moc"
+			-DQt5Core_RCC_EXECUTABLE="$(qt5_get_bindir)/rcc"
+			-DBUILD_QT5=ON
+			# Drawing module unmaintained and not ported to qt6
+			-DBUILD_DRAWING=ON
+		)
+	fi
+
+	cmake_src_configure
+}
+
+# We use the FreeCADCmd binary instead of the FreeCAD binary here
+# for two reasons:
+# 1. It works out of the box with USE=-gui as well, not needing a guard
+# 2. We don't need virtualx.eclass and it's dependencies
+# The exported environment variables are needed, so freecad does know
+# where to save it's temporary files, and where to look and write it's
+# configuration. Without those, there are sandbox violation, when it
+# tries to create /var/lib/portage/home/.FreeCAD directory.
+src_test() {
+	pushd "${BUILD_DIR}" > /dev/null || die
+	export FREECAD_USER_HOME="${HOME}"
+	export FREECAD_USER_DATA="${T}"
+	export FREECAD_USER_TEMP="${T}"
+	nonfatal ./bin/FreeCADCmd --run-test 0
+	popd > /dev/null || die
+}
+
+src_install() {
+	cmake_src_install
+
+	dobin src/Tools/freecad-thumbnailer
+
+	if use gui; then
+		newbin - freecad <<- _EOF_
+		#!/bin/sh
+		# https://github.com/coin3d/coin/issues/451
+		: \${QT_QPA_PLATFORM:=xcb}
+		export QT_QPA_PLATFORM
+		exec /usr/$(get_libdir)/${PN}/bin/FreeCAD "\${@}"
+		_EOF_
+		mv "${ED}"/usr/$(get_libdir)/${PN}/share/* "${ED}"/usr/share || die "failed to move shared resources"
+	fi
+	dosym -r /usr/$(get_libdir)/${PN}/bin/FreeCADCmd /usr/bin/freecadcmd
+
+	rm -r "${ED}"/usr/$(get_libdir)/${PN}/include/E57Format || die "failed to drop unneeded include directory E57Format"
+
+	python_optimize "${ED}"/usr/share/${PN}/data/Mod/Start/StartPage "${ED}"/usr/$(get_libdir)/${PN}{/Ext,/Mod}/
+	# compile main package in python site-packages as well
+	python_optimize
+}
+
+pkg_postinst() {
+	xdg_pkg_postinst
+
+	einfo "You can load a lot of additional workbenches using the integrated"
+	einfo "AddonManager."
+
+	# ToDo: check opencv, pysolar (::science), elmerfem (::science)
+	#		ifc++, ifcopenshell, z88 (no pkgs), calculix-ccx (::waebbl)
+	einfo "There are a lot of additional tools, for which FreeCAD has builtin"
+	einfo "support. Some of them are available in Gentoo. Take a look at"
+	einfo "https://wiki.freecadweb.org/Installing#External_software_supported_by_FreeCAD"
+	optfeature_header "Computational utilities"
+	optfeature "Statistical computation with Python" dev-python/pandas
+	optfeature "Use scientific computation with Python" dev-python/scipy
+	optfeature "Use symbolic math with Python" dev-python/sympy
+	optfeature_header "Imaging, Plotting and Rendering utilities"
+	optfeature "Dependency graphs" media-gfx/graphviz
+	optfeature_header "Import / Export"
+	optfeature "Work with COLLADA documents" dev-python/pycollada
+	optfeature "YAML importer and emitter" dev-python/pyyaml
+	optfeature "Importing and exporting 2D AutoCAD DWG files" media-gfx/libredwg
+	optfeature "Importing and exporting geospatial data formats" sci-libs/gdal
+	optfeature "Working with projection data" sci-libs/proj
+	optfeature_header "Meshing and FEM"
+	optfeature "FEM mesh generator" sci-libs/gmsh
+	optfeature "Visualization" sci-visualization/paraview
+}
+
+pkg_postrm() {
+	xdg_pkg_postrm
+}

--- a/media-gfx/freecad/freecad-1.0_rc2-r1.ebuild
+++ b/media-gfx/freecad/freecad-1.0_rc2-r1.ebuild
@@ -118,7 +118,7 @@ RDEPEND="
 	openscad? ( media-gfx/openscad )
 	pcl? ( sci-libs/pcl:=[opengl,openni2,vtk] )
 	smesh? (
-		sci-libs/hdf5:=[fortran,zlib]
+		sci-libs/hdf5:=[zlib]
 		>=sci-libs/med-4.0.0-r1
 		!qt6? ( sci-libs/vtk:=[qt5] )
 		qt6? ( sci-libs/vtk:=[-qt5,qt6] )

--- a/media-gfx/freecad/freecad-1.0_rc2-r1.ebuild
+++ b/media-gfx/freecad/freecad-1.0_rc2-r1.ebuild
@@ -27,34 +27,13 @@ fi
 # examples are licensed CC-BY-SA (without note of specific version)
 LICENSE="LGPL-2 CC-BY-SA-4.0"
 SLOT="0"
-IUSE="debug designer +gui +qt6 spacenav test X"
-
-FREECAD_EXPERIMENTAL_MODULES="cloud netgen pcl"
-FREECAD_STABLE_MODULES="addonmgr fem idf inspection
-	openscad part-design points robot show smesh
-	surface techdraw tux"
-
-for module in ${FREECAD_STABLE_MODULES}; do
-	IUSE="${IUSE} +${module}"
-done
-for module in ${FREECAD_EXPERIMENTAL_MODULES}; do
-	IUSE="${IUSE} ${module}"
-done
-unset module
-
-# To get required dependencies:
+IUSE="debug designer +gui pcl +qt6 smesh spacenav test X"
+# Modules are found in src/Mod/ and their options defined in:
+# cMake/FreeCAD_Helpers/InitializeFreeCADBuildOptions.cmake
+# To get their dependencies:
 # 'grep REQUIRES_MODS cMake/FreeCAD_Helpers/CheckInterModuleDependencies.cmake'
-# We set the following requirements by default:
-# arch, draft, drawing, import, mesh, part, qt5, sketcher, spreadsheet, start, web.
-#
-# Additionally, we auto-enable mesh_part, flat_mesh and smesh
-# Fem actually needs smesh, but as long as we don't have a smesh package, we enable
-# smesh through the mesh USE flag. Note however, the fem<-smesh dependency isn't
-# reflected by the REQUIRES_MODS macro, but at
-# cMake/FreeCAD_Helpers/InitializeFreeCADBuildOptions.cmake:187.
-#
-# The increase in auto-enabled workbenches is due to their need in parts of the
-# test suite when compiled with a minimal set of USE flags.
+IUSE+=" addonmgr cloud fem idf inspection netgen openscad points robot surface techdraw"
+
 REQUIRED_USE="
 	${PYTHON_REQUIRED_USE}
 	designer? ( gui )
@@ -223,20 +202,20 @@ src_configure() {
 		-DBUILD_MESH_PART=ON
 		-DBUILD_OPENSCAD=$(usex openscad)
 		-DBUILD_PART=ON
-		-DBUILD_PART_DESIGN=$(usex part-design)
+		-DBUILD_PART_DESIGN=ON
 		-DBUILD_PLOT=ON
 		-DBUILD_POINTS=$(usex points)
 		-DBUILD_REVERSEENGINEERING=OFF			# currently only an empty sandbox
 		-DBUILD_ROBOT=$(usex robot)
 		-DBUILD_SANDBOX=OFF
-		-DBUILD_SHOW=$(usex show)
+		-DBUILD_SHOW=$(usex gui)
 		-DBUILD_SKETCHER=ON						# needed by draft workspace
 		-DBUILD_SPREADSHEET=ON
 		-DBUILD_START=ON
 		-DBUILD_SURFACE=$(usex surface)
 		-DBUILD_TECHDRAW=$(usex techdraw)
 		-DBUILD_TEST=ON							# always build test workbench for run-time testing
-		-DBUILD_TUX=$(usex tux)
+		-DBUILD_TUX=$(usex gui)
 		-DBUILD_WEB=ON							# needed by start workspace
 
 		-DCMAKE_INSTALL_DATADIR=/usr/share/${PN}/data

--- a/media-gfx/freecad/metadata.xml
+++ b/media-gfx/freecad/metadata.xml
@@ -14,6 +14,12 @@
 			Build the addon manager module for automatic handling of 3rd 
 			party addons
 		</flag>
+		<flag name="bim">
+			Build the BIM module and workbench
+		</flag>
+		<flag name="cam">
+			Build the CAM module and workbench
+		</flag>
 		<flag name="cloud">
 			Build the Cloud workbench, to access cloud providers (mostly
 			Amazon S3).
@@ -47,6 +53,9 @@
 		</flag>
 		<flag name="material">
 			Build the material module and workbench to work with materials
+		</flag>
+		<flag name="mesh">
+			Build the mesh module and workbench
 		</flag>
 		<flag name="netgen">
 			Build support for the netgen mesher through <pkg>media-gfx/netgen</pkg>.
@@ -82,7 +91,7 @@
 			Build the show module, a helper module for visibility automation
 		</flag>
 		<flag name="smesh">
-			Build the Salome SMESH module
+			Build Salome SMESH
 		</flag>
 		<flag name="spacenav">
 			Add support for space navigator devices through

--- a/media-gfx/freecad/metadata.xml
+++ b/media-gfx/freecad/metadata.xml
@@ -72,6 +72,9 @@
 		<flag name="raytracing">
 			Build the raytracing module and workbench for raytracing and rendering
 		</flag>
+		<flag name="reverse">
+			Build the reverse engineering module and workbench
+		</flag>
 		<flag name="robot">
 			Build the robot module and workbench for studying robot movements
 		</flag>

--- a/media-gfx/freecad/metadata.xml
+++ b/media-gfx/freecad/metadata.xml
@@ -81,6 +81,10 @@
 		<flag name="smesh">
 			Build the Salome SMESH module
 		</flag>
+		<flag name="spacenav">
+			Add support for space navigator devices through
+			<pkg>dev-libs/libspnav</pkg>
+		</flag>
 		<flag name="surface">
 			Build the surface module and workbench
 		</flag>


### PR DESCRIPTION
This is not easy and there is a lot here, so certainly worth some checking and there may well be some points to raise.

dev-cpp/yaml-cpp only used by Material

dev-libs/OpenNI2 can't find any use of this (a forum post from 10 years ago though)

dev-libs/libspnav[X] only needed for 3Dconnexion input devices, and X only for X11, so add USE flags spacenav (as media-gfx/openscad) and X

dev-ruby/asciidoctor not needed since:
```
089b7d40b5 ("[Path] Improve Sanity to generate html output without... (#5)", 2023-09-11)
```

```
$ git --no-pager  tag --contains 089b7d40b5
1.0rc1
1.0rc2
```

media-libs/qhull can't find any use of this

sci-libs/hdf5:=[fortran,zlib] and >=sci-libs/med-4.0.0-r1 move to smesh?

sci-libs/opencascade:=[json,vtk] don't think vtk support is needed

sci-libs/orocos_kdl:= and `-DFREECAD_USE_EXTERNAL_KDL=ON` external kdl is currently not supported

dev-qt/qtwebengine was alredy removed in live ebuild:
543504d88b3b ("media-gfx/freecad: drop dep on qtwebengine", 2024-09-30)

dev-qt/qttools:6[designer] and dev-python/pyside6:=[designer] these are needed for the Gui not just the designer plugin (see dev-qt/designer:5 I guess. Not sure about dev-python/pyside2)

dev-python/pyside{2,6}[webchannel] don't think this is used

dev-qt/qt5compat:6 don't think this is used

addonmgr? ( dev-python/GitPython[${PYTHON_USEDEP}] ) not used since:
760aaf4afe ("Addon Manager: Complete migration away from GitPython", 2024-01-27)

Added REQUIRED_USE openscad? ( smesh ) - with `-smesh` I got:

```
-- BUILD_MESH_PART requires BUILD_SMESH to be ON, but it is "no"
-- BUILD_FLAT_MESH requires BUILD_MESH_PART to be ON, but it is "OFF"
-- BUILD_OPENSCAD requires BUILD_MESH_PART to be ON, but it is "OFF"
```

```diff
--- freecad-1.0_rc2.ebuild
+++ freecad-1.0_rc2-r1.ebuild
@@ -48,12 +48,10 @@
 	${PYTHON_DEPS}
 	dev-cpp/gtest
 	dev-cpp/yaml-cpp
-	dev-libs/OpenNI2[opengl(+)]
 	dev-libs/boost:=
 	dev-libs/libfmt:=
 	dev-libs/libspnav[X]
 	dev-libs/xerces-c[icu]
-	dev-ruby/asciidoctor
 	!qt6? (
 		dev-qt/qtconcurrent:5
 		dev-qt/qtcore:5
@@ -65,13 +63,10 @@
 		dev-qt/qtbase:6[concurrent,network,xml]
 	)
 	media-libs/freetype
-	media-libs/qhull:=
 	sci-libs/hdf5:=[fortran,zlib]
 	>=sci-libs/med-4.0.0-r1
 	sci-libs/opencascade:=[json,vtk]
-	sci-libs/orocos_kdl:=
 	sys-libs/zlib
-	virtual/libusb:1
 	cloud? (
 		dev-libs/openssl:=
 		net-misc/curl
@@ -103,7 +98,6 @@
 		)
 		qt6? (
 			designer? ( dev-qt/qttools:6[designer] )
-			dev-qt/qt5compat:6
 			dev-qt/qttools:6[widgets]
 			dev-qt/qtbase:6[gui,opengl,widgets]
 			dev-qt/qtsvg:6
@@ -127,7 +121,6 @@
 	$(python_gen_cond_dep '
 		dev-python/numpy[${PYTHON_USEDEP}]
 		dev-python/pybind11[${PYTHON_USEDEP}]
-		addonmgr? ( dev-python/GitPython[${PYTHON_USEDEP}] )
 		fem? ( dev-python/ply[${PYTHON_USEDEP}] )
 	')
 "
@@ -256,7 +249,6 @@
 
 		-DFREECAD_BUILD_DEBIAN=OFF
 
-		-DFREECAD_USE_EXTERNAL_KDL=ON
 		-DFREECAD_USE_EXTERNAL_SMESH=OFF		# no package in Gentoo
 		-DFREECAD_USE_EXTERNAL_ZIPIOS=OFF		# doesn't work yet, also no package in Gentoo tree
 		-DFREECAD_USE_FREETYPE=ON
@@ -369,15 +361,12 @@
 	einfo "support. Some of them are available in Gentoo. Take a look at"
 	einfo "https://wiki.freecadweb.org/Installing#External_software_supported_by_FreeCAD"
 	optfeature_header "Computational utilities"
-	optfeature "BLAS library" sci-libs/openblas
 	optfeature "Statistical computation with Python" dev-python/pandas
 	optfeature "Use scientific computation with Python" dev-python/scipy
 	optfeature "Use symbolic math with Python" dev-python/sympy
 	optfeature_header "Imaging, Plotting and Rendering utilities"
 	optfeature "Dependency graphs" media-gfx/graphviz
-	optfeature "PBR Rendering" media-gfx/povray
 	optfeature_header "Import / Export"
-	optfeature "Interact with git repositories" dev-python/GitPython
 	optfeature "Work with COLLADA documents" dev-python/pycollada
 	optfeature "YAML importer and emitter" dev-python/pyyaml
 	optfeature "Importing and exporting 2D AutoCAD DWG files" media-gfx/libredwg
@@ -385,7 +374,6 @@
 	optfeature "Working with projection data" sci-libs/proj
 	optfeature_header "Meshing and FEM"
 	optfeature "FEM mesh generator" sci-libs/gmsh
-	optfeature "Triangulating meshes" sci-libs/gts
 	optfeature "Visualization" sci-visualization/paraview
 }
```

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
Added with `pkgdev commit`

Please note that all boxes must be checked for the pull request to be merged.
