### PR TITLE
media-plugins/gst-plugins-webrtc-1.24.10: fix compilation 'ERROR: Feature ... cannot be disabled: webrtc option is enabled'

### DIFF
--- a/media-plugins/gst-plugins-webrtc/files/gst-plugins-webrtc-1.24.10-disable-srtp-sctp-dtls-options.patch
+++ b/media-plugins/gst-plugins-webrtc/files/gst-plugins-webrtc-1.24.10-disable-srtp-sctp-dtls-options.patch
@@ -1,0 +1,82 @@
+Upstream decided to auto-enable srtp, sctp and dtls options, when the
+webrtc option is enabled.  This is going to partially revert upstream
+fd4828bafe613eec33e8f3faef5ab5181a73c8b6 to fix webrtc compilation.
+
+https://gitlab.freedesktop.org/gstreamer/gstreamer/-/commit/fd4828bafe613eec33e8f3faef5ab5181a73c8b6
+
+../gst-plugins-bad-1.24.10/ext/dtls/meson.build:15:33: ERROR: Feature dtls cannot be disabled: webrtc option is enabled
+
+../gst-plugins-bad-1.24.10/ext/sctp/meson.build:8:33: ERROR: Feature sctp cannot be disabled: webrtc option is enabled
+
+../gst-plugins-bad-1.24.10/ext/srtp/meson.build:10:33: ERROR: Feature srtp cannot be disabled: webrtc option is enabled
+
+diff -Nuar a/ext/dtls/meson.build b/ext/dtls/meson.build
+--- a/ext/dtls/meson.build	2025-01-05 20:40:34.043318811 +0000
++++ b/ext/dtls/meson.build	2025-01-05 20:41:23.503318674 +0000
+@@ -12,9 +12,8 @@
+   'gstdtlselement.c',
+ ]
+ 
+-dtls_option = get_option('dtls').enable_if(get_option('webrtc').enabled(), error_message: 'webrtc option is enabled')
+-openssl_dep = dependency('openssl', version: '>= 1.0.1', required: dtls_option)
+-libcrypto_dep = dependency('libcrypto', required: dtls_option)
++openssl_dep = dependency('openssl', version : '>= 1.0.1', required : get_option('dtls'))
++libcrypto_dep = dependency('libcrypto', required : get_option('dtls'))
+ 
+ if openssl_dep.found() and libcrypto_dep.found()
+   gstdtls = library('gstdtls',
+
+diff -Nuar a/ext/sctp/meson.build b/ext/sctp/meson.build
+--- a/ext/sctp/meson.build	2025-01-05 20:48:48.867317441 +0000
++++ b/ext/sctp/meson.build	2025-01-05 20:50:03.807317233 +0000
+@@ -5,8 +5,7 @@
+   'sctpassociation.c'
+ ]
+ 
+-sctp_option = get_option('sctp').enable_if(get_option('webrtc').enabled(), error_message: 'webrtc option is enabled')
+-if sctp_option.disabled()
++if get_option('sctp').disabled()
+   subdir_done()
+ endif
+ 
+@@ -24,7 +23,7 @@
+   found_system_usrsctp = sctp_dep.found() and sctp_header
+ 
+   if get_option('sctp-internal-usrsctp').disabled() and not found_system_usrsctp
+-    if sctp_option.enabled()
++    if get_option('sctp').enabled()
+       error('sctp plugin enabled but could not find libusrsctp or usrsctp.h, and internal libusrsctp disabled')
+     else
+       message('Could not find libusrsctp or usrsctp.h, and internal libusrsctp disabled - not building sctp plugin')
+@@ -38,7 +37,7 @@
+   subdir('usrsctp')
+   sctp_dep = usrsctp_dep
+   sctp_header = true
+-  if sctp_option.enabled() and not sctp_dep.found()
++  if get_option('sctp').enabled() and not sctp_dep.found()
+     error('sctp plugin enabled but could not find system libusrsctp or configure internal libusrsctp')
+   endif
+ endif
+
+diff -Nuar a/ext/srtp/meson.build b/ext/srtp/meson.build
+--- a/ext/srtp/meson.build	2025-01-05 20:53:34.863316649 +0000
++++ b/ext/srtp/meson.build	2025-01-05 20:54:09.979316551 +0000
+@@ -7,8 +7,7 @@
+ ]
+ 
+ srtp_cargs = []
+-srtp_option = get_option('srtp').enable_if(get_option('webrtc').enabled(), error_message: 'webrtc option is enabled')
+-if srtp_option.disabled()
++if get_option('srtp').disabled()
+   srtp_dep = dependency('', required : false)
+   subdir_done()
+ endif
+@@ -22,7 +21,7 @@
+     srtp_dep = cc.find_library('srtp', required : false)
+   endif
+ endif
+-if not srtp_dep.found() and srtp_option.enabled()
++if not srtp_dep.found() and get_option('srtp').enabled()
+   error('srtp plugin enabled but libsrtp not found')
+ endif
+ 

