### PR TITLE
media-libs/vamp-plugin-sdk: Force -j1

### DIFF
--- a/media-libs/vamp-plugin-sdk/vamp-plugin-sdk-2.10.ebuild
+++ b/media-libs/vamp-plugin-sdk/vamp-plugin-sdk-2.10.ebuild
@@ -29,6 +29,8 @@ src_prepare() {
 }
 
 multilib_src_configure() {
+	MAKEOPTS+=" -j1" # bug #943866
+
 	# multilib for default search paths
 	sed -i -e "s:/usr/lib/vamp:${EPREFIX}/usr/$(get_libdir)/vamp:" \
 		src/vamp-hostsdk/PluginHostAdapter.cpp || die


### PR DESCRIPTION
When compiling with lto and a high MAKEOPTS this program was found to fail randomly. Lowering the MAKEOPTS to -j1 on Sam's advice has led to no further issues being found with this program during compile time.

Closes: https://bugs.gentoo.org/943866

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
