### PR TITLE
dev-build/cmake: improve errant files check

### DIFF
--- a/dev-build/cmake/cmake-9999.ebuild
+++ b/dev-build/cmake/cmake-9999.ebuild
@@ -126,6 +126,33 @@ cmake_src_bootstrap() {
 		|| die "Bootstrap failed"
 }
 
+pkg_pretend() {
+	if [[ -z ${EPREFIX} ]] ; then
+		local file
+		local errant_files=()
+
+		# See bug #599684 and  bug #753581 (at least)
+		for file in /etc/arch-release /etc/redhat-release /etc/debian_version ; do
+			if [[ -e $file ]]; then
+				errant_files+=("$file")
+			fi
+		done
+
+		# If errant files exist
+		if [[ ${#errant_files[@]} -gt 0 ]]; then
+			eerror "Errant files found!"
+			eerror "The presence of these files is known to confuse CMake's"
+			eerror "library path logic. Please (re)move these files:"
+
+			for file in "${errant_files[@]}"; do
+				eerror " mv ${file} ${file}.bak"
+			done
+
+			die "Stray files found in /etc/, see above message"
+		fi
+	fi
+}
+
 src_unpack() {
 	if [[ ${PV} == 9999 ]] ; then
 		git-r3_src_unpack
@@ -278,17 +305,6 @@ src_install() {
 }
 
 pkg_postinst() {
-	if [[ -z ${EPREFIX} ]] ; then
-		local file
-		# See bug #599684 and  bug #753581 (at least)
-		for file in /etc/arch-release /etc/redhat-release /etc/debian_version ; do
-			eerror "Errant ${file} found!"
-			eerror "The presence of these files is known to confuse CMake's"
-			eerror "library path logic. Please (re)move this file:"
-			eerror " mv ${file} ${file}.bak"
-		done
-	fi
-
 	if use gui; then
 		xdg_icon_cache_update
 		xdg_desktop_database_update


### PR DESCRIPTION
Improved errant files check and moved it to pkg_pretend

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
