### PR TITLE
lua-utils.eclass: change to ${BUILD_DIR} before running tests

### DIFF
--- a/eclass/lua-utils.eclass
+++ b/eclass/lua-utils.eclass
@@ -385,7 +385,7 @@ lua_enable_tests() {
 			test_pkg="dev-lua/busted"
 			if [[ ! ${_LUA_SINGLE_ECLASS} ]]; then
 				eval "lua_src_test() {
-					busted --lua=\"\${ELUA}\" --output=\"plainTerminal\" \"${test_directory}\" || die \"Tests fail with \${ELUA}\"
+					busted --lua=\"\${ELUA}\" --output=\"plainTerminal\" -C \"\${BUILD_DIR}\" \"${test_directory}\" || die \"Tests fail with \${ELUA}\"
 				}"
 				src_test() {
 					lua_foreach_impl lua_src_test


### PR DESCRIPTION
In case of multiple targets and with C module(s), busted fails because ${S} does not provide the compiled module.
Added '-C ${BUILD_DIR}' to go into each target directory before running tests.

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
