### PR TITLE
app-crypt/gnupg-pkcs11-scd: add 9999 ebuild

### DIFF
--- a/app-crypt/gnupg-pkcs11-scd/gnupg-pkcs11-scd-9999.ebuild
+++ b/app-crypt/gnupg-pkcs11-scd/gnupg-pkcs11-scd-9999.ebuild
@@ -1,0 +1,53 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DESCRIPTION="PKCS#11 support for GnuPG"
+HOMEPAGE="https://sourceforge.net/projects/gnupg-pkcs11/"
+
+if [[ ${PV} == "9999" ]] ; then
+	EGIT_REPO_URI="https://github.com/alonbl/gnupg-pkcs11-scd.git"
+	inherit autotools git-r3
+	KEYWORDS=""
+else
+	SRC_URI="https://github.com/alonbl/${PN}/releases/download/${P}/${P}.tar.bz2"
+	KEYWORDS="~amd64 ~x86"
+fi
+LICENSE="BSD"
+SLOT="0"
+IUSE="proxy"
+
+DEPEND="
+	dev-libs/openssl:=
+	dev-libs/libassuan:=
+	dev-libs/libgcrypt:=
+	dev-libs/libgpg-error:=
+	dev-libs/pkcs11-helper:="
+RDEPEND="
+	${DEPEND}
+	proxy? (
+		acct-group/gnupg-pkcs11
+		acct-group/gnupg-pkcs11-scd-proxy
+		acct-user/gnupg-pkcs11-scd-proxy
+	)"
+BDEPEND="virtual/pkgconfig"
+
+src_configure() {
+	eautoreconf
+	local myeconfargs=(
+		$(use_enable proxy)
+		--with-proxy-socket=/run/gnupg-pkcs11-scd-proxy/cmd
+	)
+
+	econf "${myeconfargs[@]}"
+}
+
+src_install() {
+	default
+
+	if use proxy; then
+		newinitd "${FILESDIR}"/gnupg-pkcs11-scd-proxy.initd gnupg-pkcs11-scd-proxy
+		newconfd "${FILESDIR}"/gnupg-pkcs11-scd-proxy.confd gnupg-pkcs11-scd-proxy
+	fi
+}


### PR DESCRIPTION
This project depends upon the old libassuan v2 due to a build bug which got fixed upstream in the latest "master" branch, however upstream releases are very far in between (last was in Jan 2022) so we add the 9999 ebuild which works nicely with libassuan 3.0.

I've asked upstream to cut a new release containing the fix [1] however I don't know how long that will take and we can still have the same problems down the line, so it's useful to have a 9999 git ebuild.

Link: [1] https://github.com/alonbl/gnupg-pkcs11-scd/issues/65
---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
