### PR TITLE
dev-util/pkgcruft: properly setup bindgen environment

### DIFF
--- a/dev-util/pkgcruft/pkgcruft-0.0.4.ebuild
+++ b/dev-util/pkgcruft/pkgcruft-0.0.4.ebuild
@@ -1,12 +1,13 @@
-# Copyright 2023-2024 Gentoo Authors
+# Copyright 2023-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
 CRATES=" "
+LLVM_COMPAT=( {17..19} )
 RUST_MIN_VER="1.80.0"
 
-inherit cargo edo flag-o-matic toolchain-funcs
+inherit cargo edo flag-o-matic llvm-r2 toolchain-funcs
 
 DESCRIPTION="QA library and tools based on pkgcraft"
 HOMEPAGE="https://pkgcraft.github.io/"
@@ -33,11 +34,18 @@ RESTRICT="!test? ( test )"
 
 # clang needed for bindgen
 BDEPEND+="
-	llvm-core/clang
+	$(llvm_gen_dep '
+		llvm-core/clang:${LLVM_SLOT}
+	')
 	test? ( dev-util/cargo-nextest )
 "
 
 QA_FLAGS_IGNORED="usr/bin/pkgcruft"
+
+pkg_setup() {
+	llvm-r2_pkg_setup
+	rust_pkg_setup
+}
 
 src_unpack() {
 	if [[ ${PV} == 9999 ]] ; then

--- a/dev-util/pkgcruft/pkgcruft-0.0.6.ebuild
+++ b/dev-util/pkgcruft/pkgcruft-0.0.6.ebuild
@@ -1,12 +1,13 @@
-# Copyright 2023-2024 Gentoo Authors
+# Copyright 2023-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
 CRATES=" "
+LLVM_COMPAT=( {17..19} )
 RUST_MIN_VER="1.80.0"
 
-inherit cargo edo flag-o-matic toolchain-funcs
+inherit cargo edo flag-o-matic llvm-r2 toolchain-funcs
 
 DESCRIPTION="QA library and tools based on pkgcraft"
 HOMEPAGE="https://pkgcraft.github.io/"
@@ -33,11 +34,18 @@ RESTRICT="!test? ( test )"
 
 # clang needed for bindgen
 BDEPEND+="
-	llvm-core/clang
+	$(llvm_gen_dep '
+		llvm-core/clang:${LLVM_SLOT}
+	')
 	test? ( dev-util/cargo-nextest )
 "
 
 QA_FLAGS_IGNORED="usr/bin/pkgcruft"
+
+pkg_setup() {
+	llvm-r2_pkg_setup
+	rust_pkg_setup
+}
 
 src_unpack() {
 	if [[ ${PV} == 9999 ]] ; then

--- a/dev-util/pkgcruft/pkgcruft-0.0.8.ebuild
+++ b/dev-util/pkgcruft/pkgcruft-0.0.8.ebuild
@@ -1,12 +1,13 @@
-# Copyright 2023-2024 Gentoo Authors
+# Copyright 2023-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
 CRATES=" "
+LLVM_COMPAT=( {17..19} )
 RUST_MIN_VER="1.82.0"
 
-inherit cargo edo flag-o-matic shell-completion toolchain-funcs
+inherit cargo edo flag-o-matic llvm-r2 shell-completion toolchain-funcs
 
 DESCRIPTION="QA library and tools based on pkgcraft"
 HOMEPAGE="https://pkgcraft.github.io/"
@@ -33,11 +34,18 @@ RESTRICT="!test? ( test )"
 
 # clang needed for bindgen
 BDEPEND+="
-	llvm-core/clang
+	$(llvm_gen_dep '
+		llvm-core/clang:${LLVM_SLOT}
+	')
 	test? ( dev-util/cargo-nextest )
 "
 
 QA_FLAGS_IGNORED="usr/bin/pkgcruft"
+
+pkg_setup() {
+	llvm-r2_pkg_setup
+	rust_pkg_setup
+}
 
 src_unpack() {
 	if [[ ${PV} == 9999 ]] ; then

--- a/dev-util/pkgcruft/pkgcruft-9999.ebuild
+++ b/dev-util/pkgcruft/pkgcruft-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2023-2024 Gentoo Authors
+# Copyright 2023-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8


### PR DESCRIPTION
The bindgen crate requires LIBCLANG_PATH which is setup by the llvm eclasses.



Not sure if this requires a revbump, the user will rebuild anyways with the new LLVM_COMPAT flag.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
