### PR TITLE
x11-libs/libX11: RDEPEND on x11-base/xorg-proto

### DIFF
--- a/x11-libs/libX11/libX11-1.8.10-r1.ebuild
+++ b/x11-libs/libX11/libX11-1.8.10-r1.ebuild
@@ -14,12 +14,17 @@ KEYWORDS="~alpha amd64 arm arm64 hppa ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 
 IUSE="test"
 RESTRICT="!test? ( test )"
 
+# HACK: libX11 produces .pc files that depend on xproto.pc. When libX11
+#       is installed as a binpkg, DEPEND packages are not pulled in,
+#       but to build source packages against libX11, xorg-proto is
+#       needed. Until a "build-against-depend" option is available in
+#       ebuilds, we RDEPEND on xproto. See bug #903707 and others.
 RDEPEND="
 	>=x11-libs/libxcb-1.11.1[${MULTILIB_USEDEP}]
 	x11-misc/compose-tables
+	x11-base/xorg-proto
 "
 DEPEND="${RDEPEND}
-	x11-base/xorg-proto
 	x11-libs/xtrans
 "
 BDEPEND="test? ( dev-lang/perl )"


### PR DESCRIPTION
Without this, source packages fail to build against libX11 when installed as a binpkg due to missing transitive dependencies.

Bug: https://bugs.gentoo.org/903707
Closes: https://bugs.gentoo.org/947059

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
