### PR TITLE
eapi9-pipestatus.eclass: New eclass

### DIFF
--- a/app-editors/emacs/emacs-26.3-r21.ebuild
+++ b/app-editors/emacs/emacs-26.3-r21.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit autotools elisp-common flag-o-matic readme.gentoo-r1
+inherit autotools eapi9-pipestatus elisp-common flag-o-matic readme.gentoo-r1
 
 DESCRIPTION="The extensible, customizable, self-documenting real-time display editor"
 HOMEPAGE="https://www.gnu.org/software/emacs/"
@@ -284,14 +284,14 @@ src_install() {
 			-e "/^ExecStart/s,emacs,${EPREFIX}/usr/bin/${EMACS_SUFFIX}," \
 			-e "/^ExecStop/s,emacsclient,${EPREFIX}/usr/bin/&-${EMACS_SUFFIX}," \
 			etc/emacs.service | newins - ${EMACS_SUFFIX}.service
-		assert
+		pipestatus || die
 	fi
 
 	if use gzip-el; then
 		# compress .el files when a corresponding .elc exists
 		find "${ED}"/usr/share/emacs/${FULL_VERSION}/lisp -type f \
 			-name "*.elc" -print | sed 's/\.elc$/.el/' | xargs gzip -9n
-		assert "gzip .el failed"
+		pipestatus || die "gzip .el pipeline failed"
 	fi
 
 	local cdir

--- a/app-editors/emacs/emacs-27.2-r19.ebuild
+++ b/app-editors/emacs/emacs-27.2-r19.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit autotools elisp-common flag-o-matic readme.gentoo-r1 toolchain-funcs
+inherit autotools eapi9-pipestatus elisp-common flag-o-matic readme.gentoo-r1 toolchain-funcs
 
 if [[ ${PV##*.} = 9999 ]]; then
 	inherit git-r3
@@ -352,14 +352,14 @@ src_install() {
 			-e "/^ExecStart/s,emacs,${EPREFIX}/usr/bin/${EMACS_SUFFIX}," \
 			-e "/^ExecStop/s,emacsclient,${EPREFIX}/usr/bin/&-${EMACS_SUFFIX}," \
 			etc/emacs.service | newins - ${EMACS_SUFFIX}.service
-		assert
+		pipestatus || die
 	fi
 
 	if use gzip-el; then
 		# compress .el files when a corresponding .elc exists
 		find "${ED}"/usr/share/emacs/${FULL_VERSION}/lisp -type f \
 			-name "*.elc" -print | sed 's/\.elc$/.el/' | xargs gzip -9n
-		assert "gzip .el failed"
+		pipestatus || die "gzip .el pipeline failed"
 	fi
 
 	local cdir

--- a/app-editors/emacs/emacs-28.2-r15.ebuild
+++ b/app-editors/emacs/emacs-28.2-r15.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit autotools elisp-common flag-o-matic readme.gentoo-r1 toolchain-funcs
+inherit autotools eapi9-pipestatus elisp-common flag-o-matic readme.gentoo-r1 toolchain-funcs
 
 if [[ ${PV##*.} = 9999 ]]; then
 	inherit git-r3
@@ -448,14 +448,14 @@ src_install() {
 			-e "/^ExecStart/s,emacs,${EPREFIX}/usr/bin/${EMACS_SUFFIX}," \
 			-e "/^ExecStop/s,emacsclient,${EPREFIX}/usr/bin/&-${EMACS_SUFFIX}," \
 			etc/emacs.service | newins - ${EMACS_SUFFIX}.service
-		assert
+		pipestatus || die
 	fi
 
 	if use gzip-el; then
 		# compress .el files when a corresponding .elc exists
 		find "${ED}"/usr/share/emacs/${FULL_VERSION}/lisp -type f \
 			-name "*.elc" -print | sed 's/\.elc$/.el/' | xargs gzip -9n
-		assert "gzip .el failed"
+		pipestatus || die "gzip .el pipeline failed"
 	fi
 
 	local cdir

--- a/app-editors/emacs/emacs-29.4-r1.ebuild
+++ b/app-editors/emacs/emacs-29.4-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit autotools elisp-common flag-o-matic readme.gentoo-r1 toolchain-funcs
+inherit autotools eapi9-pipestatus elisp-common flag-o-matic readme.gentoo-r1 toolchain-funcs
 
 if [[ ${PV##*.} = 9999 ]]; then
 	inherit git-r3
@@ -530,14 +530,14 @@ src_install() {
 			-e "/^ExecStart/s,emacs,${EPREFIX}/usr/bin/${EMACS_SUFFIX}," \
 			-e "/^ExecStop/s,emacsclient,${EPREFIX}/usr/bin/&-${EMACS_SUFFIX}," \
 			etc/emacs.service | newins - ${EMACS_SUFFIX}.service
-		assert
+		pipestatus || die
 	fi
 
 	if use gzip-el; then
 		# compress .el files when a corresponding .elc exists
 		find "${ED}"/usr/share/emacs/${FULL_VERSION}/lisp -type f \
 			-name "*.elc" -print | sed 's/\.elc$/.el/' | xargs gzip -9n
-		assert "gzip .el failed"
+		pipestatus || die "gzip .el pipeline failed"
 	fi
 
 	local cdir

--- a/app-editors/emacs/emacs-30.0.91.ebuild
+++ b/app-editors/emacs/emacs-30.0.91.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit autotools elisp-common flag-o-matic readme.gentoo-r1 toolchain-funcs
+inherit autotools eapi9-pipestatus elisp-common flag-o-matic readme.gentoo-r1 toolchain-funcs
 
 if [[ ${PV##*.} = 9999 ]]; then
 	inherit git-r3
@@ -517,14 +517,14 @@ src_install() {
 			-e "/^ExecStart/s,emacs,${EPREFIX}/usr/bin/${EMACS_SUFFIX}," \
 			-e "/^ExecStop/s,emacsclient,${EPREFIX}/usr/bin/&-${EMACS_SUFFIX}," \
 			etc/emacs.service | newins - ${EMACS_SUFFIX}.service
-		assert
+		pipestatus || die
 	fi
 
 	if use gzip-el; then
 		# compress .el files when a corresponding .elc exists
 		find "${ED}"/usr/share/emacs/${FULL_VERSION}/lisp -type f \
 			-name "*.elc" -print | sed 's/\.elc$/.el/' | xargs gzip -9n
-		assert "gzip .el failed"
+		pipestatus || die "gzip .el pipeline failed"
 	fi
 
 	local cdir

--- a/app-editors/emacs/emacs-30.0.92.ebuild
+++ b/app-editors/emacs/emacs-30.0.92.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit autotools elisp-common flag-o-matic readme.gentoo-r1 toolchain-funcs
+inherit autotools eapi9-pipestatus elisp-common flag-o-matic readme.gentoo-r1 toolchain-funcs
 
 if [[ ${PV##*.} = 9999 ]]; then
 	inherit git-r3
@@ -517,14 +517,14 @@ src_install() {
 			-e "/^ExecStart/s,emacs,${EPREFIX}/usr/bin/${EMACS_SUFFIX}," \
 			-e "/^ExecStop/s,emacsclient,${EPREFIX}/usr/bin/&-${EMACS_SUFFIX}," \
 			etc/emacs.service | newins - ${EMACS_SUFFIX}.service
-		assert
+		pipestatus || die
 	fi
 
 	if use gzip-el; then
 		# compress .el files when a corresponding .elc exists
 		find "${ED}"/usr/share/emacs/${FULL_VERSION}/lisp -type f \
 			-name "*.elc" -print | sed 's/\.elc$/.el/' | xargs gzip -9n
-		assert "gzip .el failed"
+		pipestatus || die "gzip .el pipeline failed"
 	fi
 
 	local cdir

--- a/app-editors/emacs/emacs-30.0.9999-r1.ebuild
+++ b/app-editors/emacs/emacs-30.0.9999-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit autotools elisp-common flag-o-matic readme.gentoo-r1 toolchain-funcs
+inherit autotools eapi9-pipestatus elisp-common flag-o-matic readme.gentoo-r1 toolchain-funcs
 
 if [[ ${PV##*.} = 9999 ]]; then
 	inherit git-r3
@@ -517,14 +517,14 @@ src_install() {
 			-e "/^ExecStart/s,emacs,${EPREFIX}/usr/bin/${EMACS_SUFFIX}," \
 			-e "/^ExecStop/s,emacsclient,${EPREFIX}/usr/bin/&-${EMACS_SUFFIX}," \
 			etc/emacs.service | newins - ${EMACS_SUFFIX}.service
-		assert
+		pipestatus || die
 	fi
 
 	if use gzip-el; then
 		# compress .el files when a corresponding .elc exists
 		find "${ED}"/usr/share/emacs/${FULL_VERSION}/lisp -type f \
 			-name "*.elc" -print | sed 's/\.elc$/.el/' | xargs gzip -9n
-		assert "gzip .el failed"
+		pipestatus || die "gzip .el pipeline failed"
 	fi
 
 	local cdir

--- a/app-editors/emacs/emacs-31.0.9999.ebuild
+++ b/app-editors/emacs/emacs-31.0.9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit autotools elisp-common flag-o-matic readme.gentoo-r1 toolchain-funcs
+inherit autotools eapi9-pipestatus elisp-common flag-o-matic readme.gentoo-r1 toolchain-funcs
 
 if [[ ${PV##*.} = 9999 ]]; then
 	inherit git-r3
@@ -517,14 +517,14 @@ src_install() {
 			-e "/^ExecStart/s,emacs,${EPREFIX}/usr/bin/${EMACS_SUFFIX}," \
 			-e "/^ExecStop/s,emacsclient,${EPREFIX}/usr/bin/&-${EMACS_SUFFIX}," \
 			etc/emacs.service | newins - ${EMACS_SUFFIX}.service
-		assert
+		pipestatus || die
 	fi
 
 	if use gzip-el; then
 		# compress .el files when a corresponding .elc exists
 		find "${ED}"/usr/share/emacs/${FULL_VERSION}/lisp -type f \
 			-name "*.elc" -print | sed 's/\.elc$/.el/' | xargs gzip -9n
-		assert "gzip .el failed"
+		pipestatus || die "gzip .el pipeline failed"
 	fi
 
 	local cdir


### PR DESCRIPTION
This implements the pipestatus command, as proposed for EAPI 9:

> Tests the shell's pipe status array, i.e. the exit status of the command(s) in the most recently executed foreground pipeline. Returns shell true (0) if all elements are zero, or the last non-zero element otherwise. If called with -v as the first argument, also outputs the pipe status array as a space-separated list.

Bug: https://bugs.gentoo.org/566342

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
