### PR TITLE
sys-apps/dstat: use importlib for plugins

### DIFF
--- a/sys-apps/dstat/dstat-0.7.4-r4.ebuild
+++ b/sys-apps/dstat/dstat-0.7.4-r4.ebuild
@@ -1,0 +1,61 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+PYTHON_COMPAT=( python3_{10..12} )
+
+inherit python-r1
+
+DESCRIPTION="Versatile replacement for vmstat, iostat and ifstat"
+HOMEPAGE="http://dag.wieers.com/home-made/dstat/"
+SRC_URI="https://github.com/dagwieers/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~alpha amd64 ~arm64 ~hppa ~mips ppc ppc64 sparc x86 ~x86-linux"
+IUSE="doc examples"
+REQUIRED_USE="${PYTHON_REQUIRED_USE}"
+
+RDEPEND="${PYTHON_DEPS}
+	dev-python/six[${PYTHON_USEDEP}]"
+DEPEND="${RDEPEND}"
+
+PATCHES=(
+	"${FILESDIR}/dstat-${PV}-skip-non-sandbox-tests.patch"
+	"${FILESDIR}/fix-collections-deprecation-warning.patch"
+	"${FILESDIR}/dstat-0.7.4-fix-csv-output.patch"
+	"${FILESDIR}/dstat-${PV}-fix-backslash-in-regex.patch"
+	"${FILESDIR}/dstat-${PV}-use-importlib.patch"
+)
+
+src_prepare() {
+	# bug fix: allow delay to be specified
+	# backport from: https://github.com/dagwieers/dstat/pull/167/files
+	sed -e 's; / op\.delay; // op.delay;' -i "dstat" || die
+
+	default
+}
+
+src_test() {
+	python_foreach_impl emake test
+}
+
+src_install() {
+	python_foreach_impl python_doscript dstat
+
+	insinto /usr/share/dstat
+	newins dstat dstat.py
+	doins plugins/dstat_*.py
+
+	doman docs/dstat.1
+
+	einstalldocs
+
+	if use examples; then
+		dodoc examples/{mstat,read}.py
+	fi
+	if use doc; then
+		dodoc docs/*.html
+	fi
+}

--- a/sys-apps/dstat/files/dstat-0.7.4-use-importlib.patch
+++ b/sys-apps/dstat/files/dstat-0.7.4-use-importlib.patch
@@ -1,0 +1,37 @@
+diff --git a/dstat b/dstat
+index 9359965..541fe95 100755
+--- a/dstat
++++ b/dstat
+@@ -2613,28 +2613,19 @@ def main():
+             pluginfile = 'dstat_' + mod.replace('-', '_')
+             try:
+                 if pluginfile not in globals():
+-                    import imp
+-                    fp, pathname, description = imp.find_module(pluginfile, pluginpath)
+-                    fp.close()
++                    import importlib.machinery
++                    spec = importlib.machinery.PathFinder().find_spec(pluginfile, pluginpath)
+ 
+                     ### TODO: Would using .pyc help with anything ?
+                     ### Try loading python plugin
+-                    if description[0] in ('.py', ):
+-                        exec(open(pathname).read())
++                    if spec.origin.endswith('.py'):
++                        exec(open(spec.origin).read())
+                         #execfile(pathname)
+                         exec('global plug; plug = dstat_plugin(); del(dstat_plugin)')
+                         plug.filename = pluginfile
+                         plug.check()
+                         plug.prepare()
+ 
+-                    ### Try loading C plugin (not functional yet)
+-                    elif description[0] == '.so':
+-                        exec('import %s; global plug; plug = %s.new()' % (pluginfile, pluginfile))
+-                        plug.check()
+-                        plug.prepare()
+-#                        print(dir(plug))
+-#                        print(plug.__module__)
+-#                        print(plug.name)
+                     else:
+                         print('Module %s is of unknown type.' % pluginfile, file=sys.stderr)
+ 


### PR DESCRIPTION
Replace imp module use with importlib
Remove unfinished code block for loading shared lib plugins

Bug: https://bugs.gentoo.org/941872

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [ x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [ x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [ x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
