### PR TITLE
sys-apps/iproute2: disable color again

### DIFF
--- a/sys-apps/iproute2/iproute2-6.11.0-r2.ebuild
+++ b/sys-apps/iproute2/iproute2-6.11.0-r2.ebuild
@@ -112,7 +112,8 @@ src_configure() {
 
 	# run "configure" script first which will create "config.mk"...
 	# Using econf breaks since 5.14.0 (a9c3d70d902a0473ee5c13336317006a52ce8242)
-	edo ./configure --color=auto --libbpf_force $(usex bpf on off)
+	eval "local -a EXTRA_ECONF=(${EXTRA_ECONF})"
+	edo ./configure --libbpf_force $(usex bpf on off) "${EXTRA_ECONF[@]}"
 
 	# Remove the definitions made by configure and allow them to be overridden
 	# by USE flags below.

--- a/sys-apps/iproute2/iproute2-9999.ebuild
+++ b/sys-apps/iproute2/iproute2-9999.ebuild
@@ -111,7 +111,8 @@ src_configure() {
 
 	# run "configure" script first which will create "config.mk"...
 	# Using econf breaks since 5.14.0 (a9c3d70d902a0473ee5c13336317006a52ce8242)
-	edo ./configure --color=auto --libbpf_force $(usex bpf on off)
+	eval "local -a EXTRA_ECONF=(${EXTRA_ECONF})"
+	edo ./configure --libbpf_force $(usex bpf on off) "${EXTRA_ECONF[@]}"
 
 	# Remove the definitions made by configure and allow them to be overridden
 	# by USE flags below.


### PR DESCRIPTION
Per discussion in IRC, use the upstream default and allow users to override it using EXTRA_ECONF.

Closes: https://bugs.gentoo.org/935049