### PR TITLE
app-shells/nushell: Fix plugin compilation

### DIFF
--- a/app-shells/nushell/nushell-0.100.0.ebuild
+++ b/app-shells/nushell/nushell-0.100.0.ebuild
@@ -762,6 +762,10 @@ src_compile() {
 src_install() {
 	cargo_src_install
 	if use plugins ; then
+		# Clear features to compile plugins
+		local myfeatures=()
+		cargo_src_configure
+		
 		cargo_src_install --path crates/nu_plugin_custom_values
 		cargo_src_install --path crates/nu_plugin_example
 		cargo_src_install --path crates/nu_plugin_formats

--- a/app-shells/nushell/nushell-0.99.1.ebuild
+++ b/app-shells/nushell/nushell-0.99.1.ebuild
@@ -769,6 +769,10 @@ src_compile() {
 src_install() {
 	cargo_src_install
 	if use plugins ; then
+		# Clear features to compile plugins
+		local myfeatures=()
+		cargo_src_configure
+		
 		cargo_src_install --path crates/nu_plugin_custom_values
 		cargo_src_install --path crates/nu_plugin_example
 		cargo_src_install --path crates/nu_plugin_formats


### PR DESCRIPTION
Plugins failed to compile when the USE flag 'system-clipboard' was enabled, because for the plugins this Cargo feature does not exist. This fix clears the 'myfeatures' variable and configures again before the plugins are compiled.

Closes: https://bugs.gentoo.org/943627

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
