### PR TITLE
profiles: mask dev-util/bpftool-7.5.0-r1

### DIFF
--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -33,6 +33,11 @@
 
 #--- END OF EXAMPLES ---
 
+# Holger Hoffstätte <holger@applied-asynchrony.com> (2024-10-03)
+# Vendors an unreleased libbpf version and announces incorrect version.
+# Please downgrade to 7.4.0. Removal on 2024-12-03.
+=dev-util/bpftool-7.5.0-r1
+
 # David Seifert <soap@gentoo.org> (2024-11-03)
 # Bug ridden package, extremely brittle build system, lots of QA issues,
 # terrible license, no other linux distro still packages this.
@@ -165,7 +170,7 @@ dev-ruby/io-event:1.3
 
 # Holger Hoffstätte <holger@applied-asynchrony.com> (2024-10-11)
 # Vendors an unreleased libbpf version and generates ABI-breaking code.
-# Bug #941185.
+# Bug #941185. Removal on 2024-12-03.
 =dev-util/bpftool-7.5.0-r2
 
 # Michał Górny <mgorny@gentoo.org> (2024-10-10)


### PR DESCRIPTION
Vendors an unreleased libbpf version and announces incorrect version.
Please downgrade to 7.4.0. Removal on 2024-12-03.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
