### PR TITLE
Bugfix/clamd initd set config files

### DIFF
--- a/app-antivirus/clamav/files/clamd.initd
+++ b/app-antivirus/clamav/files/clamd.initd
@@ -2,6 +2,7 @@
 
 # Note: the "Foreground" option in clamd.conf must be set to "no"
 command="/usr/sbin/clamd"
+command_args="-c /etc/clamd.conf"
 extra_started_commands="reload"
 
 # For now, must be manually synchronized with the PidFile variable

--- a/app-antivirus/clamav/files/freshclam.initd
+++ b/app-antivirus/clamav/files/freshclam.initd
@@ -4,5 +4,5 @@ command="/usr/bin/freshclam"
 pidfile="/run/${RC_SVCNAME}.pid"
 
 # Ignore the value of "PidFile" set in freshclam.conf.
-command_args="-p ${pidfile}"
+command_args="-p ${pidfile} --config-file /etc/freshclam.conf"
 command_args_background="--daemon"


### PR DESCRIPTION
Somehow clamav-1.4.1-r2 does not read its config files by default as it used to be. Running on default/linux/amd64/23.0/split-usr with initd. Noticed after recompiling and restarting.
Fixed by explicitly starting daemons with config file path in init file of clamd and freshclam.

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
