### PR TITLE
sys-fs/lvm2: fix build with musl

### DIFF
--- a/sys-fs/lvm2/files/lvm2-2.03.22-basename-musl.patch
+++ b/sys-fs/lvm2/files/lvm2-2.03.22-basename-musl.patch
@@ -1,0 +1,34 @@
+https://bugs.gentoo.org/937239
+https://github.com/lvmteam/lvm2/commit/f98d2ffe8753895c84160a7abce4223bd127cd9e
+
+From f98d2ffe8753895c84160a7abce4223bd127cd9e Mon Sep 17 00:00:00 2001
+From: Zdenek Kabelac <zkabelac@redhat.com>
+Date: Wed, 27 Mar 2024 00:28:14 +0100
+Subject: [PATCH] device_id: use dm_basename
+
+Avoid problems for other libc like muslc and use dm_basename.
+
+Prototype for basename has been removed from string.h from latest musl [1]
+compilers e.g. clang-18 flags the absense of prototype as error. therefore
+include libgen.h for providing it.
+
+[1] https://git.musl-libc.org/cgit/musl/commit/?id=725e17ed6dff4d0cd22487bb64470881e86a92e7
+
+Reported-by: Khem Raj <raj.khem@gmail.com>
+---
+ lib/device/device_id.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/device/device_id.c b/lib/device/device_id.c
+index 7d67a1cb7..200d39432 100644
+--- a/lib/device/device_id.c
++++ b/lib/device/device_id.c
+@@ -740,7 +740,7 @@ static int _dev_read_sys_serial(struct cmd_context *cmd, struct device *dev,
+ 		int ret;
+ 
+ 		/* /dev/vda to vda */
+-		base = basename(devname);
++		base = dm_basename(devname);
+ 
+ 		/* vda1 to vda */
+ 		for (i = 0; i < strlen(base); i++) {

--- a/sys-fs/lvm2/lvm2-2.03.22-r6.ebuild
+++ b/sys-fs/lvm2/lvm2-2.03.22-r6.ebuild
@@ -74,6 +74,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-2.03.22-autoconf-2.72-egrep.patch
 	"${FILESDIR}"/${PN}-2.03.22-thin-version-checking.patch
 	"${FILESDIR}"/${PN}-2.03.22-thin-autodetect.patch
+	"${FILESDIR}"/${PN}-2.03.22-basename-musl.patch
 )
 
 pkg_setup() {


### PR DESCRIPTION
Fixes implicit declaration of function basename on musl systems.

Closes: https://bugs.gentoo.org/937239
Upstream-Commit: https://github.com/lvmteam/lvm2/commit/f98d2ffe8753895c84160a7abce4223bd127cd9e

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
