### PR TITLE
www-client/firefox: Backport upstream commits to add python3.13 support

### DIFF
--- a/dev-lang/spidermonkey/files/spidermonkey-115.16.0-tests-add-python3.13-support.patch
+++ b/dev-lang/spidermonkey/files/spidermonkey-115.16.0-tests-add-python3.13-support.patch
@@ -1,0 +1,928 @@
+# HG changeset patch
+# User Rob Wu <rob@robwu.nl>
+# Date 1730841860 0
+#      Tue Nov 05 21:24:20 2024 +0000
+# Node ID e6aacb7e350b55e8656869a6a3a59a4980ad2ca4
+# Parent  6644fb42021841f02be5bbaf8208b352114c7b3b
+Bug 1926140 - Replace pipes imports r=jmaher
+
+pipes does not exist in Python 3.11 any more
+
+Differential Revision: https://phabricator.services.mozilla.com/D227964
+
+diff -r 6644fb420218 -r e6aacb7e350b js/src/tests/lib/results.py
+--- a/js/src/tests/lib/results.py	Mon Sep 23 11:31:31 2024 +0000
++++ b/js/src/tests/lib/results.py	Tue Nov 05 21:24:20 2024 +0000
+@@ -1,6 +1,6 @@
+ import json
+-import pipes
+ import re
++import shlex
+ 
+ from .progressbar import NullProgressBar, ProgressBar
+ from .structuredlog import TestLogger
+@@ -9,7 +9,7 @@
+ 
+ 
+ def escape_cmdline(args):
+-    return " ".join([pipes.quote(a) for a in args])
++    return " ".join([shlex.quote(a) for a in args])
+ 
+ 
+ class TestOutput:
+diff -r 6644fb420218 -r e6aacb7e350b testing/mozbase/mozdevice/mozdevice/adb.py
+--- a/testing/mozbase/mozdevice/mozdevice/adb.py	Mon Sep 23 11:31:31 2024 +0000
++++ b/testing/mozbase/mozdevice/mozdevice/adb.py	Tue Nov 05 21:24:20 2024 +0000
+@@ -4,7 +4,6 @@
+ 
+ import io
+ import os
+-import pipes
+ import posixpath
+ import re
+ import shlex
+@@ -1294,8 +1293,6 @@
+         """Utility function to return quoted version of command argument."""
+         if hasattr(shlex, "quote"):
+             quote = shlex.quote
+-        elif hasattr(pipes, "quote"):
+-            quote = pipes.quote
+         else:
+ 
+             def quote(arg):
+diff -r 6644fb420218 -r e6aacb7e350b testing/xpcshell/runxpcshelltests.py
+--- a/testing/xpcshell/runxpcshelltests.py	Mon Sep 23 11:31:31 2024 +0000
++++ b/testing/xpcshell/runxpcshelltests.py	Tue Nov 05 21:24:20 2024 +0000
+@@ -7,9 +7,9 @@
+ import copy
+ import json
+ import os
+-import pipes
+ import random
+ import re
++import shlex
+ import shutil
+ import signal
+ import subprocess
+@@ -353,11 +353,11 @@
+         )
+         self.log.info("%s | environment: %s" % (name, list(changedEnv)))
+         shell_command_tokens = [
+-            pipes.quote(tok) for tok in list(changedEnv) + completeCmd
++            shlex.quote(tok) for tok in list(changedEnv) + completeCmd
+         ]
+         self.log.info(
+             "%s | as shell command: (cd %s; %s)"
+-            % (name, pipes.quote(testdir), " ".join(shell_command_tokens))
++            % (name, shlex.quote(testdir), " ".join(shell_command_tokens))
+         )
+ 
+     def killTimeout(self, proc):
+# HG changeset patch
+# User Rob Wu <rob@robwu.nl>
+# Date 1730828835 0
+#      Tue Nov 05 17:47:15 2024 +0000
+# Node ID d28b8b0e684621bbb0c90e96b50190c66ce47fd5
+# Parent  e6aacb7e350b55e8656869a6a3a59a4980ad2ca4
+Bug 1925198 - Move telnetlib import to BaseEmulator r=jmaher
+
+emulator.py currently has an unconditional telnetlib import, but the
+file can also be imported when the functionality is not needed.
+
+Because telnetlib was removed from Python 3.13, this unconditional
+import breaks use cases that do not even care about telnet. As a stopgap
+measure until a better fix is available, move the import to the function
+that relies on telnet.
+
+Differential Revision: https://phabricator.services.mozilla.com/D227995
+
+diff -r e6aacb7e350b -r d28b8b0e6846 testing/mozbase/mozrunner/mozrunner/devices/emulator.py
+--- a/testing/mozbase/mozrunner/mozrunner/devices/emulator.py	Tue Nov 05 21:24:20 2024 +0000
++++ b/testing/mozbase/mozrunner/mozrunner/devices/emulator.py	Tue Nov 05 17:47:15 2024 +0000
+@@ -8,7 +8,6 @@
+ import subprocess
+ import tempfile
+ import time
+-from telnetlib import Telnet
+ 
+ from mozdevice import ADBHost
+ from mozprocess import ProcessHandler
+@@ -189,6 +188,11 @@
+ 
+     def _run_telnet(self, command):
+         if not self.telnet:
++            # telnetlib is dropped in Python 3.13 (bug 1925198).
++            # Import here instead of the top level to avoid breaking users of
++            # this file that are independent of telnet.
++            from telnetlib import Telnet
++
+             self.telnet = Telnet("localhost", self.port)
+             self._get_telnet_response()
+         return self._get_telnet_response(command)
+# HG changeset patch
+# User Rob Wu <rob@robwu.nl>
+# Date 1731088502 0
+#      Fri Nov 08 17:55:02 2024 +0000
+# Node ID 49a6b6deabff6b951c590fad499f356ab896e9e3
+# Parent  d28b8b0e684621bbb0c90e96b50190c66ce47fd5
+Bug 1929535 - Vendor telnetlib.py r=jmaher,jgraham
+
+telnetlib.py was removed from Python 3.13, but we still depend on its
+functionality. This patch imports the original standard library from
+https://github.com/python/cpython/blob/3.12/Lib/telnetlib.py
+
+The only changes are:
+- Prepend comments at start to attribute source.
+- Prepend fmt/noqa/ruff to suppress linting by black/ruff, to avoid
+  non-critical modifications.
+- Remove `warnings._deprecated(__name__, remove=(3, 13))` call to
+  avoid a deprecation warning when loading the module.
+
+Differential Revision: https://phabricator.services.mozilla.com/D228052
+
+diff -r d28b8b0e6846 -r 49a6b6deabff testing/mozbase/mozrunner/mozrunner/devices/android_device.py
+--- a/testing/mozbase/mozrunner/mozrunner/devices/android_device.py	Tue Nov 05 17:47:15 2024 +0000
++++ b/testing/mozbase/mozrunner/mozrunner/devices/android_device.py	Fri Nov 08 17:55:02 2024 +0000
+@@ -11,7 +11,6 @@
+ import signal
+ import subprocess
+ import sys
+-import telnetlib
+ import time
+ from distutils.spawn import find_executable
+ from enum import Enum
+@@ -20,6 +19,11 @@
+ from mozdevice import ADBDeviceFactory, ADBHost
+ from six.moves import input, urllib
+ 
++try:
++    import telnetlib
++except ImportError:  # telnetlib was removed in Python 3.13
++    from . import telnetlib
++
+ MOZBUILD_PATH = os.environ.get(
+     "MOZBUILD_STATE_PATH", os.path.expanduser(os.path.join("~", ".mozbuild"))
+ )
+diff -r d28b8b0e6846 -r 49a6b6deabff testing/mozbase/mozrunner/mozrunner/devices/emulator.py
+--- a/testing/mozbase/mozrunner/mozrunner/devices/emulator.py	Tue Nov 05 17:47:15 2024 +0000
++++ b/testing/mozbase/mozrunner/mozrunner/devices/emulator.py	Fri Nov 08 17:55:02 2024 +0000
+@@ -18,6 +18,11 @@
+ from .emulator_geo import EmulatorGeo
+ from .emulator_screen import EmulatorScreen
+ 
++try:
++    from telnetlib import Telnet
++except ImportError:  # telnetlib was removed in Python 3.13
++    from .telnetlib import Telnet
++
+ 
+ class ArchContext(object):
+     def __init__(self, arch, context, binary=None, avd=None, extra_args=None):
+@@ -188,11 +193,6 @@
+ 
+     def _run_telnet(self, command):
+         if not self.telnet:
+-            # telnetlib is dropped in Python 3.13 (bug 1925198).
+-            # Import here instead of the top level to avoid breaking users of
+-            # this file that are independent of telnet.
+-            from telnetlib import Telnet
+-
+             self.telnet = Telnet("localhost", self.port)
+             self._get_telnet_response()
+         return self._get_telnet_response(command)
+diff -r d28b8b0e6846 -r 49a6b6deabff testing/mozbase/mozrunner/mozrunner/devices/telnetlib.py
+--- /dev/null	Thu Jan 01 00:00:00 1970 +0000
++++ b/testing/mozbase/mozrunner/mozrunner/devices/telnetlib.py	Fri Nov 08 17:55:02 2024 +0000
+@@ -0,0 +1,732 @@
++# Copied from https://github.com/python/cpython/blob/3.12/Lib/telnetlib.py
++# because telnetlib was removed from Python 3.13.
++# fmt: off
++# ruff: noqa: I001, E701
++#
++# This file was part of Python 3.12 and licensed under the PSF license:
++# https://docs.python.org/3.12/license.html#psf-license
++#
++# Copyright © 2001-2023 Python Software Foundation; All Rights Reserved
++#
++# 1. This LICENSE AGREEMENT is between the Python Software Foundation ("PSF"), and
++#    the Individual or Organization ("Licensee") accessing and otherwise using Python
++#    3.12.7 software in source or binary form and its associated documentation.
++#
++# 2. Subject to the terms and conditions of this License Agreement, PSF hereby
++#    grants Licensee a nonexclusive, royalty-free, world-wide license to reproduce,
++#    analyze, test, perform and/or display publicly, prepare derivative works,
++#    distribute, and otherwise use Python 3.12.7 alone or in any derivative
++#    version, provided, however, that PSF's License Agreement and PSF's notice of
++#    copyright, i.e., "Copyright © 2001-2023 Python Software Foundation; All Rights
++#    Reserved" are retained in Python 3.12.7 alone or in any derivative version
++#    prepared by Licensee.
++#
++# 3. In the event Licensee prepares a derivative work that is based on or
++#    incorporates Python 3.12.7 or any part thereof, and wants to make the
++#    derivative work available to others as provided herein, then Licensee hereby
++#    agrees to include in any such work a brief summary of the changes made to Python
++#    3.12.7.
++#
++# 4. PSF is making Python 3.12.7 available to Licensee on an "AS IS" basis.
++#    PSF MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED.  BY WAY OF
++#    EXAMPLE, BUT NOT LIMITATION, PSF MAKES NO AND DISCLAIMS ANY REPRESENTATION OR
++#    WARRANTY OF MERCHANTABILITY OR FITNESS FOR ANY PARTICULAR PURPOSE OR THAT THE
++#    USE OF PYTHON 3.12.7 WILL NOT INFRINGE ANY THIRD PARTY RIGHTS.
++#
++# 5. PSF SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF PYTHON 3.12.7
++#    FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS AS A RESULT OF
++#    MODIFYING, DISTRIBUTING, OR OTHERWISE USING PYTHON 3.12.7, OR ANY DERIVATIVE
++#    THEREOF, EVEN IF ADVISED OF THE POSSIBILITY THEREOF.
++#
++# 6. This License Agreement will automatically terminate upon a material breach of
++#    its terms and conditions.
++#
++# 7. Nothing in this License Agreement shall be deemed to create any relationship
++#    of agency, partnership, or joint venture between PSF and Licensee.  This License
++#    Agreement does not grant permission to use PSF trademarks or trade name in a
++#    trademark sense to endorse or promote products or services of Licensee, or any
++#    third party.
++#
++# 8. By copying, installing or otherwise using Python 3.12.7, Licensee agrees
++#    to be bound by the terms and conditions of this License Agreement.
++
++# The original https://github.com/python/cpython/blob/3.12/Lib/telnetlib.py
++# content starts below. The following changed have been made:
++# - Removed "warnings._deprecated" call to avoid a deprecation warning.
++r"""TELNET client class.
++
++Based on RFC 854: TELNET Protocol Specification, by J. Postel and
++J. Reynolds
++
++Example:
++
++>>> from telnetlib import Telnet
++>>> tn = Telnet('www.python.org', 79)   # connect to finger port
++>>> tn.write(b'guido\r\n')
++>>> print(tn.read_all())
++Login       Name               TTY         Idle    When    Where
++guido    Guido van Rossum      pts/2        <Dec  2 11:10> snag.cnri.reston..
++
++>>>
++
++Note that read_all() won't read until eof -- it just reads some data
++-- but it guarantees to read at least one byte unless EOF is hit.
++
++It is possible to pass a Telnet object to a selector in order to wait until
++more data is available.  Note that in this case, read_eager() may return b''
++even if there was data on the socket, because the protocol negotiation may have
++eaten the data.  This is why EOFError is needed in some cases to distinguish
++between "no data" and "connection closed" (since the socket also appears ready
++for reading when it is closed).
++
++To do:
++- option negotiation
++- timeout should be intrinsic to the connection object instead of an
++  option on one of the read calls only
++
++"""
++
++
++# Imported modules
++import sys
++import socket
++import selectors
++from time import monotonic as _time
++
++__all__ = ["Telnet"]
++
++# Tunable parameters
++DEBUGLEVEL = 0
++
++# Telnet protocol defaults
++TELNET_PORT = 23
++
++# Telnet protocol characters (don't change)
++IAC  = bytes([255]) # "Interpret As Command"
++DONT = bytes([254])
++DO   = bytes([253])
++WONT = bytes([252])
++WILL = bytes([251])
++theNULL = bytes([0])
++
++SE  = bytes([240])  # Subnegotiation End
++NOP = bytes([241])  # No Operation
++DM  = bytes([242])  # Data Mark
++BRK = bytes([243])  # Break
++IP  = bytes([244])  # Interrupt process
++AO  = bytes([245])  # Abort output
++AYT = bytes([246])  # Are You There
++EC  = bytes([247])  # Erase Character
++EL  = bytes([248])  # Erase Line
++GA  = bytes([249])  # Go Ahead
++SB =  bytes([250])  # Subnegotiation Begin
++
++
++# Telnet protocol options code (don't change)
++# These ones all come from arpa/telnet.h
++BINARY = bytes([0]) # 8-bit data path
++ECHO = bytes([1]) # echo
++RCP = bytes([2]) # prepare to reconnect
++SGA = bytes([3]) # suppress go ahead
++NAMS = bytes([4]) # approximate message size
++STATUS = bytes([5]) # give status
++TM = bytes([6]) # timing mark
++RCTE = bytes([7]) # remote controlled transmission and echo
++NAOL = bytes([8]) # negotiate about output line width
++NAOP = bytes([9]) # negotiate about output page size
++NAOCRD = bytes([10]) # negotiate about CR disposition
++NAOHTS = bytes([11]) # negotiate about horizontal tabstops
++NAOHTD = bytes([12]) # negotiate about horizontal tab disposition
++NAOFFD = bytes([13]) # negotiate about formfeed disposition
++NAOVTS = bytes([14]) # negotiate about vertical tab stops
++NAOVTD = bytes([15]) # negotiate about vertical tab disposition
++NAOLFD = bytes([16]) # negotiate about output LF disposition
++XASCII = bytes([17]) # extended ascii character set
++LOGOUT = bytes([18]) # force logout
++BM = bytes([19]) # byte macro
++DET = bytes([20]) # data entry terminal
++SUPDUP = bytes([21]) # supdup protocol
++SUPDUPOUTPUT = bytes([22]) # supdup output
++SNDLOC = bytes([23]) # send location
++TTYPE = bytes([24]) # terminal type
++EOR = bytes([25]) # end or record
++TUID = bytes([26]) # TACACS user identification
++OUTMRK = bytes([27]) # output marking
++TTYLOC = bytes([28]) # terminal location number
++VT3270REGIME = bytes([29]) # 3270 regime
++X3PAD = bytes([30]) # X.3 PAD
++NAWS = bytes([31]) # window size
++TSPEED = bytes([32]) # terminal speed
++LFLOW = bytes([33]) # remote flow control
++LINEMODE = bytes([34]) # Linemode option
++XDISPLOC = bytes([35]) # X Display Location
++OLD_ENVIRON = bytes([36]) # Old - Environment variables
++AUTHENTICATION = bytes([37]) # Authenticate
++ENCRYPT = bytes([38]) # Encryption option
++NEW_ENVIRON = bytes([39]) # New - Environment variables
++# the following ones come from
++# http://www.iana.org/assignments/telnet-options
++# Unfortunately, that document does not assign identifiers
++# to all of them, so we are making them up
++TN3270E = bytes([40]) # TN3270E
++XAUTH = bytes([41]) # XAUTH
++CHARSET = bytes([42]) # CHARSET
++RSP = bytes([43]) # Telnet Remote Serial Port
++COM_PORT_OPTION = bytes([44]) # Com Port Control Option
++SUPPRESS_LOCAL_ECHO = bytes([45]) # Telnet Suppress Local Echo
++TLS = bytes([46]) # Telnet Start TLS
++KERMIT = bytes([47]) # KERMIT
++SEND_URL = bytes([48]) # SEND-URL
++FORWARD_X = bytes([49]) # FORWARD_X
++PRAGMA_LOGON = bytes([138]) # TELOPT PRAGMA LOGON
++SSPI_LOGON = bytes([139]) # TELOPT SSPI LOGON
++PRAGMA_HEARTBEAT = bytes([140]) # TELOPT PRAGMA HEARTBEAT
++EXOPL = bytes([255]) # Extended-Options-List
++NOOPT = bytes([0])
++
++
++# poll/select have the advantage of not requiring any extra file descriptor,
++# contrarily to epoll/kqueue (also, they require a single syscall).
++if hasattr(selectors, 'PollSelector'):
++    _TelnetSelector = selectors.PollSelector
++else:
++    _TelnetSelector = selectors.SelectSelector
++
++
++class Telnet:
++
++    """Telnet interface class.
++
++    An instance of this class represents a connection to a telnet
++    server.  The instance is initially not connected; the open()
++    method must be used to establish a connection.  Alternatively, the
++    host name and optional port number can be passed to the
++    constructor, too.
++
++    Don't try to reopen an already connected instance.
++
++    This class has many read_*() methods.  Note that some of them
++    raise EOFError when the end of the connection is read, because
++    they can return an empty string for other reasons.  See the
++    individual doc strings.
++
++    read_until(expected, [timeout])
++        Read until the expected string has been seen, or a timeout is
++        hit (default is no timeout); may block.
++
++    read_all()
++        Read all data until EOF; may block.
++
++    read_some()
++        Read at least one byte or EOF; may block.
++
++    read_very_eager()
++        Read all data available already queued or on the socket,
++        without blocking.
++
++    read_eager()
++        Read either data already queued or some data available on the
++        socket, without blocking.
++
++    read_lazy()
++        Read all data in the raw queue (processing it first), without
++        doing any socket I/O.
++
++    read_very_lazy()
++        Reads all data in the cooked queue, without doing any socket
++        I/O.
++
++    read_sb_data()
++        Reads available data between SB ... SE sequence. Don't block.
++
++    set_option_negotiation_callback(callback)
++        Each time a telnet option is read on the input flow, this callback
++        (if set) is called with the following parameters :
++        callback(telnet socket, command, option)
++            option will be chr(0) when there is no option.
++        No other action is done afterwards by telnetlib.
++
++    """
++    sock = None  # for __del__()
++
++    def __init__(self, host=None, port=0,
++                 timeout=socket._GLOBAL_DEFAULT_TIMEOUT):
++        """Constructor.
++
++        When called without arguments, create an unconnected instance.
++        With a hostname argument, it connects the instance; port number
++        and timeout are optional.
++        """
++        self.debuglevel = DEBUGLEVEL
++        self.host = host
++        self.port = port
++        self.timeout = timeout
++        self.sock = None
++        self.rawq = b''
++        self.irawq = 0
++        self.cookedq = b''
++        self.eof = 0
++        self.iacseq = b'' # Buffer for IAC sequence.
++        self.sb = 0 # flag for SB and SE sequence.
++        self.sbdataq = b''
++        self.option_callback = None
++        if host is not None:
++            self.open(host, port, timeout)
++
++    def open(self, host, port=0, timeout=socket._GLOBAL_DEFAULT_TIMEOUT):
++        """Connect to a host.
++
++        The optional second argument is the port number, which
++        defaults to the standard telnet port (23).
++
++        Don't try to reopen an already connected instance.
++        """
++        self.eof = 0
++        if not port:
++            port = TELNET_PORT
++        self.host = host
++        self.port = port
++        self.timeout = timeout
++        sys.audit("telnetlib.Telnet.open", self, host, port)
++        self.sock = socket.create_connection((host, port), timeout)
++
++    def __del__(self):
++        """Destructor -- close the connection."""
++        self.close()
++
++    def msg(self, msg, *args):
++        """Print a debug message, when the debug level is > 0.
++
++        If extra arguments are present, they are substituted in the
++        message using the standard string formatting operator.
++
++        """
++        if self.debuglevel > 0:
++            print('Telnet(%s,%s):' % (self.host, self.port), end=' ')
++            if args:
++                print(msg % args)
++            else:
++                print(msg)
++
++    def set_debuglevel(self, debuglevel):
++        """Set the debug level.
++
++        The higher it is, the more debug output you get (on sys.stdout).
++
++        """
++        self.debuglevel = debuglevel
++
++    def close(self):
++        """Close the connection."""
++        sock = self.sock
++        self.sock = None
++        self.eof = True
++        self.iacseq = b''
++        self.sb = 0
++        if sock:
++            sock.close()
++
++    def get_socket(self):
++        """Return the socket object used internally."""
++        return self.sock
++
++    def fileno(self):
++        """Return the fileno() of the socket object used internally."""
++        return self.sock.fileno()
++
++    def write(self, buffer):
++        """Write a string to the socket, doubling any IAC characters.
++
++        Can block if the connection is blocked.  May raise
++        OSError if the connection is closed.
++
++        """
++        if IAC in buffer:
++            buffer = buffer.replace(IAC, IAC+IAC)
++        sys.audit("telnetlib.Telnet.write", self, buffer)
++        self.msg("send %r", buffer)
++        self.sock.sendall(buffer)
++
++    def read_until(self, match, timeout=None):
++        """Read until a given string is encountered or until timeout.
++
++        When no match is found, return whatever is available instead,
++        possibly the empty string.  Raise EOFError if the connection
++        is closed and no cooked data is available.
++
++        """
++        n = len(match)
++        self.process_rawq()
++        i = self.cookedq.find(match)
++        if i >= 0:
++            i = i+n
++            buf = self.cookedq[:i]
++            self.cookedq = self.cookedq[i:]
++            return buf
++        if timeout is not None:
++            deadline = _time() + timeout
++        with _TelnetSelector() as selector:
++            selector.register(self, selectors.EVENT_READ)
++            while not self.eof:
++                if selector.select(timeout):
++                    i = max(0, len(self.cookedq)-n)
++                    self.fill_rawq()
++                    self.process_rawq()
++                    i = self.cookedq.find(match, i)
++                    if i >= 0:
++                        i = i+n
++                        buf = self.cookedq[:i]
++                        self.cookedq = self.cookedq[i:]
++                        return buf
++                if timeout is not None:
++                    timeout = deadline - _time()
++                    if timeout < 0:
++                        break
++        return self.read_very_lazy()
++
++    def read_all(self):
++        """Read all data until EOF; block until connection closed."""
++        self.process_rawq()
++        while not self.eof:
++            self.fill_rawq()
++            self.process_rawq()
++        buf = self.cookedq
++        self.cookedq = b''
++        return buf
++
++    def read_some(self):
++        """Read at least one byte of cooked data unless EOF is hit.
++
++        Return b'' if EOF is hit.  Block if no data is immediately
++        available.
++
++        """
++        self.process_rawq()
++        while not self.cookedq and not self.eof:
++            self.fill_rawq()
++            self.process_rawq()
++        buf = self.cookedq
++        self.cookedq = b''
++        return buf
++
++    def read_very_eager(self):
++        """Read everything that's possible without blocking in I/O (eager).
++
++        Raise EOFError if connection closed and no cooked data
++        available.  Return b'' if no cooked data available otherwise.
++        Don't block unless in the midst of an IAC sequence.
++
++        """
++        self.process_rawq()
++        while not self.eof and self.sock_avail():
++            self.fill_rawq()
++            self.process_rawq()
++        return self.read_very_lazy()
++
++    def read_eager(self):
++        """Read readily available data.
++
++        Raise EOFError if connection closed and no cooked data
++        available.  Return b'' if no cooked data available otherwise.
++        Don't block unless in the midst of an IAC sequence.
++
++        """
++        self.process_rawq()
++        while not self.cookedq and not self.eof and self.sock_avail():
++            self.fill_rawq()
++            self.process_rawq()
++        return self.read_very_lazy()
++
++    def read_lazy(self):
++        """Process and return data that's already in the queues (lazy).
++
++        Raise EOFError if connection closed and no data available.
++        Return b'' if no cooked data available otherwise.  Don't block
++        unless in the midst of an IAC sequence.
++
++        """
++        self.process_rawq()
++        return self.read_very_lazy()
++
++    def read_very_lazy(self):
++        """Return any data available in the cooked queue (very lazy).
++
++        Raise EOFError if connection closed and no data available.
++        Return b'' if no cooked data available otherwise.  Don't block.
++
++        """
++        buf = self.cookedq
++        self.cookedq = b''
++        if not buf and self.eof and not self.rawq:
++            raise EOFError('telnet connection closed')
++        return buf
++
++    def read_sb_data(self):
++        """Return any data available in the SB ... SE queue.
++
++        Return b'' if no SB ... SE available. Should only be called
++        after seeing a SB or SE command. When a new SB command is
++        found, old unread SB data will be discarded. Don't block.
++
++        """
++        buf = self.sbdataq
++        self.sbdataq = b''
++        return buf
++
++    def set_option_negotiation_callback(self, callback):
++        """Provide a callback function called after each receipt of a telnet option."""
++        self.option_callback = callback
++
++    def process_rawq(self):
++        """Transfer from raw queue to cooked queue.
++
++        Set self.eof when connection is closed.  Don't block unless in
++        the midst of an IAC sequence.
++
++        """
++        buf = [b'', b'']
++        try:
++            while self.rawq:
++                c = self.rawq_getchar()
++                if not self.iacseq:
++                    if c == theNULL:
++                        continue
++                    if c == b"\021":
++                        continue
++                    if c != IAC:
++                        buf[self.sb] = buf[self.sb] + c
++                        continue
++                    else:
++                        self.iacseq += c
++                elif len(self.iacseq) == 1:
++                    # 'IAC: IAC CMD [OPTION only for WILL/WONT/DO/DONT]'
++                    if c in (DO, DONT, WILL, WONT):
++                        self.iacseq += c
++                        continue
++
++                    self.iacseq = b''
++                    if c == IAC:
++                        buf[self.sb] = buf[self.sb] + c
++                    else:
++                        if c == SB: # SB ... SE start.
++                            self.sb = 1
++                            self.sbdataq = b''
++                        elif c == SE:
++                            self.sb = 0
++                            self.sbdataq = self.sbdataq + buf[1]
++                            buf[1] = b''
++                        if self.option_callback:
++                            # Callback is supposed to look into
++                            # the sbdataq
++                            self.option_callback(self.sock, c, NOOPT)
++                        else:
++                            # We can't offer automatic processing of
++                            # suboptions. Alas, we should not get any
++                            # unless we did a WILL/DO before.
++                            self.msg('IAC %d not recognized' % ord(c))
++                elif len(self.iacseq) == 2:
++                    cmd = self.iacseq[1:2]
++                    self.iacseq = b''
++                    opt = c
++                    if cmd in (DO, DONT):
++                        self.msg('IAC %s %d',
++                            cmd == DO and 'DO' or 'DONT', ord(opt))
++                        if self.option_callback:
++                            self.option_callback(self.sock, cmd, opt)
++                        else:
++                            self.sock.sendall(IAC + WONT + opt)
++                    elif cmd in (WILL, WONT):
++                        self.msg('IAC %s %d',
++                            cmd == WILL and 'WILL' or 'WONT', ord(opt))
++                        if self.option_callback:
++                            self.option_callback(self.sock, cmd, opt)
++                        else:
++                            self.sock.sendall(IAC + DONT + opt)
++        except EOFError: # raised by self.rawq_getchar()
++            self.iacseq = b'' # Reset on EOF
++            self.sb = 0
++        self.cookedq = self.cookedq + buf[0]
++        self.sbdataq = self.sbdataq + buf[1]
++
++    def rawq_getchar(self):
++        """Get next char from raw queue.
++
++        Block if no data is immediately available.  Raise EOFError
++        when connection is closed.
++
++        """
++        if not self.rawq:
++            self.fill_rawq()
++            if self.eof:
++                raise EOFError
++        c = self.rawq[self.irawq:self.irawq+1]
++        self.irawq = self.irawq + 1
++        if self.irawq >= len(self.rawq):
++            self.rawq = b''
++            self.irawq = 0
++        return c
++
++    def fill_rawq(self):
++        """Fill raw queue from exactly one recv() system call.
++
++        Block if no data is immediately available.  Set self.eof when
++        connection is closed.
++
++        """
++        if self.irawq >= len(self.rawq):
++            self.rawq = b''
++            self.irawq = 0
++        # The buffer size should be fairly small so as to avoid quadratic
++        # behavior in process_rawq() above
++        buf = self.sock.recv(50)
++        self.msg("recv %r", buf)
++        self.eof = (not buf)
++        self.rawq = self.rawq + buf
++
++    def sock_avail(self):
++        """Test whether data is available on the socket."""
++        with _TelnetSelector() as selector:
++            selector.register(self, selectors.EVENT_READ)
++            return bool(selector.select(0))
++
++    def interact(self):
++        """Interaction function, emulates a very dumb telnet client."""
++        if sys.platform == "win32":
++            self.mt_interact()
++            return
++        with _TelnetSelector() as selector:
++            selector.register(self, selectors.EVENT_READ)
++            selector.register(sys.stdin, selectors.EVENT_READ)
++
++            while True:
++                for key, events in selector.select():
++                    if key.fileobj is self:
++                        try:
++                            text = self.read_eager()
++                        except EOFError:
++                            print('*** Connection closed by remote host ***')
++                            return
++                        if text:
++                            sys.stdout.write(text.decode('ascii'))
++                            sys.stdout.flush()
++                    elif key.fileobj is sys.stdin:
++                        line = sys.stdin.readline().encode('ascii')
++                        if not line:
++                            return
++                        self.write(line)
++
++    def mt_interact(self):
++        """Multithreaded version of interact()."""
++        import _thread
++        _thread.start_new_thread(self.listener, ())
++        while 1:
++            line = sys.stdin.readline()
++            if not line:
++                break
++            self.write(line.encode('ascii'))
++
++    def listener(self):
++        """Helper for mt_interact() -- this executes in the other thread."""
++        while 1:
++            try:
++                data = self.read_eager()
++            except EOFError:
++                print('*** Connection closed by remote host ***')
++                return
++            if data:
++                sys.stdout.write(data.decode('ascii'))
++            else:
++                sys.stdout.flush()
++
++    def expect(self, list, timeout=None):
++        """Read until one from a list of a regular expressions matches.
++
++        The first argument is a list of regular expressions, either
++        compiled (re.Pattern instances) or uncompiled (strings).
++        The optional second argument is a timeout, in seconds; default
++        is no timeout.
++
++        Return a tuple of three items: the index in the list of the
++        first regular expression that matches; the re.Match object
++        returned; and the text read up till and including the match.
++
++        If EOF is read and no text was read, raise EOFError.
++        Otherwise, when nothing matches, return (-1, None, text) where
++        text is the text received so far (may be the empty string if a
++        timeout happened).
++
++        If a regular expression ends with a greedy match (e.g. '.*')
++        or if more than one expression can match the same input, the
++        results are undeterministic, and may depend on the I/O timing.
++
++        """
++        re = None
++        list = list[:]
++        indices = range(len(list))
++        for i in indices:
++            if not hasattr(list[i], "search"):
++                if not re: import re
++                list[i] = re.compile(list[i])
++        if timeout is not None:
++            deadline = _time() + timeout
++        with _TelnetSelector() as selector:
++            selector.register(self, selectors.EVENT_READ)
++            while not self.eof:
++                self.process_rawq()
++                for i in indices:
++                    m = list[i].search(self.cookedq)
++                    if m:
++                        e = m.end()
++                        text = self.cookedq[:e]
++                        self.cookedq = self.cookedq[e:]
++                        return (i, m, text)
++                if timeout is not None:
++                    ready = selector.select(timeout)
++                    timeout = deadline - _time()
++                    if not ready:
++                        if timeout < 0:
++                            break
++                        else:
++                            continue
++                self.fill_rawq()
++        text = self.read_very_lazy()
++        if not text and self.eof:
++            raise EOFError
++        return (-1, None, text)
++
++    def __enter__(self):
++        return self
++
++    def __exit__(self, type, value, traceback):
++        self.close()
++
++
++def test():
++    """Test program for telnetlib.
++
++    Usage: python telnetlib.py [-d] ... [host [port]]
++
++    Default host is localhost; default port is 23.
++
++    """
++    debuglevel = 0
++    while sys.argv[1:] and sys.argv[1] == '-d':
++        debuglevel = debuglevel+1
++        del sys.argv[1]
++    host = 'localhost'
++    if sys.argv[1:]:
++        host = sys.argv[1]
++    port = 0
++    if sys.argv[2:]:
++        portstr = sys.argv[2]
++        try:
++            port = int(portstr)
++        except ValueError:
++            port = socket.getservbyname(portstr, 'tcp')
++    with Telnet() as tn:
++        tn.set_debuglevel(debuglevel)
++        tn.open(host, port, timeout=0.5)
++        tn.interact()
++
++if __name__ == '__main__':
++    test()

