### PR TITLE
media-gfx/gimp: enable py3.13

### DIFF
--- a/media-gfx/gimp/gimp-3.0.0_rc1.ebuild
+++ b/media-gfx/gimp/gimp-3.0.0_rc1.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 LUA_COMPAT=( luajit )
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..13} )
 VALA_USE_DEPEND=vapigen
 
 inherit lua-single meson python-single-r1 toolchain-funcs vala xdg

--- a/media-gfx/gimp/gimp-9999.ebuild
+++ b/media-gfx/gimp/gimp-9999.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 LUA_COMPAT=( luajit )
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..13} )
 VALA_USE_DEPEND=vapigen
 
 inherit git-r3 lua-single meson python-single-r1 toolchain-funcs vala xdg

--- a/media-libs/gegl/gegl-0.4.50.ebuild
+++ b/media-libs/gegl/gegl-0.4.50.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..13} )
 # vala and introspection support is broken, bug #468208
 VALA_USE_DEPEND=vapigen
 


### PR DESCRIPTION
On @band-a-prend 's request I completed a full review of the gimp-3 ebuild and the only issue I found was py3.13 wasn't enabled so included a quick pr to add. 

Thanks for the work @band-a-prend <3

```
>>> Test phase: media-gfx/gimp-3.0.0_rc1
meson test --print-errorlogs --num-processes 32
ninja: Entering directory `/var/tmp/portage/media-gfx/gimp-3.0.0_rc1/work/gimp-3.0.0_rc1-build'
ninja: no work to do.
 1/20 gimp:app / core                                OK              3.06s0s
 2/20 gimp:app / gimpidtable                         OK              0.13s0s
 3/20 gimp:app / save-and-export                     OK              3.45s0s
 4/20 gimp:app / single-window-mode                  OK              2.39s0s
 5/20 gimp:app / ui                                  OK              4.00s0s
 6/20 gimp:app / xcf                                 OK              2.02s0s
 7/20 gimp:desktop / validate-desktop                OK              0.06s0s
 8/20 gimp:app / app-config                          OK              0.08s0s
 9/20 gimp:libgimp+C / palette                       OK              8.11s0s
10/20 gimp:libgimp+python3 / unit                    OK              8.31s0s
11/20 gimp:libgimp+C / selection-float               OK              8.32s0s
12/20 gimp:libgimp+python3 / color-parser            OK              8.36s0s
13/20 gimp:libgimp+C / color-parser                  OK              8.36s0s
14/20 gimp:libgimp+C / unit                          OK              8.34s0s
15/20 gimp:libgimp+python3 / selection-float         OK              8.36s0s
16/20 gimp:libgimp+python3 / palette                 OK              8.48s0s
17/20 gimp:libgimp+python3 / image                   OK              8.49s0s
18/20 gimp:libgimp+C / image                         OK              8.53s0s
19/20 gimp:libgimp+C / export-options                OK              8.55s0s
20/20 gimp:libgimp+python3 / export-options          OK              8.77s0s

Ok:                 20  
Expected Fail:      0   
Fail:               0   
Unexpected Pass:    0   
Skipped:            0   
Timeout:            0   

Full log written to /var/tmp/portage/media-gfx/gimp-3.0.0_rc1/work/gimp-3.0.0_rc1-build/meson-logs/testlog.txt
>>> Completed testing media-gfx/gimp-3.0.0_rc1
``` 

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
