### PR TITLE
kernel-build.eclass: install dtb into `/lib/modules` instead of `/boot`

### DIFF
--- a/eclass/kernel-build.eclass
+++ b/eclass/kernel-build.eclass
@@ -379,9 +379,10 @@ kernel-build_src_install() {
 
 	local target
 	for target in "${targets[@]}" ; do
-		emake O="${WORKDIR}"/build "${MAKEARGS[@]}" \
+		emake O="${WORKDIR}"/build "${MAKEARGS[@]}" INSTALL_PATH="${ED}/boot" \
 			INSTALL_MOD_PATH="${ED}" INSTALL_MOD_STRIP="${strip_args}" \
-			INSTALL_PATH="${ED}/boot" "${compress[@]}" "${target}"
+			INSTALL_DTBS_PATH="${ED}/lib/modules/${KV_FULL}/dtb" \
+			"${compress[@]}" "${target}"
 	done
 
 	# note: we're using mv rather than doins to save space and time


### PR DESCRIPTION
Systemd's kernel-install hooks expect it here or in the firmware directory. We need to find it for building UKI's and registering BLS type 1 entries. Fedora and Arch also install the dtb files here.

If it is needed in `/boot` then it is probably a better idea to delegate that task to `/sbin/installkernel` anyway. That way the part of the emerge that writes to `/boot` is contained to only the postinst and config phases and makes it possible to re-try this via `emerge --config ...` .

Closes: https://bugs.gentoo.org/945072

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
