### PR TITLE
app-misc/resolve-march-native: enable py3.13

### DIFF
--- a/app-misc/resolve-march-native/resolve-march-native-5.1.0.ebuild
+++ b/app-misc/resolve-march-native/resolve-march-native-5.1.0.ebuild
@@ -4,7 +4,7 @@
 EAPI="8"
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..12} )
+PYTHON_COMPAT=( python3_{9..13} )
 
 inherit distutils-r1
 


### PR DESCRIPTION
```
================================= test session starts ==================================
platform linux -- Python 3.13.0, pytest-8.2.1, pluggy-1.5.0 -- /var/tmp/portage/app-misc/resolve-march-native-5.1.0/work/resolve-march-native-5.1.0-python3_13/install/usr/bin/python3.13
cachedir: .pytest_cache
rootdir: /var/tmp/portage/app-misc/resolve-march-native-5.1.0/work/resolve-march-native-5.1.0
plugins: pkgcore-0.12.28
collecting ... collected 41 items

resolve_march_native/test/test_engine.py::TestEngine::test_armv8_a_crc PASSED   [ 1/41]
resolve_march_native/test/test_engine.py::TestEngine::test_bonnell PASSED       [ 2/41]
resolve_march_native/test/test_engine.py::TestEngine::test_corei7_avx PASSED    [ 3/41]
resolve_march_native/test/test_engine.py::TestEngine::test_sandybridge_celeron_without_avx PASSED [ 4/41]
resolve_march_native/test/test_engine.py::TestEngine::test_westmere PASSED      [ 5/41]
resolve_march_native/test/test_engine.py::TestEngineFourFiles::test_amd_k8_hammer PASSED [ 6/41]
resolve_march_native/test/test_engine.py::TestEngineFourFiles::test_cfarm110_power7 PASSED [ 7/41]
resolve_march_native/test/test_engine.py::TestEngineFourFiles::test_cfarm112_power8 PASSED [ 8/41]
resolve_march_native/test/test_engine.py::TestEngineFourFiles::test_cfarm117_armv8_a_crypto_crc PASSED [ 9/41]
resolve_march_native/test/test_engine.py::TestEngineFourFiles::test_cfarm118_armv8_a_crypto_crc PASSED [10/41]
resolve_march_native/test/test_engine.py::TestEngineFourFiles::test_cfarm120_power10 PASSED [11/41]
resolve_march_native/test/test_engine.py::TestEngineFourFiles::test_cfarm13_haswell PASSED [12/41]
resolve_march_native/test/test_engine.py::TestEngineFourFiles::test_cfarm14_haswell PASSED [13/41]
resolve_march_native/test/test_engine.py::TestEngineFourFiles::test_cfarm185_armv8_a_crypto_crc PASSED [14/41]
resolve_march_native/test/test_engine.py::TestEngineFourFiles::test_cfarm186_westmere PASSED [15/41]
resolve_march_native/test/test_engine.py::TestEngineFourFiles::test_cfarm187_westmere PASSED [16/41]
resolve_march_native/test/test_engine.py::TestEngineFourFiles::test_cfarm188_westmere PASSED [17/41]
resolve_march_native/test/test_engine.py::TestEngineFourFiles::test_cfarm230_octeon2 PASSED [18/41]
resolve_march_native/test/test_engine.py::TestEngineFourFiles::test_cfarm29_power9 PASSED [19/41]
resolve_march_native/test/test_engine.py::TestEngineFourFiles::test_cfarm70_nocona PASSED [20/41]
resolve_march_native/test/test_engine.py::TestEngineFourFiles::test_pentium PASSED [21/41]
resolve_march_native/test/test_engine.py::TestEngineFourFiles::test_sandybridge_celeron_without_avx PASSED [22/41]
resolve_march_native/test/test_engine.py::TestEngineFourFiles::test_sse4_weirdness_issue_177 PASSED [23/41]
resolve_march_native/test/test_parser.py::TestParser::test_parse_westmere_native_s PASSED [24/41]
resolve_march_native/test/test_sort.py::TestSort::test_bonnell PASSED           [25/41]
resolve_march_native/test/test_target_help_parser.py::GetFlagsImpliedByMarchTest::test PASSED [26/41]
resolve_march_native/test/test_target_help_parser.py::GetFlagsImpliedByMarchTest::test_macos PASSED [27/41]
resolve_march_native/test/test_target_help_parser.py::GetFlagsImpliedByMarchTest::test_sandybridge_celeron_without_avx__explicit PASSED [28/41]
resolve_march_native/test/test_target_help_parser.py::GetFlagsImpliedByMarchTest::test_sandybridge_celeron_without_avx__native PASSED [29/41]
resolve_march_native/test/test_target_help_parser.py::ParseGccOutputTest::test_array_value_lines PASSED [30/41]
resolve_march_native/test/test_target_help_parser.py::ParseGccOutputTest::test_assign_no_lines PASSED [31/41]
resolve_march_native/test/test_target_help_parser.py::ParseGccOutputTest::test_assign_yes_lines PASSED [32/41]
resolve_march_native/test/test_target_help_parser.py::ParseGccOutputTest::test_concat_arg_lines PASSED [33/41]
resolve_march_native/test/test_target_help_parser.py::ParseGccOutputTest::test_concat_var_lines PASSED [34/41]
resolve_march_native/test/test_target_help_parser.py::ParseGccOutputTest::test_deprecated_lines PASSED [35/41]
resolve_march_native/test/test_target_help_parser.py::ParseGccOutputTest::test_disabled_m_lines PASSED [36/41]
resolve_march_native/test/test_target_help_parser.py::ParseGccOutputTest::test_equal_value_default_lines PASSED [37/41]
resolve_march_native/test/test_target_help_parser.py::ParseGccOutputTest::test_ignore_lines PASSED [38/41]
resolve_march_native/test/test_target_help_parser.py::ParseGccOutputTest::test_ignore_marked_lines PASSED [39/41]
resolve_march_native/test/test_target_help_parser.py::ParseGccOutputTest::test_upper_value_lines PASSED [40/41]
resolve_march_native/test/test_target_help_parser.py::ParseGccOutputTest::test_value_default_lines PASSED [41/41]

================================== 41 passed in 0.10s ==================================
>>> Completed testing app-misc/resolve-march-native-5.1.0
```

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
