### PR TITLE
sys-fs/compsize: add upstream PR link to patch

### DIFF
--- a/sys-fs/compsize/files/compsize-1.5-btrfs-progs.patch
+++ b/sys-fs/compsize/files/compsize-1.5-btrfs-progs.patch
@@ -1,5 +1,4 @@
-diff --git a/compsize.c b/compsize.c
-index 42ec304..0f533e5 100644
+See upstream PR: https://github.com/kilobyte/compsize/pull/54
 --- a/compsize.c
 +++ b/compsize.c
 @@ -5,12 +5,14 @@


### PR DESCRIPTION
Requested in https://github.com/gentoo/gentoo/pull/39406#pullrequestreview-2456379485