### PR TITLE
media-sound/gmtp: c23 fices

### DIFF
--- a/media-sound/gmtp/files/gmtp-1.3.11-c23-fixes.patch
+++ b/media-sound/gmtp/files/gmtp-1.3.11-c23-fixes.patch
@@ -1,0 +1,33 @@
+From: https://sourceforge.net/p/gmtp/discussion/bugs/thread/7b11b950bd
+
+--- a/src/interface.c
++++ b/src/interface.c
+@@ -40,8 +40,8 @@
+ #include "formatdevice.h"
+ #include "progress.h"
+ 
+-void setupFileList();
+-GtkTreeViewColumn *setupFolderList();
++void setupFileList(GtkTreeView *treeviewFiles);
++GtkTreeViewColumn *setupFolderList(GtkTreeView *treeviewFolders);
+ void __fileRemove(GtkTreeRowReference *Row);
+ void __fileDownload(GtkTreeRowReference *Row);
+ void __folderRemove(GtkTreeRowReference *Row);
+@@ -713,7 +713,7 @@ GtkWidget* create_windowMain(void) {
+     gtk_tree_selection_set_mode(folderSelection, GTK_SELECTION_SINGLE);
+ 
+     folderList = gtk_tree_store_new(NUM_FOL_COLUMNS, G_TYPE_STRING, G_TYPE_STRING, G_TYPE_UINT, GDK_TYPE_PIXBUF);
+-    folderColumn = setupFolderList(treeviewFolders);
++    folderColumn = setupFolderList(GTK_TREE_VIEW(treeviewFolders));
+ 
+     folderListModel = gtk_tree_model_sort_new_with_model(GTK_TREE_MODEL(folderList));
+     gtk_tree_sortable_set_sort_column_id(GTK_TREE_SORTABLE(folderListModel),
+@@ -741,7 +741,7 @@ GtkWidget* create_windowMain(void) {
+             G_TYPE_UINT, G_TYPE_BOOLEAN, G_TYPE_UINT64, G_TYPE_STRING, G_TYPE_STRING, G_TYPE_UINT, G_TYPE_STRING,
+             G_TYPE_STRING, G_TYPE_STRING, G_TYPE_STRING, G_TYPE_STRING, G_TYPE_STRING, G_TYPE_UINT, GDK_TYPE_PIXBUF,
+             G_TYPE_STRING);
+-    setupFileList(treeviewFiles);
++    setupFileList(GTK_TREE_VIEW(treeviewFiles));
+ 
+     fileListModel = gtk_tree_model_sort_new_with_model(GTK_TREE_MODEL(fileList));
+     gtk_tree_sortable_set_sort_column_id(GTK_TREE_SORTABLE(fileListModel),

--- a/media-sound/gmtp/gmtp-1.3.11-r4.ebuild
+++ b/media-sound/gmtp/gmtp-1.3.11-r4.ebuild
@@ -1,0 +1,50 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit gnome2-utils xdg
+
+DESCRIPTION="Simple MTP client for MP3 players"
+HOMEPAGE="https://gmtp.sourceforge.net/"
+SRC_URI="https://downloads.sourceforge.net/${PN}/${P}.tar.gz"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+RDEPEND="
+	dev-libs/glib:2
+	media-libs/flac:=
+	media-libs/libid3tag:=
+	media-libs/libmtp:=
+	media-libs/libvorbis
+	x11-libs/gtk+:3"
+DEPEND="${RDEPEND}"
+BDEPEND="
+	sys-devel/gettext
+	virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-1.3.11-fno-common.patch
+	"${FILESDIR}"/${PN}-1.3.11-c23-fixes.patch
+)
+
+src_configure() {
+	econf --with-gtk3
+}
+
+pkg_preinst() {
+	xdg_pkg_preinst
+	gnome2_schemas_savelist
+}
+
+pkg_postinst() {
+	xdg_pkg_postinst
+	gnome2_schemas_update
+}
+
+pkg_postrm() {
+	xdg_pkg_postrm
+	gnome2_schemas_update
+}


### PR DESCRIPTION
After working with upstream this patch was created by the orginal creator.

It is to be noted that this will likely be the last patch by upstream and it is unlikely a 1.3.12 will be created with this patch.

Closes: https://bugs.gentoo.org/945202

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
