### PR TITLE
net-wireless/blueman: enable py3.13

### DIFF
--- a/net-wireless/blueman/blueman-2.4.3.ebuild
+++ b/net-wireless/blueman/blueman-2.4.3.ebuild
@@ -6,7 +6,7 @@ EAPI=8
 DISTUTILS_EXT=1
 DISTUTILS_SINGLE_IMPL=1
 DISTUTILS_USE_PEP517=no
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..13} )
 
 inherit autotools distutils-r1 gnome2-utils linux-info systemd xdg-utils
 

--- a/net-wireless/blueman/blueman-9999.ebuild
+++ b/net-wireless/blueman/blueman-9999.ebuild
@@ -6,7 +6,7 @@ EAPI=8
 DISTUTILS_EXT=1
 DISTUTILS_SINGLE_IMPL=1
 DISTUTILS_USE_PEP517=no
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..13} )
 
 inherit autotools distutils-r1 gnome2-utils linux-info systemd xdg-utils
 


### PR DESCRIPTION
```
----------------------------------------------------------------------
Ran 262 tests in 0.638s

OK
>>> Completed testing net-wireless/blueman-2.4.3
```

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
