### PR TITLE
sys-fs/ext3grep: fix compile errors with C23

### DIFF
--- a/sys-fs/ext3grep/ext3grep-0.10.2-r2.ebuild
+++ b/sys-fs/ext3grep/ext3grep-0.10.2-r2.ebuild
@@ -1,0 +1,37 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DESCRIPTION="Recover deleted files on an ext3 file system"
+HOMEPAGE="https://code.google.com/p/ext3grep/"
+SRC_URI="https://ext3grep.googlecode.com/files/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="debug pch"
+
+DEPEND="
+	sys-fs/e2fsprogs
+	virtual/os-headers
+"
+BDEPEND="virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-0.10.1-gcc44.patch"
+	"${FILESDIR}/${P}-include-unistd_h-for-sysconf.patch"
+	"${FILESDIR}/${P}-new-e2fsprogs.patch"
+	"${FILESDIR}/${P}-newer-e2fsprogs.patch"
+	"${FILESDIR}/${P}-missing-cassert-include.patch"
+	"${FILESDIR}/${P}-include-order.patch"
+)
+
+src_configure() {
+	local myeconfargs=(
+		$(use_enable debug)
+		$(use_enable pch)
+	)
+
+	econf "${myeconfargs[@]}"
+}

--- a/sys-fs/ext3grep/files/ext3grep-0.10.2-include-order.patch
+++ b/sys-fs/ext3grep/files/ext3grep-0.10.2-include-order.patch
@@ -1,0 +1,86 @@
+https://bugs.gentoo.org/934532
+https://bugs.gentoo.org/939024
+Ordering of includes is important, so we don't redefine "clamp" from
+under STL internals:
+https://en.cppreference.com/w/cpp/algorithm/clamp takes four args
+but clamp in ext2fs.h takes three
+diff -ur a/src/directories.cc b/src/directories.cc
+--- a/src/directories.cc	2024-12-30 14:12:51.353812001 +0400
++++ b/src/directories.cc	2024-12-30 14:13:51.472524523 +0400
+@@ -21,6 +21,10 @@
+ // You should have received a copy of the GNU General Public License
+ // along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ 
++#include <cstring>
++#include <ctime>
++#include <algorithm>
++
+ #ifndef USE_PCH
+ #include "sys.h"
+ #include "ext3.h"
+@@ -33,9 +37,6 @@
+ #include "indirect_blocks.h"
+ #include "get_block.h"
+ #include "directories.h"
+-#include <cstring>
+-#include <ctime>
+-#include <algorithm>
+ 
+ //-----------------------------------------------------------------------------
+ //
+diff -ur a/src/init_files.cc b/src/init_files.cc
+--- a/src/init_files.cc	2024-12-30 14:12:51.353812001 +0400
++++ b/src/init_files.cc	2024-12-30 14:13:37.823593692 +0400
+@@ -21,6 +21,8 @@
+ // You should have received a copy of the GNU General Public License
+ // along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ 
++#include <algorithm>
++
+ #ifndef USE_PCH
+ #include "sys.h"
+ #include <iomanip>
+@@ -33,7 +35,6 @@
+ #include "globals.h"
+ #include "forward_declarations.h"
+ #include "journal.h"
+-#include <algorithm>
+ 
+ //-----------------------------------------------------------------------------
+ //
+diff -ur a/src/journal.cc b/src/journal.cc
+--- a/src/journal.cc	2024-12-30 14:12:51.353812001 +0400
++++ b/src/journal.cc	2024-12-30 14:14:07.808441493 +0400
+@@ -21,6 +21,9 @@
+ // You should have received a copy of the GNU General Public License
+ // along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ 
++#include <algorithm>
++#include <ctime>
++
+ #ifndef USE_PCH
+ #include "sys.h"
+ #include <stdint.h>
+@@ -37,8 +40,6 @@
+ #include "indirect_blocks.h"
+ #include "get_block.h"
+ #include "commandline.h"
+-#include <algorithm>
+-#include <ctime>
+ 
+ //-----------------------------------------------------------------------------
+ //
+It throws warning - we already define LARGEFILE on Gentoo, so let's not redefine
+diff -ur a/src/sys.h.in b/src/sys.h.in
+--- a/src/sys.h.in	2024-12-30 14:12:51.353812001 +0400
++++ b/src/sys.h.in	2024-12-30 14:24:36.796244569 +0400
+@@ -31,7 +31,9 @@
+ #endif
+ 
+ // This is needed for lseek64.
++#ifndef _LARGEFILE64_SOURCE
+ #define _LARGEFILE64_SOURCE
++#endif
+ 
+ #ifdef CWDEBUG
+ #ifndef _GNU_SOURCE


### PR DESCRIPTION
They are caused by previous patch to fix compile errors with GCC-4.4 and incorrect ordering of includes. STL doesn't like when clamp is redefined from four arguments to three arguments

Bug: https://bugs.gentoo.org/939024
Bug: https://bugs.gentoo.org/934532

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
