### PR TITLE
dev-libs/cdk: fix handling of -lcdk or -lcdkw

### DIFF
--- a/dev-libs/cdk/cdk-5.0.20240619-r1.ebuild
+++ b/dev-libs/cdk/cdk-5.0.20240619-r1.ebuild
@@ -26,6 +26,10 @@ BDEPEND="
 	verify-sig? ( sec-keys/openpgp-keys-thomasdickey )
 "
 
+PATCHES=(
+	"${FILESDIR}/${PN}-5.0.20240619-xlib.patch"
+)
+
 src_configure() {
 	if [[ ${CHOST} == *-*-darwin* ]] ; then
 		export ac_cv_prog_LIBTOOL=glibtool

--- a/dev-libs/cdk/files/cdk-5.0.20240619-xlib.patch
+++ b/dev-libs/cdk/files/cdk-5.0.20240619-xlib.patch
@@ -1,0 +1,28 @@
+https://bugs.gentoo.org/831226
+
+lib name is depend on USE flag 'unicode', but for unknown reason,
+upstream remove XLIB in release 5.0.20240619 (always -lcdk instead
+of -lcdkw if unicode is enabled), which cause link failed if
+USE="unicode".
+
+diff --git a/cdk-config.in b/cdk-config.in
+index 19b2972..aa0b2c8 100644
+--- a/cdk-config.in
++++ b/cdk-config.in
+@@ -41,6 +41,7 @@ same_prefix=yes
+ same_exec_prefix=yes
+ 
+ THIS="@PACKAGE@"
++XLIB="@LIB_ROOTNAME@"
+ 
+ [ $# = 0 ] && exec @SHELL@ "$0" --error
+ 
+@@ -66,7 +67,7 @@ while [ $# -gt 0 ]; do
+ 
+ 	eval LDFLAGS='"@LDFLAGS@"'
+ 	eval LIBS='"@LIBS@"'
+-	LIBS="-l${THIS} $LIBS"
++	LIBS="-l${XLIB} $LIBS"
+ 
+ 	# If the directory given by --libdir is not in the LDFLAGS+LIBS set,
+ 	# prepend it to LDFLAGS to help link this application's library.

--- a/dev-libs/cdk/metadata.xml
+++ b/dev-libs/cdk/metadata.xml
@@ -1,7 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<!-- maintainer-needed -->
+	<maintainer type="person" proxied="yes">
+		<email>zhixu.liu@gmail.com</email>
+		<name>Z. Liu</name>
+	</maintainer>
+	<maintainer type="project" proxied="proxy">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
 	<upstream>
 		<changelog>https://dickey.his.com/cdk/CHANGES.html</changelog>
 		<remote-id type="github">ThomasDickey/cdk-snapshots</remote-id>


### PR DESCRIPTION
lib name is depend on USE flag 'unicode', but for unknown reason, upstream remove XLIB in release 5.0.20240619 (always -lcdk instead of -lcdkw if unicode is enabled), which cause link failed if USE="unicode".

Closes: https://bugs.gentoo.org/831226

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
