### PR TITLE
extend (& unify) local `numa` USE flag descriptions

### DIFF
--- a/app-emulation/qemu/metadata.xml
+++ b/app-emulation/qemu/metadata.xml
@@ -31,7 +31,7 @@
 		<pkg>sys-fs/multipath-tools</pkg>.</flag>
 		<flag name="ncurses">Enable the ncurses-based console</flag>
 		<flag name="nfs">Enable NFS support</flag>
-		<flag name="numa">Enable NUMA support</flag>
+		<flag name="numa">Enable NUMA support using <pkg>sys-process/numactl</pkg> (NUMA kernel support is also required)</flag>
 		<flag name="pin-upstream-blobs">Pin the versions of BIOS firmware to the version included in the upstream release.
 		This is needed to sanely support migration/suspend/resume/snapshotting/etc... of instances.
 		When the blobs are different, random corruption/bugs/crashes/etc... may be observed.</flag>

--- a/dev-util/lttng-ust/metadata.xml
+++ b/dev-util/lttng-ust/metadata.xml
@@ -3,7 +3,7 @@
 <pkgmetadata>
 	<!-- maintainer-needed -->
 	<use>
-		<flag name="numa">Enable numa support</flag>
+		<flag name="numa">Enable NUMA support using <pkg>sys-process/numactl</pkg> (NUMA kernel support is also required)</flag>
 	</use>
 	<longdescription>
 		The userspace tracer is designed to provide detailed information about userspace activity. UST is a port of the LTTng kernel tracer to userspace. Like the LTTng kernel tracer, performance is the main goal. Tracing does not require system calls or traps. UST instrumentation points may be added in any userspace code including signal handlers and libraries.

--- a/media-libs/x265/metadata.xml
+++ b/media-libs/x265/metadata.xml
@@ -7,7 +7,7 @@
   <use>
     <flag name="10bit">Add support for producing 10bits HEVC.</flag>
     <flag name="12bit">Add support for producing 12bits HEVC.</flag>
-    <flag name="numa">Build with support for NUMA nodes.</flag>
+    <flag name="numa">Enable NUMA support using <pkg>sys-process/numactl</pkg> (NUMA kernel support is also required)</flag>
   </use>
   <upstream>
     <remote-id type="bitbucket">multicoreware/x265_git</remote-id>

--- a/net-libs/libtrace/metadata.xml
+++ b/net-libs/libtrace/metadata.xml
@@ -6,7 +6,7 @@
 		<name>Gentoo network monitoring and analysis project</name>
 	</maintainer>
 	<use>
-		<flag name="numa">Use <pkg>sys-process/numactl</pkg></flag>
+		<flag name="numa">Enable NUMA support using <pkg>sys-process/numactl</pkg> (NUMA kernel support is also required)</flag>
 	</use>
 	<upstream>
 		<remote-id type="github">LibtraceTeam/libtrace</remote-id>

--- a/sys-block/fio/metadata.xml
+++ b/sys-block/fio/metadata.xml
@@ -15,7 +15,7 @@
 		<flag name="pandas">Install dependencies for complex python scripts</flag>
 		<flag name="io-uring">Enable efficient I/O via <pkg>sys-libs/liburing</pkg>.</flag>
 		<flag name="nfs">Enable NFS support</flag>
-		<flag name="numa">Enable numa support</flag>
+		<flag name="numa">Enable NUMA support using <pkg>sys-process/numactl</pkg> (NUMA kernel support is also required)</flag>
 		<flag name="rbd">Enable Rados block device support via <pkg>sys-cluster/ceph</pkg></flag>
 		<flag name="rdma">Enable infiniband support via <pkg>sys-cluster/rdma-core</pkg></flag>
 		<flag name="tcmalloc">Link against <pkg>dev-util/google-perftools</pkg> by default which will speed up USE=rbd up to 20%</flag>


### PR DESCRIPTION
I have just took generic `numa` USE flag descriptions and made them more detailed.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
