### PR TITLE
net-irc/anope: fix project locations

### DIFF
--- a/net-irc/anope/anope-2.0.14.ebuild
+++ b/net-irc/anope/anope-2.0.14.ebuild
@@ -6,7 +6,7 @@ EAPI=8
 inherit cmake
 
 DESCRIPTION="Anope IRC Services"
-HOMEPAGE="https://anope.org/ https://github.com/anope/anope/"
+HOMEPAGE="https://www.anope.org/ https://github.com/anope/anope/"
 SRC_URI="https://github.com/anope/anope/archive/${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="GPL-2"

--- a/net-irc/anope/metadata.xml
+++ b/net-irc/anope/metadata.xml
@@ -11,7 +11,6 @@
 		developed. It has support for multiple different IRCd linking protocols.
 	</longdescription>
 	<upstream>
-		<remote-id type="sourceforge">anope</remote-id>
 		<remote-id type="github">anope/anope</remote-id>
 	</upstream>
 	<use>


### PR DESCRIPTION
[I am the upstream for this software.]

- Anope hasn't used SourceForge for a decade
- The non-WWW version of the website is a redirect.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
