### PR TITLE
dev-java/{cache2k,identicon,jbcrypt,jsonrpc2,minidns,zxing}: small fixes

### DIFF
--- a/dev-java/cache2k-api/cache2k-api-0.23.1.ebuild
+++ b/dev-java/cache2k-api/cache2k-api-0.23.1.ebuild
@@ -11,13 +11,13 @@ inherit java-pkg-2 java-pkg-simple
 DESCRIPTION="light weight and high performance Java caching library: API"
 HOMEPAGE="https://cache2k.org"
 SRC_URI="https://github.com/cache2k/cache2k/archive/v${PV}.tar.gz -> cache2k-${PV}.tar.gz"
+S="${WORKDIR}/cache2k-${PV}/api"
+
 LICENSE="Apache-2.0"
 SLOT="0"
 KEYWORDS="amd64 ~arm64"
 
 DEPEND=">=virtual/jdk-1.8:*"
 RDEPEND=">=virtual/jre-1.8:*"
-
-S="${WORKDIR}/cache2k-${PV}/api"
 
 JAVA_SRC_DIR="src/main/java"

--- a/dev-java/cache2k-core/cache2k-core-0.23.1.ebuild
+++ b/dev-java/cache2k-core/cache2k-core-0.23.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -12,6 +12,8 @@ inherit java-pkg-2 java-pkg-simple
 DESCRIPTION="light weight and high performance Java caching library: core"
 HOMEPAGE="https://cache2k.org"
 SRC_URI="https://github.com/cache2k/cache2k/archive/v${PV}.tar.gz -> cache2k-${PV}.tar.gz"
+S="${WORKDIR}/cache2k-${PV}/core"
+
 LICENSE="Apache-2.0"
 SLOT="0"
 KEYWORDS=""
@@ -28,8 +30,6 @@ RDEPEND="
 	>=virtual/jre-1.8:*
 	${CP_DEPEND}
 "
-
-S="${WORKDIR}/cache2k-${PV}/core"
 
 JAVA_SRC_DIR="src/main/java"
 JAVA_RESOURCE_DIRS=( "src/main/resources" )

--- a/dev-java/identicon/identicon-1.0.ebuild
+++ b/dev-java/identicon/identicon-1.0.ebuild
@@ -12,6 +12,8 @@ DESCRIPTION="Visual representation of a hash value"
 HOMEPAGE="https://github.com/PauloMigAlmeida/identicon"
 COMMIT="96902d3c7c9733d9da4cce9c5ed424557fc2ec3c"
 SRC_URI="https://github.com/PauloMigAlmeida/identicon/archive/${COMMIT}.tar.gz -> ${P}.tar.gz"
+S="${WORKDIR}/${PN}-${COMMIT}/core"
+
 LICENSE="MIT"
 SLOT="1"
 KEYWORDS="amd64 ~arm64"
@@ -28,8 +30,6 @@ RDEPEND="
 	${CP_DEPEND}
 	>=virtual/jre-1.8:*
 "
-
-S="${WORKDIR}/${PN}-${COMMIT}/core"
 
 JAVA_SRC_DIR="src/main/java"
 JAVA_TEST_GENTOO_CLASSPATH="cache2k-api-2"

--- a/dev-java/jbcrypt/jbcrypt-0.4.ebuild
+++ b/dev-java/jbcrypt/jbcrypt-0.4.ebuild
@@ -10,16 +10,15 @@ JAVA_TESTING_FRAMEWORKS="junit"
 inherit java-pkg-2 java-pkg-simple
 
 DESCRIPTION="Java implementation of OpenBSD's Blowfish password hashing code"
-HOMEPAGE="https://www.mindrot.org/projects/jBCrypt"
+HOMEPAGE="https://www.mindrot.org/projects/jBCrypt/"
 SRC_URI="https://www.mindrot.org/files/jBCrypt/jBCrypt-${PV}.tar.gz"
