### PR TITLE
www-apps/davical: Restrict to PHP 8.2 and 8.3 due to missing IMAP in 8.4

### DIFF
--- a/www-apps/davical/davical-1.1.12-r1.ebuild
+++ b/www-apps/davical/davical-1.1.12-r1.ebuild
@@ -15,12 +15,20 @@ KEYWORDS="~amd64 ~x86"
 BDEPEND="sys-devel/gettext"
 
 RDEPEND="app-admin/pwgen
-	dev-lang/php[calendar,curl,iconv,imap,nls,pdo,postgres,xml]
-	dev-perl/DBD-Pg
-	dev-perl/DBI
-	dev-perl/YAML
-	>=dev-php/awl-0.64
-	virtual/httpd-php"
+		|| (
+			(
+				dev-lang/php:8.2[calendar,curl,iconv,imap,nls,pdo,postgres,xml]
+				virtual/httpd-php:8.2
+			)
+			(
+				dev-lang/php:8.3[calendar,curl,iconv,imap,nls,pdo,postgres,xml]
+				virtual/httpd-php:8.3
+			)
+		)
+		dev-perl/DBD-Pg
+		dev-perl/DBI
+		dev-perl/YAML
+		>=dev-php/awl-0.64"
 
 need_httpd
 


### PR DESCRIPTION
PHP dropped support for the IMAP integration in 8.4 and migrated the core module to PECL, which we don't have support for (yet).

See https://github.com/gentoo/gentoo/pull/39448#issuecomment-2496121325 for reference.

Should we re-apply the fix to 1.1.11 as well or do we want to drop the old version?

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