--- a/dev-lang/spidermonkey/files/spidermonkey-128.4.0-tests-add-python3.13-support.patch
+++ b/dev-lang/spidermonkey/files/spidermonkey-128.4.0-tests-add-python3.13-support.patch
@@ -1,0 +1,973 @@
+# HG changeset patch
+# User Rob Wu <rob@robwu.nl>
+# Date 1730841860 0
+#      Tue Nov 05 21:24:20 2024 +0000
+# Node ID d460a92a8e3341246f905d105c1dead8caa766ae
+# Parent  c4a5d008ee64fab523384408fa2868e2d028025d
+Bug 1926140 - Replace pipes imports r=jmaher
+
+pipes does not exist in Python 3.11 any more
+
+Differential Revision: https://phabricator.services.mozilla.com/D227964
+
+diff -r c4a5d008ee64 -r d460a92a8e33 testing/mozbase/mozdevice/mozdevice/adb.py
+--- a/testing/mozbase/mozdevice/mozdevice/adb.py	Fri Oct 18 21:58:28 2024 +0000
++++ b/testing/mozbase/mozdevice/mozdevice/adb.py	Tue Nov 05 21:24:20 2024 +0000
+@@ -4,7 +4,6 @@
+ 
+ import io
+ import os
+-import pipes
+ import posixpath
+ import re
+ import shlex
+@@ -1292,8 +1291,6 @@
+         """Utility function to return quoted version of command argument."""
+         if hasattr(shlex, "quote"):
+             quote = shlex.quote
+-        elif hasattr(pipes, "quote"):
+-            quote = pipes.quote
+         else:
+ 
+             def quote(arg):
+diff -r c4a5d008ee64 -r d460a92a8e33 testing/web-platform/tests/tools/pytest.ini
+--- a/testing/web-platform/tests/tools/pytest.ini	Fri Oct 18 21:58:28 2024 +0000
++++ b/testing/web-platform/tests/tools/pytest.ini	Tue Nov 05 21:24:20 2024 +0000
+@@ -20,8 +20,6 @@
+     ignore:This method will be removed in .*\.\s+Use 'parser\.read_file\(\)' instead\.:DeprecationWarning:mozversion
+     # ignore mozversion not cleanly closing .ini files
+     ignore:unclosed file.*\.ini:ResourceWarning:mozversion
+-    # mozdevice uses pipes module
+-    ignore:'pipes' is deprecated and slated for removal in Python 3:DeprecationWarning
+     # mozrunner uses telnetlib module
+     ignore:'telnetlib' is deprecated and slated for removal in Python 3:DeprecationWarning
+     # https://github.com/web-platform-tests/wpt/issues/39366
+diff -r c4a5d008ee64 -r d460a92a8e33 testing/xpcshell/runxpcshelltests.py
+--- a/testing/xpcshell/runxpcshelltests.py	Fri Oct 18 21:58:28 2024 +0000
++++ b/testing/xpcshell/runxpcshelltests.py	Tue Nov 05 21:24:20 2024 +0000
+@@ -7,10 +7,10 @@
+ import copy
+ import json
+ import os
+-import pipes
+ import platform
+ import random
+ import re
++import shlex
+ import shutil
+ import signal
+ import subprocess
+@@ -372,11 +372,11 @@
+         )
+         self.log.info("%s | environment: %s" % (name, list(changedEnv)))
+         shell_command_tokens = [
+-            pipes.quote(tok) for tok in list(changedEnv) + completeCmd
++            shlex.quote(tok) for tok in list(changedEnv) + completeCmd
+         ]
+         self.log.info(
+             "%s | as shell command: (cd %s; %s)"
+-            % (name, pipes.quote(testdir), " ".join(shell_command_tokens))
++            % (name, shlex.quote(testdir), " ".join(shell_command_tokens))
+         )
+ 
+     def killTimeout(self, proc):
+# HG changeset patch
+# User Rob Wu <rob@robwu.nl>
+# Date 1730828835 0
+#      Tue Nov 05 17:47:15 2024 +0000
+# Node ID 53111596a0a02f41f536b02a12aa15ae80c45214
+# Parent  d460a92a8e3341246f905d105c1dead8caa766ae
+Bug 1925198 - Move telnetlib import to BaseEmulator r=jmaher
+
+emulator.py currently has an unconditional telnetlib import, but the
+file can also be imported when the functionality is not needed.
+
+Because telnetlib was removed from Python 3.13, this unconditional
+import breaks use cases that do not even care about telnet. As a stopgap
+measure until a better fix is available, move the import to the function
+that relies on telnet.
+
+Differential Revision: https://phabricator.services.mozilla.com/D227995
+
+diff -r d460a92a8e33 -r 53111596a0a0 testing/mozbase/mozrunner/mozrunner/devices/emulator.py
+--- a/testing/mozbase/mozrunner/mozrunner/devices/emulator.py	Tue Nov 05 21:24:20 2024 +0000
++++ b/testing/mozbase/mozrunner/mozrunner/devices/emulator.py	Tue Nov 05 17:47:15 2024 +0000
+@@ -8,7 +8,6 @@
+ import subprocess
+ import tempfile
+ import time
+-from telnetlib import Telnet
+ 
+ from mozdevice import ADBHost
+ from mozprocess import ProcessHandler
+@@ -189,6 +188,11 @@
+ 
+     def _run_telnet(self, command):
+         if not self.telnet:
++            # telnetlib is dropped in Python 3.13 (bug 1925198).
++            # Import here instead of the top level to avoid breaking users of
++            # this file that are independent of telnet.
++            from telnetlib import Telnet
++
+             self.telnet = Telnet("localhost", self.port)
+             self._get_telnet_response()
+         return self._get_telnet_response(command)
+# HG changeset patch
+# User Rob Wu <rob@robwu.nl>
+# Date 1731088502 0
+#      Fri Nov 08 17:55:02 2024 +0000
+# Node ID 03d9e30817d762eaba71b4c8c20d18ae0325ebf6
+# Parent  53111596a0a02f41f536b02a12aa15ae80c45214
+Bug 1929535 - Vendor telnetlib.py r=jmaher,jgraham
+
+telnetlib.py was removed from Python 3.13, but we still depend on its
+functionality. This patch imports the original standard library from
+https://github.com/python/cpython/blob/3.12/Lib/telnetlib.py
+
+The only changes are:
+- Prepend comments at start to attribute source.
+- Prepend fmt/noqa/ruff to suppress linting by black/ruff, to avoid
+  non-critical modifications.
+- Remove `warnings._deprecated(__name__, remove=(3, 13))` call to
+  avoid a deprecation warning when loading the module.
+
+Differential Revision: https://phabricator.services.mozilla.com/D228052
+
+diff -r 53111596a0a0 -r 03d9e30817d7 testing/mozbase/mozrunner/mozrunner/devices/android_device.py
+--- a/testing/mozbase/mozrunner/mozrunner/devices/android_device.py	Tue Nov 05 17:47:15 2024 +0000
++++ b/testing/mozbase/mozrunner/mozrunner/devices/android_device.py	Fri Nov 08 17:55:02 2024 +0000
+@@ -11,7 +11,6 @@
+ import signal
+ import subprocess
+ import sys
+-import telnetlib
+ import time
+ from enum import Enum
+ 
+@@ -19,6 +18,11 @@
+ from mozdevice import ADBDeviceFactory, ADBHost
+ from six.moves import input, urllib
+ 
++try:
++    import telnetlib
++except ImportError:  # telnetlib was removed in Python 3.13
++    from . import telnetlib
++
+ MOZBUILD_PATH = os.environ.get(
+     "MOZBUILD_STATE_PATH", os.path.expanduser(os.path.join("~", ".mozbuild"))
+ )
+diff -r 53111596a0a0 -r 03d9e30817d7 testing/mozbase/mozrunner/mozrunner/devices/emulator.py
+--- a/testing/mozbase/mozrunner/mozrunner/devices/emulator.py	Tue Nov 05 17:47:15 2024 +0000
++++ b/testing/mozbase/mozrunner/mozrunner/devices/emulator.py	Fri Nov 08 17:55:02 2024 +0000
+@@ -18,6 +18,11 @@
+ from .emulator_geo import EmulatorGeo
+ from .emulator_screen import EmulatorScreen
+ 
++try:
++    from telnetlib import Telnet
++except ImportError:  # telnetlib was removed in Python 3.13
++    from .telnetlib import Telnet
++
+ 
+ class ArchContext(object):
+     def __init__(self, arch, context, binary=None, avd=None, extra_args=None):
+@@ -188,11 +193,6 @@
+ 
+     def _run_telnet(self, command):
+         if not self.telnet:
+-            # telnetlib is dropped in Python 3.13 (bug 1925198).
+-            # Import here instead of the top level to avoid breaking users of
+-            # this file that are independent of telnet.
+-            from telnetlib import Telnet
+-
+             self.telnet = Telnet("localhost", self.port)
+             self._get_telnet_response()
+         return self._get_telnet_response(command)
+diff -r 53111596a0a0 -r 03d9e30817d7 testing/mozbase/mozrunner/mozrunner/devices/telnetlib.py
+--- /dev/null	Thu Jan 01 00:00:00 1970 +0000
++++ b/testing/mozbase/mozrunner/mozrunner/devices/telnetlib.py	Fri Nov 08 17:55:02 2024 +0000
+@@ -0,0 +1,732 @@
++# Copied from https://github.com/python/cpython/blob/3.12/Lib/telnetlib.py
++# because telnetlib was removed from Python 3.13.
++# fmt: off
++# ruff: noqa: I001, E701
++#
++# This file was part of Python 3.12 and licensed under the PSF license:
++# https://docs.python.org/3.12/license.html#psf-license
++#
++# Copyright © 2001-2023 Python Software Foundation; All Rights Reserved
++#
++# 1. This LICENSE AGREEMENT is between the Python Software Foundation ("PSF"), and
++#    the Individual or Organization ("Licensee") accessing and otherwise using Python
++#    3.12.7 software in source or binary form and its associated documentation.
++#
++# 2. Subject to the terms and conditions of this License Agreement, PSF hereby
++#    grants Licensee a nonexclusive, royalty-free, world-wide license to reproduce,
++#    analyze, test, perform and/or display publicly, prepare derivative works,
++#    distribute, and otherwise use Python 3.12.7 alone or in any derivative
++#    version, provided, however, that PSF's License Agreement and PSF's notice of
++#    copyright, i.e., "Copyright © 2001-2023 Python Software Foundation; All Rights
++#    Reserved" are retained in Python 3.12.7 alone or in any derivative version
++#    prepared by Licensee.
++#
++# 3. In the event Licensee prepares a derivative work that is based on or
++#    incorporates Python 3.12.7 or any part thereof, and wants to make the
++#    derivative work available to others as provided herein, then Licensee hereby
++#    agrees to include in any such work a brief summary of the changes made to Python
++#    3.12.7.
++#
++# 4. PSF is making Python 3.12.7 available to Licensee on an "AS IS" basis.
++#    PSF MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED.  BY WAY OF
++#    EXAMPLE, BUT NOT LIMITATION, PSF MAKES NO AND DISCLAIMS ANY REPRESENTATION OR
++#    WARRANTY OF MERCHANTABILITY OR FITNESS FOR ANY PARTICULAR PURPOSE OR THAT THE
++#    USE OF PYTHON 3.12.7 WILL NOT INFRINGE ANY THIRD PARTY RIGHTS.
++#
++# 5. PSF SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF PYTHON 3.12.7
++#    FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS AS A RESULT OF
++#    MODIFYING, DISTRIBUTING, OR OTHERWISE USING PYTHON 3.12.7, OR ANY DERIVATIVE
++#    THEREOF, EVEN IF ADVISED OF THE POSSIBILITY THEREOF.
++#
++# 6. This License Agreement will automatically terminate upon a material breach of
++#    its terms and conditions.
++#
++# 7. Nothing in this License Agreement shall be deemed to create any relationship
++#    of agency, partnership, or joint venture between PSF and Licensee.  This License
++#    Agreement does not grant permission to use PSF trademarks or trade name in a
++#    trademark sense to endorse or promote products or services of Licensee, or any
++#    third party.
++#
++# 8. By copying, installing or otherwise using Python 3.12.7, Licensee agrees
++#    to be bound by the terms and conditions of this License Agreement.
++
++# The original https://github.com/python/cpython/blob/3.12/Lib/telnetlib.py
++# content starts below. The following changed have been made:
++# - Removed "warnings._deprecated" call to avoid a deprecation warning.
++r"""TELNET client class.
++
++Based on RFC 854: TELNET Protocol Specification, by J. Postel and
++J. Reynolds
++
++Example:
++
++>>> from telnetlib import Telnet
++>>> tn = Telnet('www.python.org', 79)   # connect to finger port
++>>> tn.write(b'guido\r\n')
++>>> print(tn.read_all())
++Login       Name               TTY         Idle    When    Where
++guido    Guido van Rossum      pts/2        <Dec  2 11:10> snag.cnri.reston..
++
++>>>
++
++Note that read_all() won't read until eof -- it just reads some data
++-- but it guarantees to read at least one byte unless EOF is hit.
++
++It is possible to pass a Telnet object to a selector in order to wait until
++more data is available.  Note that in this case, read_eager() may return b''
++even if there was data on the socket, because the protocol negotiation may have
++eaten the data.  This is why EOFError is needed in some cases to distinguish
++between "no data" and "connection closed" (since the socket also appears ready
++for reading when it is closed).
++
++To do:
++- option negotiation
++- timeout should be intrinsic to the connection object instead of an
++  option on one of the read calls only
++
++"""
++
++
++# Imported modules
++import sys
++import socket
++import selectors
++from time import monotonic as _time
++
++__all__ = ["Telnet"]
++
++# Tunable parameters
++DEBUGLEVEL = 0
++
++# Telnet protocol defaults
++TELNET_PORT = 23
++
++# Telnet protocol characters (don't change)
++IAC  = bytes([255]) # "Interpret As Command"
++DONT = bytes([254])
++DO   = bytes([253])
++WONT = bytes([252])
++WILL = bytes([251])
++theNULL = bytes([0])
++
++SE  = bytes([240])  # Subnegotiation End
++NOP = bytes([241])  # No Operation
++DM  = bytes([242])  # Data Mark
++BRK = bytes([243])  # Break
++IP  = bytes([244])  # Interrupt process
++AO  = bytes([245])  # Abort output
++AYT = bytes([246])  # Are You There
++EC  = bytes([247])  # Erase Character
++EL  = bytes([248])  # Erase Line
++GA  = bytes([249])  # Go Ahead
++SB =  bytes([250])  # Subnegotiation Begin
++
++
++# Telnet protocol options code (don't change)
++# These ones all come from arpa/telnet.h
++BINARY = bytes([0]) # 8-bit data path
++ECHO = bytes([1]) # echo
++RCP = bytes([2]) # prepare to reconnect
++SGA = bytes([3]) # suppress go ahead
++NAMS = bytes([4]) # approximate message size
++STATUS = bytes([5]) # give status
++TM = bytes([6]) # timing mark
++RCTE = bytes([7]) # remote controlled transmission and echo
++NAOL = bytes([8]) # negotiate about output line width
++NAOP = bytes([9]) # negotiate about output page size
++NAOCRD = bytes([10]) # negotiate about CR disposition
++NAOHTS = bytes([11]) # negotiate about horizontal tabstops
++NAOHTD = bytes([12]) # negotiate about horizontal tab disposition
++NAOFFD = bytes([13]) # negotiate about formfeed disposition
++NAOVTS = bytes([14]) # negotiate about vertical tab stops
++NAOVTD = bytes([15]) # negotiate about vertical tab disposition
++NAOLFD = bytes([16]) # negotiate about output LF disposition
++XASCII = bytes([17]) # extended ascii character set
++LOGOUT = bytes([18]) # force logout
++BM = bytes([19]) # byte macro
++DET = bytes([20]) # data entry terminal
++SUPDUP = bytes([21]) # supdup protocol
++SUPDUPOUTPUT = bytes([22]) # supdup output
++SNDLOC = bytes([23]) # send location
++TTYPE = bytes([24]) # terminal type
++EOR = bytes([25]) # end or record
++TUID = bytes([26]) # TACACS user identification
++OUTMRK = bytes([27]) # output marking
++TTYLOC = bytes([28]) # terminal location number
++VT3270REGIME = bytes([29]) # 3270 regime
++X3PAD = bytes([30]) # X.3 PAD
++NAWS = bytes([31]) # window size
++TSPEED = bytes([32]) # terminal speed
++LFLOW = bytes([33]) # remote flow control
++LINEMODE = bytes([34]) # Linemode option
++XDISPLOC = bytes([35]) # X Display Location
++OLD_ENVIRON = bytes([36]) # Old - Environment variables
++AUTHENTICATION = bytes([37]) # Authenticate
++ENCRYPT = bytes([38]) # Encryption option
++NEW_ENVIRON = bytes([39]) # New - Environment variables
++# the following ones come from
++# http://www.iana.org/assignments/telnet-options
++# Unfortunately, that document does not assign identifiers
++# to all of them, so we are making them up
++TN3270E = bytes([40]) # TN3270E
++XAUTH = bytes([41]) # XAUTH
++CHARSET = bytes([42]) # CHARSET
++RSP = bytes([43]) # Telnet Remote Serial Port
++COM_PORT_OPTION = bytes([44]) # Com Port Control Option
++SUPPRESS_LOCAL_ECHO = bytes([45]) # Telnet Suppress Local Echo
++TLS = bytes([46]) # Telnet Start TLS
++KERMIT = bytes([47]) # KERMIT
++SEND_URL = bytes([48]) # SEND-URL
++FORWARD_X = bytes([49]) # FORWARD_X
++PRAGMA_LOGON = bytes([138]) # TELOPT PRAGMA LOGON
++SSPI_LOGON = bytes([139]) # TELOPT SSPI LOGON
++PRAGMA_HEARTBEAT = bytes([140]) # TELOPT PRAGMA HEARTBEAT
++EXOPL = bytes([255]) # Extended-Options-List
++NOOPT = bytes([0])
++
++
++# poll/select have the advantage of not requiring any extra file descriptor,
++# contrarily to epoll/kqueue (also, they require a single syscall).
++if hasattr(selectors, 'PollSelector'):
++    _TelnetSelector = selectors.PollSelector
++else:
++    _TelnetSelector = selectors.SelectSelector
++
++
++class Telnet:
++
++    """Telnet interface class.
++
++    An instance of this class represents a connection to a telnet
++    server.  The instance is initially not connected; the open()
++    method must be used to establish a connection.  Alternatively, the
++    host name and optional port number can be passed to the
++    constructor, too.
++
++    Don't try to reopen an already connected instance.
++
++    This class has many read_*() methods.  Note that some of them
++    raise EOFError when the end of the connection is read, because
++    they can return an empty string for other reasons.  See the
++    individual doc strings.
++
++    read_until(expected, [timeout])
++        Read until the expected string has been seen, or a timeout is
++        hit (default is no timeout); may block.
++
++    read_all()
++        Read all data until EOF; may block.
++
++    read_some()
++        Read at least one byte or EOF; may block.
++
++    read_very_eager()
++        Read all data available already queued or on the socket,
++        without blocking.
++
++    read_eager()
++        Read either data already queued or some data available on the
++        socket, without blocking.
++
++    read_lazy()
++        Read all data in the raw queue (processing it first), without
++        doing any socket I/O.
++
++    read_very_lazy()
++        Reads all data in the cooked queue, without doing any socket
++        I/O.
++
++    read_sb_data()
++        Reads available data between SB ... SE sequence. Don't block.
++
++    set_option_negotiation_callback(callback)
++        Each time a telnet option is read on the input flow, this callback
++        (if set) is called with the following parameters :
++        callback(telnet socket, command, option)
++            option will be chr(0) when there is no option.
++        No other action is done afterwards by telnetlib.
++
++    """
++    sock = None  # for __del__()
++
++    def __init__(self, host=None, port=0,
++                 timeout=socket._GLOBAL_DEFAULT_TIMEOUT):
++        """Constructor.
++
++        When called without arguments, create an unconnected instance.
++        With a hostname argument, it connects the instance; port number
++        and timeout are optional.
++        """
++        self.debuglevel = DEBUGLEVEL
++        self.host = host
++        self.port = port
++        self.timeout = timeout
++        self.sock = None
++        self.rawq = b''
++        self.irawq = 0
++        self.cookedq = b''
++        self.eof = 0
++        self.iacseq = b'' # Buffer for IAC sequence.
++        self.sb = 0 # flag for SB and SE sequence.
++        self.sbdataq = b''
++        self.option_callback = None
++        if host is not None:
++            self.open(host, port, timeout)
++
++    def open(self, host, port=0, timeout=socket._GLOBAL_DEFAULT_TIMEOUT):
++        """Connect to a host.
++
++        The optional second argument is the port number, which
++        defaults to the standard telnet port (23).
++
++        Don't try to reopen an already connected instance.
++        """
++        self.eof = 0
++        if not port:
++            port = TELNET_PORT
++        self.host = host
++        self.port = port
++        self.timeout = timeout
++        sys.audit("telnetlib.Telnet.open", self, host, port)
++        self.sock = socket.create_connection((host, port), timeout)
++
++    def __del__(self):
++        """Destructor -- close the connection."""
++        self.close()
++
++    def msg(self, msg, *args):
++        """Print a debug message, when the debug level is > 0.
++
++        If extra arguments are present, they are substituted in the
++        message using the standard string formatting operator.
++
++        """
++        if self.debuglevel > 0:
++            print('Telnet(%s,%s):' % (self.host, self.port), end=' ')
++            if args:
++                print(msg % args)
++            else:
++                print(msg)
++
++    def set_debuglevel(self, debuglevel):
++        """Set the debug level.
++
++        The higher it is, the more debug output you get (on sys.stdout).
++
++        """
++        self.debuglevel = debuglevel
++
++    def close(self):
++        """Close the connection."""
++        sock = self.sock
++        self.sock = None
++        self.eof = True
++        self.iacseq = b''
++        self.sb = 0
++        if sock:
++            sock.close()
++
++    def get_socket(self):
++        """Return the socket object used internally."""
++        return self.sock
++
++    def fileno(self):
++        """Return the fileno() of the socket object used internally."""
++        return self.sock.fileno()
++
++    def write(self, buffer):
++        """Write a string to the socket, doubling any IAC characters.
++
++        Can block if the connection is blocked.  May raise
++        OSError if the connection is closed.
++
++        """
++        if IAC in buffer:
++            buffer = buffer.replace(IAC, IAC+IAC)
++        sys.audit("telnetlib.Telnet.write", self, buffer)
++        self.msg("send %r", buffer)
++        self.sock.sendall(buffer)
++
++    def read_until(self, match, timeout=None):
++        """Read until a given string is encountered or until timeout.
++
++        When no match is found, return whatever is available instead,
++        possibly the empty string.  Raise EOFError if the connection
++        is closed and no cooked data is available.
++
++        """
++        n = len(match)
++        self.process_rawq()
++        i = self.cookedq.find(match)
++        if i >= 0:
++            i = i+n
++            buf = self.cookedq[:i]
++            self.cookedq = self.cookedq[i:]
++            return buf
++        if timeout is not None:
++            deadline = _time() + timeout
++        with _TelnetSelector() as selector:
++            selector.register(self, selectors.EVENT_READ)
++            while not self.eof:
++                if selector.select(timeout):
++                    i = max(0, len(self.cookedq)-n)
++                    self.fill_rawq()
++                    self.process_rawq()
++                    i = self.cookedq.find(match, i)
++                    if i >= 0:
++                        i = i+n
++                        buf = self.cookedq[:i]
++                        self.cookedq = self.cookedq[i:]
++                        return buf
++                if timeout is not None:
++                    timeout = deadline - _time()
++                    if timeout < 0:
++                        break
++        return self.read_very_lazy()
++
++    def read_all(self):
++        """Read all data until EOF; block until connection closed."""
++        self.process_rawq()
++        while not self.eof:
++            self.fill_rawq()
++            self.process_rawq()
++        buf = self.cookedq
++        self.cookedq = b''
++        return buf
++
++    def read_some(self):
++        """Read at least one byte of cooked data unless EOF is hit.
++
++        Return b'' if EOF is hit.  Block if no data is immediately
++        available.
++
++        """
++        self.process_rawq()
++        while not self.cookedq and not self.eof:
++            self.fill_rawq()
++            self.process_rawq()
++        buf = self.cookedq
++        self.cookedq = b''
++        return buf
++
++    def read_very_eager(self):
++        """Read everything that's possible without blocking in I/O (eager).
++
++        Raise EOFError if connection closed and no cooked data
++        available.  Return b'' if no cooked data available otherwise.
++        Don't block unless in the midst of an IAC sequence.
++
++        """
++        self.process_rawq()
++        while not self.eof and self.sock_avail():
++            self.fill_rawq()
++            self.process_rawq()
++        return self.read_very_lazy()
++
++    def read_eager(self):
++        """Read readily available data.
++
++        Raise EOFError if connection closed and no cooked data
++        available.  Return b'' if no cooked data available otherwise.
++        Don't block unless in the midst of an IAC sequence.
++
++        """
++        self.process_rawq()
++        while not self.cookedq and not self.eof and self.sock_avail():
++            self.fill_rawq()
++            self.process_rawq()
++        return self.read_very_lazy()
++
++    def read_lazy(self):
++        """Process and return data that's already in the queues (lazy).
++
++        Raise EOFError if connection closed and no data available.
++        Return b'' if no cooked data available otherwise.  Don't block
++        unless in the midst of an IAC sequence.
++
++        """
++        self.process_rawq()
++        return self.read_very_lazy()
++
++    def read_very_lazy(self):
++        """Return any data available in the cooked queue (very lazy).
++
++        Raise EOFError if connection closed and no data available.
++        Return b'' if no cooked data available otherwise.  Don't block.
++
++        """
++        buf = self.cookedq
++        self.cookedq = b''
++        if not buf and self.eof and not self.rawq:
++            raise EOFError('telnet connection closed')
++        return buf
++
++    def read_sb_data(self):
++        """Return any data available in the SB ... SE queue.
++
++        Return b'' if no SB ... SE available. Should only be called
++        after seeing a SB or SE command. When a new SB command is
++        found, old unread SB data will be discarded. Don't block.
++
++        """
++        buf = self.sbdataq
++        self.sbdataq = b''
++        return buf
++
++    def set_option_negotiation_callback(self, callback):
++        """Provide a callback function called after each receipt of a telnet option."""
++        self.option_callback = callback
++
++    def process_rawq(self):
++        """Transfer from raw queue to cooked queue.
++
++        Set self.eof when connection is closed.  Don't block unless in
++        the midst of an IAC sequence.
++
++        """
++        buf = [b'', b'']
++        try:
++            while self.rawq:
++                c = self.rawq_getchar()
++                if not self.iacseq:
++                    if c == theNULL:
++                        continue
++                    if c == b"\021":
++                        continue
++                    if c != IAC:
++                        buf[self.sb] = buf[self.sb] + c
++                        continue
++                    else:
++                        self.iacseq += c
++                elif len(self.iacseq) == 1:
++                    # 'IAC: IAC CMD [OPTION only for WILL/WONT/DO/DONT]'
++                    if c in (DO, DONT, WILL, WONT):
++                        self.iacseq += c
++                        continue
++
++                    self.iacseq = b''
++                    if c == IAC:
++                        buf[self.sb] = buf[self.sb] + c
++                    else:
++                        if c == SB: # SB ... SE start.
++                            self.sb = 1
++                            self.sbdataq = b''
++                        elif c == SE:
++                            self.sb = 0
++                            self.sbdataq = self.sbdataq + buf[1]
++                            buf[1] = b''
++                        if self.option_callback:
++                            # Callback is supposed to look into
++                            # the sbdataq
++                            self.option_callback(self.sock, c, NOOPT)
++                        else:
++                            # We can't offer automatic processing of
++                            # suboptions. Alas, we should not get any
++                            # unless we did a WILL/DO before.
++                            self.msg('IAC %d not recognized' % ord(c))
++                elif len(self.iacseq) == 2:
++                    cmd = self.iacseq[1:2]
++                    self.iacseq = b''
++                    opt = c
++                    if cmd in (DO, DONT):
++                        self.msg('IAC %s %d',
++                            cmd == DO and 'DO' or 'DONT', ord(opt))
++                        if self.option_callback:
++                            self.option_callback(self.sock, cmd, opt)
++                        else:
++                            self.sock.sendall(IAC + WONT + opt)
++                    elif cmd in (WILL, WONT):
++                        self.msg('IAC %s %d',
++                            cmd == WILL and 'WILL' or 'WONT', ord(opt))
++                        if self.option_callback:
++                            self.option_callback(self.sock, cmd, opt)
++                        else:
++                            self.sock.sendall(IAC + DONT + opt)
++        except EOFError: # raised by self.rawq_getchar()
++            self.iacseq = b'' # Reset on EOF
++            self.sb = 0
++        self.cookedq = self.cookedq + buf[0]
++        self.sbdataq = self.sbdataq + buf[1]
++
++    def rawq_getchar(self):
++        """Get next char from raw queue.
++
++        Block if no data is immediately available.  Raise EOFError
++        when connection is closed.
++
++        """
++        if not self.rawq:
++            self.fill_rawq()
++            if self.eof:
++                raise EOFError
++        c = self.rawq[self.irawq:self.irawq+1]
++        self.irawq = self.irawq + 1
++        if self.irawq >= len(self.rawq):
++            self.rawq = b''
++            self.irawq = 0
++        return c
++
++    def fill_rawq(self):
++        """Fill raw queue from exactly one recv() system call.
++
++        Block if no data is immediately available.  Set self.eof when
++        connection is closed.
++
++        """
++        if self.irawq >= len(self.rawq):
++            self.rawq = b''
++            self.irawq = 0
++        # The buffer size should be fairly small so as to avoid quadratic
++        # behavior in process_rawq() above
++        buf = self.sock.recv(50)
++        self.msg("recv %r", buf)
++        self.eof = (not buf)
++        self.rawq = self.rawq + buf
++
++    def sock_avail(self):
++        """Test whether data is available on the socket."""
++        with _TelnetSelector() as selector:
++            selector.register(self, selectors.EVENT_READ)
++            return bool(selector.select(0))
++
++    def interact(self):
++        """Interaction function, emulates a very dumb telnet client."""
++        if sys.platform == "win32":
++            self.mt_interact()
++            return
++        with _TelnetSelector() as selector:
++            selector.register(self, selectors.EVENT_READ)
++            selector.register(sys.stdin, selectors.EVENT_READ)
++
++            while True:
++                for key, events in selector.select():
++                    if key.fileobj is self:
++                        try:
++                            text = self.read_eager()
++                        except EOFError:
++                            print('*** Connection closed by remote host ***')
++                            return
++                        if text:
++                            sys.stdout.write(text.decode('ascii'))
++                            sys.stdout.flush()
++                    elif key.fileobj is sys.stdin:
++                        line = sys.stdin.readline().encode('ascii')
++                        if not line:
++                            return
++                        self.write(line)
++
++    def mt_interact(self):
++        """Multithreaded version of interact()."""
++        import _thread
++        _thread.start_new_thread(self.listener, ())
++        while 1:
++            line = sys.stdin.readline()
++            if not line:
++                break
++            self.write(line.encode('ascii'))
++
++    def listener(self):
++        """Helper for mt_interact() -- this executes in the other thread."""
++        while 1:
++            try:
++                data = self.read_eager()
++            except EOFError:
++                print('*** Connection closed by remote host ***')
++                return
++            if data:
++                sys.stdout.write(data.decode('ascii'))
++            else:
++                sys.stdout.flush()
++
++    def expect(self, list, timeout=None):
++        """Read until one from a list of a regular expressions matches.
++
++        The first argument is a list of regular expressions, either
++        compiled (re.Pattern instances) or uncompiled (strings).
++        The optional second argument is a timeout, in seconds; default
++        is no timeout.
++
++        Return a tuple of three items: the index in the list of the
++        first regular expression that matches; the re.Match object
++        returned; and the text read up till and including the match.
++
++        If EOF is read and no text was read, raise EOFError.
++        Otherwise, when nothing matches, return (-1, None, text) where
++        text is the text received so far (may be the empty string if a
++        timeout happened).
++
++        If a regular expression ends with a greedy match (e.g. '.*')
++        or if more than one expression can match the same input, the
++        results are undeterministic, and may depend on the I/O timing.
++
++        """
++        re = None
++        list = list[:]
++        indices = range(len(list))
++        for i in indices:
++            if not hasattr(list[i], "search"):
++                if not re: import re
++                list[i] = re.compile(list[i])
++        if timeout is not None:
++            deadline = _time() + timeout
++        with _TelnetSelector() as selector:
++            selector.register(self, selectors.EVENT_READ)
++            while not self.eof:
++                self.process_rawq()
++                for i in indices:
++                    m = list[i].search(self.cookedq)
++                    if m:
++                        e = m.end()
++                        text = self.cookedq[:e]
++                        self.cookedq = self.cookedq[e:]
++                        return (i, m, text)
++                if timeout is not None:
++                    ready = selector.select(timeout)
++                    timeout = deadline - _time()
++                    if not ready:
++                        if timeout < 0:
++                            break
++                        else:
++                            continue
++                self.fill_rawq()
++        text = self.read_very_lazy()
++        if not text and self.eof:
++            raise EOFError
++        return (-1, None, text)
++
++    def __enter__(self):
++        return self
++
++    def __exit__(self, type, value, traceback):
++        self.close()
++
++
++def test():
++    """Test program for telnetlib.
++
++    Usage: python telnetlib.py [-d] ... [host [port]]
++
++    Default host is localhost; default port is 23.
++
++    """
++    debuglevel = 0
++    while sys.argv[1:] and sys.argv[1] == '-d':
++        debuglevel = debuglevel+1
++        del sys.argv[1]
++    host = 'localhost'
++    if sys.argv[1:]:
++        host = sys.argv[1]
++    port = 0
++    if sys.argv[2:]:
++        portstr = sys.argv[2]
++        try:
++            port = int(portstr)
++        except ValueError:
++            port = socket.getservbyname(portstr, 'tcp')
++    with Telnet() as tn:
++        tn.set_debuglevel(debuglevel)
++        tn.open(host, port, timeout=0.5)
++        tn.interact()
++
++if __name__ == '__main__':
++    test()
+diff -r 53111596a0a0 -r 03d9e30817d7 testing/mozbase/mozrunner/setup.py
+--- a/testing/mozbase/mozrunner/setup.py	Tue Nov 05 17:47:15 2024 +0000
++++ b/testing/mozbase/mozrunner/setup.py	Fri Nov 08 17:55:02 2024 +0000
+@@ -5,12 +5,12 @@
+ from setuptools import find_packages, setup
+ 
+ PACKAGE_NAME = "mozrunner"
+-PACKAGE_VERSION = "8.3.1"
++PACKAGE_VERSION = "8.3.2"
+ 
+ desc = """Reliable start/stop/configuration of Mozilla Applications (Firefox, Thunderbird, etc.)"""
+ 
+ deps = [
+-    "mozdevice>=4.0.0,<5",
++    "mozdevice>=4.2.0,<5",
+     "mozfile>=1.2",
+     "mozinfo>=0.7,<2",
+     "mozlog>=6.0",
+diff -r 53111596a0a0 -r 03d9e30817d7 testing/web-platform/tests/tools/pytest.ini
+--- a/testing/web-platform/tests/tools/pytest.ini	Tue Nov 05 17:47:15 2024 +0000
++++ b/testing/web-platform/tests/tools/pytest.ini	Fri Nov 08 17:55:02 2024 +0000
+@@ -20,8 +20,6 @@
+     ignore:This method will be removed in .*\.\s+Use 'parser\.read_file\(\)' instead\.:DeprecationWarning:mozversion
+     # ignore mozversion not cleanly closing .ini files
+     ignore:unclosed file.*\.ini:ResourceWarning:mozversion
+-    # mozrunner uses telnetlib module
+-    ignore:'telnetlib' is deprecated and slated for removal in Python 3:DeprecationWarning
+     # https://github.com/web-platform-tests/wpt/issues/39366
+     always:The metaschema specified by \$schema was not found\. Using the latest draft to validate, but this will raise an error in the future\.:DeprecationWarning
+     # https://github.com/web-platform-tests/wpt/issues/39359
+diff -r 53111596a0a0 -r 03d9e30817d7 testing/web-platform/tests/tools/wpt/requirements_android.txt
+--- a/testing/web-platform/tests/tools/wpt/requirements_android.txt	Tue Nov 05 17:47:15 2024 +0000
++++ b/testing/web-platform/tests/tools/wpt/requirements_android.txt	Fri Nov 08 17:55:02 2024 +0000
+@@ -1,1 +1,1 @@
+-mozrunner==8.3.1
++mozrunner==8.3.2
+diff -r 53111596a0a0 -r 03d9e30817d7 testing/web-platform/tests/tools/wptrunner/requirements_firefox.txt
+--- a/testing/web-platform/tests/tools/wptrunner/requirements_firefox.txt	Tue Nov 05 17:47:15 2024 +0000
++++ b/testing/web-platform/tests/tools/wptrunner/requirements_firefox.txt	Fri Nov 08 17:55:02 2024 +0000
+@@ -1,10 +1,10 @@
+ marionette_driver==3.4.0
+ mozcrash==2.2.0
+-mozdevice==4.1.2
++mozdevice==4.2.0
+ mozinstall==2.1.0
+ mozleak==0.2
+ mozprofile==3.0.0
+-mozrunner==8.3.1
++mozrunner==8.3.2
+ mozversion==2.4.0
+ psutil==5.9.8
+ redo==2.0.4

--- a/dev-lang/spidermonkey/spidermonkey-115.16.0-r1.ebuild
+++ b/dev-lang/spidermonkey/spidermonkey-115.16.0-r1.ebuild
@@ -9,7 +9,7 @@ SPIDERMONKEY_PATCHSET="spidermonkey-115-patches-02.tar.xz"
 
 LLVM_COMPAT=( 18 )
 
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..13} )
 PYTHON_REQ_USE="ncurses,ssl,xml(+)"
 
 RUST_NEEDS_LLVM="1"
