### PR TITLE
sys-apps/fwupd: fix sys-apps/hwdata dep

### DIFF
--- a/sys-apps/fwupd/fwupd-2.0.1.ebuild
+++ b/sys-apps/fwupd/fwupd-2.0.1.ebuild
@@ -31,6 +31,7 @@ BDEPEND="$(vala_depend)
 	')
 	>=dev-build/meson-1.3.2
 	virtual/pkgconfig
+	sys-apps/hwdata
 	gtk-doc? (
 		$(python_gen_cond_dep '
 			>=dev-python/markdown-3.2[${PYTHON_USEDEP}]


### PR DESCRIPTION
Adds a build dep for sys-apps/hwdata.

This is used at build-time to populate USB vendor information.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
