### PR TITLE
sys-apps/gawk: avoid broken/dated getopt.c with musl

### DIFF
--- a/sys-apps/gawk/gawk-5.3.1.ebuild
+++ b/sys-apps/gawk/gawk-5.3.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -24,7 +24,7 @@ if [[ ${GAWK_IS_BETA} == yes || ${PV} == *_beta* ]] ; then
 	SRC_URI="https://www.skeeve.com/gawk/${MY_P}.tar.gz"
 else
 	VERIFY_SIG_OPENPGP_KEY_PATH=/usr/share/openpgp-keys/gawk.asc
-	inherit verify-sig
+	inherit verify-sig flag-o-matic
 
 	SRC_URI="mirror://gnu/gawk/${P}.tar.xz"
 	SRC_URI+=" verify-sig? ( mirror://gnu/gawk/${P}.tar.xz.sig )"
@@ -59,6 +59,8 @@ fi
 
 src_prepare() {
 	default
+
+	use elibc_musl && append-cppflags -D__GNU_LIBRARY__
 
 	# Use symlinks rather than hardlinks, and disable version links
 	sed -i \


### PR DESCRIPTION
<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
