### PR TITLE
sys-apps/kmod: switch to meson, drop static-lib support

### DIFF
--- a/sys-apps/kmod/kmod-9999.ebuild
+++ b/sys-apps/kmod/kmod-9999.ebuild
@@ -77,15 +77,6 @@ src_install() {
 		done
 	fi
 
-	cat <<-EOF > "${T}"/usb-load-ehci-first.conf
-	softdep uhci_hcd pre: ehci_hcd
-	softdep ohci_hcd pre: ehci_hcd
-	EOF
-
-	insinto /lib/modprobe.d
-	# bug #260139
-	doins "${T}"/usb-load-ehci-first.conf
-
 	newinitd "${FILESDIR}"/kmod-static-nodes-r1 kmod-static-nodes
 }
 

--- a/sys-apps/kmod/kmod-9999.ebuild
+++ b/sys-apps/kmod/kmod-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit autotools libtool bash-completion-r1
+inherit meson shell-completion
 
 DESCRIPTION="Library and tools for managing linux kernel modules"
 HOMEPAGE="https://git.kernel.org/pub/scm/utils/kernel/kmod/kmod.git"
@@ -18,7 +18,7 @@ fi
 
 LICENSE="LGPL-2"
 SLOT="0"
-IUSE="debug doc +lzma pkcs7 static-libs +tools +zlib +zstd"
+IUSE="debug doc +lzma pkcs7 +tools +zlib +zstd"
 
 # Upstream does not support running the test suite with custom configure flags.
 # I was also told that the test suite is intended for kmod developers.
@@ -41,79 +41,39 @@ RDEPEND="
 "
 DEPEND="${RDEPEND}"
 BDEPEND="
-	doc? (
-		dev-util/gtk-doc
-		dev-build/gtk-doc-am
-	)
+	app-text/scdoc
+	doc? ( dev-util/gtk-doc )
 	lzma? ( virtual/pkgconfig )
 	zlib? ( virtual/pkgconfig )
 "
-if [[ ${PV} == 9999* ]]; then
-	BDEPEND+=" app-text/scdoc"
-fi
-
-src_prepare() {
-	default
-
-	if [[ ! -e configure ]] || use doc ; then
-		if use doc; then
-			cp "${BROOT}"/usr/share/aclocal/gtk-doc.m4 m4 || die
-			gtkdocize --copy --docdir libkmod/docs || die
-		else
-			touch libkmod/docs/gtk-doc.make
-		fi
-		eautoreconf
-	else
-		elibtoolize
-	fi
-
-	# Restore possibility of running --enable-static, bug #472608
-	sed -i \
-		-e '/--enable-static is not supported by kmod/s:as_fn_error:echo:' \
-		configure || die
-}
-
 src_configure() {
 	# TODO: >=33 enables decompressing without libraries being built in
 	# as kmod defers to the kernel. How should the ebuild be adapted?
-	local myeconfargs=(
-		--bindir="${EPREFIX}/bin"
-		--sbindir="${EPREFIX}/sbin"
-		--enable-shared
-		--with-bashcompletiondir="$(get_bashcompdir)"
-		$(use_enable debug)
-		$(usev doc '--enable-gtk-doc')
-		$(use_enable static-libs static)
-		$(use_enable tools)
-		$(use_with lzma xz)
-		$(use_with pkcs7 openssl)
-		$(use_with zlib)
-		$(use_with zstd)
+	local emesonargs=(
+		--bindir "${EPREFIX}/bin"
+		--sbindir "${EPREFIX}/sbin"
+		-Dbashcompletiondir="$(get_bashcompdir)"
+		-Dfishcompletiondir="$(get_fishcompdir)"
+		-Dzshcompletiondir="$(get_zshcompdir)"
+		$(meson_use debug debug-messages)
+		$(meson_use doc docs)
+		$(meson_use tools)
+		$(meson_feature lzma xz)
+		$(meson_feature pkcs7 openssl)
+		$(meson_feature zlib)
+		$(meson_feature zstd)
 	)
 
-	if [[ ${PV} != 9999 ]] ; then
-		# See src_install
-		myeconfargs+=( --disable-manpages )
-	fi
-
-	econf "${myeconfargs[@]}"
+	meson_src_configure
 }
 
 src_install() {
-	default
-
-	if [[ ${PV} != 9999 ]] ; then
-		# The dist logic is broken but the files are in there (bug #937942)
-		emake -C man DESTDIR="${D}" install
-	fi
-
-	find "${ED}" -type f -name "*.la" -delete || die
+	meson_src_install
 
 	if use tools; then
 		local cmd
-		for cmd in depmod insmod modprobe rmmod; do
-			rm "${ED}"/bin/${cmd} || die
-			dosym ../bin/kmod /sbin/${cmd}
+		for cmd in lsmod modinfo; do
+			dosym kmod /bin/${cmd}
 		done
 	fi
 


### PR DESCRIPTION
Over the last few months, we've got meson support upstream and the plan is to quickly migrate from autotools with just one version overlap.

There is no plan to support static-lib upstream and as illustrated in the original thread it doesn't quite work since we get lots of symbol collisions, so drop the IUSE flag and local workarounds.

Upstream has also started pulling the shell completions into the main project, to indicate that use the respective get_*compdir helpers.

Suspecting those could live behind an IUSE flag, as does scdoc... Which can come at a later day.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.

---

NOTE: This PR is done as a heads-up and is completely untested and likely broken. Please take as much or as little of it as you see fit.

Couple of questions, if I may:
 - Reading through the wiki [1], it's not entirely clear if `split-usr` is planed to be phased out. Any references?
 - Gentoo (and Debian fwiw) have been carrying `softdep Xhci_hcd pre: ehci_hcd` quirk for decade, while we have a _similar_ change in the upstream kernel since 2013 [2]. Is the local workaround still needed, any references?

Thanks in advance o/

[1] https://wiki.gentoo.org/wiki/Merge-usr
[2] https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=05c92da0c52494caf97d58be1b05b1f95a79ce4e
