### PR TITLE
app-emulation/qemu: Update live ebuild and fix one Python related issue

### DIFF
--- a/app-emulation/qemu/files/qemu-9.2.0-capstone-include-path.patch
+++ b/app-emulation/qemu/files/qemu-9.2.0-capstone-include-path.patch
@@ -1,0 +1,41 @@
+From: Sam James <sam@gentoo.org>
+Date: Sun, 6 Oct 2024 09:47:03 +0100
+Subject: [PATCH] Forward ported from qemu-7.1.0-capstone-include-path.patch.
+
+Bug: https://bugs.gentoo.org/873157
+Signed-off-by: Sam James <sam@gentoo.org>
+Signed-off-by: Michal Privoznik <mprivozn@redhat.com>
+---
+ include/disas/capstone.h | 2 +-
+ meson.build              | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/include/disas/capstone.h b/include/disas/capstone.h
+index c43033f7f6..02bc067cd8 100644
+--- a/include/disas/capstone.h
++++ b/include/disas/capstone.h
+@@ -5,7 +5,7 @@
+ 
+ #define CAPSTONE_AARCH64_COMPAT_HEADER
+ #define CAPSTONE_SYSTEMZ_COMPAT_HEADER
+-#include <capstone.h>
++#include <capstone/capstone.h>
+ 
+ #else
+ 
+diff --git a/meson.build b/meson.build
+index 2c924f8f10..86858a325b 100644
+--- a/meson.build
++++ b/meson.build
+@@ -1892,7 +1892,7 @@ if not get_option('capstone').auto() or have_system or have_user
+   # that reports a wrong -I path, causing the #include to
+   # fail later. If the system has such a broken version
+   # do not use it.
+-  if capstone.found() and not cc.compiles('#include <capstone.h>',
++  if capstone.found() and not cc.compiles('#include <capstone/capstone.h>',
+                                           dependencies: [capstone])
+     capstone = not_found
+     if get_option('capstone').enabled()
+-- 
+2.45.2
+

--- a/app-emulation/qemu/qemu-8.2.3.ebuild
+++ b/app-emulation/qemu/qemu-8.2.3.ebuild
@@ -515,6 +515,7 @@ qemu_src_configure() {
 		--disable-guest-agent
 		--disable-strip
 		--disable-download
+		--python="${PYTHON}"
 
 		# bug #746752: TCG interpreter has a few limitations:
 		# - it does not support FPU

--- a/app-emulation/qemu/qemu-8.2.7.ebuild
+++ b/app-emulation/qemu/qemu-8.2.7.ebuild
@@ -515,6 +515,7 @@ qemu_src_configure() {
 		--disable-guest-agent
 		--disable-strip
 		--disable-download
+		--python="${PYTHON}"
 
 		# bug #746752: TCG interpreter has a few limitations:
 		# - it does not support FPU

--- a/app-emulation/qemu/qemu-8.2.8.ebuild
+++ b/app-emulation/qemu/qemu-8.2.8.ebuild
@@ -515,6 +515,7 @@ qemu_src_configure() {
 		--disable-guest-agent
 		--disable-strip
 		--disable-download
+		--python="${PYTHON}"
 
 		# bug #746752: TCG interpreter has a few limitations:
 		# - it does not support FPU

--- a/app-emulation/qemu/qemu-9.0.4.ebuild
+++ b/app-emulation/qemu/qemu-9.0.4.ebuild
@@ -521,6 +521,7 @@ qemu_src_configure() {
 		--disable-guest-agent
 		--disable-strip
 		--disable-download
+		--python="${PYTHON}"
 
 		# bug #746752: TCG interpreter has a few limitations:
 		# - it does not support FPU

--- a/app-emulation/qemu/qemu-9.1.2.ebuild
+++ b/app-emulation/qemu/qemu-9.1.2.ebuild
@@ -520,6 +520,7 @@ qemu_src_configure() {
 		--disable-guest-agent
 		--disable-strip
 		--disable-download
+		--python="${PYTHON}"
 
 		# bug #746752: TCG interpreter has a few limitations:
 		# - it does not support FPU

--- a/app-emulation/qemu/qemu-9999.ebuild
+++ b/app-emulation/qemu/qemu-9999.ebuild
@@ -518,6 +518,7 @@ qemu_src_configure() {
 		--disable-guest-agent
 		--disable-strip
 		--disable-download
+		--python="${PYTHON}"
 
 		# bug #746752: TCG interpreter has a few limitations:
 		# - it does not support FPU

--- a/app-emulation/qemu/qemu-9999.ebuild
+++ b/app-emulation/qemu/qemu-9999.ebuild
@@ -90,6 +90,7 @@ COMMON_TARGETS="
 	riscv64
 	s390x
 	sh4
+	sh4eb
 	sparc
 	sparc64
 	x86_64
@@ -110,7 +111,6 @@ IUSE_USER_TARGETS="
 	mipsn32
 	mipsn32el
 	ppc64le
-	sh4eb
 	sparc32plus
 "
 
@@ -316,7 +316,7 @@ RDEPEND="
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-9.0.0-disable-keymap.patch
-	"${FILESDIR}"/${PN}-9.1.0-capstone-include-path.patch
+	"${FILESDIR}"/${PN}-9.2.0-capstone-include-path.patch
 	"${FILESDIR}"/${PN}-8.1.0-skip-tests.patch
 	"${FILESDIR}"/${PN}-8.1.0-find-sphinx.patch
 


### PR DESCRIPTION
The live ebuild needs updating (softmmu targets and rebase of a patch) and also we need to start passing specific python version to the configure script.
---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
