### PR TITLE
net-libs/gtk-vnc: x11 is optional

### DIFF
--- a/net-libs/gtk-vnc/gtk-vnc-1.3.1-r1.ebuild
+++ b/net-libs/gtk-vnc/gtk-vnc-1.3.1-r1.ebuild
@@ -25,7 +25,7 @@ RDEPEND="
 	sasl? ( >=dev-libs/cyrus-sasl-2.1.27:2 )
 	>=x11-libs/gtk+-3.24.41-r1:3[introspection?,wayland?,X?]
 	>=x11-libs/cairo-1.15.0
-	>=x11-libs/libX11-1.6.5
+	X? ( >=x11-libs/libX11-1.6.5 )
 	pulseaudio? ( media-libs/libpulse )
 	introspection? ( >=dev-libs/gobject-introspection-1.56.0:= )
 "


### PR DESCRIPTION
The current ebuild depends on >=x11-libs/libX11-1.6.5 even with -X USE flag. The dependency should be guarded by X USE flag.

Bug: https://bugs.gentoo.org/942356
Closes: https://bugs.gentoo.org/942356

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
