### PR TITLE
dev-util/android-studio: added wayland USE flag

### DIFF
--- a/dev-util/android-studio/android-studio-2024.2.1.11.ebuild
+++ b/dev-util/android-studio/android-studio-2024.2.1.11.ebuild
@@ -38,7 +38,7 @@ LICENSE="Apache-2.0 android BSD BSD-2 CDDL-1.1 CPL-0.5
 	MPL-1.1 MPL-2.0 NPL-1.1 OFL-1.1 ZLIB"
 SLOT="0"
 KEYWORDS="~amd64"
-IUSE="selinux"
+IUSE="selinux wayland"
 RESTRICT="bindist mirror strip"
 
 RDEPEND="${DEPEND}
@@ -112,7 +112,11 @@ src_install() {
 
 	newicon "bin/studio.png" "${PN}.png"
 	make_wrapper ${PN} ${dir}/bin/studio.sh
-	make_desktop_entry ${PN} "Android Studio" ${PN} "Development;IDE" "StartupWMClass=jetbrains-studio"
+	if use wayland; then
+		make_desktop_entry "${PN} -Dawt.toolkit.name=WLToolkit" "Android Studio" ${PN} "Development;IDE" "StartupWMClass=jetbrains-studio"
+	else
+		make_desktop_entry ${PN} "Android Studio" ${PN} "Development;IDE" "StartupWMClass=jetbrains-studio"
+	fi
 
 	# https://developer.android.com/studio/command-line/variables
 	newenvd - 99android-studio <<-EOF


### PR DESCRIPTION
Similiarly to dev-util/idea-community, JetBrains added a wayland support preview to IntelliJ based IDEs in 2024.2 EAP. The wayland USE flag toggles the support preview on/off accordingly.

Edit:
I have come to the realization perhaps this should be a separate ebuild under the ~amd64 keyword, and only that ebuild should have the wayland use flag. Let me know what you think.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
