### PR TITLE
dev-util/weka: add missing jar to weka

### DIFF
--- a/dev-util/weka/files/weka.desktop
+++ b/dev-util/weka/files/weka.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Name=Weka
+Comment=Waikato Environment for Knowledge Analysis
+Exec=/usr/bin/weka
+Icon=/usr/share/pixmaps/weka.ico
+Type=Application
+StartupNotify=false
+StartupWMClass=Weka
+Categories=Utility;Development
+Actions=new-empty-window;
+Keywords=weka

--- a/dev-util/weka/weka-3.8.6-r1.ebuild
+++ b/dev-util/weka/weka-3.8.6-r1.ebuild
@@ -1,0 +1,77 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+JAVA_PKG_IUSE="doc source"
+
+inherit desktop java-pkg-2 java-pkg-simple xdg
+
+DESCRIPTION="A Java data mining package"
+HOMEPAGE="https://ml.cms.waikato.ac.nz/weka"
+SRC_URI="https://downloads.sourceforge.net/project/weka/weka-3-8/${PV}/weka-${PV//./-}.zip"
+S="${WORKDIR}/${P//./-}"
+
+LICENSE="GPL-3"
+SLOT="0"
+KEYWORDS="~amd64"
+
+BDEPEND="app-arch/unzip"
+CP_DEPEND="dev-java/javacup:0"
+DEPEND="${CP_DEPEND}
+	virtual/jdk:1.8"
+RDEPEND="${CP_DEPEND}
+	>=virtual/jre-1.8:*
+	dev-java/commons-compress:0
+	dev-java/hamcrest-core:1.3
+	dev-java/istack-commons-runtime:3
+	dev-java/jakarta-activation-api:1
+	dev-java/jaxb-api:2
+	dev-java/jaxb-runtime:2
+	dev-java/jflex:0
+	dev-java/junit:4"
+
+JAVA_GENTOO_CLASSPATH_EXTRA="lib/bounce.jar:lib/mtj.jar:lib/jfilechooser-bookmarks-0.1.6.jar"
+JAVA_MAIN_CLASS="weka.gui.GUIChooser"
+JAVA_RESOURCE_DIRS="src/main/res"
+JAVA_SRC_DIR="src/main/java"
+
+src_prepare() {
+	java-pkg-2_src_prepare
+	unzip -qq "${PN}-src.jar" -d . || die "Failed to unpack the source"
+	java-pkg_clean \
+		! -path ./lib/arpack_combined.jar \
+		! -path ./lib/bounce.jar \
+		! -path ./lib/core.jar \
+		! -path ./lib/flatlaf-2.0.jar \
+		! -path ./lib/jclipboardhelper-0.1.2.jar \
+		! -path ./lib/jfilechooser-bookmarks-0.1.6.jar \
+		! -path ./lib/mtj.jar
+
+	# java-pkg-simple wants resources in JAVA_RESOURCE_DIRS.
+	mkdir -p src/main/res || die
+	pushd src/main/java > /dev/null || die
+		find -type f \
+			! -name '*.java' \
+			| xargs cp --parent -t ../res || die
+	popd > /dev/null || die
+}
+
+src_install() {
+	java-pkg-simple_src_install
+	java-pkg_dojar lib/{arpack_combined,bounce,core,mtj}.jar
+	java-pkg_dojar lib/flatlaf-2.0.jar
+	java-pkg_dojar lib/jclipboardhelper-0.1.2.jar
+	java-pkg_dojar lib/jfilechooser-bookmarks-0.1.6.jar
+
+	# Really need a virtual to list all available drivers and pull the ones
+	# instaled
+	java-pkg_register-optional-dependency hsqldb,jdbc-mysql,mckoi-1
+
+	insinto /usr/share/weka/data/
+	doins data/*
+
+	# Add icon and Desktop file
+	domenu "${FILESDIR}"/weka.desktop
+	doicon "${S}"/weka.ico
+}


### PR DESCRIPTION
The provided ebuild for weka-3.8.6 dosen't bundle some jar needed for it to work/open without errors.

Also add the desktop file and icon to the package, since the icon is provided in the weka zip file

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