@@ -228,6 +228,8 @@ src_prepare() {
 	if use elibc_glibc ; then
 		rm -v "${WORKDIR}"/firefox-patches/*bgo-748849-RUST_TARGET_override.patch || die
 	fi
+
+	eapply "${FILESDIR}"/spidermonkey-115.16.0-tests-add-python3.13-support.patch
 
 	eapply "${WORKDIR}"/firefox-patches
 	eapply "${WORKDIR}"/spidermonkey-patches

--- a/dev-lang/spidermonkey/spidermonkey-128.4.0-r1.ebuild
+++ b/dev-lang/spidermonkey/spidermonkey-128.4.0-r1.ebuild
@@ -8,7 +8,7 @@ SPIDERMONKEY_PATCHSET="spidermonkey-128-patches-02.tar.xz"
 
 LLVM_COMPAT=( 17 18 19 )
 
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..13} )
 PYTHON_REQ_USE="ncurses,ssl,xml(+)"
 
 WANT_AUTOCONF="2.1"
@@ -229,6 +229,8 @@ src_prepare() {
 	if use elibc_glibc ; then
 		rm -v "${WORKDIR}"/firefox-patches/*bgo-748849-RUST_TARGET_override.patch || die
 	fi
+
+	eapply "${FILESDIR}"/spidermonkey-128.4.0-tests-add-python3.13-support.patch
 
 	eapply "${WORKDIR}"/firefox-patches
 	eapply "${WORKDIR}"/spidermonkey-patches

--- a/www-client/firefox/files/firefox-133.0-tests-add-python3.13-support.patch
+++ b/www-client/firefox/files/firefox-133.0-tests-add-python3.13-support.patch
@@ -1,0 +1,1121 @@
+
+# HG changeset patch
+# User Rob Wu <rob@robwu.nl>
+# Date 1730841860 0
+# Node ID d12754638c687fb1faccb217c2a44a5b66806c37
+# Parent  652dabf039d013dd7acd287b5ed0a6d3ee916297
+Bug 1926140 - Replace pipes imports r=jmaher
+
+pipes does not exist in Python 3.11 any more
+
+Differential Revision: https://phabricator.services.mozilla.com/D227964
+
+diff --git a/js/src/tests/lib/results.py b/js/src/tests/lib/results.py
+--- a/js/src/tests/lib/results.py
++++ b/js/src/tests/lib/results.py
+@@ -1,20 +1,20 @@
+ import json
+-import pipes
+ import re
++import shlex
+ 
+ from .progressbar import NullProgressBar, ProgressBar
+ from .structuredlog import TestLogger
+ 
+ # subprocess.list2cmdline does not properly escape for sh-like shells
+ 
+ 
+ def escape_cmdline(args):
+-    return " ".join([pipes.quote(a) for a in args])
++    return " ".join([shlex.quote(a) for a in args])
+ 
+ 
+ class TestOutput:
+     """Output from a test run."""
+ 
+     def __init__(self, test, cmd, out, err, rc, dt, timed_out, extra=None):
+         self.test = test  # Test
+         self.cmd = cmd  # str:   command line of test
+diff --git a/testing/mozbase/mozdevice/mozdevice/adb.py b/testing/mozbase/mozdevice/mozdevice/adb.py
+--- a/testing/mozbase/mozdevice/mozdevice/adb.py
++++ b/testing/mozbase/mozdevice/mozdevice/adb.py
+@@ -1,15 +1,14 @@
+ # This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ # You can obtain one at http://mozilla.org/MPL/2.0/.
+ 
+ import io
+ import os
+-import pipes
+ import posixpath
+ import re
+ import shlex
+ import shutil
+ import signal
+ import subprocess
+ import sys
+ import tempfile
+@@ -1288,18 +1287,16 @@ class ADBDevice(ADBCommand):
+         re_quotable_chars = re.compile(r"[ ()\"&'\];]")
+         return re_quotable_chars.search(arg)
+ 
+     @staticmethod
+     def _quote(arg):
+         """Utility function to return quoted version of command argument."""
+         if hasattr(shlex, "quote"):
+             quote = shlex.quote
+-        elif hasattr(pipes, "quote"):
+-            quote = pipes.quote
+         else:
+ 
+             def quote(arg):
+                 arg = arg or ""
+                 re_unsafe = re.compile(r"[^\w@%+=:,./-]")
+                 if re_unsafe.search(arg):
+                     arg = "'" + arg.replace("'", "'\"'\"'") + "'"
+                 return arg
+diff --git a/testing/web-platform/tests/tools/pytest.ini b/testing/web-platform/tests/tools/pytest.ini
+--- a/testing/web-platform/tests/tools/pytest.ini
++++ b/testing/web-platform/tests/tools/pytest.ini
+@@ -15,18 +15,16 @@ filterwarnings =
+     # ignore mozinfo deprecation warnings
+     ignore:distutils Version classes are deprecated\. Use packaging\.version instead\.:DeprecationWarning:mozinfo
+     # ingore mozinfo's dependency on distro
+     ignore:distro\.linux_distribution\(\) is deprecated\. It should only be used as a compatibility shim with Python\'s platform\.linux_distribution\(\)\. Please use distro\.id\(\), distro\.version\(\) and distro\.name\(\) instead\.:DeprecationWarning
+     # ignore mozversion deprecation warnings
+     ignore:This method will be removed in .*\.\s+Use 'parser\.read_file\(\)' instead\.:DeprecationWarning:mozversion
+     # ignore mozversion not cleanly closing .ini files
+     ignore:unclosed file.*\.ini:ResourceWarning:mozversion
+-    # mozdevice uses pipes module
+-    ignore:'pipes' is deprecated and slated for removal in Python 3:DeprecationWarning
+     # mozrunner uses telnetlib module
+     ignore:'telnetlib' is deprecated and slated for removal in Python 3:DeprecationWarning
+     # https://github.com/web-platform-tests/wpt/issues/39366
+     always:The metaschema specified by \$schema was not found\. Using the latest draft to validate, but this will raise an error in the future\.:DeprecationWarning
+     # https://github.com/web-platform-tests/wpt/issues/39359
+     always:'cgi' is deprecated and slated for removal in Python 3:DeprecationWarning
+     # https://github.com/web-platform-tests/wpt/issues/39373
+     always:the imp module is deprecated in favour of importlib:DeprecationWarning
+diff --git a/testing/xpcshell/runxpcshelltests.py b/testing/xpcshell/runxpcshelltests.py
+--- a/testing/xpcshell/runxpcshelltests.py
++++ b/testing/xpcshell/runxpcshelltests.py
+@@ -2,20 +2,20 @@
+ #
+ # This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ 
+ import copy
+ import json
+ import os
+-import pipes
+ import platform
+ import random
+ import re
++import shlex
+ import shutil
+ import signal
+ import subprocess
+ import sys
+ import tempfile
+ import time
+ import traceback
+ from argparse import Namespace
+@@ -367,21 +367,21 @@ class XPCShellTestThread(Thread):
+         self.log.info("%s | current directory: %r" % (name, testdir))
+         # Show only those environment variables that are changed from
+         # the ambient environment.
+         changedEnv = set("%s=%s" % i for i in six.iteritems(self.env)) - set(
+             "%s=%s" % i for i in six.iteritems(os.environ)
+         )
+         self.log.info("%s | environment: %s" % (name, list(changedEnv)))
+         shell_command_tokens = [
+-            pipes.quote(tok) for tok in list(changedEnv) + completeCmd
++            shlex.quote(tok) for tok in list(changedEnv) + completeCmd
+         ]
+         self.log.info(
+             "%s | as shell command: (cd %s; %s)"
+-            % (name, pipes.quote(testdir), " ".join(shell_command_tokens))
++            % (name, shlex.quote(testdir), " ".join(shell_command_tokens))
+         )
+ 
+     def killTimeout(self, proc):
+         if proc is not None and hasattr(proc, "pid"):
+             mozcrash.kill_and_get_minidump(
+                 proc.pid, self.tempDir, utility_path=self.utility_path
+             )
+         else:
+
+
+# HG changeset patch
+# User Rob Wu <rob@robwu.nl>
+# Date 1730828835 0
+# Node ID 50d41051085b8d1201443a09faeff9207f5152af
+# Parent  025c089998e3b05f0a71fd03c9c9c9ac4c4abf17
+Bug 1925198 - Move telnetlib import to BaseEmulator r=jmaher
+
+emulator.py currently has an unconditional telnetlib import, but the
+file can also be imported when the functionality is not needed.
+
+Because telnetlib was removed from Python 3.13, this unconditional
+import breaks use cases that do not even care about telnet. As a stopgap
+measure until a better fix is available, move the import to the function
+that relies on telnet.
+
+Differential Revision: https://phabricator.services.mozilla.com/D227995
+
+diff --git a/testing/mozbase/mozrunner/mozrunner/devices/emulator.py b/testing/mozbase/mozrunner/mozrunner/devices/emulator.py
+--- a/testing/mozbase/mozrunner/mozrunner/devices/emulator.py
++++ b/testing/mozbase/mozrunner/mozrunner/devices/emulator.py
+@@ -3,17 +3,16 @@
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ 
+ import datetime
+ import os
+ import shutil
+ import subprocess
+ import tempfile
+ import time
+-from telnetlib import Telnet
+ 
+ from mozdevice import ADBHost
+ from mozprocess import ProcessHandler
+ 
+ from ..errors import TimeoutException
+ from .base import Device
+ from .emulator_battery import EmulatorBattery
+ from .emulator_geo import EmulatorGeo
+@@ -184,16 +183,21 @@ class BaseEmulator(Device):
+             output.append(line.rstrip())
+             if line.startswith("OK"):
+                 return output
+             elif line.startswith("KO:"):
+                 raise Exception("bad telnet response: %s" % line)
+ 
+     def _run_telnet(self, command):
+         if not self.telnet:
++            # telnetlib is dropped in Python 3.13 (bug 1925198).
++            # Import here instead of the top level to avoid breaking users of
++            # this file that are independent of telnet.
++            from telnetlib import Telnet
++
+             self.telnet = Telnet("localhost", self.port)
+             self._get_telnet_response()
+         return self._get_telnet_response(command)
+ 
+     def __del__(self):
+         if self.telnet:
+             self.telnet.write("exit\n")
+             self.telnet.read_all()
+
+
+# HG changeset patch
+# User Rob Wu <rob@robwu.nl>
+# Date 1731088502 0
+# Node ID f0a783f5f4813a95018c76f1be9f0e5b750389dc
+# Parent  288e8d4633ef118dcaf963c449bd6958430cef05
+Bug 1929535 - Vendor telnetlib.py r=jmaher,jgraham
+
+telnetlib.py was removed from Python 3.13, but we still depend on its
+functionality. This patch imports the original standard library from
+https://github.com/python/cpython/blob/3.12/Lib/telnetlib.py
+
+The only changes are:
+- Prepend comments at start to attribute source.
+- Prepend fmt/noqa/ruff to suppress linting by black/ruff, to avoid
+  non-critical modifications.
+- Remove `warnings._deprecated(__name__, remove=(3, 13))` call to
+  avoid a deprecation warning when loading the module.
+
+Differential Revision: https://phabricator.services.mozilla.com/D228052
+
+diff --git a/testing/mozbase/mozrunner/mozrunner/devices/android_device.py b/testing/mozbase/mozrunner/mozrunner/devices/android_device.py
+--- a/testing/mozbase/mozrunner/mozrunner/devices/android_device.py
++++ b/testing/mozbase/mozrunner/mozrunner/devices/android_device.py
+@@ -6,25 +6,29 @@ import glob
+ import os
+ import platform
+ import posixpath
+ import re
+ import shutil
+ import signal
+ import subprocess
+ import sys
+-import telnetlib
+ import time
+ from collections import namedtuple
+ from enum import Enum
+ from urllib.request import urlopen
+ 
+ import six
+ from mozdevice import ADBDeviceFactory, ADBHost
+ 
++try:
++    import telnetlib
++except ImportError:  # telnetlib was removed in Python 3.13
++    from . import telnetlib
++
+ MOZBUILD_PATH = os.environ.get(
+     "MOZBUILD_STATE_PATH", os.path.expanduser(os.path.join("~", ".mozbuild"))
+ )
+ 
+ EMULATOR_HOME_DIR = os.path.join(MOZBUILD_PATH, "android-device")
+ 
+ EMULATOR_AUTH_FILE = os.path.join(
+     os.path.expanduser("~"), ".emulator_console_auth_token"
+diff --git a/testing/mozbase/mozrunner/mozrunner/devices/emulator.py b/testing/mozbase/mozrunner/mozrunner/devices/emulator.py
+--- a/testing/mozbase/mozrunner/mozrunner/devices/emulator.py
++++ b/testing/mozbase/mozrunner/mozrunner/devices/emulator.py
+@@ -13,16 +13,21 @@ from mozdevice import ADBHost
+ from mozprocess import ProcessHandler
+ 
+ from ..errors import TimeoutException
+ from .base import Device
+ from .emulator_battery import EmulatorBattery
+ from .emulator_geo import EmulatorGeo
+ from .emulator_screen import EmulatorScreen
+ 
++try:
++    from telnetlib import Telnet
++except ImportError:  # telnetlib was removed in Python 3.13
++    from .telnetlib import Telnet
++
+ 
+ class ArchContext(object):
+     def __init__(self, arch, context, binary=None, avd=None, extra_args=None):
+         homedir = getattr(context, "homedir", "")
+         kernel = os.path.join(homedir, "prebuilts", "qemu-kernel", "%s", "%s")
+         sysdir = os.path.join(homedir, "out", "target", "product", "%s")
+         self.extra_args = []
+         self.binary = os.path.join(context.bindir or "", "emulator")
+@@ -183,21 +188,16 @@ class BaseEmulator(Device):
+             output.append(line.rstrip())
+             if line.startswith("OK"):
+                 return output
+             elif line.startswith("KO:"):
+                 raise Exception("bad telnet response: %s" % line)
+ 
+     def _run_telnet(self, command):
+         if not self.telnet:
+-            # telnetlib is dropped in Python 3.13 (bug 1925198).
+-            # Import here instead of the top level to avoid breaking users of
+-            # this file that are independent of telnet.
+-            from telnetlib import Telnet
+-
+             self.telnet = Telnet("localhost", self.port)
+             self._get_telnet_response()
+         return self._get_telnet_response(command)
+ 
+     def __del__(self):
+         if self.telnet:
+             self.telnet.write("exit\n")
+             self.telnet.read_all()
+diff --git a/testing/mozbase/mozrunner/mozrunner/devices/telnetlib.py b/testing/mozbase/mozrunner/mozrunner/devices/telnetlib.py
+new file mode 100644
+--- /dev/null
++++ b/testing/mozbase/mozrunner/mozrunner/devices/telnetlib.py
+@@ -0,0 +1,732 @@
++# Copied from https://github.com/python/cpython/blob/3.12/Lib/telnetlib.py
++# because telnetlib was removed from Python 3.13.
++# fmt: off
++# ruff: noqa: I001, E701
++#
++# This file was part of Python 3.12 and licensed under the PSF license:
++# https://docs.python.org/3.12/license.html#psf-license
++#
++# Copyright © 2001-2023 Python Software Foundation; All Rights Reserved
++#
++# 1. This LICENSE AGREEMENT is between the Python Software Foundation ("PSF"), and
++#    the Individual or Organization ("Licensee") accessing and otherwise using Python
++#    3.12.7 software in source or binary form and its associated documentation.
++#
++# 2. Subject to the terms and conditions of this License Agreement, PSF hereby
++#    grants Licensee a nonexclusive, royalty-free, world-wide license to reproduce,
++#    analyze, test, perform and/or display publicly, prepare derivative works,
++#    distribute, and otherwise use Python 3.12.7 alone or in any derivative
++#    version, provided, however, that PSF's License Agreement and PSF's notice of
++#    copyright, i.e., "Copyright © 2001-2023 Python Software Foundation; All Rights
++#    Reserved" are retained in Python 3.12.7 alone or in any derivative version
++#    prepared by Licensee.
++#
++# 3. In the event Licensee prepares a derivative work that is based on or
++#    incorporates Python 3.12.7 or any part thereof, and wants to make the
++#    derivative work available to others as provided herein, then Licensee hereby
++#    agrees to include in any such work a brief summary of the changes made to Python
++#    3.12.7.
++#
++# 4. PSF is making Python 3.12.7 available to Licensee on an "AS IS" basis.
++#    PSF MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED.  BY WAY OF
++#    EXAMPLE, BUT NOT LIMITATION, PSF MAKES NO AND DISCLAIMS ANY REPRESENTATION OR
++#    WARRANTY OF MERCHANTABILITY OR FITNESS FOR ANY PARTICULAR PURPOSE OR THAT THE
++#    USE OF PYTHON 3.12.7 WILL NOT INFRINGE ANY THIRD PARTY RIGHTS.
++#
++# 5. PSF SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF PYTHON 3.12.7
++#    FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS AS A RESULT OF
++#    MODIFYING, DISTRIBUTING, OR OTHERWISE USING PYTHON 3.12.7, OR ANY DERIVATIVE
++#    THEREOF, EVEN IF ADVISED OF THE POSSIBILITY THEREOF.
++#
++# 6. This License Agreement will automatically terminate upon a material breach of
++#    its terms and conditions.
++#
++# 7. Nothing in this License Agreement shall be deemed to create any relationship
++#    of agency, partnership, or joint venture between PSF and Licensee.  This License
++#    Agreement does not grant permission to use PSF trademarks or trade name in a
++#    trademark sense to endorse or promote products or services of Licensee, or any
++#    third party.
++#
++# 8. By copying, installing or otherwise using Python 3.12.7, Licensee agrees
++#    to be bound by the terms and conditions of this License Agreement.
++
++# The original https://github.com/python/cpython/blob/3.12/Lib/telnetlib.py
++# content starts below. The following changed have been made:
++# - Removed "warnings._deprecated" call to avoid a deprecation warning.
++r"""TELNET client class.
++
++Based on RFC 854: TELNET Protocol Specification, by J. Postel and
++J. Reynolds
++
++Example:
++
++>>> from telnetlib import Telnet
++>>> tn = Telnet('www.python.org', 79)   # connect to finger port
++>>> tn.write(b'guido\r\n')
++>>> print(tn.read_all())
++Login       Name               TTY         Idle    When    Where
++guido    Guido van Rossum      pts/2        <Dec  2 11:10> snag.cnri.reston..
++
++>>>
++
++Note that read_all() won't read until eof -- it just reads some data
++-- but it guarantees to read at least one byte unless EOF is hit.
++
++It is possible to pass a Telnet object to a selector in order to wait until
++more data is available.  Note that in this case, read_eager() may return b''
++even if there was data on the socket, because the protocol negotiation may have
++eaten the data.  This is why EOFError is needed in some cases to distinguish
++between "no data" and "connection closed" (since the socket also appears ready
++for reading when it is closed).
++
++To do:
++- option negotiation
++- timeout should be intrinsic to the connection object instead of an
++  option on one of the read calls only
++
++"""
++
++
++# Imported modules
++import sys
++import socket
++import selectors
++from time import monotonic as _time
++
++__all__ = ["Telnet"]
++
++# Tunable parameters
++DEBUGLEVEL = 0
++
++# Telnet protocol defaults
++TELNET_PORT = 23
++
++# Telnet protocol characters (don't change)
++IAC  = bytes([255]) # "Interpret As Command"
++DONT = bytes([254])
++DO   = bytes([253])
++WONT = bytes([252])
++WILL = bytes([251])
++theNULL = bytes([0])
++
++SE  = bytes([240])  # Subnegotiation End
++NOP = bytes([241])  # No Operation
++DM  = bytes([242])  # Data Mark
++BRK = bytes([243])  # Break
++IP  = bytes([244])  # Interrupt process
++AO  = bytes([245])  # Abort output
++AYT = bytes([246])  # Are You There
++EC  = bytes([247])  # Erase Character
++EL  = bytes([248])  # Erase Line
++GA  = bytes([249])  # Go Ahead
++SB =  bytes([250])  # Subnegotiation Begin
++
++
++# Telnet protocol options code (don't change)
++# These ones all come from arpa/telnet.h
++BINARY = bytes([0]) # 8-bit data path
++ECHO = bytes([1]) # echo
++RCP = bytes([2]) # prepare to reconnect
++SGA = bytes([3]) # suppress go ahead
++NAMS = bytes([4]) # approximate message size
++STATUS = bytes([5]) # give status
++TM = bytes([6]) # timing mark
++RCTE = bytes([7]) # remote controlled transmission and echo
++NAOL = bytes([8]) # negotiate about output line width
++NAOP = bytes([9]) # negotiate about output page size
++NAOCRD = bytes([10]) # negotiate about CR disposition
++NAOHTS = bytes([11]) # negotiate about horizontal tabstops
++NAOHTD = bytes([12]) # negotiate about horizontal tab disposition
++NAOFFD = bytes([13]) # negotiate about formfeed disposition
++NAOVTS = bytes([14]) # negotiate about vertical tab stops
++NAOVTD = bytes([15]) # negotiate about vertical tab disposition
++NAOLFD = bytes([16]) # negotiate about output LF disposition
++XASCII = bytes([17]) # extended ascii character set
++LOGOUT = bytes([18]) # force logout
++BM = bytes([19]) # byte macro
++DET = bytes([20]) # data entry terminal
++SUPDUP = bytes([21]) # supdup protocol
++SUPDUPOUTPUT = bytes([22]) # supdup output
++SNDLOC = bytes([23]) # send location
++TTYPE = bytes([24]) # terminal type
++EOR = bytes([25]) # end or record
++TUID = bytes([26]) # TACACS user identification
++OUTMRK = bytes([27]) # output marking
++TTYLOC = bytes([28]) # terminal location number
++VT3270REGIME = bytes([29]) # 3270 regime
++X3PAD = bytes([30]) # X.3 PAD
++NAWS = bytes([31]) # window size
++TSPEED = bytes([32]) # terminal speed
++LFLOW = bytes([33]) # remote flow control
++LINEMODE = bytes([34]) # Linemode option
++XDISPLOC = bytes([35]) # X Display Location
++OLD_ENVIRON = bytes([36]) # Old - Environment variables
++AUTHENTICATION = bytes([37]) # Authenticate
++ENCRYPT = bytes([38]) # Encryption option
++NEW_ENVIRON = bytes([39]) # New - Environment variables
++# the following ones come from
++# http://www.iana.org/assignments/telnet-options
++# Unfortunately, that document does not assign identifiers
++# to all of them, so we are making them up
++TN3270E = bytes([40]) # TN3270E
++XAUTH = bytes([41]) # XAUTH
++CHARSET = bytes([42]) # CHARSET
++RSP = bytes([43]) # Telnet Remote Serial Port
++COM_PORT_OPTION = bytes([44]) # Com Port Control Option
++SUPPRESS_LOCAL_ECHO = bytes([45]) # Telnet Suppress Local Echo
++TLS = bytes([46]) # Telnet Start TLS
++KERMIT = bytes([47]) # KERMIT
++SEND_URL = bytes([48]) # SEND-URL
++FORWARD_X = bytes([49]) # FORWARD_X
++PRAGMA_LOGON = bytes([138]) # TELOPT PRAGMA LOGON
++SSPI_LOGON = bytes([139]) # TELOPT SSPI LOGON
++PRAGMA_HEARTBEAT = bytes([140]) # TELOPT PRAGMA HEARTBEAT
++EXOPL = bytes([255]) # Extended-Options-List
++NOOPT = bytes([0])
++
++
++# poll/select have the advantage of not requiring any extra file descriptor,
++# contrarily to epoll/kqueue (also, they require a single syscall).
++if hasattr(selectors, 'PollSelector'):
++    _TelnetSelector = selectors.PollSelector
++else:
++    _TelnetSelector = selectors.SelectSelector
++
++
++class Telnet:
++
++    """Telnet interface class.
++
++    An instance of this class represents a connection to a telnet
++    server.  The instance is initially not connected; the open()
++    method must be used to establish a connection.  Alternatively, the
++    host name and optional port number can be passed to the
++    constructor, too.
++
++    Don't try to reopen an already connected instance.
++
++    This class has many read_*() methods.  Note that some of them
++    raise EOFError when the end of the connection is read, because
++    they can return an empty string for other reasons.  See the
++    individual doc strings.
++
++    read_until(expected, [timeout])
++        Read until the expected string has been seen, or a timeout is
++        hit (default is no timeout); may block.
++
++    read_all()
++        Read all data until EOF; may block.
++
++    read_some()
++        Read at least one byte or EOF; may block.
++
++    read_very_eager()
++        Read all data available already queued or on the socket,
++        without blocking.
++
++    read_eager()
++        Read either data already queued or some data available on the
++        socket, without blocking.
++
++    read_lazy()
++        Read all data in the raw queue (processing it first), without
++        doing any socket I/O.
++
++    read_very_lazy()
++        Reads all data in the cooked queue, without doing any socket
++        I/O.
++
++    read_sb_data()
++        Reads available data between SB ... SE sequence. Don't block.
++
++    set_option_negotiation_callback(callback)
++        Each time a telnet option is read on the input flow, this callback
++        (if set) is called with the following parameters :
++        callback(telnet socket, command, option)
++            option will be chr(0) when there is no option.
++        No other action is done afterwards by telnetlib.
++
++    """
++    sock = None  # for __del__()
++
++    def __init__(self, host=None, port=0,
++                 timeout=socket._GLOBAL_DEFAULT_TIMEOUT):
++        """Constructor.
++
++        When called without arguments, create an unconnected instance.
++        With a hostname argument, it connects the instance; port number
++        and timeout are optional.
++        """
++        self.debuglevel = DEBUGLEVEL
++        self.host = host
++        self.port = port
++        self.timeout = timeout
++        self.sock = None
++        self.rawq = b''
++        self.irawq = 0
++        self.cookedq = b''
++        self.eof = 0
++        self.iacseq = b'' # Buffer for IAC sequence.
++        self.sb = 0 # flag for SB and SE sequence.
++        self.sbdataq = b''
++        self.option_callback = None
++        if host is not None:
++            self.open(host, port, timeout)
++
++    def open(self, host, port=0, timeout=socket._GLOBAL_DEFAULT_TIMEOUT):
++        """Connect to a host.
++
++        The optional second argument is the port number, which
++        defaults to the standard telnet port (23).
++
++        Don't try to reopen an already connected instance.
++        """
++        self.eof = 0
++        if not port:
++            port = TELNET_PORT
++        self.host = host
++        self.port = port
++        self.timeout = timeout
++        sys.audit("telnetlib.Telnet.open", self, host, port)
++        self.sock = socket.create_connection((host, port), timeout)
++
++    def __del__(self):
++        """Destructor -- close the connection."""
++        self.close()
++
++    def msg(self, msg, *args):
++        """Print a debug message, when the debug level is > 0.
++
++        If extra arguments are present, they are substituted in the
++        message using the standard string formatting operator.
++
++        """
++        if self.debuglevel > 0:
++            print('Telnet(%s,%s):' % (self.host, self.port), end=' ')
++            if args:
++                print(msg % args)
++            else:
++                print(msg)
++
++    def set_debuglevel(self, debuglevel):
++        """Set the debug level.
++
++        The higher it is, the more debug output you get (on sys.stdout).
++
++        """
++        self.debuglevel = debuglevel
++
++    def close(self):
++        """Close the connection."""
++        sock = self.sock
++        self.sock = None
++        self.eof = True
++        self.iacseq = b''
++        self.sb = 0
++        if sock:
++            sock.close()
++
++    def get_socket(self):
++        """Return the socket object used internally."""
++        return self.sock
++
++    def fileno(self):
++        """Return the fileno() of the socket object used internally."""
++        return self.sock.fileno()
++
++    def write(self, buffer):
++        """Write a string to the socket, doubling any IAC characters.
++
++        Can block if the connection is blocked.  May raise
++        OSError if the connection is closed.
++
++        """
++        if IAC in buffer:
++            buffer = buffer.replace(IAC, IAC+IAC)
++        sys.audit("telnetlib.Telnet.write", self, buffer)
++        self.msg("send %r", buffer)
++        self.sock.sendall(buffer)
++
++    def read_until(self, match, timeout=None):
++        """Read until a given string is encountered or until timeout.
++
++        When no match is found, return whatever is available instead,
++        possibly the empty string.  Raise EOFError if the connection
++        is closed and no cooked data is available.
++
++        """
++        n = len(match)
++        self.process_rawq()
++        i = self.cookedq.find(match)
++        if i >= 0:
++            i = i+n
++            buf = self.cookedq[:i]
++            self.cookedq = self.cookedq[i:]
++            return buf
++        if timeout is not None:
++            deadline = _time() + timeout
++        with _TelnetSelector() as selector:
++            selector.register(self, selectors.EVENT_READ)
++            while not self.eof:
++                if selector.select(timeout):
++                    i = max(0, len(self.cookedq)-n)
++                    self.fill_rawq()
++                    self.process_rawq()
++                    i = self.cookedq.find(match, i)
++                    if i >= 0:
++                        i = i+n
++                        buf = self.cookedq[:i]
++                        self.cookedq = self.cookedq[i:]
++                        return buf
++                if timeout is not None:
++                    timeout = deadline - _time()
++                    if timeout < 0:
++                        break
++        return self.read_very_lazy()
++
++    def read_all(self):
++        """Read all data until EOF; block until connection closed."""
++        self.process_rawq()
++        while not self.eof:
++            self.fill_rawq()
++            self.process_rawq()
++        buf = self.cookedq
++        self.cookedq = b''
++        return buf
++
++    def read_some(self):
++        """Read at least one byte of cooked data unless EOF is hit.
++
++        Return b'' if EOF is hit.  Block if no data is immediately
++        available.
++
++        """
++        self.process_rawq()
++        while not self.cookedq and not self.eof:
++            self.fill_rawq()
++            self.process_rawq()
++        buf = self.cookedq
++        self.cookedq = b''
++        return buf
++
++    def read_very_eager(self):
++        """Read everything that's possible without blocking in I/O (eager).
++
++        Raise EOFError if connection closed and no cooked data
++        available.  Return b'' if no cooked data available otherwise.
++        Don't block unless in the midst of an IAC sequence.
++
++        """
++        self.process_rawq()
++        while not self.eof and self.sock_avail():
++            self.fill_rawq()
++            self.process_rawq()
++        return self.read_very_lazy()
++
++    def read_eager(self):
++        """Read readily available data.
++
++        Raise EOFError if connection closed and no cooked data
++        available.  Return b'' if no cooked data available otherwise.
++        Don't block unless in the midst of an IAC sequence.
++
++        """
++        self.process_rawq()
++        while not self.cookedq and not self.eof and self.sock_avail():
++            self.fill_rawq()
++            self.process_rawq()
++        return self.read_very_lazy()
++
++    def read_lazy(self):
++        """Process and return data that's already in the queues (lazy).
++
++        Raise EOFError if connection closed and no data available.
++        Return b'' if no cooked data available otherwise.  Don't block
++        unless in the midst of an IAC sequence.
++
++        """
++        self.process_rawq()
++        return self.read_very_lazy()
++
++    def read_very_lazy(self):
++        """Return any data available in the cooked queue (very lazy).
++
++        Raise EOFError if connection closed and no data available.
++        Return b'' if no cooked data available otherwise.  Don't block.
++
++        """
++        buf = self.cookedq
++        self.cookedq = b''
++        if not buf and self.eof and not self.rawq:
++            raise EOFError('telnet connection closed')
++        return buf
++
++    def read_sb_data(self):
++        """Return any data available in the SB ... SE queue.
++
++        Return b'' if no SB ... SE available. Should only be called
++        after seeing a SB or SE command. When a new SB command is
++        found, old unread SB data will be discarded. Don't block.
++
++        """
++        buf = self.sbdataq
++        self.sbdataq = b''
++        return buf
++
++    def set_option_negotiation_callback(self, callback):
++        """Provide a callback function called after each receipt of a telnet option."""
++        self.option_callback = callback
++
++    def process_rawq(self):
++        """Transfer from raw queue to cooked queue.
++
++        Set self.eof when connection is closed.  Don't block unless in
++        the midst of an IAC sequence.
++
++        """
++        buf = [b'', b'']
++        try:
++            while self.rawq:
++                c = self.rawq_getchar()
++                if not self.iacseq:
++                    if c == theNULL:
++                        continue
++                    if c == b"\021":
++                        continue
++                    if c != IAC:
++                        buf[self.sb] = buf[self.sb] + c
++                        continue
++                    else:
++                        self.iacseq += c
++                elif len(self.iacseq) == 1:
++                    # 'IAC: IAC CMD [OPTION only for WILL/WONT/DO/DONT]'
++                    if c in (DO, DONT, WILL, WONT):
++                        self.iacseq += c
++                        continue
++
++                    self.iacseq = b''
++                    if c == IAC:
++                        buf[self.sb] = buf[self.sb] + c
++                    else:
++                        if c == SB: # SB ... SE start.
++                            self.sb = 1
++                            self.sbdataq = b''
++                        elif c == SE:
++                            self.sb = 0
++                            self.sbdataq = self.sbdataq + buf[1]
++                            buf[1] = b''
++                        if self.option_callback:
++                            # Callback is supposed to look into
++                            # the sbdataq
++                            self.option_callback(self.sock, c, NOOPT)
++                        else:
++                            # We can't offer automatic processing of
++                            # suboptions. Alas, we should not get any
++                            # unless we did a WILL/DO before.
++                            self.msg('IAC %d not recognized' % ord(c))
++                elif len(self.iacseq) == 2:
++                    cmd = self.iacseq[1:2]
++                    self.iacseq = b''
++                    opt = c
++                    if cmd in (DO, DONT):
++                        self.msg('IAC %s %d',
++                            cmd == DO and 'DO' or 'DONT', ord(opt))
++                        if self.option_callback:
++                            self.option_callback(self.sock, cmd, opt)
++                        else:
++                            self.sock.sendall(IAC + WONT + opt)
++                    elif cmd in (WILL, WONT):
++                        self.msg('IAC %s %d',
++                            cmd == WILL and 'WILL' or 'WONT', ord(opt))
++                        if self.option_callback:
++                            self.option_callback(self.sock, cmd, opt)
++                        else:
++                            self.sock.sendall(IAC + DONT + opt)
++        except EOFError: # raised by self.rawq_getchar()
++            self.iacseq = b'' # Reset on EOF
++            self.sb = 0
++        self.cookedq = self.cookedq + buf[0]
++        self.sbdataq = self.sbdataq + buf[1]
++
++    def rawq_getchar(self):
++        """Get next char from raw queue.
++
++        Block if no data is immediately available.  Raise EOFError
++        when connection is closed.
++
++        """
++        if not self.rawq:
++            self.fill_rawq()
++            if self.eof:
++                raise EOFError
++        c = self.rawq[self.irawq:self.irawq+1]
++        self.irawq = self.irawq + 1
++        if self.irawq >= len(self.rawq):
++            self.rawq = b''
++            self.irawq = 0
++        return c
++
++    def fill_rawq(self):
++        """Fill raw queue from exactly one recv() system call.
++
++        Block if no data is immediately available.  Set self.eof when
++        connection is closed.
++
++        """
++        if self.irawq >= len(self.rawq):
++            self.rawq = b''
++            self.irawq = 0
++        # The buffer size should be fairly small so as to avoid quadratic
++        # behavior in process_rawq() above
++        buf = self.sock.recv(50)
++        self.msg("recv %r", buf)
++        self.eof = (not buf)
++        self.rawq = self.rawq + buf
++
++    def sock_avail(self):
++        """Test whether data is available on the socket."""
++        with _TelnetSelector() as selector:
++            selector.register(self, selectors.EVENT_READ)
++            return bool(selector.select(0))
++
++    def interact(self):
++        """Interaction function, emulates a very dumb telnet client."""
++        if sys.platform == "win32":
++            self.mt_interact()
++            return
++        with _TelnetSelector() as selector:
++            selector.register(self, selectors.EVENT_READ)
++            selector.register(sys.stdin, selectors.EVENT_READ)
++
++            while True:
++                for key, events in selector.select():
++                    if key.fileobj is self:
++                        try:
++                            text = self.read_eager()
++                        except EOFError:
++                            print('*** Connection closed by remote host ***')
++                            return
++                        if text:
++                            sys.stdout.write(text.decode('ascii'))
++                            sys.stdout.flush()
++                    elif key.fileobj is sys.stdin:
++                        line = sys.stdin.readline().encode('ascii')
++                        if not line:
++                            return
++                        self.write(line)
++
++    def mt_interact(self):
++        """Multithreaded version of interact()."""
++        import _thread
++        _thread.start_new_thread(self.listener, ())
++        while 1:
++            line = sys.stdin.readline()
++            if not line:
++                break
++            self.write(line.encode('ascii'))
++
++    def listener(self):
++        """Helper for mt_interact() -- this executes in the other thread."""
++        while 1:
++            try:
++                data = self.read_eager()
++            except EOFError:
++                print('*** Connection closed by remote host ***')
++                return
++            if data:
++                sys.stdout.write(data.decode('ascii'))
++            else:
++                sys.stdout.flush()
++
++    def expect(self, list, timeout=None):
++        """Read until one from a list of a regular expressions matches.
++
++        The first argument is a list of regular expressions, either
++        compiled (re.Pattern instances) or uncompiled (strings).
++        The optional second argument is a timeout, in seconds; default
++        is no timeout.
++
++        Return a tuple of three items: the index in the list of the
++        first regular expression that matches; the re.Match object
++        returned; and the text read up till and including the match.
++
++        If EOF is read and no text was read, raise EOFError.
++        Otherwise, when nothing matches, return (-1, None, text) where
++        text is the text received so far (may be the empty string if a
++        timeout happened).
++
++        If a regular expression ends with a greedy match (e.g. '.*')
++        or if more than one expression can match the same input, the
++        results are undeterministic, and may depend on the I/O timing.
++
++        """
++        re = None
++        list = list[:]
++        indices = range(len(list))
++        for i in indices:
++            if not hasattr(list[i], "search"):
++                if not re: import re
++                list[i] = re.compile(list[i])
++        if timeout is not None:
++            deadline = _time() + timeout
++        with _TelnetSelector() as selector:
++            selector.register(self, selectors.EVENT_READ)
++            while not self.eof:
++                self.process_rawq()
++                for i in indices:
++                    m = list[i].search(self.cookedq)
++                    if m:
++                        e = m.end()
++                        text = self.cookedq[:e]
++                        self.cookedq = self.cookedq[e:]
++                        return (i, m, text)
++                if timeout is not None:
++                    ready = selector.select(timeout)
++                    timeout = deadline - _time()
++                    if not ready:
++                        if timeout < 0:
++                            break
++                        else:
++                            continue
++                self.fill_rawq()
++        text = self.read_very_lazy()
++        if not text and self.eof:
++            raise EOFError
++        return (-1, None, text)
++
++    def __enter__(self):
++        return self
++
++    def __exit__(self, type, value, traceback):
++        self.close()
++
++
++def test():
++    """Test program for telnetlib.
++
++    Usage: python telnetlib.py [-d] ... [host [port]]
++
++    Default host is localhost; default port is 23.
++
++    """
++    debuglevel = 0
++    while sys.argv[1:] and sys.argv[1] == '-d':
++        debuglevel = debuglevel+1
++        del sys.argv[1]
++    host = 'localhost'
++    if sys.argv[1:]:
++        host = sys.argv[1]
++    port = 0
++    if sys.argv[2:]:
++        portstr = sys.argv[2]
++        try:
++            port = int(portstr)
++        except ValueError:
++            port = socket.getservbyname(portstr, 'tcp')
++    with Telnet() as tn:
++        tn.set_debuglevel(debuglevel)
++        tn.open(host, port, timeout=0.5)
++        tn.interact()
++
++if __name__ == '__main__':
++    test()
+diff --git a/testing/mozbase/mozrunner/setup.py b/testing/mozbase/mozrunner/setup.py
+--- a/testing/mozbase/mozrunner/setup.py
++++ b/testing/mozbase/mozrunner/setup.py
+@@ -1,21 +1,21 @@
+ # This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ # You can obtain one at http://mozilla.org/MPL/2.0/.
+ 
+ from setuptools import find_packages, setup
+ 
+ PACKAGE_NAME = "mozrunner"
+-PACKAGE_VERSION = "8.3.1"
++PACKAGE_VERSION = "8.3.2"
+ 
+ desc = """Reliable start/stop/configuration of Mozilla Applications (Firefox, Thunderbird, etc.)"""
+ 
+ deps = [
+-    "mozdevice>=4.0.0,<5",
++    "mozdevice>=4.2.0,<5",
+     "mozfile>=1.2",
+     "mozinfo>=0.7,<2",
+     "mozlog>=6.0",
+     "mozprocess>=1.3.0,<2",
+     "mozprofile~=3.0",
+     "six>=1.13.0,<2",
+ ]
+ 
+diff --git a/testing/web-platform/tests/tools/pytest.ini b/testing/web-platform/tests/tools/pytest.ini
+--- a/testing/web-platform/tests/tools/pytest.ini
++++ b/testing/web-platform/tests/tools/pytest.ini
+@@ -15,18 +15,16 @@ filterwarnings =
+     # ignore mozinfo deprecation warnings
+     ignore:distutils Version classes are deprecated\. Use packaging\.version instead\.:DeprecationWarning:mozinfo
+     # ingore mozinfo's dependency on distro
+     ignore:distro\.linux_distribution\(\) is deprecated\. It should only be used as a compatibility shim with Python\'s platform\.linux_distribution\(\)\. Please use distro\.id\(\), distro\.version\(\) and distro\.name\(\) instead\.:DeprecationWarning
+     # ignore mozversion deprecation warnings
+     ignore:This method will be removed in .*\.\s+Use 'parser\.read_file\(\)' instead\.:DeprecationWarning:mozversion
+     # ignore mozversion not cleanly closing .ini files
+     ignore:unclosed file.*\.ini:ResourceWarning:mozversion
+-    # mozrunner uses telnetlib module
+-    ignore:'telnetlib' is deprecated and slated for removal in Python 3:DeprecationWarning
+     # https://github.com/web-platform-tests/wpt/issues/39366
+     always:The metaschema specified by \$schema was not found\. Using the latest draft to validate, but this will raise an error in the future\.:DeprecationWarning
+     # https://github.com/web-platform-tests/wpt/issues/39359
+     always:'cgi' is deprecated and slated for removal in Python 3:DeprecationWarning
+     # https://github.com/web-platform-tests/wpt/issues/39373
+     always:the imp module is deprecated in favour of importlib:DeprecationWarning
+     # https://github.com/web-platform-tests/wpt/issues/39827
+     always:pkg_resources is deprecated as an API:DeprecationWarning
+diff --git a/testing/web-platform/tests/tools/wpt/requirements_android.txt b/testing/web-platform/tests/tools/wpt/requirements_android.txt
+--- a/testing/web-platform/tests/tools/wpt/requirements_android.txt
++++ b/testing/web-platform/tests/tools/wpt/requirements_android.txt
+@@ -1,1 +1,1 @@
+-mozrunner==8.3.1
++mozrunner==8.3.2
+diff --git a/testing/web-platform/tests/tools/wptrunner/requirements_firefox.txt b/testing/web-platform/tests/tools/wptrunner/requirements_firefox.txt
+--- a/testing/web-platform/tests/tools/wptrunner/requirements_firefox.txt
++++ b/testing/web-platform/tests/tools/wptrunner/requirements_firefox.txt
+@@ -1,10 +1,10 @@
+ marionette_driver==3.4.0
+ mozcrash==2.2.0
+-mozdevice==4.1.2
++mozdevice==4.2.0
+ mozinstall==2.1.0
+ mozleak==0.2
+ mozprofile==3.0.0
+-mozrunner==8.3.1
++mozrunner==8.3.2
+ mozversion==2.4.0
+ psutil==5.9.8
+ redo==3.0.0
+

--- a/www-client/firefox/firefox-133.0.ebuild
+++ b/www-client/firefox/firefox-133.0.ebuild
@@ -13,7 +13,7 @@ RUST_NEEDS_LLVM=1
 # If not building with clang we need at least rust 1.76
 RUST_MIN_VER=1.77.1
 
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..13} )
 PYTHON_REQ_USE="ncurses,sqlite,ssl"
 
 WANT_AUTOCONF="2.71"
@@ -588,6 +588,7 @@ src_prepare() {
 	if [[ ${use_lto} == "yes" ]]; then
 		rm -v "${WORKDIR}"/firefox-patches/*-LTO-Only-enable-LTO-*.patch || die
 	fi
+	eapply "${FILESDIR}"/firefox-133.0-tests-add-python3.13-support.patch
 
 	# Workaround for bgo#917599
 	if has_version ">=dev-libs/icu-74.1" && use system-icu ; then


### PR DESCRIPTION
The patch is a concatenation of upstream commits
d12754638c687fb1faccb217c2a44a5b66806c37,
50d41051085b8d1201443a09faeff9207f5152af, and
f0a783f5f4813a95018c76f1be9f0e5b750389dc.

This is not mergeable as is, the patch is > 20.0 KiB.  It should go into the patchset anyway.
<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
