### PR TITLE
app-misc/beep: fix issue when no caps on fs w/o xattr support

### DIFF
--- a/app-misc/beep/beep-1.4.12.ebuild
+++ b/app-misc/beep/beep-1.4.12.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -38,9 +38,23 @@ src_install() {
 
 	fperms 0711 /usr/bin/beep
 
+	local DOCS=(
+		CREDITS.md DEVELOPMENT.md INSTALL.md NEWS.md PACKAGING.md PERMISSIONS.md README.md
+	)
 	einstalldocs
 }
 
 pkg_postinst() {
-	fcaps cap_dac_override,cap_sys_tty_config "${EROOT}/usr/bin/beep"
+	FILECAPS=(
+		-m0711 cap_dac_override,cap_sys_tty_config "${EROOT}/usr/bin/beep"
+	)
+
+	elog "Please note that for security reasons, beep will no longer allow"
+	elog "to running w/ SUID or as root under sudo. You will need to give"
+	elog "permissions for the PC speaker device to allow non-root users to"
+	elog "use 'beep' by either:"
+	elog "  setfacl -m u:<youruser>:rw /dev/input/by-path/platform-pcspkr-event-spkr"
+	elog "or add yourself to the 'input' group:"
+	elog "  usermod -aG input <youruser>"
+	elog "It's preferred to use setfacl with least privilege."
 }


### PR DESCRIPTION
1. set mode so fcaps won't set SUID if fs w/o xattr support
2. show message tell user howto run as non-root user

Closes: https://bugs.gentoo.org/877095

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
