### PR TITLE
eclass/{dist-,}kernel{-utils,-build}.eclass: fix compression for >=6.12

### DIFF
--- a/eclass/dist-kernel-utils.eclass
+++ b/eclass/dist-kernel-utils.eclass
@@ -175,7 +175,8 @@ dist-kernel_get_module_suffix() {
 		echo .ko
 	elif [[ ! -r ${config} ]]; then
 		die "Cannot find kernel config ${config}"
-	elif grep -q "CONFIG_MODULE_COMPRESS_NONE=y" "${config}"; then
+	elif grep -q "CONFIG_MODULE_COMPRESS_NONE=y" "${config}" ||
+		grep -q "# CONFIG_MODULE_COMPRESS is not set" "${config}"; then
 		echo .ko
 	elif grep -q "CONFIG_MODULE_COMPRESS_GZIP=y" "${config}"; then
 		echo .ko.gz


### PR DESCRIPTION
Upstream commit [1] introduces several changes to the way module compression is configured. To summarize:
- `CONFIG_MODULE_COMPRESS_NONE` is renamed to `CONFIG_MODULE_COMPRESS` and moved up, this (and `CONFIG_MODULE_COMPRESS_<type>`) control support for module compression.
- A new switch `CONFIG_MODULE_COMPRESS_ALL` is introduced to control whether the modules are actually compressed when running make modules_install.

This change introduced several problems that are fixed here:
- `CONFIG_MODULE_COMPRESS` is not implicitly enabled by setting `CONFIG_MODULE_COMPRESS_XZ=y` in the same way that `CONFIG_MODULE_COMPRESS_NONE` was previously implicitly disabled by enabling the xz compression. Fixed by explicitly enabling these options.
- The `dist-kernel_get_module_suffix()` function did not recognize the renamed option which caused the `compressor not known` error in some configurations. Fixed by adding another condition to the `elif` statement in this function.

Furthermore, we now also set the switch `CONFIG_MODULE_COMPRESS_ALL` based on the state of the `modules-compress` USE flag. This technically makes the `suffix-y` override unnecessary for the >=6.12 kernels, but it does no harm so let's keep that as it is and not add a new version conditional here.

[1] https://github.com/torvalds/linux/commit/c7ff693fa2094ba0a9d0a20feb4ab1658eff9c33

CC @gentoo/dist-kernel 

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
