### PR TITLE
distutils-r1.eclass: Update maturin's skip auditwheel option

### DIFF
--- a/eclass/distutils-r1.eclass
+++ b/eclass/distutils-r1.eclass
@@ -271,7 +271,7 @@ _distutils_set_globals() {
 				;;
 			maturin)
 				bdep+='
-					>=dev-util/maturin-1.4.0[${PYTHON_USEDEP}]
+					>=dev-util/maturin-1.7.4[${PYTHON_USEDEP}]
 				'
 				;;
 			no)
@@ -1262,8 +1262,8 @@ distutils_pep517_install() {
 			# `maturin pep517 build-wheel --help` for options
 			local maturin_args=(
 				"${DISTUTILS_ARGS[@]}"
+				--auditwheel=skip # see bug #831171
 				--jobs="$(makeopts_jobs)"
-				--skip-auditwheel # see bug #831171
 				$(in_iuse debug && usex debug '--profile=dev' '')
 			)
 


### PR DESCRIPTION
@gentoo/python this is not urgent (still usable, just deprecated), so please take over and merge with the next distutils-r1 batch whenever it's convenient.

Meant to do this a while ago but stabilization keywords for >=1.7.1 kept lagging to update the lower bound.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
