### PR TITLE
dev-util/pycharm-community: Fixes sysctl.d config value

### DIFF
--- a/dev-util/pycharm-community/pycharm-community-2024.3-r1.ebuild
+++ b/dev-util/pycharm-community/pycharm-community-2024.3-r1.ebuild
@@ -185,7 +185,7 @@ src_install() {
 	# recommended by: https://confluence.jetbrains.com/display/IDEADEV/Inotify+Watches+Limit
 	dodir /usr/lib/sysctl.d
 	cat > "${ED}/usr/lib/sysctl.d/30-${PN}-inotify-watches.conf" <<-EOF || die
-		fs.inotify.max_user_watches = 524288"
+		fs.inotify.max_user_watches = 524288
 	EOF
 }
 


### PR DESCRIPTION
The extra quote leftover from the ebuild rewrite/update creates invalid sysctl.d config file which fails to apply the sysctl value.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
