### PR TITLE
sys-power/suspend: Fix compile on musl and newer libgcrypt

### DIFF
--- a/sys-power/suspend/files/suspend-1.0_p20200924-Use-pkgconf-for-libgcrypt.patch
+++ b/sys-power/suspend/files/suspend-1.0_p20200924-Use-pkgconf-for-libgcrypt.patch
@@ -1,0 +1,18 @@
+diff --git a/configure.ac b/configure.ac
+index 5f3adb5..b7f21eb 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -211,7 +211,12 @@ fi
+ if test "${enable_encrypt}" = "yes"; then
+ 	CONFIG_FEATURES="${CONFIG_FEATURES} encrypt"
+ 	AC_DEFINE([CONFIG_ENCRYPT], [1], [Define if encryption enabled])
+-	AM_PATH_LIBGCRYPT([1:1.6.3], [], [AC_MSG_ERROR([Cannot locate >=libgcrypt-1.6.3])])
++	PKG_CONFIG="pkg-config --static"
++		PKG_CHECK_MODULES([LIBGCRYPT],
++				  [libgcrypt >= 1.6.3],
++				  ,
++				  [AC_MSG_ERROR("Cannot locate >=libgcrypt-1.6.3")]
++		)
+ fi
+ 
+ if test "${enable_splashy}" = "yes"; then

--- a/sys-power/suspend/files/suspend-1.0_p20200924-fix-loff_t-for-musl.patch
+++ b/sys-power/suspend/files/suspend-1.0_p20200924-fix-loff_t-for-musl.patch
@@ -1,0 +1,24 @@
+diff --git a/configure.ac b/configure.ac
+index 5f3adb5..0c544c8 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -126,6 +126,7 @@ AC_CHECK_PROGS([M4], [m4])
+ AC_CHECK_PROG(PERL, perl, perl)
+ 
+ AC_SYS_LARGEFILE
++AC_USE_SYSTEM_EXTENSIONS
+ 
+ if test "${enable_create_device}" = "yes"; then
+ 	AC_CHECK_PROGS([MKNOD], [mknod])
+diff --git a/swsusp.h b/swsusp.h
+index 5f89902..6f4863e 100644
+--- a/swsusp.h
++++ b/swsusp.h
+@@ -9,6 +9,7 @@
+  *
+  */
+ 
++#include "config.h"
+ #include <stdint.h>
+ #include <linux/fs.h>
+ #include <linux/suspend_ioctls.h>

--- a/sys-power/suspend/suspend-1.0_p20200924.ebuild
+++ b/sys-power/suspend/suspend-1.0_p20200924.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -32,7 +32,11 @@ BDEPEND="
 
 S="${WORKDIR}/${PN}"
 
-PATCHES=( "${WORKDIR}/${P}.patch" )
+PATCHES=(
+	"${WORKDIR}/${P}.patch"
+	"${FILESDIR}/${PN}-1.0_p20200924-Use-pkgconf-for-libgcrypt.patch"
+	"${FILESDIR}/${PN}-1.0_p20200924-fix-loff_t-for-musl.patch"
+	)
 
 src_prepare() {
 	default


### PR DESCRIPTION
Don't use the package myself but a fellow Gentooer needed a fix and its an easy one. 

Closes: https://bugs.gentoo.org/939507

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
