### PR TITLE
sys-fs/mtpfs: fix for c23 in 1.1-r6

### DIFF
--- a/sys-fs/mtpfs/files/mtpfs-1.1-c23-fix.patch
+++ b/sys-fs/mtpfs/files/mtpfs-1.1-c23-fix.patch
@@ -1,0 +1,38 @@
+From: https://github.com/cjd/mtpfs/commit/3b7b0d3ac7e15c9b654e19489bb4be84d48698f7.patch
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Mon, 9 Dec 2024 12:49:20 +0000
+Subject: [PATCH] fix gcc-15 build
+
+--- a/mtpfs.c
++++ b/mtpfs.c
+@@ -812,7 +812,7 @@ mtpfs_release (const char *path, struct fuse_file_info *fi)
+ }
+ 
+ void
+-mtpfs_destroy ()
++mtpfs_destroy (void *buf)
+ {
+   enter_lock ("destroy");
+   if (files)
+@@ -1622,7 +1622,7 @@ mtpfs_init ()
+ }
+ 
+ int
+-mtpfs_blank()
++mtpfs_blank (const char *path, mode_t mode)
+ {
+   // Do nothing
+ }
+
+--- a/mtpfs.h
++++ b/mtpfs.h
+@@ -49,9 +49,9 @@ static int find_storage(const gchar * path);
+  
+     /* fuse functions */
+ static void * mtpfs_init (void);
+-static int mtpfs_blank ();
++static int mtpfs_blank (const char *path, mode_t mode);
+ static int mtpfs_release (const char *path, struct fuse_file_info *fi);
+-void mtpfs_destroy ();
++void mtpfs_destroy (void *buf);
+ static int mtpfs_readdir (const gchar * path, void *buf, fuse_fill_dir_t filler, off_t offset, struct fuse_file_info *fi);

--- a/sys-fs/mtpfs/mtpfs-1.1-r6.ebuild
+++ b/sys-fs/mtpfs/mtpfs-1.1-r6.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -28,7 +28,8 @@ PATCHES=( "${FILESDIR}"/${P}-fix-mutex-crash.patch
 	"${FILESDIR}"/${P}-unitialized-variable.patch
 	"${FILESDIR}"/${P}-wking-patches/
 	"${FILESDIR}"/${P}-g_printf.patch
-	"${FILESDIR}"/${P}-deprecated_lock_init.patch )
+	"${FILESDIR}"/${P}-deprecated_lock_init.patch 
+	"${FILESDIR}"/${P}-c23-fix.patch )
 
 src_prepare() {
 	default


### PR DESCRIPTION
Patch from: https://github.com/cjd/mtpfs/commit/3b7b0d3ac7e15c9b654e19489bb4be84d48698f7.patch

Closes: https://bugs.gentoo.org/945802
Signed-off-by: OldManSeph <sschaefering@gmail.com>

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
