### PR TITLE
sys-apps/bat: keyword 0.24.0-r2 for ~mips

### DIFF
--- a/dev-libs/libgit2/libgit2-1.8.4.ebuild
+++ b/dev-libs/libgit2/libgit2-1.8.4.ebuild
@@ -16,7 +16,7 @@ S=${WORKDIR}/${P/_/-}
 
 LICENSE="GPL-2-with-linking-exception"
 SLOT="0/$(ver_cut 1-2)"
-KEYWORDS="amd64 arm arm64 ppc ppc64 ~riscv ~s390 sparc x86"
+KEYWORDS="amd64 arm arm64 ~mips ppc ppc64 ~riscv ~s390 sparc x86"
 IUSE="examples gssapi +ssh test +threads trace"
 RESTRICT="!test? ( test )"
 

--- a/sys-apps/bat/bat-0.24.0-r2.ebuild
+++ b/sys-apps/bat/bat-0.24.0-r2.ebuild
@@ -202,7 +202,7 @@ LICENSE+="
 	|| ( CC0-1.0 MIT-0 )
 "
 SLOT="0"
-KEYWORDS="amd64 ~arm arm64 ppc64 ~riscv ~x86"
+KEYWORDS="amd64 ~arm arm64 ~mips ppc64 ~riscv ~x86"
 
 BDEPEND="virtual/pkgconfig"
 DEPEND="


### PR DESCRIPTION
sys-apps/bat: keyword 0.24.0-r2 for ~mips
dev-libs/libgit2: keyword 1.8.4 for ~mips

This should allow `bat` to build on mips. At least it builds on my mips64r2el machine.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
