### PR TITLE
dev-libs/capstone: add missing patch

### DIFF
--- a/dev-libs/capstone/files/capstone-5.0.2-tests.patch
+++ b/dev-libs/capstone/files/capstone-5.0.2-tests.patch
@@ -1,0 +1,17 @@
+From b77714b446e93a0ab997b125ef1fb3ad9bc4bb9b Mon Sep 17 00:00:00 2001
+From: Mario Haustein <mario.haustein@hrz.tu-chemnitz.de>
+Date: Wed, 14 Aug 2024 23:28:45 +0200
+Subject: [PATCH] Fix 'make check' for python tests
+Upstream: https://github.com/capstone-engine/capstone/pull/2439
+
+--- a/bindings/python/Makefile
++++ b/bindings/python/Makefile
+@@ -41,7 +41,7 @@ TESTS += test_lite.py test_iter.py test_customized_mnem.py test_alpha.py
+ check:
+ 	@for t in $(TESTS); do \
+ 		echo Check $$t ... ; \
+-		./$$t > /dev/null; \
++		./tests/$$t > /dev/null; \
+ 		if [ $$? -eq 0 ]; then echo OK; else echo FAILED; exit 1; fi \
+ 	done
+ 


### PR DESCRIPTION
Add missing patch accidentally delete by d607b72dc847.

Closes: https://bugs.gentoo.org/945403

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
