### PR TITLE
x11-terms/ghostty: remove IUSE glfw, always build gtk runtime

### DIFF
--- a/eclass/zig-utils.eclass
+++ b/eclass/zig-utils.eclass
@@ -1,4 +1,4 @@
-# Copyright 2024 Gentoo Authors
+# Copyright 2024-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: zig-utils.eclass
@@ -54,6 +54,14 @@ inherit edo flag-o-matic linux-info
 # and most likely changed to more common in other eclasses ZIG_MIN/
 # ZIG_MAX form.
 
+# @ECLASS_VARIABLE: ZIG_NEEDS_LLVM
+# @PRE_INHERIT
+# @DEFAULT_UNSET
+# @DESCRIPTION:
+# If set to a non-empty value, the package will BDEPEND on a Zig package
+# with LLVM enabled.  This is currently required for packages that require
+# C/C++ source files to be compiled with Zig.
+
 # @ECLASS_VARIABLE: ZIG_OPTIONAL
 # @PRE_INHERIT
 # @DEFAULT_UNSET
@@ -69,9 +77,15 @@ inherit edo flag-o-matic linux-info
 # For zig.eclass users: see documentation in zig.eclass
 # instead.
 if [[ ! ${ZIG_OPTIONAL} ]]; then
+	_ZIG_USEDEP=""
+	if [[ ${ZIG_NEEDS_LLVM} ]]; then
+		_ZIG_USEDEP="[llvm(+)]"
+	fi
+
+	# NOTE: zig-bin is always built with LLVM support, so no USE needed.
 	BDEPEND="
 		|| (
-			dev-lang/zig:${ZIG_SLOT}
+			dev-lang/zig:${ZIG_SLOT}${_ZIG_USEDEP}
 			dev-lang/zig-bin:${ZIG_SLOT}
 		)
 	"

--- a/x11-terms/ghostty/ghostty-1.0.1-r1.ebuild
+++ b/x11-terms/ghostty/ghostty-1.0.1-r1.ebuild
@@ -62,13 +62,13 @@ KEYWORDS="~amd64"
 
 # TODO: simdutf integration (missing Gentoo version)
 # TODO: spirv-cross integration (missing Gentoo package)
-# TODO: glfw integration (no option from upstream)
 # NOTE: gtk backend requires X right now since ghostty unconditionally
 #       includes gdk/x11/gdkx.h.
 #       https://github.com/ghostty-org/ghostty/issues/3477
 RDEPEND="
+	gui-libs/gtk:4=[X]
+
 	adwaita? ( gui-libs/libadwaita:1= )
-	gtk? ( gui-libs/gtk:4=[X] )
 
 	system-fontconfig? ( >=media-libs/fontconfig-2.14.2:= )
 	system-freetype? (
@@ -87,16 +87,11 @@ BDEPEND="
 	man? ( virtual/pandoc )
 "
 
-IUSE="+adwaita man +gtk glfw"
+IUSE="+adwaita man"
 # System integrations
 IUSE+="
 	+system-fontconfig +system-freetype +system-glslang +system-harfbuzz +system-libpng +system-libxml2
 	+system-oniguruma +system-zlib
-"
-
-REQUIRED_USE="
-	adwaita? ( gtk )
-	^^ ( gtk glfw )
 "
 
 # XXX: Because we set --release=fast below, Zig will automatically strip
@@ -114,6 +109,7 @@ src_configure() {
 		# XXX: Ghostty displays a banner saying it is a debug build unless ReleaseFast is used.
 		--release=fast
 
+		-Dapp-runtime=gtk
 		-Dfont-backend=fontconfig_freetype
 		-Drenderer=opengl
 		-Dgtk-adwaita=$(usex adwaita true false)
@@ -129,16 +125,6 @@ src_configure() {
 		-f$(usex system-oniguruma sys no-sys)=oniguruma
 		-f$(usex system-zlib sys no-sys)=zlib
 	)
-
-	if use gtk; then
-		my_zbs_args+=(
-			-Dapp-runtime=gtk
-		)
-	elif use glfw; then
-		my_zbs_args+=(
-			-Dapp-runtime=glfw
-		)
-	fi
 
 	zig_src_configure
 }

--- a/x11-terms/ghostty/ghostty-1.0.1.ebuild
+++ b/x11-terms/ghostty/ghostty-1.0.1.ebuild
@@ -71,7 +71,10 @@ RDEPEND="
 	gtk? ( gui-libs/gtk:4=[X] )
 
 	system-fontconfig? ( >=media-libs/fontconfig-2.14.2:= )
-	system-freetype? ( >=media-libs/freetype-2.13.2:=[bzip2] )
+	system-freetype? (
+		system-harfbuzz? ( >=media-libs/freetype-2.13.2:=[bzip2,harfbuzz] )
+		!system-harfbuzz? ( >=media-libs/freetype-2.13.2:=[bzip2] )
+	)
 	system-glslang? ( >=dev-util/glslang-1.3.296.0:= )
 	system-harfbuzz? ( >=media-libs/harfbuzz-8.4.0:= )
 	system-libpng? ( >=media-libs/libpng-1.6.43:= )

--- a/x11-terms/ghostty/ghostty-1.0.1.ebuild
+++ b/x11-terms/ghostty/ghostty-1.0.1.ebuild
@@ -42,6 +42,7 @@ declare -g -r -A ZBS_DEPENDENCIES=(
 )
 
 ZIG_SLOT="0.13"
+ZIG_NEEDS_LLVM=1
 inherit zig xdg
 
 SRC_URI="

--- a/x11-terms/ghostty/metadata.xml
+++ b/x11-terms/ghostty/metadata.xml
@@ -14,8 +14,6 @@
 	</upstream>
 	<use>
 		<flag name="adwaita">Use <pkg>gui-libs/libadwaita</pkg> for better GNOME integration</flag>
-		<flag name="gtk">Use the GTK 4 backend for windowing</flag>
-		<flag name="glfw">Use the GLFW backend for windowing</flag>
 		<flag name="system-fontconfig">Use system fontconfig instead of the bundled one</flag>
 		<flag name="system-freetype">Use system freetype instead of the bundled one</flag>
 		<flag name="system-glslang">Use system glslang instead of the bundled one</flag>


### PR DESCRIPTION
Upstream does not want the GLFW runtime to be a user-facing option. The required source packages are still included in the ebuild and users can build the backend using `ZBS_EXTRA_ARGS="-Dapp-runtime=glfw"` in `/etc/portage/package.env` if they wish.

Depends on #39938, #39949 for combined revision bump with previous commits.

Link: https://github.com/ghostty-org/ghostty/commit/e9e82d94accd13a9fa6964a897a7c692c2ec2db2

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
