### PR TITLE
app-emulation/qemu: Update live ebuild

### DIFF
--- a/app-emulation/qemu/qemu-9999.ebuild
+++ b/app-emulation/qemu/qemu-9999.ebuild
@@ -73,7 +73,6 @@ COMMON_TARGETS="
 	aarch64
 	alpha
 	arm
-	cris
 	hppa
 	i386
 	loongarch64
@@ -91,7 +90,6 @@ COMMON_TARGETS="
 	riscv64
 	s390x
 	sh4
-	sh4eb
 	sparc
 	sparc64
 	x86_64
@@ -112,6 +110,7 @@ IUSE_USER_TARGETS="
 	mipsn32
 	mipsn32el
 	ppc64le
+	sh4eb
 	sparc32plus
 "
 

--- a/app-emulation/qemu/qemu-9999.ebuild
+++ b/app-emulation/qemu/qemu-9999.ebuild
@@ -317,7 +317,6 @@ RDEPEND="
 PATCHES=(
 	"${FILESDIR}"/${PN}-9.0.0-disable-keymap.patch
 	"${FILESDIR}"/${PN}-9.1.0-capstone-include-path.patch
-	"${FILESDIR}"/${PN}-9.0.0-also-build-virtfs-proxy-helper.patch
 	"${FILESDIR}"/${PN}-8.1.0-skip-tests.patch
 	"${FILESDIR}"/${PN}-8.1.0-find-sphinx.patch
 


### PR DESCRIPTION
There were some changes merged that prevent the live ebuild from emerging (in fact, src_prepare() fails). Here are the fixes.

BTW: There is some active development happening in bringing RUST into the mix. So far, there's just one [device driver](https://gitlab.com/qemu-project/qemu/-/tree/master/rust/hw/char/pl011?ref_type=heads) and there exists C implementation of it anyways so I'm not bringing dependency on RUST, yet.

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
