### PR TITLE
net-dns/knot-3.1.9: fixdep dev-libs/libbpf

### DIFF
--- a/net-dns/knot/knot-3.1.9.ebuild
+++ b/net-dns/knot/knot-3.1.9.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -8,6 +8,8 @@ inherit flag-o-matic systemd
 DESCRIPTION="High-performance authoritative-only DNS server"
 HOMEPAGE="https://www.knot-dns.cz/ https://gitlab.nic.cz/knot/knot-dns"
 SRC_URI="https://secure.nic.cz/files/knot-dns/${P/_/-}.tar.xz"
+
+S="${WORKDIR}/${P/_/-}"
 
 LICENSE="GPL-3+"
 SLOT="0"
@@ -49,8 +51,8 @@ RDEPEND="
 	)
 	systemd? ( sys-apps/systemd:= )
 	xdp? (
-		 dev-libs/libbpf:=
-		 net-libs/libmnl:=
+		<dev-libs/libbpf-0.9:=
+		net-libs/libmnl:=
 	)
 "
 DEPEND="${RDEPEND}"
@@ -58,8 +60,6 @@ BDEPEND="
 	virtual/pkgconfig
 	doc? ( dev-python/sphinx )
 "
-
-S="${WORKDIR}/${P/_/-}"
 
 src_configure() {
 	local u


### PR DESCRIPTION
xdp useflag needs <dev-libs/libbpf-0.9 otherwise it fails to build

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
