### PR TITLE
dev-libs/libsecp256k1: cleanups, new proxied maintainer, disable USE="asm" by default except on amd64

### DIFF
--- a/dev-libs/libsecp256k1/libsecp256k1-0.1_pre20190401.ebuild
+++ b/dev-libs/libsecp256k1/libsecp256k1-0.1_pre20190401.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 inherit autotools
 
@@ -10,6 +10,7 @@ DESCRIPTION="Optimized C library for EC operations on curve secp256k1"
 HOMEPAGE="https://github.com/bitcoin-core/secp256k1"
 COMMITHASH="b19c000063be11018b4d1a6b0a85871ab9d0bdcf"
 SRC_URI="https://github.com/bitcoin-core/${MyPN}/archive/${COMMITHASH}.tar.gz -> ${PN}-v${PV}.tgz"
+S="${WORKDIR}/${MyPN}-${COMMITHASH}"
 
 LICENSE="MIT"
 SLOT="0"
@@ -34,8 +35,6 @@ BDEPEND="
 	java? ( virtual/jdk )
 	virtual/pkgconfig
 "
-
-S="${WORKDIR}/${MyPN}-${COMMITHASH}"
 
 src_prepare() {
 	default

--- a/dev-libs/libsecp256k1/libsecp256k1-0.1_pre20190401.ebuild
+++ b/dev-libs/libsecp256k1/libsecp256k1-0.1_pre20190401.ebuild
@@ -15,7 +15,7 @@ S="${WORKDIR}/${MyPN}-${COMMITHASH}"
 LICENSE="MIT"
 SLOT="0"
 KEYWORDS="amd64 ~arm ~arm64 ~ppc ~ppc64 x86 ~amd64-linux ~x86-linux"
-IUSE="+asm ecdh endomorphism experimental gmp java +recovery test test-openssl"
+IUSE="asm ecdh endomorphism experimental gmp java +recovery test test-openssl"
 RESTRICT="!test? ( test )"
 
 REQUIRED_USE="

--- a/dev-libs/libsecp256k1/libsecp256k1-0.1_pre20201028-r1.ebuild
+++ b/dev-libs/libsecp256k1/libsecp256k1-0.1_pre20201028-r1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 inherit autotools
 
@@ -10,6 +10,7 @@ DESCRIPTION="Optimized C library for EC operations on curve secp256k1"
 HOMEPAGE="https://github.com/bitcoin-core/secp256k1"
 COMMITHASH="3967d96bf184519eb98b766af665b4d4b072563e"
 SRC_URI="https://github.com/bitcoin-core/${MyPN}/archive/${COMMITHASH}.tar.gz -> ${PN}-v${PV}.tgz"
+S="${WORKDIR}/${MyPN}-${COMMITHASH}"
 
 LICENSE="MIT"
 SLOT="0"
@@ -31,8 +32,6 @@ DEPEND="${RDEPEND}
 	test-openssl? ( dev-libs/openssl:0 )
 	valgrind? ( dev-debug/valgrind )
 "
-
-S="${WORKDIR}/${MyPN}-${COMMITHASH}"
 
 src_prepare() {
 	default

--- a/dev-libs/libsecp256k1/libsecp256k1-0.1_pre20201028-r1.ebuild
+++ b/dev-libs/libsecp256k1/libsecp256k1-0.1_pre20201028-r1.ebuild
@@ -15,7 +15,7 @@ S="${WORKDIR}/${MyPN}-${COMMITHASH}"
 LICENSE="MIT"
 SLOT="0"
 KEYWORDS="amd64 ~arm ~arm64 ~ppc ~ppc64 x86 ~amd64-linux ~x86-linux"
-IUSE="+asm ecdh +experimental +extrakeys gmp lowmem +recovery +schnorr test test-openssl valgrind"
+IUSE="asm ecdh +experimental +extrakeys gmp lowmem +recovery +schnorr test test-openssl valgrind"
 RESTRICT="!test? ( test )"
 
 REQUIRED_USE="

--- a/dev-libs/libsecp256k1/libsecp256k1-0.3.0.ebuild
+++ b/dev-libs/libsecp256k1/libsecp256k1-0.3.0.ebuild
@@ -14,7 +14,7 @@ S="${WORKDIR}/${MyPN}-${PV}"
 LICENSE="MIT"
 SLOT="0/2"  # subslot is "$((_LIB_VERSION_CURRENT-_LIB_VERSION_AGE))" from configure.ac
 KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~x86 ~amd64-linux ~x86-linux"
-IUSE="+asm +ecdh experimental +extrakeys lowmem +recovery +schnorr test valgrind"
+IUSE="asm +ecdh experimental +extrakeys lowmem +recovery +schnorr test valgrind"
 RESTRICT="!test? ( test )"
 
 REQUIRED_USE="

--- a/dev-libs/libsecp256k1/libsecp256k1-0.3.0.ebuild
+++ b/dev-libs/libsecp256k1/libsecp256k1-0.3.0.ebuild
@@ -9,6 +9,7 @@ MyPN=secp256k1
 DESCRIPTION="Optimized C library for EC operations on curve secp256k1"
 HOMEPAGE="https://github.com/bitcoin-core/secp256k1"
 SRC_URI="https://github.com/bitcoin-core/secp256k1/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+S="${WORKDIR}/${MyPN}-${PV}"
 
 LICENSE="MIT"
 SLOT="0/2"  # subslot is "$((_LIB_VERSION_CURRENT-_LIB_VERSION_AGE))" from configure.ac
@@ -29,8 +30,6 @@ BDEPEND="
 PATCHES=(
 	"${FILESDIR}/0.3.0-fix-cross-compile.patch"
 )
-
-S="${WORKDIR}/${MyPN}-${PV}"
 
 src_prepare() {
 	default

--- a/dev-libs/libsecp256k1/libsecp256k1-0.3.1.ebuild
+++ b/dev-libs/libsecp256k1/libsecp256k1-0.3.1.ebuild
@@ -14,7 +14,7 @@ S="${WORKDIR}/${MyPN}-${PV}"
 LICENSE="MIT"
 SLOT="0/2"  # subslot is "$((_LIB_VERSION_CURRENT-_LIB_VERSION_AGE))" from configure.ac
 KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~x86 ~amd64-linux ~x86-linux"
-IUSE="+asm +ecdh experimental +extrakeys lowmem +recovery +schnorr test valgrind"
+IUSE="asm +ecdh experimental +extrakeys lowmem +recovery +schnorr test valgrind"
 RESTRICT="!test? ( test )"
 
 REQUIRED_USE="

--- a/dev-libs/libsecp256k1/libsecp256k1-0.3.1.ebuild
+++ b/dev-libs/libsecp256k1/libsecp256k1-0.3.1.ebuild
@@ -9,6 +9,7 @@ MyPN=secp256k1
 DESCRIPTION="Optimized C library for EC operations on curve secp256k1"
 HOMEPAGE="https://github.com/bitcoin-core/secp256k1"
 SRC_URI="https://github.com/bitcoin-core/secp256k1/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+S="${WORKDIR}/${MyPN}-${PV}"
 
 LICENSE="MIT"
 SLOT="0/2"  # subslot is "$((_LIB_VERSION_CURRENT-_LIB_VERSION_AGE))" from configure.ac
@@ -29,8 +30,6 @@ BDEPEND="
 PATCHES=(
 	"${FILESDIR}/0.3.0-fix-cross-compile.patch"
 )
-
-S="${WORKDIR}/${MyPN}-${PV}"
 
 src_prepare() {
 	default

--- a/dev-libs/libsecp256k1/libsecp256k1-0.3.2.ebuild
+++ b/dev-libs/libsecp256k1/libsecp256k1-0.3.2.ebuild
@@ -14,7 +14,7 @@ S="${WORKDIR}/${MyPN}-${PV}"
 LICENSE="MIT"
 SLOT="0/2"  # subslot is "$((_LIB_VERSION_CURRENT-_LIB_VERSION_AGE))" from configure.ac
 KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~x86 ~amd64-linux ~x86-linux"
-IUSE="+asm +ecdh experimental +extrakeys lowmem +recovery +schnorr test valgrind"
+IUSE="asm +ecdh experimental +extrakeys lowmem +recovery +schnorr test valgrind"
 RESTRICT="!test? ( test )"
 
 REQUIRED_USE="

--- a/dev-libs/libsecp256k1/libsecp256k1-0.3.2.ebuild
+++ b/dev-libs/libsecp256k1/libsecp256k1-0.3.2.ebuild
@@ -9,6 +9,7 @@ MyPN=secp256k1
 DESCRIPTION="Optimized C library for EC operations on curve secp256k1"
 HOMEPAGE="https://github.com/bitcoin-core/secp256k1"
 SRC_URI="https://github.com/bitcoin-core/secp256k1/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+S="${WORKDIR}/${MyPN}-${PV}"
 
 LICENSE="MIT"
 SLOT="0/2"  # subslot is "$((_LIB_VERSION_CURRENT-_LIB_VERSION_AGE))" from configure.ac
@@ -29,8 +30,6 @@ BDEPEND="
 PATCHES=(
 	"${FILESDIR}/0.3.0-fix-cross-compile.patch"
 )
-
-S="${WORKDIR}/${MyPN}-${PV}"
 
 src_prepare() {
 	default

--- a/dev-libs/libsecp256k1/libsecp256k1-0.4.0.ebuild
+++ b/dev-libs/libsecp256k1/libsecp256k1-0.4.0.ebuild
@@ -14,7 +14,7 @@ S="${WORKDIR}/${MyPN}-${PV}"
 LICENSE="MIT"
 SLOT="0/2"  # subslot is "$((_LIB_VERSION_CURRENT-_LIB_VERSION_AGE))" from configure.ac
 KEYWORDS="amd64 ~arm arm64 ppc ppc64 x86 ~amd64-linux ~x86-linux"
-IUSE="+asm +ecdh +ellswift experimental +extrakeys lowmem +recovery +schnorr test valgrind"
+IUSE="asm +ecdh +ellswift experimental +extrakeys lowmem +recovery +schnorr test valgrind"
 RESTRICT="!test? ( test )"
 
 REQUIRED_USE="

--- a/dev-libs/libsecp256k1/libsecp256k1-0.4.0.ebuild
+++ b/dev-libs/libsecp256k1/libsecp256k1-0.4.0.ebuild
@@ -9,6 +9,7 @@ MyPN=secp256k1
 DESCRIPTION="Optimized C library for EC operations on curve secp256k1"
 HOMEPAGE="https://github.com/bitcoin-core/secp256k1"
 SRC_URI="https://github.com/bitcoin-core/secp256k1/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+S="${WORKDIR}/${MyPN}-${PV}"
 
 LICENSE="MIT"
 SLOT="0/2"  # subslot is "$((_LIB_VERSION_CURRENT-_LIB_VERSION_AGE))" from configure.ac
@@ -29,8 +30,6 @@ BDEPEND="
 PATCHES=(
 	"${FILESDIR}/0.4.0-fix-cross-compile.patch"
 )
-
-S="${WORKDIR}/${MyPN}-${PV}"
 
 src_prepare() {
 	default

--- a/dev-libs/libsecp256k1/libsecp256k1-0.4.1.ebuild
+++ b/dev-libs/libsecp256k1/libsecp256k1-0.4.1.ebuild
@@ -9,6 +9,7 @@ MyPN=secp256k1
 DESCRIPTION="Optimized C library for EC operations on curve secp256k1"
 HOMEPAGE="https://github.com/bitcoin-core/secp256k1"
 SRC_URI="https://github.com/bitcoin-core/secp256k1/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+S="${WORKDIR}/${MyPN}-${PV}"
 
 LICENSE="MIT"
 SLOT="0/2"  # subslot is "$((_LIB_VERSION_CURRENT-_LIB_VERSION_AGE))" from configure.ac
@@ -29,8 +30,6 @@ BDEPEND="
 PATCHES=(
 	"${FILESDIR}/0.4.0-fix-cross-compile.patch"
 )
-
-S="${WORKDIR}/${MyPN}-${PV}"
 
 src_prepare() {
 	default

--- a/dev-libs/libsecp256k1/libsecp256k1-0.4.1.ebuild
+++ b/dev-libs/libsecp256k1/libsecp256k1-0.4.1.ebuild
@@ -14,7 +14,7 @@ S="${WORKDIR}/${MyPN}-${PV}"
 LICENSE="MIT"
 SLOT="0/2"  # subslot is "$((_LIB_VERSION_CURRENT-_LIB_VERSION_AGE))" from configure.ac
 KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~x86 ~amd64-linux ~x86-linux"
-IUSE="+asm +ecdh +ellswift experimental +extrakeys lowmem +recovery +schnorr test valgrind"
+IUSE="asm +ecdh +ellswift experimental +extrakeys lowmem +recovery +schnorr test valgrind"
 RESTRICT="!test? ( test )"
 
 REQUIRED_USE="

--- a/dev-libs/libsecp256k1/libsecp256k1-0.5.0.ebuild
+++ b/dev-libs/libsecp256k1/libsecp256k1-0.5.0.ebuild
@@ -14,7 +14,7 @@ S="${WORKDIR}/${MyPN}-${PV}"
 LICENSE="MIT"
 SLOT="0/2"  # subslot is "$((_LIB_VERSION_CURRENT-_LIB_VERSION_AGE))" from configure.ac
 KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~x86 ~amd64-linux ~x86-linux"
-IUSE="+asm +ecdh +ellswift experimental +extrakeys lowmem +recovery +schnorr test valgrind"
+IUSE="asm +ecdh +ellswift experimental +extrakeys lowmem +recovery +schnorr test valgrind"
 RESTRICT="!test? ( test )"
 
 REQUIRED_USE="

--- a/dev-libs/libsecp256k1/libsecp256k1-0.5.0.ebuild
+++ b/dev-libs/libsecp256k1/libsecp256k1-0.5.0.ebuild
@@ -6,11 +6,9 @@ EAPI=8
 inherit autotools
 
 MyPN=secp256k1
-
 DESCRIPTION="Optimized C library for EC operations on curve secp256k1"
 HOMEPAGE="https://github.com/bitcoin-core/secp256k1"
 SRC_URI="https://github.com/bitcoin-core/secp256k1/archive/v${PV}.tar.gz -> ${P}.tar.gz"
-
 S="${WORKDIR}/${MyPN}-${PV}"
 
 LICENSE="MIT"

--- a/dev-libs/libsecp256k1/libsecp256k1-0.5.1.ebuild
+++ b/dev-libs/libsecp256k1/libsecp256k1-0.5.1.ebuild
@@ -14,7 +14,7 @@ S="${WORKDIR}/${MyPN}-${PV}"
 LICENSE="MIT"
 SLOT="0/2"  # subslot is "$((_LIB_VERSION_CURRENT-_LIB_VERSION_AGE))" from configure.ac
 KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~x86 ~amd64-linux ~x86-linux"
-IUSE="+asm +ecdh +ellswift experimental +extrakeys lowmem +recovery +schnorr test valgrind"
+IUSE="asm +ecdh +ellswift experimental +extrakeys lowmem +recovery +schnorr test valgrind"
 RESTRICT="!test? ( test )"
 
 REQUIRED_USE="

--- a/dev-libs/libsecp256k1/libsecp256k1-0.6.0.ebuild
+++ b/dev-libs/libsecp256k1/libsecp256k1-0.6.0.ebuild
@@ -14,7 +14,7 @@ S="${WORKDIR}/${MyPN}-${PV}"
 LICENSE="MIT"
 SLOT="0/5"  # subslot is "$((_LIB_VERSION_CURRENT-_LIB_VERSION_AGE))" from configure.ac
 KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~x86 ~amd64-linux ~x86-linux"
-IUSE="+asm +ecdh +ellswift experimental +extrakeys lowmem musig +recovery +schnorr test valgrind"
+IUSE="asm +ecdh +ellswift experimental +extrakeys lowmem musig +recovery +schnorr test valgrind"
 RESTRICT="!test? ( test )"
 
 REQUIRED_USE="

--- a/dev-libs/libsecp256k1/metadata.xml
+++ b/dev-libs/libsecp256k1/metadata.xml
@@ -2,6 +2,10 @@
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
   <maintainer type="person" proxied="yes">
+    <email>gentoo@mattwhitlock.name</email>
+    <name>Matt Whitlock</name>
+  </maintainer>
+  <maintainer type="person" proxied="yes">
     <email>luke-jr+gentoobugs@utopios.org</email>
     <name>Luke Dashjr</name>
   </maintainer>
@@ -22,6 +26,6 @@
     <flag name="test-openssl">Enable OpenSSL comparison tests</flag>
   </use>
   <upstream>
-    <remote-id type="github">bitcoin/secp256k1</remote-id>
+    <remote-id type="github">bitcoin-core/secp256k1</remote-id>
   </upstream>
 </pkgmetadata>

--- a/profiles/arch/amd64/package.use
+++ b/profiles/arch/amd64/package.use
@@ -1,6 +1,11 @@
 # Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Matt Whitlock <gentoo@mattwhitlock.name> (2024-11-06)
+# Assembly optimization is experimental except on amd64, so we leave it
+# disabled by default on all other arches. Bug #941226
+dev-libs/libsecp256k1 asm
+
 # Michał Górny <mgorny@gentoo.org> (2024-09-04)
 # Build with debugging support by default to facilitate dev-debug/dtrace
 # and sys-apps/systemd[bpf].


### PR DESCRIPTION
@thesamesam As requested.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --git-remote whitslack --commits whitslack/master --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
