### PR TITLE
dev-cpp/cpptoml: fix build on system-libcxx systems

### DIFF
--- a/dev-cpp/cpptoml/cpptoml-0.1.1-r1.ebuild
+++ b/dev-cpp/cpptoml/cpptoml-0.1.1-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit cmake toolchain-funcs
+inherit cmake
 
 DESCRIPTION="Header-only library for parsing TOML"
 HOMEPAGE="https://github.com/skystrife/cpptoml"
@@ -16,16 +16,13 @@ IUSE="examples"
 
 PATCHES=(
 	"${FILESDIR}/${P}-limits.patch"
+	"${FILESDIR}/${P}-remove-libcxx-config.patch"
 )
 
 src_configure() {
 	local mycmakeargs=(
 		-DCPPTOML_BUILD_EXAMPLES=$(usex examples)
 	)
-
-	if [[ $(tc-get-cxx-stdlib) == libc++ ]]; then
-		mycmakeargs+=(-DENABLE_LIBCXX=ON)
-	fi
 
 	cmake_src_configure
 }

--- a/dev-cpp/cpptoml/files/cpptoml-0.1.1-remove-libcxx-config.patch
+++ b/dev-cpp/cpptoml/files/cpptoml-0.1.1-remove-libcxx-config.patch
@@ -1,0 +1,37 @@
+From bfb98b0f1e0ffdc187e87c79e1c3114eadc3fa0e Mon Sep 17 00:00:00 2001
+From: sin-ack <sin-ack@protonmail.com>
+Date: Sat, 23 Nov 2024 20:28:52 +0100
+Subject: [PATCH] Remove custom configuration for libc++
+
+This doesn't seem to be necessary anymore for libc++ support, and
+actually breaks builds on system-libcxx systems.
+---
+ CMakeLists.txt | 6 ------
+ 1 file changed, 6 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 4ec25cc..6f4753b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -11,7 +11,6 @@ include(CMakePushCheckState)
+ 
+ cmake_push_check_state()
+ 
+-option(ENABLE_LIBCXX "Use libc++ for the C++ standard library" ON)
+ option(CPPTOML_BUILD_EXAMPLES "Build examples" ON)
+ 
+ set(CMAKE_EXPORT_COMPILE_COMMANDS 1)
+@@ -25,11 +24,6 @@ if(UNIX OR MINGW)
+     if(CMAKE_GENERATOR STREQUAL "Ninja")
+       set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fcolor-diagnostics")
+     endif()
+-
+-    if(ENABLE_LIBCXX)
+-      find_package(LIBCXX REQUIRED)
+-      set_libcxx_required_flags()
+-    endif()
+   endif()
+ endif()
+ 
+-- 
+2.45.2


### PR DESCRIPTION
I tried to find information about `find_package(LIBCXX)` but I couldn't find anything, and testing in a system-libcxx system shows it to work without this, so just remove any configuration related to it. Tested with USE=examples and by building dev-util/watchman which has this as a dependency.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
