### PR TITLE
mailclient/alpine: list of patches must be sorted

### DIFF
--- a/mail-client/alpine/alpine-2.26-r5.ebuild
+++ b/mail-client/alpine/alpine-2.26-r5.ebuild
@@ -29,10 +29,7 @@ src_prepare() {
 	default
 
 	# apply patches from upstream git to fix compiler issues
-	local patches=$(find "${WORKDIR}/${P}-patches" -type f -name "0*.patch")
-	for patch in ${patches}; do
-		eapply "${patch}"
-	done
+	eapply "${WORKDIR}"/${P}-patches/0*.patch
 
 	# optional extra features, see https://alpineapp.email/alpine/index.html
 	use chappa && eapply "${WORKDIR}/${P}-patches/chappa-rebased.patch"


### PR DESCRIPTION
Different filesystems create different on-disk ordering for new files, so anything found by find must be explicitly sorted.

Closes: https://bugs.gentoo.org/944973

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
