### PR TITLE
sys-devel/gcc: add upstreamed patch for 14.3.9999

### DIFF
--- a/sys-devel/gcc/gcc-14.3.9999.ebuild
+++ b/sys-devel/gcc/gcc-14.3.9999.ebuild
@@ -40,6 +40,7 @@ fi
 src_prepare() {
 	local p upstreamed_patches=(
 		# add them here
+		77_all_m2_docs_sandbox.patch
 	)
 	for p in "${upstreamed_patches[@]}"; do
 		rm -v "${WORKDIR}/patch/${p}" || die


### PR DESCRIPTION
Building 14.3.9999 fails right now because this patch is already applied upstream. Some other 14.2.* ebuilds have this patch in this variable and I assumed, this is just missing.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
