### PR TITLE
media-libs/libva-intel-media-driver: GCC15 c23 fix

### DIFF
--- a/media-libs/libva-intel-media-driver/files/libva-intel-media-driver-24.4.4-c23-fix.patch
+++ b/media-libs/libva-intel-media-driver/files/libva-intel-media-driver-24.4.4-c23-fix.patch
@@ -1,0 +1,15 @@
+From https://patch-diff.githubusercontent.com/raw/intel/media-driver/pull/1849.patch
+From: Blackteahamburger <blackteahamburger@outlook.com>
+Date: Thu, 29 Aug 2024 17:04:55 +0800
+Subject: [PATCH] Fix missing cstdint for GCC 15
+
+--- a/media_common/linux/common/os/mos_defs_specific.h
++++ b/media_common/linux/common/os/mos_defs_specific.h
+@@ -29,6 +29,7 @@
+ 
+ #include <pthread.h>
+ #include <semaphore.h>
++#include <cstdint>
+ #include <string>
+ 
+ typedef pthread_mutex_t         MOS_MUTEX, *PMOS_MUTEX;         //!< mutex pointer

--- a/media-libs/libva-intel-media-driver/libva-intel-media-driver-24.4.4.ebuild
+++ b/media-libs/libva-intel-media-driver/libva-intel-media-driver-24.4.4.ebuild
@@ -37,6 +37,7 @@ RDEPEND="${DEPEND}"
 PATCHES=(
 	"${FILESDIR}"/${PN}-23.3.4-Remove-unwanted-CFLAGS.patch
 	"${FILESDIR}"/${PN}-23.3.4_testing_in_src_test.patch
+	"${FILESDIR}"/${PN}-24.4.4-c23-fix.patch
 )
 
 multilib_src_configure() {


### PR DESCRIPTION
Tested and now works fine after this patch is applied. Should be added to upstream shortly so haven't added to the live ebuild however there is no clear date when a new version will drop so applying to the last versioned to help users in the meantime.

Closes: https://bugs.gentoo.org/938537

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
