### PR TITLE
media-sound/helvum: bump LLVM_COMPAT to 19, #946131

### DIFF
--- a/media-sound/helvum/helvum-0.4.1-r2.ebuild
+++ b/media-sound/helvum/helvum-0.4.1-r2.ebuild
@@ -4,17 +4,17 @@
 EAPI=8
 
 CRATES="
-	aho-corasick@1.1.1
+	aho-corasick@1.0.4
 	anyhow@1.0.75
 	autocfg@1.1.0
 	bindgen@0.66.1
 	bitflags@1.3.2
 	bitflags@2.4.0
-	cairo-rs@0.18.2
-	cairo-sys-rs@0.18.2
-	cc@1.0.83
+	cairo-rs@0.18.0
+	cairo-sys-rs@0.18.0
+	cc@1.0.82
 	cexpr@0.6.0
-	cfg-expr@0.15.5
+	cfg-expr@0.15.4
 	cfg-if@1.0.0
 	clang-sys@1.6.1
 	convert_case@0.6.0
@@ -31,85 +31,82 @@ CRATES="
 	gdk-pixbuf-sys@0.18.0
 	gdk-pixbuf@0.18.0
 	gdk4-sys@0.7.2
-	gdk4@0.7.3
+	gdk4@0.7.2
 	gio-sys@0.18.1
-	gio@0.18.2
-	glib-macros@0.18.2
+	gio@0.18.1
+	glib-macros@0.18.0
 	glib-sys@0.18.1
-	glib@0.18.2
+	glib@0.18.1
 	glob@0.3.1
 	gobject-sys@0.18.0
 	graphene-rs@0.18.1
 	graphene-sys@0.18.1
-	gsk4-sys@0.7.3
-	gsk4@0.7.3
+	gsk4-sys@0.7.2
+	gsk4@0.7.2
 	gtk4-macros@0.7.2
-	gtk4-sys@0.7.3
-	gtk4@0.7.3
+	gtk4-sys@0.7.2
+	gtk4@0.7.2
 	hashbrown@0.14.0
 	heck@0.4.1
-	indexmap@2.0.1
+	indexmap@2.0.0
 	lazy_static@1.4.0
 	lazycell@1.3.0
-	libadwaita-sys@0.5.3
-	libadwaita@0.5.3
-	libc@0.2.148
-	libloading@0.7.4
-	libspa-sys@0.7.2
-	libspa@0.7.2
+	libc@0.2.147
+	libspa-sys@0.7.0
+	libspa@0.7.0
 	log@0.4.20
-	memchr@2.6.3
+	memchr@2.5.0
 	memoffset@0.7.1
 	memoffset@0.9.0
 	minimal-lexical@0.2.1
-	nix@0.26.4
+	nix@0.26.2
 	nom@7.1.3
 	once_cell@1.18.0
 	pango-sys@0.18.0
 	pango@0.18.0
 	peeking_take_while@0.1.2
-	pin-project-lite@0.2.13
+	pin-project-lite@0.2.12
 	pin-utils@0.1.0
-	pipewire-sys@0.7.2
-	pipewire@0.7.2
+	pipewire-sys@0.7.0
+	pipewire@0.7.0
 	pkg-config@0.3.27
 	proc-macro-crate@1.3.1
 	proc-macro-error-attr@1.0.4
 	proc-macro-error@1.0.4
-	proc-macro2@1.0.67
+	proc-macro2@1.0.66
 	quote@1.0.33
-	regex-automata@0.3.8
-	regex-syntax@0.7.5
-	regex@1.9.5
+	regex-automata@0.3.6
+	regex-syntax@0.7.4
+	regex@1.9.3
 	rustc-hash@1.1.0
 	rustc_version@0.4.0
-	semver@1.0.19
-	serde@1.0.188
-	serde_derive@1.0.188
+	semver@1.0.18
+	serde@1.0.183
 	serde_spanned@0.6.3
