### PR TITLE
*/*: post net-mail/cmd5checkpw treeclean cleanup

### DIFF
--- a/mail-mta/netqmail/metadata.xml
+++ b/mail-mta/netqmail/metadata.xml
@@ -10,7 +10,6 @@
 		<name>Proxy Maintainers</name>
 	</maintainer>
 	<use>
-		<flag name="authcram">Enable AUTHCRAM support</flag>
 		<flag name="gencertdaily">Generate SSL certificates daily instead of
 			hourly</flag>
 		<flag name="highvolume">Prepare netqmail for high volume servers</flag>

--- a/mail-mta/netqmail/netqmail-1.06-r14.ebuild
+++ b/mail-mta/netqmail/netqmail-1.06-r14.ebuild
@@ -41,7 +41,7 @@ SRC_URI="http://qmail.org/${P}.tar.gz
 LICENSE="public-domain"
 SLOT="0"
 KEYWORDS="~alpha amd64 arm ~hppa ~mips ppc64 ~s390 sparc x86"
-IUSE="authcram gencertdaily highvolume pop3 qmail-spp ssl vanilla"
+IUSE="gencertdaily highvolume pop3 qmail-spp ssl vanilla"
 REQUIRED_USE="vanilla? ( !ssl !qmail-spp !highvolume )"
 RESTRICT="test"
 
@@ -65,7 +65,6 @@ RDEPEND="${DEPEND}
 	sys-apps/ucspi-tcp
 	virtual/checkpassword
 	virtual/daemontools
-	authcram? ( >=net-mail/cmd5checkpw-0.30 )
 	!mail-mta/courier
 	!mail-mta/esmtp
 	!mail-mta/exim
@@ -134,12 +133,8 @@ src_prepare() {
 	qmail_src_postunpack
 
 	# Fix bug #33818 but for netqmail (Bug 137015)
-	if ! use authcram; then
-		einfo "Disabled CRAM_MD5 support"
-		sed -e 's,^#define CRAM_MD5$,/*&*/,' -i "${S}"/qmail-smtpd.c || die
-	else
-		einfo "Enabled CRAM_MD5 support"
-	fi
+	einfo "Disabled CRAM_MD5 support"
+	sed -e 's,^#define CRAM_MD5$,/*&*/,' -i "${S}"/qmail-smtpd.c || die
 
 	ht_fix_file Makefile*
 }

--- a/mail-mta/netqmail/netqmail-1.06-r16.ebuild
+++ b/mail-mta/netqmail/netqmail-1.06-r16.ebuild
@@ -41,7 +41,7 @@ SRC_URI="http://qmail.org/${P}.tar.gz
 LICENSE="public-domain"
 SLOT="0"
 KEYWORDS="~alpha ~amd64 ~arm ~hppa ~mips ~ppc64 ~s390 ~sparc ~x86"
-IUSE="authcram gencertdaily highvolume pop3 qmail-spp ssl vanilla"
+IUSE="gencertdaily highvolume pop3 qmail-spp ssl vanilla"
 REQUIRED_USE="vanilla? ( !ssl !qmail-spp !highvolume )"
 RESTRICT="test"
 
@@ -63,7 +63,6 @@ DEPEND="
 "
 RDEPEND="${DEPEND}
 	sys-apps/ucspi-tcp
-	authcram? ( >=net-mail/cmd5checkpw-0.30 )
 	!mail-mta/courier
 	!mail-mta/esmtp
 	!mail-mta/exim
@@ -135,12 +134,8 @@ src_prepare() {
 	qmail_src_postunpack
 
 	# Fix bug #33818 but for netqmail (Bug 137015)
-	if ! use authcram; then
-		einfo "Disabled CRAM_MD5 support"
-		sed -e 's,^#define CRAM_MD5$,/*&*/,' -i "${S}"/qmail-smtpd.c || die
-	else
-		einfo "Enabled CRAM_MD5 support"
-	fi
+	einfo "Disabled CRAM_MD5 support"
+	sed -e 's,^#define CRAM_MD5$,/*&*/,' -i "${S}"/qmail-smtpd.c || die
 
 	ht_fix_file Makefile*
 }

--- a/profiles/base/package.use.mask
+++ b/profiles/base/package.use.mask
@@ -342,10 +342,6 @@ net-libs/gssdp man
 # Needs long-EOL dev-lang/spidermonkey:60 (which also needs python:2.7).
 media-libs/coin javascript
 
-# Michał Górny <mgorny@gentoo.org> (2022-11-19)
-# Requires packages masked for removal.
-mail-mta/netqmail authcram
-
 # Matt Turner <mattst88@gentoo.org> (2022-11-16)
 # gnome-music and gnome-photos have not been ported to libsoup:3.0, while
 # other non-slotted dependencies have been.

--- a/virtual/checkpassword/checkpassword-0-r2.ebuild
+++ b/virtual/checkpassword/checkpassword-0-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -11,6 +11,5 @@ KEYWORDS="~alpha amd64 arm ~arm64 ~hppa ~m68k ~mips ppc64 ~s390 sparc x86"
 RDEPEND="|| (
 	net-mail/checkpassword
 	net-mail/checkpassword-pam
-	net-mail/cmd5checkpw
 	net-mail/vpopmail
 )"


### PR DESCRIPTION
`net-mail/cmd5checkpw` is gone for two years already. I think we should clean the rest. What about `virtual/checkpassword`? It is used only in `mail-mta/netqmail-1.06-r14`.