### PR TITLE
sys-apps/portage: prepare for unexported PMS variables

### DIFF
--- a/sys-apps/portage/portage-9999.ebuild
+++ b/sys-apps/portage/portage-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -181,18 +181,22 @@ pkg_preinst() {
 			-u PORTDIR \
 			-u PORTDIR_OVERLAY \
 			PYTHONPATH="${D}${sitedir}${PYTHONPATH:+:${PYTHONPATH}}" \
+			ED="${ED}" \
 			"${PYTHON}" -m portage._compat_upgrade.default_locations || die
 
 		env -u BINPKG_COMPRESS -u PORTAGE_REPOSITORIES \
 			PYTHONPATH="${D}${sitedir}${PYTHONPATH:+:${PYTHONPATH}}" \
+			ED="${ED}" \
 			"${PYTHON}" -m portage._compat_upgrade.binpkg_compression || die
 
 		env -u FEATURES -u PORTAGE_REPOSITORIES \
 			PYTHONPATH="${D}${sitedir}${PYTHONPATH:+:${PYTHONPATH}}" \
+			ED="${ED}" \
 			"${PYTHON}" -m portage._compat_upgrade.binpkg_multi_instance || die
 
 		env -u BINPKG_FORMAT \
 			PYTHONPATH="${D}${sitedir}${PYTHONPATH:+:${PYTHONPATH}}" \
+			ED="${ED}" \
 			"${PYTHON}" -m portage._compat_upgrade.binpkg_format || die
 	fi
 


### PR DESCRIPTION
Once a future EAPI does no longer export PMS variables (bug #721088 and [1]), we need to explicitly ensure that those are exported to helper commands which expect certain PMS variables in their process environment.

While the portage ebuild is usually deliberately not using the latest EAPI, it may be a good idea to make it explicit that the _compat_upgrade helpers expect ED in their process environment.

1: https://github.com/gentoo/portage/pull/1407
