### PR TITLE
sci-libs/caffe2: adjust cutlass dep constraint

### DIFF
--- a/sci-libs/caffe2/caffe2-2.4.0-r1.ebuild
+++ b/sci-libs/caffe2/caffe2-2.4.0-r1.ebuild
@@ -96,7 +96,7 @@ RDEPEND="
 "
 DEPEND="
 	${RDEPEND}
-	cuda? ( >=dev-libs/cutlass-3.4.1 )
+	cuda? ( <=dev-libs/cutlass-3.4.1 )
 	onednn? ( sci-libs/ideep )
 	dev-libs/psimd
 	dev-libs/FP16

--- a/sci-libs/caffe2/caffe2-2.4.1-r4.ebuild
+++ b/sci-libs/caffe2/caffe2-2.4.1-r4.ebuild
@@ -100,7 +100,7 @@ RDEPEND="
 DEPEND="
 	${RDEPEND}
 	dev-libs/clog
-	cuda? ( >=dev-libs/cutlass-3.4.1 )
+	cuda? ( <=dev-libs/cutlass-3.4.1 )
 	onednn? ( sci-libs/ideep )
 	dev-libs/psimd
 	dev-libs/FP16


### PR DESCRIPTION
With USE `cuda`, does not build with cutlass 3.5.1. Gets this error a few times:

