### PR TITLE
app-editors/emacs: die early if build with clang with USE=jit

### DIFF
--- a/app-editors/emacs/emacs-28.2-r15.ebuild
+++ b/app-editors/emacs/emacs-28.2-r15.ebuild
@@ -142,6 +142,12 @@ QA_CONFIG_IMPL_DECL_SKIP=(
 	statvfs64 re_set_syntax re_compile_pattern re_search re_match
 )
 
+pkg_pretend() {
+	if [[ ${MERGE_TYPE} != "binary" ]] && use jit && ! tc-is-gcc ; then
+		die "Emacs must be built with gcc[jit] if USE=jit is enabled."
+	fi
+}
+
 src_prepare() {
 	if [[ ${PV##*.} = 9999 ]]; then
 		FULL_VERSION=$(sed -n 's/^AC_INIT([^,]*,[^0-9.]*\([0-9.]*\).*/\1/p' \

--- a/app-editors/emacs/emacs-29.4-r1.ebuild
+++ b/app-editors/emacs/emacs-29.4-r1.ebuild
@@ -170,6 +170,12 @@ QA_CONFIG_IMPL_DECL_SKIP=(
 	statvfs64 re_set_syntax re_compile_pattern re_search re_match
 )
 
+pkg_pretend() {
+	if [[ ${MERGE_TYPE} != "binary" ]] && use jit && ! tc-is-gcc ; then
+		die "Emacs must be built with gcc[jit] if USE=jit is enabled."
+	fi
+}
+
 src_prepare() {
 	if [[ ${PV##*.} = 9999 ]]; then
 		FULL_VERSION=$(sed -n 's/^AC_INIT([^,]*,[^0-9.]*\([0-9.]*\).*/\1/p' \

--- a/app-editors/emacs/emacs-30.0.91.ebuild
+++ b/app-editors/emacs/emacs-30.0.91.ebuild
@@ -167,6 +167,12 @@ QA_CONFIG_IMPL_DECL_SKIP=(
 	statvfs64 re_set_syntax re_compile_pattern re_search re_match
 )
 
+pkg_pretend() {
+	if [[ ${MERGE_TYPE} != "binary" ]] && use jit && ! tc-is-gcc ; then
+		die "Emacs must be built with gcc[jit] if USE=jit is enabled."
+	fi
+}
+
 src_prepare() {
 	if [[ ${PV##*.} = 9999 ]]; then
 		FULL_VERSION=$(sed -n 's/^AC_INIT([^,]*,[^0-9.]*\([0-9.]*\).*/\1/p' \

--- a/app-editors/emacs/emacs-30.0.92.ebuild
+++ b/app-editors/emacs/emacs-30.0.92.ebuild
@@ -167,6 +167,12 @@ QA_CONFIG_IMPL_DECL_SKIP=(
 	statvfs64 re_set_syntax re_compile_pattern re_search re_match
 )
 
+pkg_pretend() {
+	if [[ ${MERGE_TYPE} != "binary" ]] && use jit && ! tc-is-gcc ; then
+		die "Emacs must be built with gcc[jit] if USE=jit is enabled."
+	fi
+}
+
 src_prepare() {
 	if [[ ${PV##*.} = 9999 ]]; then
 		FULL_VERSION=$(sed -n 's/^AC_INIT([^,]*,[^0-9.]*\([0-9.]*\).*/\1/p' \

--- a/app-editors/emacs/emacs-30.0.93.ebuild
+++ b/app-editors/emacs/emacs-30.0.93.ebuild
@@ -167,6 +167,12 @@ QA_CONFIG_IMPL_DECL_SKIP=(
 	statvfs64 re_set_syntax re_compile_pattern re_search re_match
 )
 
+pkg_pretend() {
+	if [[ ${MERGE_TYPE} != "binary" ]] && use jit && ! tc-is-gcc ; then
+		die "Emacs must be built with gcc[jit] if USE=jit is enabled."
+	fi
+}
+
 src_prepare() {
 	if [[ ${PV##*.} = 9999 ]]; then
 		FULL_VERSION=$(sed -n 's/^AC_INIT([^,]*,[^0-9.]*\([0-9.]*\).*/\1/p' \

--- a/app-editors/emacs/emacs-30.0.9999-r1.ebuild
+++ b/app-editors/emacs/emacs-30.0.9999-r1.ebuild
@@ -167,6 +167,12 @@ QA_CONFIG_IMPL_DECL_SKIP=(
 	statvfs64 re_set_syntax re_compile_pattern re_search re_match
 )
 
+pkg_pretend() {
+	if [[ ${MERGE_TYPE} != "binary" ]] && use jit && ! tc-is-gcc ; then
+		die "Emacs must be built with gcc[jit] if USE=jit is enabled."
+	fi
+}
+
 src_prepare() {
 	if [[ ${PV##*.} = 9999 ]]; then
 		FULL_VERSION=$(sed -n 's/^AC_INIT([^,]*,[^0-9.]*\([0-9.]*\).*/\1/p' \

--- a/app-editors/emacs/emacs-31.0.9999.ebuild
+++ b/app-editors/emacs/emacs-31.0.9999.ebuild
@@ -167,6 +167,12 @@ QA_CONFIG_IMPL_DECL_SKIP=(
 	statvfs64 re_set_syntax re_compile_pattern re_search re_match
 )
 
+pkg_pretend() {
+	if [[ ${MERGE_TYPE} != "binary" ]] && use jit && ! tc-is-gcc ; then
+		die "Emacs must be built with gcc[jit] if USE=jit is enabled."
+	fi
+}
+
 src_prepare() {
 	if [[ ${PV##*.} = 9999 ]]; then
 		FULL_VERSION=$(sed -n 's/^AC_INIT([^,]*,[^0-9.]*\([0-9.]*\).*/\1/p' \


### PR DESCRIPTION
Clang does not provide an analogue of libgccjit, see discussions at https://forums.gentoo.org/viewtopic-p-8738735.html

Closes: https://bugs.gentoo.org/874657

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
