### PR TITLE
Allow to build cross `*-gnu` environments with LLVM

### DIFF
--- a/dev-debug/gdb/gdb-14.2-r1.ebuild
+++ b/dev-debug/gdb/gdb-14.2-r1.ebuild
@@ -12,8 +12,8 @@ inherit flag-o-matic python-single-r1 strip-linguas toolchain-funcs
 export CTARGET=${CTARGET:-${CHOST}}
 
 if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
+	if [[ ${CATEGORY} == cross*-* ]] ; then
+		export CTARGET=${CATEGORY#cross*-}
 	fi
 fi
 

--- a/dev-debug/gdb/gdb-15.1-r100.ebuild
+++ b/dev-debug/gdb/gdb-15.1-r100.ebuild
@@ -13,8 +13,8 @@ inherit flag-o-matic guile-single python-single-r1 strip-linguas toolchain-funcs
 export CTARGET=${CTARGET:-${CHOST}}
 
 if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
+	if [[ ${CATEGORY} == cross*-* ]] ; then
+		export CTARGET=${CATEGORY#cross*-}
 	fi
 fi
 

--- a/dev-debug/gdb/gdb-15.1.ebuild
+++ b/dev-debug/gdb/gdb-15.1.ebuild
@@ -12,8 +12,8 @@ inherit flag-o-matic python-single-r1 strip-linguas toolchain-funcs
 export CTARGET=${CTARGET:-${CHOST}}
 
 if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
+	if [[ ${CATEGORY} == cross*-* ]] ; then
+		export CTARGET=${CATEGORY#cross*-}
 	fi
 fi
 

--- a/dev-debug/gdb/gdb-15.2-r100.ebuild
+++ b/dev-debug/gdb/gdb-15.2-r100.ebuild
@@ -13,8 +13,8 @@ inherit flag-o-matic guile-single python-single-r1 strip-linguas toolchain-funcs
 export CTARGET=${CTARGET:-${CHOST}}
 
 if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
+	if [[ ${CATEGORY} == cross*-* ]] ; then
+		export CTARGET=${CATEGORY#cross*-}
 	fi
 fi
 

--- a/dev-debug/gdb/gdb-15.2.ebuild
+++ b/dev-debug/gdb/gdb-15.2.ebuild
@@ -12,8 +12,8 @@ inherit flag-o-matic python-single-r1 strip-linguas toolchain-funcs
 export CTARGET=${CTARGET:-${CHOST}}
 
 if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
+	if [[ ${CATEGORY} == cross*-* ]] ; then
+		export CTARGET=${CATEGORY#cross*-}
 	fi
 fi
 

--- a/dev-debug/gdb/gdb-9999.ebuild
+++ b/dev-debug/gdb/gdb-9999.ebuild
@@ -13,8 +13,8 @@ inherit flag-o-matic guile-single python-single-r1 strip-linguas toolchain-funcs
 export CTARGET=${CTARGET:-${CHOST}}
 
 if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
+	if [[ ${CATEGORY} == cross*-* ]] ; then
+		export CTARGET=${CATEGORY#cross*-}
 	fi
 fi
 

--- a/eclass/toolchain.eclass
+++ b/eclass/toolchain.eclass
@@ -52,8 +52,8 @@ FEATURES=${FEATURES/multilib-strict/}
 
 export CTARGET=${CTARGET:-${CHOST}}
 if [[ ${CTARGET} = ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
+	if [[ ${CATEGORY} == cross*-* ]] ; then
+		export CTARGET=${CATEGORY#cross*-}
 	fi
 fi
 : "${TARGET_ABI:=${ABI}}"
@@ -713,7 +713,7 @@ do_gcc_gentoo_patches() {
 		fi
 
 		if [[ -n ${MUSL_VER} || -d "${WORKDIR}"/musl ]] && [[ ${CTARGET} == *musl* ]] ; then
-			if [[ ${CATEGORY} == cross-* ]] ; then
+			if [[ ${CATEGORY} == cross*-* ]] ; then
 				# We don't want to apply some patches when cross-compiling.
 				if [[ -d "${WORKDIR}"/musl/nocross ]] ; then
 					rm -fv "${WORKDIR}"/musl/nocross/*.patch || die

--- a/sys-devel/binutils-apple/binutils-apple-3.2.6-r1.ebuild
+++ b/sys-devel/binutils-apple/binutils-apple-3.2.6-r1.ebuild
@@ -130,8 +130,8 @@ src_prepare() {
 src_configure() {
 	export CTARGET=${CTARGET:-${CHOST}}
 	if [[ ${CTARGET} == ${CHOST} ]] ; then
-		if [[ ${CATEGORY} == cross-* ]] ; then
-			export CTARGET=${CATEGORY#cross-}
+		if [[ ${CATEGORY} == cross*-* ]] ; then
+			export CTARGET=${CATEGORY#cross*-}
 		fi
 	fi
 

--- a/sys-devel/binutils-apple/binutils-apple-8.2.1-r103.ebuild
+++ b/sys-devel/binutils-apple/binutils-apple-8.2.1-r103.ebuild
@@ -38,8 +38,8 @@ src_prepare() {
 src_configure() {
 	CTARGET=${CTARGET:-${CHOST}}
 	if [[ ${CTARGET} == ${CHOST} ]] ; then
-		if [[ ${CATEGORY} == cross-* ]] ; then
-			export CTARGET=${CATEGORY#cross-}
+		if [[ ${CATEGORY} == cross*-* ]] ; then
+			export CTARGET=${CATEGORY#cross*-}
 		fi
 	fi
 

--- a/sys-devel/binutils-apple/binutils-apple-8.2.1-r2.ebuild
+++ b/sys-devel/binutils-apple/binutils-apple-8.2.1-r2.ebuild
@@ -181,8 +181,8 @@ src_configure() {
 
 	export CTARGET=${CTARGET:-${CHOST}}
 	if [[ ${CTARGET} == ${CHOST} ]] ; then
-		if [[ ${CATEGORY} == cross-* ]] ; then
-			export CTARGET=${CATEGORY#cross-}
+		if [[ ${CATEGORY} == cross*-* ]] ; then
+			export CTARGET=${CATEGORY#cross*-}
 		fi
 	fi
 

--- a/sys-devel/binutils-hppa64/binutils-hppa64-2.37_p1-r2.ebuild
+++ b/sys-devel/binutils-hppa64/binutils-hppa64-2.37_p1-r2.ebuild
@@ -42,8 +42,8 @@ fi
 #
 export CTARGET=${CTARGET:-${CHOST}}
 if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
+	if [[ ${CATEGORY} == cross*-* ]] ; then
+		export CTARGET=${CATEGORY#cross*-}
 	fi
 fi
 is_cross() { [[ ${CHOST} != ${CTARGET} ]] ; }

--- a/sys-devel/binutils-hppa64/binutils-hppa64-2.38-r2.ebuild
+++ b/sys-devel/binutils-hppa64/binutils-hppa64-2.38-r2.ebuild
@@ -43,8 +43,8 @@ fi
 #
 export CTARGET=${CTARGET:-${CHOST}}
 if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
+	if [[ ${CATEGORY} == cross*-* ]] ; then
+		export CTARGET=${CATEGORY#cross*-}
 	fi
 fi
 is_cross() { [[ ${CHOST} != ${CTARGET} ]] ; }

--- a/sys-devel/binutils-hppa64/binutils-hppa64-2.39-r5.ebuild
+++ b/sys-devel/binutils-hppa64/binutils-hppa64-2.39-r5.ebuild
@@ -43,8 +43,8 @@ fi
 #
 export CTARGET=${CTARGET:-${CHOST}}
 if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
+	if [[ ${CATEGORY} == cross*-* ]] ; then
+		export CTARGET=${CATEGORY#cross*-}
 	fi
 fi
 is_cross() { [[ ${CHOST} != ${CTARGET} ]] ; }

--- a/sys-devel/binutils-hppa64/binutils-hppa64-2.40-r7.ebuild
+++ b/sys-devel/binutils-hppa64/binutils-hppa64-2.40-r7.ebuild
@@ -43,8 +43,8 @@ fi
 #
 export CTARGET=${CTARGET:-${CHOST}}
 if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
+	if [[ ${CATEGORY} == cross*-* ]] ; then
+		export CTARGET=${CATEGORY#cross*-}
 	fi
 fi
 is_cross() { [[ ${CHOST} != ${CTARGET} ]] ; }

--- a/sys-devel/binutils-hppa64/binutils-hppa64-2.41-r5.ebuild
+++ b/sys-devel/binutils-hppa64/binutils-hppa64-2.41-r5.ebuild
@@ -43,8 +43,8 @@ fi
 #
 export CTARGET=${CTARGET:-${CHOST}}
 if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
+	if [[ ${CATEGORY} == cross*-* ]] ; then
+		export CTARGET=${CATEGORY#cross*-}
 	fi
 fi
 is_cross() { [[ ${CHOST} != ${CTARGET} ]] ; }

--- a/sys-devel/binutils-hppa64/binutils-hppa64-2.42-r2.ebuild
+++ b/sys-devel/binutils-hppa64/binutils-hppa64-2.42-r2.ebuild
@@ -42,8 +42,8 @@ fi
 #
 export CTARGET=${CTARGET:-${CHOST}}
 if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
+	if [[ ${CATEGORY} == cross*-* ]] ; then
+		export CTARGET=${CATEGORY#cross*-}
 	fi
 fi
 is_cross() { [[ ${CHOST} != ${CTARGET} ]] ; }

--- a/sys-devel/binutils-hppa64/binutils-hppa64-2.43-r1.ebuild
+++ b/sys-devel/binutils-hppa64/binutils-hppa64-2.43-r1.ebuild
@@ -42,8 +42,8 @@ fi
 #
 export CTARGET=${CTARGET:-${CHOST}}
 if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
+	if [[ ${CATEGORY} == cross*-* ]] ; then
+		export CTARGET=${CATEGORY#cross*-}
 	fi
 fi
 is_cross() { [[ ${CHOST} != ${CTARGET} ]] ; }

--- a/sys-devel/binutils/binutils-2.32-r2.ebuild
+++ b/sys-devel/binutils/binutils-2.32-r2.ebuild
@@ -59,8 +59,8 @@ PATCHES=(
 #
 export CTARGET=${CTARGET:-${CHOST}}
 if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
+	if [[ ${CATEGORY} == cross*-* ]] ; then
+		export CTARGET=${CATEGORY#cross*-}
 	fi
 fi
 is_cross() { [[ ${CHOST} != ${CTARGET} ]] ; }

--- a/sys-devel/binutils/binutils-2.33.1-r1.ebuild
+++ b/sys-devel/binutils/binutils-2.33.1-r1.ebuild
@@ -51,8 +51,8 @@ PATCH_DEV=${PATCH_DEV:-slyfox}
 #
 export CTARGET=${CTARGET:-${CHOST}}
 if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
+	if [[ ${CATEGORY} == cross*-* ]] ; then
+		export CTARGET=${CATEGORY#cross*-}
 	fi
 fi
 is_cross() { [[ ${CHOST} != ${CTARGET} ]] ; }

--- a/sys-devel/binutils/binutils-2.34-r2.ebuild
+++ b/sys-devel/binutils/binutils-2.34-r2.ebuild
@@ -51,8 +51,8 @@ PATCH_DEV=${PATCH_DEV:-slyfox}
 #
 export CTARGET=${CTARGET:-${CHOST}}
 if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
+	if [[ ${CATEGORY} == cross*-* ]] ; then
+		export CTARGET=${CATEGORY#cross*-}
 	fi
 fi
 is_cross() { [[ ${CHOST} != ${CTARGET} ]] ; }

--- a/sys-devel/binutils/binutils-2.35.2.ebuild
+++ b/sys-devel/binutils/binutils-2.35.2.ebuild
@@ -40,8 +40,8 @@ fi
 #
 export CTARGET=${CTARGET:-${CHOST}}
 if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
+	if [[ ${CATEGORY} == cross*-* ]] ; then
+		export CTARGET=${CATEGORY#cross*-}
 	fi
 fi
 is_cross() { [[ ${CHOST} != ${CTARGET} ]] ; }

--- a/sys-devel/binutils/binutils-2.36.1-r2.ebuild
+++ b/sys-devel/binutils/binutils-2.36.1-r2.ebuild
@@ -40,8 +40,8 @@ fi
 #
 export CTARGET=${CTARGET:-${CHOST}}
 if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
+	if [[ ${CATEGORY} == cross*-* ]] ; then
+		export CTARGET=${CATEGORY#cross*-}
 	fi
 fi
 is_cross() { [[ ${CHOST} != ${CTARGET} ]] ; }

--- a/sys-devel/binutils/binutils-2.37_p1-r2.ebuild
+++ b/sys-devel/binutils/binutils-2.37_p1-r2.ebuild
@@ -40,8 +40,8 @@ fi
 #
 export CTARGET=${CTARGET:-${CHOST}}
 if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
+	if [[ ${CATEGORY} == cross*-* ]] ; then
+		export CTARGET=${CATEGORY#cross*-}
 	fi
 fi
 is_cross() { [[ ${CHOST} != ${CTARGET} ]] ; }

--- a/sys-devel/binutils/binutils-2.38-r2.ebuild
+++ b/sys-devel/binutils/binutils-2.38-r2.ebuild
@@ -40,8 +40,8 @@ fi
 #
 export CTARGET=${CTARGET:-${CHOST}}
 if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
+	if [[ ${CATEGORY} == cross*-* ]] ; then
+		export CTARGET=${CATEGORY#cross*-}
 	fi
 fi
 is_cross() { [[ ${CHOST} != ${CTARGET} ]] ; }

--- a/sys-devel/binutils/binutils-2.39-r5.ebuild
+++ b/sys-devel/binutils/binutils-2.39-r5.ebuild
@@ -41,8 +41,8 @@ fi
 #
 export CTARGET=${CTARGET:-${CHOST}}
 if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
+	if [[ ${CATEGORY} == cross*-* ]] ; then
+		export CTARGET=${CATEGORY#cross*-}
 	fi
 fi
 is_cross() { [[ ${CHOST} != ${CTARGET} ]] ; }

--- a/sys-devel/binutils/binutils-2.40-r9.ebuild
+++ b/sys-devel/binutils/binutils-2.40-r9.ebuild
@@ -40,8 +40,8 @@ fi
 #
 export CTARGET=${CTARGET:-${CHOST}}
 if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
+	if [[ ${CATEGORY} == cross*-* ]] ; then
+		export CTARGET=${CATEGORY#cross*-}
 	fi
 fi
 is_cross() { [[ ${CHOST} != ${CTARGET} ]] ; }

--- a/sys-devel/binutils/binutils-2.41-r5.ebuild
+++ b/sys-devel/binutils/binutils-2.41-r5.ebuild
@@ -40,8 +40,8 @@ fi
 #
 export CTARGET=${CTARGET:-${CHOST}}
 if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
+	if [[ ${CATEGORY} == cross*-* ]] ; then
+		export CTARGET=${CATEGORY#cross*-}
 	fi
 fi
 is_cross() { [[ ${CHOST} != ${CTARGET} ]] ; }

--- a/sys-devel/binutils/binutils-2.42-r2.ebuild
+++ b/sys-devel/binutils/binutils-2.42-r2.ebuild
@@ -40,8 +40,8 @@ fi
 #
 export CTARGET=${CTARGET:-${CHOST}}
 if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
+	if [[ ${CATEGORY} == cross*-* ]] ; then
+		export CTARGET=${CATEGORY#cross*-}
 	fi
 fi
 is_cross() { [[ ${CHOST} != ${CTARGET} ]] ; }

--- a/sys-devel/binutils/binutils-2.43-r1.ebuild
+++ b/sys-devel/binutils/binutils-2.43-r1.ebuild
@@ -43,8 +43,8 @@ fi
 #
 export CTARGET=${CTARGET:-${CHOST}}
 if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
+	if [[ ${CATEGORY} == cross*-* ]] ; then
+		export CTARGET=${CATEGORY#cross*-}
 	fi
 fi
 is_cross() { [[ ${CHOST} != ${CTARGET} ]] ; }

--- a/sys-devel/binutils/binutils-2.43-r2.ebuild
+++ b/sys-devel/binutils/binutils-2.43-r2.ebuild
@@ -43,8 +43,8 @@ fi
 #
 export CTARGET=${CTARGET:-${CHOST}}
 if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
+	if [[ ${CATEGORY} == cross*-* ]] ; then
+		export CTARGET=${CATEGORY#cross*-}
 	fi
 fi
 is_cross() { [[ ${CHOST} != ${CTARGET} ]] ; }

--- a/sys-devel/binutils/binutils-2.43.9999.ebuild
+++ b/sys-devel/binutils/binutils-2.43.9999.ebuild
@@ -43,8 +43,8 @@ fi
 #
 export CTARGET=${CTARGET:-${CHOST}}
 if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
+	if [[ ${CATEGORY} == cross*-* ]] ; then
+		export CTARGET=${CATEGORY#cross*-}
 	fi
 fi
 is_cross() { [[ ${CHOST} != ${CTARGET} ]] ; }

--- a/sys-devel/binutils/binutils-9999.ebuild
+++ b/sys-devel/binutils/binutils-9999.ebuild
@@ -43,8 +43,8 @@ fi
 #
 export CTARGET=${CTARGET:-${CHOST}}
 if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
+	if [[ ${CATEGORY} == cross*-* ]] ; then
+		export CTARGET=${CATEGORY#cross*-}
 	fi
 fi
 is_cross() { [[ ${CHOST} != ${CTARGET} ]] ; }

--- a/sys-devel/gcc-apple/gcc-apple-4.2.1_p5666-r3.ebuild
+++ b/sys-devel/gcc-apple/gcc-apple-4.2.1_p5666-r3.ebuild
@@ -44,8 +44,8 @@ export TPREFIX=${TPREFIX:-${EPREFIX}}
 
 export CTARGET=${CTARGET:-${CHOST}}
 if [[ ${CTARGET} = ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
+	if [[ ${CATEGORY} == cross*-* ]] ; then
+		export CTARGET=${CATEGORY#cross*-}
 	fi
 fi
 

--- a/sys-devel/gcc/gcc-11.5.0.ebuild
+++ b/sys-devel/gcc/gcc-11.5.0.ebuild
@@ -43,7 +43,7 @@ elif [[ -z ${TOOLCHAIN_USE_GIT_PATCHES} ]] ; then
 	:;
 fi
 
-if [[ ${CATEGORY} != cross-* ]] ; then
+if [[ ${CATEGORY} != cross*-* ]] ; then
 	# Technically only if USE=hardened *too* right now, but no point in complicating it further.
 	# If GCC is enabling CET by default, we need glibc to be built with support for it.
 	# bug #830454

--- a/sys-devel/gcc/gcc-12.4.0.ebuild
+++ b/sys-devel/gcc/gcc-12.4.0.ebuild
@@ -43,7 +43,7 @@ elif [[ -z ${TOOLCHAIN_USE_GIT_PATCHES} ]] ; then
 	:;
 fi
 
-if [[ ${CATEGORY} != cross-* ]] ; then
+if [[ ${CATEGORY} != cross*-* ]] ; then
 	# Technically only if USE=hardened *too* right now, but no point in complicating it further.
 	# If GCC is enabling CET by default, we need glibc to be built with support for it.
 	# bug #830454

--- a/sys-devel/gcc/gcc-12.4.1_p20241031.ebuild
+++ b/sys-devel/gcc/gcc-12.4.1_p20241031.ebuild
@@ -43,7 +43,7 @@ elif [[ -z ${TOOLCHAIN_USE_GIT_PATCHES} ]] ; then
 	:;
 fi
 
-if [[ ${CATEGORY} != cross-* ]] ; then
+if [[ ${CATEGORY} != cross*-* ]] ; then
 	# Technically only if USE=hardened *too* right now, but no point in complicating it further.
 	# If GCC is enabling CET by default, we need glibc to be built with support for it.
 	# bug #830454

--- a/sys-devel/gcc/gcc-12.5.9999.ebuild
+++ b/sys-devel/gcc/gcc-12.5.9999.ebuild
@@ -40,7 +40,7 @@ elif [[ -z ${TOOLCHAIN_USE_GIT_PATCHES} ]] ; then
 	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
 fi
 
-if [[ ${CATEGORY} != cross-* ]] ; then
+if [[ ${CATEGORY} != cross*-* ]] ; then
 	# Technically only if USE=hardened *too* right now, but no point in complicating it further.
 	# If GCC is enabling CET by default, we need glibc to be built with support for it.
 	# bug #830454

--- a/sys-devel/gcc/gcc-13.2.0.ebuild
+++ b/sys-devel/gcc/gcc-13.2.0.ebuild
@@ -43,7 +43,7 @@ elif [[ -z ${TOOLCHAIN_USE_GIT_PATCHES} ]] ; then
 	:;
 fi
 
-if [[ ${CATEGORY} != cross-* ]] ; then
+if [[ ${CATEGORY} != cross*-* ]] ; then
 	# Technically only if USE=hardened *too* right now, but no point in complicating it further.
 	# If GCC is enabling CET by default, we need glibc to be built with support for it.
 	# bug #830454

--- a/sys-devel/gcc/gcc-13.3.1_p20240614.ebuild
+++ b/sys-devel/gcc/gcc-13.3.1_p20240614.ebuild
@@ -43,7 +43,7 @@ elif [[ -z ${TOOLCHAIN_USE_GIT_PATCHES} ]] ; then
 	:;
 fi
 
-if [[ ${CATEGORY} != cross-* ]] ; then
+if [[ ${CATEGORY} != cross*-* ]] ; then
 	# Technically only if USE=hardened *too* right now, but no point in complicating it further.
 	# If GCC is enabling CET by default, we need glibc to be built with support for it.
 	# bug #830454

--- a/sys-devel/gcc/gcc-13.3.1_p20241025.ebuild
+++ b/sys-devel/gcc/gcc-13.3.1_p20241025.ebuild
@@ -43,7 +43,7 @@ elif [[ -z ${TOOLCHAIN_USE_GIT_PATCHES} ]] ; then
 	:;
 fi
 
-if [[ ${CATEGORY} != cross-* ]] ; then
+if [[ ${CATEGORY} != cross*-* ]] ; then
 	# Technically only if USE=hardened *too* right now, but no point in complicating it further.
 	# If GCC is enabling CET by default, we need glibc to be built with support for it.
 	# bug #830454

--- a/sys-devel/gcc/gcc-13.3.1_p20241101.ebuild
+++ b/sys-devel/gcc/gcc-13.3.1_p20241101.ebuild
@@ -43,7 +43,7 @@ elif [[ -z ${TOOLCHAIN_USE_GIT_PATCHES} ]] ; then
 	:;
 fi
 
-if [[ ${CATEGORY} != cross-* ]] ; then
+if [[ ${CATEGORY} != cross*-* ]] ; then
 	# Technically only if USE=hardened *too* right now, but no point in complicating it further.
 	# If GCC is enabling CET by default, we need glibc to be built with support for it.
 	# bug #830454

--- a/sys-devel/gcc/gcc-13.4.9999.ebuild
+++ b/sys-devel/gcc/gcc-13.4.9999.ebuild
@@ -42,7 +42,7 @@ elif [[ -z ${TOOLCHAIN_USE_GIT_PATCHES} ]] ; then
 	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
 fi
 
-if [[ ${CATEGORY} != cross-* ]] ; then
+if [[ ${CATEGORY} != cross*-* ]] ; then
 	# Technically only if USE=hardened *too* right now, but no point in complicating it further.
 	# If GCC is enabling CET by default, we need glibc to be built with support for it.
 	# bug #830454

--- a/sys-devel/gcc/gcc-14.2.1_p20241026.ebuild
+++ b/sys-devel/gcc/gcc-14.2.1_p20241026.ebuild
@@ -31,7 +31,7 @@ elif [[ -z ${TOOLCHAIN_USE_GIT_PATCHES} ]] ; then
 	:;
 fi
 
-if [[ ${CATEGORY} != cross-* ]] ; then
+if [[ ${CATEGORY} != cross*-* ]] ; then
 	# Technically only if USE=hardened *too* right now, but no point in complicating it further.
 	# If GCC is enabling CET by default, we need glibc to be built with support for it.
 	# bug #830454

--- a/sys-devel/gcc/gcc-14.3.9999.ebuild
+++ b/sys-devel/gcc/gcc-14.3.9999.ebuild
@@ -29,7 +29,7 @@ elif [[ -z ${TOOLCHAIN_USE_GIT_PATCHES} ]] ; then
 	:;
 fi
 
-if [[ ${CATEGORY} != cross-* ]] ; then
+if [[ ${CATEGORY} != cross*-* ]] ; then
 	# Technically only if USE=hardened *too* right now, but no point in complicating it further.
 	# If GCC is enabling CET by default, we need glibc to be built with support for it.
 	# bug #830454

--- a/sys-devel/gcc/gcc-15.0.0_pre20241027.ebuild
+++ b/sys-devel/gcc/gcc-15.0.0_pre20241027.ebuild
@@ -31,7 +31,7 @@ elif [[ -z ${TOOLCHAIN_USE_GIT_PATCHES} ]] ; then
 	:;
 fi
 
-if [[ ${CATEGORY} != cross-* ]] ; then
+if [[ ${CATEGORY} != cross*-* ]] ; then
 	# Technically only if USE=hardened *too* right now, but no point in complicating it further.
 	# If GCC is enabling CET by default, we need glibc to be built with support for it.
 	# bug #830454

--- a/sys-devel/gcc/gcc-15.0.9999.ebuild
+++ b/sys-devel/gcc/gcc-15.0.9999.ebuild
@@ -29,7 +29,7 @@ elif [[ -z ${TOOLCHAIN_USE_GIT_PATCHES} ]] ; then
 	:;
 fi
 
-if [[ ${CATEGORY} != cross-* ]] ; then
+if [[ ${CATEGORY} != cross*-* ]] ; then
 	# Technically only if USE=hardened *too* right now, but no point in complicating it further.
 	# If GCC is enabling CET by default, we need glibc to be built with support for it.
 	# bug #830454

--- a/sys-devel/gcc/gcc-8.5.0-r2.ebuild
+++ b/sys-devel/gcc/gcc-8.5.0-r2.ebuild
@@ -18,6 +18,6 @@ DEPEND="${RDEPEND}
 	elibc_glibc? ( >=sys-libs/glibc-2.13 )
 	>=${CATEGORY}/binutils-2.20"
 
-if [[ ${CATEGORY} != cross-* ]] ; then
+if [[ ${CATEGORY} != cross*-* ]] ; then
 	PDEPEND="${PDEPEND} elibc_glibc? ( >=sys-libs/glibc-2.13 )"
 fi

--- a/sys-devel/nvptx-tools/nvptx-tools-0_pre20230122.ebuild
+++ b/sys-devel/nvptx-tools/nvptx-tools-0_pre20230122.ebuild
@@ -25,8 +25,8 @@ RESTRICT="!test? ( test )"
 export CBUILD=${CBUILD:-${CHOST}}
 export CTARGET=${CTARGET:-${CHOST}}
 if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
+	if [[ ${CATEGORY} == cross*-* ]] ; then
+		export CTARGET=${CATEGORY#cross*-}
 	fi
 fi
 

--- a/sys-devel/nvptx-tools/nvptx-tools-9999.ebuild
+++ b/sys-devel/nvptx-tools/nvptx-tools-9999.ebuild
@@ -25,8 +25,8 @@ RESTRICT="!test? ( test )"
 export CBUILD=${CBUILD:-${CHOST}}
 export CTARGET=${CTARGET:-${CHOST}}
 if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
+	if [[ ${CATEGORY} == cross*-* ]] ; then
+		export CTARGET=${CATEGORY#cross*-}
 	fi
 fi
 

--- a/sys-devel/rust-std/rust-std-1.71.1.ebuild
+++ b/sys-devel/rust-std/rust-std-1.71.1.ebuild
@@ -43,8 +43,8 @@ S="${WORKDIR}/${P/-std/c}-src"
 #
 export CTARGET=${CTARGET:-${CHOST}}
 if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
+	if [[ ${CATEGORY} == cross*-* ]] ; then
+		export CTARGET=${CATEGORY#cross*-}
 	fi
 fi
 

--- a/sys-devel/rust-std/rust-std-1.74.1.ebuild
+++ b/sys-devel/rust-std/rust-std-1.74.1.ebuild
@@ -43,8 +43,8 @@ S="${WORKDIR}/${P/-std/c}-src"
 #
 export CTARGET=${CTARGET:-${CHOST}}
 if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
+	if [[ ${CATEGORY} == cross*-* ]] ; then
+		export CTARGET=${CATEGORY#cross*-}
 	fi
 fi
 

--- a/sys-devel/rust-std/rust-std-1.75.0.ebuild
+++ b/sys-devel/rust-std/rust-std-1.75.0.ebuild
@@ -47,8 +47,8 @@ S="${WORKDIR}/${P/-std/c}-src"
 #
 export CTARGET=${CTARGET:-${CHOST}}
 if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
+	if [[ ${CATEGORY} == cross*-* ]] ; then
+		export CTARGET=${CATEGORY#cross*-}
 	fi
 fi
 

--- a/sys-devel/rust-std/rust-std-1.77.1.ebuild
+++ b/sys-devel/rust-std/rust-std-1.77.1.ebuild
@@ -43,8 +43,8 @@ S="${WORKDIR}/${P/-std/c}-src"
 #
 export CTARGET=${CTARGET:-${CHOST}}
 if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
+	if [[ ${CATEGORY} == cross*-* ]] ; then
+		export CTARGET=${CATEGORY#cross*-}
 	fi
 fi
 

--- a/sys-devel/rust-std/rust-std-1.79.0.ebuild
+++ b/sys-devel/rust-std/rust-std-1.79.0.ebuild
@@ -43,8 +43,8 @@ S="${WORKDIR}/${P/-std/c}-src"
 #
 export CTARGET=${CTARGET:-${CHOST}}
 if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
+	if [[ ${CATEGORY} == cross*-* ]] ; then
+		export CTARGET=${CATEGORY#cross*-}
 	fi
 fi
 

--- a/sys-devel/rust-std/rust-std-1.80.1.ebuild
+++ b/sys-devel/rust-std/rust-std-1.80.1.ebuild
@@ -42,8 +42,8 @@ QA_FLAGS_IGNORED="usr/lib/rust/${PV}/rustlib/.*/lib/lib.*.so"
 #
 export CTARGET=${CTARGET:-${CHOST}}
 if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
+	if [[ ${CATEGORY} == cross*-* ]] ; then
+		export CTARGET=${CATEGORY#cross*-}
 	fi
 fi
 

--- a/sys-devel/rust-std/rust-std-1.81.0.ebuild
+++ b/sys-devel/rust-std/rust-std-1.81.0.ebuild
@@ -42,8 +42,8 @@ QA_FLAGS_IGNORED="usr/lib/rust/${PV}/rustlib/.*/lib/lib.*.so"
 #
 export CTARGET=${CTARGET:-${CHOST}}
 if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
+	if [[ ${CATEGORY} == cross*-* ]] ; then
+		export CTARGET=${CATEGORY#cross*-}
 	fi
 fi
 

--- a/sys-devel/rust-std/rust-std-1.82.0.ebuild
+++ b/sys-devel/rust-std/rust-std-1.82.0.ebuild
@@ -42,8 +42,8 @@ QA_FLAGS_IGNORED="usr/lib/rust/${PV}/rustlib/.*/lib/lib.*.so"
 #
 export CTARGET=${CTARGET:-${CHOST}}
 if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
+	if [[ ${CATEGORY} == cross*-* ]] ; then
+		export CTARGET=${CATEGORY#cross*-}
 	fi
 fi
 

--- a/sys-libs/glibc/glibc-2.19-r3.ebuild
+++ b/sys-libs/glibc/glibc-2.19-r3.ebuild
@@ -61,8 +61,8 @@ MIN_KERN_VER="2.6.16"
 export CBUILD=${CBUILD:-${CHOST}}
 export CTARGET=${CTARGET:-${CHOST}}
 if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
+	if [[ ${CATEGORY} == cross*-* ]] ; then
+		export CTARGET=${CATEGORY#cross*-}
 	fi
 fi
 
@@ -107,7 +107,7 @@ RDEPEND="${COMMON_DEPEND}
 	sys-apps/gentoo-functions
 "
 
-if [[ ${CATEGORY} == cross-* ]] ; then
+if [[ ${CATEGORY} == cross*-* ]] ; then
 	DEPEND+=" !headers-only? (
 		>=${CATEGORY}/binutils-2.24
 		>=${CATEGORY}/gcc-4.9

--- a/sys-libs/glibc/glibc-2.31-r7.ebuild
+++ b/sys-libs/glibc/glibc-2.31-r7.ebuild
@@ -59,8 +59,8 @@ MIN_KERN_VER="3.2.0"
 export CBUILD=${CBUILD:-${CHOST}}
 export CTARGET=${CTARGET:-${CHOST}}
 if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
+	if [[ ${CATEGORY} == cross*-* ]] ; then
+		export CTARGET=${CATEGORY#cross*-}
 	fi
 fi
 
@@ -115,7 +115,7 @@ RDEPEND="${COMMON_DEPEND}
 
 RESTRICT="!test? ( test )"
 
-if [[ ${CATEGORY} == cross-* ]] ; then
+if [[ ${CATEGORY} == cross*-* ]] ; then
 	BDEPEND+=" !headers-only? (
 		>=${CATEGORY}/binutils-2.24
 		>=${CATEGORY}/gcc-6

--- a/sys-libs/glibc/glibc-2.32-r8.ebuild
+++ b/sys-libs/glibc/glibc-2.32-r8.ebuild
@@ -60,8 +60,8 @@ MIN_KERN_VER="3.2.0"
 export CBUILD=${CBUILD:-${CHOST}}
 export CTARGET=${CTARGET:-${CHOST}}
 if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
+	if [[ ${CATEGORY} == cross*-* ]] ; then
+		export CTARGET=${CATEGORY#cross*-}
 	fi
 fi
 
@@ -132,7 +132,7 @@ RDEPEND="${COMMON_DEPEND}
 
 RESTRICT="!test? ( test )"
 
-if [[ ${CATEGORY} == cross-* ]] ; then
+if [[ ${CATEGORY} == cross*-* ]] ; then
 	BDEPEND+=" !headers-only? (
 		>=${CATEGORY}/binutils-2.24
 		>=${CATEGORY}/gcc-6

--- a/sys-libs/glibc/glibc-2.33-r14.ebuild
+++ b/sys-libs/glibc/glibc-2.33-r14.ebuild
@@ -65,8 +65,8 @@ MIN_KERN_VER="3.2.0"
 export CBUILD=${CBUILD:-${CHOST}}
 export CTARGET=${CTARGET:-${CHOST}}
 if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
+	if [[ ${CATEGORY} == cross*-* ]] ; then
+		export CTARGET=${CATEGORY#cross*-}
 	fi
 fi
 
@@ -138,7 +138,7 @@ RDEPEND="${COMMON_DEPEND}
 
 RESTRICT="!test? ( test )"
 
-if [[ ${CATEGORY} == cross-* ]] ; then
+if [[ ${CATEGORY} == cross*-* ]] ; then
 	BDEPEND+=" !headers-only? (
 		>=${CATEGORY}/binutils-2.27
 		>=${CATEGORY}/gcc-6

--- a/sys-libs/glibc/glibc-2.34-r14.ebuild
+++ b/sys-libs/glibc/glibc-2.34-r14.ebuild
@@ -68,8 +68,8 @@ MIN_PAX_UTILS_VER="1.3.3"
 export CBUILD=${CBUILD:-${CHOST}}
 export CTARGET=${CTARGET:-${CHOST}}
 if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
+	if [[ ${CATEGORY} == cross*-* ]] ; then
+		export CTARGET=${CATEGORY#cross*-}
 	fi
 fi
 
@@ -141,7 +141,7 @@ RDEPEND="${COMMON_DEPEND}
 
 RESTRICT="!test? ( test )"
 
-if [[ ${CATEGORY} == cross-* ]] ; then
+if [[ ${CATEGORY} == cross*-* ]] ; then
 	BDEPEND+=" !headers-only? (
 		>=${CATEGORY}/binutils-2.27
 		>=${CATEGORY}/gcc-6

--- a/sys-libs/glibc/glibc-2.35-r11.ebuild
+++ b/sys-libs/glibc/glibc-2.35-r11.ebuild
@@ -69,8 +69,8 @@ MIN_PAX_UTILS_VER="1.3.3"
 export CBUILD=${CBUILD:-${CHOST}}
 export CTARGET=${CTARGET:-${CHOST}}
 if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
+	if [[ ${CATEGORY} == cross*-* ]] ; then
+		export CTARGET=${CATEGORY#cross*-}
 	fi
 fi
 
@@ -142,7 +142,7 @@ RDEPEND="${COMMON_DEPEND}
 
 RESTRICT="!test? ( test )"
 
-if [[ ${CATEGORY} == cross-* ]] ; then
+if [[ ${CATEGORY} == cross*-* ]] ; then
 	BDEPEND+=" !headers-only? (
 		>=${CATEGORY}/binutils-2.27
 		>=${CATEGORY}/gcc-6.2

--- a/sys-libs/glibc/glibc-2.36-r8.ebuild
+++ b/sys-libs/glibc/glibc-2.36-r8.ebuild
@@ -68,8 +68,8 @@ MIN_PAX_UTILS_VER="1.3.3"
 export CBUILD=${CBUILD:-${CHOST}}
 export CTARGET=${CTARGET:-${CHOST}}
 if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
+	if [[ ${CATEGORY} == cross*-* ]] ; then
+		export CTARGET=${CATEGORY#cross*-}
 	fi
 fi
 
@@ -144,7 +144,7 @@ RDEPEND="${COMMON_DEPEND}
 
 RESTRICT="!test? ( test )"
 
-if [[ ${CATEGORY} == cross-* ]] ; then
+if [[ ${CATEGORY} == cross*-* ]] ; then
 	BDEPEND+=" !headers-only? (
 		>=${CATEGORY}/binutils-2.27
 		>=${CATEGORY}/gcc-6.2

--- a/sys-libs/glibc/glibc-2.37-r10.ebuild
+++ b/sys-libs/glibc/glibc-2.37-r10.ebuild
@@ -66,8 +66,8 @@ IUSE="audit caps cet compile-locales +crypt custom-cflags doc gd hash-sysv-compa
 export CBUILD=${CBUILD:-${CHOST}}
 export CTARGET=${CTARGET:-${CHOST}}
 if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
+	if [[ ${CATEGORY} == cross*-* ]] ; then
+		export CTARGET=${CATEGORY#cross*-}
 	fi
 fi
 
@@ -135,7 +135,7 @@ RDEPEND="${COMMON_DEPEND}
 
 RESTRICT="!test? ( test )"
 
-if [[ ${CATEGORY} == cross-* ]] ; then
+if [[ ${CATEGORY} == cross*-* ]] ; then
 	BDEPEND+=" !headers-only? (
 		>=${CATEGORY}/binutils-2.27
 		>=${CATEGORY}/gcc-6.2

--- a/sys-libs/glibc/glibc-2.38-r13.ebuild
+++ b/sys-libs/glibc/glibc-2.38-r13.ebuild
@@ -66,8 +66,8 @@ IUSE="audit caps cet compile-locales +crypt custom-cflags doc gd hash-sysv-compa
 export CBUILD=${CBUILD:-${CHOST}}
 export CTARGET=${CTARGET:-${CHOST}}
 if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
+	if [[ ${CATEGORY} == cross*-* ]] ; then
+		export CTARGET=${CATEGORY#cross*-}
 	fi
 fi
 
@@ -135,7 +135,7 @@ RDEPEND="${COMMON_DEPEND}
 
 RESTRICT="!test? ( test )"
 
-if [[ ${CATEGORY} == cross-* ]] ; then
+if [[ ${CATEGORY} == cross*-* ]] ; then
 	BDEPEND+=" !headers-only? (
 		>=${CATEGORY}/binutils-2.27
 		>=${CATEGORY}/gcc-6.2

--- a/sys-libs/glibc/glibc-2.39-r11.ebuild
+++ b/sys-libs/glibc/glibc-2.39-r11.ebuild
@@ -70,8 +70,8 @@ IUSE="audit caps cet compile-locales custom-cflags doc gd hash-sysv-compat heade
 export CBUILD=${CBUILD:-${CHOST}}
 export CTARGET=${CTARGET:-${CHOST}}
 if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
+	if [[ ${CATEGORY} == cross*-* ]] ; then
+		export CTARGET=${CATEGORY#cross*-}
 	fi
 fi
 
@@ -140,7 +140,7 @@ RDEPEND="${COMMON_DEPEND}
 
 RESTRICT="!test? ( test )"
 
-if [[ ${CATEGORY} == cross-* ]] ; then
+if [[ ${CATEGORY} == cross*-* ]] ; then
 	BDEPEND+=" !headers-only? (
 		>=${CATEGORY}/binutils-2.27
 		>=${CATEGORY}/gcc-6.2

--- a/sys-libs/glibc/glibc-2.39-r6.ebuild
+++ b/sys-libs/glibc/glibc-2.39-r6.ebuild
@@ -70,8 +70,8 @@ IUSE="audit caps cet compile-locales custom-cflags doc gd hash-sysv-compat heade
 export CBUILD=${CBUILD:-${CHOST}}
 export CTARGET=${CTARGET:-${CHOST}}
 if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
+	if [[ ${CATEGORY} == cross*-* ]] ; then
+		export CTARGET=${CATEGORY#cross*-}
 	fi
 fi
 
@@ -140,7 +140,7 @@ RDEPEND="${COMMON_DEPEND}
 
 RESTRICT="!test? ( test )"
 
-if [[ ${CATEGORY} == cross-* ]] ; then
+if [[ ${CATEGORY} == cross*-* ]] ; then
 	BDEPEND+=" !headers-only? (
 		>=${CATEGORY}/binutils-2.27
 		>=${CATEGORY}/gcc-6.2

--- a/sys-libs/glibc/glibc-2.40-r5.ebuild
+++ b/sys-libs/glibc/glibc-2.40-r5.ebuild
@@ -70,8 +70,8 @@ IUSE="audit caps cet compile-locales custom-cflags doc gd hash-sysv-compat heade
 export CBUILD=${CBUILD:-${CHOST}}
 export CTARGET=${CTARGET:-${CHOST}}
 if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
+	if [[ ${CATEGORY} == cross*-* ]] ; then
+		export CTARGET=${CATEGORY#cross*-}
 	fi
 fi
 
@@ -140,7 +140,7 @@ RDEPEND="${COMMON_DEPEND}
 
 RESTRICT="!test? ( test )"
 
-if [[ ${CATEGORY} == cross-* ]] ; then
+if [[ ${CATEGORY} == cross*-* ]] ; then
 	BDEPEND+=" !headers-only? (
 		>=${CATEGORY}/binutils-2.27
 		>=${CATEGORY}/gcc-6.2

--- a/sys-libs/glibc/glibc-9999.ebuild
+++ b/sys-libs/glibc/glibc-9999.ebuild
@@ -70,8 +70,8 @@ IUSE="audit caps cet compile-locales custom-cflags doc gd hash-sysv-compat heade
 export CBUILD=${CBUILD:-${CHOST}}
 export CTARGET=${CTARGET:-${CHOST}}
 if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
+	if [[ ${CATEGORY} == cross*-* ]] ; then
+		export CTARGET=${CATEGORY#cross*-}
 	fi
 fi
 
@@ -140,7 +140,7 @@ RDEPEND="${COMMON_DEPEND}
 
 RESTRICT="!test? ( test )"
 
-if [[ ${CATEGORY} == cross-* ]] ; then
+if [[ ${CATEGORY} == cross*-* ]] ; then
 	BDEPEND+=" !headers-only? (
 		>=${CATEGORY}/binutils-2.27
 		>=${CATEGORY}/gcc-6.2

--- a/sys-libs/libcxx/libcxx-18.1.8.ebuild
+++ b/sys-libs/libcxx/libcxx-18.1.8.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 PYTHON_COMPAT=( python3_{10..12} )
-inherit cmake-multilib flag-o-matic llvm.org llvm-utils python-any-r1
+inherit cmake-multilib crossdev flag-o-matic llvm.org llvm-utils python-any-r1
 inherit toolchain-funcs
 
 DESCRIPTION="New implementation of the C++ standard library, targeting C++11"
@@ -76,12 +76,15 @@ test_compiler() {
 src_configure() {
 	llvm_prepend_path "${LLVM_MAJOR}"
 
+	local sysroot
+	target_is_not_host && sysroot=/usr/${CTARGET}
+
 	# note: we need to do this before multilib kicks in since it will
 	# alter the CHOST
 	local cxxabi cxxabi_incs
 	if use libcxxabi; then
 		cxxabi=system-libcxxabi
-		cxxabi_incs="${EPREFIX}/usr/include/c++/v1"
+		cxxabi_incs="${EPREFIX}${sysroot}/usr/include/c++/v1"
 	else
 		local gcc_inc="${EPREFIX}/usr/lib/gcc/${CHOST}/$(gcc-fullversion)/include/g++-v$(gcc-major-version)"
 		cxxabi=libsupc++
@@ -93,8 +96,8 @@ src_configure() {
 
 multilib_src_configure() {
 	if use clang; then
-		local -x CC=${CHOST}-clang
-		local -x CXX=${CHOST}-clang++
+		local -x CC=${CTARGET}-clang
+		local -x CXX=${CTARGET}-clang++
 		strip-unsupported-flags
 	fi
 
@@ -102,18 +105,29 @@ multilib_src_configure() {
 	local use_compiler_rt=OFF
 	[[ $(tc-get-c-rtlib) == compiler-rt ]] && use_compiler_rt=ON
 
-	# bootstrap: cmake is unhappy if compiler can't link to stdlib
-	local nolib_flags=( -nodefaultlibs -lc )
-	if ! test_compiler; then
-		if test_compiler "${nolib_flags[@]}"; then
-			local -x LDFLAGS="${LDFLAGS} ${nolib_flags[*]}"
-			ewarn "${CXX} seems to lack runtime, trying with ${nolib_flags[*]}"
+	# Scenarios to consider:
+	#
+	# 1. Compiler test works with the default flags.
+	# 2. There is a runtime library, but no stdlib. In that case, leave the
+	#    LDFLAGS untouched, since there is no self-dependency in libc++.
+	# 3. There is no runtime library nor stdlib. In that case, overwrite the
+	#    LDFLAGS.
+	local nostdlib_flags=( -nostdlib --rtlib=compiler-rt -lc )
+	local nort_flags=( -nodefaultlibs -lc )
+	if ! test_compiler && ! test_compiler "${nostdlib_flags[@]}"; then
+		if test_compiler "${nort_flags[@]}"; then
+			local -x LDFLAGS="${LDFLAGS} ${nort_flags[*]}"
+			ewarn "${CXX} seems to lack runtime, trying with ${nort_flags[*]}"
 		fi
 	fi
 
+	local sysroot
+	target_is_not_host && sysroot=/usr/${CTARGET}
+
 	local libdir=$(get_libdir)
 	local mycmakeargs=(
-		-DCMAKE_CXX_COMPILER_TARGET="${CHOST}"
+		-DCMAKE_CXX_COMPILER_TARGET="${CTARGET}"
+		-DCMAKE_INSTALL_PREFIX="${EPREFIX}${sysroot}/usr"
 		-DPython3_EXECUTABLE="${PYTHON}"
 		-DLLVM_ENABLE_RUNTIMES=libcxx
 		-DLLVM_INCLUDE_TESTS=OFF
@@ -132,7 +146,16 @@ multilib_src_configure() {
 		# this is broken with standalone builds, and also meaningless
 		-DLIBCXXABI_USE_LLVM_UNWINDER=OFF
 	)
-
+	if is_crosspkg; then
+		# Needed to target built libc headers
+		export CFLAGS="${CFLAGS} -isystem /usr/${CTARGET}/usr/include"
+		mycmakeargs+=(
+			# Without this, the compiler will compile a test program
+			# and fail due to no builtins.
+			-DCMAKE_C_COMPILER_WORKS=1
+			-DCMAKE_CXX_COMPILER_WORKS=1
+		)
+	fi
 	if use test; then
 		mycmakeargs+=(
 			-DLLVM_EXTERNAL_LIT="${EPREFIX}/usr/bin/lit"
@@ -161,6 +184,7 @@ multilib_src_install() {
 	# since we've replaced libc++.{a,so} with ldscripts, now we have to
 	# install the extra symlinks
 	if [[ ${CHOST} != *-darwin* ]] ; then
+		target_is_not_host && into /usr/${CTARGET}
 		dolib.so lib/libc++_shared.so
 		use static-libs && dolib.a lib/libc++_static.a
 	fi

--- a/sys-libs/libcxx/libcxx-19.1.3.ebuild
+++ b/sys-libs/libcxx/libcxx-19.1.3.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 PYTHON_COMPAT=( python3_{10..13} )
-inherit cmake-multilib flag-o-matic llvm.org llvm-utils python-any-r1
+inherit cmake-multilib crossdev flag-o-matic llvm.org llvm-utils python-any-r1
 inherit toolchain-funcs
 
 DESCRIPTION="New implementation of the C++ standard library, targeting C++11"
@@ -93,18 +93,29 @@ multilib_src_configure() {
 	local use_compiler_rt=OFF
 	[[ $(tc-get-c-rtlib) == compiler-rt ]] && use_compiler_rt=ON
 
-	# bootstrap: cmake is unhappy if compiler can't link to stdlib
-	local nolib_flags=( -nodefaultlibs -lc )
-	if ! test_compiler; then
-		if test_compiler "${nolib_flags[@]}"; then
-			local -x LDFLAGS="${LDFLAGS} ${nolib_flags[*]}"
-			ewarn "${CXX} seems to lack runtime, trying with ${nolib_flags[*]}"
+	# Scenarios to consider:
+	#
+	# 1. Compiler test works with the default flags.
+	# 2. There is a runtime library, but no stdlib. In that case, leave the
+	#    LDFLAGS untouched, since there is no self-dependency in libc++.
+	# 3. There is no runtime library nor stdlib. In that case, overwrite the
+	#    LDFLAGS.
+	local nostdlib_flags=( -nostdlib --rtlib=compiler-rt -lc )
+	local nort_flags=( -nodefaultlibs -lc )
+	if ! test_compiler && ! test_compiler "${nostdlib_flags[@]}"; then
+		if test_compiler "${nort_flags[@]}"; then
+			local -x LDFLAGS="${LDFLAGS} ${nort_flags[*]}"
+			ewarn "${CXX} seems to lack runtime, trying with ${nort_flags[*]}"
 		fi
 	fi
 
+	local sysroot
+	target_is_not_host && sysroot=/usr/${CTARGET}
+
 	local libdir=$(get_libdir)
 	local mycmakeargs=(
-		-DCMAKE_CXX_COMPILER_TARGET="${CHOST}"
+		-DCMAKE_CXX_COMPILER_TARGET="${CTARGET}"
+		-DCMAKE_INSTALL_PREFIX="${EPREFIX}${sysroot}/usr"
 		-DPython3_EXECUTABLE="${PYTHON}"
 		-DLLVM_ENABLE_RUNTIMES=libcxx
 		-DLLVM_INCLUDE_TESTS=OFF
@@ -124,7 +135,16 @@ multilib_src_configure() {
 		# this is broken with standalone builds, and also meaningless
 		-DLIBCXXABI_USE_LLVM_UNWINDER=OFF
 	)
-
+	if is_crosspkg; then
+		# Needed to target built libc headers
+		export CFLAGS="${CFLAGS} -isystem /usr/${CTARGET}/usr/include"
+		mycmakeargs+=(
+			# Without this, the compiler will compile a test program
+			# and fail due to no builtins.
+			-DCMAKE_C_COMPILER_WORKS=1
+			-DCMAKE_CXX_COMPILER_WORKS=1
+		)
+	fi
 	if use test; then
 		mycmakeargs+=(
 			-DLLVM_EXTERNAL_LIT="${EPREFIX}/usr/bin/lit"
@@ -153,6 +173,7 @@ multilib_src_install() {
 	# since we've replaced libc++.{a,so} with ldscripts, now we have to
 	# install the extra symlinks
 	if [[ ${CHOST} != *-darwin* ]] ; then
+		target_is_not_host && into /usr/${CTARGET}
 		dolib.so lib/libc++_shared.so
 		use static-libs && dolib.a lib/libc++_static.a
 	fi

--- a/sys-libs/libcxxabi/libcxxabi-18.1.8.ebuild
+++ b/sys-libs/libcxxabi/libcxxabi-18.1.8.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 PYTHON_COMPAT=( python3_{10..12} )
-inherit cmake-multilib flag-o-matic llvm.org llvm-utils python-any-r1
+inherit cmake-multilib crossdev flag-o-matic llvm.org llvm-utils python-any-r1
 inherit toolchain-funcs
 
 DESCRIPTION="Low level support for a standard C++ library"
@@ -50,8 +50,8 @@ multilib_src_configure() {
 	llvm_prepend_path "${LLVM_MAJOR}"
 
 	if use clang; then
-		local -x CC=${CHOST}-clang
-		local -x CXX=${CHOST}-clang++
+		local -x CC=${CTARGET}-clang
+		local -x CXX=${CTARGET}-clang++
 		strip-unsupported-flags
 	fi
 
@@ -59,9 +59,13 @@ multilib_src_configure() {
 	local use_compiler_rt=OFF
 	[[ $(tc-get-c-rtlib) == compiler-rt ]] && use_compiler_rt=ON
 
+	local sysroot
+	target_is_not_host && sysroot=/usr/${CTARGET}
+
 	local libdir=$(get_libdir)
 	local mycmakeargs=(
-		-DCMAKE_CXX_COMPILER_TARGET="${CHOST}"
+		-DCMAKE_CXX_COMPILER_TARGET="${CTARGET}"
+		-DCMAKE_INSTALL_PREFIX="${EPREFIX}${sysroot}/usr"
 		-DPython3_EXECUTABLE="${PYTHON}"
 		-DLLVM_ENABLE_RUNTIMES="libcxxabi;libcxx"
 		-DLLVM_INCLUDE_TESTS=OFF
@@ -73,7 +77,7 @@ multilib_src_configure() {
 
 		# upstream is omitting standard search path for this
 		# probably because gcc & clang are bundling their own unwind.h
-		-DLIBCXXABI_LIBUNWIND_INCLUDES="${EPREFIX}"/usr/include
+		-DLIBCXXABI_LIBUNWIND_INCLUDES="${EPREFIX}${sysroot}"/usr/include
 		# this is broken with standalone builds, and also meaningless
 		-DLIBCXXABI_USE_LLVM_UNWINDER=OFF
 
@@ -87,6 +91,14 @@ multilib_src_configure() {
 		-DLIBCXX_INCLUDE_BENCHMARKS=OFF
 		-DLIBCXX_INCLUDE_TESTS=OFF
 	)
+	if is_crosspkg; then
+		mycmakeargs+=(
+			# Without this, the compiler will compile a test program
+			# and fail due to no builtins.
+			-DCMAKE_C_COMPILER_WORKS=1
+			-DCMAKE_CXX_COMPILER_WORKS=1
+		)
+	fi
 	if use test; then
 		mycmakeargs+=(
 			-DLLVM_EXTERNAL_LIT="${EPREFIX}/usr/bin/lit"

--- a/sys-libs/libcxxabi/libcxxabi-19.1.3.ebuild
+++ b/sys-libs/libcxxabi/libcxxabi-19.1.3.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 PYTHON_COMPAT=( python3_{10..13} )
-inherit cmake-multilib flag-o-matic llvm.org llvm-utils python-any-r1
+inherit cmake-multilib crossdev flag-o-matic llvm.org llvm-utils python-any-r1
 inherit toolchain-funcs
 
 DESCRIPTION="Low level support for a standard C++ library"
@@ -59,9 +59,13 @@ multilib_src_configure() {
 	local use_compiler_rt=OFF
 	[[ $(tc-get-c-rtlib) == compiler-rt ]] && use_compiler_rt=ON
 
+	local sysroot
+	target_is_not_host && sysroot=/usr/${CTARGET}
+
 	local libdir=$(get_libdir)
 	local mycmakeargs=(
-		-DCMAKE_CXX_COMPILER_TARGET="${CHOST}"
+		-DCMAKE_CXX_COMPILER_TARGET="${CTARGET}"
+		-DCMAKE_INSTALL_PREFIX="${EPREFIX}${sysroot}/usr"
 		-DPython3_EXECUTABLE="${PYTHON}"
 		-DLLVM_ENABLE_RUNTIMES="libcxxabi;libcxx"
 		-DLLVM_INCLUDE_TESTS=OFF
@@ -87,6 +91,14 @@ multilib_src_configure() {
 		-DLIBCXX_INCLUDE_BENCHMARKS=OFF
 		-DLIBCXX_INCLUDE_TESTS=OFF
 	)
+	if is_crosspkg; then
+		mycmakeargs+=(
+			# Without this, the compiler will compile a test program
+			# and fail due to no builtins.
+			-DCMAKE_C_COMPILER_WORKS=1
+			-DCMAKE_CXX_COMPILER_WORKS=1
+		)
+	fi
 	if use test; then
 		mycmakeargs+=(
 			-DLLVM_EXTERNAL_LIT="${EPREFIX}/usr/bin/lit"

--- a/sys-libs/libcxxabi/libcxxabi-20.0.0.9999.ebuild
+++ b/sys-libs/libcxxabi/libcxxabi-20.0.0.9999.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 PYTHON_COMPAT=( python3_{10..13} )
-inherit cmake-multilib flag-o-matic llvm.org llvm-utils python-any-r1
+inherit cmake-multilib crossdev flag-o-matic llvm.org llvm-utils python-any-r1
 inherit toolchain-funcs
 
 DESCRIPTION="Low level support for a standard C++ library"
@@ -58,9 +58,13 @@ multilib_src_configure() {
 	local use_compiler_rt=OFF
 	[[ $(tc-get-c-rtlib) == compiler-rt ]] && use_compiler_rt=ON
 
+	local sysroot
+	target_is_not_host && sysroot=/usr/${CTARGET}
+
 	local libdir=$(get_libdir)
 	local mycmakeargs=(
-		-DCMAKE_CXX_COMPILER_TARGET="${CHOST}"
+		-DCMAKE_CXX_COMPILER_TARGET="${CTARGET}"
+		-DCMAKE_INSTALL_PREFIX="${EPREFIX}${sysroot}/usr"
 		-DPython3_EXECUTABLE="${PYTHON}"
 		-DLLVM_ENABLE_RUNTIMES="libcxxabi;libcxx"
 		-DLLVM_INCLUDE_TESTS=OFF
@@ -85,6 +89,14 @@ multilib_src_configure() {
 		-DLIBCXX_INCLUDE_BENCHMARKS=OFF
 		-DLIBCXX_INCLUDE_TESTS=OFF
 	)
+	if is_crosspkg; then
+		mycmakeargs+=(
+			# Without this, the compiler will compile a test program
+			# and fail due to no builtins.
+			-DCMAKE_C_COMPILER_WORKS=1
+			-DCMAKE_CXX_COMPILER_WORKS=1
+		)
+	fi
 	if use test; then
 		mycmakeargs+=(
 			-DLLVM_EXTERNAL_LIT="${EPREFIX}/usr/bin/lit"

--- a/sys-libs/libcxxabi/libcxxabi-20.0.0_pre20241029.ebuild
+++ b/sys-libs/libcxxabi/libcxxabi-20.0.0_pre20241029.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 PYTHON_COMPAT=( python3_{10..13} )
-inherit cmake-multilib flag-o-matic llvm.org llvm-utils python-any-r1
+inherit cmake-multilib crossdev flag-o-matic llvm.org llvm-utils python-any-r1
 inherit toolchain-funcs
 
 DESCRIPTION="Low level support for a standard C++ library"
@@ -58,9 +58,13 @@ multilib_src_configure() {
 	local use_compiler_rt=OFF
 	[[ $(tc-get-c-rtlib) == compiler-rt ]] && use_compiler_rt=ON
 
+	local sysroot
+	target_is_not_host && sysroot=/usr/${CTARGET}
+
 	local libdir=$(get_libdir)
 	local mycmakeargs=(
-		-DCMAKE_CXX_COMPILER_TARGET="${CHOST}"
+		-DCMAKE_CXX_COMPILER_TARGET="${CTARGET}"
+		-DCMAKE_INSTALL_PREFIX="${EPREFIX}${sysroot}/usr"
 		-DPython3_EXECUTABLE="${PYTHON}"
 		-DLLVM_ENABLE_RUNTIMES="libcxxabi;libcxx"
 		-DLLVM_INCLUDE_TESTS=OFF
@@ -85,6 +89,14 @@ multilib_src_configure() {
 		-DLIBCXX_INCLUDE_BENCHMARKS=OFF
 		-DLIBCXX_INCLUDE_TESTS=OFF
 	)
+	if is_crosspkg; then
+		mycmakeargs+=(
+			# Without this, the compiler will compile a test program
+			# and fail due to no builtins.
+			-DCMAKE_C_COMPILER_WORKS=1
+			-DCMAKE_CXX_COMPILER_WORKS=1
+		)
+	fi
 	if use test; then
 		mycmakeargs+=(
 			-DLLVM_EXTERNAL_LIT="${EPREFIX}/usr/bin/lit"

--- a/sys-libs/llvm-libunwind/llvm-libunwind-19.1.3.ebuild
+++ b/sys-libs/llvm-libunwind/llvm-libunwind-19.1.3.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 PYTHON_COMPAT=( python3_{10..13} )
-inherit cmake-multilib flag-o-matic llvm.org llvm-utils python-any-r1
+inherit cmake-multilib crossdev flag-o-matic llvm.org llvm-utils python-any-r1
 inherit toolchain-funcs
 
 DESCRIPTION="C++ runtime stack unwinder from LLVM"
@@ -54,8 +54,8 @@ multilib_src_configure() {
 	filter-lto
 
 	if use clang; then
-		local -x CC=${CHOST}-clang
-		local -x CXX=${CHOST}-clang++
+		local -x CC=${CTARGET}-clang
+		local -x CXX=${CTARGET}-clang++
 		strip-unsupported-flags
 	fi
 
@@ -73,8 +73,12 @@ multilib_src_configure() {
 	# See also https://github.com/llvm/llvm-project/issues/86#issuecomment-1649668826.
 	use debug || append-cppflags -DNDEBUG
 
+	local sysroot
+	target_is_not_host && sysroot=/usr/${CTARGET}
+
 	local mycmakeargs=(
 		-DCMAKE_CXX_COMPILER_TARGET="${CHOST}"
+		-DCMAKE_INSTALL_PREFIX="${EPREFIX}${sysroot}/usr"
 		-DPython3_EXECUTABLE="${PYTHON}"
 		-DLLVM_ENABLE_RUNTIMES="libunwind"
 		-DLLVM_LIBDIR_SUFFIX=${libdir#lib}
@@ -91,6 +95,14 @@ multilib_src_configure() {
 		# avoid dependency on libgcc_s if compiler-rt is used
 		-DLIBUNWIND_USE_COMPILER_RT=${use_compiler_rt}
 	)
+	if is_crosspkg; then
+		mycmakeargs+=(
+			# Without this, the compiler will compile a test program
+			# and fail due to no builtins.
+			-DCMAKE_C_COMPILER_WORKS=1
+			-DCMAKE_CXX_COMPILER_WORKS=1
+		)
+	fi
 	if use test; then
 		mycmakeargs+=(
 			-DLLVM_ENABLE_RUNTIMES="libunwind;libcxxabi;libcxx"

--- a/sys-libs/llvm-libunwind/llvm-libunwind-20.0.0.9999.ebuild
+++ b/sys-libs/llvm-libunwind/llvm-libunwind-20.0.0.9999.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 PYTHON_COMPAT=( python3_{10..13} )
-inherit cmake-multilib flag-o-matic llvm.org llvm-utils python-any-r1
+inherit cmake-multilib crossdev flag-o-matic llvm.org llvm-utils python-any-r1
 inherit toolchain-funcs
 
 DESCRIPTION="C++ runtime stack unwinder from LLVM"
@@ -53,8 +53,8 @@ multilib_src_configure() {
 	filter-lto
 
 	if use clang; then
-		local -x CC=${CHOST}-clang
-		local -x CXX=${CHOST}-clang++
+		local -x CC=${CTARGET}-clang
+		local -x CXX=${CTARGET}-clang++
 		strip-unsupported-flags
 	fi
 
@@ -72,8 +72,12 @@ multilib_src_configure() {
 	# See also https://github.com/llvm/llvm-project/issues/86#issuecomment-1649668826.
 	use debug || append-cppflags -DNDEBUG
 
+	local sysroot
+	target_is_not_host && sysroot=/usr/${CTARGET}
+
 	local mycmakeargs=(
 		-DCMAKE_CXX_COMPILER_TARGET="${CHOST}"
+		-DCMAKE_INSTALL_PREFIX="${EPREFIX}${sysroot}/usr"
 		-DPython3_EXECUTABLE="${PYTHON}"
 		-DLLVM_ENABLE_RUNTIMES="libunwind"
 		-DLLVM_LIBDIR_SUFFIX=${libdir#lib}
@@ -90,6 +94,14 @@ multilib_src_configure() {
 		# avoid dependency on libgcc_s if compiler-rt is used
 		-DLIBUNWIND_USE_COMPILER_RT=${use_compiler_rt}
 	)
+	if is_crosspkg; then
+		mycmakeargs+=(
+			# Without this, the compiler will compile a test program
+			# and fail due to no builtins.
+			-DCMAKE_C_COMPILER_WORKS=1
+			-DCMAKE_CXX_COMPILER_WORKS=1
+		)
+	fi
 	if use test; then
 		mycmakeargs+=(
 			-DLLVM_ENABLE_RUNTIMES="libunwind;libcxxabi;libcxx"

--- a/sys-libs/llvm-libunwind/llvm-libunwind-20.0.0_pre20241029.ebuild
+++ b/sys-libs/llvm-libunwind/llvm-libunwind-20.0.0_pre20241029.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 PYTHON_COMPAT=( python3_{10..13} )
-inherit cmake-multilib flag-o-matic llvm.org llvm-utils python-any-r1
+inherit cmake-multilib crossdev flag-o-matic llvm.org llvm-utils python-any-r1
 inherit toolchain-funcs
 
 DESCRIPTION="C++ runtime stack unwinder from LLVM"
@@ -53,8 +53,8 @@ multilib_src_configure() {
 	filter-lto
 
 	if use clang; then
-		local -x CC=${CHOST}-clang
-		local -x CXX=${CHOST}-clang++
+		local -x CC=${CTARGET}-clang
+		local -x CXX=${CTARGET}-clang++
 		strip-unsupported-flags
 	fi
 
@@ -72,8 +72,12 @@ multilib_src_configure() {
 	# See also https://github.com/llvm/llvm-project/issues/86#issuecomment-1649668826.
 	use debug || append-cppflags -DNDEBUG
 
+	local sysroot
+	target_is_not_host && sysroot=/usr/${CTARGET}
+
 	local mycmakeargs=(
 		-DCMAKE_CXX_COMPILER_TARGET="${CHOST}"
+		-DCMAKE_INSTALL_PREFIX="${EPREFIX}${sysroot}/usr"
 		-DPython3_EXECUTABLE="${PYTHON}"
 		-DLLVM_ENABLE_RUNTIMES="libunwind"
 		-DLLVM_LIBDIR_SUFFIX=${libdir#lib}
@@ -90,6 +94,14 @@ multilib_src_configure() {
 		# avoid dependency on libgcc_s if compiler-rt is used
 		-DLIBUNWIND_USE_COMPILER_RT=${use_compiler_rt}
 	)
+	if is_crosspkg; then
+		mycmakeargs+=(
+			# Without this, the compiler will compile a test program
+			# and fail due to no builtins.
+			-DCMAKE_C_COMPILER_WORKS=1
+			-DCMAKE_CXX_COMPILER_WORKS=1
+		)
+	fi
 	if use test; then
 		mycmakeargs+=(
 			-DLLVM_ENABLE_RUNTIMES="libunwind;libcxxabi;libcxx"

--- a/sys-libs/musl/musl-1.2.3-r8.ebuild
+++ b/sys-libs/musl/musl-1.2.3-r8.ebuild
@@ -28,8 +28,8 @@ SRC_URI+="
 export CBUILD=${CBUILD:-${CHOST}}
 export CTARGET=${CTARGET:-${CHOST}}
 if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
+	if [[ ${CATEGORY} == cross*-* ]] ; then
+		export CTARGET=${CATEGORY#cross*-}
 	fi
 fi
 
@@ -49,7 +49,7 @@ QA_PRESTRIPPED="usr/lib/crtn.o"
 # built as part as crossdev. Also, elide the blockers when in cross-*,
 # as it doesn't make sense to block the normal CBUILD libxcrypt at all
 # there when we're installing into /usr/${CHOST} anyway.
-if [[ ${CATEGORY} == cross-* ]] ; then
+if [[ ${CATEGORY} == cross*-* ]] ; then
 	IUSE="${IUSE/crypt/+crypt}"
 else
 	RDEPEND="crypt? ( !sys-libs/libxcrypt[system] )"
@@ -121,7 +121,7 @@ src_compile() {
 	just_headers && return 0
 
 	emake
-	if [[ ${CATEGORY} != cross-* ]] ; then
+	if [[ ${CATEGORY} != cross*-* ]] ; then
 		emake -C "${T}" getconf getent iconv \
 			CC="$(tc-getCC)" \
 			CFLAGS="${CFLAGS}" \
@@ -152,7 +152,7 @@ src_install() {
 		rm "${ED}/usr/$(get_libdir)/libcrypt.a" || die
 	fi
 
-	if [[ ${CATEGORY} != cross-* ]] ; then
+	if [[ ${CATEGORY} != cross*-* ]] ; then
 		# Fish out of config:
 		#   ARCH = ...
 		#   SUBARCH = ...

--- a/sys-libs/newlib/newlib-4.1.0-r2.ebuild
+++ b/sys-libs/newlib/newlib-4.1.0-r2.ebuild
@@ -16,8 +16,8 @@ fi
 export CBUILD=${CBUILD:-${CHOST}}
 export CTARGET=${CTARGET:-${CHOST}}
 if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
+	if [[ ${CATEGORY} == cross*-* ]] ; then
+		export CTARGET=${CATEGORY#cross*-}
 	fi
 fi
 

--- a/sys-libs/newlib/newlib-4.2.0.20211231-r1.ebuild
+++ b/sys-libs/newlib/newlib-4.2.0.20211231-r1.ebuild
@@ -16,8 +16,8 @@ fi
 export CBUILD=${CBUILD:-${CHOST}}
 export CTARGET=${CTARGET:-${CHOST}}
 if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
+	if [[ ${CATEGORY} == cross*-* ]] ; then
+		export CTARGET=${CATEGORY#cross*-}
 	fi
 fi
 

--- a/sys-libs/newlib/newlib-4.3.0.20230120-r1.ebuild
+++ b/sys-libs/newlib/newlib-4.3.0.20230120-r1.ebuild
@@ -16,8 +16,8 @@ fi
 export CBUILD=${CBUILD:-${CHOST}}
 export CTARGET=${CTARGET:-${CHOST}}
 if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
+	if [[ ${CATEGORY} == cross*-* ]] ; then
+		export CTARGET=${CATEGORY#cross*-}
 	fi
 fi
 

--- a/sys-libs/newlib/newlib-4.3.0.20230120-r2.ebuild
+++ b/sys-libs/newlib/newlib-4.3.0.20230120-r2.ebuild
@@ -16,8 +16,8 @@ fi
 export CBUILD=${CBUILD:-${CHOST}}
 export CTARGET=${CTARGET:-${CHOST}}
 if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
+	if [[ ${CATEGORY} == cross*-* ]] ; then
+		export CTARGET=${CATEGORY#cross*-}
 	fi
 fi
 

--- a/sys-libs/newlib/newlib-4.4.0.20231231.ebuild
+++ b/sys-libs/newlib/newlib-4.4.0.20231231.ebuild
@@ -16,8 +16,8 @@ fi
 export CBUILD=${CBUILD:-${CHOST}}
 export CTARGET=${CTARGET:-${CHOST}}
 if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
+	if [[ ${CATEGORY} == cross*-* ]] ; then
+		export CTARGET=${CATEGORY#cross*-}
 	fi
 fi
 

--- a/sys-libs/newlib/newlib-9999.ebuild
+++ b/sys-libs/newlib/newlib-9999.ebuild
@@ -16,8 +16,8 @@ fi
 export CBUILD=${CBUILD:-${CHOST}}
 export CTARGET=${CTARGET:-${CHOST}}
 if [[ ${CTARGET} == ${CHOST} ]] ; then
-	if [[ ${CATEGORY} == cross-* ]] ; then
-		export CTARGET=${CATEGORY#cross-}
+	if [[ ${CATEGORY} == cross*-* ]] ; then
+		export CTARGET=${CATEGORY#cross*-}
 	fi
 fi
 


### PR DESCRIPTION
<!-- Please put the pull request description above -->

Apply neccessary changes across ebuild to make it possible to bootstrap `*-gnu` cross environments with LLVM (and GCC used only as a fallback compiler for glibc):

- Look for `cross*-*` category prefix, instead of `cross-*`. The latter doesn't catch the `cross_llvm` prefix, therefore doesn't work for LLVM-based cross environments.
- Enforce usage of GCC as a compiler for glibc, even when cross building.

This pull request is a necessary prerequisite for 

See individual commits for more details.

Depends on #39280

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
