### PR TITLE
dist-kernel: misc small fixes

### DIFF
--- a/eclass/kernel-build.eclass
+++ b/eclass/kernel-build.eclass
@@ -447,6 +447,11 @@ kernel-build_src_install() {
 
 	# Copy built key/certificate files
 	cp -p build/certs/* "${ED}${kernel_dir}/certs/" || die
+	# If a key was generated, exclude it from the binpkg
+	local generated_key=${ED}${kernel_dir}/certs/signing_key.pem
+	if [[ -r ${generated_key} ]]; then
+		mv "${generated_key}" "${T}/signing_key.pem" || die
+	fi
 
 	# building modules fails with 'vmlinux has no symtab?' if stripped
 	use ppc64 && dostrip -x "${kernel_dir}/${image_path}"
@@ -654,7 +659,6 @@ kernel-build_pkg_postinst() {
 			ewarn "MODULES_SIGN_KEY was not set, this means the kernel build system"
 			ewarn "automatically generated the signing key. This key was installed"
 			ewarn "in ${EROOT}/usr/src/linux-${KV_FULL}/certs"
-			ewarn "and will also be included in any binary packages."
 			ewarn "Please take appropriate action to protect the key!"
 			ewarn
 			ewarn "Recompiling this package causes a new key to be generated. As"

--- a/eclass/kernel-build.eclass
+++ b/eclass/kernel-build.eclass
@@ -137,6 +137,9 @@ fi
 kernel-build_pkg_setup() {
 	python-any-r1_pkg_setup
 	if [[ ${KERNEL_IUSE_MODULES_SIGN} && ${MERGE_TYPE} != binary ]]; then
+		# inherits linux-info to check config values for keys
+		# ensure KV_FULL will not be set globally, that breaks configure
+		local KV_FULL
 		secureboot_pkg_setup
 
 		if use modules-sign && [[ -n ${MODULES_SIGN_KEY} ]]; then

--- a/eclass/kernel-install.eclass
+++ b/eclass/kernel-install.eclass
@@ -607,6 +607,15 @@ kernel-install_pkg_preinst() {
 	[[ ! -d ${kernel_dir} ]] &&
 		die "Kernel directory ${kernel_dir} not installed!"
 
+	# We moved this in order to omit it from the binpkg, move it back
+	if [[ -r "${T}/signing_key.pem" ]]; then
+		# cp instead of mv to set owner to root in one go
+		(
+			umask 066 &&
+				cp "${T}/signing_key.pem" "${kernel_dir}/certs/signing_key.pem"
+		) || die
+	fi
+
 	# perform the version check for release ebuilds only
 	if [[ ${PV} != *9999 ]]; then
 		local expected_ver=$(dist-kernel_PV_to_KV "${PV}")

--- a/eclass/linux-mod-r1.eclass
+++ b/eclass/linux-mod-r1.eclass
@@ -333,7 +333,7 @@ linux-mod-r1_pkg_setup() {
 	_MODULES_GLOBAL[ran:pkg_setup]=1
 	_modules_check_function ${#} 0 0 || return 0
 
-	if [[ -z ${ROOT} && ${MODULES_INITRAMFS_IUSE} ]] &&
+	if [[ ${MODULES_INITRAMFS_IUSE} ]] &&
 		use dist-kernel && use ${MODULES_INITRAMFS_IUSE#+}
 	then
 		# Check, but don't die because we can fix the problem and then

--- a/sys-firmware/intel-microcode/intel-microcode-20240813_p20240815.ebuild
+++ b/sys-firmware/intel-microcode/intel-microcode-20240813_p20240815.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -95,7 +95,7 @@ pkg_pretend() {
 		if use dist-kernel; then
 			# Check, but don't die because we can fix the problem and then
 			# emerge --config ... to re-run installation.
-			[[ -z ${ROOT} ]] && nonfatal mount-boot_check_status
+			nonfatal mount-boot_check_status
 		else
 			mount-boot_pkg_pretend
 		fi
@@ -311,7 +311,7 @@ pkg_postrm() {
 pkg_postinst() {
 	if use initramfs; then
 		if use dist-kernel; then
-			[[ -z ${ROOT} ]] && dist-kernel_reinstall_initramfs "${KV_DIR}" "${KV_FULL}"
+			dist-kernel_reinstall_initramfs "${KV_DIR}" "${KV_FULL}"
 		else
 			# Don't forget to umount /boot if it was previously mounted by us.
 			mount-boot_pkg_postinst

--- a/sys-firmware/intel-microcode/intel-microcode-20240910_p20240915.ebuild
+++ b/sys-firmware/intel-microcode/intel-microcode-20240910_p20240915.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -95,7 +95,7 @@ pkg_pretend() {
 		if use dist-kernel; then
 			# Check, but don't die because we can fix the problem and then
 			# emerge --config ... to re-run installation.
-			[[ -z ${ROOT} ]] && nonfatal mount-boot_check_status
+			nonfatal mount-boot_check_status
 		else
 			mount-boot_pkg_pretend
 		fi
@@ -311,7 +311,7 @@ pkg_postrm() {
 pkg_postinst() {
 	if use initramfs; then
 		if use dist-kernel; then
-			[[ -z ${ROOT} ]] && dist-kernel_reinstall_initramfs "${KV_DIR}" "${KV_FULL}"
+			dist-kernel_reinstall_initramfs "${KV_DIR}" "${KV_FULL}"
 		else
 			# Don't forget to umount /boot if it was previously mounted by us.
 			mount-boot_pkg_postinst

--- a/sys-firmware/intel-microcode/intel-microcode-20241112_p20241103.ebuild
+++ b/sys-firmware/intel-microcode/intel-microcode-20241112_p20241103.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -95,7 +95,7 @@ pkg_pretend() {
 		if use dist-kernel; then
 			# Check, but don't die because we can fix the problem and then
 			# emerge --config ... to re-run installation.
-			[[ -z ${ROOT} ]] && nonfatal mount-boot_check_status
+			nonfatal mount-boot_check_status
 		else
 			mount-boot_pkg_pretend
 		fi
@@ -311,7 +311,7 @@ pkg_postrm() {
 pkg_postinst() {
 	if use initramfs; then
 		if use dist-kernel; then
-			[[ -z ${ROOT} ]] && dist-kernel_reinstall_initramfs "${KV_DIR}" "${KV_FULL}"
+			dist-kernel_reinstall_initramfs "${KV_DIR}" "${KV_FULL}"
 		else
 			# Don't forget to umount /boot if it was previously mounted by us.
 			mount-boot_pkg_postinst

--- a/sys-kernel/linux-firmware/linux-firmware-20241017-r3.ebuild
+++ b/sys-kernel/linux-firmware/linux-firmware-20241017-r3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -83,7 +83,7 @@ pkg_pretend() {
 		if use dist-kernel; then
 			# Check, but don't die because we can fix the problem and then
 			# emerge --config ... to re-run installation.
-			[[ -z ${ROOT} ]] && nonfatal mount-boot_check_status
+			nonfatal mount-boot_check_status
 		else
 			mount-boot_pkg_pretend
 		fi
@@ -388,7 +388,7 @@ pkg_postinst() {
 
 	if use initramfs; then
 		if use dist-kernel; then
-			[[ -z ${ROOT} ]] && dist-kernel_reinstall_initramfs "${KV_DIR}" "${KV_FULL}"
+			dist-kernel_reinstall_initramfs "${KV_DIR}" "${KV_FULL}"
 		else
 			# Don't forget to umount /boot if it was previously mounted by us.
 			mount-boot_pkg_postinst

--- a/sys-kernel/linux-firmware/linux-firmware-20241110.ebuild
+++ b/sys-kernel/linux-firmware/linux-firmware-20241110.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -82,7 +82,7 @@ pkg_pretend() {
 		if use dist-kernel; then
 			# Check, but don't die because we can fix the problem and then
 			# emerge --config ... to re-run installation.
-			[[ -z ${ROOT} ]] && nonfatal mount-boot_check_status
+			nonfatal mount-boot_check_status
 		else
 			mount-boot_pkg_pretend
 		fi
@@ -387,7 +387,7 @@ pkg_postinst() {
 
 	if use initramfs; then
 		if use dist-kernel; then
-			[[ -z ${ROOT} ]] && dist-kernel_reinstall_initramfs "${KV_DIR}" "${KV_FULL}"
+			dist-kernel_reinstall_initramfs "${KV_DIR}" "${KV_FULL}"
 		else
 			# Don't forget to umount /boot if it was previously mounted by us.
 			mount-boot_pkg_postinst

--- a/sys-kernel/linux-firmware/linux-firmware-20241210-r1.ebuild
+++ b/sys-kernel/linux-firmware/linux-firmware-20241210-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -82,7 +82,7 @@ pkg_pretend() {
 		if use dist-kernel; then
 			# Check, but don't die because we can fix the problem and then
 			# emerge --config ... to re-run installation.
-			[[ -z ${ROOT} ]] && nonfatal mount-boot_check_status
+			nonfatal mount-boot_check_status
 		else
 			mount-boot_pkg_pretend
 		fi
@@ -387,7 +387,7 @@ pkg_postinst() {
 
 	if use initramfs; then
 		if use dist-kernel; then
-			[[ -z ${ROOT} ]] && dist-kernel_reinstall_initramfs "${KV_DIR}" "${KV_FULL}"
+			dist-kernel_reinstall_initramfs "${KV_DIR}" "${KV_FULL}"
 		else
 			# Don't forget to umount /boot if it was previously mounted by us.
 			mount-boot_pkg_postinst

--- a/sys-kernel/linux-firmware/linux-firmware-20241210.ebuild
+++ b/sys-kernel/linux-firmware/linux-firmware-20241210.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -82,7 +82,7 @@ pkg_pretend() {
 		if use dist-kernel; then
 			# Check, but don't die because we can fix the problem and then
 			# emerge --config ... to re-run installation.
-			[[ -z ${ROOT} ]] && nonfatal mount-boot_check_status
+			nonfatal mount-boot_check_status
 		else
 			mount-boot_pkg_pretend
 		fi
@@ -387,7 +387,7 @@ pkg_postinst() {
 
 	if use initramfs; then
 		if use dist-kernel; then
-			[[ -z ${ROOT} ]] && dist-kernel_reinstall_initramfs "${KV_DIR}" "${KV_FULL}"
+			dist-kernel_reinstall_initramfs "${KV_DIR}" "${KV_FULL}"
 		else
 			# Don't forget to umount /boot if it was previously mounted by us.
 			mount-boot_pkg_postinst

--- a/sys-kernel/linux-firmware/linux-firmware-99999999.ebuild
+++ b/sys-kernel/linux-firmware/linux-firmware-99999999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -81,7 +81,7 @@ pkg_pretend() {
 		if use dist-kernel; then
 			# Check, but don't die because we can fix the problem and then
 			# emerge --config ... to re-run installation.
-			[[ -z ${ROOT} ]] && nonfatal mount-boot_check_status
+			nonfatal mount-boot_check_status
 		else
 			mount-boot_pkg_pretend
 		fi
@@ -381,7 +381,7 @@ pkg_postinst() {
 
 	if use initramfs; then
 		if use dist-kernel; then
-			[[ -z ${ROOT} ]] && dist-kernel_reinstall_initramfs "${KV_DIR}" "${KV_FULL}"
+			dist-kernel_reinstall_initramfs "${KV_DIR}" "${KV_FULL}"
 		else
 			# Don't forget to umount /boot if it was previously mounted by us.
 			mount-boot_pkg_postinst


### PR DESCRIPTION
- Dropped obsolete `-z ROOT` conditions from `linux-mod-r1.eclass`, `intel-microcode.ebuild` and `linux-firmware.ebuild`
- Fixed an issue where `linux-info.eclass` would set `KV_FULL` via `secureboot.eclass`
- If the kernel build system generated a module signing key, it is now explicitly omitted from any binary packages.

CC @gentoo/dist-kernel  

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
