### PR TITLE
app-text/xdvik: silence QA error

### DIFF
--- a/app-text/xdvik/xdvik-22.87.06-r1.ebuild
+++ b/app-text/xdvik/xdvik-22.87.06-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -42,6 +42,10 @@ RDEPEND="${DEPEND}
 BDEPEND="app-alternatives/lex
 	app-alternatives/yacc
 	virtual/pkgconfig"
+
+# https://bugs.gentoo.org/900537
+# Windows-exclusive function
+QA_CONFIG_IMPL_DECL_SKIP=(memicmp)
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-22.87.06-configure-clang16.patch


### PR DESCRIPTION
memicmp is windows-only function, this is false positive

Bug: https://bugs.gentoo.org/900537

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