-	shlex@1.2.0
-	slab@0.4.9
-	smallvec@1.11.1
+	shlex@1.1.0
+	slab@0.4.8
+	smallvec@1.11.0
+	static_assertions@1.1.0
 	syn@1.0.109
-	syn@2.0.37
+	syn@2.0.29
 	system-deps@6.1.1
 	target-lexicon@0.12.11
-	thiserror-impl@1.0.49
-	thiserror@1.0.49
-	toml@0.7.8
+	thiserror-impl@1.0.47
+	thiserror@1.0.47
+	toml@0.7.6
 	toml_datetime@0.6.3
-	toml_edit@0.19.15
-	unicode-ident@1.0.12
+	toml_edit@0.19.14
+	unicode-ident@1.0.11
 	unicode-segmentation@1.10.1
 	version-compare@0.1.1
 	version_check@0.9.4
 	winapi-i686-pc-windows-gnu@0.4.0
 	winapi-x86_64-pc-windows-gnu@0.4.0
 	winapi@0.3.9
-	winnow@0.5.15
+	winnow@0.5.12
 "
 
-LLVM_COMPAT=( {16..18} )
+LLVM_COMPAT=( {16..19} )
 
 inherit cargo desktop llvm-r1 xdg
 
@@ -123,8 +120,7 @@ SRC_URI="
 LICENSE="GPL-3"
 # Dependent crate licenses
 LICENSE+="
-	Apache-2.0 Apache-2.0-with-LLVM-exceptions BSD ISC MIT
-	Unicode-DFS-2016
+	Apache-2.0 Apache-2.0-with-LLVM-exceptions BSD MIT Unicode-DFS-2016
 "
 SLOT="0"
 KEYWORDS="~amd64"
@@ -141,7 +137,6 @@ BDEPEND="
 DEPEND="
 	>=dev-libs/glib-2.66:2
 	>=gui-libs/gtk-4.4.0:4
-	>=gui-libs/libadwaita-1.3:1
 	media-libs/graphene
 	>=media-video/pipewire-0.3:=
 	x11-libs/cairo

--- a/media-sound/helvum/helvum-0.5.1-r4.ebuild
+++ b/media-sound/helvum/helvum-0.5.1-r4.ebuild
@@ -4,17 +4,17 @@
 EAPI=8
 
 CRATES="
-	aho-corasick@1.0.4
+	aho-corasick@1.1.1
 	anyhow@1.0.75
 	autocfg@1.1.0
 	bindgen@0.66.1
 	bitflags@1.3.2
 	bitflags@2.4.0
-	cairo-rs@0.18.0
-	cairo-sys-rs@0.18.0
-	cc@1.0.82
+	cairo-rs@0.18.2
+	cairo-sys-rs@0.18.2
+	cc@1.0.83
 	cexpr@0.6.0
-	cfg-expr@0.15.4
+	cfg-expr@0.15.5
 	cfg-if@1.0.0
 	clang-sys@1.6.1
 	convert_case@0.6.0
@@ -31,82 +31,85 @@ CRATES="
 	gdk-pixbuf-sys@0.18.0
 	gdk-pixbuf@0.18.0
 	gdk4-sys@0.7.2
-	gdk4@0.7.2
+	gdk4@0.7.3
 	gio-sys@0.18.1
-	gio@0.18.1
-	glib-macros@0.18.0
+	gio@0.18.2
+	glib-macros@0.18.2
 	glib-sys@0.18.1
-	glib@0.18.1
+	glib@0.18.2
 	glob@0.3.1
 	gobject-sys@0.18.0
 	graphene-rs@0.18.1
 	graphene-sys@0.18.1
-	gsk4-sys@0.7.2
-	gsk4@0.7.2
+	gsk4-sys@0.7.3
+	gsk4@0.7.3
 	gtk4-macros@0.7.2
-	gtk4-sys@0.7.2
-	gtk4@0.7.2
+	gtk4-sys@0.7.3
+	gtk4@0.7.3
 	hashbrown@0.14.0
 	heck@0.4.1
