### PR TITLE
net-misc/socat: set QA_CONFIG_IMPL_DECL_SKIP

### DIFF
--- a/net-misc/socat/socat-1.7.4.4-r1.ebuild
+++ b/net-misc/socat/socat-1.7.4.4-r1.ebuild
@@ -46,4 +46,8 @@ src_install() {
 
 	docinto html
 	dodoc doc/*.html doc/*.css
+
+	if use elibc_musl; then
+		QA_CONFIG_IMPL_DECL_SKIP=( getprotobynumber_r )
+	fi
 }

--- a/net-misc/socat/socat-1.8.0.0.ebuild
+++ b/net-misc/socat/socat-1.8.0.0.ebuild
@@ -57,4 +57,8 @@ src_install() {
 
 	docinto html
 	dodoc doc/*.html doc/*.css
+
+	if use elibc_musl; then
+		QA_CONFIG_IMPL_DECL_SKIP=( getprotobynumber_r )
+	fi
 }

--- a/net-misc/socat/socat-1.8.0.1.ebuild
+++ b/net-misc/socat/socat-1.8.0.1.ebuild
@@ -52,4 +52,8 @@ src_install() {
 
 	docinto html
 	dodoc doc/*.html doc/*.css
+
+	if use elibc_musl; then
+		QA_CONFIG_IMPL_DECL_SKIP=( getprotobynumber_r )
+	fi
 }

--- a/net-misc/socat/socat-1.8.0.2.ebuild
+++ b/net-misc/socat/socat-1.8.0.2.ebuild
@@ -53,4 +53,8 @@ src_install() {
 
 	docinto html
 	dodoc doc/*.html doc/*.css
+
+	if use elibc_musl; then
+		QA_CONFIG_IMPL_DECL_SKIP=( getprotobynumber_r )
+	fi
 }


### PR DESCRIPTION
musl doesn't has getprotobynumber_r

Closes: https://bugs.gentoo.org/924495

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
