### PR TITLE
net-analyzer/nfdump: fix compilation with USE="-zstd"

### DIFF
--- a/net-analyzer/nfdump/nfdump-1.7.4.ebuild
+++ b/net-analyzer/nfdump/nfdump-1.7.4.ebuild
@@ -76,7 +76,7 @@ src_configure() {
 		$(use_enable nsel)
 		$(use_enable readpcap)
 		$(use_enable sflow)
-		$(use_with zstd "zstdpath=${EPREFIX}/usr")
+		$(use_with zstd "zstdpath" "${EPREFIX}/usr")
 	)
 	econf "${myeconfargs[@]}"
 }


### PR DESCRIPTION
My previous fix works well with ```USE="zstd"```, but it breaks the compilation with that ``USE``` flag disabled.

Closes: https://bugs.gentoo.org/944974
Signed-off-by: Cristian Othón Martínez Vera <cfuga@cfuga.mx>

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
