### PR TITLE
dev-python/mido: Enable Python3_13

### DIFF
--- a/dev-python/mido/mido-1.3.3.ebuild
+++ b/dev-python/mido/mido-1.3.3.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..13} )
 DISTUTILS_USE_PEP517=setuptools
 
 inherit distutils-r1 pypi

--- a/dev-python/python-rtmidi/python-rtmidi-1.5.8.ebuild
+++ b/dev-python/python-rtmidi/python-rtmidi-1.5.8.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..12} )
+PYTHON_COMPAT=( python3_{10..13} )
 DOCS_BUILDER="sphinx"
 DOCS_DEPEND="dev-python/myst-parser"
 DOCS_DIR="docs"


### PR DESCRIPTION
```
================================= test session starts ==================================
platform linux -- Python 3.13.0, pytest-8.3.4, pluggy-1.5.0 -- /var/tmp/portage/dev-python/mido-1.3.3/work/mido-1.3.3-python3_13/install/usr/bin/python3.13
cachedir: .pytest_cache
rootdir: /var/tmp/portage/dev-python/mido-1.3.3/work/mido-1.3.3
configfile: pyproject.toml
testpaths: tests
collecting ... collected 122 items / 1 deselected / 121 selected

tests/backends/test_backend.py::test_split_api PASSED                         [  1/121]
tests/backends/test_rtmidi.py::test_expand_alsa_port_name PASSED              [  2/121]
tests/messages/test_checks.py::test_check_time PASSED                         [  3/121]
tests/messages/test_decode.py::test_sysex PASSED                              [  4/121]
tests/messages/test_decode.py::test_channel PASSED                            [  5/121]
tests/messages/test_decode.py::test_sysex_end PASSED                          [  6/121]
tests/messages/test_decode.py::test_zero_bytes PASSED                         [  7/121]
tests/messages/test_decode.py::test_too_few_bytes PASSED                      [  8/121]
tests/messages/test_decode.py::test_too_many_bytes PASSED                     [  9/121]
tests/messages/test_decode.py::test_invalid_status PASSED                     [ 10/121]
tests/messages/test_decode.py::test_sysex_without_stop_byte PASSED            [ 11/121]
tests/messages/test_encode.py::test_encode_decode_all PASSED                  [ 12/121]
tests/messages/test_messages.py::test_msg_time_equality PASSED                [ 13/121]
tests/messages/test_messages.py::test_set_type PASSED                         [ 14/121]
tests/messages/test_messages.py::test_encode_pitchwheel PASSED                [ 15/121]
tests/messages/test_messages.py::test_decode_pitchwheel PASSED                [ 16/121]
tests/messages/test_messages.py::test_encode_songpos PASSED                   [ 17/121]
tests/messages/test_messages.py::test_decode_songpos PASSED                   [ 18/121]
tests/messages/test_messages.py::test_sysex_data_is_sysexdata_object PASSED   [ 19/121]
tests/messages/test_messages.py::test_sysex_data_accepts_different_types PASSED [ 20/121]
tests/messages/test_messages.py::test_copy PASSED                             [ 21/121]
tests/messages/test_messages.py::test_init_invalid_argument PASSED            [ 22/121]
tests/messages/test_messages.py::test_copy_invalid_argument PASSED            [ 23/121]
tests/messages/test_messages.py::test_copy_cant_change_type PASSED            [ 24/121]
tests/messages/test_messages.py::test_copy_can_have_same_type PASSED          [ 25/121]
tests/messages/test_messages.py::test_copy_handles_data_generator PASSED      [ 26/121]
tests/messages/test_messages.py::test_compare_with_nonmessage PASSED          [ 27/121]
tests/messages/test_messages.py::test_from_dict_default_values PASSED         [ 28/121]
tests/messages/test_messages.py::test_dict_sysex_data PASSED                  [ 29/121]
tests/messages/test_messages.py::test_from_hex_sysex_data_type PASSED         [ 30/121]
tests/messages/test_messages.py::test_repr PASSED                             [ 31/121]
tests/messages/test_strings.py::test_decode_sysex PASSED                      [ 32/121]
tests/messages/test_strings.py::test_decode_invalid_sysex_with_spaces PASSED  [ 33/121]
tests/messages/test_strings.py::test_encode_sysex PASSED                      [ 34/121]
tests/midifiles/test_meta.py::test_copy_invalid_argument PASSED               [ 35/121]
tests/midifiles/test_meta.py::test_copy_cant_override_type PASSED             [ 36/121]
tests/midifiles/test_meta.py::TestKeySignature::test_bad_key_sig_throws_key_signature_error[bad_key_sig0] PASSED [ 37/121]
tests/midifiles/test_meta.py::TestKeySignature::test_bad_key_sig_throws_key_signature_error[bad_key_sig1] PASSED [ 38/121]
tests/midifiles/test_meta.py::TestKeySignature::test_bad_key_sig_throws_key_signature_error[bad_key_sig2] PASSED [ 39/121]
tests/midifiles/test_meta.py::TestKeySignature::test_bad_key_sig_throws_key_signature_error[bad_key_sig3] PASSED [ 40/121]
tests/midifiles/test_meta.py::TestKeySignature::test_bad_key_sig_throws_key_signature_error[bad_key_sig4] PASSED [ 41/121]
tests/midifiles/test_meta.py::TestKeySignature::test_key_signature[input_bytes0-C] PASSED [ 42/121]
tests/midifiles/test_meta.py::TestKeySignature::test_key_signature[input_bytes1-Am] PASSED [ 43/121]
tests/midifiles/test_meta.py::TestKeySignature::test_key_signature[input_bytes2-Cb] PASSED [ 44/121]
tests/midifiles/test_meta.py::TestKeySignature::test_key_signature[input_bytes3-Abm] PASSED [ 45/121]
tests/midifiles/test_meta.py::TestKeySignature::test_key_signature[input_bytes4-A#m] PASSED [ 46/121]
tests/midifiles/test_meta.py::test_meta_message_repr PASSED                   [ 47/121]
tests/midifiles/test_meta.py::test_unknown_meta_message_repr PASSED           [ 48/121]
tests/midifiles/test_meta.py::test_meta_from_bytes_invalid PASSED             [ 49/121]
tests/midifiles/test_meta.py::test_meta_from_bytes_data_too_short PASSED      [ 50/121]
tests/midifiles/test_meta.py::test_meta_from_bytes_data_too_long PASSED       [ 51/121]
tests/midifiles/test_meta.py::test_meta_from_bytes_text PASSED                [ 52/121]
tests/midifiles/test_midifiles.py::test_no_tracks PASSED                      [ 53/121]
tests/midifiles/test_midifiles.py::test_single_message PASSED                 [ 54/121]
tests/midifiles/test_midifiles.py::test_too_long_message PASSED               [ 55/121]
tests/midifiles/test_midifiles.py::test_two_tracks PASSED                     [ 56/121]
tests/midifiles/test_midifiles.py::test_empty_file PASSED                     [ 57/121]
tests/midifiles/test_midifiles.py::test_eof_in_track PASSED                   [ 58/121]
tests/midifiles/test_midifiles.py::test_invalid_data_byte_no_clipping PASSED  [ 59/121]
tests/midifiles/test_midifiles.py::test_invalid_data_byte_with_clipping_high PASSED [ 60/121]
tests/midifiles/test_midifiles.py::test_meta_messages PASSED                  [ 61/121]
tests/midifiles/test_midifiles.py::test_meta_message_bad_key_sig_throws_key_signature_error_sharps PASSED [ 62/121]
tests/midifiles/test_midifiles.py::test_meta_message_bad_key_sig_throws_key_signature_error_flats PASSED [ 63/121]
tests/midifiles/test_midifiles.py::test_meta_messages_with_length_0 PASSED    [ 64/121]
tests/midifiles/test_midifiles.py::test_midifile_repr PASSED                  [ 65/121]
tests/midifiles/test_tracks.py::test_track_slice PASSED                       [ 66/121]
tests/midifiles/test_tracks.py::test_track_name PASSED                        [ 67/121]
tests/midifiles/test_tracks.py::test_track_repr PASSED                        [ 68/121]
tests/midifiles/test_units.py::test_tempo2bpm PASSED                          [ 69/121]
tests/midifiles/test_units.py::test_bpm2tempo PASSED                          [ 70/121]
tests/midifiles/test_units.py::test_tick2second PASSED                        [ 71/121]
tests/midifiles/test_units.py::test_second2tick PASSED                        [ 72/121]
tests/test_frozen.py::test_hashability PASSED                                 [ 73/121]
tests/test_frozen.py::test_freeze_and_thaw PASSED                             [ 74/121]
tests/test_frozen.py::test_thawed_message_is_copy PASSED                      [ 75/121]
tests/test_frozen.py::test_is_frozen PASSED                                   [ 76/121]
tests/test_frozen.py::test_frozen_repr PASSED                                 [ 77/121]
tests/test_frozen.py::test_frozen_meta_repr PASSED                            [ 78/121]
tests/test_frozen.py::test_frozen_unknown_meta_repr PASSED                    [ 79/121]
tests/test_parser.py::test_parse PASSED                                       [ 80/121]
tests/test_parser.py::test_parse_stray_data PASSED                            [ 81/121]
tests/test_parser.py::test_parse_stray_status_bytes PASSED                    [ 82/121]
tests/test_parser.py::test_encode_and_parse PASSED                            [ 83/121]
tests/test_parser.py::test_feed_byte PASSED                                   [ 84/121]
tests/test_parser.py::test_feed PASSED                                        [ 85/121]
tests/test_parser.py::test_parse_random_bytes PASSED                          [ 86/121]
tests/test_parser.py::test_parse_channel PASSED                               [ 87/121]
tests/test_parser.py::test_one_byte_message PASSED                            [ 88/121]
tests/test_parser.py::test_undefined_messages PASSED                          [ 89/121]
tests/test_parser.py::test_realtime_inside_sysex PASSED                       [ 90/121]
tests/test_parser.py::test_undefined_realtime_inside_sysex PASSED             [ 91/121]
tests/test_parser.py::test_encode_and_parse_all PASSED                        [ 92/121]
tests/test_parser.py::test_parser_ascii_text PASSED                           [ 93/121]
tests/test_ports.py::TestIOPort::test_basic PASSED                            [ 94/121]
tests/test_ports.py::TestIOPort::test_recv_non_blocking PASSED                [ 95/121]
tests/test_ports.py::TestIOPort::test_send_message PASSED                     [ 96/121]
tests/test_ports.py::TestIOPort::test_port_close PASSED                       [ 97/121]
tests/test_ports.py::TestIOPort::test_mido_port_non_blocking_recv PASSED      [ 98/121]
tests/test_ports.py::test_close_inside_iteration PASSED                       [ 99/121]
tests/test_sockets.py::TestParseAddress::test_parse_address_normal[:8080-expected0] PASSED [100/121]
tests/test_sockets.py::TestParseAddress::test_parse_address_normal[localhost:8080-expected1] PASSED [101/121]
tests/test_sockets.py::TestParseAddress::test_too_many_colons_raises_value_error PASSED [102/121]
tests/test_sockets.py::TestParseAddress::test_only_hostname_raises_value_error PASSED [103/121]
tests/test_sockets.py::TestParseAddress::test_empty_string_raises_value_error PASSED [104/121]
tests/test_sockets.py::TestParseAddress::test_only_colon_raises_value_error PASSED [105/121]
tests/test_sockets.py::TestParseAddress::test_non_number_port_raises_value_error PASSED [106/121]
tests/test_sockets.py::TestParseAddress::test_port_zero_raises_value_error PASSED [107/121]
tests/test_sockets.py::TestParseAddress::test_out_of_range_port_raises_value_error PASSED [108/121]
tests/test_syx.py::test_read PASSED                                           [109/121]
tests/test_syx.py::test_handle_any_whitespace PASSED                          [110/121]
tests/test_syx.py::test_write PASSED                                          [111/121]
tests/test_tokenizer.py::test_channel_message PASSED                          [112/121]
tests/test_tokenizer.py::test_sysex PASSED                                    [113/121]
tests/test_tokenizer.py::test_empty_sysex PASSED                              [114/121]
tests/test_tokenizer.py::test_realtime PASSED                                 [115/121]
tests/test_tokenizer.py::test_double_realtime PASSED                          [116/121]
tests/test_tokenizer.py::test_realtime_inside_message PASSED                  [117/121]
tests/test_tokenizer.py::test_realtime_inside_sysex PASSED                    [118/121]
tests/test_tokenizer.py::test_message_inside_sysex PASSED                     [119/121]
tests/test_tokenizer.py::test_sysex_inside_sysex PASSED                       [120/121]
tests/test_tokenizer.py::test_stray_data_bytes PASSED                         [121/121]
```

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
