### PR TITLE
dev-python/pycairo: superflous x11-base/xorg-proto DEPEND

### DIFF
--- a/dev-python/pycairo/pycairo-1.27.0.ebuild
+++ b/dev-python/pycairo/pycairo-1.27.0.ebuild
@@ -31,7 +31,6 @@ RDEPEND="
 "
 DEPEND="
 	${RDEPEND}
-	x11-base/xorg-proto
 "
 BDEPEND="
 	virtual/pkgconfig


### PR DESCRIPTION
pycairo has not direct x11 dependencies, only transitively based on x11-libs/cairo build flags. Therefore, x11-base/xorg-proto should be removed.

all x11 related code guarded by cairo macros cairo/surface.c:

    #ifdef CAIRO_HAS_XLIB_SURFACE
    #include <cairo-xlib.h>

    #ifdef CAIRO_HAS_XCB_SURFACE
    #include <cairo-xcb.h>

    #ifdef CAIRO_HAS_TEE_SURFACE
    #include <cairo-tee.h>

x11-libs/cairo-1.18.2-r1:

* X USE flag includes x11-base/xorg-proto
* X USE flag enables the X dependent surfaces: $(meson_feature X tee) $(meson_feature X xcb) $(meson_feature X xlib)

Bug: https://bugs.gentoo.org/942352
Closes: https://bugs.gentoo.org/942352

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
