### PR TITLE
x11-terms/ghostty: require gui-libs/gtk[X] for gtk backend

### DIFF
--- a/x11-terms/ghostty/ghostty-1.0.0-r1.ebuild
+++ b/x11-terms/ghostty/ghostty-1.0.0-r1.ebuild
@@ -63,9 +63,12 @@ KEYWORDS="~amd64"
 # TODO: simdutf integration (missing Gentoo version)
 # TODO: spirv-cross integration (missing Gentoo package)
 # TODO: glfw integration (no option from upstream)
+# NOTE: gtk backend requires X right now since ghostty unconditionally
+#       includes gdk/x11/gdkx.h.
+#       https://github.com/ghostty-org/ghostty/issues/3477
 RDEPEND="
 	adwaita? ( gui-libs/libadwaita:1= )
-	gtk? ( gui-libs/gtk:4= )
+	gtk? ( gui-libs/gtk:4=[X] )
 
 	system-fontconfig? ( >=media-libs/fontconfig-2.14.2:= )
 	system-freetype? ( >=media-libs/freetype-2.13.2:=[bzip2] )


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/947032

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
