### PR TITLE
verify-sig.eclass: Add verify-sig_uncompress_verify_unpack 

### DIFF
--- a/sys-kernel/vanilla-kernel/vanilla-kernel-6.12.6.ebuild
+++ b/sys-kernel/vanilla-kernel/vanilla-kernel-6.12.6.ebuild
@@ -60,10 +60,8 @@ VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/openpgp-keys/kernel.org.asc
 
 src_unpack() {
 	if use verify-sig; then
-		einfo "Unpacking linux-${PV}.tar.xz ..."
-		verify-sig_verify_detached - "${DISTDIR}"/linux-${PV}.tar.sign \
-			< <(xz -cd "${DISTDIR}"/linux-${PV}.tar.xz | tee >(tar -xf -))
-		assert "Unpack failed"
+		verify-sig_uncompress_verify_unpack \
+			"${DISTDIR}"/linux-${PV}.tar.{xz,sign}
 		unpack "gentoo-kernel-config-${GENTOO_CONFIG_VER}.tar.gz"
 	else
 		default


### PR DESCRIPTION
Add a function that carries out the surprisingly common pattern of uncompress-verify-unpack found in kernel.org distfiles, where the signature is created against the uncompressed archive rather than the actual distfile.  Just like the code currently copied across ebuilds, the function uses a pipeline to simultaneously decompress, unpack and verify the signature, except with correct error handling this time.

Note that the code technically implies that the archive will be unpacked even if the signature does not match -- the ebuild will abort afterwards.

Thanks to Ulrich Müller for the suggestion!