### PR TITLE
media-gfx/freecad: Make BIM optional and always disable Drawing

### DIFF
--- a/media-gfx/freecad/freecad-9999.ebuild
+++ b/media-gfx/freecad/freecad-9999.ebuild
@@ -26,18 +26,17 @@ fi
 # examples are licensed CC-BY-SA (without note of specific version)
 LICENSE="LGPL-2 CC-BY-SA-4.0"
 SLOT="0"
-IUSE="debug designer +gui netgen pcl +smesh spacenav test X"
+IUSE="debug designer +gui netgen pcl smesh spacenav test X"
 # Modules are found in src/Mod/ and their options defined in:
 # cMake/FreeCAD_Helpers/InitializeFreeCADBuildOptions.cmake
 # To get their dependencies:
 # 'grep REQUIRES_MODS cMake/FreeCAD_Helpers/CheckInterModuleDependencies.cmake'
-IUSE+=" addonmgr +bim cam cloud fem idf inspection +mesh openscad points reverse robot surface +techdraw"
+IUSE+=" addonmgr bim cam cloud fem idf inspection mesh openscad points reverse robot surface +techdraw"
 
 REQUIRED_USE="
 	${PYTHON_REQUIRED_USE}
 	bim? ( mesh )
 	cam? ( mesh )
-	gui? ( bim )
 	designer? ( gui )
 	fem? ( smesh )
 	inspection? ( points )
@@ -46,7 +45,6 @@ REQUIRED_USE="
 	reverse? ( mesh points )
 	test? ( techdraw )
 "
-# Draft Workbench needs BIM
 
 RESTRICT="!test? ( test )"
 

--- a/media-gfx/freecad/freecad-9999.ebuild
+++ b/media-gfx/freecad/freecad-9999.ebuild
@@ -153,7 +153,7 @@ src_configure() {
 		-DBUILD_CAM=$(usex cam)
 		-DBUILD_CLOUD=$(usex cloud)
 		-DBUILD_DRAFT=ON
-		# see below for DRAWING
+		-DBUILD_DRAWING=OFF						# Unmaintained and not ported to Qt 6
 		-DBUILD_FEM=$(usex fem)
 		-DBUILD_FEM_NETGEN=$(usex fem $(usex netgen))
 		-DBUILD_FLAT_MESH=$(usex mesh)			# a submodule of MeshPart
@@ -230,8 +230,6 @@ src_configure() {
 			-DQt6Core_MOC_EXECUTABLE="$(qt6_get_bindir)/moc"
 			-DQt6Core_RCC_EXECUTABLE="$(qt6_get_bindir)/rcc"
 			-DBUILD_QT5=OFF
-			# Drawing module unmaintained and not ported to qt6
-			-DBUILD_DRAWING=OFF
 		)
 	fi
 


### PR DESCRIPTION
Always explicitly disable Drawing

In main Draft will now work without BIM, so can build without Mesh, SMESH and requiring VTK

https://github.com/FreeCAD/FreeCAD/commit/7183de92a44e1438b5b25234ec0eb7156dfeec8f
https://github.com/FreeCAD/FreeCAD/commit/ee2f384b2fdfb5a3201b2d619fde8f45950da9f8

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Added with `pkgdev commit`

Please note that all boxes must be checked for the pull request to be merged.
