### PR TITLE
dev-libs/udis86: update PYTHON_COMPAT

### DIFF
--- a/dev-libs/udis86/udis86-1.7.2-r1.ebuild
+++ b/dev-libs/udis86/udis86-1.7.2-r1.ebuild
@@ -3,13 +3,13 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{10..11} )
+PYTHON_COMPAT=( python3_{10..13} )
 PYTHON_REQ_USE="xml(+)"
 
 inherit autotools multilib-minimal python-any-r1
 
 DESCRIPTION="Disassembler library for the x86/-64 architecture sets"
-HOMEPAGE="http://udis86.sourceforge.net/"
+HOMEPAGE="https://udis86.sourceforge.net/"
 SRC_URI="https://downloads.sourceforge.net/${PN}/${P}.tar.gz"
 
 LICENSE="BSD"
@@ -22,6 +22,7 @@ BDEPEND="
 	${PYTHON_DEPS}
 	test? (
 		amd64? ( dev-lang/yasm )
+		arm64? ( dev-lang/yasm )
 		x86? ( dev-lang/yasm )
 	)"
 


### PR DESCRIPTION
Also fixes test deps for arm64

Closes: https://bugs.gentoo.org/929431

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
