### PR TITLE
net-firewall/firehol: NF_CONNTRACK_IPV4 removed for kernels > 4.19

### DIFF
--- a/net-firewall/firehol/firehol-3.1.7-r2.ebuild
+++ b/net-firewall/firehol/firehol-3.1.7-r2.ebuild
@@ -46,12 +46,16 @@ pkg_setup() {
 		~NETFILTER_XT_MATCH_OWNER \
 		~NETFILTER_XT_MATCH_STATE \
 		~NF_CONNTRACK \
-		~NF_CONNTRACK_IPV4 \
 		~NF_CONNTRACK_MARK \
 		~NF_NAT \
 		~NF_NAT_FTP \
 		~NF_NAT_IRC \
 	"
+
+	if kernel_is -lt 4 19; then
+		CONFIG_CHECK+=" ~NF_CONNTRACK_IPV4"
+	fi
+
 	linux-info_pkg_setup
 }
 


### PR DESCRIPTION
Signed-off-by: Cristian Othón Martínez Vera <cfuga@cfuga.mx>

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
