### PR TITLE
sys-libs/glibc: run fixincludes in pkg_postinst

### DIFF
--- a/sys-libs/glibc/glibc-9999.ebuild
+++ b/sys-libs/glibc/glibc-9999.ebuild
@@ -1731,6 +1731,29 @@ pkg_postinst() {
 		use loong && glibc_refresh_ldconfig
 
 		use compile-locales || run_locale_gen "${EROOT}/"
+
+		# If fixincludes was/is active for a particular GCC slot, we
+		# must refresh it. See bug #933282 and GCC's documentation:
+		# https://gcc.gnu.org/onlinedocs/gcc/Fixed-Headers.html
+		#
+		# TODO: Could this be done for non-cross? Some care would be needed
+		# to pass the right arguments.
+		while IFS= read -r -d $'\0' slot ; do
+			local mkheaders_path="${BROOT}"/usr/libexec/gcc/${CBUILD}/${slot##*/}/install-tools/mkheaders
+			local pthread_h="${BROOT}"/usr/lib/gcc/${CBUILD}/${slot##*/}/include-fixed/pthread.h
+			if [[ -x ${mkheaders_path} ]] ; then
+				ebegin "Refreshing fixincludes for ${CBUILD} with gcc-${slot##*/}"
+				${mkheaders_path} -v
+				eend $?
+			elif [[ -f ${pthread_h} ]] ; then
+				# fixincludes might have been enabled in the past for this
+				# GCC slot but not since we fixed toolchain.eclass to install
+				# mkheaders, so we need to manually delete pthread.h at least.
+				ebegin "Deleting stale fixincludes'd pthread.h for ${CBUILD} with gcc-${slot##*/}"
+				mv -v "${pthread_h}" "${pthread_h}.bak"
+				eend $?
+			fi
+		done < <(find "${BROOT}"/usr/libexec/gcc/${CBUILD}/ -mindepth 1 -maxdepth 1 -type d -print0)
 	fi
 
 	upgrade_warning


### PR DESCRIPTION
```
    sys-libs/glibc: run fixincludes in pkg_postinst

    We enabled fixincludes for a window between GCC 13 and whatever the just
    released version of glibc was at the time to cover Float128 changes. We
    then turned it off again when it was (mostly) no longer needed.

    (Though arguably it was/still is needed for some upgrade paths or combinations
    and maybe we should reconsider that given we now have a proper solution here
    to "defanging" fixincludes (as it turns out we were kind of using it wrong,
    see bug #30701)).

    Anyway, for any glibc installed during that window, a fixincludes'd pthread.h
    would've been installed to the include-fixed directory, which then becomes
    a cached stale copy when the rest of glibc changes like:
    ```
    --- pthread.h-fixincludes       2024-12-12 06:49:06.918089635 +0000
    +++ /usr/include/pthread.h      2024-12-06 16:49:09.306028087 +0000
    [...]
    @@ -232,7 +223,7 @@
        the thread in *THREAD_RETURN, if THREAD_RETURN is not NULL.  */
     extern int pthread_tryjoin_np (pthread_t __th, void **__thread_return) __THROW;

    -# ifndef __USE_TIME_BITS64
    +# ifndef __USE_TIME64_REDIRECTS
    ```
    because the guards no longer match up with the rest of glibc.

    The fix is for us to refresh fixincludes using `mkheaders` (if available)
    which we weren't installing until recently (7d99be77433bf10fb0ce6fc99c7b40de700ed650)
    in pkg_postinst for sys-libs/glibc. We will likely need to add similar
    logic into linux-headers at least too. I am considering adding such an update
    to gcc-config too.

    Note that we also have to cover the case where mkheaders isn't available
    *but* a cached broken pthread.h exists, so if mkheaders doesn't exist, but
    pthread.h does in include-fixed, we move that away to .bak.

    Bug: https://gcc.gnu.org/PR20166
    Bug: https://gcc.gnu.org/PR94089
    Bug: https://gcc.gnu.org/PR107059
    Bug: https://gcc.gnu.org/PR118009
    Bug: https://bugs.gentoo.org/30701
    Bug: https://bugs.gentoo.org/933282
    Tested-by: Matt Jolly <kangie@gentoo.org>
    Signed-off-by: Sam James <sam@gentoo.org>
```