### PR TITLE
app-emulation/virt-manager: fix dying rm with USE="-gui"

### DIFF
--- a/app-emulation/virt-manager/virt-manager-5.0.0-r1.ebuild
+++ b/app-emulation/virt-manager/virt-manager-5.0.0-r1.ebuild
@@ -89,7 +89,8 @@ src_install() {
 
 	if ! use gui; then
 		rm -r "${ED}/usr/share/applications/${PN}.desktop" || die
-		rm -r "${ED}/usr/share/${PN}/{ui,icons}/" || die
+		rm -r "${ED}/usr/share/${PN}/icons/" || die
+		rm -r "${ED}/usr/share/${PN}/ui/" || die
 		rm -r "${ED}/usr/share/icons/" || die
 		rm -r "${ED}/usr/bin/${PN}" || die
 	fi

--- a/app-emulation/virt-manager/virt-manager-9999.ebuild
+++ b/app-emulation/virt-manager/virt-manager-9999.ebuild
@@ -89,7 +89,8 @@ src_install() {
 
 	if ! use gui; then
 		rm -r "${ED}/usr/share/applications/${PN}.desktop" || die
-		rm -r "${ED}/usr/share/${PN}/{ui,icons}/" || die
+		rm -r "${ED}/usr/share/${PN}/icons/" || die
+		rm -r "${ED}/usr/share/${PN}/ui/" || die
 		rm -r "${ED}/usr/share/icons/" || die
 		rm -r "${ED}/usr/bin/${PN}" || die
 	fi


### PR DESCRIPTION
No revbump as the code changes only for USE="-gui" which did not compile before, so no code will be changed.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
