### PR TITLE
app-text/msort: c23 porting

### DIFF
--- a/app-text/msort/files/msort-8.53-fix-missing-prototypes.patch
+++ b/app-text/msort/files/msort-8.53-fix-missing-prototypes.patch
@@ -1,0 +1,21 @@
+--- msort-8.53.orig/configure.ac	2024-11-17 17:40:59.811316465 +0000
++++ msort-8.53/configure.ac	2024-11-17 17:44:22.697222141 +0000
+@@ -3,6 +3,8 @@
+ AM_CONFIG_HEADER([config.h])
+ AM_INIT_AUTOMAKE
+ 
++AC_USE_SYSTEM_EXTENSIONS
++
+ AC_DEFUN([AC_C_LONG_LONG],
+ [AC_CACHE_CHECK(for long long int, ac_cv_c_long_long,
+ [if test "$GCC" = yes; then
+--- msort-8.53.orig/misc.c	2024-11-17 17:40:59.812316460 +0000
++++ msort-8.53/misc.c	2024-11-17 17:42:50.841717590 +0000
+@@ -419,7 +419,6 @@
+ OpenFile(char *file,char *mode,char *pgname)
+ {
+   FILE *fp;
+-  extern FILE *fopen();
+    
+   if((fp = fopen(file,mode)) != NULL) return fp;
+   else{

--- a/app-text/msort/msort-8.53-r3.ebuild
+++ b/app-text/msort/msort-8.53-r3.ebuild
@@ -1,0 +1,48 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools
+
+DESCRIPTION="A program for sorting files in sophisticated ways"
+HOMEPAGE="https://billposer.org/Software/msort.html"
+SRC_URI="https://billposer.org/Software/Downloads/${P}.tar.bz2"
+
+KEYWORDS="~amd64 ~x86"
+LICENSE="GPL-3 LGPL-3"
+SLOT="0"
+IUSE="heap +icu +libuninum"
+
+RDEPEND="dev-libs/tre
+	icu? ( dev-libs/icu:= )
+	!icu? ( dev-libs/libutf8proc:= )
+	libuninum? ( dev-libs/libuninum:= )"
+
+DEPEND="${RDEPEND}"
+
+PATCHES=(
+	"${FILESDIR}/${P}-fix-icu-build.patch"
+	"${FILESDIR}/${P}-fix-missing-limits-header.patch"
+	"${FILESDIR}/${P}-fix-segfault-on-certain-input.patch"
+	"${FILESDIR}/${P}-respect-users-cflags.patch"
+	"${FILESDIR}/${P}-configure-clang16.patch"
+	"${FILESDIR}/${P}-fix-missing-prototypes.patch"
+)
+
+src_prepare() {
+	default
+
+	eautoreconf
+}
+
+src_configure() {
+	local myeconfargs=(
+		$(use_enable !heap allocaok)
+		$(use_enable !icu utf8proc)
+		$(use_enable libuninum uninum)
+		--disable-debugbuild
+	)
+
+	econf "${myeconfargs[@]}"
+}


### PR DESCRIPTION
Remove erroneous extern, fix configure so it enables fopen()

Bug: https://bugs.gentoo.org/880333

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
