### PR TITLE
dev-cpp/mvfst: use the correct CMake variables

### DIFF
--- a/dev-cpp/mvfst/mvfst-2024.11.04.00-r1.ebuild
+++ b/dev-cpp/mvfst/mvfst-2024.11.04.00-r1.ebuild
@@ -40,8 +40,8 @@ DEPEND="
 
 src_configure() {
 	local mycmakeargs=(
-		-DCMAKE_INSTALL_DIR="$(get_libdir)/cmake/${PN}"
-		-DLIB_INSTALL_DIR="$(get_libdir)"
+		-DCMAKE_INSTALL_MODULE_DIR="$(get_libdir)/cmake/${PN}"
+		-DCMAKE_INSTALL_LIBDIR="$(get_libdir)"
 		-DBUILD_TESTS="$(usex test ON OFF)"
 	)
 


### PR DESCRIPTION
For some reason these are different than most of the Facebook C++ libraries.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
