### PR TITLE
dev-libs/libratbag: check if CONFIG_HIDRAW is set

### DIFF
--- a/dev-libs/libratbag/libratbag-0.17-r3.ebuild
+++ b/dev-libs/libratbag/libratbag-0.17-r3.ebuild
@@ -1,0 +1,119 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+PYTHON_COMPAT=( python3_{10..12} )
+
+inherit meson python-single-r1 systemd udev linux-info
+
+DESCRIPTION="Library to configure gaming mice"
+HOMEPAGE="https://github.com/libratbag/libratbag"
+
+if [[ ${PV} == 9999 ]]; then
+	inherit git-r3
+	EGIT_REPO_URI="https://github.com/libratbag/libratbag.git"
+else
+	SRC_URI="https://github.com/${PN}/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+	KEYWORDS="~amd64 ~x86"
+fi
+
+LICENSE="MIT"
+SLOT="0"
+IUSE="doc elogind systemd test"
+REQUIRED_USE="
+	${PYTHON_REQUIRED_USE}
+	^^ ( elogind systemd )
+"
+RESTRICT="!test? ( test )"
+
+BDEPEND="
+	${PYTHON_DEPS}
+	dev-lang/swig
+	virtual/pkgconfig
+	doc? (
+		$(python_gen_cond_dep '
+			dev-python/sphinx[${PYTHON_USEDEP}]
+			dev-python/sphinx-rtd-theme[${PYTHON_USEDEP}]
+		')
+	)
+	test? (
+		dev-libs/check
+		dev-libs/gobject-introspection
+		dev-debug/valgrind
+		$(python_gen_cond_dep '
+			dev-python/evdev[${PYTHON_USEDEP}]
+			dev-python/pygobject:3[${PYTHON_USEDEP}]
+		')
+	)
+"
+RDEPEND="
+	${PYTHON_DEPS}
+	acct-group/plugdev
+	dev-libs/glib:2
+	dev-libs/json-glib
+	dev-libs/libevdev
+	dev-libs/libunistring:=
+	virtual/libudev:=
+	$(python_gen_cond_dep '
+		dev-python/pygobject:3[${PYTHON_USEDEP}]
+		dev-python/evdev[${PYTHON_USEDEP}]
+	')
+	elogind? ( sys-auth/elogind )
+	systemd? ( sys-apps/systemd )
+"
+DEPEND="
+	${RDEPEND}
+	dev-libs/gobject-introspection
+"
+
+PATCHES=(
+	"${FILESDIR}"/libratbag-0.17-python3.12-imp.patch
+)
+
+pkg_setup() {
+	CONFIG_CHECK="HIDRAW"
+	if [[ -n ${CONFIG_CHECK} ]]; then
+		linux-info_pkg_setup
+	fi
+}
+
+src_prepare() {
+	default
+
+	if use elogind ; then
+		# Fix systemd includes for elogind
+		sed -i -e 's@include <systemd@include <elogind@' \
+			ratbagd/ratbag*.c || die
+	fi
+}
+
+src_configure() {
+	python_setup
+
+	local emesonargs=(
+		$(meson_use doc documentation)
+		$(meson_use systemd)
+		$(meson_use test tests)
+		-Ddbus-group="plugdev"
+		-Dlogind-provider=$(usex elogind elogind systemd)
+		-Dsystemd-unit-dir="$(systemd_get_systemunitdir)"
+		-Dudev-dir="${EPREFIX}$(get_udevdir)"
+	)
+
+	meson_src_configure
+}
+
+src_install() {
+	meson_src_install
+	python_fix_shebang "${ED}"/usr/bin/
+	newinitd "${FILESDIR}"/ratbagd.init ratbagd
+}
+
+pkg_postinst() {
+	if [[ -z "${REPLACING_VERSIONS}" ]] ; then
+		elog 'You need to be in "plugdev" group in order to access the'
+		elog 'ratbagd dbus interface'
+	fi
+	elog 'You may be required to create and/or be part of the "games" group if you intend on using piper'
+}


### PR DESCRIPTION
libratbag uses `libudev`, namely devices in: `/dev/hidraw*`.  If CONFIG_HIDRAW is not set, the package will never find any devices. (Which was true in my case, as I had HIDRAW disabled.)

This is visible in the libratbag git commit df3c73e, function `ratbagd_run_enumerate`, on line 436:

    r = udev_enumerate_add_match_subsystem(e, "hidraw");
    if (r < 0)
            goto exit;

This will not `goto exit` when there are no devices, neither does any of the subsequent code. The code's intent is not wrong, if there really are no HIDRAW-capable devices connected, it would work as if CONFIG_HIDRAW is not set.

But it does purely depend on the fact that CONFIG_HIDRAW is set in the first place, or else it just makes no sense to use libratbag and may cause frustration if the intent is to really make use of libratbag (e.g. piper) and won't ever find any devices.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
