### PR TITLE
media-sound/mp3c: update EAPI 7 -> 8, port to C23

### DIFF
--- a/media-sound/mp3c/files/mp3c-c23.patch
+++ b/media-sound/mp3c/files/mp3c-c23.patch
@@ -1,0 +1,27 @@
+https://bugs.gentoo.org/899854
+also, feature-macro'd glibc functions
+--- a/configure.ac	2025-01-05 00:30:25.475280699 +0400
++++ b/configure.ac	2025-01-05 00:30:38.800207692 +0400
+@@ -6,7 +6,8 @@
+ 
+ AM_INIT_AUTOMAKE
++AC_USE_SYSTEM_EXTENSIONS
+ AM_GNU_GETTEXT([external])
+-AM_GNU_GETTEXT_VERSION
++AM_GNU_GETTEXT_VERSION(0.21)
+ AM_ICONV
+ 
+ AC_PROG_CC
+Bad definition, fails with C23
+https://bugs.gentoo.org/945206
+--- a/src/keys.c	2025-01-05 00:39:12.053395586 +0400
++++ b/src/keys.c	2025-01-05 00:39:42.420229207 +0400
+@@ -76,7 +76,7 @@
+ extern int build_data_tree(char *cddb_server, char *local_cddb_db,
+ 			   song_typ **ret_tree, BOOL force_sampler);
+ extern int cddb_internet_lookup (char *addr, char *cddb_path, BOOL force);
+-extern void option_menu();
++extern void option_menu(WINDOW *win);
+ extern int output_batch(song_typ *anchor, char *filenm, BOOL ask_overwrite);
+ extern void calc_tot_frm();
+ extern int add_to_m3u(song_typ *song);

--- a/media-sound/mp3c/mp3c-0.31-r2.ebuild
+++ b/media-sound/mp3c/mp3c-0.31-r2.ebuild
@@ -1,0 +1,47 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit flag-o-matic toolchain-funcs autotools
+
+DESCRIPTION="console based mp3 ripper, with cddb support"
+HOMEPAGE="http://wspse.de/WSPse/Linux-MP3c.php3"
+SRC_URI="ftp://ftp.wspse.de/pub/linux/wspse/${P}.tar.bz2"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~sparc ~x86"
+IUSE="mp3 vorbis"
+
+DEPEND="sys-libs/ncurses:0="
+RDEPEND="
+	${DEPEND}
+	app-cdr/cdrtools
+	mp3? (
+		media-sound/lame
+		media-sound/mp3info
+	)
+	vorbis? ( media-sound/vorbis-tools )"
+BDEPEND="virtual/pkgconfig"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-buffer.patch
+	"${FILESDIR}"/${PN}-c23.patch
+)
+
+src_prepare() {
+	default
+
+	eautoreconf
+}
+
+src_configure() {
+	append-libs $($(tc-getPKG_CONFIG) --libs ncurses)
+	econf $(use_enable vorbis oggdefaults)
+}
+
+src_install() {
+	default
+	dodoc BATCH.README CDDB_HOWTO OTHERS
+}


### PR DESCRIPTION
As usual, AC_USE_SYSTEM_EXTENSIONS, autoreconf and correction of wrong function declaration.

Bug: https://bugs.gentoo.org/899854
Bug: https://bugs.gentoo.org/945206

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