```
/usr/include/cutlass/epilogue/fusion/sm90_visitor_load_tma_warpspecialized.hpp(566): error: static assertion failed with "Row broadcast doesn't support smem usage"
    static_assert(Stages == 0, "Row broadcast doesn't support smem usage");
    ^
          detected during:
            instantiation of class "cutlass::epilogue::fusion::Sm90RowBroadcast<Stages, CtaTileShapeMNK, Element, StrideMNL, Alignment, EnableNullptr> [with Stages=1, CtaTileShapeMNK=cute::tuple<cute::_64, cute::_128, cute::_128>, Element=cutlass::bfloat16_t, StrideMNL=cute::tuple<cute::_0, cute::_1, cute::_0>, Alignment=8, EnableNullptr=true]" at line 909 of /usr/include/cutlass/epilogue/fusion/sm90_visitor_tma_warpspecialized.hpp
            instantiation of class "cutlass::epilogue::fusion::detail::Sm90VisitorImplBase<Op0, Op1, Op2> [with Op0=cutlass::epilogue::fusion::Sm90RowBroadcast<1, cute::tuple<cute::_64, cute::_128, cute::_128>, cutlass::bfloat16_t, cute::tuple<cute::_0, cute::_1, cute::_0>, 8, true>, Op1=cutlass::epilogue::fusion::Sm90TreeVisitor<<unnamed>::Multiply, cutlass::epilogue::fusion::Sm90ColBroadcast<0, cute::tuple<cute::_64, cute::_128, cute::_128>, <unnamed>::DtypeScale, cute::tuple<cute::_1, cute::_0, cute::C<0>>, 4, true>, cutlass::epilogue::fusion::Sm90TreeVisitor<<unnamed>::Multiply, cutlass::epilogue::fusion::Sm90RowBroadcast<1, cute::tuple<cute::_64, cute::_128, cute::_128>, <unnamed>::DtypeScale, cute::tuple<cute::_0, cute::_1, cute::_0>, 4, true>, cutlass::epilogue::fusion::Sm90AccFetch>>, Op2=<unnamed>::Add]" at line 305 of /usr/include/cutlass/epilogue/fusion/sm90_visitor_tma_warpspecialized.hpp
            instantiation of class "cutlass::epilogue::fusion::detail::Sm90VisitorImpl<Ops...> [with Ops=<cutlass::epilogue::fusion::Sm90RowBroadcast<1, cute::tuple<cute::_64, cute::_128, cute::_128>, cutlass::bfloat16_t, cute::tuple<cute::_0, cute::_1, cute::_0>, 8, true>, cutlass::epilogue::fusion::Sm90TreeVisitor<<unnamed>::Multiply, cutlass::epilogue::fusion::Sm90ColBroadcast<0, cute::tuple<cute::_64, cute::_128, cute::_128>, <unnamed>::DtypeScale, cute::tuple<cute::_1, cute::_0, cute::C<0>>, 4, true>, cutlass::epilogue::fusion::Sm90TreeVisitor<<unnamed>::Multiply, cutlass::epilogue::fusion::Sm90RowBroadcast<1, cute::tuple<cute::_64, cute::_128, cute::_128>, <unnamed>::DtypeScale, cute::tuple<cute::_0, cute::_1, cute::_0>, 4, true>, cutlass::epilogue::fusion::Sm90AccFetch>>, <unnamed>::Add>]" at line 564 of /usr/include/cutlass/epilogue/fusion/sm90_visitor_tma_warpspecialized.hpp
            instantiation of class "cutlass::epilogue::fusion::Sm90TreeVisitor<NodeOp, ChildOps...> [with NodeOp=<unnamed>::Add, ChildOps=<cutlass::epilogue::fusion::Sm90RowBroadcast<1, cute::tuple<cute::_64, cute::_128, cute::_128>, cutlass::bfloat16_t, cute::tuple<cute::_0, cute::_1, cute::_0>, 8, true>, cutlass::epilogue::fusion::Sm90TreeVisitor<<unnamed>::Multiply, cutlass::epilogue::fusion::Sm90ColBroadcast<0, cute::tuple<cute::_64, cute::_128, cute::_128>, <unnamed>::DtypeScale, cute::tuple<cute::_1, cute::_0, cute::C<0>>, 4, true>, cutlass::epilogue::fusion::Sm90TreeVisitor<<unnamed>::Multiply, cutlass::epilogue::fusion::Sm90RowBroadcast<1, cute::tuple<cute::_64, cute::_128, cute::_128>, <unnamed>::DtypeScale, cute::tuple<cute::_0, cute::_1, cute::_0>, 4, true>, cutlass::epilogue::fusion::Sm90AccFetch>>>]" at line 821 of /usr/include/cutlass/epilogue/fusion/sm90_visitor_tma_warpspecialized.hpp
            instantiation of class "cutlass::epilogue::fusion::detail::Sm90VisitorImplBase<Op0, Op1> [with Op0=cutlass::epilogue::fusion::Sm90TreeVisitor<<unnamed>::Add, cutlass::epilogue::fusion::Sm90RowBroadcast<1, cute::tuple<cute::_64, cute::_128, cute::_128>, cutlass::bfloat16_t, cute::tuple<cute::_0, cute::_1, cute::_0>, 8, true>, cutlass::epilogue::fusion::Sm90TreeVisitor<<unnamed>::Multiply, cutlass::epilogue::fusion::Sm90ColBroadcast<0, cute::tuple<cute::_64, cute::_128, cute::_128>, <unnamed>::DtypeScale, cute::tuple<cute::_1, cute::_0, cute::C<0>>, 4, true>, cutlass::epilogue::fusion::Sm90TreeVisitor<<unnamed>::Multiply, cutlass::epilogue::fusion::Sm90RowBroadcast<1, cute::tuple<cute::_64, cute::_128, cute::_128>, <unnamed>::DtypeScale, cute::tuple<cute::_0, cute::_1, cute::_0>, 4, true>, cutlass::epilogue::fusion::Sm90AccFetch>>>, Op1=<unnamed>::Cast]" at line 305 of /usr/include/cutlass/epilogue/fusion/sm90_visitor_tma_warpspecialized.hpp
            [ 5 instantiation contexts not shown ]
            instantiation of "void <unnamed>::dispatch_fp8_rowwise_kernel_on_tile_size<ClusterShape,Types...>(at::Tensor, at::Tensor, at::Tensor, at::Tensor, std::optional<at::Tensor>, at::Tensor) [with ClusterShape=cute::tuple<cute::_1, cute::_2, cute::_1>, Types=<std::false_type, std::true_type, cutlass::float_e5m2_t, cutlass::float_e4m3_t, cutlass::bfloat16_t>]" at line 357 of /var/tmp/portage/sci-libs/caffe2-2.5.1-r2/work/pytorch-2.5.1/aten/src/ATen/native/cuda/RowwiseScaledMM.cu
            instantiation of "void <unnamed>::handle_transposition<ClusterShape,Transposed,FastAccum,DtypeA,DtypeB,DtypeBias>(at::Tensor, at::Tensor, at::Tensor, at::Tensor, std::optional<at::Tensor>, at::Tensor) [with ClusterShape=cute::tuple<cute::_1, cute::_2, cute::_1>, Transposed=std::false_type, FastAccum=std::true_type, DtypeA=cutlass::float_e5m2_t, DtypeB=cutlass::float_e4m3_t, DtypeBias=cutlass::bfloat16_t]" at line 390 of /var/tmp/portage/sci-libs/caffe2-2.5.1-r2/work/pytorch-2.5.1/aten/src/ATen/native/cuda/RowwiseScaledMM.cu
            instantiation of "void <unnamed>::dispatch_fp8_rowwise_kernel_on_cluster_size_and_transpose<Types...>(at::Tensor, at::Tensor, at::Tensor, at::Tensor, std::optional<at::Tensor>, at::Tensor) [with Types=<std::true_type, cutlass::float_e5m2_t, cutlass::float_e4m3_t, cutlass::bfloat16_t>]" at line 466 of /var/tmp/portage/sci-libs/caffe2-2.5.1-r2/work/pytorch-2.5.1/aten/src/ATen/native/cuda/RowwiseScaledMM.cu
            instantiation of "void <unnamed>::dispatch_fp8_rowwise_kernel_on_fast_accum<Types...>(at::Tensor, at::Tensor, at::Tensor, at::Tensor, std::optional<at::Tensor>, __nv_bool, at::Tensor) [with Types=<cutlass::float_e5m2_t, cutlass::float_e4m3_t, cutlass::bfloat16_t>]" at line 487 of /var/tmp/portage/sci-libs/caffe2-2.5.1-r2/work/pytorch-2.5.1/aten/src/ATen/native/cuda/RowwiseScaledMM.cu
            instantiation of "void <unnamed>::dispatch_fp8_rowwise_kernel_on_input_dtypes<Types...>(at::Tensor, at::Tensor, at::Tensor, at::Tensor, std::optional<at::Tensor>, __nv_bool, at::Tensor) [with Types=<cutlass::bfloat16_t>]" at line 505 of /var/tmp/portage/sci-libs/caffe2-2.5.1-r2/work/pytorch-2.5.1/aten/src/ATen/native/cuda/RowwiseScaledMM.cu
```

Signed-off-by: Andrew Udvare <audvare@gmail.com>

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
