### PR TITLE
net-analyzer/netdata: Add an upstream patch to fix building with clang-19

### DIFF
--- a/net-analyzer/netdata/files/netdata-dlib-global_optimization-add-template-argument-list.patch
+++ b/net-analyzer/netdata/files/netdata-dlib-global_optimization-add-template-argument-list.patch
@@ -1,0 +1,30 @@
+From 0947215ddb268fef192e45c140c9430f77648166 Mon Sep 17 00:00:00 2001
+From: Drew Risinger <10198051+drewrisinger@users.noreply.github.com>
+Date: Tue, 25 Jun 2024 19:01:12 -0700
+Subject: [PATCH] global_optimization: add template argument list (#2973)
+
+Fixes error (-Wmissing-template-arg-list-after-template-kw) from clang-19 compiler.
+
+Co-authored-by: Drew Risinger <drewrisinger@users.noreply.github.com>
+
+Origin: upstream, https://github.com/davisking/dlib/pull/2973
+---
+ src/ml/dlib/dlib/global_optimization/find_max_global.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/ml/dlib/dlib/global_optimization/find_max_global.h b/src/ml/dlib/dlib/global_optimization/find_max_global.h
+index 12e496e69894..8a05ae9050d4 100644
+--- a/src/ml/dlib/dlib/global_optimization/find_max_global.h
++++ b/src/ml/dlib/dlib/global_optimization/find_max_global.h
+@@ -58,7 +58,7 @@ namespace dlib
+             }
+ 
+             template <typename T>
+-            static auto go(T&& f, const matrix<double,0,1>& a) -> decltype(call_function_and_expand_args<max_unpack-1>::template go(std::forward<T>(f),a))
++            static auto go(T&& f, const matrix<double,0,1>& a) -> decltype(call_function_and_expand_args<max_unpack-1>::template go<T>(std::forward<T>(f),a))
+             {
+                 return call_function_and_expand_args<max_unpack-1>::go(std::forward<T>(f),a);
+             }
+-- 
+2.43.0
+

--- a/net-analyzer/netdata/netdata-1.45.4.ebuild
+++ b/net-analyzer/netdata/netdata-1.45.4.ebuild
@@ -94,6 +94,10 @@ pkg_setup() {
 	linux-info_pkg_setup
 }
 
