### PR TITLE
dev-db/mongodb: fix build error w/ clang 19

### DIFF
--- a/dev-db/mongodb/files/mongodb-5.0.26-mozjs-remove-unused-constructor.patch
+++ b/dev-db/mongodb/files/mongodb-5.0.26-mozjs-remove-unused-constructor.patch
@@ -1,0 +1,25 @@
+https://phabricator.services.mozilla.com/D209108
+https://github.com/mozilla/gecko-dev/commit/33cdc6655b0de44cb7a431216dcbb0d5a552aec6
+
+clang 19 will report error if w/o this patch:
+
+  src/third_party/mozjs-60/extract/js/src/threading/ExclusiveData.h:124:33: error: reference to non-static member function must be called
+
+diff --git a/src/third_party/mozjs-60/extract/js/src/threading/ExclusiveData.h b/src/third_party/mozjs-60/extract/js/src/threading/ExclusiveData.h
+index 25b977e..379a509 100644
+--- a/src/third_party/mozjs-60/extract/js/src/threading/ExclusiveData.h
++++ b/src/third_party/mozjs-60/extract/js/src/threading/ExclusiveData.h
+@@ -120,13 +120,6 @@ class ExclusiveData
+         release();
+     }
+ 
+-    ExclusiveData(ExclusiveData&& rhs)
+-      : lock_(mozilla::Move(rhs.lock))
+-    {
+-        MOZ_ASSERT(&rhs != this, "self-move disallowed!");
+-        new (mozilla::KnownNotNull, value_.addr()) T(mozilla::Move(*rhs.value_.addr()));
+-    }
+-
+     ExclusiveData& operator=(ExclusiveData&& rhs) {
+         this->~ExclusiveData();
+         new (mozilla::KnownNotNull, this) ExclusiveData(mozilla::Move(rhs));

--- a/dev-db/mongodb/mongodb-5.0.26.ebuild
+++ b/dev-db/mongodb/mongodb-5.0.26.ebuild
@@ -77,6 +77,7 @@ PATCHES=(
 	"${FILESDIR}/${PN}-5.0.26-boost-1.85.patch"
 	"${FILESDIR}/${PN}-5.0.26-boost-1.85-extra.patch"
 	"${FILESDIR}/${PN}-5.0.26-scons.patch"
+	"${FILESDIR}/${PN}-5.0.26-mozjs-remove-unused-constructor.patch"
 )
 
 python_check_deps() {

--- a/dev-db/mongodb/mongodb-5.0.30.ebuild
+++ b/dev-db/mongodb/mongodb-5.0.30.ebuild
@@ -78,6 +78,8 @@ PATCHES=(
 	"${FILESDIR}/${PN}-5.0.26-boost-1.85.patch"
 	"${FILESDIR}/${PN}-5.0.26-boost-1.85-extra.patch"
 	"${FILESDIR}/${PN}-5.0.30-gcc-15.patch"
+	"${FILESDIR}/${PN}-5.0.26-scons.patch"
+	"${FILESDIR}/${PN}-5.0.26-mozjs-remove-unused-constructor.patch"
 )
 
 python_check_deps() {


### PR DESCRIPTION
Backport from upstream commit 33cdc6655b0de44cb7a431216dcbb0d5a552aec6

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
