### PR TITLE
x11-terms/ghostty: ebuild enhancements

### DIFF
--- a/x11-terms/ghostty/ghostty-1.0.1-r1.ebuild
+++ b/x11-terms/ghostty/ghostty-1.0.1-r1.ebuild
@@ -62,19 +62,19 @@ KEYWORDS="~amd64"
 
 # TODO: simdutf integration (missing Gentoo version)
 # TODO: spirv-cross integration (missing Gentoo package)
-# TODO: glfw integration (no option from upstream)
 RDEPEND="
+	gui-libs/gtk:4=[X?]
+
 	adwaita? ( gui-libs/libadwaita:1= )
-	gtk? (
-		gui-libs/gtk:4=[X?]
-		X? ( x11-libs/libX11 )
-	)
+	X? ( x11-libs/libX11 )
 
 	system-fontconfig? ( >=media-libs/fontconfig-2.14.2:= )
 	system-freetype? (
 		system-harfbuzz? ( >=media-libs/freetype-2.13.2:=[bzip2,harfbuzz] )
 		!system-harfbuzz? ( >=media-libs/freetype-2.13.2:=[bzip2] )
 	)
+	system-fontconfig? ( >=media-libs/fontconfig-2.14.2:= )
+	system-freetype? ( >=media-libs/freetype-2.13.2:=[bzip2] )
 	system-glslang? ( >=dev-util/glslang-1.3.296.0:= )
 	system-harfbuzz? ( >=media-libs/harfbuzz-8.4.0:= )
 	system-libpng? ( >=media-libs/libpng-1.6.43:= )
@@ -87,17 +87,11 @@ BDEPEND="
 	man? ( virtual/pandoc )
 "
 
-IUSE="+X +adwaita man +gtk glfw"
+IUSE="+X +adwaita man"
 # System integrations
 IUSE+="
 	+system-fontconfig +system-freetype +system-glslang +system-harfbuzz +system-libpng +system-libxml2
 	+system-oniguruma +system-zlib
-"
-
-REQUIRED_USE="
-	X? ( gtk )
-	adwaita? ( gtk )
-	^^ ( gtk glfw )
 "
 
 # XXX: Because we set --release=fast below, Zig will automatically strip
@@ -115,6 +109,7 @@ src_configure() {
 		# XXX: Ghostty displays a banner saying it is a debug build unless ReleaseFast is used.
 		--release=fast
 
+		-Dapp-runtime=gtk
 		-Dfont-backend=fontconfig_freetype
 		-Drenderer=opengl
 		-Dgtk-adwaita=$(usex adwaita true false)
@@ -131,16 +126,6 @@ src_configure() {
 		-f$(usex system-oniguruma sys no-sys)=oniguruma
 		-f$(usex system-zlib sys no-sys)=zlib
 	)
-
-	if use gtk; then
-		my_zbs_args+=(
-			-Dapp-runtime=gtk
-		)
-	elif use glfw; then
-		my_zbs_args+=(
-			-Dapp-runtime=glfw
-		)
-	fi
 
 	zig_src_configure
 }

--- a/x11-terms/ghostty/ghostty-1.0.1-r1.ebuild
+++ b/x11-terms/ghostty/ghostty-1.0.1-r1.ebuild
@@ -67,7 +67,6 @@ RDEPEND="
 
 	adwaita? ( gui-libs/libadwaita:1= )
 	X? ( x11-libs/libX11 )
-
 	system-fontconfig? ( >=media-libs/fontconfig-2.14.2:= )
 	system-freetype? (
 		system-harfbuzz? ( >=media-libs/freetype-2.13.2:=[bzip2,harfbuzz] )
@@ -89,10 +88,8 @@ BDEPEND="
 
 IUSE="+X +adwaita man"
 # System integrations
-IUSE+="
-	+system-fontconfig +system-freetype +system-glslang +system-harfbuzz +system-libpng +system-libxml2
-	+system-oniguruma +system-zlib
-"
+IUSE+=" +system-fontconfig +system-freetype +system-glslang +system-harfbuzz +system-libpng +system-libxml2"
+IUSE+=" +system-oniguruma +system-zlib"
 
 # XXX: Because we set --release=fast below, Zig will automatically strip
 #      the binary. Until Ghostty provides a way to disable the banner while

--- a/x11-terms/ghostty/ghostty-1.0.1-r1.ebuild
+++ b/x11-terms/ghostty/ghostty-1.0.1-r1.ebuild
@@ -42,6 +42,7 @@ declare -g -r -A ZBS_DEPENDENCIES=(
 )
 
 ZIG_SLOT="0.13"
+ZIG_NEEDS_LLVM=1
 inherit zig xdg
 
 SRC_URI="

--- a/x11-terms/ghostty/ghostty-1.0.1-r1.ebuild
+++ b/x11-terms/ghostty/ghostty-1.0.1-r1.ebuild
@@ -71,7 +71,10 @@ RDEPEND="
 	)
 
 	system-fontconfig? ( >=media-libs/fontconfig-2.14.2:= )
