### PR TITLE
net-p2p/deluge: Add RDEP dev-python/legacy-cgi for py3_13

### DIFF
--- a/net-p2p/deluge/deluge-2.1.1-r5.ebuild
+++ b/net-p2p/deluge/deluge-2.1.1-r5.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..13} )
+PYTHON_COMPAT=( python3_{10..12} )
 DISTUTILS_USE_PEP517=setuptools
 DISTUTILS_SINGLE_IMPL=1
 inherit distutils-r1 systemd xdg

--- a/net-p2p/deluge/deluge-2.1.1-r6.ebuild
+++ b/net-p2p/deluge/deluge-2.1.1-r6.ebuild
@@ -1,0 +1,176 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+PYTHON_COMPAT=( python3_{10..13} )
+DISTUTILS_USE_PEP517=setuptools
+DISTUTILS_SINGLE_IMPL=1
+inherit distutils-r1 systemd xdg
+
+DESCRIPTION="BitTorrent client with a client/server model"
+HOMEPAGE="https://deluge-torrent.org/"
+
+if [[ ${PV} == 9999 ]]; then
+	inherit git-r3
+	EGIT_REPO_URI="https://git.deluge-torrent.org/${PN}"
+else
+	SRC_URI="http://download.deluge-torrent.org/source/$(ver_cut 1-2)/${P}.tar.xz"
+	KEYWORDS="~amd64 ~arm ~arm64 ~riscv ~x86"
+fi
+
+LICENSE="GPL-2"
+SLOT="0"
+IUSE="console gui libnotify sound webinterface"
+REQUIRED_USE="
+	libnotify? ( gui )
+	sound? ( gui )
+"
+
+BDEPEND="
+	dev-util/intltool
+	test? (
+		$(python_gen_cond_dep '
+			>=dev-python/pytest-twisted-1.13.4-r1[${PYTHON_USEDEP}]
+		')
+	)
+"
+
+RDEPEND="
+	acct-group/deluge
+	acct-user/deluge
+	net-libs/libtorrent-rasterbar:=[python,${PYTHON_SINGLE_USEDEP}]
+	$(python_gen_cond_dep '
+		gui? (
+			sound? ( dev-python/pygame[${PYTHON_USEDEP}] )
+			dev-python/pygobject:3[${PYTHON_USEDEP}]
+			gnome-base/librsvg
+			libnotify? ( x11-libs/libnotify )
+		)
+		dev-python/chardet[${PYTHON_USEDEP}]
+		dev-python/distro[${PYTHON_USEDEP}]
+		dev-python/pillow[${PYTHON_USEDEP}]
+		dev-python/pyopenssl[${PYTHON_USEDEP}]
+		dev-python/pyxdg[${PYTHON_USEDEP}]
+		dev-python/rencode[${PYTHON_USEDEP}]
+		dev-python/setproctitle[${PYTHON_USEDEP}]
+		>=dev-python/twisted-17.1.0[ssl(-),${PYTHON_USEDEP}]
+		>=dev-python/zope-interface-4.4.2[${PYTHON_USEDEP}]
+		dev-python/mako[${PYTHON_USEDEP}]
+	')
+"
+
+PATCHES=(
+	"${FILESDIR}/${P}-twisted-22.10.patch"
+	# https://dev.deluge-torrent.org/ticket/3598
+	"${FILESDIR}/${P}-ayatana.patch"
+	# https://dev.deluge-torrent.org/ticket/3582
+	"${FILESDIR}/${P}-consoleui-deferred.patch"
+	"${FILESDIR}/${P}-email-module-replace.patch"
+)
+
+distutils_enable_tests pytest
+
+python_prepare_all() {
+	local args=(
+		-e 's|"new_release_check": True|"new_release_check": False|'
+		-e 's|"check_new_releases": True|"check_new_releases": False|'
+		-e 's|"show_new_releases": True|"show_new_releases": False|'
+	)
+	sed -i "${args[@]}" -- 'deluge/core/preferencesmanager.py' || die
+
+	distutils-r1_python_prepare_all
+}
+
+python_test() {
+	local EPYTEST_IGNORE=(
+		# Upstream CI/CD skips these and they seem to intentionally segfault to collect core dumps...
+		deluge/plugins/Stats/deluge_stats/tests/test_stats.py
+		# Skipped upstream
+		deluge/tests/test_security.py
+	)
+	local EPYTEST_DESELECT=(
+		# Skipped upstream
+		'deluge/plugins/WebUi/deluge_webui/tests/test_plugin_webui.py::TestWebUIPlugin::test_enable_webui'
+		'deluge/tests/test_torrent.py::TestTorrent::test_torrent_error_resume_data_unaltered'
+		'deluge/tests/test_tracker_icons.py::TestTrackerIcons::test_get_seo_svg_with_sni'
+		# never returns
+		'deluge/tests/test_ui_entry.py::TestConsoleScriptEntryWithDaemon'
+		# failing network(?)-related tests, even with sandbox disabled
+		'deluge/tests/test_common.py::TestCommon::test_is_interface'
+		# fails
+		'deluge/tests/test_core.py::TestCore::test_pause_torrents'
+		# fails because of network sandbox
+		'deluge/tests/test_core.py::TestCore::test_test_listen_port'
+		'deluge/tests/test_tracker_icons.py::TestTrackerIcons::test_get_deluge_png'
+		'deluge/tests/test_tracker_icons.py::TestTrackerIcons::test_get_google_ico'
+		'deluge/tests/test_tracker_icons.py::TestTrackerIcons::test_get_google_ico_hebrew'
+		'deluge/tests/test_tracker_icons.py::TestTrackerIcons::test_get_google_ico_with_redirect'
+		# segfaults with FEATURES="network-sandbox"
+		'deluge/tests/test_core.py::TestCore::test_pause_torrent'
+	)
+
+	# dev-python/pytest-twisted has disabled autoloading
+	epytest -m "not (todo or gtkui)" -p pytest_twisted -v
+}
+
+python_install_all() {
+	distutils-r1_python_install_all
+	if ! use console ; then
+		rm -r "${D}/$(python_get_sitedir)/deluge/ui/console/" || die
+		rm "${ED}/usr/bin/deluge-console" || die
+		rm "${ED}/usr/share/man/man1/deluge-console.1" ||die
+	fi
+	if ! use gui ; then
+		rm -r "${D}/$(python_get_sitedir)/deluge/ui/gtk3/" || die
+		rm -r "${ED}/usr/share/icons/" || die
+		rm "${ED}/usr/bin/deluge-gtk" || die
+		rm "${ED}/usr/share/man/man1/deluge-gtk.1" || die
+	else
+		mkdir -p "${ED}/usr/share/applications/" || die
+		cp "${WORKDIR}/${P}/deluge/ui/data/share/applications/deluge.desktop" "${ED}/usr/share/applications/" || die
+		mkdir -p "${ED}/usr/share/metainfo" || die
+		cp "${WORKDIR}/${P}/deluge/ui/data/share/appdata/deluge.appdata.xml" "${ED}/usr/share/metainfo/" || die
+	fi
+
+	if use webinterface; then
+		newinitd "${FILESDIR}/deluge-web.init-2" deluge-web
+		newconfd "${FILESDIR}/deluge-web.conf" deluge-web
+		systemd_newunit "${FILESDIR}/deluge-web.service-4" deluge-web.service
+		systemd_install_serviced "${FILESDIR}/deluge-web.service.conf"
+	else
+		rm -r "${D}/$(python_get_sitedir)/deluge/ui/web/" || die
+		rm "${ED}/usr/bin/deluge-web" || die
+		rm "${ED}/usr/share/man/man1/deluge-web.1" || die
+	fi
+
+	newinitd "${FILESDIR}"/deluged.init-2 deluged
+	newconfd "${FILESDIR}"/deluged.conf-2 deluged
+	systemd_newunit "${FILESDIR}"/deluged.service-2 deluged.service
+	systemd_install_serviced "${FILESDIR}"/deluged.service.conf
+
+	python_optimize
+}
+
+pkg_postinst() {
+	xdg_pkg_postinst
+
+	elog
+	elog "If, after upgrading, deluge doesn't work please back up and then"
+	elog "remove your '~/.config/deluge' directory and try again"
+	elog
+	elog "To start the daemon either run 'deluged' as user"
+	elog "or modify /etc/conf.d/deluged and run"
+	elog "'/etc/init.d/deluged start' as root if you use OpenRC"
+	elog "or"
+	elog "'systemctl start deluged.service' as root if you use systemd"
+	elog "You can still use deluge the old way"
+	elog
+	elog "Systemd unit files for deluged and deluge-web no longer source"
+	elog "/etc/conf.d/deluge* files. Environment variable customization now"
+	elog "happens in /etc/systemd/system/deluged.service.d/00gentoo.conf"
+	elog "and /etc/systemd/system/deluge-web.service.d/00gentoo.conf"
+	elog
+	elog "For more information see https://dev.deluge-torrent.org/wiki/Faq"
+	elog
+}

--- a/net-p2p/deluge/files/deluge-2.1.1-email-module-replace.patch
+++ b/net-p2p/deluge/files/deluge-2.1.1-email-module-replace.patch
@@ -1,0 +1,95 @@
+From https://github.com/deluge-torrent/deluge/commit/5d96cfc72f0bfa36d90afd2725aa2216b8073d66
+From: Mamoru TASAKA <mtasaka@fedoraproject.org>
+Date: Thu, 29 Aug 2024 15:31:25 +0900
+Subject: [PATCH] [UI] Replace deprecated cgi module with email
+
+As PEP 594 says, cgi module is marked as deprecated
+in python 3.11, and will be removed in 3.13
+(actually removed at least in 3.13 rc1).
+
+As suggested on PEP 594, replace cgi.parse_header
+with email.message.EmailMessage introduced in python 3.6.
+
+Updated test modify test_download_with_rename_sanitised
+- With RFC2045 specification, Content-Disposition filenames
+parameter containing slash (directory separator) must be
+quoted, so changing as such.
+
+Ref: https://peps.python.org/pep-0594/#deprecated-modules
+Ref: https://peps.python.org/pep-0594/#cgi
+
+Closes: https://github.com/deluge-torrent/deluge/pull/462
+--- a/deluge/httpdownloader.py
++++ b/deluge/httpdownloader.py
+@@ -6,7 +6,7 @@
+ # See LICENSE for more details.
+ #
+ 
+-import cgi
++import email.message
+ import logging
+ import os.path
+ import zlib
+@@ -133,9 +133,10 @@ def request_callback(self, response):
+                 content_disp = headers.getRawHeaders(b'content-disposition')[0].decode(
+                     'utf-8'
+                 )
+-                content_disp_params = cgi.parse_header(content_disp)[1]
+-                if 'filename' in content_disp_params:
+-                    new_file_name = content_disp_params['filename']
++                message = email.message.EmailMessage()
++                message['content-disposition'] = content_disp
++                new_file_name = message.get_filename()
++                if new_file_name:
+                     new_file_name = sanitise_filename(new_file_name)
+                     new_file_name = os.path.join(
+                         os.path.split(self.filename)[0], new_file_name
+@@ -152,7 +153,10 @@ def request_callback(self, response):
+                     self.filename = new_file_name
+ 
+             cont_type_header = headers.getRawHeaders(b'content-type')[0].decode()
+-            cont_type, params = cgi.parse_header(cont_type_header)
++            message = email.message.EmailMessage()
++            message['content-type'] = cont_type_header
++            cont_type = message.get_content_type()
++            params = message['content-type'].params
+             # Only re-ecode text content types.
+             encoding = None
+             if cont_type.startswith('text/'):
+--- a/deluge/tests/test_httpdownloader.py
++++ b/deluge/tests/test_httpdownloader.py
+@@ -206,10 +206,10 @@ async def test_download_with_rename_exists(self):
+         self.assert_contains(filename, 'This file should be called renamed')
+ 
+     async def test_download_with_rename_sanitised(self):
+-        url = self.get_url('rename?filename=/etc/passwd')
++        url = self.get_url('rename?filename="/etc/passwd"')
+         filename = await download_file(url, fname('original'))
+         assert filename == fname('passwd')
+-        self.assert_contains(filename, 'This file should be called /etc/passwd')
++        self.assert_contains(filename, 'This file should be called "/etc/passwd"')
+ 
+     async def test_download_with_attachment_no_filename(self):
+         url = self.get_url('attachment')
+--- a/deluge/ui/web/json_api.py
++++ b/deluge/ui/web/json_api.py
+@@ -6,7 +6,7 @@
+ # See LICENSE for more details.
+ #
+ 
+-import cgi
++import email.message
+ import json
+ import logging
+ import os
+@@ -191,7 +191,9 @@ def _on_json_request(self, request):
+         Handler to take the json data as a string and pass it on to the
+         _handle_request method for further processing.
+         """
+-        content_type, _ = cgi.parse_header(request.getHeader(b'content-type').decode())
++        message = email.message.EmailMessage()
++        message['content-type'] = request.getHeader(b'content-type').decode()
++        content_type = message.get_content_type()
+         if content_type != 'application/json':
+             message = 'Invalid JSON request content-type: %s' % content_type
+             raise JSONException(message)


### PR DESCRIPTION
Used upstream patch to replace cgi with email module which has been a part of Python since 3.6 and created a r6 revbump, also dropped py3_13 from the -r5 ebuild.

Closes: https://bugs.gentoo.org/947117

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
