### PR TITLE
media-plugins/gst-plugins-webrtc: fix typo in patch file

### DIFF
--- a/media-plugins/gst-plugins-webrtc/files/gst-plugins-webrtc-1.24.10-disable-srtp-sctp-dtls-options.patch
+++ b/media-plugins/gst-plugins-webrtc/files/gst-plugins-webrtc-1.24.10-disable-srtp-sctp-dtls-options.patch
@@ -27,9 +27,8 @@ https://gitlab.freedesktop.org/gstreamer/gstreamer/-/commit/fd4828bafe613eec33e8
  ]
  
 -sctp_option = get_option('sctp').enable_if(get_option('webrtc').enabled(), error_message: 'webrtc option is enabled')
--if sctp_option.disabled()
 +sctp_option = get_option('sctp')
-+if srtp_option.disabled()
+ if sctp_option.disabled()
    subdir_done()
  endif
  
@@ -40,9 +39,8 @@ https://gitlab.freedesktop.org/gstreamer/gstreamer/-/commit/fd4828bafe613eec33e8
  
  srtp_cargs = []
 -srtp_option = get_option('srtp').enable_if(get_option('webrtc').enabled(), error_message: 'webrtc option is enabled')
--if srtp_option.disabled()
 +srtp_option = get_option('srtp')
-+if get_option('srtp').disabled()
+ if srtp_option.disabled()
    srtp_dep = dependency('', required : false)
    subdir_done()
  endif


### PR DESCRIPTION
Hello,

Could you please change `srtp_option -> sctp_option` in `ext/sctp/meson.build`, and reuse the `srtp_option` variable in `ext/srtp/meson.build`?

Thanks.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
