### PR TITLE
app-portage/mirrorselect: enable py3.13

### DIFF
--- a/app-portage/mirrorselect/mirrorselect-2.5.0.ebuild
+++ b/app-portage/mirrorselect/mirrorselect-2.5.0.ebuild
@@ -4,7 +4,7 @@
 EAPI="8"
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..13} )
 PYTHON_REQ_USE="xml(+)"
 
 inherit edo distutils-r1 prefix

--- a/app-portage/mirrorselect/mirrorselect-9999.ebuild
+++ b/app-portage/mirrorselect/mirrorselect-9999.ebuild
@@ -4,7 +4,7 @@
 EAPI="8"
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..13} )
 PYTHON_REQ_USE="xml(+)"
 
 inherit edo distutils-r1 prefix


### PR DESCRIPTION
```
>>> Test phase: app-portage/mirrorselect-2.5.0
 * python3_13: running distutils-r1_run_phase python_test
python3.13 -m unittest discover -v
test_write_make_conf (tests.test_write_make_conf.WriteMakeConfTestCase.test_write_make_conf) ... ok

----------------------------------------------------------------------
Ran 1 test in 0.023s

OK
>>> Completed testing app-portage/mirrorselect-2.5.0
```
---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
