### PR TITLE
sci-libs/rocFFT: force using hip-config.cmake instead of FindHIP.cmake

### DIFF
--- a/sci-libs/rocFFT/files/rocFFT-6.1.1-find-hip-use-config.patch
+++ b/sci-libs/rocFFT/files/rocFFT-6.1.1-find-hip-use-config.patch
@@ -1,0 +1,31 @@
+Upstream PR: https://github.com/ROCm/rocFFT/pull/530
+From b29c984bfaaec9d372fb566f5136fe3c473ff22d Mon Sep 17 00:00:00 2001
+From: Yiyang Wu <xgreenlandforwyy@gmail.com>
+Date: Sun, 20 Oct 2024 23:22:50 +0800
+Subject: [PATCH] Require rocFFT use hip-config.cmake to find HIP
+
+Sometimes rocFFT use FindHIP.cmake which is not desired -- it does not
+have hip::device and hip::host target imported and result in cmake
+generating error.
+
+Reference: https://bugs.gentoo.org/932155
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index bcb9819c..da697834 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -186,7 +186,7 @@ set(AMDGPU_TARGETS "${DEFAULT_GPUS}" CACHE STRING "Target default GPUs if AMDGPU
+ rocm_check_target_ids(AMDGPU_TARGETS TARGETS "${AMDGPU_TARGETS}")
+   
+ # HIP is required - library and clients use HIP to access the device
+-find_package( HIP REQUIRED )
++find_package( HIP REQUIRED CONFIG )
+ 
+ # The nvidia backend can be used to compile for CUDA devices.
+ # Specify the CUDA prefix in the CUDA_PREFIX variable.
+-- 
+2.45.2
+

--- a/sci-libs/rocFFT/rocFFT-5.7.1-r2.ebuild
+++ b/sci-libs/rocFFT/rocFFT-5.7.1-r2.ebuild
@@ -61,6 +61,7 @@ S="${WORKDIR}/rocFFT-rocm-${PV}"
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-5.7.1-fix-rocm-link-path.patch
+	"${FILESDIR}"/${PN}-6.1.1-find-hip-use-config.patch
 )
 
 required_mem() {

--- a/sci-libs/rocFFT/rocFFT-6.1.1.ebuild
+++ b/sci-libs/rocFFT/rocFFT-6.1.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -59,6 +59,7 @@ RESTRICT="!test? ( test )"
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-5.7.1-fix-rocm-link-path.patch
+	"${FILESDIR}"/${PN}-6.1.1-find-hip-use-config.patch
 )
 
 required_mem() {

--- a/sci-libs/rocFFT/rocFFT-6.3.0.ebuild
+++ b/sci-libs/rocFFT/rocFFT-6.3.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -59,6 +59,7 @@ RESTRICT="!test? ( test )"
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-5.7.1-fix-rocm-link-path.patch
+	"${FILESDIR}"/${PN}-6.1.1-find-hip-use-config.patch
 )
 
 required_mem() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/932155

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
