### PR TITLE
dev-libs/cyrus-sasl: fix #887291 building with LLD

### DIFF
--- a/dev-libs/cyrus-sasl/cyrus-sasl-2.1.28-r5.ebuild
+++ b/dev-libs/cyrus-sasl/cyrus-sasl-2.1.28-r5.ebuild
@@ -117,7 +117,7 @@ multilib_src_configure() {
 		$(use_enable ldapdb)
 		$(multilib_native_use_enable sample)
 		$(use_enable kerberos gssapi)
-		$(multilib_native_use_with mysql mysql "${EPREFIX}"/usr)
+		$(multilib_native_use_with mysql mysql "${EPREFIX}/usr/$(get_libdir)")
 		$(multilib_native_use_with postgres pgsql "${EPREFIX}/usr/$(get_libdir)/postgresql")
 		$(use_with sqlite sqlite3 "${EPREFIX}/usr/$(get_libdir)")
 		$(use_enable srp)


### PR DESCRIPTION
Closes: #887291 

Updates cyrus-sasl to include $(get_libdir) when building with mysql

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
