### PR TITLE
dev-libs/libburn: fix C23 compat

### DIFF
--- a/dev-libs/libburn/files/libburn-1.5.6-c23.patch
+++ b/dev-libs/libburn/files/libburn-1.5.6-c23.patch
@@ -1,0 +1,26 @@
+https://bugs.gentoo.org/943701
+https://dev.lovelyhq.com/libburnia/libburn/commit/d537f9dd35282df834a311ead5f113af67d223b3
+
+From d537f9dd35282df834a311ead5f113af67d223b3 Mon Sep 17 00:00:00 2001
+From: Thomas Schmitt <scdbackup@gmx.net>
+Date: Tue, 26 Nov 2024 23:02:03 +0100
+Subject: [PATCH] Bug fix: Faulty signal handler prototype spoiled compilation
+ under C23
+
+---
+ test/poll.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/test/poll.c b/test/poll.c
+index 660f384..cd5ff90 100644
+--- a/test/poll.c
++++ b/test/poll.c
+@@ -14,7 +14,7 @@ static struct burn_drive_info *drives;
+ static unsigned int n_drives;
+ int NEXT;
+
+-static void catch_int ()
++static void catch_int (int signum)
+ {
+	NEXT = 1;
+ }

--- a/dev-libs/libburn/libburn-1.5.6-r1.ebuild
+++ b/dev-libs/libburn/libburn-1.5.6-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit autotools flag-o-matic
+inherit autotools
 
 DESCRIPTION="Open-source library for reading, mastering and writing optical discs"
 HOMEPAGE="https://dev.lovelyhq.com/libburnia/web/wiki/Libburn"
@@ -21,6 +21,10 @@ DEPEND="
 	${RDEPEND}
 "
 
+PATCHES=(
+	"${FILESDIR}"/${PN}-1.5.6-c23.patch
+)
+
 src_prepare() {
 	default
 
@@ -29,9 +33,6 @@ src_prepare() {
 }
 
 src_configure() {
-	# bug #943701
-	append-cflags -std=gnu17
-
 	econf \
 		$(use_enable static-libs static) \
 		--disable-ldconfig-at-install \


### PR DESCRIPTION
Backport upstream patch [1] to fix building with gcc 15.

[1] https://dev.lovelyhq.com/libburnia/libburn/commit/d537f9dd35

Bug: https://bugs.gentoo.org/943701

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
