### PR TITLE
media-sound/klick: use boost::bind instead of std::bind2nd

### DIFF
--- a/media-sound/klick/files/klick-0.12.2-use-boost-bind.patch
+++ b/media-sound/klick/files/klick-0.12.2-use-boost-bind.patch
@@ -1,0 +1,34 @@
+From c3be3e56aa1bdb6689a5b5642e0119c8602f2263 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Dominic=20Sacr=C3=A9?= <dominic.sacre@gmx.de>
+Date: Mon, 14 Jan 2013 14:26:06 +0000
+Subject: [PATCH] use boost::bind instead of std::bind2nd
+
+git-svn-id: svn+ssh://kobol/srv/svn/klick/trunk@262 c380f6eb-e629-0410-afc2-bdd98b771d42
+---
+ src/tempomap.cc | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/tempomap.cc b/src/tempomap.cc
+index ea00ae2..23834f9 100644
+--- a/src/tempomap.cc
++++ b/src/tempomap.cc
+@@ -21,6 +21,7 @@
+ #include <boost/tokenizer.hpp>
+ #include <functional>
+ #include <algorithm>
++#include <boost/bind.hpp>
+ 
+ #include "util/string.hh"
+ #include "util/regex.hh"
+@@ -147,7 +148,7 @@ std::vector<float> TempoMap::parse_tempi(std::string const &s, float tempo1, int
+ void TempoMap::check_entry(Entry const & e)
+ {
+     if ((e.tempo <= 0 && e.tempi.empty()) ||
+-        std::find_if(e.tempi.begin(), e.tempi.end(), std::bind2nd(std::less_equal<float>(), 0.0f)) != e.tempi.end()) {
++        std::find_if(e.tempi.begin(), e.tempi.end(), boost::bind(std::less_equal<float>(), _1, 0.0f)) != e.tempi.end()) {
+         throw ParseError("tempo must be greater than zero");
+     }
+     if (e.bars <= 0 && e.bars != -1) {
+-- 
+2.45.2
+

--- a/media-sound/klick/klick-0.12.2-r5.ebuild
+++ b/media-sound/klick/klick-0.12.2-r5.ebuild
@@ -1,0 +1,55 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+PYTHON_COMPAT=( python3_{10..12} )
+
+inherit python-any-r1 scons-utils toolchain-funcs
+
+DESCRIPTION="An advanced command-line based metronome for JACK"
+HOMEPAGE="https://das.nasophon.de/klick/"
+SRC_URI="https://das.nasophon.de/download/${P}.tar.gz"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86"
+IUSE="debug osc rubberband"
+
+RDEPEND="media-libs/libsamplerate
+	media-libs/libsndfile
+	virtual/jack
+	osc? ( media-libs/liblo )
+	rubberband? ( media-libs/rubberband )"
+DEPEND="${RDEPEND}
+	dev-libs/boost"
+BDEPEND="virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-sconstruct.patch
+	"${FILESDIR}"/${P}-gcc6.patch
+	"${FILESDIR}"/${P}-use-boost-bind.patch
+)
+
+HTML_DOCS=( doc/manual.html )
+
+src_configure() {
+	MYSCONS=(
+		CXX="$(tc-getCXX)"
+		CXXFLAGS="${CXXFLAGS}"
+		LINKFLAGS="${LDFLAGS}"
+		PREFIX="${EPREFIX}/usr"
+		DEBUG=$(usex debug)
+		OSC=$(usex osc)
+		RUBBERBAND=$(usex rubberband)
+	)
+}
+
+src_compile() {
+	escons "${MYSCONS[@]}"
+}
+
+src_install() {
+	escons "${MYSCONS[@]}" DESTDIR="${D}" install
+	einstalldocs
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/929094

---

Please check all the boxes that apply:

- [ ] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [ ] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [ ] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
