### PR TITLE
dev-tcltk/expect: fix patching on macos

### DIFF
--- a/dev-tcltk/expect/expect-5.45.4-r5.ebuild
+++ b/dev-tcltk/expect/expect-5.45.4-r5.ebuild
@@ -39,7 +39,7 @@ src_prepare() {
 
 	# fix install_name on darwin
 	[[ ${CHOST} == *-darwin* ]] && \
-		eapply "${FILESDIR}"/${P}-darwin-install_name.patch
+		eapply "${FILESDIR}"/${PN}-5.45-darwin-install_name.patch
 
 	mv configure.{in,ac} || die
 


### PR DESCRIPTION
i haven't tested it as i don't have a mac but it was clearly broken and would have failed on `macos`.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
