### PR TITLE
dev-php/pecl-raphf: update EAPI 7 -> 8 and revbump to support php 8.2 and 8.3

### DIFF
--- a/dev-php/pecl-raphf/pecl-raphf-2.0.1-r3.ebuild
+++ b/dev-php/pecl-raphf/pecl-raphf-2.0.1-r3.ebuild
@@ -1,0 +1,21 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="8"
+
+PHP_EXT_NAME="raphf"
+PHP_EXT_INI="yes"
+PHP_EXT_ZENDEXT="no"
+PHP_EXT_ECONF_ARGS=""
+PHP_INI_NAME="30-${PHP_EXT_NAME}"
+
+USE_PHP="php8-1 php8-2 php8-3"
+
+inherit php-ext-pecl-r3
+
+KEYWORDS="~amd64 ~x86"
+
+DESCRIPTION="A reusable, persistent handle and resource factory API"
+LICENSE="BSD-2"
+SLOT="7"
+IUSE=""


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/946231

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
