### PR TITLE
sys-process/runit: build w/ -std=gnu17

### DIFF
--- a/sys-process/runit/runit-2.1.2-r6.ebuild
+++ b/sys-process/runit/runit-2.1.2-r6.ebuild
@@ -45,6 +45,7 @@ src_prepare() {
 src_configure() {
 	use static && append-ldflags -static
 
+	append-flags -std=gnu17  # XXX https://bugs.gentoo.org/946137, workaround for gcc15
 	echo "$(tc-getCC) ${CFLAGS}"  > conf-cc || die
 	echo "$(tc-getCC) ${LDFLAGS}" > conf-ld || die
 	sed -i -e "s:ar cr:$(tc-getAR) cr:" print-ar.sh || die

--- a/sys-process/runit/runit-2.2.0.ebuild
+++ b/sys-process/runit/runit-2.2.0.ebuild
@@ -37,6 +37,7 @@ src_prepare() {
 src_configure() {
 	use static && append-ldflags -static
 
+	append-flags -std=gnu17  # XXX https://bugs.gentoo.org/946137, workaround for gcc15
 	echo "$(tc-getCC) ${CFLAGS}"  > conf-cc || die
 	echo "$(tc-getCC) ${LDFLAGS}" > conf-ld || die
 	sed -i -e "s:ar cr:$(tc-getAR) cr:" print-ar.sh || die


### PR DESCRIPTION
workaround for gcc 15, will remove after gcc 15 is released officially.

Closes: https://bugs.gentoo.org/946137

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
