### PR TITLE
{app-emulation/qemu,sci-libs/opencascade}: remove jemalloc USE, complete <upstream> in metadata

### DIFF
--- a/app-emulation/qemu/metadata.xml
+++ b/app-emulation/qemu/metadata.xml
@@ -64,6 +64,9 @@
 		<flag name="xen">Enables support for Xen backends</flag>
 	</use>
 	<upstream>
+		<bugs-to>https://gitlab.com/qemu-project/qemu/-/issues</bugs-to>
+		<changelog>https://wiki.qemu.org/ChangeLog</changelog>
+		<doc>https://www.qemu.org/docs/master</doc>
 		<remote-id type="gitlab">qemu-project/qemu</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/app-emulation/qemu/metadata.xml
+++ b/app-emulation/qemu/metadata.xml
@@ -48,7 +48,6 @@
 		<flag name="static-user">Build the User targets as static binaries</flag>
 		<flag name="static">Build the User and Software MMU (system) targets as well as tools as static binaries</flag>
 		<flag name="systemtap">Enable SystemTap/DTrace tracing</flag>
-		<flag name="jemalloc">Enable jemalloc allocator support</flag>
 		<flag name="jpeg">Enable jpeg image support for the VNC console server</flag>
 		<flag name="png">Enable png image support for the VNC console server</flag>
 		<flag name="usb">Enable USB passthrough via <pkg>dev-libs/libusb</pkg></flag>

--- a/sci-libs/opencascade/metadata.xml
+++ b/sci-libs/opencascade/metadata.xml
@@ -14,7 +14,6 @@
 	<flag name="freeimage">Enable support for image i/o via <pkg>media-libs/freeimage</pkg></flag>
 	<flag name="freetype">Enable <pkg>media-libs/freetype</pkg> support</flag>
 	<flag name="inspector">Build Inspector tool</flag>
-	<flag name="jemalloc">Enable jemalloc allocator support via <pkg>dev-libs/jemalloc</pkg></flag>
 	<flag name="json">Enable JSON support through <pkg>dev-libs/rapidjson</pkg></flag>
 	<flag name="optimize">Don't clear allocated memory. Use optimized memory manager unlesstbb USE flag is set.</flag>
 	<flag name="tbb">Enable multithreading with the Intel Threads Building Block <pkg>dev-cpp/tbb</pkg></flag>

--- a/sci-libs/opencascade/metadata.xml
+++ b/sci-libs/opencascade/metadata.xml
@@ -22,6 +22,9 @@
 	<flag name="vtk">Enable Visualization Toolkit support via <pkg>sci-libs/vtk</pkg></flag>
 </use>
 <upstream>
+	<bugs-to>https://github.com/Open-Cascade-SAS/OCCT/issues</bugs-to>
+	<changelog>https://github.com/Open-Cascade-SAS/OCCT/releases</changelog>
+	<doc>https://github.com/Open-Cascade-SAS/OCCT/wiki</doc>
 	<remote-id type="github">Open-Cascade-SAS/OCCT</remote-id>
 </upstream>
 </pkgmetadata>


### PR DESCRIPTION
I have noticed that jemalloc is a global USE flag so I have decided to clean up the metadata.
On the way I have completed the `upstream` tag

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
