### PR TITLE
dev-java/saslprep: 1.1-r2 pin to stringprep of same version #946526 | profiles: deprecate dev-java/saslprep #946526

### DIFF
--- a/dev-java/saslprep/saslprep-1.1-r2.ebuild
+++ b/dev-java/saslprep/saslprep-1.1-r2.ebuild
@@ -16,7 +16,7 @@ LICENSE="BSD-2"
 SLOT="0"
 KEYWORDS="amd64 ppc64"
 
-CP_DEPEND="dev-java/stringprep:0"
+CP_DEPEND="~dev-java/stringprep-${PV}:0"
 DEPEND=">=virtual/jdk-1.8:*
 	${CP_DEPEND}"
 RDEPEND=">=virtual/jre-1.8:*

--- a/dev-java/stringprep/stringprep-2.2.ebuild
+++ b/dev-java/stringprep/stringprep-2.2.ebuild
@@ -16,7 +16,7 @@ S="${WORKDIR}/${P}"
 
 LICENSE="BSD-2"
 SLOT="0"
-KEYWORDS="~amd64 ~ppc64 ~x86"
+KEYWORDS="~amd64 ~ppc64"
 
 DEPEND=">=virtual/jdk-11:*"	# module-info
 RDEPEND=">=virtual/jre-1.8:*"

--- a/profiles/base/package.use.stable.mask
+++ b/profiles/base/package.use.stable.mask
@@ -4,10 +4,6 @@
 # This file requires eapi 5 or later. New entries go on top.
 # Please use the same syntax as in package.use.mask
 
-# Volkmar W. Pogatzki <gentoo@pogatzki.net> (2024-10-11)
-# No suitable version of dev-libs/protobuf available.
-=dev-java/protobuf-java-4.28.1 system-protoc
-
 # Andreas Sturmlechner <asturm@gentoo.org> (2024-08-29)
 # Pin down kf6compat mask to currently stable versions.
 <kde-apps/kio-extras-24.02.2-r2 kf6compat

--- a/profiles/package.deprecated
+++ b/profiles/package.deprecated
@@ -17,6 +17,11 @@
 
 #--- END OF EXAMPLES ---
 
+# Volkmar W. Pogatzki <gentoo@pogatzki.net> (2024-12-16)
+# Bug #946526. There is a newer version in dev-java/stringprep-2.2 pending for
+# stabilization. Then dev-java/saslprep should be last-rited.
+dev-java/saslprep
+
 # Michał Górny <mgorny@gentoo.org> (2024-06-15)
 # Stop-gap compatibility package.  Upstreams really need to move away
 # from the removed cgi module rather than rely on this.


### PR DESCRIPTION
<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
