### PR TITLE
net-vpn/pptpd: fix compile on MUSL

### DIFF
--- a/net-vpn/pptpd/files/pptpd-1.4.0-logwtmp.patch
+++ b/net-vpn/pptpd/files/pptpd-1.4.0-logwtmp.patch
@@ -1,0 +1,25 @@
+diff '--color=auto' -ru a/Makefile.am b/Makefile.am
+--- a/Makefile.am	2025-01-05 09:10:10.847711246 +0000
++++ b/Makefile.am	2025-01-05 09:11:31.846314376 +0000
+@@ -51,7 +51,9 @@
+ 
+ bcrelay_SOURCES = bcrelay.c defaults.h our_syslog.h our_getopt.h
+ 
++if HAVE_LOGWTMP
+ subdirs = plugins
++endif
+ 
+ all-local:
+ 	for d in $(subdirs); do $(MAKE) $(MFLAGS) -C $$d all; done
+diff '--color=auto' -ru a/configure.ac b/configure.ac
+--- a/configure.ac	2025-01-05 09:10:10.855711207 +0000
++++ b/configure.ac	2025-01-05 09:11:01.901461097 +0000
+@@ -187,6 +187,8 @@
+ AC_CHECK_LIB(socket, accept)
+ AC_CHECK_LIB(nsl, gethostbyname)
+ AC_CHECK_LIB(util, openpty)
++AC_CHECK_LIB(util, logwtmp, [has_logwtmp=true])
++AM_CONDITIONAL([HAVE_LOGWTMP], [test "x$has_logwtmp" = "xtrue"])
+ AC_CHECK_LIB(intl, gettext)
+ LIBS="$XYZZY_LIBS"
+ if test "$ac_cv_lib_c_accept" = no; then

--- a/net-vpn/pptpd/pptpd-1.4.0-r5.ebuild
+++ b/net-vpn/pptpd/pptpd-1.4.0-r5.ebuild
@@ -1,0 +1,83 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools flag-o-matic toolchain-funcs
+
+DESCRIPTION="Linux Point-to-Point Tunnelling Protocol Server"
+HOMEPAGE="https://poptop.sourceforge.net/"
+SRC_URI="https://downloads.sourceforge.net/poptop/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~hppa ~ppc ~ppc64 ~sparc ~x86"
+IUSE="gre-extreme-debug tcpd"
+
+RDEPEND="net-dialup/ppp:=
+	tcpd? ( sys-apps/tcp-wrappers )"
+DEPEND="${RDEPEND}
+	elibc_musl? ( net-libs/ppp-defs )"
+
+DOCS=( AUTHORS ChangeLog NEWS README TODO )
+
+src_prepare() {
+	# configure.in is actually configure.ac
+	mv configure.in configure.ac || die
+
+	# Automake 1.13 compatibility, bug #469476
+	sed -i -e 's/AM_CONFIG_HEADER/AC_CONFIG_HEADER/' configure.ac || die 'sed on configure.ac failed'
+
+	# remove 'missing' script to prevent warnings
+	rm missing || die 'remove missing script failed'
+
+	# respect compiler, bug #461722
+	tc-export CC
+
+	local PATCHES=(
+		"${FILESDIR}/${P}-gentoo.patch"
+		"${FILESDIR}/${P}-sandbox-fix.patch"
+		"${FILESDIR}/${P}-pidfile.patch"
+		"${FILESDIR}/${P}-libdir.patch"
+		"${FILESDIR}/${P}-musl.patch"
+		"${FILESDIR}/${P}-c99.patch"
+		"${FILESDIR}/${P}-logwtmp.patch"
+	)
+
+	if has_version -d ">=net-dialup/ppp-2.5.0"; then
+		# https://bugs.gentoo.org/904877
+		PATCHES+=( "${FILESDIR}/${P}-ppp-2.5.0.patch" )
+	fi
+
+	# Call to default src_prepare to apply patches
+	default
+
+	eautoreconf
+}
+
+src_configure() {
+	use gre-extreme-debug && append-cppflags "-DLOG_DEBUG_GRE_ACCEPTING_PACKET"
+	econf \
+		--enable-bcrelay \
+		$(use tcpd && echo "--with-libwrap")
+}
+
+src_compile() {
+	emake COPTS="${CFLAGS}"
+}
+
+src_install() {
+	default
+
+	insinto /etc
+	doins samples/pptpd.conf
+
+	insinto /etc/ppp
+	doins samples/options.pptpd
+
+	newinitd "${FILESDIR}/pptpd-init-r2" pptpd
+	newconfd "${FILESDIR}/pptpd-confd" pptpd
+
+	dodoc README.*
+	dodoc -r samples
+}


### PR DESCRIPTION
Add conditional compilation to build system, so on systems lacking logwtmp, we don't build plugin that uses logwtmp

Bug: https://bugs.gentoo.org/937134

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
