### PR TITLE
sys-apps/checkpolicy: Force checkpoilcy-3.6 to use libsepol-3.6

### DIFF
--- a/sys-apps/checkpolicy/checkpolicy-3.6.ebuild
+++ b/sys-apps/checkpolicy/checkpolicy-3.6.ebuild
@@ -25,7 +25,7 @@ LICENSE="GPL-2"
 SLOT="0"
 IUSE="debug"
 
-RDEPEND=">=sys-libs/libsepol-${PV}:=[static-libs(+)]"
+RDEPEND="~sys-libs/libsepol-${PV}"
 DEPEND="${RDEPEND}"
 BDEPEND="sys-devel/flex
 	sys-devel/bison"


### PR DESCRIPTION
API change between libsepol-3.6 and 3.7 causes checkpolicy-3.6 to fail to compile when the wrong version of libsepol is used.

Bug: https://bugs.gentoo.org/942889

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
