### PR TITLE
sys-apps/dbus: python interpeter is required unconditionally

### DIFF
--- a/sys-apps/dbus/dbus-1.15.8.ebuild
+++ b/sys-apps/dbus/dbus-1.15.8.ebuild
@@ -25,6 +25,7 @@ IUSE="debug doc elogind selinux static-libs systemd test valgrind X"
 RESTRICT="!test? ( test )"
 
 BDEPEND="
+	${PYTHON_DEPS}
 	acct-user/messagebus
 	app-text/xmlto
 	app-text/docbook-xml-dtd:4.4
@@ -48,10 +49,7 @@ COMMON_DEPEND="
 DEPEND="
 	${COMMON_DEPEND}
 	dev-libs/expat
-	test? (
-		${PYTHON_DEPS}
-		>=dev-libs/glib-2.40:2
-	)
+	test? ( >=dev-libs/glib-2.40:2 )
 	valgrind? ( >=dev-debug/valgrind-3.6 )
 	X? ( x11-base/xorg-proto )
 "
@@ -72,7 +70,8 @@ PATCHES=(
 )
 
 pkg_setup() {
-	use test && python-any-r1_pkg_setup
+	# Python interpeter required unconditionally (bug #932517)
+	python-any-r1_pkg_setup
 
 	if use kernel_linux; then
 		CONFIG_CHECK="~EPOLL"


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/932517

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
