### PR TITLE
net-libs/zeromq: move from autotools to cmake

### DIFF
--- a/net-libs/zeromq/metadata.xml
+++ b/net-libs/zeromq/metadata.xml
@@ -1,7 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<!-- maintainer-needed -->
+	<maintainer type="person" proxied="yes">
+		<email>davidroman96@gmail.com</email>
+		<name>David Roman</name>
+	</maintainer>
+	<maintainer type="project" proxied="proxy">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
 	<upstream>
 		<maintainer>
 			<email>sustrik@fastmq.com</email>

--- a/net-libs/zeromq/metadata.xml
+++ b/net-libs/zeromq/metadata.xml
@@ -29,6 +29,9 @@
 			Build draft API, which may change at any time without any notice, and
 			is therefore not recommended for normal use.
 		</flag>
+		<flag name="intrinsics">
+			Build using compiler intrinsics for atomic ops.
+		</flag>
 		<flag name="libbsd">
 			Use strlcpy() from <pkg>dev-libs/libbsd</pkg> instead of internal
 			implementation.

--- a/net-libs/zeromq/zeromq-4.3.5-r2.ebuild
+++ b/net-libs/zeromq/zeromq-4.3.5-r2.ebuild
@@ -1,0 +1,51 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit cmake
+
+DESCRIPTION="High-performance asynchronous messaging library"
+HOMEPAGE="https://zeromq.org/"
+SRC_URI="https://github.com/zeromq/libzmq/releases/download/v${PV}/${P}.tar.gz"
+
+LICENSE="MPL-2.0"
+SLOT="0/5"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~arm64-macos ~x64-macos"
+IUSE="doc drafts intrinsics +libbsd +sodium static-libs test unwind"
+RESTRICT="!test? ( test )"
+
+RDEPEND="
+	!elibc_Darwin? ( unwind? ( sys-libs/libunwind ) )
+	libbsd? ( dev-libs/libbsd:= )
+	sodium? ( dev-libs/libsodium:= )
+"
+DEPEND="
+	${RDEPEND}
+	!elibc_Darwin? ( sys-apps/util-linux )
+"
+BDEPEND="
+	virtual/pkgconfig
+	doc? (
+		app-text/asciidoc
+		app-text/xmlto
+	)
+"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-4.3.5-c99.patch
+)
+
+src_configure() {
+	local mycmakeargs=(
+		-DBUILD_SHARED=ON
+		-DBUILD_STATIC=$(usex static-libs)
+		-DENABLE_DRAFTS=$(usex drafts)
+		-DENABLE_INTRINSICS=$(usex intrinsics)
+		-DWITH_DOCS=$(usex doc)
+		-DWITH_LIBBSD=$(usex libbsd)
+		-DWITH_LIBSODIUM=$(usex sodium)
+	)
+
+	cmake_src_configure
+}


### PR DESCRIPTION
Also adds new USE=intrinsics which could help to reduce
false tsan positives (according to upstream PR 3919).

Moving to cmake also simplifies the ebuild.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
