### PR TITLE
app-i18n/uim: use set-face-underline

### DIFF
--- a/app-i18n/uim/files/uim-set-face-underline.patch
+++ b/app-i18n/uim/files/uim-set-face-underline.patch
@@ -1,0 +1,32 @@
+https://github.com/uim/uim/commit/7b903ddf144344e49da12cc070f7c11f82ae61db
+
+commit 7b903ddf144344e49da12cc070f7c11f82ae61db
+Author: Sutou Kouhei <kou@clear-code.com>
+Date:   Fri Aug 11 10:44:26 2023 +0900
+
+    emacs: use set-face-underline
+    
+    set-face-underline-p is removed in Emacs 29.
+
+diff --git a/emacs/uim-var.el b/emacs/uim-var.el
+index 189f91c9..ce40b6db 100644
+--- a/emacs/uim-var.el
++++ b/emacs/uim-var.el
+@@ -435,7 +435,7 @@ keeps the size of it when showing the candidates.")
+ (make-face 'uim-preedit-face)
+ 
+ (copy-face 'uim-preedit-face 'uim-preedit-underline-face)
+-(set-face-underline-p        'uim-preedit-underline-face t)
++(set-face-underline          'uim-preedit-underline-face t)
+ 
+ ;; highlight
+ (make-face 'uim-preedit-highlight-face)
+@@ -443,7 +443,7 @@ keeps the size of it when showing the candidates.")
+ (set-face-background 'uim-preedit-highlight-face "Blue3")
+ 
+ (copy-face 'uim-preedit-highlight-face 'uim-preedit-highlight-underline-face)
+-(set-face-underline-p 'uim-preedit-highlight-underline-face t)
++(set-face-underline   'uim-preedit-highlight-underline-face t)
+ 
+ ;; separator
+ (make-face 'uim-separator-face)

--- a/app-i18n/uim/uim-1.8.9-r2.ebuild
+++ b/app-i18n/uim/uim-1.8.9-r2.ebuild
@@ -90,6 +90,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-Wconversion.patch
 	"${FILESDIR}"/${PN}-xkb.patch
 	"${FILESDIR}"/${PN}-zh-TW.patch
+	"${FILESDIR}"/${PN}-set-face-underline.patch
 )
 
 DOCS=( AUTHORS NEWS README RELNOTE doc )


### PR DESCRIPTION
apply patch from upstream which "s/set-face-underline-p/set-face-underline/g"

Closes: https://bugs.gentoo.org/912958

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
