### PR TITLE
sys-fs/compsize: fix build with btrfs-progs >= 6.10.1

### DIFF
--- a/sys-fs/compsize/compsize-1.5.ebuild
+++ b/sys-fs/compsize/compsize-1.5.ebuild
@@ -22,6 +22,8 @@ IUSE="debug"
 
 DEPEND="sys-fs/btrfs-progs"
 
+PATCHES=( "${FILESDIR}/${P}-btrfs-progs.patch" )
+
 src_prepare() {
 	default
 	# Don't try to install a gzipped manfile during emake install

--- a/sys-fs/compsize/files/compsize-1.5-btrfs-progs.patch
+++ b/sys-fs/compsize/files/compsize-1.5-btrfs-progs.patch
@@ -1,0 +1,35 @@
+diff --git a/compsize.c b/compsize.c
+index 42ec304..0f533e5 100644
+--- a/compsize.c
++++ b/compsize.c
+@@ -5,12 +5,14 @@
+ #include <unistd.h>
+ #include <fcntl.h>
+ #include <dirent.h>
++#include "kerncompat.h"
+ #include <btrfs/ioctl.h>
+ #include <btrfs/ctree.h>
+ #include <stdarg.h>
+ #include <stdlib.h>
+ #include <sys/ioctl.h>
+ #include <inttypes.h>
++#include <errno.h>
+ #include <linux/limits.h>
+ #include <getopt.h>
+ #include <signal.h>
+diff --git a/radix-tree.h b/radix-tree.h
+index bf96d83..d99ea7e 100644
+--- a/radix-tree.h
++++ b/radix-tree.h
+@@ -37,11 +37,7 @@
+ #ifndef _LINUX_RADIX_TREE_H
+ #define _LINUX_RADIX_TREE_H
+ 
+-#if BTRFS_FLAT_INCLUDES
+ #include "kerncompat.h"
+-#else
+-#include <btrfs/kerncompat.h>
+-#endif /* BTRFS_FLAT_INCLUDES */
+ 
+ #define RADIX_TREE_MAX_TAGS 2
+ 

--- a/sys-fs/compsize/metadata.xml
+++ b/sys-fs/compsize/metadata.xml
@@ -1,7 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<!-- maintainer-needed -->
+	<maintainer type="person" proxied="yes">
+		<email>davidroman96@gmail.com</email>
+		<name>David Roman</name>
+	</maintainer>
+	<maintainer type="project" proxied="proxy">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
 	<upstream>
 		<remote-id type="github">kilobyte/compsize</remote-id>
 	</upstream>


### PR DESCRIPTION
I don't know if it's completely right to patch a stable ebuild, but since it had build failures and the patch was small thought it would be okay. 

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
