### PR TITLE
dev-libs/nettle: fix conflicting types for 'getopt' on musl /w gcc15

### DIFF
--- a/dev-libs/nettle/nettle-3.10.1.ebuild
+++ b/dev-libs/nettle/nettle-3.10.1.ebuild
@@ -1,10 +1,10 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
 VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/openpgp-keys/nettle.asc
-inherit multilib-build multilib-minimal toolchain-funcs verify-sig
+inherit multilib-build multilib-minimal toolchain-funcs verify-sig flag-o-matic
 
 DESCRIPTION="Low-level cryptographic library"
 HOMEPAGE="https://www.lysator.liu.se/~nisse/nettle/ https://git.lysator.liu.se/nettle/nettle"
@@ -57,6 +57,8 @@ multilib_src_configure() {
 	# We don't want to run Valgrind within ebuilds, it often gets
 	# confused by sandbox, etc.
 	export nettle_cv_prog_valgrind=no
+
+	use elibc_musl && append-cppflags -D__GNU_LIBRARY__ #945970
 
 	# TODO: USE=debug w/ --enable-extra-asserts?
 	local myeconfargs=(


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/945970

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
