### PR TITLE
net-proxy/privoxy: use slotted mbedtls:0

### DIFF
--- a/net-proxy/privoxy/privoxy-3.0.34-r1.ebuild
+++ b/net-proxy/privoxy/privoxy-3.0.34-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -12,6 +12,8 @@ inherit autotools systemd toolchain-funcs
 DESCRIPTION="A web proxy with advanced filtering capabilities for enhancing privacy"
 HOMEPAGE="https://www.privoxy.org https://sourceforge.net/projects/ijbswa/"
 SRC_URI="https://downloads.sourceforge.net/ijbswa/${P%_*}-${PRIVOXY_STATUS}-src.tar.gz"
+
+S="${WORKDIR}/${P%_*}-${PRIVOXY_STATUS}"
 
 LICENSE="GPL-2+"
 SLOT="0"
@@ -28,7 +30,7 @@ DEPEND="
 	dev-libs/libpcre
 	brotli? ( app-arch/brotli )
 	ssl? (
-		mbedtls? ( net-libs/mbedtls:= )
+		mbedtls? ( net-libs/mbedtls:0= )
 		openssl? ( dev-libs/openssl:= )
 	)
 	zlib? ( sys-libs/zlib:= )
@@ -50,8 +52,6 @@ REQUIRED_USE="
 	ssl? ( ^^ ( mbedtls openssl ) threads )
 	toggle? ( editor )
 "
-
-S="${WORKDIR}/${P%_*}-${PRIVOXY_STATUS}"
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-3.0.32-gentoo.patch


### PR DESCRIPTION
Privoxy requires optional dependency MbedTLS from 2.28.x branch. Minor fixes to ebuild (reorder S variable location).

Closes: https://bugs.gentoo.org/804978

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