+S="${WORKDIR}/jBCrypt-${PV}"
 LICENSE="BSD"
 SLOT="0"
 KEYWORDS="amd64 ~arm64"
 
 DEPEND=">=virtual/jdk-1.8:*"
 RDEPEND=">=virtual/jre-1.8:*"
-
-S="${WORKDIR}/jBCrypt-${PV}"
 
 JAVA_SRC_DIR="src"
 JAVA_TEST_SRC_DIR="test"

--- a/dev-java/json-smart/json-smart-1.3.3.ebuild
+++ b/dev-java/json-smart/json-smart-1.3.3.ebuild
@@ -12,14 +12,14 @@ inherit java-pkg-2 java-pkg-simple
 DESCRIPTION="old JSON parser"
 HOMEPAGE="https://urielch.github.io"
 SRC_URI="https://github.com/netplex/json-smart-v1/archive/${PV}.tar.gz -> ${P}.tar.gz"
+S="${WORKDIR}/${PN}-v1-${PV}/json-smart"
+
 LICENSE="Apache-2.0"
 SLOT="1"
 KEYWORDS="amd64 ~arm64"
 
 DEPEND=">=virtual/jdk-1.8:*"
 RDEPEND=">=virtual/jre-1.8:*"
-
-S="${WORKDIR}/${PN}-v1-${PV}/json-smart"
 
 JAVA_SRC_DIR="src/main/java"
 JAVA_TEST_SRC_DIR="src/test/java"

--- a/dev-java/jsonrpc2-base/jsonrpc2-base-1.38.2.ebuild
+++ b/dev-java/jsonrpc2-base/jsonrpc2-base-1.38.2.ebuild
@@ -12,6 +12,8 @@ inherit java-pkg-2 java-pkg-simple
 DESCRIPTION="Represent, parse and serialise JSON-RPC 2.0 messages"
 HOMEPAGE="https://software.dzhuvinov.com/json-rpc-2.0-base.html"
 SRC_URI="https://bitbucket.org/thetransactioncompany/json-rpc-2.0-base/get/${PV}.tar.bz2 -> ${P}.tar.bz2"
+S="${WORKDIR}/thetransactioncompany-json-rpc-2.0-base-75e66af02953"
+
 LICENSE="Apache-2.0"
 SLOT="1"
 KEYWORDS="amd64 ~arm64"
@@ -26,8 +28,6 @@ RDEPEND="
 	${CP_DEPEND}
 	>=virtual/jre-1.8:*
 "
-
-S="${WORKDIR}/thetransactioncompany-json-rpc-2.0-base-75e66af02953"
 
 JAVA_SRC_DIR="src/main/java"
 JAVA_TEST_SRC_DIR="src/test/java"

--- a/dev-java/jsonrpc2-server/jsonrpc2-server-1.11.1.ebuild
+++ b/dev-java/jsonrpc2-server/jsonrpc2-server-1.11.1.ebuild
@@ -12,6 +12,8 @@ inherit java-pkg-2 java-pkg-simple
 DESCRIPTION="Server framework for processing JSON-RPC 2.0 messages"
 HOMEPAGE="https://software.dzhuvinov.com/json-rpc-2.0-server.html"
 SRC_URI="https://bitbucket.org/thetransactioncompany/json-rpc-2.0-server/get/${PV}.tar.bz2 -> ${P}.tar.bz2"
+S="${WORKDIR}/thetransactioncompany-json-rpc-2.0-server-40234a8c2029"
+
 LICENSE="Apache-2.0"
 SLOT="1"
 KEYWORDS="amd64 ~arm64"
@@ -34,8 +36,6 @@ RDEPEND="
 	${CP_DEPEND}
 	>=virtual/jre-1.8:*
 "
-
-S="${WORKDIR}/thetransactioncompany-json-rpc-2.0-server-40234a8c2029"
 
 JAVA_CLASSPATH_EXTRA="javax-servlet-api-3.0"
 JAVA_SRC_DIR="src/main/java"

