### PR TITLE
x11-plugins/wmbinclock: port to C99

### DIFF
--- a/x11-plugins/wmbinclock/files/wmbinclock-0.5-gcc-14.patch
+++ b/x11-plugins/wmbinclock/files/wmbinclock-0.5-gcc-14.patch
@@ -1,0 +1,77 @@
+https://bugs.gentoo.org/877109
+fix type confusion
+also add fix glib feature macro for usleep
+diff -ru a/wmBinClock.c b/wmBinClock.c
+--- a/wmBinClock.c	2025-01-05 11:53:41.163293987 +0400
++++ b/wmBinClock.c	2025-01-05 11:55:33.251648423 +0400
+@@ -6,6 +6,7 @@
+ * Copyright (C) 2015 - Thomas Kuiper <tkuiper at inxsoft.net> and Sune Molgaard <sune at molgaard.org> (BSD license)
+ */
+ 
++#define _DEFAULT_SOURCE
+ #include <stdio.h>
+ #include <unistd.h>
+ #include <stdlib.h>
+@@ -66,7 +67,7 @@
+ int             DisplayDepth;
+ GC NormalGC;
+ 
+-void IntToBinary(int x, int *str[]);
++void IntToBinary(int x, int str[]);
+ void PrintHelp(char err[]);
+ 
+ int main(int argc, char *argv[])
+@@ -667,7 +668,7 @@
+ 	    }
+ 
+ 	    tmp_hour = tmworld->tm_hour;
+-	    IntToBinary(tmp_hour, &tmp_str);
++	    IntToBinary(tmp_hour, tmp_str);
+ 
+ 	    for (s = 0; s < 6; s++)
+ 	    {
+@@ -678,7 +679,7 @@
+ 	    }
+ 
+ 	    tmp_minute = tmworld->tm_min;
+-	    IntToBinary(tmp_minute, &tmp_str);
++	    IntToBinary(tmp_minute, tmp_str);
+ 	    for (s = 0; s < 6; s++)
+ 	    {
+ 		if (tmp_str[s] == 1)
+@@ -688,7 +689,7 @@
+ 	    }
+ 	
+ 	    tmp_second = tmworld->tm_sec;
+-	    IntToBinary(tmp_second, &tmp_str);
++	    IntToBinary(tmp_second, tmp_str);
+ 	    
+ 	    for (s = 0; s < 6; s++)
+ 	    {
+@@ -699,7 +700,7 @@
+ 	    }
+ 	    
+ 	    tmp_day = tmworld->tm_mday;
+-	    IntToBinary(tmp_day, &tmp_str);
++	    IntToBinary(tmp_day, tmp_str);
+ 	    
+ 	    for (s = 0; s < 6; s++)
+ 	    {
+@@ -710,7 +711,7 @@
+ 	    }
+ 
+ 	    tmp_month = tmworld->tm_mon + 1;
+-	    IntToBinary(tmp_month, &tmp_str);
++	    IntToBinary(tmp_month, tmp_str);
+ 	    
+ 	    for (s = 0; s < 6; s++)
+ 	    {
+@@ -780,7 +781,7 @@
+ 	usleep(DELAY);
+     }
+ }
+-void IntToBinary(int x, int *str[])
++void IntToBinary(int x, int str[])
+ {
+     int i = 0;
+     int counter = 0;

--- a/x11-plugins/wmbinclock/wmbinclock-0.51-r1.ebuild
+++ b/x11-plugins/wmbinclock/wmbinclock-0.51-r1.ebuild
@@ -1,0 +1,37 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit toolchain-funcs
+
+DESCRIPTION="a nifty little binary clock dockapp"
+HOMEPAGE="https://www.dockapps.net/wmbinclock"
+SRC_URI="https://downloads.sourceforge.net/${PN}/${P}.tar.gz"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~ppc64 ~sparc ~x86"
+
+RDEPEND="x11-libs/libX11
+	x11-libs/libXpm
+	x11-libs/libXext"
+DEPEND="${RDEPEND}
+	x11-base/xorg-proto"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-0.5-gcc-10.patch
+	"${FILESDIR}"/${PN}-0.5-gcc-14.patch
+)
+DOCS=( CHANGELOG README.md )
+
+src_compile() {
+	emake CC="$(tc-getCC)" CFLAGS="${CFLAGS}" \
+		INCDIR="-I/usr/include/X11" LIBDIR="" \
+		SYSTEM="${LDFLAGS}"
+}
+
+src_install() {
+	dobin wmBinClock
+	einstalldocs
+}


### PR DESCRIPTION
There was a type confusion between array, pointer and pointer to array

Bug: https://bugs.gentoo.org/877109

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
