### PR TITLE
app-i18n/rime-data: fix rime-cantonese missing author files.

### DIFF
--- a/app-i18n/rime-data/rime-data-1.0.20241201-r1.ebuild
+++ b/app-i18n/rime-data/rime-data-1.0.20241201-r1.ebuild
@@ -72,7 +72,9 @@ src_install() {
 		for pkg in "${!LIST[@]}"; do
 			doins "${pkg}-${LIST[$pkg]}"/*[!AUTHORS\|LICENSE\|README.md\|check.py]
 			for f in AUTHORS LICENSE README.md; do
-				newdoc "${pkg}-${LIST[$pkg]}/${f}" "${pkg}_${f}"
+				if [ -f "${pkg}-${LIST[$pkg]}/${f}" ]; then
+					newdoc "${pkg}-${LIST[$pkg]}/${f}" "${pkg}_${f}"
+				fi
 			done
 		done
 	}


### PR DESCRIPTION
We should need to check if the documentation file exists before installing it

Closes: https://bugs.gentoo.org/946467
Signed-off-by: Yongxiang Liang <tanekliang@gmail.com>

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
