### PR TITLE
net-im/zoom: patched rpath for qt libraries

### DIFF
--- a/net-im/zoom/zoom-6.2.6.2503.ebuild
+++ b/net-im/zoom/zoom-6.2.6.2503.ebuild
@@ -73,6 +73,7 @@ RDEPEND="zoom-symlink? ( !games-engines/zoom )
 		dev-qt/qtwidgets:5
 		dev-qt/qtx11extras:5
 		dev-qt/qtxml:5
+		dev-util/patchelf
 		wayland? ( dev-qt/qtwayland )
 	)"
 
@@ -171,6 +172,11 @@ src_install() {
 }
 
 pkg_postinst() {
+	if use bundled-qt; then
+		patchelf --set-rpath /opt/zoom/Qt/lib /opt/zoom/zoom
+		patchelf --set-rpath /opt/zoom/Qt/lib /opt/zoom/ZoomWebviewHost
+		patchelf --set-rpath /opt/zoom/Qt/lib /opt/zoom/zopen
+	fi
 	xdg_desktop_database_update
 	xdg_icon_cache_update
 	readme.gentoo_print_elog


### PR DESCRIPTION
When the bundled-qt USE flag is set, Zoom has it's rpath set using patchelf. This should fix issues where bundled-qt libraries are not found by Zoom. 

There is a redundant version warning for zoom, about unstable versions. Generated from the `pkgcheck scan --commits --net`. I believe it is unrelated to my commit.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [ x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [ x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [ x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
