### PR TITLE
sci-libs/rocBLAS: fix sed expression for -m16c removal

### DIFF
--- a/sci-libs/rocBLAS/rocBLAS-6.1.1-r1.ebuild
+++ b/sci-libs/rocBLAS/rocBLAS-6.1.1-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -59,7 +59,7 @@ src_prepare() {
 	sed -e "s:,-rpath=.*\":\":" -i clients/CMakeLists.txt || die
 
 	# bug 944820: f16c instuctions cause SIGILL on pre-AVX512 CPUs
-	sed -i -e "s/-mf16c /" clients/benchmarks/CMakeLists.txt \
+	sed -i -e "s/-mf16c //" clients/benchmarks/CMakeLists.txt \
 		clients/gtest/CMakeLists.txt clients/samples/CMakeLists.txt library/CMakeLists.txt || die
 }
 


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/947599

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
