### PR TITLE
sci-physics/thepeg: add missing include

### DIFF
--- a/sci-physics/thepeg/files/thepeg-2.3.0-functional.patch
+++ b/sci-physics/thepeg/files/thepeg-2.3.0-functional.patch
@@ -1,0 +1,10 @@
+--- a/Config/std.h	2024-10-20 14:58:16.121021570 +0200
++++ b/Config/std.h	2024-10-20 14:58:25.804498716 +0200
+@@ -37,6 +37,7 @@
+ #include <typeinfo>
+ #include <stdexcept>
+ #include <cmath>
++#include <functional>
+ 
+ namespace std {
+ 

--- a/sci-physics/thepeg/thepeg-2.3.0.ebuild
+++ b/sci-physics/thepeg/thepeg-2.3.0.ebuild
@@ -53,6 +53,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-1.8.3-java.patch
 	"${FILESDIR}"/${PN}-2.0.4-gcc6.patch
 	"${FILESDIR}"/${PN}-2.3.0-rivet.patch # properly support rivet/yoda weights in thepeg, reported to upstream by mail.
+	"${FILESDIR}"/${PN}-2.3.0-functional.patch # https://bugs.gentoo.org/941477
 )
 
 src_prepare() {


### PR DESCRIPTION
I only presume that fixes the bug, since I was not sure how to check it. But it looks very indicative of missing include. I sent a mail to upstream.

Closes: https://bugs.gentoo.org/941477

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgdev commit` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
