### PR TITLE
sci-physics/rivet: add patch to fix autoconfigure sed

### DIFF
--- a/sci-physics/rivet/files/rivet-3.1.10-versions.patch
+++ b/sci-physics/rivet/files/rivet-3.1.10-versions.patch
@@ -1,0 +1,65 @@
+--- a/configure.ac	2024-11-28 14:14:00.608290493 +0100
++++ b/configure.ac	2024-11-28 14:19:41.434877928 +0100
+@@ -21,9 +21,9 @@
+ AC_SUBST(LT_OBJDIR)
+ 
+ ## Compute version code
+-let rivet_major=[`echo "$PACKAGE_VERSION" | cut -d. -f1 | sed -e 's/^0*//'`]
+-let rivet_minor=[`echo "$PACKAGE_VERSION" | cut -d. -f2 | sed -e 's/^0*//'`]
+-let rivet_micro=[`echo "$PACKAGE_VERSION" | cut -d. -f3 | sed -e 's/^0*//' | sed -e 's/[^0-9].*//g'`]
++let rivet_major=[`echo "$PACKAGE_VERSION" | cut -d. -f1 | sed -e 's/^0*//;s/\([0-9]*\).*/\1/g;s/^$/0/'`]
++let rivet_minor=[`echo "$PACKAGE_VERSION" | cut -d. -f2 | sed -e 's/^0*//;s/\([0-9]*\).*/\1/g;s/^$/0/'`]
++let rivet_micro=[`echo "$PACKAGE_VERSION" | cut -d. -f3 | sed -e 's/^0*//;s/\([0-9]*\).*/\1/g;s/^$/0/'`]
+ let PACKAGE_VERSION_CODE=10000*$rivet_major+100*$rivet_minor+$rivet_micro
+ 
+ ## Package-specific #defines
+@@ -79,9 +79,9 @@
+   AC_MSG_CHECKING([YODA version using yoda-config])
+   YODA_VERSION=`$YODACONFIG --version`
+   AC_MSG_RESULT([$YODA_VERSION])
+-  YODA_VERSION1=[`echo $YODA_VERSION | cut -d. -f1 | sed -e 's/^0*//' | sed -e 's/\([0-9]*\).*/\1/g'`]
+-  YODA_VERSION2=[`echo $YODA_VERSION | cut -d. -f2 | sed -e 's/^0*//' | sed -e 's/\([0-9]*\).*/\1/g'`]
+-  YODA_VERSION3=[`echo $YODA_VERSION | cut -d. -f3 | sed -e 's/^0*//' | sed -e 's/\([0-9]*\).*/\1/g'`]
++  YODA_VERSION1=[`echo $YODA_VERSION | cut -d. -f1 | sed -e 's/^0*//;s/\([0-9]*\).*/\1/g;s/^$/0/'`]
++  YODA_VERSION2=[`echo $YODA_VERSION | cut -d. -f2 | sed -e 's/^0*//;s/\([0-9]*\).*/\1/g;s/^$/0/'`]
++  YODA_VERSION3=[`echo $YODA_VERSION | cut -d. -f3 | sed -e 's/^0*//;s/\([0-9]*\).*/\1/g;s/^$/0/'`]
+   let YODA_VERSION_INT=YODA_VERSION1*10000+YODA_VERSION2*100+YODA_VERSION3
+   if test $YODA_VERSION_INT -lt 10800; then
+     AC_MSG_ERROR([YODA version isn't sufficient: at least version 1.8.0 required])
+@@ -154,8 +154,8 @@
+   fi
+   hepmc_version=`./conftest`
+   if test x$hepmc_version != x; then
+-    let hepmc_major=[`echo "$hepmc_version" | cut -d. -f1 | sed -e 's/^0*//'`]
+-    let hepmc_minor=[`echo "$hepmc_version" | cut -d. -f2 | sed -e 's/^0*//'`]
++    let hepmc_major=[`echo "$hepmc_version" | cut -d. -f1 | sed -e 's/^0*//;s/\([0-9]*\).*/\1/g;s/^$/0/'`]
++    let hepmc_minor=[`echo "$hepmc_version" | cut -d. -f2 | sed -e 's/^0*//;s/\([0-9]*\).*/\1/g;s/^$/0/'`]
+   fi
+   rm -f conftest conftest.cpp conftest.cc conftest.C
+   HEPMC_VERSION=$hepmc_major$hepmc_minor
+@@ -184,9 +184,9 @@
+   fi
+   hepmc_version=`./conftest`
+   if test x$hepmc_version != x; then
+-    let hepmc_major=[`echo "$hepmc_version" | cut -d. -f1 | sed -e 's/^0*//'`]
+-    let hepmc_minor=[`echo "$hepmc_version" | cut -d. -f2 | sed -e 's/^0*//'`]
+-    let hepmc_third=[`echo "$hepmc_version" | cut -d. -f3 | sed -e 's/^0*//'`]
++    let hepmc_major=[`echo "$hepmc_version" | cut -d. -f1 | sed -e 's/^0*//;s/\([0-9]*\).*/\1/g;s/^$/0/'`]
++    let hepmc_minor=[`echo "$hepmc_version" | cut -d. -f2 | sed -e 's/^0*//;s/\([0-9]*\).*/\1/g;s/^$/0/'`]
++    let hepmc_third=[`echo "$hepmc_version" | cut -d. -f3 | sed -e 's/^0*//;s/\([0-9]*\).*/\1/g;s/^$/0/'`]
+   fi
+   rm -f conftest conftest.cpp conftest.cc conftest.C
+   HEPMC_VERSION=$hepmc_major$hepmc_minor$hepmc_third
+@@ -219,9 +219,9 @@
+   AC_MSG_CHECKING([FastJet version using fastjet-config])
+   fjversion=`$FJCONFIG --version`
+   AC_MSG_RESULT([$fjversion])
+-  fjmajor=$(echo $fjversion | cut -f1 -d.)
+-  fjminor=$(echo $fjversion | cut -f2 -d.)
+-  fjmicro=$(echo $fjversion | cut -f3 -d.)
++  fjmajor=$(echo $fjversion | cut -f1 -d. | sed -e 's/^0*//;s/\([0-9]*\).*/\1/g;s/^$/0/')
++  fjminor=$(echo $fjversion | cut -f2 -d. | sed -e 's/^0*//;s/\([0-9]*\).*/\1/g;s/^$/0/')
++  fjmicro=$(echo $fjversion | cut -f3 -d. | sed -e 's/^0*//;s/\([0-9]*\).*/\1/g;s/^$/0/')
+   if test "$fjmajor" -lt 3 -o "$fjminor" -lt 2 ; then  #< only works for v3.x
+     AC_MSG_ERROR([FastJet version 3.2.0 or later is required])
+   fi

--- a/sci-physics/rivet/rivet-3.1.10-r1.ebuild
+++ b/sci-physics/rivet/rivet-3.1.10-r1.ebuild
@@ -36,7 +36,7 @@ RDEPEND="
 	>=sci-physics/fastjet-3.4.0[plugins]
 	>=sci-physics/fastjet-contrib-1.048
 	hepmc2? ( sci-physics/hepmc:2=[-cm(-),gev(+)] )
-	hepmc3? ( sci-physics/hepmc:3=[-cm(-),gev(+)] )
+	hepmc3? ( <sci-physics/hepmc-3.3.0:3=[-cm(-),gev(+)] )
 
 	sci-libs/gsl
 	zlib? ( sys-libs/zlib )
@@ -67,6 +67,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-3.1.6-binreloc.patch
 	"${FILESDIR}"/${PN}-3.1.9-pythontests.patch
 	"${FILESDIR}"/${PN}-3.1.10-ref_cin.patch # https://gitlab.com/hepcedar/rivet/-/merge_requests/844
+	"${FILESDIR}"/${PN}-3.1.10-versions.patch # https://gitlab.com/hepcedar/rivet/-/merge_requests/979
 )
 
 pkg_setup() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/937357

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgdev commit` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
