### PR TITLE
media-video/ffmpeg: metadata: complete upstream tag

### DIFF
--- a/media-video/ffmpeg/metadata.xml
+++ b/media-video/ffmpeg/metadata.xml
@@ -95,6 +95,9 @@
 		as required, so always pin dependencies to this slot when appropriate.</slot>
 	</slots>
 	<upstream>
+		<bugs-to>https://trac.ffmpeg.org</bugs-to>
+		<changelog>https://git.ffmpeg.org/gitweb/ffmpeg.git/blob/HEAD:/Changelog</changelog><!-- original upstream -->
+		<doc>https://ffmpeg.org/documentation.html</doc>
 		<remote-id type="github">FFmpeg/FFmpeg</remote-id>
 		<remote-id type="cpe">cpe:/a:ffmpeg:ffmpeg</remote-id>
 	</upstream>


### PR DESCRIPTION
I wanted to see the changelog and noticed that we do not have it so I have filled it.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
