### PR TITLE
dev-libs/glib: 2.80.5-r1: Fix gobject-introspection bootstrap

### DIFF
--- a/dev-libs/glib/glib-2.80.5-r1.ebuild
+++ b/dev-libs/glib/glib-2.80.5-r1.ebuild
@@ -288,6 +288,9 @@ multilib_src_configure() {
 			export LD_LIBRARY_PATH="${BUILD_DIR}/${gliblib}:${LD_LIBRARY_PATH}"
 		done
 
+		# Add the path to introspection libraries so that glib can call gir utilities
+		export LD_LIBRARY_PATH="${INTROSPECTION_LIB_DIR}:${LD_LIBRARY_PATH}"
+
 		# Add the paths to the gobject-introspection python modules to python path so they can be imported
 		export PYTHONPATH="${INTROSPECTION_LIB_DIR}/gobject-introspection:${PYTHONPATH}"
 	fi


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/946735

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
