### PR TITLE
dev-python/ipython: Backport upstream fix for python3.13 regression

### DIFF
--- a/dev-python/ipython/files/ipython-8.30.0-python3.13-debugger-pdb-curframe.patch
+++ b/dev-python/ipython/files/ipython-8.30.0-python3.13-debugger-pdb-curframe.patch
@@ -1,0 +1,30 @@
+FAILED IPython/core/tests/test_run.py::TestMagicRunPass::test_run_debug_twice - AttributeError: 'Pdb' object has no attribute 'curframe'. Did you mean: 'botframe'?
+FAILED IPython/core/tests/test_run.py::TestMagicRunPass::test_run_debug_twice_with_breakpoint - AttributeError: 'Pdb' object has no attribute 'curframe'. Did you mean: 'botframe'?
+https://bugs.gentoo.org/946568
+https://github.com/ipython/ipython/pull/14598
+https://github.com/ipython/ipython/commit/c1e945b5bc8fb673109cf32c4f238f6d5e0f5149.patch
+
+From c1e945b5bc8fb673109cf32c4f238f6d5e0f5149 Mon Sep 17 00:00:00 2001
+From: M Bussonnier <bussonniermatthias@gmail.com>
+Date: Sun, 8 Dec 2024 11:37:11 +0100
+Subject: [PATCH] Fix pdb issues in Python 3.13.1
+
+For some reason it is not always set, it was/is a bug in IPython to not
+check.
+---
+ IPython/core/debugger.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/IPython/core/debugger.py b/IPython/core/debugger.py
+index 1f0d7b2fba..76c42e0230 100644
+--- a/IPython/core/debugger.py
++++ b/IPython/core/debugger.py
+@@ -550,7 +550,7 @@ def _get_frame_locals(self, frame):
+         So if frame is self.current_frame we instead return self.curframe_locals
+ 
+         """
+-        if frame is self.curframe:
++        if frame is getattr(self, "curframe", None):
+             return self.curframe_locals
+         else:
+             return frame.f_locals

--- a/dev-python/ipython/ipython-8.30.0-r1.ebuild
+++ b/dev-python/ipython/ipython-8.30.0-r1.ebuild
@@ -81,6 +81,8 @@ PDEPEND="
 	)
 "
 
+PATCHES=( "${FILESDIR}"/${P}-python3.13-debugger-pdb-curframe.patch ) # bug #946568
+
 python_prepare_all() {
 	# Rename the test directory to reduce sys.path pollution
 	# https://github.com/ipython/ipython/issues/12892


### PR DESCRIPTION
The regression was detected by ipython's own testsuite: 
```
FAILED IPython/core/tests/test_run.py::TestMagicRunPass::test_run_debug_twice - AttributeError: 'Pdb' object has no attribute 'curframe'. Did you mean: 'botframe'?
FAILED IPython/core/tests/test_run.py::TestMagicRunPass::test_run_debug_twice_with_breakpoint - AttributeError: 'Pdb' object has no attribute 'curframe'. Did you mean: 'botframe'?
```

Url: https://github.com/ipython/ipython/pull/14598
Url: https://github.com/ipython/ipython/commit/c1e945b5bc8fb673109cf32c4f238f6d5e0f5149
Closes: https://bugs.gentoo.org/946568

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:https://github.com/gabifalk/gentoo/pull/new/fix-ipython-python3.13-pdb

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
