### PR TITLE
dev-qt/qtdeclarative: version 5.15.16 requires SSE2 for USE="jit" and x86 arch

### DIFF
--- a/dev-qt/qtdeclarative/qtdeclarative-5.15.16.ebuild
+++ b/dev-qt/qtdeclarative/qtdeclarative-5.15.16.ebuild
@@ -13,7 +13,7 @@ inherit flag-o-matic python-any-r1 qt5-build
 
 DESCRIPTION="The QML and Quick modules for the Qt5 framework"
 
-IUSE="gles2-only +jit localstorage vulkan +widgets"
+IUSE="cpu_flags_x86_sse2 gles2-only +jit localstorage vulkan +widgets"
 
 # qtgui[gles2-only=] is needed because of bug 504322
 DEPEND="
@@ -27,6 +27,10 @@ DEPEND="
 "
 RDEPEND="${DEPEND}"
 BDEPEND="${PYTHON_DEPS}"
+REQUIRED_USE="jit? (
+		x86? ( cpu_flags_x86_sse2 )
+	)
+"
 
 PATCHES=(
 	"${FILESDIR}/${PN}-5.14.2-QQuickItemView-fix-maxXY-extent.patch" # QTBUG-83890


### PR DESCRIPTION
    ERROR: Feature 'qml-jit' was enabled, but the pre-condition '
    (arch.i386   && tests.pointer_32bit && features.sse2)
    || (arch.x86_64 && tests.pointer_64bit && features.sse2)
    || (arch.arm    && tests.pointer_32bit && tests.arm_fp && tests.arm_thumb
    && (config.linux || config.ios || config.tvos || config.qnx))
    || (arch.arm64  && tests.pointer_64bit && tests.arm_fp
    && (config.linux || config.ios || config.tvos || config.qnx || config.integrity))' failed.

Add ```USE_REQUIRED``` for x86 machines without SSE2 support.

Signed-off-by: Cristian Othón Martínez Vera <cfuga@cfuga.mx>

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
