### PR TITLE
profiles: selinux: unmask homed USE flag

### DIFF
--- a/profiles/features/selinux/use.mask
+++ b/profiles/features/selinux/use.mask
@@ -8,6 +8,3 @@
 
 -hardened
 -selinux
-
-# no policy yet
-homed


### PR DESCRIPTION
Upstream refpolicy as well as Gentoo downstream refpolicy have had systemd-homed and systemd-userdb support for quite a while now.

The initial policy support was added 2 years ago: https://github.com/gentoo/hardened-refpolicy/commit/006bc33c0ddb00e9f9c628a4ea17fe029a51964f.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.