### PR TITLE
sys-apps/bolt: C23 porting: upstream patch

### DIFF
--- a/sys-apps/bolt/bolt-0.9.8-r1.ebuild
+++ b/sys-apps/bolt/bolt-0.9.8-r1.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_1{0..2} )
+PYTHON_COMPAT=( python3_1{0..3} )
 inherit linux-info python-any-r1 meson udev
 
 DESCRIPTION="Userspace system daemon to enable security levels for Thunderbolt 3"
@@ -43,6 +43,8 @@ BDEPEND="
 		)
 	)
 "
+
+PATCHES=( "${FILESDIR}"/${P}-sockaddr.patch )
 
 pkg_setup() {
 	if use kernel_linux && kernel_is lt 5 6; then

--- a/sys-apps/bolt/files/bolt-0.9.8-sockaddr.patch
+++ b/sys-apps/bolt/files/bolt-0.9.8-sockaddr.patch
@@ -1,0 +1,46 @@
+https://gitlab.freedesktop.org/bolt/bolt/-/commit/9f85914f1efd7b74fb7bd906b339fcba2214d86a
+From 9f85914f1efd7b74fb7bd906b339fcba2214d86a Mon Sep 17 00:00:00 2001
+From: Kate Hsuan <hpa@redhat.com>
+Date: Mon, 6 Jan 2025 14:12:47 +0800
+Subject: [PATCH] tests: bolt-test: Fix build error with gcc14
+
+Fix build errors with gcc14.
+The fix includes:
+1. Cast sockaddr correctly.
+
+build errors:
+
+x86_64-pc-linux-musl-gcc -Itest-auth.p -I. -I../bolt-0.9.8 -I../bolt-0.9.8/tests -I../bolt-0.9.8/common -I../bolt-0.9.8/boltd -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include -I/usr/include/sysprof-4 -I/usr/lib/libffi/include -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/gio-unix-2.0 -I/usr/include/polkit-1 -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=gnu99 -fstack-protector-strong -Waggregate-return -Wunused -Warray-bounds -Wcast-align -Wclobbered -Wdeclaration-after-statement -Wempty-body -Wformat=2 -Wformat-nonliteral -Wformat-security -Wformat-signedness -Wignored-qualifiers -Wimplicit-function-declaration -Winit-self -Wmissing-declarations -Wmissing-format-attribute -Wmissing-include-dirs -Wmissing-noreturn -Wmissing-parameter-type -Wmissing-prototypes -Wnested-externs -Wno-discarded-qualifiers -Wno-missing-field-initializers -Wno-suggest-attribute=format -Wno-unused-parameter -Wold-style-definition -Woverride-init -Wpointer-arith -Wredundant-decls -Wreturn-type -Wshadow -Wsign-compare -Wstrict-aliasing=3 -Wstrict-prototypes -Wstringop-overflow -Wstringop-truncation -Wtype-limits -Wundef -Wuninitialized -Wunused-but-set-variable -Wwrite-strings -O2 -pipe -march=native -fno-diagnostics-color -pthread -MD -MQ test-auth.p/tests_bolt-test.c.o -MF test-auth.p/tests_bolt-test.c.o.d -o test-auth.p/tests_bolt-test.c.o -c ../bolt-0.9.8/tests/bolt-test.c
+../bolt-0.9.8/tests/bolt-test.c: In function 'notify_socket_new':
+../bolt-0.9.8/tests/bolt-test.c:131:17: error: passing argument 2 of 'bind' from incompatible pointer type [-Wincompatible-pointer-types]
+  131 |   r = bind (fd, &sau, socklen);
+      |                 ^~~~
+      |                 |
+      |                 struct sockaddr_un *
+In file included from ../bolt-0.9.8/tests/bolt-test.c:37:
+/usr/include/sys/socket.h:385:16: note: expected 'const struct sockaddr *' but argument is of type 'struct sockaddr_un *'
+  385 | int bind (int, const struct sockaddr *, socklen_t);
+      |                ^~~~~~~~~~~~~~~~~~~~~~~
+
+Resolves: #192
+Link: https://bugs.gentoo.org/937273
+---
+ tests/bolt-test.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tests/bolt-test.c b/tests/bolt-test.c
+index beabb8d..aa94222 100644
+--- a/tests/bolt-test.c
++++ b/tests/bolt-test.c
+@@ -128,7 +128,7 @@ notify_socket_new (void)
+     + strlen (sau.sun_path)
+     + 1;
+ 
+-  r = bind (fd, &sau, socklen);
++  r = bind (fd, (struct sockaddr *) &sau, socklen);
+   g_assert_cmpint (r, >, -1);
+ 
+   r = setsockopt (fd, SOL_SOCKET, SO_PASSCRED, &one, sizeof (one));
+-- 
+GitLab
+


### PR DESCRIPTION
https://gitlab.freedesktop.org/bolt/bolt/-/commit/9f85914f1efd7b74fb7bd906b339fcba2214d86a
Also pushed Python to 3.13

Bug: https://bugs.gentoo.org/937273

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
