### PR TITLE
dev-python/nbclient: add missing pytest-rerunfailures bdepend for USE=test

### DIFF
--- a/dev-python/nbclient/nbclient-0.10.1.ebuild
+++ b/dev-python/nbclient/nbclient-0.10.1.ebuild
@@ -33,6 +33,7 @@ BDEPEND="
 		dev-python/ipywidgets[${PYTHON_USEDEP}]
 		dev-python/nbconvert[${PYTHON_USEDEP}]
 		dev-python/pytest-asyncio[${PYTHON_USEDEP}]
+		dev-python/pytest-rerunfailures[${PYTHON_USEDEP}]
 		dev-python/testpath[${PYTHON_USEDEP}]
 		dev-python/xmltodict[${PYTHON_USEDEP}]
 	)


### PR DESCRIPTION
nbclient fails tests due to missing bdep on dev-python/pytest-rerunfailures.
```
>>> Test phase: dev-python/nbclient-0.10.1
 * python3_13: running distutils-r1_run_phase python_test
python3.13 -m pytest -vv -ra -l -Wdefault -Werror::pytest.PytestUnhandledCoroutineWarning --color=yes -o console_output_style=count -o tmp_path_retention_count=0 -o tmp_path_retention_policy=failed -p xdist -n 6
 --dist=worksteal --deselect tests/test_client.py::test_run_all_notebooks[Interrupt.ipynb-opts6] -p asyncio -p rerunfailures --reruns=3
Traceback (most recent call last):
  File "/usr/lib/python3.13/site-packages/_pytest/config/__init__.py", line 858, in import_plugin
    __import__(importspec)
    ~~~~~~~~~~^^^^^^^^^^^^
ModuleNotFoundError: No module named 'rerunfailures'
```

Closes: https://bugs.gentoo.org/946569

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
