### PR TITLE
dev-lang/rust: Remove i586 sed

### DIFF
--- a/dev-lang/rust/rust-1.82.0.ebuild
+++ b/dev-lang/rust/rust-1.82.0.ebuild
@@ -310,7 +310,8 @@ src_prepare() {
 	if use x86; then
 		if ! use cpu_flags_x86_sse2; then
 			eapply "${FILESDIR}/1.82.0-i586-baseline.patch"
-			grep -rl cmd.args.push\(\"-march=i686\" . | xargs sed  -i 's/march=i686/-march=i586/g' || die
+			# Required for i586 support, commented out until ready for wider use.
+			#grep -rl cmd.args.push\(\"-march=i686\" . | xargs sed  -i 's/march=i686/-march=i586/g' || die
 		fi
 	fi
 


### PR DESCRIPTION
This was left in by mistake and requires a second patch which is not ready for primetime at this moment.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [xI have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
