### PR TITLE
dev-libs/OpenNI2: 2.2_beta2-r2 allow Java higher than 1.8

### DIFF
--- a/dev-libs/OpenNI/OpenNI-1.5.7.10-r4.ebuild
+++ b/dev-libs/OpenNI/OpenNI-1.5.7.10-r4.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 SCM=""
 if [ "${PV#9999}" != "${PV}" ] ; then
@@ -25,16 +25,24 @@ LICENSE="Apache-2.0"
 SLOT="0"
 IUSE="doc java opengl"
 
-RDEPEND="
+COMMON_DEPEND="
 	media-libs/libjpeg-turbo:=
 	virtual/libusb:1
 	virtual/libudev
 	dev-libs/tinyxml
 	opengl? ( media-libs/freeglut !dev-libs/OpenNI2[opengl] )
-	java? ( virtual/jre:1.8 )
 "
-DEPEND="${RDEPEND}
-	java? ( virtual/jdk:1.8 )"
+
+DEPEND="
+	${COMMON_DEPEND}
+	java? ( >=virtual/jdk-1.8:* !dev-libs/OpenNI2[java] )
+"
+
+RDEPEND="
+	${COMMON_DEPEND}
+	java? ( >=virtual/jre-1.8:* !dev-libs/OpenNI2[java] )
+"
+
 BDEPEND="doc? ( app-text/doxygen )"
 
 PATCHES=(
@@ -53,7 +61,8 @@ src_prepare() {
 		echo "" > ${i}
 	done
 
-	find . -type f -print0 | xargs -0 sed -i "s:\".*/SamplesConfig.xml:\"${EPREFIX}/usr/share/${PN}/SamplesConfig.xml:" || die
+	find . -type f -print0 |
+		xargs -0 sed -i "s:\".*/SamplesConfig.xml:\"${EPREFIX}/usr/share/${PN}/SamplesConfig.xml:" || die
 }
 
 src_compile() {

--- a/dev-libs/OpenNI/OpenNI-1.5.7.10-r4.ebuild
+++ b/dev-libs/OpenNI/OpenNI-1.5.7.10-r4.ebuild
@@ -9,7 +9,7 @@ if [ "${PV#9999}" != "${PV}" ] ; then
 	EGIT_REPO_URI="https://github.com/OpenNI/OpenNI"
 fi
 
-inherit ${SCM} flag-o-matic toolchain-funcs java-pkg-opt-2
+inherit ${SCM} eapi9-pipestatus flag-o-matic java-pkg-opt-2 toolchain-funcs
 
 if [ "${PV#9999}" != "${PV}" ] ; then
 	SRC_URI=""
@@ -61,8 +61,10 @@ src_prepare() {
 		echo "" > ${i}
 	done
 
+	local status
 	find . -type f -print0 |
-		xargs -0 sed -i "s:\".*/SamplesConfig.xml:\"${EPREFIX}/usr/share/${PN}/SamplesConfig.xml:" || die
+		xargs -0 sed -i "s:\".*/SamplesConfig.xml:\"${EPREFIX}/usr/share/${PN}/SamplesConfig.xml:"
+	status=$(pipestatus -v) || die "fails to sed SamplesConfig, (PIPESTATUS: ${status})"
 }
 
 src_compile() {

--- a/dev-libs/OpenNI/OpenNI-9999.ebuild
+++ b/dev-libs/OpenNI/OpenNI-9999.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 SCM=""
 if [ "${PV#9999}" != "${PV}" ] ; then
@@ -25,16 +25,24 @@ LICENSE="Apache-2.0"
 SLOT="0"
 IUSE="doc java opengl"
 
-RDEPEND="
+COMMON_DEPEND="
 	media-libs/libjpeg-turbo:=
 	virtual/libusb:1
 	virtual/libudev
 	dev-libs/tinyxml
 	opengl? ( media-libs/freeglut !dev-libs/OpenNI2[opengl] )
-	java? ( virtual/jre:1.8 )
 "
-DEPEND="${RDEPEND}
-	java? ( virtual/jdk:1.8 )"
+
+DEPEND="
+	${COMMON_DEPEND}
+	java? ( >=virtual/jdk-1.8:* !dev-libs/OpenNI2[java] )
+"
+
+RDEPEND="
+	${COMMON_DEPEND}
+	java? ( >=virtual/jre-1.8:* !dev-libs/OpenNI2[java] )
+"
+
 BDEPEND="doc? ( app-text/doxygen )"
 
 PATCHES=(
@@ -52,7 +60,8 @@ src_prepare() {
 		echo "" > ${i}
 	done
 
-	find . -type f -print0 | xargs -0 sed -i "s:\".*/SamplesConfig.xml:\"${EPREFIX}/usr/share/${PN}/SamplesConfig.xml:" || die
+	find . -type f -print0 |
+		xargs -0 sed -i "s:\".*/SamplesConfig.xml:\"${EPREFIX}/usr/share/${PN}/SamplesConfig.xml:" || die
 }
 
 src_compile() {

--- a/dev-libs/OpenNI/OpenNI-9999.ebuild
+++ b/dev-libs/OpenNI/OpenNI-9999.ebuild
@@ -9,7 +9,7 @@ if [ "${PV#9999}" != "${PV}" ] ; then
 	EGIT_REPO_URI="https://github.com/OpenNI/OpenNI"
 fi
 
-inherit ${SCM} flag-o-matic toolchain-funcs java-pkg-opt-2
+inherit ${SCM} eapi9-pipestatus flag-o-matic java-pkg-opt-2 toolchain-funcs
 
 if [ "${PV#9999}" != "${PV}" ] ; then
 	SRC_URI=""
@@ -61,7 +61,8 @@ src_prepare() {
 	done
 
 	find . -type f -print0 |
-		xargs -0 sed -i "s:\".*/SamplesConfig.xml:\"${EPREFIX}/usr/share/${PN}/SamplesConfig.xml:" || die
+		xargs -0 sed -i "s:\".*/SamplesConfig.xml:\"${EPREFIX}/usr/share/${PN}/SamplesConfig.xml:"
+	status=$(pipestatus -v) || die "fails to sed SamplesConfig, (PIPESTATUS: ${status})"
 }
 
 src_compile() {

--- a/dev-libs/OpenNI2/OpenNI2-2.2_beta2-r2.ebuild
+++ b/dev-libs/OpenNI2/OpenNI2-2.2_beta2-r2.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 SCM=""
 if [ "${PV#9999}" != "${PV}" ] ; then
@@ -15,26 +15,33 @@ if [ "${PV#9999}" != "${PV}" ] ; then
 	SRC_URI=""
 else
 	KEYWORDS="amd64 ~arm"
-	SRC_URI="https://github.com/occipital/OpenNI2/archive/${PV/_/-}.tar.gz -> ${P}.tar.gz"
+	SRC_URI="https://github.com/structureio/OpenNI2/archive/${PV/_/-}.tar.gz -> ${P}.tar.gz"
 	S="${WORKDIR}/${P/_/-}"
 fi
 
 DESCRIPTION="OpenNI2 SDK"
-HOMEPAGE="https://structure.io/openni"
+HOMEPAGE="https://structure.io/openni/"
 LICENSE="Apache-2.0"
 SLOT="0"
 IUSE="cpu_flags_arm_neon doc java opengl static-libs"
 
-RDEPEND="
+COMMON_DEPEND="
 	media-libs/libjpeg-turbo:=
 	virtual/libusb:1
 	virtual/libudev
 	opengl? ( media-libs/freeglut )
-	java? ( virtual/jre:1.8 )
 "
-DEPEND="${RDEPEND}
+
+DEPEND="
+	${COMMON_DEPEND}
 	doc? ( app-text/doxygen )
-	java? ( virtual/jdk:1.8 )"
+	java? ( >=virtual/jdk-1.8:* !dev-libs/OpenNI[java] )
+"
+
+RDEPEND="
+	${COMMON_DEPEND}
+	java? ( >=virtual/jre-1.8:* !dev-libs/OpenNI[java] )
+"
 
 PATCHES=(
 	"${FILESDIR}/jpeg.patch"

--- a/dev-libs/OpenNI2/OpenNI2-9999.ebuild
+++ b/dev-libs/OpenNI2/OpenNI2-9999.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 SCM=""
 if [ "${PV#9999}" != "${PV}" ] ; then
@@ -20,21 +20,28 @@ else
 fi
 
 DESCRIPTION="OpenNI2 SDK"
-HOMEPAGE="https://structure.io/openni"
+HOMEPAGE="https://structure.io/openni/"
 LICENSE="Apache-2.0"
 SLOT="0"
 IUSE="cpu_flags_arm_neon doc java opengl static-libs"
 
-RDEPEND="
+COMMON_DEPEND="
 	media-libs/libjpeg-turbo:=
 	virtual/libusb:1
 	virtual/libudev
 	opengl? ( media-libs/freeglut )
-	java? ( virtual/jre:1.8 )
 "
-DEPEND="${RDEPEND}
+
+DEPEND="
+	${COMMON_DEPEND}
 	doc? ( app-text/doxygen )
-	java? ( virtual/jdk:1.8 )"
+	java? ( >=virtual/jdk-1.8:* !dev-libs/OpenNI[java] )
+"
+
+RDEPEND="
+	${COMMON_DEPEND}
+	java? ( >=virtual/jre-1.8:* !dev-libs/OpenNI[java] )
+"
 
 PATCHES=(
 	"${FILESDIR}/jpeg.patch"

--- a/dev-libs/OpenNI2/metadata.xml
+++ b/dev-libs/OpenNI2/metadata.xml
@@ -6,6 +6,6 @@
     <name>Alexis Ballier</name>
   </maintainer>
   <upstream>
-    <remote-id type="github">occipital/OpenNI2</remote-id>
+    <remote-id type="github">structureio/OpenNI2</remote-id>
   </upstream>
 </pkgmetadata>


### PR DESCRIPTION
ebuilds which are pinned to 1.8 should go away before eol of openjdk:8

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
