### PR TITLE
sci-physics/fastjet-contrib: Update patches

### DIFF
--- a/sci-physics/fastjet-contrib/fastjet-contrib-1.055.ebuild
+++ b/sci-physics/fastjet-contrib/fastjet-contrib-1.055.ebuild
@@ -23,6 +23,7 @@ RDEPEND="${DEPEND}"
 PATCHES=(
 	"${FILESDIR}"/${PN}-1.049-soname.patch
 	"${FILESDIR}"/${PN}-1.049-ar.patch
+	"${FILESDIR}"/${PN}-1.055-ar-part2.patch # https://github.com/fjcontrib/fjcontrib/issues/3
 )
 
 src_configure() {

--- a/sci-physics/fastjet-contrib/files/fastjet-contrib-1.049-soname.patch
+++ b/sci-physics/fastjet-contrib/files/fastjet-contrib-1.049-soname.patch
@@ -5,7 +5,7 @@
  fragile_SHARED_SRC_LIST=@FRAGILE_SHARED_SRC_LIST@
  libfastjetcontribfragile.@DYNLIBEXT@: $(fragile_SHARED_SRC_LIST)
 -	$(CXX) @DYNLIBOPT@ -fPIC -DPIC $(CXXFLAGS) `$(FASTJETCONFIG) --cxxflags --libs` $(fragile_SHARED_SRC_LIST) -o libfastjetcontribfragile.@DYNLIBEXT@
-+	$(CXX) @DYNLIBOPT@ -fPIC -DPIC -Wl,-Ol -Wl,--as-needed -Wl,-soname,fastjetcontribfragile.so.0 $(LDFLAGS) $(CXXFLAGS) `$(FASTJETCONFIG) --cxxflags --libs` $(fragile_SHARED_SRC_LIST) -o libfastjetcontribfragile.@DYNLIBEXT@
++	$(CXX) @DYNLIBOPT@ -fPIC -DPIC -Wl,--as-needed -Wl,-soname,fastjetcontribfragile.so.0 $(LDFLAGS) $(CXXFLAGS) `$(FASTJETCONFIG) --cxxflags --libs` $(fragile_SHARED_SRC_LIST) -o libfastjetcontribfragile.@DYNLIBEXT@
  
  fragile-shared-install: fragile-shared
  	utils/install-sh -c -m 755 libfastjetcontribfragile.@DYNLIBEXT@ $(PREFIX)/lib

--- a/sci-physics/fastjet-contrib/files/fastjet-contrib-1.055-ar-part2.patch
+++ b/sci-physics/fastjet-contrib/files/fastjet-contrib-1.055-ar-part2.patch
@@ -1,0 +1,13 @@
+--- a/SignalFreeBackgroundEstimator/Makefile
++++ b/SignalFreeBackgroundEstimator/Makefile
+@@ -39,8 +39,8 @@
+ all: lib$(NAME).a
+ 
+ lib$(NAME).a: $(OBJS) 
+-	ar cru lib$(NAME).a $(OBJS)
+-	ranlib lib$(NAME).a
++	$(AR) cru lib$(NAME).a $(OBJS)
++	$(RANLIB) lib$(NAME).a
+ 
+ # building the examples
+ examples: $(EXAMPLES)

--- a/sci-physics/fastjet-contrib/metadata.xml
+++ b/sci-physics/fastjet-contrib/metadata.xml
@@ -16,4 +16,7 @@
 	<longdescription lang="en">
 	The fastjet-contrib space is intended to provide a common location for access to 3rd party extensions of FastJet.
 	</longdescription>
+	<upstream>
+		<remote-id type="github">fjcontrib/fjcontrib</remote-id>
+	</upstream>
 </pkgmetadata>


### PR DESCRIPTION
Update ar and soname patches. Also add upstream github (technically a mirror from hepforge svn, but the mirror is maintained by one of their devs).

`-Ol` was probably a typo of `-O1`.

~~I could also make the 1.055 patch smaller and reuse the 1.049 patch. Might be better,right?~~ Done

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgdev commit` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
