### PR TITLE
sys-devel/lld: allow LTO

### DIFF
--- a/sys-devel/lld/lld-18.1.8.ebuild
+++ b/sys-devel/lld/lld-18.1.8.ebuild
@@ -59,9 +59,6 @@ src_unpack() {
 src_configure() {
 	llvm_prepend_path "${LLVM_MAJOR}"
 
-	# ODR violations (https://github.com/llvm/llvm-project/issues/83529, bug #922353)
-	filter-lto
-
 	# LLVM_ENABLE_ASSERTIONS=NO does not guarantee this for us, #614844
 	use debug || local -x CPPFLAGS="${CPPFLAGS} -DNDEBUG"
 

--- a/sys-devel/lld/lld-19.1.4.ebuild
+++ b/sys-devel/lld/lld-19.1.4.ebuild
@@ -59,9 +59,6 @@ src_unpack() {
 src_configure() {
 	llvm_prepend_path "${LLVM_MAJOR}"
 
-	# ODR violations (https://github.com/llvm/llvm-project/issues/83529, bug #922353)
-	filter-lto
-
 	# LLVM_ENABLE_ASSERTIONS=NO does not guarantee this for us, #614844
 	use debug || local -x CPPFLAGS="${CPPFLAGS} -DNDEBUG"
 

--- a/sys-devel/lld/lld-20.0.0.9999.ebuild
+++ b/sys-devel/lld/lld-20.0.0.9999.ebuild
@@ -58,9 +58,6 @@ src_unpack() {
 src_configure() {
 	llvm_prepend_path "${LLVM_MAJOR}"
 
-	# ODR violations (https://github.com/llvm/llvm-project/issues/83529, bug #922353)
-	filter-lto
-
 	# LLVM_ENABLE_ASSERTIONS=NO does not guarantee this for us, #614844
 	use debug || local -x CPPFLAGS="${CPPFLAGS} -DNDEBUG"
 


### PR DESCRIPTION
The ODR warnings have been fixed upstream [1] [2], so we can now allow building with LTO for 18.x and newer.

[1] https://github.com/llvm/llvm-project/issues/83529
[2] https://github.com/llvm/llvm-project/pull/83604

Bug: https://bugs.gentoo.org/922353

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
