### PR TITLE
dev-util/gitlab-cli: fix BDEPEND

### DIFF
--- a/dev-util/gitlab-cli/gitlab-cli-1.48.0.ebuild
+++ b/dev-util/gitlab-cli/gitlab-cli-1.48.0.ebuild
@@ -15,7 +15,7 @@ LICENSE="MIT"
 SLOT="0"
 KEYWORDS="~amd64"
 
-BDEPEND=">=dev-lang/go-1.23.0"
+BDEPEND=">=dev-lang/go-1.23.2"
 
 # tests communicate with gitlab.com and require a personal access token
 RESTRICT="test"


### PR DESCRIPTION
gitlab-cli 1.48.0 requires go 1.23.2.

Closes: https://bugs.gentoo.org/942996

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgdev commit` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
