### PR TITLE
app-text/po4a: Backport upstream testsuite fixes for perl >= 5.40

### DIFF
--- a/app-text/po4a/files/po4a-0.69-invalid-byte.patch
+++ b/app-text/po4a/files/po4a-0.69-invalid-byte.patch
@@ -1,0 +1,27 @@
+https://bugs.gentoo.org/938967
+https://github.com/mquinson/po4a/commit/7cf7b79ee28de7e58378b225570d49fd114ff75e.patch
+
+From 7cf7b79ee28de7e58378b225570d49fd114ff75e Mon Sep 17 00:00:00 2001
+From: Jan Palus <jpalus@fastmail.com>
+Date: Mon, 3 Jul 2023 14:56:04 +0200
+Subject: [PATCH] SGML: replace invalid byte (0xa0) in comment with space
+ (0x20)
+
+Fixes #428
+---
+ lib/Locale/Po4a/Sgml.pm | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/Locale/Po4a/Sgml.pm b/lib/Locale/Po4a/Sgml.pm
+index 39dd66f2..d02f269d 100644
+--- a/lib/Locale/Po4a/Sgml.pm
++++ b/lib/Locale/Po4a/Sgml.pm
+@@ -773,7 +773,7 @@ sub parse_file {
+             while ( $origfile =~ /^(.*?)&$key(;.*$|[^-_:.A-Za-z0-9].*$|$)/s ) {
+ 
+                 # Since we will include a new file, we
+-                # must do a new round of substitutions.
++                # must do a new round of substitutions.
+                 $dosubstitution = 1;
+                 my ( $begin, $end ) = ( $1, $2 );
+                 $end = "" unless ( defined $end );

--- a/app-text/po4a/files/po4a-0.69-perl5.40.patch
+++ b/app-text/po4a/files/po4a-0.69-perl5.40.patch
@@ -1,0 +1,31 @@
+https://bugs.gentoo.org/938967
+https://github.com/mquinson/po4a/commit/28fe52651eb8096d97d6bd3a97b3168522ba5306 (backport)
+
+From 45c835a04a388940c627f0c6b8c26554c0ee2b14 Mon Sep 17 00:00:00 2001
+From: Martin Quinson <martin.quinson@ens-rennes.fr>
+Date: Fri, 12 Jul 2024 10:21:34 +0200
+Subject: [PATCH] Fix failures with DynaLoader on Perl 5.40
+
+Thanks to dstoecker for the patch provided in the OpenSuse package,
+and to ana for pointing me to it.
+
+Fixes https://github.com/mquinson/po4a/issues/508
+
+(cherry picked from commit 28fe52651eb8096d97d6bd3a97b3168522ba5306)
+---
+ lib/Locale/Po4a/TransTractor.pm | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/lib/Locale/Po4a/TransTractor.pm b/lib/Locale/Po4a/TransTractor.pm
+index b83dd25b..68296cb1 100644
+--- a/lib/Locale/Po4a/TransTractor.pm
++++ b/lib/Locale/Po4a/TransTractor.pm
+@@ -5,6 +5,8 @@ require Exporter;
+ package Locale::Po4a::TransTractor;
+ use DynaLoader;
+ 
++sub import { }
++
+ use 5.006;
+ use strict;
+ use warnings;

--- a/app-text/po4a/files/po4a-perl5.40.patch
+++ b/app-text/po4a/files/po4a-perl5.40.patch
@@ -1,0 +1,29 @@
+https://bugs.gentoo.org/938967
+https://github.com/mquinson/po4a/commit/28fe52651eb8096d97d6bd3a97b3168522ba5306.patch
+
+From 28fe52651eb8096d97d6bd3a97b3168522ba5306 Mon Sep 17 00:00:00 2001
+From: Martin Quinson <martin.quinson@ens-rennes.fr>
+Date: Fri, 12 Jul 2024 10:21:34 +0200
+Subject: [PATCH] Fix failures with DynaLoader on Perl 5.40
+
+Thanks to dstoecker for the patch provided in the OpenSuse package,
+and to ana for pointing me to it.
+
+Fixes https://github.com/mquinson/po4a/issues/508
+---
+ lib/Locale/Po4a/TransTractor.pm | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/lib/Locale/Po4a/TransTractor.pm b/lib/Locale/Po4a/TransTractor.pm
+index 7bf59ef05..7b6112433 100644
+--- a/lib/Locale/Po4a/TransTractor.pm
++++ b/lib/Locale/Po4a/TransTractor.pm
+@@ -5,6 +5,8 @@ require Exporter;
+ package Locale::Po4a::TransTractor;
+ use DynaLoader;
+ 
++sub import { }
++
+ use 5.16.0;
+ use strict;
+ use warnings;

--- a/app-text/po4a/po4a-0.69-r2.ebuild
+++ b/app-text/po4a/po4a-0.69-r2.ebuild
@@ -1,0 +1,62 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="8"
+PLOCALES="ace af ar ca cs da de eo es et eu fr hr hu id it ja ka kn ko nb nl pl pt pt_BR ru sl sr_Cyrl sv uk vi zh_CN zh_HK zh_Hant"
+
+inherit perl-module plocale
+
+DESCRIPTION="Tools to ease the translation of documentation"
+HOMEPAGE="https://po4a.org/"
+SRC_URI="https://github.com/mquinson/${PN}/releases/download/v${PV}/${P}.tar.gz"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~arm64-macos ~ppc-macos ~x64-macos ~x64-solaris"
+IUSE="test"
+RESTRICT="!test? ( test )"
+
+RDEPEND="app-text/opensp
+	dev-libs/libxslt
+	dev-perl/Locale-gettext
+	dev-perl/Pod-Parser
+	dev-perl/SGMLSpm
+	dev-perl/Syntax-Keyword-Try
+	dev-perl/TermReadKey
+	dev-perl/Text-WrapI18N
+	dev-perl/Unicode-LineBreak
+	dev-perl/YAML-Tiny
+	sys-devel/gettext"
+DEPEND="${RDEPEND}"
+BDEPEND="app-text/docbook-xml-dtd:4.1.2
+	app-text/docbook-xsl-stylesheets
+	dev-perl/Module-Build
+	sys-devel/gettext
+	test? (
+		app-text/docbook-sgml-dtd:4.1
+		dev-perl/Test-Pod
+		virtual/latex-base
+	)"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-man.patch
+	"${FILESDIR}"/${P}-xmlcatalog.patch
+	"${FILESDIR}"/${P}-perl5.40.patch # bug #938967
+	# The perl5.40 patch triggers:
+	# XX Update po/bin/po4a.pot
+	# xgettext: Comment at or before ../../lib/Locale/Po4a/Sgml.pm:776 is not UTF-8 encoded.
+	"${FILESDIR}"/${P}-invalid-byte.patch
+)
+
+DIST_TEST="do"
+
+src_prepare() {
+	plocale_find_changes "${S}/po/bin" '' '.po'
+
+	rm_locale() {
+		PERL_RM_FILES+=( po/{bin,pod}/${1}.po )
+	}
+	plocale_for_each_disabled_locale rm_locale
+
+	perl-module_src_prepare
+}

--- a/app-text/po4a/po4a-0.71-r1.ebuild
+++ b/app-text/po4a/po4a-0.71-r1.ebuild
@@ -38,7 +38,10 @@ BDEPEND="app-text/docbook-xml-dtd:4.1.2
 		virtual/latex-base
 	)"
 
