### PR TITLE
dev-java/openjdk: ensure libc++ is linked dynamically

### DIFF
--- a/dev-java/openjdk/openjdk-17.0.13_p11.ebuild
+++ b/dev-java/openjdk/openjdk-17.0.13_p11.ebuild
@@ -226,6 +226,8 @@ src_configure() {
 		$(tc-is-clang && echo "--with-toolchain-type=clang")
 	)
 
+	[[ $(tc-get-cxx-stdlib) = libc++ ]] && myconf+=( --with-stdc++lib=dynamic )
+
 	use lto && myconf+=( --with-jvm-features=link-time-opt )
 
 	if use javafx; then

--- a/dev-java/openjdk/openjdk-21.0.5_p11.ebuild
+++ b/dev-java/openjdk/openjdk-21.0.5_p11.ebuild
@@ -224,6 +224,8 @@ src_configure() {
 		$(tc-is-clang && echo "--with-toolchain-type=clang")
 	)
 
+	[[ $(tc-get-cxx-stdlib) = libc++ ]] && myconf+=( --with-stdc++lib=dynamic )
+
 	use riscv && myconf+=( --with-boot-jdk-jvmargs="-Djdk.lang.Process.launchMechanism=vfork" )
 
 	# Werror=odr

--- a/dev-java/openjdk/openjdk-23.0.1_p11.ebuild
+++ b/dev-java/openjdk/openjdk-23.0.1_p11.ebuild
@@ -226,6 +226,8 @@ src_configure() {
 		$(tc-is-clang && echo "--with-toolchain-type=clang")
 	)
 
+	[[ $(tc-get-cxx-stdlib) = libc++ ]] && myconf+=( --with-stdc++lib=dynamic )
+
 	use riscv && myconf+=( --with-boot-jdk-jvmargs="-Djdk.lang.Process.launchMechanism=vfork" )
 
 	# Werror=odr


### PR DESCRIPTION
OpenJDK attempts to link the C++ STL statically by default, which causes linking to fail with libc++ due to some relocation errors. Pass --with-stdc++lib=dynamic when libc++ is used to ensure that libc++ is linked dynamically. I'm sure this issue also exists in OpenJDK 11 and OpenJDK 8 but those versions are already mega broken with libc++, so this would not be very helpful.

Closes: https://bugs.gentoo.org/935803

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
