### PR TITLE
mail-client/evolution: make sound and desktop notifications optional

### DIFF
--- a/gnome-extra/evolution-data-server/evolution-data-server-3.52.4-r2.ebuild
+++ b/gnome-extra/evolution-data-server/evolution-data-server-3.52.4-r2.ebuild
@@ -14,7 +14,7 @@ SLOT="0/64-11-21-4-3-27-2-27-4-0" # subslot = libcamel-1.2/libebackend-1.2/libeb
 
 KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86 ~amd64-linux ~x86-linux"
 
-IUSE="berkdb +gnome-online-accounts +gtk gtk-doc +introspection ldap kerberos oauth-gtk3 oauth-gtk4 vala +weather"
+IUSE="berkdb +gnome-online-accounts +gtk gtk-doc +introspection ldap kerberos oauth-gtk3 oauth-gtk4 sound vala +weather"
 REQUIRED_USE="
 	oauth-gtk3? ( gtk )
 	oauth-gtk4? ( gtk )
@@ -42,9 +42,11 @@ RDEPEND="
 	gtk? (
 		>=x11-libs/gtk+-3.20:3
 		>=gui-libs/gtk-4.4:4
-		|| (
-			media-libs/libcanberra-gtk3
-			>=media-libs/libcanberra-0.25[gtk3(-)]
+		sound? (
+			|| (
+				media-libs/libcanberra-gtk3
+				>=media-libs/libcanberra-0.25[gtk3(-)]
+			)
 		)
 
 		oauth-gtk3? ( >=net-libs/webkit-gtk-2.34.0:4.1 )
@@ -127,7 +129,6 @@ src_configure() {
 		-DENABLE_SMIME=ON
 		-DENABLE_GTK=$(usex gtk)
 		-DENABLE_GTK4=$(usex gtk)
-		-DENABLE_CANBERRA=$(usex gtk)
 		-DENABLE_OAUTH2_WEBKITGTK=$(usex oauth-gtk3)
 		-DENABLE_OAUTH2_WEBKITGTK4=$(usex oauth-gtk4)
 		-DENABLE_EXAMPLES=OFF
@@ -140,6 +141,12 @@ src_configure() {
 		-DENABLE_VALA_BINDINGS=$(usex vala)
 		-DENABLE_TESTS=$(usex test)
 	)
+	if use gtk && use sound; then
+		mycmakeargs+=( -DENABLE_CANBERRA=ON )
+	else
+		mycmakeargs+=( -DENABLE_CANBERRA=OFF )
+	fi
+
 	cmake_src_configure
 }
 

--- a/gnome-extra/evolution-data-server/metadata.xml
+++ b/gnome-extra/evolution-data-server/metadata.xml
@@ -10,6 +10,7 @@
     <flag name="gnome-online-accounts">Enable <pkg>net-libs/gnome-online-accounts</pkg> based Google authentication support</flag>
     <flag name="oauth-gtk3">Enable internal OAuth2 authentication for GTK+3 applications (libedataserverui-*.so) support for Google and Outlook.com. If gnome-online-accounts is enabled and used, this is not necessary, but both can be supported at the same time with different setup at runtime</flag>
     <flag name="oauth-gtk4">Enable internal OAuth2 authentication for GTK 4 applications (libedataserverui4-*.so) support for Google and Outlook.com. If gnome-online-accounts is enabled and used, this is not necessary, but both can be supported at the same time with different setup at runtime</flag>
+    <flag name="sound">Sound notification support through <pkg>media-libs/libcanberra-gtk3</pkg> (does nothing without USE=gtk)</flag>
     <flag name="weather">Enable optional weather calendar support</flag>
   </use>
   <upstream>

--- a/mail-client/evolution/evolution-3.52.4-r2.ebuild
+++ b/mail-client/evolution/evolution-3.52.4-r2.ebuild
@@ -14,7 +14,7 @@ SLOT="2.0"
 
 KEYWORDS="~amd64 ~arm ~arm64 ~loong ~ppc64 ~riscv ~x86"
 
-IUSE="archive +bogofilter geolocation gtk-doc highlight ldap selinux spamassassin spell ssl +weather ytnef"
+IUSE="archive +bogofilter geolocation gtk-doc highlight ldap libnotify selinux sound spamassassin spell ssl +weather ytnef"
 
 # glade-3 support is for maintainers only per configure.ac
 # pst is not mature enough and changes API/ABI frequently
@@ -30,17 +30,12 @@ DEPEND="
 	>=dev-libs/libxml2-2.7.3:2
 	>=gnome-base/gnome-desktop-2.91.3:3=
 	>=gnome-base/gsettings-desktop-schemas-2.91.92
-	>=gnome-extra/evolution-data-server-${PV}:=[gtk,weather?]
-	|| (
-		media-libs/libcanberra-gtk3
-		>=media-libs/libcanberra-0.25[gtk3(-)]
-	)
+	>=gnome-extra/evolution-data-server-${PV}:=[gtk,sound?,weather?]
 	>=net-libs/libsoup-3.0:3.0
 	>=net-libs/webkit-gtk-2.38.0:4.1[spell?]
 	>=x11-libs/cairo-1.9.15[glib]
 	>=x11-libs/gdk-pixbuf-2.24:2
 	>=x11-libs/gtk+-3.22:3
-	>=x11-libs/libnotify-0.7
 	>=x11-misc/shared-mime-info-0.22
 
 	app-text/cmark:=
@@ -57,6 +52,13 @@ DEPEND="
 		>=media-libs/clutter-gtk-0.90:1.0
 		>=sci-geosciences/geocode-glib-3.26.3:2 )
 	ldap? ( >=net-nds/openldap-2:= )
+	libnotify? ( >=x11-libs/libnotify-0.7 )
+	sound? (
+		|| (
+			media-libs/libcanberra-gtk3
+			>=media-libs/libcanberra-0.25[gtk3(-)]
+		)
+	)
 	spamassassin? ( mail-filter/spamassassin )
 	spell? ( >=app-text/gspell-1.8:= )
 	ssl? (
@@ -101,6 +103,11 @@ file from /usr/share/applications if you use a different browser)."
 # call; if needed, set them after cmake_src_prepare call, if that works
 
 src_prepare() {
+	# libnotify is automagically detected, but a quick and easy way to
+	# force-disable it is to delete the "yes it's there" variable from
+	# CMakeLists.txt.
+	use libnotify || sed '/HAVE_LIBNOTIFY/d' -i CMakeLists.txt || die
+
 	cmake_src_prepare
 	gnome2_src_prepare
 }
@@ -115,7 +122,7 @@ src_configure() {
 		-DENABLE_SMIME=$(usex ssl)
 		-DENABLE_GNOME_DESKTOP=ON
 		-DWITH_ENCHANT_VERSION=2
-		-DENABLE_CANBERRA=ON
+		-DENABLE_CANBERRA=$(usex sound)
 		-DENABLE_AUTOAR=$(usex archive)
 		-DWITH_HELP=ON
 		-DENABLE_YTNEF=OFF

--- a/mail-client/evolution/metadata.xml
+++ b/mail-client/evolution/metadata.xml
@@ -11,7 +11,9 @@
     <flag name="geolocation">Enable support for displaying contacts on a map inside evolution using <pkg>media-libs/libchamplain</pkg></flag>
     <flag name="highlight">Enable text highlighting plugin</flag>
     <flag name="ldap">Enable support for fetching contacts from an LDAP or Active Directory server using <pkg>net-nds/openldap</pkg></flag>
+    <flag name="libnotify">Enable desktop notifications through <pkg>x11-libs/libnotify</pkg></flag>
     <flag name="spamassassin">Build <pkg>mail-filter/spamassassin</pkg> plugin</flag>
+    <flag name="sound">Enable sound notifications using <pkg>media-libs/libcanberra-gtk3</pkg></flag>
     <flag name="weather">Enable optional weather calendar support</flag>
     <flag name="ytnef">Enable optional TNEF attachments parser support using <pkg>net-mail/ytnef</pkg></flag>
   </use>


### PR DESCRIPTION
Installing mail-client/evolution on a wayland system wants to pull in x11 support for desktop and sound notifications, neither of which I use, and both of which are already optional in the build system of Evolution and EDS. This PR just adds the necessary flags.

There is a chance that some consumer of EDS[gtk] will notice the missing sound support. I grepped through ::gentoo and tried to figure out what EDS does for, say, abiword... but it's not easy. In any case I think it's better to leave the "sound" flag only on EDS rather than propagate it everywhere. I added it to Evolution only because Evolution actually links to it. `USE=sound` is global and enabled in the desktop profile so hopefully anyone who wants sound enabled has it on already.