+PATCHES=(
+	"${FILESDIR}"/${PN}-dlib-global_optimization-add-template-argument-list.patch
+)
+
 src_configure() {
 	# -Werror=strict-aliasing
 	# https://bugs.gentoo.org/927174

--- a/net-analyzer/netdata/netdata-1.46.1.ebuild
+++ b/net-analyzer/netdata/netdata-1.46.1.ebuild
@@ -94,6 +94,10 @@ pkg_setup() {
 	linux-info_pkg_setup
 }
 
+PATCHES=(
+	"${FILESDIR}"/${PN}-dlib-global_optimization-add-template-argument-list.patch
+)
+
 src_configure() {
 	local mycmakeargs=(
 		-DCMAKE_DISABLE_FIND_PACKAGE_Git=TRUE

--- a/net-analyzer/netdata/netdata-1.46.2.ebuild
+++ b/net-analyzer/netdata/netdata-1.46.2.ebuild
@@ -94,6 +94,10 @@ pkg_setup() {
 	linux-info_pkg_setup
 }
 
+PATCHES=(
+	"${FILESDIR}"/${PN}-dlib-global_optimization-add-template-argument-list.patch
+)
+
 src_configure() {
 	local mycmakeargs=(
 		-DCMAKE_DISABLE_FIND_PACKAGE_Git=TRUE

--- a/net-analyzer/netdata/netdata-1.46.3.ebuild
+++ b/net-analyzer/netdata/netdata-1.46.3.ebuild
@@ -94,6 +94,10 @@ pkg_setup() {
 	linux-info_pkg_setup
 }
 
+PATCHES=(
+	"${FILESDIR}"/${PN}-dlib-global_optimization-add-template-argument-list.patch
+)
+
 src_configure() {
 	local mycmakeargs=(
 		-DCMAKE_DISABLE_FIND_PACKAGE_Git=TRUE

--- a/net-analyzer/netdata/netdata-1.47.0.ebuild
+++ b/net-analyzer/netdata/netdata-1.47.0.ebuild
@@ -94,6 +94,10 @@ pkg_setup() {
 	linux-info_pkg_setup
 }
 
+PATCHES=(
+	"${FILESDIR}"/${PN}-dlib-global_optimization-add-template-argument-list.patch
+)
+
 src_configure() {
 	local mycmakeargs=(
 		-DCMAKE_DISABLE_FIND_PACKAGE_Git=TRUE

--- a/net-analyzer/netdata/netdata-1.47.1.ebuild
+++ b/net-analyzer/netdata/netdata-1.47.1.ebuild
@@ -94,6 +94,10 @@ pkg_setup() {
 	linux-info_pkg_setup
 }
 
+PATCHES=(
+	"${FILESDIR}"/${PN}-dlib-global_optimization-add-template-argument-list.patch
+)
+
 src_configure() {
 	local mycmakeargs=(
 		-DCMAKE_DISABLE_FIND_PACKAGE_Git=TRUE

--- a/net-analyzer/netdata/netdata-1.47.2.ebuild
+++ b/net-analyzer/netdata/netdata-1.47.2.ebuild
@@ -94,6 +94,10 @@ pkg_setup() {
 	linux-info_pkg_setup
 }
 
+PATCHES=(
+	"${FILESDIR}"/${PN}-dlib-global_optimization-add-template-argument-list.patch
+)
+
 src_configure() {
 	local mycmakeargs=(
 		-DCMAKE_DISABLE_FIND_PACKAGE_Git=TRUE

--- a/net-analyzer/netdata/netdata-1.47.4.ebuild
+++ b/net-analyzer/netdata/netdata-1.47.4.ebuild
@@ -94,6 +94,10 @@ pkg_setup() {
 	linux-info_pkg_setup
 }
 
+PATCHES=(
+	"${FILESDIR}"/${PN}-dlib-global_optimization-add-template-argument-list.patch
+)
+
 src_configure() {
 	local mycmakeargs=(
 		-DCMAKE_DISABLE_FIND_PACKAGE_Git=TRUE

--- a/net-analyzer/netdata/netdata-1.47.5.ebuild
+++ b/net-analyzer/netdata/netdata-1.47.5.ebuild
@@ -94,6 +94,10 @@ pkg_setup() {
 	linux-info_pkg_setup
 }
 
+PATCHES=(
+	"${FILESDIR}"/${PN}-dlib-global_optimization-add-template-argument-list.patch
+)
+
 src_configure() {
 	local mycmakeargs=(
 		-DCMAKE_DISABLE_FIND_PACKAGE_Git=TRUE

--- a/net-analyzer/netdata/netdata-9999.ebuild
+++ b/net-analyzer/netdata/netdata-9999.ebuild
@@ -94,6 +94,10 @@ pkg_setup() {
 	linux-info_pkg_setup
 }
 
+PATCHES=(
+	"${FILESDIR}"/${PN}-dlib-global_optimization-add-template-argument-list.patch
+)
+
 src_configure() {
 	local mycmakeargs=(
 		-DCMAKE_DISABLE_FIND_PACKAGE_Git=TRUE


### PR DESCRIPTION
Clang has a new warning (`-Wmissing-template-arg-list-after-template-kw`) that requires a template argument list after using the template keyword. The upstream dlib (transcluded into netdata by the means of git submodules) has fixed this issue (https://github.com/davisking/dlib/commit/0947215ddb268fef192e45c140c9430f77648166), but netdata has not yet picked up this change. Instead, apply the change directly to the vendored dlib for all versions affected by this.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
