### PR TITLE
dev-libs/xmlrpc-c: Build old upstream versions as C++14

### DIFF
--- a/dev-libs/xmlrpc-c/xmlrpc-c-1.54.05-r3.ebuild
+++ b/dev-libs/xmlrpc-c/xmlrpc-c-1.54.05-r3.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit autotools toolchain-funcs
+inherit flag-o-matic autotools toolchain-funcs
 
 # Upstream maintains 3 release channels: https://xmlrpc-c.sourceforge.net/release.html
 # 1. Only the "Super Stable" series is released as a tarball
@@ -51,6 +51,9 @@ src_prepare() {
 
 src_configure() {
 	tc-export PKG_CONFIG
+
+	# xmlrpc-c uses std::auto_ptr which has been removed in C++17
+	append-cxxflags "-std=c++14"
 
 	econf \
 		--disable-libwww-client \

--- a/dev-libs/xmlrpc-c/xmlrpc-c-1.54.06-r1.ebuild
+++ b/dev-libs/xmlrpc-c/xmlrpc-c-1.54.06-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit autotools toolchain-funcs
+inherit flag-o-matic autotools toolchain-funcs
 
 # Upstream maintains 3 release channels: https://xmlrpc-c.sourceforge.net/release.html
 # 1. Only the "Super Stable" series is released as a tarball
@@ -53,6 +53,9 @@ src_prepare() {
 
 src_configure() {
 	tc-export PKG_CONFIG
+
+	# xmlrpc-c uses std::auto_ptr which has been removed in C++17
+	append-cxxflags "-std=c++14"
 
 	econf \
 		--disable-libwww-client \


### PR DESCRIPTION
xmlrpc-c 1.54 uses `std::auto_ptr` which has been removed in C++17. To ensure `std::auto_ptr` is present in the standard library, force compilation as C++14.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
