### PR TITLE
media-libs/{speex,speexdsp}: fix autoreconf with slibtoolize

### DIFF
--- a/media-libs/speex/files/speex-1.2.1-slibtoolize.patch
+++ b/media-libs/speex/files/speex-1.2.1-slibtoolize.patch
@@ -1,0 +1,28 @@
+https://github.com/xiph/speex/pull/24
+https://github.com/xiph/speex/commit/1de1260d24e01224df5fbb8b92893106c89bb8de
+
+From 1de1260d24e01224df5fbb8b92893106c89bb8de Mon Sep 17 00:00:00 2001
+From: orbea <orbea@riseup.net>
+Date: Tue, 4 Jun 2024 08:59:02 -0700
+Subject: [PATCH] configure.ac: don't use internal GNU libtool functions
+
+This doesn't work when using slibtoolize instead of GNU libtoolize and
+is not necessary anyways.
+
+Signed-off-by: orbea <orbea@riseup.net>
+---
+ configure.ac | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index 0a7d5c1c..0a631b15 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -27,7 +27,6 @@ AM_INIT_AUTOMAKE([foreign no-define])
+ AM_MAINTAINER_MODE([enable])
+ 
+ AC_CANONICAL_HOST
+-_LT_SET_OPTION([LT_INIT],[win32-dll])
+ LT_INIT
+ 
+ AC_C_BIGENDIAN

--- a/media-libs/speex/speex-1.2.1-r2.ebuild
+++ b/media-libs/speex/speex-1.2.1-r2.ebuild
@@ -12,6 +12,8 @@ DESCRIPTION="Audio compression format designed for speech"
 HOMEPAGE="https://www.speex.org/"
 SRC_URI="https://downloads.xiph.org/releases/speex/${MY_P}.tar.gz"
 
+S="${WORKDIR}/${MY_P}"
+
 LICENSE="BSD"
 SLOT="0"
 KEYWORDS="~alpha amd64 arm arm64 ~hppa ~loong ~mips ppc ppc64 ~riscv sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos"
@@ -27,8 +29,6 @@ DEPEND="
 	valgrind? ( dev-debug/valgrind )
 "
 BDEPEND="virtual/pkgconfig"
-
-S="${WORKDIR}/${MY_P}"
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-1.2.0-configure.patch

--- a/media-libs/speex/speex-1.2.1-r2.ebuild
+++ b/media-libs/speex/speex-1.2.1-r2.ebuild
@@ -33,6 +33,7 @@ S="${WORKDIR}/${MY_P}"
 PATCHES=(
 	"${FILESDIR}"/${PN}-1.2.0-configure.patch
 	"${FILESDIR}"/${P}-vla-detection.patch
+	"${FILESDIR}"/${P}-slibtoolize.patch
 	"${FILESDIR}"/${PN}-1.2.1-valgrind.patch
 )
 

--- a/media-libs/speexdsp/files/speexdsp-1.2.1-slibtoolize.patch
+++ b/media-libs/speexdsp/files/speexdsp-1.2.1-slibtoolize.patch
@@ -1,0 +1,28 @@
+https://github.com/xiph/speexdsp/pull/48
+https://github.com/xiph/speexdsp/commit/dbd421d149a9c362ea16150694b75b63d757a521
+
+From dbd421d149a9c362ea16150694b75b63d757a521 Mon Sep 17 00:00:00 2001
+From: orbea <orbea@riseup.net>
+Date: Tue, 4 Jun 2024 08:54:37 -0700
+Subject: [PATCH] configure.ac: don't use internal GNU libtool functions
+
+This doesn't work when using slibtoolize instead of GNU libtoolize and
+is not necessary anyways.
+
+Signed-off-by: orbea <orbea@riseup.net>
+---
+ configure.ac | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index cd433ffe..413f71da 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -22,7 +22,6 @@ AM_INIT_AUTOMAKE([foreign no-define])
+ AM_MAINTAINER_MODE([enable])
+ 
+ AC_CANONICAL_HOST
+-_LT_SET_OPTION([LT_INIT],[win32-dll])
+ LT_INIT
+ 
+ AC_C_BIGENDIAN

--- a/media-libs/speexdsp/speexdsp-1.2.1.ebuild
+++ b/media-libs/speexdsp/speexdsp-1.2.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -23,6 +23,7 @@ S="${WORKDIR}/${MY_P}"
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-1.2.0-configure.patch
+	"${FILESDIR}"/${P}-slibtoolize.patch
 )
 
 src_prepare() {

--- a/media-libs/speexdsp/speexdsp-1.2.1.ebuild
+++ b/media-libs/speexdsp/speexdsp-1.2.1.ebuild
@@ -12,14 +12,14 @@ DESCRIPTION="Audio compression format designed for speech -- DSP"
 HOMEPAGE="https://www.speex.org/"
 SRC_URI="https://downloads.xiph.org/releases/speex/${MY_P}.tar.gz"
 
+S="${WORKDIR}/${MY_P}"
+
 LICENSE="BSD"
 SLOT="0"
 KEYWORDS="~alpha amd64 arm arm64 ~hppa ~loong ~mips ppc ppc64 ~riscv sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos"
 IUSE="cpu_flags_x86_sse cpu_flags_x86_sse2 cpu_flags_arm_neon"
 
 BDEPEND="virtual/pkgconfig"
-
-S="${WORKDIR}/${MY_P}"
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-1.2.0-configure.patch


### PR DESCRIPTION
Removes internal libtool functions that doesn't work with slibtoolize and is not required anyways. Same patch for both projects. I also fixed some trivial `variable S should occur before IUSE` messages from pkgcheck.

Upstream-PR: https://github.com/xiph/speex/pull/24
Upstream-Commit: https://github.com/xiph/speex/commit/1de1260d24e01224df5fbb8b92893106c89bb8de
Upstream-PR: https://github.com/xiph/speexdsp/pull/48
Upstream-Commit: https://github.com/xiph/speexdsp/commit/dbd421d149a9c362ea16150694b75b63d757a521

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
