### PR TITLE
sys-fs/snapraid: Add to proxy maintainer; post-install hints

### DIFF
--- a/sys-fs/snapraid/snapraid-12.3-r1.ebuild
+++ b/sys-fs/snapraid/snapraid-12.3-r1.ebuild
@@ -1,0 +1,27 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools
+
+DESCRIPTION="a backup program for disk array for home media centers"
+HOMEPAGE="https://www.snapraid.it/"
+SRC_URI="https://github.com/amadvance/${PN}/releases/download/v${PV}/${P}.tar.gz"
+
+LICENSE="GPL-3"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+DOCS=( "AUTHORS" "HISTORY" "README" "TODO" "snapraid.conf.example" )
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+pkg_postinst() {
+	elog "To start using SnapRAID, change the example configuration"
+	elog "${EPREFIX}/usr/share/doc/${PF}/snapraid.conf.example.bz2"
+	elog "to fit your needs and copy it to ${EPREFIX}/etc/snapraid.conf"
+}

--- a/sys-fs/snapraid/snapraid-12.3-r1.ebuild
+++ b/sys-fs/snapraid/snapraid-12.3-r1.ebuild
@@ -5,13 +5,16 @@ EAPI=8
 
 inherit autotools
 
-DESCRIPTION="a backup program for disk array for home media centers"
+DESCRIPTION="Backup program with disk array for cold data on existing filesystems"
 HOMEPAGE="https://www.snapraid.it/"
 SRC_URI="https://github.com/amadvance/${PN}/releases/download/v${PV}/${P}.tar.gz"
 
 LICENSE="GPL-3"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
+IUSE="test"
+RESTRICT="!test? ( test )"
+BDEPEND="test? ( sys-apps/smartmontools )"
 
 DOCS=( "AUTHORS" "HISTORY" "README" "TODO" "snapraid.conf.example" )
 


### PR DESCRIPTION
- I have been using snapraid on Windows for years and it is my first time to setup snapraid on my Linux workstation.

- Firstly, I built a single executable from source and have it done the job. Then I found the gentoo package snapraid-12.3 doing quite the same job. Surprisingly found the package laking a maintainer, I learnt ebuild basics and decided to watch or help maintain the package. 

- It is my pleasure to keep an eye on the upstream, discuss the bugs and try fixing around this small and robust package.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
