### PR TITLE
dev-lang/luajit: add 2.1.9999999999

### DIFF
--- a/dev-lang/luajit/luajit-2.1.9999999999.ebuild
+++ b/dev-lang/luajit/luajit-2.1.9999999999.ebuild
@@ -1,0 +1,79 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+# Upstream doesn't make releases anymore and instead have a (broken) "rolling
+# git tag" model.
+#
+# https://github.com/LuaJIT/LuaJIT/issues/665#issuecomment-784452583
+# https://www.freelists.org/post/luajit/LuaJIT-uses-rolling-releases
+#
+# Regular snapshots should be made from the v2.1 branch. Get the version with
+# `git show -s --format=%ct`
+
+inherit toolchain-funcs
+
+DESCRIPTION="Just-In-Time Compiler for the Lua programming language"
+HOMEPAGE="https://luajit.org/"
+
+if [[ ${PV} == 2.1.9999999999 ]]; then
+	# This is the 2.1 rolling release live build. When a 2.2 or 3.x branch comes
+	# out, create a new ebuild for it.
+	#
+	# Upstream recommends pulling rolling releases from the v2.1 branch.
+	# > The old git master branch is phased out and stays pinned to the v2.0
+	# > branch. Please follow the versioned branches instead.
+	#
+	# See http://luajit.org/status.html for additional information.
+	EGIT_BRANCH="v2.1"
+	EGIT_REPO_URI="https://luajit.org/git/luajit.git"
+	inherit git-r3
+else
+	# Update this commit hash to bump a pinned-commit ebuild.
+	GIT_COMMIT=""
+	SRC_URI="https://github.com/LuaJIT/LuaJIT/archive/${GIT_COMMIT}.tar.gz -> ${P}.tar.gz"
+	S="${WORKDIR}/LuaJIT-${GIT_COMMIT}"
+
+	KEYWORDS="~amd64 ~arm ~arm64 -hppa ~mips ~ppc -riscv -sparc ~x86 ~amd64-linux ~x86-linux"
+fi
+
+LICENSE="MIT"
+# this should probably be pkgmoved to 2.1 for sake of consistency.
+SLOT="2/${PV}"
+IUSE="lua52compat static-libs"
+
+_emake() {
+	emake \
+		Q= \
+		PREFIX="${EPREFIX}/usr" \
+		MULTILIB="$(get_libdir)" \
+		DESTDIR="${D}" \
+		CFLAGS="" \
+		LDFLAGS="" \
+		HOST_CC="$(tc-getBUILD_CC)" \
+		HOST_CFLAGS="${BUILD_CPPFLAGS} ${BUILD_CFLAGS}" \
+		HOST_LDFLAGS="${BUILD_LDFLAGS}" \
+		STATIC_CC="$(tc-getCC)" \
+		DYNAMIC_CC="$(tc-getCC) -fPIC" \
+		TARGET_LD="$(tc-getCC)" \
+		TARGET_CFLAGS="${CPPFLAGS} ${CFLAGS}" \
+		TARGET_LDFLAGS="${LDFLAGS}" \
+		TARGET_AR="$(tc-getAR) rcus" \
+		BUILDMODE="$(usex static-libs mixed dynamic)" \
+		TARGET_STRIP="true" \
+		INSTALL_LIB="${ED}/usr/$(get_libdir)" \
+		"$@"
+}
+
+src_compile() {
+	tc-export_build_env
+	_emake XCFLAGS="$(usex lua52compat "-DLUAJIT_ENABLE_LUA52COMPAT" "")"
+}
+
+src_install() {
+	_emake install
+	dosym luajit-"${PV}" /usr/bin/luajit
+
+	HTML_DOCS="doc/." einstalldocs
+}


### PR DESCRIPTION
This addresses the 9999 request at https://bugs.gentoo.org/843773

Currently, all changes get pushed to v2.1 branch current.

Per http://luajit.org/status.html,

> The old git master branch is phased out and stays pinned to the v2.0 branch. Please follow the versioned branches instead.

I think that tracking v2.1 is in the spirit of the original request anyhow; most people interested in this ebuild will want to have the latest rolling commit of v2.1, and will not want to suddenly be switched to a new incompatible version of luajit. To be consistent, I've versioned it 2.1.9999999999 so we can create a 2.2.9999999999 or 3.0.9999999999 if the time comes. I've included enough nines that we should be good for the next hundred or so years ;)

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