-PATCHES=( "${FILESDIR}"/${PN}-man.patch )
+PATCHES=(
+	"${FILESDIR}"/${PN}-man.patch
+	"${FILESDIR}"/${PN}-perl5.40.patch # bug #938967
+)
 
 DIST_TEST="do"
 

--- a/app-text/po4a/po4a-0.72-r1.ebuild
+++ b/app-text/po4a/po4a-0.72-r1.ebuild
@@ -38,7 +38,10 @@ BDEPEND="app-text/docbook-xml-dtd:4.1.2
 		virtual/latex-base
 	)"
 
-PATCHES=( "${FILESDIR}"/${PN}-man.patch )
+PATCHES=(
+	"${FILESDIR}"/${PN}-man.patch
+	"${FILESDIR}"/${PN}-perl5.40.patch # bug #938967
+)
 
 DIST_TEST="do"
 

--- a/app-text/po4a/po4a-0.73-r1.ebuild
+++ b/app-text/po4a/po4a-0.73-r1.ebuild
@@ -1,0 +1,57 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="8"
+PLOCALES="ace af ar ca cs da de eo es et eu fr hr hu id it ja ka kn ko nb nl pl pt pt_BR ru sl sr sr_Cyrl sv uk vi zh_Hans zh_Hant"
+
+inherit perl-module plocale
+
+DESCRIPTION="Tools to ease the translation of documentation"
+HOMEPAGE="https://po4a.org/"
+SRC_URI="https://github.com/mquinson/${PN}/releases/download/v${PV}/${P}.tar.gz"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~arm64-macos ~ppc-macos ~x64-macos ~x64-solaris"
+IUSE="test"
+RESTRICT="!test? ( test )"
+
+RDEPEND="app-text/opensp
+	dev-libs/libxslt
+	dev-perl/Locale-gettext
+	dev-perl/Pod-Parser
+	dev-perl/SGMLSpm
+	dev-perl/Syntax-Keyword-Try
+	dev-perl/TermReadKey
+	dev-perl/Text-WrapI18N
+	dev-perl/Unicode-LineBreak
+	dev-perl/YAML-Tiny
+	sys-devel/gettext"
+DEPEND="${RDEPEND}"
+BDEPEND="app-text/docbook-xml-dtd:4.1.2
+	app-text/docbook-xsl-stylesheets
+	dev-perl/Module-Build
+	sys-devel/gettext
+	test? (
+		app-text/docbook-sgml-dtd:4.1
+		dev-perl/Test-Pod
+		virtual/latex-base
+	)"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-man.patch
+	"${FILESDIR}"/${PN}-perl5.40.patch # bug #938967
+)
+
+DIST_TEST="do"
+
+src_prepare() {
+	plocale_find_changes "${S}/po/bin" '' '.po'
+
+	rm_locale() {
+		PERL_RM_FILES+=( po/{bin,pod}/${1}.po )
+	}
+	plocale_for_each_disabled_locale rm_locale
+
+	perl-module_src_prepare
+}


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/938967

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.