### PR TITLE
Remove USE=dmalloc and friends

### DIFF
--- a/app-admin/conserver/conserver-8.2.6-r3.ebuild
+++ b/app-admin/conserver/conserver-8.2.6-r3.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 inherit autotools pam ssl-cert
 
@@ -12,12 +12,11 @@ SRC_URI="https://github.com/${PN}/${PN}/releases/download/v${PV}/${P}.tar.gz"
 LICENSE="BSD BSD-with-attribution"
 SLOT="0"
 KEYWORDS="~alpha amd64 ppc ppc64 ~sparc x86"
-IUSE="debug ipv6 freeipmi kerberos pam ssl test tcpd"
+IUSE="ipv6 freeipmi kerberos pam ssl test tcpd"
 RESTRICT="!test? ( test )"
 
 DEPEND="net-libs/libnsl:=
 	virtual/libcrypt:=
-	debug? ( dev-libs/dmalloc:= )
 	freeipmi? ( sys-libs/freeipmi:= )
 	kerberos? (
 		virtual/krb5
@@ -45,13 +44,13 @@ src_prepare() {
 
 src_configure() {
 	local myconf=(
-		$(use_with debug dmalloc)
 		$(use_with ipv6)
 		$(use_with freeipmi)
 		$(use_with kerberos gssapi)
 		$(use_with ssl openssl)
 		$(use_with pam)
 		$(use_with tcpd libwrap)
+		--without-dmalloc
 		--with-cffile=conserver/conserver.cf
 		--with-logfile=/var/log/conserver.log
 		--with-master=localhost

--- a/app-admin/conserver/metadata.xml
+++ b/app-admin/conserver/metadata.xml
@@ -25,4 +25,7 @@
 	<use>
 		<flag name="freeipmi">Compile in FreeIPMI support via <pkg>sys-libs/freeipmi</pkg></flag>
 	</use>
+	<upstream>
+		<remote-id type="github">conserver/conserver</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/media-gfx/enblend/enblend-4.2.0_p20240424.ebuild
+++ b/media-gfx/enblend/enblend-4.2.0_p20240424.ebuild
@@ -14,9 +14,7 @@ S=${WORKDIR}/enblend
 LICENSE="GPL-2+ FDL-1.2+"
 SLOT="0"
 KEYWORDS="amd64 arm64 x86"
-IUSE="cpu_flags_x86_sse2 debug doc openmp tcmalloc"
-
-REQUIRED_USE="tcmalloc? ( !debug )"
+IUSE="cpu_flags_x86_sse2 doc openmp tcmalloc"
 
 BDEPEND="
 	sys-apps/help2man
@@ -40,7 +38,6 @@ RDEPEND="
 	media-libs/tiff:=
 	media-libs/vigra[openexr]
 	sci-libs/gsl:=
-	debug? ( dev-libs/dmalloc[threads] )
 	tcmalloc? ( dev-util/google-perftools )
 "
 DEPEND="${RDEPEND}
@@ -65,7 +62,7 @@ src_prepare() {
 src_configure() {
 	local mycmakeargs=(
 		-DENABLE_SSE2=$(usex cpu_flags_x86_sse2)
-		-DENABLE_DMALLOC=$(usex debug)
+		-DENABLE_DMALLOC=no
 		-DDOC=$(usex doc)
 		-DENABLE_OPENMP=$(usex openmp)
 		-DENABLE_TCMALLOC=$(usex tcmalloc)

--- a/net-analyzer/traceproto/traceproto-1.1.2_beta1.ebuild
+++ b/net-analyzer/traceproto/traceproto-1.1.2_beta1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 inherit autotools
 
@@ -14,13 +14,11 @@ SRC_URI="mirror://gentoo/${PN}-${MY_PV}.tar.gz"
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~amd64 ~ppc x86"
-IUSE="debug"
 
 RDEPEND="
 	net-libs/libnet:1.1
 	net-libs/libpcap
 	sys-libs/ncurses:0=
-	debug? ( dev-libs/dmalloc )
 "
 DEPEND="${RDEPEND}"
 BDEPEND="
@@ -43,5 +41,5 @@ src_prepare() {
 }
 
 src_configure() {
-	econf $(use_enable debug dmalloc)
+	econf --disable-dmalloc
 }

--- a/net-fs/autofs/autofs-5.1.9-r1.ebuild
+++ b/net-fs/autofs/autofs-5.1.9-r1.ebuild
@@ -12,13 +12,12 @@ SRC_URI="https://www.kernel.org/pub/linux/daemons/${PN}/v5/${P}.tar.xz"
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~alpha amd64 arm ~arm64 ~hppa ~mips ppc ppc64 ~riscv sparc x86"
-IUSE="dmalloc ldap +libtirpc mount-locking sasl selinux systemd"
+IUSE="ldap +libtirpc mount-locking sasl selinux systemd"
 
 # currently, sasl code assumes the presence of kerberosV
 RDEPEND="
 	net-libs/libnsl:=
 	>=sys-apps/util-linux-2.20
-	dmalloc? ( dev-libs/dmalloc[threads] )
 	ldap? (
 		>=net-nds/openldap-2.0:=
 		sasl? (
@@ -77,7 +76,7 @@ src_configure() {
 	local myeconfargs=(
 		--with-confdir=/etc/conf.d
 		--with-mapdir=/etc/autofs
-		$(use_with dmalloc)
+		--without-dmalloc
 		$(use_with ldap openldap)
 		$(use_with libtirpc)
 		$(use_with sasl)

--- a/net-fs/autofs/metadata.xml
+++ b/net-fs/autofs/metadata.xml
@@ -6,7 +6,6 @@
 		<name>Yixun Lan</name>
 	</maintainer>
 	<use>
-		<flag name="dmalloc">Enable debugging with the dmalloc library</flag>
 		<flag name="ldap">Install LDAP module</flag>
 		<flag name="libtirpc">Use TiRPC library instead of SunRPC</flag>
 		<flag name="mount-locking">

--- a/net-mail/mboxgrep/mboxgrep-0.7.9-r3.ebuild
+++ b/net-mail/mboxgrep/mboxgrep-0.7.9-r3.ebuild
@@ -11,13 +11,11 @@ SRC_URI="https://downloads.sourceforge.net/mboxgrep/${P}.tar.gz"
 LICENSE="GPL-2+"
 SLOT="0"
 KEYWORDS="~amd64 ~ppc x86"
-IUSE="dmalloc"
 
 RDEPEND="
 	app-arch/bzip2
 	dev-libs/libpcre
 	sys-libs/zlib
-	dmalloc? ( dev-libs/dmalloc )
 "
 DEPEND="
 	${RDEPEND}
@@ -36,7 +34,7 @@ src_prepare() {
 
 src_configure() {
 	econf \
-		$(use_with dmalloc dmalloc $(usex dmalloc yes no))
+		--without-dmalloc
 }
 
 src_install() {

--- a/net-mail/mboxgrep/metadata.xml
+++ b/net-mail/mboxgrep/metadata.xml
@@ -2,9 +2,6 @@
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
 	<!-- maintainer-needed -->
-<use>
-<flag name="dmalloc">Enable debugging using <pkg>dev-libs/dmalloc</pkg></flag>
-</use>
 	<upstream>
 		<remote-id type="sourceforge">mboxgrep</remote-id>
 	</upstream>

--- a/sci-biology/yass/metadata.xml
+++ b/sci-biology/yass/metadata.xml
@@ -6,7 +6,6 @@
     <name>Gentoo Biology Project</name>
   </maintainer>
   <use>
-    <flag name="dmalloc">Enable debugging with the dmalloc library</flag>
     <flag name="lowmem">Build for environments with low amounts of memory</flag>
   </use>
 </pkgmetadata>

--- a/sci-biology/yass/yass-1.14-r3.ebuild
+++ b/sci-biology/yass/yass-1.14-r3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -12,10 +12,7 @@ SRC_URI="http://bioinfo.lifl.fr/yass/files/${P}.tar.gz"
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE="dmalloc lowmem threads"
-
-DEPEND="dmalloc? ( dev-libs/dmalloc )"
-RDEPEND="${DEPEND}"
+IUSE="lowmem threads"
 
 PATCHES=( "${FILESDIR}"/${PV}-as-needed.patch )
 
@@ -28,5 +25,5 @@ src_configure() {
 	econf \
 		$(use_enable threads) \
 		$(use_enable lowmem lowmemory) \
-		$(use_with dmalloc)
+		--without-dmalloc
 }


### PR DESCRIPTION
After communication with Sam it was suggested to rip dmalloc support from ebuilds.
It's janky as hell and causes bugs.

Quick grep gives me following candidates to look at for a removal, with possibility of false positives:

- [x] app-admin/conserver
- [X] media-sound/gtick (false positive)
- [X] app-admin/procinfo-ng (false positive)
- [X] sys-devel/autogen (false positive, I thought --with-dmalloc was implicit, it's not)
- [x] net-fs/autofs
- [X] net-analyzer/traceproto (but I recommend whole package dropped)
- [x] net-mail/mboxgrep
- [x] media-gfx/enblend
- [X] sci-biology/yass
- [X] games-mud/tf (false positive)

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
