### PR TITLE
app-text/xournalpp: add X and wayland use flags

### DIFF
--- a/app-text/xournalpp/xournalpp-1.2.3.ebuild
+++ b/app-text/xournalpp/xournalpp-1.2.3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -19,6 +19,7 @@ HOMEPAGE="https://github.com/xournalpp/xournalpp"
 
 LICENSE="GPL-2"
 SLOT="0"
+IUSE="wayland +X"
 
 REQUIRED_USE="${LUA_REQUIRED_USE}"
 
@@ -32,7 +33,7 @@ COMMON_DEPEND="
 	>=media-libs/portaudio-12[cxx]
 	>=media-libs/libsndfile-1.0.25
 	sys-libs/zlib:=
-	>=x11-libs/gtk+-3.18.9:3
+	>=x11-libs/gtk+-3.18.9:3[X?,wayland?]
 "
 RDEPEND="${COMMON_DEPEND}"
 DEPEND="${COMMON_DEPEND}"
@@ -50,6 +51,7 @@ PATCHES=(
 src_configure() {
 	local mycmakeargs=(
 		-DLUA_VERSION="$(lua_get_version)"
+		-DCMAKE_DISABLE_FIND_PACKAGE_X11="$(usex X OFF ON)"
 	)
 
 	cmake_src_configure

--- a/app-text/xournalpp/xournalpp-1.2.5.ebuild
+++ b/app-text/xournalpp/xournalpp-1.2.5.ebuild
@@ -19,6 +19,7 @@ HOMEPAGE="https://github.com/xournalpp/xournalpp"
 
 LICENSE="GPL-2"
 SLOT="0"
+IUSE="wayland +X"
 
 REQUIRED_USE="${LUA_REQUIRED_USE}"
 
@@ -32,7 +33,7 @@ COMMON_DEPEND="
 	>=media-libs/portaudio-12[cxx]
 	>=media-libs/libsndfile-1.0.25
 	sys-libs/zlib:=
-	>=x11-libs/gtk+-3.18.9:3
+	>=x11-libs/gtk+-3.18.9:3[X?,wayland?]
 "
 RDEPEND="${COMMON_DEPEND}"
 DEPEND="${COMMON_DEPEND}"
@@ -50,6 +51,7 @@ PATCHES=(
 src_configure() {
 	local mycmakeargs=(
 		-DLUA_VERSION="$(lua_get_version)"
+		-DCMAKE_DISABLE_FIND_PACKAGE_X11="$(usex X OFF ON)"
 	)
 
 	cmake_src_configure

--- a/app-text/xournalpp/xournalpp-9999.ebuild
+++ b/app-text/xournalpp/xournalpp-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -19,6 +19,7 @@ HOMEPAGE="https://github.com/xournalpp/xournalpp"
 
 LICENSE="GPL-2"
 SLOT="0"
+IUSE="wayland +X"
 
 REQUIRED_USE="${LUA_REQUIRED_USE}"
 
@@ -32,7 +33,7 @@ COMMON_DEPEND="
 	>=media-libs/portaudio-12[cxx]
 	>=media-libs/libsndfile-1.0.25
 	sys-libs/zlib:=
-	>=x11-libs/gtk+-3.18.9:3
+	>=x11-libs/gtk+-3.18.9:3[X?,wayland?]
 "
 RDEPEND="${COMMON_DEPEND}"
 DEPEND="${COMMON_DEPEND}"
@@ -50,6 +51,7 @@ PATCHES=(
 src_configure() {
 	local mycmakeargs=(
 		-DLUA_VERSION="$(lua_get_version)"
+		-DCMAKE_DISABLE_FIND_PACKAGE_X11="$(usex X OFF ON)"
 	)
 
 	cmake_src_configure


### PR DESCRIPTION
Allow users to disable X when building. The X is enabled by default
to follow the old behavior.

The wayland flag was added for consistency reasons.


- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

--

The flags follow the behavior that was default, since gtk with X use flag was required and now there's an option to disable it. From what I can read the revbump is not required.