### PR TITLE
media-video/ffmpeg: fix build with gcc 14 on ppc

### DIFF
--- a/media-video/ffmpeg/ffmpeg-6.1.1-r8.ebuild
+++ b/media-video/ffmpeg/ffmpeg-6.1.1-r8.ebuild
@@ -386,6 +386,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-6.1.1-wint-inconversion-libgcrypt.patch
 	"${FILESDIR}"/${PN}-6.1.1-amd-av1-vaapi.patch
 	"${FILESDIR}"/${PN}-6.1.1-wint-inconversion-vulkan.patch
+	"${FILESDIR}"/${PN}-6.1.1-incmptbl-pntr-types.patch
 )
 
 MULTILIB_WRAPPED_HEADERS=(

--- a/media-video/ffmpeg/ffmpeg-6.1.2.ebuild
+++ b/media-video/ffmpeg/ffmpeg-6.1.2.ebuild
@@ -384,6 +384,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-6.1.1-wint-inconversion-libgcrypt.patch
 	"${FILESDIR}"/${PN}-6.1.1-amd-av1-vaapi.patch
 	"${FILESDIR}"/${PN}-6.1.1-wint-inconversion-vulkan.patch
+	"${FILESDIR}"/${PN}-6.1.1-incmptbl-pntr-types.patch
 )
 
 MULTILIB_WRAPPED_HEADERS=(

--- a/media-video/ffmpeg/files/ffmpeg-6.1.1-incmptbl-pntr-types.patch
+++ b/media-video/ffmpeg/files/ffmpeg-6.1.1-incmptbl-pntr-types.patch
@@ -1,0 +1,50 @@
+https://git.ffmpeg.org/gitweb/ffmpeg.git/commit/347a70f101be28f8d78e8fd62ffc3a78324f49e9
+https://bugs.gentoo.org/922621
+
+From 347a70f101be28f8d78e8fd62ffc3a78324f49e9 Mon Sep 17 00:00:00 2001
+From: Andreas Rheinhardt <andreas.rheinhardt@outlook.com>
+Date: Thu, 28 Mar 2024 05:35:36 +0100
+Subject: [PATCH] avcodec/pcm-bluray/dvd: Use correct pointer types on BE
+
+Signed-off-by: Andreas Rheinhardt <andreas.rheinhardt@outlook.com>
+---
+ libavcodec/pcm-bluray.c | 5 +++--
+ libavcodec/pcm-dvd.c    | 2 +-
+ 2 files changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/libavcodec/pcm-bluray.c b/libavcodec/pcm-bluray.c
+index f65609514a1c1..235020d78f0cf 100644
+--- a/libavcodec/pcm-bluray.c
++++ b/libavcodec/pcm-bluray.c
+@@ -167,7 +167,7 @@ static int pcm_bluray_decode_frame(AVCodecContext *avctx, AVFrame *frame,
+             samples *= num_source_channels;
+             if (AV_SAMPLE_FMT_S16 == avctx->sample_fmt) {
+ #if HAVE_BIGENDIAN
+-                bytestream2_get_buffer(&gb, dst16, buf_size);
++                bytestream2_get_buffer(&gb, (uint8_t*)dst16, buf_size);
+ #else
+                 do {
+                     *dst16++ = bytestream2_get_be16u(&gb);
+@@ -187,7 +187,8 @@ static int pcm_bluray_decode_frame(AVCodecContext *avctx, AVFrame *frame,
+             if (AV_SAMPLE_FMT_S16 == avctx->sample_fmt) {
+                 do {
+ #if HAVE_BIGENDIAN
+-                    bytestream2_get_buffer(&gb, dst16, avctx->ch_layout.nb_channels * 2);
++                    bytestream2_get_buffer(&gb, (uint8_t*)dst16,
++                                           avctx->ch_layout.nb_channels * 2);
+                     dst16 += avctx->ch_layout.nb_channels;
+ #else
+                     channel = avctx->ch_layout.nb_channels;
+diff --git a/libavcodec/pcm-dvd.c b/libavcodec/pcm-dvd.c
+index 419b2a138f887..319746c62e2dc 100644
+--- a/libavcodec/pcm-dvd.c
++++ b/libavcodec/pcm-dvd.c
+@@ -157,7 +157,7 @@ static void *pcm_dvd_decode_samples(AVCodecContext *avctx, const uint8_t *src,
+     switch (avctx->bits_per_coded_sample) {
+     case 16: {
+ #if HAVE_BIGENDIAN
+-        bytestream2_get_buffer(&gb, dst16, blocks * s->block_size);
++        bytestream2_get_buffer(&gb, (uint8_t*)dst16, blocks * s->block_size);
+         dst16 += blocks * s->block_size / 2;
+ #else
+         int samples = blocks * avctx->ch_layout.nb_channels;


### PR DESCRIPTION
Backport patch [1] to fix building with gcc 14 on ppc.

[1] https://git.ffmpeg.org/gitweb/ffmpeg.git/commit/347a70f

Closes: https://bugs.gentoo.org/922621

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
