### PR TITLE
dev-ruby/with_advisory_lock: fix running tests

### DIFF
--- a/dev-ruby/with_advisory_lock/with_advisory_lock-5.1.0.ebuild
+++ b/dev-ruby/with_advisory_lock/with_advisory_lock-5.1.0.ebuild
@@ -27,6 +27,8 @@ ruby_add_bdepend "test? (
 	>=dev-ruby/activerecord-6.1:*[sqlite]
 	dev-ruby/maxitest
 	dev-ruby/mocha
+	dev-ruby/sqlite3:0
+	dev-ruby/yard
 )
 "
 


### PR DESCRIPTION
Added missed dependencies dev-ruby/sqlite3:0 and dev-ruby/yard.

Closes: https://bugs.gentoo.org/945695

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
