### PR TITLE
dev-python/respx: limit <httpx-0.28.0 due to broken compatibility

### DIFF
--- a/dev-python/respx/respx-0.21.1-r1.ebuild
+++ b/dev-python/respx/respx-0.21.1-r1.ebuild
@@ -24,8 +24,10 @@ LICENSE="BSD"
 SLOT="0"
 KEYWORDS="amd64 arm64 x86"
 
+# https://bugs.gentoo.org/945735
+# https://github.com/lundberg/respx/issues/277
 RDEPEND="
-	dev-python/httpx[${PYTHON_USEDEP}]
+	<dev-python/httpx-0.28.0[${PYTHON_USEDEP}]
 "
 BDEPEND="
 	test? (


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/945735

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
