### PR TITLE
net-misc/spice-gtk: X dependency is optional

### DIFF
--- a/net-misc/spice-gtk/spice-gtk-0.42-r4.ebuild
+++ b/net-misc/spice-gtk/spice-gtk-0.42-r4.ebuild
@@ -24,7 +24,9 @@ fi
 
 LICENSE="LGPL-2.1"
 SLOT="0"
-IUSE="gtk-doc +gtk3 +introspection lz4 mjpeg policykit sasl smartcard usbredir vala valgrind wayland webdav"
+IUSE="gtk-doc +gtk3 +introspection lz4 mjpeg policykit sasl smartcard usbredir vala valgrind wayland webdav X"
+
+REQUIRED_USE="|| ( wayland X ) wayland? ( gtk3 )"
 
 # TODO:
 # * check if sys-freebsd/freebsd-lib (from virtual/acl) provides acl/libacl.h
@@ -40,8 +42,8 @@ RDEPEND="
 	sys-libs/zlib
 	>=x11-libs/cairo-1.2
 	>=x11-libs/pixman-0.17.7
-	x11-libs/libX11
-	gtk3? ( x11-libs/gtk+:3[introspection?] )
+	X? ( x11-libs/libX11 )
+	gtk3? ( x11-libs/gtk+:3[X?,wayland?,introspection?] )
 	introspection? ( dev-libs/gobject-introspection )
 	dev-libs/openssl:=
 	lz4? ( app-arch/lz4 )


### PR DESCRIPTION
x11-libs/libX11 is optional, but it must be consistent with gtk+ USE flags. Thus the added X USE flag for expressing that.

Bug: https://bugs.gentoo.org/942349
Closes: https://bugs.gentoo.org/942349

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
