### PR TITLE
toolchain.eclass: unconditionally pass --disable-cet on x86

### DIFF
--- a/eclass/toolchain.eclass
+++ b/eclass/toolchain.eclass
@@ -1588,6 +1588,7 @@ toolchain_src_configure() {
 
 		enable_cet_for 'x86_64' 'gnu' 'cet'
 		enable_cet_for 'aarch64' 'gnu' 'standard-branch-protection'
+		[[ ${CTARGET} == i[34567]86-* ]] && confgcc+=( --disable-cet )
 	fi
 
 	if in_iuse systemtap ; then


### PR DESCRIPTION
d6cb7a61dad7e9672a8448597835dbbf9b9e0ccf removed the check that passed --enable-cet or --disable-cet to configure making the script fallback to automagic. The goal was to prevent passing --enable-cet on x86 gnu triples as that would lead to gcc failing to build under crossdev. Note that this specific crossdev cet issue has been solved in crossdev by package.use.mask'ing the cet USE flag for gcc on x86 but targets configured before that can still have the cet USE flag enabled.

Bug: https://bugs.gentoo.org/943332

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