-	system-freetype? ( >=media-libs/freetype-2.13.2:=[bzip2] )
+	system-freetype? (
+		system-harfbuzz? ( >=media-libs/freetype-2.13.2:=[bzip2,harfbuzz] )
+		!system-harfbuzz? ( >=media-libs/freetype-2.13.2:=[bzip2] )
+	)
 	system-glslang? ( >=dev-util/glslang-1.3.296.0:= )
 	system-harfbuzz? ( >=media-libs/harfbuzz-8.4.0:= )
 	system-libpng? ( >=media-libs/libpng-1.6.43:= )

--- a/x11-terms/ghostty/ghostty-1.0.1.ebuild
+++ b/x11-terms/ghostty/ghostty-1.0.1.ebuild
@@ -62,12 +62,12 @@ KEYWORDS="~amd64"
 # TODO: simdutf integration (missing Gentoo version)
 # TODO: spirv-cross integration (missing Gentoo package)
 # TODO: glfw integration (no option from upstream)
-# NOTE: gtk backend requires X right now since ghostty unconditionally
-#       includes gdk/x11/gdkx.h.
-#       https://github.com/ghostty-org/ghostty/issues/3477
 RDEPEND="
 	adwaita? ( gui-libs/libadwaita:1= )
-	gtk? ( gui-libs/gtk:4=[X] )
+	gtk? (
+		gui-libs/gtk:4=[X?]
+		X? ( x11-libs/libX11 )
+	)
 
 	system-fontconfig? ( >=media-libs/fontconfig-2.14.2:= )
 	system-freetype? ( >=media-libs/freetype-2.13.2:=[bzip2] )
@@ -83,7 +83,7 @@ BDEPEND="
 	man? ( virtual/pandoc )
 "
 
-IUSE="+adwaita man +gtk glfw"
+IUSE="+X +adwaita man +gtk glfw"
 # System integrations
 IUSE+="
 	+system-fontconfig +system-freetype +system-glslang +system-harfbuzz +system-libpng +system-libxml2
@@ -91,6 +91,7 @@ IUSE+="
 "
 
 REQUIRED_USE="
+	X? ( gtk )
 	adwaita? ( gtk )
 	^^ ( gtk glfw )
 "
@@ -113,6 +114,7 @@ src_configure() {
 		-Dfont-backend=fontconfig_freetype
 		-Drenderer=opengl
 		-Dgtk-adwaita=$(usex adwaita true false)
+		-Dgtk-x11=$(usex X true false)
 		-Demit-docs=$(usex man true false)
 		-Dversion-string="${PV}"
 

--- a/x11-terms/ghostty/metadata.xml
+++ b/x11-terms/ghostty/metadata.xml
@@ -14,8 +14,6 @@
 	</upstream>
 	<use>
 		<flag name="adwaita">Use <pkg>gui-libs/libadwaita</pkg> for better GNOME integration</flag>
-		<flag name="gtk">Use the GTK 4 backend for windowing</flag>
-		<flag name="glfw">Use the GLFW backend for windowing</flag>
 		<flag name="system-fontconfig">Use system fontconfig instead of the bundled one</flag>
 		<flag name="system-freetype">Use system freetype instead of the bundled one</flag>
 		<flag name="system-glslang">Use system glslang instead of the bundled one</flag>


### PR DESCRIPTION
Combines the three PRs into one: #39938, #39949, #39950.

The following changes are done:
- The ebuild no longer hard-depends on `gui-libs/gtk[X]`. `IUSE=X` is added to control whether X11 support is enabled.
- We now depend on `dev-lang/zig[llvm]` since Ghostty compiles C/C++ source files which requires a Zig built with LLVM.
- `IUSE=glfw` is dropped to respect upstream wishes. `IUSE=gtk` is also dropped as it's no longer conditional.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
