### PR TITLE
net-libs/webkit-gtk: fix build against icu-76.1

### DIFF
--- a/net-libs/webkit-gtk/files/2.44.4-fix-icu76.1.patch
+++ b/net-libs/webkit-gtk/files/2.44.4-fix-icu76.1.patch
@@ -1,0 +1,31 @@
+https://bugs.gentoo.org/943213
+https://bugs.webkit.org/show_bug.cgi?id=282120
+https://github.com/WebKit/WebKit/commit/63f7badbada070ebaadd318b2801818ecf7e7ea0
+https://github.com/WebKit/WebKit/pull/35743
+https://unicode-org.atlassian.net/jira/software/c/projects/ICU/issues/ICU-22954
+
+From 63f7badbada070ebaadd318b2801818ecf7e7ea0 Mon Sep 17 00:00:00 2001
+From: Don Olmstead <don.olmstead@sony.com>
+Date: Sat, 26 Oct 2024 08:27:01 -0700
+Subject: [PATCH] Support ICU 76.1 build
+ https://bugs.webkit.org/show_bug.cgi?id=282120
+
+Reviewed by Yusuke Suzuki.
+
+In ICU 76.1 an additional macro `U_SHOW_CPLUSPLUS_HEADER_API` was added to
+control visibility of the C++ API within ICU. Set this value to `0` since WebKit
+wants to only use the C API.
+
+* Source/WTF/wtf/Platform.h:
+
+Canonical link: https://commits.webkit.org/285727@main
+--- a/Source/WTF/wtf/Platform.h
++++ b/Source/WTF/wtf/Platform.h
+@@ -115,6 +115,7 @@
+ /* ICU configuration. Some of these match ICU defaults on some platforms, but we would like them consistently set everywhere we build WebKit. */
+ #define U_HIDE_DEPRECATED_API 1
+ #define U_SHOW_CPLUSPLUS_API 0
++#define U_SHOW_CPLUSPLUS_HEADER_API 0
+ #ifdef __cplusplus
+ #define UCHAR_TYPE char16_t
+ #endif

--- a/net-libs/webkit-gtk/webkit-gtk-2.44.4-r410.ebuild
+++ b/net-libs/webkit-gtk/webkit-gtk-2.44.4-r410.ebuild
@@ -147,6 +147,9 @@ src_prepare() {
 
 	# Fix USE=-jumbo-build on all arches
 	eapply "${FILESDIR}"/2.44.1-non-unified-build-fixes.patch
+
+	# https://bugs.gentoo.org/943213
+	eapply "${FILESDIR}"/2.44.4-fix-icu76.1.patch
 }
 
 src_configure() {

--- a/net-libs/webkit-gtk/webkit-gtk-2.44.4-r600.ebuild
+++ b/net-libs/webkit-gtk/webkit-gtk-2.44.4-r600.ebuild
@@ -158,6 +158,9 @@ src_prepare() {
 
 	# Fix USE=-jumbo-build on all arches
 	eapply "${FILESDIR}"/2.44.1-non-unified-build-fixes.patch
+
+	# https://bugs.gentoo.org/943213
+	eapply "${FILESDIR}"/2.44.4-fix-icu76.1.patch
 }
 
 src_configure() {

--- a/net-libs/webkit-gtk/webkit-gtk-2.44.4.ebuild
+++ b/net-libs/webkit-gtk/webkit-gtk-2.44.4.ebuild
@@ -145,6 +145,9 @@ src_prepare() {
 
 	# Fix USE=-jumbo-build on all arches
 	eapply "${FILESDIR}"/2.44.1-non-unified-build-fixes.patch
+
+	# https://bugs.gentoo.org/943213
+	eapply "${FILESDIR}"/2.44.4-fix-icu76.1.patch
 }
 
 src_configure() {

--- a/net-libs/webkit-gtk/webkit-gtk-2.46.3-r410.ebuild
+++ b/net-libs/webkit-gtk/webkit-gtk-2.46.3-r410.ebuild
@@ -150,6 +150,9 @@ pkg_setup() {
 src_prepare() {
 	cmake_src_prepare
 	gnome2_src_prepare
+
+	# https://bugs.gentoo.org/943213
+	eapply "${FILESDIR}"/2.44.4-fix-icu76.1.patch
 }
 
 src_configure() {

--- a/net-libs/webkit-gtk/webkit-gtk-2.46.3-r600.ebuild
+++ b/net-libs/webkit-gtk/webkit-gtk-2.46.3-r600.ebuild
@@ -161,6 +161,9 @@ pkg_setup() {
 src_prepare() {
 	cmake_src_prepare
 	gnome2_src_prepare
+
+	# https://bugs.gentoo.org/943213
+	eapply "${FILESDIR}"/2.44.4-fix-icu76.1.patch
 }
 
 src_configure() {

--- a/net-libs/webkit-gtk/webkit-gtk-2.46.3.ebuild
+++ b/net-libs/webkit-gtk/webkit-gtk-2.46.3.ebuild
@@ -150,6 +150,9 @@ pkg_setup() {
 src_prepare() {
 	cmake_src_prepare
 	gnome2_src_prepare
+
+	# https://bugs.gentoo.org/943213
+	eapply "${FILESDIR}"/2.44.4-fix-icu76.1.patch
 }
 
 src_configure() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/943213

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
