### PR TITLE
media-sound/flake: update EAPI 7 -> 8, fix build instability

### DIFF
--- a/media-sound/flake/files/flake-0.11-make-instability.patch
+++ b/media-sound/flake/files/flake-0.11-make-instability.patch
@@ -1,0 +1,33 @@
+https://bugs.gentoo.org/917760
+We can't build program without library, utils dependency is just in case
+diff -ru a/Makefile b/Makefile
+--- a/Makefile	2025-01-09 11:48:10.117085442 +0400
++++ b/Makefile	2025-01-09 11:48:27.041979565 +0400
+@@ -19,10 +19,10 @@
+ lib:
+ 	$(MAKE) -C libflake all
+ 
+-progs:
++progs: lib
+ 	$(MAKE) -C flake all
+ 
+-utils:
++utils: progs lib
+ 	$(MAKE) -C util all
+ 
+ .PHONY: install
+https://bugs.gentoo.org/912148
+https://bugs.gentoo.org/880819
+False dependency, if we put flake in build graph, make uses default build
+rules, doesn't include library and failure to link occurs.
+diff -ru a/flake/Makefile b/flake/Makefile
+--- a/flake/Makefile	2025-01-09 11:57:17.279914146 +0400
++++ b/flake/Makefile	2025-01-09 11:59:25.559155784 +0400
+@@ -21,6 +21,6 @@
+ 
+-all: $(PROGS_G) $(PROGS)
++all: $(PROGS_G)
+ 
+ flake_g$(EXESUF): flake.o wav.o $(DEP_LIBS)
+ 	$(CC) $(FLAKE_LIBDIRS) $(LDFLAGS) -o $@ flake.o wav.o $(FLAKE_LIBS) $(EXTRALIBS)
+ 	cp -p flake_g$(EXESUF) flake$(EXESUF)

--- a/media-sound/flake/flake-0.11.ebuild
+++ b/media-sound/flake/flake-0.11.ebuild
@@ -1,17 +1,19 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 inherit toolchain-funcs
 
 DESCRIPTION="An alternative to the FLAC reference encoder"
-HOMEPAGE="http://flake-enc.sourceforge.net"
+HOMEPAGE="https://flake-enc.sourceforge.net"
 SRC_URI="https://downloads.sourceforge.net/flake-enc/${P}.tar.bz2"
 
 LICENSE="LGPL-2.1"
 SLOT="0"
 KEYWORDS="amd64 x86"
+
+PATCHES=("${FILESDIR}"/${P}-make-instability.patch)
 
 src_configure() {
 	# NIH configure script
@@ -19,14 +21,10 @@ src_configure() {
 		--ar="$(tc-getAR)" \
 		--cc="$(tc-getCC)" \
 		--ranlib="$(tc-getRANLIB)" \
-		--prefix="${ED}"/usr \
+		--prefix="${EPREFIX}"/usr \
 		--disable-opts \
 		--disable-debug \
 		--disable-strip || die "configure failed"
-}
-
-src_compile() {
-	emake -j1
 }
 
 src_install() {


### PR DESCRIPTION
Fixed wrong variable usage in ebuild
Two main problems in makefile - lack of dependency of the program to library, so it fails if program is build before library. And false dependency for flake with weird renaming going on, so depgraph gets confused and make builds flake using default rules, not including library, or second compilation unit. One is fixed by rules addition, another is fixed by rule removal

Closes: https://bugs.gentoo.org/880819
Closes: https://bugs.gentoo.org/912148
Closes: https://bugs.gentoo.org/917760
Closes: https://bugs.gentoo.org/836076

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [X] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [X] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [X] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
