### PR TITLE
dev-libs/newt: fix to use C99.

### DIFF
--- a/dev-libs/newt/files/newt-0.52.24-c99-fix.patch
+++ b/dev-libs/newt/files/newt-0.52.24-c99-fix.patch
@@ -1,0 +1,12 @@
+diff --git a/form.c b/form.c
+index 24c601d..c6c15f5 100644
+--- a/form.c
++++ b/form.c
+@@ -5,6 +5,7 @@
+ #include <slang.h>
+ #include <stdarg.h>
+ #include <stdlib.h>
++#include <string.h>
+ #ifdef HAVE_SYS_SELECT_H
+ #include <sys/select.h>
+ #endif

--- a/dev-libs/newt/newt-0.52.24.ebuild
+++ b/dev-libs/newt/newt-0.52.24.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -34,6 +34,7 @@ BDEPEND="sys-devel/gettext"
 PATCHES=(
 	"${FILESDIR}"/${PN}-0.52.23-gold.patch
 	"${FILESDIR}"/${PN}-0.52.21-python-sitedir.patch
+	"${FILESDIR}"/${PN}-0.52.24-c99-fix.patch
 )
 
 S=${WORKDIR}/${PN}-${MY_PV}


### PR DESCRIPTION
This patch fixes 'error: implicit declaration of function 'strncmp'' which made it impossible to compile this program in modern versions of the C standard.

Closes: https://bugs.gentoo.org/947171
Signed-off-by: Solegaiter meartzheast877@gmail.com

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
