### PR TITLE
Skip tests for watchman dependencies

### DIFF
--- a/dev-cpp/edencommon/edencommon-2024.11.04.00.ebuild
+++ b/dev-cpp/edencommon/edencommon-2024.11.04.00.ebuild
@@ -13,7 +13,7 @@ EAPI=8
 # dev-cpp/wangle
 # dev-util/watchman
 
-inherit cmake
+inherit cmake toolchain-funcs
 
 DESCRIPTION="Shared library for Watchman and Eden projects"
 HOMEPAGE="https://github.com/facebookexperimental/edencommon"
@@ -46,4 +46,16 @@ src_configure() {
 	)
 
 	cmake_src_configure
+}
+
+src_test() {
+	CMAKE_SKIP_TESTS=()
+
+	# This test fails on GCC 13.
+	# https://github.com/facebookexperimental/edencommon/issues/22
+	if tc-is-gcc && ver_test $(gcc-version) -lt 14.0.0; then
+		CMAKE_SKIP_TESTS+=(PathFuncs.move_or_copy)
+	fi
+
+	cmake_src_test
 }

--- a/dev-cpp/folly/folly-2024.11.04.00-r1.ebuild
+++ b/dev-cpp/folly/folly-2024.11.04.00-r1.ebuild
@@ -90,5 +90,15 @@ src_test() {
 		'concurrency_concurrent_hash_map_test.*'
 	)
 
+	if use arm64; then
+		CMAKE_SKIP_TESTS+=(
+			# Tests are flaky/timing dependent on both QEMU chroot and real hardware
+			io_async_hh_wheel_timer_test.HHWheelTimerTest
+			# Times out on real hardware
+			concurrent_skip_list_test.ConcurrentSkipList
+			futures_retrying_test.RetryingTest.largeRetries
+		)
+	fi
+
 	cmake_src_test
 }

--- a/dev-cpp/folly/folly-2024.11.04.00-r1.ebuild
+++ b/dev-cpp/folly/folly-2024.11.04.00-r1.ebuild
@@ -13,7 +13,7 @@ EAPI=8
 # dev-cpp/wangle
 # dev-util/watchman
 
-inherit cmake
+inherit flag-o-matic cmake
 
 DESCRIPTION="An open-source C++ library developed and used at Facebook"
 HOMEPAGE="https://github.com/facebook/folly"
@@ -74,6 +74,9 @@ src_configure() {
 		# https://github.com/gentoo/gentoo/pull/29393
 		-DCMAKE_LIBRARY_ARCHITECTURE=$(usex amd64 x86_64 ${ARCH})
 	)
+
+	# https://github.com/facebook/folly/issues/1984
+	use arm64 && append-cxxflags "-flax-vector-conversions"
 
 	cmake_src_configure
 }

--- a/dev-cpp/mvfst/mvfst-2024.11.04.00.ebuild
+++ b/dev-cpp/mvfst/mvfst-2024.11.04.00.ebuild
@@ -47,3 +47,16 @@ src_configure() {
 
 	cmake_src_configure
 }
+
+src_test() {
+	if use arm64; then
+		# These tests segfault on arm64.
+		# https://github.com/facebook/mvfst/issues/363
+		CMAKE_SKIP_TESTS=(
+			QuicClientTransportIntegrationTest.ResetClient
+			QuicClientTransportIntegrationTest.TestStatelessResetToken
+		)
+	fi
+
+	cmake_src_test
+}

--- a/dev-cpp/wangle/wangle-2024.11.04.00.ebuild
+++ b/dev-cpp/wangle/wangle-2024.11.04.00.ebuild
@@ -58,5 +58,11 @@ src_test() {
 		SSLContextManagerTest
 	)
 
+	if use arm64; then
+		# This test fails on arm64.
+		# https://github.com/facebook/wangle/issues/241
+		CMAKE_SKIP_TESTS+=(TLSInMemoryTicketProcessorTest)
+	fi
+
 	cmake_src_test
 }


### PR DESCRIPTION
I found these tests to be failing in an arm64 QEMU chroot.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
