### PR TITLE
net-dns/knot: 3.2.9 fixdep libbpf xdp-tools

### DIFF
--- a/net-dns/knot/knot-3.2.9-r1.ebuild
+++ b/net-dns/knot/knot-3.2.9-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -11,6 +11,8 @@ KNOT_SUBSLOT="13.9.4"
 DESCRIPTION="High-performance authoritative-only DNS server"
 HOMEPAGE="https://www.knot-dns.cz/ https://gitlab.nic.cz/knot/knot-dns"
 SRC_URI="https://secure.nic.cz/files/knot-dns/${P/_/-}.tar.xz"
+
+S="${WORKDIR}/${P/_/-}"
 
 LICENSE="GPL-3+"
 SLOT="0/${KNOT_SUBSLOT}"
@@ -53,8 +55,9 @@ RDEPEND="
 	quic? ( >=net-libs/ngtcp2-0.13.1:=[gnutls] )
 	systemd? ( sys-apps/systemd:= )
 	xdp? (
-		 dev-libs/libbpf:=
-		 net-libs/libmnl:=
+		>=dev-libs/libbpf-1.0:=
+		net-libs/libmnl:=
+		net-libs/xdp-tools
 	)
 "
 DEPEND="${RDEPEND}"
@@ -62,8 +65,6 @@ BDEPEND="
 	virtual/pkgconfig
 	doc? ( dev-python/sphinx )
 "
-
-S="${WORKDIR}/${P/_/-}"
 
 src_configure() {
 	local u


### PR DESCRIPTION
xdp useflag needs dev-libs/libbpf and net-libs/xdp-tools otherwise it fails to build :
>In file included from libknot/xdp/bpf-user.c:27:
>./libknot/xdp/bpf-user.h:31:11: fatal error: bpf/xsk.h: No such file or
>directory
>31 | #include <bpf/xsk.h>
>| ^~~~~~~~~~~
See #39065 
---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
