### PR TITLE
dev-libs/efl: fix build error for gcc 15 and clang 19

### DIFF
--- a/dev-libs/efl/efl-1.27.0-r1.ebuild
+++ b/dev-libs/efl/efl-1.27.0-r1.ebuild
@@ -132,6 +132,8 @@ BDEPEND="${PYTHON_DEPS}
 	nls? ( sys-devel/gettext )
 	wayland? ( dev-util/wayland-scanner )"
 
+PATCHES=( "${FILESDIR}/${PN}-1.27-eina_string_view.patch" )
+
 pkg_setup() {
 	# Deprecated, provided for backward-compatibility. Everything is moved to libefreet.so.
 	QA_FLAGS_IGNORED="/usr/$(get_libdir)/libefreet_trash.so.${PV}

--- a/dev-libs/efl/files/efl-1.27-eina_string_view.patch
+++ b/dev-libs/efl/files/efl-1.27-eina_string_view.patch
@@ -1,0 +1,32 @@
+https://git.enlightenment.org/enlightenment/efl/issues/71
+
+commit 6c3630ffda0884b86e6ffc9d00d7315ab67858e5
+Author: Ted Rodgers <ted.d.rodgers@gmail.com>
+Date:   Wed Aug 21 10:56:13 2024 -0400
+
+    eina_string_view.hh change lenght to length
+    
+    fixes #71
+
+diff --git a/src/bindings/cxx/eina_cxx/eina_string_view.hh b/src/bindings/cxx/eina_cxx/eina_string_view.hh
+index 77798db70f..f0bbcb705d 100644
+--- a/src/bindings/cxx/eina_cxx/eina_string_view.hh
++++ b/src/bindings/cxx/eina_cxx/eina_string_view.hh
+@@ -181,7 +181,7 @@ public:
+    size_type rfind(basic_string_view<CharT, Traits> const& s) const
+    {
+       const_reverse_iterator iter = std::search(crbegin(), crend(), s.crbegin(), s.crend(), Traits::eq);
+-      return iter == crend() ? npos : reverse_distance(crbegin(), iter) - s.lenght();
++      return iter == crend() ? npos : reverse_distance(crbegin(), iter) - s.length();
+    }
+ 
+    size_type rfind(basic_string_view<CharT, Traits> const& s, size_type pos) const
+@@ -189,7 +189,7 @@ public:
+       if (pos >= _len)
+         return npos;
+       const_reverse_iterator iter = std::search(crbegin()+pos, crend(), s.crbegin(), s.crend(), Traits::eq);
+-      return iter == crend() ? npos : reverse_distance(crbegin(), iter) - s.lenght();
++      return iter == crend() ? npos : reverse_distance(crbegin(), iter) - s.length();
+    }
+ 
+    size_type rfind(CharT c) const


### PR DESCRIPTION
patch from https://git.enlightenment.org/enlightenment/efl/issues/71

it's weird that the older compiler report no error even for typo, ... 
<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
