### PR TITLE
net-analyzer/nfdump: fix version 1.7.4 with USE="zstd"

### DIFF
--- a/net-analyzer/nfdump/nfdump-1.7.4.ebuild
+++ b/net-analyzer/nfdump/nfdump-1.7.4.ebuild
@@ -76,7 +76,7 @@ src_configure() {
 		$(use_enable nsel)
 		$(use_enable readpcap)
 		$(use_enable sflow)
-		$(use_with zstd zstdpath)
+		$(use_with zstd "zstdpath=/usr")
 	)
 	econf "${myeconfargs[@]}"
 }

--- a/net-analyzer/nfdump/nfdump-1.7.4.ebuild
+++ b/net-analyzer/nfdump/nfdump-1.7.4.ebuild
@@ -67,7 +67,7 @@ src_configure() {
 
 	# --without-ftconf is not handled well, bug #322201
 	local myeconfargs=(
-		$(usex ftconv "--enable-ftconv --with-ftpath=/usr")
+		$(usex ftconv "--enable-ftconv --with-ftpath=${EPREFIX}/usr")
 		$(usex nfpcapd --enable-nfpcapd)
 		$(usex nfprofile --enable-nfprofile)
 		$(usex nftrack --enable-nftrack)
@@ -76,7 +76,7 @@ src_configure() {
 		$(use_enable nsel)
 		$(use_enable readpcap)
 		$(use_enable sflow)
-		$(use_with zstd "zstdpath=/usr")
+		$(use_with zstd "zstdpath=${EPREFIX}/usr")
 	)
 	econf "${myeconfargs[@]}"
 }


### PR DESCRIPTION
When ```configure``` receive the option ```--with-zstdpath``` without a path, pollutes the ```CPPFLAGS``` variable with a spurious 'yes/lib' string.

This patch adds a path, like the ftconv ```USE```  flag does.

Closes: https://bugs.gentoo.org/937022
Signed-off-by: Cristian Othón Martínez Vera <cfuga@cfuga.mx>

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
