### PR TITLE
app-emulation/qemu-guest-agent: Ensure pip is available

### DIFF
--- a/app-emulation/qemu-guest-agent/qemu-guest-agent-8.2.0.ebuild
+++ b/app-emulation/qemu-guest-agent/qemu-guest-agent-8.2.0.ebuild
@@ -4,6 +4,7 @@
 EAPI=8
 
 PYTHON_COMPAT=( python3_{10..13} )
+PYTHON_REQ_USE="ensurepip(-),ncurses,readline"
 
 inherit edo systemd toolchain-funcs python-any-r1 udev
 


### PR DESCRIPTION
While we list python as a dependency, it's not enough because the configure script creates a venv and installs various tools into it using pip. Make sure pip is available by setting PYTHON_REQ_USE="ensurepip". Now, since qemu-guest-agent and qemu are both built from the same sources, I just copied PYTHON_REQ_USE from the latter, verbatim. So it lists more USE flags, but that's possibly okay.

NB, this is similar to how app-emulation/qemu evolved:

dafdf8f41fe242a8b2b51d2b8982a6e447115a58 added dev-python/pip into BDEPEND,

a9ca061a7fa2393c69be5b3de53bac2db1289ef1 allowed
dev-lang/python[ensurepip] to be chosen instead,

f09045568b3e4ec1aab0e0f7a3c237671c6070b7 moved entry from BDEPEND to PYTHON_REQ_USE.

Closes: https://bugs.gentoo.org/943034

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
