### PR TITLE
sci-physics/yoda: metadata indents

### DIFF
--- a/sci-physics/yoda/metadata.xml
+++ b/sci-physics/yoda/metadata.xml
@@ -6,8 +6,8 @@
   <name>Alexander Puck Neuwirth</name>
 </maintainer>
 <maintainer type="person" proxied="proxy">
-	<email>andrewammerlaan@gentoo.org</email>
-	<name>Andrew Ammerlaan</name>
+  <email>andrewammerlaan@gentoo.org</email>
+  <name>Andrew Ammerlaan</name>
 </maintainer>
 <maintainer type="project">
   <email>sci-physics@gentoo.org</email>


### PR DESCRIPTION
I'll see if I can configure `pkgdev commit` to fail on warnings. Follow up to https://github.com/gentoo/gentoo/pull/38833.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgdev commit` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
