### PR TITLE
dev-python/twisted: add more IDEPEND for regen-cache

### DIFF
--- a/dev-python/twisted/twisted-24.10.0.ebuild
+++ b/dev-python/twisted/twisted-24.10.0.ebuild
@@ -58,6 +58,7 @@ RDEPEND="
 IDEPEND="
 	>=dev-python/attrs-19.2.0[${PYTHON_USEDEP}]
 	>=dev-python/constantly-15.1[${PYTHON_USEDEP}]
+	>=dev-python/typing-extensions-4.2.0[${PYTHON_USEDEP}]
 	>=dev-python/zope-interface-5[${PYTHON_USEDEP}]
 "
 BDEPEND="

--- a/dev-python/twisted/twisted-24.7.0.ebuild
+++ b/dev-python/twisted/twisted-24.7.0.ebuild
@@ -58,6 +58,7 @@ RDEPEND="
 IDEPEND="
 	>=dev-python/attrs-19.2.0[${PYTHON_USEDEP}]
 	>=dev-python/constantly-15.1[${PYTHON_USEDEP}]
+	>=dev-python/typing-extensions-4.2.0[${PYTHON_USEDEP}]
 	>=dev-python/zope-interface-5[${PYTHON_USEDEP}]
 "
 BDEPEND="


### PR DESCRIPTION
One additional IDEPEND is needed that was missed in the previous commit on this issue (d74d1d24e34cfd796a297695d05fec023a783701). twisted-regen-cache should run without error now that typing-extensions is pulled in. This was tested from an image with nothing else installed so should finally have everything.

One note is that incremental is also technically required at install time and may be missing, however there are no real cases where this is an issue because it is in both BDEPEND and RDEPEND and emerging with --nodeps does not install IDEPEND so the fact that install would fail in that case is expected.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
