### PR TITLE
gui-wm/hyprland: fix up 9999 ebuild

### DIFF
--- a/gui-wm/hyprland/hyprland-9999.ebuild
+++ b/gui-wm/hyprland/hyprland-9999.ebuild
@@ -36,6 +36,7 @@ RDEPEND="
 	dev-cpp/tomlplusplus
 	dev-libs/glib:2
 	dev-libs/libinput
+	dev-libs/re2
 	>=dev-libs/udis86-1.7.2
 	>=dev-libs/wayland-1.22.90
 	>=gui-libs/aquamarine-0.4.2


### PR DESCRIPTION
Git build of Hyprland now requires re2 package. Adding to runtime deps 

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
