### PR TITLE
app-emulation/libvirt: Backport a TPM related crasher

### DIFF
--- a/app-emulation/libvirt/files/libvirt-10.10.0-qemu-tpm-do-not-update-profile-name-for-transient-do.patch
+++ b/app-emulation/libvirt/files/libvirt-10.10.0-qemu-tpm-do-not-update-profile-name-for-transient-do.patch
@@ -1,0 +1,70 @@
+From 81da7a2c2a2d490cddaaa77d3e3b36e210b38bd7 Mon Sep 17 00:00:00 2001
+Message-ID: <81da7a2c2a2d490cddaaa77d3e3b36e210b38bd7.1735210585.git.mprivozn@redhat.com>
+From: =?UTF-8?q?J=C3=A1n=20Tomko?= <jtomko@redhat.com>
+Date: Tue, 3 Dec 2024 12:00:08 +0100
+Subject: [PATCH] qemu: tpm: do not update profile name for transient domains
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+If we do not have a persistent definition, there's no point in
+looking for it since we cannot store it.
+
+Also skip the update if the tpm device(s) in the persistent
+definition are different.
+
+This fixes the crash when starting a transient domain.
+
+https://issues.redhat.com/browse/RHEL-69774
+https://gitlab.com/libvirt/libvirt/-/issues/715
+
+Fixes: d79542eec669eb9c449bb8228179e7a87e768017
+Signed-off-by: Ján Tomko <jtomko@redhat.com>
+Reviewed-by: Jiri Denemark <jdenemar@redhat.com>
+Reviewed-by: Stefan Berger <stefanb@linux.ibm.com>
+Signed-off-by: Michal Privoznik <mprivozn@redhat.com>
+---
+ src/qemu/qemu_extdevice.c | 13 ++++++++++++-
+ src/qemu/qemu_tpm.c       |  2 +-
+ 2 files changed, 13 insertions(+), 2 deletions(-)
+
+diff --git a/src/qemu/qemu_extdevice.c b/src/qemu/qemu_extdevice.c
+index a6f31f9773..954cb323a4 100644
+--- a/src/qemu/qemu_extdevice.c
++++ b/src/qemu/qemu_extdevice.c
+@@ -190,7 +190,18 @@ qemuExtDevicesStart(virQEMUDriver *driver,
+ 
+     for (i = 0; i < def->ntpms; i++) {
+         virDomainTPMDef *tpm = def->tpms[i];
+-        virDomainTPMDef *persistentTPMDef = persistentDef->tpms[i];
++        virDomainTPMDef *persistentTPMDef = NULL;
++
++        if (persistentDef) {
++            /* do not try to update the profile in the persistent definition
++             * if the device does not match */
++            if (persistentDef->ntpms == def->ntpms)
++                persistentTPMDef = persistentDef->tpms[i];
++            if (persistentTPMDef &&
++                (persistentTPMDef->type != tpm->type ||
++                 persistentTPMDef->model != tpm->model))
++                persistentTPMDef = NULL;
++        }
+ 
+         if (tpm->type == VIR_DOMAIN_TPM_TYPE_EMULATOR &&
+             qemuExtTPMStart(driver, vm, tpm, persistentTPMDef,
+diff --git a/src/qemu/qemu_tpm.c b/src/qemu/qemu_tpm.c
+index f223dcb9ae..f5e0184e54 100644
+--- a/src/qemu/qemu_tpm.c
++++ b/src/qemu/qemu_tpm.c
+@@ -773,7 +773,7 @@ qemuTPMEmulatorBuildCommand(virDomainTPMDef *tpm,
+                                 incomingMigration) < 0)
+         goto error;
+ 
+-    if (run_setup && !incomingMigration &&
++    if (run_setup && !incomingMigration && persistentTPMDef &&
+         qemuTPMEmulatorUpdateProfileName(&tpm->data.emulator, persistentTPMDef,
+                                          cfg, saveDef) < 0)
+         goto error;
+-- 
+2.45.2
+

--- a/app-emulation/libvirt/libvirt-10.10.0-r1.ebuild
+++ b/app-emulation/libvirt/libvirt-10.10.0-r1.ebuild
@@ -159,6 +159,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-9.4.0-fix_paths_in_libvirt-guests_sh.patch
 	"${FILESDIR}"/${PN}-9.9.0-do-not-use-sysconfig.patch
 	"${FILESDIR}"/${PN}-10.7.0-fix-paths-for-apparmor.patch
+	"${FILESDIR}"/${PN}-10.10.0-qemu-tpm-do-not-update-profile-name-for-transient-do.patch
 )
 
 python_check_deps() {


### PR DESCRIPTION
When installing a VM, it may happen that layered tools like virt-install will add TPM to domain definition (some guests like Windows 11 require it). But in libvirt-10.10.0 there is a crasher and those layered tools tickle it. Backport a fix from upstream.

Closes: https://bugs.gentoo.org/946930

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
