### PR TITLE
x11-wm/fvwm3: fix typo in CFLAGS

### DIFF
--- a/x11-wm/fvwm3/fvwm3-1.1.1-r1.ebuild
+++ b/x11-wm/fvwm3/fvwm3-1.1.1-r1.ebuild
@@ -107,7 +107,7 @@ PATCHES=(
 src_configure() {
 	# Signed chars are required.
 	for arch in arm arm64 ppc ppc64; do
-		use $arch && append-flags -fsigned-chars
+		use $arch && append-flags -fsigned-char
 	done
 
 	local emesonargs=(

--- a/x11-wm/fvwm3/fvwm3-9999.ebuild
+++ b/x11-wm/fvwm3/fvwm3-9999.ebuild
@@ -103,7 +103,7 @@ DEPEND="${COMMON_DEPEND}"
 src_configure() {
 	# Signed chars are required.
 	for arch in arm arm64 ppc ppc64; do
-		use $arch && append-flags -fsigned-chars
+		use $arch && append-flags -fsigned-char
 	done
 
 	local emesonargs=(


### PR DESCRIPTION
I tried it on arm64, so far so good.  I'll try it on arm32 too and I'll update the bug https://bugs.gentoo.org/921601
