### PR TITLE
net-nds/openldap: fix build issue with llvm profile

### DIFF
--- a/net-nds/openldap/files/openldap-2.6.1-fix-missing-mapping.v2.patch
+++ b/net-nds/openldap/files/openldap-2.6.1-fix-missing-mapping.v2.patch
@@ -1,0 +1,53 @@
+Fix of lber.mao & ldap.map from Fedora with URL below:
+  https://src.fedoraproject.org/rpms/openldap/raw/rawhide/f/openldap-add-export-symbols-LDAP_CONNECTIONLESS.patch
+
+  From 6779e56fafb0aa8ae5efa7068da34a630b51b530 Mon Sep 17 00:00:00 2001
+  From: Simon Pichugin <spichugi@redhat.com>
+  Date: Fri, 5 Aug 2022 13:23:52 -0700
+  Subject: [PATCH] Add export symbols related to LDAP_CONNECTIONLESS
+
+Upstream Issue: https://bugs.openldap.org/show_bug.cgi?id=9739
+
+But above patch is not complete, 'ber_sockbuf_io_udp' is part of an unsupported
+feature (cldap or ldap over udp), only built when the unsupported
+LDAP_CONNECTIONLESS flag is defined. All the user of 'ber_sockbuf_io_udp'
+are included by #ifdef, so it make no sense to not include it too.
+
+diff --git a/include/lber.h b/include/lber.h
+index 530359dc92..fd4957ddcd 100644
+--- a/include/lber.h
++++ b/include/lber.h
+@@ -590,7 +590,9 @@ LBER_V( Sockbuf_IO ) ber_sockbuf_io_tcp;
+ LBER_V( Sockbuf_IO ) ber_sockbuf_io_readahead;
+ LBER_V( Sockbuf_IO ) ber_sockbuf_io_fd;
+ LBER_V( Sockbuf_IO ) ber_sockbuf_io_debug;
++#ifdef LDAP_CONNECTIONLESS
+ LBER_V( Sockbuf_IO ) ber_sockbuf_io_udp;
++#endif
+ 
+ /*
+  * LBER memory.c
+diff --git a/libraries/liblber/lber.map b/libraries/liblber/lber.map
+index 9a4094b0fe..083cd1f322 100644
+--- a/libraries/liblber/lber.map
++++ b/libraries/liblber/lber.map
+@@ -121,6 +121,7 @@ OPENLDAP_2.200
+     ber_sockbuf_io_fd;
+     ber_sockbuf_io_readahead;
+     ber_sockbuf_io_tcp;
++    ber_sockbuf_io_udp;
+     ber_sockbuf_remove_io;
+     ber_sos_dump;
+     ber_start;
+diff --git a/libraries/libldap/ldap.map b/libraries/libldap/ldap.map
+index b28c9c21e7..021aaba63c 100644
+--- a/libraries/libldap/ldap.map
++++ b/libraries/libldap/ldap.map
+@@ -200,6 +200,7 @@ OPENLDAP_2.200
+     ldap_is_ldap_url;
+     ldap_is_ldapi_url;
+     ldap_is_ldaps_url;
++    ldap_is_ldapc_url;
+     ldap_is_read_ready;
+     ldap_is_write_ready;
+     ldap_ld_free;

--- a/net-nds/openldap/openldap-2.6.4-r4.ebuild
+++ b/net-nds/openldap/openldap-2.6.4-r4.ebuild
@@ -26,7 +26,7 @@ S="${WORKDIR}"/${PN}-OPENLDAP_REL_ENG_${MY_PV}
 LICENSE="OPENLDAP GPL-2"
 # Subslot added for bug #835654
 SLOT="0/$(ver_cut 1-2)"
-KEYWORDS="~alpha amd64 arm arm64 ~hppa ~loong ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux"
 
 IUSE_DAEMON="argon2 +cleartext crypt experimental minimal samba tcpd"
 IUSE_OVERLAY="overlays perl autoca"
@@ -34,17 +34,15 @@ IUSE_OPTIONAL="debug gnutls iodbc odbc sasl ssl selinux static-libs +syslog test
 IUSE_CONTRIB="kerberos kinit pbkdf2 sha2 smbkrb5passwd"
 IUSE_CONTRIB="${IUSE_CONTRIB} cxx"
 IUSE="systemd ${IUSE_DAEMON} ${IUSE_BACKEND} ${IUSE_OVERLAY} ${IUSE_OPTIONAL} ${IUSE_CONTRIB}"
-REQUIRED_USE="
-	cxx? ( sasl )
+REQUIRED_USE="cxx? ( sasl )
 	pbkdf2? ( ssl )
 	test? ( cleartext sasl debug )
 	autoca? ( !gnutls )
 	?? ( test minimal )
-	kerberos? ( ?? ( kinit smbkrb5passwd ) )
-"
+	kerberos? ( ?? ( kinit smbkrb5passwd ) )"
 RESTRICT="!test? ( test )"
 
-SYSTEM_LMDB_VER=0.9.31
+SYSTEM_LMDB_VER=0.9.30
 # openssl is needed to generate lanman-passwords required by samba
 COMMON_DEPEND="
 	kernel_linux? ( sys-apps/util-linux )
@@ -82,22 +80,19 @@ COMMON_DEPEND="
 		)
 	)
 "
-DEPEND="
-	${COMMON_DEPEND}
+DEPEND="${COMMON_DEPEND}
 	sys-apps/groff
 "
-RDEPEND="
-	${COMMON_DEPEND}
+RDEPEND="${COMMON_DEPEND}
 	selinux? ( sec-policy/selinux-ldap )
 "
 
 # The user/group are only used for running daemons which are
 # disabled in minimal builds, so elide the accounts too.
-BDEPEND="
-	!minimal? (
+BDEPEND="!minimal? (
 		acct-group/ldap
 		acct-user/ldap
-	)
+)
 "
 
 # for tracking versions
@@ -147,10 +142,9 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-2.6.1-system-mdb.patch
 	"${FILESDIR}"/${PN}-2.6.1-cloak.patch
 	"${FILESDIR}"/${PN}-2.6.1-flags.patch
-	"${FILESDIR}"/${PN}-2.6.1-fix-missing-mapping.patch
-	"${FILESDIR}"/${PN}-2.6.6-fix-type-mismatch-lloadd.patch
-	"${FILESDIR}"/${PN}-2.6.x-gnutls-pointer-error.patch
-	"${FILESDIR}"/${PN}-2.6.x-slapd-pointer-types.patch
+	"${FILESDIR}"/${PN}-2.6.1-fix-missing-mapping.v2.patch
+	"${FILESDIR}"/${PN}-2.6.4-clang16.patch
+	"${FILESDIR}"/${PN}-2.6.4-libressl.patch #903001
 )
 
 openldap_filecount() {
@@ -401,6 +395,9 @@ build_contrib_module() {
 }
 
 multilib_src_configure() {
+	# Workaround for bug #923334, #938553, #946816
+	append-ldflags $(test-flags-CCLD -Wl,--undefined-version)
+
 	# Optional Features
 	myconf+=(
 		--enable-option-checking
@@ -686,7 +683,7 @@ multilib_src_test() {
 		#TESTS+=( pldif ) # not done by default, so also exclude here
 		#use odbc && TESTS+=( psql ) # not done by default, so also exclude here
 
-		emake -Onone "${TESTS[@]}"
+		emake "${TESTS[@]}"
 	fi
 }
 
@@ -817,7 +814,6 @@ multilib_src_install() {
 multilib_src_install_all() {
 	dodoc ANNOUNCEMENT CHANGES COPYRIGHT README
 	docinto rfc ; dodoc doc/rfc/*.txt
-	rmdir -p "${D}"/var/openldap-lloadd # Created but not used by any part of current codebase.
 }
 
 pkg_preinst() {

--- a/net-nds/openldap/openldap-2.6.6-r3.ebuild
+++ b/net-nds/openldap/openldap-2.6.6-r3.ebuild
@@ -26,7 +26,7 @@ S="${WORKDIR}"/${PN}-OPENLDAP_REL_ENG_${MY_PV}
 LICENSE="OPENLDAP GPL-2"
 # Subslot added for bug #835654
 SLOT="0/$(ver_cut 1-2)"
-KEYWORDS="~alpha amd64 arm arm64 ~hppa ~loong ~mips ppc ppc64 ~riscv ~s390 sparc x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux"
 
 IUSE_DAEMON="argon2 +cleartext crypt experimental minimal samba tcpd"
 IUSE_OVERLAY="overlays perl autoca"
@@ -37,7 +37,7 @@ IUSE="systemd ${IUSE_DAEMON} ${IUSE_BACKEND} ${IUSE_OVERLAY} ${IUSE_OPTIONAL} ${
 REQUIRED_USE="
 	cxx? ( sasl )
 	pbkdf2? ( ssl )
-	test? ( cleartext sasl debug )
+	test? ( cleartext sasl )
 	autoca? ( !gnutls )
 	?? ( test minimal )
 	kerberos? ( ?? ( kinit smbkrb5passwd ) )
@@ -147,7 +147,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-2.6.1-system-mdb.patch
 	"${FILESDIR}"/${PN}-2.6.1-cloak.patch
 	"${FILESDIR}"/${PN}-2.6.1-flags.patch
-	"${FILESDIR}"/${PN}-2.6.1-fix-missing-mapping.patch
+	"${FILESDIR}"/${PN}-2.6.1-fix-missing-mapping.v2.patch
 	"${FILESDIR}"/${PN}-2.6.6-fix-type-mismatch-lloadd.patch
 	"${FILESDIR}"/${PN}-2.6.x-gnutls-pointer-error.patch
 	"${FILESDIR}"/${PN}-2.6.x-slapd-pointer-types.patch
@@ -401,6 +401,9 @@ build_contrib_module() {
 }
 
 multilib_src_configure() {
+	# Workaround for bug #923334, #938553, #946816
+	append-ldflags $(test-flags-CCLD -Wl,--undefined-version)
+
 	# Optional Features
 	myconf+=(
 		--enable-option-checking


### PR DESCRIPTION
openldap define all the dynamic symbols in libraries/{liblber/lber, libldap/ldap}.map, but some of the symbols are available only when the configure option is set. We've found HAVE_TLS, HAVE_CYRUS_SASL, LDAP_CONNECTIONLESS will cause build failed. Issue has been reported to upstream. Gentoo's workaround is to remove the symbol from .map file if the option is not set.

Upstream Bug: https://bugs.openldap.org/show_bug.cgi?id=9739

FreeBSD's Bug: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=277585

Closes: https://bugs.gentoo.org/923334
Closes: https://bugs.gentoo.org/938553
Closes: https://bugs.gentoo.org/946816

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
