### PR TITLE
net-ftp/ftp: build with -std=gnu17 in 0.17.34.0.2.5.1

### DIFF
--- a/net-ftp/ftp/ftp-0.17.34.0.2.5.1.ebuild
+++ b/net-ftp/ftp/ftp-0.17.34.0.2.5.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -55,6 +55,9 @@ src_configure() {
 	# bug #101038
 	append-lfs-flags
 	tc-export CC
+
+	# bug #943875
+	append-cflags "-std=gnu17"
 
 	# Not an autoconf script
 	edo ./configure \


### PR DESCRIPTION
net-ftp/ftp: build with -std=gnu17 in 0.17.34.0.2.5.1

this version of the package will not compile with c23. 'append-cflags' 
was added to the ebuild to use '-std=gnu17' to compile the package 
successfully.

The error give with c23:
error: two or more data types in declaration specifiers	

Closes: https://bugs.gentoo.org/943875
Signed-off-by: OldManSeph7818 <sschaefering@gmail.com>

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
