### PR TITLE
gui-apps/waybar: add patch for tray icons

### DIFF
--- a/gui-apps/waybar/files/tray-icons-fix.patch
+++ b/gui-apps/waybar/files/tray-icons-fix.patch
@@ -1,0 +1,99 @@
+diff --git a/src/modules/sni/item.cpp b/src/modules/sni/item.cpp
+index 8afb39fb3..6c4ec8c06 100644
+--- a/src/modules/sni/item.cpp
++++ b/src/modules/sni/item.cpp
+@@ -104,11 +104,9 @@ void Item::proxyReady(Glib::RefPtr<Gio::AsyncResult>& result) {
+     this->updateImage();
+ 
+   } catch (const Glib::Error& err) {
+-    spdlog::error("Failed to create DBus Proxy for {} {}: {}", bus_name, object_path,
+-                  std::string(err.what()));
++    spdlog::error("Failed to create DBus Proxy for {} {}: {}", bus_name, object_path, err.what());
+   } catch (const std::exception& err) {
+-    spdlog::error("Failed to create DBus Proxy for {} {}: {}", bus_name, object_path,
+-                  std::string(err.what()));
++    spdlog::error("Failed to create DBus Proxy for {} {}: {}", bus_name, object_path, err.what());
+   }
+ }
+ 
+@@ -126,15 +124,14 @@ ToolTip get_variant<ToolTip>(const Glib::VariantBase& value) {
+   result.text = get_variant<Glib::ustring>(container.get_child(2));
+   auto description = get_variant<Glib::ustring>(container.get_child(3));
+   if (!description.empty()) {
+-    result.text = fmt::format("<b>{}</b>\n{}", std::string(result.text), std::string(description));
++    result.text = fmt::format("<b>{}</b>\n{}", result.text, description);
+   }
+   return result;
+ }
+ 
+ void Item::setProperty(const Glib::ustring& name, Glib::VariantBase& value) {
+   try {
+-    spdlog::trace("Set tray item property: {}.{} = {}", id.empty() ? bus_name : id,
+-                  std::string(name), get_variant<std::string>(value));
++    spdlog::trace("Set tray item property: {}.{} = {}", id.empty() ? bus_name : id, name, value);
+ 
+     if (name == "Category") {
+       category = get_variant<std::string>(value);
+@@ -179,12 +176,10 @@ void Item::setProperty(const Glib::ustring& name, Glib::VariantBase& value) {
+     }
+   } catch (const Glib::Error& err) {
+     spdlog::warn("Failed to set tray item property: {}.{}, value = {}, err = {}",
+-                 id.empty() ? bus_name : id, std::string(name), get_variant<std::string>(value),
+-                 std::string(err.what()));
++                 id.empty() ? bus_name : id, name, value, err.what());
+   } catch (const std::exception& err) {
+     spdlog::warn("Failed to set tray item property: {}.{}, value = {}, err = {}",
+-                 id.empty() ? bus_name : id, std::string(name), get_variant<std::string>(value),
+-                 std::string(err.what()));
++                 id.empty() ? bus_name : id, name, value, err.what());
+   }
+ }
+ 
+@@ -226,9 +221,9 @@ void Item::processUpdatedProperties(Glib::RefPtr<Gio::AsyncResult>& _result) {
+ 
+     this->updateImage();
+   } catch (const Glib::Error& err) {
+-    spdlog::warn("Failed to update properties: {}", std::string(err.what()));
++    spdlog::warn("Failed to update properties: {}", err.what());
+   } catch (const std::exception& err) {
+-    spdlog::warn("Failed to update properties: {}", std::string(err.what()));
++    spdlog::warn("Failed to update properties: {}", err.what());
+   }
+   update_pending_.clear();
+ }
+@@ -250,7 +245,7 @@ static const std::map<std::string_view, std::set<std::string_view>> signal2props
+ 
+ void Item::onSignal(const Glib::ustring& sender_name, const Glib::ustring& signal_name,
+                     const Glib::VariantContainerBase& arguments) {
+-  spdlog::trace("Tray item '{}' got signal {}", id, std::string(signal_name));
++  spdlog::trace("Tray item '{}' got signal {}", id, signal_name);
+   auto changed = signal2props.find(signal_name.raw());
+   if (changed != signal2props.end()) {
+     if (update_pending_.empty()) {
+diff --git a/subprojects/fmt.wrap b/subprojects/fmt.wrap
+index 42b615963..fd508477f 100644
+--- a/subprojects/fmt.wrap
++++ b/subprojects/fmt.wrap
+@@ -1,13 +1,13 @@
+ [wrap-file]
+-directory = fmt-11.0.1
+-source_url = https://github.com/fmtlib/fmt/archive/11.0.1.tar.gz
+-source_filename = fmt-11.0.1.tar.gz
+-source_hash = 7d009f7f89ac84c0a83f79ed602463d092fbf66763766a907c97fd02b100f5e9
+-patch_filename = fmt_11.0.1-1_patch.zip
+-patch_url = https://wrapdb.mesonbuild.com/v2/fmt_11.0.1-1/get_patch
+-patch_hash = 0a8b93d1ee6d84a82d3872a9bfb4c3977d8a53f7f484d42d1f7ed63ed496d549
+-source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/fmt_11.0.1-1/fmt-11.0.1.tar.gz
+-wrapdb_version = 11.0.1-1
++directory = fmt-11.0.2
++source_url = https://github.com/fmtlib/fmt/archive/11.0.2.tar.gz
++source_filename = fmt-11.0.2.tar.gz
++source_hash = 6cb1e6d37bdcb756dbbe59be438790db409cdb4868c66e888d5df9f13f7c027f
++patch_filename = fmt_11.0.2-1_patch.zip
++patch_url = https://wrapdb.mesonbuild.com/v2/fmt_11.0.2-1/get_patch
++patch_hash = 90c9e3b8e8f29713d40ca949f6f93ad115d78d7fb921064112bc6179e6427c5e
++source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/fmt_11.0.2-1/fmt-11.0.2.tar.gz
++wrapdb_version = 11.0.2-1
+ 
+ [provide]
+ fmt = fmt_dep

--- a/gui-apps/waybar/waybar-0.11.0-r1.ebuild
+++ b/gui-apps/waybar/waybar-0.11.0-r1.ebuild
@@ -1,0 +1,105 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit meson
+
+DESCRIPTION="Highly customizable Wayland bar for Sway and Wlroots based compositors"
+HOMEPAGE="https://github.com/Alexays/Waybar"
+
+if [[ ${PV} == 9999 ]]; then
+	inherit git-r3
+	EGIT_REPO_URI="https://github.com/Alexays/${PN^}.git"
+else
+	SRC_URI="https://github.com/Alexays/${PN^}/archive/${PV}.tar.gz -> ${P}.tar.gz"
+	KEYWORDS="~amd64 ~arm64"
+	S="${WORKDIR}/${PN^}-${PV}"
+fi
+
+LICENSE="MIT"
+SLOT="0"
+IUSE="evdev experimental jack +libinput +logind mpd mpris network pipewire pulseaudio sndio systemd test tray +udev upower wifi"
+REQUIRED_USE="
+	upower? ( logind )
+"
+
+RESTRICT="!test? ( test )"
+
+BDEPEND="
+	>=app-text/scdoc-1.9.2
+	dev-util/gdbus-codegen
+	dev-util/wayland-scanner
+	virtual/pkgconfig
+"
+RDEPEND="
+	dev-cpp/cairomm:0
+	dev-cpp/glibmm:2
+	dev-cpp/gtkmm:3.0
+	dev-libs/glib:2
+	dev-libs/jsoncpp:=
+	dev-libs/libsigc++:2
+	>=dev-libs/libfmt-8.1.1:=
+	>=dev-libs/spdlog-1.10.0:=
+	dev-libs/date:=
+	dev-libs/wayland
+	gui-libs/gtk-layer-shell
+	media-video/pipewire:=
+	x11-libs/gtk+:3[wayland]
+	x11-libs/libxkbcommon
+	evdev? ( dev-libs/libevdev )
+	jack? ( virtual/jack )
+	libinput? ( dev-libs/libinput:= )
+	logind? (
+		|| ( sys-apps/systemd
+			 sys-auth/elogind )
+	)
+	mpd? ( media-libs/libmpdclient )
+	mpris? ( >=media-sound/playerctl-2 )
+	network? ( dev-libs/libnl:3 )
+	pipewire? ( media-video/wireplumber:0/0.5 )
+	pulseaudio? ( media-libs/libpulse )
+	sndio? ( media-sound/sndio:= )
+	systemd? ( sys-apps/systemd:= )
+	tray? (
+		dev-libs/libayatana-appindicator
+		dev-libs/libdbusmenu[gtk3]
+	)
+	udev? ( virtual/libudev:= )
+	upower? ( sys-power/upower:= )
+	wifi? ( sys-apps/util-linux )
+"
+DEPEND="${RDEPEND}
+	dev-libs/wayland-protocols
+	test? ( dev-cpp/catch:0 )
+"
+
+PATCHES=(
+	"${FILESDIR}"/tray-icons-fix.patch
+)
+
+src_configure() {
+	local emesonargs=(
+		-Dman-pages=enabled
+		-Dcava=disabled
+		$(meson_feature evdev libevdev)
+		$(meson_feature jack)
+		$(meson_feature libinput)
+		$(meson_feature logind)
+		$(meson_feature mpd)
+		$(meson_feature mpris)
+		$(meson_feature network libnl)
+		$(meson_feature pulseaudio)
+		$(meson_feature pipewire wireplumber)
+		$(meson_feature pipewire)
+		$(meson_feature sndio)
+		$(meson_feature systemd)
+		$(meson_feature test tests)
+		$(meson_feature tray dbusmenu-gtk)
+		$(meson_feature udev libudev)
+		$(meson_feature upower upower_glib)
+		$(meson_feature wifi rfkill)
+		$(meson_use experimental)
+	)
+	meson_src_configure
+}


### PR DESCRIPTION
Waybar 0.11.0 has a bug where the tray doesn't work properly (https://github.com/Alexays/Waybar/issues/3597)
The following PR fixes the bug: https://github.com/Alexays/Waybar/pull/3604

This includes the above PR for 0.11.0

Closes: https://bugs.gentoo.org/942543

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
