### PR TITLE
app-emulation/hercules: fix implicit function declarations in configure

### DIFF
--- a/app-emulation/hercules/files/hercules-3.13-autoconf.patch
+++ b/app-emulation/hercules/files/hercules-3.13-autoconf.patch
@@ -1,0 +1,81 @@
+From 8a399018269bebd3ee99d2f4f51656b1b74ed02d Mon Sep 17 00:00:00 2001
+From: "Z. Liu" <zhixu.liu@gmail.com>
+Date: Thu, 9 Jan 2025 14:19:48 +0800
+Subject: [PATCH] autoconf: fix -Wimplicit-function-declaration
+
+With modern C compilers this is a bug and will cause false positives in
+feature tests.
+
+Signed-off-by: Z. Liu <zhixu.liu@gmail.com>
+---
+ autoconf/hercules.m4 | 17 ++++++++++++-----
+ configure.ac         |  3 +++
+ 2 files changed, 15 insertions(+), 5 deletions(-)
+
+diff --git a/autoconf/hercules.m4 b/autoconf/hercules.m4
+index edd71d63..08647581 100644
+--- a/autoconf/hercules.m4
++++ b/autoconf/hercules.m4
+@@ -291,6 +291,7 @@ AC_DEFUN([_HC_CHECK_NEED_GETOPT_WRAPPER],
+                    Will the linker complain about duplicate
+                    symbols for getopt? We'll soon find out!
+                 */
++                extern int getopt(int, char *const[], const char *);
+                 extern char *optarg;
+                 extern int optind;
+ 
+@@ -315,6 +316,8 @@ DUPGETOPT1
+                    needs getopt. Will linker complain about
+                    duplicate symbols for getopt? Let's see.
+                 */
++                extern int getopt(int, char *const[], const char *);
++                extern int test1();
+                 extern char *optarg;
+                 extern int optind;
+                 extern int test2();
+@@ -334,11 +337,11 @@ DUPGETOPT1
+                 }
+ DUPGETOPT2
+ 
+-            libtool --mode=compile ${CC-cc} conftest1.c -c -o conftest1.lo > /dev/null 2>&1
+-            libtool --mode=compile ${CC-cc} conftest2.c -c -o conftest2.lo > /dev/null 2>&1
++            libtool --tag=CC --mode=compile ${CC-cc} conftest1.c -c -o conftest1.lo > /dev/null 2>&1
++            libtool --tag=CC --mode=compile ${CC-cc} conftest2.c -c -o conftest2.lo > /dev/null 2>&1
+ 
+-            libtool --mode=link ${CC-cc} -shared -rpath /lib -no-undefined conftest1.lo                 -o libconftest1.la > /dev/null 2>&1
+-            libtool --mode=link ${CC-cc} -shared -rpath /lib -no-undefined conftest2.lo libconftest1.la -o libconftest2.la > /dev/null 2>&1
++            libtool --tag=CC --mode=link ${CC-cc} -shared -rpath /lib -no-undefined conftest1.lo                 -o libconftest1.la > /dev/null 2>&1
++            libtool --tag=CC --mode=link ${CC-cc} -shared -rpath /lib -no-undefined conftest2.lo libconftest1.la -o libconftest2.la > /dev/null 2>&1
+ 
+             if test $? = 0; then
+ 
+@@ -385,7 +388,11 @@ AC_DEFUN([HC_CHECK_NEED_GETOPT_OPTRESET],
+         [hc_cv_need_getopt_optreset],
+         [
+             AC_TRY_LINK(
+-                [],
++                [
++                    #ifdef HAVE_UNISTD_H
++                    #include <unistd.h>
++                    #endif
++                ],
+                 [
+                     extern int optreset;
+                     optreset=1;
+diff --git a/configure.ac b/configure.ac
+index f12d4705..68dae467 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -1168,6 +1168,9 @@ if test "$GCC" = "yes"; then
+ 
+                             -g -O2 -fomit-frame-pointer
+                     */
++                    #if HAVE_STRING_H
++                    #include <string.h>
++                    #endif
+ 
+                     int foo ()
+                     {
+-- 
+2.45.2
+

--- a/app-emulation/hercules/hercules-3.13-r1.ebuild
+++ b/app-emulation/hercules/hercules-3.13-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="7"
@@ -26,6 +26,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-3.13-posix-test.patch
 	"${FILESDIR}"/${PN}-3.13-unbundle-libltdl.patch
 	"${FILESDIR}"/${PN}-3.13-user-install.patch
+	"${FILESDIR}"/${PN}-3.13-autoconf.patch
 )
 
 src_prepare() {
@@ -43,6 +44,9 @@ src_prepare() {
 
 src_configure() {
 	use custom-cflags || strip-flags
+
+	append-cflags -std=gnu17 # workaround for gcc15
+
 	local -x ac_cv_lib_bz2_BZ2_bzBuffToBuffDecompress=$(usex bzip2)
 	econf \
 		$(use_enable bzip2 cckd-bzip2) \


### PR DESCRIPTION
"./libtool -> libtool" based on Gentoo's earlier patch

A PR is available at https://github.com/rbowler/spinhawk/pull/111 ,
But it's incomplete, because errors during compiling & linking are discarded.

Upstream inactive over 4 years, will submit this if they become active again.

Closes: https://bugs.gentoo.org/879629
Closes: https://bugs.gentoo.org/900328

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