--- a/media-plugins/gst-plugins-webrtc/gst-plugins-webrtc-1.24.10-r1.ebuild
+++ b/media-plugins/gst-plugins-webrtc/gst-plugins-webrtc-1.24.10-r1.ebuild
@@ -1,0 +1,42 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+GST_ORG_MODULE=gst-plugins-bad
+
+inherit gstreamer-meson
+
+DESCRIPTION="WebRTC plugins for GStreamer"
+KEYWORDS="~amd64 ~arm64"
+
+RDEPEND="
+	>=media-plugins/gst-plugins-sctp-${PV}:1.0[${MULTILIB_USEDEP}]
+	>=media-libs/webrtc-audio-processing-1.0:1[${MULTILIB_USEDEP}]
+	>=net-libs/libnice-0.1.21[${MULTILIB_USEDEP}]
+"
+DEPEND="${RDEPEND}"
+
+GST_PLUGINS_ENABLED="webrtc webrtcdsp"
+GST_PLUGINS_BUILD_DIR="webrtc webrtcdsp"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-1.24.10-disable-srtp-sctp-dtls-options.patch"
+)
+
+src_prepare() {
+	default
+	gstreamer_system_package \
+		gstwebrtc_dep:gstreamer-webrtc \
+		gstsctp_dep:gstreamer-sctp \
+		gstbadaudio_dep:gstreamer-bad-audio
+}
+
+multilib_src_install() {
+	# TODO: Fix this properly, see bug #907470 and bug #909079.
+	insinto /usr/$(get_libdir)
+	doins "${BUILD_DIR}"/ext/webrtc/libgstwebrtc.so
+	doins "${BUILD_DIR}"/gst-libs/gst/webrtc/nice/libgstwebrtcnice-1.0.so*
+	insinto /usr/include/gstreamer-1.0/gst/webrtc/nice
+	doins "${S}"/gst-libs/gst/webrtc/nice/*.h
+	gstreamer_multilib_src_install
+}


### PR DESCRIPTION
Hello,

This is a quick and trivial fix for the following error:

`ERROR: Feature ... cannot be disabled: webrtc option is enabled`

Upstream decided to auto-enable `srtp`, `sctp` and `dtls` options, when the `webrtc` option is enabled: [fd4828bafe613eec33e8f3faef5ab5181a73c8b6](https://gitlab.freedesktop.org/gstreamer/gstreamer/-/commit/fd4828bafe613eec33e8f3faef5ab5181a73c8b6).

The attached patch partially reverts the upstream commit in order to allow the stand-alone compilation of `webrtc`.

```
$ diff gst-plugins-webrtc-1.24.10.ebuild gst-plugins-webrtc-1.24.10-r1.ebuild 
1c1
< # Copyright 1999-2024 Gentoo Authors
---
> # Copyright 1999-2025 Gentoo Authors
20a21,24
> 
> PATCHES=(
>       "${FILESDIR}/${PN}-1.24.10-disable-srtp-sctp-dtls-options.patch"
> )
```

```
$ pkgcheck scan --commits --net
...
media-plugins/gst-plugins-webrtc
  UnstableOnly: for arch: [ arm64 ], all versions are unstable: [ 1.22.11, 1.22.12, 1.24.10, 1.24.10-r1 ]
  PythonCompatUpdate: version 1.22.11: PYTHON_COMPAT updates available: python3_13, python3_13t
  RedundantVersion: version 1.22.11: slot(1.0) keywords are overshadowed by version: 1.22.12
  PotentialStable: version 1.22.12: slot(1.0), stabled arch: [ amd64 ], potential: [ ~arm64 ]
  PythonCompatUpdate: version 1.22.12: PYTHON_COMPAT updates available: python3_13, python3_13t
  PythonCompatUpdate: version 1.24.10: PYTHON_COMPAT updates available: python3_13, python3_13t
  RedundantVersion: version 1.24.10: slot(1.0) keywords are overshadowed by version: 1.24.10-r1
  PythonCompatUpdate: version 1.24.10-r1: PYTHON_COMPAT updates available: python3_13, python3_13t
...
```

Thanks ;)

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
