### PR TITLE
dev-cpp/tbb: reinstate MacOS support in the newest ebuild

### DIFF
--- a/dev-cpp/tbb/tbb-2022.0.0-r1.ebuild
+++ b/dev-cpp/tbb/tbb-2022.0.0-r1.ebuild
@@ -14,11 +14,11 @@ LICENSE="Apache-2.0"
 # https://github.com/oneapi-src/oneTBB/blob/master/CMakeLists.txt#L53
 # libtbb<SONAME>-libtbbmalloc<SONAME>-libtbbbind<SONAME>
 SLOT="0/12.14-2.14-3.14"
-KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~ppc ~ppc64 ~riscv ~sparc ~x86 ~amd64-linux ~x86-linux ~x64-macos"
 IUSE="test"
 RESTRICT="!test? ( test )"
 
-RDEPEND="sys-apps/hwloc:="
+RDEPEND="!kernel_Darwin? ( sys-apps/hwloc:= )"
 DEPEND="${RDEPEND}"
 BDEPEND="virtual/pkgconfig"
 


### PR DESCRIPTION
This PR fixes the accidental MacOS drop from my last PR (https://github.com/gentoo/gentoo/pull/39781) spotted by @Nowa-Ammerlaan.

~arm64-macos is supported only by `tbb-2021.9.0` so I am not reinstating it.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
