### PR TITLE
app-misc/fastfetch: metadata: complete upstream tag

### DIFF
--- a/app-misc/fastfetch/metadata.xml
+++ b/app-misc/fastfetch/metadata.xml
@@ -6,6 +6,9 @@
 	<description>Primary maintainer</description>
 </maintainer>
 <upstream>
+	<bugs-to>https://github.com/fastfetch-cli/fastfetch/issues</bugs-to>
+	<changelog>https://github.com/fastfetch-cli/fastfetch/blob/dev/CHANGELOG.md</changelog>
+	<doc>https://github.com/fastfetch-cli/fastfetch/wiki</doc>
 	<remote-id type="github">fastfetch-cli/fastfetch</remote-id>
 </upstream>
 <use>


### PR DESCRIPTION
once again I found that changelog was missing, so I have completed the whole upstream tag

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
