### PR TITLE
net-wireless/gnuradio: fix build w/ libfmt-11.0

### DIFF
--- a/net-wireless/gnuradio/files/gnuradio-3.10.9.2-libfmt-11.patch
+++ b/net-wireless/gnuradio/files/gnuradio-3.10.9.2-libfmt-11.patch
@@ -1,0 +1,50 @@
+From 19b070051c1c2b5fb6f2da8fb6422b27418c3dfa Mon Sep 17 00:00:00 2001
+From: Kefu Chai <tchaikov@gmail.com>
+Date: Mon, 15 Jul 2024 09:27:16 +0800
+Subject: [PATCH] blocks,runtime: io_signature: include spdlog/*/ranges.h for
+ using fmt::join()
+
+fmt::join() was moved into fmt/ranges.h since fmt 11, so let's
+include the corresponding header in spdlog for using it.
+
+Signed-off-by: Kefu Chai <tchaikov@gmail.com>
+---
+ gnuradio-runtime/lib/io_signature.cc | 5 +++++
+ gr-blocks/lib/message_debug_impl.cc  | 5 +++++
+ 2 files changed, 10 insertions(+)
+
+diff --git a/gnuradio-runtime/lib/io_signature.cc b/gnuradio-runtime/lib/io_signature.cc
+index 812f444f8..76bb2aba6 100644
+--- a/gnuradio-runtime/lib/io_signature.cc
++++ b/gnuradio-runtime/lib/io_signature.cc
+@@ -16,6 +16,11 @@
+ #include <spdlog/tweakme.h>
+ 
+ #include <spdlog/fmt/fmt.h>
++#if __has_include(<spdlog/fmt/ranges.h>)
++#include <spdlog/fmt/ranges.h>
++#elif __has_include(<spdlog/fmt/bundled/ranges.h>)
++#include <spdlog/fmt/bundled/ranges.h>
++#endif
+ #include <string_view>
+ #include <algorithm>
+ #include <memory>
+diff --git a/gr-blocks/lib/message_debug_impl.cc b/gr-blocks/lib/message_debug_impl.cc
+index 41d312e43..373287b02 100644
+--- a/gr-blocks/lib/message_debug_impl.cc
++++ b/gr-blocks/lib/message_debug_impl.cc
+@@ -19,6 +19,11 @@
+ #include <pmt/pmt.h>
+ #include <spdlog/common.h>
+ #include <spdlog/fmt/fmt.h>
++#if __has_include(<spdlog/fmt/ranges.h>)
++#include <spdlog/fmt/ranges.h>
++#elif __has_include(<spdlog/fmt/bundled/ranges.h>)
++#include <spdlog/fmt/bundled/ranges.h>
++#endif
+ #include <functional>
+ #include <utility>
+ #include <vector>
+-- 
+2.45.2
+

--- a/net-wireless/gnuradio/gnuradio-3.10.9.2-r6.ebuild
+++ b/net-wireless/gnuradio/gnuradio-3.10.9.2-r6.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -131,7 +131,10 @@ DEPEND="${RDEPEND}
 	zeromq? ( net-libs/cppzmq )
 "
 
-PATCHES=( "${FILESDIR}/PR7093.patch" )
+PATCHES=(
+	"${FILESDIR}/PR7093.patch"
+	"${FILESDIR}"/${PN}-3.10.9.2-libfmt-11.patch
+)
 
 src_prepare() {
 	xdg_environment_reset #534582


### PR DESCRIPTION
patch from upstream

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
