### PR TITLE
Selinux change defaults

### DIFF
--- a/profiles/features/selinux/make.defaults
+++ b/profiles/features/selinux/make.defaults
@@ -11,7 +11,8 @@ USE="selinux"
 
 FEATURES="selinux sesandbox sfperms -pid-sandbox"
 
-POLICY_TYPES="strict targeted"
+# Build all policy types by default
+POLICY_TYPES="strict targeted mcs mls"
 PORTAGE_T="portage_t"
 PORTAGE_FETCH_T="portage_fetch_t"
 PORTAGE_SANDBOX_T="portage_sandbox_t"

--- a/sec-policy/selinux-base/files/config
+++ b/sec-policy/selinux-base/files/config
@@ -12,4 +12,4 @@ SELINUX=permissive
 #	mls      - Full SELinux protection with Multi-Level Security
 #	mcs      - Full SELinux protection with Multi-Category Security 
 #	           (mls, but only one sensitivity level)
-SELINUXTYPE=strict
+SELINUXTYPE=mcs


### PR DESCRIPTION
As mcs is our default recommend policy type for most users, it makes sense to default to it if unspecified by the user. Let's also build all policy types if the `POLICY_TYPES` variable is unset, imo it doesn't make sense to restrict to a subset of strict and targeted, especially as mcs, our recommended policy type, is not contained in that.

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
