### PR TITLE
dev-build/make: fix to use C23.

### DIFF
--- a/dev-build/make/files/make-4.4.1-r100-c23-fix.patch
+++ b/dev-build/make/files/make-4.4.1-r100-c23-fix.patch
@@ -1,0 +1,39 @@
+diff --git a/lib/fnmatch.c b/lib/fnmatch.c
+index 01da376..cb1c856 100644
+--- a/lib/fnmatch.c
++++ b/lib/fnmatch.c
+@@ -121,7 +121,7 @@ USA.  */
+    whose names are inconsistent.  */
+ 
+ # if !defined _LIBC && !defined getenv
+-extern char *getenv ();
++extern char *getenv (const char *);
+ # endif
+ 
+ # ifndef errno
+diff --git a/src/getopt.c b/src/getopt.c
+index 7a792de..76251cc 100644
+--- a/src/getopt.c
++++ b/src/getopt.c
+@@ -202,7 +202,7 @@ static char *posixly_correct;
+    whose names are inconsistent.  */
+ 
+ #ifndef getenv
+-extern char *getenv ();
++extern char *getenv (const char *);
+ #endif
+ 
+ static char *
+diff --git a/src/getopt.h b/src/getopt.h
+index df18cee..f84b36d 100644
+--- a/src/getopt.h
++++ b/src/getopt.h
+@@ -102,7 +102,7 @@ struct option
+    errors, only prototype getopt for the GNU C library.  */
+ extern int getopt (int argc, char *const *argv, const char *shortopts);
+ #else /* not __GNU_LIBRARY__ */
+-extern int getopt ();
++extern int getopt (int argc, char *const *argv, const char *shortopts);
+ #endif /* __GNU_LIBRARY__ */
+ extern int getopt_long (int argc, char *const *argv, const char *shortopts,
+ 		        const struct option *longopts, int *longind);

--- a/dev-build/make/make-4.4.1-r100.ebuild
+++ b/dev-build/make/make-4.4.1-r100.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -46,6 +46,7 @@ DOCS="AUTHORS NEWS README*"
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-4.4-default-cxx.patch
+	"${FILESDIR}"/${PN}-4.4.1-r100-c23-fix.patch
 )
 
 src_unpack() {


### PR DESCRIPTION
This patch fixes 'error: conflicting types for 'getenv'; have 'char *(void)'' which made it impossible to compile this program on the C23 version of the C standard on musl systems.

Closes: https://bugs.gentoo.org/945968
Signed-off-by: Solegaiter meartzheast877@gmail.com

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
