### PR TITLE
app-cdr/cue2toc: fix implicit declarations in configure, for GCC-14

### DIFF
--- a/app-cdr/cue2toc/cue2toc-0.4-r2.ebuild
+++ b/app-cdr/cue2toc/cue2toc-0.4-r2.ebuild
@@ -1,0 +1,23 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools
+
+DESCRIPTION="Convert CUE files to cdrdao's TOC format"
+HOMEPAGE="https://cue2toc.sourceforge.net/"
+SRC_URI="https://downloads.sourceforge.net/cue2toc/${P}.tar.gz"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~hppa ~ppc ~ppc64 ~sparc ~x86"
+
+DEPEND="!!app-cdr/cdrdao"
+
+src_prepare() {
+	default
+
+	#bug https://bugs.gentoo.org/900128, implicit defines in configure
+	eautoreconf
+}


### PR DESCRIPTION
Standard fix - autoreconf, done.

Closes: https://bugs.gentoo.org/900128

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
