### PR TITLE
sys-kernel/linux-firmware: remove chmod workarounds

### DIFF
--- a/sys-kernel/linux-firmware/linux-firmware-99999999.ebuild
+++ b/sys-kernel/linux-firmware/linux-firmware-99999999.ebuild
@@ -120,14 +120,6 @@ src_unpack() {
 src_prepare() {
 	default
 
-	find . -type f -not -perm 0644 -print0 \
-		| xargs --null --no-run-if-empty chmod 0644 \
-		|| die
-
-	chmod +x "${S}"/{copy-firmware.sh,dedup-firmware.sh,check_whence.py,build_packages.py} || die
-	chmod +x "${S}"/{carl9170fw/autogen.sh,carl9170fw/genapi.sh} || die
-	chmod +x "${S}"/contrib/process_linux_firmware.py || die
-
 	cp "${FILESDIR}/${PN}-make-amd-ucode-img.bash" "${T}/make-amd-ucode-img" || die
 	chmod +x "${T}/make-amd-ucode-img" || die
 


### PR DESCRIPTION
The upstream tooling has been updated recently to include file module validation and all the firmware files have dropped their execute bit.

Thus we no longer need the local chmod workarounds.

NOTE: I'm not a Gentoo individual, so the change has  _not_ been tested.

NOTE: If you're planning to release 20242017 you will need something like https://gitlab.com/kernel-firmware/linux-firmware/-/merge_requests/339

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
