### PR TITLE
net-analyzer/yersinia: Port to C23

### DIFF
--- a/net-analyzer/yersinia/files/yersinia-0.8.2-C23.patch
+++ b/net-analyzer/yersinia/files/yersinia-0.8.2-C23.patch
@@ -1,0 +1,12 @@
+diff -ru a/src/yersinia.c b/src/yersinia.c
+--- a/src/yersinia.c	2025-01-06 20:10:12.501482780 +0400
++++ b/src/yersinia.c	2025-01-06 20:11:08.635172681 +0400
+@@ -927,7 +927,7 @@
+  * POSIX functions for signals 
+  */
+ int 
+-posix_signal( int signo, void (*handler)() )
++posix_signal( int signo, void (*handler)(int) )
+ {
+     struct sigaction act;
+ 

--- a/net-analyzer/yersinia/yersinia-0.8.2_p20221119.ebuild
+++ b/net-analyzer/yersinia/yersinia-0.8.2_p20221119.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -36,6 +36,7 @@ DOCS=( AUTHORS ChangeLog FAQ README THANKS TODO )
 PATCHES=(
 	"${FILESDIR}"/${PN}-0.7.1-no-ncurses.patch
 	"${FILESDIR}"/${PN}-0.7.3-tinfo.patch
+	"${FILESDIR}"/${PN}-0.8.2-C23.patch
 )
 
 src_prepare() {


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/943801

See also: https://github.com/tomac/yersinia/pull/94

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
