### PR TITLE
dev-php/pecl-radius: add php 8.3 support

### DIFF
--- a/dev-php/pecl-radius/pecl-radius-1.4.0_beta1-r4.ebuild
+++ b/dev-php/pecl-radius/pecl-radius-1.4.0_beta1-r4.ebuild
@@ -1,0 +1,31 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="8"
+
+PHP_EXT_NAME="radius"
+PHP_EXT_INI="yes"
+PHP_EXT_ZENDEXT="no"
+
+USE_PHP="php8-2 php8-3"
+PHP_EXT_PECL_FILENAME="${PN/pecl-/}-${PV/_beta/b}.tgz"
+PHP_EXT_S="${WORKDIR}/${PHP_EXT_PECL_FILENAME%.tgz}"
+PHP_EXT_NEEDED_USE="pcntl(-),sockets(-)"
+
+inherit php-ext-pecl-r3
+
+DESCRIPTION="Provides support for RADIUS authentication (RFC 2865) and accounting (RFC 2866)"
+HOMEPAGE="https://pecl.php.net/package/radius"
+S="${PHP_EXT_S}"
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="examples"
+
+PATCHES=( "${FILESDIR}/1.4.0-php8.patch" )
+
+src_unpack() {
+	default
+	# Non-portable test
+	rm "${S}/tests/radius_close.phpt" || die
+}


### PR DESCRIPTION
Tests pass on ~amd64 with php 8.2/8.3.

Bug: https://bugs.gentoo.org/943650

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
