### PR TITLE
www-servers/nginx: add lua config if USE="nginx_modules_http_lua"

### DIFF
--- a/www-servers/nginx/files/nginx.conf-r3
+++ b/www-servers/nginx/files/nginx.conf-r3
@@ -67,4 +67,6 @@ http {
 
 	#	root /var/www/localhost/htdocs;
 	#}
+
+	include /etc/nginx/*_vhost.conf;
 }

--- a/www-servers/nginx/nginx-1.26.2-r8.ebuild
+++ b/www-servers/nginx/nginx-1.26.2-r8.ebuild
@@ -808,6 +808,12 @@ src_install() {
 	if use nginx_modules_http_lua; then
 		docinto ${HTTP_LUA_MODULE_P}
 		dodoc "${HTTP_LUA_MODULE_WD}"/README.markdown
+		insinto /etc/nginx
+		newins - 00-config.lua_vhost.conf <<-EOF
+			lua_package_path "/etc/nginx/?.lua;;";
+		EOF
+		insinto /etc/nginx/resty
+		touch "${ED}"/etc/nginx/resty/core.lua
 	fi
 
 	if use nginx_modules_http_auth_pam; then


### PR DESCRIPTION
Start from commit
https://github.com/openresty/lua-nginx-module/commit/60736e686ac5ca5af9a5bf118cb9bd4a9126cefc 'resty.core' is now mandatorily loaded, and the 'lua_load_resty_core' directive is deprecated. See also https://github.com/openresty/lua-nginx-module/pull/1501

If nginx is built with USE="nginx_modules_http_lua", there must have resty.core (OpenResty or a module named 'resty') exist, otherwise nginx will fail to start w/ messages like bellow:

  nginx: [alert] failed to load the 'resty.core' module (https://github.com/openresty/lua-resty-core); ensure you are using an OpenResty release from https://openresty.org/en/download.html (reason: module 'resty.core' not found:
          no field package.preload['resty.core']
          no file './resty/core.lua'
          no file '/usr/share/luajit-2.1.0-beta3/resty/core.lua'
          no file '/usr/local/share/lua/5.1/resty/core.lua'
          no file '/usr/local/share/lua/5.1/resty/core/init.lua'
          no file '/usr/share/lua/5.1/resty/core.lua'
          no file '/usr/share/lua/5.1/resty/core/init.lua'
          no file './resty/core.so'
          no file '/usr/local/lib/lua/5.1/resty/core.so'
          no file '/usr/lib64/lua/5.1/resty/core.so'
          no file '/usr/local/lib/lua/5.1/loadall.so'
          no file './resty.so'
          no file '/usr/local/lib/lua/5.1/resty.so'
          no file '/usr/lib64/lua/5.1/resty.so'
          no file '/usr/local/lib/lua/5.1/loadall.so') in /etc/nginx/nginx.conf:47

Closes: https://bugs.gentoo.org/726728

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
