### PR TITLE
net-irc/ngircd: fix unexpected feature test error

### DIFF
--- a/net-irc/ngircd/files/ngircd-26.1-configure-getaddrinfo.patch
+++ b/net-irc/ngircd/files/ngircd-26.1-configure-getaddrinfo.patch
@@ -1,0 +1,23 @@
+https://bugs.gentoo.org/946998
+
+configure report getaddrinfo not works because of stricter compiler check:
+  configure:6303: x86_64-pc-linux-gnu-gcc -o conftest -g -O2 -pipe -W -Wall -Wpointer-arith -Wstrict-prototypes -fstack-protector -DSYSCONFDIR='"$(sysconfdir)"' -DDOCDIR='"$(docdir)"' conftest.c >&5
+  conftest.c: In function 'main':
+  conftest.c:99:9: error: implicit declaration of function 'memset' [-Wimplicit-function-declaration]
+
+configure.ac still use de-ANSI-fication (which is only available in old
+automake) in order to support old systems. So we can't patch configure.ac
+and run eautoreconf. see https://github.com/ngircd/ngircd/issues/261
+
+diff --git a/configure b/configure
+index e4023a3..9337a85 100755
+--- a/configure
++++ b/configure
+@@ -6283,6 +6283,7 @@ else
+ /* end confdefs.h.  */
+ 
+ #include <stdio.h>
++#include <string.h>
+ #include <sys/types.h>
+ #include <sys/socket.h>
+ #include <netdb.h>

--- a/net-irc/ngircd/metadata.xml
+++ b/net-irc/ngircd/metadata.xml
@@ -1,7 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<!-- maintainer-needed -->
+	<maintainer type="person" proxied="yes">
+		<email>zhixu.liu@gmail.com</email>
+		<name>Z. Liu</name>
+	</maintainer>
+	<maintainer type="project" proxied="proxy">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
 	<use>
 		<flag name="ident">Enables support for <pkg>net-libs/libident</pkg></flag>
 		<flag name="irc-plus">Enables support for the IRC+ protocol (needs <pkg>virtual/libiconv</pkg>)</flag>

