### PR TITLE
java-pkg-simple.eclass: add support to files for the resources

### DIFF
--- a/eclass/java-pkg-simple.eclass
+++ b/eclass/java-pkg-simple.eclass
@@ -115,8 +115,9 @@ fi
 # @ECLASS_VARIABLE: JAVA_RESOURCE_DIRS
 # @DEFAULT_UNSET
 # @DESCRIPTION:
-# An array of directories relative to ${S} which contain the
-# resources of the application. If you do not set the variable,
+# An array of files or directories relative to ${S} which contain the
+# resources of the application. Files are copied with parents directory,
+# directories are recursively copied. If you do not set the variable,
 # there will be no resources added to the compiled jar file.
 #
 # @CODE
@@ -339,8 +340,12 @@ java-pkg-simple_prepend_resources() {
 
 	# add resources directory to classpath
 	for resource in "${resources[@]}"; do
-		cp -rT "${resource:-.}" "${destination}"\
-			|| die "Could not copy resources from ${resource:-.} to ${destination}"
+		if [[ -f "${resource:-.}" ]]; then
+			cp --parents "${resource}" "${destination}"
+		else
+			cp -rT "${resource:-.}" "${destination}"
+		fi
+		[[ $? -ne 0 ]] && die "Could not copy resources from ${resource:-.} to ${destination}"
 	done
 }
 


### PR DESCRIPTION
The eclass variable JAVA_RESOURCE_DIRS is currently used to copy recursively a folder from ${S} to the target folder to generate the jar archive later. Sometimes the resources are hidden among the folders containing the sources, with this patch it is possible to "extract" single file resources copying them to the destination recreating the full path.
<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
