### PR TITLE
dev-util/patchelf: Backport dt-mips-xhash patch

### DIFF
--- a/dev-util/patchelf/files/patchelf-0.17.2-dt-mips-xhash.patch
+++ b/dev-util/patchelf/files/patchelf-0.17.2-dt-mips-xhash.patch
@@ -1,0 +1,14 @@
+--- /dev/null	2024-11-05 18:50:26.176666244 +0000
++++ b/src/elfmips.h	2024-11-10 19:02:29.662347993 +0000
+@@ -0,0 +1,3 @@
++#ifndef DT_MIPS_XHASH
++#define DT_MIPS_XHASH 0x70000036
++#endif
+--- a/src/patchelf.h	2024-11-10 18:59:50.300318823 +0000
++++ b/src/patchelf.h	2024-11-10 19:11:20.597382739 +0000
+@@ -1,3 +1,5 @@
++#include "elfmips.h"
++
+ using FileContents = std::shared_ptr<std::vector<unsigned char>>;
+ 
+ #define ElfFileParams class Elf_Ehdr, class Elf_Phdr, class Elf_Shdr, class Elf_Addr, class Elf_Off, class Elf_Dyn, class Elf_Sym, class Elf_Verneed, class Elf_Versym

--- a/dev-util/patchelf/patchelf-0.17.2-r1.ebuild
+++ b/dev-util/patchelf/patchelf-0.17.2-r1.ebuild
@@ -1,0 +1,26 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools
+
+DESCRIPTION="Small utility to modify the dynamic linker and RPATH of ELF executables"
+HOMEPAGE="https://github.com/NixOS/patchelf"
+SRC_URI="https://github.com/NixOS/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~loong ~m68k ~ppc ~ppc64 ~riscv ~s390 sparc ~x86 ~amd64-linux ~riscv-linux ~x86-linux"
+LICENSE="GPL-3"
+
+PATCHES=("${FILESDIR}"/${PN}-0.17.2-dt-mips-xhash.patch)
+
+src_prepare() {
+	default
+	rm src/elf.h || die
+
+	sed -i \
+		-e 's:-Werror::g' \
+		configure.ac || die
+
+	eautoreconf
+}


### PR DESCRIPTION
As patchelf-0.18.0 is still not working correctly on all arches, this patch will allow 0.17.2 to continue to compile in the meantime.

Created as r1 as it's a small compile and will give a clear marker if this causes any new issues for other users.

Bug: https://bugs.gentoo.org/943026

Tested on both m68k and amd64:

```
============================================================================
Testsuite summary for patchelf 0.17.2
============================================================================
# TOTAL: 48
# PASS:  48
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
```

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
