### PR TITLE
dev-libs/glib: Backport upstream fix for autoptr test

### DIFF
--- a/dev-libs/glib/files/glib-2.80.5-tests-autoptr-ffi.patch
+++ b/dev-libs/glib/files/glib-2.80.5-tests-autoptr-ffi.patch
@@ -1,0 +1,29 @@
+https://gitlab.gnome.org/GNOME/glib/-/commit/99382cfb4b5edf56f7c62eccc155f361a640298a.patch
+https://bugs.gentoo.org/946789
+
+From 99382cfb4b5edf56f7c62eccc155f361a640298a Mon Sep 17 00:00:00 2001
+From: Andoni Morales Alastruey <ylatuya@gmail.com>
+Date: Tue, 28 May 2024 17:26:38 +0200
+Subject: [PATCH] girepository: fix autoptr tests build
+
+In macOS compilation fails with the following error:
+```
+In file included from ../girepository/tests/autoptr.c:23:
+../girepository/girffi.h:30:10: fatal error: 'ffi.h' file not found
+```
+---
+ girepository/tests/meson.build | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/girepository/tests/meson.build b/girepository/tests/meson.build
+index 6fa947cfdf..f9928267d5 100644
+--- a/girepository/tests/meson.build
++++ b/girepository/tests/meson.build
+@@ -72,6 +72,7 @@ if enable_gir
+   if cc.get_id() != 'msvc'
+     girepository_tests += {
+       'autoptr-girepository' : {
++        'dependencies': [libffi_dep],
+         'source' : 'autoptr.c',
+         'depends': gio_gir_testing_dep,
+       },

--- a/dev-libs/glib/glib-2.80.5-r1.ebuild
+++ b/dev-libs/glib/glib-2.80.5-r1.ebuild
@@ -93,6 +93,7 @@ MULTILIB_CHOST_TOOLS=(
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-2.64.1-mark-gdbus-server-auth-test-flaky.patch
+	"${FILESDIR}"/${P}-tests-autoptr-ffi.patch
 )
 
 python_check_deps() {


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/946789

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.