### PR TITLE
dev-db/spatialite: fix compile errors

### DIFF
--- a/dev-db/spatialite/files/spatialite-5.1.0-macro-surgery.patch
+++ b/dev-db/spatialite/files/spatialite-5.1.0-macro-surgery.patch
@@ -1,0 +1,80 @@
+https://bugs.gentoo.org/919177
+https://www.gaia-gis.it/fossil/libspatialite/tktview?name=d5c8f926be
+https://www.gaia-gis.it/fossil/libspatialite/tktview/af38159360a2e740b2339e279103bcdaf951498e
+Macro out things upstream forgot to conditionally exclude, macro in things upstream forgot
+In particular, functions that appear only when GEOM is enabled should not be used
+when GEOM is disabled, and having fallback for ancient version of PROJ is well and good;
+upstream forgot version for modern one in one place.
+--- a/src/gaiageo/gg_advanced.c
++++ b/src/gaiageo/gg_advanced.c
+@@ -2286,6 +2286,7 @@
+ / identifying toxic geometries 
+ / i.e. geoms making GEOS to crash !!!
+ */
++#ifndef OMIT_GEOS  /* don't do anything if there's no GEOS */
+     int ib;
+     gaiaPointPtr point;
+     gaiaLinestringPtr line;
+@@ -2350,6 +2351,7 @@
+ 	    }
+ 	  polyg = polyg->Next;
+       }
++#endif /* OMIT_GEOS */
+     return 0;
+ }
+ 
+@@ -2377,11 +2379,13 @@
+ 	return 0;
+     else
+       {
++#ifndef OMIT_GEOS /*can't report error if GEOS is not build, skipping */
+ 	  if (cache != NULL)
+ 	      gaiaSetGeosAuxErrorMsg_r (cache,
+ 					"gaia detected a not-closed Ring");
+ 	  else
+ 	      gaiaSetGeosAuxErrorMsg ("gaia detected a not-closed Ring");
++#endif
+ 	  return 1;
+       }
+ }
+--- a/src/spatialite/spatialite.c
++++ b/src/spatialite/spatialite.c
+@@ -23472,9 +23472,11 @@
+ 	sqlite3_result_null (context);
+     else
+       {
++#ifndef OMIT_GEOS /* Only if GEOS enabled */
+ 	  if (!gaiaInterpolatePoint (cache, line, point, &m_value))
+ 	      sqlite3_result_null (context);
+ 	  else
++#endif
+ 	      sqlite3_result_double (context, m_value);
+       }
+     if (line != NULL)
+--- a/src/connection_cache/alloc_cache.c
++++ b/connection_cache/alloc_cache.c
+@@ -646,8 +646,12 @@
+ #endif
+ 
+ #else /* supporting old PROJ.4 */
++#ifdef PROJ_NEW /* PROJ.6* */
++    cache->PROJ_handle = proj_context_create ();
++#else
+     cache->PROJ_handle = pj_ctx_alloc ();
+ #endif
++#endif
+ #endif /* end PROJ.4  */
+ 
+ #ifdef ENABLE_RTTOPO		/* initializing the RTTOPO context */
+@@ -706,7 +706,11 @@
+ #endif /* end GEOS  */
+ 
+ #ifndef OMIT_PROJ		/* initializing the PROJ.4 context */
++#ifndef PROJ_NEW		/* Only in case where PROJ.5 not needed */
+     cache->PROJ_handle = pj_ctx_alloc ();
++#else				/* PROJ.6* */
++    cache->PROJ_handle = proj_context_create ();
++#endif
+ #endif /* end PROJ.4  */
+ 
+   done:

--- a/dev-db/spatialite/spatialite-5.1.0-r2.ebuild
+++ b/dev-db/spatialite/spatialite-5.1.0-r2.ebuild
@@ -1,0 +1,63 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit libtool
+
+MY_PN="lib${PN}"
+MY_P="${MY_PN}-${PV}"
+
+DESCRIPTION="Complete Spatial DBMS in a nutshell built upon sqlite"
+HOMEPAGE="https://www.gaia-gis.it/gaia-sins/"
+SRC_URI="https://www.gaia-gis.it/gaia-sins/${MY_PN}-sources/${MY_P}.tar.gz"
+S="${WORKDIR}/${MY_P}"
+
+LICENSE="MPL-1.1"
+SLOT="0"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc ~ppc64 ~riscv ~x86"
+IUSE="+geos iconv +proj rttopo test +xls"
+REQUIRED_USE="test? ( iconv )"
+# Further poking required
+RESTRICT="test"
+
+RDEPEND="
+	>=dev-db/sqlite-3.7.5:3[extensions(+)]
+	dev-libs/libxml2
+	sys-libs/zlib[minizip]
+	geos? ( >=sci-libs/geos-3.11.0 )
+	proj? ( sci-libs/proj:= )
+	rttopo? ( sci-geosciences/librttopo )
+	xls? ( >=dev-libs/freexl-2.0.0[xml(+)] )
+"
+DEPEND="${RDEPEND}"
+
+PATCHES=( "${FILESDIR}/${P}-macro-surgery.patch" )
+
+src_prepare() {
+	default
+	elibtoolize
+}
+
+src_configure() {
+	# 1) gcp disabled for now to preserve MPL licence
+	econf \
+		--disable-gcp \
+		--disable-examples \
+		--disable-static \
+		--enable-epsg \
+		--enable-libxml2 \
+		$(use_enable geos) \
+		$(use_enable geos geosadvanced) \
+		$(use_enable geos geos3100) \
+		$(use_enable geos geos3110) \
+		$(use_enable iconv) \
+		$(use_enable proj) \
+		$(use_enable rttopo) \
+		$(use_enable xls freexl)
+}
+
+src_install() {
+	default
+	find "${ED}" -name '*.la' -delete || die
+}


### PR DESCRIPTION
Upstream forgot to:
1. remove usage of functions whose existence depends on USE=geos
2. add modern interfaces for PROJ.6+ in all places where fallback to PROJ.4 existed.

Bug: https://bugs.gentoo.org/919177

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
