### PR TITLE
gnome-extra/gnome-network-displays: Add runtime dep for avahi

### DIFF
--- a/gnome-extra/gnome-network-displays/gnome-network-displays-0.92.1-r1.ebuild
+++ b/gnome-extra/gnome-network-displays/gnome-network-displays-0.92.1-r1.ebuild
@@ -26,6 +26,7 @@ RDEPEND="
 	>=net-misc/networkmanager-1.16.0[wifi]
 	>=dev-libs/libportal-0.7[gtk]
 	>=gui-libs/libadwaita-1
+	net-dns/avahi[introspection]
 	net-dns/dnsmasq
 	net-wireless/wpa_supplicant[p2p]
 	sys-apps/xdg-desktop-portal[screencast(+)]


### PR DESCRIPTION
<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
