### PR TITLE
dev-util/watchman: keyword 2024.11.04.00 for ~arm64

### DIFF
--- a/dev-cpp/cpptoml/cpptoml-0.1.1.ebuild
+++ b/dev-cpp/cpptoml/cpptoml-0.1.1.ebuild
@@ -11,7 +11,7 @@ SRC_URI="https://github.com/skystrife/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~amd64"
+KEYWORDS="~amd64 ~arm64"
 IUSE="examples"
 
 PATCHES=(

--- a/dev-cpp/edencommon/edencommon-2024.11.04.00.ebuild
+++ b/dev-cpp/edencommon/edencommon-2024.11.04.00.ebuild
@@ -21,7 +21,7 @@ SRC_URI="https://github.com/facebookexperimental/edencommon/archive/refs/tags/v$
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="~amd64"
+KEYWORDS="~amd64 ~arm64"
 IUSE="llvm-libunwind"
 
 RDEPEND="

--- a/dev-cpp/fast_float/fast_float-6.1.6.ebuild
+++ b/dev-cpp/fast_float/fast_float-6.1.6.ebuild
@@ -11,7 +11,7 @@ SRC_URI="https://github.com/fastfloat/fast_float/archive/refs/tags/v${PV}.tar.gz
 
 LICENSE="|| ( Apache-2.0 Boost-1.0 MIT )"
 SLOT="0"
-KEYWORDS="~amd64 ~ppc64 ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64 ~ppc64 ~riscv ~x86"
 IUSE="test"
 
 BDEPEND="test? ( dev-cpp/doctest )"

--- a/dev-cpp/fb303/fb303-2024.11.04.00.ebuild
+++ b/dev-cpp/fb303/fb303-2024.11.04.00.ebuild
@@ -21,7 +21,7 @@ SRC_URI="https://github.com/facebook/fb303/archive/refs/tags/v${PV}.tar.gz -> ${
 
 LICENSE="Apache-2.0"
 SLOT="0/${PV}"
-KEYWORDS="~amd64"
+KEYWORDS="~amd64 ~arm64"
 IUSE="test"
 
 # See https://github.com/facebook/fb303/issues/61

--- a/dev-cpp/fbthrift/fbthrift-2024.11.04.00.ebuild
+++ b/dev-cpp/fbthrift/fbthrift-2024.11.04.00.ebuild
@@ -21,7 +21,7 @@ SRC_URI="https://github.com/facebook/fbthrift/archive/refs/tags/v${PV}.tar.gz ->
 
 LICENSE="Apache-2.0"
 SLOT="0/${PV}"
-KEYWORDS="~amd64"
+KEYWORDS="~amd64 ~arm64"
 IUSE="test"
 
 # See https://github.com/facebook/fbthrift/issues/628

--- a/dev-cpp/fizz/fizz-2024.11.04.00.ebuild
+++ b/dev-cpp/fizz/fizz-2024.11.04.00.ebuild
@@ -23,7 +23,7 @@ SRC_URI="https://github.com/facebookincubator/fizz/archive/refs/tags/v${PV}.tar.
 
 LICENSE="BSD"
 SLOT="0/${PV}"
-KEYWORDS="~amd64"
+KEYWORDS="~amd64 ~arm64"
 IUSE="test"
 RESTRICT="!test? ( test )"
 

--- a/dev-cpp/folly/folly-2024.11.04.00-r1.ebuild
+++ b/dev-cpp/folly/folly-2024.11.04.00-r1.ebuild
@@ -21,7 +21,7 @@ SRC_URI="https://github.com/facebook/folly/releases/download/v${PV}/${PN}-v${PV}
 
 LICENSE="Apache-2.0"
 SLOT="0/${PV}"
-KEYWORDS="~amd64 ~ppc64"
+KEYWORDS="~amd64 ~arm64 ~ppc64"
 IUSE="llvm-libunwind test"
 RESTRICT="!test? ( test )"
 

--- a/dev-cpp/mvfst/mvfst-2024.11.04.00-r1.ebuild
+++ b/dev-cpp/mvfst/mvfst-2024.11.04.00-r1.ebuild
@@ -21,7 +21,7 @@ SRC_URI="https://github.com/facebook/mvfst/archive/refs/tags/v${PV}.tar.gz -> ${
 
 LICENSE="MIT"
 SLOT="0/${PV}"
-KEYWORDS="~amd64"
+KEYWORDS="~amd64 ~arm64"
 IUSE="test"
 RESTRICT="!test? ( test )"
 

--- a/dev-cpp/wangle/wangle-2024.11.04.00.ebuild
+++ b/dev-cpp/wangle/wangle-2024.11.04.00.ebuild
@@ -23,7 +23,7 @@ SRC_URI="https://github.com/facebook/wangle/archive/refs/tags/v${PV}.tar.gz -> $
 
 LICENSE="Apache-2.0"
 SLOT="0/${PV}"
-KEYWORDS="~amd64"
+KEYWORDS="~amd64 ~arm64"
 IUSE="test"
 
 RESTRICT="!test? ( test )"

--- a/dev-util/watchman/watchman-2024.11.04.00.ebuild
+++ b/dev-util/watchman/watchman-2024.11.04.00.ebuild
@@ -244,7 +244,7 @@ LICENSE="MIT"
 # Dependent crate licenses
 LICENSE+=" Apache-2.0 MIT Unicode-DFS-2016 WTFPL-2"
 SLOT="0"
-KEYWORDS="~amd64"
+KEYWORDS="~amd64 ~arm64"
 IUSE="llvm-libunwind python"
 REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
 


### PR DESCRIPTION
All dependencies with tests were confirmed to pass inside a QEMU chroot.

Depends on #39296.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
