### PR TITLE
net-analyzer/raddump: update EAPI 7 -> 8, port to gcc-14

### DIFF
--- a/net-analyzer/raddump/files/raddump-0.3.1-gcc14.patch
+++ b/net-analyzer/raddump/files/raddump-0.3.1-gcc14.patch
@@ -1,0 +1,13 @@
+https://bugs.gentoo.org/919358
+diff -ru a/pktrecord.h b/pktrecord.h
+--- a/pktrecord.h	2025-01-05 15:55:08.349684611 +0400
++++ b/pktrecord.h	2025-01-05 15:57:49.645807285 +0400
+@@ -25,7 +25,7 @@
+   unsigned int included_len;   /* how much of it we actually have here */
+   unsigned int ts_secs;	       /* timestamp, seconds component */
+   unsigned int ts_usecs;       /* timestamp, microseconds component */
+-  unsigned char *pkt_data;     /* pointer to the actual packet data */
++  const unsigned char *pkt_data;     /* pointer to the actual packet data */
+ };
+ 
+ struct prec_handle;

--- a/net-analyzer/raddump/raddump-0.3.1-r1.ebuild
+++ b/net-analyzer/raddump/raddump-0.3.1-r1.ebuild
@@ -1,0 +1,24 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools
+
+DESCRIPTION="RADIUS packet interpreter"
+HOMEPAGE="https://sourceforge.net/projects/raddump/"
+SRC_URI="https://downloads.sourceforge.net/${PN}/${P}.tar.gz"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~ppc ~x86"
+
+RDEPEND=">=net-analyzer/tcpdump-3.8.3-r1"
+DEPEND=${RDEPEND}
+
+PATCHES=( "${FILESDIR}/${P}-gcc14.patch" )
+
+src_prepare() {
+	default
+	eautoreconf
+}


### PR DESCRIPTION
Const-correctness in struct definition

Bug: https://bugs.gentoo.org/919358

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
