### PR TITLE
Only force bfd linker when gold linker is used

### DIFF
--- a/dev-db/mariadb/mariadb-10.11.10.ebuild
+++ b/dev-db/mariadb/mariadb-10.11.10.ebuild
@@ -281,7 +281,7 @@ src_configure() {
 	# bug #855233 (MDEV-11914, MDEV-25633) at least
 	filter-lto
 	# bug 508724 mariadb cannot use ld.gold
-	tc-ld-force-bfd
+	tc-ld-is-gold && tc-ld-force-bfd
 	# Bug #114895, bug #110149
 	filter-flags "-O" "-O[01]"
 

--- a/dev-db/mariadb/mariadb-10.6.20.ebuild
+++ b/dev-db/mariadb/mariadb-10.6.20.ebuild
@@ -292,7 +292,7 @@ src_configure() {
 	# bug #855233 (MDEV-11914, MDEV-25633) at least
 	filter-lto
 	# bug 508724 mariadb cannot use ld.gold
-	tc-ld-force-bfd
+	tc-ld-is-gold && tc-ld-force-bfd
 	# Bug #114895, bug #110149
 	filter-flags "-O" "-O[01]"
 


### PR DESCRIPTION
Currently, last mariadb ebuilds force bfd linker to prevent gold linker usage but this is wrong when lld linker is being used (in fact it fails if LDFLAGS contains lld specific options).

Since it links and works perfectly with lld linker this will only force bfd linker when gold linker is used

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
