### PR TITLE
{x11-libs/wxGTK,sci-electronics/kicad}: add optional egl backend

### DIFF
--- a/sci-electronics/kicad/kicad-8.0.6.ebuild
+++ b/sci-electronics/kicad/kicad-8.0.6.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -28,7 +28,7 @@ fi
 # BSD for bundled pybind
 LICENSE="GPL-2+ GPL-3+ Boost-1.0 BSD"
 SLOT="0"
-IUSE="doc examples nls openmp test"
+IUSE="doc egl examples nls openmp test"
 
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 
@@ -53,7 +53,7 @@ COMMON_DEPEND="
 	>=x11-libs/pixman-0.30
 	>sci-electronics/ngspice-27[shared]
 	sys-libs/zlib
-	>=x11-libs/wxGTK-3.2.2.1-r3:${WX_GTK_VER}[X,opengl]
+	>=x11-libs/wxGTK-3.2.2.1-r3:${WX_GTK_VER}[X,opengl,egl=]
 	$(python_gen_cond_dep '
 		dev-libs/boost:=[context,nls,python,${PYTHON_USEDEP}]
 		>=dev-python/wxpython-4.2.0:*[${PYTHON_USEDEP}]
@@ -107,7 +107,7 @@ src_configure() {
 		-DKICAD_DOCS="${EPREFIX}/usr/share/doc/${PN}-doc-${PV}"
 
 		-DKICAD_SCRIPTING_WXPYTHON=ON
-		-DKICAD_USE_EGL=OFF
+		-DKICAD_USE_EGL="$(usex egl)"
 
 		-DKICAD_BUILD_I18N="$(usex nls)"
 		-DKICAD_I18N_UNIX_STRICT_PATH="$(usex nls)"

--- a/x11-libs/wxGTK/wxGTK-3.2.5.ebuild
+++ b/x11-libs/wxGTK/wxGTK-3.2.5.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -21,8 +21,8 @@ S="${WORKDIR}/wxWidgets-${PV}"
 LICENSE="wxWinLL-3 GPL-2 doc? ( wxWinFDL-3 )"
 SLOT="${WXRELEASE}"
 KEYWORDS="~alpha amd64 ~arm ~arm64 ~hppa ~loong ~mips ppc ~ppc64 ~riscv ~sparc x86 ~amd64-linux ~x86-linux"
-IUSE="+X curl doc debug keyring gstreamer libnotify +lzma opengl pch sdl +spell test tiff wayland webkit"
-REQUIRED_USE="test? ( tiff ) tiff? ( X ) spell? ( X ) keyring? ( X )"
+IUSE="+X curl doc debug egl keyring gstreamer libnotify +lzma opengl pch sdl +spell test tiff wayland webkit"
+REQUIRED_USE="test? ( tiff ) tiff? ( X ) spell? ( X ) keyring? ( X ) egl? ( opengl )"
 RESTRICT="!test? ( test )"
 
 RDEPEND="
@@ -166,7 +166,7 @@ multilib_src_configure() {
 	#
 	# Check that the macro wxUSE_GLCANVAS_EGL is set to 1.
 	#
-	myeconfargs+=( "--disable-glcanvasegl" )
+	use egl || myeconfargs+=( "--disable-glcanvasegl" )
 
 	# debug in >=2.9
 	# there is no longer separate debug libraries (gtk2ud)


### PR DESCRIPTION
x11-libs/wxGTK: Add use flag for egl backend. Prusaslicer issue is closed (can egl be default yet?)
sci-electronics/kicad: Add egl use flag. Allows it to run in native wayland.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
