### PR TITLE
games-emulation/dolphin: use slotted mbedtls:0

### DIFF
--- a/games-emulation/dolphin/dolphin-2407-r1.ebuild
+++ b/games-emulation/dolphin/dolphin-2407-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -81,7 +81,7 @@ RDEPEND="
 	media-libs/libsfml:=
 	media-libs/libspng
 	>=net-libs/enet-1.3.18:1.3=
-	net-libs/mbedtls:=
+	net-libs/mbedtls:0=
 	net-misc/curl
 	x11-libs/libX11
 	x11-libs/libXi

--- a/games-emulation/dolphin/dolphin-5.0_p20220520-r4.ebuild
+++ b/games-emulation/dolphin/dolphin-5.0_p20220520-r4.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -54,7 +54,7 @@ RDEPEND="
 	media-libs/libsfml:=
 	media-libs/mesa[egl(+)]
 	net-libs/enet:1.3
-	net-libs/mbedtls:=
+	net-libs/mbedtls:0=
 	net-misc/curl:=
 	sys-libs/readline:=
 	sys-libs/zlib:=[minizip]

--- a/games-emulation/dolphin/dolphin-9999.ebuild
+++ b/games-emulation/dolphin/dolphin-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -81,7 +81,7 @@ RDEPEND="
 	media-libs/libsfml:=
 	media-libs/libspng
 	>=net-libs/enet-1.3.18:1.3=
-	net-libs/mbedtls:=
+	net-libs/mbedtls:0=
 	net-misc/curl
 	x11-libs/libX11
 	x11-libs/libXi


### PR DESCRIPTION
Dolphin requires MbedTLS from 2.28.x branch.

Closes: https://bugs.gentoo.org/804966

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
