### PR TITLE
net-dns/knot-resolver: fix RUNDIR

### DIFF
--- a/net-dns/knot-resolver/files/kresd.initd-r2
+++ b/net-dns/knot-resolver/files/kresd.initd-r2
@@ -1,0 +1,31 @@
+#!/sbin/openrc-run
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+: ${KRESD_GROUP:=knot-resolver}
+: ${KRESD_USER:=knot-resolver}
+: ${KRESD_CONFIG:=/etc/knot-resolver/kresd.conf}
+: ${KRESD_RUNDIR:=/var/run/knot-resolver}
+: ${KRESD_PIDFILE:=/var/run/kresd.pid}
+
+command="/usr/sbin/kresd"
+command_args="${KRESD_OPTS} -n -c ${KRESD_CONFIG} ${KRESD_RUNDIR}"
+command_user="${KRESD_USER}:${KRESD_GROUP}"
+pidfile="${KRESD_PIDFILE}"
+command_background=true
+retry="TERM/60/KILL/5"
+
+capabilities="^cap_net_bind_service,^cap_setpcap"
+
+name="knot-resolver"
+description="scaleable caching DNS resolver"
+
+depend() {
+    need net
+    use logger
+    provide dns
+}
+
+start_pre() {
+        checkpath -d -m 0750 -o "${KRESD_USER}:${KRESD_GROUP}" ${KRESD_RUNDIR}
+}

--- a/net-dns/knot-resolver/knot-resolver-5.7.4-r1.ebuild
+++ b/net-dns/knot-resolver/knot-resolver-5.7.4-r1.ebuild
@@ -83,7 +83,7 @@ src_install() {
 	meson_src_install
 	fowners -R ${PN}: /etc/${PN}
 
-	newinitd "${FILESDIR}"/kresd.initd-r1 kresd
+	newinitd "${FILESDIR}"/kresd.initd-r2 kresd
 	newconfd "${FILESDIR}"/kresd.confd-r1 kresd
 }
 


### PR DESCRIPTION
default value for RUNDIR (/var/run/kresd) does not match the one provided by [upstream tmpfile](https://gitlab.nic.cz/knot/knot-resolver/-/blob/v5.7.2/meson.build#L55) (/var/run/knot-resolver)

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
