### PR TITLE
net-nds/389-ds-base: Fixes for systemd support

### DIFF
--- a/net-nds/389-ds-base/389-ds-base-3.0.2.ebuild
+++ b/net-nds/389-ds-base/389-ds-base-3.0.2.ebuild
@@ -231,22 +231,17 @@ src_configure() {
 		$(use_enable ldapi)
 		$(use_with selinux)
 		$(use_with !systemd initddir "/etc/init.d")
+		$(use_with systemd)
 		$(use_enable test cmocka)
+		--with-systemdgroupname="dirsrv.target"
+		--with-tmpfiles-d="${EPREFIX}/usr/lib/tmpfiles.d"
+		--with-systemdsystemunitdir="$(systemd_get_systemunitdir)"
 		--enable-rust-offline
 		--with-pythonexec="${PYTHON}"
 		--with-fhs
 		--with-openldap
 		--with-db-inc="${EPREFIX}"/usr/include/db5.3
 		--disable-cockpit
-	)
-
-	# https://github.com/389ds/389-ds-base/issues/4292 part 2
-	# creates wrongly named unit file if == no
-	use systemd && myconf+=(
-		$(use_with systemd)
-		$(use_with systemdgroupname "dirsrv.target")
-		$(use_with tmpfiles-d "/usr/lib/tmpfiles.d")
-		--with-systemdsystemunitdir="$(systemd_get_systemunitdir)"
 	)
 
 	econf "${myeconfargs[@]}"


### PR DESCRIPTION
<!-- Please put the pull request description above -->
Fixes issues found when USE-flag systemd is used for ebuild net-nds/389-ds-base. 
* USE Flag 'tmpfiles-d' not in IUSE for net-nds/389-ds-base
* USE Flag 'systemdgroupname'' not in IUSE for net-nds/389-ds-base
*  Ebuild does not configure software for systemd (systemd unit missing)
---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.