### PR TITLE
*/*: use https, minor ebuild improvements

### DIFF
--- a/app-admin/logmon/logmon-0.4.4-r1.ebuild
+++ b/app-admin/logmon/logmon-0.4.4-r1.ebuild
@@ -7,8 +7,8 @@ inherit autotools flag-o-matic
 
 MY_P="LogMon-${PV}"
 DESCRIPTION="Split-screen terminal/ncurses based log viewer"
-HOMEPAGE="http://www.edespot.com/logmon/"
-SRC_URI="http://www.edespot.com/logmon/files/${MY_P}.tar.bz2 -> ${P}.r1.tar.bz2"
+HOMEPAGE="https://www.edespot.com/logmon/"
+SRC_URI="https://www.edespot.com/logmon/files/${MY_P}.tar.bz2 -> ${P}.r1.tar.bz2"
 S="${WORKDIR}/${PV}/${MY_P}"
 
 LICENSE="Artistic"

--- a/app-admin/logmon/logmon-0.4.4-r2.ebuild
+++ b/app-admin/logmon/logmon-0.4.4-r2.ebuild
@@ -7,8 +7,8 @@ inherit autotools flag-o-matic
 
 MY_P="LogMon-${PV}"
 DESCRIPTION="Split-screen terminal/ncurses based log viewer"
-HOMEPAGE="http://www.edespot.com/logmon/"
-SRC_URI="http://www.edespot.com/logmon/files/${MY_P}.tar.bz2"
+HOMEPAGE="https://www.edespot.com/logmon/"
+SRC_URI="https://www.edespot.com/logmon/files/${MY_P}.tar.bz2"
 S="${WORKDIR}/${PV}/${MY_P}"
 
 LICENSE="Artistic"

--- a/dev-util/cunit/cunit-2.1_p3-r1.ebuild
+++ b/dev-util/cunit/cunit-2.1_p3-r1.ebuild
@@ -10,7 +10,7 @@ MY_PV="${PV/_p*}-3"
 MY_P="${MY_PN}-${MY_PV}"
 
 DESCRIPTION="C Unit Test Framework"
-HOMEPAGE="http://cunit.sourceforge.net"
+HOMEPAGE="https://cunit.sourceforge.net"
 SRC_URI="https://downloads.sourceforge.net/cunit/${MY_P}.tar.bz2"
 
 LICENSE="LGPL-2"

--- a/dev-util/tmake/tmake-2.12-r2.ebuild
+++ b/dev-util/tmake/tmake-2.12-r2.ebuild
@@ -3,14 +3,13 @@
 
 EAPI=8
 
-DESCRIPTION="A Cross platform Makefile tool"
+DESCRIPTION="Cross platform Makefile tool"
+HOMEPAGE="https://tmake.sourceforge.net"
 SRC_URI="https://downloads.sourceforge.net/tmake/${P}.tar.bz2"
-HOMEPAGE="http://tmake.sourceforge.net"
 
 LICENSE="HPND"
 SLOT="0"
 KEYWORDS="amd64 ppc x86 ~x86-linux ~ppc-macos"
-IUSE=""
 
 RDEPEND=">=dev-lang/perl-5"
 

--- a/media-gfx/solvespace/metadata.xml
+++ b/media-gfx/solvespace/metadata.xml
@@ -15,4 +15,7 @@
     <use>
         <flag name="system-mimalloc">Use system <pkg>dev-libs/mimalloc</pkg> instead of vendored library</flag>
     </use>
+    <upstream>
+        <remote-id type="github">solvespace/solvespace</remote-id>
+    </upstream>
 </pkgmetadata>

--- a/media-gfx/solvespace/solvespace-3.1-r1.ebuild
+++ b/media-gfx/solvespace/solvespace-3.1-r1.ebuild
@@ -18,7 +18,7 @@ MIMALLOC_P="mimalloc-${MIMALLOC_PV}-${MIMALLOC_COMMIT}"
 inherit cmake toolchain-funcs xdg
 
 DESCRIPTION="Parametric 2d/3d CAD"
-HOMEPAGE="http://solvespace.com"
+HOMEPAGE="https://solvespace.com"
 SRC_URI="https://github.com/solvespace/solvespace/archive/v${PV}.tar.gz -> ${P}.tar.gz
 	https://github.com/solvespace/libdxfrw/archive/${DXFRW_COMMIT}.tar.gz -> ${DXFRW_P}.tar.gz
 	!system-mimalloc? ( https://github.com/microsoft/mimalloc/archive/${MIMALLOC_COMMIT}.tar.gz -> ${MIMALLOC_P}.tar.gz )"
@@ -29,10 +29,10 @@ SRC_URI="https://github.com/solvespace/solvespace/archive/v${PV}.tar.gz -> ${P}.
 # + libdxfrw (GPL-2+)
 # + mimalloc (MIT)
 
-IUSE="openmp +system-mimalloc"
-KEYWORDS="amd64 ~arm64 ~x86"
 LICENSE="BitstreamVera GPL-2+ GPL-3+ !system-mimalloc? ( MIT )"
 SLOT="0"
+KEYWORDS="amd64 ~arm64 ~x86"
+IUSE="openmp +system-mimalloc"
 
 RDEPEND="
 	dev-cpp/atkmm:0

--- a/media-gfx/wings/wings-2.2.6.1.ebuild
+++ b/media-gfx/wings/wings-2.2.6.1.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 inherit toolchain-funcs
 
 DESCRIPTION="Wings 3D is an advanced subdivision modeler"
-HOMEPAGE="http://www.wings3d.com/"
+HOMEPAGE="https://www.wings3d.com/"
 SRC_URI="https://downloads.sourceforge.net/wings/${P}.tar.bz2"
 
 LICENSE="BSD"

--- a/media-gfx/wings/wings-2.3.ebuild
+++ b/media-gfx/wings/wings-2.3.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 inherit toolchain-funcs
 
 DESCRIPTION="Wings 3D is an advanced subdivision modeler"
-HOMEPAGE="http://www.wings3d.com/"
+HOMEPAGE="https://www.wings3d.com/"
 SRC_URI="https://downloads.sourceforge.net/wings/${P}.tar.bz2"
 
 LICENSE="BSD"

--- a/media-libs/libsidplay/libsidplay-1.36.59-r3.ebuild
+++ b/media-libs/libsidplay/libsidplay-1.36.59-r3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -12,9 +12,6 @@ SRC_URI="http://critical.ch/distfiles/${P}.tgz"
 LICENSE="GPL-2"
 SLOT="1"
 KEYWORDS="~alpha amd64 ~arm64 ~hppa ppc ppc64 ~riscv sparc x86"
-IUSE=""
-DEPEND=""
-RDEPEND=""
 
 DOCS=( AUTHORS DEVELOPER )
 PATCHES=(

--- a/media-libs/libsidplay/libsidplay-2.1.1-r7.ebuild
+++ b/media-libs/libsidplay/libsidplay-2.1.1-r7.ebuild
@@ -8,8 +8,9 @@ inherit autotools flag-o-matic multilib-minimal
 MY_P=sidplay-libs-${PV}
 
 DESCRIPTION="C64 SID player library"
-HOMEPAGE="http://sidplay2.sourceforge.net/"
+HOMEPAGE="https://sidplay2.sourceforge.net/"
 SRC_URI="https://downloads.sourceforge.net/sidplay2/${MY_P}.tar.gz"
+S="${WORKDIR}/${MY_P}"
 
 LICENSE="GPL-2"
 SLOT="2"
@@ -32,8 +33,6 @@ PATCHES=(
 	"${FILESDIR}"/${P}-slibtool.patch
 	"${FILESDIR}"/${P}-clang16.patch
 )
-
-S="${WORKDIR}/${MY_P}"
 
 src_prepare() {
 	default

--- a/media-sound/podracer/podracer-1.4-r3.ebuild
+++ b/media-sound/podracer/podracer-1.4-r3.ebuild
@@ -3,8 +3,8 @@
 
 EAPI=8
 
-DESCRIPTION="A simple podcast aggregator, designed for cron"
-HOMEPAGE="http://podracer.sourceforge.net/"
+DESCRIPTION="Simple podcast aggregator, designed for cron"
+HOMEPAGE="https://podracer.sourceforge.net/"
 SRC_URI="https://downloads.sourceforge.net/${PN}/${P}.tar.bz2"
 
 LICENSE="MIT"


### PR DESCRIPTION
Just a few `HOMEPAGE` updates to use `https` instead of `http`. Also fixed a few ebuild style issues


---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
