### PR TITLE
app-tect/yelp-tools + sys-apps/systemd-utils - Enable Py3.13

### DIFF
--- a/app-text/yelp-tools/yelp-tools-42.1.ebuild
+++ b/app-text/yelp-tools/yelp-tools-42.1.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..13} )
 inherit gnome2 meson python-single-r1
 
 DESCRIPTION="Collection of tools for building and converting documentation"

--- a/sys-apps/systemd-utils/systemd-utils-255.12.ebuild
+++ b/sys-apps/systemd-utils/systemd-utils-255.12.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..13} )
 
 QA_PKGCONFIG_VERSION=$(ver_cut 1)
 


### PR DESCRIPTION
yelp-tools doesn't have any meaningful test results so have run for a week without any issues noticed

>>> Test phase: sys-apps/systemd-utils-255.12
 * abi_x86_32.x86: running multilib-minimal_abi_src_test
meson test --print-errorlogs --num-processes 32 --no-rebuild --suite libudev
1/3 systemd:libudev / test-libudev-sym        OK              0.01s
2/3 systemd:libudev / test-udev-device-thread OK              0.01s
3/3 systemd:libudev / test-libudev            OK              5.14s

Ok:                 3
Expected Fail:      0
Fail:               0
Unexpected Pass:    0
Skipped:            0
Timeout:            0

Full log written to /var/tmp/portage/sys-apps/systemd-utils-255.12/work/systemd-stable-255.12-abi_x86_32.x86/meson-logs/testlog.txt
 * abi_x86_64.amd64: running multilib-minimal_abi_src_test
meson test --print-errorlogs --num-processes 32 --no-rebuild --suite boot --suite kernel-install --suite tmpfiles --suite udev --suite libudev
 1/20 systemd:udev / test-link-config-tables            OK               0.08s
 2/20 systemd:libudev / test-libudev-sym                OK               0.05s
 3/20 systemd:libudev / test-udev-device-thread         OK               0.04s
 4/20 systemd:udev / udev-rules-check                   OK               0.03s
 5/20 systemd:udev / test-fido-id-desc                  OK               0.09s
 6/20 systemd:udev / test-udev-builtin                  OK               0.08s
 7/20 systemd:udev / test-udev-format                   OK               0.08s
 8/20 systemd:udev / test-udev-manager                  OK               0.07s
 9/20 systemd:udev / test-udev-node                     OK               0.07s
10/20 systemd:udev / test-udev-rules                    OK               0.07s
11/20 systemd:udev / test-udev-spawn                    OK               0.06s
12/20 systemd:tmpfiles / test-offline-passwd            OK               0.06s
13/20 systemd:udev / dmidecode_HP-Z600                  OK               0.03s
14/20 systemd:udev / dmidecode_Lenovo-ThinkPad-X280     OK               0.03s
15/20 systemd:udev / dmidecode_Lenovo-Thinkcentre-m720s OK               0.03s
16/20 systemd:boot / test-bootctl-json                  OK               0.07s
17/20 systemd:udev / test-udev                          SKIP             0.16s   exit status 77
18/20 systemd:tmpfiles / test-systemd-tmpfiles          OK               0.37s
19/20 systemd:kernel-install / test-kernel-install      OK               0.41s
20/20 systemd:libudev / test-libudev                    OK               4.27s

Ok:                 19
Expected Fail:      0
Fail:               0
Unexpected Pass:    0
Skipped:            1
Timeout:            0

Full log written to /var/tmp/portage/sys-apps/systemd-utils-255.12/work/systemd-stable-255.12-abi_x86_64.amd64/meson-logs/testlog.txt
>>> Completed testing sys-apps/systemd-utils-255.12
---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
