### PR TITLE
dev-libs/liblogging: add BDEPEND on dev-python/docutils

### DIFF
--- a/dev-libs/liblogging/liblogging-1.0.7.ebuild
+++ b/dev-libs/liblogging/liblogging-1.0.7.ebuild
@@ -17,7 +17,10 @@ IUSE="systemd"
 
 RDEPEND="systemd? ( sys-apps/systemd )"
 DEPEND="${RDEPEND}"
-BDEPEND="virtual/pkgconfig"
+BDEPEND="
+	dev-python/docutils
+	virtual/pkgconfig
+"
 
 DOCS=( ChangeLog )
 


### PR DESCRIPTION
otherwise, congfigure will failed with error:

  rst2man is required to build man pages. You can use the release tarball
  with pregenerated man pages to avoid this depedency. Alternatively, use
  --disable-man-pages to build without them.

Closes: https://bugs.gentoo.org/944743

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