--- a/dev-java/minidns-core/minidns-core-1.0.4.ebuild
+++ b/dev-java/minidns-core/minidns-core-1.0.4.ebuild
@@ -11,14 +11,14 @@ inherit java-pkg-2 java-pkg-simple
 DESCRIPTION="DNS library for Java and Android systems"
 HOMEPAGE="https://github.com/minidns/minidns"
 SRC_URI="https://github.com/MiniDNS/minidns/archive/${PV}.tar.gz -> ${P}.tar.gz"
+S="${WORKDIR}/minidns-${PV}/${PN}"
+
 LICENSE="Apache-2.0"
 SLOT="1"
 KEYWORDS="amd64 ~arm64"
 
 DEPEND=">=virtual/jdk-1.8:*"
 RDEPEND=">=virtual/jre-1.8:*"
-
-S="${WORKDIR}/minidns-${PV}/${PN}"
 
 JAVA_SRC_DIR="src/main/java"
 # needs junit:5

--- a/dev-java/zxing-core/zxing-core-3.5.1.ebuild
+++ b/dev-java/zxing-core/zxing-core-3.5.1.ebuild
@@ -10,16 +10,16 @@ JAVA_TESTING_FRAMEWORKS="junit-4"
 inherit java-pkg-2 java-pkg-simple
 
 DESCRIPTION="Core barcode encoding/decoding library"
-HOMEPAGE="https://github.com/zxing/zxing/core"
+HOMEPAGE="https://zxing.github.io/zxing/"
 SRC_URI="https://github.com/zxing/zxing/archive/zxing-${PV}.tar.gz"
+S="${WORKDIR}/zxing-zxing-${PV}/core"
+
 LICENSE="Apache-2.0"
 SLOT="3"
 KEYWORDS="amd64 ~arm64"
 
 DEPEND=">=virtual/jdk-1.8:*"
 RDEPEND=">=virtual/jre-1.8:*"
-
-S="${WORKDIR}/zxing-zxing-${PV}/core"
 
 JAVA_AUTOMATIC_MODULE_NAME="com.google.zxing"
 JAVA_SRC_DIR="src/main/java"

--- a/dev-java/zxing-javase/zxing-javase-3.5.1.ebuild
+++ b/dev-java/zxing-javase/zxing-javase-3.5.1.ebuild
@@ -10,8 +10,10 @@ JAVA_TESTING_FRAMEWORKS="junit-4"
 inherit java-pkg-2 java-pkg-simple
 
 DESCRIPTION="Core barcode encoding/decoding library"
-HOMEPAGE="https://github.com/zxing/zxing"
+HOMEPAGE="https://zxing.github.io/zxing/"
 SRC_URI="https://github.com/zxing/zxing/archive/zxing-${PV}.tar.gz"
+S="${WORKDIR}/zxing-zxing-${PV}/javase"
+
 LICENSE="Apache-2.0"
 SLOT="3"
 KEYWORDS="amd64 ~arm64"
@@ -28,8 +30,6 @@ RDEPEND="
 	${CP_DEPEND}
 	>=virtual/jre-1.8:*
 "
-
-S="${WORKDIR}/zxing-zxing-${PV}/javase"
 
 PATCHES=(
 	"${FILESDIR}/${PV}-test-available-formats.patch"


### PR DESCRIPTION
while looking at the QA bot logs, it seems that some QA issues (`VariableOrderWrong` & `RedirectedUrl` so mostly cosmetic) were found in pretty much all of the `dev-java/*` pkgs I'm taking care of. in an excess of tidiness, here goes the small fixes.

on a related note, it seems that I added `dev-java/cache2k-core` but it not referenced anywhere in the tree. and with #39112, `dev-java/cache2k-api` & `dev-java/identicon` will also dangle. what's the policy on removing such uneeded pkgs?

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.