### PR TITLE
dev-util/bpftool: make CO-RE feature detection more robust

### DIFF
--- a/dev-util/bpftool/bpftool-7.4.0.ebuild
+++ b/dev-util/bpftool/bpftool-7.4.0.ebuild
@@ -97,6 +97,17 @@ src_prepare() {
 	# remove hardcoded/unhelpful flags from bpftool
 	sed -i -e '/CFLAGS += -O2/d' -e 's/-W //g' -e 's/-Wextra //g' src/Makefile || die
 
+	# CO-RE support is an optional feature, but unfortunately the detection of
+	# its support via clang cannot be turned off by disabling the corresponding
+	# feature flag; the test is run unconditionally.
+	# Therefore we use our toolchain's clang when the dependency is satisfied,
+	# else we remove the feature check and explicitly leave CLANG undefined.
+	if has_version -b "sys-devel/clang:${LLVM_SLOT}[llvm_targets_BPF]" ; then
+		export CLANG="$(get_llvm_prefix)/bin/clang"
+	else
+		sed -i -e '/^FEATURE_TESTS :=/s/clang-bpf-co-re//' src/Makefile || die
+	fi
+
 	# Use rst2man or rst2man.py depending on which one exists (#930076)
 	type -P rst2man >/dev/null || sed -i -e 's/rst2man/rst2man.py/g' docs/Makefile || die
 }


### PR DESCRIPTION
Fully qualify the clang command when the CO-RE optfeature can be built. This also requires upstream build surgery to disable the feature detection when clang is not found.

Closes: https://bugs.gentoo.org/943029

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
