### PR TITLE
dev-db/mariadb: Only force bfd linker when gold linker is used

### DIFF
--- a/dev-db/mariadb/mariadb-10.11.10.ebuild
+++ b/dev-db/mariadb/mariadb-10.11.10.ebuild
@@ -281,7 +281,7 @@ src_configure() {
 	# bug #855233 (MDEV-11914, MDEV-25633) at least
 	filter-lto
 	# bug 508724 mariadb cannot use ld.gold
-	tc-ld-force-bfd
+	tc-ld-is-gold && tc-ld-force-bfd
 	# Bug #114895, bug #110149
 	filter-flags "-O" "-O[01]"
 

--- a/dev-db/mariadb/mariadb-10.6.20.ebuild
+++ b/dev-db/mariadb/mariadb-10.6.20.ebuild
@@ -292,7 +292,7 @@ src_configure() {
 	# bug #855233 (MDEV-11914, MDEV-25633) at least
 	filter-lto
 	# bug 508724 mariadb cannot use ld.gold
-	tc-ld-force-bfd
+	tc-ld-is-gold && tc-ld-force-bfd
 	# Bug #114895, bug #110149
 	filter-flags "-O" "-O[01]"
 

--- a/dev-db/mariadb/mariadb-11.4.4.ebuild
+++ b/dev-db/mariadb/mariadb-11.4.4.ebuild
@@ -281,7 +281,7 @@ src_configure() {
 	# bug #855233 (MDEV-11914, MDEV-25633) at least
 	filter-lto
 	# bug 508724 mariadb cannot use ld.gold
-	tc-ld-force-bfd
+	tc-ld-is-gold && tc-ld-force-bfd
 	# Bug #114895, bug #110149
 	filter-flags "-O" "-O[01]"
 


### PR DESCRIPTION
By silently forcing BFD build failures might happen if users have special LLD link flags in LDFLAGS and there is no reason to force BFD when using LLD (only when using Gold linker)

Fixes: 995a68e3bb9c ("dev-db/mariadb: add 10.6.20")
Fixes: 4ef76f37461d ("dev-db/mariadb: add 10.11.10")
Fixes: a1354b25554e ("dev-db/mariadb: add 11.4.4")

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

I messed up git in last attempt (https://github.com/gentoo/gentoo/pull/39289) and prefered to create a this new PR which addresses all issues
