### PR TITLE
dev-libs/libatasmart: add 0.19_p5-r1 with improvements

### DIFF
--- a/dev-libs/libatasmart/files/libatasmart-0.19_p5_do-not-fortify-source.patch
+++ b/dev-libs/libatasmart/files/libatasmart-0.19_p5_do-not-fortify-source.patch
@@ -1,0 +1,23 @@
+From: Filip Kobierski <fkobi@pm.me>
+
+Bug: https://bugs.gentoo.org/890275
+---
+ configure.ac | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index 1f47716..c78f06e 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -88,7 +88,7 @@ CC_CHECK_FLAGS_APPEND([with_cflags], [CFLAGS], [\
+         -Wunsafe-loop-optimizations \
+         -Wpacked \
+         -Werror=overflow \
+-        -Wp,-D_FORTIFY_SOURCE=2 \
++        -Wp, \
+         -ffast-math \
+         -fno-common \
+         -fdiagnostics-show-option \
+-- 
+2.45.2
+

--- a/dev-libs/libatasmart/libatasmart-0.19_p5-r1.ebuild
+++ b/dev-libs/libatasmart/libatasmart-0.19_p5-r1.ebuild
@@ -1,0 +1,52 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs
+
+DESCRIPTION="A small and lightweight parser library for ATA S.M.A.R.T. hard disks"
+HOMEPAGE="https://salsa.debian.org/utopia-team/libatasmart"
+SRC_URI="mirror://debian/pool/main/liba/${PN}/${PN}_${PV/_p*}.orig.tar.xz
+	mirror://debian/pool/main/liba/${PN}/${PN}_${PV/_p/-}.debian.tar.xz"
+S="${WORKDIR}/${P/_p*}"
+
+LICENSE="LGPL-2.1+"
+SLOT="0/4"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~mips ~ppc ~ppc64 ~riscv ~sparc ~x86"
+IUSE="static-libs"
+
+RDEPEND="virtual/libudev:="
+DEPEND="${RDEPEND}"
+BDEPEND="virtual/pkgconfig"
+
+PATCHES=( "${FILESDIR}"/${PN}-0.19_p5_do-not-fortify-source.patch )
+
+src_prepare() {
+	# https://bugs.gentoo.org/470874
+	local d="${WORKDIR}/debian/patches"
+	sed -i -e '/#/d' \
+		-e "s|^|${d}/|" "${d}"/series || die
+	eapply $(<"${d}"/series)
+	eapply_user
+}
+
+src_configure() {
+	econf $(use_enable static-libs static)
+}
+
+src_compile() {
+	if tc-is-cross-compiler; then
+		tc-export_build_env
+		emake -C strpool strpool \
+			CFLAGS="${BUILD_CFLAGS}" \
+			CPPFLAGS="${BUILD_CPPFLAGS}" \
+			LDFLAGS="${BUILD_LDFLAGS}"
+	fi
+	emake
+}
+
+src_install() {
+	default
+	find "${ED}" -type f -name "*.la" -delete || die
+}


### PR DESCRIPTION
- bump EAPI
- do not fortify source
- update LICENSE
- fix variable order

Bug: https://bugs.gentoo.org/890275

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
