### PR TITLE
app-emulation/qemu: remove broken edk2 logic

### DIFF
--- a/app-emulation/qemu/qemu-9.2.0-r1.ebuild
+++ b/app-emulation/qemu/qemu-9.2.0-r1.ebuild
@@ -245,16 +245,11 @@ SEABIOS_VERSION="1.16.3"
 
 X86_FIRMWARE_DEPEND="
 	pin-upstream-blobs? (
-		~sys-firmware/edk2-bin-${EDK2_OVMF_VERSION}
 		~sys-firmware/ipxe-1.21.1[binary,qemu]
 		~sys-firmware/seabios-bin-${SEABIOS_VERSION}
 		~sys-firmware/sgabios-0.1_pre10[binary]
 	)
 	!pin-upstream-blobs? (
-		|| (
-			>=sys-firmware/edk2-${EDK2_OVMF_VERSION}
-			>=sys-firmware/edk2-bin-${EDK2_OVMF_VERSION}
-		)
 		sys-firmware/ipxe[qemu]
 		|| (
 			>=sys-firmware/seabios-${SEABIOS_VERSION}[seavgabios]
@@ -956,12 +951,6 @@ pkg_postinst() {
 	if use pin-upstream-blobs && firmware_abi_change; then
 		ewarn "This version of qemu pins new versions of firmware blobs:"
 
-		if has_version 'sys-firmware/edk2-bin'; then
-			ewarn "	$(best_version sys-firmware/edk2-bin)"
-		else
-			ewarn " $(best_version sys-firmware/edk2)"
-		fi
-
 		if has_version 'sys-firmware/seabios-bin'; then
 			ewarn "	$(best_version sys-firmware/seabios-bin)"
 		else
@@ -982,12 +971,6 @@ pkg_postinst() {
 pkg_info() {
 	echo "Using:"
 	echo "  $(best_version app-emulation/spice-protocol)"
-
-	if has_version 'sys-firmware/edk2-bin'; then
-		echo "  $(best_version sys-firmware/edk2-bin)"
-	else
-		echo "  $(best_version sys-firmware/edk2)"
-	fi
 
 	if has_version 'sys-firmware/seabios-bin'; then
 		echo "  $(best_version sys-firmware/seabios-bin)"

--- a/app-emulation/qemu/qemu-9999.ebuild
+++ b/app-emulation/qemu/qemu-9999.ebuild
@@ -245,16 +245,11 @@ SEABIOS_VERSION="1.16.3"
 
 X86_FIRMWARE_DEPEND="
 	pin-upstream-blobs? (
-		~sys-firmware/edk2-bin-${EDK2_OVMF_VERSION}
 		~sys-firmware/ipxe-1.21.1[binary,qemu]
 		~sys-firmware/seabios-bin-${SEABIOS_VERSION}
 		~sys-firmware/sgabios-0.1_pre10[binary]
 	)
 	!pin-upstream-blobs? (
-		|| (
-			>=sys-firmware/edk2-${EDK2_OVMF_VERSION}
-			>=sys-firmware/edk2-bin-${EDK2_OVMF_VERSION}
-		)
 		sys-firmware/ipxe[qemu]
 		|| (
 			>=sys-firmware/seabios-${SEABIOS_VERSION}[seavgabios]
@@ -956,12 +951,6 @@ pkg_postinst() {
 	if use pin-upstream-blobs && firmware_abi_change; then
 		ewarn "This version of qemu pins new versions of firmware blobs:"
 
-		if has_version 'sys-firmware/edk2-bin'; then
-			ewarn "	$(best_version sys-firmware/edk2-bin)"
-		else
-			ewarn " $(best_version sys-firmware/edk2)"
-		fi
-
 		if has_version 'sys-firmware/seabios-bin'; then
 			ewarn "	$(best_version sys-firmware/seabios-bin)"
 		else
@@ -982,12 +971,6 @@ pkg_postinst() {
 pkg_info() {
 	echo "Using:"
 	echo "  $(best_version app-emulation/spice-protocol)"
-
-	if has_version 'sys-firmware/edk2-bin'; then
-		echo "  $(best_version sys-firmware/edk2-bin)"
-	else
-		echo "  $(best_version sys-firmware/edk2)"
-	fi
 
 	if has_version 'sys-firmware/seabios-bin'; then
 		echo "  $(best_version sys-firmware/seabios-bin)"


### PR DESCRIPTION
qemu always installs pre-built blobs in /usr/share/qemu and we don't attempt to replace them with symlinks.

The current edk2 package does not install all of the necessary files we would need to make this work like other firmware blobs.