### PR TITLE
zig.eclass: fix rare spurious `error.BrokenPipe` during `src_test`

### DIFF
--- a/eclass/zig.eclass
+++ b/eclass/zig.eclass
@@ -520,9 +520,10 @@ zig_src_test() {
 	# by whitespaces is not enough for some cases.
 	# We probably need something like  "--list-steps names_only".
 	# In practice, almost nobody sets such names.
+	# Ignore failures like rare random "error.BrokenPipe" here.
+	# If they are real, they would appear in "ezig build test" anyway.
 	if grep -q '^[ ]*test[ ]' < <(
-		nonfatal ezig build --list-steps "${args[@]}" ||
-			die "ZBS: listing steps failed"
+		nonfatal ezig build --list-steps "${args[@]}"
 	); then
 		einfo "ZBS: testing with: ${args[@]}"
 		nonfatal ezig build test "${args[@]}" ||


### PR DESCRIPTION
Most likely caused by `grep -q` processing too fast when steps are filtered. Can sometimes be reproduced with this command (you might need several retries to hit it):

```console
$ for i in {0..20}; do zig build --list-steps | grep -q test; done
error: BrokenPipe
/usr/lib64/zig/9999/lib/compiler/build_runner.zig:1229:9: 0x1518f3e in steps__anon_4736 (build)
        try out_stream.print("  {s:<28} {s}\n", .{ name, top_level_step.description });
        ^
/usr/lib64/zig/9999/lib/compiler/build_runner.zig:374:9: 0x1511b81 in main (build)
        return steps(builder, stdout_writer);
        ^
error: the following build command failed with exit code 1:
/home/bratishkaerik/github.com/zig/.zig-cache/o/4b3846557c333ec9e467b7cc136d3698/build /usr/lib64/zig/9999/bin/zig /usr/lib64/zig/9999/lib /home/bratishkaerik/github.com/zig /home/bratishkaerik/github.com/zig/.zig-cache /home/bratishkaerik/.cache/zig --seed 0x86f5c718 -Z7b5e4ad814524daf --list-steps
```

Caught this today when I merged and tested `dev-lang/zig:9999` 9 times in a row because I was checking patch for upstream. Out of these 9 times it failed only once. I couldn't reproduce this on `sys-fs/ncdu` or `gui-wm/river::guru`, my guess here is that `test` step is listed last there, so zig pipe catches up with it.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
