### PR TITLE
dev-php/pecl-xattr: add php 8.3 support

### DIFF
--- a/dev-php/pecl-xattr/pecl-xattr-1.4.0-r1.ebuild
+++ b/dev-php/pecl-xattr/pecl-xattr-1.4.0-r1.ebuild
@@ -1,0 +1,19 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+PHP_EXT_INI="yes"
+PHP_EXT_NAME="xattr"
+PHP_EXT_NEEDED_USE=""
+PHP_EXT_ZENDEXT="no"
+USE_PHP="php8-2 php8-3"
+
+inherit php-ext-pecl-r3
+
+DESCRIPTION="Extended attributes for PHP"
+SRC_URI="${SRC_URI} -> ${P}.tgz"
+
+LICENSE="PHP-3.01"
+SLOT="8"
+KEYWORDS="~amd64 ~x86"


### PR DESCRIPTION
```bash
--- pecl-xattr-1.4.0.ebuild     2024-01-19 19:40:48.457703729 +0000
+++ pecl-xattr-1.4.0-r1.ebuild  2024-11-29 16:27:06.137734757 +0000
@@ -1,13 +1,13 @@
 # Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="8"
+EAPI=8
 
 PHP_EXT_INI="yes"
 PHP_EXT_NAME="xattr"
 PHP_EXT_NEEDED_USE=""
 PHP_EXT_ZENDEXT="no"
-USE_PHP="php8-1 php8-2"
+USE_PHP="php8-2 php8-3"
 
 inherit php-ext-pecl-r3
```

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
