### PR TITLE
sys-boot/plymouth: Allow build with +pango but -X

### DIFF
--- a/sys-boot/plymouth/plymouth-22.02.122-r3.ebuild
+++ b/sys-boot/plymouth/plymouth-22.02.122-r3.ebuild
@@ -33,12 +33,13 @@ CDEPEND="
 	)
 	pango? (
 		x11-libs/cairo
-		>=x11-libs/pango-1.21[X]
+		>=x11-libs/pango-1.21
+		gtk? ( >=x11-libs/pango-1.21[X] )
 	)
 "
 DEPEND="${CDEPEND}
 	elibc_musl? ( sys-libs/rpmatch-standalone )
-	pango? ( x11-base/xorg-proto )
+	pango? ( gtk? ( x11-base/xorg-proto ) )
 	app-text/docbook-xsl-stylesheets
 	dev-libs/libxslt
 	virtual/pkgconfig

--- a/sys-boot/plymouth/plymouth-24.004.60-r1.ebuild
+++ b/sys-boot/plymouth/plymouth-24.004.60-r1.ebuild
@@ -44,7 +44,8 @@ COMMON_DEPEND="
 	)
 	pango? (
 		x11-libs/cairo
-		>=x11-libs/pango-1.21[X]
+		>=x11-libs/pango-1.21
+		gtk? ( >=x11-libs/pango-1.21[X] )
 	)
 	systemd? ( sys-apps/systemd )
 	udev? ( virtual/libudev )
@@ -52,7 +53,7 @@ COMMON_DEPEND="
 
 DEPEND="${COMMON_DEPEND}
 	elibc_musl? ( sys-libs/rpmatch-standalone )
-	pango? ( x11-base/xorg-proto )
+	pango? ( gtk? ( x11-base/xorg-proto ) )
 "
 
 RDEPEND="${COMMON_DEPEND}

--- a/sys-boot/plymouth/plymouth-9999.ebuild
+++ b/sys-boot/plymouth/plymouth-9999.ebuild
@@ -44,7 +44,8 @@ COMMON_DEPEND="
 	)
 	pango? (
 		x11-libs/cairo
-		>=x11-libs/pango-1.21[X]
+		>=x11-libs/pango-1.21
+		gtk? ( >=x11-libs/pango-1.21[X] )
 	)
 	systemd? ( sys-apps/systemd )
 	udev? ( virtual/libudev )
@@ -52,7 +53,7 @@ COMMON_DEPEND="
 
 DEPEND="${COMMON_DEPEND}
 	elibc_musl? ( sys-libs/rpmatch-standalone )
-	pango? ( x11-base/xorg-proto )
+	pango? ( gtk? ( x11-base/xorg-proto ) )
 "
 
 RDEPEND="${COMMON_DEPEND}


### PR DESCRIPTION
This patch allows building plymouth with pango enabled but without requiring X11 dependencies.

This is only possible when GTK support is disabled. Enabling GTK also requires pango to be built with X support.

See https://github.com/gentoo/gentoo/pull/36091#issuecomment-2439912657

https://github.com/dracut-ng/dracut-ng/issues/732 should not be affected. Dracut CI builds plymouth with both pango and gtk enabled.

All ebuilds are building without issues, USE="drm pango udev -debug -doc -freetype -gtk -static-libs -selinux -split-usr":

* sys-boot/plymouth-22.02.122-r3
* sys-boot/plymouth-24.004.60-r1
* sys-boot/plymouth-9999

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
