### PR TITLE
app-shells/starship: Use optfeature for fonts

### DIFF
--- a/app-shells/starship/starship-1.21.1-r1.ebuild
+++ b/app-shells/starship/starship-1.21.1-r1.ebuild
@@ -397,7 +397,7 @@ CRATES="
 "
 
 RUST_MIN_VER="1.80.0"
-inherit cargo
+inherit cargo optfeature
 
 DESCRIPTION="The minimal, blazing-fast, and infinitely customizable prompt for any shell"
 HOMEPAGE="https://starship.rs/"
@@ -435,4 +435,8 @@ src_configure() {
 src_install() {
 	cargo_src_install
 	dodoc README.md
+}
+
+pkg_postinst() {
+	optfeature "font support" media-fonts/iosevka media-fonts/noto-emoji
 }


### PR DESCRIPTION
These fonts seem to work decently well with starship in my experience, but they are not the only suitable fonts. The user can install any nerdfont they wish as described by uptsream's documentation.

starship doesn't require fonts to be installed on the same machine it is running on necessarily. For example, if starship is installed on a remote system accessed via ssh, the fonts should be installed on the client machine.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
