### PR TITLE
fix_build_crash_alacritty-0.12.3-r1

### DIFF
--- a/x11-terms/alacritty/alacritty-0.12.3-r1.ebuild
+++ b/x11-terms/alacritty/alacritty-0.12.3-r1.ebuild
@@ -303,6 +303,7 @@ src_unpack() {
 }
 
 src_configure() {
+	rust_pkg_setup
 	local myfeatures=(
 		$(usex X x11 '')
 		$(usev wayland)


### PR DESCRIPTION
 Fix this error:
```
 * ERROR: x11-terms/alacritty-0.12.3-r1::gentoo failed (compile phase):
 * CARGO is not set; was rust_pkg_setup run?
```

0.12.3 is a stable version, which does not have many errors related to the keyboard layout, I suggest not deleting it.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
