### PR TITLE
media-gfx/tintii: setup-wxwidgets called from src_configure

### DIFF
--- a/media-gfx/tintii/tintii-2.10.0-r2.ebuild
+++ b/media-gfx/tintii/tintii-2.10.0-r2.ebuild
@@ -23,12 +23,8 @@ DEPEND="${RDEPEND}
 "
 BDEPEND="app-alternatives/bc"
 
-src_prepare() {
-	default
-	setup-wxwidgets
-}
-
 src_configure() {
+	setup-wxwidgets
 	econf --disable-assert
 }
 


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/935478

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
