### PR TITLE
profiles/package.mask: mask Rails 6.1 for removal

### DIFF
--- a/dev-ruby/i18n/i18n-1.14.1.ebuild
+++ b/dev-ruby/i18n/i18n-1.14.1.ebuild
@@ -17,10 +17,7 @@ LICENSE="MIT"
 SLOT="$(ver_cut 1)"
 KEYWORDS="~alpha amd64 arm arm64 ~hppa ~loong ppc ppc64 ~riscv ~s390 sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x64-solaris"
 
-ruby_add_rdepend "
-	dev-ruby/concurrent-ruby:1
-	>=dev-ruby/racc-1.7:0
-"
+ruby_add_rdepend "dev-ruby/concurrent-ruby:1"
 
 ruby_add_bdepend "
 	test? (
@@ -35,23 +32,29 @@ ruby_add_bdepend "
 all_ruby_prepare() {
 	rm -f gemfiles/*.lock || die
 
-	# Remove optional unpackaged oj gem.
-	# Make mocha dependency more lenient.
-	sed -e '/oj/ s:^:#:' \
-		-e '/mocha/ s/2.1.0/2.1/' \
-		-i gemfiles/* || die
+	# Remove optional unpackaged oj gem
+	sed -i -e '/oj/ s:^:#:' gemfiles/* || die
+
+	# Update old test dependencies
+	sed -i -e '/rake/ s/~>/>=/' -e '/mocha/ s/1.7.0/2.0/' -e '3igem "json"' -e '4igem "racc"' gemfiles/* || die
+
+	# Use mocha 2 to avoid minitest deprecation issues.
+	sed -i -e 's:mocha/setup:mocha/minitest:' test/test_helper.rb || die
 }
 
 each_ruby_test() {
 	case ${RUBY} in
 		*ruby33)
-			versions="7.0 7.1"
+			versions="7.0"
 			;;
 		*ruby32)
-			versions="6.1 7.0 7.1"
+			versions="6.1 7.0"
 			;;
 		*ruby31)
-			versions="6.1 7.0 7.1"
+			versions="6.1 7.0"
+			;;
+		*ruby30)
+			versions="6.0 6.1 7.0"
 			;;
 	esac
 

--- a/dev-ruby/i18n/i18n-1.14.6.ebuild
+++ b/dev-ruby/i18n/i18n-1.14.6.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://github.com/ruby-i18n/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz
 
 LICENSE="MIT"
 SLOT="$(ver_cut 1)"
-KEYWORDS="~alpha amd64 arm arm64 ~hppa ~loong ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x64-solaris"
+KEYWORDS="~alpha amd64 arm arm64 ~hppa ~loong ppc ppc64 ~riscv ~s390 sparc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x64-solaris"
 
 ruby_add_rdepend "
 	dev-ruby/concurrent-ruby:1

--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -33,6 +33,28 @@
 
 #--- END OF EXAMPLES ---
 
+# Hans de Graaff <graaff@gentoo.org> (2026-03-20)
+# Rails 6.1 is no longer supported upstream. Use a newer Rails version
+# instead. Packages depending exclusively on Rails 6.1 will also be
+# removed. Removal on 2025-04-20.
+dev-ruby/rails:6.1
+dev-ruby/actiontext:6.1
+dev-ruby/actionmailbox:6.1
+dev-ruby/activestorage:6.1
+dev-ruby/actionmailer:6.1
+dev-ruby/actioncable:6.1
+dev-ruby/railties:6.1
+dev-ruby/activejob:6.1
+dev-ruby/actionpack:6.1
+dev-ruby/actionview:6.1
+dev-ruby/activerecord:6.1
+dev-ruby/activemodel:6.1
+dev-ruby/activesupport:6.1
+dev-ruby/actionpack-action_caching
+dev-ruby/coffee-rails
+dev-ruby/will_paginate:3
+=www-apps/redmine-5*
+
 # Andreas Sturmlechner <asturm@gentoo.org> (2025-03-23)
 # No revdeps after net-im/psi treecleaning. Depends on Qt5.
 # Removal on 2025-04-22. Bug #951936


### PR DESCRIPTION
Test PR to check CI for any missing Rails 6.1-only packages.