### PR TITLE
x11-terms/alacritty: use --locked when installing

### DIFF
--- a/x11-terms/alacritty/alacritty-9999.ebuild
+++ b/x11-terms/alacritty/alacritty-9999.ebuild
@@ -94,7 +94,7 @@ src_compile() {
 }
 
 src_install() {
-	cargo_src_install --path alacritty
+	cargo_src_install --locked --path alacritty
 
 	doman alacritty.1 alacritty.5 alacritty-msg.1 alacritty-bindings.5
 


### PR DESCRIPTION
Fix an issue when applying a patch that pulls git dependency will fail to build because during install it'll try to go online for no particular reason.