### PR TITLE
app-editors/wxhexeditor: setup-wxwidgets called from src_configure

### DIFF
--- a/app-editors/wxhexeditor/wxhexeditor-0.24-r3.ebuild
+++ b/app-editors/wxhexeditor/wxhexeditor-0.24-r3.ebuild
@@ -38,11 +38,15 @@ pkg_setup() {
 }
 
 src_prepare() {
-	setup-wxwidgets
 	default
 
 	# -Werror=odr, -Werror=lto-type-mismatch
 	# https://bugs.gentoo.org/854414
 	# https://github.com/EUA/wxHexEditor/issues/222
 	filter-lto
+}
+
+src_configure() {
+	setup-wxwidgets
+	default
 }


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/935465

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
