### PR TITLE
gui-wm/hyprland: backport patch to build without X on gcc13

### DIFF
--- a/gui-wm/hyprland/files/no_xwayland_backport.patch
+++ b/gui-wm/hyprland/files/no_xwayland_backport.patch
@@ -1,0 +1,21 @@
+From e09ae925a5847b9af7b0d422997cb64f093c75ef Mon Sep 17 00:00:00 2001
+From: Nick H <gerkola@gmail.com>
+Date: Tue, 27 Aug 2024 00:59:21 +0200
+Subject: [PATCH] Fix NO_XWAYLAND compilation
+
+---
+ src/xwayland/XWayland.hpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/xwayland/XWayland.hpp b/src/xwayland/XWayland.hpp
+index d1cc4421887..40c0ba656cd 100644
+--- a/src/xwayland/XWayland.hpp
++++ b/src/xwayland/XWayland.hpp
+@@ -3,6 +3,7 @@
+ #include <memory>
+ #include "../helpers/signal/Signal.hpp"
+ #include "../helpers/memory/Memory.hpp"
++#include "../macros.hpp"
+ 
+ #include "XSurface.hpp"
+ 

--- a/gui-wm/hyprland/hyprland-0.42.0-r2.ebuild
+++ b/gui-wm/hyprland/hyprland-0.42.0-r2.ebuild
@@ -1,0 +1,104 @@
+# Copyright 2023-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit meson toolchain-funcs
+
+DESCRIPTION="A dynamic tiling Wayland compositor that doesn't sacrifice on its looks"
+HOMEPAGE="https://github.com/hyprwm/Hyprland"
+
+if [[ "${PV}" = *9999 ]]; then
+	inherit git-r3
+	EGIT_REPO_URI="https://github.com/hyprwm/${PN^}.git"
+else
+	SRC_URI="https://github.com/hyprwm/${PN^}/releases/download/v${PV}/source-v${PV}.tar.gz -> ${P}.gh.tar.gz"
+	S="${WORKDIR}/${PN}-source"
+
+	KEYWORDS="~amd64"
+fi
+
+LICENSE="BSD"
+SLOT="0"
+IUSE="X legacy-renderer systemd"
+
+# hyprpm (hyprland plugin manager) requires the dependencies at runtime
+# so that it can clone, compile and install plugins.
+HYPRPM_RDEPEND="
+	app-alternatives/ninja
+	dev-build/cmake
+	dev-build/meson
+	dev-libs/libliftoff
+	dev-vcs/git
+	virtual/pkgconfig
+"
+RDEPEND="
+	${HYPRPM_RDEPEND}
+	dev-cpp/tomlplusplus
+	dev-libs/glib:2
+	dev-libs/libinput
+	>=dev-libs/wayland-1.20.0
+	gui-libs/aquamarine
+	>=gui-libs/hyprcursor-0.1.9
+	media-libs/libglvnd
+	x11-libs/cairo
+	x11-libs/libdrm
+	x11-libs/libxkbcommon
+	x11-libs/pango
+	x11-libs/pixman
+	x11-libs/libXcursor
+	X? (
+		x11-libs/libxcb:0=
+		x11-base/xwayland
+		x11-libs/xcb-util-errors
+		x11-libs/xcb-util-wm
+	)
+"
+DEPEND="
+	${RDEPEND}
+	>=dev-libs/hyprland-protocols-0.3
+	>=dev-libs/hyprlang-0.3.2
+	>=dev-libs/wayland-protocols-1.36
+	>=gui-libs/hyprutils-0.2.1
+"
+BDEPEND="
+	|| ( >=sys-devel/gcc-13:* >=sys-devel/clang-16:* )
+	app-misc/jq
+	dev-build/cmake
+	>=dev-util/hyprwayland-scanner-0.3.8
+	virtual/pkgconfig
+"
+
+PATCHES=(
+	"${FILESDIR}"/no_xwayland_backport.patch
+)
+
+pkg_setup() {
+	[[ ${MERGE_TYPE} == binary ]] && return
+
+	if tc-is-gcc && ver_test $(gcc-version) -lt 13 ; then
+		eerror "Hyprland requires >=sys-devel/gcc-13 to build"
+		eerror "Please upgrade GCC: emerge -v1 sys-devel/gcc"
+		die "GCC version is too old to compile Hyprland!"
+	elif tc-is-clang && ver_test $(clang-version) -lt 16 ; then
+		eerror "Hyprland requires >=sys-devel/clang-16 to build"
+		eerror "Please upgrade Clang: emerge -v1 sys-devel/clang"
+		die "Clang version is too old to compile Hyprland!"
+	fi
+}
+
+src_prepare() {
+	# skip version.h
+	sed -i -e "s|scripts/generateVersion.sh|echo|g" meson.build || die
+	default
+}
+
+src_configure() {
+	local emesonargs=(
+		$(meson_feature legacy-renderer legacy_renderer)
+		$(meson_feature systemd)
+		$(meson_feature X xwayland)
+	)
+
+	meson_src_configure
+}


### PR DESCRIPTION
Backport patch from https://github.com/hyprwm/Hyprland/pull/7538 so users on GCC-13 can build Hyprland without X support

Bug: https://bugs.gentoo.org/935322

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
