### PR TITLE
app-cdr/ccd2iso: implicit-in-configure

### DIFF
--- a/app-cdr/ccd2iso/ccd2iso-0.3-r2.ebuild
+++ b/app-cdr/ccd2iso/ccd2iso-0.3-r2.ebuild
@@ -1,0 +1,22 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools
+
+DESCRIPTION="Convert CD images from ccd (CloneCD) to iso"
+HOMEPAGE="https://sourceforge.net/projects/ccd2iso/"
+SRC_URI="https://downloads.sourceforge.net/ccd2iso/${P}.tar.gz"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos"
+
+PATCHES=( "${FILESDIR}"/${P}-headers.patch )
+
+src_prepare() {
+	default
+	#C99 https://bugs.gentoo.org/900126
+	eautoreconf
+}


### PR DESCRIPTION
Fixed by autoreconf

Bug: https://bugs.gentoo.org/900126

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
