### PR TITLE
dev-python/meson-python: BDEPEND pyproject-metadata

### DIFF
--- a/dev-python/meson-python/meson-python-0.17.1.ebuild
+++ b/dev-python/meson-python/meson-python-0.17.1.ebuild
@@ -31,6 +31,7 @@ RDEPEND="
 	' 3.10)
 "
 BDEPEND="
+	${RDEPEND}
 	>=dev-python/cython-0.29.34[${PYTHON_USEDEP}]
 	test? (
 		>=dev-python/packaging-23.1[${PYTHON_USEDEP}]


### PR DESCRIPTION
Fix issue where meson-python fails to build if
pyproject-metadata is not installed at build time.
This is needed e.g. when building a binpkg.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
