### PR TITLE
app-admin/qtpass: fix profiles issue for Qt6

### DIFF
--- a/app-admin/qtpass/files/qtpass-1.4.0-qt-6.8-profiles.patch
+++ b/app-admin/qtpass/files/qtpass-1.4.0-qt-6.8-profiles.patch
@@ -1,0 +1,42 @@
+From 315397bb882a840eba68b343659b567a7409f34f Mon Sep 17 00:00:00 2001
+From: John Doe <johndoe@example.com>
+Date: Sat, 25 May 2024 01:23:33 +0800
+Subject: [PATCH] Fix multiple profiles issue for Qt6
+
+---
+ src/mainwindow.cpp | 4 ++++
+ src/mainwindow.h   | 4 ++++
+ 2 files changed, 8 insertions(+)
+
+diff --git a/src/mainwindow.cpp b/src/mainwindow.cpp
+index b39d3147..66b87dc2 100644
+--- a/src/mainwindow.cpp
++++ b/src/mainwindow.cpp
+@@ -787,7 +787,11 @@ void MainWindow::updateProfileBox() {
+  * correct "profile"
+  * @param name
+  */
++#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+ void MainWindow::on_profileBox_currentIndexChanged(QString name) {
++#else
++void MainWindow::on_profileBox_currentTextChanged(QString name) {
++#endif
+   if (m_qtPass->isFreshStart() || name == QtPassSettings::getProfile())
+     return;
+ 
+diff --git a/src/mainwindow.h b/src/mainwindow.h
+index 172e326f..b5325f61 100644
+--- a/src/mainwindow.h
++++ b/src/mainwindow.h
+@@ -97,7 +97,11 @@ private slots:
+   void clearPanel(bool notify = true);
+   void on_lineEdit_textChanged(const QString &arg1);
+   void on_lineEdit_returnPressed();
++#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+   void on_profileBox_currentIndexChanged(QString);
++#else
++  void on_profileBox_currentTextChanged(QString);
++#endif
+   void showContextMenu(const QPoint &pos);
+   void showBrowserContextMenu(const QPoint &pos);
+   void openFolder();

--- a/app-admin/qtpass/qtpass-1.4.0-r2.ebuild
+++ b/app-admin/qtpass/qtpass-1.4.0-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -31,7 +31,10 @@ BDEPEND="dev-qt/qttools:6[linguist]"
 
 DOCS=( {CHANGELOG,CONTRIBUTING,FAQ,README}.md )
 
-PATCHES=( "${FILESDIR}"/${P}-qt-6.8-buildfix.patch )
+PATCHES=(
+	"${FILESDIR}"/${P}-qt-6.8-buildfix.patch
+	"${FILESDIR}"/${P}-qt-6.8-profiles.patch
+)
 
 src_prepare() {
 	default


### PR DESCRIPTION
<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
