### PR TITLE
media-sound/id3tool: update EAPI 7 -> 8, fix impl. function in configure

### DIFF
--- a/media-sound/id3tool/id3tool-1.2a-r1.ebuild
+++ b/media-sound/id3tool/id3tool-1.2a-r1.ebuild
@@ -1,0 +1,21 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools
+
+DESCRIPTION="Tool for easy manipulation of the ID3 tags present in MP3 audio files"
+HOMEPAGE="http://nekohako.xware.cx/id3tool/"
+SRC_URI="http://nekohako.xware.cx/id3tool/${P}.tar.gz"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~ppc ~ppc64 ~sparc ~x86"
+
+src_prepare() {
+	default
+
+	#implied function in configure, bug https://bugs.gentoo.org/899852
+	eautoreconf
+}


### PR DESCRIPTION
Autoreconf solves some trivial problems without a second thought.

Bug: https://bugs.gentoo.org/899852

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
