### PR TITLE
dev-python/python-multipart: rename the Python package to `python_multipart`

### DIFF
--- a/dev-python/python-multipart/files/python-multipart-0.0.12-rename.patch
+++ b/dev-python/python-multipart/files/python-multipart-0.0.12-rename.patch
@@ -1,0 +1,54 @@
+From d6e30eb0269fa04d4a16133bd94405f10240aeb0 Mon Sep 17 00:00:00 2001
+From: Henry Schreiner <henryschreineriii@gmail.com>
+Date: Fri, 11 Oct 2024 17:11:21 -0400
+Subject: [PATCH 1/2] refactor: rename to python_multipart
+
+Signed-off-by: Henry Schreiner <henryschreineriii@gmail.com>
+
+diff --git a/pyproject.toml b/pyproject.toml
+index fb03f83..1a81077 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -62,13 +65,10 @@ Changelog = "https://github.com/Kludex/python-multipart/blob/master/CHANGELOG.md
+ Source = "https://github.com/Kludex/python-multipart"
+ 
+ [tool.hatch.version]
+-path = "multipart/__init__.py"
+-
+-[tool.hatch.build.targets.wheel]
+-packages = ["multipart"]
++path = "python_multipart/__init__.py"
+ 
+ [tool.hatch.build.targets.sdist]
+-include = ["/multipart", "/tests", "CHANGELOG.md", "LICENSE.txt"]
++include = ["/python_multipart", "/tests", "CHANGELOG.md", "LICENSE.txt", "_python_multipart.pth", "_python_multipart_loader.py"]
+ 
+ [tool.mypy]
+ strict = true
+diff --git a/tests/test_multipart.py b/tests/test_multipart.py
+index b824f19..f5f8e7e 100644
+--- a/tests/test_multipart.py
++++ b/tests/test_multipart.py
+@@ -11,9 +11,9 @@
+ 
+ import yaml
+ 
+-from multipart.decoders import Base64Decoder, QuotedPrintableDecoder
+-from multipart.exceptions import DecodeError, FileError, FormParserError, MultipartParseError, QuerystringParseError
+-from multipart.multipart import (
++from python_multipart.decoders import Base64Decoder, QuotedPrintableDecoder
++from python_multipart.exceptions import DecodeError, FileError, FormParserError, MultipartParseError, QuerystringParseError
++from python_multipart.multipart import (
+     BaseParser,
+     Field,
+     File,
+@@ -31,7 +31,7 @@
+ if TYPE_CHECKING:
+     from typing import Any, Iterator, TypedDict
+ 
+-    from multipart.multipart import FieldProtocol, FileConfig, FileProtocol
++    from python_multipart.multipart import FieldProtocol, FileConfig, FileProtocol
+ 
+     class TestParams(TypedDict):
+         name: str
+

--- a/dev-python/python-multipart/python-multipart-0.0.12-r100.ebuild
+++ b/dev-python/python-multipart/python-multipart-0.0.12-r100.ebuild
@@ -1,0 +1,47 @@
+# Copyright 2022-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DISTUTILS_USE_PEP517=hatchling
+PYTHON_COMPAT=( pypy3 python3_{10..13} )
+
+inherit distutils-r1
+
+DESCRIPTION="A streaming multipart parser for Python"
+HOMEPAGE="
+	https://github.com/Kludex/python-multipart/
+	https://pypi.org/project/python-multipart/
+"
+SRC_URI="
+	https://github.com/Kludex/python-multipart/archive/${PV}.tar.gz
+		-> ${P}.gh.tar.gz
+"
+
+LICENSE="Apache-2.0"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+
+BDEPEND="
+	test? (
+		dev-python/pyyaml[${PYTHON_USEDEP}]
+	)
+"
+
+distutils_enable_tests pytest
+
+src_prepare() {
+	local PATCHES=(
+		# https://github.com/Kludex/python-multipart/pull/166
+		"${FILESDIR}/${P}-rename.patch"
+	)
+
+	distutils-r1_src_prepare
+
+	mv multipart python_multipart || die
+}
+
+python_test() {
+	local -x PYTEST_DISABLE_PLUGIN_AUTOLOAD=1
+	epytest
+}

--- a/dev-python/starlette/starlette-0.39.2-r1.ebuild
+++ b/dev-python/starlette/starlette-0.39.2-r1.ebuild
@@ -24,7 +24,7 @@ S=${WORKDIR}/${MY_P}
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+KEYWORDS="amd64 arm arm64 hppa ~loong ppc ppc64 ~riscv ~s390 sparc x86"
 
 RDEPEND="
 	<dev-python/anyio-5[${PYTHON_USEDEP}]
@@ -32,7 +32,7 @@ RDEPEND="
 	>=dev-python/httpx-0.22.0[${PYTHON_USEDEP}]
 	dev-python/itsdangerous[${PYTHON_USEDEP}]
 	dev-python/jinja[${PYTHON_USEDEP}]
-	>=dev-python/python-multipart-0.0.7[${PYTHON_USEDEP}]
+	<dev-python/python-multipart-0.0.12-r100[${PYTHON_USEDEP}]
 	dev-python/pyyaml[${PYTHON_USEDEP}]
 "
 BDEPEND="

--- a/dev-python/starlette/starlette-0.41.0-r1.ebuild
+++ b/dev-python/starlette/starlette-0.41.0-r1.ebuild
@@ -24,7 +24,7 @@ S=${WORKDIR}/${MY_P}
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="amd64 arm arm64 hppa ~loong ppc ppc64 ~riscv ~s390 sparc x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
 
 RDEPEND="
 	<dev-python/anyio-5[${PYTHON_USEDEP}]
@@ -32,7 +32,7 @@ RDEPEND="
 	>=dev-python/httpx-0.22.0[${PYTHON_USEDEP}]
 	dev-python/itsdangerous[${PYTHON_USEDEP}]
 	dev-python/jinja[${PYTHON_USEDEP}]
-	>=dev-python/python-multipart-0.0.7[${PYTHON_USEDEP}]
+	<dev-python/python-multipart-0.0.12-r100[${PYTHON_USEDEP}]
 	dev-python/pyyaml[${PYTHON_USEDEP}]
 "
 BDEPEND="

--- a/dev-python/starlette/starlette-0.41.0-r2.ebuild
+++ b/dev-python/starlette/starlette-0.41.0-r2.ebuild
@@ -1,0 +1,65 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DISTUTILS_USE_PEP517=hatchling
+PYTHON_COMPAT=( pypy3 python3_{10..13} )
+
+inherit distutils-r1
+
+MY_P=${P/_p/.post}
+DESCRIPTION="The little ASGI framework that shines"
+HOMEPAGE="
+	https://www.starlette.io/
+	https://github.com/encode/starlette/
+	https://pypi.org/project/starlette/
+"
+# no docs or tests in sdist, as of 0.27.0
+SRC_URI="
+	https://github.com/encode/starlette/archive/${PV/_p/.post}.tar.gz
+		-> ${MY_P}.gh.tar.gz
+"
+S=${WORKDIR}/${MY_P}
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+
+RDEPEND="
+	<dev-python/anyio-5[${PYTHON_USEDEP}]
+	>=dev-python/anyio-3.4.0[${PYTHON_USEDEP}]
+	>=dev-python/httpx-0.22.0[${PYTHON_USEDEP}]
+	dev-python/itsdangerous[${PYTHON_USEDEP}]
+	dev-python/jinja[${PYTHON_USEDEP}]
+	>=dev-python/python-multipart-0.0.12-r100[${PYTHON_USEDEP}]
+	dev-python/pyyaml[${PYTHON_USEDEP}]
+"
+BDEPEND="
+	test? (
+		>=dev-python/pytest-8[${PYTHON_USEDEP}]
+		dev-python/trio[${PYTHON_USEDEP}]
+	)
+"
+
+: ${EPYTEST_TIMEOUT:-180}
+distutils_enable_tests pytest
+
+src_prepare() {
+	distutils-r1_src_prepare
+
+	# python-multipart package renamed in Gentoo to python_multipart
+	sed -e "s:from multipart:from python_multipart:" \
+		-e "s:import multipart:import python_multipart as multipart:" \
+		-i starlette/*.py || die
+}
+
+python_test() {
+	local EPYTEST_IGNORE=(
+		# Unpackaged 'databases' dependency
+		tests/test_database.py
+	)
+
+	local -x PYTEST_DISABLE_PLUGIN_AUTOLOAD=1
+	epytest -p anyio
+}

--- a/net-im/synapse/synapse-1.113.0-r1.ebuild
+++ b/net-im/synapse/synapse-1.113.0-r1.ebuild
@@ -5,11 +5,11 @@ EAPI=8
 
 DISTUTILS_EXT=1
 DISTUTILS_USE_PEP517=poetry
-PYTHON_COMPAT=( python3_{10..13} )
+PYTHON_COMPAT=( python3_{10..12} )
 
 CRATES="
 	aho-corasick@1.1.3
-	anyhow@1.0.89
+	anyhow@1.0.86
 	arc-swap@1.7.1
 	autocfg@1.3.0
 	base64@0.21.7
@@ -17,7 +17,7 @@ CRATES="
 	blake2@0.10.6
 	block-buffer@0.10.4
 	bumpalo@3.16.0
-	bytes@1.7.2
+	bytes@1.6.1
 	cfg-if@1.0.0
 	cpufeatures@0.2.12
 	crypto-common@0.1.6
@@ -61,12 +61,12 @@ CRATES="
 	redox_syscall@0.5.1
 	regex-automata@0.4.6
 	regex-syntax@0.8.3
-	regex@1.10.6
+	regex@1.10.5
 	ryu@1.0.18
 	scopeguard@1.2.0
-	serde@1.0.210
-	serde_derive@1.0.210
-	serde_json@1.0.128
+	serde@1.0.204
+	serde_derive@1.0.204
+	serde_json@1.0.122
 	sha1@0.10.6
 	sha2@0.10.8
 	smallvec@1.13.2
@@ -116,7 +116,7 @@ LICENSE+="
 	|| ( Apache-2.0 Boost-1.0 )
 "
 SLOT="0"
-KEYWORDS="~amd64 ~arm64 ~ppc64"
+KEYWORDS="amd64 ~arm64 ~ppc64"
 IUSE="postgres systemd test"
 RESTRICT="!test? ( test )"
 
@@ -150,7 +150,7 @@ RDEPEND="
 	dev-python/pydantic[${PYTHON_USEDEP}]
 	dev-python/pymacaroons[${PYTHON_USEDEP}]
 	dev-python/pyopenssl[${PYTHON_USEDEP}]
-	dev-python/python-multipart[${PYTHON_USEDEP}]
+	<dev-python/python-multipart-0.0.12-r100[${PYTHON_USEDEP}]
 	dev-python/pyyaml[${PYTHON_USEDEP}]
 	dev-python/service-identity[${PYTHON_USEDEP}]
 	dev-python/signedjson[${PYTHON_USEDEP}]

--- a/net-im/synapse/synapse-1.114.0-r1.ebuild
+++ b/net-im/synapse/synapse-1.114.0-r1.ebuild
@@ -150,7 +150,7 @@ RDEPEND="
 	dev-python/pydantic[${PYTHON_USEDEP}]
 	dev-python/pymacaroons[${PYTHON_USEDEP}]
 	dev-python/pyopenssl[${PYTHON_USEDEP}]
-	dev-python/python-multipart[${PYTHON_USEDEP}]
+	<dev-python/python-multipart-0.0.12-r100[${PYTHON_USEDEP}]
 	dev-python/pyyaml[${PYTHON_USEDEP}]
 	dev-python/service-identity[${PYTHON_USEDEP}]
 	dev-python/signedjson[${PYTHON_USEDEP}]

--- a/net-im/synapse/synapse-1.115.0-r2.ebuild
+++ b/net-im/synapse/synapse-1.115.0-r2.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 DISTUTILS_EXT=1
 DISTUTILS_USE_PEP517=poetry
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..13} )
 
 CRATES="
 	aho-corasick@1.1.3
@@ -17,7 +17,7 @@ CRATES="
 	blake2@0.10.6
 	block-buffer@0.10.4
 	bumpalo@3.16.0
-	bytes@1.6.1
+	bytes@1.7.1
 	cfg-if@1.0.0
 	cpufeatures@0.2.12
 	crypto-common@0.1.6
@@ -61,12 +61,12 @@ CRATES="
 	redox_syscall@0.5.1
 	regex-automata@0.4.6
 	regex-syntax@0.8.3
-	regex@1.10.5
+	regex@1.10.6
 	ryu@1.0.18
 	scopeguard@1.2.0
-	serde@1.0.204
-	serde_derive@1.0.204
-	serde_json@1.0.122
+	serde@1.0.209
+	serde_derive@1.0.209
+	serde_json@1.0.127
 	sha1@0.10.6
 	sha2@0.10.8
 	smallvec@1.13.2
@@ -116,7 +116,7 @@ LICENSE+="
 	|| ( Apache-2.0 Boost-1.0 )
 "
 SLOT="0"
-KEYWORDS="amd64 ~arm64 ~ppc64"
+KEYWORDS="~amd64 ~arm64 ~ppc64"
 IUSE="postgres systemd test"
 RESTRICT="!test? ( test )"
 
@@ -150,7 +150,7 @@ RDEPEND="
 	dev-python/pydantic[${PYTHON_USEDEP}]
 	dev-python/pymacaroons[${PYTHON_USEDEP}]
 	dev-python/pyopenssl[${PYTHON_USEDEP}]
-	dev-python/python-multipart[${PYTHON_USEDEP}]
+	<dev-python/python-multipart-0.0.12-r100[${PYTHON_USEDEP}]
 	dev-python/pyyaml[${PYTHON_USEDEP}]
 	dev-python/service-identity[${PYTHON_USEDEP}]
 	dev-python/signedjson[${PYTHON_USEDEP}]
@@ -159,6 +159,9 @@ RDEPEND="
 	dev-python/twisted[${PYTHON_USEDEP}]
 	dev-python/typing-extensions[${PYTHON_USEDEP}]
 	dev-python/unpaddedbase64[${PYTHON_USEDEP}]
+	$(python_gen_cond_dep '
+		dev-python/legacy-cgi[${PYTHON_USEDEP}]
+	' 3.13)
 	postgres? ( dev-python/psycopg:2[${PYTHON_USEDEP}] )
 	systemd? ( dev-python/python-systemd[${PYTHON_USEDEP}] )
 "

--- a/net-im/synapse/synapse-1.116.0-r1.ebuild
+++ b/net-im/synapse/synapse-1.116.0-r1.ebuild
@@ -9,7 +9,7 @@ PYTHON_COMPAT=( python3_{10..13} )
 
 CRATES="
 	aho-corasick@1.1.3
-	anyhow@1.0.86
+	anyhow@1.0.89
 	arc-swap@1.7.1
 	autocfg@1.3.0
 	base64@0.21.7
@@ -17,7 +17,7 @@ CRATES="
 	blake2@0.10.6
 	block-buffer@0.10.4
 	bumpalo@3.16.0
-	bytes@1.7.1
+	bytes@1.7.2
 	cfg-if@1.0.0
 	cpufeatures@0.2.12
 	crypto-common@0.1.6
@@ -64,9 +64,9 @@ CRATES="
 	regex@1.10.6
 	ryu@1.0.18
 	scopeguard@1.2.0
-	serde@1.0.209
-	serde_derive@1.0.209
-	serde_json@1.0.127
+	serde@1.0.210
+	serde_derive@1.0.210
+	serde_json@1.0.128
 	sha1@0.10.6
 	sha2@0.10.8
 	smallvec@1.13.2
@@ -150,7 +150,7 @@ RDEPEND="
 	dev-python/pydantic[${PYTHON_USEDEP}]
 	dev-python/pymacaroons[${PYTHON_USEDEP}]
 	dev-python/pyopenssl[${PYTHON_USEDEP}]
-	dev-python/python-multipart[${PYTHON_USEDEP}]
+	<dev-python/python-multipart-0.0.12-r100[${PYTHON_USEDEP}]
 	dev-python/pyyaml[${PYTHON_USEDEP}]
 	dev-python/service-identity[${PYTHON_USEDEP}]
 	dev-python/signedjson[${PYTHON_USEDEP}]
@@ -159,9 +159,6 @@ RDEPEND="
 	dev-python/twisted[${PYTHON_USEDEP}]
 	dev-python/typing-extensions[${PYTHON_USEDEP}]
 	dev-python/unpaddedbase64[${PYTHON_USEDEP}]
-	$(python_gen_cond_dep '
-		dev-python/legacy-cgi[${PYTHON_USEDEP}]
-	' 3.13)
 	postgres? ( dev-python/psycopg:2[${PYTHON_USEDEP}] )
 	systemd? ( dev-python/python-systemd[${PYTHON_USEDEP}] )
 "

--- a/net-im/synapse/synapse-1.116.0-r2.ebuild
+++ b/net-im/synapse/synapse-1.116.0-r2.ebuild
@@ -1,0 +1,253 @@
+# Copyright 2022-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DISTUTILS_EXT=1
+DISTUTILS_USE_PEP517=poetry
+PYTHON_COMPAT=( python3_{10..13} )
+
+CRATES="
+	aho-corasick@1.1.3
+	anyhow@1.0.89
+	arc-swap@1.7.1
+	autocfg@1.3.0
+	base64@0.21.7
+	bitflags@2.5.0
+	blake2@0.10.6
+	block-buffer@0.10.4
+	bumpalo@3.16.0
+	bytes@1.7.2
+	cfg-if@1.0.0
+	cpufeatures@0.2.12
+	crypto-common@0.1.6
+	digest@0.10.7
+	fnv@1.0.7
+	generic-array@0.14.7
+	getrandom@0.2.15
+	headers-core@0.3.0
+	headers@0.4.0
+	heck@0.4.1
+	hex@0.4.3
+	http@1.1.0
+	httpdate@1.0.3
+	indoc@2.0.5
+	itoa@1.0.11
+	js-sys@0.3.69
+	lazy_static@1.5.0
+	libc@0.2.154
+	lock_api@0.4.12
+	log@0.4.22
+	memchr@2.7.2
+	memoffset@0.9.1
+	mime@0.3.17
+	once_cell@1.19.0
+	parking_lot@0.12.2
+	parking_lot_core@0.9.10
+	portable-atomic@1.6.0
+	ppv-lite86@0.2.17
+	proc-macro2@1.0.82
+	pyo3-build-config@0.21.2
+	pyo3-ffi@0.21.2
+	pyo3-log@0.10.0
+	pyo3-macros-backend@0.21.2
+	pyo3-macros@0.21.2
+	pyo3@0.21.2
+	pythonize@0.21.1
+	quote@1.0.36
+	rand@0.8.5
+	rand_chacha@0.3.1
+	rand_core@0.6.4
+	redox_syscall@0.5.1
+	regex-automata@0.4.6
+	regex-syntax@0.8.3
+	regex@1.10.6
+	ryu@1.0.18
+	scopeguard@1.2.0
+	serde@1.0.210
+	serde_derive@1.0.210
+	serde_json@1.0.128
+	sha1@0.10.6
+	sha2@0.10.8
+	smallvec@1.13.2
+	subtle@2.5.0
+	syn@2.0.61
+	target-lexicon@0.12.14
+	typenum@1.17.0
+	ulid@1.1.3
+	unicode-ident@1.0.12
+	unindent@0.2.3
+	version_check@0.9.4
+	wasi@0.11.0+wasi-snapshot-preview1
+	wasm-bindgen-backend@0.2.92
+	wasm-bindgen-macro-support@0.2.92
+	wasm-bindgen-macro@0.2.92
+	wasm-bindgen-shared@0.2.92
+	wasm-bindgen@0.2.92
+	web-time@1.1.0
+	windows-targets@0.52.5
+	windows_aarch64_gnullvm@0.52.5
+	windows_aarch64_msvc@0.52.5
+	windows_i686_gnu@0.52.5
+	windows_i686_gnullvm@0.52.5
+	windows_i686_msvc@0.52.5
+	windows_x86_64_gnu@0.52.5
+	windows_x86_64_gnullvm@0.52.5
+	windows_x86_64_msvc@0.52.5
+"
+
+inherit cargo distutils-r1 multiprocessing optfeature systemd
+
+DESCRIPTION="Reference implementation of Matrix homeserver"
+HOMEPAGE="
+	https://matrix.org/
+	https://github.com/element-hq/synapse
+"
+SRC_URI="
+	https://github.com/element-hq/${PN}/archive/v${PV}.tar.gz
+		-> ${P}.gh.tar.gz
+	${CARGO_CRATE_URIS}
+"
+
+LICENSE="AGPL-3+"
+# Dependent crate licenses
+LICENSE+="
+	Apache-2.0-with-LLVM-exceptions BSD MIT Unicode-DFS-2016
+	|| ( Apache-2.0 Boost-1.0 )
+"
+SLOT="0"
+KEYWORDS="~amd64 ~arm64 ~ppc64"
+IUSE="postgres systemd test"
+RESTRICT="!test? ( test )"
+
+DEPEND="
+	acct-user/synapse
+	acct-group/synapse
+"
+# The dev-python/twisted-24.3.0_p20240628 snapshot available in our tree
+# introduces some breaking changes for synapse,
+# see https://github.com/element-hq/synapse/issues/17075
+RDEPEND="
+	${DEPEND}
+	dev-python/attrs[${PYTHON_USEDEP}]
+	dev-python/bcrypt[${PYTHON_USEDEP}]
+	dev-python/bleach[${PYTHON_USEDEP}]
+	>=dev-python/canonicaljson-2[${PYTHON_USEDEP}]
+	dev-python/cryptography[${PYTHON_USEDEP}]
+	dev-python/ijson[${PYTHON_USEDEP}]
+	dev-python/immutabledict[${PYTHON_USEDEP}]
+	>=dev-python/jinja-3.0[${PYTHON_USEDEP}]
+	dev-python/jsonschema[${PYTHON_USEDEP}]
+	>=dev-python/matrix-common-1.3.0[${PYTHON_USEDEP}]
+	dev-python/msgpack[${PYTHON_USEDEP}]
+	dev-python/netaddr[${PYTHON_USEDEP}]
+	dev-python/packaging[${PYTHON_USEDEP}]
+	dev-python/phonenumbers[${PYTHON_USEDEP}]
+	>=dev-python/pillow-10.0.1[${PYTHON_USEDEP},webp]
+	dev-python/prometheus-client[${PYTHON_USEDEP}]
+	dev-python/pyasn1-modules[${PYTHON_USEDEP}]
+	dev-python/pyasn1[${PYTHON_USEDEP}]
+	dev-python/pydantic[${PYTHON_USEDEP}]
+	dev-python/pymacaroons[${PYTHON_USEDEP}]
+	dev-python/pyopenssl[${PYTHON_USEDEP}]
+	>=dev-python/python-multipart-0.0.12-r100[${PYTHON_USEDEP}]
+	dev-python/pyyaml[${PYTHON_USEDEP}]
+	dev-python/service-identity[${PYTHON_USEDEP}]
+	dev-python/signedjson[${PYTHON_USEDEP}]
+	dev-python/sortedcontainers[${PYTHON_USEDEP}]
+	dev-python/treq[${PYTHON_USEDEP}]
+	dev-python/twisted[${PYTHON_USEDEP}]
+	dev-python/typing-extensions[${PYTHON_USEDEP}]
+	dev-python/unpaddedbase64[${PYTHON_USEDEP}]
+	postgres? ( dev-python/psycopg:2[${PYTHON_USEDEP}] )
+	systemd? ( dev-python/python-systemd[${PYTHON_USEDEP}] )
+"
+BDEPEND="
+	dev-python/setuptools-rust[${PYTHON_USEDEP}]
+	test? (
+		${RDEPEND}
+		dev-python/hiredis[${PYTHON_USEDEP}]
+		dev-python/idna[${PYTHON_USEDEP}]
+		dev-python/parameterized[${PYTHON_USEDEP}]
+		dev-python/pyicu[${PYTHON_USEDEP}]
+		dev-python/txredisapi[${PYTHON_USEDEP}]
+		postgres? ( dev-db/postgresql[server] )
+	)
+"
+
+# Rust extension
+QA_FLAGS_IGNORED="usr/lib/python3.*/site-packages/synapse/synapse_rust.abi3.so"
+
+src_prepare() {
+	distutils-r1_src_prepare
+
+	# python-multipart package renamed in Gentoo to python_multipart
+	sed -e 's:import multipart:import python_multipart as multipart:' \
+		-i synapse/http/client.py || die
+}
+
+src_test() {
+	if use postgres; then
+		einfo "Preparing postgres test instance"
+		initdb --pgdata="${T}/pgsql" || die
+		pg_ctl --wait --pgdata="${T}/pgsql" start \
+			--options="-h '' -k '${T}'" || die
+		createdb --host="${T}" synapse_test || die
+
+		# See https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#running-tests-under-postgresql
+		local -x SYNAPSE_POSTGRES=1
+		local -x SYNAPSE_POSTGRES_HOST="${T}"
+	fi
+
+	# This remove is necessary otherwise python is not able to locate
+	# synapse_rust.abi3.so.
+	rm -rf synapse || die
+
+	nonfatal distutils-r1_src_test
+	local ret=${?}
+
+	if use postgres; then
+		einfo "Stopping postgres test instance"
+		pg_ctl --wait --pgdata="${T}/pgsql" stop || die
+	fi
+
+	[[ ${ret} -ne 0 ]] && die
+}
+
+python_test() {
+	"${EPYTHON}" -m twisted.trial -j "$(makeopts_jobs)" tests
+}
+
+src_install() {
+	distutils-r1_src_install
+	keepdir /var/{lib,log}/synapse /etc/synapse
+	fowners synapse:synapse /var/{lib,log}/synapse /etc/synapse
+	fperms 0750 /var/{lib,log}/synapse /etc/synapse
+	newinitd "${FILESDIR}/${PN}.initd-r1" "${PN}"
+	systemd_dounit "${FILESDIR}/synapse.service"
+}
+
+pkg_postinst() {
+	optfeature "Improve user search for international display names" dev-python/pyicu
+	optfeature "Redis support" dev-python/txredisapi
+	optfeature "VoIP relaying on your homeserver with turn" net-im/coturn
+
+	if [[ -z "${REPLACING_VERSIONS}" ]]; then
+		einfo
+		elog "In order to generate initial configuration run:"
+		elog "sudo -u synapse synapse_homeserver \\"
+		elog "    --server-name matrix.domain.tld \\"
+		elog "    --config-path /etc/synapse/homeserver.yaml \\"
+		elog "    --generate-config \\"
+		elog "    --data-directory /var/lib/synapse \\"
+		elog "    --report-stats=no"
+		einfo
+	else
+		einfo
+		elog "Please refer to upgrade notes if any special steps are required"
+		elog "to upgrade from the version you currently have installed:"
+		elog
+		elog "  https://github.com/element-hq/synapse/blob/develop/docs/upgrade.md"
+		einfo
+	fi
+}


### PR DESCRIPTION
Following similar concept as https://github.com/Kludex/python-multipart/pull/166 ; except that we don't need the compatibility thingy, we instead patch the revdeps. This will enable add to us `dev-python/multipart` and start unbundling it everywhere where `python-multipart` conflict forced it to be bundled.