### PR TITLE
sys-auth/sssd: Remove unrecognized configure options

### DIFF
--- a/sys-auth/sssd/sssd-2.9.6.ebuild
+++ b/sys-auth/sssd/sssd-2.9.6.ebuild
@@ -9,7 +9,7 @@ PLOCALE_BACKUP="sv"
 PYTHON_COMPAT=( python3_{10..12} )
 
 inherit autotools linux-info multilib-minimal optfeature plocale \
-	python-single-r1 pam systemd udev toolchain-funcs
+	python-single-r1 pam systemd toolchain-funcs
 
 DESCRIPTION="System Security Services Daemon provides access to identity and authentication"
 HOMEPAGE="https://github.com/SSSD/sssd"
@@ -182,8 +182,6 @@ multilib_src_configure() {
 		--with-mcache-path="${EPREFIX}"/var/lib/sss/mc
 		--with-secrets-db-path="${EPREFIX}"/var/lib/sss/secrets
 		--with-log-path="${EPREFIX}"/var/log/sssd
-		--with-tmpfilesdir=/usr/lib/tmpfiles.d
-		--with-udevrulesdir="$(get_udevdir)/rules.d"
 		--with-kcm
 		--enable-kcm-renewal
 		--with-os=gentoo


### PR DESCRIPTION
Remove some configure options backported in error. They aren't needed, because the files aren't present.

Closes: https://bugs.gentoo.org/945961

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
