### PR TITLE
app-shells/rc: fix build failure, port to C23

### DIFF
--- a/app-shells/rc/files/rc-1.7.4-C23.patch
+++ b/app-shells/rc/files/rc-1.7.4-C23.patch
@@ -1,0 +1,30 @@
+just use build-ins when C is modern enough
+and other glibc defines that need enablement
+diff -ru a/rc.h b/rc.h
+--- a/rc.h	2025-01-05 21:16:39.487999355 +0400
++++ b/rc.h	2025-01-05 21:21:13.688559101 +0400
+@@ -44,9 +44,14 @@
+ 	eError, eBreak, eReturn, eVarstack, eArena, eFifo, eFd
+ } ecodes;
+ 
++#if __STDC_VERSION__ <= 201710L
+ typedef enum bool {
+ 	FALSE, TRUE
+ } bool;
++#else
++#define FALSE false
++#define TRUE true
++#endif
+ 
+ typedef enum redirtype {
+ 	rFrom, rCreate, rAppend, rHeredoc, rHerestring
+diff -ru a/configure.ac b/configure.ac
+--- a/configure.ac	2025-01-05 21:33:03.952267739 +0400
++++ b/configure.ac	2025-01-05 21:33:20.702194221 +0400
+@@ -1,5 +1,6 @@
+ dnl Our package name, version, ...
+ AC_INIT([rc], [1.7.4])
++AC_USE_SYSTEM_EXTENSIONS
+ 
+ dnl ... and release date
+ RELDATE=`date -I`

--- a/app-shells/rc/files/rc-1.7.4-libedit.patch
+++ b/app-shells/rc/files/rc-1.7.4-libedit.patch
@@ -1,0 +1,17 @@
+bug https://bugs.gentoo.org/925558
+truncating number of lines from long uint to int and hoping
+for the best, due to API mismatch
+diff -ru a/edit-edit.c b/edit-edit.c
+--- a/edit-edit.c	2025-01-05 20:59:08.759555902 +0400
++++ b/edit-edit.c	2025-01-05 21:01:03.040010129 +0400
+@@ -50,8 +50,8 @@
+ 
+ 	oldint = sys_signal(SIGINT, edit_catcher);
+ 	oldquit = sys_signal(SIGQUIT, edit_catcher);
+-
+-	r = el_gets(c->el, count);
++	int trunc_count = *count;
++	r = el_gets(c->el, &trunc_count);
+ 
+ 	sys_signal(SIGINT, oldint);
+ 	sys_signal(SIGQUIT, oldquit);

--- a/app-shells/rc/rc-1.7.4-r3.ebuild
+++ b/app-shells/rc/rc-1.7.4-r3.ebuild
@@ -1,0 +1,55 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools
+
+DESCRIPTION="A reimplementation of the Plan 9 shell"
+HOMEPAGE="http://static.tobold.org/"
+SRC_URI="http://static.tobold.org/${PN}/${P}.tar.gz"
+
+LICENSE="rc"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="libedit readline"
+
+RDEPEND="sys-libs/ncurses:=
+	readline? ( sys-libs/readline:= )
+	libedit? ( dev-libs/libedit )"
+DEPEND="${RDEPEND}"
+
+DOCS=( AUTHORS ChangeLog NEWS README )
+
+PATCHES=(
+	"${FILESDIR}"/"${P}"-libedit.patch
+	"${FILESDIR}"/"${P}"-C23.patch
+)
+
+src_prepare() {
+	default
+	eautoreconf
+}
+
+src_configure() {
+	local myconf="--with-history"
+	use readline && myconf="--with-edit=readline"
+	use libedit && myconf="--with-edit=edit"
+
+	econf "${myconf}"
+}
+
+src_install() {
+	into /usr
+	newbin "${PN}" "${PN}sh"
+	newman "${PN}.1" "${PN}sh.1"
+	einstalldocs
+}
+
+pkg_postinst() {
+	if ! grep -q '^/usr/bin/rcsh$' "${EROOT}"/etc/shells ; then
+		ebegin "Updating /etc/shells"
+		echo "/usr/bin/rcsh" >> "${EROOT}"/etc/shells
+		eend $?
+	fi
+}


### PR DESCRIPTION
For libedit, we need to carefully truncate size_t to int but that's number of lines, so it should work in sane situations

C23 porting is limited to autoreconf and dealing with bool defines Code is not bit-rotten too much

Bug: https://bugs.gentoo.org/925558

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
