### PR TITLE
net-im/gajim: remove net-libs/gupnp-igd dependency

### DIFF
--- a/net-im/gajim/gajim-1.8.4-r1.ebuild
+++ b/net-im/gajim/gajim-1.8.4-r1.ebuild
@@ -1,0 +1,104 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_REQ_USE="sqlite,xml(+)"
+DISTUTILS_USE_PEP517=standalone
+DISTUTILS_SINGLE_IMPL=1
+
+inherit distutils-r1 xdg-utils
+
+DESCRIPTION="Jabber client written in PyGTK"
+HOMEPAGE="https://gajim.org/"
+SRC_URI="https://gajim.org/downloads/$(ver_cut 1-2)/${P/_p/-}.tar.gz"
+
+LICENSE="GPL-3"
+SLOT="0"
+# KEYWORDS="~amd64 ~arm64 ~loong ~riscv ~x86"
+# Gajim depends now on omemo-dr. Add KEYWORDS again,
+# when https://bugs.gentoo.org/912285 is fixed.
+
+KEYWORDS="~amd64 ~arm64 ~loong ~riscv ~x86"
+IUSE="+crypt geolocation jingle remote rst +spell +webp"
+
+COMMON_DEPEND="
+	dev-libs/gobject-introspection[cairo(+)]
+	>=x11-libs/gtk+-3.22:3[introspection]
+	x11-libs/gtksourceview:4[introspection]"
+DEPEND="${COMMON_DEPEND}
+	app-arch/unzip
+	virtual/pkgconfig
+	>=x11-libs/pango-1.5.0
+	>=sys-devel/gettext-0.17-r1"
+RDEPEND="${COMMON_DEPEND}
+	$(python_gen_cond_dep '
+		dev-python/idna[${PYTHON_USEDEP}]
+		>=dev-python/nbxmpp-4.2.2[${PYTHON_USEDEP}]
+		<dev-python/nbxmpp-5.0.0[${PYTHON_USEDEP}]
+		dev-python/precis-i18n[${PYTHON_USEDEP}]
+		dev-python/pyasn1[${PYTHON_USEDEP}]
+		dev-python/pycairo[${PYTHON_USEDEP}]
+		dev-python/pycurl[${PYTHON_USEDEP}]
+		dev-python/pygobject:3[cairo,${PYTHON_USEDEP}]
+		x11-libs/libXScrnSaver
+		app-crypt/libsecret[crypt,introspection]
+		dev-python/keyring[${PYTHON_USEDEP}]
+		>=dev-python/secretstorage-3.1.1[${PYTHON_USEDEP}]
+		dev-python/css-parser[${PYTHON_USEDEP}]
+		dev-python/packaging[${PYTHON_USEDEP}]
+		net-libs/libsoup:3.0[introspection]
+		media-libs/gsound[introspection]
+		dev-python/pillow[${PYTHON_USEDEP}]
+		dev-python/jaraco-classes[${PYTHON_USEDEP}]
+		dev-python/python-axolotl[${PYTHON_USEDEP}]
+		dev-python/qrcode[${PYTHON_USEDEP}]
+		dev-python/cryptography[${PYTHON_USEDEP}]
+		dev-python/omemo-dr[${PYTHON_USEDEP}]
+		crypt? (
+			dev-python/pycryptodome[${PYTHON_USEDEP}]
+			>=dev-python/python-gnupg-0.4.0[${PYTHON_USEDEP}] )
+		geolocation? ( app-misc/geoclue[introspection] )
+		jingle? (
+			net-libs/farstream:0.2[introspection]
+			media-libs/gstreamer:1.0[introspection]
+			media-libs/gst-plugins-base:1.0[introspection]
+			media-libs/gst-plugins-ugly:1.0
+			media-plugins/gst-plugins-gtk
+		)
+		remote? (
+			>=dev-python/dbus-python-1.2.0[${PYTHON_USEDEP}]
+			sys-apps/dbus[X]
+		)
+		rst? ( dev-python/docutils[${PYTHON_USEDEP}] )
+		spell? (
+			app-text/gspell[introspection]
+			app-text/hunspell
+		)
+	')"
+
+python_compile() {
+	distutils-r1_python_compile
+	./pep517build/build_metadata.py -o dist/metadata
+}
+
+python_install() {
+	distutils-r1_python_install
+	./pep517build/install_metadata.py dist/metadata --prefix="${D}/usr"
+
+	gzip -d "${ED}"/usr/share/man/man1/*.gz || die
+}
+
+pkg_postinst() {
+	xdg_icon_cache_update
+	xdg_desktop_database_update
+}
+
+pkg_postrm() {
+	xdg_icon_cache_update
+	xdg_desktop_database_update
+}
+
+# Tests are unfortunately regularly broken
+RESTRICT="test"

--- a/net-im/gajim/gajim-1.9.5-r1.ebuild
+++ b/net-im/gajim/gajim-1.9.5-r1.ebuild
@@ -1,0 +1,106 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_REQ_USE="sqlite,xml(+)"
+DISTUTILS_USE_PEP517=standalone
+DISTUTILS_SINGLE_IMPL=1
+
+inherit distutils-r1 xdg-utils
+
+DESCRIPTION="XMPP client written in PyGTK"
+HOMEPAGE="https://gajim.org/"
+SRC_URI="https://gajim.org/downloads/$(ver_cut 1-2)/${P/_p/-}.tar.gz"
+
+LICENSE="GPL-3"
+SLOT="0"
+
+# Rekeyword for ~long, ~x86 and ~riscv, when https://bugs.gentoo.org/937582 is fixed.
+# KEYWORDS="~amd64 ~arm64 ~loong ~riscv ~x86"
+KEYWORDS="~amd64 ~arm64"
+IUSE="+crypt geolocation jingle remote rst +spell +webp"
+
+COMMON_DEPEND="
+	dev-libs/gobject-introspection[cairo(+)]
+	>=x11-libs/gtk+-3.24.30:3[introspection]
+	x11-libs/gtksourceview:4[introspection]"
+DEPEND="${COMMON_DEPEND}
+	app-arch/unzip
+	virtual/pkgconfig
+	>=x11-libs/pango-1.50.0
+	>=sys-devel/gettext-0.17-r1"
+RDEPEND="${COMMON_DEPEND}
+	$(python_gen_cond_dep '
+		dev-python/idna[${PYTHON_USEDEP}]
+		>=dev-python/nbxmpp-5.0.4[${PYTHON_USEDEP}]
+		dev-python/precis-i18n[${PYTHON_USEDEP}]
+		dev-python/pyasn1[${PYTHON_USEDEP}]
+		dev-python/pycairo[${PYTHON_USEDEP}]
+		dev-python/pycurl[${PYTHON_USEDEP}]
+		dev-python/pygobject:3[cairo,${PYTHON_USEDEP}]
+		x11-libs/libXScrnSaver
+		app-crypt/libsecret[crypt,introspection]
+		dev-python/keyring[${PYTHON_USEDEP}]
+		>=dev-python/secretstorage-3.1.1[${PYTHON_USEDEP}]
+		dev-python/css-parser[${PYTHON_USEDEP}]
+		dev-python/packaging[${PYTHON_USEDEP}]
+		net-libs/libsoup:3.0[introspection]
+		media-libs/gsound[introspection]
+		dev-python/pillow[${PYTHON_USEDEP}]
+		dev-python/jaraco-classes[${PYTHON_USEDEP}]
+		dev-python/python-axolotl[${PYTHON_USEDEP}]
+		dev-python/sqlalchemy[${PYTHON_USEDEP}]
+		dev-python/emoji[${PYTHON_USEDEP}]
+		dev-python/qrcode[${PYTHON_USEDEP}]
+		dev-python/cryptography[${PYTHON_USEDEP}]
+		dev-python/omemo-dr[${PYTHON_USEDEP}]
+		crypt? (
+			dev-python/pycryptodome[${PYTHON_USEDEP}]
+			>=dev-python/python-gnupg-0.4.0[${PYTHON_USEDEP}] )
+		geolocation? ( app-misc/geoclue[introspection] )
+		jingle? (
+			net-libs/farstream:0.2[introspection]
+			media-libs/gstreamer:1.0[introspection]
+			media-libs/gst-plugins-base:1.0[introspection]
+			media-libs/gst-plugins-ugly:1.0
+			media-plugins/gst-plugins-gtk
+		)
+		remote? (
+			>=dev-python/dbus-python-1.2.0[${PYTHON_USEDEP}]
+			sys-apps/dbus[X]
+		)
+		rst? ( dev-python/docutils[${PYTHON_USEDEP}] )
+		spell? (
+			app-text/gspell[introspection]
+			app-text/hunspell
+		)
+	')"
+
+python_compile() {
+	./make.py build --dist unix || die
+	distutils-r1_python_compile
+}
+
+python_install() {
+	distutils-r1_python_install
+	./make.py install --dist unix --prefix="${ED}/usr" || die
+
+	gzip -d "${ED}"/usr/share/man/man1/*.gz || die
+}
+
+pkg_postinst() {
+	ewarn "The chat database format changes when upgrading from 1.8.x to 1.9.x."
+	ewarn "The first time the user starts Gajim, an automatic migration is performed."
+	xdg_icon_cache_update
+	xdg_desktop_database_update
+}
+
+pkg_postrm() {
+	xdg_icon_cache_update
+	xdg_desktop_database_update
+}
+
+# Tests are unfortunately regularly broken
+RESTRICT="test"


### PR DESCRIPTION
Upstream removed that dependency since version 1.5.3

https://dev.gajim.org/gajim/gajim/-/issues/11183
https://dev.gajim.org/gajim/gajim/-/commit/4b497df5d065af3b3bc95f7c26096e7792bc467a

Signed-off-by: Cristian Othón Martínez Vera <cfuga@cfuga.mx>

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
