### PR TITLE
gui-libs/hyprcursor: backport patch for llvm/clang builds

### DIFF
--- a/gui-libs/hyprcursor/files/0.1.10-llvm-fix.patch
+++ b/gui-libs/hyprcursor/files/0.1.10-llvm-fix.patch
@@ -1,0 +1,27 @@
+From f8e8455e998e0ff8b4708220006a479d1d7e4e8b Mon Sep 17 00:00:00 2001
+From: Jan Beich <jbeich@FreeBSD.org>
+Date: Tue, 1 Oct 2024 01:01:47 +0200
+Subject: [PATCH] lib: add missing header for libc++ after 5a95d8512b3e
+
+libhyprcursor/hyprcursor.cpp:23:27: error: implicit instantiation of undefined template 'std::basic_stringstream<char>'
+   23 |         std::stringstream envXdgStream(envXdgData);
+      |                           ^
+/usr/include/c++/v1/__fwd/sstream.h:29:28: note: template is declared here
+   29 | class _LIBCPP_TEMPLATE_VIS basic_stringstream;
+      |                            ^
+---
+ libhyprcursor/hyprcursor.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/libhyprcursor/hyprcursor.cpp b/libhyprcursor/hyprcursor.cpp
+index 3a83a26..f7fb82c 100644
+--- a/libhyprcursor/hyprcursor.cpp
++++ b/libhyprcursor/hyprcursor.cpp
+@@ -2,6 +2,7 @@
+ #include "internalSharedTypes.hpp"
+ #include "internalDefines.hpp"
+ #include <array>
++#include <sstream>
+ #include <cstdio>
+ #include <filesystem>
+ #include <zip.h>

--- a/gui-libs/hyprcursor/hyprcursor-0.1.10-r1.ebuild
+++ b/gui-libs/hyprcursor/hyprcursor-0.1.10-r1.ebuild
@@ -1,0 +1,30 @@
+# Copyright 2023-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit cmake
+
+DESCRIPTION="The hyprland cursor format, library and utilities"
+HOMEPAGE="https://github.com/hyprwm/hyprcursor"
+SRC_URI="https://github.com/hyprwm/hyprcursor/archive/v${PV}.tar.gz -> ${P}.gh.tar.gz"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~amd64 ~riscv"
+
+# Disable tests since as per upstream, tests require a theme to be installed
+# See also https://github.com/hyprwm/hyprcursor/commit/94361fd8a75178b92c4bb24dcd8c7fac8423acf3
+RESTRICT="test"
+
+RDEPEND="
+	dev-cpp/tomlplusplus
+	>=dev-libs/hyprlang-0.4.2
+	dev-libs/libzip
+	gnome-base/librsvg:2
+	x11-libs/cairo
+"
+
+PATCHES=(
+	"${FILESDIR}"/0.1.10-llvm-fix.patch
+)


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/944500

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
