### PR TITLE
app-crypt/dehydrated: Ignore output of "openssl req"

### DIFF
--- a/app-crypt/dehydrated/dehydrated-0.7.1-r1.ebuild
+++ b/app-crypt/dehydrated/dehydrated-0.7.1-r1.ebuild
@@ -1,0 +1,63 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="8"
+
+VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/openpgp-keys/dehydrated.asc
+
+inherit verify-sig
+
+DESCRIPTION="A client for signing certificates with an ACME-server"
+HOMEPAGE="https://dehydrated.io/"
+SRC_URI="
+	https://github.com/dehydrated-io/${PN}/releases/download/v${PV}/${P}.tar.gz
+	verify-sig? ( https://github.com/dehydrated-io/${PN}/releases/download/v${PV}/${P}.tar.gz.asc )
+"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~riscv ~x86"
+IUSE="+cron"
+
+BDEPEND="verify-sig? ( sec-keys/openpgp-keys-dehydrated )"
+RDEPEND="acct-group/dehydrated
+	acct-user/dehydrated
+	app-shells/bash
+	net-misc/curl
+	cron? ( virtual/cron )"
+
+PATCHES=( "${FILESDIR}"/${P}-openssl-stdout.patch )
+
+src_configure() {
+	default
+	sed -i  's,^#CONFIG_D=.*,CONFIG_D="/etc/dehydrated/config.d",' docs/examples/config \
+		|| die "could not set config (CONFIG_D)"
+}
+
+src_install() {
+	dobin ${PN}
+	insinto /etc/${PN}
+	doins docs/examples/{config,domains.txt,hook.sh}
+	fperms u+x /etc/${PN}/hook.sh
+	dodoc docs/*.md
+
+	insinto /etc/${PN}/config.d
+	newins "${FILESDIR}"/00_gentoo.sh-r1 00_gentoo.sh
+
+	keepdir /etc/${PN}/domains.d
+
+	doman  docs/man/dehydrated.1
+
+	if use cron ; then
+		insinto /etc/cron.d
+		newins "${FILESDIR}"/cron-r1 ${PN}
+	fi
+}
+
+pkg_postinst() {
+	if [[ -z "${REPLACING_VERSIONS}" ]] ; then
+		einfo "See /etc/dehydrated/config for configuration."
+
+		use cron && einfo "After finishing setup you should enable the cronjob in /etc/cron.d/dehydrated."
+	fi
+}

--- a/app-crypt/dehydrated/files/dehydrated-0.7.1-openssl-stdout.patch
+++ b/app-crypt/dehydrated/files/dehydrated-0.7.1-openssl-stdout.patch
@@ -1,0 +1,19 @@
+https://bugs.gentoo.org/942637
+
+commit 4fd777e87e589652b1127b79ac6688ed7cb151fe
+Author: Wilfried Teiken <wteiken@teiken.org>
+Date:   Sun Dec 3 15:07:01 2023 -0500
+
+    Ignore output of 'openssl req -verify'.
+
+--- a/dehydrated
++++ b/dehydrated
+@@ -1011,7 +1011,7 @@ signed_request() {
+ extract_altnames() {
+   csr="${1}" # the CSR itself (not a file)
+ 
+-  if ! <<<"${csr}" "${OPENSSL}" req -verify -noout 2>/dev/null; then
++  if ! <<<"${csr}" "${OPENSSL}" req -verify -noout >/dev/null 2>&1; then
+     _exiterr "Certificate signing request isn't valid"
+   fi
+ 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/942637

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