--- a/net-irc/ngircd/ngircd-26.1-r6.ebuild
+++ b/net-irc/ngircd/ngircd-26.1-r6.ebuild
@@ -1,0 +1,130 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/openpgp-keys/alexbarton.asc
+inherit tmpfiles systemd verify-sig
+
+DESCRIPTION="An IRC server written from scratch"
+HOMEPAGE="https://ngircd.barton.de/"
+SRC_URI="https://arthur.barton.de/pub/${PN}/${P}.tar.xz"
+SRC_URI+=" verify-sig? ( https://arthur.barton.de/pub/${PN}/${P}.tar.xz.sig )"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="amd64 arm arm64 x86 ~x64-macos"
+IUSE="debug gnutls ident +irc-plus +ipv6 pam +ssl strict-rfc tcpd test zlib"
+
+# Flaky test needs investigation (bug #719256)
+RESTRICT="test"
+
+RDEPEND="
+	acct-user/ngircd
+	irc-plus? ( virtual/libiconv )
+	ident? ( net-libs/libident )
+	pam? ( sys-libs/pam )
+	ssl? (
+		gnutls? ( net-libs/gnutls:= )
+		!gnutls? (
+			dev-libs/openssl:0=
+		)
+	)
+	tcpd? ( sys-apps/tcp-wrappers )
+	zlib? ( sys-libs/zlib )
+"
+DEPEND="${RDEPEND}"
+BDEPEND="
+	test? (
+		dev-tcltk/expect
+		net-misc/netkit-telnetd
+	)
+	verify-sig? ( >=sec-keys/openpgp-keys-alexbarton-20241211 )
+"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-26.1-systemd-unit.patch
+	"${FILESDIR}"/${PN}-26.1-configure-getaddrinfo.patch # XXX #946998 PLEASE CHECK PER RELEASE
+)
+
+src_prepare() {
+	default
+
+	if ! use prefix ; then
+		sed -i \
+			-e "/;ServerUID = /s/65534/ngircd/" \
+			-e "/;ServerGID = /s/65534/ngircd/" \
+			doc/sample-ngircd.conf.tmpl || die
+	fi
+
+	# Make pidfiles work out-of-the-box
+	sed -i \
+		-e "/;PidFile = /s/;//" \
+		-e "/;ServerUID = /s/;//" \
+		-e "/;ServerGID = /s/;//" \
+		doc/sample-ngircd.conf.tmpl || die
+
+	# Note that if we need to use automake, we need a certain version (for now):
+	# https://github.com/ngircd/ngircd/issues/261
+	# WANT_AUTOMAKE=1.11
+	# eautomake
+}
+
+src_configure() {
+	local myeconfargs=(
+		--sysconfdir="${EPREFIX}"/etc/${PN}
+
+		$(use_enable debug sniffer)
+		$(use_enable debug)
+		$(use_enable irc-plus ircplus)
+		$(use_enable ipv6)
+		$(use_enable strict-rfc)
+		$(use_with irc-plus iconv)
+		$(use_with ident)
+		$(use_with pam)
+		$(use_with tcpd tcp-wrappers)
+		$(use_with zlib)
+	)
+
+	if use ssl ; then
+		if use gnutls ; then
+			myeconfargs+=(
+				$( use_with gnutls )
+			)
+		else
+			myeconfargs+=(
+				$( use_with !gnutls openssl )
+			)
+		fi
+	fi
+
+	econf "${myeconfargs[@]}"
+}
+
+src_install() {
+	default
+
+	fowners root:ngircd /etc/ngircd/{,ngircd.conf}
+	fperms 0750 /etc/ngircd/
+	fperms 0640 /etc/ngircd/ngircd.conf
+
+	newinitd "${FILESDIR}"/ngircd.init-r2.d ngircd
+	newconfd "${FILESDIR}"/ngircd.conf.d ngircd
+
+	systemd_dounit contrib/ngircd.{service,socket}
+
+	dotmpfiles "${FILESDIR}"/ngircd.conf
+}
+
+pkg_postinst() {
+	if [[ -z ${REPLACING_VERSIONS} ]] && use pam ; then
+		elog "ngircd will use PAMIsOptionalPAM by default, please change this option."
+		elog "You may not be able to login until you change this."
+	fi
+
+	if ! use irc-plus ; then
+		ewarn "server-login-test occasional failure had been reported. Upstream suggests"
+		ewarn "to enable ircplus by default. See Gentoo bug #719256. You have been warned."
+	fi
+	tmpfiles_process ngircd.conf
+}


### PR DESCRIPTION
1. USE="irc-plus" is default enabled now
2. /etc/ngircd/{,ngircd.conf} owned by root:ngircd, and update permissions
3. configure report getaddrinfo not works because of stricter compiler check:
     checking whether getaddrinfo() works... no
     configure:6303: x86_64-pc-linux-gnu-gcc -o conftest -g -O2 -pipe -W -Wall -Wpointer-arith -Wstrict-prototypes -fstack-protector -DSYSCONFDIR='"$(sysconfdir)"' -DDOCDIR='"$(docdir)"'   conftest.c  >&5
     conftest.c: In function 'main':
     conftest.c:99:9: error: implicit declaration of function 'memset' [-Wimplicit-function-declaration]

   configure.ac still use de-ANSI-fication (which is only available in
   old automake) in order to support old systems. So we can't patch
   configure.ac and run eautoreconf. see
   https://github.com/ngircd/ngircd/issues/261

   It's important to make sure ngircd-26.1-configure-getaddrinfo.patch
   works correctly for each new release.

Closes: https://bugs.gentoo.org/719256
Closes: https://bugs.gentoo.org/900082
Closes: https://bugs.gentoo.org/908349
Closes: https://bugs.gentoo.org/946998


<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
