### PR TITLE
net-wireless/wireless-regdb: fix typo in warning message

### DIFF
--- a/net-wireless/wireless-regdb/wireless-regdb-20240508.ebuild
+++ b/net-wireless/wireless-regdb/wireless-regdb-20240508.ebuild
@@ -27,7 +27,7 @@ pkg_pretend() {
 				ewarn "  or add regulatory.db and regulatory.db.p7s to CONFIG_EXTRA_FIRMWARE."
 			fi
 			if ! linux_chkconfig_present CFG80211; then
-				ewarn "REGULARTORY DOMAIN PROBLEM:"
+				ewarn "REGULATORY DOMAIN PROBLEM:"
 				ewarn "  With CONFIG_CFG80211 unset, the driver(s) won't be able to load the regulatory.db from"
 				ewarn "  /lib/firmware, resulting in broken regulatory domain support. Please set CONFIG_CFG80211=m."
 			fi


### PR DESCRIPTION
Fixed a typo in one of the warning messages `REGULARTORY` -> `REGULATORY`

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
