### PR TITLE
latex-package.eclass: do not set $@ in latex-package_src_doinstall's loop

### DIFF
--- a/dev-tex/minted/minted-3.4.0.ebuild
+++ b/dev-tex/minted/minted-3.4.0.ebuild
@@ -79,11 +79,6 @@ src_install() {
 		local -x PYTHONPATH="${ED}/usr/lib/${EPYTHON}/site-packages"
 		local -x PATH="${ED}/usr/lib/python-exec/${EPYTHON}:${PATH}"
 		latex-package_src_doinstall doc
-		# The following line shouldn't be required, as 'doc' is expaned
-		# by latex-package.eclass to "… dtx … pdf", but without this,
-		# the pdf is *not* installed. Maybe a bug in
-		# latex-package.eclass?
-		latex-package_src_doinstall pdf
 	fi
 	popd &> /dev/null || die
 }

--- a/eclass/latex-package.eclass
+++ b/eclass/latex-package.eclass
@@ -200,6 +200,9 @@ latex-package_src_doinstall() {
 			"all")
 				latex-package_src_doinstall styles fonts bin doc
 				;;
+			*)
+				die "Unknown module: ${1}"
+				;;
 		esac
 	shift
 	done

--- a/eclass/latex-package.eclass
+++ b/eclass/latex-package.eclass
@@ -137,11 +137,16 @@ latex-package_src_doinstall() {
 						continue
 
 						einfo "Making documentation: ${i}"
+						local mypdflatex=(
+							pdflatex
+							${LATEX_DOC_ARGUMENTS}
+							--halt-on-error
+							--interaction=nonstopmode
+							"${i}"
+						)
 						# some macros need compiler called twice, do it here.
-						set -- pdflatex ${LATEX_DOC_ARGUMENTS} \
-							--halt-on-error --interaction=nonstopmode "${i}"
-						if "${@}"; then
-							"${@}"
+						if "${mypdflatex[@]}"; then
+							"${mypdflatex[@]}"
 						else
 							einfo "pdflatex failed, trying texi2dvi"
 							texi2dvi -q -c --language=latex "${i}" || die


### PR DESCRIPTION
Since 595611085bc5 ("latex-package: kill POSIX and old EAPI"), the 'tex' and 'dtx' case handling of latex-package_src_doinstall's loop would set $@ to a pdflatex invocation. However, the main loop of this function iterates over $@, and after $@ is set to a pdflatex command, this iteration would continue to process the components of the pdflatex command.

As result, ebuild have to

latex-package_src_doinstall doc
latex-package_src_doinstall pdf

when

latex-package_src_doinstall doc

should be sufficient, because the 'doc' case expands to the "tex dtx dvi ps pdf" cases. However, once a 'tex' or 'dtx' case was processed, the remaining onces are no longer be processed, due the bug described above.

The fix is simple: do not abuse $@ to save the pdflatex command, instead, use a dedicated local variable.

Fixes: 595611085bc532afb9f31fa23cee734bc37d21a4