### PR TITLE
toolchain.eclass: Throw an error if trying to disable time64

### DIFF
--- a/eclass/toolchain.eclass
+++ b/eclass/toolchain.eclass
@@ -576,6 +576,19 @@ toolchain_pkg_pretend() {
 		_tc_use_if_iuse objc++ && \
 			ewarn 'Obj-C++ requires a C++ compiler, disabled due to USE="-cxx"'
 	fi
+
+	# Do the check for pure source builds only, since the overide
+	# cannot work with binary packages, see https://bugs.gentoo.org/944198
+	if [[ ${BUILD_TYPE} == source ]] && in_iuse time64 && ! use time64 &&
+		has_version -r "${CATEGORY}/${PN}[time64(-)]" &&
+		[[ ! ${TC_FORCE_TIME32} ]]
+	then
+		eerror "Attempting to build USE=-time64 version of gcc when at least"
+		eerror "one USE=time64 version is installed. Did you accidentally"
+		eerror "switch back to a non-time64 profile? If this is really"
+		eerror "desirable, set TC_FORCE_TIME32=1 to force the build."
+		die "Attempting to build USE=-time64 on a USE=time64 system"
+	fi
 }
 
 #---->> pkg_setup <<----


### PR DESCRIPTION
Throw an error if the user is trying to build a non-time64 version of GCC on a system featuring a time64 GCC already.  Most of the time, this will mean that the user has accidentally switched to a non-time64 profile.

CC @gentoo/toolchain 