### PR TITLE
dev-qt/*: unkeyword ~sparc

### DIFF
--- a/dev-build/qconf/qconf-2.5.ebuild
+++ b/dev-build/qconf/qconf-2.5.ebuild
@@ -11,7 +11,7 @@ SRC_URI="https://github.com/psi-im/qconf/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 ~arm ~hppa ppc ppc64 ~sparc x86"
+KEYWORDS="amd64 ~arm ~hppa ppc ppc64 x86"
 IUSE=""
 
 DEPEND="

--- a/dev-qt/assistant/assistant-5.15.14.ebuild
+++ b/dev-qt/assistant/assistant-5.15.14.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 if [[ ${PV} != *9999* ]]; then
 	QT5_KDEPATCHSET_REV=1
-	KEYWORDS="amd64 ~arm arm64 ~hppa ppc64 ~sparc x86"
+	KEYWORDS="amd64 ~arm arm64 ~hppa ppc64 x86"
 fi
 
 QT5_MODULE="qttools"

--- a/dev-qt/assistant/assistant-5.15.16.ebuild
+++ b/dev-qt/assistant/assistant-5.15.16.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 if [[ ${PV} != *9999* ]]; then
 	QT5_KDEPATCHSET_REV=1
-	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ppc64 ~sparc x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ppc64 x86"
 fi
 
 QT5_MODULE="qttools"

--- a/dev-qt/linguist-tools/linguist-tools-5.15.14.ebuild
+++ b/dev-qt/linguist-tools/linguist-tools-5.15.14.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 if [[ ${PV} != *9999* ]]; then
 	QT5_KDEPATCHSET_REV=1
-	KEYWORDS="amd64 arm arm64 ~hppa ~loong ppc ppc64 ~riscv ~sparc x86"
+	KEYWORDS="amd64 arm arm64 ~hppa ~loong ppc ppc64 ~riscv x86"
 fi
 
 QT5_MODULE="qttools"

--- a/dev-qt/linguist-tools/linguist-tools-5.15.16.ebuild
+++ b/dev-qt/linguist-tools/linguist-tools-5.15.16.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 if [[ ${PV} != *9999* ]]; then
 	QT5_KDEPATCHSET_REV=1
-	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ppc ppc64 ~riscv ~sparc x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ppc ppc64 ~riscv x86"
 fi
 
 QT5_MODULE="qttools"

--- a/dev-qt/pixeltool/pixeltool-5.15.14.ebuild
+++ b/dev-qt/pixeltool/pixeltool-5.15.14.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 if [[ ${PV} != *9999* ]]; then
 	QT5_KDEPATCHSET_REV=1
-	KEYWORDS="amd64 ~arm arm64 ~hppa ppc64 ~sparc x86"
+	KEYWORDS="amd64 ~arm arm64 ~hppa ppc64 x86"
 fi
 
 QT5_MODULE="qttools"

--- a/dev-qt/pixeltool/pixeltool-5.15.16.ebuild
+++ b/dev-qt/pixeltool/pixeltool-5.15.16.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 if [[ ${PV} != *9999* ]]; then
 	QT5_KDEPATCHSET_REV=1
-	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ppc64 ~sparc x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ppc64 x86"
 fi
 
 QT5_MODULE="qttools"

--- a/dev-qt/qdbus/qdbus-5.15.14.ebuild
+++ b/dev-qt/qdbus/qdbus-5.15.14.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 if [[ ${PV} != *9999* ]]; then
 	QT5_KDEPATCHSET_REV=1
-	KEYWORDS="amd64 ~arm arm64 ~hppa ~loong ppc ppc64 ~riscv ~sparc x86"
+	KEYWORDS="amd64 ~arm arm64 ~hppa ~loong ppc ppc64 ~riscv x86"
 fi
 
 QT5_MODULE="qttools"

--- a/dev-qt/qdbus/qdbus-5.15.16.ebuild
+++ b/dev-qt/qdbus/qdbus-5.15.16.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 if [[ ${PV} != *9999* ]]; then
 	QT5_KDEPATCHSET_REV=1
-	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ppc ppc64 ~riscv ~sparc x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ppc ppc64 ~riscv x86"
 fi
 
 QT5_MODULE="qttools"

--- a/dev-qt/qdbusviewer/qdbusviewer-5.15.14.ebuild
+++ b/dev-qt/qdbusviewer/qdbusviewer-5.15.14.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 if [[ ${PV} != *9999* ]]; then
 	QT5_KDEPATCHSET_REV=1
-	KEYWORDS="amd64 ~arm arm64 ~hppa ppc64 ~sparc x86"
+	KEYWORDS="amd64 ~arm arm64 ~hppa ppc64 x86"
 fi
 
 QT5_MODULE="qttools"

--- a/dev-qt/qdbusviewer/qdbusviewer-5.15.16.ebuild
+++ b/dev-qt/qdbusviewer/qdbusviewer-5.15.16.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 if [[ ${PV} != *9999* ]]; then
 	QT5_KDEPATCHSET_REV=1
-	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ppc64 ~sparc x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ppc64 x86"
 fi
 
 QT5_MODULE="qttools"

--- a/dev-qt/qt-docs/qt-docs-5.15.2_p202011130614.ebuild
+++ b/dev-qt/qt-docs/qt-docs-5.15.2_p202011130614.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -55,7 +55,7 @@ HOMEPAGE="https://doc.qt.io/"
 
 LICENSE="FDL-1.3"
 SLOT="5"
-KEYWORDS="amd64 arm arm64 ~hppa ~loong ~ppc ppc64 ~riscv ~sparc x86"
+KEYWORDS="amd64 arm arm64 ~hppa ~loong ~ppc ppc64 ~riscv x86"
 
 IUSE="charts datavis +html networkauth +qch script timeline virtualkeyboard webengine"
 REQUIRED_USE="|| ( html qch )"

--- a/dev-qt/qt-docs/qt-docs-6.7.2_p202406110334.ebuild
+++ b/dev-qt/qt-docs/qt-docs-6.7.2_p202406110334.ebuild
@@ -10,7 +10,7 @@ HOMEPAGE="https://doc.qt.io/"
 
 LICENSE="FDL-1.3"
 SLOT="6"
-KEYWORDS="amd64 arm arm64 ~hppa ~loong ppc ppc64 ~riscv ~sparc x86"
+KEYWORDS="amd64 arm arm64 ~hppa ~loong ppc ppc64 ~riscv x86"
 IUSE="+examples +html +qch"
 REQUIRED_USE="|| ( examples html qch )"
 

--- a/dev-qt/qt-docs/qt-docs-6.7.3_p202409200836.ebuild
+++ b/dev-qt/qt-docs/qt-docs-6.7.3_p202409200836.ebuild
@@ -10,7 +10,7 @@ HOMEPAGE="https://doc.qt.io/"
 
 LICENSE="FDL-1.3"
 SLOT="6"
-KEYWORDS="amd64 arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~sparc x86"
+KEYWORDS="amd64 arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv x86"
 IUSE="+examples +html +qch"
 REQUIRED_USE="|| ( examples html qch )"
 

--- a/dev-qt/qt-docs/qt-docs-6.8.1_p202411221531.ebuild
+++ b/dev-qt/qt-docs/qt-docs-6.8.1_p202411221531.ebuild
@@ -10,7 +10,7 @@ HOMEPAGE="https://doc.qt.io/"
 
 LICENSE="FDL-1.3"
 SLOT="6"
-KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~x86"
 IUSE="+examples +html +qch"
 REQUIRED_USE="|| ( examples html qch )"
 

--- a/dev-qt/qtbase/qtbase-6.7.2-r5.ebuild
+++ b/dev-qt/qtbase/qtbase-6.7.2-r5.ebuild
@@ -8,7 +8,7 @@ inherit flag-o-matic qt6-build toolchain-funcs
 DESCRIPTION="Cross-platform application development framework"
 
 if [[ ${QT6_BUILD_TYPE} == release ]]; then
-	KEYWORDS="amd64 arm arm64 ~hppa ~loong ppc ppc64 ~riscv ~sparc x86"
+	KEYWORDS="amd64 arm arm64 ~hppa ~loong ppc ppc64 ~riscv x86"
 fi
 
 declare -A QT6_IUSE=(

--- a/dev-qt/qtbase/qtbase-6.7.3-r2.ebuild
+++ b/dev-qt/qtbase/qtbase-6.7.3-r2.ebuild
@@ -8,7 +8,7 @@ inherit flag-o-matic qt6-build toolchain-funcs
 DESCRIPTION="Cross-platform application development framework"
 
 if [[ ${QT6_BUILD_TYPE} == release ]]; then
-	KEYWORDS="amd64 arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~sparc x86"
+	KEYWORDS="amd64 arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv x86"
 fi
 
 declare -A QT6_IUSE=(

--- a/dev-qt/qtbase/qtbase-6.8.1.ebuild
+++ b/dev-qt/qtbase/qtbase-6.8.1.ebuild
@@ -8,7 +8,7 @@ inherit flag-o-matic qt6-build toolchain-funcs
 DESCRIPTION="Cross-platform application development framework"
 
 if [[ ${QT6_BUILD_TYPE} == release ]]; then
-	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~x86"
 fi
 
 declare -A QT6_IUSE=(

--- a/dev-qt/qtbase/qtbase-6.8.9999.ebuild
+++ b/dev-qt/qtbase/qtbase-6.8.9999.ebuild
@@ -8,7 +8,7 @@ inherit flag-o-matic qt6-build toolchain-funcs
 DESCRIPTION="Cross-platform application development framework"
 
 if [[ ${QT6_BUILD_TYPE} == release ]]; then
-	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~x86"
 fi
 
 declare -A QT6_IUSE=(

--- a/dev-qt/qtbase/qtbase-6.9.9999.ebuild
+++ b/dev-qt/qtbase/qtbase-6.9.9999.ebuild
@@ -8,7 +8,7 @@ inherit flag-o-matic qt6-build toolchain-funcs
 DESCRIPTION="Cross-platform application development framework"
 
 if [[ ${QT6_BUILD_TYPE} == release ]]; then
-	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~x86"
 fi
 
 declare -A QT6_IUSE=(

--- a/dev-qt/qtbase/qtbase-6.9999.ebuild
+++ b/dev-qt/qtbase/qtbase-6.9999.ebuild
@@ -8,7 +8,7 @@ inherit flag-o-matic qt6-build toolchain-funcs
 DESCRIPTION="Cross-platform application development framework"
 
 if [[ ${QT6_BUILD_TYPE} == release ]]; then
-	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~x86"
 fi
 
 declare -A QT6_IUSE=(

--- a/dev-qt/qtchooser/qtchooser-66-r2.ebuild
+++ b/dev-qt/qtchooser/qtchooser-66-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -13,7 +13,7 @@ if [[ ${PV} == *9999* ]]; then
 	inherit git-r3
 else
 	SRC_URI="https://download.qt.io/official_releases/${PN}/${P}.tar.xz"
-	KEYWORDS="amd64 arm arm64 ~hppa ~loong ppc ppc64 ~riscv ~sparc x86"
+	KEYWORDS="amd64 arm arm64 ~hppa ~loong ppc ppc64 ~riscv x86"
 fi
 
 LICENSE="|| ( LGPL-2.1 GPL-3 )"

--- a/dev-qt/qtconcurrent/qtconcurrent-5.15.14.ebuild
+++ b/dev-qt/qtconcurrent/qtconcurrent-5.15.14.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 if [[ ${PV} != *9999* ]]; then
 	QT5_KDEPATCHSET_REV=1
-	KEYWORDS="amd64 arm arm64 ~hppa ~loong ppc ppc64 ~riscv ~sparc x86"
+	KEYWORDS="amd64 arm arm64 ~hppa ~loong ppc ppc64 ~riscv x86"
 fi
 
 QT5_MODULE="qtbase"

--- a/dev-qt/qtconcurrent/qtconcurrent-5.15.16.ebuild
+++ b/dev-qt/qtconcurrent/qtconcurrent-5.15.16.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 if [[ ${PV} != *9999* ]]; then
 	QT5_KDEPATCHSET_REV=1
-	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ppc ppc64 ~riscv ~sparc x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ppc ppc64 ~riscv x86"
 fi
 
 QT5_MODULE="qtbase"

--- a/dev-qt/qtcore/qtcore-5.15.14.ebuild
+++ b/dev-qt/qtcore/qtcore-5.15.14.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 if [[ ${PV} != *9999* ]]; then
 	QT5_KDEPATCHSET_REV=1
-	KEYWORDS="amd64 arm arm64 ~hppa ~loong ppc ppc64 ~riscv ~sparc x86"
+	KEYWORDS="amd64 arm arm64 ~hppa ~loong ppc ppc64 ~riscv x86"
 fi
 
 QT5_MODULE="qtbase"

--- a/dev-qt/qtcore/qtcore-5.15.16.ebuild
+++ b/dev-qt/qtcore/qtcore-5.15.16.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 if [[ ${PV} != *9999* ]]; then
 	QT5_KDEPATCHSET_REV=1
-	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ppc ppc64 ~riscv ~sparc x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ppc ppc64 ~riscv x86"
 fi
 
 QT5_MODULE="qtbase"

--- a/dev-qt/qtdbus/qtdbus-5.15.14.ebuild
+++ b/dev-qt/qtdbus/qtdbus-5.15.14.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 if [[ ${PV} != *9999* ]]; then
 	QT5_KDEPATCHSET_REV=1
-	KEYWORDS="amd64 arm arm64 ~hppa ~loong ppc ppc64 ~riscv ~sparc x86"
+	KEYWORDS="amd64 arm arm64 ~hppa ~loong ppc ppc64 ~riscv x86"
 fi
 
 QT5_MODULE="qtbase"

--- a/dev-qt/qtdbus/qtdbus-5.15.16.ebuild
+++ b/dev-qt/qtdbus/qtdbus-5.15.16.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 if [[ ${PV} != *9999* ]]; then
 	QT5_KDEPATCHSET_REV=1
-	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ppc ppc64 ~riscv ~sparc x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ppc ppc64 ~riscv x86"
 fi
 
 QT5_MODULE="qtbase"

--- a/dev-qt/qtdeclarative/qtdeclarative-5.15.14.ebuild
+++ b/dev-qt/qtdeclarative/qtdeclarative-5.15.14.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 if [[ ${PV} != *9999* ]]; then
 	QT5_KDEPATCHSET_REV=1
-	KEYWORDS="amd64 arm arm64 ~hppa ~loong ppc ppc64 ~riscv ~sparc x86"
+	KEYWORDS="amd64 arm arm64 ~hppa ~loong ppc ppc64 ~riscv x86"
 fi
 
 PYTHON_COMPAT=( python3_{8..13} )

--- a/dev-qt/qtdeclarative/qtdeclarative-5.15.16.ebuild
+++ b/dev-qt/qtdeclarative/qtdeclarative-5.15.16.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 if [[ ${PV} != *9999* ]]; then
 	QT5_KDEPATCHSET_REV=1
-	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ppc ppc64 ~riscv ~sparc x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ppc ppc64 ~riscv x86"
 fi
 
 PYTHON_COMPAT=( python3_{8..13} )

--- a/dev-qt/qtdeclarative/qtdeclarative-6.7.2.ebuild
+++ b/dev-qt/qtdeclarative/qtdeclarative-6.7.2.ebuild
@@ -14,7 +14,7 @@ inherit python-any-r1 qt6-build
 DESCRIPTION="Qt Declarative (Quick 2)"
 
 if [[ ${QT6_BUILD_TYPE} == release ]]; then
-	KEYWORDS="amd64 arm arm64 ~hppa ~loong ppc ppc64 ~riscv ~sparc x86"
+	KEYWORDS="amd64 arm arm64 ~hppa ~loong ppc ppc64 ~riscv x86"
 fi
 
 IUSE="accessibility +jit +network opengl qmlls +sql +ssl svg vulkan +widgets"

--- a/dev-qt/qtdeclarative/qtdeclarative-6.7.3-r4.ebuild
+++ b/dev-qt/qtdeclarative/qtdeclarative-6.7.3-r4.ebuild
@@ -14,7 +14,7 @@ inherit python-any-r1 qt6-build
 DESCRIPTION="Qt Declarative (Quick 2)"
 
 if [[ ${QT6_BUILD_TYPE} == release ]]; then
-	KEYWORDS="amd64 arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~sparc x86"
+	KEYWORDS="amd64 arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv x86"
 fi
 
 IUSE="accessibility +jit +network opengl qmlls +sql +ssl svg vulkan +widgets"

--- a/dev-qt/qtdeclarative/qtdeclarative-6.8.1.ebuild
+++ b/dev-qt/qtdeclarative/qtdeclarative-6.8.1.ebuild
@@ -14,7 +14,7 @@ inherit python-any-r1 qt6-build
 DESCRIPTION="Qt Declarative (Quick 2)"
 
 if [[ ${QT6_BUILD_TYPE} == release ]]; then
-	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~x86"
 fi
 
 IUSE="accessibility +jit +network opengl qmlls +sql +ssl svg vulkan +widgets"

--- a/dev-qt/qtdeclarative/qtdeclarative-6.8.9999.ebuild
+++ b/dev-qt/qtdeclarative/qtdeclarative-6.8.9999.ebuild
@@ -14,7 +14,7 @@ inherit python-any-r1 qt6-build
 DESCRIPTION="Qt Declarative (Quick 2)"
 
 if [[ ${QT6_BUILD_TYPE} == release ]]; then
-	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~x86"
 fi
 
 IUSE="accessibility +jit +network opengl qmlls +sql +ssl svg vulkan +widgets"

--- a/dev-qt/qtdeclarative/qtdeclarative-6.9.9999.ebuild
+++ b/dev-qt/qtdeclarative/qtdeclarative-6.9.9999.ebuild
@@ -14,7 +14,7 @@ inherit python-any-r1 qt6-build
 DESCRIPTION="Qt Declarative (Quick 2)"
 
 if [[ ${QT6_BUILD_TYPE} == release ]]; then
-	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~x86"
 fi
 
 IUSE="accessibility +jit +network opengl qmlls +sql +ssl svg vulkan +widgets"

--- a/dev-qt/qtdeclarative/qtdeclarative-6.9999.ebuild
+++ b/dev-qt/qtdeclarative/qtdeclarative-6.9999.ebuild
@@ -14,7 +14,7 @@ inherit python-any-r1 qt6-build
 DESCRIPTION="Qt Declarative (Quick 2)"
 
 if [[ ${QT6_BUILD_TYPE} == release ]]; then
-	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~x86"
 fi
 
 IUSE="accessibility +jit +network opengl qmlls +sql +ssl svg vulkan +widgets"

--- a/dev-qt/qtdiag/qtdiag-5.15.14.ebuild
+++ b/dev-qt/qtdiag/qtdiag-5.15.14.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 if [[ ${PV} != *9999* ]]; then
 	QT5_KDEPATCHSET_REV=1
-	KEYWORDS="amd64 ~arm ~hppa ~ppc64 ~sparc x86"
+	KEYWORDS="amd64 ~arm ~hppa ~ppc64 x86"
 fi
 
 QT5_MODULE="qttools"

--- a/dev-qt/qtdiag/qtdiag-5.15.16.ebuild
+++ b/dev-qt/qtdiag/qtdiag-5.15.16.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 if [[ ${PV} != *9999* ]]; then
 	QT5_KDEPATCHSET_REV=1
-	KEYWORDS="~amd64 ~arm ~hppa ~ppc64 ~sparc x86"
+	KEYWORDS="~amd64 ~arm ~hppa ~ppc64 x86"
 fi
 
 QT5_MODULE="qttools"

--- a/dev-qt/qtgui/qtgui-5.15.14.ebuild
+++ b/dev-qt/qtgui/qtgui-5.15.14.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 if [[ ${PV} != *9999* ]]; then
 	QT5_KDEPATCHSET_REV=1
-	KEYWORDS="amd64 arm arm64 ~hppa ~loong ppc ppc64 ~riscv ~sparc x86"
+	KEYWORDS="amd64 arm arm64 ~hppa ~loong ppc ppc64 ~riscv x86"
 fi
 
 QT5_MODULE="qtbase"

--- a/dev-qt/qtgui/qtgui-5.15.16.ebuild
+++ b/dev-qt/qtgui/qtgui-5.15.16.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 if [[ ${PV} != *9999* ]]; then
 	QT5_KDEPATCHSET_REV=1
-	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ppc ppc64 ~riscv ~sparc x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ppc ppc64 ~riscv x86"
 fi
 
 QT5_MODULE="qtbase"

--- a/dev-qt/qthelp/qthelp-5.15.14.ebuild
+++ b/dev-qt/qthelp/qthelp-5.15.14.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 if [[ ${PV} != *9999* ]]; then
 	QT5_KDEPATCHSET_REV=1
-	KEYWORDS="amd64 arm arm64 ~hppa ~loong ppc ppc64 ~riscv ~sparc x86"
+	KEYWORDS="amd64 arm arm64 ~hppa ~loong ppc ppc64 ~riscv x86"
 fi
 
 QT5_MODULE="qttools"

--- a/dev-qt/qthelp/qthelp-5.15.16.ebuild
+++ b/dev-qt/qthelp/qthelp-5.15.16.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 if [[ ${PV} != *9999* ]]; then
 	QT5_KDEPATCHSET_REV=1
-	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ppc ppc64 ~riscv ~sparc x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ppc ppc64 ~riscv x86"
 fi
 
 QT5_MODULE="qttools"

--- a/dev-qt/qtimageformats/qtimageformats-5.15.14.ebuild
+++ b/dev-qt/qtimageformats/qtimageformats-5.15.14.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 if [[ ${PV} != *9999* ]]; then
 	QT5_KDEPATCHSET_REV=1
-	KEYWORDS="amd64 arm arm64 ~hppa ~loong ppc64 ~riscv ~sparc x86"
+	KEYWORDS="amd64 arm arm64 ~hppa ~loong ppc64 ~riscv x86"
 fi
 
 inherit qt5-build

--- a/dev-qt/qtimageformats/qtimageformats-5.15.16.ebuild
+++ b/dev-qt/qtimageformats/qtimageformats-5.15.16.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 if [[ ${PV} != *9999* ]]; then
 	QT5_KDEPATCHSET_REV=1
-	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ppc64 ~riscv ~sparc x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ppc64 ~riscv x86"
 fi
 
 inherit qt5-build

--- a/dev-qt/qtmultimedia/qtmultimedia-5.15.14.ebuild
+++ b/dev-qt/qtmultimedia/qtmultimedia-5.15.14.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 if [[ ${PV} != *9999* ]]; then
 	QT5_KDEPATCHSET_REV=1
-	KEYWORDS="amd64 arm arm64 ~hppa ~loong ppc ppc64 ~riscv ~sparc x86"
+	KEYWORDS="amd64 arm arm64 ~hppa ~loong ppc ppc64 ~riscv x86"
 fi
 
 inherit qt5-build

--- a/dev-qt/qtmultimedia/qtmultimedia-5.15.16.ebuild
+++ b/dev-qt/qtmultimedia/qtmultimedia-5.15.16.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 if [[ ${PV} != *9999* ]]; then
 	QT5_KDEPATCHSET_REV=1
-	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ppc ppc64 ~riscv ~sparc x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ppc ppc64 ~riscv x86"
 fi
 
 inherit qt5-build

--- a/dev-qt/qtnetwork/qtnetwork-5.15.14-r1.ebuild
+++ b/dev-qt/qtnetwork/qtnetwork-5.15.14-r1.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 if [[ ${PV} != *9999* ]]; then
 	QT5_KDEPATCHSET_REV=1
-	KEYWORDS="amd64 arm arm64 ~hppa ~loong ppc ppc64 ~riscv ~sparc x86"
+	KEYWORDS="amd64 arm arm64 ~hppa ~loong ppc ppc64 ~riscv x86"
 fi
 
 QT5_MODULE="qtbase"

--- a/dev-qt/qtnetwork/qtnetwork-5.15.16.ebuild
+++ b/dev-qt/qtnetwork/qtnetwork-5.15.16.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 if [[ ${PV} != *9999* ]]; then
 	QT5_KDEPATCHSET_REV=1
-	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ppc ppc64 ~riscv ~sparc x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ppc ppc64 ~riscv x86"
 fi
 
 QT5_MODULE="qtbase"

--- a/dev-qt/qtopengl/qtopengl-5.15.14.ebuild
+++ b/dev-qt/qtopengl/qtopengl-5.15.14.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 if [[ ${PV} != *9999* ]]; then
 	QT5_KDEPATCHSET_REV=1
-	KEYWORDS="amd64 arm arm64 ~hppa ~loong ppc ppc64 ~riscv ~sparc x86"
+	KEYWORDS="amd64 arm arm64 ~hppa ~loong ppc ppc64 ~riscv x86"
 fi
 
 QT5_MODULE="qtbase"

--- a/dev-qt/qtopengl/qtopengl-5.15.16.ebuild
+++ b/dev-qt/qtopengl/qtopengl-5.15.16.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 if [[ ${PV} != *9999* ]]; then
 	QT5_KDEPATCHSET_REV=1
-	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ppc ppc64 ~riscv ~sparc x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ppc ppc64 ~riscv x86"
 fi
 
 QT5_MODULE="qtbase"

--- a/dev-qt/qtpaths/qtpaths-5.15.14.ebuild
+++ b/dev-qt/qtpaths/qtpaths-5.15.14.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 if [[ ${PV} != *9999* ]]; then
 	QT5_KDEPATCHSET_REV=1
-	KEYWORDS="amd64 ~arm arm64 ~hppa ~loong ppc ppc64 ~riscv ~sparc x86"
+	KEYWORDS="amd64 ~arm arm64 ~hppa ~loong ppc ppc64 ~riscv x86"
 fi
 
 QT5_MODULE="qttools"

--- a/dev-qt/qtpaths/qtpaths-5.15.16.ebuild
+++ b/dev-qt/qtpaths/qtpaths-5.15.16.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 if [[ ${PV} != *9999* ]]; then
 	QT5_KDEPATCHSET_REV=1
-	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ppc ppc64 ~riscv ~sparc x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ppc ppc64 ~riscv x86"
 fi
 
 QT5_MODULE="qttools"

--- a/dev-qt/qtpositioning/qtpositioning-5.15.14.ebuild
+++ b/dev-qt/qtpositioning/qtpositioning-5.15.14.ebuild
@@ -9,7 +9,7 @@ inherit qt5-build
 DESCRIPTION="Physical position determination library for the Qt5 framework"
 
 if [[ ${QT5_BUILD_TYPE} == release ]]; then
-	KEYWORDS="amd64 arm arm64 ~hppa ~loong ppc ppc64 ~riscv ~sparc x86"
+	KEYWORDS="amd64 arm arm64 ~hppa ~loong ppc ppc64 ~riscv x86"
 fi
 
 IUSE="geoclue +qml"

--- a/dev-qt/qtpositioning/qtpositioning-5.15.16.ebuild
+++ b/dev-qt/qtpositioning/qtpositioning-5.15.16.ebuild
@@ -9,7 +9,7 @@ inherit qt5-build
 DESCRIPTION="Physical position determination library for the Qt5 framework"
 
 if [[ ${QT5_BUILD_TYPE} == release ]]; then
-	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ppc ppc64 ~riscv ~sparc x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ppc ppc64 ~riscv x86"
 fi
 
 IUSE="geoclue +qml"

--- a/dev-qt/qtprintsupport/qtprintsupport-5.15.14.ebuild
+++ b/dev-qt/qtprintsupport/qtprintsupport-5.15.14.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 if [[ ${PV} != *9999* ]]; then
 	QT5_KDEPATCHSET_REV=1
-	KEYWORDS="amd64 arm arm64 ~hppa ~loong ppc ppc64 ~riscv ~sparc x86"
+	KEYWORDS="amd64 arm arm64 ~hppa ~loong ppc ppc64 ~riscv x86"
 fi
 
 QT5_MODULE="qtbase"

--- a/dev-qt/qtprintsupport/qtprintsupport-5.15.16.ebuild
+++ b/dev-qt/qtprintsupport/qtprintsupport-5.15.16.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 if [[ ${PV} != *9999* ]]; then
 	QT5_KDEPATCHSET_REV=1
-	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ppc ppc64 ~riscv ~sparc x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ppc ppc64 ~riscv x86"
 fi
 
 QT5_MODULE="qtbase"

--- a/dev-qt/qtscript/qtscript-5.15.14.ebuild
+++ b/dev-qt/qtscript/qtscript-5.15.14.ebuild
@@ -8,7 +8,7 @@ inherit qt5-build
 DESCRIPTION="Application scripting library for the Qt5 framework (deprecated)"
 
 if [[ ${QT5_BUILD_TYPE} == release ]]; then
-	KEYWORDS="amd64 ~arm arm64 ~hppa ppc ppc64 ~riscv ~sparc x86"
+	KEYWORDS="amd64 ~arm arm64 ~hppa ppc ppc64 ~riscv x86"
 fi
 
 IUSE="+jit scripttools"

--- a/dev-qt/qtscript/qtscript-5.15.16.ebuild
+++ b/dev-qt/qtscript/qtscript-5.15.16.ebuild
@@ -8,7 +8,7 @@ inherit qt5-build
 DESCRIPTION="Application scripting library for the Qt5 framework (deprecated)"
 
 if [[ ${QT5_BUILD_TYPE} == release ]]; then
-	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ppc ppc64 ~riscv ~sparc x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ppc ppc64 ~riscv x86"
 fi
 
 IUSE="+jit scripttools"

--- a/dev-qt/qtsensors/qtsensors-5.15.14.ebuild
+++ b/dev-qt/qtsensors/qtsensors-5.15.14.ebuild
@@ -8,7 +8,7 @@ inherit qt5-build
 DESCRIPTION="Hardware sensor access library for the Qt5 framework"
 
 if [[ ${QT5_BUILD_TYPE} == release ]]; then
-	KEYWORDS="amd64 arm arm64 ~hppa ~loong ~ppc ppc64 ~riscv ~sparc x86"
+	KEYWORDS="amd64 arm arm64 ~hppa ~loong ~ppc ppc64 ~riscv x86"
 fi
 
 # TODO: simulator

--- a/dev-qt/qtsensors/qtsensors-5.15.16.ebuild
+++ b/dev-qt/qtsensors/qtsensors-5.15.16.ebuild
@@ -8,7 +8,7 @@ inherit qt5-build
 DESCRIPTION="Hardware sensor access library for the Qt5 framework"
 
 if [[ ${QT5_BUILD_TYPE} == release ]]; then
-	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ppc64 ~riscv ~sparc x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ppc64 ~riscv x86"
 fi
 
 # TODO: simulator

--- a/dev-qt/qtserialport/qtserialport-5.15.14.ebuild
+++ b/dev-qt/qtserialport/qtserialport-5.15.14.ebuild
@@ -8,7 +8,7 @@ inherit qt5-build
 DESCRIPTION="Serial port abstraction library for the Qt5 framework"
 
 if [[ ${QT5_BUILD_TYPE} == release ]]; then
-	KEYWORDS="amd64 arm arm64 ~hppa ~loong ppc ppc64 ~riscv ~sparc x86"
+	KEYWORDS="amd64 arm arm64 ~hppa ~loong ppc ppc64 ~riscv x86"
 fi
 
 IUSE=""

--- a/dev-qt/qtserialport/qtserialport-5.15.16.ebuild
+++ b/dev-qt/qtserialport/qtserialport-5.15.16.ebuild
@@ -8,7 +8,7 @@ inherit qt5-build
 DESCRIPTION="Serial port abstraction library for the Qt5 framework"
 
 if [[ ${QT5_BUILD_TYPE} == release ]]; then
-	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ppc ppc64 ~riscv ~sparc x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ppc ppc64 ~riscv x86"
 fi
 
 IUSE=""

--- a/dev-qt/qtshadertools/qtshadertools-6.7.2.ebuild
+++ b/dev-qt/qtshadertools/qtshadertools-6.7.2.ebuild
@@ -8,7 +8,7 @@ inherit qt6-build
 DESCRIPTION="Qt APIs and Tools for Graphics Pipelines"
 
 if [[ ${QT6_BUILD_TYPE} == release ]]; then
-	KEYWORDS="amd64 arm arm64 ~hppa ~loong ppc ppc64 ~riscv ~sparc x86"
+	KEYWORDS="amd64 arm arm64 ~hppa ~loong ppc ppc64 ~riscv x86"
 fi
 
 RDEPEND="

--- a/dev-qt/qtshadertools/qtshadertools-6.7.3.ebuild
+++ b/dev-qt/qtshadertools/qtshadertools-6.7.3.ebuild
@@ -8,7 +8,7 @@ inherit qt6-build
 DESCRIPTION="Qt APIs and Tools for Graphics Pipelines"
 
 if [[ ${QT6_BUILD_TYPE} == release ]]; then
-	KEYWORDS="amd64 arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~sparc x86"
+	KEYWORDS="amd64 arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv x86"
 fi
 
 RDEPEND="

--- a/dev-qt/qtshadertools/qtshadertools-6.8.1.ebuild
+++ b/dev-qt/qtshadertools/qtshadertools-6.8.1.ebuild
@@ -8,7 +8,7 @@ inherit qt6-build
 DESCRIPTION="Qt APIs and Tools for Graphics Pipelines"
 
 if [[ ${QT6_BUILD_TYPE} == release ]]; then
-	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~x86"
 fi
 
 RDEPEND="

--- a/dev-qt/qtshadertools/qtshadertools-6.8.9999.ebuild
+++ b/dev-qt/qtshadertools/qtshadertools-6.8.9999.ebuild
@@ -8,7 +8,7 @@ inherit qt6-build
 DESCRIPTION="Qt APIs and Tools for Graphics Pipelines"
 
 if [[ ${QT6_BUILD_TYPE} == release ]]; then
-	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~x86"
 fi
 
 RDEPEND="

--- a/dev-qt/qtshadertools/qtshadertools-6.9.9999.ebuild
+++ b/dev-qt/qtshadertools/qtshadertools-6.9.9999.ebuild
@@ -8,7 +8,7 @@ inherit qt6-build
 DESCRIPTION="Qt APIs and Tools for Graphics Pipelines"
 
 if [[ ${QT6_BUILD_TYPE} == release ]]; then
-	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~x86"
 fi
 
 RDEPEND="

--- a/dev-qt/qtshadertools/qtshadertools-6.9999.ebuild
+++ b/dev-qt/qtshadertools/qtshadertools-6.9999.ebuild
@@ -8,7 +8,7 @@ inherit qt6-build
 DESCRIPTION="Qt APIs and Tools for Graphics Pipelines"
 
 if [[ ${QT6_BUILD_TYPE} == release ]]; then
-	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~x86"
 fi
 
 RDEPEND="

--- a/dev-qt/qtsql/qtsql-5.15.14.ebuild
+++ b/dev-qt/qtsql/qtsql-5.15.14.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 if [[ ${PV} != *9999* ]]; then
 	QT5_KDEPATCHSET_REV=1
-	KEYWORDS="amd64 arm arm64 ~hppa ~loong ppc ppc64 ~riscv ~sparc x86"
+	KEYWORDS="amd64 arm arm64 ~hppa ~loong ppc ppc64 ~riscv x86"
 fi
 
 QT5_MODULE="qtbase"

--- a/dev-qt/qtsql/qtsql-5.15.16.ebuild
+++ b/dev-qt/qtsql/qtsql-5.15.16.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 if [[ ${PV} != *9999* ]]; then
 	QT5_KDEPATCHSET_REV=1
-	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ppc ppc64 ~riscv ~sparc x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ppc ppc64 ~riscv x86"
 fi
 
 QT5_MODULE="qtbase"

--- a/dev-qt/qtsvg/qtsvg-5.15.14.ebuild
+++ b/dev-qt/qtsvg/qtsvg-5.15.14.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 if [[ ${PV} != *9999* ]]; then
 	QT5_KDEPATCHSET_REV=1
-	KEYWORDS="amd64 arm arm64 ~hppa ~loong ppc ppc64 ~riscv ~sparc x86"
+	KEYWORDS="amd64 arm arm64 ~hppa ~loong ppc ppc64 ~riscv x86"
 fi
 
 inherit qt5-build

--- a/dev-qt/qtsvg/qtsvg-5.15.16.ebuild
+++ b/dev-qt/qtsvg/qtsvg-5.15.16.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 if [[ ${PV} != *9999* ]]; then
 	QT5_KDEPATCHSET_REV=1
-	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ppc ppc64 ~riscv ~sparc x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ppc ppc64 ~riscv x86"
 fi
 
 inherit qt5-build

--- a/dev-qt/qttest/qttest-5.15.14.ebuild
+++ b/dev-qt/qttest/qttest-5.15.14.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 if [[ ${PV} != *9999* ]]; then
 	QT5_KDEPATCHSET_REV=1
-	KEYWORDS="amd64 arm arm64 ~hppa ~loong ppc ppc64 ~riscv ~sparc x86"
+	KEYWORDS="amd64 arm arm64 ~hppa ~loong ppc ppc64 ~riscv x86"
 fi
 
 QT5_MODULE="qtbase"

--- a/dev-qt/qttest/qttest-5.15.16.ebuild
+++ b/dev-qt/qttest/qttest-5.15.16.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 if [[ ${PV} != *9999* ]]; then
 	QT5_KDEPATCHSET_REV=1
-	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ppc ppc64 ~riscv ~sparc x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ppc ppc64 ~riscv x86"
 fi
 
 QT5_MODULE="qtbase"

--- a/dev-qt/qttools/qttools-6.7.2.ebuild
+++ b/dev-qt/qttools/qttools-6.7.2.ebuild
@@ -16,7 +16,7 @@ inherit desktop llvm-r1 optfeature qt6-build
 DESCRIPTION="Qt Tools Collection"
 
 if [[ ${QT6_BUILD_TYPE} == release ]]; then
-	KEYWORDS="amd64 arm arm64 ~hppa ~loong ppc ppc64 ~riscv ~sparc x86"
+	KEYWORDS="amd64 arm arm64 ~hppa ~loong ppc ppc64 ~riscv x86"
 fi
 
 IUSE="

--- a/dev-qt/qttools/qttools-6.7.3.ebuild
+++ b/dev-qt/qttools/qttools-6.7.3.ebuild
@@ -16,7 +16,7 @@ inherit desktop llvm-r1 optfeature qt6-build
 DESCRIPTION="Qt Tools Collection"
 
 if [[ ${QT6_BUILD_TYPE} == release ]]; then
-	KEYWORDS="amd64 arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~sparc x86"
+	KEYWORDS="amd64 arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv x86"
 fi
 
 IUSE="

--- a/dev-qt/qttools/qttools-6.8.1.ebuild
+++ b/dev-qt/qttools/qttools-6.8.1.ebuild
@@ -16,7 +16,7 @@ inherit desktop llvm-r1 optfeature qt6-build
 DESCRIPTION="Qt Tools Collection"
 
 if [[ ${QT6_BUILD_TYPE} == release ]]; then
-	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~x86"
 fi
 
 IUSE="

--- a/dev-qt/qttools/qttools-6.8.9999.ebuild
+++ b/dev-qt/qttools/qttools-6.8.9999.ebuild
@@ -16,7 +16,7 @@ inherit desktop llvm-r1 optfeature qt6-build
 DESCRIPTION="Qt Tools Collection"
 
 if [[ ${QT6_BUILD_TYPE} == release ]]; then
-	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~x86"
 fi
 
 IUSE="

--- a/dev-qt/qttools/qttools-6.9.9999.ebuild
+++ b/dev-qt/qttools/qttools-6.9.9999.ebuild
@@ -16,7 +16,7 @@ inherit desktop llvm-r1 optfeature qt6-build
 DESCRIPTION="Qt Tools Collection"
 
 if [[ ${QT6_BUILD_TYPE} == release ]]; then
-	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~x86"
 fi
 
 IUSE="

--- a/dev-qt/qttools/qttools-6.9999.ebuild
+++ b/dev-qt/qttools/qttools-6.9999.ebuild
@@ -16,7 +16,7 @@ inherit desktop llvm-r1 optfeature qt6-build
 DESCRIPTION="Qt Tools Collection"
 
 if [[ ${QT6_BUILD_TYPE} == release ]]; then
-	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~x86"
 fi
 
 IUSE="

--- a/dev-qt/qttranslations/qttranslations-5.15.14.ebuild
+++ b/dev-qt/qttranslations/qttranslations-5.15.14.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 if [[ ${PV} != *9999* ]]; then
-	KEYWORDS="amd64 arm arm64 ~hppa ~loong ppc ppc64 ~riscv ~sparc x86"
+	KEYWORDS="amd64 arm arm64 ~hppa ~loong ppc ppc64 ~riscv x86"
 fi
 
 inherit qt5-build

--- a/dev-qt/qttranslations/qttranslations-5.15.16.ebuild
+++ b/dev-qt/qttranslations/qttranslations-5.15.16.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 if [[ ${PV} != *9999* ]]; then
-	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ppc ppc64 ~riscv ~sparc x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ppc ppc64 ~riscv x86"
 fi
 
 inherit qt5-build

--- a/dev-qt/qttranslations/qttranslations-6.7.2.ebuild
+++ b/dev-qt/qttranslations/qttranslations-6.7.2.ebuild
@@ -9,7 +9,7 @@ inherit qt6-build
 DESCRIPTION="Translation files for the Qt6 framework"
 
 if [[ ${QT6_BUILD_TYPE} == release ]]; then
-	KEYWORDS="amd64 arm arm64 ~hppa ~loong ppc ppc64 ~riscv ~sparc x86"
+	KEYWORDS="amd64 arm arm64 ~hppa ~loong ppc ppc64 ~riscv x86"
 fi
 
 DEPEND="~dev-qt/qtbase-${PV}:6"

--- a/dev-qt/qttranslations/qttranslations-6.7.3.ebuild
+++ b/dev-qt/qttranslations/qttranslations-6.7.3.ebuild
@@ -9,7 +9,7 @@ inherit qt6-build
 DESCRIPTION="Translation files for the Qt6 framework"
 
 if [[ ${QT6_BUILD_TYPE} == release ]]; then
-	KEYWORDS="amd64 arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~sparc x86"
+	KEYWORDS="amd64 arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv x86"
 fi
 
 DEPEND="~dev-qt/qtbase-${PV}:6"

--- a/dev-qt/qttranslations/qttranslations-6.8.1.ebuild
+++ b/dev-qt/qttranslations/qttranslations-6.8.1.ebuild
@@ -9,7 +9,7 @@ inherit qt6-build
 DESCRIPTION="Translation files for the Qt6 framework"
 
 if [[ ${QT6_BUILD_TYPE} == release ]]; then
-	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~x86"
 fi
 
 DEPEND="~dev-qt/qtbase-${PV}:6"

--- a/dev-qt/qttranslations/qttranslations-6.8.9999.ebuild
+++ b/dev-qt/qttranslations/qttranslations-6.8.9999.ebuild
@@ -9,7 +9,7 @@ inherit qt6-build
 DESCRIPTION="Translation files for the Qt6 framework"
 
 if [[ ${QT6_BUILD_TYPE} == release ]]; then
-	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~x86"
 fi
 
 DEPEND="~dev-qt/qtbase-${PV}:6"

--- a/dev-qt/qttranslations/qttranslations-6.9.9999.ebuild
+++ b/dev-qt/qttranslations/qttranslations-6.9.9999.ebuild
@@ -9,7 +9,7 @@ inherit qt6-build
 DESCRIPTION="Translation files for the Qt6 framework"
 
 if [[ ${QT6_BUILD_TYPE} == release ]]; then
-	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~x86"
 fi
 
 DEPEND="~dev-qt/qtbase-${PV}:6"

--- a/dev-qt/qttranslations/qttranslations-6.9999.ebuild
+++ b/dev-qt/qttranslations/qttranslations-6.9999.ebuild
@@ -9,7 +9,7 @@ inherit qt6-build
 DESCRIPTION="Translation files for the Qt6 framework"
 
 if [[ ${QT6_BUILD_TYPE} == release ]]; then
-	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~x86"
 fi
 
 DEPEND="~dev-qt/qtbase-${PV}:6"

--- a/dev-qt/qtwayland/qtwayland-5.15.14.ebuild
+++ b/dev-qt/qtwayland/qtwayland-5.15.14.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 if [[ ${PV} != *9999* ]]; then
 	QT5_KDEPATCHSET_REV=1
-	KEYWORDS="amd64 arm arm64 ~hppa ~loong ppc ppc64 ~riscv ~sparc x86"
+	KEYWORDS="amd64 arm arm64 ~hppa ~loong ppc ppc64 ~riscv x86"
 fi
 
 inherit qt5-build

--- a/dev-qt/qtwayland/qtwayland-5.15.16-r1.ebuild
+++ b/dev-qt/qtwayland/qtwayland-5.15.16-r1.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 if [[ ${PV} != *9999* ]]; then
 	QT5_KDEPATCHSET_REV=2
-	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ppc ppc64 ~riscv ~sparc x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ppc ppc64 ~riscv x86"
 fi
 
 inherit qt5-build

--- a/dev-qt/qtwayland/qtwayland-6.7.2-r3.ebuild
+++ b/dev-qt/qtwayland/qtwayland-6.7.2-r3.ebuild
@@ -8,7 +8,7 @@ inherit qt6-build
 DESCRIPTION="Wayland platform plugin for Qt"
 
 if [[ ${QT6_BUILD_TYPE} == release ]]; then
-	KEYWORDS="amd64 arm arm64 ~loong ppc ppc64 ~riscv ~sparc x86"
+	KEYWORDS="amd64 arm arm64 ~loong ppc ppc64 ~riscv x86"
 fi
 
 IUSE="accessibility compositor qml vulkan"

--- a/dev-qt/qtwayland/qtwayland-6.7.3-r1.ebuild
+++ b/dev-qt/qtwayland/qtwayland-6.7.3-r1.ebuild
@@ -8,7 +8,7 @@ inherit qt6-build
 DESCRIPTION="Wayland platform plugin for Qt"
 
 if [[ ${QT6_BUILD_TYPE} == release ]]; then
-	KEYWORDS="amd64 arm ~arm64 ~loong ~ppc ~ppc64 ~riscv ~sparc x86"
+	KEYWORDS="amd64 arm ~arm64 ~loong ~ppc ~ppc64 ~riscv x86"
 fi
 
 IUSE="accessibility compositor qml vulkan"

--- a/dev-qt/qtwayland/qtwayland-6.8.1.ebuild
+++ b/dev-qt/qtwayland/qtwayland-6.8.1.ebuild
@@ -8,7 +8,7 @@ inherit qt6-build
 DESCRIPTION="Wayland platform plugin for Qt"
 
 if [[ ${QT6_BUILD_TYPE} == release ]]; then
-	KEYWORDS="~amd64 ~arm ~arm64 ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~loong ~ppc ~ppc64 ~riscv ~x86"
 fi
 
 IUSE="accessibility compositor gnome qml vulkan"

--- a/dev-qt/qtwayland/qtwayland-6.8.9999.ebuild
+++ b/dev-qt/qtwayland/qtwayland-6.8.9999.ebuild
@@ -8,7 +8,7 @@ inherit qt6-build
 DESCRIPTION="Wayland platform plugin for Qt"
 
 if [[ ${QT6_BUILD_TYPE} == release ]]; then
-	KEYWORDS="~amd64 ~arm ~arm64 ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~loong ~ppc ~ppc64 ~riscv ~x86"
 fi
 
 IUSE="accessibility compositor gnome qml vulkan"

--- a/dev-qt/qtwayland/qtwayland-6.9.9999.ebuild
+++ b/dev-qt/qtwayland/qtwayland-6.9.9999.ebuild
@@ -8,7 +8,7 @@ inherit qt6-build
 DESCRIPTION="Wayland platform plugin for Qt"
 
 if [[ ${QT6_BUILD_TYPE} == release ]]; then
-	KEYWORDS="~amd64 ~arm ~arm64 ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~loong ~ppc ~ppc64 ~riscv ~x86"
 fi
 
 IUSE="accessibility compositor gnome qml vulkan"

--- a/dev-qt/qtwayland/qtwayland-6.9999.ebuild
+++ b/dev-qt/qtwayland/qtwayland-6.9999.ebuild
@@ -8,7 +8,7 @@ inherit qt6-build
 DESCRIPTION="Wayland platform plugin for Qt"
 
 if [[ ${QT6_BUILD_TYPE} == release ]]; then
-	KEYWORDS="~amd64 ~arm ~arm64 ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~loong ~ppc ~ppc64 ~riscv ~x86"
 fi
 
 IUSE="accessibility compositor gnome qml vulkan"

--- a/dev-qt/qtwaylandscanner/qtwaylandscanner-5.15.14.ebuild
+++ b/dev-qt/qtwaylandscanner/qtwaylandscanner-5.15.14.ebuild
@@ -9,7 +9,7 @@ inherit qt5-build
 DESCRIPTION="Tool that generates certain boilerplate C++ code from Wayland protocol xml spec"
 
 if [[ ${QT5_BUILD_TYPE} == release ]]; then
-	KEYWORDS="amd64 arm arm64 ~hppa ~loong ppc ppc64 ~riscv ~sparc x86"
+	KEYWORDS="amd64 arm arm64 ~hppa ~loong ppc ppc64 ~riscv x86"
 fi
 
 DEPEND="=dev-qt/qtcore-${QT5_PV}*:5="

--- a/dev-qt/qtwaylandscanner/qtwaylandscanner-5.15.16.ebuild
+++ b/dev-qt/qtwaylandscanner/qtwaylandscanner-5.15.16.ebuild
@@ -9,7 +9,7 @@ inherit qt5-build
 DESCRIPTION="Tool that generates certain boilerplate C++ code from Wayland protocol xml spec"
 
 if [[ ${QT5_BUILD_TYPE} == release ]]; then
-	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ppc ppc64 ~riscv ~sparc x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ppc ppc64 ~riscv x86"
 fi
 
 DEPEND="=dev-qt/qtcore-${QT5_PV}*:5="

--- a/dev-qt/qtwebsockets/qtwebsockets-5.15.14.ebuild
+++ b/dev-qt/qtwebsockets/qtwebsockets-5.15.14.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 if [[ ${PV} != *9999* ]]; then
 	QT5_KDEPATCHSET_REV=1
-	KEYWORDS="amd64 arm arm64 ~hppa ~loong ~ppc ppc64 ~riscv ~sparc x86"
+	KEYWORDS="amd64 arm arm64 ~hppa ~loong ~ppc ppc64 ~riscv x86"
 fi
 
 inherit qt5-build

--- a/dev-qt/qtwebsockets/qtwebsockets-5.15.16.ebuild
+++ b/dev-qt/qtwebsockets/qtwebsockets-5.15.16.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 if [[ ${PV} != *9999* ]]; then
 	QT5_KDEPATCHSET_REV=1
-	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ppc64 ~riscv ~sparc x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ppc64 ~riscv x86"
 fi
 
 inherit qt5-build

--- a/dev-qt/qtwidgets/qtwidgets-5.15.14.ebuild
+++ b/dev-qt/qtwidgets/qtwidgets-5.15.14.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 if [[ ${PV} != *9999* ]]; then
 	QT5_KDEPATCHSET_REV=1
-	KEYWORDS="amd64 arm arm64 ~hppa ~loong ppc ppc64 ~riscv ~sparc x86"
+	KEYWORDS="amd64 arm arm64 ~hppa ~loong ppc ppc64 ~riscv x86"
 fi
 
 QT5_MODULE="qtbase"

--- a/dev-qt/qtwidgets/qtwidgets-5.15.16.ebuild
+++ b/dev-qt/qtwidgets/qtwidgets-5.15.16.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 if [[ ${PV} != *9999* ]]; then
 	QT5_KDEPATCHSET_REV=1
-	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ppc ppc64 ~riscv ~sparc x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ppc ppc64 ~riscv x86"
 fi
 
 QT5_MODULE="qtbase"

--- a/dev-qt/qtx11extras/qtx11extras-5.15.14.ebuild
+++ b/dev-qt/qtx11extras/qtx11extras-5.15.14.ebuild
@@ -8,7 +8,7 @@ inherit qt5-build
 DESCRIPTION="Linux/X11-specific support library for the Qt5 framework"
 
 if [[ ${QT5_BUILD_TYPE} == release ]]; then
-	KEYWORDS="amd64 arm arm64 ~hppa ~loong ppc ppc64 ~riscv ~sparc x86"
+	KEYWORDS="amd64 arm arm64 ~hppa ~loong ppc ppc64 ~riscv x86"
 fi
 
 IUSE=""

--- a/dev-qt/qtx11extras/qtx11extras-5.15.16.ebuild
+++ b/dev-qt/qtx11extras/qtx11extras-5.15.16.ebuild
@@ -8,7 +8,7 @@ inherit qt5-build
 DESCRIPTION="Linux/X11-specific support library for the Qt5 framework"
 
 if [[ ${QT5_BUILD_TYPE} == release ]]; then
-	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ppc ppc64 ~riscv ~sparc x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ppc ppc64 ~riscv x86"
 fi
 
 IUSE=""

--- a/dev-qt/qtxml/qtxml-5.15.14.ebuild
+++ b/dev-qt/qtxml/qtxml-5.15.14.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 if [[ ${PV} != *9999* ]]; then
 	QT5_KDEPATCHSET_REV=1
-	KEYWORDS="amd64 arm arm64 ~hppa ~loong ppc ppc64 ~riscv ~sparc x86"
+	KEYWORDS="amd64 arm arm64 ~hppa ~loong ppc ppc64 ~riscv x86"
 fi
 
 QT5_MODULE="qtbase"

--- a/dev-qt/qtxml/qtxml-5.15.16.ebuild
+++ b/dev-qt/qtxml/qtxml-5.15.16.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 if [[ ${PV} != *9999* ]]; then
 	QT5_KDEPATCHSET_REV=1
-	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ppc ppc64 ~riscv ~sparc x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ppc ppc64 ~riscv x86"
 fi
 
 QT5_MODULE="qtbase"

--- a/dev-qt/qtxmlpatterns/qtxmlpatterns-5.15.14.ebuild
+++ b/dev-qt/qtxmlpatterns/qtxmlpatterns-5.15.14.ebuild
@@ -8,7 +8,7 @@ inherit qt5-build
 DESCRIPTION="XPath, XQuery, XSLT, and XML Schema validation library for the Qt5 framework"
 
 if [[ ${QT5_BUILD_TYPE} == release ]]; then
-	KEYWORDS="amd64 arm arm64 ~hppa ~loong ppc ppc64 ~riscv ~sparc x86"
+	KEYWORDS="amd64 arm arm64 ~hppa ~loong ppc ppc64 ~riscv x86"
 fi
 
 IUSE="qml"

--- a/dev-qt/qtxmlpatterns/qtxmlpatterns-5.15.16.ebuild
+++ b/dev-qt/qtxmlpatterns/qtxmlpatterns-5.15.16.ebuild
@@ -8,7 +8,7 @@ inherit qt5-build
 DESCRIPTION="XPath, XQuery, XSLT, and XML Schema validation library for the Qt5 framework"
 
 if [[ ${QT5_BUILD_TYPE} == release ]]; then
-	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ppc ppc64 ~riscv ~sparc x86"
+	KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~loong ppc ppc64 ~riscv x86"
 fi
 
 IUSE="qml"

--- a/profiles/arch/sparc/package.use.mask
+++ b/profiles/arch/sparc/package.use.mask
@@ -1,6 +1,11 @@
 # Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
+# Ionen Wolkens <ionen@gentoo.org> (2024-12-18)
+# dev-qt/* is not keyworded here
+app-text/doxygen gui
+dev-build/cmake gui
+
 # Sam James <sam@gentoo.org> (2024-12-17)
 # dev-lang/ada-bootstrap exists here
 >=sys-devel/gcc-14 -ada
@@ -8,11 +13,6 @@
 # Matt Jolly <kangie@gentoo.org> (2024-12-08)
 # dev-vcs/mercurial is not keyworded on sparc
 app-eselect/eselect-repository mercurial
-
-# Ionen Wolkens <ionen@gentoo.org> (2024-12-02)
-# Needs dev-qt/qtsvg:6 which is not keyworded here (bug #918896),
-# but neither is gnome so integration is not very useful either way.
-dev-qt/qtwayland:6 gnome
 
 # Felix Janda <felix.janda@posteo.de> (2024-10-20)
 # requires dev-libs/libcss and net-libs/libdom to be keyworded
@@ -74,18 +74,9 @@ media-gfx/graphicsmagick jpeg2k
 # Requires dev-util/shelltestrunner
 app-arch/mt-st test
 
-# Ionen Wolkens <ionen@gentoo.org> (2024-04-02)
-# dev-qt/qtsvg:6 is not keyworded here yet (bug #918896)
-dev-qt/qtdeclarative:6 svg
-
 # Eray Aslan <eras@gentoo.org> (2024-03-08)
 # mongodb dependencies are not keyworded
 mail-mta/postfix mongodb
-
-# Ionen Wolkens <ionen@gentoo.org> (2024-02-13)
-# Needs dev-qt/qtquick3d:6 which itself needs media-libs/assimp that
-# is not keyworded here and currently fails tests (bug #924430).
-dev-qt/qtmultimedia:6 qml
 
 # Eray Aslan <eras@gentoo.org> (2024-02-13)
 # tests require dev-db/mongodb which is not keyworded
@@ -145,12 +136,6 @@ dev-python/nbconvert test
 # Violet Purcell <vimproved@inventati.org> (2023-10-12)
 # dev-build/samurai is not keyworded here.
 app-alternatives/ninja samurai
-
-# Andreas Sturmlechner <asturm@gentoo.org> (2023-10-08)
-# Vulkan is not available on sparc.
-dev-qt/qtdeclarative vulkan
-dev-qt/qtgui vulkan
->=dev-qt/qtwayland-5.15.11:5 compositor
 
 # Patrick McLean <chutzpah@gentoo.org> (2023-10-03)
 # sys-apps/s6-linux-init has not been tested on this arch
@@ -432,10 +417,6 @@ net-analyzer/pnp4nagios icinga
 net-im/pidgin gstreamer
 
 # Rolf Eike Beer <eike@sf-mail.de> (2020-04-15)
-# dev-qt/designer is not keyworded on sparc
-x11-libs/qwt designer
-
-# Rolf Eike Beer <eike@sf-mail.de> (2020-04-15)
 # USE=bpf depends on llvm-core/clang which is not keyworded on sparc
 media-libs/libv4l bpf
 
@@ -596,10 +577,6 @@ dev-python/pyquery test
 # Pacho Ramos <pacho@gentoo.org> (2015-11-15)
 # Missing keywords
 >=media-plugins/grilo-plugins-0.2.14 upnp-av
-
-# Davide Pesavento <pesa@gentoo.org> (2015-10-26)
-# Tests require non-keyworded qt5
-dev-qt/qtchooser test
 
 # Sergey Popov <pinkbyte@gentoo.org> (2015-10-24)
 # Not tested

--- a/profiles/arch/sparc/package.use.stable.mask
+++ b/profiles/arch/sparc/package.use.stable.mask
@@ -5,19 +5,11 @@
 # dev-lang/ada-bootstrap exists here (but is not yet marked stable)
 >=sys-devel/gcc-14 ada
 
-# Sam James <sam@gentoo.org> (2024-07-31)
-# Qt 6 not stable here.
-dev-build/cmake gui
-
 # Eli Schwartz <eschwartz93@gmail.com> (2024-02-05)
 # app-text/mupdf is not stable. bug #923811
 net-print/cups-filters pdf
 net-print/libcupsfilters pdf
 net-print/cups-meta pdf
-
-# Sam James <sam@gentoo.org> (2023-12-30)
-# Qt not marked stable here.
-app-text/doxygen gui
 
 # Rolf Eike Beer <eike@sf-mail.de> (2023-12-22)
 # media-libs/libavif isn't stable here

--- a/profiles/arch/sparc/use.mask
+++ b/profiles/arch/sparc/use.mask
@@ -10,7 +10,9 @@
 memcached
 
 # Ionen Wolkens <ionen@gentoo.org> (2024-01-27)
-# Needs bug #918896 for missing Qt6 keywords
+# dev-qt/* is not keyworded here, and is mostly known buggy so that is
+# unlikely to change without real interest (e.g. bug #914033, #916867).
+qt5
 qt6
 
 # matoro <matoro_gentoo@matoro.tk> (2023-06-17)
@@ -232,10 +234,6 @@ alsa_cards_wavefront
 # if a sub-profile want's it, it can -use.mask it
 multilib
 
-# Ben de Groot <yngwin@gentoo.org> (2009-02-11)
-# Both dev-qt/qtphonon and media-sound/phonon are unkeyworded
-phonon
-
 # nvidia toolkit for binary drivers
 cg
 
@@ -252,7 +250,3 @@ llvm
 
 # sys-libs/libseccomp has not been ported to this arch yet #524148
 seccomp
-
-# Ben de Groot <yngwin@gentoo.org> (2015-02-01)
-# please remove when keyworded
-qt5

--- a/x11-misc/synergy/synergy-1.14.1.32.ebuild
+++ b/x11-misc/synergy/synergy-1.14.1.32.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -24,7 +24,7 @@ S=${WORKDIR}/${MY_P}
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 ~arm ~ppc ~ppc64 ~sparc ~x86 ~amd64-linux ~x86-linux"
+KEYWORDS="amd64 ~arm ~ppc ~ppc64 ~x86 ~amd64-linux ~x86-linux"
 IUSE="gui test"
 RESTRICT="!test? ( test )"
 

--- a/x11-misc/xaos/xaos-3.6.ebuild
+++ b/x11-misc/xaos/xaos-3.6.ebuild
@@ -13,7 +13,7 @@ SRC_URI="
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 ~ppc sparc ~x86 ~amd64-linux ~x86-linux"
+KEYWORDS="amd64 ~ppc ~x86 ~amd64-linux ~x86-linux"
 IUSE="aalib doc gtk nls png svga threads X"
 
 RDEPEND="

--- a/x11-misc/xaos/xaos-4.2.1_p20210828.ebuild
+++ b/x11-misc/xaos/xaos-4.2.1_p20210828.ebuild
@@ -18,7 +18,7 @@ S="${WORKDIR}/XaoS-${COMMIT}"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 ppc ~sparc x86 ~amd64-linux ~x86-linux"
+KEYWORDS="amd64 ppc x86 ~amd64-linux ~x86-linux"
 
 RDEPEND="
 	dev-qt/qtgui:5

--- a/x11-misc/xaos/xaos-4.3.3.ebuild
+++ b/x11-misc/xaos/xaos-4.3.3.ebuild
@@ -16,7 +16,7 @@ S="${WORKDIR}/XaoS-release-${PV}"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~amd64 ~ppc ~sparc ~x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~amd64 ~ppc ~x86 ~amd64-linux ~x86-linux"
 
 RDEPEND="dev-qt/qtbase:6[gui,widgets]"
 DEPEND="${RDEPEND}"


### PR DESCRIPTION
Putting this here first just in case anyone wants to speak up and to double-check CI, albeit we hardly lose anything from this and keywords were just giving headaches (I'm sure xaos sparc users will be devastated).

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
