### PR TITLE
sys-libs/libcxx: fix build on clang macos prefix

### DIFF
--- a/sys-libs/libcxx/files/libcxx-19.1.3-macos-reexports.patch
+++ b/sys-libs/libcxx/files/libcxx-19.1.3-macos-reexports.patch
@@ -1,0 +1,17 @@
+Fix build of standalone libc++ on Gentoo Prefix
+
+Partial revert of https://github.com/llvm/llvm-project/pull/79012
+
+Fixed upstream (in a more involved way) in https://github.com/llvm/llvm-project/pull/110920
+
+--- a/libcxx/src/CMakeLists.txt
++++ b/libcxx/src/CMakeLists.txt
+@@ -234,7 +234,7 @@ if (LIBCXX_ENABLE_SHARED)
+   # into libc++ because in that case there's no dylib to re-export from.
+   if (APPLE AND LIBCXX_CXX_ABI MATCHES "libcxxabi$"
+             AND NOT LIBCXX_STATICALLY_LINK_ABI_IN_SHARED_LIBRARY)
+-    target_link_libraries(cxx_shared PRIVATE cxxabi-reexports)
++    target_link_libraries(cxx_shared PRIVATE $<TARGET_NAME_IF_EXISTS:cxxabi-reexports>)
+ 
+     # TODO: These exports controls should not be tied to whether we re-export libc++abi symbols
+     target_link_libraries(cxx_shared PRIVATE

--- a/sys-libs/libcxx/libcxx-19.1.3.ebuild
+++ b/sys-libs/libcxx/libcxx-19.1.3.ebuild
@@ -40,6 +40,10 @@ BDEPEND="
 	)
 "
 
+PATCHES=(
+	"${FILESDIR}/${P}-macos-reexports.patch"
+)
+
 LLVM_COMPONENTS=( runtimes libcxx{,abi} llvm/{cmake,utils/llvm-lit} cmake )
 llvm.org_set_globals
 


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/758167

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [ ] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [ ] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [ ] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
