### PR TITLE
net-dns/knot: fix QA implicit function in configure

### DIFF
--- a/net-dns/knot/knot-3.2.2.ebuild
+++ b/net-dns/knot/knot-3.2.2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -11,6 +11,8 @@ KNOT_SUBSLOT="13.9.4"
 DESCRIPTION="High-performance authoritative-only DNS server"
 HOMEPAGE="https://www.knot-dns.cz/ https://gitlab.nic.cz/knot/knot-dns"
 SRC_URI="https://secure.nic.cz/files/knot-dns/${P/_/-}.tar.xz"
+
+S="${WORKDIR}/${P/_/-}"
 
 LICENSE="GPL-3+"
 SLOT="0/${KNOT_SUBSLOT}"
@@ -53,8 +55,8 @@ RDEPEND="
 	quic? ( net-libs/ngtcp2:=[gnutls] )
 	systemd? ( sys-apps/systemd:= )
 	xdp? (
-		 dev-libs/libbpf:=
-		 net-libs/libmnl:=
+		dev-libs/libbpf:=
+		net-libs/libmnl:=
 	)
 "
 DEPEND="${RDEPEND}"
@@ -63,7 +65,9 @@ BDEPEND="
 	doc? ( dev-python/sphinx )
 "
 
-S="${WORKDIR}/${P/_/-}"
+# Used to check cpuset_t in sched.h with NetBSD.
+# False positive because linux have sched.h too but with cpu_set_t
+QA_CONFIG_IMPL_DECL_SKIP=( cpuset_create cpuset_destroy )
 
 src_configure() {
 	local u

--- a/net-dns/knot/knot-3.2.9-r1.ebuild
+++ b/net-dns/knot/knot-3.2.9-r1.ebuild
@@ -66,6 +66,10 @@ BDEPEND="
 	doc? ( dev-python/sphinx )
 "
 
+# Used to check cpuset_t in sched.h with NetBSD.
+# False positive because linux have sched.h too but with cpu_set_t
+QA_CONFIG_IMPL_DECL_SKIP=( cpuset_create cpuset_destroy )
+
 src_configure() {
 	local u
 	local my_conf=(

--- a/net-dns/knot/knot-3.4.2-r2.ebuild
+++ b/net-dns/knot/knot-3.4.2-r2.ebuild
@@ -77,6 +77,10 @@ BDEPEND="
 	)
 "
 
+# Used to check cpuset_t in sched.h with NetBSD.
+# False positive because linux have sched.h too but with cpu_set_t
+QA_CONFIG_IMPL_DECL_SKIP=( cpuset_create cpuset_destroy )
+
 src_prepare() {
 	default
 

--- a/net-dns/knot/knot-3.4.3-r1.ebuild
+++ b/net-dns/knot/knot-3.4.3-r1.ebuild
@@ -77,6 +77,10 @@ BDEPEND="
 	)
 "
 
+# Used to check cpuset_t in sched.h with NetBSD.
+# False positive because linux have sched.h too but with cpu_set_t
+QA_CONFIG_IMPL_DECL_SKIP=( cpuset_create cpuset_destroy )
+
 src_prepare() {
 	# https://gitlab.nic.cz/knot/knot-dns/-/issues/946
 	cat > tests/contrib/test_atomic.c <<-_EOF_ || die


### PR DESCRIPTION
> QA Notice: cpuset_create cpuset_destroy

Used to check cpuset_t in sched.h with NetBSD.
False positive because linux have sched.h too but with cpu_set_t

Closes: https://bugs.gentoo.org/879723

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
