### PR TITLE
app-misc/ranger: add 1.9.4_p20250104

### DIFF
--- a/app-misc/ranger/files/ranger-1.9.4-ncurses-compat.patch
+++ b/app-misc/ranger/files/ranger-1.9.4-ncurses-compat.patch
@@ -1,0 +1,33 @@
+Backport of upstream bugfix PR#3039 [0] for compatibility with newer
+versions of ncurses.
+
+[0] https://github.com/ranger/ranger/pull/3039/files
+
+--- a/ranger/gui/ui.py
++++ b/ranger/gui/ui.py
+@@ -151,10 +151,6 @@ def suspend(self):
+         self.win.keypad(0)
+         curses.nocbreak()
+         curses.echo()
+-        try:
+-            curses.curs_set(1)
+-        except curses.error:
+-            pass
+         if self.settings.mouse_enabled:
+             _setup_mouse({"value": False})
+         curses.endwin()
+
+--- a/ranger/gui/ui.py
++++ b/ranger/gui/ui.py
+@@ -128,9 +128,10 @@ def initialize(self):
+             self.is_set_up = True
+             self.setup()
+             self.win.addstr("loading...")
+-            self.win.refresh()
+             self._draw_title = curses.tigetflag('hs')  # has_status_line
+ 
++        self.win.refresh()
++
+         self.update_size()
+         self.is_on = True
+ 

--- a/app-misc/ranger/ranger-1.9.4_p20250104.ebuild
+++ b/app-misc/ranger/ranger-1.9.4_p20250104.ebuild
@@ -1,0 +1,52 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DISTUTILS_SINGLE_IMPL=1
+DISTUTILS_USE_PEP517=setuptools
+PYTHON_COMPAT=( python3_{10..13} )
+PYTHON_REQ_USE="ncurses"
+inherit distutils-r1 xdg
+
+MY_PV=$(ver_cut 1-3)
+MY_P="${PN}-${MY_PV}"
+
+if [[ ${PV} == 9999 ]]; then
+	inherit git-r3
+	EGIT_REPO_URI="https://github.com/ranger/ranger.git"
+else
+	SRC_URI="
+		https://github.com/ranger/ranger/archive/v${MY_PV}.tar.gz
+			-> ${MY_P}.gh.tar.gz
+	"
+	S="${WORKDIR}/${MY_P}"
+	KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~riscv ~x86"
+fi
+
+DESCRIPTION="Vim-inspired file manager for the console"
+HOMEPAGE="https://ranger.github.io/"
+
+LICENSE="GPL-3"
+SLOT="0"
+
+distutils_enable_tests pytest
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-1.9.3-color-crash-fix.patch
+)
+
+src_prepare() {
+	distutils-r1_src_prepare
+
+	sed -i "s|share/doc/ranger|share/doc/${PF}|" setup.py doc/ranger.1 || die
+}
+
+pkg_postinst() {
+	xdg_pkg_postinst
+
+	if [[ ! ${REPLACING_VERSIONS} ]]; then
+		elog "${PN^} has many optional dependencies to support enhanced file previews."
+		elog "See ${EROOT}/usr/share/doc/${PF}/README.md* for more details."
+	fi
+}


### PR DESCRIPTION
This _p version adds a backport for an important bugfix for the currently broken bulkrename, a major feature of ranger. As the activity on the upstream issue [0] indicates, this bugfix is of high interest for users of ranger.

[0] https://github.com/ranger/ranger/pull/2935

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
