### PR TITLE
media-gfx/gimp: Xmu pulled with -X

### DIFF
--- a/media-gfx/gimp/gimp-2.99.18-r1.ebuild
+++ b/media-gfx/gimp/gimp-2.99.18-r1.ebuild
@@ -54,7 +54,6 @@ COMMON_DEPEND="
 	>=x11-libs/gdk-pixbuf-2.40.0:2[introspection]
 	>=x11-libs/gtk+-3.24.16:3[introspection]
 	>=x11-libs/pango-1.50.0
-	>=x11-libs/libXmu-1.1.4
 	aalib? ( media-libs/aalib )
 	alsa? ( >=media-libs/alsa-lib-1.0.0 )
 	fits? ( sci-libs/cfitsio )
@@ -81,7 +80,10 @@ COMMON_DEPEND="
 	unwind? ( >=sys-libs/libunwind-1.1.0:= )
 	webp? ( >=media-libs/libwebp-0.6.0:= )
 	wmf? ( >=media-libs/libwmf-0.2.8 )
-	X? ( x11-libs/libXcursor )
+	X? (
+		x11-libs/libXcursor
+		>=x11-libs/libXmu-1.1.4
+	)
 	xpm? ( x11-libs/libXpm )
 "
 


### PR DESCRIPTION
`>=x11-libs/libXmu-1.1.4` is in depend even with -X USE flag. The PR
guards it behind X? USE flag. The meson dependencies treats Xmu as grouped X dependencies and gimp builds and runs without Xmu.

Bug: https://bugs.gentoo.org/942358
Closes: https://bugs.gentoo.org/942358

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
