### PR TITLE
x11-terms/alacritty: Add libxkbcommon[X?,wayland?]

### DIFF
--- a/x11-terms/alacritty/alacritty-0.13.2-r1.ebuild
+++ b/x11-terms/alacritty/alacritty-0.13.2-r1.ebuild
@@ -289,7 +289,7 @@ REQUIRED_USE="|| ( wayland X )"
 COMMON_DEPEND="
 	media-libs/fontconfig:=
 	media-libs/freetype:2
-	x11-libs/libxkbcommon
+	x11-libs/libxkbcommon[X?,wayland?]
 	X? ( x11-libs/libxcb:= )
 "
 

--- a/x11-terms/alacritty/alacritty-0.14.0-r1.ebuild
+++ b/x11-terms/alacritty/alacritty-0.14.0-r1.ebuild
@@ -318,7 +318,7 @@ REQUIRED_USE="|| ( wayland X )"
 COMMON_DEPEND="
 	media-libs/fontconfig:=
 	media-libs/freetype:2
-	x11-libs/libxkbcommon
+	x11-libs/libxkbcommon[X?,wayland?]
 	X? ( x11-libs/libxcb:= )
 "
 

--- a/x11-terms/alacritty/alacritty-9999.ebuild
+++ b/x11-terms/alacritty/alacritty-9999.ebuild
@@ -39,7 +39,7 @@ REQUIRED_USE="|| ( wayland X )"
 COMMON_DEPEND="
 	media-libs/fontconfig:=
 	media-libs/freetype:2
-	x11-libs/libxkbcommon
+	x11-libs/libxkbcommon[X?,wayland?]
 	X? ( x11-libs/libxcb:= )
 "
 


### PR DESCRIPTION
Fix Alacritty not starting due to missing library.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