-	indexmap@2.0.0
+	indexmap@2.0.1
 	lazy_static@1.4.0
 	lazycell@1.3.0
-	libc@0.2.147
-	libspa-sys@0.7.0
-	libspa@0.7.0
+	libadwaita-sys@0.5.3
+	libadwaita@0.5.3
+	libc@0.2.148
+	libloading@0.7.4
+	libspa-sys@0.7.2
+	libspa@0.7.2
 	log@0.4.20
-	memchr@2.5.0
+	memchr@2.6.3
 	memoffset@0.7.1
 	memoffset@0.9.0
 	minimal-lexical@0.2.1
-	nix@0.26.2
+	nix@0.26.4
 	nom@7.1.3
 	once_cell@1.18.0
 	pango-sys@0.18.0
 	pango@0.18.0
 	peeking_take_while@0.1.2
-	pin-project-lite@0.2.12
+	pin-project-lite@0.2.13
 	pin-utils@0.1.0
-	pipewire-sys@0.7.0
-	pipewire@0.7.0
+	pipewire-sys@0.7.2
+	pipewire@0.7.2
 	pkg-config@0.3.27
 	proc-macro-crate@1.3.1
 	proc-macro-error-attr@1.0.4
 	proc-macro-error@1.0.4
-	proc-macro2@1.0.66
+	proc-macro2@1.0.67
 	quote@1.0.33
-	regex-automata@0.3.6
-	regex-syntax@0.7.4
-	regex@1.9.3
+	regex-automata@0.3.8
+	regex-syntax@0.7.5
+	regex@1.9.5
 	rustc-hash@1.1.0
 	rustc_version@0.4.0
-	semver@1.0.18
-	serde@1.0.183
+	semver@1.0.19
+	serde@1.0.188
+	serde_derive@1.0.188
 	serde_spanned@0.6.3
-	shlex@1.1.0
-	slab@0.4.8
-	smallvec@1.11.0
-	static_assertions@1.1.0
+	shlex@1.2.0
+	slab@0.4.9
+	smallvec@1.11.1
 	syn@1.0.109
-	syn@2.0.29
+	syn@2.0.37
 	system-deps@6.1.1
 	target-lexicon@0.12.11
-	thiserror-impl@1.0.47
-	thiserror@1.0.47
-	toml@0.7.6
+	thiserror-impl@1.0.49
+	thiserror@1.0.49
+	toml@0.7.8
 	toml_datetime@0.6.3
-	toml_edit@0.19.14
-	unicode-ident@1.0.11
+	toml_edit@0.19.15
+	unicode-ident@1.0.12
 	unicode-segmentation@1.10.1
 	version-compare@0.1.1
 	version_check@0.9.4
 	winapi-i686-pc-windows-gnu@0.4.0
 	winapi-x86_64-pc-windows-gnu@0.4.0
 	winapi@0.3.9
-	winnow@0.5.12
+	winnow@0.5.15
 "
 
-LLVM_COMPAT=( {16..18} )
+LLVM_COMPAT=( {16..19} )
 
 inherit cargo desktop llvm-r1 xdg
 
@@ -120,7 +123,8 @@ SRC_URI="
 LICENSE="GPL-3"
 # Dependent crate licenses
 LICENSE+="
-	Apache-2.0 Apache-2.0-with-LLVM-exceptions BSD MIT Unicode-DFS-2016
+	Apache-2.0 Apache-2.0-with-LLVM-exceptions BSD ISC MIT
+	Unicode-DFS-2016
 "
 SLOT="0"
 KEYWORDS="~amd64"
@@ -137,6 +141,7 @@ BDEPEND="
 DEPEND="
 	>=dev-libs/glib-2.66:2
 	>=gui-libs/gtk-4.4.0:4
+	>=gui-libs/libadwaita-1.3:1
 	media-libs/graphene
 	>=media-video/pipewire-0.3:=
 	x11-libs/cairo


### PR DESCRIPTION
Bumps to LLVM 19 support since LLVM 19 is stable on amd64.

Closes: https://bugs.gentoo.org/946131

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
