### PR TITLE
net-proxy/shadowsocks-libev: use slotted mbedtls:0

### DIFF
--- a/net-proxy/shadowsocks-libev/shadowsocks-libev-3.3.5-r1.ebuild
+++ b/net-proxy/shadowsocks-libev/shadowsocks-libev-3.3.5-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -19,7 +19,7 @@ SLOT="0"
 KEYWORDS="~amd64 ~arm ~arm64 ~riscv ~x86"
 IUSE="debug doc"
 
-RDEPEND="net-libs/mbedtls:=
+RDEPEND="net-libs/mbedtls:0=
 	>=net-libs/libbloom-1.6
 	net-libs/libcork
 	net-libs/libcorkipset


### PR DESCRIPTION
shadowsocks-libev requires MbedTLS from 2.28.x branch.

Closes: https://bugs.gentoo.org/804963

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
